### PR TITLE
fix(KEN-885): a codex status item is matched by shape, not by token count

### DIFF
--- a/.agents/skills/orch/scripts/lib/lane-context.sh
+++ b/.agents/skills/orch/scripts/lib/lane-context.sh
@@ -85,16 +85,24 @@ lane_context_emit() {
     }'
 }
 
-# Read one context figure from a captured screen on stdin. Prints
-# `<harness>\t<used percent>`; exits 1 when the screen carries neither shape.
+# Read one context figure from a captured screen on stdin. $1 is the pane's
+# foreground process, and it decides which shape is offered: `codex` the codex
+# shape alone, a claude wrapper spelling or `agent-confine` the claude shape
+# alone. Anything else — `pi`, or an empty name for a pane that has left the
+# enumeration — is offered both, because a reader with no rule for a harness
+# has nothing better than the shapes themselves. Prints
+# `<harness>\t<used percent>`; exits 1 when the shape offered found nothing.
 #
 # The codex shape is offered the FINAL NON-EMPTY line and no other. The
 # claude shape is offered every line and its LAST match wins; no window is
 # taken off the bottom, because the footer under a claude status line is one
 # row per running agent and has no bound, so any count would lose exactly the
-# busiest lanes. A final line that carries the codex shape settles the
-# reading, out of range included: falling through to a claude match higher up
-# would be the search the position rule exists to refuse.
+# busiest lanes. Where both are offered, a final line carrying the codex shape
+# settles the reading, out of range included: falling through to a claude
+# match higher up would be the search the position rule exists to refuse. On a
+# codex pane there is no falling through at all — the claude shape is never
+# offered, so a screen that does not end in a codex status line is
+# could-not-tell however much of this fleet's transcript sits above it.
 #
 # Matching is done on a lowercased copy of each line: a model name is a word,
 # and the harness spells it differently in different places. The claude
@@ -127,10 +135,15 @@ lane_context_emit() {
 # context figure and is dropped rather than reported, whichever shape carried
 # it.
 lane_context_parse() {
-  local out
-  out="$(awk '
+  local out shape="both"
+  case "${1:-}" in
+    codex) shape="codex" ;;
+    *claude | agent-confine) shape="claude" ;;
+  esac
+  out="$(awk -v shape="$shape" '
     {
       if ($0 ~ /[^ \t]/) last = $0
+      if (shape == "codex") next
       low = tolower($0)
       if (match(low, /^[ \t]*[^ \t()]+([ \t]+\([^)]*\))?[ \t]+(opus|sonnet|haiku|fable)[ \t]+[0-9]+(\.[0-9]+)?([ \t]*\([^)]*\))?[ \t]+[0-9]+%[ \t]+\([^) \t]+\)([ \t]+\/[^ \t]*)*[ \t]*$/)) {
         s = substr(low, RSTART, RLENGTH)
@@ -141,7 +154,7 @@ lane_context_parse() {
       }
     }
     END {
-      low = tolower(last)
+      low = (shape == "claude") ? "" : tolower(last)
       if (match(low, /^[^a-z0-9]*context:?[ \t]+[0-9]+%[ \t]+(left|used)([ \t]+(·|[|])[ \t]+[^ \t].*)?[ \t]*$/)) {
         codex_line = 1
         s = substr(low, RSTART, RLENGTH)
@@ -171,7 +184,9 @@ lane_context_parse() {
 # against an unrelated local pane and emitted as ok. So the claim's server is
 # compared against this one, enumerated once, before anything is captured.
 # The same enumeration carries each pane's foreground process, which is what
-# says whether a harness is still drawing the screen about to be read.
+# says whether a harness is still drawing the screen about to be read — and
+# WHICH harness, which is how the reader knows the shape to look for without
+# guessing it from a screen that quotes both all day.
 lane_context_collect() {
   local claims="$1" alias_fn="$2" cfg lane server pane screen parsed
   local this_server detail cmd pane_cmds p_pid p_pane p_cmd
@@ -215,9 +230,14 @@ lane_context_collect() {
           "unreadable" "the pane could not be captured; it is gone from this server"
         continue
       fi
-      if ! parsed="$(lane_context_parse <<<"$screen")"; then
+      if ! parsed="$(lane_context_parse "$cmd" <<<"$screen")"; then
+        case "$cmd" in
+          codex) detail="the screen does not end in a codex status line; whatever moved it — a dialog over the footer, a redraw caught mid-frame — is covering the figure" ;;
+          *claude | agent-confine) detail="the screen carries no claude status line" ;;
+          *) detail="the screen carries neither harness's context figure" ;;
+        esac
         lane_context_emit "$lane" "$pane" "$cfg" "$("$alias_fn" "$cfg")" "" "" \
-          "no_status_line" "the screen carries neither harness's context figure"
+          "no_status_line" "$detail"
         continue
       fi
       lane_context_emit "$lane" "$pane" "$cfg" "$("$alias_fn" "$cfg")" \

--- a/.agents/skills/orch/scripts/lib/lane-context.sh
+++ b/.agents/skills/orch/scripts/lib/lane-context.sh
@@ -57,9 +57,10 @@ set -euo pipefail
 # running less, vim or git log still holds the old footer and passes any
 # not-a-shell test. `[a-z0-9]*claude` covers the per-account wrappers this
 # fleet launches through — nclaude, dclaude, 1claude — which exec the real
-# binary, and agent-confine is the launcher they exec through. Anything else
-# is refused BY NAME, so a harness missing from this list reads as a named
-# refusal in the report rather than as a lane that stopped being measured.
+# binary, and agent-confine is the launcher both harnesses exec through, so
+# it names neither. Anything else is refused BY NAME, so a harness missing
+# from this list reads as a named refusal in the report rather than as a lane
+# that stopped being measured.
 LANE_CONTEXT_HARNESSES='[a-z0-9]*claude|codex|pi|agent-confine'
 
 # Shells choose the refusal's wording and nothing else: a pane back at its
@@ -87,10 +88,11 @@ lane_context_emit() {
 
 # Read one context figure from a captured screen on stdin. $1 is the pane's
 # foreground process, and it decides which shape is offered: `codex` the codex
-# shape alone, a claude wrapper spelling or `agent-confine` the claude shape
-# alone. Anything else — `pi`, or an empty name for a pane that has left the
-# enumeration — is offered both, because a reader with no rule for a harness
-# has nothing better than the shapes themselves. Prints
+# shape alone, a claude wrapper spelling the claude shape alone. Anything else
+# is offered both, because a reader with no rule for a harness has nothing
+# better than the shapes themselves — `pi`, an empty name for a pane that has
+# left the enumeration, and `agent-confine`, which is the launcher BOTH
+# harnesses exec through and so names neither. Prints
 # `<harness>\t<used percent>`; exits 1 when the shape offered found nothing.
 #
 # The codex shape is offered the FINAL NON-EMPTY line and no other. The
@@ -138,7 +140,7 @@ lane_context_parse() {
   local out shape="both"
   case "${1:-}" in
     codex) shape="codex" ;;
-    *claude | agent-confine) shape="claude" ;;
+    *claude) shape="claude" ;;
   esac
   out="$(awk -v shape="$shape" '
     {
@@ -233,7 +235,7 @@ lane_context_collect() {
       if ! parsed="$(lane_context_parse "$cmd" <<<"$screen")"; then
         case "$cmd" in
           codex) detail="the screen does not end in a codex status line; whatever moved it — a dialog over the footer, a redraw caught mid-frame — is covering the figure" ;;
-          *claude | agent-confine) detail="the screen carries no claude status line" ;;
+          *claude) detail="the screen carries no claude status line" ;;
           *) detail="the screen carries neither harness's context figure" ;;
         esac
         lane_context_emit "$lane" "$pane" "$cfg" "$("$alias_fn" "$cfg")" "" "" \

--- a/.agents/skills/orch/scripts/lib/lane-context.sh
+++ b/.agents/skills/orch/scripts/lib/lane-context.sh
@@ -86,14 +86,27 @@ lane_context_emit() {
     }'
 }
 
+# The shape a pane's foreground process ($1) offers, decided here and in no
+# other place: `codex` the codex shape alone, a claude wrapper spelling the
+# claude shape alone, and anything else `both`, because a reader with no rule
+# for a harness has nothing better than the shapes themselves — `pi`, an empty
+# name for a pane that has left the enumeration, and `agent-confine`, which is
+# the launcher BOTH harnesses exec through and so names neither. Reading the
+# screen and refusing it both select on this answer, so a wrapper spelling
+# added to one list and not the other cannot read one harness's screen and
+# name the other's in its refusal.
+lane_context_shape() {
+  case "${1:-}" in
+    codex) printf 'codex\n' ;;
+    *claude) printf 'claude\n' ;;
+    *) printf 'both\n' ;;
+  esac
+}
+
 # Read one context figure from a captured screen on stdin. $1 is the pane's
-# foreground process, and it decides which shape is offered: `codex` the codex
-# shape alone, a claude wrapper spelling the claude shape alone. Anything else
-# is offered both, because a reader with no rule for a harness has nothing
-# better than the shapes themselves — `pi`, an empty name for a pane that has
-# left the enumeration, and `agent-confine`, which is the launcher BOTH
-# harnesses exec through and so names neither. Prints
-# `<harness>\t<used percent>`; exits 1 when the shape offered found nothing.
+# foreground process, which `lane_context_shape` turns into the shape offered.
+# Prints `<harness>\t<used percent>`; exits 1 when the shape offered found
+# nothing.
 #
 # The codex shape is offered the FINAL NON-EMPTY line and no other. The
 # claude shape is offered every line and its LAST match wins; no window is
@@ -137,11 +150,8 @@ lane_context_emit() {
 # context figure and is dropped rather than reported, whichever shape carried
 # it.
 lane_context_parse() {
-  local out shape="both"
-  case "${1:-}" in
-    codex) shape="codex" ;;
-    *claude) shape="claude" ;;
-  esac
+  local out shape
+  shape="$(lane_context_shape "${1:-}")"
   out="$(awk -v shape="$shape" '
     {
       if ($0 ~ /[^ \t]/) last = $0
@@ -233,9 +243,9 @@ lane_context_collect() {
         continue
       fi
       if ! parsed="$(lane_context_parse "$cmd" <<<"$screen")"; then
-        case "$cmd" in
+        case "$(lane_context_shape "$cmd")" in
           codex) detail="the screen does not end in a valid codex context figure; the last non-empty row is the only row a codex reading is taken from" ;;
-          *claude) detail="the screen carries no claude status line" ;;
+          claude) detail="the screen carries no claude status line" ;;
           *) detail="the screen carries neither harness's context figure" ;;
         esac
         lane_context_emit "$lane" "$pane" "$cfg" "$("$alias_fn" "$cfg")" "" "" \

--- a/.agents/skills/orch/scripts/lib/lane-context.sh
+++ b/.agents/skills/orch/scripts/lib/lane-context.sh
@@ -94,11 +94,12 @@ lane_context_emit() {
 # nothing alphanumeric — and what may follow it is another status item behind
 # a separator, never running text. `Documentation: Context 60% used means
 # compact now` fails the opening; `Context 60% used means compact now` fails
-# the end; and `Context 60% used · and that is an example` fails it too,
-# because a trailing item is capped at three tokens — the longest status item
-# this reader has seen (`Opus 5 41%`) — where a sentence is longer. Each is a
-# fragment a bottom-most rule would otherwise let take the verdict from the
-# real line above it.
+# the end. A trailing item is matched by SHAPE, not by token count: codex
+# puts its working directory there, so each item behind a separator is one
+# whitespace-free path — `/…` or `~/…`, ellipsised where the width runs out.
+# A count admits whatever is short enough, and `Context 60% used · compact
+# now` is two words: it is prose the reader took for a status line, and under
+# a bottom-most rule it took the verdict from the real line above it.
 # The codex shape is tested first and consumes its line, so a screen carrying
 # both never takes the claude direction for a codex reading. Codex's status
 # item is user-configured and both directions ship, so both are matched and
@@ -109,7 +110,7 @@ lane_context_parse() {
   out="$(awk '
     {
       low = tolower($0)
-      if (match(low, /^[^a-z0-9]*context:?[ \t]+[0-9]+%[ \t]+(left|used)([ \t]+(·|[|])[ \t]+[^ \t]+([ \t]+[^ \t]+){0,2})?[ \t]*$/)) {
+      if (match(low, /^[^a-z0-9]*context:?[ \t]+[0-9]+%[ \t]+(left|used)([ \t]+(·|[|])[ \t]+[~\/][^ \t]*)*[ \t]*$/)) {
         s = substr(low, RSTART, RLENGTH)
         match(s, /[0-9]+%[ \t]+(left|used)/)
         s = substr(s, RSTART, RLENGTH)

--- a/.agents/skills/orch/scripts/lib/lane-context.sh
+++ b/.agents/skills/orch/scripts/lib/lane-context.sh
@@ -13,15 +13,32 @@
 # which harness a pane runs. Both are reported as CONTEXT_USED_PCT: one
 # direction, and a rising number always means a fuller context.
 #
-# WHERE the status line sits is not a line count. Claude draws ONE ROW PER
-# RUNNING AGENT below it, so the footer grows with the fleet — and the
-# deepest footers belong to the orchestrating lanes, the ones this
-# measurement exists for. The whole captured screen is read and the
-# BOTTOM-MOST reading wins: anything above it is an earlier render of the
-# same lane, from before it compacted. Bottom-most is safe only because a
-# reading is a whole STATUS LINE and never a fragment prose can carry too:
-# otherwise the lowest sentence naming a model and a percentage beats the
-# real status line above it.
+# WHERE the status line sits differs by harness, and that is what decides
+# how each one is found.
+#
+# Codex draws its status line LAST. In every captured pane it is the final
+# non-empty row, with blank rows and nothing else below it, so the codex
+# reading is taken from that row and from no other row on the screen. A
+# final row that is not a status line is no reading at all, never a search
+# up the transcript for something shaped like one. POSITION carries that
+# refusal because shape cannot: codex's status items are user-configured
+# (`[tui].status_line` — model with reasoning, git branch, project name,
+# codex version, tokens used, working directory), and `gpt-5.6-sol default`
+# is a configured item while `compact now` is a sentence about compaction,
+# and the two are the same shape. A reader that refuses what it does not
+# recognise leaves the lane unmeasured, and an unmeasured lane is never
+# compacted — which is the outcome compaction exists to prevent. So what
+# follows the separator is taken as it comes.
+#
+# Claude draws ONE ROW PER RUNNING AGENT below its status line, so the
+# footer grows with the fleet — and the deepest footers belong to the
+# orchestrating lanes, the ones this measurement exists for. Its status line
+# is never the final row, so the claude reading is the BOTTOM-MOST whole-line
+# match instead: anything above it is an earlier render of the same lane,
+# from before it compacted. Bottom-most is safe only because a reading is a
+# whole STATUS LINE and never a fragment prose can carry too: otherwise the
+# lowest sentence naming a model and a percentage beats the real status line
+# above it.
 #
 # A screen that outlived its harness is refused rather than measured, and
 # that refusal takes positive evidence, never distance: the pane's
@@ -71,9 +88,13 @@ lane_context_emit() {
 # Read one context figure from a captured screen on stdin. Prints
 # `<harness>\t<used percent>`; exits 1 when the screen carries neither shape.
 #
-# Every line is offered and the LAST match wins. No window is taken off the
-# bottom: the footer under the status line is one row per running agent and
-# has no bound, so any count would lose exactly the busiest lanes.
+# The codex shape is offered the FINAL NON-EMPTY line and no other. The
+# claude shape is offered every line and its LAST match wins; no window is
+# taken off the bottom, because the footer under a claude status line is one
+# row per running agent and has no bound, so any count would lose exactly the
+# busiest lanes. A final line that carries the codex shape settles the
+# reading, out of range included: falling through to a claude match higher up
+# would be the search the position rule exists to refuse.
 #
 # Matching is done on a lowercased copy of each line: a model name is a word,
 # and the harness spells it differently in different places. The claude
@@ -89,45 +110,50 @@ lane_context_emit() {
 # command (`/rc`) — never running text. The branch parenthetical is optional:
 # a lane outside a repository has none, and a session that has not rendered a
 # percentage yet matches nothing at all.
-# The codex reading is a WHOLE LINE at both ends for the same reason: the
-# context item OPENS its line — leading whitespace or box decoration only,
-# nothing alphanumeric — and what may follow it is another status item behind
-# a separator, never running text. `Documentation: Context 60% used means
-# compact now` fails the opening; `Context 60% used means compact now` fails
-# the end. A trailing item is matched by SHAPE, not by token count: codex
-# puts its working directory there, so each item behind a separator is one
-# whitespace-free path — `/…` or `~/…`, ellipsised where the width runs out.
-# A count admits whatever is short enough, and `Context 60% used · compact
-# now` is two words: it is prose the reader took for a status line, and under
-# a bottom-most rule it took the verdict from the real line above it.
-# The codex shape is tested first and consumes its line, so a screen carrying
-# both never takes the claude direction for a codex reading. Codex's status
-# item is user-configured and both directions ship, so both are matched and
-# only `left` is converted. A percentage over 100 is not a context figure and
-# is dropped rather than reported, whichever shape carried it.
+# The codex reading is a WHOLE LINE at its OPENING and takes what follows as
+# it comes. The context item opens the line — leading whitespace or box
+# decoration only, nothing alphanumeric — so `Documentation: Context 60% used
+# means compact now` is not one, and `Context 60% used means compact now`
+# needs the separator its configured items are drawn behind. Past that
+# separator the line is read no further. Every candidate for the job — a path
+# (`/var/tmp/…`), a model with its reasoning effort (`gpt-5.6-sol default`), a
+# git branch, a project name, a version, a token count — is one to three bare
+# words, and so is a sentence's opening; a shape that admits the ones this
+# reader has seen and refuses the rest refuses configured status lines it has
+# not seen, and leaves those lanes unmeasured. Position is what keeps prose
+# out, so the shape does not have to try.
+# Codex's status item is user-configured and both directions ship, so both
+# are matched and only `left` is converted. A percentage over 100 is not a
+# context figure and is dropped rather than reported, whichever shape carried
+# it.
 lane_context_parse() {
   local out
   out="$(awk '
     {
+      if ($0 ~ /[^ \t]/) last = $0
       low = tolower($0)
-      if (match(low, /^[^a-z0-9]*context:?[ \t]+[0-9]+%[ \t]+(left|used)([ \t]+(·|[|])[ \t]+[~\/][^ \t]*)*[ \t]*$/)) {
+      if (match(low, /^[ \t]*[^ \t()]+([ \t]+\([^)]*\))?[ \t]+(opus|sonnet|haiku|fable)[ \t]+[0-9]+(\.[0-9]+)?([ \t]*\([^)]*\))?[ \t]+[0-9]+%[ \t]+\([^) \t]+\)([ \t]+\/[^ \t]*)*[ \t]*$/)) {
+        s = substr(low, RSTART, RLENGTH)
+        match(s, /[0-9]+%[ \t]+\([^) \t]+\)/)
+        s = substr(s, RSTART, RLENGTH)
+        sub(/%.*$/, "", s)
+        if (s != "" && s + 0 <= 100) { c_found = 1; c_used = s + 0 }
+      }
+    }
+    END {
+      low = tolower(last)
+      if (match(low, /^[^a-z0-9]*context:?[ \t]+[0-9]+%[ \t]+(left|used)([ \t]+(·|[|])[ \t]+[^ \t].*)?[ \t]*$/)) {
+        codex_line = 1
         s = substr(low, RSTART, RLENGTH)
         match(s, /[0-9]+%[ \t]+(left|used)/)
         s = substr(s, RSTART, RLENGTH)
         remaining = (s ~ /left$/)
         gsub(/[^0-9]/, "", s)
         if (s + 0 <= 100) { harness = "codex"; used = remaining ? 100 - (s + 0) : s + 0 }
-        next
       }
-      if (match(low, /^[ \t]*[^ \t()]+([ \t]+\([^)]*\))?[ \t]+(opus|sonnet|haiku|fable)[ \t]+[0-9]+(\.[0-9]+)?([ \t]*\([^)]*\))?[ \t]+[0-9]+%[ \t]+\([^) \t]+\)([ \t]+\/[^ \t]*)*[ \t]*$/)) {
-        s = substr(low, RSTART, RLENGTH)
-        match(s, /[0-9]+%[ \t]+\([^) \t]+\)/)
-        s = substr(s, RSTART, RLENGTH)
-        sub(/%.*$/, "", s)
-        if (s != "" && s + 0 <= 100) { harness = "claude"; used = s + 0 }
-      }
+      if (!codex_line && c_found) { harness = "claude"; used = c_used }
+      if (harness != "") printf "%s\t%d\n", harness, used
     }
-    END { if (harness != "") printf "%s\t%d\n", harness, used }
   ')"
   [[ -n "$out" ]] || return 1
   printf '%s\n' "$out"

--- a/.agents/skills/orch/scripts/lib/lane-context.sh
+++ b/.agents/skills/orch/scripts/lib/lane-context.sh
@@ -234,7 +234,7 @@ lane_context_collect() {
       fi
       if ! parsed="$(lane_context_parse "$cmd" <<<"$screen")"; then
         case "$cmd" in
-          codex) detail="the screen does not end in a codex status line; whatever moved it — a dialog over the footer, a redraw caught mid-frame — is covering the figure" ;;
+          codex) detail="the screen does not end in a valid codex context figure; the last non-empty row is the only row a codex reading is taken from" ;;
           *claude) detail="the screen carries no claude status line" ;;
           *) detail="the screen carries neither harness's context figure" ;;
         esac

