### PR TITLE
fix(KEN-839): kendex keeps the ui size limit its own policy sets

### DIFF
--- a/kendex.settings.toml
+++ b/kendex.settings.toml
@@ -260,6 +260,15 @@ GH_ISSUE_PATTERN = "ken-[0-9]+"
 LINEAR_FORMAT = "safe"
 ORCH_STATE_DIR = "tmp"
 
+# File-size ratchet classes this repo sets for itself, matched before the
+# shipped list. ui/ TypeScript is held to 250, tighter than the shipped
+# default, because a component that long has stopped being one component.
+# The two test entries lead only to keep the shipped test class reaching ui/
+# test files: this list is matched first, so without them `ui/*.ts` — whose
+# `*` crosses `/` — would take every ui test file at 250, and tests are a
+# frozen class, so none of those rows could ever rise.
+SIZE_RATCHET_CLASSES = "*.test.*=800;*.spec.*=800;ui/*.ts=250;ui/*.tsx=250"
+
 # ── Worktrees ────────────────────────────────────────────────────────────
 # What a fresh issue worktree gets from this checkout: only paths git does
 # not carry. An entry does nothing when git carries every path under it, and

--- a/kendex.settings.toml
+++ b/kendex.settings.toml
@@ -260,14 +260,23 @@ GH_ISSUE_PATTERN = "ken-[0-9]+"
 LINEAR_FORMAT = "safe"
 ORCH_STATE_DIR = "tmp"
 
-# File-size ratchet classes this repo sets for itself, matched before the
-# shipped list. ui/ TypeScript is held to 250, tighter than the shipped
-# default, because a component that long has stopped being one component.
-# The two test entries lead only to keep the shipped test class reaching ui/
-# test files: this list is matched first, so without them `ui/*.ts` — whose
-# `*` crosses `/` — would take every ui test file at 250, and tests are a
-# frozen class, so none of those rows could ever rise.
-SIZE_RATCHET_CLASSES = "*.test.*=800;*.spec.*=800;ui/*.ts=250;ui/*.tsx=250"
+# File-size ratchet classes this repo sets for itself. ui/ TypeScript is held
+# to 250 lines — tighter than the 400-line base threshold it would otherwise
+# fall through to, the shipped list naming no TypeScript class — because a
+# component that long has stopped being one component.
+#
+# Every entry is scoped to ui/, and the test entries lead, for one reason:
+# this list is matched before the shipped one and its globs cross `/`, so a
+# repo class shadows every shipped class whose paths it also matches, and
+# each shadowed class has to be re-led at the same scope. `ui/*.ts` alone
+# takes ui/ test files at 250 — the ones named for a test and the ones that
+# are one by directory alike — while the freeze still reaches them, and a
+# frozen row can never rise. Scoping every entry to ui/ is the other half:
+# an unscoped `*.test.*` would also lead the shipped markdown classes, and a
+# test-named markdown file would take a line count in place of its byte
+# ceiling. Both directory forms are spelled out for the shipped list's own
+# reason: `*` may match nothing, but the literal `/` must still be there.
+SIZE_RATCHET_CLASSES = "ui/*.test.*=800;ui/*.spec.*=800;ui/test/*=800;ui/*/test/*=800;ui/tests/*=800;ui/*/tests/*=800;ui/__tests__/*=800;ui/*/__tests__/*=800;ui/*.ts=250;ui/*.tsx=250"
 
 # ── Worktrees ────────────────────────────────────────────────────────────
 # What a fresh issue worktree gets from this checkout: only paths git does

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -131,4 +131,5 @@ skills/size-ratchet/scripts/size-ratchet	1587
 skills/worktree/scripts/worktree	4980
 skills/worktree/scripts/worktree-session-guard	1197
 skills/worktree/tests/worktree_session_guard.sh	1282
+ui/src/stores/marketplaces.ts	282
 ui/src/stores/settings.ts	521


### PR DESCRIPTION
## Summary

- kendex's own box on KEN-839's propagation checklist. An audit of the whole leg found kendex already on the package defaults: renders in sync with all four trees, no override equal to a shipped default, no local script a package lane replaces, CI already running the index-wide `todo-ban` at both sites. `kendex verify` is clean at 142/142.
- One real regression fixed. KEN-832 deleted kendex's `SIZE_RATCHET_CLASSES` line whole, but two entries in it held ui TypeScript to 250, tighter than the 400 base threshold. Under this issue's own rule an override that differs is policy and stays, so ui TypeScript had silently loosened to 400 and lost its `ui/src/stores/marketplaces.ts` baseline row. Both are restored.
- Every restored entry is scoped to `ui/`. The repo list is matched before the shipped one and its globs cross `/`, so a directory-scoped repo class shadows every shipped class whose paths it also matches. Each shadowed test class is re-led at `ui/` scope in both directory forms, which keeps `ui/src/test/` helpers on the shipped 800 instead of dropping them to 250 inside a frozen class, and keeps the shipped markdown byte ceilings ahead of everything outside `ui/`.

## Completed Issues

- Part of KEN-839 - Propagation: every active consumer on the package defaults, local duplicates deleted

This is the first of seven PRs, one per repo. KEN-839 stays open until drovr, hyprtrade, hyprtrade-io, memsira, vg and vgs land theirs.

## Test Plan

- `size-ratchet` clean at HEAD: 2764 tracked files, exit 0.
- Class resolution swept across all 2764 tracked paths under the old and new lists: 654 paths change which pattern decides them, exactly two change the number, and those two are the reported defect. No markdown file's class changes in either direction.
- Must-fail controls, each red before green: without the re-led test classes, 30 ui test files clamp to 250; without the baseline row, `marketplaces.ts` reports as a new offender at 282; with the row but no raise declared, the bootstrap is refused.
- Live controls still bite: a 300-line `ui/src/components/big.tsx` fails at `class ui/*.tsx`, a 900-line `ui/src/components/foo.test.tsx` fails at `class ui/*.test.*`, so the 800 test class is a ceiling and not an exemption.
- `tools/guard` exit 0, preflight clean, all six growth-guards lanes clean, full pre-commit and commit-msg chain green.

## Known residue

Inside `ui/`, the test classes still lead the shipped markdown classes, so a future markdown file that is test-named or sits in a `ui/test/` directory would be measured in lines rather than its 64KiB byte ceiling. `ui/` holds one markdown file today and it matches no repo entry, so nothing is affected now.

This is the same root cause as the fixed defect, and patching it again would add more hardcoded copies of shipped constants. It is closed at its source instead, in a separate PR that lands before the six remaining propagation PRs.
