### PR TITLE
fix(KEN-875): a repo class no longer shadows a shipped frozen class

### DIFF
--- a/.agents/skills/size-ratchet/DEVELOPMENT.md
+++ b/.agents/skills/size-ratchet/DEVELOPMENT.md
@@ -128,6 +128,19 @@ shipped list alone — exact single-threshold behavior needs the repo's own
 entries in the shipped list, so a README or a doc under a `tests/` directory
 is judged as the document it is.
 
+First match wins **except on a frozen path**. `*` crosses `/`, so a repo
+class scoped to a directory (`ui/*.ts=250`) also matches every test file and
+document under it; those are frozen, and a frozen row never rises, so a
+tightened threshold there asks for a remedy the freeze forbids. The engine
+skips such an entry and lets the shipped class that names the path decide. A
+repo that means to move a frozen class restates that class's own pattern
+(`*/SKILL.md=8k`), and that entry still wins — restating the pattern is how
+a repo names which class it is moving. Where the shipped list claims the
+path at all is the whole question: with no shipped class to hand it to, the
+skipped entry stands rather than falling through to a base threshold nobody
+wrote for it. A consumer therefore never restates a shipped threshold to
+express a narrower policy on one directory.
+
 A directory name takes both class forms: `*` may match nothing but the
 literal `/` in `*/tests/*` still must be there, so `*/tests/*` covers
 `pkg/tests/x` and never a root-level `tests/x` — that one needs `tests/*`.

--- a/.agents/skills/size-ratchet/DEVELOPMENT.md
+++ b/.agents/skills/size-ratchet/DEVELOPMENT.md
@@ -128,18 +128,33 @@ shipped list alone — exact single-threshold behavior needs the repo's own
 entries in the shipped list, so a README or a doc under a `tests/` directory
 is judged as the document it is.
 
-First match wins **except on a frozen path**. `*` crosses `/`, so a repo
-class scoped to a directory (`ui/*.ts=250`) also matches every test file and
-document under it; those are frozen, and a frozen row never rises, so a
-tightened threshold there asks for a remedy the freeze forbids. The engine
-skips such an entry and lets the shipped class that names the path decide. A
-repo that means to move a frozen class restates that class's own pattern
+First match wins **except on a frozen path that the shipped list also
+classifies**. `*` crosses `/`, so a repo class scoped to a directory
+(`ui/*.ts=250`) also matches every test file under it, and a broader one
+(`docs/*=250`) reaches documents too. Those paths already have a shipped
+class naming them, and the repo never named them: the entry retitles that
+class silently, the counting UNIT included, so a `docs/*=250` written for
+code judges a byte class in lines. The engine skips such an entry and lets
+the shipped class decide. The rule runs in both directions, a looser repo
+entry as much as a tighter one, because what it protects is the shipped
+class naming the path rather than any one number.
+
+A repo that means to move a frozen class restates that class's own pattern
 (`*/SKILL.md=8k`), and that entry still wins — restating the pattern is how
 a repo names which class it is moving. Where the shipped list claims the
 path at all is the whole question: with no shipped class to hand it to, the
 skipped entry stands rather than falling through to a base threshold nobody
-wrote for it. A consumer therefore never restates a shipped threshold to
-express a narrower policy on one directory.
+wrote for it, and where two entries were skipped the first one stands, the
+way first-match-wins decides every other path. A consumer therefore never
+restates a shipped threshold to express a narrower policy on one directory.
+
+The verdict line reports what each repo entry actually governed, which is
+why it is assembled after the classification pass rather than at parse time.
+An entry that yielded somewhere reads `ui/*.ts=250 (yielded on frozen
+paths)`; one that yielded on every path it matched reads `(governed nothing:
+yielded on every path it matched)`, because a run printing an inert entry as
+the mapping in force would be a clean run advertising a threshold no file
+was judged against.
 
 A directory name takes both class forms: `*` may match nothing but the
 literal `/` in `*/tests/*` still must be there, so `*/tests/*` covers
@@ -211,7 +226,14 @@ see one — the reason belongs in the commit body, where review reads it.
 `SIZE_RATCHET_FROZEN_CLASSES` refuses a RAISE regardless of that
 declaration, and defaults to every markdown class and every test class. It
 does not refuse a first row: a new path still gets its bootstrap row, which
