### PR TITLE
fix(KEN-848): a moved baseline is judged against the rows it moved

### DIFF
--- a/.agents/skills/size-ratchet/DEVELOPMENT.md
+++ b/.agents/skills/size-ratchet/DEVELOPMENT.md
@@ -206,17 +206,18 @@ a first `--seed`, a baseline this change introduces) has nothing to compare,
 so the raise gate alone is skipped — every other verdict still judges the
 snapshot and can fail it — and the verdict line says the added and raised
 checks did not run, because "no reference" must never read as "checked and
-clean". Which file HEAD's
-baseline WAS is asked before the rows in it, on every run. That file is the
-one HEAD's own settings named, resolved through the same chain over a scratch
-tree holding HEAD's view of every source that chain consults, so a commit that
-MOVES the baseline cannot land the raise an unjudged gate would have carried,
-and a stale row set sitting at the destination is not mistaken for HEAD's own.
-The script header lists what that tree must hold for each source kind, and a
-source it cannot reproduce refuses rather than reading as "HEAD has no rows",
-which is the state this exists to stop reaching without judgement. None of the
-three no-baseline cases can misfire on it, because each leaves HEAD naming
-either the path the run already read or one HEAD carries no rows at. A row whose
+clean". A commit that MOVES the
+baseline reaches that same emptiness without being one of the three, and every
+raise in it would land unjudged, so it is refused instead. The gate does not
+follow the move: where HEAD's baseline was is a question only HEAD's settings
+answer, and they resolve through a chain this script consults but does not
+own, so answering it means keeping a second implementation of that contract in
+step with it. The discriminator is what the change does to the old file, a path
+HEAD carried a row set at that the judged snapshot no longer carries, which
+none of the three bootstraps produces. A move whose rows arrive byte for byte
+as they left passes, because no row rose across it. The bound worth knowing is
+that a change pointing the setting elsewhere while leaving the old file tracked
+removes nothing, and is not a move the check can name. A row whose
 file is at or under its threshold is reported as stale instead, so one root
 cause reads as one verdict. A class that changes its UNIT does not escape:
 HEAD's row is re-expressed in the unit the class counts now, measured from

--- a/.agents/skills/size-ratchet/DEVELOPMENT.md
+++ b/.agents/skills/size-ratchet/DEVELOPMENT.md
@@ -206,7 +206,13 @@ a first `--seed`, a baseline this change introduces) has nothing to compare,
 so the raise gate alone is skipped — every other verdict still judges the
 snapshot and can fail it — and the verdict line says the added and raised
 checks did not run, because "no reference" must never read as "checked and
-clean". A row whose
+clean". A commit that MOVES the
+baseline is not such a HEAD: the rows are followed to the path HEAD's own
+settings named, resolved through the same chain with the versioned settings
+taken from HEAD, so a relocation cannot land the raise an unjudged gate would
+have carried. None of the three no-baseline cases can misfire on that lookup,
+because each leaves HEAD naming either the path the run already read or one
+HEAD carries no rows at. A row whose
 file is at or under its threshold is reported as stale instead, so one root
 cause reads as one verdict. A class that changes its UNIT does not escape:
 HEAD's row is re-expressed in the unit the class counts now, measured from

--- a/.agents/skills/size-ratchet/DEVELOPMENT.md
+++ b/.agents/skills/size-ratchet/DEVELOPMENT.md
@@ -206,16 +206,17 @@ a first `--seed`, a baseline this change introduces) has nothing to compare,
 so the raise gate alone is skipped — every other verdict still judges the
 snapshot and can fail it — and the verdict line says the added and raised
 checks did not run, because "no reference" must never read as "checked and
-clean". A commit that MOVES the
-baseline is not such a HEAD. The rows are followed to the path HEAD's own
-settings named, resolved through the same chain over a scratch tree holding
-HEAD's view of every source that chain consults, so a relocation cannot land
-the raise an unjudged gate would have carried. The script header lists what
-that tree must hold for each source kind, and a source it cannot reproduce
-refuses rather than reading as "HEAD has no rows", which is the state the
-lookup exists to stop reaching without judgement. None of the three
-no-baseline cases can misfire on it, because each leaves HEAD naming either
-the path the run already read or one HEAD carries no rows at. A row whose
+clean". Which file HEAD's
+baseline WAS is asked before the rows in it, on every run. That file is the
+one HEAD's own settings named, resolved through the same chain over a scratch
+tree holding HEAD's view of every source that chain consults, so a commit that
+MOVES the baseline cannot land the raise an unjudged gate would have carried,
+and a stale row set sitting at the destination is not mistaken for HEAD's own.
+The script header lists what that tree must hold for each source kind, and a
+source it cannot reproduce refuses rather than reading as "HEAD has no rows",
+which is the state this exists to stop reaching without judgement. None of the
+three no-baseline cases can misfire on it, because each leaves HEAD naming
+either the path the run already read or one HEAD carries no rows at. A row whose
 file is at or under its threshold is reported as stale instead, so one root
 cause reads as one verdict. A class that changes its UNIT does not escape:
 HEAD's row is re-expressed in the unit the class counts now, measured from

--- a/.agents/skills/size-ratchet/DEVELOPMENT.md
+++ b/.agents/skills/size-ratchet/DEVELOPMENT.md
@@ -207,12 +207,15 @@ so the raise gate alone is skipped — every other verdict still judges the
 snapshot and can fail it — and the verdict line says the added and raised
 checks did not run, because "no reference" must never read as "checked and
 clean". A commit that MOVES the
-baseline is not such a HEAD: the rows are followed to the path HEAD's own
-settings named, resolved through the same chain with the versioned settings
-taken from HEAD, so a relocation cannot land the raise an unjudged gate would
-have carried. None of the three no-baseline cases can misfire on that lookup,
-because each leaves HEAD naming either the path the run already read or one
-HEAD carries no rows at. A row whose
+baseline is not such a HEAD. The rows are followed to the path HEAD's own
+settings named, resolved through the same chain over a scratch tree holding
+HEAD's view of every source that chain consults, so a relocation cannot land
+the raise an unjudged gate would have carried. The script header lists what
+that tree must hold for each source kind, and a source it cannot reproduce
+refuses rather than reading as "HEAD has no rows", which is the state the
+lookup exists to stop reaching without judgement. None of the three
+no-baseline cases can misfire on it, because each leaves HEAD naming either
+the path the run already read or one HEAD carries no rows at. A row whose
 file is at or under its threshold is reported as stale instead, so one root
 cause reads as one verdict. A class that changes its UNIT does not escape:
 HEAD's row is re-expressed in the unit the class counts now, measured from

--- a/.agents/skills/size-ratchet/README.md
+++ b/.agents/skills/size-ratchet/README.md
@@ -73,6 +73,11 @@ raises is that threshold routed around.
 - **A first row** for a path HEAD's baseline carries none for is a
   **bootstrap**, not a raise, and the declaration admits it in every class,
   frozen included. A renamed path is such a path, so a rename bootstraps.
+- **A commit that moves the baseline** — a changed `SIZE_RATCHET_BASELINE` —
+  is judged against HEAD's rows at the path HEAD's own settings named, so a
+  relocation carries no row past this check. The versioned settings come from
+  HEAD; the environment, `.env.local` and `--baseline` belong to the
+  invocation, not the commit, and are read as they are.
 - A repo whose HEAD carries no baseline rows yet is bootstrapping, and the
   gate says so on its verdict line rather than reporting a clean raise check.
 

--- a/.agents/skills/size-ratchet/README.md
+++ b/.agents/skills/size-ratchet/README.md
@@ -73,12 +73,13 @@ raises is that threshold routed around.
 - **A first row** for a path HEAD's baseline carries none for is a
   **bootstrap**, not a raise, and the declaration admits it in every class,
   frozen included. A renamed path is such a path, so a rename bootstraps.
-- **A commit that moves the baseline** — a changed `SIZE_RATCHET_BASELINE` —
-  is judged against HEAD's rows at the path HEAD's own settings named, so a
-  relocation carries no row past this check. Every source that resolution
-  reads comes from HEAD when git tracks it and from the invocation when it
-  does not; one the lookup cannot reproduce is a loud refusal, never a silent
-  "no rows". `--baseline` is the operator's override and skips the lookup.
+- **HEAD's baseline is the file HEAD's own settings named**, asked before the
+  rows in it, so a changed `SIZE_RATCHET_BASELINE` carries no row past this
+  check and a stale row set at the new path is not read as HEAD's. Every
+  source that resolution reads comes from HEAD when git tracks it and from the
+  invocation when it does not; one the lookup cannot reproduce is a loud
+  refusal, never a silent "no rows". `--baseline` is the operator's override
+  and skips the lookup.
 - A repo whose HEAD carries no baseline rows yet is bootstrapping, and the
   gate says so on its verdict line rather than reporting a clean raise check.
 

--- a/.agents/skills/size-ratchet/README.md
+++ b/.agents/skills/size-ratchet/README.md
@@ -73,13 +73,12 @@ raises is that threshold routed around.
 - **A first row** for a path HEAD's baseline carries none for is a
   **bootstrap**, not a raise, and the declaration admits it in every class,
   frozen included. A renamed path is such a path, so a rename bootstraps.
-- **HEAD's baseline is the file HEAD's own settings named**, asked before the
-  rows in it, so a changed `SIZE_RATCHET_BASELINE` carries no row past this
-  check and a stale row set at the new path is not read as HEAD's. Every
-  source that resolution reads comes from HEAD when git tracks it and from the
-  invocation when it does not; one the lookup cannot reproduce is a loud
-  refusal, never a silent "no rows". `--baseline` is the operator's override
-  and skips the lookup.
+- **A commit that MOVES the baseline** — a changed `SIZE_RATCHET_BASELINE` —
+  leaves HEAD carrying nothing at the path the run reads, so a raise would land
+  with nothing to compare it against. It is refused unless the rows arriving at
+  the new path are byte for byte the rows that left the old one. Move the
+  baseline in a commit that changes nothing else, then change its rows in the
+  next one.
 - A repo whose HEAD carries no baseline rows yet is bootstrapping, and the
   gate says so on its verdict line rather than reporting a clean raise check.
 

--- a/.agents/skills/size-ratchet/README.md
+++ b/.agents/skills/size-ratchet/README.md
@@ -75,9 +75,10 @@ raises is that threshold routed around.
   frozen included. A renamed path is such a path, so a rename bootstraps.
 - **A commit that moves the baseline** — a changed `SIZE_RATCHET_BASELINE` —
   is judged against HEAD's rows at the path HEAD's own settings named, so a
-  relocation carries no row past this check. The versioned settings come from
-  HEAD; the environment, `.env.local` and `--baseline` belong to the
-  invocation, not the commit, and are read as they are.
+  relocation carries no row past this check. Every source that resolution
+  reads comes from HEAD when git tracks it and from the invocation when it
+  does not; one the lookup cannot reproduce is a loud refusal, never a silent
+  "no rows". `--baseline` is the operator's override and skips the lookup.
 - A repo whose HEAD carries no baseline rows yet is bootstrapping, and the
   gate says so on its verdict line rather than reporting a clean raise check.
 

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -1450,21 +1450,30 @@ read_head_baseline() {
 # implementation of someone else's contract in step with it. A move is refused
 # instead, and the rows travel in a commit that changes nothing else.
 #
-# The discriminator is what the change does to the OLD file: a path HEAD
-# carried a row set at, which the judged snapshot no longer carries. It cannot
-# misfire on the three bootstraps. An unborn HEAD has no paths to remove. A
-# baseline this change introduces leaves HEAD carrying no row set anywhere, so
-# there is none to remove. A placeholder committed empty is AT the configured
-# path and is filled rather than removed, and holds no rows to recognize even
-# if it were. What the check does see is one bound worth stating: a change that
-# points the setting elsewhere while leaving the old file tracked, rows and
-# all, removes nothing and is not a move it can name.
+# The discriminator is what the change does to the OLD file: HEAD's blob there
+# was a row set, and the judged snapshot's is not. That is stricter than "this
+# path changed" and it is what keeps an ordinary edit out — a row-shaped file
+# whose numbers move is still a row set, so it never reports. Only a file that
+# STOPPED being one does: deleted, emptied, or replaced with something that is
+# not rows.
+#
+# It cannot misfire on the three bootstraps. An unborn HEAD has no changed
+# paths at all. A baseline this change introduces leaves HEAD carrying no row
+# set anywhere, so no changed path has one to lose. A placeholder committed
+# empty holds no rows at HEAD to recognize, and is at the configured path,
+# which this scan skips. One bound is worth stating: a change that points the
+# setting elsewhere while leaving the old file tracked with its rows loses no
+# row set, and is not a move this can name.
+#
+# The scan runs whether or not HEAD carries rows at the configured path. Rows
+# there do not establish they were the baseline HEAD used — a destination that
+# already existed carries its own, and comparing against those is how a raise
+# reads as grandfathered while HEAD's real row said something else.
 #
 # A pure move passes. The rows that arrive are byte for byte the rows that
 # left, so no row rose across it; anything else about them is the next
 # commit's business.
 baseline_moved() { # CANDIDATE-BASELINE — violations on stdout
-  [ -z "$HEAD_BASELINE" ] || return 0
   local p head_status=0 diff_status=0
   git rev-parse --verify --quiet HEAD >/dev/null 2>&1 || head_status=$?
   case "$head_status" in
@@ -1479,16 +1488,20 @@ baseline_moved() { # CANDIDATE-BASELINE — violations on stdout
   # baseline would read as absent. It also terminates each path with a NUL,
   # which is the one byte a path cannot contain — a newline can, so the read
   # below splits on NUL rather than translating NULs into newlines.
+  # Every changed path, not only the deleted ones: emptying the old baseline in
+  # place, or writing something else over it, is the same move and reports as a
+  # modification. The predicate below is what keeps the wider list honest.
   if [ "$STAGED" -eq 1 ]; then
-    git diff --cached --no-renames -z --name-only --diff-filter=D HEAD >"$TMP/removed.paths" || diff_status=$?
+    git diff --cached --no-renames -z --name-only HEAD >"$TMP/removed.paths" || diff_status=$?
   else
-    git diff --no-renames -z --name-only --diff-filter=D HEAD >"$TMP/removed.paths" || diff_status=$?
+    git diff --no-renames -z --name-only HEAD >"$TMP/removed.paths" || diff_status=$?
   fi
-  [ "$diff_status" -eq 0 ] || collection_error "could not list what this change removes (git diff exit $diff_status) — refusing to treat a moved baseline as absent"
+  [ "$diff_status" -eq 0 ] || collection_error "could not list what this change touches (git diff exit $diff_status) — refusing to treat a moved baseline as absent"
   while IFS= read -r -d '' p || [ -n "$p" ]; do
     [ -n "$p" ] || continue
     [ "$p" != "$BASELINE_FILE" ] || continue
     head_rows_removed "$p" || continue
+    snapshot_rows_at "$p" && continue
     cmp -s -- "$TMP/removed.head" "$1" && continue
     # "-" placeholders, never empty fields: report() reads these rows with
     # tab-IFS, and whitespace IFS collapses consecutive tabs.
@@ -1496,21 +1509,39 @@ baseline_moved() { # CANDIDATE-BASELINE — violations on stdout
   done <"$TMP/removed.paths"
 }
 
-# Whether HEAD's blob at PATH was a baseline. The row shape is the only
-# question — sorting and duplicates are the governing copy's business, and a
-# file that fails them is still the row set this change carried away.
-head_rows_removed() { # PATH — 0 when HEAD held a row set there, at $TMP/removed.head
+# Whether FILE holds a row set. The row shape is the only question — sorting
+# and duplicates are the governing copy's business, and a file that fails them
+# is still the row set this change carried away.
+blob_is_row_set() { # FILE
   local status=0
+  [ "$(count_nonempty_lines "$1")" -gt 0 ] || return 1
+  grep -qEv -- "$BASELINE_ROW_RE" "$1" || status=$?
+  case "$status" in
+    0) return 1 ;; # a line that is not a row
+    1) return 0 ;;
+    *) collection_error "could not read $1 to tell whether it holds baseline rows (grep exit $status)" ;;
+  esac
+}
+
+head_rows_removed() { # PATH — 0 when HEAD held a row set there, at $TMP/removed.head
   read_head_file_mode "$1"
   case "$HEAD_FILE_MODE" in 100*) ;; *) return 1 ;; esac
   git show "HEAD:$1" >"$TMP/removed.head" || collection_error "could not read $1 from HEAD to tell whether it was the baseline this change moved"
-  [ "$(count_nonempty_lines "$TMP/removed.head")" -gt 0 ] || return 1
-  grep -qEv -- "$BASELINE_ROW_RE" "$TMP/removed.head" || status=$?
-  case "$status" in
-    0) return 1 ;; # a line that is not a row: whatever left, it was not a baseline
-    1) return 0 ;;
-    *) collection_error "could not read $1 from HEAD to tell whether it was the baseline this change moved (grep exit $status)" ;;
-  esac
+  blob_is_row_set "$TMP/removed.head"
+}
+
+# The judged snapshot's copy, from the same side the enumeration above read:
+# the index under --staged, the worktree otherwise.
+snapshot_rows_at() { # PATH — 0 when the snapshot still holds a row set there
+  if [ "$STAGED" -eq 1 ]; then
+    read_index_file_mode "$1"
+    case "$INDEX_FILE_MODE" in 100*) ;; *) return 1 ;; esac
+    git show ":$1" >"$TMP/removed.now" || collection_error "could not read the staged copy of $1 to tell whether it still holds baseline rows"
+  else
+    [ -f "$1" ] || return 1
+    cp -- "$1" "$TMP/removed.now" || collection_error "could not copy $1 to tell whether it still holds baseline rows"
+  fi
+  blob_is_row_set "$TMP/removed.now"
 }
 
 # A change that moves a class from lines to bytes (or back) leaves HEAD's rows

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -158,9 +158,10 @@ cannot see one, so the reason belongs in the commit body for review, not in
 a check.
 
 A commit that MOVES SIZE_RATCHET_BASELINE is judged against HEAD's rows at
-the path HEAD's own settings named: the versioned settings come from HEAD,
-the environment and .env.local from the invocation, and --baseline skips the
-lookup as the operator override it is.
+the path HEAD's own settings named. Every source that resolution reads comes
+from HEAD when git tracks it and from the invocation when it does not, and a
+source it cannot reproduce is a loud refusal rather than a silent "no rows".
+--baseline skips the lookup, being the operator's override and not a commit.
 
 A run whose HEAD carries no baseline rows has no reference for the added and
 raised checks, so the verdict line says so rather than reading as clean.
@@ -1437,57 +1438,141 @@ read_head_rows_at() { # PATH — fills HEAD_BASELINE, "" when HEAD carries none 
   HEAD_BASELINE="$TMP/baseline.head"
 }
 
-# Where HEAD's own configuration put the baseline. Resolved through the SAME
-# sr_setting chain this run used, with only the VERSIONED layer — the settings
-# TOML — taken from HEAD. The environment and .env.local are the invocation's,
-# not the commit's: they are identical on both sides by construction, so the
-# two resolutions differ exactly when the change under judgement moves the
-# path. --baseline is skipped outright for the same reason — a flag is the
-# operator pointing this run at a file, never a commit relocating anything.
+# --- where HEAD's own configuration put the baseline -------------------------
+# Resolved through the SAME sr_setting chain this run used, over a scratch tree
+# holding HEAD's view of every source that chain consults. The tree is the
+# whole answer: a source it does not reproduce faithfully makes the HEAD-side
+# resolution equal the run's own for a reason that is not HEAD's configuration,
+# and "HEAD has no rows" is then reached without judgement, which is the defect
+# itself. So each source kind is reproduced or the run refuses; nothing falls
+# through. What the tree must hold, by the route sr_setting reaches the source:
+#
+#   set in the environment      nothing. One process answers both sides.
+#   SIZE_RATCHET_SETTINGS_FILE=/dev/null
+#                               nothing. It selects no source at all.
+#   an absolute path            nothing. The same file answers both sides.
+#   a relative path that leaves the repository
+#                               the worktree file, at its own spelling. No
+#                               commit can carry it, so it is the invocation's.
+#   a path git tracks nowhere   the worktree file. Unversioned, so the
+#                               invocation's; a commit reaches this gate
+#                               through --staged, where an added source is in
+#                               the index and the branch below governs.
+#   tracked, absent at HEAD     nothing. This change ADDS the source.
+#   a regular file at HEAD      HEAD's blob.
+#   a symlink at HEAD           HEAD's blob at the end of the chain, resolved
+#                               through HEAD, staged at the link's spelling.
+#                               sr_setting reads bytes, so a regular file
+#                               there reads identically.
+#   anything else at HEAD       a refusal. A chain that leaves the repository,
+#                               loops, or ends on a directory or a gitlink is
+#                               not reproducible, and neither is an absolute
+#                               link target.
+#
+# --baseline is skipped outright: a flag is the operator pointing this run at a
+# file, never a commit relocating anything.
 HEAD_SETTINGS_BASELINE=""