--- a/.agents/skills/orch/tests/lanes_context.sh
+++ b/.agents/skills/orch/tests/lanes_context.sh
@@ -13,9 +13,12 @@
 # different places. Codex draws it LAST, so the codex reading comes from the
 # final non-empty line and from no other. Claude draws a row per running
 # agent BELOW its status line, so its footer has no bound and its reading is
-# the bottom-most whole-line match. Case 1's screen is a real
-# `tmux capture-pane`; the other claude screens are built from real status
-# lines. Cases hold each half shut, one per mutation:
+# the bottom-most whole-line match. WHICH rule a pane gets comes from the
+# pane's own foreground process, never from what is on the screen: this fleet
+# pastes both harnesses' screens into both harnesses' terminals all day, and
+# the panes here carry a process per case for that reason. Case 1's screen is
+# a real `tmux capture-pane`; the other claude screens are built from real
+# status lines. Cases hold each half shut, one per mutation:
 #   case 1  an orchestrating lane's real footer, whose final line is an agent
 #           row — dies the moment the claude reading is taken by position
 #           too, or any bottom window narrower than the footer is taken off
@@ -32,6 +35,12 @@
 #   case 24 a configured status item that is not a working directory — dies
 #           the moment the codex shape judges what follows the separator,
 #           because no shape separates a configured item from a sentence
+#   case 26 a codex pane on a dialog with a claude status line in its
+#           transcript — dies the moment a codex pane can reach the claude
+#           shape, which is the one way the fail-closed rule was bypassed
+#   case 27 a claude pane quoting a codex status line on its final row —
+#           dies the moment the harness is inferred from the screen instead
+#           of taken from the pane
 #   case 13 a pane that exited to its shell — dies if the liveness evidence
 #           is dropped, which is the only thing a window ever stood in for
 #
@@ -43,9 +52,9 @@
 #   3. the bottom-most claude reading wins over one repainted past
 #   4. a screen with neither shape is no_status_line, never 0
 #   5. a pane that cannot be captured is unreadable, never 0
-#   6. a percentage over 100 is not a context figure, in either shape, and a
-#      codex line carrying one settles the reading rather than falling
-#      through to a claude match higher up
+#   6. a percentage over 100 is not a context figure, in either shape, and on
+#      a pane offered both shapes a codex line carrying one settles the
+#      reading rather than falling through to a claude match higher up
 #   7. the table names the direction it reports, in its header and its rows
 #   8. an empty fleet says so; an unreadable claim store refuses
 #   9. the account column names the lane the pane runs under
@@ -74,6 +83,9 @@
 #  24. the configured status items `[tui].status_line` draws are accepted,
 #      one item or several, none of them a working directory
 #  25. every committed codex capture parses to the figure on its screen
+#  26. a codex pane that does not end in a codex status line carries no
+#      reading, whatever its transcript holds, and says what it could not read
+#  27. a claude pane is read by the claude shape however its screen ends
 #
 # errexit is on: every case here either succeeds or is guarded, so an
 # unexpected non-zero is a broken fixture, not a finding to print past.
