### PR TITLE
fix(KEN-886): a squeeze budget belongs to a candidate, not to a run

### DIFF
--- a/.agents/skills/orch/scripts/queue-wait
+++ b/.agents/skills/orch/scripts/queue-wait
@@ -103,11 +103,11 @@ nothing and is reported as "still queued", named in unconfirmed_verdict so
 the reading is not lost. So that the deadline does not simply CUT a
 confirmation short, the polls a standing candidate still needs are moved
 INSIDE the budget — the gap before each shrinks to fit, at most
-QUEUE_WAIT_CONFIRM_POLLS - 1 times per run, and max_wait stays the upper
-bound it is documented as. ejected and disarmed are transitions, observed
-once as queued-then-out or armed-then-unarmed, and a re-run starts with
-those priors false: an ejection cut off by the deadline is re-observed by
-nobody, where conflicting is read from mergeable every poll and a re-run
+QUEUE_WAIT_CONFIRM_POLLS - 1 times per candidate verdict, and max_wait stays
+the upper bound it is documented as. ejected and disarmed are transitions,
+observed once as queued-then-out or armed-then-unarmed, and a re-run starts
+with those priors false: an ejection cut off by the deadline is re-observed
+by nobody, where conflicting is read from mergeable every poll and a re-run
 sees it again. While a candidate is waiting for its confirmation
 the failed-check probe is skipped too, so one probe observation cannot
 overtake a standing conflict and route it to a CI cycle. A poll that routes
@@ -874,6 +874,7 @@ note_candidate() {
     candidate_verdict="$verdict"
     candidate_cause="$cause"
     candidate_count=1
+    confirm_squeezes=0
   fi
 }
 
@@ -887,17 +888,16 @@ clear_candidate() {
 # while a candidate still owes confirmation polls the remaining budget cannot
 # fit at that interval, so the confirmation finishes INSIDE the budget instead
 # of being cut off by it. ejected and disarmed are TRANSITIONS — was_in_queue
-# then out, was_queued then unarmed — and a re-run of this script starts with
-# those priors false, so a candidate the deadline cuts off is re-observed by
-# no one: the caller re-runs, reads not_queued, and merge-pr re-arms a PR the
-# queue already threw out. conflicting is read from mergeable on every poll
-# and survives a re-run, which is why only these two are lost.
+# then out, was_queued then unarmed — and a re-run starts with those priors
+# false, so a candidate the deadline cuts off is re-observed by no one: the
+# caller re-runs, reads not_queued, and merge-pr re-arms a PR the queue threw
+# out. conflicting is read from mergeable every poll and survives a re-run.
 #
 # Bounded twice over: never past the deadline, and at most CONFIRM_POLLS - 1
-# shortened gaps per run, so a candidate flapping in the last seconds cannot
-# spin the poll loop. A shortened gap is a weaker blip filter than a full
-# interval — two reads seconds apart rather than minutes — and it is still
-# two independent reads, against losing the observation entirely.
+# shortened gaps per candidate verdict — the polls that verdict owes — so a
+# flapping candidate cannot spin the poll loop, while a transition arriving
+# after an earlier one still has the squeezes that one spent. A shortened gap
+# is a weaker blip filter than a full interval, and still two reads.
 poll_gap="$POLL_INTERVAL"
 confirm_squeezes=0
 MAX_CONFIRM_SQUEEZES=$((CONFIRM_POLLS - 1))
@@ -912,10 +912,10 @@ set_next_poll_gap() {
   update_elapsed
   remaining=$((MAX_WAIT - elapsed))
   [ "$remaining" -gt 0 ] || return 0
-  [ $((need * POLL_INTERVAL)) -gt "$remaining" ] || return 0
+  [ $((need * POLL_INTERVAL)) -ge "$remaining" ] || return 0
   confirm_squeezes=$((confirm_squeezes + 1))
-  # One slot more than the polls owed: the last gap must not land exactly on
-  # the deadline, or the loop ends with the poll it was shortened for unmade.
+  # Fitting is strict (-ge above) and the divisor is one slot more than the
+  # polls owed: a gap landing ON the deadline leaves that poll unmade.
   poll_gap=$((remaining / (need + 1)))
 }
 

--- a/.agents/skills/orch/tests/queue_wait_confirmation.sh
+++ b/.agents/skills/orch/tests/queue_wait_confirmation.sh
@@ -21,6 +21,12 @@
 #   4. a blip is still not routed, shortened gap or not
 #   5. the count is still the whole rule: a candidate that cannot reach it
 #      even shortened is reported beside the timeout, never as a verdict
+#   6. the squeeze allowance is per candidate verdict, so a transition
+#      arriving after an earlier candidate spent it is still confirmed
+#      (KEN-886)
+#   7. a transition whose owed polls fit the budget exactly is squeezed
+#      anyway, because a gap landing ON the deadline is a poll never made
+#      (KEN-886)
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -71,7 +77,9 @@ ln -s "$REPO_ROOT/skills/orch" "$TMP_ROOT/repo/.agents/skills/orch"
 #   $STUB_SEQ_DIR/queue-<n>.json   queue-membership GraphQL body
 # `<prefix>-last.json` serves every poll past the last numbered fixture, and
 # review-thread reads answer with an empty set so the late-findings guard
-# stays quiet.
+# stays quiet. `STUB_QUEUE_DELAY` makes the queue read itself cost that many
+# seconds, the production condition under which a confirmation count can be
+# larger than the remaining budget can hold however short the gaps are made.
 cat > "$TMP_ROOT/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 set -uo pipefail
@@ -126,6 +134,7 @@ case "${1:-}" in
         echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}'
         exit 0
       fi
