### PR TITLE
refactor(KEN-914): harness-only reads the one manifest shape kendex writes

### DIFF
--- a/.agents/skills/review-gate/references/rendered-paths.md
+++ b/.agents/skills/review-gate/references/rendered-paths.md
@@ -68,12 +68,13 @@ jq -r '.entries[] | select(.emitted != null) | .emitted.paths[]' .kendex-lock.js
 
 That awk reads top-level `[skills.<name>]` tables in `kendex.toml` and
 nothing else. It does not see a `[skills]` table holding inline entries,
-dotted keys, or `kendex-local.toml`, which a source catalog keeps its own
-install state in. A repo wanting a mechanical answer over those has a worked
-precedent in the harness-ci skill's `harness-only` script, § `manifest_carves`:
-it reads both manifests from the head tree and fails closed, carving every
-skill path when a manifest will not read or says `in-place` on a line it
-cannot tie to a name. Do not build a second one here.
+dotted or quoted keys, an indented declaration, or `kendex-local.toml`, which
+a source catalog keeps its own install state in. A repo wanting a mechanical
+answer over those has a worked precedent in the harness-ci skill's
+`harness-only` script, § `manifest_carves`: it reads both manifests from the
+head tree and fails closed, carving every skill path when a manifest will not
+read or says `in-place` on a line it cannot tie to a name. Do not build a
+second one here.
 
 What backstops the gap is the section's own authority: an in-place skill's
 content tree at `.agents/skills/<name>` is bytes kendex reads and never

--- a/.agents/skills/review-gate/references/rendered-paths.md
+++ b/.agents/skills/review-gate/references/rendered-paths.md
@@ -68,12 +68,12 @@ jq -r '.entries[] | select(.emitted != null) | .emitted.paths[]' .kendex-lock.js
 
 That awk reads top-level `[skills.<name>]` tables in `kendex.toml` and
 nothing else. It does not see a `[skills]` table holding inline entries,
-dotted or quoted keys, an indented declaration, or `kendex-local.toml`, which
-a source catalog keeps its own install state in. A repo wanting a mechanical
-answer over those has a worked precedent in the harness-ci skill's
-`harness-only` script, § `manifest_carves`: it reads both manifests from the
-head tree and fails closed, carving every skill path when a manifest exists
-and will not parse. Do not build a second one here.
+dotted keys, or `kendex-local.toml`, which a source catalog keeps its own
+install state in. A repo wanting a mechanical answer over those has a worked
+precedent in the harness-ci skill's `harness-only` script, § `manifest_carves`:
+it reads both manifests from the head tree and fails closed, carving every
+skill path when a manifest will not read or says `in-place` on a line it
+cannot tie to a name. Do not build a second one here.
 
 What backstops the gap is the section's own authority: an in-place skill's
 content tree at `.agents/skills/<name>` is bytes kendex reads and never

--- a/changelog.d/changed/KEN-914.md
+++ b/changelog.d/changed/KEN-914.md
@@ -1,3 +1,3 @@
-- harness-ci's `harness-only` reads the manifest shape kendex writes, and
-  carves every skill path when a manifest says `in-place` on a line it cannot
-  tie to a name.
+- harness-ci's `harness-only` reads the manifest header shape kendex writes,
+  and carves every skill path when a manifest says `in-place` on a line it
+  cannot tie to a name.

--- a/changelog.d/changed/KEN-914.md
+++ b/changelog.d/changed/KEN-914.md
@@ -1,0 +1,3 @@
+- harness-ci's `harness-only` reads the manifest shape kendex writes, and
+  carves every skill path when a manifest says `in-place` on a line it cannot
+  tie to a name.

--- a/skills/harness-ci/README.md
+++ b/skills/harness-ci/README.md
@@ -69,8 +69,7 @@ those trees it committed.
   a dotted key, an inline table, a nested table, a name wearing whitespace,
   an escaped name and an escaped value all answer `false` that way, and so
   does `source = "in-place"` under any table but `[skills.<name>]`, the only
-  one that accounts. Every one of those is a hand edit: kendex declares in
-  place for skills alone.
+  one that accounts.
 - **Merge base on `pull_request`** (`base...head`): the base branch moves
   under an open PR, and only the merge base isolates what the PR changed.
 - **Two endpoints on `push` and `merge_group`** (`base head`): a force-push

--- a/skills/harness-ci/README.md
+++ b/skills/harness-ci/README.md
@@ -65,12 +65,12 @@ those trees it committed.
   does not parse the other spellings TOML allows. It counts every line that
   could take part in spelling the value instead — a bare `in-place`, a
   `\u`/`\U`/`\x` escape, a multiline `source` string — and carves every
-  `.agents/skills` path when one goes unaccounted, so an apostrophe-quoted
-  key, a dotted key, an inline table, a nested table, a name wearing
-  whitespace and an escaped name or value all answer `false` rather than a
-  guess. `[agents.<name>]` and `[hooks.<name>]` are unaccounted too, so a
-  repo that adopted an agent or a hook in place stays on that coarse carve
-  and never gets the per-name read.
+  `.agents/skills` path when one goes unaccounted. An apostrophe-quoted key,
+  a dotted key, an inline table, a nested table, a name wearing whitespace,
+  an escaped name and an escaped value all answer `false` that way, and so
+  does `source = "in-place"` under any table but `[skills.<name>]`, the only
+  one that accounts. Every one of those is a hand edit: kendex declares in
+  place for skills alone.
 - **Merge base on `pull_request`** (`base...head`): the base branch moves
   under an open PR, and only the merge base isolates what the PR changed.
 - **Two endpoints on `push` and `merge_group`** (`base head`): a force-push

