### PR TITLE
test(KEN-869): an empty fake-cargo log proves the fake was reachable

### DIFF
--- a/pi-extensions/pi-hooks/tests/hooks.test.ts
+++ b/pi-extensions/pi-hooks/tests/hooks.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 
+import { runCargo } from "../extensions/cargo.ts";
 import piHooks from "../extensions/hooks.ts";
 
 const CONFIG_ID = "@vanillagreen/pi-hooks";
@@ -98,6 +99,22 @@ function installToolCallHandler(): ToolCallHandler {
 	return handler;
 }
 
+const PROBE_ARG = "--pi-hooks-reachability-probe";
+
+/**
+ * Prove the fake is the cargo a spawn from this process resolves, then hand the
+ * body an empty log. Without this an empty log means nothing: it reads the same
+ * whether no check ran or the substitution broke. Bun's spawnSync inherits an
+ * environment snapshot rather than the live `process.env`, so the fake sat
+ * unreachable and every assertion below was vacuous until runCargo started
+ * passing an explicit env (KEN-843).
+ */
+function expectFakeCargoReachable(cwd: string, log: string): void {
+	runCargo([PROBE_ARG], cwd, 5000);
+	expect(cargoLog(log)).toBe(`${PROBE_ARG}\n`);
+	writeFileSync(log, "");
+}
+
 async function withFakeCargo<T>(run: (paths: { bin: string; log: string }) => Promise<T>): Promise<T> {
 	const root = mkdtempSync(join(tmpdir(), "pi-hooks-cargo-"));
 	const paths = fakeCargoBin(root);
@@ -107,6 +124,7 @@ async function withFakeCargo<T>(run: (paths: { bin: string; log: string }) => Pr
 	process.env.PATH = `${paths.bin}:${oldPath ?? ""}`;
 	process.env.FAKE_CARGO_LOG = paths.log;
 	try {
+		expectFakeCargoReachable(root, paths.log);
 		return await run(paths);
 	} finally {
 		if (oldPath === undefined) delete process.env.PATH;
@@ -136,8 +154,9 @@ function cargoLog(log: string): string {
 }
 
 describe("pi-hooks pre-commit tool_call", () => {
-	// A fake cargo stays on PATH throughout as the control: the gate defers or
-	// refuses, and never runs a check of its own, so the log must stay empty.
+	// A fake cargo stays on PATH throughout as the control: withFakeCargo proves
+	// it reachable before handing over, and the gate defers or refuses without
+	// running a check of its own, so the log must stay empty.
 	test("defers to an armed repository without running anything", async () => {
 		await withFakeCargo(async ({ log }) => {
 			const project = initRustRepo("pi-hooks-project-");


### PR DESCRIPTION
## What

`withFakeCargo` substitutes a fake cargo by mutating `process.env.PATH`. Under Bun, `node:child_process.spawnSync` runs against an environment snapshot taken before the mutation, so the fake was never on the spawned process's PATH and never ran. The tests using it assert the fake's log stays empty — which passed for the whole time the fake was unreachable, against the real cargo on the machine.

KEN-843 (#1858) fixed the reachability at the source: `runCargo` names `env: process.env` on the spawn, a no-op under Node where that is already the default. What remained is that nothing asserted the fake actually ran. An empty log is equally consistent with "the code correctly did not invoke cargo" and "the substitution silently broke again", so the suite would stay green through a second regression of exactly the kind KEN-843 found.

## The assertion

`withFakeCargo` now runs the fake once through `runCargo` with a marker argument, asserts the log recorded exactly that line, truncates the log, and then calls the body. Every caller asserting an empty log gets the control, and a caller added later inherits it rather than having to remember it.

The probe goes through `runCargo` — the same function the production path uses — which is what makes it sensitive to the regression rather than to a PATH lookup the test performs for itself.

## The must-fail result

| `runCargo` spawn | pi-hooks suite |
|---|---|
| `env: process.env` present | 118 pass, 0 fail |
| the line deleted | **8 fail** |

The failures are the `withFakeCargo` callers, each dying on the probe with an empty log where the marker line was expected. Measured on this branch after rebasing onto `fb7394d60`, so the control is verified against the merged state rather than a preview.

The Bun behaviour was confirmed directly rather than inferred: mutate `process.env.PATH`, then `spawnSync("cargo", ["--version"])` runs the real cargo and leaves the fake's log empty; the same call with `env: process.env` runs the fake. Bun 1.3.14, real cargo 1.96.1 on PATH.

## Not in this change

`runCommandAsync` in `extensions/process.ts` spawns with no explicit env — the same blind spot, reachable from `preCommitGate`'s git lookups — and the PATH scrub in `tests/bash-guards.test.ts` is inert for the same reason and guards nothing regardless, since `bash-guards.ts` resolves no kendex binary. Both are KEN-871.

Closes KEN-869