+      [[ -n "${STUB_QUEUE_DELAY:-}" ]] && sleep "$STUB_QUEUE_DELAY"
       _emit_fixture queue "$(_next graphql)"
     fi
     if [[ "${2:-}" == "user" ]]; then echo "test-user"; exit 0; fi
@@ -158,6 +167,7 @@ write_fixture() { # <prefix> <n|last> <json>
 }
 
 pr_open_mergeable='{"state":"OPEN","mergedAt":null,"mergeable":"MERGEABLE"}'
+pr_open_conflicting='{"state":"OPEN","mergedAt":null,"mergeable":"CONFLICTING"}'
 
 q_in_queue='{"data":{"repository":{"pullRequest":{"id":"PR_node1","isInMergeQueue":true,"mergeQueueEntry":{"state":"QUEUED"},"autoMergeRequest":{"enabledAt":"2026-07-24T09:00:00Z"}}}}}'
 q_out='{"data":{"repository":{"pullRequest":{"id":"PR_node1","isInMergeQueue":false,"mergeQueueEntry":null,"autoMergeRequest":null}}}}'
@@ -248,21 +258,64 @@ assert_eq "$(jq -r .unconfirmed_verdict <<<"$out")" "null" \
 # the candidate cannot reach its count. It is not handed back wearing a
 # confirmed verdict's name — that is the routing the count exists to prevent
 # — and it is not lost either: unconfirmed_verdict carries it beside the
-# timeout.
+# timeout. A shortened gap can be zero, so it is the poll's own cost that
+# makes the count unreachable: STUB_QUEUE_DELAY buys each read a second, as
+# a real merge-queue read does, and nine polls do not fit in four.
 new_case ejected_unreachable_count
 write_fixture state last "$pr_open_mergeable"
 write_fixture queue 1 "$q_in_queue"
 write_fixture queue last "$q_out"
 err="$TMP_ROOT/e4"
-out="$(run_queue_wait QUEUE_WAIT_CONFIRM_POLLS=9 -- 1 1 3 --json --no-check-probe 2>"$err")" && rc=0 || rc=$?
+out="$(run_queue_wait QUEUE_WAIT_CONFIRM_POLLS=9 STUB_QUEUE_DELAY=1 -- 1 1 4 --json --no-check-probe 2>"$err")" && rc=0 || rc=$?
 assert_eq "$(jq -r .verdict <<<"$out")" "queued" \
   "a candidate that cannot reach its count carries no confirmed verdict" "$err"
 assert_eq "$(jq -r .status <<<"$out")" "timeout" \
   "that exit is a timeout" "$err"
 assert_eq "$(jq -r .unconfirmed_verdict <<<"$out")" "ejected" \
   "the standing reading is reported beside the verdict, never dropped" "$err"
-assert_le "$(jq -r .elapsed_seconds <<<"$out")" "3" \
+assert_le "$(jq -r .elapsed_seconds <<<"$out")" "4" \
   "an unreachable count does not spin the poll loop past the budget" "$err"