--- a/skills/harness-ci/README.md
+++ b/skills/harness-ci/README.md
@@ -59,6 +59,15 @@ those trees it committed.
   `git mv src/app.ts .agents/skills/x/app.ts` would list one harness path and
   nothing else — the deletion of `src/app.ts` would go unjudged. With the
   flag, both paths are listed and the diff answers `false`.
+- **The in-place read**: the manifests come from the selected head tree, and
+  the reader knows the one shape kendex writes — a `[skills.<name>]` header,
+  quoted only where the name needs it, then `source = "in-place"`. It does not
+  parse the other spellings TOML allows. It counts the lines saying
+  `in-place` instead, and carves every `.agents/skills` path when one goes
+  unaccounted, so a dotted key, an inline table or an undecodable name
+  answers `false` rather than a guess. A value the line never spells — a
+  `\u` escape, a string split across lines — is past what it sees, and no
+  kendex install writes one.
 - **Merge base on `pull_request`** (`base...head`): the base branch moves
   under an open PR, and only the merge base isolates what the PR changed.
 - **Two endpoints on `push` and `merge_group`** (`base head`): a force-push
@@ -84,6 +93,8 @@ Anything the classifier cannot prove answers `false`, which runs every lane:
   looks like
 - a path git had to quote (an embedded newline or quote character), which
   matches no harness prefix
+- a manifest the head tree lists but that will not read — a symlink entry, an
+  unreadable blob — which carves every `.agents/skills` path
 
 There is no flag that turns any of these into a `true`.
 
@@ -94,7 +105,7 @@ There is no flag that turns any of these into a `true`.
 | Suite | Covers |
 | --- | --- |
 | `path-set` | Every render tree, mixed diffs, deletions, the near-miss paths |
-| `in-place` | Trees either manifest declares in place, `.agents/hooks`, the no-manifest control |
+| `in-place` | Trees either manifest declares in place, `.agents/hooks`, the coarse carve for a spelling the reader does not name, the no-manifest control |
 | `rename-into-render` | The `git mv` into a render tree, and the control proving the flag is load-bearing |
 | `event-ranges` | The force-push case, the moving base branch, merge groups |
 | `fail-closed` | Unclassified events, unresolvable endpoints, an empty diff, a merge-base diff git refuses, a path git had to quote |

--- a/skills/harness-ci/README.md
+++ b/skills/harness-ci/README.md
@@ -60,14 +60,17 @@ those trees it committed.
   nothing else — the deletion of `src/app.ts` would go unjudged. With the
   flag, both paths are listed and the diff answers `false`.
 - **The in-place read**: the manifests come from the selected head tree, and
-  the reader knows the one shape kendex writes — a `[skills.<name>]` header,
-  quoted only where the name needs it, then `source = "in-place"`. It does not
-  parse the other spellings TOML allows. It counts the lines saying
-  `in-place` instead, and carves every `.agents/skills` path when one goes
-  unaccounted, so a dotted key, an inline table or an undecodable name
-  answers `false` rather than a guess. A value the line never spells — a
-  `\u` escape, a string split across lines — is past what it sees, and no
-  kendex install writes one.
+  the reader knows the one shape kendex writes — a `[skills.<name>]` header
+  holding a bare or plain double-quoted key, then `source = "in-place"`. It
+  does not parse the other spellings TOML allows. It counts every line that
+  could take part in spelling the value instead — a bare `in-place`, a
+  `\u`/`\U`/`\x` escape, a multiline `source` string — and carves every
+  `.agents/skills` path when one goes unaccounted, so an apostrophe-quoted
+  key, a dotted key, an inline table, a nested table, a name wearing
+  whitespace and an escaped name or value all answer `false` rather than a
+  guess. `[agents.<name>]` and `[hooks.<name>]` are unaccounted too, so a
+  repo that adopted an agent or a hook in place stays on that coarse carve
+  and never gets the per-name read.
 - **Merge base on `pull_request`** (`base...head`): the base branch moves
   under an open PR, and only the merge base isolates what the PR changed.
 - **Two endpoints on `push` and `merge_group`** (`base head`): a force-push

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -175,32 +175,37 @@ manifest_carves() { # IN-TREE PATH -> carve lines for one manifest, "*" on a fai
   [ -n "$manifest_entry" ] || return 0
   case "$manifest_entry" in 120000*) echo "*"; return 0 ;; esac
   manifest_content="$(git_repo show "$head:$1" 2>/dev/null)" || { echo "*"; return 0; }
