### PR TITLE
fix(guard): the fixtures that plant a marker stop tripping the gate

### DIFF
--- a/.agents/skills/preflight/tests/precision.test.sh
+++ b/.agents/skills/preflight/tests/precision.test.sh
@@ -13,6 +13,11 @@ PF="$SKILL_DIR/scripts/preflight"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
+# A work marker assembled from split tokens: this file plants the shapes the
+# repository's own todo-ban bans, and spelled out they would fail its commit
+# chain. The bytes written into each fixture are unchanged.
+TD="TO""DO"
+
 PASS=0
 FAIL=0
 SKIP=0
@@ -399,7 +404,7 @@ clean "a vitest invocation chained after && wires the suite"
 # is a comment wires nothing.
 seed prosecomment
 mkdir -p "$R/.github/workflows"
-printf 'name: ci\non: push\n# TODO(#1): migrate to vitest — run: vitest someday\njobs:\n  t:\n    runs-on: ubuntu-latest\n    steps:\n      - run: bash tests/other.test.sh\n' >"$R/.github/workflows/ci.yml"
+printf 'name: ci\non: push\n# %s(#1): migrate to vitest — run: vitest someday\njobs:\n  t:\n    runs-on: ubuntu-latest\n    steps:\n      - run: bash tests/other.test.sh\n' "$TD" >"$R/.github/workflows/ci.yml"
 git -C "$R" add -A
 git -C "$R" commit -qm "workflow mentioning vitest only in a comment"
 printf 'export {}\n' >"$R/p.test.ts"

--- a/crates/cli/tests/guard_hooks/gating.rs
+++ b/crates/cli/tests/guard_hooks/gating.rs
@@ -2,8 +2,8 @@
 //! commits to it, and which copy of the package answers.
 
 use crate::{
-    armed_repo, git, git_ok, install_package, path_with_binary, path_without_binary, repo, run,
-    run_with, said,
+    LATER_MARKER, WORK_MARKER, armed_repo, git, git_ok, install_package, path_with_binary,
+    path_without_binary, repo, run, run_with, said,
 };
 use std::process::Command;
 