+
+# --- 6. the squeeze allowance is per candidate verdict (KEN-886) ----------
+# A conflicting reading stands first and spends the run's one squeeze, then
+# the poll after it reads the PR out of the queue. That second candidate is a
+# TRANSITION: cut off here it is re-observed by nobody, and merge-pr re-arms
+# a PR the queue threw out. Budgeted per run, the ejection gets no shortened
+# gap and the deadline takes it; budgeted per candidate verdict, it gets the
+# allowance its own confirmation owes.
+new_case later_candidate_after_spent_budget
+write_fixture state 1 "$pr_open_mergeable"
+write_fixture state 2 "$pr_open_conflicting"
+write_fixture state last "$pr_open_mergeable"
+write_fixture queue 1 "$q_in_queue"
+write_fixture queue 2 "$q_in_queue"
+write_fixture queue last "$q_out"
+err="$TMP_ROOT/e5"
+out="$(run_queue_wait -- 1 3 5 --json --no-check-probe 2>"$err")" && rc=0 || rc=$?
+assert_eq "$(jq -r .verdict <<<"$out")" "ejected" \
+  "an ejection after a spent candidate is still confirmed" "$err"
+assert_eq "$(jq -r .cause <<<"$out")" "merge_group_failed" \
+  "it carries its own cause, not the earlier candidate's" "$err"
+assert_le "$(jq -r .elapsed_seconds <<<"$out")" "5" \
+  "the second confirmation still finishes inside the budget" "$err"
+
+# --- 7. owed polls that fit the budget exactly (KEN-886) ------------------
+# The loop runs while elapsed < max_wait, so polls owed at exactly the
+# remaining budget land the last one ON the deadline, where it is never made.
+# Three confirmations at a one-second interval, first seen within two seconds
+# of it, meet that equality on a step and the count is never reached.
+new_case owed_polls_fit_exactly
+write_fixture state last "$pr_open_mergeable"
+write_fixture queue 1 "$q_in_queue"
+write_fixture queue last "$q_out"
+err="$TMP_ROOT/e6"
+out="$(run_queue_wait QUEUE_WAIT_CONFIRM_POLLS=3 -- 1 1 3 --json --no-check-probe 2>"$err")" && rc=0 || rc=$?
+assert_eq "$(jq -r .verdict <<<"$out")" "ejected" \
+  "a transition owed exactly the remaining budget is squeezed, not cut" "$err"
+assert_eq "$(jq -r .status <<<"$out")" "complete" \
+  "that exit is a complete verdict, not a timeout" "$err"
+assert_le "$(jq -r .elapsed_seconds <<<"$out")" "3" \
+  "squeezing at the boundary does not overrun max_wait" "$err"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/.agents/skills/orch/tests/queue_wait_conflicting.sh
+++ b/.agents/skills/orch/tests/queue_wait_conflicting.sh
@@ -84,6 +84,8 @@ ln -s "$REPO_ROOT/skills/orch" "$TMP_ROOT/repo/.agents/skills/orch"
 # stays quiet; no case here exercises it. `gh pr checks` and the Actions-run
 # read belong to the real ci-wait the failed-check probe delegates to:
 # STUB_PR_CHECKS_MODE=failure is what lets that probe reach a verdict at all.
+# STUB_QUEUE_DELAY makes the queue read itself cost that many seconds, the
+# production condition under which a confirmation count outlasts the budget.
 cat > "$TMP_ROOT/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 set -uo pipefail
@@ -138,6 +140,7 @@ case "${1:-}" in
         echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}'
         exit 0
       fi
+      [[ -n "${STUB_QUEUE_DELAY:-}" ]] && sleep "$STUB_QUEUE_DELAY"
       _emit_fixture queue "$(_next graphql)"
     fi
     if [[ "${2:-}" == "user" ]]; then echo "test-user"; exit 0; fi
@@ -239,12 +242,15 @@ assert_eq "$(jq -r .verdict <<<"$out")" "queued" "a one-poll CONFLICTING blip is
 # standing. Handing that back as `conflicting` gives a single unconfirmed
 # observation the name a confirmed one carries, and a caller routing on
 # verdict cannot tell them apart. The reading is not lost either: it is