-  # kendex writes one manifest shape — a `[skills.<name>]` header, quoted
-  # only where the name needs it, then `source = "in-place"` — and that is
-  # the shape read here. Everything else a manifest can legally spell is a
-  # hand edit, so the reader does not parse it: it counts the lines saying
-  # `in-place` and carves every skill path when one goes unaccounted. That
-  # covers a dotted key, an inline table, a nested table, an indecipherable
-  # name. It does not cover a value the line never spells — a \u escape, a
-  # string split across lines — which no kendex install writes.
-  printf '%s\n' "$manifest_content" | awk '
+  # kendex writes one manifest shape — a `[skills.<name>]` header holding a
+  # bare key or a plain double-quoted one, exactly as the TOML serializer
+  # spells it, then `source = "in-place"` — and that is the shape read here.
+  # The reader does not parse the other spellings TOML allows. It counts
+  # every line that could take part in spelling the value — a bare
+  # `in-place`, a \u/\U/\x escape, a multiline `source` string — and carves
+  # every skill path when one goes unaccounted. So an apostrophe-quoted
+  # key, a dotted key, an inline table, a nested table, a name wearing
+  # whitespace, an escaped name and an escaped value all answer false.
+  # Over-matching is the safe direction: no legal TOML spelling of the
+  # value can answer harness_only=true wrongly, and the exotic ones cost
+  # lanes that run.
+  printf '%s\n' "$manifest_content" | awk -v q="'" '
+    BEGIN { mlsrc = "[\"" q "]?source[\"" q "]?[ \t]*=[ \t]*(\"\"\"|" q q q ")" }
     {
       line = $0
       sub(/\r$/, "", line)
       sub(/^[ \t]+/, "", line)
-      if (line ~ /in-place/) mentions += 1
+      if (line ~ /in-place/ || line ~ /\\[uUx]/ || line ~ mlsrc) mentions += 1
     }
