### PR TITLE
fix(KEN-873): a lane's idleness is read below its last user turn

### DIFF
--- a/.agents/skills/orch/scripts/oversee-watch
+++ b/.agents/skills/orch/scripts/oversee-watch
@@ -29,14 +29,14 @@
 #                 all is not an answer: that lane stays watched, noted once on
 #                 stderr
 #   5. usage-limit a listed lane whose harness has not exited shows the
-#                 account's limit banner below the last user turn on its
-#                 screen — one pass, and the claimed config dir when a live
-#                 lane claim names the window
-#   6. question   a question/selection prompt below the last user turn
-#   7. idle-after-return a listed lane whose harness has not exited sits at
-#                 its composer with no work in flight on two consecutive
-#                 passes
+#                 account's limit banner on its screen — one pass, and the
+#                 claimed config dir when a live lane claim names the window
+#   6. question   a question/selection prompt
+#   7. idle-after-return a listed lane whose harness has not exited sits at its
+#                 composer with no work in flight on two consecutive passes
 #   8. heartbeat  after --max-loops passes with no event
+# Every pane check reads only the lines below the last user turn, 5-7 and any
+# added later: above it is scrollback the lane has already worked past.
 #
 # Output on the first event: `EVENT <kind> ...` on stdout — one line, except
 # `merged`, which prints one `EVENT merged` line per merged item so the
@@ -82,7 +82,7 @@ PR_WATCH="${OVERSEE_WATCH_PR_WATCH:-$SKILLS_DIR/review-gate/scripts/pr-watch.sh}
 PW_STATE_DIR="${OVERSEE_WATCH_STATE_DIR:-$PROJECT_ROOT/tmp/oversee-watch}"
 
 # Every pane predicate lives here, one line each, matched with `grep -E`
-# against the whole pane capture.
+# against pane_below_last_turn's slice — never the whole capture.
 # A dialog waiting on an answer: the selected numbered row, drawn with each
 # harness's marker, and Claude Code's question and key hints.
 QUESTION_RE='(❯|›) [0-9]+\. |Do you want to|Enter to select|Esc to cancel'
