### PR TITLE
refactor(KEN-562): move GitHub contracts into command help

### DIFF
--- a/.agents/skills/github/DEVELOPMENT.md
+++ b/.agents/skills/github/DEVELOPMENT.md
@@ -8,6 +8,7 @@
 - `scripts/git-diff-summary` — Standalone changed-file domain/scope and risk-flag summary helper
 - `scripts/lib/github-api.sh` — Shared auth, GraphQL, REST, and error handling
 - `scripts/lib/gh-auth.sh` — Token resolution and keyring fallback
+- `scripts/lib/bounded.sh` — Portable wall-clock bound for GitHub subprocesses
 - `scripts/lib/kendex-env.sh` — Project settings / `.env.local` loader
 - `scripts/lib/ci-run-correlation.sh` — Check-rollup run scoping, shared with orch `ci-wait`
 - `scripts/lib/verify-lib.sh` — Merge simulation and build/test detection for `pr-cross-check --verify`

--- a/.agents/skills/github/README.md
+++ b/.agents/skills/github/README.md
@@ -6,8 +6,9 @@ fetching CI failure logs; gating and performing merges; and comparing several
 PRs before a batch merge.
 
 Every command prints JSON by default, so output can be piped straight into
-`jq`. `SKILL.md` is the full command reference; `DEVELOPMENT.md` covers
-internals.
+`jq`. Start with `./scripts/github.sh --help`, then use
+`./scripts/github.sh <command> --help` for the full contract. `SKILL.md`
+carries agent routing and recovery; `DEVELOPMENT.md` covers internals.
 
 ## Setup
 

--- a/.agents/skills/github/SKILL.md
+++ b/.agents/skills/github/SKILL.md
@@ -15,7 +15,7 @@ tags: [git, integration]
 
 # GitHub Queries
 
-> **Problem with this skill?** Run `kendex report`.
+> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
 
 ```bash
 .agents/skills/github/scripts/github.sh [-C <path>] <command> [options]
@@ -50,8 +50,8 @@ tags: [git, integration]
 | `edit-comment <id> [body \| --body-file PATH]` | Edit existing comment. |
 | `sticky-comment <PR> [--verdict\|--analysis\|--body]` | Get bot sticky comment. `--verdict`: quick pass/fail. `--analysis`: deep recommendation. |
 
-CI waiting belongs to the orch skill's `ci-wait`; `await-mergeable` waits
-for merge-state resolution.
+CI waiting belongs to `.agents/skills/orch/scripts/ci-wait`; `await-mergeable`
+waits for merge-state resolution.
 
 ### Label application contract
 
@@ -59,16 +59,15 @@ Label modes and failures: `label-add --help`.
 
 ### Git HTTPS Auth Helper
 
-GitHub SSH-to-HTTPS fallback contract: `git-https-auth --help`.
+Contract: `git-https-auth --help`.
 
 ### Diff Summary Helper
 
-Output and risk flags: `git-diff-summary --help`.
+Contract: `git-diff-summary --help`.
 
 ### PR Merge Outcomes
 
-Exit codes, volatility, exact-head mutation, thread bounds, `--check`, and
-`--force`: `pr-merge --help`.
+Full contract: `pr-merge --help`.
 Exit `75` is volatile, so keep a watcher running until `MERGED`.
 If `can_merge` is false with no `issues`, read `state`.
 The thread gate is **Policy, not mechanism.** `--force` is its only override.

--- a/.agents/skills/github/SKILL.md
+++ b/.agents/skills/github/SKILL.md
@@ -15,14 +15,10 @@ tags: [git, integration]
 
 # GitHub Queries
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
-
-CLI wrapper for GitHub API operations used in PR workflows. Structured JSON
-output, bot account support, configurable issue ID extraction.
+> **Problem with this skill?** Run `kendex report`.
 
 ```bash
-.agents/skills/github/scripts/github.sh <command> [options]
-.agents/skills/github/scripts/github.sh -C <path> <command> [options]  # Run in different directory
+.agents/skills/github/scripts/github.sh [-C <path>] <command> [options]
 ```
 
 ## Commands
@@ -54,127 +50,28 @@ output, bot account support, configurable issue ID extraction.
 | `edit-comment <id> [body \| --body-file PATH]` | Edit existing comment. |
 | `sticky-comment <PR> [--verdict\|--analysis\|--body]` | Get bot sticky comment. `--verdict`: quick pass/fail. `--analysis`: deep recommendation. |
 
-Wherever a body is accepted, prefer `--body-file`: an inline `--body` is safe
-only for plain strings, and Markdown carrying backticks or code fences needs
-the file. `label-add`/`label-remove` also load current-project env when their
-command scripts are executed directly rather than through `github.sh`.
-
-Most commands accept no PR number to auto-detect from the current branch.
-Exception: `post-reply` with a numeric comment ID never auto-detects — it
-requires an explicit `--pr <N>` (thread `PRRT_...` IDs need no PR number).
-
-There is no CI wait command here. Blocking until CI completes is the orch
-skill's `.agents/skills/orch/scripts/ci-wait <PR_NUMBER> [interval] [max_wait]
-[--json]`. `ci-logs` only fetches failure logs, and `await-mergeable` waits for
-merge-state resolution, not check completion.
-
-Unknown flags and extra positionals are rejected.
+CI waiting belongs to the orch skill's `ci-wait`; `await-mergeable` waits
+for merge-state resolution.
 
 ### Label application contract
 
-Workflow-required QA labels use `--required` (the default), even against a
-misconfigured repo; use `--optional` only where project policy marks the
-label non-gating. Mode semantics, exit codes, and the error classes that are
-never optional skips: `label-add --help`.
+Label modes and failures: `label-add --help`.
 
 ### Git HTTPS Auth Helper
 
-`git-https-auth [-C path] <git args...>` runs `git` normally, but when the
-target repo or an explicit URL uses a GitHub SSH remote and `gh` auth is valid,
-it adds per-command config for `gh auth git-credential` and rewrites GitHub SSH
-URLs to HTTPS. It never persists git config.
-
-```bash
-.agents/skills/github/scripts/git-https-auth -C . fetch --prune origin
-.agents/skills/github/scripts/git-https-auth -C . push -u origin HEAD:refs/heads/my-branch
-```
-
-Set `KENDEX_GITHUB_GIT_HTTPS_FALLBACK=never` to disable the fallback, or
-`always` to force it.
+GitHub SSH-to-HTTPS fallback contract: `git-https-auth --help`.
 
 ### Diff Summary Helper
 
-`git-diff-summary [-C path] [base-branch|--staged|--head]` emits JSON with
-changed-file domains, scope, insert/delete stats, and `risk_flags` for review
-routing. The flag definitions — including which `test_panic_path_added`
-surfaces are informational rather than risk — are in `git-diff-summary --help`.
+Output and risk flags: `git-diff-summary --help`.
 
 ### PR Merge Outcomes
 
-`pr-merge` returns three distinct outcomes — branch on the exit code, not on
-parsing stderr:
-
-| Exit | Meaning | Stderr line | When |
-|------|---------|-------------|------|
-| `0`  | MERGED | `MERGED PR #N` | Merge completed immediately |
-| `0`  | MERGED | `ALREADY MERGED PR #N <mergedAt>` | PR was merged before the call; nothing attempted |
-| `75` | MERGE PENDING (volatile) | `QUEUED IN MERGE QUEUE PR #N` | A required GitHub merge queue has an active entry — launch the prepared durable lifecycle before returning |
-| `75` | MERGE PENDING (volatile) | `AUTO-MERGE ENABLED PR #N` | Classic auto-merge is armed until protection clears — launch the prepared durable lifecycle before returning |
-| `1`  | BLOCKED | `BLOCKED PR #N` | Nothing merged, queued, or armed |
-| `1`  | BLOCKED | `CLOSED (not merged) PR #N` | PR is closed unmerged; nothing attempted |
-
-Exit `75` is not a resting state: an ejection or a failed protection check
-disarms it silently. The caller prepares and launches
-`.agents/skills/orch/scripts/merge-queue-watch`, which binds the repository,
-PR, expected head, and watch generation before arming. Its one-shot worker writes a durable verdict and claims one recovery action. The review-gate reducer can still report fleet attention.
-Verdict routing is in README.md § Exit 75 recovery; re-arm only through
-`.agents/skills/github/scripts/github.sh pr-merge <N> --auto` after that route.
-`await-mergeable` is not that watcher — it returns as soon as GitHub computes a merge state.
-
-A PR that has left `OPEN` is terminal and short-circuits every mode before any
-check, auth, or mutation. `--check` reports it through its `state` field.
-
-Merge state is mutated only against the exact resolved head, via
-`--match-head-commit`. Queue membership is read with GraphQL: an `OPEN` PR
-with no `autoMergeRequest` is still a successful exit `75` when its required queue
-entry is active, and an `OPEN` PR with neither queue nor auto-merge proof fails
-closed.
-
-Actionable review threads — unresolved and not outdated — are a hard local
-gate. They make `can_merge` false and block both immediate merge and `--auto`
-before any mutation. A failed or malformed thread lookup blocks too. Two
-bounds on that gate:
-
-- **Narrower than branch protection.** GitHub's
-  `required_conversation_resolution` requires *all* conversations resolved and
-  draws no outdated/active distinction. `pr-merge` counts only threads that are
-  unresolved *and* not outdated. Relying on `pr-merge` alone is a narrower
-  guarantee than branch protection.
-- **Policy, not mechanism.** `pr-merge` gates only merges routed through it. A
-  raw `gh pr merge` or the GitHub UI Merge button bypasses the skill entirely.
-
-`--force` is the only deliberate override and skips every check. It is
-immediate-only, cannot be combined with `--auto` (the pair fails before any
-GitHub lookup), and stays BLOCKED when its mutation fails and the exact-head
-post-state is not `MERGED`.
-
-BLOCKED is classified on stderr as **transient** (mergeable UNKNOWN,
-`ci_pending`, CI fetch uncertainty — `await-mergeable` then retry) or
-**permanent** (conflicts, `ci_failed`, `changes_requested` — fix and re-push).
-Callers read the `transient` field from `--check`:
-
-```json
-{"can_merge": true, "issues": [], "warnings": [], "mergeable": "MERGEABLE", "review": "APPROVED", "transient": false, "state": "OPEN", "merged_at": "", "head_runs": [17234567890], "checks": [{"name": "Cargo", "state": "SUCCESS", "bucket": "pass", "workflow": "CI", "link": "https://github.com/owner/repo/actions/runs/17234567890/job/1", "startedAt": "…"}]}
-```
-
-`state` is the PR's lifecycle state (`OPEN`, `MERGED`, `CLOSED`, `UNKNOWN`), and
-`merged_at` carries the merge timestamp when that state is `MERGED`.
-`can_merge: false` with an empty `issues` array means the PR is terminal — read
-`state` before treating a refusal as a blocker to clear. `head_runs` lists the
-run ids the CI classification was scoped to (the authoritative run per
-workflow plus the runs custom commit statuses link to — a mixed head names
-both); `--check` repeats them on stderr as `head-run: <ids>` under the
-one-word verdict (`mergeable`, `blocked`, `merged`, `closed`). `checks` is the
-raw rollup that classification read. To turn a refusal into a named cause —
-including which failing checks are run-correlated to the authoritative run and
-which runs were superseded — run `ci-classify-refusal <N>`; it scopes the
-`checks` snapshot embedded in the `--check` JSON rather than refetching, so
-its detail lines and the verdict describe one fetch.
-
-`transient: true` means every blocking issue is recoverable by waiting
-(prefixes `unknown:`, `ci_pending:`, `ci_unconfigured:`, `ci_fetch_failed:`).
-Still-running checks report as `ci_pending:`; terminal failing or cancelled
-checks remain `ci_failed:`.
+Exit codes, volatility, exact-head mutation, thread bounds, `--check`, and
+`--force`: `pr-merge --help`.
+Exit `75` is volatile, so keep a watcher running until `MERGED`.
+If `can_merge` is false with no `issues`, read `state`.
+The thread gate is **Policy, not mechanism.** `--force` is its only override.
 
 ### PR blocked with no visible conversations
 
@@ -205,61 +102,24 @@ skill's reducer when installed
 
 ## Output Formats
 
-`--format` is command-specific, not a global flag; the per-command modes, the
-`--json` alias, and the reject-unknown rules are in `github.sh --help`.
+Formats and flag rules: `github.sh --help`.
 
 ## Configuration
 
-| Variable | Purpose | Default |
-|----------|---------|---------|
-| `GH_TOKEN` / `GITHUB_TOKEN` | Pre-resolved GitHub token from the parent process | Falls back to `gh` auth |
-| `GH_BOT_TOKEN` | Bot account GitHub token (in `.env.local` or parent env) | Falls back to `GH_TOKEN` / `GITHUB_TOKEN`, then `gh` auth |
-| `GH_BOT_USERNAME` | Bot username for review/comment filtering | `review-bot[bot]` |
-| `GH_ISSUE_PATTERN` | Regex for issue ID extraction from branches | `[A-Z]+-[0-9]+` |
-| `GH_VERIFY_CMD` | Overrides build/test detection in `pr-cross-check --verify` | auto-detect |
-| `KENDEX_GITHUB_OP_TIMEOUT` | Seconds to wait for `op read` when resolving token references | `10` |
-| `KENDEX_GITHUB_AUTH_TIMEOUT` | Seconds to wait for GitHub auth preflight in `pr-view` | `10` |
-| `KENDEX_GITHUB_PR_VIEW_TIMEOUT` | Seconds to wait for `gh pr view` in `pr-view` | `30` |
-| `KENDEX_GITHUB_GIT_HTTPS_FALLBACK` | `auto`, `never`, or `always` for `git-https-auth` SSH→HTTPS fallback | `auto` |
-
-Tokens may be literal (`ghp_*`, `gho_*`, `ghu_*`, `ghs_*`, `ghr_*`,
-`github_pat_*`) or 1Password references (`op://vault/item/field`). Keep them in
-`.env.local`; non-secret defaults belong in committed `kendex.settings.toml`
-under `[env]`.
-
-Parent-process values win over project files. `github.sh` then selects ONE
-router token before resolving any `op://` reference — resolved `GH_TOKEN`, then
-`GH_BOT_TOKEN`, then `GITHUB_TOKEN`, falling back to `op://` references in that
-same order — and runs `op read` for that single selection only. An unresolvable
-selection drops `GH_TOKEN`/`GITHUB_TOKEN` so `gh` uses keyring auth; a selected
-`GH_BOT_TOKEN` keeps its bot identity instead. Auth preflight validates env
-tokens with `gh api user`, and `gh auth status` is authoritative only when no
-env token is selected.
-
-## Error Handling
-
-- Most commands emit `{"error": "message"}` on stderr and exit 1.
-- `pr-view --json ...` emits structured failure JSON on stdout (the `status`
-  values and shape: `pr-view --help`).
-- Rate limits retry automatically (3 attempts, exponential backoff).
-- An unreadable thread list, comment list, or CI log is reported as a failure,
-  never as "none found".
+Keep secrets in `.env.local`; commit non-secret defaults to
+`kendex.settings.toml` under `[env]`. Other contracts: `github.sh --help`.
 
 ## Troubleshooting
 
-**`Expected VAR_SIGN, actual: UNKNOWN_CHAR`**: use a multi-line GraphQL query
-with `-F` variables — `$` in a single-line query hits shell escaping.
+**`VAR_SIGN`**: use a multi-line GraphQL query with `-F` variables.
 
-**`bad credentials` / `HTTP 401` while `gh auth status` looks healthy**: a
-stale `GH_TOKEN`/`GITHUB_TOKEN` masks keyring credentials. Check
-`env | grep -E '^(GH_TOKEN|GITHUB_TOKEN)='`, then clear BOTH for the call:
+**Stale-token `HTTP 401`**: clear both environment tokens:
 
 ```bash
 env -u GH_TOKEN -u GITHUB_TOKEN gh pr list
 ```
 
-`github.sh` does this automatically when the selected env token fails and
-keyring auth succeeds.
+`github.sh` falls back when keyring auth succeeds.
 
 ## Dependencies
 

--- a/.agents/skills/github/scripts/commands/label-add.sh
+++ b/.agents/skills/github/scripts/commands/label-add.sh
@@ -37,6 +37,11 @@ or resembling booleans, integers, nulls, and placeholders. Neither mode
 mutates anything on a refusal, and auth, lookup, rate-limit, and server
 errors are operational errors in both modes — never optional skips.
 
+Configuration:
+  Direct execution loads the current project's kendex.settings.toml,
+  .kendex/settings.toml, and .env.local before selecting auth. Parent-process
+  values keep precedence.
+
 Examples:
   label-add.sh 44 needs-qa
   label-add.sh 123 needs-triage --issue

--- a/.agents/skills/github/scripts/commands/label-remove.sh
+++ b/.agents/skills/github/scripts/commands/label-remove.sh
@@ -24,6 +24,11 @@ Options:
   --pr              Treat the ref as a PR (default).
   --help, -h        Show this help.
 
+Configuration:
+  Direct execution loads the current project's kendex.settings.toml,
+  .kendex/settings.toml, and .env.local before selecting auth. Parent-process
+  values keep precedence.
+
 Examples:
   label-remove.sh 44 needs-qa
   label-remove.sh 123 needs-triage --issue

--- a/.agents/skills/github/scripts/commands/pr-merge.sh
+++ b/.agents/skills/github/scripts/commands/pr-merge.sh
@@ -64,22 +64,22 @@ Exit codes:
        The PR is closed unmerged. Nothing was attempted.
 
 Exit 75 is volatile:
-  A queue ejection or failed protection check can disarm merge state without
-  another notification. Keep a watcher running until the PR is MERGED. Use
-  the orch skill's queue-wait <N> or the review-gate pr-watch.sh reducer, then
-  repair the named cause and re-arm with github.sh pr-merge <N> --auto.
-  Neither watcher is durable. await-mergeable is not an ejection watcher; it
-  stops when GitHub finishes computing the current merge state.
+  A queue ejection or failed protection check can disarm merge state silently.
+  Launch the prepared .agents/skills/orch/scripts/merge-queue-watch before returning; it binds repository, PR, expected head, and watch generation.
+  Its one-shot worker writes a durable verdict and claims one recovery action; the review-gate reducer still reports fleet attention.
+  Route verdicts through README.md "Exit 75 recovery". Re-arm only through
+  github.sh pr-merge <N> --auto after that route. await-mergeable is not the
+  lifecycle watcher; it stops when GitHub computes the current merge state.
 
 Terminal and mutation rules:
-  A PR outside OPEN is terminal. Every mode returns its state before checks,
-  auth, or mutation. --check reports that lifecycle in state.
+  After github.sh router setup, a PR outside OPEN short-circuits pr-merge safety
+  checks, bot-token load, and merge-state mutation. --check reports state.
 
-  Every mutation resolves the checked head and passes --match-head-commit.
-  A post-mutation snapshot for another head is BLOCKED. Queue membership comes
-  from GraphQL isInMergeQueue and mergeQueueEntry. An OPEN PR with an active
-  queue entry exits 75 even when autoMergeRequest is absent. An OPEN PR with
-  no queue or auto-merge proof fails closed.
+  Every gh pr merge invocation is exact-head guarded by --match-head-commit; a changed head is BLOCKED.
+  Queue membership comes from GraphQL isInMergeQueue and mergeQueueEntry. An
+  OPEN PR with an active queue entry exits 75 even when autoMergeRequest is
+  absent. An OPEN PR with no queue or auto-merge proof fails closed. The
+  --delete-branch cleanup after MERGED is best-effort, not merge-state mutation.
 
 Review-thread gate:
   Unresolved, non-outdated review threads make can_merge false and block both

--- a/.agents/skills/github/scripts/commands/pr-merge.sh
+++ b/.agents/skills/github/scripts/commands/pr-merge.sh
@@ -75,8 +75,8 @@ Exit 75 is volatile:
   lifecycle watcher; it stops when GitHub computes the current merge state.
 
 Terminal and mutation rules:
-  After github.sh router setup, a PR outside OPEN short-circuits pr-merge safety
-  checks, bot-token load, and merge-state mutation. --check reports state.
+  After github.sh router setup, MERGED or CLOSED short-circuits pr-merge safety
+  checks, bot-token load, and merge-state mutation; UNKNOWN continues. --check reports state.
 
   Every gh pr merge invocation is exact-head guarded by --match-head-commit; a changed head is BLOCKED.
   Queue membership comes from GraphQL isInMergeQueue and mergeQueueEntry. An

--- a/.agents/skills/github/scripts/commands/pr-merge.sh
+++ b/.agents/skills/github/scripts/commands/pr-merge.sh
@@ -67,12 +67,10 @@ Merge-mode exit codes:
   blocked or CLOSED. Argument or dispatch failures before JSON remain nonzero.
 
 Exit 75 is volatile:
-  A queue ejection or failed protection check can disarm merge state silently.
-  Launch the prepared .agents/skills/orch/scripts/merge-queue-watch before returning; it binds repository, PR, expected head, and watch generation.
-  Its one-shot worker writes a durable verdict and claims one recovery action; the review-gate reducer still reports fleet attention.
-  Route verdicts through README.md "Exit 75 recovery". Re-arm only through
-  github.sh pr-merge <N> --auto after that route. await-mergeable is not the
-  lifecycle watcher; it stops when GitHub computes the current merge state.
+  A queue ejection can disarm merge state. Launch the prepared .agents/skills/orch/scripts/merge-queue-watch before returning; it binds repository, PR, expected head, and watch generation.
+  Its one-shot worker writes a durable verdict and claims one recovery action. Route verdicts through README.md "Exit 75 recovery"; the review-gate reducer still reports fleet attention.
+  Re-arm only through github.sh pr-merge <N> --auto after that route.
+  await-mergeable is not the lifecycle watcher; it stops when GitHub computes state.
 
 Terminal and mutation rules:
   After github.sh router setup, MERGED or CLOSED short-circuits pr-merge safety