@@ -199,8 +211,12 @@ echo "=== lanes context ==="
 
 # Foreground process per pane. %9 is the one that exited to its shell.
 {
-  for n in 1 2 3 4 5 10 13 14 15 16 21; do printf '%s %%%s claude\n' "$LIVE_PID" "$n"; done
-  for n in 6 7 8 19 20 22 23; do printf '%s %%%s codex\n' "$LIVE_PID" "$n"; done
+  for n in 1 3 4 5 10 13 14 15 16 21 26; do printf '%s %%%s claude\n' "$LIVE_PID" "$n"; done
+  for n in 2 6 7 8 19 20 22 23 24 25; do printf '%s %%%s codex\n' "$LIVE_PID" "$n"; done
+  # 6, both-shapes arm. `pi` is a harness this reader measures and has no
+  # shape rule for, so both are offered and the fall-through guard is
+  # reachable — the only place it still is.
+  printf '%s %%27 pi\n' "$LIVE_PID"
   printf '%s %%9 fish\n' "$LIVE_PID"
   # tmux reports a login shell with the leading dash it was started with.
   printf '%s %%11 -bash\n' "$LIVE_PID"
@@ -235,6 +251,10 @@ write_claim twentyone "%20" "$H/.codex"  "ken-121"
 write_claim twentytwo   "%21" "$H/.claude" "ken-122"
 write_claim twentythree "%22" "$H/.codex"  "ken-123"
 write_claim twentyfour  "%23" "$H/.codex"  "ken-124"
+write_claim twentyfive  "%24" "$H/.codex"  "ken-125"
+write_claim twentysix   "%25" "$H/.codex"  "ken-126"
+write_claim twentyseven "%26" "$H/.claude" "ken-127"
+write_claim twentyeight "%27" "$H/.codex"  "ken-128"
 # The foreign lane's pane NUMBER exists here too, on a screen that parses
 # cleanly: %1 is ken-101's, reading 35.
 write_claim_on "$FOREIGN_PID" foreign "%1" "$H/.claude" "ken-110"
@@ -275,11 +295,7 @@ screen 4 'plain shell output with no harness status line'
 screen 6 '  Codex is working
   Context 40% used'
 screen 7 '  Context 86% left · Opus 5 41%'
-# 6, codex arm. The claude status line above is what a fall-through would
-# find: a codex line the reader cannot use is a refusal, not a reason to go
-# looking further up the screen.
-screen 8 '  kendex (🌳 ken-108) Opus 5 35% (brad@drovr.dev)     /rc
-  Context 140% left'
+screen 8 '  Context 140% left'
 screen 9 '  kendex (🌳 ken-109) Opus 5 41% (brad@drovr.dev)     /rc
   ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents
 $ git status
@@ -359,6 +375,36 @@ screen 21 '  kendex (🌳 ken-122) Opus 5 41% (brad@drovr.dev)     /rc
 # an unmeasured lane, which the overseer never compacts.
 screen 22 '  Context 100% left · gpt-5.6-sol default'
 screen 23 '  Context 78% left · gpt-5.6-sol default · ken-885 · kendex · 0.151.0'
+# 26. A codex pane with a dialog over its footer, and a claude status line in
+# the transcript above — this fleet pastes both harnesses' screens into both
+# harnesses' terminals, so that line is ordinary here. %24 has a real codex
+# status line above the dialog and %25 has none, and the two must agree: the
+# dialog is covering whatever the lane is showing now, so neither is a
+# reading. Falling through to the claude shape answers with the wrong harness
+# AND the wrong number, and finding the covered status line by searching past
+# the dialog answers with a figure the lane has moved on from.
+screen 24 '  Codex is working
+  kendex (🌳 ken-125) Opus 5 35% (brad@drovr.dev)     /rc
+  Context 86% left
+  Press enter to continue'
+screen 25 '  Codex is working
+  kendex (🌳 ken-126) Opus 5 35% (brad@drovr.dev)     /rc
+  Press enter to continue'
+# 27. The same confusion the other way round. A claude pane whose final row
+# quotes a codex status line is still a claude lane, and reading it as codex
+# reports 14 used for a lane that is 41 used. Which harness a pane runs is the
+# caller's to say; the screen cannot be asked.
+screen 26 '  kendex (🌳 ken-127) Opus 5 41% (brad@drovr.dev)     /rc
+  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents
+● A codex lane prints:
+  Context 86% left'
+# 6, both-shapes arm. A pane running a harness with no shape rule is offered
+# both, and there the codex line on the final row still settles the reading:
+# out of range, it is a refusal, not a reason to take the claude status line
+# above it. That fall-through is unreachable on a codex pane, where the claude
+# shape is never offered at all.
+screen 27 '  kendex (🌳 ken-128) Opus 5 35% (brad@drovr.dev)     /rc
+  Context 140% left'
 
 OUT="$(run_ctx --json)"
 
@@ -405,12 +451,15 @@ assert_eq "$(jq -r '.[] | select(.lane=="ken-107") | .harness' <<<"$OUT")" "code
   "the context item at the line's opening is what names the harness"
 
 # 6 (codex arm). Over 100 is not a context figure in either shape: unguarded,
-# the conversion turns 140 left into -40 used. The claude status line sitting
-# above it is what a fall-through would report instead — 35, from a line the
-# screen does not end on — so the codex line settles the reading either way.
+# the conversion turns 140 left into -40 used. %27 is the same line on a pane
+# whose harness has no shape rule, where both shapes ARE offered: the claude
+# status line above it is what a fall-through would report instead, 35, from a
+# line the screen does not end on.
 assert_eq "$(jq -r '.[] | select(.lane=="ken-108") | .status' <<<"$OUT")" "no_status_line" \
   "a codex percentage over 100 is not read as a context figure"
 assert_eq "$(jq -r '.[] | select(.lane=="ken-108") | .context_used_pct' <<<"$OUT")" "null" \
+  "an out-of-range codex reading carries no number"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-128") | .context_used_pct' <<<"$OUT")" "null" \
   "an out-of-range codex line refuses rather than falling through to a match above it"
 
 # 13. The pane exited to its shell. Its last render is still on the screen and
@@ -521,6 +570,33 @@ assert_eq "$(jq -r '.[] | select(.lane=="ken-124") | .context_used_pct' <<<"$OUT
 assert_eq "$(jq -r '.[] | select(.lane=="ken-124") | .status' <<<"$OUT")" "ok" \
   "several items behind the separator are not a reason to refuse the lane"
 
+# 26. THE fail-closed rule, held shut against the one thing that bypassed it:
+# a claude-shaped line in a codex pane's transcript. The claude shape is not
+# offered on a codex pane at all, so both screens refuse — the one whose
+# status line the dialog covers and the one that has none. Bottom-most
+# recovered the covered line and answered 14; the claude fallback answered
+# claude 35. Neither is what the lane is showing.
+assert_eq "$(jq -r '.[] | select(.lane=="ken-125") | .status' <<<"$OUT")" "no_status_line" \
+  "a dialog over a codex footer is could-not-tell, not the status line it covers"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-125") | .context_used_pct' <<<"$OUT")" "null" \
+  "a claude-shaped line in a codex pane's transcript is not a reading"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-125") | .harness' <<<"$OUT")" "null" \
+  "and it does not put the wrong harness in the report either"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-126") | .status' <<<"$OUT")" "no_status_line" \
+  "the same pane with no codex status line at all answers the same way"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-126") | .context_used_pct' <<<"$OUT")" "null" \
+  "the two halves agree rather than differing by what sits above the dialog"
+assert_contains "$(jq -r '.[] | select(.lane=="ken-125") | .detail' <<<"$OUT")" "does not end in a codex status line" \
+  "the refusal names what it could not read, not a missing figure of either shape"
+
+# 27. And the same confusion in the other direction. A codex status line
+# quoted in a claude pane's transcript is not this lane's reading, whatever
+# row it lands on.
+assert_eq "$(jq -r '.[] | select(.lane=="ken-127") | .context_used_pct' <<<"$OUT")" "41" \
+  "a codex status line quoted on a claude pane does not take the lane's reading"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-127") | .harness' <<<"$OUT")" "claude" \
+  "the pane's own harness is what names the reading"
+
 # 25. Every committed codex capture, parsed as it stands. These are real
 # `tmux capture-pane` output from Codex 0.151.0 (KEN-863), and they are the
 # evidence the position rule rests on: in all four that carry a status line
@@ -531,7 +607,7 @@ assert_eq "$(jq -r '.[] | select(.lane=="ken-124") | .status' <<<"$OUT")" "ok" \
 FIXTURES="$TEST_DIR/fixtures/oversee-watch"
 
 parse_fixture() { # <capture file name>
-  "$BASH" -c 'source "$1"; lane_context_parse <"$2"' _ \
+  "$BASH" -c 'source "$1"; lane_context_parse codex <"$2"' _ \
     "$SCRIPTS_DIR/lib/lane-context.sh" "$FIXTURES/$1" || printf 'none\n'
 }
 
@@ -565,6 +641,8 @@ assert_eq "$(jq -r '.[] | select(.lane=="ken-104") | .status' <<<"$OUT")" "no_st
   "a screen with neither shape is no_status_line"
 assert_eq "$(jq -r '.[] | select(.lane=="ken-104") | .context_used_pct' <<<"$OUT")" "null" \
   "a lane with no status line carries no number"
+assert_contains "$(jq -r '.[] | select(.lane=="ken-104") | .detail' <<<"$OUT")" "no claude status line" \
+  "the refusal names the shape that pane was read for, not both shapes"
 
 write_claim five "%5" "$H/.claude" "ken-105"
 UNREAD="$(run_ctx --json)"

--- a/.agents/skills/orch/tests/lanes_context.sh
+++ b/.agents/skills/orch/tests/lanes_context.sh
@@ -27,6 +27,9 @@
 #   case 22 the same sentence in the CODEX shape, which carries its fragment
 #           in ordinary prose about compaction — dies the moment the codex
 #           branch is loosened back to matching anywhere in a line
+#   case 24 the same sentence two words long — dies the moment the codex
+#           trailing item is admitted by token COUNT rather than by shape,
+#           which is how `compact now` passed for a status item
 #   case 13 a pane that exited to its shell — dies if the liveness evidence
 #           is dropped, which is the only thing a window ever stood in for
 #
@@ -44,7 +47,8 @@
 #  10. a claim on ANOTHER tmux server is unreadable, never a local pane's
 #      number under its name
 #  11. codex's other status item, `Context 40% used`, is taken as it stands
-#  12. one line carrying both shapes reads as codex, not claude
+#  12. a claude status item behind the codex separator is not a codex
+#      status line; the codex status item carries a path and nothing else
 #  13. a pane that has exited to its shell is not measured from what it left
 #  14. a model and a percentage in prose is not a status line
 #  15. an unenumerable tmux server refuses every claim, not just foreign ones
@@ -62,6 +66,8 @@
 #  22. a codex context fragment in prose is not a status line, alone or
 #      below a real one
 #  23. the table still carries every row where `column` is not installed
+#  24. two words behind the codex separator are prose, not a status item
+#  25. every committed codex capture parses to the figure on its screen
 #
 # errexit is on: every case here either succeeds or is guarded, so an
 # unexpected non-zero is a broken fixture, not a finding to print past.
@@ -188,7 +194,7 @@ echo "=== lanes context ==="
 # Foreground process per pane. %9 is the one that exited to its shell.
 {
   for n in 1 2 3 4 5 10 13 14 15 16 21; do printf '%s %%%s claude\n' "$LIVE_PID" "$n"; done
-  for n in 6 7 8 19 20 22; do printf '%s %%%s codex\n' "$LIVE_PID" "$n"; done
+  for n in 6 7 8 19 20 22 23; do printf '%s %%%s codex\n' "$LIVE_PID" "$n"; done
   printf '%s %%9 fish\n' "$LIVE_PID"
   # tmux reports a login shell with the leading dash it was started with.
   printf '%s %%11 -bash\n' "$LIVE_PID"
@@ -222,6 +228,7 @@ write_claim twenty    "%19" "$H/.codex"  "ken-120"
 write_claim twentyone "%20" "$H/.codex"  "ken-121"
 write_claim twentytwo   "%21" "$H/.claude" "ken-122"
 write_claim twentythree "%22" "$H/.codex"  "ken-123"
+write_claim twentyfour  "%23" "$H/.codex"  "ken-124"
 # The foreign lane's pane NUMBER exists here too, on a screen that parses
 # cleanly: %1 is ken-101's, reading 35.
 write_claim_on "$FOREIGN_PID" foreign "%1" "$H/.claude" "ken-110"
@@ -317,9 +324,9 @@ screen 19 '  Codex is working
   Context 86% left
 ● Documentation: Context 60% used means compact now'
 screen 20 '● Documentation: Context 60% used means compact now'
-# 23 and 24. The other end of the same fragment. Prose can put the sentence
-# AFTER the status shape as easily as before it, and then the status-shaped
-# PREFIX is what matches while the sentence it sits inside never has to. Both
+# 22, trailing half. The other end of the same fragment. Prose can put the
+# sentence AFTER the status shape as easily as before it, and then the
+# status-shaped PREFIX matches while the sentence it sits in never has to. Both
 # screens put that line BELOW a real status line, which is where bottom-most
 # hands it the verdict.
 screen 21 '  kendex (🌳 ken-122) Opus 5 41% (brad@drovr.dev)     /rc
@@ -328,6 +335,15 @@ screen 21 '  kendex (🌳 ken-122) Opus 5 41% (brad@drovr.dev)     /rc
 screen 22 '  Context 86% left
 ● Context 77% used means compact now
 ● Context 77% used · and that is an example'
+# 24. The reproduction from KEN-885, and the shortest sentence of the class:
+# two words behind the separator. A trailing item admitted by token COUNT
+# takes `compact now` for a status item, and bottom-most then reports 60 used
+# for a lane that is 14 used — the overseer compacts the emptiest lane in the
+# fleet and skips the full one. Codex puts its working directory behind that
+# separator, so the item is matched by that shape and a sentence of any
+# length fails it.
+screen 23 'Context 86% left
+Context 60% used · compact now'
 
 OUT="$(run_ctx --json)"
 
@@ -361,13 +377,15 @@ assert_eq "$(jq -r '.[] | select(.lane=="ken-106") | .context_used_pct' <<<"$OUT
 assert_eq "$(jq -r '.[] | select(.lane=="ken-106") | .harness' <<<"$OUT")" "codex" \
   "the codex used shape names the codex harness"
 
-# 12. One line carrying both shapes. The codex branch consumes its line, so
-# the claude branch never re-reads it in the opposite direction: without that,
-# this screen reports 41 used for a lane that is 14 used.
-assert_eq "$(jq -r '.[] | select(.lane=="ken-107") | .context_used_pct' <<<"$OUT")" "14" \
-  "a line carrying both shapes is read as codex"
-assert_eq "$(jq -r '.[] | select(.lane=="ken-107") | .harness' <<<"$OUT")" "codex" \
-  "the codex shape wins the line it matched"
+# 12. `Opus 5 41%` is a claude status item, and behind the codex separator it
+# is not a status line of either harness: codex draws its working directory
+# there and nothing else, and the claude shape needs an account parenthetical
+# this line has none of. A trailing item admitted by token count took it for a
+# codex reading, which is the same allowance `compact now` walked through.
+assert_eq "$(jq -r '.[] | select(.lane=="ken-107") | .status' <<<"$OUT")" "no_status_line" \
+  "a claude status item behind the codex separator is not a codex status line"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-107") | .context_used_pct' <<<"$OUT")" "null" \
+  "that lane carries no number, not the one that shape carried"
 
 # 6 (codex arm). Over 100 is not a context figure in either shape: unguarded,
 # the conversion turns 140 left into -40 used.
@@ -459,15 +477,48 @@ assert_eq "$(jq -r '.[] | select(.lane=="ken-121") | .status' <<<"$OUT")" "no_st
 assert_eq "$(jq -r '.[] | select(.lane=="ken-121") | .context_used_pct' <<<"$OUT")" "null" \
   "that lane carries no number, not the sentence's"
 
-# 23 and 24. The trailing half of the same class: a status-shaped PREFIX with
-# prose after it. The claude line ends in its account and claude's own
-# right-hand hint; the codex line ends in its context item or one short
-# status item behind a separator. Neither end admits a sentence, so the real
-# status line above keeps the verdict.
+# 22, trailing half. A status-shaped PREFIX with prose after it. The claude
+# line ends in its account and claude's own right-hand hint; the codex line
+# ends in its context item or a working directory behind a separator. Neither
+# end admits a sentence, so the real status line above keeps the verdict.
 assert_eq "$(jq -r '.[] | select(.lane=="ken-122") | .context_used_pct' <<<"$OUT")" "41" \
   "claude prose after a status-shaped prefix does not outrank the status line above it"
 assert_eq "$(jq -r '.[] | select(.lane=="ken-123") | .context_used_pct' <<<"$OUT")" "14" \
   "codex prose after a status-shaped prefix does not outrank the status line above it"
+
+# 24. The reproduction from KEN-885. Two words behind the separator is the
+# shortest sentence of this class and the one a token count cannot refuse:
+# the lane has 14 used and the report called it 60, so the overseer compacted
+# the emptiest lane in the fleet and left the full one running.
+assert_eq "$(jq -r '.[] | select(.lane=="ken-124") | .context_used_pct' <<<"$OUT")" "14" \
+  "two words behind the codex separator are prose, not a status item"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-124") | .harness' <<<"$OUT")" "codex" \
+  "the real status line above keeps the verdict, and the harness with it"
+
+# 25. Every committed codex capture, parsed as it stands. These are real
+# `tmux capture-pane` output from Codex 0.151.0 (KEN-863), so what the reader
+# anchors to is what the harness draws: `Context <N>% left`, a separator, and
+# the session's working directory, ellipsised where the width ran out. A
+# capture whose screen carries no status line is a refusal, never a zero.
+FIXTURES="$TEST_DIR/fixtures/oversee-watch"
+
+parse_fixture() { # <capture file name>
+  "$BASH" -c 'source "$1"; lane_context_parse <"$2"' _ \
+    "$SCRIPTS_DIR/lib/lane-context.sh" "$FIXTURES/$1" || printf 'none\n'
+}
+
+assert_eq "$(parse_fixture codex-working.txt)" "$(printf 'codex\t0')" \
+  "the working capture reads 100% left as a context with nothing used"
+assert_eq "$(parse_fixture codex-composer-draft.txt)" "$(printf 'codex\t0')" \
+  "the composer-draft capture parses to the figure on its screen"
+assert_eq "$(parse_fixture codex-composer-idle.txt)" "$(printf 'codex\t0')" \
+  "the composer-idle capture parses to the figure on its screen"
+assert_eq "$(parse_fixture codex-idle-after-turn.txt)" "$(printf 'codex\t1')" \
+  "the idle-after-turn capture converts 99% left to 1 used"
+assert_eq "$(parse_fixture codex-dialog-model.txt)" "none" \
+  "a capture whose dialog covers the status line carries no reading"
+assert_eq "$(parse_fixture codex-dialog-trust.txt)" "none" \
+  "the trust-dialog capture carries no reading either"
 
 # 10. `capture-pane -t %N` answers from THIS server only, and pane ids restart
 # at %0 on each one. ken-110 claims %1 on another server; %1 here is ken-101's

--- a/.agents/skills/orch/tests/lanes_context.sh
+++ b/.agents/skills/orch/tests/lanes_context.sh
@@ -41,6 +41,9 @@
 #   case 27 a claude pane quoting a codex status line on its final row —
 #           dies the moment the harness is inferred from the screen instead
 #           of taken from the pane
+#   case 28 a codex lane whose pane command is the agent-confine wrapper —
+#           dies the moment that wrapper is read as a harness spelling
+#           instead of as the launcher both harnesses exec through
 #   case 13 a pane that exited to its shell — dies if the liveness evidence
 #           is dropped, which is the only thing a window ever stood in for
 #
@@ -86,6 +89,9 @@
 #  26. a codex pane that does not end in a codex status line carries no
 #      reading, whatever its transcript holds, and says what it could not read
 #  27. a claude pane is read by the claude shape however its screen ends
+#  28. the agent-confine wrapper names no harness, so a pane running it is
+#      offered both shapes and a wrapped codex lane is measured like any
+#      other
 #
 # errexit is on: every case here either succeeds or is guarded, so an
 # unexpected non-zero is a broken fixture, not a finding to print past.
@@ -217,6 +223,10 @@ echo "=== lanes context ==="
   # shape rule for, so both are offered and the fall-through guard is
   # reachable — the only place it still is.
   printf '%s %%27 pi\n' "$LIVE_PID"
+  # 28. agent-confine is the launcher BOTH harnesses exec through, so its
+  # pane command names neither and both shapes are offered. %28 is a wrapped
+  # codex lane, %29 a wrapped claude one, %30 a wrapped pane showing neither.
+  for n in 28 29 30; do printf '%s %%%s agent-confine\n' "$LIVE_PID" "$n"; done
   printf '%s %%9 fish\n' "$LIVE_PID"
   # tmux reports a login shell with the leading dash it was started with.
   printf '%s %%11 -bash\n' "$LIVE_PID"
@@ -255,6 +265,9 @@ write_claim twentyfive  "%24" "$H/.codex"  "ken-125"
 write_claim twentysix   "%25" "$H/.codex"  "ken-126"
 write_claim twentyseven "%26" "$H/.claude" "ken-127"
 write_claim twentyeight "%27" "$H/.codex"  "ken-128"
+write_claim twentynine  "%28" "$H/.codex"  "ken-129"
+write_claim thirty      "%29" "$H/.claude" "ken-130"
+write_claim thirtyone   "%30" "$H/.codex"  "ken-131"
 # The foreign lane's pane NUMBER exists here too, on a screen that parses
 # cleanly: %1 is ken-101's, reading 35.
 write_claim_on "$FOREIGN_PID" foreign "%1" "$H/.claude" "ken-110"
@@ -405,6 +418,20 @@ screen 26 '  kendex (🌳 ken-127) Opus 5 41% (brad@drovr.dev)     /rc
 # shape is never offered at all.
 screen 27 '  kendex (🌳 ken-128) Opus 5 35% (brad@drovr.dev)     /rc
   Context 140% left'
+# 28. A wrapped lane. Its pane command is `agent-confine`, which is what both
+# harnesses exec through, so it names neither and both shapes are offered.
+# %28 is a codex lane whose screen ends on its own status line: read for the
+# claude shape alone it is a refusal, and an unmeasured lane is one the
+# overseer never compacts. %29 holds the other half shut — a wrapped claude
+# lane under an agent-row footer, which the codex shape cannot reach because
+# that footer is what the screen ends on. %30 shows neither shape, and its
+# refusal names both.
+screen 28 '  Codex is working
+  Context 86% left'
+screen 29 '  kendex (🌳 ken-130) Opus 5 27% (brad@drovr.dev)     /rc
+  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← 1 agent
+  ◯ dev-ken-885  Follow workflow: .agents/skills/dev/workflo… 4m 2s'
+screen 30 'plain shell output with no harness status line'
 
 OUT="$(run_ctx --json)"
 
@@ -596,6 +623,24 @@ assert_eq "$(jq -r '.[] | select(.lane=="ken-127") | .context_used_pct' <<<"$OUT
   "a codex status line quoted on a claude pane does not take the lane's reading"
 assert_eq "$(jq -r '.[] | select(.lane=="ken-127") | .harness' <<<"$OUT")" "claude" \
   "the pane's own harness is what names the reading"
+
+# 28. The wrapper is not a harness spelling. Dispatched to the claude shape
+# alone, %28's perfectly good final row is a refusal and the lane goes
+# unmeasured — the outcome this reader exists to prevent, on the one pane
+# command a codex lane is as likely to present as a claude one. %29 is what
+# offering both shapes must not cost: the codex shape only ever sees the last
+# row, and a claude footer sits below the status line, so the wrapped claude
+# lane keeps its reading.
+assert_eq "$(jq -r '.[] | select(.lane=="ken-129") | .context_used_pct' <<<"$OUT")" "14" \
+  "a wrapped codex lane is read at the line its screen ends on"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-129") | .harness' <<<"$OUT")" "codex" \
+  "the wrapper names no harness; the shape that matched does"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-130") | .context_used_pct' <<<"$OUT")" "27" \
+  "a wrapped claude lane keeps its reading from under the agent-row footer"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-130") | .harness' <<<"$OUT")" "claude" \
+  "and is still named claude"
+assert_contains "$(jq -r '.[] | select(.lane=="ken-131") | .detail' <<<"$OUT")" "neither harness's context figure" \
+  "a wrapped pane showing neither shape is refused for both, not for claude alone"
 
 # 25. Every committed codex capture, parsed as it stands. These are real
 # `tmux capture-pane` output from Codex 0.151.0 (KEN-863), and they are the

--- a/.agents/skills/orch/tests/lanes_context.sh
+++ b/.agents/skills/orch/tests/lanes_context.sh
@@ -486,6 +486,8 @@ assert_eq "$(jq -r '.[] | select(.lane=="ken-108") | .status' <<<"$OUT")" "no_st
   "a codex percentage over 100 is not read as a context figure"
 assert_eq "$(jq -r '.[] | select(.lane=="ken-108") | .context_used_pct' <<<"$OUT")" "null" \
   "an out-of-range codex reading carries no number"
+assert_contains "$(jq -r '.[] | select(.lane=="ken-108") | .detail' <<<"$OUT")" "does not end in a valid codex context figure" \
+  "the refusal states what it checked, on the pane whose figure nothing is covering"
 assert_eq "$(jq -r '.[] | select(.lane=="ken-128") | .context_used_pct' <<<"$OUT")" "null" \
   "an out-of-range codex line refuses rather than falling through to a match above it"
 

--- a/.agents/skills/orch/tests/lanes_context.sh
+++ b/.agents/skills/orch/tests/lanes_context.sh
@@ -9,14 +9,16 @@
 # the overseer to compact the emptiest lane in the fleet, so the direction is
 # what these cases pin.
 #
-# Where the status line SITS is pinned too, and by property rather than by
-# count. Case 1's screen is a real `tmux capture-pane`; the other claude
-# screens are built from real status lines. The footer under a status line
-# grows by a row per running agent, so no line count reaches an
-# orchestrating lane's. Four cases hold that shut, each against a different
-# mutation:
-#   case 1  an orchestrating lane's real footer — dies the moment any bottom
-#           window narrower than it is taken off the screen
+# Where the status line SITS is pinned too, and the two harnesses put it in
+# different places. Codex draws it LAST, so the codex reading comes from the
+# final non-empty line and from no other. Claude draws a row per running
+# agent BELOW its status line, so its footer has no bound and its reading is
+# the bottom-most whole-line match. Case 1's screen is a real
+# `tmux capture-pane`; the other claude screens are built from real status
+# lines. Cases hold each half shut, one per mutation:
+#   case 1  an orchestrating lane's real footer, whose final line is an agent
+#           row — dies the moment the claude reading is taken by position
+#           too, or any bottom window narrower than the footer is taken off
 #   case 14 a session with no percentage yet, under prose that names a model
 #           and one — dies if the claude shape is loosened back to accepting
 #           words between the model name and the percentage
@@ -24,31 +26,34 @@
 #           dies if a reading is a FRAGMENT of the status line rather than
 #           the whole line, because bottom-most then hands the sentence the
 #           verdict over the real line above it
-#   case 22 the same sentence in the CODEX shape, which carries its fragment
-#           in ordinary prose about compaction — dies the moment the codex
-#           branch is loosened back to matching anywhere in a line
-#   case 24 the same sentence two words long — dies the moment the codex
-#           trailing item is admitted by token COUNT rather than by shape,
-#           which is how `compact now` passed for a status item
+#   case 22 a codex screen whose final line is not a status line, with a real
+#           one above it — dies the moment the codex reading goes back to
+#           searching the screen instead of reading the line it ends on
+#   case 24 a configured status item that is not a working directory — dies
+#           the moment the codex shape judges what follows the separator,
+#           because no shape separates a configured item from a sentence
 #   case 13 a pane that exited to its shell — dies if the liveness evidence
 #           is dropped, which is the only thing a window ever stood in for
 #
 # Covered:
 #   1. the claude shape reports its number as used, wherever the footer puts
 #      the status line
-#   2. the codex shape is converted, not reported raw
-#   3. the bottom-most reading wins over one repainted past
+#   2. the codex shape is converted, not reported raw, and is read off the
+#      line the screen ends on, blank rows below it and all
+#   3. the bottom-most claude reading wins over one repainted past
 #   4. a screen with neither shape is no_status_line, never 0
 #   5. a pane that cannot be captured is unreadable, never 0
-#   6. a percentage over 100 is not a context figure, in either shape
+#   6. a percentage over 100 is not a context figure, in either shape, and a
+#      codex line carrying one settles the reading rather than falling
+#      through to a claude match higher up
 #   7. the table names the direction it reports, in its header and its rows
 #   8. an empty fleet says so; an unreadable claim store refuses
 #   9. the account column names the lane the pane runs under
 #  10. a claim on ANOTHER tmux server is unreadable, never a local pane's
 #      number under its name
 #  11. codex's other status item, `Context 40% used`, is taken as it stands
-#  12. a claude status item behind the codex separator is not a codex
-#      status line; the codex status item carries a path and nothing else
+#  12. whatever follows the codex separator is taken as it comes, a claude
+#      status item included; the shape reads no further than the separator
 #  13. a pane that has exited to its shell is not measured from what it left
 #  14. a model and a percentage in prose is not a status line
 #  15. an unenumerable tmux server refuses every claim, not just foreign ones
@@ -63,10 +68,11 @@
 #      refused, and the refusal names the process it found
 #  21. the per-account wrapper spellings the fleet launches through are
 #      harnesses, and their panes are measured
-#  22. a codex context fragment in prose is not a status line, alone or
-#      below a real one
+#  22. a codex screen whose final line is not a status line carries no
+#      reading, and the real status line above it is not searched out
 #  23. the table still carries every row where `column` is not installed
-#  24. two words behind the codex separator are prose, not a status item
+#  24. the configured status items `[tui].status_line` draws are accepted,
+#      one item or several, none of them a working directory
 #  25. every committed codex capture parses to the figure on its screen
 #
 # errexit is on: every case here either succeeds or is guarded, so an
@@ -251,8 +257,13 @@ screen 1 '  ⎿  Tip: Use /clear to start fresh when switching topics and free u
   ◯ dev-ken835  Follow workflow: .agents/skills/dev/workflows/dev-...   7m 45s · ↓ 937.0k tokens
   ◯ dev-ken-845  Follow workflow: .agents/skills/dev/workflo… 8m 45s · ↓ 364.8k tokens
   ◯ dev-ken-844-c  Follow workflow: .agents/skills/dev/workflo… 4m 2s · ↓ 75.8k tokens'
+# 2. The codex status line is the last NON-EMPTY row: a real capture carries
+# blank rows under it, and a rule that read the last row outright would find
+# one of those and report nothing.
 screen 2 '  Codex is working
-  Context 86% left'
+  Context 86% left
+
+'
 # A repaint after a compaction leaves the previous render on the screen.
 screen 3 '  kendex (🌳 ken-103) Opus 5 92% (brad@drovr.dev)     /rc
   ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents
@@ -264,7 +275,11 @@ screen 4 'plain shell output with no harness status line'
 screen 6 '  Codex is working
   Context 40% used'
 screen 7 '  Context 86% left · Opus 5 41%'
-screen 8 '  Context 140% left'
+# 6, codex arm. The claude status line above is what a fall-through would
+# find: a codex line the reader cannot use is a refusal, not a reason to go
+# looking further up the screen.
+screen 8 '  kendex (🌳 ken-108) Opus 5 35% (brad@drovr.dev)     /rc
+  Context 140% left'
 screen 9 '  kendex (🌳 ken-109) Opus 5 41% (brad@drovr.dev)     /rc
   ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents
 $ git status
@@ -314,36 +329,36 @@ screen 17 '  kendex (🌳 ken-118) Opus 5 66% (brad@drovr.dev)     /rc
   ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents'
 screen 18 '  kendex (🌳 ken-119) Opus 5 27% (brad@drovr.dev)     /rc
   ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents'
-# 22. The codex sibling of 18 and 19. The compaction rule is written about
-# in the terminal it governs, so `Context <N>% used` turns up in ordinary
-# transcript prose — and a fragment match hands that sentence the verdict
-# over the real status line above it, exactly as the claude fragment did.
-# %19 puts the sentence BELOW a real codex status line; %20 gives it a
-# screen of its own.
+# 22. THE fail-closed case. A codex screen whose final line is not a status
+# line carries no reading, and the real status line above it is not searched
+# out: a screen that does not end in its status line is a screen the reader
+# cannot vouch for — caught mid-redraw, or with a dialog over the footer —
+# and reporting the last figure it can find there is reporting a number from
+# before whatever moved the line. %19 puts a real status line above a line
+# that is not one; %20 gives that line a screen of its own.
 screen 19 '  Codex is working
   Context 86% left
 ● Documentation: Context 60% used means compact now'
 screen 20 '● Documentation: Context 60% used means compact now'
-# 22, trailing half. The other end of the same fragment. Prose can put the
+# 18, trailing half. The other end of the same fragment. Prose can put the
 # sentence AFTER the status shape as easily as before it, and then the
-# status-shaped PREFIX matches while the sentence it sits in never has to. Both
-# screens put that line BELOW a real status line, which is where bottom-most
-# hands it the verdict.
+# status-shaped PREFIX matches while the sentence it sits in never has to.
+# The claude reading is the bottom-most match, so this screen puts that line
+# below a real status line, which is where bottom-most would hand it the
+# verdict. There is no codex sibling any more: a codex screen is read at the
+# line it ends on, so what a sentence there is shaped like never comes up.
 screen 21 '  kendex (🌳 ken-122) Opus 5 41% (brad@drovr.dev)     /rc
   ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents
 /fake Opus 5 99% (work) is an example'
-screen 22 '  Context 86% left
-● Context 77% used means compact now
-● Context 77% used · and that is an example'
-# 24. The reproduction from KEN-885, and the shortest sentence of the class:
-# two words behind the separator. A trailing item admitted by token COUNT
-# takes `compact now` for a status item, and bottom-most then reports 60 used
-# for a lane that is 14 used — the overseer compacts the emptiest lane in the
-# fleet and skips the full one. Codex puts its working directory behind that
-# separator, so the item is matched by that shape and a sentence of any
-# length fails it.
-screen 23 'Context 86% left
-Context 60% used · compact now'
+# 24. `[tui].status_line` is a real config key, and the items it draws behind
+# the separator are not all working directories. %22 carries the one the
+# committed captures do not: a model with its reasoning effort, two bare
+# words. %23 carries four items at once — model, git branch, project name,
+# codex version — because the key takes a list. A shape that judges what
+# follows the separator refuses one or both of these, and a refused lane is
+# an unmeasured lane, which the overseer never compacts.
+screen 22 '  Context 100% left · gpt-5.6-sol default'
+screen 23 '  Context 78% left · gpt-5.6-sol default · ken-885 · kendex · 0.151.0'
 
 OUT="$(run_ctx --json)"
 
@@ -358,9 +373,12 @@ assert_eq "$(jq -r '.[] | select(.lane=="ken-101") | .status' <<<"$OUT")" "ok" \
 
 # 2. THE conversion. `Context 86% left` is a nearly EMPTY context; reported
 # raw it is the fullest lane in the fleet and the overseer compacts the wrong
-# one.
+# one. The screen ends in blank rows, as a real capture does, so this also
+# holds the codex reading to the last NON-EMPTY line.
 assert_eq "$(jq -r '.[] | select(.lane=="ken-102") | .context_used_pct' <<<"$OUT")" "14" \
   "the codex status line is converted from remaining to used"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-102") | .status' <<<"$OUT")" "ok" \
+  "blank rows below the status line do not cost the lane its reading"
 assert_eq "$(jq -r '.[] | select(.lane=="ken-102") | .harness' <<<"$OUT")" "codex" \
   "the codex shape names the codex harness"
 
@@ -377,22 +395,23 @@ assert_eq "$(jq -r '.[] | select(.lane=="ken-106") | .context_used_pct' <<<"$OUT
 assert_eq "$(jq -r '.[] | select(.lane=="ken-106") | .harness' <<<"$OUT")" "codex" \
   "the codex used shape names the codex harness"
 
-# 12. `Opus 5 41%` is a claude status item, and behind the codex separator it
-# is not a status line of either harness: codex draws its working directory
-# there and nothing else, and the claude shape needs an account parenthetical
-# this line has none of. A trailing item admitted by token count took it for a
-# codex reading, which is the same allowance `compact now` walked through.
-assert_eq "$(jq -r '.[] | select(.lane=="ken-107") | .status' <<<"$OUT")" "no_status_line" \
-  "a claude status item behind the codex separator is not a codex status line"
-assert_eq "$(jq -r '.[] | select(.lane=="ken-107") | .context_used_pct' <<<"$OUT")" "null" \
-  "that lane carries no number, not the one that shape carried"
+# 12. The shape reads no further than the separator, so what sits past it is
+# taken as it comes — here a claude status item, which no codex config draws
+# and which the reader therefore has no business judging. The line still opens
+# with the codex context item, and that is what the reading is taken from.
+assert_eq "$(jq -r '.[] | select(.lane=="ken-107") | .context_used_pct' <<<"$OUT")" "14" \
+  "whatever follows the codex separator is taken as it comes"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-107") | .harness' <<<"$OUT")" "codex" \
+  "the context item at the line's opening is what names the harness"
 
 # 6 (codex arm). Over 100 is not a context figure in either shape: unguarded,
-# the conversion turns 140 left into -40 used.
+# the conversion turns 140 left into -40 used. The claude status line sitting
+# above it is what a fall-through would report instead — 35, from a line the
+# screen does not end on — so the codex line settles the reading either way.
 assert_eq "$(jq -r '.[] | select(.lane=="ken-108") | .status' <<<"$OUT")" "no_status_line" \
   "a codex percentage over 100 is not read as a context figure"
 assert_eq "$(jq -r '.[] | select(.lane=="ken-108") | .context_used_pct' <<<"$OUT")" "null" \
-  "an out-of-range codex reading carries no number"
+  "an out-of-range codex line refuses rather than falling through to a match above it"
 
 # 13. The pane exited to its shell. Its last render is still on the screen and
 # is not a measurement of anything: what refuses it is the foreground process
@@ -467,39 +486,48 @@ assert_eq "$(jq -r '.[] | select(.lane=="ken-119") | .context_used_pct' <<<"$OUT
 assert_eq "$(jq -r '.[] | select(.lane=="ken-119") | .status' <<<"$OUT")" "ok" \
   "that lane is ok, not a refusal"
 
-# 22. A codex reading is the whole line too. Below a real status line the
-# sentence wins on bottom-most and the lane reports 60 used for a lane that
-# is 14 used; on a screen of its own it is a reading invented out of prose.
-assert_eq "$(jq -r '.[] | select(.lane=="ken-120") | .context_used_pct' <<<"$OUT")" "14" \
-  "codex prose below a status line does not outrank the status line above it"
+# 22. THE fail-closed case. %19 ends in a line that is not a status line and
+# carries a real one above it: the reading is refused rather than searched
+# out, because a screen that does not end in its status line is one the reader
+# cannot vouch for. %20 is the same line with nothing above it. Both are
+# no_status_line, and the moment the codex reading goes back to searching the
+# screen, %19 reports 14 from a line the screen has moved past.
+assert_eq "$(jq -r '.[] | select(.lane=="ken-120") | .status' <<<"$OUT")" "no_status_line" \
+  "a codex screen not ending in a status line carries no reading"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-120") | .context_used_pct' <<<"$OUT")" "null" \
+  "the status line above it is not searched out"
 assert_eq "$(jq -r '.[] | select(.lane=="ken-121") | .status' <<<"$OUT")" "no_status_line" \
   "a screen whose only context percentage sits in codex prose carries no reading"
 assert_eq "$(jq -r '.[] | select(.lane=="ken-121") | .context_used_pct' <<<"$OUT")" "null" \
   "that lane carries no number, not the sentence's"
 
-# 22, trailing half. A status-shaped PREFIX with prose after it. The claude
-# line ends in its account and claude's own right-hand hint; the codex line
-# ends in its context item or a working directory behind a separator. Neither
-# end admits a sentence, so the real status line above keeps the verdict.
+# 18, trailing half. A status-shaped PREFIX with prose after it. The claude
+# line ends in its account and claude's own right-hand hint, and admits no
+# sentence past either, so the real status line above keeps the verdict.
 assert_eq "$(jq -r '.[] | select(.lane=="ken-122") | .context_used_pct' <<<"$OUT")" "41" \
   "claude prose after a status-shaped prefix does not outrank the status line above it"
-assert_eq "$(jq -r '.[] | select(.lane=="ken-123") | .context_used_pct' <<<"$OUT")" "14" \
-  "codex prose after a status-shaped prefix does not outrank the status line above it"
 
-# 24. The reproduction from KEN-885. Two words behind the separator is the
-# shortest sentence of this class and the one a token count cannot refuse:
-# the lane has 14 used and the report called it 60, so the overseer compacted
-# the emptiest lane in the fleet and left the full one running.
-assert_eq "$(jq -r '.[] | select(.lane=="ken-124") | .context_used_pct' <<<"$OUT")" "14" \
-  "two words behind the codex separator are prose, not a status item"
-assert_eq "$(jq -r '.[] | select(.lane=="ken-124") | .harness' <<<"$OUT")" "codex" \
-  "the real status line above keeps the verdict, and the harness with it"
+# 24. The configured status items. `gpt-5.6-sol default` is two bare words
+# and so is `compact now`, so no shape tells them apart — and a shape that
+# refuses the one it has not seen leaves that lane unmeasured, which is the
+# lane the overseer then never compacts. Position is what refuses prose, so
+# these are accepted: one item, and the four a list config draws.
+assert_eq "$(jq -r '.[] | select(.lane=="ken-123") | .context_used_pct' <<<"$OUT")" "0" \
+  "a model with its reasoning effort is a status item, not a sentence"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-123") | .harness' <<<"$OUT")" "codex" \
+  "that lane is measured rather than left out of the report"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-124") | .context_used_pct' <<<"$OUT")" "22" \
+  "a status line carrying four configured items is read like any other"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-124") | .status' <<<"$OUT")" "ok" \
+  "several items behind the separator are not a reason to refuse the lane"
 
 # 25. Every committed codex capture, parsed as it stands. These are real
-# `tmux capture-pane` output from Codex 0.151.0 (KEN-863), so what the reader
-# anchors to is what the harness draws: `Context <N>% left`, a separator, and
-# the session's working directory, ellipsised where the width ran out. A
-# capture whose screen carries no status line is a refusal, never a zero.
+# `tmux capture-pane` output from Codex 0.151.0 (KEN-863), and they are the
+# evidence the position rule rests on: in all four that carry a status line
+# it is the last non-empty row, blank rows below it and nothing else. The
+# other two end in a dialog drawn over the footer, and a reader that searched
+# the screen would report the figure that dialog is covering. A capture whose
+# screen carries no status line is a refusal, never a zero.
 FIXTURES="$TEST_DIR/fixtures/oversee-watch"
 
 parse_fixture() { # <capture file name>

--- a/.agents/skills/orch/tests/lanes_context.sh
+++ b/.agents/skills/orch/tests/lanes_context.sh
@@ -613,7 +613,7 @@ assert_eq "$(jq -r '.[] | select(.lane=="ken-126") | .status' <<<"$OUT")" "no_st
   "the same pane with no codex status line at all answers the same way"
 assert_eq "$(jq -r '.[] | select(.lane=="ken-126") | .context_used_pct' <<<"$OUT")" "null" \
   "the two halves agree rather than differing by what sits above the dialog"
-assert_contains "$(jq -r '.[] | select(.lane=="ken-125") | .detail' <<<"$OUT")" "does not end in a codex status line" \
+assert_contains "$(jq -r '.[] | select(.lane=="ken-125") | .detail' <<<"$OUT")" "does not end in a valid codex context figure" \
   "the refusal names what it could not read, not a missing figure of either shape"
 
 # 27. And the same confusion in the other direction. A codex status line

--- a/skills/orch/scripts/lib/lane-context.sh
+++ b/skills/orch/scripts/lib/lane-context.sh
@@ -85,16 +85,24 @@ lane_context_emit() {
     }'
 }
 
-# Read one context figure from a captured screen on stdin. Prints
-# `<harness>\t<used percent>`; exits 1 when the screen carries neither shape.
+# Read one context figure from a captured screen on stdin. $1 is the pane's
+# foreground process, and it decides which shape is offered: `codex` the codex
+# shape alone, a claude wrapper spelling or `agent-confine` the claude shape
+# alone. Anything else — `pi`, or an empty name for a pane that has left the
+# enumeration — is offered both, because a reader with no rule for a harness
+# has nothing better than the shapes themselves. Prints
+# `<harness>\t<used percent>`; exits 1 when the shape offered found nothing.
 #
 # The codex shape is offered the FINAL NON-EMPTY line and no other. The
 # claude shape is offered every line and its LAST match wins; no window is
 # taken off the bottom, because the footer under a claude status line is one
 # row per running agent and has no bound, so any count would lose exactly the
-# busiest lanes. A final line that carries the codex shape settles the
-# reading, out of range included: falling through to a claude match higher up
-# would be the search the position rule exists to refuse.
+# busiest lanes. Where both are offered, a final line carrying the codex shape
+# settles the reading, out of range included: falling through to a claude
+# match higher up would be the search the position rule exists to refuse. On a
+# codex pane there is no falling through at all — the claude shape is never
+# offered, so a screen that does not end in a codex status line is
+# could-not-tell however much of this fleet's transcript sits above it.
 #
 # Matching is done on a lowercased copy of each line: a model name is a word,
 # and the harness spells it differently in different places. The claude
@@ -127,10 +135,15 @@ lane_context_emit() {
 # context figure and is dropped rather than reported, whichever shape carried
 # it.
 lane_context_parse() {
-  local out
-  out="$(awk '
+  local out shape="both"
+  case "${1:-}" in
+    codex) shape="codex" ;;
+    *claude | agent-confine) shape="claude" ;;
+  esac
+  out="$(awk -v shape="$shape" '
     {
       if ($0 ~ /[^ \t]/) last = $0
+      if (shape == "codex") next
       low = tolower($0)
       if (match(low, /^[ \t]*[^ \t()]+([ \t]+\([^)]*\))?[ \t]+(opus|sonnet|haiku|fable)[ \t]+[0-9]+(\.[0-9]+)?([ \t]*\([^)]*\))?[ \t]+[0-9]+%[ \t]+\([^) \t]+\)([ \t]+\/[^ \t]*)*[ \t]*$/)) {
         s = substr(low, RSTART, RLENGTH)
@@ -141,7 +154,7 @@ lane_context_parse() {
       }
     }
     END {
-      low = tolower(last)
+      low = (shape == "claude") ? "" : tolower(last)
       if (match(low, /^[^a-z0-9]*context:?[ \t]+[0-9]+%[ \t]+(left|used)([ \t]+(·|[|])[ \t]+[^ \t].*)?[ \t]*$/)) {
         codex_line = 1
         s = substr(low, RSTART, RLENGTH)
@@ -171,7 +184,9 @@ lane_context_parse() {
 # against an unrelated local pane and emitted as ok. So the claim's server is
 # compared against this one, enumerated once, before anything is captured.
 # The same enumeration carries each pane's foreground process, which is what
-# says whether a harness is still drawing the screen about to be read.
+# says whether a harness is still drawing the screen about to be read — and
+# WHICH harness, which is how the reader knows the shape to look for without
+# guessing it from a screen that quotes both all day.
 lane_context_collect() {
   local claims="$1" alias_fn="$2" cfg lane server pane screen parsed
   local this_server detail cmd pane_cmds p_pid p_pane p_cmd
@@ -215,9 +230,14 @@ lane_context_collect() {
           "unreadable" "the pane could not be captured; it is gone from this server"
         continue
       fi
-      if ! parsed="$(lane_context_parse <<<"$screen")"; then
+      if ! parsed="$(lane_context_parse "$cmd" <<<"$screen")"; then
+        case "$cmd" in
+          codex) detail="the screen does not end in a codex status line; whatever moved it — a dialog over the footer, a redraw caught mid-frame — is covering the figure" ;;
+          *claude | agent-confine) detail="the screen carries no claude status line" ;;
+          *) detail="the screen carries neither harness's context figure" ;;
+        esac
         lane_context_emit "$lane" "$pane" "$cfg" "$("$alias_fn" "$cfg")" "" "" \
-          "no_status_line" "the screen carries neither harness's context figure"
+          "no_status_line" "$detail"
         continue
       fi
       lane_context_emit "$lane" "$pane" "$cfg" "$("$alias_fn" "$cfg")" \

--- a/skills/orch/scripts/lib/lane-context.sh
+++ b/skills/orch/scripts/lib/lane-context.sh
@@ -57,9 +57,10 @@ set -euo pipefail
 # running less, vim or git log still holds the old footer and passes any
 # not-a-shell test. `[a-z0-9]*claude` covers the per-account wrappers this
 # fleet launches through — nclaude, dclaude, 1claude — which exec the real
-# binary, and agent-confine is the launcher they exec through. Anything else
-# is refused BY NAME, so a harness missing from this list reads as a named
-# refusal in the report rather than as a lane that stopped being measured.
+# binary, and agent-confine is the launcher both harnesses exec through, so
+# it names neither. Anything else is refused BY NAME, so a harness missing
+# from this list reads as a named refusal in the report rather than as a lane
+# that stopped being measured.
 LANE_CONTEXT_HARNESSES='[a-z0-9]*claude|codex|pi|agent-confine'
 
 # Shells choose the refusal's wording and nothing else: a pane back at its
@@ -87,10 +88,11 @@ lane_context_emit() {
 
 # Read one context figure from a captured screen on stdin. $1 is the pane's
 # foreground process, and it decides which shape is offered: `codex` the codex
-# shape alone, a claude wrapper spelling or `agent-confine` the claude shape
-# alone. Anything else — `pi`, or an empty name for a pane that has left the
-# enumeration — is offered both, because a reader with no rule for a harness
-# has nothing better than the shapes themselves. Prints
+# shape alone, a claude wrapper spelling the claude shape alone. Anything else
+# is offered both, because a reader with no rule for a harness has nothing
+# better than the shapes themselves — `pi`, an empty name for a pane that has
+# left the enumeration, and `agent-confine`, which is the launcher BOTH
+# harnesses exec through and so names neither. Prints
 # `<harness>\t<used percent>`; exits 1 when the shape offered found nothing.
 #
 # The codex shape is offered the FINAL NON-EMPTY line and no other. The
@@ -138,7 +140,7 @@ lane_context_parse() {
   local out shape="both"
   case "${1:-}" in
     codex) shape="codex" ;;
-    *claude | agent-confine) shape="claude" ;;
+    *claude) shape="claude" ;;
   esac
   out="$(awk -v shape="$shape" '
     {
@@ -233,7 +235,7 @@ lane_context_collect() {
       if ! parsed="$(lane_context_parse "$cmd" <<<"$screen")"; then
         case "$cmd" in
           codex) detail="the screen does not end in a codex status line; whatever moved it — a dialog over the footer, a redraw caught mid-frame — is covering the figure" ;;
-          *claude | agent-confine) detail="the screen carries no claude status line" ;;
+          *claude) detail="the screen carries no claude status line" ;;
           *) detail="the screen carries neither harness's context figure" ;;
         esac
         lane_context_emit "$lane" "$pane" "$cfg" "$("$alias_fn" "$cfg")" "" "" \