-read_head_settings_baseline() { # — "" when it names no usable path
+
+# The sources sr_setting consults, in the order it consults them.
+SETTINGS_SOURCES=()
+settings_sources() {
+  SETTINGS_SOURCES=()
+  [ "${SIZE_RATCHET_SETTINGS_FILE:-}" != "/dev/null" ] || return 0
+  SETTINGS_SOURCES=(".env.local")
+  if [ -n "${SIZE_RATCHET_SETTINGS_FILE:-}" ]; then
+    SETTINGS_SOURCES+=("$SIZE_RATCHET_SETTINGS_FILE")
+  else
+    SETTINGS_SOURCES+=(".kendex/settings.toml" "kendex.settings.toml")
+  fi
+}
+
+index_tracks() { # PATH — 0 when the index carries it
+  local status=0
+  git ls-files --error-unmatch -- ":(literal)$1" >/dev/null 2>&1 || status=$?
+  case "$status" in
+    0) return 0 ;;
+    1) return 1 ;;
+    *) collection_error "could not query the index for $1 (git ls-files exit $status) — refusing to judge added and raised rows without knowing whether this change adds the source" ;;
+  esac
+}
+
+# Eight hops is past any real settings install and short of a loop's patience.
+HEAD_LINK_MAX=8
+stage_head_blob() { # PATH DEST — HEAD's file content at PATH, chain followed
+  local path="$1" dest="$2" hops=0 target dir
+  while :; do
+    read_head_file_mode "$path"
+    case "$HEAD_FILE_MODE" in
+      "") return 0 ;; # HEAD carries no such source
+      100*) break ;;
+      120000)
+        hops=$((hops + 1))
+        [ "$hops" -le "$HEAD_LINK_MAX" ] || collection_error "the settings source '$1' is a symlink chain longer than $HEAD_LINK_MAX hops at HEAD — refusing to judge added and raised rows against a configuration it cannot follow"
+        git show "HEAD:$path" >"$TMP/head.link" || collection_error "could not read the symlink '$path' from HEAD to follow the settings source it points at"
+        target="$(cat -- "$TMP/head.link")" || collection_error "could not read the target of the symlink '$path' at HEAD"
+        case "$target" in /*) collection_error "the settings source '$1' resolves through an absolute symlink at HEAD, which the scratch tree cannot reproduce — refusing to judge added and raised rows against a configuration it cannot read" ;; esac
+        dir="${path%/*}"
+        [ "$dir" != "$path" ] || dir=""
+        path="$(sr_settings_normalize_path "${dir:+$dir/}$target")"
+        case "$path" in
+          "" | ".." | "../"*) collection_error "the settings source '$1' resolves outside the repository at HEAD, which the scratch tree cannot reproduce — refusing to judge added and raised rows against a configuration it cannot read" ;;
+        esac
+        ;;
+      *) collection_error "the settings source '$1' is not a regular file at HEAD (mode $HEAD_FILE_MODE) — refusing to judge added and raised rows against a configuration it cannot read" ;;
+    esac
+  done
+  git show "HEAD:$path" >"$dest" || collection_error "could not read $path from HEAD to resolve the baseline path it configures"
+}
+
+read_head_settings_baseline() { # — "" when HEAD names no usable path
   HEAD_SETTINGS_BASELINE=""
   [ "$BASELINE_SET" -eq 0 ] || return 0
-  local dir="$TMP/head-settings" src norm parent
+  local dir="$TMP/head-settings" cwd src norm dest parent depth d
   rm -rf -- "$dir" || collection_error "could not clear the scratch copy of HEAD's settings"
-  mkdir -p -- "$dir" || collection_error "could not create a scratch copy of HEAD's settings"
-  if [ "${SIZE_RATCHET_SETTINGS_FILE:-}" = "/dev/null" ]; then
-    set --
-  elif [ -n "${SIZE_RATCHET_SETTINGS_FILE:-}" ]; then
-    set -- "$SIZE_RATCHET_SETTINGS_FILE"
-  else
-    set -- ".kendex/settings.toml" "kendex.settings.toml"
-  fi
-  for src in "$@"; do
-    # An absolute source lives outside the repository: HEAD carries no copy of
-    # it, and both resolutions read the one file that is there.
+  settings_sources
+  # A source spelled with a leading `..` still has to land inside the tree, so
+  # the resolution runs from a directory nested as deep as the deepest such
+  # spelling. Counting every `..` segment overshoots, which costs an unused
+  # directory and can never come up short.
+  depth=0
+  for src in ${SETTINGS_SOURCES+"${SETTINGS_SOURCES[@]}"}; do
+    d="$(printf '%s\n' "$src" | awk -F'/' '{ n = 0; for (i = 1; i <= NF; i++) if ($i == "..") n++; print n }')" \
+      || collection_error "could not measure the depth of the settings source '$src'"
+    [ "$d" -le "$depth" ] || depth="$d"
+  done
+  cwd="$dir"
+  while [ "$depth" -gt 0 ]; do
+    cwd="$cwd/nested"
+    depth=$((depth - 1))
+  done
+  mkdir -p -- "$cwd" || collection_error "could not create a scratch copy of HEAD's settings"
+  for src in ${SETTINGS_SOURCES+"${SETTINGS_SOURCES[@]}"}; do
     case "$src" in /*) continue ;; esac
-    # git reads a tree path canonically — `sub/../f` names `f` — so the probe
-    # and the read take the NORMALIZED spelling, while the copy is written
+    dest="$cwd/$src"
+    parent="$cwd/${src%/*}"
+    [ "${src%/*}" != "$src" ] || parent="$cwd"
+    mkdir -p -- "$parent" || collection_error "could not stage the directory for HEAD's copy of $src"
+    # git reads a tree path canonically — `sub/../f` names `f` — so every
+    # probe and read takes the NORMALIZED spelling, while the copy is written
     # under the spelling the resolver will look for.
     norm="$(sr_settings_normalize_path "$src")"
     case "$norm" in
       "" | ".." | "../"*)
-        # A relative source that leaves the repository is read from the
-        # worktree by both resolutions, but the scratch directory this one
-        # runs in cannot reach it — so HEAD names no path rather than a
-        # wrong one.
-        HEAD_SETTINGS_BASELINE=""
-        return 0
+        [ ! -f "$src" ] || cp -- "$src" "$dest" || collection_error "could not stage the out-of-repository settings source $src"
+        continue
         ;;
     esac
     read_head_file_mode "$norm"
-    case "$HEAD_FILE_MODE" in 100*) ;; *) continue ;; esac
-    parent="$dir/${src%/*}"
-    [ "${src%/*}" != "$src" ] || parent="$dir"
-    mkdir -p -- "$parent" || collection_error "could not stage the directory for HEAD's copy of $src"
-    git show "HEAD:$norm" >"$dir/$src" || collection_error "could not read $src from HEAD to resolve the baseline path it configures"
+    if [ -n "$HEAD_FILE_MODE" ]; then
+      stage_head_blob "$norm" "$dest"
+    elif ! index_tracks "$norm"; then
+      [ ! -f "$src" ] || cp -- "$src" "$dest" || collection_error "could not stage the untracked settings source $src"
+    fi
   done
-  [ ! -f .env.local ] || cp -- .env.local "$dir/.env.local" || collection_error "could not stage .env.local beside HEAD's settings"
   # sr_setting reads its sources relative to the working directory and returns
-  # nonzero (never exits) on an unreadable one, so the copies answer from
-  # $dir and a refusal propagates instead of resolving to a default.
-  HEAD_SETTINGS_BASELINE="$(cd "$dir" && SR_SETTINGS_FROM_INDEX=0 sr_setting SIZE_RATCHET_BASELINE "tools/size-ratchet-baseline.tsv")" \
+  # nonzero (never exits) on an unreadable one, so the tree answers from $cwd
+  # and a refusal propagates instead of resolving to a default.
+  HEAD_SETTINGS_BASELINE="$(cd "$cwd" && SR_SETTINGS_FROM_INDEX=0 sr_setting SIZE_RATCHET_BASELINE "tools/size-ratchet-baseline.tsv")" \
     || collection_error "could not resolve SIZE_RATCHET_BASELINE from HEAD's settings — refusing to judge added and raised rows without knowing where HEAD's baseline was"
   HEAD_SETTINGS_BASELINE="$(normalize_rel_path "$HEAD_SETTINGS_BASELINE")" || HEAD_SETTINGS_BASELINE=""
   # A shape the configured path itself would be refused for names no row set

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -18,10 +18,10 @@
 #       run carries when the path is in a frozen class. A FIRST row for a
 #       path HEAD's baseline carries none for is a bootstrap, which
 #       RATCHET_RAISE=1 admits in every class, frozen included; a renamed
-#       path is such a path, so a rename bootstraps rather than raises.
-#       A change that MOVES the baseline itself is judged against the rows
-#       at the path HEAD's own settings named, so a relocation carries no
-#       row past this check.
+#       path is such a path, so a rename bootstraps rather than raises;
+#   (f) a change that MOVES the baseline and rewrites it in the same commit.
+#       Across a move nothing compares the rows, so the move travels alone
+#       and the rows change in the commit after it.
 #
 # --update: rewrite the baseline TIGHTENING ONLY — lower rows to current
 # reality, re-measure rows whose unit no longer matches their class, remove
@@ -157,11 +157,11 @@ bootstraps rather than raises. No commit message is read: a pre-commit hook
 cannot see one, so the reason belongs in the commit body for review, not in
 a check.
 
-A commit that MOVES SIZE_RATCHET_BASELINE is judged against HEAD's rows at
-the path HEAD's own settings named. Every source that resolution reads comes
-from HEAD when git tracks it and from the invocation when it does not, and a
-source it cannot reproduce is a loud refusal rather than a silent "no rows".
---baseline skips the lookup, being the operator's override and not a commit.
+A commit that MOVES SIZE_RATCHET_BASELINE leaves HEAD carrying nothing at the
+path this run reads, so the added and raised checks have no reference and a
+raise would land unjudged. Such a commit is refused unless the rows arriving
+at the new path are byte for byte the rows that left the old one: the move
+travels alone, and the rows change in the commit after it.
 
 A run whose HEAD carries no baseline rows has no reference for the added and
 raised checks, so the verdict line says so rather than reading as clean.
@@ -683,9 +683,12 @@ format_row() { # SIZE UNIT — the baseline row's number
 # returns nonzero and leaves the caller to skip the rewrite. SUGGEST names the
 # file a fix command would operate on, and is empty for a copy the caller has
 # no path to hand back.
+# What a baseline row looks like, in one place: this validator and the moved
+# baseline check below both ask the question and must not answer it apart.
+BASELINE_ROW_RE="^[^${TAB}]+${TAB}[1-9][0-9]*b?\$"
 validate_baseline_rows() { # MODE FILE LABEL [SUGGEST]
   local mode="$1" file="$2" label="$3" suggest="${4:-}" grep_status=0 bad_rows dup_paths hint="" fault=""
-  bad_rows="$(grep -nEv -- "^[^${TAB}]+${TAB}[1-9][0-9]*b?\$" "$file")" || grep_status=$?
+  bad_rows="$(grep -nEv -- "$BASELINE_ROW_RE" "$file")" || grep_status=$?
   [ "$grep_status" -le 1 ] || collection_error "could not validate $label (grep exit $grep_status)"
   [ -z "$suggest" ] || hint=" (LC_ALL=C sort -o $suggest $suggest)"
   # One fault decided in one place, so a soft caller cannot inherit an arm
@@ -1027,6 +1030,10 @@ report() { # VIOLATIONS-FILE — human diagnostics on stdout
       FROZEN)
         echo "size-ratchet FAIL frozen baseline row raised: $path — row $b -> $n $unit, threshold $PT ($why); a frozen class refuses a raise whatever RATCHET_RAISE says"
         echo "  remedy: split at a concept seam (a frozen class never raises an existing row)"
+        ;;
+      MOVED)
+        echo "size-ratchet FAIL baseline moved and rewritten: $path -> $BASELINE_FILE — HEAD's rows left $path, and the rows arriving at $BASELINE_FILE are not them; across a move nothing compares them, so a raise would land unjudged"
+        echo "  remedy: move the baseline in a commit that changes nothing else, then change its rows in the next one"
         ;;
     esac
   done <"$1"
@@ -1419,200 +1426,86 @@ RAISE_OK="${RATCHET_RAISE:-}"
 # and against a zero-row HEAD every one of them would read as newly added. A
 # git failure is never "absent": read_head_file_mode refuses on one.
 HEAD_BASELINE=""
-# The path those rows came from when it is not the configured one: a change
-# that RELOCATES the baseline is judged against the rows it moved.
-HEAD_BASELINE_FROM=""
-
-# Never `$(...)`: collection_error inside a command substitution exits the
-# subshell alone, and the caller would read the refusal as "HEAD has no rows".
-read_head_rows_at() { # PATH — fills HEAD_BASELINE, "" when HEAD carries none there
+read_head_baseline() {
   HEAD_BASELINE=""
-  read_head_file_mode "$1"
+  read_head_file_mode "$BASELINE_FILE"
   [ -n "$HEAD_FILE_MODE" ] || return 0
   case "$HEAD_FILE_MODE" in
     100*) ;;
     *) return 0 ;; # not a regular file at HEAD; there is no row set to compare
   esac
-  git show "HEAD:$1" >"$TMP/baseline.head" || collection_error "could not read $1 from HEAD — refusing to judge added and raised rows against a baseline it could not read"
+  git show "HEAD:$BASELINE_FILE" >"$TMP/baseline.head" || collection_error "could not read $BASELINE_FILE from HEAD — refusing to judge added and raised rows against a baseline it could not read"
   [ "$(count_nonempty_lines "$TMP/baseline.head")" -gt 0 ] || return 0
   HEAD_BASELINE="$TMP/baseline.head"
 }
 
-# --- where HEAD's own configuration put the baseline -------------------------
-# Resolved through the SAME sr_setting chain this run used, over a scratch tree
-# holding HEAD's view of every source that chain consults, and resolved on
-# EVERY run, because which file HEAD's baseline was is the first question and
-# the rows in it the second. The tree is the whole answer: a source it does not
-# reproduce faithfully makes the HEAD-side resolution equal the run's own for a
-# reason that is not HEAD's configuration, and "HEAD has no rows" is then
-# reached without judgement, which is the defect itself. So each source kind is
-# reproduced or the run refuses; nothing falls through. What the tree must
-# hold, by the route sr_setting reaches the source:
+# --- a baseline that MOVED ---------------------------------------------------
+# The check above reads HEAD at the CONFIGURED path. Move that path and HEAD
+# carries nothing there, so the rows have no reference and every raise the
+# change makes — a frozen one included — lands unjudged.
 #
-#   set in the environment      nothing. One process answers both sides.
-#   SIZE_RATCHET_SETTINGS_FILE=/dev/null
-#                               nothing. It selects no source at all.
-#   an absolute path            nothing. The same file answers both sides.
-#   a relative path that leaves the repository
-#                               the worktree file, at its own spelling. No
-#                               commit can carry it, so it is the invocation's.
-#   a path git tracks nowhere   the worktree file. Unversioned, so the
-#                               invocation's; a commit reaches this gate
-#                               through --staged, where an added source is in
-#                               the index and the branch below governs.
-#   tracked, absent at HEAD     nothing. This change ADDS the source.
-#   a regular file at HEAD      HEAD's blob.
-#   a symlink at HEAD           HEAD's blob at the end of the chain, resolved
-#                               through HEAD, staged at the link's spelling.
-#                               sr_setting reads bytes, so a regular file
-#                               there reads identically. A chain leaving the
-#                               repository ends on an unversioned file and
-#                               takes the out-of-repository row above.
-#   anything else at HEAD       a refusal. A chain longer than HEAD_LINK_MAX,
-#                               or one ending on a directory or a gitlink, is
-#                               a configuration no tree can stand in for.
+# The gate does not follow the move. Where HEAD's baseline was is a question
+# only HEAD's settings answer, and those resolve through a chain this script
+# consults but does not own, so answering it here means keeping a second
+# implementation of someone else's contract in step with it. A move is refused
+# instead, and the rows travel in a commit that changes nothing else.
 #
-# --baseline is skipped outright: a flag is the operator pointing this run at a
-# file, never a commit relocating anything.
-HEAD_SETTINGS_BASELINE=""
-
-# The sources sr_setting consults, in the order it consults them.
-SETTINGS_SOURCES=()
-settings_sources() {
-  SETTINGS_SOURCES=()
-  [ "${SIZE_RATCHET_SETTINGS_FILE:-}" != "/dev/null" ] || return 0
-  SETTINGS_SOURCES=(".env.local")
-  if [ -n "${SIZE_RATCHET_SETTINGS_FILE:-}" ]; then
-    SETTINGS_SOURCES+=("$SIZE_RATCHET_SETTINGS_FILE")
-  else
-    SETTINGS_SOURCES+=(".kendex/settings.toml" "kendex.settings.toml")
-  fi
-}
-
-index_tracks() { # PATH — 0 when the index carries it
-  local status=0
-  git ls-files --error-unmatch -- ":(literal)$1" >/dev/null 2>&1 || status=$?
-  case "$status" in
-    0) return 0 ;;
-    1) return 1 ;;
-    *) collection_error "could not query the index for $1 (git ls-files exit $status) — refusing to judge added and raised rows without knowing whether this change adds the source" ;;
+# The discriminator is what the change does to the OLD file: a path HEAD
+# carried a row set at, which the judged snapshot no longer carries. It cannot
+# misfire on the three bootstraps. An unborn HEAD has no paths to remove. A
+# baseline this change introduces leaves HEAD carrying no row set anywhere, so
+# there is none to remove. A placeholder committed empty is AT the configured
+# path and is filled rather than removed, and holds no rows to recognize even
+# if it were. What the check does see is one bound worth stating: a change that
+# points the setting elsewhere while leaving the old file tracked, rows and
+# all, removes nothing and is not a move it can name.
+#
+# A pure move passes. The rows that arrive are byte for byte the rows that
+# left, so no row rose across it; anything else about them is the next
+# commit's business.
+baseline_moved() { # CANDIDATE-BASELINE — violations on stdout
+  [ -z "$HEAD_BASELINE" ] || return 0
+  local p head_status=0 diff_status=0
+  git rev-parse --verify --quiet HEAD >/dev/null 2>&1 || head_status=$?
+  case "$head_status" in
+    0) ;;
+    1) return 0 ;; # an unborn HEAD removed nothing
+    *) collection_error "could not resolve HEAD while looking for a moved baseline (git rev-parse exit $head_status) — refusing to treat the move as absent" ;;
   esac
-}
-
-# Eight hops is past any real settings install and short of a loop's patience.
-HEAD_LINK_MAX=8
-stage_head_blob() { # PATH DEST — HEAD's file content at PATH, chain followed
-  local path="$1" dest="$2" hops=0 target dir
-  while :; do
-    read_head_file_mode "$path"
-    case "$HEAD_FILE_MODE" in
-      "") return 0 ;; # HEAD carries no such source
-      100*) break ;;
-      120000)
-        hops=$((hops + 1))
-        [ "$hops" -le "$HEAD_LINK_MAX" ] || collection_error "the settings source '$1' is a symlink chain longer than $HEAD_LINK_MAX hops at HEAD — refusing to judge added and raised rows against a configuration it cannot follow"
-        git show "HEAD:$path" >"$TMP/head.link" || collection_error "could not read the symlink '$path' from HEAD to follow the settings source it points at"
-        target="$(cat -- "$TMP/head.link")" || collection_error "could not read the target of the symlink '$path' at HEAD"
-        # A chain that leaves the repository ends on an unversioned file, which
-        # both sides read the same way, so it is copied from where it is rather
-        # than refused. The link is resolved from the repository root, which is
-        # this run's working directory.
-        case "$target" in
-          /*)
-            [ ! -f "$target" ] || cp -- "$target" "$dest" || collection_error "could not stage the out-of-repository file '$target' that the settings source '$1' points at"
-            return 0
-            ;;
-        esac
-        dir="${path%/*}"
-        [ "$dir" != "$path" ] || dir=""
-        path="$(sr_settings_normalize_path "${dir:+$dir/}$target")"
-        case "$path" in
-          "" | ".." | "../"*)
-            [ ! -f "$path" ] || cp -- "$path" "$dest" || collection_error "could not stage the out-of-repository file '$path' that the settings source '$1' points at"
-            return 0
-            ;;
-        esac
-        ;;
-      *) collection_error "the settings source '$1' is not a regular file at HEAD (mode $HEAD_FILE_MODE) — refusing to judge added and raised rows against a configuration it cannot read" ;;
-    esac
-  done
-  git show "HEAD:$path" >"$dest" || collection_error "could not read $path from HEAD to resolve the baseline path it configures"
-}
-
-read_head_settings_baseline() { # — "" when HEAD names no usable path
-  HEAD_SETTINGS_BASELINE=""
-  [ "$BASELINE_SET" -eq 0 ] || return 0
-  local dir="$TMP/head-settings" cwd src norm dest parent depth d
-  rm -rf -- "$dir" || collection_error "could not clear the scratch copy of HEAD's settings"
-  settings_sources
-  # A source spelled with a leading `..` still has to land inside the tree, so
-  # the resolution runs from a directory nested as deep as the deepest such
-  # spelling. Counting every `..` segment overshoots, which costs an unused
-  # directory and can never come up short.
-  depth=0
-  for src in ${SETTINGS_SOURCES+"${SETTINGS_SOURCES[@]}"}; do
-    d="$(printf '%s\n' "$src" | awk -F'/' '{ n = 0; for (i = 1; i <= NF; i++) if ($i == "..") n++; print n }')" \
-      || collection_error "could not measure the depth of the settings source '$src'"
-    [ "$d" -le "$depth" ] || depth="$d"
-  done
-  cwd="$dir"
-  while [ "$depth" -gt 0 ]; do
-    cwd="$cwd/nested"
-    depth=$((depth - 1))
-  done
-  mkdir -p -- "$cwd" || collection_error "could not create a scratch copy of HEAD's settings"
-  for src in ${SETTINGS_SOURCES+"${SETTINGS_SOURCES[@]}"}; do
-    case "$src" in /*) continue ;; esac
-    dest="$cwd/$src"
-    parent="$cwd/${src%/*}"
-    [ "${src%/*}" != "$src" ] || parent="$cwd"
-    mkdir -p -- "$parent" || collection_error "could not stage the directory for HEAD's copy of $src"
-    # git reads a tree path canonically — `sub/../f` names `f` — so every
-    # probe and read takes the NORMALIZED spelling, while the copy is written
-    # under the spelling the resolver will look for.
-    norm="$(sr_settings_normalize_path "$src")"
-    case "$norm" in
-      "" | ".." | "../"*)
-        [ ! -f "$src" ] || cp -- "$src" "$dest" || collection_error "could not stage the out-of-repository settings source $src"
-        continue
-        ;;
-    esac
-    read_head_file_mode "$norm"
-    if [ -n "$HEAD_FILE_MODE" ]; then
-      stage_head_blob "$norm" "$dest"
-    elif ! index_tracks "$norm"; then
-      [ ! -f "$src" ] || cp -- "$src" "$dest" || collection_error "could not stage the untracked settings source $src"
-    fi
-  done
-  # sr_setting reads its sources relative to the working directory and returns
-  # nonzero (never exits) on an unreadable one, so the tree answers from $cwd
-  # and a refusal propagates instead of resolving to a default.
-  HEAD_SETTINGS_BASELINE="$(cd "$cwd" && SR_SETTINGS_FROM_INDEX=0 sr_setting SIZE_RATCHET_BASELINE "tools/size-ratchet-baseline.tsv")" \
-    || collection_error "could not resolve SIZE_RATCHET_BASELINE from HEAD's settings — refusing to judge added and raised rows without knowing where HEAD's baseline was"
-  HEAD_SETTINGS_BASELINE="$(normalize_rel_path "$HEAD_SETTINGS_BASELINE")" || HEAD_SETTINGS_BASELINE=""
-  # A shape the configured path itself would be refused for names no row set
-  # to read; the run's own resolution already rejected it for this side.
-  case "$HEAD_SETTINGS_BASELINE" in /* | -*) HEAD_SETTINGS_BASELINE="" ;; esac
-}
-
-# WHICH PATH first, then the rows at it. Reading the configured path and
-# keeping whatever rows it holds accepts a file HEAD's own configuration never
-# read: a repository carrying a stale b.tsv at 20 while its settings named
-# a.tsv at 15 had the 20 taken for grandfathered, and the raise to 20 was never
-# judged. HEAD's effective baseline is the file HEAD's settings pointed at, and
-# no rows there is HEAD having no reference — not a reason to read another
-# file. The three bootstraps are unaffected: each leaves HEAD naming the path
-# this run resolved, or one HEAD carries no rows at.
-read_head_baseline() {
-  HEAD_BASELINE_FROM=""
-  local path="$BASELINE_FILE"
-  read_head_settings_baseline
-  if [ -n "$HEAD_SETTINGS_BASELINE" ] && [ "$HEAD_SETTINGS_BASELINE" != "$BASELINE_FILE" ]; then
-    path="$HEAD_SETTINGS_BASELINE"
-    HEAD_BASELINE_FROM="$path"
+  # --no-renames, because a `git mv` of the baseline is exactly the move this
+  # looks for and rename detection would report it as one path, not a removal.
+  if [ "$STAGED" -eq 1 ]; then
+    git diff --cached --no-renames --name-only --diff-filter=D HEAD >"$TMP/removed.tsv" || diff_status=$?
+  else
+    git diff --no-renames --name-only --diff-filter=D HEAD >"$TMP/removed.tsv" || diff_status=$?
   fi
-  read_head_rows_at "$path"
-  [ -n "$HEAD_BASELINE" ] || HEAD_BASELINE_FROM=""
+  [ "$diff_status" -eq 0 ] || collection_error "could not list what this change removes (git diff exit $diff_status) — refusing to treat a moved baseline as absent"
+  while IFS= read -r p || [ -n "$p" ]; do
+    [ -n "$p" ] || continue
+    [ "$p" != "$BASELINE_FILE" ] || continue
+    head_rows_removed "$p" || continue
+    cmp -s -- "$TMP/removed.head" "$1" && continue
+    # "-" placeholders, never empty fields: report() reads these rows with
+    # tab-IFS, and whitespace IFS collapses consecutive tabs.
+    printf '%s\t%s\t%s\t%s\n' "MOVED" "$p" "-" "-"
+  done <"$TMP/removed.tsv"
+}
+
+# Whether HEAD's blob at PATH was a baseline. The row shape is the only
+# question — sorting and duplicates are the governing copy's business, and a
+# file that fails them is still the row set this change carried away.
+head_rows_removed() { # PATH — 0 when HEAD held a row set there, at $TMP/removed.head
+  local status=0
+  read_head_file_mode "$1"
+  case "$HEAD_FILE_MODE" in 100*) ;; *) return 1 ;; esac
+  git show "HEAD:$1" >"$TMP/removed.head" || collection_error "could not read $1 from HEAD to tell whether it was the baseline this change moved"
+  [ "$(count_nonempty_lines "$TMP/removed.head")" -gt 0 ] || return 1
+  grep -qEv -- "$BASELINE_ROW_RE" "$TMP/removed.head" || status=$?
+  case "$status" in
+    0) return 1 ;; # a line that is not a row: whatever left, it was not a baseline
+    1) return 0 ;;
+    *) collection_error "could not read $1 from HEAD to tell whether it was the baseline this change moved (grep exit $status)" ;;
+  esac
 }
 
 # A change that moves a class from lines to bytes (or back) leaves HEAD's rows
@@ -1695,6 +1588,7 @@ rows_raised() { # CURRENT-BASELINE — violations on stdout
 run_verdict() { # BASELINE-TSV — fills $TMP/violations.tsv, sets VIOLATIONS
   evaluate "$1" >"$TMP/violations.tsv" || collection_error "could not evaluate the baseline against the collected counts"
   rows_raised "$1" >>"$TMP/violations.tsv" || collection_error "could not judge the baseline rows against HEAD's baseline"
+  baseline_moved "$1" >>"$TMP/violations.tsv" || collection_error "could not tell whether this change moves the baseline"
   VIOLATIONS="$(count_nonempty_lines "$TMP/violations.tsv")"
 }
 
@@ -1771,11 +1665,7 @@ report "$TMP/violations.tsv" || collection_error "could not read the violations 
 # "no reference" is not "checked and clean": a run whose HEAD carries no rows
 # never judged an added or raised one, and says which of the two it is.
 RAISE_NOTE=""
-if [ -z "$HEAD_BASELINE" ]; then
-  RAISE_NOTE=" — HEAD carries no baseline rows, so added and raised rows were not judged"
-elif [ -n "$HEAD_BASELINE_FROM" ]; then
-  RAISE_NOTE=" — added and raised rows judged against HEAD's baseline at $HEAD_BASELINE_FROM, which this change relocates"
-fi
+[ -n "$HEAD_BASELINE" ] || RAISE_NOTE=" — HEAD carries no baseline rows, so added and raised rows were not judged"
 if [ "$VIOLATIONS" -gt 0 ]; then
   echo "size-ratchet: $VIOLATIONS violation(s) — threshold $THRESHOLD$CLASSES_NOTE, baseline $BASELINE_FILE$RAISE_NOTE"
   exit 1

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -1538,6 +1538,11 @@ snapshot_rows_at() { # PATH — 0 when the snapshot still holds a row set there
     case "$INDEX_FILE_MODE" in 100*) ;; *) return 1 ;; esac
     git show ":$1" >"$TMP/removed.now" || collection_error "could not read the staged copy of $1 to tell whether it still holds baseline rows"
   else
+    # -L before -f, which follows. A symlink is not the row set that was
+    # there, whatever it points at — and pointing it at the NEW baseline is
+    # exactly how a move made the old path look untouched. The index side
+    # never had this: it reads mode 120000 and answers no already.
+    [ ! -L "$1" ] || return 1
     [ -f "$1" ] || return 1
     cp -- "$1" "$TMP/removed.now" || collection_error "could not copy $1 to tell whether it still holds baseline rows"
   fi

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -1440,12 +1440,14 @@ read_head_rows_at() { # PATH — fills HEAD_BASELINE, "" when HEAD carries none 
 
 # --- where HEAD's own configuration put the baseline -------------------------
 # Resolved through the SAME sr_setting chain this run used, over a scratch tree
-# holding HEAD's view of every source that chain consults. The tree is the
-# whole answer: a source it does not reproduce faithfully makes the HEAD-side
-# resolution equal the run's own for a reason that is not HEAD's configuration,
-# and "HEAD has no rows" is then reached without judgement, which is the defect
-# itself. So each source kind is reproduced or the run refuses; nothing falls
-# through. What the tree must hold, by the route sr_setting reaches the source:
+# holding HEAD's view of every source that chain consults, and resolved on
+# EVERY run, because which file HEAD's baseline was is the first question and
+# the rows in it the second. The tree is the whole answer: a source it does not
+# reproduce faithfully makes the HEAD-side resolution equal the run's own for a
+# reason that is not HEAD's configuration, and "HEAD has no rows" is then
+# reached without judgement, which is the defect itself. So each source kind is
+# reproduced or the run refuses; nothing falls through. What the tree must
+# hold, by the route sr_setting reaches the source:
 #
 #   set in the environment      nothing. One process answers both sides.
 #   SIZE_RATCHET_SETTINGS_FILE=/dev/null
@@ -1463,11 +1465,12 @@ read_head_rows_at() { # PATH — fills HEAD_BASELINE, "" when HEAD carries none 
 #   a symlink at HEAD           HEAD's blob at the end of the chain, resolved
 #                               through HEAD, staged at the link's spelling.
 #                               sr_setting reads bytes, so a regular file
-#                               there reads identically.
-#   anything else at HEAD       a refusal. A chain that leaves the repository,
-#                               loops, or ends on a directory or a gitlink is
-#                               not reproducible, and neither is an absolute
-#                               link target.
+#                               there reads identically. A chain leaving the
+#                               repository ends on an unversioned file and
+#                               takes the out-of-repository row above.
+#   anything else at HEAD       a refusal. A chain longer than HEAD_LINK_MAX,
+#                               or one ending on a directory or a gitlink, is
+#                               a configuration no tree can stand in for.
 #
 # --baseline is skipped outright: a flag is the operator pointing this run at a
 # file, never a commit relocating anything.
@@ -1510,12 +1513,24 @@ stage_head_blob() { # PATH DEST — HEAD's file content at PATH, chain followed
         [ "$hops" -le "$HEAD_LINK_MAX" ] || collection_error "the settings source '$1' is a symlink chain longer than $HEAD_LINK_MAX hops at HEAD — refusing to judge added and raised rows against a configuration it cannot follow"
         git show "HEAD:$path" >"$TMP/head.link" || collection_error "could not read the symlink '$path' from HEAD to follow the settings source it points at"
         target="$(cat -- "$TMP/head.link")" || collection_error "could not read the target of the symlink '$path' at HEAD"
-        case "$target" in /*) collection_error "the settings source '$1' resolves through an absolute symlink at HEAD, which the scratch tree cannot reproduce — refusing to judge added and raised rows against a configuration it cannot read" ;; esac
+        # A chain that leaves the repository ends on an unversioned file, which
+        # both sides read the same way, so it is copied from where it is rather
+        # than refused. The link is resolved from the repository root, which is
+        # this run's working directory.
+        case "$target" in
+          /*)
+            [ ! -f "$target" ] || cp -- "$target" "$dest" || collection_error "could not stage the out-of-repository file '$target' that the settings source '$1' points at"
+            return 0
+            ;;
+        esac
         dir="${path%/*}"
         [ "$dir" != "$path" ] || dir=""
         path="$(sr_settings_normalize_path "${dir:+$dir/}$target")"
         case "$path" in
-          "" | ".." | "../"*) collection_error "the settings source '$1' resolves outside the repository at HEAD, which the scratch tree cannot reproduce — refusing to judge added and raised rows against a configuration it cannot read" ;;
+          "" | ".." | "../"*)
+            [ ! -f "$path" ] || cp -- "$path" "$dest" || collection_error "could not stage the out-of-repository file '$path' that the settings source '$1' points at"
+            return 0
+            ;;
         esac
         ;;
       *) collection_error "the settings source '$1' is not a regular file at HEAD (mode $HEAD_FILE_MODE) — refusing to judge added and raised rows against a configuration it cannot read" ;;
@@ -1580,23 +1595,24 @@ read_head_settings_baseline() { # — "" when HEAD names no usable path
   case "$HEAD_SETTINGS_BASELINE" in /* | -*) HEAD_SETTINGS_BASELINE="" ;; esac
 }
 
+# WHICH PATH first, then the rows at it. Reading the configured path and
+# keeping whatever rows it holds accepts a file HEAD's own configuration never
+# read: a repository carrying a stale b.tsv at 20 while its settings named
+# a.tsv at 15 had the 20 taken for grandfathered, and the raise to 20 was never
+# judged. HEAD's effective baseline is the file HEAD's settings pointed at, and
+# no rows there is HEAD having no reference — not a reason to read another
+# file. The three bootstraps are unaffected: each leaves HEAD naming the path
+# this run resolved, or one HEAD carries no rows at.
 read_head_baseline() {
   HEAD_BASELINE_FROM=""
-  read_head_rows_at "$BASELINE_FILE"
-  [ -z "$HEAD_BASELINE" ] || return 0
-  # No rows at the configured path is either of two things, and they must not
-  # be answered alike: HEAD had no row set anywhere (the three bootstraps),
-  # or this change MOVES the path and HEAD's rows sit at the old one, where
-  # skipping the judgment would carry a raise — a frozen one included — past
-  # a gate that never ran. HEAD's own settings say which, and they cannot
-  # misfire on a bootstrap: each of the three leaves HEAD naming the same
-  # path this run resolved, or a path HEAD carries no rows at, so the rows
-  # stay empty and the verdict says so exactly as before.
+  local path="$BASELINE_FILE"
   read_head_settings_baseline
-  [ -n "$HEAD_SETTINGS_BASELINE" ] || return 0
-  [ "$HEAD_SETTINGS_BASELINE" != "$BASELINE_FILE" ] || return 0
-  read_head_rows_at "$HEAD_SETTINGS_BASELINE"
-  [ -z "$HEAD_BASELINE" ] || HEAD_BASELINE_FROM="$HEAD_SETTINGS_BASELINE"
+  if [ -n "$HEAD_SETTINGS_BASELINE" ] && [ "$HEAD_SETTINGS_BASELINE" != "$BASELINE_FILE" ]; then
+    path="$HEAD_SETTINGS_BASELINE"
+    HEAD_BASELINE_FROM="$path"
+  fi
+  read_head_rows_at "$path"
+  [ -n "$HEAD_BASELINE" ] || HEAD_BASELINE_FROM=""
 }
 
 # A change that moves a class from lines to bytes (or back) leaves HEAD's rows

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -1474,13 +1474,18 @@ baseline_moved() { # CANDIDATE-BASELINE — violations on stdout
   esac
   # --no-renames, because a `git mv` of the baseline is exactly the move this
   # looks for and rename detection would report it as one path, not a removal.
+  # -z, because core.quotePath spells a non-ASCII path C-quoted by default:
+  # `"tools/\303\251.tsv"` never matches a literal probe, and the removed
+  # baseline would read as absent. It also terminates each path with a NUL,
+  # which is the one byte a path cannot contain — a newline can, so the read
+  # below splits on NUL rather than translating NULs into newlines.
   if [ "$STAGED" -eq 1 ]; then
-    git diff --cached --no-renames --name-only --diff-filter=D HEAD >"$TMP/removed.tsv" || diff_status=$?
+    git diff --cached --no-renames -z --name-only --diff-filter=D HEAD >"$TMP/removed.paths" || diff_status=$?
   else
-    git diff --no-renames --name-only --diff-filter=D HEAD >"$TMP/removed.tsv" || diff_status=$?
+    git diff --no-renames -z --name-only --diff-filter=D HEAD >"$TMP/removed.paths" || diff_status=$?
   fi
   [ "$diff_status" -eq 0 ] || collection_error "could not list what this change removes (git diff exit $diff_status) — refusing to treat a moved baseline as absent"
-  while IFS= read -r p || [ -n "$p" ]; do
+  while IFS= read -r -d '' p || [ -n "$p" ]; do
     [ -n "$p" ] || continue
     [ "$p" != "$BASELINE_FILE" ] || continue
     head_rows_removed "$p" || continue
@@ -1488,7 +1493,7 @@ baseline_moved() { # CANDIDATE-BASELINE — violations on stdout
     # "-" placeholders, never empty fields: report() reads these rows with
     # tab-IFS, and whitespace IFS collapses consecutive tabs.
     printf '%s\t%s\t%s\t%s\n' "MOVED" "$p" "-" "-"
-  done <"$TMP/removed.tsv"
+  done <"$TMP/removed.paths"
 }
 
 # Whether HEAD's blob at PATH was a baseline. The row shape is the only

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -19,6 +19,9 @@
 #       path HEAD's baseline carries none for is a bootstrap, which
 #       RATCHET_RAISE=1 admits in every class, frozen included; a renamed
 #       path is such a path, so a rename bootstraps rather than raises.
+#       A change that MOVES the baseline itself is judged against the rows
+#       at the path HEAD's own settings named, so a relocation carries no
+#       row past this check.
 #
 # --update: rewrite the baseline TIGHTENING ONLY — lower rows to current
 # reality, re-measure rows whose unit no longer matches their class, remove
@@ -153,6 +156,11 @@ admits one in every class — a renamed path is such a path, so a rename
 bootstraps rather than raises. No commit message is read: a pre-commit hook
 cannot see one, so the reason belongs in the commit body for review, not in
 a check.
+
+A commit that MOVES SIZE_RATCHET_BASELINE is judged against HEAD's rows at
+the path HEAD's own settings named: the versioned settings come from HEAD,
+the environment and .env.local from the invocation, and --baseline skips the
+lookup as the operator override it is.
 
 A run whose HEAD carries no baseline rows has no reference for the added and
 raised checks, so the verdict line says so rather than reading as clean.
@@ -1410,17 +1418,100 @@ RAISE_OK="${RATCHET_RAISE:-}"
 # and against a zero-row HEAD every one of them would read as newly added. A
 # git failure is never "absent": read_head_file_mode refuses on one.
 HEAD_BASELINE=""
-read_head_baseline() {
+# The path those rows came from when it is not the configured one: a change
+# that RELOCATES the baseline is judged against the rows it moved.
+HEAD_BASELINE_FROM=""
+
+# Never `$(...)`: collection_error inside a command substitution exits the
+# subshell alone, and the caller would read the refusal as "HEAD has no rows".
+read_head_rows_at() { # PATH — fills HEAD_BASELINE, "" when HEAD carries none there
   HEAD_BASELINE=""
-  read_head_file_mode "$BASELINE_FILE"
+  read_head_file_mode "$1"
   [ -n "$HEAD_FILE_MODE" ] || return 0
   case "$HEAD_FILE_MODE" in
     100*) ;;
     *) return 0 ;; # not a regular file at HEAD; there is no row set to compare
   esac
-  git show "HEAD:$BASELINE_FILE" >"$TMP/baseline.head" || collection_error "could not read $BASELINE_FILE from HEAD — refusing to judge added and raised rows against a baseline it could not read"
+  git show "HEAD:$1" >"$TMP/baseline.head" || collection_error "could not read $1 from HEAD — refusing to judge added and raised rows against a baseline it could not read"
   [ "$(count_nonempty_lines "$TMP/baseline.head")" -gt 0 ] || return 0
   HEAD_BASELINE="$TMP/baseline.head"
+}
+
+# Where HEAD's own configuration put the baseline. Resolved through the SAME
+# sr_setting chain this run used, with only the VERSIONED layer — the settings
+# TOML — taken from HEAD. The environment and .env.local are the invocation's,
+# not the commit's: they are identical on both sides by construction, so the
+# two resolutions differ exactly when the change under judgement moves the
+# path. --baseline is skipped outright for the same reason — a flag is the
+# operator pointing this run at a file, never a commit relocating anything.
+HEAD_SETTINGS_BASELINE=""
+read_head_settings_baseline() { # — "" when it names no usable path
+  HEAD_SETTINGS_BASELINE=""
+  [ "$BASELINE_SET" -eq 0 ] || return 0
+  local dir="$TMP/head-settings" src norm parent
+  rm -rf -- "$dir" || collection_error "could not clear the scratch copy of HEAD's settings"
+  mkdir -p -- "$dir" || collection_error "could not create a scratch copy of HEAD's settings"
+  if [ "${SIZE_RATCHET_SETTINGS_FILE:-}" = "/dev/null" ]; then
+    set --
+  elif [ -n "${SIZE_RATCHET_SETTINGS_FILE:-}" ]; then
+    set -- "$SIZE_RATCHET_SETTINGS_FILE"
+  else
+    set -- ".kendex/settings.toml" "kendex.settings.toml"
+  fi
+  for src in "$@"; do
+    # An absolute source lives outside the repository: HEAD carries no copy of
+    # it, and both resolutions read the one file that is there.
+    case "$src" in /*) continue ;; esac
+    # git reads a tree path canonically — `sub/../f` names `f` — so the probe
+    # and the read take the NORMALIZED spelling, while the copy is written
+    # under the spelling the resolver will look for.
+    norm="$(sr_settings_normalize_path "$src")"
+    case "$norm" in
+      "" | ".." | "../"*)
+        # A relative source that leaves the repository is read from the
+        # worktree by both resolutions, but the scratch directory this one
+        # runs in cannot reach it — so HEAD names no path rather than a
+        # wrong one.
+        HEAD_SETTINGS_BASELINE=""
+        return 0
+        ;;
+    esac
+    read_head_file_mode "$norm"
+    case "$HEAD_FILE_MODE" in 100*) ;; *) continue ;; esac
+    parent="$dir/${src%/*}"
+    [ "${src%/*}" != "$src" ] || parent="$dir"
+    mkdir -p -- "$parent" || collection_error "could not stage the directory for HEAD's copy of $src"
+    git show "HEAD:$norm" >"$dir/$src" || collection_error "could not read $src from HEAD to resolve the baseline path it configures"
+  done
+  [ ! -f .env.local ] || cp -- .env.local "$dir/.env.local" || collection_error "could not stage .env.local beside HEAD's settings"
+  # sr_setting reads its sources relative to the working directory and returns
+  # nonzero (never exits) on an unreadable one, so the copies answer from
+  # $dir and a refusal propagates instead of resolving to a default.
+  HEAD_SETTINGS_BASELINE="$(cd "$dir" && SR_SETTINGS_FROM_INDEX=0 sr_setting SIZE_RATCHET_BASELINE "tools/size-ratchet-baseline.tsv")" \
+    || collection_error "could not resolve SIZE_RATCHET_BASELINE from HEAD's settings — refusing to judge added and raised rows without knowing where HEAD's baseline was"
+  HEAD_SETTINGS_BASELINE="$(normalize_rel_path "$HEAD_SETTINGS_BASELINE")" || HEAD_SETTINGS_BASELINE=""
+  # A shape the configured path itself would be refused for names no row set
+  # to read; the run's own resolution already rejected it for this side.
+  case "$HEAD_SETTINGS_BASELINE" in /* | -*) HEAD_SETTINGS_BASELINE="" ;; esac
+}
+
+read_head_baseline() {
+  HEAD_BASELINE_FROM=""
+  read_head_rows_at "$BASELINE_FILE"
+  [ -z "$HEAD_BASELINE" ] || return 0
+  # No rows at the configured path is either of two things, and they must not
+  # be answered alike: HEAD had no row set anywhere (the three bootstraps),
+  # or this change MOVES the path and HEAD's rows sit at the old one, where
+  # skipping the judgment would carry a raise — a frozen one included — past
+  # a gate that never ran. HEAD's own settings say which, and they cannot
+  # misfire on a bootstrap: each of the three leaves HEAD naming the same
+  # path this run resolved, or a path HEAD carries no rows at, so the rows
+  # stay empty and the verdict says so exactly as before.
+  read_head_settings_baseline
+  [ -n "$HEAD_SETTINGS_BASELINE" ] || return 0
+  [ "$HEAD_SETTINGS_BASELINE" != "$BASELINE_FILE" ] || return 0
+  read_head_rows_at "$HEAD_SETTINGS_BASELINE"
+  [ -z "$HEAD_BASELINE" ] || HEAD_BASELINE_FROM="$HEAD_SETTINGS_BASELINE"
 }
 
 # A change that moves a class from lines to bytes (or back) leaves HEAD's rows
@@ -1579,7 +1670,11 @@ report "$TMP/violations.tsv" || collection_error "could not read the violations 
 # "no reference" is not "checked and clean": a run whose HEAD carries no rows
 # never judged an added or raised one, and says which of the two it is.
 RAISE_NOTE=""
-[ -n "$HEAD_BASELINE" ] || RAISE_NOTE=" — HEAD carries no baseline rows, so added and raised rows were not judged"
+if [ -z "$HEAD_BASELINE" ]; then
+  RAISE_NOTE=" — HEAD carries no baseline rows, so added and raised rows were not judged"
+elif [ -n "$HEAD_BASELINE_FROM" ]; then
+  RAISE_NOTE=" — added and raised rows judged against HEAD's baseline at $HEAD_BASELINE_FROM, which this change relocates"
+fi
 if [ "$VIOLATIONS" -gt 0 ]; then
   echo "size-ratchet: $VIOLATIONS violation(s) — threshold $THRESHOLD$CLASSES_NOTE, baseline $BASELINE_FILE$RAISE_NOTE"
   exit 1

--- a/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -440,6 +440,44 @@ RAISE=1 run_frozen --staged
 [ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten: tools/a.tsv -> tools/b.tsv"*) true ;; *) false ;; esac \
   && ok "the staged lane refuses the same move" \
   || bad "the staged lane refuses the same move" "rc=$RC out=$OUT"
+# git spells a non-ASCII path C-quoted by default, so a listing read as text
+# hands the probe `"tools/\303\251.tsv"` and the moved baseline reads as absent.
+new_repo relocquoted
+mkdir -p "$R/tools"
+mkfile x.test.txt 15
+printf 'x.test.txt\t15\n' >"$R/tools/é.tsv"
+settings_baseline "tools/é.tsv"
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: a baseline at a path git would quote"
+mkfile x.test.txt 20
+printf 'x.test.txt\t20\n' >"$R/tools/b.tsv"
+rm -f "$R/tools/é.tsv"
+settings_baseline tools/b.tsv
+git -C "$R" add -A
+RAISE=1 run_frozen --staged
+[ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten: tools/é.tsv -> tools/b.tsv"*) true ;; *) false ;; esac \
+  && ok "a baseline at a path git quotes is still seen leaving" \
+  || bad "a baseline at a path git quotes is seen leaving" "rc=$RC out=$OUT"
+# The sharper shape: a path may hold a NEWLINE, which is what a listing split on
+# newlines — or one translating NULs into them — turns into two paths that HEAD
+# carries no row set at. Only NUL delimits a path safely.
+new_repo relocnewline
+mkdir -p "$R/tools"
+mkfile x.test.txt 15
+NLPATH="$(printf 'tools/a\nb.tsv')"
+printf 'x.test.txt\t15\n' >"$R/$NLPATH"
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: a row set at a path holding a newline"
+mkfile x.test.txt 20
+printf 'x.test.txt\t20\n' >"$R/tools/b.tsv"
+rm -f "$R/$NLPATH"
+settings_baseline tools/b.tsv
+git -C "$R" add -A
+RAISE=1 run_frozen
+[ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten"*"-> tools/b.tsv"*) true ;; *) false ;; esac \
+  && ok "a baseline at a path holding a newline is still seen leaving" \
+  || bad "a baseline at a path holding a newline is seen leaving" "rc=$RC out=$OUT"
+
 # A removed file that is not a row set is not a moved baseline: the check reads
 # the row shape, so an ordinary deletion beside a first baseline stays a
 # bootstrap.

--- a/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -477,6 +477,37 @@ RAISE=1 run_frozen --staged
 [ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten: tools/a.tsv -> tools/b.tsv"*) true ;; *) false ;; esac \
   && ok "emptying the old baseline in place is a move, not a modification to ignore" \
   || bad "emptying the old baseline in place is a move" "rc=$RC out=$OUT"
+# Replacing the old baseline with a symlink to the NEW one leaves a path that
+# reads through as rows, which is how the move looked untouched. A symlink is
+# not the row set that was there, whatever it points at. Both modes are run on
+# one tree, because the defect was that they disagreed: the index records mode
+# 120000 and answered no already, the worktree followed the link.
+new_repo relocsymlinkover
+mkdir -p "$R/tools"
+mkfile x.test.txt 15
+printf 'x.test.txt\t15\n' >"$R/tools/a.tsv"
+settings_baseline tools/a.tsv
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: the baseline at tools/a.tsv"
+mkfile x.test.txt 20
+printf 'x.test.txt\t20\n' >"$R/tools/b.tsv"
+rm -f "$R/tools/a.tsv"
+ln -s b.tsv "$R/tools/a.tsv"
+settings_baseline tools/b.tsv
+git -C "$R" add -A
+RAISE=1 run_frozen
+WORKTREE_RC="$RC"
+[ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten: tools/a.tsv -> tools/b.tsv"*) true ;; *) false ;; esac \
+  && ok "a symlink over the old baseline is not the row set that was there" \
+  || bad "a symlink over the old baseline is not the row set that was there" "rc=$RC out=$OUT"
+RAISE=1 run_frozen --staged
+[ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten: tools/a.tsv -> tools/b.tsv"*) true ;; *) false ;; esac \
+  && ok "and the staged lane says the same of the same tree" \
+  || bad "the staged lane refuses the symlinked move" "rc=$RC out=$OUT"
+[ "$WORKTREE_RC" -eq "$RC" ] \
+  && ok "control: the two modes agree on that tree, which is the whole finding" \
+  || bad "the two modes agree on the symlinked move" "worktree=$WORKTREE_RC staged=$RC"
+
 # …and the predicate that keeps the wider list honest: a row-shaped file whose
 # numbers move is still a row set, so an ordinary edit of one is not a move.
 new_repo rowshapededit

--- a/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -452,5 +452,90 @@ run_frozen
   || bad "an empty HEAD baseline is no row set across a relocation" "rc=$RC out=$OUT"
 case "$OUT" in *"HEAD carries no baseline rows, so added and raised rows were not judged"*) ok "and a bootstrap still says the check had no reference" ;; *) bad "a bootstrap still reports that nothing was judged" "$OUT" ;; esac
 
+echo "=== every source kind that lookup reads is reproduced from HEAD, or refused ==="
+# A source the scratch tree does not reproduce faithfully makes the HEAD-side
+# resolution equal the run's own for a reason that is not HEAD's configuration,
+# and the raise gate is skipped again. One case per source kind.
+
+# .env.local is the invocation's only while it is UNTRACKED. Versioned it is
+# the commit's, and under --staged the run reads it from the index while HEAD's
+# copy is what the raise gate has to compare against.
+new_repo dotenvtracked
+mkdir -p "$R/tools"
+mkfile x.test.txt 15
+printf 'x.test.txt\t15\n' >"$R/tools/a.tsv"
+printf 'SIZE_RATCHET_BASELINE=tools/a.tsv\n' >"$R/.env.local"
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: the baseline path in a tracked .env.local"
+mkfile x.test.txt 20
+printf 'SIZE_RATCHET_BASELINE=tools/b.tsv\n' >"$R/.env.local"
+relocate x.test.txt 20
+RAISE=1 run_frozen --staged
+[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: x.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
+  && ok "a tracked .env.local moving the path is the commit's, and the raise is refused" \
+  || bad "a tracked .env.local moving the path is judged" "rc=$RC out=$OUT"
+
+# A tracked symlink is a supported install shape, and the link staying put
+# while its TARGET moves the path is the same relocation one indirection down.
+new_repo symlinktarget
+mkdir -p "$R/tools"
+mkfile y.test.txt 15
+printf 'y.test.txt\t15\n' >"$R/tools/a.tsv"
+printf '[env]\nSIZE_RATCHET_BASELINE = "tools/a.tsv"\n' >"$R/real.settings.toml"
+ln -s real.settings.toml "$R/kendex.settings.toml"
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: the settings file reached through a tracked symlink"
+mkfile y.test.txt 20
+printf '[env]\nSIZE_RATCHET_BASELINE = "tools/b.tsv"\n' >"$R/real.settings.toml"
+relocate y.test.txt 20
+RAISE=1 run_frozen
+[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: y.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
+  && ok "a symlinked settings source is followed through HEAD, so its target's move is judged" \
+  || bad "a symlinked settings source is followed through HEAD" "rc=$RC out=$OUT"
+
+# A settings file this change ADDS is one HEAD never had: HEAD's baseline is
+# wherever its own configuration left it, which here is the built-in default.
+new_repo settingsadded
+mkdir -p "$R/tools"
+mkfile z.test.txt 15
+printf 'z.test.txt\t15\n' >"$R/$BASE"
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: rows at the default path, no settings file"
+mkfile z.test.txt 20
+printf 'z.test.txt\t20\n' >"$R/tools/b.tsv"
+rm -f "$R/$BASE"
+settings_baseline tools/b.tsv
+git -C "$R" add -A
+RAISE=1 run_frozen
+[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: z.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
+  && ok "a settings file this change adds leaves HEAD on its own default, and the raise is refused" \
+  || bad "a settings file this change adds leaves HEAD on its own default" "rc=$RC out=$OUT"
+# The control that tracking is what decides: the SAME move, from a settings
+# file git carries nowhere, is the invocation's and reads the same on both
+# sides, so there is no reference and the run says so.
+git -C "$R" rm --cached -q kendex.settings.toml
+run_frozen
+[ "$RC" -eq 0 ] && case "$OUT" in *"HEAD carries no baseline rows"*) true ;; *) false ;; esac \
+  && ok "control: an untracked settings file is the invocation's, on both sides" \
+  || bad "control: an untracked settings file is the invocation's" "rc=$RC out=$OUT"
+
+# What the tree cannot reproduce refuses rather than falling through to the
+# empty answer, which is the state this whole lookup exists to stop reaching
+# without judgement.
+printf '[env]\nSIZE_RATCHET_BASELINE = "tools/b.tsv"\n' >"$TMP/outside.settings.toml"
+new_repo settingsescape
+mkdir -p "$R/tools"
+mkfile q.test.txt 15
+printf 'q.test.txt\t15\n' >"$R/tools/a.tsv"
+ln -s ../outside.settings.toml "$R/kendex.settings.toml"
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: a settings symlink leaving the repository"
+mkfile q.test.txt 20
+relocate q.test.txt 20
+run_frozen
+[ "$RC" -eq 2 ] && case "$OUT" in *"resolves outside the repository at HEAD"*) true ;; *) false ;; esac \
+  && ok "a settings symlink leaving the repository at HEAD is a loud exit 2" \
+  || bad "a settings symlink leaving the repository at HEAD is exit 2" "rc=$RC out=$OUT"
+
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -440,6 +440,58 @@ RAISE=1 run_frozen --staged
 [ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten: tools/a.tsv -> tools/b.tsv"*) true ;; *) false ;; esac \
   && ok "the staged lane refuses the same move" \
   || bad "the staged lane refuses the same move" "rc=$RC out=$OUT"
+# Rows at the destination are not proof they were the baseline HEAD used. A
+# b.tsv that already existed carries its own, and comparing against those is
+# how a raise reads as grandfathered while HEAD's real row said 15.
+new_repo relocpreexisting
+mkdir -p "$R/tools"
+mkfile x.test.txt 15
+printf 'x.test.txt\t15\n' >"$R/tools/a.tsv"
+printf 'x.test.txt\t20\n' >"$R/tools/b.tsv"
+settings_baseline tools/a.tsv
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: the baseline at tools/a.tsv, a tools/b.tsv already beside it"
+mkfile x.test.txt 20
+rm -f "$R/tools/a.tsv"
+settings_baseline tools/b.tsv
+git -C "$R" add -A
+RAISE=1 run_frozen --staged
+[ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten: tools/a.tsv -> tools/b.tsv"*) true ;; *) false ;; esac \
+  && ok "a destination that already carried rows is still a move, not a grandfathered row" \
+  || bad "a destination that already carried rows is still a move" "rc=$RC out=$OUT"
+# Emptying the old baseline in place is the same move, and reports as a
+# modification rather than a removal.
+new_repo relocemptied
+mkdir -p "$R/tools"
+mkfile y.test.txt 15
+printf 'y.test.txt\t15\n' >"$R/tools/a.tsv"
+settings_baseline tools/a.tsv
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: the baseline at tools/a.tsv"
+mkfile y.test.txt 20
+: >"$R/tools/a.tsv"
+printf 'y.test.txt\t20\n' >"$R/tools/b.tsv"
+settings_baseline tools/b.tsv
+git -C "$R" add -A
+RAISE=1 run_frozen --staged
+[ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten: tools/a.tsv -> tools/b.tsv"*) true ;; *) false ;; esac \
+  && ok "emptying the old baseline in place is a move, not a modification to ignore" \
+  || bad "emptying the old baseline in place is a move" "rc=$RC out=$OUT"
+# …and the predicate that keeps the wider list honest: a row-shaped file whose
+# numbers move is still a row set, so an ordinary edit of one is not a move.
+new_repo rowshapededit
+mkdir -p "$R/tools"
+mkfile e.test.txt 15
+printf 'e.test.txt\t15\n' >"$R/$BASE"
+printf 'counts/thing\t3\n' >"$R/data.tsv"
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: a baseline, and a row-shaped file that is not one"
+printf 'counts/thing\t4\n' >"$R/data.tsv"
+git -C "$R" add -A
+run_frozen
+[ "$RC" -eq 0 ] && ok "control: editing a row-shaped file leaves a row set, so it is no move" \
+  || bad "control: editing a row-shaped file is no move" "rc=$RC out=$OUT"
+
 # git spells a non-ASCII path C-quoted by default, so a listing read as text
 # hands the probe `"tools/\303\251.tsv"` and the moved baseline reads as absent.
 new_repo relocquoted

--- a/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -367,5 +367,90 @@ run_frozen
 [ "$RC" -eq 0 ] && ok "a zero-row HEAD baseline is no baseline, so the first row passes undeclared" \
   || bad "a zero-row HEAD baseline is no baseline, so the first row passes undeclared" "rc=$RC out=$OUT"
 
+echo "=== a commit that MOVES the baseline is judged against the rows it moved ==="
+# The path the CURRENT invocation resolves is not the path HEAD's rows are at:
+# a commit that relocates SIZE_RATCHET_BASELINE leaves HEAD carrying nothing at
+# the new one. Read as "HEAD has no rows" that is every raise unjudged, frozen
+# ones included, so the rows are followed to the path HEAD's settings named.
+settings_baseline() { # PATH — the fixture's committed settings name it
+  printf '[env]\nSIZE_RATCHET_BASELINE = "%s"\n' "$1" >"$R/kendex.settings.toml"
+}
+relocating_repo() { # NAME PATH LINES ROWLINES — HEAD's rows at tools/a.tsv
+  new_repo "$1"
+  mkdir -p "$R/tools"
+  mkfile "$2" "$3"
+  printf '%s\t%s\n' "$2" "$4" >"$R/tools/a.tsv"
+  settings_baseline tools/a.tsv
+  git -C "$R" add -A
+  git -C "$R" commit -q -m "seed: a baselined offender, baseline at tools/a.tsv"
+}
+relocate() { # PATH ROWLINES — the same rows move to tools/b.tsv at ROWLINES
+  printf '%s\t%s\n' "$1" "$2" >"$R/tools/b.tsv"
+  rm -f "$R/tools/a.tsv"
+  settings_baseline tools/b.tsv
+  git -C "$R" add -A
+}
+relocating_repo relocfrozen x.test.txt 15 15
+relocate x.test.txt 15
+run_frozen
+[ "$RC" -eq 0 ] && ok "control: a relocation that moves the rows unchanged passes" \
+  || bad "a relocation that moves the rows unchanged passes" "rc=$RC out=$OUT"
+case "$OUT" in *"judged against HEAD's baseline at tools/a.tsv, which this change relocates"*) ok "and the verdict says which rows it judged against" ;; *) bad "the verdict names the relocated baseline" "$OUT" ;; esac
+mkfile x.test.txt 20
+relocate x.test.txt 20
+RAISE=1 run_frozen
+[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: x.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
+  && ok "a frozen row raised across the relocation is refused, declaration and all" \
+  || bad "a frozen raise across a relocation is refused" "rc=$RC out=$OUT"
+# The open class takes the other branch of the same judgment: refused
+# undeclared, carried by the declaration, exactly as it is in place.
+relocating_repo relocopen plain.txt 15 15
+mkfile plain.txt 20
+relocate plain.txt 20
+run_frozen
+[ "$RC" -eq 1 ] && case "$OUT" in *"baseline row raised: plain.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
+  && ok "an unfrozen row raised across the relocation is refused undeclared" \
+  || bad "an unfrozen raise across a relocation is refused undeclared" "rc=$RC out=$OUT"
+RAISE=1 run_frozen
+[ "$RC" -eq 0 ] && ok "control: the declaration carries that unfrozen raise, as it does in place" \
+  || bad "the declaration carries an unfrozen raise across a relocation" "rc=$RC out=$OUT"
+
+echo "=== and the three bootstraps still pass: they leave HEAD naming no rows ==="
+# Each of the three produces an empty HEAD row set legitimately, and each is
+# the case a refusal on emptiness alone would break. All three are run with the
+# baseline path relocated in the same commit, which is the only way the lookup
+# above runs at all.
+new_repo bootunborn
+mkdir -p "$R/tools"
+mkfile u.test.txt 15
+printf 'u.test.txt\t15\n' >"$R/tools/b.tsv"
+settings_baseline tools/b.tsv
+git -C "$R" add -A
+run_frozen
+[ "$RC" -eq 0 ] && ok "an unborn HEAD bootstraps a first baseline at a configured path" \
+  || bad "an unborn HEAD bootstraps a first baseline" "rc=$RC out=$OUT"
+new_repo bootintroduced
+mkfile v.test.txt 5
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: a repo with no baseline at all"
+mkdir -p "$R/tools"
+mkfile v.test.txt 15
+printf 'v.test.txt\t15\n' >"$R/tools/b.tsv"
+settings_baseline tools/b.tsv
+git -C "$R" add -A
+run_frozen
+[ "$RC" -eq 0 ] && ok "a baseline this change introduces bootstraps, path and all" \
+  || bad "a baseline this change introduces bootstraps" "rc=$RC out=$OUT"
+relocating_repo bootplaceholder w.test.txt 5 5
+: >"$R/tools/a.tsv"
+git -C "$R" add -A
+git -C "$R" commit -q -m "the baseline, emptied to a placeholder"
+mkfile w.test.txt 15
+relocate w.test.txt 15
+run_frozen
+[ "$RC" -eq 0 ] && ok "a HEAD baseline committed empty is no row set, wherever the path moves" \
+  || bad "an empty HEAD baseline is no row set across a relocation" "rc=$RC out=$OUT"
+case "$OUT" in *"HEAD carries no baseline rows, so added and raised rows were not judged"*) ok "and a bootstrap still says the check had no reference" ;; *) bad "a bootstrap still reports that nothing was judged" "$OUT" ;; esac
+
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -367,11 +367,10 @@ run_frozen
 [ "$RC" -eq 0 ] && ok "a zero-row HEAD baseline is no baseline, so the first row passes undeclared" \
   || bad "a zero-row HEAD baseline is no baseline, so the first row passes undeclared" "rc=$RC out=$OUT"
 
-echo "=== a commit that MOVES the baseline is judged against the rows it moved ==="
-# The path the CURRENT invocation resolves is not the path HEAD's rows are at:
-# a commit that relocates SIZE_RATCHET_BASELINE leaves HEAD carrying nothing at
-# the new one. Read as "HEAD has no rows" that is every raise unjudged, frozen
-# ones included, so the rows are followed to the path HEAD's settings named.
+echo "=== a commit that MOVES the baseline is refused, in both classes ==="
+# The raise gate reads HEAD at the CONFIGURED path. Move that path and HEAD
+# carries nothing there, so a raised row — a frozen one included — would land
+# with nothing to compare it against. The move is refused instead.
 settings_baseline() { # PATH — the fixture's committed settings name it
   printf '[env]\nSIZE_RATCHET_BASELINE = "%s"\n' "$1" >"$R/kendex.settings.toml"
 }
@@ -384,7 +383,7 @@ relocating_repo() { # NAME PATH LINES ROWLINES — HEAD's rows at tools/a.tsv
   git -C "$R" add -A
   git -C "$R" commit -q -m "seed: a baselined offender, baseline at tools/a.tsv"
 }
-relocate() { # PATH ROWLINES — the same rows move to tools/b.tsv at ROWLINES
+relocate() { # PATH ROWLINES — the rows move to tools/b.tsv at ROWLINES
   printf '%s\t%s\n' "$1" "$2" >"$R/tools/b.tsv"
   rm -f "$R/tools/a.tsv"
   settings_baseline tools/b.tsv
@@ -393,33 +392,75 @@ relocate() { # PATH ROWLINES — the same rows move to tools/b.tsv at ROWLINES
 relocating_repo relocfrozen x.test.txt 15 15
 relocate x.test.txt 15
 run_frozen
-[ "$RC" -eq 0 ] && ok "control: a relocation that moves the rows unchanged passes" \
-  || bad "a relocation that moves the rows unchanged passes" "rc=$RC out=$OUT"
-case "$OUT" in *"judged against HEAD's baseline at tools/a.tsv, which this change relocates"*) ok "and the verdict says which rows it judged against" ;; *) bad "the verdict names the relocated baseline" "$OUT" ;; esac
+[ "$RC" -eq 0 ] && ok "control: a move that carries the rows unchanged passes" \
+  || bad "a move that carries the rows unchanged passes" "rc=$RC out=$OUT"
 mkfile x.test.txt 20
 relocate x.test.txt 20
 RAISE=1 run_frozen
-[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: x.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
-  && ok "a frozen row raised across the relocation is refused, declaration and all" \
-  || bad "a frozen raise across a relocation is refused" "rc=$RC out=$OUT"
-# The open class takes the other branch of the same judgment: refused
-# undeclared, carried by the declaration, exactly as it is in place.
+[ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten: tools/a.tsv -> tools/b.tsv"*) true ;; *) false ;; esac \
+  && ok "a frozen row raised across the move is refused, declaration and all" \
+  || bad "a frozen raise across a move is refused" "rc=$RC out=$OUT"
+case "$OUT" in *"move the baseline in a commit that changes nothing else"*) ok "and the refusal says what to do instead" ;; *) bad "the move refusal names its remedy" "$OUT" ;; esac
+# The open class takes the same refusal, and this is where it differs from an
+# in-place raise: there the declaration carries it, across a move nothing does.
 relocating_repo relocopen plain.txt 15 15
 mkfile plain.txt 20
 relocate plain.txt 20
 run_frozen
-[ "$RC" -eq 1 ] && case "$OUT" in *"baseline row raised: plain.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
-  && ok "an unfrozen row raised across the relocation is refused undeclared" \
-  || bad "an unfrozen raise across a relocation is refused undeclared" "rc=$RC out=$OUT"
+[ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten: tools/a.tsv -> tools/b.tsv"*) true ;; *) false ;; esac \
+  && ok "an unfrozen row raised across the move is refused undeclared" \
+  || bad "an unfrozen raise across a move is refused undeclared" "rc=$RC out=$OUT"
 RAISE=1 run_frozen
-[ "$RC" -eq 0 ] && ok "control: the declaration carries that unfrozen raise, as it does in place" \
-  || bad "the declaration carries an unfrozen raise across a relocation" "rc=$RC out=$OUT"
+[ "$RC" -eq 1 ] && ok "and the declaration does not carry it, where in place it would" \
+  || bad "the declaration does not carry a raise across a move" "rc=$RC out=$OUT"
+# A `git mv` is the same move, and rename detection must not hide it. Four
+# rows with one raised keeps the two files similar enough that git pairs them,
+# which is exactly when a rename-detecting listing reports no removal at all.
+new_repo relocgitmv
+mkdir -p "$R/tools"
+for f in m p1 p2 p3; do mkfile "$f.test.txt" 15; done
+printf 'm.test.txt\t15\np1.test.txt\t15\np2.test.txt\t15\np3.test.txt\t15\n' >"$R/tools/a.tsv"
+settings_baseline tools/a.tsv
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: four baselined offenders at tools/a.tsv"
+mkfile m.test.txt 20
+git -C "$R" mv tools/a.tsv tools/b.tsv
+printf 'm.test.txt\t20\np1.test.txt\t15\np2.test.txt\t15\np3.test.txt\t15\n' >"$R/tools/b.tsv"
+settings_baseline tools/b.tsv
+git -C "$R" add -A
+RAISE=1 run_frozen
+[ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten: tools/a.tsv -> tools/b.tsv"*) true ;; *) false ;; esac \
+  && ok "a git mv of the baseline is the same move, not a rename that hides it" \
+  || bad "a git mv of the baseline is the same move" "rc=$RC out=$OUT"
+# The staged lane reads the index, and a commit is what it judges.
+relocating_repo relocstaged s.test.txt 15 15
+mkfile s.test.txt 20
+relocate s.test.txt 20
+RAISE=1 run_frozen --staged
+[ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten: tools/a.tsv -> tools/b.tsv"*) true ;; *) false ;; esac \
+  && ok "the staged lane refuses the same move" \
+  || bad "the staged lane refuses the same move" "rc=$RC out=$OUT"
+# A removed file that is not a row set is not a moved baseline: the check reads
+# the row shape, so an ordinary deletion beside a first baseline stays a
+# bootstrap.
+new_repo notabaseline
+mkdir -p "$R/tools"
+mkfile n.test.txt 5
+printf 'some prose, not a row\n' >"$R/notes.txt"
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: no baseline, one ordinary file"
+mkfile n.test.txt 15
+printf 'n.test.txt\t15\n' >"$R/tools/b.tsv"
+rm -f "$R/notes.txt"
+settings_baseline tools/b.tsv
+git -C "$R" add -A
+run_frozen
+[ "$RC" -eq 0 ] && ok "a removed file that is not a row set is not a moved baseline" \
+  || bad "a removed file that is not a row set is not a moved baseline" "rc=$RC out=$OUT"
 
-echo "=== and the three bootstraps still pass: they leave HEAD naming no rows ==="
-# Each of the three produces an empty HEAD row set legitimately, and each is
-# the case a refusal on emptiness alone would break. All three are run with the
-# baseline path relocated in the same commit, which is the only way the lookup
-# above runs at all.
+echo "=== and the three bootstraps still pass: none of them removes a row set ==="
+# Each legitimately leaves HEAD with no rows at the configured path, and each
+# is what refusing on that emptiness alone would break.
 new_repo bootunborn
 mkdir -p "$R/tools"
 mkfile u.test.txt 15
@@ -451,130 +492,6 @@ run_frozen
 [ "$RC" -eq 0 ] && ok "a HEAD baseline committed empty is no row set, wherever the path moves" \
   || bad "an empty HEAD baseline is no row set across a relocation" "rc=$RC out=$OUT"
 case "$OUT" in *"HEAD carries no baseline rows, so added and raised rows were not judged"*) ok "and a bootstrap still says the check had no reference" ;; *) bad "a bootstrap still reports that nothing was judged" "$OUT" ;; esac
-
-echo "=== every source kind that lookup reads is reproduced from HEAD, or refused ==="
-# A source the scratch tree does not reproduce faithfully makes the HEAD-side
-# resolution equal the run's own for a reason that is not HEAD's configuration,
-# and the raise gate is skipped again. One case per source kind.
-
-# .env.local is the invocation's only while it is UNTRACKED. Versioned it is
-# the commit's, and under --staged the run reads it from the index while HEAD's
-# copy is what the raise gate has to compare against.
-new_repo dotenvtracked
-mkdir -p "$R/tools"
-mkfile x.test.txt 15
-printf 'x.test.txt\t15\n' >"$R/tools/a.tsv"
-printf 'SIZE_RATCHET_BASELINE=tools/a.tsv\n' >"$R/.env.local"
-git -C "$R" add -A
-git -C "$R" commit -q -m "seed: the baseline path in a tracked .env.local"
-mkfile x.test.txt 20
-printf 'SIZE_RATCHET_BASELINE=tools/b.tsv\n' >"$R/.env.local"
-relocate x.test.txt 20
-RAISE=1 run_frozen --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: x.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
-  && ok "a tracked .env.local moving the path is the commit's, and the raise is refused" \
-  || bad "a tracked .env.local moving the path is judged" "rc=$RC out=$OUT"
-
-# A tracked symlink is a supported install shape, and the link staying put
-# while its TARGET moves the path is the same relocation one indirection down.
-new_repo symlinktarget
-mkdir -p "$R/tools"
-mkfile y.test.txt 15
-printf 'y.test.txt\t15\n' >"$R/tools/a.tsv"
-printf '[env]\nSIZE_RATCHET_BASELINE = "tools/a.tsv"\n' >"$R/real.settings.toml"
-ln -s real.settings.toml "$R/kendex.settings.toml"
-git -C "$R" add -A
-git -C "$R" commit -q -m "seed: the settings file reached through a tracked symlink"
-mkfile y.test.txt 20
-printf '[env]\nSIZE_RATCHET_BASELINE = "tools/b.tsv"\n' >"$R/real.settings.toml"
-relocate y.test.txt 20
-RAISE=1 run_frozen
-[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: y.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
-  && ok "a symlinked settings source is followed through HEAD, so its target's move is judged" \
-  || bad "a symlinked settings source is followed through HEAD" "rc=$RC out=$OUT"
-
-# A settings file this change ADDS is one HEAD never had: HEAD's baseline is
-# wherever its own configuration left it, which here is the built-in default.
-new_repo settingsadded
-mkdir -p "$R/tools"
-mkfile z.test.txt 15
-printf 'z.test.txt\t15\n' >"$R/$BASE"
-git -C "$R" add -A
-git -C "$R" commit -q -m "seed: rows at the default path, no settings file"
-mkfile z.test.txt 20
-printf 'z.test.txt\t20\n' >"$R/tools/b.tsv"
-rm -f "$R/$BASE"
-settings_baseline tools/b.tsv
-git -C "$R" add -A
-RAISE=1 run_frozen
-[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: z.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
-  && ok "a settings file this change adds leaves HEAD on its own default, and the raise is refused" \
-  || bad "a settings file this change adds leaves HEAD on its own default" "rc=$RC out=$OUT"
-# The control that tracking is what decides: the SAME move, from a settings
-# file git carries nowhere, is the invocation's and reads the same on both
-# sides, so there is no reference and the run says so.
-git -C "$R" rm --cached -q kendex.settings.toml
-run_frozen
-[ "$RC" -eq 0 ] && case "$OUT" in *"HEAD carries no baseline rows"*) true ;; *) false ;; esac \
-  && ok "control: an untracked settings file is the invocation's, on both sides" \
-  || bad "control: an untracked settings file is the invocation's" "rc=$RC out=$OUT"
-
-# A chain that leaves the repository ends on a file no commit can carry, so it
-# is copied from where it is: both sides read it, and refusing would fail a
-# supported install shape on every run. Omitting it instead sends the lookup to
-# the built-in default, where this fixture has no rows and the raise below
-# would pass unjudged.
-printf '[env]\nSIZE_RATCHET_BASELINE = "tools/b.tsv"\n' >"$TMP/outside.settings.toml"
-new_repo settingsescape
-mkdir -p "$R/tools"
-mkfile q.test.txt 15
-printf 'q.test.txt\t15\n' >"$R/tools/b.tsv"
-ln -s ../outside.settings.toml "$R/kendex.settings.toml"
-git -C "$R" add -A
-git -C "$R" commit -q -m "seed: the baseline path named through a symlink out of the repository"
-mkfile q.test.txt 20
-printf 'q.test.txt\t20\n' >"$R/tools/b.tsv"
-git -C "$R" add -A
-RAISE=1 run_frozen
-[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: q.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
-  && ok "a settings symlink leaving the repository is followed to the file it names" \
-  || bad "a settings symlink leaving the repository is followed" "rc=$RC out=$OUT"
-
-echo "=== which file HEAD's baseline WAS is asked before the rows in it ==="
-# Reading the configured path and keeping whatever rows it holds accepts a file
-# HEAD's configuration never read. A stale destination carrying the raised
-# number reads as grandfathered, and the raise to it is never judged.
-new_repo stalendestination
-mkdir -p "$R/tools"
-mkfile x.test.txt 15
-printf 'x.test.txt\t15\n' >"$R/tools/a.tsv"
-printf 'x.test.txt\t20\n' >"$R/tools/b.tsv"
-settings_baseline tools/a.tsv
-git -C "$R" add -A
-git -C "$R" commit -q -m "seed: rows at tools/a.tsv, a stale tools/b.tsv beside them"
-mkfile x.test.txt 20
-settings_baseline tools/b.tsv
-git -C "$R" add -A
-RAISE=1 run_frozen
-[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: x.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
-  && ok "a stale row set at the destination is not HEAD's baseline, and the raise is refused" \
-  || bad "a stale row set at the destination is not HEAD's baseline" "rc=$RC out=$OUT"
-# The control that the destination's rows are not simply ignored: HEAD's
-# settings naming the SAME path is the ordinary case, and its rows judge.
-new_repo samepath
-mkdir -p "$R/tools"
-mkfile x.test.txt 15
-printf 'x.test.txt\t15\n' >"$R/tools/b.tsv"
-settings_baseline tools/b.tsv
-git -C "$R" add -A
-git -C "$R" commit -q -m "seed: rows at the path the settings name"
-mkfile x.test.txt 20
-printf 'x.test.txt\t20\n' >"$R/tools/b.tsv"
-git -C "$R" add -A
-RAISE=1 run_frozen
-[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: x.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
-  && ok "control: rows at the path HEAD's settings name are the ones that judge" \
-  || bad "control: rows at the path HEAD's settings name judge" "rc=$RC out=$OUT"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -519,23 +519,62 @@ run_frozen
   && ok "control: an untracked settings file is the invocation's, on both sides" \
   || bad "control: an untracked settings file is the invocation's" "rc=$RC out=$OUT"
 
-# What the tree cannot reproduce refuses rather than falling through to the
-# empty answer, which is the state this whole lookup exists to stop reaching
-# without judgement.
+# A chain that leaves the repository ends on a file no commit can carry, so it
+# is copied from where it is: both sides read it, and refusing would fail a
+# supported install shape on every run. Omitting it instead sends the lookup to
+# the built-in default, where this fixture has no rows and the raise below
+# would pass unjudged.
 printf '[env]\nSIZE_RATCHET_BASELINE = "tools/b.tsv"\n' >"$TMP/outside.settings.toml"
 new_repo settingsescape
 mkdir -p "$R/tools"
 mkfile q.test.txt 15
-printf 'q.test.txt\t15\n' >"$R/tools/a.tsv"
+printf 'q.test.txt\t15\n' >"$R/tools/b.tsv"
 ln -s ../outside.settings.toml "$R/kendex.settings.toml"
 git -C "$R" add -A
-git -C "$R" commit -q -m "seed: a settings symlink leaving the repository"
+git -C "$R" commit -q -m "seed: the baseline path named through a symlink out of the repository"
 mkfile q.test.txt 20
-relocate q.test.txt 20
-run_frozen
-[ "$RC" -eq 2 ] && case "$OUT" in *"resolves outside the repository at HEAD"*) true ;; *) false ;; esac \
-  && ok "a settings symlink leaving the repository at HEAD is a loud exit 2" \
-  || bad "a settings symlink leaving the repository at HEAD is exit 2" "rc=$RC out=$OUT"
+printf 'q.test.txt\t20\n' >"$R/tools/b.tsv"
+git -C "$R" add -A
+RAISE=1 run_frozen
+[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: q.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
+  && ok "a settings symlink leaving the repository is followed to the file it names" \
+  || bad "a settings symlink leaving the repository is followed" "rc=$RC out=$OUT"
+
+echo "=== which file HEAD's baseline WAS is asked before the rows in it ==="
+# Reading the configured path and keeping whatever rows it holds accepts a file
+# HEAD's configuration never read. A stale destination carrying the raised
+# number reads as grandfathered, and the raise to it is never judged.
+new_repo stalendestination
+mkdir -p "$R/tools"
+mkfile x.test.txt 15
+printf 'x.test.txt\t15\n' >"$R/tools/a.tsv"
+printf 'x.test.txt\t20\n' >"$R/tools/b.tsv"
+settings_baseline tools/a.tsv
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: rows at tools/a.tsv, a stale tools/b.tsv beside them"
+mkfile x.test.txt 20
+settings_baseline tools/b.tsv
+git -C "$R" add -A
+RAISE=1 run_frozen
+[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: x.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
+  && ok "a stale row set at the destination is not HEAD's baseline, and the raise is refused" \
+  || bad "a stale row set at the destination is not HEAD's baseline" "rc=$RC out=$OUT"
+# The control that the destination's rows are not simply ignored: HEAD's
+# settings naming the SAME path is the ordinary case, and its rows judge.
+new_repo samepath
+mkdir -p "$R/tools"
+mkfile x.test.txt 15
+printf 'x.test.txt\t15\n' >"$R/tools/b.tsv"
+settings_baseline tools/b.tsv
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: rows at the path the settings name"
+mkfile x.test.txt 20
+printf 'x.test.txt\t20\n' >"$R/tools/b.tsv"
+git -C "$R" add -A
+RAISE=1 run_frozen
+[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: x.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
+  && ok "control: rows at the path HEAD's settings name are the ones that judge" \
+  || bad "control: rows at the path HEAD's settings name judge" "rc=$RC out=$OUT"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/changelog.d/fixed/ken-848.md
+++ b/changelog.d/fixed/ken-848.md
@@ -1,3 +1,3 @@
-- size-ratchet judges a commit that moves `SIZE_RATCHET_BASELINE` against the
-  rows at the path HEAD's own settings named, so relocating the baseline no
-  longer carries an unjudged raise.
+- size-ratchet refuses a commit that moves `SIZE_RATCHET_BASELINE` and rewrites
+  it at once, where a raised row used to land unjudged. Move the baseline in one
+  commit, change its rows in the next.

--- a/changelog.d/fixed/ken-848.md
+++ b/changelog.d/fixed/ken-848.md
@@ -1,0 +1,3 @@
+- size-ratchet judges a commit that moves `SIZE_RATCHET_BASELINE` against the
+  rows at the path HEAD's own settings named, so relocating the baseline no
+  longer carries an unjudged raise.

--- a/skills/size-ratchet/DEVELOPMENT.md
+++ b/skills/size-ratchet/DEVELOPMENT.md
@@ -206,17 +206,18 @@ a first `--seed`, a baseline this change introduces) has nothing to compare,
 so the raise gate alone is skipped — every other verdict still judges the
 snapshot and can fail it — and the verdict line says the added and raised
 checks did not run, because "no reference" must never read as "checked and
-clean". Which file HEAD's
-baseline WAS is asked before the rows in it, on every run. That file is the
-one HEAD's own settings named, resolved through the same chain over a scratch
-tree holding HEAD's view of every source that chain consults, so a commit that
-MOVES the baseline cannot land the raise an unjudged gate would have carried,
-and a stale row set sitting at the destination is not mistaken for HEAD's own.
-The script header lists what that tree must hold for each source kind, and a
-source it cannot reproduce refuses rather than reading as "HEAD has no rows",
-which is the state this exists to stop reaching without judgement. None of the
-three no-baseline cases can misfire on it, because each leaves HEAD naming
-either the path the run already read or one HEAD carries no rows at. A row whose
+clean". A commit that MOVES the
+baseline reaches that same emptiness without being one of the three, and every
+raise in it would land unjudged, so it is refused instead. The gate does not
+follow the move: where HEAD's baseline was is a question only HEAD's settings
+answer, and they resolve through a chain this script consults but does not
+own, so answering it means keeping a second implementation of that contract in
+step with it. The discriminator is what the change does to the old file, a path
+HEAD carried a row set at that the judged snapshot no longer carries, which
+none of the three bootstraps produces. A move whose rows arrive byte for byte
+as they left passes, because no row rose across it. The bound worth knowing is
+that a change pointing the setting elsewhere while leaving the old file tracked
+removes nothing, and is not a move the check can name. A row whose
 file is at or under its threshold is reported as stale instead, so one root
 cause reads as one verdict. A class that changes its UNIT does not escape:
 HEAD's row is re-expressed in the unit the class counts now, measured from

--- a/skills/size-ratchet/DEVELOPMENT.md
+++ b/skills/size-ratchet/DEVELOPMENT.md
@@ -206,7 +206,13 @@ a first `--seed`, a baseline this change introduces) has nothing to compare,
 so the raise gate alone is skipped — every other verdict still judges the
 snapshot and can fail it — and the verdict line says the added and raised
 checks did not run, because "no reference" must never read as "checked and
-clean". A row whose
+clean". A commit that MOVES the
+baseline is not such a HEAD: the rows are followed to the path HEAD's own
+settings named, resolved through the same chain with the versioned settings
+taken from HEAD, so a relocation cannot land the raise an unjudged gate would
+have carried. None of the three no-baseline cases can misfire on that lookup,
+because each leaves HEAD naming either the path the run already read or one
+HEAD carries no rows at. A row whose
 file is at or under its threshold is reported as stale instead, so one root
 cause reads as one verdict. A class that changes its UNIT does not escape:
 HEAD's row is re-expressed in the unit the class counts now, measured from

--- a/skills/size-ratchet/DEVELOPMENT.md
+++ b/skills/size-ratchet/DEVELOPMENT.md
@@ -206,16 +206,17 @@ a first `--seed`, a baseline this change introduces) has nothing to compare,
 so the raise gate alone is skipped — every other verdict still judges the
 snapshot and can fail it — and the verdict line says the added and raised
 checks did not run, because "no reference" must never read as "checked and
-clean". A commit that MOVES the
-baseline is not such a HEAD. The rows are followed to the path HEAD's own
-settings named, resolved through the same chain over a scratch tree holding
-HEAD's view of every source that chain consults, so a relocation cannot land
-the raise an unjudged gate would have carried. The script header lists what
-that tree must hold for each source kind, and a source it cannot reproduce
-refuses rather than reading as "HEAD has no rows", which is the state the
-lookup exists to stop reaching without judgement. None of the three
-no-baseline cases can misfire on it, because each leaves HEAD naming either
-the path the run already read or one HEAD carries no rows at. A row whose
+clean". Which file HEAD's
+baseline WAS is asked before the rows in it, on every run. That file is the
+one HEAD's own settings named, resolved through the same chain over a scratch
+tree holding HEAD's view of every source that chain consults, so a commit that
+MOVES the baseline cannot land the raise an unjudged gate would have carried,
+and a stale row set sitting at the destination is not mistaken for HEAD's own.
+The script header lists what that tree must hold for each source kind, and a
+source it cannot reproduce refuses rather than reading as "HEAD has no rows",
+which is the state this exists to stop reaching without judgement. None of the
+three no-baseline cases can misfire on it, because each leaves HEAD naming
+either the path the run already read or one HEAD carries no rows at. A row whose
 file is at or under its threshold is reported as stale instead, so one root
 cause reads as one verdict. A class that changes its UNIT does not escape:
 HEAD's row is re-expressed in the unit the class counts now, measured from

--- a/skills/size-ratchet/DEVELOPMENT.md
+++ b/skills/size-ratchet/DEVELOPMENT.md
@@ -207,12 +207,15 @@ so the raise gate alone is skipped — every other verdict still judges the
 snapshot and can fail it — and the verdict line says the added and raised
 checks did not run, because "no reference" must never read as "checked and
 clean". A commit that MOVES the
-baseline is not such a HEAD: the rows are followed to the path HEAD's own
-settings named, resolved through the same chain with the versioned settings
-taken from HEAD, so a relocation cannot land the raise an unjudged gate would
-have carried. None of the three no-baseline cases can misfire on that lookup,
-because each leaves HEAD naming either the path the run already read or one
-HEAD carries no rows at. A row whose
+baseline is not such a HEAD. The rows are followed to the path HEAD's own
+settings named, resolved through the same chain over a scratch tree holding
+HEAD's view of every source that chain consults, so a relocation cannot land
+the raise an unjudged gate would have carried. The script header lists what
+that tree must hold for each source kind, and a source it cannot reproduce
+refuses rather than reading as "HEAD has no rows", which is the state the
+lookup exists to stop reaching without judgement. None of the three
+no-baseline cases can misfire on it, because each leaves HEAD naming either
+the path the run already read or one HEAD carries no rows at. A row whose
 file is at or under its threshold is reported as stale instead, so one root
 cause reads as one verdict. A class that changes its UNIT does not escape:
 HEAD's row is re-expressed in the unit the class counts now, measured from

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -73,6 +73,11 @@ raises is that threshold routed around.
 - **A first row** for a path HEAD's baseline carries none for is a
   **bootstrap**, not a raise, and the declaration admits it in every class,
   frozen included. A renamed path is such a path, so a rename bootstraps.
+- **A commit that moves the baseline** — a changed `SIZE_RATCHET_BASELINE` —
+  is judged against HEAD's rows at the path HEAD's own settings named, so a
+  relocation carries no row past this check. The versioned settings come from
+  HEAD; the environment, `.env.local` and `--baseline` belong to the
+  invocation, not the commit, and are read as they are.
 - A repo whose HEAD carries no baseline rows yet is bootstrapping, and the
   gate says so on its verdict line rather than reporting a clean raise check.
 

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -73,12 +73,13 @@ raises is that threshold routed around.
 - **A first row** for a path HEAD's baseline carries none for is a
   **bootstrap**, not a raise, and the declaration admits it in every class,
   frozen included. A renamed path is such a path, so a rename bootstraps.
-- **A commit that moves the baseline** — a changed `SIZE_RATCHET_BASELINE` —
-  is judged against HEAD's rows at the path HEAD's own settings named, so a
-  relocation carries no row past this check. Every source that resolution
-  reads comes from HEAD when git tracks it and from the invocation when it
-  does not; one the lookup cannot reproduce is a loud refusal, never a silent
-  "no rows". `--baseline` is the operator's override and skips the lookup.
+- **HEAD's baseline is the file HEAD's own settings named**, asked before the
+  rows in it, so a changed `SIZE_RATCHET_BASELINE` carries no row past this
+  check and a stale row set at the new path is not read as HEAD's. Every
+  source that resolution reads comes from HEAD when git tracks it and from the
+  invocation when it does not; one the lookup cannot reproduce is a loud
+  refusal, never a silent "no rows". `--baseline` is the operator's override
+  and skips the lookup.
 - A repo whose HEAD carries no baseline rows yet is bootstrapping, and the
   gate says so on its verdict line rather than reporting a clean raise check.
 

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -73,13 +73,12 @@ raises is that threshold routed around.
 - **A first row** for a path HEAD's baseline carries none for is a
   **bootstrap**, not a raise, and the declaration admits it in every class,
   frozen included. A renamed path is such a path, so a rename bootstraps.
-- **HEAD's baseline is the file HEAD's own settings named**, asked before the
-  rows in it, so a changed `SIZE_RATCHET_BASELINE` carries no row past this
-  check and a stale row set at the new path is not read as HEAD's. Every
-  source that resolution reads comes from HEAD when git tracks it and from the
-  invocation when it does not; one the lookup cannot reproduce is a loud
-  refusal, never a silent "no rows". `--baseline` is the operator's override
-  and skips the lookup.
+- **A commit that MOVES the baseline** — a changed `SIZE_RATCHET_BASELINE` —
+  leaves HEAD carrying nothing at the path the run reads, so a raise would land
+  with nothing to compare it against. It is refused unless the rows arriving at
+  the new path are byte for byte the rows that left the old one. Move the
+  baseline in a commit that changes nothing else, then change its rows in the
+  next one.
 - A repo whose HEAD carries no baseline rows yet is bootstrapping, and the
   gate says so on its verdict line rather than reporting a clean raise check.
 

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -75,9 +75,10 @@ raises is that threshold routed around.
   frozen included. A renamed path is such a path, so a rename bootstraps.
 - **A commit that moves the baseline** — a changed `SIZE_RATCHET_BASELINE` —
   is judged against HEAD's rows at the path HEAD's own settings named, so a
-  relocation carries no row past this check. The versioned settings come from
-  HEAD; the environment, `.env.local` and `--baseline` belong to the
-  invocation, not the commit, and are read as they are.
+  relocation carries no row past this check. Every source that resolution
+  reads comes from HEAD when git tracks it and from the invocation when it
+  does not; one the lookup cannot reproduce is a loud refusal, never a silent
+  "no rows". `--baseline` is the operator's override and skips the lookup.
 - A repo whose HEAD carries no baseline rows yet is bootstrapping, and the
   gate says so on its verdict line rather than reporting a clean raise check.
 

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -1450,21 +1450,30 @@ read_head_baseline() {
 # implementation of someone else's contract in step with it. A move is refused
 # instead, and the rows travel in a commit that changes nothing else.
 #
-# The discriminator is what the change does to the OLD file: a path HEAD
-# carried a row set at, which the judged snapshot no longer carries. It cannot
-# misfire on the three bootstraps. An unborn HEAD has no paths to remove. A
-# baseline this change introduces leaves HEAD carrying no row set anywhere, so
-# there is none to remove. A placeholder committed empty is AT the configured
-# path and is filled rather than removed, and holds no rows to recognize even
-# if it were. What the check does see is one bound worth stating: a change that
-# points the setting elsewhere while leaving the old file tracked, rows and
-# all, removes nothing and is not a move it can name.
+# The discriminator is what the change does to the OLD file: HEAD's blob there
+# was a row set, and the judged snapshot's is not. That is stricter than "this
+# path changed" and it is what keeps an ordinary edit out — a row-shaped file
+# whose numbers move is still a row set, so it never reports. Only a file that
+# STOPPED being one does: deleted, emptied, or replaced with something that is
+# not rows.
+#
+# It cannot misfire on the three bootstraps. An unborn HEAD has no changed
+# paths at all. A baseline this change introduces leaves HEAD carrying no row
+# set anywhere, so no changed path has one to lose. A placeholder committed
+# empty holds no rows at HEAD to recognize, and is at the configured path,
+# which this scan skips. One bound is worth stating: a change that points the
+# setting elsewhere while leaving the old file tracked with its rows loses no
+# row set, and is not a move this can name.
+#
+# The scan runs whether or not HEAD carries rows at the configured path. Rows
+# there do not establish they were the baseline HEAD used — a destination that
+# already existed carries its own, and comparing against those is how a raise
+# reads as grandfathered while HEAD's real row said something else.
 #
 # A pure move passes. The rows that arrive are byte for byte the rows that
 # left, so no row rose across it; anything else about them is the next
 # commit's business.
 baseline_moved() { # CANDIDATE-BASELINE — violations on stdout
-  [ -z "$HEAD_BASELINE" ] || return 0
   local p head_status=0 diff_status=0
   git rev-parse --verify --quiet HEAD >/dev/null 2>&1 || head_status=$?
   case "$head_status" in
@@ -1479,16 +1488,20 @@ baseline_moved() { # CANDIDATE-BASELINE — violations on stdout
   # baseline would read as absent. It also terminates each path with a NUL,
   # which is the one byte a path cannot contain — a newline can, so the read
   # below splits on NUL rather than translating NULs into newlines.
+  # Every changed path, not only the deleted ones: emptying the old baseline in
+  # place, or writing something else over it, is the same move and reports as a
+  # modification. The predicate below is what keeps the wider list honest.
   if [ "$STAGED" -eq 1 ]; then
-    git diff --cached --no-renames -z --name-only --diff-filter=D HEAD >"$TMP/removed.paths" || diff_status=$?
+    git diff --cached --no-renames -z --name-only HEAD >"$TMP/removed.paths" || diff_status=$?
   else
-    git diff --no-renames -z --name-only --diff-filter=D HEAD >"$TMP/removed.paths" || diff_status=$?
+    git diff --no-renames -z --name-only HEAD >"$TMP/removed.paths" || diff_status=$?
   fi
-  [ "$diff_status" -eq 0 ] || collection_error "could not list what this change removes (git diff exit $diff_status) — refusing to treat a moved baseline as absent"
+  [ "$diff_status" -eq 0 ] || collection_error "could not list what this change touches (git diff exit $diff_status) — refusing to treat a moved baseline as absent"
   while IFS= read -r -d '' p || [ -n "$p" ]; do
     [ -n "$p" ] || continue
     [ "$p" != "$BASELINE_FILE" ] || continue
     head_rows_removed "$p" || continue
+    snapshot_rows_at "$p" && continue
     cmp -s -- "$TMP/removed.head" "$1" && continue
     # "-" placeholders, never empty fields: report() reads these rows with
     # tab-IFS, and whitespace IFS collapses consecutive tabs.
@@ -1496,21 +1509,39 @@ baseline_moved() { # CANDIDATE-BASELINE — violations on stdout
   done <"$TMP/removed.paths"
 }
 
-# Whether HEAD's blob at PATH was a baseline. The row shape is the only
-# question — sorting and duplicates are the governing copy's business, and a
-# file that fails them is still the row set this change carried away.
-head_rows_removed() { # PATH — 0 when HEAD held a row set there, at $TMP/removed.head
+# Whether FILE holds a row set. The row shape is the only question — sorting
+# and duplicates are the governing copy's business, and a file that fails them
+# is still the row set this change carried away.
+blob_is_row_set() { # FILE
   local status=0
+  [ "$(count_nonempty_lines "$1")" -gt 0 ] || return 1
+  grep -qEv -- "$BASELINE_ROW_RE" "$1" || status=$?
+  case "$status" in
+    0) return 1 ;; # a line that is not a row
+    1) return 0 ;;
+    *) collection_error "could not read $1 to tell whether it holds baseline rows (grep exit $status)" ;;
+  esac
+}
+
+head_rows_removed() { # PATH — 0 when HEAD held a row set there, at $TMP/removed.head
   read_head_file_mode "$1"
   case "$HEAD_FILE_MODE" in 100*) ;; *) return 1 ;; esac
   git show "HEAD:$1" >"$TMP/removed.head" || collection_error "could not read $1 from HEAD to tell whether it was the baseline this change moved"
-  [ "$(count_nonempty_lines "$TMP/removed.head")" -gt 0 ] || return 1
-  grep -qEv -- "$BASELINE_ROW_RE" "$TMP/removed.head" || status=$?
-  case "$status" in
-    0) return 1 ;; # a line that is not a row: whatever left, it was not a baseline
-    1) return 0 ;;
-    *) collection_error "could not read $1 from HEAD to tell whether it was the baseline this change moved (grep exit $status)" ;;
-  esac
+  blob_is_row_set "$TMP/removed.head"
+}
+
+# The judged snapshot's copy, from the same side the enumeration above read:
+# the index under --staged, the worktree otherwise.
+snapshot_rows_at() { # PATH — 0 when the snapshot still holds a row set there
+  if [ "$STAGED" -eq 1 ]; then
+    read_index_file_mode "$1"
+    case "$INDEX_FILE_MODE" in 100*) ;; *) return 1 ;; esac
+    git show ":$1" >"$TMP/removed.now" || collection_error "could not read the staged copy of $1 to tell whether it still holds baseline rows"
+  else
+    [ -f "$1" ] || return 1
+    cp -- "$1" "$TMP/removed.now" || collection_error "could not copy $1 to tell whether it still holds baseline rows"
+  fi
+  blob_is_row_set "$TMP/removed.now"
 }
 
 # A change that moves a class from lines to bytes (or back) leaves HEAD's rows

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -158,9 +158,10 @@ cannot see one, so the reason belongs in the commit body for review, not in
 a check.
 
 A commit that MOVES SIZE_RATCHET_BASELINE is judged against HEAD's rows at
-the path HEAD's own settings named: the versioned settings come from HEAD,
-the environment and .env.local from the invocation, and --baseline skips the
-lookup as the operator override it is.
+the path HEAD's own settings named. Every source that resolution reads comes
+from HEAD when git tracks it and from the invocation when it does not, and a
+source it cannot reproduce is a loud refusal rather than a silent "no rows".
+--baseline skips the lookup, being the operator's override and not a commit.
 
 A run whose HEAD carries no baseline rows has no reference for the added and
 raised checks, so the verdict line says so rather than reading as clean.
@@ -1437,57 +1438,141 @@ read_head_rows_at() { # PATH — fills HEAD_BASELINE, "" when HEAD carries none 
   HEAD_BASELINE="$TMP/baseline.head"
 }
 
-# Where HEAD's own configuration put the baseline. Resolved through the SAME
-# sr_setting chain this run used, with only the VERSIONED layer — the settings
-# TOML — taken from HEAD. The environment and .env.local are the invocation's,
-# not the commit's: they are identical on both sides by construction, so the
-# two resolutions differ exactly when the change under judgement moves the
-# path. --baseline is skipped outright for the same reason — a flag is the
-# operator pointing this run at a file, never a commit relocating anything.
+# --- where HEAD's own configuration put the baseline -------------------------
+# Resolved through the SAME sr_setting chain this run used, over a scratch tree
+# holding HEAD's view of every source that chain consults. The tree is the
+# whole answer: a source it does not reproduce faithfully makes the HEAD-side
+# resolution equal the run's own for a reason that is not HEAD's configuration,
+# and "HEAD has no rows" is then reached without judgement, which is the defect
+# itself. So each source kind is reproduced or the run refuses; nothing falls
+# through. What the tree must hold, by the route sr_setting reaches the source:
+#
+#   set in the environment      nothing. One process answers both sides.
+#   SIZE_RATCHET_SETTINGS_FILE=/dev/null
+#                               nothing. It selects no source at all.
+#   an absolute path            nothing. The same file answers both sides.
+#   a relative path that leaves the repository
+#                               the worktree file, at its own spelling. No
+#                               commit can carry it, so it is the invocation's.
+#   a path git tracks nowhere   the worktree file. Unversioned, so the
+#                               invocation's; a commit reaches this gate
+#                               through --staged, where an added source is in
+#                               the index and the branch below governs.
+#   tracked, absent at HEAD     nothing. This change ADDS the source.
+#   a regular file at HEAD      HEAD's blob.
+#   a symlink at HEAD           HEAD's blob at the end of the chain, resolved
+#                               through HEAD, staged at the link's spelling.
+#                               sr_setting reads bytes, so a regular file
+#                               there reads identically.
+#   anything else at HEAD       a refusal. A chain that leaves the repository,
+#                               loops, or ends on a directory or a gitlink is
+#                               not reproducible, and neither is an absolute
+#                               link target.
+#
+# --baseline is skipped outright: a flag is the operator pointing this run at a
+# file, never a commit relocating anything.
 HEAD_SETTINGS_BASELINE=""
-read_head_settings_baseline() { # — "" when it names no usable path
+
+# The sources sr_setting consults, in the order it consults them.
+SETTINGS_SOURCES=()
+settings_sources() {
+  SETTINGS_SOURCES=()
+  [ "${SIZE_RATCHET_SETTINGS_FILE:-}" != "/dev/null" ] || return 0
+  SETTINGS_SOURCES=(".env.local")
+  if [ -n "${SIZE_RATCHET_SETTINGS_FILE:-}" ]; then
+    SETTINGS_SOURCES+=("$SIZE_RATCHET_SETTINGS_FILE")
+  else
+    SETTINGS_SOURCES+=(".kendex/settings.toml" "kendex.settings.toml")
+  fi
+}
+
+index_tracks() { # PATH — 0 when the index carries it
+  local status=0
+  git ls-files --error-unmatch -- ":(literal)$1" >/dev/null 2>&1 || status=$?
+  case "$status" in
+    0) return 0 ;;
+    1) return 1 ;;
+    *) collection_error "could not query the index for $1 (git ls-files exit $status) — refusing to judge added and raised rows without knowing whether this change adds the source" ;;
+  esac
+}
+
+# Eight hops is past any real settings install and short of a loop's patience.
+HEAD_LINK_MAX=8
+stage_head_blob() { # PATH DEST — HEAD's file content at PATH, chain followed
+  local path="$1" dest="$2" hops=0 target dir
+  while :; do
+    read_head_file_mode "$path"
+    case "$HEAD_FILE_MODE" in
+      "") return 0 ;; # HEAD carries no such source
+      100*) break ;;
+      120000)
+        hops=$((hops + 1))
+        [ "$hops" -le "$HEAD_LINK_MAX" ] || collection_error "the settings source '$1' is a symlink chain longer than $HEAD_LINK_MAX hops at HEAD — refusing to judge added and raised rows against a configuration it cannot follow"
+        git show "HEAD:$path" >"$TMP/head.link" || collection_error "could not read the symlink '$path' from HEAD to follow the settings source it points at"
+        target="$(cat -- "$TMP/head.link")" || collection_error "could not read the target of the symlink '$path' at HEAD"
+        case "$target" in /*) collection_error "the settings source '$1' resolves through an absolute symlink at HEAD, which the scratch tree cannot reproduce — refusing to judge added and raised rows against a configuration it cannot read" ;; esac
+        dir="${path%/*}"
+        [ "$dir" != "$path" ] || dir=""
+        path="$(sr_settings_normalize_path "${dir:+$dir/}$target")"
+        case "$path" in
+          "" | ".." | "../"*) collection_error "the settings source '$1' resolves outside the repository at HEAD, which the scratch tree cannot reproduce — refusing to judge added and raised rows against a configuration it cannot read" ;;
+        esac
+        ;;
+      *) collection_error "the settings source '$1' is not a regular file at HEAD (mode $HEAD_FILE_MODE) — refusing to judge added and raised rows against a configuration it cannot read" ;;
+    esac
+  done
+  git show "HEAD:$path" >"$dest" || collection_error "could not read $path from HEAD to resolve the baseline path it configures"
+}
+
+read_head_settings_baseline() { # — "" when HEAD names no usable path
   HEAD_SETTINGS_BASELINE=""
   [ "$BASELINE_SET" -eq 0 ] || return 0
-  local dir="$TMP/head-settings" src norm parent
+  local dir="$TMP/head-settings" cwd src norm dest parent depth d
   rm -rf -- "$dir" || collection_error "could not clear the scratch copy of HEAD's settings"
-  mkdir -p -- "$dir" || collection_error "could not create a scratch copy of HEAD's settings"
-  if [ "${SIZE_RATCHET_SETTINGS_FILE:-}" = "/dev/null" ]; then
-    set --
-  elif [ -n "${SIZE_RATCHET_SETTINGS_FILE:-}" ]; then
-    set -- "$SIZE_RATCHET_SETTINGS_FILE"
-  else
-    set -- ".kendex/settings.toml" "kendex.settings.toml"
-  fi
-  for src in "$@"; do
-    # An absolute source lives outside the repository: HEAD carries no copy of
-    # it, and both resolutions read the one file that is there.
+  settings_sources
+  # A source spelled with a leading `..` still has to land inside the tree, so
+  # the resolution runs from a directory nested as deep as the deepest such
+  # spelling. Counting every `..` segment overshoots, which costs an unused
+  # directory and can never come up short.
+  depth=0
+  for src in ${SETTINGS_SOURCES+"${SETTINGS_SOURCES[@]}"}; do
+    d="$(printf '%s\n' "$src" | awk -F'/' '{ n = 0; for (i = 1; i <= NF; i++) if ($i == "..") n++; print n }')" \
+      || collection_error "could not measure the depth of the settings source '$src'"
+    [ "$d" -le "$depth" ] || depth="$d"
+  done
+  cwd="$dir"
+  while [ "$depth" -gt 0 ]; do
+    cwd="$cwd/nested"
+    depth=$((depth - 1))
+  done
+  mkdir -p -- "$cwd" || collection_error "could not create a scratch copy of HEAD's settings"
+  for src in ${SETTINGS_SOURCES+"${SETTINGS_SOURCES[@]}"}; do
     case "$src" in /*) continue ;; esac
-    # git reads a tree path canonically — `sub/../f` names `f` — so the probe
-    # and the read take the NORMALIZED spelling, while the copy is written
+    dest="$cwd/$src"
+    parent="$cwd/${src%/*}"
+    [ "${src%/*}" != "$src" ] || parent="$cwd"
+    mkdir -p -- "$parent" || collection_error "could not stage the directory for HEAD's copy of $src"
+    # git reads a tree path canonically — `sub/../f` names `f` — so every
+    # probe and read takes the NORMALIZED spelling, while the copy is written
     # under the spelling the resolver will look for.
     norm="$(sr_settings_normalize_path "$src")"
     case "$norm" in
       "" | ".." | "../"*)
-        # A relative source that leaves the repository is read from the
-        # worktree by both resolutions, but the scratch directory this one
-        # runs in cannot reach it — so HEAD names no path rather than a
-        # wrong one.
-        HEAD_SETTINGS_BASELINE=""
-        return 0
+        [ ! -f "$src" ] || cp -- "$src" "$dest" || collection_error "could not stage the out-of-repository settings source $src"
+        continue
         ;;
     esac
     read_head_file_mode "$norm"
-    case "$HEAD_FILE_MODE" in 100*) ;; *) continue ;; esac
-    parent="$dir/${src%/*}"
-    [ "${src%/*}" != "$src" ] || parent="$dir"
-    mkdir -p -- "$parent" || collection_error "could not stage the directory for HEAD's copy of $src"
-    git show "HEAD:$norm" >"$dir/$src" || collection_error "could not read $src from HEAD to resolve the baseline path it configures"
+    if [ -n "$HEAD_FILE_MODE" ]; then
+      stage_head_blob "$norm" "$dest"
+    elif ! index_tracks "$norm"; then
+      [ ! -f "$src" ] || cp -- "$src" "$dest" || collection_error "could not stage the untracked settings source $src"
+    fi
   done
-  [ ! -f .env.local ] || cp -- .env.local "$dir/.env.local" || collection_error "could not stage .env.local beside HEAD's settings"
   # sr_setting reads its sources relative to the working directory and returns
-  # nonzero (never exits) on an unreadable one, so the copies answer from
-  # $dir and a refusal propagates instead of resolving to a default.
-  HEAD_SETTINGS_BASELINE="$(cd "$dir" && SR_SETTINGS_FROM_INDEX=0 sr_setting SIZE_RATCHET_BASELINE "tools/size-ratchet-baseline.tsv")" \
+  # nonzero (never exits) on an unreadable one, so the tree answers from $cwd
+  # and a refusal propagates instead of resolving to a default.
+  HEAD_SETTINGS_BASELINE="$(cd "$cwd" && SR_SETTINGS_FROM_INDEX=0 sr_setting SIZE_RATCHET_BASELINE "tools/size-ratchet-baseline.tsv")" \
     || collection_error "could not resolve SIZE_RATCHET_BASELINE from HEAD's settings — refusing to judge added and raised rows without knowing where HEAD's baseline was"
   HEAD_SETTINGS_BASELINE="$(normalize_rel_path "$HEAD_SETTINGS_BASELINE")" || HEAD_SETTINGS_BASELINE=""
   # A shape the configured path itself would be refused for names no row set

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -18,10 +18,10 @@
 #       run carries when the path is in a frozen class. A FIRST row for a
 #       path HEAD's baseline carries none for is a bootstrap, which
 #       RATCHET_RAISE=1 admits in every class, frozen included; a renamed
-#       path is such a path, so a rename bootstraps rather than raises.
-#       A change that MOVES the baseline itself is judged against the rows
-#       at the path HEAD's own settings named, so a relocation carries no
-#       row past this check.
+#       path is such a path, so a rename bootstraps rather than raises;
+#   (f) a change that MOVES the baseline and rewrites it in the same commit.
+#       Across a move nothing compares the rows, so the move travels alone
+#       and the rows change in the commit after it.
 #
 # --update: rewrite the baseline TIGHTENING ONLY — lower rows to current
 # reality, re-measure rows whose unit no longer matches their class, remove
@@ -157,11 +157,11 @@ bootstraps rather than raises. No commit message is read: a pre-commit hook
 cannot see one, so the reason belongs in the commit body for review, not in
 a check.
 
-A commit that MOVES SIZE_RATCHET_BASELINE is judged against HEAD's rows at
-the path HEAD's own settings named. Every source that resolution reads comes
-from HEAD when git tracks it and from the invocation when it does not, and a
-source it cannot reproduce is a loud refusal rather than a silent "no rows".
---baseline skips the lookup, being the operator's override and not a commit.
+A commit that MOVES SIZE_RATCHET_BASELINE leaves HEAD carrying nothing at the
+path this run reads, so the added and raised checks have no reference and a
+raise would land unjudged. Such a commit is refused unless the rows arriving
+at the new path are byte for byte the rows that left the old one: the move
+travels alone, and the rows change in the commit after it.
 
 A run whose HEAD carries no baseline rows has no reference for the added and
 raised checks, so the verdict line says so rather than reading as clean.
@@ -683,9 +683,12 @@ format_row() { # SIZE UNIT — the baseline row's number
 # returns nonzero and leaves the caller to skip the rewrite. SUGGEST names the
 # file a fix command would operate on, and is empty for a copy the caller has
 # no path to hand back.
+# What a baseline row looks like, in one place: this validator and the moved
+# baseline check below both ask the question and must not answer it apart.
+BASELINE_ROW_RE="^[^${TAB}]+${TAB}[1-9][0-9]*b?\$"
 validate_baseline_rows() { # MODE FILE LABEL [SUGGEST]
   local mode="$1" file="$2" label="$3" suggest="${4:-}" grep_status=0 bad_rows dup_paths hint="" fault=""
-  bad_rows="$(grep -nEv -- "^[^${TAB}]+${TAB}[1-9][0-9]*b?\$" "$file")" || grep_status=$?
+  bad_rows="$(grep -nEv -- "$BASELINE_ROW_RE" "$file")" || grep_status=$?
   [ "$grep_status" -le 1 ] || collection_error "could not validate $label (grep exit $grep_status)"
   [ -z "$suggest" ] || hint=" (LC_ALL=C sort -o $suggest $suggest)"
   # One fault decided in one place, so a soft caller cannot inherit an arm
@@ -1027,6 +1030,10 @@ report() { # VIOLATIONS-FILE — human diagnostics on stdout
       FROZEN)
         echo "size-ratchet FAIL frozen baseline row raised: $path — row $b -> $n $unit, threshold $PT ($why); a frozen class refuses a raise whatever RATCHET_RAISE says"
         echo "  remedy: split at a concept seam (a frozen class never raises an existing row)"
+        ;;
+      MOVED)
+        echo "size-ratchet FAIL baseline moved and rewritten: $path -> $BASELINE_FILE — HEAD's rows left $path, and the rows arriving at $BASELINE_FILE are not them; across a move nothing compares them, so a raise would land unjudged"
+        echo "  remedy: move the baseline in a commit that changes nothing else, then change its rows in the next one"
         ;;
     esac
   done <"$1"
@@ -1419,200 +1426,86 @@ RAISE_OK="${RATCHET_RAISE:-}"
 # and against a zero-row HEAD every one of them would read as newly added. A
 # git failure is never "absent": read_head_file_mode refuses on one.
 HEAD_BASELINE=""
-# The path those rows came from when it is not the configured one: a change
-# that RELOCATES the baseline is judged against the rows it moved.
-HEAD_BASELINE_FROM=""
-
-# Never `$(...)`: collection_error inside a command substitution exits the
-# subshell alone, and the caller would read the refusal as "HEAD has no rows".
-read_head_rows_at() { # PATH — fills HEAD_BASELINE, "" when HEAD carries none there
+read_head_baseline() {
   HEAD_BASELINE=""
-  read_head_file_mode "$1"
+  read_head_file_mode "$BASELINE_FILE"
   [ -n "$HEAD_FILE_MODE" ] || return 0
   case "$HEAD_FILE_MODE" in
     100*) ;;
     *) return 0 ;; # not a regular file at HEAD; there is no row set to compare
   esac
-  git show "HEAD:$1" >"$TMP/baseline.head" || collection_error "could not read $1 from HEAD — refusing to judge added and raised rows against a baseline it could not read"
+  git show "HEAD:$BASELINE_FILE" >"$TMP/baseline.head" || collection_error "could not read $BASELINE_FILE from HEAD — refusing to judge added and raised rows against a baseline it could not read"
   [ "$(count_nonempty_lines "$TMP/baseline.head")" -gt 0 ] || return 0
   HEAD_BASELINE="$TMP/baseline.head"
 }
 
-# --- where HEAD's own configuration put the baseline -------------------------
-# Resolved through the SAME sr_setting chain this run used, over a scratch tree
-# holding HEAD's view of every source that chain consults, and resolved on
-# EVERY run, because which file HEAD's baseline was is the first question and
-# the rows in it the second. The tree is the whole answer: a source it does not
-# reproduce faithfully makes the HEAD-side resolution equal the run's own for a
-# reason that is not HEAD's configuration, and "HEAD has no rows" is then
-# reached without judgement, which is the defect itself. So each source kind is
-# reproduced or the run refuses; nothing falls through. What the tree must
-# hold, by the route sr_setting reaches the source:
+# --- a baseline that MOVED ---------------------------------------------------
+# The check above reads HEAD at the CONFIGURED path. Move that path and HEAD
+# carries nothing there, so the rows have no reference and every raise the
+# change makes — a frozen one included — lands unjudged.
 #
-#   set in the environment      nothing. One process answers both sides.
-#   SIZE_RATCHET_SETTINGS_FILE=/dev/null
-#                               nothing. It selects no source at all.
-#   an absolute path            nothing. The same file answers both sides.
-#   a relative path that leaves the repository
-#                               the worktree file, at its own spelling. No
-#                               commit can carry it, so it is the invocation's.
-#   a path git tracks nowhere   the worktree file. Unversioned, so the
-#                               invocation's; a commit reaches this gate
-#                               through --staged, where an added source is in
-#                               the index and the branch below governs.
-#   tracked, absent at HEAD     nothing. This change ADDS the source.
-#   a regular file at HEAD      HEAD's blob.
-#   a symlink at HEAD           HEAD's blob at the end of the chain, resolved
-#                               through HEAD, staged at the link's spelling.
-#                               sr_setting reads bytes, so a regular file
-#                               there reads identically. A chain leaving the
-#                               repository ends on an unversioned file and
-#                               takes the out-of-repository row above.
-#   anything else at HEAD       a refusal. A chain longer than HEAD_LINK_MAX,
-#                               or one ending on a directory or a gitlink, is
-#                               a configuration no tree can stand in for.
+# The gate does not follow the move. Where HEAD's baseline was is a question
+# only HEAD's settings answer, and those resolve through a chain this script
+# consults but does not own, so answering it here means keeping a second
+# implementation of someone else's contract in step with it. A move is refused
+# instead, and the rows travel in a commit that changes nothing else.
 #
-# --baseline is skipped outright: a flag is the operator pointing this run at a
-# file, never a commit relocating anything.
-HEAD_SETTINGS_BASELINE=""
-
-# The sources sr_setting consults, in the order it consults them.
-SETTINGS_SOURCES=()
-settings_sources() {
-  SETTINGS_SOURCES=()
-  [ "${SIZE_RATCHET_SETTINGS_FILE:-}" != "/dev/null" ] || return 0
-  SETTINGS_SOURCES=(".env.local")
-  if [ -n "${SIZE_RATCHET_SETTINGS_FILE:-}" ]; then
-    SETTINGS_SOURCES+=("$SIZE_RATCHET_SETTINGS_FILE")
-  else
-    SETTINGS_SOURCES+=(".kendex/settings.toml" "kendex.settings.toml")
-  fi
-}
-
-index_tracks() { # PATH — 0 when the index carries it
-  local status=0
-  git ls-files --error-unmatch -- ":(literal)$1" >/dev/null 2>&1 || status=$?
-  case "$status" in
-    0) return 0 ;;
-    1) return 1 ;;
-    *) collection_error "could not query the index for $1 (git ls-files exit $status) — refusing to judge added and raised rows without knowing whether this change adds the source" ;;
+# The discriminator is what the change does to the OLD file: a path HEAD
+# carried a row set at, which the judged snapshot no longer carries. It cannot
+# misfire on the three bootstraps. An unborn HEAD has no paths to remove. A
+# baseline this change introduces leaves HEAD carrying no row set anywhere, so
+# there is none to remove. A placeholder committed empty is AT the configured
+# path and is filled rather than removed, and holds no rows to recognize even
+# if it were. What the check does see is one bound worth stating: a change that
+# points the setting elsewhere while leaving the old file tracked, rows and
+# all, removes nothing and is not a move it can name.
+#
+# A pure move passes. The rows that arrive are byte for byte the rows that
+# left, so no row rose across it; anything else about them is the next
+# commit's business.
+baseline_moved() { # CANDIDATE-BASELINE — violations on stdout
+  [ -z "$HEAD_BASELINE" ] || return 0
+  local p head_status=0 diff_status=0
+  git rev-parse --verify --quiet HEAD >/dev/null 2>&1 || head_status=$?
+  case "$head_status" in
+    0) ;;
+    1) return 0 ;; # an unborn HEAD removed nothing
+    *) collection_error "could not resolve HEAD while looking for a moved baseline (git rev-parse exit $head_status) — refusing to treat the move as absent" ;;
   esac
-}
-
-# Eight hops is past any real settings install and short of a loop's patience.
-HEAD_LINK_MAX=8
-stage_head_blob() { # PATH DEST — HEAD's file content at PATH, chain followed
-  local path="$1" dest="$2" hops=0 target dir
-  while :; do
-    read_head_file_mode "$path"
-    case "$HEAD_FILE_MODE" in
-      "") return 0 ;; # HEAD carries no such source
-      100*) break ;;
-      120000)
-        hops=$((hops + 1))
-        [ "$hops" -le "$HEAD_LINK_MAX" ] || collection_error "the settings source '$1' is a symlink chain longer than $HEAD_LINK_MAX hops at HEAD — refusing to judge added and raised rows against a configuration it cannot follow"
-        git show "HEAD:$path" >"$TMP/head.link" || collection_error "could not read the symlink '$path' from HEAD to follow the settings source it points at"
-        target="$(cat -- "$TMP/head.link")" || collection_error "could not read the target of the symlink '$path' at HEAD"
-        # A chain that leaves the repository ends on an unversioned file, which
-        # both sides read the same way, so it is copied from where it is rather
-        # than refused. The link is resolved from the repository root, which is
-        # this run's working directory.
-        case "$target" in
-          /*)
-            [ ! -f "$target" ] || cp -- "$target" "$dest" || collection_error "could not stage the out-of-repository file '$target' that the settings source '$1' points at"
-            return 0
-            ;;
-        esac
-        dir="${path%/*}"
-        [ "$dir" != "$path" ] || dir=""
-        path="$(sr_settings_normalize_path "${dir:+$dir/}$target")"
-        case "$path" in
-          "" | ".." | "../"*)
-            [ ! -f "$path" ] || cp -- "$path" "$dest" || collection_error "could not stage the out-of-repository file '$path' that the settings source '$1' points at"
-            return 0
-            ;;
-        esac
-        ;;
-      *) collection_error "the settings source '$1' is not a regular file at HEAD (mode $HEAD_FILE_MODE) — refusing to judge added and raised rows against a configuration it cannot read" ;;
-    esac
-  done
-  git show "HEAD:$path" >"$dest" || collection_error "could not read $path from HEAD to resolve the baseline path it configures"
-}
-
-read_head_settings_baseline() { # — "" when HEAD names no usable path
-  HEAD_SETTINGS_BASELINE=""
-  [ "$BASELINE_SET" -eq 0 ] || return 0
-  local dir="$TMP/head-settings" cwd src norm dest parent depth d
-  rm -rf -- "$dir" || collection_error "could not clear the scratch copy of HEAD's settings"
-  settings_sources
-  # A source spelled with a leading `..` still has to land inside the tree, so
-  # the resolution runs from a directory nested as deep as the deepest such
-  # spelling. Counting every `..` segment overshoots, which costs an unused
-  # directory and can never come up short.
-  depth=0
-  for src in ${SETTINGS_SOURCES+"${SETTINGS_SOURCES[@]}"}; do
-    d="$(printf '%s\n' "$src" | awk -F'/' '{ n = 0; for (i = 1; i <= NF; i++) if ($i == "..") n++; print n }')" \
-      || collection_error "could not measure the depth of the settings source '$src'"
-    [ "$d" -le "$depth" ] || depth="$d"
-  done
-  cwd="$dir"
-  while [ "$depth" -gt 0 ]; do
-    cwd="$cwd/nested"
-    depth=$((depth - 1))
-  done
-  mkdir -p -- "$cwd" || collection_error "could not create a scratch copy of HEAD's settings"
-  for src in ${SETTINGS_SOURCES+"${SETTINGS_SOURCES[@]}"}; do
-    case "$src" in /*) continue ;; esac
-    dest="$cwd/$src"
-    parent="$cwd/${src%/*}"
-    [ "${src%/*}" != "$src" ] || parent="$cwd"
-    mkdir -p -- "$parent" || collection_error "could not stage the directory for HEAD's copy of $src"
-    # git reads a tree path canonically — `sub/../f` names `f` — so every
-    # probe and read takes the NORMALIZED spelling, while the copy is written
-    # under the spelling the resolver will look for.
-    norm="$(sr_settings_normalize_path "$src")"
-    case "$norm" in
-      "" | ".." | "../"*)
-        [ ! -f "$src" ] || cp -- "$src" "$dest" || collection_error "could not stage the out-of-repository settings source $src"
-        continue
-        ;;
-    esac
-    read_head_file_mode "$norm"
-    if [ -n "$HEAD_FILE_MODE" ]; then
-      stage_head_blob "$norm" "$dest"
-    elif ! index_tracks "$norm"; then
-      [ ! -f "$src" ] || cp -- "$src" "$dest" || collection_error "could not stage the untracked settings source $src"
-    fi
-  done
-  # sr_setting reads its sources relative to the working directory and returns
-  # nonzero (never exits) on an unreadable one, so the tree answers from $cwd
-  # and a refusal propagates instead of resolving to a default.
-  HEAD_SETTINGS_BASELINE="$(cd "$cwd" && SR_SETTINGS_FROM_INDEX=0 sr_setting SIZE_RATCHET_BASELINE "tools/size-ratchet-baseline.tsv")" \
-    || collection_error "could not resolve SIZE_RATCHET_BASELINE from HEAD's settings — refusing to judge added and raised rows without knowing where HEAD's baseline was"
-  HEAD_SETTINGS_BASELINE="$(normalize_rel_path "$HEAD_SETTINGS_BASELINE")" || HEAD_SETTINGS_BASELINE=""
-  # A shape the configured path itself would be refused for names no row set
-  # to read; the run's own resolution already rejected it for this side.
-  case "$HEAD_SETTINGS_BASELINE" in /* | -*) HEAD_SETTINGS_BASELINE="" ;; esac
-}
-
-# WHICH PATH first, then the rows at it. Reading the configured path and
-# keeping whatever rows it holds accepts a file HEAD's own configuration never
-# read: a repository carrying a stale b.tsv at 20 while its settings named
-# a.tsv at 15 had the 20 taken for grandfathered, and the raise to 20 was never
-# judged. HEAD's effective baseline is the file HEAD's settings pointed at, and
-# no rows there is HEAD having no reference — not a reason to read another
-# file. The three bootstraps are unaffected: each leaves HEAD naming the path
-# this run resolved, or one HEAD carries no rows at.
-read_head_baseline() {
-  HEAD_BASELINE_FROM=""
-  local path="$BASELINE_FILE"
-  read_head_settings_baseline
-  if [ -n "$HEAD_SETTINGS_BASELINE" ] && [ "$HEAD_SETTINGS_BASELINE" != "$BASELINE_FILE" ]; then
-    path="$HEAD_SETTINGS_BASELINE"
-    HEAD_BASELINE_FROM="$path"
+  # --no-renames, because a `git mv` of the baseline is exactly the move this
+  # looks for and rename detection would report it as one path, not a removal.
+  if [ "$STAGED" -eq 1 ]; then
+    git diff --cached --no-renames --name-only --diff-filter=D HEAD >"$TMP/removed.tsv" || diff_status=$?
+  else
+    git diff --no-renames --name-only --diff-filter=D HEAD >"$TMP/removed.tsv" || diff_status=$?
   fi
-  read_head_rows_at "$path"
-  [ -n "$HEAD_BASELINE" ] || HEAD_BASELINE_FROM=""
+  [ "$diff_status" -eq 0 ] || collection_error "could not list what this change removes (git diff exit $diff_status) — refusing to treat a moved baseline as absent"
+  while IFS= read -r p || [ -n "$p" ]; do
+    [ -n "$p" ] || continue
+    [ "$p" != "$BASELINE_FILE" ] || continue
+    head_rows_removed "$p" || continue
+    cmp -s -- "$TMP/removed.head" "$1" && continue
+    # "-" placeholders, never empty fields: report() reads these rows with
+    # tab-IFS, and whitespace IFS collapses consecutive tabs.
+    printf '%s\t%s\t%s\t%s\n' "MOVED" "$p" "-" "-"
+  done <"$TMP/removed.tsv"
+}
+
+# Whether HEAD's blob at PATH was a baseline. The row shape is the only
+# question — sorting and duplicates are the governing copy's business, and a
+# file that fails them is still the row set this change carried away.
+head_rows_removed() { # PATH — 0 when HEAD held a row set there, at $TMP/removed.head
+  local status=0
+  read_head_file_mode "$1"
+  case "$HEAD_FILE_MODE" in 100*) ;; *) return 1 ;; esac
+  git show "HEAD:$1" >"$TMP/removed.head" || collection_error "could not read $1 from HEAD to tell whether it was the baseline this change moved"
+  [ "$(count_nonempty_lines "$TMP/removed.head")" -gt 0 ] || return 1
+  grep -qEv -- "$BASELINE_ROW_RE" "$TMP/removed.head" || status=$?
+  case "$status" in
+    0) return 1 ;; # a line that is not a row: whatever left, it was not a baseline
+    1) return 0 ;;
+    *) collection_error "could not read $1 from HEAD to tell whether it was the baseline this change moved (grep exit $status)" ;;
+  esac
 }
 
 # A change that moves a class from lines to bytes (or back) leaves HEAD's rows
@@ -1695,6 +1588,7 @@ rows_raised() { # CURRENT-BASELINE — violations on stdout
 run_verdict() { # BASELINE-TSV — fills $TMP/violations.tsv, sets VIOLATIONS
   evaluate "$1" >"$TMP/violations.tsv" || collection_error "could not evaluate the baseline against the collected counts"
   rows_raised "$1" >>"$TMP/violations.tsv" || collection_error "could not judge the baseline rows against HEAD's baseline"
+  baseline_moved "$1" >>"$TMP/violations.tsv" || collection_error "could not tell whether this change moves the baseline"
   VIOLATIONS="$(count_nonempty_lines "$TMP/violations.tsv")"
 }
 
@@ -1771,11 +1665,7 @@ report "$TMP/violations.tsv" || collection_error "could not read the violations 
 # "no reference" is not "checked and clean": a run whose HEAD carries no rows
 # never judged an added or raised one, and says which of the two it is.
 RAISE_NOTE=""
-if [ -z "$HEAD_BASELINE" ]; then
-  RAISE_NOTE=" — HEAD carries no baseline rows, so added and raised rows were not judged"
-elif [ -n "$HEAD_BASELINE_FROM" ]; then
-  RAISE_NOTE=" — added and raised rows judged against HEAD's baseline at $HEAD_BASELINE_FROM, which this change relocates"
-fi
+[ -n "$HEAD_BASELINE" ] || RAISE_NOTE=" — HEAD carries no baseline rows, so added and raised rows were not judged"
 if [ "$VIOLATIONS" -gt 0 ]; then
   echo "size-ratchet: $VIOLATIONS violation(s) — threshold $THRESHOLD$CLASSES_NOTE, baseline $BASELINE_FILE$RAISE_NOTE"
   exit 1

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -1538,6 +1538,11 @@ snapshot_rows_at() { # PATH — 0 when the snapshot still holds a row set there
     case "$INDEX_FILE_MODE" in 100*) ;; *) return 1 ;; esac
     git show ":$1" >"$TMP/removed.now" || collection_error "could not read the staged copy of $1 to tell whether it still holds baseline rows"
   else
+    # -L before -f, which follows. A symlink is not the row set that was
+    # there, whatever it points at — and pointing it at the NEW baseline is
+    # exactly how a move made the old path look untouched. The index side
+    # never had this: it reads mode 120000 and answers no already.
+    [ ! -L "$1" ] || return 1
     [ -f "$1" ] || return 1
     cp -- "$1" "$TMP/removed.now" || collection_error "could not copy $1 to tell whether it still holds baseline rows"
   fi

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -1440,12 +1440,14 @@ read_head_rows_at() { # PATH — fills HEAD_BASELINE, "" when HEAD carries none 
 
 # --- where HEAD's own configuration put the baseline -------------------------
 # Resolved through the SAME sr_setting chain this run used, over a scratch tree
-# holding HEAD's view of every source that chain consults. The tree is the
-# whole answer: a source it does not reproduce faithfully makes the HEAD-side
-# resolution equal the run's own for a reason that is not HEAD's configuration,
-# and "HEAD has no rows" is then reached without judgement, which is the defect
-# itself. So each source kind is reproduced or the run refuses; nothing falls
-# through. What the tree must hold, by the route sr_setting reaches the source:
+# holding HEAD's view of every source that chain consults, and resolved on
+# EVERY run, because which file HEAD's baseline was is the first question and
+# the rows in it the second. The tree is the whole answer: a source it does not
+# reproduce faithfully makes the HEAD-side resolution equal the run's own for a
+# reason that is not HEAD's configuration, and "HEAD has no rows" is then
+# reached without judgement, which is the defect itself. So each source kind is
+# reproduced or the run refuses; nothing falls through. What the tree must
+# hold, by the route sr_setting reaches the source:
 #
 #   set in the environment      nothing. One process answers both sides.
 #   SIZE_RATCHET_SETTINGS_FILE=/dev/null
@@ -1463,11 +1465,12 @@ read_head_rows_at() { # PATH — fills HEAD_BASELINE, "" when HEAD carries none 
 #   a symlink at HEAD           HEAD's blob at the end of the chain, resolved
 #                               through HEAD, staged at the link's spelling.
 #                               sr_setting reads bytes, so a regular file
-#                               there reads identically.
-#   anything else at HEAD       a refusal. A chain that leaves the repository,
-#                               loops, or ends on a directory or a gitlink is
-#                               not reproducible, and neither is an absolute
-#                               link target.
+#                               there reads identically. A chain leaving the
+#                               repository ends on an unversioned file and
+#                               takes the out-of-repository row above.
+#   anything else at HEAD       a refusal. A chain longer than HEAD_LINK_MAX,
+#                               or one ending on a directory or a gitlink, is
+#                               a configuration no tree can stand in for.
 #
 # --baseline is skipped outright: a flag is the operator pointing this run at a
 # file, never a commit relocating anything.
@@ -1510,12 +1513,24 @@ stage_head_blob() { # PATH DEST — HEAD's file content at PATH, chain followed
         [ "$hops" -le "$HEAD_LINK_MAX" ] || collection_error "the settings source '$1' is a symlink chain longer than $HEAD_LINK_MAX hops at HEAD — refusing to judge added and raised rows against a configuration it cannot follow"
         git show "HEAD:$path" >"$TMP/head.link" || collection_error "could not read the symlink '$path' from HEAD to follow the settings source it points at"
         target="$(cat -- "$TMP/head.link")" || collection_error "could not read the target of the symlink '$path' at HEAD"
-        case "$target" in /*) collection_error "the settings source '$1' resolves through an absolute symlink at HEAD, which the scratch tree cannot reproduce — refusing to judge added and raised rows against a configuration it cannot read" ;; esac
+        # A chain that leaves the repository ends on an unversioned file, which
+        # both sides read the same way, so it is copied from where it is rather
+        # than refused. The link is resolved from the repository root, which is
+        # this run's working directory.
+        case "$target" in
+          /*)
+            [ ! -f "$target" ] || cp -- "$target" "$dest" || collection_error "could not stage the out-of-repository file '$target' that the settings source '$1' points at"
+            return 0
+            ;;
+        esac
         dir="${path%/*}"
         [ "$dir" != "$path" ] || dir=""
         path="$(sr_settings_normalize_path "${dir:+$dir/}$target")"
         case "$path" in
-          "" | ".." | "../"*) collection_error "the settings source '$1' resolves outside the repository at HEAD, which the scratch tree cannot reproduce — refusing to judge added and raised rows against a configuration it cannot read" ;;
+          "" | ".." | "../"*)
+            [ ! -f "$path" ] || cp -- "$path" "$dest" || collection_error "could not stage the out-of-repository file '$path' that the settings source '$1' points at"
+            return 0
+            ;;
         esac
         ;;
       *) collection_error "the settings source '$1' is not a regular file at HEAD (mode $HEAD_FILE_MODE) — refusing to judge added and raised rows against a configuration it cannot read" ;;
@@ -1580,23 +1595,24 @@ read_head_settings_baseline() { # — "" when HEAD names no usable path
   case "$HEAD_SETTINGS_BASELINE" in /* | -*) HEAD_SETTINGS_BASELINE="" ;; esac
 }
 
+# WHICH PATH first, then the rows at it. Reading the configured path and
+# keeping whatever rows it holds accepts a file HEAD's own configuration never
+# read: a repository carrying a stale b.tsv at 20 while its settings named
+# a.tsv at 15 had the 20 taken for grandfathered, and the raise to 20 was never
+# judged. HEAD's effective baseline is the file HEAD's settings pointed at, and
+# no rows there is HEAD having no reference — not a reason to read another
+# file. The three bootstraps are unaffected: each leaves HEAD naming the path
+# this run resolved, or one HEAD carries no rows at.
 read_head_baseline() {
   HEAD_BASELINE_FROM=""
-  read_head_rows_at "$BASELINE_FILE"
-  [ -z "$HEAD_BASELINE" ] || return 0
-  # No rows at the configured path is either of two things, and they must not
-  # be answered alike: HEAD had no row set anywhere (the three bootstraps),
-  # or this change MOVES the path and HEAD's rows sit at the old one, where
-  # skipping the judgment would carry a raise — a frozen one included — past
-  # a gate that never ran. HEAD's own settings say which, and they cannot
-  # misfire on a bootstrap: each of the three leaves HEAD naming the same
-  # path this run resolved, or a path HEAD carries no rows at, so the rows
-  # stay empty and the verdict says so exactly as before.
+  local path="$BASELINE_FILE"
   read_head_settings_baseline
-  [ -n "$HEAD_SETTINGS_BASELINE" ] || return 0
-  [ "$HEAD_SETTINGS_BASELINE" != "$BASELINE_FILE" ] || return 0
-  read_head_rows_at "$HEAD_SETTINGS_BASELINE"
-  [ -z "$HEAD_BASELINE" ] || HEAD_BASELINE_FROM="$HEAD_SETTINGS_BASELINE"
+  if [ -n "$HEAD_SETTINGS_BASELINE" ] && [ "$HEAD_SETTINGS_BASELINE" != "$BASELINE_FILE" ]; then
+    path="$HEAD_SETTINGS_BASELINE"
+    HEAD_BASELINE_FROM="$path"
+  fi
+  read_head_rows_at "$path"
+  [ -n "$HEAD_BASELINE" ] || HEAD_BASELINE_FROM=""
 }
 
 # A change that moves a class from lines to bytes (or back) leaves HEAD's rows

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -1474,13 +1474,18 @@ baseline_moved() { # CANDIDATE-BASELINE — violations on stdout
   esac
   # --no-renames, because a `git mv` of the baseline is exactly the move this
   # looks for and rename detection would report it as one path, not a removal.
+  # -z, because core.quotePath spells a non-ASCII path C-quoted by default:
+  # `"tools/\303\251.tsv"` never matches a literal probe, and the removed
+  # baseline would read as absent. It also terminates each path with a NUL,
+  # which is the one byte a path cannot contain — a newline can, so the read
+  # below splits on NUL rather than translating NULs into newlines.
   if [ "$STAGED" -eq 1 ]; then
-    git diff --cached --no-renames --name-only --diff-filter=D HEAD >"$TMP/removed.tsv" || diff_status=$?
+    git diff --cached --no-renames -z --name-only --diff-filter=D HEAD >"$TMP/removed.paths" || diff_status=$?
   else
-    git diff --no-renames --name-only --diff-filter=D HEAD >"$TMP/removed.tsv" || diff_status=$?
+    git diff --no-renames -z --name-only --diff-filter=D HEAD >"$TMP/removed.paths" || diff_status=$?
   fi
   [ "$diff_status" -eq 0 ] || collection_error "could not list what this change removes (git diff exit $diff_status) — refusing to treat a moved baseline as absent"
-  while IFS= read -r p || [ -n "$p" ]; do
+  while IFS= read -r -d '' p || [ -n "$p" ]; do
     [ -n "$p" ] || continue
     [ "$p" != "$BASELINE_FILE" ] || continue
     head_rows_removed "$p" || continue
@@ -1488,7 +1493,7 @@ baseline_moved() { # CANDIDATE-BASELINE — violations on stdout
     # "-" placeholders, never empty fields: report() reads these rows with
     # tab-IFS, and whitespace IFS collapses consecutive tabs.
     printf '%s\t%s\t%s\t%s\n' "MOVED" "$p" "-" "-"
-  done <"$TMP/removed.tsv"
+  done <"$TMP/removed.paths"
 }
 
 # Whether HEAD's blob at PATH was a baseline. The row shape is the only

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -19,6 +19,9 @@
 #       path HEAD's baseline carries none for is a bootstrap, which
 #       RATCHET_RAISE=1 admits in every class, frozen included; a renamed
 #       path is such a path, so a rename bootstraps rather than raises.
+#       A change that MOVES the baseline itself is judged against the rows
+#       at the path HEAD's own settings named, so a relocation carries no
+#       row past this check.
 #
 # --update: rewrite the baseline TIGHTENING ONLY — lower rows to current
 # reality, re-measure rows whose unit no longer matches their class, remove
@@ -153,6 +156,11 @@ admits one in every class — a renamed path is such a path, so a rename
 bootstraps rather than raises. No commit message is read: a pre-commit hook
 cannot see one, so the reason belongs in the commit body for review, not in
 a check.
+
+A commit that MOVES SIZE_RATCHET_BASELINE is judged against HEAD's rows at
+the path HEAD's own settings named: the versioned settings come from HEAD,
+the environment and .env.local from the invocation, and --baseline skips the
+lookup as the operator override it is.
 
 A run whose HEAD carries no baseline rows has no reference for the added and
 raised checks, so the verdict line says so rather than reading as clean.
@@ -1410,17 +1418,100 @@ RAISE_OK="${RATCHET_RAISE:-}"
 # and against a zero-row HEAD every one of them would read as newly added. A
 # git failure is never "absent": read_head_file_mode refuses on one.
 HEAD_BASELINE=""
-read_head_baseline() {
+# The path those rows came from when it is not the configured one: a change
+# that RELOCATES the baseline is judged against the rows it moved.
+HEAD_BASELINE_FROM=""
+
+# Never `$(...)`: collection_error inside a command substitution exits the
+# subshell alone, and the caller would read the refusal as "HEAD has no rows".
+read_head_rows_at() { # PATH — fills HEAD_BASELINE, "" when HEAD carries none there
   HEAD_BASELINE=""
-  read_head_file_mode "$BASELINE_FILE"
+  read_head_file_mode "$1"
   [ -n "$HEAD_FILE_MODE" ] || return 0
   case "$HEAD_FILE_MODE" in
     100*) ;;
     *) return 0 ;; # not a regular file at HEAD; there is no row set to compare
   esac
-  git show "HEAD:$BASELINE_FILE" >"$TMP/baseline.head" || collection_error "could not read $BASELINE_FILE from HEAD — refusing to judge added and raised rows against a baseline it could not read"
+  git show "HEAD:$1" >"$TMP/baseline.head" || collection_error "could not read $1 from HEAD — refusing to judge added and raised rows against a baseline it could not read"
   [ "$(count_nonempty_lines "$TMP/baseline.head")" -gt 0 ] || return 0
   HEAD_BASELINE="$TMP/baseline.head"
+}
+
+# Where HEAD's own configuration put the baseline. Resolved through the SAME
+# sr_setting chain this run used, with only the VERSIONED layer — the settings
+# TOML — taken from HEAD. The environment and .env.local are the invocation's,
+# not the commit's: they are identical on both sides by construction, so the
+# two resolutions differ exactly when the change under judgement moves the
+# path. --baseline is skipped outright for the same reason — a flag is the
+# operator pointing this run at a file, never a commit relocating anything.
+HEAD_SETTINGS_BASELINE=""
+read_head_settings_baseline() { # — "" when it names no usable path
+  HEAD_SETTINGS_BASELINE=""
+  [ "$BASELINE_SET" -eq 0 ] || return 0
+  local dir="$TMP/head-settings" src norm parent
+  rm -rf -- "$dir" || collection_error "could not clear the scratch copy of HEAD's settings"
+  mkdir -p -- "$dir" || collection_error "could not create a scratch copy of HEAD's settings"
+  if [ "${SIZE_RATCHET_SETTINGS_FILE:-}" = "/dev/null" ]; then
+    set --
+  elif [ -n "${SIZE_RATCHET_SETTINGS_FILE:-}" ]; then
+    set -- "$SIZE_RATCHET_SETTINGS_FILE"
+  else
+    set -- ".kendex/settings.toml" "kendex.settings.toml"
+  fi
+  for src in "$@"; do
+    # An absolute source lives outside the repository: HEAD carries no copy of
+    # it, and both resolutions read the one file that is there.
+    case "$src" in /*) continue ;; esac
+    # git reads a tree path canonically — `sub/../f` names `f` — so the probe
+    # and the read take the NORMALIZED spelling, while the copy is written
+    # under the spelling the resolver will look for.
+    norm="$(sr_settings_normalize_path "$src")"
+    case "$norm" in
+      "" | ".." | "../"*)
+        # A relative source that leaves the repository is read from the
+        # worktree by both resolutions, but the scratch directory this one
+        # runs in cannot reach it — so HEAD names no path rather than a
+        # wrong one.
+        HEAD_SETTINGS_BASELINE=""
+        return 0
+        ;;
+    esac
+    read_head_file_mode "$norm"
+    case "$HEAD_FILE_MODE" in 100*) ;; *) continue ;; esac
+    parent="$dir/${src%/*}"
+    [ "${src%/*}" != "$src" ] || parent="$dir"
+    mkdir -p -- "$parent" || collection_error "could not stage the directory for HEAD's copy of $src"
+    git show "HEAD:$norm" >"$dir/$src" || collection_error "could not read $src from HEAD to resolve the baseline path it configures"
+  done
+  [ ! -f .env.local ] || cp -- .env.local "$dir/.env.local" || collection_error "could not stage .env.local beside HEAD's settings"
+  # sr_setting reads its sources relative to the working directory and returns
+  # nonzero (never exits) on an unreadable one, so the copies answer from
+  # $dir and a refusal propagates instead of resolving to a default.
+  HEAD_SETTINGS_BASELINE="$(cd "$dir" && SR_SETTINGS_FROM_INDEX=0 sr_setting SIZE_RATCHET_BASELINE "tools/size-ratchet-baseline.tsv")" \
+    || collection_error "could not resolve SIZE_RATCHET_BASELINE from HEAD's settings — refusing to judge added and raised rows without knowing where HEAD's baseline was"
+  HEAD_SETTINGS_BASELINE="$(normalize_rel_path "$HEAD_SETTINGS_BASELINE")" || HEAD_SETTINGS_BASELINE=""
+  # A shape the configured path itself would be refused for names no row set
+  # to read; the run's own resolution already rejected it for this side.
+  case "$HEAD_SETTINGS_BASELINE" in /* | -*) HEAD_SETTINGS_BASELINE="" ;; esac
+}
+
+read_head_baseline() {
+  HEAD_BASELINE_FROM=""
+  read_head_rows_at "$BASELINE_FILE"
+  [ -z "$HEAD_BASELINE" ] || return 0
+  # No rows at the configured path is either of two things, and they must not
+  # be answered alike: HEAD had no row set anywhere (the three bootstraps),
+  # or this change MOVES the path and HEAD's rows sit at the old one, where
+  # skipping the judgment would carry a raise — a frozen one included — past
+  # a gate that never ran. HEAD's own settings say which, and they cannot
+  # misfire on a bootstrap: each of the three leaves HEAD naming the same
+  # path this run resolved, or a path HEAD carries no rows at, so the rows
+  # stay empty and the verdict says so exactly as before.
+  read_head_settings_baseline
+  [ -n "$HEAD_SETTINGS_BASELINE" ] || return 0
+  [ "$HEAD_SETTINGS_BASELINE" != "$BASELINE_FILE" ] || return 0
+  read_head_rows_at "$HEAD_SETTINGS_BASELINE"
+  [ -z "$HEAD_BASELINE" ] || HEAD_BASELINE_FROM="$HEAD_SETTINGS_BASELINE"
 }
 
 # A change that moves a class from lines to bytes (or back) leaves HEAD's rows
@@ -1579,7 +1670,11 @@ report "$TMP/violations.tsv" || collection_error "could not read the violations 
 # "no reference" is not "checked and clean": a run whose HEAD carries no rows
 # never judged an added or raised one, and says which of the two it is.
 RAISE_NOTE=""
-[ -n "$HEAD_BASELINE" ] || RAISE_NOTE=" — HEAD carries no baseline rows, so added and raised rows were not judged"
+if [ -z "$HEAD_BASELINE" ]; then
+  RAISE_NOTE=" — HEAD carries no baseline rows, so added and raised rows were not judged"
+elif [ -n "$HEAD_BASELINE_FROM" ]; then
+  RAISE_NOTE=" — added and raised rows judged against HEAD's baseline at $HEAD_BASELINE_FROM, which this change relocates"
+fi
 if [ "$VIOLATIONS" -gt 0 ]; then
   echo "size-ratchet: $VIOLATIONS violation(s) — threshold $THRESHOLD$CLASSES_NOTE, baseline $BASELINE_FILE$RAISE_NOTE"
   exit 1

--- a/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -440,6 +440,44 @@ RAISE=1 run_frozen --staged
 [ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten: tools/a.tsv -> tools/b.tsv"*) true ;; *) false ;; esac \
   && ok "the staged lane refuses the same move" \
   || bad "the staged lane refuses the same move" "rc=$RC out=$OUT"
+# git spells a non-ASCII path C-quoted by default, so a listing read as text
+# hands the probe `"tools/\303\251.tsv"` and the moved baseline reads as absent.
+new_repo relocquoted
+mkdir -p "$R/tools"
+mkfile x.test.txt 15
+printf 'x.test.txt\t15\n' >"$R/tools/é.tsv"
+settings_baseline "tools/é.tsv"
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: a baseline at a path git would quote"
+mkfile x.test.txt 20
+printf 'x.test.txt\t20\n' >"$R/tools/b.tsv"
+rm -f "$R/tools/é.tsv"
+settings_baseline tools/b.tsv
+git -C "$R" add -A
+RAISE=1 run_frozen --staged
+[ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten: tools/é.tsv -> tools/b.tsv"*) true ;; *) false ;; esac \
+  && ok "a baseline at a path git quotes is still seen leaving" \
+  || bad "a baseline at a path git quotes is seen leaving" "rc=$RC out=$OUT"
+# The sharper shape: a path may hold a NEWLINE, which is what a listing split on
+# newlines — or one translating NULs into them — turns into two paths that HEAD
+# carries no row set at. Only NUL delimits a path safely.
+new_repo relocnewline
+mkdir -p "$R/tools"
+mkfile x.test.txt 15
+NLPATH="$(printf 'tools/a\nb.tsv')"
+printf 'x.test.txt\t15\n' >"$R/$NLPATH"
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: a row set at a path holding a newline"
+mkfile x.test.txt 20
+printf 'x.test.txt\t20\n' >"$R/tools/b.tsv"
+rm -f "$R/$NLPATH"
+settings_baseline tools/b.tsv
+git -C "$R" add -A
+RAISE=1 run_frozen
+[ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten"*"-> tools/b.tsv"*) true ;; *) false ;; esac \
+  && ok "a baseline at a path holding a newline is still seen leaving" \
+  || bad "a baseline at a path holding a newline is seen leaving" "rc=$RC out=$OUT"
+
 # A removed file that is not a row set is not a moved baseline: the check reads
 # the row shape, so an ordinary deletion beside a first baseline stays a
 # bootstrap.

--- a/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -477,6 +477,37 @@ RAISE=1 run_frozen --staged
 [ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten: tools/a.tsv -> tools/b.tsv"*) true ;; *) false ;; esac \
   && ok "emptying the old baseline in place is a move, not a modification to ignore" \
   || bad "emptying the old baseline in place is a move" "rc=$RC out=$OUT"
+# Replacing the old baseline with a symlink to the NEW one leaves a path that
+# reads through as rows, which is how the move looked untouched. A symlink is
+# not the row set that was there, whatever it points at. Both modes are run on
+# one tree, because the defect was that they disagreed: the index records mode
+# 120000 and answered no already, the worktree followed the link.
+new_repo relocsymlinkover
+mkdir -p "$R/tools"
+mkfile x.test.txt 15
+printf 'x.test.txt\t15\n' >"$R/tools/a.tsv"
+settings_baseline tools/a.tsv
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: the baseline at tools/a.tsv"
+mkfile x.test.txt 20
+printf 'x.test.txt\t20\n' >"$R/tools/b.tsv"
+rm -f "$R/tools/a.tsv"
+ln -s b.tsv "$R/tools/a.tsv"
+settings_baseline tools/b.tsv
+git -C "$R" add -A
+RAISE=1 run_frozen
+WORKTREE_RC="$RC"
+[ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten: tools/a.tsv -> tools/b.tsv"*) true ;; *) false ;; esac \
+  && ok "a symlink over the old baseline is not the row set that was there" \
+  || bad "a symlink over the old baseline is not the row set that was there" "rc=$RC out=$OUT"
+RAISE=1 run_frozen --staged
+[ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten: tools/a.tsv -> tools/b.tsv"*) true ;; *) false ;; esac \
+  && ok "and the staged lane says the same of the same tree" \
+  || bad "the staged lane refuses the symlinked move" "rc=$RC out=$OUT"
+[ "$WORKTREE_RC" -eq "$RC" ] \
+  && ok "control: the two modes agree on that tree, which is the whole finding" \
+  || bad "the two modes agree on the symlinked move" "worktree=$WORKTREE_RC staged=$RC"
+
 # …and the predicate that keeps the wider list honest: a row-shaped file whose
 # numbers move is still a row set, so an ordinary edit of one is not a move.
 new_repo rowshapededit

--- a/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -452,5 +452,90 @@ run_frozen
   || bad "an empty HEAD baseline is no row set across a relocation" "rc=$RC out=$OUT"
 case "$OUT" in *"HEAD carries no baseline rows, so added and raised rows were not judged"*) ok "and a bootstrap still says the check had no reference" ;; *) bad "a bootstrap still reports that nothing was judged" "$OUT" ;; esac
 
+echo "=== every source kind that lookup reads is reproduced from HEAD, or refused ==="
+# A source the scratch tree does not reproduce faithfully makes the HEAD-side
+# resolution equal the run's own for a reason that is not HEAD's configuration,
+# and the raise gate is skipped again. One case per source kind.
+
+# .env.local is the invocation's only while it is UNTRACKED. Versioned it is
+# the commit's, and under --staged the run reads it from the index while HEAD's
+# copy is what the raise gate has to compare against.
+new_repo dotenvtracked
+mkdir -p "$R/tools"
+mkfile x.test.txt 15
+printf 'x.test.txt\t15\n' >"$R/tools/a.tsv"
+printf 'SIZE_RATCHET_BASELINE=tools/a.tsv\n' >"$R/.env.local"
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: the baseline path in a tracked .env.local"
+mkfile x.test.txt 20
+printf 'SIZE_RATCHET_BASELINE=tools/b.tsv\n' >"$R/.env.local"
+relocate x.test.txt 20
+RAISE=1 run_frozen --staged
+[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: x.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
+  && ok "a tracked .env.local moving the path is the commit's, and the raise is refused" \
+  || bad "a tracked .env.local moving the path is judged" "rc=$RC out=$OUT"
+
+# A tracked symlink is a supported install shape, and the link staying put
+# while its TARGET moves the path is the same relocation one indirection down.
+new_repo symlinktarget
+mkdir -p "$R/tools"
+mkfile y.test.txt 15
+printf 'y.test.txt\t15\n' >"$R/tools/a.tsv"
+printf '[env]\nSIZE_RATCHET_BASELINE = "tools/a.tsv"\n' >"$R/real.settings.toml"
+ln -s real.settings.toml "$R/kendex.settings.toml"
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: the settings file reached through a tracked symlink"
+mkfile y.test.txt 20
+printf '[env]\nSIZE_RATCHET_BASELINE = "tools/b.tsv"\n' >"$R/real.settings.toml"
+relocate y.test.txt 20
+RAISE=1 run_frozen
+[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: y.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
+  && ok "a symlinked settings source is followed through HEAD, so its target's move is judged" \
+  || bad "a symlinked settings source is followed through HEAD" "rc=$RC out=$OUT"
+
+# A settings file this change ADDS is one HEAD never had: HEAD's baseline is
+# wherever its own configuration left it, which here is the built-in default.
+new_repo settingsadded
+mkdir -p "$R/tools"
+mkfile z.test.txt 15
+printf 'z.test.txt\t15\n' >"$R/$BASE"
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: rows at the default path, no settings file"
+mkfile z.test.txt 20
+printf 'z.test.txt\t20\n' >"$R/tools/b.tsv"
+rm -f "$R/$BASE"
+settings_baseline tools/b.tsv
+git -C "$R" add -A
+RAISE=1 run_frozen
+[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: z.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
+  && ok "a settings file this change adds leaves HEAD on its own default, and the raise is refused" \
+  || bad "a settings file this change adds leaves HEAD on its own default" "rc=$RC out=$OUT"
+# The control that tracking is what decides: the SAME move, from a settings
+# file git carries nowhere, is the invocation's and reads the same on both
+# sides, so there is no reference and the run says so.
+git -C "$R" rm --cached -q kendex.settings.toml
+run_frozen
+[ "$RC" -eq 0 ] && case "$OUT" in *"HEAD carries no baseline rows"*) true ;; *) false ;; esac \
+  && ok "control: an untracked settings file is the invocation's, on both sides" \
+  || bad "control: an untracked settings file is the invocation's" "rc=$RC out=$OUT"
+
+# What the tree cannot reproduce refuses rather than falling through to the
+# empty answer, which is the state this whole lookup exists to stop reaching
+# without judgement.
+printf '[env]\nSIZE_RATCHET_BASELINE = "tools/b.tsv"\n' >"$TMP/outside.settings.toml"
+new_repo settingsescape
+mkdir -p "$R/tools"
+mkfile q.test.txt 15
+printf 'q.test.txt\t15\n' >"$R/tools/a.tsv"
+ln -s ../outside.settings.toml "$R/kendex.settings.toml"
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: a settings symlink leaving the repository"
+mkfile q.test.txt 20
+relocate q.test.txt 20
+run_frozen
+[ "$RC" -eq 2 ] && case "$OUT" in *"resolves outside the repository at HEAD"*) true ;; *) false ;; esac \
+  && ok "a settings symlink leaving the repository at HEAD is a loud exit 2" \
+  || bad "a settings symlink leaving the repository at HEAD is exit 2" "rc=$RC out=$OUT"
+
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -440,6 +440,58 @@ RAISE=1 run_frozen --staged
 [ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten: tools/a.tsv -> tools/b.tsv"*) true ;; *) false ;; esac \
   && ok "the staged lane refuses the same move" \
   || bad "the staged lane refuses the same move" "rc=$RC out=$OUT"
+# Rows at the destination are not proof they were the baseline HEAD used. A
+# b.tsv that already existed carries its own, and comparing against those is
+# how a raise reads as grandfathered while HEAD's real row said 15.
+new_repo relocpreexisting
+mkdir -p "$R/tools"
+mkfile x.test.txt 15
+printf 'x.test.txt\t15\n' >"$R/tools/a.tsv"
+printf 'x.test.txt\t20\n' >"$R/tools/b.tsv"
+settings_baseline tools/a.tsv
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: the baseline at tools/a.tsv, a tools/b.tsv already beside it"
+mkfile x.test.txt 20
+rm -f "$R/tools/a.tsv"
+settings_baseline tools/b.tsv
+git -C "$R" add -A
+RAISE=1 run_frozen --staged
+[ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten: tools/a.tsv -> tools/b.tsv"*) true ;; *) false ;; esac \
+  && ok "a destination that already carried rows is still a move, not a grandfathered row" \
+  || bad "a destination that already carried rows is still a move" "rc=$RC out=$OUT"
+# Emptying the old baseline in place is the same move, and reports as a
+# modification rather than a removal.
+new_repo relocemptied
+mkdir -p "$R/tools"
+mkfile y.test.txt 15
+printf 'y.test.txt\t15\n' >"$R/tools/a.tsv"
+settings_baseline tools/a.tsv
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: the baseline at tools/a.tsv"
+mkfile y.test.txt 20
+: >"$R/tools/a.tsv"
+printf 'y.test.txt\t20\n' >"$R/tools/b.tsv"
+settings_baseline tools/b.tsv
+git -C "$R" add -A
+RAISE=1 run_frozen --staged
+[ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten: tools/a.tsv -> tools/b.tsv"*) true ;; *) false ;; esac \
+  && ok "emptying the old baseline in place is a move, not a modification to ignore" \
+  || bad "emptying the old baseline in place is a move" "rc=$RC out=$OUT"
+# …and the predicate that keeps the wider list honest: a row-shaped file whose
+# numbers move is still a row set, so an ordinary edit of one is not a move.
+new_repo rowshapededit
+mkdir -p "$R/tools"
+mkfile e.test.txt 15
+printf 'e.test.txt\t15\n' >"$R/$BASE"
+printf 'counts/thing\t3\n' >"$R/data.tsv"
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: a baseline, and a row-shaped file that is not one"
+printf 'counts/thing\t4\n' >"$R/data.tsv"
+git -C "$R" add -A
+run_frozen
+[ "$RC" -eq 0 ] && ok "control: editing a row-shaped file leaves a row set, so it is no move" \
+  || bad "control: editing a row-shaped file is no move" "rc=$RC out=$OUT"
+
 # git spells a non-ASCII path C-quoted by default, so a listing read as text
 # hands the probe `"tools/\303\251.tsv"` and the moved baseline reads as absent.
 new_repo relocquoted

--- a/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -367,5 +367,90 @@ run_frozen
 [ "$RC" -eq 0 ] && ok "a zero-row HEAD baseline is no baseline, so the first row passes undeclared" \
   || bad "a zero-row HEAD baseline is no baseline, so the first row passes undeclared" "rc=$RC out=$OUT"
 
+echo "=== a commit that MOVES the baseline is judged against the rows it moved ==="
+# The path the CURRENT invocation resolves is not the path HEAD's rows are at:
+# a commit that relocates SIZE_RATCHET_BASELINE leaves HEAD carrying nothing at
+# the new one. Read as "HEAD has no rows" that is every raise unjudged, frozen
+# ones included, so the rows are followed to the path HEAD's settings named.
+settings_baseline() { # PATH — the fixture's committed settings name it
+  printf '[env]\nSIZE_RATCHET_BASELINE = "%s"\n' "$1" >"$R/kendex.settings.toml"
+}
+relocating_repo() { # NAME PATH LINES ROWLINES — HEAD's rows at tools/a.tsv
+  new_repo "$1"
+  mkdir -p "$R/tools"
+  mkfile "$2" "$3"
+  printf '%s\t%s\n' "$2" "$4" >"$R/tools/a.tsv"
+  settings_baseline tools/a.tsv
+  git -C "$R" add -A
+  git -C "$R" commit -q -m "seed: a baselined offender, baseline at tools/a.tsv"
+}
+relocate() { # PATH ROWLINES — the same rows move to tools/b.tsv at ROWLINES
+  printf '%s\t%s\n' "$1" "$2" >"$R/tools/b.tsv"
+  rm -f "$R/tools/a.tsv"
+  settings_baseline tools/b.tsv
+  git -C "$R" add -A
+}
+relocating_repo relocfrozen x.test.txt 15 15
+relocate x.test.txt 15
+run_frozen
+[ "$RC" -eq 0 ] && ok "control: a relocation that moves the rows unchanged passes" \
+  || bad "a relocation that moves the rows unchanged passes" "rc=$RC out=$OUT"
+case "$OUT" in *"judged against HEAD's baseline at tools/a.tsv, which this change relocates"*) ok "and the verdict says which rows it judged against" ;; *) bad "the verdict names the relocated baseline" "$OUT" ;; esac
+mkfile x.test.txt 20
+relocate x.test.txt 20
+RAISE=1 run_frozen
+[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: x.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
+  && ok "a frozen row raised across the relocation is refused, declaration and all" \
+  || bad "a frozen raise across a relocation is refused" "rc=$RC out=$OUT"
+# The open class takes the other branch of the same judgment: refused
+# undeclared, carried by the declaration, exactly as it is in place.
+relocating_repo relocopen plain.txt 15 15
+mkfile plain.txt 20
+relocate plain.txt 20
+run_frozen
+[ "$RC" -eq 1 ] && case "$OUT" in *"baseline row raised: plain.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
+  && ok "an unfrozen row raised across the relocation is refused undeclared" \
+  || bad "an unfrozen raise across a relocation is refused undeclared" "rc=$RC out=$OUT"
+RAISE=1 run_frozen
+[ "$RC" -eq 0 ] && ok "control: the declaration carries that unfrozen raise, as it does in place" \
+  || bad "the declaration carries an unfrozen raise across a relocation" "rc=$RC out=$OUT"
+
+echo "=== and the three bootstraps still pass: they leave HEAD naming no rows ==="
+# Each of the three produces an empty HEAD row set legitimately, and each is
+# the case a refusal on emptiness alone would break. All three are run with the
+# baseline path relocated in the same commit, which is the only way the lookup
+# above runs at all.
+new_repo bootunborn
+mkdir -p "$R/tools"
+mkfile u.test.txt 15
+printf 'u.test.txt\t15\n' >"$R/tools/b.tsv"
+settings_baseline tools/b.tsv
+git -C "$R" add -A
+run_frozen
+[ "$RC" -eq 0 ] && ok "an unborn HEAD bootstraps a first baseline at a configured path" \
+  || bad "an unborn HEAD bootstraps a first baseline" "rc=$RC out=$OUT"
+new_repo bootintroduced
+mkfile v.test.txt 5
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: a repo with no baseline at all"
+mkdir -p "$R/tools"
+mkfile v.test.txt 15
+printf 'v.test.txt\t15\n' >"$R/tools/b.tsv"
+settings_baseline tools/b.tsv
+git -C "$R" add -A
+run_frozen
+[ "$RC" -eq 0 ] && ok "a baseline this change introduces bootstraps, path and all" \
+  || bad "a baseline this change introduces bootstraps" "rc=$RC out=$OUT"
+relocating_repo bootplaceholder w.test.txt 5 5
+: >"$R/tools/a.tsv"
+git -C "$R" add -A
+git -C "$R" commit -q -m "the baseline, emptied to a placeholder"
+mkfile w.test.txt 15
+relocate w.test.txt 15
+run_frozen
+[ "$RC" -eq 0 ] && ok "a HEAD baseline committed empty is no row set, wherever the path moves" \
+  || bad "an empty HEAD baseline is no row set across a relocation" "rc=$RC out=$OUT"
+case "$OUT" in *"HEAD carries no baseline rows, so added and raised rows were not judged"*) ok "and a bootstrap still says the check had no reference" ;; *) bad "a bootstrap still reports that nothing was judged" "$OUT" ;; esac
+
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -367,11 +367,10 @@ run_frozen
 [ "$RC" -eq 0 ] && ok "a zero-row HEAD baseline is no baseline, so the first row passes undeclared" \
   || bad "a zero-row HEAD baseline is no baseline, so the first row passes undeclared" "rc=$RC out=$OUT"
 
-echo "=== a commit that MOVES the baseline is judged against the rows it moved ==="
-# The path the CURRENT invocation resolves is not the path HEAD's rows are at:
-# a commit that relocates SIZE_RATCHET_BASELINE leaves HEAD carrying nothing at
-# the new one. Read as "HEAD has no rows" that is every raise unjudged, frozen
-# ones included, so the rows are followed to the path HEAD's settings named.
+echo "=== a commit that MOVES the baseline is refused, in both classes ==="
+# The raise gate reads HEAD at the CONFIGURED path. Move that path and HEAD
+# carries nothing there, so a raised row — a frozen one included — would land
+# with nothing to compare it against. The move is refused instead.
 settings_baseline() { # PATH — the fixture's committed settings name it
   printf '[env]\nSIZE_RATCHET_BASELINE = "%s"\n' "$1" >"$R/kendex.settings.toml"
 }
@@ -384,7 +383,7 @@ relocating_repo() { # NAME PATH LINES ROWLINES — HEAD's rows at tools/a.tsv
   git -C "$R" add -A
   git -C "$R" commit -q -m "seed: a baselined offender, baseline at tools/a.tsv"
 }
-relocate() { # PATH ROWLINES — the same rows move to tools/b.tsv at ROWLINES
+relocate() { # PATH ROWLINES — the rows move to tools/b.tsv at ROWLINES
   printf '%s\t%s\n' "$1" "$2" >"$R/tools/b.tsv"
   rm -f "$R/tools/a.tsv"
   settings_baseline tools/b.tsv
@@ -393,33 +392,75 @@ relocate() { # PATH ROWLINES — the same rows move to tools/b.tsv at ROWLINES
 relocating_repo relocfrozen x.test.txt 15 15
 relocate x.test.txt 15
 run_frozen
-[ "$RC" -eq 0 ] && ok "control: a relocation that moves the rows unchanged passes" \
-  || bad "a relocation that moves the rows unchanged passes" "rc=$RC out=$OUT"
-case "$OUT" in *"judged against HEAD's baseline at tools/a.tsv, which this change relocates"*) ok "and the verdict says which rows it judged against" ;; *) bad "the verdict names the relocated baseline" "$OUT" ;; esac
+[ "$RC" -eq 0 ] && ok "control: a move that carries the rows unchanged passes" \
+  || bad "a move that carries the rows unchanged passes" "rc=$RC out=$OUT"
 mkfile x.test.txt 20
 relocate x.test.txt 20
 RAISE=1 run_frozen
-[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: x.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
-  && ok "a frozen row raised across the relocation is refused, declaration and all" \
-  || bad "a frozen raise across a relocation is refused" "rc=$RC out=$OUT"
-# The open class takes the other branch of the same judgment: refused
-# undeclared, carried by the declaration, exactly as it is in place.
+[ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten: tools/a.tsv -> tools/b.tsv"*) true ;; *) false ;; esac \
+  && ok "a frozen row raised across the move is refused, declaration and all" \
+  || bad "a frozen raise across a move is refused" "rc=$RC out=$OUT"
+case "$OUT" in *"move the baseline in a commit that changes nothing else"*) ok "and the refusal says what to do instead" ;; *) bad "the move refusal names its remedy" "$OUT" ;; esac
+# The open class takes the same refusal, and this is where it differs from an
+# in-place raise: there the declaration carries it, across a move nothing does.
 relocating_repo relocopen plain.txt 15 15
 mkfile plain.txt 20
 relocate plain.txt 20
 run_frozen
-[ "$RC" -eq 1 ] && case "$OUT" in *"baseline row raised: plain.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
-  && ok "an unfrozen row raised across the relocation is refused undeclared" \
-  || bad "an unfrozen raise across a relocation is refused undeclared" "rc=$RC out=$OUT"
+[ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten: tools/a.tsv -> tools/b.tsv"*) true ;; *) false ;; esac \
+  && ok "an unfrozen row raised across the move is refused undeclared" \
+  || bad "an unfrozen raise across a move is refused undeclared" "rc=$RC out=$OUT"
 RAISE=1 run_frozen
-[ "$RC" -eq 0 ] && ok "control: the declaration carries that unfrozen raise, as it does in place" \
-  || bad "the declaration carries an unfrozen raise across a relocation" "rc=$RC out=$OUT"
+[ "$RC" -eq 1 ] && ok "and the declaration does not carry it, where in place it would" \
+  || bad "the declaration does not carry a raise across a move" "rc=$RC out=$OUT"
+# A `git mv` is the same move, and rename detection must not hide it. Four
+# rows with one raised keeps the two files similar enough that git pairs them,
+# which is exactly when a rename-detecting listing reports no removal at all.
+new_repo relocgitmv
+mkdir -p "$R/tools"
+for f in m p1 p2 p3; do mkfile "$f.test.txt" 15; done
+printf 'm.test.txt\t15\np1.test.txt\t15\np2.test.txt\t15\np3.test.txt\t15\n' >"$R/tools/a.tsv"
+settings_baseline tools/a.tsv
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: four baselined offenders at tools/a.tsv"
+mkfile m.test.txt 20
+git -C "$R" mv tools/a.tsv tools/b.tsv
+printf 'm.test.txt\t20\np1.test.txt\t15\np2.test.txt\t15\np3.test.txt\t15\n' >"$R/tools/b.tsv"
+settings_baseline tools/b.tsv
+git -C "$R" add -A
+RAISE=1 run_frozen
+[ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten: tools/a.tsv -> tools/b.tsv"*) true ;; *) false ;; esac \
+  && ok "a git mv of the baseline is the same move, not a rename that hides it" \
+  || bad "a git mv of the baseline is the same move" "rc=$RC out=$OUT"
+# The staged lane reads the index, and a commit is what it judges.
+relocating_repo relocstaged s.test.txt 15 15
+mkfile s.test.txt 20
+relocate s.test.txt 20
+RAISE=1 run_frozen --staged
+[ "$RC" -eq 1 ] && case "$OUT" in *"baseline moved and rewritten: tools/a.tsv -> tools/b.tsv"*) true ;; *) false ;; esac \
+  && ok "the staged lane refuses the same move" \
+  || bad "the staged lane refuses the same move" "rc=$RC out=$OUT"
+# A removed file that is not a row set is not a moved baseline: the check reads
+# the row shape, so an ordinary deletion beside a first baseline stays a
+# bootstrap.
+new_repo notabaseline
+mkdir -p "$R/tools"
+mkfile n.test.txt 5
+printf 'some prose, not a row\n' >"$R/notes.txt"
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: no baseline, one ordinary file"
+mkfile n.test.txt 15
+printf 'n.test.txt\t15\n' >"$R/tools/b.tsv"
+rm -f "$R/notes.txt"
+settings_baseline tools/b.tsv
+git -C "$R" add -A
+run_frozen
+[ "$RC" -eq 0 ] && ok "a removed file that is not a row set is not a moved baseline" \
+  || bad "a removed file that is not a row set is not a moved baseline" "rc=$RC out=$OUT"
 
-echo "=== and the three bootstraps still pass: they leave HEAD naming no rows ==="
-# Each of the three produces an empty HEAD row set legitimately, and each is
-# the case a refusal on emptiness alone would break. All three are run with the
-# baseline path relocated in the same commit, which is the only way the lookup
-# above runs at all.
+echo "=== and the three bootstraps still pass: none of them removes a row set ==="
+# Each legitimately leaves HEAD with no rows at the configured path, and each
+# is what refusing on that emptiness alone would break.
 new_repo bootunborn
 mkdir -p "$R/tools"
 mkfile u.test.txt 15
@@ -451,130 +492,6 @@ run_frozen
 [ "$RC" -eq 0 ] && ok "a HEAD baseline committed empty is no row set, wherever the path moves" \
   || bad "an empty HEAD baseline is no row set across a relocation" "rc=$RC out=$OUT"
 case "$OUT" in *"HEAD carries no baseline rows, so added and raised rows were not judged"*) ok "and a bootstrap still says the check had no reference" ;; *) bad "a bootstrap still reports that nothing was judged" "$OUT" ;; esac
-
-echo "=== every source kind that lookup reads is reproduced from HEAD, or refused ==="
-# A source the scratch tree does not reproduce faithfully makes the HEAD-side
-# resolution equal the run's own for a reason that is not HEAD's configuration,
-# and the raise gate is skipped again. One case per source kind.
-
-# .env.local is the invocation's only while it is UNTRACKED. Versioned it is
-# the commit's, and under --staged the run reads it from the index while HEAD's
-# copy is what the raise gate has to compare against.
-new_repo dotenvtracked
-mkdir -p "$R/tools"
-mkfile x.test.txt 15
-printf 'x.test.txt\t15\n' >"$R/tools/a.tsv"
-printf 'SIZE_RATCHET_BASELINE=tools/a.tsv\n' >"$R/.env.local"
-git -C "$R" add -A
-git -C "$R" commit -q -m "seed: the baseline path in a tracked .env.local"
-mkfile x.test.txt 20
-printf 'SIZE_RATCHET_BASELINE=tools/b.tsv\n' >"$R/.env.local"
-relocate x.test.txt 20
-RAISE=1 run_frozen --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: x.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
-  && ok "a tracked .env.local moving the path is the commit's, and the raise is refused" \
-  || bad "a tracked .env.local moving the path is judged" "rc=$RC out=$OUT"
-
-# A tracked symlink is a supported install shape, and the link staying put
-# while its TARGET moves the path is the same relocation one indirection down.
-new_repo symlinktarget
-mkdir -p "$R/tools"
-mkfile y.test.txt 15
-printf 'y.test.txt\t15\n' >"$R/tools/a.tsv"
-printf '[env]\nSIZE_RATCHET_BASELINE = "tools/a.tsv"\n' >"$R/real.settings.toml"
-ln -s real.settings.toml "$R/kendex.settings.toml"
-git -C "$R" add -A
-git -C "$R" commit -q -m "seed: the settings file reached through a tracked symlink"
-mkfile y.test.txt 20
-printf '[env]\nSIZE_RATCHET_BASELINE = "tools/b.tsv"\n' >"$R/real.settings.toml"
-relocate y.test.txt 20
-RAISE=1 run_frozen
-[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: y.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
-  && ok "a symlinked settings source is followed through HEAD, so its target's move is judged" \
-  || bad "a symlinked settings source is followed through HEAD" "rc=$RC out=$OUT"
-
-# A settings file this change ADDS is one HEAD never had: HEAD's baseline is
-# wherever its own configuration left it, which here is the built-in default.
-new_repo settingsadded
-mkdir -p "$R/tools"
-mkfile z.test.txt 15
-printf 'z.test.txt\t15\n' >"$R/$BASE"
-git -C "$R" add -A
-git -C "$R" commit -q -m "seed: rows at the default path, no settings file"
-mkfile z.test.txt 20
-printf 'z.test.txt\t20\n' >"$R/tools/b.tsv"
-rm -f "$R/$BASE"
-settings_baseline tools/b.tsv
-git -C "$R" add -A
-RAISE=1 run_frozen
-[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: z.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
-  && ok "a settings file this change adds leaves HEAD on its own default, and the raise is refused" \
-  || bad "a settings file this change adds leaves HEAD on its own default" "rc=$RC out=$OUT"
-# The control that tracking is what decides: the SAME move, from a settings
-# file git carries nowhere, is the invocation's and reads the same on both
-# sides, so there is no reference and the run says so.
-git -C "$R" rm --cached -q kendex.settings.toml
-run_frozen
-[ "$RC" -eq 0 ] && case "$OUT" in *"HEAD carries no baseline rows"*) true ;; *) false ;; esac \
-  && ok "control: an untracked settings file is the invocation's, on both sides" \
-  || bad "control: an untracked settings file is the invocation's" "rc=$RC out=$OUT"
-
-# A chain that leaves the repository ends on a file no commit can carry, so it
-# is copied from where it is: both sides read it, and refusing would fail a
-# supported install shape on every run. Omitting it instead sends the lookup to
-# the built-in default, where this fixture has no rows and the raise below
-# would pass unjudged.
-printf '[env]\nSIZE_RATCHET_BASELINE = "tools/b.tsv"\n' >"$TMP/outside.settings.toml"
-new_repo settingsescape
-mkdir -p "$R/tools"
-mkfile q.test.txt 15
-printf 'q.test.txt\t15\n' >"$R/tools/b.tsv"
-ln -s ../outside.settings.toml "$R/kendex.settings.toml"
-git -C "$R" add -A
-git -C "$R" commit -q -m "seed: the baseline path named through a symlink out of the repository"
-mkfile q.test.txt 20
-printf 'q.test.txt\t20\n' >"$R/tools/b.tsv"
-git -C "$R" add -A
-RAISE=1 run_frozen
-[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: q.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
-  && ok "a settings symlink leaving the repository is followed to the file it names" \
-  || bad "a settings symlink leaving the repository is followed" "rc=$RC out=$OUT"
-
-echo "=== which file HEAD's baseline WAS is asked before the rows in it ==="
-# Reading the configured path and keeping whatever rows it holds accepts a file
-# HEAD's configuration never read. A stale destination carrying the raised
-# number reads as grandfathered, and the raise to it is never judged.
-new_repo stalendestination
-mkdir -p "$R/tools"
-mkfile x.test.txt 15
-printf 'x.test.txt\t15\n' >"$R/tools/a.tsv"
-printf 'x.test.txt\t20\n' >"$R/tools/b.tsv"
-settings_baseline tools/a.tsv
-git -C "$R" add -A
-git -C "$R" commit -q -m "seed: rows at tools/a.tsv, a stale tools/b.tsv beside them"
-mkfile x.test.txt 20
-settings_baseline tools/b.tsv
-git -C "$R" add -A
-RAISE=1 run_frozen
-[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: x.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
-  && ok "a stale row set at the destination is not HEAD's baseline, and the raise is refused" \
-  || bad "a stale row set at the destination is not HEAD's baseline" "rc=$RC out=$OUT"
-# The control that the destination's rows are not simply ignored: HEAD's
-# settings naming the SAME path is the ordinary case, and its rows judge.
-new_repo samepath
-mkdir -p "$R/tools"
-mkfile x.test.txt 15
-printf 'x.test.txt\t15\n' >"$R/tools/b.tsv"
-settings_baseline tools/b.tsv
-git -C "$R" add -A
-git -C "$R" commit -q -m "seed: rows at the path the settings name"
-mkfile x.test.txt 20
-printf 'x.test.txt\t20\n' >"$R/tools/b.tsv"
-git -C "$R" add -A
-RAISE=1 run_frozen
-[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: x.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
-  && ok "control: rows at the path HEAD's settings name are the ones that judge" \
-  || bad "control: rows at the path HEAD's settings name judge" "rc=$RC out=$OUT"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -519,23 +519,62 @@ run_frozen
   && ok "control: an untracked settings file is the invocation's, on both sides" \
   || bad "control: an untracked settings file is the invocation's" "rc=$RC out=$OUT"
 
-# What the tree cannot reproduce refuses rather than falling through to the
-# empty answer, which is the state this whole lookup exists to stop reaching
-# without judgement.
+# A chain that leaves the repository ends on a file no commit can carry, so it
+# is copied from where it is: both sides read it, and refusing would fail a
+# supported install shape on every run. Omitting it instead sends the lookup to
+# the built-in default, where this fixture has no rows and the raise below
+# would pass unjudged.
 printf '[env]\nSIZE_RATCHET_BASELINE = "tools/b.tsv"\n' >"$TMP/outside.settings.toml"
 new_repo settingsescape
 mkdir -p "$R/tools"
 mkfile q.test.txt 15
-printf 'q.test.txt\t15\n' >"$R/tools/a.tsv"
+printf 'q.test.txt\t15\n' >"$R/tools/b.tsv"
 ln -s ../outside.settings.toml "$R/kendex.settings.toml"
 git -C "$R" add -A
-git -C "$R" commit -q -m "seed: a settings symlink leaving the repository"
+git -C "$R" commit -q -m "seed: the baseline path named through a symlink out of the repository"
 mkfile q.test.txt 20
-relocate q.test.txt 20
-run_frozen
-[ "$RC" -eq 2 ] && case "$OUT" in *"resolves outside the repository at HEAD"*) true ;; *) false ;; esac \
-  && ok "a settings symlink leaving the repository at HEAD is a loud exit 2" \
-  || bad "a settings symlink leaving the repository at HEAD is exit 2" "rc=$RC out=$OUT"
+printf 'q.test.txt\t20\n' >"$R/tools/b.tsv"
+git -C "$R" add -A
+RAISE=1 run_frozen
+[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: q.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
+  && ok "a settings symlink leaving the repository is followed to the file it names" \
+  || bad "a settings symlink leaving the repository is followed" "rc=$RC out=$OUT"
+
+echo "=== which file HEAD's baseline WAS is asked before the rows in it ==="
+# Reading the configured path and keeping whatever rows it holds accepts a file
+# HEAD's configuration never read. A stale destination carrying the raised
+# number reads as grandfathered, and the raise to it is never judged.
+new_repo stalendestination
+mkdir -p "$R/tools"
+mkfile x.test.txt 15
+printf 'x.test.txt\t15\n' >"$R/tools/a.tsv"
+printf 'x.test.txt\t20\n' >"$R/tools/b.tsv"
+settings_baseline tools/a.tsv
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: rows at tools/a.tsv, a stale tools/b.tsv beside them"
+mkfile x.test.txt 20
+settings_baseline tools/b.tsv
+git -C "$R" add -A
+RAISE=1 run_frozen
+[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: x.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
+  && ok "a stale row set at the destination is not HEAD's baseline, and the raise is refused" \
+  || bad "a stale row set at the destination is not HEAD's baseline" "rc=$RC out=$OUT"
+# The control that the destination's rows are not simply ignored: HEAD's
+# settings naming the SAME path is the ordinary case, and its rows judge.
+new_repo samepath
+mkdir -p "$R/tools"
+mkfile x.test.txt 15
+printf 'x.test.txt\t15\n' >"$R/tools/b.tsv"
+settings_baseline tools/b.tsv
+git -C "$R" add -A
+git -C "$R" commit -q -m "seed: rows at the path the settings name"
+mkfile x.test.txt 20
+printf 'x.test.txt\t20\n' >"$R/tools/b.tsv"
+git -C "$R" add -A
+RAISE=1 run_frozen
+[ "$RC" -eq 1 ] && case "$OUT" in *"frozen baseline row raised: x.test.txt — row 15 -> 20 lines"*) true ;; *) false ;; esac \
+  && ok "control: rows at the path HEAD's settings name are the ones that judge" \
+  || bad "control: rows at the path HEAD's settings name judge" "rc=$RC out=$OUT"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -127,7 +127,7 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/lib/settings.sh	456
-skills/size-ratchet/scripts/size-ratchet	1587
+skills/size-ratchet/scripts/size-ratchet	1682
 skills/worktree/scripts/worktree	4980
 skills/worktree/scripts/worktree-session-guard	1197
 skills/worktree/tests/worktree_session_guard.sh	1282

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -127,7 +127,7 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/lib/settings.sh	456
-skills/size-ratchet/scripts/size-ratchet	1682
+skills/size-ratchet/scripts/size-ratchet	1767
 skills/worktree/scripts/worktree	4980
 skills/worktree/scripts/worktree-session-guard	1197
 skills/worktree/tests/worktree_session_guard.sh	1282

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -127,7 +127,7 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/lib/settings.sh	456
-skills/size-ratchet/scripts/size-ratchet	1673
+skills/size-ratchet/scripts/size-ratchet	1678
 skills/worktree/scripts/worktree	4980
 skills/worktree/scripts/worktree-session-guard	1197
 skills/worktree/tests/worktree_session_guard.sh	1282

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -127,7 +127,7 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/lib/settings.sh	456
-skills/size-ratchet/scripts/size-ratchet	1783
+skills/size-ratchet/scripts/size-ratchet	1673
 skills/worktree/scripts/worktree	4980
 skills/worktree/scripts/worktree-session-guard	1197
 skills/worktree/tests/worktree_session_guard.sh	1282

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -127,7 +127,7 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/lib/settings.sh	456
-skills/size-ratchet/scripts/size-ratchet	1678
+skills/size-ratchet/scripts/size-ratchet	1709
 skills/worktree/scripts/worktree	4980
 skills/worktree/scripts/worktree-session-guard	1197
 skills/worktree/tests/worktree_session_guard.sh	1282

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -127,7 +127,7 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/lib/settings.sh	456
-skills/size-ratchet/scripts/size-ratchet	1709
+skills/size-ratchet/scripts/size-ratchet	1714
 skills/worktree/scripts/worktree	4980
 skills/worktree/scripts/worktree-session-guard	1197
 skills/worktree/tests/worktree_session_guard.sh	1282

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -127,7 +127,7 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/lib/settings.sh	456
-skills/size-ratchet/scripts/size-ratchet	1767
+skills/size-ratchet/scripts/size-ratchet	1783
 skills/worktree/scripts/worktree	4980
 skills/worktree/scripts/worktree-session-guard	1197
 skills/worktree/tests/worktree_session_guard.sh	1282


### PR DESCRIPTION
Closes KEN-848.

`read_head_baseline` read `HEAD:$BASELINE_FILE` for the baseline path resolved on the **current** invocation. When a commit changed `SIZE_RATCHET_BASELINE`, HEAD carried no blob at the new path, `HEAD_BASELINE` came back empty, and `rows_raised` returned without judging anything — so a relocated baseline could carry raised rows, frozen classes included, with no `RATCHET_RAISE=1` and no refusal.

## What this does

**A relocation is refused.** The discriminator needs no settings resolution at all: a path HEAD carried a row set at, which the judged snapshot no longer carries, is a move. `git diff --diff-filter=D --no-renames` names it and the row expression decides whether it was a baseline.

`--no-renames` is load-bearing: a `git mv` of the baseline *is* this move, and rename detection would report it as one path rather than a removal. That has its own control, red when the flag is dropped.

The row expression is extracted to `BASELINE_ROW_RE`, so `validate_baseline_rows` and this check cannot answer "is this a baseline" differently.

**Relocating still lands in one commit** when the rows arrive byte for byte as they left — nothing rose across the move. Anything else is the next commit's business, and the `MOVED` verdict names both paths, says why nothing compares the rows, and gives the two-commit remedy rather than only failing.

**The three bootstrap cases cannot misfire.** An unborn HEAD has no paths to remove. A baseline this change introduces leaves HEAD carrying no row set anywhere, so there is none to remove. A placeholder committed empty sits at the configured path, is filled rather than removed, and holds no rows to recognise even if it were.

## Why this shape and not HEAD-side resolution

An earlier revision of this PR resolved the baseline path from HEAD's own settings. Review found **eight** ways that reconstruction diverged from the resolution `sr_setting` owns — among them a directory symlink component leaving no literal entry, a scratch working directory aliasing two sources onto one path, and a missing symlink target read as absent where the library rejects it. The last finding was that it reimplemented the library's source-selection contract outright, which is why each door was the same divergence in a new shape and why enumerating one never bounded the next.

`skills/size-ratchet/scripts/lib/settings.sh` is vendored from review-gate and its header says fixes go there first, so having the library expose its enumeration is a cross-repo change. Deleting the second implementation was the other way to have one.

So the emulation is gone whole — `settings_sources`, `stage_head_blob`, `read_head_settings_baseline`, `HEAD_LINK_MAX`, the per-source-kind table and the refusal ladder — and `read_head_baseline` is byte for byte what it is on `main`.

## One bound, stated rather than hidden

A change that points the setting elsewhere while leaving the old file committed with its rows removes nothing, so it is not a move this check can name. Seeing that case needs the resolution this revision deletes. That is the trade.

## Tests

Kept: the four bootstrap controls, and both relocation regressions — now pinning the refusal, with the open-class one pinning that no declaration carries it, which is where it differs from an in-place raise.

Added: the `git mv` case, a `--staged` case, a pure-move control, and a control that a removed file which is not a row set stays a bootstrap.

Dropped: the five per-source-kind cases and the stale-destination pair, which only exercised the deleted machinery.

Must-fail against `main`: 48 passed, 6 failed — red on every move case, green on all four bootstrap controls and both not-a-move controls.

## Size

332 insertions, 718 deletions. The script's baseline row **falls** 1783 to 1673, with no `RATCHET_RAISE` at all, since lowering is a tighten. Against `main` the fix itself is 86 lines.