-# reported beside the still-queued verdict rather than as one.
+# reported beside the still-queued verdict rather than as one. A gap
+# shortened to fit the budget can be zero, so it is the poll's own cost that
+# puts the count out of reach: STUB_QUEUE_DELAY buys each read a second, as a
+# real merge-queue read does, and nine polls do not fit in four.
 new_case conflicting_unconfirmed_at_deadline
 write_fixture state last "$(pr_state OPEN CONFLICTING)"
 write_fixture queue last "$q_in_queue"
 err="$TMP_ROOT/e2b"
-out="$(run_queue_wait QUEUE_WAIT_CONFIRM_POLLS=9 -- 1 1 3 --json --no-check-probe 2>"$err")" && rc=0 || rc=$?
+out="$(run_queue_wait QUEUE_WAIT_CONFIRM_POLLS=9 STUB_QUEUE_DELAY=1 -- 1 1 4 --json --no-check-probe 2>"$err")" && rc=0 || rc=$?
 assert_eq "$(jq -r .verdict <<<"$out")" "queued" \
   "an unconfirmed candidate does not carry a confirmed verdict's name at the deadline" "$err"
 assert_eq "$(jq -r .status <<<"$out")" "timeout" \

--- a/skills/orch/scripts/queue-wait
+++ b/skills/orch/scripts/queue-wait
@@ -103,11 +103,11 @@ nothing and is reported as "still queued", named in unconfirmed_verdict so
 the reading is not lost. So that the deadline does not simply CUT a
 confirmation short, the polls a standing candidate still needs are moved
 INSIDE the budget — the gap before each shrinks to fit, at most
-QUEUE_WAIT_CONFIRM_POLLS - 1 times per run, and max_wait stays the upper
-bound it is documented as. ejected and disarmed are transitions, observed
-once as queued-then-out or armed-then-unarmed, and a re-run starts with
-those priors false: an ejection cut off by the deadline is re-observed by
-nobody, where conflicting is read from mergeable every poll and a re-run
+QUEUE_WAIT_CONFIRM_POLLS - 1 times per candidate verdict, and max_wait stays
+the upper bound it is documented as. ejected and disarmed are transitions,
+observed once as queued-then-out or armed-then-unarmed, and a re-run starts
+with those priors false: an ejection cut off by the deadline is re-observed
+by nobody, where conflicting is read from mergeable every poll and a re-run
 sees it again. While a candidate is waiting for its confirmation
 the failed-check probe is skipped too, so one probe observation cannot
 overtake a standing conflict and route it to a CI cycle. A poll that routes
@@ -874,6 +874,7 @@ note_candidate() {
     candidate_verdict="$verdict"
     candidate_cause="$cause"
     candidate_count=1
+    confirm_squeezes=0
   fi
 }
 