@@ -301,8 +299,7 @@ run_checks() {
         fi
     fi
 
-    # reviewDecision is only populated with branch protection rules requiring approvals.
-    # Fall back to checking latestReviews for both APPROVED and CHANGES_REQUESTED states.
+    # reviewDecision requires branch protection; latestReviews covers both terminal review states.
     local review="" has_approved_review=false has_changes_requested=false
     local review_json
     if ! review_json=$(json_or_default '{}' object gh pr view "$pr_num" --json reviewDecision,latestReviews); then
@@ -627,7 +624,6 @@ main() {
         echo "BLOCKED PR #$pr_num — prepared head changed before merge attempt (expected=$expected_head, actual=$current_head)" >&2; exit 1
     fi
 
-    # --auto queues the exact head until GitHub's requirements clear.
     local -a cmd=(pr merge "$pr_num" "$method" --match-head-commit "$expected_head")
     [ "$auto" = true ] && cmd+=(--auto)
 

--- a/.agents/skills/github/scripts/commands/pr-merge.sh
+++ b/.agents/skills/github/scripts/commands/pr-merge.sh
@@ -58,7 +58,7 @@ Merge-mode exit codes:
   75   AUTO-MERGE ENABLED PR #N
        Classic auto-merge is armed until protection clears.
   1    BLOCKED PR #N
-       Nothing merged, queued, or armed.
+       The requested operation failed; a pre-existing queue entry or auto-merge request may remain active.
   1    CLOSED (not merged) PR #N
        The PR is closed unmerged. Nothing was attempted.
 

--- a/.agents/skills/github/scripts/commands/pr-merge.sh
+++ b/.agents/skills/github/scripts/commands/pr-merge.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Source shared library for load_bot_token (also sets PROJECT_ROOT)
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/../lib/github-api.sh"
 # Issue prefixes that resolve on their own once GitHub finishes computing or
@@ -49,7 +48,7 @@ Modes:
   --force          Deliberately skip all checks, including review threads
   --auto           Enable auto-merge when immediate merge is blocked
 
-Exit codes:
+Merge-mode exit codes:
   0    MERGED PR #N
        Merge completed immediately.
   0    ALREADY MERGED PR #N <mergedAt>
@@ -62,6 +61,10 @@ Exit codes:
        Nothing merged, queued, or armed.
   1    CLOSED (not merged) PR #N
        The PR is closed unmerged. Nothing was attempted.
+
+--check exit:
+  --check exits 0 after any valid readiness JSON, including can_merge=false for
+  blocked or CLOSED. Argument or dispatch failures before JSON remain nonzero.
 
 Exit 75 is volatile:
   A queue ejection or failed protection check can disarm merge state silently.
@@ -228,7 +231,6 @@ run_checks() {
         return 0
     fi
 
-    # 1. Check mergeable status
     local mergeable
     mergeable=$(gh pr view "$pr_num" --json mergeable --jq '.mergeable' 2>/dev/null || echo "UNKNOWN")
     if [ "$mergeable" = "MERGEABLE" ]; then
@@ -299,7 +301,6 @@ run_checks() {
         fi
     fi
 
-    # 4. Check review status
     # reviewDecision is only populated with branch protection rules requiring approvals.
     # Fall back to checking latestReviews for both APPROVED and CHANGES_REQUESTED states.
     local review="" has_approved_review=false has_changes_requested=false
@@ -320,7 +321,6 @@ run_checks() {
         fi
     fi
 
-    # Output JSON
     local issues_json warnings_json
     issues_json=$(printf '%s\n' "${issues[@]:-}" | jq -R -s -c 'split("\n") | map(select(. != ""))')
     warnings_json=$(printf '%s\n' "${warnings[@]:-}" | jq -R -s -c 'split("\n") | map(select(. != ""))')

--- a/.agents/skills/github/scripts/commands/pr-merge.sh
+++ b/.agents/skills/github/scripts/commands/pr-merge.sh
@@ -1,38 +1,4 @@
 #!/bin/bash
-# Merge PR as bot account with safety checks
-# Usage: pr-merge <PR_NUMBER> [--check] [--force] [--auto] [--dry-run]
-#
-# Outcomes (distinct exit codes + messages):
-#   0   MERGED                 — merge completed immediately
-#   0   ALREADY MERGED         — PR was already merged; nothing attempted
-#   75  QUEUED / AUTO-MERGE     — merge queue entry or classic auto-merge is active;
-#                                 VOLATILE: a queue ejection disarms it silently,
-#                                 so the caller keeps watching until MERGED
-#   1   BLOCKED                — checks failed; no merge attempted, none queued
-#   1   CLOSED (not merged)    — PR is closed unmerged; nothing attempted
-#
-# A PR that has left OPEN is terminal and short-circuits before any check or
-# mutation: `mergeable` stays UNKNOWN forever once a PR is merged or closed, so
-# running the checks against it manufactures blockers that can never clear.
-#
-# Actionable unresolved review threads are a local hard gate: neither an
-# immediate merge nor `--auto` may mutate merge state while they remain. Only
-# the deliberately dangerous `--force` override skips this gate.
-#
-# `--auto` is idempotent for merge-queue repositories: a re-invocation on a PR
-# that is already enrolled reports QUEUED (75) from the authoritative post-call
-# snapshot, not BLOCKED, even though `gh pr merge --auto` exits nonzero when the
-# PR is already queued.
-# `--force` is deliberately different: it promises an immediate attempt, so a
-# nonzero merge mutation stays BLOCKED unless the exact head is now MERGED.
-# Auto-merge or a queue entry already active before the call is not success
-# proof for this mode.
-#
-# When BLOCKED, stderr distinguishes TRANSIENT issues (mergeable UNKNOWN,
-# ci pending — caller should `await-mergeable` and retry) from PERMANENT
-# issues (conflicts, ci_failed, changes_requested — caller must fix and re-push).
-# Still-running checks are emitted as ci_pending, not ci_failed.
-
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -84,10 +50,79 @@ Modes:
   --auto           Enable auto-merge when immediate merge is blocked
 
 Exit codes:
-  0    MERGED / ALREADY MERGED — merge completed now, or the PR was already merged
-  75   QUEUED / AUTO-MERGE     — merge queue entry or classic auto-merge is active
-                                 (volatile: an ejection disarms it silently — keep watching)
-  1    BLOCKED / CLOSED        — checks failed or the PR is closed unmerged; nothing queued
+  0    MERGED PR #N
+       Merge completed immediately.
+  0    ALREADY MERGED PR #N <mergedAt>
+       The PR was merged before this call. Nothing was attempted.
+  75   QUEUED IN MERGE QUEUE PR #N
+       The required merge queue has an active entry.
+  75   AUTO-MERGE ENABLED PR #N
+       Classic auto-merge is armed until protection clears.
+  1    BLOCKED PR #N
+       Nothing merged, queued, or armed.
+  1    CLOSED (not merged) PR #N
+       The PR is closed unmerged. Nothing was attempted.
+
+Exit 75 is volatile:
+  A queue ejection or failed protection check can disarm merge state without
+  another notification. Keep a watcher running until the PR is MERGED. Use
+  the orch skill's queue-wait <N> or the review-gate pr-watch.sh reducer, then
+  repair the named cause and re-arm with github.sh pr-merge <N> --auto.
+  Neither watcher is durable. await-mergeable is not an ejection watcher; it
+  stops when GitHub finishes computing the current merge state.
+
+Terminal and mutation rules:
+  A PR outside OPEN is terminal. Every mode returns its state before checks,
+  auth, or mutation. --check reports that lifecycle in state.
+
+  Every mutation resolves the checked head and passes --match-head-commit.
+  A post-mutation snapshot for another head is BLOCKED. Queue membership comes
+  from GraphQL isInMergeQueue and mergeQueueEntry. An OPEN PR with an active
+  queue entry exits 75 even when autoMergeRequest is absent. An OPEN PR with
+  no queue or auto-merge proof fails closed.
+
+Review-thread gate:
+  Unresolved, non-outdated review threads make can_merge false and block both
+  immediate merge and --auto. A failed or malformed thread lookup also blocks.
+  This is narrower than required_conversation_resolution, which requires every
+  conversation resolved and does not exclude outdated threads.
+
+  The gate is policy, not mechanism. It applies only through pr-merge. A raw
+  gh pr merge call or the GitHub UI Merge button bypasses it.
+
+Force rules:
+  --force is the only deliberate override. It skips every check, including the
+  thread gate. It is immediate-only and cannot be combined with --auto. A
+  failed force mutation remains BLOCKED unless the exact-head post-state is
+  MERGED; a pre-existing queue entry or auto-merge request is not success.
+
+--check JSON:
+  stdout is one object with these fields:
+    can_merge   boolean readiness result
+    issues      blocking issue strings
+    warnings    non-blocking issue strings
+    mergeable   MERGEABLE, CONFLICTING, or UNKNOWN
+    review      GitHub review decision
+    transient   true only when every blocker can clear by waiting
+    state       OPEN, MERGED, CLOSED, or UNKNOWN
+    merged_at   merge timestamp, or an empty string
+    head_runs   run IDs used for CI classification
+    checks      raw check rollup read by the classification
+
+  stderr carries mergeable, blocked, merged, or closed, followed by
+  head-run: <ids> when CI runs were classified. can_merge=false with an empty
+  issues array means the PR is terminal; inspect state instead of treating it
+  as a blocker to repair.
+
+  transient=true requires every issue prefix to be unknown:, ci_pending:,
+  ci_unconfigured:, or ci_fetch_failed:. A ci_failed: issue is permanent, as
+  are conflicts and changes_requested. Running checks use ci_pending: while
+  failed or cancelled checks use ci_failed:.
+
+  head_runs contains the authoritative workflow run plus runs referenced by
+  custom commit statuses. checks is the same snapshot consumed by
+  ci-classify-refusal <N>, so cause:, fail:, and superseded: lines cannot race
+  a second fetch.
 
 Examples:
   github.sh pr-merge 42 --check          # Check only, JSON output
@@ -170,18 +205,6 @@ exit_terminal_state() {
     esac
 }
 
-# Run safety checks, output JSON
-# JSON shape:
-#   {can_merge, issues, warnings, mergeable, review,
-#    transient: bool,     # true when only TRANSIENT issues are blocking
-#    state,               # PR lifecycle state: OPEN, MERGED, CLOSED, UNKNOWN
-#    merged_at,           # merge timestamp, "" unless state is MERGED
-#    head_runs,           # run ids the CI classification was scoped to
-#                         # (classify_checks_rollup); [] when none or no fetch
-#    checks}              # the raw rollup this classification read — the
-#                         # ONE snapshot ci-classify-refusal re-scopes
-#                         # instead of refetching; [] on fetch failure or
-#                         # no configured checks
 run_checks() {
     local pr_num="$1"
     local can_merge=true
@@ -324,7 +347,6 @@ run_checks() {
         '{can_merge: $can_merge, issues: $issues, warnings: $warnings, mergeable: $mergeable, review: $review, transient: $transient, state: $state, merged_at: $merged_at, head_runs: $head_runs, checks: $checks}'
 }
 
-# Print BLOCKED breakdown to stderr, distinguishing transient vs permanent.
 print_blocked() {
     local check_result="$1"
     local pr_num="$2"
@@ -363,10 +385,6 @@ gh_with_token() {
     fi
 }
 
-# Exit 75 is not a resting state: a merge-group failure ejects the entry, a
-# failed protection check drops classic auto-merge, and GitHub disarms the PR
-# silently either way — it can sit open, gate-clear, and unwatched. Every 75
-# exit says so and names runnable watchers.
 volatile_note() {
     local pr_num="$1" repo="${GH_REPO:-}" remote resolved reducer
     # pr-watch.sh requires GH_REPO; print the reducer with the repository it
@@ -413,10 +431,6 @@ volatile_note() {
     echo "  Launch the prepared .agents/skills/orch/scripts/merge-queue-watch once; route its claimed action by orch merge-pr.md § 5 step 1, and never re-arm an unrecognized verdict. The fleet reducer is $reducer; repair what the cause names before re-arming with .agents/skills/github/scripts/github.sh pr-merge $pr_num --auto" >&2
 }
 
-# Read one authoritative post-mutation snapshot. `gh pr view --json` does not
-# expose merge-queue membership, so required-queue repositories need GraphQL.
-# Fall back to the classic `gh pr view` fields when the queue query itself is
-# unavailable; queue membership remains false in that fail-closed fallback.
 post_merge_snapshot() {
     local pr_num="$1"
     local auth_token="$2"
@@ -536,8 +550,6 @@ main() {
         echo "Error: --expected-head must be a 40-character commit SHA" >&2; exit 1
     fi
 
-    # Check-only mode: JSON on stdout stays the machine interface; the verdict
-    # and run scope (shared check_verdict_lines) go to stderr for jq pipelines.
     if [ "$check_only" = true ]; then
         local check_json
         check_json=$(run_checks "$pr_num")
@@ -546,10 +558,6 @@ main() {
         exit 0
     fi
 
-    # Terminal-state short-circuit, ahead of every mode's checks, auth, and
-    # mutation. Retrying a merge on a PR that already left OPEN can only
-    # produce false diagnostics, and there is nothing left to mutate.
-    # An unreadable state is not terminal — fall through to the normal path.
     if load_pr_state_json "$pr_num"; then
         exit_terminal_state \
             "$(jq -r '.state // ""' <<<"$PR_STATE_JSON")" \
@@ -560,7 +568,6 @@ main() {
     local token
     token=$(load_bot_token)
 
-    # Unless --force, run checks
     local check_result=""
     if [ "$force" = false ]; then
         local can_merge checked_state checked_merged_at
@@ -583,15 +590,12 @@ main() {
             local has_review_thread_gate
             has_review_thread_gate=$(echo "$check_result" | jq '[.issues[] | select(test("^(unresolved_threads|review_threads_fetch_failed):"))] | length > 0')
 
-            # If --auto, fall through to enable auto-merge below.
-            # Otherwise, exit BLOCKED with breakdown.
             if [ "$auto" != true ] || [ "$has_review_thread_gate" = "true" ]; then
                 print_blocked "$check_result" "$pr_num"
                 exit 1
             fi
         fi
 
-        # Show warnings even on success
         local warnings
         warnings=$(echo "$check_result" | jq -r '.warnings | length')
         if [ "$warnings" -gt 0 ]; then

--- a/.agents/skills/github/scripts/commands/pr-view.sh
+++ b/.agents/skills/github/scripts/commands/pr-view.sh
@@ -87,18 +87,20 @@ EOF
 }
 
 main() {
-    local pr_num=""
-    local json_fields=""
-    local -a extra_args=()
+    local -a cmd=(gh pr view)
 
     while [ $# -gt 0 ]; do
         case "$1" in
             --json)
-                json_fields="$2"
-                shift 2
+                cmd+=("$1")
+                shift
+                if [ $# -gt 0 ]; then
+                    cmd+=("$1")
+                    shift
+                fi
                 ;;
             --json=*)
-                json_fields="${1#--json=}"
+                cmd+=("$1")
                 shift
                 ;;
             --help|-h)
@@ -112,25 +114,12 @@ main() {
                     2
                 exit 2
                 ;;
-            -*)
-                extra_args+=("$1")
-                shift
-                ;;
             *)
-                if [ -z "$pr_num" ]; then
-                    pr_num="$1"
-                else
-                    extra_args+=("$1")
-                fi
+                cmd+=("$1")
                 shift
                 ;;
         esac
     done
-
-    local -a cmd=(gh pr view)
-    [ -n "$pr_num" ] && cmd+=("$pr_num")
-    [ -n "$json_fields" ] && cmd+=(--json "$json_fields")
-    [ ${#extra_args[@]} -gt 0 ] && cmd+=("${extra_args[@]}")
 
     local auth_out auth_err pr_out pr_err
     PR_VIEW_TMP_DIR="$(mktemp -d)"

--- a/.agents/skills/github/scripts/commands/pr-view.sh
+++ b/.agents/skills/github/scripts/commands/pr-view.sh
@@ -68,6 +68,8 @@ Options:
 Note:
   --format is not supported here. For a normalized safe/raw PR view use
   'github.sh pr-data [PR] --format=safe|raw'.
+  Other unrecognized flags and extra positionals pass through to gh pr view
+  for compatibility.
 
 Errors:
   Emits structured JSON on stdout ({"status":..., "error":..., "detail":...,

--- a/.agents/skills/github/scripts/commands/pr-view.sh
+++ b/.agents/skills/github/scripts/commands/pr-view.sh
@@ -91,7 +91,7 @@ main() {
 
     while [ $# -gt 0 ]; do
         case "$1" in
-            --json)
+            --json|--jq|--template|--repo|-q|-t|-R)
                 cmd+=("$1")
                 shift
                 if [ $# -gt 0 ]; then

--- a/.agents/skills/github/scripts/commands/sticky-comment.sh
+++ b/.agents/skills/github/scripts/commands/sticky-comment.sh
@@ -40,6 +40,10 @@ Options:
   --bot <login>    Override $GH_BOT_USERNAME for this call (e.g. for Codex)
   --help, -h       Show this help
 
+Compatibility:
+  Unrecognized flags become positional input. Surplus positionals after the
+  PR number and output selector are ignored.
+
 Output (default):
   JSON object with body, updated_at, id, and computed verdict
 

--- a/.agents/skills/github/scripts/github.sh
+++ b/.agents/skills/github/scripts/github.sh
@@ -73,6 +73,58 @@ Output Formats:
   pr-data and pr-threads take --format=safe|raw only and reject unknown
   flags.
 
+Configuration:
+  Project files load in this order, from lowest to highest precedence:
+    kendex.settings.toml [env]
+    .kendex/settings.toml [env]
+    .env.local
+  Values exported by the parent process override every project file. A .env
+  file is never read.
+
+  GH_TOKEN / GITHUB_TOKEN
+      Pre-resolved user token. Falls back to gh keyring auth.
+  GH_BOT_TOKEN
+      Bot token. Falls back to GH_TOKEN, GITHUB_TOKEN, then gh keyring auth.
+  GH_BOT_USERNAME
+      Username used for review and comment filtering. Default: review-bot[bot]
+  GH_ISSUE_PATTERN
+      Branch issue-id regex. Default: [A-Z]+-[0-9]+
+  GH_VERIFY_CMD
+      Command used by pr-cross-check --verify. Default: auto-detect.
+  KENDEX_GITHUB_OP_TIMEOUT
+      Seconds allowed for op read. Default: 10.
+  KENDEX_GITHUB_AUTH_TIMEOUT
+      Seconds allowed for GitHub auth preflight. Default: 10.
+  KENDEX_GITHUB_PR_VIEW_TIMEOUT
+      Seconds allowed for gh pr view in pr-view. Default: 30.
+  KENDEX_GITHUB_GIT_HTTPS_FALLBACK
+      git-https-auth mode: auto, never, or always. Default: auto.
+
+Token selection:
+  Tokens may be literal ghp_*, gho_*, ghu_*, ghs_*, ghr_*, or github_pat_*
+  values, or op://vault/item/field references. The router selects one token
+  before resolving any 1Password reference. It first checks resolved values
+  in GH_TOKEN, GH_BOT_TOKEN, GITHUB_TOKEN order, then checks op:// references
+  in the same order. Only that selection is passed to op read.
+
+  A resolved selection is exported as GH_TOKEN and GITHUB_TOKEN is removed.
+  If an op:// selection cannot resolve, GH_TOKEN and GITHUB_TOKEN are removed
+  so gh may use keyring auth. A selected GH_BOT_TOKEN keeps its bot identity
+  and does not fall back to a different keyring identity after auth failure.
+
+Auth preflight:
+  When GH_TOKEN or GITHUB_TOKEN is selected, gh api user is authoritative.
+  gh auth status is authoritative only when no environment token is selected.
+  A failed non-bot environment token is removed only when keyring auth passes.
+
+Errors and retries:
+  Most commands write {"error": "message"} JSON to stderr and exit 1.
+  pr-view --json writes its structured failure object to stdout; run
+  'github.sh pr-view --help' for its status values and exit codes.
+  API rate limits and retryable request failures get at most 3 attempts with
+  exponential backoff. An unreadable thread list, comment list, or CI log is
+  an error, never an empty result.
+
 Examples:
   # Get PR data with all threads and comments
   ./github.sh pr-data 23

--- a/.agents/skills/github/scripts/github.sh
+++ b/.agents/skills/github/scripts/github.sh
@@ -73,6 +73,11 @@ Output Formats:
   pr-data and pr-threads take --format=safe|raw only and reject unknown
   flags.
 
+Argument rules:
+  Subcommands reject unknown flags and positionals beyond their documented
+  Usage. A positional body or omitted PR number is accepted only when that
+  command's Usage shows it.
+
 Configuration:
   Project files load in this order, from lowest to highest precedence:
     kendex.settings.toml [env]
@@ -121,9 +126,11 @@ Errors and retries:
   Most commands write {"error": "message"} JSON to stderr and exit 1.
   pr-view --json writes its structured failure object to stdout; run
   'github.sh pr-view --help' for its status values and exit codes.
-  API rate limits and retryable request failures get at most 3 attempts with
-  exponential backoff. An unreadable thread list, comment list, or CI log is
-  an error, never an empty result.
+  Operations routed through the shared gh_graphql and gh_rest wrappers retry
+  rate limits and retryable request failures for at most 3 attempts with
+  exponential backoff. Other operations keep their command-specific
+  first-failure behavior. An unreadable thread list, comment list, or CI log
+  is an error, never an empty result.
 
 Examples:
   # Get PR data with all threads and comments

--- a/.agents/skills/github/scripts/github.sh
+++ b/.agents/skills/github/scripts/github.sh
@@ -74,9 +74,10 @@ Output Formats:
   flags.
 
 Argument rules:
-  Subcommands reject unknown flags and positionals beyond their documented
-  Usage. A positional body or omitted PR number is accepted only when that
-  command's Usage shows it.
+  Most subcommands reject unknown flags and extra positionals beyond Usage.
+  pr-view passes other flags and extra positionals to gh pr view, except its
+  explicit --format rejection. sticky-comment keeps legacy permissive parsing:
+  unrecognized flags become positional input, and surplus positionals are ignored.
 
 Configuration:
   Project files load in this order, from lowest to highest precedence:

--- a/.agents/skills/github/scripts/github.sh
+++ b/.agents/skills/github/scripts/github.sh
@@ -127,11 +127,13 @@ Errors and retries:
   Most commands write {"error": "message"} JSON to stderr and exit 1.
   pr-view --json writes its structured failure object to stdout; run
   'github.sh pr-view --help' for its status values and exit codes.
-  Operations routed through the shared gh_graphql and gh_rest wrappers retry
-  rate limits and retryable request failures for at most 3 attempts with
-  exponential backoff. Other operations keep their command-specific
-  first-failure behavior. An unreadable thread list, comment list, or CI log
-  is an error, never an empty result.
+  gh_graphql retries only nonzero gh command failures with no GraphQL errors
+  object. gh_rest retries rate limits and other command failures except
+  authentication and not-found responses. Both stop after at most 3 attempts
+  with exponential backoff. GraphQL error objects and excluded REST failures
+  return on the first attempt. Other operations keep command-specific failure
+  behavior. An unreadable thread list, comment list, or CI log is an error,
+  never an empty result.
 
 Examples:
   # Get PR data with all threads and comments

--- a/.agents/skills/github/scripts/github.sh
+++ b/.agents/skills/github/scripts/github.sh
@@ -189,7 +189,8 @@ _takes_value() {
         pr-create:--base | pr-create:--head | pr-create:--label) return 0 ;;
         pr-data:--format | pr-threads:--format) return 0 ;;
         pr-edit-body:--body-file) return 0 ;;
-        pr-view:--json) return 0 ;;
+        pr-view:--json | pr-view:--jq | pr-view:--template | pr-view:--repo) return 0 ;;
+        pr-view:-q | pr-view:-t | pr-view:-R) return 0 ;;
         sticky-comment:--bot) return 0 ;;
         *) return 1 ;;
     esac
@@ -203,7 +204,7 @@ for _arg in "$@"; do
     fi
     case "$_arg" in
         --help|-h) _help_route=1; break ;;
-        --*) if _takes_value "$_arg"; then _skip_value=1; fi ;;
+        -*) if _takes_value "$_arg"; then _skip_value=1; fi ;;
     esac
 done
 unset _arg _skip_value

--- a/.agents/skills/github/scripts/lib/bounded.sh
+++ b/.agents/skills/github/scripts/lib/bounded.sh
@@ -6,9 +6,13 @@ kendex_github_run_bounded() {
   shift
 
   case "$seconds" in
-    0) "$@"; return ;;
     ''|*[!0-9]*) return 125 ;;
   esac
+  seconds=$((10#$seconds))
+  if [ "$seconds" -eq 0 ]; then
+    "$@"
+    return
+  fi
 
   local restore_monitor=0 pid ticks=0 max_ticks status=0 grace=0 target
   case "$-" in

--- a/.agents/skills/github/scripts/lib/bounded.sh
+++ b/.agents/skills/github/scripts/lib/bounded.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Portable wall-clock bound for GitHub helper subprocesses.
+
+kendex_github_run_bounded() {
+  local seconds="$1"
+  shift
+
+  case "$seconds" in
+    0) "$@"; return ;;
+    ''|*[!0-9]*) return 125 ;;
+  esac
+
+  local restore_monitor=0 pid ticks=0 max_ticks status=0 grace=0 target
+  case "$-" in
+    *m*) ;;
+    *) set -m; restore_monitor=1 ;;
+  esac
+
+  "$@" &
+  pid=$!
+  [ "$restore_monitor" -eq 0 ] || set +m
+  target="-$pid"
+  if ! kill -0 -- "$target" 2>/dev/null; then
+    target="$pid"
+  fi
+  max_ticks=$((seconds * 10))
+
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ "$ticks" -ge "$max_ticks" ]; then
+      kill -TERM -- "$target" 2>/dev/null || true
+      while kill -0 -- "$target" 2>/dev/null && [ "$grace" -lt 10 ]; do
+        sleep 0.1
+        grace=$((grace + 1))
+      done
+      kill -KILL -- "$target" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+      return 124
+    fi
+    sleep 0.1
+    ticks=$((ticks + 1))
+  done
+
+  wait "$pid" || status=$?
+  return "$status"
+}
+
+kendex_github_run_bounded_capture() {
+  local seconds="$1" stdout_file="$2" stderr_file="$3"
+  shift 3
+  kendex_github_run_bounded "$seconds" "$@" >"$stdout_file" 2>"$stderr_file"
+}

--- a/.agents/skills/github/scripts/lib/bounded.sh
+++ b/.agents/skills/github/scripts/lib/bounded.sh
@@ -1,6 +1,38 @@
 #!/usr/bin/env bash
 # Portable wall-clock bound for GitHub helper subprocesses.
 
+_kendex_github_restore_trap() {
+  local signal="$1" saved="$2"
+  if [ -n "$saved" ]; then
+    eval "$saved"
+  else
+    trap - "$signal"
+  fi
+}
+
+_kendex_github_stop_bounded_group() {
+  local signal="$1" target="$2" pid="$3" grace=0
+  [ -n "$target" ] || return 0
+  kill -s "$signal" -- "$target" 2>/dev/null || true
+  while kill -0 -- "$target" 2>/dev/null && [ "$grace" -lt 10 ]; do
+    sleep 0.1
+    grace=$((grace + 1))
+  done
+  kill -KILL -- "$target" 2>/dev/null || true
+  [ -z "$pid" ] || wait "$pid" 2>/dev/null || true
+}
+
+_kendex_github_forward_bounded_signal() {
+  local signal="$1" target="$2" pid="$3" old_hup="$4" old_int="$5" old_term="$6"
+  trap - HUP INT TERM
+  _kendex_github_stop_bounded_group "$signal" "$target" "$pid"
+  _kendex_github_restore_trap HUP "$old_hup"
+  _kendex_github_restore_trap INT "$old_int"
+  _kendex_github_restore_trap TERM "$old_term"
+  kill -s "$signal" "$$" 2>/dev/null || true
+  case "$signal" in HUP) return 129 ;; INT) return 130 ;; TERM) return 143 ;; esac
+}
+
 kendex_github_run_bounded() {
   local seconds="$1"
   shift
@@ -14,7 +46,14 @@ kendex_github_run_bounded() {
     return
   fi
 
-  local restore_monitor=0 pid ticks=0 max_ticks status=0 grace=0 target
+  local restore_monitor=0 pid="" ticks=0 max_ticks status=0 target=""
+  local old_hup old_int old_term
+  old_hup="$(trap -p HUP)"
+  old_int="$(trap -p INT)"
+  old_term="$(trap -p TERM)"
+  trap '_kendex_github_forward_bounded_signal HUP "$target" "$pid" "$old_hup" "$old_int" "$old_term"' HUP
+  trap '_kendex_github_forward_bounded_signal INT "$target" "$pid" "$old_hup" "$old_int" "$old_term"' INT
+  trap '_kendex_github_forward_bounded_signal TERM "$target" "$pid" "$old_hup" "$old_int" "$old_term"' TERM
   case "$-" in
     *m*) ;;
     *) set -m; restore_monitor=1 ;;