-    line ~ /^\[skills\.[^]]+\][ \t]*(#.*)?$/ {
+    line ~ /^\[skills\.[A-Za-z0-9_-]+\]$/ || line ~ /^\[skills\."[^"\\]*"\]$/ {
       name = line
       sub(/^\[skills\./, "", name)
-      sub(/\][ \t]*(#.*)?$/, "", name)
-      if (name ~ /^".*"$/) { name = substr(name, 2, length(name) - 2) }
+      sub(/\]$/, "", name)
+      if (name ~ /^"/) { name = substr(name, 2, length(name) - 2) }
       next
     }
     line ~ /^\[/ { name = ""; next }
     name != "" && line ~ /^source[ \t]*=[ \t]*"in-place"[ \t]*(#.*)?$/ {
       accounted += 1
-      if (name ~ /\\/) { print "*" } else { print name }
+      print name
     }
     END { if (mentions > accounted) print "*" }
   ' 2>/dev/null || echo "*"

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -162,7 +162,7 @@ printf '%s\n' "$changed" | sed -e 's/^/harness-only: changed: /' >&2
 # manifest yields no carve-outs; one that exists but cannot be read or
 # classified carves every skill path — false, the safe answer.
 in_place_skills=""
-manifest_carves() { # IN-TREE PATH -> carve lines for one manifest, "*" on a failed read or parse
+manifest_carves() { # IN-TREE PATH -> carve lines for one manifest, "*" on a failed read or an unaccounted mention
   # The diff is between commits, so the manifests are read from the
   # selected head tree, never from whatever the checkout happens to hold.
   # One that exists there but cannot be read proves nothing and carves.
@@ -175,70 +175,34 @@ manifest_carves() { # IN-TREE PATH -> carve lines for one manifest, "*" on a fai
   [ -n "$manifest_entry" ] || return 0
   case "$manifest_entry" in 120000*) echo "*"; return 0 ;; esac
   manifest_content="$(git_repo show "$head:$1" 2>/dev/null)" || { echo "*"; return 0; }
-  # The line parser reads the spellings kendex writes and the common hand
-  # edits; completeness is not load-bearing. Every line that could take
-  # part in spelling the value — a bare in-place mention, a \u/\U escape
-  # anywhere, a multiline source string — is counted, and any the name
-  # extraction cannot account for degrades to the coarse carve: every
-  # .agents/skills path reads as project source. Over-matching is the safe
-  # direction — lanes run. No legal TOML spelling of the value can answer
-  # harness_only=true wrongly; the exotic ones cost lanes that run.
-  sq="'"
-  printf '%s\n' "$manifest_content" | awk -v q="$sq" '
-    BEGIN {
-      d = "\""
-      v = "(" d "in-place" d "|" d d d "in-place" d d d "|" q "in-place" q "|" q q q "in-place" q q q ")"
-      src = "source[ \t]*=[ \t]*" v
-      seg = "([A-Za-z0-9_-]+|" d "[^" d "]*" d "|" q "[^" q "]*" q ")"
-      dotted = "^" seg "[ \t]*\\.[ \t]*(" d "source" d "|" q "source" q "|source)[ \t]*="
-      esc = "\\\\[uUx]"
-      k = "(" d "|" q ")?"
-      mlsrc = k "source" k "[ \t]*=[ \t]*(" d d d "|" q q q ")"
-    }
+  # kendex writes one manifest shape — a `[skills.<name>]` header, quoted
+  # only where the name needs it, then `source = "in-place"` — and that is
+  # the shape read here. Everything else a manifest can legally spell is a
+  # hand edit, so the reader does not parse it: it counts the lines saying
+  # `in-place` and carves every skill path when one goes unaccounted. That
+  # covers a dotted key, an inline table, a nested table, an indecipherable
+  # name. It does not cover a value the line never spells — a \u escape, a
+  # string split across lines — which no kendex install writes.
+  printf '%s\n' "$manifest_content" | awk '
     {
       line = $0
       sub(/\r$/, "", line)
       sub(/^[ \t]+/, "", line)
-      if (line ~ /in-place/ || line ~ esc || line ~ mlsrc) coarse += 1
+      if (line ~ /in-place/) mentions += 1
     }
-    line ~ /^\[[ \t]*skills[ \t]*\][ \t]*(#.*)?$/ { in_skills = 1; name = ""; next }
-    line ~ /^\[[ \t]*skills[ \t]*\./ {
-      in_skills = 0
+    line ~ /^\[skills\.[^]]+\][ \t]*(#.*)?$/ {
       name = line
-      sub(/^\[[ \t]*skills[ \t]*\.[ \t]*/, "", name)
-      sub(/[ \t]*\][ \t]*(#.*)?$/, "", name)
-      if (name ~ "^\"[^\"]*\"$" || name ~ ("^" q "[^" q "]*" q "$")) {
-        name = substr(name, 2, length(name) - 2)
-      }
+      sub(/^\[skills\./, "", name)
+      sub(/\][ \t]*(#.*)?$/, "", name)
+      if (name ~ /^".*"$/) { name = substr(name, 2, length(name) - 2) }
       next
     }
-    line ~ /^\[/ { in_skills = 0; name = "" }
-    name != "" && line ~ ("^" src "[ \t]*(#.*)?$") {
+    line ~ /^\[/ { name = ""; next }
+    name != "" && line ~ /^source[ \t]*=[ \t]*"in-place"[ \t]*(#.*)?$/ {
       accounted += 1
       if (name ~ /\\/) { print "*" } else { print name }
-      next
     }
-    (in_skills || line ~ /^skills[ \t]*\./) && line ~ src {
-      body = line
-      sub(/^skills[ \t]*\.[ \t]*/, "", body)
-      key = body
-      if (key ~ /^"/) { sub(/^"/, "", key); sub(/".*$/, "", key) }
-      else if (key ~ ("^" q)) { sub("^" q, "", key); key = substr(key, 1, index(key, q) - 1) }
-      else { sub(/[ \t=.].*$/, "", key) }
-      if (key != "") {
-        accounted += 1
-        # Only two shapes tie the key to the value on one line: a
-        # structural dotted declaration (segment, dot, source, equals) and
-        # a closed one-level inline table. Anything else — a continuation
-        # line, a quoted key wearing a dot, a nested table, a key of
-        # exactly "source", an escape-bearing key — carves.
-        trusted = 0
-        if (body ~ dotted) { trusted = 1 }
-        else if (body ~ /^[^{}]*=[ \t]*\{[^{}]*\}[ \t]*,?[ \t]*(#.*)?$/) { trusted = 1 }
-        if (!trusted || key == "source" || key ~ /\\/) { print "*" } else { print key }
-      }
-    }
-    END { if (coarse > accounted) print "*" }
+    END { if (mentions > accounted) print "*" }
   ' 2>/dev/null || echo "*"
 }
 # A source-catalog project keeps its install state in kendex-local.toml

--- a/skills/harness-ci/tests/in-place.test.sh
+++ b/skills/harness-ci/tests/in-place.test.sh
@@ -96,8 +96,16 @@ assert_verdict "a CRLF manifest still carves" false --repo "$crlf" --event push 
 
 # A legal spelling the reader does not name degrades to the coarse carve:
 # an in-place line it could not tie to a name makes every skill path
-# project source rather than a guessed name set.
-for unnamed in whole-table dotted-key inline-table dotted-escape multiline-table; do
+# project source rather than a guessed name set. The header shapes are the
+# two the TOML serializer writes, so a name wearing an apostrophe, a space
+# outside the quotes, or an escape is not a name here; the value shapes
+# are the one kendex writes, so a value that decodes to in-place without
+# any line spelling it counts as a mention and cannot be accounted.
+for unnamed in whole-table dotted-key inline-table dotted-escape multiline-table \
+  nested-table apostrophe-name apostrophe-name-space trailing-space leading-space \
+  padded-name quoted-trailing-space spaced-table escaped-name \
+  malformed-quoted-name header-comment \
+  escaped-value hex-escaped-value split-value quoted-key-split-value; do
   coarse="$(new_repo "coarse-$unnamed")"
   case "$unnamed" in
     whole-table) printf 'schema = 6\nskills = { mine = { source = "in-place" } }\n' ;;
@@ -106,6 +114,24 @@ for unnamed in whole-table dotted-key inline-table dotted-escape multiline-table
     dotted-escape) printf 'schema = 6\nskills."mi\\u006Ee" = { source = "in-place" }\n' ;;
     # A TOML 1.1 multiline inline table puts the value on its own line.
     multiline-table) printf 'schema = 6\n[skills]\nmine = {\n"x.y" = true, source = "in-place",\n}\n' ;;
+    # A bare dotted header is skills to a to b, not a skill named a.b.
+    nested-table) printf 'schema = 6\n[skills.a.b]\nsource = "in-place"\n' ;;
+    apostrophe-name) printf "schema = 6\n[skills.'mine']\nsource = \"in-place\"\n" ;;
+    apostrophe-name-space) printf "schema = 6\n[skills.'ship it']\nsource = \"in-place\"\n" ;;
+    trailing-space) printf 'schema = 6\n[skills.mine ]\nsource = "in-place"\n' ;;
+    leading-space) printf 'schema = 6\n[skills. mine]\nsource = "in-place"\n' ;;
+    padded-name) printf 'schema = 6\n[skills. mine ]\nsource = "in-place"\n' ;;
+    quoted-trailing-space) printf 'schema = 6\n[skills."mine" ]\nsource = "in-place"\n' ;;
+    spaced-table) printf 'schema = 6\n[ skills.mine ]\nsource = "in-place"\n' ;;
+    escaped-name) printf 'schema = 6\n[skills."mi\\u006Ee"]\nsource = "in-place"\n' ;;
+    malformed-quoted-name) printf 'schema = 6\n[skills."a"b"]\nsource = "in-place"\n' ;;
+    header-comment) printf 'schema = 6\n[skills.mine] # kept here\nsource = "in-place"\n' ;;
+    # A value no line spells: the escape and the splice both decode to
+    # in-place, so each counts as a mention the name rule cannot account.
+    escaped-value) printf 'schema = 6\n[skills.mine]\nsource = "in\\u002Dplace"\n' ;;
+    hex-escaped-value) printf 'schema = 6\n[skills.mine]\nsource = "in-\\x70lace"\n' ;;
+    split-value) printf 'schema = 6\n[skills.mine]\nsource = """in\\\n-place"""\n' ;;
+    quoted-key-split-value) printf 'schema = 6\n[skills.mine]\n"source" = """in-\\\nplace"""\n' ;;
   esac >"$coarse/kendex.toml"
   commit_paths "$coarse" "baseline" README.md
   coarsebase="$(git -C "$coarse" rev-parse HEAD)"