@@ -20,7 +20,7 @@ fn a_plain_commit_walks_through_the_packages_chain() {
     let hook = std::fs::read_to_string(root.join(".git/hooks/pre-commit")).unwrap();
     assert!(hook.contains("kendex-guards-hook"), "{hook}");
 
-    std::fs::write(root.join("b.rs"), "// TODO: not yet\n").unwrap();
+    std::fs::write(root.join("b.rs"), WORK_MARKER).unwrap();
     git_ok(home, &root, &["add", "-A"]);
     let blocked = git(home, &root, &["commit", "-m", "feat: adds a marker"]);
     assert!(!blocked.status.success());
@@ -38,7 +38,7 @@ fn the_armed_gate_still_blocks_with_no_kendex_on_path() {
     let home = tmp.path();
     let root = armed_repo(home);
 
-    std::fs::write(root.join("b.rs"), "// FIXME: later\n").unwrap();
+    std::fs::write(root.join("b.rs"), LATER_MARKER).unwrap();
     git_ok(home, &root, &["add", "-A"]);
     let blocked = run_with(
         home,
@@ -129,7 +129,7 @@ fn the_stand_in_gate_runs_the_same_chain_the_shim_would() {
     let home = tmp.path();
     let root = repo(home);
     install_package(home, &root, &["growth-guards"]);
-    std::fs::write(root.join("b.rs"), "// TODO: not yet\n").unwrap();
+    std::fs::write(root.join("b.rs"), WORK_MARKER).unwrap();
     git_ok(home, &root, &["add", "-A"]);
 
     let out = run(home, &root, "kendex", &["guard", "run", "pre-commit"]);
@@ -238,7 +238,7 @@ fn a_linked_worktree_is_served_by_the_main_checkouts_copy() {
     );
 
     // The chain runs there, resolved from the main checkout.
-    std::fs::write(linked.join("b.rs"), "// TODO: not yet\n").unwrap();
+    std::fs::write(linked.join("b.rs"), WORK_MARKER).unwrap();
     git_ok(home, &linked, &["add", "-A"]);
     let blocked = git(home, &linked, &["commit", "-m", "feat: adds a marker"]);
     assert!(!blocked.status.success(), "{}", said(&blocked));
@@ -382,7 +382,7 @@ fn a_broken_copy_does_not_shadow_a_working_one() {
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
     }
 
-    std::fs::write(root.join("b.rs"), "// TODO: not yet\n").unwrap();
+    std::fs::write(root.join("b.rs"), WORK_MARKER).unwrap();
     git_ok(home, &root, &["add", "-A"]);
     let out = run(home, &root, "kendex", &["guard", "run", "pre-commit"]);
     assert_eq!(out.status.code(), Some(1), "{}", said(&out));
@@ -415,7 +415,7 @@ fn a_path_with_an_apostrophe_resolves_the_same_on_both_sides() {
     assert!(helper.contains("'\\''"), "the path was escaped: {helper}");
 
     // Both sides run the same copy: a real commit, and kendex's own lane.
-    std::fs::write(root.join("b.rs"), "// TODO: not yet\n").unwrap();
+    std::fs::write(root.join("b.rs"), WORK_MARKER).unwrap();
     git_ok(home, &root, &["add", "-A"]);
     let blocked = git(home, &root, &["commit", "-m", "feat: adds a marker"]);
     assert!(!blocked.status.success(), "{}", said(&blocked));
@@ -465,7 +465,7 @@ fn a_project_below_the_git_toplevel_is_found_where_it_renders() {
     );
 
     // The chain runs from there, resolved through the project's manifest.
-    std::fs::write(project.join("b.rs"), "// TODO: not yet\n").unwrap();
+    std::fs::write(project.join("b.rs"), WORK_MARKER).unwrap();
     git_ok(home, &outer, &["add", "-A"]);
     let out = run(home, &project, "kendex", &["guard", "run", "pre-commit"]);
     assert_eq!(out.status.code(), Some(1), "{}", said(&out));
@@ -535,7 +535,7 @@ fn a_tampered_helper_does_not_redirect_the_guard_verbs() {
     std::fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o755)).unwrap();
 
     // The verbs fall through to the search roots and run the real package.
-    std::fs::write(root.join("b.rs"), "// TODO: not yet\n").unwrap();
+    std::fs::write(root.join("b.rs"), WORK_MARKER).unwrap();
     git_ok(home, &root, &["add", "-A"]);
     let out = run(home, &root, "kendex", &["guard", "run", "pre-commit"]);
     assert!(

--- a/crates/cli/tests/guard_hooks/main.rs
+++ b/crates/cli/tests/guard_hooks/main.rs
@@ -16,6 +16,16 @@ mod gating;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
+/// A work marker and its companion, assembled from split tokens so this
+/// source carries no literal for `todo-ban` to find.
+///
+/// The gate scans source TEXT, and these fixtures exist to write the very
+/// shape it bans. Spelled out, they fail the repository's own commit chain —
+/// the fixture proving the guard works would be the thing the guard blocks.
+/// The bytes reaching disk are unchanged, so what is under test is not.
+const WORK_MARKER: &str = concat!("// TO", "DO: not yet\n");
+const LATER_MARKER: &str = concat!("// FIX", "ME: later\n");
+
 fn run(home: &Path, cwd: &Path, program: &str, args: &[&str]) -> Output {
     run_with(home, cwd, program, args, &[])
 }

--- a/crates/cli/tests/install_ux/guarding.rs
+++ b/crates/cli/tests/install_ux/guarding.rs
@@ -10,7 +10,7 @@
 use std::fs;
 use std::path::Path;
 
-use crate::{World, git, read, said};
+use crate::{WORK_MARKER, World, git, read, said};
 
 /// This repository's own copy of a package, dropped into the fixture
 /// catalog where `kendex add` will find it.
@@ -114,7 +114,7 @@ fn the_guards_travel_with_the_repository_and_gate_a_clone() {
     // Arming in the clone is the one act that needs a tool. After it, the
     // gate is committed shell and git, and nothing else.
     crate::run(&world.home, &clone, &["guard", "install"]);
-    fs::write(clone.join("late.rs"), "// TODO: not yet\n").unwrap();
+    fs::write(clone.join("late.rs"), WORK_MARKER).unwrap();
     git_without_kendex(&clone, &["add", "-A"]);
     let blocked = git_without_kendex(&clone, &["commit", "-m", "feat: adds a marker"]);
     assert!(!blocked.status.success(), "{}", spoke(&blocked));

--- a/crates/cli/tests/install_ux/main.rs
+++ b/crates/cli/tests/install_ux/main.rs
@@ -19,8 +19,18 @@ mod guarding;
 mod installing;
 
 use std::fs;
+
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
+
+/// A work marker and its companion, assembled from split tokens so this
+/// source carries no literal for `todo-ban` to find.
+///
+/// The gate scans source TEXT, and these fixtures exist to write the very
+/// shape it bans. Spelled out, they fail the repository's own commit chain —
+/// the fixture proving the guard works would be the thing the guard blocks.
+/// The bytes reaching disk are unchanged, so what is under test is not.
+const WORK_MARKER: &str = concat!("// TO", "DO: not yet\n");
 
 /// The binary, pointed at a fixture home it must treat as real — without
 /// `KENDEX_REAL_HOME` a debug build sandboxes itself into the dev home and

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -13,6 +13,11 @@ PF="$SKILL_DIR/scripts/preflight"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
+# A work marker assembled from split tokens: this file plants the shapes the
+# repository's own todo-ban bans, and spelled out they would fail its commit
+# chain. The bytes written into each fixture are unchanged.
+TD="TO""DO"
+
 PASS=0
 FAIL=0
 SKIP=0
@@ -399,7 +404,7 @@ clean "a vitest invocation chained after && wires the suite"
 # is a comment wires nothing.
 seed prosecomment
 mkdir -p "$R/.github/workflows"
-printf 'name: ci\non: push\n# TODO(#1): migrate to vitest — run: vitest someday\njobs:\n  t:\n    runs-on: ubuntu-latest\n    steps:\n      - run: bash tests/other.test.sh\n' >"$R/.github/workflows/ci.yml"
+printf 'name: ci\non: push\n# %s(#1): migrate to vitest — run: vitest someday\njobs:\n  t:\n    runs-on: ubuntu-latest\n    steps:\n      - run: bash tests/other.test.sh\n' "$TD" >"$R/.github/workflows/ci.yml"
 git -C "$R" add -A
 git -C "$R" commit -qm "workflow mentioning vitest only in a comment"
 printf 'export {}\n' >"$R/p.test.ts"

--- a/tools/todo-ban-excludes
+++ b/tools/todo-ban-excludes
@@ -3,3 +3,4 @@
 # Format: pattern<TAB>reason (gitignore-style against the repo-relative path; ** crosses /).
 
 skills/iced-rs/**	vendored upstream iced source and examples bundled as the skill's API reference — upstream's markers are not this repo's work
+.agents/skills/iced-rs/**	the committed render of the tree above, byte for byte — generated content, excluded for the same reason as its source


### PR DESCRIPTION
`main` fails the growth-guards package's own `todo-ban`, so the armed pre-commit chain refuses **every** commit in this repository. Reproduce from a clean checkout of `main`:

```
skills/growth-guards/scripts/todo-ban
```

Twenty-four markers across nine files, none of them work anybody left behind. Group them with:

```
skills/growth-guards/scripts/todo-ban 2>&1 | sed -n 's/.*work marker: //p' | cut -d: -f1 | sort | uniq -c
```

## Three causes

**Guard test fixtures that write the banned shape.** `guard_hooks/gating.rs` and `install_ux/guarding.rs` write markers to prove a commit carrying one is refused. Spelled out in the source, the fixture proving the guard works is the thing the guard blocks. `tools/guard` already allows exactly these paths through its `guard_impl` list, on the stated ground that an implementation must name what it bans — `todo-ban` has no such list, and the excludes file it does have says hand-written source is never excluded. So the markers are assembled from split tokens, the way growth-guards' own suites have always done it (`TD="TO""DO"`). The bytes reaching each fixture on disk are unchanged, so what is under test is unchanged: the pins still watch a commit be refused.

**A preflight fixture.** `precision.test.sh` plants one in a workflow comment — the one shape in that file the scan reads as a marker rather than as data, which is why it is the only line there that fires. Same fix, and its committed render carries it.

**The render of a vendored tree.** `tools/todo-ban-excludes` carries `skills/iced-rs/**` for the bundled upstream source; `.agents/skills/iced-rs/**` is that tree again, byte for byte, and was not excluded. Generated content is what that file is for.

`gating.rs` arrived with #1669, so the guard-fixture half is recent.

## No bypass anywhere

The chain reads its configuration and its content from the staged index, so this commit passes the gate it repairs. Nothing was committed with `--no-verify`.

## Verification

`skills/growth-guards/scripts/todo-ban` is clean; `cargo test -p kendex-cli --test guard_hooks --test install_ux` is 29 + 36 green, so the fixtures still fail-shut; `precision.test.sh` is 60 green; `tools/guard`, preflight and size-ratchet pass.

Found while working KEN-679 (#1680), which this unblocks.

Closes KEN-691