-is what a repo adopting a class needs on day one.
+is what a repo adopting a class needs on day one, and the `new offender` and
+`baseline row added` diagnostics both name that bootstrap as the remedy
+beside the split. The freeze speaks only to a row that already exists.
+
+The setting carries a second duty, in [Path-class
+evaluation](#path-class-evaluation): its paths keep the shipped class that
+names them rather than a repo entry's. Adding a glob to the freeze list to
+lock rows therefore also stops a repo class retitling those paths.
 
 Rows already at HEAD are grandfathered, because the gate judges the change
 and not the history it inherited. A HEAD with no baseline (an unborn HEAD,

--- a/.agents/skills/size-ratchet/DEVELOPMENT.md
+++ b/.agents/skills/size-ratchet/DEVELOPMENT.md
@@ -128,32 +128,20 @@ shipped list alone — exact single-threshold behavior needs the repo's own
 entries in the shipped list, so a README or a doc under a `tests/` directory
 is judged as the document it is.
 
-First match wins **except on a frozen path that the shipped list also
-classifies**. `*` crosses `/`, so a repo class scoped to a directory
-(`ui/*.ts=250`) also matches every test file under it, and a broader one
-(`docs/*=250`) reaches documents too. Those paths already have a shipped
-class naming them, and the repo never named them: the entry retitles that
-class silently, the counting UNIT included, so a `docs/*=250` written for
-code judges a byte class in lines. The engine skips such an entry and lets
-the shipped class decide. The rule runs in both directions, a looser repo
-entry as much as a tighter one, because what it protects is the shipped
-class naming the path rather than any one number.
+First match wins except on a frozen path, where the class inversion applies.
+[README.md § Path classes](README.md#path-classes) is the only statement of
+that rule; `path_threshold` implements it, one branch per exit. Nothing here
+restates it — a rule paraphrased at six sites loses a clause at one of them.
 
-A repo that means to move a frozen class restates that class's own pattern
-(`*/SKILL.md=8k`), and that entry still wins — restating the pattern is how
-a repo names which class it is moving. Where the shipped list claims the
-path at all is the whole question: with no shipped class to hand it to, the
-skipped entry stands rather than falling through to a base threshold nobody
-wrote for it, and where two entries were skipped the first one stands, the
-way first-match-wins decides every other path. A consumer therefore never
-restates a shipped threshold to express a narrower policy on one directory.
-
-The verdict line reports what each repo entry actually governed, which is
-why it is assembled after the classification pass rather than at parse time.
-An entry that yielded somewhere reads `ui/*.ts=250 (yielded on frozen
-paths)`; one that yielded on every path it matched reads `(governed nothing:
-yielded on every path it matched)`, because a run printing an inert entry as
-the mapping in force would be a clean run advertising a threshold no file
+What belongs here is the shape of the implementation. Both lists are parsed
+into one indexed array, the repo's entries first, and `REPO_CLASS_COUNT`
+divides them; a repo entry whose pattern the shipped list also carries is
+marked in `CLASS_RESTATED` once, after both parses. `path_threshold` stamps
+every repo entry it passes over or lets decide, so the verdict line can be
+assembled after the classification pass rather than at parse time — it
+reports what each entry actually governed, and an entry that decided nothing
+is named as such however it got there, because a run printing an inert entry
+as the mapping in force would be a clean run advertising a threshold no file
 was judged against.
 
 A directory name takes both class forms: `*` may match nothing but the
@@ -226,14 +214,16 @@ see one — the reason belongs in the commit body, where review reads it.
 `SIZE_RATCHET_FROZEN_CLASSES` refuses a RAISE regardless of that
 declaration, and defaults to every markdown class and every test class. It
 does not refuse a first row: a new path still gets its bootstrap row, which
-is what a repo adopting a class needs on day one, and the `new offender` and
-`baseline row added` diagnostics both name that bootstrap as the remedy
-beside the split. The freeze speaks only to a row that already exists.
+is what a repo adopting a class needs on day one. Every size remedy follows
+one predicate, whether HEAD's baseline carries the path — a path HEAD does
+not carry names the bootstrap beside the split, a path HEAD carries names
+the split alone in a frozen class. The verdict label decides nothing: `new
+offender` appears on both sides of that line, since a change can delete a row
+HEAD still carries.
 
-The setting carries a second duty, in [Path-class
-evaluation](#path-class-evaluation): its paths keep the shipped class that
-names them rather than a repo entry's. Adding a glob to the freeze list to
-lock rows therefore also stops a repo class retitling those paths.
+The setting carries a second duty: frozen paths are where the class
+inversion applies, so a glob added here changes which class decides those
+paths too. [README.md § Path classes](README.md#path-classes) says how.
 
 Rows already at HEAD are grandfathered, because the gate judges the change
 and not the history it inherited. A HEAD with no baseline (an unborn HEAD,

--- a/.agents/skills/size-ratchet/README.md
+++ b/.agents/skills/size-ratchet/README.md
@@ -45,6 +45,10 @@ even then. Markdown is measured in bytes and code in lines. Flags and exit codes
      instead of comparing it.
   5. **A row added or raised over HEAD's baseline** — see
      [Raising a row](#raising-a-row).
+  6. **The baseline moved and its rows changed** — HEAD's rows left the old
+     path and the rows arriving at the new one are not them, so nothing
+     compares them and a raise would land unjudged. Move the baseline in a
+     commit that changes nothing else, then change its rows in the next one.
 - **`--staged`** counts index blobs for every tracked file rather than
   preferring the worktree copy: what the commit records is the blob. Use it
   in a pre-commit hook; CI, which checks out a clean tree, does not need it.
@@ -166,9 +170,10 @@ clause in one of them.
 The verdict line says what each entry governed. An entry that decided some
 paths and was passed over on frozen ones reads `ui/*.ts=250 (yielded on
 frozen paths)`; one that decided none reads `(governed nothing: decided no
-counted path)`. It does not say why, because a pattern matching nothing, a
-pattern an earlier entry already claimed, and one passed over on frozen paths
-all reach that state and the engine cannot tell them apart.
+counted path)`. It reports the state, not the cause: a pattern matching
+nothing and a pattern an earlier entry already claimed cannot be told apart,
+and an entry passed over on frozen paths reads the same once it decided
+nothing, because one reason is enough.
 
 `SIZE_RATCHET_DEFAULT_CLASSES = ""` drops the shipped list; the repo's own
 `SIZE_RATCHET_CLASSES` still matches first, so single-threshold behavior

--- a/.agents/skills/size-ratchet/README.md
+++ b/.agents/skills/size-ratchet/README.md
@@ -164,10 +164,11 @@ names it and points here, because a rule paraphrased in six places loses a
 clause in one of them.
 
 The verdict line says what each entry governed. An entry that decided some
-paths and lost others reads `ui/*.ts=250 (yielded on frozen paths)`; one that
-decided none reads `(governed nothing: yielded on every path it matched)`, or
-`(governed nothing: matched no counted path)` where a typo'd or stale pattern
-matched nothing at all.
+paths and was passed over on frozen ones reads `ui/*.ts=250 (yielded on
+frozen paths)`; one that decided none reads `(governed nothing: decided no
+counted path)`. It does not say why, because a pattern matching nothing, a
+pattern an earlier entry already claimed, and one passed over on frozen paths
+all reach that state and the engine cannot tell them apart.
 
 `SIZE_RATCHET_DEFAULT_CLASSES = ""` drops the shipped list; the repo's own
 `SIZE_RATCHET_CLASSES` still matches first, so single-threshold behavior

--- a/.agents/skills/size-ratchet/README.md
+++ b/.agents/skills/size-ratchet/README.md
@@ -29,11 +29,10 @@ even then. Markdown is measured in bytes and code in lines. Flags and exit codes
   everything else in lines.
 - **Threshold**: `SIZE_RATCHET_CLASSES` first, then the shipped
   `SIZE_RATCHET_DEFAULT_CLASSES`, then `SIZE_RATCHET_THRESHOLD` (default
-  `400` lines) — see [Path classes](#path-classes), which carries the one
-  inversion: on a frozen path that the shipped list also classifies, the
-  shipped class wins unless the repo entry restates its pattern. Every file
-  resolves to exactly one threshold, and every other semantic runs per file
-  against it.
+  `400` lines), with one inversion on frozen paths. [Path
+  classes](#path-classes) states that rule and is the only place that does.
+  Every file resolves to exactly one threshold, and every other semantic runs
+  per file against it.
 - **FAIL** (exit 1) on any of:
   1. **New offender** — a file over its threshold with no baseline row.
   2. **Growth** — a baselined file whose actual size exceeds its row.
@@ -69,10 +68,10 @@ raises is that threshold routed around.
 - **Frozen classes** (`SIZE_RATCHET_FROZEN_CLASSES`, default every markdown
   class and every test class) refuse a **raise of an existing row** outright,
   whatever the run carries. A test splits and a document is cut; neither is
-  ever the fix that needs the added lines. The setting has a second duty in
-  [Path classes](#path-classes): its paths keep the shipped class that names
-  them rather than a repo entry's, so adding a glob here to lock rows also
-  stops a repo class retitling those paths.
+  ever the fix that needs the added lines. The setting has a second duty:
+  frozen paths are where the class inversion in [Path
+  classes](#path-classes) applies, so a glob added here to lock rows changes
+  which class decides those paths too.
 - **Every other added or raised row** needs `RATCHET_RAISE=1` on the
   invocation. No commit message is read — a pre-commit hook cannot see one —
   so the reason belongs in the commit body, where review reads it.
@@ -159,10 +158,16 @@ the `*/SKILL.md` example above does: an entry naming a pattern the shipped
 list carries still wins. Where the shipped list names no class for a frozen
 path, the repo entry stands.
 
-The verdict line says what each entry governed: an entry that yielded
-somewhere reads `ui/*.ts=250 (yielded on frozen paths)`, and one that
-yielded on every path it matched reads `(governed nothing: yielded on every
-path it matched)`.
+**This is the only statement of the rule.** Every other surface — the
+`--help` text, the block comments, `DEVELOPMENT.md`, the settings table —
+names it and points here, because a rule paraphrased in six places loses a
+clause in one of them.
+
+The verdict line says what each entry governed. An entry that decided some
+paths and lost others reads `ui/*.ts=250 (yielded on frozen paths)`; one that
+decided none reads `(governed nothing: yielded on every path it matched)`, or
+`(governed nothing: matched no counted path)` where a typo'd or stale pattern
+matched nothing at all.
 
 `SIZE_RATCHET_DEFAULT_CLASSES = ""` drops the shipped list; the repo's own
 `SIZE_RATCHET_CLASSES` still matches first, so single-threshold behavior
@@ -199,9 +204,9 @@ src/gen/*.rs	generated bindings
 | Key | Default | Meaning |
 |---|---|---|
 | `SIZE_RATCHET_THRESHOLD` | `400` | Line threshold for paths matching no class. |
-| `SIZE_RATCHET_CLASSES` | *(none)* | This repo's overrides, `pattern=threshold` separated by `;`, matched before the shipped list — except on a frozen path that the shipped list also classifies, where only an entry restating that class's own pattern decides. |
+| `SIZE_RATCHET_CLASSES` | *(none)* | This repo's overrides, `pattern=threshold` separated by `;`, matched before the shipped list, with one inversion on frozen paths — see [Path classes](#path-classes). |
 | `SIZE_RATCHET_DEFAULT_CLASSES` | *(the shipped list)* | The class list the package ships; empty runs with no classes. |
-| `SIZE_RATCHET_FROZEN_CLASSES` | *(markdown and tests)* | `;`-separated globs with two duties: their rows may never rise, and their paths keep the shipped class that names them rather than a repo entry's. |
+| `SIZE_RATCHET_FROZEN_CLASSES` | *(markdown and tests)* | `;`-separated globs whose rows may never rise; they also decide where the [Path classes](#path-classes) inversion applies. |
 | `SIZE_RATCHET_BASELINE` | `tools/size-ratchet-baseline.tsv` | Baseline path. |
 | `SIZE_RATCHET_EXCLUDES` | `tools/size-ratchet-excludes` | Exclusion-list path. |
 

--- a/.agents/skills/size-ratchet/README.md
+++ b/.agents/skills/size-ratchet/README.md
@@ -29,8 +29,9 @@ even then. Markdown is measured in bytes and code in lines. Flags and exit codes
   everything else in lines.
 - **Threshold**: `SIZE_RATCHET_CLASSES` first, then the shipped
   `SIZE_RATCHET_DEFAULT_CLASSES`, then `SIZE_RATCHET_THRESHOLD` (default
-  `400` lines) — see [Path classes](#path-classes). Every file resolves to
-  exactly one threshold, and every other semantic runs per file against it.
+  `400` lines) — see [Path classes](#path-classes). On a frozen path the
+  shipped class wins instead. Every file resolves to exactly one threshold,
+  and every other semantic runs per file against it.
 - **FAIL** (exit 1) on any of:
   1. **New offender** — a file over its threshold with no baseline row.
   2. **Growth** — a baselined file whose actual size exceeds its row.
@@ -133,6 +134,23 @@ and the shipped list decides everything they leave alone.
 SIZE_RATCHET_CLASSES = "*/SKILL.md=32k"
 ```
 
+**A repo entry never shadows a frozen class.** `*` crosses `/`, so
+`ui/*.ts=250` also matches the test files under `ui/`; they are frozen, and a
+frozen row never rises, so a tighter number there would demand a split the
+shipped class already sized. Such an entry is skipped and the shipped class
+that names the path decides — no consumer restates a shipped threshold to
+scope a narrower policy to one directory:
+
+```toml
+[env]
+SIZE_RATCHET_CLASSES = "ui/*.ts=250;ui/*.tsx=250"  # ui/ tests stay at 800
+```
+
+To move a frozen class deliberately, restate that class's own pattern, as
+the `*/SKILL.md` example above does: an entry naming a pattern the shipped
+list carries still wins. Where the shipped list names no class for a frozen
+path, the repo entry stands.
+
 `SIZE_RATCHET_DEFAULT_CLASSES = ""` drops the shipped list; the repo's own
 `SIZE_RATCHET_CLASSES` still matches first, so single-threshold behavior
 needs both empty.
@@ -168,7 +186,7 @@ src/gen/*.rs	generated bindings
 | Key | Default | Meaning |
 |---|---|---|
 | `SIZE_RATCHET_THRESHOLD` | `400` | Line threshold for paths matching no class. |
-| `SIZE_RATCHET_CLASSES` | *(none)* | This repo's overrides, `pattern=threshold` separated by `;`, matched before the shipped list. |
+| `SIZE_RATCHET_CLASSES` | *(none)* | This repo's overrides, `pattern=threshold` separated by `;`, matched before the shipped list — except on a frozen path, where only an entry restating a shipped pattern decides. |
 | `SIZE_RATCHET_DEFAULT_CLASSES` | *(the shipped list)* | The class list the package ships; empty runs with no classes. |
 | `SIZE_RATCHET_FROZEN_CLASSES` | *(markdown and tests)* | `;`-separated globs whose rows may never rise. |
 | `SIZE_RATCHET_BASELINE` | `tools/size-ratchet-baseline.tsv` | Baseline path. |

--- a/.agents/skills/size-ratchet/README.md
+++ b/.agents/skills/size-ratchet/README.md
@@ -29,9 +29,11 @@ even then. Markdown is measured in bytes and code in lines. Flags and exit codes
   everything else in lines.
 - **Threshold**: `SIZE_RATCHET_CLASSES` first, then the shipped
   `SIZE_RATCHET_DEFAULT_CLASSES`, then `SIZE_RATCHET_THRESHOLD` (default
-  `400` lines) — see [Path classes](#path-classes). On a frozen path the
-  shipped class wins instead. Every file resolves to exactly one threshold,
-  and every other semantic runs per file against it.
+  `400` lines) — see [Path classes](#path-classes), which carries the one
+  inversion: on a frozen path that the shipped list also classifies, the
+  shipped class wins unless the repo entry restates its pattern. Every file
+  resolves to exactly one threshold, and every other semantic runs per file
+  against it.
 - **FAIL** (exit 1) on any of:
   1. **New offender** — a file over its threshold with no baseline row.
   2. **Growth** — a baselined file whose actual size exceeds its row.
@@ -67,7 +69,10 @@ raises is that threshold routed around.
 - **Frozen classes** (`SIZE_RATCHET_FROZEN_CLASSES`, default every markdown
   class and every test class) refuse a **raise of an existing row** outright,
   whatever the run carries. A test splits and a document is cut; neither is
-  ever the fix that needs the added lines.
+  ever the fix that needs the added lines. The setting has a second duty in
+  [Path classes](#path-classes): its paths keep the shipped class that names
+  them rather than a repo entry's, so adding a glob here to lock rows also
+  stops a repo class retitling those paths.
 - **Every other added or raised row** needs `RATCHET_RAISE=1` on the
   invocation. No commit message is read — a pre-commit hook cannot see one —
   so the reason belongs in the commit body, where review reads it.
@@ -135,21 +140,29 @@ SIZE_RATCHET_CLASSES = "*/SKILL.md=32k"
 ```
 
 **A repo entry never shadows a frozen class.** `*` crosses `/`, so
-`ui/*.ts=250` also matches the test files under `ui/`; they are frozen, and a
-frozen row never rises, so a tighter number there would demand a split the
-shipped class already sized. Such an entry is skipped and the shipped class
-that names the path decides — no consumer restates a shipped threshold to
-scope a narrower policy to one directory:
+`ui/*.ts=250` also matches the test files under `ui/`, and a broader
+`docs/*=250` reaches documents too. Those paths already have a shipped class
+naming them, and the repo never named them: the entry retitles that class
+silently, the counting UNIT included, so a `docs/*=250` written for code
+judges a byte class in lines. Such an entry is skipped and the shipped class
+decides. The rule holds in both directions, a looser repo entry as much as a
+tighter one, so no consumer restates a shipped threshold to scope a narrower
+policy to one directory:
 
 ```toml
 [env]
-SIZE_RATCHET_CLASSES = "ui/*.ts=250;ui/*.tsx=250"  # ui/ tests stay at 800
+SIZE_RATCHET_CLASSES = "ui/*.ts=250;ui/*.tsx=250"  # ui/ test files stay at 800
 ```
 
 To move a frozen class deliberately, restate that class's own pattern, as
 the `*/SKILL.md` example above does: an entry naming a pattern the shipped
 list carries still wins. Where the shipped list names no class for a frozen
 path, the repo entry stands.
+
+The verdict line says what each entry governed: an entry that yielded
+somewhere reads `ui/*.ts=250 (yielded on frozen paths)`, and one that
+yielded on every path it matched reads `(governed nothing: yielded on every
+path it matched)`.
 
 `SIZE_RATCHET_DEFAULT_CLASSES = ""` drops the shipped list; the repo's own
 `SIZE_RATCHET_CLASSES` still matches first, so single-threshold behavior
@@ -186,9 +199,9 @@ src/gen/*.rs	generated bindings
 | Key | Default | Meaning |
 |---|---|---|
 | `SIZE_RATCHET_THRESHOLD` | `400` | Line threshold for paths matching no class. |
-| `SIZE_RATCHET_CLASSES` | *(none)* | This repo's overrides, `pattern=threshold` separated by `;`, matched before the shipped list — except on a frozen path, where only an entry restating a shipped pattern decides. |
+| `SIZE_RATCHET_CLASSES` | *(none)* | This repo's overrides, `pattern=threshold` separated by `;`, matched before the shipped list — except on a frozen path that the shipped list also classifies, where only an entry restating that class's own pattern decides. |
 | `SIZE_RATCHET_DEFAULT_CLASSES` | *(the shipped list)* | The class list the package ships; empty runs with no classes. |
-| `SIZE_RATCHET_FROZEN_CLASSES` | *(markdown and tests)* | `;`-separated globs whose rows may never rise. |
+| `SIZE_RATCHET_FROZEN_CLASSES` | *(markdown and tests)* | `;`-separated globs with two duties: their rows may never rise, and their paths keep the shipped class that names them rather than a repo entry's. |
 | `SIZE_RATCHET_BASELINE` | `tools/size-ratchet-baseline.tsv` | Baseline path. |
 | `SIZE_RATCHET_EXCLUDES` | `tools/size-ratchet-excludes` | Exclusion-list path. |
 

--- a/.agents/skills/size-ratchet/SKILL.md
+++ b/.agents/skills/size-ratchet/SKILL.md
@@ -39,14 +39,16 @@ migration note for repos already using this format:
 
 ## Responding to a failure
 
-Every diagnostic names the file, its size, the baseline row it violated,
-the deciding threshold (class pattern or default), and the remedy: *split
-at a concept seam*.
+Every size diagnostic names the file, its size, the baseline row it
+violated, the deciding threshold (class pattern or default), and the remedy:
+*split at a concept seam*.
 
-Two verdicts are not a size problem and take no judgment. **A row in the
+Three verdicts are not a size problem and take no judgment. **A row in the
 wrong unit** is a class that changed what it counts: run `--update`, which
 re-measures the row. **A shrunk row** under `--staged` is already lowered
-and staged by the run itself.
+and staged by the run itself. **A moved baseline** names the two paths
+instead of a file and a size: move the baseline in a commit that changes
+nothing else, then change its rows in the next one.
 
 **Check composition before the seam.** A file over its cap whose bulk is
 inline tests needs those tests moved to the language's separate-test

--- a/.agents/skills/size-ratchet/references/threshold-change.md
+++ b/.agents/skills/size-ratchet/references/threshold-change.md
@@ -1,8 +1,11 @@
 # Threshold change sweep
 
-Run this before a changed `SIZE_RATCHET_THRESHOLD`, `SIZE_RATCHET_CLASSES` or
-`SIZE_RATCHET_DEFAULT_CLASSES` entry lands, in either direction, and when an entry changes UNIT — the
-number a path is judged against moves either way. Run it at `--seed` too when
+Run this before a changed `SIZE_RATCHET_THRESHOLD`, `SIZE_RATCHET_CLASSES`,
+`SIZE_RATCHET_DEFAULT_CLASSES` or `SIZE_RATCHET_FROZEN_CLASSES` entry lands, in
+either direction, and when an entry changes UNIT — the number a path is judged
+against moves either way. A glob added to or removed from the frozen list moves
+matching paths between a repo class and a shipped one, which moves that number
+and, for markdown, the unit. Run it at `--seed` too when
 the repo already had a prose size rule: seeding records no row for an
 under-threshold fragment, so the repo inherits that rule's fragments and
 nothing else points at them.

--- a/.agents/skills/size-ratchet/references/threshold-change.md
+++ b/.agents/skills/size-ratchet/references/threshold-change.md
@@ -3,9 +3,10 @@
 Run this before a changed `SIZE_RATCHET_THRESHOLD`, `SIZE_RATCHET_CLASSES`,
 `SIZE_RATCHET_DEFAULT_CLASSES` or `SIZE_RATCHET_FROZEN_CLASSES` entry lands, in
 either direction, and when an entry changes UNIT — the number a path is judged
-against moves either way. A glob added to or removed from the frozen list moves
-matching paths between a repo class and a shipped one, which moves that number
-and, for markdown, the unit. Run it at `--seed` too when
+against moves either way. The frozen list moves it too, through the class
+inversion in [README.md § Path
+classes](../README.md#path-classes): a glob added or removed there moves
+matching paths between a repo class and a shipped one. Run it at `--seed` too when
 the repo already had a prose size rule: seeding records no row for an
 under-threshold fragment, so the repo inherits that rule's fragments and
 nothing else points at them.

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -649,14 +649,10 @@ is_excluded() { # PATH — 0 when some exclusion glob matches the full path
 # report() re-runs it to name the threshold that judged the path — including
 # for a baseline row whose file left the tracked set.
 #
-# A repo entry is matched first, EXCEPT on a frozen path. `*` crosses `/`, so
-# a repo class scoped to a directory (`ui/*.ts=250`) also matches paths the
-# repo never named, and silently retitles the shipped class that named them,
-# the counting UNIT included: a `docs/*=250` meant for code judges a byte
-# class in lines. That is what the skip below prevents, and it prevents it in
-# both directions, because what it protects is the shipped class naming the
-# path rather than any one number. The rule and its two exits are stated once,
-# in README.md "Path classes"; each exit is a branch below.
+# A repo entry is matched first, EXCEPT on a frozen path: the skip below is
+# there so a directory-scoped entry cannot retitle a shipped class for paths
+# the repo never named. The rule and its two exits are stated once, in
+# README.md "Path classes"; each exit is a branch below.
 path_threshold() { # PATH
   local i=0 frozen="" shadowed="" skipped="" hit="" s
   # Indexed iteration bounded by CLASS_COUNT: a whole-array expansion on an
@@ -996,11 +992,11 @@ LC_ALL=C sort -- "$TMP/counts.classed" >"$TMP/counts.tsv" || collection_error "c
 
 # The verdict line reports the mapping the run actually USED, which is why it
 # is built here and not at parse time: the pass above put every tracked path
-# through the resolver, so each repo entry now knows whether it decided a path
-# or yielded one to a frozen class. An entry that decided none governs
-# nothing, and a run that printed it as the mapping in force would advertise a
-# threshold no file was ever judged against — a clean run saying something
-# false. The raw setting's spacing and empty entries stay out: they
+# through the resolver, so each repo entry now knows whether it decided one.
+# An entry that decided none governs nothing, and a run that printed it as the
+# mapping in force would advertise a threshold no file was ever judged
+# against — a clean run saying something false. The raw setting's spacing and
+# empty entries stay out: they
 # read as behavior the matcher never sees. The shipped list is a count, not a
 # transcript — it is the same everywhere, and the per-file diagnostics already
 # name the class that decided each path.
@@ -1009,15 +1005,12 @@ sr_ni=0
 while [ "$sr_ni" -lt "$REPO_CLASS_COUNT" ]; do
   sr_entry="${CLASS_PATTERNS[$sr_ni]}=${CLASS_RAW[$sr_ni]}"
   # DECIDED is the predicate, so the bare rendering is unreachable for an
-  # entry that governed nothing however it got there — yielded away, or a
-  # typo'd or stale pattern that matched no counted path at all. YIELDED only
-  # supplies the reason.
+  # entry that governed nothing. WHY it governed nothing is not said: a
+  # pattern matching nothing, a pattern an earlier entry already claimed, and
+  # one passed over on frozen paths all arrive here, and the engine holds no
+  # state that tells them apart. The line says the part it can stand behind.
   if [ "${CLASS_DECIDED[$sr_ni]:-0}" != "1" ]; then
-    if [ "${CLASS_YIELDED[$sr_ni]:-0}" = "1" ]; then
-      sr_entry="$sr_entry (governed nothing: yielded on every path it matched)"
-    else
-      sr_entry="$sr_entry (governed nothing: matched no counted path)"
-    fi
+    sr_entry="$sr_entry (governed nothing: decided no counted path)"
   elif [ "${CLASS_YIELDED[$sr_ni]:-0}" = "1" ]; then
     sr_entry="$sr_entry (yielded on frozen paths)"
   fi

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -38,7 +38,10 @@
 # SIZE_RATCHET_CLASSES (a repo's own overrides) then
 # SIZE_RATCHET_DEFAULT_CLASSES (the list this package ships), else
 # SIZE_RATCHET_THRESHOLD. Class patterns are the excludes file's globs and
-# run through the same matcher.
+# run through the same matcher. One inversion: on a frozen path the shipped
+# list also classifies, a repo entry decides only if it restates that list's
+# own pattern, so a directory-scoped class cannot silently retitle the tests
+# and documents under it.
 #
 # A class threshold carries its UNIT: `pattern=400` is 400 lines,
 # `pattern=24k` is 24*1024 bytes. Lines are newline counts (`wc -l`), bytes
@@ -129,8 +132,10 @@ kendex.settings.toml [env] > default):
   SIZE_RATCHET_THRESHOLD   line threshold for a path in no class (default 400)
   SIZE_RATCHET_CLASSES     this repo's OVERRIDES: `pattern=threshold`
                            entries separated by `;`, excludes-file glob
-                           semantics, matched BEFORE the shipped list
-                           (default none)
+                           semantics, matched BEFORE the shipped list —
+                           except on a frozen path the shipped list also
+                           classifies, where only an entry restating that
+                           list's own pattern decides   (default none)
   SIZE_RATCHET_DEFAULT_CLASSES
                            the class list this package ships, same syntax;
                            set it empty to drop the shipped list alone —
@@ -355,7 +360,9 @@ parse_classes() { # SETTING-NAME VALUE — appends entries; sets PARSED_NOTE
 }
 
 # A repo's own entries are matched FIRST, so it overrides a class without
-# restating the list; the shipped list decides everything it leaves alone.
+# restating the list; the shipped list decides everything it leaves alone. On
+# a frozen path the shipped list also classifies, that order inverts —
+# path_threshold says why.
 CLASSES="$(sr_setting SIZE_RATCHET_CLASSES "")" || exit 2
 parse_classes SIZE_RATCHET_CLASSES "$CLASSES"
 # The verdict line reports the mapping the run actually used, rebuilt from
@@ -370,6 +377,24 @@ DEFAULT_CLASSES="$(sr_setting SIZE_RATCHET_DEFAULT_CLASSES "$SHIPPED_CLASSES")" 
 parse_classes SIZE_RATCHET_DEFAULT_CLASSES "$DEFAULT_CLASSES"
 SHIPPED_CLASS_COUNT=$((CLASS_COUNT - REPO_CLASS_COUNT))
 [ "$SHIPPED_CLASS_COUNT" -eq 0 ] || CLASSES_NOTE="$CLASSES_NOTE, $SHIPPED_CLASS_COUNT shipped class(es)"
+
+# A repo entry naming a pattern the shipped list already carries RESTATES that
+# class — the one way to say "this class, our number", and the only repo entry
+# path_threshold lets decide a frozen path.
+CLASS_RESTATED=()
+sr_ri=0
+while [ "$sr_ri" -lt "$REPO_CLASS_COUNT" ]; do
+  CLASS_RESTATED+=(0)
+  sr_si="$REPO_CLASS_COUNT"
+  while [ "$sr_si" -lt "$CLASS_COUNT" ]; do
+    if [ "${CLASS_PATTERNS[$sr_ri]}" = "${CLASS_PATTERNS[$sr_si]}" ]; then
+      CLASS_RESTATED[$sr_ri]=1
+      break
+    fi
+    sr_si=$((sr_si + 1))
+  done
+  sr_ri=$((sr_ri + 1))
+done
 
 # --- frozen classes: globs whose rows may never rise -------------------------
 # Same glob language as the classes and the exclusion list, no thresholds.
@@ -624,12 +649,33 @@ is_excluded() { # PATH — 0 when some exclusion glob matches the full path
 # Single resolver: collection stamps every counted row with PT and PU, and
 # report() re-runs it to name the threshold that judged the path — including
 # for a baseline row whose file left the tracked set.
+#
+# A repo entry is matched first, EXCEPT on a frozen path: `*` crosses `/`, so
+# a repo class scoped to a directory (`ui/*.ts=250`) also takes every test and
+# document under it, and a frozen path has no answer to a tightened threshold
+# — its row never rises, so the run demands a remedy the freeze forbids. Such
+# an entry is skipped and the shipped class that names the path decides. A
+# repo meaning to move a frozen class restates that class's own pattern, and
+# that entry still wins; where nothing else matched, the skipped entry stands,
+# because the base threshold is a number nobody wrote for that path.
 path_threshold() { # PATH
-  local i=0
+  local i=0 frozen="" shadowed=""
   # Indexed iteration bounded by CLASS_COUNT: a whole-array expansion on an
   # empty array is an unbound variable under Bash 3.2 with set -u.
   while [ "$i" -lt "$CLASS_COUNT" ]; do
     if glob_match "$1" "${CLASS_PATTERNS[$i]}"; then
+      if [ "$i" -lt "$REPO_CLASS_COUNT" ] && [ "${CLASS_RESTATED[$i]:-0}" != "1" ]; then
+        # The freeze list is a second glob sweep, so it is asked once per path
+        # and only for a repo entry that actually matched.
+        if [ -z "$frozen" ]; then
+          if is_frozen "$1"; then frozen="y"; else frozen="n"; fi
+        fi
+        if [ "$frozen" = "y" ]; then
+          [ -n "$shadowed" ] || shadowed="$i"
+          i=$((i + 1))
+          continue
+        fi
+      fi
       PT="${CLASS_THRESHOLDS[$i]}"
       PU="${CLASS_UNITS[$i]}"
       PC="${CLASS_PATTERNS[$i]}"
@@ -637,6 +683,12 @@ path_threshold() { # PATH
     fi
     i=$((i + 1))
   done
+  if [ -n "$shadowed" ]; then
+    PT="${CLASS_THRESHOLDS[$shadowed]}"
+    PU="${CLASS_UNITS[$shadowed]}"
+    PC="${CLASS_PATTERNS[$shadowed]}"
+    return 0
+  fi
   # SIZE_RATCHET_THRESHOLD is a line count: code is what falls through to it,
   # and lines are what every linter caps code by.
   PT="$THRESHOLD"

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -38,10 +38,9 @@
 # SIZE_RATCHET_CLASSES (a repo's own overrides) then
 # SIZE_RATCHET_DEFAULT_CLASSES (the list this package ships), else
 # SIZE_RATCHET_THRESHOLD. Class patterns are the excludes file's globs and
-# run through the same matcher. One inversion: on a frozen path that the
-# shipped list also classifies, a repo entry decides only if it restates that
-# list's own pattern, so a directory-scoped class cannot silently retitle the
-# shipped classes covering paths it never named.
+# run through the same matcher. Frozen paths carry the one inversion to that
+# order: README.md "Path classes" states the rule, path_threshold implements
+# it, and neither is paraphrased anywhere else.
 #
 # A class threshold carries its UNIT: `pattern=400` is 400 lines,
 # `pattern=24k` is 24*1024 bytes. Lines are newline counts (`wc -l`), bytes
@@ -132,21 +131,19 @@ kendex.settings.toml [env] > default):
   SIZE_RATCHET_THRESHOLD   line threshold for a path in no class (default 400)
   SIZE_RATCHET_CLASSES     this repo's OVERRIDES: `pattern=threshold`
                            entries separated by `;`, excludes-file glob
-                           semantics, matched BEFORE the shipped list —
-                           except on a frozen path that the shipped list also
-                           classifies, where only an entry restating that
-                           list's own pattern decides   (default none)
+                           semantics, matched BEFORE the shipped list, with
+                           one inversion on frozen paths (README.md, "Path
+                           classes")   (default none)
   SIZE_RATCHET_DEFAULT_CLASSES
                            the class list this package ships, same syntax;
                            set it empty to drop the shipped list alone —
                            SIZE_RATCHET_CLASSES still matches first, so
                            single-threshold behavior needs both empty
   SIZE_RATCHET_FROZEN_CLASSES
-                           `;`-separated globs with two duties: their rows
-                           may never rise, whatever RATCHET_RAISE says, and
-                           their paths keep the shipped class that names
-                           them rather than a repo entry's
-                           (default: markdown and tests)
+                           `;`-separated globs whose rows may never rise,
+                           whatever RATCHET_RAISE says; they also decide
+                           where the class inversion applies (README.md,
+                           "Path classes")   (default: markdown and tests)
   SIZE_RATCHET_BASELINE    baseline path            (default tools/size-ratchet-baseline.tsv)
   SIZE_RATCHET_EXCLUDES    exclusion-list path      (default tools/size-ratchet-excludes)
 Flags override both for the path settings.
@@ -363,9 +360,8 @@ parse_classes() { # SETTING-NAME VALUE — appends entries
 }
 
 # A repo's own entries are matched FIRST, so it overrides a class without
-# restating the list; the shipped list decides everything it leaves alone. On
-# a frozen path that the shipped list also classifies, that order inverts —
-# path_threshold says why.
+# restating the list; the shipped list decides everything it leaves alone.
+# Frozen paths invert that order — path_threshold is the rule.
 CLASSES="$(sr_setting SIZE_RATCHET_CLASSES "")" || exit 2
 parse_classes SIZE_RATCHET_CLASSES "$CLASSES"
 REPO_CLASS_COUNT="$CLASS_COUNT"
@@ -653,24 +649,22 @@ is_excluded() { # PATH — 0 when some exclusion glob matches the full path
 # report() re-runs it to name the threshold that judged the path — including
 # for a baseline row whose file left the tracked set.
 #
-# A repo entry is matched first, EXCEPT on a frozen path that the shipped list
-# also classifies. `*` crosses `/`, so a repo class scoped to a directory
-# (`ui/*.ts=250`) also matches paths the repo never named — every test file
-# under it, and under a broader pattern every document too — and silently
-# retitles the shipped class that named them, the counting UNIT included: a
-# `docs/*=250` meant for code judges a byte class in lines. The rule runs in
-# both directions, a looser repo entry as much as a tighter one, because what
-# it protects is the shipped class naming the path, not any one number. Such
-# an entry is skipped and the shipped class decides. A repo meaning to move a
-# frozen class restates that class's own pattern, and that entry still wins;
-# where nothing else matched, the skipped entry stands, because the base
-# threshold is a number nobody wrote for that path.
+# A repo entry is matched first, EXCEPT on a frozen path. `*` crosses `/`, so
+# a repo class scoped to a directory (`ui/*.ts=250`) also matches paths the
+# repo never named, and silently retitles the shipped class that named them,
+# the counting UNIT included: a `docs/*=250` meant for code judges a byte
+# class in lines. That is what the skip below prevents, and it prevents it in
+# both directions, because what it protects is the shipped class naming the
+# path rather than any one number. The rule and its two exits are stated once,
+# in README.md "Path classes"; each exit is a branch below.
 path_threshold() { # PATH
   local i=0 frozen="" shadowed="" skipped="" hit="" s
   # Indexed iteration bounded by CLASS_COUNT: a whole-array expansion on an
   # empty array is an unbound variable under Bash 3.2 with set -u.
   while [ "$i" -lt "$CLASS_COUNT" ]; do
     if glob_match "$1" "${CLASS_PATTERNS[$i]}"; then
+      # Exit one: an entry restating a shipped pattern is the repo naming the
+      # class it means to move, so it is no shadow and is never skipped.
       if [ "$i" -lt "$REPO_CLASS_COUNT" ] && [ "${CLASS_RESTATED[$i]:-0}" != "1" ]; then
         # The freeze list is a second glob sweep, so it is asked once per path
         # and only for a repo entry that actually matched.
@@ -689,8 +683,9 @@ path_threshold() { # PATH
     fi
     i=$((i + 1))
   done
-  # Where the shipped list names no class for the frozen path, the first entry
-  # the skip passed over stands after all.
+  # Exit two: where the shipped list names no class for the frozen path, the
+  # first entry the skip passed over stands after all — the base threshold is
+  # a number nobody wrote for that path.
   [ -n "$hit" ] || hit="$shadowed"
   # An entry the skip passed over LOST this path, unless that fallback just
   # handed the same path back to it. The verdict line reports both.
@@ -1002,10 +997,10 @@ LC_ALL=C sort -- "$TMP/counts.classed" >"$TMP/counts.tsv" || collection_error "c
 # The verdict line reports the mapping the run actually USED, which is why it
 # is built here and not at parse time: the pass above put every tracked path
 # through the resolver, so each repo entry now knows whether it decided a path
-# or yielded one to a frozen class. An entry that yielded and decided nothing
-# governs nothing, and a run that printed it as the mapping in force would
-# advertise a threshold no file was ever judged against — a clean run saying
-# something false. The raw setting's spacing and empty entries stay out: they
+# or yielded one to a frozen class. An entry that decided none governs
+# nothing, and a run that printed it as the mapping in force would advertise a
+# threshold no file was ever judged against — a clean run saying something
+# false. The raw setting's spacing and empty entries stay out: they
 # read as behavior the matcher never sees. The shipped list is a count, not a
 # transcript — it is the same everywhere, and the per-file diagnostics already
 # name the class that decided each path.
@@ -1013,12 +1008,18 @@ CLASSES_NOTE=""
 sr_ni=0
 while [ "$sr_ni" -lt "$REPO_CLASS_COUNT" ]; do
   sr_entry="${CLASS_PATTERNS[$sr_ni]}=${CLASS_RAW[$sr_ni]}"
-  if [ "${CLASS_YIELDED[$sr_ni]:-0}" = "1" ]; then
-    if [ "${CLASS_DECIDED[$sr_ni]:-0}" = "1" ]; then
-      sr_entry="$sr_entry (yielded on frozen paths)"
-    else
+  # DECIDED is the predicate, so the bare rendering is unreachable for an
+  # entry that governed nothing however it got there — yielded away, or a
+  # typo'd or stale pattern that matched no counted path at all. YIELDED only
+  # supplies the reason.
+  if [ "${CLASS_DECIDED[$sr_ni]:-0}" != "1" ]; then
+    if [ "${CLASS_YIELDED[$sr_ni]:-0}" = "1" ]; then
       sr_entry="$sr_entry (governed nothing: yielded on every path it matched)"
+    else
+      sr_entry="$sr_entry (governed nothing: matched no counted path)"
     fi
+  elif [ "${CLASS_YIELDED[$sr_ni]:-0}" = "1" ]; then
+    sr_entry="$sr_entry (yielded on frozen paths)"
   fi
   CLASSES_NOTE="${CLASSES_NOTE:+$CLASSES_NOTE;}$sr_entry"
   sr_ni=$((sr_ni + 1))
@@ -1068,8 +1069,24 @@ evaluate() { # BASELINE-TSV — violations on stdout, one per line, tab-separate
   ' "$1" "$TMP/counts.tsv"
 }
 
+# Does HEAD's baseline carry a row for this path? One predicate decides every
+# size remedy, so no verdict label can be paired with the wrong one: a path
+# HEAD does not carry has no row to raise, so the declaration admits a first
+# one in every class, frozen included; a path HEAD carries is a RAISE, which a
+# frozen class refuses whatever the declaration says. Reading the label instead
+# misdirects in both directions — a genuine bootstrap told no declaration helps,
+# and a deleted row told to bootstrap a row HEAD still carries.
+head_carries_row() { # PATH
+  [ -n "$HEAD_BASELINE" ] || return 1
+  local p n
+  while IFS="$TAB" read -r p n || [ -n "$p" ]; do
+    if [ "$p" = "$1" ]; then return 0; fi
+  done <"$HEAD_BASELINE"
+  return 1
+}
+
 report() { # VIOLATIONS-FILE — human diagnostics on stdout
-  local kind path n b raw why rem boot unit
+  local kind path n b raw why remedy unit
   while IFS="$TAB" read -r kind path n raw; do
     path_threshold "$path"; if [ -n "$PC" ]; then why="class $PC"; else why="default"; fi
     unit="$(unit_noun "$PU")s"
@@ -1077,26 +1094,21 @@ report() { # VIOLATIONS-FILE — human diagnostics on stdout
     # the row's `b` suffix comes off — except in the wrong-unit verdict,
     # where the suffix IS the finding.
     b="$(row_value "$raw")"
-    # `rem` speaks to a row that already exists: GROW and RAISED, where a
-    # frozen class refuses the raise. NEW and ADDED have no such row — the
-    # file carries none at all — so both get `boot`, the bootstrap the
-    # declaration admits in every class, frozen included. Handing either one
-    # `rem` would tell its author no declaration helps at the one moment one
-    # would have carried the run.
-    if is_frozen "$path"; then
-      rem="split at a concept seam (a frozen class never raises an existing row)"
+    if ! head_carries_row "$path"; then
+      remedy="split at a concept seam, or declare the row with RATCHET_RAISE=1 — a first row for a path HEAD's baseline does not carry is a bootstrap, admitted in every class"
+    elif is_frozen "$path"; then
+      remedy="split at a concept seam (a frozen class never raises an existing row)"
     else
-      rem="split at a concept seam (RATCHET_RAISE=1 raises the row only when the added lines are the fix with no seam, or fragments of one concept are merged back into one file)"
+      remedy="split at a concept seam (RATCHET_RAISE=1 raises the row only when the added lines are the fix with no seam, or fragments of one concept are merged back into one file)"
     fi
-    boot="split at a concept seam, or declare the row with RATCHET_RAISE=1 — a first row for a path HEAD's baseline does not carry is a bootstrap, admitted in every class"
     case "$kind" in
       NEW)
         echo "size-ratchet FAIL new offender: $path — $n $unit > threshold $PT ($why), no baseline row"
-        echo "  remedy: $boot"
+        echo "  remedy: $remedy"
         ;;
       GROW)
         echo "size-ratchet FAIL baselined file grew: $path — $n $unit > baseline $b (threshold $PT, $why)"
-        echo "  remedy: $rem"
+        echo "  remedy: $remedy"
         ;;
       LOOSE)
         echo "size-ratchet FAIL baseline looser than reality: $path — baseline $b > actual $n $unit, still over threshold $PT ($why); the ratchet only moves down"
@@ -1116,15 +1128,15 @@ report() { # VIOLATIONS-FILE — human diagnostics on stdout
         ;;
       ADDED)
         echo "size-ratchet FAIL baseline row added: $path — a first row, at $n $unit (threshold $PT, $why); HEAD's baseline carries no row for it"
-        echo "  remedy: $boot"
+        echo "  remedy: $remedy"
         ;;
       RAISED)
         echo "size-ratchet FAIL baseline row raised: $path — row $b -> $n $unit, threshold $PT ($why)"
-        echo "  remedy: $rem"
+        echo "  remedy: $remedy"
         ;;
       FROZEN)
         echo "size-ratchet FAIL frozen baseline row raised: $path — row $b -> $n $unit, threshold $PT ($why); a frozen class refuses a raise whatever RATCHET_RAISE says"
-        echo "  remedy: split at a concept seam (a frozen class never raises an existing row)"
+        echo "  remedy: $remedy"
         ;;
       MOVED)
         echo "size-ratchet FAIL baseline moved and rewritten: $path -> $BASELINE_FILE — HEAD's rows left $path, and the rows arriving at $BASELINE_FILE are not them; across a move nothing compares them, so a raise would land unjudged"

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -1006,9 +1006,10 @@ while [ "$sr_ni" -lt "$REPO_CLASS_COUNT" ]; do
   sr_entry="${CLASS_PATTERNS[$sr_ni]}=${CLASS_RAW[$sr_ni]}"
   # DECIDED is the predicate, so the bare rendering is unreachable for an
   # entry that governed nothing. WHY it governed nothing is not said: a
-  # pattern matching nothing, a pattern an earlier entry already claimed, and
-  # one passed over on frozen paths all arrive here, and the engine holds no
-  # state that tells them apart. The line says the part it can stand behind.
+  # pattern matching nothing and a pattern an earlier entry already claimed
+  # arrive here alike and no state tells those two apart. An entry the frozen
+  # skip passed over does carry its own state, and reads the same here anyway,
+  # because one reason is enough once the entry governed nothing at all.
   if [ "${CLASS_DECIDED[$sr_ni]:-0}" != "1" ]; then
     sr_entry="$sr_entry (governed nothing: decided no counted path)"
   elif [ "${CLASS_YIELDED[$sr_ni]:-0}" = "1" ]; then

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -38,10 +38,10 @@
 # SIZE_RATCHET_CLASSES (a repo's own overrides) then
 # SIZE_RATCHET_DEFAULT_CLASSES (the list this package ships), else
 # SIZE_RATCHET_THRESHOLD. Class patterns are the excludes file's globs and
-# run through the same matcher. One inversion: on a frozen path the shipped
-# list also classifies, a repo entry decides only if it restates that list's
-# own pattern, so a directory-scoped class cannot silently retitle the tests
-# and documents under it.
+# run through the same matcher. One inversion: on a frozen path that the
+# shipped list also classifies, a repo entry decides only if it restates that
+# list's own pattern, so a directory-scoped class cannot silently retitle the
+# shipped classes covering paths it never named.
 #
 # A class threshold carries its UNIT: `pattern=400` is 400 lines,
 # `pattern=24k` is 24*1024 bytes. Lines are newline counts (`wc -l`), bytes
@@ -133,7 +133,7 @@ kendex.settings.toml [env] > default):
   SIZE_RATCHET_CLASSES     this repo's OVERRIDES: `pattern=threshold`
                            entries separated by `;`, excludes-file glob
                            semantics, matched BEFORE the shipped list —
-                           except on a frozen path the shipped list also
+                           except on a frozen path that the shipped list also
                            classifies, where only an entry restating that
                            list's own pattern decides   (default none)
   SIZE_RATCHET_DEFAULT_CLASSES
@@ -142,9 +142,11 @@ kendex.settings.toml [env] > default):
                            SIZE_RATCHET_CLASSES still matches first, so
                            single-threshold behavior needs both empty
   SIZE_RATCHET_FROZEN_CLASSES
-                           `;`-separated globs whose rows may never rise,
-                           whatever RATCHET_RAISE says (default: markdown
-                           and tests)
+                           `;`-separated globs with two duties: their rows
+                           may never rise, whatever RATCHET_RAISE says, and
+                           their paths keep the shipped class that names
+                           them rather than a repo entry's
+                           (default: markdown and tests)
   SIZE_RATCHET_BASELINE    baseline path            (default tools/size-ratchet-baseline.tsv)
   SIZE_RATCHET_EXCLUDES    exclusion-list path      (default tools/size-ratchet-excludes)
 Flags override both for the path settings.
@@ -305,11 +307,12 @@ esac
 CLASS_PATTERNS=()
 CLASS_THRESHOLDS=()
 CLASS_UNITS=()
+# The threshold as written (`250`, `24k`), kept so the verdict line can name
+# an entry exactly as its author typed it.
+CLASS_RAW=()
 CLASS_COUNT=0
-PARSED_NOTE=""
-parse_classes() { # SETTING-NAME VALUE — appends entries; sets PARSED_NOTE
+parse_classes() { # SETTING-NAME VALUE — appends entries
   local name="$1" rest="$2" pair cpat cthr craw cunit
-  PARSED_NOTE=""
   while [ -n "$rest" ]; do
     case "$rest" in
       *";"*)
@@ -354,29 +357,21 @@ parse_classes() { # SETTING-NAME VALUE — appends entries; sets PARSED_NOTE
     CLASS_PATTERNS+=("$cpat")
     CLASS_THRESHOLDS+=("$cthr")
     CLASS_UNITS+=("$cunit")
-    PARSED_NOTE="${PARSED_NOTE:+$PARSED_NOTE;}$cpat=$craw"
+    CLASS_RAW+=("$craw")
     CLASS_COUNT=$((CLASS_COUNT + 1))
   done
 }
 
 # A repo's own entries are matched FIRST, so it overrides a class without
 # restating the list; the shipped list decides everything it leaves alone. On
-# a frozen path the shipped list also classifies, that order inverts —
+# a frozen path that the shipped list also classifies, that order inverts —
 # path_threshold says why.
 CLASSES="$(sr_setting SIZE_RATCHET_CLASSES "")" || exit 2
 parse_classes SIZE_RATCHET_CLASSES "$CLASSES"
-# The verdict line reports the mapping the run actually used, rebuilt from
-# the parsed entries — the raw setting's spacing and empty entries would read
-# as behavior the matcher never sees. The shipped list is a count, not a
-# transcript: it is the same everywhere and the per-file diagnostics already
-# name the class that decided each path.
-CLASSES_NOTE="$PARSED_NOTE"
-[ -z "$CLASSES_NOTE" ] || CLASSES_NOTE=", classes $CLASSES_NOTE"
 REPO_CLASS_COUNT="$CLASS_COUNT"
 DEFAULT_CLASSES="$(sr_setting SIZE_RATCHET_DEFAULT_CLASSES "$SHIPPED_CLASSES")" || exit 2
 parse_classes SIZE_RATCHET_DEFAULT_CLASSES "$DEFAULT_CLASSES"
 SHIPPED_CLASS_COUNT=$((CLASS_COUNT - REPO_CLASS_COUNT))
-[ "$SHIPPED_CLASS_COUNT" -eq 0 ] || CLASSES_NOTE="$CLASSES_NOTE, $SHIPPED_CLASS_COUNT shipped class(es)"
 
 # A repo entry naming a pattern the shipped list already carries RESTATES that
 # class — the one way to say "this class, our number", and the only repo entry
@@ -395,6 +390,14 @@ while [ "$sr_ri" -lt "$REPO_CLASS_COUNT" ]; do
   done
   sr_ri=$((sr_ri + 1))
 done
+
+# What each repo entry actually did over the tracked set, stamped by
+# path_threshold and read back by the verdict line: DECIDED on at least one
+# path, YIELDED to a frozen class on at least one. An entry that yielded and
+# decided nothing governs nothing, and the run says so rather than printing it
+# as the mapping in force.
+CLASS_DECIDED=()
+CLASS_YIELDED=()
 
 # --- frozen classes: globs whose rows may never rise -------------------------
 # Same glob language as the classes and the exclusion list, no thresholds.
@@ -650,16 +653,20 @@ is_excluded() { # PATH — 0 when some exclusion glob matches the full path
 # report() re-runs it to name the threshold that judged the path — including
 # for a baseline row whose file left the tracked set.
 #
-# A repo entry is matched first, EXCEPT on a frozen path: `*` crosses `/`, so
-# a repo class scoped to a directory (`ui/*.ts=250`) also takes every test and
-# document under it, and a frozen path has no answer to a tightened threshold
-# — its row never rises, so the run demands a remedy the freeze forbids. Such
-# an entry is skipped and the shipped class that names the path decides. A
-# repo meaning to move a frozen class restates that class's own pattern, and
-# that entry still wins; where nothing else matched, the skipped entry stands,
-# because the base threshold is a number nobody wrote for that path.
+# A repo entry is matched first, EXCEPT on a frozen path that the shipped list
+# also classifies. `*` crosses `/`, so a repo class scoped to a directory
+# (`ui/*.ts=250`) also matches paths the repo never named — every test file
+# under it, and under a broader pattern every document too — and silently
+# retitles the shipped class that named them, the counting UNIT included: a
+# `docs/*=250` meant for code judges a byte class in lines. The rule runs in
+# both directions, a looser repo entry as much as a tighter one, because what
+# it protects is the shipped class naming the path, not any one number. Such
+# an entry is skipped and the shipped class decides. A repo meaning to move a
+# frozen class restates that class's own pattern, and that entry still wins;
+# where nothing else matched, the skipped entry stands, because the base
+# threshold is a number nobody wrote for that path.
 path_threshold() { # PATH
-  local i=0 frozen="" shadowed=""
+  local i=0 frozen="" shadowed="" skipped="" hit="" s
   # Indexed iteration bounded by CLASS_COUNT: a whole-array expansion on an
   # empty array is an unbound variable under Bash 3.2 with set -u.
   while [ "$i" -lt "$CLASS_COUNT" ]; do
@@ -672,28 +679,36 @@ path_threshold() { # PATH
         fi
         if [ "$frozen" = "y" ]; then
           [ -n "$shadowed" ] || shadowed="$i"
+          skipped="$skipped $i"
           i=$((i + 1))
           continue
         fi
       fi
-      PT="${CLASS_THRESHOLDS[$i]}"
-      PU="${CLASS_UNITS[$i]}"
-      PC="${CLASS_PATTERNS[$i]}"
-      return 0
+      hit="$i"
+      break
     fi
     i=$((i + 1))
   done
-  if [ -n "$shadowed" ]; then
-    PT="${CLASS_THRESHOLDS[$shadowed]}"
-    PU="${CLASS_UNITS[$shadowed]}"
-    PC="${CLASS_PATTERNS[$shadowed]}"
+  # Where the shipped list names no class for the frozen path, the first entry
+  # the skip passed over stands after all.
+  [ -n "$hit" ] || hit="$shadowed"
+  # An entry the skip passed over LOST this path, unless that fallback just
+  # handed the same path back to it. The verdict line reports both.
+  for s in $skipped; do
+    if [ "$s" = "$hit" ]; then CLASS_DECIDED[$s]=1; else CLASS_YIELDED[$s]=1; fi
+  done
+  if [ -z "$hit" ]; then
+    # SIZE_RATCHET_THRESHOLD is a line count: code is what falls through to
+    # it, and lines are what every linter caps code by.
+    PT="$THRESHOLD"
+    PU="l"
+    PC=""
     return 0
   fi
-  # SIZE_RATCHET_THRESHOLD is a line count: code is what falls through to it,
-  # and lines are what every linter caps code by.
-  PT="$THRESHOLD"
-  PU="l"
-  PC=""
+  if [ "$hit" -lt "$REPO_CLASS_COUNT" ]; then CLASS_DECIDED[$hit]=1; fi
+  PT="${CLASS_THRESHOLDS[$hit]}"
+  PU="${CLASS_UNITS[$hit]}"
+  PC="${CLASS_PATTERNS[$hit]}"
 }
 
 is_frozen() { # PATH — 0 when a frozen-class glob matches the full path
@@ -984,6 +999,33 @@ classed="$(count_nonempty_lines "$TMP/counts.classed")"
 [ "$classed" -eq "$counted" ] || collection_error "classified $classed of the $counted measured row(s) — refusing to report a verdict over a subset"
 LC_ALL=C sort -- "$TMP/counts.classed" >"$TMP/counts.tsv" || collection_error "could not sort the collected counts — the measurement is incomplete, refusing to report a verdict"
 
+# The verdict line reports the mapping the run actually USED, which is why it
+# is built here and not at parse time: the pass above put every tracked path
+# through the resolver, so each repo entry now knows whether it decided a path
+# or yielded one to a frozen class. An entry that yielded and decided nothing
+# governs nothing, and a run that printed it as the mapping in force would
+# advertise a threshold no file was ever judged against — a clean run saying
+# something false. The raw setting's spacing and empty entries stay out: they
+# read as behavior the matcher never sees. The shipped list is a count, not a
+# transcript — it is the same everywhere, and the per-file diagnostics already
+# name the class that decided each path.
+CLASSES_NOTE=""
+sr_ni=0
+while [ "$sr_ni" -lt "$REPO_CLASS_COUNT" ]; do
+  sr_entry="${CLASS_PATTERNS[$sr_ni]}=${CLASS_RAW[$sr_ni]}"
+  if [ "${CLASS_YIELDED[$sr_ni]:-0}" = "1" ]; then
+    if [ "${CLASS_DECIDED[$sr_ni]:-0}" = "1" ]; then
+      sr_entry="$sr_entry (yielded on frozen paths)"
+    else
+      sr_entry="$sr_entry (governed nothing: yielded on every path it matched)"
+    fi
+  fi
+  CLASSES_NOTE="${CLASSES_NOTE:+$CLASSES_NOTE;}$sr_entry"
+  sr_ni=$((sr_ni + 1))
+done
+[ -z "$CLASSES_NOTE" ] || CLASSES_NOTE=", classes $CLASSES_NOTE"
+[ "$SHIPPED_CLASS_COUNT" -eq 0 ] || CLASSES_NOTE="$CLASSES_NOTE, $SHIPPED_CLASS_COUNT shipped class(es)"
+
 # --- evaluate a baseline against the counts ----------------------------------
 # Counts rows are `path<TAB>size<TAB>threshold<TAB>unit` — the class resolver
 # already ran at collection, so every judgment here reads the path's own
@@ -1035,11 +1077,12 @@ report() { # VIOLATIONS-FILE — human diagnostics on stdout
     # the row's `b` suffix comes off — except in the wrong-unit verdict,
     # where the suffix IS the finding.
     b="$(row_value "$raw")"
-    # A frozen class refuses a RAISE of an existing row, which is what `rem`
-    # speaks to. A row HEAD's baseline carries none for is a BOOTSTRAP, which
-    # the declaration admits in every class, so the ADDED verdict gets `boot`
-    # instead: telling its author no declaration helps names the wrong cause
-    # at the one moment one would have carried the run.
+    # `rem` speaks to a row that already exists: GROW and RAISED, where a
+    # frozen class refuses the raise. NEW and ADDED have no such row — the
+    # file carries none at all — so both get `boot`, the bootstrap the
+    # declaration admits in every class, frozen included. Handing either one
+    # `rem` would tell its author no declaration helps at the one moment one
+    # would have carried the run.
     if is_frozen "$path"; then
       rem="split at a concept seam (a frozen class never raises an existing row)"
     else
@@ -1049,7 +1092,7 @@ report() { # VIOLATIONS-FILE — human diagnostics on stdout
     case "$kind" in
       NEW)
         echo "size-ratchet FAIL new offender: $path — $n $unit > threshold $PT ($why), no baseline row"
-        echo "  remedy: $rem"
+        echo "  remedy: $boot"
         ;;
       GROW)
         echo "size-ratchet FAIL baselined file grew: $path — $n $unit > baseline $b (threshold $PT, $why)"

--- a/.agents/skills/size-ratchet/tests/path-classes.test.sh
+++ b/.agents/skills/size-ratchet/tests/path-classes.test.sh
@@ -55,6 +55,17 @@ run_raw() { # [VAR=val ...] [-- script-args...] — run $SR in $R; sets OUT, RC
   OUT="$(cd "$R" && env ${envs[@]+"${envs[@]}"} "$SR" ${args[@]+"${args[@]}"} 2>&1)" || RC=$?
 }
 
+echo "=== the README heading every other surface points at still exists ==="
+# The rule is stated once, in README.md "Path classes". The script header, two
+# --help entries, two block comments, DEVELOPMENT.md and two settings-table
+# links all name that heading, the last two through its #path-classes anchor.
+# Retitle it and all of them rot silently, onto paraphrases that were deleted.
+if grep -qx '## Path classes' "$SKILL_DIR/README.md"; then
+  ok "README.md carries the '## Path classes' heading the pointers name"
+else
+  bad "the canonical heading exists at its stated level" "no '## Path classes' line in $SKILL_DIR/README.md"
+fi
+
 echo "=== a class threshold governs the paths it matches; the base governs the rest ==="
 new_repo classes
 mkfile src/big.txt 500

--- a/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -93,9 +93,12 @@ git -C "$R" commit -q -m row
 mkfile x.test.txt 15
 git -C "$R" add -A
 run_frozen
+# Both halves: the string it IS given, and the absence of either wording that
+# carries RATCHET_RAISE. Without the positive half an empty remedy passes.
 if [ "$RC" -eq 1 ] && case "$OUT" in *"baselined file grew: x.test.txt"*) true ;; *) false ;; esac \
+  && case "$OUT" in *"remedy: split at a concept seam (a frozen class never raises an existing row)"*) true ;; *) false ;; esac \
   && case "$OUT" in *RATCHET_RAISE*) false ;; *) true ;; esac; then
-  ok "control: a frozen path whose row exists is never offered a raise"
+  ok "control: a frozen baselined file that grew is told to split, and offered no raise"
 else
   bad "control: a frozen row refuses the raise" "rc=$RC out=$OUT"
 fi

--- a/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -88,6 +88,8 @@ case "$OUT" in *"$BOOT"*) ok "and is offered the bootstrap: no row exists yet, s
 # alone. That is the case the freeze speaks to, and the only one.
 mkdir -p "$R/tools"
 printf 'x.test.txt\t11\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+git -C "$R" commit -q -m row
 mkfile x.test.txt 15
 git -C "$R" add -A
 run_frozen
@@ -104,6 +106,9 @@ mkfile big.txt 15
 mkdir -p "$R/tools"
 printf 'big.txt\t15\n' >"$R/tools/size-ratchet-baseline.tsv"
 git -C "$R" add -A
+# HEAD carries the row from here on, so a growth verdict below is a RAISE the
+# remedy speaks to rather than a first row nothing has frozen yet.
+git -C "$R" commit -q -m row
 run_sr
 [ "$RC" -eq 0 ] && ok "baselined offender at exactly its row passes" || bad "baselined offender at exactly its row passes" "rc=$RC out=$OUT"
 

--- a/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -24,6 +24,9 @@ ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
 bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
 
 REMEDY="split at a concept seam (RATCHET_RAISE=1 raises the row only when the added lines are the fix with no seam, or fragments of one concept are merged back into one file)"
+# The remedy for a verdict whose path carries NO row yet. Both such verdicts
+# take it, frozen or not: the declaration admits a first row in every class.
+BOOT="split at a concept seam, or declare the row with RATCHET_RAISE=1 — a first row for a path HEAD's baseline does not carry is a bootstrap, admitted in every class"
 
 new_repo() { # NAME — fresh fixture repo in $R
   R="$TMP/$1"
@@ -70,9 +73,9 @@ run_sr
 [ "$RC" -eq 1 ] && case "$OUT" in *"new offender: big.txt — 11 lines > threshold 10"*) true ;; *) false ;; esac \
   && ok "one line over the threshold fails as a new offender, naming file/count/threshold" \
   || bad "one line over the threshold fails as a new offender" "rc=$RC out=$OUT"
-case "$OUT" in *"$REMEDY"*) ok "new-offender diagnostic carries the remedy verbatim" ;; *) bad "new-offender diagnostic carries the remedy verbatim" "$OUT" ;; esac
+case "$OUT" in *"$BOOT"*) ok "new-offender diagnostic carries the bootstrap remedy verbatim" ;; *) bad "new-offender diagnostic carries the bootstrap remedy verbatim" "$OUT" ;; esac
 
-echo "=== a frozen-class offender gets the split remedy alone ==="
+echo "=== the freeze refuses a raise of an EXISTING row, and a new offender has none ==="
 new_repo testoff
 mkfile x.test.txt 11
 git -C "$R" add -A
@@ -80,10 +83,20 @@ run_frozen
 [ "$RC" -eq 1 ] && case "$OUT" in *"new offender: x.test.txt"*) true ;; *) false ;; esac \
   && ok "a frozen path over the threshold is still a new offender" \
   || bad "a frozen path over the threshold is still a new offender" "rc=$RC out=$OUT"
-case "$OUT" in *RATCHET_RAISE*) bad "a frozen offender is never offered a raise" "$OUT" ;; *) ok "a frozen offender is never offered a raise" ;; esac
-# The control: the same file outside the frozen list is offered the raise.
-run_sr
-case "$OUT" in *RATCHET_RAISE*) ok "control: an unfrozen offender is offered the declaration" ;; *) bad "control: an unfrozen offender is offered the declaration" "$OUT" ;; esac
+case "$OUT" in *"$BOOT"*) ok "and is offered the bootstrap: no row exists yet, so the freeze has none to refuse" ;; *) bad "a frozen new offender is offered the bootstrap" "$OUT" ;; esac
+# The control: once the row EXISTS, the same frozen path is offered the split
+# alone. That is the case the freeze speaks to, and the only one.
+mkdir -p "$R/tools"
+printf 'x.test.txt\t11\n' >"$R/tools/size-ratchet-baseline.tsv"
+mkfile x.test.txt 15
+git -C "$R" add -A
+run_frozen
+if [ "$RC" -eq 1 ] && case "$OUT" in *"baselined file grew: x.test.txt"*) true ;; *) false ;; esac \
+  && case "$OUT" in *RATCHET_RAISE*) false ;; *) true ;; esac; then
+  ok "control: a frozen path whose row exists is never offered a raise"
+else
+  bad "control: a frozen row refuses the raise" "rc=$RC out=$OUT"
+fi
 
 echo "=== a baseline row at the current count freezes the offender ==="
 new_repo frozen

--- a/.agents/skills/size-ratchet/tests/shipped-defaults.test.sh
+++ b/.agents/skills/size-ratchet/tests/shipped-defaults.test.sh
@@ -284,14 +284,122 @@ if [ "$RC" -eq 1 ] && has "docs/guide.md — 300 lines > threshold 250 (class do
 else
   bad "control: markdown shadow" "rc=$RC out=$OUT"
 fi
+# Restating the shipped class's own pattern is how a repo names the class it
+# means to move, and that entry decides the frozen path.
+run 'SIZE_RATCHET_CLASSES=ui/*.ts=250;*.test.*=100'
+if [ "$RC" -eq 1 ] && has "ui/src/App.test.ts — 500 lines > threshold 100 (class *.test.*)"; then
+  ok "an entry restating a shipped pattern wins on a frozen path"
+else
+  bad "restating a shipped pattern wins" "rc=$RC out=$OUT"
+fi
+
 # A frozen path the shipped list names no class for still takes the repo's
-# entry: the base threshold is a number nobody wrote for it.
-run 'SIZE_RATCHET_CLASSES=ui/*.ts=250' SIZE_RATCHET_DEFAULT_CLASSES=
+# entry: the base threshold is a number nobody wrote for it. The shipped list
+# is non-empty and simply names nothing under ui/, which is the shape a
+# consumer meets; the emptied-list arm below is the degenerate one.
+run 'SIZE_RATCHET_CLASSES=ui/*.ts=250' 'SIZE_RATCHET_DEFAULT_CLASSES=*.rs=100'
 if [ "$RC" -eq 1 ] && has "ui/src/App.test.ts — 500 lines > threshold 250 (class ui/*.ts)"; then
   ok "with no shipped class to hand the frozen path to, the repo entry still decides it"
 else
   bad "skipped entry stands where the shipped list claims nothing" "rc=$RC out=$OUT"
 fi
+run 'SIZE_RATCHET_CLASSES=ui/*.ts=250' SIZE_RATCHET_DEFAULT_CLASSES=
+if [ "$RC" -eq 1 ] && has "ui/src/App.test.ts — 500 lines > threshold 250 (class ui/*.ts)"; then
+  ok "and the same holds with the shipped list dropped entirely"
+else
+  bad "skipped entry stands with an empty shipped list" "rc=$RC out=$OUT"
+fi
+# Two entries reach the frozen path and both are skipped. The FIRST is the one
+# that stands, the way first-match-wins decides every other path.
+run 'SIZE_RATCHET_CLASSES=ui/*.ts=250;ui/*=900' SIZE_RATCHET_DEFAULT_CLASSES=
+if [ "$RC" -eq 1 ] && has "ui/src/App.test.ts — 500 lines > threshold 250 (class ui/*.ts)" \
+  && ! has "class ui/*)"; then
+  ok "the first skipped entry stands, not the last"
+else
+  bad "the fallback keeps first-match-wins" "rc=$RC out=$OUT"
+fi
+
+# The rule protects the shipped class that NAMES the path, not any one number,
+# so it runs in both directions: a looser repo entry is skipped too.
+new_repo shadowloose
+mklines ui/src/Wide.test.ts 900
+git -C "$R" add -A
+run 'SIZE_RATCHET_CLASSES=ui/*=2000'
+if [ "$RC" -eq 1 ] && has "ui/src/Wide.test.ts — 900 lines > threshold 800 (class *.test.*)"; then
+  ok "a LOOSER repo entry is skipped too — the shipped 800 judges the ui test file"
+else
+  bad "the skip is direction-agnostic" "rc=$RC out=$OUT"
+fi
+# The control: the same entry governs the same directory where nothing is
+# frozen, so the fixture really is within its reach at 2000.
+run 'SIZE_RATCHET_CLASSES=ui/*=2000' SIZE_RATCHET_FROZEN_CLASSES=
+[ "$RC" -eq 0 ] && ok "control: unfrozen, that entry does take the 900-line file at 2000" \
+  || bad "control: the looser entry reaches the fixture" "rc=$RC out=$OUT"
+
+echo "=== the verdict line reports what each repo entry actually governed ==="
+# A yielded entry that still governs its own paths is named as such; one that
+# yielded on every path it matched governed nothing, and a run that printed it
+# as the mapping in force would advertise a threshold nothing was judged
+# against — a clean run saying something false.
+new_repo shadownote
+mklines ui/src/App.ts 300
+mklines ui/src/App.test.ts 500
+git -C "$R" add -A
+run 'SIZE_RATCHET_CLASSES=ui/src/*.test.ts=100'
+if [ "$RC" -eq 0 ] && has "classes ui/src/*.test.ts=100 (governed nothing: yielded on every path it matched)"; then
+  ok "an entry every one of whose paths is frozen is reported as governing nothing"
+else
+  bad "a wholly yielded entry says so on the verdict line" "rc=$RC out=$OUT"
+fi
+run 'SIZE_RATCHET_CLASSES=ui/*.ts=400'
+if [ "$RC" -eq 0 ] && has "classes ui/*.ts=400 (yielded on frozen paths)"; then
+  ok "an entry that governs some paths and yields others is reported as yielding"
+else
+  bad "a partly yielded entry says so on the verdict line" "rc=$RC out=$OUT"
+fi
+# The control: an entry that yields nowhere carries no annotation at all.
+run 'SIZE_RATCHET_CLASSES=ui/*.ts=400' SIZE_RATCHET_FROZEN_CLASSES=
+if [ "$RC" -eq 1 ] && has "classes ui/*.ts=400," && ! has "yielded"; then
+  ok "control: with nothing frozen the same entry is reported plain"
+else
+  bad "control: an unyielded entry carries no annotation" "rc=$RC out=$OUT"
+fi
+
+echo "=== a NEW offender is offered the bootstrap, frozen class included ==="
+# NEW fires when a path is over its threshold with NO baseline row, so there is
+# no row for the freeze to refuse. The freeze speaks to raising an EXISTING
+# row, which is the GROW and RAISED case.
+new_repo bootstrap
+mklines src/a.test.ts 900
+mklines src/big.ts 500
+mkdir -p "$R/tools"
+printf 'src/big.ts	500
+' >"$R/$BASE"
+git -C "$R" add -A
+git -C "$R" commit -q -m seed
+run
+if [ "$RC" -eq 1 ] && has "new offender: src/a.test.ts — 900 lines > threshold 800 (class *.test.*)" \
+  && has "remedy: split at a concept seam, or declare the row with RATCHET_RAISE=1"; then
+  ok "a frozen new offender is offered the bootstrap, not a remedy the freeze forbids"
+else
+  bad "NEW on a frozen path names the bootstrap" "rc=$RC out=$OUT"
+fi
+# The control: writing that row turns the same path into the ADDED verdict,
+# which names the same remedy, and the declaration then carries the run.
+printf 'src/a.test.ts	900
+src/big.ts	500
+' >"$R/$BASE"
+git -C "$R" add -A
+run
+if [ "$RC" -eq 1 ] && has "baseline row added: src/a.test.ts" \
+  && has "remedy: split at a concept seam, or declare the row with RATCHET_RAISE=1"; then
+  ok "control: the ADDED verdict for the same path names the same remedy"
+else
+  bad "control: ADDED names the bootstrap" "rc=$RC out=$OUT"
+fi
+run RATCHET_RAISE=1
+[ "$RC" -eq 0 ] && ok "control: and the declaration carries that first row in a frozen class" \
+  || bad "control: the bootstrap is admitted in a frozen class" "rc=$RC out=$OUT"
 
 echo "=== the package excludes CHANGELOG*.md by default ==="
 new_repo changelog

--- a/.agents/skills/size-ratchet/tests/shipped-defaults.test.sh
+++ b/.agents/skills/size-ratchet/tests/shipped-defaults.test.sh
@@ -249,9 +249,9 @@ has "skills/x/SKILL.md" && bad "control: SKILL.md passes under the shipped class
   || ok "control: without the override the 10000-byte SKILL.md is under 24k and passes"
 
 echo "=== a repo class scoped to a directory does not shadow a frozen class ==="
-# `*` crosses `/`, so `ui/*.ts` reaches the test files under ui/ too. They are
-# frozen, so a 250-line ceiling on them would demand a split the class the
-# package ships already sized at 800.
+# `*` crosses `/`, so `ui/*.ts` reaches the test files under ui/ too, and an
+# entry written for components would retitle the class the package ships for
+# them. The rule these arms pin: README.md "Path classes".
 new_repo shadow
 mklines ui/src/App.ts 300
 mklines ui/src/App.test.ts 500
@@ -357,18 +357,30 @@ if [ "$RC" -eq 0 ] && has "classes ui/*.ts=400 (yielded on frozen paths)"; then
 else
   bad "a partly yielded entry says so on the verdict line" "rc=$RC out=$OUT"
 fi
-# The control: an entry that yields nowhere carries no annotation at all.
+# An entry that matched nothing at all governs nothing too — a typo'd or stale
+# pattern is the likeliest way to get there, and a run confirming it as the
+# mapping in force is the one that hides it.
+run 'SIZE_RATCHET_CLASSES=uii/*.ts=1'
+if [ "$RC" -eq 0 ] && has "classes uii/*.ts=1 (governed nothing: matched no counted path)"; then
+  ok "an entry no counted path matches is reported as governing nothing"
+else
+  bad "a never-matched entry says so on the verdict line" "rc=$RC out=$OUT"
+fi
+# The control: an entry that yields nowhere and governs its paths carries no
+# annotation at all, so the annotations above are not on every entry.
 run 'SIZE_RATCHET_CLASSES=ui/*.ts=400' SIZE_RATCHET_FROZEN_CLASSES=
-if [ "$RC" -eq 1 ] && has "classes ui/*.ts=400," && ! has "yielded"; then
+if [ "$RC" -eq 1 ] && has "classes ui/*.ts=400," && ! has "governed nothing" && ! has "yielded"; then
   ok "control: with nothing frozen the same entry is reported plain"
 else
   bad "control: an unyielded entry carries no annotation" "rc=$RC out=$OUT"
 fi
 
-echo "=== a NEW offender is offered the bootstrap, frozen class included ==="
-# NEW fires when a path is over its threshold with NO baseline row, so there is
-# no row for the freeze to refuse. The freeze speaks to raising an EXISTING
-# row, which is the GROW and RAISED case.
+echo "=== the remedy follows HEAD's baseline, not the verdict label ==="
+# One predicate decides every size remedy: whether HEAD's baseline carries the
+# path. A path HEAD does not carry has no row to raise, so the declaration
+# admits a first one in every class; a path HEAD carries is a raise, which a
+# frozen class refuses. The NEW label appears on both sides of that line, so
+# reading the label instead misdirects in one direction or the other.
 new_repo bootstrap
 mklines src/a.test.ts 900
 mklines src/big.ts 500
@@ -400,6 +412,39 @@ fi
 run RATCHET_RAISE=1
 [ "$RC" -eq 0 ] && ok "control: and the declaration carries that first row in a frozen class" \
   || bad "control: the bootstrap is admitted in a frozen class" "rc=$RC out=$OUT"
+
+# The other direction, same NEW label: HEAD carries the row, the change deletes
+# it and the file grows. Bootstrapping is impossible here — restoring the row
+# at the new size is the raise a frozen class refuses — so the remedy is the
+# split, and the arm above is its control.
+new_repo remedy-head
+mkbytes docs/guide.md 30000
+mkdir -p "$R/tools"
+printf 'docs/guide.md	30000b
+' >"$R/$BASE"
+git -C "$R" add -A
+git -C "$R" commit -q -m row
+mkbytes docs/guide.md 70000
+: >"$R/$BASE"
+git -C "$R" add -A
+run
+if [ "$RC" -eq 1 ] && has "new offender: docs/guide.md — 70000 bytes > threshold 65536 (class *.md)" \
+  && has "remedy: split at a concept seam (a frozen class never raises an existing row)"; then
+  ok "a NEW verdict for a path HEAD's baseline carries is offered the split, not a bootstrap"
+else
+  bad "the deleted-row NEW verdict names the raise it cannot have" "rc=$RC out=$OUT"
+fi
+# And the route the bootstrap wording would have sent its author down is the
+# one the gate refuses, which is why that wording must not appear here.
+printf 'docs/guide.md	70000b
+' >"$R/$BASE"
+git -C "$R" add -A
+run RATCHET_RAISE=1
+if [ "$RC" -eq 1 ] && has "frozen baseline row raised: docs/guide.md — row 30000 -> 70000 bytes"; then
+  ok "control: restoring that row and declaring it is refused, so the bootstrap remedy would misdirect"
+else
+  bad "control: the declared raise of the restored row is refused" "rc=$RC out=$OUT"
+fi
 
 echo "=== the package excludes CHANGELOG*.md by default ==="
 new_repo changelog

--- a/.agents/skills/size-ratchet/tests/shipped-defaults.test.sh
+++ b/.agents/skills/size-ratchet/tests/shipped-defaults.test.sh
@@ -248,6 +248,51 @@ run
 has "skills/x/SKILL.md" && bad "control: SKILL.md passes under the shipped class" "$OUT" \
   || ok "control: without the override the 10000-byte SKILL.md is under 24k and passes"
 
+echo "=== a repo class scoped to a directory does not shadow a frozen class ==="
+# `*` crosses `/`, so `ui/*.ts` reaches the test files under ui/ too. They are
+# frozen, so a 250-line ceiling on them would demand a split the class the
+# package ships already sized at 800.
+new_repo shadow
+mklines ui/src/App.ts 300
+mklines ui/src/App.test.ts 500
+mklines docs/guide.md 300
+git -C "$R" add -A
+run 'SIZE_RATCHET_CLASSES=ui/*.ts=250;ui/*.tsx=250'
+if [ "$RC" -eq 1 ] \
+  && has "ui/src/App.ts — 300 lines > threshold 250 (class ui/*.ts)" \
+  && ! has "ui/src/App.test.ts" && ! has "docs/guide.md"; then
+  ok "the repo class judges the component and hands the frozen test and doc back to the shipped list"
+else
+  bad "a directory-scoped repo class spares frozen paths" "rc=$RC out=$OUT"
+fi
+# The control: the freeze is what routes those two paths. Drop it and the same
+# repo class takes them at 250 — which is the defect this section pins.
+run 'SIZE_RATCHET_CLASSES=ui/*.ts=250;ui/*.tsx=250' SIZE_RATCHET_FROZEN_CLASSES=
+if [ "$RC" -eq 1 ] && has "ui/src/App.test.ts — 500 lines > threshold 250 (class ui/*.ts)"; then
+  ok "control: with nothing frozen the same class does take the test file at 250"
+else
+  bad "control: the freeze is what routes the shadowed path" "rc=$RC out=$OUT"
+fi
+# Markdown carries the unit too: the shadow would have judged 300 lines where
+# the shipped class judges bytes.
+run 'SIZE_RATCHET_CLASSES=docs/*=250'
+[ "$RC" -eq 0 ] && ok "a doc under a directory-scoped class keeps its shipped byte ceiling" \
+  || bad "markdown keeps its class under a directory-scoped repo entry" "rc=$RC out=$OUT"
+run 'SIZE_RATCHET_CLASSES=docs/*=250' SIZE_RATCHET_FROZEN_CLASSES=
+if [ "$RC" -eq 1 ] && has "docs/guide.md — 300 lines > threshold 250 (class docs/*)"; then
+  ok "control: unfrozen, that same entry judges the doc in lines at 250"
+else
+  bad "control: markdown shadow" "rc=$RC out=$OUT"
+fi
+# A frozen path the shipped list names no class for still takes the repo's
+# entry: the base threshold is a number nobody wrote for it.
+run 'SIZE_RATCHET_CLASSES=ui/*.ts=250' SIZE_RATCHET_DEFAULT_CLASSES=
+if [ "$RC" -eq 1 ] && has "ui/src/App.test.ts — 500 lines > threshold 250 (class ui/*.ts)"; then
+  ok "with no shipped class to hand the frozen path to, the repo entry still decides it"
+else
+  bad "skipped entry stands where the shipped list claims nothing" "rc=$RC out=$OUT"
+fi
+
 echo "=== the package excludes CHANGELOG*.md by default ==="
 new_repo changelog
 mkbytes CHANGELOG.md 200000

--- a/.agents/skills/size-ratchet/tests/shipped-defaults.test.sh
+++ b/.agents/skills/size-ratchet/tests/shipped-defaults.test.sh
@@ -337,36 +337,48 @@ run 'SIZE_RATCHET_CLASSES=ui/*=2000' SIZE_RATCHET_FROZEN_CLASSES=
   || bad "control: the looser entry reaches the fixture" "rc=$RC out=$OUT"
 
 echo "=== the verdict line reports what each repo entry actually governed ==="
-# A yielded entry that still governs its own paths is named as such; one that
-# yielded on every path it matched governed nothing, and a run that printed it
+# An entry that decided no counted path governs nothing, and a run printing it
 # as the mapping in force would advertise a threshold nothing was judged
-# against — a clean run saying something false.
+# against. Three shapes arrive at that state and the line names none of them,
+# because the engine holds no state that tells them apart: every arm below
+# asserts the SAME reason.
 new_repo shadownote
 mklines ui/src/App.ts 300
 mklines ui/src/App.test.ts 500
 git -C "$R" add -A
+NOTHING="(governed nothing: decided no counted path)"
+# Shape one: every path it matches is frozen, so it is passed over on all of
+# them.
 run 'SIZE_RATCHET_CLASSES=ui/src/*.test.ts=100'
-if [ "$RC" -eq 0 ] && has "classes ui/src/*.test.ts=100 (governed nothing: yielded on every path it matched)"; then
+if [ "$RC" -eq 0 ] && has "classes ui/src/*.test.ts=100 $NOTHING"; then
   ok "an entry every one of whose paths is frozen is reported as governing nothing"
 else
   bad "a wholly yielded entry says so on the verdict line" "rc=$RC out=$OUT"
 fi
+# Shape two: it matches a counted path, but an EARLIER repo entry already
+# claimed it. Nothing was frozen and nothing yielded.
+run SIZE_RATCHET_DEFAULT_CLASSES= SIZE_RATCHET_FROZEN_CLASSES= 'SIZE_RATCHET_CLASSES=*.ts=400;ui/*.ts=250'
+if [ "$RC" -eq 1 ] && has "classes *.ts=400;ui/*.ts=250 $NOTHING"; then
+  ok "an entry an earlier one shadows is reported the same way, with no cause claimed"
+else
+  bad "an ordering-shadowed entry says the same thing" "rc=$RC out=$OUT"
+fi
+# Shape three: no counted path matches it at all.
+run 'SIZE_RATCHET_CLASSES=uii/*.ts=1'
+if [ "$RC" -eq 0 ] && has "classes uii/*.ts=1 $NOTHING"; then
+  ok "an entry no counted path matches is reported the same way"
+else
+  bad "a never-matched entry says the same thing" "rc=$RC out=$OUT"
+fi
+# An entry that DOES govern its own paths and was passed over on frozen ones
+# is a different statement, and that one the engine can stand behind.
 run 'SIZE_RATCHET_CLASSES=ui/*.ts=400'
-if [ "$RC" -eq 0 ] && has "classes ui/*.ts=400 (yielded on frozen paths)"; then
-  ok "an entry that governs some paths and yields others is reported as yielding"
+if [ "$RC" -eq 0 ] && has "classes ui/*.ts=400 (yielded on frozen paths)" && ! has "governed nothing"; then
+  ok "an entry that governs some paths and is passed over on frozen ones says exactly that"
 else
   bad "a partly yielded entry says so on the verdict line" "rc=$RC out=$OUT"
 fi
-# An entry that matched nothing at all governs nothing too — a typo'd or stale
-# pattern is the likeliest way to get there, and a run confirming it as the
-# mapping in force is the one that hides it.
-run 'SIZE_RATCHET_CLASSES=uii/*.ts=1'
-if [ "$RC" -eq 0 ] && has "classes uii/*.ts=1 (governed nothing: matched no counted path)"; then
-  ok "an entry no counted path matches is reported as governing nothing"
-else
-  bad "a never-matched entry says so on the verdict line" "rc=$RC out=$OUT"
-fi
-# The control: an entry that yields nowhere and governs its paths carries no
+# The control: an entry that governs its paths with nothing frozen carries no
 # annotation at all, so the annotations above are not on every entry.
 run 'SIZE_RATCHET_CLASSES=ui/*.ts=400' SIZE_RATCHET_FROZEN_CLASSES=
 if [ "$RC" -eq 1 ] && has "classes ui/*.ts=400," && ! has "governed nothing" && ! has "yielded"; then

--- a/changelog.d/fixed/KEN-875.md
+++ b/changelog.d/fixed/KEN-875.md
@@ -1,0 +1,3 @@
+- A repo's `SIZE_RATCHET_CLASSES` entry no longer shadows a frozen shipped
+  class: `ui/*.ts=250` leaves the tests and documents under `ui/` to the
+  shipped classes that name them.

--- a/changelog.d/fixed/KEN-875.md
+++ b/changelog.d/fixed/KEN-875.md
@@ -1,3 +1,3 @@
 - **Breaking:** a repo `SIZE_RATCHET_CLASSES` entry no longer decides a frozen
-  path a shipped class names. Restate that pattern to keep your number, or
-  accept the shipped one and run `--update`.
+  path a shipped class names. Restate the pattern to keep your number, or take
+  the shipped one and do what the run says.

--- a/changelog.d/fixed/KEN-875.md
+++ b/changelog.d/fixed/KEN-875.md
@@ -1,3 +1,3 @@
-- A repo's `SIZE_RATCHET_CLASSES` entry no longer shadows a frozen shipped
-  class: `ui/*.ts=250` leaves the tests and documents under `ui/` to the
-  shipped classes that name them.
+- **Breaking:** a repo `SIZE_RATCHET_CLASSES` entry no longer decides a frozen
+  path a shipped class names. Restate that pattern to keep your number, or
+  accept the shipped one and run `--update`.

--- a/kendex.settings.toml
+++ b/kendex.settings.toml
@@ -265,18 +265,11 @@ ORCH_STATE_DIR = "tmp"
 # fall through to, the shipped list naming no TypeScript class — because a
 # component that long has stopped being one component.
 #
-# Every entry is scoped to ui/, and the test entries lead, for one reason:
-# this list is matched before the shipped one and its globs cross `/`, so a
-# repo class shadows every shipped class whose paths it also matches, and
-# each shadowed class has to be re-led at the same scope. `ui/*.ts` alone
-# takes ui/ test files at 250 — the ones named for a test and the ones that
-# are one by directory alike — while the freeze still reaches them, and a
-# frozen row can never rise. Scoping every entry to ui/ is the other half:
-# an unscoped `*.test.*` would also lead the shipped markdown classes, and a
-# test-named markdown file would take a line count in place of its byte
-# ceiling. Both directory forms are spelled out for the shipped list's own
-# reason: `*` may match nothing, but the literal `/` must still be there.
-SIZE_RATCHET_CLASSES = "ui/*.test.*=800;ui/*.spec.*=800;ui/test/*=800;ui/*/test/*=800;ui/tests/*=800;ui/*/tests/*=800;ui/__tests__/*=800;ui/*/__tests__/*=800;ui/*.ts=250;ui/*.tsx=250"
+# These globs cross `/`, so `ui/*.ts` also matches ui/ test files and any
+# other frozen path under ui/. The engine hands those back to the shipped
+# class that names them, so the two entries here are policy and nothing else
+# needs restating.
+SIZE_RATCHET_CLASSES = "ui/*.ts=250;ui/*.tsx=250"
 
 # ── Worktrees ────────────────────────────────────────────────────────────
 # What a fresh issue worktree gets from this checkout: only paths git does

--- a/kendex.settings.toml
+++ b/kendex.settings.toml
@@ -266,9 +266,9 @@ ORCH_STATE_DIR = "tmp"
 # component that long has stopped being one component.
 #
 # These globs cross `/`, so `ui/*.ts` also matches ui/ test files and any
-# other frozen path under ui/. The engine hands those back to the shipped
-# class that names them, so the two entries here are policy and nothing else
-# needs restating.
+# other frozen path under ui/. The engine hands those back to the class the
+# package ships for them (size-ratchet README.md, "Path classes"), so these
+# two entries are policy and nothing else needs restating.
 SIZE_RATCHET_CLASSES = "ui/*.ts=250;ui/*.tsx=250"
 
 # ── Worktrees ────────────────────────────────────────────────────────────

--- a/skills/size-ratchet/DEVELOPMENT.md
+++ b/skills/size-ratchet/DEVELOPMENT.md
@@ -128,6 +128,19 @@ shipped list alone — exact single-threshold behavior needs the repo's own
 entries in the shipped list, so a README or a doc under a `tests/` directory
 is judged as the document it is.
 
+First match wins **except on a frozen path**. `*` crosses `/`, so a repo
+class scoped to a directory (`ui/*.ts=250`) also matches every test file and
+document under it; those are frozen, and a frozen row never rises, so a
+tightened threshold there asks for a remedy the freeze forbids. The engine
+skips such an entry and lets the shipped class that names the path decide. A
+repo that means to move a frozen class restates that class's own pattern
+(`*/SKILL.md=8k`), and that entry still wins — restating the pattern is how
+a repo names which class it is moving. Where the shipped list claims the
+path at all is the whole question: with no shipped class to hand it to, the
+skipped entry stands rather than falling through to a base threshold nobody
+wrote for it. A consumer therefore never restates a shipped threshold to
+express a narrower policy on one directory.
+
 A directory name takes both class forms: `*` may match nothing but the
 literal `/` in `*/tests/*` still must be there, so `*/tests/*` covers
 `pkg/tests/x` and never a root-level `tests/x` — that one needs `tests/*`.

--- a/skills/size-ratchet/DEVELOPMENT.md
+++ b/skills/size-ratchet/DEVELOPMENT.md
@@ -128,18 +128,33 @@ shipped list alone — exact single-threshold behavior needs the repo's own
 entries in the shipped list, so a README or a doc under a `tests/` directory
 is judged as the document it is.
 
-First match wins **except on a frozen path**. `*` crosses `/`, so a repo
-class scoped to a directory (`ui/*.ts=250`) also matches every test file and
-document under it; those are frozen, and a frozen row never rises, so a
-tightened threshold there asks for a remedy the freeze forbids. The engine
-skips such an entry and lets the shipped class that names the path decide. A
-repo that means to move a frozen class restates that class's own pattern
+First match wins **except on a frozen path that the shipped list also
+classifies**. `*` crosses `/`, so a repo class scoped to a directory
+(`ui/*.ts=250`) also matches every test file under it, and a broader one
+(`docs/*=250`) reaches documents too. Those paths already have a shipped
+class naming them, and the repo never named them: the entry retitles that
+class silently, the counting UNIT included, so a `docs/*=250` written for
+code judges a byte class in lines. The engine skips such an entry and lets
+the shipped class decide. The rule runs in both directions, a looser repo
+entry as much as a tighter one, because what it protects is the shipped
+class naming the path rather than any one number.
+
+A repo that means to move a frozen class restates that class's own pattern
 (`*/SKILL.md=8k`), and that entry still wins — restating the pattern is how
 a repo names which class it is moving. Where the shipped list claims the
 path at all is the whole question: with no shipped class to hand it to, the
 skipped entry stands rather than falling through to a base threshold nobody
-wrote for it. A consumer therefore never restates a shipped threshold to
-express a narrower policy on one directory.
+wrote for it, and where two entries were skipped the first one stands, the
+way first-match-wins decides every other path. A consumer therefore never
+restates a shipped threshold to express a narrower policy on one directory.
+
+The verdict line reports what each repo entry actually governed, which is
+why it is assembled after the classification pass rather than at parse time.
+An entry that yielded somewhere reads `ui/*.ts=250 (yielded on frozen
+paths)`; one that yielded on every path it matched reads `(governed nothing:
+yielded on every path it matched)`, because a run printing an inert entry as
+the mapping in force would be a clean run advertising a threshold no file
+was judged against.
 
 A directory name takes both class forms: `*` may match nothing but the
 literal `/` in `*/tests/*` still must be there, so `*/tests/*` covers
@@ -211,7 +226,14 @@ see one — the reason belongs in the commit body, where review reads it.
 `SIZE_RATCHET_FROZEN_CLASSES` refuses a RAISE regardless of that
 declaration, and defaults to every markdown class and every test class. It
 does not refuse a first row: a new path still gets its bootstrap row, which
-is what a repo adopting a class needs on day one.
+is what a repo adopting a class needs on day one, and the `new offender` and
+`baseline row added` diagnostics both name that bootstrap as the remedy
+beside the split. The freeze speaks only to a row that already exists.
+
+The setting carries a second duty, in [Path-class
+evaluation](#path-class-evaluation): its paths keep the shipped class that
+names them rather than a repo entry's. Adding a glob to the freeze list to
+lock rows therefore also stops a repo class retitling those paths.
 
 Rows already at HEAD are grandfathered, because the gate judges the change
 and not the history it inherited. A HEAD with no baseline (an unborn HEAD,

--- a/skills/size-ratchet/DEVELOPMENT.md
+++ b/skills/size-ratchet/DEVELOPMENT.md
@@ -128,32 +128,20 @@ shipped list alone — exact single-threshold behavior needs the repo's own
 entries in the shipped list, so a README or a doc under a `tests/` directory
 is judged as the document it is.
 
-First match wins **except on a frozen path that the shipped list also
-classifies**. `*` crosses `/`, so a repo class scoped to a directory
-(`ui/*.ts=250`) also matches every test file under it, and a broader one
-(`docs/*=250`) reaches documents too. Those paths already have a shipped
-class naming them, and the repo never named them: the entry retitles that
-class silently, the counting UNIT included, so a `docs/*=250` written for
-code judges a byte class in lines. The engine skips such an entry and lets
-the shipped class decide. The rule runs in both directions, a looser repo
-entry as much as a tighter one, because what it protects is the shipped
-class naming the path rather than any one number.
+First match wins except on a frozen path, where the class inversion applies.
+[README.md § Path classes](README.md#path-classes) is the only statement of
+that rule; `path_threshold` implements it, one branch per exit. Nothing here
+restates it — a rule paraphrased at six sites loses a clause at one of them.
 
-A repo that means to move a frozen class restates that class's own pattern
-(`*/SKILL.md=8k`), and that entry still wins — restating the pattern is how
-a repo names which class it is moving. Where the shipped list claims the
-path at all is the whole question: with no shipped class to hand it to, the
-skipped entry stands rather than falling through to a base threshold nobody
-wrote for it, and where two entries were skipped the first one stands, the
-way first-match-wins decides every other path. A consumer therefore never
-restates a shipped threshold to express a narrower policy on one directory.
-
-The verdict line reports what each repo entry actually governed, which is
-why it is assembled after the classification pass rather than at parse time.
-An entry that yielded somewhere reads `ui/*.ts=250 (yielded on frozen
-paths)`; one that yielded on every path it matched reads `(governed nothing:
-yielded on every path it matched)`, because a run printing an inert entry as
-the mapping in force would be a clean run advertising a threshold no file
+What belongs here is the shape of the implementation. Both lists are parsed
+into one indexed array, the repo's entries first, and `REPO_CLASS_COUNT`
+divides them; a repo entry whose pattern the shipped list also carries is
+marked in `CLASS_RESTATED` once, after both parses. `path_threshold` stamps
+every repo entry it passes over or lets decide, so the verdict line can be
+assembled after the classification pass rather than at parse time — it
+reports what each entry actually governed, and an entry that decided nothing
+is named as such however it got there, because a run printing an inert entry
+as the mapping in force would be a clean run advertising a threshold no file
 was judged against.
 
 A directory name takes both class forms: `*` may match nothing but the
@@ -226,14 +214,16 @@ see one — the reason belongs in the commit body, where review reads it.
 `SIZE_RATCHET_FROZEN_CLASSES` refuses a RAISE regardless of that
 declaration, and defaults to every markdown class and every test class. It
 does not refuse a first row: a new path still gets its bootstrap row, which
-is what a repo adopting a class needs on day one, and the `new offender` and
-`baseline row added` diagnostics both name that bootstrap as the remedy
-beside the split. The freeze speaks only to a row that already exists.
+is what a repo adopting a class needs on day one. Every size remedy follows
+one predicate, whether HEAD's baseline carries the path — a path HEAD does
+not carry names the bootstrap beside the split, a path HEAD carries names
+the split alone in a frozen class. The verdict label decides nothing: `new
+offender` appears on both sides of that line, since a change can delete a row
+HEAD still carries.
 
-The setting carries a second duty, in [Path-class
-evaluation](#path-class-evaluation): its paths keep the shipped class that
-names them rather than a repo entry's. Adding a glob to the freeze list to
-lock rows therefore also stops a repo class retitling those paths.
+The setting carries a second duty: frozen paths are where the class
+inversion applies, so a glob added here changes which class decides those
+paths too. [README.md § Path classes](README.md#path-classes) says how.
 
 Rows already at HEAD are grandfathered, because the gate judges the change
 and not the history it inherited. A HEAD with no baseline (an unborn HEAD,

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -45,6 +45,10 @@ even then. Markdown is measured in bytes and code in lines. Flags and exit codes
      instead of comparing it.
   5. **A row added or raised over HEAD's baseline** — see
      [Raising a row](#raising-a-row).
+  6. **The baseline moved and its rows changed** — HEAD's rows left the old
+     path and the rows arriving at the new one are not them, so nothing
+     compares them and a raise would land unjudged. Move the baseline in a
+     commit that changes nothing else, then change its rows in the next one.
 - **`--staged`** counts index blobs for every tracked file rather than
   preferring the worktree copy: what the commit records is the blob. Use it
   in a pre-commit hook; CI, which checks out a clean tree, does not need it.
@@ -166,9 +170,10 @@ clause in one of them.
 The verdict line says what each entry governed. An entry that decided some
 paths and was passed over on frozen ones reads `ui/*.ts=250 (yielded on
 frozen paths)`; one that decided none reads `(governed nothing: decided no
-counted path)`. It does not say why, because a pattern matching nothing, a
-pattern an earlier entry already claimed, and one passed over on frozen paths
-all reach that state and the engine cannot tell them apart.
+counted path)`. It reports the state, not the cause: a pattern matching
+nothing and a pattern an earlier entry already claimed cannot be told apart,
+and an entry passed over on frozen paths reads the same once it decided
+nothing, because one reason is enough.
 
 `SIZE_RATCHET_DEFAULT_CLASSES = ""` drops the shipped list; the repo's own
 `SIZE_RATCHET_CLASSES` still matches first, so single-threshold behavior

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -164,10 +164,11 @@ names it and points here, because a rule paraphrased in six places loses a
 clause in one of them.
 
 The verdict line says what each entry governed. An entry that decided some
-paths and lost others reads `ui/*.ts=250 (yielded on frozen paths)`; one that
-decided none reads `(governed nothing: yielded on every path it matched)`, or
-`(governed nothing: matched no counted path)` where a typo'd or stale pattern
-matched nothing at all.
+paths and was passed over on frozen ones reads `ui/*.ts=250 (yielded on
+frozen paths)`; one that decided none reads `(governed nothing: decided no
+counted path)`. It does not say why, because a pattern matching nothing, a
+pattern an earlier entry already claimed, and one passed over on frozen paths
+all reach that state and the engine cannot tell them apart.
 
 `SIZE_RATCHET_DEFAULT_CLASSES = ""` drops the shipped list; the repo's own
 `SIZE_RATCHET_CLASSES` still matches first, so single-threshold behavior

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -29,11 +29,10 @@ even then. Markdown is measured in bytes and code in lines. Flags and exit codes
   everything else in lines.
 - **Threshold**: `SIZE_RATCHET_CLASSES` first, then the shipped
   `SIZE_RATCHET_DEFAULT_CLASSES`, then `SIZE_RATCHET_THRESHOLD` (default
-  `400` lines) — see [Path classes](#path-classes), which carries the one
-  inversion: on a frozen path that the shipped list also classifies, the
-  shipped class wins unless the repo entry restates its pattern. Every file
-  resolves to exactly one threshold, and every other semantic runs per file
-  against it.
+  `400` lines), with one inversion on frozen paths. [Path
+  classes](#path-classes) states that rule and is the only place that does.
+  Every file resolves to exactly one threshold, and every other semantic runs
+  per file against it.
 - **FAIL** (exit 1) on any of:
   1. **New offender** — a file over its threshold with no baseline row.
   2. **Growth** — a baselined file whose actual size exceeds its row.
@@ -69,10 +68,10 @@ raises is that threshold routed around.
 - **Frozen classes** (`SIZE_RATCHET_FROZEN_CLASSES`, default every markdown
   class and every test class) refuse a **raise of an existing row** outright,
   whatever the run carries. A test splits and a document is cut; neither is
-  ever the fix that needs the added lines. The setting has a second duty in
-  [Path classes](#path-classes): its paths keep the shipped class that names
-  them rather than a repo entry's, so adding a glob here to lock rows also
-  stops a repo class retitling those paths.
+  ever the fix that needs the added lines. The setting has a second duty:
+  frozen paths are where the class inversion in [Path
+  classes](#path-classes) applies, so a glob added here to lock rows changes
+  which class decides those paths too.
 - **Every other added or raised row** needs `RATCHET_RAISE=1` on the
   invocation. No commit message is read — a pre-commit hook cannot see one —
   so the reason belongs in the commit body, where review reads it.
@@ -159,10 +158,16 @@ the `*/SKILL.md` example above does: an entry naming a pattern the shipped
 list carries still wins. Where the shipped list names no class for a frozen
 path, the repo entry stands.
 
-The verdict line says what each entry governed: an entry that yielded
-somewhere reads `ui/*.ts=250 (yielded on frozen paths)`, and one that
-yielded on every path it matched reads `(governed nothing: yielded on every
-path it matched)`.
+**This is the only statement of the rule.** Every other surface — the
+`--help` text, the block comments, `DEVELOPMENT.md`, the settings table —
+names it and points here, because a rule paraphrased in six places loses a
+clause in one of them.
+
+The verdict line says what each entry governed. An entry that decided some
+paths and lost others reads `ui/*.ts=250 (yielded on frozen paths)`; one that
+decided none reads `(governed nothing: yielded on every path it matched)`, or
+`(governed nothing: matched no counted path)` where a typo'd or stale pattern
+matched nothing at all.
 
 `SIZE_RATCHET_DEFAULT_CLASSES = ""` drops the shipped list; the repo's own
 `SIZE_RATCHET_CLASSES` still matches first, so single-threshold behavior
@@ -199,9 +204,9 @@ src/gen/*.rs	generated bindings
 | Key | Default | Meaning |
 |---|---|---|
 | `SIZE_RATCHET_THRESHOLD` | `400` | Line threshold for paths matching no class. |
-| `SIZE_RATCHET_CLASSES` | *(none)* | This repo's overrides, `pattern=threshold` separated by `;`, matched before the shipped list — except on a frozen path that the shipped list also classifies, where only an entry restating that class's own pattern decides. |
+| `SIZE_RATCHET_CLASSES` | *(none)* | This repo's overrides, `pattern=threshold` separated by `;`, matched before the shipped list, with one inversion on frozen paths — see [Path classes](#path-classes). |
 | `SIZE_RATCHET_DEFAULT_CLASSES` | *(the shipped list)* | The class list the package ships; empty runs with no classes. |
-| `SIZE_RATCHET_FROZEN_CLASSES` | *(markdown and tests)* | `;`-separated globs with two duties: their rows may never rise, and their paths keep the shipped class that names them rather than a repo entry's. |
+| `SIZE_RATCHET_FROZEN_CLASSES` | *(markdown and tests)* | `;`-separated globs whose rows may never rise; they also decide where the [Path classes](#path-classes) inversion applies. |
 | `SIZE_RATCHET_BASELINE` | `tools/size-ratchet-baseline.tsv` | Baseline path. |
 | `SIZE_RATCHET_EXCLUDES` | `tools/size-ratchet-excludes` | Exclusion-list path. |
 

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -29,8 +29,9 @@ even then. Markdown is measured in bytes and code in lines. Flags and exit codes
   everything else in lines.
 - **Threshold**: `SIZE_RATCHET_CLASSES` first, then the shipped
   `SIZE_RATCHET_DEFAULT_CLASSES`, then `SIZE_RATCHET_THRESHOLD` (default
-  `400` lines) — see [Path classes](#path-classes). Every file resolves to
-  exactly one threshold, and every other semantic runs per file against it.
+  `400` lines) — see [Path classes](#path-classes). On a frozen path the
+  shipped class wins instead. Every file resolves to exactly one threshold,
+  and every other semantic runs per file against it.
 - **FAIL** (exit 1) on any of:
   1. **New offender** — a file over its threshold with no baseline row.
   2. **Growth** — a baselined file whose actual size exceeds its row.
@@ -133,6 +134,23 @@ and the shipped list decides everything they leave alone.
 SIZE_RATCHET_CLASSES = "*/SKILL.md=32k"
 ```
 
+**A repo entry never shadows a frozen class.** `*` crosses `/`, so
+`ui/*.ts=250` also matches the test files under `ui/`; they are frozen, and a
+frozen row never rises, so a tighter number there would demand a split the
+shipped class already sized. Such an entry is skipped and the shipped class
+that names the path decides — no consumer restates a shipped threshold to
+scope a narrower policy to one directory:
+
+```toml
+[env]
+SIZE_RATCHET_CLASSES = "ui/*.ts=250;ui/*.tsx=250"  # ui/ tests stay at 800
+```
+
+To move a frozen class deliberately, restate that class's own pattern, as
+the `*/SKILL.md` example above does: an entry naming a pattern the shipped
+list carries still wins. Where the shipped list names no class for a frozen
+path, the repo entry stands.
+
 `SIZE_RATCHET_DEFAULT_CLASSES = ""` drops the shipped list; the repo's own
 `SIZE_RATCHET_CLASSES` still matches first, so single-threshold behavior
 needs both empty.
@@ -168,7 +186,7 @@ src/gen/*.rs	generated bindings
 | Key | Default | Meaning |
 |---|---|---|
 | `SIZE_RATCHET_THRESHOLD` | `400` | Line threshold for paths matching no class. |
-| `SIZE_RATCHET_CLASSES` | *(none)* | This repo's overrides, `pattern=threshold` separated by `;`, matched before the shipped list. |
+| `SIZE_RATCHET_CLASSES` | *(none)* | This repo's overrides, `pattern=threshold` separated by `;`, matched before the shipped list — except on a frozen path, where only an entry restating a shipped pattern decides. |
 | `SIZE_RATCHET_DEFAULT_CLASSES` | *(the shipped list)* | The class list the package ships; empty runs with no classes. |
 | `SIZE_RATCHET_FROZEN_CLASSES` | *(markdown and tests)* | `;`-separated globs whose rows may never rise. |
 | `SIZE_RATCHET_BASELINE` | `tools/size-ratchet-baseline.tsv` | Baseline path. |

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -29,9 +29,11 @@ even then. Markdown is measured in bytes and code in lines. Flags and exit codes
   everything else in lines.
 - **Threshold**: `SIZE_RATCHET_CLASSES` first, then the shipped
   `SIZE_RATCHET_DEFAULT_CLASSES`, then `SIZE_RATCHET_THRESHOLD` (default
-  `400` lines) — see [Path classes](#path-classes). On a frozen path the
-  shipped class wins instead. Every file resolves to exactly one threshold,
-  and every other semantic runs per file against it.
+  `400` lines) — see [Path classes](#path-classes), which carries the one
+  inversion: on a frozen path that the shipped list also classifies, the
+  shipped class wins unless the repo entry restates its pattern. Every file
+  resolves to exactly one threshold, and every other semantic runs per file
+  against it.
 - **FAIL** (exit 1) on any of:
   1. **New offender** — a file over its threshold with no baseline row.
   2. **Growth** — a baselined file whose actual size exceeds its row.
@@ -67,7 +69,10 @@ raises is that threshold routed around.
 - **Frozen classes** (`SIZE_RATCHET_FROZEN_CLASSES`, default every markdown
   class and every test class) refuse a **raise of an existing row** outright,
   whatever the run carries. A test splits and a document is cut; neither is
-  ever the fix that needs the added lines.
+  ever the fix that needs the added lines. The setting has a second duty in
+  [Path classes](#path-classes): its paths keep the shipped class that names
+  them rather than a repo entry's, so adding a glob here to lock rows also
+  stops a repo class retitling those paths.
 - **Every other added or raised row** needs `RATCHET_RAISE=1` on the
   invocation. No commit message is read — a pre-commit hook cannot see one —
   so the reason belongs in the commit body, where review reads it.
@@ -135,21 +140,29 @@ SIZE_RATCHET_CLASSES = "*/SKILL.md=32k"
 ```
 
 **A repo entry never shadows a frozen class.** `*` crosses `/`, so
-`ui/*.ts=250` also matches the test files under `ui/`; they are frozen, and a
-frozen row never rises, so a tighter number there would demand a split the
-shipped class already sized. Such an entry is skipped and the shipped class
-that names the path decides — no consumer restates a shipped threshold to
-scope a narrower policy to one directory:
+`ui/*.ts=250` also matches the test files under `ui/`, and a broader
+`docs/*=250` reaches documents too. Those paths already have a shipped class
+naming them, and the repo never named them: the entry retitles that class
+silently, the counting UNIT included, so a `docs/*=250` written for code
+judges a byte class in lines. Such an entry is skipped and the shipped class
+decides. The rule holds in both directions, a looser repo entry as much as a
+tighter one, so no consumer restates a shipped threshold to scope a narrower
+policy to one directory:
 
 ```toml
 [env]
-SIZE_RATCHET_CLASSES = "ui/*.ts=250;ui/*.tsx=250"  # ui/ tests stay at 800
+SIZE_RATCHET_CLASSES = "ui/*.ts=250;ui/*.tsx=250"  # ui/ test files stay at 800
 ```
 
 To move a frozen class deliberately, restate that class's own pattern, as
 the `*/SKILL.md` example above does: an entry naming a pattern the shipped
 list carries still wins. Where the shipped list names no class for a frozen
 path, the repo entry stands.
+
+The verdict line says what each entry governed: an entry that yielded
+somewhere reads `ui/*.ts=250 (yielded on frozen paths)`, and one that
+yielded on every path it matched reads `(governed nothing: yielded on every
+path it matched)`.
 
 `SIZE_RATCHET_DEFAULT_CLASSES = ""` drops the shipped list; the repo's own
 `SIZE_RATCHET_CLASSES` still matches first, so single-threshold behavior
@@ -186,9 +199,9 @@ src/gen/*.rs	generated bindings
 | Key | Default | Meaning |
 |---|---|---|
 | `SIZE_RATCHET_THRESHOLD` | `400` | Line threshold for paths matching no class. |
-| `SIZE_RATCHET_CLASSES` | *(none)* | This repo's overrides, `pattern=threshold` separated by `;`, matched before the shipped list — except on a frozen path, where only an entry restating a shipped pattern decides. |
+| `SIZE_RATCHET_CLASSES` | *(none)* | This repo's overrides, `pattern=threshold` separated by `;`, matched before the shipped list — except on a frozen path that the shipped list also classifies, where only an entry restating that class's own pattern decides. |
 | `SIZE_RATCHET_DEFAULT_CLASSES` | *(the shipped list)* | The class list the package ships; empty runs with no classes. |
-| `SIZE_RATCHET_FROZEN_CLASSES` | *(markdown and tests)* | `;`-separated globs whose rows may never rise. |
+| `SIZE_RATCHET_FROZEN_CLASSES` | *(markdown and tests)* | `;`-separated globs with two duties: their rows may never rise, and their paths keep the shipped class that names them rather than a repo entry's. |
 | `SIZE_RATCHET_BASELINE` | `tools/size-ratchet-baseline.tsv` | Baseline path. |
 | `SIZE_RATCHET_EXCLUDES` | `tools/size-ratchet-excludes` | Exclusion-list path. |
 

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -39,14 +39,16 @@ migration note for repos already using this format:
 
 ## Responding to a failure
 
-Every diagnostic names the file, its size, the baseline row it violated,
-the deciding threshold (class pattern or default), and the remedy: *split
-at a concept seam*.
+Every size diagnostic names the file, its size, the baseline row it
+violated, the deciding threshold (class pattern or default), and the remedy:
+*split at a concept seam*.
 
-Two verdicts are not a size problem and take no judgment. **A row in the
+Three verdicts are not a size problem and take no judgment. **A row in the
 wrong unit** is a class that changed what it counts: run `--update`, which
 re-measures the row. **A shrunk row** under `--staged` is already lowered
-and staged by the run itself.
+and staged by the run itself. **A moved baseline** names the two paths
+instead of a file and a size: move the baseline in a commit that changes
+nothing else, then change its rows in the next one.
 
 **Check composition before the seam.** A file over its cap whose bulk is
 inline tests needs those tests moved to the language's separate-test

--- a/skills/size-ratchet/references/threshold-change.md
+++ b/skills/size-ratchet/references/threshold-change.md
@@ -1,8 +1,11 @@
 # Threshold change sweep
 
-Run this before a changed `SIZE_RATCHET_THRESHOLD`, `SIZE_RATCHET_CLASSES` or
-`SIZE_RATCHET_DEFAULT_CLASSES` entry lands, in either direction, and when an entry changes UNIT — the
-number a path is judged against moves either way. Run it at `--seed` too when
+Run this before a changed `SIZE_RATCHET_THRESHOLD`, `SIZE_RATCHET_CLASSES`,
+`SIZE_RATCHET_DEFAULT_CLASSES` or `SIZE_RATCHET_FROZEN_CLASSES` entry lands, in
+either direction, and when an entry changes UNIT — the number a path is judged
+against moves either way. A glob added to or removed from the frozen list moves
+matching paths between a repo class and a shipped one, which moves that number
+and, for markdown, the unit. Run it at `--seed` too when
 the repo already had a prose size rule: seeding records no row for an
 under-threshold fragment, so the repo inherits that rule's fragments and
 nothing else points at them.

--- a/skills/size-ratchet/references/threshold-change.md
+++ b/skills/size-ratchet/references/threshold-change.md
@@ -3,9 +3,10 @@
 Run this before a changed `SIZE_RATCHET_THRESHOLD`, `SIZE_RATCHET_CLASSES`,
 `SIZE_RATCHET_DEFAULT_CLASSES` or `SIZE_RATCHET_FROZEN_CLASSES` entry lands, in
 either direction, and when an entry changes UNIT — the number a path is judged
-against moves either way. A glob added to or removed from the frozen list moves
-matching paths between a repo class and a shipped one, which moves that number
-and, for markdown, the unit. Run it at `--seed` too when
+against moves either way. The frozen list moves it too, through the class
+inversion in [README.md § Path
+classes](../README.md#path-classes): a glob added or removed there moves
+matching paths between a repo class and a shipped one. Run it at `--seed` too when
 the repo already had a prose size rule: seeding records no row for an
 under-threshold fragment, so the repo inherits that rule's fragments and
 nothing else points at them.

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -649,14 +649,10 @@ is_excluded() { # PATH — 0 when some exclusion glob matches the full path
 # report() re-runs it to name the threshold that judged the path — including
 # for a baseline row whose file left the tracked set.
 #
-# A repo entry is matched first, EXCEPT on a frozen path. `*` crosses `/`, so
-# a repo class scoped to a directory (`ui/*.ts=250`) also matches paths the
-# repo never named, and silently retitles the shipped class that named them,
-# the counting UNIT included: a `docs/*=250` meant for code judges a byte
-# class in lines. That is what the skip below prevents, and it prevents it in
-# both directions, because what it protects is the shipped class naming the
-# path rather than any one number. The rule and its two exits are stated once,
-# in README.md "Path classes"; each exit is a branch below.
+# A repo entry is matched first, EXCEPT on a frozen path: the skip below is
+# there so a directory-scoped entry cannot retitle a shipped class for paths
+# the repo never named. The rule and its two exits are stated once, in
+# README.md "Path classes"; each exit is a branch below.
 path_threshold() { # PATH
   local i=0 frozen="" shadowed="" skipped="" hit="" s
   # Indexed iteration bounded by CLASS_COUNT: a whole-array expansion on an
@@ -996,11 +992,11 @@ LC_ALL=C sort -- "$TMP/counts.classed" >"$TMP/counts.tsv" || collection_error "c
 
 # The verdict line reports the mapping the run actually USED, which is why it
 # is built here and not at parse time: the pass above put every tracked path
-# through the resolver, so each repo entry now knows whether it decided a path
-# or yielded one to a frozen class. An entry that decided none governs
-# nothing, and a run that printed it as the mapping in force would advertise a
-# threshold no file was ever judged against — a clean run saying something
-# false. The raw setting's spacing and empty entries stay out: they
+# through the resolver, so each repo entry now knows whether it decided one.
+# An entry that decided none governs nothing, and a run that printed it as the
+# mapping in force would advertise a threshold no file was ever judged
+# against — a clean run saying something false. The raw setting's spacing and
+# empty entries stay out: they
 # read as behavior the matcher never sees. The shipped list is a count, not a
 # transcript — it is the same everywhere, and the per-file diagnostics already
 # name the class that decided each path.
@@ -1009,15 +1005,12 @@ sr_ni=0
 while [ "$sr_ni" -lt "$REPO_CLASS_COUNT" ]; do
   sr_entry="${CLASS_PATTERNS[$sr_ni]}=${CLASS_RAW[$sr_ni]}"
   # DECIDED is the predicate, so the bare rendering is unreachable for an
-  # entry that governed nothing however it got there — yielded away, or a
-  # typo'd or stale pattern that matched no counted path at all. YIELDED only
-  # supplies the reason.
+  # entry that governed nothing. WHY it governed nothing is not said: a
+  # pattern matching nothing, a pattern an earlier entry already claimed, and
+  # one passed over on frozen paths all arrive here, and the engine holds no
+  # state that tells them apart. The line says the part it can stand behind.
   if [ "${CLASS_DECIDED[$sr_ni]:-0}" != "1" ]; then
-    if [ "${CLASS_YIELDED[$sr_ni]:-0}" = "1" ]; then
-      sr_entry="$sr_entry (governed nothing: yielded on every path it matched)"
-    else
-      sr_entry="$sr_entry (governed nothing: matched no counted path)"
-    fi
+    sr_entry="$sr_entry (governed nothing: decided no counted path)"
   elif [ "${CLASS_YIELDED[$sr_ni]:-0}" = "1" ]; then
     sr_entry="$sr_entry (yielded on frozen paths)"
   fi

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -38,7 +38,10 @@
 # SIZE_RATCHET_CLASSES (a repo's own overrides) then
 # SIZE_RATCHET_DEFAULT_CLASSES (the list this package ships), else
 # SIZE_RATCHET_THRESHOLD. Class patterns are the excludes file's globs and
-# run through the same matcher.
+# run through the same matcher. One inversion: on a frozen path the shipped
+# list also classifies, a repo entry decides only if it restates that list's
+# own pattern, so a directory-scoped class cannot silently retitle the tests
+# and documents under it.
 #
 # A class threshold carries its UNIT: `pattern=400` is 400 lines,
 # `pattern=24k` is 24*1024 bytes. Lines are newline counts (`wc -l`), bytes
@@ -129,8 +132,10 @@ kendex.settings.toml [env] > default):
   SIZE_RATCHET_THRESHOLD   line threshold for a path in no class (default 400)
   SIZE_RATCHET_CLASSES     this repo's OVERRIDES: `pattern=threshold`
                            entries separated by `;`, excludes-file glob
-                           semantics, matched BEFORE the shipped list
-                           (default none)
+                           semantics, matched BEFORE the shipped list —
+                           except on a frozen path the shipped list also
+                           classifies, where only an entry restating that
+                           list's own pattern decides   (default none)
   SIZE_RATCHET_DEFAULT_CLASSES
                            the class list this package ships, same syntax;
                            set it empty to drop the shipped list alone —
@@ -355,7 +360,9 @@ parse_classes() { # SETTING-NAME VALUE — appends entries; sets PARSED_NOTE
 }
 
 # A repo's own entries are matched FIRST, so it overrides a class without
-# restating the list; the shipped list decides everything it leaves alone.
+# restating the list; the shipped list decides everything it leaves alone. On
+# a frozen path the shipped list also classifies, that order inverts —
+# path_threshold says why.
 CLASSES="$(sr_setting SIZE_RATCHET_CLASSES "")" || exit 2
 parse_classes SIZE_RATCHET_CLASSES "$CLASSES"
 # The verdict line reports the mapping the run actually used, rebuilt from
@@ -370,6 +377,24 @@ DEFAULT_CLASSES="$(sr_setting SIZE_RATCHET_DEFAULT_CLASSES "$SHIPPED_CLASSES")" 
 parse_classes SIZE_RATCHET_DEFAULT_CLASSES "$DEFAULT_CLASSES"
 SHIPPED_CLASS_COUNT=$((CLASS_COUNT - REPO_CLASS_COUNT))
 [ "$SHIPPED_CLASS_COUNT" -eq 0 ] || CLASSES_NOTE="$CLASSES_NOTE, $SHIPPED_CLASS_COUNT shipped class(es)"
+
+# A repo entry naming a pattern the shipped list already carries RESTATES that
+# class — the one way to say "this class, our number", and the only repo entry
+# path_threshold lets decide a frozen path.
+CLASS_RESTATED=()
+sr_ri=0
+while [ "$sr_ri" -lt "$REPO_CLASS_COUNT" ]; do
+  CLASS_RESTATED+=(0)
+  sr_si="$REPO_CLASS_COUNT"
+  while [ "$sr_si" -lt "$CLASS_COUNT" ]; do
+    if [ "${CLASS_PATTERNS[$sr_ri]}" = "${CLASS_PATTERNS[$sr_si]}" ]; then
+      CLASS_RESTATED[$sr_ri]=1
+      break
+    fi
+    sr_si=$((sr_si + 1))
+  done
+  sr_ri=$((sr_ri + 1))
+done
 
 # --- frozen classes: globs whose rows may never rise -------------------------
 # Same glob language as the classes and the exclusion list, no thresholds.
@@ -624,12 +649,33 @@ is_excluded() { # PATH — 0 when some exclusion glob matches the full path
 # Single resolver: collection stamps every counted row with PT and PU, and
 # report() re-runs it to name the threshold that judged the path — including
 # for a baseline row whose file left the tracked set.
+#
+# A repo entry is matched first, EXCEPT on a frozen path: `*` crosses `/`, so
+# a repo class scoped to a directory (`ui/*.ts=250`) also takes every test and
+# document under it, and a frozen path has no answer to a tightened threshold
+# — its row never rises, so the run demands a remedy the freeze forbids. Such
+# an entry is skipped and the shipped class that names the path decides. A
+# repo meaning to move a frozen class restates that class's own pattern, and
+# that entry still wins; where nothing else matched, the skipped entry stands,
+# because the base threshold is a number nobody wrote for that path.
 path_threshold() { # PATH
-  local i=0
+  local i=0 frozen="" shadowed=""
   # Indexed iteration bounded by CLASS_COUNT: a whole-array expansion on an
   # empty array is an unbound variable under Bash 3.2 with set -u.
   while [ "$i" -lt "$CLASS_COUNT" ]; do
     if glob_match "$1" "${CLASS_PATTERNS[$i]}"; then
+      if [ "$i" -lt "$REPO_CLASS_COUNT" ] && [ "${CLASS_RESTATED[$i]:-0}" != "1" ]; then
+        # The freeze list is a second glob sweep, so it is asked once per path
+        # and only for a repo entry that actually matched.
+        if [ -z "$frozen" ]; then
+          if is_frozen "$1"; then frozen="y"; else frozen="n"; fi
+        fi
+        if [ "$frozen" = "y" ]; then
+          [ -n "$shadowed" ] || shadowed="$i"
+          i=$((i + 1))
+          continue
+        fi
+      fi
       PT="${CLASS_THRESHOLDS[$i]}"
       PU="${CLASS_UNITS[$i]}"
       PC="${CLASS_PATTERNS[$i]}"
@@ -637,6 +683,12 @@ path_threshold() { # PATH
     fi
     i=$((i + 1))
   done
+  if [ -n "$shadowed" ]; then
+    PT="${CLASS_THRESHOLDS[$shadowed]}"
+    PU="${CLASS_UNITS[$shadowed]}"
+    PC="${CLASS_PATTERNS[$shadowed]}"
+    return 0
+  fi
   # SIZE_RATCHET_THRESHOLD is a line count: code is what falls through to it,
   # and lines are what every linter caps code by.
   PT="$THRESHOLD"

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -38,10 +38,9 @@
 # SIZE_RATCHET_CLASSES (a repo's own overrides) then
 # SIZE_RATCHET_DEFAULT_CLASSES (the list this package ships), else
 # SIZE_RATCHET_THRESHOLD. Class patterns are the excludes file's globs and
-# run through the same matcher. One inversion: on a frozen path that the
-# shipped list also classifies, a repo entry decides only if it restates that
-# list's own pattern, so a directory-scoped class cannot silently retitle the
-# shipped classes covering paths it never named.
+# run through the same matcher. Frozen paths carry the one inversion to that
+# order: README.md "Path classes" states the rule, path_threshold implements
+# it, and neither is paraphrased anywhere else.
 #
 # A class threshold carries its UNIT: `pattern=400` is 400 lines,
 # `pattern=24k` is 24*1024 bytes. Lines are newline counts (`wc -l`), bytes
@@ -132,21 +131,19 @@ kendex.settings.toml [env] > default):
   SIZE_RATCHET_THRESHOLD   line threshold for a path in no class (default 400)
   SIZE_RATCHET_CLASSES     this repo's OVERRIDES: `pattern=threshold`
                            entries separated by `;`, excludes-file glob
-                           semantics, matched BEFORE the shipped list —
-                           except on a frozen path that the shipped list also
-                           classifies, where only an entry restating that
-                           list's own pattern decides   (default none)
+                           semantics, matched BEFORE the shipped list, with
+                           one inversion on frozen paths (README.md, "Path
+                           classes")   (default none)
   SIZE_RATCHET_DEFAULT_CLASSES
                            the class list this package ships, same syntax;
                            set it empty to drop the shipped list alone —
                            SIZE_RATCHET_CLASSES still matches first, so
                            single-threshold behavior needs both empty
   SIZE_RATCHET_FROZEN_CLASSES
-                           `;`-separated globs with two duties: their rows
-                           may never rise, whatever RATCHET_RAISE says, and
-                           their paths keep the shipped class that names
-                           them rather than a repo entry's
-                           (default: markdown and tests)
+                           `;`-separated globs whose rows may never rise,
+                           whatever RATCHET_RAISE says; they also decide
+                           where the class inversion applies (README.md,
+                           "Path classes")   (default: markdown and tests)
   SIZE_RATCHET_BASELINE    baseline path            (default tools/size-ratchet-baseline.tsv)
   SIZE_RATCHET_EXCLUDES    exclusion-list path      (default tools/size-ratchet-excludes)
 Flags override both for the path settings.
@@ -363,9 +360,8 @@ parse_classes() { # SETTING-NAME VALUE — appends entries
 }
 
 # A repo's own entries are matched FIRST, so it overrides a class without
-# restating the list; the shipped list decides everything it leaves alone. On
-# a frozen path that the shipped list also classifies, that order inverts —
-# path_threshold says why.
+# restating the list; the shipped list decides everything it leaves alone.
+# Frozen paths invert that order — path_threshold is the rule.
 CLASSES="$(sr_setting SIZE_RATCHET_CLASSES "")" || exit 2
 parse_classes SIZE_RATCHET_CLASSES "$CLASSES"
 REPO_CLASS_COUNT="$CLASS_COUNT"
@@ -653,24 +649,22 @@ is_excluded() { # PATH — 0 when some exclusion glob matches the full path
 # report() re-runs it to name the threshold that judged the path — including
 # for a baseline row whose file left the tracked set.
 #
-# A repo entry is matched first, EXCEPT on a frozen path that the shipped list
-# also classifies. `*` crosses `/`, so a repo class scoped to a directory
-# (`ui/*.ts=250`) also matches paths the repo never named — every test file
-# under it, and under a broader pattern every document too — and silently
-# retitles the shipped class that named them, the counting UNIT included: a
-# `docs/*=250` meant for code judges a byte class in lines. The rule runs in
-# both directions, a looser repo entry as much as a tighter one, because what
-# it protects is the shipped class naming the path, not any one number. Such
-# an entry is skipped and the shipped class decides. A repo meaning to move a
-# frozen class restates that class's own pattern, and that entry still wins;
-# where nothing else matched, the skipped entry stands, because the base
-# threshold is a number nobody wrote for that path.
+# A repo entry is matched first, EXCEPT on a frozen path. `*` crosses `/`, so
+# a repo class scoped to a directory (`ui/*.ts=250`) also matches paths the
+# repo never named, and silently retitles the shipped class that named them,
+# the counting UNIT included: a `docs/*=250` meant for code judges a byte
+# class in lines. That is what the skip below prevents, and it prevents it in
+# both directions, because what it protects is the shipped class naming the
+# path rather than any one number. The rule and its two exits are stated once,
+# in README.md "Path classes"; each exit is a branch below.
 path_threshold() { # PATH
   local i=0 frozen="" shadowed="" skipped="" hit="" s
   # Indexed iteration bounded by CLASS_COUNT: a whole-array expansion on an
   # empty array is an unbound variable under Bash 3.2 with set -u.
   while [ "$i" -lt "$CLASS_COUNT" ]; do
     if glob_match "$1" "${CLASS_PATTERNS[$i]}"; then
+      # Exit one: an entry restating a shipped pattern is the repo naming the
+      # class it means to move, so it is no shadow and is never skipped.
       if [ "$i" -lt "$REPO_CLASS_COUNT" ] && [ "${CLASS_RESTATED[$i]:-0}" != "1" ]; then
         # The freeze list is a second glob sweep, so it is asked once per path
         # and only for a repo entry that actually matched.
@@ -689,8 +683,9 @@ path_threshold() { # PATH
     fi
     i=$((i + 1))
   done
-  # Where the shipped list names no class for the frozen path, the first entry
-  # the skip passed over stands after all.
+  # Exit two: where the shipped list names no class for the frozen path, the
+  # first entry the skip passed over stands after all — the base threshold is
+  # a number nobody wrote for that path.
   [ -n "$hit" ] || hit="$shadowed"
   # An entry the skip passed over LOST this path, unless that fallback just
   # handed the same path back to it. The verdict line reports both.
@@ -1002,10 +997,10 @@ LC_ALL=C sort -- "$TMP/counts.classed" >"$TMP/counts.tsv" || collection_error "c
 # The verdict line reports the mapping the run actually USED, which is why it
 # is built here and not at parse time: the pass above put every tracked path
 # through the resolver, so each repo entry now knows whether it decided a path
-# or yielded one to a frozen class. An entry that yielded and decided nothing
-# governs nothing, and a run that printed it as the mapping in force would
-# advertise a threshold no file was ever judged against — a clean run saying
-# something false. The raw setting's spacing and empty entries stay out: they
+# or yielded one to a frozen class. An entry that decided none governs
+# nothing, and a run that printed it as the mapping in force would advertise a
+# threshold no file was ever judged against — a clean run saying something
+# false. The raw setting's spacing and empty entries stay out: they
 # read as behavior the matcher never sees. The shipped list is a count, not a
 # transcript — it is the same everywhere, and the per-file diagnostics already
 # name the class that decided each path.
@@ -1013,12 +1008,18 @@ CLASSES_NOTE=""
 sr_ni=0
 while [ "$sr_ni" -lt "$REPO_CLASS_COUNT" ]; do
   sr_entry="${CLASS_PATTERNS[$sr_ni]}=${CLASS_RAW[$sr_ni]}"
-  if [ "${CLASS_YIELDED[$sr_ni]:-0}" = "1" ]; then
-    if [ "${CLASS_DECIDED[$sr_ni]:-0}" = "1" ]; then
-      sr_entry="$sr_entry (yielded on frozen paths)"
-    else
+  # DECIDED is the predicate, so the bare rendering is unreachable for an
+  # entry that governed nothing however it got there — yielded away, or a
+  # typo'd or stale pattern that matched no counted path at all. YIELDED only
+  # supplies the reason.
+  if [ "${CLASS_DECIDED[$sr_ni]:-0}" != "1" ]; then
+    if [ "${CLASS_YIELDED[$sr_ni]:-0}" = "1" ]; then
       sr_entry="$sr_entry (governed nothing: yielded on every path it matched)"
+    else
+      sr_entry="$sr_entry (governed nothing: matched no counted path)"
     fi
+  elif [ "${CLASS_YIELDED[$sr_ni]:-0}" = "1" ]; then
+    sr_entry="$sr_entry (yielded on frozen paths)"
   fi
   CLASSES_NOTE="${CLASSES_NOTE:+$CLASSES_NOTE;}$sr_entry"
   sr_ni=$((sr_ni + 1))
@@ -1068,8 +1069,24 @@ evaluate() { # BASELINE-TSV — violations on stdout, one per line, tab-separate
   ' "$1" "$TMP/counts.tsv"
 }
 
+# Does HEAD's baseline carry a row for this path? One predicate decides every
+# size remedy, so no verdict label can be paired with the wrong one: a path
+# HEAD does not carry has no row to raise, so the declaration admits a first
+# one in every class, frozen included; a path HEAD carries is a RAISE, which a
+# frozen class refuses whatever the declaration says. Reading the label instead
+# misdirects in both directions — a genuine bootstrap told no declaration helps,
+# and a deleted row told to bootstrap a row HEAD still carries.
+head_carries_row() { # PATH
+  [ -n "$HEAD_BASELINE" ] || return 1
+  local p n
+  while IFS="$TAB" read -r p n || [ -n "$p" ]; do
+    if [ "$p" = "$1" ]; then return 0; fi
+  done <"$HEAD_BASELINE"
+  return 1
+}
+
 report() { # VIOLATIONS-FILE — human diagnostics on stdout
-  local kind path n b raw why rem boot unit
+  local kind path n b raw why remedy unit
   while IFS="$TAB" read -r kind path n raw; do
     path_threshold "$path"; if [ -n "$PC" ]; then why="class $PC"; else why="default"; fi
     unit="$(unit_noun "$PU")s"
@@ -1077,26 +1094,21 @@ report() { # VIOLATIONS-FILE — human diagnostics on stdout
     # the row's `b` suffix comes off — except in the wrong-unit verdict,
     # where the suffix IS the finding.
     b="$(row_value "$raw")"
-    # `rem` speaks to a row that already exists: GROW and RAISED, where a
-    # frozen class refuses the raise. NEW and ADDED have no such row — the
-    # file carries none at all — so both get `boot`, the bootstrap the
-    # declaration admits in every class, frozen included. Handing either one
-    # `rem` would tell its author no declaration helps at the one moment one
-    # would have carried the run.
-    if is_frozen "$path"; then
-      rem="split at a concept seam (a frozen class never raises an existing row)"
+    if ! head_carries_row "$path"; then
+      remedy="split at a concept seam, or declare the row with RATCHET_RAISE=1 — a first row for a path HEAD's baseline does not carry is a bootstrap, admitted in every class"
+    elif is_frozen "$path"; then
+      remedy="split at a concept seam (a frozen class never raises an existing row)"
     else
-      rem="split at a concept seam (RATCHET_RAISE=1 raises the row only when the added lines are the fix with no seam, or fragments of one concept are merged back into one file)"
+      remedy="split at a concept seam (RATCHET_RAISE=1 raises the row only when the added lines are the fix with no seam, or fragments of one concept are merged back into one file)"
     fi
-    boot="split at a concept seam, or declare the row with RATCHET_RAISE=1 — a first row for a path HEAD's baseline does not carry is a bootstrap, admitted in every class"
     case "$kind" in
       NEW)
         echo "size-ratchet FAIL new offender: $path — $n $unit > threshold $PT ($why), no baseline row"
-        echo "  remedy: $boot"
+        echo "  remedy: $remedy"
         ;;
       GROW)
         echo "size-ratchet FAIL baselined file grew: $path — $n $unit > baseline $b (threshold $PT, $why)"
-        echo "  remedy: $rem"
+        echo "  remedy: $remedy"
         ;;
       LOOSE)
         echo "size-ratchet FAIL baseline looser than reality: $path — baseline $b > actual $n $unit, still over threshold $PT ($why); the ratchet only moves down"
@@ -1116,15 +1128,15 @@ report() { # VIOLATIONS-FILE — human diagnostics on stdout
         ;;
       ADDED)
         echo "size-ratchet FAIL baseline row added: $path — a first row, at $n $unit (threshold $PT, $why); HEAD's baseline carries no row for it"
-        echo "  remedy: $boot"
+        echo "  remedy: $remedy"
         ;;
       RAISED)
         echo "size-ratchet FAIL baseline row raised: $path — row $b -> $n $unit, threshold $PT ($why)"
-        echo "  remedy: $rem"
+        echo "  remedy: $remedy"
         ;;
       FROZEN)
         echo "size-ratchet FAIL frozen baseline row raised: $path — row $b -> $n $unit, threshold $PT ($why); a frozen class refuses a raise whatever RATCHET_RAISE says"
-        echo "  remedy: split at a concept seam (a frozen class never raises an existing row)"
+        echo "  remedy: $remedy"
         ;;
       MOVED)
         echo "size-ratchet FAIL baseline moved and rewritten: $path -> $BASELINE_FILE — HEAD's rows left $path, and the rows arriving at $BASELINE_FILE are not them; across a move nothing compares them, so a raise would land unjudged"

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -1006,9 +1006,10 @@ while [ "$sr_ni" -lt "$REPO_CLASS_COUNT" ]; do
   sr_entry="${CLASS_PATTERNS[$sr_ni]}=${CLASS_RAW[$sr_ni]}"
   # DECIDED is the predicate, so the bare rendering is unreachable for an
   # entry that governed nothing. WHY it governed nothing is not said: a
-  # pattern matching nothing, a pattern an earlier entry already claimed, and
-  # one passed over on frozen paths all arrive here, and the engine holds no
-  # state that tells them apart. The line says the part it can stand behind.
+  # pattern matching nothing and a pattern an earlier entry already claimed
+  # arrive here alike and no state tells those two apart. An entry the frozen
+  # skip passed over does carry its own state, and reads the same here anyway,
+  # because one reason is enough once the entry governed nothing at all.
   if [ "${CLASS_DECIDED[$sr_ni]:-0}" != "1" ]; then
     sr_entry="$sr_entry (governed nothing: decided no counted path)"
   elif [ "${CLASS_YIELDED[$sr_ni]:-0}" = "1" ]; then

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -38,10 +38,10 @@
 # SIZE_RATCHET_CLASSES (a repo's own overrides) then
 # SIZE_RATCHET_DEFAULT_CLASSES (the list this package ships), else
 # SIZE_RATCHET_THRESHOLD. Class patterns are the excludes file's globs and
-# run through the same matcher. One inversion: on a frozen path the shipped
-# list also classifies, a repo entry decides only if it restates that list's
-# own pattern, so a directory-scoped class cannot silently retitle the tests
-# and documents under it.
+# run through the same matcher. One inversion: on a frozen path that the
+# shipped list also classifies, a repo entry decides only if it restates that
+# list's own pattern, so a directory-scoped class cannot silently retitle the
+# shipped classes covering paths it never named.
 #
 # A class threshold carries its UNIT: `pattern=400` is 400 lines,
 # `pattern=24k` is 24*1024 bytes. Lines are newline counts (`wc -l`), bytes
@@ -133,7 +133,7 @@ kendex.settings.toml [env] > default):
   SIZE_RATCHET_CLASSES     this repo's OVERRIDES: `pattern=threshold`
                            entries separated by `;`, excludes-file glob
                            semantics, matched BEFORE the shipped list —
-                           except on a frozen path the shipped list also
+                           except on a frozen path that the shipped list also
                            classifies, where only an entry restating that
                            list's own pattern decides   (default none)
   SIZE_RATCHET_DEFAULT_CLASSES
@@ -142,9 +142,11 @@ kendex.settings.toml [env] > default):
                            SIZE_RATCHET_CLASSES still matches first, so
                            single-threshold behavior needs both empty
   SIZE_RATCHET_FROZEN_CLASSES
-                           `;`-separated globs whose rows may never rise,
-                           whatever RATCHET_RAISE says (default: markdown
-                           and tests)
+                           `;`-separated globs with two duties: their rows
+                           may never rise, whatever RATCHET_RAISE says, and
+                           their paths keep the shipped class that names
+                           them rather than a repo entry's
+                           (default: markdown and tests)
   SIZE_RATCHET_BASELINE    baseline path            (default tools/size-ratchet-baseline.tsv)
   SIZE_RATCHET_EXCLUDES    exclusion-list path      (default tools/size-ratchet-excludes)
 Flags override both for the path settings.
@@ -305,11 +307,12 @@ esac
 CLASS_PATTERNS=()
 CLASS_THRESHOLDS=()
 CLASS_UNITS=()
+# The threshold as written (`250`, `24k`), kept so the verdict line can name
+# an entry exactly as its author typed it.
+CLASS_RAW=()
 CLASS_COUNT=0
-PARSED_NOTE=""
-parse_classes() { # SETTING-NAME VALUE — appends entries; sets PARSED_NOTE
+parse_classes() { # SETTING-NAME VALUE — appends entries
   local name="$1" rest="$2" pair cpat cthr craw cunit
-  PARSED_NOTE=""
   while [ -n "$rest" ]; do
     case "$rest" in
       *";"*)
@@ -354,29 +357,21 @@ parse_classes() { # SETTING-NAME VALUE — appends entries; sets PARSED_NOTE
     CLASS_PATTERNS+=("$cpat")
     CLASS_THRESHOLDS+=("$cthr")
     CLASS_UNITS+=("$cunit")
-    PARSED_NOTE="${PARSED_NOTE:+$PARSED_NOTE;}$cpat=$craw"
+    CLASS_RAW+=("$craw")
     CLASS_COUNT=$((CLASS_COUNT + 1))
   done
 }
 
 # A repo's own entries are matched FIRST, so it overrides a class without
 # restating the list; the shipped list decides everything it leaves alone. On
-# a frozen path the shipped list also classifies, that order inverts —
+# a frozen path that the shipped list also classifies, that order inverts —
 # path_threshold says why.
 CLASSES="$(sr_setting SIZE_RATCHET_CLASSES "")" || exit 2
 parse_classes SIZE_RATCHET_CLASSES "$CLASSES"
-# The verdict line reports the mapping the run actually used, rebuilt from
-# the parsed entries — the raw setting's spacing and empty entries would read
-# as behavior the matcher never sees. The shipped list is a count, not a
-# transcript: it is the same everywhere and the per-file diagnostics already
-# name the class that decided each path.
-CLASSES_NOTE="$PARSED_NOTE"
-[ -z "$CLASSES_NOTE" ] || CLASSES_NOTE=", classes $CLASSES_NOTE"
 REPO_CLASS_COUNT="$CLASS_COUNT"
 DEFAULT_CLASSES="$(sr_setting SIZE_RATCHET_DEFAULT_CLASSES "$SHIPPED_CLASSES")" || exit 2
 parse_classes SIZE_RATCHET_DEFAULT_CLASSES "$DEFAULT_CLASSES"
 SHIPPED_CLASS_COUNT=$((CLASS_COUNT - REPO_CLASS_COUNT))
-[ "$SHIPPED_CLASS_COUNT" -eq 0 ] || CLASSES_NOTE="$CLASSES_NOTE, $SHIPPED_CLASS_COUNT shipped class(es)"
 
 # A repo entry naming a pattern the shipped list already carries RESTATES that
 # class — the one way to say "this class, our number", and the only repo entry
@@ -395,6 +390,14 @@ while [ "$sr_ri" -lt "$REPO_CLASS_COUNT" ]; do
   done
   sr_ri=$((sr_ri + 1))
 done
+
+# What each repo entry actually did over the tracked set, stamped by
+# path_threshold and read back by the verdict line: DECIDED on at least one
+# path, YIELDED to a frozen class on at least one. An entry that yielded and
+# decided nothing governs nothing, and the run says so rather than printing it
+# as the mapping in force.
+CLASS_DECIDED=()
+CLASS_YIELDED=()
 
 # --- frozen classes: globs whose rows may never rise -------------------------
 # Same glob language as the classes and the exclusion list, no thresholds.
@@ -650,16 +653,20 @@ is_excluded() { # PATH — 0 when some exclusion glob matches the full path
 # report() re-runs it to name the threshold that judged the path — including
 # for a baseline row whose file left the tracked set.
 #
-# A repo entry is matched first, EXCEPT on a frozen path: `*` crosses `/`, so
-# a repo class scoped to a directory (`ui/*.ts=250`) also takes every test and
-# document under it, and a frozen path has no answer to a tightened threshold
-# — its row never rises, so the run demands a remedy the freeze forbids. Such
-# an entry is skipped and the shipped class that names the path decides. A
-# repo meaning to move a frozen class restates that class's own pattern, and
-# that entry still wins; where nothing else matched, the skipped entry stands,
-# because the base threshold is a number nobody wrote for that path.
+# A repo entry is matched first, EXCEPT on a frozen path that the shipped list
+# also classifies. `*` crosses `/`, so a repo class scoped to a directory
+# (`ui/*.ts=250`) also matches paths the repo never named — every test file
+# under it, and under a broader pattern every document too — and silently
+# retitles the shipped class that named them, the counting UNIT included: a
+# `docs/*=250` meant for code judges a byte class in lines. The rule runs in
+# both directions, a looser repo entry as much as a tighter one, because what
+# it protects is the shipped class naming the path, not any one number. Such
+# an entry is skipped and the shipped class decides. A repo meaning to move a
+# frozen class restates that class's own pattern, and that entry still wins;
+# where nothing else matched, the skipped entry stands, because the base
+# threshold is a number nobody wrote for that path.
 path_threshold() { # PATH
-  local i=0 frozen="" shadowed=""
+  local i=0 frozen="" shadowed="" skipped="" hit="" s
   # Indexed iteration bounded by CLASS_COUNT: a whole-array expansion on an
   # empty array is an unbound variable under Bash 3.2 with set -u.
   while [ "$i" -lt "$CLASS_COUNT" ]; do
@@ -672,28 +679,36 @@ path_threshold() { # PATH
         fi
         if [ "$frozen" = "y" ]; then
           [ -n "$shadowed" ] || shadowed="$i"
+          skipped="$skipped $i"
           i=$((i + 1))
           continue
         fi
       fi
-      PT="${CLASS_THRESHOLDS[$i]}"
-      PU="${CLASS_UNITS[$i]}"
-      PC="${CLASS_PATTERNS[$i]}"
-      return 0
+      hit="$i"
+      break
     fi
     i=$((i + 1))
   done
-  if [ -n "$shadowed" ]; then
-    PT="${CLASS_THRESHOLDS[$shadowed]}"
-    PU="${CLASS_UNITS[$shadowed]}"
-    PC="${CLASS_PATTERNS[$shadowed]}"
+  # Where the shipped list names no class for the frozen path, the first entry
+  # the skip passed over stands after all.
+  [ -n "$hit" ] || hit="$shadowed"
+  # An entry the skip passed over LOST this path, unless that fallback just
+  # handed the same path back to it. The verdict line reports both.
+  for s in $skipped; do
+    if [ "$s" = "$hit" ]; then CLASS_DECIDED[$s]=1; else CLASS_YIELDED[$s]=1; fi
+  done
+  if [ -z "$hit" ]; then
+    # SIZE_RATCHET_THRESHOLD is a line count: code is what falls through to
+    # it, and lines are what every linter caps code by.
+    PT="$THRESHOLD"
+    PU="l"
+    PC=""
     return 0
   fi
-  # SIZE_RATCHET_THRESHOLD is a line count: code is what falls through to it,
-  # and lines are what every linter caps code by.
-  PT="$THRESHOLD"
-  PU="l"
-  PC=""
+  if [ "$hit" -lt "$REPO_CLASS_COUNT" ]; then CLASS_DECIDED[$hit]=1; fi
+  PT="${CLASS_THRESHOLDS[$hit]}"
+  PU="${CLASS_UNITS[$hit]}"
+  PC="${CLASS_PATTERNS[$hit]}"
 }
 
 is_frozen() { # PATH — 0 when a frozen-class glob matches the full path
@@ -984,6 +999,33 @@ classed="$(count_nonempty_lines "$TMP/counts.classed")"
 [ "$classed" -eq "$counted" ] || collection_error "classified $classed of the $counted measured row(s) — refusing to report a verdict over a subset"
 LC_ALL=C sort -- "$TMP/counts.classed" >"$TMP/counts.tsv" || collection_error "could not sort the collected counts — the measurement is incomplete, refusing to report a verdict"
 
+# The verdict line reports the mapping the run actually USED, which is why it
+# is built here and not at parse time: the pass above put every tracked path
+# through the resolver, so each repo entry now knows whether it decided a path
+# or yielded one to a frozen class. An entry that yielded and decided nothing
+# governs nothing, and a run that printed it as the mapping in force would
+# advertise a threshold no file was ever judged against — a clean run saying
+# something false. The raw setting's spacing and empty entries stay out: they
+# read as behavior the matcher never sees. The shipped list is a count, not a
+# transcript — it is the same everywhere, and the per-file diagnostics already
+# name the class that decided each path.
+CLASSES_NOTE=""
+sr_ni=0
+while [ "$sr_ni" -lt "$REPO_CLASS_COUNT" ]; do
+  sr_entry="${CLASS_PATTERNS[$sr_ni]}=${CLASS_RAW[$sr_ni]}"
+  if [ "${CLASS_YIELDED[$sr_ni]:-0}" = "1" ]; then
+    if [ "${CLASS_DECIDED[$sr_ni]:-0}" = "1" ]; then
+      sr_entry="$sr_entry (yielded on frozen paths)"
+    else
+      sr_entry="$sr_entry (governed nothing: yielded on every path it matched)"
+    fi
+  fi
+  CLASSES_NOTE="${CLASSES_NOTE:+$CLASSES_NOTE;}$sr_entry"
+  sr_ni=$((sr_ni + 1))
+done
+[ -z "$CLASSES_NOTE" ] || CLASSES_NOTE=", classes $CLASSES_NOTE"
+[ "$SHIPPED_CLASS_COUNT" -eq 0 ] || CLASSES_NOTE="$CLASSES_NOTE, $SHIPPED_CLASS_COUNT shipped class(es)"
+
 # --- evaluate a baseline against the counts ----------------------------------
 # Counts rows are `path<TAB>size<TAB>threshold<TAB>unit` — the class resolver
 # already ran at collection, so every judgment here reads the path's own
@@ -1035,11 +1077,12 @@ report() { # VIOLATIONS-FILE — human diagnostics on stdout
     # the row's `b` suffix comes off — except in the wrong-unit verdict,
     # where the suffix IS the finding.
     b="$(row_value "$raw")"
-    # A frozen class refuses a RAISE of an existing row, which is what `rem`
-    # speaks to. A row HEAD's baseline carries none for is a BOOTSTRAP, which
-    # the declaration admits in every class, so the ADDED verdict gets `boot`
-    # instead: telling its author no declaration helps names the wrong cause
-    # at the one moment one would have carried the run.
+    # `rem` speaks to a row that already exists: GROW and RAISED, where a
+    # frozen class refuses the raise. NEW and ADDED have no such row — the
+    # file carries none at all — so both get `boot`, the bootstrap the
+    # declaration admits in every class, frozen included. Handing either one
+    # `rem` would tell its author no declaration helps at the one moment one
+    # would have carried the run.
     if is_frozen "$path"; then
       rem="split at a concept seam (a frozen class never raises an existing row)"
     else
@@ -1049,7 +1092,7 @@ report() { # VIOLATIONS-FILE — human diagnostics on stdout
     case "$kind" in
       NEW)
         echo "size-ratchet FAIL new offender: $path — $n $unit > threshold $PT ($why), no baseline row"
-        echo "  remedy: $rem"
+        echo "  remedy: $boot"
         ;;
       GROW)
         echo "size-ratchet FAIL baselined file grew: $path — $n $unit > baseline $b (threshold $PT, $why)"

--- a/skills/size-ratchet/tests/path-classes.test.sh
+++ b/skills/size-ratchet/tests/path-classes.test.sh
@@ -55,6 +55,17 @@ run_raw() { # [VAR=val ...] [-- script-args...] — run $SR in $R; sets OUT, RC
   OUT="$(cd "$R" && env ${envs[@]+"${envs[@]}"} "$SR" ${args[@]+"${args[@]}"} 2>&1)" || RC=$?
 }
 
+echo "=== the README heading every other surface points at still exists ==="
+# The rule is stated once, in README.md "Path classes". The script header, two
+# --help entries, two block comments, DEVELOPMENT.md and two settings-table
+# links all name that heading, the last two through its #path-classes anchor.
+# Retitle it and all of them rot silently, onto paraphrases that were deleted.
+if grep -qx '## Path classes' "$SKILL_DIR/README.md"; then
+  ok "README.md carries the '## Path classes' heading the pointers name"
+else
+  bad "the canonical heading exists at its stated level" "no '## Path classes' line in $SKILL_DIR/README.md"
+fi
+
 echo "=== a class threshold governs the paths it matches; the base governs the rest ==="
 new_repo classes
 mkfile src/big.txt 500

--- a/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -93,9 +93,12 @@ git -C "$R" commit -q -m row
 mkfile x.test.txt 15
 git -C "$R" add -A
 run_frozen
+# Both halves: the string it IS given, and the absence of either wording that
+# carries RATCHET_RAISE. Without the positive half an empty remedy passes.
 if [ "$RC" -eq 1 ] && case "$OUT" in *"baselined file grew: x.test.txt"*) true ;; *) false ;; esac \
+  && case "$OUT" in *"remedy: split at a concept seam (a frozen class never raises an existing row)"*) true ;; *) false ;; esac \
   && case "$OUT" in *RATCHET_RAISE*) false ;; *) true ;; esac; then
-  ok "control: a frozen path whose row exists is never offered a raise"
+  ok "control: a frozen baselined file that grew is told to split, and offered no raise"
 else
   bad "control: a frozen row refuses the raise" "rc=$RC out=$OUT"
 fi

--- a/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -88,6 +88,8 @@ case "$OUT" in *"$BOOT"*) ok "and is offered the bootstrap: no row exists yet, s
 # alone. That is the case the freeze speaks to, and the only one.
 mkdir -p "$R/tools"
 printf 'x.test.txt\t11\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+git -C "$R" commit -q -m row
 mkfile x.test.txt 15
 git -C "$R" add -A
 run_frozen
@@ -104,6 +106,9 @@ mkfile big.txt 15
 mkdir -p "$R/tools"
 printf 'big.txt\t15\n' >"$R/tools/size-ratchet-baseline.tsv"
 git -C "$R" add -A
+# HEAD carries the row from here on, so a growth verdict below is a RAISE the
+# remedy speaks to rather than a first row nothing has frozen yet.
+git -C "$R" commit -q -m row
 run_sr
 [ "$RC" -eq 0 ] && ok "baselined offender at exactly its row passes" || bad "baselined offender at exactly its row passes" "rc=$RC out=$OUT"
 

--- a/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -24,6 +24,9 @@ ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
 bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
 
 REMEDY="split at a concept seam (RATCHET_RAISE=1 raises the row only when the added lines are the fix with no seam, or fragments of one concept are merged back into one file)"
+# The remedy for a verdict whose path carries NO row yet. Both such verdicts
+# take it, frozen or not: the declaration admits a first row in every class.
+BOOT="split at a concept seam, or declare the row with RATCHET_RAISE=1 — a first row for a path HEAD's baseline does not carry is a bootstrap, admitted in every class"
 
 new_repo() { # NAME — fresh fixture repo in $R
   R="$TMP/$1"
@@ -70,9 +73,9 @@ run_sr
 [ "$RC" -eq 1 ] && case "$OUT" in *"new offender: big.txt — 11 lines > threshold 10"*) true ;; *) false ;; esac \
   && ok "one line over the threshold fails as a new offender, naming file/count/threshold" \
   || bad "one line over the threshold fails as a new offender" "rc=$RC out=$OUT"
-case "$OUT" in *"$REMEDY"*) ok "new-offender diagnostic carries the remedy verbatim" ;; *) bad "new-offender diagnostic carries the remedy verbatim" "$OUT" ;; esac
+case "$OUT" in *"$BOOT"*) ok "new-offender diagnostic carries the bootstrap remedy verbatim" ;; *) bad "new-offender diagnostic carries the bootstrap remedy verbatim" "$OUT" ;; esac
 
-echo "=== a frozen-class offender gets the split remedy alone ==="
+echo "=== the freeze refuses a raise of an EXISTING row, and a new offender has none ==="
 new_repo testoff
 mkfile x.test.txt 11
 git -C "$R" add -A
@@ -80,10 +83,20 @@ run_frozen
 [ "$RC" -eq 1 ] && case "$OUT" in *"new offender: x.test.txt"*) true ;; *) false ;; esac \
   && ok "a frozen path over the threshold is still a new offender" \
   || bad "a frozen path over the threshold is still a new offender" "rc=$RC out=$OUT"
-case "$OUT" in *RATCHET_RAISE*) bad "a frozen offender is never offered a raise" "$OUT" ;; *) ok "a frozen offender is never offered a raise" ;; esac
-# The control: the same file outside the frozen list is offered the raise.
-run_sr
-case "$OUT" in *RATCHET_RAISE*) ok "control: an unfrozen offender is offered the declaration" ;; *) bad "control: an unfrozen offender is offered the declaration" "$OUT" ;; esac
+case "$OUT" in *"$BOOT"*) ok "and is offered the bootstrap: no row exists yet, so the freeze has none to refuse" ;; *) bad "a frozen new offender is offered the bootstrap" "$OUT" ;; esac
+# The control: once the row EXISTS, the same frozen path is offered the split
+# alone. That is the case the freeze speaks to, and the only one.
+mkdir -p "$R/tools"
+printf 'x.test.txt\t11\n' >"$R/tools/size-ratchet-baseline.tsv"
+mkfile x.test.txt 15
+git -C "$R" add -A
+run_frozen
+if [ "$RC" -eq 1 ] && case "$OUT" in *"baselined file grew: x.test.txt"*) true ;; *) false ;; esac \
+  && case "$OUT" in *RATCHET_RAISE*) false ;; *) true ;; esac; then
+  ok "control: a frozen path whose row exists is never offered a raise"
+else
+  bad "control: a frozen row refuses the raise" "rc=$RC out=$OUT"
+fi
 
 echo "=== a baseline row at the current count freezes the offender ==="
 new_repo frozen

--- a/skills/size-ratchet/tests/shipped-defaults.test.sh
+++ b/skills/size-ratchet/tests/shipped-defaults.test.sh
@@ -284,14 +284,122 @@ if [ "$RC" -eq 1 ] && has "docs/guide.md — 300 lines > threshold 250 (class do
 else
   bad "control: markdown shadow" "rc=$RC out=$OUT"
 fi
+# Restating the shipped class's own pattern is how a repo names the class it
+# means to move, and that entry decides the frozen path.
+run 'SIZE_RATCHET_CLASSES=ui/*.ts=250;*.test.*=100'
+if [ "$RC" -eq 1 ] && has "ui/src/App.test.ts — 500 lines > threshold 100 (class *.test.*)"; then
+  ok "an entry restating a shipped pattern wins on a frozen path"
+else
+  bad "restating a shipped pattern wins" "rc=$RC out=$OUT"
+fi
+
 # A frozen path the shipped list names no class for still takes the repo's
-# entry: the base threshold is a number nobody wrote for it.
-run 'SIZE_RATCHET_CLASSES=ui/*.ts=250' SIZE_RATCHET_DEFAULT_CLASSES=
+# entry: the base threshold is a number nobody wrote for it. The shipped list
+# is non-empty and simply names nothing under ui/, which is the shape a
+# consumer meets; the emptied-list arm below is the degenerate one.
+run 'SIZE_RATCHET_CLASSES=ui/*.ts=250' 'SIZE_RATCHET_DEFAULT_CLASSES=*.rs=100'
 if [ "$RC" -eq 1 ] && has "ui/src/App.test.ts — 500 lines > threshold 250 (class ui/*.ts)"; then
   ok "with no shipped class to hand the frozen path to, the repo entry still decides it"
 else
   bad "skipped entry stands where the shipped list claims nothing" "rc=$RC out=$OUT"
 fi
+run 'SIZE_RATCHET_CLASSES=ui/*.ts=250' SIZE_RATCHET_DEFAULT_CLASSES=
+if [ "$RC" -eq 1 ] && has "ui/src/App.test.ts — 500 lines > threshold 250 (class ui/*.ts)"; then
+  ok "and the same holds with the shipped list dropped entirely"
+else
+  bad "skipped entry stands with an empty shipped list" "rc=$RC out=$OUT"
+fi
+# Two entries reach the frozen path and both are skipped. The FIRST is the one
+# that stands, the way first-match-wins decides every other path.
+run 'SIZE_RATCHET_CLASSES=ui/*.ts=250;ui/*=900' SIZE_RATCHET_DEFAULT_CLASSES=
+if [ "$RC" -eq 1 ] && has "ui/src/App.test.ts — 500 lines > threshold 250 (class ui/*.ts)" \
+  && ! has "class ui/*)"; then
+  ok "the first skipped entry stands, not the last"
+else
+  bad "the fallback keeps first-match-wins" "rc=$RC out=$OUT"
+fi
+
+# The rule protects the shipped class that NAMES the path, not any one number,
+# so it runs in both directions: a looser repo entry is skipped too.
+new_repo shadowloose
+mklines ui/src/Wide.test.ts 900
+git -C "$R" add -A
+run 'SIZE_RATCHET_CLASSES=ui/*=2000'
+if [ "$RC" -eq 1 ] && has "ui/src/Wide.test.ts — 900 lines > threshold 800 (class *.test.*)"; then
+  ok "a LOOSER repo entry is skipped too — the shipped 800 judges the ui test file"
+else
+  bad "the skip is direction-agnostic" "rc=$RC out=$OUT"
+fi
+# The control: the same entry governs the same directory where nothing is
+# frozen, so the fixture really is within its reach at 2000.
+run 'SIZE_RATCHET_CLASSES=ui/*=2000' SIZE_RATCHET_FROZEN_CLASSES=
+[ "$RC" -eq 0 ] && ok "control: unfrozen, that entry does take the 900-line file at 2000" \
+  || bad "control: the looser entry reaches the fixture" "rc=$RC out=$OUT"
+
+echo "=== the verdict line reports what each repo entry actually governed ==="
+# A yielded entry that still governs its own paths is named as such; one that
+# yielded on every path it matched governed nothing, and a run that printed it
+# as the mapping in force would advertise a threshold nothing was judged
+# against — a clean run saying something false.
+new_repo shadownote
+mklines ui/src/App.ts 300
+mklines ui/src/App.test.ts 500
+git -C "$R" add -A
+run 'SIZE_RATCHET_CLASSES=ui/src/*.test.ts=100'
+if [ "$RC" -eq 0 ] && has "classes ui/src/*.test.ts=100 (governed nothing: yielded on every path it matched)"; then
+  ok "an entry every one of whose paths is frozen is reported as governing nothing"
+else
+  bad "a wholly yielded entry says so on the verdict line" "rc=$RC out=$OUT"
+fi
+run 'SIZE_RATCHET_CLASSES=ui/*.ts=400'
+if [ "$RC" -eq 0 ] && has "classes ui/*.ts=400 (yielded on frozen paths)"; then
+  ok "an entry that governs some paths and yields others is reported as yielding"
+else
+  bad "a partly yielded entry says so on the verdict line" "rc=$RC out=$OUT"
+fi
+# The control: an entry that yields nowhere carries no annotation at all.
+run 'SIZE_RATCHET_CLASSES=ui/*.ts=400' SIZE_RATCHET_FROZEN_CLASSES=
+if [ "$RC" -eq 1 ] && has "classes ui/*.ts=400," && ! has "yielded"; then
+  ok "control: with nothing frozen the same entry is reported plain"
+else
+  bad "control: an unyielded entry carries no annotation" "rc=$RC out=$OUT"
+fi
+
+echo "=== a NEW offender is offered the bootstrap, frozen class included ==="
+# NEW fires when a path is over its threshold with NO baseline row, so there is
+# no row for the freeze to refuse. The freeze speaks to raising an EXISTING
+# row, which is the GROW and RAISED case.
+new_repo bootstrap
+mklines src/a.test.ts 900
+mklines src/big.ts 500
+mkdir -p "$R/tools"
+printf 'src/big.ts	500
+' >"$R/$BASE"
+git -C "$R" add -A
+git -C "$R" commit -q -m seed
+run
+if [ "$RC" -eq 1 ] && has "new offender: src/a.test.ts — 900 lines > threshold 800 (class *.test.*)" \
+  && has "remedy: split at a concept seam, or declare the row with RATCHET_RAISE=1"; then
+  ok "a frozen new offender is offered the bootstrap, not a remedy the freeze forbids"
+else
+  bad "NEW on a frozen path names the bootstrap" "rc=$RC out=$OUT"
+fi
+# The control: writing that row turns the same path into the ADDED verdict,
+# which names the same remedy, and the declaration then carries the run.
+printf 'src/a.test.ts	900
+src/big.ts	500
+' >"$R/$BASE"
+git -C "$R" add -A
+run
+if [ "$RC" -eq 1 ] && has "baseline row added: src/a.test.ts" \
+  && has "remedy: split at a concept seam, or declare the row with RATCHET_RAISE=1"; then
+  ok "control: the ADDED verdict for the same path names the same remedy"
+else
+  bad "control: ADDED names the bootstrap" "rc=$RC out=$OUT"
+fi
+run RATCHET_RAISE=1
+[ "$RC" -eq 0 ] && ok "control: and the declaration carries that first row in a frozen class" \
+  || bad "control: the bootstrap is admitted in a frozen class" "rc=$RC out=$OUT"
 
 echo "=== the package excludes CHANGELOG*.md by default ==="
 new_repo changelog

--- a/skills/size-ratchet/tests/shipped-defaults.test.sh
+++ b/skills/size-ratchet/tests/shipped-defaults.test.sh
@@ -249,9 +249,9 @@ has "skills/x/SKILL.md" && bad "control: SKILL.md passes under the shipped class
   || ok "control: without the override the 10000-byte SKILL.md is under 24k and passes"
 
 echo "=== a repo class scoped to a directory does not shadow a frozen class ==="
-# `*` crosses `/`, so `ui/*.ts` reaches the test files under ui/ too. They are
-# frozen, so a 250-line ceiling on them would demand a split the class the
-# package ships already sized at 800.
+# `*` crosses `/`, so `ui/*.ts` reaches the test files under ui/ too, and an
+# entry written for components would retitle the class the package ships for
+# them. The rule these arms pin: README.md "Path classes".
 new_repo shadow
 mklines ui/src/App.ts 300
 mklines ui/src/App.test.ts 500
@@ -357,18 +357,30 @@ if [ "$RC" -eq 0 ] && has "classes ui/*.ts=400 (yielded on frozen paths)"; then
 else
   bad "a partly yielded entry says so on the verdict line" "rc=$RC out=$OUT"
 fi
-# The control: an entry that yields nowhere carries no annotation at all.
+# An entry that matched nothing at all governs nothing too — a typo'd or stale
+# pattern is the likeliest way to get there, and a run confirming it as the
+# mapping in force is the one that hides it.
+run 'SIZE_RATCHET_CLASSES=uii/*.ts=1'
+if [ "$RC" -eq 0 ] && has "classes uii/*.ts=1 (governed nothing: matched no counted path)"; then
+  ok "an entry no counted path matches is reported as governing nothing"
+else
+  bad "a never-matched entry says so on the verdict line" "rc=$RC out=$OUT"
+fi
+# The control: an entry that yields nowhere and governs its paths carries no
+# annotation at all, so the annotations above are not on every entry.
 run 'SIZE_RATCHET_CLASSES=ui/*.ts=400' SIZE_RATCHET_FROZEN_CLASSES=
-if [ "$RC" -eq 1 ] && has "classes ui/*.ts=400," && ! has "yielded"; then
+if [ "$RC" -eq 1 ] && has "classes ui/*.ts=400," && ! has "governed nothing" && ! has "yielded"; then
   ok "control: with nothing frozen the same entry is reported plain"
 else
   bad "control: an unyielded entry carries no annotation" "rc=$RC out=$OUT"
 fi
 
-echo "=== a NEW offender is offered the bootstrap, frozen class included ==="
-# NEW fires when a path is over its threshold with NO baseline row, so there is
-# no row for the freeze to refuse. The freeze speaks to raising an EXISTING
-# row, which is the GROW and RAISED case.
+echo "=== the remedy follows HEAD's baseline, not the verdict label ==="
+# One predicate decides every size remedy: whether HEAD's baseline carries the
+# path. A path HEAD does not carry has no row to raise, so the declaration
+# admits a first one in every class; a path HEAD carries is a raise, which a
+# frozen class refuses. The NEW label appears on both sides of that line, so
+# reading the label instead misdirects in one direction or the other.
 new_repo bootstrap
 mklines src/a.test.ts 900
 mklines src/big.ts 500
@@ -400,6 +412,39 @@ fi
 run RATCHET_RAISE=1
 [ "$RC" -eq 0 ] && ok "control: and the declaration carries that first row in a frozen class" \
   || bad "control: the bootstrap is admitted in a frozen class" "rc=$RC out=$OUT"
+
+# The other direction, same NEW label: HEAD carries the row, the change deletes
+# it and the file grows. Bootstrapping is impossible here — restoring the row
+# at the new size is the raise a frozen class refuses — so the remedy is the
+# split, and the arm above is its control.
+new_repo remedy-head
+mkbytes docs/guide.md 30000
+mkdir -p "$R/tools"
+printf 'docs/guide.md	30000b
+' >"$R/$BASE"
+git -C "$R" add -A
+git -C "$R" commit -q -m row
+mkbytes docs/guide.md 70000
+: >"$R/$BASE"
+git -C "$R" add -A
+run
+if [ "$RC" -eq 1 ] && has "new offender: docs/guide.md — 70000 bytes > threshold 65536 (class *.md)" \
+  && has "remedy: split at a concept seam (a frozen class never raises an existing row)"; then
+  ok "a NEW verdict for a path HEAD's baseline carries is offered the split, not a bootstrap"
+else
+  bad "the deleted-row NEW verdict names the raise it cannot have" "rc=$RC out=$OUT"
+fi
+# And the route the bootstrap wording would have sent its author down is the
+# one the gate refuses, which is why that wording must not appear here.
+printf 'docs/guide.md	70000b
+' >"$R/$BASE"
+git -C "$R" add -A
+run RATCHET_RAISE=1
+if [ "$RC" -eq 1 ] && has "frozen baseline row raised: docs/guide.md — row 30000 -> 70000 bytes"; then
+  ok "control: restoring that row and declaring it is refused, so the bootstrap remedy would misdirect"
+else
+  bad "control: the declared raise of the restored row is refused" "rc=$RC out=$OUT"
+fi
 
 echo "=== the package excludes CHANGELOG*.md by default ==="
 new_repo changelog

--- a/skills/size-ratchet/tests/shipped-defaults.test.sh
+++ b/skills/size-ratchet/tests/shipped-defaults.test.sh
@@ -248,6 +248,51 @@ run
 has "skills/x/SKILL.md" && bad "control: SKILL.md passes under the shipped class" "$OUT" \
   || ok "control: without the override the 10000-byte SKILL.md is under 24k and passes"
 
+echo "=== a repo class scoped to a directory does not shadow a frozen class ==="
+# `*` crosses `/`, so `ui/*.ts` reaches the test files under ui/ too. They are
+# frozen, so a 250-line ceiling on them would demand a split the class the
+# package ships already sized at 800.
+new_repo shadow
+mklines ui/src/App.ts 300
+mklines ui/src/App.test.ts 500
+mklines docs/guide.md 300
+git -C "$R" add -A
+run 'SIZE_RATCHET_CLASSES=ui/*.ts=250;ui/*.tsx=250'
+if [ "$RC" -eq 1 ] \
+  && has "ui/src/App.ts — 300 lines > threshold 250 (class ui/*.ts)" \
+  && ! has "ui/src/App.test.ts" && ! has "docs/guide.md"; then
+  ok "the repo class judges the component and hands the frozen test and doc back to the shipped list"
+else
+  bad "a directory-scoped repo class spares frozen paths" "rc=$RC out=$OUT"
+fi
+# The control: the freeze is what routes those two paths. Drop it and the same
+# repo class takes them at 250 — which is the defect this section pins.
+run 'SIZE_RATCHET_CLASSES=ui/*.ts=250;ui/*.tsx=250' SIZE_RATCHET_FROZEN_CLASSES=
+if [ "$RC" -eq 1 ] && has "ui/src/App.test.ts — 500 lines > threshold 250 (class ui/*.ts)"; then
+  ok "control: with nothing frozen the same class does take the test file at 250"
+else
+  bad "control: the freeze is what routes the shadowed path" "rc=$RC out=$OUT"
+fi
+# Markdown carries the unit too: the shadow would have judged 300 lines where
+# the shipped class judges bytes.
+run 'SIZE_RATCHET_CLASSES=docs/*=250'
+[ "$RC" -eq 0 ] && ok "a doc under a directory-scoped class keeps its shipped byte ceiling" \
+  || bad "markdown keeps its class under a directory-scoped repo entry" "rc=$RC out=$OUT"
+run 'SIZE_RATCHET_CLASSES=docs/*=250' SIZE_RATCHET_FROZEN_CLASSES=
+if [ "$RC" -eq 1 ] && has "docs/guide.md — 300 lines > threshold 250 (class docs/*)"; then
+  ok "control: unfrozen, that same entry judges the doc in lines at 250"
+else
+  bad "control: markdown shadow" "rc=$RC out=$OUT"
+fi
+# A frozen path the shipped list names no class for still takes the repo's
+# entry: the base threshold is a number nobody wrote for it.
+run 'SIZE_RATCHET_CLASSES=ui/*.ts=250' SIZE_RATCHET_DEFAULT_CLASSES=
+if [ "$RC" -eq 1 ] && has "ui/src/App.test.ts — 500 lines > threshold 250 (class ui/*.ts)"; then
+  ok "with no shipped class to hand the frozen path to, the repo entry still decides it"
+else
+  bad "skipped entry stands where the shipped list claims nothing" "rc=$RC out=$OUT"
+fi
+
 echo "=== the package excludes CHANGELOG*.md by default ==="
 new_repo changelog
 mkbytes CHANGELOG.md 200000

--- a/skills/size-ratchet/tests/shipped-defaults.test.sh
+++ b/skills/size-ratchet/tests/shipped-defaults.test.sh
@@ -337,36 +337,48 @@ run 'SIZE_RATCHET_CLASSES=ui/*=2000' SIZE_RATCHET_FROZEN_CLASSES=
   || bad "control: the looser entry reaches the fixture" "rc=$RC out=$OUT"
 
 echo "=== the verdict line reports what each repo entry actually governed ==="
-# A yielded entry that still governs its own paths is named as such; one that
-# yielded on every path it matched governed nothing, and a run that printed it
+# An entry that decided no counted path governs nothing, and a run printing it
 # as the mapping in force would advertise a threshold nothing was judged
-# against — a clean run saying something false.
+# against. Three shapes arrive at that state and the line names none of them,
+# because the engine holds no state that tells them apart: every arm below
+# asserts the SAME reason.
 new_repo shadownote
 mklines ui/src/App.ts 300
 mklines ui/src/App.test.ts 500
 git -C "$R" add -A
+NOTHING="(governed nothing: decided no counted path)"
+# Shape one: every path it matches is frozen, so it is passed over on all of
+# them.
 run 'SIZE_RATCHET_CLASSES=ui/src/*.test.ts=100'
-if [ "$RC" -eq 0 ] && has "classes ui/src/*.test.ts=100 (governed nothing: yielded on every path it matched)"; then
+if [ "$RC" -eq 0 ] && has "classes ui/src/*.test.ts=100 $NOTHING"; then
   ok "an entry every one of whose paths is frozen is reported as governing nothing"
 else
   bad "a wholly yielded entry says so on the verdict line" "rc=$RC out=$OUT"
 fi
+# Shape two: it matches a counted path, but an EARLIER repo entry already
+# claimed it. Nothing was frozen and nothing yielded.
+run SIZE_RATCHET_DEFAULT_CLASSES= SIZE_RATCHET_FROZEN_CLASSES= 'SIZE_RATCHET_CLASSES=*.ts=400;ui/*.ts=250'
+if [ "$RC" -eq 1 ] && has "classes *.ts=400;ui/*.ts=250 $NOTHING"; then
+  ok "an entry an earlier one shadows is reported the same way, with no cause claimed"
+else
+  bad "an ordering-shadowed entry says the same thing" "rc=$RC out=$OUT"
+fi
+# Shape three: no counted path matches it at all.
+run 'SIZE_RATCHET_CLASSES=uii/*.ts=1'
+if [ "$RC" -eq 0 ] && has "classes uii/*.ts=1 $NOTHING"; then
+  ok "an entry no counted path matches is reported the same way"
+else
+  bad "a never-matched entry says the same thing" "rc=$RC out=$OUT"
+fi
+# An entry that DOES govern its own paths and was passed over on frozen ones
+# is a different statement, and that one the engine can stand behind.
 run 'SIZE_RATCHET_CLASSES=ui/*.ts=400'
-if [ "$RC" -eq 0 ] && has "classes ui/*.ts=400 (yielded on frozen paths)"; then
-  ok "an entry that governs some paths and yields others is reported as yielding"
+if [ "$RC" -eq 0 ] && has "classes ui/*.ts=400 (yielded on frozen paths)" && ! has "governed nothing"; then
+  ok "an entry that governs some paths and is passed over on frozen ones says exactly that"
 else
   bad "a partly yielded entry says so on the verdict line" "rc=$RC out=$OUT"
 fi
-# An entry that matched nothing at all governs nothing too — a typo'd or stale
-# pattern is the likeliest way to get there, and a run confirming it as the
-# mapping in force is the one that hides it.
-run 'SIZE_RATCHET_CLASSES=uii/*.ts=1'
-if [ "$RC" -eq 0 ] && has "classes uii/*.ts=1 (governed nothing: matched no counted path)"; then
-  ok "an entry no counted path matches is reported as governing nothing"
-else
-  bad "a never-matched entry says so on the verdict line" "rc=$RC out=$OUT"
-fi
-# The control: an entry that yields nowhere and governs its paths carries no
+# The control: an entry that governs its paths with nothing frozen carries no
 # annotation at all, so the annotations above are not on every entry.
 run 'SIZE_RATCHET_CLASSES=ui/*.ts=400' SIZE_RATCHET_FROZEN_CLASSES=
 if [ "$RC" -eq 1 ] && has "classes ui/*.ts=400," && ! has "governed nothing" && ! has "yielded"; then

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -127,7 +127,7 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/lib/settings.sh	456
-skills/size-ratchet/scripts/size-ratchet	1766
+skills/size-ratchet/scripts/size-ratchet	1809
 skills/worktree/scripts/worktree	4980
 skills/worktree/scripts/worktree-session-guard	1197
 skills/worktree/tests/worktree_session_guard.sh	1282

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -127,7 +127,7 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/lib/settings.sh	456
-skills/size-ratchet/scripts/size-ratchet	1809
+skills/size-ratchet/scripts/size-ratchet	1821
 skills/worktree/scripts/worktree	4980
 skills/worktree/scripts/worktree-session-guard	1197
 skills/worktree/tests/worktree_session_guard.sh	1282

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -127,7 +127,7 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/lib/settings.sh	456
-skills/size-ratchet/scripts/size-ratchet	1714
+skills/size-ratchet/scripts/size-ratchet	1766
 skills/worktree/scripts/worktree	4980
 skills/worktree/scripts/worktree-session-guard	1197
 skills/worktree/tests/worktree_session_guard.sh	1282

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -127,7 +127,7 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/lib/settings.sh	456
-skills/size-ratchet/scripts/size-ratchet	1821
+skills/size-ratchet/scripts/size-ratchet	1814
 skills/worktree/scripts/worktree	4980
 skills/worktree/scripts/worktree-session-guard	1197
 skills/worktree/tests/worktree_session_guard.sh	1282

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -127,7 +127,7 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/lib/settings.sh	456
-skills/size-ratchet/scripts/size-ratchet	1814
+skills/size-ratchet/scripts/size-ratchet	1815
 skills/worktree/scripts/worktree	4980
 skills/worktree/scripts/worktree-session-guard	1197
 skills/worktree/tests/worktree_session_guard.sh	1282


### PR DESCRIPTION
## Summary

- A repo `SIZE_RATCHET_CLASSES` entry scoped to a directory no longer decides a frozen path a shipped class also names. `*` crosses `/` in this dialect, so `ui/*.ts=250` matched every test file under `ui/` too, silently retitling the shipped class and its counting unit for paths the repo never named. An entry that restates a shipped pattern still wins, so a repo can still move a frozen class on purpose, and where no shipped class names the frozen path the repo entry stands.
- The verdict line stops advertising an entry that decided nothing. It now annotates by outcome, so a typo'd or shadowed pattern reads `(governed nothing: decided no counted path)` instead of printing as the mapping in force on a clean run.
- The remedy a diagnostic prints follows one predicate, whether HEAD's baseline carries the path, rather than the verdict label. That fixes two opposite misdirections: a genuine bootstrap told to split, and a deleted frozen row told to declare a raise the freeze then refuses.
- kendex's own `SIZE_RATCHET_CLASSES` drops from ten entries to the two that are policy. The other eight existed only to restate shipped thresholds ahead of a repo entry, which is the workaround this change removes.

## Completed Issues

- Closes KEN-875 - size-ratchet: a repo class must not shadow shipped frozen classes

Blocks the six remaining KEN-839 propagation PRs, which no longer need restatements of their own.

## Test Plan

- All ten size-ratchet suites green, 452 counted assertions. `ratchet-directions` 62, `shipped-defaults` 95, `path-classes` 37.
- Mutation evidence, eight mutants, eight killed by named assertions: `head_carries_row` forced false and forced true, current-baseline substituted for HEAD, last-shadowed-wins, direction-limited skip, the annotation re-keyed on `YIELDED`, annotate-always, and every remedy string emptied. The last of those used to leave the frozen-growth arm green.
- Fleet sweep before choosing this design: both engines run over all seven consumer repos produce byte-identical output. `hyprtrade` and `vg` carry only verbatim restatements at the shipped 800; four repos set no classes; kendex's `ui/` entries are the accidental capture this change removes.
- Verified on real bash 3.2.57, which CI does not cover: its macOS runner runs `cargo test` only, so every shell suite otherwise runs on Linux bash 5.
- The rebase onto KEN-848 was checked by reconstructing the ideal three-way merge with `git merge-file`; its output is byte-identical to the rebased blob, and both directional diffs isolate each side's own lines.

## Known limits

The verdict line reports that an entry governed nothing without saying why. A pattern that matched nothing and one an earlier entry already claimed reach that state indistinguishably, so the line reports the state rather than guessing a cause. Telling those apart would need state the engine does not keep.