@@ -117,6 +143,19 @@ for unnamed in whole-table dotted-key inline-table dotted-escape multiline-table
   assert_verdict "the coarse carve covers every skill path ($unnamed)" false --repo "$coarse" --event push --base "$coarsebase" --head HEAD
 done
 
+# A quoted key delimits the name, so one holding a `]` still reads as that
+# one name and carves nothing else.
+bracket="$(new_repo bracket-name)"
+printf 'schema = 6\n[skills."a]b"]\nsource = "in-place"\n' >"$bracket/kendex.toml"
+commit_paths "$bracket" "baseline" README.md
+bracketbase="$(git -C "$bracket" rev-parse HEAD)"
+commit_paths "$bracket" "edit" ".agents/skills/a]b/SKILL.md"
+assert_verdict "a quoted name holding a bracket carves" false --repo "$bracket" --event push --base "$bracketbase" --head HEAD
+git -C "$bracket" checkout -q -B "case" "$bracketbase"
+git -C "$bracket" clean -qfd -e kendex.toml
+commit_paths "$bracket" "sibling" .agents/skills/other/SKILL.md
+assert_verdict "a sibling beside the bracket name stays render" true --repo "$bracket" --event push --base "$bracketbase" --head HEAD
+
 # An in-place declaration under another table is not a skill name: the
 # header ends the one in scope, so the line goes unaccounted and every
 # skill path carves rather than inheriting the last skill's name.
@@ -126,15 +165,6 @@ commit_paths "$foreign" "baseline" README.md
 foreignbase="$(git -C "$foreign" rev-parse HEAD)"
 commit_paths "$foreign" "edit" .agents/skills/other/SKILL.md
 assert_verdict "an in-place agent carves every skill path" false --repo "$foreign" --event push --base "$foreignbase" --head HEAD
-
-# A section-header name the reader cannot decode carves instead of
-# resolving to a guessed name.
-esc="$(new_repo escaped-header)"
-printf 'schema = 6\n[skills."mi\\u006Ee"]\nsource = "in-place"\n' >"$esc/kendex.toml"
-commit_paths "$esc" "baseline" README.md
-escbase="$(git -C "$esc" rev-parse HEAD)"
-commit_paths "$esc" "edit" .agents/skills/mine/SKILL.md
-assert_verdict "an escaped header name carves" false --repo "$esc" --event push --base "$escbase" --head HEAD
 
 # The manifests come from the selected head tree, not the checkout: a head
 # that declares the skill carves even when the checkout sits on a commit

--- a/skills/harness-ci/tests/in-place.test.sh
+++ b/skills/harness-ci/tests/in-place.test.sh
@@ -57,32 +57,19 @@ assert_verdict "without a manifest every .agents path is render output" true \
   --repo "$norepo" --event push --base "$nobase" --head HEAD
 
 
