### PR TITLE
fix(KEN-863): a Codex dialog is a question, its composer is idle

### DIFF
--- a/.agents/skills/orch/scripts/oversee-watch
+++ b/.agents/skills/orch/scripts/oversee-watch
@@ -83,19 +83,20 @@ PW_STATE_DIR="${OVERSEE_WATCH_STATE_DIR:-$PROJECT_ROOT/tmp/oversee-watch}"
 
 # Every pane predicate lives here, one line each, matched with `grep -E`
 # against the whole pane capture.
-QUESTION_RE='❯ [0-9]+\. |Do you want to|Enter to select|Esc to cancel'
-# The account is spent. Both harnesses: Claude Code opens the banner with
-# "You've hit your <bucket> limit" / "You've reached your…" and points at
-# /usage-credits; Codex prints "Usage limit reached" and its out-of-credits
-# wording. `.` stands in for the apostrophe, which is ASCII in the binaries
-# and typographic once rendered.
+# A dialog waiting on an answer: the selected numbered row, drawn with each
+# harness's marker; Claude Code's question and key hints; Codex's enter hint.
+QUESTION_RE='(❯|›) [0-9]+\. |Do you want to|Enter to select|Esc to cancel|Press enter to '
+# The account is spent. Claude Code opens the banner with "You've hit your
+# <bucket> limit" / "You've reached your…" and points at /usage-credits; Codex
+# prints "Usage limit reached" and its out-of-credits wording. `.` stands in
+# for the apostrophe: ASCII in the binaries, typographic once rendered.
 USAGE_LIMIT_RE='You.(ve|re) (hit|reached) your [a-z ]*limit|[Uu]sage limit reached|hit usage limits|out of (usage )?credits|/usage-credits'
 # A turn in flight: the interrupt hint (both harnesses), the hint shown while
 # a foreground shell runs, or the streaming token counter of the status line.
 WORKING_RE='to interrupt|to run in background|↓ [0-9][0-9.]*[kKmM]? tokens'
-# A ready input prompt: Claude Code's composer line, Codex's submit hint.
-# Present while working too, so it decides idleness only with WORKING_RE out.
-IDLE_PROMPT_RE='^❯|to submit message'
+# A ready input prompt: either harness's marker at column 0, or Codex's submit
+# hint. Present while working, so it decides idleness only with WORKING_RE out.
+IDLE_PROMPT_RE='^❯|^›|to submit message'
 # The marker each harness draws at column 0 for a submitted user message
 # echoed into the transcript AND for the composer the lane sits at: Claude
 # Code `❯`, Codex `›`. Spelled as an alternation of literals and NEVER as a
@@ -106,9 +107,8 @@ IDLE_PROMPT_RE='^❯|to submit message'
 PANE_MARKER_RE='^❯|^›'
 # The live input a lane is sitting at, as opposed to a turn it already took:
 # one signature per harness, both measured off a running session.
-#   Claude Code draws its composer as the marker then U+00A0, with or without
-#   an unsent draft, and indents its dialog rows, so only the composer reaches
-#   column 0 as live input.
+#   Claude Code draws its composer as the marker then U+00A0, draft or not,
+#   and indents its dialog rows, so only the composer reaches column 0.
 #   Codex draws its composer, its placeholder, its draft AND its selected
 #   dialog row all as the marker, a blank and text — the same shape as a turn —
 #   and always draws one of them below the transcript. So every Codex screen
@@ -184,9 +184,9 @@ Events, checked in this order every pass:
                              turn (last 40 non-empty pane lines follow)
   EVENT idle-after-return <lane>
                              the harness has not exited and its pane sits at
