### PR TITLE
test(KEN-872): stage the deadline boundary instead of racing it

### DIFF
--- a/.agents/skills/second-opinion/tests/self-background.test.sh
+++ b/.agents/skills/second-opinion/tests/self-background.test.sh
@@ -460,29 +460,6 @@ done
 [[ $resume_rc -eq 0 ]] || fail "resumed wait did not collect the terminal result"
 assert_contains "$TMP_ROOT/resume-answer" "slow answer" \
   "bounded wait resumes to the final artifact"
-cat > "$TMP_ROOT/bin/instant-worker" <<'SH'
-#!/usr/bin/env bash
-output=""
-for arg in "$@"; do case "$arg" in --output=*) output="${arg#--output=}" ;; esac; done
-printf 'instant answer\n' > "$output"
-printf '0\n' > "$BOUNDARY_STATUS_DIR/worker.status"
-sleep 1.2
-SH
-chmod +x "$TMP_ROOT/bin/instant-worker"
-mkdir "$TMP_ROOT/boundary-runtime"
-BOUNDARY_STATUS_DIR="$TMP_ROOT/boundary-runtime" \
-  "$RUNTIME" launch "$TMP_ROOT/bin/instant-worker" "$TMP_ROOT/boundary-answer" \
-    "$TMP_ROOT/boundary-runtime" 2 false 1 3 x >"$TMP_ROOT/boundary-launch.stdout"
-boundary_wait_cmd="$(sed -n 's/^wait: //p' "$TMP_ROOT/boundary-launch.stdout")"
-boundary_rc=0
-bash -c "$boundary_wait_cmd" >"$TMP_ROOT/boundary-wait.stdout" \
-  2>"$TMP_ROOT/boundary-wait.stderr" || boundary_rc=$?
-if [[ $boundary_rc -ne 0 ]]; then
-  sed -n '1,100p' "$TMP_ROOT/boundary-wait.stderr" >&2 || true
-  fail "deadline event overrode an atomically completed worker"
-fi
-assert_contains "$TMP_ROOT/boundary-answer" "instant answer" \
-  "completion wins the post-worker deadline boundary"
 cat > "$TMP_ROOT/bin/empty-worker" <<'SH'
 #!/usr/bin/env bash
 exit 0

