### PR TITLE
fix(KEN-878): a delegation names a worktree the agent proves it is in

### DIFF
--- a/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -1,38 +1,34 @@
 #!/usr/bin/env bash
 # Regression lint for KEN-878. A delegated agent's shell does not reliably
-# start in the worktree it was delegated: two lanes on 2026-08-30 each ran
-# bare-relative commands — `tools/guard` among them — against another lane's
-# worktree, and both noticed only after a confusing downstream failure.
+# start in the worktree it was delegated: two lanes each ran bare-relative
+# commands — `tools/guard` among them — against another lane's worktree,
+# and both noticed only after a confusing downstream failure.
 #
-# The cure is a precondition the agent runs before anything repo-relative:
-# every `Worktree: [PLACEHOLDER]` line inside a `<delegation_format>` block
-# is followed immediately by a `Worktree Check:` line that OPENS with a
-# backticked `pwd` and names that SAME placeholder. `pwd` reports where the
-# shell actually is, so the check can fail; a line that merely restates the
-# delegated path cannot.
+# The cure is a precondition the agent runs before anything repo-relative,
+# and this lint holds it as ONE canonical sentence rather than as a set of
+# shape rules. Every shipped check line is byte-identical apart from the
+# block's own placeholder token, so the test carries that sentence in
+# $CANON with `@TOKEN@` where the token goes, and each site must equal it
+# with its own token substituted in. Equality is the whole predicate:
+# nothing infers "opens with a command", "mentions pwd", or "names the
+# token", so no prose mutation can satisfy the letter of a heuristic while
+# leaving the agent with nothing to run. A future wording change is made in
+# $CANON and at every site together, or the lint reds.
 #
-# All three conditions are load-bearing, and the command one is the reason
-# this lint was rewritten twice. Matching the label and the placeholder
-# alone is fail-open: replacing the opening of a real check with `Worktree
-# Check: trust the path.` left the whole suite green, because the rest of
-# the line still carried its placeholder. Matching `pwd` ANYWHERE on the
-# line is the same hole one step further in — that mutation still said
-# "re-run `pwd`" in its remedy clause. Matching the FIRST backticked span
-# wherever it falls is that hole a third time: a check opening with prose
-# and offering `pwd` later still passes, because the first span found is a
-# later one. So the match is anchored to the start of the line: what has to
-# hold is that the first executable step IS the command, asserted by
-# position rather than by mention.
+# Two rules are enforced inside a `<delegation_format>` block:
 #
-# This lint is the answer to the recurrence, not to the individual sites: a
-# new delegation block that carries `Worktree:` without a working check
-# fails here rather than shipping the silent-wrong-tree hazard again.
+#   1. A `Worktree: [TOKEN]` line is followed on the very next line by the
+#      canonical `Worktree Check:` line for that same TOKEN.
+#   2. A block that hands the delegate a repo-relative path — a bare path
+#      opening `.agents/`, `skills/` or `tools/` — carries that pair at
+#      all. Without it the delegate runs those paths wherever its shell
+#      happens to be. A block whose paths are all placeholders is out of
+#      scope: the caller resolves those, and the lint cannot judge them.
 #
-# Scope is every skill doc that can carry a delegation, not one directory —
-# scoping the first sweep to orch/workflows is what let the
-# project-management site sit unguarded. Tests are excluded: their probe
-# fixtures carry deliberately broken blocks. A `Worktree:` mention in prose
-# or in a fenced example is not a delegation and is not scanned.
+# Scope is every skill doc that can carry a delegation, not one directory.
+# Tests are excluded: their probe fixtures carry deliberately broken
+# blocks. A `Worktree:` mention in prose or in a fenced example is not a
+# delegation and is not scanned.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -46,37 +42,31 @@ FAIL=0
 pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
 fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 
+# The canonical check line, with @TOKEN@ standing in for the block's own
+# placeholder name. This is the single source of truth for the sentence;
+# the shipped docs must match it character for character.
+CANON='Worktree Check: `pwd` before any repo-relative command. It must print [@TOKEN@]; your shell can start in another lane'"'"'s worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [@TOKEN@], because a bare `cd` may not survive into the next tool call.'
+
 # scan_worktree_precondition <file>
-# Emits one "file:line: ..." line per defect. Inside a <delegation_format>
-# block, a `Worktree: [TOKEN]` line must be followed on the very next line by
-# a `Worktree Check:` line that (a) BEGINS with a backticked `pwd` — the
-# match is anchored, so nothing may precede the code span and the agent's
-# first executable step is the command that reports where the shell
-# actually is — and (b) contains `[TOKEN]`, the same placeholder, so a
-# filled delegation compares against its own path and not another site's.
+# Emits one "file:line: ..." line per defect, per the two rules above.
 # Lines outside a delegation block are never scanned.
 scan_worktree_precondition() {
-  awk -v f="$1" '
-    /^[[:space:]]*<delegation_format>[[:space:]]*$/ { indel = 1; pending = 0; next }
+  awk -v f="$1" -v canon="$CANON" '
+    function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+    /^[[:space:]]*<delegation_format>[[:space:]]*$/ {
+      indel = 1; pending = 0; haswt = 0; relline = 0; relpath = ""; next
+    }
     /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ {
       if (pending) printf "%s:%d: Worktree: [%s] ends the delegation with no Worktree Check line\n", f, pendline, token
+      if (indel && !haswt && relline) printf "%s:%d: delegation hands over the repo-relative path %s but carries no Worktree:/Worktree Check: pair\n", f, relline, relpath
       indel = 0; pending = 0; next
     }
     indel {
       if (pending) {
-        if ($0 !~ /^[[:space:]]*Worktree Check:/) {
-          printf "%s:%d: Worktree: [%s] is not followed by a Worktree Check line\n", f, pendline, token
-        } else {
-          rest = $0
-          sub(/^[[:space:]]*Worktree Check:[[:space:]]*/, "", rest)
-          cmd = ""
-          if (match(rest, /^`[^`]*`/)) cmd = substr(rest, RSTART + 1, RLENGTH - 2)
-          if (cmd != "pwd") {
-            printf "%s:%d: Worktree Check does not open with a backticked pwd (first command: %s)\n", f, NR, (cmd == "" ? "none" : cmd)
-          }
-          if (index($0, "[" token "]") == 0) {
-            printf "%s:%d: Worktree Check names no [%s] to compare pwd against\n", f, NR, token
-          }
+        want = canon
+        gsub(/@TOKEN@/, token, want)
+        if (trim($0) != want) {
+          printf "%s:%d: the line after Worktree: [%s] is not the canonical Worktree Check (got: %s)\n", f, NR, token, trim($0)
         }
         pending = 0
       }
@@ -84,9 +74,32 @@ scan_worktree_precondition() {
         line = $0
         sub(/^[[:space:]]*Worktree:[[:space:]]*\[/, "", line)
         sub(/\].*$/, "", line)
-        token = line; pendline = NR; pending = 1
+        token = line; pendline = NR; pending = 1; haswt = 1
+      }
+      if (!relline) {
+        probe = " " $0
+        if (match(probe, /[^A-Za-z0-9_.\/-](\.agents|skills|tools)\/[A-Za-z0-9._\/-]+/)) {
+          relline = NR
+          relpath = substr(probe, RSTART + 1, RLENGTH - 1)
+        }
       }
     }
+  ' "$1"
+}
+
+# count_guarded_relpath_blocks <file>
+# Prints the number of delegation blocks that name a repo-relative path AND
+# carry a Worktree: line — the population rule 2 is meant to hold.
+count_guarded_relpath_blocks() {
+  awk '
+    /^[[:space:]]*<delegation_format>[[:space:]]*$/ { indel = 1; haswt = 0; hasrel = 0; next }
+    /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ { if (indel && haswt && hasrel) n++; indel = 0; next }
+    indel {
+      if ($0 ~ /^[[:space:]]*Worktree:[[:space:]]*\[[A-Za-z_][A-Za-z0-9_]*\][[:space:]]*$/) haswt = 1
+      probe = " " $0
+      if (match(probe, /[^A-Za-z0-9_.\/-](\.agents|skills|tools)\/[A-Za-z0-9._\/-]+/)) hasrel = 1
+    }
+    END { print n + 0 }
   ' "$1"
 }
 
@@ -99,14 +112,16 @@ echo "=== orch delegation worktree-cwd-precondition lint ==="
 DOCS="$(find "$SKILLS_ROOT" -name '*.md' -not -path '*/tests/*' | sort)"
 offenders=""
 sites=0
+guarded=0
 for doc in $DOCS; do
   out="$(scan_worktree_precondition "$doc")"
   [ -n "$out" ] && offenders="$offenders$out"$'\n'
   n="$(grep -c '^[[:space:]]*Worktree Check:' "$doc" || true)"
   sites=$((sites + n))
+  guarded=$((guarded + $(count_guarded_relpath_blocks "$doc")))
 done
 if [ -z "$offenders" ]; then
-  pass "every delegated Worktree: line is followed by its Worktree Check"
+  pass "every delegated Worktree: line is followed by its canonical Worktree Check"
 else
   fail "delegation blocks missing the worktree cwd precondition:"
   printf '%s' "$offenders" | sed 's/^/          /'
@@ -120,6 +135,15 @@ else
   fail "no Worktree Check lines found — the scan matched nothing to check"
 fi
 
+# The same guard for rule 2: with no shipped block naming a repo-relative
+# path, the repo-path rule passed over an empty population and proves
+# nothing.
+if [ "$guarded" -gt 0 ]; then
+  pass "the scan read $guarded repo-relative delegation block(s) carrying the pair"
+else
+  fail "no repo-relative delegation blocks found — the repo-path rule matched nothing"
+fi
+
 # --- Part b: the lint has teeth -------------------------------------------
 
 # probe <name> <body> → prints scratch-file path.
@@ -131,26 +155,26 @@ probe() {
   printf '%s' "$scratch"
 }
 
-CHECK='Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH].'
+CHECK="${CANON//@TOKEN@/WORKTREE_PATH}"
 
-# b.1 — the reported shape (a bare Worktree: line, as all eleven sites read
-# before this change) IS flagged.
+# b.1 — the reported shape (a bare Worktree: line, as every site read before
+# this change) IS flagged.
 if [ -n "$(scan_worktree_precondition "$(probe bare 'Issue: [ISSUE_ID]\nWorktree: [WORKTREE_PATH]\nRound ID: [DEV_ROUND_ID]')" )" ]; then
   pass "lint flags a Worktree: line with no Worktree Check"
 else
   fail "lint MISSED a bare Worktree: line (no teeth)"
 fi
 
-# b.2 — the fixed shape is NOT flagged.
+# b.2 — the canonical shape is NOT flagged.
 if [ -z "$(scan_worktree_precondition "$(probe fixed "Worktree: [WORKTREE_PATH]\n$CHECK")" )" ]; then
-  pass "lint accepts Worktree: followed by its Worktree Check"
+  pass "lint accepts Worktree: followed by the canonical Worktree Check"
 else
-  fail "lint false-flagged the fixed shape"
+  fail "lint false-flagged the canonical shape"
 fi
 
 # b.3 — a check naming a DIFFERENT placeholder IS flagged: a filled
 # delegation would compare pwd against a path this block never carries.
-if [ -n "$(scan_worktree_precondition "$(probe crossed 'Worktree: [WT_PATH]\nWorktree Check: `pwd` must print [WORKTREE_PATH].')" )" ]; then
+if [ -n "$(scan_worktree_precondition "$(probe crossed "Worktree: [WT_PATH]\n$CHECK")" )" ]; then
   pass "lint flags a Worktree Check naming the wrong placeholder"
 else
   fail "lint MISSED a cross-wired placeholder"
@@ -163,27 +187,36 @@ else
   fail "lint MISSED a trailing Worktree: line"
 fi
 
-# b.7 — THE REPORTED FAIL-OPEN. The exact mutation two reviewers landed
-# independently: the opening command replaced by prose, everything after it
-# left intact. The line still carries its placeholder AND still says `pwd` in
-# the remedy clause, so both a placeholder check and an anywhere-on-the-line
-# `pwd` check pass it. Only asserting the line's OPENING span catches it.
+# b.7 — the leading command replaced by prose, everything after it left
+# intact. The line still carries its placeholder AND still says `pwd` later,
+# so a placeholder check and an anywhere-on-the-line `pwd` check both pass
+# it. Equality does not.
 MUTANT='Worktree: [WORKTREE_PATH]\nWorktree Check: trust the path. It must print [WORKTREE_PATH]; a bare `git status` answers about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.'
 if [ -n "$(scan_worktree_precondition "$(probe mutant "$MUTANT")" )" ]; then
   pass "lint flags a check whose leading command was replaced by prose"
 else
-  fail "lint MISSED the reported fail-open (a check that runs nothing)"
+  fail "lint MISSED a check that runs nothing"
 fi
 
-# b.10 — THE ROUND-THREE FAIL-OPEN. Prose in front, a backticked `pwd`
-# behind it: the first backticked span on the line IS `pwd`, so an unanchored
-# match accepts a check that demotes the command to optional. Only anchoring
-# to the start of the line rejects it.
+# b.10 — prose in front, a backticked `pwd` behind it: the first backticked
+# span on the line IS `pwd`, so an unanchored shape match accepts a check
+# that demotes the command to optional.
 DEMOTED='Worktree: [WORKTREE_PATH]\nWorktree Check: trust the path; optional check: `pwd` must print [WORKTREE_PATH].'
 if [ -n "$(scan_worktree_precondition "$(probe demoted "$DEMOTED")" )" ]; then
   pass "lint flags a check whose pwd sits behind leading prose"
 else
   fail "lint MISSED a backticked pwd demoted behind prose"
+fi
+
+# b.11 — the token is present and the line opens with a backticked `pwd`,
+# but nothing binds one to the other: the check tells the agent to ignore
+# what it just measured. Every shape heuristic passes this; equality is the
+# only predicate that does not.
+UNBOUND='Worktree: [WORKTREE_PATH]\nWorktree Check: `pwd` before any repo-relative command. Ignore [WORKTREE_PATH].'
+if [ -n "$(scan_worktree_precondition "$(probe unbound "$UNBOUND")" )" ]; then
+  pass "lint flags a check whose pwd and placeholder are unbound"
+else
+  fail "lint MISSED an unbound pwd and placeholder"
 fi
 
 # b.8 — a check opening with the WRONG command is flagged. `pwd` has to be
@@ -202,9 +235,43 @@ else
   fail "lint MISSED an unbackticked pwd"
 fi
 
+# b.12 — the recovery clause must not rest on a bare `cd`. A harness that
+# spawns a fresh shell per tool call drops it, and the agent resumes
+# repo-relative work in the wrong tree believing it recovered.
+STALE_CD='Worktree: [WORKTREE_PATH]\nWorktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.'
+if [ -n "$(scan_worktree_precondition "$(probe stalecd "$STALE_CD")" )" ]; then
+  pass "lint flags a check whose remedy is a bare cd"
+else
+  fail "lint MISSED a remedy resting on a cd that may not persist"
+fi
+
+# b.13 — RULE 2. A block that hands over a repo-relative path with no
+# Worktree:/Worktree Check: pair IS flagged: the delegate runs that path
+# wherever its shell happens to be.
+if [ -n "$(scan_worktree_precondition "$(probe relpath 'Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md\n\nArguments: --project-order')" )" ]; then
+  pass "lint flags a delegation naming a repo-relative path with no Worktree pair"
+else
+  fail "lint MISSED a repo-relative delegation with no Worktree pair"
+fi
+
+# b.14 — the same block WITH the pair is not flagged.
+if [ -z "$(scan_worktree_precondition "$(probe relok "Follow workflow: .agents/skills/x/y.md\nWorktree: [WORKTREE_PATH]\n$CHECK")" )" ]; then
+  pass "lint accepts a repo-relative delegation carrying the pair"
+else
+  fail "lint false-flagged a repo-relative delegation that carries the pair"
+fi
+
+# b.15 — a block whose paths are ALL placeholders is out of scope: the
+# caller resolves them, and the lint cannot judge where they land.
+if [ -z "$(scan_worktree_precondition "$(probe placeholders 'Read: [RESEARCH_DOCS_PATH]/[ISSUE_ID]/findings.md\nWrite: [INPUT_FILE_PATH]')" )" ]; then
+  pass "lint ignores a delegation whose paths are all placeholders"
+else
+  fail "lint false-flagged a placeholder-only delegation"
+fi
+
 # b.5 — a Worktree: mention outside a delegation block is NOT scanned.
 PROSE="$TMP_ROOT/probe-prose.md"
-printf 'Fill the delegation Worktree: [WORKTREE_PATH] from the claim output.\n' > "$PROSE"
+printf 'Fill the delegation Worktree: [WORKTREE_PATH] from the claim output, per .agents/skills/orch/SKILL.md.\n' > "$PROSE"
 if [ -z "$(scan_worktree_precondition "$PROSE")" ]; then
   pass "lint ignores a Worktree: mention outside a delegation block"
 else

--- a/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -18,6 +18,11 @@
 # leaving the agent with nothing to run. A future wording change is made in
 # $CANON and at every site together, or the lint reds.
 #
+# Both sides of the comparison are physical paths. `git-context` derives
+# the delegated path with `git rev-parse --show-toplevel`, so the check
+# runs `pwd -P`: a bare `pwd` prints the logical path and would halt a
+# correct delegate whose shell entered the checkout through a symlink.
+#
 # Two rules are enforced inside a `<delegation_format>` block:
 #
 #   1. A `Worktree: [TOKEN]` line is followed on the very next line by the
@@ -68,7 +73,7 @@ fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 # The canonical check line, with @TOKEN@ standing in for the block's own
 # placeholder name. This is the single source of truth for the sentence;
 # the shipped docs must match it character for character.
-CANON='Worktree Check: `pwd` before any repo-relative command. It must print [@TOKEN@]; your shell can start in another lane'"'"'s worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.'
+CANON='Worktree Check: `pwd -P` before any repo-relative command. It must print [@TOKEN@]; your shell can start in another lane'"'"'s worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.'
 
 # scan_worktree_precondition <file>
 # Emits one "file:line: ..." line per defect, per the two rules above.
@@ -158,12 +163,15 @@ done
 
 # --- Part b: the lint has teeth -------------------------------------------
 
-# probe <name> <body> → prints scratch-file path.
+# probe <name> <body> [tag_indent] → prints scratch-file path.
 # Writes a standalone delegation block containing <body> (printf %b, so \n
 # splits it into lines) under $TMP_ROOT, removed by the EXIT trap.
+# <tag_indent> is prefixed to both tags, so a probe can put the block itself
+# off column zero the way dev-fix.md nests one in a numbered step; it
+# defaults to empty, which is what every probe but b.6 wants.
 probe() {
   scratch="$TMP_ROOT/probe-$1.md"
-  printf '<delegation_format>\n%b\n</delegation_format>\n' "$2" > "$scratch"
+  printf '%s<delegation_format>\n%b\n%s</delegation_format>\n' "${3-}" "$2" "${3-}" > "$scratch"
   printf '%s' "$scratch"
 }
 
@@ -280,6 +288,17 @@ else
   fail "lint MISSED a remedy an absolute path cannot deliver"
 fi
 
+# b.17 — the pre-fix sentence, identical but for a bare `pwd`. The delegated
+# path is physical (`git rev-parse --show-toplevel`), so a logical `pwd` halts
+# a correct delegate whose shell reached the checkout through a symlink. The
+# logical form must not come back unnoticed.
+LOGICAL="${CHECK//pwd -P/pwd}"
+if reports "$(scan_worktree_precondition "$(probe logical "Worktree: [WORKTREE_PATH]\n$LOGICAL")")" "$UNCANON"; then
+  pass "lint flags a check measuring the cwd with a bare pwd"
+else
+  fail "lint MISSED a check comparing a logical pwd against a physical path"
+fi
+
 # b.13 — RULE 2. A block with no Worktree:/Worktree Check: pair at all IS
 # flagged, whatever it hands over: a placeholder the caller fills with a
 # repo path is invisible to any matcher, so no block is out of scope.
@@ -299,13 +318,19 @@ else
 fi
 
 # b.6 — an indented delegation block (dev-fix.md nests one in a numbered
-# step) is scanned, not skipped for its leading whitespace. Rule 2 flags this
-# same fixture the moment the indent tolerance breaks, so the assertion names
-# rule 1's message. The indent stays in the fixture; it is the thing tested.
-if reports "$(scan_worktree_precondition "$(probe indented '   Worktree: [WORKTREE_PATH]\n   Round ID: [DEV_ROUND_ID]')")" "$UNCANON"; then
-  pass "lint scans an indented delegation block"
+# step) is scanned, not skipped for its leading whitespace. The TAGS are
+# indented too, not just the body: tags at column zero leave both matchers'
+# tolerance untested. The fixture draws one message from each side of the
+# block — the uncanonical line is reported only if the opening tag let the
+# scan in, the unclosed one only if the closing tag was recognised — so
+# restricting EITHER matcher to column zero reds this probe. Rule 2 stays
+# silent here (the block does carry a Worktree: line), so neither assertion
+# can be satisfied by the other rule. The indent is the thing tested.
+INDENTED="$(scan_worktree_precondition "$(probe indented '   Worktree: [WORKTREE_PATH]\n   Round ID: [DEV_ROUND_ID]\n   Worktree: [WORKTREE_PATH]' '   ')")"
+if reports "$INDENTED" "$UNCANON" && reports "$INDENTED" "$UNCLOSED"; then
+  pass "lint scans an indented delegation block, opening tag to closing tag"
 else
-  fail "rule 1 MISSED an indented Worktree: line"
+  fail "lint MISSED an indented delegation block"
 fi
 
 # --- Part c: both trees are actually scanned ------------------------------

--- a/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -12,13 +12,17 @@
 # delegated path cannot.
 #
 # All three conditions are load-bearing, and the command one is the reason
-# this lint was rewritten. Matching the label and the placeholder alone is
-# fail-open: replacing the opening of a real check with `Worktree Check:
-# trust the path.` left the whole suite green, because the rest of the line
-# still carried its placeholder. Matching `pwd` ANYWHERE on the line is the
-# same hole one step further in — that mutation still said "re-run `pwd`" in
-# its remedy clause. What has to hold is that the first executable step is
-# the command, so the check is asserted by position, not by mention.
+# this lint was rewritten twice. Matching the label and the placeholder
+# alone is fail-open: replacing the opening of a real check with `Worktree
+# Check: trust the path.` left the whole suite green, because the rest of
+# the line still carried its placeholder. Matching `pwd` ANYWHERE on the
+# line is the same hole one step further in — that mutation still said
+# "re-run `pwd`" in its remedy clause. Matching the FIRST backticked span
+# wherever it falls is that hole a third time: a check opening with prose
+# and offering `pwd` later still passes, because the first span found is a
+# later one. So the match is anchored to the start of the line: what has to
+# hold is that the first executable step IS the command, asserted by
+# position rather than by mention.
 #
 # This lint is the answer to the recurrence, not to the individual sites: a
 # new delegation block that carries `Worktree:` without a working check
@@ -45,11 +49,12 @@ fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 # scan_worktree_precondition <file>
 # Emits one "file:line: ..." line per defect. Inside a <delegation_format>
 # block, a `Worktree: [TOKEN]` line must be followed on the very next line by
-# a `Worktree Check:` line that (a) opens with `pwd` as its first backticked
-# span, so the agent's first executable step is the command that reports
-# where the shell actually is, and (b) contains `[TOKEN]` — the same
-# placeholder, so a filled delegation compares against its own path and not
-# another site's. Lines outside a delegation block are never scanned.
+# a `Worktree Check:` line that (a) BEGINS with a backticked `pwd` — the
+# match is anchored, so nothing may precede the code span and the agent's
+# first executable step is the command that reports where the shell
+# actually is — and (b) contains `[TOKEN]`, the same placeholder, so a
+# filled delegation compares against its own path and not another site's.
+# Lines outside a delegation block are never scanned.
 scan_worktree_precondition() {
   awk -v f="$1" '
     /^[[:space:]]*<delegation_format>[[:space:]]*$/ { indel = 1; pending = 0; next }
@@ -65,7 +70,7 @@ scan_worktree_precondition() {
           rest = $0
           sub(/^[[:space:]]*Worktree Check:[[:space:]]*/, "", rest)
           cmd = ""
-          if (match(rest, /`[^`]*`/)) cmd = substr(rest, RSTART + 1, RLENGTH - 2)
+          if (match(rest, /^`[^`]*`/)) cmd = substr(rest, RSTART + 1, RLENGTH - 2)
           if (cmd != "pwd") {
             printf "%s:%d: Worktree Check does not open with a backticked pwd (first command: %s)\n", f, NR, (cmd == "" ? "none" : cmd)
           }
@@ -162,12 +167,23 @@ fi
 # independently: the opening command replaced by prose, everything after it
 # left intact. The line still carries its placeholder AND still says `pwd` in
 # the remedy clause, so both a placeholder check and an anywhere-on-the-line
-# `pwd` check pass it. Only asserting the FIRST backticked span catches it.
-MUTANT='Worktree: [WORKTREE_PATH]\nWorktree Check: trust the path. It must print [WORKTREE_PATH]; a bare `git status` answers about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.'
+# `pwd` check pass it. Only asserting the line's OPENING span catches it.
+MUTANT='Worktree: [WORKTREE_PATH]\nWorktree Check: trust the path. It must print [WORKTREE_PATH]; a bare `git status` answers about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.'
 if [ -n "$(scan_worktree_precondition "$(probe mutant "$MUTANT")" )" ]; then
   pass "lint flags a check whose leading command was replaced by prose"
 else
   fail "lint MISSED the reported fail-open (a check that runs nothing)"
+fi
+
+# b.10 — THE ROUND-THREE FAIL-OPEN. Prose in front, a backticked `pwd`
+# behind it: the first backticked span on the line IS `pwd`, so an unanchored
+# match accepts a check that demotes the command to optional. Only anchoring
+# to the start of the line rejects it.
+DEMOTED='Worktree: [WORKTREE_PATH]\nWorktree Check: trust the path; optional check: `pwd` must print [WORKTREE_PATH].'
+if [ -n "$(scan_worktree_precondition "$(probe demoted "$DEMOTED")" )" ]; then
+  pass "lint flags a check whose pwd sits behind leading prose"
+else
+  fail "lint MISSED a backticked pwd demoted behind prose"
 fi
 
 # b.8 — a check opening with the WRONG command is flagged. `pwd` has to be

--- a/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -23,7 +23,7 @@
 # runs `pwd -P`: a bare `pwd` prints the logical path and would halt a
 # correct delegate whose shell entered the checkout through a symlink.
 #
-# Four rules are enforced:
+# Six rules are enforced:
 #
 #   1. A `Worktree: [TOKEN]` line is followed on the very next line by the
 #      canonical `Worktree Check:` line for that same TOKEN.
@@ -59,8 +59,33 @@
 #      Do not widen it; write a conflicting instruction in the canonical
 #      shape or leave the boundary where it is.
 #
-#      Rules 1 and 2 read inside a `<delegation_format>` block; rules 3
-#      and 4 read the lines between one block and the block before it.
+#   5. Exactly one `Worktree:` line and one `Worktree Check:` line per
+#      block, and every check line sits directly under a `Worktree:` line.
+#      Rule 1 read the line after a `Worktree:` line and recorded a
+#      boolean, so a block could carry the canonical pair and then append
+#      `Worktree Check: on mismatch continue`, leaving the delegate two
+#      checks with no ordering between them and the suite green; a
+#      duplicated pair passed for the same reason. The rule counts, it
+#      does not read: a second check line is reported for existing, not
+#      for what it says. A check line whose preceding line is not a
+#      `Worktree:` line is an orphan and is reported at its own line.
+#
+#   6. A file carrying the canonical fill line names `[DIR]` on some other
+#      line. The fill line introduces `[DIR]` and never says what it is,
+#      and three workflows shipped it with the token bound nowhere: the
+#      caller had nothing to substitute, so the placeholder came out empty
+#      and the delegation dropped both lines. Only the DECIDABLE half is
+#      asserted. Each workflow resolves the path its own way, so there is
+#      no canonical binding sentence to compare against, and the predicate
+#      is that the token appears somewhere else in the file. Whether that
+#      mention BINDS the token is semantic judgment, which this repo has
+#      ruled out of a lexical scanner, so prose merely naming `[DIR]`
+#      clears the rule. What it catches is the shipped defect: a token
+#      introduced once and defined nowhere.
+#
+#      Rules 1, 2 and 5 read inside a `<delegation_format>` block; rules 3
+#      and 4 read the lines between one block and the block before it;
+#      rule 6 reads the whole file.
 #
 # A block ends at three terminators, not one: its closing tag, a new opening
 # tag arriving while it is still open, and end of file. All three route
@@ -168,7 +193,7 @@ CANON_FILL='Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-
 CANON_FILL_OPEN='Fill `Worktree:` and its `Worktree Check:`'
 
 # scan_worktree_precondition <file>
-# Emits one "file:line: ..." line per defect, per the two rules above.
+# Emits one "file:line: ..." line per defect, per rules 1, 2 and 5 above.
 # Lines outside a delegation block are never scanned.
 #
 # Every rule that judges a whole block lives in `close_block`, and all three
@@ -184,17 +209,23 @@ scan_worktree_precondition() {
       if (!indel) return
       if (reason != "") printf "%s:%d: delegation block is never closed (%s)\n", f, delline, reason
       if (pending) printf "%s:%d: Worktree: [%s] ends the delegation with no Worktree Check line\n", f, pendline, token
-      if (!haswt) printf "%s:%d: delegation carries no Worktree:/Worktree Check: pair\n", f, delline
-      indel = 0; pending = 0; haswt = 0
+      if (nwt == 0) printf "%s:%d: delegation carries no Worktree:/Worktree Check: pair\n", f, delline
+      if (nwt > 1) printf "%s:%d: delegation carries %d Worktree: lines; exactly one is required\n", f, delline, nwt
+      if (nchk > 1) printf "%s:%d: delegation carries %d Worktree Check: lines; exactly one is required\n", f, delline, nchk
+      indel = 0; pending = 0; nwt = 0; nchk = 0
     }
     /^[[:space:]]*<delegation_format>[[:space:]]*$/ {
       close_block("a new <delegation_format> opens at line " NR)
-      indel = 1; pending = 0; haswt = 0; delline = NR; next
+      indel = 1; pending = 0; nwt = 0; nchk = 0; delline = NR; next
     }
     /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ {
       close_block(""); next
     }
     indel {
+      # Rule 5 asks whether the PREVIOUS line was a Worktree: line, which is
+      # what `pending` records — so it is read into `under_wt` before rule 1
+      # consumes it.
+      under_wt = pending
       if (pending) {
         want = canon
         gsub(/@TOKEN@/, token, want)
@@ -203,11 +234,15 @@ scan_worktree_precondition() {
         }
         pending = 0
       }
+      if (match($0, /^[[:space:]]*Worktree Check:/)) {
+        nchk++
+        if (!under_wt) printf "%s:%d: Worktree Check line with no Worktree: line above it\n", f, NR
+      }
       if (match($0, /^[[:space:]]*Worktree:[[:space:]]*\[[A-Za-z_][A-Za-z0-9_]*\][[:space:]]*$/)) {
         line = $0
         sub(/^[[:space:]]*Worktree:[[:space:]]*\[/, "", line)
         sub(/\].*$/, "", line)
-        token = line; pendline = NR; pending = 1; haswt = 1
+        token = line; pendline = NR; pending = 1; nwt++
       }
     }
     END { close_block("reached end of file") }
@@ -261,6 +296,34 @@ scan_worktree_fill() {
   ' "$1"
 }
 
+# scan_worktree_binding <file>
+# RULE 6. Emits one defect line for a file that carries the canonical fill
+# line and names `[DIR]` nowhere else. The fill line hands the caller a token
+# it never defines; review.md, review-pr.md and review-codebase.md each
+# shipped it with no binding anywhere, so the caller had nothing to
+# substitute and the delegate got an empty path or no pair at all.
+#
+# The predicate is a mention, not a definition. Each workflow resolves the
+# path its own way, so there is no sentence to compare against and equality
+# is unavailable here; a rule that read the mention for meaning would be the
+# semantic judgment this repo has kept out of a lexical scanner. So prose
+# that merely names `[DIR]` clears this, deliberately. The fill line's own
+# `[DIR]` does not count, or the rule would be satisfied by the line that
+# creates the problem.
+scan_worktree_binding() {
+  awk -v f="$1" -v canon="$CANON_FILL" '
+    function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+    {
+      if (trim($0) == canon) { if (!fillline) fillline = NR; next }
+      if (index($0, "[DIR]") > 0) bound = 1
+    }
+    END {
+      if (fillline && !bound)
+        printf "%s:%d: the fill line names [DIR] and no other line in this file binds it\n", f, fillline
+    }
+  ' "$1"
+}
+
 # scan_trees <root>...
 # Emits every defect line found in every non-test *.md under the given
 # roots. A missing root is itself a defect: the caller asked for a tree
@@ -274,6 +337,7 @@ scan_trees() {
     find "$root" -name '*.md' -not -path '*/tests/*' | sort | while IFS= read -r doc; do
       scan_worktree_precondition "$doc"
       scan_worktree_fill "$doc"
+      scan_worktree_binding "$doc"
     done
   done
 }
@@ -335,6 +399,11 @@ probe() {
 }
 
 CHECK="${CANON//@TOKEN@/WORKTREE_PATH}"
+
+# A binding sentence for `[DIR]`, in the shape the workflows carry. Rule 6
+# asks every file carrying the fill line for one, so every fixture that
+# writes the fill line to a scanned tree writes this beside it.
+BINDING='`[DIR]` is the `[PATH_OR_PWD]` § 1 resolves `WT_PATH` from.'
 
 # reports <scan output> <fragment> — the scan named THIS defect, not merely
 # some defect. Rule 2 fires on every block rule 1 failed to see, so a probe
@@ -510,13 +579,58 @@ fi
 # block — the uncanonical line is reported only if the opening tag let the
 # scan in, the unclosed one only if the closing tag was recognised — so
 # restricting EITHER matcher to column zero reds this probe. Rule 2 stays
-# silent here (the block does carry a Worktree: line), so neither assertion
-# can be satisfied by the other rule. The indent is the thing tested.
+# silent here (the block does carry a Worktree: line) and rule 5 speaks in a
+# message of its own about the second one, so neither assertion below can be
+# satisfied by another rule. The indent is the thing tested.
 INDENTED="$(scan_worktree_precondition "$(probe indented '   Worktree: [WORKTREE_PATH]\n   Round ID: [DEV_ROUND_ID]\n   Worktree: [WORKTREE_PATH]' '   ')")"
 if reports "$INDENTED" "$UNCANON" && reports "$INDENTED" "$UNCLOSED"; then
   pass "lint scans an indented delegation block, opening tag to closing tag"
 else
   fail "lint MISSED an indented delegation block"
+fi
+
+# RULE 5. Rule 1 read the line after a Worktree: line and set a boolean, so
+# everything below shipped a block the delegate reads as carrying two
+# contradicting instructions, with the suite green. All three outputs are
+# compared WHOLE: a probe that named some other line, or drew rule 2 instead,
+# fails as readily as one that drew nothing.
+ORPHAN='Worktree Check line with no Worktree: line above it'
+
+# b.18 — a second check line appended after the canonical pair. This is the
+# reported shape: the pair is perfect and the line under it says the
+# opposite. It is an orphan (its predecessor is a check line, not a
+# Worktree: line) and it is the second check in the block.
+APPENDED="$TMP_ROOT/probe-appended-check.md"
+printf '<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\nWorktree Check: on mismatch continue.\n</delegation_format>\n' "$CHECK" > "$APPENDED"
+if [ "$(scan_worktree_precondition "$APPENDED")" = "$APPENDED:4: $ORPHAN
+$APPENDED:1: delegation carries 2 Worktree Check: lines; exactly one is required" ]; then
+  pass "lint flags a second Worktree Check appended after the canonical pair"
+else
+  fail "lint MISSED a second Worktree Check appended after the canonical pair"
+fi
+
+# b.19 — the canonical pair twice over. Every line is canonical and every
+# check sits under its own Worktree: line, so the orphan rule cannot see it;
+# only the counts can. The delegate is handed two paths to compare against.
+DOUBLED="$TMP_ROOT/probe-doubled-pair.md"
+printf '<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' "$CHECK" "$CHECK" > "$DOUBLED"
+if [ "$(scan_worktree_precondition "$DOUBLED")" = "$DOUBLED:1: delegation carries 2 Worktree: lines; exactly one is required
+$DOUBLED:1: delegation carries 2 Worktree Check: lines; exactly one is required" ]; then
+  pass "lint flags a duplicated canonical pair"
+else
+  fail "lint MISSED a duplicated canonical pair"
+fi
+
+# b.20 — a check line with no Worktree: line above it anywhere in the block.
+# It has no path to compare against, so it halts nothing. Rule 2 also fires,
+# and the whole-output comparison pins which line each message names.
+LOOSE="$TMP_ROOT/probe-loose-check.md"
+printf '<delegation_format>\nBranch: [BRANCH]\n%s\n</delegation_format>\n' "$CHECK" > "$LOOSE"
+if [ "$(scan_worktree_precondition "$LOOSE")" = "$LOOSE:3: $ORPHAN
+$LOOSE:1: $NOPAIR" ]; then
+  pass "lint flags an orphan Worktree Check with no Worktree: line"
+else
+  fail "lint MISSED an orphan Worktree Check with no Worktree: line"
 fi
 
 # --- Part c: both trees are actually scanned ------------------------------
@@ -529,7 +643,7 @@ TWO="$TMP_ROOT/two-trees"
 mkdir -p "$TWO/skills/x" "$TWO/.agents/skills/x"
 GOOD="Worktree: [WORKTREE_PATH]\n$CHECK"
 BROKEN='Worktree: [WORKTREE_PATH]'
-write_half() { printf '%s\n\n<delegation_format>\n%b\n</delegation_format>\n' "$CANON_FILL" "$2" > "$TWO/$1/x/y.md"; }
+write_half() { printf '%s\n%s\n\n<delegation_format>\n%b\n</delegation_format>\n' "$CANON_FILL" "$BINDING" "$2" > "$TWO/$1/x/y.md"; }
 
 # c.1 — control: both halves carry the check, nothing is flagged. Without
 # this the two probes below could red for any reason at all.
@@ -766,6 +880,59 @@ if [ -z "$(scan_worktree_fill "$NEARBY")" ]; then
   pass "lint leaves ordinary prose naming a path alone"
 else
   fail "lint false-flagged prose that merely names a path"
+fi
+
+# --- Part g: the fill line's own placeholder is bound somewhere -----------
+# RULE 6. The fill line hands the caller `[DIR]` and never says what it is.
+# Three workflows shipped it with the token defined nowhere in the file, so
+# the caller had nothing to substitute and the delegation dropped the pair.
+# The predicate is a mention elsewhere in the file, and the probes pin both
+# sides of that boundary: g.4 is the one that says out loud what this rule
+# cannot decide.
+UNBOUND_DIR='the fill line names [DIR] and no other line in this file binds it'
+
+# g.1 — the shipped defect: the canonical fill line, a well-formed block,
+# and no other mention of the token. The fill line carries `[DIR]` itself,
+# so this also pins that its own occurrence does not clear the rule.
+NOBIND="$TMP_ROOT/probe-unbound-dir.md"
+printf '%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' "$CANON_FILL" "$CHECK" > "$NOBIND"
+if [ "$(scan_worktree_binding "$NOBIND")" = "$NOBIND:1: $UNBOUND_DIR" ]; then
+  pass "lint flags a fill line whose [DIR] is bound nowhere in the file"
+else
+  fail "lint MISSED a fill line whose [DIR] is bound nowhere"
+fi
+
+# g.2 — the fix: a binding sentence under the fill line, in the shape the
+# workflows carry. Without this the rule could be unsatisfiable and g.1
+# would still pass.
+BOUND="$TMP_ROOT/probe-bound-dir.md"
+printf '%s\n%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' "$CANON_FILL" "$BINDING" "$CHECK" > "$BOUND"
+if [ -z "$(scan_worktree_binding "$BOUND")" ]; then
+  pass "lint accepts a fill line whose [DIR] the file binds"
+else
+  fail "lint false-flagged a bound [DIR]"
+fi
+
+# g.3 — a file carrying no fill line is asked for no binding, whatever it
+# says about paths. Otherwise every doc in both trees would have to define a
+# token it never uses.
+if [ -z "$(scan_worktree_binding "$PROSE")" ]; then
+  pass "lint asks no [DIR] binding of a file carrying no fill line"
+else
+  fail "lint demanded a [DIR] binding of a file with no fill line"
+fi
+
+# g.4 — THE BOUNDARY, stated as a fixture. A mention that does not bind the
+# token clears the rule, because deciding that a sentence binds a
+# placeholder is semantic judgment and this scanner does none. If a later
+# round wants the stronger rule, it needs a canonical binding sentence to
+# compare against; until then this probe is what says so.
+MENTION="$TMP_ROOT/probe-mentioned-dir.md"
+printf '%s\nThe delegate writes its round artifact under `[DIR]/tmp`.\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' "$CANON_FILL" "$CHECK" > "$MENTION"
+if [ -z "$(scan_worktree_binding "$MENTION")" ]; then
+  pass "lint accepts a bare mention of [DIR]; it counts mentions, not bindings"
+else
+  fail "lint read a mention for meaning, which it cannot decide"
 fi
 
 echo

--- a/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -6,17 +6,29 @@
 #
 # The cure is a precondition the agent runs before anything repo-relative:
 # every `Worktree: [PLACEHOLDER]` line inside a `<delegation_format>` block
-# is followed immediately by a `Worktree Check:` line naming that SAME
-# placeholder. `pwd` reports where the shell actually is, so the check can
-# fail; a line that merely restates the delegated path cannot.
+# is followed immediately by a `Worktree Check:` line that OPENS with a
+# backticked `pwd` and names that SAME placeholder. `pwd` reports where the
+# shell actually is, so the check can fail; a line that merely restates the
+# delegated path cannot.
 #
-# This lint is the answer to the recurrence, not to the eleven sites: a new
-# delegation block that carries `Worktree:` without its check fails here
-# rather than shipping the silent-wrong-tree hazard again.
+# All three conditions are load-bearing, and the command one is the reason
+# this lint was rewritten. Matching the label and the placeholder alone is
+# fail-open: replacing the opening of a real check with `Worktree Check:
+# trust the path.` left the whole suite green, because the rest of the line
+# still carried its placeholder. Matching `pwd` ANYWHERE on the line is the
+# same hole one step further in — that mutation still said "re-run `pwd`" in
+# its remedy clause. What has to hold is that the first executable step is
+# the command, so the check is asserted by position, not by mention.
 #
-# Scoped to `<delegation_format>` blocks in orch's workflows. A `Worktree:`
-# mention in prose or in a fenced example is not a delegation and is not
-# scanned.
+# This lint is the answer to the recurrence, not to the individual sites: a
+# new delegation block that carries `Worktree:` without a working check
+# fails here rather than shipping the silent-wrong-tree hazard again.
+#
+# Scope is every skill doc that can carry a delegation, not one directory —
+# scoping the first sweep to orch/workflows is what let the
+# project-management site sit unguarded. Tests are excluded: their probe
+# fixtures carry deliberately broken blocks. A `Worktree:` mention in prose
+# or in a fenced example is not a delegation and is not scanned.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -33,7 +45,9 @@ fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 # scan_worktree_precondition <file>
 # Emits one "file:line: ..." line per defect. Inside a <delegation_format>
 # block, a `Worktree: [TOKEN]` line must be followed on the very next line by
-# a `Worktree Check:` line whose text contains `[TOKEN]` — the same
+# a `Worktree Check:` line that (a) opens with `pwd` as its first backticked
+# span, so the agent's first executable step is the command that reports
+# where the shell actually is, and (b) contains `[TOKEN]` — the same
 # placeholder, so a filled delegation compares against its own path and not
 # another site's. Lines outside a delegation block are never scanned.
 scan_worktree_precondition() {
@@ -47,8 +61,17 @@ scan_worktree_precondition() {
       if (pending) {
         if ($0 !~ /^[[:space:]]*Worktree Check:/) {
           printf "%s:%d: Worktree: [%s] is not followed by a Worktree Check line\n", f, pendline, token
-        } else if (index($0, "[" token "]") == 0) {
-          printf "%s:%d: Worktree Check names no [%s] to compare pwd against\n", f, NR, token
+        } else {
+          rest = $0
+          sub(/^[[:space:]]*Worktree Check:[[:space:]]*/, "", rest)
+          cmd = ""
+          if (match(rest, /`[^`]*`/)) cmd = substr(rest, RSTART + 1, RLENGTH - 2)
+          if (cmd != "pwd") {
+            printf "%s:%d: Worktree Check does not open with a backticked pwd (first command: %s)\n", f, NR, (cmd == "" ? "none" : cmd)
+          }
+          if (index($0, "[" token "]") == 0) {
+            printf "%s:%d: Worktree Check names no [%s] to compare pwd against\n", f, NR, token
+          }
         }
         pending = 0
       }
@@ -65,7 +88,10 @@ scan_worktree_precondition() {
 echo "=== orch delegation worktree-cwd-precondition lint ==="
 
 # --- Part a: every shipped delegation block carries the precondition -------
-DOCS="$(ls "$SKILLS_ROOT"/orch/workflows/*.md)"
+# Every skill doc, not one skill's workflows: a delegation that hands over a
+# worktree is checked wherever it lives. Tests are excluded — their probe
+# fixtures carry deliberately broken blocks.
+DOCS="$(find "$SKILLS_ROOT" -name '*.md' -not -path '*/tests/*' | sort)"
 offenders=""
 sites=0
 for doc in $DOCS; do
@@ -130,6 +156,34 @@ if [ -n "$(scan_worktree_precondition "$(probe last 'Branch: [BRANCH]\nWorktree:
   pass "lint flags a Worktree: line that closes the delegation"
 else
   fail "lint MISSED a trailing Worktree: line"
+fi
+
+# b.7 — THE REPORTED FAIL-OPEN. The exact mutation two reviewers landed
+# independently: the opening command replaced by prose, everything after it
+# left intact. The line still carries its placeholder AND still says `pwd` in
+# the remedy clause, so both a placeholder check and an anywhere-on-the-line
+# `pwd` check pass it. Only asserting the FIRST backticked span catches it.
+MUTANT='Worktree: [WORKTREE_PATH]\nWorktree Check: trust the path. It must print [WORKTREE_PATH]; a bare `git status` answers about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.'
+if [ -n "$(scan_worktree_precondition "$(probe mutant "$MUTANT")" )" ]; then
+  pass "lint flags a check whose leading command was replaced by prose"
+else
+  fail "lint MISSED the reported fail-open (a check that runs nothing)"
+fi
+
+# b.8 — a check opening with the WRONG command is flagged. `pwd` has to be
+# the first executable step; a different command does not report the cwd.
+if [ -n "$(scan_worktree_precondition "$(probe wrongcmd 'Worktree: [WORKTREE_PATH]\nWorktree Check: `git status` before any repo-relative command. It must print [WORKTREE_PATH].')" )" ]; then
+  pass "lint flags a check opening with a command other than pwd"
+else
+  fail "lint MISSED a check opening with the wrong command"
+fi
+
+# b.9 — an unbackticked mention is not a command. Without the code span
+# there is nothing marked for the agent to run.
+if [ -n "$(scan_worktree_precondition "$(probe unmarked 'Worktree: [WORKTREE_PATH]\nWorktree Check: run pwd before any repo-relative command. It must print [WORKTREE_PATH].')" )" ]; then
+  pass "lint flags a check whose pwd is not a marked command"
+else
+  fail "lint MISSED an unbackticked pwd"
 fi
 
 # b.5 — a Worktree: mention outside a delegation block is NOT scanned.

--- a/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -22,11 +22,12 @@
 #
 #   1. A `Worktree: [TOKEN]` line is followed on the very next line by the
 #      canonical `Worktree Check:` line for that same TOKEN.
-#   2. A block that hands the delegate a repo-relative path — a bare path
-#      opening `.agents/`, `skills/` or `tools/` — carries that pair at
-#      all. Without it the delegate runs those paths wherever its shell
-#      happens to be. A block whose paths are all placeholders is out of
-#      scope: the caller resolves those, and the lint cannot judge them.
+#   2. EVERY block carries that pair. No path matcher decides which
+#      delegations need it: judging "does this delegate touch the repo"
+#      from the block's literal text missed blocks with no pair at all,
+#      then missed blocks whose paths are placeholders the caller fills.
+#      The pair costs two lines on a delegation that never touches the
+#      repo, and uniform is the only rule that cannot be wrong.
 #
 # Scope is every skill doc that can carry a delegation, in BOTH trees: the
 # `skills/` source and the `.agents/skills/` render agents actually load.
@@ -76,11 +77,11 @@ scan_worktree_precondition() {
   awk -v f="$1" -v canon="$CANON" '
     function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
     /^[[:space:]]*<delegation_format>[[:space:]]*$/ {
-      indel = 1; pending = 0; haswt = 0; relline = 0; relpath = ""; next
+      indel = 1; pending = 0; haswt = 0; delline = NR; next
     }
     /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ {
       if (pending) printf "%s:%d: Worktree: [%s] ends the delegation with no Worktree Check line\n", f, pendline, token
-      if (indel && !haswt && relline) printf "%s:%d: delegation hands over the repo-relative path %s but carries no Worktree:/Worktree Check: pair\n", f, relline, relpath
+      if (indel && !haswt) printf "%s:%d: delegation carries no Worktree:/Worktree Check: pair\n", f, delline
       indel = 0; pending = 0; next
     }
     indel {
@@ -98,30 +99,7 @@ scan_worktree_precondition() {
         sub(/\].*$/, "", line)
         token = line; pendline = NR; pending = 1; haswt = 1
       }
-      if (!relline) {
-        probe = " " $0
-        if (match(probe, /[^A-Za-z0-9_.\/-](\.agents|skills|tools)\/[A-Za-z0-9._\/-]+/)) {
-          relline = NR
-          relpath = substr(probe, RSTART + 1, RLENGTH - 1)
-        }
-      }
     }
-  ' "$1"
-}
-
-# count_guarded_relpath_blocks <file>
-# Prints the number of delegation blocks that name a repo-relative path AND
-# carry a Worktree: line — the population rule 2 is meant to hold.
-count_guarded_relpath_blocks() {
-  awk '
-    /^[[:space:]]*<delegation_format>[[:space:]]*$/ { indel = 1; haswt = 0; hasrel = 0; next }
-    /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ { if (indel && haswt && hasrel) n++; indel = 0; next }
-    indel {
-      if ($0 ~ /^[[:space:]]*Worktree:[[:space:]]*\[[A-Za-z_][A-Za-z0-9_]*\][[:space:]]*$/) haswt = 1
-      probe = " " $0
-      if (match(probe, /[^A-Za-z0-9_.\/-](\.agents|skills|tools)\/[A-Za-z0-9._\/-]+/)) hasrel = 1
-    }
-    END { print n + 0 }
   ' "$1"
 }
 
@@ -141,22 +119,13 @@ scan_trees() {
   done
 }
 
-# count_sites <root> — shipped Worktree Check lines under one tree.
-count_sites() {
-  find "$1" -name '*.md' -not -path '*/tests/*' -exec grep -c '^[[:space:]]*Worktree Check:' {} + 2>/dev/null |
+# count_blocks <root> — delegation blocks the scan opened under one tree.
+# Counting blocks rather than shipped check lines guards the scanner's own
+# unit: if the block opener stopped matching, every rule would pass on an
+# empty population while the docs still read as full of check lines.
+count_blocks() {
+  find "$1" -name '*.md' -not -path '*/tests/*' -exec grep -c '^[[:space:]]*<delegation_format>[[:space:]]*$' {} + 2>/dev/null |
     awk -F: '{ n += $NF } END { print n + 0 }'
-}
-
-# count_guarded <root> — guarded repo-relative blocks under one tree.
-count_guarded() {
-  total=0
-  while IFS= read -r doc; do
-    [ -n "$doc" ] || continue
-    total=$((total + $(count_guarded_relpath_blocks "$doc")))
-  done <<EOF
-$(find "$1" -name '*.md' -not -path '*/tests/*' | sort)
-EOF
-  printf '%d' "$total"
 }
 
 echo "=== orch delegation worktree-cwd-precondition lint ==="
@@ -179,17 +148,11 @@ fi
 # counted on its own and an empty population in EITHER reds.
 for root in "$SOURCE_ROOT" "$RENDER_ROOT"; do
   label="${root#$REPO_ROOT/}"
-  sites="$(count_sites "$root")"
-  guarded="$(count_guarded "$root")"
-  if [ "$sites" -gt 0 ]; then
-    pass "$label: the scan read $sites delegated Worktree Check line(s)"
+  blocks="$(count_blocks "$root")"
+  if [ "$blocks" -gt 0 ]; then
+    pass "$label: the scan opened $blocks delegation block(s)"
   else
-    fail "$label: no Worktree Check lines found — the scan matched nothing to check"
-  fi
-  if [ "$guarded" -gt 0 ]; then
-    pass "$label: the scan read $guarded repo-relative delegation block(s) carrying the pair"
-  else
-    fail "$label: no repo-relative delegation blocks found — the repo-path rule matched nothing"
+    fail "$label: no delegation blocks found — the scan matched nothing to check"
   fi
 done
 
@@ -306,28 +269,13 @@ else
   fail "lint MISSED a remedy an absolute path cannot deliver"
 fi
 
-# b.13 — RULE 2. A block that hands over a repo-relative path with no
-# Worktree:/Worktree Check: pair IS flagged: the delegate runs that path
-# wherever its shell happens to be.
-if [ -n "$(scan_worktree_precondition "$(probe relpath 'Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md\n\nArguments: --project-order')" )" ]; then
-  pass "lint flags a delegation naming a repo-relative path with no Worktree pair"
+# b.13 — RULE 2. A block with no Worktree:/Worktree Check: pair at all IS
+# flagged, whatever it hands over: a placeholder the caller fills with a
+# repo path is invisible to any matcher, so no block is out of scope.
+if [ -n "$(scan_worktree_precondition "$(probe nopair 'Read: [RESEARCH_DOCS_PATH]/[ISSUE_ID]/findings.md\n\nArguments: --project-order')" )" ]; then
+  pass "lint flags a delegation carrying no Worktree pair"
 else
-  fail "lint MISSED a repo-relative delegation with no Worktree pair"
-fi
-
-# b.14 — the same block WITH the pair is not flagged.
-if [ -z "$(scan_worktree_precondition "$(probe relok "Follow workflow: .agents/skills/x/y.md\nWorktree: [WORKTREE_PATH]\n$CHECK")" )" ]; then
-  pass "lint accepts a repo-relative delegation carrying the pair"
-else
-  fail "lint false-flagged a repo-relative delegation that carries the pair"
-fi
-
-# b.15 — a block whose paths are ALL placeholders is out of scope: the
-# caller resolves them, and the lint cannot judge where they land.
-if [ -z "$(scan_worktree_precondition "$(probe placeholders 'Read: [RESEARCH_DOCS_PATH]/[ISSUE_ID]/findings.md\nWrite: [INPUT_FILE_PATH]')" )" ]; then
-  pass "lint ignores a delegation whose paths are all placeholders"
-else
-  fail "lint false-flagged a placeholder-only delegation"
+  fail "lint MISSED a delegation with no Worktree pair"
 fi
 
 # b.5 — a Worktree: mention outside a delegation block is NOT scanned.
@@ -355,8 +303,8 @@ fi
 # half and a render half, and a defect planted in EITHER half must red.
 TWO="$TMP_ROOT/two-trees"
 mkdir -p "$TWO/skills/x" "$TWO/.agents/skills/x"
-GOOD="Follow workflow: .agents/skills/x/y.md\nWorktree: [WORKTREE_PATH]\n$CHECK"
-BROKEN='Follow workflow: .agents/skills/x/y.md\nWorktree: [WORKTREE_PATH]'
+GOOD="Worktree: [WORKTREE_PATH]\n$CHECK"
+BROKEN='Worktree: [WORKTREE_PATH]'
 write_half() { printf '<delegation_format>\n%b\n</delegation_format>\n' "$2" > "$TWO/$1/x/y.md"; }
 
 # c.1 — control: both halves carry the check, nothing is flagged. Without
@@ -397,10 +345,10 @@ fi
 
 # c.5 — the real run reached both trees, so parts a and b judged the shipped
 # render and not just the source.
-if [ "$(count_sites "$SOURCE_ROOT")" -gt 0 ] && [ "$(count_sites "$RENDER_ROOT")" -gt 0 ]; then
+if [ "$(count_blocks "$SOURCE_ROOT")" -gt 0 ] && [ "$(count_blocks "$RENDER_ROOT")" -gt 0 ]; then
   pass "the shipped scan covered skills/ and .agents/skills/ alike"
 else
-  fail "one of the two shipped trees carried no Worktree Check line"
+  fail "one of the two shipped trees carried no delegation block"
 fi
 
 echo

--- a/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -130,7 +130,7 @@ CANON='Worktree Check: `pwd -P` before any repo-relative command. It must print 
 
 # The canonical fill line, verbatim. It carries no per-block token: `[DIR]`
 # is literal in every doc, so the whole line is compared as it stands.
-CANON_FILL='Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.'
+CANON_FILL='Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.'
 
 # scan_worktree_precondition <file>
 # Emits one "file:line: ..." line per defect, per the two rules above.

--- a/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -18,12 +18,12 @@
 # leaving the agent with nothing to run. A future wording change is made in
 # $CANON and at every site together, or the lint reds.
 #
-# Both sides of the comparison are physical paths. `git-context` derives
+# Both sides of the comparison are physical paths. The fill line derives
 # the delegated path with `git rev-parse --show-toplevel`, so the check
 # runs `pwd -P`: a bare `pwd` prints the logical path and would halt a
 # correct delegate whose shell entered the checkout through a symlink.
 #
-# Three rules are enforced:
+# Four rules are enforced:
 #
 #   1. A `Worktree: [TOKEN]` line is followed on the very next line by the
 #      canonical `Worktree Check:` line for that same TOKEN.
@@ -38,14 +38,29 @@
 #      nothing if the value poured into it is not what `pwd -P` prints, and
 #      the workflows resolved that value to `.` or to "the current
 #      directory", so a filled delegation halted in a CORRECT checkout. The
-#      fill line names `git-context repo-root`, whose `--show-toplevel`
-#      output is absolute and physical, so both sides of the comparison
-#      agree by construction. Per block, because a doc satisfying the rule
-#      once bought silence for every later block: the second block in
-#      audit-issues.md carried its own resolution, to an absolute LOGICAL
-#      path, and a file-wide assertion never read it. Rules 1 and 2 read
-#      inside a `<delegation_format>` block; rule 3 reads the lines between
-#      one block and the block before it.
+#      fill line names plain `git rev-parse --show-toplevel`, whose output
+#      is absolute and physical, so both sides of the comparison agree by
+#      construction. Plain, not an orch wrapper around it: the fill line
+#      also ships in project-management, which declares `git` and not orch,
+#      so a wrapper would not exist in an install carrying one skill and
+#      not the other — the placeholder would come out empty and the
+#      precondition would vanish with it. Per block, because a doc
+#      satisfying the rule once bought silence for every later block: the
+#      second block in audit-issues.md carried its own resolution, to an
+#      absolute LOGICAL path, and a file-wide assertion never read it.
+#   4. No line among those rule 3 reads opens with the fill line's opening
+#      clause and then diverges from it. A second instruction addressing
+#      the same two fields does not clear `hasfill`, so the canonical line
+#      plus a contradicting one read as clean. The rule is the DECIDABLE
+#      half of that: same opening clause, not byte-equal. It is not a
+#      conflict detector — prose that contradicts the fill line in its own
+#      words is not caught, and deciding that it does would be semantic
+#      judgment, which this repo has twice ruled out of a lexical scanner.
+#      Do not widen it; write a conflicting instruction in the canonical
+#      shape or leave the boundary where it is.
+#
+#      Rules 1 and 2 read inside a `<delegation_format>` block; rules 3
+#      and 4 read the lines between one block and the block before it.
 #
 # A block ends at three terminators, not one: its closing tag, a new opening
 # tag arriving while it is still open, and end of file. All three route
@@ -142,7 +157,15 @@ CANON='Worktree Check: `pwd -P` before any repo-relative command. It must print 
 
 # The canonical fill line, verbatim. It carries no per-block token: `[DIR]`
 # is literal in every doc, so the whole line is compared as it stands.
-CANON_FILL='Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.'
+CANON_FILL='Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.'
+
+# The fill line's opening clause: the part that names the two fields being
+# filled, before it says where the value comes from. A line opening with it
+# is addressing the same pair, so a byte difference after it is a second,
+# contradicting instruction. Held as its own literal and asserted a PROPER
+# prefix of $CANON_FILL by f.1 — rewording the sentence without rewording
+# this reds there, rather than leaving rule 4 matching nothing in silence.
+CANON_FILL_OPEN='Fill `Worktree:` and its `Worktree Check:`'
 
 # scan_worktree_precondition <file>
 # Emits one "file:line: ..." line per defect, per the two rules above.
@@ -208,8 +231,17 @@ scan_worktree_precondition() {
 # not preceded by. The function is a no-op outside a block, so a closed
 # block's successor keeps the lines read since. Malformed structure is
 # reported once, by scan_worktree_precondition.
+#
+# Rule 4 rides the same lines. `hasfill` is a latch — it is set and never
+# unset — so the canonical line followed by a divergent one still opens the
+# next block clean, and the delegating agent reads two instructions with no
+# ordering between them. A line opening with $CANON_FILL_OPEN and not equal
+# to $CANON_FILL is reported at its own line, whether or not the canonical
+# line also appears: same clause, different bytes, nothing semantic. Prose
+# contradicting the fill line in its own words is out of scope and stays
+# silent; see rule 4 in the header for why that boundary is where it is.
 scan_worktree_fill() {
-  awk -v f="$1" -v canon="$CANON_FILL" '
+  awk -v f="$1" -v canon="$CANON_FILL" -v open="$CANON_FILL_OPEN" '
     function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
     function close_block() { if (!indel) return; indel = 0; hasfill = 0 }
     /^[[:space:]]*<delegation_format>[[:space:]]*$/ {
@@ -219,7 +251,12 @@ scan_worktree_fill() {
       indel = 1; next
     }
     /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ { close_block(); next }
-    !indel { if (trim($0) == canon) hasfill = 1 }
+    !indel {
+      line = trim($0)
+      if (line == canon) hasfill = 1
+      else if (index(line, open) == 1)
+        printf "%s:%d: fill instruction opens like the canonical Worktree fill line and diverges from it (got: %s)\n", f, NR, line
+    }
     END { close_block() }
   ' "$1"
 }
@@ -677,6 +714,58 @@ if [ "$(scan_worktree_fill "$CARRIED")" = "$CARRIED:6: $NOFILL" ]; then
   pass "lint flags a block whose fill line was carried across an unclosed block"
 else
   fail "lint let an unclosed block carry its fill line to the next block"
+fi
+
+# --- Part f: a second instruction in the fill line's own shape ------------
+# RULE 4. `hasfill` latches, so a divergent instruction after the canonical
+# one leaves the block reading clean. Only the decidable half is caught:
+# same opening clause, different bytes. The probes pin both sides of that
+# boundary so the next reader does not take this for a conflict detector.
+
+# f.1 — the clause is a PROPER prefix of the sentence. Rule 4 matches by
+# `index(line, open) == 1`, so a clause reworded out of $CANON_FILL would
+# match nothing and the rule would go quiet without a single test failing;
+# a clause grown to the whole sentence would match only the canonical line
+# and do the same. This is the fixture that reds instead.
+case "$CANON_FILL" in
+  "$CANON_FILL_OPEN"*)
+    if [ "${#CANON_FILL_OPEN}" -lt "${#CANON_FILL}" ]; then
+      pass "the fill line's opening clause is a proper prefix of the canonical sentence"
+    else
+      fail "the opening clause is the whole canonical sentence — rule 4 matches only the canonical line"
+    fi
+    ;;
+  *) fail "the opening clause is not a prefix of \$CANON_FILL — rule 4 matches nothing" ;;
+esac
+
+CONFLICT_FILL='Fill `Worktree:` and its `Worktree Check:` with whichever directory this workflow is running in.'
+
+# f.2 — the canonical line, then a byte-different line in the same shape.
+# The block is preceded by the canonical sentence, so rule 3 is satisfied
+# and this output can come from nothing but rule 4. Compared whole, so the
+# probe fails if the scan names the wrong line as readily as if it names
+# none.
+CONFLICTED="$TMP_ROOT/probe-conflicting-fill.md"
+printf '%s\n\n%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' \
+  "$CANON_FILL" "$CONFLICT_FILL" "$CHECK" > "$CONFLICTED"
+DIVERGES='fill instruction opens like the canonical Worktree fill line and diverges from it'
+if [ "$(scan_worktree_fill "$CONFLICTED")" = "$CONFLICTED:3: $DIVERGES (got: $CONFLICT_FILL)" ]; then
+  pass "lint flags a second fill instruction that opens canonically and diverges"
+else
+  fail "lint MISSED a second fill instruction in the canonical shape"
+fi
+
+# f.3 — and the boundary from the other side: ordinary prose after the
+# canonical line, mentioning a path, is not an instruction in the fill
+# line's shape and stays clean. Without this the rule could be widened to
+# any line naming a directory and f.2 would still pass.
+NEARBY="$TMP_ROOT/probe-nearby-prose.md"
+printf '%s\n\nThe delegate writes its round artifact under `[DIR]/tmp`, which the collect step reads back.\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' \
+  "$CANON_FILL" "$CHECK" > "$NEARBY"
+if [ -z "$(scan_worktree_fill "$NEARBY")" ]; then
+  pass "lint leaves ordinary prose naming a path alone"
+else
+  fail "lint false-flagged prose that merely names a path"
 fi
 
 echo

--- a/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -5,11 +5,14 @@
 # and both noticed only after a confusing downstream failure.
 #
 # The cure is a precondition the agent runs before anything repo-relative,
-# and this lint holds it as ONE canonical sentence rather than as a set of
-# shape rules. Every shipped check line is byte-identical apart from the
-# block's own placeholder token, so the test carries that sentence in
-# $CANON with `@TOKEN@` where the token goes, and each site must equal it
-# with its own token substituted in. Equality is the whole predicate:
+# and it HALTS: a tool like `tools/guard` re-derives the repo from the
+# process cwd, so no path spelling makes a wrong-tree shell safe and there
+# is no remedy for the check to get right. This lint holds the precondition
+# as ONE canonical sentence rather than as a set of shape rules. Every
+# shipped check line is byte-identical apart from the block's own
+# placeholder token, so the test carries that sentence in $CANON with
+# `@TOKEN@` where the token goes, and each site must equal it with its own
+# token substituted in. Equality is the whole predicate:
 # nothing infers "opens with a command", "mentions pwd", or "names the
 # token", so no prose mutation can satisfy the letter of a heuristic while
 # leaving the agent with nothing to run. A future wording change is made in
@@ -25,14 +28,33 @@
 #      happens to be. A block whose paths are all placeholders is out of
 #      scope: the caller resolves those, and the lint cannot judge them.
 #
-# Scope is every skill doc that can carry a delegation, not one directory.
-# Tests are excluded: their probe fixtures carry deliberately broken
-# blocks. A `Worktree:` mention in prose or in a fenced example is not a
-# delegation and is not scanned.
+# Scope is every skill doc that can carry a delegation, in BOTH trees: the
+# `skills/` source and the `.agents/skills/` render agents actually load.
+# Deriving the scan root from this file's own location would leave each
+# copy scanning only its own half, and CI runs the source copy alone — the
+# render would ship unguarded with the suite green. Tests are excluded:
+# their probe fixtures carry deliberately broken blocks. A `Worktree:`
+# mention in prose or in a fenced example is not a delegation and is not
+# scanned.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SKILLS_ROOT="$(cd "$TEST_DIR/../.." && pwd)"
+
+# The nearest ancestor holding both trees. Walked, not counted in `../`,
+# so the source copy and the render copy resolve to the same repo root and
+# scan the same two directories.
+REPO_ROOT="$TEST_DIR"
+while [ "$REPO_ROOT" != "/" ]; do
+  if [ -d "$REPO_ROOT/skills" ] && [ -d "$REPO_ROOT/.agents/skills" ]; then break; fi
+  REPO_ROOT="$(dirname "$REPO_ROOT")"
+done
+if [ "$REPO_ROOT" = "/" ]; then
+  printf 'FAIL  no ancestor of %s holds both skills/ and .agents/skills/\n' "$TEST_DIR" >&2
+  exit 1
+fi
+SOURCE_ROOT="$REPO_ROOT/skills"
+RENDER_ROOT="$REPO_ROOT/.agents/skills"
+
 TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
@@ -45,7 +67,7 @@ fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 # The canonical check line, with @TOKEN@ standing in for the block's own
 # placeholder name. This is the single source of truth for the sentence;
 # the shipped docs must match it character for character.
-CANON='Worktree Check: `pwd` before any repo-relative command. It must print [@TOKEN@]; your shell can start in another lane'"'"'s worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [@TOKEN@], because a bare `cd` may not survive into the next tool call.'
+CANON='Worktree Check: `pwd` before any repo-relative command. It must print [@TOKEN@]; your shell can start in another lane'"'"'s worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.'
 
 # scan_worktree_precondition <file>
 # Emits one "file:line: ..." line per defect, per the two rules above.
@@ -103,46 +125,73 @@ count_guarded_relpath_blocks() {
   ' "$1"
 }
 
+# scan_trees <root>...
+# Emits every defect line found in every non-test *.md under the given
+# roots. A missing root is itself a defect: the caller asked for a tree
+# that is not there, and reporting nothing would read as clean.
+scan_trees() {
+  for root in "$@"; do
+    if [ ! -d "$root" ]; then
+      printf '%s: scan root does not exist\n' "$root"
+      continue
+    fi
+    find "$root" -name '*.md' -not -path '*/tests/*' | sort | while IFS= read -r doc; do
+      scan_worktree_precondition "$doc"
+    done
+  done
+}
+
+# count_sites <root> — shipped Worktree Check lines under one tree.
+count_sites() {
+  find "$1" -name '*.md' -not -path '*/tests/*' -exec grep -c '^[[:space:]]*Worktree Check:' {} + 2>/dev/null |
+    awk -F: '{ n += $NF } END { print n + 0 }'
+}
+
+# count_guarded <root> — guarded repo-relative blocks under one tree.
+count_guarded() {
+  total=0
+  while IFS= read -r doc; do
+    [ -n "$doc" ] || continue
+    total=$((total + $(count_guarded_relpath_blocks "$doc")))
+  done <<EOF
+$(find "$1" -name '*.md' -not -path '*/tests/*' | sort)
+EOF
+  printf '%d' "$total"
+}
+
 echo "=== orch delegation worktree-cwd-precondition lint ==="
 
 # --- Part a: every shipped delegation block carries the precondition -------
-# Every skill doc, not one skill's workflows: a delegation that hands over a
-# worktree is checked wherever it lives. Tests are excluded — their probe
-# fixtures carry deliberately broken blocks.
-DOCS="$(find "$SKILLS_ROOT" -name '*.md' -not -path '*/tests/*' | sort)"
-offenders=""
-sites=0
-guarded=0
-for doc in $DOCS; do
-  out="$(scan_worktree_precondition "$doc")"
-  [ -n "$out" ] && offenders="$offenders$out"$'\n'
-  n="$(grep -c '^[[:space:]]*Worktree Check:' "$doc" || true)"
-  sites=$((sites + n))
-  guarded=$((guarded + $(count_guarded_relpath_blocks "$doc")))
-done
+# Every skill doc in BOTH trees, not one skill's workflows and not the half
+# this copy of the test sits in: a delegation that hands over a worktree is
+# checked wherever it lives. Tests are excluded — their probe fixtures carry
+# deliberately broken blocks.
+offenders="$(scan_trees "$SOURCE_ROOT" "$RENDER_ROOT")"
 if [ -z "$offenders" ]; then
   pass "every delegated Worktree: line is followed by its canonical Worktree Check"
 else
   fail "delegation blocks missing the worktree cwd precondition:"
-  printf '%s' "$offenders" | sed 's/^/          /'
+  printf '%s\n' "$offenders" | sed 's/^/          /'
 fi
 
-# The precondition is worth nothing if no delegation carries it: a lint that
-# passes over zero sites is the vacuous case this asserts against.
-if [ "$sites" -gt 0 ]; then
-  pass "the scan read $sites delegated Worktree Check line(s)"
-else
-  fail "no Worktree Check lines found — the scan matched nothing to check"
-fi
-
-# The same guard for rule 2: with no shipped block naming a repo-relative
-# path, the repo-path rule passed over an empty population and proves
-# nothing.
-if [ "$guarded" -gt 0 ]; then
-  pass "the scan read $guarded repo-relative delegation block(s) carrying the pair"
-else
-  fail "no repo-relative delegation blocks found — the repo-path rule matched nothing"
-fi
+# The precondition is worth nothing if no delegation carries it, and one
+# tree going missing is the same vacuity a level up — so each tree is
+# counted on its own and an empty population in EITHER reds.
+for root in "$SOURCE_ROOT" "$RENDER_ROOT"; do
+  label="${root#$REPO_ROOT/}"
+  sites="$(count_sites "$root")"
+  guarded="$(count_guarded "$root")"
+  if [ "$sites" -gt 0 ]; then
+    pass "$label: the scan read $sites delegated Worktree Check line(s)"
+  else
+    fail "$label: no Worktree Check lines found — the scan matched nothing to check"
+  fi
+  if [ "$guarded" -gt 0 ]; then
+    pass "$label: the scan read $guarded repo-relative delegation block(s) carrying the pair"
+  else
+    fail "$label: no repo-relative delegation blocks found — the repo-path rule matched nothing"
+  fi
+done
 
 # --- Part b: the lint has teeth -------------------------------------------
 
@@ -245,6 +294,18 @@ else
   fail "lint MISSED a remedy resting on a cd that may not persist"
 fi
 
+# b.16 — nor on an absolute path. `tools/guard` re-derives the repo from
+# the process cwd on its own first line, so the path it is invoked by never
+# reaches that decision and a wrong-tree shell still judges the wrong lane.
+# The canonical sentence halts instead, and any remedy written in its place
+# reds.
+ABS_REMEDY='Worktree: [WORKTREE_PATH]\nWorktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]. Any other path — give every later command an absolute path under [WORKTREE_PATH].'
+if [ -n "$(scan_worktree_precondition "$(probe absremedy "$ABS_REMEDY")" )" ]; then
+  pass "lint flags a remedy resting on an absolute path"
+else
+  fail "lint MISSED a remedy an absolute path cannot deliver"
+fi
+
 # b.13 — RULE 2. A block that hands over a repo-relative path with no
 # Worktree:/Worktree Check: pair IS flagged: the delegate runs that path
 # wherever its shell happens to be.
@@ -284,6 +345,62 @@ if [ -n "$(scan_worktree_precondition "$(probe indented '   Worktree: [WORKTREE_
   pass "lint scans an indented delegation block"
 else
   fail "lint MISSED a bare Worktree: line inside an indented block"
+fi
+
+# --- Part c: both trees are actually scanned ------------------------------
+# A scan root derived from this file's own location would give the source
+# copy only skills/ and the render copy only .agents/skills/, and CI runs
+# the source copy alone — a check deleted from the render would ship with
+# the suite green. The fixture below is a repo root in miniature, a source
+# half and a render half, and a defect planted in EITHER half must red.
+TWO="$TMP_ROOT/two-trees"
+mkdir -p "$TWO/skills/x" "$TWO/.agents/skills/x"
+GOOD="Follow workflow: .agents/skills/x/y.md\nWorktree: [WORKTREE_PATH]\n$CHECK"
+BROKEN='Follow workflow: .agents/skills/x/y.md\nWorktree: [WORKTREE_PATH]'
+write_half() { printf '<delegation_format>\n%b\n</delegation_format>\n' "$2" > "$TWO/$1/x/y.md"; }
+
+# c.1 — control: both halves carry the check, nothing is flagged. Without
+# this the two probes below could red for any reason at all.
+write_half skills "$GOOD"
+write_half .agents/skills "$GOOD"
+if [ -z "$(scan_trees "$TWO/skills" "$TWO/.agents/skills")" ]; then
+  pass "two-tree scan is clean when both halves carry the check"
+else
+  fail "two-tree scan false-flagged two correct halves"
+fi
+
+# c.2 — the render half loses its check. This is the case a source-rooted
+# scan cannot see: the tree agents load, unguarded, with CI passing.
+write_half .agents/skills "$BROKEN"
+if [ -n "$(scan_trees "$TWO/skills" "$TWO/.agents/skills")" ]; then
+  pass "two-tree scan reds on a check deleted from the render half"
+else
+  fail "two-tree scan MISSED a check deleted from the render half"
+fi
+
+# c.3 — and symmetrically, the source half.
+write_half .agents/skills "$GOOD"
+write_half skills "$BROKEN"
+if [ -n "$(scan_trees "$TWO/skills" "$TWO/.agents/skills")" ]; then
+  pass "two-tree scan reds on a check deleted from the source half"
+else
+  fail "two-tree scan MISSED a check deleted from the source half"
+fi
+
+# c.4 — a root that is not there is reported, not passed over. A renamed or
+# unrendered tree would otherwise contribute zero defects and read as clean.
+if [ -n "$(scan_trees "$TWO/skills" "$TWO/nonexistent")" ]; then
+  pass "two-tree scan reds on a missing scan root"
+else
+  fail "two-tree scan MISSED a missing scan root"
+fi
+
+# c.5 — the real run reached both trees, so parts a and b judged the shipped
+# render and not just the source.
+if [ "$(count_sites "$SOURCE_ROOT")" -gt 0 ] && [ "$(count_sites "$RENDER_ROOT")" -gt 0 ]; then
+  pass "the shipped scan covered skills/ and .agents/skills/ alike"
+else
+  fail "one of the two shipped trees carried no Worktree Check line"
 fi
 
 echo

--- a/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -169,9 +169,20 @@ probe() {
 
 CHECK="${CANON//@TOKEN@/WORKTREE_PATH}"
 
+# reports <scan output> <fragment> — the scan named THIS defect, not merely
+# some defect. Rule 2 fires on every block rule 1 failed to see, so a probe
+# asserting bare non-emptiness stays green when the rule it is named for stops
+# working. Each probe below names the message it must draw: rule 1 on a wrong
+# line after the pair, rule 1 on a block ending at the Worktree: line, rule 2
+# on a block carrying no pair.
+reports() { case "$1" in *"$2"*) return 0 ;; *) return 1 ;; esac; }
+UNCANON='after Worktree: [WORKTREE_PATH] is not the canonical Worktree Check'
+UNCLOSED='Worktree: [WORKTREE_PATH] ends the delegation with no Worktree Check line'
+NOPAIR='delegation carries no Worktree:/Worktree Check: pair'
+
 # b.1 — the reported shape (a bare Worktree: line, as every site read before
 # this change) IS flagged.
-if [ -n "$(scan_worktree_precondition "$(probe bare 'Issue: [ISSUE_ID]\nWorktree: [WORKTREE_PATH]\nRound ID: [DEV_ROUND_ID]')" )" ]; then
+if reports "$(scan_worktree_precondition "$(probe bare 'Issue: [ISSUE_ID]\nWorktree: [WORKTREE_PATH]\nRound ID: [DEV_ROUND_ID]')")" "$UNCANON"; then
   pass "lint flags a Worktree: line with no Worktree Check"
 else
   fail "lint MISSED a bare Worktree: line (no teeth)"
@@ -186,14 +197,14 @@ fi
 
 # b.3 — a check naming a DIFFERENT placeholder IS flagged: a filled
 # delegation would compare pwd against a path this block never carries.
-if [ -n "$(scan_worktree_precondition "$(probe crossed "Worktree: [WT_PATH]\n$CHECK")" )" ]; then
+if reports "$(scan_worktree_precondition "$(probe crossed "Worktree: [WT_PATH]\n$CHECK")")" 'after Worktree: [WT_PATH] is not the canonical Worktree Check'; then
   pass "lint flags a Worktree Check naming the wrong placeholder"
 else
   fail "lint MISSED a cross-wired placeholder"
 fi
 
 # b.4 — a Worktree: line ending the block with no check IS flagged.
-if [ -n "$(scan_worktree_precondition "$(probe last 'Branch: [BRANCH]\nWorktree: [WORKTREE_PATH]')" )" ]; then
+if reports "$(scan_worktree_precondition "$(probe last 'Branch: [BRANCH]\nWorktree: [WORKTREE_PATH]')")" "$UNCLOSED"; then
   pass "lint flags a Worktree: line that closes the delegation"
 else
   fail "lint MISSED a trailing Worktree: line"
@@ -204,7 +215,7 @@ fi
 # so a placeholder check and an anywhere-on-the-line `pwd` check both pass
 # it. Equality does not.
 MUTANT='Worktree: [WORKTREE_PATH]\nWorktree Check: trust the path. It must print [WORKTREE_PATH]; a bare `git status` answers about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.'
-if [ -n "$(scan_worktree_precondition "$(probe mutant "$MUTANT")" )" ]; then
+if reports "$(scan_worktree_precondition "$(probe mutant "$MUTANT")")" "$UNCANON"; then
   pass "lint flags a check whose leading command was replaced by prose"
 else
   fail "lint MISSED a check that runs nothing"
@@ -214,7 +225,7 @@ fi
 # span on the line IS `pwd`, so an unanchored shape match accepts a check
 # that demotes the command to optional.
 DEMOTED='Worktree: [WORKTREE_PATH]\nWorktree Check: trust the path; optional check: `pwd` must print [WORKTREE_PATH].'
-if [ -n "$(scan_worktree_precondition "$(probe demoted "$DEMOTED")" )" ]; then
+if reports "$(scan_worktree_precondition "$(probe demoted "$DEMOTED")")" "$UNCANON"; then
   pass "lint flags a check whose pwd sits behind leading prose"
 else
   fail "lint MISSED a backticked pwd demoted behind prose"
@@ -225,7 +236,7 @@ fi
 # what it just measured. Every shape heuristic passes this; equality is the
 # only predicate that does not.
 UNBOUND='Worktree: [WORKTREE_PATH]\nWorktree Check: `pwd` before any repo-relative command. Ignore [WORKTREE_PATH].'
-if [ -n "$(scan_worktree_precondition "$(probe unbound "$UNBOUND")" )" ]; then
+if reports "$(scan_worktree_precondition "$(probe unbound "$UNBOUND")")" "$UNCANON"; then
   pass "lint flags a check whose pwd and placeholder are unbound"
 else
   fail "lint MISSED an unbound pwd and placeholder"
@@ -233,7 +244,7 @@ fi
 
 # b.8 — a check opening with the WRONG command is flagged. `pwd` has to be
 # the first executable step; a different command does not report the cwd.
-if [ -n "$(scan_worktree_precondition "$(probe wrongcmd 'Worktree: [WORKTREE_PATH]\nWorktree Check: `git status` before any repo-relative command. It must print [WORKTREE_PATH].')" )" ]; then
+if reports "$(scan_worktree_precondition "$(probe wrongcmd 'Worktree: [WORKTREE_PATH]\nWorktree Check: `git status` before any repo-relative command. It must print [WORKTREE_PATH].')")" "$UNCANON"; then
   pass "lint flags a check opening with a command other than pwd"
 else
   fail "lint MISSED a check opening with the wrong command"
@@ -241,7 +252,7 @@ fi
 
 # b.9 — an unbackticked mention is not a command. Without the code span
 # there is nothing marked for the agent to run.
-if [ -n "$(scan_worktree_precondition "$(probe unmarked 'Worktree: [WORKTREE_PATH]\nWorktree Check: run pwd before any repo-relative command. It must print [WORKTREE_PATH].')" )" ]; then
+if reports "$(scan_worktree_precondition "$(probe unmarked 'Worktree: [WORKTREE_PATH]\nWorktree Check: run pwd before any repo-relative command. It must print [WORKTREE_PATH].')")" "$UNCANON"; then
   pass "lint flags a check whose pwd is not a marked command"
 else
   fail "lint MISSED an unbackticked pwd"
@@ -251,7 +262,7 @@ fi
 # spawns a fresh shell per tool call drops it, and the agent resumes
 # repo-relative work in the wrong tree believing it recovered.
 STALE_CD='Worktree: [WORKTREE_PATH]\nWorktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.'
-if [ -n "$(scan_worktree_precondition "$(probe stalecd "$STALE_CD")" )" ]; then
+if reports "$(scan_worktree_precondition "$(probe stalecd "$STALE_CD")")" "$UNCANON"; then
   pass "lint flags a check whose remedy is a bare cd"
 else
   fail "lint MISSED a remedy resting on a cd that may not persist"
@@ -263,7 +274,7 @@ fi
 # The canonical sentence halts instead, and any remedy written in its place
 # reds.
 ABS_REMEDY='Worktree: [WORKTREE_PATH]\nWorktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]. Any other path — give every later command an absolute path under [WORKTREE_PATH].'
-if [ -n "$(scan_worktree_precondition "$(probe absremedy "$ABS_REMEDY")" )" ]; then
+if reports "$(scan_worktree_precondition "$(probe absremedy "$ABS_REMEDY")")" "$UNCANON"; then
   pass "lint flags a remedy resting on an absolute path"
 else
   fail "lint MISSED a remedy an absolute path cannot deliver"
@@ -272,7 +283,7 @@ fi
 # b.13 — RULE 2. A block with no Worktree:/Worktree Check: pair at all IS
 # flagged, whatever it hands over: a placeholder the caller fills with a
 # repo path is invisible to any matcher, so no block is out of scope.
-if [ -n "$(scan_worktree_precondition "$(probe nopair 'Read: [RESEARCH_DOCS_PATH]/[ISSUE_ID]/findings.md\n\nArguments: --project-order')" )" ]; then
+if reports "$(scan_worktree_precondition "$(probe nopair 'Read: [RESEARCH_DOCS_PATH]/[ISSUE_ID]/findings.md\n\nArguments: --project-order')")" "$NOPAIR"; then
   pass "lint flags a delegation carrying no Worktree pair"
 else
   fail "lint MISSED a delegation with no Worktree pair"
@@ -288,11 +299,13 @@ else
 fi
 
 # b.6 — an indented delegation block (dev-fix.md nests one in a numbered
-# step) is scanned, not skipped for its leading whitespace.
-if [ -n "$(scan_worktree_precondition "$(probe indented '   Worktree: [WORKTREE_PATH]\n   Round ID: [DEV_ROUND_ID]')" )" ]; then
+# step) is scanned, not skipped for its leading whitespace. Rule 2 flags this
+# same fixture the moment the indent tolerance breaks, so the assertion names
+# rule 1's message. The indent stays in the fixture; it is the thing tested.
+if reports "$(scan_worktree_precondition "$(probe indented '   Worktree: [WORKTREE_PATH]\n   Round ID: [DEV_ROUND_ID]')")" "$UNCANON"; then
   pass "lint scans an indented delegation block"
 else
-  fail "lint MISSED a bare Worktree: line inside an indented block"
+  fail "rule 1 MISSED an indented Worktree: line"
 fi
 
 # --- Part c: both trees are actually scanned ------------------------------
@@ -320,7 +333,7 @@ fi
 # c.2 — the render half loses its check. This is the case a source-rooted
 # scan cannot see: the tree agents load, unguarded, with CI passing.
 write_half .agents/skills "$BROKEN"
-if [ -n "$(scan_trees "$TWO/skills" "$TWO/.agents/skills")" ]; then
+if reports "$(scan_trees "$TWO/skills" "$TWO/.agents/skills")" "$TWO/.agents/skills/x/y.md"; then
   pass "two-tree scan reds on a check deleted from the render half"
 else
   fail "two-tree scan MISSED a check deleted from the render half"
@@ -329,7 +342,7 @@ fi
 # c.3 — and symmetrically, the source half.
 write_half .agents/skills "$GOOD"
 write_half skills "$BROKEN"
-if [ -n "$(scan_trees "$TWO/skills" "$TWO/.agents/skills")" ]; then
+if reports "$(scan_trees "$TWO/skills" "$TWO/.agents/skills")" "$TWO/skills/x/y.md"; then
   pass "two-tree scan reds on a check deleted from the source half"
 else
   fail "two-tree scan MISSED a check deleted from the source half"
@@ -337,7 +350,7 @@ fi
 
 # c.4 — a root that is not there is reported, not passed over. A renamed or
 # unrendered tree would otherwise contribute zero defects and read as clean.
-if [ -n "$(scan_trees "$TWO/skills" "$TWO/nonexistent")" ]; then
+if reports "$(scan_trees "$TWO/skills" "$TWO/nonexistent")" "$TWO/nonexistent: scan root does not exist"; then
   pass "two-tree scan reds on a missing scan root"
 else
   fail "two-tree scan MISSED a missing scan root"

--- a/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -47,6 +47,14 @@
 #      inside a `<delegation_format>` block; rule 3 reads the lines between
 #      one block and the block before it.
 #
+# A block ends at three terminators, not one: its closing tag, a new opening
+# tag arriving while it is still open, and end of file. All three route
+# through one `close_block`, so no rule is reachable only through a
+# well-formed block — deleting a closing tag along with the pair used to
+# leave the delegation unscanned and the suite green. An unterminated block
+# is itself reported, naming the opener's line, so a reader sees that the
+# document is malformed and not only that a pair is missing.
+#
 # Scope is every skill doc that can carry a delegation, in BOTH trees where
 # both exist: the `skills/` source and the `.agents/skills/` render agents
 # actually load. Deriving the scan root from this file's own location would
@@ -139,16 +147,29 @@ CANON_FILL='Fill `Worktree:` and its `Worktree Check:` from `git-context repo-ro
 # scan_worktree_precondition <file>
 # Emits one "file:line: ..." line per defect, per the two rules above.
 # Lines outside a delegation block are never scanned.
+#
+# Every rule that judges a whole block lives in `close_block`, and all three
+# terminators call it: the closing tag, a new opening tag, and END. Writing
+# them at the closing tag alone was the fail-open — a block missing that tag
+# escaped both rules, so deleting the pair and the tag together shipped an
+# unguarded delegation with the suite green. `reason` is empty for the one
+# terminator that is well formed; the other two also report the block itself.
 scan_worktree_precondition() {
   awk -v f="$1" -v canon="$CANON" '
     function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+    function close_block(reason) {
+      if (!indel) return
+      if (reason != "") printf "%s:%d: delegation block is never closed (%s)\n", f, delline, reason
+      if (pending) printf "%s:%d: Worktree: [%s] ends the delegation with no Worktree Check line\n", f, pendline, token
+      if (!haswt) printf "%s:%d: delegation carries no Worktree:/Worktree Check: pair\n", f, delline
+      indel = 0; pending = 0; haswt = 0
+    }
     /^[[:space:]]*<delegation_format>[[:space:]]*$/ {
+      close_block("a new <delegation_format> opens at line " NR)
       indel = 1; pending = 0; haswt = 0; delline = NR; next
     }
     /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ {
-      if (pending) printf "%s:%d: Worktree: [%s] ends the delegation with no Worktree Check line\n", f, pendline, token
-      if (indel && !haswt) printf "%s:%d: delegation carries no Worktree:/Worktree Check: pair\n", f, delline
-      indel = 0; pending = 0; next
+      close_block(""); next
     }
     indel {
       if (pending) {
@@ -166,6 +187,7 @@ scan_worktree_precondition() {
         token = line; pendline = NR; pending = 1; haswt = 1
       }
     }
+    END { close_block("reached end of file") }
   ' "$1"
 }
 
@@ -175,20 +197,30 @@ scan_worktree_precondition() {
 # canonical resolution once and a divergent one before a later block passed a
 # file-wide assertion, and the later block is the one that poured a logical
 # path into a `pwd -P` comparison. So the demand is raised at every opening
-# tag and the evidence is cleared at every closing tag — each block is asked
+# tag and the evidence is cleared at every terminator — each block is asked
 # for the sentence again, in the lines between it and the block before it.
 # Equality against $CANON_FILL is the whole predicate, so a resolution
 # reworded back to `.` or to the current directory reds.
+#
+# The clearing routes through one `close_block` for the same reason as the
+# scanner above: clearing at the closing tag alone let an unterminated block
+# carry its evidence forward, and the next block passed on a fill line it is
+# not preceded by. The function is a no-op outside a block, so a closed
+# block's successor keeps the lines read since. Malformed structure is
+# reported once, by scan_worktree_precondition.
 scan_worktree_fill() {
   awk -v f="$1" -v canon="$CANON_FILL" '
     function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+    function close_block() { if (!indel) return; indel = 0; hasfill = 0 }
     /^[[:space:]]*<delegation_format>[[:space:]]*$/ {
+      close_block()
       if (!hasfill)
         printf "%s:%d: delegation block is not preceded by the canonical Worktree fill line\n", f, NR
       indel = 1; next
     }
-    /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ { indel = 0; hasfill = 0; next }
+    /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ { close_block(); next }
     !indel { if (trim($0) == canon) hasfill = 1 }
+    END { close_block() }
   ' "$1"
 }
 
@@ -398,6 +430,33 @@ else
   fail "lint MISSED a delegation with no Worktree pair"
 fi
 
+# b.14 — RULE 2 THROUGH THE END-OF-FILE TERMINATOR. Codex's mutation: the
+# pair and the closing tag deleted together, the fill line kept so rule 3 is
+# satisfied at the opener. With the block rules written at the closing tag
+# alone, this shipped a delegation carrying no precondition at all and the
+# suite stayed green. The output is compared whole, so the probe fails if the
+# scan names the wrong line as readily as if it names none.
+EOFOPEN="$TMP_ROOT/probe-eof-open.md"
+printf '<delegation_format>\nRead: [RESEARCH_DOCS_PATH]/findings.md\nArguments: --project-order\n' > "$EOFOPEN"
+if [ "$(scan_worktree_precondition "$EOFOPEN")" = "$EOFOPEN:1: delegation block is never closed (reached end of file)
+$EOFOPEN:1: $NOPAIR" ]; then
+  pass "lint reds on a delegation block left open at end of file"
+else
+  fail "lint MISSED a delegation block left open at end of file"
+fi
+
+# b.15 — and through the other terminator: the closing tag replaced by the
+# next opening tag. The second block is well formed, so nothing but the
+# first block's own rules can produce this output.
+NEXTOPEN="$TMP_ROOT/probe-next-open.md"
+printf '<delegation_format>\nRead: [RESEARCH_DOCS_PATH]/findings.md\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' "$CHECK" > "$NEXTOPEN"
+if [ "$(scan_worktree_precondition "$NEXTOPEN")" = "$NEXTOPEN:1: delegation block is never closed (a new <delegation_format> opens at line 3)
+$NEXTOPEN:1: $NOPAIR" ]; then
+  pass "lint reds on a block whose closing tag is replaced by the next opener"
+else
+  fail "lint MISSED a block whose closing tag is replaced by the next opener"
+fi
+
 # b.5 — a Worktree: mention outside a delegation block is NOT scanned.
 PROSE="$TMP_ROOT/probe-prose.md"
 printf 'Fill the delegation Worktree: [WORKTREE_PATH] from the claim output, per .agents/skills/orch/SKILL.md.\n' > "$PROSE"
@@ -604,6 +663,20 @@ if [ -z "$(scan_worktree_fill "$BOTHFILLED")" ]; then
   pass "lint accepts a doc whose every block carries the canonical fill line"
 else
   fail "lint false-flagged a doc filling both its blocks canonically"
+fi
+
+# e.8 — RULE 3 THROUGH THE SAME TERMINATOR. The first block carries the
+# canonical fill line and is never closed; the second is preceded by nothing
+# but the first block's body. Clearing the evidence at the closing tag alone
+# carried it across and the second block passed on a sentence it does not
+# follow. Compared whole: naming the first block instead would be wrong.
+CARRIED="$TMP_ROOT/probe-carried-fill.md"
+printf '%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' \
+  "$CANON_FILL" "$CHECK" "$CHECK" > "$CARRIED"
+if [ "$(scan_worktree_fill "$CARRIED")" = "$CARRIED:6: $NOFILL" ]; then
+  pass "lint flags a block whose fill line was carried across an unclosed block"
+else
+  fail "lint let an unclosed block carry its fill line to the next block"
 fi
 
 echo

--- a/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -23,7 +23,7 @@
 # runs `pwd -P`: a bare `pwd` prints the logical path and would halt a
 # correct delegate whose shell entered the checkout through a symlink.
 #
-# Two rules are enforced inside a `<delegation_format>` block:
+# Three rules are enforced:
 #
 #   1. A `Worktree: [TOKEN]` line is followed on the very next line by the
 #      canonical `Worktree Check:` line for that same TOKEN.
@@ -33,33 +33,86 @@
 #      then missed blocks whose paths are placeholders the caller fills.
 #      The pair costs two lines on a delegation that never touches the
 #      repo, and uniform is the only rule that cannot be wrong.
+#   3. A doc carrying a block also carries the canonical fill line, held in
+#      $CANON_FILL by the same equality predicate. The pair is worth
+#      nothing if the value poured into it is not what `pwd -P` prints, and
+#      the workflows resolved that value to `.` or to "the current
+#      directory", so a filled delegation halted in a CORRECT checkout. The
+#      fill line names `git-context repo-root`, whose `--show-toplevel`
+#      output is absolute and physical, so both sides of the comparison
+#      agree by construction. Rules 1 and 2 read inside a
+#      `<delegation_format>` block; rule 3 reads the doc around it.
 #
-# Scope is every skill doc that can carry a delegation, in BOTH trees: the
-# `skills/` source and the `.agents/skills/` render agents actually load.
-# Deriving the scan root from this file's own location would leave each
-# copy scanning only its own half, and CI runs the source copy alone — the
-# render would ship unguarded with the suite green. Tests are excluded:
+# Scope is every skill doc that can carry a delegation, in BOTH trees where
+# both exist: the `skills/` source and the `.agents/skills/` render agents
+# actually load. Deriving the scan root from this file's own location would
+# leave each copy scanning only its own half, and CI runs the source copy
+# alone, so the render would ship unguarded with the suite green. An
+# INSTALLED layout has no `skills/` at all (the CLI integration check runs
+# this suite from `.agents/skills/orch/tests/`); there the lint scans the
+# one tree it has and names that mode in its output, so no reader mistakes
+# an installed run for a full one. A `skills/` tree whose render is missing
+# is a defect, not an installed layout, and stays red. Tests are excluded:
 # their probe fixtures carry deliberately broken blocks. A `Worktree:`
 # mention in prose or in a fenced example is not a delegation and is not
 # scanned.
 set -euo pipefail
 
-TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
-# The nearest ancestor holding both trees. Walked, not counted in `../`,
-# so the source copy and the render copy resolve to the same repo root and
-# scan the same two directories.
-REPO_ROOT="$TEST_DIR"
-while [ "$REPO_ROOT" != "/" ]; do
-  if [ -d "$REPO_ROOT/skills" ] && [ -d "$REPO_ROOT/.agents/skills" ]; then break; fi
-  REPO_ROOT="$(dirname "$REPO_ROOT")"
-done
-if [ "$REPO_ROOT" = "/" ]; then
-  printf 'FAIL  no ancestor of %s holds both skills/ and .agents/skills/\n' "$TEST_DIR" >&2
+# resolve_roots <start_dir>
+# Prints "<mode> <root>" for the layout above <start_dir>, or a diagnostic
+# and returns 1. Walked, not counted in `../`, so the source copy and the
+# render copy resolve to the same root and scan the same directories.
+#
+# The walk anchors on `.agents/skills`, never on a bare directory named
+# `skills`: a render tree's own parent holds one, so a search for that name
+# alone matches inside the render and would read an installed tree as a
+# source checkout. Once the render root is known, `skills/` beside it
+# decides the mode. A tree holding `skills/` and no render reaches neither
+# arm and fails, which is what keeps a missing render a defect.
+resolve_roots() {
+  local start dir render_root="" src_root=""
+  start="$(cd "$1" && pwd -P)"
+  dir="$start"
+  while [ "$dir" != "/" ]; do
+    if [ -d "$dir/.agents/skills" ]; then render_root="$dir"; break; fi
+    dir="$(dirname "$dir")"
+  done
+  if [ -n "$render_root" ]; then
+    if [ -d "$render_root/skills" ]; then
+      printf 'both %s\n' "$render_root"
+    else
+      printf 'installed %s\n' "$render_root"
+    fi
+    return 0
+  fi
+  dir="$start"
+  while [ "$dir" != "/" ]; do
+    if [ -d "$dir/skills" ]; then src_root="$dir"; break; fi
+    dir="$(dirname "$dir")"
+  done
+  if [ -n "$src_root" ]; then
+    printf '%s holds skills/ but no .agents/skills/ render beside it\n' "$src_root"
+    return 1
+  fi
+  printf 'no ancestor of %s holds .agents/skills/\n' "$start"
+  return 1
+}
+
+if ! RESOLVED="$(resolve_roots "$TEST_DIR")"; then
+  printf 'FAIL  %s\n' "$RESOLVED" >&2
   exit 1
 fi
+MODE="${RESOLVED%% *}"
+REPO_ROOT="${RESOLVED#* }"
 SOURCE_ROOT="$REPO_ROOT/skills"
 RENDER_ROOT="$REPO_ROOT/.agents/skills"
+if [ "$MODE" = both ]; then
+  SCAN_ROOTS=("$SOURCE_ROOT" "$RENDER_ROOT")
+else
+  SCAN_ROOTS=("$RENDER_ROOT")
+fi
 
 TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
@@ -74,6 +127,10 @@ fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 # placeholder name. This is the single source of truth for the sentence;
 # the shipped docs must match it character for character.
 CANON='Worktree Check: `pwd -P` before any repo-relative command. It must print [@TOKEN@]; your shell can start in another lane'"'"'s worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.'
+
+# The canonical fill line, verbatim. It carries no per-block token: `[DIR]`
+# is literal in every doc, so the whole line is compared as it stands.
+CANON_FILL='Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.'
 
 # scan_worktree_precondition <file>
 # Emits one "file:line: ..." line per defect, per the two rules above.
@@ -108,6 +165,24 @@ scan_worktree_precondition() {
   ' "$1"
 }
 
+# scan_worktree_fill <file>
+# Emits one defect line when a doc opens a delegation block but never states,
+# outside every block, that the delegated path comes from `git-context
+# repo-root`. Equality against $CANON_FILL is the whole predicate, so a
+# resolution reworded back to `.` or to the current directory reds.
+scan_worktree_fill() {
+  awk -v f="$1" -v canon="$CANON_FILL" '
+    function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+    /^[[:space:]]*<delegation_format>[[:space:]]*$/ { indel = 1; hasblock = 1; next }
+    /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ { indel = 0; next }
+    !indel { if (trim($0) == canon) hasfill = 1 }
+    END {
+      if (hasblock && !hasfill)
+        printf "%s: carries a delegation block but no canonical Worktree fill line\n", f
+    }
+  ' "$1"
+}
+
 # scan_trees <root>...
 # Emits every defect line found in every non-test *.md under the given
 # roots. A missing root is itself a defect: the caller asked for a tree
@@ -120,6 +195,7 @@ scan_trees() {
     fi
     find "$root" -name '*.md' -not -path '*/tests/*' | sort | while IFS= read -r doc; do
       scan_worktree_precondition "$doc"
+      scan_worktree_fill "$doc"
     done
   done
 }
@@ -134,13 +210,18 @@ count_blocks() {
 }
 
 echo "=== orch delegation worktree-cwd-precondition lint ==="
+if [ "$MODE" = both ]; then
+  printf 'mode: source checkout, scanning skills/ and .agents/skills/ under %s\n' "$REPO_ROOT"
+else
+  printf 'mode: INSTALLED layout, scanning .agents/skills/ only under %s (no skills/ tree)\n' "$REPO_ROOT"
+fi
 
 # --- Part a: every shipped delegation block carries the precondition -------
 # Every skill doc in BOTH trees, not one skill's workflows and not the half
 # this copy of the test sits in: a delegation that hands over a worktree is
 # checked wherever it lives. Tests are excluded — their probe fixtures carry
 # deliberately broken blocks.
-offenders="$(scan_trees "$SOURCE_ROOT" "$RENDER_ROOT")"
+offenders="$(scan_trees "${SCAN_ROOTS[@]}")"
 if [ -z "$offenders" ]; then
   pass "every delegated Worktree: line is followed by its canonical Worktree Check"
 else
@@ -151,7 +232,7 @@ fi
 # The precondition is worth nothing if no delegation carries it, and one
 # tree going missing is the same vacuity a level up — so each tree is
 # counted on its own and an empty population in EITHER reds.
-for root in "$SOURCE_ROOT" "$RENDER_ROOT"; do
+for root in "${SCAN_ROOTS[@]}"; do
   label="${root#$REPO_ROOT/}"
   blocks="$(count_blocks "$root")"
   if [ "$blocks" -gt 0 ]; then
@@ -343,7 +424,7 @@ TWO="$TMP_ROOT/two-trees"
 mkdir -p "$TWO/skills/x" "$TWO/.agents/skills/x"
 GOOD="Worktree: [WORKTREE_PATH]\n$CHECK"
 BROKEN='Worktree: [WORKTREE_PATH]'
-write_half() { printf '<delegation_format>\n%b\n</delegation_format>\n' "$2" > "$TWO/$1/x/y.md"; }
+write_half() { printf '%s\n\n<delegation_format>\n%b\n</delegation_format>\n' "$CANON_FILL" "$2" > "$TWO/$1/x/y.md"; }
 
 # c.1 — control: both halves carry the check, nothing is flagged. Without
 # this the two probes below could red for any reason at all.
@@ -381,12 +462,107 @@ else
   fail "two-tree scan MISSED a missing scan root"
 fi
 
-# c.5 — the real run reached both trees, so parts a and b judged the shipped
-# render and not just the source.
-if [ "$(count_blocks "$SOURCE_ROOT")" -gt 0 ] && [ "$(count_blocks "$RENDER_ROOT")" -gt 0 ]; then
-  pass "the shipped scan covered skills/ and .agents/skills/ alike"
+# c.5 — the real run reached every tree its mode names, so parts a and b
+# judged the shipped render and not just the source.
+if [ "$MODE" = both ]; then
+  if [ "$(count_blocks "$SOURCE_ROOT")" -gt 0 ] && [ "$(count_blocks "$RENDER_ROOT")" -gt 0 ]; then
+    pass "the shipped scan covered skills/ and .agents/skills/ alike"
+  else
+    fail "one of the two shipped trees carried no delegation block"
+  fi
 else
-  fail "one of the two shipped trees carried no delegation block"
+  if [ "$(count_blocks "$RENDER_ROOT")" -gt 0 ]; then
+    pass "installed layout: the shipped scan covered .agents/skills/"
+  else
+    fail "installed layout: .agents/skills/ carried no delegation block"
+  fi
+fi
+
+# --- Part d: the scan root resolves to the layout it is actually in --------
+# Three layouts stay distinct. Two trees is the source checkout and the CI
+# path. One tree is the installed layout the CLI integration check runs this
+# suite from, where no top-level skills/ exists. A skills/ tree whose render
+# is missing is neither: it is the fail-open this lint was tightened to
+# catch, and it must stay red rather than degrade to a one-tree scan.
+LAYOUTS="$TMP_ROOT/layouts"
+mkdir -p "$LAYOUTS/both/skills/x" "$LAYOUTS/both/.agents/skills/orch/tests"
+mkdir -p "$LAYOUTS/inst/.agents/skills/orch/tests"
+mkdir -p "$LAYOUTS/src/skills/orch/tests"
+
+# d.1 — both halves present: two-tree mode, rooted where both live.
+if [ "$(resolve_roots "$LAYOUTS/both/.agents/skills/orch/tests")" = "both $LAYOUTS/both" ]; then
+  pass "a root holding both trees resolves to two-tree mode"
+else
+  fail "a root holding both trees did not resolve to two-tree mode"
+fi
+
+# d.2 — the installed layout: one tree, named as such, no walk to /.
+if [ "$(resolve_roots "$LAYOUTS/inst/.agents/skills/orch/tests")" = "installed $LAYOUTS/inst" ]; then
+  pass "an installed root with no skills/ resolves to one-tree mode"
+else
+  fail "an installed root did not resolve to one-tree mode"
+fi
+
+# d.3 — skills/ present, render missing. This must NOT be read as installed.
+if src_only="$(resolve_roots "$LAYOUTS/src/skills/orch/tests")"; then
+  fail "a skills/ tree with no render was accepted instead of reported"
+elif reports "$src_only" "$LAYOUTS/src holds skills/ but no .agents/skills/ render beside it"; then
+  pass "a skills/ tree with no render is reported, not degraded to one tree"
+else
+  fail "a skills/ tree with no render drew the wrong diagnostic"
+fi
+
+# --- Part e: the delegated path is resolved before it fills the pair -------
+# The check is worth nothing if the value handed to it is not what `pwd -P`
+# prints. The workflows resolved it to `.` or to "the current directory", so
+# a delegate filled from them halted in a CORRECT checkout. The fill line is
+# held by the same equality predicate as the check line.
+NOFILL='carries a delegation block but no canonical Worktree fill line'
+
+# e.1 — a delegating doc that never says where the path comes from IS
+# flagged, even with a perfect check line inside the block.
+if reports "$(scan_worktree_fill "$(probe nofill "Worktree: [WORKTREE_PATH]\n$CHECK")")" "$NOFILL"; then
+  pass "lint flags a delegating doc carrying no fill line"
+else
+  fail "lint MISSED a delegating doc with no fill line"
+fi
+
+# e.2 — the canonical fill line is accepted.
+FILLED="$TMP_ROOT/probe-filled.md"
+printf '%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' "$CANON_FILL" "$CHECK" > "$FILLED"
+if [ -z "$(scan_worktree_fill "$FILLED")" ]; then
+  pass "lint accepts a doc carrying the canonical fill line"
+else
+  fail "lint false-flagged the canonical fill line"
+fi
+
+# e.3 — the shipped defect, spelled out: the fill line resolves the delegated
+# path to the current directory. `pwd -P` prints an absolute physical path
+# and can never equal a relative one, so this halts every correct delegate.
+RELFILL='Fill `Worktree:` and its `Worktree Check:` with the current directory. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.'
+RELATIVE="$TMP_ROOT/probe-relative-fill.md"
+printf '%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' "$RELFILL" "$CHECK" > "$RELATIVE"
+if reports "$(scan_worktree_fill "$RELATIVE")" "$NOFILL"; then
+  pass "lint flags a fill line resolving the delegated path to the current directory"
+else
+  fail "lint MISSED a delegated path resolved to the current directory"
+fi
+
+# e.4 — the fill line inside the block does not count: it has to be the
+# doc's instruction to the filler, not a line the delegate reads as content.
+INBLOCK="$TMP_ROOT/probe-inblock-fill.md"
+printf '<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n%s\n</delegation_format>\n' "$CHECK" "$CANON_FILL" > "$INBLOCK"
+if reports "$(scan_worktree_fill "$INBLOCK")" "$NOFILL"; then
+  pass "lint does not count a fill line buried inside the delegation block"
+else
+  fail "lint counted a fill line inside the block"
+fi
+
+# e.5 — a doc carrying no delegation is asked for no fill line.
+if [ -z "$(scan_worktree_fill "$PROSE")" ]; then
+  pass "lint asks no fill line of a doc carrying no delegation"
+else
+  fail "lint demanded a fill line of a non-delegating doc"
 fi
 
 echo

--- a/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -33,15 +33,19 @@
 #      then missed blocks whose paths are placeholders the caller fills.
 #      The pair costs two lines on a delegation that never touches the
 #      repo, and uniform is the only rule that cannot be wrong.
-#   3. A doc carrying a block also carries the canonical fill line, held in
+#   3. EVERY block is preceded by the canonical fill line, held in
 #      $CANON_FILL by the same equality predicate. The pair is worth
 #      nothing if the value poured into it is not what `pwd -P` prints, and
 #      the workflows resolved that value to `.` or to "the current
 #      directory", so a filled delegation halted in a CORRECT checkout. The
 #      fill line names `git-context repo-root`, whose `--show-toplevel`
 #      output is absolute and physical, so both sides of the comparison
-#      agree by construction. Rules 1 and 2 read inside a
-#      `<delegation_format>` block; rule 3 reads the doc around it.
+#      agree by construction. Per block, because a doc satisfying the rule
+#      once bought silence for every later block: the second block in
+#      audit-issues.md carried its own resolution, to an absolute LOGICAL
+#      path, and a file-wide assertion never read it. Rules 1 and 2 read
+#      inside a `<delegation_format>` block; rule 3 reads the lines between
+#      one block and the block before it.
 #
 # Scope is every skill doc that can carry a delegation, in BOTH trees where
 # both exist: the `skills/` source and the `.agents/skills/` render agents
@@ -166,20 +170,25 @@ scan_worktree_precondition() {
 }
 
 # scan_worktree_fill <file>
-# Emits one defect line when a doc opens a delegation block but never states,
-# outside every block, that the delegated path comes from `git-context
-# repo-root`. Equality against $CANON_FILL is the whole predicate, so a
-# resolution reworded back to `.` or to the current directory reds.
+# Emits one defect line per delegation block the canonical fill line does not
+# precede. The scope is the BLOCK, not the file: a doc that states the
+# canonical resolution once and a divergent one before a later block passed a
+# file-wide assertion, and the later block is the one that poured a logical
+# path into a `pwd -P` comparison. So the demand is raised at every opening
+# tag and the evidence is cleared at every closing tag — each block is asked
+# for the sentence again, in the lines between it and the block before it.
+# Equality against $CANON_FILL is the whole predicate, so a resolution
+# reworded back to `.` or to the current directory reds.
 scan_worktree_fill() {
   awk -v f="$1" -v canon="$CANON_FILL" '
     function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
-    /^[[:space:]]*<delegation_format>[[:space:]]*$/ { indel = 1; hasblock = 1; next }
-    /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ { indel = 0; next }
-    !indel { if (trim($0) == canon) hasfill = 1 }
-    END {
-      if (hasblock && !hasfill)
-        printf "%s: carries a delegation block but no canonical Worktree fill line\n", f
+    /^[[:space:]]*<delegation_format>[[:space:]]*$/ {
+      if (!hasfill)
+        printf "%s:%d: delegation block is not preceded by the canonical Worktree fill line\n", f, NR
+      indel = 1; next
     }
+    /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ { indel = 0; hasfill = 0; next }
+    !indel { if (trim($0) == canon) hasfill = 1 }
   ' "$1"
 }
 
@@ -517,7 +526,9 @@ fi
 # prints. The workflows resolved it to `.` or to "the current directory", so
 # a delegate filled from them halted in a CORRECT checkout. The fill line is
 # held by the same equality predicate as the check line.
-NOFILL='carries a delegation block but no canonical Worktree fill line'
+# The demand is per block, so the fragment carries no file half and each
+# probe below pins the block it must name.
+NOFILL='delegation block is not preceded by the canonical Worktree fill line'
 
 # e.1 — a delegating doc that never says where the path comes from IS
 # flagged, even with a perfect check line inside the block.
@@ -563,6 +574,36 @@ if [ -z "$(scan_worktree_fill "$PROSE")" ]; then
   pass "lint asks no fill line of a doc carrying no delegation"
 else
   fail "lint demanded a fill line of a non-delegating doc"
+fi
+
+# e.6 — the shape a file-wide assertion hid, and the reason rule 3 is now
+# per block: the canonical line before the FIRST block, a resolution of the
+# doc's own before the second. The one in audit-issues.md § 4.1 said
+# "the absolute path of the caller worktree", which admits a LOGICAL path —
+# a checkout entered through a symlink — and `pwd -P` then halts a correctly
+# placed delegate. The output is compared whole, so the probe fails if the
+# scan names the wrong block as readily as if it names none.
+TWOBLOCK="$TMP_ROOT/probe-two-blocks.md"
+DIVERGENT='Fill both fields with the absolute path of the caller worktree the collect step resolves.'
+printf '%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n\n%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' \
+  "$CANON_FILL" "$CHECK" "$DIVERGENT" "$CHECK" > "$TWOBLOCK"
+SECOND_OPEN="$(grep -n '^<delegation_format>$' "$TWOBLOCK" | sed -n '2s/:.*//p')"
+if [ "$(scan_worktree_fill "$TWOBLOCK")" = "$TWOBLOCK:$SECOND_OPEN: $NOFILL" ]; then
+  pass "lint flags the second block of a doc whose first block alone carries the fill line"
+else
+  fail "lint MISSED a second block carrying a divergent fill instruction"
+fi
+
+# e.7 — and the same two blocks, each preceded by the canonical line, are
+# clean. Without this the reset at the closing tag could demand the sentence
+# somewhere a doc can never put it and e.6 would still pass.
+BOTHFILLED="$TMP_ROOT/probe-two-blocks-filled.md"
+printf '%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n\n%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' \
+  "$CANON_FILL" "$CHECK" "$CANON_FILL" "$CHECK" > "$BOTHFILLED"
+if [ -z "$(scan_worktree_fill "$BOTHFILLED")" ]; then
+  pass "lint accepts a doc whose every block carries the canonical fill line"
+else
+  fail "lint false-flagged a doc filling both its blocks canonically"
 fi
 
 echo

--- a/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Regression lint for KEN-878. A delegated agent's shell does not reliably
+# start in the worktree it was delegated: two lanes on 2026-08-30 each ran
+# bare-relative commands — `tools/guard` among them — against another lane's
+# worktree, and both noticed only after a confusing downstream failure.
+#
+# The cure is a precondition the agent runs before anything repo-relative:
+# every `Worktree: [PLACEHOLDER]` line inside a `<delegation_format>` block
+# is followed immediately by a `Worktree Check:` line naming that SAME
+# placeholder. `pwd` reports where the shell actually is, so the check can
+# fail; a line that merely restates the delegated path cannot.
+#
+# This lint is the answer to the recurrence, not to the eleven sites: a new
+# delegation block that carries `Worktree:` without its check fails here
+# rather than shipping the silent-wrong-tree hazard again.
+#
+# Scoped to `<delegation_format>` blocks in orch's workflows. A `Worktree:`
+# mention in prose or in a fenced example is not a delegation and is not
+# scanned.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILLS_ROOT="$(cd "$TEST_DIR/../.." && pwd)"
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+
+# scan_worktree_precondition <file>
+# Emits one "file:line: ..." line per defect. Inside a <delegation_format>
+# block, a `Worktree: [TOKEN]` line must be followed on the very next line by
+# a `Worktree Check:` line whose text contains `[TOKEN]` — the same
+# placeholder, so a filled delegation compares against its own path and not
+# another site's. Lines outside a delegation block are never scanned.
+scan_worktree_precondition() {
+  awk -v f="$1" '
+    /^[[:space:]]*<delegation_format>[[:space:]]*$/ { indel = 1; pending = 0; next }
+    /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ {
+      if (pending) printf "%s:%d: Worktree: [%s] ends the delegation with no Worktree Check line\n", f, pendline, token
+      indel = 0; pending = 0; next
+    }
+    indel {
+      if (pending) {
+        if ($0 !~ /^[[:space:]]*Worktree Check:/) {
+          printf "%s:%d: Worktree: [%s] is not followed by a Worktree Check line\n", f, pendline, token
+        } else if (index($0, "[" token "]") == 0) {
+          printf "%s:%d: Worktree Check names no [%s] to compare pwd against\n", f, NR, token
+        }
+        pending = 0
+      }
+      if (match($0, /^[[:space:]]*Worktree:[[:space:]]*\[[A-Za-z_][A-Za-z0-9_]*\][[:space:]]*$/)) {
+        line = $0
+        sub(/^[[:space:]]*Worktree:[[:space:]]*\[/, "", line)
+        sub(/\].*$/, "", line)
+        token = line; pendline = NR; pending = 1
+      }
+    }
+  ' "$1"
+}
+
+echo "=== orch delegation worktree-cwd-precondition lint ==="
+
+# --- Part a: every shipped delegation block carries the precondition -------
+DOCS="$(ls "$SKILLS_ROOT"/orch/workflows/*.md)"
+offenders=""
+sites=0
+for doc in $DOCS; do
+  out="$(scan_worktree_precondition "$doc")"
+  [ -n "$out" ] && offenders="$offenders$out"$'\n'
+  n="$(grep -c '^[[:space:]]*Worktree Check:' "$doc" || true)"
+  sites=$((sites + n))
+done
+if [ -z "$offenders" ]; then
+  pass "every delegated Worktree: line is followed by its Worktree Check"
+else
+  fail "delegation blocks missing the worktree cwd precondition:"
+  printf '%s' "$offenders" | sed 's/^/          /'
+fi
+
+# The precondition is worth nothing if no delegation carries it: a lint that
+# passes over zero sites is the vacuous case this asserts against.
+if [ "$sites" -gt 0 ]; then
+  pass "the scan read $sites delegated Worktree Check line(s)"
+else
+  fail "no Worktree Check lines found — the scan matched nothing to check"
+fi
+
+# --- Part b: the lint has teeth -------------------------------------------
+
+# probe <name> <body> → prints scratch-file path.
+# Writes a standalone delegation block containing <body> (printf %b, so \n
+# splits it into lines) under $TMP_ROOT, removed by the EXIT trap.
+probe() {
+  scratch="$TMP_ROOT/probe-$1.md"
+  printf '<delegation_format>\n%b\n</delegation_format>\n' "$2" > "$scratch"
+  printf '%s' "$scratch"
+}
+
+CHECK='Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH].'
+
+# b.1 — the reported shape (a bare Worktree: line, as all eleven sites read
+# before this change) IS flagged.
+if [ -n "$(scan_worktree_precondition "$(probe bare 'Issue: [ISSUE_ID]\nWorktree: [WORKTREE_PATH]\nRound ID: [DEV_ROUND_ID]')" )" ]; then
+  pass "lint flags a Worktree: line with no Worktree Check"
+else
+  fail "lint MISSED a bare Worktree: line (no teeth)"
+fi
+
+# b.2 — the fixed shape is NOT flagged.
+if [ -z "$(scan_worktree_precondition "$(probe fixed "Worktree: [WORKTREE_PATH]\n$CHECK")" )" ]; then
+  pass "lint accepts Worktree: followed by its Worktree Check"
+else
+  fail "lint false-flagged the fixed shape"
+fi
+
+# b.3 — a check naming a DIFFERENT placeholder IS flagged: a filled
+# delegation would compare pwd against a path this block never carries.
+if [ -n "$(scan_worktree_precondition "$(probe crossed 'Worktree: [WT_PATH]\nWorktree Check: `pwd` must print [WORKTREE_PATH].')" )" ]; then
+  pass "lint flags a Worktree Check naming the wrong placeholder"
+else
+  fail "lint MISSED a cross-wired placeholder"
+fi
+
+# b.4 — a Worktree: line ending the block with no check IS flagged.
+if [ -n "$(scan_worktree_precondition "$(probe last 'Branch: [BRANCH]\nWorktree: [WORKTREE_PATH]')" )" ]; then
+  pass "lint flags a Worktree: line that closes the delegation"
+else
+  fail "lint MISSED a trailing Worktree: line"
+fi
+
+# b.5 — a Worktree: mention outside a delegation block is NOT scanned.
+PROSE="$TMP_ROOT/probe-prose.md"
+printf 'Fill the delegation Worktree: [WORKTREE_PATH] from the claim output.\n' > "$PROSE"
+if [ -z "$(scan_worktree_precondition "$PROSE")" ]; then
+  pass "lint ignores a Worktree: mention outside a delegation block"
+else
+  fail "lint false-flagged a prose mention"
+fi
+
+# b.6 — an indented delegation block (dev-fix.md nests one in a numbered
+# step) is scanned, not skipped for its leading whitespace.
+if [ -n "$(scan_worktree_precondition "$(probe indented '   Worktree: [WORKTREE_PATH]\n   Round ID: [DEV_ROUND_ID]')" )" ]; then
+  pass "lint scans an indented delegation block"
+else
+  fail "lint MISSED a bare Worktree: line inside an indented block"
+fi
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.agents/skills/orch/workflows/ci-fix.md
+++ b/.agents/skills/orch/workflows/ci-fix.md
@@ -76,7 +76,7 @@ Error output:
 [truncated error logs]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
 Worktree Lease: [WORKTREE_LEASE]
 
 1. Verify possession before changing anything: `.agents/skills/orch/scripts/worktree-claim --worktree [WORKTREE_PATH] --issue [ISSUE_ID] --expect-gen [WORKTREE_LEASE]`. Any non-zero exit ends the round here — change nothing and report its stderr verbatim.
@@ -109,7 +109,7 @@ Merge queue CI failure — integration issue across stacked PRs.
 
 Draft PR: #[PR_NUMBER]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
 Stack: [PRs in the stack with their domains]
 
 Error output:

--- a/.agents/skills/orch/workflows/ci-fix.md
+++ b/.agents/skills/orch/workflows/ci-fix.md
@@ -37,7 +37,7 @@ Formatting, obvious lint, and a missing import are fixed directly; a test failur
 
 ### 3.1 Direct Fixes
 
-Resolve the worktree (`github.sh pr-issue [PR_NUMBER] --format=text`, then `worktree exists`/`worktree path`, creating with `--pr [PR_NUMBER]` when missing) as `[DIR]`; `WORKTREE_PATH` is `git-context repo-root [DIR]`. Apply the fix, then:
+Resolve the worktree (`github.sh pr-issue [PR_NUMBER] --format=text`, then `worktree exists`/`worktree path`, creating with `--pr [PR_NUMBER]` when missing) as `[DIR]`; `WORKTREE_PATH` is `git-context repo-root "[DIR]"`. Apply the fix, then:
 
 ```bash
 git -C "[WORKTREE_PATH]" commit -am "fix([ISSUE_ID]): Resolve CI failure ([ERROR_TYPE])"
@@ -64,7 +64,7 @@ Stamp the round as separate tool calls immediately before delegating, and arm th
 
 `worktree-claim` exit 75 aborts the delegation (another session holds this worktree; stderr names the holder); exit 1 stops the workflow and is reported. Its printed token is the delegation's `Worktree Lease:` line.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 This agent pushes its fix directly and writes **no** dev-return artifact; the round-mode check for this token reports `ok == false`, which is expected. Accept this round on the agent's return message plus the pushed fix commit; on an absent return follow the escalation ladder.
 

--- a/.agents/skills/orch/workflows/ci-fix.md
+++ b/.agents/skills/orch/workflows/ci-fix.md
@@ -37,7 +37,7 @@ Formatting, obvious lint, and a missing import are fixed directly; a test failur
 
 ### 3.1 Direct Fixes
 
-Resolve the worktree (`github.sh pr-issue [PR_NUMBER] --format=text`, then `worktree exists`/`worktree path`, creating with `--pr [PR_NUMBER]` when missing), apply the fix, then:
+Resolve the worktree (`github.sh pr-issue [PR_NUMBER] --format=text`, then `worktree exists`/`worktree path`, creating with `--pr [PR_NUMBER]` when missing) as `[DIR]`; `WORKTREE_PATH` is `git-context repo-root [DIR]`. Apply the fix, then:
 
 ```bash
 git -C "[WORKTREE_PATH]" commit -am "fix([ISSUE_ID]): Resolve CI failure ([ERROR_TYPE])"
@@ -63,6 +63,8 @@ Stamp the round as separate tool calls immediately before delegating, and arm th
 ```
 
 `worktree-claim` exit 75 aborts the delegation (another session holds this worktree; stderr names the holder); exit 1 stops the workflow and is reported. Its printed token is the delegation's `Worktree Lease:` line.
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 This agent pushes its fix directly and writes **no** dev-return artifact; the round-mode check for this token reports `ok == false`, which is expected. Accept this round on the agent's return message plus the pushed fix commit; on an absent return follow the escalation ladder.
 

--- a/.agents/skills/orch/workflows/ci-fix.md
+++ b/.agents/skills/orch/workflows/ci-fix.md
@@ -76,7 +76,7 @@ Error output:
 [truncated error logs]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
 Worktree Lease: [WORKTREE_LEASE]
 
 1. Verify possession before changing anything: `.agents/skills/orch/scripts/worktree-claim --worktree [WORKTREE_PATH] --issue [ISSUE_ID] --expect-gen [WORKTREE_LEASE]`. Any non-zero exit ends the round here — change nothing and report its stderr verbatim.
@@ -109,7 +109,7 @@ Merge queue CI failure — integration issue across stacked PRs.
 
 Draft PR: #[PR_NUMBER]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
 Stack: [PRs in the stack with their domains]
 
 Error output:

--- a/.agents/skills/orch/workflows/ci-fix.md
+++ b/.agents/skills/orch/workflows/ci-fix.md
@@ -104,7 +104,10 @@ gh pr view [DRAFT_PR] --json commits --jq '.commits[].oid'
 
 Cross-reference those commits with the original PRs to identify which file failed, which commit introduced it, and which PR that commit belongs to. A single identifiable PR routes to that PR's agent; a genuine cross-PR integration issue routes to the architecture reviewer for analysis; an unclear source goes to the user.
 
-For an integration issue, create a worktree from the draft branch (`worktree create [ISSUE_ID] "[DRAFT_BRANCH]" --pr [DRAFT_PR_NUMBER]`) and delegate analysis:
+For an integration issue, create a worktree from the draft branch (`worktree create [ISSUE_ID] "[DRAFT_BRANCH]" --pr [DRAFT_PR_NUMBER]`) and delegate analysis.
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the worktree just created from the draft branch.
 
 <delegation_format>
 Merge queue CI failure — integration issue across stacked PRs.

--- a/.agents/skills/orch/workflows/ci-fix.md
+++ b/.agents/skills/orch/workflows/ci-fix.md
@@ -76,6 +76,7 @@ Error output:
 [truncated error logs]
 
 Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
 Worktree Lease: [WORKTREE_LEASE]
 
 1. Verify possession before changing anything: `.agents/skills/orch/scripts/worktree-claim --worktree [WORKTREE_PATH] --issue [ISSUE_ID] --expect-gen [WORKTREE_LEASE]`. Any non-zero exit ends the round here — change nothing and report its stderr verbatim.
@@ -108,6 +109,7 @@ Merge queue CI failure — integration issue across stacked PRs.
 
 Draft PR: #[PR_NUMBER]
 Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
 Stack: [PRs in the stack with their domains]
 
 Error output:

--- a/.agents/skills/orch/workflows/ci-fix.md
+++ b/.agents/skills/orch/workflows/ci-fix.md
@@ -64,7 +64,7 @@ Stamp the round as separate tool calls immediately before delegating, and arm th
 
 `worktree-claim` exit 75 aborts the delegation (another session holds this worktree; stderr names the holder); exit 1 stops the workflow and is reported. Its printed token is the delegation's `Worktree Lease:` line.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 This agent pushes its fix directly and writes **no** dev-return artifact; the round-mode check for this token reports `ok == false`, which is expected. Accept this round on the agent's return message plus the pushed fix commit; on an absent return follow the escalation ladder.
 
@@ -106,7 +106,7 @@ Cross-reference those commits with the original PRs to identify which file faile
 
 For an integration issue, create a worktree from the draft branch (`worktree create [ISSUE_ID] "[DRAFT_BRANCH]" --pr [DRAFT_PR_NUMBER]`) and delegate analysis.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the worktree just created from the draft branch.
 
 <delegation_format>

--- a/.agents/skills/orch/workflows/ci-fix.md
+++ b/.agents/skills/orch/workflows/ci-fix.md
@@ -76,7 +76,7 @@ Error output:
 [truncated error logs]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Worktree Lease: [WORKTREE_LEASE]
 
 1. Verify possession before changing anything: `.agents/skills/orch/scripts/worktree-claim --worktree [WORKTREE_PATH] --issue [ISSUE_ID] --expect-gen [WORKTREE_LEASE]`. Any non-zero exit ends the round here — change nothing and report its stderr verbatim.
@@ -109,7 +109,7 @@ Merge queue CI failure — integration issue across stacked PRs.
 
 Draft PR: #[PR_NUMBER]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Stack: [PRs in the stack with their domains]
 
 Error output:

--- a/.agents/skills/orch/workflows/ci-fix.md
+++ b/.agents/skills/orch/workflows/ci-fix.md
@@ -76,7 +76,7 @@ Error output:
 [truncated error logs]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Worktree Lease: [WORKTREE_LEASE]
 
 1. Verify possession before changing anything: `.agents/skills/orch/scripts/worktree-claim --worktree [WORKTREE_PATH] --issue [ISSUE_ID] --expect-gen [WORKTREE_LEASE]`. Any non-zero exit ends the round here — change nothing and report its stderr verbatim.
@@ -109,7 +109,7 @@ Merge queue CI failure — integration issue across stacked PRs.
 
 Draft PR: #[PR_NUMBER]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Stack: [PRs in the stack with their domains]
 
 Error output:

--- a/.agents/skills/orch/workflows/dev-fix.md
+++ b/.agents/skills/orch/workflows/dev-fix.md
@@ -10,9 +10,9 @@ Delegate fix items to a specialist dev agent. Standalone (user-initiated) or man
 
 **Caller context** (via `⤵`): `worktree`; `lifecycle` — `"managed"` (return at § 3) or `"self"` (default); `dev_agent` — a live dev agent; `issue_id` — the workflow-state key, the normalized issue ID (`issue-N` for GitHub, `PROJ-123` for Linear), never the bare GitHub issue number; `items` — formatted review items; `source` — `pr-review` | `qa-review` | `review` | `local-review` (default `conversation`); `qa_agent`.
 
-**Standalone init** (`lifecycle: "self"`). Use the argument as `ISSUE_ID`, else `git-context issue-from-branch .`. Apply [Worktree Scope](../SKILL.md#workflow-execution) and resolve `WT_PATH` as `git-context repo-root [DIR]` (inside a worktree `[DIR]` is `.`; from the main repo, `worktree path [ISSUE_ID]`, asking before creating).
+**Standalone init** (`lifecycle: "self"`). Use the argument as `ISSUE_ID`, else `git-context issue-from-branch .`. Apply [Worktree Scope](../SKILL.md#workflow-execution) and resolve `WT_PATH` as `git-context repo-root "[DIR]"` (inside a worktree `[DIR]` is `.`; from the main repo, `worktree path [ISSUE_ID]`, asking before creating).
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 ## 1. Build Fix Items
 

--- a/.agents/skills/orch/workflows/dev-fix.md
+++ b/.agents/skills/orch/workflows/dev-fix.md
@@ -110,7 +110,7 @@ Cancel ends the workflow; a selection goes to § 2.
    Source: [SOURCE]
    Issue: [ISSUE_ID]
    Worktree: [WORKTREE_PATH]
-   Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+   Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
    Worktree Lease: [WORKTREE_LEASE]
    Round ID: [DEV_ROUND_ID]
    Artifact Key: [ISSUE_ID]

--- a/.agents/skills/orch/workflows/dev-fix.md
+++ b/.agents/skills/orch/workflows/dev-fix.md
@@ -110,6 +110,7 @@ Cancel ends the workflow; a selection goes to § 2.
    Source: [SOURCE]
    Issue: [ISSUE_ID]
    Worktree: [WORKTREE_PATH]
+   Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
    Worktree Lease: [WORKTREE_LEASE]
    Round ID: [DEV_ROUND_ID]
    Artifact Key: [ISSUE_ID]

--- a/.agents/skills/orch/workflows/dev-fix.md
+++ b/.agents/skills/orch/workflows/dev-fix.md
@@ -110,7 +110,7 @@ Cancel ends the workflow; a selection goes to § 2.
    Source: [SOURCE]
    Issue: [ISSUE_ID]
    Worktree: [WORKTREE_PATH]
-   Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
+   Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
    Worktree Lease: [WORKTREE_LEASE]
    Round ID: [DEV_ROUND_ID]
    Artifact Key: [ISSUE_ID]

--- a/.agents/skills/orch/workflows/dev-fix.md
+++ b/.agents/skills/orch/workflows/dev-fix.md
@@ -12,7 +12,7 @@ Delegate fix items to a specialist dev agent. Standalone (user-initiated) or man
 
 **Standalone init** (`lifecycle: "self"`). Use the argument as `ISSUE_ID`, else `git-context issue-from-branch .`. Apply [Worktree Scope](../SKILL.md#workflow-execution) and resolve `WT_PATH` as `git-context repo-root "[DIR]"` (inside a worktree `[DIR]` is `.`; from the main repo, `worktree path [ISSUE_ID]`, asking before creating).
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 ## 1. Build Fix Items
 

--- a/.agents/skills/orch/workflows/dev-fix.md
+++ b/.agents/skills/orch/workflows/dev-fix.md
@@ -10,7 +10,9 @@ Delegate fix items to a specialist dev agent. Standalone (user-initiated) or man
 
 **Caller context** (via `⤵`): `worktree`; `lifecycle` — `"managed"` (return at § 3) or `"self"` (default); `dev_agent` — a live dev agent; `issue_id` — the workflow-state key, the normalized issue ID (`issue-N` for GitHub, `PROJ-123` for Linear), never the bare GitHub issue number; `items` — formatted review items; `source` — `pr-review` | `qa-review` | `review` | `local-review` (default `conversation`); `qa_agent`.
 
-**Standalone init** (`lifecycle: "self"`). Use the argument as `ISSUE_ID`, else `git-context issue-from-branch .`. Apply [Worktree Scope](../SKILL.md#workflow-execution) and resolve `WT_PATH` (inside a worktree, the current directory; from the main repo, `worktree path [ISSUE_ID]`, asking before creating).
+**Standalone init** (`lifecycle: "self"`). Use the argument as `ISSUE_ID`, else `git-context issue-from-branch .`. Apply [Worktree Scope](../SKILL.md#workflow-execution) and resolve `WT_PATH` as `git-context repo-root [DIR]` (inside a worktree `[DIR]` is `.`; from the main repo, `worktree path [ISSUE_ID]`, asking before creating).
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 ## 1. Build Fix Items
 

--- a/.agents/skills/orch/workflows/dev-fix.md
+++ b/.agents/skills/orch/workflows/dev-fix.md
@@ -110,7 +110,7 @@ Cancel ends the workflow; a selection goes to § 2.
    Source: [SOURCE]
    Issue: [ISSUE_ID]
    Worktree: [WORKTREE_PATH]
-   Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
+   Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
    Worktree Lease: [WORKTREE_LEASE]
    Round ID: [DEV_ROUND_ID]
    Artifact Key: [ISSUE_ID]

--- a/.agents/skills/orch/workflows/dev-fix.md
+++ b/.agents/skills/orch/workflows/dev-fix.md
@@ -110,7 +110,7 @@ Cancel ends the workflow; a selection goes to § 2.
    Source: [SOURCE]
    Issue: [ISSUE_ID]
    Worktree: [WORKTREE_PATH]
-   Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+   Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
    Worktree Lease: [WORKTREE_LEASE]
    Round ID: [DEV_ROUND_ID]
    Artifact Key: [ISSUE_ID]

--- a/.agents/skills/orch/workflows/dev-start.md
+++ b/.agents/skills/orch/workflows/dev-start.md
@@ -103,6 +103,8 @@ Group pending sub-issues by `agent:[TYPE]` label and order them per [SKILL.md §
 
 Between groups, read each completed sub-issue's comments for a `Handoff Notes` section and combine them into the next delegation. Re-run all four § 2 stamps immediately before each group's delegation.
 
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+
 <delegation_format>
 Follow workflow: .agents/skills/dev/workflows/dev-implement.md
 

--- a/.agents/skills/orch/workflows/dev-start.md
+++ b/.agents/skills/orch/workflows/dev-start.md
@@ -86,7 +86,7 @@ Follow workflow: .agents/skills/dev/workflows/dev-implement.md
 
 Issue: [ISSUE_ID]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]
@@ -111,7 +111,7 @@ Sub-Issues:
 ↳ [SUB_ISSUE_3]: [TITLE] | blocked by: [SUB_ISSUE_2]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]

--- a/.agents/skills/orch/workflows/dev-start.md
+++ b/.agents/skills/orch/workflows/dev-start.md
@@ -86,7 +86,7 @@ Follow workflow: .agents/skills/dev/workflows/dev-implement.md
 
 Issue: [ISSUE_ID]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]
@@ -111,7 +111,7 @@ Sub-Issues:
 ↳ [SUB_ISSUE_3]: [TITLE] | blocked by: [SUB_ISSUE_2]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]

--- a/.agents/skills/orch/workflows/dev-start.md
+++ b/.agents/skills/orch/workflows/dev-start.md
@@ -86,7 +86,7 @@ Follow workflow: .agents/skills/dev/workflows/dev-implement.md
 
 Issue: [ISSUE_ID]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]
@@ -111,7 +111,7 @@ Sub-Issues:
 ↳ [SUB_ISSUE_3]: [TITLE] | blocked by: [SUB_ISSUE_2]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]

--- a/.agents/skills/orch/workflows/dev-start.md
+++ b/.agents/skills/orch/workflows/dev-start.md
@@ -86,6 +86,7 @@ Follow workflow: .agents/skills/dev/workflows/dev-implement.md
 
 Issue: [ISSUE_ID]
 Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]
@@ -110,6 +111,7 @@ Sub-Issues:
 ↳ [SUB_ISSUE_3]: [TITLE] | blocked by: [SUB_ISSUE_2]
 
 Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]

--- a/.agents/skills/orch/workflows/dev-start.md
+++ b/.agents/skills/orch/workflows/dev-start.md
@@ -86,7 +86,7 @@ Follow workflow: .agents/skills/dev/workflows/dev-implement.md
 
 Issue: [ISSUE_ID]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]
@@ -111,7 +111,7 @@ Sub-Issues:
 ↳ [SUB_ISSUE_3]: [TITLE] | blocked by: [SUB_ISSUE_2]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]

--- a/.agents/skills/orch/workflows/dev-start.md
+++ b/.agents/skills/orch/workflows/dev-start.md
@@ -27,7 +27,9 @@ Resolve `TRACKER` first — `github` skips the Linear-only container preflight.
 
 Apply the Ancestor gate ([SKILL.md § Coordination](../SKILL.md#coordination)). A container is refused before anything is initialized, with its unblocked children surfaced as the startable items. A `(one PR)` ancestor promotion is TERMINAL for this invocation: stop and route to `/orch start [PARENT_ID]` rather than continuing with the child's id. A blocked child stops with its live blockers named. Caller context `audit_bundle: true` is equivalent to the `(one PR)` marker: skip the refusal for that parent and carry `Audit Bundle: yes` in the delegation. Managed callers already ran this gate.
 
-Apply [Worktree Scope](../SKILL.md#workflow-execution) and resolve `WT_PATH`: inside a worktree use the current directory; from the main repo use `worktree path [ISSUE_ID]` when it exists, and ask the user before creating one when it does not.
+Apply [Worktree Scope](../SKILL.md#workflow-execution) and resolve `WT_PATH` as `git-context repo-root [DIR]`. Inside a worktree `[DIR]` is `.`; from the main repo it is `worktree path [ISSUE_ID]` when that exists, and ask the user before creating one when it does not.
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 Initialize state unless it exists:
 

--- a/.agents/skills/orch/workflows/dev-start.md
+++ b/.agents/skills/orch/workflows/dev-start.md
@@ -29,7 +29,7 @@ Apply the Ancestor gate ([SKILL.md § Coordination](../SKILL.md#coordination)). 
 
 Apply [Worktree Scope](../SKILL.md#workflow-execution) and resolve `WT_PATH` as `git-context repo-root "[DIR]"`. Inside a worktree `[DIR]` is `.`; from the main repo it is `worktree path [ISSUE_ID]` when that exists, and ask the user before creating one when it does not.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 Initialize state unless it exists:
 
@@ -103,7 +103,7 @@ Group pending sub-issues by `agent:[TYPE]` label and order them per [SKILL.md §
 
 Between groups, read each completed sub-issue's comments for a `Handoff Notes` section and combine them into the next delegation. Re-run all four § 2 stamps immediately before each group's delegation.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 <delegation_format>
 Follow workflow: .agents/skills/dev/workflows/dev-implement.md

--- a/.agents/skills/orch/workflows/dev-start.md
+++ b/.agents/skills/orch/workflows/dev-start.md
@@ -27,9 +27,9 @@ Resolve `TRACKER` first — `github` skips the Linear-only container preflight.
 
 Apply the Ancestor gate ([SKILL.md § Coordination](../SKILL.md#coordination)). A container is refused before anything is initialized, with its unblocked children surfaced as the startable items. A `(one PR)` ancestor promotion is TERMINAL for this invocation: stop and route to `/orch start [PARENT_ID]` rather than continuing with the child's id. A blocked child stops with its live blockers named. Caller context `audit_bundle: true` is equivalent to the `(one PR)` marker: skip the refusal for that parent and carry `Audit Bundle: yes` in the delegation. Managed callers already ran this gate.
 
-Apply [Worktree Scope](../SKILL.md#workflow-execution) and resolve `WT_PATH` as `git-context repo-root [DIR]`. Inside a worktree `[DIR]` is `.`; from the main repo it is `worktree path [ISSUE_ID]` when that exists, and ask the user before creating one when it does not.
+Apply [Worktree Scope](../SKILL.md#workflow-execution) and resolve `WT_PATH` as `git-context repo-root "[DIR]"`. Inside a worktree `[DIR]` is `.`; from the main repo it is `worktree path [ISSUE_ID]` when that exists, and ask the user before creating one when it does not.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 Initialize state unless it exists:
 

--- a/.agents/skills/orch/workflows/post-summary.md
+++ b/.agents/skills/orch/workflows/post-summary.md
@@ -10,7 +10,7 @@ Post the session summary to the git host and issue tracker, plus selective hando
 
 **Caller context** (via `⤵`): `worktree`; `lifecycle` — `"managed"` (return at § 3) or `"self"` (default); `issue_id` — the workflow-state key, the normalized issue ID, never the bare GitHub issue number; `pr_number`. Every lifecycle path resolves `TRACKER` and `ISSUE_REF` from `issue_id` per [Tracker Resolution](../SKILL.md#tracker-resolution), and `SUB_ISSUE_REF` the same way from each completed sub-issue's own id, before rendering the summary.
 
-**Standalone init** (`lifecycle: "self"`): `git-context issue-from-branch .` gives `ISSUE_ID`; resolve `TRACKER` per [Tracker Resolution](../SKILL.md#tracker-resolution); `WT_PATH` is `git-context repo-root [DIR]`, `[DIR]` being `.` unless `worktree exists`/`worktree path` says otherwise; `pr-view-json [WT_PATH] --json number` gives `PR_NUMBER`. When `workflow-state exists --json [ISSUE_ID]` reports false, initialize with `git-context branch [WT_PATH]` and `workflow-state init`.
+**Standalone init** (`lifecycle: "self"`): `git-context issue-from-branch .` gives `ISSUE_ID`; resolve `TRACKER` per [Tracker Resolution](../SKILL.md#tracker-resolution); `WT_PATH` is `git-context repo-root "[DIR]"`, `[DIR]` being `.` unless `worktree exists`/`worktree path` says otherwise; `pr-view-json [WT_PATH] --json number` gives `PR_NUMBER`. When `workflow-state exists --json [ISSUE_ID]` reports false, initialize with `git-context branch [WT_PATH]` and `workflow-state init`.
 
 ## 1. Post The Summary
 

--- a/.agents/skills/orch/workflows/post-summary.md
+++ b/.agents/skills/orch/workflows/post-summary.md
@@ -10,7 +10,7 @@ Post the session summary to the git host and issue tracker, plus selective hando
 
 **Caller context** (via `⤵`): `worktree`; `lifecycle` — `"managed"` (return at § 3) or `"self"` (default); `issue_id` — the workflow-state key, the normalized issue ID, never the bare GitHub issue number; `pr_number`. Every lifecycle path resolves `TRACKER` and `ISSUE_REF` from `issue_id` per [Tracker Resolution](../SKILL.md#tracker-resolution), and `SUB_ISSUE_REF` the same way from each completed sub-issue's own id, before rendering the summary.
 
-**Standalone init** (`lifecycle: "self"`): `git-context issue-from-branch .` gives `ISSUE_ID`; resolve `TRACKER` per [Tracker Resolution](../SKILL.md#tracker-resolution); `WT_PATH` is the current directory unless `worktree exists`/`worktree path` says otherwise; `pr-view-json [WT_PATH] --json number` gives `PR_NUMBER`. When `workflow-state exists --json [ISSUE_ID]` reports false, initialize with `git-context branch [WT_PATH]` and `workflow-state init`.
+**Standalone init** (`lifecycle: "self"`): `git-context issue-from-branch .` gives `ISSUE_ID`; resolve `TRACKER` per [Tracker Resolution](../SKILL.md#tracker-resolution); `WT_PATH` is `git-context repo-root [DIR]`, `[DIR]` being `.` unless `worktree exists`/`worktree path` says otherwise; `pr-view-json [WT_PATH] --json number` gives `PR_NUMBER`. When `workflow-state exists --json [ISSUE_ID]` reports false, initialize with `git-context branch [WT_PATH]` and `workflow-state init`.
 
 ## 1. Post The Summary
 

--- a/.agents/skills/orch/workflows/review-codebase.md
+++ b/.agents/skills/orch/workflows/review-codebase.md
@@ -15,6 +15,8 @@ Ad-hoc whole-codebase reviewer fanout. No PR, no issue, no diff, no fix delegati
 
 Not a git worktree → report `review-codebase requires a git worktree` and **END**. Otherwise use the output as `WT_PATH` and `mkdir -p "$WT_PATH/tmp"`.
 
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+
 ## 2. Delegate
 
 `[AGENTS]` is every `reviewer-*` agent this harness exposes; use the full list and do not path-filter. None available → report `No reviewer agents installed; cannot run codebase review` and **END**.

--- a/.agents/skills/orch/workflows/review-codebase.md
+++ b/.agents/skills/orch/workflows/review-codebase.md
@@ -15,7 +15,7 @@ Ad-hoc whole-codebase reviewer fanout. No PR, no issue, no diff, no fix delegati
 
 Not a git worktree → report `review-codebase requires a git worktree` and **END**. Otherwise use the output as `WT_PATH` and `mkdir -p "$WT_PATH/tmp"`.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 ## 2. Delegate
 

--- a/.agents/skills/orch/workflows/review-codebase.md
+++ b/.agents/skills/orch/workflows/review-codebase.md
@@ -31,6 +31,7 @@ Resolve the reviewer mode per [SKILL.md § Agent Lifecycle](../SKILL.md#agent-li
 Follow workflow: .agents/skills/reviewer/workflows/codebase-review.md
 
 Worktree: [WT_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WT_PATH]`, re-run `pwd`, and report where it started.
 Scope: Whole codebase. Inspect tracked, non-generated project code, plus the tests, configs, and docs relevant to your review domain. Do not sample or restrict to changed files. No PR, no issue, no diff.
 Exclusions: generated artifacts, dependency and vendor directories, build outputs, binary assets, harness mirrors, and lockfiles unless your domain specifically requires them.
 </delegation_format>

--- a/.agents/skills/orch/workflows/review-codebase.md
+++ b/.agents/skills/orch/workflows/review-codebase.md
@@ -31,7 +31,7 @@ Resolve the reviewer mode per [SKILL.md § Agent Lifecycle](../SKILL.md#agent-li
 Follow workflow: .agents/skills/reviewer/workflows/codebase-review.md
 
 Worktree: [WT_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WT_PATH]`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WT_PATH]"`, re-run `pwd`, and report where it started.
 Scope: Whole codebase. Inspect tracked, non-generated project code, plus the tests, configs, and docs relevant to your review domain. Do not sample or restrict to changed files. No PR, no issue, no diff.
 Exclusions: generated artifacts, dependency and vendor directories, build outputs, binary assets, harness mirrors, and lockfiles unless your domain specifically requires them.
 </delegation_format>

--- a/.agents/skills/orch/workflows/review-codebase.md
+++ b/.agents/skills/orch/workflows/review-codebase.md
@@ -31,7 +31,7 @@ Resolve the reviewer mode per [SKILL.md § Agent Lifecycle](../SKILL.md#agent-li
 Follow workflow: .agents/skills/reviewer/workflows/codebase-review.md
 
 Worktree: [WT_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Scope: Whole codebase. Inspect tracked, non-generated project code, plus the tests, configs, and docs relevant to your review domain. Do not sample or restrict to changed files. No PR, no issue, no diff.
 Exclusions: generated artifacts, dependency and vendor directories, build outputs, binary assets, harness mirrors, and lockfiles unless your domain specifically requires them.
 </delegation_format>

--- a/.agents/skills/orch/workflows/review-codebase.md
+++ b/.agents/skills/orch/workflows/review-codebase.md
@@ -31,7 +31,7 @@ Resolve the reviewer mode per [SKILL.md § Agent Lifecycle](../SKILL.md#agent-li
 Follow workflow: .agents/skills/reviewer/workflows/codebase-review.md
 
 Worktree: [WT_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WT_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Scope: Whole codebase. Inspect tracked, non-generated project code, plus the tests, configs, and docs relevant to your review domain. Do not sample or restrict to changed files. No PR, no issue, no diff.
 Exclusions: generated artifacts, dependency and vendor directories, build outputs, binary assets, harness mirrors, and lockfiles unless your domain specifically requires them.
 </delegation_format>

--- a/.agents/skills/orch/workflows/review-codebase.md
+++ b/.agents/skills/orch/workflows/review-codebase.md
@@ -15,7 +15,7 @@ Ad-hoc whole-codebase reviewer fanout. No PR, no issue, no diff, no fix delegati
 
 Not a git worktree → report `review-codebase requires a git worktree` and **END**. Otherwise use the output as `WT_PATH` and `mkdir -p "$WT_PATH/tmp"`.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 ## 2. Delegate
 

--- a/.agents/skills/orch/workflows/review-codebase.md
+++ b/.agents/skills/orch/workflows/review-codebase.md
@@ -31,7 +31,7 @@ Resolve the reviewer mode per [SKILL.md § Agent Lifecycle](../SKILL.md#agent-li
 Follow workflow: .agents/skills/reviewer/workflows/codebase-review.md
 
 Worktree: [WT_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WT_PATH]"`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WT_PATH], because a bare `cd` may not survive into the next tool call.
 Scope: Whole codebase. Inspect tracked, non-generated project code, plus the tests, configs, and docs relevant to your review domain. Do not sample or restrict to changed files. No PR, no issue, no diff.
 Exclusions: generated artifacts, dependency and vendor directories, build outputs, binary assets, harness mirrors, and lockfiles unless your domain specifically requires them.
 </delegation_format>

--- a/.agents/skills/orch/workflows/review-codebase.md
+++ b/.agents/skills/orch/workflows/review-codebase.md
@@ -16,6 +16,7 @@ Ad-hoc whole-codebase reviewer fanout. No PR, no issue, no diff, no fix delegati
 Not a git worktree → report `review-codebase requires a git worktree` and **END**. Otherwise use the output as `WT_PATH` and `mkdir -p "$WT_PATH/tmp"`.
 
 Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the `[PATH_OR_PWD]` § 1 resolves `WT_PATH` from.
 
 ## 2. Delegate
 

--- a/.agents/skills/orch/workflows/review-pr-comments.md
+++ b/.agents/skills/orch/workflows/review-pr-comments.md
@@ -72,7 +72,7 @@ Analyze these PR review comments for your domain.
 PR: #[PR_NUMBER] - [TITLE]
 Parent Issue: [ISSUE_ID]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
 
 Decision context (read before classifying — do NOT suggest changes that contradict these):
 [For each verified decision: "[DECISION_ID]: [ONE_LINE_SUMMARY] — [DECISION_FILE_PATH]"]
@@ -238,7 +238,7 @@ Source: pr-comments
 Issue: [ISSUE_ID]
 PR: #[PR_NUMBER]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]

--- a/.agents/skills/orch/workflows/review-pr-comments.md
+++ b/.agents/skills/orch/workflows/review-pr-comments.md
@@ -72,7 +72,7 @@ Analyze these PR review comments for your domain.
 PR: #[PR_NUMBER] - [TITLE]
 Parent Issue: [ISSUE_ID]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 
 Decision context (read before classifying — do NOT suggest changes that contradict these):
 [For each verified decision: "[DECISION_ID]: [ONE_LINE_SUMMARY] — [DECISION_FILE_PATH]"]
@@ -238,7 +238,7 @@ Source: pr-comments
 Issue: [ISSUE_ID]
 PR: #[PR_NUMBER]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]

--- a/.agents/skills/orch/workflows/review-pr-comments.md
+++ b/.agents/skills/orch/workflows/review-pr-comments.md
@@ -44,7 +44,11 @@ gh api user -q .login
 
 **Extract** per item: `thread_id`/`comment_id`, `author`, `body`, `path`, `line`, `url`, and `source` (`inline` or `pr-level`). Bot review summaries additionally get a `section` and a keyword-derived source type — architectural, documentation, security, testing, performance, or plain suggestion — plus `blocking: true` for security items and `false` when the text says non-blocking or optional. Skip anything the bot labels an inline comment: those are already captured as review threads, with the bot username as `author`. Never filter bot inline threads out.
 
-**Issue context.** `issue_id` from the caller, else `git-context issue-from-branch .`; ask the user if nothing matches. Resolve `WT_PATH` from `worktree exists`/`worktree path`, falling back to `.`. Then gather decisions:
+**Issue context.** `issue_id` from the caller, else `git-context issue-from-branch .`; ask the user if nothing matches. Resolve `WT_PATH` as `git-context repo-root [DIR]`, `[DIR]` being `worktree exists`/`worktree path` when they match and `.` otherwise.
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+
+Then gather decisions:
 
 ```bash
 .agents/skills/decider/scripts/decisions search --issue [ISSUE_ID]

--- a/.agents/skills/orch/workflows/review-pr-comments.md
+++ b/.agents/skills/orch/workflows/review-pr-comments.md
@@ -72,7 +72,7 @@ Analyze these PR review comments for your domain.
 PR: #[PR_NUMBER] - [TITLE]
 Parent Issue: [ISSUE_ID]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 
 Decision context (read before classifying — do NOT suggest changes that contradict these):
 [For each verified decision: "[DECISION_ID]: [ONE_LINE_SUMMARY] — [DECISION_FILE_PATH]"]
@@ -238,7 +238,7 @@ Source: pr-comments
 Issue: [ISSUE_ID]
 PR: #[PR_NUMBER]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]

--- a/.agents/skills/orch/workflows/review-pr-comments.md
+++ b/.agents/skills/orch/workflows/review-pr-comments.md
@@ -72,7 +72,7 @@ Analyze these PR review comments for your domain.
 PR: #[PR_NUMBER] - [TITLE]
 Parent Issue: [ISSUE_ID]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
 
 Decision context (read before classifying — do NOT suggest changes that contradict these):
 [For each verified decision: "[DECISION_ID]: [ONE_LINE_SUMMARY] — [DECISION_FILE_PATH]"]
@@ -238,7 +238,7 @@ Source: pr-comments
 Issue: [ISSUE_ID]
 PR: #[PR_NUMBER]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]

--- a/.agents/skills/orch/workflows/review-pr-comments.md
+++ b/.agents/skills/orch/workflows/review-pr-comments.md
@@ -44,9 +44,9 @@ gh api user -q .login
 
 **Extract** per item: `thread_id`/`comment_id`, `author`, `body`, `path`, `line`, `url`, and `source` (`inline` or `pr-level`). Bot review summaries additionally get a `section` and a keyword-derived source type — architectural, documentation, security, testing, performance, or plain suggestion — plus `blocking: true` for security items and `false` when the text says non-blocking or optional. Skip anything the bot labels an inline comment: those are already captured as review threads, with the bot username as `author`. Never filter bot inline threads out.
 
-**Issue context.** `issue_id` from the caller, else `git-context issue-from-branch .`; ask the user if nothing matches. Resolve `WT_PATH` as `git-context repo-root [DIR]`, `[DIR]` being `worktree exists`/`worktree path` when they match and `.` otherwise.
+**Issue context.** `issue_id` from the caller, else `git-context issue-from-branch .`; ask the user if nothing matches. Resolve `WT_PATH` as `git-context repo-root "[DIR]"`, `[DIR]` being `worktree exists`/`worktree path` when they match and `.` otherwise.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 Then gather decisions:
 

--- a/.agents/skills/orch/workflows/review-pr-comments.md
+++ b/.agents/skills/orch/workflows/review-pr-comments.md
@@ -235,6 +235,8 @@ When the list is non-empty, write `[WORKTREE_PATH]/tmp/dev-round-adds-[DEV_ROUND
 
 ⚠ Fill placeholders only ([Format Tags Are Literal](../SKILL.md#format-tags-are-literal)). `Recommendation:` is the technical fix; the agent owns its own process.
 
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+
 <delegation_format>
 Follow workflow: .agents/skills/dev/workflows/dev-fix.md
 

--- a/.agents/skills/orch/workflows/review-pr-comments.md
+++ b/.agents/skills/orch/workflows/review-pr-comments.md
@@ -72,6 +72,7 @@ Analyze these PR review comments for your domain.
 PR: #[PR_NUMBER] - [TITLE]
 Parent Issue: [ISSUE_ID]
 Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
 
 Decision context (read before classifying — do NOT suggest changes that contradict these):
 [For each verified decision: "[DECISION_ID]: [ONE_LINE_SUMMARY] — [DECISION_FILE_PATH]"]
@@ -237,6 +238,7 @@ Source: pr-comments
 Issue: [ISSUE_ID]
 PR: #[PR_NUMBER]
 Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]

--- a/.agents/skills/orch/workflows/review-pr-comments.md
+++ b/.agents/skills/orch/workflows/review-pr-comments.md
@@ -46,7 +46,7 @@ gh api user -q .login
 
 **Issue context.** `issue_id` from the caller, else `git-context issue-from-branch .`; ask the user if nothing matches. Resolve `WT_PATH` as `git-context repo-root "[DIR]"`, `[DIR]` being `worktree exists`/`worktree path` when they match and `.` otherwise.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 Then gather decisions:
 
@@ -235,7 +235,7 @@ When the list is non-empty, write `[WORKTREE_PATH]/tmp/dev-round-adds-[DEV_ROUND
 
 ⚠ Fill placeholders only ([Format Tags Are Literal](../SKILL.md#format-tags-are-literal)). `Recommendation:` is the technical fix; the agent owns its own process.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 <delegation_format>
 Follow workflow: .agents/skills/dev/workflows/dev-fix.md

--- a/.agents/skills/orch/workflows/review-pr.md
+++ b/.agents/skills/orch/workflows/review-pr.md
@@ -130,7 +130,7 @@ Delegate to every reviewer in the active set in parallel. When `EXTERNAL_REVIEW_
 Follow workflow: .agents/skills/reviewer/workflows/review.md
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
 Branch: [BRANCH]
 Artifact: [ARTIFACT_PATH]
 
@@ -370,7 +370,7 @@ Issue: [ISSUE_ID]
 Tracker: [TRACKER] [OWNER/REPO]
 Branch: [BRANCH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
 Trigger: [QA signal]
 
 Dev summary:

--- a/.agents/skills/orch/workflows/review-pr.md
+++ b/.agents/skills/orch/workflows/review-pr.md
@@ -12,7 +12,7 @@ Pre-submission review: reviewer fan-out, bounded fix rounds, QA checks, and the 
 
 **With a PR number**: `github.sh pr-issue [PR_NUMBER] --format=text` gives `ISSUE`. Apply [Worktree Scope](../SKILL.md#workflow-execution); ask before `worktree create $ISSUE --pr [PR_NUMBER]`. With no argument, `WT_PATH` is `git-context repo-root .`.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 **Standalone init** (`lifecycle: "self"`): resolve `ISSUE_ID` with `git-context issue-from-branch .`, then `workflow-state exists --json [ISSUE_ID]`; when absent, initialize with `git-context branch [WT_PATH]` and `workflow-state init`, and resolve `TRACKER`. On this path § 5 derives its QA signals from the diff scan and judgment — there is no dev artifact.
 

--- a/.agents/skills/orch/workflows/review-pr.md
+++ b/.agents/skills/orch/workflows/review-pr.md
@@ -12,7 +12,7 @@ Pre-submission review: reviewer fan-out, bounded fix rounds, QA checks, and the 
 
 **With a PR number**: `github.sh pr-issue [PR_NUMBER] --format=text` gives `ISSUE`. Apply [Worktree Scope](../SKILL.md#workflow-execution); ask before `worktree create $ISSUE --pr [PR_NUMBER]`. With no argument, `WT_PATH` is `git-context repo-root .`.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 **Standalone init** (`lifecycle: "self"`): resolve `ISSUE_ID` with `git-context issue-from-branch .`, then `workflow-state exists --json [ISSUE_ID]`; when absent, initialize with `git-context branch [WT_PATH]` and `workflow-state init`, and resolve `TRACKER`. On this path § 5 derives its QA signals from the diff scan and judgment — there is no dev artifact.
 
@@ -365,7 +365,7 @@ Drop a signal when the triggering code is trivial or test-only; never drop one f
 
 Map each signal to its agent — `needs-safety-audit` → `reviewer-safety`, `needs-perf-test` → `reviewer-perf`, `needs-review` → `reviewer-correctness`; a project may override the mapping in its instructions. For each, delegate and wait.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 <delegation_format>
 Follow workflow: .agents/skills/reviewer/workflows/qa-review.md

--- a/.agents/skills/orch/workflows/review-pr.md
+++ b/.agents/skills/orch/workflows/review-pr.md
@@ -130,7 +130,7 @@ Delegate to every reviewer in the active set in parallel. When `EXTERNAL_REVIEW_
 Follow workflow: .agents/skills/reviewer/workflows/review.md
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Branch: [BRANCH]
 Artifact: [ARTIFACT_PATH]
 
@@ -370,7 +370,7 @@ Issue: [ISSUE_ID]
 Tracker: [TRACKER] [OWNER/REPO]
 Branch: [BRANCH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Trigger: [QA signal]
 
 Dev summary:

--- a/.agents/skills/orch/workflows/review-pr.md
+++ b/.agents/skills/orch/workflows/review-pr.md
@@ -10,7 +10,9 @@ Pre-submission review: reviewer fan-out, bounded fix rounds, QA checks, and the 
 
 **Caller context** (via `⤵`): `worktree`; `agents` — an explicit reviewer panel, default every `reviewer-*` agent the harness exposes; `lifecycle` — `"managed"` (return at § 9) or `"self"` (default); `dev_agent` — a live dev agent for fix delegation; `issue_id` — the workflow-state key, the normalized issue ID, never the bare GitHub issue number.
 
-**With a PR number**: `github.sh pr-issue [PR_NUMBER] --format=text` gives `ISSUE`. Apply [Worktree Scope](../SKILL.md#workflow-execution); ask before `worktree create $ISSUE --pr [PR_NUMBER]`. With no argument, `WT_PATH` is the current directory.
+**With a PR number**: `github.sh pr-issue [PR_NUMBER] --format=text` gives `ISSUE`. Apply [Worktree Scope](../SKILL.md#workflow-execution); ask before `worktree create $ISSUE --pr [PR_NUMBER]`. With no argument, `WT_PATH` is `git-context repo-root .`.
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 **Standalone init** (`lifecycle: "self"`): resolve `ISSUE_ID` with `git-context issue-from-branch .`, then `workflow-state exists --json [ISSUE_ID]`; when absent, initialize with `git-context branch [WT_PATH]` and `workflow-state init`, and resolve `TRACKER`. On this path § 5 derives its QA signals from the diff scan and judgment — there is no dev artifact.
 

--- a/.agents/skills/orch/workflows/review-pr.md
+++ b/.agents/skills/orch/workflows/review-pr.md
@@ -130,7 +130,7 @@ Delegate to every reviewer in the active set in parallel. When `EXTERNAL_REVIEW_
 Follow workflow: .agents/skills/reviewer/workflows/review.md
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
 Branch: [BRANCH]
 Artifact: [ARTIFACT_PATH]
 
@@ -370,7 +370,7 @@ Issue: [ISSUE_ID]
 Tracker: [TRACKER] [OWNER/REPO]
 Branch: [BRANCH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
 Trigger: [QA signal]
 
 Dev summary:

--- a/.agents/skills/orch/workflows/review-pr.md
+++ b/.agents/skills/orch/workflows/review-pr.md
@@ -130,7 +130,7 @@ Delegate to every reviewer in the active set in parallel. When `EXTERNAL_REVIEW_
 Follow workflow: .agents/skills/reviewer/workflows/review.md
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Branch: [BRANCH]
 Artifact: [ARTIFACT_PATH]
 
@@ -370,7 +370,7 @@ Issue: [ISSUE_ID]
 Tracker: [TRACKER] [OWNER/REPO]
 Branch: [BRANCH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Trigger: [QA signal]
 
 Dev summary:

--- a/.agents/skills/orch/workflows/review-pr.md
+++ b/.agents/skills/orch/workflows/review-pr.md
@@ -363,7 +363,9 @@ Drop a signal when the triggering code is trivial or test-only; never drop one f
 
 **Skip if** the recorded `qa_decision.signals` is empty → § 7, which finds no QA artifacts, converges, and routes on: the exit is decided in one place even when QA never ran.
 
-Map each signal to its agent — `needs-safety-audit` → `reviewer-safety`, `needs-perf-test` → `reviewer-perf`, `needs-review` → `reviewer-correctness`; a project may override the mapping in its instructions. For each, delegate and wait:
+Map each signal to its agent — `needs-safety-audit` → `reviewer-safety`, `needs-perf-test` → `reviewer-perf`, `needs-review` → `reviewer-correctness`; a project may override the mapping in its instructions. For each, delegate and wait.
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 <delegation_format>
 Follow workflow: .agents/skills/reviewer/workflows/qa-review.md

--- a/.agents/skills/orch/workflows/review-pr.md
+++ b/.agents/skills/orch/workflows/review-pr.md
@@ -13,6 +13,7 @@ Pre-submission review: reviewer fan-out, bounded fix rounds, QA checks, and the 
 **With a PR number**: `github.sh pr-issue [PR_NUMBER] --format=text` gives `ISSUE`. Apply [Worktree Scope](../SKILL.md#workflow-execution); ask before `worktree create $ISSUE --pr [PR_NUMBER]`. With no argument, `WT_PATH` is `git-context repo-root .`.
 
 Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the checkout the paragraph above resolves `WT_PATH` from.
 
 **Standalone init** (`lifecycle: "self"`): resolve `ISSUE_ID` with `git-context issue-from-branch .`, then `workflow-state exists --json [ISSUE_ID]`; when absent, initialize with `git-context branch [WT_PATH]` and `workflow-state init`, and resolve `TRACKER`. On this path § 5 derives its QA signals from the diff scan and judgment — there is no dev artifact.
 
@@ -366,6 +367,7 @@ Drop a signal when the triggering code is trivial or test-only; never drop one f
 Map each signal to its agent — `needs-safety-audit` → `reviewer-safety`, `needs-perf-test` → `reviewer-perf`, `needs-review` → `reviewer-correctness`; a project may override the mapping in its instructions. For each, delegate and wait.
 
 Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the checkout the top of this workflow resolves `WT_PATH` from.
 
 <delegation_format>
 Follow workflow: .agents/skills/reviewer/workflows/qa-review.md

--- a/.agents/skills/orch/workflows/review-pr.md
+++ b/.agents/skills/orch/workflows/review-pr.md
@@ -130,6 +130,7 @@ Delegate to every reviewer in the active set in parallel. When `EXTERNAL_REVIEW_
 Follow workflow: .agents/skills/reviewer/workflows/review.md
 
 Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
 Branch: [BRANCH]
 Artifact: [ARTIFACT_PATH]
 
@@ -369,6 +370,7 @@ Issue: [ISSUE_ID]
 Tracker: [TRACKER] [OWNER/REPO]
 Branch: [BRANCH]
 Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
 Trigger: [QA signal]
 
 Dev summary:

--- a/.agents/skills/orch/workflows/review.md
+++ b/.agents/skills/orch/workflows/review.md
@@ -20,6 +20,7 @@ On-demand review of local changes: review, present findings, and offer to fix th
 Use the outputs as `BRANCH`, `ISSUE_ID` (empty means skip every workflow-state step), and `BASE_BRANCH`; `WT_PATH` is `git-context repo-root .`.
 
 Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the `.` the line above resolves `WT_PATH` from.
 
 | Argument | `DIFF_RANGE` |
 |----------|-------------|

--- a/.agents/skills/orch/workflows/review.md
+++ b/.agents/skills/orch/workflows/review.md
@@ -19,7 +19,7 @@ On-demand review of local changes: review, present findings, and offer to fix th
 
 Use the outputs as `BRANCH`, `ISSUE_ID` (empty means skip every workflow-state step), and `BASE_BRANCH`; `WT_PATH` is `git-context repo-root .`.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 | Argument | `DIFF_RANGE` |
 |----------|-------------|

--- a/.agents/skills/orch/workflows/review.md
+++ b/.agents/skills/orch/workflows/review.md
@@ -17,7 +17,9 @@ On-demand review of local changes: review, present findings, and offer to fix th
 .agents/skills/orch/scripts/resolve-base-branch .
 ```
 
-Use the outputs as `BRANCH`, `ISSUE_ID` (empty means skip every workflow-state step), and `BASE_BRANCH`; `WT_PATH` is the current directory.
+Use the outputs as `BRANCH`, `ISSUE_ID` (empty means skip every workflow-state step), and `BASE_BRANCH`; `WT_PATH` is `git-context repo-root .`.
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 | Argument | `DIFF_RANGE` |
 |----------|-------------|

--- a/.agents/skills/orch/workflows/review.md
+++ b/.agents/skills/orch/workflows/review.md
@@ -60,7 +60,7 @@ A failed check omits the path and carries `- decision index lookup failed for [D
 Follow workflow: .agents/skills/reviewer/workflows/review.md
 
 Worktree: [WT_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WT_PATH]"`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WT_PATH], because a bare `cd` may not survive into the next tool call.
 Branch: [BRANCH]
 Diff-range: [DIFF_RANGE]
 

--- a/.agents/skills/orch/workflows/review.md
+++ b/.agents/skills/orch/workflows/review.md
@@ -60,6 +60,7 @@ A failed check omits the path and carries `- decision index lookup failed for [D
 Follow workflow: .agents/skills/reviewer/workflows/review.md
 
 Worktree: [WT_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WT_PATH]`, re-run `pwd`, and report where it started.
 Branch: [BRANCH]
 Diff-range: [DIFF_RANGE]
 

--- a/.agents/skills/orch/workflows/review.md
+++ b/.agents/skills/orch/workflows/review.md
@@ -60,7 +60,7 @@ A failed check omits the path and carries `- decision index lookup failed for [D
 Follow workflow: .agents/skills/reviewer/workflows/review.md
 
 Worktree: [WT_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WT_PATH]`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WT_PATH]"`, re-run `pwd`, and report where it started.
 Branch: [BRANCH]
 Diff-range: [DIFF_RANGE]
 

--- a/.agents/skills/orch/workflows/review.md
+++ b/.agents/skills/orch/workflows/review.md
@@ -60,7 +60,7 @@ A failed check omits the path and carries `- decision index lookup failed for [D
 Follow workflow: .agents/skills/reviewer/workflows/review.md
 
 Worktree: [WT_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WT_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Branch: [BRANCH]
 Diff-range: [DIFF_RANGE]
 

--- a/.agents/skills/orch/workflows/review.md
+++ b/.agents/skills/orch/workflows/review.md
@@ -60,7 +60,7 @@ A failed check omits the path and carries `- decision index lookup failed for [D
 Follow workflow: .agents/skills/reviewer/workflows/review.md
 
 Worktree: [WT_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Branch: [BRANCH]
 Diff-range: [DIFF_RANGE]
 

--- a/.agents/skills/orch/workflows/review.md
+++ b/.agents/skills/orch/workflows/review.md
@@ -19,7 +19,7 @@ On-demand review of local changes: review, present findings, and offer to fix th
 
 Use the outputs as `BRANCH`, `ISSUE_ID` (empty means skip every workflow-state step), and `BASE_BRANCH`; `WT_PATH` is `git-context repo-root .`.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 | Argument | `DIFF_RANGE` |
 |----------|-------------|

--- a/.agents/skills/orch/workflows/start-worktree.md
+++ b/.agents/skills/orch/workflows/start-worktree.md
@@ -15,7 +15,7 @@ The full session from inside a worktree: implement → review → submit → fin
    .agents/skills/orch/scripts/git-context issue-from-branch .
    ```
 
-   Resolve `TRACKER` per [SKILL.md § Tracker Resolution](../SKILL.md#tracker-resolution). Set `WORKTREE_PATH` to the current directory.
+   Resolve `TRACKER` per [SKILL.md § Tracker Resolution](../SKILL.md#tracker-resolution). Set `WORKTREE_PATH` to `git-context repo-root .`.
 
 2. **Refuse containers** — Linear only, before any state exists. Apply the Ancestor gate ([SKILL.md § Coordination](../SKILL.md#coordination)) to:
 

--- a/.agents/skills/orch/workflows/submit-pr.md
+++ b/.agents/skills/orch/workflows/submit-pr.md
@@ -10,7 +10,7 @@ Run a local pre-PR review, push, create or update the PR, triage review comments
 
 **Caller context** (via `⤵`): `worktree`; `lifecycle` — `"managed"` (return at § 7) or `"self"` (default); `issue_id` — the workflow-state key, the normalized issue ID, never the bare GitHub issue number.
 
-**With a PR number**: `github.sh pr-issue [PR_NUMBER] --format=text` gives `ISSUE_ID`; `worktree exists`/`worktree path` give `[DIR]`, or ask before creating one when already inside the PR checkout; with no argument `[DIR]` is `.`. `WT_PATH` is `git-context repo-root [DIR]`.
+**With a PR number**: `github.sh pr-issue [PR_NUMBER] --format=text` gives `ISSUE_ID`; `worktree exists`/`worktree path` give `[DIR]`, or ask before creating one when already inside the PR checkout; with no argument `[DIR]` is `.`. `WT_PATH` is `git-context repo-root "[DIR]"`.
 
 **Standalone init** (`lifecycle: "self"`): resolve `ISSUE_ID` with `git-context issue-from-branch .`, then `workflow-state exists --json [ISSUE_ID]`; when absent, initialize with `git-context branch [WT_PATH]` and `workflow-state init`.
 

--- a/.agents/skills/orch/workflows/submit-pr.md
+++ b/.agents/skills/orch/workflows/submit-pr.md
@@ -10,7 +10,7 @@ Run a local pre-PR review, push, create or update the PR, triage review comments
 
 **Caller context** (via `⤵`): `worktree`; `lifecycle` — `"managed"` (return at § 7) or `"self"` (default); `issue_id` — the workflow-state key, the normalized issue ID, never the bare GitHub issue number.
 
-**With a PR number**: `github.sh pr-issue [PR_NUMBER] --format=text` gives `ISSUE_ID`; `worktree exists`/`worktree path` give `WT_PATH`, or ask before creating one when already inside the PR checkout. With no argument, `WT_PATH` is the current directory.
+**With a PR number**: `github.sh pr-issue [PR_NUMBER] --format=text` gives `ISSUE_ID`; `worktree exists`/`worktree path` give `[DIR]`, or ask before creating one when already inside the PR checkout; with no argument `[DIR]` is `.`. `WT_PATH` is `git-context repo-root [DIR]`.
 
 **Standalone init** (`lifecycle: "self"`): resolve `ISSUE_ID` with `git-context issue-from-branch .`, then `workflow-state exists --json [ISSUE_ID]`; when absent, initialize with `git-context branch [WT_PATH]` and `workflow-state init`.
 

--- a/.agents/skills/project-management/workflows/audit-issues.md
+++ b/.agents/skills/project-management/workflows/audit-issues.md
@@ -146,10 +146,11 @@ Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
 
 Arguments: --project "[PROJECT_NAME]" | --team | --issues [FILE_PATH]
 Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
 Tracker: [TRACKER] [OWNER/REPO]
 </delegation_format>
 
-Omit `Worktree:` for the main repo and `[OWNER/REPO]` when `TRACKER=linear`.
+Omit `Worktree:` and its `Worktree Check:` together for the main repo, and `[OWNER/REPO]` when `TRACKER=linear`.
 
 ### 4.2 Collect and Validate
 

--- a/.agents/skills/project-management/workflows/audit-issues.md
+++ b/.agents/skills/project-management/workflows/audit-issues.md
@@ -93,7 +93,8 @@ Worktree: [WORKTREE_PATH]
 Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 </delegation_format>
 
-Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, per § 4.1.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the caller's own checkout, per § 4.1.
 
 ### 2.2 Materialize and Present
 

--- a/.agents/skills/project-management/workflows/audit-issues.md
+++ b/.agents/skills/project-management/workflows/audit-issues.md
@@ -146,11 +146,11 @@ Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
 
 Arguments: --project "[PROJECT_NAME]" | --team | --issues [FILE_PATH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
 Tracker: [TRACKER] [OWNER/REPO]
 </delegation_format>
 
-Omit `Worktree:` and its `Worktree Check:` together for the main repo, and `[OWNER/REPO]` when `TRACKER=linear`.
+`Worktree:` and its `Worktree Check:` always ship together, main repo included — fill both with the main checkout's absolute path, which the delegate proves against exactly as it would a worktree's. Omit `[OWNER/REPO]` when `TRACKER=linear`.
 
 ### 4.2 Collect and Validate
 

--- a/.agents/skills/project-management/workflows/audit-issues.md
+++ b/.agents/skills/project-management/workflows/audit-issues.md
@@ -90,7 +90,7 @@ Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
 
 Arguments: --project-order
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 </delegation_format>
 
 Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, per § 4.1.
@@ -150,7 +150,7 @@ Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
 
 Arguments: --project "[PROJECT_NAME]" | --team | --issues [FILE_PATH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Tracker: [TRACKER] [OWNER/REPO]
 </delegation_format>
 

--- a/.agents/skills/project-management/workflows/audit-issues.md
+++ b/.agents/skills/project-management/workflows/audit-issues.md
@@ -85,7 +85,7 @@ No sync step. Load project taxonomy the same way as Linear mode; with no declare
 
 Spawn a one-shot `[TPM]` sub-agent (not a teammate — no re-delegation).
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the caller's own checkout, per § 4.1.
 
 <delegation_format>
@@ -146,7 +146,7 @@ With `TARGET` set, use it. Otherwise take the first `session-status.projects` en
 
 Spawn a one-shot `[TPM]` sub-agent (not a teammate).
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the caller worktree § 4.2 step 2 resolves, which is the main checkout only when the main checkout is the caller.
 
 <delegation_format>

--- a/.agents/skills/project-management/workflows/audit-issues.md
+++ b/.agents/skills/project-management/workflows/audit-issues.md
@@ -90,7 +90,7 @@ Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
 
 Arguments: --project-order
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 </delegation_format>
 
 Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, per § 4.1.
@@ -150,7 +150,7 @@ Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
 
 Arguments: --project "[PROJECT_NAME]" | --team | --issues [FILE_PATH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Tracker: [TRACKER] [OWNER/REPO]
 </delegation_format>
 

--- a/.agents/skills/project-management/workflows/audit-issues.md
+++ b/.agents/skills/project-management/workflows/audit-issues.md
@@ -89,7 +89,11 @@ Spawn a one-shot `[TPM]` sub-agent (not a teammate — no re-delegation):
 Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
 
 Arguments: --project-order
+Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
 </delegation_format>
+
+Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, per § 4.1.
 
 ### 2.2 Materialize and Present
 
@@ -146,7 +150,7 @@ Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
 
 Arguments: --project "[PROJECT_NAME]" | --team | --issues [FILE_PATH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
 Tracker: [TRACKER] [OWNER/REPO]
 </delegation_format>
 

--- a/.agents/skills/project-management/workflows/audit-issues.md
+++ b/.agents/skills/project-management/workflows/audit-issues.md
@@ -86,7 +86,7 @@ No sync step. Load project taxonomy the same way as Linear mode; with no declare
 Spawn a one-shot `[TPM]` sub-agent (not a teammate — no re-delegation).
 
 Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
-`[DIR]` is the caller's own checkout, per § 4.1.
+`[DIR]` is the current repo root; project-order mode takes no input file.
 
 <delegation_format>
 Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
@@ -147,7 +147,7 @@ With `TARGET` set, use it. Otherwise take the first `session-status.projects` en
 Spawn a one-shot `[TPM]` sub-agent (not a teammate).
 
 Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
-`[DIR]` is the caller worktree § 4.2 step 2 resolves, which is the main checkout only when the main checkout is the caller.
+`[DIR]` is the input file's `worktree` when the invocation supplied one, the current repo root otherwise.
 
 <delegation_format>
 Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md

--- a/.agents/skills/project-management/workflows/audit-issues.md
+++ b/.agents/skills/project-management/workflows/audit-issues.md
@@ -154,7 +154,7 @@ Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_
 Tracker: [TRACKER] [OWNER/REPO]
 </delegation_format>
 
-`Worktree:` and its `Worktree Check:` always ship together, main repo included — fill both with the main checkout's absolute path, which the delegate proves against exactly as it would a worktree's. Omit `[OWNER/REPO]` when `TRACKER=linear`.
+`Worktree:` and its `Worktree Check:` always ship together. Fill both with the absolute path of the caller worktree § 4.2 step 2 resolves, which is the main checkout only when the main checkout is the caller. Omit `[OWNER/REPO]` when `TRACKER=linear`.
 
 ### 4.2 Collect and Validate
 

--- a/.agents/skills/project-management/workflows/audit-issues.md
+++ b/.agents/skills/project-management/workflows/audit-issues.md
@@ -83,7 +83,10 @@ No sync step. Load project taxonomy the same way as Linear mode; with no declare
 
 ### 2.1 Delegate
 
-Spawn a one-shot `[TPM]` sub-agent (not a teammate — no re-delegation):
+Spawn a one-shot `[TPM]` sub-agent (not a teammate — no re-delegation).
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the caller's own checkout, per § 4.1.
 
 <delegation_format>
 Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
@@ -92,9 +95,6 @@ Arguments: --project-order
 Worktree: [WORKTREE_PATH]
 Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 </delegation_format>
-
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
-`[DIR]` is the caller's own checkout, per § 4.1.
 
 ### 2.2 Materialize and Present
 
@@ -144,7 +144,10 @@ With `TARGET` set, use it. Otherwise take the first `session-status.projects` en
 
 ### 4.1 Delegate
 
-Spawn a one-shot `[TPM]` sub-agent (not a teammate):
+Spawn a one-shot `[TPM]` sub-agent (not a teammate).
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the caller worktree § 4.2 step 2 resolves, which is the main checkout only when the main checkout is the caller.
 
 <delegation_format>
 Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
@@ -155,7 +158,7 @@ Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTR
 Tracker: [TRACKER] [OWNER/REPO]
 </delegation_format>
 
-`Worktree:` and its `Worktree Check:` always ship together. Fill both with the absolute path of the caller worktree § 4.2 step 2 resolves, which is the main checkout only when the main checkout is the caller. Omit `[OWNER/REPO]` when `TRACKER=linear`.
+Omit `[OWNER/REPO]` when `TRACKER=linear`.
 
 ### 4.2 Collect and Validate
 

--- a/.agents/skills/project-management/workflows/audit-issues.md
+++ b/.agents/skills/project-management/workflows/audit-issues.md
@@ -93,7 +93,7 @@ Worktree: [WORKTREE_PATH]
 Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 </delegation_format>
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the caller's own checkout, per § 4.1.
 
 ### 2.2 Materialize and Present

--- a/.agents/skills/project-management/workflows/cycle-plan.md
+++ b/.agents/skills/project-management/workflows/cycle-plan.md
@@ -15,7 +15,7 @@ This workflow mutates project state, so it reconciles before anything reads the 
    <delegation_format>
    Follow workflow: .agents/skills/project-management/workflows/tpm-cycle-plan.md
    Worktree: [WORKTREE_PATH]
-   Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+   Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
    </delegation_format>
 
    Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, main checkout included.

--- a/.agents/skills/project-management/workflows/cycle-plan.md
+++ b/.agents/skills/project-management/workflows/cycle-plan.md
@@ -15,7 +15,7 @@ This workflow mutates project state, so it reconciles before anything reads the 
    <delegation_format>
    Follow workflow: .agents/skills/project-management/workflows/tpm-cycle-plan.md
    Worktree: [WORKTREE_PATH]
-   Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+   Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
    </delegation_format>
 
    Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, main checkout included.

--- a/.agents/skills/project-management/workflows/cycle-plan.md
+++ b/.agents/skills/project-management/workflows/cycle-plan.md
@@ -12,7 +12,7 @@ This workflow mutates project state, so it reconciles before anything reads the 
 
 1. **Delegate** to a one-shot `[TPM]` sub-agent.
 
-   Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+   Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
    `[DIR]` is the caller's own checkout, main checkout included.
 
    <delegation_format>

--- a/.agents/skills/project-management/workflows/cycle-plan.md
+++ b/.agents/skills/project-management/workflows/cycle-plan.md
@@ -14,7 +14,11 @@ This workflow mutates project state, so it reconciles before anything reads the 
 
    <delegation_format>
    Follow workflow: .agents/skills/project-management/workflows/tpm-cycle-plan.md
+   Worktree: [WORKTREE_PATH]
+   Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
    </delegation_format>
+
+   Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, main checkout included.
 
 2. **Materialize the artifact.** The agent returns a `File:` hint and fenced JSON. Write the inline JSON to that path under the current repo root and read it; if inline JSON is missing and the path is not already readable, halt and request a rerun with inline JSON.
 

--- a/.agents/skills/project-management/workflows/cycle-plan.md
+++ b/.agents/skills/project-management/workflows/cycle-plan.md
@@ -18,7 +18,7 @@ This workflow mutates project state, so it reconciles before anything reads the 
    Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
    </delegation_format>
 
-   Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+   Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
    `[DIR]` is the caller's own checkout, main checkout included.
 
 2. **Materialize the artifact.** The agent returns a `File:` hint and fenced JSON. Write the inline JSON to that path under the current repo root and read it; if inline JSON is missing and the path is not already readable, halt and request a rerun with inline JSON.

--- a/.agents/skills/project-management/workflows/cycle-plan.md
+++ b/.agents/skills/project-management/workflows/cycle-plan.md
@@ -10,16 +10,16 @@ This workflow mutates project state, so it reconciles before anything reads the 
 .agents/skills/linear/scripts/linear.sh sync --reconcile
 ```
 
-1. **Delegate** to a one-shot `[TPM]` sub-agent:
+1. **Delegate** to a one-shot `[TPM]` sub-agent.
+
+   Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+   `[DIR]` is the caller's own checkout, main checkout included.
 
    <delegation_format>
    Follow workflow: .agents/skills/project-management/workflows/tpm-cycle-plan.md
    Worktree: [WORKTREE_PATH]
    Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
    </delegation_format>
-
-   Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
-   `[DIR]` is the caller's own checkout, main checkout included.
 
 2. **Materialize the artifact.** The agent returns a `File:` hint and fenced JSON. Write the inline JSON to that path under the current repo root and read it; if inline JSON is missing and the path is not already readable, halt and request a rerun with inline JSON.
 

--- a/.agents/skills/project-management/workflows/cycle-plan.md
+++ b/.agents/skills/project-management/workflows/cycle-plan.md
@@ -18,7 +18,8 @@ This workflow mutates project state, so it reconciles before anything reads the 
    Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
    </delegation_format>
 
-   Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, main checkout included.
+   Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+   `[DIR]` is the caller's own checkout, main checkout included.
 
 2. **Materialize the artifact.** The agent returns a `File:` hint and fenced JSON. Write the inline JSON to that path under the current repo root and read it; if inline JSON is missing and the path is not already readable, halt and request a rerun with inline JSON.
 

--- a/.agents/skills/project-management/workflows/research-complete.md
+++ b/.agents/skills/project-management/workflows/research-complete.md
@@ -51,7 +51,10 @@ With several references, convert to a bulleted list under one `**Research**:` he
 
 ## 5. Analyze Impact
 
-Run exactly one flow, unless it escalates. In either flow, fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, main checkout included.
+Run exactly one flow, unless it escalates. Both flows fill the delegation the same way.
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the caller's own checkout, main checkout included.
 
 ### 5.1 Targeted
 

--- a/.agents/skills/project-management/workflows/research-complete.md
+++ b/.agents/skills/project-management/workflows/research-complete.md
@@ -53,7 +53,7 @@ With several references, convert to a bulleted list under one `**Research**:` he
 
 Run exactly one flow, unless it escalates. Both flows fill the delegation the same way.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 ### 5.1 Targeted
@@ -88,7 +88,7 @@ List a technical change only when it changes what a user or operator experiences
 
 Delegate the same analysis to every affected domain agent in parallel, minus the cross-domain and scope questions. Then delegate the synthesis to the architecture review agent.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 <delegation_format>
 Synthesize the domain reports into a cross-cutting impact analysis.

--- a/.agents/skills/project-management/workflows/research-complete.md
+++ b/.agents/skills/project-management/workflows/research-complete.md
@@ -86,7 +86,9 @@ List a technical change only when it changes what a user or operator experiences
 
 ### 5.2 Pervasive
 
-Delegate the same analysis to every affected domain agent in parallel, minus the cross-domain and scope questions. Then delegate the synthesis to the architecture review agent:
+Delegate the same analysis to every affected domain agent in parallel, minus the cross-domain and scope questions. Then delegate the synthesis to the architecture review agent.
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 <delegation_format>
 Synthesize the domain reports into a cross-cutting impact analysis.

--- a/.agents/skills/project-management/workflows/research-complete.md
+++ b/.agents/skills/project-management/workflows/research-complete.md
@@ -51,7 +51,7 @@ With several references, convert to a bulleted list under one `**Research**:` he
 
 ## 5. Analyze Impact
 
-Run exactly one flow, unless it escalates.
+Run exactly one flow, unless it escalates. In either flow, fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, main checkout included.
 
 ### 5.1 Targeted
 
@@ -61,7 +61,7 @@ Delegate to the domain agent:
 Analyze the impact of these research findings on your domain.
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 
 Read: [RESEARCH_DOCS_PATH]/[ISSUE_ID]/findings.md
 
@@ -89,7 +89,7 @@ Delegate the same analysis to every affected domain agent in parallel, minus the
 Synthesize the domain reports into a cross-cutting impact analysis.
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 
 Read: [RESEARCH_DOCS_PATH]/[ISSUE_ID]/findings.md
 

--- a/.agents/skills/project-management/workflows/research-complete.md
+++ b/.agents/skills/project-management/workflows/research-complete.md
@@ -53,7 +53,7 @@ With several references, convert to a bulleted list under one `**Research**:` he
 
 Run exactly one flow, unless it escalates. Both flows fill the delegation the same way.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 ### 5.1 Targeted

--- a/.agents/skills/project-management/workflows/research-complete.md
+++ b/.agents/skills/project-management/workflows/research-complete.md
@@ -60,6 +60,9 @@ Delegate to the domain agent:
 <delegation_format>
 Analyze the impact of these research findings on your domain.
 
+Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+
 Read: [RESEARCH_DOCS_PATH]/[ISSUE_ID]/findings.md
 
 Report with tables:
@@ -84,6 +87,9 @@ Delegate the same analysis to every affected domain agent in parallel, minus the
 
 <delegation_format>
 Synthesize the domain reports into a cross-cutting impact analysis.
+
+Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 
 Read: [RESEARCH_DOCS_PATH]/[ISSUE_ID]/findings.md
 

--- a/.agents/skills/project-management/workflows/research-issue.md
+++ b/.agents/skills/project-management/workflows/research-issue.md
@@ -82,7 +82,7 @@ Re-delegate to `[CONSULTATION_AGENT_NAME]` when the caller supplied one, omittin
 Research: [RESEARCH_ISSUE_ID] - [TOPIC]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 
 Blocked issue: [BLOCKED_ISSUE_ID]
 Read it: `.agents/skills/linear/scripts/linear.sh cache issues get [BLOCKED_ISSUE_ID]`
@@ -155,7 +155,7 @@ Otherwise delegate to `researcher` (or `[RESEARCHER_AGENT_NAME]`):
 Research issue: [RESEARCH_ISSUE_ID] - [TOPIC]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 
 Read:
 - [RESEARCH_DOCS_PATH]/[RESEARCH_ISSUE_ID]/prompt.txt

--- a/.agents/skills/project-management/workflows/research-issue.md
+++ b/.agents/skills/project-management/workflows/research-issue.md
@@ -103,7 +103,7 @@ Draft your domain's contribution:
 Reply with a structured section per item.
 </delegation_format>
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 ### 2.2 Assemble

--- a/.agents/skills/project-management/workflows/research-issue.md
+++ b/.agents/skills/project-management/workflows/research-issue.md
@@ -154,6 +154,9 @@ Otherwise delegate to `researcher` (or `[RESEARCHER_AGENT_NAME]`):
 <delegation_format>
 Research issue: [RESEARCH_ISSUE_ID] - [TOPIC]
 
+Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+
 Read:
 - [RESEARCH_DOCS_PATH]/[RESEARCH_ISSUE_ID]/prompt.txt
 - [RESEARCH_DOCS_PATH]/[RESEARCH_ISSUE_ID]/context-*.md

--- a/.agents/skills/project-management/workflows/research-issue.md
+++ b/.agents/skills/project-management/workflows/research-issue.md
@@ -82,7 +82,7 @@ Re-delegate to `[CONSULTATION_AGENT_NAME]` when the caller supplied one, omittin
 Research: [RESEARCH_ISSUE_ID] - [TOPIC]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 
 Blocked issue: [BLOCKED_ISSUE_ID]
 Read it: `.agents/skills/linear/scripts/linear.sh cache issues get [BLOCKED_ISSUE_ID]`

--- a/.agents/skills/project-management/workflows/research-issue.md
+++ b/.agents/skills/project-management/workflows/research-issue.md
@@ -103,7 +103,8 @@ Draft your domain's contribution:
 Reply with a structured section per item.
 </delegation_format>
 
-Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, main checkout included.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the caller's own checkout, main checkout included.
 
 ### 2.2 Assemble
 

--- a/.agents/skills/project-management/workflows/research-issue.md
+++ b/.agents/skills/project-management/workflows/research-issue.md
@@ -78,6 +78,9 @@ Map each domain label to its agent type (project-configurable) and delegate in p
 
 Re-delegate to `[CONSULTATION_AGENT_NAME]` when the caller supplied one, omitting the reading block below. Otherwise start a fresh agent with the full block.
 
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the caller's own checkout, main checkout included.
+
 <delegation_format>
 Research: [RESEARCH_ISSUE_ID] - [TOPIC]
 
@@ -102,9 +105,6 @@ Draft your domain's contribution:
 
 Reply with a structured section per item.
 </delegation_format>
-
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
-`[DIR]` is the caller's own checkout, main checkout included.
 
 ### 2.2 Assemble
 
@@ -150,7 +150,10 @@ Run `[RESEARCH_DOCS_PATH]/[RESEARCH_ISSUE_ID]/run.sh`, or use Pi `web_research` 
 
 **If `auto_execute` is false**: present the issue and assets and stop, noting that the issue is labeled `agent:researcher` and ready.
 
-Otherwise delegate to `researcher` (or `[RESEARCHER_AGENT_NAME]`):
+Otherwise delegate to `researcher` (or `[RESEARCHER_AGENT_NAME]`).
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>
 Research issue: [RESEARCH_ISSUE_ID] - [TOPIC]

--- a/.agents/skills/project-management/workflows/research-issue.md
+++ b/.agents/skills/project-management/workflows/research-issue.md
@@ -78,7 +78,7 @@ Map each domain label to its agent type (project-configurable) and delegate in p
 
 Re-delegate to `[CONSULTATION_AGENT_NAME]` when the caller supplied one, omitting the reading block below. Otherwise start a fresh agent with the full block.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>
@@ -152,7 +152,7 @@ Run `[RESEARCH_DOCS_PATH]/[RESEARCH_ISSUE_ID]/run.sh`, or use Pi `web_research` 
 
 Otherwise delegate to `researcher` (or `[RESEARCHER_AGENT_NAME]`).
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>

--- a/.agents/skills/project-management/workflows/research-issue.md
+++ b/.agents/skills/project-management/workflows/research-issue.md
@@ -81,6 +81,9 @@ Re-delegate to `[CONSULTATION_AGENT_NAME]` when the caller supplied one, omittin
 <delegation_format>
 Research: [RESEARCH_ISSUE_ID] - [TOPIC]
 
+Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+
 Blocked issue: [BLOCKED_ISSUE_ID]
 Read it: `.agents/skills/linear/scripts/linear.sh cache issues get [BLOCKED_ISSUE_ID]`
 Read: [RESEARCH_PATHS]
@@ -99,6 +102,8 @@ Draft your domain's contribution:
 
 Reply with a structured section per item.
 </delegation_format>
+
+Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, main checkout included.
 
 ### 2.2 Assemble
 

--- a/.agents/skills/project-management/workflows/roadmap-plan.md
+++ b/.agents/skills/project-management/workflows/roadmap-plan.md
@@ -61,7 +61,7 @@ With no match, ask the user:
 
 Otherwise, match `FEATURE` keywords and component paths to domain agents (project-configurable) to get `RELEVANT_AGENTS[]`, then delegate to each in parallel.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>
@@ -95,7 +95,7 @@ Build `PROPOSED_ISSUES[]` per [roadmap-plan-input.md](../schemas/roadmap-plan-in
 
 Write the input file per [roadmap-plan-input.md](../schemas/roadmap-plan-input.md) to `tmp/roadmap-input-YYYYMMDD-HHMMSS.json`, including `origin_issue`, `planner_handoff`, and `spec_path` (each null when absent; `spec_path` is set exactly when the artifact in hand — the `@[path]` input or the § 1 disk match — classified as a SPEC). Delegate to a one-shot `[TPM]` sub-agent.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>
@@ -114,7 +114,7 @@ Materialize the returned artifact the same way as audit-issues § 4.2. Read `hie
 
 Delegate to the architecture review agent.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>

--- a/.agents/skills/project-management/workflows/roadmap-plan.md
+++ b/.agents/skills/project-management/workflows/roadmap-plan.md
@@ -100,7 +100,8 @@ Worktree: [WORKTREE_PATH]
 Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 </delegation_format>
 
-Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, main checkout included.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the caller's own checkout, main checkout included.
 
 Materialize the returned artifact the same way as audit-issues § 4.2. Read `hierarchy_recommendation`, `cross_project_findings`, `architecture_gaps[]`, `organized_issues[]`, and `project_placement`.
 

--- a/.agents/skills/project-management/workflows/roadmap-plan.md
+++ b/.agents/skills/project-management/workflows/roadmap-plan.md
@@ -100,7 +100,7 @@ Worktree: [WORKTREE_PATH]
 Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 </delegation_format>
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 Materialize the returned artifact the same way as audit-issues § 4.2. Read `hierarchy_recommendation`, `cross_project_findings`, `architecture_gaps[]`, `organized_issues[]`, and `project_placement`.

--- a/.agents/skills/project-management/workflows/roadmap-plan.md
+++ b/.agents/skills/project-management/workflows/roadmap-plan.md
@@ -95,7 +95,7 @@ Follow workflow: .agents/skills/project-management/workflows/tpm-roadmap-plan.md
 
 Arguments: --input [INPUT_FILE_PATH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 </delegation_format>
 
 Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, main checkout included.

--- a/.agents/skills/project-management/workflows/roadmap-plan.md
+++ b/.agents/skills/project-management/workflows/roadmap-plan.md
@@ -94,7 +94,11 @@ Write the input file per [roadmap-plan-input.md](../schemas/roadmap-plan-input.m
 Follow workflow: .agents/skills/project-management/workflows/tpm-roadmap-plan.md
 
 Arguments: --input [INPUT_FILE_PATH]
+Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
 </delegation_format>
+
+Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, main checkout included.
 
 Materialize the returned artifact the same way as audit-issues § 4.2. Read `hierarchy_recommendation`, `cross_project_findings`, `architecture_gaps[]`, `organized_issues[]`, and `project_placement`.
 

--- a/.agents/skills/project-management/workflows/roadmap-plan.md
+++ b/.agents/skills/project-management/workflows/roadmap-plan.md
@@ -65,6 +65,8 @@ Otherwise, match `FEATURE` keywords and component paths to domain agents (projec
 Feature: [FEATURE]
 Research: [RESEARCH_PATH or "None"]
 Spec: [SPEC_PATH or "None"] — when set, its approach and workstreams are binding: do not re-litigate them; cut its phases into PR-sized issues
+Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 
 List implementation issues for your domain only. Reply as a table with these columns:
 
@@ -113,6 +115,8 @@ Review proposed roadmap for: [FEATURE]
 
 Proposed project: [project_placement.project_name]
 Spec: [SPEC_PATH or "None"] — when set, the spec's phases bound the roadmap: report anything beyond them as out-of-spec, with why it is needed
+Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 
 Organized issues:
 [organized_issues]

--- a/.agents/skills/project-management/workflows/roadmap-plan.md
+++ b/.agents/skills/project-management/workflows/roadmap-plan.md
@@ -59,7 +59,10 @@ With no match, ask the user:
 
 **Slicing mode (SPEC in hand):** delegate one slicing pass per repo or domain the spec touches — at most one specialist each; the template's `Spec:` line carries the binding constraint, and they cut the spec's phases into PR-sized issues with real estimates and conflicts read from the code. Slicing delegates receive the same `<delegation_format>` below and answer in its table.
 
-Otherwise, match `FEATURE` keywords and component paths to domain agents (project-configurable) to get `RELEVANT_AGENTS[]`, then delegate to each in parallel:
+Otherwise, match `FEATURE` keywords and component paths to domain agents (project-configurable) to get `RELEVANT_AGENTS[]`, then delegate to each in parallel.
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>
 Feature: [FEATURE]
@@ -90,7 +93,10 @@ Build `PROPOSED_ISSUES[]` per [roadmap-plan-input.md](../schemas/roadmap-plan-in
 
 ## 3. TPM Analysis
 
-Write the input file per [roadmap-plan-input.md](../schemas/roadmap-plan-input.md) to `tmp/roadmap-input-YYYYMMDD-HHMMSS.json`, including `origin_issue`, `planner_handoff`, and `spec_path` (each null when absent; `spec_path` is set exactly when the artifact in hand — the `@[path]` input or the § 1 disk match — classified as a SPEC). Delegate to a one-shot `[TPM]` sub-agent:
+Write the input file per [roadmap-plan-input.md](../schemas/roadmap-plan-input.md) to `tmp/roadmap-input-YYYYMMDD-HHMMSS.json`, including `origin_issue`, `planner_handoff`, and `spec_path` (each null when absent; `spec_path` is set exactly when the artifact in hand — the `@[path]` input or the § 1 disk match — classified as a SPEC). Delegate to a one-shot `[TPM]` sub-agent.
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>
 Follow workflow: .agents/skills/project-management/workflows/tpm-roadmap-plan.md
@@ -100,16 +106,16 @@ Worktree: [WORKTREE_PATH]
 Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 </delegation_format>
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
-`[DIR]` is the caller's own checkout, main checkout included.
-
 Materialize the returned artifact the same way as audit-issues § 4.2. Read `hierarchy_recommendation`, `cross_project_findings`, `architecture_gaps[]`, `organized_issues[]`, and `project_placement`.
 
 ---
 
 ## 4. Architecture Review
 
-Delegate to the architecture review agent:
+Delegate to the architecture review agent.
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>
 Review proposed roadmap for: [FEATURE]

--- a/.agents/skills/project-management/workflows/roadmap-plan.md
+++ b/.agents/skills/project-management/workflows/roadmap-plan.md
@@ -66,7 +66,7 @@ Feature: [FEATURE]
 Research: [RESEARCH_PATH or "None"]
 Spec: [SPEC_PATH or "None"] — when set, its approach and workstreams are binding: do not re-litigate them; cut its phases into PR-sized issues
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 
 List implementation issues for your domain only. Reply as a table with these columns:
 
@@ -97,7 +97,7 @@ Follow workflow: .agents/skills/project-management/workflows/tpm-roadmap-plan.md
 
 Arguments: --input [INPUT_FILE_PATH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 </delegation_format>
 
 Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, main checkout included.
@@ -116,7 +116,7 @@ Review proposed roadmap for: [FEATURE]
 Proposed project: [project_placement.project_name]
 Spec: [SPEC_PATH or "None"] — when set, the spec's phases bound the roadmap: report anything beyond them as out-of-spec, with why it is needed
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 
 Organized issues:
 [organized_issues]

--- a/changelog.d/fixed/KEN-878.md
+++ b/changelog.d/fixed/KEN-878.md
@@ -1,0 +1,3 @@
+- orch: a delegation states its worktree as a cwd precondition the agent
+  proves with `pwd` before anything repo-relative, so a shell started in
+  another lane's worktree is caught at the first command.

--- a/changelog.d/fixed/KEN-878.md
+++ b/changelog.d/fixed/KEN-878.md
@@ -1,3 +1,3 @@
 - orch: a delegation states its worktree as a cwd precondition the agent
-  proves with `pwd` before anything repo-relative, so a shell started in
-  another lane's worktree is caught at the first command.
+  proves with `pwd -P` before anything repo-relative, so a shell in another
+  lane's worktree is caught at the first command.

--- a/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -1,38 +1,34 @@
 #!/usr/bin/env bash
 # Regression lint for KEN-878. A delegated agent's shell does not reliably
-# start in the worktree it was delegated: two lanes on 2026-08-30 each ran
-# bare-relative commands — `tools/guard` among them — against another lane's
-# worktree, and both noticed only after a confusing downstream failure.
+# start in the worktree it was delegated: two lanes each ran bare-relative
+# commands — `tools/guard` among them — against another lane's worktree,
+# and both noticed only after a confusing downstream failure.
 #
-# The cure is a precondition the agent runs before anything repo-relative:
-# every `Worktree: [PLACEHOLDER]` line inside a `<delegation_format>` block
-# is followed immediately by a `Worktree Check:` line that OPENS with a
-# backticked `pwd` and names that SAME placeholder. `pwd` reports where the
-# shell actually is, so the check can fail; a line that merely restates the
-# delegated path cannot.
+# The cure is a precondition the agent runs before anything repo-relative,
+# and this lint holds it as ONE canonical sentence rather than as a set of
+# shape rules. Every shipped check line is byte-identical apart from the
+# block's own placeholder token, so the test carries that sentence in
+# $CANON with `@TOKEN@` where the token goes, and each site must equal it
+# with its own token substituted in. Equality is the whole predicate:
+# nothing infers "opens with a command", "mentions pwd", or "names the
+# token", so no prose mutation can satisfy the letter of a heuristic while
+# leaving the agent with nothing to run. A future wording change is made in
+# $CANON and at every site together, or the lint reds.
 #
-# All three conditions are load-bearing, and the command one is the reason
-# this lint was rewritten twice. Matching the label and the placeholder
-# alone is fail-open: replacing the opening of a real check with `Worktree
-# Check: trust the path.` left the whole suite green, because the rest of
-# the line still carried its placeholder. Matching `pwd` ANYWHERE on the
-# line is the same hole one step further in — that mutation still said
-# "re-run `pwd`" in its remedy clause. Matching the FIRST backticked span
-# wherever it falls is that hole a third time: a check opening with prose
-# and offering `pwd` later still passes, because the first span found is a
-# later one. So the match is anchored to the start of the line: what has to
-# hold is that the first executable step IS the command, asserted by
-# position rather than by mention.
+# Two rules are enforced inside a `<delegation_format>` block:
 #
-# This lint is the answer to the recurrence, not to the individual sites: a
-# new delegation block that carries `Worktree:` without a working check
-# fails here rather than shipping the silent-wrong-tree hazard again.
+#   1. A `Worktree: [TOKEN]` line is followed on the very next line by the
+#      canonical `Worktree Check:` line for that same TOKEN.
+#   2. A block that hands the delegate a repo-relative path — a bare path
+#      opening `.agents/`, `skills/` or `tools/` — carries that pair at
+#      all. Without it the delegate runs those paths wherever its shell
+#      happens to be. A block whose paths are all placeholders is out of
+#      scope: the caller resolves those, and the lint cannot judge them.
 #
-# Scope is every skill doc that can carry a delegation, not one directory —
-# scoping the first sweep to orch/workflows is what let the
-# project-management site sit unguarded. Tests are excluded: their probe
-# fixtures carry deliberately broken blocks. A `Worktree:` mention in prose
-# or in a fenced example is not a delegation and is not scanned.
+# Scope is every skill doc that can carry a delegation, not one directory.
+# Tests are excluded: their probe fixtures carry deliberately broken
+# blocks. A `Worktree:` mention in prose or in a fenced example is not a
+# delegation and is not scanned.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -46,37 +42,31 @@ FAIL=0
 pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
 fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 
+# The canonical check line, with @TOKEN@ standing in for the block's own
+# placeholder name. This is the single source of truth for the sentence;
+# the shipped docs must match it character for character.
+CANON='Worktree Check: `pwd` before any repo-relative command. It must print [@TOKEN@]; your shell can start in another lane'"'"'s worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [@TOKEN@], because a bare `cd` may not survive into the next tool call.'
+
 # scan_worktree_precondition <file>
-# Emits one "file:line: ..." line per defect. Inside a <delegation_format>
-# block, a `Worktree: [TOKEN]` line must be followed on the very next line by
-# a `Worktree Check:` line that (a) BEGINS with a backticked `pwd` — the
-# match is anchored, so nothing may precede the code span and the agent's
-# first executable step is the command that reports where the shell
-# actually is — and (b) contains `[TOKEN]`, the same placeholder, so a
-# filled delegation compares against its own path and not another site's.
+# Emits one "file:line: ..." line per defect, per the two rules above.
 # Lines outside a delegation block are never scanned.
 scan_worktree_precondition() {
-  awk -v f="$1" '
-    /^[[:space:]]*<delegation_format>[[:space:]]*$/ { indel = 1; pending = 0; next }
+  awk -v f="$1" -v canon="$CANON" '
+    function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+    /^[[:space:]]*<delegation_format>[[:space:]]*$/ {
+      indel = 1; pending = 0; haswt = 0; relline = 0; relpath = ""; next
+    }
     /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ {
       if (pending) printf "%s:%d: Worktree: [%s] ends the delegation with no Worktree Check line\n", f, pendline, token
+      if (indel && !haswt && relline) printf "%s:%d: delegation hands over the repo-relative path %s but carries no Worktree:/Worktree Check: pair\n", f, relline, relpath
       indel = 0; pending = 0; next
     }
     indel {
       if (pending) {
-        if ($0 !~ /^[[:space:]]*Worktree Check:/) {
-          printf "%s:%d: Worktree: [%s] is not followed by a Worktree Check line\n", f, pendline, token
-        } else {
-          rest = $0
-          sub(/^[[:space:]]*Worktree Check:[[:space:]]*/, "", rest)
-          cmd = ""
-          if (match(rest, /^`[^`]*`/)) cmd = substr(rest, RSTART + 1, RLENGTH - 2)
-          if (cmd != "pwd") {
-            printf "%s:%d: Worktree Check does not open with a backticked pwd (first command: %s)\n", f, NR, (cmd == "" ? "none" : cmd)
-          }
-          if (index($0, "[" token "]") == 0) {
-            printf "%s:%d: Worktree Check names no [%s] to compare pwd against\n", f, NR, token
-          }
+        want = canon
+        gsub(/@TOKEN@/, token, want)
+        if (trim($0) != want) {
+          printf "%s:%d: the line after Worktree: [%s] is not the canonical Worktree Check (got: %s)\n", f, NR, token, trim($0)
         }
         pending = 0
       }
@@ -84,9 +74,32 @@ scan_worktree_precondition() {
         line = $0
         sub(/^[[:space:]]*Worktree:[[:space:]]*\[/, "", line)
         sub(/\].*$/, "", line)
-        token = line; pendline = NR; pending = 1
+        token = line; pendline = NR; pending = 1; haswt = 1
+      }
+      if (!relline) {
+        probe = " " $0
+        if (match(probe, /[^A-Za-z0-9_.\/-](\.agents|skills|tools)\/[A-Za-z0-9._\/-]+/)) {
+          relline = NR
+          relpath = substr(probe, RSTART + 1, RLENGTH - 1)
+        }
       }
     }
+  ' "$1"
+}
+
+# count_guarded_relpath_blocks <file>
+# Prints the number of delegation blocks that name a repo-relative path AND
+# carry a Worktree: line — the population rule 2 is meant to hold.
+count_guarded_relpath_blocks() {
+  awk '
+    /^[[:space:]]*<delegation_format>[[:space:]]*$/ { indel = 1; haswt = 0; hasrel = 0; next }
+    /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ { if (indel && haswt && hasrel) n++; indel = 0; next }
+    indel {
+      if ($0 ~ /^[[:space:]]*Worktree:[[:space:]]*\[[A-Za-z_][A-Za-z0-9_]*\][[:space:]]*$/) haswt = 1
+      probe = " " $0
+      if (match(probe, /[^A-Za-z0-9_.\/-](\.agents|skills|tools)\/[A-Za-z0-9._\/-]+/)) hasrel = 1
+    }
+    END { print n + 0 }
   ' "$1"
 }
 
@@ -99,14 +112,16 @@ echo "=== orch delegation worktree-cwd-precondition lint ==="
 DOCS="$(find "$SKILLS_ROOT" -name '*.md' -not -path '*/tests/*' | sort)"
 offenders=""
 sites=0
+guarded=0
 for doc in $DOCS; do
   out="$(scan_worktree_precondition "$doc")"
   [ -n "$out" ] && offenders="$offenders$out"$'\n'
   n="$(grep -c '^[[:space:]]*Worktree Check:' "$doc" || true)"
   sites=$((sites + n))
+  guarded=$((guarded + $(count_guarded_relpath_blocks "$doc")))
 done
 if [ -z "$offenders" ]; then
-  pass "every delegated Worktree: line is followed by its Worktree Check"
+  pass "every delegated Worktree: line is followed by its canonical Worktree Check"
 else
   fail "delegation blocks missing the worktree cwd precondition:"
   printf '%s' "$offenders" | sed 's/^/          /'
@@ -120,6 +135,15 @@ else
   fail "no Worktree Check lines found — the scan matched nothing to check"
 fi
 
+# The same guard for rule 2: with no shipped block naming a repo-relative
+# path, the repo-path rule passed over an empty population and proves
+# nothing.
+if [ "$guarded" -gt 0 ]; then
+  pass "the scan read $guarded repo-relative delegation block(s) carrying the pair"
+else
+  fail "no repo-relative delegation blocks found — the repo-path rule matched nothing"
+fi
+
 # --- Part b: the lint has teeth -------------------------------------------
 
 # probe <name> <body> → prints scratch-file path.
@@ -131,26 +155,26 @@ probe() {
   printf '%s' "$scratch"
 }
 
-CHECK='Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH].'
+CHECK="${CANON//@TOKEN@/WORKTREE_PATH}"
 
-# b.1 — the reported shape (a bare Worktree: line, as all eleven sites read
-# before this change) IS flagged.
+# b.1 — the reported shape (a bare Worktree: line, as every site read before
+# this change) IS flagged.
 if [ -n "$(scan_worktree_precondition "$(probe bare 'Issue: [ISSUE_ID]\nWorktree: [WORKTREE_PATH]\nRound ID: [DEV_ROUND_ID]')" )" ]; then
   pass "lint flags a Worktree: line with no Worktree Check"
 else
   fail "lint MISSED a bare Worktree: line (no teeth)"
 fi
 
-# b.2 — the fixed shape is NOT flagged.
+# b.2 — the canonical shape is NOT flagged.
 if [ -z "$(scan_worktree_precondition "$(probe fixed "Worktree: [WORKTREE_PATH]\n$CHECK")" )" ]; then
-  pass "lint accepts Worktree: followed by its Worktree Check"
+  pass "lint accepts Worktree: followed by the canonical Worktree Check"
 else
-  fail "lint false-flagged the fixed shape"
+  fail "lint false-flagged the canonical shape"
 fi
 
 # b.3 — a check naming a DIFFERENT placeholder IS flagged: a filled
 # delegation would compare pwd against a path this block never carries.
-if [ -n "$(scan_worktree_precondition "$(probe crossed 'Worktree: [WT_PATH]\nWorktree Check: `pwd` must print [WORKTREE_PATH].')" )" ]; then
+if [ -n "$(scan_worktree_precondition "$(probe crossed "Worktree: [WT_PATH]\n$CHECK")" )" ]; then
   pass "lint flags a Worktree Check naming the wrong placeholder"
 else
   fail "lint MISSED a cross-wired placeholder"
@@ -163,27 +187,36 @@ else
   fail "lint MISSED a trailing Worktree: line"
 fi
 
-# b.7 — THE REPORTED FAIL-OPEN. The exact mutation two reviewers landed
-# independently: the opening command replaced by prose, everything after it
-# left intact. The line still carries its placeholder AND still says `pwd` in
-# the remedy clause, so both a placeholder check and an anywhere-on-the-line
-# `pwd` check pass it. Only asserting the line's OPENING span catches it.
+# b.7 — the leading command replaced by prose, everything after it left
+# intact. The line still carries its placeholder AND still says `pwd` later,
+# so a placeholder check and an anywhere-on-the-line `pwd` check both pass
+# it. Equality does not.
 MUTANT='Worktree: [WORKTREE_PATH]\nWorktree Check: trust the path. It must print [WORKTREE_PATH]; a bare `git status` answers about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.'
 if [ -n "$(scan_worktree_precondition "$(probe mutant "$MUTANT")" )" ]; then
   pass "lint flags a check whose leading command was replaced by prose"
 else
-  fail "lint MISSED the reported fail-open (a check that runs nothing)"
+  fail "lint MISSED a check that runs nothing"
 fi
 
-# b.10 — THE ROUND-THREE FAIL-OPEN. Prose in front, a backticked `pwd`
-# behind it: the first backticked span on the line IS `pwd`, so an unanchored
-# match accepts a check that demotes the command to optional. Only anchoring
-# to the start of the line rejects it.
+# b.10 — prose in front, a backticked `pwd` behind it: the first backticked
+# span on the line IS `pwd`, so an unanchored shape match accepts a check
+# that demotes the command to optional.
 DEMOTED='Worktree: [WORKTREE_PATH]\nWorktree Check: trust the path; optional check: `pwd` must print [WORKTREE_PATH].'
 if [ -n "$(scan_worktree_precondition "$(probe demoted "$DEMOTED")" )" ]; then
   pass "lint flags a check whose pwd sits behind leading prose"
 else
   fail "lint MISSED a backticked pwd demoted behind prose"
+fi
+
+# b.11 — the token is present and the line opens with a backticked `pwd`,
+# but nothing binds one to the other: the check tells the agent to ignore
+# what it just measured. Every shape heuristic passes this; equality is the
+# only predicate that does not.
+UNBOUND='Worktree: [WORKTREE_PATH]\nWorktree Check: `pwd` before any repo-relative command. Ignore [WORKTREE_PATH].'
+if [ -n "$(scan_worktree_precondition "$(probe unbound "$UNBOUND")" )" ]; then
+  pass "lint flags a check whose pwd and placeholder are unbound"
+else
+  fail "lint MISSED an unbound pwd and placeholder"
 fi
 
 # b.8 — a check opening with the WRONG command is flagged. `pwd` has to be
@@ -202,9 +235,43 @@ else
   fail "lint MISSED an unbackticked pwd"
 fi
 
+# b.12 — the recovery clause must not rest on a bare `cd`. A harness that
+# spawns a fresh shell per tool call drops it, and the agent resumes
+# repo-relative work in the wrong tree believing it recovered.
+STALE_CD='Worktree: [WORKTREE_PATH]\nWorktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.'
+if [ -n "$(scan_worktree_precondition "$(probe stalecd "$STALE_CD")" )" ]; then
+  pass "lint flags a check whose remedy is a bare cd"
+else
+  fail "lint MISSED a remedy resting on a cd that may not persist"
+fi
+
+# b.13 — RULE 2. A block that hands over a repo-relative path with no
+# Worktree:/Worktree Check: pair IS flagged: the delegate runs that path
+# wherever its shell happens to be.
+if [ -n "$(scan_worktree_precondition "$(probe relpath 'Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md\n\nArguments: --project-order')" )" ]; then
+  pass "lint flags a delegation naming a repo-relative path with no Worktree pair"
+else
+  fail "lint MISSED a repo-relative delegation with no Worktree pair"
+fi
+
+# b.14 — the same block WITH the pair is not flagged.
+if [ -z "$(scan_worktree_precondition "$(probe relok "Follow workflow: .agents/skills/x/y.md\nWorktree: [WORKTREE_PATH]\n$CHECK")" )" ]; then
+  pass "lint accepts a repo-relative delegation carrying the pair"
+else
+  fail "lint false-flagged a repo-relative delegation that carries the pair"
+fi
+
+# b.15 — a block whose paths are ALL placeholders is out of scope: the
+# caller resolves them, and the lint cannot judge where they land.
+if [ -z "$(scan_worktree_precondition "$(probe placeholders 'Read: [RESEARCH_DOCS_PATH]/[ISSUE_ID]/findings.md\nWrite: [INPUT_FILE_PATH]')" )" ]; then
+  pass "lint ignores a delegation whose paths are all placeholders"
+else
+  fail "lint false-flagged a placeholder-only delegation"
+fi
+
 # b.5 — a Worktree: mention outside a delegation block is NOT scanned.
 PROSE="$TMP_ROOT/probe-prose.md"
-printf 'Fill the delegation Worktree: [WORKTREE_PATH] from the claim output.\n' > "$PROSE"
+printf 'Fill the delegation Worktree: [WORKTREE_PATH] from the claim output, per .agents/skills/orch/SKILL.md.\n' > "$PROSE"
 if [ -z "$(scan_worktree_precondition "$PROSE")" ]; then
   pass "lint ignores a Worktree: mention outside a delegation block"
 else

--- a/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -18,6 +18,11 @@
 # leaving the agent with nothing to run. A future wording change is made in
 # $CANON and at every site together, or the lint reds.
 #
+# Both sides of the comparison are physical paths. `git-context` derives
+# the delegated path with `git rev-parse --show-toplevel`, so the check
+# runs `pwd -P`: a bare `pwd` prints the logical path and would halt a
+# correct delegate whose shell entered the checkout through a symlink.
+#
 # Two rules are enforced inside a `<delegation_format>` block:
 #
 #   1. A `Worktree: [TOKEN]` line is followed on the very next line by the
@@ -68,7 +73,7 @@ fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 # The canonical check line, with @TOKEN@ standing in for the block's own
 # placeholder name. This is the single source of truth for the sentence;
 # the shipped docs must match it character for character.
-CANON='Worktree Check: `pwd` before any repo-relative command. It must print [@TOKEN@]; your shell can start in another lane'"'"'s worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.'
+CANON='Worktree Check: `pwd -P` before any repo-relative command. It must print [@TOKEN@]; your shell can start in another lane'"'"'s worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.'
 
 # scan_worktree_precondition <file>
 # Emits one "file:line: ..." line per defect, per the two rules above.
@@ -158,12 +163,15 @@ done
 
 # --- Part b: the lint has teeth -------------------------------------------
 
-# probe <name> <body> → prints scratch-file path.
+# probe <name> <body> [tag_indent] → prints scratch-file path.
 # Writes a standalone delegation block containing <body> (printf %b, so \n
 # splits it into lines) under $TMP_ROOT, removed by the EXIT trap.
+# <tag_indent> is prefixed to both tags, so a probe can put the block itself
+# off column zero the way dev-fix.md nests one in a numbered step; it
+# defaults to empty, which is what every probe but b.6 wants.
 probe() {
   scratch="$TMP_ROOT/probe-$1.md"
-  printf '<delegation_format>\n%b\n</delegation_format>\n' "$2" > "$scratch"
+  printf '%s<delegation_format>\n%b\n%s</delegation_format>\n' "${3-}" "$2" "${3-}" > "$scratch"
   printf '%s' "$scratch"
 }
 
@@ -280,6 +288,17 @@ else
   fail "lint MISSED a remedy an absolute path cannot deliver"
 fi
 
+# b.17 — the pre-fix sentence, identical but for a bare `pwd`. The delegated
+# path is physical (`git rev-parse --show-toplevel`), so a logical `pwd` halts
+# a correct delegate whose shell reached the checkout through a symlink. The
+# logical form must not come back unnoticed.
+LOGICAL="${CHECK//pwd -P/pwd}"
+if reports "$(scan_worktree_precondition "$(probe logical "Worktree: [WORKTREE_PATH]\n$LOGICAL")")" "$UNCANON"; then
+  pass "lint flags a check measuring the cwd with a bare pwd"
+else
+  fail "lint MISSED a check comparing a logical pwd against a physical path"
+fi
+
 # b.13 — RULE 2. A block with no Worktree:/Worktree Check: pair at all IS
 # flagged, whatever it hands over: a placeholder the caller fills with a
 # repo path is invisible to any matcher, so no block is out of scope.
@@ -299,13 +318,19 @@ else
 fi
 
 # b.6 — an indented delegation block (dev-fix.md nests one in a numbered
-# step) is scanned, not skipped for its leading whitespace. Rule 2 flags this
-# same fixture the moment the indent tolerance breaks, so the assertion names
-# rule 1's message. The indent stays in the fixture; it is the thing tested.
-if reports "$(scan_worktree_precondition "$(probe indented '   Worktree: [WORKTREE_PATH]\n   Round ID: [DEV_ROUND_ID]')")" "$UNCANON"; then
-  pass "lint scans an indented delegation block"
+# step) is scanned, not skipped for its leading whitespace. The TAGS are
+# indented too, not just the body: tags at column zero leave both matchers'
+# tolerance untested. The fixture draws one message from each side of the
+# block — the uncanonical line is reported only if the opening tag let the
+# scan in, the unclosed one only if the closing tag was recognised — so
+# restricting EITHER matcher to column zero reds this probe. Rule 2 stays
+# silent here (the block does carry a Worktree: line), so neither assertion
+# can be satisfied by the other rule. The indent is the thing tested.
+INDENTED="$(scan_worktree_precondition "$(probe indented '   Worktree: [WORKTREE_PATH]\n   Round ID: [DEV_ROUND_ID]\n   Worktree: [WORKTREE_PATH]' '   ')")"
+if reports "$INDENTED" "$UNCANON" && reports "$INDENTED" "$UNCLOSED"; then
+  pass "lint scans an indented delegation block, opening tag to closing tag"
 else
-  fail "rule 1 MISSED an indented Worktree: line"
+  fail "lint MISSED an indented delegation block"
 fi
 
 # --- Part c: both trees are actually scanned ------------------------------

--- a/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -12,13 +12,17 @@
 # delegated path cannot.
 #
 # All three conditions are load-bearing, and the command one is the reason
-# this lint was rewritten. Matching the label and the placeholder alone is
-# fail-open: replacing the opening of a real check with `Worktree Check:
-# trust the path.` left the whole suite green, because the rest of the line
-# still carried its placeholder. Matching `pwd` ANYWHERE on the line is the
-# same hole one step further in — that mutation still said "re-run `pwd`" in
-# its remedy clause. What has to hold is that the first executable step is
-# the command, so the check is asserted by position, not by mention.
+# this lint was rewritten twice. Matching the label and the placeholder
+# alone is fail-open: replacing the opening of a real check with `Worktree
+# Check: trust the path.` left the whole suite green, because the rest of
+# the line still carried its placeholder. Matching `pwd` ANYWHERE on the
+# line is the same hole one step further in — that mutation still said
+# "re-run `pwd`" in its remedy clause. Matching the FIRST backticked span
+# wherever it falls is that hole a third time: a check opening with prose
+# and offering `pwd` later still passes, because the first span found is a
+# later one. So the match is anchored to the start of the line: what has to
+# hold is that the first executable step IS the command, asserted by
+# position rather than by mention.
 #
 # This lint is the answer to the recurrence, not to the individual sites: a
 # new delegation block that carries `Worktree:` without a working check
@@ -45,11 +49,12 @@ fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 # scan_worktree_precondition <file>
 # Emits one "file:line: ..." line per defect. Inside a <delegation_format>
 # block, a `Worktree: [TOKEN]` line must be followed on the very next line by
-# a `Worktree Check:` line that (a) opens with `pwd` as its first backticked
-# span, so the agent's first executable step is the command that reports
-# where the shell actually is, and (b) contains `[TOKEN]` — the same
-# placeholder, so a filled delegation compares against its own path and not
-# another site's. Lines outside a delegation block are never scanned.
+# a `Worktree Check:` line that (a) BEGINS with a backticked `pwd` — the
+# match is anchored, so nothing may precede the code span and the agent's
+# first executable step is the command that reports where the shell
+# actually is — and (b) contains `[TOKEN]`, the same placeholder, so a
+# filled delegation compares against its own path and not another site's.
+# Lines outside a delegation block are never scanned.
 scan_worktree_precondition() {
   awk -v f="$1" '
     /^[[:space:]]*<delegation_format>[[:space:]]*$/ { indel = 1; pending = 0; next }
@@ -65,7 +70,7 @@ scan_worktree_precondition() {
           rest = $0
           sub(/^[[:space:]]*Worktree Check:[[:space:]]*/, "", rest)
           cmd = ""
-          if (match(rest, /`[^`]*`/)) cmd = substr(rest, RSTART + 1, RLENGTH - 2)
+          if (match(rest, /^`[^`]*`/)) cmd = substr(rest, RSTART + 1, RLENGTH - 2)
           if (cmd != "pwd") {
             printf "%s:%d: Worktree Check does not open with a backticked pwd (first command: %s)\n", f, NR, (cmd == "" ? "none" : cmd)
           }
@@ -162,12 +167,23 @@ fi
 # independently: the opening command replaced by prose, everything after it
 # left intact. The line still carries its placeholder AND still says `pwd` in
 # the remedy clause, so both a placeholder check and an anywhere-on-the-line
-# `pwd` check pass it. Only asserting the FIRST backticked span catches it.
-MUTANT='Worktree: [WORKTREE_PATH]\nWorktree Check: trust the path. It must print [WORKTREE_PATH]; a bare `git status` answers about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.'
+# `pwd` check pass it. Only asserting the line's OPENING span catches it.
+MUTANT='Worktree: [WORKTREE_PATH]\nWorktree Check: trust the path. It must print [WORKTREE_PATH]; a bare `git status` answers about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.'
 if [ -n "$(scan_worktree_precondition "$(probe mutant "$MUTANT")" )" ]; then
   pass "lint flags a check whose leading command was replaced by prose"
 else
   fail "lint MISSED the reported fail-open (a check that runs nothing)"
+fi
+
+# b.10 — THE ROUND-THREE FAIL-OPEN. Prose in front, a backticked `pwd`
+# behind it: the first backticked span on the line IS `pwd`, so an unanchored
+# match accepts a check that demotes the command to optional. Only anchoring
+# to the start of the line rejects it.
+DEMOTED='Worktree: [WORKTREE_PATH]\nWorktree Check: trust the path; optional check: `pwd` must print [WORKTREE_PATH].'
+if [ -n "$(scan_worktree_precondition "$(probe demoted "$DEMOTED")" )" ]; then
+  pass "lint flags a check whose pwd sits behind leading prose"
+else
+  fail "lint MISSED a backticked pwd demoted behind prose"
 fi
 
 # b.8 — a check opening with the WRONG command is flagged. `pwd` has to be

--- a/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -23,7 +23,7 @@
 # runs `pwd -P`: a bare `pwd` prints the logical path and would halt a
 # correct delegate whose shell entered the checkout through a symlink.
 #
-# Four rules are enforced:
+# Six rules are enforced:
 #
 #   1. A `Worktree: [TOKEN]` line is followed on the very next line by the
 #      canonical `Worktree Check:` line for that same TOKEN.
@@ -59,8 +59,33 @@
 #      Do not widen it; write a conflicting instruction in the canonical
 #      shape or leave the boundary where it is.
 #
-#      Rules 1 and 2 read inside a `<delegation_format>` block; rules 3
-#      and 4 read the lines between one block and the block before it.
+#   5. Exactly one `Worktree:` line and one `Worktree Check:` line per
+#      block, and every check line sits directly under a `Worktree:` line.
+#      Rule 1 read the line after a `Worktree:` line and recorded a
+#      boolean, so a block could carry the canonical pair and then append
+#      `Worktree Check: on mismatch continue`, leaving the delegate two
+#      checks with no ordering between them and the suite green; a
+#      duplicated pair passed for the same reason. The rule counts, it
+#      does not read: a second check line is reported for existing, not
+#      for what it says. A check line whose preceding line is not a
+#      `Worktree:` line is an orphan and is reported at its own line.
+#
+#   6. A file carrying the canonical fill line names `[DIR]` on some other
+#      line. The fill line introduces `[DIR]` and never says what it is,
+#      and three workflows shipped it with the token bound nowhere: the
+#      caller had nothing to substitute, so the placeholder came out empty
+#      and the delegation dropped both lines. Only the DECIDABLE half is
+#      asserted. Each workflow resolves the path its own way, so there is
+#      no canonical binding sentence to compare against, and the predicate
+#      is that the token appears somewhere else in the file. Whether that
+#      mention BINDS the token is semantic judgment, which this repo has
+#      ruled out of a lexical scanner, so prose merely naming `[DIR]`
+#      clears the rule. What it catches is the shipped defect: a token
+#      introduced once and defined nowhere.
+#
+#      Rules 1, 2 and 5 read inside a `<delegation_format>` block; rules 3
+#      and 4 read the lines between one block and the block before it;
+#      rule 6 reads the whole file.
 #
 # A block ends at three terminators, not one: its closing tag, a new opening
 # tag arriving while it is still open, and end of file. All three route
@@ -168,7 +193,7 @@ CANON_FILL='Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-
 CANON_FILL_OPEN='Fill `Worktree:` and its `Worktree Check:`'
 
 # scan_worktree_precondition <file>
-# Emits one "file:line: ..." line per defect, per the two rules above.
+# Emits one "file:line: ..." line per defect, per rules 1, 2 and 5 above.
 # Lines outside a delegation block are never scanned.
 #
 # Every rule that judges a whole block lives in `close_block`, and all three
@@ -184,17 +209,23 @@ scan_worktree_precondition() {
       if (!indel) return
       if (reason != "") printf "%s:%d: delegation block is never closed (%s)\n", f, delline, reason
       if (pending) printf "%s:%d: Worktree: [%s] ends the delegation with no Worktree Check line\n", f, pendline, token
-      if (!haswt) printf "%s:%d: delegation carries no Worktree:/Worktree Check: pair\n", f, delline
-      indel = 0; pending = 0; haswt = 0
+      if (nwt == 0) printf "%s:%d: delegation carries no Worktree:/Worktree Check: pair\n", f, delline
+      if (nwt > 1) printf "%s:%d: delegation carries %d Worktree: lines; exactly one is required\n", f, delline, nwt
+      if (nchk > 1) printf "%s:%d: delegation carries %d Worktree Check: lines; exactly one is required\n", f, delline, nchk
+      indel = 0; pending = 0; nwt = 0; nchk = 0
     }
     /^[[:space:]]*<delegation_format>[[:space:]]*$/ {
       close_block("a new <delegation_format> opens at line " NR)
-      indel = 1; pending = 0; haswt = 0; delline = NR; next
+      indel = 1; pending = 0; nwt = 0; nchk = 0; delline = NR; next
     }
     /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ {
       close_block(""); next
     }
     indel {
+      # Rule 5 asks whether the PREVIOUS line was a Worktree: line, which is
+      # what `pending` records — so it is read into `under_wt` before rule 1
+      # consumes it.
+      under_wt = pending
       if (pending) {
         want = canon
         gsub(/@TOKEN@/, token, want)
@@ -203,11 +234,15 @@ scan_worktree_precondition() {
         }
         pending = 0
       }
+      if (match($0, /^[[:space:]]*Worktree Check:/)) {
+        nchk++
+        if (!under_wt) printf "%s:%d: Worktree Check line with no Worktree: line above it\n", f, NR
+      }
       if (match($0, /^[[:space:]]*Worktree:[[:space:]]*\[[A-Za-z_][A-Za-z0-9_]*\][[:space:]]*$/)) {
         line = $0
         sub(/^[[:space:]]*Worktree:[[:space:]]*\[/, "", line)
         sub(/\].*$/, "", line)
-        token = line; pendline = NR; pending = 1; haswt = 1
+        token = line; pendline = NR; pending = 1; nwt++
       }
     }
     END { close_block("reached end of file") }
@@ -261,6 +296,34 @@ scan_worktree_fill() {
   ' "$1"
 }
 
+# scan_worktree_binding <file>
+# RULE 6. Emits one defect line for a file that carries the canonical fill
+# line and names `[DIR]` nowhere else. The fill line hands the caller a token
+# it never defines; review.md, review-pr.md and review-codebase.md each
+# shipped it with no binding anywhere, so the caller had nothing to
+# substitute and the delegate got an empty path or no pair at all.
+#
+# The predicate is a mention, not a definition. Each workflow resolves the
+# path its own way, so there is no sentence to compare against and equality
+# is unavailable here; a rule that read the mention for meaning would be the
+# semantic judgment this repo has kept out of a lexical scanner. So prose
+# that merely names `[DIR]` clears this, deliberately. The fill line's own
+# `[DIR]` does not count, or the rule would be satisfied by the line that
+# creates the problem.
+scan_worktree_binding() {
+  awk -v f="$1" -v canon="$CANON_FILL" '
+    function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+    {
+      if (trim($0) == canon) { if (!fillline) fillline = NR; next }
+      if (index($0, "[DIR]") > 0) bound = 1
+    }
+    END {
+      if (fillline && !bound)
+        printf "%s:%d: the fill line names [DIR] and no other line in this file binds it\n", f, fillline
+    }
+  ' "$1"
+}
+
 # scan_trees <root>...
 # Emits every defect line found in every non-test *.md under the given
 # roots. A missing root is itself a defect: the caller asked for a tree
@@ -274,6 +337,7 @@ scan_trees() {
     find "$root" -name '*.md' -not -path '*/tests/*' | sort | while IFS= read -r doc; do
       scan_worktree_precondition "$doc"
       scan_worktree_fill "$doc"
+      scan_worktree_binding "$doc"
     done
   done
 }
@@ -335,6 +399,11 @@ probe() {
 }
 
 CHECK="${CANON//@TOKEN@/WORKTREE_PATH}"
+
+# A binding sentence for `[DIR]`, in the shape the workflows carry. Rule 6
+# asks every file carrying the fill line for one, so every fixture that
+# writes the fill line to a scanned tree writes this beside it.
+BINDING='`[DIR]` is the `[PATH_OR_PWD]` § 1 resolves `WT_PATH` from.'
 
 # reports <scan output> <fragment> — the scan named THIS defect, not merely
 # some defect. Rule 2 fires on every block rule 1 failed to see, so a probe
@@ -510,13 +579,58 @@ fi
 # block — the uncanonical line is reported only if the opening tag let the
 # scan in, the unclosed one only if the closing tag was recognised — so
 # restricting EITHER matcher to column zero reds this probe. Rule 2 stays
-# silent here (the block does carry a Worktree: line), so neither assertion
-# can be satisfied by the other rule. The indent is the thing tested.
+# silent here (the block does carry a Worktree: line) and rule 5 speaks in a
+# message of its own about the second one, so neither assertion below can be
+# satisfied by another rule. The indent is the thing tested.
 INDENTED="$(scan_worktree_precondition "$(probe indented '   Worktree: [WORKTREE_PATH]\n   Round ID: [DEV_ROUND_ID]\n   Worktree: [WORKTREE_PATH]' '   ')")"
 if reports "$INDENTED" "$UNCANON" && reports "$INDENTED" "$UNCLOSED"; then
   pass "lint scans an indented delegation block, opening tag to closing tag"
 else
   fail "lint MISSED an indented delegation block"
+fi
+
+# RULE 5. Rule 1 read the line after a Worktree: line and set a boolean, so
+# everything below shipped a block the delegate reads as carrying two
+# contradicting instructions, with the suite green. All three outputs are
+# compared WHOLE: a probe that named some other line, or drew rule 2 instead,
+# fails as readily as one that drew nothing.
+ORPHAN='Worktree Check line with no Worktree: line above it'
+
+# b.18 — a second check line appended after the canonical pair. This is the
+# reported shape: the pair is perfect and the line under it says the
+# opposite. It is an orphan (its predecessor is a check line, not a
+# Worktree: line) and it is the second check in the block.
+APPENDED="$TMP_ROOT/probe-appended-check.md"
+printf '<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\nWorktree Check: on mismatch continue.\n</delegation_format>\n' "$CHECK" > "$APPENDED"
+if [ "$(scan_worktree_precondition "$APPENDED")" = "$APPENDED:4: $ORPHAN
+$APPENDED:1: delegation carries 2 Worktree Check: lines; exactly one is required" ]; then
+  pass "lint flags a second Worktree Check appended after the canonical pair"
+else
+  fail "lint MISSED a second Worktree Check appended after the canonical pair"
+fi
+
+# b.19 — the canonical pair twice over. Every line is canonical and every
+# check sits under its own Worktree: line, so the orphan rule cannot see it;
+# only the counts can. The delegate is handed two paths to compare against.
+DOUBLED="$TMP_ROOT/probe-doubled-pair.md"
+printf '<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' "$CHECK" "$CHECK" > "$DOUBLED"
+if [ "$(scan_worktree_precondition "$DOUBLED")" = "$DOUBLED:1: delegation carries 2 Worktree: lines; exactly one is required
+$DOUBLED:1: delegation carries 2 Worktree Check: lines; exactly one is required" ]; then
+  pass "lint flags a duplicated canonical pair"
+else
+  fail "lint MISSED a duplicated canonical pair"
+fi
+
+# b.20 — a check line with no Worktree: line above it anywhere in the block.
+# It has no path to compare against, so it halts nothing. Rule 2 also fires,
+# and the whole-output comparison pins which line each message names.
+LOOSE="$TMP_ROOT/probe-loose-check.md"
+printf '<delegation_format>\nBranch: [BRANCH]\n%s\n</delegation_format>\n' "$CHECK" > "$LOOSE"
+if [ "$(scan_worktree_precondition "$LOOSE")" = "$LOOSE:3: $ORPHAN
+$LOOSE:1: $NOPAIR" ]; then
+  pass "lint flags an orphan Worktree Check with no Worktree: line"
+else
+  fail "lint MISSED an orphan Worktree Check with no Worktree: line"
 fi
 
 # --- Part c: both trees are actually scanned ------------------------------
@@ -529,7 +643,7 @@ TWO="$TMP_ROOT/two-trees"
 mkdir -p "$TWO/skills/x" "$TWO/.agents/skills/x"
 GOOD="Worktree: [WORKTREE_PATH]\n$CHECK"
 BROKEN='Worktree: [WORKTREE_PATH]'
-write_half() { printf '%s\n\n<delegation_format>\n%b\n</delegation_format>\n' "$CANON_FILL" "$2" > "$TWO/$1/x/y.md"; }
+write_half() { printf '%s\n%s\n\n<delegation_format>\n%b\n</delegation_format>\n' "$CANON_FILL" "$BINDING" "$2" > "$TWO/$1/x/y.md"; }
 
 # c.1 — control: both halves carry the check, nothing is flagged. Without
 # this the two probes below could red for any reason at all.
@@ -766,6 +880,59 @@ if [ -z "$(scan_worktree_fill "$NEARBY")" ]; then
   pass "lint leaves ordinary prose naming a path alone"
 else
   fail "lint false-flagged prose that merely names a path"
+fi
+
+# --- Part g: the fill line's own placeholder is bound somewhere -----------
+# RULE 6. The fill line hands the caller `[DIR]` and never says what it is.
+# Three workflows shipped it with the token defined nowhere in the file, so
+# the caller had nothing to substitute and the delegation dropped the pair.
+# The predicate is a mention elsewhere in the file, and the probes pin both
+# sides of that boundary: g.4 is the one that says out loud what this rule
+# cannot decide.
+UNBOUND_DIR='the fill line names [DIR] and no other line in this file binds it'
+
+# g.1 — the shipped defect: the canonical fill line, a well-formed block,
+# and no other mention of the token. The fill line carries `[DIR]` itself,
+# so this also pins that its own occurrence does not clear the rule.
+NOBIND="$TMP_ROOT/probe-unbound-dir.md"
+printf '%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' "$CANON_FILL" "$CHECK" > "$NOBIND"
+if [ "$(scan_worktree_binding "$NOBIND")" = "$NOBIND:1: $UNBOUND_DIR" ]; then
+  pass "lint flags a fill line whose [DIR] is bound nowhere in the file"
+else
+  fail "lint MISSED a fill line whose [DIR] is bound nowhere"
+fi
+
+# g.2 — the fix: a binding sentence under the fill line, in the shape the
+# workflows carry. Without this the rule could be unsatisfiable and g.1
+# would still pass.
+BOUND="$TMP_ROOT/probe-bound-dir.md"
+printf '%s\n%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' "$CANON_FILL" "$BINDING" "$CHECK" > "$BOUND"
+if [ -z "$(scan_worktree_binding "$BOUND")" ]; then
+  pass "lint accepts a fill line whose [DIR] the file binds"
+else
+  fail "lint false-flagged a bound [DIR]"
+fi
+
+# g.3 — a file carrying no fill line is asked for no binding, whatever it
+# says about paths. Otherwise every doc in both trees would have to define a
+# token it never uses.
+if [ -z "$(scan_worktree_binding "$PROSE")" ]; then
+  pass "lint asks no [DIR] binding of a file carrying no fill line"
+else
+  fail "lint demanded a [DIR] binding of a file with no fill line"
+fi
+
+# g.4 — THE BOUNDARY, stated as a fixture. A mention that does not bind the
+# token clears the rule, because deciding that a sentence binds a
+# placeholder is semantic judgment and this scanner does none. If a later
+# round wants the stronger rule, it needs a canonical binding sentence to
+# compare against; until then this probe is what says so.
+MENTION="$TMP_ROOT/probe-mentioned-dir.md"
+printf '%s\nThe delegate writes its round artifact under `[DIR]/tmp`.\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' "$CANON_FILL" "$CHECK" > "$MENTION"
+if [ -z "$(scan_worktree_binding "$MENTION")" ]; then
+  pass "lint accepts a bare mention of [DIR]; it counts mentions, not bindings"
+else
+  fail "lint read a mention for meaning, which it cannot decide"
 fi
 
 echo

--- a/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -6,17 +6,29 @@
 #
 # The cure is a precondition the agent runs before anything repo-relative:
 # every `Worktree: [PLACEHOLDER]` line inside a `<delegation_format>` block
-# is followed immediately by a `Worktree Check:` line naming that SAME
-# placeholder. `pwd` reports where the shell actually is, so the check can
-# fail; a line that merely restates the delegated path cannot.
+# is followed immediately by a `Worktree Check:` line that OPENS with a
+# backticked `pwd` and names that SAME placeholder. `pwd` reports where the
+# shell actually is, so the check can fail; a line that merely restates the
+# delegated path cannot.
 #
-# This lint is the answer to the recurrence, not to the eleven sites: a new
-# delegation block that carries `Worktree:` without its check fails here
-# rather than shipping the silent-wrong-tree hazard again.
+# All three conditions are load-bearing, and the command one is the reason
+# this lint was rewritten. Matching the label and the placeholder alone is
+# fail-open: replacing the opening of a real check with `Worktree Check:
+# trust the path.` left the whole suite green, because the rest of the line
+# still carried its placeholder. Matching `pwd` ANYWHERE on the line is the
+# same hole one step further in — that mutation still said "re-run `pwd`" in
+# its remedy clause. What has to hold is that the first executable step is
+# the command, so the check is asserted by position, not by mention.
 #
-# Scoped to `<delegation_format>` blocks in orch's workflows. A `Worktree:`
-# mention in prose or in a fenced example is not a delegation and is not
-# scanned.
+# This lint is the answer to the recurrence, not to the individual sites: a
+# new delegation block that carries `Worktree:` without a working check
+# fails here rather than shipping the silent-wrong-tree hazard again.
+#
+# Scope is every skill doc that can carry a delegation, not one directory —
+# scoping the first sweep to orch/workflows is what let the
+# project-management site sit unguarded. Tests are excluded: their probe
+# fixtures carry deliberately broken blocks. A `Worktree:` mention in prose
+# or in a fenced example is not a delegation and is not scanned.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -33,7 +45,9 @@ fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 # scan_worktree_precondition <file>
 # Emits one "file:line: ..." line per defect. Inside a <delegation_format>
 # block, a `Worktree: [TOKEN]` line must be followed on the very next line by
-# a `Worktree Check:` line whose text contains `[TOKEN]` — the same
+# a `Worktree Check:` line that (a) opens with `pwd` as its first backticked
+# span, so the agent's first executable step is the command that reports
+# where the shell actually is, and (b) contains `[TOKEN]` — the same
 # placeholder, so a filled delegation compares against its own path and not
 # another site's. Lines outside a delegation block are never scanned.
 scan_worktree_precondition() {
@@ -47,8 +61,17 @@ scan_worktree_precondition() {
       if (pending) {
         if ($0 !~ /^[[:space:]]*Worktree Check:/) {
           printf "%s:%d: Worktree: [%s] is not followed by a Worktree Check line\n", f, pendline, token
-        } else if (index($0, "[" token "]") == 0) {
-          printf "%s:%d: Worktree Check names no [%s] to compare pwd against\n", f, NR, token
+        } else {
+          rest = $0
+          sub(/^[[:space:]]*Worktree Check:[[:space:]]*/, "", rest)
+          cmd = ""
+          if (match(rest, /`[^`]*`/)) cmd = substr(rest, RSTART + 1, RLENGTH - 2)
+          if (cmd != "pwd") {
+            printf "%s:%d: Worktree Check does not open with a backticked pwd (first command: %s)\n", f, NR, (cmd == "" ? "none" : cmd)
+          }
+          if (index($0, "[" token "]") == 0) {
+            printf "%s:%d: Worktree Check names no [%s] to compare pwd against\n", f, NR, token
+          }
         }
         pending = 0
       }
@@ -65,7 +88,10 @@ scan_worktree_precondition() {
 echo "=== orch delegation worktree-cwd-precondition lint ==="
 
 # --- Part a: every shipped delegation block carries the precondition -------
-DOCS="$(ls "$SKILLS_ROOT"/orch/workflows/*.md)"
+# Every skill doc, not one skill's workflows: a delegation that hands over a
+# worktree is checked wherever it lives. Tests are excluded — their probe
+# fixtures carry deliberately broken blocks.
+DOCS="$(find "$SKILLS_ROOT" -name '*.md' -not -path '*/tests/*' | sort)"
 offenders=""
 sites=0
 for doc in $DOCS; do
@@ -130,6 +156,34 @@ if [ -n "$(scan_worktree_precondition "$(probe last 'Branch: [BRANCH]\nWorktree:
   pass "lint flags a Worktree: line that closes the delegation"
 else
   fail "lint MISSED a trailing Worktree: line"
+fi
+
+# b.7 — THE REPORTED FAIL-OPEN. The exact mutation two reviewers landed
+# independently: the opening command replaced by prose, everything after it
+# left intact. The line still carries its placeholder AND still says `pwd` in
+# the remedy clause, so both a placeholder check and an anywhere-on-the-line
+# `pwd` check pass it. Only asserting the FIRST backticked span catches it.
+MUTANT='Worktree: [WORKTREE_PATH]\nWorktree Check: trust the path. It must print [WORKTREE_PATH]; a bare `git status` answers about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.'
+if [ -n "$(scan_worktree_precondition "$(probe mutant "$MUTANT")" )" ]; then
+  pass "lint flags a check whose leading command was replaced by prose"
+else
+  fail "lint MISSED the reported fail-open (a check that runs nothing)"
+fi
+
+# b.8 — a check opening with the WRONG command is flagged. `pwd` has to be
+# the first executable step; a different command does not report the cwd.
+if [ -n "$(scan_worktree_precondition "$(probe wrongcmd 'Worktree: [WORKTREE_PATH]\nWorktree Check: `git status` before any repo-relative command. It must print [WORKTREE_PATH].')" )" ]; then
+  pass "lint flags a check opening with a command other than pwd"
+else
+  fail "lint MISSED a check opening with the wrong command"
+fi
+
+# b.9 — an unbackticked mention is not a command. Without the code span
+# there is nothing marked for the agent to run.
+if [ -n "$(scan_worktree_precondition "$(probe unmarked 'Worktree: [WORKTREE_PATH]\nWorktree Check: run pwd before any repo-relative command. It must print [WORKTREE_PATH].')" )" ]; then
+  pass "lint flags a check whose pwd is not a marked command"
+else
+  fail "lint MISSED an unbackticked pwd"
 fi
 
 # b.5 — a Worktree: mention outside a delegation block is NOT scanned.

--- a/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -22,11 +22,12 @@
 #
 #   1. A `Worktree: [TOKEN]` line is followed on the very next line by the
 #      canonical `Worktree Check:` line for that same TOKEN.
-#   2. A block that hands the delegate a repo-relative path — a bare path
-#      opening `.agents/`, `skills/` or `tools/` — carries that pair at
-#      all. Without it the delegate runs those paths wherever its shell
-#      happens to be. A block whose paths are all placeholders is out of
-#      scope: the caller resolves those, and the lint cannot judge them.
+#   2. EVERY block carries that pair. No path matcher decides which
+#      delegations need it: judging "does this delegate touch the repo"
+#      from the block's literal text missed blocks with no pair at all,
+#      then missed blocks whose paths are placeholders the caller fills.
+#      The pair costs two lines on a delegation that never touches the
+#      repo, and uniform is the only rule that cannot be wrong.
 #
 # Scope is every skill doc that can carry a delegation, in BOTH trees: the
 # `skills/` source and the `.agents/skills/` render agents actually load.
@@ -76,11 +77,11 @@ scan_worktree_precondition() {
   awk -v f="$1" -v canon="$CANON" '
     function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
     /^[[:space:]]*<delegation_format>[[:space:]]*$/ {
-      indel = 1; pending = 0; haswt = 0; relline = 0; relpath = ""; next
+      indel = 1; pending = 0; haswt = 0; delline = NR; next
     }
     /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ {
       if (pending) printf "%s:%d: Worktree: [%s] ends the delegation with no Worktree Check line\n", f, pendline, token
-      if (indel && !haswt && relline) printf "%s:%d: delegation hands over the repo-relative path %s but carries no Worktree:/Worktree Check: pair\n", f, relline, relpath
+      if (indel && !haswt) printf "%s:%d: delegation carries no Worktree:/Worktree Check: pair\n", f, delline
       indel = 0; pending = 0; next
     }
     indel {
@@ -98,30 +99,7 @@ scan_worktree_precondition() {
         sub(/\].*$/, "", line)
         token = line; pendline = NR; pending = 1; haswt = 1
       }
-      if (!relline) {
-        probe = " " $0
-        if (match(probe, /[^A-Za-z0-9_.\/-](\.agents|skills|tools)\/[A-Za-z0-9._\/-]+/)) {
-          relline = NR
-          relpath = substr(probe, RSTART + 1, RLENGTH - 1)
-        }
-      }
     }
-  ' "$1"
-}
-
-# count_guarded_relpath_blocks <file>
-# Prints the number of delegation blocks that name a repo-relative path AND
-# carry a Worktree: line — the population rule 2 is meant to hold.
-count_guarded_relpath_blocks() {
-  awk '
-    /^[[:space:]]*<delegation_format>[[:space:]]*$/ { indel = 1; haswt = 0; hasrel = 0; next }
-    /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ { if (indel && haswt && hasrel) n++; indel = 0; next }
-    indel {
-      if ($0 ~ /^[[:space:]]*Worktree:[[:space:]]*\[[A-Za-z_][A-Za-z0-9_]*\][[:space:]]*$/) haswt = 1
-      probe = " " $0
-      if (match(probe, /[^A-Za-z0-9_.\/-](\.agents|skills|tools)\/[A-Za-z0-9._\/-]+/)) hasrel = 1
-    }
-    END { print n + 0 }
   ' "$1"
 }
 
@@ -141,22 +119,13 @@ scan_trees() {
   done
 }
 
-# count_sites <root> — shipped Worktree Check lines under one tree.
-count_sites() {
-  find "$1" -name '*.md' -not -path '*/tests/*' -exec grep -c '^[[:space:]]*Worktree Check:' {} + 2>/dev/null |
+# count_blocks <root> — delegation blocks the scan opened under one tree.
+# Counting blocks rather than shipped check lines guards the scanner's own
+# unit: if the block opener stopped matching, every rule would pass on an
+# empty population while the docs still read as full of check lines.
+count_blocks() {
+  find "$1" -name '*.md' -not -path '*/tests/*' -exec grep -c '^[[:space:]]*<delegation_format>[[:space:]]*$' {} + 2>/dev/null |
     awk -F: '{ n += $NF } END { print n + 0 }'
-}
-
-# count_guarded <root> — guarded repo-relative blocks under one tree.
-count_guarded() {
-  total=0
-  while IFS= read -r doc; do
-    [ -n "$doc" ] || continue
-    total=$((total + $(count_guarded_relpath_blocks "$doc")))
-  done <<EOF
-$(find "$1" -name '*.md' -not -path '*/tests/*' | sort)
-EOF
-  printf '%d' "$total"
 }
 
 echo "=== orch delegation worktree-cwd-precondition lint ==="
@@ -179,17 +148,11 @@ fi
 # counted on its own and an empty population in EITHER reds.
 for root in "$SOURCE_ROOT" "$RENDER_ROOT"; do
   label="${root#$REPO_ROOT/}"
-  sites="$(count_sites "$root")"
-  guarded="$(count_guarded "$root")"
-  if [ "$sites" -gt 0 ]; then
-    pass "$label: the scan read $sites delegated Worktree Check line(s)"
+  blocks="$(count_blocks "$root")"
+  if [ "$blocks" -gt 0 ]; then
+    pass "$label: the scan opened $blocks delegation block(s)"
   else
-    fail "$label: no Worktree Check lines found — the scan matched nothing to check"
-  fi
-  if [ "$guarded" -gt 0 ]; then
-    pass "$label: the scan read $guarded repo-relative delegation block(s) carrying the pair"
-  else
-    fail "$label: no repo-relative delegation blocks found — the repo-path rule matched nothing"
+    fail "$label: no delegation blocks found — the scan matched nothing to check"
   fi
 done
 
@@ -306,28 +269,13 @@ else
   fail "lint MISSED a remedy an absolute path cannot deliver"
 fi
 
-# b.13 — RULE 2. A block that hands over a repo-relative path with no
-# Worktree:/Worktree Check: pair IS flagged: the delegate runs that path
-# wherever its shell happens to be.
-if [ -n "$(scan_worktree_precondition "$(probe relpath 'Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md\n\nArguments: --project-order')" )" ]; then
-  pass "lint flags a delegation naming a repo-relative path with no Worktree pair"
+# b.13 — RULE 2. A block with no Worktree:/Worktree Check: pair at all IS
+# flagged, whatever it hands over: a placeholder the caller fills with a
+# repo path is invisible to any matcher, so no block is out of scope.
+if [ -n "$(scan_worktree_precondition "$(probe nopair 'Read: [RESEARCH_DOCS_PATH]/[ISSUE_ID]/findings.md\n\nArguments: --project-order')" )" ]; then
+  pass "lint flags a delegation carrying no Worktree pair"
 else
-  fail "lint MISSED a repo-relative delegation with no Worktree pair"
-fi
-
-# b.14 — the same block WITH the pair is not flagged.
-if [ -z "$(scan_worktree_precondition "$(probe relok "Follow workflow: .agents/skills/x/y.md\nWorktree: [WORKTREE_PATH]\n$CHECK")" )" ]; then
-  pass "lint accepts a repo-relative delegation carrying the pair"
-else
-  fail "lint false-flagged a repo-relative delegation that carries the pair"
-fi
-
-# b.15 — a block whose paths are ALL placeholders is out of scope: the
-# caller resolves them, and the lint cannot judge where they land.
-if [ -z "$(scan_worktree_precondition "$(probe placeholders 'Read: [RESEARCH_DOCS_PATH]/[ISSUE_ID]/findings.md\nWrite: [INPUT_FILE_PATH]')" )" ]; then
-  pass "lint ignores a delegation whose paths are all placeholders"
-else
-  fail "lint false-flagged a placeholder-only delegation"
+  fail "lint MISSED a delegation with no Worktree pair"
 fi
 
 # b.5 — a Worktree: mention outside a delegation block is NOT scanned.
@@ -355,8 +303,8 @@ fi
 # half and a render half, and a defect planted in EITHER half must red.
 TWO="$TMP_ROOT/two-trees"
 mkdir -p "$TWO/skills/x" "$TWO/.agents/skills/x"
-GOOD="Follow workflow: .agents/skills/x/y.md\nWorktree: [WORKTREE_PATH]\n$CHECK"
-BROKEN='Follow workflow: .agents/skills/x/y.md\nWorktree: [WORKTREE_PATH]'
+GOOD="Worktree: [WORKTREE_PATH]\n$CHECK"
+BROKEN='Worktree: [WORKTREE_PATH]'
 write_half() { printf '<delegation_format>\n%b\n</delegation_format>\n' "$2" > "$TWO/$1/x/y.md"; }
 
 # c.1 — control: both halves carry the check, nothing is flagged. Without
@@ -397,10 +345,10 @@ fi
 
 # c.5 — the real run reached both trees, so parts a and b judged the shipped
 # render and not just the source.
-if [ "$(count_sites "$SOURCE_ROOT")" -gt 0 ] && [ "$(count_sites "$RENDER_ROOT")" -gt 0 ]; then
+if [ "$(count_blocks "$SOURCE_ROOT")" -gt 0 ] && [ "$(count_blocks "$RENDER_ROOT")" -gt 0 ]; then
   pass "the shipped scan covered skills/ and .agents/skills/ alike"
 else
-  fail "one of the two shipped trees carried no Worktree Check line"
+  fail "one of the two shipped trees carried no delegation block"
 fi
 
 echo

--- a/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -130,7 +130,7 @@ CANON='Worktree Check: `pwd -P` before any repo-relative command. It must print 
 
 # The canonical fill line, verbatim. It carries no per-block token: `[DIR]`
 # is literal in every doc, so the whole line is compared as it stands.
-CANON_FILL='Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.'
+CANON_FILL='Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.'
 
 # scan_worktree_precondition <file>
 # Emits one "file:line: ..." line per defect, per the two rules above.

--- a/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -18,12 +18,12 @@
 # leaving the agent with nothing to run. A future wording change is made in
 # $CANON and at every site together, or the lint reds.
 #
-# Both sides of the comparison are physical paths. `git-context` derives
+# Both sides of the comparison are physical paths. The fill line derives
 # the delegated path with `git rev-parse --show-toplevel`, so the check
 # runs `pwd -P`: a bare `pwd` prints the logical path and would halt a
 # correct delegate whose shell entered the checkout through a symlink.
 #
-# Three rules are enforced:
+# Four rules are enforced:
 #
 #   1. A `Worktree: [TOKEN]` line is followed on the very next line by the
 #      canonical `Worktree Check:` line for that same TOKEN.
@@ -38,14 +38,29 @@
 #      nothing if the value poured into it is not what `pwd -P` prints, and
 #      the workflows resolved that value to `.` or to "the current
 #      directory", so a filled delegation halted in a CORRECT checkout. The
-#      fill line names `git-context repo-root`, whose `--show-toplevel`
-#      output is absolute and physical, so both sides of the comparison
-#      agree by construction. Per block, because a doc satisfying the rule
-#      once bought silence for every later block: the second block in
-#      audit-issues.md carried its own resolution, to an absolute LOGICAL
-#      path, and a file-wide assertion never read it. Rules 1 and 2 read
-#      inside a `<delegation_format>` block; rule 3 reads the lines between
-#      one block and the block before it.
+#      fill line names plain `git rev-parse --show-toplevel`, whose output
+#      is absolute and physical, so both sides of the comparison agree by
+#      construction. Plain, not an orch wrapper around it: the fill line
+#      also ships in project-management, which declares `git` and not orch,
+#      so a wrapper would not exist in an install carrying one skill and
+#      not the other — the placeholder would come out empty and the
+#      precondition would vanish with it. Per block, because a doc
+#      satisfying the rule once bought silence for every later block: the
+#      second block in audit-issues.md carried its own resolution, to an
+#      absolute LOGICAL path, and a file-wide assertion never read it.
+#   4. No line among those rule 3 reads opens with the fill line's opening
+#      clause and then diverges from it. A second instruction addressing
+#      the same two fields does not clear `hasfill`, so the canonical line
+#      plus a contradicting one read as clean. The rule is the DECIDABLE
+#      half of that: same opening clause, not byte-equal. It is not a
+#      conflict detector — prose that contradicts the fill line in its own
+#      words is not caught, and deciding that it does would be semantic
+#      judgment, which this repo has twice ruled out of a lexical scanner.
+#      Do not widen it; write a conflicting instruction in the canonical
+#      shape or leave the boundary where it is.
+#
+#      Rules 1 and 2 read inside a `<delegation_format>` block; rules 3
+#      and 4 read the lines between one block and the block before it.
 #
 # A block ends at three terminators, not one: its closing tag, a new opening
 # tag arriving while it is still open, and end of file. All three route
@@ -142,7 +157,15 @@ CANON='Worktree Check: `pwd -P` before any repo-relative command. It must print 
 
 # The canonical fill line, verbatim. It carries no per-block token: `[DIR]`
 # is literal in every doc, so the whole line is compared as it stands.
-CANON_FILL='Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.'
+CANON_FILL='Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.'
+
+# The fill line's opening clause: the part that names the two fields being
+# filled, before it says where the value comes from. A line opening with it
+# is addressing the same pair, so a byte difference after it is a second,
+# contradicting instruction. Held as its own literal and asserted a PROPER
+# prefix of $CANON_FILL by f.1 — rewording the sentence without rewording
+# this reds there, rather than leaving rule 4 matching nothing in silence.
+CANON_FILL_OPEN='Fill `Worktree:` and its `Worktree Check:`'
 
 # scan_worktree_precondition <file>
 # Emits one "file:line: ..." line per defect, per the two rules above.
@@ -208,8 +231,17 @@ scan_worktree_precondition() {
 # not preceded by. The function is a no-op outside a block, so a closed
 # block's successor keeps the lines read since. Malformed structure is
 # reported once, by scan_worktree_precondition.
+#
+# Rule 4 rides the same lines. `hasfill` is a latch — it is set and never
+# unset — so the canonical line followed by a divergent one still opens the
+# next block clean, and the delegating agent reads two instructions with no
+# ordering between them. A line opening with $CANON_FILL_OPEN and not equal
+# to $CANON_FILL is reported at its own line, whether or not the canonical
+# line also appears: same clause, different bytes, nothing semantic. Prose
+# contradicting the fill line in its own words is out of scope and stays
+# silent; see rule 4 in the header for why that boundary is where it is.
 scan_worktree_fill() {
-  awk -v f="$1" -v canon="$CANON_FILL" '
+  awk -v f="$1" -v canon="$CANON_FILL" -v open="$CANON_FILL_OPEN" '
     function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
     function close_block() { if (!indel) return; indel = 0; hasfill = 0 }
     /^[[:space:]]*<delegation_format>[[:space:]]*$/ {
@@ -219,7 +251,12 @@ scan_worktree_fill() {
       indel = 1; next
     }
     /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ { close_block(); next }
-    !indel { if (trim($0) == canon) hasfill = 1 }
+    !indel {
+      line = trim($0)
+      if (line == canon) hasfill = 1
+      else if (index(line, open) == 1)
+        printf "%s:%d: fill instruction opens like the canonical Worktree fill line and diverges from it (got: %s)\n", f, NR, line
+    }
     END { close_block() }
   ' "$1"
 }
@@ -677,6 +714,58 @@ if [ "$(scan_worktree_fill "$CARRIED")" = "$CARRIED:6: $NOFILL" ]; then
   pass "lint flags a block whose fill line was carried across an unclosed block"
 else
   fail "lint let an unclosed block carry its fill line to the next block"
+fi
+
+# --- Part f: a second instruction in the fill line's own shape ------------
+# RULE 4. `hasfill` latches, so a divergent instruction after the canonical
+# one leaves the block reading clean. Only the decidable half is caught:
+# same opening clause, different bytes. The probes pin both sides of that
+# boundary so the next reader does not take this for a conflict detector.
+
+# f.1 — the clause is a PROPER prefix of the sentence. Rule 4 matches by
+# `index(line, open) == 1`, so a clause reworded out of $CANON_FILL would
+# match nothing and the rule would go quiet without a single test failing;
+# a clause grown to the whole sentence would match only the canonical line
+# and do the same. This is the fixture that reds instead.
+case "$CANON_FILL" in
+  "$CANON_FILL_OPEN"*)
+    if [ "${#CANON_FILL_OPEN}" -lt "${#CANON_FILL}" ]; then
+      pass "the fill line's opening clause is a proper prefix of the canonical sentence"
+    else
+      fail "the opening clause is the whole canonical sentence — rule 4 matches only the canonical line"
+    fi
+    ;;
+  *) fail "the opening clause is not a prefix of \$CANON_FILL — rule 4 matches nothing" ;;
+esac
+
+CONFLICT_FILL='Fill `Worktree:` and its `Worktree Check:` with whichever directory this workflow is running in.'
+
+# f.2 — the canonical line, then a byte-different line in the same shape.
+# The block is preceded by the canonical sentence, so rule 3 is satisfied
+# and this output can come from nothing but rule 4. Compared whole, so the
+# probe fails if the scan names the wrong line as readily as if it names
+# none.
+CONFLICTED="$TMP_ROOT/probe-conflicting-fill.md"
+printf '%s\n\n%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' \
+  "$CANON_FILL" "$CONFLICT_FILL" "$CHECK" > "$CONFLICTED"
+DIVERGES='fill instruction opens like the canonical Worktree fill line and diverges from it'
+if [ "$(scan_worktree_fill "$CONFLICTED")" = "$CONFLICTED:3: $DIVERGES (got: $CONFLICT_FILL)" ]; then
+  pass "lint flags a second fill instruction that opens canonically and diverges"
+else
+  fail "lint MISSED a second fill instruction in the canonical shape"
+fi
+
+# f.3 — and the boundary from the other side: ordinary prose after the
+# canonical line, mentioning a path, is not an instruction in the fill
+# line's shape and stays clean. Without this the rule could be widened to
+# any line naming a directory and f.2 would still pass.
+NEARBY="$TMP_ROOT/probe-nearby-prose.md"
+printf '%s\n\nThe delegate writes its round artifact under `[DIR]/tmp`, which the collect step reads back.\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' \
+  "$CANON_FILL" "$CHECK" > "$NEARBY"
+if [ -z "$(scan_worktree_fill "$NEARBY")" ]; then
+  pass "lint leaves ordinary prose naming a path alone"
+else
+  fail "lint false-flagged prose that merely names a path"
 fi
 
 echo

--- a/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -5,11 +5,14 @@
 # and both noticed only after a confusing downstream failure.
 #
 # The cure is a precondition the agent runs before anything repo-relative,
-# and this lint holds it as ONE canonical sentence rather than as a set of
-# shape rules. Every shipped check line is byte-identical apart from the
-# block's own placeholder token, so the test carries that sentence in
-# $CANON with `@TOKEN@` where the token goes, and each site must equal it
-# with its own token substituted in. Equality is the whole predicate:
+# and it HALTS: a tool like `tools/guard` re-derives the repo from the
+# process cwd, so no path spelling makes a wrong-tree shell safe and there
+# is no remedy for the check to get right. This lint holds the precondition
+# as ONE canonical sentence rather than as a set of shape rules. Every
+# shipped check line is byte-identical apart from the block's own
+# placeholder token, so the test carries that sentence in $CANON with
+# `@TOKEN@` where the token goes, and each site must equal it with its own
+# token substituted in. Equality is the whole predicate:
 # nothing infers "opens with a command", "mentions pwd", or "names the
 # token", so no prose mutation can satisfy the letter of a heuristic while
 # leaving the agent with nothing to run. A future wording change is made in
@@ -25,14 +28,33 @@
 #      happens to be. A block whose paths are all placeholders is out of
 #      scope: the caller resolves those, and the lint cannot judge them.
 #
-# Scope is every skill doc that can carry a delegation, not one directory.
-# Tests are excluded: their probe fixtures carry deliberately broken
-# blocks. A `Worktree:` mention in prose or in a fenced example is not a
-# delegation and is not scanned.
+# Scope is every skill doc that can carry a delegation, in BOTH trees: the
+# `skills/` source and the `.agents/skills/` render agents actually load.
+# Deriving the scan root from this file's own location would leave each
+# copy scanning only its own half, and CI runs the source copy alone — the
+# render would ship unguarded with the suite green. Tests are excluded:
+# their probe fixtures carry deliberately broken blocks. A `Worktree:`
+# mention in prose or in a fenced example is not a delegation and is not
+# scanned.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SKILLS_ROOT="$(cd "$TEST_DIR/../.." && pwd)"
+
+# The nearest ancestor holding both trees. Walked, not counted in `../`,
+# so the source copy and the render copy resolve to the same repo root and
+# scan the same two directories.
+REPO_ROOT="$TEST_DIR"
+while [ "$REPO_ROOT" != "/" ]; do
+  if [ -d "$REPO_ROOT/skills" ] && [ -d "$REPO_ROOT/.agents/skills" ]; then break; fi
+  REPO_ROOT="$(dirname "$REPO_ROOT")"
+done
+if [ "$REPO_ROOT" = "/" ]; then
+  printf 'FAIL  no ancestor of %s holds both skills/ and .agents/skills/\n' "$TEST_DIR" >&2
+  exit 1
+fi
+SOURCE_ROOT="$REPO_ROOT/skills"
+RENDER_ROOT="$REPO_ROOT/.agents/skills"
+
 TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
@@ -45,7 +67,7 @@ fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 # The canonical check line, with @TOKEN@ standing in for the block's own
 # placeholder name. This is the single source of truth for the sentence;
 # the shipped docs must match it character for character.
-CANON='Worktree Check: `pwd` before any repo-relative command. It must print [@TOKEN@]; your shell can start in another lane'"'"'s worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [@TOKEN@], because a bare `cd` may not survive into the next tool call.'
+CANON='Worktree Check: `pwd` before any repo-relative command. It must print [@TOKEN@]; your shell can start in another lane'"'"'s worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.'
 
 # scan_worktree_precondition <file>
 # Emits one "file:line: ..." line per defect, per the two rules above.
@@ -103,46 +125,73 @@ count_guarded_relpath_blocks() {
   ' "$1"
 }
 
+# scan_trees <root>...
+# Emits every defect line found in every non-test *.md under the given
+# roots. A missing root is itself a defect: the caller asked for a tree
+# that is not there, and reporting nothing would read as clean.
+scan_trees() {
+  for root in "$@"; do
+    if [ ! -d "$root" ]; then
+      printf '%s: scan root does not exist\n' "$root"
+      continue
+    fi
+    find "$root" -name '*.md' -not -path '*/tests/*' | sort | while IFS= read -r doc; do
+      scan_worktree_precondition "$doc"
+    done
+  done
+}
+
+# count_sites <root> — shipped Worktree Check lines under one tree.
+count_sites() {
+  find "$1" -name '*.md' -not -path '*/tests/*' -exec grep -c '^[[:space:]]*Worktree Check:' {} + 2>/dev/null |
+    awk -F: '{ n += $NF } END { print n + 0 }'
+}
+
+# count_guarded <root> — guarded repo-relative blocks under one tree.
+count_guarded() {
+  total=0
+  while IFS= read -r doc; do
+    [ -n "$doc" ] || continue
+    total=$((total + $(count_guarded_relpath_blocks "$doc")))
+  done <<EOF
+$(find "$1" -name '*.md' -not -path '*/tests/*' | sort)
+EOF
+  printf '%d' "$total"
+}
+
 echo "=== orch delegation worktree-cwd-precondition lint ==="
 
 # --- Part a: every shipped delegation block carries the precondition -------
-# Every skill doc, not one skill's workflows: a delegation that hands over a
-# worktree is checked wherever it lives. Tests are excluded — their probe
-# fixtures carry deliberately broken blocks.
-DOCS="$(find "$SKILLS_ROOT" -name '*.md' -not -path '*/tests/*' | sort)"
-offenders=""
-sites=0
-guarded=0
-for doc in $DOCS; do
-  out="$(scan_worktree_precondition "$doc")"
-  [ -n "$out" ] && offenders="$offenders$out"$'\n'
-  n="$(grep -c '^[[:space:]]*Worktree Check:' "$doc" || true)"
-  sites=$((sites + n))
-  guarded=$((guarded + $(count_guarded_relpath_blocks "$doc")))
-done
+# Every skill doc in BOTH trees, not one skill's workflows and not the half
+# this copy of the test sits in: a delegation that hands over a worktree is
+# checked wherever it lives. Tests are excluded — their probe fixtures carry
+# deliberately broken blocks.
+offenders="$(scan_trees "$SOURCE_ROOT" "$RENDER_ROOT")"
 if [ -z "$offenders" ]; then
   pass "every delegated Worktree: line is followed by its canonical Worktree Check"
 else
   fail "delegation blocks missing the worktree cwd precondition:"
-  printf '%s' "$offenders" | sed 's/^/          /'
+  printf '%s\n' "$offenders" | sed 's/^/          /'
 fi
 
-# The precondition is worth nothing if no delegation carries it: a lint that
-# passes over zero sites is the vacuous case this asserts against.
-if [ "$sites" -gt 0 ]; then
-  pass "the scan read $sites delegated Worktree Check line(s)"
-else
-  fail "no Worktree Check lines found — the scan matched nothing to check"
-fi
-
-# The same guard for rule 2: with no shipped block naming a repo-relative
-# path, the repo-path rule passed over an empty population and proves
-# nothing.
-if [ "$guarded" -gt 0 ]; then
-  pass "the scan read $guarded repo-relative delegation block(s) carrying the pair"
-else
-  fail "no repo-relative delegation blocks found — the repo-path rule matched nothing"
-fi
+# The precondition is worth nothing if no delegation carries it, and one
+# tree going missing is the same vacuity a level up — so each tree is
+# counted on its own and an empty population in EITHER reds.
+for root in "$SOURCE_ROOT" "$RENDER_ROOT"; do
+  label="${root#$REPO_ROOT/}"
+  sites="$(count_sites "$root")"
+  guarded="$(count_guarded "$root")"
+  if [ "$sites" -gt 0 ]; then
+    pass "$label: the scan read $sites delegated Worktree Check line(s)"
+  else
+    fail "$label: no Worktree Check lines found — the scan matched nothing to check"
+  fi
+  if [ "$guarded" -gt 0 ]; then
+    pass "$label: the scan read $guarded repo-relative delegation block(s) carrying the pair"
+  else
+    fail "$label: no repo-relative delegation blocks found — the repo-path rule matched nothing"
+  fi
+done
 
 # --- Part b: the lint has teeth -------------------------------------------
 
@@ -245,6 +294,18 @@ else
   fail "lint MISSED a remedy resting on a cd that may not persist"
 fi
 
+# b.16 — nor on an absolute path. `tools/guard` re-derives the repo from
+# the process cwd on its own first line, so the path it is invoked by never
+# reaches that decision and a wrong-tree shell still judges the wrong lane.
+# The canonical sentence halts instead, and any remedy written in its place
+# reds.
+ABS_REMEDY='Worktree: [WORKTREE_PATH]\nWorktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]. Any other path — give every later command an absolute path under [WORKTREE_PATH].'
+if [ -n "$(scan_worktree_precondition "$(probe absremedy "$ABS_REMEDY")" )" ]; then
+  pass "lint flags a remedy resting on an absolute path"
+else
+  fail "lint MISSED a remedy an absolute path cannot deliver"
+fi
+
 # b.13 — RULE 2. A block that hands over a repo-relative path with no
 # Worktree:/Worktree Check: pair IS flagged: the delegate runs that path
 # wherever its shell happens to be.
@@ -284,6 +345,62 @@ if [ -n "$(scan_worktree_precondition "$(probe indented '   Worktree: [WORKTREE_
   pass "lint scans an indented delegation block"
 else
   fail "lint MISSED a bare Worktree: line inside an indented block"
+fi
+
+# --- Part c: both trees are actually scanned ------------------------------
+# A scan root derived from this file's own location would give the source
+# copy only skills/ and the render copy only .agents/skills/, and CI runs
+# the source copy alone — a check deleted from the render would ship with
+# the suite green. The fixture below is a repo root in miniature, a source
+# half and a render half, and a defect planted in EITHER half must red.
+TWO="$TMP_ROOT/two-trees"
+mkdir -p "$TWO/skills/x" "$TWO/.agents/skills/x"
+GOOD="Follow workflow: .agents/skills/x/y.md\nWorktree: [WORKTREE_PATH]\n$CHECK"
+BROKEN='Follow workflow: .agents/skills/x/y.md\nWorktree: [WORKTREE_PATH]'
+write_half() { printf '<delegation_format>\n%b\n</delegation_format>\n' "$2" > "$TWO/$1/x/y.md"; }
+
+# c.1 — control: both halves carry the check, nothing is flagged. Without
+# this the two probes below could red for any reason at all.
+write_half skills "$GOOD"
+write_half .agents/skills "$GOOD"
+if [ -z "$(scan_trees "$TWO/skills" "$TWO/.agents/skills")" ]; then
+  pass "two-tree scan is clean when both halves carry the check"
+else
+  fail "two-tree scan false-flagged two correct halves"
+fi
+
+# c.2 — the render half loses its check. This is the case a source-rooted
+# scan cannot see: the tree agents load, unguarded, with CI passing.
+write_half .agents/skills "$BROKEN"
+if [ -n "$(scan_trees "$TWO/skills" "$TWO/.agents/skills")" ]; then
+  pass "two-tree scan reds on a check deleted from the render half"
+else
+  fail "two-tree scan MISSED a check deleted from the render half"
+fi
+
+# c.3 — and symmetrically, the source half.
+write_half .agents/skills "$GOOD"
+write_half skills "$BROKEN"
+if [ -n "$(scan_trees "$TWO/skills" "$TWO/.agents/skills")" ]; then
+  pass "two-tree scan reds on a check deleted from the source half"
+else
+  fail "two-tree scan MISSED a check deleted from the source half"
+fi
+
+# c.4 — a root that is not there is reported, not passed over. A renamed or
+# unrendered tree would otherwise contribute zero defects and read as clean.
+if [ -n "$(scan_trees "$TWO/skills" "$TWO/nonexistent")" ]; then
+  pass "two-tree scan reds on a missing scan root"
+else
+  fail "two-tree scan MISSED a missing scan root"
+fi
+
+# c.5 — the real run reached both trees, so parts a and b judged the shipped
+# render and not just the source.
+if [ "$(count_sites "$SOURCE_ROOT")" -gt 0 ] && [ "$(count_sites "$RENDER_ROOT")" -gt 0 ]; then
+  pass "the shipped scan covered skills/ and .agents/skills/ alike"
+else
+  fail "one of the two shipped trees carried no Worktree Check line"
 fi
 
 echo

--- a/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -169,9 +169,20 @@ probe() {
 
 CHECK="${CANON//@TOKEN@/WORKTREE_PATH}"
 
+# reports <scan output> <fragment> — the scan named THIS defect, not merely
+# some defect. Rule 2 fires on every block rule 1 failed to see, so a probe
+# asserting bare non-emptiness stays green when the rule it is named for stops
+# working. Each probe below names the message it must draw: rule 1 on a wrong
+# line after the pair, rule 1 on a block ending at the Worktree: line, rule 2
+# on a block carrying no pair.
+reports() { case "$1" in *"$2"*) return 0 ;; *) return 1 ;; esac; }
+UNCANON='after Worktree: [WORKTREE_PATH] is not the canonical Worktree Check'
+UNCLOSED='Worktree: [WORKTREE_PATH] ends the delegation with no Worktree Check line'
+NOPAIR='delegation carries no Worktree:/Worktree Check: pair'
+
 # b.1 — the reported shape (a bare Worktree: line, as every site read before
 # this change) IS flagged.
-if [ -n "$(scan_worktree_precondition "$(probe bare 'Issue: [ISSUE_ID]\nWorktree: [WORKTREE_PATH]\nRound ID: [DEV_ROUND_ID]')" )" ]; then
+if reports "$(scan_worktree_precondition "$(probe bare 'Issue: [ISSUE_ID]\nWorktree: [WORKTREE_PATH]\nRound ID: [DEV_ROUND_ID]')")" "$UNCANON"; then
   pass "lint flags a Worktree: line with no Worktree Check"
 else
   fail "lint MISSED a bare Worktree: line (no teeth)"
@@ -186,14 +197,14 @@ fi
 
 # b.3 — a check naming a DIFFERENT placeholder IS flagged: a filled
 # delegation would compare pwd against a path this block never carries.
-if [ -n "$(scan_worktree_precondition "$(probe crossed "Worktree: [WT_PATH]\n$CHECK")" )" ]; then
+if reports "$(scan_worktree_precondition "$(probe crossed "Worktree: [WT_PATH]\n$CHECK")")" 'after Worktree: [WT_PATH] is not the canonical Worktree Check'; then
   pass "lint flags a Worktree Check naming the wrong placeholder"
 else
   fail "lint MISSED a cross-wired placeholder"
 fi
 
 # b.4 — a Worktree: line ending the block with no check IS flagged.
-if [ -n "$(scan_worktree_precondition "$(probe last 'Branch: [BRANCH]\nWorktree: [WORKTREE_PATH]')" )" ]; then
+if reports "$(scan_worktree_precondition "$(probe last 'Branch: [BRANCH]\nWorktree: [WORKTREE_PATH]')")" "$UNCLOSED"; then
   pass "lint flags a Worktree: line that closes the delegation"
 else
   fail "lint MISSED a trailing Worktree: line"
@@ -204,7 +215,7 @@ fi
 # so a placeholder check and an anywhere-on-the-line `pwd` check both pass
 # it. Equality does not.
 MUTANT='Worktree: [WORKTREE_PATH]\nWorktree Check: trust the path. It must print [WORKTREE_PATH]; a bare `git status` answers about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.'
-if [ -n "$(scan_worktree_precondition "$(probe mutant "$MUTANT")" )" ]; then
+if reports "$(scan_worktree_precondition "$(probe mutant "$MUTANT")")" "$UNCANON"; then
   pass "lint flags a check whose leading command was replaced by prose"
 else
   fail "lint MISSED a check that runs nothing"
@@ -214,7 +225,7 @@ fi
 # span on the line IS `pwd`, so an unanchored shape match accepts a check
 # that demotes the command to optional.
 DEMOTED='Worktree: [WORKTREE_PATH]\nWorktree Check: trust the path; optional check: `pwd` must print [WORKTREE_PATH].'
-if [ -n "$(scan_worktree_precondition "$(probe demoted "$DEMOTED")" )" ]; then
+if reports "$(scan_worktree_precondition "$(probe demoted "$DEMOTED")")" "$UNCANON"; then
   pass "lint flags a check whose pwd sits behind leading prose"
 else
   fail "lint MISSED a backticked pwd demoted behind prose"
@@ -225,7 +236,7 @@ fi
 # what it just measured. Every shape heuristic passes this; equality is the
 # only predicate that does not.
 UNBOUND='Worktree: [WORKTREE_PATH]\nWorktree Check: `pwd` before any repo-relative command. Ignore [WORKTREE_PATH].'
-if [ -n "$(scan_worktree_precondition "$(probe unbound "$UNBOUND")" )" ]; then
+if reports "$(scan_worktree_precondition "$(probe unbound "$UNBOUND")")" "$UNCANON"; then
   pass "lint flags a check whose pwd and placeholder are unbound"
 else
   fail "lint MISSED an unbound pwd and placeholder"
@@ -233,7 +244,7 @@ fi
 
 # b.8 — a check opening with the WRONG command is flagged. `pwd` has to be
 # the first executable step; a different command does not report the cwd.
-if [ -n "$(scan_worktree_precondition "$(probe wrongcmd 'Worktree: [WORKTREE_PATH]\nWorktree Check: `git status` before any repo-relative command. It must print [WORKTREE_PATH].')" )" ]; then
+if reports "$(scan_worktree_precondition "$(probe wrongcmd 'Worktree: [WORKTREE_PATH]\nWorktree Check: `git status` before any repo-relative command. It must print [WORKTREE_PATH].')")" "$UNCANON"; then
   pass "lint flags a check opening with a command other than pwd"
 else
   fail "lint MISSED a check opening with the wrong command"
@@ -241,7 +252,7 @@ fi
 
 # b.9 — an unbackticked mention is not a command. Without the code span
 # there is nothing marked for the agent to run.
-if [ -n "$(scan_worktree_precondition "$(probe unmarked 'Worktree: [WORKTREE_PATH]\nWorktree Check: run pwd before any repo-relative command. It must print [WORKTREE_PATH].')" )" ]; then
+if reports "$(scan_worktree_precondition "$(probe unmarked 'Worktree: [WORKTREE_PATH]\nWorktree Check: run pwd before any repo-relative command. It must print [WORKTREE_PATH].')")" "$UNCANON"; then
   pass "lint flags a check whose pwd is not a marked command"
 else
   fail "lint MISSED an unbackticked pwd"
@@ -251,7 +262,7 @@ fi
 # spawns a fresh shell per tool call drops it, and the agent resumes
 # repo-relative work in the wrong tree believing it recovered.
 STALE_CD='Worktree: [WORKTREE_PATH]\nWorktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.'
-if [ -n "$(scan_worktree_precondition "$(probe stalecd "$STALE_CD")" )" ]; then
+if reports "$(scan_worktree_precondition "$(probe stalecd "$STALE_CD")")" "$UNCANON"; then
   pass "lint flags a check whose remedy is a bare cd"
 else
   fail "lint MISSED a remedy resting on a cd that may not persist"
@@ -263,7 +274,7 @@ fi
 # The canonical sentence halts instead, and any remedy written in its place
 # reds.
 ABS_REMEDY='Worktree: [WORKTREE_PATH]\nWorktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]. Any other path — give every later command an absolute path under [WORKTREE_PATH].'
-if [ -n "$(scan_worktree_precondition "$(probe absremedy "$ABS_REMEDY")" )" ]; then
+if reports "$(scan_worktree_precondition "$(probe absremedy "$ABS_REMEDY")")" "$UNCANON"; then
   pass "lint flags a remedy resting on an absolute path"
 else
   fail "lint MISSED a remedy an absolute path cannot deliver"
@@ -272,7 +283,7 @@ fi
 # b.13 — RULE 2. A block with no Worktree:/Worktree Check: pair at all IS
 # flagged, whatever it hands over: a placeholder the caller fills with a
 # repo path is invisible to any matcher, so no block is out of scope.
-if [ -n "$(scan_worktree_precondition "$(probe nopair 'Read: [RESEARCH_DOCS_PATH]/[ISSUE_ID]/findings.md\n\nArguments: --project-order')" )" ]; then
+if reports "$(scan_worktree_precondition "$(probe nopair 'Read: [RESEARCH_DOCS_PATH]/[ISSUE_ID]/findings.md\n\nArguments: --project-order')")" "$NOPAIR"; then
   pass "lint flags a delegation carrying no Worktree pair"
 else
   fail "lint MISSED a delegation with no Worktree pair"
@@ -288,11 +299,13 @@ else
 fi
 
 # b.6 — an indented delegation block (dev-fix.md nests one in a numbered
-# step) is scanned, not skipped for its leading whitespace.
-if [ -n "$(scan_worktree_precondition "$(probe indented '   Worktree: [WORKTREE_PATH]\n   Round ID: [DEV_ROUND_ID]')" )" ]; then
+# step) is scanned, not skipped for its leading whitespace. Rule 2 flags this
+# same fixture the moment the indent tolerance breaks, so the assertion names
+# rule 1's message. The indent stays in the fixture; it is the thing tested.
+if reports "$(scan_worktree_precondition "$(probe indented '   Worktree: [WORKTREE_PATH]\n   Round ID: [DEV_ROUND_ID]')")" "$UNCANON"; then
   pass "lint scans an indented delegation block"
 else
-  fail "lint MISSED a bare Worktree: line inside an indented block"
+  fail "rule 1 MISSED an indented Worktree: line"
 fi
 
 # --- Part c: both trees are actually scanned ------------------------------
@@ -320,7 +333,7 @@ fi
 # c.2 — the render half loses its check. This is the case a source-rooted
 # scan cannot see: the tree agents load, unguarded, with CI passing.
 write_half .agents/skills "$BROKEN"
-if [ -n "$(scan_trees "$TWO/skills" "$TWO/.agents/skills")" ]; then
+if reports "$(scan_trees "$TWO/skills" "$TWO/.agents/skills")" "$TWO/.agents/skills/x/y.md"; then
   pass "two-tree scan reds on a check deleted from the render half"
 else
   fail "two-tree scan MISSED a check deleted from the render half"
@@ -329,7 +342,7 @@ fi
 # c.3 — and symmetrically, the source half.
 write_half .agents/skills "$GOOD"
 write_half skills "$BROKEN"
-if [ -n "$(scan_trees "$TWO/skills" "$TWO/.agents/skills")" ]; then
+if reports "$(scan_trees "$TWO/skills" "$TWO/.agents/skills")" "$TWO/skills/x/y.md"; then
   pass "two-tree scan reds on a check deleted from the source half"
 else
   fail "two-tree scan MISSED a check deleted from the source half"
@@ -337,7 +350,7 @@ fi
 
 # c.4 — a root that is not there is reported, not passed over. A renamed or
 # unrendered tree would otherwise contribute zero defects and read as clean.
-if [ -n "$(scan_trees "$TWO/skills" "$TWO/nonexistent")" ]; then
+if reports "$(scan_trees "$TWO/skills" "$TWO/nonexistent")" "$TWO/nonexistent: scan root does not exist"; then
   pass "two-tree scan reds on a missing scan root"
 else
   fail "two-tree scan MISSED a missing scan root"

--- a/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -47,6 +47,14 @@
 #      inside a `<delegation_format>` block; rule 3 reads the lines between
 #      one block and the block before it.
 #
+# A block ends at three terminators, not one: its closing tag, a new opening
+# tag arriving while it is still open, and end of file. All three route
+# through one `close_block`, so no rule is reachable only through a
+# well-formed block — deleting a closing tag along with the pair used to
+# leave the delegation unscanned and the suite green. An unterminated block
+# is itself reported, naming the opener's line, so a reader sees that the
+# document is malformed and not only that a pair is missing.
+#
 # Scope is every skill doc that can carry a delegation, in BOTH trees where
 # both exist: the `skills/` source and the `.agents/skills/` render agents
 # actually load. Deriving the scan root from this file's own location would
@@ -139,16 +147,29 @@ CANON_FILL='Fill `Worktree:` and its `Worktree Check:` from `git-context repo-ro
 # scan_worktree_precondition <file>
 # Emits one "file:line: ..." line per defect, per the two rules above.
 # Lines outside a delegation block are never scanned.
+#
+# Every rule that judges a whole block lives in `close_block`, and all three
+# terminators call it: the closing tag, a new opening tag, and END. Writing
+# them at the closing tag alone was the fail-open — a block missing that tag
+# escaped both rules, so deleting the pair and the tag together shipped an
+# unguarded delegation with the suite green. `reason` is empty for the one
+# terminator that is well formed; the other two also report the block itself.
 scan_worktree_precondition() {
   awk -v f="$1" -v canon="$CANON" '
     function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+    function close_block(reason) {
+      if (!indel) return
+      if (reason != "") printf "%s:%d: delegation block is never closed (%s)\n", f, delline, reason
+      if (pending) printf "%s:%d: Worktree: [%s] ends the delegation with no Worktree Check line\n", f, pendline, token
+      if (!haswt) printf "%s:%d: delegation carries no Worktree:/Worktree Check: pair\n", f, delline
+      indel = 0; pending = 0; haswt = 0
+    }
     /^[[:space:]]*<delegation_format>[[:space:]]*$/ {
+      close_block("a new <delegation_format> opens at line " NR)
       indel = 1; pending = 0; haswt = 0; delline = NR; next
     }
     /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ {
-      if (pending) printf "%s:%d: Worktree: [%s] ends the delegation with no Worktree Check line\n", f, pendline, token
-      if (indel && !haswt) printf "%s:%d: delegation carries no Worktree:/Worktree Check: pair\n", f, delline
-      indel = 0; pending = 0; next
+      close_block(""); next
     }
     indel {
       if (pending) {
@@ -166,6 +187,7 @@ scan_worktree_precondition() {
         token = line; pendline = NR; pending = 1; haswt = 1
       }
     }
+    END { close_block("reached end of file") }
   ' "$1"
 }
 
@@ -175,20 +197,30 @@ scan_worktree_precondition() {
 # canonical resolution once and a divergent one before a later block passed a
 # file-wide assertion, and the later block is the one that poured a logical
 # path into a `pwd -P` comparison. So the demand is raised at every opening
-# tag and the evidence is cleared at every closing tag — each block is asked
+# tag and the evidence is cleared at every terminator — each block is asked
 # for the sentence again, in the lines between it and the block before it.
 # Equality against $CANON_FILL is the whole predicate, so a resolution
 # reworded back to `.` or to the current directory reds.
+#
+# The clearing routes through one `close_block` for the same reason as the
+# scanner above: clearing at the closing tag alone let an unterminated block
+# carry its evidence forward, and the next block passed on a fill line it is
+# not preceded by. The function is a no-op outside a block, so a closed
+# block's successor keeps the lines read since. Malformed structure is
+# reported once, by scan_worktree_precondition.
 scan_worktree_fill() {
   awk -v f="$1" -v canon="$CANON_FILL" '
     function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+    function close_block() { if (!indel) return; indel = 0; hasfill = 0 }
     /^[[:space:]]*<delegation_format>[[:space:]]*$/ {
+      close_block()
       if (!hasfill)
         printf "%s:%d: delegation block is not preceded by the canonical Worktree fill line\n", f, NR
       indel = 1; next
     }
-    /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ { indel = 0; hasfill = 0; next }
+    /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ { close_block(); next }
     !indel { if (trim($0) == canon) hasfill = 1 }
+    END { close_block() }
   ' "$1"
 }
 
@@ -398,6 +430,33 @@ else
   fail "lint MISSED a delegation with no Worktree pair"
 fi
 
+# b.14 — RULE 2 THROUGH THE END-OF-FILE TERMINATOR. Codex's mutation: the
+# pair and the closing tag deleted together, the fill line kept so rule 3 is
+# satisfied at the opener. With the block rules written at the closing tag
+# alone, this shipped a delegation carrying no precondition at all and the
+# suite stayed green. The output is compared whole, so the probe fails if the
+# scan names the wrong line as readily as if it names none.
+EOFOPEN="$TMP_ROOT/probe-eof-open.md"
+printf '<delegation_format>\nRead: [RESEARCH_DOCS_PATH]/findings.md\nArguments: --project-order\n' > "$EOFOPEN"
+if [ "$(scan_worktree_precondition "$EOFOPEN")" = "$EOFOPEN:1: delegation block is never closed (reached end of file)
+$EOFOPEN:1: $NOPAIR" ]; then
+  pass "lint reds on a delegation block left open at end of file"
+else
+  fail "lint MISSED a delegation block left open at end of file"
+fi
+
+# b.15 — and through the other terminator: the closing tag replaced by the
+# next opening tag. The second block is well formed, so nothing but the
+# first block's own rules can produce this output.
+NEXTOPEN="$TMP_ROOT/probe-next-open.md"
+printf '<delegation_format>\nRead: [RESEARCH_DOCS_PATH]/findings.md\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' "$CHECK" > "$NEXTOPEN"
+if [ "$(scan_worktree_precondition "$NEXTOPEN")" = "$NEXTOPEN:1: delegation block is never closed (a new <delegation_format> opens at line 3)
+$NEXTOPEN:1: $NOPAIR" ]; then
+  pass "lint reds on a block whose closing tag is replaced by the next opener"
+else
+  fail "lint MISSED a block whose closing tag is replaced by the next opener"
+fi
+
 # b.5 — a Worktree: mention outside a delegation block is NOT scanned.
 PROSE="$TMP_ROOT/probe-prose.md"
 printf 'Fill the delegation Worktree: [WORKTREE_PATH] from the claim output, per .agents/skills/orch/SKILL.md.\n' > "$PROSE"
@@ -604,6 +663,20 @@ if [ -z "$(scan_worktree_fill "$BOTHFILLED")" ]; then
   pass "lint accepts a doc whose every block carries the canonical fill line"
 else
   fail "lint false-flagged a doc filling both its blocks canonically"
+fi
+
+# e.8 — RULE 3 THROUGH THE SAME TERMINATOR. The first block carries the
+# canonical fill line and is never closed; the second is preceded by nothing
+# but the first block's body. Clearing the evidence at the closing tag alone
+# carried it across and the second block passed on a sentence it does not
+# follow. Compared whole: naming the first block instead would be wrong.
+CARRIED="$TMP_ROOT/probe-carried-fill.md"
+printf '%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' \
+  "$CANON_FILL" "$CHECK" "$CHECK" > "$CARRIED"
+if [ "$(scan_worktree_fill "$CARRIED")" = "$CARRIED:6: $NOFILL" ]; then
+  pass "lint flags a block whose fill line was carried across an unclosed block"
+else
+  fail "lint let an unclosed block carry its fill line to the next block"
 fi
 
 echo

--- a/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -23,7 +23,7 @@
 # runs `pwd -P`: a bare `pwd` prints the logical path and would halt a
 # correct delegate whose shell entered the checkout through a symlink.
 #
-# Two rules are enforced inside a `<delegation_format>` block:
+# Three rules are enforced:
 #
 #   1. A `Worktree: [TOKEN]` line is followed on the very next line by the
 #      canonical `Worktree Check:` line for that same TOKEN.
@@ -33,33 +33,86 @@
 #      then missed blocks whose paths are placeholders the caller fills.
 #      The pair costs two lines on a delegation that never touches the
 #      repo, and uniform is the only rule that cannot be wrong.
+#   3. A doc carrying a block also carries the canonical fill line, held in
+#      $CANON_FILL by the same equality predicate. The pair is worth
+#      nothing if the value poured into it is not what `pwd -P` prints, and
+#      the workflows resolved that value to `.` or to "the current
+#      directory", so a filled delegation halted in a CORRECT checkout. The
+#      fill line names `git-context repo-root`, whose `--show-toplevel`
+#      output is absolute and physical, so both sides of the comparison
+#      agree by construction. Rules 1 and 2 read inside a
+#      `<delegation_format>` block; rule 3 reads the doc around it.
 #
-# Scope is every skill doc that can carry a delegation, in BOTH trees: the
-# `skills/` source and the `.agents/skills/` render agents actually load.
-# Deriving the scan root from this file's own location would leave each
-# copy scanning only its own half, and CI runs the source copy alone — the
-# render would ship unguarded with the suite green. Tests are excluded:
+# Scope is every skill doc that can carry a delegation, in BOTH trees where
+# both exist: the `skills/` source and the `.agents/skills/` render agents
+# actually load. Deriving the scan root from this file's own location would
+# leave each copy scanning only its own half, and CI runs the source copy
+# alone, so the render would ship unguarded with the suite green. An
+# INSTALLED layout has no `skills/` at all (the CLI integration check runs
+# this suite from `.agents/skills/orch/tests/`); there the lint scans the
+# one tree it has and names that mode in its output, so no reader mistakes
+# an installed run for a full one. A `skills/` tree whose render is missing
+# is a defect, not an installed layout, and stays red. Tests are excluded:
 # their probe fixtures carry deliberately broken blocks. A `Worktree:`
 # mention in prose or in a fenced example is not a delegation and is not
 # scanned.
 set -euo pipefail
 
-TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
-# The nearest ancestor holding both trees. Walked, not counted in `../`,
-# so the source copy and the render copy resolve to the same repo root and
-# scan the same two directories.
-REPO_ROOT="$TEST_DIR"
-while [ "$REPO_ROOT" != "/" ]; do
-  if [ -d "$REPO_ROOT/skills" ] && [ -d "$REPO_ROOT/.agents/skills" ]; then break; fi
-  REPO_ROOT="$(dirname "$REPO_ROOT")"
-done
-if [ "$REPO_ROOT" = "/" ]; then
-  printf 'FAIL  no ancestor of %s holds both skills/ and .agents/skills/\n' "$TEST_DIR" >&2
+# resolve_roots <start_dir>
+# Prints "<mode> <root>" for the layout above <start_dir>, or a diagnostic
+# and returns 1. Walked, not counted in `../`, so the source copy and the
+# render copy resolve to the same root and scan the same directories.
+#
+# The walk anchors on `.agents/skills`, never on a bare directory named
+# `skills`: a render tree's own parent holds one, so a search for that name
+# alone matches inside the render and would read an installed tree as a
+# source checkout. Once the render root is known, `skills/` beside it
+# decides the mode. A tree holding `skills/` and no render reaches neither
+# arm and fails, which is what keeps a missing render a defect.
+resolve_roots() {
+  local start dir render_root="" src_root=""
+  start="$(cd "$1" && pwd -P)"
+  dir="$start"
+  while [ "$dir" != "/" ]; do
+    if [ -d "$dir/.agents/skills" ]; then render_root="$dir"; break; fi
+    dir="$(dirname "$dir")"
+  done
+  if [ -n "$render_root" ]; then
+    if [ -d "$render_root/skills" ]; then
+      printf 'both %s\n' "$render_root"
+    else
+      printf 'installed %s\n' "$render_root"
+    fi
+    return 0
+  fi
+  dir="$start"
+  while [ "$dir" != "/" ]; do
+    if [ -d "$dir/skills" ]; then src_root="$dir"; break; fi
+    dir="$(dirname "$dir")"
+  done
+  if [ -n "$src_root" ]; then
+    printf '%s holds skills/ but no .agents/skills/ render beside it\n' "$src_root"
+    return 1
+  fi
+  printf 'no ancestor of %s holds .agents/skills/\n' "$start"
+  return 1
+}
+
+if ! RESOLVED="$(resolve_roots "$TEST_DIR")"; then
+  printf 'FAIL  %s\n' "$RESOLVED" >&2
   exit 1
 fi
+MODE="${RESOLVED%% *}"
+REPO_ROOT="${RESOLVED#* }"
 SOURCE_ROOT="$REPO_ROOT/skills"
 RENDER_ROOT="$REPO_ROOT/.agents/skills"
+if [ "$MODE" = both ]; then
+  SCAN_ROOTS=("$SOURCE_ROOT" "$RENDER_ROOT")
+else
+  SCAN_ROOTS=("$RENDER_ROOT")
+fi
 
 TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
@@ -74,6 +127,10 @@ fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 # placeholder name. This is the single source of truth for the sentence;
 # the shipped docs must match it character for character.
 CANON='Worktree Check: `pwd -P` before any repo-relative command. It must print [@TOKEN@]; your shell can start in another lane'"'"'s worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.'
+
+# The canonical fill line, verbatim. It carries no per-block token: `[DIR]`
+# is literal in every doc, so the whole line is compared as it stands.
+CANON_FILL='Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.'
 
 # scan_worktree_precondition <file>
 # Emits one "file:line: ..." line per defect, per the two rules above.
@@ -108,6 +165,24 @@ scan_worktree_precondition() {
   ' "$1"
 }
 
+# scan_worktree_fill <file>
+# Emits one defect line when a doc opens a delegation block but never states,
+# outside every block, that the delegated path comes from `git-context
+# repo-root`. Equality against $CANON_FILL is the whole predicate, so a
+# resolution reworded back to `.` or to the current directory reds.
+scan_worktree_fill() {
+  awk -v f="$1" -v canon="$CANON_FILL" '
+    function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+    /^[[:space:]]*<delegation_format>[[:space:]]*$/ { indel = 1; hasblock = 1; next }
+    /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ { indel = 0; next }
+    !indel { if (trim($0) == canon) hasfill = 1 }
+    END {
+      if (hasblock && !hasfill)
+        printf "%s: carries a delegation block but no canonical Worktree fill line\n", f
+    }
+  ' "$1"
+}
+
 # scan_trees <root>...
 # Emits every defect line found in every non-test *.md under the given
 # roots. A missing root is itself a defect: the caller asked for a tree
@@ -120,6 +195,7 @@ scan_trees() {
     fi
     find "$root" -name '*.md' -not -path '*/tests/*' | sort | while IFS= read -r doc; do
       scan_worktree_precondition "$doc"
+      scan_worktree_fill "$doc"
     done
   done
 }
@@ -134,13 +210,18 @@ count_blocks() {
 }
 
 echo "=== orch delegation worktree-cwd-precondition lint ==="
+if [ "$MODE" = both ]; then
+  printf 'mode: source checkout, scanning skills/ and .agents/skills/ under %s\n' "$REPO_ROOT"
+else
+  printf 'mode: INSTALLED layout, scanning .agents/skills/ only under %s (no skills/ tree)\n' "$REPO_ROOT"
+fi
 
 # --- Part a: every shipped delegation block carries the precondition -------
 # Every skill doc in BOTH trees, not one skill's workflows and not the half
 # this copy of the test sits in: a delegation that hands over a worktree is
 # checked wherever it lives. Tests are excluded — their probe fixtures carry
 # deliberately broken blocks.
-offenders="$(scan_trees "$SOURCE_ROOT" "$RENDER_ROOT")"
+offenders="$(scan_trees "${SCAN_ROOTS[@]}")"
 if [ -z "$offenders" ]; then
   pass "every delegated Worktree: line is followed by its canonical Worktree Check"
 else
@@ -151,7 +232,7 @@ fi
 # The precondition is worth nothing if no delegation carries it, and one
 # tree going missing is the same vacuity a level up — so each tree is
 # counted on its own and an empty population in EITHER reds.
-for root in "$SOURCE_ROOT" "$RENDER_ROOT"; do
+for root in "${SCAN_ROOTS[@]}"; do
   label="${root#$REPO_ROOT/}"
   blocks="$(count_blocks "$root")"
   if [ "$blocks" -gt 0 ]; then
@@ -343,7 +424,7 @@ TWO="$TMP_ROOT/two-trees"
 mkdir -p "$TWO/skills/x" "$TWO/.agents/skills/x"
 GOOD="Worktree: [WORKTREE_PATH]\n$CHECK"
 BROKEN='Worktree: [WORKTREE_PATH]'
-write_half() { printf '<delegation_format>\n%b\n</delegation_format>\n' "$2" > "$TWO/$1/x/y.md"; }
+write_half() { printf '%s\n\n<delegation_format>\n%b\n</delegation_format>\n' "$CANON_FILL" "$2" > "$TWO/$1/x/y.md"; }
 
 # c.1 — control: both halves carry the check, nothing is flagged. Without
 # this the two probes below could red for any reason at all.
@@ -381,12 +462,107 @@ else
   fail "two-tree scan MISSED a missing scan root"
 fi
 
-# c.5 — the real run reached both trees, so parts a and b judged the shipped
-# render and not just the source.
-if [ "$(count_blocks "$SOURCE_ROOT")" -gt 0 ] && [ "$(count_blocks "$RENDER_ROOT")" -gt 0 ]; then
-  pass "the shipped scan covered skills/ and .agents/skills/ alike"
+# c.5 — the real run reached every tree its mode names, so parts a and b
+# judged the shipped render and not just the source.
+if [ "$MODE" = both ]; then
+  if [ "$(count_blocks "$SOURCE_ROOT")" -gt 0 ] && [ "$(count_blocks "$RENDER_ROOT")" -gt 0 ]; then
+    pass "the shipped scan covered skills/ and .agents/skills/ alike"
+  else
+    fail "one of the two shipped trees carried no delegation block"
+  fi
 else
-  fail "one of the two shipped trees carried no delegation block"
+  if [ "$(count_blocks "$RENDER_ROOT")" -gt 0 ]; then
+    pass "installed layout: the shipped scan covered .agents/skills/"
+  else
+    fail "installed layout: .agents/skills/ carried no delegation block"
+  fi
+fi
+
+# --- Part d: the scan root resolves to the layout it is actually in --------
+# Three layouts stay distinct. Two trees is the source checkout and the CI
+# path. One tree is the installed layout the CLI integration check runs this
+# suite from, where no top-level skills/ exists. A skills/ tree whose render
+# is missing is neither: it is the fail-open this lint was tightened to
+# catch, and it must stay red rather than degrade to a one-tree scan.
+LAYOUTS="$TMP_ROOT/layouts"
+mkdir -p "$LAYOUTS/both/skills/x" "$LAYOUTS/both/.agents/skills/orch/tests"
+mkdir -p "$LAYOUTS/inst/.agents/skills/orch/tests"
+mkdir -p "$LAYOUTS/src/skills/orch/tests"
+
+# d.1 — both halves present: two-tree mode, rooted where both live.
+if [ "$(resolve_roots "$LAYOUTS/both/.agents/skills/orch/tests")" = "both $LAYOUTS/both" ]; then
+  pass "a root holding both trees resolves to two-tree mode"
+else
+  fail "a root holding both trees did not resolve to two-tree mode"
+fi
+
+# d.2 — the installed layout: one tree, named as such, no walk to /.
+if [ "$(resolve_roots "$LAYOUTS/inst/.agents/skills/orch/tests")" = "installed $LAYOUTS/inst" ]; then
+  pass "an installed root with no skills/ resolves to one-tree mode"
+else
+  fail "an installed root did not resolve to one-tree mode"
+fi
+
+# d.3 — skills/ present, render missing. This must NOT be read as installed.
+if src_only="$(resolve_roots "$LAYOUTS/src/skills/orch/tests")"; then
+  fail "a skills/ tree with no render was accepted instead of reported"
+elif reports "$src_only" "$LAYOUTS/src holds skills/ but no .agents/skills/ render beside it"; then
+  pass "a skills/ tree with no render is reported, not degraded to one tree"
+else
+  fail "a skills/ tree with no render drew the wrong diagnostic"
+fi
+
+# --- Part e: the delegated path is resolved before it fills the pair -------
+# The check is worth nothing if the value handed to it is not what `pwd -P`
+# prints. The workflows resolved it to `.` or to "the current directory", so
+# a delegate filled from them halted in a CORRECT checkout. The fill line is
+# held by the same equality predicate as the check line.
+NOFILL='carries a delegation block but no canonical Worktree fill line'
+
+# e.1 — a delegating doc that never says where the path comes from IS
+# flagged, even with a perfect check line inside the block.
+if reports "$(scan_worktree_fill "$(probe nofill "Worktree: [WORKTREE_PATH]\n$CHECK")")" "$NOFILL"; then
+  pass "lint flags a delegating doc carrying no fill line"
+else
+  fail "lint MISSED a delegating doc with no fill line"
+fi
+
+# e.2 — the canonical fill line is accepted.
+FILLED="$TMP_ROOT/probe-filled.md"
+printf '%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' "$CANON_FILL" "$CHECK" > "$FILLED"
+if [ -z "$(scan_worktree_fill "$FILLED")" ]; then
+  pass "lint accepts a doc carrying the canonical fill line"
+else
+  fail "lint false-flagged the canonical fill line"
+fi
+
+# e.3 — the shipped defect, spelled out: the fill line resolves the delegated
+# path to the current directory. `pwd -P` prints an absolute physical path
+# and can never equal a relative one, so this halts every correct delegate.
+RELFILL='Fill `Worktree:` and its `Worktree Check:` with the current directory. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.'
+RELATIVE="$TMP_ROOT/probe-relative-fill.md"
+printf '%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' "$RELFILL" "$CHECK" > "$RELATIVE"
+if reports "$(scan_worktree_fill "$RELATIVE")" "$NOFILL"; then
+  pass "lint flags a fill line resolving the delegated path to the current directory"
+else
+  fail "lint MISSED a delegated path resolved to the current directory"
+fi
+
+# e.4 — the fill line inside the block does not count: it has to be the
+# doc's instruction to the filler, not a line the delegate reads as content.
+INBLOCK="$TMP_ROOT/probe-inblock-fill.md"
+printf '<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n%s\n</delegation_format>\n' "$CHECK" "$CANON_FILL" > "$INBLOCK"
+if reports "$(scan_worktree_fill "$INBLOCK")" "$NOFILL"; then
+  pass "lint does not count a fill line buried inside the delegation block"
+else
+  fail "lint counted a fill line inside the block"
+fi
+
+# e.5 — a doc carrying no delegation is asked for no fill line.
+if [ -z "$(scan_worktree_fill "$PROSE")" ]; then
+  pass "lint asks no fill line of a doc carrying no delegation"
+else
+  fail "lint demanded a fill line of a non-delegating doc"
 fi
 
 echo

--- a/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -33,15 +33,19 @@
 #      then missed blocks whose paths are placeholders the caller fills.
 #      The pair costs two lines on a delegation that never touches the
 #      repo, and uniform is the only rule that cannot be wrong.
-#   3. A doc carrying a block also carries the canonical fill line, held in
+#   3. EVERY block is preceded by the canonical fill line, held in
 #      $CANON_FILL by the same equality predicate. The pair is worth
 #      nothing if the value poured into it is not what `pwd -P` prints, and
 #      the workflows resolved that value to `.` or to "the current
 #      directory", so a filled delegation halted in a CORRECT checkout. The
 #      fill line names `git-context repo-root`, whose `--show-toplevel`
 #      output is absolute and physical, so both sides of the comparison
-#      agree by construction. Rules 1 and 2 read inside a
-#      `<delegation_format>` block; rule 3 reads the doc around it.
+#      agree by construction. Per block, because a doc satisfying the rule
+#      once bought silence for every later block: the second block in
+#      audit-issues.md carried its own resolution, to an absolute LOGICAL
+#      path, and a file-wide assertion never read it. Rules 1 and 2 read
+#      inside a `<delegation_format>` block; rule 3 reads the lines between
+#      one block and the block before it.
 #
 # Scope is every skill doc that can carry a delegation, in BOTH trees where
 # both exist: the `skills/` source and the `.agents/skills/` render agents
@@ -166,20 +170,25 @@ scan_worktree_precondition() {
 }
 
 # scan_worktree_fill <file>
-# Emits one defect line when a doc opens a delegation block but never states,
-# outside every block, that the delegated path comes from `git-context
-# repo-root`. Equality against $CANON_FILL is the whole predicate, so a
-# resolution reworded back to `.` or to the current directory reds.
+# Emits one defect line per delegation block the canonical fill line does not
+# precede. The scope is the BLOCK, not the file: a doc that states the
+# canonical resolution once and a divergent one before a later block passed a
+# file-wide assertion, and the later block is the one that poured a logical
+# path into a `pwd -P` comparison. So the demand is raised at every opening
+# tag and the evidence is cleared at every closing tag — each block is asked
+# for the sentence again, in the lines between it and the block before it.
+# Equality against $CANON_FILL is the whole predicate, so a resolution
+# reworded back to `.` or to the current directory reds.
 scan_worktree_fill() {
   awk -v f="$1" -v canon="$CANON_FILL" '
     function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
-    /^[[:space:]]*<delegation_format>[[:space:]]*$/ { indel = 1; hasblock = 1; next }
-    /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ { indel = 0; next }
-    !indel { if (trim($0) == canon) hasfill = 1 }
-    END {
-      if (hasblock && !hasfill)
-        printf "%s: carries a delegation block but no canonical Worktree fill line\n", f
+    /^[[:space:]]*<delegation_format>[[:space:]]*$/ {
+      if (!hasfill)
+        printf "%s:%d: delegation block is not preceded by the canonical Worktree fill line\n", f, NR
+      indel = 1; next
     }
+    /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ { indel = 0; hasfill = 0; next }
+    !indel { if (trim($0) == canon) hasfill = 1 }
   ' "$1"
 }
 
@@ -517,7 +526,9 @@ fi
 # prints. The workflows resolved it to `.` or to "the current directory", so
 # a delegate filled from them halted in a CORRECT checkout. The fill line is
 # held by the same equality predicate as the check line.
-NOFILL='carries a delegation block but no canonical Worktree fill line'
+# The demand is per block, so the fragment carries no file half and each
+# probe below pins the block it must name.
+NOFILL='delegation block is not preceded by the canonical Worktree fill line'
 
 # e.1 — a delegating doc that never says where the path comes from IS
 # flagged, even with a perfect check line inside the block.
@@ -563,6 +574,36 @@ if [ -z "$(scan_worktree_fill "$PROSE")" ]; then
   pass "lint asks no fill line of a doc carrying no delegation"
 else
   fail "lint demanded a fill line of a non-delegating doc"
+fi
+
+# e.6 — the shape a file-wide assertion hid, and the reason rule 3 is now
+# per block: the canonical line before the FIRST block, a resolution of the
+# doc's own before the second. The one in audit-issues.md § 4.1 said
+# "the absolute path of the caller worktree", which admits a LOGICAL path —
+# a checkout entered through a symlink — and `pwd -P` then halts a correctly
+# placed delegate. The output is compared whole, so the probe fails if the
+# scan names the wrong block as readily as if it names none.
+TWOBLOCK="$TMP_ROOT/probe-two-blocks.md"
+DIVERGENT='Fill both fields with the absolute path of the caller worktree the collect step resolves.'
+printf '%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n\n%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' \
+  "$CANON_FILL" "$CHECK" "$DIVERGENT" "$CHECK" > "$TWOBLOCK"
+SECOND_OPEN="$(grep -n '^<delegation_format>$' "$TWOBLOCK" | sed -n '2s/:.*//p')"
+if [ "$(scan_worktree_fill "$TWOBLOCK")" = "$TWOBLOCK:$SECOND_OPEN: $NOFILL" ]; then
+  pass "lint flags the second block of a doc whose first block alone carries the fill line"
+else
+  fail "lint MISSED a second block carrying a divergent fill instruction"
+fi
+
+# e.7 — and the same two blocks, each preceded by the canonical line, are
+# clean. Without this the reset at the closing tag could demand the sentence
+# somewhere a doc can never put it and e.6 would still pass.
+BOTHFILLED="$TMP_ROOT/probe-two-blocks-filled.md"
+printf '%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n\n%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' \
+  "$CANON_FILL" "$CHECK" "$CANON_FILL" "$CHECK" > "$BOTHFILLED"
+if [ -z "$(scan_worktree_fill "$BOTHFILLED")" ]; then
+  pass "lint accepts a doc whose every block carries the canonical fill line"
+else
+  fail "lint false-flagged a doc filling both its blocks canonically"
 fi
 
 echo

--- a/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Regression lint for KEN-878. A delegated agent's shell does not reliably
+# start in the worktree it was delegated: two lanes on 2026-08-30 each ran
+# bare-relative commands — `tools/guard` among them — against another lane's
+# worktree, and both noticed only after a confusing downstream failure.
+#
+# The cure is a precondition the agent runs before anything repo-relative:
+# every `Worktree: [PLACEHOLDER]` line inside a `<delegation_format>` block
+# is followed immediately by a `Worktree Check:` line naming that SAME
+# placeholder. `pwd` reports where the shell actually is, so the check can
+# fail; a line that merely restates the delegated path cannot.
+#
+# This lint is the answer to the recurrence, not to the eleven sites: a new
+# delegation block that carries `Worktree:` without its check fails here
+# rather than shipping the silent-wrong-tree hazard again.
+#
+# Scoped to `<delegation_format>` blocks in orch's workflows. A `Worktree:`
+# mention in prose or in a fenced example is not a delegation and is not
+# scanned.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILLS_ROOT="$(cd "$TEST_DIR/../.." && pwd)"
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+
+# scan_worktree_precondition <file>
+# Emits one "file:line: ..." line per defect. Inside a <delegation_format>
+# block, a `Worktree: [TOKEN]` line must be followed on the very next line by
+# a `Worktree Check:` line whose text contains `[TOKEN]` — the same
+# placeholder, so a filled delegation compares against its own path and not
+# another site's. Lines outside a delegation block are never scanned.
+scan_worktree_precondition() {
+  awk -v f="$1" '
+    /^[[:space:]]*<delegation_format>[[:space:]]*$/ { indel = 1; pending = 0; next }
+    /^[[:space:]]*<\/delegation_format>[[:space:]]*$/ {
+      if (pending) printf "%s:%d: Worktree: [%s] ends the delegation with no Worktree Check line\n", f, pendline, token
+      indel = 0; pending = 0; next
+    }
+    indel {
+      if (pending) {
+        if ($0 !~ /^[[:space:]]*Worktree Check:/) {
+          printf "%s:%d: Worktree: [%s] is not followed by a Worktree Check line\n", f, pendline, token
+        } else if (index($0, "[" token "]") == 0) {
+          printf "%s:%d: Worktree Check names no [%s] to compare pwd against\n", f, NR, token
+        }
+        pending = 0
+      }
+      if (match($0, /^[[:space:]]*Worktree:[[:space:]]*\[[A-Za-z_][A-Za-z0-9_]*\][[:space:]]*$/)) {
+        line = $0
+        sub(/^[[:space:]]*Worktree:[[:space:]]*\[/, "", line)
+        sub(/\].*$/, "", line)
+        token = line; pendline = NR; pending = 1
+      }
+    }
+  ' "$1"
+}
+
+echo "=== orch delegation worktree-cwd-precondition lint ==="
+
+# --- Part a: every shipped delegation block carries the precondition -------
+DOCS="$(ls "$SKILLS_ROOT"/orch/workflows/*.md)"
+offenders=""
+sites=0
+for doc in $DOCS; do
+  out="$(scan_worktree_precondition "$doc")"
+  [ -n "$out" ] && offenders="$offenders$out"$'\n'
+  n="$(grep -c '^[[:space:]]*Worktree Check:' "$doc" || true)"
+  sites=$((sites + n))
+done
+if [ -z "$offenders" ]; then
+  pass "every delegated Worktree: line is followed by its Worktree Check"
+else
+  fail "delegation blocks missing the worktree cwd precondition:"
+  printf '%s' "$offenders" | sed 's/^/          /'
+fi
+
+# The precondition is worth nothing if no delegation carries it: a lint that
+# passes over zero sites is the vacuous case this asserts against.
+if [ "$sites" -gt 0 ]; then
+  pass "the scan read $sites delegated Worktree Check line(s)"
+else
+  fail "no Worktree Check lines found — the scan matched nothing to check"
+fi
+
+# --- Part b: the lint has teeth -------------------------------------------
+
+# probe <name> <body> → prints scratch-file path.
+# Writes a standalone delegation block containing <body> (printf %b, so \n
+# splits it into lines) under $TMP_ROOT, removed by the EXIT trap.
+probe() {
+  scratch="$TMP_ROOT/probe-$1.md"
+  printf '<delegation_format>\n%b\n</delegation_format>\n' "$2" > "$scratch"
+  printf '%s' "$scratch"
+}
+
+CHECK='Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH].'
+
+# b.1 — the reported shape (a bare Worktree: line, as all eleven sites read
+# before this change) IS flagged.
+if [ -n "$(scan_worktree_precondition "$(probe bare 'Issue: [ISSUE_ID]\nWorktree: [WORKTREE_PATH]\nRound ID: [DEV_ROUND_ID]')" )" ]; then
+  pass "lint flags a Worktree: line with no Worktree Check"
+else
+  fail "lint MISSED a bare Worktree: line (no teeth)"
+fi
+
+# b.2 — the fixed shape is NOT flagged.
+if [ -z "$(scan_worktree_precondition "$(probe fixed "Worktree: [WORKTREE_PATH]\n$CHECK")" )" ]; then
+  pass "lint accepts Worktree: followed by its Worktree Check"
+else
+  fail "lint false-flagged the fixed shape"
+fi
+
+# b.3 — a check naming a DIFFERENT placeholder IS flagged: a filled
+# delegation would compare pwd against a path this block never carries.
+if [ -n "$(scan_worktree_precondition "$(probe crossed 'Worktree: [WT_PATH]\nWorktree Check: `pwd` must print [WORKTREE_PATH].')" )" ]; then
+  pass "lint flags a Worktree Check naming the wrong placeholder"
+else
+  fail "lint MISSED a cross-wired placeholder"
+fi
+
+# b.4 — a Worktree: line ending the block with no check IS flagged.
+if [ -n "$(scan_worktree_precondition "$(probe last 'Branch: [BRANCH]\nWorktree: [WORKTREE_PATH]')" )" ]; then
+  pass "lint flags a Worktree: line that closes the delegation"
+else
+  fail "lint MISSED a trailing Worktree: line"
+fi
+
+# b.5 — a Worktree: mention outside a delegation block is NOT scanned.
+PROSE="$TMP_ROOT/probe-prose.md"
+printf 'Fill the delegation Worktree: [WORKTREE_PATH] from the claim output.\n' > "$PROSE"
+if [ -z "$(scan_worktree_precondition "$PROSE")" ]; then
+  pass "lint ignores a Worktree: mention outside a delegation block"
+else
+  fail "lint false-flagged a prose mention"
+fi
+
+# b.6 — an indented delegation block (dev-fix.md nests one in a numbered
+# step) is scanned, not skipped for its leading whitespace.
+if [ -n "$(scan_worktree_precondition "$(probe indented '   Worktree: [WORKTREE_PATH]\n   Round ID: [DEV_ROUND_ID]')" )" ]; then
+  pass "lint scans an indented delegation block"
+else
+  fail "lint MISSED a bare Worktree: line inside an indented block"
+fi
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/skills/orch/workflows/ci-fix.md
+++ b/skills/orch/workflows/ci-fix.md
@@ -76,7 +76,7 @@ Error output:
 [truncated error logs]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
 Worktree Lease: [WORKTREE_LEASE]
 
 1. Verify possession before changing anything: `.agents/skills/orch/scripts/worktree-claim --worktree [WORKTREE_PATH] --issue [ISSUE_ID] --expect-gen [WORKTREE_LEASE]`. Any non-zero exit ends the round here — change nothing and report its stderr verbatim.
@@ -109,7 +109,7 @@ Merge queue CI failure — integration issue across stacked PRs.
 
 Draft PR: #[PR_NUMBER]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
 Stack: [PRs in the stack with their domains]
 
 Error output:

--- a/skills/orch/workflows/ci-fix.md
+++ b/skills/orch/workflows/ci-fix.md
@@ -37,7 +37,7 @@ Formatting, obvious lint, and a missing import are fixed directly; a test failur
 
 ### 3.1 Direct Fixes
 
-Resolve the worktree (`github.sh pr-issue [PR_NUMBER] --format=text`, then `worktree exists`/`worktree path`, creating with `--pr [PR_NUMBER]` when missing) as `[DIR]`; `WORKTREE_PATH` is `git-context repo-root [DIR]`. Apply the fix, then:
+Resolve the worktree (`github.sh pr-issue [PR_NUMBER] --format=text`, then `worktree exists`/`worktree path`, creating with `--pr [PR_NUMBER]` when missing) as `[DIR]`; `WORKTREE_PATH` is `git-context repo-root "[DIR]"`. Apply the fix, then:
 
 ```bash
 git -C "[WORKTREE_PATH]" commit -am "fix([ISSUE_ID]): Resolve CI failure ([ERROR_TYPE])"
@@ -64,7 +64,7 @@ Stamp the round as separate tool calls immediately before delegating, and arm th
 
 `worktree-claim` exit 75 aborts the delegation (another session holds this worktree; stderr names the holder); exit 1 stops the workflow and is reported. Its printed token is the delegation's `Worktree Lease:` line.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 This agent pushes its fix directly and writes **no** dev-return artifact; the round-mode check for this token reports `ok == false`, which is expected. Accept this round on the agent's return message plus the pushed fix commit; on an absent return follow the escalation ladder.
 

--- a/skills/orch/workflows/ci-fix.md
+++ b/skills/orch/workflows/ci-fix.md
@@ -37,7 +37,7 @@ Formatting, obvious lint, and a missing import are fixed directly; a test failur
 
 ### 3.1 Direct Fixes
 
-Resolve the worktree (`github.sh pr-issue [PR_NUMBER] --format=text`, then `worktree exists`/`worktree path`, creating with `--pr [PR_NUMBER]` when missing), apply the fix, then:
+Resolve the worktree (`github.sh pr-issue [PR_NUMBER] --format=text`, then `worktree exists`/`worktree path`, creating with `--pr [PR_NUMBER]` when missing) as `[DIR]`; `WORKTREE_PATH` is `git-context repo-root [DIR]`. Apply the fix, then:
 
 ```bash
 git -C "[WORKTREE_PATH]" commit -am "fix([ISSUE_ID]): Resolve CI failure ([ERROR_TYPE])"
@@ -63,6 +63,8 @@ Stamp the round as separate tool calls immediately before delegating, and arm th
 ```
 
 `worktree-claim` exit 75 aborts the delegation (another session holds this worktree; stderr names the holder); exit 1 stops the workflow and is reported. Its printed token is the delegation's `Worktree Lease:` line.
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 This agent pushes its fix directly and writes **no** dev-return artifact; the round-mode check for this token reports `ok == false`, which is expected. Accept this round on the agent's return message plus the pushed fix commit; on an absent return follow the escalation ladder.
 

--- a/skills/orch/workflows/ci-fix.md
+++ b/skills/orch/workflows/ci-fix.md
@@ -76,7 +76,7 @@ Error output:
 [truncated error logs]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
 Worktree Lease: [WORKTREE_LEASE]
 
 1. Verify possession before changing anything: `.agents/skills/orch/scripts/worktree-claim --worktree [WORKTREE_PATH] --issue [ISSUE_ID] --expect-gen [WORKTREE_LEASE]`. Any non-zero exit ends the round here — change nothing and report its stderr verbatim.
@@ -109,7 +109,7 @@ Merge queue CI failure — integration issue across stacked PRs.
 
 Draft PR: #[PR_NUMBER]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
 Stack: [PRs in the stack with their domains]
 
 Error output:

--- a/skills/orch/workflows/ci-fix.md
+++ b/skills/orch/workflows/ci-fix.md
@@ -104,7 +104,10 @@ gh pr view [DRAFT_PR] --json commits --jq '.commits[].oid'
 
 Cross-reference those commits with the original PRs to identify which file failed, which commit introduced it, and which PR that commit belongs to. A single identifiable PR routes to that PR's agent; a genuine cross-PR integration issue routes to the architecture reviewer for analysis; an unclear source goes to the user.
 
-For an integration issue, create a worktree from the draft branch (`worktree create [ISSUE_ID] "[DRAFT_BRANCH]" --pr [DRAFT_PR_NUMBER]`) and delegate analysis:
+For an integration issue, create a worktree from the draft branch (`worktree create [ISSUE_ID] "[DRAFT_BRANCH]" --pr [DRAFT_PR_NUMBER]`) and delegate analysis.
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the worktree just created from the draft branch.
 
 <delegation_format>
 Merge queue CI failure — integration issue across stacked PRs.

--- a/skills/orch/workflows/ci-fix.md
+++ b/skills/orch/workflows/ci-fix.md
@@ -76,6 +76,7 @@ Error output:
 [truncated error logs]
 
 Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
 Worktree Lease: [WORKTREE_LEASE]
 
 1. Verify possession before changing anything: `.agents/skills/orch/scripts/worktree-claim --worktree [WORKTREE_PATH] --issue [ISSUE_ID] --expect-gen [WORKTREE_LEASE]`. Any non-zero exit ends the round here — change nothing and report its stderr verbatim.
@@ -108,6 +109,7 @@ Merge queue CI failure — integration issue across stacked PRs.
 
 Draft PR: #[PR_NUMBER]
 Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
 Stack: [PRs in the stack with their domains]
 
 Error output:

--- a/skills/orch/workflows/ci-fix.md
+++ b/skills/orch/workflows/ci-fix.md
@@ -64,7 +64,7 @@ Stamp the round as separate tool calls immediately before delegating, and arm th
 
 `worktree-claim` exit 75 aborts the delegation (another session holds this worktree; stderr names the holder); exit 1 stops the workflow and is reported. Its printed token is the delegation's `Worktree Lease:` line.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 This agent pushes its fix directly and writes **no** dev-return artifact; the round-mode check for this token reports `ok == false`, which is expected. Accept this round on the agent's return message plus the pushed fix commit; on an absent return follow the escalation ladder.
 
@@ -106,7 +106,7 @@ Cross-reference those commits with the original PRs to identify which file faile
 
 For an integration issue, create a worktree from the draft branch (`worktree create [ISSUE_ID] "[DRAFT_BRANCH]" --pr [DRAFT_PR_NUMBER]`) and delegate analysis.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the worktree just created from the draft branch.
 
 <delegation_format>

--- a/skills/orch/workflows/ci-fix.md
+++ b/skills/orch/workflows/ci-fix.md
@@ -76,7 +76,7 @@ Error output:
 [truncated error logs]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Worktree Lease: [WORKTREE_LEASE]
 
 1. Verify possession before changing anything: `.agents/skills/orch/scripts/worktree-claim --worktree [WORKTREE_PATH] --issue [ISSUE_ID] --expect-gen [WORKTREE_LEASE]`. Any non-zero exit ends the round here — change nothing and report its stderr verbatim.
@@ -109,7 +109,7 @@ Merge queue CI failure — integration issue across stacked PRs.
 
 Draft PR: #[PR_NUMBER]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Stack: [PRs in the stack with their domains]
 
 Error output:

--- a/skills/orch/workflows/ci-fix.md
+++ b/skills/orch/workflows/ci-fix.md
@@ -76,7 +76,7 @@ Error output:
 [truncated error logs]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Worktree Lease: [WORKTREE_LEASE]
 
 1. Verify possession before changing anything: `.agents/skills/orch/scripts/worktree-claim --worktree [WORKTREE_PATH] --issue [ISSUE_ID] --expect-gen [WORKTREE_LEASE]`. Any non-zero exit ends the round here — change nothing and report its stderr verbatim.
@@ -109,7 +109,7 @@ Merge queue CI failure — integration issue across stacked PRs.
 
 Draft PR: #[PR_NUMBER]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Stack: [PRs in the stack with their domains]
 
 Error output:

--- a/skills/orch/workflows/dev-fix.md
+++ b/skills/orch/workflows/dev-fix.md
@@ -10,9 +10,9 @@ Delegate fix items to a specialist dev agent. Standalone (user-initiated) or man
 
 **Caller context** (via `⤵`): `worktree`; `lifecycle` — `"managed"` (return at § 3) or `"self"` (default); `dev_agent` — a live dev agent; `issue_id` — the workflow-state key, the normalized issue ID (`issue-N` for GitHub, `PROJ-123` for Linear), never the bare GitHub issue number; `items` — formatted review items; `source` — `pr-review` | `qa-review` | `review` | `local-review` (default `conversation`); `qa_agent`.
 
-**Standalone init** (`lifecycle: "self"`). Use the argument as `ISSUE_ID`, else `git-context issue-from-branch .`. Apply [Worktree Scope](../SKILL.md#workflow-execution) and resolve `WT_PATH` as `git-context repo-root [DIR]` (inside a worktree `[DIR]` is `.`; from the main repo, `worktree path [ISSUE_ID]`, asking before creating).
+**Standalone init** (`lifecycle: "self"`). Use the argument as `ISSUE_ID`, else `git-context issue-from-branch .`. Apply [Worktree Scope](../SKILL.md#workflow-execution) and resolve `WT_PATH` as `git-context repo-root "[DIR]"` (inside a worktree `[DIR]` is `.`; from the main repo, `worktree path [ISSUE_ID]`, asking before creating).
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 ## 1. Build Fix Items
 

--- a/skills/orch/workflows/dev-fix.md
+++ b/skills/orch/workflows/dev-fix.md
@@ -110,7 +110,7 @@ Cancel ends the workflow; a selection goes to § 2.
    Source: [SOURCE]
    Issue: [ISSUE_ID]
    Worktree: [WORKTREE_PATH]
-   Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+   Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
    Worktree Lease: [WORKTREE_LEASE]
    Round ID: [DEV_ROUND_ID]
    Artifact Key: [ISSUE_ID]

--- a/skills/orch/workflows/dev-fix.md
+++ b/skills/orch/workflows/dev-fix.md
@@ -110,6 +110,7 @@ Cancel ends the workflow; a selection goes to § 2.
    Source: [SOURCE]
    Issue: [ISSUE_ID]
    Worktree: [WORKTREE_PATH]
+   Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
    Worktree Lease: [WORKTREE_LEASE]
    Round ID: [DEV_ROUND_ID]
    Artifact Key: [ISSUE_ID]

--- a/skills/orch/workflows/dev-fix.md
+++ b/skills/orch/workflows/dev-fix.md
@@ -110,7 +110,7 @@ Cancel ends the workflow; a selection goes to § 2.
    Source: [SOURCE]
    Issue: [ISSUE_ID]
    Worktree: [WORKTREE_PATH]
-   Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
+   Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
    Worktree Lease: [WORKTREE_LEASE]
    Round ID: [DEV_ROUND_ID]
    Artifact Key: [ISSUE_ID]

--- a/skills/orch/workflows/dev-fix.md
+++ b/skills/orch/workflows/dev-fix.md
@@ -12,7 +12,7 @@ Delegate fix items to a specialist dev agent. Standalone (user-initiated) or man
 
 **Standalone init** (`lifecycle: "self"`). Use the argument as `ISSUE_ID`, else `git-context issue-from-branch .`. Apply [Worktree Scope](../SKILL.md#workflow-execution) and resolve `WT_PATH` as `git-context repo-root "[DIR]"` (inside a worktree `[DIR]` is `.`; from the main repo, `worktree path [ISSUE_ID]`, asking before creating).
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 ## 1. Build Fix Items
 

--- a/skills/orch/workflows/dev-fix.md
+++ b/skills/orch/workflows/dev-fix.md
@@ -10,7 +10,9 @@ Delegate fix items to a specialist dev agent. Standalone (user-initiated) or man
 
 **Caller context** (via `⤵`): `worktree`; `lifecycle` — `"managed"` (return at § 3) or `"self"` (default); `dev_agent` — a live dev agent; `issue_id` — the workflow-state key, the normalized issue ID (`issue-N` for GitHub, `PROJ-123` for Linear), never the bare GitHub issue number; `items` — formatted review items; `source` — `pr-review` | `qa-review` | `review` | `local-review` (default `conversation`); `qa_agent`.
 
-**Standalone init** (`lifecycle: "self"`). Use the argument as `ISSUE_ID`, else `git-context issue-from-branch .`. Apply [Worktree Scope](../SKILL.md#workflow-execution) and resolve `WT_PATH` (inside a worktree, the current directory; from the main repo, `worktree path [ISSUE_ID]`, asking before creating).
+**Standalone init** (`lifecycle: "self"`). Use the argument as `ISSUE_ID`, else `git-context issue-from-branch .`. Apply [Worktree Scope](../SKILL.md#workflow-execution) and resolve `WT_PATH` as `git-context repo-root [DIR]` (inside a worktree `[DIR]` is `.`; from the main repo, `worktree path [ISSUE_ID]`, asking before creating).
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 ## 1. Build Fix Items
 

--- a/skills/orch/workflows/dev-fix.md
+++ b/skills/orch/workflows/dev-fix.md
@@ -110,7 +110,7 @@ Cancel ends the workflow; a selection goes to § 2.
    Source: [SOURCE]
    Issue: [ISSUE_ID]
    Worktree: [WORKTREE_PATH]
-   Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
+   Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
    Worktree Lease: [WORKTREE_LEASE]
    Round ID: [DEV_ROUND_ID]
    Artifact Key: [ISSUE_ID]

--- a/skills/orch/workflows/dev-fix.md
+++ b/skills/orch/workflows/dev-fix.md
@@ -110,7 +110,7 @@ Cancel ends the workflow; a selection goes to § 2.
    Source: [SOURCE]
    Issue: [ISSUE_ID]
    Worktree: [WORKTREE_PATH]
-   Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+   Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
    Worktree Lease: [WORKTREE_LEASE]
    Round ID: [DEV_ROUND_ID]
    Artifact Key: [ISSUE_ID]

--- a/skills/orch/workflows/dev-start.md
+++ b/skills/orch/workflows/dev-start.md
@@ -103,6 +103,8 @@ Group pending sub-issues by `agent:[TYPE]` label and order them per [SKILL.md §
 
 Between groups, read each completed sub-issue's comments for a `Handoff Notes` section and combine them into the next delegation. Re-run all four § 2 stamps immediately before each group's delegation.
 
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+
 <delegation_format>
 Follow workflow: .agents/skills/dev/workflows/dev-implement.md
 

--- a/skills/orch/workflows/dev-start.md
+++ b/skills/orch/workflows/dev-start.md
@@ -86,7 +86,7 @@ Follow workflow: .agents/skills/dev/workflows/dev-implement.md
 
 Issue: [ISSUE_ID]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]
@@ -111,7 +111,7 @@ Sub-Issues:
 ↳ [SUB_ISSUE_3]: [TITLE] | blocked by: [SUB_ISSUE_2]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]

--- a/skills/orch/workflows/dev-start.md
+++ b/skills/orch/workflows/dev-start.md
@@ -86,7 +86,7 @@ Follow workflow: .agents/skills/dev/workflows/dev-implement.md
 
 Issue: [ISSUE_ID]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]
@@ -111,7 +111,7 @@ Sub-Issues:
 ↳ [SUB_ISSUE_3]: [TITLE] | blocked by: [SUB_ISSUE_2]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]

--- a/skills/orch/workflows/dev-start.md
+++ b/skills/orch/workflows/dev-start.md
@@ -86,7 +86,7 @@ Follow workflow: .agents/skills/dev/workflows/dev-implement.md
 
 Issue: [ISSUE_ID]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]
@@ -111,7 +111,7 @@ Sub-Issues:
 ↳ [SUB_ISSUE_3]: [TITLE] | blocked by: [SUB_ISSUE_2]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]

--- a/skills/orch/workflows/dev-start.md
+++ b/skills/orch/workflows/dev-start.md
@@ -86,6 +86,7 @@ Follow workflow: .agents/skills/dev/workflows/dev-implement.md
 
 Issue: [ISSUE_ID]
 Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]
@@ -110,6 +111,7 @@ Sub-Issues:
 ↳ [SUB_ISSUE_3]: [TITLE] | blocked by: [SUB_ISSUE_2]
 
 Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]

--- a/skills/orch/workflows/dev-start.md
+++ b/skills/orch/workflows/dev-start.md
@@ -86,7 +86,7 @@ Follow workflow: .agents/skills/dev/workflows/dev-implement.md
 
 Issue: [ISSUE_ID]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]
@@ -111,7 +111,7 @@ Sub-Issues:
 ↳ [SUB_ISSUE_3]: [TITLE] | blocked by: [SUB_ISSUE_2]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]

--- a/skills/orch/workflows/dev-start.md
+++ b/skills/orch/workflows/dev-start.md
@@ -27,7 +27,9 @@ Resolve `TRACKER` first — `github` skips the Linear-only container preflight.
 
 Apply the Ancestor gate ([SKILL.md § Coordination](../SKILL.md#coordination)). A container is refused before anything is initialized, with its unblocked children surfaced as the startable items. A `(one PR)` ancestor promotion is TERMINAL for this invocation: stop and route to `/orch start [PARENT_ID]` rather than continuing with the child's id. A blocked child stops with its live blockers named. Caller context `audit_bundle: true` is equivalent to the `(one PR)` marker: skip the refusal for that parent and carry `Audit Bundle: yes` in the delegation. Managed callers already ran this gate.
 
-Apply [Worktree Scope](../SKILL.md#workflow-execution) and resolve `WT_PATH`: inside a worktree use the current directory; from the main repo use `worktree path [ISSUE_ID]` when it exists, and ask the user before creating one when it does not.
+Apply [Worktree Scope](../SKILL.md#workflow-execution) and resolve `WT_PATH` as `git-context repo-root [DIR]`. Inside a worktree `[DIR]` is `.`; from the main repo it is `worktree path [ISSUE_ID]` when that exists, and ask the user before creating one when it does not.
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 Initialize state unless it exists:
 

--- a/skills/orch/workflows/dev-start.md
+++ b/skills/orch/workflows/dev-start.md
@@ -29,7 +29,7 @@ Apply the Ancestor gate ([SKILL.md § Coordination](../SKILL.md#coordination)). 
 
 Apply [Worktree Scope](../SKILL.md#workflow-execution) and resolve `WT_PATH` as `git-context repo-root "[DIR]"`. Inside a worktree `[DIR]` is `.`; from the main repo it is `worktree path [ISSUE_ID]` when that exists, and ask the user before creating one when it does not.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 Initialize state unless it exists:
 
@@ -103,7 +103,7 @@ Group pending sub-issues by `agent:[TYPE]` label and order them per [SKILL.md §
 
 Between groups, read each completed sub-issue's comments for a `Handoff Notes` section and combine them into the next delegation. Re-run all four § 2 stamps immediately before each group's delegation.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 <delegation_format>
 Follow workflow: .agents/skills/dev/workflows/dev-implement.md

--- a/skills/orch/workflows/dev-start.md
+++ b/skills/orch/workflows/dev-start.md
@@ -27,9 +27,9 @@ Resolve `TRACKER` first — `github` skips the Linear-only container preflight.
 
 Apply the Ancestor gate ([SKILL.md § Coordination](../SKILL.md#coordination)). A container is refused before anything is initialized, with its unblocked children surfaced as the startable items. A `(one PR)` ancestor promotion is TERMINAL for this invocation: stop and route to `/orch start [PARENT_ID]` rather than continuing with the child's id. A blocked child stops with its live blockers named. Caller context `audit_bundle: true` is equivalent to the `(one PR)` marker: skip the refusal for that parent and carry `Audit Bundle: yes` in the delegation. Managed callers already ran this gate.
 
-Apply [Worktree Scope](../SKILL.md#workflow-execution) and resolve `WT_PATH` as `git-context repo-root [DIR]`. Inside a worktree `[DIR]` is `.`; from the main repo it is `worktree path [ISSUE_ID]` when that exists, and ask the user before creating one when it does not.
+Apply [Worktree Scope](../SKILL.md#workflow-execution) and resolve `WT_PATH` as `git-context repo-root "[DIR]"`. Inside a worktree `[DIR]` is `.`; from the main repo it is `worktree path [ISSUE_ID]` when that exists, and ask the user before creating one when it does not.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 Initialize state unless it exists:
 

--- a/skills/orch/workflows/post-summary.md
+++ b/skills/orch/workflows/post-summary.md
@@ -10,7 +10,7 @@ Post the session summary to the git host and issue tracker, plus selective hando
 
 **Caller context** (via `⤵`): `worktree`; `lifecycle` — `"managed"` (return at § 3) or `"self"` (default); `issue_id` — the workflow-state key, the normalized issue ID, never the bare GitHub issue number; `pr_number`. Every lifecycle path resolves `TRACKER` and `ISSUE_REF` from `issue_id` per [Tracker Resolution](../SKILL.md#tracker-resolution), and `SUB_ISSUE_REF` the same way from each completed sub-issue's own id, before rendering the summary.
 
-**Standalone init** (`lifecycle: "self"`): `git-context issue-from-branch .` gives `ISSUE_ID`; resolve `TRACKER` per [Tracker Resolution](../SKILL.md#tracker-resolution); `WT_PATH` is `git-context repo-root [DIR]`, `[DIR]` being `.` unless `worktree exists`/`worktree path` says otherwise; `pr-view-json [WT_PATH] --json number` gives `PR_NUMBER`. When `workflow-state exists --json [ISSUE_ID]` reports false, initialize with `git-context branch [WT_PATH]` and `workflow-state init`.
+**Standalone init** (`lifecycle: "self"`): `git-context issue-from-branch .` gives `ISSUE_ID`; resolve `TRACKER` per [Tracker Resolution](../SKILL.md#tracker-resolution); `WT_PATH` is `git-context repo-root "[DIR]"`, `[DIR]` being `.` unless `worktree exists`/`worktree path` says otherwise; `pr-view-json [WT_PATH] --json number` gives `PR_NUMBER`. When `workflow-state exists --json [ISSUE_ID]` reports false, initialize with `git-context branch [WT_PATH]` and `workflow-state init`.
 
 ## 1. Post The Summary
 

--- a/skills/orch/workflows/post-summary.md
+++ b/skills/orch/workflows/post-summary.md
@@ -10,7 +10,7 @@ Post the session summary to the git host and issue tracker, plus selective hando
 
 **Caller context** (via `⤵`): `worktree`; `lifecycle` — `"managed"` (return at § 3) or `"self"` (default); `issue_id` — the workflow-state key, the normalized issue ID, never the bare GitHub issue number; `pr_number`. Every lifecycle path resolves `TRACKER` and `ISSUE_REF` from `issue_id` per [Tracker Resolution](../SKILL.md#tracker-resolution), and `SUB_ISSUE_REF` the same way from each completed sub-issue's own id, before rendering the summary.
 
-**Standalone init** (`lifecycle: "self"`): `git-context issue-from-branch .` gives `ISSUE_ID`; resolve `TRACKER` per [Tracker Resolution](../SKILL.md#tracker-resolution); `WT_PATH` is the current directory unless `worktree exists`/`worktree path` says otherwise; `pr-view-json [WT_PATH] --json number` gives `PR_NUMBER`. When `workflow-state exists --json [ISSUE_ID]` reports false, initialize with `git-context branch [WT_PATH]` and `workflow-state init`.
+**Standalone init** (`lifecycle: "self"`): `git-context issue-from-branch .` gives `ISSUE_ID`; resolve `TRACKER` per [Tracker Resolution](../SKILL.md#tracker-resolution); `WT_PATH` is `git-context repo-root [DIR]`, `[DIR]` being `.` unless `worktree exists`/`worktree path` says otherwise; `pr-view-json [WT_PATH] --json number` gives `PR_NUMBER`. When `workflow-state exists --json [ISSUE_ID]` reports false, initialize with `git-context branch [WT_PATH]` and `workflow-state init`.
 
 ## 1. Post The Summary
 

--- a/skills/orch/workflows/review-codebase.md
+++ b/skills/orch/workflows/review-codebase.md
@@ -15,6 +15,8 @@ Ad-hoc whole-codebase reviewer fanout. No PR, no issue, no diff, no fix delegati
 
 Not a git worktree → report `review-codebase requires a git worktree` and **END**. Otherwise use the output as `WT_PATH` and `mkdir -p "$WT_PATH/tmp"`.
 
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+
 ## 2. Delegate
 
 `[AGENTS]` is every `reviewer-*` agent this harness exposes; use the full list and do not path-filter. None available → report `No reviewer agents installed; cannot run codebase review` and **END**.

--- a/skills/orch/workflows/review-codebase.md
+++ b/skills/orch/workflows/review-codebase.md
@@ -15,7 +15,7 @@ Ad-hoc whole-codebase reviewer fanout. No PR, no issue, no diff, no fix delegati
 
 Not a git worktree → report `review-codebase requires a git worktree` and **END**. Otherwise use the output as `WT_PATH` and `mkdir -p "$WT_PATH/tmp"`.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 ## 2. Delegate
 

--- a/skills/orch/workflows/review-codebase.md
+++ b/skills/orch/workflows/review-codebase.md
@@ -31,6 +31,7 @@ Resolve the reviewer mode per [SKILL.md § Agent Lifecycle](../SKILL.md#agent-li
 Follow workflow: .agents/skills/reviewer/workflows/codebase-review.md
 
 Worktree: [WT_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WT_PATH]`, re-run `pwd`, and report where it started.
 Scope: Whole codebase. Inspect tracked, non-generated project code, plus the tests, configs, and docs relevant to your review domain. Do not sample or restrict to changed files. No PR, no issue, no diff.
 Exclusions: generated artifacts, dependency and vendor directories, build outputs, binary assets, harness mirrors, and lockfiles unless your domain specifically requires them.
 </delegation_format>

--- a/skills/orch/workflows/review-codebase.md
+++ b/skills/orch/workflows/review-codebase.md
@@ -31,7 +31,7 @@ Resolve the reviewer mode per [SKILL.md § Agent Lifecycle](../SKILL.md#agent-li
 Follow workflow: .agents/skills/reviewer/workflows/codebase-review.md
 
 Worktree: [WT_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WT_PATH]`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WT_PATH]"`, re-run `pwd`, and report where it started.
 Scope: Whole codebase. Inspect tracked, non-generated project code, plus the tests, configs, and docs relevant to your review domain. Do not sample or restrict to changed files. No PR, no issue, no diff.
 Exclusions: generated artifacts, dependency and vendor directories, build outputs, binary assets, harness mirrors, and lockfiles unless your domain specifically requires them.
 </delegation_format>

--- a/skills/orch/workflows/review-codebase.md
+++ b/skills/orch/workflows/review-codebase.md
@@ -31,7 +31,7 @@ Resolve the reviewer mode per [SKILL.md § Agent Lifecycle](../SKILL.md#agent-li
 Follow workflow: .agents/skills/reviewer/workflows/codebase-review.md
 
 Worktree: [WT_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Scope: Whole codebase. Inspect tracked, non-generated project code, plus the tests, configs, and docs relevant to your review domain. Do not sample or restrict to changed files. No PR, no issue, no diff.
 Exclusions: generated artifacts, dependency and vendor directories, build outputs, binary assets, harness mirrors, and lockfiles unless your domain specifically requires them.
 </delegation_format>

--- a/skills/orch/workflows/review-codebase.md
+++ b/skills/orch/workflows/review-codebase.md
@@ -31,7 +31,7 @@ Resolve the reviewer mode per [SKILL.md § Agent Lifecycle](../SKILL.md#agent-li
 Follow workflow: .agents/skills/reviewer/workflows/codebase-review.md
 
 Worktree: [WT_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WT_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Scope: Whole codebase. Inspect tracked, non-generated project code, plus the tests, configs, and docs relevant to your review domain. Do not sample or restrict to changed files. No PR, no issue, no diff.
 Exclusions: generated artifacts, dependency and vendor directories, build outputs, binary assets, harness mirrors, and lockfiles unless your domain specifically requires them.
 </delegation_format>

--- a/skills/orch/workflows/review-codebase.md
+++ b/skills/orch/workflows/review-codebase.md
@@ -15,7 +15,7 @@ Ad-hoc whole-codebase reviewer fanout. No PR, no issue, no diff, no fix delegati
 
 Not a git worktree → report `review-codebase requires a git worktree` and **END**. Otherwise use the output as `WT_PATH` and `mkdir -p "$WT_PATH/tmp"`.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 ## 2. Delegate
 

--- a/skills/orch/workflows/review-codebase.md
+++ b/skills/orch/workflows/review-codebase.md
@@ -31,7 +31,7 @@ Resolve the reviewer mode per [SKILL.md § Agent Lifecycle](../SKILL.md#agent-li
 Follow workflow: .agents/skills/reviewer/workflows/codebase-review.md
 
 Worktree: [WT_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WT_PATH]"`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WT_PATH], because a bare `cd` may not survive into the next tool call.
 Scope: Whole codebase. Inspect tracked, non-generated project code, plus the tests, configs, and docs relevant to your review domain. Do not sample or restrict to changed files. No PR, no issue, no diff.
 Exclusions: generated artifacts, dependency and vendor directories, build outputs, binary assets, harness mirrors, and lockfiles unless your domain specifically requires them.
 </delegation_format>

--- a/skills/orch/workflows/review-codebase.md
+++ b/skills/orch/workflows/review-codebase.md
@@ -16,6 +16,7 @@ Ad-hoc whole-codebase reviewer fanout. No PR, no issue, no diff, no fix delegati
 Not a git worktree → report `review-codebase requires a git worktree` and **END**. Otherwise use the output as `WT_PATH` and `mkdir -p "$WT_PATH/tmp"`.
 
 Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the `[PATH_OR_PWD]` § 1 resolves `WT_PATH` from.
 
 ## 2. Delegate
 

--- a/skills/orch/workflows/review-pr-comments.md
+++ b/skills/orch/workflows/review-pr-comments.md
@@ -72,7 +72,7 @@ Analyze these PR review comments for your domain.
 PR: #[PR_NUMBER] - [TITLE]
 Parent Issue: [ISSUE_ID]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
 
 Decision context (read before classifying — do NOT suggest changes that contradict these):
 [For each verified decision: "[DECISION_ID]: [ONE_LINE_SUMMARY] — [DECISION_FILE_PATH]"]
@@ -238,7 +238,7 @@ Source: pr-comments
 Issue: [ISSUE_ID]
 PR: #[PR_NUMBER]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]

--- a/skills/orch/workflows/review-pr-comments.md
+++ b/skills/orch/workflows/review-pr-comments.md
@@ -72,7 +72,7 @@ Analyze these PR review comments for your domain.
 PR: #[PR_NUMBER] - [TITLE]
 Parent Issue: [ISSUE_ID]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 
 Decision context (read before classifying — do NOT suggest changes that contradict these):
 [For each verified decision: "[DECISION_ID]: [ONE_LINE_SUMMARY] — [DECISION_FILE_PATH]"]
@@ -238,7 +238,7 @@ Source: pr-comments
 Issue: [ISSUE_ID]
 PR: #[PR_NUMBER]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]

--- a/skills/orch/workflows/review-pr-comments.md
+++ b/skills/orch/workflows/review-pr-comments.md
@@ -44,7 +44,11 @@ gh api user -q .login
 
 **Extract** per item: `thread_id`/`comment_id`, `author`, `body`, `path`, `line`, `url`, and `source` (`inline` or `pr-level`). Bot review summaries additionally get a `section` and a keyword-derived source type — architectural, documentation, security, testing, performance, or plain suggestion — plus `blocking: true` for security items and `false` when the text says non-blocking or optional. Skip anything the bot labels an inline comment: those are already captured as review threads, with the bot username as `author`. Never filter bot inline threads out.
 
-**Issue context.** `issue_id` from the caller, else `git-context issue-from-branch .`; ask the user if nothing matches. Resolve `WT_PATH` from `worktree exists`/`worktree path`, falling back to `.`. Then gather decisions:
+**Issue context.** `issue_id` from the caller, else `git-context issue-from-branch .`; ask the user if nothing matches. Resolve `WT_PATH` as `git-context repo-root [DIR]`, `[DIR]` being `worktree exists`/`worktree path` when they match and `.` otherwise.
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+
+Then gather decisions:
 
 ```bash
 .agents/skills/decider/scripts/decisions search --issue [ISSUE_ID]

--- a/skills/orch/workflows/review-pr-comments.md
+++ b/skills/orch/workflows/review-pr-comments.md
@@ -72,7 +72,7 @@ Analyze these PR review comments for your domain.
 PR: #[PR_NUMBER] - [TITLE]
 Parent Issue: [ISSUE_ID]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 
 Decision context (read before classifying — do NOT suggest changes that contradict these):
 [For each verified decision: "[DECISION_ID]: [ONE_LINE_SUMMARY] — [DECISION_FILE_PATH]"]
@@ -238,7 +238,7 @@ Source: pr-comments
 Issue: [ISSUE_ID]
 PR: #[PR_NUMBER]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]

--- a/skills/orch/workflows/review-pr-comments.md
+++ b/skills/orch/workflows/review-pr-comments.md
@@ -72,7 +72,7 @@ Analyze these PR review comments for your domain.
 PR: #[PR_NUMBER] - [TITLE]
 Parent Issue: [ISSUE_ID]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
 
 Decision context (read before classifying — do NOT suggest changes that contradict these):
 [For each verified decision: "[DECISION_ID]: [ONE_LINE_SUMMARY] — [DECISION_FILE_PATH]"]
@@ -238,7 +238,7 @@ Source: pr-comments
 Issue: [ISSUE_ID]
 PR: #[PR_NUMBER]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]

--- a/skills/orch/workflows/review-pr-comments.md
+++ b/skills/orch/workflows/review-pr-comments.md
@@ -44,9 +44,9 @@ gh api user -q .login
 
 **Extract** per item: `thread_id`/`comment_id`, `author`, `body`, `path`, `line`, `url`, and `source` (`inline` or `pr-level`). Bot review summaries additionally get a `section` and a keyword-derived source type — architectural, documentation, security, testing, performance, or plain suggestion — plus `blocking: true` for security items and `false` when the text says non-blocking or optional. Skip anything the bot labels an inline comment: those are already captured as review threads, with the bot username as `author`. Never filter bot inline threads out.
 
-**Issue context.** `issue_id` from the caller, else `git-context issue-from-branch .`; ask the user if nothing matches. Resolve `WT_PATH` as `git-context repo-root [DIR]`, `[DIR]` being `worktree exists`/`worktree path` when they match and `.` otherwise.
+**Issue context.** `issue_id` from the caller, else `git-context issue-from-branch .`; ask the user if nothing matches. Resolve `WT_PATH` as `git-context repo-root "[DIR]"`, `[DIR]` being `worktree exists`/`worktree path` when they match and `.` otherwise.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 Then gather decisions:
 

--- a/skills/orch/workflows/review-pr-comments.md
+++ b/skills/orch/workflows/review-pr-comments.md
@@ -235,6 +235,8 @@ When the list is non-empty, write `[WORKTREE_PATH]/tmp/dev-round-adds-[DEV_ROUND
 
 ⚠ Fill placeholders only ([Format Tags Are Literal](../SKILL.md#format-tags-are-literal)). `Recommendation:` is the technical fix; the agent owns its own process.
 
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+
 <delegation_format>
 Follow workflow: .agents/skills/dev/workflows/dev-fix.md
 

--- a/skills/orch/workflows/review-pr-comments.md
+++ b/skills/orch/workflows/review-pr-comments.md
@@ -72,6 +72,7 @@ Analyze these PR review comments for your domain.
 PR: #[PR_NUMBER] - [TITLE]
 Parent Issue: [ISSUE_ID]
 Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
 
 Decision context (read before classifying — do NOT suggest changes that contradict these):
 [For each verified decision: "[DECISION_ID]: [ONE_LINE_SUMMARY] — [DECISION_FILE_PATH]"]
@@ -237,6 +238,7 @@ Source: pr-comments
 Issue: [ISSUE_ID]
 PR: #[PR_NUMBER]
 Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]

--- a/skills/orch/workflows/review-pr-comments.md
+++ b/skills/orch/workflows/review-pr-comments.md
@@ -46,7 +46,7 @@ gh api user -q .login
 
 **Issue context.** `issue_id` from the caller, else `git-context issue-from-branch .`; ask the user if nothing matches. Resolve `WT_PATH` as `git-context repo-root "[DIR]"`, `[DIR]` being `worktree exists`/`worktree path` when they match and `.` otherwise.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 Then gather decisions:
 
@@ -235,7 +235,7 @@ When the list is non-empty, write `[WORKTREE_PATH]/tmp/dev-round-adds-[DEV_ROUND
 
 ⚠ Fill placeholders only ([Format Tags Are Literal](../SKILL.md#format-tags-are-literal)). `Recommendation:` is the technical fix; the agent owns its own process.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 <delegation_format>
 Follow workflow: .agents/skills/dev/workflows/dev-fix.md

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -130,7 +130,7 @@ Delegate to every reviewer in the active set in parallel. When `EXTERNAL_REVIEW_
 Follow workflow: .agents/skills/reviewer/workflows/review.md
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
 Branch: [BRANCH]
 Artifact: [ARTIFACT_PATH]
 
@@ -370,7 +370,7 @@ Issue: [ISSUE_ID]
 Tracker: [TRACKER] [OWNER/REPO]
 Branch: [BRANCH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
 Trigger: [QA signal]
 
 Dev summary:

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -12,7 +12,7 @@ Pre-submission review: reviewer fan-out, bounded fix rounds, QA checks, and the 
 
 **With a PR number**: `github.sh pr-issue [PR_NUMBER] --format=text` gives `ISSUE`. Apply [Worktree Scope](../SKILL.md#workflow-execution); ask before `worktree create $ISSUE --pr [PR_NUMBER]`. With no argument, `WT_PATH` is `git-context repo-root .`.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 **Standalone init** (`lifecycle: "self"`): resolve `ISSUE_ID` with `git-context issue-from-branch .`, then `workflow-state exists --json [ISSUE_ID]`; when absent, initialize with `git-context branch [WT_PATH]` and `workflow-state init`, and resolve `TRACKER`. On this path § 5 derives its QA signals from the diff scan and judgment — there is no dev artifact.
 

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -12,7 +12,7 @@ Pre-submission review: reviewer fan-out, bounded fix rounds, QA checks, and the 
 
 **With a PR number**: `github.sh pr-issue [PR_NUMBER] --format=text` gives `ISSUE`. Apply [Worktree Scope](../SKILL.md#workflow-execution); ask before `worktree create $ISSUE --pr [PR_NUMBER]`. With no argument, `WT_PATH` is `git-context repo-root .`.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 **Standalone init** (`lifecycle: "self"`): resolve `ISSUE_ID` with `git-context issue-from-branch .`, then `workflow-state exists --json [ISSUE_ID]`; when absent, initialize with `git-context branch [WT_PATH]` and `workflow-state init`, and resolve `TRACKER`. On this path § 5 derives its QA signals from the diff scan and judgment — there is no dev artifact.
 
@@ -365,7 +365,7 @@ Drop a signal when the triggering code is trivial or test-only; never drop one f
 
 Map each signal to its agent — `needs-safety-audit` → `reviewer-safety`, `needs-perf-test` → `reviewer-perf`, `needs-review` → `reviewer-correctness`; a project may override the mapping in its instructions. For each, delegate and wait.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 <delegation_format>
 Follow workflow: .agents/skills/reviewer/workflows/qa-review.md

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -130,7 +130,7 @@ Delegate to every reviewer in the active set in parallel. When `EXTERNAL_REVIEW_
 Follow workflow: .agents/skills/reviewer/workflows/review.md
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Branch: [BRANCH]
 Artifact: [ARTIFACT_PATH]
 
@@ -370,7 +370,7 @@ Issue: [ISSUE_ID]
 Tracker: [TRACKER] [OWNER/REPO]
 Branch: [BRANCH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Trigger: [QA signal]
 
 Dev summary:

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -10,7 +10,9 @@ Pre-submission review: reviewer fan-out, bounded fix rounds, QA checks, and the 
 
 **Caller context** (via `⤵`): `worktree`; `agents` — an explicit reviewer panel, default every `reviewer-*` agent the harness exposes; `lifecycle` — `"managed"` (return at § 9) or `"self"` (default); `dev_agent` — a live dev agent for fix delegation; `issue_id` — the workflow-state key, the normalized issue ID, never the bare GitHub issue number.
 
-**With a PR number**: `github.sh pr-issue [PR_NUMBER] --format=text` gives `ISSUE`. Apply [Worktree Scope](../SKILL.md#workflow-execution); ask before `worktree create $ISSUE --pr [PR_NUMBER]`. With no argument, `WT_PATH` is the current directory.
+**With a PR number**: `github.sh pr-issue [PR_NUMBER] --format=text` gives `ISSUE`. Apply [Worktree Scope](../SKILL.md#workflow-execution); ask before `worktree create $ISSUE --pr [PR_NUMBER]`. With no argument, `WT_PATH` is `git-context repo-root .`.
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 **Standalone init** (`lifecycle: "self"`): resolve `ISSUE_ID` with `git-context issue-from-branch .`, then `workflow-state exists --json [ISSUE_ID]`; when absent, initialize with `git-context branch [WT_PATH]` and `workflow-state init`, and resolve `TRACKER`. On this path § 5 derives its QA signals from the diff scan and judgment — there is no dev artifact.
 

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -130,7 +130,7 @@ Delegate to every reviewer in the active set in parallel. When `EXTERNAL_REVIEW_
 Follow workflow: .agents/skills/reviewer/workflows/review.md
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
 Branch: [BRANCH]
 Artifact: [ARTIFACT_PATH]
 
@@ -370,7 +370,7 @@ Issue: [ISSUE_ID]
 Tracker: [TRACKER] [OWNER/REPO]
 Branch: [BRANCH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
 Trigger: [QA signal]
 
 Dev summary:

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -130,7 +130,7 @@ Delegate to every reviewer in the active set in parallel. When `EXTERNAL_REVIEW_
 Follow workflow: .agents/skills/reviewer/workflows/review.md
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Branch: [BRANCH]
 Artifact: [ARTIFACT_PATH]
 
@@ -370,7 +370,7 @@ Issue: [ISSUE_ID]
 Tracker: [TRACKER] [OWNER/REPO]
 Branch: [BRANCH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Trigger: [QA signal]
 
 Dev summary:

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -363,7 +363,9 @@ Drop a signal when the triggering code is trivial or test-only; never drop one f
 
 **Skip if** the recorded `qa_decision.signals` is empty → § 7, which finds no QA artifacts, converges, and routes on: the exit is decided in one place even when QA never ran.
 
-Map each signal to its agent — `needs-safety-audit` → `reviewer-safety`, `needs-perf-test` → `reviewer-perf`, `needs-review` → `reviewer-correctness`; a project may override the mapping in its instructions. For each, delegate and wait:
+Map each signal to its agent — `needs-safety-audit` → `reviewer-safety`, `needs-perf-test` → `reviewer-perf`, `needs-review` → `reviewer-correctness`; a project may override the mapping in its instructions. For each, delegate and wait.
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 <delegation_format>
 Follow workflow: .agents/skills/reviewer/workflows/qa-review.md

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -13,6 +13,7 @@ Pre-submission review: reviewer fan-out, bounded fix rounds, QA checks, and the 
 **With a PR number**: `github.sh pr-issue [PR_NUMBER] --format=text` gives `ISSUE`. Apply [Worktree Scope](../SKILL.md#workflow-execution); ask before `worktree create $ISSUE --pr [PR_NUMBER]`. With no argument, `WT_PATH` is `git-context repo-root .`.
 
 Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the checkout the paragraph above resolves `WT_PATH` from.
 
 **Standalone init** (`lifecycle: "self"`): resolve `ISSUE_ID` with `git-context issue-from-branch .`, then `workflow-state exists --json [ISSUE_ID]`; when absent, initialize with `git-context branch [WT_PATH]` and `workflow-state init`, and resolve `TRACKER`. On this path § 5 derives its QA signals from the diff scan and judgment — there is no dev artifact.
 
@@ -366,6 +367,7 @@ Drop a signal when the triggering code is trivial or test-only; never drop one f
 Map each signal to its agent — `needs-safety-audit` → `reviewer-safety`, `needs-perf-test` → `reviewer-perf`, `needs-review` → `reviewer-correctness`; a project may override the mapping in its instructions. For each, delegate and wait.
 
 Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the checkout the top of this workflow resolves `WT_PATH` from.
 
 <delegation_format>
 Follow workflow: .agents/skills/reviewer/workflows/qa-review.md

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -130,6 +130,7 @@ Delegate to every reviewer in the active set in parallel. When `EXTERNAL_REVIEW_
 Follow workflow: .agents/skills/reviewer/workflows/review.md
 
 Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
 Branch: [BRANCH]
 Artifact: [ARTIFACT_PATH]
 
@@ -369,6 +370,7 @@ Issue: [ISSUE_ID]
 Tracker: [TRACKER] [OWNER/REPO]
 Branch: [BRANCH]
 Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
 Trigger: [QA signal]
 
 Dev summary:

--- a/skills/orch/workflows/review.md
+++ b/skills/orch/workflows/review.md
@@ -20,6 +20,7 @@ On-demand review of local changes: review, present findings, and offer to fix th
 Use the outputs as `BRANCH`, `ISSUE_ID` (empty means skip every workflow-state step), and `BASE_BRANCH`; `WT_PATH` is `git-context repo-root .`.
 
 Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the `.` the line above resolves `WT_PATH` from.
 
 | Argument | `DIFF_RANGE` |
 |----------|-------------|

--- a/skills/orch/workflows/review.md
+++ b/skills/orch/workflows/review.md
@@ -19,7 +19,7 @@ On-demand review of local changes: review, present findings, and offer to fix th
 
 Use the outputs as `BRANCH`, `ISSUE_ID` (empty means skip every workflow-state step), and `BASE_BRANCH`; `WT_PATH` is `git-context repo-root .`.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 | Argument | `DIFF_RANGE` |
 |----------|-------------|

--- a/skills/orch/workflows/review.md
+++ b/skills/orch/workflows/review.md
@@ -17,7 +17,9 @@ On-demand review of local changes: review, present findings, and offer to fix th
 .agents/skills/orch/scripts/resolve-base-branch .
 ```
 
-Use the outputs as `BRANCH`, `ISSUE_ID` (empty means skip every workflow-state step), and `BASE_BRANCH`; `WT_PATH` is the current directory.
+Use the outputs as `BRANCH`, `ISSUE_ID` (empty means skip every workflow-state step), and `BASE_BRANCH`; `WT_PATH` is `git-context repo-root .`.
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 | Argument | `DIFF_RANGE` |
 |----------|-------------|

--- a/skills/orch/workflows/review.md
+++ b/skills/orch/workflows/review.md
@@ -60,7 +60,7 @@ A failed check omits the path and carries `- decision index lookup failed for [D
 Follow workflow: .agents/skills/reviewer/workflows/review.md
 
 Worktree: [WT_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WT_PATH]"`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WT_PATH], because a bare `cd` may not survive into the next tool call.
 Branch: [BRANCH]
 Diff-range: [DIFF_RANGE]
 

--- a/skills/orch/workflows/review.md
+++ b/skills/orch/workflows/review.md
@@ -60,6 +60,7 @@ A failed check omits the path and carries `- decision index lookup failed for [D
 Follow workflow: .agents/skills/reviewer/workflows/review.md
 
 Worktree: [WT_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WT_PATH]`, re-run `pwd`, and report where it started.
 Branch: [BRANCH]
 Diff-range: [DIFF_RANGE]
 

--- a/skills/orch/workflows/review.md
+++ b/skills/orch/workflows/review.md
@@ -60,7 +60,7 @@ A failed check omits the path and carries `- decision index lookup failed for [D
 Follow workflow: .agents/skills/reviewer/workflows/review.md
 
 Worktree: [WT_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WT_PATH]`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WT_PATH]"`, re-run `pwd`, and report where it started.
 Branch: [BRANCH]
 Diff-range: [DIFF_RANGE]
 

--- a/skills/orch/workflows/review.md
+++ b/skills/orch/workflows/review.md
@@ -60,7 +60,7 @@ A failed check omits the path and carries `- decision index lookup failed for [D
 Follow workflow: .agents/skills/reviewer/workflows/review.md
 
 Worktree: [WT_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WT_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Branch: [BRANCH]
 Diff-range: [DIFF_RANGE]
 

--- a/skills/orch/workflows/review.md
+++ b/skills/orch/workflows/review.md
@@ -60,7 +60,7 @@ A failed check omits the path and carries `- decision index lookup failed for [D
 Follow workflow: .agents/skills/reviewer/workflows/review.md
 
 Worktree: [WT_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Branch: [BRANCH]
 Diff-range: [DIFF_RANGE]
 

--- a/skills/orch/workflows/review.md
+++ b/skills/orch/workflows/review.md
@@ -19,7 +19,7 @@ On-demand review of local changes: review, present findings, and offer to fix th
 
 Use the outputs as `BRANCH`, `ISSUE_ID` (empty means skip every workflow-state step), and `BASE_BRANCH`; `WT_PATH` is `git-context repo-root .`.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 | Argument | `DIFF_RANGE` |
 |----------|-------------|

--- a/skills/orch/workflows/start-worktree.md
+++ b/skills/orch/workflows/start-worktree.md
@@ -15,7 +15,7 @@ The full session from inside a worktree: implement → review → submit → fin
    .agents/skills/orch/scripts/git-context issue-from-branch .
    ```
 
-   Resolve `TRACKER` per [SKILL.md § Tracker Resolution](../SKILL.md#tracker-resolution). Set `WORKTREE_PATH` to the current directory.
+   Resolve `TRACKER` per [SKILL.md § Tracker Resolution](../SKILL.md#tracker-resolution). Set `WORKTREE_PATH` to `git-context repo-root .`.
 
 2. **Refuse containers** — Linear only, before any state exists. Apply the Ancestor gate ([SKILL.md § Coordination](../SKILL.md#coordination)) to:
 

--- a/skills/orch/workflows/submit-pr.md
+++ b/skills/orch/workflows/submit-pr.md
@@ -10,7 +10,7 @@ Run a local pre-PR review, push, create or update the PR, triage review comments
 
 **Caller context** (via `⤵`): `worktree`; `lifecycle` — `"managed"` (return at § 7) or `"self"` (default); `issue_id` — the workflow-state key, the normalized issue ID, never the bare GitHub issue number.
 
-**With a PR number**: `github.sh pr-issue [PR_NUMBER] --format=text` gives `ISSUE_ID`; `worktree exists`/`worktree path` give `[DIR]`, or ask before creating one when already inside the PR checkout; with no argument `[DIR]` is `.`. `WT_PATH` is `git-context repo-root [DIR]`.
+**With a PR number**: `github.sh pr-issue [PR_NUMBER] --format=text` gives `ISSUE_ID`; `worktree exists`/`worktree path` give `[DIR]`, or ask before creating one when already inside the PR checkout; with no argument `[DIR]` is `.`. `WT_PATH` is `git-context repo-root "[DIR]"`.
 
 **Standalone init** (`lifecycle: "self"`): resolve `ISSUE_ID` with `git-context issue-from-branch .`, then `workflow-state exists --json [ISSUE_ID]`; when absent, initialize with `git-context branch [WT_PATH]` and `workflow-state init`.
 

--- a/skills/orch/workflows/submit-pr.md
+++ b/skills/orch/workflows/submit-pr.md
@@ -10,7 +10,7 @@ Run a local pre-PR review, push, create or update the PR, triage review comments
 
 **Caller context** (via `⤵`): `worktree`; `lifecycle` — `"managed"` (return at § 7) or `"self"` (default); `issue_id` — the workflow-state key, the normalized issue ID, never the bare GitHub issue number.
 
-**With a PR number**: `github.sh pr-issue [PR_NUMBER] --format=text` gives `ISSUE_ID`; `worktree exists`/`worktree path` give `WT_PATH`, or ask before creating one when already inside the PR checkout. With no argument, `WT_PATH` is the current directory.
+**With a PR number**: `github.sh pr-issue [PR_NUMBER] --format=text` gives `ISSUE_ID`; `worktree exists`/`worktree path` give `[DIR]`, or ask before creating one when already inside the PR checkout; with no argument `[DIR]` is `.`. `WT_PATH` is `git-context repo-root [DIR]`.
 
 **Standalone init** (`lifecycle: "self"`): resolve `ISSUE_ID` with `git-context issue-from-branch .`, then `workflow-state exists --json [ISSUE_ID]`; when absent, initialize with `git-context branch [WT_PATH]` and `workflow-state init`.
 

--- a/skills/project-management/workflows/audit-issues.md
+++ b/skills/project-management/workflows/audit-issues.md
@@ -146,10 +146,11 @@ Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
 
 Arguments: --project "[PROJECT_NAME]" | --team | --issues [FILE_PATH]
 Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
 Tracker: [TRACKER] [OWNER/REPO]
 </delegation_format>
 
-Omit `Worktree:` for the main repo and `[OWNER/REPO]` when `TRACKER=linear`.
+Omit `Worktree:` and its `Worktree Check:` together for the main repo, and `[OWNER/REPO]` when `TRACKER=linear`.
 
 ### 4.2 Collect and Validate
 

--- a/skills/project-management/workflows/audit-issues.md
+++ b/skills/project-management/workflows/audit-issues.md
@@ -93,7 +93,8 @@ Worktree: [WORKTREE_PATH]
 Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 </delegation_format>
 
-Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, per § 4.1.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the caller's own checkout, per § 4.1.
 
 ### 2.2 Materialize and Present
 

--- a/skills/project-management/workflows/audit-issues.md
+++ b/skills/project-management/workflows/audit-issues.md
@@ -146,11 +146,11 @@ Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
 
 Arguments: --project "[PROJECT_NAME]" | --team | --issues [FILE_PATH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd [WORKTREE_PATH]`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
 Tracker: [TRACKER] [OWNER/REPO]
 </delegation_format>
 
-Omit `Worktree:` and its `Worktree Check:` together for the main repo, and `[OWNER/REPO]` when `TRACKER=linear`.
+`Worktree:` and its `Worktree Check:` always ship together, main repo included — fill both with the main checkout's absolute path, which the delegate proves against exactly as it would a worktree's. Omit `[OWNER/REPO]` when `TRACKER=linear`.
 
 ### 4.2 Collect and Validate
 

--- a/skills/project-management/workflows/audit-issues.md
+++ b/skills/project-management/workflows/audit-issues.md
@@ -90,7 +90,7 @@ Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
 
 Arguments: --project-order
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 </delegation_format>
 
 Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, per § 4.1.
@@ -150,7 +150,7 @@ Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
 
 Arguments: --project "[PROJECT_NAME]" | --team | --issues [FILE_PATH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Tracker: [TRACKER] [OWNER/REPO]
 </delegation_format>
 

--- a/skills/project-management/workflows/audit-issues.md
+++ b/skills/project-management/workflows/audit-issues.md
@@ -85,7 +85,7 @@ No sync step. Load project taxonomy the same way as Linear mode; with no declare
 
 Spawn a one-shot `[TPM]` sub-agent (not a teammate — no re-delegation).
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the caller's own checkout, per § 4.1.
 
 <delegation_format>
@@ -146,7 +146,7 @@ With `TARGET` set, use it. Otherwise take the first `session-status.projects` en
 
 Spawn a one-shot `[TPM]` sub-agent (not a teammate).
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the caller worktree § 4.2 step 2 resolves, which is the main checkout only when the main checkout is the caller.
 
 <delegation_format>

--- a/skills/project-management/workflows/audit-issues.md
+++ b/skills/project-management/workflows/audit-issues.md
@@ -90,7 +90,7 @@ Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
 
 Arguments: --project-order
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 </delegation_format>
 
 Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, per § 4.1.
@@ -150,7 +150,7 @@ Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
 
 Arguments: --project "[PROJECT_NAME]" | --team | --issues [FILE_PATH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 Tracker: [TRACKER] [OWNER/REPO]
 </delegation_format>
 

--- a/skills/project-management/workflows/audit-issues.md
+++ b/skills/project-management/workflows/audit-issues.md
@@ -89,7 +89,11 @@ Spawn a one-shot `[TPM]` sub-agent (not a teammate — no re-delegation):
 Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
 
 Arguments: --project-order
+Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
 </delegation_format>
+
+Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, per § 4.1.
 
 ### 2.2 Materialize and Present
 
@@ -146,7 +150,7 @@ Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
 
 Arguments: --project "[PROJECT_NAME]" | --team | --issues [FILE_PATH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
 Tracker: [TRACKER] [OWNER/REPO]
 </delegation_format>
 

--- a/skills/project-management/workflows/audit-issues.md
+++ b/skills/project-management/workflows/audit-issues.md
@@ -86,7 +86,7 @@ No sync step. Load project taxonomy the same way as Linear mode; with no declare
 Spawn a one-shot `[TPM]` sub-agent (not a teammate — no re-delegation).
 
 Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
-`[DIR]` is the caller's own checkout, per § 4.1.
+`[DIR]` is the current repo root; project-order mode takes no input file.
 
 <delegation_format>
 Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
@@ -147,7 +147,7 @@ With `TARGET` set, use it. Otherwise take the first `session-status.projects` en
 Spawn a one-shot `[TPM]` sub-agent (not a teammate).
 
 Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
-`[DIR]` is the caller worktree § 4.2 step 2 resolves, which is the main checkout only when the main checkout is the caller.
+`[DIR]` is the input file's `worktree` when the invocation supplied one, the current repo root otherwise.
 
 <delegation_format>
 Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md

--- a/skills/project-management/workflows/audit-issues.md
+++ b/skills/project-management/workflows/audit-issues.md
@@ -154,7 +154,7 @@ Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_
 Tracker: [TRACKER] [OWNER/REPO]
 </delegation_format>
 
-`Worktree:` and its `Worktree Check:` always ship together, main repo included — fill both with the main checkout's absolute path, which the delegate proves against exactly as it would a worktree's. Omit `[OWNER/REPO]` when `TRACKER=linear`.
+`Worktree:` and its `Worktree Check:` always ship together. Fill both with the absolute path of the caller worktree § 4.2 step 2 resolves, which is the main checkout only when the main checkout is the caller. Omit `[OWNER/REPO]` when `TRACKER=linear`.
 
 ### 4.2 Collect and Validate
 

--- a/skills/project-management/workflows/audit-issues.md
+++ b/skills/project-management/workflows/audit-issues.md
@@ -83,7 +83,10 @@ No sync step. Load project taxonomy the same way as Linear mode; with no declare
 
 ### 2.1 Delegate
 
-Spawn a one-shot `[TPM]` sub-agent (not a teammate — no re-delegation):
+Spawn a one-shot `[TPM]` sub-agent (not a teammate — no re-delegation).
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the caller's own checkout, per § 4.1.
 
 <delegation_format>
 Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
@@ -92,9 +95,6 @@ Arguments: --project-order
 Worktree: [WORKTREE_PATH]
 Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 </delegation_format>
-
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
-`[DIR]` is the caller's own checkout, per § 4.1.
 
 ### 2.2 Materialize and Present
 
@@ -144,7 +144,10 @@ With `TARGET` set, use it. Otherwise take the first `session-status.projects` en
 
 ### 4.1 Delegate
 
-Spawn a one-shot `[TPM]` sub-agent (not a teammate):
+Spawn a one-shot `[TPM]` sub-agent (not a teammate).
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the caller worktree § 4.2 step 2 resolves, which is the main checkout only when the main checkout is the caller.
 
 <delegation_format>
 Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
@@ -155,7 +158,7 @@ Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTR
 Tracker: [TRACKER] [OWNER/REPO]
 </delegation_format>
 
-`Worktree:` and its `Worktree Check:` always ship together. Fill both with the absolute path of the caller worktree § 4.2 step 2 resolves, which is the main checkout only when the main checkout is the caller. Omit `[OWNER/REPO]` when `TRACKER=linear`.
+Omit `[OWNER/REPO]` when `TRACKER=linear`.
 
 ### 4.2 Collect and Validate
 

--- a/skills/project-management/workflows/audit-issues.md
+++ b/skills/project-management/workflows/audit-issues.md
@@ -93,7 +93,7 @@ Worktree: [WORKTREE_PATH]
 Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 </delegation_format>
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the caller's own checkout, per § 4.1.
 
 ### 2.2 Materialize and Present

--- a/skills/project-management/workflows/cycle-plan.md
+++ b/skills/project-management/workflows/cycle-plan.md
@@ -15,7 +15,7 @@ This workflow mutates project state, so it reconciles before anything reads the 
    <delegation_format>
    Follow workflow: .agents/skills/project-management/workflows/tpm-cycle-plan.md
    Worktree: [WORKTREE_PATH]
-   Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+   Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
    </delegation_format>
 
    Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, main checkout included.

--- a/skills/project-management/workflows/cycle-plan.md
+++ b/skills/project-management/workflows/cycle-plan.md
@@ -15,7 +15,7 @@ This workflow mutates project state, so it reconciles before anything reads the 
    <delegation_format>
    Follow workflow: .agents/skills/project-management/workflows/tpm-cycle-plan.md
    Worktree: [WORKTREE_PATH]
-   Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+   Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
    </delegation_format>
 
    Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, main checkout included.

--- a/skills/project-management/workflows/cycle-plan.md
+++ b/skills/project-management/workflows/cycle-plan.md
@@ -12,7 +12,7 @@ This workflow mutates project state, so it reconciles before anything reads the 
 
 1. **Delegate** to a one-shot `[TPM]` sub-agent.
 
-   Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+   Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
    `[DIR]` is the caller's own checkout, main checkout included.
 
    <delegation_format>

--- a/skills/project-management/workflows/cycle-plan.md
+++ b/skills/project-management/workflows/cycle-plan.md
@@ -14,7 +14,11 @@ This workflow mutates project state, so it reconciles before anything reads the 
 
    <delegation_format>
    Follow workflow: .agents/skills/project-management/workflows/tpm-cycle-plan.md
+   Worktree: [WORKTREE_PATH]
+   Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
    </delegation_format>
+
+   Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, main checkout included.
 
 2. **Materialize the artifact.** The agent returns a `File:` hint and fenced JSON. Write the inline JSON to that path under the current repo root and read it; if inline JSON is missing and the path is not already readable, halt and request a rerun with inline JSON.
 

--- a/skills/project-management/workflows/cycle-plan.md
+++ b/skills/project-management/workflows/cycle-plan.md
@@ -18,7 +18,7 @@ This workflow mutates project state, so it reconciles before anything reads the 
    Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
    </delegation_format>
 
-   Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+   Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
    `[DIR]` is the caller's own checkout, main checkout included.
 
 2. **Materialize the artifact.** The agent returns a `File:` hint and fenced JSON. Write the inline JSON to that path under the current repo root and read it; if inline JSON is missing and the path is not already readable, halt and request a rerun with inline JSON.

--- a/skills/project-management/workflows/cycle-plan.md
+++ b/skills/project-management/workflows/cycle-plan.md
@@ -10,16 +10,16 @@ This workflow mutates project state, so it reconciles before anything reads the 
 .agents/skills/linear/scripts/linear.sh sync --reconcile
 ```
 
-1. **Delegate** to a one-shot `[TPM]` sub-agent:
+1. **Delegate** to a one-shot `[TPM]` sub-agent.
+
+   Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+   `[DIR]` is the caller's own checkout, main checkout included.
 
    <delegation_format>
    Follow workflow: .agents/skills/project-management/workflows/tpm-cycle-plan.md
    Worktree: [WORKTREE_PATH]
    Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
    </delegation_format>
-
-   Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
-   `[DIR]` is the caller's own checkout, main checkout included.
 
 2. **Materialize the artifact.** The agent returns a `File:` hint and fenced JSON. Write the inline JSON to that path under the current repo root and read it; if inline JSON is missing and the path is not already readable, halt and request a rerun with inline JSON.
 

--- a/skills/project-management/workflows/cycle-plan.md
+++ b/skills/project-management/workflows/cycle-plan.md
@@ -18,7 +18,8 @@ This workflow mutates project state, so it reconciles before anything reads the 
    Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
    </delegation_format>
 
-   Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, main checkout included.
+   Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+   `[DIR]` is the caller's own checkout, main checkout included.
 
 2. **Materialize the artifact.** The agent returns a `File:` hint and fenced JSON. Write the inline JSON to that path under the current repo root and read it; if inline JSON is missing and the path is not already readable, halt and request a rerun with inline JSON.
 

--- a/skills/project-management/workflows/research-complete.md
+++ b/skills/project-management/workflows/research-complete.md
@@ -51,7 +51,10 @@ With several references, convert to a bulleted list under one `**Research**:` he
 
 ## 5. Analyze Impact
 
-Run exactly one flow, unless it escalates. In either flow, fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, main checkout included.
+Run exactly one flow, unless it escalates. Both flows fill the delegation the same way.
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the caller's own checkout, main checkout included.
 
 ### 5.1 Targeted
 

--- a/skills/project-management/workflows/research-complete.md
+++ b/skills/project-management/workflows/research-complete.md
@@ -53,7 +53,7 @@ With several references, convert to a bulleted list under one `**Research**:` he
 
 Run exactly one flow, unless it escalates. Both flows fill the delegation the same way.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 ### 5.1 Targeted
@@ -88,7 +88,7 @@ List a technical change only when it changes what a user or operator experiences
 
 Delegate the same analysis to every affected domain agent in parallel, minus the cross-domain and scope questions. Then delegate the synthesis to the architecture review agent.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 <delegation_format>
 Synthesize the domain reports into a cross-cutting impact analysis.

--- a/skills/project-management/workflows/research-complete.md
+++ b/skills/project-management/workflows/research-complete.md
@@ -86,7 +86,9 @@ List a technical change only when it changes what a user or operator experiences
 
 ### 5.2 Pervasive
 
-Delegate the same analysis to every affected domain agent in parallel, minus the cross-domain and scope questions. Then delegate the synthesis to the architecture review agent:
+Delegate the same analysis to every affected domain agent in parallel, minus the cross-domain and scope questions. Then delegate the synthesis to the architecture review agent.
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 
 <delegation_format>
 Synthesize the domain reports into a cross-cutting impact analysis.

--- a/skills/project-management/workflows/research-complete.md
+++ b/skills/project-management/workflows/research-complete.md
@@ -51,7 +51,7 @@ With several references, convert to a bulleted list under one `**Research**:` he
 
 ## 5. Analyze Impact
 
-Run exactly one flow, unless it escalates.
+Run exactly one flow, unless it escalates. In either flow, fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, main checkout included.
 
 ### 5.1 Targeted
 
@@ -61,7 +61,7 @@ Delegate to the domain agent:
 Analyze the impact of these research findings on your domain.
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 
 Read: [RESEARCH_DOCS_PATH]/[ISSUE_ID]/findings.md
 
@@ -89,7 +89,7 @@ Delegate the same analysis to every affected domain agent in parallel, minus the
 Synthesize the domain reports into a cross-cutting impact analysis.
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 
 Read: [RESEARCH_DOCS_PATH]/[ISSUE_ID]/findings.md
 

--- a/skills/project-management/workflows/research-complete.md
+++ b/skills/project-management/workflows/research-complete.md
@@ -53,7 +53,7 @@ With several references, convert to a bulleted list under one `**Research**:` he
 
 Run exactly one flow, unless it escalates. Both flows fill the delegation the same way.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 ### 5.1 Targeted

--- a/skills/project-management/workflows/research-complete.md
+++ b/skills/project-management/workflows/research-complete.md
@@ -60,6 +60,9 @@ Delegate to the domain agent:
 <delegation_format>
 Analyze the impact of these research findings on your domain.
 
+Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+
 Read: [RESEARCH_DOCS_PATH]/[ISSUE_ID]/findings.md
 
 Report with tables:
@@ -84,6 +87,9 @@ Delegate the same analysis to every affected domain agent in parallel, minus the
 
 <delegation_format>
 Synthesize the domain reports into a cross-cutting impact analysis.
+
+Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 
 Read: [RESEARCH_DOCS_PATH]/[ISSUE_ID]/findings.md
 

--- a/skills/project-management/workflows/research-issue.md
+++ b/skills/project-management/workflows/research-issue.md
@@ -82,7 +82,7 @@ Re-delegate to `[CONSULTATION_AGENT_NAME]` when the caller supplied one, omittin
 Research: [RESEARCH_ISSUE_ID] - [TOPIC]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 
 Blocked issue: [BLOCKED_ISSUE_ID]
 Read it: `.agents/skills/linear/scripts/linear.sh cache issues get [BLOCKED_ISSUE_ID]`
@@ -155,7 +155,7 @@ Otherwise delegate to `researcher` (or `[RESEARCHER_AGENT_NAME]`):
 Research issue: [RESEARCH_ISSUE_ID] - [TOPIC]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 
 Read:
 - [RESEARCH_DOCS_PATH]/[RESEARCH_ISSUE_ID]/prompt.txt

--- a/skills/project-management/workflows/research-issue.md
+++ b/skills/project-management/workflows/research-issue.md
@@ -103,7 +103,7 @@ Draft your domain's contribution:
 Reply with a structured section per item.
 </delegation_format>
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 ### 2.2 Assemble

--- a/skills/project-management/workflows/research-issue.md
+++ b/skills/project-management/workflows/research-issue.md
@@ -154,6 +154,9 @@ Otherwise delegate to `researcher` (or `[RESEARCHER_AGENT_NAME]`):
 <delegation_format>
 Research issue: [RESEARCH_ISSUE_ID] - [TOPIC]
 
+Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+
 Read:
 - [RESEARCH_DOCS_PATH]/[RESEARCH_ISSUE_ID]/prompt.txt
 - [RESEARCH_DOCS_PATH]/[RESEARCH_ISSUE_ID]/context-*.md

--- a/skills/project-management/workflows/research-issue.md
+++ b/skills/project-management/workflows/research-issue.md
@@ -82,7 +82,7 @@ Re-delegate to `[CONSULTATION_AGENT_NAME]` when the caller supplied one, omittin
 Research: [RESEARCH_ISSUE_ID] - [TOPIC]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 
 Blocked issue: [BLOCKED_ISSUE_ID]
 Read it: `.agents/skills/linear/scripts/linear.sh cache issues get [BLOCKED_ISSUE_ID]`

--- a/skills/project-management/workflows/research-issue.md
+++ b/skills/project-management/workflows/research-issue.md
@@ -103,7 +103,8 @@ Draft your domain's contribution:
 Reply with a structured section per item.
 </delegation_format>
 
-Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, main checkout included.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the caller's own checkout, main checkout included.
 
 ### 2.2 Assemble
 

--- a/skills/project-management/workflows/research-issue.md
+++ b/skills/project-management/workflows/research-issue.md
@@ -78,6 +78,9 @@ Map each domain label to its agent type (project-configurable) and delegate in p
 
 Re-delegate to `[CONSULTATION_AGENT_NAME]` when the caller supplied one, omitting the reading block below. Otherwise start a fresh agent with the full block.
 
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the caller's own checkout, main checkout included.
+
 <delegation_format>
 Research: [RESEARCH_ISSUE_ID] - [TOPIC]
 
@@ -102,9 +105,6 @@ Draft your domain's contribution:
 
 Reply with a structured section per item.
 </delegation_format>
-
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
-`[DIR]` is the caller's own checkout, main checkout included.
 
 ### 2.2 Assemble
 
@@ -150,7 +150,10 @@ Run `[RESEARCH_DOCS_PATH]/[RESEARCH_ISSUE_ID]/run.sh`, or use Pi `web_research` 
 
 **If `auto_execute` is false**: present the issue and assets and stop, noting that the issue is labeled `agent:researcher` and ready.
 
-Otherwise delegate to `researcher` (or `[RESEARCHER_AGENT_NAME]`):
+Otherwise delegate to `researcher` (or `[RESEARCHER_AGENT_NAME]`).
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>
 Research issue: [RESEARCH_ISSUE_ID] - [TOPIC]

--- a/skills/project-management/workflows/research-issue.md
+++ b/skills/project-management/workflows/research-issue.md
@@ -78,7 +78,7 @@ Map each domain label to its agent type (project-configurable) and delegate in p
 
 Re-delegate to `[CONSULTATION_AGENT_NAME]` when the caller supplied one, omitting the reading block below. Otherwise start a fresh agent with the full block.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>
@@ -152,7 +152,7 @@ Run `[RESEARCH_DOCS_PATH]/[RESEARCH_ISSUE_ID]/run.sh`, or use Pi `web_research` 
 
 Otherwise delegate to `researcher` (or `[RESEARCHER_AGENT_NAME]`).
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>

--- a/skills/project-management/workflows/research-issue.md
+++ b/skills/project-management/workflows/research-issue.md
@@ -81,6 +81,9 @@ Re-delegate to `[CONSULTATION_AGENT_NAME]` when the caller supplied one, omittin
 <delegation_format>
 Research: [RESEARCH_ISSUE_ID] - [TOPIC]
 
+Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+
 Blocked issue: [BLOCKED_ISSUE_ID]
 Read it: `.agents/skills/linear/scripts/linear.sh cache issues get [BLOCKED_ISSUE_ID]`
 Read: [RESEARCH_PATHS]
@@ -99,6 +102,8 @@ Draft your domain's contribution:
 
 Reply with a structured section per item.
 </delegation_format>
+
+Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, main checkout included.
 
 ### 2.2 Assemble
 

--- a/skills/project-management/workflows/roadmap-plan.md
+++ b/skills/project-management/workflows/roadmap-plan.md
@@ -61,7 +61,7 @@ With no match, ask the user:
 
 Otherwise, match `FEATURE` keywords and component paths to domain agents (project-configurable) to get `RELEVANT_AGENTS[]`, then delegate to each in parallel.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>
@@ -95,7 +95,7 @@ Build `PROPOSED_ISSUES[]` per [roadmap-plan-input.md](../schemas/roadmap-plan-in
 
 Write the input file per [roadmap-plan-input.md](../schemas/roadmap-plan-input.md) to `tmp/roadmap-input-YYYYMMDD-HHMMSS.json`, including `origin_issue`, `planner_handoff`, and `spec_path` (each null when absent; `spec_path` is set exactly when the artifact in hand — the `@[path]` input or the § 1 disk match — classified as a SPEC). Delegate to a one-shot `[TPM]` sub-agent.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>
@@ -114,7 +114,7 @@ Materialize the returned artifact the same way as audit-issues § 4.2. Read `hie
 
 Delegate to the architecture review agent.
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>

--- a/skills/project-management/workflows/roadmap-plan.md
+++ b/skills/project-management/workflows/roadmap-plan.md
@@ -100,7 +100,8 @@ Worktree: [WORKTREE_PATH]
 Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 </delegation_format>
 
-Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, main checkout included.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the caller's own checkout, main checkout included.
 
 Materialize the returned artifact the same way as audit-issues § 4.2. Read `hierarchy_recommendation`, `cross_project_findings`, `architecture_gaps[]`, `organized_issues[]`, and `project_placement`.
 

--- a/skills/project-management/workflows/roadmap-plan.md
+++ b/skills/project-management/workflows/roadmap-plan.md
@@ -100,7 +100,7 @@ Worktree: [WORKTREE_PATH]
 Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 </delegation_format>
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root [DIR]`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 Materialize the returned artifact the same way as audit-issues § 4.2. Read `hierarchy_recommendation`, `cross_project_findings`, `architecture_gaps[]`, `organized_issues[]`, and `project_placement`.

--- a/skills/project-management/workflows/roadmap-plan.md
+++ b/skills/project-management/workflows/roadmap-plan.md
@@ -95,7 +95,7 @@ Follow workflow: .agents/skills/project-management/workflows/tpm-roadmap-plan.md
 
 Arguments: --input [INPUT_FILE_PATH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 </delegation_format>
 
 Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, main checkout included.

--- a/skills/project-management/workflows/roadmap-plan.md
+++ b/skills/project-management/workflows/roadmap-plan.md
@@ -94,7 +94,11 @@ Write the input file per [roadmap-plan-input.md](../schemas/roadmap-plan-input.m
 Follow workflow: .agents/skills/project-management/workflows/tpm-roadmap-plan.md
 
 Arguments: --input [INPUT_FILE_PATH]
+Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, where a bare `git status` or `tools/guard` answers confidently about the wrong tree. On any other path, report where the shell started and give every later command an absolute path under [WORKTREE_PATH], because a bare `cd` may not survive into the next tool call.
 </delegation_format>
+
+Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, main checkout included.
 
 Materialize the returned artifact the same way as audit-issues § 4.2. Read `hierarchy_recommendation`, `cross_project_findings`, `architecture_gaps[]`, `organized_issues[]`, and `project_placement`.
 

--- a/skills/project-management/workflows/roadmap-plan.md
+++ b/skills/project-management/workflows/roadmap-plan.md
@@ -65,6 +65,8 @@ Otherwise, match `FEATURE` keywords and component paths to domain agents (projec
 Feature: [FEATURE]
 Research: [RESEARCH_PATH or "None"]
 Spec: [SPEC_PATH or "None"] — when set, its approach and workstreams are binding: do not re-litigate them; cut its phases into PR-sized issues
+Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 
 List implementation issues for your domain only. Reply as a table with these columns:
 
@@ -113,6 +115,8 @@ Review proposed roadmap for: [FEATURE]
 
 Proposed project: [project_placement.project_name]
 Spec: [SPEC_PATH or "None"] — when set, the spec's phases bound the roadmap: report anything beyond them as out-of-spec, with why it is needed
+Worktree: [WORKTREE_PATH]
+Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 
 Organized issues:
 [organized_issues]

--- a/skills/project-management/workflows/roadmap-plan.md
+++ b/skills/project-management/workflows/roadmap-plan.md
@@ -59,7 +59,10 @@ With no match, ask the user:
 
 **Slicing mode (SPEC in hand):** delegate one slicing pass per repo or domain the spec touches — at most one specialist each; the template's `Spec:` line carries the binding constraint, and they cut the spec's phases into PR-sized issues with real estimates and conflicts read from the code. Slicing delegates receive the same `<delegation_format>` below and answer in its table.
 
-Otherwise, match `FEATURE` keywords and component paths to domain agents (project-configurable) to get `RELEVANT_AGENTS[]`, then delegate to each in parallel:
+Otherwise, match `FEATURE` keywords and component paths to domain agents (project-configurable) to get `RELEVANT_AGENTS[]`, then delegate to each in parallel.
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>
 Feature: [FEATURE]
@@ -90,7 +93,10 @@ Build `PROPOSED_ISSUES[]` per [roadmap-plan-input.md](../schemas/roadmap-plan-in
 
 ## 3. TPM Analysis
 
-Write the input file per [roadmap-plan-input.md](../schemas/roadmap-plan-input.md) to `tmp/roadmap-input-YYYYMMDD-HHMMSS.json`, including `origin_issue`, `planner_handoff`, and `spec_path` (each null when absent; `spec_path` is set exactly when the artifact in hand — the `@[path]` input or the § 1 disk match — classified as a SPEC). Delegate to a one-shot `[TPM]` sub-agent:
+Write the input file per [roadmap-plan-input.md](../schemas/roadmap-plan-input.md) to `tmp/roadmap-input-YYYYMMDD-HHMMSS.json`, including `origin_issue`, `planner_handoff`, and `spec_path` (each null when absent; `spec_path` is set exactly when the artifact in hand — the `@[path]` input or the § 1 disk match — classified as a SPEC). Delegate to a one-shot `[TPM]` sub-agent.
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>
 Follow workflow: .agents/skills/project-management/workflows/tpm-roadmap-plan.md
@@ -100,16 +106,16 @@ Worktree: [WORKTREE_PATH]
 Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 </delegation_format>
 
-Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
-`[DIR]` is the caller's own checkout, main checkout included.
-
 Materialize the returned artifact the same way as audit-issues § 4.2. Read `hierarchy_recommendation`, `cross_project_findings`, `architecture_gaps[]`, `organized_issues[]`, and `project_placement`.
 
 ---
 
 ## 4. Architecture Review
 
-Delegate to the architecture review agent:
+Delegate to the architecture review agent.
+
+Fill `Worktree:` and its `Worktree Check:` from `git-context repo-root "[DIR]"`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+`[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>
 Review proposed roadmap for: [FEATURE]

--- a/skills/project-management/workflows/roadmap-plan.md
+++ b/skills/project-management/workflows/roadmap-plan.md
@@ -66,7 +66,7 @@ Feature: [FEATURE]
 Research: [RESEARCH_PATH or "None"]
 Spec: [SPEC_PATH or "None"] — when set, its approach and workstreams are binding: do not re-litigate them; cut its phases into PR-sized issues
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 
 List implementation issues for your domain only. Reply as a table with these columns:
 
@@ -97,7 +97,7 @@ Follow workflow: .agents/skills/project-management/workflows/tpm-roadmap-plan.md
 
 Arguments: --input [INPUT_FILE_PATH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 </delegation_format>
 
 Fill `Worktree:` and its `Worktree Check:` with the caller's absolute repo root, main checkout included.
@@ -116,7 +116,7 @@ Review proposed roadmap for: [FEATURE]
 Proposed project: [project_placement.project_name]
 Spec: [SPEC_PATH or "None"] — when set, the spec's phases bound the roadmap: report anything beyond them as out-of-spec, with why it is needed
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
 
 Organized issues:
 [organized_issues]

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -110,6 +110,7 @@ skills/orch/tests/ci_wait.sh	824
 skills/orch/tests/lanes.sh	890
 skills/orch/tests/oversee_watch_lanes.sh	815
 skills/orch/tests/queue_wait.sh	920
+skills/orch/tests/worktree-cwd-precondition-lint.test.sh	940
 skills/preflight/scripts/preflight	1289
 skills/review-gate/scripts/pr-watch.sh	871
 skills/review-gate/scripts/review-predicate-selftest.sh	2514


### PR DESCRIPTION
Two lanes hit this during the KEN-870 and KEN-871 rounds: a delegated agent's shell started in the *other* lane's worktree. Neither wrote to the wrong tree, but the failure is silent while it lasts — a bare `git status`, `tools/guard` or suite run answers confidently about the wrong worktree, and with several live at once the answers look plausible. The KEN-871 lane found it only when `git commit -F tmp/...` could not read its own message file, after guard had already judged the wrong tree.

The delegation carried `Worktree: <absolute path>` as context. Nothing established it as the shell's cwd and nothing checked.

## The change

Every `<delegation_format>` block carries a `Worktree:` line and, on the line below it, a `Worktree Check:` that has the delegate run `pwd` and compare the result against the delegated path before any repo-relative command. On a mismatch the delegate **stops and reports where its shell started**. It does not attempt recovery.

That halt is a deliberate reversal of this PR's first design, which told the delegate to `cd` back. A one-line prose remedy cannot specify a correct cwd fix: a standalone `cd` need not survive into the next tool call under the one-command-per-call contract, and an absolute invocation path does not help either, because `tools/guard:13` is `cd "$(git rev-parse --show-toplevel)"` and re-derives the repo from the process cwd whatever path you invoked it by. Detect-and-halt has nothing left to get wrong, and worktree assignment is the orchestrator's call anyway.

Nothing here is transcribed. The exact sentence lives once, as `$CANON` in the lint below, and every site must equal it with that block's own placeholder substituted. Derive the population rather than reading a count out of this description:

```
bash skills/orch/tests/worktree-cwd-precondition-lint.test.sh   # prints the block count per tree
grep -rl 'Worktree Check:' skills --include='*.md' | grep -v tests
```

At the time of writing that is 21 delegation blocks per tree across 12 workflows in `orch` and `project-management`, and both trees are scanned.

`pwd` rather than anything cleverer, for two reasons. `cd [PATH] && git rev-parse --show-toplevel` establishes the directory and then compares it against itself, which proves nothing. A self-asserting `[ "$PWD" = ... ] || echo` is `&&`/`||` control syntax, which `references/codex-runtime.md` documents the Codex approval=never classifier rejecting — unrunnable on one of three harnesses. `pwd` is one simple command that reports where the shell actually is rather than the path it was handed.

## The lint

`skills/orch/tests/worktree-cwd-precondition-lint.test.sh` — the house pattern, joining thirteen sibling lints in that directory. Part a scans the shipped docs in **both** `skills/` and `.agents/skills/`, part b proves teeth against fixtures, part c proves the two-tree scan itself.

Two things it deliberately does not do, each a reversal of an earlier revision of this PR:

- It does not infer the check from its shape. Matching the label, then the first backticked span, then an anchored span each admitted the next sentence that satisfied the letter and not the point. Whole-sentence comparison ends that: any prose change fails, with no new heuristic and no new probe.
- It does not decide which blocks need the pair. Requiring it only of blocks naming a literal repo-relative path missed blocks with no pair at all, and then blocks whose repo-relative path arrives through a placeholder (`docs/research/[FEATURE].md` reaching a delegate as `RESEARCH_PATH`). The pair is now required of every delegation block, with no path matcher and no carve-out.

Each probe asserts *which* rule fired rather than that something did, so a weakened rule reds the probe that names it rather than passing on a neighbour's failure.

## Live evidence

Three occurrences in one day, the third during this issue's own work: the implementing agent's `pwd` printed the main checkout, caught before any repo-relative command. My own shell drifted mid-round too — `workflow-state update` failed with "run init first" because it resolves its state directory from cwd, and `worktree-push` then declined to record its rebase map for the same reason. Since then the check has fired for real in this lane: a delegate aimed at a sibling worktree halted on it instead of working the wrong tree.

Closes KEN-878