-                             the composer (`❯`, Codex's submit
-                             hint) with no work in flight (no interrupt hint,
-                             no background-shell hint, no streaming token
+                             the composer (Claude Code `❯` or Codex `›` at
+                             column 0) with no work in flight (no interrupt
+                             hint, no background-shell hint, no streaming token
                              counter) on two consecutive passes: the round is
                              over and the lane is waiting on the overseer
                              (last 40 non-empty pane lines follow)

--- a/.agents/skills/orch/scripts/oversee-watch
+++ b/.agents/skills/orch/scripts/oversee-watch
@@ -84,8 +84,8 @@ PW_STATE_DIR="${OVERSEE_WATCH_STATE_DIR:-$PROJECT_ROOT/tmp/oversee-watch}"
 # Every pane predicate lives here, one line each, matched with `grep -E`
 # against the whole pane capture.
 # A dialog waiting on an answer: the selected numbered row, drawn with each
-# harness's marker; Claude Code's question and key hints; Codex's enter hint.
-QUESTION_RE='(❯|›) [0-9]+\. |Do you want to|Enter to select|Esc to cancel|Press enter to '
+# harness's marker, and Claude Code's question and key hints.
+QUESTION_RE='(❯|›) [0-9]+\. |Do you want to|Enter to select|Esc to cancel'
 # The account is spent. Claude Code opens the banner with "You've hit your
 # <bucket> limit" / "You've reached your…" and points at /usage-credits; Codex
 # prints "Usage limit reached" and its out-of-credits wording. `.` stands in

--- a/.agents/skills/orch/tests/fixtures/oversee-watch/codex-composer-draft.txt
+++ b/.agents/skills/orch/tests/fixtures/oversee-watch/codex-composer-draft.txt
@@ -1,0 +1,40 @@
+╭────────────────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.151.0)                         │
+│                                                    │
+│ model:       gpt-5.6-sol high   /model to change   │
+│ directory:   /var/tmp/claude/…/scratchpad/codexcap │
+│ permissions: YOLO mode                             │
+╰────────────────────────────────────────────────────╯
+
+  Tip: Try the Desktop app on Linux: install it from https://learn.chatgpt.com/docs/linux/linux-app and run 'chatgpt'.
+
+• You have 1 usage limit reset available. Run /usage to use one.
+
+
+› some draft text
+
+  Context 100% left · /var/tmp/claude/claude-1000/-home-method-dev-kendex/19f120b0-90ae-4c87-aefc-59eec757deb9/scratchp…
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/.agents/skills/orch/tests/fixtures/oversee-watch/codex-composer-idle.txt
+++ b/.agents/skills/orch/tests/fixtures/oversee-watch/codex-composer-idle.txt
@@ -1,0 +1,40 @@
+╭────────────────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.151.0)                         │
+│                                                    │
+│ model:       gpt-5.6-sol high   /model to change   │
+│ directory:   /var/tmp/claude/…/scratchpad/codexcap │
+│ permissions: YOLO mode                             │
+╰────────────────────────────────────────────────────╯
+
+  Tip: Try the Desktop app on Linux: install it from https://learn.chatgpt.com/docs/linux/linux-app and run 'chatgpt'.
+
+• You have 1 usage limit reset available. Run /usage to use one.
+
+
+› Ask Codex to do anything
+
+  Context 100% left · /var/tmp/claude/claude-1000/-home-method-dev-kendex/19f120b0-90ae-4c87-aefc-59eec757deb9/scratchp…
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/.agents/skills/orch/tests/fixtures/oversee-watch/codex-dialog-model.txt
+++ b/.agents/skills/orch/tests/fixtures/oversee-watch/codex-dialog-model.txt
@@ -1,0 +1,40 @@
+╭────────────────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.151.0)                         │
+│                                                    │
+│ model:       gpt-5.6-sol high   /model to change   │
+│ directory:   /var/tmp/claude/…/scratchpad/codexcap │
+│ permissions: YOLO mode                             │
+╰────────────────────────────────────────────────────╯
+
+  Tip: Try the Desktop app on Linux: install it from https://learn.chatgpt.com/docs/linux/linux-app and run 'chatgpt'.
+
+• You have 1 usage limit reset available. Run /usage to use one.
+
+
+  Select Model and Effort
+  Access legacy models by running codex -m <model_name> or in your config.toml
+
+› 1. gpt-5.6-sol (current)  Latest frontier agentic coding model.
+  2. gpt-5.6-terra          Balanced agentic coding model for everyday work.
+  3. gpt-5.6-luna           Fast and affordable agentic coding model.
+  4. gpt-5.5                Frontier model for complex coding, research, and real-world work.
+  5. gpt-5.4                Strong model for everyday coding.
+  6. gpt-5.4-mini           Small, fast, and cost-efficient model for simpler coding tasks.
+  7. gpt-5.3-codex-spark    Ultra-fast coding model.
+
+  Press enter to confirm or esc to go back
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/.agents/skills/orch/tests/fixtures/oversee-watch/codex-dialog-trust.txt
+++ b/.agents/skills/orch/tests/fixtures/oversee-watch/codex-dialog-trust.txt
@@ -1,0 +1,40 @@
+> You are in /var/tmp/claude/claude-1000/-home-method-dev-kendex/19f120b0-90ae-4c87-aefc-59eec757deb9/scratchpad/codexca
+
+  Do you trust the contents of this directory? Working with untrusted contents comes with higher risk of prompt
+  injection. Trusting the directory allows project-local config, hooks, and exec policies to load.
+
+› 1. Yes, continue
+  2. No, quit
+
+  Press enter to continue
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/.agents/skills/orch/tests/fixtures/oversee-watch/codex-idle-after-turn.txt
+++ b/.agents/skills/orch/tests/fixtures/oversee-watch/codex-idle-after-turn.txt
@@ -1,0 +1,40 @@
+  repository settings, auto-merge may wait for B to update, trigger another test cycle, or merge B with results that are
+  now stale. Auto-merge automates the final click, but it does not necessarily coordinate competing changes.
+
+  A merge queue creates a candidate based on the branch state that would actually exist when the queued change lands.
+  After A merges, the queue builds and tests B on top of A. B reaches the target branch only if that candidate passes
+  the required checks. If the branch changes again before B lands, the queue may rebuild the candidate and rerun its
+  checks. This gives the repository a stronger guarantee: the system tested the proposed result, not merely the pull
+  request in isolation against yesterday’s branch tip.
+
+  Queues also impose order. Ready pull requests enter a line, although administrators may provide priorities or allow
+  urgent changes to move ahead. Some systems test one entry at a time. Others use speculative execution, preparing later
+  entries while earlier ones are still running. A queue may also batch several pull requests into one candidate to
+  improve throughput. Batching is faster, but a failed batch requires the system to identify which change caused the
+  problem. The exact strategy differs by platform, but the queue owns sequencing. Plain auto-merge generally leaves
+  sequencing to whichever pull request becomes eligible first.
+
+  Failure behavior is another practical difference. If a queued candidate fails, the queue can remove that entry,
+  preserve the healthy entries behind it, and continue processing. The failed pull request returns to its author with
+  evidence tied to the combined branch state. A merge conflict, new commit, dismissed approval, or changed requirement
+  may also remove or rebuild an entry. Auto-merge usually has a narrower response. It keeps waiting until the individual
+  pull request becomes eligible, or disables itself when the pull request changes.
+
+  Neither mechanism replaces continuous integration or branch protection. Reviews and required checks still determine
+  whether a change is ready. The queue adds a controlled validation step between “ready” and “merged.” That step costs
+  time and computing capacity. Flaky tests can stall a queue, long test suites can increase waiting time, and poor queue
+  visibility can frustrate developers. Teams therefore need sensible timeouts, retry policies, priority rules, and clear
+  status reporting.
+
+  Plain auto-merge works well when changes arrive infrequently, checks are fast, and collisions are rare. It removes
+  routine waiting with little operational complexity. A merge queue becomes valuable when many developers merge
+  concurrently or when keeping the target branch green matters more than landing each change at the first possible
+  moment. In short, auto-merge asks, “May this pull request merge now?” A merge queue asks, “Can this pull request
+  safely become the next state of the branch?”
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+
+› Ask Codex to do anything
+
+  Context 99% left · /var/tmp/claude/claude-1000/-home-method-dev-kendex/19f120b0-90ae-4c87-aefc-59eec757deb9/scratchpa…

--- a/.agents/skills/orch/tests/fixtures/oversee-watch/codex-working.txt
+++ b/.agents/skills/orch/tests/fixtures/oversee-watch/codex-working.txt
@@ -1,0 +1,40 @@
+╭───────────────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.151.0)                        │
+│                                                   │
+│ model:     gpt-5.6-sol high   /model to change    │
+│ directory: /var/tmp/claude/…/scratchpad/codexwork │
+╰───────────────────────────────────────────────────╯
+
+  Tip: New Use /fast to enable our fastest inference with increased plan usage.
+
+• You have 1 usage limit reset available. Run /usage to use one.
+
+
+› Write a detailed 600-word explanation of how a merge queue differs from plain auto-merge. Prose only, no commands, no
+  file reads.
+
+
+• I’m applying the required unslop writing guidance to keep the explanation natural and precise.
+
+• Explored
+  └ Read SKILL.md
+
+• Working (8s • esc to interrupt)
+
+
+› Ask Codex to do anything
+
+  Context 100% left · /var/tmp/claude/claude-1000/-home-method-dev-kendex/19f120b0-90ae-4c87-aefc-59eec757deb9/scratchp…
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/.agents/skills/orch/tests/oversee_watch_lanes.sh
+++ b/.agents/skills/orch/tests/oversee_watch_lanes.sh
@@ -638,21 +638,31 @@ assert_eq "$(head -1 <<<"$out")" "EVENT idle-after-return gh-2" \
   "an idle prompt on two consecutive passes is the event" "$err"
 assert_contains "$out" "the PR is merged" "the pane tail follows the idle event" "$err"
 