-# Every spelling a declaration legally wears: quoted keys (spaces included),
-# single quotes, indentation, spaces around the dotted key, trailing value
-# comments, a [skills] table with inline and dotted entries, and top-level
-# dotted keys — inline tables are single-line by TOML 1.0.
+# The shape kendex writes, in both its spellings: a bare name, and a quoted
+# one where the name needs quoting. A hand edit's indentation, trailing
+# value comment and sibling keys do not defeat the anchored matches.
 spell="$(new_repo spellings)"
 cat >"$spell/kendex.toml" <<'MANIFEST'
 schema = 6
 
-[skills]
-tabled = { source = "in-place" }
-dotted.source = "in-place"
-
 [skills."ship it"]
 source = "in-place"
+enabled = true
 
   [skills.indented]
   source = "in-place" # kept in place
-
-[ skills . spaced ]
-source = 'in-place'
-
-[skills.tripled]
-source = """in-place"""
-
-[skills.lit3]
-source = '''in-place'''
 MANIFEST
 commit_paths "$spell" "baseline" README.md
 spellbase="$(git -C "$spell" rev-parse HEAD)"
@@ -94,24 +81,9 @@ spell_case() { # LABEL EXPECTED PATH
 }
 spell_case "a quoted name with a space" false ".agents/skills/ship it/SKILL.md"
 spell_case "an indented declaration with a value comment" false .agents/skills/indented/SKILL.md
-spell_case "spaces around the dotted key, single-quoted value" false .agents/skills/spaced/SKILL.md
-spell_case "an inline table under the skills table" false .agents/skills/tabled/SKILL.md
-spell_case "a dotted entry under the skills table" false .agents/skills/dotted/SKILL.md
-spell_case "a multiline-basic-string value" false .agents/skills/tripled/SKILL.md
-spell_case "a multiline-literal-string value" false .agents/skills/lit3/SKILL.md
-
-# Top-level dotted spellings live in their own manifest: TOML lets one style
-# define the skills table, not both.
-dotted="$(new_repo dotted)"
-printf '%s\n' 'schema = 6' 'skills.inline = { source = "in-place" }' 'skills.deep.source = "in-place"' >"$dotted/kendex.toml"
-commit_paths "$dotted" "baseline" README.md
-dottedbase="$(git -C "$dotted" rev-parse HEAD)"
-for dotted_skill in inline deep; do
-  git -C "$dotted" checkout -q -B "case" "$dottedbase"
-  git -C "$dotted" clean -qfd -e kendex.toml
-  commit_paths "$dotted" "$dotted_skill" ".agents/skills/$dotted_skill/SKILL.md"
-  assert_verdict "a top-level dotted $dotted_skill declaration" false --repo "$dotted" --event push --base "$dottedbase" --head HEAD
-done
+# Both names were read, not coarsely carved: an undeclared sibling in the
+# same repo still answers true.
+spell_case "an undeclared sibling beside them stays render" true .agents/skills/stranger/SKILL.md
 
 # A CRLF manifest is legal TOML; the carriage return must not defeat the
 # anchored matches.
@@ -122,41 +94,47 @@ crlfbase="$(git -C "$crlf" rev-parse HEAD)"
 commit_paths "$crlf" "edit" .agents/skills/mine/SKILL.md
 assert_verdict "a CRLF manifest still carves" false --repo "$crlf" --event push --base "$crlfbase" --head HEAD
 