--- a/skills/orch/scripts/lib/lane-context.sh
+++ b/skills/orch/scripts/lib/lane-context.sh
@@ -86,14 +86,27 @@ lane_context_emit() {
     }'
 }
 
+# The shape a pane's foreground process ($1) offers, decided here and in no
+# other place: `codex` the codex shape alone, a claude wrapper spelling the
+# claude shape alone, and anything else `both`, because a reader with no rule
+# for a harness has nothing better than the shapes themselves — `pi`, an empty
+# name for a pane that has left the enumeration, and `agent-confine`, which is
+# the launcher BOTH harnesses exec through and so names neither. Reading the
+# screen and refusing it both select on this answer, so a wrapper spelling
+# added to one list and not the other cannot read one harness's screen and
+# name the other's in its refusal.
+lane_context_shape() {
+  case "${1:-}" in
+    codex) printf 'codex\n' ;;
+    *claude) printf 'claude\n' ;;
+    *) printf 'both\n' ;;
+  esac
+}
+
 # Read one context figure from a captured screen on stdin. $1 is the pane's
-# foreground process, and it decides which shape is offered: `codex` the codex
-# shape alone, a claude wrapper spelling the claude shape alone. Anything else
-# is offered both, because a reader with no rule for a harness has nothing
-# better than the shapes themselves — `pi`, an empty name for a pane that has
-# left the enumeration, and `agent-confine`, which is the launcher BOTH
-# harnesses exec through and so names neither. Prints
-# `<harness>\t<used percent>`; exits 1 when the shape offered found nothing.
+# foreground process, which `lane_context_shape` turns into the shape offered.
+# Prints `<harness>\t<used percent>`; exits 1 when the shape offered found
+# nothing.
 #
 # The codex shape is offered the FINAL NON-EMPTY line and no other. The
 # claude shape is offered every line and its LAST match wins; no window is