-# Codex's ready prompt reads differently and counts the same. Its composer
-# draws no submit hint at all — only the marker and either the placeholder or
-# an unsent draft — so the marker is what has to carry idleness. The fixture
-# is the capture: the hint this case used to assert on renders nowhere here.
+# Codex's ready prompt reads differently and counts the same. The fixture is
+# the state this event is named for: a lane that finished its turn and is
+# waiting. Codex draws no submit hint at its composer — only the marker and
+# either the placeholder or an unsent draft — so the marker carries idleness,
+# and the hint this case used to assert on renders on none of these screens.
 new_case idle_after_return_codex
 printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
-cat "$CODEX_PANES/codex-composer-idle.txt" > "$STUB_DIR/pane-gh-2.txt"
+cat "$CODEX_PANES/codex-idle-after-turn.txt" > "$STUB_DIR/pane-gh-2.txt"
 err="$TMP_ROOT/e4b2"
 out="$(run_watch -- gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
 assert_eq "$(head -1 <<<"$out")" "EVENT idle-after-return gh-2" \
-  "a codex lane at its composer is idle too" "$err"
+  "a codex lane that finished its turn is idle too" "$err"
 assert_not_contains "$(cat "$STUB_DIR/pane-gh-2.txt")" "to submit message" \
   "the real composer carries no submit hint, so the marker alone decides" "$err"
 
-# ...and holding an unsent draft, which has the same shape as a taken turn
+# ...a composer the lane never took a turn at, and one holding an unsent
+# draft, which has the same shape as a turn already taken
+new_case idle_after_return_codex_composer
+printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
+cat "$CODEX_PANES/codex-composer-idle.txt" > "$STUB_DIR/pane-gh-2.txt"
+err="$TMP_ROOT/e4b2a"
+out="$(run_watch -- gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
+assert_eq "$(head -1 <<<"$out")" "EVENT idle-after-return gh-2" \
+  "a codex lane at a fresh composer is idle too" "$err"
+
 new_case idle_after_return_codex_draft
 printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
 cat "$CODEX_PANES/codex-composer-draft.txt" > "$STUB_DIR/pane-gh-2.txt"
@@ -660,6 +670,26 @@ err="$TMP_ROOT/e4b2b"
 out="$(run_watch -- gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
 assert_eq "$(head -1 <<<"$out")" "EVENT idle-after-return gh-2" \
   "a codex composer holding a draft is idle too" "$err"
+
+# The gate that makes the Codex marker safe to read as an idle prompt. Codex
+# draws its composer BELOW the working indicator, so the marker is on screen
+# for the whole turn and WORKING_RE alone keeps a busy lane out. It matches
+# through `to interrupt`, which is what `• Working (8s • esc to interrupt)`
+# carries; refresh this capture against a Codex that words it differently and
+# this case goes red rather than waking every busy lane.
+new_case idle_after_return_codex_working
+printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
+cat "$CODEX_PANES/codex-working.txt" > "$STUB_DIR/pane-gh-2.txt"
+err="$TMP_ROOT/e4b2c"
+out="$(run_watch -- gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
+assert_contains "$(cat "$STUB_DIR/pane-gh-2.txt")" "› Ask Codex to do anything" \
+  "a busy codex screen draws its composer, so the marker cannot decide alone" "$err"
+assert_contains "$(cat "$STUB_DIR/pane-gh-2.txt")" "esc to interrupt" \
+  "the interrupt hint is the alternative carrying the gate, not the token counter" "$err"
+assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=2 interval=0s since=none" \
+  "a working codex lane is not idle, its marker notwithstanding" "$err"
+assert_not_contains "$out" "EVENT idle-after-return" \
+  "WORKING_RE is what keeps the codex marker from waking a busy lane" "$err"
 
 # The idle check reads the same liveness answer too
 new_case idle_after_return_wrapped_shell

--- a/.agents/skills/orch/tests/oversee_watch_lanes.sh
+++ b/.agents/skills/orch/tests/oversee_watch_lanes.sh
@@ -549,10 +549,11 @@ out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
 assert_eq "$(head -1 <<<"$out")" "EVENT question gh-2" \
   "a wrapped lane's question is still the event" "$err"
 
-# Codex on a dialog. It marks the row it has selected with `›`, not `❯`,
-# and closes the screen with its own enter hint, so nothing Claude Code draws
-# reaches these two screens: before KEN-863 both fell through every predicate
-# and the pass said nothing about the lane.
+# Codex on a dialog. It marks the row it has selected with `›`, not `❯`, and
+# words its key hints its own way, so nothing Claude Code draws reaches these
+# two screens: before KEN-863 both fell through every predicate and the pass
+# said nothing about the lane. The marker is the whole signature — these two
+# cases are what proves a Codex enter hint would be redundant.
 new_case question_codex_dialog_trust
 printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
 cat "$CODEX_PANES/codex-dialog-trust.txt" > "$STUB_DIR/pane-gh-2.txt"

--- a/.agents/skills/orch/tests/oversee_watch_lanes.sh
+++ b/.agents/skills/orch/tests/oversee_watch_lanes.sh
@@ -19,11 +19,12 @@
 #       lane claim maps the window to; a pruned claim names none; a healthy
 #       pane never fires; a banner under an exited harness is lane-exited
 #       instead; and a banner above a later user turn is scrollback, while
-#       one below that turn still fires
+#       one below that turn still fires. Codex's benign reset OFFER is not a
+#       spent account
 #   4.  a lane pane showing a question prompt (pane tail follows), under a
-#       wrapped shell too; a selection list above the last user turn is one
-#       the lane already answered and never fires, while one below that turn
-#       still does
+#       wrapped shell too, and on either harness's dialog screen; a selection
+#       list above the last user turn is one the lane already answered and
+#       never fires, while one below that turn still does
 #   4b. idle-after-return: a harness at its composer with nothing in flight
 #       on two consecutive passes (either harness's prompt, and under a
 #       wrapped shell); one pass alone, a working indicator alongside the
@@ -32,6 +33,12 @@ set -euo pipefail
 
 # shellcheck source=lib/oversee-watch-harness.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/oversee-watch-harness.sh"
+
+# Byte-exact 120x40 captures of a live Codex 0.151.0 pane, recorded for
+# KEN-863. A Codex shape is asserted from one of these, never hand-written:
+# every predicate in this area that was reasoned instead of measured has been
+# wrong about the screen it claimed to describe.
+CODEX_PANES="$REPO_ROOT/skills/orch/tests/fixtures/oversee-watch"
 
 echo "=== oversee-watch lanes ==="
 
