### PR TITLE
fix(KEN-887): make merge-watch retries generation-safe

### DIFF
--- a/.agents/skills/orch/scripts/lib/merge-queue-state.sh
+++ b/.agents/skills/orch/scripts/lib/merge-queue-state.sh
@@ -1,7 +1,7 @@
 # shellcheck shell=bash
 
 MERGE_QUEUE_REPORT_FILTER='{issue_id,watch_id,status,action,repository,pr_number,head_sha,worktree_branch,
-  gate_mode,recovery_count,artifact_path,log_path,deadline,verdict,verdict_cause,
+  gate_mode,recovery_count,launch_attempt,launch_attempt_id,runtime_dir,artifact_path,log_path,deadline,verdict,verdict_cause,
   lane_postmerge,cleanup,diagnostic,error:(.diagnostic.error // null),
   worker_exit_code:(.diagnostic.worker_exit_code // null),
   diagnostic_path:(.diagnostic.diagnostic_path // .log_path)}'

--- a/.agents/skills/orch/scripts/lib/merge-queue-supervisor.sh
+++ b/.agents/skills/orch/scripts/lib/merge-queue-supervisor.sh
@@ -26,7 +26,7 @@ merge_queue_supervise() {
     (flock -w 10 9 || exit 1
       jq -e --arg watch "$watch_id" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" --arg token "$process_token" '
         .watch_id==$watch and .launch_attempt_id==$attempt and .runtime_dir==$runtime and .artifact_path==$artifact and
-        .supervisor_token==$token and (.status|IN("launching","watching"))' "$state_file" >/dev/null || exit 1
+        .supervisor_token==$token and (.status|IN("launching","watching","launch_failed"))' "$state_file" >/dev/null || exit 1
       ln "$output" "$artifact"
     ) 9>"$state_file.lock"
   }
@@ -71,12 +71,13 @@ merge_queue_supervise() {
     [[ $(date +%s) -lt "$deadline" ]] || printf 'deadline\n' > "$event_fifo"
   ) & watchdog_pid=$!
   printf '%s\n' "$$" > "$runtime/supervisor.pid"; chmod 600 "$runtime/supervisor.pid"
+  attempt_is_current || return 1
   set -m
   (
     exec 7>"$event_fifo"
     set +e
     cd "$main_root" || exit 1
-    env -u GH_REPO -u GITHUB_REPOSITORY GH_REPO="$repo" \
+    env -u GH_REPO -u GITHUB_REPOSITORY -u MERGE_QUEUE_SUPERVISOR_TOKEN GH_REPO="$repo" \
       "$waiter" "$pr" "$poll" "$max_wait" --json > "$temp" 2>> "$log"
     rc=$?; printf '%s\n' "$rc" > "$runtime/worker.status"; printf 'worker\n' >&7; exit "$rc"
   ) & worker_pid=$!

--- a/.agents/skills/orch/scripts/lib/merge-queue-supervisor.sh
+++ b/.agents/skills/orch/scripts/lib/merge-queue-supervisor.sh
@@ -4,28 +4,29 @@ merge_queue_supervise() {
   local state_file="$1" watch_id="$2" attempt_id="$3" runtime="$4" artifact="$5" deadline="$6"
   local waiter="$7" poll="$8" max_wait="$9"
   local repo pr head main_root log temp output worker_pid="" worker_rc=0 event=""
-  local event_fifo owner_fifo watchdog_pid="" published=false
+  local event_fifo owner_fifo watchdog_pid="" published=false process_token="${MERGE_QUEUE_SUPERVISOR_TOKEN:-}"
   repo=$(jq -r .repository "$state_file"); pr=$(jq -r .pr_number "$state_file")
   head=$(jq -r .head_sha "$state_file")
   main_root=$(jq -r .main_repo_root "$state_file")
   log=$(jq -r .log_path "$state_file"); temp="$runtime/worker.json"; output="$runtime/artifact.tmp"
   event_fifo="$runtime/events"; owner_fifo="$runtime/deadline-owner"
-  [[ -d "$runtime" && ! -L "$runtime" && "$(cat < "$runtime/token")" == "$attempt_id" ]] || return 1
+  [[ "$process_token" =~ ^[A-Za-z0-9._-]+$ && -d "$runtime" && ! -L "$runtime" && \
+     "$(cat < "$runtime/token")" == "$attempt_id" ]] || return 1
   [[ -d "$main_root" ]] || return 1
 
   attempt_is_current() {
     (flock -s -w 10 9 || exit 1
-      jq -e --arg watch "$watch_id" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" '
+      jq -e --arg watch "$watch_id" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" --arg token "$process_token" '
         .watch_id==$watch and .launch_attempt_id==$attempt and .runtime_dir==$runtime and .artifact_path==$artifact and
-        (.status|IN("launching","watching"))' "$state_file" >/dev/null
+        .supervisor_token==$token and (.status|IN("launching","watching"))' "$state_file" >/dev/null
     ) 9>"$state_file.lock"
   }
   publish_output() {
     chmod 600 "$output" || return 1
     (flock -w 10 9 || exit 1
-      jq -e --arg watch "$watch_id" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" '
+      jq -e --arg watch "$watch_id" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" --arg token "$process_token" '
         .watch_id==$watch and .launch_attempt_id==$attempt and .runtime_dir==$runtime and .artifact_path==$artifact and
-        (.status|IN("launching","watching"))' "$state_file" >/dev/null || exit 1
+        .supervisor_token==$token and (.status|IN("launching","watching"))' "$state_file" >/dev/null || exit 1
       ln "$output" "$artifact"
     ) 9>"$state_file.lock"
   }

--- a/.agents/skills/orch/scripts/lib/merge-queue-supervisor.sh
+++ b/.agents/skills/orch/scripts/lib/merge-queue-supervisor.sh
@@ -1,17 +1,35 @@
 # shellcheck shell=bash
 
 merge_queue_supervise() {
-  local state_file="$1" watch_id="$2" waiter="$3" poll="$4" max_wait="$5"
-  local repo pr head main_root artifact log runtime deadline temp output worker_pid="" worker_rc=0 event=""
+  local state_file="$1" watch_id="$2" attempt_id="$3" runtime="$4" artifact="$5" deadline="$6"
+  local waiter="$7" poll="$8" max_wait="$9"
+  local repo pr head main_root log temp output worker_pid="" worker_rc=0 event=""
   local event_fifo owner_fifo watchdog_pid="" published=false
   repo=$(jq -r .repository "$state_file"); pr=$(jq -r .pr_number "$state_file")
-  head=$(jq -r .head_sha "$state_file"); artifact=$(jq -r .artifact_path "$state_file")
+  head=$(jq -r .head_sha "$state_file")
   main_root=$(jq -r .main_repo_root "$state_file")
-  log=$(jq -r .log_path "$state_file"); runtime=$(jq -r .runtime_dir "$state_file")
-  deadline=$(jq -r .deadline "$state_file"); temp="$runtime/worker.json"; output="$runtime/artifact.tmp"
+  log=$(jq -r .log_path "$state_file"); temp="$runtime/worker.json"; output="$runtime/artifact.tmp"
   event_fifo="$runtime/events"; owner_fifo="$runtime/deadline-owner"
-  [[ -d "$runtime" && ! -L "$runtime" && "$(cat < "$runtime/token")" == "$watch_id" ]] || return 1
+  [[ -d "$runtime" && ! -L "$runtime" && "$(cat < "$runtime/token")" == "$attempt_id" ]] || return 1
   [[ -d "$main_root" ]] || return 1
+
+  attempt_is_current() {
+    (flock -s -w 10 9 || exit 1
+      jq -e --arg watch "$watch_id" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" '
+        .watch_id==$watch and .launch_attempt_id==$attempt and .runtime_dir==$runtime and .artifact_path==$artifact and
+        (.status|IN("launching","watching"))' "$state_file" >/dev/null
+    ) 9>"$state_file.lock"
+  }
+  publish_output() {
+    chmod 600 "$output" || return 1
+    (flock -w 10 9 || exit 1
+      jq -e --arg watch "$watch_id" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" '
+        .watch_id==$watch and .launch_attempt_id==$attempt and .runtime_dir==$runtime and .artifact_path==$artifact and
+        (.status|IN("launching","watching"))' "$state_file" >/dev/null || exit 1
+      ln "$output" "$artifact"
+    ) 9>"$state_file.lock"
+  }
+  attempt_is_current || return 1
 
   stop_worker() {
     local i
@@ -25,12 +43,12 @@ merge_queue_supervise() {
   publish_unknown() {
     local reason="$1" rc="$2"
     [[ -e "$artifact" ]] && return 0
-    jq -n --arg repo "$repo" --argjson pr "$pr" --arg head "$head" --arg watch "$watch_id" \
+    jq -n --arg repo "$repo" --argjson pr "$pr" --arg head "$head" --arg watch "$watch_id" --arg attempt "$attempt_id" \
       --arg reason "$reason" --argjson rc "$rc" --arg log "$log" \
       '{schema_version:1,status:"error",verdict:"unknown",repository:$repo,pr_number:$pr,
-        expected_head:$head,observed_head:"",watch_id:$watch,cause:$reason,
+        expected_head:$head,observed_head:"",watch_id:$watch,launch_attempt_id:$attempt,cause:$reason,
         worker_exit_code:$rc,diagnostic_path:$log}' > "$output" || return 1
-    chmod 600 "$output" && ln "$output" "$artifact" && published=true
+    publish_output && published=true
   }
   cleanup() {
     local rc=$?
@@ -73,10 +91,10 @@ merge_queue_supervise() {
       (.verdict|IN("merged","conflicting","ejected","disarmed","dequeued","closed","queued","not_queued","unknown"))' "$temp" >/dev/null 2>&1; then
     publish_unknown worker_output_invalid "$worker_rc"; trap - EXIT TERM HUP INT; return 0
   fi
-  jq --arg repo "$repo" --argjson pr "$pr" --arg head "$head" --arg watch "$watch_id" --arg log "$log" \
+  jq --arg repo "$repo" --argjson pr "$pr" --arg head "$head" --arg watch "$watch_id" --arg attempt "$attempt_id" --arg log "$log" \
     '. + {schema_version:1,repository:$repo,pr_number:$pr,expected_head:$head,
-      observed_head:"",watch_id:$watch,diagnostic_path:$log}' "$temp" > "$output"
-  chmod 600 "$output" && ln "$output" "$artifact" || return 1
+      observed_head:"",watch_id:$watch,launch_attempt_id:$attempt,diagnostic_path:$log}' "$temp" > "$output"
+  publish_output || return 1
   published=true; printf '%s\n' "$worker_rc" > "$runtime/terminal"; chmod 600 "$runtime/terminal"
   trap - EXIT TERM HUP INT
 }

--- a/.agents/skills/orch/scripts/merge-queue-watch
+++ b/.agents/skills/orch/scripts/merge-queue-watch
@@ -88,15 +88,27 @@ supervisor_pid() {
   printf '%s' "$pid"
 }
 supervisor_live() {
-  local pid="$1" attempt_id="$2" command
+  local pid="$1" attempt_id="$2" runtime="$3" artifact="$4" command arg i
+  local argv=()
   [[ "$pid" =~ ^[1-9][0-9]*$ ]] || return 1
   kill -0 "$pid" 2>/dev/null || return 1
-  command=$(ps -p "$pid" -o command= 2>/dev/null) || return 1
-  [[ "$command" == *"merge-queue-watch __supervise"* && "$command" == *"$WATCH_ID"* && "$command" == *"$attempt_id"* ]]
+  if [[ -r "/proc/$pid/cmdline" ]]; then
+    while IFS= read -r -d '' arg; do argv[${#argv[@]}]="$arg"; done < "/proc/$pid/cmdline"
+  else
+    [[ "$SELF$STATE_FILE$WATCH_ID$attempt_id$runtime$artifact" != *[[:space:]]* ]] || return 1
+    command=$(ps -ww -p "$pid" -o command= 2>/dev/null) || return 1
+    read -r -a argv <<<"$command"
+  fi
+  for ((i=0; i+6<${#argv[@]}; i++)); do
+    [[ "${argv[i]}" == "$SELF" && "${argv[i+1]}" == __supervise && "${argv[i+2]}" == "$STATE_FILE" &&
+       "${argv[i+3]}" == "$WATCH_ID" && "${argv[i+4]}" == "$attempt_id" && "${argv[i+5]}" == "$runtime" &&
+       "${argv[i+6]}" == "$artifact" ]] && return 0
+  done
+  return 1
 }
 terminate_supervisor() {
-  local pid="$1" attempt_id="$2" i
-  supervisor_live "$pid" "$attempt_id" || return 0
+  local pid="$1" attempt_id="$2" runtime="$3" artifact="$4" i
+  supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" || return 0
   kill -TERM "$pid" 2>/dev/null || true
   for ((i=0; i<50; i++)); do kill -0 "$pid" 2>/dev/null || return 0; sleep 0.1; done
   kill -KILL "$pid" 2>/dev/null || true
@@ -104,13 +116,13 @@ terminate_supervisor() {
   return 1
 }
 launch_failure() {
-  local detail="$1" attempt_id="$2" runtime="$3" pid="${4:-}"
-  pid=$(supervisor_pid "$runtime" "$pid"); [[ -z "$pid" ]] || terminate_supervisor "$pid" "$attempt_id" || true
-  atomic_update 'if .watch_id!=$watch or .launch_attempt_id!=$attempt or .runtime_dir!=$runtime or
+  local detail="$1" attempt_id="$2" runtime="$3" artifact="$4" pid="${5:-}"
+  pid=$(supervisor_pid "$runtime" "$pid"); [[ -z "$pid" ]] || terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" || true
+  atomic_update 'if .watch_id!=$watch or .launch_attempt_id!=$attempt or .runtime_dir!=$runtime or .artifact_path!=$artifact or
       (.status|IN("launching","watching")|not) then error("launch claim lost") else
       .status="launch_failed"|.action="launch"|.terminal=false|.supervisor_pid=null|
       .diagnostic={cause:"launch_failed",detail:$detail}|.updated_at=(now|floor) end' \
-    --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg detail "$detail" \
+    --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" --arg detail "$detail" \
     || die "could not claim launch recovery; inspect the active lifecycle before handback"
 }
 live_pr() {
@@ -237,7 +249,7 @@ launch() {
   fi
   if [[ "$method" == setsid ]]; then
     setsid -f "$SELF" __supervise "$STATE_FILE" "$WATCH_ID" "$attempt_id" "$runtime" "$artifact" "$deadline" "$waiter" "$poll" "$max_wait" >> "$log" 2>&1 \
-      || { launch_failure "setsid could not launch supervisor; see $log" "$attempt_id" "$runtime"; die "detached supervisor launch failed; see $log"; }
+      || { launch_failure "setsid could not launch supervisor; see $log" "$attempt_id" "$runtime" "$artifact"; die "detached supervisor launch failed; see $log"; }
   else
     nohup "$SELF" __supervise "$STATE_FILE" "$WATCH_ID" "$attempt_id" "$runtime" "$artifact" "$deadline" "$waiter" "$poll" "$max_wait" </dev/null >> "$log" 2>&1 &
   fi
@@ -247,17 +259,17 @@ launch() {
     sleep 0.05
   done
   if [[ ! -f "$ready" ]]; then
-    launch_failure "supervisor did not establish worker liveness; see $log" "$attempt_id" "$runtime"
+    launch_failure "supervisor did not establish worker liveness; see $log" "$attempt_id" "$runtime" "$artifact"
     tail -20 "$log" >&2 || true
     die "supervisor setup failed; diagnostics: $log"
   fi
   pid=$(cat < "$runtime/supervisor.pid")
-  [[ "$pid" =~ ^[1-9][0-9]*$ ]] || { launch_failure "supervisor pid is malformed" "$attempt_id" "$runtime"; die "supervisor pid is malformed"; }
+  [[ "$pid" =~ ^[1-9][0-9]*$ ]] || { launch_failure "supervisor pid is malformed" "$attempt_id" "$runtime" "$artifact"; die "supervisor pid is malformed"; }
   if ! atomic_update 'if .watch_id!=$watch or .launch_attempt_id!=$attempt or .runtime_dir!=$runtime or
       .artifact_path!=$artifact or .status!="launching" then error("launch claim lost") else
       .status="watching"|.supervisor_pid=$pid|.updated_at=(now|floor) end' \
       --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" --argjson pid "$pid"; then
-    terminate_supervisor "$pid" "$attempt_id" || true
+    terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" || true
     die "lifecycle was terminalized during launch"
   fi
   json_report
@@ -307,7 +319,7 @@ consume() {
   recovery=$(jq -r .recovery_count <<<"$snapshot"); log=$(jq -r .log_path <<<"$snapshot"); now=$(date +%s)
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
     pid=$(supervisor_pid "$runtime" "$recorded_pid")
-    if supervisor_live "$pid" "$attempt_id"; then
+    if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact"; then
       if [[ "$now" -le "$setup_deadline" ]]; then
         jq -cn --arg watch "$WATCH_ID" '{status:"launching",watch_id:$watch,action:"pending"}'; return
       fi
@@ -318,17 +330,17 @@ consume() {
     elif [[ -z "$pid" && "$now" -le "$setup_deadline" ]]; then
       jq -cn --arg watch "$WATCH_ID" '{status:"launching",watch_id:$watch,action:"pending"}'; return
     else
-      launch_failure "launching supervisor died or missed its setup deadline; see $log" "$attempt_id" "$runtime" "$recorded_pid"
+      launch_failure "launching supervisor died or missed its setup deadline; see $log" "$attempt_id" "$runtime" "$artifact" "$recorded_pid"
       consume_report; return
     fi
   fi
   if [[ ! -s "$artifact" ]]; then
     pid=$(supervisor_pid "$runtime" "$recorded_pid"); token="$runtime/token"
-    if [[ -f "$token" && "$(cat < "$token")" == "$attempt_id" && "$now" -le "$deadline" ]] && supervisor_live "$pid" "$attempt_id"; then
+    if [[ -f "$token" && "$(cat < "$token")" == "$attempt_id" && "$now" -le "$deadline" ]] && supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact"; then
       jq -cn --arg status pending --arg watch "$WATCH_ID" '{status:$status,watch_id:$watch,action:"pending"}'
       return
     fi
-    terminate_supervisor "$pid" "$attempt_id" || true
+    terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" || true
     fail_state watch_lost "artifact missing and supervisor dead or overdue; see $log" "$attempt_id" "$artifact"
     json_report; return
   fi
@@ -385,10 +397,10 @@ event() {
   deadline=$(jq -r '.deadline // 0' <<<"$snapshot"); setup_deadline=$(jq -r '.setup_deadline // 0' <<<"$snapshot")
   now=$(date +%s); pid=$(supervisor_pid "$runtime" "$recorded_pid")
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
-    if supervisor_live "$pid" "$attempt_id"; then [[ "$now" -le "$setup_deadline" ]] && exit 1; printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
+    if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact"; then [[ "$now" -le "$setup_deadline" ]] && exit 1; printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
     [[ -z "$pid" && "$now" -le "$setup_deadline" ]] && exit 1
   fi
-  if [[ -s "$artifact" ]] || [[ "$now" -gt "$deadline" ]] || ! supervisor_live "$pid" "$attempt_id"; then printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
+  if [[ -s "$artifact" ]] || [[ "$now" -gt "$deadline" ]] || ! supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact"; then printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
   exit 1
 }
 
@@ -431,15 +443,26 @@ acknowledge() {
 }
 
 fail_command() {
-  local cause="" snapshot attempt_id runtime recorded_pid pid
+  local cause="" snapshot fresh attempt_id runtime artifact recorded_pid pid i fresh_attempt fresh_artifact
   while [[ $# -gt 0 ]]; do case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;;
     --watch-id) WATCH_ID="${2:-}"; shift 2 ;; --cause) cause="${2:-}"; shift 2 ;; *) die "unknown fail option: $1" ;; esac; done
   resolve_state; require_state; [[ "$cause" =~ ^(arm_failed|merge_blocked|launch_failed|operator_abandoned)$ ]] || die "invalid failure cause"
-  snapshot=$(state_snapshot) || die "cannot snapshot active launch attempt"
-  WATCH_ID="${WATCH_ID:-$(jq -r .watch_id <<<"$snapshot")}"
-  attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
-  recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot"); pid=$(supervisor_pid "$runtime" "$recorded_pid")
-  fail_state "$cause" "$cause"; terminate_supervisor "$pid" "$attempt_id" || true; json_report
+  for ((i=0; i<2; i++)); do
+    snapshot=$(state_snapshot) || die "cannot snapshot active launch attempt"
+    WATCH_ID="${WATCH_ID:-$(jq -r .watch_id <<<"$snapshot")}"
+    attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
+    artifact=$(jq -r .artifact_path <<<"$snapshot"); recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot")
+    pid=$(supervisor_pid "$runtime" "$recorded_pid")
+    if fail_state "$cause" "$cause" "$attempt_id" "$artifact"; then
+      terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" || true
+      json_report; return
+    fi
+    fresh=$(state_snapshot) || die "cannot resnapshot launch attempt after failure claim loss"
+    fresh_attempt=$(jq -r '.launch_attempt_id // empty' <<<"$fresh"); fresh_artifact=$(jq -r .artifact_path <<<"$fresh")
+    [[ "$fresh_attempt" == "$attempt_id" && "$fresh_artifact" == "$artifact" ]] \
+      || die "launch attempt changed before failure claim; replacement was left active"
+  done
+  die "could not claim failure for the active launch attempt"
 }
 
 inspect() { parse_root_issue "$@"; cat < "$STATE_FILE"; }

--- a/.agents/skills/orch/scripts/merge-queue-watch
+++ b/.agents/skills/orch/scripts/merge-queue-watch
@@ -58,6 +58,26 @@ atomic_update() {
     chmod 600 "$tmp" && mv -f -- "$tmp" "$STATE_FILE"
   ) 9>"$STATE_FILE.lock"
 }
+migrate_legacy_state() {
+  local snapshot status watch artifact runtime watch_dir runtime_root legacy_id
+  snapshot=$(state_snapshot) || die "cannot inspect durable watch generation"
+  status=$(jq -r .status <<<"$snapshot")
+  [[ "$status" == watching || "$status" == launch_failed ]] || return 0
+  [[ "$(jq -r '.launch_attempt_id // empty' <<<"$snapshot")" == "" ||
+     "$(jq -r '.supervisor_token // empty' <<<"$snapshot")" == "" ||
+     "$(jq -r '.runtime_root // empty' <<<"$snapshot")" == "" ]] || return 0
+  watch=$(jq -r .watch_id <<<"$snapshot"); artifact=$(jq -r .artifact_path <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
+  watch_dir="${artifact%/*}"; runtime_root="$watch_dir/runtime-attempts"; legacy_id="$watch-legacy"
+  [[ -n "$watch" && "$watch_dir" != "$artifact" && -d "$watch_dir" && ! -L "$watch_dir" && "$runtime" == "$watch_dir/"* ]] \
+    || die "legacy durable watch paths are invalid"
+  mkdir -p -- "$runtime_root" || die "cannot create migrated runtime root: $runtime_root"
+  chmod 700 "$runtime_root" || die "cannot secure migrated runtime root: $runtime_root"
+  atomic_update 'if (.status|IN("watching","launch_failed")) and
+      ((.launch_attempt_id // "")=="" or (.supervisor_token // "")=="" or (.runtime_root // "")=="") then
+      .watch_dir=$watch_dir|.runtime_root=$runtime_root|.launch_attempt=1|.launch_attempt_id=$legacy|
+      .supervisor_token=$legacy|.legacy_generation=true|.updated_at=(now|floor) else . end' \
+    --arg watch_dir "$watch_dir" --arg runtime_root "$runtime_root" --arg legacy "$legacy_id"
+}
 fail_state() {
   local cause="$1" detail="$2" attempt_id="${3:-}" artifact="${4:-}"
   atomic_update 'if .watch_id != $watch or ($attempt!="" and
@@ -106,7 +126,7 @@ supervisor_live() {
     return 1
   fi
   command=$(ps eww -p "$pid" -o command= 2>/dev/null) || return 1
-  [[ " $command " == *" MERGE_QUEUE_SUPERVISOR_TOKEN=$supervisor_token "* ]]
+  [[ " $command " == *" __supervise "* && " $command " == *" MERGE_QUEUE_SUPERVISOR_TOKEN=$supervisor_token "* ]]
 }
 terminate_supervisor() {
   local pid="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" i
@@ -125,16 +145,21 @@ terminate_supervisor() {
   return 1
 }
 launch_failure() {
-  local detail="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" pid="${6:-}"
-  pid=$(supervisor_pid "$runtime" "$pid"); [[ -z "$pid" ]] || terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
+  local detail="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" pid="${6:-}" snapshot
   atomic_update 'if .watch_id!=$watch or .launch_attempt_id!=$attempt or .runtime_dir!=$runtime or .artifact_path!=$artifact or
       .supervisor_token!=$token or
       (.status|IN("launching","watching")|not) then error("launch claim lost") else
-      .status="launch_failed"|.action="launch"|.terminal=false|.supervisor_pid=null|
+      .status="launch_failed"|.action="launch"|.terminal=false|
       .diagnostic={cause:"launch_failed",detail:$detail}|.updated_at=(now|floor) end' \
     --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" \
     --arg token "$supervisor_token" --arg detail "$detail" \
     || die "could not claim launch recovery; inspect the active lifecycle before handback"
+  snapshot=$(state_snapshot) || die "cannot snapshot claimed launch failure"
+  pid=$(supervisor_pid "$runtime" "$(jq -r '.supervisor_pid // empty' <<<"$snapshot")")
+  [[ -z "$pid" ]] || terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
+  atomic_update 'if .watch_id==$watch and .launch_attempt_id==$attempt and .status=="launch_failed"
+      then .supervisor_pid=null|.updated_at=(now|floor) else error("launch failure claim changed") end' \
+    --arg watch "$WATCH_ID" --arg attempt "$attempt_id"
 }
 live_pr() {
   local repo pr router
@@ -218,6 +243,7 @@ launch() {
       --max-wait) max_wait="${2:-}"; shift 2 ;; *) die "unknown launch option: $1" ;; esac
   done
   resolve_state; require_state
+  migrate_legacy_state
   [[ "$poll" =~ ^[1-9][0-9]*$ && "$max_wait" =~ ^[1-9][0-9]*$ && "$poll" -le "$max_wait" ]] || die "invalid wait bounds"
   snapshot=$(state_snapshot) || die "cannot snapshot prepared lifecycle"
   status=$(jq -r .status <<<"$snapshot"); prior_attempt=$(jq -r '.launch_attempt // 0' <<<"$snapshot")
@@ -251,7 +277,7 @@ launch() {
   if ! atomic_update 'if .watch_id!=$watch or .head_sha!=$head or .status!=$status or (.launch_attempt // 0)!=$prior
       then error("prepared claim lost") else .artifact_path=$artifact|.runtime_dir=$runtime|
       .launch_attempt=$attempt|.launch_attempt_id=$attempt_id|.status="launching"|.action=null|.diagnostic=null|
-      .supervisor_pid=null|.supervisor_token=$token|.launch_method=$method|.launched_at=$now|
+      .supervisor_pid=null|.supervisor_token=$token|.legacy_generation=false|.launch_method=$method|.launched_at=$now|
       .setup_deadline=($now+10)|.deadline=$deadline|.updated_at=$now end' \
     --arg watch "$WATCH_ID" --arg head "$head" --arg status "$status" --argjson prior "$prior_attempt" \
     --arg runtime "$runtime" --arg artifact "$artifact" --arg attempt_id "$attempt_id" --arg token "$supervisor_token" --arg method "$method" \
@@ -320,8 +346,9 @@ claim() {
 
 consume() {
   parse_root_issue "$@"
+  migrate_legacy_state
   local snapshot status artifact runtime attempt_id supervisor_token pid recorded_pid deadline setup_deadline now runtime_token body live live_state
-  local observed expected repo pr verdict result cause action diag error_text exit_code diag_path unconfirmed recovery log
+  local observed expected repo pr verdict result cause action diag error_text exit_code diag_path unconfirmed recovery log legacy
   snapshot=$(state_snapshot) || die "cannot snapshot active launch attempt"
   WATCH_ID=$(jq -r .watch_id <<<"$snapshot"); status=$(jq -r .status <<<"$snapshot")
   case "$status" in claimed|launch_failed|failed|abandoned|awaiting_lane_postmerge|cleanup_pending|cleanup_complete|complete) consume_report; return ;; esac
@@ -331,6 +358,7 @@ consume() {
   deadline=$(jq -r '.deadline // 0' <<<"$snapshot"); setup_deadline=$(jq -r '.setup_deadline // 0' <<<"$snapshot")
   expected=$(jq -r .head_sha <<<"$snapshot"); repo=$(jq -r .repository <<<"$snapshot"); pr=$(jq -r .pr_number <<<"$snapshot")
   recovery=$(jq -r .recovery_count <<<"$snapshot"); log=$(jq -r .log_path <<<"$snapshot"); now=$(date +%s)
+  legacy=$(jq -r '.legacy_generation // false' <<<"$snapshot")
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
     pid=$(supervisor_pid "$runtime" "$recorded_pid")
     if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then
@@ -349,6 +377,13 @@ consume() {
       consume_report; return
     fi
   fi
+  if [[ "$legacy" == true && "$status" == watching && ! -s "$artifact" ]]; then
+    pid=$(supervisor_pid "$runtime" "$recorded_pid")
+    if [[ "$pid" =~ ^[1-9][0-9]*$ && "$now" -le "$deadline" ]] && kill -0 "$pid" 2>/dev/null; then
+      jq -cn --arg watch "$WATCH_ID" '{status:"watching",watch_id:$watch,action:"pending"}'
+      return
+    fi
+  fi
   if [[ ! -s "$artifact" ]]; then
     pid=$(supervisor_pid "$runtime" "$recorded_pid"); runtime_token="$runtime/token"
     if [[ -f "$runtime_token" && "$(cat < "$runtime_token")" == "$attempt_id" && "$now" -le "$deadline" ]] && \
@@ -356,12 +391,14 @@ consume() {
       jq -cn --arg status pending --arg watch "$WATCH_ID" '{status:$status,watch_id:$watch,action:"pending"}'
       return
     fi
-    terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
     fail_state watch_lost "artifact missing and supervisor dead or overdue; see $log" "$attempt_id" "$artifact"
+    pid=$(supervisor_pid "$runtime")
+    [[ -z "$pid" ]] || terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
     json_report; return
   fi
-  if ! jq -e --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg repo "$repo" --arg head "$expected" --argjson pr "$pr" '
-      type=="object" and .schema_version==1 and .watch_id==$watch and .launch_attempt_id==$attempt and .repository==$repo and
+  if ! jq -e --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg repo "$repo" --arg head "$expected" --argjson pr "$pr" --argjson legacy "$legacy" '
+      type=="object" and .schema_version==1 and .watch_id==$watch and
+      (.launch_attempt_id==$attempt or ($legacy and (.launch_attempt_id==null))) and .repository==$repo and
       .pr_number==$pr and .expected_head==$head and (.observed_head|type=="string") and
       (.status|IN("complete","timeout","error")) and (.verdict|IN("merged","conflicting","ejected","disarmed","dequeued","closed","queued","not_queued","unknown"))' "$artifact" >/dev/null; then
     fail_state malformed_artifact "verdict artifact is malformed or belongs to another launch attempt" "$attempt_id" "$artifact"
@@ -403,8 +440,8 @@ consume() {
 event() {
   while [[ $# -gt 0 ]]; do case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;; *) die "unknown event option: $1" ;; esac; done
   [[ -n "$ROOT" && -n "$ISSUE" ]] || die "--root and --issue are required"
-  resolve_state; [[ -f "$STATE_FILE" ]] || exit 1
-  local snapshot status artifact runtime attempt_id supervisor_token recorded_pid pid deadline setup_deadline now
+  resolve_state; [[ -f "$STATE_FILE" ]] || exit 1; migrate_legacy_state
+  local snapshot status artifact runtime attempt_id supervisor_token recorded_pid pid deadline setup_deadline now legacy
   snapshot=$(state_snapshot) || exit 1; WATCH_ID=$(jq -r .watch_id <<<"$snapshot")
   status=$(jq -r .status <<<"$snapshot"); [[ "$status" == watching || "$status" == launching || "$status" == launch_failed ]] || exit 1
   [[ "$status" == launch_failed ]] && { printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; }
@@ -412,7 +449,9 @@ event() {
   attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot")
   supervisor_token=$(jq -r '.supervisor_token // empty' <<<"$snapshot")
   deadline=$(jq -r '.deadline // 0' <<<"$snapshot"); setup_deadline=$(jq -r '.setup_deadline // 0' <<<"$snapshot")
-  now=$(date +%s); pid=$(supervisor_pid "$runtime" "$recorded_pid")
+  legacy=$(jq -r '.legacy_generation // false' <<<"$snapshot"); now=$(date +%s); pid=$(supervisor_pid "$runtime" "$recorded_pid")
+  if [[ "$legacy" == true && "$status" == watching && ! -s "$artifact" && "$pid" =~ ^[1-9][0-9]*$ &&
+        "$now" -le "$deadline" ]] && kill -0 "$pid" 2>/dev/null; then exit 1; fi
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
     if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then [[ "$now" -le "$setup_deadline" ]] && exit 1; printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
     [[ -z "$pid" && "$now" -le "$setup_deadline" ]] && exit 1
@@ -469,9 +508,10 @@ fail_command() {
     WATCH_ID="${WATCH_ID:-$(jq -r .watch_id <<<"$snapshot")}"
     attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
     artifact=$(jq -r .artifact_path <<<"$snapshot"); supervisor_token=$(jq -r '.supervisor_token // empty' <<<"$snapshot")
-    recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot")
-    pid=$(supervisor_pid "$runtime" "$recorded_pid")
     if fail_state "$cause" "$cause" "$attempt_id" "$artifact"; then
+      fresh=$(state_snapshot) || die "cannot snapshot claimed failure"
+      recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$fresh")
+      pid=$(supervisor_pid "$runtime" "$recorded_pid")
       terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
       json_report; return
     fi

--- a/.agents/skills/orch/scripts/merge-queue-watch
+++ b/.agents/skills/orch/scripts/merge-queue-watch
@@ -155,7 +155,7 @@ prepare() {
     '{schema_version:1,issue_id:$issue,repository:$repo,pr_number:$pr,head_sha:$head,
       watch_id:$watch,gate_mode:$gate,recovery_count:$recovery,main_repo_root:$root,
       worktree:$worktree,worktree_branch:$worktree_branch,artifact_path:$artifact,log_path:$log,runtime_dir:$runtime,
-      prepared_at:$now,status:"prepared",action:null,terminal:false,
+      prepared_at:$now,launch_attempt:0,status:"prepared",action:null,terminal:false,
       supervisor_pid:null,launched_at:null,deadline:null,lane_postmerge:null,
       cleanup:{required:$cleanup,status:"not_started",diagnostic:null},diagnostic:null}' > "$new_state"
   (
@@ -182,7 +182,7 @@ prepare() {
 }
 
 launch() {
-  local poll=30 max_wait=2400 method pid deadline now ready log runtime waiter
+  local poll=30 max_wait=2400 method pid deadline now ready log runtime waiter artifact retry_artifact attempt
   while [[ $# -gt 0 ]]; do
     case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;;
       --watch-id) WATCH_ID="${2:-}"; shift 2 ;; --poll) poll="${2:-}"; shift 2 ;;
@@ -191,6 +191,8 @@ launch() {
   resolve_state; require_state
   [[ "$poll" =~ ^[1-9][0-9]*$ && "$max_wait" =~ ^[1-9][0-9]*$ && "$poll" -le "$max_wait" ]] || die "invalid wait bounds"
   now=$(date +%s); deadline=$((now + max_wait + 90)); runtime=$(state_value .runtime_dir); log=$(state_value .log_path)
+  artifact=$(state_value .artifact_path); attempt=$(state_value '(.launch_attempt // 0) + 1')
+  retry_artifact="${artifact%/*}/verdict-$attempt.json"
   waiter="$SCRIPT_DIR/queue-wait"
   if [[ ! -x "$waiter" ]]; then
     launch_failure "queue-wait is missing: $waiter; diagnostics: $log"
@@ -198,9 +200,11 @@ launch() {
   fi
   if command -v setsid >/dev/null 2>&1; then method="setsid"; else method="nohup"; fi
   atomic_update 'if .watch_id!=$watch or .head_sha!=$head or (.status|IN("prepared","launch_failed")|not) then error("prepared claim lost") else
-      .status="launching"|.action=null|.diagnostic=null|.launch_method=$method|.launched_at=$now|
+      .artifact_path=(if .status=="launch_failed" then $retry_artifact else .artifact_path end)|
+      .launch_attempt=$attempt|.status="launching"|.action=null|.diagnostic=null|.launch_method=$method|.launched_at=$now|
       .setup_deadline=($now+10)|.deadline=$deadline|.updated_at=$now end' \
-    --arg watch "$WATCH_ID" --arg head "$(state_value .head_sha)" --arg method "$method" --argjson now "$now" --argjson deadline "$deadline" \
+    --arg watch "$WATCH_ID" --arg head "$(state_value .head_sha)" --arg method "$method" --arg retry_artifact "$retry_artifact" \
+    --argjson attempt "$attempt" --argjson now "$now" --argjson deadline "$deadline" \
     || die "prepared lifecycle was terminalized before launch"
   if [[ "$method" == setsid ]]; then
     setsid -f "$SELF" __supervise "$STATE_FILE" "$WATCH_ID" "$waiter" "$poll" "$max_wait" >> "$log" 2>&1 \

--- a/.agents/skills/orch/scripts/merge-queue-watch
+++ b/.agents/skills/orch/scripts/merge-queue-watch
@@ -276,6 +276,8 @@ launch() {
       --max-wait) max_wait="${2:-}"; shift 2 ;; *) die "unknown launch option: $1" ;; esac
   done
   resolve_state; require_state
+  exec 8>"$STATE_FILE.launch.lock"
+  flock -w 10 8 || die "another launch attempt owns generation reservation"
   migrate_legacy_state
   [[ "$poll" =~ ^[1-9][0-9]*$ && "$max_wait" =~ ^[1-9][0-9]*$ && "$poll" -le "$max_wait" ]] || die "invalid wait bounds"
   snapshot=$(state_snapshot) || die "cannot snapshot prepared lifecycle"
@@ -307,6 +309,12 @@ launch() {
       || die "prepared attempt runtime is invalid: $runtime"
   else
     runtime="$runtime_root/$attempt_id"; artifact="$watch_dir/verdict-$attempt_id.json"
+    if [[ -e "$runtime" ]]; then
+      [[ "$(jq -r .runtime_dir <<<"$snapshot")" != "$runtime" &&
+         "$(jq -r '.launch_attempt_id // empty' <<<"$snapshot")" != "$attempt_id" ]] \
+        || die "registered launch attempt runtime cannot be reclaimed: $runtime"
+      rm -rf -- "$runtime" || die "cannot reclaim unregistered launch attempt runtime: $runtime"
+    fi
     mkdir -- "$runtime" || die "cannot reserve launch attempt runtime: $runtime"
     created=true; chmod 700 "$runtime"
     printf '%s\n' "$attempt_id" > "$runtime/token" && chmod 600 "$runtime/token" \
@@ -324,6 +332,7 @@ launch() {
     $created && { rm -f -- "$runtime/token"; rmdir -- "$runtime" 2>/dev/null || true; }
     die "prepared lifecycle was terminalized before launch"
   fi
+  flock -u 8; exec 8>&-
   if [[ "$method" == setsid ]]; then
     env "MERGE_QUEUE_SUPERVISOR_TOKEN=$supervisor_token" setsid -f "$SELF" __supervise "$STATE_FILE" "$WATCH_ID" "$attempt_id" "$runtime" "$artifact" "$deadline" "$waiter" "$poll" "$max_wait" >> "$log" 2>&1 \
       || { launch_failure "setsid could not launch supervisor; see $log" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; die "detached supervisor launch failed; see $log"; }

--- a/.agents/skills/orch/scripts/merge-queue-watch
+++ b/.agents/skills/orch/scripts/merge-queue-watch
@@ -62,20 +62,29 @@ migrate_legacy_state() {
   local snapshot status watch artifact runtime watch_dir runtime_root legacy_id
   snapshot=$(state_snapshot) || die "cannot inspect durable watch generation"
   status=$(jq -r .status <<<"$snapshot")
-  [[ "$status" == launching || "$status" == watching || "$status" == launch_failed || "$status" == failed ]] || return 0
-  [[ "$(jq -r '.launch_attempt_id // empty' <<<"$snapshot")" == "" ||
-     "$(jq -r '.supervisor_token // empty' <<<"$snapshot")" == "" ||
-     "$(jq -r '.runtime_root // empty' <<<"$snapshot")" == "" ]] || return 0
+  [[ "$status" == prepared || "$status" == launching || "$status" == watching || "$status" == launch_failed || "$status" == failed ]] || return 0
+  if [[ "$status" == prepared ]]; then
+    [[ "$(jq -r '.watch_dir // empty' <<<"$snapshot")" == "" ||
+       "$(jq -r '.runtime_root // empty' <<<"$snapshot")" == "" ||
+       "$(jq -r '.launch_attempt // empty' <<<"$snapshot")" == "" ]] || return 0
+  else
+    [[ "$(jq -r '.launch_attempt_id // empty' <<<"$snapshot")" == "" ||
+       "$(jq -r '.supervisor_token // empty' <<<"$snapshot")" == "" ||
+       "$(jq -r '.runtime_root // empty' <<<"$snapshot")" == "" ]] || return 0
+  fi
   watch=$(jq -r .watch_id <<<"$snapshot"); artifact=$(jq -r .artifact_path <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
   watch_dir="${artifact%/*}"; runtime_root="$watch_dir/runtime-attempts"; legacy_id="$watch-legacy"
   [[ -n "$watch" && "$watch_dir" != "$artifact" && -d "$watch_dir" && ! -L "$watch_dir" && "$runtime" == "$watch_dir/"* ]] \
     || die "legacy durable watch paths are invalid"
   mkdir -p -- "$runtime_root" || die "cannot create migrated runtime root: $runtime_root"
   chmod 700 "$runtime_root" || die "cannot secure migrated runtime root: $runtime_root"
-  atomic_update 'if (.status|IN("launching","watching","launch_failed","failed")) and
-      ((.launch_attempt_id // "")=="" or (.supervisor_token // "")=="" or (.runtime_root // "")=="") then
-      .watch_dir=$watch_dir|.runtime_root=$runtime_root|.launch_attempt=1|.launch_attempt_id=$legacy|
-      .supervisor_token=$legacy|.legacy_generation=true|.updated_at=(now|floor) else . end' \
+  atomic_update 'if (.status=="prepared" and
+      ((.watch_dir // "")=="" or (.runtime_root // "")=="" or (.launch_attempt // null)==null)) or
+      ((.status|IN("launching","watching","launch_failed","failed")) and
+       ((.launch_attempt_id // "")=="" or (.supervisor_token // "")=="" or (.runtime_root // "")=="")) then
+      .watch_dir=$watch_dir|.runtime_root=$runtime_root|.legacy_generation=true|.updated_at=(now|floor)|
+      if .status=="prepared" then .launch_attempt=0|.launch_attempt_id=null|.supervisor_token=null
+      else .launch_attempt=1|.launch_attempt_id=$legacy|.supervisor_token=$legacy end else . end' \
     --arg watch_dir "$watch_dir" --arg runtime_root "$runtime_root" --arg legacy "$legacy_id"
 }
 fail_state() {
@@ -278,9 +287,13 @@ launch() {
   resolve_state; require_state
   exec 8>"$STATE_FILE.launch.lock"
   flock -w 10 8 || die "another launch attempt owns generation reservation"
+  snapshot=$(state_snapshot) || die "cannot snapshot prepared lifecycle"
+  [[ "$WATCH_ID" =~ ^[A-Za-z0-9._-]+$ && "$WATCH_ID" != *..* ]] || die "watch id is not path-safe: $WATCH_ID"
+  [[ "$(jq -r '.watch_id // empty' <<<"$snapshot")" == "$WATCH_ID" ]] || die "watch id does not match active lifecycle"
   migrate_legacy_state
   [[ "$poll" =~ ^[1-9][0-9]*$ && "$max_wait" =~ ^[1-9][0-9]*$ && "$poll" -le "$max_wait" ]] || die "invalid wait bounds"
   snapshot=$(state_snapshot) || die "cannot snapshot prepared lifecycle"
+  [[ "$(jq -r '.watch_id // empty' <<<"$snapshot")" == "$WATCH_ID" ]] || die "watch id changed during launch"
   status=$(jq -r .status <<<"$snapshot"); prior_attempt=$(jq -r '.launch_attempt // 0' <<<"$snapshot")
   [[ "$prior_attempt" =~ ^[0-9]+$ && ( "$status" == prepared || "$status" == launch_failed ) ]] || die "prepared claim lost"
   legacy=$(jq -r '.legacy_generation // false' <<<"$snapshot")
@@ -303,7 +316,7 @@ launch() {
     die "queue-wait is missing: $waiter; diagnostics: $log"
   fi
   runtime_root=$(jq -r .runtime_root <<<"$snapshot"); watch_dir=$(jq -r .watch_dir <<<"$snapshot")
-  if [[ "$prior_attempt" -eq 0 ]]; then
+  if [[ "$prior_attempt" -eq 0 && "$legacy" != true ]]; then
     runtime=$(jq -r .runtime_dir <<<"$snapshot"); artifact=$(jq -r .artifact_path <<<"$snapshot")
     [[ -d "$runtime" && ! -L "$runtime" && -f "$runtime/token" && "$(cat < "$runtime/token")" == "$attempt_id" ]] \
       || die "prepared attempt runtime is invalid: $runtime"

--- a/.agents/skills/orch/scripts/merge-queue-watch
+++ b/.agents/skills/orch/scripts/merge-queue-watch
@@ -62,7 +62,7 @@ migrate_legacy_state() {
   local snapshot status watch artifact runtime watch_dir runtime_root legacy_id
   snapshot=$(state_snapshot) || die "cannot inspect durable watch generation"
   status=$(jq -r .status <<<"$snapshot")
-  [[ "$status" == watching || "$status" == launch_failed ]] || return 0
+  [[ "$status" == launching || "$status" == watching || "$status" == launch_failed || "$status" == failed ]] || return 0
   [[ "$(jq -r '.launch_attempt_id // empty' <<<"$snapshot")" == "" ||
      "$(jq -r '.supervisor_token // empty' <<<"$snapshot")" == "" ||
      "$(jq -r '.runtime_root // empty' <<<"$snapshot")" == "" ]] || return 0
@@ -72,7 +72,7 @@ migrate_legacy_state() {
     || die "legacy durable watch paths are invalid"
   mkdir -p -- "$runtime_root" || die "cannot create migrated runtime root: $runtime_root"
   chmod 700 "$runtime_root" || die "cannot secure migrated runtime root: $runtime_root"
-  atomic_update 'if (.status|IN("watching","launch_failed")) and
+  atomic_update 'if (.status|IN("launching","watching","launch_failed","failed")) and
       ((.launch_attempt_id // "")=="" or (.supervisor_token // "")=="" or (.runtime_root // "")=="") then
       .watch_dir=$watch_dir|.runtime_root=$runtime_root|.launch_attempt=1|.launch_attempt_id=$legacy|
       .supervisor_token=$legacy|.legacy_generation=true|.updated_at=(now|floor) else . end' \
@@ -107,11 +107,18 @@ supervisor_pid() {
   fi
   printf '%s' "$pid"
 }
+process_running() {
+  local pid="$1" state
+  [[ "$pid" =~ ^[1-9][0-9]*$ ]] || return 1
+  state=$(ps -p "$pid" -o stat= 2>/dev/null) || return 1
+  state="${state//[[:space:]]/}"
+  [[ -n "$state" && "$state" != Z* ]]
+}
 supervisor_live() {
   local pid="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" command arg i argv_match=false
   local argv=()
   [[ "$pid" =~ ^[1-9][0-9]*$ && "$supervisor_token" =~ ^[A-Za-z0-9._-]+$ ]] || return 1
-  kill -0 "$pid" 2>/dev/null || return 1
+  process_running "$pid" || return 1
   if [[ -r "/proc/$pid/cmdline" && "${MERGE_QUEUE_FORCE_PS_IDENTITY:-0}" != 1 ]]; then
     while IFS= read -r -d '' arg; do argv[${#argv[@]}]="$arg"; done < "/proc/$pid/cmdline"
     for ((i=0; i+6<${#argv[@]}; i++)); do
@@ -128,6 +135,21 @@ supervisor_live() {
   command=$(ps eww -p "$pid" -o command= 2>/dev/null) || return 1
   [[ " $command " == *" __supervise "* && " $command " == *" MERGE_QUEUE_SUPERVISOR_TOKEN=$supervisor_token "* ]]
 }
+legacy_supervisor_live() {
+  local pid="$1" command arg i
+  local argv=()
+  process_running "$pid" || return 1
+  if [[ -r "/proc/$pid/cmdline" ]]; then
+    while IFS= read -r -d '' arg; do argv[${#argv[@]}]="$arg"; done < "/proc/$pid/cmdline"
+    for ((i=0; i+4<${#argv[@]}; i++)); do
+      [[ "${argv[i]}" == "$SELF" && "${argv[i+1]}" == __supervise && "${argv[i+2]}" == "$STATE_FILE" &&
+         "${argv[i+3]}" == "$WATCH_ID" && "${argv[i+4]}" == "$SCRIPT_DIR/queue-wait" ]] && return 0
+    done
+    return 1
+  fi
+  command=$(ps -ww -p "$pid" -o command= 2>/dev/null) || return 1
+  [[ "$command" == *"$SELF __supervise $STATE_FILE $WATCH_ID $SCRIPT_DIR/queue-wait "* ]]
+}
 terminate_supervisor() {
   local pid="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" i
   supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || return 0
@@ -142,6 +164,16 @@ terminate_supervisor() {
     supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || return 0
     sleep 0.1
   done
+  return 1
+}
+terminate_legacy_supervisor() {
+  local pid="$1" i
+  legacy_supervisor_live "$pid" || return 0
+  kill -TERM "$pid" 2>/dev/null || true
+  for ((i=0; i<50; i++)); do legacy_supervisor_live "$pid" || return 0; sleep 0.1; done
+  legacy_supervisor_live "$pid" || return 0
+  kill -KILL "$pid" 2>/dev/null || true
+  for ((i=0; i<20; i++)); do legacy_supervisor_live "$pid" || return 0; sleep 0.1; done
   return 1
 }
 launch_failure() {
@@ -379,7 +411,7 @@ consume() {
   fi
   if [[ "$legacy" == true && "$status" == watching && ! -s "$artifact" ]]; then
     pid=$(supervisor_pid "$runtime" "$recorded_pid")
-    if [[ "$pid" =~ ^[1-9][0-9]*$ && "$now" -le "$deadline" ]] && kill -0 "$pid" 2>/dev/null; then
+    if [[ "$now" -le "$deadline" ]] && legacy_supervisor_live "$pid"; then
       jq -cn --arg watch "$WATCH_ID" '{status:"watching",watch_id:$watch,action:"pending"}'
       return
     fi
@@ -393,7 +425,8 @@ consume() {
     fi
     fail_state watch_lost "artifact missing and supervisor dead or overdue; see $log" "$attempt_id" "$artifact"
     pid=$(supervisor_pid "$runtime")
-    [[ -z "$pid" ]] || terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
+    if [[ -n "$pid" && "$legacy" == true ]]; then terminate_legacy_supervisor "$pid" || true
+    elif [[ -n "$pid" ]]; then terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true; fi
     json_report; return
   fi
   if ! jq -e --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg repo "$repo" --arg head "$expected" --argjson pr "$pr" --argjson legacy "$legacy" '
@@ -450,8 +483,8 @@ event() {
   supervisor_token=$(jq -r '.supervisor_token // empty' <<<"$snapshot")
   deadline=$(jq -r '.deadline // 0' <<<"$snapshot"); setup_deadline=$(jq -r '.setup_deadline // 0' <<<"$snapshot")
   legacy=$(jq -r '.legacy_generation // false' <<<"$snapshot"); now=$(date +%s); pid=$(supervisor_pid "$runtime" "$recorded_pid")
-  if [[ "$legacy" == true && "$status" == watching && ! -s "$artifact" && "$pid" =~ ^[1-9][0-9]*$ &&
-        "$now" -le "$deadline" ]] && kill -0 "$pid" 2>/dev/null; then exit 1; fi
+  if [[ "$legacy" == true && "$status" == watching && ! -s "$artifact" && "$now" -le "$deadline" ]] &&
+      legacy_supervisor_live "$pid"; then exit 1; fi
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
     if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then [[ "$now" -le "$setup_deadline" ]] && exit 1; printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
     [[ -z "$pid" && "$now" -le "$setup_deadline" ]] && exit 1
@@ -499,20 +532,23 @@ acknowledge() {
 }
 
 fail_command() {
-  local cause="" snapshot fresh attempt_id runtime artifact supervisor_token recorded_pid pid i fresh_attempt fresh_artifact
+  local cause="" snapshot fresh attempt_id runtime artifact supervisor_token recorded_pid pid i fresh_attempt fresh_artifact legacy
   while [[ $# -gt 0 ]]; do case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;;
     --watch-id) WATCH_ID="${2:-}"; shift 2 ;; --cause) cause="${2:-}"; shift 2 ;; *) die "unknown fail option: $1" ;; esac; done
   resolve_state; require_state; [[ "$cause" =~ ^(arm_failed|merge_blocked|launch_failed|operator_abandoned)$ ]] || die "invalid failure cause"
+  migrate_legacy_state
   for ((i=0; i<2; i++)); do
     snapshot=$(state_snapshot) || die "cannot snapshot active launch attempt"
     WATCH_ID="${WATCH_ID:-$(jq -r .watch_id <<<"$snapshot")}"
     attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
     artifact=$(jq -r .artifact_path <<<"$snapshot"); supervisor_token=$(jq -r '.supervisor_token // empty' <<<"$snapshot")
+    legacy=$(jq -r '.legacy_generation // false' <<<"$snapshot")
     if fail_state "$cause" "$cause" "$attempt_id" "$artifact"; then
       fresh=$(state_snapshot) || die "cannot snapshot claimed failure"
       recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$fresh")
       pid=$(supervisor_pid "$runtime" "$recorded_pid")
-      terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
+      if [[ "$legacy" == true ]]; then terminate_legacy_supervisor "$pid" || true
+      else terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true; fi
       json_report; return
     fi
     fresh=$(state_snapshot) || die "cannot resnapshot launch attempt after failure claim loss"

--- a/.agents/skills/orch/scripts/merge-queue-watch
+++ b/.agents/skills/orch/scripts/merge-queue-watch
@@ -88,41 +88,52 @@ supervisor_pid() {
   printf '%s' "$pid"
 }
 supervisor_live() {
-  local pid="$1" attempt_id="$2" runtime="$3" artifact="$4" command arg i
+  local pid="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" command arg i argv_match=false
   local argv=()
-  [[ "$pid" =~ ^[1-9][0-9]*$ ]] || return 1
+  [[ "$pid" =~ ^[1-9][0-9]*$ && "$supervisor_token" =~ ^[A-Za-z0-9._-]+$ ]] || return 1
   kill -0 "$pid" 2>/dev/null || return 1
-  if [[ -r "/proc/$pid/cmdline" ]]; then
+  if [[ -r "/proc/$pid/cmdline" && "${MERGE_QUEUE_FORCE_PS_IDENTITY:-0}" != 1 ]]; then
     while IFS= read -r -d '' arg; do argv[${#argv[@]}]="$arg"; done < "/proc/$pid/cmdline"
-  else
-    [[ "$SELF$STATE_FILE$WATCH_ID$attempt_id$runtime$artifact" != *[[:space:]]* ]] || return 1
-    command=$(ps -ww -p "$pid" -o command= 2>/dev/null) || return 1
-    read -r -a argv <<<"$command"
+    for ((i=0; i+6<${#argv[@]}; i++)); do
+      [[ "${argv[i]}" == "$SELF" && "${argv[i+1]}" == __supervise && "${argv[i+2]}" == "$STATE_FILE" &&
+         "${argv[i+3]}" == "$WATCH_ID" && "${argv[i+4]}" == "$attempt_id" && "${argv[i+5]}" == "$runtime" &&
+         "${argv[i+6]}" == "$artifact" ]] && { argv_match=true; break; }
+    done
+    $argv_match || return 1
+    while IFS= read -r -d '' arg; do
+      [[ "$arg" == "MERGE_QUEUE_SUPERVISOR_TOKEN=$supervisor_token" ]] && return 0
+    done < "/proc/$pid/environ"
+    return 1
   fi
-  for ((i=0; i+6<${#argv[@]}; i++)); do
-    [[ "${argv[i]}" == "$SELF" && "${argv[i+1]}" == __supervise && "${argv[i+2]}" == "$STATE_FILE" &&
-       "${argv[i+3]}" == "$WATCH_ID" && "${argv[i+4]}" == "$attempt_id" && "${argv[i+5]}" == "$runtime" &&
-       "${argv[i+6]}" == "$artifact" ]] && return 0
+  command=$(ps eww -p "$pid" -o command= 2>/dev/null) || return 1
+  [[ " $command " == *" MERGE_QUEUE_SUPERVISOR_TOKEN=$supervisor_token "* ]]
+}
+terminate_supervisor() {
+  local pid="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" i
+  supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || return 0
+  kill -TERM "$pid" 2>/dev/null || true
+  for ((i=0; i<50; i++)); do
+    supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || return 0
+    sleep 0.1
+  done
+  supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || return 0
+  kill -KILL "$pid" 2>/dev/null || true
+  for ((i=0; i<20; i++)); do
+    supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || return 0
+    sleep 0.1
   done
   return 1
 }
-terminate_supervisor() {
-  local pid="$1" attempt_id="$2" runtime="$3" artifact="$4" i
-  supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" || return 0
-  kill -TERM "$pid" 2>/dev/null || true
-  for ((i=0; i<50; i++)); do kill -0 "$pid" 2>/dev/null || return 0; sleep 0.1; done
-  kill -KILL "$pid" 2>/dev/null || true
-  for ((i=0; i<20; i++)); do kill -0 "$pid" 2>/dev/null || return 0; sleep 0.1; done
-  return 1
-}
 launch_failure() {
-  local detail="$1" attempt_id="$2" runtime="$3" artifact="$4" pid="${5:-}"
-  pid=$(supervisor_pid "$runtime" "$pid"); [[ -z "$pid" ]] || terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" || true
+  local detail="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" pid="${6:-}"
+  pid=$(supervisor_pid "$runtime" "$pid"); [[ -z "$pid" ]] || terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
   atomic_update 'if .watch_id!=$watch or .launch_attempt_id!=$attempt or .runtime_dir!=$runtime or .artifact_path!=$artifact or
+      .supervisor_token!=$token or
       (.status|IN("launching","watching")|not) then error("launch claim lost") else
       .status="launch_failed"|.action="launch"|.terminal=false|.supervisor_pid=null|
       .diagnostic={cause:"launch_failed",detail:$detail}|.updated_at=(now|floor) end' \
-    --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" --arg detail "$detail" \
+    --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" \
+    --arg token "$supervisor_token" --arg detail "$detail" \
     || die "could not claim launch recovery; inspect the active lifecycle before handback"
 }
 live_pr() {
@@ -173,7 +184,7 @@ prepare() {
       worktree:$worktree,worktree_branch:$worktree_branch,watch_dir:$watch_dir,artifact_path:$artifact,log_path:$log,
       runtime_root:$runtime_root,runtime_dir:$runtime,prepared_at:$now,launch_attempt:0,launch_attempt_id:null,
       status:"prepared",action:null,terminal:false,
-      supervisor_pid:null,launched_at:null,deadline:null,lane_postmerge:null,
+      supervisor_pid:null,supervisor_token:null,launched_at:null,deadline:null,lane_postmerge:null,
       cleanup:{required:$cleanup,status:"not_started",diagnostic:null},diagnostic:null}' > "$new_state"
   (
     flock -w 10 9 || exit 1
@@ -199,7 +210,7 @@ prepare() {
 }
 
 launch() {
-  local poll=30 max_wait=2400 method pid deadline now ready log runtime waiter artifact attempt attempt_id
+  local poll=30 max_wait=2400 method pid deadline now ready log runtime waiter artifact attempt attempt_id supervisor_token
   local snapshot status prior_attempt head runtime_root watch_dir created=false
   while [[ $# -gt 0 ]]; do
     case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;;
@@ -211,7 +222,8 @@ launch() {
   snapshot=$(state_snapshot) || die "cannot snapshot prepared lifecycle"
   status=$(jq -r .status <<<"$snapshot"); prior_attempt=$(jq -r '.launch_attempt // 0' <<<"$snapshot")
   [[ "$prior_attempt" =~ ^[0-9]+$ && ( "$status" == prepared || "$status" == launch_failed ) ]] || die "prepared claim lost"
-  attempt=$((prior_attempt+1)); attempt_id="$WATCH_ID-attempt-$attempt"; head=$(jq -r .head_sha <<<"$snapshot")
+  attempt=$((prior_attempt+1)); attempt_id="$WATCH_ID-attempt-$attempt"; supervisor_token="$attempt_id-$RANDOM$RANDOM"
+  head=$(jq -r .head_sha <<<"$snapshot")
   now=$(date +%s); deadline=$((now + max_wait + 90)); log=$(jq -r .log_path <<<"$snapshot")
   waiter="$SCRIPT_DIR/queue-wait"
   if [[ ! -x "$waiter" ]]; then
@@ -239,19 +251,19 @@ launch() {
   if ! atomic_update 'if .watch_id!=$watch or .head_sha!=$head or .status!=$status or (.launch_attempt // 0)!=$prior
       then error("prepared claim lost") else .artifact_path=$artifact|.runtime_dir=$runtime|
       .launch_attempt=$attempt|.launch_attempt_id=$attempt_id|.status="launching"|.action=null|.diagnostic=null|
-      .supervisor_pid=null|.launch_method=$method|.launched_at=$now|
+      .supervisor_pid=null|.supervisor_token=$token|.launch_method=$method|.launched_at=$now|
       .setup_deadline=($now+10)|.deadline=$deadline|.updated_at=$now end' \
     --arg watch "$WATCH_ID" --arg head "$head" --arg status "$status" --argjson prior "$prior_attempt" \
-    --arg runtime "$runtime" --arg artifact "$artifact" --arg attempt_id "$attempt_id" --arg method "$method" \
+    --arg runtime "$runtime" --arg artifact "$artifact" --arg attempt_id "$attempt_id" --arg token "$supervisor_token" --arg method "$method" \
     --argjson attempt "$attempt" --argjson now "$now" --argjson deadline "$deadline"; then
     $created && { rm -f -- "$runtime/token"; rmdir -- "$runtime" 2>/dev/null || true; }
     die "prepared lifecycle was terminalized before launch"
   fi
   if [[ "$method" == setsid ]]; then
-    setsid -f "$SELF" __supervise "$STATE_FILE" "$WATCH_ID" "$attempt_id" "$runtime" "$artifact" "$deadline" "$waiter" "$poll" "$max_wait" >> "$log" 2>&1 \
-      || { launch_failure "setsid could not launch supervisor; see $log" "$attempt_id" "$runtime" "$artifact"; die "detached supervisor launch failed; see $log"; }
+    env "MERGE_QUEUE_SUPERVISOR_TOKEN=$supervisor_token" setsid -f "$SELF" __supervise "$STATE_FILE" "$WATCH_ID" "$attempt_id" "$runtime" "$artifact" "$deadline" "$waiter" "$poll" "$max_wait" >> "$log" 2>&1 \
+      || { launch_failure "setsid could not launch supervisor; see $log" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; die "detached supervisor launch failed; see $log"; }
   else
-    nohup "$SELF" __supervise "$STATE_FILE" "$WATCH_ID" "$attempt_id" "$runtime" "$artifact" "$deadline" "$waiter" "$poll" "$max_wait" </dev/null >> "$log" 2>&1 &
+    env "MERGE_QUEUE_SUPERVISOR_TOKEN=$supervisor_token" nohup "$SELF" __supervise "$STATE_FILE" "$WATCH_ID" "$attempt_id" "$runtime" "$artifact" "$deadline" "$waiter" "$poll" "$max_wait" </dev/null >> "$log" 2>&1 &
   fi
   ready="$runtime/ready"
   for ((i=0; i<100; i++)); do
@@ -259,17 +271,18 @@ launch() {
     sleep 0.05
   done
   if [[ ! -f "$ready" ]]; then
-    launch_failure "supervisor did not establish worker liveness; see $log" "$attempt_id" "$runtime" "$artifact"
+    launch_failure "supervisor did not establish worker liveness; see $log" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"
     tail -20 "$log" >&2 || true
     die "supervisor setup failed; diagnostics: $log"
   fi
   pid=$(cat < "$runtime/supervisor.pid")
-  [[ "$pid" =~ ^[1-9][0-9]*$ ]] || { launch_failure "supervisor pid is malformed" "$attempt_id" "$runtime" "$artifact"; die "supervisor pid is malformed"; }
+  [[ "$pid" =~ ^[1-9][0-9]*$ ]] || { launch_failure "supervisor pid is malformed" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; die "supervisor pid is malformed"; }
   if ! atomic_update 'if .watch_id!=$watch or .launch_attempt_id!=$attempt or .runtime_dir!=$runtime or
-      .artifact_path!=$artifact or .status!="launching" then error("launch claim lost") else
+      .artifact_path!=$artifact or .supervisor_token!=$token or .status!="launching" then error("launch claim lost") else
       .status="watching"|.supervisor_pid=$pid|.updated_at=(now|floor) end' \
-      --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" --argjson pid "$pid"; then
-    terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" || true
+      --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" \
+      --arg token "$supervisor_token" --argjson pid "$pid"; then
+    terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
     die "lifecycle was terminalized during launch"
   fi
   json_report
@@ -307,40 +320,43 @@ claim() {
 
 consume() {
   parse_root_issue "$@"
-  local snapshot status artifact runtime attempt_id pid recorded_pid deadline setup_deadline now token body live live_state
+  local snapshot status artifact runtime attempt_id supervisor_token pid recorded_pid deadline setup_deadline now runtime_token body live live_state
   local observed expected repo pr verdict result cause action diag error_text exit_code diag_path unconfirmed recovery log
   snapshot=$(state_snapshot) || die "cannot snapshot active launch attempt"
   WATCH_ID=$(jq -r .watch_id <<<"$snapshot"); status=$(jq -r .status <<<"$snapshot")
   case "$status" in claimed|launch_failed|failed|abandoned|awaiting_lane_postmerge|cleanup_pending|cleanup_complete|complete) consume_report; return ;; esac
   artifact=$(jq -r .artifact_path <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
   attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot")
+  supervisor_token=$(jq -r '.supervisor_token // empty' <<<"$snapshot")
   deadline=$(jq -r '.deadline // 0' <<<"$snapshot"); setup_deadline=$(jq -r '.setup_deadline // 0' <<<"$snapshot")
   expected=$(jq -r .head_sha <<<"$snapshot"); repo=$(jq -r .repository <<<"$snapshot"); pr=$(jq -r .pr_number <<<"$snapshot")
   recovery=$(jq -r .recovery_count <<<"$snapshot"); log=$(jq -r .log_path <<<"$snapshot"); now=$(date +%s)
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
     pid=$(supervisor_pid "$runtime" "$recorded_pid")
-    if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact"; then
+    if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then
       if [[ "$now" -le "$setup_deadline" ]]; then
         jq -cn --arg watch "$WATCH_ID" '{status:"launching",watch_id:$watch,action:"pending"}'; return
       fi
       atomic_update 'if .watch_id==$watch and .launch_attempt_id==$attempt and .runtime_dir==$runtime and
-          .artifact_path==$artifact and .status=="launching" then .status="watching"|.supervisor_pid=$pid|.updated_at=(now|floor)
+          .artifact_path==$artifact and .supervisor_token==$token and .status=="launching"
+          then .status="watching"|.supervisor_pid=$pid|.updated_at=(now|floor)
           else error("launch attempt changed") end' --arg watch "$WATCH_ID" --arg attempt "$attempt_id" \
-        --arg runtime "$runtime" --arg artifact "$artifact" --argjson pid "$pid"; status=watching
+        --arg runtime "$runtime" --arg artifact "$artifact" --arg token "$supervisor_token" --argjson pid "$pid"; status=watching
     elif [[ -z "$pid" && "$now" -le "$setup_deadline" ]]; then
       jq -cn --arg watch "$WATCH_ID" '{status:"launching",watch_id:$watch,action:"pending"}'; return
     else
-      launch_failure "launching supervisor died or missed its setup deadline; see $log" "$attempt_id" "$runtime" "$artifact" "$recorded_pid"
+      launch_failure "launching supervisor died or missed its setup deadline; see $log" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" "$recorded_pid"
       consume_report; return
     fi
   fi
   if [[ ! -s "$artifact" ]]; then
-    pid=$(supervisor_pid "$runtime" "$recorded_pid"); token="$runtime/token"
-    if [[ -f "$token" && "$(cat < "$token")" == "$attempt_id" && "$now" -le "$deadline" ]] && supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact"; then
+    pid=$(supervisor_pid "$runtime" "$recorded_pid"); runtime_token="$runtime/token"
+    if [[ -f "$runtime_token" && "$(cat < "$runtime_token")" == "$attempt_id" && "$now" -le "$deadline" ]] && \
+        supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then
       jq -cn --arg status pending --arg watch "$WATCH_ID" '{status:$status,watch_id:$watch,action:"pending"}'
       return
     fi
-    terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" || true
+    terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
     fail_state watch_lost "artifact missing and supervisor dead or overdue; see $log" "$attempt_id" "$artifact"
     json_report; return
   fi
@@ -388,19 +404,20 @@ event() {
   while [[ $# -gt 0 ]]; do case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;; *) die "unknown event option: $1" ;; esac; done
   [[ -n "$ROOT" && -n "$ISSUE" ]] || die "--root and --issue are required"
   resolve_state; [[ -f "$STATE_FILE" ]] || exit 1
-  local snapshot status artifact runtime attempt_id recorded_pid pid deadline setup_deadline now
+  local snapshot status artifact runtime attempt_id supervisor_token recorded_pid pid deadline setup_deadline now
   snapshot=$(state_snapshot) || exit 1; WATCH_ID=$(jq -r .watch_id <<<"$snapshot")
   status=$(jq -r .status <<<"$snapshot"); [[ "$status" == watching || "$status" == launching || "$status" == launch_failed ]] || exit 1
   [[ "$status" == launch_failed ]] && { printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; }
   artifact=$(jq -r .artifact_path <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
   attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot")
+  supervisor_token=$(jq -r '.supervisor_token // empty' <<<"$snapshot")
   deadline=$(jq -r '.deadline // 0' <<<"$snapshot"); setup_deadline=$(jq -r '.setup_deadline // 0' <<<"$snapshot")
   now=$(date +%s); pid=$(supervisor_pid "$runtime" "$recorded_pid")
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
-    if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact"; then [[ "$now" -le "$setup_deadline" ]] && exit 1; printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
+    if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then [[ "$now" -le "$setup_deadline" ]] && exit 1; printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
     [[ -z "$pid" && "$now" -le "$setup_deadline" ]] && exit 1
   fi
-  if [[ -s "$artifact" ]] || [[ "$now" -gt "$deadline" ]] || ! supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact"; then printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
+  if [[ -s "$artifact" ]] || [[ "$now" -gt "$deadline" ]] || ! supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
   exit 1
 }
 
@@ -443,7 +460,7 @@ acknowledge() {
 }
 
 fail_command() {
-  local cause="" snapshot fresh attempt_id runtime artifact recorded_pid pid i fresh_attempt fresh_artifact
+  local cause="" snapshot fresh attempt_id runtime artifact supervisor_token recorded_pid pid i fresh_attempt fresh_artifact
   while [[ $# -gt 0 ]]; do case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;;
     --watch-id) WATCH_ID="${2:-}"; shift 2 ;; --cause) cause="${2:-}"; shift 2 ;; *) die "unknown fail option: $1" ;; esac; done
   resolve_state; require_state; [[ "$cause" =~ ^(arm_failed|merge_blocked|launch_failed|operator_abandoned)$ ]] || die "invalid failure cause"
@@ -451,10 +468,11 @@ fail_command() {
     snapshot=$(state_snapshot) || die "cannot snapshot active launch attempt"
     WATCH_ID="${WATCH_ID:-$(jq -r .watch_id <<<"$snapshot")}"
     attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
-    artifact=$(jq -r .artifact_path <<<"$snapshot"); recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot")
+    artifact=$(jq -r .artifact_path <<<"$snapshot"); supervisor_token=$(jq -r '.supervisor_token // empty' <<<"$snapshot")
+    recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot")
     pid=$(supervisor_pid "$runtime" "$recorded_pid")
     if fail_state "$cause" "$cause" "$attempt_id" "$artifact"; then
-      terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" || true
+      terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
       json_report; return
     fi
     fresh=$(state_snapshot) || die "cannot resnapshot launch attempt after failure claim loss"

--- a/.agents/skills/orch/scripts/merge-queue-watch
+++ b/.agents/skills/orch/scripts/merge-queue-watch
@@ -177,7 +177,7 @@ terminate_legacy_supervisor() {
   return 1
 }
 launch_failure() {
-  local detail="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" pid="${6:-}" snapshot
+  local detail="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" pid="${6:-}" legacy="${7:-false}" snapshot
   atomic_update 'if .watch_id!=$watch or .launch_attempt_id!=$attempt or .runtime_dir!=$runtime or .artifact_path!=$artifact or
       .supervisor_token!=$token or
       (.status|IN("launching","watching")|not) then error("launch claim lost") else
@@ -188,7 +188,8 @@ launch_failure() {
     || die "could not claim launch recovery; inspect the active lifecycle before handback"
   snapshot=$(state_snapshot) || die "cannot snapshot claimed launch failure"
   pid=$(supervisor_pid "$runtime" "$(jq -r '.supervisor_pid // empty' <<<"$snapshot")")
-  [[ -z "$pid" ]] || terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
+  if [[ -n "$pid" && "$legacy" == true ]]; then terminate_legacy_supervisor "$pid" || true
+  elif [[ -n "$pid" ]]; then terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true; fi
   atomic_update 'if .watch_id==$watch and .launch_attempt_id==$attempt and .status=="launch_failed"
       then .supervisor_pid=null|.updated_at=(now|floor) else error("launch failure claim changed") end' \
     --arg watch "$WATCH_ID" --arg attempt "$attempt_id"
@@ -268,7 +269,7 @@ prepare() {
 
 launch() {
   local poll=30 max_wait=2400 method pid deadline now ready log runtime waiter artifact attempt attempt_id supervisor_token
-  local snapshot status prior_attempt head runtime_root watch_dir created=false
+  local snapshot status prior_attempt head runtime_root watch_dir created=false legacy recorded_pid
   while [[ $# -gt 0 ]]; do
     case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;;
       --watch-id) WATCH_ID="${2:-}"; shift 2 ;; --poll) poll="${2:-}"; shift 2 ;;
@@ -280,6 +281,12 @@ launch() {
   snapshot=$(state_snapshot) || die "cannot snapshot prepared lifecycle"
   status=$(jq -r .status <<<"$snapshot"); prior_attempt=$(jq -r '.launch_attempt // 0' <<<"$snapshot")
   [[ "$prior_attempt" =~ ^[0-9]+$ && ( "$status" == prepared || "$status" == launch_failed ) ]] || die "prepared claim lost"
+  legacy=$(jq -r '.legacy_generation // false' <<<"$snapshot")
+  if [[ "$status" == launch_failed && "$legacy" == true ]]; then
+    runtime=$(jq -r .runtime_dir <<<"$snapshot"); recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot")
+    pid=$(supervisor_pid "$runtime" "$recorded_pid")
+    [[ -z "$pid" ]] || terminate_legacy_supervisor "$pid" || die "legacy supervisor survived launch recovery teardown"
+  fi
   attempt=$((prior_attempt+1)); attempt_id="$WATCH_ID-attempt-$attempt"; supervisor_token="$attempt_id-$RANDOM$RANDOM"
   head=$(jq -r .head_sha <<<"$snapshot")
   now=$(date +%s); deadline=$((now + max_wait + 90)); log=$(jq -r .log_path <<<"$snapshot")
@@ -393,7 +400,15 @@ consume() {
   legacy=$(jq -r '.legacy_generation // false' <<<"$snapshot")
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
     pid=$(supervisor_pid "$runtime" "$recorded_pid")
-    if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then
+    if [[ "$legacy" == true ]] && legacy_supervisor_live "$pid"; then
+      if [[ "$now" -le "$setup_deadline" ]]; then
+        jq -cn --arg watch "$WATCH_ID" '{status:"launching",watch_id:$watch,action:"pending"}'; return
+      fi
+      atomic_update 'if .watch_id==$watch and .launch_attempt_id==$attempt and .legacy_generation==true and
+          .status=="launching" then .status="watching"|.supervisor_pid=$pid|.updated_at=(now|floor)
+          else error("legacy launch attempt changed") end' --arg watch "$WATCH_ID" --arg attempt "$attempt_id" \
+        --argjson pid "$pid"; status=watching
+    elif supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then
       if [[ "$now" -le "$setup_deadline" ]]; then
         jq -cn --arg watch "$WATCH_ID" '{status:"launching",watch_id:$watch,action:"pending"}'; return
       fi
@@ -405,7 +420,7 @@ consume() {
     elif [[ -z "$pid" && "$now" -le "$setup_deadline" ]]; then
       jq -cn --arg watch "$WATCH_ID" '{status:"launching",watch_id:$watch,action:"pending"}'; return
     else
-      launch_failure "launching supervisor died or missed its setup deadline; see $log" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" "$recorded_pid"
+      launch_failure "launching supervisor died or missed its setup deadline; see $log" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" "$recorded_pid" "$legacy"
       consume_report; return
     fi
   fi
@@ -486,6 +501,7 @@ event() {
   if [[ "$legacy" == true && "$status" == watching && ! -s "$artifact" && "$now" -le "$deadline" ]] &&
       legacy_supervisor_live "$pid"; then exit 1; fi
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
+    if [[ "$legacy" == true ]] && legacy_supervisor_live "$pid"; then [[ "$now" -le "$setup_deadline" ]] && exit 1; printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
     if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then [[ "$now" -le "$setup_deadline" ]] && exit 1; printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
     [[ -z "$pid" && "$now" -le "$setup_deadline" ]] && exit 1
   fi

--- a/.agents/skills/orch/scripts/merge-queue-watch
+++ b/.agents/skills/orch/scripts/merge-queue-watch
@@ -48,6 +48,7 @@ resolve_state() {
 }
 state_value() { jq -r "$1" "$STATE_FILE"; }
 require_state() { [[ -f "$STATE_FILE" && ! -L "$STATE_FILE" ]] || die "no durable merge watch for $ISSUE"; }
+state_snapshot() { (flock -s -w 10 9 || exit 1; cat < "$STATE_FILE") 9>"$STATE_FILE.lock"; }
 atomic_update() {
   local filter="$1"; shift
   local tmp="$STATE_DIR/.${ISSUE}.state.$$"
@@ -58,11 +59,13 @@ atomic_update() {
   ) 9>"$STATE_FILE.lock"
 }
 fail_state() {
-  local cause="$1" detail="$2"
-  atomic_update 'if .watch_id != $watch then error("watch id changed") else
+  local cause="$1" detail="$2" attempt_id="${3:-}" artifact="${4:-}"
+  atomic_update 'if .watch_id != $watch or ($attempt!="" and
+      (.launch_attempt_id!=$attempt or .artifact_path!=$artifact)) then error("watch or launch attempt changed") else
       .status="failed" | .action="failed" | .terminal=true |
       .diagnostic={cause:$cause, detail:$detail} | .updated_at=(now|floor) end' \
-    --arg watch "$WATCH_ID" --arg cause "$cause" --arg detail "$detail"
+    --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg artifact "$artifact" \
+    --arg cause "$cause" --arg detail "$detail"
 }
 parse_root_issue() {
   while [[ $# -gt 0 ]]; do
@@ -77,25 +80,23 @@ parse_root_issue() {
   resolve_state; require_state
 }
 supervisor_pid() {
-  local pid
-  pid=$(jq -r '.supervisor_pid // empty' "$STATE_FILE")
+  local runtime="$1" pid="${2:-}"
   if [[ -z "$pid" ]]; then
-    local pid_file
-    pid_file=$(state_value '.runtime_dir + "/supervisor.pid"')
+    local pid_file="$runtime/supervisor.pid"
     [[ -f "$pid_file" ]] && pid=$(cat < "$pid_file")
   fi
   printf '%s' "$pid"
 }
 supervisor_live() {
-  local pid="$1" command
+  local pid="$1" attempt_id="$2" command
   [[ "$pid" =~ ^[1-9][0-9]*$ ]] || return 1
   kill -0 "$pid" 2>/dev/null || return 1
   command=$(ps -p "$pid" -o command= 2>/dev/null) || return 1
-  [[ "$command" == *"merge-queue-watch __supervise"* && "$command" == *"$WATCH_ID"* ]]
+  [[ "$command" == *"merge-queue-watch __supervise"* && "$command" == *"$WATCH_ID"* && "$command" == *"$attempt_id"* ]]
 }
 terminate_supervisor() {
-  local pid="$1" i
-  supervisor_live "$pid" || return 0
+  local pid="$1" attempt_id="$2" i
+  supervisor_live "$pid" "$attempt_id" || return 0
   kill -TERM "$pid" 2>/dev/null || true
   for ((i=0; i<50; i++)); do kill -0 "$pid" 2>/dev/null || return 0; sleep 0.1; done
   kill -KILL "$pid" 2>/dev/null || true
@@ -103,12 +104,13 @@ terminate_supervisor() {
   return 1
 }
 launch_failure() {
-  local detail="$1" pid
-  pid=$(supervisor_pid); [[ -z "$pid" ]] || terminate_supervisor "$pid" || true
-  atomic_update 'if .watch_id!=$watch or (.status|IN("prepared","launching")|not) then error("launch claim lost") else
+  local detail="$1" attempt_id="$2" runtime="$3" pid="${4:-}"
+  pid=$(supervisor_pid "$runtime" "$pid"); [[ -z "$pid" ]] || terminate_supervisor "$pid" "$attempt_id" || true
+  atomic_update 'if .watch_id!=$watch or .launch_attempt_id!=$attempt or .runtime_dir!=$runtime or
+      (.status|IN("launching","watching")|not) then error("launch claim lost") else
       .status="launch_failed"|.action="launch"|.terminal=false|.supervisor_pid=null|
       .diagnostic={cause:"launch_failed",detail:$detail}|.updated_at=(now|floor) end' \
-    --arg watch "$WATCH_ID" --arg detail "$detail" \
+    --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg detail "$detail" \
     || die "could not claim launch recovery; inspect the active lifecycle before handback"
 }
 live_pr() {
@@ -138,24 +140,27 @@ prepare() {
   [[ "$gate" =~ ^(approval|review|off)$ && "$recovery" =~ ^[0-9]+$ ]] || die "prepare gate mode or recovery count is malformed"
   [[ "$cleanup" == true || "$cleanup" == false ]] || die "prepare cleanup flag is malformed"
   resolve_state
-  local now watch_dir artifact log runtime new_state old_status="" pointer worktree_branch
+  local now watch_dir artifact log runtime_root runtime attempt_id new_state old_status="" pointer worktree_branch
   now=$(date +%s); WATCH_ID="$now-$$-$RANDOM$RANDOM"
   worktree_branch=$(git -C "$worktree" branch --show-current 2>/dev/null) || die "cannot read prepared worktree branch"
   watch_dir="$STATE_DIR/runs/$ISSUE-$WATCH_ID"
   mkdir -- "$watch_dir" || die "cannot reserve watch directory"
   chmod 700 "$watch_dir"
-  artifact="$watch_dir/verdict.json"; log="$watch_dir/watch.log"; runtime="$watch_dir/runtime"
-  mkdir -- "$runtime" && chmod 700 "$runtime"
-  printf '%s\n' "$WATCH_ID" > "$runtime/token" && chmod 600 "$runtime/token"
+  attempt_id="$WATCH_ID-attempt-1"; artifact="$watch_dir/verdict-$attempt_id.json"; log="$watch_dir/watch.log"
+  runtime_root="$watch_dir/runtime"; runtime="$runtime_root/$attempt_id"
+  mkdir -- "$runtime_root" "$runtime" && chmod 700 "$runtime_root" "$runtime"
+  printf '%s\n' "$attempt_id" > "$runtime/token" && chmod 600 "$runtime/token"
   new_state="$watch_dir/prepared.json"
   jq -n --arg issue "$ISSUE" --arg repo "$repo" --argjson pr "$pr" --arg head "$head" \
     --arg watch "$WATCH_ID" --arg gate "$gate" --argjson recovery "$recovery" \
     --arg root "$ROOT" --arg worktree "$(cd "$worktree" && pwd -P)" --arg worktree_branch "$worktree_branch" \
-    --arg artifact "$artifact" --arg log "$log" --arg runtime "$runtime" --argjson now "$now" --argjson cleanup "$cleanup" \
+    --arg watch_dir "$watch_dir" --arg artifact "$artifact" --arg log "$log" --arg runtime_root "$runtime_root" --arg runtime "$runtime" \
+    --argjson now "$now" --argjson cleanup "$cleanup" \
     '{schema_version:1,issue_id:$issue,repository:$repo,pr_number:$pr,head_sha:$head,
       watch_id:$watch,gate_mode:$gate,recovery_count:$recovery,main_repo_root:$root,
-      worktree:$worktree,worktree_branch:$worktree_branch,artifact_path:$artifact,log_path:$log,runtime_dir:$runtime,
-      prepared_at:$now,launch_attempt:0,status:"prepared",action:null,terminal:false,
+      worktree:$worktree,worktree_branch:$worktree_branch,watch_dir:$watch_dir,artifact_path:$artifact,log_path:$log,
+      runtime_root:$runtime_root,runtime_dir:$runtime,prepared_at:$now,launch_attempt:0,launch_attempt_id:null,
+      status:"prepared",action:null,terminal:false,
       supervisor_pid:null,launched_at:null,deadline:null,lane_postmerge:null,
       cleanup:{required:$cleanup,status:"not_started",diagnostic:null},diagnostic:null}' > "$new_state"
   (
@@ -182,7 +187,8 @@ prepare() {
 }
 
 launch() {
-  local poll=30 max_wait=2400 method pid deadline now ready log runtime waiter artifact retry_artifact attempt
+  local poll=30 max_wait=2400 method pid deadline now ready log runtime waiter artifact attempt attempt_id
+  local snapshot status prior_attempt head runtime_root watch_dir created=false
   while [[ $# -gt 0 ]]; do
     case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;;
       --watch-id) WATCH_ID="${2:-}"; shift 2 ;; --poll) poll="${2:-}"; shift 2 ;;
@@ -190,27 +196,50 @@ launch() {
   done
   resolve_state; require_state
   [[ "$poll" =~ ^[1-9][0-9]*$ && "$max_wait" =~ ^[1-9][0-9]*$ && "$poll" -le "$max_wait" ]] || die "invalid wait bounds"
-  now=$(date +%s); deadline=$((now + max_wait + 90)); runtime=$(state_value .runtime_dir); log=$(state_value .log_path)
-  artifact=$(state_value .artifact_path); attempt=$(state_value '(.launch_attempt // 0) + 1')
-  retry_artifact="${artifact%/*}/verdict-$attempt.json"
+  snapshot=$(state_snapshot) || die "cannot snapshot prepared lifecycle"
+  status=$(jq -r .status <<<"$snapshot"); prior_attempt=$(jq -r '.launch_attempt // 0' <<<"$snapshot")
+  [[ "$prior_attempt" =~ ^[0-9]+$ && ( "$status" == prepared || "$status" == launch_failed ) ]] || die "prepared claim lost"
+  attempt=$((prior_attempt+1)); attempt_id="$WATCH_ID-attempt-$attempt"; head=$(jq -r .head_sha <<<"$snapshot")
+  now=$(date +%s); deadline=$((now + max_wait + 90)); log=$(jq -r .log_path <<<"$snapshot")
   waiter="$SCRIPT_DIR/queue-wait"
   if [[ ! -x "$waiter" ]]; then
-    launch_failure "queue-wait is missing: $waiter; diagnostics: $log"
+    atomic_update 'if .watch_id!=$watch or .status!=$status or (.launch_attempt // 0)!=$prior then error("prepared claim lost") else
+        .status="launch_failed"|.action="launch"|.terminal=false|.supervisor_pid=null|
+        .diagnostic={cause:"launch_failed",detail:$detail}|.updated_at=(now|floor) end' \
+      --arg watch "$WATCH_ID" --arg status "$status" --argjson prior "$prior_attempt" \
+      --arg detail "queue-wait is missing: $waiter; diagnostics: $log" \
+      || die "could not claim launch recovery; inspect the active lifecycle before handback"
     die "queue-wait is missing: $waiter; diagnostics: $log"
   fi
-  if command -v setsid >/dev/null 2>&1; then method="setsid"; else method="nohup"; fi
-  atomic_update 'if .watch_id!=$watch or .head_sha!=$head or (.status|IN("prepared","launch_failed")|not) then error("prepared claim lost") else
-      .artifact_path=(if .status=="launch_failed" then $retry_artifact else .artifact_path end)|
-      .launch_attempt=$attempt|.status="launching"|.action=null|.diagnostic=null|.launch_method=$method|.launched_at=$now|
-      .setup_deadline=($now+10)|.deadline=$deadline|.updated_at=$now end' \
-    --arg watch "$WATCH_ID" --arg head "$(state_value .head_sha)" --arg method "$method" --arg retry_artifact "$retry_artifact" \
-    --argjson attempt "$attempt" --argjson now "$now" --argjson deadline "$deadline" \
-    || die "prepared lifecycle was terminalized before launch"
-  if [[ "$method" == setsid ]]; then
-    setsid -f "$SELF" __supervise "$STATE_FILE" "$WATCH_ID" "$waiter" "$poll" "$max_wait" >> "$log" 2>&1 \
-      || { launch_failure "setsid could not launch supervisor; see $log"; die "detached supervisor launch failed; see $log"; }
+  runtime_root=$(jq -r .runtime_root <<<"$snapshot"); watch_dir=$(jq -r .watch_dir <<<"$snapshot")
+  if [[ "$prior_attempt" -eq 0 ]]; then
+    runtime=$(jq -r .runtime_dir <<<"$snapshot"); artifact=$(jq -r .artifact_path <<<"$snapshot")
+    [[ -d "$runtime" && ! -L "$runtime" && -f "$runtime/token" && "$(cat < "$runtime/token")" == "$attempt_id" ]] \
+      || die "prepared attempt runtime is invalid: $runtime"
   else
-    nohup "$SELF" __supervise "$STATE_FILE" "$WATCH_ID" "$waiter" "$poll" "$max_wait" </dev/null >> "$log" 2>&1 &
+    runtime="$runtime_root/$attempt_id"; artifact="$watch_dir/verdict-$attempt_id.json"
+    mkdir -- "$runtime" || die "cannot reserve launch attempt runtime: $runtime"
+    created=true; chmod 700 "$runtime"
+    printf '%s\n' "$attempt_id" > "$runtime/token" && chmod 600 "$runtime/token" \
+      || { rm -f -- "$runtime/token"; rmdir -- "$runtime" 2>/dev/null || true; die "cannot bind launch attempt runtime: $runtime"; }
+  fi
+  if command -v setsid >/dev/null 2>&1; then method="setsid"; else method="nohup"; fi
+  if ! atomic_update 'if .watch_id!=$watch or .head_sha!=$head or .status!=$status or (.launch_attempt // 0)!=$prior
+      then error("prepared claim lost") else .artifact_path=$artifact|.runtime_dir=$runtime|
+      .launch_attempt=$attempt|.launch_attempt_id=$attempt_id|.status="launching"|.action=null|.diagnostic=null|
+      .supervisor_pid=null|.launch_method=$method|.launched_at=$now|
+      .setup_deadline=($now+10)|.deadline=$deadline|.updated_at=$now end' \
+    --arg watch "$WATCH_ID" --arg head "$head" --arg status "$status" --argjson prior "$prior_attempt" \
+    --arg runtime "$runtime" --arg artifact "$artifact" --arg attempt_id "$attempt_id" --arg method "$method" \
+    --argjson attempt "$attempt" --argjson now "$now" --argjson deadline "$deadline"; then
+    $created && { rm -f -- "$runtime/token"; rmdir -- "$runtime" 2>/dev/null || true; }
+    die "prepared lifecycle was terminalized before launch"
+  fi
+  if [[ "$method" == setsid ]]; then
+    setsid -f "$SELF" __supervise "$STATE_FILE" "$WATCH_ID" "$attempt_id" "$runtime" "$artifact" "$deadline" "$waiter" "$poll" "$max_wait" >> "$log" 2>&1 \
+      || { launch_failure "setsid could not launch supervisor; see $log" "$attempt_id" "$runtime"; die "detached supervisor launch failed; see $log"; }
+  else
+    nohup "$SELF" __supervise "$STATE_FILE" "$WATCH_ID" "$attempt_id" "$runtime" "$artifact" "$deadline" "$waiter" "$poll" "$max_wait" </dev/null >> "$log" 2>&1 &
   fi
   ready="$runtime/ready"
   for ((i=0; i<100; i++)); do
@@ -218,130 +247,148 @@ launch() {
     sleep 0.05
   done
   if [[ ! -f "$ready" ]]; then
-    launch_failure "supervisor did not establish worker liveness; see $log"
+    launch_failure "supervisor did not establish worker liveness; see $log" "$attempt_id" "$runtime"
     tail -20 "$log" >&2 || true
     die "supervisor setup failed; diagnostics: $log"
   fi
   pid=$(cat < "$runtime/supervisor.pid")
-  [[ "$pid" =~ ^[1-9][0-9]*$ ]] || { launch_failure "supervisor pid is malformed"; die "supervisor pid is malformed"; }
-  if ! atomic_update 'if .watch_id!=$watch or .status!="launching" then error("launch claim lost") else
-      .status="watching"|.supervisor_pid=$pid|.updated_at=(now|floor) end' --arg watch "$WATCH_ID" --argjson pid "$pid"; then
-    terminate_supervisor "$pid" || true
+  [[ "$pid" =~ ^[1-9][0-9]*$ ]] || { launch_failure "supervisor pid is malformed" "$attempt_id" "$runtime"; die "supervisor pid is malformed"; }
+  if ! atomic_update 'if .watch_id!=$watch or .launch_attempt_id!=$attempt or .runtime_dir!=$runtime or
+      .artifact_path!=$artifact or .status!="launching" then error("launch claim lost") else
+      .status="watching"|.supervisor_pid=$pid|.updated_at=(now|floor) end' \
+      --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" --argjson pid "$pid"; then
+    terminate_supervisor "$pid" "$attempt_id" || true
     die "lifecycle was terminalized during launch"
   fi
   json_report
 }
 
 claim() {
-  local action="$1" verdict="$2" cause="$3" diagnostic_file="${4:-/dev/null}" max recovery status
-  max=$("$SCRIPT_DIR/orch-env" CI_FIX_MAX_CYCLES 6); recovery=$(state_value .recovery_count)
+  local action="$1" verdict="$2" cause="$3" diagnostic_file="$4" attempt_id="$5" artifact="$6" expected_head="$7" recovery="$8"
+  local max status
+  max=$("$SCRIPT_DIR/orch-env" CI_FIX_MAX_CYCLES 6)
   status=claimed
   case "$action" in
     recovery)
       if (( recovery >= max )); then
-        atomic_update 'if .watch_id!=$watch or (.status|IN("watching","launching")|not) then error("verdict already claimed") else
+        atomic_update 'if .watch_id!=$watch or .launch_attempt_id!=$attempt or .artifact_path!=$artifact or
+            (.status|IN("watching","launching")|not) then error("verdict already claimed") else
           .status="failed"|.action="failed"|.verdict=$verdict|.verdict_cause="recovery_cap"|.terminal=true|
           .diagnostic=($diagnostic[0]+{recovery_cap:$max})|.updated_at=(now|floor) end' \
-          --arg watch "$WATCH_ID" --arg verdict "$verdict" --argjson max "$max" --slurpfile diagnostic "$diagnostic_file"
+          --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg artifact "$artifact" \
+          --arg verdict "$verdict" --argjson max "$max" --slurpfile diagnostic "$diagnostic_file"
         json_report; return
       fi
       recovery=$((recovery+1)) ;;
     failed) status=failed ;; abandoned) status=abandoned ;;
   esac
-  atomic_update 'if .watch_id!=$watch or .head_sha!=$head or (.status|IN("watching","launching")|not) then error("verdict already claimed") else
+  atomic_update 'if .watch_id!=$watch or .head_sha!=$head or .launch_attempt_id!=$attempt or .artifact_path!=$artifact or
+      (.status|IN("watching","launching")|not) then error("verdict already claimed") else
       .status=$status|.action=$action|.verdict=$verdict|.verdict_cause=$cause|
       .diagnostic=(if $diagnostic[0]==null then null else $diagnostic[0] end)|
       .recovery_count=$recovery|.terminal=($status|IN("failed","abandoned"))|.updated_at=(now|floor) end' \
-    --arg watch "$WATCH_ID" --arg head "$(state_value .head_sha)" --arg status "$status" --arg action "$action" \
+    --arg watch "$WATCH_ID" --arg head "$expected_head" --arg attempt "$attempt_id" --arg artifact "$artifact" \
+    --arg status "$status" --arg action "$action" \
     --arg verdict "$verdict" --arg cause "$cause" --argjson recovery "$recovery" --slurpfile diagnostic "$diagnostic_file"
   json_report
 }
 
 consume() {
   parse_root_issue "$@"
-  WATCH_ID=$(state_value .watch_id)
-  local status artifact pid deadline now token body live live_state observed expected verdict result cause action diag error_text exit_code diag_path unconfirmed
-  status=$(state_value .status)
+  local snapshot status artifact runtime attempt_id pid recorded_pid deadline setup_deadline now token body live live_state
+  local observed expected repo pr verdict result cause action diag error_text exit_code diag_path unconfirmed recovery log
+  snapshot=$(state_snapshot) || die "cannot snapshot active launch attempt"
+  WATCH_ID=$(jq -r .watch_id <<<"$snapshot"); status=$(jq -r .status <<<"$snapshot")
   case "$status" in claimed|launch_failed|failed|abandoned|awaiting_lane_postmerge|cleanup_pending|cleanup_complete|complete) consume_report; return ;; esac
-  artifact=$(state_value .artifact_path); now=$(date +%s); deadline=$(state_value '.deadline // 0')
+  artifact=$(jq -r .artifact_path <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
+  attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot")
+  deadline=$(jq -r '.deadline // 0' <<<"$snapshot"); setup_deadline=$(jq -r '.setup_deadline // 0' <<<"$snapshot")
+  expected=$(jq -r .head_sha <<<"$snapshot"); repo=$(jq -r .repository <<<"$snapshot"); pr=$(jq -r .pr_number <<<"$snapshot")
+  recovery=$(jq -r .recovery_count <<<"$snapshot"); log=$(jq -r .log_path <<<"$snapshot"); now=$(date +%s)
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
-    pid=$(supervisor_pid)
-    if supervisor_live "$pid"; then
-      if [[ "$now" -le "$(state_value '.setup_deadline // 0')" ]]; then
+    pid=$(supervisor_pid "$runtime" "$recorded_pid")
+    if supervisor_live "$pid" "$attempt_id"; then
+      if [[ "$now" -le "$setup_deadline" ]]; then
         jq -cn --arg watch "$WATCH_ID" '{status:"launching",watch_id:$watch,action:"pending"}'; return
       fi
-      atomic_update 'if .watch_id==$watch and .status=="launching" then .status="watching"|.supervisor_pid=$pid|.updated_at=(now|floor) else . end' \
-        --arg watch "$WATCH_ID" --argjson pid "$pid"; status=watching
-    elif [[ -z "$pid" && "$now" -le "$(state_value '.setup_deadline // 0')" ]]; then
+      atomic_update 'if .watch_id==$watch and .launch_attempt_id==$attempt and .runtime_dir==$runtime and
+          .artifact_path==$artifact and .status=="launching" then .status="watching"|.supervisor_pid=$pid|.updated_at=(now|floor)
+          else error("launch attempt changed") end' --arg watch "$WATCH_ID" --arg attempt "$attempt_id" \
+        --arg runtime "$runtime" --arg artifact "$artifact" --argjson pid "$pid"; status=watching
+    elif [[ -z "$pid" && "$now" -le "$setup_deadline" ]]; then
       jq -cn --arg watch "$WATCH_ID" '{status:"launching",watch_id:$watch,action:"pending"}'; return
     else
-      launch_failure "launching supervisor died or missed its setup deadline; see $(state_value .log_path)"
+      launch_failure "launching supervisor died or missed its setup deadline; see $log" "$attempt_id" "$runtime" "$recorded_pid"
       consume_report; return
     fi
   fi
   if [[ ! -s "$artifact" ]]; then
-    pid=$(supervisor_pid); token=$(state_value '.runtime_dir + "/token"')
-    if [[ -f "$token" && "$(cat < "$token")" == "$WATCH_ID" && "$now" -le "$deadline" ]] && supervisor_live "$pid"; then
+    pid=$(supervisor_pid "$runtime" "$recorded_pid"); token="$runtime/token"
+    if [[ -f "$token" && "$(cat < "$token")" == "$attempt_id" && "$now" -le "$deadline" ]] && supervisor_live "$pid" "$attempt_id"; then
       jq -cn --arg status pending --arg watch "$WATCH_ID" '{status:$status,watch_id:$watch,action:"pending"}'
       return
     fi
-    terminate_supervisor "$pid" || true
-    fail_state watch_lost "artifact missing and supervisor dead or overdue; see $(state_value .log_path)"
+    terminate_supervisor "$pid" "$attempt_id" || true
+    fail_state watch_lost "artifact missing and supervisor dead or overdue; see $log" "$attempt_id" "$artifact"
     json_report; return
   fi
-  if ! jq -e --arg watch "$WATCH_ID" --arg repo "$(state_value .repository)" --arg head "$(state_value .head_sha)" --argjson pr "$(state_value .pr_number)" '
-      type=="object" and .schema_version==1 and .watch_id==$watch and .repository==$repo and
+  if ! jq -e --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg repo "$repo" --arg head "$expected" --argjson pr "$pr" '
+      type=="object" and .schema_version==1 and .watch_id==$watch and .launch_attempt_id==$attempt and .repository==$repo and
       .pr_number==$pr and .expected_head==$head and (.observed_head|type=="string") and
       (.status|IN("complete","timeout","error")) and (.verdict|IN("merged","conflicting","ejected","disarmed","dequeued","closed","queued","not_queued","unknown"))' "$artifact" >/dev/null; then
-    fail_state malformed_artifact "verdict artifact is malformed or belongs to another watch"
+    fail_state malformed_artifact "verdict artifact is malformed or belongs to another launch attempt" "$attempt_id" "$artifact"
     json_report; return
   fi
   result=$(jq -r .status "$artifact"); verdict=$(jq -r .verdict "$artifact"); cause=$(jq -r '.cause // ""' "$artifact")
   error_text=$(jq -r '.error // ""' "$artifact"); exit_code=$(jq -r '.worker_exit_code // empty' "$artifact"); diag_path=$(jq -r '.diagnostic_path // ""' "$artifact")
   unconfirmed=$(jq -r '.unconfirmed_verdict // ""' "$artifact")
-  diag="$(state_value .runtime_dir)/consume-diagnostic.$$"
+  diag="$runtime/consume-diagnostic.$$"
   (umask 077; set -C; : > "$diag") || die "cannot create diagnostic binding"
   body=$(live_pr) || body='{"headRefOid":"","state":"UNKNOWN"}'
   live=$(jq -r '.headRefOid // ""' <<<"$body"); live_state=$(jq -r '.state // ""' <<<"$body")
-  observed=$(jq -r .observed_head "$artifact"); expected=$(state_value .head_sha)
+  observed=$(jq -r .observed_head "$artifact")
   jq -n --arg cause "${cause:-$verdict}" --arg error "$error_text" --arg exit "$exit_code" --arg path "$diag_path" --arg unconfirmed "$unconfirmed" \
     --arg expected "$expected" --arg observed "$observed" --arg live "$live" --arg state "$live_state" \
     '{cause:$cause,error:(if $error=="" then null else $error end),unconfirmed_verdict:(if $unconfirmed=="" then null else $unconfirmed end),worker_exit_code:(if $exit=="" then null else ($exit|tonumber) end),
       diagnostic_path:$path,head_verification:{expected:$expected,artifact_observed:$observed,live:$live,live_state:$state}}' > "$diag"
-  if [[ -z "$live" ]]; then claim failed "$verdict" live_pr_unreadable "$diag"; rm -f -- "$diag"; return; fi
+  if [[ -z "$live" ]]; then claim failed "$verdict" live_pr_unreadable "$diag" "$attempt_id" "$artifact" "$expected" "$recovery"; rm -f -- "$diag"; return; fi
   if [[ "$live" != "$expected" || ( -n "$observed" && "$observed" != "$expected" ) ]]; then
-    claim failed "$verdict" head_mismatch "$diag"; rm -f -- "$diag"; return
+    claim failed "$verdict" head_mismatch "$diag" "$attempt_id" "$artifact" "$expected" "$recovery"; rm -f -- "$diag"; return
   fi
-  if [[ "$live_state" == MERGED ]]; then claim postmerge merged merged_race "$diag"; rm -f -- "$diag"; return; fi
+  if [[ "$live_state" == MERGED ]]; then claim postmerge merged merged_race "$diag" "$attempt_id" "$artifact" "$expected" "$recovery"; rm -f -- "$diag"; return; fi
   if [[ "$result" == error && "$verdict:$cause" == dequeued:late_findings_dequeue_failed ]]; then
-    claim manual_dequeue "$verdict" "$cause" "$diag"; rm -f -- "$diag"; return
+    claim manual_dequeue "$verdict" "$cause" "$diag" "$attempt_id" "$artifact" "$expected" "$recovery"; rm -f -- "$diag"; return
   fi
   if [[ "$result" == error || "$verdict" == unknown ]]; then
-    claim failed "$verdict" "${cause:-watch_error}" "$diag"; rm -f -- "$diag"; return
+    claim failed "$verdict" "${cause:-watch_error}" "$diag" "$attempt_id" "$artifact" "$expected" "$recovery"; rm -f -- "$diag"; return
   fi
   case "$verdict:$live_state" in merged:MERGED|closed:CLOSED|unknown:*|conflicting:OPEN|ejected:OPEN|disarmed:OPEN|dequeued:OPEN|queued:OPEN|not_queued:OPEN) ;; *)
-    claim failed "$verdict" live_state_mismatch "$diag"; rm -f -- "$diag"; return ;; esac
+    claim failed "$verdict" live_state_mismatch "$diag" "$attempt_id" "$artifact" "$expected" "$recovery"; rm -f -- "$diag"; return ;; esac
   case "$verdict:$cause" in
     merged:*) action=postmerge ;; conflicting:*) action=restack ;; ejected:*|disarmed:*|queued:stalled) action=recovery ;;
     dequeued:*) action=triage ;; queued:still_progressing) action=rewatch ;;
     not_queued:*) action=rearm ;; closed:*) action=abandoned ;; *) action=failed ;;
   esac
-  claim "$action" "$verdict" "$cause" "$diag"; rm -f -- "$diag"
+  claim "$action" "$verdict" "$cause" "$diag" "$attempt_id" "$artifact" "$expected" "$recovery"; rm -f -- "$diag"
 }
 
 event() {
   while [[ $# -gt 0 ]]; do case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;; *) die "unknown event option: $1" ;; esac; done
   [[ -n "$ROOT" && -n "$ISSUE" ]] || die "--root and --issue are required"
-  resolve_state; [[ -f "$STATE_FILE" ]] || exit 1; WATCH_ID=$(state_value .watch_id)
-  local status artifact pid deadline now
-  status=$(state_value .status); [[ "$status" == watching || "$status" == launching || "$status" == launch_failed ]] || exit 1
+  resolve_state; [[ -f "$STATE_FILE" ]] || exit 1
+  local snapshot status artifact runtime attempt_id recorded_pid pid deadline setup_deadline now
+  snapshot=$(state_snapshot) || exit 1; WATCH_ID=$(jq -r .watch_id <<<"$snapshot")
+  status=$(jq -r .status <<<"$snapshot"); [[ "$status" == watching || "$status" == launching || "$status" == launch_failed ]] || exit 1
   [[ "$status" == launch_failed ]] && { printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; }
-  artifact=$(state_value .artifact_path); deadline=$(state_value '.deadline // 0'); now=$(date +%s); pid=$(supervisor_pid)
+  artifact=$(jq -r .artifact_path <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
+  attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot")
+  deadline=$(jq -r '.deadline // 0' <<<"$snapshot"); setup_deadline=$(jq -r '.setup_deadline // 0' <<<"$snapshot")
+  now=$(date +%s); pid=$(supervisor_pid "$runtime" "$recorded_pid")
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
-    if supervisor_live "$pid"; then [[ "$now" -le "$(state_value '.setup_deadline // 0')" ]] && exit 1; printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
-    [[ -z "$pid" && "$now" -le "$(state_value '.setup_deadline // 0')" ]] && exit 1
+    if supervisor_live "$pid" "$attempt_id"; then [[ "$now" -le "$setup_deadline" ]] && exit 1; printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
+    [[ -z "$pid" && "$now" -le "$setup_deadline" ]] && exit 1
   fi
-  if [[ -s "$artifact" ]] || [[ "$now" -gt "$deadline" ]] || ! supervisor_live "$pid"; then printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
+  if [[ -s "$artifact" ]] || [[ "$now" -gt "$deadline" ]] || ! supervisor_live "$pid" "$attempt_id"; then printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
   exit 1
 }
 
@@ -384,12 +431,15 @@ acknowledge() {
 }
 
 fail_command() {
-  local cause="" pid=""
+  local cause="" snapshot attempt_id runtime recorded_pid pid
   while [[ $# -gt 0 ]]; do case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;;
     --watch-id) WATCH_ID="${2:-}"; shift 2 ;; --cause) cause="${2:-}"; shift 2 ;; *) die "unknown fail option: $1" ;; esac; done
   resolve_state; require_state; [[ "$cause" =~ ^(arm_failed|merge_blocked|launch_failed|operator_abandoned)$ ]] || die "invalid failure cause"
-  WATCH_ID="${WATCH_ID:-$(state_value .watch_id)}"; pid=$(supervisor_pid)
-  fail_state "$cause" "$cause"; terminate_supervisor "$pid" || true; json_report
+  snapshot=$(state_snapshot) || die "cannot snapshot active launch attempt"
+  WATCH_ID="${WATCH_ID:-$(jq -r .watch_id <<<"$snapshot")}"
+  attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
+  recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot"); pid=$(supervisor_pid "$runtime" "$recorded_pid")
+  fail_state "$cause" "$cause"; terminate_supervisor "$pid" "$attempt_id" || true; json_report
 }
 
 inspect() { parse_root_issue "$@"; cat < "$STATE_FILE"; }

--- a/.agents/skills/orch/tests/merge_queue_watch.sh
+++ b/.agents/skills/orch/tests/merge_queue_watch.sh
@@ -13,6 +13,7 @@ eq() { if [[ "$1" == "$2" ]]; then ok "$3"; else bad "$3 (expected $2, got $1)";
 wait_file() { local i; for ((i=0;i<100;i++)); do [[ -s "$1" ]] && return 0; sleep 0.05; done; return 1; }
 wait_exists() { local i; for ((i=0;i<100;i++)); do [[ -e "$1" ]] && return 0; sleep 0.05; done; return 1; }
 wait_state() { local i; for ((i=0;i<200;i++)); do [[ "$(jq -r .status "$1")" == "$2" ]] && return 0; sleep 0.05; done; return 1; }
+running() { local state; state=$(ps -p "$1" -o stat= 2>/dev/null) || return 1; state="${state//[[:space:]]/}"; [[ -n "$state" && "$state" != Z* ]]; }
 inode() { stat -c %i "$1" 2>/dev/null || stat -f %i "$1"; }
 
 MAIN="$TMP/main" WT="$TMP/worktree" BIN="$TMP/bin" SCRIPTS="$TMP/orch/scripts"
@@ -143,6 +144,7 @@ chmod +x "$BIN/flock"
 cat > "$BIN/ps" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+if [[ -n "${WATCH_PS_ZOMBIE_PID:-}" && "$*" == "-p $WATCH_PS_ZOMBIE_PID -o stat=" ]]; then printf 'Z\n'; exit 0; fi
 if [[ "${MERGE_QUEUE_FORCE_PS_IDENTITY:-0}" == 1 ]]; then printf '%s\n' "$*" >> "$WATCH_PS_LOG"; fi
 if [[ -f "$WATCH_SUPERVISOR_PID_GATE.enabled" ]]; then
   calls=0; [[ ! -f "$WATCH_SUPERVISOR_PID_GATE.calls" ]] || calls=$(cat < "$WATCH_SUPERVISOR_PID_GATE.calls")
@@ -183,8 +185,8 @@ launch_bounded() {
   local watch="$1" out="$TMP/launch.out" err="$TMP/launch.err" pid i rc=0
   "$SCRIPTS/merge-queue-watch" launch --root "$MAIN" --issue KEN-829 --watch-id "$watch" --poll 1 --max-wait 10 >"$out" 2>"$err" &
   pid=$!
-  for ((i=0;i<100;i++)); do kill -0 "$pid" 2>/dev/null || break; sleep 0.05; done
-  if kill -0 "$pid" 2>/dev/null; then kill -TERM "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true; bad "launch returns before worker release"; return 1; fi
+  for ((i=0;i<100;i++)); do running "$pid" || break; sleep 0.05; done
+  if running "$pid"; then kill -TERM "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true; bad "launch returns before worker release"; return 1; fi
   wait "$pid" || rc=$?
   eq "$rc" 0 "launch returns before worker release"
   [[ "$rc" -eq 0 ]] || sed 's/^/        /' "$err"
@@ -210,7 +212,7 @@ launch_bounded "$watch"
 grep -Fxq "$MAIN|owner/repo|ghp_project" "$WATCH_WORKER_LOG" && ok "detached waiter enters persisted main repo with its project auth and repo scope" || bad "detached waiter lost main repo auth or scope"
 if [[ ! -e "$artifact" ]]; then ok "no verdict exists before worker release"; else bad "partial verdict appeared"; fi
 supervisor=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .supervisor_pid)
-if kill -0 "$supervisor" 2>/dev/null; then ok "supervisor survives the launch command boundary"; else bad "supervisor died at command boundary"; fi
+if running "$supervisor"; then ok "supervisor survives the launch command boundary"; else bad "supervisor died at command boundary"; fi
 touch "$RELEASE"; wait_file "$artifact" || bad "merged verdict was not published"
 eq "$(jq -r .watch_id "$artifact")" "$watch" "artifact binds watch id"
 eq "$(jq -r .expected_head "$artifact")" "$HEAD_A" "artifact binds expected head"
@@ -368,7 +370,7 @@ eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -
 
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
-jq --arg attempt "$watch-attempt-1" '.launch_attempt=1|.launch_attempt_id=$attempt|.status="launching"|.setup_deadline=((now|floor)+10)|.deadline=((now|floor)+600)' "$state_path" > "$TMP/completed-launch.json"
+jq --arg attempt "$watch-attempt-1" --arg token "$watch-attempt-1-test" '.launch_attempt=1|.launch_attempt_id=$attempt|.supervisor_token=$token|.status="launching"|.setup_deadline=((now|floor)+10)|.deadline=((now|floor)+600)' "$state_path" > "$TMP/completed-launch.json"
 chmod 600 "$TMP/completed-launch.json"; mv "$TMP/completed-launch.json" "$state_path"
 jq -n --arg watch "$watch" --arg attempt "$watch-attempt-1" --arg head "$HEAD_A" '{schema_version:1,status:"complete",verdict:"merged",repository:"owner/repo",pr_number:42,expected_head:$head,observed_head:"",watch_id:$watch,launch_attempt_id:$attempt}' > "$artifact"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
@@ -383,7 +385,7 @@ state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_
 jq '.deadline=0' "$state_path" > "$TMP/expired.json"; chmod 600 "$TMP/expired.json"; mv "$TMP/expired.json" "$state_path"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .diagnostic.cause <<<"$result")" watch_lost "overdue live supervisor fails closed"
-if ! kill -0 "$supervisor" 2>/dev/null; then ok "overdue verified supervisor is terminated"; else bad "overdue supervisor survived consume"; fi
+if ! running "$supervisor"; then ok "overdue verified supervisor is terminated"; else bad "overdue supervisor survived consume"; fi
 
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
 launch_bounded "$watch"; supervisor=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .supervisor_pid)
@@ -526,8 +528,8 @@ touch "$WATCH_FAIL_FLOCK_GATE.release"
 set +e; wait "$fail_race_pid"; fail_race_rc=$?; set -e
 [[ "$fail_race_rc" -ne 0 ]] && ok "stale fail refuses after retry registration" || bad "stale fail reported success across retry"
 eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .status)" watching "stale fail leaves replacement state active"
-kill -0 "$replacement_supervisor" 2>/dev/null && ok "stale fail does not signal replacement supervisor" || bad "stale fail signaled replacement supervisor"
-kill -0 "$old_supervisor" 2>/dev/null && ok "stale fail does not confuse captured supervisor identity" || bad "stale fail signaled its captured supervisor after claim loss"
+running "$replacement_supervisor" && ok "stale fail does not signal replacement supervisor" || bad "stale fail signaled replacement supervisor"
+running "$old_supervisor" && ok "stale fail does not confuse captured supervisor identity" || bad "stale fail signaled its captured supervisor after claim loss"
 touch "$RELEASE"; wait_file "$replacement_artifact" || bad "replacement verdict missing after stale fail"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .action <<<"$result")" recovery "replacement verdict survives stale fail"
@@ -542,7 +544,7 @@ bash -c 'while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$s
 jq --argjson pid "$similar_attempt_pid" '.supervisor_pid=$pid' "$state_path" > "$TMP/similar-attempt-state.json"
 chmod 600 "$TMP/similar-attempt-state.json"; mv "$TMP/similar-attempt-state.json" "$state_path"
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
-kill -0 "$similar_attempt_pid" 2>/dev/null && ok "attempt identity compares argv fields exactly" || bad "attempt-1 matched and signaled attempt-10"
+running "$similar_attempt_pid" && ok "attempt identity compares argv fields exactly" || bad "attempt-1 matched and signaled attempt-10"
 kill "$similar_attempt_pid" 2>/dev/null || true; wait "$similar_attempt_pid" 2>/dev/null || true
 touch "$RELEASE"
 
@@ -554,7 +556,7 @@ ps_calls=$(wc -l < "$WATCH_PS_LOG")
 export MERGE_QUEUE_FORCE_PS_IDENTITY=1
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 [[ "$(wc -l < "$WATCH_PS_LOG")" -gt "$ps_calls" ]] && ok "forced whitespace identity check invokes ps" || bad "forced whitespace identity check bypassed ps"
-if ! kill -0 "$fallback_supervisor" 2>/dev/null; then ok "ps environment identity supports repository paths with spaces"; else bad "ps fallback rejected a valid supervisor under a whitespace path"; fi
+if ! running "$fallback_supervisor"; then ok "ps environment identity supports repository paths with spaces"; else bad "ps fallback rejected a valid supervisor under a whitespace path"; fi
 unset MERGE_QUEUE_FORCE_PS_IDENTITY
 touch "$RELEASE"
 
@@ -569,7 +571,7 @@ ps_calls=$(wc -l < "$WATCH_PS_LOG")
 export MERGE_QUEUE_FORCE_PS_IDENTITY=1
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 [[ "$(wc -l < "$WATCH_PS_LOG")" -gt "$ps_calls" ]] && ok "forced similar-generation check invokes ps" || bad "forced similar-generation check bypassed ps"
-kill -0 "$similar_identity_pid" 2>/dev/null && ok "ps environment identity rejects a similar generation" || bad "ps fallback matched a similar generation token"
+running "$similar_identity_pid" && ok "ps environment identity rejects a similar generation" || bad "ps fallback matched a similar generation token"
 unset MERGE_QUEUE_FORCE_PS_IDENTITY
 kill "$similar_identity_pid" 2>/dev/null || true; wait "$similar_identity_pid" 2>/dev/null || true
 touch "$RELEASE"
@@ -587,7 +589,7 @@ export MERGE_QUEUE_FORCE_PS_IDENTITY=1
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 [[ "$(wc -l < "$WATCH_PS_LOG")" -gt "$ps_calls" ]] && ok "forced identity-change check invokes ps" || bad "forced identity-change check bypassed ps"
 wait_exists "$identity_changed" && ok "teardown sent TERM to the captured identity" || bad "teardown never signaled the captured identity"
-kill -0 "$changed_identity_pid" 2>/dev/null && ok "teardown stops when the PID changes identity" || bad "teardown escalated KILL after identity changed"
+running "$changed_identity_pid" && ok "teardown stops when the PID changes identity" || bad "teardown escalated KILL after identity changed"
 unset MERGE_QUEUE_FORCE_PS_IDENTITY
 kill "$changed_identity_pid" 2>/dev/null || true; wait "$changed_identity_pid" 2>/dev/null || true
 touch "$RELEASE"
@@ -601,7 +603,7 @@ jq --argjson pid "$worker_pid" '.supervisor_pid=$pid' "$state_path" > "$TMP/work
 chmod 600 "$TMP/worker-pid-state.json"; mv "$TMP/worker-pid-state.json" "$state_path"
 export MERGE_QUEUE_FORCE_PS_IDENTITY=1
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
-kill -0 "$worker_pid" 2>/dev/null && ok "reused worker PID cannot identify as supervisor" || bad "supervisor teardown signaled queue-wait descendant"
+running "$worker_pid" && ok "reused worker PID cannot identify as supervisor" || bad "supervisor teardown signaled queue-wait descendant"
 unset MERGE_QUEUE_FORCE_PS_IDENTITY
 touch "$RELEASE"
 
@@ -614,7 +616,7 @@ jq --argjson pid "$wrong_command_pid" '.supervisor_pid=$pid' "$state_path" > "$T
 chmod 600 "$TMP/wrong-command-state.json"; mv "$TMP/wrong-command-state.json" "$state_path"
 export MERGE_QUEUE_FORCE_PS_IDENTITY=1
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
-kill -0 "$wrong_command_pid" 2>/dev/null && ok "ps fallback requires supervisor command identity" || bad "ps fallback accepted non-supervisor command"
+running "$wrong_command_pid" && ok "ps fallback requires supervisor command identity" || bad "ps fallback accepted non-supervisor command"
 unset MERGE_QUEUE_FORCE_PS_IDENTITY
 kill "$wrong_command_pid" 2>/dev/null || true; wait "$wrong_command_pid" 2>/dev/null || true
 touch "$RELEASE"
@@ -633,22 +635,42 @@ set +e; wait "$registration_launch_pid"; registration_launch_rc=$?; set -e
 sleep 0.3
 eq "$(wc -l < "$WATCH_WORKER_LOG")" "$worker_count" "supervisor rechecks state after PID publication"
 registration_pid=$(cat < "$registration_runtime/supervisor.pid")
-if ! kill -0 "$registration_pid" 2>/dev/null; then ok "late-registering supervisor exits before deadline"; else bad "late-registering supervisor survived its failed generation"; fi
+if ! running "$registration_pid"; then ok "late-registering supervisor exits before deadline"; else bad "late-registering supervisor survived its failed generation"; fi
 touch "$RELEASE"
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 rm -f -- "$WATCH_REGISTRATION_GATE.enabled" "$WATCH_REGISTRATION_GATE.entered" "$WATCH_REGISTRATION_GATE.release"
 
 prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
-launch_bounded "$watch"
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
-legacy_supervisor=$(jq -r .supervisor_pid "$state_path")
-jq 'del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-watching.json"
+bash -c 'while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$state_path" "$watch" "$SCRIPTS/queue-wait" 1 10 & legacy_supervisor=$!
+jq --argjson pid "$legacy_supervisor" '.status="watching"|.supervisor_pid=$pid|.deadline=((now|floor)+600)|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-watching.json"
 chmod 600 "$TMP/legacy-watching.json"; mv "$TMP/legacy-watching.json" "$state_path"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .action <<<"$result")" pending "legacy watching state remains active"
-kill -0 "$legacy_supervisor" 2>/dev/null && ok "legacy watching supervisor is preserved" || bad "legacy watching supervisor was terminated"
+running "$legacy_supervisor" && ok "legacy watching supervisor is preserved" || bad "legacy watching supervisor was terminated"
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
-touch "$RELEASE"
+if ! running "$legacy_supervisor"; then ok "direct legacy failure terminates tokenless supervisor"; else bad "direct legacy failure left tokenless supervisor running"; fi
+wait "$legacy_supervisor" 2>/dev/null || true
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+bash -c 'while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$state_path" "$watch" "$SCRIPTS/queue-wait" 1 10 & zombie_pid=$!
+export WATCH_PS_ZOMBIE_PID="$zombie_pid"
+jq --argjson pid "$zombie_pid" '.status="watching"|.supervisor_pid=$pid|.deadline=((now|floor)+600)|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-zombie.json"
+chmod 600 "$TMP/legacy-zombie.json"; mv "$TMP/legacy-zombie.json" "$state_path"
+result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
+eq "$(jq -r .status <<<"$result")" failed "production liveness treats zombie state as exited"
+if ! running "$zombie_pid"; then ok "test liveness helper treats zombie state as exited"; else bad "test liveness helper accepted zombie state"; fi
+unset WATCH_PS_ZOMBIE_PID
+kill "$zombie_pid" 2>/dev/null || true; wait "$zombie_pid" 2>/dev/null || true
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+jq '.status="launching"|.setup_deadline=0|.deadline=((now|floor)+600)|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-launching.json"
+chmod 600 "$TMP/legacy-launching.json"; mv "$TMP/legacy-launching.json" "$state_path"
+result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
+eq "$(jq -r .action <<<"$result")" resume_launch "orphaned legacy launch enters recovery"
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 
 prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)

--- a/.agents/skills/orch/tests/merge_queue_watch.sh
+++ b/.agents/skills/orch/tests/merge_queue_watch.sh
@@ -237,7 +237,6 @@ set -e
 if [[ "$early_ack_rc" -ne 0 ]]; then ok "pass acknowledgment refuses before cleanup"; else bad "pass acknowledgment completed before cleanup"; fi
 printf 'first postmerge stopped\n' > "$TMP/first.err"
 "$SCRIPTS/merge-queue-watch" acknowledge --root "$MAIN" --issue KEN-829 --watch-id "$watch" --result fail --diagnostic-file "$TMP/first.err" >/dev/null
-
 prep=$(prepare ejected review 0); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
 launch_bounded "$watch"; touch "$RELEASE"; wait_file "$artifact" || bad "ejected verdict missing"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
@@ -251,12 +250,10 @@ prepare ejected off 0 >/dev/null 2>"$TMP/reset.err"
 reset_rc=$?
 set -e
 if [[ "$reset_rc" -ne 0 ]]; then ok "next generation cannot reset gate mode or recovery count"; else bad "recovery context reset was accepted"; fi
-
 prep=$(prepare ejected review 1); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
 launch_bounded "$watch"; touch "$RELEASE"; wait_file "$artifact" || bad "cap verdict missing"
 result=$(CI_FIX_MAX_CYCLES=1 "$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .status <<<"$result")" failed "recovery cap terminalizes state"
-
 verdict_case disarmed recovery
 verdict_case conflicting restack
 verdict_case dequeued triage
@@ -264,7 +261,6 @@ verdict_case dequeue_failed manual_dequeue
 verdict_case stalled recovery
 verdict_case progressing rewatch
 verdict_case not_queued rearm
-
 prep=$(prepare dequeue_failed); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
 launch_bounded "$watch"; touch "$RELEASE"; wait_file "$artifact" || bad "dequeue-race verdict missing"
 printf 'merged\n' > "$MODE"
@@ -274,7 +270,6 @@ eq "$(jq -r .verdict_cause <<<"$result")" merged_race "merged dequeue race recor
 "$SCRIPTS/merge-queue-watch" merge-pr-complete --root "$MAIN" --issue KEN-829 --watch-id "$watch" >/dev/null
 printf 'race control complete\n' > "$TMP/race.err"
 "$SCRIPTS/merge-queue-watch" acknowledge --root "$MAIN" --issue KEN-829 --watch-id "$watch" --result fail --diagnostic-file "$TMP/race.err" >/dev/null
-
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
 launch_bounded "$watch"; touch "$RELEASE"; wait_file "$artifact" || bad "head-mismatch verdict missing"
 printf '%s\n' "$HEAD_B" > "$HEAD_FILE"
@@ -283,23 +278,19 @@ eq "$(jq -r .status <<<"$result")" failed "live head mismatch blocks merged post
 eq "$(jq -r .verdict_cause <<<"$result")" head_mismatch "head mismatch names the routing cause"
 eq "$(jq -r .diagnostic.cause <<<"$result")" merged "head mismatch preserves the producer verdict"
 printf '%s\n' "$HEAD_A" > "$HEAD_FILE"
-
 prep=$(prepare malformed); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
 launch_bounded "$watch"; touch "$RELEASE"; wait_file "$artifact" || bad "malformed-worker error artifact missing"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .status <<<"$result")" failed "unknown worker output terminalizes failed"
 eq "$(jq -r .worker_exit_code <<<"$result")" 7 "unknown output preserves worker exit"
 if [[ "$(jq -r .diagnostic_path <<<"$result")" == /* ]]; then ok "unknown output preserves absolute producer diagnostics"; else bad "unknown output lost diagnostics"; fi
-
 prep=$(prepare closed); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
 launch_bounded "$watch"; touch "$RELEASE"; wait_file "$artifact" || bad "closed verdict missing"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .status <<<"$result")" abandoned "closed verdict terminalizes abandoned"
-
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .diagnostic.cause <<<"$result")" watch_lost "missing stale artifact fails closed"
-
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause arm_failed >/dev/null
 set +e
@@ -307,7 +298,6 @@ set +e
 revive_rc=$?
 set -e
 if [[ "$revive_rc" -ne 0 ]]; then ok "failed prepared state cannot be revived by launch"; else bad "launch revived failed state"; fi
-
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
 touch "$WATCH_GH_PAUSE.enabled"
 "$SCRIPTS/merge-queue-watch" direct-merged --root "$MAIN" --issue KEN-829 --watch-id "$watch" >"$TMP/direct.out" 2>"$TMP/direct.err" & direct_pid=$!
@@ -317,7 +307,6 @@ touch "$WATCH_GH_PAUSE.release"
 set +e; wait "$direct_pid"; direct_rc=$?; set -e
 if [[ "$direct_rc" -ne 0 ]]; then ok "fail wins against an in-flight direct merge claim"; else bad "direct merge revived failed state"; fi
 rm -f "$WATCH_GH_PAUSE.enabled" "$WATCH_GH_PAUSE.entered" "$WATCH_GH_PAUSE.release"
-
 if [[ -n "$REAL_SETSID" ]]; then
   prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
   touch "$WATCH_SETUP_GATE.enabled"
@@ -329,7 +318,6 @@ if [[ -n "$REAL_SETSID" ]]; then
   eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .status)" watching "launch owns setup through watching transition"
   "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
   rm -f "$WATCH_SETUP_GATE.enabled" "$WATCH_SETUP_GATE.entered" "$WATCH_SETUP_GATE.release"
-
   prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
   touch "$WATCH_SETSID_FAIL"
   set +e; "$SCRIPTS/merge-queue-watch" launch --root "$MAIN" --issue KEN-829 --watch-id "$watch" >/dev/null 2>&1; setsid_rc=$?; set -e
@@ -342,7 +330,14 @@ if [[ -n "$REAL_SETSID" ]]; then
 else
   ok "launch setup race control skipped without setsid"
 fi
-
+prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep"); state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path); watch_dir=$(jq -r .watch_dir "$state_path"); legacy_runtime="$watch_dir/legacy-runtime"
+mkdir "$legacy_runtime"; printf '%s\n' "$watch" > "$legacy_runtime/token"
+jq --arg artifact "$watch_dir/verdict.json" --arg runtime "$legacy_runtime" '.artifact_path=$artifact|.runtime_dir=$runtime|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token,.legacy_generation)' "$state_path" > "$TMP/legacy-prepared.json"; chmod 600 "$TMP/legacy-prepared.json"; mv "$TMP/legacy-prepared.json" "$state_path"
+launch_bounded "$watch"
+legacy_state=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829)
+eq "$(jq -r .status <<<"$legacy_state")" watching "legacy prepared lifecycle launches after upgrade"
+[[ "$(jq -r .launch_attempt_id <<<"$legacy_state")" == "$watch-attempt-1" && "$(jq -r .runtime_dir <<<"$legacy_state")" != "$legacy_runtime" && "$(jq -r .watch_dir <<<"$legacy_state")" == "$watch_dir" ]] && ok "legacy prepared migration preserves watch cleanup identity" || bad "legacy prepared migration lost generation or cleanup identity"
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
 jq --arg attempt "$watch-attempt-1" --arg token "$watch-attempt-1-test" '.launch_attempt=1|.launch_attempt_id=$attempt|.supervisor_token=$token|.status="launching"|.setup_deadline=0|.deadline=((now|floor)+600)' "$state_path" > "$TMP/orphan.json"
@@ -432,7 +427,12 @@ rm -f -- "$WATCH_SUPERVISOR_PID_GATE.enabled" "$WATCH_SUPERVISOR_PID_GATE.entere
 if [[ "$setup_rc" -ne 0 ]]; then ok "supervisor failure before ready exits nonzero"; else bad "supervisor failure before ready exited zero"; fi
 eq "$(jq -r .verdict "$artifact")" unknown "dead supervisor publishes its setup failure"
 old_inode=$(inode "$artifact")
-retry_state=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829); reserved_runtime="$(jq -r .runtime_root <<<"$retry_state")/$watch-attempt-2"; mkdir "$reserved_runtime"; touch "$reserved_runtime/interrupted-marker"
+retry_state=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829); runtime_root=$(jq -r .runtime_root <<<"$retry_state"); outside_runtime="$(dirname "$(dirname "$runtime_root")")/outside-attempt-2"; mismatch_runtime="$runtime_root/other-watch-attempt-2"
+mkdir "$outside_runtime" "$mismatch_runtime"; touch "$outside_runtime/sentinel" "$mismatch_runtime/sentinel"
+set +e; "$SCRIPTS/merge-queue-watch" launch --root "$MAIN" --issue KEN-829 --watch-id ../../outside --poll 1 --max-wait 10 >/dev/null 2>&1; traversal_rc=$?; "$SCRIPTS/merge-queue-watch" launch --root "$MAIN" --issue KEN-829 --watch-id other-watch --poll 1 --max-wait 10 >/dev/null 2>&1; mismatch_rc=$?; set -e
+[[ "$traversal_rc" -ne 0 && -e "$outside_runtime/sentinel" ]] && ok "traversal watch id cannot change an external attempt path" || bad "traversal watch id changed an external attempt path"
+[[ "$mismatch_rc" -ne 0 && -e "$mismatch_runtime/sentinel" ]] && ok "mismatched watch id cannot change an attempt path" || bad "mismatched watch id changed an attempt path"
+reserved_runtime="$runtime_root/$watch-attempt-2"; mkdir "$reserved_runtime"; touch "$reserved_runtime/interrupted-marker"
 launch_bounded "$watch"
 [[ ! -e "$reserved_runtime/interrupted-marker" ]] && ok "retry reclaims only unregistered attempt runtime" || bad "interrupted reservation wedged retry"
 retry_artifact=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .artifact_path)

--- a/.agents/skills/orch/tests/merge_queue_watch.sh
+++ b/.agents/skills/orch/tests/merge_queue_watch.sh
@@ -118,7 +118,10 @@ fi
 cat > "$BIN/chmod" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-if [[ -f "$WATCH_SUPERVISOR_PID_DELAY" && "${*: -1}" == */supervisor.pid ]]; then sleep 6; fi
+if [[ -f "$WATCH_SUPERVISOR_PID_GATE.enabled" && "${*: -1}" == */supervisor.pid ]]; then
+  touch "$WATCH_SUPERVISOR_PID_GATE.entered"
+  while [[ ! -f "$WATCH_SUPERVISOR_PID_GATE.release" ]]; do sleep 0.05; done
+fi
 exec "$WATCH_REAL_CHMOD" "$@"
 EOF
 chmod +x "$BIN/chmod"
@@ -137,12 +140,17 @@ cat > "$BIN/ps" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 if [[ "${MERGE_QUEUE_FORCE_PS_IDENTITY:-0}" == 1 ]]; then printf '%s\n' "$*" >> "$WATCH_PS_LOG"; fi
+if [[ -f "$WATCH_SUPERVISOR_PID_GATE.enabled" ]]; then
+  calls=0; [[ ! -f "$WATCH_SUPERVISOR_PID_GATE.calls" ]] || calls=$(cat < "$WATCH_SUPERVISOR_PID_GATE.calls")
+  calls=$((calls+1)); printf '%s\n' "$calls" > "$WATCH_SUPERVISOR_PID_GATE.calls"
+  [[ "$calls" -lt 2 ]] || touch "$WATCH_SUPERVISOR_PID_GATE.release"
+fi
 exec "$WATCH_REAL_PS" "$@"
 EOF
 chmod +x "$BIN/ps"
 export PATH="$BIN:$PATH" WATCH_MODE="$MODE" WATCH_RELEASE="$RELEASE" WATCH_HEAD_FILE="$HEAD_FILE" WATCH_MAIN="$MAIN" WATCH_WORKTREE="$WT"
 export WATCH_GH_PAUSE="$TMP/gh-pause" WATCH_SETUP_GATE="$TMP/setup-gate" WATCH_REAL_SETSID="$REAL_SETSID" WATCH_CLEANUP_FAIL="$TMP/cleanup-fail" WATCH_CLEANUP_INTERRUPT="$TMP/cleanup-interrupt"
-export WATCH_SETSID_FAIL="$TMP/setsid-fail" WATCH_SETSID_DELAY="$TMP/setsid-delay" WATCH_CLEANUP_PAUSE="$TMP/cleanup-pause" WATCH_AUTH_LOG="$TMP/auth.log" WATCH_WORKER_LOG="$TMP/worker.log" WATCH_REAL_CHMOD="$REAL_CHMOD" WATCH_REAL_FLOCK="$REAL_FLOCK" WATCH_FAIL_FLOCK_GATE="$TMP/fail-flock-gate" WATCH_REAL_PS="$REAL_PS" WATCH_PS_LOG="$TMP/ps.log" WATCH_SUPERVISOR_PID_DELAY="$TMP/supervisor-pid-delay" GH_REPO=wrong/repository GITHUB_REPOSITORY=wrong/repository
+export WATCH_SETSID_FAIL="$TMP/setsid-fail" WATCH_SETSID_DELAY="$TMP/setsid-delay" WATCH_CLEANUP_PAUSE="$TMP/cleanup-pause" WATCH_AUTH_LOG="$TMP/auth.log" WATCH_WORKER_LOG="$TMP/worker.log" WATCH_REAL_CHMOD="$REAL_CHMOD" WATCH_REAL_FLOCK="$REAL_FLOCK" WATCH_FAIL_FLOCK_GATE="$TMP/fail-flock-gate" WATCH_REAL_PS="$REAL_PS" WATCH_PS_LOG="$TMP/ps.log" WATCH_SUPERVISOR_PID_GATE="$TMP/supervisor-pid-gate" GH_REPO=wrong/repository GITHUB_REPOSITORY=wrong/repository
 touch "$WATCH_PS_LOG"
 unset GH_TOKEN GITHUB_TOKEN GH_BOT_TOKEN
 init_out=$("$SCRIPTS/merge-queue-watch" init --worktree "$WT" --issue KEN-829 --branch watch-test)
@@ -385,12 +393,17 @@ eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 
 prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
-touch "$WATCH_SUPERVISOR_PID_DELAY"
+rm -f -- "$WATCH_SUPERVISOR_PID_GATE.entered" "$WATCH_SUPERVISOR_PID_GATE.release" "$WATCH_SUPERVISOR_PID_GATE.calls"
+touch "$WATCH_SUPERVISOR_PID_GATE.enabled"
+export MERGE_QUEUE_FORCE_PS_IDENTITY=1
 set +e
 "$SCRIPTS/merge-queue-watch" launch --root "$MAIN" --issue KEN-829 --watch-id "$watch" --poll 1 --max-wait 10 >/dev/null 2>&1
 setup_rc=$?
 set -e
-rm -f -- "$WATCH_SUPERVISOR_PID_DELAY"
+unset MERGE_QUEUE_FORCE_PS_IDENTITY
+wait_exists "$WATCH_SUPERVISOR_PID_GATE.entered" && ok "supervisor setup entered the explicit delay gate" || bad "supervisor setup bypassed the explicit delay gate"
+wait_exists "$WATCH_SUPERVISOR_PID_GATE.release" && ok "teardown released the delayed supervisor" || bad "teardown never released the delayed supervisor"
+rm -f -- "$WATCH_SUPERVISOR_PID_GATE.enabled" "$WATCH_SUPERVISOR_PID_GATE.entered" "$WATCH_SUPERVISOR_PID_GATE.release" "$WATCH_SUPERVISOR_PID_GATE.calls"
 if [[ "$setup_rc" -ne 0 ]]; then ok "supervisor failure before ready exits nonzero"; else bad "supervisor failure before ready exited zero"; fi
 eq "$(jq -r .verdict "$artifact")" unknown "dead supervisor publishes its setup failure"
 old_inode=$(inode "$artifact")

--- a/.agents/skills/orch/tests/merge_queue_watch.sh
+++ b/.agents/skills/orch/tests/merge_queue_watch.sh
@@ -3,8 +3,9 @@ set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ORCH="$(cd "$TEST_DIR/.." && pwd)"
-TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+TMP_ROOT="$(mktemp -d)"; TMP="$TMP_ROOT/watch path"
+mkdir "$TMP"
+trap 'rm -rf "$TMP_ROOT"' EXIT
 PASS=0 FAIL=0
 ok() { PASS=$((PASS+1)); printf '  ok    %s\n' "$1"; }
 bad() { FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$1"; }
@@ -308,7 +309,7 @@ fi
 
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
-jq --arg attempt "$watch-attempt-1" '.launch_attempt=1|.launch_attempt_id=$attempt|.status="launching"|.setup_deadline=0|.deadline=((now|floor)+600)' "$state_path" > "$TMP/orphan.json"
+jq --arg attempt "$watch-attempt-1" --arg token "$watch-attempt-1-test" '.launch_attempt=1|.launch_attempt_id=$attempt|.supervisor_token=$token|.status="launching"|.setup_deadline=0|.deadline=((now|floor)+600)' "$state_path" > "$TMP/orphan.json"
 chmod 600 "$TMP/orphan.json"; mv "$TMP/orphan.json" "$state_path"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .action <<<"$result")" resume_launch "orphaned launching state wakes into launch recovery"
@@ -500,6 +501,46 @@ chmod 600 "$TMP/similar-attempt-state.json"; mv "$TMP/similar-attempt-state.json
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 kill -0 "$similar_attempt_pid" 2>/dev/null && ok "attempt identity compares argv fields exactly" || bad "attempt-1 matched and signaled attempt-10"
 kill "$similar_attempt_pid" 2>/dev/null || true; wait "$similar_attempt_pid" 2>/dev/null || true
+touch "$RELEASE"
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+launch_bounded "$watch"
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+fallback_supervisor=$(jq -r .supervisor_pid "$state_path")
+export MERGE_QUEUE_FORCE_PS_IDENTITY=1
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+if ! kill -0 "$fallback_supervisor" 2>/dev/null; then ok "ps environment identity supports repository paths with spaces"; else bad "ps fallback rejected a valid supervisor under a whitespace path"; fi
+unset MERGE_QUEUE_FORCE_PS_IDENTITY
+touch "$RELEASE"
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+launch_bounded "$watch"
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+attempt=$(jq -r .launch_attempt_id "$state_path"); runtime=$(jq -r .runtime_dir "$state_path"); artifact=$(jq -r .artifact_path "$state_path"); identity=$(jq -r .supervisor_token "$state_path")
+env "MERGE_QUEUE_SUPERVISOR_TOKEN=${identity}0" bash -c 'while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$state_path" "$watch" "$attempt" "$runtime" "$artifact" 999 "$SCRIPTS/queue-wait" 1 10 & similar_identity_pid=$!
+jq --argjson pid "$similar_identity_pid" '.supervisor_pid=$pid' "$state_path" > "$TMP/similar-identity-state.json"
+chmod 600 "$TMP/similar-identity-state.json"; mv "$TMP/similar-identity-state.json" "$state_path"
+export MERGE_QUEUE_FORCE_PS_IDENTITY=1
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+kill -0 "$similar_identity_pid" 2>/dev/null && ok "ps environment identity rejects a similar generation" || bad "ps fallback matched a similar generation token"
+unset MERGE_QUEUE_FORCE_PS_IDENTITY
+kill "$similar_identity_pid" 2>/dev/null || true; wait "$similar_identity_pid" 2>/dev/null || true
+touch "$RELEASE"
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+launch_bounded "$watch"
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+attempt=$(jq -r .launch_attempt_id "$state_path"); runtime=$(jq -r .runtime_dir "$state_path"); artifact=$(jq -r .artifact_path "$state_path"); identity=$(jq -r .supervisor_token "$state_path")
+identity_changed="$TMP/identity-changed"
+env "WATCH_IDENTITY_CHANGED=$identity_changed" "MERGE_QUEUE_SUPERVISOR_TOKEN=$identity" bash -c 'trap '\''touch "$WATCH_IDENTITY_CHANGED"; exec env -u MERGE_QUEUE_SUPERVISOR_TOKEN sleep 30'\'' TERM; while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$state_path" "$watch" "$attempt" "$runtime" "$artifact" 999 "$SCRIPTS/queue-wait" 1 10 & changed_identity_pid=$!
+jq --argjson pid "$changed_identity_pid" '.supervisor_pid=$pid' "$state_path" > "$TMP/changed-identity-state.json"
+chmod 600 "$TMP/changed-identity-state.json"; mv "$TMP/changed-identity-state.json" "$state_path"
+export MERGE_QUEUE_FORCE_PS_IDENTITY=1
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+wait_exists "$identity_changed" && ok "teardown sent TERM to the captured identity" || bad "teardown never signaled the captured identity"
+kill -0 "$changed_identity_pid" 2>/dev/null && ok "teardown stops when the PID changes identity" || bad "teardown escalated KILL after identity changed"
+unset MERGE_QUEUE_FORCE_PS_IDENTITY
+kill "$changed_identity_pid" 2>/dev/null || true; wait "$changed_identity_pid" 2>/dev/null || true
 touch "$RELEASE"
 
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")

--- a/.agents/skills/orch/tests/merge_queue_watch.sh
+++ b/.agents/skills/orch/tests/merge_queue_watch.sh
@@ -407,7 +407,9 @@ if [[ "$setup_error" == *"$SCRIPTS/queue-wait"* && "$setup_error" == *"diagnosti
 eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .status)" launch_failed "setup failure remains an active lifecycle"
 replay=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .action <<<"$replay")" resume_launch "setup failure cannot hand back before launch recovery"
+registered_runtime=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .runtime_dir); touch "$registered_runtime/registered-marker"
 launch_bounded "$watch"
+[[ -e "$registered_runtime/registered-marker" ]] && ok "registered attempt runtime is never reclaimed" || bad "retry reclaimed registered attempt runtime"
 eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .status)" watching "same watch retries after setup repair"
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 
@@ -430,7 +432,9 @@ rm -f -- "$WATCH_SUPERVISOR_PID_GATE.enabled" "$WATCH_SUPERVISOR_PID_GATE.entere
 if [[ "$setup_rc" -ne 0 ]]; then ok "supervisor failure before ready exits nonzero"; else bad "supervisor failure before ready exited zero"; fi
 eq "$(jq -r .verdict "$artifact")" unknown "dead supervisor publishes its setup failure"
 old_inode=$(inode "$artifact")
+retry_state=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829); reserved_runtime="$(jq -r .runtime_root <<<"$retry_state")/$watch-attempt-2"; mkdir "$reserved_runtime"; touch "$reserved_runtime/interrupted-marker"
 launch_bounded "$watch"
+[[ ! -e "$reserved_runtime/interrupted-marker" ]] && ok "retry reclaims only unregistered attempt runtime" || bad "interrupted reservation wedged retry"
 retry_artifact=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .artifact_path)
 [[ "$retry_artifact" != "$artifact" ]] && ok "retry reserves a fresh artifact identity" || bad "retry reused the dead supervisor artifact"
 touch "$RELEASE"; wait_file "$retry_artifact" || bad "retried supervisor verdict missing"

--- a/.agents/skills/orch/tests/merge_queue_watch.sh
+++ b/.agents/skills/orch/tests/merge_queue_watch.sh
@@ -643,13 +643,18 @@ rm -f -- "$WATCH_REGISTRATION_GATE.enabled" "$WATCH_REGISTRATION_GATE.entered" "
 prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
 bash -c 'while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$state_path" "$watch" "$SCRIPTS/queue-wait" 1 10 & legacy_supervisor=$!
-jq --argjson pid "$legacy_supervisor" '.status="watching"|.supervisor_pid=$pid|.deadline=((now|floor)+600)|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-watching.json"
+jq --argjson pid "$legacy_supervisor" '.status="launching"|.supervisor_pid=$pid|.setup_deadline=((now|floor)+10)|.deadline=((now|floor)+600)|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-watching.json"
 chmod 600 "$TMP/legacy-watching.json"; mv "$TMP/legacy-watching.json" "$state_path"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
-eq "$(jq -r .action <<<"$result")" pending "legacy watching state remains active"
+eq "$(jq -r .action <<<"$result")" pending "live legacy launching remains pending"
+jq '.setup_deadline=0' "$state_path" > "$TMP/legacy-launch-expired.json"; chmod 600 "$TMP/legacy-launch-expired.json"; mv "$TMP/legacy-launch-expired.json" "$state_path"
+result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
+eq "$(jq -r .action <<<"$result")" pending "expired live legacy launch is adopted"
+eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .status)" watching "legacy launch adoption persists watching"
 running "$legacy_supervisor" && ok "legacy watching supervisor is preserved" || bad "legacy watching supervisor was terminated"
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 if ! running "$legacy_supervisor"; then ok "direct legacy failure terminates tokenless supervisor"; else bad "direct legacy failure left tokenless supervisor running"; fi
+kill "$legacy_supervisor" 2>/dev/null || true
 wait "$legacy_supervisor" 2>/dev/null || true
 
 prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
@@ -676,12 +681,16 @@ prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
 legacy_runtime=$(jq -r .runtime_dir "$state_path")
 printf '%s\n' "$watch" > "$legacy_runtime/token"
-jq '.status="launch_failed"|.action="launch"|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-launch-failed.json"
+bash -c 'while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$state_path" "$watch" "$SCRIPTS/queue-wait" 1 10 & legacy_retry_supervisor=$!
+jq --argjson pid "$legacy_retry_supervisor" '.status="launch_failed"|.action="launch"|.supervisor_pid=$pid|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-launch-failed.json"
 chmod 600 "$TMP/legacy-launch-failed.json"; mv "$TMP/legacy-launch-failed.json" "$state_path"
 launch_bounded "$watch"
 legacy_retry_state=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .status <<<"$legacy_retry_state")" watching "legacy launch failure retries on a migrated generation"
 [[ "$(jq -r .runtime_dir <<<"$legacy_retry_state")" != "$legacy_runtime" ]] && ok "legacy retry receives an isolated runtime" || bad "legacy retry reused legacy runtime"
+if ! running "$legacy_retry_supervisor"; then ok "legacy retry terminates old supervisor before replacement"; else bad "legacy retry left old supervisor running"; fi
+kill "$legacy_retry_supervisor" 2>/dev/null || true
+wait "$legacy_retry_supervisor" 2>/dev/null || true
 if [[ "$(jq -r .status <<<"$legacy_retry_state")" == watching ]]; then
   legacy_retry_artifact=$(jq -r .artifact_path <<<"$legacy_retry_state")
   touch "$RELEASE"; wait_file "$legacy_retry_artifact" || bad "legacy retry verdict missing"

--- a/.agents/skills/orch/tests/merge_queue_watch.sh
+++ b/.agents/skills/orch/tests/merge_queue_watch.sh
@@ -11,6 +11,7 @@ bad() { FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$1"; }
 eq() { if [[ "$1" == "$2" ]]; then ok "$3"; else bad "$3 (expected $2, got $1)"; fi; }
 wait_file() { local i; for ((i=0;i<100;i++)); do [[ -s "$1" ]] && return 0; sleep 0.05; done; return 1; }
 wait_exists() { local i; for ((i=0;i<100;i++)); do [[ -e "$1" ]] && return 0; sleep 0.05; done; return 1; }
+inode() { stat -c %i "$1" 2>/dev/null || stat -f %i "$1"; }
 
 MAIN="$TMP/main" WT="$TMP/worktree" BIN="$TMP/bin" SCRIPTS="$TMP/orch/scripts"
 REAL_SETSID=$(command -v setsid || true)
@@ -102,6 +103,10 @@ cat > "$BIN/setsid" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 [[ ! -f "$WATCH_SETSID_FAIL" ]] || exit 41
+if [[ -f "$WATCH_SETSID_DELAY.enabled" ]]; then
+  "$WATCH_REAL_SETSID" -f bash -c 'touch "$WATCH_SETSID_DELAY.entered"; while [[ ! -f "$WATCH_SETSID_DELAY.release" ]]; do sleep 0.05; done; exec "$@"' bash "$WATCH_REAL_SETSID" "$@"
+  exit 0
+fi
 if [[ -f "$WATCH_SETUP_GATE.enabled" ]]; then touch "$WATCH_SETUP_GATE.entered"; while [[ ! -f "$WATCH_SETUP_GATE.release" ]]; do sleep 0.05; done; fi
 exec "$WATCH_REAL_SETSID" "$@"
 EOF
@@ -116,7 +121,7 @@ EOF
 chmod +x "$BIN/chmod"
 export PATH="$BIN:$PATH" WATCH_MODE="$MODE" WATCH_RELEASE="$RELEASE" WATCH_HEAD_FILE="$HEAD_FILE" WATCH_MAIN="$MAIN" WATCH_WORKTREE="$WT"
 export WATCH_GH_PAUSE="$TMP/gh-pause" WATCH_SETUP_GATE="$TMP/setup-gate" WATCH_REAL_SETSID="$REAL_SETSID" WATCH_CLEANUP_FAIL="$TMP/cleanup-fail" WATCH_CLEANUP_INTERRUPT="$TMP/cleanup-interrupt"
-export WATCH_SETSID_FAIL="$TMP/setsid-fail" WATCH_CLEANUP_PAUSE="$TMP/cleanup-pause" WATCH_AUTH_LOG="$TMP/auth.log" WATCH_WORKER_LOG="$TMP/worker.log" WATCH_REAL_CHMOD="$REAL_CHMOD" WATCH_SUPERVISOR_PID_DELAY="$TMP/supervisor-pid-delay" GH_REPO=wrong/repository GITHUB_REPOSITORY=wrong/repository
+export WATCH_SETSID_FAIL="$TMP/setsid-fail" WATCH_SETSID_DELAY="$TMP/setsid-delay" WATCH_CLEANUP_PAUSE="$TMP/cleanup-pause" WATCH_AUTH_LOG="$TMP/auth.log" WATCH_WORKER_LOG="$TMP/worker.log" WATCH_REAL_CHMOD="$REAL_CHMOD" WATCH_SUPERVISOR_PID_DELAY="$TMP/supervisor-pid-delay" GH_REPO=wrong/repository GITHUB_REPOSITORY=wrong/repository
 unset GH_TOKEN GITHUB_TOKEN GH_BOT_TOKEN
 init_out=$("$SCRIPTS/merge-queue-watch" init --worktree "$WT" --issue KEN-829 --branch watch-test)
 eq "$(jq -r .exists <<<"$init_out")" true "standalone init creates workflow state"
@@ -162,6 +167,7 @@ if kill -0 "$supervisor" 2>/dev/null; then ok "supervisor survives the launch co
 touch "$RELEASE"; wait_file "$artifact" || bad "merged verdict was not published"
 eq "$(jq -r .watch_id "$artifact")" "$watch" "artifact binds watch id"
 eq "$(jq -r .expected_head "$artifact")" "$HEAD_A" "artifact binds expected head"
+eq "$(jq -r .launch_attempt_id "$artifact")" "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .launch_attempt_id)" "artifact binds launch attempt"
 event_out=$("$SCRIPTS/merge-queue-watch" event --root "$MAIN" --issue KEN-829)
 if [[ "$event_out" == ready* ]]; then ok "fleet event wakes the owner once verdict exists"; else bad "fleet event missing"; fi
 event_again=$("$SCRIPTS/merge-queue-watch" event --root "$MAIN" --issue KEN-829)
@@ -290,7 +296,7 @@ fi
 
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
-jq '.status="launching"|.setup_deadline=0|.deadline=((now|floor)+600)' "$state_path" > "$TMP/orphan.json"
+jq --arg attempt "$watch-attempt-1" '.launch_attempt=1|.launch_attempt_id=$attempt|.status="launching"|.setup_deadline=0|.deadline=((now|floor)+600)' "$state_path" > "$TMP/orphan.json"
 chmod 600 "$TMP/orphan.json"; mv "$TMP/orphan.json" "$state_path"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .action <<<"$result")" resume_launch "orphaned launching state wakes into launch recovery"
@@ -315,9 +321,9 @@ eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -
 
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
-jq '.status="launching"|.setup_deadline=((now|floor)+10)|.deadline=((now|floor)+600)' "$state_path" > "$TMP/completed-launch.json"
+jq --arg attempt "$watch-attempt-1" '.launch_attempt=1|.launch_attempt_id=$attempt|.status="launching"|.setup_deadline=((now|floor)+10)|.deadline=((now|floor)+600)' "$state_path" > "$TMP/completed-launch.json"
 chmod 600 "$TMP/completed-launch.json"; mv "$TMP/completed-launch.json" "$state_path"
-jq -n --arg watch "$watch" --arg head "$HEAD_A" '{schema_version:1,status:"complete",verdict:"merged",repository:"owner/repo",pr_number:42,expected_head:$head,observed_head:"",watch_id:$watch}' > "$artifact"
+jq -n --arg watch "$watch" --arg attempt "$watch-attempt-1" --arg head "$HEAD_A" '{schema_version:1,status:"complete",verdict:"merged",repository:"owner/repo",pr_number:42,expected_head:$head,observed_head:"",watch_id:$watch,launch_attempt_id:$attempt}' > "$artifact"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .action <<<"$result")" postmerge "completed artifact outranks launching setup state"
 "$SCRIPTS/merge-queue-watch" merge-pr-complete --root "$MAIN" --issue KEN-829 --watch-id "$watch" >/dev/null
@@ -365,14 +371,65 @@ set -e
 rm -f -- "$WATCH_SUPERVISOR_PID_DELAY"
 if [[ "$setup_rc" -ne 0 ]]; then ok "supervisor failure before ready exits nonzero"; else bad "supervisor failure before ready exited zero"; fi
 eq "$(jq -r .verdict "$artifact")" unknown "dead supervisor publishes its setup failure"
+old_inode=$(inode "$artifact")
 launch_bounded "$watch"
 retry_artifact=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .artifact_path)
 [[ "$retry_artifact" != "$artifact" ]] && ok "retry reserves a fresh artifact identity" || bad "retry reused the dead supervisor artifact"
 touch "$RELEASE"; wait_file "$retry_artifact" || bad "retried supervisor verdict missing"
 eq "$(jq -r .verdict "$retry_artifact")" ejected "retry publishes the new supervisor verdict"
+eq "$(jq -r .verdict "$artifact")" unknown "retry preserves the dead supervisor artifact"
+[[ "$(inode "$retry_artifact")" != "$old_inode" ]] && ok "retry artifact has its own inode" || bad "retry artifact reused the dead supervisor output inode"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .action <<<"$result")" recovery "consume routes the retried supervisor verdict"
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
+launch_bounded "$watch"; touch "$RELEASE"; wait_file "$artifact" || bad "stale-consume fixture verdict missing"
+touch "$WATCH_GH_PAUSE.enabled"
+"$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829 >"$TMP/stale-consume.out" 2>"$TMP/stale-consume.err" & stale_consume_pid=$!
+wait_exists "$WATCH_GH_PAUSE.entered" || bad "consume did not capture the old launch attempt"
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+jq '.status="launch_failed"|.action="launch"|.supervisor_pid=null' "$state_path" > "$TMP/stale-consume-state.json"
+chmod 600 "$TMP/stale-consume-state.json"; mv "$TMP/stale-consume-state.json" "$state_path"
+launch_bounded "$watch"
+replacement_artifact=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .artifact_path)
+touch "$WATCH_GH_PAUSE.release"
+set +e; wait "$stale_consume_pid"; stale_consume_rc=$?; set -e
+[[ "$stale_consume_rc" -ne 0 ]] && ok "stale consume cannot claim the replacement attempt" || bad "stale consume claimed across the launch-attempt fence"
+eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .status)" watching "stale consume leaves the replacement attempt active"
+wait_file "$replacement_artifact" || bad "replacement verdict missing after stale consume"
+result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
+eq "$(jq -r .action <<<"$result")" recovery "replacement verdict survives stale consume"
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+rm -f -- "$WATCH_GH_PAUSE.enabled" "$WATCH_GH_PAUSE.entered" "$WATCH_GH_PAUSE.release"
+
+if [[ -n "$REAL_SETSID" ]]; then
+  prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
+  delayed_runtime=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .runtime_dir)
+  touch "$WATCH_SETSID_DELAY.enabled"
+  set +e; "$SCRIPTS/merge-queue-watch" launch --root "$MAIN" --issue KEN-829 --watch-id "$watch" --poll 1 --max-wait 10 >/dev/null 2>&1; delayed_rc=$?; set -e
+  [[ "$delayed_rc" -ne 0 ]] && ok "pre-PID supervisor delay enters launch recovery" || bad "pre-PID supervisor delay reported success"
+  wait_exists "$WATCH_SETSID_DELAY.entered" || bad "pre-PID supervisor did not enter its delay gate"
+  rm -f -- "$WATCH_SETSID_DELAY.enabled"
+  launch_bounded "$watch"
+  delayed_replacement_artifact=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .artifact_path)
+  delayed_replacement_runtime=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .runtime_dir)
+  [[ "$delayed_replacement_runtime" != "$delayed_runtime" ]] && ok "replacement attempt has its own runtime directory" || bad "replacement reused the delayed supervisor runtime"
+  touch "$RELEASE"
+  wait_file "$delayed_replacement_artifact" || bad "replacement verdict missing after delayed supervisor release"
+  printf 'malformed\n' > "$MODE"
+  touch "$WATCH_SETSID_DELAY.release"
+  sleep 0.5
+  [[ ! -e "$artifact" ]] && ok "unregistered delayed supervisor cannot publish into retry files" || bad "unregistered delayed supervisor published after retry"
+  eq "$(jq -r .verdict "$delayed_replacement_artifact")" ejected "unregistered delayed supervisor cannot rewrite the replacement verdict"
+  printf 'ejected\n' > "$MODE"
+  result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
+  eq "$(jq -r .action <<<"$result")" recovery "replacement verdict wins after delayed supervisor release"
+  "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+  rm -f -- "$WATCH_SETSID_DELAY.entered" "$WATCH_SETSID_DELAY.release"
+else
+  ok "pre-PID supervisor fence skipped without setsid"
+fi
 
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
 "$SCRIPTS/merge-queue-watch" direct-merged --root "$MAIN" --issue KEN-829 --watch-id "$watch" >/dev/null

--- a/.agents/skills/orch/tests/merge_queue_watch.sh
+++ b/.agents/skills/orch/tests/merge_queue_watch.sh
@@ -18,6 +18,7 @@ MAIN="$TMP/main" WT="$TMP/worktree" BIN="$TMP/bin" SCRIPTS="$TMP/orch/scripts"
 REAL_SETSID=$(command -v setsid || true)
 REAL_CHMOD=$(command -v chmod)
 REAL_FLOCK=$(command -v flock)
+REAL_PS=$(command -v ps)
 mkdir -p "$MAIN" "$BIN" "$SCRIPTS/lib"
 git -C "$MAIN" init -q
 git -C "$MAIN" config user.email test@example.com
@@ -132,9 +133,17 @@ fi
 exec "$WATCH_REAL_FLOCK" "$@"
 EOF
 chmod +x "$BIN/flock"
+cat > "$BIN/ps" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${MERGE_QUEUE_FORCE_PS_IDENTITY:-0}" == 1 ]]; then printf '%s\n' "$*" >> "$WATCH_PS_LOG"; fi
+exec "$WATCH_REAL_PS" "$@"
+EOF
+chmod +x "$BIN/ps"
 export PATH="$BIN:$PATH" WATCH_MODE="$MODE" WATCH_RELEASE="$RELEASE" WATCH_HEAD_FILE="$HEAD_FILE" WATCH_MAIN="$MAIN" WATCH_WORKTREE="$WT"
 export WATCH_GH_PAUSE="$TMP/gh-pause" WATCH_SETUP_GATE="$TMP/setup-gate" WATCH_REAL_SETSID="$REAL_SETSID" WATCH_CLEANUP_FAIL="$TMP/cleanup-fail" WATCH_CLEANUP_INTERRUPT="$TMP/cleanup-interrupt"
-export WATCH_SETSID_FAIL="$TMP/setsid-fail" WATCH_SETSID_DELAY="$TMP/setsid-delay" WATCH_CLEANUP_PAUSE="$TMP/cleanup-pause" WATCH_AUTH_LOG="$TMP/auth.log" WATCH_WORKER_LOG="$TMP/worker.log" WATCH_REAL_CHMOD="$REAL_CHMOD" WATCH_REAL_FLOCK="$REAL_FLOCK" WATCH_FAIL_FLOCK_GATE="$TMP/fail-flock-gate" WATCH_SUPERVISOR_PID_DELAY="$TMP/supervisor-pid-delay" GH_REPO=wrong/repository GITHUB_REPOSITORY=wrong/repository
+export WATCH_SETSID_FAIL="$TMP/setsid-fail" WATCH_SETSID_DELAY="$TMP/setsid-delay" WATCH_CLEANUP_PAUSE="$TMP/cleanup-pause" WATCH_AUTH_LOG="$TMP/auth.log" WATCH_WORKER_LOG="$TMP/worker.log" WATCH_REAL_CHMOD="$REAL_CHMOD" WATCH_REAL_FLOCK="$REAL_FLOCK" WATCH_FAIL_FLOCK_GATE="$TMP/fail-flock-gate" WATCH_REAL_PS="$REAL_PS" WATCH_PS_LOG="$TMP/ps.log" WATCH_SUPERVISOR_PID_DELAY="$TMP/supervisor-pid-delay" GH_REPO=wrong/repository GITHUB_REPOSITORY=wrong/repository
+touch "$WATCH_PS_LOG"
 unset GH_TOKEN GITHUB_TOKEN GH_BOT_TOKEN
 init_out=$("$SCRIPTS/merge-queue-watch" init --worktree "$WT" --issue KEN-829 --branch watch-test)
 eq "$(jq -r .exists <<<"$init_out")" true "standalone init creates workflow state"
@@ -507,8 +516,10 @@ prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
 launch_bounded "$watch"
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
 fallback_supervisor=$(jq -r .supervisor_pid "$state_path")
+ps_calls=$(wc -l < "$WATCH_PS_LOG")
 export MERGE_QUEUE_FORCE_PS_IDENTITY=1
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+[[ "$(wc -l < "$WATCH_PS_LOG")" -gt "$ps_calls" ]] && ok "forced whitespace identity check invokes ps" || bad "forced whitespace identity check bypassed ps"
 if ! kill -0 "$fallback_supervisor" 2>/dev/null; then ok "ps environment identity supports repository paths with spaces"; else bad "ps fallback rejected a valid supervisor under a whitespace path"; fi
 unset MERGE_QUEUE_FORCE_PS_IDENTITY
 touch "$RELEASE"
@@ -520,8 +531,10 @@ attempt=$(jq -r .launch_attempt_id "$state_path"); runtime=$(jq -r .runtime_dir 
 env "MERGE_QUEUE_SUPERVISOR_TOKEN=${identity}0" bash -c 'while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$state_path" "$watch" "$attempt" "$runtime" "$artifact" 999 "$SCRIPTS/queue-wait" 1 10 & similar_identity_pid=$!
 jq --argjson pid "$similar_identity_pid" '.supervisor_pid=$pid' "$state_path" > "$TMP/similar-identity-state.json"
 chmod 600 "$TMP/similar-identity-state.json"; mv "$TMP/similar-identity-state.json" "$state_path"
+ps_calls=$(wc -l < "$WATCH_PS_LOG")
 export MERGE_QUEUE_FORCE_PS_IDENTITY=1
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+[[ "$(wc -l < "$WATCH_PS_LOG")" -gt "$ps_calls" ]] && ok "forced similar-generation check invokes ps" || bad "forced similar-generation check bypassed ps"
 kill -0 "$similar_identity_pid" 2>/dev/null && ok "ps environment identity rejects a similar generation" || bad "ps fallback matched a similar generation token"
 unset MERGE_QUEUE_FORCE_PS_IDENTITY
 kill "$similar_identity_pid" 2>/dev/null || true; wait "$similar_identity_pid" 2>/dev/null || true
@@ -535,8 +548,10 @@ identity_changed="$TMP/identity-changed"
 env "WATCH_IDENTITY_CHANGED=$identity_changed" "MERGE_QUEUE_SUPERVISOR_TOKEN=$identity" bash -c 'trap '\''touch "$WATCH_IDENTITY_CHANGED"; exec env -u MERGE_QUEUE_SUPERVISOR_TOKEN sleep 30'\'' TERM; while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$state_path" "$watch" "$attempt" "$runtime" "$artifact" 999 "$SCRIPTS/queue-wait" 1 10 & changed_identity_pid=$!
 jq --argjson pid "$changed_identity_pid" '.supervisor_pid=$pid' "$state_path" > "$TMP/changed-identity-state.json"
 chmod 600 "$TMP/changed-identity-state.json"; mv "$TMP/changed-identity-state.json" "$state_path"
+ps_calls=$(wc -l < "$WATCH_PS_LOG")
 export MERGE_QUEUE_FORCE_PS_IDENTITY=1
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+[[ "$(wc -l < "$WATCH_PS_LOG")" -gt "$ps_calls" ]] && ok "forced identity-change check invokes ps" || bad "forced identity-change check bypassed ps"
 wait_exists "$identity_changed" && ok "teardown sent TERM to the captured identity" || bad "teardown never signaled the captured identity"
 kill -0 "$changed_identity_pid" 2>/dev/null && ok "teardown stops when the PID changes identity" || bad "teardown escalated KILL after identity changed"
 unset MERGE_QUEUE_FORCE_PS_IDENTITY

--- a/.agents/skills/orch/tests/merge_queue_watch.sh
+++ b/.agents/skills/orch/tests/merge_queue_watch.sh
@@ -14,6 +14,7 @@ wait_exists() { local i; for ((i=0;i<100;i++)); do [[ -e "$1" ]] && return 0; sl
 
 MAIN="$TMP/main" WT="$TMP/worktree" BIN="$TMP/bin" SCRIPTS="$TMP/orch/scripts"
 REAL_SETSID=$(command -v setsid || true)
+REAL_CHMOD=$(command -v chmod)
 mkdir -p "$MAIN" "$BIN" "$SCRIPTS/lib"
 git -C "$MAIN" init -q
 git -C "$MAIN" config user.email test@example.com
@@ -106,9 +107,16 @@ exec "$WATCH_REAL_SETSID" "$@"
 EOF
 chmod +x "$BIN/setsid"
 fi
+cat > "$BIN/chmod" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ -f "$WATCH_SUPERVISOR_PID_DELAY" && "${*: -1}" == */supervisor.pid ]]; then sleep 6; fi
+exec "$WATCH_REAL_CHMOD" "$@"
+EOF
+chmod +x "$BIN/chmod"
 export PATH="$BIN:$PATH" WATCH_MODE="$MODE" WATCH_RELEASE="$RELEASE" WATCH_HEAD_FILE="$HEAD_FILE" WATCH_MAIN="$MAIN" WATCH_WORKTREE="$WT"
 export WATCH_GH_PAUSE="$TMP/gh-pause" WATCH_SETUP_GATE="$TMP/setup-gate" WATCH_REAL_SETSID="$REAL_SETSID" WATCH_CLEANUP_FAIL="$TMP/cleanup-fail" WATCH_CLEANUP_INTERRUPT="$TMP/cleanup-interrupt"
-export WATCH_SETSID_FAIL="$TMP/setsid-fail" WATCH_CLEANUP_PAUSE="$TMP/cleanup-pause" WATCH_AUTH_LOG="$TMP/auth.log" WATCH_WORKER_LOG="$TMP/worker.log" GH_REPO=wrong/repository GITHUB_REPOSITORY=wrong/repository
+export WATCH_SETSID_FAIL="$TMP/setsid-fail" WATCH_CLEANUP_PAUSE="$TMP/cleanup-pause" WATCH_AUTH_LOG="$TMP/auth.log" WATCH_WORKER_LOG="$TMP/worker.log" WATCH_REAL_CHMOD="$REAL_CHMOD" WATCH_SUPERVISOR_PID_DELAY="$TMP/supervisor-pid-delay" GH_REPO=wrong/repository GITHUB_REPOSITORY=wrong/repository
 unset GH_TOKEN GITHUB_TOKEN GH_BOT_TOKEN
 init_out=$("$SCRIPTS/merge-queue-watch" init --worktree "$WT" --issue KEN-829 --branch watch-test)
 eq "$(jq -r .exists <<<"$init_out")" true "standalone init creates workflow state"
@@ -346,6 +354,24 @@ replay=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .action <<<"$replay")" resume_launch "setup failure cannot hand back before launch recovery"
 launch_bounded "$watch"
 eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .status)" watching "same watch retries after setup repair"
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
+touch "$WATCH_SUPERVISOR_PID_DELAY"
+set +e
+"$SCRIPTS/merge-queue-watch" launch --root "$MAIN" --issue KEN-829 --watch-id "$watch" --poll 1 --max-wait 10 >/dev/null 2>&1
+setup_rc=$?
+set -e
+rm -f -- "$WATCH_SUPERVISOR_PID_DELAY"
+if [[ "$setup_rc" -ne 0 ]]; then ok "supervisor failure before ready exits nonzero"; else bad "supervisor failure before ready exited zero"; fi
+eq "$(jq -r .verdict "$artifact")" unknown "dead supervisor publishes its setup failure"
+launch_bounded "$watch"
+retry_artifact=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .artifact_path)
+[[ "$retry_artifact" != "$artifact" ]] && ok "retry reserves a fresh artifact identity" || bad "retry reused the dead supervisor artifact"
+touch "$RELEASE"; wait_file "$retry_artifact" || bad "retried supervisor verdict missing"
+eq "$(jq -r .verdict "$retry_artifact")" ejected "retry publishes the new supervisor verdict"
+result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
+eq "$(jq -r .action <<<"$result")" recovery "consume routes the retried supervisor verdict"
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")

--- a/.agents/skills/orch/tests/merge_queue_watch.sh
+++ b/.agents/skills/orch/tests/merge_queue_watch.sh
@@ -12,6 +12,7 @@ bad() { FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$1"; }
 eq() { if [[ "$1" == "$2" ]]; then ok "$3"; else bad "$3 (expected $2, got $1)"; fi; }
 wait_file() { local i; for ((i=0;i<100;i++)); do [[ -s "$1" ]] && return 0; sleep 0.05; done; return 1; }
 wait_exists() { local i; for ((i=0;i<100;i++)); do [[ -e "$1" ]] && return 0; sleep 0.05; done; return 1; }
+wait_state() { local i; for ((i=0;i<200;i++)); do [[ "$(jq -r .status "$1")" == "$2" ]] && return 0; sleep 0.05; done; return 1; }
 inode() { stat -c %i "$1" 2>/dev/null || stat -f %i "$1"; }
 
 MAIN="$TMP/main" WT="$TMP/worktree" BIN="$TMP/bin" SCRIPTS="$TMP/orch/scripts"
@@ -19,6 +20,7 @@ REAL_SETSID=$(command -v setsid || true)
 REAL_CHMOD=$(command -v chmod)
 REAL_FLOCK=$(command -v flock)
 REAL_PS=$(command -v ps)
+REAL_MKFIFO=$(command -v mkfifo)
 mkdir -p "$MAIN" "$BIN" "$SCRIPTS/lib"
 git -C "$MAIN" init -q
 git -C "$MAIN" config user.email test@example.com
@@ -59,6 +61,8 @@ set -euo pipefail
 source .env.local
 [[ "$GH_BOT_TOKEN" == ghp_project && "$GH_REPO" == owner/repo ]] || { printf '{"status":"error","verdict":"unknown","error":"detached auth scope missing"}\n'; exit 3; }
 printf '%s\n' "$PWD|$GH_REPO|$GH_BOT_TOKEN" >> "$WATCH_WORKER_LOG"
+printf '%s\n' "$$" > "$WATCH_WORKER_PID"
+printf '%s\n' "${MERGE_QUEUE_SUPERVISOR_TOKEN:-unset}" > "$WATCH_WORKER_TOKEN"
 while [[ ! -f "$WATCH_RELEASE" ]]; do sleep 0.05; done
 mode=$(cat < "$WATCH_MODE")
 case "$mode" in
@@ -143,14 +147,27 @@ if [[ "${MERGE_QUEUE_FORCE_PS_IDENTITY:-0}" == 1 ]]; then printf '%s\n' "$*" >> 
 if [[ -f "$WATCH_SUPERVISOR_PID_GATE.enabled" ]]; then
   calls=0; [[ ! -f "$WATCH_SUPERVISOR_PID_GATE.calls" ]] || calls=$(cat < "$WATCH_SUPERVISOR_PID_GATE.calls")
   calls=$((calls+1)); printf '%s\n' "$calls" > "$WATCH_SUPERVISOR_PID_GATE.calls"
+  if [[ "$calls" -eq 1 && -n "${WATCH_SUPERVISOR_PID_GATE_STATE:-}" ]]; then
+    jq -r .status "$WATCH_SUPERVISOR_PID_GATE_STATE" > "$WATCH_SUPERVISOR_PID_GATE.observed-status"
+  fi
   [[ "$calls" -lt 2 ]] || touch "$WATCH_SUPERVISOR_PID_GATE.release"
 fi
 exec "$WATCH_REAL_PS" "$@"
 EOF
 chmod +x "$BIN/ps"
+cat > "$BIN/mkfifo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ -f "$WATCH_REGISTRATION_GATE.enabled" && "$*" == *"/events"* ]]; then
+  touch "$WATCH_REGISTRATION_GATE.entered"
+  while [[ ! -f "$WATCH_REGISTRATION_GATE.release" ]]; do sleep 0.05; done
+fi
+exec "$WATCH_REAL_MKFIFO" "$@"
+EOF
+chmod +x "$BIN/mkfifo"
 export PATH="$BIN:$PATH" WATCH_MODE="$MODE" WATCH_RELEASE="$RELEASE" WATCH_HEAD_FILE="$HEAD_FILE" WATCH_MAIN="$MAIN" WATCH_WORKTREE="$WT"
 export WATCH_GH_PAUSE="$TMP/gh-pause" WATCH_SETUP_GATE="$TMP/setup-gate" WATCH_REAL_SETSID="$REAL_SETSID" WATCH_CLEANUP_FAIL="$TMP/cleanup-fail" WATCH_CLEANUP_INTERRUPT="$TMP/cleanup-interrupt"
-export WATCH_SETSID_FAIL="$TMP/setsid-fail" WATCH_SETSID_DELAY="$TMP/setsid-delay" WATCH_CLEANUP_PAUSE="$TMP/cleanup-pause" WATCH_AUTH_LOG="$TMP/auth.log" WATCH_WORKER_LOG="$TMP/worker.log" WATCH_REAL_CHMOD="$REAL_CHMOD" WATCH_REAL_FLOCK="$REAL_FLOCK" WATCH_FAIL_FLOCK_GATE="$TMP/fail-flock-gate" WATCH_REAL_PS="$REAL_PS" WATCH_PS_LOG="$TMP/ps.log" WATCH_SUPERVISOR_PID_GATE="$TMP/supervisor-pid-gate" GH_REPO=wrong/repository GITHUB_REPOSITORY=wrong/repository
+export WATCH_SETSID_FAIL="$TMP/setsid-fail" WATCH_SETSID_DELAY="$TMP/setsid-delay" WATCH_CLEANUP_PAUSE="$TMP/cleanup-pause" WATCH_AUTH_LOG="$TMP/auth.log" WATCH_WORKER_LOG="$TMP/worker.log" WATCH_WORKER_PID="$TMP/worker.pid" WATCH_WORKER_TOKEN="$TMP/worker.token" WATCH_REAL_CHMOD="$REAL_CHMOD" WATCH_REAL_FLOCK="$REAL_FLOCK" WATCH_FAIL_FLOCK_GATE="$TMP/fail-flock-gate" WATCH_REAL_PS="$REAL_PS" WATCH_PS_LOG="$TMP/ps.log" WATCH_SUPERVISOR_PID_GATE="$TMP/supervisor-pid-gate" WATCH_REAL_MKFIFO="$REAL_MKFIFO" WATCH_REGISTRATION_GATE="$TMP/registration-gate" GH_REPO=wrong/repository GITHUB_REPOSITORY=wrong/repository
 touch "$WATCH_PS_LOG"
 unset GH_TOKEN GITHUB_TOKEN GH_BOT_TOKEN
 init_out=$("$SCRIPTS/merge-queue-watch" init --worktree "$WT" --issue KEN-829 --branch watch-test)
@@ -393,17 +410,21 @@ eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 
 prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
-rm -f -- "$WATCH_SUPERVISOR_PID_GATE.entered" "$WATCH_SUPERVISOR_PID_GATE.release" "$WATCH_SUPERVISOR_PID_GATE.calls"
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+rm -f -- "$WATCH_SUPERVISOR_PID_GATE.entered" "$WATCH_SUPERVISOR_PID_GATE.release" "$WATCH_SUPERVISOR_PID_GATE.calls" "$WATCH_SUPERVISOR_PID_GATE.observed-status"
 touch "$WATCH_SUPERVISOR_PID_GATE.enabled"
+export WATCH_SUPERVISOR_PID_GATE_STATE="$state_path"
 export MERGE_QUEUE_FORCE_PS_IDENTITY=1
 set +e
 "$SCRIPTS/merge-queue-watch" launch --root "$MAIN" --issue KEN-829 --watch-id "$watch" --poll 1 --max-wait 10 >/dev/null 2>&1
 setup_rc=$?
 set -e
 unset MERGE_QUEUE_FORCE_PS_IDENTITY
+unset WATCH_SUPERVISOR_PID_GATE_STATE
 wait_exists "$WATCH_SUPERVISOR_PID_GATE.entered" && ok "supervisor setup entered the explicit delay gate" || bad "supervisor setup bypassed the explicit delay gate"
 wait_exists "$WATCH_SUPERVISOR_PID_GATE.release" && ok "teardown released the delayed supervisor" || bad "teardown never released the delayed supervisor"
-rm -f -- "$WATCH_SUPERVISOR_PID_GATE.enabled" "$WATCH_SUPERVISOR_PID_GATE.entered" "$WATCH_SUPERVISOR_PID_GATE.release" "$WATCH_SUPERVISOR_PID_GATE.calls"
+eq "$(cat < "$WATCH_SUPERVISOR_PID_GATE.observed-status")" launch_failed "launch failure claims state before supervisor teardown"
+rm -f -- "$WATCH_SUPERVISOR_PID_GATE.enabled" "$WATCH_SUPERVISOR_PID_GATE.entered" "$WATCH_SUPERVISOR_PID_GATE.release" "$WATCH_SUPERVISOR_PID_GATE.calls" "$WATCH_SUPERVISOR_PID_GATE.observed-status"
 if [[ "$setup_rc" -ne 0 ]]; then ok "supervisor failure before ready exits nonzero"; else bad "supervisor failure before ready exited zero"; fi
 eq "$(jq -r .verdict "$artifact")" unknown "dead supervisor publishes its setup failure"
 old_inode=$(inode "$artifact")
@@ -570,6 +591,82 @@ kill -0 "$changed_identity_pid" 2>/dev/null && ok "teardown stops when the PID c
 unset MERGE_QUEUE_FORCE_PS_IDENTITY
 kill "$changed_identity_pid" 2>/dev/null || true; wait "$changed_identity_pid" 2>/dev/null || true
 touch "$RELEASE"
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+launch_bounded "$watch"
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+worker_pid=$(cat < "$WATCH_WORKER_PID")
+eq "$(cat < "$WATCH_WORKER_TOKEN")" unset "queue-wait worker does not inherit supervisor identity"
+jq --argjson pid "$worker_pid" '.supervisor_pid=$pid' "$state_path" > "$TMP/worker-pid-state.json"
+chmod 600 "$TMP/worker-pid-state.json"; mv "$TMP/worker-pid-state.json" "$state_path"
+export MERGE_QUEUE_FORCE_PS_IDENTITY=1
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+kill -0 "$worker_pid" 2>/dev/null && ok "reused worker PID cannot identify as supervisor" || bad "supervisor teardown signaled queue-wait descendant"
+unset MERGE_QUEUE_FORCE_PS_IDENTITY
+touch "$RELEASE"
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+launch_bounded "$watch"
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+identity=$(jq -r .supervisor_token "$state_path")
+env "MERGE_QUEUE_SUPERVISOR_TOKEN=$identity" bash -c 'while :; do sleep 1; done' "$SCRIPTS/queue-wait" 42 1 10 --json & wrong_command_pid=$!
+jq --argjson pid "$wrong_command_pid" '.supervisor_pid=$pid' "$state_path" > "$TMP/wrong-command-state.json"
+chmod 600 "$TMP/wrong-command-state.json"; mv "$TMP/wrong-command-state.json" "$state_path"
+export MERGE_QUEUE_FORCE_PS_IDENTITY=1
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+kill -0 "$wrong_command_pid" 2>/dev/null && ok "ps fallback requires supervisor command identity" || bad "ps fallback accepted non-supervisor command"
+unset MERGE_QUEUE_FORCE_PS_IDENTITY
+kill "$wrong_command_pid" 2>/dev/null || true; wait "$wrong_command_pid" 2>/dev/null || true
+touch "$RELEASE"
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+registration_runtime=$(jq -r .runtime_dir "$state_path"); worker_count=$(wc -l < "$WATCH_WORKER_LOG")
+rm -f -- "$WATCH_REGISTRATION_GATE.entered" "$WATCH_REGISTRATION_GATE.release"
+touch "$WATCH_REGISTRATION_GATE.enabled"
+"$SCRIPTS/merge-queue-watch" launch --root "$MAIN" --issue KEN-829 --watch-id "$watch" --poll 1 --max-wait 10 >"$TMP/registration-launch.out" 2>"$TMP/registration-launch.err" & registration_launch_pid=$!
+wait_exists "$WATCH_REGISTRATION_GATE.entered" || bad "supervisor did not pause before PID registration"
+wait_state "$state_path" launch_failed || bad "launch failure did not claim before PID registration"
+touch "$WATCH_REGISTRATION_GATE.release"
+set +e; wait "$registration_launch_pid"; registration_launch_rc=$?; set -e
+[[ "$registration_launch_rc" -ne 0 ]] && ok "post-check registration remains a launch failure" || bad "post-check registration revived launch"
+sleep 0.3
+eq "$(wc -l < "$WATCH_WORKER_LOG")" "$worker_count" "supervisor rechecks state after PID publication"
+registration_pid=$(cat < "$registration_runtime/supervisor.pid")
+if ! kill -0 "$registration_pid" 2>/dev/null; then ok "late-registering supervisor exits before deadline"; else bad "late-registering supervisor survived its failed generation"; fi
+touch "$RELEASE"
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+rm -f -- "$WATCH_REGISTRATION_GATE.enabled" "$WATCH_REGISTRATION_GATE.entered" "$WATCH_REGISTRATION_GATE.release"
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+launch_bounded "$watch"
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+legacy_supervisor=$(jq -r .supervisor_pid "$state_path")
+jq 'del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-watching.json"
+chmod 600 "$TMP/legacy-watching.json"; mv "$TMP/legacy-watching.json" "$state_path"
+result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
+eq "$(jq -r .action <<<"$result")" pending "legacy watching state remains active"
+kill -0 "$legacy_supervisor" 2>/dev/null && ok "legacy watching supervisor is preserved" || bad "legacy watching supervisor was terminated"
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+touch "$RELEASE"
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+legacy_runtime=$(jq -r .runtime_dir "$state_path")
+printf '%s\n' "$watch" > "$legacy_runtime/token"
+jq '.status="launch_failed"|.action="launch"|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-launch-failed.json"
+chmod 600 "$TMP/legacy-launch-failed.json"; mv "$TMP/legacy-launch-failed.json" "$state_path"
+launch_bounded "$watch"
+legacy_retry_state=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829)
+eq "$(jq -r .status <<<"$legacy_retry_state")" watching "legacy launch failure retries on a migrated generation"
+[[ "$(jq -r .runtime_dir <<<"$legacy_retry_state")" != "$legacy_runtime" ]] && ok "legacy retry receives an isolated runtime" || bad "legacy retry reused legacy runtime"
+if [[ "$(jq -r .status <<<"$legacy_retry_state")" == watching ]]; then
+  legacy_retry_artifact=$(jq -r .artifact_path <<<"$legacy_retry_state")
+  touch "$RELEASE"; wait_file "$legacy_retry_artifact" || bad "legacy retry verdict missing"
+  result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
+  eq "$(jq -r .action <<<"$result")" recovery "legacy retry verdict is consumable"
+fi
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
 "$SCRIPTS/merge-queue-watch" direct-merged --root "$MAIN" --issue KEN-829 --watch-id "$watch" >/dev/null

--- a/.agents/skills/orch/tests/merge_queue_watch.sh
+++ b/.agents/skills/orch/tests/merge_queue_watch.sh
@@ -16,6 +16,7 @@ inode() { stat -c %i "$1" 2>/dev/null || stat -f %i "$1"; }
 MAIN="$TMP/main" WT="$TMP/worktree" BIN="$TMP/bin" SCRIPTS="$TMP/orch/scripts"
 REAL_SETSID=$(command -v setsid || true)
 REAL_CHMOD=$(command -v chmod)
+REAL_FLOCK=$(command -v flock)
 mkdir -p "$MAIN" "$BIN" "$SCRIPTS/lib"
 git -C "$MAIN" init -q
 git -C "$MAIN" config user.email test@example.com
@@ -119,9 +120,20 @@ if [[ -f "$WATCH_SUPERVISOR_PID_DELAY" && "${*: -1}" == */supervisor.pid ]]; the
 exec "$WATCH_REAL_CHMOD" "$@"
 EOF
 chmod +x "$BIN/chmod"
+cat > "$BIN/flock" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ -f "$WATCH_FAIL_FLOCK_GATE.enabled" && "${1:-}" == -w ]]; then
+  rm -f -- "$WATCH_FAIL_FLOCK_GATE.enabled"
+  touch "$WATCH_FAIL_FLOCK_GATE.entered"
+  while [[ ! -f "$WATCH_FAIL_FLOCK_GATE.release" ]]; do sleep 0.05; done
+fi
+exec "$WATCH_REAL_FLOCK" "$@"
+EOF
+chmod +x "$BIN/flock"
 export PATH="$BIN:$PATH" WATCH_MODE="$MODE" WATCH_RELEASE="$RELEASE" WATCH_HEAD_FILE="$HEAD_FILE" WATCH_MAIN="$MAIN" WATCH_WORKTREE="$WT"
 export WATCH_GH_PAUSE="$TMP/gh-pause" WATCH_SETUP_GATE="$TMP/setup-gate" WATCH_REAL_SETSID="$REAL_SETSID" WATCH_CLEANUP_FAIL="$TMP/cleanup-fail" WATCH_CLEANUP_INTERRUPT="$TMP/cleanup-interrupt"
-export WATCH_SETSID_FAIL="$TMP/setsid-fail" WATCH_SETSID_DELAY="$TMP/setsid-delay" WATCH_CLEANUP_PAUSE="$TMP/cleanup-pause" WATCH_AUTH_LOG="$TMP/auth.log" WATCH_WORKER_LOG="$TMP/worker.log" WATCH_REAL_CHMOD="$REAL_CHMOD" WATCH_SUPERVISOR_PID_DELAY="$TMP/supervisor-pid-delay" GH_REPO=wrong/repository GITHUB_REPOSITORY=wrong/repository
+export WATCH_SETSID_FAIL="$TMP/setsid-fail" WATCH_SETSID_DELAY="$TMP/setsid-delay" WATCH_CLEANUP_PAUSE="$TMP/cleanup-pause" WATCH_AUTH_LOG="$TMP/auth.log" WATCH_WORKER_LOG="$TMP/worker.log" WATCH_REAL_CHMOD="$REAL_CHMOD" WATCH_REAL_FLOCK="$REAL_FLOCK" WATCH_FAIL_FLOCK_GATE="$TMP/fail-flock-gate" WATCH_SUPERVISOR_PID_DELAY="$TMP/supervisor-pid-delay" GH_REPO=wrong/repository GITHUB_REPOSITORY=wrong/repository
 unset GH_TOKEN GITHUB_TOKEN GH_BOT_TOKEN
 init_out=$("$SCRIPTS/merge-queue-watch" init --worktree "$WT" --issue KEN-829 --branch watch-test)
 eq "$(jq -r .exists <<<"$init_out")" true "standalone init creates workflow state"
@@ -403,6 +415,26 @@ eq "$(jq -r .action <<<"$result")" recovery "replacement verdict survives stale 
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 rm -f -- "$WATCH_GH_PAUSE.enabled" "$WATCH_GH_PAUSE.entered" "$WATCH_GH_PAUSE.release"
 
+old_release="$TMP/publication-old-release"; new_release="$TMP/publication-new-release"
+rm -f -- "$old_release" "$new_release"
+export WATCH_RELEASE="$old_release"
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
+launch_bounded "$watch"
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+jq '.status="launch_failed"|.action="launch"|.supervisor_pid=null' "$state_path" > "$TMP/publication-state.json"
+chmod 600 "$TMP/publication-state.json"; mv "$TMP/publication-state.json" "$state_path"
+export WATCH_RELEASE="$new_release"
+launch_bounded "$watch"
+publication_replacement=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .artifact_path)
+touch "$new_release"; wait_file "$publication_replacement" || bad "publication-fence replacement verdict missing"
+touch "$old_release"; sleep 0.5
+[[ ! -e "$artifact" ]] && ok "stale started supervisor cannot publish after replacement" || bad "publication fence admitted the stale started supervisor"
+eq "$(jq -r .verdict "$publication_replacement")" ejected "stale publication leaves the replacement verdict intact"
+result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
+eq "$(jq -r .action <<<"$result")" recovery "replacement verdict survives stale publication"
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+export WATCH_RELEASE="$RELEASE"
+
 if [[ -n "$REAL_SETSID" ]]; then
   prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
   delayed_runtime=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .runtime_dir)
@@ -417,9 +449,11 @@ if [[ -n "$REAL_SETSID" ]]; then
   [[ "$delayed_replacement_runtime" != "$delayed_runtime" ]] && ok "replacement attempt has its own runtime directory" || bad "replacement reused the delayed supervisor runtime"
   touch "$RELEASE"
   wait_file "$delayed_replacement_artifact" || bad "replacement verdict missing after delayed supervisor release"
+  worker_count=$(wc -l < "$WATCH_WORKER_LOG")
   printf 'malformed\n' > "$MODE"
   touch "$WATCH_SETSID_DELAY.release"
   sleep 0.5
+  eq "$(wc -l < "$WATCH_WORKER_LOG")" "$worker_count" "unregistered delayed supervisor cannot start a worker"
   [[ ! -e "$artifact" ]] && ok "unregistered delayed supervisor cannot publish into retry files" || bad "unregistered delayed supervisor published after retry"
   eq "$(jq -r .verdict "$delayed_replacement_artifact")" ejected "unregistered delayed supervisor cannot rewrite the replacement verdict"
   printf 'ejected\n' > "$MODE"
@@ -430,6 +464,43 @@ if [[ -n "$REAL_SETSID" ]]; then
 else
   ok "pre-PID supervisor fence skipped without setsid"
 fi
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+launch_bounded "$watch"
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+old_attempt=$(jq -r .launch_attempt_id "$state_path"); old_runtime=$(jq -r .runtime_dir "$state_path"); old_artifact=$(jq -r .artifact_path "$state_path")
+old_supervisor=$(jq -r .supervisor_pid "$state_path")
+touch "$WATCH_FAIL_FLOCK_GATE.enabled"
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >"$TMP/fail-race.out" 2>"$TMP/fail-race.err" & fail_race_pid=$!
+wait_exists "$WATCH_FAIL_FLOCK_GATE.entered" || bad "fail command did not pause after generation capture"
+jq '.status="launch_failed"|.action="launch"|.supervisor_pid=null' "$state_path" > "$TMP/fail-race-state.json"
+chmod 600 "$TMP/fail-race-state.json"; mv "$TMP/fail-race-state.json" "$state_path"
+launch_bounded "$watch"
+replacement_supervisor=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .supervisor_pid)
+replacement_artifact=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .artifact_path)
+touch "$WATCH_FAIL_FLOCK_GATE.release"
+set +e; wait "$fail_race_pid"; fail_race_rc=$?; set -e
+[[ "$fail_race_rc" -ne 0 ]] && ok "stale fail refuses after retry registration" || bad "stale fail reported success across retry"
+eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .status)" watching "stale fail leaves replacement state active"
+kill -0 "$replacement_supervisor" 2>/dev/null && ok "stale fail does not signal replacement supervisor" || bad "stale fail signaled replacement supervisor"
+kill -0 "$old_supervisor" 2>/dev/null && ok "stale fail does not confuse captured supervisor identity" || bad "stale fail signaled its captured supervisor after claim loss"
+touch "$RELEASE"; wait_file "$replacement_artifact" || bad "replacement verdict missing after stale fail"
+result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
+eq "$(jq -r .action <<<"$result")" recovery "replacement verdict survives stale fail"
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+rm -f -- "$WATCH_FAIL_FLOCK_GATE.entered" "$WATCH_FAIL_FLOCK_GATE.release"
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+launch_bounded "$watch"
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+attempt=$(jq -r .launch_attempt_id "$state_path"); runtime=$(jq -r .runtime_dir "$state_path"); artifact=$(jq -r .artifact_path "$state_path")
+bash -c 'while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$state_path" "$watch" "${attempt}0" "$runtime" "$artifact" 999 "$SCRIPTS/queue-wait" 1 10 & similar_attempt_pid=$!
+jq --argjson pid "$similar_attempt_pid" '.supervisor_pid=$pid' "$state_path" > "$TMP/similar-attempt-state.json"
+chmod 600 "$TMP/similar-attempt-state.json"; mv "$TMP/similar-attempt-state.json" "$state_path"
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+kill -0 "$similar_attempt_pid" 2>/dev/null && ok "attempt identity compares argv fields exactly" || bad "attempt-1 matched and signaled attempt-10"
+kill "$similar_attempt_pid" 2>/dev/null || true; wait "$similar_attempt_pid" 2>/dev/null || true
+touch "$RELEASE"
 
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
 "$SCRIPTS/merge-queue-watch" direct-merged --root "$MAIN" --issue KEN-829 --watch-id "$watch" >/dev/null

--- a/changelog.d/fixed/KEN-887.md
+++ b/changelog.d/fixed/KEN-887.md
@@ -1,0 +1,1 @@
+- Merge-queue watch retries now consume the replacement supervisor's verdict instead of the failed supervisor's stale result.

--- a/skills/orch/scripts/lib/merge-queue-state.sh
+++ b/skills/orch/scripts/lib/merge-queue-state.sh
@@ -1,7 +1,7 @@
 # shellcheck shell=bash
 
 MERGE_QUEUE_REPORT_FILTER='{issue_id,watch_id,status,action,repository,pr_number,head_sha,worktree_branch,
-  gate_mode,recovery_count,artifact_path,log_path,deadline,verdict,verdict_cause,
+  gate_mode,recovery_count,launch_attempt,launch_attempt_id,runtime_dir,artifact_path,log_path,deadline,verdict,verdict_cause,
   lane_postmerge,cleanup,diagnostic,error:(.diagnostic.error // null),
   worker_exit_code:(.diagnostic.worker_exit_code // null),
   diagnostic_path:(.diagnostic.diagnostic_path // .log_path)}'

--- a/skills/orch/scripts/lib/merge-queue-supervisor.sh
+++ b/skills/orch/scripts/lib/merge-queue-supervisor.sh
@@ -26,7 +26,7 @@ merge_queue_supervise() {
     (flock -w 10 9 || exit 1
       jq -e --arg watch "$watch_id" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" --arg token "$process_token" '
         .watch_id==$watch and .launch_attempt_id==$attempt and .runtime_dir==$runtime and .artifact_path==$artifact and
-        .supervisor_token==$token and (.status|IN("launching","watching"))' "$state_file" >/dev/null || exit 1
+        .supervisor_token==$token and (.status|IN("launching","watching","launch_failed"))' "$state_file" >/dev/null || exit 1
       ln "$output" "$artifact"
     ) 9>"$state_file.lock"
   }
@@ -71,12 +71,13 @@ merge_queue_supervise() {
     [[ $(date +%s) -lt "$deadline" ]] || printf 'deadline\n' > "$event_fifo"
   ) & watchdog_pid=$!
   printf '%s\n' "$$" > "$runtime/supervisor.pid"; chmod 600 "$runtime/supervisor.pid"
+  attempt_is_current || return 1
   set -m
   (
     exec 7>"$event_fifo"
     set +e
     cd "$main_root" || exit 1
-    env -u GH_REPO -u GITHUB_REPOSITORY GH_REPO="$repo" \
+    env -u GH_REPO -u GITHUB_REPOSITORY -u MERGE_QUEUE_SUPERVISOR_TOKEN GH_REPO="$repo" \
       "$waiter" "$pr" "$poll" "$max_wait" --json > "$temp" 2>> "$log"
     rc=$?; printf '%s\n' "$rc" > "$runtime/worker.status"; printf 'worker\n' >&7; exit "$rc"
   ) & worker_pid=$!

--- a/skills/orch/scripts/lib/merge-queue-supervisor.sh
+++ b/skills/orch/scripts/lib/merge-queue-supervisor.sh
@@ -4,28 +4,29 @@ merge_queue_supervise() {
   local state_file="$1" watch_id="$2" attempt_id="$3" runtime="$4" artifact="$5" deadline="$6"
   local waiter="$7" poll="$8" max_wait="$9"
   local repo pr head main_root log temp output worker_pid="" worker_rc=0 event=""
-  local event_fifo owner_fifo watchdog_pid="" published=false
+  local event_fifo owner_fifo watchdog_pid="" published=false process_token="${MERGE_QUEUE_SUPERVISOR_TOKEN:-}"
   repo=$(jq -r .repository "$state_file"); pr=$(jq -r .pr_number "$state_file")
   head=$(jq -r .head_sha "$state_file")
   main_root=$(jq -r .main_repo_root "$state_file")
   log=$(jq -r .log_path "$state_file"); temp="$runtime/worker.json"; output="$runtime/artifact.tmp"
   event_fifo="$runtime/events"; owner_fifo="$runtime/deadline-owner"
-  [[ -d "$runtime" && ! -L "$runtime" && "$(cat < "$runtime/token")" == "$attempt_id" ]] || return 1
+  [[ "$process_token" =~ ^[A-Za-z0-9._-]+$ && -d "$runtime" && ! -L "$runtime" && \
+     "$(cat < "$runtime/token")" == "$attempt_id" ]] || return 1
   [[ -d "$main_root" ]] || return 1
 
   attempt_is_current() {
     (flock -s -w 10 9 || exit 1
-      jq -e --arg watch "$watch_id" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" '
+      jq -e --arg watch "$watch_id" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" --arg token "$process_token" '
         .watch_id==$watch and .launch_attempt_id==$attempt and .runtime_dir==$runtime and .artifact_path==$artifact and
-        (.status|IN("launching","watching"))' "$state_file" >/dev/null
+        .supervisor_token==$token and (.status|IN("launching","watching"))' "$state_file" >/dev/null
     ) 9>"$state_file.lock"
   }
   publish_output() {
     chmod 600 "$output" || return 1
     (flock -w 10 9 || exit 1
-      jq -e --arg watch "$watch_id" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" '
+      jq -e --arg watch "$watch_id" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" --arg token "$process_token" '
         .watch_id==$watch and .launch_attempt_id==$attempt and .runtime_dir==$runtime and .artifact_path==$artifact and
-        (.status|IN("launching","watching"))' "$state_file" >/dev/null || exit 1
+        .supervisor_token==$token and (.status|IN("launching","watching"))' "$state_file" >/dev/null || exit 1
       ln "$output" "$artifact"
     ) 9>"$state_file.lock"
   }

--- a/skills/orch/scripts/lib/merge-queue-supervisor.sh
+++ b/skills/orch/scripts/lib/merge-queue-supervisor.sh
@@ -1,17 +1,35 @@
 # shellcheck shell=bash
 
 merge_queue_supervise() {
-  local state_file="$1" watch_id="$2" waiter="$3" poll="$4" max_wait="$5"
-  local repo pr head main_root artifact log runtime deadline temp output worker_pid="" worker_rc=0 event=""
+  local state_file="$1" watch_id="$2" attempt_id="$3" runtime="$4" artifact="$5" deadline="$6"
+  local waiter="$7" poll="$8" max_wait="$9"
+  local repo pr head main_root log temp output worker_pid="" worker_rc=0 event=""
   local event_fifo owner_fifo watchdog_pid="" published=false
   repo=$(jq -r .repository "$state_file"); pr=$(jq -r .pr_number "$state_file")
-  head=$(jq -r .head_sha "$state_file"); artifact=$(jq -r .artifact_path "$state_file")
+  head=$(jq -r .head_sha "$state_file")
   main_root=$(jq -r .main_repo_root "$state_file")
-  log=$(jq -r .log_path "$state_file"); runtime=$(jq -r .runtime_dir "$state_file")
-  deadline=$(jq -r .deadline "$state_file"); temp="$runtime/worker.json"; output="$runtime/artifact.tmp"
+  log=$(jq -r .log_path "$state_file"); temp="$runtime/worker.json"; output="$runtime/artifact.tmp"
   event_fifo="$runtime/events"; owner_fifo="$runtime/deadline-owner"
-  [[ -d "$runtime" && ! -L "$runtime" && "$(cat < "$runtime/token")" == "$watch_id" ]] || return 1
+  [[ -d "$runtime" && ! -L "$runtime" && "$(cat < "$runtime/token")" == "$attempt_id" ]] || return 1
   [[ -d "$main_root" ]] || return 1
+
+  attempt_is_current() {
+    (flock -s -w 10 9 || exit 1
+      jq -e --arg watch "$watch_id" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" '
+        .watch_id==$watch and .launch_attempt_id==$attempt and .runtime_dir==$runtime and .artifact_path==$artifact and
+        (.status|IN("launching","watching"))' "$state_file" >/dev/null
+    ) 9>"$state_file.lock"
+  }
+  publish_output() {
+    chmod 600 "$output" || return 1
+    (flock -w 10 9 || exit 1
+      jq -e --arg watch "$watch_id" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" '
+        .watch_id==$watch and .launch_attempt_id==$attempt and .runtime_dir==$runtime and .artifact_path==$artifact and
+        (.status|IN("launching","watching"))' "$state_file" >/dev/null || exit 1
+      ln "$output" "$artifact"
+    ) 9>"$state_file.lock"
+  }
+  attempt_is_current || return 1
 
   stop_worker() {
     local i
@@ -25,12 +43,12 @@ merge_queue_supervise() {
   publish_unknown() {
     local reason="$1" rc="$2"
     [[ -e "$artifact" ]] && return 0
-    jq -n --arg repo "$repo" --argjson pr "$pr" --arg head "$head" --arg watch "$watch_id" \
+    jq -n --arg repo "$repo" --argjson pr "$pr" --arg head "$head" --arg watch "$watch_id" --arg attempt "$attempt_id" \
       --arg reason "$reason" --argjson rc "$rc" --arg log "$log" \
       '{schema_version:1,status:"error",verdict:"unknown",repository:$repo,pr_number:$pr,
-        expected_head:$head,observed_head:"",watch_id:$watch,cause:$reason,
+        expected_head:$head,observed_head:"",watch_id:$watch,launch_attempt_id:$attempt,cause:$reason,
         worker_exit_code:$rc,diagnostic_path:$log}' > "$output" || return 1
-    chmod 600 "$output" && ln "$output" "$artifact" && published=true
+    publish_output && published=true
   }
   cleanup() {
     local rc=$?
@@ -73,10 +91,10 @@ merge_queue_supervise() {
       (.verdict|IN("merged","conflicting","ejected","disarmed","dequeued","closed","queued","not_queued","unknown"))' "$temp" >/dev/null 2>&1; then
     publish_unknown worker_output_invalid "$worker_rc"; trap - EXIT TERM HUP INT; return 0
   fi
-  jq --arg repo "$repo" --argjson pr "$pr" --arg head "$head" --arg watch "$watch_id" --arg log "$log" \
+  jq --arg repo "$repo" --argjson pr "$pr" --arg head "$head" --arg watch "$watch_id" --arg attempt "$attempt_id" --arg log "$log" \
     '. + {schema_version:1,repository:$repo,pr_number:$pr,expected_head:$head,
-      observed_head:"",watch_id:$watch,diagnostic_path:$log}' "$temp" > "$output"
-  chmod 600 "$output" && ln "$output" "$artifact" || return 1
+      observed_head:"",watch_id:$watch,launch_attempt_id:$attempt,diagnostic_path:$log}' "$temp" > "$output"
+  publish_output || return 1
   published=true; printf '%s\n' "$worker_rc" > "$runtime/terminal"; chmod 600 "$runtime/terminal"
   trap - EXIT TERM HUP INT
 }

--- a/skills/orch/scripts/merge-queue-watch
+++ b/skills/orch/scripts/merge-queue-watch
@@ -88,15 +88,27 @@ supervisor_pid() {
   printf '%s' "$pid"
 }
 supervisor_live() {
-  local pid="$1" attempt_id="$2" command
+  local pid="$1" attempt_id="$2" runtime="$3" artifact="$4" command arg i
+  local argv=()
   [[ "$pid" =~ ^[1-9][0-9]*$ ]] || return 1
   kill -0 "$pid" 2>/dev/null || return 1
-  command=$(ps -p "$pid" -o command= 2>/dev/null) || return 1
-  [[ "$command" == *"merge-queue-watch __supervise"* && "$command" == *"$WATCH_ID"* && "$command" == *"$attempt_id"* ]]
+  if [[ -r "/proc/$pid/cmdline" ]]; then
+    while IFS= read -r -d '' arg; do argv[${#argv[@]}]="$arg"; done < "/proc/$pid/cmdline"
+  else
+    [[ "$SELF$STATE_FILE$WATCH_ID$attempt_id$runtime$artifact" != *[[:space:]]* ]] || return 1
+    command=$(ps -ww -p "$pid" -o command= 2>/dev/null) || return 1
+    read -r -a argv <<<"$command"
+  fi
+  for ((i=0; i+6<${#argv[@]}; i++)); do
+    [[ "${argv[i]}" == "$SELF" && "${argv[i+1]}" == __supervise && "${argv[i+2]}" == "$STATE_FILE" &&
+       "${argv[i+3]}" == "$WATCH_ID" && "${argv[i+4]}" == "$attempt_id" && "${argv[i+5]}" == "$runtime" &&
+       "${argv[i+6]}" == "$artifact" ]] && return 0
+  done
+  return 1
 }
 terminate_supervisor() {
-  local pid="$1" attempt_id="$2" i
-  supervisor_live "$pid" "$attempt_id" || return 0
+  local pid="$1" attempt_id="$2" runtime="$3" artifact="$4" i
+  supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" || return 0
   kill -TERM "$pid" 2>/dev/null || true
   for ((i=0; i<50; i++)); do kill -0 "$pid" 2>/dev/null || return 0; sleep 0.1; done
   kill -KILL "$pid" 2>/dev/null || true
@@ -104,13 +116,13 @@ terminate_supervisor() {
   return 1
 }
 launch_failure() {
-  local detail="$1" attempt_id="$2" runtime="$3" pid="${4:-}"
-  pid=$(supervisor_pid "$runtime" "$pid"); [[ -z "$pid" ]] || terminate_supervisor "$pid" "$attempt_id" || true
-  atomic_update 'if .watch_id!=$watch or .launch_attempt_id!=$attempt or .runtime_dir!=$runtime or
+  local detail="$1" attempt_id="$2" runtime="$3" artifact="$4" pid="${5:-}"
+  pid=$(supervisor_pid "$runtime" "$pid"); [[ -z "$pid" ]] || terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" || true
+  atomic_update 'if .watch_id!=$watch or .launch_attempt_id!=$attempt or .runtime_dir!=$runtime or .artifact_path!=$artifact or
       (.status|IN("launching","watching")|not) then error("launch claim lost") else
       .status="launch_failed"|.action="launch"|.terminal=false|.supervisor_pid=null|
       .diagnostic={cause:"launch_failed",detail:$detail}|.updated_at=(now|floor) end' \
-    --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg detail "$detail" \
+    --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" --arg detail "$detail" \
     || die "could not claim launch recovery; inspect the active lifecycle before handback"
 }
 live_pr() {
@@ -237,7 +249,7 @@ launch() {
   fi
   if [[ "$method" == setsid ]]; then
     setsid -f "$SELF" __supervise "$STATE_FILE" "$WATCH_ID" "$attempt_id" "$runtime" "$artifact" "$deadline" "$waiter" "$poll" "$max_wait" >> "$log" 2>&1 \
-      || { launch_failure "setsid could not launch supervisor; see $log" "$attempt_id" "$runtime"; die "detached supervisor launch failed; see $log"; }
+      || { launch_failure "setsid could not launch supervisor; see $log" "$attempt_id" "$runtime" "$artifact"; die "detached supervisor launch failed; see $log"; }
   else
     nohup "$SELF" __supervise "$STATE_FILE" "$WATCH_ID" "$attempt_id" "$runtime" "$artifact" "$deadline" "$waiter" "$poll" "$max_wait" </dev/null >> "$log" 2>&1 &
   fi
@@ -247,17 +259,17 @@ launch() {
     sleep 0.05
   done
   if [[ ! -f "$ready" ]]; then
-    launch_failure "supervisor did not establish worker liveness; see $log" "$attempt_id" "$runtime"
+    launch_failure "supervisor did not establish worker liveness; see $log" "$attempt_id" "$runtime" "$artifact"
     tail -20 "$log" >&2 || true
     die "supervisor setup failed; diagnostics: $log"
   fi
   pid=$(cat < "$runtime/supervisor.pid")
-  [[ "$pid" =~ ^[1-9][0-9]*$ ]] || { launch_failure "supervisor pid is malformed" "$attempt_id" "$runtime"; die "supervisor pid is malformed"; }
+  [[ "$pid" =~ ^[1-9][0-9]*$ ]] || { launch_failure "supervisor pid is malformed" "$attempt_id" "$runtime" "$artifact"; die "supervisor pid is malformed"; }
   if ! atomic_update 'if .watch_id!=$watch or .launch_attempt_id!=$attempt or .runtime_dir!=$runtime or
       .artifact_path!=$artifact or .status!="launching" then error("launch claim lost") else
       .status="watching"|.supervisor_pid=$pid|.updated_at=(now|floor) end' \
       --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" --argjson pid "$pid"; then
-    terminate_supervisor "$pid" "$attempt_id" || true
+    terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" || true
     die "lifecycle was terminalized during launch"
   fi
   json_report
@@ -307,7 +319,7 @@ consume() {
   recovery=$(jq -r .recovery_count <<<"$snapshot"); log=$(jq -r .log_path <<<"$snapshot"); now=$(date +%s)
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
     pid=$(supervisor_pid "$runtime" "$recorded_pid")
-    if supervisor_live "$pid" "$attempt_id"; then
+    if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact"; then
       if [[ "$now" -le "$setup_deadline" ]]; then
         jq -cn --arg watch "$WATCH_ID" '{status:"launching",watch_id:$watch,action:"pending"}'; return
       fi
@@ -318,17 +330,17 @@ consume() {
     elif [[ -z "$pid" && "$now" -le "$setup_deadline" ]]; then
       jq -cn --arg watch "$WATCH_ID" '{status:"launching",watch_id:$watch,action:"pending"}'; return
     else
-      launch_failure "launching supervisor died or missed its setup deadline; see $log" "$attempt_id" "$runtime" "$recorded_pid"
+      launch_failure "launching supervisor died or missed its setup deadline; see $log" "$attempt_id" "$runtime" "$artifact" "$recorded_pid"
       consume_report; return
     fi
   fi
   if [[ ! -s "$artifact" ]]; then
     pid=$(supervisor_pid "$runtime" "$recorded_pid"); token="$runtime/token"
-    if [[ -f "$token" && "$(cat < "$token")" == "$attempt_id" && "$now" -le "$deadline" ]] && supervisor_live "$pid" "$attempt_id"; then
+    if [[ -f "$token" && "$(cat < "$token")" == "$attempt_id" && "$now" -le "$deadline" ]] && supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact"; then
       jq -cn --arg status pending --arg watch "$WATCH_ID" '{status:$status,watch_id:$watch,action:"pending"}'
       return
     fi
-    terminate_supervisor "$pid" "$attempt_id" || true
+    terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" || true
     fail_state watch_lost "artifact missing and supervisor dead or overdue; see $log" "$attempt_id" "$artifact"
     json_report; return
   fi
@@ -385,10 +397,10 @@ event() {
   deadline=$(jq -r '.deadline // 0' <<<"$snapshot"); setup_deadline=$(jq -r '.setup_deadline // 0' <<<"$snapshot")
   now=$(date +%s); pid=$(supervisor_pid "$runtime" "$recorded_pid")
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
-    if supervisor_live "$pid" "$attempt_id"; then [[ "$now" -le "$setup_deadline" ]] && exit 1; printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
+    if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact"; then [[ "$now" -le "$setup_deadline" ]] && exit 1; printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
     [[ -z "$pid" && "$now" -le "$setup_deadline" ]] && exit 1
   fi
-  if [[ -s "$artifact" ]] || [[ "$now" -gt "$deadline" ]] || ! supervisor_live "$pid" "$attempt_id"; then printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
+  if [[ -s "$artifact" ]] || [[ "$now" -gt "$deadline" ]] || ! supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact"; then printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
   exit 1
 }
 
@@ -431,15 +443,26 @@ acknowledge() {
 }
 
 fail_command() {
-  local cause="" snapshot attempt_id runtime recorded_pid pid
+  local cause="" snapshot fresh attempt_id runtime artifact recorded_pid pid i fresh_attempt fresh_artifact
   while [[ $# -gt 0 ]]; do case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;;
     --watch-id) WATCH_ID="${2:-}"; shift 2 ;; --cause) cause="${2:-}"; shift 2 ;; *) die "unknown fail option: $1" ;; esac; done
   resolve_state; require_state; [[ "$cause" =~ ^(arm_failed|merge_blocked|launch_failed|operator_abandoned)$ ]] || die "invalid failure cause"
-  snapshot=$(state_snapshot) || die "cannot snapshot active launch attempt"
-  WATCH_ID="${WATCH_ID:-$(jq -r .watch_id <<<"$snapshot")}"
-  attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
-  recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot"); pid=$(supervisor_pid "$runtime" "$recorded_pid")
-  fail_state "$cause" "$cause"; terminate_supervisor "$pid" "$attempt_id" || true; json_report
+  for ((i=0; i<2; i++)); do
+    snapshot=$(state_snapshot) || die "cannot snapshot active launch attempt"
+    WATCH_ID="${WATCH_ID:-$(jq -r .watch_id <<<"$snapshot")}"
+    attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
+    artifact=$(jq -r .artifact_path <<<"$snapshot"); recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot")
+    pid=$(supervisor_pid "$runtime" "$recorded_pid")
+    if fail_state "$cause" "$cause" "$attempt_id" "$artifact"; then
+      terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" || true
+      json_report; return
+    fi
+    fresh=$(state_snapshot) || die "cannot resnapshot launch attempt after failure claim loss"
+    fresh_attempt=$(jq -r '.launch_attempt_id // empty' <<<"$fresh"); fresh_artifact=$(jq -r .artifact_path <<<"$fresh")
+    [[ "$fresh_attempt" == "$attempt_id" && "$fresh_artifact" == "$artifact" ]] \
+      || die "launch attempt changed before failure claim; replacement was left active"
+  done
+  die "could not claim failure for the active launch attempt"
 }
 
 inspect() { parse_root_issue "$@"; cat < "$STATE_FILE"; }

--- a/skills/orch/scripts/merge-queue-watch
+++ b/skills/orch/scripts/merge-queue-watch
@@ -58,6 +58,26 @@ atomic_update() {
     chmod 600 "$tmp" && mv -f -- "$tmp" "$STATE_FILE"
   ) 9>"$STATE_FILE.lock"
 }
+migrate_legacy_state() {
+  local snapshot status watch artifact runtime watch_dir runtime_root legacy_id
+  snapshot=$(state_snapshot) || die "cannot inspect durable watch generation"
+  status=$(jq -r .status <<<"$snapshot")
+  [[ "$status" == watching || "$status" == launch_failed ]] || return 0
+  [[ "$(jq -r '.launch_attempt_id // empty' <<<"$snapshot")" == "" ||
+     "$(jq -r '.supervisor_token // empty' <<<"$snapshot")" == "" ||
+     "$(jq -r '.runtime_root // empty' <<<"$snapshot")" == "" ]] || return 0
+  watch=$(jq -r .watch_id <<<"$snapshot"); artifact=$(jq -r .artifact_path <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
+  watch_dir="${artifact%/*}"; runtime_root="$watch_dir/runtime-attempts"; legacy_id="$watch-legacy"
+  [[ -n "$watch" && "$watch_dir" != "$artifact" && -d "$watch_dir" && ! -L "$watch_dir" && "$runtime" == "$watch_dir/"* ]] \
+    || die "legacy durable watch paths are invalid"
+  mkdir -p -- "$runtime_root" || die "cannot create migrated runtime root: $runtime_root"
+  chmod 700 "$runtime_root" || die "cannot secure migrated runtime root: $runtime_root"
+  atomic_update 'if (.status|IN("watching","launch_failed")) and
+      ((.launch_attempt_id // "")=="" or (.supervisor_token // "")=="" or (.runtime_root // "")=="") then
+      .watch_dir=$watch_dir|.runtime_root=$runtime_root|.launch_attempt=1|.launch_attempt_id=$legacy|
+      .supervisor_token=$legacy|.legacy_generation=true|.updated_at=(now|floor) else . end' \
+    --arg watch_dir "$watch_dir" --arg runtime_root "$runtime_root" --arg legacy "$legacy_id"
+}
 fail_state() {
   local cause="$1" detail="$2" attempt_id="${3:-}" artifact="${4:-}"
   atomic_update 'if .watch_id != $watch or ($attempt!="" and
@@ -106,7 +126,7 @@ supervisor_live() {
     return 1
   fi
   command=$(ps eww -p "$pid" -o command= 2>/dev/null) || return 1
-  [[ " $command " == *" MERGE_QUEUE_SUPERVISOR_TOKEN=$supervisor_token "* ]]
+  [[ " $command " == *" __supervise "* && " $command " == *" MERGE_QUEUE_SUPERVISOR_TOKEN=$supervisor_token "* ]]
 }
 terminate_supervisor() {
   local pid="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" i
@@ -125,16 +145,21 @@ terminate_supervisor() {
   return 1
 }
 launch_failure() {
-  local detail="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" pid="${6:-}"
-  pid=$(supervisor_pid "$runtime" "$pid"); [[ -z "$pid" ]] || terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
+  local detail="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" pid="${6:-}" snapshot
   atomic_update 'if .watch_id!=$watch or .launch_attempt_id!=$attempt or .runtime_dir!=$runtime or .artifact_path!=$artifact or
       .supervisor_token!=$token or
       (.status|IN("launching","watching")|not) then error("launch claim lost") else
-      .status="launch_failed"|.action="launch"|.terminal=false|.supervisor_pid=null|
+      .status="launch_failed"|.action="launch"|.terminal=false|
       .diagnostic={cause:"launch_failed",detail:$detail}|.updated_at=(now|floor) end' \
     --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" \
     --arg token "$supervisor_token" --arg detail "$detail" \
     || die "could not claim launch recovery; inspect the active lifecycle before handback"
+  snapshot=$(state_snapshot) || die "cannot snapshot claimed launch failure"
+  pid=$(supervisor_pid "$runtime" "$(jq -r '.supervisor_pid // empty' <<<"$snapshot")")
+  [[ -z "$pid" ]] || terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
+  atomic_update 'if .watch_id==$watch and .launch_attempt_id==$attempt and .status=="launch_failed"
+      then .supervisor_pid=null|.updated_at=(now|floor) else error("launch failure claim changed") end' \
+    --arg watch "$WATCH_ID" --arg attempt "$attempt_id"
 }
 live_pr() {
   local repo pr router
@@ -218,6 +243,7 @@ launch() {
       --max-wait) max_wait="${2:-}"; shift 2 ;; *) die "unknown launch option: $1" ;; esac
   done
   resolve_state; require_state
+  migrate_legacy_state
   [[ "$poll" =~ ^[1-9][0-9]*$ && "$max_wait" =~ ^[1-9][0-9]*$ && "$poll" -le "$max_wait" ]] || die "invalid wait bounds"
   snapshot=$(state_snapshot) || die "cannot snapshot prepared lifecycle"
   status=$(jq -r .status <<<"$snapshot"); prior_attempt=$(jq -r '.launch_attempt // 0' <<<"$snapshot")
@@ -251,7 +277,7 @@ launch() {
   if ! atomic_update 'if .watch_id!=$watch or .head_sha!=$head or .status!=$status or (.launch_attempt // 0)!=$prior
       then error("prepared claim lost") else .artifact_path=$artifact|.runtime_dir=$runtime|
       .launch_attempt=$attempt|.launch_attempt_id=$attempt_id|.status="launching"|.action=null|.diagnostic=null|
-      .supervisor_pid=null|.supervisor_token=$token|.launch_method=$method|.launched_at=$now|
+      .supervisor_pid=null|.supervisor_token=$token|.legacy_generation=false|.launch_method=$method|.launched_at=$now|
       .setup_deadline=($now+10)|.deadline=$deadline|.updated_at=$now end' \
     --arg watch "$WATCH_ID" --arg head "$head" --arg status "$status" --argjson prior "$prior_attempt" \
     --arg runtime "$runtime" --arg artifact "$artifact" --arg attempt_id "$attempt_id" --arg token "$supervisor_token" --arg method "$method" \
@@ -320,8 +346,9 @@ claim() {
 
 consume() {
   parse_root_issue "$@"
+  migrate_legacy_state
   local snapshot status artifact runtime attempt_id supervisor_token pid recorded_pid deadline setup_deadline now runtime_token body live live_state
-  local observed expected repo pr verdict result cause action diag error_text exit_code diag_path unconfirmed recovery log
+  local observed expected repo pr verdict result cause action diag error_text exit_code diag_path unconfirmed recovery log legacy
   snapshot=$(state_snapshot) || die "cannot snapshot active launch attempt"
   WATCH_ID=$(jq -r .watch_id <<<"$snapshot"); status=$(jq -r .status <<<"$snapshot")
   case "$status" in claimed|launch_failed|failed|abandoned|awaiting_lane_postmerge|cleanup_pending|cleanup_complete|complete) consume_report; return ;; esac
@@ -331,6 +358,7 @@ consume() {
   deadline=$(jq -r '.deadline // 0' <<<"$snapshot"); setup_deadline=$(jq -r '.setup_deadline // 0' <<<"$snapshot")
   expected=$(jq -r .head_sha <<<"$snapshot"); repo=$(jq -r .repository <<<"$snapshot"); pr=$(jq -r .pr_number <<<"$snapshot")
   recovery=$(jq -r .recovery_count <<<"$snapshot"); log=$(jq -r .log_path <<<"$snapshot"); now=$(date +%s)
+  legacy=$(jq -r '.legacy_generation // false' <<<"$snapshot")
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
     pid=$(supervisor_pid "$runtime" "$recorded_pid")
     if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then
@@ -349,6 +377,13 @@ consume() {
       consume_report; return
     fi
   fi
+  if [[ "$legacy" == true && "$status" == watching && ! -s "$artifact" ]]; then
+    pid=$(supervisor_pid "$runtime" "$recorded_pid")
+    if [[ "$pid" =~ ^[1-9][0-9]*$ && "$now" -le "$deadline" ]] && kill -0 "$pid" 2>/dev/null; then
+      jq -cn --arg watch "$WATCH_ID" '{status:"watching",watch_id:$watch,action:"pending"}'
+      return
+    fi
+  fi
   if [[ ! -s "$artifact" ]]; then
     pid=$(supervisor_pid "$runtime" "$recorded_pid"); runtime_token="$runtime/token"
     if [[ -f "$runtime_token" && "$(cat < "$runtime_token")" == "$attempt_id" && "$now" -le "$deadline" ]] && \
@@ -356,12 +391,14 @@ consume() {
       jq -cn --arg status pending --arg watch "$WATCH_ID" '{status:$status,watch_id:$watch,action:"pending"}'
       return
     fi
-    terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
     fail_state watch_lost "artifact missing and supervisor dead or overdue; see $log" "$attempt_id" "$artifact"
+    pid=$(supervisor_pid "$runtime")
+    [[ -z "$pid" ]] || terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
     json_report; return
   fi
-  if ! jq -e --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg repo "$repo" --arg head "$expected" --argjson pr "$pr" '
-      type=="object" and .schema_version==1 and .watch_id==$watch and .launch_attempt_id==$attempt and .repository==$repo and
+  if ! jq -e --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg repo "$repo" --arg head "$expected" --argjson pr "$pr" --argjson legacy "$legacy" '
+      type=="object" and .schema_version==1 and .watch_id==$watch and
+      (.launch_attempt_id==$attempt or ($legacy and (.launch_attempt_id==null))) and .repository==$repo and
       .pr_number==$pr and .expected_head==$head and (.observed_head|type=="string") and
       (.status|IN("complete","timeout","error")) and (.verdict|IN("merged","conflicting","ejected","disarmed","dequeued","closed","queued","not_queued","unknown"))' "$artifact" >/dev/null; then
     fail_state malformed_artifact "verdict artifact is malformed or belongs to another launch attempt" "$attempt_id" "$artifact"
@@ -403,8 +440,8 @@ consume() {
 event() {
   while [[ $# -gt 0 ]]; do case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;; *) die "unknown event option: $1" ;; esac; done
   [[ -n "$ROOT" && -n "$ISSUE" ]] || die "--root and --issue are required"
-  resolve_state; [[ -f "$STATE_FILE" ]] || exit 1
-  local snapshot status artifact runtime attempt_id supervisor_token recorded_pid pid deadline setup_deadline now
+  resolve_state; [[ -f "$STATE_FILE" ]] || exit 1; migrate_legacy_state
+  local snapshot status artifact runtime attempt_id supervisor_token recorded_pid pid deadline setup_deadline now legacy
   snapshot=$(state_snapshot) || exit 1; WATCH_ID=$(jq -r .watch_id <<<"$snapshot")
   status=$(jq -r .status <<<"$snapshot"); [[ "$status" == watching || "$status" == launching || "$status" == launch_failed ]] || exit 1
   [[ "$status" == launch_failed ]] && { printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; }
@@ -412,7 +449,9 @@ event() {
   attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot")
   supervisor_token=$(jq -r '.supervisor_token // empty' <<<"$snapshot")
   deadline=$(jq -r '.deadline // 0' <<<"$snapshot"); setup_deadline=$(jq -r '.setup_deadline // 0' <<<"$snapshot")
-  now=$(date +%s); pid=$(supervisor_pid "$runtime" "$recorded_pid")
+  legacy=$(jq -r '.legacy_generation // false' <<<"$snapshot"); now=$(date +%s); pid=$(supervisor_pid "$runtime" "$recorded_pid")
+  if [[ "$legacy" == true && "$status" == watching && ! -s "$artifact" && "$pid" =~ ^[1-9][0-9]*$ &&
+        "$now" -le "$deadline" ]] && kill -0 "$pid" 2>/dev/null; then exit 1; fi
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
     if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then [[ "$now" -le "$setup_deadline" ]] && exit 1; printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
     [[ -z "$pid" && "$now" -le "$setup_deadline" ]] && exit 1
@@ -469,9 +508,10 @@ fail_command() {
     WATCH_ID="${WATCH_ID:-$(jq -r .watch_id <<<"$snapshot")}"
     attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
     artifact=$(jq -r .artifact_path <<<"$snapshot"); supervisor_token=$(jq -r '.supervisor_token // empty' <<<"$snapshot")
-    recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot")
-    pid=$(supervisor_pid "$runtime" "$recorded_pid")
     if fail_state "$cause" "$cause" "$attempt_id" "$artifact"; then
+      fresh=$(state_snapshot) || die "cannot snapshot claimed failure"
+      recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$fresh")
+      pid=$(supervisor_pid "$runtime" "$recorded_pid")
       terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
       json_report; return
     fi

--- a/skills/orch/scripts/merge-queue-watch
+++ b/skills/orch/scripts/merge-queue-watch
@@ -155,7 +155,7 @@ prepare() {
     '{schema_version:1,issue_id:$issue,repository:$repo,pr_number:$pr,head_sha:$head,
       watch_id:$watch,gate_mode:$gate,recovery_count:$recovery,main_repo_root:$root,
       worktree:$worktree,worktree_branch:$worktree_branch,artifact_path:$artifact,log_path:$log,runtime_dir:$runtime,
-      prepared_at:$now,status:"prepared",action:null,terminal:false,
+      prepared_at:$now,launch_attempt:0,status:"prepared",action:null,terminal:false,
       supervisor_pid:null,launched_at:null,deadline:null,lane_postmerge:null,
       cleanup:{required:$cleanup,status:"not_started",diagnostic:null},diagnostic:null}' > "$new_state"
   (
@@ -182,7 +182,7 @@ prepare() {
 }
 
 launch() {
-  local poll=30 max_wait=2400 method pid deadline now ready log runtime waiter
+  local poll=30 max_wait=2400 method pid deadline now ready log runtime waiter artifact retry_artifact attempt
   while [[ $# -gt 0 ]]; do
     case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;;
       --watch-id) WATCH_ID="${2:-}"; shift 2 ;; --poll) poll="${2:-}"; shift 2 ;;
@@ -191,6 +191,8 @@ launch() {
   resolve_state; require_state
   [[ "$poll" =~ ^[1-9][0-9]*$ && "$max_wait" =~ ^[1-9][0-9]*$ && "$poll" -le "$max_wait" ]] || die "invalid wait bounds"
   now=$(date +%s); deadline=$((now + max_wait + 90)); runtime=$(state_value .runtime_dir); log=$(state_value .log_path)
+  artifact=$(state_value .artifact_path); attempt=$(state_value '(.launch_attempt // 0) + 1')
+  retry_artifact="${artifact%/*}/verdict-$attempt.json"
   waiter="$SCRIPT_DIR/queue-wait"
   if [[ ! -x "$waiter" ]]; then
     launch_failure "queue-wait is missing: $waiter; diagnostics: $log"
@@ -198,9 +200,11 @@ launch() {
   fi
   if command -v setsid >/dev/null 2>&1; then method="setsid"; else method="nohup"; fi
   atomic_update 'if .watch_id!=$watch or .head_sha!=$head or (.status|IN("prepared","launch_failed")|not) then error("prepared claim lost") else
-      .status="launching"|.action=null|.diagnostic=null|.launch_method=$method|.launched_at=$now|
+      .artifact_path=(if .status=="launch_failed" then $retry_artifact else .artifact_path end)|
+      .launch_attempt=$attempt|.status="launching"|.action=null|.diagnostic=null|.launch_method=$method|.launched_at=$now|
       .setup_deadline=($now+10)|.deadline=$deadline|.updated_at=$now end' \
-    --arg watch "$WATCH_ID" --arg head "$(state_value .head_sha)" --arg method "$method" --argjson now "$now" --argjson deadline "$deadline" \
+    --arg watch "$WATCH_ID" --arg head "$(state_value .head_sha)" --arg method "$method" --arg retry_artifact "$retry_artifact" \
+    --argjson attempt "$attempt" --argjson now "$now" --argjson deadline "$deadline" \
     || die "prepared lifecycle was terminalized before launch"
   if [[ "$method" == setsid ]]; then
     setsid -f "$SELF" __supervise "$STATE_FILE" "$WATCH_ID" "$waiter" "$poll" "$max_wait" >> "$log" 2>&1 \

--- a/skills/orch/scripts/merge-queue-watch
+++ b/skills/orch/scripts/merge-queue-watch
@@ -276,6 +276,8 @@ launch() {
       --max-wait) max_wait="${2:-}"; shift 2 ;; *) die "unknown launch option: $1" ;; esac
   done
   resolve_state; require_state
+  exec 8>"$STATE_FILE.launch.lock"
+  flock -w 10 8 || die "another launch attempt owns generation reservation"
   migrate_legacy_state
   [[ "$poll" =~ ^[1-9][0-9]*$ && "$max_wait" =~ ^[1-9][0-9]*$ && "$poll" -le "$max_wait" ]] || die "invalid wait bounds"
   snapshot=$(state_snapshot) || die "cannot snapshot prepared lifecycle"
@@ -307,6 +309,12 @@ launch() {
       || die "prepared attempt runtime is invalid: $runtime"
   else
     runtime="$runtime_root/$attempt_id"; artifact="$watch_dir/verdict-$attempt_id.json"
+    if [[ -e "$runtime" ]]; then
+      [[ "$(jq -r .runtime_dir <<<"$snapshot")" != "$runtime" &&
+         "$(jq -r '.launch_attempt_id // empty' <<<"$snapshot")" != "$attempt_id" ]] \
+        || die "registered launch attempt runtime cannot be reclaimed: $runtime"
+      rm -rf -- "$runtime" || die "cannot reclaim unregistered launch attempt runtime: $runtime"
+    fi
     mkdir -- "$runtime" || die "cannot reserve launch attempt runtime: $runtime"
     created=true; chmod 700 "$runtime"
     printf '%s\n' "$attempt_id" > "$runtime/token" && chmod 600 "$runtime/token" \
@@ -324,6 +332,7 @@ launch() {
     $created && { rm -f -- "$runtime/token"; rmdir -- "$runtime" 2>/dev/null || true; }
     die "prepared lifecycle was terminalized before launch"
   fi
+  flock -u 8; exec 8>&-
   if [[ "$method" == setsid ]]; then
     env "MERGE_QUEUE_SUPERVISOR_TOKEN=$supervisor_token" setsid -f "$SELF" __supervise "$STATE_FILE" "$WATCH_ID" "$attempt_id" "$runtime" "$artifact" "$deadline" "$waiter" "$poll" "$max_wait" >> "$log" 2>&1 \
       || { launch_failure "setsid could not launch supervisor; see $log" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; die "detached supervisor launch failed; see $log"; }

--- a/skills/orch/scripts/merge-queue-watch
+++ b/skills/orch/scripts/merge-queue-watch
@@ -62,20 +62,29 @@ migrate_legacy_state() {
   local snapshot status watch artifact runtime watch_dir runtime_root legacy_id
   snapshot=$(state_snapshot) || die "cannot inspect durable watch generation"
   status=$(jq -r .status <<<"$snapshot")
-  [[ "$status" == launching || "$status" == watching || "$status" == launch_failed || "$status" == failed ]] || return 0
-  [[ "$(jq -r '.launch_attempt_id // empty' <<<"$snapshot")" == "" ||
-     "$(jq -r '.supervisor_token // empty' <<<"$snapshot")" == "" ||
-     "$(jq -r '.runtime_root // empty' <<<"$snapshot")" == "" ]] || return 0
+  [[ "$status" == prepared || "$status" == launching || "$status" == watching || "$status" == launch_failed || "$status" == failed ]] || return 0
+  if [[ "$status" == prepared ]]; then
+    [[ "$(jq -r '.watch_dir // empty' <<<"$snapshot")" == "" ||
+       "$(jq -r '.runtime_root // empty' <<<"$snapshot")" == "" ||
+       "$(jq -r '.launch_attempt // empty' <<<"$snapshot")" == "" ]] || return 0
+  else
+    [[ "$(jq -r '.launch_attempt_id // empty' <<<"$snapshot")" == "" ||
+       "$(jq -r '.supervisor_token // empty' <<<"$snapshot")" == "" ||
+       "$(jq -r '.runtime_root // empty' <<<"$snapshot")" == "" ]] || return 0
+  fi
   watch=$(jq -r .watch_id <<<"$snapshot"); artifact=$(jq -r .artifact_path <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
   watch_dir="${artifact%/*}"; runtime_root="$watch_dir/runtime-attempts"; legacy_id="$watch-legacy"
   [[ -n "$watch" && "$watch_dir" != "$artifact" && -d "$watch_dir" && ! -L "$watch_dir" && "$runtime" == "$watch_dir/"* ]] \
     || die "legacy durable watch paths are invalid"
   mkdir -p -- "$runtime_root" || die "cannot create migrated runtime root: $runtime_root"
   chmod 700 "$runtime_root" || die "cannot secure migrated runtime root: $runtime_root"
-  atomic_update 'if (.status|IN("launching","watching","launch_failed","failed")) and
-      ((.launch_attempt_id // "")=="" or (.supervisor_token // "")=="" or (.runtime_root // "")=="") then
-      .watch_dir=$watch_dir|.runtime_root=$runtime_root|.launch_attempt=1|.launch_attempt_id=$legacy|
-      .supervisor_token=$legacy|.legacy_generation=true|.updated_at=(now|floor) else . end' \
+  atomic_update 'if (.status=="prepared" and
+      ((.watch_dir // "")=="" or (.runtime_root // "")=="" or (.launch_attempt // null)==null)) or
+      ((.status|IN("launching","watching","launch_failed","failed")) and
+       ((.launch_attempt_id // "")=="" or (.supervisor_token // "")=="" or (.runtime_root // "")=="")) then
+      .watch_dir=$watch_dir|.runtime_root=$runtime_root|.legacy_generation=true|.updated_at=(now|floor)|
+      if .status=="prepared" then .launch_attempt=0|.launch_attempt_id=null|.supervisor_token=null
+      else .launch_attempt=1|.launch_attempt_id=$legacy|.supervisor_token=$legacy end else . end' \
     --arg watch_dir "$watch_dir" --arg runtime_root "$runtime_root" --arg legacy "$legacy_id"
 }
 fail_state() {
@@ -278,9 +287,13 @@ launch() {
   resolve_state; require_state
   exec 8>"$STATE_FILE.launch.lock"
   flock -w 10 8 || die "another launch attempt owns generation reservation"
+  snapshot=$(state_snapshot) || die "cannot snapshot prepared lifecycle"
+  [[ "$WATCH_ID" =~ ^[A-Za-z0-9._-]+$ && "$WATCH_ID" != *..* ]] || die "watch id is not path-safe: $WATCH_ID"
+  [[ "$(jq -r '.watch_id // empty' <<<"$snapshot")" == "$WATCH_ID" ]] || die "watch id does not match active lifecycle"
   migrate_legacy_state
   [[ "$poll" =~ ^[1-9][0-9]*$ && "$max_wait" =~ ^[1-9][0-9]*$ && "$poll" -le "$max_wait" ]] || die "invalid wait bounds"
   snapshot=$(state_snapshot) || die "cannot snapshot prepared lifecycle"
+  [[ "$(jq -r '.watch_id // empty' <<<"$snapshot")" == "$WATCH_ID" ]] || die "watch id changed during launch"
   status=$(jq -r .status <<<"$snapshot"); prior_attempt=$(jq -r '.launch_attempt // 0' <<<"$snapshot")
   [[ "$prior_attempt" =~ ^[0-9]+$ && ( "$status" == prepared || "$status" == launch_failed ) ]] || die "prepared claim lost"
   legacy=$(jq -r '.legacy_generation // false' <<<"$snapshot")
@@ -303,7 +316,7 @@ launch() {
     die "queue-wait is missing: $waiter; diagnostics: $log"
   fi
   runtime_root=$(jq -r .runtime_root <<<"$snapshot"); watch_dir=$(jq -r .watch_dir <<<"$snapshot")
-  if [[ "$prior_attempt" -eq 0 ]]; then
+  if [[ "$prior_attempt" -eq 0 && "$legacy" != true ]]; then
     runtime=$(jq -r .runtime_dir <<<"$snapshot"); artifact=$(jq -r .artifact_path <<<"$snapshot")
     [[ -d "$runtime" && ! -L "$runtime" && -f "$runtime/token" && "$(cat < "$runtime/token")" == "$attempt_id" ]] \
       || die "prepared attempt runtime is invalid: $runtime"

--- a/skills/orch/scripts/merge-queue-watch
+++ b/skills/orch/scripts/merge-queue-watch
@@ -62,7 +62,7 @@ migrate_legacy_state() {
   local snapshot status watch artifact runtime watch_dir runtime_root legacy_id
   snapshot=$(state_snapshot) || die "cannot inspect durable watch generation"
   status=$(jq -r .status <<<"$snapshot")
-  [[ "$status" == watching || "$status" == launch_failed ]] || return 0
+  [[ "$status" == launching || "$status" == watching || "$status" == launch_failed || "$status" == failed ]] || return 0
   [[ "$(jq -r '.launch_attempt_id // empty' <<<"$snapshot")" == "" ||
      "$(jq -r '.supervisor_token // empty' <<<"$snapshot")" == "" ||
      "$(jq -r '.runtime_root // empty' <<<"$snapshot")" == "" ]] || return 0
@@ -72,7 +72,7 @@ migrate_legacy_state() {
     || die "legacy durable watch paths are invalid"
   mkdir -p -- "$runtime_root" || die "cannot create migrated runtime root: $runtime_root"
   chmod 700 "$runtime_root" || die "cannot secure migrated runtime root: $runtime_root"
-  atomic_update 'if (.status|IN("watching","launch_failed")) and
+  atomic_update 'if (.status|IN("launching","watching","launch_failed","failed")) and
       ((.launch_attempt_id // "")=="" or (.supervisor_token // "")=="" or (.runtime_root // "")=="") then
       .watch_dir=$watch_dir|.runtime_root=$runtime_root|.launch_attempt=1|.launch_attempt_id=$legacy|
       .supervisor_token=$legacy|.legacy_generation=true|.updated_at=(now|floor) else . end' \
@@ -107,11 +107,18 @@ supervisor_pid() {
   fi
   printf '%s' "$pid"
 }
+process_running() {
+  local pid="$1" state
+  [[ "$pid" =~ ^[1-9][0-9]*$ ]] || return 1
+  state=$(ps -p "$pid" -o stat= 2>/dev/null) || return 1
+  state="${state//[[:space:]]/}"
+  [[ -n "$state" && "$state" != Z* ]]
+}
 supervisor_live() {
   local pid="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" command arg i argv_match=false
   local argv=()
   [[ "$pid" =~ ^[1-9][0-9]*$ && "$supervisor_token" =~ ^[A-Za-z0-9._-]+$ ]] || return 1
-  kill -0 "$pid" 2>/dev/null || return 1
+  process_running "$pid" || return 1
   if [[ -r "/proc/$pid/cmdline" && "${MERGE_QUEUE_FORCE_PS_IDENTITY:-0}" != 1 ]]; then
     while IFS= read -r -d '' arg; do argv[${#argv[@]}]="$arg"; done < "/proc/$pid/cmdline"
     for ((i=0; i+6<${#argv[@]}; i++)); do
@@ -128,6 +135,21 @@ supervisor_live() {
   command=$(ps eww -p "$pid" -o command= 2>/dev/null) || return 1
   [[ " $command " == *" __supervise "* && " $command " == *" MERGE_QUEUE_SUPERVISOR_TOKEN=$supervisor_token "* ]]
 }
+legacy_supervisor_live() {
+  local pid="$1" command arg i
+  local argv=()
+  process_running "$pid" || return 1
+  if [[ -r "/proc/$pid/cmdline" ]]; then
+    while IFS= read -r -d '' arg; do argv[${#argv[@]}]="$arg"; done < "/proc/$pid/cmdline"
+    for ((i=0; i+4<${#argv[@]}; i++)); do
+      [[ "${argv[i]}" == "$SELF" && "${argv[i+1]}" == __supervise && "${argv[i+2]}" == "$STATE_FILE" &&
+         "${argv[i+3]}" == "$WATCH_ID" && "${argv[i+4]}" == "$SCRIPT_DIR/queue-wait" ]] && return 0
+    done
+    return 1
+  fi
+  command=$(ps -ww -p "$pid" -o command= 2>/dev/null) || return 1
+  [[ "$command" == *"$SELF __supervise $STATE_FILE $WATCH_ID $SCRIPT_DIR/queue-wait "* ]]
+}
 terminate_supervisor() {
   local pid="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" i
   supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || return 0
@@ -142,6 +164,16 @@ terminate_supervisor() {
     supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || return 0
     sleep 0.1
   done
+  return 1
+}
+terminate_legacy_supervisor() {
+  local pid="$1" i
+  legacy_supervisor_live "$pid" || return 0
+  kill -TERM "$pid" 2>/dev/null || true
+  for ((i=0; i<50; i++)); do legacy_supervisor_live "$pid" || return 0; sleep 0.1; done
+  legacy_supervisor_live "$pid" || return 0
+  kill -KILL "$pid" 2>/dev/null || true
+  for ((i=0; i<20; i++)); do legacy_supervisor_live "$pid" || return 0; sleep 0.1; done
   return 1
 }
 launch_failure() {
@@ -379,7 +411,7 @@ consume() {
   fi
   if [[ "$legacy" == true && "$status" == watching && ! -s "$artifact" ]]; then
     pid=$(supervisor_pid "$runtime" "$recorded_pid")
-    if [[ "$pid" =~ ^[1-9][0-9]*$ && "$now" -le "$deadline" ]] && kill -0 "$pid" 2>/dev/null; then
+    if [[ "$now" -le "$deadline" ]] && legacy_supervisor_live "$pid"; then
       jq -cn --arg watch "$WATCH_ID" '{status:"watching",watch_id:$watch,action:"pending"}'
       return
     fi
@@ -393,7 +425,8 @@ consume() {
     fi
     fail_state watch_lost "artifact missing and supervisor dead or overdue; see $log" "$attempt_id" "$artifact"
     pid=$(supervisor_pid "$runtime")
-    [[ -z "$pid" ]] || terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
+    if [[ -n "$pid" && "$legacy" == true ]]; then terminate_legacy_supervisor "$pid" || true
+    elif [[ -n "$pid" ]]; then terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true; fi
     json_report; return
   fi
   if ! jq -e --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg repo "$repo" --arg head "$expected" --argjson pr "$pr" --argjson legacy "$legacy" '
@@ -450,8 +483,8 @@ event() {
   supervisor_token=$(jq -r '.supervisor_token // empty' <<<"$snapshot")
   deadline=$(jq -r '.deadline // 0' <<<"$snapshot"); setup_deadline=$(jq -r '.setup_deadline // 0' <<<"$snapshot")
   legacy=$(jq -r '.legacy_generation // false' <<<"$snapshot"); now=$(date +%s); pid=$(supervisor_pid "$runtime" "$recorded_pid")
-  if [[ "$legacy" == true && "$status" == watching && ! -s "$artifact" && "$pid" =~ ^[1-9][0-9]*$ &&
-        "$now" -le "$deadline" ]] && kill -0 "$pid" 2>/dev/null; then exit 1; fi
+  if [[ "$legacy" == true && "$status" == watching && ! -s "$artifact" && "$now" -le "$deadline" ]] &&
+      legacy_supervisor_live "$pid"; then exit 1; fi
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
     if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then [[ "$now" -le "$setup_deadline" ]] && exit 1; printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
     [[ -z "$pid" && "$now" -le "$setup_deadline" ]] && exit 1
@@ -499,20 +532,23 @@ acknowledge() {
 }
 
 fail_command() {
-  local cause="" snapshot fresh attempt_id runtime artifact supervisor_token recorded_pid pid i fresh_attempt fresh_artifact
+  local cause="" snapshot fresh attempt_id runtime artifact supervisor_token recorded_pid pid i fresh_attempt fresh_artifact legacy
   while [[ $# -gt 0 ]]; do case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;;
     --watch-id) WATCH_ID="${2:-}"; shift 2 ;; --cause) cause="${2:-}"; shift 2 ;; *) die "unknown fail option: $1" ;; esac; done
   resolve_state; require_state; [[ "$cause" =~ ^(arm_failed|merge_blocked|launch_failed|operator_abandoned)$ ]] || die "invalid failure cause"
+  migrate_legacy_state
   for ((i=0; i<2; i++)); do
     snapshot=$(state_snapshot) || die "cannot snapshot active launch attempt"
     WATCH_ID="${WATCH_ID:-$(jq -r .watch_id <<<"$snapshot")}"
     attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
     artifact=$(jq -r .artifact_path <<<"$snapshot"); supervisor_token=$(jq -r '.supervisor_token // empty' <<<"$snapshot")
+    legacy=$(jq -r '.legacy_generation // false' <<<"$snapshot")
     if fail_state "$cause" "$cause" "$attempt_id" "$artifact"; then
       fresh=$(state_snapshot) || die "cannot snapshot claimed failure"
       recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$fresh")
       pid=$(supervisor_pid "$runtime" "$recorded_pid")
-      terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
+      if [[ "$legacy" == true ]]; then terminate_legacy_supervisor "$pid" || true
+      else terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true; fi
       json_report; return
     fi
     fresh=$(state_snapshot) || die "cannot resnapshot launch attempt after failure claim loss"

--- a/skills/orch/scripts/merge-queue-watch
+++ b/skills/orch/scripts/merge-queue-watch
@@ -88,41 +88,52 @@ supervisor_pid() {
   printf '%s' "$pid"
 }
 supervisor_live() {
-  local pid="$1" attempt_id="$2" runtime="$3" artifact="$4" command arg i
+  local pid="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" command arg i argv_match=false
   local argv=()
-  [[ "$pid" =~ ^[1-9][0-9]*$ ]] || return 1
+  [[ "$pid" =~ ^[1-9][0-9]*$ && "$supervisor_token" =~ ^[A-Za-z0-9._-]+$ ]] || return 1
   kill -0 "$pid" 2>/dev/null || return 1
-  if [[ -r "/proc/$pid/cmdline" ]]; then
+  if [[ -r "/proc/$pid/cmdline" && "${MERGE_QUEUE_FORCE_PS_IDENTITY:-0}" != 1 ]]; then
     while IFS= read -r -d '' arg; do argv[${#argv[@]}]="$arg"; done < "/proc/$pid/cmdline"
-  else
-    [[ "$SELF$STATE_FILE$WATCH_ID$attempt_id$runtime$artifact" != *[[:space:]]* ]] || return 1
-    command=$(ps -ww -p "$pid" -o command= 2>/dev/null) || return 1
-    read -r -a argv <<<"$command"
+    for ((i=0; i+6<${#argv[@]}; i++)); do
+      [[ "${argv[i]}" == "$SELF" && "${argv[i+1]}" == __supervise && "${argv[i+2]}" == "$STATE_FILE" &&
+         "${argv[i+3]}" == "$WATCH_ID" && "${argv[i+4]}" == "$attempt_id" && "${argv[i+5]}" == "$runtime" &&
+         "${argv[i+6]}" == "$artifact" ]] && { argv_match=true; break; }
+    done
+    $argv_match || return 1
+    while IFS= read -r -d '' arg; do
+      [[ "$arg" == "MERGE_QUEUE_SUPERVISOR_TOKEN=$supervisor_token" ]] && return 0
+    done < "/proc/$pid/environ"
+    return 1
   fi
-  for ((i=0; i+6<${#argv[@]}; i++)); do
-    [[ "${argv[i]}" == "$SELF" && "${argv[i+1]}" == __supervise && "${argv[i+2]}" == "$STATE_FILE" &&
-       "${argv[i+3]}" == "$WATCH_ID" && "${argv[i+4]}" == "$attempt_id" && "${argv[i+5]}" == "$runtime" &&
-       "${argv[i+6]}" == "$artifact" ]] && return 0
+  command=$(ps eww -p "$pid" -o command= 2>/dev/null) || return 1
+  [[ " $command " == *" MERGE_QUEUE_SUPERVISOR_TOKEN=$supervisor_token "* ]]
+}
+terminate_supervisor() {
+  local pid="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" i
+  supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || return 0
+  kill -TERM "$pid" 2>/dev/null || true
+  for ((i=0; i<50; i++)); do
+    supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || return 0
+    sleep 0.1
+  done
+  supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || return 0
+  kill -KILL "$pid" 2>/dev/null || true
+  for ((i=0; i<20; i++)); do
+    supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || return 0
+    sleep 0.1
   done
   return 1
 }
-terminate_supervisor() {
-  local pid="$1" attempt_id="$2" runtime="$3" artifact="$4" i
-  supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" || return 0
-  kill -TERM "$pid" 2>/dev/null || true
-  for ((i=0; i<50; i++)); do kill -0 "$pid" 2>/dev/null || return 0; sleep 0.1; done
-  kill -KILL "$pid" 2>/dev/null || true
-  for ((i=0; i<20; i++)); do kill -0 "$pid" 2>/dev/null || return 0; sleep 0.1; done
-  return 1
-}
 launch_failure() {
-  local detail="$1" attempt_id="$2" runtime="$3" artifact="$4" pid="${5:-}"
-  pid=$(supervisor_pid "$runtime" "$pid"); [[ -z "$pid" ]] || terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" || true
+  local detail="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" pid="${6:-}"
+  pid=$(supervisor_pid "$runtime" "$pid"); [[ -z "$pid" ]] || terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
   atomic_update 'if .watch_id!=$watch or .launch_attempt_id!=$attempt or .runtime_dir!=$runtime or .artifact_path!=$artifact or
+      .supervisor_token!=$token or
       (.status|IN("launching","watching")|not) then error("launch claim lost") else
       .status="launch_failed"|.action="launch"|.terminal=false|.supervisor_pid=null|
       .diagnostic={cause:"launch_failed",detail:$detail}|.updated_at=(now|floor) end' \
-    --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" --arg detail "$detail" \
+    --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" \
+    --arg token "$supervisor_token" --arg detail "$detail" \
     || die "could not claim launch recovery; inspect the active lifecycle before handback"
 }
 live_pr() {
@@ -173,7 +184,7 @@ prepare() {
       worktree:$worktree,worktree_branch:$worktree_branch,watch_dir:$watch_dir,artifact_path:$artifact,log_path:$log,
       runtime_root:$runtime_root,runtime_dir:$runtime,prepared_at:$now,launch_attempt:0,launch_attempt_id:null,
       status:"prepared",action:null,terminal:false,
-      supervisor_pid:null,launched_at:null,deadline:null,lane_postmerge:null,
+      supervisor_pid:null,supervisor_token:null,launched_at:null,deadline:null,lane_postmerge:null,
       cleanup:{required:$cleanup,status:"not_started",diagnostic:null},diagnostic:null}' > "$new_state"
   (
     flock -w 10 9 || exit 1
@@ -199,7 +210,7 @@ prepare() {
 }
 
 launch() {
-  local poll=30 max_wait=2400 method pid deadline now ready log runtime waiter artifact attempt attempt_id
+  local poll=30 max_wait=2400 method pid deadline now ready log runtime waiter artifact attempt attempt_id supervisor_token
   local snapshot status prior_attempt head runtime_root watch_dir created=false
   while [[ $# -gt 0 ]]; do
     case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;;
@@ -211,7 +222,8 @@ launch() {
   snapshot=$(state_snapshot) || die "cannot snapshot prepared lifecycle"
   status=$(jq -r .status <<<"$snapshot"); prior_attempt=$(jq -r '.launch_attempt // 0' <<<"$snapshot")
   [[ "$prior_attempt" =~ ^[0-9]+$ && ( "$status" == prepared || "$status" == launch_failed ) ]] || die "prepared claim lost"
-  attempt=$((prior_attempt+1)); attempt_id="$WATCH_ID-attempt-$attempt"; head=$(jq -r .head_sha <<<"$snapshot")
+  attempt=$((prior_attempt+1)); attempt_id="$WATCH_ID-attempt-$attempt"; supervisor_token="$attempt_id-$RANDOM$RANDOM"
+  head=$(jq -r .head_sha <<<"$snapshot")
   now=$(date +%s); deadline=$((now + max_wait + 90)); log=$(jq -r .log_path <<<"$snapshot")
   waiter="$SCRIPT_DIR/queue-wait"
   if [[ ! -x "$waiter" ]]; then
@@ -239,19 +251,19 @@ launch() {
   if ! atomic_update 'if .watch_id!=$watch or .head_sha!=$head or .status!=$status or (.launch_attempt // 0)!=$prior
       then error("prepared claim lost") else .artifact_path=$artifact|.runtime_dir=$runtime|
       .launch_attempt=$attempt|.launch_attempt_id=$attempt_id|.status="launching"|.action=null|.diagnostic=null|
-      .supervisor_pid=null|.launch_method=$method|.launched_at=$now|
+      .supervisor_pid=null|.supervisor_token=$token|.launch_method=$method|.launched_at=$now|
       .setup_deadline=($now+10)|.deadline=$deadline|.updated_at=$now end' \
     --arg watch "$WATCH_ID" --arg head "$head" --arg status "$status" --argjson prior "$prior_attempt" \
-    --arg runtime "$runtime" --arg artifact "$artifact" --arg attempt_id "$attempt_id" --arg method "$method" \
+    --arg runtime "$runtime" --arg artifact "$artifact" --arg attempt_id "$attempt_id" --arg token "$supervisor_token" --arg method "$method" \
     --argjson attempt "$attempt" --argjson now "$now" --argjson deadline "$deadline"; then
     $created && { rm -f -- "$runtime/token"; rmdir -- "$runtime" 2>/dev/null || true; }
     die "prepared lifecycle was terminalized before launch"
   fi
   if [[ "$method" == setsid ]]; then
-    setsid -f "$SELF" __supervise "$STATE_FILE" "$WATCH_ID" "$attempt_id" "$runtime" "$artifact" "$deadline" "$waiter" "$poll" "$max_wait" >> "$log" 2>&1 \
-      || { launch_failure "setsid could not launch supervisor; see $log" "$attempt_id" "$runtime" "$artifact"; die "detached supervisor launch failed; see $log"; }
+    env "MERGE_QUEUE_SUPERVISOR_TOKEN=$supervisor_token" setsid -f "$SELF" __supervise "$STATE_FILE" "$WATCH_ID" "$attempt_id" "$runtime" "$artifact" "$deadline" "$waiter" "$poll" "$max_wait" >> "$log" 2>&1 \
+      || { launch_failure "setsid could not launch supervisor; see $log" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; die "detached supervisor launch failed; see $log"; }
   else
-    nohup "$SELF" __supervise "$STATE_FILE" "$WATCH_ID" "$attempt_id" "$runtime" "$artifact" "$deadline" "$waiter" "$poll" "$max_wait" </dev/null >> "$log" 2>&1 &
+    env "MERGE_QUEUE_SUPERVISOR_TOKEN=$supervisor_token" nohup "$SELF" __supervise "$STATE_FILE" "$WATCH_ID" "$attempt_id" "$runtime" "$artifact" "$deadline" "$waiter" "$poll" "$max_wait" </dev/null >> "$log" 2>&1 &
   fi
   ready="$runtime/ready"
   for ((i=0; i<100; i++)); do
@@ -259,17 +271,18 @@ launch() {
     sleep 0.05
   done
   if [[ ! -f "$ready" ]]; then
-    launch_failure "supervisor did not establish worker liveness; see $log" "$attempt_id" "$runtime" "$artifact"
+    launch_failure "supervisor did not establish worker liveness; see $log" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"
     tail -20 "$log" >&2 || true
     die "supervisor setup failed; diagnostics: $log"
   fi
   pid=$(cat < "$runtime/supervisor.pid")
-  [[ "$pid" =~ ^[1-9][0-9]*$ ]] || { launch_failure "supervisor pid is malformed" "$attempt_id" "$runtime" "$artifact"; die "supervisor pid is malformed"; }
+  [[ "$pid" =~ ^[1-9][0-9]*$ ]] || { launch_failure "supervisor pid is malformed" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; die "supervisor pid is malformed"; }
   if ! atomic_update 'if .watch_id!=$watch or .launch_attempt_id!=$attempt or .runtime_dir!=$runtime or
-      .artifact_path!=$artifact or .status!="launching" then error("launch claim lost") else
+      .artifact_path!=$artifact or .supervisor_token!=$token or .status!="launching" then error("launch claim lost") else
       .status="watching"|.supervisor_pid=$pid|.updated_at=(now|floor) end' \
-      --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" --argjson pid "$pid"; then
-    terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" || true
+      --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" \
+      --arg token "$supervisor_token" --argjson pid "$pid"; then
+    terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
     die "lifecycle was terminalized during launch"
   fi
   json_report
@@ -307,40 +320,43 @@ claim() {
 
 consume() {
   parse_root_issue "$@"
-  local snapshot status artifact runtime attempt_id pid recorded_pid deadline setup_deadline now token body live live_state
+  local snapshot status artifact runtime attempt_id supervisor_token pid recorded_pid deadline setup_deadline now runtime_token body live live_state
   local observed expected repo pr verdict result cause action diag error_text exit_code diag_path unconfirmed recovery log
   snapshot=$(state_snapshot) || die "cannot snapshot active launch attempt"
   WATCH_ID=$(jq -r .watch_id <<<"$snapshot"); status=$(jq -r .status <<<"$snapshot")
   case "$status" in claimed|launch_failed|failed|abandoned|awaiting_lane_postmerge|cleanup_pending|cleanup_complete|complete) consume_report; return ;; esac
   artifact=$(jq -r .artifact_path <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
   attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot")
+  supervisor_token=$(jq -r '.supervisor_token // empty' <<<"$snapshot")
   deadline=$(jq -r '.deadline // 0' <<<"$snapshot"); setup_deadline=$(jq -r '.setup_deadline // 0' <<<"$snapshot")
   expected=$(jq -r .head_sha <<<"$snapshot"); repo=$(jq -r .repository <<<"$snapshot"); pr=$(jq -r .pr_number <<<"$snapshot")
   recovery=$(jq -r .recovery_count <<<"$snapshot"); log=$(jq -r .log_path <<<"$snapshot"); now=$(date +%s)
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
     pid=$(supervisor_pid "$runtime" "$recorded_pid")
-    if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact"; then
+    if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then
       if [[ "$now" -le "$setup_deadline" ]]; then
         jq -cn --arg watch "$WATCH_ID" '{status:"launching",watch_id:$watch,action:"pending"}'; return
       fi
       atomic_update 'if .watch_id==$watch and .launch_attempt_id==$attempt and .runtime_dir==$runtime and
-          .artifact_path==$artifact and .status=="launching" then .status="watching"|.supervisor_pid=$pid|.updated_at=(now|floor)
+          .artifact_path==$artifact and .supervisor_token==$token and .status=="launching"
+          then .status="watching"|.supervisor_pid=$pid|.updated_at=(now|floor)
           else error("launch attempt changed") end' --arg watch "$WATCH_ID" --arg attempt "$attempt_id" \
-        --arg runtime "$runtime" --arg artifact "$artifact" --argjson pid "$pid"; status=watching
+        --arg runtime "$runtime" --arg artifact "$artifact" --arg token "$supervisor_token" --argjson pid "$pid"; status=watching
     elif [[ -z "$pid" && "$now" -le "$setup_deadline" ]]; then
       jq -cn --arg watch "$WATCH_ID" '{status:"launching",watch_id:$watch,action:"pending"}'; return
     else
-      launch_failure "launching supervisor died or missed its setup deadline; see $log" "$attempt_id" "$runtime" "$artifact" "$recorded_pid"
+      launch_failure "launching supervisor died or missed its setup deadline; see $log" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" "$recorded_pid"
       consume_report; return
     fi
   fi
   if [[ ! -s "$artifact" ]]; then
-    pid=$(supervisor_pid "$runtime" "$recorded_pid"); token="$runtime/token"
-    if [[ -f "$token" && "$(cat < "$token")" == "$attempt_id" && "$now" -le "$deadline" ]] && supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact"; then
+    pid=$(supervisor_pid "$runtime" "$recorded_pid"); runtime_token="$runtime/token"
+    if [[ -f "$runtime_token" && "$(cat < "$runtime_token")" == "$attempt_id" && "$now" -le "$deadline" ]] && \
+        supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then
       jq -cn --arg status pending --arg watch "$WATCH_ID" '{status:$status,watch_id:$watch,action:"pending"}'
       return
     fi
-    terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" || true
+    terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
     fail_state watch_lost "artifact missing and supervisor dead or overdue; see $log" "$attempt_id" "$artifact"
     json_report; return
   fi
@@ -388,19 +404,20 @@ event() {
   while [[ $# -gt 0 ]]; do case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;; *) die "unknown event option: $1" ;; esac; done
   [[ -n "$ROOT" && -n "$ISSUE" ]] || die "--root and --issue are required"
   resolve_state; [[ -f "$STATE_FILE" ]] || exit 1
-  local snapshot status artifact runtime attempt_id recorded_pid pid deadline setup_deadline now
+  local snapshot status artifact runtime attempt_id supervisor_token recorded_pid pid deadline setup_deadline now
   snapshot=$(state_snapshot) || exit 1; WATCH_ID=$(jq -r .watch_id <<<"$snapshot")
   status=$(jq -r .status <<<"$snapshot"); [[ "$status" == watching || "$status" == launching || "$status" == launch_failed ]] || exit 1
   [[ "$status" == launch_failed ]] && { printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; }
   artifact=$(jq -r .artifact_path <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
   attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot")
+  supervisor_token=$(jq -r '.supervisor_token // empty' <<<"$snapshot")
   deadline=$(jq -r '.deadline // 0' <<<"$snapshot"); setup_deadline=$(jq -r '.setup_deadline // 0' <<<"$snapshot")
   now=$(date +%s); pid=$(supervisor_pid "$runtime" "$recorded_pid")
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
-    if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact"; then [[ "$now" -le "$setup_deadline" ]] && exit 1; printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
+    if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then [[ "$now" -le "$setup_deadline" ]] && exit 1; printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
     [[ -z "$pid" && "$now" -le "$setup_deadline" ]] && exit 1
   fi
-  if [[ -s "$artifact" ]] || [[ "$now" -gt "$deadline" ]] || ! supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact"; then printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
+  if [[ -s "$artifact" ]] || [[ "$now" -gt "$deadline" ]] || ! supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
   exit 1
 }
 
@@ -443,7 +460,7 @@ acknowledge() {
 }
 
 fail_command() {
-  local cause="" snapshot fresh attempt_id runtime artifact recorded_pid pid i fresh_attempt fresh_artifact
+  local cause="" snapshot fresh attempt_id runtime artifact supervisor_token recorded_pid pid i fresh_attempt fresh_artifact
   while [[ $# -gt 0 ]]; do case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;;
     --watch-id) WATCH_ID="${2:-}"; shift 2 ;; --cause) cause="${2:-}"; shift 2 ;; *) die "unknown fail option: $1" ;; esac; done
   resolve_state; require_state; [[ "$cause" =~ ^(arm_failed|merge_blocked|launch_failed|operator_abandoned)$ ]] || die "invalid failure cause"
@@ -451,10 +468,11 @@ fail_command() {
     snapshot=$(state_snapshot) || die "cannot snapshot active launch attempt"
     WATCH_ID="${WATCH_ID:-$(jq -r .watch_id <<<"$snapshot")}"
     attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
-    artifact=$(jq -r .artifact_path <<<"$snapshot"); recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot")
+    artifact=$(jq -r .artifact_path <<<"$snapshot"); supervisor_token=$(jq -r '.supervisor_token // empty' <<<"$snapshot")
+    recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot")
     pid=$(supervisor_pid "$runtime" "$recorded_pid")
     if fail_state "$cause" "$cause" "$attempt_id" "$artifact"; then
-      terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" || true
+      terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
       json_report; return
     fi
     fresh=$(state_snapshot) || die "cannot resnapshot launch attempt after failure claim loss"

--- a/skills/orch/scripts/merge-queue-watch
+++ b/skills/orch/scripts/merge-queue-watch
@@ -177,7 +177,7 @@ terminate_legacy_supervisor() {
   return 1
 }
 launch_failure() {
-  local detail="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" pid="${6:-}" snapshot
+  local detail="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" pid="${6:-}" legacy="${7:-false}" snapshot
   atomic_update 'if .watch_id!=$watch or .launch_attempt_id!=$attempt or .runtime_dir!=$runtime or .artifact_path!=$artifact or
       .supervisor_token!=$token or
       (.status|IN("launching","watching")|not) then error("launch claim lost") else
@@ -188,7 +188,8 @@ launch_failure() {
     || die "could not claim launch recovery; inspect the active lifecycle before handback"
   snapshot=$(state_snapshot) || die "cannot snapshot claimed launch failure"
   pid=$(supervisor_pid "$runtime" "$(jq -r '.supervisor_pid // empty' <<<"$snapshot")")
-  [[ -z "$pid" ]] || terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
+  if [[ -n "$pid" && "$legacy" == true ]]; then terminate_legacy_supervisor "$pid" || true
+  elif [[ -n "$pid" ]]; then terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true; fi
   atomic_update 'if .watch_id==$watch and .launch_attempt_id==$attempt and .status=="launch_failed"
       then .supervisor_pid=null|.updated_at=(now|floor) else error("launch failure claim changed") end' \
     --arg watch "$WATCH_ID" --arg attempt "$attempt_id"
@@ -268,7 +269,7 @@ prepare() {
 
 launch() {
   local poll=30 max_wait=2400 method pid deadline now ready log runtime waiter artifact attempt attempt_id supervisor_token
-  local snapshot status prior_attempt head runtime_root watch_dir created=false
+  local snapshot status prior_attempt head runtime_root watch_dir created=false legacy recorded_pid
   while [[ $# -gt 0 ]]; do
     case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;;
       --watch-id) WATCH_ID="${2:-}"; shift 2 ;; --poll) poll="${2:-}"; shift 2 ;;
@@ -280,6 +281,12 @@ launch() {
   snapshot=$(state_snapshot) || die "cannot snapshot prepared lifecycle"
   status=$(jq -r .status <<<"$snapshot"); prior_attempt=$(jq -r '.launch_attempt // 0' <<<"$snapshot")
   [[ "$prior_attempt" =~ ^[0-9]+$ && ( "$status" == prepared || "$status" == launch_failed ) ]] || die "prepared claim lost"
+  legacy=$(jq -r '.legacy_generation // false' <<<"$snapshot")
+  if [[ "$status" == launch_failed && "$legacy" == true ]]; then
+    runtime=$(jq -r .runtime_dir <<<"$snapshot"); recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot")
+    pid=$(supervisor_pid "$runtime" "$recorded_pid")
+    [[ -z "$pid" ]] || terminate_legacy_supervisor "$pid" || die "legacy supervisor survived launch recovery teardown"
+  fi
   attempt=$((prior_attempt+1)); attempt_id="$WATCH_ID-attempt-$attempt"; supervisor_token="$attempt_id-$RANDOM$RANDOM"
   head=$(jq -r .head_sha <<<"$snapshot")
   now=$(date +%s); deadline=$((now + max_wait + 90)); log=$(jq -r .log_path <<<"$snapshot")
@@ -393,7 +400,15 @@ consume() {
   legacy=$(jq -r '.legacy_generation // false' <<<"$snapshot")
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
     pid=$(supervisor_pid "$runtime" "$recorded_pid")
-    if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then
+    if [[ "$legacy" == true ]] && legacy_supervisor_live "$pid"; then
+      if [[ "$now" -le "$setup_deadline" ]]; then
+        jq -cn --arg watch "$WATCH_ID" '{status:"launching",watch_id:$watch,action:"pending"}'; return
+      fi
+      atomic_update 'if .watch_id==$watch and .launch_attempt_id==$attempt and .legacy_generation==true and
+          .status=="launching" then .status="watching"|.supervisor_pid=$pid|.updated_at=(now|floor)
+          else error("legacy launch attempt changed") end' --arg watch "$WATCH_ID" --arg attempt "$attempt_id" \
+        --argjson pid "$pid"; status=watching
+    elif supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then
       if [[ "$now" -le "$setup_deadline" ]]; then
         jq -cn --arg watch "$WATCH_ID" '{status:"launching",watch_id:$watch,action:"pending"}'; return
       fi
@@ -405,7 +420,7 @@ consume() {
     elif [[ -z "$pid" && "$now" -le "$setup_deadline" ]]; then
       jq -cn --arg watch "$WATCH_ID" '{status:"launching",watch_id:$watch,action:"pending"}'; return
     else
-      launch_failure "launching supervisor died or missed its setup deadline; see $log" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" "$recorded_pid"
+      launch_failure "launching supervisor died or missed its setup deadline; see $log" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" "$recorded_pid" "$legacy"
       consume_report; return
     fi
   fi
@@ -486,6 +501,7 @@ event() {
   if [[ "$legacy" == true && "$status" == watching && ! -s "$artifact" && "$now" -le "$deadline" ]] &&
       legacy_supervisor_live "$pid"; then exit 1; fi
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
+    if [[ "$legacy" == true ]] && legacy_supervisor_live "$pid"; then [[ "$now" -le "$setup_deadline" ]] && exit 1; printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
     if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then [[ "$now" -le "$setup_deadline" ]] && exit 1; printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
     [[ -z "$pid" && "$now" -le "$setup_deadline" ]] && exit 1
   fi

--- a/skills/orch/scripts/merge-queue-watch
+++ b/skills/orch/scripts/merge-queue-watch
@@ -48,6 +48,7 @@ resolve_state() {
 }
 state_value() { jq -r "$1" "$STATE_FILE"; }
 require_state() { [[ -f "$STATE_FILE" && ! -L "$STATE_FILE" ]] || die "no durable merge watch for $ISSUE"; }
+state_snapshot() { (flock -s -w 10 9 || exit 1; cat < "$STATE_FILE") 9>"$STATE_FILE.lock"; }
 atomic_update() {
   local filter="$1"; shift
   local tmp="$STATE_DIR/.${ISSUE}.state.$$"
@@ -58,11 +59,13 @@ atomic_update() {
   ) 9>"$STATE_FILE.lock"
 }
 fail_state() {
-  local cause="$1" detail="$2"
-  atomic_update 'if .watch_id != $watch then error("watch id changed") else
+  local cause="$1" detail="$2" attempt_id="${3:-}" artifact="${4:-}"
+  atomic_update 'if .watch_id != $watch or ($attempt!="" and
+      (.launch_attempt_id!=$attempt or .artifact_path!=$artifact)) then error("watch or launch attempt changed") else
       .status="failed" | .action="failed" | .terminal=true |
       .diagnostic={cause:$cause, detail:$detail} | .updated_at=(now|floor) end' \
-    --arg watch "$WATCH_ID" --arg cause "$cause" --arg detail "$detail"
+    --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg artifact "$artifact" \
+    --arg cause "$cause" --arg detail "$detail"
 }
 parse_root_issue() {
   while [[ $# -gt 0 ]]; do
@@ -77,25 +80,23 @@ parse_root_issue() {
   resolve_state; require_state
 }
 supervisor_pid() {
-  local pid
-  pid=$(jq -r '.supervisor_pid // empty' "$STATE_FILE")
+  local runtime="$1" pid="${2:-}"
   if [[ -z "$pid" ]]; then
-    local pid_file
-    pid_file=$(state_value '.runtime_dir + "/supervisor.pid"')
+    local pid_file="$runtime/supervisor.pid"
     [[ -f "$pid_file" ]] && pid=$(cat < "$pid_file")
   fi
   printf '%s' "$pid"
 }
 supervisor_live() {
-  local pid="$1" command
+  local pid="$1" attempt_id="$2" command
   [[ "$pid" =~ ^[1-9][0-9]*$ ]] || return 1
   kill -0 "$pid" 2>/dev/null || return 1
   command=$(ps -p "$pid" -o command= 2>/dev/null) || return 1
-  [[ "$command" == *"merge-queue-watch __supervise"* && "$command" == *"$WATCH_ID"* ]]
+  [[ "$command" == *"merge-queue-watch __supervise"* && "$command" == *"$WATCH_ID"* && "$command" == *"$attempt_id"* ]]
 }
 terminate_supervisor() {
-  local pid="$1" i
-  supervisor_live "$pid" || return 0
+  local pid="$1" attempt_id="$2" i
+  supervisor_live "$pid" "$attempt_id" || return 0
   kill -TERM "$pid" 2>/dev/null || true
   for ((i=0; i<50; i++)); do kill -0 "$pid" 2>/dev/null || return 0; sleep 0.1; done
   kill -KILL "$pid" 2>/dev/null || true
@@ -103,12 +104,13 @@ terminate_supervisor() {
   return 1
 }
 launch_failure() {
-  local detail="$1" pid
-  pid=$(supervisor_pid); [[ -z "$pid" ]] || terminate_supervisor "$pid" || true
-  atomic_update 'if .watch_id!=$watch or (.status|IN("prepared","launching")|not) then error("launch claim lost") else
+  local detail="$1" attempt_id="$2" runtime="$3" pid="${4:-}"
+  pid=$(supervisor_pid "$runtime" "$pid"); [[ -z "$pid" ]] || terminate_supervisor "$pid" "$attempt_id" || true
+  atomic_update 'if .watch_id!=$watch or .launch_attempt_id!=$attempt or .runtime_dir!=$runtime or
+      (.status|IN("launching","watching")|not) then error("launch claim lost") else
       .status="launch_failed"|.action="launch"|.terminal=false|.supervisor_pid=null|
       .diagnostic={cause:"launch_failed",detail:$detail}|.updated_at=(now|floor) end' \
-    --arg watch "$WATCH_ID" --arg detail "$detail" \
+    --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg detail "$detail" \
     || die "could not claim launch recovery; inspect the active lifecycle before handback"
 }
 live_pr() {
@@ -138,24 +140,27 @@ prepare() {
   [[ "$gate" =~ ^(approval|review|off)$ && "$recovery" =~ ^[0-9]+$ ]] || die "prepare gate mode or recovery count is malformed"
   [[ "$cleanup" == true || "$cleanup" == false ]] || die "prepare cleanup flag is malformed"
   resolve_state
-  local now watch_dir artifact log runtime new_state old_status="" pointer worktree_branch
+  local now watch_dir artifact log runtime_root runtime attempt_id new_state old_status="" pointer worktree_branch
   now=$(date +%s); WATCH_ID="$now-$$-$RANDOM$RANDOM"
   worktree_branch=$(git -C "$worktree" branch --show-current 2>/dev/null) || die "cannot read prepared worktree branch"
   watch_dir="$STATE_DIR/runs/$ISSUE-$WATCH_ID"
   mkdir -- "$watch_dir" || die "cannot reserve watch directory"
   chmod 700 "$watch_dir"
-  artifact="$watch_dir/verdict.json"; log="$watch_dir/watch.log"; runtime="$watch_dir/runtime"
-  mkdir -- "$runtime" && chmod 700 "$runtime"
-  printf '%s\n' "$WATCH_ID" > "$runtime/token" && chmod 600 "$runtime/token"
+  attempt_id="$WATCH_ID-attempt-1"; artifact="$watch_dir/verdict-$attempt_id.json"; log="$watch_dir/watch.log"
+  runtime_root="$watch_dir/runtime"; runtime="$runtime_root/$attempt_id"
+  mkdir -- "$runtime_root" "$runtime" && chmod 700 "$runtime_root" "$runtime"
+  printf '%s\n' "$attempt_id" > "$runtime/token" && chmod 600 "$runtime/token"
   new_state="$watch_dir/prepared.json"
   jq -n --arg issue "$ISSUE" --arg repo "$repo" --argjson pr "$pr" --arg head "$head" \
     --arg watch "$WATCH_ID" --arg gate "$gate" --argjson recovery "$recovery" \
     --arg root "$ROOT" --arg worktree "$(cd "$worktree" && pwd -P)" --arg worktree_branch "$worktree_branch" \
-    --arg artifact "$artifact" --arg log "$log" --arg runtime "$runtime" --argjson now "$now" --argjson cleanup "$cleanup" \
+    --arg watch_dir "$watch_dir" --arg artifact "$artifact" --arg log "$log" --arg runtime_root "$runtime_root" --arg runtime "$runtime" \
+    --argjson now "$now" --argjson cleanup "$cleanup" \
     '{schema_version:1,issue_id:$issue,repository:$repo,pr_number:$pr,head_sha:$head,
       watch_id:$watch,gate_mode:$gate,recovery_count:$recovery,main_repo_root:$root,
-      worktree:$worktree,worktree_branch:$worktree_branch,artifact_path:$artifact,log_path:$log,runtime_dir:$runtime,
-      prepared_at:$now,launch_attempt:0,status:"prepared",action:null,terminal:false,
+      worktree:$worktree,worktree_branch:$worktree_branch,watch_dir:$watch_dir,artifact_path:$artifact,log_path:$log,
+      runtime_root:$runtime_root,runtime_dir:$runtime,prepared_at:$now,launch_attempt:0,launch_attempt_id:null,
+      status:"prepared",action:null,terminal:false,
       supervisor_pid:null,launched_at:null,deadline:null,lane_postmerge:null,
       cleanup:{required:$cleanup,status:"not_started",diagnostic:null},diagnostic:null}' > "$new_state"
   (
@@ -182,7 +187,8 @@ prepare() {
 }
 
 launch() {
-  local poll=30 max_wait=2400 method pid deadline now ready log runtime waiter artifact retry_artifact attempt
+  local poll=30 max_wait=2400 method pid deadline now ready log runtime waiter artifact attempt attempt_id
+  local snapshot status prior_attempt head runtime_root watch_dir created=false
   while [[ $# -gt 0 ]]; do
     case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;;
       --watch-id) WATCH_ID="${2:-}"; shift 2 ;; --poll) poll="${2:-}"; shift 2 ;;
@@ -190,27 +196,50 @@ launch() {
   done
   resolve_state; require_state
   [[ "$poll" =~ ^[1-9][0-9]*$ && "$max_wait" =~ ^[1-9][0-9]*$ && "$poll" -le "$max_wait" ]] || die "invalid wait bounds"
-  now=$(date +%s); deadline=$((now + max_wait + 90)); runtime=$(state_value .runtime_dir); log=$(state_value .log_path)
-  artifact=$(state_value .artifact_path); attempt=$(state_value '(.launch_attempt // 0) + 1')
-  retry_artifact="${artifact%/*}/verdict-$attempt.json"
+  snapshot=$(state_snapshot) || die "cannot snapshot prepared lifecycle"
+  status=$(jq -r .status <<<"$snapshot"); prior_attempt=$(jq -r '.launch_attempt // 0' <<<"$snapshot")
+  [[ "$prior_attempt" =~ ^[0-9]+$ && ( "$status" == prepared || "$status" == launch_failed ) ]] || die "prepared claim lost"
+  attempt=$((prior_attempt+1)); attempt_id="$WATCH_ID-attempt-$attempt"; head=$(jq -r .head_sha <<<"$snapshot")
+  now=$(date +%s); deadline=$((now + max_wait + 90)); log=$(jq -r .log_path <<<"$snapshot")
   waiter="$SCRIPT_DIR/queue-wait"
   if [[ ! -x "$waiter" ]]; then
-    launch_failure "queue-wait is missing: $waiter; diagnostics: $log"
+    atomic_update 'if .watch_id!=$watch or .status!=$status or (.launch_attempt // 0)!=$prior then error("prepared claim lost") else
+        .status="launch_failed"|.action="launch"|.terminal=false|.supervisor_pid=null|
+        .diagnostic={cause:"launch_failed",detail:$detail}|.updated_at=(now|floor) end' \
+      --arg watch "$WATCH_ID" --arg status "$status" --argjson prior "$prior_attempt" \
+      --arg detail "queue-wait is missing: $waiter; diagnostics: $log" \
+      || die "could not claim launch recovery; inspect the active lifecycle before handback"
     die "queue-wait is missing: $waiter; diagnostics: $log"
   fi
-  if command -v setsid >/dev/null 2>&1; then method="setsid"; else method="nohup"; fi
-  atomic_update 'if .watch_id!=$watch or .head_sha!=$head or (.status|IN("prepared","launch_failed")|not) then error("prepared claim lost") else
-      .artifact_path=(if .status=="launch_failed" then $retry_artifact else .artifact_path end)|
-      .launch_attempt=$attempt|.status="launching"|.action=null|.diagnostic=null|.launch_method=$method|.launched_at=$now|
-      .setup_deadline=($now+10)|.deadline=$deadline|.updated_at=$now end' \
-    --arg watch "$WATCH_ID" --arg head "$(state_value .head_sha)" --arg method "$method" --arg retry_artifact "$retry_artifact" \
-    --argjson attempt "$attempt" --argjson now "$now" --argjson deadline "$deadline" \
-    || die "prepared lifecycle was terminalized before launch"
-  if [[ "$method" == setsid ]]; then
-    setsid -f "$SELF" __supervise "$STATE_FILE" "$WATCH_ID" "$waiter" "$poll" "$max_wait" >> "$log" 2>&1 \
-      || { launch_failure "setsid could not launch supervisor; see $log"; die "detached supervisor launch failed; see $log"; }
+  runtime_root=$(jq -r .runtime_root <<<"$snapshot"); watch_dir=$(jq -r .watch_dir <<<"$snapshot")
+  if [[ "$prior_attempt" -eq 0 ]]; then
+    runtime=$(jq -r .runtime_dir <<<"$snapshot"); artifact=$(jq -r .artifact_path <<<"$snapshot")
+    [[ -d "$runtime" && ! -L "$runtime" && -f "$runtime/token" && "$(cat < "$runtime/token")" == "$attempt_id" ]] \
+      || die "prepared attempt runtime is invalid: $runtime"
   else
-    nohup "$SELF" __supervise "$STATE_FILE" "$WATCH_ID" "$waiter" "$poll" "$max_wait" </dev/null >> "$log" 2>&1 &
+    runtime="$runtime_root/$attempt_id"; artifact="$watch_dir/verdict-$attempt_id.json"
+    mkdir -- "$runtime" || die "cannot reserve launch attempt runtime: $runtime"
+    created=true; chmod 700 "$runtime"
+    printf '%s\n' "$attempt_id" > "$runtime/token" && chmod 600 "$runtime/token" \
+      || { rm -f -- "$runtime/token"; rmdir -- "$runtime" 2>/dev/null || true; die "cannot bind launch attempt runtime: $runtime"; }
+  fi
+  if command -v setsid >/dev/null 2>&1; then method="setsid"; else method="nohup"; fi
+  if ! atomic_update 'if .watch_id!=$watch or .head_sha!=$head or .status!=$status or (.launch_attempt // 0)!=$prior
+      then error("prepared claim lost") else .artifact_path=$artifact|.runtime_dir=$runtime|
+      .launch_attempt=$attempt|.launch_attempt_id=$attempt_id|.status="launching"|.action=null|.diagnostic=null|
+      .supervisor_pid=null|.launch_method=$method|.launched_at=$now|
+      .setup_deadline=($now+10)|.deadline=$deadline|.updated_at=$now end' \
+    --arg watch "$WATCH_ID" --arg head "$head" --arg status "$status" --argjson prior "$prior_attempt" \
+    --arg runtime "$runtime" --arg artifact "$artifact" --arg attempt_id "$attempt_id" --arg method "$method" \
+    --argjson attempt "$attempt" --argjson now "$now" --argjson deadline "$deadline"; then
+    $created && { rm -f -- "$runtime/token"; rmdir -- "$runtime" 2>/dev/null || true; }
+    die "prepared lifecycle was terminalized before launch"
+  fi
+  if [[ "$method" == setsid ]]; then
+    setsid -f "$SELF" __supervise "$STATE_FILE" "$WATCH_ID" "$attempt_id" "$runtime" "$artifact" "$deadline" "$waiter" "$poll" "$max_wait" >> "$log" 2>&1 \
+      || { launch_failure "setsid could not launch supervisor; see $log" "$attempt_id" "$runtime"; die "detached supervisor launch failed; see $log"; }
+  else
+    nohup "$SELF" __supervise "$STATE_FILE" "$WATCH_ID" "$attempt_id" "$runtime" "$artifact" "$deadline" "$waiter" "$poll" "$max_wait" </dev/null >> "$log" 2>&1 &
   fi
   ready="$runtime/ready"
   for ((i=0; i<100; i++)); do
@@ -218,130 +247,148 @@ launch() {
     sleep 0.05
   done
   if [[ ! -f "$ready" ]]; then
-    launch_failure "supervisor did not establish worker liveness; see $log"
+    launch_failure "supervisor did not establish worker liveness; see $log" "$attempt_id" "$runtime"
     tail -20 "$log" >&2 || true
     die "supervisor setup failed; diagnostics: $log"
   fi
   pid=$(cat < "$runtime/supervisor.pid")
-  [[ "$pid" =~ ^[1-9][0-9]*$ ]] || { launch_failure "supervisor pid is malformed"; die "supervisor pid is malformed"; }
-  if ! atomic_update 'if .watch_id!=$watch or .status!="launching" then error("launch claim lost") else
-      .status="watching"|.supervisor_pid=$pid|.updated_at=(now|floor) end' --arg watch "$WATCH_ID" --argjson pid "$pid"; then
-    terminate_supervisor "$pid" || true
+  [[ "$pid" =~ ^[1-9][0-9]*$ ]] || { launch_failure "supervisor pid is malformed" "$attempt_id" "$runtime"; die "supervisor pid is malformed"; }
+  if ! atomic_update 'if .watch_id!=$watch or .launch_attempt_id!=$attempt or .runtime_dir!=$runtime or
+      .artifact_path!=$artifact or .status!="launching" then error("launch claim lost") else
+      .status="watching"|.supervisor_pid=$pid|.updated_at=(now|floor) end' \
+      --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg runtime "$runtime" --arg artifact "$artifact" --argjson pid "$pid"; then
+    terminate_supervisor "$pid" "$attempt_id" || true
     die "lifecycle was terminalized during launch"
   fi
   json_report
 }
 
 claim() {
-  local action="$1" verdict="$2" cause="$3" diagnostic_file="${4:-/dev/null}" max recovery status
-  max=$("$SCRIPT_DIR/orch-env" CI_FIX_MAX_CYCLES 6); recovery=$(state_value .recovery_count)
+  local action="$1" verdict="$2" cause="$3" diagnostic_file="$4" attempt_id="$5" artifact="$6" expected_head="$7" recovery="$8"
+  local max status
+  max=$("$SCRIPT_DIR/orch-env" CI_FIX_MAX_CYCLES 6)
   status=claimed
   case "$action" in
     recovery)
       if (( recovery >= max )); then
-        atomic_update 'if .watch_id!=$watch or (.status|IN("watching","launching")|not) then error("verdict already claimed") else
+        atomic_update 'if .watch_id!=$watch or .launch_attempt_id!=$attempt or .artifact_path!=$artifact or
+            (.status|IN("watching","launching")|not) then error("verdict already claimed") else
           .status="failed"|.action="failed"|.verdict=$verdict|.verdict_cause="recovery_cap"|.terminal=true|
           .diagnostic=($diagnostic[0]+{recovery_cap:$max})|.updated_at=(now|floor) end' \
-          --arg watch "$WATCH_ID" --arg verdict "$verdict" --argjson max "$max" --slurpfile diagnostic "$diagnostic_file"
+          --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg artifact "$artifact" \
+          --arg verdict "$verdict" --argjson max "$max" --slurpfile diagnostic "$diagnostic_file"
         json_report; return
       fi
       recovery=$((recovery+1)) ;;
     failed) status=failed ;; abandoned) status=abandoned ;;
   esac
-  atomic_update 'if .watch_id!=$watch or .head_sha!=$head or (.status|IN("watching","launching")|not) then error("verdict already claimed") else
+  atomic_update 'if .watch_id!=$watch or .head_sha!=$head or .launch_attempt_id!=$attempt or .artifact_path!=$artifact or
+      (.status|IN("watching","launching")|not) then error("verdict already claimed") else
       .status=$status|.action=$action|.verdict=$verdict|.verdict_cause=$cause|
       .diagnostic=(if $diagnostic[0]==null then null else $diagnostic[0] end)|
       .recovery_count=$recovery|.terminal=($status|IN("failed","abandoned"))|.updated_at=(now|floor) end' \
-    --arg watch "$WATCH_ID" --arg head "$(state_value .head_sha)" --arg status "$status" --arg action "$action" \
+    --arg watch "$WATCH_ID" --arg head "$expected_head" --arg attempt "$attempt_id" --arg artifact "$artifact" \
+    --arg status "$status" --arg action "$action" \
     --arg verdict "$verdict" --arg cause "$cause" --argjson recovery "$recovery" --slurpfile diagnostic "$diagnostic_file"
   json_report
 }
 
 consume() {
   parse_root_issue "$@"
-  WATCH_ID=$(state_value .watch_id)
-  local status artifact pid deadline now token body live live_state observed expected verdict result cause action diag error_text exit_code diag_path unconfirmed
-  status=$(state_value .status)
+  local snapshot status artifact runtime attempt_id pid recorded_pid deadline setup_deadline now token body live live_state
+  local observed expected repo pr verdict result cause action diag error_text exit_code diag_path unconfirmed recovery log
+  snapshot=$(state_snapshot) || die "cannot snapshot active launch attempt"
+  WATCH_ID=$(jq -r .watch_id <<<"$snapshot"); status=$(jq -r .status <<<"$snapshot")
   case "$status" in claimed|launch_failed|failed|abandoned|awaiting_lane_postmerge|cleanup_pending|cleanup_complete|complete) consume_report; return ;; esac
-  artifact=$(state_value .artifact_path); now=$(date +%s); deadline=$(state_value '.deadline // 0')
+  artifact=$(jq -r .artifact_path <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
+  attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot")
+  deadline=$(jq -r '.deadline // 0' <<<"$snapshot"); setup_deadline=$(jq -r '.setup_deadline // 0' <<<"$snapshot")
+  expected=$(jq -r .head_sha <<<"$snapshot"); repo=$(jq -r .repository <<<"$snapshot"); pr=$(jq -r .pr_number <<<"$snapshot")
+  recovery=$(jq -r .recovery_count <<<"$snapshot"); log=$(jq -r .log_path <<<"$snapshot"); now=$(date +%s)
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
-    pid=$(supervisor_pid)
-    if supervisor_live "$pid"; then
-      if [[ "$now" -le "$(state_value '.setup_deadline // 0')" ]]; then
+    pid=$(supervisor_pid "$runtime" "$recorded_pid")
+    if supervisor_live "$pid" "$attempt_id"; then
+      if [[ "$now" -le "$setup_deadline" ]]; then
         jq -cn --arg watch "$WATCH_ID" '{status:"launching",watch_id:$watch,action:"pending"}'; return
       fi
-      atomic_update 'if .watch_id==$watch and .status=="launching" then .status="watching"|.supervisor_pid=$pid|.updated_at=(now|floor) else . end' \
-        --arg watch "$WATCH_ID" --argjson pid "$pid"; status=watching
-    elif [[ -z "$pid" && "$now" -le "$(state_value '.setup_deadline // 0')" ]]; then
+      atomic_update 'if .watch_id==$watch and .launch_attempt_id==$attempt and .runtime_dir==$runtime and
+          .artifact_path==$artifact and .status=="launching" then .status="watching"|.supervisor_pid=$pid|.updated_at=(now|floor)
+          else error("launch attempt changed") end' --arg watch "$WATCH_ID" --arg attempt "$attempt_id" \
+        --arg runtime "$runtime" --arg artifact "$artifact" --argjson pid "$pid"; status=watching
+    elif [[ -z "$pid" && "$now" -le "$setup_deadline" ]]; then
       jq -cn --arg watch "$WATCH_ID" '{status:"launching",watch_id:$watch,action:"pending"}'; return
     else
-      launch_failure "launching supervisor died or missed its setup deadline; see $(state_value .log_path)"
+      launch_failure "launching supervisor died or missed its setup deadline; see $log" "$attempt_id" "$runtime" "$recorded_pid"
       consume_report; return
     fi
   fi
   if [[ ! -s "$artifact" ]]; then
-    pid=$(supervisor_pid); token=$(state_value '.runtime_dir + "/token"')
-    if [[ -f "$token" && "$(cat < "$token")" == "$WATCH_ID" && "$now" -le "$deadline" ]] && supervisor_live "$pid"; then
+    pid=$(supervisor_pid "$runtime" "$recorded_pid"); token="$runtime/token"
+    if [[ -f "$token" && "$(cat < "$token")" == "$attempt_id" && "$now" -le "$deadline" ]] && supervisor_live "$pid" "$attempt_id"; then
       jq -cn --arg status pending --arg watch "$WATCH_ID" '{status:$status,watch_id:$watch,action:"pending"}'
       return
     fi
-    terminate_supervisor "$pid" || true
-    fail_state watch_lost "artifact missing and supervisor dead or overdue; see $(state_value .log_path)"
+    terminate_supervisor "$pid" "$attempt_id" || true
+    fail_state watch_lost "artifact missing and supervisor dead or overdue; see $log" "$attempt_id" "$artifact"
     json_report; return
   fi
-  if ! jq -e --arg watch "$WATCH_ID" --arg repo "$(state_value .repository)" --arg head "$(state_value .head_sha)" --argjson pr "$(state_value .pr_number)" '
-      type=="object" and .schema_version==1 and .watch_id==$watch and .repository==$repo and
+  if ! jq -e --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg repo "$repo" --arg head "$expected" --argjson pr "$pr" '
+      type=="object" and .schema_version==1 and .watch_id==$watch and .launch_attempt_id==$attempt and .repository==$repo and
       .pr_number==$pr and .expected_head==$head and (.observed_head|type=="string") and
       (.status|IN("complete","timeout","error")) and (.verdict|IN("merged","conflicting","ejected","disarmed","dequeued","closed","queued","not_queued","unknown"))' "$artifact" >/dev/null; then
-    fail_state malformed_artifact "verdict artifact is malformed or belongs to another watch"
+    fail_state malformed_artifact "verdict artifact is malformed or belongs to another launch attempt" "$attempt_id" "$artifact"
     json_report; return
   fi
   result=$(jq -r .status "$artifact"); verdict=$(jq -r .verdict "$artifact"); cause=$(jq -r '.cause // ""' "$artifact")
   error_text=$(jq -r '.error // ""' "$artifact"); exit_code=$(jq -r '.worker_exit_code // empty' "$artifact"); diag_path=$(jq -r '.diagnostic_path // ""' "$artifact")
   unconfirmed=$(jq -r '.unconfirmed_verdict // ""' "$artifact")
-  diag="$(state_value .runtime_dir)/consume-diagnostic.$$"
+  diag="$runtime/consume-diagnostic.$$"
   (umask 077; set -C; : > "$diag") || die "cannot create diagnostic binding"
   body=$(live_pr) || body='{"headRefOid":"","state":"UNKNOWN"}'
   live=$(jq -r '.headRefOid // ""' <<<"$body"); live_state=$(jq -r '.state // ""' <<<"$body")
-  observed=$(jq -r .observed_head "$artifact"); expected=$(state_value .head_sha)
+  observed=$(jq -r .observed_head "$artifact")
   jq -n --arg cause "${cause:-$verdict}" --arg error "$error_text" --arg exit "$exit_code" --arg path "$diag_path" --arg unconfirmed "$unconfirmed" \
     --arg expected "$expected" --arg observed "$observed" --arg live "$live" --arg state "$live_state" \
     '{cause:$cause,error:(if $error=="" then null else $error end),unconfirmed_verdict:(if $unconfirmed=="" then null else $unconfirmed end),worker_exit_code:(if $exit=="" then null else ($exit|tonumber) end),
       diagnostic_path:$path,head_verification:{expected:$expected,artifact_observed:$observed,live:$live,live_state:$state}}' > "$diag"
-  if [[ -z "$live" ]]; then claim failed "$verdict" live_pr_unreadable "$diag"; rm -f -- "$diag"; return; fi
+  if [[ -z "$live" ]]; then claim failed "$verdict" live_pr_unreadable "$diag" "$attempt_id" "$artifact" "$expected" "$recovery"; rm -f -- "$diag"; return; fi
   if [[ "$live" != "$expected" || ( -n "$observed" && "$observed" != "$expected" ) ]]; then
-    claim failed "$verdict" head_mismatch "$diag"; rm -f -- "$diag"; return
+    claim failed "$verdict" head_mismatch "$diag" "$attempt_id" "$artifact" "$expected" "$recovery"; rm -f -- "$diag"; return
   fi
-  if [[ "$live_state" == MERGED ]]; then claim postmerge merged merged_race "$diag"; rm -f -- "$diag"; return; fi
+  if [[ "$live_state" == MERGED ]]; then claim postmerge merged merged_race "$diag" "$attempt_id" "$artifact" "$expected" "$recovery"; rm -f -- "$diag"; return; fi
   if [[ "$result" == error && "$verdict:$cause" == dequeued:late_findings_dequeue_failed ]]; then
-    claim manual_dequeue "$verdict" "$cause" "$diag"; rm -f -- "$diag"; return
+    claim manual_dequeue "$verdict" "$cause" "$diag" "$attempt_id" "$artifact" "$expected" "$recovery"; rm -f -- "$diag"; return
   fi
   if [[ "$result" == error || "$verdict" == unknown ]]; then
-    claim failed "$verdict" "${cause:-watch_error}" "$diag"; rm -f -- "$diag"; return
+    claim failed "$verdict" "${cause:-watch_error}" "$diag" "$attempt_id" "$artifact" "$expected" "$recovery"; rm -f -- "$diag"; return
   fi
   case "$verdict:$live_state" in merged:MERGED|closed:CLOSED|unknown:*|conflicting:OPEN|ejected:OPEN|disarmed:OPEN|dequeued:OPEN|queued:OPEN|not_queued:OPEN) ;; *)
-    claim failed "$verdict" live_state_mismatch "$diag"; rm -f -- "$diag"; return ;; esac
+    claim failed "$verdict" live_state_mismatch "$diag" "$attempt_id" "$artifact" "$expected" "$recovery"; rm -f -- "$diag"; return ;; esac
   case "$verdict:$cause" in
     merged:*) action=postmerge ;; conflicting:*) action=restack ;; ejected:*|disarmed:*|queued:stalled) action=recovery ;;
     dequeued:*) action=triage ;; queued:still_progressing) action=rewatch ;;
     not_queued:*) action=rearm ;; closed:*) action=abandoned ;; *) action=failed ;;
   esac
-  claim "$action" "$verdict" "$cause" "$diag"; rm -f -- "$diag"
+  claim "$action" "$verdict" "$cause" "$diag" "$attempt_id" "$artifact" "$expected" "$recovery"; rm -f -- "$diag"
 }
 
 event() {
   while [[ $# -gt 0 ]]; do case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;; *) die "unknown event option: $1" ;; esac; done
   [[ -n "$ROOT" && -n "$ISSUE" ]] || die "--root and --issue are required"
-  resolve_state; [[ -f "$STATE_FILE" ]] || exit 1; WATCH_ID=$(state_value .watch_id)
-  local status artifact pid deadline now
-  status=$(state_value .status); [[ "$status" == watching || "$status" == launching || "$status" == launch_failed ]] || exit 1
+  resolve_state; [[ -f "$STATE_FILE" ]] || exit 1
+  local snapshot status artifact runtime attempt_id recorded_pid pid deadline setup_deadline now
+  snapshot=$(state_snapshot) || exit 1; WATCH_ID=$(jq -r .watch_id <<<"$snapshot")
+  status=$(jq -r .status <<<"$snapshot"); [[ "$status" == watching || "$status" == launching || "$status" == launch_failed ]] || exit 1
   [[ "$status" == launch_failed ]] && { printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; }
-  artifact=$(state_value .artifact_path); deadline=$(state_value '.deadline // 0'); now=$(date +%s); pid=$(supervisor_pid)
+  artifact=$(jq -r .artifact_path <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
+  attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot")
+  deadline=$(jq -r '.deadline // 0' <<<"$snapshot"); setup_deadline=$(jq -r '.setup_deadline // 0' <<<"$snapshot")
+  now=$(date +%s); pid=$(supervisor_pid "$runtime" "$recorded_pid")
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
-    if supervisor_live "$pid"; then [[ "$now" -le "$(state_value '.setup_deadline // 0')" ]] && exit 1; printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
-    [[ -z "$pid" && "$now" -le "$(state_value '.setup_deadline // 0')" ]] && exit 1
+    if supervisor_live "$pid" "$attempt_id"; then [[ "$now" -le "$setup_deadline" ]] && exit 1; printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
+    [[ -z "$pid" && "$now" -le "$setup_deadline" ]] && exit 1
   fi
-  if [[ -s "$artifact" ]] || [[ "$now" -gt "$deadline" ]] || ! supervisor_live "$pid"; then printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
+  if [[ -s "$artifact" ]] || [[ "$now" -gt "$deadline" ]] || ! supervisor_live "$pid" "$attempt_id"; then printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
   exit 1
 }
 
@@ -384,12 +431,15 @@ acknowledge() {
 }
 
 fail_command() {
-  local cause="" pid=""
+  local cause="" snapshot attempt_id runtime recorded_pid pid
   while [[ $# -gt 0 ]]; do case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;;
     --watch-id) WATCH_ID="${2:-}"; shift 2 ;; --cause) cause="${2:-}"; shift 2 ;; *) die "unknown fail option: $1" ;; esac; done
   resolve_state; require_state; [[ "$cause" =~ ^(arm_failed|merge_blocked|launch_failed|operator_abandoned)$ ]] || die "invalid failure cause"
-  WATCH_ID="${WATCH_ID:-$(state_value .watch_id)}"; pid=$(supervisor_pid)
-  fail_state "$cause" "$cause"; terminate_supervisor "$pid" || true; json_report
+  snapshot=$(state_snapshot) || die "cannot snapshot active launch attempt"
+  WATCH_ID="${WATCH_ID:-$(jq -r .watch_id <<<"$snapshot")}"
+  attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
+  recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot"); pid=$(supervisor_pid "$runtime" "$recorded_pid")
+  fail_state "$cause" "$cause"; terminate_supervisor "$pid" "$attempt_id" || true; json_report
 }
 
 inspect() { parse_root_issue "$@"; cat < "$STATE_FILE"; }

--- a/skills/orch/tests/merge_queue_watch.sh
+++ b/skills/orch/tests/merge_queue_watch.sh
@@ -13,6 +13,7 @@ eq() { if [[ "$1" == "$2" ]]; then ok "$3"; else bad "$3 (expected $2, got $1)";
 wait_file() { local i; for ((i=0;i<100;i++)); do [[ -s "$1" ]] && return 0; sleep 0.05; done; return 1; }
 wait_exists() { local i; for ((i=0;i<100;i++)); do [[ -e "$1" ]] && return 0; sleep 0.05; done; return 1; }
 wait_state() { local i; for ((i=0;i<200;i++)); do [[ "$(jq -r .status "$1")" == "$2" ]] && return 0; sleep 0.05; done; return 1; }
+running() { local state; state=$(ps -p "$1" -o stat= 2>/dev/null) || return 1; state="${state//[[:space:]]/}"; [[ -n "$state" && "$state" != Z* ]]; }
 inode() { stat -c %i "$1" 2>/dev/null || stat -f %i "$1"; }
 
 MAIN="$TMP/main" WT="$TMP/worktree" BIN="$TMP/bin" SCRIPTS="$TMP/orch/scripts"
@@ -143,6 +144,7 @@ chmod +x "$BIN/flock"
 cat > "$BIN/ps" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+if [[ -n "${WATCH_PS_ZOMBIE_PID:-}" && "$*" == "-p $WATCH_PS_ZOMBIE_PID -o stat=" ]]; then printf 'Z\n'; exit 0; fi
 if [[ "${MERGE_QUEUE_FORCE_PS_IDENTITY:-0}" == 1 ]]; then printf '%s\n' "$*" >> "$WATCH_PS_LOG"; fi
 if [[ -f "$WATCH_SUPERVISOR_PID_GATE.enabled" ]]; then
   calls=0; [[ ! -f "$WATCH_SUPERVISOR_PID_GATE.calls" ]] || calls=$(cat < "$WATCH_SUPERVISOR_PID_GATE.calls")
@@ -183,8 +185,8 @@ launch_bounded() {
   local watch="$1" out="$TMP/launch.out" err="$TMP/launch.err" pid i rc=0
   "$SCRIPTS/merge-queue-watch" launch --root "$MAIN" --issue KEN-829 --watch-id "$watch" --poll 1 --max-wait 10 >"$out" 2>"$err" &
   pid=$!
-  for ((i=0;i<100;i++)); do kill -0 "$pid" 2>/dev/null || break; sleep 0.05; done
-  if kill -0 "$pid" 2>/dev/null; then kill -TERM "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true; bad "launch returns before worker release"; return 1; fi
+  for ((i=0;i<100;i++)); do running "$pid" || break; sleep 0.05; done
+  if running "$pid"; then kill -TERM "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true; bad "launch returns before worker release"; return 1; fi
   wait "$pid" || rc=$?
   eq "$rc" 0 "launch returns before worker release"
   [[ "$rc" -eq 0 ]] || sed 's/^/        /' "$err"
@@ -210,7 +212,7 @@ launch_bounded "$watch"
 grep -Fxq "$MAIN|owner/repo|ghp_project" "$WATCH_WORKER_LOG" && ok "detached waiter enters persisted main repo with its project auth and repo scope" || bad "detached waiter lost main repo auth or scope"
 if [[ ! -e "$artifact" ]]; then ok "no verdict exists before worker release"; else bad "partial verdict appeared"; fi
 supervisor=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .supervisor_pid)
-if kill -0 "$supervisor" 2>/dev/null; then ok "supervisor survives the launch command boundary"; else bad "supervisor died at command boundary"; fi
+if running "$supervisor"; then ok "supervisor survives the launch command boundary"; else bad "supervisor died at command boundary"; fi
 touch "$RELEASE"; wait_file "$artifact" || bad "merged verdict was not published"
 eq "$(jq -r .watch_id "$artifact")" "$watch" "artifact binds watch id"
 eq "$(jq -r .expected_head "$artifact")" "$HEAD_A" "artifact binds expected head"
@@ -368,7 +370,7 @@ eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -
 
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
-jq --arg attempt "$watch-attempt-1" '.launch_attempt=1|.launch_attempt_id=$attempt|.status="launching"|.setup_deadline=((now|floor)+10)|.deadline=((now|floor)+600)' "$state_path" > "$TMP/completed-launch.json"
+jq --arg attempt "$watch-attempt-1" --arg token "$watch-attempt-1-test" '.launch_attempt=1|.launch_attempt_id=$attempt|.supervisor_token=$token|.status="launching"|.setup_deadline=((now|floor)+10)|.deadline=((now|floor)+600)' "$state_path" > "$TMP/completed-launch.json"
 chmod 600 "$TMP/completed-launch.json"; mv "$TMP/completed-launch.json" "$state_path"
 jq -n --arg watch "$watch" --arg attempt "$watch-attempt-1" --arg head "$HEAD_A" '{schema_version:1,status:"complete",verdict:"merged",repository:"owner/repo",pr_number:42,expected_head:$head,observed_head:"",watch_id:$watch,launch_attempt_id:$attempt}' > "$artifact"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
@@ -383,7 +385,7 @@ state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_
 jq '.deadline=0' "$state_path" > "$TMP/expired.json"; chmod 600 "$TMP/expired.json"; mv "$TMP/expired.json" "$state_path"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .diagnostic.cause <<<"$result")" watch_lost "overdue live supervisor fails closed"
-if ! kill -0 "$supervisor" 2>/dev/null; then ok "overdue verified supervisor is terminated"; else bad "overdue supervisor survived consume"; fi
+if ! running "$supervisor"; then ok "overdue verified supervisor is terminated"; else bad "overdue supervisor survived consume"; fi
 
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
 launch_bounded "$watch"; supervisor=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .supervisor_pid)
@@ -526,8 +528,8 @@ touch "$WATCH_FAIL_FLOCK_GATE.release"
 set +e; wait "$fail_race_pid"; fail_race_rc=$?; set -e
 [[ "$fail_race_rc" -ne 0 ]] && ok "stale fail refuses after retry registration" || bad "stale fail reported success across retry"
 eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .status)" watching "stale fail leaves replacement state active"
-kill -0 "$replacement_supervisor" 2>/dev/null && ok "stale fail does not signal replacement supervisor" || bad "stale fail signaled replacement supervisor"
-kill -0 "$old_supervisor" 2>/dev/null && ok "stale fail does not confuse captured supervisor identity" || bad "stale fail signaled its captured supervisor after claim loss"
+running "$replacement_supervisor" && ok "stale fail does not signal replacement supervisor" || bad "stale fail signaled replacement supervisor"
+running "$old_supervisor" && ok "stale fail does not confuse captured supervisor identity" || bad "stale fail signaled its captured supervisor after claim loss"
 touch "$RELEASE"; wait_file "$replacement_artifact" || bad "replacement verdict missing after stale fail"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .action <<<"$result")" recovery "replacement verdict survives stale fail"
@@ -542,7 +544,7 @@ bash -c 'while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$s
 jq --argjson pid "$similar_attempt_pid" '.supervisor_pid=$pid' "$state_path" > "$TMP/similar-attempt-state.json"
 chmod 600 "$TMP/similar-attempt-state.json"; mv "$TMP/similar-attempt-state.json" "$state_path"
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
-kill -0 "$similar_attempt_pid" 2>/dev/null && ok "attempt identity compares argv fields exactly" || bad "attempt-1 matched and signaled attempt-10"
+running "$similar_attempt_pid" && ok "attempt identity compares argv fields exactly" || bad "attempt-1 matched and signaled attempt-10"
 kill "$similar_attempt_pid" 2>/dev/null || true; wait "$similar_attempt_pid" 2>/dev/null || true
 touch "$RELEASE"
 
@@ -554,7 +556,7 @@ ps_calls=$(wc -l < "$WATCH_PS_LOG")
 export MERGE_QUEUE_FORCE_PS_IDENTITY=1
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 [[ "$(wc -l < "$WATCH_PS_LOG")" -gt "$ps_calls" ]] && ok "forced whitespace identity check invokes ps" || bad "forced whitespace identity check bypassed ps"
-if ! kill -0 "$fallback_supervisor" 2>/dev/null; then ok "ps environment identity supports repository paths with spaces"; else bad "ps fallback rejected a valid supervisor under a whitespace path"; fi
+if ! running "$fallback_supervisor"; then ok "ps environment identity supports repository paths with spaces"; else bad "ps fallback rejected a valid supervisor under a whitespace path"; fi
 unset MERGE_QUEUE_FORCE_PS_IDENTITY
 touch "$RELEASE"
 
@@ -569,7 +571,7 @@ ps_calls=$(wc -l < "$WATCH_PS_LOG")
 export MERGE_QUEUE_FORCE_PS_IDENTITY=1
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 [[ "$(wc -l < "$WATCH_PS_LOG")" -gt "$ps_calls" ]] && ok "forced similar-generation check invokes ps" || bad "forced similar-generation check bypassed ps"
-kill -0 "$similar_identity_pid" 2>/dev/null && ok "ps environment identity rejects a similar generation" || bad "ps fallback matched a similar generation token"
+running "$similar_identity_pid" && ok "ps environment identity rejects a similar generation" || bad "ps fallback matched a similar generation token"
 unset MERGE_QUEUE_FORCE_PS_IDENTITY
 kill "$similar_identity_pid" 2>/dev/null || true; wait "$similar_identity_pid" 2>/dev/null || true
 touch "$RELEASE"
@@ -587,7 +589,7 @@ export MERGE_QUEUE_FORCE_PS_IDENTITY=1
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 [[ "$(wc -l < "$WATCH_PS_LOG")" -gt "$ps_calls" ]] && ok "forced identity-change check invokes ps" || bad "forced identity-change check bypassed ps"
 wait_exists "$identity_changed" && ok "teardown sent TERM to the captured identity" || bad "teardown never signaled the captured identity"
-kill -0 "$changed_identity_pid" 2>/dev/null && ok "teardown stops when the PID changes identity" || bad "teardown escalated KILL after identity changed"
+running "$changed_identity_pid" && ok "teardown stops when the PID changes identity" || bad "teardown escalated KILL after identity changed"
 unset MERGE_QUEUE_FORCE_PS_IDENTITY
 kill "$changed_identity_pid" 2>/dev/null || true; wait "$changed_identity_pid" 2>/dev/null || true
 touch "$RELEASE"
@@ -601,7 +603,7 @@ jq --argjson pid "$worker_pid" '.supervisor_pid=$pid' "$state_path" > "$TMP/work
 chmod 600 "$TMP/worker-pid-state.json"; mv "$TMP/worker-pid-state.json" "$state_path"
 export MERGE_QUEUE_FORCE_PS_IDENTITY=1
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
-kill -0 "$worker_pid" 2>/dev/null && ok "reused worker PID cannot identify as supervisor" || bad "supervisor teardown signaled queue-wait descendant"
+running "$worker_pid" && ok "reused worker PID cannot identify as supervisor" || bad "supervisor teardown signaled queue-wait descendant"
 unset MERGE_QUEUE_FORCE_PS_IDENTITY
 touch "$RELEASE"
 
@@ -614,7 +616,7 @@ jq --argjson pid "$wrong_command_pid" '.supervisor_pid=$pid' "$state_path" > "$T
 chmod 600 "$TMP/wrong-command-state.json"; mv "$TMP/wrong-command-state.json" "$state_path"
 export MERGE_QUEUE_FORCE_PS_IDENTITY=1
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
-kill -0 "$wrong_command_pid" 2>/dev/null && ok "ps fallback requires supervisor command identity" || bad "ps fallback accepted non-supervisor command"
+running "$wrong_command_pid" && ok "ps fallback requires supervisor command identity" || bad "ps fallback accepted non-supervisor command"
 unset MERGE_QUEUE_FORCE_PS_IDENTITY
 kill "$wrong_command_pid" 2>/dev/null || true; wait "$wrong_command_pid" 2>/dev/null || true
 touch "$RELEASE"
@@ -633,22 +635,42 @@ set +e; wait "$registration_launch_pid"; registration_launch_rc=$?; set -e
 sleep 0.3
 eq "$(wc -l < "$WATCH_WORKER_LOG")" "$worker_count" "supervisor rechecks state after PID publication"
 registration_pid=$(cat < "$registration_runtime/supervisor.pid")
-if ! kill -0 "$registration_pid" 2>/dev/null; then ok "late-registering supervisor exits before deadline"; else bad "late-registering supervisor survived its failed generation"; fi
+if ! running "$registration_pid"; then ok "late-registering supervisor exits before deadline"; else bad "late-registering supervisor survived its failed generation"; fi
 touch "$RELEASE"
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 rm -f -- "$WATCH_REGISTRATION_GATE.enabled" "$WATCH_REGISTRATION_GATE.entered" "$WATCH_REGISTRATION_GATE.release"
 
 prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
-launch_bounded "$watch"
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
-legacy_supervisor=$(jq -r .supervisor_pid "$state_path")
-jq 'del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-watching.json"
+bash -c 'while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$state_path" "$watch" "$SCRIPTS/queue-wait" 1 10 & legacy_supervisor=$!
+jq --argjson pid "$legacy_supervisor" '.status="watching"|.supervisor_pid=$pid|.deadline=((now|floor)+600)|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-watching.json"
 chmod 600 "$TMP/legacy-watching.json"; mv "$TMP/legacy-watching.json" "$state_path"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .action <<<"$result")" pending "legacy watching state remains active"
-kill -0 "$legacy_supervisor" 2>/dev/null && ok "legacy watching supervisor is preserved" || bad "legacy watching supervisor was terminated"
+running "$legacy_supervisor" && ok "legacy watching supervisor is preserved" || bad "legacy watching supervisor was terminated"
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
-touch "$RELEASE"
+if ! running "$legacy_supervisor"; then ok "direct legacy failure terminates tokenless supervisor"; else bad "direct legacy failure left tokenless supervisor running"; fi
+wait "$legacy_supervisor" 2>/dev/null || true
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+bash -c 'while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$state_path" "$watch" "$SCRIPTS/queue-wait" 1 10 & zombie_pid=$!
+export WATCH_PS_ZOMBIE_PID="$zombie_pid"
+jq --argjson pid "$zombie_pid" '.status="watching"|.supervisor_pid=$pid|.deadline=((now|floor)+600)|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-zombie.json"
+chmod 600 "$TMP/legacy-zombie.json"; mv "$TMP/legacy-zombie.json" "$state_path"
+result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
+eq "$(jq -r .status <<<"$result")" failed "production liveness treats zombie state as exited"
+if ! running "$zombie_pid"; then ok "test liveness helper treats zombie state as exited"; else bad "test liveness helper accepted zombie state"; fi
+unset WATCH_PS_ZOMBIE_PID
+kill "$zombie_pid" 2>/dev/null || true; wait "$zombie_pid" 2>/dev/null || true
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+jq '.status="launching"|.setup_deadline=0|.deadline=((now|floor)+600)|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-launching.json"
+chmod 600 "$TMP/legacy-launching.json"; mv "$TMP/legacy-launching.json" "$state_path"
+result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
+eq "$(jq -r .action <<<"$result")" resume_launch "orphaned legacy launch enters recovery"
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 
 prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)

--- a/skills/orch/tests/merge_queue_watch.sh
+++ b/skills/orch/tests/merge_queue_watch.sh
@@ -237,7 +237,6 @@ set -e
 if [[ "$early_ack_rc" -ne 0 ]]; then ok "pass acknowledgment refuses before cleanup"; else bad "pass acknowledgment completed before cleanup"; fi
 printf 'first postmerge stopped\n' > "$TMP/first.err"
 "$SCRIPTS/merge-queue-watch" acknowledge --root "$MAIN" --issue KEN-829 --watch-id "$watch" --result fail --diagnostic-file "$TMP/first.err" >/dev/null
-
 prep=$(prepare ejected review 0); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
 launch_bounded "$watch"; touch "$RELEASE"; wait_file "$artifact" || bad "ejected verdict missing"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
@@ -251,12 +250,10 @@ prepare ejected off 0 >/dev/null 2>"$TMP/reset.err"
 reset_rc=$?
 set -e
 if [[ "$reset_rc" -ne 0 ]]; then ok "next generation cannot reset gate mode or recovery count"; else bad "recovery context reset was accepted"; fi
-
 prep=$(prepare ejected review 1); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
 launch_bounded "$watch"; touch "$RELEASE"; wait_file "$artifact" || bad "cap verdict missing"
 result=$(CI_FIX_MAX_CYCLES=1 "$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .status <<<"$result")" failed "recovery cap terminalizes state"
-
 verdict_case disarmed recovery
 verdict_case conflicting restack
 verdict_case dequeued triage
@@ -264,7 +261,6 @@ verdict_case dequeue_failed manual_dequeue
 verdict_case stalled recovery
 verdict_case progressing rewatch
 verdict_case not_queued rearm
-
 prep=$(prepare dequeue_failed); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
 launch_bounded "$watch"; touch "$RELEASE"; wait_file "$artifact" || bad "dequeue-race verdict missing"
 printf 'merged\n' > "$MODE"
@@ -274,7 +270,6 @@ eq "$(jq -r .verdict_cause <<<"$result")" merged_race "merged dequeue race recor
 "$SCRIPTS/merge-queue-watch" merge-pr-complete --root "$MAIN" --issue KEN-829 --watch-id "$watch" >/dev/null
 printf 'race control complete\n' > "$TMP/race.err"
 "$SCRIPTS/merge-queue-watch" acknowledge --root "$MAIN" --issue KEN-829 --watch-id "$watch" --result fail --diagnostic-file "$TMP/race.err" >/dev/null
-
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
 launch_bounded "$watch"; touch "$RELEASE"; wait_file "$artifact" || bad "head-mismatch verdict missing"
 printf '%s\n' "$HEAD_B" > "$HEAD_FILE"
@@ -283,23 +278,19 @@ eq "$(jq -r .status <<<"$result")" failed "live head mismatch blocks merged post
 eq "$(jq -r .verdict_cause <<<"$result")" head_mismatch "head mismatch names the routing cause"
 eq "$(jq -r .diagnostic.cause <<<"$result")" merged "head mismatch preserves the producer verdict"
 printf '%s\n' "$HEAD_A" > "$HEAD_FILE"
-
 prep=$(prepare malformed); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
 launch_bounded "$watch"; touch "$RELEASE"; wait_file "$artifact" || bad "malformed-worker error artifact missing"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .status <<<"$result")" failed "unknown worker output terminalizes failed"
 eq "$(jq -r .worker_exit_code <<<"$result")" 7 "unknown output preserves worker exit"
 if [[ "$(jq -r .diagnostic_path <<<"$result")" == /* ]]; then ok "unknown output preserves absolute producer diagnostics"; else bad "unknown output lost diagnostics"; fi
-
 prep=$(prepare closed); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
 launch_bounded "$watch"; touch "$RELEASE"; wait_file "$artifact" || bad "closed verdict missing"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .status <<<"$result")" abandoned "closed verdict terminalizes abandoned"
-
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .diagnostic.cause <<<"$result")" watch_lost "missing stale artifact fails closed"
-
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause arm_failed >/dev/null
 set +e
@@ -307,7 +298,6 @@ set +e
 revive_rc=$?
 set -e
 if [[ "$revive_rc" -ne 0 ]]; then ok "failed prepared state cannot be revived by launch"; else bad "launch revived failed state"; fi
-
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
 touch "$WATCH_GH_PAUSE.enabled"
 "$SCRIPTS/merge-queue-watch" direct-merged --root "$MAIN" --issue KEN-829 --watch-id "$watch" >"$TMP/direct.out" 2>"$TMP/direct.err" & direct_pid=$!
@@ -317,7 +307,6 @@ touch "$WATCH_GH_PAUSE.release"
 set +e; wait "$direct_pid"; direct_rc=$?; set -e
 if [[ "$direct_rc" -ne 0 ]]; then ok "fail wins against an in-flight direct merge claim"; else bad "direct merge revived failed state"; fi
 rm -f "$WATCH_GH_PAUSE.enabled" "$WATCH_GH_PAUSE.entered" "$WATCH_GH_PAUSE.release"
-
 if [[ -n "$REAL_SETSID" ]]; then
   prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
   touch "$WATCH_SETUP_GATE.enabled"
@@ -329,7 +318,6 @@ if [[ -n "$REAL_SETSID" ]]; then
   eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .status)" watching "launch owns setup through watching transition"
   "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
   rm -f "$WATCH_SETUP_GATE.enabled" "$WATCH_SETUP_GATE.entered" "$WATCH_SETUP_GATE.release"
-
   prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
   touch "$WATCH_SETSID_FAIL"
   set +e; "$SCRIPTS/merge-queue-watch" launch --root "$MAIN" --issue KEN-829 --watch-id "$watch" >/dev/null 2>&1; setsid_rc=$?; set -e
@@ -342,7 +330,14 @@ if [[ -n "$REAL_SETSID" ]]; then
 else
   ok "launch setup race control skipped without setsid"
 fi
-
+prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep"); state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path); watch_dir=$(jq -r .watch_dir "$state_path"); legacy_runtime="$watch_dir/legacy-runtime"
+mkdir "$legacy_runtime"; printf '%s\n' "$watch" > "$legacy_runtime/token"
+jq --arg artifact "$watch_dir/verdict.json" --arg runtime "$legacy_runtime" '.artifact_path=$artifact|.runtime_dir=$runtime|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token,.legacy_generation)' "$state_path" > "$TMP/legacy-prepared.json"; chmod 600 "$TMP/legacy-prepared.json"; mv "$TMP/legacy-prepared.json" "$state_path"
+launch_bounded "$watch"
+legacy_state=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829)
+eq "$(jq -r .status <<<"$legacy_state")" watching "legacy prepared lifecycle launches after upgrade"
+[[ "$(jq -r .launch_attempt_id <<<"$legacy_state")" == "$watch-attempt-1" && "$(jq -r .runtime_dir <<<"$legacy_state")" != "$legacy_runtime" && "$(jq -r .watch_dir <<<"$legacy_state")" == "$watch_dir" ]] && ok "legacy prepared migration preserves watch cleanup identity" || bad "legacy prepared migration lost generation or cleanup identity"
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
 jq --arg attempt "$watch-attempt-1" --arg token "$watch-attempt-1-test" '.launch_attempt=1|.launch_attempt_id=$attempt|.supervisor_token=$token|.status="launching"|.setup_deadline=0|.deadline=((now|floor)+600)' "$state_path" > "$TMP/orphan.json"
@@ -432,7 +427,12 @@ rm -f -- "$WATCH_SUPERVISOR_PID_GATE.enabled" "$WATCH_SUPERVISOR_PID_GATE.entere
 if [[ "$setup_rc" -ne 0 ]]; then ok "supervisor failure before ready exits nonzero"; else bad "supervisor failure before ready exited zero"; fi
 eq "$(jq -r .verdict "$artifact")" unknown "dead supervisor publishes its setup failure"
 old_inode=$(inode "$artifact")
-retry_state=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829); reserved_runtime="$(jq -r .runtime_root <<<"$retry_state")/$watch-attempt-2"; mkdir "$reserved_runtime"; touch "$reserved_runtime/interrupted-marker"
+retry_state=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829); runtime_root=$(jq -r .runtime_root <<<"$retry_state"); outside_runtime="$(dirname "$(dirname "$runtime_root")")/outside-attempt-2"; mismatch_runtime="$runtime_root/other-watch-attempt-2"
+mkdir "$outside_runtime" "$mismatch_runtime"; touch "$outside_runtime/sentinel" "$mismatch_runtime/sentinel"
+set +e; "$SCRIPTS/merge-queue-watch" launch --root "$MAIN" --issue KEN-829 --watch-id ../../outside --poll 1 --max-wait 10 >/dev/null 2>&1; traversal_rc=$?; "$SCRIPTS/merge-queue-watch" launch --root "$MAIN" --issue KEN-829 --watch-id other-watch --poll 1 --max-wait 10 >/dev/null 2>&1; mismatch_rc=$?; set -e
+[[ "$traversal_rc" -ne 0 && -e "$outside_runtime/sentinel" ]] && ok "traversal watch id cannot change an external attempt path" || bad "traversal watch id changed an external attempt path"
+[[ "$mismatch_rc" -ne 0 && -e "$mismatch_runtime/sentinel" ]] && ok "mismatched watch id cannot change an attempt path" || bad "mismatched watch id changed an attempt path"
+reserved_runtime="$runtime_root/$watch-attempt-2"; mkdir "$reserved_runtime"; touch "$reserved_runtime/interrupted-marker"
 launch_bounded "$watch"
 [[ ! -e "$reserved_runtime/interrupted-marker" ]] && ok "retry reclaims only unregistered attempt runtime" || bad "interrupted reservation wedged retry"
 retry_artifact=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .artifact_path)

--- a/skills/orch/tests/merge_queue_watch.sh
+++ b/skills/orch/tests/merge_queue_watch.sh
@@ -118,7 +118,10 @@ fi
 cat > "$BIN/chmod" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-if [[ -f "$WATCH_SUPERVISOR_PID_DELAY" && "${*: -1}" == */supervisor.pid ]]; then sleep 6; fi
+if [[ -f "$WATCH_SUPERVISOR_PID_GATE.enabled" && "${*: -1}" == */supervisor.pid ]]; then
+  touch "$WATCH_SUPERVISOR_PID_GATE.entered"
+  while [[ ! -f "$WATCH_SUPERVISOR_PID_GATE.release" ]]; do sleep 0.05; done
+fi
 exec "$WATCH_REAL_CHMOD" "$@"
 EOF
 chmod +x "$BIN/chmod"
@@ -137,12 +140,17 @@ cat > "$BIN/ps" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 if [[ "${MERGE_QUEUE_FORCE_PS_IDENTITY:-0}" == 1 ]]; then printf '%s\n' "$*" >> "$WATCH_PS_LOG"; fi
+if [[ -f "$WATCH_SUPERVISOR_PID_GATE.enabled" ]]; then
+  calls=0; [[ ! -f "$WATCH_SUPERVISOR_PID_GATE.calls" ]] || calls=$(cat < "$WATCH_SUPERVISOR_PID_GATE.calls")
+  calls=$((calls+1)); printf '%s\n' "$calls" > "$WATCH_SUPERVISOR_PID_GATE.calls"
+  [[ "$calls" -lt 2 ]] || touch "$WATCH_SUPERVISOR_PID_GATE.release"
+fi
 exec "$WATCH_REAL_PS" "$@"
 EOF
 chmod +x "$BIN/ps"
 export PATH="$BIN:$PATH" WATCH_MODE="$MODE" WATCH_RELEASE="$RELEASE" WATCH_HEAD_FILE="$HEAD_FILE" WATCH_MAIN="$MAIN" WATCH_WORKTREE="$WT"
 export WATCH_GH_PAUSE="$TMP/gh-pause" WATCH_SETUP_GATE="$TMP/setup-gate" WATCH_REAL_SETSID="$REAL_SETSID" WATCH_CLEANUP_FAIL="$TMP/cleanup-fail" WATCH_CLEANUP_INTERRUPT="$TMP/cleanup-interrupt"
-export WATCH_SETSID_FAIL="$TMP/setsid-fail" WATCH_SETSID_DELAY="$TMP/setsid-delay" WATCH_CLEANUP_PAUSE="$TMP/cleanup-pause" WATCH_AUTH_LOG="$TMP/auth.log" WATCH_WORKER_LOG="$TMP/worker.log" WATCH_REAL_CHMOD="$REAL_CHMOD" WATCH_REAL_FLOCK="$REAL_FLOCK" WATCH_FAIL_FLOCK_GATE="$TMP/fail-flock-gate" WATCH_REAL_PS="$REAL_PS" WATCH_PS_LOG="$TMP/ps.log" WATCH_SUPERVISOR_PID_DELAY="$TMP/supervisor-pid-delay" GH_REPO=wrong/repository GITHUB_REPOSITORY=wrong/repository
+export WATCH_SETSID_FAIL="$TMP/setsid-fail" WATCH_SETSID_DELAY="$TMP/setsid-delay" WATCH_CLEANUP_PAUSE="$TMP/cleanup-pause" WATCH_AUTH_LOG="$TMP/auth.log" WATCH_WORKER_LOG="$TMP/worker.log" WATCH_REAL_CHMOD="$REAL_CHMOD" WATCH_REAL_FLOCK="$REAL_FLOCK" WATCH_FAIL_FLOCK_GATE="$TMP/fail-flock-gate" WATCH_REAL_PS="$REAL_PS" WATCH_PS_LOG="$TMP/ps.log" WATCH_SUPERVISOR_PID_GATE="$TMP/supervisor-pid-gate" GH_REPO=wrong/repository GITHUB_REPOSITORY=wrong/repository
 touch "$WATCH_PS_LOG"
 unset GH_TOKEN GITHUB_TOKEN GH_BOT_TOKEN
 init_out=$("$SCRIPTS/merge-queue-watch" init --worktree "$WT" --issue KEN-829 --branch watch-test)
@@ -385,12 +393,17 @@ eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 
 prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
-touch "$WATCH_SUPERVISOR_PID_DELAY"
+rm -f -- "$WATCH_SUPERVISOR_PID_GATE.entered" "$WATCH_SUPERVISOR_PID_GATE.release" "$WATCH_SUPERVISOR_PID_GATE.calls"
+touch "$WATCH_SUPERVISOR_PID_GATE.enabled"
+export MERGE_QUEUE_FORCE_PS_IDENTITY=1
 set +e
 "$SCRIPTS/merge-queue-watch" launch --root "$MAIN" --issue KEN-829 --watch-id "$watch" --poll 1 --max-wait 10 >/dev/null 2>&1
 setup_rc=$?
 set -e
-rm -f -- "$WATCH_SUPERVISOR_PID_DELAY"
+unset MERGE_QUEUE_FORCE_PS_IDENTITY
+wait_exists "$WATCH_SUPERVISOR_PID_GATE.entered" && ok "supervisor setup entered the explicit delay gate" || bad "supervisor setup bypassed the explicit delay gate"
+wait_exists "$WATCH_SUPERVISOR_PID_GATE.release" && ok "teardown released the delayed supervisor" || bad "teardown never released the delayed supervisor"
+rm -f -- "$WATCH_SUPERVISOR_PID_GATE.enabled" "$WATCH_SUPERVISOR_PID_GATE.entered" "$WATCH_SUPERVISOR_PID_GATE.release" "$WATCH_SUPERVISOR_PID_GATE.calls"
 if [[ "$setup_rc" -ne 0 ]]; then ok "supervisor failure before ready exits nonzero"; else bad "supervisor failure before ready exited zero"; fi
 eq "$(jq -r .verdict "$artifact")" unknown "dead supervisor publishes its setup failure"
 old_inode=$(inode "$artifact")

--- a/skills/orch/tests/merge_queue_watch.sh
+++ b/skills/orch/tests/merge_queue_watch.sh
@@ -3,8 +3,9 @@ set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ORCH="$(cd "$TEST_DIR/.." && pwd)"
-TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+TMP_ROOT="$(mktemp -d)"; TMP="$TMP_ROOT/watch path"
+mkdir "$TMP"
+trap 'rm -rf "$TMP_ROOT"' EXIT
 PASS=0 FAIL=0
 ok() { PASS=$((PASS+1)); printf '  ok    %s\n' "$1"; }
 bad() { FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$1"; }
@@ -308,7 +309,7 @@ fi
 
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
-jq --arg attempt "$watch-attempt-1" '.launch_attempt=1|.launch_attempt_id=$attempt|.status="launching"|.setup_deadline=0|.deadline=((now|floor)+600)' "$state_path" > "$TMP/orphan.json"
+jq --arg attempt "$watch-attempt-1" --arg token "$watch-attempt-1-test" '.launch_attempt=1|.launch_attempt_id=$attempt|.supervisor_token=$token|.status="launching"|.setup_deadline=0|.deadline=((now|floor)+600)' "$state_path" > "$TMP/orphan.json"
 chmod 600 "$TMP/orphan.json"; mv "$TMP/orphan.json" "$state_path"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .action <<<"$result")" resume_launch "orphaned launching state wakes into launch recovery"
@@ -500,6 +501,46 @@ chmod 600 "$TMP/similar-attempt-state.json"; mv "$TMP/similar-attempt-state.json
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 kill -0 "$similar_attempt_pid" 2>/dev/null && ok "attempt identity compares argv fields exactly" || bad "attempt-1 matched and signaled attempt-10"
 kill "$similar_attempt_pid" 2>/dev/null || true; wait "$similar_attempt_pid" 2>/dev/null || true
+touch "$RELEASE"
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+launch_bounded "$watch"
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+fallback_supervisor=$(jq -r .supervisor_pid "$state_path")
+export MERGE_QUEUE_FORCE_PS_IDENTITY=1
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+if ! kill -0 "$fallback_supervisor" 2>/dev/null; then ok "ps environment identity supports repository paths with spaces"; else bad "ps fallback rejected a valid supervisor under a whitespace path"; fi
+unset MERGE_QUEUE_FORCE_PS_IDENTITY
+touch "$RELEASE"
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+launch_bounded "$watch"
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+attempt=$(jq -r .launch_attempt_id "$state_path"); runtime=$(jq -r .runtime_dir "$state_path"); artifact=$(jq -r .artifact_path "$state_path"); identity=$(jq -r .supervisor_token "$state_path")
+env "MERGE_QUEUE_SUPERVISOR_TOKEN=${identity}0" bash -c 'while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$state_path" "$watch" "$attempt" "$runtime" "$artifact" 999 "$SCRIPTS/queue-wait" 1 10 & similar_identity_pid=$!
+jq --argjson pid "$similar_identity_pid" '.supervisor_pid=$pid' "$state_path" > "$TMP/similar-identity-state.json"
+chmod 600 "$TMP/similar-identity-state.json"; mv "$TMP/similar-identity-state.json" "$state_path"
+export MERGE_QUEUE_FORCE_PS_IDENTITY=1
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+kill -0 "$similar_identity_pid" 2>/dev/null && ok "ps environment identity rejects a similar generation" || bad "ps fallback matched a similar generation token"
+unset MERGE_QUEUE_FORCE_PS_IDENTITY
+kill "$similar_identity_pid" 2>/dev/null || true; wait "$similar_identity_pid" 2>/dev/null || true
+touch "$RELEASE"
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+launch_bounded "$watch"
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+attempt=$(jq -r .launch_attempt_id "$state_path"); runtime=$(jq -r .runtime_dir "$state_path"); artifact=$(jq -r .artifact_path "$state_path"); identity=$(jq -r .supervisor_token "$state_path")
+identity_changed="$TMP/identity-changed"
+env "WATCH_IDENTITY_CHANGED=$identity_changed" "MERGE_QUEUE_SUPERVISOR_TOKEN=$identity" bash -c 'trap '\''touch "$WATCH_IDENTITY_CHANGED"; exec env -u MERGE_QUEUE_SUPERVISOR_TOKEN sleep 30'\'' TERM; while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$state_path" "$watch" "$attempt" "$runtime" "$artifact" 999 "$SCRIPTS/queue-wait" 1 10 & changed_identity_pid=$!
+jq --argjson pid "$changed_identity_pid" '.supervisor_pid=$pid' "$state_path" > "$TMP/changed-identity-state.json"
+chmod 600 "$TMP/changed-identity-state.json"; mv "$TMP/changed-identity-state.json" "$state_path"
+export MERGE_QUEUE_FORCE_PS_IDENTITY=1
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+wait_exists "$identity_changed" && ok "teardown sent TERM to the captured identity" || bad "teardown never signaled the captured identity"
+kill -0 "$changed_identity_pid" 2>/dev/null && ok "teardown stops when the PID changes identity" || bad "teardown escalated KILL after identity changed"
+unset MERGE_QUEUE_FORCE_PS_IDENTITY
+kill "$changed_identity_pid" 2>/dev/null || true; wait "$changed_identity_pid" 2>/dev/null || true
 touch "$RELEASE"
 
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")

--- a/skills/orch/tests/merge_queue_watch.sh
+++ b/skills/orch/tests/merge_queue_watch.sh
@@ -407,7 +407,9 @@ if [[ "$setup_error" == *"$SCRIPTS/queue-wait"* && "$setup_error" == *"diagnosti
 eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .status)" launch_failed "setup failure remains an active lifecycle"
 replay=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .action <<<"$replay")" resume_launch "setup failure cannot hand back before launch recovery"
+registered_runtime=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .runtime_dir); touch "$registered_runtime/registered-marker"
 launch_bounded "$watch"
+[[ -e "$registered_runtime/registered-marker" ]] && ok "registered attempt runtime is never reclaimed" || bad "retry reclaimed registered attempt runtime"
 eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .status)" watching "same watch retries after setup repair"
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 
@@ -430,7 +432,9 @@ rm -f -- "$WATCH_SUPERVISOR_PID_GATE.enabled" "$WATCH_SUPERVISOR_PID_GATE.entere
 if [[ "$setup_rc" -ne 0 ]]; then ok "supervisor failure before ready exits nonzero"; else bad "supervisor failure before ready exited zero"; fi
 eq "$(jq -r .verdict "$artifact")" unknown "dead supervisor publishes its setup failure"
 old_inode=$(inode "$artifact")
+retry_state=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829); reserved_runtime="$(jq -r .runtime_root <<<"$retry_state")/$watch-attempt-2"; mkdir "$reserved_runtime"; touch "$reserved_runtime/interrupted-marker"
 launch_bounded "$watch"
+[[ ! -e "$reserved_runtime/interrupted-marker" ]] && ok "retry reclaims only unregistered attempt runtime" || bad "interrupted reservation wedged retry"
 retry_artifact=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .artifact_path)
 [[ "$retry_artifact" != "$artifact" ]] && ok "retry reserves a fresh artifact identity" || bad "retry reused the dead supervisor artifact"
 touch "$RELEASE"; wait_file "$retry_artifact" || bad "retried supervisor verdict missing"

--- a/skills/orch/tests/merge_queue_watch.sh
+++ b/skills/orch/tests/merge_queue_watch.sh
@@ -643,13 +643,18 @@ rm -f -- "$WATCH_REGISTRATION_GATE.enabled" "$WATCH_REGISTRATION_GATE.entered" "
 prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
 bash -c 'while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$state_path" "$watch" "$SCRIPTS/queue-wait" 1 10 & legacy_supervisor=$!
-jq --argjson pid "$legacy_supervisor" '.status="watching"|.supervisor_pid=$pid|.deadline=((now|floor)+600)|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-watching.json"
+jq --argjson pid "$legacy_supervisor" '.status="launching"|.supervisor_pid=$pid|.setup_deadline=((now|floor)+10)|.deadline=((now|floor)+600)|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-watching.json"
 chmod 600 "$TMP/legacy-watching.json"; mv "$TMP/legacy-watching.json" "$state_path"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
-eq "$(jq -r .action <<<"$result")" pending "legacy watching state remains active"
+eq "$(jq -r .action <<<"$result")" pending "live legacy launching remains pending"
+jq '.setup_deadline=0' "$state_path" > "$TMP/legacy-launch-expired.json"; chmod 600 "$TMP/legacy-launch-expired.json"; mv "$TMP/legacy-launch-expired.json" "$state_path"
+result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
+eq "$(jq -r .action <<<"$result")" pending "expired live legacy launch is adopted"
+eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .status)" watching "legacy launch adoption persists watching"
 running "$legacy_supervisor" && ok "legacy watching supervisor is preserved" || bad "legacy watching supervisor was terminated"
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 if ! running "$legacy_supervisor"; then ok "direct legacy failure terminates tokenless supervisor"; else bad "direct legacy failure left tokenless supervisor running"; fi
+kill "$legacy_supervisor" 2>/dev/null || true
 wait "$legacy_supervisor" 2>/dev/null || true
 
 prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
@@ -676,12 +681,16 @@ prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
 legacy_runtime=$(jq -r .runtime_dir "$state_path")
 printf '%s\n' "$watch" > "$legacy_runtime/token"
-jq '.status="launch_failed"|.action="launch"|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-launch-failed.json"
+bash -c 'while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$state_path" "$watch" "$SCRIPTS/queue-wait" 1 10 & legacy_retry_supervisor=$!
+jq --argjson pid "$legacy_retry_supervisor" '.status="launch_failed"|.action="launch"|.supervisor_pid=$pid|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-launch-failed.json"
 chmod 600 "$TMP/legacy-launch-failed.json"; mv "$TMP/legacy-launch-failed.json" "$state_path"
 launch_bounded "$watch"
 legacy_retry_state=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .status <<<"$legacy_retry_state")" watching "legacy launch failure retries on a migrated generation"
 [[ "$(jq -r .runtime_dir <<<"$legacy_retry_state")" != "$legacy_runtime" ]] && ok "legacy retry receives an isolated runtime" || bad "legacy retry reused legacy runtime"
+if ! running "$legacy_retry_supervisor"; then ok "legacy retry terminates old supervisor before replacement"; else bad "legacy retry left old supervisor running"; fi
+kill "$legacy_retry_supervisor" 2>/dev/null || true
+wait "$legacy_retry_supervisor" 2>/dev/null || true
 if [[ "$(jq -r .status <<<"$legacy_retry_state")" == watching ]]; then
   legacy_retry_artifact=$(jq -r .artifact_path <<<"$legacy_retry_state")
   touch "$RELEASE"; wait_file "$legacy_retry_artifact" || bad "legacy retry verdict missing"

--- a/skills/orch/tests/merge_queue_watch.sh
+++ b/skills/orch/tests/merge_queue_watch.sh
@@ -11,6 +11,7 @@ bad() { FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$1"; }
 eq() { if [[ "$1" == "$2" ]]; then ok "$3"; else bad "$3 (expected $2, got $1)"; fi; }
 wait_file() { local i; for ((i=0;i<100;i++)); do [[ -s "$1" ]] && return 0; sleep 0.05; done; return 1; }
 wait_exists() { local i; for ((i=0;i<100;i++)); do [[ -e "$1" ]] && return 0; sleep 0.05; done; return 1; }
+inode() { stat -c %i "$1" 2>/dev/null || stat -f %i "$1"; }
 
 MAIN="$TMP/main" WT="$TMP/worktree" BIN="$TMP/bin" SCRIPTS="$TMP/orch/scripts"
 REAL_SETSID=$(command -v setsid || true)
@@ -102,6 +103,10 @@ cat > "$BIN/setsid" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 [[ ! -f "$WATCH_SETSID_FAIL" ]] || exit 41
+if [[ -f "$WATCH_SETSID_DELAY.enabled" ]]; then
+  "$WATCH_REAL_SETSID" -f bash -c 'touch "$WATCH_SETSID_DELAY.entered"; while [[ ! -f "$WATCH_SETSID_DELAY.release" ]]; do sleep 0.05; done; exec "$@"' bash "$WATCH_REAL_SETSID" "$@"
+  exit 0
+fi
 if [[ -f "$WATCH_SETUP_GATE.enabled" ]]; then touch "$WATCH_SETUP_GATE.entered"; while [[ ! -f "$WATCH_SETUP_GATE.release" ]]; do sleep 0.05; done; fi
 exec "$WATCH_REAL_SETSID" "$@"
 EOF
@@ -116,7 +121,7 @@ EOF
 chmod +x "$BIN/chmod"
 export PATH="$BIN:$PATH" WATCH_MODE="$MODE" WATCH_RELEASE="$RELEASE" WATCH_HEAD_FILE="$HEAD_FILE" WATCH_MAIN="$MAIN" WATCH_WORKTREE="$WT"
 export WATCH_GH_PAUSE="$TMP/gh-pause" WATCH_SETUP_GATE="$TMP/setup-gate" WATCH_REAL_SETSID="$REAL_SETSID" WATCH_CLEANUP_FAIL="$TMP/cleanup-fail" WATCH_CLEANUP_INTERRUPT="$TMP/cleanup-interrupt"
-export WATCH_SETSID_FAIL="$TMP/setsid-fail" WATCH_CLEANUP_PAUSE="$TMP/cleanup-pause" WATCH_AUTH_LOG="$TMP/auth.log" WATCH_WORKER_LOG="$TMP/worker.log" WATCH_REAL_CHMOD="$REAL_CHMOD" WATCH_SUPERVISOR_PID_DELAY="$TMP/supervisor-pid-delay" GH_REPO=wrong/repository GITHUB_REPOSITORY=wrong/repository
+export WATCH_SETSID_FAIL="$TMP/setsid-fail" WATCH_SETSID_DELAY="$TMP/setsid-delay" WATCH_CLEANUP_PAUSE="$TMP/cleanup-pause" WATCH_AUTH_LOG="$TMP/auth.log" WATCH_WORKER_LOG="$TMP/worker.log" WATCH_REAL_CHMOD="$REAL_CHMOD" WATCH_SUPERVISOR_PID_DELAY="$TMP/supervisor-pid-delay" GH_REPO=wrong/repository GITHUB_REPOSITORY=wrong/repository
 unset GH_TOKEN GITHUB_TOKEN GH_BOT_TOKEN
 init_out=$("$SCRIPTS/merge-queue-watch" init --worktree "$WT" --issue KEN-829 --branch watch-test)
 eq "$(jq -r .exists <<<"$init_out")" true "standalone init creates workflow state"
@@ -162,6 +167,7 @@ if kill -0 "$supervisor" 2>/dev/null; then ok "supervisor survives the launch co
 touch "$RELEASE"; wait_file "$artifact" || bad "merged verdict was not published"
 eq "$(jq -r .watch_id "$artifact")" "$watch" "artifact binds watch id"
 eq "$(jq -r .expected_head "$artifact")" "$HEAD_A" "artifact binds expected head"
+eq "$(jq -r .launch_attempt_id "$artifact")" "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .launch_attempt_id)" "artifact binds launch attempt"
 event_out=$("$SCRIPTS/merge-queue-watch" event --root "$MAIN" --issue KEN-829)
 if [[ "$event_out" == ready* ]]; then ok "fleet event wakes the owner once verdict exists"; else bad "fleet event missing"; fi
 event_again=$("$SCRIPTS/merge-queue-watch" event --root "$MAIN" --issue KEN-829)
@@ -290,7 +296,7 @@ fi
 
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
-jq '.status="launching"|.setup_deadline=0|.deadline=((now|floor)+600)' "$state_path" > "$TMP/orphan.json"
+jq --arg attempt "$watch-attempt-1" '.launch_attempt=1|.launch_attempt_id=$attempt|.status="launching"|.setup_deadline=0|.deadline=((now|floor)+600)' "$state_path" > "$TMP/orphan.json"
 chmod 600 "$TMP/orphan.json"; mv "$TMP/orphan.json" "$state_path"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .action <<<"$result")" resume_launch "orphaned launching state wakes into launch recovery"
@@ -315,9 +321,9 @@ eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -
 
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
-jq '.status="launching"|.setup_deadline=((now|floor)+10)|.deadline=((now|floor)+600)' "$state_path" > "$TMP/completed-launch.json"
+jq --arg attempt "$watch-attempt-1" '.launch_attempt=1|.launch_attempt_id=$attempt|.status="launching"|.setup_deadline=((now|floor)+10)|.deadline=((now|floor)+600)' "$state_path" > "$TMP/completed-launch.json"
 chmod 600 "$TMP/completed-launch.json"; mv "$TMP/completed-launch.json" "$state_path"
-jq -n --arg watch "$watch" --arg head "$HEAD_A" '{schema_version:1,status:"complete",verdict:"merged",repository:"owner/repo",pr_number:42,expected_head:$head,observed_head:"",watch_id:$watch}' > "$artifact"
+jq -n --arg watch "$watch" --arg attempt "$watch-attempt-1" --arg head "$HEAD_A" '{schema_version:1,status:"complete",verdict:"merged",repository:"owner/repo",pr_number:42,expected_head:$head,observed_head:"",watch_id:$watch,launch_attempt_id:$attempt}' > "$artifact"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .action <<<"$result")" postmerge "completed artifact outranks launching setup state"
 "$SCRIPTS/merge-queue-watch" merge-pr-complete --root "$MAIN" --issue KEN-829 --watch-id "$watch" >/dev/null
@@ -365,14 +371,65 @@ set -e
 rm -f -- "$WATCH_SUPERVISOR_PID_DELAY"
 if [[ "$setup_rc" -ne 0 ]]; then ok "supervisor failure before ready exits nonzero"; else bad "supervisor failure before ready exited zero"; fi
 eq "$(jq -r .verdict "$artifact")" unknown "dead supervisor publishes its setup failure"
+old_inode=$(inode "$artifact")
 launch_bounded "$watch"
 retry_artifact=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .artifact_path)
 [[ "$retry_artifact" != "$artifact" ]] && ok "retry reserves a fresh artifact identity" || bad "retry reused the dead supervisor artifact"
 touch "$RELEASE"; wait_file "$retry_artifact" || bad "retried supervisor verdict missing"
 eq "$(jq -r .verdict "$retry_artifact")" ejected "retry publishes the new supervisor verdict"
+eq "$(jq -r .verdict "$artifact")" unknown "retry preserves the dead supervisor artifact"
+[[ "$(inode "$retry_artifact")" != "$old_inode" ]] && ok "retry artifact has its own inode" || bad "retry artifact reused the dead supervisor output inode"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .action <<<"$result")" recovery "consume routes the retried supervisor verdict"
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
+launch_bounded "$watch"; touch "$RELEASE"; wait_file "$artifact" || bad "stale-consume fixture verdict missing"
+touch "$WATCH_GH_PAUSE.enabled"
+"$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829 >"$TMP/stale-consume.out" 2>"$TMP/stale-consume.err" & stale_consume_pid=$!
+wait_exists "$WATCH_GH_PAUSE.entered" || bad "consume did not capture the old launch attempt"
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+jq '.status="launch_failed"|.action="launch"|.supervisor_pid=null' "$state_path" > "$TMP/stale-consume-state.json"
+chmod 600 "$TMP/stale-consume-state.json"; mv "$TMP/stale-consume-state.json" "$state_path"
+launch_bounded "$watch"
+replacement_artifact=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .artifact_path)
+touch "$WATCH_GH_PAUSE.release"
+set +e; wait "$stale_consume_pid"; stale_consume_rc=$?; set -e
+[[ "$stale_consume_rc" -ne 0 ]] && ok "stale consume cannot claim the replacement attempt" || bad "stale consume claimed across the launch-attempt fence"
+eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .status)" watching "stale consume leaves the replacement attempt active"
+wait_file "$replacement_artifact" || bad "replacement verdict missing after stale consume"
+result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
+eq "$(jq -r .action <<<"$result")" recovery "replacement verdict survives stale consume"
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+rm -f -- "$WATCH_GH_PAUSE.enabled" "$WATCH_GH_PAUSE.entered" "$WATCH_GH_PAUSE.release"
+
+if [[ -n "$REAL_SETSID" ]]; then
+  prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
+  delayed_runtime=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .runtime_dir)
+  touch "$WATCH_SETSID_DELAY.enabled"
+  set +e; "$SCRIPTS/merge-queue-watch" launch --root "$MAIN" --issue KEN-829 --watch-id "$watch" --poll 1 --max-wait 10 >/dev/null 2>&1; delayed_rc=$?; set -e
+  [[ "$delayed_rc" -ne 0 ]] && ok "pre-PID supervisor delay enters launch recovery" || bad "pre-PID supervisor delay reported success"
+  wait_exists "$WATCH_SETSID_DELAY.entered" || bad "pre-PID supervisor did not enter its delay gate"
+  rm -f -- "$WATCH_SETSID_DELAY.enabled"
+  launch_bounded "$watch"
+  delayed_replacement_artifact=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .artifact_path)
+  delayed_replacement_runtime=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .runtime_dir)
+  [[ "$delayed_replacement_runtime" != "$delayed_runtime" ]] && ok "replacement attempt has its own runtime directory" || bad "replacement reused the delayed supervisor runtime"
+  touch "$RELEASE"
+  wait_file "$delayed_replacement_artifact" || bad "replacement verdict missing after delayed supervisor release"
+  printf 'malformed\n' > "$MODE"
+  touch "$WATCH_SETSID_DELAY.release"
+  sleep 0.5
+  [[ ! -e "$artifact" ]] && ok "unregistered delayed supervisor cannot publish into retry files" || bad "unregistered delayed supervisor published after retry"
+  eq "$(jq -r .verdict "$delayed_replacement_artifact")" ejected "unregistered delayed supervisor cannot rewrite the replacement verdict"
+  printf 'ejected\n' > "$MODE"
+  result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
+  eq "$(jq -r .action <<<"$result")" recovery "replacement verdict wins after delayed supervisor release"
+  "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+  rm -f -- "$WATCH_SETSID_DELAY.entered" "$WATCH_SETSID_DELAY.release"
+else
+  ok "pre-PID supervisor fence skipped without setsid"
+fi
 
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
 "$SCRIPTS/merge-queue-watch" direct-merged --root "$MAIN" --issue KEN-829 --watch-id "$watch" >/dev/null

--- a/skills/orch/tests/merge_queue_watch.sh
+++ b/skills/orch/tests/merge_queue_watch.sh
@@ -18,6 +18,7 @@ MAIN="$TMP/main" WT="$TMP/worktree" BIN="$TMP/bin" SCRIPTS="$TMP/orch/scripts"
 REAL_SETSID=$(command -v setsid || true)
 REAL_CHMOD=$(command -v chmod)
 REAL_FLOCK=$(command -v flock)
+REAL_PS=$(command -v ps)
 mkdir -p "$MAIN" "$BIN" "$SCRIPTS/lib"
 git -C "$MAIN" init -q
 git -C "$MAIN" config user.email test@example.com
@@ -132,9 +133,17 @@ fi
 exec "$WATCH_REAL_FLOCK" "$@"
 EOF
 chmod +x "$BIN/flock"
+cat > "$BIN/ps" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${MERGE_QUEUE_FORCE_PS_IDENTITY:-0}" == 1 ]]; then printf '%s\n' "$*" >> "$WATCH_PS_LOG"; fi
+exec "$WATCH_REAL_PS" "$@"
+EOF
+chmod +x "$BIN/ps"
 export PATH="$BIN:$PATH" WATCH_MODE="$MODE" WATCH_RELEASE="$RELEASE" WATCH_HEAD_FILE="$HEAD_FILE" WATCH_MAIN="$MAIN" WATCH_WORKTREE="$WT"
 export WATCH_GH_PAUSE="$TMP/gh-pause" WATCH_SETUP_GATE="$TMP/setup-gate" WATCH_REAL_SETSID="$REAL_SETSID" WATCH_CLEANUP_FAIL="$TMP/cleanup-fail" WATCH_CLEANUP_INTERRUPT="$TMP/cleanup-interrupt"
-export WATCH_SETSID_FAIL="$TMP/setsid-fail" WATCH_SETSID_DELAY="$TMP/setsid-delay" WATCH_CLEANUP_PAUSE="$TMP/cleanup-pause" WATCH_AUTH_LOG="$TMP/auth.log" WATCH_WORKER_LOG="$TMP/worker.log" WATCH_REAL_CHMOD="$REAL_CHMOD" WATCH_REAL_FLOCK="$REAL_FLOCK" WATCH_FAIL_FLOCK_GATE="$TMP/fail-flock-gate" WATCH_SUPERVISOR_PID_DELAY="$TMP/supervisor-pid-delay" GH_REPO=wrong/repository GITHUB_REPOSITORY=wrong/repository
+export WATCH_SETSID_FAIL="$TMP/setsid-fail" WATCH_SETSID_DELAY="$TMP/setsid-delay" WATCH_CLEANUP_PAUSE="$TMP/cleanup-pause" WATCH_AUTH_LOG="$TMP/auth.log" WATCH_WORKER_LOG="$TMP/worker.log" WATCH_REAL_CHMOD="$REAL_CHMOD" WATCH_REAL_FLOCK="$REAL_FLOCK" WATCH_FAIL_FLOCK_GATE="$TMP/fail-flock-gate" WATCH_REAL_PS="$REAL_PS" WATCH_PS_LOG="$TMP/ps.log" WATCH_SUPERVISOR_PID_DELAY="$TMP/supervisor-pid-delay" GH_REPO=wrong/repository GITHUB_REPOSITORY=wrong/repository
+touch "$WATCH_PS_LOG"
 unset GH_TOKEN GITHUB_TOKEN GH_BOT_TOKEN
 init_out=$("$SCRIPTS/merge-queue-watch" init --worktree "$WT" --issue KEN-829 --branch watch-test)
 eq "$(jq -r .exists <<<"$init_out")" true "standalone init creates workflow state"
@@ -507,8 +516,10 @@ prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
 launch_bounded "$watch"
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
 fallback_supervisor=$(jq -r .supervisor_pid "$state_path")
+ps_calls=$(wc -l < "$WATCH_PS_LOG")
 export MERGE_QUEUE_FORCE_PS_IDENTITY=1
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+[[ "$(wc -l < "$WATCH_PS_LOG")" -gt "$ps_calls" ]] && ok "forced whitespace identity check invokes ps" || bad "forced whitespace identity check bypassed ps"
 if ! kill -0 "$fallback_supervisor" 2>/dev/null; then ok "ps environment identity supports repository paths with spaces"; else bad "ps fallback rejected a valid supervisor under a whitespace path"; fi
 unset MERGE_QUEUE_FORCE_PS_IDENTITY
 touch "$RELEASE"
@@ -520,8 +531,10 @@ attempt=$(jq -r .launch_attempt_id "$state_path"); runtime=$(jq -r .runtime_dir 
 env "MERGE_QUEUE_SUPERVISOR_TOKEN=${identity}0" bash -c 'while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$state_path" "$watch" "$attempt" "$runtime" "$artifact" 999 "$SCRIPTS/queue-wait" 1 10 & similar_identity_pid=$!
 jq --argjson pid "$similar_identity_pid" '.supervisor_pid=$pid' "$state_path" > "$TMP/similar-identity-state.json"
 chmod 600 "$TMP/similar-identity-state.json"; mv "$TMP/similar-identity-state.json" "$state_path"
+ps_calls=$(wc -l < "$WATCH_PS_LOG")
 export MERGE_QUEUE_FORCE_PS_IDENTITY=1
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+[[ "$(wc -l < "$WATCH_PS_LOG")" -gt "$ps_calls" ]] && ok "forced similar-generation check invokes ps" || bad "forced similar-generation check bypassed ps"
 kill -0 "$similar_identity_pid" 2>/dev/null && ok "ps environment identity rejects a similar generation" || bad "ps fallback matched a similar generation token"
 unset MERGE_QUEUE_FORCE_PS_IDENTITY
 kill "$similar_identity_pid" 2>/dev/null || true; wait "$similar_identity_pid" 2>/dev/null || true
@@ -535,8 +548,10 @@ identity_changed="$TMP/identity-changed"
 env "WATCH_IDENTITY_CHANGED=$identity_changed" "MERGE_QUEUE_SUPERVISOR_TOKEN=$identity" bash -c 'trap '\''touch "$WATCH_IDENTITY_CHANGED"; exec env -u MERGE_QUEUE_SUPERVISOR_TOKEN sleep 30'\'' TERM; while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$state_path" "$watch" "$attempt" "$runtime" "$artifact" 999 "$SCRIPTS/queue-wait" 1 10 & changed_identity_pid=$!
 jq --argjson pid "$changed_identity_pid" '.supervisor_pid=$pid' "$state_path" > "$TMP/changed-identity-state.json"
 chmod 600 "$TMP/changed-identity-state.json"; mv "$TMP/changed-identity-state.json" "$state_path"
+ps_calls=$(wc -l < "$WATCH_PS_LOG")
 export MERGE_QUEUE_FORCE_PS_IDENTITY=1
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+[[ "$(wc -l < "$WATCH_PS_LOG")" -gt "$ps_calls" ]] && ok "forced identity-change check invokes ps" || bad "forced identity-change check bypassed ps"
 wait_exists "$identity_changed" && ok "teardown sent TERM to the captured identity" || bad "teardown never signaled the captured identity"
 kill -0 "$changed_identity_pid" 2>/dev/null && ok "teardown stops when the PID changes identity" || bad "teardown escalated KILL after identity changed"
 unset MERGE_QUEUE_FORCE_PS_IDENTITY

--- a/skills/orch/tests/merge_queue_watch.sh
+++ b/skills/orch/tests/merge_queue_watch.sh
@@ -14,6 +14,7 @@ wait_exists() { local i; for ((i=0;i<100;i++)); do [[ -e "$1" ]] && return 0; sl
 
 MAIN="$TMP/main" WT="$TMP/worktree" BIN="$TMP/bin" SCRIPTS="$TMP/orch/scripts"
 REAL_SETSID=$(command -v setsid || true)
+REAL_CHMOD=$(command -v chmod)
 mkdir -p "$MAIN" "$BIN" "$SCRIPTS/lib"
 git -C "$MAIN" init -q
 git -C "$MAIN" config user.email test@example.com
@@ -106,9 +107,16 @@ exec "$WATCH_REAL_SETSID" "$@"
 EOF
 chmod +x "$BIN/setsid"
 fi
+cat > "$BIN/chmod" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ -f "$WATCH_SUPERVISOR_PID_DELAY" && "${*: -1}" == */supervisor.pid ]]; then sleep 6; fi
+exec "$WATCH_REAL_CHMOD" "$@"
+EOF
+chmod +x "$BIN/chmod"
 export PATH="$BIN:$PATH" WATCH_MODE="$MODE" WATCH_RELEASE="$RELEASE" WATCH_HEAD_FILE="$HEAD_FILE" WATCH_MAIN="$MAIN" WATCH_WORKTREE="$WT"
 export WATCH_GH_PAUSE="$TMP/gh-pause" WATCH_SETUP_GATE="$TMP/setup-gate" WATCH_REAL_SETSID="$REAL_SETSID" WATCH_CLEANUP_FAIL="$TMP/cleanup-fail" WATCH_CLEANUP_INTERRUPT="$TMP/cleanup-interrupt"
-export WATCH_SETSID_FAIL="$TMP/setsid-fail" WATCH_CLEANUP_PAUSE="$TMP/cleanup-pause" WATCH_AUTH_LOG="$TMP/auth.log" WATCH_WORKER_LOG="$TMP/worker.log" GH_REPO=wrong/repository GITHUB_REPOSITORY=wrong/repository
+export WATCH_SETSID_FAIL="$TMP/setsid-fail" WATCH_CLEANUP_PAUSE="$TMP/cleanup-pause" WATCH_AUTH_LOG="$TMP/auth.log" WATCH_WORKER_LOG="$TMP/worker.log" WATCH_REAL_CHMOD="$REAL_CHMOD" WATCH_SUPERVISOR_PID_DELAY="$TMP/supervisor-pid-delay" GH_REPO=wrong/repository GITHUB_REPOSITORY=wrong/repository
 unset GH_TOKEN GITHUB_TOKEN GH_BOT_TOKEN
 init_out=$("$SCRIPTS/merge-queue-watch" init --worktree "$WT" --issue KEN-829 --branch watch-test)
 eq "$(jq -r .exists <<<"$init_out")" true "standalone init creates workflow state"
@@ -346,6 +354,24 @@ replay=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .action <<<"$replay")" resume_launch "setup failure cannot hand back before launch recovery"
 launch_bounded "$watch"
 eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .status)" watching "same watch retries after setup repair"
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
+touch "$WATCH_SUPERVISOR_PID_DELAY"
+set +e
+"$SCRIPTS/merge-queue-watch" launch --root "$MAIN" --issue KEN-829 --watch-id "$watch" --poll 1 --max-wait 10 >/dev/null 2>&1
+setup_rc=$?
+set -e
+rm -f -- "$WATCH_SUPERVISOR_PID_DELAY"
+if [[ "$setup_rc" -ne 0 ]]; then ok "supervisor failure before ready exits nonzero"; else bad "supervisor failure before ready exited zero"; fi
+eq "$(jq -r .verdict "$artifact")" unknown "dead supervisor publishes its setup failure"
+launch_bounded "$watch"
+retry_artifact=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .artifact_path)
+[[ "$retry_artifact" != "$artifact" ]] && ok "retry reserves a fresh artifact identity" || bad "retry reused the dead supervisor artifact"
+touch "$RELEASE"; wait_file "$retry_artifact" || bad "retried supervisor verdict missing"
+eq "$(jq -r .verdict "$retry_artifact")" ejected "retry publishes the new supervisor verdict"
+result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
+eq "$(jq -r .action <<<"$result")" recovery "consume routes the retried supervisor verdict"
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")

--- a/skills/orch/tests/merge_queue_watch.sh
+++ b/skills/orch/tests/merge_queue_watch.sh
@@ -12,6 +12,7 @@ bad() { FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$1"; }
 eq() { if [[ "$1" == "$2" ]]; then ok "$3"; else bad "$3 (expected $2, got $1)"; fi; }
 wait_file() { local i; for ((i=0;i<100;i++)); do [[ -s "$1" ]] && return 0; sleep 0.05; done; return 1; }
 wait_exists() { local i; for ((i=0;i<100;i++)); do [[ -e "$1" ]] && return 0; sleep 0.05; done; return 1; }
+wait_state() { local i; for ((i=0;i<200;i++)); do [[ "$(jq -r .status "$1")" == "$2" ]] && return 0; sleep 0.05; done; return 1; }
 inode() { stat -c %i "$1" 2>/dev/null || stat -f %i "$1"; }
 
 MAIN="$TMP/main" WT="$TMP/worktree" BIN="$TMP/bin" SCRIPTS="$TMP/orch/scripts"
@@ -19,6 +20,7 @@ REAL_SETSID=$(command -v setsid || true)
 REAL_CHMOD=$(command -v chmod)
 REAL_FLOCK=$(command -v flock)
 REAL_PS=$(command -v ps)
+REAL_MKFIFO=$(command -v mkfifo)
 mkdir -p "$MAIN" "$BIN" "$SCRIPTS/lib"
 git -C "$MAIN" init -q
 git -C "$MAIN" config user.email test@example.com
@@ -59,6 +61,8 @@ set -euo pipefail
 source .env.local
 [[ "$GH_BOT_TOKEN" == ghp_project && "$GH_REPO" == owner/repo ]] || { printf '{"status":"error","verdict":"unknown","error":"detached auth scope missing"}\n'; exit 3; }
 printf '%s\n' "$PWD|$GH_REPO|$GH_BOT_TOKEN" >> "$WATCH_WORKER_LOG"
+printf '%s\n' "$$" > "$WATCH_WORKER_PID"
+printf '%s\n' "${MERGE_QUEUE_SUPERVISOR_TOKEN:-unset}" > "$WATCH_WORKER_TOKEN"
 while [[ ! -f "$WATCH_RELEASE" ]]; do sleep 0.05; done
 mode=$(cat < "$WATCH_MODE")
 case "$mode" in
@@ -143,14 +147,27 @@ if [[ "${MERGE_QUEUE_FORCE_PS_IDENTITY:-0}" == 1 ]]; then printf '%s\n' "$*" >> 
 if [[ -f "$WATCH_SUPERVISOR_PID_GATE.enabled" ]]; then
   calls=0; [[ ! -f "$WATCH_SUPERVISOR_PID_GATE.calls" ]] || calls=$(cat < "$WATCH_SUPERVISOR_PID_GATE.calls")
   calls=$((calls+1)); printf '%s\n' "$calls" > "$WATCH_SUPERVISOR_PID_GATE.calls"
+  if [[ "$calls" -eq 1 && -n "${WATCH_SUPERVISOR_PID_GATE_STATE:-}" ]]; then
+    jq -r .status "$WATCH_SUPERVISOR_PID_GATE_STATE" > "$WATCH_SUPERVISOR_PID_GATE.observed-status"
+  fi
   [[ "$calls" -lt 2 ]] || touch "$WATCH_SUPERVISOR_PID_GATE.release"
 fi
 exec "$WATCH_REAL_PS" "$@"
 EOF
 chmod +x "$BIN/ps"
+cat > "$BIN/mkfifo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ -f "$WATCH_REGISTRATION_GATE.enabled" && "$*" == *"/events"* ]]; then
+  touch "$WATCH_REGISTRATION_GATE.entered"
+  while [[ ! -f "$WATCH_REGISTRATION_GATE.release" ]]; do sleep 0.05; done
+fi
+exec "$WATCH_REAL_MKFIFO" "$@"
+EOF
+chmod +x "$BIN/mkfifo"
 export PATH="$BIN:$PATH" WATCH_MODE="$MODE" WATCH_RELEASE="$RELEASE" WATCH_HEAD_FILE="$HEAD_FILE" WATCH_MAIN="$MAIN" WATCH_WORKTREE="$WT"
 export WATCH_GH_PAUSE="$TMP/gh-pause" WATCH_SETUP_GATE="$TMP/setup-gate" WATCH_REAL_SETSID="$REAL_SETSID" WATCH_CLEANUP_FAIL="$TMP/cleanup-fail" WATCH_CLEANUP_INTERRUPT="$TMP/cleanup-interrupt"
-export WATCH_SETSID_FAIL="$TMP/setsid-fail" WATCH_SETSID_DELAY="$TMP/setsid-delay" WATCH_CLEANUP_PAUSE="$TMP/cleanup-pause" WATCH_AUTH_LOG="$TMP/auth.log" WATCH_WORKER_LOG="$TMP/worker.log" WATCH_REAL_CHMOD="$REAL_CHMOD" WATCH_REAL_FLOCK="$REAL_FLOCK" WATCH_FAIL_FLOCK_GATE="$TMP/fail-flock-gate" WATCH_REAL_PS="$REAL_PS" WATCH_PS_LOG="$TMP/ps.log" WATCH_SUPERVISOR_PID_GATE="$TMP/supervisor-pid-gate" GH_REPO=wrong/repository GITHUB_REPOSITORY=wrong/repository
+export WATCH_SETSID_FAIL="$TMP/setsid-fail" WATCH_SETSID_DELAY="$TMP/setsid-delay" WATCH_CLEANUP_PAUSE="$TMP/cleanup-pause" WATCH_AUTH_LOG="$TMP/auth.log" WATCH_WORKER_LOG="$TMP/worker.log" WATCH_WORKER_PID="$TMP/worker.pid" WATCH_WORKER_TOKEN="$TMP/worker.token" WATCH_REAL_CHMOD="$REAL_CHMOD" WATCH_REAL_FLOCK="$REAL_FLOCK" WATCH_FAIL_FLOCK_GATE="$TMP/fail-flock-gate" WATCH_REAL_PS="$REAL_PS" WATCH_PS_LOG="$TMP/ps.log" WATCH_SUPERVISOR_PID_GATE="$TMP/supervisor-pid-gate" WATCH_REAL_MKFIFO="$REAL_MKFIFO" WATCH_REGISTRATION_GATE="$TMP/registration-gate" GH_REPO=wrong/repository GITHUB_REPOSITORY=wrong/repository
 touch "$WATCH_PS_LOG"
 unset GH_TOKEN GITHUB_TOKEN GH_BOT_TOKEN
 init_out=$("$SCRIPTS/merge-queue-watch" init --worktree "$WT" --issue KEN-829 --branch watch-test)
@@ -393,17 +410,21 @@ eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 
 prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
-rm -f -- "$WATCH_SUPERVISOR_PID_GATE.entered" "$WATCH_SUPERVISOR_PID_GATE.release" "$WATCH_SUPERVISOR_PID_GATE.calls"
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+rm -f -- "$WATCH_SUPERVISOR_PID_GATE.entered" "$WATCH_SUPERVISOR_PID_GATE.release" "$WATCH_SUPERVISOR_PID_GATE.calls" "$WATCH_SUPERVISOR_PID_GATE.observed-status"
 touch "$WATCH_SUPERVISOR_PID_GATE.enabled"
+export WATCH_SUPERVISOR_PID_GATE_STATE="$state_path"
 export MERGE_QUEUE_FORCE_PS_IDENTITY=1
 set +e
 "$SCRIPTS/merge-queue-watch" launch --root "$MAIN" --issue KEN-829 --watch-id "$watch" --poll 1 --max-wait 10 >/dev/null 2>&1
 setup_rc=$?
 set -e
 unset MERGE_QUEUE_FORCE_PS_IDENTITY
+unset WATCH_SUPERVISOR_PID_GATE_STATE
 wait_exists "$WATCH_SUPERVISOR_PID_GATE.entered" && ok "supervisor setup entered the explicit delay gate" || bad "supervisor setup bypassed the explicit delay gate"
 wait_exists "$WATCH_SUPERVISOR_PID_GATE.release" && ok "teardown released the delayed supervisor" || bad "teardown never released the delayed supervisor"
-rm -f -- "$WATCH_SUPERVISOR_PID_GATE.enabled" "$WATCH_SUPERVISOR_PID_GATE.entered" "$WATCH_SUPERVISOR_PID_GATE.release" "$WATCH_SUPERVISOR_PID_GATE.calls"
+eq "$(cat < "$WATCH_SUPERVISOR_PID_GATE.observed-status")" launch_failed "launch failure claims state before supervisor teardown"
+rm -f -- "$WATCH_SUPERVISOR_PID_GATE.enabled" "$WATCH_SUPERVISOR_PID_GATE.entered" "$WATCH_SUPERVISOR_PID_GATE.release" "$WATCH_SUPERVISOR_PID_GATE.calls" "$WATCH_SUPERVISOR_PID_GATE.observed-status"
 if [[ "$setup_rc" -ne 0 ]]; then ok "supervisor failure before ready exits nonzero"; else bad "supervisor failure before ready exited zero"; fi
 eq "$(jq -r .verdict "$artifact")" unknown "dead supervisor publishes its setup failure"
 old_inode=$(inode "$artifact")
@@ -570,6 +591,82 @@ kill -0 "$changed_identity_pid" 2>/dev/null && ok "teardown stops when the PID c
 unset MERGE_QUEUE_FORCE_PS_IDENTITY
 kill "$changed_identity_pid" 2>/dev/null || true; wait "$changed_identity_pid" 2>/dev/null || true
 touch "$RELEASE"
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+launch_bounded "$watch"
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+worker_pid=$(cat < "$WATCH_WORKER_PID")
+eq "$(cat < "$WATCH_WORKER_TOKEN")" unset "queue-wait worker does not inherit supervisor identity"
+jq --argjson pid "$worker_pid" '.supervisor_pid=$pid' "$state_path" > "$TMP/worker-pid-state.json"
+chmod 600 "$TMP/worker-pid-state.json"; mv "$TMP/worker-pid-state.json" "$state_path"
+export MERGE_QUEUE_FORCE_PS_IDENTITY=1
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+kill -0 "$worker_pid" 2>/dev/null && ok "reused worker PID cannot identify as supervisor" || bad "supervisor teardown signaled queue-wait descendant"
+unset MERGE_QUEUE_FORCE_PS_IDENTITY
+touch "$RELEASE"
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+launch_bounded "$watch"
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+identity=$(jq -r .supervisor_token "$state_path")
+env "MERGE_QUEUE_SUPERVISOR_TOKEN=$identity" bash -c 'while :; do sleep 1; done' "$SCRIPTS/queue-wait" 42 1 10 --json & wrong_command_pid=$!
+jq --argjson pid "$wrong_command_pid" '.supervisor_pid=$pid' "$state_path" > "$TMP/wrong-command-state.json"
+chmod 600 "$TMP/wrong-command-state.json"; mv "$TMP/wrong-command-state.json" "$state_path"
+export MERGE_QUEUE_FORCE_PS_IDENTITY=1
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+kill -0 "$wrong_command_pid" 2>/dev/null && ok "ps fallback requires supervisor command identity" || bad "ps fallback accepted non-supervisor command"
+unset MERGE_QUEUE_FORCE_PS_IDENTITY
+kill "$wrong_command_pid" 2>/dev/null || true; wait "$wrong_command_pid" 2>/dev/null || true
+touch "$RELEASE"
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+registration_runtime=$(jq -r .runtime_dir "$state_path"); worker_count=$(wc -l < "$WATCH_WORKER_LOG")
+rm -f -- "$WATCH_REGISTRATION_GATE.entered" "$WATCH_REGISTRATION_GATE.release"
+touch "$WATCH_REGISTRATION_GATE.enabled"
+"$SCRIPTS/merge-queue-watch" launch --root "$MAIN" --issue KEN-829 --watch-id "$watch" --poll 1 --max-wait 10 >"$TMP/registration-launch.out" 2>"$TMP/registration-launch.err" & registration_launch_pid=$!
+wait_exists "$WATCH_REGISTRATION_GATE.entered" || bad "supervisor did not pause before PID registration"
+wait_state "$state_path" launch_failed || bad "launch failure did not claim before PID registration"
+touch "$WATCH_REGISTRATION_GATE.release"
+set +e; wait "$registration_launch_pid"; registration_launch_rc=$?; set -e
+[[ "$registration_launch_rc" -ne 0 ]] && ok "post-check registration remains a launch failure" || bad "post-check registration revived launch"
+sleep 0.3
+eq "$(wc -l < "$WATCH_WORKER_LOG")" "$worker_count" "supervisor rechecks state after PID publication"
+registration_pid=$(cat < "$registration_runtime/supervisor.pid")
+if ! kill -0 "$registration_pid" 2>/dev/null; then ok "late-registering supervisor exits before deadline"; else bad "late-registering supervisor survived its failed generation"; fi
+touch "$RELEASE"
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+rm -f -- "$WATCH_REGISTRATION_GATE.enabled" "$WATCH_REGISTRATION_GATE.entered" "$WATCH_REGISTRATION_GATE.release"
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+launch_bounded "$watch"
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+legacy_supervisor=$(jq -r .supervisor_pid "$state_path")
+jq 'del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-watching.json"
+chmod 600 "$TMP/legacy-watching.json"; mv "$TMP/legacy-watching.json" "$state_path"
+result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
+eq "$(jq -r .action <<<"$result")" pending "legacy watching state remains active"
+kill -0 "$legacy_supervisor" 2>/dev/null && ok "legacy watching supervisor is preserved" || bad "legacy watching supervisor was terminated"
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+touch "$RELEASE"
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+legacy_runtime=$(jq -r .runtime_dir "$state_path")
+printf '%s\n' "$watch" > "$legacy_runtime/token"
+jq '.status="launch_failed"|.action="launch"|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-launch-failed.json"
+chmod 600 "$TMP/legacy-launch-failed.json"; mv "$TMP/legacy-launch-failed.json" "$state_path"
+launch_bounded "$watch"
+legacy_retry_state=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829)
+eq "$(jq -r .status <<<"$legacy_retry_state")" watching "legacy launch failure retries on a migrated generation"
+[[ "$(jq -r .runtime_dir <<<"$legacy_retry_state")" != "$legacy_runtime" ]] && ok "legacy retry receives an isolated runtime" || bad "legacy retry reused legacy runtime"
+if [[ "$(jq -r .status <<<"$legacy_retry_state")" == watching ]]; then
+  legacy_retry_artifact=$(jq -r .artifact_path <<<"$legacy_retry_state")
+  touch "$RELEASE"; wait_file "$legacy_retry_artifact" || bad "legacy retry verdict missing"
+  result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
+  eq "$(jq -r .action <<<"$result")" recovery "legacy retry verdict is consumable"
+fi
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
 "$SCRIPTS/merge-queue-watch" direct-merged --root "$MAIN" --issue KEN-829 --watch-id "$watch" >/dev/null

--- a/skills/orch/tests/merge_queue_watch.sh
+++ b/skills/orch/tests/merge_queue_watch.sh
@@ -16,6 +16,7 @@ inode() { stat -c %i "$1" 2>/dev/null || stat -f %i "$1"; }
 MAIN="$TMP/main" WT="$TMP/worktree" BIN="$TMP/bin" SCRIPTS="$TMP/orch/scripts"
 REAL_SETSID=$(command -v setsid || true)
 REAL_CHMOD=$(command -v chmod)
+REAL_FLOCK=$(command -v flock)
 mkdir -p "$MAIN" "$BIN" "$SCRIPTS/lib"
 git -C "$MAIN" init -q
 git -C "$MAIN" config user.email test@example.com
@@ -119,9 +120,20 @@ if [[ -f "$WATCH_SUPERVISOR_PID_DELAY" && "${*: -1}" == */supervisor.pid ]]; the
 exec "$WATCH_REAL_CHMOD" "$@"
 EOF
 chmod +x "$BIN/chmod"
+cat > "$BIN/flock" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ -f "$WATCH_FAIL_FLOCK_GATE.enabled" && "${1:-}" == -w ]]; then
+  rm -f -- "$WATCH_FAIL_FLOCK_GATE.enabled"
+  touch "$WATCH_FAIL_FLOCK_GATE.entered"
+  while [[ ! -f "$WATCH_FAIL_FLOCK_GATE.release" ]]; do sleep 0.05; done
+fi
+exec "$WATCH_REAL_FLOCK" "$@"
+EOF
+chmod +x "$BIN/flock"
 export PATH="$BIN:$PATH" WATCH_MODE="$MODE" WATCH_RELEASE="$RELEASE" WATCH_HEAD_FILE="$HEAD_FILE" WATCH_MAIN="$MAIN" WATCH_WORKTREE="$WT"
 export WATCH_GH_PAUSE="$TMP/gh-pause" WATCH_SETUP_GATE="$TMP/setup-gate" WATCH_REAL_SETSID="$REAL_SETSID" WATCH_CLEANUP_FAIL="$TMP/cleanup-fail" WATCH_CLEANUP_INTERRUPT="$TMP/cleanup-interrupt"
-export WATCH_SETSID_FAIL="$TMP/setsid-fail" WATCH_SETSID_DELAY="$TMP/setsid-delay" WATCH_CLEANUP_PAUSE="$TMP/cleanup-pause" WATCH_AUTH_LOG="$TMP/auth.log" WATCH_WORKER_LOG="$TMP/worker.log" WATCH_REAL_CHMOD="$REAL_CHMOD" WATCH_SUPERVISOR_PID_DELAY="$TMP/supervisor-pid-delay" GH_REPO=wrong/repository GITHUB_REPOSITORY=wrong/repository
+export WATCH_SETSID_FAIL="$TMP/setsid-fail" WATCH_SETSID_DELAY="$TMP/setsid-delay" WATCH_CLEANUP_PAUSE="$TMP/cleanup-pause" WATCH_AUTH_LOG="$TMP/auth.log" WATCH_WORKER_LOG="$TMP/worker.log" WATCH_REAL_CHMOD="$REAL_CHMOD" WATCH_REAL_FLOCK="$REAL_FLOCK" WATCH_FAIL_FLOCK_GATE="$TMP/fail-flock-gate" WATCH_SUPERVISOR_PID_DELAY="$TMP/supervisor-pid-delay" GH_REPO=wrong/repository GITHUB_REPOSITORY=wrong/repository
 unset GH_TOKEN GITHUB_TOKEN GH_BOT_TOKEN
 init_out=$("$SCRIPTS/merge-queue-watch" init --worktree "$WT" --issue KEN-829 --branch watch-test)
 eq "$(jq -r .exists <<<"$init_out")" true "standalone init creates workflow state"
@@ -403,6 +415,26 @@ eq "$(jq -r .action <<<"$result")" recovery "replacement verdict survives stale 
 "$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 rm -f -- "$WATCH_GH_PAUSE.enabled" "$WATCH_GH_PAUSE.entered" "$WATCH_GH_PAUSE.release"
 
+old_release="$TMP/publication-old-release"; new_release="$TMP/publication-new-release"
+rm -f -- "$old_release" "$new_release"
+export WATCH_RELEASE="$old_release"
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
+launch_bounded "$watch"
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+jq '.status="launch_failed"|.action="launch"|.supervisor_pid=null' "$state_path" > "$TMP/publication-state.json"
+chmod 600 "$TMP/publication-state.json"; mv "$TMP/publication-state.json" "$state_path"
+export WATCH_RELEASE="$new_release"
+launch_bounded "$watch"
+publication_replacement=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .artifact_path)
+touch "$new_release"; wait_file "$publication_replacement" || bad "publication-fence replacement verdict missing"
+touch "$old_release"; sleep 0.5
+[[ ! -e "$artifact" ]] && ok "stale started supervisor cannot publish after replacement" || bad "publication fence admitted the stale started supervisor"
+eq "$(jq -r .verdict "$publication_replacement")" ejected "stale publication leaves the replacement verdict intact"
+result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
+eq "$(jq -r .action <<<"$result")" recovery "replacement verdict survives stale publication"
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+export WATCH_RELEASE="$RELEASE"
+
 if [[ -n "$REAL_SETSID" ]]; then
   prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
   delayed_runtime=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .runtime_dir)
@@ -417,9 +449,11 @@ if [[ -n "$REAL_SETSID" ]]; then
   [[ "$delayed_replacement_runtime" != "$delayed_runtime" ]] && ok "replacement attempt has its own runtime directory" || bad "replacement reused the delayed supervisor runtime"
   touch "$RELEASE"
   wait_file "$delayed_replacement_artifact" || bad "replacement verdict missing after delayed supervisor release"
+  worker_count=$(wc -l < "$WATCH_WORKER_LOG")
   printf 'malformed\n' > "$MODE"
   touch "$WATCH_SETSID_DELAY.release"
   sleep 0.5
+  eq "$(wc -l < "$WATCH_WORKER_LOG")" "$worker_count" "unregistered delayed supervisor cannot start a worker"
   [[ ! -e "$artifact" ]] && ok "unregistered delayed supervisor cannot publish into retry files" || bad "unregistered delayed supervisor published after retry"
   eq "$(jq -r .verdict "$delayed_replacement_artifact")" ejected "unregistered delayed supervisor cannot rewrite the replacement verdict"
   printf 'ejected\n' > "$MODE"
@@ -430,6 +464,43 @@ if [[ -n "$REAL_SETSID" ]]; then
 else
   ok "pre-PID supervisor fence skipped without setsid"
 fi
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+launch_bounded "$watch"
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+old_attempt=$(jq -r .launch_attempt_id "$state_path"); old_runtime=$(jq -r .runtime_dir "$state_path"); old_artifact=$(jq -r .artifact_path "$state_path")
+old_supervisor=$(jq -r .supervisor_pid "$state_path")
+touch "$WATCH_FAIL_FLOCK_GATE.enabled"
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >"$TMP/fail-race.out" 2>"$TMP/fail-race.err" & fail_race_pid=$!
+wait_exists "$WATCH_FAIL_FLOCK_GATE.entered" || bad "fail command did not pause after generation capture"
+jq '.status="launch_failed"|.action="launch"|.supervisor_pid=null' "$state_path" > "$TMP/fail-race-state.json"
+chmod 600 "$TMP/fail-race-state.json"; mv "$TMP/fail-race-state.json" "$state_path"
+launch_bounded "$watch"
+replacement_supervisor=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .supervisor_pid)
+replacement_artifact=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .artifact_path)
+touch "$WATCH_FAIL_FLOCK_GATE.release"
+set +e; wait "$fail_race_pid"; fail_race_rc=$?; set -e
+[[ "$fail_race_rc" -ne 0 ]] && ok "stale fail refuses after retry registration" || bad "stale fail reported success across retry"
+eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .status)" watching "stale fail leaves replacement state active"
+kill -0 "$replacement_supervisor" 2>/dev/null && ok "stale fail does not signal replacement supervisor" || bad "stale fail signaled replacement supervisor"
+kill -0 "$old_supervisor" 2>/dev/null && ok "stale fail does not confuse captured supervisor identity" || bad "stale fail signaled its captured supervisor after claim loss"
+touch "$RELEASE"; wait_file "$replacement_artifact" || bad "replacement verdict missing after stale fail"
+result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
+eq "$(jq -r .action <<<"$result")" recovery "replacement verdict survives stale fail"
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+rm -f -- "$WATCH_FAIL_FLOCK_GATE.entered" "$WATCH_FAIL_FLOCK_GATE.release"
+
+prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+launch_bounded "$watch"
+state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
+attempt=$(jq -r .launch_attempt_id "$state_path"); runtime=$(jq -r .runtime_dir "$state_path"); artifact=$(jq -r .artifact_path "$state_path")
+bash -c 'while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$state_path" "$watch" "${attempt}0" "$runtime" "$artifact" 999 "$SCRIPTS/queue-wait" 1 10 & similar_attempt_pid=$!
+jq --argjson pid "$similar_attempt_pid" '.supervisor_pid=$pid' "$state_path" > "$TMP/similar-attempt-state.json"
+chmod 600 "$TMP/similar-attempt-state.json"; mv "$TMP/similar-attempt-state.json" "$state_path"
+"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+kill -0 "$similar_attempt_pid" 2>/dev/null && ok "attempt identity compares argv fields exactly" || bad "attempt-1 matched and signaled attempt-10"
+kill "$similar_attempt_pid" 2>/dev/null || true; wait "$similar_attempt_pid" 2>/dev/null || true
+touch "$RELEASE"
 
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
 "$SCRIPTS/merge-queue-watch" direct-merged --root "$MAIN" --issue KEN-829 --watch-id "$watch" >/dev/null

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -102,7 +102,7 @@ skills/orch/scripts/ci-wait	669
 skills/orch/scripts/dev-artifact-check	482
 skills/orch/scripts/dev-return-write	430
 skills/orch/scripts/lanes	575
-skills/orch/scripts/merge-queue-watch	477
+skills/orch/scripts/merge-queue-watch	495
 skills/orch/scripts/open-terminal	639
 skills/orch/scripts/oversee-watch	654
 skills/orch/scripts/queue-wait	1127

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -102,7 +102,7 @@ skills/orch/scripts/ci-wait	669
 skills/orch/scripts/dev-artifact-check	482
 skills/orch/scripts/dev-return-write	430
 skills/orch/scripts/lanes	575
-skills/orch/scripts/merge-queue-watch	454
+skills/orch/scripts/merge-queue-watch	477
 skills/orch/scripts/open-terminal	639
 skills/orch/scripts/oversee-watch	654
 skills/orch/scripts/queue-wait	1127

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -102,7 +102,7 @@ skills/orch/scripts/ci-wait	669
 skills/orch/scripts/dev-artifact-check	482
 skills/orch/scripts/dev-return-write	430
 skills/orch/scripts/lanes	575
-skills/orch/scripts/merge-queue-watch	587
+skills/orch/scripts/merge-queue-watch	596
 skills/orch/scripts/open-terminal	639
 skills/orch/scripts/oversee-watch	654
 skills/orch/scripts/queue-wait	1127

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -102,7 +102,7 @@ skills/orch/scripts/ci-wait	669
 skills/orch/scripts/dev-artifact-check	482
 skills/orch/scripts/dev-return-write	430
 skills/orch/scripts/lanes	575
-skills/orch/scripts/merge-queue-watch	571
+skills/orch/scripts/merge-queue-watch	587
 skills/orch/scripts/open-terminal	639
 skills/orch/scripts/oversee-watch	654
 skills/orch/scripts/queue-wait	1127

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -102,7 +102,7 @@ skills/orch/scripts/ci-wait	669
 skills/orch/scripts/dev-artifact-check	482
 skills/orch/scripts/dev-return-write	430
 skills/orch/scripts/lanes	575
-skills/orch/scripts/merge-queue-watch	404
+skills/orch/scripts/merge-queue-watch	454
 skills/orch/scripts/open-terminal	639
 skills/orch/scripts/oversee-watch	654
 skills/orch/scripts/queue-wait	1127

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -102,7 +102,7 @@ skills/orch/scripts/ci-wait	669
 skills/orch/scripts/dev-artifact-check	482
 skills/orch/scripts/dev-return-write	430
 skills/orch/scripts/lanes	575
-skills/orch/scripts/merge-queue-watch	495
+skills/orch/scripts/merge-queue-watch	535
 skills/orch/scripts/open-terminal	639
 skills/orch/scripts/oversee-watch	654
 skills/orch/scripts/queue-wait	1127

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -102,7 +102,7 @@ skills/orch/scripts/ci-wait	669
 skills/orch/scripts/dev-artifact-check	482
 skills/orch/scripts/dev-return-write	430
 skills/orch/scripts/lanes	575
-skills/orch/scripts/merge-queue-watch	596
+skills/orch/scripts/merge-queue-watch	609
 skills/orch/scripts/open-terminal	639
 skills/orch/scripts/oversee-watch	654
 skills/orch/scripts/queue-wait	1127

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -102,7 +102,7 @@ skills/orch/scripts/ci-wait	669
 skills/orch/scripts/dev-artifact-check	482
 skills/orch/scripts/dev-return-write	430
 skills/orch/scripts/lanes	575
-skills/orch/scripts/merge-queue-watch	535
+skills/orch/scripts/merge-queue-watch	571
 skills/orch/scripts/open-terminal	639
 skills/orch/scripts/oversee-watch	654
 skills/orch/scripts/queue-wait	1127

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -102,6 +102,7 @@ skills/orch/scripts/ci-wait	669
 skills/orch/scripts/dev-artifact-check	482
 skills/orch/scripts/dev-return-write	430
 skills/orch/scripts/lanes	575
+skills/orch/scripts/merge-queue-watch	404
 skills/orch/scripts/open-terminal	639
 skills/orch/scripts/oversee-watch	654
 skills/orch/scripts/queue-wait	1127


### PR DESCRIPTION
## Summary

- isolate every merge-watch retry by immutable launch generation
- bind supervisor publication, consumption, teardown, and process identity to that generation
- prove stale, delayed, reused-PID, and non-proc whitespace-path interleavings independently

## Completed Issues

- Closes KEN-887 - The documented resume_launch retry cannot succeed

## Test Plan

- `bash skills/orch/tests/merge_queue_watch.sh`
- `tools/guard`