--- a/.agents/skills/second-opinion/tests/supervisor-deadline-boundary.test.sh
+++ b/.agents/skills/second-opinion/tests/supervisor-deadline-boundary.test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The detached supervisor's deadline event must not override a completion
+# status the worker has already published. The state is staged, never raced:
+# the status file is on disk before the run starts, the deadline is already
+# elapsed so the watchdog posts its event unconditionally rather than on a
+# timer, and the worker is killed before the runtime can post a worker event —
+# so the deadline event is the only one the supervisor can read. Nothing here
+# depends on the clock or on process scheduling.
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+fail() { printf 'FAIL: %s\n' "$1" >&2; exit 1; }
+assert_contains() { grep -Fq "$2" "$1" || fail "$3"; printf 'PASS: %s\n' "$3"; }
+assert_not_contains() {
+  if grep -Fq "$2" "$1"; then fail "$3"; fi
+  printf 'PASS: %s\n' "$3"
+}
+
+mkdir -p "$TMP_ROOT/proj/skills" "$TMP_ROOT/bin"
+cp -R "$REPO_ROOT/skills/second-opinion" "$TMP_ROOT/proj/skills/second-opinion"
+RUNTIME="$TMP_ROOT/proj/skills/second-opinion/scripts/second-opinion-runtime"
+
+# SIGKILL on the runtime's worker subshell leaves a published status behind
+# with no worker event to announce it — the exact state the deadline event
+# must not override. The subshell dies at 137, which is the status staged
+# below, so the supervisor's status/exit agreement check still has to pass.
+cat > "$TMP_ROOT/bin/staged-worker" <<'SH'
+#!/usr/bin/env bash
+output=""
+for arg in "$@"; do case "$arg" in --output=*) output="${arg#--output=}" ;; esac; done
+printf 'instant answer\n' > "$output"
+kill -KILL "$PPID"
+kill -KILL $$
+SH
+chmod +x "$TMP_ROOT/bin/staged-worker"
+
+run_boundary_case() {
+  local runtime="$1" runtime_dir="$2" artifact="$3" stderr_file="$4" rc=0
+  mkdir "$runtime_dir"
+  printf 'boundary\n' > "$runtime_dir/token"
+  printf '137\n' > "$runtime_dir/worker.status"
+  "$runtime" supervise "$TMP_ROOT/bin/staged-worker" "$artifact" "$runtime_dir" \
+    "$(date +%s)" false boundary 1 x >/dev/null 2>"$stderr_file" || rc=$?
+  printf '%s\n' "$rc"
+}
+
+boundary_rc="$(run_boundary_case "$RUNTIME" "$TMP_ROOT/boundary-runtime" \
+  "$TMP_ROOT/boundary-answer" "$TMP_ROOT/boundary.stderr")"
+if [[ $boundary_rc -ne 137 ]]; then
+  sed -n '1,100p' "$TMP_ROOT/boundary.stderr" >&2 || true
+  fail "deadline event overrode an atomically completed worker"
+fi
+assert_contains "$TMP_ROOT/boundary-answer" "instant answer" \
+  "completion wins the post-worker deadline boundary"
+assert_contains "$TMP_ROOT/boundary.stderr" "__SECOND_OPINION_EXIT_boundary__=137" \
+  "the supervisor published the worker status, not its deadline"
+assert_not_contains "$TMP_ROOT/boundary.stderr" "reached its supervisor deadline" \
+  "an elapsed deadline did not become the run result"
+
+# Control: the same staged state against a supervisor whose deadline branch has
+# lost its published-status guard must report the deadline instead. Without it
+# the case above cannot say which branch decided the run.
+cp -R "$TMP_ROOT/proj/skills/second-opinion/scripts" "$TMP_ROOT/mutant"
+MUTANT="$TMP_ROOT/mutant/second-opinion-runtime"
+sed 's/&& ! -f "\$status_file" //' "$RUNTIME" > "$MUTANT.new"
+mv -f "$MUTANT.new" "$MUTANT"
+chmod +x "$MUTANT"
+if cmp -s "$RUNTIME" "$MUTANT"; then
+  fail "deadline control mutated nothing"
+fi
+mutant_rc="$(run_boundary_case "$MUTANT" "$TMP_ROOT/mutant-runtime" \
+  "$TMP_ROOT/mutant-answer" "$TMP_ROOT/mutant.stderr")"
+[[ $mutant_rc -eq 124 ]] \
+  || fail "deadline control accepted a supervisor that ignores a published status"
+assert_contains "$TMP_ROOT/mutant.stderr" "reached its supervisor deadline" \
+  "the deadline control rejects a live mutant"

--- a/skills/second-opinion/tests/self-background.test.sh
+++ b/skills/second-opinion/tests/self-background.test.sh
@@ -460,29 +460,6 @@ done
 [[ $resume_rc -eq 0 ]] || fail "resumed wait did not collect the terminal result"
 assert_contains "$TMP_ROOT/resume-answer" "slow answer" \
   "bounded wait resumes to the final artifact"