@@ -316,10 +323,25 @@ printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
 } > "$STUB_DIR/pane-gh-2.txt"
 err="$TMP_ROOT/e3fd"
 out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=1 interval=0s since=none" \
+assert_eq "$(head -1 <<<"$out")" "EVENT question gh-2" \
   "a codex dialog row is live input, so the banner above the turn stays scrollback" "$err"
 assert_not_contains "$out" "EVENT usage-limit" \
   "the codex dialog row never resurrects a stale banner" "$err"
+
+# The near-miss control. Every fresh Codex prints a benign reset OFFER, and
+# loosening USAGE_LIMIT_RE toward a bare `usage limit` would turn the startup
+# screen of every Codex lane into a spent-account event.
+new_case usage_limit_codex_reset_offer
+printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
+cat "$CODEX_PANES/codex-composer-idle.txt" > "$STUB_DIR/pane-gh-2.txt"
+err="$TMP_ROOT/e3fg"
+out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
+assert_contains "$(cat "$STUB_DIR/pane-gh-2.txt")" "You have 1 usage limit reset available" \
+  "the fixture really carries the reset offer, so the control is not vacuous" "$err"
+assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=1 interval=0s since=none" \
+  "a codex startup screen is no event at all" "$err"
+assert_not_contains "$out" "EVENT usage-limit" \
+  "an offered reset is credit to spend, never a spent account" "$err"
 
 # ...and its control: the banner below the turn on the same dialog screen
 new_case usage_limit_codex_dialog_live_banner
@@ -527,6 +549,30 @@ out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
 assert_eq "$(head -1 <<<"$out")" "EVENT question gh-2" \
   "a wrapped lane's question is still the event" "$err"
 
+# Codex on a dialog. It marks the row it has selected with `›`, not `❯`,
+# and closes the screen with its own enter hint, so nothing Claude Code draws
+# reaches these two screens: before KEN-863 both fell through every predicate
+# and the pass said nothing about the lane.
+new_case question_codex_dialog_trust
+printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
+cat "$CODEX_PANES/codex-dialog-trust.txt" > "$STUB_DIR/pane-gh-2.txt"
+err="$TMP_ROOT/e4c1"
+out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
+assert_eq "$(head -1 <<<"$out")" "EVENT question gh-2" \
+  "a codex directory-trust dialog is a question" "$err"
+assert_contains "$out" "Do you trust the contents of this directory?" \
+  "the pane tail carries what the lane is being asked" "$err"
+
+new_case question_codex_dialog_model
+printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
+cat "$CODEX_PANES/codex-dialog-model.txt" > "$STUB_DIR/pane-gh-2.txt"
+err="$TMP_ROOT/e4c2"
+out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
+assert_eq "$(head -1 <<<"$out")" "EVENT question gh-2" \
+  "a codex model picker is a question" "$err"
+assert_contains "$out" "Select Model and Effort" \
+  "the pane tail carries the choice on offer" "$err"
+
 # A tmux window name carries any character, so two lanes can differ only
 # outside a filename-safe set. Their pane snapshots must stay separate or each
 # lane is classified on the other's screen.
@@ -592,14 +638,28 @@ assert_eq "$(head -1 <<<"$out")" "EVENT idle-after-return gh-2" \
   "an idle prompt on two consecutive passes is the event" "$err"
 assert_contains "$out" "the PR is merged" "the pane tail follows the idle event" "$err"
 
-# Codex's ready prompt reads differently and counts the same
+# Codex's ready prompt reads differently and counts the same. Its composer
+# draws no submit hint at all — only the marker and either the placeholder or
+# an unsent draft — so the marker is what has to carry idleness. The fixture
+# is the capture: the hint this case used to assert on renders nowhere here.
 new_case idle_after_return_codex
 printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
-printf '· Ran the test suite\n  ⏎ to submit message\n' > "$STUB_DIR/pane-gh-2.txt"
+cat "$CODEX_PANES/codex-composer-idle.txt" > "$STUB_DIR/pane-gh-2.txt"
 err="$TMP_ROOT/e4b2"
 out="$(run_watch -- gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
 assert_eq "$(head -1 <<<"$out")" "EVENT idle-after-return gh-2" \
-  "a codex lane at its submit prompt is idle too" "$err"
+  "a codex lane at its composer is idle too" "$err"
+assert_not_contains "$(cat "$STUB_DIR/pane-gh-2.txt")" "to submit message" \
+  "the real composer carries no submit hint, so the marker alone decides" "$err"
+
+# ...and holding an unsent draft, which has the same shape as a taken turn
+new_case idle_after_return_codex_draft
+printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
+cat "$CODEX_PANES/codex-composer-draft.txt" > "$STUB_DIR/pane-gh-2.txt"
+err="$TMP_ROOT/e4b2b"
+out="$(run_watch -- gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
+assert_eq "$(head -1 <<<"$out")" "EVENT idle-after-return gh-2" \
+  "a codex composer holding a draft is idle too" "$err"
 
 # The idle check reads the same liveness answer too
 new_case idle_after_return_wrapped_shell

--- a/skills/orch/scripts/oversee-watch
+++ b/skills/orch/scripts/oversee-watch
@@ -83,19 +83,20 @@ PW_STATE_DIR="${OVERSEE_WATCH_STATE_DIR:-$PROJECT_ROOT/tmp/oversee-watch}"
 
 # Every pane predicate lives here, one line each, matched with `grep -E`
 # against the whole pane capture.
-QUESTION_RE='❯ [0-9]+\. |Do you want to|Enter to select|Esc to cancel'
-# The account is spent. Both harnesses: Claude Code opens the banner with
-# "You've hit your <bucket> limit" / "You've reached your…" and points at
-# /usage-credits; Codex prints "Usage limit reached" and its out-of-credits
-# wording. `.` stands in for the apostrophe, which is ASCII in the binaries
-# and typographic once rendered.
+# A dialog waiting on an answer: the selected numbered row, drawn with each
+# harness's marker; Claude Code's question and key hints; Codex's enter hint.
+QUESTION_RE='(❯|›) [0-9]+\. |Do you want to|Enter to select|Esc to cancel|Press enter to '
+# The account is spent. Claude Code opens the banner with "You've hit your
+# <bucket> limit" / "You've reached your…" and points at /usage-credits; Codex
+# prints "Usage limit reached" and its out-of-credits wording. `.` stands in
+# for the apostrophe: ASCII in the binaries, typographic once rendered.
 USAGE_LIMIT_RE='You.(ve|re) (hit|reached) your [a-z ]*limit|[Uu]sage limit reached|hit usage limits|out of (usage )?credits|/usage-credits'
 # A turn in flight: the interrupt hint (both harnesses), the hint shown while
 # a foreground shell runs, or the streaming token counter of the status line.
 WORKING_RE='to interrupt|to run in background|↓ [0-9][0-9.]*[kKmM]? tokens'
