### PR TITLE
fix(KEN-865): a privileged run writes no record

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,6 +2267,7 @@ version = "5.0.1"
 dependencies = [
  "kendex-core",
  "png 0.18.1",
+ "rustix",
  "serde",
  "serde_json",
  "specta",
@@ -2288,6 +2289,7 @@ dependencies = [
  "clap",
  "cliclack",
  "kendex-core",
+ "rustix",
  "serde_json",
  "tempfile",
  "toml 1.1.4+spec-1.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,10 @@ similar = "2"
 yaml-rust2 = "0.10"
 fd-lock = "4"
 # Already in the tree under fd-lock; used directly for the explicit unlock
-# that releases a lock's open file description before the fd closes.
-rustix = { version = "1", features = ["fs"] }
+# that releases a lock's open file description before the fd closes, and
+# for the effective uid, which is how a run learns it is privileged without
+# reading a variable whoever invoked it chose.
+rustix = { version = "1", features = ["fs", "process"] }
 unicode-normalization = "0.1"
 semver = "1"
 # The app already verifies its own downloads with these, through

--- a/changelog.d/security/KEN-865.md
+++ b/changelog.d/security/KEN-865.md
@@ -1,0 +1,3 @@
+- A run with root privilege writes no `kendex` record file, so a `sudoers` policy
+  keeping `HOME` cannot point a root write at a path the invoking account owns.
+  The next unprivileged run records it.

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -43,6 +43,12 @@ tauri-plugin-updater = "2"
 png = "0.18"
 tempfile.workspace = true
 
+[target.'cfg(unix)'.dev-dependencies]
+# The effective uid, read straight from the syscall so a suite can say why
+# it can observe no record on a runner that is already root — a read the
+# guard under test cannot answer for. Already in the workspace under core.
+rustix.workspace = true
+
 [build-dependencies]
 tauri-build.workspace = true
 

--- a/crates/app/src/app_update/tests.rs
+++ b/crates/app/src/app_update/tests.rs
@@ -2,6 +2,10 @@ use kendex_core::install_channel::HostProbe as _;
 
 use super::*;
 
+#[path = "../../../test_util.rs"]
+mod test_util;
+use test_util::no_record_on_this_runner;
+
 #[test]
 fn only_debug_builds_accept_a_feed_override() {
     let fixture = "file:///fixtures/feed.json".to_owned();
@@ -283,6 +287,9 @@ fn a_failed_app_half_says_whether_the_command_went_ahead_of_it() {
 /// kendex in.
 #[test]
 fn the_app_s_own_image_is_never_the_command_it_carries() {
+    if no_record_on_this_runner() {
+        return;
+    }
     let dir = tempfile::tempdir().unwrap();
     let bin = dir.path().join("bin");
     std::fs::create_dir_all(&bin).unwrap();
@@ -379,6 +386,9 @@ fn a_recorded_command(dir: &tempfile::TempDir) -> (Env, std::ffi::OsString, Path
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_command_that_changed_under_the_card_refuses_the_install() {
+    if no_record_on_this_runner() {
+        return;
+    }
     let dir = tempfile::tempdir().unwrap();
     let (env, path_var, command) = a_recorded_command(&dir);
     let install = AppInstall::AppImage(None);
@@ -413,6 +423,9 @@ fn a_command_that_changed_under_the_card_refuses_the_install() {
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_command_that_became_ours_under_the_card_refuses_too() {
+    if no_record_on_this_runner() {
+        return;
+    }
     let dir = tempfile::tempdir().unwrap();
     let (env, path_var, command) = a_recorded_command(&dir);
     let install = AppInstall::AppImage(None);

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -27,5 +27,11 @@ toml.workspace = true
 # path is a grammar, not a substitution. Already in the tree under tauri.
 url = "2"
 
+[target.'cfg(unix)'.dev-dependencies]
+# The effective uid, read straight from the syscall so a suite can say why
+# it can observe no record on a runner that is already root — a read the
+# guard under test cannot answer for. Already in the workspace under core.
+rustix.workspace = true
+
 [lints]
 workspace = true

--- a/crates/cli/src/commands/update/tests.rs
+++ b/crates/cli/src/commands/update/tests.rs
@@ -8,6 +8,10 @@ use super::*;
 mod fixture_url;
 use fixture_url::file_url;
 
+#[path = "../../../../test_util.rs"]
+mod test_util;
+use test_util::no_record_on_this_runner;
+
 /// The one skew this order can still leave is an app already across
 /// and a command that would not move. It is not a dead end — the
 /// command's version is unchanged, so the next run reads newer and
@@ -451,6 +455,9 @@ fn missing_asset_message_never_calls_current_or_older_available() {
 /// refuse the app the command it just brought current.
 #[test]
 fn an_update_records_the_command_it_is_running_as() {
+    if no_record_on_this_runner() {
+        return;
+    }
     for force in [true, false] {
         let dir = tempfile::tempdir().unwrap();
         let (env, feed_url, installed) = a_release_is_out(&dir);
@@ -492,6 +499,9 @@ fn an_update_records_the_command_it_is_running_as() {
 /// existed is missing, and the digest is what makes it usable.
 #[test]
 fn a_run_with_nothing_to_do_records_the_bytes_already_installed() {
+    if no_record_on_this_runner() {
+        return;
+    }
     let dir = tempfile::tempdir().unwrap();
     let (env, _, installed) = a_release_is_out(&dir);
     // A feed offering exactly what is running: nothing to fetch, nothing
@@ -532,6 +542,11 @@ fn a_run_with_nothing_to_do_records_the_bytes_already_installed() {
 /// tell the app to replace bytes the CLI just refused to touch.
 #[test]
 fn a_package_managed_run_records_nothing() {
+    // The nothing this asserts is the package-managed arm's. Under a
+    // root runner it would be the guard's, and every arm would pass.
+    if no_record_on_this_runner() {
+        return;
+    }
     let dir = tempfile::tempdir().unwrap();
     let (env, feed_url, installed) = a_release_is_out(&dir);
     let brew = InstallChannel::Managed {

--- a/crates/cli/tests/command_record.rs
+++ b/crates/cli/tests/command_record.rs
@@ -5,11 +5,18 @@
 //! the defect was never that the write was wrong, it was that nothing
 //! called it outside `kendex update`, and a test that calls the seam
 //! itself would have passed throughout.
+//!
+//! Which is why every case here needs a runner that can write a record.
+//! A run acting as root writes none, and the refusals below — a record
+//! left alone, a link not written through, a pipe never opened — are the
+//! same nothing the guard produces, so under a root runner they would
+//! hold without the code under test having decided anything. Each says so
+//! and stops instead; see `no_record_on_this_runner`.
 #![cfg(unix)]
 
 #[path = "../../test_util.rs"]
 mod test_util;
-use test_util::rooted;
+use test_util::{no_record_on_this_runner, rooted};
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -132,6 +139,9 @@ fn older_than_the_command(link: &Path, command: &Path) {
 #[test]
 #[allow(clippy::unwrap_used)]
 fn any_verb_records_the_command_an_install_never_recorded() {
+    if no_record_on_this_runner() {
+        return;
+    }
     let tmp = tempfile::tempdir().unwrap();
     // The canonical root, and the same one handed to the run: a resolver
     // asked about a different spelling of that directory reads an empty one.
@@ -166,6 +176,9 @@ fn any_verb_records_the_command_an_install_never_recorded() {
 #[test]
 #[allow(clippy::unwrap_used)]
 fn the_forms_clap_answers_itself_record_the_command_too() {
+    if no_record_on_this_runner() {
+        return;
+    }
     for form in ["--version", "--help"] {
         let tmp = tempfile::tempdir().unwrap();
         let home = rooted(&tmp);
@@ -194,6 +207,9 @@ fn the_forms_clap_answers_itself_record_the_command_too() {
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_record_already_there_is_not_written_over_by_a_first_run() {
+    if no_record_on_this_runner() {
+        return;
+    }
     let tmp = tempfile::tempdir().unwrap();
     let home = rooted(&tmp);
     let env = kendex_core::env::Env::host_rooted(&home);
@@ -241,6 +257,9 @@ fn a_record_already_there_is_not_written_over_by_a_first_run() {
 #[test]
 #[allow(clippy::unwrap_used)]
 fn concurrent_first_runs_leave_one_whole_record() {
+    if no_record_on_this_runner() {
+        return;
+    }
     let tmp = tempfile::tempdir().unwrap();
     let home = rooted(&tmp);
     let env = kendex_core::env::Env::host_rooted(&home);
@@ -288,6 +307,9 @@ fn concurrent_first_runs_leave_one_whole_record() {
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_run_does_not_take_the_record_off_another_install() {
+    if no_record_on_this_runner() {
+        return;
+    }
     let tmp = tempfile::tempdir().unwrap();
     let home = rooted(&tmp);
     let env = kendex_core::env::Env::host_rooted(&home);
@@ -305,18 +327,17 @@ fn a_run_does_not_take_the_record_off_another_install() {
     );
 }
 
-/// The bytes a record names after the run that replaced them wrote its own
-/// record somewhere else. What an elevated `kendex update` leaves behind:
-/// the path is still the person's command, the digest is a file that is
-/// gone, and `command_beside_app` stops matching the one command the card
-/// was offering.
+/// The bytes a record names after the run that replaced them wrote no
+/// record. What an elevated `kendex update` leaves behind: the path is
+/// still the person's command, the digest is a file that is gone, and
+/// `command_beside_app` stops matching the one command the card was
+/// offering.
 const REPLACED: &[u8] = b"the bytes an elevated update replaced";
 
-/// A replacement made with privilege the app lacks writes its record into
-/// the privileged account's data directory, so this one keeps naming bytes
-/// that are gone. The next run from the recorded path is running those new
-/// bytes, which is the same proof a first run offers, and it says what is
-/// there now.
+/// A replacement made with privilege the app lacks writes no record at
+/// all, so this one keeps naming bytes that are gone. The next run from
+/// the recorded path is running those new bytes, which is the same proof
+/// a first run offers, and it says what is there now.
 ///
 /// Read back through the resolver rather than off the file: what has to
 /// hold is the answer the app gets, and a test that parses the file itself
@@ -324,6 +345,9 @@ const REPLACED: &[u8] = b"the bytes an elevated update replaced";
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_run_from_the_recorded_path_says_what_replaced_its_bytes() {
+    if no_record_on_this_runner() {
+        return;
+    }
     let tmp = tempfile::tempdir().unwrap();
     let home = rooted(&tmp);
     let env = kendex_core::env::Env::host_rooted(&home);
@@ -357,6 +381,9 @@ fn a_run_from_the_recorded_path_says_what_replaced_its_bytes() {
 #[cfg(target_os = "linux")]
 #[allow(clippy::unwrap_used)]
 fn the_record_a_run_moves_is_the_one_xdg_data_home_names() {
+    if no_record_on_this_runner() {
+        return;
+    }
     let tmp = tempfile::tempdir().unwrap();
     let home = rooted(&tmp);
     // A second home whose Linux data directory is the one the run is told
@@ -394,6 +421,9 @@ fn the_record_a_run_moves_is_the_one_xdg_data_home_names() {
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_run_does_not_say_what_replaced_another_installs_bytes() {
+    if no_record_on_this_runner() {
+        return;
+    }
     let tmp = tempfile::tempdir().unwrap();
     let home = rooted(&tmp);
     let env = kendex_core::env::Env::host_rooted(&home);
@@ -430,6 +460,9 @@ fn a_run_does_not_say_what_replaced_another_installs_bytes() {
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_record_that_still_matches_keeps_its_content_and_stops_being_reread() {
+    if no_record_on_this_runner() {
+        return;
+    }
     let tmp = tempfile::tempdir().unwrap();
     let home = rooted(&tmp);
     let env = kendex_core::env::Env::host_rooted(&home);
@@ -472,6 +505,9 @@ fn a_record_that_still_matches_keeps_its_content_and_stops_being_reread() {
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_repair_leaves_the_record_naming_the_bytes_it_read() {
+    if no_record_on_this_runner() {
+        return;
+    }
     let tmp = tempfile::tempdir().unwrap();
     let home = rooted(&tmp);
     let env = kendex_core::env::Env::host_rooted(&home);
@@ -497,6 +533,9 @@ fn a_repair_leaves_the_record_naming_the_bytes_it_read() {
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_pipe_at_the_record_path_does_not_hold_the_command() {
+    if no_record_on_this_runner() {
+        return;
+    }
     let tmp = tempfile::tempdir().unwrap();
     let home = rooted(&tmp);
     let env = kendex_core::env::Env::host_rooted(&home);
@@ -526,6 +565,9 @@ fn a_pipe_at_the_record_path_does_not_hold_the_command() {
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_link_at_the_record_path_is_not_written_through() {
+    if no_record_on_this_runner() {
+        return;
+    }
     let tmp = tempfile::tempdir().unwrap();
     let home = rooted(&tmp);
     let env = kendex_core::env::Env::host_rooted(&home);

--- a/crates/core/src/command_update/record.rs
+++ b/crates/core/src/command_update/record.rs
@@ -3,12 +3,11 @@
 //!
 //! `install.sh` writes it, `kendex update` refreshes it for the binary it
 //! is running as, and every replacement rewrites it for the bytes that
-//! landed. A replacement made under another account writes that account's
-//! record instead, so the next run from the recorded path moves this one to
-//! the bytes it finds there. Read by `command_update::command_beside_app`,
-//! which will not replace a file no record vouches for.
-//!
-//! Nothing here is written by a privileged run. See [`acting_as_root`].
+//! landed. A replacement made by a privileged run writes no record at all
+//! — see [`acting_as_root`] — so the next run from the recorded path moves
+//! this one to the bytes it finds there. Read by
+//! `command_update::command_beside_app`, which will not replace a file no
+//! record vouches for.
 
 use std::path::{Path, PathBuf};
 
@@ -92,10 +91,15 @@ pub fn record_command(env: &Env, path: &Path, bytes: &[u8]) -> Result<(), String
     record_command_as(env, path, bytes, acting_as_root())
 }
 
-/// The write itself, told who is making it. Split out so a test can drive
-/// the root arm on a machine where it cannot become root; every caller in
-/// the tree reaches it through [`record_command`], which asks the process.
-fn record_command_as(env: &Env, path: &Path, bytes: &[u8], root: bool) -> Result<(), String> {
+/// The write itself, told who is making it. Split out so a suite can drive
+/// either arm whatever uid it is running under; every caller outside a test
+/// reaches it through [`record_command`], which asks the process.
+pub(super) fn record_command_as(
+    env: &Env,
+    path: &Path,
+    bytes: &[u8],
+    root: bool,
+) -> Result<(), String> {
     if root {
         return Ok(());
     }
@@ -187,7 +191,7 @@ pub fn record_first_run(env: &Env, running: &Path) -> Result<(), String> {
 /// [`record_command_as`] is, and guarded before the directory is made:
 /// `create_dir_all` under a root run is already root writing into a tree
 /// the invoking account named.
-fn record_first_run_as(env: &Env, running: &Path, root: bool) -> Result<(), String> {
+pub(super) fn record_first_run_as(env: &Env, running: &Path, root: bool) -> Result<(), String> {
     if root {
         return Ok(());
     }
@@ -259,12 +263,12 @@ fn record_first_run_as(env: &Env, running: &Path, root: bool) -> Result<(), Stri
 /// Move the digest of a record that names the file this process is running
 /// from, where the bytes at that file are no longer the ones it names.
 ///
-/// An update run with the privilege the desktop app lacks writes its record
-/// into the privileged account's data directory, so the record here keeps
-/// naming the bytes that run replaced. `command_beside_app` then stops
-/// matching a command kendex does own, and the card that offered the one
-/// command out of that state falls to the arm that names nobody. The person
-/// is left with a current command the app will never offer to move again.
+/// An update run with the privilege the desktop app lacks writes no record
+/// at all — see [`acting_as_root`] — so the record here keeps naming the
+/// bytes that run replaced. `command_beside_app` then stops matching a
+/// command kendex does own, and the card that offered the one command out
+/// of that state falls to the arm that names nobody. The person is left
+/// with a current command the app will never offer to move again.
 ///
 /// What licenses the write is what licenses a first run, and it is the same
 /// file: a process running from the recorded path is the recorded command,
@@ -354,10 +358,21 @@ fn stamp(file: &Path, written_at: std::time::SystemTime) -> Result<(), String> {
 
 /// The same record, taken from a file already on disk — the running
 /// command identifying itself, where the bytes are not in hand.
+///
+/// A run acting as root writes nothing here either — see
+/// [`acting_as_root`].
 pub fn record_installed(env: &Env, path: &Path) -> Result<(), String> {
+    record_installed_as(env, path, acting_as_root())
+}
+
+/// The read and the write, told who is making them. Split for the reason
+/// [`record_command_as`] is. The read happens either way: it is the caller's
+/// own file, and a root arm that skipped it would leave a suite unable to
+/// tell a refused write from a missing fixture.
+pub(super) fn record_installed_as(env: &Env, path: &Path, root: bool) -> Result<(), String> {
     let bytes = std::fs::read(path)
         .map_err(|error| format!("{} could not be read: {error}", path.display()))?;
-    record_command(env, path, &bytes)
+    record_command_as(env, path, &bytes, root)
 }
 
 #[cfg(test)]

--- a/crates/core/src/command_update/record.rs
+++ b/crates/core/src/command_update/record.rs
@@ -7,6 +7,8 @@
 //! record instead, so the next run from the recorded path moves this one to
 //! the bytes it finds there. Read by `command_update::command_beside_app`,
 //! which will not replace a file no record vouches for.
+//!
+//! Nothing here is written by a privileged run. See [`acting_as_root`].
 
 use std::path::{Path, PathBuf};
 
@@ -30,6 +32,39 @@ pub struct InstalledCommand {
     pub digest: String,
 }
 
+/// Whether this process is acting as root.
+///
+/// Every path written below is resolved from the environment this process
+/// was handed — `HOME` and `XDG_DATA_HOME` decide where [`Env`] puts the
+/// record — and a privileged run was handed that environment by whoever
+/// invoked it. `sudo` resets it on most machines, but a `sudoers` carrying
+/// `env_keep HOME` does not, and then a root process opens a file every
+/// component of whose name belongs to the invoking account: a link there
+/// is followed, and root writes wherever it points.
+///
+/// So a run acting as root writes no record. Nothing is lost by that:
+/// [`refresh_the_replaced_bytes`] moves the digest on any later run from
+/// the recorded path, so the person's own next unprivileged run — any
+/// verb, `--version` included — records the bytes the privileged run put
+/// there, into the file their own account owns.
+///
+/// The effective uid and nothing else. `sudo`, `su`, `doas` and a root
+/// login are one case here and none of them is distinguishable by a
+/// variable: `SUDO_USER` and its neighbours are set by whoever invoked the
+/// command, so a check reading one would be a check the invoker decides.
+#[cfg(unix)]
+fn acting_as_root() -> bool {
+    rustix::process::geteuid().is_root()
+}
+
+/// Windows has no uid to answer with, and none of the elevation this
+/// guards for — a command re-run under another account against the first
+/// account's environment — is reachable there.
+#[cfg(not(unix))]
+fn acting_as_root() -> bool {
+    false
+}
+
 /// The `kendex` command an installer recorded.
 ///
 /// Absent where nothing has been recorded — an install older than this
@@ -50,7 +85,20 @@ pub fn recorded_command(env: &Env) -> Option<InstalledCommand> {
 /// the command there, and rewritten by whatever replaces it: a record left
 /// naming bytes that are gone is a record that stops matching, which
 /// refuses a command kendex does own rather than replacing one it does not.
+///
+/// A run acting as root writes nothing and says so with success — see
+/// [`acting_as_root`].
 pub fn record_command(env: &Env, path: &Path, bytes: &[u8]) -> Result<(), String> {
+    record_command_as(env, path, bytes, acting_as_root())
+}
+
+/// The write itself, told who is making it. Split out so a test can drive
+/// the root arm on a machine where it cannot become root; every caller in
+/// the tree reaches it through [`record_command`], which asks the process.
+fn record_command_as(env: &Env, path: &Path, bytes: &[u8], root: bool) -> Result<(), String> {
+    if root {
+        return Ok(());
+    }
     let file = env.installed_command_file();
     if let Some(parent) = file.parent() {
         std::fs::create_dir_all(parent)
@@ -129,7 +177,20 @@ fn stage(
 /// reads it as no record and the app refuses the command, which is the safe
 /// direction; `kendex update` rewrites it, because that is the run replacing
 /// the bytes.
+///
+/// A run acting as root writes nothing here either — see [`acting_as_root`].
 pub fn record_first_run(env: &Env, running: &Path) -> Result<(), String> {
+    record_first_run_as(env, running, acting_as_root())
+}
+
+/// The bootstrap itself, told who is making it. Split for the reason
+/// [`record_command_as`] is, and guarded before the directory is made:
+/// `create_dir_all` under a root run is already root writing into a tree
+/// the invoking account named.
+fn record_first_run_as(env: &Env, running: &Path, root: bool) -> Result<(), String> {
+    if root {
+        return Ok(());
+    }
     let file = env.installed_command_file();
     let Some(parent) = file.parent() else {
         return Err(format!("{} names no directory", file.display()));

--- a/crates/core/src/command_update/record.rs
+++ b/crates/core/src/command_update/record.rs
@@ -64,6 +64,46 @@ fn acting_as_root() -> bool {
     false
 }
 
+/// What a run is asking to record. The three entries below differ only in
+/// this value, so [`acting_as_root`] is read in one place: a wrapper that
+/// read it for itself would be a second place to get wrong, and only that
+/// wrapper's own test would ever notice.
+pub(super) enum Write<'a> {
+    /// The path a replacement landed at, and the bytes now there.
+    Command(&'a Path, &'a [u8]),
+    /// The file this process is running from.
+    FirstRun(&'a Path),
+    /// A path whose bytes are still on disk to be read.
+    Installed(&'a Path),
+}
+
+/// Make the write, unless this process is one that may not make it.
+fn record(env: &Env, write: Write<'_>) -> Result<(), String> {
+    record_as(env, write, acting_as_root())
+}
+
+/// The same, told who is making it, so a suite drives either arm whatever
+/// uid it is running under. Every caller outside a test comes through
+/// [`record`], which asks the process.
+///
+/// Guarded here and nowhere below, ahead of every read and every
+/// `create_dir_all`: a root run does nothing at all, rather than part of it
+/// into a tree the invoking account named.
+pub(super) fn record_as(env: &Env, write: Write<'_>, root: bool) -> Result<(), String> {
+    if root {
+        return Ok(());
+    }
+    match write {
+        Write::Command(path, bytes) => write_the_command(env, path, bytes),
+        Write::FirstRun(running) => write_the_first_run(env, running),
+        Write::Installed(path) => {
+            let bytes = std::fs::read(path)
+                .map_err(|error| format!("{} could not be read: {error}", path.display()))?;
+            write_the_command(env, path, &bytes)
+        }
+    }
+}
+
 /// The `kendex` command an installer recorded.
 ///
 /// Absent where nothing has been recorded — an install older than this
@@ -86,23 +126,14 @@ pub fn recorded_command(env: &Env) -> Option<InstalledCommand> {
 /// refuses a command kendex does own rather than replacing one it does not.
 ///
 /// A run acting as root writes nothing and says so with success — see
-/// [`acting_as_root`].
+/// [`record_as`].
 pub fn record_command(env: &Env, path: &Path, bytes: &[u8]) -> Result<(), String> {
-    record_command_as(env, path, bytes, acting_as_root())
+    record(env, Write::Command(path, bytes))
 }
 
-/// The write itself, told who is making it. Split out so a suite can drive
-/// either arm whatever uid it is running under; every caller outside a test
-/// reaches it through [`record_command`], which asks the process.
-pub(super) fn record_command_as(
-    env: &Env,
-    path: &Path,
-    bytes: &[u8],
-    root: bool,
-) -> Result<(), String> {
-    if root {
-        return Ok(());
-    }
+/// The write itself. Reached only through [`record_as`], which has already
+/// established this process may make it.
+fn write_the_command(env: &Env, path: &Path, bytes: &[u8]) -> Result<(), String> {
     let file = env.installed_command_file();
     if let Some(parent) = file.parent() {
         std::fs::create_dir_all(parent)
@@ -182,19 +213,15 @@ fn stage(
 /// direction; `kendex update` rewrites it, because that is the run replacing
 /// the bytes.
 ///
-/// A run acting as root writes nothing here either — see [`acting_as_root`].
+/// A run acting as root writes nothing here either — see [`record_as`].
 pub fn record_first_run(env: &Env, running: &Path) -> Result<(), String> {
-    record_first_run_as(env, running, acting_as_root())
+    record(env, Write::FirstRun(running))
 }
 
-/// The bootstrap itself, told who is making it. Split for the reason
-/// [`record_command_as`] is, and guarded before the directory is made:
-/// `create_dir_all` under a root run is already root writing into a tree
-/// the invoking account named.
-pub(super) fn record_first_run_as(env: &Env, running: &Path, root: bool) -> Result<(), String> {
-    if root {
-        return Ok(());
-    }
+/// The bootstrap itself. Reached only through [`record_as`], which refuses
+/// a root run ahead of the `create_dir_all` below: that call is already
+/// root writing into a tree the invoking account named.
+fn write_the_first_run(env: &Env, running: &Path) -> Result<(), String> {
     let file = env.installed_command_file();
     let Some(parent) = file.parent() else {
         return Err(format!("{} names no directory", file.display()));
@@ -359,20 +386,10 @@ fn stamp(file: &Path, written_at: std::time::SystemTime) -> Result<(), String> {
 /// The same record, taken from a file already on disk — the running
 /// command identifying itself, where the bytes are not in hand.
 ///
-/// A run acting as root writes nothing here either — see
-/// [`acting_as_root`].
+/// A run acting as root writes nothing here either, and does not read the
+/// file to find that out — see [`record_as`].
 pub fn record_installed(env: &Env, path: &Path) -> Result<(), String> {
-    record_installed_as(env, path, acting_as_root())
-}
-
-/// The read and the write, told who is making them. Split for the reason
-/// [`record_command_as`] is. The read happens either way: it is the caller's
-/// own file, and a root arm that skipped it would leave a suite unable to
-/// tell a refused write from a missing fixture.
-pub(super) fn record_installed_as(env: &Env, path: &Path, root: bool) -> Result<(), String> {
-    let bytes = std::fs::read(path)
-        .map_err(|error| format!("{} could not be read: {error}", path.display()))?;
-    record_command_as(env, path, &bytes, root)
+    record(env, Write::Installed(path))
 }
 
 #[cfg(test)]

--- a/crates/core/src/command_update/record/tests.rs
+++ b/crates/core/src/command_update/record/tests.rs
@@ -2,12 +2,12 @@
 //! The lookup itself lives in the parent; these are the arms that turn on
 //! the record alone, against real files rather than a described machine.
 //!
-//! The writes below go through the `_as` seam with the identity spelled
-//! out, rather than through the entry points that ask this process. None
-//! of these tests is about privilege, and a suite run as root — a root
-//! dev container is one — would otherwise assert against records the
-//! guard refused to write. That the entry points do ask the process is
-//! proved once, in `a_public_write_follows_this_process_uid`.
+//! The writes below go through [`record_as`] with the identity spelled
+//! out, rather than through the entries that ask this process. None of
+//! these tests is about privilege, and a suite run as root — a root dev
+//! container is one — would otherwise assert against records the guard
+//! refused to write. That every entry does ask the process is proved in
+//! `every_public_write_follows_this_process_uid`.
 
 use super::*;
 
@@ -54,7 +54,7 @@ fn a_record_that_is_not_a_path_and_a_digest_is_no_record() {
 
     // The control: the same file, well formed, is read. Without it every
     // assertion above passes for a reader that returns `None` always.
-    record_command_as(&env, Path::new(installed), WRAPPER, false).unwrap();
+    record_as(&env, Write::Command(Path::new(installed), WRAPPER), false).unwrap();
     assert_eq!(
         recorded_command(&env),
         Some(InstalledCommand {
@@ -75,7 +75,7 @@ fn a_first_run_vouches_for_its_own_file_and_no_other() {
     let env = Env::host_rooted(dir.path());
     let ours = dir.path().join("kendex");
     std::fs::write(&ours, b"the binary that ran").unwrap();
-    record_first_run_as(&env, &ours, false).unwrap();
+    record_as(&env, Write::FirstRun(&ours), false).unwrap();
 
     let wrapper = dir.path().join("bin/kendex");
     std::fs::create_dir_all(wrapper.parent().unwrap()).unwrap();
@@ -188,8 +188,8 @@ fn a_run_acting_as_root_writes_no_record() {
     let running = dir.path().join("kendex");
     std::fs::write(&running, WRAPPER).unwrap();
 
-    record_first_run_as(&env, &running, true).unwrap();
-    record_command_as(&env, &running, WRAPPER, true).unwrap();
+    record_as(&env, Write::FirstRun(&running), true).unwrap();
+    record_as(&env, Write::Command(&running, WRAPPER), true).unwrap();
     assert!(
         !file.exists(),
         "{} was written by a root run",
@@ -203,7 +203,7 @@ fn a_run_acting_as_root_writes_no_record() {
 
     // The control. Same home, same file, same bytes, and the only thing
     // that changed is who is making the write.
-    record_first_run_as(&env, &running, false).unwrap();
+    record_as(&env, Write::FirstRun(&running), false).unwrap();
     assert_eq!(
         recorded_command(&env),
         Some(InstalledCommand {
@@ -213,7 +213,7 @@ fn a_run_acting_as_root_writes_no_record() {
         "the bootstrap did not write where the root arm was asked not to"
     );
     let replaced = b"the bytes that replaced it";
-    record_command_as(&env, &running, replaced, false).unwrap();
+    record_as(&env, Write::Command(&running, replaced), false).unwrap();
     assert_eq!(
         recorded_command(&env).unwrap().digest,
         crate::hash::sha256_hex(replaced),
@@ -221,46 +221,67 @@ fn a_run_acting_as_root_writes_no_record() {
     );
 }
 
-/// The guard is wired to this process's own uid and not to a constant.
+/// The guard is wired to this process's own uid and not to a constant,
+/// on every entry that writes a record.
 ///
-/// The one test here that drives a public entry point, and the one that
-/// has to: what the seam above cannot show is that anything reads the uid
-/// at all. So the entry point is called and its answer held against the
-/// uid read independently — from the syscall, not from [`acting_as_root`],
-/// which is the function this is checking the wiring of.
+/// The tests above drive the seam, which is told an identity and so can
+/// say nothing about where the identity came from. These drive the public
+/// entries, and hold each answer against the uid read independently —
+/// from the syscall, not from [`acting_as_root`], which is the function
+/// whose wiring is in question.
 ///
-/// Both directions fall out of that. A build answering `true` always
-/// strands every person on the record they already had, and fails this on
-/// any unprivileged runner, which is every CI job; a build answering
-/// `false` always is the defect this change exists to close, and fails it
-/// under a root runner. Neither uid is skipped and neither passes for
-/// free.
+/// All three, because the seam takes the identity as an argument and an
+/// argument can be a literal. One entry passing its process's answer says
+/// nothing about the next: `record_command` is the write `kendex update`
+/// makes after the bytes land, and a constant there is this defect back
+/// with the bootstrap still covered.
+///
+/// Both directions fall out of the comparison. A build answering `true`
+/// always strands every person on the record they already had, and fails
+/// this on any unprivileged runner, which is every CI job; a build
+/// answering `false` always is the defect this change exists to close, and
+/// fails it under a root runner. Neither uid is skipped and neither passes
+/// for free.
 #[test]
 #[cfg(unix)]
-fn a_public_write_follows_this_process_uid() {
+fn every_public_write_follows_this_process_uid() {
     let privileged = rustix::process::geteuid().is_root();
-    let dir = tempfile::tempdir().unwrap();
-    let env = Env::host_rooted(dir.path());
-    let running = dir.path().join("kendex");
-    std::fs::write(&running, WRAPPER).unwrap();
+    let entries: [(&str, &dyn Fn(&Env, &Path) -> Result<(), String>); 3] = [
+        ("record_command", &|env, path| {
+            record_command(env, path, WRAPPER)
+        }),
+        ("record_first_run", &record_first_run),
+        ("record_installed", &record_installed),
+    ];
 
-    record_first_run(&env, &running).unwrap();
+    // A home of its own for each: a record already there is what
+    // `record_first_run` reads to decide it is not the first, so one home
+    // shared between them would have an earlier entry answering for a
+    // later one.
+    for (entry, write) in entries {
+        let dir = tempfile::tempdir().unwrap();
+        let env = Env::host_rooted(dir.path());
+        let running = dir.path().join("kendex");
+        std::fs::write(&running, WRAPPER).unwrap();
 
-    assert_eq!(
-        recorded_command(&env).map(|record| record.digest),
-        (!privileged).then(|| crate::hash::sha256_hex(WRAPPER)),
-        "the entry point did not follow this process's uid (root: {privileged})"
-    );
+        write(&env, &running).unwrap();
+
+        assert_eq!(
+            recorded_command(&env).map(|record| record.digest),
+            (!privileged).then(|| crate::hash::sha256_hex(WRAPPER)),
+            "{entry} did not follow this process's uid (root: {privileged})"
+        );
+    }
 
     // The control, on a home of its own: the same write told the opposite
-    // identity does the opposite thing. Without it the assertion above
+    // identity does the opposite thing. Without it every assertion above
     // holds for a writer that never writes, and for one that always does.
     let other = tempfile::tempdir().unwrap();
     let env = Env::host_rooted(other.path());
     let running = other.path().join("kendex");
     std::fs::write(&running, WRAPPER).unwrap();
 
-    record_first_run_as(&env, &running, !privileged).unwrap();
+    record_as(&env, Write::FirstRun(&running), !privileged).unwrap();
 
     assert_eq!(
         recorded_command(&env).map(|record| record.digest),

--- a/crates/core/src/command_update/record/tests.rs
+++ b/crates/core/src/command_update/record/tests.rs
@@ -152,3 +152,84 @@ fn a_staging_write_with_no_free_name_fails() {
         "the taken name was written anyway"
     );
 }
+
+/// A run acting as root writes no record, wherever `HOME` points it.
+///
+/// The case: `sudoers` carrying `env_keep HOME`, so an elevated `kendex
+/// update` resolves the record path out of the invoking account's home and
+/// root then opens a file every component of whose name that account can
+/// replace. Both writers are driven — `record_first_run`, which every verb
+/// reaches before its arguments are parsed, and `record_command`, which
+/// `kendex update` reaches after the bytes land — and neither leaves so
+/// much as the directory behind.
+///
+/// Root is passed in rather than become: this suite runs as a person. What
+/// is real is everything else — the same `Env`, the same functions, a home
+/// on disk. The control is the second half, where the identical calls with
+/// the identical fixture write both records; without it every assertion
+/// above would hold for a pair of functions that never wrote anything.
+#[test]
+#[cfg(unix)]
+fn a_run_acting_as_root_writes_no_record() {
+    let dir = tempfile::tempdir().unwrap();
+    // The home an elevated run would be pointed at: this account's, kept
+    // across the privilege change by the sudoers policy.
+    let theirs = dir.path().join("home");
+    let env = Env::host_rooted(&theirs);
+    let file = env.installed_command_file();
+    let running = dir.path().join("kendex");
+    std::fs::write(&running, WRAPPER).unwrap();
+
+    record_first_run_as(&env, &running, true).unwrap();
+    record_command_as(&env, &running, WRAPPER, true).unwrap();
+    assert!(
+        !file.exists(),
+        "{} was written by a root run",
+        file.display()
+    );
+    assert!(
+        !file.parent().unwrap().exists(),
+        "{} was created by a root run",
+        file.parent().unwrap().display()
+    );
+
+    // The control. Same home, same file, same bytes, and the only thing
+    // that changed is who is making the write.
+    record_first_run_as(&env, &running, false).unwrap();
+    assert_eq!(
+        recorded_command(&env),
+        Some(InstalledCommand {
+            path: running.clone(),
+            digest: crate::hash::sha256_hex(WRAPPER),
+        }),
+        "the bootstrap did not write where the root arm was asked not to"
+    );
+    let replaced = b"the bytes that replaced it";
+    record_command_as(&env, &running, replaced, false).unwrap();
+    assert_eq!(
+        recorded_command(&env).unwrap().digest,
+        crate::hash::sha256_hex(replaced),
+        "the update write did not land where the root arm was asked not to"
+    );
+}
+
+/// The guard is wired to this process's own uid and not to a constant.
+/// Read the other way round, an unprivileged run still records: the public
+/// entry points ask [`acting_as_root`], the suite runs as a person, and the
+/// record lands. A build that answered `true` always would strand every
+/// person on the record they already had.
+#[test]
+#[cfg(unix)]
+fn an_unprivileged_run_still_records() {
+    assert!(!acting_as_root(), "this suite is meant to run unprivileged");
+    let dir = tempfile::tempdir().unwrap();
+    let env = Env::host_rooted(dir.path());
+    let running = dir.path().join("kendex");
+    std::fs::write(&running, WRAPPER).unwrap();
+
+    record_first_run(&env, &running).unwrap();
+    assert_eq!(
+        recorded_command(&env).map(|record| record.digest),
+        Some(crate::hash::sha256_hex(WRAPPER))
+    );
+}

--- a/crates/core/src/command_update/record/tests.rs
+++ b/crates/core/src/command_update/record/tests.rs
@@ -1,6 +1,13 @@
 //! What the record proves about a file, and what it refuses to prove.
 //! The lookup itself lives in the parent; these are the arms that turn on
 //! the record alone, against real files rather than a described machine.
+//!
+//! The writes below go through the `_as` seam with the identity spelled
+//! out, rather than through the entry points that ask this process. None
+//! of these tests is about privilege, and a suite run as root — a root
+//! dev container is one — would otherwise assert against records the
+//! guard refused to write. That the entry points do ask the process is
+//! proved once, in `a_public_write_follows_this_process_uid`.
 
 use super::*;
 
@@ -47,7 +54,7 @@ fn a_record_that_is_not_a_path_and_a_digest_is_no_record() {
 
     // The control: the same file, well formed, is read. Without it every
     // assertion above passes for a reader that returns `None` always.
-    record_command(&env, Path::new(installed), WRAPPER).unwrap();
+    record_command_as(&env, Path::new(installed), WRAPPER, false).unwrap();
     assert_eq!(
         recorded_command(&env),
         Some(InstalledCommand {
@@ -68,7 +75,7 @@ fn a_first_run_vouches_for_its_own_file_and_no_other() {
     let env = Env::host_rooted(dir.path());
     let ours = dir.path().join("kendex");
     std::fs::write(&ours, b"the binary that ran").unwrap();
-    record_first_run(&env, &ours).unwrap();
+    record_first_run_as(&env, &ours, false).unwrap();
 
     let wrapper = dir.path().join("bin/kendex");
     std::fs::create_dir_all(wrapper.parent().unwrap()).unwrap();
@@ -163,11 +170,12 @@ fn a_staging_write_with_no_free_name_fails() {
 /// `kendex update` reaches after the bytes land — and neither leaves so
 /// much as the directory behind.
 ///
-/// Root is passed in rather than become: this suite runs as a person. What
-/// is real is everything else — the same `Env`, the same functions, a home
-/// on disk. The control is the second half, where the identical calls with
-/// the identical fixture write both records; without it every assertion
-/// above would hold for a pair of functions that never wrote anything.
+/// Root is passed in rather than become: a suite does not choose the uid it
+/// is started under. What is real is everything else — the same `Env`, the
+/// same functions, a home on disk. The control is the second half, where
+/// the identical calls with the identical fixture write both records;
+/// without it every assertion above would hold for a pair of functions
+/// that never wrote anything.
 #[test]
 #[cfg(unix)]
 fn a_run_acting_as_root_writes_no_record() {
@@ -214,22 +222,49 @@ fn a_run_acting_as_root_writes_no_record() {
 }
 
 /// The guard is wired to this process's own uid and not to a constant.
-/// Read the other way round, an unprivileged run still records: the public
-/// entry points ask [`acting_as_root`], the suite runs as a person, and the
-/// record lands. A build that answered `true` always would strand every
-/// person on the record they already had.
+///
+/// The one test here that drives a public entry point, and the one that
+/// has to: what the seam above cannot show is that anything reads the uid
+/// at all. So the entry point is called and its answer held against the
+/// uid read independently — from the syscall, not from [`acting_as_root`],
+/// which is the function this is checking the wiring of.
+///
+/// Both directions fall out of that. A build answering `true` always
+/// strands every person on the record they already had, and fails this on
+/// any unprivileged runner, which is every CI job; a build answering
+/// `false` always is the defect this change exists to close, and fails it
+/// under a root runner. Neither uid is skipped and neither passes for
+/// free.
 #[test]
 #[cfg(unix)]
-fn an_unprivileged_run_still_records() {
-    assert!(!acting_as_root(), "this suite is meant to run unprivileged");
+fn a_public_write_follows_this_process_uid() {
+    let privileged = rustix::process::geteuid().is_root();
     let dir = tempfile::tempdir().unwrap();
     let env = Env::host_rooted(dir.path());
     let running = dir.path().join("kendex");
     std::fs::write(&running, WRAPPER).unwrap();
 
     record_first_run(&env, &running).unwrap();
+
     assert_eq!(
         recorded_command(&env).map(|record| record.digest),
-        Some(crate::hash::sha256_hex(WRAPPER))
+        (!privileged).then(|| crate::hash::sha256_hex(WRAPPER)),
+        "the entry point did not follow this process's uid (root: {privileged})"
+    );
+
+    // The control, on a home of its own: the same write told the opposite
+    // identity does the opposite thing. Without it the assertion above
+    // holds for a writer that never writes, and for one that always does.
+    let other = tempfile::tempdir().unwrap();
+    let env = Env::host_rooted(other.path());
+    let running = other.path().join("kendex");
+    std::fs::write(&running, WRAPPER).unwrap();
+
+    record_first_run_as(&env, &running, !privileged).unwrap();
+
+    assert_eq!(
+        recorded_command(&env).map(|record| record.digest),
+        privileged.then(|| crate::hash::sha256_hex(WRAPPER)),
+        "the write does the same thing whichever identity it is told"
     );
 }

--- a/crates/core/src/command_update/tests.rs
+++ b/crates/core/src/command_update/tests.rs
@@ -1,14 +1,14 @@
 //! The lookup and the halves it drives, against real files.
 //!
-//! Records are written through `record`'s `_as` seam with the identity
-//! spelled out. None of these cases is about privilege, and the entry
-//! points beside that seam write nothing when the process is root — a
-//! root dev container is one — which would leave the lookups here
-//! answering for a record that was never written.
+//! Records are written through `record`'s own seam with the identity
+//! spelled out. None of these cases is about privilege, and the entries
+//! beside that seam write nothing when the process is root — a root dev
+//! container is one — which would leave the lookups here answering for a
+//! record that was never written.
 
 use super::*;
 use crate::install_channel::Host;
-use record::{record_command_as, record_installed_as};
+use record::{Write, record_as};
 
 mod described;
 
@@ -437,7 +437,7 @@ fn the_command_an_installer_recorded_is_carried_across() {
     }
     let dir = tempfile::tempdir().unwrap();
     let (env, command) = a_kendex_on_this_machine(&dir);
-    record_installed_as(&env, &command, false).unwrap();
+    record_as(&env, Write::Installed(&command), false).unwrap();
     let probed = vec![command.clone()];
 
     let beside = command_beside_app(&Host, &probed, &[], recorded_command(&env).as_ref());
@@ -470,7 +470,7 @@ fn the_command_an_installer_recorded_is_carried_across() {
 fn a_different_file_at_the_recorded_path_is_not_the_recorded_command() {
     let dir = tempfile::tempdir().unwrap();
     let (env, command) = a_kendex_on_this_machine(&dir);
-    record_installed_as(&env, &command, false).unwrap();
+    record_as(&env, Write::Installed(&command), false).unwrap();
     let probed = vec![command.clone()];
 
     // The control: what the same lookup says while the recorded bytes are
@@ -504,13 +504,8 @@ const SOMEONE_ELSES: &[u8] = b"#!/bin/sh\nexec /opt/other/kendex \"$@\"\n";
 fn a_record_of_one_command_does_not_vouch_for_another() {
     let dir = tempfile::tempdir().unwrap();
     let (env, wrapper) = a_kendex_on_this_machine(&dir);
-    record_command_as(
-        &env,
-        Path::new("/home/pat/.local/bin/kendex"),
-        WRAPPER,
-        false,
-    )
-    .unwrap();
+    let theirs = Path::new("/home/pat/.local/bin/kendex");
+    record_as(&env, Write::Command(theirs, WRAPPER), false).unwrap();
 
     assert_eq!(
         command_beside_app(&Host, &[wrapper], &[], recorded_command(&env).as_ref()),

--- a/crates/core/src/command_update/tests.rs
+++ b/crates/core/src/command_update/tests.rs
@@ -1,5 +1,20 @@
+//! The lookup and the halves it drives, against real files.
+//!
+//! Records are written through `record`'s `_as` seam with the identity
+//! spelled out. None of these cases is about privilege, and the entry
+//! points beside that seam write nothing when the process is root — a
+//! root dev container is one — which would leave the lookups here
+//! answering for a record that was never written.
+
 use super::*;
 use crate::install_channel::Host;
+use record::{record_command_as, record_installed_as};
+
+mod described;
+
+#[path = "../../../test_util.rs"]
+mod test_util;
+use test_util::no_record_on_this_runner;
 
 #[path = "../../../fixture_url.rs"]
 mod fixture_url;
@@ -294,225 +309,6 @@ fn recorded(machine: &Machine, path: &str) -> InstalledCommand {
     }
 }
 
-/// `PATH` order decides which `kendex` a person runs, so it decides which
-/// one a family update replaces: the search reads `PATH` before the
-/// installer's own directories and stops at the first candidate that
-/// exists. Replacing a second copy further down would move the half nobody
-/// runs and leave the half they do.
-#[test]
-fn the_command_a_shell_resolves_first_is_the_one_replaced() {
-    let on_path = "/opt/bin/kendex";
-    let machine = Machine {
-        present: candidates(&[on_path, "/home/pat/.local/bin/kendex"]),
-        ..Machine::default()
-    };
-    let probed = command_candidates(
-        Path::new("/home/pat"),
-        Some(&std::ffi::OsString::from("/opt/bin")),
-    );
-
-    assert_eq!(
-        located(&machine, &probed, on_path),
-        CommandBeside::Ours(on_path.into())
-    );
-}
-
-/// A copy another installer owns is never replaced, and the answer names
-/// who owns it, so the card can tell the person which command moves it
-/// rather than leaving the app to update alone in silence. Judged by the
-/// file behind the name, because a link on `PATH` is how a package's copy
-/// is reached without ever naming its prefix.
-///
-/// Both arms of "not ours" run: a distro whose helper this build can name,
-/// and one it cannot, where the honest answer carries no command at all.
-#[test]
-fn a_command_another_installer_owns_is_never_ours_and_names_its_owner() {
-    let named = candidates(&["/usr/bin/kendex"]);
-    let linked = candidates(&["/home/pat/.local/bin/kendex"]);
-    let cases = [
-        (
-            Machine {
-                present: named.clone(),
-                arch: true,
-                ..Machine::default()
-            },
-            &named,
-            InstallChannel::Managed {
-                manager: "an AUR helper".to_owned(),
-                command: "update kendex with your AUR helper".to_owned(),
-            },
-        ),
-        (
-            Machine {
-                present: linked.clone(),
-                links: vec![(linked[0].clone(), named[0].clone())],
-                ..Machine::default()
-            },
-            &linked,
-            InstallChannel::Unknown,
-        ),
-    ];
-    for (machine, probed, owner) in cases {
-        // Recorded, so the refusal is the installer's ownership and not
-        // a missing record.
-        assert_eq!(
-            located(&machine, probed, &probed[0].display().to_string()),
-            CommandBeside::NotOurs(owner),
-            "{probed:?}"
-        );
-    }
-}
-
-/// Two ways to have no command to move. Nothing installed under any
-/// candidate is a dmg or msi install; the running app reachable as
-/// `kendex` is not a command to carry — written over, it would take the
-/// command binary and then be written back by the app half, leaving the
-/// machine with neither.
-#[test]
-fn nothing_installed_and_the_running_app_both_read_absent() {
-    let image = PathBuf::from("/home/pat/.local/bin/kendex");
-    let probed = vec![image.clone()];
-    assert_eq!(
-        located(&Machine::default(), &probed, &image.display().to_string()),
-        CommandBeside::Absent
-    );
-
-    let only_the_app = Machine {
-        present: probed.clone(),
-        ..Machine::default()
-    };
-    assert_eq!(
-        command_beside_app(
-            &only_the_app,
-            &probed,
-            &[image.clone()],
-            Some(&recorded(&only_the_app, &image.display().to_string()))
-        ),
-        CommandBeside::Absent
-    );
-}
-
-/// Windows is the case the updater's own path cannot cover. It judges no
-/// path there, so nothing but the running executable itself keeps the app
-/// out of the search — and the desktop executable is `kendex.exe`, the
-/// name the command carries, so an install directory on `PATH` puts the
-/// app first in line. Taken for the command, it would be overwritten with
-/// the CLI binary before the updater ever ran.
-#[test]
-fn a_windows_app_on_path_is_never_taken_for_the_command() {
-    let exe = PathBuf::from("C:/Program Files/kendex/kendex.exe");
-    let machine = Machine {
-        present: vec![exe.clone()],
-        ..Machine::default()
-    };
-    let probed = vec![exe.clone()];
-
-    // What the updater offers on Windows: no path at all. Recorded, so
-    // the fixture reaches the app and the exclusion is what stops it.
-    assert_eq!(
-        command_beside_app(
-            &machine,
-            &probed,
-            &[],
-            Some(&recorded(&machine, &exe.display().to_string()))
-        ),
-        CommandBeside::Ours(exe.clone()),
-        "the fixture has to reach the app before the exclusion can be what stops it"
-    );
-    assert_eq!(
-        command_beside_app(
-            &machine,
-            &probed,
-            &[exe.clone()],
-            Some(&recorded(&machine, &exe.display().to_string()))
-        ),
-        CommandBeside::Absent
-    );
-}
-
-/// A candidate has to be a command. A directory and a data file each carry
-/// the name in a writable place, which answers every other question the
-/// way a real command does, and each would take a release binary written
-/// over it. The search passes both and lands on the command behind them.
-#[test]
-fn a_directory_or_a_data_file_named_kendex_is_not_a_command() {
-    let real = PathBuf::from("/usr/local/bin/kendex");
-    let machine = Machine {
-        present: vec![real.clone()],
-        not_commands: candidates(&["/opt/a/kendex", "/opt/b/kendex"]),
-        ..Machine::default()
-    };
-    let probed = candidates(&["/opt/a/kendex", "/opt/b/kendex", "/usr/local/bin/kendex"]);
-
-    assert_eq!(
-        located(&machine, &probed, "/usr/local/bin/kendex"),
-        CommandBeside::Ours(real)
-    );
-
-    // With nothing runnable behind them they stop nothing: the answer is
-    // that there is no command here, not that one of them is it.
-    let neither = Machine {
-        not_commands: candidates(&["/opt/a/kendex", "/opt/b/kendex"]),
-        ..Machine::default()
-    };
-    assert_eq!(
-        located(&neither, &probed[..2], "/usr/local/bin/kendex"),
-        CommandBeside::Absent
-    );
-}
-
-/// `PATH` first, then the two directories `install.sh` chooses between,
-/// each named once — a launcher whose `PATH` already carries `.local/bin`
-/// must not have it probed twice.
-///
-/// Written against the constants rather than against their values: what
-/// those values have to be is `install.sh`'s to say, and the contract test
-/// in `crates/cli/tests/install_script.rs` reads them out of the script.
-#[test]
-fn candidates_are_path_then_the_installer_s_own_dirs_without_repeats() {
-    let home = Path::new("/home/pat");
-    let home_bin = home.join(INSTALLER_HOME_BIN);
-    let system = Path::new(INSTALLER_SYSTEM_BIN).join(COMMAND_NAME);
-    // `PATH` is built by the rule that reads it back: Windows splits on
-    // `;`, and a hand-written `:` leaves the whole variable as one entry.
-    let other = Path::new("/usr/bin");
-    let path = std::env::join_paths([home_bin.as_path(), other]).unwrap();
-
-    assert_eq!(
-        command_candidates(home, Some(path.as_os_str())),
-        vec![
-            home_bin.join(COMMAND_NAME),
-            other.join(COMMAND_NAME),
-            system.clone(),
-        ]
-    );
-
-    // No PATH at all still leaves the installer's own two, in its order.
-    assert_eq!(
-        command_candidates(home, None),
-        vec![home_bin.join(COMMAND_NAME), system]
-    );
-}
-
-#[test]
-fn fetched_urls_are_always_positional_arguments() {
-    assert_eq!(
-        curl_args("--output=/tmp/owned"),
-        [
-            "-fsS",
-            "--location",
-            "--max-redirs",
-            "3",
-            "--proto",
-            "=https,file",
-            "--proto-redir",
-            "=https",
-            "--",
-            "--output=/tmp/owned",
-        ]
-    );
-}
-
 fn artifact(bytes: &[u8], signature: &[u8]) -> SignedArtifact {
     SignedArtifact {
         bytes: bytes.to_vec(),
@@ -631,9 +427,17 @@ fn a_command_no_installer_recorded_is_never_replaced() {
 /// cannot prove, which refuses an update nobody had to be refused.
 #[test]
 fn the_command_an_installer_recorded_is_carried_across() {
+    // The rewrite this asserts is `across_in`'s own, through the entry
+    // point that asks the process — the one write here that is not a
+    // fixture, and so the one that cannot be told a different identity.
+    // A root runner suppresses it, correctly: the record is repaired by
+    // the person's next unprivileged run, which is not this process.
+    if no_record_on_this_runner() {
+        return;
+    }
     let dir = tempfile::tempdir().unwrap();
     let (env, command) = a_kendex_on_this_machine(&dir);
-    record_installed(&env, &command).unwrap();
+    record_installed_as(&env, &command, false).unwrap();
     let probed = vec![command.clone()];
 
     let beside = command_beside_app(&Host, &probed, &[], recorded_command(&env).as_ref());
@@ -666,7 +470,7 @@ fn the_command_an_installer_recorded_is_carried_across() {
 fn a_different_file_at_the_recorded_path_is_not_the_recorded_command() {
     let dir = tempfile::tempdir().unwrap();
     let (env, command) = a_kendex_on_this_machine(&dir);
-    record_installed(&env, &command).unwrap();
+    record_installed_as(&env, &command, false).unwrap();
     let probed = vec![command.clone()];
 
     // The control: what the same lookup says while the recorded bytes are
@@ -700,7 +504,13 @@ const SOMEONE_ELSES: &[u8] = b"#!/bin/sh\nexec /opt/other/kendex \"$@\"\n";
 fn a_record_of_one_command_does_not_vouch_for_another() {
     let dir = tempfile::tempdir().unwrap();
     let (env, wrapper) = a_kendex_on_this_machine(&dir);
-    record_command(&env, Path::new("/home/pat/.local/bin/kendex"), WRAPPER).unwrap();
+    record_command_as(
+        &env,
+        Path::new("/home/pat/.local/bin/kendex"),
+        WRAPPER,
+        false,
+    )
+    .unwrap();
 
     assert_eq!(
         command_beside_app(&Host, &[wrapper], &[], recorded_command(&env).as_ref()),

--- a/crates/core/src/command_update/tests/described.rs
+++ b/crates/core/src/command_update/tests/described.rs
@@ -1,0 +1,224 @@
+//! The lookup against a described machine: what `PATH`, the installer's
+//! own directories and an owner's claim decide, with no file on disk to
+//! decide it instead. The cases that need real files are next door.
+
+use super::*;
+
+/// `PATH` order decides which `kendex` a person runs, so it decides which
+/// one a family update replaces: the search reads `PATH` before the
+/// installer's own directories and stops at the first candidate that
+/// exists. Replacing a second copy further down would move the half nobody
+/// runs and leave the half they do.
+#[test]
+fn the_command_a_shell_resolves_first_is_the_one_replaced() {
+    let on_path = "/opt/bin/kendex";
+    let machine = Machine {
+        present: candidates(&[on_path, "/home/pat/.local/bin/kendex"]),
+        ..Machine::default()
+    };
+    let probed = command_candidates(
+        Path::new("/home/pat"),
+        Some(&std::ffi::OsString::from("/opt/bin")),
+    );
+
+    assert_eq!(
+        located(&machine, &probed, on_path),
+        CommandBeside::Ours(on_path.into())
+    );
+}
+
+/// A copy another installer owns is never replaced, and the answer names
+/// who owns it, so the card can tell the person which command moves it
+/// rather than leaving the app to update alone in silence. Judged by the
+/// file behind the name, because a link on `PATH` is how a package's copy
+/// is reached without ever naming its prefix.
+///
+/// Both arms of "not ours" run: a distro whose helper this build can name,
+/// and one it cannot, where the honest answer carries no command at all.
+#[test]
+fn a_command_another_installer_owns_is_never_ours_and_names_its_owner() {
+    let named = candidates(&["/usr/bin/kendex"]);
+    let linked = candidates(&["/home/pat/.local/bin/kendex"]);
+    let cases = [
+        (
+            Machine {
+                present: named.clone(),
+                arch: true,
+                ..Machine::default()
+            },
+            &named,
+            InstallChannel::Managed {
+                manager: "an AUR helper".to_owned(),
+                command: "update kendex with your AUR helper".to_owned(),
+            },
+        ),
+        (
+            Machine {
+                present: linked.clone(),
+                links: vec![(linked[0].clone(), named[0].clone())],
+                ..Machine::default()
+            },
+            &linked,
+            InstallChannel::Unknown,
+        ),
+    ];
+    for (machine, probed, owner) in cases {
+        // Recorded, so the refusal is the installer's ownership and not
+        // a missing record.
+        assert_eq!(
+            located(&machine, probed, &probed[0].display().to_string()),
+            CommandBeside::NotOurs(owner),
+            "{probed:?}"
+        );
+    }
+}
+
+/// Two ways to have no command to move. Nothing installed under any
+/// candidate is a dmg or msi install; the running app reachable as
+/// `kendex` is not a command to carry — written over, it would take the
+/// command binary and then be written back by the app half, leaving the
+/// machine with neither.
+#[test]
+fn nothing_installed_and_the_running_app_both_read_absent() {
+    let image = PathBuf::from("/home/pat/.local/bin/kendex");
+    let probed = vec![image.clone()];
+    assert_eq!(
+        located(&Machine::default(), &probed, &image.display().to_string()),
+        CommandBeside::Absent
+    );
+
+    let only_the_app = Machine {
+        present: probed.clone(),
+        ..Machine::default()
+    };
+    assert_eq!(
+        command_beside_app(
+            &only_the_app,
+            &probed,
+            &[image.clone()],
+            Some(&recorded(&only_the_app, &image.display().to_string()))
+        ),
+        CommandBeside::Absent
+    );
+}
+
+/// Windows is the case the updater's own path cannot cover. It judges no
+/// path there, so nothing but the running executable itself keeps the app
+/// out of the search — and the desktop executable is `kendex.exe`, the
+/// name the command carries, so an install directory on `PATH` puts the
+/// app first in line. Taken for the command, it would be overwritten with
+/// the CLI binary before the updater ever ran.
+#[test]
+fn a_windows_app_on_path_is_never_taken_for_the_command() {
+    let exe = PathBuf::from("C:/Program Files/kendex/kendex.exe");
+    let machine = Machine {
+        present: vec![exe.clone()],
+        ..Machine::default()
+    };
+    let probed = vec![exe.clone()];
+
+    // What the updater offers on Windows: no path at all. Recorded, so
+    // the fixture reaches the app and the exclusion is what stops it.
+    assert_eq!(
+        command_beside_app(
+            &machine,
+            &probed,
+            &[],
+            Some(&recorded(&machine, &exe.display().to_string()))
+        ),
+        CommandBeside::Ours(exe.clone()),
+        "the fixture has to reach the app before the exclusion can be what stops it"
+    );
+    assert_eq!(
+        command_beside_app(
+            &machine,
+            &probed,
+            &[exe.clone()],
+            Some(&recorded(&machine, &exe.display().to_string()))
+        ),
+        CommandBeside::Absent
+    );
+}
+
+/// A candidate has to be a command. A directory and a data file each carry
+/// the name in a writable place, which answers every other question the
+/// way a real command does, and each would take a release binary written
+/// over it. The search passes both and lands on the command behind them.
+#[test]
+fn a_directory_or_a_data_file_named_kendex_is_not_a_command() {
+    let real = PathBuf::from("/usr/local/bin/kendex");
+    let machine = Machine {
+        present: vec![real.clone()],
+        not_commands: candidates(&["/opt/a/kendex", "/opt/b/kendex"]),
+        ..Machine::default()
+    };
+    let probed = candidates(&["/opt/a/kendex", "/opt/b/kendex", "/usr/local/bin/kendex"]);
+
+    assert_eq!(
+        located(&machine, &probed, "/usr/local/bin/kendex"),
+        CommandBeside::Ours(real)
+    );
+
+    // With nothing runnable behind them they stop nothing: the answer is
+    // that there is no command here, not that one of them is it.
+    let neither = Machine {
+        not_commands: candidates(&["/opt/a/kendex", "/opt/b/kendex"]),
+        ..Machine::default()
+    };
+    assert_eq!(
+        located(&neither, &probed[..2], "/usr/local/bin/kendex"),
+        CommandBeside::Absent
+    );
+}
+
+/// `PATH` first, then the two directories `install.sh` chooses between,
+/// each named once — a launcher whose `PATH` already carries `.local/bin`
+/// must not have it probed twice.
+///
+/// Written against the constants rather than against their values: what
+/// those values have to be is `install.sh`'s to say, and the contract test
+/// in `crates/cli/tests/install_script.rs` reads them out of the script.
+#[test]
+fn candidates_are_path_then_the_installer_s_own_dirs_without_repeats() {
+    let home = Path::new("/home/pat");
+    let home_bin = home.join(INSTALLER_HOME_BIN);
+    let system = Path::new(INSTALLER_SYSTEM_BIN).join(COMMAND_NAME);
+    // `PATH` is built by the rule that reads it back: Windows splits on
+    // `;`, and a hand-written `:` leaves the whole variable as one entry.
+    let other = Path::new("/usr/bin");
+    let path = std::env::join_paths([home_bin.as_path(), other]).unwrap();
+
+    assert_eq!(
+        command_candidates(home, Some(path.as_os_str())),
+        vec![
+            home_bin.join(COMMAND_NAME),
+            other.join(COMMAND_NAME),
+            system.clone(),
+        ]
+    );
+
+    // No PATH at all still leaves the installer's own two, in its order.
+    assert_eq!(
+        command_candidates(home, None),
+        vec![home_bin.join(COMMAND_NAME), system]
+    );
+}
+
+#[test]
+fn fetched_urls_are_always_positional_arguments() {
+    assert_eq!(
+        curl_args("--output=/tmp/owned"),
+        [
+            "-fsS",
+            "--location",
+            "--max-redirs",
+            "3",
+            "--proto",
+            "=https,file",
+            "--proto-redir",
+            "=https",
+            "--",
+            "--output=/tmp/owned",
+        ]
+    );
+}

--- a/crates/test_util.rs
+++ b/crates/test_util.rs
@@ -34,3 +34,43 @@ pub fn source_path(path: &Path) -> String {
         .trim_end()
         .to_owned()
 }
+
+/// Whether this runner can observe the record `kendex` writes for the
+/// command it installed.
+///
+/// A run acting as root writes none, so a case that drives the writers —
+/// through the entry points, or through the built binary — has nothing to
+/// look at on a runner that is already root, which a root dev container
+/// is. Those cases say so and stop, rather than asserting against a record
+/// that was never written: several would otherwise pass, holding for a
+/// write that was refused instead of for the run that was meant to make
+/// it.
+///
+/// The uid comes from the syscall rather than from the guard that reads
+/// it. Asked the other way round, a build whose guard answered a constant
+/// would talk these cases out of running on the very runner that would
+/// have caught it.
+#[cfg(unix)]
+#[allow(
+    dead_code,
+    clippy::print_stderr,
+    reason = "every test binary includes this whole module and uses the part it needs; a skipped case has to say so"
+)]
+pub fn no_record_on_this_runner() -> bool {
+    let root = rustix::process::geteuid().is_root();
+    if root {
+        eprintln!("skipped: a run acting as root writes no record");
+    }
+    root
+}
+
+/// Windows has no uid to read and none of the elevation the guard turns
+/// on, so every such case runs there.
+#[cfg(not(unix))]
+#[allow(
+    dead_code,
+    reason = "every test binary includes this whole module and uses the part it needs"
+)]
+pub fn no_record_on_this_runner() -> bool {
+    false
+}


### PR DESCRIPTION
## The write

`sudo kendex update` wrote its record from the elevated process. Under sudo's default `env_reset` that lands in the privileged account's own data directory and is harmless. A `sudoers` carrying `env_keep HOME` changes where it lands: the elevated process resolves the record path through the invoking person's `HOME`, and root opens a file every component of whose name that account controls. A link there is followed, and root writes wherever it points.

That is the class PR #1843 was withdrawn over (reverted in `d926e38de`). The withdrawn fix set `HOME` on the sudo line; this one does not depend on that, because a sudoers policy supplies the condition without kendex asking.

## What changed

A run acting as root writes no record.

Nothing is lost by that. `refresh_the_replaced_bytes` moves the digest of a record naming the file the process runs from, and `record_first_run` is reached by every verb before clap parses arguments — so the person's next unprivileged run of anything, `--version` included, records the bytes the elevated run installed, into the file their own account owns. KEN-853 is what made this option available; the elevated record is redundant rather than merely misplaced.

The check is `rustix::process::geteuid().is_root()` and nothing else. No variable is read, so `sudo`, `su`, `doas` and a root login are one case — and none of them is distinguishable by a variable the invoker also sets, so a check reading `SUDO_USER` would be a check the invoker decides. On Windows there is no uid to answer with and none of the elevation this guards for is reachable, so it answers false.

## The second writer

The issue named `record_installed` and `record_command`, both in `update.rs`. Guarding only those would not have satisfied Requirement 1.

`sudo kendex update` reaches `record_first_run` **first**, before argument parsing, and that function calls `create_dir_all` on the HOME-derived path — already root writing into the invoking account's tree, before either named call site runs. Both writers are guarded: `record_command` (which covers `record_installed` and the app's `bring_command_across`) and `record_first_run`, guarded ahead of its `create_dir_all`.

## Requirement 3, and why the shipped test is not enough on its own

`a_run_acting_as_root_writes_no_record` drives both writers with a real `Env` and a real `HOME` on disk, root injected, and asserts neither the record nor its directory exists. Its second half runs the identical calls with the flag off and asserts both records land — so the assertions cannot pass for a pair of functions that never wrote anything.

Root is **injected** there, not become. That proves the guard body runs; it proves nothing about whether the public entry point reads the real uid. Must-fail, three variants against the real suite:

| variant | result |
|---|---|
| both guards removed | 5 passed, 1 failed |
| only `record_command_as` guard removed | 5 passed, 1 failed |
| only `record_first_run_as` guard removed | 5 passed, 1 failed |
| restored | 6 passed, 0 failed |

Each variant fails on the same assertion, `installed-command was written by a root run`. Guarding either writer alone does not make it pass.

The wiring gap was closed by hand at real euid 0, under an unprivileged user namespace: `unshare -Ur env -i HOME=<tree> ... kendex --version`, with `id -u` printing 0 inside. Nothing was left under that tree, not even `.local`. The same binary run unprivileged with the same environment wrote `.local/share/kendex/installed-command` holding the path and digest.

That run is **not shipped as a test**: it needs an unprivileged user namespace, which macOS CI has none of and Ubuntu 24 AppArmor can refuse, so it would skip rather than run.

## Suites

kendex-core 1789 passed / 0 failed · kendex-cli 347 passed / 0 failed · `tools/guard` exit 0.

## Not changed

`rustix` gained its `process` feature; it was already a workspace dependency for `fs`, and `Cargo.lock` is unchanged.

`cargo clippy --manifest-path crates/core/Cargo.toml --all-targets` fails with two `clippy::expect_used` errors in `crates/core/tests/credential_lock_process.rs:37` and `:60`. Pre-existing on main (the file was last touched by #1662) and untouched here.

Closes KEN-865