@@ -137,11 +150,8 @@ lane_context_emit() {
 # context figure and is dropped rather than reported, whichever shape carried
 # it.
 lane_context_parse() {
-  local out shape="both"
-  case "${1:-}" in
-    codex) shape="codex" ;;
-    *claude) shape="claude" ;;
-  esac
+  local out shape
+  shape="$(lane_context_shape "${1:-}")"
   out="$(awk -v shape="$shape" '
     {
       if ($0 ~ /[^ \t]/) last = $0
@@ -233,9 +243,9 @@ lane_context_collect() {
         continue
       fi
       if ! parsed="$(lane_context_parse "$cmd" <<<"$screen")"; then
-        case "$cmd" in
+        case "$(lane_context_shape "$cmd")" in
           codex) detail="the screen does not end in a valid codex context figure; the last non-empty row is the only row a codex reading is taken from" ;;
-          *claude) detail="the screen carries no claude status line" ;;
+          claude) detail="the screen carries no claude status line" ;;
           *) detail="the screen carries neither harness's context figure" ;;
         esac
         lane_context_emit "$lane" "$pane" "$cfg" "$("$alias_fn" "$cfg")" "" "" \

--- a/skills/orch/scripts/lib/lane-context.sh
+++ b/skills/orch/scripts/lib/lane-context.sh
@@ -94,11 +94,12 @@ lane_context_emit() {
 # nothing alphanumeric — and what may follow it is another status item behind
 # a separator, never running text. `Documentation: Context 60% used means
 # compact now` fails the opening; `Context 60% used means compact now` fails
-# the end; and `Context 60% used · and that is an example` fails it too,
-# because a trailing item is capped at three tokens — the longest status item
-# this reader has seen (`Opus 5 41%`) — where a sentence is longer. Each is a
-# fragment a bottom-most rule would otherwise let take the verdict from the
-# real line above it.
+# the end. A trailing item is matched by SHAPE, not by token count: codex
+# puts its working directory there, so each item behind a separator is one
+# whitespace-free path — `/…` or `~/…`, ellipsised where the width runs out.
+# A count admits whatever is short enough, and `Context 60% used · compact
+# now` is two words: it is prose the reader took for a status line, and under
+# a bottom-most rule it took the verdict from the real line above it.
 # The codex shape is tested first and consumes its line, so a screen carrying
 # both never takes the claude direction for a codex reading. Codex's status
 # item is user-configured and both directions ship, so both are matched and
@@ -109,7 +110,7 @@ lane_context_parse() {
   out="$(awk '
     {
       low = tolower($0)
-      if (match(low, /^[^a-z0-9]*context:?[ \t]+[0-9]+%[ \t]+(left|used)([ \t]+(·|[|])[ \t]+[^ \t]+([ \t]+[^ \t]+){0,2})?[ \t]*$/)) {
+      if (match(low, /^[^a-z0-9]*context:?[ \t]+[0-9]+%[ \t]+(left|used)([ \t]+(·|[|])[ \t]+[~\/][^ \t]*)*[ \t]*$/)) {
         s = substr(low, RSTART, RLENGTH)
         match(s, /[0-9]+%[ \t]+(left|used)/)
         s = substr(s, RSTART, RLENGTH)

--- a/skills/orch/scripts/lib/lane-context.sh
+++ b/skills/orch/scripts/lib/lane-context.sh
@@ -13,15 +13,32 @@
 # which harness a pane runs. Both are reported as CONTEXT_USED_PCT: one
 # direction, and a rising number always means a fuller context.
 #
-# WHERE the status line sits is not a line count. Claude draws ONE ROW PER
-# RUNNING AGENT below it, so the footer grows with the fleet — and the
-# deepest footers belong to the orchestrating lanes, the ones this
-# measurement exists for. The whole captured screen is read and the
-# BOTTOM-MOST reading wins: anything above it is an earlier render of the
-# same lane, from before it compacted. Bottom-most is safe only because a
-# reading is a whole STATUS LINE and never a fragment prose can carry too:
-# otherwise the lowest sentence naming a model and a percentage beats the
-# real status line above it.
+# WHERE the status line sits differs by harness, and that is what decides
+# how each one is found.
+#
+# Codex draws its status line LAST. In every captured pane it is the final
+# non-empty row, with blank rows and nothing else below it, so the codex
+# reading is taken from that row and from no other row on the screen. A
+# final row that is not a status line is no reading at all, never a search
+# up the transcript for something shaped like one. POSITION carries that
+# refusal because shape cannot: codex's status items are user-configured
+# (`[tui].status_line` — model with reasoning, git branch, project name,
+# codex version, tokens used, working directory), and `gpt-5.6-sol default`
+# is a configured item while `compact now` is a sentence about compaction,
+# and the two are the same shape. A reader that refuses what it does not
+# recognise leaves the lane unmeasured, and an unmeasured lane is never
+# compacted — which is the outcome compaction exists to prevent. So what
+# follows the separator is taken as it comes.
+#
+# Claude draws ONE ROW PER RUNNING AGENT below its status line, so the
+# footer grows with the fleet — and the deepest footers belong to the
+# orchestrating lanes, the ones this measurement exists for. Its status line
+# is never the final row, so the claude reading is the BOTTOM-MOST whole-line
+# match instead: anything above it is an earlier render of the same lane,
+# from before it compacted. Bottom-most is safe only because a reading is a
+# whole STATUS LINE and never a fragment prose can carry too: otherwise the
+# lowest sentence naming a model and a percentage beats the real status line
+# above it.
 #
 # A screen that outlived its harness is refused rather than measured, and
 # that refusal takes positive evidence, never distance: the pane's
@@ -71,9 +88,13 @@ lane_context_emit() {
 # Read one context figure from a captured screen on stdin. Prints
 # `<harness>\t<used percent>`; exits 1 when the screen carries neither shape.
 #
-# Every line is offered and the LAST match wins. No window is taken off the
-# bottom: the footer under the status line is one row per running agent and
-# has no bound, so any count would lose exactly the busiest lanes.
+# The codex shape is offered the FINAL NON-EMPTY line and no other. The
+# claude shape is offered every line and its LAST match wins; no window is
+# taken off the bottom, because the footer under a claude status line is one
+# row per running agent and has no bound, so any count would lose exactly the
+# busiest lanes. A final line that carries the codex shape settles the
+# reading, out of range included: falling through to a claude match higher up
+# would be the search the position rule exists to refuse.
 #
 # Matching is done on a lowercased copy of each line: a model name is a word,
 # and the harness spells it differently in different places. The claude
@@ -89,45 +110,50 @@ lane_context_emit() {
 # command (`/rc`) — never running text. The branch parenthetical is optional:
 # a lane outside a repository has none, and a session that has not rendered a
 # percentage yet matches nothing at all.
-# The codex reading is a WHOLE LINE at both ends for the same reason: the
-# context item OPENS its line — leading whitespace or box decoration only,
-# nothing alphanumeric — and what may follow it is another status item behind
-# a separator, never running text. `Documentation: Context 60% used means
-# compact now` fails the opening; `Context 60% used means compact now` fails
-# the end. A trailing item is matched by SHAPE, not by token count: codex
-# puts its working directory there, so each item behind a separator is one
-# whitespace-free path — `/…` or `~/…`, ellipsised where the width runs out.
-# A count admits whatever is short enough, and `Context 60% used · compact
-# now` is two words: it is prose the reader took for a status line, and under
-# a bottom-most rule it took the verdict from the real line above it.
-# The codex shape is tested first and consumes its line, so a screen carrying
-# both never takes the claude direction for a codex reading. Codex's status
-# item is user-configured and both directions ship, so both are matched and
-# only `left` is converted. A percentage over 100 is not a context figure and
-# is dropped rather than reported, whichever shape carried it.
+# The codex reading is a WHOLE LINE at its OPENING and takes what follows as
+# it comes. The context item opens the line — leading whitespace or box
+# decoration only, nothing alphanumeric — so `Documentation: Context 60% used
+# means compact now` is not one, and `Context 60% used means compact now`
+# needs the separator its configured items are drawn behind. Past that
+# separator the line is read no further. Every candidate for the job — a path
+# (`/var/tmp/…`), a model with its reasoning effort (`gpt-5.6-sol default`), a
+# git branch, a project name, a version, a token count — is one to three bare
+# words, and so is a sentence's opening; a shape that admits the ones this
+# reader has seen and refuses the rest refuses configured status lines it has
+# not seen, and leaves those lanes unmeasured. Position is what keeps prose
+# out, so the shape does not have to try.
+# Codex's status item is user-configured and both directions ship, so both
+# are matched and only `left` is converted. A percentage over 100 is not a
+# context figure and is dropped rather than reported, whichever shape carried
+# it.
 lane_context_parse() {
   local out
   out="$(awk '
     {
+      if ($0 ~ /[^ \t]/) last = $0
       low = tolower($0)
-      if (match(low, /^[^a-z0-9]*context:?[ \t]+[0-9]+%[ \t]+(left|used)([ \t]+(·|[|])[ \t]+[~\/][^ \t]*)*[ \t]*$/)) {
+      if (match(low, /^[ \t]*[^ \t()]+([ \t]+\([^)]*\))?[ \t]+(opus|sonnet|haiku|fable)[ \t]+[0-9]+(\.[0-9]+)?([ \t]*\([^)]*\))?[ \t]+[0-9]+%[ \t]+\([^) \t]+\)([ \t]+\/[^ \t]*)*[ \t]*$/)) {
+        s = substr(low, RSTART, RLENGTH)
+        match(s, /[0-9]+%[ \t]+\([^) \t]+\)/)
+        s = substr(s, RSTART, RLENGTH)
+        sub(/%.*$/, "", s)
+        if (s != "" && s + 0 <= 100) { c_found = 1; c_used = s + 0 }
+      }
+    }
+    END {
+      low = tolower(last)
+      if (match(low, /^[^a-z0-9]*context:?[ \t]+[0-9]+%[ \t]+(left|used)([ \t]+(·|[|])[ \t]+[^ \t].*)?[ \t]*$/)) {
+        codex_line = 1
         s = substr(low, RSTART, RLENGTH)
         match(s, /[0-9]+%[ \t]+(left|used)/)
         s = substr(s, RSTART, RLENGTH)
         remaining = (s ~ /left$/)
         gsub(/[^0-9]/, "", s)
         if (s + 0 <= 100) { harness = "codex"; used = remaining ? 100 - (s + 0) : s + 0 }
-        next
       }
-      if (match(low, /^[ \t]*[^ \t()]+([ \t]+\([^)]*\))?[ \t]+(opus|sonnet|haiku|fable)[ \t]+[0-9]+(\.[0-9]+)?([ \t]*\([^)]*\))?[ \t]+[0-9]+%[ \t]+\([^) \t]+\)([ \t]+\/[^ \t]*)*[ \t]*$/)) {
-        s = substr(low, RSTART, RLENGTH)
-        match(s, /[0-9]+%[ \t]+\([^) \t]+\)/)
-        s = substr(s, RSTART, RLENGTH)
-        sub(/%.*$/, "", s)
-        if (s != "" && s + 0 <= 100) { harness = "claude"; used = s + 0 }
-      }
+      if (!codex_line && c_found) { harness = "claude"; used = c_used }
+      if (harness != "") printf "%s\t%d\n", harness, used
     }
-    END { if (harness != "") printf "%s\t%d\n", harness, used }
   ')"
   [[ -n "$out" ]] || return 1
   printf '%s\n' "$out"

--- a/skills/orch/scripts/lib/lane-context.sh
+++ b/skills/orch/scripts/lib/lane-context.sh
@@ -234,7 +234,7 @@ lane_context_collect() {
       fi
       if ! parsed="$(lane_context_parse "$cmd" <<<"$screen")"; then
         case "$cmd" in
-          codex) detail="the screen does not end in a codex status line; whatever moved it — a dialog over the footer, a redraw caught mid-frame — is covering the figure" ;;
+          codex) detail="the screen does not end in a valid codex context figure; the last non-empty row is the only row a codex reading is taken from" ;;
           *claude) detail="the screen carries no claude status line" ;;
           *) detail="the screen carries neither harness's context figure" ;;
         esac