-# A ready input prompt: Claude Code's composer line, Codex's submit hint.
-# Present while working too, so it decides idleness only with WORKING_RE out.
-IDLE_PROMPT_RE='^❯|to submit message'
+# A ready input prompt: either harness's marker at column 0, or Codex's submit
+# hint. Present while working, so it decides idleness only with WORKING_RE out.
+IDLE_PROMPT_RE='^❯|^›|to submit message'
 # The marker each harness draws at column 0 for a submitted user message
 # echoed into the transcript AND for the composer the lane sits at: Claude
 # Code `❯`, Codex `›`. Spelled as an alternation of literals and NEVER as a
@@ -106,9 +107,8 @@ IDLE_PROMPT_RE='^❯|to submit message'
 PANE_MARKER_RE='^❯|^›'
 # The live input a lane is sitting at, as opposed to a turn it already took:
 # one signature per harness, both measured off a running session.
-#   Claude Code draws its composer as the marker then U+00A0, with or without
-#   an unsent draft, and indents its dialog rows, so only the composer reaches
-#   column 0 as live input.
+#   Claude Code draws its composer as the marker then U+00A0, draft or not,
+#   and indents its dialog rows, so only the composer reaches column 0.
 #   Codex draws its composer, its placeholder, its draft AND its selected
 #   dialog row all as the marker, a blank and text — the same shape as a turn —
 #   and always draws one of them below the transcript. So every Codex screen
@@ -184,9 +184,9 @@ Events, checked in this order every pass:
                              turn (last 40 non-empty pane lines follow)
   EVENT idle-after-return <lane>
                              the harness has not exited and its pane sits at
-                             the composer (`❯`, Codex's submit
-                             hint) with no work in flight (no interrupt hint,
-                             no background-shell hint, no streaming token
+                             the composer (Claude Code `❯` or Codex `›` at
+                             column 0) with no work in flight (no interrupt
+                             hint, no background-shell hint, no streaming token
                              counter) on two consecutive passes: the round is
                              over and the lane is waiting on the overseer
                              (last 40 non-empty pane lines follow)

--- a/skills/orch/scripts/oversee-watch
+++ b/skills/orch/scripts/oversee-watch
@@ -84,8 +84,8 @@ PW_STATE_DIR="${OVERSEE_WATCH_STATE_DIR:-$PROJECT_ROOT/tmp/oversee-watch}"
 # Every pane predicate lives here, one line each, matched with `grep -E`
 # against the whole pane capture.
 # A dialog waiting on an answer: the selected numbered row, drawn with each
-# harness's marker; Claude Code's question and key hints; Codex's enter hint.
-QUESTION_RE='(❯|›) [0-9]+\. |Do you want to|Enter to select|Esc to cancel|Press enter to '
+# harness's marker, and Claude Code's question and key hints.
+QUESTION_RE='(❯|›) [0-9]+\. |Do you want to|Enter to select|Esc to cancel'
 # The account is spent. Claude Code opens the banner with "You've hit your
 # <bucket> limit" / "You've reached your…" and points at /usage-credits; Codex
 # prints "Usage limit reached" and its out-of-credits wording. `.` stands in

--- a/skills/orch/tests/fixtures/oversee-watch/codex-composer-draft.txt
+++ b/skills/orch/tests/fixtures/oversee-watch/codex-composer-draft.txt
@@ -1,0 +1,40 @@
+╭────────────────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.151.0)                         │
+│                                                    │
+│ model:       gpt-5.6-sol high   /model to change   │
+│ directory:   /var/tmp/claude/…/scratchpad/codexcap │
+│ permissions: YOLO mode                             │
+╰────────────────────────────────────────────────────╯
+
+  Tip: Try the Desktop app on Linux: install it from https://learn.chatgpt.com/docs/linux/linux-app and run 'chatgpt'.
+
+• You have 1 usage limit reset available. Run /usage to use one.
+
+
+› some draft text
+
+  Context 100% left · /var/tmp/claude/claude-1000/-home-method-dev-kendex/19f120b0-90ae-4c87-aefc-59eec757deb9/scratchp…
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/skills/orch/tests/fixtures/oversee-watch/codex-composer-idle.txt
+++ b/skills/orch/tests/fixtures/oversee-watch/codex-composer-idle.txt
@@ -1,0 +1,40 @@
+╭────────────────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.151.0)                         │
+│                                                    │
+│ model:       gpt-5.6-sol high   /model to change   │
+│ directory:   /var/tmp/claude/…/scratchpad/codexcap │
+│ permissions: YOLO mode                             │
+╰────────────────────────────────────────────────────╯
+
+  Tip: Try the Desktop app on Linux: install it from https://learn.chatgpt.com/docs/linux/linux-app and run 'chatgpt'.
+
+• You have 1 usage limit reset available. Run /usage to use one.
+
+
+› Ask Codex to do anything
+
+  Context 100% left · /var/tmp/claude/claude-1000/-home-method-dev-kendex/19f120b0-90ae-4c87-aefc-59eec757deb9/scratchp…
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/skills/orch/tests/fixtures/oversee-watch/codex-dialog-model.txt
+++ b/skills/orch/tests/fixtures/oversee-watch/codex-dialog-model.txt
@@ -1,0 +1,40 @@
+╭────────────────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.151.0)                         │
+│                                                    │
+│ model:       gpt-5.6-sol high   /model to change   │
+│ directory:   /var/tmp/claude/…/scratchpad/codexcap │
+│ permissions: YOLO mode                             │
+╰────────────────────────────────────────────────────╯
+
+  Tip: Try the Desktop app on Linux: install it from https://learn.chatgpt.com/docs/linux/linux-app and run 'chatgpt'.
+
+• You have 1 usage limit reset available. Run /usage to use one.
+
+
+  Select Model and Effort
+  Access legacy models by running codex -m <model_name> or in your config.toml
+
+› 1. gpt-5.6-sol (current)  Latest frontier agentic coding model.
+  2. gpt-5.6-terra          Balanced agentic coding model for everyday work.
+  3. gpt-5.6-luna           Fast and affordable agentic coding model.
+  4. gpt-5.5                Frontier model for complex coding, research, and real-world work.
+  5. gpt-5.4                Strong model for everyday coding.
+  6. gpt-5.4-mini           Small, fast, and cost-efficient model for simpler coding tasks.
+  7. gpt-5.3-codex-spark    Ultra-fast coding model.
+
+  Press enter to confirm or esc to go back
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/skills/orch/tests/fixtures/oversee-watch/codex-dialog-trust.txt
+++ b/skills/orch/tests/fixtures/oversee-watch/codex-dialog-trust.txt
@@ -1,0 +1,40 @@
+> You are in /var/tmp/claude/claude-1000/-home-method-dev-kendex/19f120b0-90ae-4c87-aefc-59eec757deb9/scratchpad/codexca
+
+  Do you trust the contents of this directory? Working with untrusted contents comes with higher risk of prompt
+  injection. Trusting the directory allows project-local config, hooks, and exec policies to load.
+
+› 1. Yes, continue
+  2. No, quit
+
+  Press enter to continue
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/skills/orch/tests/fixtures/oversee-watch/codex-idle-after-turn.txt
+++ b/skills/orch/tests/fixtures/oversee-watch/codex-idle-after-turn.txt
@@ -1,0 +1,40 @@
+  repository settings, auto-merge may wait for B to update, trigger another test cycle, or merge B with results that are
+  now stale. Auto-merge automates the final click, but it does not necessarily coordinate competing changes.
+
+  A merge queue creates a candidate based on the branch state that would actually exist when the queued change lands.
+  After A merges, the queue builds and tests B on top of A. B reaches the target branch only if that candidate passes
+  the required checks. If the branch changes again before B lands, the queue may rebuild the candidate and rerun its
+  checks. This gives the repository a stronger guarantee: the system tested the proposed result, not merely the pull
+  request in isolation against yesterday’s branch tip.
+
+  Queues also impose order. Ready pull requests enter a line, although administrators may provide priorities or allow
+  urgent changes to move ahead. Some systems test one entry at a time. Others use speculative execution, preparing later
+  entries while earlier ones are still running. A queue may also batch several pull requests into one candidate to
+  improve throughput. Batching is faster, but a failed batch requires the system to identify which change caused the
+  problem. The exact strategy differs by platform, but the queue owns sequencing. Plain auto-merge generally leaves
+  sequencing to whichever pull request becomes eligible first.
+
+  Failure behavior is another practical difference. If a queued candidate fails, the queue can remove that entry,
+  preserve the healthy entries behind it, and continue processing. The failed pull request returns to its author with
+  evidence tied to the combined branch state. A merge conflict, new commit, dismissed approval, or changed requirement
+  may also remove or rebuild an entry. Auto-merge usually has a narrower response. It keeps waiting until the individual
+  pull request becomes eligible, or disables itself when the pull request changes.
+
+  Neither mechanism replaces continuous integration or branch protection. Reviews and required checks still determine
+  whether a change is ready. The queue adds a controlled validation step between “ready” and “merged.” That step costs
+  time and computing capacity. Flaky tests can stall a queue, long test suites can increase waiting time, and poor queue
+  visibility can frustrate developers. Teams therefore need sensible timeouts, retry policies, priority rules, and clear
+  status reporting.
+
+  Plain auto-merge works well when changes arrive infrequently, checks are fast, and collisions are rare. It removes
+  routine waiting with little operational complexity. A merge queue becomes valuable when many developers merge
+  concurrently or when keeping the target branch green matters more than landing each change at the first possible
+  moment. In short, auto-merge asks, “May this pull request merge now?” A merge queue asks, “Can this pull request
+  safely become the next state of the branch?”
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+
+› Ask Codex to do anything
+
+  Context 99% left · /var/tmp/claude/claude-1000/-home-method-dev-kendex/19f120b0-90ae-4c87-aefc-59eec757deb9/scratchpa…