@@ -887,17 +888,16 @@ clear_candidate() {
 # while a candidate still owes confirmation polls the remaining budget cannot
 # fit at that interval, so the confirmation finishes INSIDE the budget instead
 # of being cut off by it. ejected and disarmed are TRANSITIONS — was_in_queue
-# then out, was_queued then unarmed — and a re-run of this script starts with
-# those priors false, so a candidate the deadline cuts off is re-observed by
-# no one: the caller re-runs, reads not_queued, and merge-pr re-arms a PR the
-# queue already threw out. conflicting is read from mergeable on every poll
-# and survives a re-run, which is why only these two are lost.
+# then out, was_queued then unarmed — and a re-run starts with those priors
+# false, so a candidate the deadline cuts off is re-observed by no one: the
+# caller re-runs, reads not_queued, and merge-pr re-arms a PR the queue threw
+# out. conflicting is read from mergeable every poll and survives a re-run.
 #
 # Bounded twice over: never past the deadline, and at most CONFIRM_POLLS - 1
-# shortened gaps per run, so a candidate flapping in the last seconds cannot
-# spin the poll loop. A shortened gap is a weaker blip filter than a full
-# interval — two reads seconds apart rather than minutes — and it is still
-# two independent reads, against losing the observation entirely.
+# shortened gaps per candidate verdict — the polls that verdict owes — so a
+# flapping candidate cannot spin the poll loop, while a transition arriving
+# after an earlier one still has the squeezes that one spent. A shortened gap
+# is a weaker blip filter than a full interval, and still two reads.
 poll_gap="$POLL_INTERVAL"
 confirm_squeezes=0
 MAX_CONFIRM_SQUEEZES=$((CONFIRM_POLLS - 1))
@@ -912,10 +912,10 @@ set_next_poll_gap() {
   update_elapsed
   remaining=$((MAX_WAIT - elapsed))
   [ "$remaining" -gt 0 ] || return 0
-  [ $((need * POLL_INTERVAL)) -gt "$remaining" ] || return 0
+  [ $((need * POLL_INTERVAL)) -ge "$remaining" ] || return 0
   confirm_squeezes=$((confirm_squeezes + 1))
-  # One slot more than the polls owed: the last gap must not land exactly on
-  # the deadline, or the loop ends with the poll it was shortened for unmade.
+  # Fitting is strict (-ge above) and the divisor is one slot more than the
+  # polls owed: a gap landing ON the deadline leaves that poll unmade.
   poll_gap=$((remaining / (need + 1)))
 }
 

--- a/skills/orch/tests/queue_wait_confirmation.sh
+++ b/skills/orch/tests/queue_wait_confirmation.sh
@@ -21,6 +21,12 @@
 #   4. a blip is still not routed, shortened gap or not
 #   5. the count is still the whole rule: a candidate that cannot reach it
 #      even shortened is reported beside the timeout, never as a verdict
+#   6. the squeeze allowance is per candidate verdict, so a transition
+#      arriving after an earlier candidate spent it is still confirmed
+#      (KEN-886)
+#   7. a transition whose owed polls fit the budget exactly is squeezed
+#      anyway, because a gap landing ON the deadline is a poll never made
+#      (KEN-886)
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -71,7 +77,9 @@ ln -s "$REPO_ROOT/skills/orch" "$TMP_ROOT/repo/.agents/skills/orch"
 #   $STUB_SEQ_DIR/queue-<n>.json   queue-membership GraphQL body
 # `<prefix>-last.json` serves every poll past the last numbered fixture, and
 # review-thread reads answer with an empty set so the late-findings guard
-# stays quiet.
+# stays quiet. `STUB_QUEUE_DELAY` makes the queue read itself cost that many
+# seconds, the production condition under which a confirmation count can be
+# larger than the remaining budget can hold however short the gaps are made.
 cat > "$TMP_ROOT/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 set -uo pipefail
@@ -126,6 +134,7 @@ case "${1:-}" in
         echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}'
         exit 0
       fi
+      [[ -n "${STUB_QUEUE_DELAY:-}" ]] && sleep "$STUB_QUEUE_DELAY"
       _emit_fixture queue "$(_next graphql)"
     fi
     if [[ "${2:-}" == "user" ]]; then echo "test-user"; exit 0; fi
@@ -158,6 +167,7 @@ write_fixture() { # <prefix> <n|last> <json>
 }
 
 pr_open_mergeable='{"state":"OPEN","mergedAt":null,"mergeable":"MERGEABLE"}'
+pr_open_conflicting='{"state":"OPEN","mergedAt":null,"mergeable":"CONFLICTING"}'
 
 q_in_queue='{"data":{"repository":{"pullRequest":{"id":"PR_node1","isInMergeQueue":true,"mergeQueueEntry":{"state":"QUEUED"},"autoMergeRequest":{"enabledAt":"2026-07-24T09:00:00Z"}}}}}'
 q_out='{"data":{"repository":{"pullRequest":{"id":"PR_node1","isInMergeQueue":false,"mergeQueueEntry":null,"autoMergeRequest":null}}}}'
@@ -248,21 +258,64 @@ assert_eq "$(jq -r .unconfirmed_verdict <<<"$out")" "null" \
 # the candidate cannot reach its count. It is not handed back wearing a
 # confirmed verdict's name — that is the routing the count exists to prevent
 # — and it is not lost either: unconfirmed_verdict carries it beside the
-# timeout.
+# timeout. A shortened gap can be zero, so it is the poll's own cost that
+# makes the count unreachable: STUB_QUEUE_DELAY buys each read a second, as
+# a real merge-queue read does, and nine polls do not fit in four.
 new_case ejected_unreachable_count
 write_fixture state last "$pr_open_mergeable"
 write_fixture queue 1 "$q_in_queue"
 write_fixture queue last "$q_out"
 err="$TMP_ROOT/e4"
