### PR TITLE
fix(KEN-864): a question is the prompt below the last user turn

### DIFF
--- a/.agents/skills/orch/scripts/oversee-watch
+++ b/.agents/skills/orch/scripts/oversee-watch
@@ -32,7 +32,7 @@
 #                 account's limit banner below the last user turn on its
 #                 screen — one pass, and the claimed config dir when a live
 #                 lane claim names the window
-#   6. question   a listed lane's pane shows a question/selection prompt
+#   6. question   a question/selection prompt below the last user turn
 #   7. idle-after-return a listed lane whose harness has not exited sits at
 #                 its composer with no work in flight on two consecutive
 #                 passes
@@ -180,8 +180,8 @@ Events, checked in this order every pass:
                              since worked past is old news. The config dir is
                              appended when a live lane claim names this window
                              (last 40 non-empty pane lines follow)
-  EVENT question <lane>      the lane's pane shows a question/selection
-                             prompt (last 40 non-empty pane lines follow)
+  EVENT question <lane>      a question/selection prompt below the last user
+                             turn (last 40 non-empty pane lines follow)
   EVENT idle-after-return <lane>
                              the harness has not exited and its pane sits at
                              the composer (`❯`, Codex's submit

--- a/.agents/skills/orch/scripts/oversee-watch
+++ b/.agents/skills/orch/scripts/oversee-watch
@@ -595,15 +595,15 @@ check_lanes() {
       exit 0
     fi
   done
-  # A pane keeps its last screen after the harness exits, so a stale prompt
-  # under a bare shell is not a question anyone can answer — and reporting it
-  # every pass would starve the lane-exited its second pass earns.
+  # A pane keeps its last screen, so neither a stale prompt under a bare shell
+  # nor a dialog answered passes ago is a live question, and reporting either
+  # starves the events below it: lane-exited's second pass, idle-after-return.
   i=0
   for lane in "${LANES[@]}"; do
     i=$((i + 1))
     if [[ "$(lane_state "$states" "$i")" == exited ]]; then continue; fi
     pane="$(cat -- "$(lane_pane_file "$i")")"
-    if grep -Eq -- "$QUESTION_RE" <<<"$pane"; then
+    if grep -Eq -- "$QUESTION_RE" <<<"$(pane_below_last_turn "$pane")"; then
       echo "EVENT question $lane"
       pane_tail "$pane"
       pr_watch_context

--- a/.agents/skills/orch/tests/oversee_watch_lanes.sh
+++ b/.agents/skills/orch/tests/oversee_watch_lanes.sh
@@ -21,7 +21,9 @@
 #       instead; and a banner above a later user turn is scrollback, while
 #       one below that turn still fires
 #   4.  a lane pane showing a question prompt (pane tail follows), under a
-#       wrapped shell too
+#       wrapped shell too; a selection list above the last user turn is one
+#       the lane already answered and never fires, while one below that turn
+#       still does
 #   4b. idle-after-return: a harness at its composer with nothing in flight
 #       on two consecutive passes (either harness's prompt, and under a
 #       wrapped shell); one pass alone, a working indicator alongside the
@@ -539,6 +541,42 @@ out="$(run_watch -- --max-loops 1 'a+b' 'a:b' 2>"$err")" && rc=0 || rc=$?
 assert_eq "$rc" "0" "colliding lane names exit 0" "$err"
 assert_eq "$(head -1 <<<"$out")" "EVENT question a+b" \
   "lanes whose names flatten to one slug keep separate pane snapshots" "$err"
+
+# A dialog the lane already answered stays on the screen. Only the slice below
+# the last user turn is a question still waiting: read off the whole pane, an
+# answered list re-fires every pass and masks the event the lane is really at.
+new_case question_answered_dialog_above_turn
+{
+  printf '⏺ I found two ways to do this.\n'
+  printf 'Do you want to proceed?\n'
+  printf '   ❯ 1. Yes\n     2. No\n'
+  printf '❯ go with the first one\n'
+  printf '⏺ Done: the PR is merged and the worktree is gone.\n'
+  printf '\xe2\x9d\xaf\xc2\xa0\n'
+  printf '  bypass permissions on\n'
+} > "$STUB_DIR/pane-gh-2.txt"
+err="$TMP_ROOT/e4a4"
+out="$(run_watch -- gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
+assert_eq "$rc" "0" "an answered dialog exits 0" "$err"
+assert_not_contains "$out" "EVENT question" \
+  "a selection list above the last user turn is answered, not waiting" "$err"
+assert_eq "$(head -1 <<<"$out")" "EVENT idle-after-return gh-2" \
+  "the lane reaches the idle event the answered list was masking" "$err"
+
+# ...and its must-fail control: the same list BELOW the last user turn is a
+# question nobody has answered, so the slice can never pass by muting the check
+new_case question_live_dialog_below_turn
+{
+  printf '❯ go ahead and refactor it\n'
+  printf '⏺ I found two ways to do this.\n'
+  printf 'Do you want to proceed?\n'
+  printf '   ❯ 1. Yes\n     2. No\n'
+} > "$STUB_DIR/pane-gh-2.txt"
+err="$TMP_ROOT/e4a5"
+out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
+assert_eq "$(head -1 <<<"$out")" "EVENT question gh-2" \
+  "a selection list below the last user turn is still the event" "$err"
+assert_contains "$out" "   ❯ 1. Yes" "the pane tail follows the event line" "$err"
 
 # --- 4b. idle-after-return: the round is over and nobody is driving ---------
 new_case idle_after_return

--- a/skills/orch/scripts/oversee-watch
+++ b/skills/orch/scripts/oversee-watch
@@ -32,7 +32,7 @@
 #                 account's limit banner below the last user turn on its
 #                 screen — one pass, and the claimed config dir when a live
 #                 lane claim names the window
-#   6. question   a listed lane's pane shows a question/selection prompt
+#   6. question   a question/selection prompt below the last user turn
 #   7. idle-after-return a listed lane whose harness has not exited sits at
 #                 its composer with no work in flight on two consecutive
 #                 passes
@@ -180,8 +180,8 @@ Events, checked in this order every pass:
                              since worked past is old news. The config dir is
                              appended when a live lane claim names this window
                              (last 40 non-empty pane lines follow)
-  EVENT question <lane>      the lane's pane shows a question/selection
-                             prompt (last 40 non-empty pane lines follow)
+  EVENT question <lane>      a question/selection prompt below the last user
+                             turn (last 40 non-empty pane lines follow)
   EVENT idle-after-return <lane>
                              the harness has not exited and its pane sits at
                              the composer (`❯`, Codex's submit

--- a/skills/orch/scripts/oversee-watch
+++ b/skills/orch/scripts/oversee-watch
@@ -595,15 +595,15 @@ check_lanes() {
       exit 0
     fi
   done
-  # A pane keeps its last screen after the harness exits, so a stale prompt
-  # under a bare shell is not a question anyone can answer — and reporting it
-  # every pass would starve the lane-exited its second pass earns.
+  # A pane keeps its last screen, so neither a stale prompt under a bare shell
+  # nor a dialog answered passes ago is a live question, and reporting either
+  # starves the events below it: lane-exited's second pass, idle-after-return.
   i=0
   for lane in "${LANES[@]}"; do
     i=$((i + 1))
     if [[ "$(lane_state "$states" "$i")" == exited ]]; then continue; fi
     pane="$(cat -- "$(lane_pane_file "$i")")"
-    if grep -Eq -- "$QUESTION_RE" <<<"$pane"; then
+    if grep -Eq -- "$QUESTION_RE" <<<"$(pane_below_last_turn "$pane")"; then
       echo "EVENT question $lane"
       pane_tail "$pane"
       pr_watch_context

--- a/skills/orch/tests/oversee_watch_lanes.sh
+++ b/skills/orch/tests/oversee_watch_lanes.sh
@@ -21,7 +21,9 @@
 #       instead; and a banner above a later user turn is scrollback, while
 #       one below that turn still fires
 #   4.  a lane pane showing a question prompt (pane tail follows), under a
-#       wrapped shell too
+#       wrapped shell too; a selection list above the last user turn is one
+#       the lane already answered and never fires, while one below that turn
+#       still does
 #   4b. idle-after-return: a harness at its composer with nothing in flight
 #       on two consecutive passes (either harness's prompt, and under a
 #       wrapped shell); one pass alone, a working indicator alongside the
@@ -539,6 +541,42 @@ out="$(run_watch -- --max-loops 1 'a+b' 'a:b' 2>"$err")" && rc=0 || rc=$?
 assert_eq "$rc" "0" "colliding lane names exit 0" "$err"
 assert_eq "$(head -1 <<<"$out")" "EVENT question a+b" \
   "lanes whose names flatten to one slug keep separate pane snapshots" "$err"
+
+# A dialog the lane already answered stays on the screen. Only the slice below
+# the last user turn is a question still waiting: read off the whole pane, an
+# answered list re-fires every pass and masks the event the lane is really at.
+new_case question_answered_dialog_above_turn
+{
+  printf '⏺ I found two ways to do this.\n'
+  printf 'Do you want to proceed?\n'
+  printf '   ❯ 1. Yes\n     2. No\n'
+  printf '❯ go with the first one\n'
+  printf '⏺ Done: the PR is merged and the worktree is gone.\n'
+  printf '\xe2\x9d\xaf\xc2\xa0\n'
+  printf '  bypass permissions on\n'
+} > "$STUB_DIR/pane-gh-2.txt"
+err="$TMP_ROOT/e4a4"
+out="$(run_watch -- gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
+assert_eq "$rc" "0" "an answered dialog exits 0" "$err"
+assert_not_contains "$out" "EVENT question" \
+  "a selection list above the last user turn is answered, not waiting" "$err"
+assert_eq "$(head -1 <<<"$out")" "EVENT idle-after-return gh-2" \
+  "the lane reaches the idle event the answered list was masking" "$err"
+
+# ...and its must-fail control: the same list BELOW the last user turn is a
+# question nobody has answered, so the slice can never pass by muting the check
+new_case question_live_dialog_below_turn
+{
+  printf '❯ go ahead and refactor it\n'
+  printf '⏺ I found two ways to do this.\n'
+  printf 'Do you want to proceed?\n'
+  printf '   ❯ 1. Yes\n     2. No\n'
+} > "$STUB_DIR/pane-gh-2.txt"
+err="$TMP_ROOT/e4a5"
+out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
+assert_eq "$(head -1 <<<"$out")" "EVENT question gh-2" \
+  "a selection list below the last user turn is still the event" "$err"
+assert_contains "$out" "   ❯ 1. Yes" "the pane tail follows the event line" "$err"
 
 # --- 4b. idle-after-return: the round is over and nobody is driving ---------
 new_case idle_after_return


### PR DESCRIPTION
The `question` check read the whole pane capture, so a selection list a lane had already answered kept matching for as long as it stayed on screen. The watch re-fired `question` for that lane every pass, and since `question` is checked ahead of `idle-after-return`, the lane never reached the event it was actually sitting at — the overseer was handed a prompt answered passes ago.

KEN-845 fixed the same exposure one check above this one, in `usage-limit`, and the helper it added covers both harnesses. This is the other call site: `pane_below_last_turn "$pane"` in place of `$pane`, unchanged otherwise.

`pane_below_last_turn` widens the slice when it cannot recognise the composer, which is the right direction here too — reporting a question that may be stale beats never reporting a live one — so no narrowing fallback was added.

## Controls

In `skills/orch/tests/oversee_watch_lanes.sh`, which is the pane side of the watch (`oversee_watch.sh` is the GitHub side; the issue named the wrong file):

- An answered selection list above the last user turn produces no `question`, and the lane goes on to `idle-after-return`.
- The must-fail control: the same list below the last user turn still produces `question`, with the pane tail following.

Both halves of the first control are red with the one-line change reverted and the must-fail control stays green there, which is what says the fix is not muting the check. Full `skills/orch/tests/run-all.sh`: 60 files, all pass. That suite's shard is merge-queue-only, so it was run locally rather than waited for.

The `.agents/` render is byte-identical to the source in the same commit. `skills/orch/scripts/oversee-watch` stays at 654, its ratchet row unchanged.

Closes KEN-864