--- a/skills/orch/tests/fixtures/oversee-watch/codex-working.txt
+++ b/skills/orch/tests/fixtures/oversee-watch/codex-working.txt
@@ -1,0 +1,40 @@
+╭───────────────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.151.0)                        │
+│                                                   │
+│ model:     gpt-5.6-sol high   /model to change    │
+│ directory: /var/tmp/claude/…/scratchpad/codexwork │
+╰───────────────────────────────────────────────────╯
+
+  Tip: New Use /fast to enable our fastest inference with increased plan usage.
+
+• You have 1 usage limit reset available. Run /usage to use one.
+
+
+› Write a detailed 600-word explanation of how a merge queue differs from plain auto-merge. Prose only, no commands, no
+  file reads.
+
+
+• I’m applying the required unslop writing guidance to keep the explanation natural and precise.
+
+• Explored
+  └ Read SKILL.md
+
+• Working (8s • esc to interrupt)
+
+
+› Ask Codex to do anything
+
+  Context 100% left · /var/tmp/claude/claude-1000/-home-method-dev-kendex/19f120b0-90ae-4c87-aefc-59eec757deb9/scratchp…
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/skills/orch/tests/oversee_watch_lanes.sh
+++ b/skills/orch/tests/oversee_watch_lanes.sh
@@ -638,21 +638,31 @@ assert_eq "$(head -1 <<<"$out")" "EVENT idle-after-return gh-2" \
   "an idle prompt on two consecutive passes is the event" "$err"
 assert_contains "$out" "the PR is merged" "the pane tail follows the idle event" "$err"
 
-# Codex's ready prompt reads differently and counts the same. Its composer
-# draws no submit hint at all — only the marker and either the placeholder or
-# an unsent draft — so the marker is what has to carry idleness. The fixture
-# is the capture: the hint this case used to assert on renders nowhere here.
+# Codex's ready prompt reads differently and counts the same. The fixture is
+# the state this event is named for: a lane that finished its turn and is
+# waiting. Codex draws no submit hint at its composer — only the marker and
+# either the placeholder or an unsent draft — so the marker carries idleness,
+# and the hint this case used to assert on renders on none of these screens.
 new_case idle_after_return_codex
 printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
-cat "$CODEX_PANES/codex-composer-idle.txt" > "$STUB_DIR/pane-gh-2.txt"
+cat "$CODEX_PANES/codex-idle-after-turn.txt" > "$STUB_DIR/pane-gh-2.txt"
 err="$TMP_ROOT/e4b2"
 out="$(run_watch -- gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
 assert_eq "$(head -1 <<<"$out")" "EVENT idle-after-return gh-2" \
-  "a codex lane at its composer is idle too" "$err"
+  "a codex lane that finished its turn is idle too" "$err"
 assert_not_contains "$(cat "$STUB_DIR/pane-gh-2.txt")" "to submit message" \
   "the real composer carries no submit hint, so the marker alone decides" "$err"
 
-# ...and holding an unsent draft, which has the same shape as a taken turn
+# ...a composer the lane never took a turn at, and one holding an unsent
+# draft, which has the same shape as a turn already taken
+new_case idle_after_return_codex_composer
+printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
+cat "$CODEX_PANES/codex-composer-idle.txt" > "$STUB_DIR/pane-gh-2.txt"
+err="$TMP_ROOT/e4b2a"
+out="$(run_watch -- gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
+assert_eq "$(head -1 <<<"$out")" "EVENT idle-after-return gh-2" \
+  "a codex lane at a fresh composer is idle too" "$err"
+
 new_case idle_after_return_codex_draft
 printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
 cat "$CODEX_PANES/codex-composer-draft.txt" > "$STUB_DIR/pane-gh-2.txt"