-out="$(run_queue_wait QUEUE_WAIT_CONFIRM_POLLS=9 -- 1 1 3 --json --no-check-probe 2>"$err")" && rc=0 || rc=$?
+out="$(run_queue_wait QUEUE_WAIT_CONFIRM_POLLS=9 STUB_QUEUE_DELAY=1 -- 1 1 4 --json --no-check-probe 2>"$err")" && rc=0 || rc=$?
 assert_eq "$(jq -r .verdict <<<"$out")" "queued" \
   "a candidate that cannot reach its count carries no confirmed verdict" "$err"
 assert_eq "$(jq -r .status <<<"$out")" "timeout" \
   "that exit is a timeout" "$err"
 assert_eq "$(jq -r .unconfirmed_verdict <<<"$out")" "ejected" \
   "the standing reading is reported beside the verdict, never dropped" "$err"
-assert_le "$(jq -r .elapsed_seconds <<<"$out")" "3" \
+assert_le "$(jq -r .elapsed_seconds <<<"$out")" "4" \
   "an unreachable count does not spin the poll loop past the budget" "$err"
+
+# --- 6. the squeeze allowance is per candidate verdict (KEN-886) ----------
+# A conflicting reading stands first and spends the run's one squeeze, then
+# the poll after it reads the PR out of the queue. That second candidate is a
+# TRANSITION: cut off here it is re-observed by nobody, and merge-pr re-arms
+# a PR the queue threw out. Budgeted per run, the ejection gets no shortened
+# gap and the deadline takes it; budgeted per candidate verdict, it gets the
+# allowance its own confirmation owes.
+new_case later_candidate_after_spent_budget
+write_fixture state 1 "$pr_open_mergeable"
+write_fixture state 2 "$pr_open_conflicting"
+write_fixture state last "$pr_open_mergeable"
+write_fixture queue 1 "$q_in_queue"
+write_fixture queue 2 "$q_in_queue"
+write_fixture queue last "$q_out"
+err="$TMP_ROOT/e5"
+out="$(run_queue_wait -- 1 3 5 --json --no-check-probe 2>"$err")" && rc=0 || rc=$?
+assert_eq "$(jq -r .verdict <<<"$out")" "ejected" \
+  "an ejection after a spent candidate is still confirmed" "$err"
+assert_eq "$(jq -r .cause <<<"$out")" "merge_group_failed" \
+  "it carries its own cause, not the earlier candidate's" "$err"
+assert_le "$(jq -r .elapsed_seconds <<<"$out")" "5" \
+  "the second confirmation still finishes inside the budget" "$err"
+
+# --- 7. owed polls that fit the budget exactly (KEN-886) ------------------
+# The loop runs while elapsed < max_wait, so polls owed at exactly the
+# remaining budget land the last one ON the deadline, where it is never made.
+# Three confirmations at a one-second interval, first seen within two seconds
+# of it, meet that equality on a step and the count is never reached.
+new_case owed_polls_fit_exactly
+write_fixture state last "$pr_open_mergeable"
+write_fixture queue 1 "$q_in_queue"
+write_fixture queue last "$q_out"
+err="$TMP_ROOT/e6"
+out="$(run_queue_wait QUEUE_WAIT_CONFIRM_POLLS=3 -- 1 1 3 --json --no-check-probe 2>"$err")" && rc=0 || rc=$?
+assert_eq "$(jq -r .verdict <<<"$out")" "ejected" \
+  "a transition owed exactly the remaining budget is squeezed, not cut" "$err"
+assert_eq "$(jq -r .status <<<"$out")" "complete" \
+  "that exit is a complete verdict, not a timeout" "$err"
+assert_le "$(jq -r .elapsed_seconds <<<"$out")" "3" \
+  "squeezing at the boundary does not overrun max_wait" "$err"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/orch/tests/queue_wait_conflicting.sh
+++ b/skills/orch/tests/queue_wait_conflicting.sh
@@ -84,6 +84,8 @@ ln -s "$REPO_ROOT/skills/orch" "$TMP_ROOT/repo/.agents/skills/orch"
 # stays quiet; no case here exercises it. `gh pr checks` and the Actions-run
 # read belong to the real ci-wait the failed-check probe delegates to:
 # STUB_PR_CHECKS_MODE=failure is what lets that probe reach a verdict at all.
+# STUB_QUEUE_DELAY makes the queue read itself cost that many seconds, the
+# production condition under which a confirmation count outlasts the budget.
 cat > "$TMP_ROOT/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 set -uo pipefail