-cat > "$TMP_ROOT/bin/instant-worker" <<'SH'
-#!/usr/bin/env bash
-output=""
-for arg in "$@"; do case "$arg" in --output=*) output="${arg#--output=}" ;; esac; done
-printf 'instant answer\n' > "$output"
-printf '0\n' > "$BOUNDARY_STATUS_DIR/worker.status"
-sleep 1.2
-SH
-chmod +x "$TMP_ROOT/bin/instant-worker"
-mkdir "$TMP_ROOT/boundary-runtime"
-BOUNDARY_STATUS_DIR="$TMP_ROOT/boundary-runtime" \
-  "$RUNTIME" launch "$TMP_ROOT/bin/instant-worker" "$TMP_ROOT/boundary-answer" \
-    "$TMP_ROOT/boundary-runtime" 2 false 1 3 x >"$TMP_ROOT/boundary-launch.stdout"
-boundary_wait_cmd="$(sed -n 's/^wait: //p' "$TMP_ROOT/boundary-launch.stdout")"
-boundary_rc=0
-bash -c "$boundary_wait_cmd" >"$TMP_ROOT/boundary-wait.stdout" \
-  2>"$TMP_ROOT/boundary-wait.stderr" || boundary_rc=$?
-if [[ $boundary_rc -ne 0 ]]; then
-  sed -n '1,100p' "$TMP_ROOT/boundary-wait.stderr" >&2 || true
-  fail "deadline event overrode an atomically completed worker"
-fi
-assert_contains "$TMP_ROOT/boundary-answer" "instant answer" \
-  "completion wins the post-worker deadline boundary"
 cat > "$TMP_ROOT/bin/empty-worker" <<'SH'
 #!/usr/bin/env bash
 exit 0

--- a/skills/second-opinion/tests/supervisor-deadline-boundary.test.sh
+++ b/skills/second-opinion/tests/supervisor-deadline-boundary.test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The detached supervisor's deadline event must not override a completion
+# status the worker has already published. The state is staged, never raced:
+# the status file is on disk before the run starts, the deadline is already
+# elapsed so the watchdog posts its event unconditionally rather than on a
+# timer, and the worker is killed before the runtime can post a worker event —
+# so the deadline event is the only one the supervisor can read. Nothing here
+# depends on the clock or on process scheduling.
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+fail() { printf 'FAIL: %s\n' "$1" >&2; exit 1; }
+assert_contains() { grep -Fq "$2" "$1" || fail "$3"; printf 'PASS: %s\n' "$3"; }
+assert_not_contains() {
+  if grep -Fq "$2" "$1"; then fail "$3"; fi
+  printf 'PASS: %s\n' "$3"
+}
+
+mkdir -p "$TMP_ROOT/proj/skills" "$TMP_ROOT/bin"
+cp -R "$REPO_ROOT/skills/second-opinion" "$TMP_ROOT/proj/skills/second-opinion"
+RUNTIME="$TMP_ROOT/proj/skills/second-opinion/scripts/second-opinion-runtime"
+
+# SIGKILL on the runtime's worker subshell leaves a published status behind
+# with no worker event to announce it — the exact state the deadline event
+# must not override. The subshell dies at 137, which is the status staged
+# below, so the supervisor's status/exit agreement check still has to pass.
+cat > "$TMP_ROOT/bin/staged-worker" <<'SH'
+#!/usr/bin/env bash
+output=""
+for arg in "$@"; do case "$arg" in --output=*) output="${arg#--output=}" ;; esac; done
+printf 'instant answer\n' > "$output"
+kill -KILL "$PPID"
+kill -KILL $$
+SH
+chmod +x "$TMP_ROOT/bin/staged-worker"
+
+run_boundary_case() {
+  local runtime="$1" runtime_dir="$2" artifact="$3" stderr_file="$4" rc=0
+  mkdir "$runtime_dir"
+  printf 'boundary\n' > "$runtime_dir/token"
+  printf '137\n' > "$runtime_dir/worker.status"
+  "$runtime" supervise "$TMP_ROOT/bin/staged-worker" "$artifact" "$runtime_dir" \
+    "$(date +%s)" false boundary 1 x >/dev/null 2>"$stderr_file" || rc=$?
+  printf '%s\n' "$rc"
+}
+
+boundary_rc="$(run_boundary_case "$RUNTIME" "$TMP_ROOT/boundary-runtime" \
+  "$TMP_ROOT/boundary-answer" "$TMP_ROOT/boundary.stderr")"
+if [[ $boundary_rc -ne 137 ]]; then
+  sed -n '1,100p' "$TMP_ROOT/boundary.stderr" >&2 || true
+  fail "deadline event overrode an atomically completed worker"
+fi
+assert_contains "$TMP_ROOT/boundary-answer" "instant answer" \
+  "completion wins the post-worker deadline boundary"
+assert_contains "$TMP_ROOT/boundary.stderr" "__SECOND_OPINION_EXIT_boundary__=137" \
+  "the supervisor published the worker status, not its deadline"
+assert_not_contains "$TMP_ROOT/boundary.stderr" "reached its supervisor deadline" \
+  "an elapsed deadline did not become the run result"
+
+# Control: the same staged state against a supervisor whose deadline branch has
+# lost its published-status guard must report the deadline instead. Without it
+# the case above cannot say which branch decided the run.
+cp -R "$TMP_ROOT/proj/skills/second-opinion/scripts" "$TMP_ROOT/mutant"
+MUTANT="$TMP_ROOT/mutant/second-opinion-runtime"
+sed 's/&& ! -f "\$status_file" //' "$RUNTIME" > "$MUTANT.new"
+mv -f "$MUTANT.new" "$MUTANT"
+chmod +x "$MUTANT"
+if cmp -s "$RUNTIME" "$MUTANT"; then
+  fail "deadline control mutated nothing"
+fi
+mutant_rc="$(run_boundary_case "$MUTANT" "$TMP_ROOT/mutant-runtime" \
+  "$TMP_ROOT/mutant-answer" "$TMP_ROOT/mutant.stderr")"
+[[ $mutant_rc -eq 124 ]] \
+  || fail "deadline control accepted a supervisor that ignores a published status"
+assert_contains "$TMP_ROOT/mutant.stderr" "reached its supervisor deadline" \
+  "the deadline control rejects a live mutant"