--- a/skills/orch/tests/lanes_context.sh
+++ b/skills/orch/tests/lanes_context.sh
@@ -13,9 +13,12 @@
 # different places. Codex draws it LAST, so the codex reading comes from the
 # final non-empty line and from no other. Claude draws a row per running
 # agent BELOW its status line, so its footer has no bound and its reading is
-# the bottom-most whole-line match. Case 1's screen is a real
-# `tmux capture-pane`; the other claude screens are built from real status
-# lines. Cases hold each half shut, one per mutation:
+# the bottom-most whole-line match. WHICH rule a pane gets comes from the
+# pane's own foreground process, never from what is on the screen: this fleet
+# pastes both harnesses' screens into both harnesses' terminals all day, and
+# the panes here carry a process per case for that reason. Case 1's screen is
+# a real `tmux capture-pane`; the other claude screens are built from real
+# status lines. Cases hold each half shut, one per mutation:
 #   case 1  an orchestrating lane's real footer, whose final line is an agent
 #           row — dies the moment the claude reading is taken by position
 #           too, or any bottom window narrower than the footer is taken off
@@ -32,6 +35,12 @@
 #   case 24 a configured status item that is not a working directory — dies
 #           the moment the codex shape judges what follows the separator,
 #           because no shape separates a configured item from a sentence
+#   case 26 a codex pane on a dialog with a claude status line in its
+#           transcript — dies the moment a codex pane can reach the claude
+#           shape, which is the one way the fail-closed rule was bypassed
+#   case 27 a claude pane quoting a codex status line on its final row —
+#           dies the moment the harness is inferred from the screen instead
+#           of taken from the pane
 #   case 13 a pane that exited to its shell — dies if the liveness evidence
 #           is dropped, which is the only thing a window ever stood in for
 #
@@ -43,9 +52,9 @@
 #   3. the bottom-most claude reading wins over one repainted past
 #   4. a screen with neither shape is no_status_line, never 0
 #   5. a pane that cannot be captured is unreadable, never 0
-#   6. a percentage over 100 is not a context figure, in either shape, and a
-#      codex line carrying one settles the reading rather than falling
-#      through to a claude match higher up
+#   6. a percentage over 100 is not a context figure, in either shape, and on
+#      a pane offered both shapes a codex line carrying one settles the
+#      reading rather than falling through to a claude match higher up
 #   7. the table names the direction it reports, in its header and its rows
 #   8. an empty fleet says so; an unreadable claim store refuses
 #   9. the account column names the lane the pane runs under
@@ -74,6 +83,9 @@
 #  24. the configured status items `[tui].status_line` draws are accepted,
 #      one item or several, none of them a working directory
 #  25. every committed codex capture parses to the figure on its screen
+#  26. a codex pane that does not end in a codex status line carries no
+#      reading, whatever its transcript holds, and says what it could not read
+#  27. a claude pane is read by the claude shape however its screen ends
 #
 # errexit is on: every case here either succeeds or is guarded, so an
 # unexpected non-zero is a broken fixture, not a finding to print past.