@@ -138,6 +140,7 @@ case "${1:-}" in
         echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}'
         exit 0
       fi
+      [[ -n "${STUB_QUEUE_DELAY:-}" ]] && sleep "$STUB_QUEUE_DELAY"
       _emit_fixture queue "$(_next graphql)"
     fi
     if [[ "${2:-}" == "user" ]]; then echo "test-user"; exit 0; fi
@@ -239,12 +242,15 @@ assert_eq "$(jq -r .verdict <<<"$out")" "queued" "a one-poll CONFLICTING blip is
 # standing. Handing that back as `conflicting` gives a single unconfirmed
 # observation the name a confirmed one carries, and a caller routing on
 # verdict cannot tell them apart. The reading is not lost either: it is
-# reported beside the still-queued verdict rather than as one.
+# reported beside the still-queued verdict rather than as one. A gap
+# shortened to fit the budget can be zero, so it is the poll's own cost that
+# puts the count out of reach: STUB_QUEUE_DELAY buys each read a second, as a
+# real merge-queue read does, and nine polls do not fit in four.
 new_case conflicting_unconfirmed_at_deadline
 write_fixture state last "$(pr_state OPEN CONFLICTING)"
 write_fixture queue last "$q_in_queue"
 err="$TMP_ROOT/e2b"
-out="$(run_queue_wait QUEUE_WAIT_CONFIRM_POLLS=9 -- 1 1 3 --json --no-check-probe 2>"$err")" && rc=0 || rc=$?
+out="$(run_queue_wait QUEUE_WAIT_CONFIRM_POLLS=9 STUB_QUEUE_DELAY=1 -- 1 1 4 --json --no-check-probe 2>"$err")" && rc=0 || rc=$?
 assert_eq "$(jq -r .verdict <<<"$out")" "queued" \
   "an unconfirmed candidate does not carry a confirmed verdict's name at the deadline" "$err"
 assert_eq "$(jq -r .status <<<"$out")" "timeout" \


### PR DESCRIPTION
The confirmation squeeze budget was computed once per run (`MAX_CONFIRM_SQUEEZES = CONFIRM_POLLS-1`) rather than per candidate verdict. A first candidate burned it, and a later ejection or disarm then reached the deadline unconfirmed: the run exits `queued` or `unconfirmed_verdict`, a re-run reads `not_queued`, and merge-pr re-arms a PR without repairing whatever CI failure ejected it.

A second, narrower case: a transition first seen on the final budget second got no squeeze at all, because the fit was gated on `remaining -gt 0`.

## The change is the accounting, and only the accounting

Two lines. `confirm_squeezes` resets per candidate verdict, so a transition arriving after an earlier one still has the squeezes that one spent. And the fitting test moves from `-gt` to `-ge`, because a gap landing exactly ON the deadline is a poll never made.

Per-candidate budgeting was chosen over restoring the post-loop emit that #1847's round 6 deleted: the emit reported a verdict the loop never confirmed, which is the weaker guarantee, while budgeting per candidate keeps every reported verdict backed by two independent reads. No new mechanism, no new flag, no second loop — the issue asks for the existing loop's accounting and that is what moved.

`queue-wait` holds its 1127 baseline row; the comment rewordings pay for the added lines.

## Must-fail control

Reverting both changes on a scratch tree turns the new assertions red:

```
FAIL  an ejection after a spent candidate is still confirmed
FAIL  it carries its own cause, not the earlier candidate's
FAIL  a transition owed exactly the remaining budget is squeezed, not cut
FAIL  that exit is a complete verdict, not a timeout
```

## On the neighbouring flake, checked rather than assumed

`queue_wait_confirmation.sh` is known to flake (KEN-879), so a red run in this suite is not self-evidently attributable. Two things were measured rather than reasoned:

**This fix does not cure that flake.** Six runs on the fixed tree still produced 2, 2, 0, 1, 0 and 5 failures. KEN-879 is a separate layer — a wall-clock race in the test's own deadline arithmetic — exactly as its Context says, and the two were deliberately not folded together.

**This PR's new controls are not part of it.** Across eight runs on the fixed tree, the only assertions ever seen failing were the pre-existing `a disarm standing at the deadline is confirmed inside the budget` and `the confirmed disarm names its cause`. No new control failed once.

Closes KEN-886
