### PR TITLE
fix(KEN-871): every pi-hooks spawn resolves against the live PATH

### DIFF
--- a/pi-extensions/pi-hooks/extensions/process.ts
+++ b/pi-extensions/pi-hooks/extensions/process.ts
@@ -39,6 +39,13 @@ export function runCommandAsync(command: string, args: string[], cwd: string, ti
 			child = spawn(command, args, {
 				cwd,
 				detached,
+				// Name the live object rather than let the runtime choose an env.
+				// Bun's spawnSync defaults to a boot-time snapshot, which is what
+				// left a fake binary on PATH unreachable in runCargo (KEN-843).
+				// Bun's async spawn reads process.env today, so this is a no-op
+				// here as it is under Node. It is the guarantee a test planting a
+				// binary rests on, not a runtime default.
+				env: process.env,
 				stdio: ["ignore", "pipe", "pipe"],
 			});
 		} catch (error) {

--- a/pi-extensions/pi-hooks/tests/bash-guards.test.ts
+++ b/pi-extensions/pi-hooks/tests/bash-guards.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 
 import { isBareCd, preCommitGate, scanCommand } from "../extensions/bash-guards.ts";
+import { runCommandAsync } from "../extensions/process.ts";
 
 // The marker the growth-guards installer ends its delegating line with, and
 // the only thing that makes a hook file ours as far as this gate is
@@ -46,6 +47,27 @@ function plantAnnouncingScript(repo: string, log: string): void {
 	chmodSync(join(scripts, "pre-commit"), 0o755);
 }
 
+const PROBE = "pi-hooks-path-probe";
+
+/**
+ * Prove the narrowed PATH is the one the gate's own spawns resolve against,
+ * then take the probe back out so the directory holds git, sh and bash alone.
+ * A narrowing that never reaches a child reads exactly like one that holds.
+ * That is how a fake cargo sat unreachable while every assertion around it
+ * passed (KEN-843), Bun's spawnSync having defaulted to a boot-time
+ * environment snapshot. The probe runs through `runCommandAsync` because that
+ * is the helper the gate spawns git with, so it answers for the gate's own
+ * resolution and not for a lookup this file did itself.
+ */
+async function expectNarrowedPathReachable(bin: string, cwd: string): Promise<void> {
+	const probe = join(bin, PROBE);
+	writeFileSync(probe, "#!/bin/sh\nprintf reached\n");
+	chmodSync(probe, 0o755);
+	const result = await runCommandAsync(PROBE, [], cwd, 5000);
+	expect([result.exitCode, result.stdout]).toEqual([0, "reached"]);
+	rmSync(probe);
+}
+
 describe("pre-commit gate: the bash hook's contract", () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-hooks-gate-"));
 	const ranLog = join(root, "ran.log");
@@ -60,13 +82,15 @@ describe("pre-commit gate: the bash hook's contract", () => {
 	let foreign: string;
 	let mixed: string;
 	let notARepo: string;
-	// Bare PATH: the armed hook gates a commit with no binary involved, and the
-	// refusal for an unarmed one needs none either. Git reads no config of the
+	// Narrowed PATH: git is the one binary this gate resolves, so the fixtures
+	// run against a directory holding git, sh and bash and nothing else. A
+	// resolution the gate is not supposed to make fails here rather than
+	// quietly finding the developer's copy. Git also reads no config of the
 	// developer's: a global core.hooksPath would disarm every fixture.
 	const savedEnv: Record<string, string | undefined> = {};
 	const isolatedEnv: Record<string, string> = { GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_NOSYSTEM: "1" };
 
-	beforeAll(() => {
+	beforeAll(async () => {
 		for (const [name, value] of Object.entries(isolatedEnv)) {
 			savedEnv[name] = process.env[name];
 			process.env[name] = value;
@@ -136,7 +160,7 @@ describe("pre-commit gate: the bash hook's contract", () => {
 			plantAnnouncingScript(repo, ranLog);
 		}
 
-		const bin = join(root, "no-kendex-bin");
+		const bin = join(root, "git-only-bin");
 		mkdirSync(bin);
 		for (const tool of ["git", "sh", "bash"]) {
 			const found = spawnSync("sh", ["-c", `command -v ${tool}`], { encoding: "utf8" }).stdout.trim();
@@ -144,6 +168,7 @@ describe("pre-commit gate: the bash hook's contract", () => {
 		}
 		savedEnv.PATH = process.env.PATH;
 		process.env.PATH = bin;
+		await expectNarrowedPathReachable(bin, root);
 	});
 
 	afterAll(() => {


### PR DESCRIPTION
## The issue's premise was wrong, and that is the main finding

KEN-871 said `runCommandAsync` carried the same blind spot KEN-843 fixed in `runCargo`: that under Bun a `process.env.PATH` mutation never reaches a spawned process, so a test planting a fake binary would be inert. That is true of `spawnSync`. It is not true of the async `spawn` this helper uses.

Measured directly on Bun 1.3.14 — reassign `PATH` after boot, then run the same binary both ways:

```
spawnSync:   ENOENT
async spawn: "reached"
```

Bun snapshots the environment for the sync spawn only. So the KEN-843 defect never applied to `runCommandAsync`, and the PATH narrowing in `bash-guards.test.ts` was live all along rather than inert. Both halves of the issue's problem statement were mistaken.

## What changed anyway, and why

`runCommandAsync` names `env: process.env` on its spawn. It is a no-op on both runtimes, and it pins the guarantee to the code rather than to a runtime default that differs between two spawn functions in the same library.

The PATH narrowing is kept and restated rather than deleted. Its directory was named `no-kendex-bin`, which claimed the gate resolves no `kendex` binary — `bash-guards.ts` never attempts that resolution, so the name guarded nothing. The claim that does hold is narrower: git is the one binary this gate resolves. The directory is now `git-only-bin`, holding git, sh and bash alone, so a resolution the gate is not supposed to make fails in the suite instead of quietly finding the developer's copy.

`expectNarrowedPathReachable` plants an executable reachable only through the narrowed directory, runs it through `runCommandAsync`, asserts exit 0 and its output, then removes it. That is the assertion the narrowing lacked: it proves the substitution takes effect, rather than only that an effect is absent.

## Must-fail

Deleting `env: process.env` from `runCommandAsync` leaves the suite at 118 pass / 0 fail, because async `spawn` reads the live environment either way. Reporting that rather than a red count, since the delegation asked for the number actually seen.

The control that does run red is the real defect class — the environment replaced by a module-load snapshot: **72 pass, 11 fail**, the probe failing first with `[-1, ""]` against `[0, "reached"]` and taking its `beforeAll` with it. Both variants were restored; HEAD is 118 pass / 0 fail.

## Not changed

No changelog fragment: engine-internal, no consumer-visible behaviour, and it touches neither `crates/` nor `ui/`.

Closes KEN-871