@@ -618,8 +618,8 @@ check_lanes() {
     i=$((i + 1))
     if [[ "$(lane_state "$states" "$i")" == exited ]]; then continue; fi
     pane="$(cat -- "$(lane_pane_file "$i")")"
-    if grep -Eq -- "$WORKING_RE" <<<"$pane"; then continue; fi
-    if ! grep -Eq -- "$IDLE_PROMPT_RE" <<<"$pane"; then continue; fi
+    if grep -Eq -- "$WORKING_RE" <<<"$(pane_below_last_turn "$pane")"; then continue; fi
+    if ! grep -Eq -- "$IDLE_PROMPT_RE" <<<"$(pane_below_last_turn "$pane")"; then continue; fi
     idle_now+="$i"$'\n'
     if grep -qxF -- "$i" <<<"$LANE_IDLE_SEEN"; then
       echo "EVENT idle-after-return $lane"

--- a/.agents/skills/orch/tests/oversee_watch_lanes.sh
+++ b/.agents/skills/orch/tests/oversee_watch_lanes.sh
@@ -28,7 +28,10 @@
 #   4b. idle-after-return: a harness at its composer with nothing in flight
 #       on two consecutive passes (either harness's prompt, and under a
 #       wrapped shell); one pass alone, a working indicator alongside the
-#       prompt, and an idle pass followed by a working one are not events
+#       prompt, and an idle pass followed by a working one are not events; a
+#       working indicator above the last user turn is scrollback and still
+#       fires, while one below that turn does not, and a user turn's marker
+#       above that boundary is not the composer the lane sits at
 set -euo pipefail
 
 # shellcheck source=lib/oversee-watch-harness.sh
@@ -743,6 +746,53 @@ out="$(run_watch -- gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
 assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=2 interval=0s since=none" \
   "an idle pass followed by a working one is not the event" "$err"
 assert_not_contains "$out" "EVENT idle-after-return" "a non-consecutive idle reading never fires" "$err"
+
+# Scrollback never goes away, so a working indicator the lane has since taken
+# a turn past would suppress this event for good — the debounce cannot help,
+# the line is not transient. Only the slice below the last user turn is work
+# in flight now.
+new_case idle_after_return_working_above_turn
+{
+  printf '⏺ Thinking (esc to interrupt)\n'
+  printf '❯ actually stop there and write it up\n'
+  printf '⏺ Done: the PR is merged and the worktree is gone.\n'
+  printf '\xe2\x9d\xaf\xc2\xa0\n'
+  printf '  bypass permissions on\n'
+} > "$STUB_DIR/pane-gh-2.txt"
+err="$TMP_ROOT/e4b8"
+out="$(run_watch -- gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
+assert_eq "$rc" "0" "an interrupt hint in scrollback exits 0" "$err"
+assert_eq "$(head -1 <<<"$out")" "EVENT idle-after-return gh-2" \
+  "an interrupt hint above the last user turn is scrollback, not work in flight" "$err"
+
+# ...and its must-fail control: the same hint BELOW the last user turn is a
+# lane really working, so the slice can never pass by muting the check
+new_case idle_after_return_working_below_turn
+{
+  printf '❯ go ahead and refactor it\n'
+  printf '⏺ Thinking (esc to interrupt)\n'
+  printf '\xe2\x9d\xaf\xc2\xa0\n'
+} > "$STUB_DIR/pane-gh-2.txt"
+err="$TMP_ROOT/e4b9"
+out="$(run_watch -- gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
+assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=2 interval=0s since=none" \
+  "an interrupt hint below the last user turn still means busy" "$err"
+assert_not_contains "$out" "EVENT idle-after-return" "the slice does not mute the working check" "$err"
+
+# The prompt half of the same rule: a submitted user turn opens with the same
+# marker the composer does, so read off the whole pane a lane that is nowhere
+# near its composer satisfies the idle prompt off scrollback alone.
+new_case idle_after_return_prompt_above_turn
+{
+  printf '❯ run the suite\n'
+  printf '⏺ Bash(cargo test)\n'
+  printf '  ⎿ Compiling kendex v5.0.0\n'
+} > "$STUB_DIR/pane-gh-2.txt"
+err="$TMP_ROOT/e4b10"
+out="$(run_watch -- gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
+assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=2 interval=0s since=none" \
+  "a scrollback user turn is not the composer the lane is sitting at" "$err"
+assert_not_contains "$out" "EVENT idle-after-return" "a marker above the last user turn never reads as idle" "$err"
 
 # A pane keeps its last screen after the harness exits, so a stale prompt
 # under a bare shell is not a question anyone can answer — and firing it every

--- a/skills/orch/scripts/oversee-watch
+++ b/skills/orch/scripts/oversee-watch
@@ -29,14 +29,14 @@
 #                 all is not an answer: that lane stays watched, noted once on
 #                 stderr
 #   5. usage-limit a listed lane whose harness has not exited shows the
-#                 account's limit banner below the last user turn on its
-#                 screen — one pass, and the claimed config dir when a live
-#                 lane claim names the window
-#   6. question   a question/selection prompt below the last user turn
-#   7. idle-after-return a listed lane whose harness has not exited sits at
-#                 its composer with no work in flight on two consecutive
-#                 passes
+#                 account's limit banner on its screen — one pass, and the
+#                 claimed config dir when a live lane claim names the window
+#   6. question   a question/selection prompt
+#   7. idle-after-return a listed lane whose harness has not exited sits at its
+#                 composer with no work in flight on two consecutive passes
 #   8. heartbeat  after --max-loops passes with no event
+# Every pane check reads only the lines below the last user turn, 5-7 and any
+# added later: above it is scrollback the lane has already worked past.
 #
 # Output on the first event: `EVENT <kind> ...` on stdout — one line, except
 # `merged`, which prints one `EVENT merged` line per merged item so the
@@ -82,7 +82,7 @@ PR_WATCH="${OVERSEE_WATCH_PR_WATCH:-$SKILLS_DIR/review-gate/scripts/pr-watch.sh}
 PW_STATE_DIR="${OVERSEE_WATCH_STATE_DIR:-$PROJECT_ROOT/tmp/oversee-watch}"
 
 # Every pane predicate lives here, one line each, matched with `grep -E`
-# against the whole pane capture.
+# against pane_below_last_turn's slice — never the whole capture.
 # A dialog waiting on an answer: the selected numbered row, drawn with each
 # harness's marker, and Claude Code's question and key hints.
 QUESTION_RE='(❯|›) [0-9]+\. |Do you want to|Enter to select|Esc to cancel'
@@ -618,8 +618,8 @@ check_lanes() {
     i=$((i + 1))
     if [[ "$(lane_state "$states" "$i")" == exited ]]; then continue; fi
     pane="$(cat -- "$(lane_pane_file "$i")")"
-    if grep -Eq -- "$WORKING_RE" <<<"$pane"; then continue; fi
-    if ! grep -Eq -- "$IDLE_PROMPT_RE" <<<"$pane"; then continue; fi
+    if grep -Eq -- "$WORKING_RE" <<<"$(pane_below_last_turn "$pane")"; then continue; fi
+    if ! grep -Eq -- "$IDLE_PROMPT_RE" <<<"$(pane_below_last_turn "$pane")"; then continue; fi
     idle_now+="$i"$'\n'
     if grep -qxF -- "$i" <<<"$LANE_IDLE_SEEN"; then
       echo "EVENT idle-after-return $lane"

--- a/skills/orch/tests/oversee_watch_lanes.sh
+++ b/skills/orch/tests/oversee_watch_lanes.sh
@@ -28,7 +28,10 @@
 #   4b. idle-after-return: a harness at its composer with nothing in flight
 #       on two consecutive passes (either harness's prompt, and under a
 #       wrapped shell); one pass alone, a working indicator alongside the
-#       prompt, and an idle pass followed by a working one are not events
+#       prompt, and an idle pass followed by a working one are not events; a
+#       working indicator above the last user turn is scrollback and still
+#       fires, while one below that turn does not, and a user turn's marker
+#       above that boundary is not the composer the lane sits at
 set -euo pipefail
 
 # shellcheck source=lib/oversee-watch-harness.sh
@@ -743,6 +746,53 @@ out="$(run_watch -- gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
 assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=2 interval=0s since=none" \
   "an idle pass followed by a working one is not the event" "$err"
 assert_not_contains "$out" "EVENT idle-after-return" "a non-consecutive idle reading never fires" "$err"
+
+# Scrollback never goes away, so a working indicator the lane has since taken
+# a turn past would suppress this event for good — the debounce cannot help,
+# the line is not transient. Only the slice below the last user turn is work
+# in flight now.
+new_case idle_after_return_working_above_turn
+{
+  printf '⏺ Thinking (esc to interrupt)\n'
+  printf '❯ actually stop there and write it up\n'
+  printf '⏺ Done: the PR is merged and the worktree is gone.\n'
+  printf '\xe2\x9d\xaf\xc2\xa0\n'
+  printf '  bypass permissions on\n'
+} > "$STUB_DIR/pane-gh-2.txt"
+err="$TMP_ROOT/e4b8"
+out="$(run_watch -- gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
+assert_eq "$rc" "0" "an interrupt hint in scrollback exits 0" "$err"
+assert_eq "$(head -1 <<<"$out")" "EVENT idle-after-return gh-2" \
+  "an interrupt hint above the last user turn is scrollback, not work in flight" "$err"
+
+# ...and its must-fail control: the same hint BELOW the last user turn is a
+# lane really working, so the slice can never pass by muting the check
+new_case idle_after_return_working_below_turn
+{
+  printf '❯ go ahead and refactor it\n'
+  printf '⏺ Thinking (esc to interrupt)\n'
+  printf '\xe2\x9d\xaf\xc2\xa0\n'
+} > "$STUB_DIR/pane-gh-2.txt"
+err="$TMP_ROOT/e4b9"
+out="$(run_watch -- gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
+assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=2 interval=0s since=none" \
+  "an interrupt hint below the last user turn still means busy" "$err"
+assert_not_contains "$out" "EVENT idle-after-return" "the slice does not mute the working check" "$err"
+
+# The prompt half of the same rule: a submitted user turn opens with the same
+# marker the composer does, so read off the whole pane a lane that is nowhere
+# near its composer satisfies the idle prompt off scrollback alone.
+new_case idle_after_return_prompt_above_turn
+{
+  printf '❯ run the suite\n'
+  printf '⏺ Bash(cargo test)\n'
+  printf '  ⎿ Compiling kendex v5.0.0\n'
+} > "$STUB_DIR/pane-gh-2.txt"
+err="$TMP_ROOT/e4b10"
+out="$(run_watch -- gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
+assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=2 interval=0s since=none" \
+  "a scrollback user turn is not the composer the lane is sitting at" "$err"
+assert_not_contains "$out" "EVENT idle-after-return" "a marker above the last user turn never reads as idle" "$err"
 
 # A pane keeps its last screen after the harness exits, so a stale prompt
 # under a bare shell is not a question anyone can answer — and firing it every

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -111,6 +111,7 @@ skills/orch/scripts/workflow-state	546
 skills/orch/tests/approval_wait.sh	1585
 skills/orch/tests/ci_wait.sh	824
 skills/orch/tests/lanes.sh	890
+skills/orch/tests/oversee_watch_lanes.sh	815
 skills/orch/tests/queue_wait.sh	920
 skills/preflight/scripts/preflight	1289
 skills/review-gate/scripts/pr-watch.sh	854


### PR DESCRIPTION
The `idle-after-return` checks read `$pane`, the whole capture, so scrollback decided whether a lane was idle. Both greps now read `pane_below_last_turn "$pane"`, the slice `usage-limit` has read since KEN-845 and `question` since KEN-864. This is the third and last site of that class.

## The half that matters

`WORKING_RE` is `to interrupt|to run in background|↓ [0-9][0-9.]*[kKmM]? tokens`. One scrollback line matching any of those made the check `continue` for that lane on **every** pass, so `idle-after-return` was suppressed permanently — and the two-consecutive-passes debounce could not help, because the condition was a line sitting in scrollback rather than a transient screen. A finished lane never woke the overseer. That is fail-silent in a watcher whose only job is to say a lane needs attention.

The `IDLE_PROMPT_RE` half is the milder direction: `^❯` matches a scrollback user turn, so a lane that is not at its composer could satisfy the prompt condition off scrollback alone. It still had to clear `WORKING_RE` and two passes.

`pane_below_last_turn` needed no change: it returns the marker before the last one when the last is a live composer, so the composer line the idle check looks for is inside the slice by construction. No narrowing fallback was added — an empty slice would mute the check outright, which is the failure this issue is about.

## Controls

In `skills/orch/tests/oversee_watch_lanes.sh`:

- An interrupt hint above the last user turn is scrollback, and the lane still reaches `idle-after-return`.
- A marker above the last user turn does not read as idle on its own.
- A scrollback user turn is not the composer the lane is sitting at.
- The must-fail control: a lane genuinely working, interrupt hint **below** the last user turn, still does not reach the event.

Reverting both greps to `$pane` turns the first three red while the must-fail control stays green — which is what says the fix reads the right slice rather than weakening the gate. Verified again after the rebase onto #1869, since that PR changed predicates in the same file and a pre-rebase result would not have covered it.

`oversee_watch_lanes` 115 pass / 0 fail.

## One line so a fourth check is not written against `$pane`

The per-event "below the last user turn" qualifiers are replaced by a single statement covering events 5–7 **and any added later**. That is the issue's own request, and removing the repetitions pays for it: `oversee-watch` is still exactly 654 and its ratchet row does not move.

`skills/orch/tests/queue_wait_confirmation.sh` is red and unrelated — it touches no file this branch changes. Filed as KEN-879, which now carries the likely root cause from KEN-872's fix.

Closes KEN-873