@@ -660,6 +670,26 @@ err="$TMP_ROOT/e4b2b"
 out="$(run_watch -- gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
 assert_eq "$(head -1 <<<"$out")" "EVENT idle-after-return gh-2" \
   "a codex composer holding a draft is idle too" "$err"
+
+# The gate that makes the Codex marker safe to read as an idle prompt. Codex
+# draws its composer BELOW the working indicator, so the marker is on screen
+# for the whole turn and WORKING_RE alone keeps a busy lane out. It matches
+# through `to interrupt`, which is what `• Working (8s • esc to interrupt)`
+# carries; refresh this capture against a Codex that words it differently and
+# this case goes red rather than waking every busy lane.
+new_case idle_after_return_codex_working
+printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
+cat "$CODEX_PANES/codex-working.txt" > "$STUB_DIR/pane-gh-2.txt"
+err="$TMP_ROOT/e4b2c"
+out="$(run_watch -- gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
+assert_contains "$(cat "$STUB_DIR/pane-gh-2.txt")" "› Ask Codex to do anything" \
+  "a busy codex screen draws its composer, so the marker cannot decide alone" "$err"
+assert_contains "$(cat "$STUB_DIR/pane-gh-2.txt")" "esc to interrupt" \
+  "the interrupt hint is the alternative carrying the gate, not the token counter" "$err"
+assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=2 interval=0s since=none" \
+  "a working codex lane is not idle, its marker notwithstanding" "$err"
+assert_not_contains "$out" "EVENT idle-after-return" \
+  "WORKING_RE is what keeps the codex marker from waking a busy lane" "$err"
 
 # The idle check reads the same liveness answer too
 new_case idle_after_return_wrapped_shell

--- a/skills/orch/tests/oversee_watch_lanes.sh
+++ b/skills/orch/tests/oversee_watch_lanes.sh
@@ -549,10 +549,11 @@ out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
 assert_eq "$(head -1 <<<"$out")" "EVENT question gh-2" \
   "a wrapped lane's question is still the event" "$err"
 
-# Codex on a dialog. It marks the row it has selected with `›`, not `❯`,
-# and closes the screen with its own enter hint, so nothing Claude Code draws
-# reaches these two screens: before KEN-863 both fell through every predicate
-# and the pass said nothing about the lane.
+# Codex on a dialog. It marks the row it has selected with `›`, not `❯`, and
+# words its key hints its own way, so nothing Claude Code draws reaches these
+# two screens: before KEN-863 both fell through every predicate and the pass
+# said nothing about the lane. The marker is the whole signature — these two
+# cases are what proves a Codex enter hint would be redundant.
 new_case question_codex_dialog_trust
 printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
 cat "$CODEX_PANES/codex-dialog-trust.txt" > "$STUB_DIR/pane-gh-2.txt"

--- a/skills/orch/tests/oversee_watch_lanes.sh
+++ b/skills/orch/tests/oversee_watch_lanes.sh
@@ -19,11 +19,12 @@
 #       lane claim maps the window to; a pruned claim names none; a healthy
 #       pane never fires; a banner under an exited harness is lane-exited
 #       instead; and a banner above a later user turn is scrollback, while
-#       one below that turn still fires
+#       one below that turn still fires. Codex's benign reset OFFER is not a
+#       spent account
 #   4.  a lane pane showing a question prompt (pane tail follows), under a
-#       wrapped shell too; a selection list above the last user turn is one
-#       the lane already answered and never fires, while one below that turn
-#       still does
+#       wrapped shell too, and on either harness's dialog screen; a selection
+#       list above the last user turn is one the lane already answered and
+#       never fires, while one below that turn still does
 #   4b. idle-after-return: a harness at its composer with nothing in flight
 #       on two consecutive passes (either harness's prompt, and under a
 #       wrapped shell); one pass alone, a working indicator alongside the
@@ -32,6 +33,12 @@ set -euo pipefail
 
 # shellcheck source=lib/oversee-watch-harness.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/oversee-watch-harness.sh"
+
+# Byte-exact 120x40 captures of a live Codex 0.151.0 pane, recorded for
+# KEN-863. A Codex shape is asserted from one of these, never hand-written:
+# every predicate in this area that was reasoned instead of measured has been
+# wrong about the screen it claimed to describe.
+CODEX_PANES="$REPO_ROOT/skills/orch/tests/fixtures/oversee-watch"
 
 echo "=== oversee-watch lanes ==="
 
@@ -316,10 +323,25 @@ printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
 } > "$STUB_DIR/pane-gh-2.txt"
 err="$TMP_ROOT/e3fd"
 out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=1 interval=0s since=none" \
+assert_eq "$(head -1 <<<"$out")" "EVENT question gh-2" \
   "a codex dialog row is live input, so the banner above the turn stays scrollback" "$err"
 assert_not_contains "$out" "EVENT usage-limit" \
   "the codex dialog row never resurrects a stale banner" "$err"
+
+# The near-miss control. Every fresh Codex prints a benign reset OFFER, and
+# loosening USAGE_LIMIT_RE toward a bare `usage limit` would turn the startup
+# screen of every Codex lane into a spent-account event.
+new_case usage_limit_codex_reset_offer
+printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
+cat "$CODEX_PANES/codex-composer-idle.txt" > "$STUB_DIR/pane-gh-2.txt"
+err="$TMP_ROOT/e3fg"
+out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
+assert_contains "$(cat "$STUB_DIR/pane-gh-2.txt")" "You have 1 usage limit reset available" \
+  "the fixture really carries the reset offer, so the control is not vacuous" "$err"
+assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=1 interval=0s since=none" \
+  "a codex startup screen is no event at all" "$err"
+assert_not_contains "$out" "EVENT usage-limit" \
+  "an offered reset is credit to spend, never a spent account" "$err"
 
 # ...and its control: the banner below the turn on the same dialog screen
 new_case usage_limit_codex_dialog_live_banner
@@ -527,6 +549,30 @@ out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
 assert_eq "$(head -1 <<<"$out")" "EVENT question gh-2" \
   "a wrapped lane's question is still the event" "$err"
 
+# Codex on a dialog. It marks the row it has selected with `›`, not `❯`,
+# and closes the screen with its own enter hint, so nothing Claude Code draws
+# reaches these two screens: before KEN-863 both fell through every predicate
+# and the pass said nothing about the lane.
+new_case question_codex_dialog_trust
+printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
+cat "$CODEX_PANES/codex-dialog-trust.txt" > "$STUB_DIR/pane-gh-2.txt"
+err="$TMP_ROOT/e4c1"
+out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
+assert_eq "$(head -1 <<<"$out")" "EVENT question gh-2" \
+  "a codex directory-trust dialog is a question" "$err"
+assert_contains "$out" "Do you trust the contents of this directory?" \
+  "the pane tail carries what the lane is being asked" "$err"
+
+new_case question_codex_dialog_model
+printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
+cat "$CODEX_PANES/codex-dialog-model.txt" > "$STUB_DIR/pane-gh-2.txt"
+err="$TMP_ROOT/e4c2"
+out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
+assert_eq "$(head -1 <<<"$out")" "EVENT question gh-2" \
+  "a codex model picker is a question" "$err"
+assert_contains "$out" "Select Model and Effort" \
+  "the pane tail carries the choice on offer" "$err"
+
 # A tmux window name carries any character, so two lanes can differ only
 # outside a filename-safe set. Their pane snapshots must stay separate or each
 # lane is classified on the other's screen.