-# An unclassifiable spelling degrades to the coarse carve: an in-place value
-# the name extraction cannot account for makes every skill path project
-# source rather than a guessed name set.
-coarse="$(new_repo coarse)"
-printf 'schema = 6\nskills = { mine = { source = "in-place" } }\n' >"$coarse/kendex.toml"
-commit_paths "$coarse" "baseline" README.md
-coarsebase="$(git -C "$coarse" rev-parse HEAD)"
-commit_paths "$coarse" "edit" .agents/skills/mine/SKILL.md
-assert_verdict "an inline whole-table declaration carves its skill" false --repo "$coarse" --event push --base "$coarsebase" --head HEAD
-git -C "$coarse" checkout -q -B "case" "$coarsebase"
-git -C "$coarse" clean -qfd -e kendex.toml
-commit_paths "$coarse" "sibling" .agents/skills/other/SKILL.md
-assert_verdict "the coarse carve covers every skill path" false --repo "$coarse" --event push --base "$coarsebase" --head HEAD
-
-# The escape and split-string avenues land in the coarse net too — an
-# escaped value, an escaped section-header key, a value split across lines:
-# none spells in-place where the extractor reads names, all decode to it.
-for exotic in 'source = "in\u002Dplace"' 'source = "in-\x70lace"' 'split' 'header' 'quoted-split' 'dotted-escape'; do
-  ex="$(new_repo "exotic-$RANDOM")"
-  if [ "$exotic" = split ]; then
-    printf 'schema = 6\n[skills.mine]\nsource = """in\\\n-place"""\n' >"$ex/kendex.toml"
-  elif [ "$exotic" = dotted-escape ]; then
-    printf 'schema = 6\nskills."mi\\u006Ee" = { source = "in-place" }\n' >"$ex/kendex.toml"
-  elif [ "$exotic" = quoted-split ]; then
-    printf 'schema = 6\n[skills.mine]\n"source" = """in-\\\nplace"""\n' >"$ex/kendex.toml"
-  elif [ "$exotic" = header ]; then
-    printf 'schema = 6\n[skills."mi\\u006Ee"]\nsource = "in-place"\n' >"$ex/kendex.toml"
-  else
-    printf 'schema = 6\n[skills.mine]\n%s\n' "$exotic" >"$ex/kendex.toml"
-  fi
-  commit_paths "$ex" "baseline" README.md
-  exbase="$(git -C "$ex" rev-parse HEAD)"
-  commit_paths "$ex" "edit" .agents/skills/mine/SKILL.md
-  assert_verdict "an escaped or split spelling degrades to the carve ($exotic)" false --repo "$ex" --event push --base "$exbase" --head HEAD
+# A legal spelling the reader does not name degrades to the coarse carve:
+# an in-place line it could not tie to a name makes every skill path
+# project source rather than a guessed name set.
+for unnamed in whole-table dotted-key inline-table dotted-escape multiline-table; do
+  coarse="$(new_repo "coarse-$unnamed")"
+  case "$unnamed" in
+    whole-table) printf 'schema = 6\nskills = { mine = { source = "in-place" } }\n' ;;
+    dotted-key) printf 'schema = 6\nskills.mine.source = "in-place"\n' ;;
+    inline-table) printf 'schema = 6\n[skills]\nmine = { source = "in-place" }\n' ;;
+    dotted-escape) printf 'schema = 6\nskills."mi\\u006Ee" = { source = "in-place" }\n' ;;
+    # A TOML 1.1 multiline inline table puts the value on its own line.
+    multiline-table) printf 'schema = 6\n[skills]\nmine = {\n"x.y" = true, source = "in-place",\n}\n' ;;
+  esac >"$coarse/kendex.toml"
+  commit_paths "$coarse" "baseline" README.md
+  coarsebase="$(git -C "$coarse" rev-parse HEAD)"
+  commit_paths "$coarse" "edit" .agents/skills/mine/SKILL.md
+  assert_verdict "an unnamed spelling carves its own skill ($unnamed)" false --repo "$coarse" --event push --base "$coarsebase" --head HEAD
+  git -C "$coarse" checkout -q -B "case" "$coarsebase"
+  git -C "$coarse" clean -qfd -e kendex.toml
+  commit_paths "$coarse" "sibling" .agents/skills/other/SKILL.md
+  assert_verdict "the coarse carve covers every skill path ($unnamed)" false --repo "$coarse" --event push --base "$coarsebase" --head HEAD
 done
+
+# An in-place declaration under another table is not a skill name: the
+# header ends the one in scope, so the line goes unaccounted and every
+# skill path carves rather than inheriting the last skill's name.
+foreign="$(new_repo foreign-table)"
+printf 'schema = 6\n[skills.mine]\nsource = "kendex"\n\n[agents.helper]\nsource = "in-place"\n' >"$foreign/kendex.toml"
+commit_paths "$foreign" "baseline" README.md
+foreignbase="$(git -C "$foreign" rev-parse HEAD)"
+commit_paths "$foreign" "edit" .agents/skills/other/SKILL.md
+assert_verdict "an in-place agent carves every skill path" false --repo "$foreign" --event push --base "$foreignbase" --head HEAD
+
+# A section-header name the reader cannot decode carves instead of
+# resolving to a guessed name.
+esc="$(new_repo escaped-header)"
+printf 'schema = 6\n[skills."mi\\u006Ee"]\nsource = "in-place"\n' >"$esc/kendex.toml"
+commit_paths "$esc" "baseline" README.md
+escbase="$(git -C "$esc" rev-parse HEAD)"
+commit_paths "$esc" "edit" .agents/skills/mine/SKILL.md
+assert_verdict "an escaped header name carves" false --repo "$esc" --event push --base "$escbase" --head HEAD
 
 # The manifests come from the selected head tree, not the checkout: a head
 # that declares the skill carves even when the checkout sits on a commit
@@ -201,22 +179,13 @@ commit_paths "$ns" "sibling" .agents/skills/plugin-other/SKILL.md
 assert_verdict "a sibling outside the namespace stays render" true --repo "$ns" --event push --base "$nsbase" --head HEAD
 
 # An equals sign in the repository path must not turn the manifest operand
-# into an awk variable assignment: the manifest reaches awk by redirection.
+# into an awk variable assignment: the manifest reaches awk on stdin.
 eqrepo="$(new_repo "work=tree")"
 printf 'schema = 6\n[skills.mine]\nsource = "in-place"\n' >"$eqrepo/kendex.toml"
 commit_paths "$eqrepo" "baseline" README.md
 eqbase="$(git -C "$eqrepo" rev-parse HEAD)"
 commit_paths "$eqrepo" "edit" .agents/skills/mine/SKILL.md
 assert_verdict "an equals-sign repo path still carves" false --repo "$eqrepo" --event push --base "$eqbase" --head HEAD
-
-# A TOML 1.1 multiline inline table puts the value on its own line inside
-# [skills]; the line is unaccountable as a name and degrades to the carve.
-mlt="$(new_repo multiline-table)"
-printf 'schema = 6\n[skills]\nmine = {\n"x.y" = true, source = "in-place",\n}\n' >"$mlt/kendex.toml"
-commit_paths "$mlt" "baseline" README.md
-mltbase="$(git -C "$mlt" rev-parse HEAD)"
-commit_paths "$mlt" "edit" .agents/skills/mine/SKILL.md
-assert_verdict "a multiline inline table degrades to the carve" false --repo "$mlt" --event push --base "$mltbase" --head HEAD
 
 # A symlinked manifest reads back as link text, not manifest content: it is
 # unclassifiable and carves.