@@ -199,8 +211,12 @@ echo "=== lanes context ==="
 
 # Foreground process per pane. %9 is the one that exited to its shell.
 {
-  for n in 1 2 3 4 5 10 13 14 15 16 21; do printf '%s %%%s claude\n' "$LIVE_PID" "$n"; done
-  for n in 6 7 8 19 20 22 23; do printf '%s %%%s codex\n' "$LIVE_PID" "$n"; done
+  for n in 1 3 4 5 10 13 14 15 16 21 26; do printf '%s %%%s claude\n' "$LIVE_PID" "$n"; done
+  for n in 2 6 7 8 19 20 22 23 24 25; do printf '%s %%%s codex\n' "$LIVE_PID" "$n"; done
+  # 6, both-shapes arm. `pi` is a harness this reader measures and has no
+  # shape rule for, so both are offered and the fall-through guard is
+  # reachable — the only place it still is.
+  printf '%s %%27 pi\n' "$LIVE_PID"
   printf '%s %%9 fish\n' "$LIVE_PID"
   # tmux reports a login shell with the leading dash it was started with.
   printf '%s %%11 -bash\n' "$LIVE_PID"
@@ -235,6 +251,10 @@ write_claim twentyone "%20" "$H/.codex"  "ken-121"
 write_claim twentytwo   "%21" "$H/.claude" "ken-122"
 write_claim twentythree "%22" "$H/.codex"  "ken-123"
 write_claim twentyfour  "%23" "$H/.codex"  "ken-124"
+write_claim twentyfive  "%24" "$H/.codex"  "ken-125"
+write_claim twentysix   "%25" "$H/.codex"  "ken-126"
+write_claim twentyseven "%26" "$H/.claude" "ken-127"
+write_claim twentyeight "%27" "$H/.codex"  "ken-128"
 # The foreign lane's pane NUMBER exists here too, on a screen that parses
 # cleanly: %1 is ken-101's, reading 35.
 write_claim_on "$FOREIGN_PID" foreign "%1" "$H/.claude" "ken-110"
@@ -275,11 +295,7 @@ screen 4 'plain shell output with no harness status line'
 screen 6 '  Codex is working
   Context 40% used'
 screen 7 '  Context 86% left · Opus 5 41%'
-# 6, codex arm. The claude status line above is what a fall-through would
-# find: a codex line the reader cannot use is a refusal, not a reason to go
-# looking further up the screen.
-screen 8 '  kendex (🌳 ken-108) Opus 5 35% (brad@drovr.dev)     /rc
-  Context 140% left'
+screen 8 '  Context 140% left'
 screen 9 '  kendex (🌳 ken-109) Opus 5 41% (brad@drovr.dev)     /rc
   ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents
 $ git status
@@ -359,6 +375,36 @@ screen 21 '  kendex (🌳 ken-122) Opus 5 41% (brad@drovr.dev)     /rc
 # an unmeasured lane, which the overseer never compacts.
 screen 22 '  Context 100% left · gpt-5.6-sol default'
 screen 23 '  Context 78% left · gpt-5.6-sol default · ken-885 · kendex · 0.151.0'
+# 26. A codex pane with a dialog over its footer, and a claude status line in
+# the transcript above — this fleet pastes both harnesses' screens into both
+# harnesses' terminals, so that line is ordinary here. %24 has a real codex
+# status line above the dialog and %25 has none, and the two must agree: the
+# dialog is covering whatever the lane is showing now, so neither is a
+# reading. Falling through to the claude shape answers with the wrong harness
+# AND the wrong number, and finding the covered status line by searching past
+# the dialog answers with a figure the lane has moved on from.
+screen 24 '  Codex is working
+  kendex (🌳 ken-125) Opus 5 35% (brad@drovr.dev)     /rc
+  Context 86% left
+  Press enter to continue'
+screen 25 '  Codex is working
+  kendex (🌳 ken-126) Opus 5 35% (brad@drovr.dev)     /rc
+  Press enter to continue'
+# 27. The same confusion the other way round. A claude pane whose final row
+# quotes a codex status line is still a claude lane, and reading it as codex
+# reports 14 used for a lane that is 41 used. Which harness a pane runs is the
+# caller's to say; the screen cannot be asked.
+screen 26 '  kendex (🌳 ken-127) Opus 5 41% (brad@drovr.dev)     /rc
+  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents
+● A codex lane prints:
+  Context 86% left'
+# 6, both-shapes arm. A pane running a harness with no shape rule is offered
+# both, and there the codex line on the final row still settles the reading:
+# out of range, it is a refusal, not a reason to take the claude status line
+# above it. That fall-through is unreachable on a codex pane, where the claude
+# shape is never offered at all.
+screen 27 '  kendex (🌳 ken-128) Opus 5 35% (brad@drovr.dev)     /rc
+  Context 140% left'
 
 OUT="$(run_ctx --json)"
 
@@ -405,12 +451,15 @@ assert_eq "$(jq -r '.[] | select(.lane=="ken-107") | .harness' <<<"$OUT")" "code
   "the context item at the line's opening is what names the harness"
 
 # 6 (codex arm). Over 100 is not a context figure in either shape: unguarded,
-# the conversion turns 140 left into -40 used. The claude status line sitting
-# above it is what a fall-through would report instead — 35, from a line the
-# screen does not end on — so the codex line settles the reading either way.
+# the conversion turns 140 left into -40 used. %27 is the same line on a pane
+# whose harness has no shape rule, where both shapes ARE offered: the claude
+# status line above it is what a fall-through would report instead, 35, from a
+# line the screen does not end on.
 assert_eq "$(jq -r '.[] | select(.lane=="ken-108") | .status' <<<"$OUT")" "no_status_line" \
   "a codex percentage over 100 is not read as a context figure"
 assert_eq "$(jq -r '.[] | select(.lane=="ken-108") | .context_used_pct' <<<"$OUT")" "null" \
+  "an out-of-range codex reading carries no number"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-128") | .context_used_pct' <<<"$OUT")" "null" \
   "an out-of-range codex line refuses rather than falling through to a match above it"
 
 # 13. The pane exited to its shell. Its last render is still on the screen and
@@ -521,6 +570,33 @@ assert_eq "$(jq -r '.[] | select(.lane=="ken-124") | .context_used_pct' <<<"$OUT
 assert_eq "$(jq -r '.[] | select(.lane=="ken-124") | .status' <<<"$OUT")" "ok" \
   "several items behind the separator are not a reason to refuse the lane"
 
+# 26. THE fail-closed rule, held shut against the one thing that bypassed it:
+# a claude-shaped line in a codex pane's transcript. The claude shape is not
+# offered on a codex pane at all, so both screens refuse — the one whose
+# status line the dialog covers and the one that has none. Bottom-most
+# recovered the covered line and answered 14; the claude fallback answered
+# claude 35. Neither is what the lane is showing.
+assert_eq "$(jq -r '.[] | select(.lane=="ken-125") | .status' <<<"$OUT")" "no_status_line" \
+  "a dialog over a codex footer is could-not-tell, not the status line it covers"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-125") | .context_used_pct' <<<"$OUT")" "null" \
+  "a claude-shaped line in a codex pane's transcript is not a reading"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-125") | .harness' <<<"$OUT")" "null" \
+  "and it does not put the wrong harness in the report either"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-126") | .status' <<<"$OUT")" "no_status_line" \
+  "the same pane with no codex status line at all answers the same way"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-126") | .context_used_pct' <<<"$OUT")" "null" \
+  "the two halves agree rather than differing by what sits above the dialog"
+assert_contains "$(jq -r '.[] | select(.lane=="ken-125") | .detail' <<<"$OUT")" "does not end in a codex status line" \
+  "the refusal names what it could not read, not a missing figure of either shape"
+
+# 27. And the same confusion in the other direction. A codex status line
+# quoted in a claude pane's transcript is not this lane's reading, whatever
+# row it lands on.
+assert_eq "$(jq -r '.[] | select(.lane=="ken-127") | .context_used_pct' <<<"$OUT")" "41" \
+  "a codex status line quoted on a claude pane does not take the lane's reading"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-127") | .harness' <<<"$OUT")" "claude" \
+  "the pane's own harness is what names the reading"
+
 # 25. Every committed codex capture, parsed as it stands. These are real
 # `tmux capture-pane` output from Codex 0.151.0 (KEN-863), and they are the
 # evidence the position rule rests on: in all four that carry a status line
@@ -531,7 +607,7 @@ assert_eq "$(jq -r '.[] | select(.lane=="ken-124") | .status' <<<"$OUT")" "ok" \
 FIXTURES="$TEST_DIR/fixtures/oversee-watch"
 
 parse_fixture() { # <capture file name>
-  "$BASH" -c 'source "$1"; lane_context_parse <"$2"' _ \
+  "$BASH" -c 'source "$1"; lane_context_parse codex <"$2"' _ \
     "$SCRIPTS_DIR/lib/lane-context.sh" "$FIXTURES/$1" || printf 'none\n'
 }
 
@@ -565,6 +641,8 @@ assert_eq "$(jq -r '.[] | select(.lane=="ken-104") | .status' <<<"$OUT")" "no_st
   "a screen with neither shape is no_status_line"
 assert_eq "$(jq -r '.[] | select(.lane=="ken-104") | .context_used_pct' <<<"$OUT")" "null" \
   "a lane with no status line carries no number"
+assert_contains "$(jq -r '.[] | select(.lane=="ken-104") | .detail' <<<"$OUT")" "no claude status line" \
+  "the refusal names the shape that pane was read for, not both shapes"
 
 write_claim five "%5" "$H/.claude" "ken-105"
 UNREAD="$(run_ctx --json)"

--- a/skills/orch/tests/lanes_context.sh
+++ b/skills/orch/tests/lanes_context.sh
@@ -27,6 +27,9 @@
 #   case 22 the same sentence in the CODEX shape, which carries its fragment
 #           in ordinary prose about compaction — dies the moment the codex
 #           branch is loosened back to matching anywhere in a line
+#   case 24 the same sentence two words long — dies the moment the codex
+#           trailing item is admitted by token COUNT rather than by shape,
+#           which is how `compact now` passed for a status item
 #   case 13 a pane that exited to its shell — dies if the liveness evidence
 #           is dropped, which is the only thing a window ever stood in for
 #
@@ -44,7 +47,8 @@
 #  10. a claim on ANOTHER tmux server is unreadable, never a local pane's
 #      number under its name
 #  11. codex's other status item, `Context 40% used`, is taken as it stands
-#  12. one line carrying both shapes reads as codex, not claude
+#  12. a claude status item behind the codex separator is not a codex
+#      status line; the codex status item carries a path and nothing else
 #  13. a pane that has exited to its shell is not measured from what it left
 #  14. a model and a percentage in prose is not a status line
 #  15. an unenumerable tmux server refuses every claim, not just foreign ones
@@ -62,6 +66,8 @@
 #  22. a codex context fragment in prose is not a status line, alone or
 #      below a real one
 #  23. the table still carries every row where `column` is not installed
+#  24. two words behind the codex separator are prose, not a status item
+#  25. every committed codex capture parses to the figure on its screen
 #
 # errexit is on: every case here either succeeds or is guarded, so an
 # unexpected non-zero is a broken fixture, not a finding to print past.
@@ -188,7 +194,7 @@ echo "=== lanes context ==="
 # Foreground process per pane. %9 is the one that exited to its shell.
 {
   for n in 1 2 3 4 5 10 13 14 15 16 21; do printf '%s %%%s claude\n' "$LIVE_PID" "$n"; done
-  for n in 6 7 8 19 20 22; do printf '%s %%%s codex\n' "$LIVE_PID" "$n"; done
+  for n in 6 7 8 19 20 22 23; do printf '%s %%%s codex\n' "$LIVE_PID" "$n"; done
   printf '%s %%9 fish\n' "$LIVE_PID"
   # tmux reports a login shell with the leading dash it was started with.
   printf '%s %%11 -bash\n' "$LIVE_PID"
@@ -222,6 +228,7 @@ write_claim twenty    "%19" "$H/.codex"  "ken-120"
 write_claim twentyone "%20" "$H/.codex"  "ken-121"
 write_claim twentytwo   "%21" "$H/.claude" "ken-122"
 write_claim twentythree "%22" "$H/.codex"  "ken-123"
+write_claim twentyfour  "%23" "$H/.codex"  "ken-124"
 # The foreign lane's pane NUMBER exists here too, on a screen that parses
 # cleanly: %1 is ken-101's, reading 35.
 write_claim_on "$FOREIGN_PID" foreign "%1" "$H/.claude" "ken-110"
@@ -317,9 +324,9 @@ screen 19 '  Codex is working
   Context 86% left
 ● Documentation: Context 60% used means compact now'
 screen 20 '● Documentation: Context 60% used means compact now'
-# 23 and 24. The other end of the same fragment. Prose can put the sentence
-# AFTER the status shape as easily as before it, and then the status-shaped
-# PREFIX is what matches while the sentence it sits inside never has to. Both
+# 22, trailing half. The other end of the same fragment. Prose can put the
+# sentence AFTER the status shape as easily as before it, and then the
+# status-shaped PREFIX matches while the sentence it sits in never has to. Both
 # screens put that line BELOW a real status line, which is where bottom-most
 # hands it the verdict.
 screen 21 '  kendex (🌳 ken-122) Opus 5 41% (brad@drovr.dev)     /rc
@@ -328,6 +335,15 @@ screen 21 '  kendex (🌳 ken-122) Opus 5 41% (brad@drovr.dev)     /rc
 screen 22 '  Context 86% left
 ● Context 77% used means compact now
 ● Context 77% used · and that is an example'
+# 24. The reproduction from KEN-885, and the shortest sentence of the class:
+# two words behind the separator. A trailing item admitted by token COUNT
+# takes `compact now` for a status item, and bottom-most then reports 60 used
+# for a lane that is 14 used — the overseer compacts the emptiest lane in the
+# fleet and skips the full one. Codex puts its working directory behind that
+# separator, so the item is matched by that shape and a sentence of any
+# length fails it.
+screen 23 'Context 86% left
+Context 60% used · compact now'
 
 OUT="$(run_ctx --json)"
 
@@ -361,13 +377,15 @@ assert_eq "$(jq -r '.[] | select(.lane=="ken-106") | .context_used_pct' <<<"$OUT
 assert_eq "$(jq -r '.[] | select(.lane=="ken-106") | .harness' <<<"$OUT")" "codex" \
   "the codex used shape names the codex harness"
 
-# 12. One line carrying both shapes. The codex branch consumes its line, so
-# the claude branch never re-reads it in the opposite direction: without that,
-# this screen reports 41 used for a lane that is 14 used.
-assert_eq "$(jq -r '.[] | select(.lane=="ken-107") | .context_used_pct' <<<"$OUT")" "14" \
-  "a line carrying both shapes is read as codex"
-assert_eq "$(jq -r '.[] | select(.lane=="ken-107") | .harness' <<<"$OUT")" "codex" \
-  "the codex shape wins the line it matched"
+# 12. `Opus 5 41%` is a claude status item, and behind the codex separator it
+# is not a status line of either harness: codex draws its working directory
+# there and nothing else, and the claude shape needs an account parenthetical
+# this line has none of. A trailing item admitted by token count took it for a
+# codex reading, which is the same allowance `compact now` walked through.
+assert_eq "$(jq -r '.[] | select(.lane=="ken-107") | .status' <<<"$OUT")" "no_status_line" \
+  "a claude status item behind the codex separator is not a codex status line"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-107") | .context_used_pct' <<<"$OUT")" "null" \
+  "that lane carries no number, not the one that shape carried"
 
 # 6 (codex arm). Over 100 is not a context figure in either shape: unguarded,
 # the conversion turns 140 left into -40 used.
@@ -459,15 +477,48 @@ assert_eq "$(jq -r '.[] | select(.lane=="ken-121") | .status' <<<"$OUT")" "no_st
 assert_eq "$(jq -r '.[] | select(.lane=="ken-121") | .context_used_pct' <<<"$OUT")" "null" \
   "that lane carries no number, not the sentence's"
 
-# 23 and 24. The trailing half of the same class: a status-shaped PREFIX with
-# prose after it. The claude line ends in its account and claude's own
-# right-hand hint; the codex line ends in its context item or one short
-# status item behind a separator. Neither end admits a sentence, so the real
-# status line above keeps the verdict.
+# 22, trailing half. A status-shaped PREFIX with prose after it. The claude
+# line ends in its account and claude's own right-hand hint; the codex line
+# ends in its context item or a working directory behind a separator. Neither
+# end admits a sentence, so the real status line above keeps the verdict.
 assert_eq "$(jq -r '.[] | select(.lane=="ken-122") | .context_used_pct' <<<"$OUT")" "41" \
   "claude prose after a status-shaped prefix does not outrank the status line above it"
 assert_eq "$(jq -r '.[] | select(.lane=="ken-123") | .context_used_pct' <<<"$OUT")" "14" \
   "codex prose after a status-shaped prefix does not outrank the status line above it"
+
+# 24. The reproduction from KEN-885. Two words behind the separator is the
+# shortest sentence of this class and the one a token count cannot refuse:
+# the lane has 14 used and the report called it 60, so the overseer compacted
+# the emptiest lane in the fleet and left the full one running.
+assert_eq "$(jq -r '.[] | select(.lane=="ken-124") | .context_used_pct' <<<"$OUT")" "14" \
+  "two words behind the codex separator are prose, not a status item"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-124") | .harness' <<<"$OUT")" "codex" \
+  "the real status line above keeps the verdict, and the harness with it"
+
+# 25. Every committed codex capture, parsed as it stands. These are real
+# `tmux capture-pane` output from Codex 0.151.0 (KEN-863), so what the reader
+# anchors to is what the harness draws: `Context <N>% left`, a separator, and
+# the session's working directory, ellipsised where the width ran out. A
+# capture whose screen carries no status line is a refusal, never a zero.
+FIXTURES="$TEST_DIR/fixtures/oversee-watch"
+
+parse_fixture() { # <capture file name>
+  "$BASH" -c 'source "$1"; lane_context_parse <"$2"' _ \
+    "$SCRIPTS_DIR/lib/lane-context.sh" "$FIXTURES/$1" || printf 'none\n'
+}
+
+assert_eq "$(parse_fixture codex-working.txt)" "$(printf 'codex\t0')" \
+  "the working capture reads 100% left as a context with nothing used"
+assert_eq "$(parse_fixture codex-composer-draft.txt)" "$(printf 'codex\t0')" \
+  "the composer-draft capture parses to the figure on its screen"
+assert_eq "$(parse_fixture codex-composer-idle.txt)" "$(printf 'codex\t0')" \
+  "the composer-idle capture parses to the figure on its screen"
+assert_eq "$(parse_fixture codex-idle-after-turn.txt)" "$(printf 'codex\t1')" \
+  "the idle-after-turn capture converts 99% left to 1 used"
+assert_eq "$(parse_fixture codex-dialog-model.txt)" "none" \
+  "a capture whose dialog covers the status line carries no reading"
+assert_eq "$(parse_fixture codex-dialog-trust.txt)" "none" \
+  "the trust-dialog capture carries no reading either"
 
 # 10. `capture-pane -t %N` answers from THIS server only, and pane ids restart
 # at %0 on each one. ken-110 claims %1 on another server; %1 here is ken-101's

--- a/skills/orch/tests/lanes_context.sh
+++ b/skills/orch/tests/lanes_context.sh
@@ -41,6 +41,9 @@
 #   case 27 a claude pane quoting a codex status line on its final row —
 #           dies the moment the harness is inferred from the screen instead
 #           of taken from the pane
+#   case 28 a codex lane whose pane command is the agent-confine wrapper —
+#           dies the moment that wrapper is read as a harness spelling
+#           instead of as the launcher both harnesses exec through
 #   case 13 a pane that exited to its shell — dies if the liveness evidence
 #           is dropped, which is the only thing a window ever stood in for
 #
@@ -86,6 +89,9 @@
 #  26. a codex pane that does not end in a codex status line carries no
 #      reading, whatever its transcript holds, and says what it could not read
 #  27. a claude pane is read by the claude shape however its screen ends
+#  28. the agent-confine wrapper names no harness, so a pane running it is
+#      offered both shapes and a wrapped codex lane is measured like any
+#      other
 #
 # errexit is on: every case here either succeeds or is guarded, so an
 # unexpected non-zero is a broken fixture, not a finding to print past.
@@ -217,6 +223,10 @@ echo "=== lanes context ==="
   # shape rule for, so both are offered and the fall-through guard is
   # reachable — the only place it still is.
   printf '%s %%27 pi\n' "$LIVE_PID"
+  # 28. agent-confine is the launcher BOTH harnesses exec through, so its
+  # pane command names neither and both shapes are offered. %28 is a wrapped
+  # codex lane, %29 a wrapped claude one, %30 a wrapped pane showing neither.
+  for n in 28 29 30; do printf '%s %%%s agent-confine\n' "$LIVE_PID" "$n"; done
   printf '%s %%9 fish\n' "$LIVE_PID"
   # tmux reports a login shell with the leading dash it was started with.
   printf '%s %%11 -bash\n' "$LIVE_PID"
@@ -255,6 +265,9 @@ write_claim twentyfive  "%24" "$H/.codex"  "ken-125"
 write_claim twentysix   "%25" "$H/.codex"  "ken-126"
 write_claim twentyseven "%26" "$H/.claude" "ken-127"
 write_claim twentyeight "%27" "$H/.codex"  "ken-128"
+write_claim twentynine  "%28" "$H/.codex"  "ken-129"
+write_claim thirty      "%29" "$H/.claude" "ken-130"
+write_claim thirtyone   "%30" "$H/.codex"  "ken-131"
 # The foreign lane's pane NUMBER exists here too, on a screen that parses
 # cleanly: %1 is ken-101's, reading 35.
 write_claim_on "$FOREIGN_PID" foreign "%1" "$H/.claude" "ken-110"
@@ -405,6 +418,20 @@ screen 26 '  kendex (🌳 ken-127) Opus 5 41% (brad@drovr.dev)     /rc
 # shape is never offered at all.
 screen 27 '  kendex (🌳 ken-128) Opus 5 35% (brad@drovr.dev)     /rc
   Context 140% left'
+# 28. A wrapped lane. Its pane command is `agent-confine`, which is what both
+# harnesses exec through, so it names neither and both shapes are offered.
+# %28 is a codex lane whose screen ends on its own status line: read for the
+# claude shape alone it is a refusal, and an unmeasured lane is one the
+# overseer never compacts. %29 holds the other half shut — a wrapped claude
+# lane under an agent-row footer, which the codex shape cannot reach because
+# that footer is what the screen ends on. %30 shows neither shape, and its
+# refusal names both.
+screen 28 '  Codex is working
+  Context 86% left'
+screen 29 '  kendex (🌳 ken-130) Opus 5 27% (brad@drovr.dev)     /rc
+  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← 1 agent
+  ◯ dev-ken-885  Follow workflow: .agents/skills/dev/workflo… 4m 2s'
+screen 30 'plain shell output with no harness status line'
 
 OUT="$(run_ctx --json)"
 
@@ -596,6 +623,24 @@ assert_eq "$(jq -r '.[] | select(.lane=="ken-127") | .context_used_pct' <<<"$OUT
   "a codex status line quoted on a claude pane does not take the lane's reading"
 assert_eq "$(jq -r '.[] | select(.lane=="ken-127") | .harness' <<<"$OUT")" "claude" \
   "the pane's own harness is what names the reading"
+
+# 28. The wrapper is not a harness spelling. Dispatched to the claude shape
+# alone, %28's perfectly good final row is a refusal and the lane goes
+# unmeasured — the outcome this reader exists to prevent, on the one pane
+# command a codex lane is as likely to present as a claude one. %29 is what
+# offering both shapes must not cost: the codex shape only ever sees the last
+# row, and a claude footer sits below the status line, so the wrapped claude
+# lane keeps its reading.
+assert_eq "$(jq -r '.[] | select(.lane=="ken-129") | .context_used_pct' <<<"$OUT")" "14" \
+  "a wrapped codex lane is read at the line its screen ends on"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-129") | .harness' <<<"$OUT")" "codex" \
+  "the wrapper names no harness; the shape that matched does"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-130") | .context_used_pct' <<<"$OUT")" "27" \
+  "a wrapped claude lane keeps its reading from under the agent-row footer"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-130") | .harness' <<<"$OUT")" "claude" \
+  "and is still named claude"
+assert_contains "$(jq -r '.[] | select(.lane=="ken-131") | .detail' <<<"$OUT")" "neither harness's context figure" \
+  "a wrapped pane showing neither shape is refused for both, not for claude alone"
 
 # 25. Every committed codex capture, parsed as it stands. These are real
 # `tmux capture-pane` output from Codex 0.151.0 (KEN-863), and they are the

--- a/skills/orch/tests/lanes_context.sh
+++ b/skills/orch/tests/lanes_context.sh
@@ -486,6 +486,8 @@ assert_eq "$(jq -r '.[] | select(.lane=="ken-108") | .status' <<<"$OUT")" "no_st
   "a codex percentage over 100 is not read as a context figure"
 assert_eq "$(jq -r '.[] | select(.lane=="ken-108") | .context_used_pct' <<<"$OUT")" "null" \
   "an out-of-range codex reading carries no number"
+assert_contains "$(jq -r '.[] | select(.lane=="ken-108") | .detail' <<<"$OUT")" "does not end in a valid codex context figure" \
+  "the refusal states what it checked, on the pane whose figure nothing is covering"
 assert_eq "$(jq -r '.[] | select(.lane=="ken-128") | .context_used_pct' <<<"$OUT")" "null" \
   "an out-of-range codex line refuses rather than falling through to a match above it"
 

--- a/skills/orch/tests/lanes_context.sh
+++ b/skills/orch/tests/lanes_context.sh
@@ -9,14 +9,16 @@
 # the overseer to compact the emptiest lane in the fleet, so the direction is
 # what these cases pin.
 #
-# Where the status line SITS is pinned too, and by property rather than by
-# count. Case 1's screen is a real `tmux capture-pane`; the other claude
-# screens are built from real status lines. The footer under a status line
-# grows by a row per running agent, so no line count reaches an
-# orchestrating lane's. Four cases hold that shut, each against a different
-# mutation:
-#   case 1  an orchestrating lane's real footer — dies the moment any bottom
-#           window narrower than it is taken off the screen
+# Where the status line SITS is pinned too, and the two harnesses put it in
+# different places. Codex draws it LAST, so the codex reading comes from the
+# final non-empty line and from no other. Claude draws a row per running
+# agent BELOW its status line, so its footer has no bound and its reading is
+# the bottom-most whole-line match. Case 1's screen is a real
+# `tmux capture-pane`; the other claude screens are built from real status
+# lines. Cases hold each half shut, one per mutation:
+#   case 1  an orchestrating lane's real footer, whose final line is an agent
+#           row — dies the moment the claude reading is taken by position
+#           too, or any bottom window narrower than the footer is taken off
 #   case 14 a session with no percentage yet, under prose that names a model
 #           and one — dies if the claude shape is loosened back to accepting
 #           words between the model name and the percentage
@@ -24,31 +26,34 @@
 #           dies if a reading is a FRAGMENT of the status line rather than
 #           the whole line, because bottom-most then hands the sentence the
 #           verdict over the real line above it
-#   case 22 the same sentence in the CODEX shape, which carries its fragment
-#           in ordinary prose about compaction — dies the moment the codex
-#           branch is loosened back to matching anywhere in a line
-#   case 24 the same sentence two words long — dies the moment the codex
-#           trailing item is admitted by token COUNT rather than by shape,
-#           which is how `compact now` passed for a status item
+#   case 22 a codex screen whose final line is not a status line, with a real
+#           one above it — dies the moment the codex reading goes back to
+#           searching the screen instead of reading the line it ends on
+#   case 24 a configured status item that is not a working directory — dies
+#           the moment the codex shape judges what follows the separator,
+#           because no shape separates a configured item from a sentence
 #   case 13 a pane that exited to its shell — dies if the liveness evidence
 #           is dropped, which is the only thing a window ever stood in for
 #
 # Covered:
 #   1. the claude shape reports its number as used, wherever the footer puts
 #      the status line
-#   2. the codex shape is converted, not reported raw
-#   3. the bottom-most reading wins over one repainted past
+#   2. the codex shape is converted, not reported raw, and is read off the
+#      line the screen ends on, blank rows below it and all
+#   3. the bottom-most claude reading wins over one repainted past
 #   4. a screen with neither shape is no_status_line, never 0
 #   5. a pane that cannot be captured is unreadable, never 0
-#   6. a percentage over 100 is not a context figure, in either shape
+#   6. a percentage over 100 is not a context figure, in either shape, and a
+#      codex line carrying one settles the reading rather than falling
+#      through to a claude match higher up
 #   7. the table names the direction it reports, in its header and its rows
 #   8. an empty fleet says so; an unreadable claim store refuses
 #   9. the account column names the lane the pane runs under
 #  10. a claim on ANOTHER tmux server is unreadable, never a local pane's
 #      number under its name
 #  11. codex's other status item, `Context 40% used`, is taken as it stands
-#  12. a claude status item behind the codex separator is not a codex
-#      status line; the codex status item carries a path and nothing else
+#  12. whatever follows the codex separator is taken as it comes, a claude
+#      status item included; the shape reads no further than the separator
 #  13. a pane that has exited to its shell is not measured from what it left
 #  14. a model and a percentage in prose is not a status line
 #  15. an unenumerable tmux server refuses every claim, not just foreign ones
@@ -63,10 +68,11 @@
 #      refused, and the refusal names the process it found
 #  21. the per-account wrapper spellings the fleet launches through are
 #      harnesses, and their panes are measured
-#  22. a codex context fragment in prose is not a status line, alone or
-#      below a real one
+#  22. a codex screen whose final line is not a status line carries no
+#      reading, and the real status line above it is not searched out
 #  23. the table still carries every row where `column` is not installed
-#  24. two words behind the codex separator are prose, not a status item
+#  24. the configured status items `[tui].status_line` draws are accepted,
+#      one item or several, none of them a working directory
 #  25. every committed codex capture parses to the figure on its screen
 #
 # errexit is on: every case here either succeeds or is guarded, so an
@@ -251,8 +257,13 @@ screen 1 '  ⎿  Tip: Use /clear to start fresh when switching topics and free u
   ◯ dev-ken835  Follow workflow: .agents/skills/dev/workflows/dev-...   7m 45s · ↓ 937.0k tokens
   ◯ dev-ken-845  Follow workflow: .agents/skills/dev/workflo… 8m 45s · ↓ 364.8k tokens
   ◯ dev-ken-844-c  Follow workflow: .agents/skills/dev/workflo… 4m 2s · ↓ 75.8k tokens'
+# 2. The codex status line is the last NON-EMPTY row: a real capture carries
+# blank rows under it, and a rule that read the last row outright would find
+# one of those and report nothing.
 screen 2 '  Codex is working
-  Context 86% left'
+  Context 86% left
+
+'
 # A repaint after a compaction leaves the previous render on the screen.
 screen 3 '  kendex (🌳 ken-103) Opus 5 92% (brad@drovr.dev)     /rc
   ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents
@@ -264,7 +275,11 @@ screen 4 'plain shell output with no harness status line'
 screen 6 '  Codex is working
   Context 40% used'
 screen 7 '  Context 86% left · Opus 5 41%'
-screen 8 '  Context 140% left'
+# 6, codex arm. The claude status line above is what a fall-through would
+# find: a codex line the reader cannot use is a refusal, not a reason to go
+# looking further up the screen.
+screen 8 '  kendex (🌳 ken-108) Opus 5 35% (brad@drovr.dev)     /rc
+  Context 140% left'
 screen 9 '  kendex (🌳 ken-109) Opus 5 41% (brad@drovr.dev)     /rc
   ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents
 $ git status
@@ -314,36 +329,36 @@ screen 17 '  kendex (🌳 ken-118) Opus 5 66% (brad@drovr.dev)     /rc
   ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents'
 screen 18 '  kendex (🌳 ken-119) Opus 5 27% (brad@drovr.dev)     /rc
   ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents'
-# 22. The codex sibling of 18 and 19. The compaction rule is written about
-# in the terminal it governs, so `Context <N>% used` turns up in ordinary
-# transcript prose — and a fragment match hands that sentence the verdict
-# over the real status line above it, exactly as the claude fragment did.
-# %19 puts the sentence BELOW a real codex status line; %20 gives it a
-# screen of its own.
+# 22. THE fail-closed case. A codex screen whose final line is not a status
+# line carries no reading, and the real status line above it is not searched
+# out: a screen that does not end in its status line is a screen the reader
+# cannot vouch for — caught mid-redraw, or with a dialog over the footer —
+# and reporting the last figure it can find there is reporting a number from
+# before whatever moved the line. %19 puts a real status line above a line
+# that is not one; %20 gives that line a screen of its own.
 screen 19 '  Codex is working
   Context 86% left
 ● Documentation: Context 60% used means compact now'
 screen 20 '● Documentation: Context 60% used means compact now'
-# 22, trailing half. The other end of the same fragment. Prose can put the
+# 18, trailing half. The other end of the same fragment. Prose can put the
 # sentence AFTER the status shape as easily as before it, and then the
-# status-shaped PREFIX matches while the sentence it sits in never has to. Both
-# screens put that line BELOW a real status line, which is where bottom-most
-# hands it the verdict.
+# status-shaped PREFIX matches while the sentence it sits in never has to.
+# The claude reading is the bottom-most match, so this screen puts that line
+# below a real status line, which is where bottom-most would hand it the
+# verdict. There is no codex sibling any more: a codex screen is read at the
+# line it ends on, so what a sentence there is shaped like never comes up.
 screen 21 '  kendex (🌳 ken-122) Opus 5 41% (brad@drovr.dev)     /rc
   ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents
 /fake Opus 5 99% (work) is an example'
-screen 22 '  Context 86% left
-● Context 77% used means compact now
-● Context 77% used · and that is an example'
-# 24. The reproduction from KEN-885, and the shortest sentence of the class:
-# two words behind the separator. A trailing item admitted by token COUNT
-# takes `compact now` for a status item, and bottom-most then reports 60 used
-# for a lane that is 14 used — the overseer compacts the emptiest lane in the
-# fleet and skips the full one. Codex puts its working directory behind that
-# separator, so the item is matched by that shape and a sentence of any
-# length fails it.
-screen 23 'Context 86% left
-Context 60% used · compact now'
+# 24. `[tui].status_line` is a real config key, and the items it draws behind
+# the separator are not all working directories. %22 carries the one the
+# committed captures do not: a model with its reasoning effort, two bare
+# words. %23 carries four items at once — model, git branch, project name,
+# codex version — because the key takes a list. A shape that judges what
+# follows the separator refuses one or both of these, and a refused lane is
+# an unmeasured lane, which the overseer never compacts.
+screen 22 '  Context 100% left · gpt-5.6-sol default'
+screen 23 '  Context 78% left · gpt-5.6-sol default · ken-885 · kendex · 0.151.0'
 
 OUT="$(run_ctx --json)"
 
@@ -358,9 +373,12 @@ assert_eq "$(jq -r '.[] | select(.lane=="ken-101") | .status' <<<"$OUT")" "ok" \
 
 # 2. THE conversion. `Context 86% left` is a nearly EMPTY context; reported
 # raw it is the fullest lane in the fleet and the overseer compacts the wrong
-# one.
+# one. The screen ends in blank rows, as a real capture does, so this also
+# holds the codex reading to the last NON-EMPTY line.
 assert_eq "$(jq -r '.[] | select(.lane=="ken-102") | .context_used_pct' <<<"$OUT")" "14" \
   "the codex status line is converted from remaining to used"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-102") | .status' <<<"$OUT")" "ok" \
+  "blank rows below the status line do not cost the lane its reading"
 assert_eq "$(jq -r '.[] | select(.lane=="ken-102") | .harness' <<<"$OUT")" "codex" \
   "the codex shape names the codex harness"
 
@@ -377,22 +395,23 @@ assert_eq "$(jq -r '.[] | select(.lane=="ken-106") | .context_used_pct' <<<"$OUT
 assert_eq "$(jq -r '.[] | select(.lane=="ken-106") | .harness' <<<"$OUT")" "codex" \
   "the codex used shape names the codex harness"
 
-# 12. `Opus 5 41%` is a claude status item, and behind the codex separator it
-# is not a status line of either harness: codex draws its working directory
-# there and nothing else, and the claude shape needs an account parenthetical
-# this line has none of. A trailing item admitted by token count took it for a
-# codex reading, which is the same allowance `compact now` walked through.
-assert_eq "$(jq -r '.[] | select(.lane=="ken-107") | .status' <<<"$OUT")" "no_status_line" \
-  "a claude status item behind the codex separator is not a codex status line"
-assert_eq "$(jq -r '.[] | select(.lane=="ken-107") | .context_used_pct' <<<"$OUT")" "null" \
-  "that lane carries no number, not the one that shape carried"
+# 12. The shape reads no further than the separator, so what sits past it is
+# taken as it comes — here a claude status item, which no codex config draws
+# and which the reader therefore has no business judging. The line still opens
+# with the codex context item, and that is what the reading is taken from.
+assert_eq "$(jq -r '.[] | select(.lane=="ken-107") | .context_used_pct' <<<"$OUT")" "14" \
+  "whatever follows the codex separator is taken as it comes"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-107") | .harness' <<<"$OUT")" "codex" \
+  "the context item at the line's opening is what names the harness"
 
 # 6 (codex arm). Over 100 is not a context figure in either shape: unguarded,
-# the conversion turns 140 left into -40 used.
+# the conversion turns 140 left into -40 used. The claude status line sitting
+# above it is what a fall-through would report instead — 35, from a line the
+# screen does not end on — so the codex line settles the reading either way.
 assert_eq "$(jq -r '.[] | select(.lane=="ken-108") | .status' <<<"$OUT")" "no_status_line" \
   "a codex percentage over 100 is not read as a context figure"
 assert_eq "$(jq -r '.[] | select(.lane=="ken-108") | .context_used_pct' <<<"$OUT")" "null" \
-  "an out-of-range codex reading carries no number"
+  "an out-of-range codex line refuses rather than falling through to a match above it"
 
 # 13. The pane exited to its shell. Its last render is still on the screen and
 # is not a measurement of anything: what refuses it is the foreground process
@@ -467,39 +486,48 @@ assert_eq "$(jq -r '.[] | select(.lane=="ken-119") | .context_used_pct' <<<"$OUT
 assert_eq "$(jq -r '.[] | select(.lane=="ken-119") | .status' <<<"$OUT")" "ok" \
   "that lane is ok, not a refusal"
 
-# 22. A codex reading is the whole line too. Below a real status line the
-# sentence wins on bottom-most and the lane reports 60 used for a lane that
-# is 14 used; on a screen of its own it is a reading invented out of prose.
-assert_eq "$(jq -r '.[] | select(.lane=="ken-120") | .context_used_pct' <<<"$OUT")" "14" \
-  "codex prose below a status line does not outrank the status line above it"
+# 22. THE fail-closed case. %19 ends in a line that is not a status line and
+# carries a real one above it: the reading is refused rather than searched
+# out, because a screen that does not end in its status line is one the reader
+# cannot vouch for. %20 is the same line with nothing above it. Both are
+# no_status_line, and the moment the codex reading goes back to searching the
+# screen, %19 reports 14 from a line the screen has moved past.
+assert_eq "$(jq -r '.[] | select(.lane=="ken-120") | .status' <<<"$OUT")" "no_status_line" \
+  "a codex screen not ending in a status line carries no reading"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-120") | .context_used_pct' <<<"$OUT")" "null" \
+  "the status line above it is not searched out"
 assert_eq "$(jq -r '.[] | select(.lane=="ken-121") | .status' <<<"$OUT")" "no_status_line" \
   "a screen whose only context percentage sits in codex prose carries no reading"
 assert_eq "$(jq -r '.[] | select(.lane=="ken-121") | .context_used_pct' <<<"$OUT")" "null" \
   "that lane carries no number, not the sentence's"
 
-# 22, trailing half. A status-shaped PREFIX with prose after it. The claude
-# line ends in its account and claude's own right-hand hint; the codex line
-# ends in its context item or a working directory behind a separator. Neither
-# end admits a sentence, so the real status line above keeps the verdict.
+# 18, trailing half. A status-shaped PREFIX with prose after it. The claude
+# line ends in its account and claude's own right-hand hint, and admits no
+# sentence past either, so the real status line above keeps the verdict.
 assert_eq "$(jq -r '.[] | select(.lane=="ken-122") | .context_used_pct' <<<"$OUT")" "41" \
   "claude prose after a status-shaped prefix does not outrank the status line above it"
-assert_eq "$(jq -r '.[] | select(.lane=="ken-123") | .context_used_pct' <<<"$OUT")" "14" \
-  "codex prose after a status-shaped prefix does not outrank the status line above it"
 
-# 24. The reproduction from KEN-885. Two words behind the separator is the
-# shortest sentence of this class and the one a token count cannot refuse:
-# the lane has 14 used and the report called it 60, so the overseer compacted
-# the emptiest lane in the fleet and left the full one running.
-assert_eq "$(jq -r '.[] | select(.lane=="ken-124") | .context_used_pct' <<<"$OUT")" "14" \
-  "two words behind the codex separator are prose, not a status item"
-assert_eq "$(jq -r '.[] | select(.lane=="ken-124") | .harness' <<<"$OUT")" "codex" \
-  "the real status line above keeps the verdict, and the harness with it"
+# 24. The configured status items. `gpt-5.6-sol default` is two bare words
+# and so is `compact now`, so no shape tells them apart — and a shape that
+# refuses the one it has not seen leaves that lane unmeasured, which is the
+# lane the overseer then never compacts. Position is what refuses prose, so
+# these are accepted: one item, and the four a list config draws.
+assert_eq "$(jq -r '.[] | select(.lane=="ken-123") | .context_used_pct' <<<"$OUT")" "0" \
+  "a model with its reasoning effort is a status item, not a sentence"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-123") | .harness' <<<"$OUT")" "codex" \
+  "that lane is measured rather than left out of the report"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-124") | .context_used_pct' <<<"$OUT")" "22" \
+  "a status line carrying four configured items is read like any other"
+assert_eq "$(jq -r '.[] | select(.lane=="ken-124") | .status' <<<"$OUT")" "ok" \
+  "several items behind the separator are not a reason to refuse the lane"
 
 # 25. Every committed codex capture, parsed as it stands. These are real
-# `tmux capture-pane` output from Codex 0.151.0 (KEN-863), so what the reader
-# anchors to is what the harness draws: `Context <N>% left`, a separator, and
-# the session's working directory, ellipsised where the width ran out. A
-# capture whose screen carries no status line is a refusal, never a zero.
+# `tmux capture-pane` output from Codex 0.151.0 (KEN-863), and they are the
+# evidence the position rule rests on: in all four that carry a status line
+# it is the last non-empty row, blank rows below it and nothing else. The
+# other two end in a dialog drawn over the footer, and a reader that searched
+# the screen would report the figure that dialog is covering. A capture whose
+# screen carries no status line is a refusal, never a zero.
 FIXTURES="$TEST_DIR/fixtures/oversee-watch"
 
 parse_fixture() { # <capture file name>

--- a/skills/orch/tests/lanes_context.sh
+++ b/skills/orch/tests/lanes_context.sh
@@ -613,7 +613,7 @@ assert_eq "$(jq -r '.[] | select(.lane=="ken-126") | .status' <<<"$OUT")" "no_st
   "the same pane with no codex status line at all answers the same way"
 assert_eq "$(jq -r '.[] | select(.lane=="ken-126") | .context_used_pct' <<<"$OUT")" "null" \
   "the two halves agree rather than differing by what sits above the dialog"
-assert_contains "$(jq -r '.[] | select(.lane=="ken-125") | .detail' <<<"$OUT")" "does not end in a codex status line" \
+assert_contains "$(jq -r '.[] | select(.lane=="ken-125") | .detail' <<<"$OUT")" "does not end in a valid codex context figure" \
   "the refusal names what it could not read, not a missing figure of either shape"
 
 # 27. And the same confusion in the other direction. A codex status line


### PR DESCRIPTION
`lane_context_parse`'s Codex branch admitted prose, so a line below the real status line took the verdict and the overseer compacted a lane with 86% left while skipping one that was full.

## The mechanism is position, not shape

The first attempt anchored the suffix to a path. Review showed that is wrong: `[tui].status_line` is user-configurable — the vocabulary includes `model-with-reasoning`, `git-branch`, `project-name`, `codex-version`, `used-tokens` — so `Context 100% left · gpt-5.6-sol default` is a real status line, and a lane whose status line is refused is never measured, and an unmeasured lane is never compacted. That is the outcome compaction exists to prevent.

Widening the pattern cannot work either:

```
Context 60% used · compact now              the reported defect, must be refused
Context 100% left · gpt-5.6-sol default     a real configured line, must be accepted
```

Both are a separator and two bare words. The item identifiers are a known set; their rendered values are arbitrary user data. So no suffix shape separates them.

Position does. Codex draws its status line last: in all six live captures committed for KEN-863 it is the final non-empty row. The Codex shape is now applied once, in `END`, to that row and to no other. A final row that is not a status line is no reading at all — never a search up the transcript for something shaped like one. With position carrying the refusal, the suffix is permissive again and configured items are read.

**The two harnesses are found differently, and that asymmetry is the point.** Claude draws a row per running agent *below* its status line, so a Claude status line is never the last row — the footer is unbounded and grows with the fleet, and the deepest footers belong to the orchestrating lanes this measurement exists for. Claude keeps the bottom-most whole-line rule. Applying position to both kills 13 assertions, including one whose fixture is a real capture of an orchestrating lane with three agent rows under its status line.

## The pane says which harness it runs

Position alone was not enough, and review caught why. When the final row is not a Codex status line, the Codex reading is refused — but the Claude scan still ran, and a Claude-shaped line anywhere in a Codex transcript then supplied a reading. In this repository that is not exotic: captures of both harnesses' panes are committed here as fixtures, and agents paste pane content into transcripts constantly.

Measured against `origin/main`:

| pane | main | position alone | now |
|---|---|---|---|
| Codex on a dialog, Claude-shaped line in transcript, no Codex status line | `claude 35` | `claude 35` | no reading |
| the same, **with a real Codex status line above the dialog** | `codex 14` | `claude 35` | no reading |
| a Claude pane whose final row quotes a Codex status line | `codex 14` | `codex 14` | `claude 41` |

The second row is a regression this branch introduced and the reason for this round: main's search recovered the status line the dialog covers, position cannot, and the fallback then reported the wrong harness and a number taken from transcript.

`lane_context_parse` now takes the pane's foreground process, which `lane_context_collect` already has and already uses one line earlier to reject panes that run no harness. `codex` is offered the Codex shape alone, a Claude wrapper the Claude shape alone, and anything else — `pi`, or an empty name — both, because refusing there would stop measuring those lanes and an unmeasured lane is never compacted. The harness is never inferred from screen content: a Claude pane quoting Codex and a Codex pane quoting Claude both occur here, and inference gets them wrong in opposite directions.

Both halves of the first two rows now agree, and the second is also a change from main. A dialog covering the status line is the could-not-tell case, so no reading is the answer rather than a recovery of `codex 14` — that 14 came from searching past the dialog to a line the lane is no longer showing.

**A latent fixture defect surfaced when the dispatch landed**: the pane table listed `%2` as running `claude` while its screen carries a Codex status line. Nothing noticed while both shapes were offered to every pane; under dispatch it went red at once. Corrected in the same commit.

### agent-confine is a launcher, not a harness

The first dispatch read `agent-confine` as a Claude spelling. The evidence that it is not is `open-terminal:307-312`, which sits in the **Codex** arms and explains they must stay shell-inert *because* the composed line crosses an agent-confine wrapper before the spawned window's shell runs it. A Codex launch goes through that wrapper, so the pane command can be `agent-confine` with Codex underneath.

The existing comment beside `LANE_CONTEXT_HARNESSES` pointed the other way and is corrected here: it read `agent-confine is the launcher they exec through`, where *they* are the per-account Claude wrappers named in the preceding clause. That Claude-only reading is what the dispatch inherited. So a Codex lane behind it was offered the Claude shape alone and its valid final `Context 86% left` row was refused — the overseer would never compact that lane, which is the failure this PR exists to prevent.

`agent-confine` now falls through to the both arm beside `pi` and an empty name. Its pane command carries no harness identity, which is what a wrapper is, so there is nothing to preserve and nothing to infer; unwrapping it by inspecting child processes would be a new and racy mechanism. Measured:

| pane command | screen | reading |
|---|---|---|
| `agent-confine` | Codex status line last | `codex 14` |
| `agent-confine` | Claude status line under an agent-row footer | `claude 35` |
| `codex` / `claude` | unchanged | unchanged |

**Residual, stated rather than hidden:** on an `agent-confine` pane both shapes are offered, so the Claude scan runs when the final row is not a Codex status line, and a Claude-shaped line in a wrapped Codex transcript can still supply a reading. That is unavoidable without harness identity, it is the behaviour that shipped before this PR, and it is confined to wrapped panes.

## Must-fail controls

Each reverts one part in place:

| Control | Reverted | Result |
|---|---|---|
| A | position back to a search of the screen | `pass: 72 fail: 2` |
| B | the path anchor back on the suffix | `pass: 68 fail: 6` |
| C | the out-of-range fall-through guard removed | `pass: 72 fail: 2` |
| D | the Claude reading taken by position too | `pass: 61 fail: 13` |

A is the fail-closed one: `a codex screen not ending in a status line carries no reading`, and `the status line above it is not searched out`. The two dialog captures are a second real instance — they end in `Press enter to continue`, and a search would report the figure the dialog is covering.

## Measured, not asserted

All six committed captures parse to their `origin/main` values, compared run-for-run: `codex 0` for working, composer-draft and composer-idle; `codex 1` for idle-after-turn; no reading for the two dialog captures. Every row identical.

Configured items now read: `· gpt-5.6-sol default` → `codex 0`, `· main` → `codex 58`, a two-item line → `codex 7`. A capture ending in ordinary transcript → no reading.

`lanes_context` 74 pass / 0 fail.

## Superseded, and recorded on the issue

KEN-885's Requirements said to anchor the suffix while keeping the bottom-most-match rule, and its first Done-when said the reproduction returns the real percentage rather than 60. Both were the issue's own suggested mechanism. Under position **the reproduction returns `codex 60`**, and nothing was tuned to move it: that input puts prose below the status line, so the prose *is* the last row. The arrangement cannot occur in a real pane, which is what the captures establish, and tuning shape to satisfy a synthetic case is how the rejected anchor got written. The defect the issue reports is real and fixed; the mechanism it proposed is not the one that fixes it.

Closes KEN-885