@@ -592,14 +638,28 @@ assert_eq "$(head -1 <<<"$out")" "EVENT idle-after-return gh-2" \
   "an idle prompt on two consecutive passes is the event" "$err"
 assert_contains "$out" "the PR is merged" "the pane tail follows the idle event" "$err"
 
-# Codex's ready prompt reads differently and counts the same
+# Codex's ready prompt reads differently and counts the same. Its composer
+# draws no submit hint at all — only the marker and either the placeholder or
+# an unsent draft — so the marker is what has to carry idleness. The fixture
+# is the capture: the hint this case used to assert on renders nowhere here.
 new_case idle_after_return_codex
 printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
-printf '· Ran the test suite\n  ⏎ to submit message\n' > "$STUB_DIR/pane-gh-2.txt"
+cat "$CODEX_PANES/codex-composer-idle.txt" > "$STUB_DIR/pane-gh-2.txt"
 err="$TMP_ROOT/e4b2"
 out="$(run_watch -- gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
 assert_eq "$(head -1 <<<"$out")" "EVENT idle-after-return gh-2" \
-  "a codex lane at its submit prompt is idle too" "$err"
+  "a codex lane at its composer is idle too" "$err"
+assert_not_contains "$(cat "$STUB_DIR/pane-gh-2.txt")" "to submit message" \
+  "the real composer carries no submit hint, so the marker alone decides" "$err"
+
+# ...and holding an unsent draft, which has the same shape as a taken turn
+new_case idle_after_return_codex_draft
+printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
+cat "$CODEX_PANES/codex-composer-draft.txt" > "$STUB_DIR/pane-gh-2.txt"
+err="$TMP_ROOT/e4b2b"
+out="$(run_watch -- gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
+assert_eq "$(head -1 <<<"$out")" "EVENT idle-after-return gh-2" \
+  "a codex composer holding a draft is idle too" "$err"
 
 # The idle check reads the same liveness answer too
 new_case idle_after_return_wrapped_shell


### PR DESCRIPTION
A Codex lane sitting on a dialog matched none of `oversee-watch`'s pane predicates, so the pass emitted nothing for it: never a question, never idle, and its slot stayed held until someone read the pane by hand.

`QUESTION_RE` now reads the selected numbered row through either harness's marker and Codex's enter hint; `IDLE_PROMPT_RE` reads either marker at column 0. `oversee-watch` stays at exactly 654, held by rewording two comment blocks rather than raising the baseline row.

## The captures are the fixtures

The issue asks for a real capture rather than a predicate reasoned from the binary, because #1850 found the fixtures here wrong about exactly this. Six byte-exact 120x40 captures of a live Codex 0.151.0 pane ship as files under `skills/orch/tests/fixtures/oversee-watch/`, so "byte for byte" is checkable rather than claimed: the directory-trust dialog, the `/model` selection list, the composer empty and holding a draft, a turn in flight, and the same lane once that turn finished.

All four predicates matched nothing on any at-rest Codex screen. The dialog fell through, and so did the composer.

## Two things the issue does not mention

**`idle_after_return_codex` was vacuous.** Its fixture asserted through `⏎ to submit message`, which is the only reason `IDLE_PROMPT_RE` matched it — and that hint renders on none of these screens. The test passed against a screen Codex does not draw while a real idle Codex lane produced nothing. The string is live in the binary's hint table, so it is a shape drawn in some state rather than an invention; the alternative stays in the regex and the fixture is now the finished-turn capture, the state the event is named for.

**A test pinned the bug.** `usage_limit_codex_dialog_stale_banner` asserted `EVENT heartbeat` for a Codex lane on a dialog — no event, which is the defect. It now asserts `EVENT question`, keeping its `assert_not_contains "EVENT usage-limit"` half intact.

## The control that makes the marker safe to read

`^›` also matches a submitted turn in scrollback, so `WORKING_RE` is the only thing keeping a busy Codex lane out of `idle-after-return`. `idle_after_return_codex_working` runs the real watch over the in-flight capture and asserts a heartbeat with no idle event, over two passes so the debounce cannot mask it. It also asserts the fixture contains both the composer marker and `esc to interrupt`, so the case cannot pass through an absent marker or the token-counter alternative.

`WORKING_RE` keeps the bare `to interrupt` rather than pinning the key. The directions are not symmetric: a rebind to `ctrl+c to interrupt` leaves the bare alternative matching and the gate holding, while a pinned spelling stops matching and wakes every busy Codex lane as idle. Both harnesses spell it identically today, so one alternative covers both.

A control also pins that Codex's benign `You have 1 usage limit reset available` startup line produces no `usage-limit` event, so loosening `USAGE_LIMIT_RE` toward a bare `usage limit` cannot turn it into one.

`Press enter to ` was tried as a second dialog signature and cut again. The `question` check has no `WORKING_RE` gate, so a lane whose transcript merely contains the phrase fires `EVENT question` — and since `question` is checked before `idle-after-return`, that starves the idle event rather than adding a transient one, which is the masking failure KEN-864 fixed one check above. It also earned nothing: both captured dialogs fire on the numbered-row alternative, and the numberless dialog it was written for is a screen nobody has captured. `Do you want to` carries the same ungated property and stays: it reads as a question being asked rather than as CLI documentation, and it predates this diff.

## Verification

Every new assertion was run red first, on the real component: reverting `QUESTION_RE` fails 5 cases including the stale-banner flip, reverting `IDLE_PROMPT_RE` fails 3 idle cases, removing `to interrupt` from `WORKING_RE` fails the working control plus 2 Claude cases, and loosening `USAGE_LIMIT_RE` fails the reset-offer control.

`oversee_watch_lanes` 109 pass / 0 fail, `oversee_watch` 84 pass / 0 fail.

`skills/orch/tests/queue_wait_confirmation.sh` is red and unrelated: it touches no file this branch changes, its copy here is identical to main's, and it loses a wall-clock deadline race. Filed as KEN-879.

The Done-when names `skills/orch/tests/oversee_watch.sh`; these are pane cases, so they go to `oversee_watch_lanes.sh` where every existing Codex case already lives.

Closes KEN-863