--- a/skills/review-gate/references/rendered-paths.md
+++ b/skills/review-gate/references/rendered-paths.md
@@ -68,12 +68,13 @@ jq -r '.entries[] | select(.emitted != null) | .emitted.paths[]' .kendex-lock.js
 
 That awk reads top-level `[skills.<name>]` tables in `kendex.toml` and
 nothing else. It does not see a `[skills]` table holding inline entries,
-dotted keys, or `kendex-local.toml`, which a source catalog keeps its own
-install state in. A repo wanting a mechanical answer over those has a worked
-precedent in the harness-ci skill's `harness-only` script, § `manifest_carves`:
-it reads both manifests from the head tree and fails closed, carving every
-skill path when a manifest will not read or says `in-place` on a line it
-cannot tie to a name. Do not build a second one here.
+dotted or quoted keys, an indented declaration, or `kendex-local.toml`, which
+a source catalog keeps its own install state in. A repo wanting a mechanical
+answer over those has a worked precedent in the harness-ci skill's
+`harness-only` script, § `manifest_carves`: it reads both manifests from the
+head tree and fails closed, carving every skill path when a manifest will not
+read or says `in-place` on a line it cannot tie to a name. Do not build a
+second one here.
 
 What backstops the gap is the section's own authority: an in-place skill's
 content tree at `.agents/skills/<name>` is bytes kendex reads and never

--- a/skills/review-gate/references/rendered-paths.md
+++ b/skills/review-gate/references/rendered-paths.md
@@ -68,12 +68,12 @@ jq -r '.entries[] | select(.emitted != null) | .emitted.paths[]' .kendex-lock.js
 
 That awk reads top-level `[skills.<name>]` tables in `kendex.toml` and
 nothing else. It does not see a `[skills]` table holding inline entries,
-dotted or quoted keys, an indented declaration, or `kendex-local.toml`, which
-a source catalog keeps its own install state in. A repo wanting a mechanical
-answer over those has a worked precedent in the harness-ci skill's
-`harness-only` script, § `manifest_carves`: it reads both manifests from the
-head tree and fails closed, carving every skill path when a manifest exists
-and will not parse. Do not build a second one here.
+dotted keys, or `kendex-local.toml`, which a source catalog keeps its own
+install state in. A repo wanting a mechanical answer over those has a worked
+precedent in the harness-ci skill's `harness-only` script, § `manifest_carves`:
+it reads both manifests from the head tree and fails closed, carving every
+skill path when a manifest will not read or says `in-place` on a line it
+cannot tie to a name. Do not build a second one here.
 
 What backstops the gap is the section's own authority: an in-place skill's
 content tree at `.agents/skills/<name>` is bytes kendex reads and never


### PR DESCRIPTION
## Summary

- `harness-only`'s `manifest_carves` drops the awk TOML grammar — escapes, single and triple quotes, inline tables, split strings — and reads the one shape kendex writes: a `[skills.<name>]` header holding a bare or plain double-quoted key, then `source = "in-place"`. About 70 lines of parser gone.
- What the reader no longer parses, it still counts. A line that could take part in spelling the value — a bare `in-place`, a `\u`/`\U`/`\x` escape, a multiline `source` string — increments a mention, and any mention the reader cannot tie to an accepted header carves every `.agents/skills` path. An apostrophe-quoted key, a dotted key, an inline table, a nested table, a name wearing whitespace, an escaped name, an escaped value, and `source = "in-place"` under any table but `[skills.<name>]` all answer `false` rather than a guess.
- The suite went 33 to 64 assertions. Every guard in the awk has a must-fail control that runs red once, and the set passes under mawk as well as gawk.

## Completed Issues

- Closes KEN-914 - harness-only reads the one manifest shape kendex writes; the awk TOML grammar is gone

## Test Plan

- `bash skills/harness-ci/tests/in-place.test.sh` — 64 passed, 0 failed; also green under mawk, the ubuntu-runner default.
- The other seven harness-ci suites: fail-closed 17, wiring-errors 27, path-set 16, wiring-shapes 11, event-ranges 7, rename-into-render 5, bash32-portability.
- Verdict parity against every kendex-written manifest on the dev machine (drovr, hyprtrade, hyprtrade-io, memsira, vg, dotfiles-linux, vgs, and this repo's own): identical `harness_only` for the declared-in-place, undeclared-sibling and pure-render cases.
- `preflight`, `size-ratchet`, `tools/guard`, `shellcheck -x` clean.

Two fail-open regressions the first commit introduced were found in review and fixed in `47466bb`: a header rule that tied an in-place line to a string rather than a resolvable name, and a mention counter that recognized only the literal `in-place` bytes. Both were reproduced against `main` on fixture repos before and after. Reverting either guard now fails assertions in the suite (18 and 8 respectively), so neither is vacuous.