@@ -31,13 +70,10 @@ kendex_github_run_bounded() {
 
   while kill -0 "$pid" 2>/dev/null; do
     if [ "$ticks" -ge "$max_ticks" ]; then
-      kill -TERM -- "$target" 2>/dev/null || true
-      while kill -0 -- "$target" 2>/dev/null && [ "$grace" -lt 10 ]; do
-        sleep 0.1
-        grace=$((grace + 1))
-      done
-      kill -KILL -- "$target" 2>/dev/null || true
-      wait "$pid" 2>/dev/null || true
+      _kendex_github_stop_bounded_group TERM "$target" "$pid"
+      _kendex_github_restore_trap HUP "$old_hup"
+      _kendex_github_restore_trap INT "$old_int"
+      _kendex_github_restore_trap TERM "$old_term"
       return 124
     fi
     sleep 0.1
@@ -45,6 +81,9 @@ kendex_github_run_bounded() {
   done
 
   wait "$pid" || status=$?
+  _kendex_github_restore_trap HUP "$old_hup"
+  _kendex_github_restore_trap INT "$old_int"
+  _kendex_github_restore_trap TERM "$old_term"
   return "$status"
 }
 

--- a/.agents/skills/github/scripts/lib/bounded.sh
+++ b/.agents/skills/github/scripts/lib/bounded.sh
@@ -10,11 +10,41 @@ _kendex_github_restore_trap() {
   fi
 }
 
+_kendex_github_bounded_group_members() {
+  local group="$1" leader="$2"
+  ps -eo pid=,pgid= 2>/dev/null | awk -v group="$group" -v leader="$leader" '
+    $2 == group && $1 != leader { print $1 }
+  '
+}
+
 _kendex_github_stop_bounded_group() {
-  local signal="$1" target="$2" pid="$3" grace=0
+  local signal="$1" target="$2" pid="$3" grace=0 group="" members="" member scan_failed=0
   [ -n "$target" ] || return 0
-  kill -s "$signal" -- "$target" 2>/dev/null || true
-  while kill -0 -- "$target" 2>/dev/null && [ "$grace" -lt 10 ]; do
+
+  case "$target" in -*) group="${target#-}" ;; esac
+  if [ -n "$group" ]; then
+    while [ "$grace" -lt 10 ]; do
+      if ! members="$(_kendex_github_bounded_group_members "$group" "$pid")"; then
+        scan_failed=1
+        break
+      fi
+      [ -n "$members" ] || break
+      while IFS= read -r member; do
+        [ -z "$member" ] || kill -s "$signal" "$member" 2>/dev/null || true
+      done <<<"$members"
+      sleep 0.1
+      grace=$((grace + 1))
+    done
+  fi
+
+  if [ "$scan_failed" -eq 1 ]; then
+    kill -s "$signal" -- "$target" 2>/dev/null || true
+  elif [ -n "$pid" ]; then
+    kill -s "$signal" "$pid" 2>/dev/null || true
+  fi
+
+  grace=0
+  while [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && [ "$grace" -lt 10 ]; do
     sleep 0.1
     grace=$((grace + 1))
   done

--- a/.agents/skills/github/scripts/lib/gh-auth.sh
+++ b/.agents/skills/github/scripts/lib/gh-auth.sh
@@ -9,25 +9,10 @@ kendex_github_is_resolved_token() {
   [[ "$token" =~ ^gh[pours]_ ]] || [[ "$token" =~ ^github_pat_ ]]
 }
 
-kendex_github_run_bounded() {
-  local seconds="$1"
-  shift
-
-  if command -v timeout >/dev/null 2>&1; then
-    timeout "${seconds}s" "$@"
-  else
-    "$@"
-  fi
-}
-
-kendex_github_run_bounded_capture() {
-  local seconds="$1"
-  local stdout_file="$2"
-  local stderr_file="$3"
-  shift 3
-
-  kendex_github_run_bounded "$seconds" "$@" >"$stdout_file" 2>"$stderr_file"
-}
+_GH_AUTH_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bounded.sh
+source "$_GH_AUTH_LIB_DIR/bounded.sh"
+unset _GH_AUTH_LIB_DIR
 
 kendex_github_has_env_token() {
   [[ -n "${GH_TOKEN:-}${GITHUB_TOKEN:-}" ]]
@@ -90,11 +75,7 @@ kendex_github_resolve_op_reference_to_var() {
     return 1
   fi
 
-  if command -v timeout >/dev/null 2>&1; then
-    op_output=$(timeout "${op_timeout}s" op read "$ref" 2>&1) || op_status=$?
-  else
-    op_output=$(op read "$ref" 2>&1) || op_status=$?
-  fi
+  op_output=$(kendex_github_run_bounded "$op_timeout" op read "$ref" 2>&1) || op_status=$?
 
   if [[ "$op_status" -eq 0 && -n "$op_output" ]]; then
     printf -v "$out_var" '%s' "$op_output"

--- a/.agents/skills/github/tests/bounded-signal.test.sh
+++ b/.agents/skills/github/tests/bounded-signal.test.sh
@@ -3,6 +3,35 @@ set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BOUNDED="$(cd "$TEST_DIR/.." && pwd)/scripts/lib/bounded.sh"
+SELF="$TEST_DIR/$(basename "${BASH_SOURCE[0]}")"
+
+if [[ "${KENDEX_BOUNDED_NONREAPING_PID1:-0}" != "1" ]] \
+  && command -v unshare >/dev/null 2>&1 \
+  && command -v python3 >/dev/null 2>&1 \
+  && unshare --user --map-root-user --pid --fork --mount-proc true 2>/dev/null; then
+  exec unshare --user --map-root-user --pid --fork --mount-proc \
+    python3 -c '
+import glob, os, subprocess, sys, time
+env = os.environ.copy()
+env["KENDEX_BOUNDED_NONREAPING_PID1"] = "1"
+run = subprocess.run(["bash", sys.argv[1]], env=env)
+time.sleep(0.1)
+zombies = []
+for path in glob.glob("/proc/[0-9]*/stat"):
+    try:
+        fields = open(path).read().split()
+        if fields[2] == "Z" and fields[3] == "1":
+            zombies.append((fields[0], fields[1], fields[4]))
+    except (IndexError, OSError):
+        pass
+if zombies:
+    print("FAIL  non-reaping PID 1 adopted zombies: %r" % (zombies,))
+    sys.exit(1)
+print("ok    non-reaping PID 1 adopted no zombies")
+sys.exit(run.returncode)
+' "$SELF"
+fi
+
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 

--- a/.agents/skills/github/tests/bounded-signal.test.sh
+++ b/.agents/skills/github/tests/bounded-signal.test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BOUNDED="$(cd "$TEST_DIR/.." && pwd)/scripts/lib/bounded.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+
+cat >"$TMP/worker.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$$" >"$PID_FILE"
+exec >/dev/null 2>&1
+sleep 30
+EOF
+chmod +x "$TMP/worker.sh"
+
+cat >"$TMP/wrapper.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+source "$BOUNDED"
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+kendex_github_run_bounded 30 "$WORKER"
+EOF
+chmod +x "$TMP/wrapper.sh"
+
+check_signal() {
+  local signal="$1" expected="$2" rc child_pid="" tries=0
+  local pid_file="$TMP/$signal.pid"
+  set +e
+  SIGNAL="$signal" BOUNDED="$BOUNDED" WORKER="$TMP/worker.sh" \
+    WRAPPER="$TMP/wrapper.sh" PID_FILE="$pid_file" \
+    bash -c '
+      set -m
+      "$WRAPPER" &
+      wrapper=$!
+      tries=0
+      while [[ ! -s "$PID_FILE" && "$tries" -lt 100 ]]; do
+        sleep 0.02
+        tries=$((tries + 1))
+      done
+      kill -s "$SIGNAL" "$wrapper"
+      wait "$wrapper"
+      exit $?
+    ' >"$TMP/$signal.out" 2>"$TMP/$signal.err"
+  rc=$?
+  set -e
+
+  if [[ "$rc" -eq "$expected" ]]; then
+    PASS=$((PASS + 1)); printf '  ok    %s exits %s\n' "$signal" "$expected"
+  else
+    FAIL=$((FAIL + 1)); printf '  FAIL  %s exit: expected %s, got %s\n' "$signal" "$expected" "$rc"
+  fi
+
+  if [[ -s "$pid_file" ]]; then
+    child_pid="$(<"$pid_file")"
+  fi
+  while [[ -n "$child_pid" ]] && kill -0 -- "-$child_pid" 2>/dev/null \
+    && [[ "$tries" -lt 20 ]]; do
+    sleep 0.05
+    tries=$((tries + 1))
+  done
+  if [[ -n "$child_pid" ]] && kill -0 -- "-$child_pid" 2>/dev/null; then
+    FAIL=$((FAIL + 1)); printf '  FAIL  %s left process group %s alive\n' "$signal" "$child_pid"
+    kill -KILL -- "-$child_pid" 2>/dev/null || true
+  elif [[ -n "$child_pid" ]]; then
+    PASS=$((PASS + 1)); printf '  ok    %s cleaned process group %s\n' "$signal" "$child_pid"
+  else
+    FAIL=$((FAIL + 1)); printf '  FAIL  %s worker wrote no pid\n' "$signal"
+  fi
+}
+
+echo "=== bounded runner signal cleanup ==="
+check_signal HUP 129
+check_signal INT 130
+check_signal TERM 143
+
+printf '\npass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/.agents/skills/github/tests/help-contracts.test.sh
+++ b/.agents/skills/github/tests/help-contracts.test.sh
@@ -167,10 +167,15 @@ run_help_contracts() {
   done
 
   for token in 'ALREADY MERGED PR #N' 'QUEUED IN MERGE QUEUE PR #N' \
-    'AUTO-MERGE ENABLED PR #N' 'CLOSED (not merged) PR #N'; do
+    'AUTO-MERGE ENABLED PR #N' 'BLOCKED PR #N' \
+    'The requested operation failed' 'pre-existing queue entry' \
+    'auto-merge request may remain active' 'CLOSED (not merged) PR #N'; do
     assert_section_token "$merge_help" 'Merge-mode exit codes:' '--check exit:' "$token" \
       "$label exit codes carry $token"
   done
+  assert_section_rejects_token "$merge_help" 'Merge-mode exit codes:' '--check exit:' \
+    'Nothing merged, queued, or armed.' \
+    "$label BLOCKED outcome does not erase pre-existing pending state"
 
   for token in '--check exits 0' 'valid readiness JSON' 'can_merge=false' \
     'CLOSED' 'nonzero'; do
@@ -229,6 +234,15 @@ merge_decoy=$'Exit 75 is volatile:\nwatch only\nTerminal and mutation rules:\nej
 assert_section_rejects_decoy "$merge_decoy" 'Exit 75 is volatile:' \
   'Terminal and mutation rules:' 'ejected' \
   'pr-merge token in a sibling section does not satisfy ownership'
+
+stale_blocked_help=$'Merge-mode exit codes:\n  1 BLOCKED PR #N\n  Nothing merged, queued, or armed.\n--check exit:'
+if section_has_token "$stale_blocked_help" 'Merge-mode exit codes:' '--check exit:' \
+    'Nothing merged, queued, or armed.'; then
+  pass 'stale BLOCKED claim is detectable inside its owning section'
+else
+  fail 'stale BLOCKED claim is detectable inside its owning section' \
+    'the stale-claim control did not reach the merge exit table'
+fi
 
 echo
 echo "=== SKILL word ceiling and mirror ==="

--- a/.agents/skills/github/tests/help-contracts.test.sh
+++ b/.agents/skills/github/tests/help-contracts.test.sh
@@ -2,79 +2,209 @@
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-GITHUB_SH="$(cd "$TEST_DIR/.." && pwd)/scripts/github.sh"
+PACKAGE_ROOT="$(cd "$TEST_DIR/.." && pwd)"
+REPO_ROOT="$(git -C "$TEST_DIR" rev-parse --show-toplevel)"
+CANONICAL="$REPO_ROOT/skills/github"
+MIRROR="$REPO_ROOT/.agents/skills/github"
+[[ -d "$CANONICAL" ]] || CANONICAL="$PACKAGE_ROOT"
+[[ -d "$MIRROR" ]] || MIRROR="$PACKAGE_ROOT"
 
 PASS=0
 FAIL=0
 
-assert_token() {
-  local output="$1" token="$2" name="$3"
-  if grep -qF -- "$token" <<<"$output"; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
+pass() {
+  PASS=$((PASS + 1))
+  printf '  ok    %s\n' "$1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  printf '  FAIL  %s\n        %s\n' "$1" "$2"
+}
+
+extract_section() {
+  local output="$1" start="$2" end="$3" start_count end_count
+  start_count=$(grep -cxF -- "$start" <<<"$output" || true)
+  end_count=$(grep -cxF -- "$end" <<<"$output" || true)
+  [[ "$start_count" -eq 1 && "$end_count" -eq 1 ]] || return 2
+  awk -v start="$start" -v end="$end" '
+    $0 == start { inside = 1; next }
+    $0 == end { if (inside) exit }
+    inside { print }
+  ' <<<"$output"
+}
+
+section_has_token() {
+  local output="$1" start="$2" end="$3" token="$4" section
+  section=$(extract_section "$output" "$start" "$end") || return 1
+  grep -qF -- "$token" <<<"$section"
+}
+
+assert_section_token() {
+  local output="$1" start="$2" end="$3" token="$4" name="$5"
+  if section_has_token "$output" "$start" "$end" "$token"; then
+    pass "$name"
   else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        missing token: %s\n' "$name" "$token"
+    fail "$name" "missing $token inside $start"
   fi
 }
 
-echo "=== github.sh help owns configuration and error contracts ==="
-github_help="$($GITHUB_SH --help)"
-for token in \
-  'Configuration:' \
-  'GH_TOKEN' \
-  'GITHUB_TOKEN' \
-  'GH_BOT_TOKEN' \
-  'GH_BOT_USERNAME' \
-  'GH_ISSUE_PATTERN' \
-  'GH_VERIFY_CMD' \
-  'KENDEX_GITHUB_OP_TIMEOUT' \
-  'KENDEX_GITHUB_AUTH_TIMEOUT' \
-  'KENDEX_GITHUB_PR_VIEW_TIMEOUT' \
-  'KENDEX_GITHUB_GIT_HTTPS_FALLBACK' \
-  'kendex.settings.toml' \
-  '.kendex/settings.toml' \
-  '.env.local' \
-  'op://' \
-  'gh api user' \
-  'gh auth status' \
-  '{"error": "message"}' \
-  'pr-view --json' \
-  '3 attempts'; do
-  assert_token "$github_help" "$token" "github.sh help carries $token"
-done
+assert_section_rejects_decoy() {
+  local output="$1" start="$2" end="$3" token="$4" name="$5"
+  if section_has_token "$output" "$start" "$end" "$token"; then
+    fail "$name" "accepted $token from a sibling section"
+  else
+    pass "$name"
+  fi
+}
+
+word_count_at_most() {
+  local text="$1" limit="$2" count
+  count=$(wc -w <<<"$text")
+  [[ "$count" -le "$limit" ]]
+}
+
+assert_file_word_limit() {
+  local file="$1" name="$2" text count
+  text=$(<"$file")
+  count=$(wc -w <<<"$text")
+  if word_count_at_most "$text" 900; then
+    pass "$name ($count words)"
+  else
+    fail "$name" "$count words exceeds 900"
+  fi
+}
+
+assert_file_token() {
+  local file="$1" token="$2" name="$3"
+  if grep -qF -- "$token" "$file"; then
+    pass "$name"
+  else
+    fail "$name" "missing token: $token"
+  fi
+}
+
+run_help_contracts() {
+  local label="$1" root="$2" github_help merge_help label_add_help label_remove_help token
+  github_help=$("$root/scripts/github.sh" --help)
+  merge_help=$("$root/scripts/github.sh" pr-merge --help)
+  label_add_help=$("$root/scripts/github.sh" label-add --help)
+  label_remove_help=$("$root/scripts/github.sh" label-remove --help)
+
+  for token in 'unknown flags' 'positionals' 'positional body' 'omitted PR number'; do
+    assert_section_token "$github_help" 'Argument rules:' 'Configuration:' "$token" \
+      "$label argument rules carry $token"
+  done
+
+  for token in 'GH_TOKEN' 'GITHUB_TOKEN' 'GH_BOT_TOKEN' 'GH_BOT_USERNAME' \
+    'GH_ISSUE_PATTERN' 'GH_VERIFY_CMD' 'KENDEX_GITHUB_OP_TIMEOUT' \
+    'KENDEX_GITHUB_AUTH_TIMEOUT' 'KENDEX_GITHUB_PR_VIEW_TIMEOUT' \
+    'KENDEX_GITHUB_GIT_HTTPS_FALLBACK' 'kendex.settings.toml' \
+    '.kendex/settings.toml' '.env.local'; do
+    assert_section_token "$github_help" 'Configuration:' 'Token selection:' "$token" \
+      "$label configuration carries $token"
+  done
+
+  for token in 'GH_TOKEN, GH_BOT_TOKEN, GITHUB_TOKEN' 'op://' 'op read'; do
+    assert_section_token "$github_help" 'Token selection:' 'Auth preflight:' "$token" \
+      "$label token selection carries $token"
+  done
+
+  for token in 'gh api user' 'gh auth status'; do
+    assert_section_token "$github_help" 'Auth preflight:' 'Errors and retries:' "$token" \
+      "$label auth preflight carries $token"
+  done
+
+  for token in '{"error": "message"}' 'pr-view --json' 'gh_graphql' 'gh_rest' \
+    '3 attempts' 'first-failure'; do
+    assert_section_token "$github_help" 'Errors and retries:' 'Examples:' "$token" \
+      "$label errors carry $token"
+  done
+
+  for token in 'kendex.settings.toml' '.kendex/settings.toml' '.env.local' \
+    'Parent-process'; do
+    assert_section_token "$label_add_help" 'Configuration:' 'Examples:' "$token" \
+      "$label label-add configuration carries $token"
+    assert_section_token "$label_remove_help" 'Configuration:' 'Examples:' "$token" \
+      "$label label-remove configuration carries $token"
+  done
+
+  for token in 'ALREADY MERGED PR #N' 'QUEUED IN MERGE QUEUE PR #N' \
+    'AUTO-MERGE ENABLED PR #N' 'CLOSED (not merged) PR #N'; do
+    assert_section_token "$merge_help" 'Exit codes:' 'Exit 75 is volatile:' "$token" \
+      "$label exit codes carry $token"
+  done
+
+  for token in 'queue-wait <N>' 'pr-watch.sh' 'ejected' 'disarmed' 'not_queued' \
+    'Dequeued' 'closed' 'unknown' 'README.md "Exit 75 recovery"' 'await-mergeable'; do
+    assert_section_token "$merge_help" 'Exit 75 is volatile:' 'Terminal and mutation rules:' "$token" \
+      "$label exit-75 routing carries $token"
+  done
+
+  for token in 'github.sh router setup' 'bot-token load' 'merge-state mutation' \
+    'exact-head guarded' '--match-head-commit' '--delete-branch' \
+    'best-effort'; do
+    assert_section_token "$merge_help" 'Terminal and mutation rules:' 'Review-thread gate:' "$token" \
+      "$label terminal and mutation rules carry $token"
+  done
+
+  for token in 'required_conversation_resolution' 'gh pr merge' 'UI Merge button'; do
+    assert_section_token "$merge_help" 'Review-thread gate:' 'Force rules:' "$token" \
+      "$label review-thread gate carries $token"
+  done
+
+  for token in '--force' '--auto' 'exact-head post-state'; do
+    assert_section_token "$merge_help" 'Force rules:' '--check JSON:' "$token" \
+      "$label force rules carry $token"
+  done
+
+  for token in 'can_merge' 'issues' 'transient' 'state' 'merged_at' 'head_runs' \
+    'checks' 'ci-classify-refusal' 'unknown:' 'ci_pending:' 'ci_unconfigured:' \
+    'ci_fetch_failed:' 'ci_failed:'; do
+    assert_section_token "$merge_help" '--check JSON:' 'Examples:' "$token" \
+      "$label check JSON carries $token"
+  done
+}
+
+echo "=== bounded help contracts ==="
+run_help_contracts canonical "$CANONICAL"
+run_help_contracts mirror "$MIRROR"
 
 echo
-echo "=== pr-merge help owns merge outcomes and checks ==="
-merge_help="$($GITHUB_SH pr-merge --help)"
-for token in \
-  'Exit codes:' \
-  'ALREADY MERGED PR #N' \
-  'QUEUED IN MERGE QUEUE PR #N' \
-  'AUTO-MERGE ENABLED PR #N' \
-  'CLOSED (not merged) PR #N' \
-  'queue-wait <N>' \
-  'pr-watch.sh' \
-  'await-mergeable' \
-  '--match-head-commit' \
-  'isInMergeQueue' \
-  'required_conversation_resolution' \
-  'gh pr merge' \
-  'can_merge' \
-  'issues' \
-  'transient' \
-  'state' \
-  'merged_at' \
-  'head_runs' \
-  'checks' \
-  'ci-classify-refusal' \
-  'unknown:' \
-  'ci_pending:' \
-  'ci_unconfigured:' \
-  'ci_fetch_failed:' \
-  'ci_failed:'; do
-  assert_token "$merge_help" "$token" "pr-merge help carries $token"
-done
+echo "=== section-boundary must-fail controls ==="
+github_decoy=$'Argument rules:\nknown only\nConfiguration:\nunknown flags\nToken selection:'
+assert_section_rejects_decoy "$github_decoy" 'Argument rules:' 'Configuration:' \
+  'unknown flags' 'github token in a sibling section does not satisfy ownership'
+
+merge_decoy=$'Exit 75 is volatile:\nwatch only\nTerminal and mutation rules:\nejected\nReview-thread gate:'
+assert_section_rejects_decoy "$merge_decoy" 'Exit 75 is volatile:' \
+  'Terminal and mutation rules:' 'ejected' \
+  'pr-merge token in a sibling section does not satisfy ownership'
+
+echo
+echo "=== SKILL word ceiling and mirror ==="
+assert_file_word_limit "$CANONICAL/SKILL.md" 'canonical SKILL stays within 900 words'
+assert_file_word_limit "$MIRROR/SKILL.md" 'mirror SKILL stays within 900 words'
+assert_file_token "$CANONICAL/SKILL.md" 'Do not hand-file' \
+  'canonical SKILL keeps the report banner'
+assert_file_token "$MIRROR/SKILL.md" 'Do not hand-file' \
+  'mirror SKILL keeps the report banner'
+assert_file_token "$CANONICAL/SKILL.md" '.agents/skills/orch/scripts/ci-wait' \
+  'canonical SKILL routes CI waiting to orch'
+assert_file_token "$MIRROR/SKILL.md" '.agents/skills/orch/scripts/ci-wait' \
+  'mirror SKILL routes CI waiting to orch'
+if cmp -s "$CANONICAL/SKILL.md" "$MIRROR/SKILL.md"; then
+  pass 'canonical and mirror SKILL files are byte-equivalent'
+else
+  fail 'canonical and mirror SKILL files are byte-equivalent' 'cmp reported drift'
+fi
+
+over_limit=$(awk 'BEGIN { for (i = 1; i <= 901; i++) printf "word " }')
+if word_count_at_most "$over_limit" 900; then
+  fail '901-word control exceeds the ceiling' 'word limit accepted 901 words'
+else
+  pass '901-word control exceeds the ceiling'
+fi
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/.agents/skills/github/tests/help-contracts.test.sh
+++ b/.agents/skills/github/tests/help-contracts.test.sh
@@ -63,6 +63,15 @@ assert_section_rejects_decoy() {
   fi
 }
 
+assert_section_rejects_token() {
+  local output="$1" start="$2" end="$3" token="$4" name="$5"
+  if section_has_token "$output" "$start" "$end" "$token"; then
+    fail "$name" "found stale token: $token"
+  else
+    pass "$name"
+  fi
+}
+
 word_count_at_most() {
   local text="$1" limit="$2" count
   count=$(wc -w <<<"$text")
@@ -90,13 +99,22 @@ assert_file_token() {
 }
 
 run_help_contracts() {
-  local label="$1" root="$2" github_help merge_help label_add_help label_remove_help pr_view_help sticky_help token
+  local label="$1" root="$2" github_help merge_help label_add_help label_remove_help pr_view_help sticky_help readme token
   github_help=$("$root/scripts/github.sh" --help)
   merge_help=$("$root/scripts/github.sh" pr-merge --help)
   label_add_help=$("$root/scripts/github.sh" label-add --help)
   label_remove_help=$("$root/scripts/github.sh" label-remove --help)
   pr_view_help=$("$root/scripts/github.sh" pr-view --help)
   sticky_help=$("$root/scripts/github.sh" sticky-comment --help)
+  readme="$(<"$root/README.md")"
+
+  for token in 'github.sh --help' '<command> --help' 'SKILL.md' 'DEVELOPMENT.md'; do
+    assert_section_token "$readme" '# GitHub Queries' '## Setup' "$token" \
+      "$label README entry point carries $token"
+  done
+  assert_section_rejects_token "$readme" '# GitHub Queries' '## Setup' \
+    'SKILL.md` is the full command reference' \
+    "$label README does not call SKILL.md the full reference"
 
   for token in 'Most subcommands' 'pr-view' 'gh pr view' '--format' \
     'sticky-comment' 'unrecognized flags' 'positional input' 'ignored'; do

--- a/.agents/skills/github/tests/help-contracts.test.sh
+++ b/.agents/skills/github/tests/help-contracts.test.sh
@@ -28,9 +28,14 @@ extract_section() {
   end_count=$(grep -cxF -- "$end" <<<"$output" || true)
   [[ "$start_count" -eq 1 && "$end_count" -eq 1 ]] || return 2
   awk -v start="$start" -v end="$end" '
-    $0 == start { inside = 1; next }
-    $0 == end { if (inside) exit }
-    inside { print }
+    $0 == end {
+      if (!seen_start) bad = 1
+      else seen_end = 1
+      exit
+    }
+    $0 == start { seen_start = 1; next }
+    seen_start { print }
+    END { if (bad || !seen_start || !seen_end) exit 2 }
   ' <<<"$output"
 }
 
@@ -85,15 +90,28 @@ assert_file_token() {
 }
 
 run_help_contracts() {
-  local label="$1" root="$2" github_help merge_help label_add_help label_remove_help token
+  local label="$1" root="$2" github_help merge_help label_add_help label_remove_help pr_view_help sticky_help token
   github_help=$("$root/scripts/github.sh" --help)
   merge_help=$("$root/scripts/github.sh" pr-merge --help)
   label_add_help=$("$root/scripts/github.sh" label-add --help)
   label_remove_help=$("$root/scripts/github.sh" label-remove --help)
+  pr_view_help=$("$root/scripts/github.sh" pr-view --help)
+  sticky_help=$("$root/scripts/github.sh" sticky-comment --help)
 
-  for token in 'unknown flags' 'positionals' 'positional body' 'omitted PR number'; do
+  for token in 'Most subcommands' 'pr-view' 'gh pr view' '--format' \
+    'sticky-comment' 'unrecognized flags' 'positional input' 'ignored'; do
     assert_section_token "$github_help" 'Argument rules:' 'Configuration:' "$token" \
       "$label argument rules carry $token"
+  done
+
+  for token in '--format' 'unrecognized flags' 'extra positionals' 'gh pr view'; do
+    assert_section_token "$pr_view_help" 'Note:' 'Errors:' "$token" \
+      "$label pr-view compatibility carries $token"
+  done
+
+  for token in 'Unrecognized flags' 'positional input' 'Surplus positionals' 'ignored'; do
+    assert_section_token "$sticky_help" 'Compatibility:' 'Output (default):' "$token" \
+      "$label sticky-comment compatibility carries $token"
   done
 
   for token in 'GH_TOKEN' 'GITHUB_TOKEN' 'GH_BOT_TOKEN' 'GH_BOT_USERNAME' \
@@ -131,8 +149,14 @@ run_help_contracts() {
 
   for token in 'ALREADY MERGED PR #N' 'QUEUED IN MERGE QUEUE PR #N' \
     'AUTO-MERGE ENABLED PR #N' 'CLOSED (not merged) PR #N'; do
-    assert_section_token "$merge_help" 'Exit codes:' 'Exit 75 is volatile:' "$token" \
+    assert_section_token "$merge_help" 'Merge-mode exit codes:' '--check exit:' "$token" \
       "$label exit codes carry $token"
+  done
+
+  for token in '--check exits 0' 'valid readiness JSON' 'can_merge=false' \
+    'CLOSED' 'nonzero'; do
+    assert_section_token "$merge_help" '--check exit:' 'Exit 75 is volatile:' "$token" \
+      "$label check exit carries $token"
   done
 
   for token in 'queue-wait <N>' 'pr-watch.sh' 'ejected' 'disarmed' 'not_queued' \
@@ -175,6 +199,10 @@ echo "=== section-boundary must-fail controls ==="
 github_decoy=$'Argument rules:\nknown only\nConfiguration:\nunknown flags\nToken selection:'
 assert_section_rejects_decoy "$github_decoy" 'Argument rules:' 'Configuration:' \
   'unknown flags' 'github token in a sibling section does not satisfy ownership'
+
+reversed_decoy=$'Configuration:\nArgument rules:\nunknown flags\nToken selection:'
+assert_section_rejects_decoy "$reversed_decoy" 'Argument rules:' 'Configuration:' \
+  'unknown flags' 'end-before-start section boundaries are rejected'
 
 merge_decoy=$'Exit 75 is volatile:\nwatch only\nTerminal and mutation rules:\nejected\nReview-thread gate:'
 assert_section_rejects_decoy "$merge_decoy" 'Exit 75 is volatile:' \

--- a/.agents/skills/github/tests/help-contracts.test.sh
+++ b/.agents/skills/github/tests/help-contracts.test.sh
@@ -160,8 +160,9 @@ run_help_contracts() {
       "$label check exit carries $token"
   done
 
-  for token in 'queue-wait <N>' 'pr-watch.sh' 'ejected' 'disarmed' 'not_queued' \
-    'Dequeued' 'closed' 'unknown' 'README.md "Exit 75 recovery"' 'await-mergeable'; do
+  for token in 'merge-queue-watch' 'expected head' 'watch generation' \
+    'durable verdict' 'recovery action' 'README.md "Exit 75 recovery"' \
+    'github.sh pr-merge <N> --auto' 'await-mergeable'; do
     assert_section_token "$merge_help" 'Exit 75 is volatile:' 'Terminal and mutation rules:' "$token" \
       "$label exit-75 routing carries $token"
   done

--- a/.agents/skills/github/tests/help-contracts.test.sh
+++ b/.agents/skills/github/tests/help-contracts.test.sh
@@ -133,8 +133,9 @@ run_help_contracts() {
       "$label auth preflight carries $token"
   done
 
-  for token in '{"error": "message"}' 'pr-view --json' 'gh_graphql' 'gh_rest' \
-    '3 attempts' 'first-failure'; do
+  for token in '{"error": "message"}' 'pr-view --json' 'gh_graphql' 'nonzero' \
+    'GraphQL errors' 'gh_rest' 'rate limits' 'authentication' 'not-found' \
+    '3 attempts' 'first attempt'; do
     assert_section_token "$github_help" 'Errors and retries:' 'Examples:' "$token" \
       "$label errors carry $token"
   done
@@ -165,7 +166,8 @@ run_help_contracts() {
       "$label exit-75 routing carries $token"
   done
 
-  for token in 'github.sh router setup' 'bot-token load' 'merge-state mutation' \
+  for token in 'github.sh router setup' 'MERGED or CLOSED' 'UNKNOWN continues' \
+    'bot-token load' 'merge-state mutation' \
     'exact-head guarded' '--match-head-commit' '--delete-branch' \
     'best-effort'; do
     assert_section_token "$merge_help" 'Terminal and mutation rules:' 'Review-thread gate:' "$token" \

--- a/.agents/skills/github/tests/help-contracts.test.sh
+++ b/.agents/skills/github/tests/help-contracts.test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GITHUB_SH="$(cd "$TEST_DIR/.." && pwd)/scripts/github.sh"
+
+PASS=0
+FAIL=0
+
+assert_token() {
+  local output="$1" token="$2" name="$3"
+  if grep -qF -- "$token" <<<"$output"; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        missing token: %s\n' "$name" "$token"
+  fi
+}
+
+echo "=== github.sh help owns configuration and error contracts ==="
+github_help="$($GITHUB_SH --help)"
+for token in \
+  'Configuration:' \
+  'GH_TOKEN' \
+  'GITHUB_TOKEN' \
+  'GH_BOT_TOKEN' \
+  'GH_BOT_USERNAME' \
+  'GH_ISSUE_PATTERN' \
+  'GH_VERIFY_CMD' \
+  'KENDEX_GITHUB_OP_TIMEOUT' \
+  'KENDEX_GITHUB_AUTH_TIMEOUT' \
+  'KENDEX_GITHUB_PR_VIEW_TIMEOUT' \
+  'KENDEX_GITHUB_GIT_HTTPS_FALLBACK' \
+  'kendex.settings.toml' \
+  '.kendex/settings.toml' \
+  '.env.local' \
+  'op://' \
+  'gh api user' \
+  'gh auth status' \
+  '{"error": "message"}' \
+  'pr-view --json' \
+  '3 attempts'; do
+  assert_token "$github_help" "$token" "github.sh help carries $token"
+done
+
+echo
+echo "=== pr-merge help owns merge outcomes and checks ==="
+merge_help="$($GITHUB_SH pr-merge --help)"
+for token in \
+  'Exit codes:' \
+  'ALREADY MERGED PR #N' \
+  'QUEUED IN MERGE QUEUE PR #N' \
+  'AUTO-MERGE ENABLED PR #N' \
+  'CLOSED (not merged) PR #N' \
+  'queue-wait <N>' \
+  'pr-watch.sh' \
+  'await-mergeable' \
+  '--match-head-commit' \
+  'isInMergeQueue' \
+  'required_conversation_resolution' \
+  'gh pr merge' \
+  'can_merge' \
+  'issues' \
+  'transient' \
+  'state' \
+  'merged_at' \
+  'head_runs' \
+  'checks' \
+  'ci-classify-refusal' \
+  'unknown:' \
+  'ci_pending:' \
+  'ci_unconfigured:' \
+  'ci_fetch_failed:' \
+  'ci_failed:'; do
+  assert_token "$merge_help" "$token" "pr-merge help carries $token"
+done
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/.agents/skills/github/tests/pr-merge-thread-gate-docs.test.sh
+++ b/.agents/skills/github/tests/pr-merge-thread-gate-docs.test.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
 # Docs regression tests for pr-merge's review-thread gate (kendex#825).
 #
-# pr-merge counts only threads that are unresolved AND not outdated, which is
-# deliberately narrower than GitHub's required_conversation_resolution. That
-# divergence, the fact that the gate binds only merges routed through the
-# skill, and the recovery path for outdated threads that block a merge while
-# being unreachable in the UI all live in prose only. These tests pin that
-# prose to the real script behavior so neither side can drift silently.
+# pr-merge counts only threads that are unresolved and not outdated. Its help
+# records that bound; SKILL.md keeps routing and recovery instructions.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -14,6 +10,7 @@ REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
 SKILL_MD="$REPO_ROOT/skills/github/SKILL.md"
 README_MD="$REPO_ROOT/skills/github/README.md"
 PR_MERGE="$REPO_ROOT/skills/github/scripts/commands/pr-merge.sh"
+GITHUB_SH="$REPO_ROOT/skills/github/scripts/github.sh"
 
 PASS=0
 FAIL=0
@@ -40,17 +37,8 @@ assert_matches() {
   fi
 }
 
-# The doc checks pin STRUCTURE — the two bolded rule labels, the API setting
-# name, the escape-path heading and the commands under it, the routing rows
-# that point at it. review-bots.md: a token pin establishes that a structural
-# element is present, never that a behavioral claim written in prose is true,
-# so the SKILL's statement that outdated threads are excluded and the README's
-# statement of the unreachable-in-the-UI hazard have no lint. Nor the escape
-# section's account of how a thread becomes unreachable, nor the README's own
-# policy-not-mechanism bound: SKILL.md carries that one as a bolded label
-# other documents cite, the README as an ordinary sentence. Both of those
-# predate this branch. The script
-# assertions above hold the filter itself, which is what proves the exclusion.
+# Documentation assertions pin headings, commands, flags, and field names.
+# Script assertions prove the filter itself.
 
 echo "=== pr-merge thread-gate docs match the script (kendex#825) ==="
 
@@ -65,21 +53,22 @@ assert_matches "$script_src" 'unresolved_threads\|review_threads_fetch_failed' \
 
 skill_src=$(cat "$SKILL_MD")
 readme_src=$(cat "$README_MD")
+merge_help=$($GITHUB_SH pr-merge --help)
 
 # 1. Actionable-only semantics, named against the platform setting it diverges
 #    from, so an operator can tell the two guarantees apart.
-assert_contains "$skill_src" 'required_conversation_resolution' \
-  "SKILL.md names required_conversation_resolution"
-assert_contains "$skill_src" 'Narrower than branch protection' \
-  "SKILL.md carries the narrower-than-branch-protection rule"
+assert_contains "$merge_help" 'required_conversation_resolution' \
+  "pr-merge help names required_conversation_resolution"
+assert_contains "$merge_help" 'Review-thread gate:' \
+  "pr-merge help carries the review-thread gate"
 
 # 2. Policy, not mechanism: the gate binds only merges routed through pr-merge.
 assert_matches "$skill_src" 'Policy, not mechanism' \
   "SKILL.md frames the gate as policy rather than mechanism"
-assert_matches "$skill_src" 'UI Merge button|Merge button' \
-  "SKILL.md names the UI Merge button as a bypass"
-assert_matches "$skill_src" 'raw .gh pr merge' \
-  "SKILL.md names raw gh pr merge as a bypass"
+assert_contains "$merge_help" 'UI Merge button' \
+  "pr-merge help names the UI Merge button"
+assert_contains "$merge_help" 'gh pr merge' \
+  "pr-merge help names gh pr merge"
 
 # 3. The unreachable-thread escape path. Match on the searchable heading an
 #    operator would land on, then on both commands the recovery needs.

--- a/.agents/skills/github/tests/pr-merge-volatile-75-docs.test.sh
+++ b/.agents/skills/github/tests/pr-merge-volatile-75-docs.test.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
-# Exit 75 (queued / auto-merge armed) is volatile: an ejection disarms it
-# silently. The script says so on every 75 exit and the SKILL.md outcome table
-# names the durable lifecycle a caller must launch; these pins keep the two from
-# drifting apart.
+# Exit 75 is volatile. The script and its help name the durable lifecycle a
+# caller must launch.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -64,21 +62,20 @@ else
   PASS=$((PASS + 1)); printf '  ok    %s\n' "volatile_note makes no gh request"
 fi
 
-table=$(sed -n '/^### PR Merge Outcomes$/,/^### /p' "$SKILL_MD")
-assert_count "$table" '^\| `75` \| MERGE PENDING \(volatile\)' 2 \
-  "both 75 rows of the outcomes table are marked volatile"
-assert_matches "$table" 'launch the prepared durable lifecycle before returning' \
-  "the 75 rows require the prepared lifecycle before return"
-assert_matches "$table" 'one-shot worker writes a durable verdict' \
-  "the outcomes section states the lifecycle durability boundary"
+merge_help=$($GITHUB_SH pr-merge --help)
+volatile_help=$(sed -n '/^Exit 75 is volatile:$/,/^Terminal and mutation rules:$/p' <<<"$merge_help")
+assert_matches "$volatile_help" '^Exit 75 is volatile:$' \
+  "pr-merge help carries the exit-75 contract"
+assert_matches "$volatile_help" 'merge-queue-watch' \
+  "pr-merge help names the durable lifecycle"
+assert_matches "$volatile_help" 'durable verdict' \
+  "pr-merge help states the lifecycle durability boundary"
 assert_matches "$script_src" 'Launch the prepared .*merge-queue-watch once' \
   "the note says to launch one durable lifecycle generation"
-assert_matches "$table" 'merge-queue-watch' \
-  "the outcomes section names merge-queue-watch as the required follow-up"
-assert_matches "$(tr '\n' ' ' <<<"$table")" 'github\.sh pr-merge <N> --auto' \
-  "the outcomes section names the re-arm by its installed entry point"
-assert_matches "$table" 'README\.md § Exit 75 recovery' \
-  "the outcomes section points at the README recovery section (progressive disclosure)"
+assert_matches "$volatile_help" 'github\.sh pr-merge <N> --auto' \
+  "pr-merge help names the re-arm command"
+assert_matches "$volatile_help" 'README\.md "Exit 75 recovery"' \
+  "pr-merge help links the recovery section"
 readme_src=$(sed -n '/^## Exit 75 recovery$/,/^## /p' "$REPO_ROOT/skills/github/README.md")
 assert_matches "$readme_src" 'exits 75 when the PR is queued or auto-merge is armed' \
   "README states the volatile 75 contract"
@@ -113,8 +110,8 @@ assert_matches "$watch_src" 'conflicting:\*\) action=restack' \
   "the lifecycle maps the conflicting producer verdict to that restack action"
 assert_matches "$watch_src" 'malformed_artifact' \
   "an artifact outside the accepted verdict set fails closed"
-assert_matches "$table" 'await-mergeable` is not that' \
-  "the outcomes section states await-mergeable is not the ejection watcher"
+assert_matches "$volatile_help" 'await-mergeable' \
+  "pr-merge help names await-mergeable"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.agents/skills/github/tests/pr-merge-volatile-75-docs.test.sh
+++ b/.agents/skills/github/tests/pr-merge-volatile-75-docs.test.sh
@@ -7,8 +7,8 @@ set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
-SKILL_MD="$REPO_ROOT/skills/github/SKILL.md"
 PR_MERGE="$REPO_ROOT/skills/github/scripts/commands/pr-merge.sh"
+GITHUB_SH="$REPO_ROOT/skills/github/scripts/github.sh"
 
 PASS=0
 FAIL=0
@@ -36,7 +36,7 @@ assert_count() { # GOT PATTERN EXPECTED NAME
   fi
 }
 
-echo "=== pr-merge exit 75 is documented as volatile, in the script and the SKILL ==="
+echo "=== pr-merge exit 75 contract matches script and help ==="
 
 script_src=$(cat "$PR_MERGE")
 # Both 75 exits route through the one note (queued and classic auto-merge).

--- a/.agents/skills/github/tests/pr-view.sh
+++ b/.agents/skills/github/tests/pr-view.sh
@@ -179,6 +179,15 @@ run_pr_view_json_help_value() {
        pr-view --json --help)
 }
 
+run_pr_view_help_value() {
+  local calls_file="$1" flag="$2"
+  (cd "$TMP_ROOT/repo" \
+    && PATH="$TMP_ROOT/bin:$PATH" \
+       STUB_GH_CALLS="$calls_file" \
+       env -u GH_TOKEN -u GITHUB_TOKEN "$GITHUB_SH" -C "$TMP_ROOT/repo" \
+       pr-view "$flag" --help)
+}
+
 without_timeout_utility() {
   command() {
     if [[ "${1:-}" == "-v" && "${2:-}" == "timeout" ]]; then
@@ -386,6 +395,19 @@ set -e
 assert_eq "$rc" "0" "pr-view accepts a help-shaped JSON field value" "$stderr"
 assert_contains "$(cat "$calls")" "pr view --json --help" \
   "pr-view keeps the JSON field value with its option"
+
+for flag in --template --jq --repo -t -q -R; do
+  calls="$TMP_ROOT/pr-view-help-value-${flag#-}.calls"
+  : >"$calls"
+  stderr="$TMP_ROOT/pr-view-help-value-${flag#-}.err"
+  set +e
+  output=$(run_pr_view_help_value "$calls" "$flag" 2>"$stderr")
+  rc=$?
+  set -e
+  assert_eq "$rc" "0" "pr-view accepts --help as the $flag value" "$stderr"
+  assert_contains "$(cat "$calls")" "pr view $flag --help" \
+    "pr-view forwards $flag with its help-shaped value"
+done
 
 echo
 echo "=== github.sh pr-view --format rejection ==="

--- a/.agents/skills/github/tests/pr-view.sh
+++ b/.agents/skills/github/tests/pr-view.sh
@@ -52,6 +52,10 @@ _auth_ok() {
   if [[ "$tok" == op://* ]]; then
     return 1
   fi
+  if [[ "${STUB_TOKEN_ONLY:-0}" == "1" ]]; then
+    [[ "$tok" == "ghs_VALIDBOT123" ]]
+    return
+  fi
   [[ "${STUB_AUTH_OK:-1}" == "1" ]]
 }
 
@@ -226,6 +230,16 @@ assert_eq "$rc" "124" "auth timeout works without the timeout utility" "$stderr"
 assert_eq "$(jq -r .status <<<"$output")" "auth_timeout" \
   "no-utility auth timeout emits structured status" "$stderr"
 
+stderr="$TMP_ROOT/auth-leading-zero.err"
+set +e
+output=$(without_timeout_utility run_pr_view \
+  KENDEX_GITHUB_AUTH_TIMEOUT=08 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "0" "auth timeout accepts a leading-zero decimal" "$stderr"
+assert_eq "$(jq -r .number <<<"$output")" "42" \
+  "leading-zero auth bound reaches gh" "$stderr"
+
 stderr="$TMP_ROOT/api-user-auth-timeout.err"
 set +e
 output=$(run_pr_view GH_TOKEN=ghs_VALIDBOT123 STUB_API_USER_SLEEP=1 KENDEX_GITHUB_AUTH_TIMEOUT=1 2>"$stderr")
@@ -260,6 +274,16 @@ assert_eq "$rc" "124" "gh pr view timeout works without the timeout utility" "$s
 assert_eq "$(jq -r .status <<<"$output")" "gh_timeout" \
   "no-utility gh timeout emits structured status" "$stderr"
 
+stderr="$TMP_ROOT/pr-view-leading-zero.err"
+set +e
+output=$(without_timeout_utility run_pr_view \
+  KENDEX_GITHUB_PR_VIEW_TIMEOUT=09 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "0" "gh timeout accepts a leading-zero decimal" "$stderr"
+assert_eq "$(jq -r .number <<<"$output")" "42" \
+  "leading-zero gh bound returns PR JSON" "$stderr"
+
 rm -f "$TMP_ROOT/op.calls"
 stderr="$TMP_ROOT/inherited-gh-token-op.err"
 set +e
@@ -283,6 +307,16 @@ assert_eq "$(wc -l <"$TMP_ROOT/op.calls")" "1" "inherited op GITHUB_TOKEN attemp
 cat > "$TMP_ROOT/repo/.env.local" <<'ENVEOF'
 GH_BOT_TOKEN=op://vault/item/field
 ENVEOF
+
+stderr="$TMP_ROOT/op-leading-zero.err"
+set +e
+output=$(without_timeout_utility run_pr_view \
+  STUB_TOKEN_ONLY=1 STUB_OP_MODE=ok KENDEX_GITHUB_OP_TIMEOUT=08 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "0" "op timeout accepts a leading-zero decimal" "$stderr"
+assert_eq "$(jq -r .number <<<"$output")" "42" \
+  "leading-zero op bound reaches gh" "$stderr"
 
 stderr="$TMP_ROOT/op-fail.err"
 set +e

--- a/.agents/skills/github/tests/pr-view.sh
+++ b/.agents/skills/github/tests/pr-view.sh
@@ -148,6 +148,15 @@ run_pr_view_format() {
        env -u GH_TOKEN -u GITHUB_TOKEN "$GITHUB_SH" -C "$TMP_ROOT/repo" pr-view 42 "--format=$fmt")
 }
 
+run_pr_view_passthrough() {
+  local calls_file="$1"
+  (cd "$TMP_ROOT/repo" \
+    && PATH="$TMP_ROOT/bin:$PATH" \
+       STUB_GH_CALLS="$calls_file" \
+       env -u GH_TOKEN -u GITHUB_TOKEN "$GITHUB_SH" -C "$TMP_ROOT/repo" \
+       pr-view 42 --web extra-position)
+}
+
 assert_not_contains() {
   local haystack="$1" needle="$2" name="$3"
   if grep -qF -- "$needle" <<<"$haystack"; then
@@ -251,6 +260,17 @@ rc=$?
 set -e
 assert_eq "$rc" "0" "successful pr-view exits 0" "$stderr"
 assert_eq "$(jq -r .number <<<"$output")" "42" "successful pr-view preserves gh JSON" "$stderr"
+
+calls="$TMP_ROOT/pr-view-passthrough.calls"
+: >"$calls"
+stderr="$TMP_ROOT/pr-view-passthrough.err"
+set +e
+output=$(run_pr_view_passthrough "$calls" 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "0" "pr-view accepts passthrough arguments" "$stderr"
+assert_contains "$(cat "$calls")" "pr view 42 --web extra-position" \
+  "pr-view forwards unknown flags and extra positionals"
 
 echo
 echo "=== github.sh pr-view --format rejection ==="

--- a/.agents/skills/github/tests/pr-view.sh
+++ b/.agents/skills/github/tests/pr-view.sh
@@ -157,6 +157,35 @@ run_pr_view_passthrough() {
        pr-view 42 --web extra-position)
 }
 
+run_pr_view_no_pr_passthrough() {
+  local calls_file="$1"
+  (cd "$TMP_ROOT/repo" \
+    && PATH="$TMP_ROOT/bin:$PATH" \
+       STUB_GH_CALLS="$calls_file" \
+       env -u GH_TOKEN -u GITHUB_TOKEN "$GITHUB_SH" -C "$TMP_ROOT/repo" \
+       pr-view --repo owner/repo --json number,state)
+}
+
+run_pr_view_json_help_value() {
+  local calls_file="$1"
+  (cd "$TMP_ROOT/repo" \
+    && PATH="$TMP_ROOT/bin:$PATH" \
+       STUB_GH_CALLS="$calls_file" \
+       env -u GH_TOKEN -u GITHUB_TOKEN "$GITHUB_SH" -C "$TMP_ROOT/repo" \
+       pr-view --json --help)
+}
+
+without_timeout_utility() {
+  command() {
+    if [[ "${1:-}" == "-v" && "${2:-}" == "timeout" ]]; then
+      return 1
+    fi
+    builtin command "$@"
+  }
+  export -f command
+  "$@"
+}
+
 assert_not_contains() {
   local haystack="$1" needle="$2" name="$3"
   if grep -qF -- "$needle" <<<"$haystack"; then
@@ -187,6 +216,16 @@ set -e
 assert_eq "$rc" "124" "auth preflight timeout exits 124" "$stderr"
 assert_eq "$(jq -r .status <<<"$output")" "auth_timeout" "auth timeout emits structured status" "$stderr"
 
+stderr="$TMP_ROOT/auth-timeout-no-utility.err"
+set +e
+output=$(without_timeout_utility run_pr_view \
+  STUB_AUTH_SLEEP=1 KENDEX_GITHUB_AUTH_TIMEOUT=1 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "124" "auth timeout works without the timeout utility" "$stderr"
+assert_eq "$(jq -r .status <<<"$output")" "auth_timeout" \
+  "no-utility auth timeout emits structured status" "$stderr"
+
 stderr="$TMP_ROOT/api-user-auth-timeout.err"
 set +e
 output=$(run_pr_view GH_TOKEN=ghs_VALIDBOT123 STUB_API_USER_SLEEP=1 KENDEX_GITHUB_AUTH_TIMEOUT=1 2>"$stderr")
@@ -210,6 +249,16 @@ rc=$?
 set -e
 assert_eq "$rc" "124" "gh pr view timeout exits 124" "$stderr"
 assert_eq "$(jq -r .status <<<"$output")" "gh_timeout" "gh timeout emits structured status" "$stderr"
+
+stderr="$TMP_ROOT/pr-view-timeout-no-utility.err"
+set +e
+output=$(without_timeout_utility run_pr_view \
+  STUB_PR_MODE=hang KENDEX_GITHUB_PR_VIEW_TIMEOUT=1 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "124" "gh pr view timeout works without the timeout utility" "$stderr"
+assert_eq "$(jq -r .status <<<"$output")" "gh_timeout" \
+  "no-utility gh timeout emits structured status" "$stderr"
 
 rm -f "$TMP_ROOT/op.calls"
 stderr="$TMP_ROOT/inherited-gh-token-op.err"
@@ -251,6 +300,16 @@ set -e
 assert_eq "$rc" "3" "token resolution timeout exits auth code" "$stderr"
 assert_eq "$(jq -r .status <<<"$output")" "token_resolution_timeout" "token timeout emits structured status" "$stderr"
 
+stderr="$TMP_ROOT/op-timeout-no-utility.err"
+set +e
+output=$(without_timeout_utility run_pr_view \
+  STUB_AUTH_OK=0 STUB_OP_MODE=slow KENDEX_GITHUB_OP_TIMEOUT=1 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "3" "op timeout works without the timeout utility" "$stderr"
+assert_eq "$(jq -r .status <<<"$output")" "token_resolution_timeout" \
+  "no-utility op timeout emits structured status" "$stderr"
+
 rm -f "$TMP_ROOT/repo/.env.local"
 
 stderr="$TMP_ROOT/success.err"
@@ -271,6 +330,28 @@ set -e
 assert_eq "$rc" "0" "pr-view accepts passthrough arguments" "$stderr"
 assert_contains "$(cat "$calls")" "pr view 42 --web extra-position" \
   "pr-view forwards unknown flags and extra positionals"
+
+calls="$TMP_ROOT/pr-view-no-pr-passthrough.calls"
+: >"$calls"
+stderr="$TMP_ROOT/pr-view-no-pr-passthrough.err"
+set +e
+output=$(run_pr_view_no_pr_passthrough "$calls" 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "0" "pr-view accepts option values without a PR number" "$stderr"
+assert_contains "$(cat "$calls")" "pr view --repo owner/repo --json number,state" \
+  "pr-view preserves no-PR option-value order"
+
+calls="$TMP_ROOT/pr-view-json-help-value.calls"
+: >"$calls"
+stderr="$TMP_ROOT/pr-view-json-help-value.err"
+set +e
+output=$(run_pr_view_json_help_value "$calls" 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "0" "pr-view accepts a help-shaped JSON field value" "$stderr"
+assert_contains "$(cat "$calls")" "pr view --json --help" \
+  "pr-view keeps the JSON field value with its option"
 
 echo
 echo "=== github.sh pr-view --format rejection ==="

--- a/.agents/skills/github/tests/sticky-comment-cli.test.sh
+++ b/.agents/skills/github/tests/sticky-comment-cli.test.sh
@@ -94,6 +94,10 @@ echo "=== sticky-comment.sh CLI fallback ==="
 out=$("$STICKY" 123 --verdict)
 assert_eq "$out" "approved" "default fallback selects known claude[bot] review summary"
 
+out=$("$STICKY" 123 --legacy-extra ignored --verdict)
+assert_eq "$out" "approved" \
+    "legacy parser accepts unknown flags and ignores surplus positionals"
+
 assert_fails_with \
     "explicit --bot disables known-bot fallback" \
     "No sticky comment found" \

--- a/skills/github/DEVELOPMENT.md
+++ b/skills/github/DEVELOPMENT.md
@@ -8,6 +8,7 @@
 - `scripts/git-diff-summary` — Standalone changed-file domain/scope and risk-flag summary helper
 - `scripts/lib/github-api.sh` — Shared auth, GraphQL, REST, and error handling
 - `scripts/lib/gh-auth.sh` — Token resolution and keyring fallback
+- `scripts/lib/bounded.sh` — Portable wall-clock bound for GitHub subprocesses
 - `scripts/lib/kendex-env.sh` — Project settings / `.env.local` loader
 - `scripts/lib/ci-run-correlation.sh` — Check-rollup run scoping, shared with orch `ci-wait`
 - `scripts/lib/verify-lib.sh` — Merge simulation and build/test detection for `pr-cross-check --verify`

--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -6,8 +6,9 @@ fetching CI failure logs; gating and performing merges; and comparing several
 PRs before a batch merge.
 
 Every command prints JSON by default, so output can be piped straight into
-`jq`. `SKILL.md` is the full command reference; `DEVELOPMENT.md` covers
-internals.
+`jq`. Start with `./scripts/github.sh --help`, then use
+`./scripts/github.sh <command> --help` for the full contract. `SKILL.md`
+carries agent routing and recovery; `DEVELOPMENT.md` covers internals.
 
 ## Setup
 

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -15,7 +15,7 @@ tags: [git, integration]
 
 # GitHub Queries
 
-> **Problem with this skill?** Run `kendex report`.
+> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
 
 ```bash
 .agents/skills/github/scripts/github.sh [-C <path>] <command> [options]
@@ -50,8 +50,8 @@ tags: [git, integration]
 | `edit-comment <id> [body \| --body-file PATH]` | Edit existing comment. |
 | `sticky-comment <PR> [--verdict\|--analysis\|--body]` | Get bot sticky comment. `--verdict`: quick pass/fail. `--analysis`: deep recommendation. |
 
-CI waiting belongs to the orch skill's `ci-wait`; `await-mergeable` waits
-for merge-state resolution.
+CI waiting belongs to `.agents/skills/orch/scripts/ci-wait`; `await-mergeable`
+waits for merge-state resolution.
 
 ### Label application contract
 
@@ -59,16 +59,15 @@ Label modes and failures: `label-add --help`.
 
 ### Git HTTPS Auth Helper
 
-GitHub SSH-to-HTTPS fallback contract: `git-https-auth --help`.
+Contract: `git-https-auth --help`.
 
 ### Diff Summary Helper
 
-Output and risk flags: `git-diff-summary --help`.
+Contract: `git-diff-summary --help`.
 
 ### PR Merge Outcomes
 
-Exit codes, volatility, exact-head mutation, thread bounds, `--check`, and
-`--force`: `pr-merge --help`.
+Full contract: `pr-merge --help`.
 Exit `75` is volatile, so keep a watcher running until `MERGED`.
 If `can_merge` is false with no `issues`, read `state`.
 The thread gate is **Policy, not mechanism.** `--force` is its only override.

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -15,14 +15,10 @@ tags: [git, integration]
 
 # GitHub Queries
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
-
-CLI wrapper for GitHub API operations used in PR workflows. Structured JSON
-output, bot account support, configurable issue ID extraction.
+> **Problem with this skill?** Run `kendex report`.
 
 ```bash
-.agents/skills/github/scripts/github.sh <command> [options]
-.agents/skills/github/scripts/github.sh -C <path> <command> [options]  # Run in different directory
+.agents/skills/github/scripts/github.sh [-C <path>] <command> [options]
 ```
 
 ## Commands
@@ -54,127 +50,28 @@ output, bot account support, configurable issue ID extraction.
 | `edit-comment <id> [body \| --body-file PATH]` | Edit existing comment. |
 | `sticky-comment <PR> [--verdict\|--analysis\|--body]` | Get bot sticky comment. `--verdict`: quick pass/fail. `--analysis`: deep recommendation. |
 
-Wherever a body is accepted, prefer `--body-file`: an inline `--body` is safe
-only for plain strings, and Markdown carrying backticks or code fences needs
-the file. `label-add`/`label-remove` also load current-project env when their
-command scripts are executed directly rather than through `github.sh`.
-
-Most commands accept no PR number to auto-detect from the current branch.
-Exception: `post-reply` with a numeric comment ID never auto-detects — it
-requires an explicit `--pr <N>` (thread `PRRT_...` IDs need no PR number).
-
-There is no CI wait command here. Blocking until CI completes is the orch
-skill's `.agents/skills/orch/scripts/ci-wait <PR_NUMBER> [interval] [max_wait]
-[--json]`. `ci-logs` only fetches failure logs, and `await-mergeable` waits for
-merge-state resolution, not check completion.
-
-Unknown flags and extra positionals are rejected.
+CI waiting belongs to the orch skill's `ci-wait`; `await-mergeable` waits
+for merge-state resolution.
 
 ### Label application contract
 
-Workflow-required QA labels use `--required` (the default), even against a
-misconfigured repo; use `--optional` only where project policy marks the
-label non-gating. Mode semantics, exit codes, and the error classes that are
-never optional skips: `label-add --help`.
+Label modes and failures: `label-add --help`.
 
 ### Git HTTPS Auth Helper
 
-`git-https-auth [-C path] <git args...>` runs `git` normally, but when the
-target repo or an explicit URL uses a GitHub SSH remote and `gh` auth is valid,
-it adds per-command config for `gh auth git-credential` and rewrites GitHub SSH
-URLs to HTTPS. It never persists git config.
-
-```bash
-.agents/skills/github/scripts/git-https-auth -C . fetch --prune origin
-.agents/skills/github/scripts/git-https-auth -C . push -u origin HEAD:refs/heads/my-branch
-```
-
-Set `KENDEX_GITHUB_GIT_HTTPS_FALLBACK=never` to disable the fallback, or
-`always` to force it.
+GitHub SSH-to-HTTPS fallback contract: `git-https-auth --help`.
 
 ### Diff Summary Helper
 
-`git-diff-summary [-C path] [base-branch|--staged|--head]` emits JSON with
-changed-file domains, scope, insert/delete stats, and `risk_flags` for review
-routing. The flag definitions — including which `test_panic_path_added`
-surfaces are informational rather than risk — are in `git-diff-summary --help`.
+Output and risk flags: `git-diff-summary --help`.
 
 ### PR Merge Outcomes
 
-`pr-merge` returns three distinct outcomes — branch on the exit code, not on
-parsing stderr:
-
-| Exit | Meaning | Stderr line | When |
-|------|---------|-------------|------|
-| `0`  | MERGED | `MERGED PR #N` | Merge completed immediately |
-| `0`  | MERGED | `ALREADY MERGED PR #N <mergedAt>` | PR was merged before the call; nothing attempted |
-| `75` | MERGE PENDING (volatile) | `QUEUED IN MERGE QUEUE PR #N` | A required GitHub merge queue has an active entry — launch the prepared durable lifecycle before returning |
-| `75` | MERGE PENDING (volatile) | `AUTO-MERGE ENABLED PR #N` | Classic auto-merge is armed until protection clears — launch the prepared durable lifecycle before returning |
-| `1`  | BLOCKED | `BLOCKED PR #N` | Nothing merged, queued, or armed |
-| `1`  | BLOCKED | `CLOSED (not merged) PR #N` | PR is closed unmerged; nothing attempted |
-
-Exit `75` is not a resting state: an ejection or a failed protection check
-disarms it silently. The caller prepares and launches
-`.agents/skills/orch/scripts/merge-queue-watch`, which binds the repository,
-PR, expected head, and watch generation before arming. Its one-shot worker writes a durable verdict and claims one recovery action. The review-gate reducer can still report fleet attention.
-Verdict routing is in README.md § Exit 75 recovery; re-arm only through
-`.agents/skills/github/scripts/github.sh pr-merge <N> --auto` after that route.
-`await-mergeable` is not that watcher — it returns as soon as GitHub computes a merge state.
-
-A PR that has left `OPEN` is terminal and short-circuits every mode before any
-check, auth, or mutation. `--check` reports it through its `state` field.
-
-Merge state is mutated only against the exact resolved head, via
-`--match-head-commit`. Queue membership is read with GraphQL: an `OPEN` PR
-with no `autoMergeRequest` is still a successful exit `75` when its required queue
-entry is active, and an `OPEN` PR with neither queue nor auto-merge proof fails
-closed.
-
-Actionable review threads — unresolved and not outdated — are a hard local
-gate. They make `can_merge` false and block both immediate merge and `--auto`
-before any mutation. A failed or malformed thread lookup blocks too. Two
-bounds on that gate:
-
-- **Narrower than branch protection.** GitHub's
-  `required_conversation_resolution` requires *all* conversations resolved and
-  draws no outdated/active distinction. `pr-merge` counts only threads that are
-  unresolved *and* not outdated. Relying on `pr-merge` alone is a narrower
-  guarantee than branch protection.
-- **Policy, not mechanism.** `pr-merge` gates only merges routed through it. A
-  raw `gh pr merge` or the GitHub UI Merge button bypasses the skill entirely.
-
-`--force` is the only deliberate override and skips every check. It is
-immediate-only, cannot be combined with `--auto` (the pair fails before any
-GitHub lookup), and stays BLOCKED when its mutation fails and the exact-head
-post-state is not `MERGED`.
-
-BLOCKED is classified on stderr as **transient** (mergeable UNKNOWN,
-`ci_pending`, CI fetch uncertainty — `await-mergeable` then retry) or
-**permanent** (conflicts, `ci_failed`, `changes_requested` — fix and re-push).
-Callers read the `transient` field from `--check`:
-
-```json
-{"can_merge": true, "issues": [], "warnings": [], "mergeable": "MERGEABLE", "review": "APPROVED", "transient": false, "state": "OPEN", "merged_at": "", "head_runs": [17234567890], "checks": [{"name": "Cargo", "state": "SUCCESS", "bucket": "pass", "workflow": "CI", "link": "https://github.com/owner/repo/actions/runs/17234567890/job/1", "startedAt": "…"}]}
-```
-
-`state` is the PR's lifecycle state (`OPEN`, `MERGED`, `CLOSED`, `UNKNOWN`), and
-`merged_at` carries the merge timestamp when that state is `MERGED`.
-`can_merge: false` with an empty `issues` array means the PR is terminal — read
-`state` before treating a refusal as a blocker to clear. `head_runs` lists the
-run ids the CI classification was scoped to (the authoritative run per
-workflow plus the runs custom commit statuses link to — a mixed head names
-both); `--check` repeats them on stderr as `head-run: <ids>` under the
-one-word verdict (`mergeable`, `blocked`, `merged`, `closed`). `checks` is the
-raw rollup that classification read. To turn a refusal into a named cause —
-including which failing checks are run-correlated to the authoritative run and
-which runs were superseded — run `ci-classify-refusal <N>`; it scopes the
-`checks` snapshot embedded in the `--check` JSON rather than refetching, so
-its detail lines and the verdict describe one fetch.
-
-`transient: true` means every blocking issue is recoverable by waiting
-(prefixes `unknown:`, `ci_pending:`, `ci_unconfigured:`, `ci_fetch_failed:`).
-Still-running checks report as `ci_pending:`; terminal failing or cancelled
-checks remain `ci_failed:`.
+Exit codes, volatility, exact-head mutation, thread bounds, `--check`, and
+`--force`: `pr-merge --help`.
+Exit `75` is volatile, so keep a watcher running until `MERGED`.
+If `can_merge` is false with no `issues`, read `state`.
+The thread gate is **Policy, not mechanism.** `--force` is its only override.
 
 ### PR blocked with no visible conversations
 
@@ -205,61 +102,24 @@ skill's reducer when installed
 
 ## Output Formats
 
-`--format` is command-specific, not a global flag; the per-command modes, the
-`--json` alias, and the reject-unknown rules are in `github.sh --help`.
+Formats and flag rules: `github.sh --help`.
 
 ## Configuration
 
-| Variable | Purpose | Default |
-|----------|---------|---------|
-| `GH_TOKEN` / `GITHUB_TOKEN` | Pre-resolved GitHub token from the parent process | Falls back to `gh` auth |
-| `GH_BOT_TOKEN` | Bot account GitHub token (in `.env.local` or parent env) | Falls back to `GH_TOKEN` / `GITHUB_TOKEN`, then `gh` auth |
-| `GH_BOT_USERNAME` | Bot username for review/comment filtering | `review-bot[bot]` |
-| `GH_ISSUE_PATTERN` | Regex for issue ID extraction from branches | `[A-Z]+-[0-9]+` |
-| `GH_VERIFY_CMD` | Overrides build/test detection in `pr-cross-check --verify` | auto-detect |
-| `KENDEX_GITHUB_OP_TIMEOUT` | Seconds to wait for `op read` when resolving token references | `10` |
-| `KENDEX_GITHUB_AUTH_TIMEOUT` | Seconds to wait for GitHub auth preflight in `pr-view` | `10` |
-| `KENDEX_GITHUB_PR_VIEW_TIMEOUT` | Seconds to wait for `gh pr view` in `pr-view` | `30` |
-| `KENDEX_GITHUB_GIT_HTTPS_FALLBACK` | `auto`, `never`, or `always` for `git-https-auth` SSH→HTTPS fallback | `auto` |
-
-Tokens may be literal (`ghp_*`, `gho_*`, `ghu_*`, `ghs_*`, `ghr_*`,
-`github_pat_*`) or 1Password references (`op://vault/item/field`). Keep them in
-`.env.local`; non-secret defaults belong in committed `kendex.settings.toml`
-under `[env]`.
-
-Parent-process values win over project files. `github.sh` then selects ONE
-router token before resolving any `op://` reference — resolved `GH_TOKEN`, then
-`GH_BOT_TOKEN`, then `GITHUB_TOKEN`, falling back to `op://` references in that
-same order — and runs `op read` for that single selection only. An unresolvable
-selection drops `GH_TOKEN`/`GITHUB_TOKEN` so `gh` uses keyring auth; a selected
-`GH_BOT_TOKEN` keeps its bot identity instead. Auth preflight validates env
-tokens with `gh api user`, and `gh auth status` is authoritative only when no
-env token is selected.
-
-## Error Handling
-
-- Most commands emit `{"error": "message"}` on stderr and exit 1.
-- `pr-view --json ...` emits structured failure JSON on stdout (the `status`
-  values and shape: `pr-view --help`).
-- Rate limits retry automatically (3 attempts, exponential backoff).
-- An unreadable thread list, comment list, or CI log is reported as a failure,
-  never as "none found".
+Keep secrets in `.env.local`; commit non-secret defaults to
+`kendex.settings.toml` under `[env]`. Other contracts: `github.sh --help`.
 
 ## Troubleshooting
 
-**`Expected VAR_SIGN, actual: UNKNOWN_CHAR`**: use a multi-line GraphQL query
-with `-F` variables — `$` in a single-line query hits shell escaping.
+**`VAR_SIGN`**: use a multi-line GraphQL query with `-F` variables.
 
-**`bad credentials` / `HTTP 401` while `gh auth status` looks healthy**: a
-stale `GH_TOKEN`/`GITHUB_TOKEN` masks keyring credentials. Check
-`env | grep -E '^(GH_TOKEN|GITHUB_TOKEN)='`, then clear BOTH for the call:
+**Stale-token `HTTP 401`**: clear both environment tokens:
 
 ```bash
 env -u GH_TOKEN -u GITHUB_TOKEN gh pr list
 ```
 
-`github.sh` does this automatically when the selected env token fails and
-keyring auth succeeds.
+`github.sh` falls back when keyring auth succeeds.
 
 ## Dependencies
 

--- a/skills/github/scripts/commands/label-add.sh
+++ b/skills/github/scripts/commands/label-add.sh
@@ -37,6 +37,11 @@ or resembling booleans, integers, nulls, and placeholders. Neither mode
 mutates anything on a refusal, and auth, lookup, rate-limit, and server
 errors are operational errors in both modes — never optional skips.
 
+Configuration:
+  Direct execution loads the current project's kendex.settings.toml,
+  .kendex/settings.toml, and .env.local before selecting auth. Parent-process
+  values keep precedence.
+
 Examples:
   label-add.sh 44 needs-qa
   label-add.sh 123 needs-triage --issue

--- a/skills/github/scripts/commands/label-remove.sh
+++ b/skills/github/scripts/commands/label-remove.sh
@@ -24,6 +24,11 @@ Options:
   --pr              Treat the ref as a PR (default).
   --help, -h        Show this help.
 
+Configuration:
+  Direct execution loads the current project's kendex.settings.toml,
+  .kendex/settings.toml, and .env.local before selecting auth. Parent-process
+  values keep precedence.
+
 Examples:
   label-remove.sh 44 needs-qa
   label-remove.sh 123 needs-triage --issue

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -64,22 +64,22 @@ Exit codes:
        The PR is closed unmerged. Nothing was attempted.
 
 Exit 75 is volatile:
-  A queue ejection or failed protection check can disarm merge state without
-  another notification. Keep a watcher running until the PR is MERGED. Use
-  the orch skill's queue-wait <N> or the review-gate pr-watch.sh reducer, then
-  repair the named cause and re-arm with github.sh pr-merge <N> --auto.
-  Neither watcher is durable. await-mergeable is not an ejection watcher; it
-  stops when GitHub finishes computing the current merge state.
+  A queue ejection or failed protection check can disarm merge state silently.
+  Launch the prepared .agents/skills/orch/scripts/merge-queue-watch before returning; it binds repository, PR, expected head, and watch generation.
+  Its one-shot worker writes a durable verdict and claims one recovery action; the review-gate reducer still reports fleet attention.
+  Route verdicts through README.md "Exit 75 recovery". Re-arm only through
+  github.sh pr-merge <N> --auto after that route. await-mergeable is not the
+  lifecycle watcher; it stops when GitHub computes the current merge state.
 
 Terminal and mutation rules:
-  A PR outside OPEN is terminal. Every mode returns its state before checks,
-  auth, or mutation. --check reports that lifecycle in state.
+  After github.sh router setup, a PR outside OPEN short-circuits pr-merge safety
+  checks, bot-token load, and merge-state mutation. --check reports state.
 
-  Every mutation resolves the checked head and passes --match-head-commit.
-  A post-mutation snapshot for another head is BLOCKED. Queue membership comes
-  from GraphQL isInMergeQueue and mergeQueueEntry. An OPEN PR with an active
-  queue entry exits 75 even when autoMergeRequest is absent. An OPEN PR with
-  no queue or auto-merge proof fails closed.
+  Every gh pr merge invocation is exact-head guarded by --match-head-commit; a changed head is BLOCKED.
+  Queue membership comes from GraphQL isInMergeQueue and mergeQueueEntry. An
+  OPEN PR with an active queue entry exits 75 even when autoMergeRequest is
+  absent. An OPEN PR with no queue or auto-merge proof fails closed. The
+  --delete-branch cleanup after MERGED is best-effort, not merge-state mutation.
 
 Review-thread gate:
   Unresolved, non-outdated review threads make can_merge false and block both

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -75,8 +75,8 @@ Exit 75 is volatile:
   lifecycle watcher; it stops when GitHub computes the current merge state.
 
 Terminal and mutation rules:
-  After github.sh router setup, a PR outside OPEN short-circuits pr-merge safety
-  checks, bot-token load, and merge-state mutation. --check reports state.
+  After github.sh router setup, MERGED or CLOSED short-circuits pr-merge safety
+  checks, bot-token load, and merge-state mutation; UNKNOWN continues. --check reports state.
 
   Every gh pr merge invocation is exact-head guarded by --match-head-commit; a changed head is BLOCKED.
   Queue membership comes from GraphQL isInMergeQueue and mergeQueueEntry. An

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -67,12 +67,10 @@ Merge-mode exit codes:
   blocked or CLOSED. Argument or dispatch failures before JSON remain nonzero.
 
 Exit 75 is volatile:
-  A queue ejection or failed protection check can disarm merge state silently.
-  Launch the prepared .agents/skills/orch/scripts/merge-queue-watch before returning; it binds repository, PR, expected head, and watch generation.
-  Its one-shot worker writes a durable verdict and claims one recovery action; the review-gate reducer still reports fleet attention.
-  Route verdicts through README.md "Exit 75 recovery". Re-arm only through
-  github.sh pr-merge <N> --auto after that route. await-mergeable is not the
-  lifecycle watcher; it stops when GitHub computes the current merge state.
+  A queue ejection can disarm merge state. Launch the prepared .agents/skills/orch/scripts/merge-queue-watch before returning; it binds repository, PR, expected head, and watch generation.
+  Its one-shot worker writes a durable verdict and claims one recovery action. Route verdicts through README.md "Exit 75 recovery"; the review-gate reducer still reports fleet attention.
+  Re-arm only through github.sh pr-merge <N> --auto after that route.
+  await-mergeable is not the lifecycle watcher; it stops when GitHub computes state.
 
 Terminal and mutation rules:
   After github.sh router setup, MERGED or CLOSED short-circuits pr-merge safety
@@ -301,8 +299,7 @@ run_checks() {
         fi
     fi
 
-    # reviewDecision is only populated with branch protection rules requiring approvals.
-    # Fall back to checking latestReviews for both APPROVED and CHANGES_REQUESTED states.
+    # reviewDecision requires branch protection; latestReviews covers both terminal review states.
     local review="" has_approved_review=false has_changes_requested=false
     local review_json
     if ! review_json=$(json_or_default '{}' object gh pr view "$pr_num" --json reviewDecision,latestReviews); then
@@ -627,7 +624,6 @@ main() {
         echo "BLOCKED PR #$pr_num — prepared head changed before merge attempt (expected=$expected_head, actual=$current_head)" >&2; exit 1
     fi
 
-    # --auto queues the exact head until GitHub's requirements clear.
     local -a cmd=(pr merge "$pr_num" "$method" --match-head-commit "$expected_head")
     [ "$auto" = true ] && cmd+=(--auto)
 

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -58,7 +58,7 @@ Merge-mode exit codes:
   75   AUTO-MERGE ENABLED PR #N
        Classic auto-merge is armed until protection clears.
   1    BLOCKED PR #N
-       Nothing merged, queued, or armed.
+       The requested operation failed; a pre-existing queue entry or auto-merge request may remain active.
   1    CLOSED (not merged) PR #N
        The PR is closed unmerged. Nothing was attempted.
 

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Source shared library for load_bot_token (also sets PROJECT_ROOT)
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/../lib/github-api.sh"
 # Issue prefixes that resolve on their own once GitHub finishes computing or
@@ -49,7 +48,7 @@ Modes:
   --force          Deliberately skip all checks, including review threads
   --auto           Enable auto-merge when immediate merge is blocked
 
-Exit codes:
+Merge-mode exit codes:
   0    MERGED PR #N
        Merge completed immediately.
   0    ALREADY MERGED PR #N <mergedAt>
@@ -62,6 +61,10 @@ Exit codes:
        Nothing merged, queued, or armed.
   1    CLOSED (not merged) PR #N
        The PR is closed unmerged. Nothing was attempted.
+
+--check exit:
+  --check exits 0 after any valid readiness JSON, including can_merge=false for
+  blocked or CLOSED. Argument or dispatch failures before JSON remain nonzero.
 
 Exit 75 is volatile:
   A queue ejection or failed protection check can disarm merge state silently.
@@ -228,7 +231,6 @@ run_checks() {
         return 0
     fi
 
-    # 1. Check mergeable status
     local mergeable
     mergeable=$(gh pr view "$pr_num" --json mergeable --jq '.mergeable' 2>/dev/null || echo "UNKNOWN")
     if [ "$mergeable" = "MERGEABLE" ]; then
@@ -299,7 +301,6 @@ run_checks() {
         fi
     fi
 
-    # 4. Check review status
     # reviewDecision is only populated with branch protection rules requiring approvals.
     # Fall back to checking latestReviews for both APPROVED and CHANGES_REQUESTED states.
     local review="" has_approved_review=false has_changes_requested=false
@@ -320,7 +321,6 @@ run_checks() {
         fi
     fi
 
-    # Output JSON
     local issues_json warnings_json
     issues_json=$(printf '%s\n' "${issues[@]:-}" | jq -R -s -c 'split("\n") | map(select(. != ""))')
     warnings_json=$(printf '%s\n' "${warnings[@]:-}" | jq -R -s -c 'split("\n") | map(select(. != ""))')

--- a/skills/github/scripts/commands/pr-merge.sh
+++ b/skills/github/scripts/commands/pr-merge.sh
@@ -1,38 +1,4 @@
 #!/bin/bash
-# Merge PR as bot account with safety checks
-# Usage: pr-merge <PR_NUMBER> [--check] [--force] [--auto] [--dry-run]
-#
-# Outcomes (distinct exit codes + messages):
-#   0   MERGED                 — merge completed immediately
-#   0   ALREADY MERGED         — PR was already merged; nothing attempted
-#   75  QUEUED / AUTO-MERGE     — merge queue entry or classic auto-merge is active;
-#                                 VOLATILE: a queue ejection disarms it silently,
-#                                 so the caller keeps watching until MERGED
-#   1   BLOCKED                — checks failed; no merge attempted, none queued
-#   1   CLOSED (not merged)    — PR is closed unmerged; nothing attempted
-#
-# A PR that has left OPEN is terminal and short-circuits before any check or
-# mutation: `mergeable` stays UNKNOWN forever once a PR is merged or closed, so
-# running the checks against it manufactures blockers that can never clear.
-#
-# Actionable unresolved review threads are a local hard gate: neither an
-# immediate merge nor `--auto` may mutate merge state while they remain. Only
-# the deliberately dangerous `--force` override skips this gate.
-#
-# `--auto` is idempotent for merge-queue repositories: a re-invocation on a PR
-# that is already enrolled reports QUEUED (75) from the authoritative post-call
-# snapshot, not BLOCKED, even though `gh pr merge --auto` exits nonzero when the
-# PR is already queued.
-# `--force` is deliberately different: it promises an immediate attempt, so a
-# nonzero merge mutation stays BLOCKED unless the exact head is now MERGED.
-# Auto-merge or a queue entry already active before the call is not success
-# proof for this mode.
-#
-# When BLOCKED, stderr distinguishes TRANSIENT issues (mergeable UNKNOWN,
-# ci pending — caller should `await-mergeable` and retry) from PERMANENT
-# issues (conflicts, ci_failed, changes_requested — caller must fix and re-push).
-# Still-running checks are emitted as ci_pending, not ci_failed.
-
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -84,10 +50,79 @@ Modes:
   --auto           Enable auto-merge when immediate merge is blocked
 
 Exit codes:
-  0    MERGED / ALREADY MERGED — merge completed now, or the PR was already merged
-  75   QUEUED / AUTO-MERGE     — merge queue entry or classic auto-merge is active
-                                 (volatile: an ejection disarms it silently — keep watching)
-  1    BLOCKED / CLOSED        — checks failed or the PR is closed unmerged; nothing queued
+  0    MERGED PR #N
+       Merge completed immediately.
+  0    ALREADY MERGED PR #N <mergedAt>
+       The PR was merged before this call. Nothing was attempted.
+  75   QUEUED IN MERGE QUEUE PR #N
+       The required merge queue has an active entry.
+  75   AUTO-MERGE ENABLED PR #N
+       Classic auto-merge is armed until protection clears.
+  1    BLOCKED PR #N
+       Nothing merged, queued, or armed.
+  1    CLOSED (not merged) PR #N
+       The PR is closed unmerged. Nothing was attempted.
+
+Exit 75 is volatile:
+  A queue ejection or failed protection check can disarm merge state without
+  another notification. Keep a watcher running until the PR is MERGED. Use
+  the orch skill's queue-wait <N> or the review-gate pr-watch.sh reducer, then
+  repair the named cause and re-arm with github.sh pr-merge <N> --auto.
+  Neither watcher is durable. await-mergeable is not an ejection watcher; it
+  stops when GitHub finishes computing the current merge state.
+
+Terminal and mutation rules:
+  A PR outside OPEN is terminal. Every mode returns its state before checks,
+  auth, or mutation. --check reports that lifecycle in state.
+
+  Every mutation resolves the checked head and passes --match-head-commit.
+  A post-mutation snapshot for another head is BLOCKED. Queue membership comes
+  from GraphQL isInMergeQueue and mergeQueueEntry. An OPEN PR with an active
+  queue entry exits 75 even when autoMergeRequest is absent. An OPEN PR with
+  no queue or auto-merge proof fails closed.
+
+Review-thread gate:
+  Unresolved, non-outdated review threads make can_merge false and block both
+  immediate merge and --auto. A failed or malformed thread lookup also blocks.
+  This is narrower than required_conversation_resolution, which requires every
+  conversation resolved and does not exclude outdated threads.
+
+  The gate is policy, not mechanism. It applies only through pr-merge. A raw
+  gh pr merge call or the GitHub UI Merge button bypasses it.
+
+Force rules:
+  --force is the only deliberate override. It skips every check, including the
+  thread gate. It is immediate-only and cannot be combined with --auto. A
+  failed force mutation remains BLOCKED unless the exact-head post-state is
+  MERGED; a pre-existing queue entry or auto-merge request is not success.
+
+--check JSON:
+  stdout is one object with these fields:
+    can_merge   boolean readiness result
+    issues      blocking issue strings
+    warnings    non-blocking issue strings
+    mergeable   MERGEABLE, CONFLICTING, or UNKNOWN
+    review      GitHub review decision
+    transient   true only when every blocker can clear by waiting
+    state       OPEN, MERGED, CLOSED, or UNKNOWN
+    merged_at   merge timestamp, or an empty string
+    head_runs   run IDs used for CI classification
+    checks      raw check rollup read by the classification
+
+  stderr carries mergeable, blocked, merged, or closed, followed by
+  head-run: <ids> when CI runs were classified. can_merge=false with an empty
+  issues array means the PR is terminal; inspect state instead of treating it
+  as a blocker to repair.
+
+  transient=true requires every issue prefix to be unknown:, ci_pending:,
+  ci_unconfigured:, or ci_fetch_failed:. A ci_failed: issue is permanent, as
+  are conflicts and changes_requested. Running checks use ci_pending: while
+  failed or cancelled checks use ci_failed:.
+
+  head_runs contains the authoritative workflow run plus runs referenced by
+  custom commit statuses. checks is the same snapshot consumed by
+  ci-classify-refusal <N>, so cause:, fail:, and superseded: lines cannot race
+  a second fetch.
 
 Examples:
   github.sh pr-merge 42 --check          # Check only, JSON output
@@ -170,18 +205,6 @@ exit_terminal_state() {
     esac
 }
 
-# Run safety checks, output JSON
-# JSON shape:
-#   {can_merge, issues, warnings, mergeable, review,
-#    transient: bool,     # true when only TRANSIENT issues are blocking
-#    state,               # PR lifecycle state: OPEN, MERGED, CLOSED, UNKNOWN
-#    merged_at,           # merge timestamp, "" unless state is MERGED
-#    head_runs,           # run ids the CI classification was scoped to
-#                         # (classify_checks_rollup); [] when none or no fetch
-#    checks}              # the raw rollup this classification read — the
-#                         # ONE snapshot ci-classify-refusal re-scopes
-#                         # instead of refetching; [] on fetch failure or
-#                         # no configured checks
 run_checks() {
     local pr_num="$1"
     local can_merge=true
@@ -324,7 +347,6 @@ run_checks() {
         '{can_merge: $can_merge, issues: $issues, warnings: $warnings, mergeable: $mergeable, review: $review, transient: $transient, state: $state, merged_at: $merged_at, head_runs: $head_runs, checks: $checks}'
 }
 
-# Print BLOCKED breakdown to stderr, distinguishing transient vs permanent.
 print_blocked() {
     local check_result="$1"
     local pr_num="$2"
@@ -363,10 +385,6 @@ gh_with_token() {
     fi
 }
 
-# Exit 75 is not a resting state: a merge-group failure ejects the entry, a
-# failed protection check drops classic auto-merge, and GitHub disarms the PR
-# silently either way — it can sit open, gate-clear, and unwatched. Every 75
-# exit says so and names runnable watchers.
 volatile_note() {
     local pr_num="$1" repo="${GH_REPO:-}" remote resolved reducer
     # pr-watch.sh requires GH_REPO; print the reducer with the repository it
@@ -413,10 +431,6 @@ volatile_note() {
     echo "  Launch the prepared .agents/skills/orch/scripts/merge-queue-watch once; route its claimed action by orch merge-pr.md § 5 step 1, and never re-arm an unrecognized verdict. The fleet reducer is $reducer; repair what the cause names before re-arming with .agents/skills/github/scripts/github.sh pr-merge $pr_num --auto" >&2
 }
 
-# Read one authoritative post-mutation snapshot. `gh pr view --json` does not
-# expose merge-queue membership, so required-queue repositories need GraphQL.
-# Fall back to the classic `gh pr view` fields when the queue query itself is
-# unavailable; queue membership remains false in that fail-closed fallback.
 post_merge_snapshot() {
     local pr_num="$1"
     local auth_token="$2"
@@ -536,8 +550,6 @@ main() {
         echo "Error: --expected-head must be a 40-character commit SHA" >&2; exit 1
     fi
 
-    # Check-only mode: JSON on stdout stays the machine interface; the verdict
-    # and run scope (shared check_verdict_lines) go to stderr for jq pipelines.
     if [ "$check_only" = true ]; then
         local check_json
         check_json=$(run_checks "$pr_num")
@@ -546,10 +558,6 @@ main() {
         exit 0
     fi
 
-    # Terminal-state short-circuit, ahead of every mode's checks, auth, and
-    # mutation. Retrying a merge on a PR that already left OPEN can only
-    # produce false diagnostics, and there is nothing left to mutate.
-    # An unreadable state is not terminal — fall through to the normal path.
     if load_pr_state_json "$pr_num"; then
         exit_terminal_state \
             "$(jq -r '.state // ""' <<<"$PR_STATE_JSON")" \
@@ -560,7 +568,6 @@ main() {
     local token
     token=$(load_bot_token)
 
-    # Unless --force, run checks
     local check_result=""
     if [ "$force" = false ]; then
         local can_merge checked_state checked_merged_at
@@ -583,15 +590,12 @@ main() {
             local has_review_thread_gate
             has_review_thread_gate=$(echo "$check_result" | jq '[.issues[] | select(test("^(unresolved_threads|review_threads_fetch_failed):"))] | length > 0')
 
-            # If --auto, fall through to enable auto-merge below.
-            # Otherwise, exit BLOCKED with breakdown.
             if [ "$auto" != true ] || [ "$has_review_thread_gate" = "true" ]; then
                 print_blocked "$check_result" "$pr_num"
                 exit 1
             fi
         fi
 
-        # Show warnings even on success
         local warnings
         warnings=$(echo "$check_result" | jq -r '.warnings | length')
         if [ "$warnings" -gt 0 ]; then

--- a/skills/github/scripts/commands/pr-view.sh
+++ b/skills/github/scripts/commands/pr-view.sh
@@ -87,18 +87,20 @@ EOF
 }
 
 main() {
-    local pr_num=""
-    local json_fields=""
-    local -a extra_args=()
+    local -a cmd=(gh pr view)
 
     while [ $# -gt 0 ]; do
         case "$1" in
             --json)
-                json_fields="$2"
-                shift 2
+                cmd+=("$1")
+                shift
+                if [ $# -gt 0 ]; then
+                    cmd+=("$1")
+                    shift
+                fi
                 ;;
             --json=*)
-                json_fields="${1#--json=}"
+                cmd+=("$1")
                 shift
                 ;;
             --help|-h)
@@ -112,25 +114,12 @@ main() {
                     2
                 exit 2
                 ;;
-            -*)
-                extra_args+=("$1")
-                shift
-                ;;
             *)
-                if [ -z "$pr_num" ]; then
-                    pr_num="$1"
-                else
-                    extra_args+=("$1")
-                fi
+                cmd+=("$1")
                 shift
                 ;;
         esac
     done
-
-    local -a cmd=(gh pr view)
-    [ -n "$pr_num" ] && cmd+=("$pr_num")
-    [ -n "$json_fields" ] && cmd+=(--json "$json_fields")
-    [ ${#extra_args[@]} -gt 0 ] && cmd+=("${extra_args[@]}")
 
     local auth_out auth_err pr_out pr_err
     PR_VIEW_TMP_DIR="$(mktemp -d)"

--- a/skills/github/scripts/commands/pr-view.sh
+++ b/skills/github/scripts/commands/pr-view.sh
@@ -68,6 +68,8 @@ Options:
 Note:
   --format is not supported here. For a normalized safe/raw PR view use
   'github.sh pr-data [PR] --format=safe|raw'.
+  Other unrecognized flags and extra positionals pass through to gh pr view
+  for compatibility.
 
 Errors:
   Emits structured JSON on stdout ({"status":..., "error":..., "detail":...,

--- a/skills/github/scripts/commands/pr-view.sh
+++ b/skills/github/scripts/commands/pr-view.sh
@@ -91,7 +91,7 @@ main() {
 
     while [ $# -gt 0 ]; do
         case "$1" in
-            --json)
+            --json|--jq|--template|--repo|-q|-t|-R)
                 cmd+=("$1")
                 shift
                 if [ $# -gt 0 ]; then

--- a/skills/github/scripts/commands/sticky-comment.sh
+++ b/skills/github/scripts/commands/sticky-comment.sh
@@ -40,6 +40,10 @@ Options:
   --bot <login>    Override $GH_BOT_USERNAME for this call (e.g. for Codex)
   --help, -h       Show this help
 
+Compatibility:
+  Unrecognized flags become positional input. Surplus positionals after the
+  PR number and output selector are ignored.
+
 Output (default):
   JSON object with body, updated_at, id, and computed verdict
 

--- a/skills/github/scripts/github.sh
+++ b/skills/github/scripts/github.sh
@@ -73,6 +73,58 @@ Output Formats:
   pr-data and pr-threads take --format=safe|raw only and reject unknown
   flags.
 
+Configuration:
+  Project files load in this order, from lowest to highest precedence:
+    kendex.settings.toml [env]
+    .kendex/settings.toml [env]
+    .env.local
+  Values exported by the parent process override every project file. A .env
+  file is never read.
+
+  GH_TOKEN / GITHUB_TOKEN
+      Pre-resolved user token. Falls back to gh keyring auth.
+  GH_BOT_TOKEN
+      Bot token. Falls back to GH_TOKEN, GITHUB_TOKEN, then gh keyring auth.
+  GH_BOT_USERNAME
+      Username used for review and comment filtering. Default: review-bot[bot]
+  GH_ISSUE_PATTERN
+      Branch issue-id regex. Default: [A-Z]+-[0-9]+
+  GH_VERIFY_CMD
+      Command used by pr-cross-check --verify. Default: auto-detect.
+  KENDEX_GITHUB_OP_TIMEOUT
+      Seconds allowed for op read. Default: 10.
+  KENDEX_GITHUB_AUTH_TIMEOUT
+      Seconds allowed for GitHub auth preflight. Default: 10.
+  KENDEX_GITHUB_PR_VIEW_TIMEOUT
+      Seconds allowed for gh pr view in pr-view. Default: 30.
+  KENDEX_GITHUB_GIT_HTTPS_FALLBACK
+      git-https-auth mode: auto, never, or always. Default: auto.
+
+Token selection:
+  Tokens may be literal ghp_*, gho_*, ghu_*, ghs_*, ghr_*, or github_pat_*
+  values, or op://vault/item/field references. The router selects one token
+  before resolving any 1Password reference. It first checks resolved values
+  in GH_TOKEN, GH_BOT_TOKEN, GITHUB_TOKEN order, then checks op:// references
+  in the same order. Only that selection is passed to op read.
+
+  A resolved selection is exported as GH_TOKEN and GITHUB_TOKEN is removed.
+  If an op:// selection cannot resolve, GH_TOKEN and GITHUB_TOKEN are removed
+  so gh may use keyring auth. A selected GH_BOT_TOKEN keeps its bot identity
+  and does not fall back to a different keyring identity after auth failure.
+
+Auth preflight:
+  When GH_TOKEN or GITHUB_TOKEN is selected, gh api user is authoritative.
+  gh auth status is authoritative only when no environment token is selected.
+  A failed non-bot environment token is removed only when keyring auth passes.
+
+Errors and retries:
+  Most commands write {"error": "message"} JSON to stderr and exit 1.
+  pr-view --json writes its structured failure object to stdout; run
+  'github.sh pr-view --help' for its status values and exit codes.
+  API rate limits and retryable request failures get at most 3 attempts with
+  exponential backoff. An unreadable thread list, comment list, or CI log is
+  an error, never an empty result.
+
 Examples:
   # Get PR data with all threads and comments
   ./github.sh pr-data 23

--- a/skills/github/scripts/github.sh
+++ b/skills/github/scripts/github.sh
@@ -73,6 +73,11 @@ Output Formats:
   pr-data and pr-threads take --format=safe|raw only and reject unknown
   flags.
 
+Argument rules:
+  Subcommands reject unknown flags and positionals beyond their documented
+  Usage. A positional body or omitted PR number is accepted only when that
+  command's Usage shows it.
+
 Configuration:
   Project files load in this order, from lowest to highest precedence:
     kendex.settings.toml [env]
@@ -121,9 +126,11 @@ Errors and retries:
   Most commands write {"error": "message"} JSON to stderr and exit 1.
   pr-view --json writes its structured failure object to stdout; run
   'github.sh pr-view --help' for its status values and exit codes.
-  API rate limits and retryable request failures get at most 3 attempts with
-  exponential backoff. An unreadable thread list, comment list, or CI log is
-  an error, never an empty result.
+  Operations routed through the shared gh_graphql and gh_rest wrappers retry
+  rate limits and retryable request failures for at most 3 attempts with
+  exponential backoff. Other operations keep their command-specific
+  first-failure behavior. An unreadable thread list, comment list, or CI log
+  is an error, never an empty result.
 
 Examples:
   # Get PR data with all threads and comments

--- a/skills/github/scripts/github.sh
+++ b/skills/github/scripts/github.sh
@@ -74,9 +74,10 @@ Output Formats:
   flags.
 
 Argument rules:
-  Subcommands reject unknown flags and positionals beyond their documented
-  Usage. A positional body or omitted PR number is accepted only when that
-  command's Usage shows it.
+  Most subcommands reject unknown flags and extra positionals beyond Usage.
+  pr-view passes other flags and extra positionals to gh pr view, except its
+  explicit --format rejection. sticky-comment keeps legacy permissive parsing:
+  unrecognized flags become positional input, and surplus positionals are ignored.
 
 Configuration:
   Project files load in this order, from lowest to highest precedence:

--- a/skills/github/scripts/github.sh
+++ b/skills/github/scripts/github.sh
@@ -127,11 +127,13 @@ Errors and retries:
   Most commands write {"error": "message"} JSON to stderr and exit 1.
   pr-view --json writes its structured failure object to stdout; run
   'github.sh pr-view --help' for its status values and exit codes.
-  Operations routed through the shared gh_graphql and gh_rest wrappers retry
-  rate limits and retryable request failures for at most 3 attempts with
-  exponential backoff. Other operations keep their command-specific
-  first-failure behavior. An unreadable thread list, comment list, or CI log
-  is an error, never an empty result.
+  gh_graphql retries only nonzero gh command failures with no GraphQL errors
+  object. gh_rest retries rate limits and other command failures except
+  authentication and not-found responses. Both stop after at most 3 attempts
+  with exponential backoff. GraphQL error objects and excluded REST failures
+  return on the first attempt. Other operations keep command-specific failure
+  behavior. An unreadable thread list, comment list, or CI log is an error,
+  never an empty result.
 
 Examples:
   # Get PR data with all threads and comments

--- a/skills/github/scripts/github.sh
+++ b/skills/github/scripts/github.sh
@@ -189,7 +189,8 @@ _takes_value() {
         pr-create:--base | pr-create:--head | pr-create:--label) return 0 ;;
         pr-data:--format | pr-threads:--format) return 0 ;;
         pr-edit-body:--body-file) return 0 ;;
-        pr-view:--json) return 0 ;;
+        pr-view:--json | pr-view:--jq | pr-view:--template | pr-view:--repo) return 0 ;;
+        pr-view:-q | pr-view:-t | pr-view:-R) return 0 ;;
         sticky-comment:--bot) return 0 ;;
         *) return 1 ;;
     esac
@@ -203,7 +204,7 @@ for _arg in "$@"; do
     fi
     case "$_arg" in
         --help|-h) _help_route=1; break ;;
-        --*) if _takes_value "$_arg"; then _skip_value=1; fi ;;
+        -*) if _takes_value "$_arg"; then _skip_value=1; fi ;;
     esac
 done
 unset _arg _skip_value

--- a/skills/github/scripts/lib/bounded.sh
+++ b/skills/github/scripts/lib/bounded.sh
@@ -6,9 +6,13 @@ kendex_github_run_bounded() {
   shift
 
   case "$seconds" in
-    0) "$@"; return ;;
     ''|*[!0-9]*) return 125 ;;
   esac
+  seconds=$((10#$seconds))
+  if [ "$seconds" -eq 0 ]; then
+    "$@"
+    return
+  fi
 
   local restore_monitor=0 pid ticks=0 max_ticks status=0 grace=0 target
   case "$-" in

--- a/skills/github/scripts/lib/bounded.sh
+++ b/skills/github/scripts/lib/bounded.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Portable wall-clock bound for GitHub helper subprocesses.
+
+kendex_github_run_bounded() {
+  local seconds="$1"
+  shift
+
+  case "$seconds" in
+    0) "$@"; return ;;
+    ''|*[!0-9]*) return 125 ;;
+  esac
+
+  local restore_monitor=0 pid ticks=0 max_ticks status=0 grace=0 target
+  case "$-" in
+    *m*) ;;
+    *) set -m; restore_monitor=1 ;;
+  esac
+
+  "$@" &
+  pid=$!
+  [ "$restore_monitor" -eq 0 ] || set +m
+  target="-$pid"
+  if ! kill -0 -- "$target" 2>/dev/null; then
+    target="$pid"
+  fi
+  max_ticks=$((seconds * 10))
+
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ "$ticks" -ge "$max_ticks" ]; then
+      kill -TERM -- "$target" 2>/dev/null || true
+      while kill -0 -- "$target" 2>/dev/null && [ "$grace" -lt 10 ]; do
+        sleep 0.1
+        grace=$((grace + 1))
+      done
+      kill -KILL -- "$target" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+      return 124
+    fi
+    sleep 0.1
+    ticks=$((ticks + 1))
+  done
+
+  wait "$pid" || status=$?
+  return "$status"
+}
+
+kendex_github_run_bounded_capture() {
+  local seconds="$1" stdout_file="$2" stderr_file="$3"
+  shift 3
+  kendex_github_run_bounded "$seconds" "$@" >"$stdout_file" 2>"$stderr_file"
+}

--- a/skills/github/scripts/lib/bounded.sh
+++ b/skills/github/scripts/lib/bounded.sh
@@ -1,6 +1,38 @@
 #!/usr/bin/env bash
 # Portable wall-clock bound for GitHub helper subprocesses.
 
+_kendex_github_restore_trap() {
+  local signal="$1" saved="$2"
+  if [ -n "$saved" ]; then
+    eval "$saved"
+  else
+    trap - "$signal"
+  fi
+}
+
+_kendex_github_stop_bounded_group() {
+  local signal="$1" target="$2" pid="$3" grace=0
+  [ -n "$target" ] || return 0
+  kill -s "$signal" -- "$target" 2>/dev/null || true
+  while kill -0 -- "$target" 2>/dev/null && [ "$grace" -lt 10 ]; do
+    sleep 0.1
+    grace=$((grace + 1))
+  done
+  kill -KILL -- "$target" 2>/dev/null || true
+  [ -z "$pid" ] || wait "$pid" 2>/dev/null || true
+}
+
+_kendex_github_forward_bounded_signal() {
+  local signal="$1" target="$2" pid="$3" old_hup="$4" old_int="$5" old_term="$6"
+  trap - HUP INT TERM
+  _kendex_github_stop_bounded_group "$signal" "$target" "$pid"
+  _kendex_github_restore_trap HUP "$old_hup"
+  _kendex_github_restore_trap INT "$old_int"
+  _kendex_github_restore_trap TERM "$old_term"
+  kill -s "$signal" "$$" 2>/dev/null || true
+  case "$signal" in HUP) return 129 ;; INT) return 130 ;; TERM) return 143 ;; esac
+}
+
 kendex_github_run_bounded() {
   local seconds="$1"
   shift
@@ -14,7 +46,14 @@ kendex_github_run_bounded() {
     return
   fi
 
-  local restore_monitor=0 pid ticks=0 max_ticks status=0 grace=0 target
+  local restore_monitor=0 pid="" ticks=0 max_ticks status=0 target=""
+  local old_hup old_int old_term
+  old_hup="$(trap -p HUP)"
+  old_int="$(trap -p INT)"
+  old_term="$(trap -p TERM)"
+  trap '_kendex_github_forward_bounded_signal HUP "$target" "$pid" "$old_hup" "$old_int" "$old_term"' HUP
+  trap '_kendex_github_forward_bounded_signal INT "$target" "$pid" "$old_hup" "$old_int" "$old_term"' INT
+  trap '_kendex_github_forward_bounded_signal TERM "$target" "$pid" "$old_hup" "$old_int" "$old_term"' TERM
   case "$-" in
     *m*) ;;
     *) set -m; restore_monitor=1 ;;
@@ -31,13 +70,10 @@ kendex_github_run_bounded() {
 
   while kill -0 "$pid" 2>/dev/null; do
     if [ "$ticks" -ge "$max_ticks" ]; then
-      kill -TERM -- "$target" 2>/dev/null || true
-      while kill -0 -- "$target" 2>/dev/null && [ "$grace" -lt 10 ]; do
-        sleep 0.1
-        grace=$((grace + 1))
-      done
-      kill -KILL -- "$target" 2>/dev/null || true
-      wait "$pid" 2>/dev/null || true
+      _kendex_github_stop_bounded_group TERM "$target" "$pid"
+      _kendex_github_restore_trap HUP "$old_hup"
+      _kendex_github_restore_trap INT "$old_int"
+      _kendex_github_restore_trap TERM "$old_term"
       return 124
     fi
     sleep 0.1
@@ -45,6 +81,9 @@ kendex_github_run_bounded() {
   done
 
   wait "$pid" || status=$?
+  _kendex_github_restore_trap HUP "$old_hup"
+  _kendex_github_restore_trap INT "$old_int"
+  _kendex_github_restore_trap TERM "$old_term"
   return "$status"
 }
 

--- a/skills/github/scripts/lib/bounded.sh
+++ b/skills/github/scripts/lib/bounded.sh
@@ -10,11 +10,41 @@ _kendex_github_restore_trap() {
   fi
 }
 
+_kendex_github_bounded_group_members() {
+  local group="$1" leader="$2"
+  ps -eo pid=,pgid= 2>/dev/null | awk -v group="$group" -v leader="$leader" '
+    $2 == group && $1 != leader { print $1 }
+  '
+}
+
 _kendex_github_stop_bounded_group() {
-  local signal="$1" target="$2" pid="$3" grace=0
+  local signal="$1" target="$2" pid="$3" grace=0 group="" members="" member scan_failed=0
   [ -n "$target" ] || return 0
-  kill -s "$signal" -- "$target" 2>/dev/null || true
-  while kill -0 -- "$target" 2>/dev/null && [ "$grace" -lt 10 ]; do
+
+  case "$target" in -*) group="${target#-}" ;; esac
+  if [ -n "$group" ]; then
+    while [ "$grace" -lt 10 ]; do
+      if ! members="$(_kendex_github_bounded_group_members "$group" "$pid")"; then
+        scan_failed=1
+        break
+      fi
+      [ -n "$members" ] || break
+      while IFS= read -r member; do
+        [ -z "$member" ] || kill -s "$signal" "$member" 2>/dev/null || true
+      done <<<"$members"
+      sleep 0.1
+      grace=$((grace + 1))
+    done
+  fi
+
+  if [ "$scan_failed" -eq 1 ]; then
+    kill -s "$signal" -- "$target" 2>/dev/null || true
+  elif [ -n "$pid" ]; then
+    kill -s "$signal" "$pid" 2>/dev/null || true
+  fi
+
+  grace=0
+  while [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && [ "$grace" -lt 10 ]; do
     sleep 0.1
     grace=$((grace + 1))
   done

--- a/skills/github/scripts/lib/gh-auth.sh
+++ b/skills/github/scripts/lib/gh-auth.sh
@@ -9,25 +9,10 @@ kendex_github_is_resolved_token() {
   [[ "$token" =~ ^gh[pours]_ ]] || [[ "$token" =~ ^github_pat_ ]]
 }
 
-kendex_github_run_bounded() {
-  local seconds="$1"
-  shift
-
-  if command -v timeout >/dev/null 2>&1; then
-    timeout "${seconds}s" "$@"
-  else
-    "$@"
-  fi
-}
-
-kendex_github_run_bounded_capture() {
-  local seconds="$1"
-  local stdout_file="$2"
-  local stderr_file="$3"
-  shift 3
-
-  kendex_github_run_bounded "$seconds" "$@" >"$stdout_file" 2>"$stderr_file"
-}
+_GH_AUTH_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bounded.sh
+source "$_GH_AUTH_LIB_DIR/bounded.sh"
+unset _GH_AUTH_LIB_DIR
 
 kendex_github_has_env_token() {
   [[ -n "${GH_TOKEN:-}${GITHUB_TOKEN:-}" ]]
@@ -90,11 +75,7 @@ kendex_github_resolve_op_reference_to_var() {
     return 1
   fi
 
-  if command -v timeout >/dev/null 2>&1; then
-    op_output=$(timeout "${op_timeout}s" op read "$ref" 2>&1) || op_status=$?
-  else
-    op_output=$(op read "$ref" 2>&1) || op_status=$?
-  fi
+  op_output=$(kendex_github_run_bounded "$op_timeout" op read "$ref" 2>&1) || op_status=$?
 
   if [[ "$op_status" -eq 0 && -n "$op_output" ]]; then
     printf -v "$out_var" '%s' "$op_output"

--- a/skills/github/tests/bounded-signal.test.sh
+++ b/skills/github/tests/bounded-signal.test.sh
@@ -3,6 +3,35 @@ set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BOUNDED="$(cd "$TEST_DIR/.." && pwd)/scripts/lib/bounded.sh"
+SELF="$TEST_DIR/$(basename "${BASH_SOURCE[0]}")"
+
+if [[ "${KENDEX_BOUNDED_NONREAPING_PID1:-0}" != "1" ]] \
+  && command -v unshare >/dev/null 2>&1 \
+  && command -v python3 >/dev/null 2>&1 \
+  && unshare --user --map-root-user --pid --fork --mount-proc true 2>/dev/null; then
+  exec unshare --user --map-root-user --pid --fork --mount-proc \
+    python3 -c '
+import glob, os, subprocess, sys, time
+env = os.environ.copy()
+env["KENDEX_BOUNDED_NONREAPING_PID1"] = "1"
+run = subprocess.run(["bash", sys.argv[1]], env=env)
+time.sleep(0.1)
+zombies = []
+for path in glob.glob("/proc/[0-9]*/stat"):
+    try:
+        fields = open(path).read().split()
+        if fields[2] == "Z" and fields[3] == "1":
+            zombies.append((fields[0], fields[1], fields[4]))
+    except (IndexError, OSError):
+        pass
+if zombies:
+    print("FAIL  non-reaping PID 1 adopted zombies: %r" % (zombies,))
+    sys.exit(1)
+print("ok    non-reaping PID 1 adopted no zombies")
+sys.exit(run.returncode)
+' "$SELF"
+fi
+
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 

--- a/skills/github/tests/bounded-signal.test.sh
+++ b/skills/github/tests/bounded-signal.test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BOUNDED="$(cd "$TEST_DIR/.." && pwd)/scripts/lib/bounded.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+
+cat >"$TMP/worker.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$$" >"$PID_FILE"
+exec >/dev/null 2>&1
+sleep 30
+EOF
+chmod +x "$TMP/worker.sh"
+
+cat >"$TMP/wrapper.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+source "$BOUNDED"
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+kendex_github_run_bounded 30 "$WORKER"
+EOF
+chmod +x "$TMP/wrapper.sh"
+
+check_signal() {
+  local signal="$1" expected="$2" rc child_pid="" tries=0
+  local pid_file="$TMP/$signal.pid"
+  set +e
+  SIGNAL="$signal" BOUNDED="$BOUNDED" WORKER="$TMP/worker.sh" \
+    WRAPPER="$TMP/wrapper.sh" PID_FILE="$pid_file" \
+    bash -c '
+      set -m
+      "$WRAPPER" &
+      wrapper=$!
+      tries=0
+      while [[ ! -s "$PID_FILE" && "$tries" -lt 100 ]]; do
+        sleep 0.02
+        tries=$((tries + 1))
+      done
+      kill -s "$SIGNAL" "$wrapper"
+      wait "$wrapper"
+      exit $?
+    ' >"$TMP/$signal.out" 2>"$TMP/$signal.err"
+  rc=$?
+  set -e
+
+  if [[ "$rc" -eq "$expected" ]]; then
+    PASS=$((PASS + 1)); printf '  ok    %s exits %s\n' "$signal" "$expected"
+  else
+    FAIL=$((FAIL + 1)); printf '  FAIL  %s exit: expected %s, got %s\n' "$signal" "$expected" "$rc"
+  fi
+
+  if [[ -s "$pid_file" ]]; then
+    child_pid="$(<"$pid_file")"
+  fi
+  while [[ -n "$child_pid" ]] && kill -0 -- "-$child_pid" 2>/dev/null \
+    && [[ "$tries" -lt 20 ]]; do
+    sleep 0.05
+    tries=$((tries + 1))
+  done
+  if [[ -n "$child_pid" ]] && kill -0 -- "-$child_pid" 2>/dev/null; then
+    FAIL=$((FAIL + 1)); printf '  FAIL  %s left process group %s alive\n' "$signal" "$child_pid"
+    kill -KILL -- "-$child_pid" 2>/dev/null || true
+  elif [[ -n "$child_pid" ]]; then
+    PASS=$((PASS + 1)); printf '  ok    %s cleaned process group %s\n' "$signal" "$child_pid"
+  else
+    FAIL=$((FAIL + 1)); printf '  FAIL  %s worker wrote no pid\n' "$signal"
+  fi
+}
+
+echo "=== bounded runner signal cleanup ==="
+check_signal HUP 129
+check_signal INT 130
+check_signal TERM 143
+
+printf '\npass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/github/tests/help-contracts.test.sh
+++ b/skills/github/tests/help-contracts.test.sh
@@ -167,10 +167,15 @@ run_help_contracts() {
   done
 
   for token in 'ALREADY MERGED PR #N' 'QUEUED IN MERGE QUEUE PR #N' \
-    'AUTO-MERGE ENABLED PR #N' 'CLOSED (not merged) PR #N'; do
+    'AUTO-MERGE ENABLED PR #N' 'BLOCKED PR #N' \
+    'The requested operation failed' 'pre-existing queue entry' \
+    'auto-merge request may remain active' 'CLOSED (not merged) PR #N'; do
     assert_section_token "$merge_help" 'Merge-mode exit codes:' '--check exit:' "$token" \
       "$label exit codes carry $token"
   done
+  assert_section_rejects_token "$merge_help" 'Merge-mode exit codes:' '--check exit:' \
+    'Nothing merged, queued, or armed.' \
+    "$label BLOCKED outcome does not erase pre-existing pending state"
 
   for token in '--check exits 0' 'valid readiness JSON' 'can_merge=false' \
     'CLOSED' 'nonzero'; do
@@ -229,6 +234,15 @@ merge_decoy=$'Exit 75 is volatile:\nwatch only\nTerminal and mutation rules:\nej
 assert_section_rejects_decoy "$merge_decoy" 'Exit 75 is volatile:' \
   'Terminal and mutation rules:' 'ejected' \
   'pr-merge token in a sibling section does not satisfy ownership'
+
+stale_blocked_help=$'Merge-mode exit codes:\n  1 BLOCKED PR #N\n  Nothing merged, queued, or armed.\n--check exit:'
+if section_has_token "$stale_blocked_help" 'Merge-mode exit codes:' '--check exit:' \
+    'Nothing merged, queued, or armed.'; then
+  pass 'stale BLOCKED claim is detectable inside its owning section'
+else
+  fail 'stale BLOCKED claim is detectable inside its owning section' \
+    'the stale-claim control did not reach the merge exit table'
+fi
 
 echo
 echo "=== SKILL word ceiling and mirror ==="

--- a/skills/github/tests/help-contracts.test.sh
+++ b/skills/github/tests/help-contracts.test.sh
@@ -2,79 +2,209 @@
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-GITHUB_SH="$(cd "$TEST_DIR/.." && pwd)/scripts/github.sh"
+PACKAGE_ROOT="$(cd "$TEST_DIR/.." && pwd)"
+REPO_ROOT="$(git -C "$TEST_DIR" rev-parse --show-toplevel)"
+CANONICAL="$REPO_ROOT/skills/github"
+MIRROR="$REPO_ROOT/.agents/skills/github"
+[[ -d "$CANONICAL" ]] || CANONICAL="$PACKAGE_ROOT"
+[[ -d "$MIRROR" ]] || MIRROR="$PACKAGE_ROOT"
 
 PASS=0
 FAIL=0
 
-assert_token() {
-  local output="$1" token="$2" name="$3"
-  if grep -qF -- "$token" <<<"$output"; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
+pass() {
+  PASS=$((PASS + 1))
+  printf '  ok    %s\n' "$1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  printf '  FAIL  %s\n        %s\n' "$1" "$2"
+}
+
+extract_section() {
+  local output="$1" start="$2" end="$3" start_count end_count
+  start_count=$(grep -cxF -- "$start" <<<"$output" || true)
+  end_count=$(grep -cxF -- "$end" <<<"$output" || true)
+  [[ "$start_count" -eq 1 && "$end_count" -eq 1 ]] || return 2
+  awk -v start="$start" -v end="$end" '
+    $0 == start { inside = 1; next }
+    $0 == end { if (inside) exit }
+    inside { print }
+  ' <<<"$output"
+}
+
+section_has_token() {
+  local output="$1" start="$2" end="$3" token="$4" section
+  section=$(extract_section "$output" "$start" "$end") || return 1
+  grep -qF -- "$token" <<<"$section"
+}
+
+assert_section_token() {
+  local output="$1" start="$2" end="$3" token="$4" name="$5"
+  if section_has_token "$output" "$start" "$end" "$token"; then
+    pass "$name"
   else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        missing token: %s\n' "$name" "$token"
+    fail "$name" "missing $token inside $start"
   fi
 }
 
-echo "=== github.sh help owns configuration and error contracts ==="
-github_help="$($GITHUB_SH --help)"
-for token in \
-  'Configuration:' \
-  'GH_TOKEN' \
-  'GITHUB_TOKEN' \
-  'GH_BOT_TOKEN' \
-  'GH_BOT_USERNAME' \
-  'GH_ISSUE_PATTERN' \
-  'GH_VERIFY_CMD' \
-  'KENDEX_GITHUB_OP_TIMEOUT' \
-  'KENDEX_GITHUB_AUTH_TIMEOUT' \
-  'KENDEX_GITHUB_PR_VIEW_TIMEOUT' \
-  'KENDEX_GITHUB_GIT_HTTPS_FALLBACK' \
-  'kendex.settings.toml' \
-  '.kendex/settings.toml' \
-  '.env.local' \
-  'op://' \
-  'gh api user' \
-  'gh auth status' \
-  '{"error": "message"}' \
-  'pr-view --json' \
-  '3 attempts'; do
-  assert_token "$github_help" "$token" "github.sh help carries $token"
-done
+assert_section_rejects_decoy() {
+  local output="$1" start="$2" end="$3" token="$4" name="$5"
+  if section_has_token "$output" "$start" "$end" "$token"; then
+    fail "$name" "accepted $token from a sibling section"
+  else
+    pass "$name"
+  fi
+}
+
+word_count_at_most() {
+  local text="$1" limit="$2" count
+  count=$(wc -w <<<"$text")
+  [[ "$count" -le "$limit" ]]
+}
+
+assert_file_word_limit() {
+  local file="$1" name="$2" text count
+  text=$(<"$file")
+  count=$(wc -w <<<"$text")
+  if word_count_at_most "$text" 900; then
+    pass "$name ($count words)"
+  else
+    fail "$name" "$count words exceeds 900"
+  fi
+}
+
+assert_file_token() {
+  local file="$1" token="$2" name="$3"
+  if grep -qF -- "$token" "$file"; then
+    pass "$name"
+  else
+    fail "$name" "missing token: $token"
+  fi
+}
+
+run_help_contracts() {
+  local label="$1" root="$2" github_help merge_help label_add_help label_remove_help token
+  github_help=$("$root/scripts/github.sh" --help)
+  merge_help=$("$root/scripts/github.sh" pr-merge --help)
+  label_add_help=$("$root/scripts/github.sh" label-add --help)
+  label_remove_help=$("$root/scripts/github.sh" label-remove --help)
+
+  for token in 'unknown flags' 'positionals' 'positional body' 'omitted PR number'; do
+    assert_section_token "$github_help" 'Argument rules:' 'Configuration:' "$token" \
+      "$label argument rules carry $token"
+  done
+
+  for token in 'GH_TOKEN' 'GITHUB_TOKEN' 'GH_BOT_TOKEN' 'GH_BOT_USERNAME' \
+    'GH_ISSUE_PATTERN' 'GH_VERIFY_CMD' 'KENDEX_GITHUB_OP_TIMEOUT' \
+    'KENDEX_GITHUB_AUTH_TIMEOUT' 'KENDEX_GITHUB_PR_VIEW_TIMEOUT' \
+    'KENDEX_GITHUB_GIT_HTTPS_FALLBACK' 'kendex.settings.toml' \
+    '.kendex/settings.toml' '.env.local'; do
+    assert_section_token "$github_help" 'Configuration:' 'Token selection:' "$token" \
+      "$label configuration carries $token"
+  done
+
+  for token in 'GH_TOKEN, GH_BOT_TOKEN, GITHUB_TOKEN' 'op://' 'op read'; do
+    assert_section_token "$github_help" 'Token selection:' 'Auth preflight:' "$token" \
+      "$label token selection carries $token"
+  done
+
+  for token in 'gh api user' 'gh auth status'; do
+    assert_section_token "$github_help" 'Auth preflight:' 'Errors and retries:' "$token" \
+      "$label auth preflight carries $token"
+  done
+
+  for token in '{"error": "message"}' 'pr-view --json' 'gh_graphql' 'gh_rest' \
+    '3 attempts' 'first-failure'; do
+    assert_section_token "$github_help" 'Errors and retries:' 'Examples:' "$token" \
+      "$label errors carry $token"
+  done
+
+  for token in 'kendex.settings.toml' '.kendex/settings.toml' '.env.local' \
+    'Parent-process'; do
+    assert_section_token "$label_add_help" 'Configuration:' 'Examples:' "$token" \
+      "$label label-add configuration carries $token"
+    assert_section_token "$label_remove_help" 'Configuration:' 'Examples:' "$token" \
+      "$label label-remove configuration carries $token"
+  done
+
+  for token in 'ALREADY MERGED PR #N' 'QUEUED IN MERGE QUEUE PR #N' \
+    'AUTO-MERGE ENABLED PR #N' 'CLOSED (not merged) PR #N'; do
+    assert_section_token "$merge_help" 'Exit codes:' 'Exit 75 is volatile:' "$token" \
+      "$label exit codes carry $token"
+  done
+
+  for token in 'queue-wait <N>' 'pr-watch.sh' 'ejected' 'disarmed' 'not_queued' \
+    'Dequeued' 'closed' 'unknown' 'README.md "Exit 75 recovery"' 'await-mergeable'; do
+    assert_section_token "$merge_help" 'Exit 75 is volatile:' 'Terminal and mutation rules:' "$token" \
+      "$label exit-75 routing carries $token"
+  done
+
+  for token in 'github.sh router setup' 'bot-token load' 'merge-state mutation' \
+    'exact-head guarded' '--match-head-commit' '--delete-branch' \
+    'best-effort'; do
+    assert_section_token "$merge_help" 'Terminal and mutation rules:' 'Review-thread gate:' "$token" \
+      "$label terminal and mutation rules carry $token"
+  done
+
+  for token in 'required_conversation_resolution' 'gh pr merge' 'UI Merge button'; do
+    assert_section_token "$merge_help" 'Review-thread gate:' 'Force rules:' "$token" \
+      "$label review-thread gate carries $token"
+  done
+
+  for token in '--force' '--auto' 'exact-head post-state'; do
+    assert_section_token "$merge_help" 'Force rules:' '--check JSON:' "$token" \
+      "$label force rules carry $token"
+  done
+
+  for token in 'can_merge' 'issues' 'transient' 'state' 'merged_at' 'head_runs' \
+    'checks' 'ci-classify-refusal' 'unknown:' 'ci_pending:' 'ci_unconfigured:' \
+    'ci_fetch_failed:' 'ci_failed:'; do
+    assert_section_token "$merge_help" '--check JSON:' 'Examples:' "$token" \
+      "$label check JSON carries $token"
+  done
+}
+
+echo "=== bounded help contracts ==="
+run_help_contracts canonical "$CANONICAL"
+run_help_contracts mirror "$MIRROR"
 
 echo
-echo "=== pr-merge help owns merge outcomes and checks ==="
-merge_help="$($GITHUB_SH pr-merge --help)"
-for token in \
-  'Exit codes:' \
-  'ALREADY MERGED PR #N' \
-  'QUEUED IN MERGE QUEUE PR #N' \
-  'AUTO-MERGE ENABLED PR #N' \
-  'CLOSED (not merged) PR #N' \
-  'queue-wait <N>' \
-  'pr-watch.sh' \
-  'await-mergeable' \
-  '--match-head-commit' \
-  'isInMergeQueue' \
-  'required_conversation_resolution' \
-  'gh pr merge' \
-  'can_merge' \
-  'issues' \
-  'transient' \
-  'state' \
-  'merged_at' \
-  'head_runs' \
-  'checks' \
-  'ci-classify-refusal' \
-  'unknown:' \
-  'ci_pending:' \
-  'ci_unconfigured:' \
-  'ci_fetch_failed:' \
-  'ci_failed:'; do
-  assert_token "$merge_help" "$token" "pr-merge help carries $token"
-done
+echo "=== section-boundary must-fail controls ==="
+github_decoy=$'Argument rules:\nknown only\nConfiguration:\nunknown flags\nToken selection:'
+assert_section_rejects_decoy "$github_decoy" 'Argument rules:' 'Configuration:' \
+  'unknown flags' 'github token in a sibling section does not satisfy ownership'
+
+merge_decoy=$'Exit 75 is volatile:\nwatch only\nTerminal and mutation rules:\nejected\nReview-thread gate:'
+assert_section_rejects_decoy "$merge_decoy" 'Exit 75 is volatile:' \
+  'Terminal and mutation rules:' 'ejected' \
+  'pr-merge token in a sibling section does not satisfy ownership'
+
+echo
+echo "=== SKILL word ceiling and mirror ==="
+assert_file_word_limit "$CANONICAL/SKILL.md" 'canonical SKILL stays within 900 words'
+assert_file_word_limit "$MIRROR/SKILL.md" 'mirror SKILL stays within 900 words'
+assert_file_token "$CANONICAL/SKILL.md" 'Do not hand-file' \
+  'canonical SKILL keeps the report banner'
+assert_file_token "$MIRROR/SKILL.md" 'Do not hand-file' \
+  'mirror SKILL keeps the report banner'
+assert_file_token "$CANONICAL/SKILL.md" '.agents/skills/orch/scripts/ci-wait' \
+  'canonical SKILL routes CI waiting to orch'
+assert_file_token "$MIRROR/SKILL.md" '.agents/skills/orch/scripts/ci-wait' \
+  'mirror SKILL routes CI waiting to orch'
+if cmp -s "$CANONICAL/SKILL.md" "$MIRROR/SKILL.md"; then
+  pass 'canonical and mirror SKILL files are byte-equivalent'
+else
+  fail 'canonical and mirror SKILL files are byte-equivalent' 'cmp reported drift'
+fi
+
+over_limit=$(awk 'BEGIN { for (i = 1; i <= 901; i++) printf "word " }')
+if word_count_at_most "$over_limit" 900; then
+  fail '901-word control exceeds the ceiling' 'word limit accepted 901 words'
+else
+  pass '901-word control exceeds the ceiling'
+fi
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/github/tests/help-contracts.test.sh
+++ b/skills/github/tests/help-contracts.test.sh
@@ -63,6 +63,15 @@ assert_section_rejects_decoy() {
   fi
 }
 
+assert_section_rejects_token() {
+  local output="$1" start="$2" end="$3" token="$4" name="$5"
+  if section_has_token "$output" "$start" "$end" "$token"; then
+    fail "$name" "found stale token: $token"
+  else
+    pass "$name"
+  fi
+}
+
 word_count_at_most() {
   local text="$1" limit="$2" count
   count=$(wc -w <<<"$text")
@@ -90,13 +99,22 @@ assert_file_token() {
 }
 
 run_help_contracts() {
-  local label="$1" root="$2" github_help merge_help label_add_help label_remove_help pr_view_help sticky_help token
+  local label="$1" root="$2" github_help merge_help label_add_help label_remove_help pr_view_help sticky_help readme token
   github_help=$("$root/scripts/github.sh" --help)
   merge_help=$("$root/scripts/github.sh" pr-merge --help)
   label_add_help=$("$root/scripts/github.sh" label-add --help)
   label_remove_help=$("$root/scripts/github.sh" label-remove --help)
   pr_view_help=$("$root/scripts/github.sh" pr-view --help)
   sticky_help=$("$root/scripts/github.sh" sticky-comment --help)
+  readme="$(<"$root/README.md")"
+
+  for token in 'github.sh --help' '<command> --help' 'SKILL.md' 'DEVELOPMENT.md'; do
+    assert_section_token "$readme" '# GitHub Queries' '## Setup' "$token" \
+      "$label README entry point carries $token"
+  done
+  assert_section_rejects_token "$readme" '# GitHub Queries' '## Setup' \
+    'SKILL.md` is the full command reference' \
+    "$label README does not call SKILL.md the full reference"
 
   for token in 'Most subcommands' 'pr-view' 'gh pr view' '--format' \
     'sticky-comment' 'unrecognized flags' 'positional input' 'ignored'; do

--- a/skills/github/tests/help-contracts.test.sh
+++ b/skills/github/tests/help-contracts.test.sh
@@ -28,9 +28,14 @@ extract_section() {
   end_count=$(grep -cxF -- "$end" <<<"$output" || true)
   [[ "$start_count" -eq 1 && "$end_count" -eq 1 ]] || return 2
   awk -v start="$start" -v end="$end" '
-    $0 == start { inside = 1; next }
-    $0 == end { if (inside) exit }
-    inside { print }
+    $0 == end {
+      if (!seen_start) bad = 1
+      else seen_end = 1
+      exit
+    }
+    $0 == start { seen_start = 1; next }
+    seen_start { print }
+    END { if (bad || !seen_start || !seen_end) exit 2 }
   ' <<<"$output"
 }
 
@@ -85,15 +90,28 @@ assert_file_token() {
 }
 
 run_help_contracts() {
-  local label="$1" root="$2" github_help merge_help label_add_help label_remove_help token
+  local label="$1" root="$2" github_help merge_help label_add_help label_remove_help pr_view_help sticky_help token
   github_help=$("$root/scripts/github.sh" --help)
   merge_help=$("$root/scripts/github.sh" pr-merge --help)
   label_add_help=$("$root/scripts/github.sh" label-add --help)
   label_remove_help=$("$root/scripts/github.sh" label-remove --help)
+  pr_view_help=$("$root/scripts/github.sh" pr-view --help)
+  sticky_help=$("$root/scripts/github.sh" sticky-comment --help)
 
-  for token in 'unknown flags' 'positionals' 'positional body' 'omitted PR number'; do
+  for token in 'Most subcommands' 'pr-view' 'gh pr view' '--format' \
+    'sticky-comment' 'unrecognized flags' 'positional input' 'ignored'; do
     assert_section_token "$github_help" 'Argument rules:' 'Configuration:' "$token" \
       "$label argument rules carry $token"
+  done
+
+  for token in '--format' 'unrecognized flags' 'extra positionals' 'gh pr view'; do
+    assert_section_token "$pr_view_help" 'Note:' 'Errors:' "$token" \
+      "$label pr-view compatibility carries $token"
+  done
+
+  for token in 'Unrecognized flags' 'positional input' 'Surplus positionals' 'ignored'; do
+    assert_section_token "$sticky_help" 'Compatibility:' 'Output (default):' "$token" \
+      "$label sticky-comment compatibility carries $token"
   done
 
   for token in 'GH_TOKEN' 'GITHUB_TOKEN' 'GH_BOT_TOKEN' 'GH_BOT_USERNAME' \
@@ -131,8 +149,14 @@ run_help_contracts() {
 
   for token in 'ALREADY MERGED PR #N' 'QUEUED IN MERGE QUEUE PR #N' \
     'AUTO-MERGE ENABLED PR #N' 'CLOSED (not merged) PR #N'; do
-    assert_section_token "$merge_help" 'Exit codes:' 'Exit 75 is volatile:' "$token" \
+    assert_section_token "$merge_help" 'Merge-mode exit codes:' '--check exit:' "$token" \
       "$label exit codes carry $token"
+  done
+
+  for token in '--check exits 0' 'valid readiness JSON' 'can_merge=false' \
+    'CLOSED' 'nonzero'; do
+    assert_section_token "$merge_help" '--check exit:' 'Exit 75 is volatile:' "$token" \
+      "$label check exit carries $token"
   done
 
   for token in 'queue-wait <N>' 'pr-watch.sh' 'ejected' 'disarmed' 'not_queued' \
@@ -175,6 +199,10 @@ echo "=== section-boundary must-fail controls ==="
 github_decoy=$'Argument rules:\nknown only\nConfiguration:\nunknown flags\nToken selection:'
 assert_section_rejects_decoy "$github_decoy" 'Argument rules:' 'Configuration:' \
   'unknown flags' 'github token in a sibling section does not satisfy ownership'
+
+reversed_decoy=$'Configuration:\nArgument rules:\nunknown flags\nToken selection:'
+assert_section_rejects_decoy "$reversed_decoy" 'Argument rules:' 'Configuration:' \
+  'unknown flags' 'end-before-start section boundaries are rejected'
 
 merge_decoy=$'Exit 75 is volatile:\nwatch only\nTerminal and mutation rules:\nejected\nReview-thread gate:'
 assert_section_rejects_decoy "$merge_decoy" 'Exit 75 is volatile:' \

--- a/skills/github/tests/help-contracts.test.sh
+++ b/skills/github/tests/help-contracts.test.sh
@@ -160,8 +160,9 @@ run_help_contracts() {
       "$label check exit carries $token"
   done
 
-  for token in 'queue-wait <N>' 'pr-watch.sh' 'ejected' 'disarmed' 'not_queued' \
-    'Dequeued' 'closed' 'unknown' 'README.md "Exit 75 recovery"' 'await-mergeable'; do
+  for token in 'merge-queue-watch' 'expected head' 'watch generation' \
+    'durable verdict' 'recovery action' 'README.md "Exit 75 recovery"' \
+    'github.sh pr-merge <N> --auto' 'await-mergeable'; do
     assert_section_token "$merge_help" 'Exit 75 is volatile:' 'Terminal and mutation rules:' "$token" \
       "$label exit-75 routing carries $token"
   done

--- a/skills/github/tests/help-contracts.test.sh
+++ b/skills/github/tests/help-contracts.test.sh
@@ -133,8 +133,9 @@ run_help_contracts() {
       "$label auth preflight carries $token"
   done
 
-  for token in '{"error": "message"}' 'pr-view --json' 'gh_graphql' 'gh_rest' \
-    '3 attempts' 'first-failure'; do
+  for token in '{"error": "message"}' 'pr-view --json' 'gh_graphql' 'nonzero' \
+    'GraphQL errors' 'gh_rest' 'rate limits' 'authentication' 'not-found' \
+    '3 attempts' 'first attempt'; do
     assert_section_token "$github_help" 'Errors and retries:' 'Examples:' "$token" \
       "$label errors carry $token"
   done
@@ -165,7 +166,8 @@ run_help_contracts() {
       "$label exit-75 routing carries $token"
   done
 
-  for token in 'github.sh router setup' 'bot-token load' 'merge-state mutation' \
+  for token in 'github.sh router setup' 'MERGED or CLOSED' 'UNKNOWN continues' \
+    'bot-token load' 'merge-state mutation' \
     'exact-head guarded' '--match-head-commit' '--delete-branch' \
     'best-effort'; do
     assert_section_token "$merge_help" 'Terminal and mutation rules:' 'Review-thread gate:' "$token" \

--- a/skills/github/tests/help-contracts.test.sh
+++ b/skills/github/tests/help-contracts.test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GITHUB_SH="$(cd "$TEST_DIR/.." && pwd)/scripts/github.sh"
+
+PASS=0
+FAIL=0
+
+assert_token() {
+  local output="$1" token="$2" name="$3"
+  if grep -qF -- "$token" <<<"$output"; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        missing token: %s\n' "$name" "$token"
+  fi
+}
+
+echo "=== github.sh help owns configuration and error contracts ==="
+github_help="$($GITHUB_SH --help)"
+for token in \
+  'Configuration:' \
+  'GH_TOKEN' \
+  'GITHUB_TOKEN' \
+  'GH_BOT_TOKEN' \
+  'GH_BOT_USERNAME' \
+  'GH_ISSUE_PATTERN' \
+  'GH_VERIFY_CMD' \
+  'KENDEX_GITHUB_OP_TIMEOUT' \
+  'KENDEX_GITHUB_AUTH_TIMEOUT' \
+  'KENDEX_GITHUB_PR_VIEW_TIMEOUT' \
+  'KENDEX_GITHUB_GIT_HTTPS_FALLBACK' \
+  'kendex.settings.toml' \
+  '.kendex/settings.toml' \
+  '.env.local' \
+  'op://' \
+  'gh api user' \
+  'gh auth status' \
+  '{"error": "message"}' \
+  'pr-view --json' \
+  '3 attempts'; do
+  assert_token "$github_help" "$token" "github.sh help carries $token"
+done
+
+echo
+echo "=== pr-merge help owns merge outcomes and checks ==="
+merge_help="$($GITHUB_SH pr-merge --help)"
+for token in \
+  'Exit codes:' \
+  'ALREADY MERGED PR #N' \
+  'QUEUED IN MERGE QUEUE PR #N' \
+  'AUTO-MERGE ENABLED PR #N' \
+  'CLOSED (not merged) PR #N' \
+  'queue-wait <N>' \
+  'pr-watch.sh' \
+  'await-mergeable' \
+  '--match-head-commit' \
+  'isInMergeQueue' \
+  'required_conversation_resolution' \
+  'gh pr merge' \
+  'can_merge' \
+  'issues' \
+  'transient' \
+  'state' \
+  'merged_at' \
+  'head_runs' \
+  'checks' \
+  'ci-classify-refusal' \
+  'unknown:' \
+  'ci_pending:' \
+  'ci_unconfigured:' \
+  'ci_fetch_failed:' \
+  'ci_failed:'; do
+  assert_token "$merge_help" "$token" "pr-merge help carries $token"
+done
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/github/tests/pr-merge-thread-gate-docs.test.sh
+++ b/skills/github/tests/pr-merge-thread-gate-docs.test.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
 # Docs regression tests for pr-merge's review-thread gate (kendex#825).
 #
-# pr-merge counts only threads that are unresolved AND not outdated, which is
-# deliberately narrower than GitHub's required_conversation_resolution. That
-# divergence, the fact that the gate binds only merges routed through the
-# skill, and the recovery path for outdated threads that block a merge while
-# being unreachable in the UI all live in prose only. These tests pin that
-# prose to the real script behavior so neither side can drift silently.
+# pr-merge counts only threads that are unresolved and not outdated. Its help
+# records that bound; SKILL.md keeps routing and recovery instructions.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -14,6 +10,7 @@ REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
 SKILL_MD="$REPO_ROOT/skills/github/SKILL.md"
 README_MD="$REPO_ROOT/skills/github/README.md"
 PR_MERGE="$REPO_ROOT/skills/github/scripts/commands/pr-merge.sh"
+GITHUB_SH="$REPO_ROOT/skills/github/scripts/github.sh"
 
 PASS=0
 FAIL=0
@@ -40,17 +37,8 @@ assert_matches() {
   fi
 }
 
-# The doc checks pin STRUCTURE — the two bolded rule labels, the API setting
-# name, the escape-path heading and the commands under it, the routing rows
-# that point at it. review-bots.md: a token pin establishes that a structural
-# element is present, never that a behavioral claim written in prose is true,
-# so the SKILL's statement that outdated threads are excluded and the README's
-# statement of the unreachable-in-the-UI hazard have no lint. Nor the escape
-# section's account of how a thread becomes unreachable, nor the README's own
-# policy-not-mechanism bound: SKILL.md carries that one as a bolded label
-# other documents cite, the README as an ordinary sentence. Both of those
-# predate this branch. The script
-# assertions above hold the filter itself, which is what proves the exclusion.
+# Documentation assertions pin headings, commands, flags, and field names.
+# Script assertions prove the filter itself.
 
 echo "=== pr-merge thread-gate docs match the script (kendex#825) ==="
 
@@ -65,21 +53,22 @@ assert_matches "$script_src" 'unresolved_threads\|review_threads_fetch_failed' \
 
 skill_src=$(cat "$SKILL_MD")
 readme_src=$(cat "$README_MD")
+merge_help=$($GITHUB_SH pr-merge --help)
 
 # 1. Actionable-only semantics, named against the platform setting it diverges
 #    from, so an operator can tell the two guarantees apart.
-assert_contains "$skill_src" 'required_conversation_resolution' \
-  "SKILL.md names required_conversation_resolution"
-assert_contains "$skill_src" 'Narrower than branch protection' \
-  "SKILL.md carries the narrower-than-branch-protection rule"
+assert_contains "$merge_help" 'required_conversation_resolution' \
+  "pr-merge help names required_conversation_resolution"
+assert_contains "$merge_help" 'Review-thread gate:' \
+  "pr-merge help carries the review-thread gate"
 
 # 2. Policy, not mechanism: the gate binds only merges routed through pr-merge.
 assert_matches "$skill_src" 'Policy, not mechanism' \
   "SKILL.md frames the gate as policy rather than mechanism"
-assert_matches "$skill_src" 'UI Merge button|Merge button' \
-  "SKILL.md names the UI Merge button as a bypass"
-assert_matches "$skill_src" 'raw .gh pr merge' \
-  "SKILL.md names raw gh pr merge as a bypass"
+assert_contains "$merge_help" 'UI Merge button' \
+  "pr-merge help names the UI Merge button"
+assert_contains "$merge_help" 'gh pr merge' \
+  "pr-merge help names gh pr merge"
 
 # 3. The unreachable-thread escape path. Match on the searchable heading an
 #    operator would land on, then on both commands the recovery needs.

--- a/skills/github/tests/pr-merge-volatile-75-docs.test.sh
+++ b/skills/github/tests/pr-merge-volatile-75-docs.test.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
-# Exit 75 (queued / auto-merge armed) is volatile: an ejection disarms it
-# silently. The script says so on every 75 exit and the SKILL.md outcome table
-# names the durable lifecycle a caller must launch; these pins keep the two from
-# drifting apart.
+# Exit 75 is volatile. The script and its help name the durable lifecycle a
+# caller must launch.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -64,21 +62,20 @@ else
   PASS=$((PASS + 1)); printf '  ok    %s\n' "volatile_note makes no gh request"
 fi
 
-table=$(sed -n '/^### PR Merge Outcomes$/,/^### /p' "$SKILL_MD")
-assert_count "$table" '^\| `75` \| MERGE PENDING \(volatile\)' 2 \
-  "both 75 rows of the outcomes table are marked volatile"
-assert_matches "$table" 'launch the prepared durable lifecycle before returning' \
-  "the 75 rows require the prepared lifecycle before return"
-assert_matches "$table" 'one-shot worker writes a durable verdict' \
-  "the outcomes section states the lifecycle durability boundary"
+merge_help=$($GITHUB_SH pr-merge --help)
+volatile_help=$(sed -n '/^Exit 75 is volatile:$/,/^Terminal and mutation rules:$/p' <<<"$merge_help")
+assert_matches "$volatile_help" '^Exit 75 is volatile:$' \
+  "pr-merge help carries the exit-75 contract"
+assert_matches "$volatile_help" 'merge-queue-watch' \
+  "pr-merge help names the durable lifecycle"
+assert_matches "$volatile_help" 'durable verdict' \
+  "pr-merge help states the lifecycle durability boundary"
 assert_matches "$script_src" 'Launch the prepared .*merge-queue-watch once' \
   "the note says to launch one durable lifecycle generation"
-assert_matches "$table" 'merge-queue-watch' \
-  "the outcomes section names merge-queue-watch as the required follow-up"
-assert_matches "$(tr '\n' ' ' <<<"$table")" 'github\.sh pr-merge <N> --auto' \
-  "the outcomes section names the re-arm by its installed entry point"
-assert_matches "$table" 'README\.md § Exit 75 recovery' \
-  "the outcomes section points at the README recovery section (progressive disclosure)"
+assert_matches "$volatile_help" 'github\.sh pr-merge <N> --auto' \
+  "pr-merge help names the re-arm command"
+assert_matches "$volatile_help" 'README\.md "Exit 75 recovery"' \
+  "pr-merge help links the recovery section"
 readme_src=$(sed -n '/^## Exit 75 recovery$/,/^## /p' "$REPO_ROOT/skills/github/README.md")
 assert_matches "$readme_src" 'exits 75 when the PR is queued or auto-merge is armed' \
   "README states the volatile 75 contract"
@@ -113,8 +110,8 @@ assert_matches "$watch_src" 'conflicting:\*\) action=restack' \
   "the lifecycle maps the conflicting producer verdict to that restack action"
 assert_matches "$watch_src" 'malformed_artifact' \
   "an artifact outside the accepted verdict set fails closed"
-assert_matches "$table" 'await-mergeable` is not that' \
-  "the outcomes section states await-mergeable is not the ejection watcher"
+assert_matches "$volatile_help" 'await-mergeable' \
+  "pr-merge help names await-mergeable"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/github/tests/pr-merge-volatile-75-docs.test.sh
+++ b/skills/github/tests/pr-merge-volatile-75-docs.test.sh
@@ -7,8 +7,8 @@ set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
-SKILL_MD="$REPO_ROOT/skills/github/SKILL.md"
 PR_MERGE="$REPO_ROOT/skills/github/scripts/commands/pr-merge.sh"
+GITHUB_SH="$REPO_ROOT/skills/github/scripts/github.sh"
 
 PASS=0
 FAIL=0
@@ -36,7 +36,7 @@ assert_count() { # GOT PATTERN EXPECTED NAME
   fi
 }
 
-echo "=== pr-merge exit 75 is documented as volatile, in the script and the SKILL ==="
+echo "=== pr-merge exit 75 contract matches script and help ==="
 
 script_src=$(cat "$PR_MERGE")
 # Both 75 exits route through the one note (queued and classic auto-merge).

--- a/skills/github/tests/pr-view.sh
+++ b/skills/github/tests/pr-view.sh
@@ -179,6 +179,15 @@ run_pr_view_json_help_value() {
        pr-view --json --help)
 }
 
+run_pr_view_help_value() {
+  local calls_file="$1" flag="$2"
+  (cd "$TMP_ROOT/repo" \
+    && PATH="$TMP_ROOT/bin:$PATH" \
+       STUB_GH_CALLS="$calls_file" \
+       env -u GH_TOKEN -u GITHUB_TOKEN "$GITHUB_SH" -C "$TMP_ROOT/repo" \
+       pr-view "$flag" --help)
+}
+
 without_timeout_utility() {
   command() {
     if [[ "${1:-}" == "-v" && "${2:-}" == "timeout" ]]; then
@@ -386,6 +395,19 @@ set -e
 assert_eq "$rc" "0" "pr-view accepts a help-shaped JSON field value" "$stderr"
 assert_contains "$(cat "$calls")" "pr view --json --help" \
   "pr-view keeps the JSON field value with its option"
+
+for flag in --template --jq --repo -t -q -R; do
+  calls="$TMP_ROOT/pr-view-help-value-${flag#-}.calls"
+  : >"$calls"
+  stderr="$TMP_ROOT/pr-view-help-value-${flag#-}.err"
+  set +e
+  output=$(run_pr_view_help_value "$calls" "$flag" 2>"$stderr")
+  rc=$?
+  set -e
+  assert_eq "$rc" "0" "pr-view accepts --help as the $flag value" "$stderr"
+  assert_contains "$(cat "$calls")" "pr view $flag --help" \
+    "pr-view forwards $flag with its help-shaped value"
+done
 
 echo
 echo "=== github.sh pr-view --format rejection ==="

--- a/skills/github/tests/pr-view.sh
+++ b/skills/github/tests/pr-view.sh
@@ -52,6 +52,10 @@ _auth_ok() {
   if [[ "$tok" == op://* ]]; then
     return 1
   fi
+  if [[ "${STUB_TOKEN_ONLY:-0}" == "1" ]]; then
+    [[ "$tok" == "ghs_VALIDBOT123" ]]
+    return
+  fi
   [[ "${STUB_AUTH_OK:-1}" == "1" ]]
 }
 
@@ -226,6 +230,16 @@ assert_eq "$rc" "124" "auth timeout works without the timeout utility" "$stderr"
 assert_eq "$(jq -r .status <<<"$output")" "auth_timeout" \
   "no-utility auth timeout emits structured status" "$stderr"
 
+stderr="$TMP_ROOT/auth-leading-zero.err"
+set +e
+output=$(without_timeout_utility run_pr_view \
+  KENDEX_GITHUB_AUTH_TIMEOUT=08 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "0" "auth timeout accepts a leading-zero decimal" "$stderr"
+assert_eq "$(jq -r .number <<<"$output")" "42" \
+  "leading-zero auth bound reaches gh" "$stderr"
+
 stderr="$TMP_ROOT/api-user-auth-timeout.err"
 set +e
 output=$(run_pr_view GH_TOKEN=ghs_VALIDBOT123 STUB_API_USER_SLEEP=1 KENDEX_GITHUB_AUTH_TIMEOUT=1 2>"$stderr")
@@ -260,6 +274,16 @@ assert_eq "$rc" "124" "gh pr view timeout works without the timeout utility" "$s
 assert_eq "$(jq -r .status <<<"$output")" "gh_timeout" \
   "no-utility gh timeout emits structured status" "$stderr"
 
+stderr="$TMP_ROOT/pr-view-leading-zero.err"
+set +e
+output=$(without_timeout_utility run_pr_view \
+  KENDEX_GITHUB_PR_VIEW_TIMEOUT=09 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "0" "gh timeout accepts a leading-zero decimal" "$stderr"
+assert_eq "$(jq -r .number <<<"$output")" "42" \
+  "leading-zero gh bound returns PR JSON" "$stderr"
+
 rm -f "$TMP_ROOT/op.calls"
 stderr="$TMP_ROOT/inherited-gh-token-op.err"
 set +e
@@ -283,6 +307,16 @@ assert_eq "$(wc -l <"$TMP_ROOT/op.calls")" "1" "inherited op GITHUB_TOKEN attemp
 cat > "$TMP_ROOT/repo/.env.local" <<'ENVEOF'
 GH_BOT_TOKEN=op://vault/item/field
 ENVEOF
+
+stderr="$TMP_ROOT/op-leading-zero.err"
+set +e
+output=$(without_timeout_utility run_pr_view \
+  STUB_TOKEN_ONLY=1 STUB_OP_MODE=ok KENDEX_GITHUB_OP_TIMEOUT=08 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "0" "op timeout accepts a leading-zero decimal" "$stderr"
+assert_eq "$(jq -r .number <<<"$output")" "42" \
+  "leading-zero op bound reaches gh" "$stderr"
 
 stderr="$TMP_ROOT/op-fail.err"
 set +e

--- a/skills/github/tests/pr-view.sh
+++ b/skills/github/tests/pr-view.sh
@@ -148,6 +148,15 @@ run_pr_view_format() {
        env -u GH_TOKEN -u GITHUB_TOKEN "$GITHUB_SH" -C "$TMP_ROOT/repo" pr-view 42 "--format=$fmt")
 }
 
+run_pr_view_passthrough() {
+  local calls_file="$1"
+  (cd "$TMP_ROOT/repo" \
+    && PATH="$TMP_ROOT/bin:$PATH" \
+       STUB_GH_CALLS="$calls_file" \
+       env -u GH_TOKEN -u GITHUB_TOKEN "$GITHUB_SH" -C "$TMP_ROOT/repo" \
+       pr-view 42 --web extra-position)
+}
+
 assert_not_contains() {
   local haystack="$1" needle="$2" name="$3"
   if grep -qF -- "$needle" <<<"$haystack"; then
@@ -251,6 +260,17 @@ rc=$?
 set -e
 assert_eq "$rc" "0" "successful pr-view exits 0" "$stderr"
 assert_eq "$(jq -r .number <<<"$output")" "42" "successful pr-view preserves gh JSON" "$stderr"
+
+calls="$TMP_ROOT/pr-view-passthrough.calls"
+: >"$calls"
+stderr="$TMP_ROOT/pr-view-passthrough.err"
+set +e
+output=$(run_pr_view_passthrough "$calls" 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "0" "pr-view accepts passthrough arguments" "$stderr"
+assert_contains "$(cat "$calls")" "pr view 42 --web extra-position" \
+  "pr-view forwards unknown flags and extra positionals"
 
 echo
 echo "=== github.sh pr-view --format rejection ==="

--- a/skills/github/tests/pr-view.sh
+++ b/skills/github/tests/pr-view.sh
@@ -157,6 +157,35 @@ run_pr_view_passthrough() {
        pr-view 42 --web extra-position)
 }
 
+run_pr_view_no_pr_passthrough() {
+  local calls_file="$1"
+  (cd "$TMP_ROOT/repo" \
+    && PATH="$TMP_ROOT/bin:$PATH" \
+       STUB_GH_CALLS="$calls_file" \
+       env -u GH_TOKEN -u GITHUB_TOKEN "$GITHUB_SH" -C "$TMP_ROOT/repo" \
+       pr-view --repo owner/repo --json number,state)
+}
+
+run_pr_view_json_help_value() {
+  local calls_file="$1"
+  (cd "$TMP_ROOT/repo" \
+    && PATH="$TMP_ROOT/bin:$PATH" \
+       STUB_GH_CALLS="$calls_file" \
+       env -u GH_TOKEN -u GITHUB_TOKEN "$GITHUB_SH" -C "$TMP_ROOT/repo" \
+       pr-view --json --help)
+}
+
+without_timeout_utility() {
+  command() {
+    if [[ "${1:-}" == "-v" && "${2:-}" == "timeout" ]]; then
+      return 1
+    fi
+    builtin command "$@"
+  }
+  export -f command
+  "$@"
+}
+
 assert_not_contains() {
   local haystack="$1" needle="$2" name="$3"
   if grep -qF -- "$needle" <<<"$haystack"; then
@@ -187,6 +216,16 @@ set -e
 assert_eq "$rc" "124" "auth preflight timeout exits 124" "$stderr"
 assert_eq "$(jq -r .status <<<"$output")" "auth_timeout" "auth timeout emits structured status" "$stderr"
 
+stderr="$TMP_ROOT/auth-timeout-no-utility.err"
+set +e
+output=$(without_timeout_utility run_pr_view \
+  STUB_AUTH_SLEEP=1 KENDEX_GITHUB_AUTH_TIMEOUT=1 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "124" "auth timeout works without the timeout utility" "$stderr"
+assert_eq "$(jq -r .status <<<"$output")" "auth_timeout" \
+  "no-utility auth timeout emits structured status" "$stderr"
+
 stderr="$TMP_ROOT/api-user-auth-timeout.err"
 set +e
 output=$(run_pr_view GH_TOKEN=ghs_VALIDBOT123 STUB_API_USER_SLEEP=1 KENDEX_GITHUB_AUTH_TIMEOUT=1 2>"$stderr")
@@ -210,6 +249,16 @@ rc=$?
 set -e
 assert_eq "$rc" "124" "gh pr view timeout exits 124" "$stderr"
 assert_eq "$(jq -r .status <<<"$output")" "gh_timeout" "gh timeout emits structured status" "$stderr"
+
+stderr="$TMP_ROOT/pr-view-timeout-no-utility.err"
+set +e
+output=$(without_timeout_utility run_pr_view \
+  STUB_PR_MODE=hang KENDEX_GITHUB_PR_VIEW_TIMEOUT=1 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "124" "gh pr view timeout works without the timeout utility" "$stderr"
+assert_eq "$(jq -r .status <<<"$output")" "gh_timeout" \
+  "no-utility gh timeout emits structured status" "$stderr"
 
 rm -f "$TMP_ROOT/op.calls"
 stderr="$TMP_ROOT/inherited-gh-token-op.err"
@@ -251,6 +300,16 @@ set -e
 assert_eq "$rc" "3" "token resolution timeout exits auth code" "$stderr"
 assert_eq "$(jq -r .status <<<"$output")" "token_resolution_timeout" "token timeout emits structured status" "$stderr"
 
+stderr="$TMP_ROOT/op-timeout-no-utility.err"
+set +e
+output=$(without_timeout_utility run_pr_view \
+  STUB_AUTH_OK=0 STUB_OP_MODE=slow KENDEX_GITHUB_OP_TIMEOUT=1 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "3" "op timeout works without the timeout utility" "$stderr"
+assert_eq "$(jq -r .status <<<"$output")" "token_resolution_timeout" \
+  "no-utility op timeout emits structured status" "$stderr"
+
 rm -f "$TMP_ROOT/repo/.env.local"
 
 stderr="$TMP_ROOT/success.err"
@@ -271,6 +330,28 @@ set -e
 assert_eq "$rc" "0" "pr-view accepts passthrough arguments" "$stderr"
 assert_contains "$(cat "$calls")" "pr view 42 --web extra-position" \
   "pr-view forwards unknown flags and extra positionals"
+
+calls="$TMP_ROOT/pr-view-no-pr-passthrough.calls"
+: >"$calls"
+stderr="$TMP_ROOT/pr-view-no-pr-passthrough.err"
+set +e
+output=$(run_pr_view_no_pr_passthrough "$calls" 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "0" "pr-view accepts option values without a PR number" "$stderr"
+assert_contains "$(cat "$calls")" "pr view --repo owner/repo --json number,state" \
+  "pr-view preserves no-PR option-value order"
+
+calls="$TMP_ROOT/pr-view-json-help-value.calls"
+: >"$calls"
+stderr="$TMP_ROOT/pr-view-json-help-value.err"
+set +e
+output=$(run_pr_view_json_help_value "$calls" 2>"$stderr")
+rc=$?
+set -e
+assert_eq "$rc" "0" "pr-view accepts a help-shaped JSON field value" "$stderr"
+assert_contains "$(cat "$calls")" "pr view --json --help" \
+  "pr-view keeps the JSON field value with its option"
 
 echo
 echo "=== github.sh pr-view --format rejection ==="

--- a/skills/github/tests/sticky-comment-cli.test.sh
+++ b/skills/github/tests/sticky-comment-cli.test.sh
@@ -94,6 +94,10 @@ echo "=== sticky-comment.sh CLI fallback ==="
 out=$("$STICKY" 123 --verdict)
 assert_eq "$out" "approved" "default fallback selects known claude[bot] review summary"
 
+out=$("$STICKY" 123 --legacy-extra ignored --verdict)
+assert_eq "$out" "approved" \
+    "legacy parser accepts unknown flags and ignores surplus positionals"
+
 assert_fails_with \
     "explicit --bot disables known-bot fallback" \
     "No sticky comment found" \

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -64,7 +64,7 @@ skills/decider/scripts/decisions	484
 skills/deep-research/scripts/deep-research	529
 skills/github/scripts/commands/pr-merge.sh	713
 skills/github/scripts/git-diff-summary	961
-skills/github/scripts/lib/gh-auth.sh	494
+skills/github/scripts/lib/gh-auth.sh	475
 skills/github/scripts/lib/github-api.sh	897
 skills/github/scripts/lib/verify-lib.sh	415
 skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh	2128


### PR DESCRIPTION
## Summary
- move merge outcome, token selection, authentication, and retry contracts into command help
- cut the canonical GitHub skill guide from 2,180 to 894 words
- add token-based ownership and word-limit controls while preserving existing behavior

## Completed Issues
- Closes KEN-562 - github SKILL.md round 2: merge-outcome and config contracts move to --help

## Test Plan
- GitHub help-contract suite: 26/26
- orch queue-wait suite: 2/2
- help mutation controls: 3/3, stable 10/10
- diff-scoped preflight, size ratchet, mirror parity, and `tools/guard`