### PR DESCRIPTION
`self-background.test.sh`'s case "deadline event overrode an atomically completed worker" ejected two unrelated PRs from the merge group in one shift — #1849 and #1857, neither touching `skills/second-opinion`. Each re-arm costs a full merge-group run, charged to whichever PR is in the group.

## The defect is the test, and the evidence says so

Both ejections printed `second-opinion: deadline passed without terminal completion; rerun the same wait command` — `wait_for_run`'s exit 75, not the supervisor's 124. Run `33302798822` line 4208 carries it directly above the `FAIL:`.

`launch` computes `deadline=$(date +%s) + budget`, so `budget 2, grace 1` gives a run window of `1 - frac(launch)` seconds rather than 1 second, and `wait_for_run` clamps its own attempt deadline to that same epoch. A phase sweep reproduces it on an idle machine:

| launch offset in the second | outcome |
|---|---|
| 0.00–0.90 | pass, 24/24 |
| 0.94 | 5/8 exit 75 |
| 0.96 | 2/8 exit 124 |
| 0.98 | 8/8 exit 75 |

Neither exit is a runtime bug. Exit 75 is the documented resumable result, with the supervisor legitimately still running when the waiter hits its bound; 124 is the timeout those arguments asked for. The rule under test — a `deadline` event yielding to an existing `worker.status` — was never wrong. It was being asked the question before the answer existed.

## The fix

The case drives `supervise` directly with every input staged rather than timed: `worker.status` on disk before the run starts, an already-elapsed deadline so the watchdog posts without sleeping, and a worker that SIGKILLs the runtime's worker subshell so no worker event can reach the event FIFO. The deadline event is the only one the supervisor can read, by construction. No retry, no loop, no widened margin.

It moves to its own file rather than raising a baseline row: the staged case needs none of `self-background`'s launch/wait fixtures, and that file was already at the 800-line test-class cap.

## Control

The same staged state against a runtime whose deadline branch has lost `! -f "$status_file"` must return 124, and the control fails if the mutation is a no-op.

Verified independently of the author: mutating that guard in the worktree takes the suite to `FAIL ... __SECOND_OPINION_EXIT_boundary__=124`, then reverts clean. Ten consecutive green runs, five of them under eight busy cores, where the old case failed 8/8 at the worst launch phase on an idle machine.

Closes KEN-872
