### PR TITLE
refactor(KEN-912): the channel guard carries no restore path

### DIFF
--- a/crates/cli/tests/release_workflow/channel_point.rs
+++ b/crates/cli/tests/release_workflow/channel_point.rs
@@ -2,10 +2,12 @@
 //! job runs. It is the only thing that writes the fixed pre-release release,
 //! and every write it makes is destructive: two manifests overwritten in
 //! place, on the one URL every candidate machine reads its updates from. So
-//! what is asked of it here is which reads let a write through and which
-//! leave the channel as it was.
+//! what is asked of it here is which channel states let a write through and
+//! which stop it with the channel as it was.
 //!
-//! Which tags reach it at all, and which job runs it, are `channel.rs`.
+//! What a write that failed partway leaves, and what the run after it does
+//! with that, are `channel_point_failure.rs`. Which tags reach the guard at
+//! all, and which job runs it, are `channel.rs`.
 
 #[cfg(unix)]
 use std::fs;
@@ -17,7 +19,7 @@ use crate::test_util::rooted;
 use crate::{job, job_declaring, step, workflow};
 
 /// The guard the channel job runs, as a path this test can execute.
-fn channel_script() -> std::path::PathBuf {
+pub(crate) fn channel_script() -> std::path::PathBuf {
     std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(format!("../../{CHANNEL_SCRIPT}"))
 }
 
@@ -28,21 +30,21 @@ const CHANNEL_SCRIPT: &str = "tools/release-channel-point";
 
 /// What one run of the channel step did.
 #[cfg(unix)]
-struct Pointed {
-    code: i32,
-    calls: Vec<String>,
+pub(crate) struct Pointed {
+    pub(crate) code: i32,
+    pub(crate) calls: Vec<String>,
     /// Everything the run printed. A refusal that does not say what it found
     /// leaves nobody able to repair the channel, so the message is part of
     /// the behaviour rather than decoration on it.
-    output: String,
+    pub(crate) output: String,
     /// What the channel carries once the run is over, sorted, or `None` if
     /// no release is published there.
-    after: Option<Vec<String>>,
+    pub(crate) after: Option<Vec<String>>,
 }
 
 #[cfg(unix)]
 impl Pointed {
-    fn ran(&self, verb: &str) -> Option<&String> {
+    pub(crate) fn ran(&self, verb: &str) -> Option<&String> {
         self.calls.iter().find(|c| c.starts_with(verb))
     }
 }
@@ -50,7 +52,7 @@ impl Pointed {
 /// The state of the pre-release channel a run finds.
 #[cfg(unix)]
 #[derive(Clone, Copy, Debug)]
-enum Channel<'a> {
+pub(crate) enum Channel<'a> {
     /// No channel release published yet.
     Absent,
     /// Published, with nothing uploaded to it — the one state that leaves
@@ -71,7 +73,7 @@ enum Channel<'a> {
 /// its target, so the guard cannot hold a list of them and these tests would
 /// not notice a guard that published the manifests alone.
 #[cfg(unix)]
-const STAGED: [&str; 4] = [
+pub(crate) const STAGED: [&str; 4] = [
     "latest.json",
     "feed.json",
     "digests-x86_64-unknown-linux-gnu.json",
@@ -79,27 +81,28 @@ const STAGED: [&str; 4] = [
 ];
 
 /// One channel and one `dist`, which the guard can be run against more than
-/// once. What a failed run leaves behind is what the next run reads, so the
-/// two are asked of the same channel rather than of a second fixture posed
-/// to look like the first one's wreckage.
+/// once. What a run leaves behind is what the next one reads, assets and
+/// manifest contents alike: an upload copies the staged file onto the
+/// channel and the download copies it back, so the two are asked of the same
+/// channel rather than of a second fixture posed to look like the first
+/// one's wreckage.
 ///
 /// The stub keeps the channel as a directory, one file per asset, so a call
 /// reads what the calls before it actually wrote. A run cannot be shown a
 /// channel that never existed, and the assertions below are about the state
 /// the run left rather than the calls it happened to make.
 #[cfg(unix)]
-struct Fixture {
+pub(crate) struct Fixture {
     /// Held for its `Drop`: the paths below live inside it.
     _dir: tempfile::TempDir,
     root: std::path::PathBuf,
     published: std::path::PathBuf,
-    manifest: String,
 }
 
 #[cfg(unix)]
 #[allow(clippy::unwrap_used)]
 impl Fixture {
-    fn new(channel: Channel, staged: &[&str]) -> Fixture {
+    pub(crate) fn new(channel: Channel, staged: &[&str]) -> Fixture {
         use std::os::unix::fs::PermissionsExt;
         let dir = tempfile::tempdir().unwrap();
         let root = rooted(&dir);
@@ -119,14 +122,17 @@ impl Fixture {
                  # `--clobber` deletes an asset before uploading its\n\
                  # replacement, so an upload that fails loses what it was\n\
                  # replacing. GH_LANDED names the replacements that got up\n\
-                 # before it gave up.\n\
+                 # before it gave up; the rest are gone.\n\
                  shift 3\n\
                  while [ $# -gt 0 ]; do\n\
                    case \"$1\" in --repo) shift 2; continue ;; --*) shift; continue ;; esac\n\
-                   rm -f \"$GH_CHANNEL/$(basename \"$1\")\"\n\
+                   name=$(basename \"$1\")\n\
+                   rm -f \"$GH_CHANNEL/$name\"\n\
+                   for got in $GH_LANDED; do\n\
+                     [ \"$got\" = \"$name\" ] && cp \"$1\" \"$GH_CHANNEL/$name\"\n\
+                   done\n\
                    shift\n\
                  done\n\
-                 for name in $GH_LANDED; do touch \"$GH_CHANNEL/$name\"; done\n\
                fi\n\
                exit 1\n\
              fi\n\
@@ -136,7 +142,7 @@ impl Fixture {
                  shift 3\n\
                  while [ $# -gt 0 ]; do\n\
                    case \"$1\" in --repo) shift 2; continue ;; --*) shift; continue ;; esac\n\
-                   touch \"$GH_CHANNEL/$(basename \"$1\")\"\n\
+                   cp \"$1\" \"$GH_CHANNEL/$(basename \"$1\")\"\n\
                    shift\n\
                  done\n\
                  exit 0 ;;\n\
@@ -155,7 +161,7 @@ impl Fixture {
                  [ \"$want\" = \" latest.json\" ] || exit 1\n\
                  mkdir -p \"$dir\"\n\
                  if [ -e \"$GH_CHANNEL/latest.json\" ]; then\n\
-                   printf '%s\\n' \"$GH_MANIFEST\" > \"$dir/latest.json\"\n\
+                   cp \"$GH_CHANNEL/latest.json\" \"$dir/latest.json\"\n\
                  fi\n\
                  exit 0 ;;\n\
              esac\n\
@@ -176,26 +182,26 @@ impl Fixture {
         fs::set_permissions(bin.join("gh"), fs::Permissions::from_mode(0o755)).unwrap();
 
         let published = root.join("channel");
-        let manifest = match channel {
-            Channel::Carrying(version) => format!(r#"{{"version":"{version}"}}"#),
-            _ => "{}".to_owned(),
-        };
         if !matches!(channel, Channel::Absent) {
             fs::create_dir_all(&published).unwrap();
         }
         if matches!(channel, Channel::Carrying(_) | Channel::Unreadable) {
-            for name in ["latest.json", "feed.json"] {
-                fs::write(published.join(name), "").unwrap();
-            }
+            // The seed for a channel no run here wrote. Past the first
+            // upload the channel carries what that upload put on it.
+            let seed = match channel {
+                Channel::Carrying(version) => format!(r#"{{"version":"{version}"}}"#),
+                _ => "{}".to_owned(),
+            };
+            fs::write(published.join("latest.json"), seed).unwrap();
+            fs::write(published.join("feed.json"), "{}").unwrap();
         }
         if matches!(channel, Channel::HalfWritten) {
-            fs::write(published.join("feed.json"), "").unwrap();
+            fs::write(published.join("feed.json"), "{}").unwrap();
         }
         Fixture {
             _dir: dir,
             root,
             published,
-            manifest,
         }
     }
 
@@ -203,12 +209,24 @@ impl Fixture {
     /// fail, standing in for the transient errors every read here has to
     /// tell apart from an answer; `landed` names the assets a failing upload
     /// gets onto the channel before it gives up.
-    fn run(&self, new_version: &str, fail: &[&str], landed: &[&str]) -> Pointed {
+    pub(crate) fn run(&self, new_version: &str, fail: &[&str], landed: &[&str]) -> Pointed {
         let log = self.root.join("gh.log");
         let failing = self.root.join("gh.fail");
-        // Per run, so the calls below are this run's and not the last one's.
+        // Per run, so the calls below are this run's and not the last one's,
+        // and so the version the guard reads back is one this run's own
+        // download wrote rather than a leftover of the run before it.
         fs::write(&log, "").unwrap();
         fs::write(&failing, fail.join("\n")).unwrap();
+        fs::remove_dir_all(self.root.join("manifest")).ok();
+        // What the release job stages is the manifest of the tag it built.
+        let staged_manifest = self.root.join("dist/latest.json");
+        if staged_manifest.is_file() {
+            fs::write(
+                &staged_manifest,
+                format!(r#"{{"version":"{new_version}"}}"#),
+            )
+            .unwrap();
+        }
         let run = std::process::Command::new(channel_script())
             .current_dir(&self.root)
             .env_clear()
@@ -224,7 +242,6 @@ impl Fixture {
             .env("GH_FAIL", &failing)
             .env("GH_LANDED", landed.join(" "))
             .env("GH_CHANNEL", &self.published)
-            .env("GH_MANIFEST", &self.manifest)
             .env("GITHUB_REPOSITORY", "vanillagreencom/kendex")
             .env("CHANNEL", channel_step_env("CHANNEL"))
             .env("NEW_VERSION", new_version)
@@ -442,118 +459,37 @@ fn a_run_handed_no_manifests_writes_nothing() {
     );
 }
 
-/// The upload is the one call that changes the channel, and the branch that
-/// catches it failing has to fail the job. A guard that printed its error and
-/// then exited 0 would let the release workflow's channel job go green with
-/// the channel short a manifest, which every candidate machine reads as no
-/// update at all.
-///
-/// Which repair it needs is not something the run can read off its own
-/// failure, so the message names both, and both are asserted: a channel that
-/// kept its latest.json is one the next tag run writes over, and a channel
-/// that lost it needs a person before any tag run means anything.
+/// The channel's two manifests are one answer, and either one alone is half
+/// of it: the app stays on the version the stale latest.json names while
+/// `kendex update` follows feed.json to the new one, with nothing on the
+/// channel reporting the two as disagreeing. Driven over both names, so
+/// neither direction can regress on its own.
 #[cfg(unix)]
 #[test]
-fn a_failed_upload_fails_the_job_and_names_both_repairs() {
-    let run = Fixture::new(Channel::Carrying("1.0.0-rc1"), &STAGED).run(
-        "1.0.0-rc2",
-        &["dist/latest.json"],
-        &["latest.json", "feed.json"],
-    );
-    assert_ne!(
-        run.code, 0,
-        "a failed upload was survivable: {:?}",
-        run.calls
-    );
-    // The fixture reached the upload rather than stopping at an earlier read,
-    // so it is that branch this exercises and not one above it.
-    assert!(
-        run.ran("release upload").is_some(),
-        "the run never got as far as the upload: {:?}",
-        run.calls
-    );
-    for said in [
-        "Uploading to the prerelease channel failed",
-        "Re-run the tag if the channel still carries latest.json",
-        "deletes the assets left on it",
+fn a_run_handed_half_the_manifests_writes_nothing() {
+    for (missing, staged) in [
+        (
+            "latest.json",
+            ["feed.json", "digests-x86_64-unknown-linux-gnu.json"],
+        ),
+        (
+            "feed.json",
+            ["latest.json", "digests-x86_64-unknown-linux-gnu.json"],
+        ),
     ] {
-        assert!(run.output.contains(said), "{said} missing: {}", run.output);
+        let run = point_channel_staging(Channel::Carrying("1.0.0-rc1"), "1.0.0-rc2", &[], &staged);
+        assert_ne!(run.code, 0, "{missing}: {:?}", run.calls);
+        assert!(
+            run.ran("release upload").is_none(),
+            "half the answer still went up without {missing}: {:?}",
+            run.calls
+        );
+        assert!(
+            run.output.contains(&format!("was handed no {missing}")),
+            "the run did not say which half it was missing: {}",
+            run.output
+        );
     }
-}
-
-/// The other half of that message, driven. An upload that fails after
-/// `--clobber` has deleted latest.json leaves the channel carrying assets
-/// nothing can read a version off, and the guard refuses exactly that state
-/// — so the tag re-run the operator would otherwise reach for publishes
-/// nothing, and the channel needs a person first. Both runs are against the
-/// one channel: the second reads what the first actually left.
-#[cfg(unix)]
-#[test]
-fn a_failed_upload_that_lost_latest_json_refuses_every_later_run() {
-    let channel = Fixture::new(Channel::Carrying("1.0.0-rc1"), &STAGED);
-    let failed = channel.run("1.0.0-rc2", &["dist/latest.json"], &["feed.json"]);
-    assert_ne!(
-        failed.code, 0,
-        "a failed upload was survivable: {:?}",
-        failed.calls
-    );
-    assert_eq!(
-        failed.after,
-        Some(vec!["feed.json".to_owned()]),
-        "the fixture did not lose latest.json, so this proves nothing: {:?}",
-        failed.calls
-    );
-
-    // The re-run the message would send them on, with nothing failing.
-    let again = channel.run("1.0.0-rc2", &[], &[]);
-    assert_ne!(
-        again.code, 0,
-        "the re-run wrote over a channel nothing can read: {:?}",
-        again.calls
-    );
-    assert!(
-        again.ran("release upload").is_none(),
-        "the re-run published over the leftovers: {:?}",
-        again.calls
-    );
-    assert!(
-        again.output.contains("carries assets but no latest.json"),
-        "{}",
-        again.output
-    );
-    assert_eq!(
-        again.after,
-        Some(vec!["feed.json".to_owned()]),
-        "the re-run changed the channel it refused: {:?}",
-        again.calls
-    );
-}
-
-/// The channel's two manifests are one answer. Handed a `dist` carrying
-/// feed.json and no latest.json, a run that published what it had would leave
-/// the channel naming one version in the file candidates read and another in
-/// the file they check it against, and nothing downstream reports that as
-/// wrong.
-#[cfg(unix)]
-#[test]
-fn a_run_handed_no_latest_json_writes_nothing() {
-    let run = point_channel_staging(
-        Channel::Carrying("1.0.0-rc1"),
-        "1.0.0-rc2",
-        &[],
-        &["feed.json", "digests-x86_64-unknown-linux-gnu.json"],
-    );
-    assert_ne!(run.code, 0, "{:?}", run.calls);
-    assert!(
-        run.ran("release upload").is_none(),
-        "half the answer still went up: {:?}",
-        run.calls
-    );
-    assert!(
-        run.output.contains("was handed no latest.json"),
-        "the run did not say what it found: {}",
-        run.output
-    );
 }
 
 /// A channel a write did not finish on is not a channel this run may take.

--- a/crates/cli/tests/release_workflow/channel_point.rs
+++ b/crates/cli/tests/release_workflow/channel_point.rs
@@ -59,7 +59,8 @@ enum Channel<'a> {
     /// Published, its manifest naming this version.
     Carrying(&'a str),
     /// Published, carrying `feed.json` and no `latest.json` — the shape a
-    /// half-written channel is left in, which the guard reads as fresh.
+    /// half-written channel is left in, and the one the guard refuses
+    /// because nothing on it can say what version it holds.
     HalfWritten,
     /// Published, with a manifest that names no version at all.
     Unreadable,
@@ -77,165 +78,202 @@ const STAGED: [&str; 4] = [
     "digests-x86_64-unknown-linux-gnu.json.sig",
 ];
 
-/// Runs the guard with `gh` stubbed. `fail` holds fragments of the `gh`
-/// calls that should fail, standing in for the transient errors every read
-/// here has to tell apart from an answer.
+/// One channel and one `dist`, which the guard can be run against more than
+/// once. What a failed run leaves behind is what the next run reads, so the
+/// two are asked of the same channel rather than of a second fixture posed
+/// to look like the first one's wreckage.
 ///
 /// The stub keeps the channel as a directory, one file per asset, so a call
 /// reads what the calls before it actually wrote. A run cannot be shown a
 /// channel that never existed, and the assertions below are about the state
 /// the run left rather than the calls it happened to make.
 #[cfg(unix)]
+struct Fixture {
+    /// Held for its `Drop`: the paths below live inside it.
+    _dir: tempfile::TempDir,
+    root: std::path::PathBuf,
+    published: std::path::PathBuf,
+    manifest: String,
+}
+
+#[cfg(unix)]
 #[allow(clippy::unwrap_used)]
+impl Fixture {
+    fn new(channel: Channel, staged: &[&str]) -> Fixture {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let root = rooted(&dir);
+        let dist = root.join("dist");
+        fs::create_dir_all(&dist).unwrap();
+        for name in staged {
+            fs::write(dist.join(name), "{}").unwrap();
+        }
+        let bin = root.join("bin");
+        fs::create_dir_all(&bin).unwrap();
+        fs::write(
+            bin.join("gh"),
+            "#!/bin/sh\n\
+             printf '%s\\n' \"$*\" >> \"$GH_LOG\"\n\
+             if [ -s \"$GH_FAIL\" ] && printf '%s\\n' \"$*\" | grep -qFf \"$GH_FAIL\"; then\n\
+               if [ \"$1 $2\" = \"release upload\" ]; then\n\
+                 # `--clobber` deletes an asset before uploading its\n\
+                 # replacement, so an upload that fails loses what it was\n\
+                 # replacing. GH_LANDED names the replacements that got up\n\
+                 # before it gave up.\n\
+                 shift 3\n\
+                 while [ $# -gt 0 ]; do\n\
+                   case \"$1\" in --repo) shift 2; continue ;; --*) shift; continue ;; esac\n\
+                   rm -f \"$GH_CHANNEL/$(basename \"$1\")\"\n\
+                   shift\n\
+                 done\n\
+                 for name in $GH_LANDED; do touch \"$GH_CHANNEL/$name\"; done\n\
+               fi\n\
+               exit 1\n\
+             fi\n\
+             case \"$1 $2\" in\n\
+               \"release create\") mkdir -p \"$GH_CHANNEL\"; exit 0 ;;\n\
+               \"release upload\")\n\
+                 shift 3\n\
+                 while [ $# -gt 0 ]; do\n\
+                   case \"$1\" in --repo) shift 2; continue ;; --*) shift; continue ;; esac\n\
+                   touch \"$GH_CHANNEL/$(basename \"$1\")\"\n\
+                   shift\n\
+                 done\n\
+                 exit 0 ;;\n\
+               \"release download\")\n\
+                 dir=\"\"; want=\"\"\n\
+                 while [ $# -gt 0 ]; do\n\
+                   [ \"$1\" = \"--dir\" ] && dir=$2\n\
+                   [ \"$1\" = \"--pattern\" ] && want=\"$want $2\"\n\
+                   shift\n\
+                 done\n\
+                 [ -n \"$dir\" ] || exit 1\n\
+                 # The channel's version is the only thing the guard comes\n\
+                 # down here for. Any other pattern is a call it does not\n\
+                 # make, and answering one would document behaviour it does\n\
+                 # not have.\n\
+                 [ \"$want\" = \" latest.json\" ] || exit 1\n\
+                 mkdir -p \"$dir\"\n\
+                 if [ -e \"$GH_CHANNEL/latest.json\" ]; then\n\
+                   printf '%s\\n' \"$GH_MANIFEST\" > \"$dir/latest.json\"\n\
+                 fi\n\
+                 exit 0 ;;\n\
+             esac\n\
+             case \"$2\" in\n\
+               */releases)\n\
+                 [ -d \"$GH_CHANNEL\" ] && printf '%s\\n' \"$CHANNEL\"\n\
+                 exit 0\n\
+                 ;;\n\
+               */releases/tags/*)\n\
+                 [ -d \"$GH_CHANNEL\" ] || exit 1\n\
+                 ls \"$GH_CHANNEL\"\n\
+                 exit 0\n\
+                 ;;\n\
+             esac\n\
+             exit 0\n",
+        )
+        .unwrap();
+        fs::set_permissions(bin.join("gh"), fs::Permissions::from_mode(0o755)).unwrap();
+
+        let published = root.join("channel");
+        let manifest = match channel {
+            Channel::Carrying(version) => format!(r#"{{"version":"{version}"}}"#),
+            _ => "{}".to_owned(),
+        };
+        if !matches!(channel, Channel::Absent) {
+            fs::create_dir_all(&published).unwrap();
+        }
+        if matches!(channel, Channel::Carrying(_) | Channel::Unreadable) {
+            for name in ["latest.json", "feed.json"] {
+                fs::write(published.join(name), "").unwrap();
+            }
+        }
+        if matches!(channel, Channel::HalfWritten) {
+            fs::write(published.join("feed.json"), "").unwrap();
+        }
+        Fixture {
+            _dir: dir,
+            root,
+            published,
+            manifest,
+        }
+    }
+
+    /// Runs the guard. `fail` holds fragments of the `gh` calls that should
+    /// fail, standing in for the transient errors every read here has to
+    /// tell apart from an answer; `landed` names the assets a failing upload
+    /// gets onto the channel before it gives up.
+    fn run(&self, new_version: &str, fail: &[&str], landed: &[&str]) -> Pointed {
+        let log = self.root.join("gh.log");
+        let failing = self.root.join("gh.fail");
+        // Per run, so the calls below are this run's and not the last one's.
+        fs::write(&log, "").unwrap();
+        fs::write(&failing, fail.join("\n")).unwrap();
+        let run = std::process::Command::new(channel_script())
+            .current_dir(&self.root)
+            .env_clear()
+            .env(
+                "PATH",
+                format!(
+                    "{}:{}",
+                    self.root.join("bin").display(),
+                    std::env::var("PATH").unwrap_or_default()
+                ),
+            )
+            .env("GH_LOG", &log)
+            .env("GH_FAIL", &failing)
+            .env("GH_LANDED", landed.join(" "))
+            .env("GH_CHANNEL", &self.published)
+            .env("GH_MANIFEST", &self.manifest)
+            .env("GITHUB_REPOSITORY", "vanillagreencom/kendex")
+            .env("CHANNEL", channel_step_env("CHANNEL"))
+            .env("NEW_VERSION", new_version)
+            .env("GH_TOKEN", "token")
+            .output()
+            .unwrap();
+        let calls = fs::read_to_string(&log)
+            .unwrap_or_default()
+            .lines()
+            .map(str::to_owned)
+            .collect();
+        let after = fs::read_dir(&self.published).ok().map(|entries| {
+            let mut names: Vec<String> = entries
+                .filter_map(Result::ok)
+                .map(|e| e.file_name().to_string_lossy().into_owned())
+                .collect();
+            names.sort();
+            names
+        });
+        Pointed {
+            code: run.status.code().unwrap_or(-1),
+            calls,
+            output: format!(
+                "{}{}",
+                String::from_utf8_lossy(&run.stdout),
+                String::from_utf8_lossy(&run.stderr)
+            ),
+            after,
+        }
+    }
+}
+
+/// One run against a channel in this state, with the release's whole output
+/// staged.
+#[cfg(unix)]
 fn point_channel(channel: Channel, new_version: &str, fail: &[&str]) -> Pointed {
     point_channel_staging(channel, new_version, fail, &STAGED)
 }
 
 /// The same, with the release's output named rather than assumed, for the
-/// case that is about what `dist` held.
+/// cases that are about what `dist` held.
 #[cfg(unix)]
-#[allow(clippy::unwrap_used)]
 fn point_channel_staging(
     channel: Channel,
     new_version: &str,
     fail: &[&str],
     staged: &[&str],
 ) -> Pointed {
-    use std::os::unix::fs::PermissionsExt;
-    let dir = tempfile::tempdir().unwrap();
-    let root = rooted(&dir);
-    let dist = root.join("dist");
-    fs::create_dir_all(&dist).unwrap();
-    for name in staged {
-        fs::write(dist.join(name), "{}").unwrap();
-    }
-    let bin = root.join("bin");
-    fs::create_dir_all(&bin).unwrap();
-    let log = root.join("gh.log");
-    let failing = root.join("gh.fail");
-    fs::write(&failing, fail.join("\n")).unwrap();
-    let published = root.join("channel");
-    fs::write(
-        bin.join("gh"),
-        "#!/bin/sh\n\
-         printf '%s\\n' \"$*\" >> \"$GH_LOG\"\n\
-         if [ -s \"$GH_FAIL\" ] && printf '%s\\n' \"$*\" | grep -qFf \"$GH_FAIL\"; then\n\
-           exit 1\n\
-         fi\n\
-         case \"$1 $2\" in\n\
-           \"release create\") mkdir -p \"$GH_CHANNEL\"; exit 0 ;;\n\
-           \"release delete\") rm -rf \"$GH_CHANNEL\"; exit 0 ;;\n\
-           \"release delete-asset\")\n\
-             [ -e \"$GH_CHANNEL/$4\" ] || exit 1\n\
-             rm -f \"$GH_CHANNEL/$4\"\n\
-             exit 0 ;;\n\
-           \"release upload\")\n\
-             shift 3\n\
-             while [ $# -gt 0 ]; do\n\
-               case \"$1\" in --repo) shift 2; continue ;; --*) shift; continue ;; esac\n\
-               touch \"$GH_CHANNEL/$(basename \"$1\")\"\n\
-               shift\n\
-             done\n\
-             exit 0 ;;\n\
-           \"release download\")\n\
-             dir=\"\"; want=\"\"\n\
-             while [ $# -gt 0 ]; do\n\
-               [ \"$1\" = \"--dir\" ] && dir=$2\n\
-               [ \"$1\" = \"--pattern\" ] && want=\"$want $2\"\n\
-               shift\n\
-             done\n\
-             [ -n \"$dir\" ] || exit 1\n\
-             mkdir -p \"$dir\"\n\
-             for name in $want; do\n\
-               [ -e \"$GH_CHANNEL/$name\" ] || continue\n\
-               case \"$name\" in\n\
-                 latest.json) printf '%s\\n' \"$GH_MANIFEST\" > \"$dir/latest.json\" ;;\n\
-                 feed.json) printf '%s\\n' \"$GH_FEED\" > \"$dir/feed.json\" ;;\n\
-                 *) cp \"$GH_CHANNEL/$name\" \"$dir/$name\" ;;\n\
-               esac\n\
-             done\n\
-             exit 0 ;;\n\
-         esac\n\
-         case \"$2\" in\n\
-           */releases)\n\
-             [ -d \"$GH_CHANNEL\" ] && printf '%s\\n' \"$CHANNEL\"\n\
-             exit 0\n\
-             ;;\n\
-           */releases/tags/*)\n\
-             [ -d \"$GH_CHANNEL\" ] || exit 1\n\
-             ls \"$GH_CHANNEL\"\n\
-             exit 0\n\
-             ;;\n\
-         esac\n\
-         exit 0\n",
-    )
-    .unwrap();
-    fs::set_permissions(bin.join("gh"), fs::Permissions::from_mode(0o755)).unwrap();
-
-    let manifest = match channel {
-        Channel::Carrying(version) => format!(r#"{{"version":"{version}"}}"#),
-        _ => "{}".to_owned(),
-    };
-    if !matches!(channel, Channel::Absent) {
-        fs::create_dir_all(&published).unwrap();
-    }
-    if matches!(channel, Channel::Carrying(_) | Channel::Unreadable) {
-        for name in ["latest.json", "feed.json"] {
-            fs::write(published.join(name), "").unwrap();
-        }
-    }
-    if matches!(channel, Channel::HalfWritten) {
-        fs::write(published.join("feed.json"), "").unwrap();
-    }
-
-    let run = std::process::Command::new(channel_script())
-        .current_dir(&root)
-        .env_clear()
-        .env(
-            "PATH",
-            format!(
-                "{}:{}",
-                bin.display(),
-                std::env::var("PATH").unwrap_or_default()
-            ),
-        )
-        .env("GH_LOG", &log)
-        .env("GH_FAIL", &failing)
-        .env("GH_CHANNEL", &published)
-        .env("GH_MANIFEST", &manifest)
-        .env(
-            "GH_FEED",
-            r#"{"schema":1,"version":"published","assets":{}}"#,
-        )
-        .env("GITHUB_REPOSITORY", "vanillagreencom/kendex")
-        .env("CHANNEL", channel_step_env("CHANNEL"))
-        .env("NEW_VERSION", new_version)
-        .env("GH_TOKEN", "token")
-        .output()
-        .unwrap();
-    let calls = fs::read_to_string(&log)
-        .unwrap_or_default()
-        .lines()
-        .map(str::to_owned)
-        .collect();
-    let after = fs::read_dir(&published).ok().map(|entries| {
-        let mut names: Vec<String> = entries
-            .filter_map(Result::ok)
-            .map(|e| e.file_name().to_string_lossy().into_owned())
-            .collect();
-        names.sort();
-        names
-    });
-    Pointed {
-        code: run.status.code().unwrap_or(-1),
-        calls,
-        output: format!(
-            "{}{}",
-            String::from_utf8_lossy(&run.stdout),
-            String::from_utf8_lossy(&run.stderr)
-        ),
-        after,
-    }
+    Fixture::new(channel, staged).run(new_version, fail, &[])
 }
 
 /// A read that failed is not an empty channel. Every one of these leaves
@@ -401,6 +439,120 @@ fn a_run_handed_no_manifests_writes_nothing() {
         run.ran("release upload").is_none(),
         "an empty dist still uploaded: {:?}",
         run.calls
+    );
+}
+
+/// The upload is the one call that changes the channel, and the branch that
+/// catches it failing has to fail the job. A guard that printed its error and
+/// then exited 0 would let the release workflow's channel job go green with
+/// the channel short a manifest, which every candidate machine reads as no
+/// update at all.
+///
+/// Which repair it needs is not something the run can read off its own
+/// failure, so the message names both, and both are asserted: a channel that
+/// kept its latest.json is one the next tag run writes over, and a channel
+/// that lost it needs a person before any tag run means anything.
+#[cfg(unix)]
+#[test]
+fn a_failed_upload_fails_the_job_and_names_both_repairs() {
+    let run = Fixture::new(Channel::Carrying("1.0.0-rc1"), &STAGED).run(
+        "1.0.0-rc2",
+        &["dist/latest.json"],
+        &["latest.json", "feed.json"],
+    );
+    assert_ne!(
+        run.code, 0,
+        "a failed upload was survivable: {:?}",
+        run.calls
+    );
+    // The fixture reached the upload rather than stopping at an earlier read,
+    // so it is that branch this exercises and not one above it.
+    assert!(
+        run.ran("release upload").is_some(),
+        "the run never got as far as the upload: {:?}",
+        run.calls
+    );
+    for said in [
+        "Uploading to the prerelease channel failed",
+        "Re-run the tag if the channel still carries latest.json",
+        "deletes the assets left on it",
+    ] {
+        assert!(run.output.contains(said), "{said} missing: {}", run.output);
+    }
+}
+
+/// The other half of that message, driven. An upload that fails after
+/// `--clobber` has deleted latest.json leaves the channel carrying assets
+/// nothing can read a version off, and the guard refuses exactly that state
+/// — so the tag re-run the operator would otherwise reach for publishes
+/// nothing, and the channel needs a person first. Both runs are against the
+/// one channel: the second reads what the first actually left.
+#[cfg(unix)]
+#[test]
+fn a_failed_upload_that_lost_latest_json_refuses_every_later_run() {
+    let channel = Fixture::new(Channel::Carrying("1.0.0-rc1"), &STAGED);
+    let failed = channel.run("1.0.0-rc2", &["dist/latest.json"], &["feed.json"]);
+    assert_ne!(
+        failed.code, 0,
+        "a failed upload was survivable: {:?}",
+        failed.calls
+    );
+    assert_eq!(
+        failed.after,
+        Some(vec!["feed.json".to_owned()]),
+        "the fixture did not lose latest.json, so this proves nothing: {:?}",
+        failed.calls
+    );
+
+    // The re-run the message would send them on, with nothing failing.
+    let again = channel.run("1.0.0-rc2", &[], &[]);
+    assert_ne!(
+        again.code, 0,
+        "the re-run wrote over a channel nothing can read: {:?}",
+        again.calls
+    );
+    assert!(
+        again.ran("release upload").is_none(),
+        "the re-run published over the leftovers: {:?}",
+        again.calls
+    );
+    assert!(
+        again.output.contains("carries assets but no latest.json"),
+        "{}",
+        again.output
+    );
+    assert_eq!(
+        again.after,
+        Some(vec!["feed.json".to_owned()]),
+        "the re-run changed the channel it refused: {:?}",
+        again.calls
+    );
+}
+
+/// The channel's two manifests are one answer. Handed a `dist` carrying
+/// feed.json and no latest.json, a run that published what it had would leave
+/// the channel naming one version in the file candidates read and another in
+/// the file they check it against, and nothing downstream reports that as
+/// wrong.
+#[cfg(unix)]
+#[test]
+fn a_run_handed_no_latest_json_writes_nothing() {
+    let run = point_channel_staging(
+        Channel::Carrying("1.0.0-rc1"),
+        "1.0.0-rc2",
+        &[],
+        &["feed.json", "digests-x86_64-unknown-linux-gnu.json"],
+    );
+    assert_ne!(run.code, 0, "{:?}", run.calls);
+    assert!(
+        run.ran("release upload").is_none(),
+        "half the answer still went up: {:?}",
+        run.calls
+    );
+    assert!(
+        run.output.contains("was handed no latest.json"),
+        "the run did not say what it found: {}",
+        run.output
     );
 }
 

--- a/crates/cli/tests/release_workflow/channel_point.rs
+++ b/crates/cli/tests/release_workflow/channel_point.rs
@@ -2,8 +2,8 @@
 //! job runs. It is the only thing that writes the fixed pre-release release,
 //! and every write it makes is destructive: two manifests overwritten in
 //! place, on the one URL every candidate machine reads its updates from. So
-//! what is asked of it here is not what it does when the calls succeed but
-//! what it leaves behind when one of them does not.
+//! what is asked of it here is which reads let a write through and which
+//! leave the channel as it was.
 //!
 //! Which tags reach it at all, and which job runs it, are `channel.rs`.
 
@@ -31,9 +31,9 @@ const CHANNEL_SCRIPT: &str = "tools/release-channel-point";
 struct Pointed {
     code: i32,
     calls: Vec<String>,
-    /// Everything the run printed. A channel left half written is bad; one
-    /// that announces itself as repaired is what stops anyone looking, so
-    /// the message is part of the behaviour rather than decoration on it.
+    /// Everything the run printed. A refusal that does not say what it found
+    /// leaves nobody able to repair the channel, so the message is part of
+    /// the behaviour rather than decoration on it.
     output: String,
     /// What the channel carries once the run is over, sorted, or `None` if
     /// no release is published there.
@@ -61,10 +61,6 @@ enum Channel<'a> {
     /// Published, carrying `feed.json` and no `latest.json` — the shape a
     /// half-written channel is left in, which the guard reads as fresh.
     HalfWritten,
-    /// Published and carrying the whole set a candidate reads, signatures
-    /// beside the digests documents. What a channel this release job has
-    /// already written once looks like.
-    CarryingSigned(&'static str),
     /// Published, with a manifest that names no version at all.
     Unreadable,
 }
@@ -83,8 +79,7 @@ const STAGED: [&str; 4] = [
 
 /// Runs the guard with `gh` stubbed. `fail` holds fragments of the `gh`
 /// calls that should fail, standing in for the transient errors every read
-/// here has to tell apart from an answer; `landed` names the manifests a
-/// failing upload gets onto the channel before it gives up.
+/// here has to tell apart from an answer.
 ///
 /// The stub keeps the channel as a directory, one file per asset, so a call
 /// reads what the calls before it actually wrote. A run cannot be shown a
@@ -92,8 +87,8 @@ const STAGED: [&str; 4] = [
 /// the run left rather than the calls it happened to make.
 #[cfg(unix)]
 #[allow(clippy::unwrap_used)]
-fn point_channel(channel: Channel, new_version: &str, fail: &[&str], landed: &[&str]) -> Pointed {
-    point_channel_staging(channel, new_version, fail, landed, &STAGED)
+fn point_channel(channel: Channel, new_version: &str, fail: &[&str]) -> Pointed {
+    point_channel_staging(channel, new_version, fail, &STAGED)
 }
 
 /// The same, with the release's output named rather than assumed, for the
@@ -104,7 +99,6 @@ fn point_channel_staging(
     channel: Channel,
     new_version: &str,
     fail: &[&str],
-    landed: &[&str],
     staged: &[&str],
 ) -> Pointed {
     use std::os::unix::fs::PermissionsExt;
@@ -126,17 +120,6 @@ fn point_channel_staging(
         "#!/bin/sh\n\
          printf '%s\\n' \"$*\" >> \"$GH_LOG\"\n\
          if [ -s \"$GH_FAIL\" ] && printf '%s\\n' \"$*\" | grep -qFf \"$GH_FAIL\"; then\n\
-           if [ \"$1 $2\" = \"release upload\" ]; then\n\
-             # `--clobber` deletes an asset before uploading its replacement,\n\
-             # so an upload that fails loses what it was replacing.\n\
-             shift 3\n\
-             while [ $# -gt 0 ]; do\n\
-               case \"$1\" in --repo) shift 2; continue ;; --*) shift; continue ;; esac\n\
-               rm -f \"$GH_CHANNEL/$(basename \"$1\")\"\n\
-               shift\n\
-             done\n\
-             for name in $GH_LANDED; do touch \"$GH_CHANNEL/$name\"; done\n\
-           fi\n\
            exit 1\n\
          fi\n\
          case \"$1 $2\" in\n\
@@ -190,9 +173,7 @@ fn point_channel_staging(
     fs::set_permissions(bin.join("gh"), fs::Permissions::from_mode(0o755)).unwrap();
 
     let manifest = match channel {
-        Channel::Carrying(version) | Channel::CarryingSigned(version) => {
-            format!(r#"{{"version":"{version}"}}"#)
-        }
+        Channel::Carrying(version) => format!(r#"{{"version":"{version}"}}"#),
         _ => "{}".to_owned(),
     };
     if !matches!(channel, Channel::Absent) {
@@ -200,11 +181,6 @@ fn point_channel_staging(
     }
     if matches!(channel, Channel::Carrying(_) | Channel::Unreadable) {
         for name in ["latest.json", "feed.json"] {
-            fs::write(published.join(name), "").unwrap();
-        }
-    }
-    if matches!(channel, Channel::CarryingSigned(_)) {
-        for name in STAGED {
             fs::write(published.join(name), "").unwrap();
         }
     }
@@ -225,7 +201,6 @@ fn point_channel_staging(
         )
         .env("GH_LOG", &log)
         .env("GH_FAIL", &failing)
-        .env("GH_LANDED", landed.join(" "))
         .env("GH_CHANNEL", &published)
         .env("GH_MANIFEST", &manifest)
         .env(
@@ -268,26 +243,48 @@ fn point_channel_staging(
 /// treated that as "nothing there" would upload over whatever is — which
 /// is the rollback the guard exists to prevent, reached through a lost
 /// connection instead of a stale tag.
+///
+/// Each names the read it could not make, because every one of these stops
+/// the run whatever the guard concludes afterwards — a download nobody
+/// checked leaves no manifest to read, which stops the write too, under a
+/// message sending the operator at a channel that is fine.
 #[cfg(unix)]
 #[test]
 fn a_read_it_could_not_make_stops_the_write() {
-    for (state, failing) in [
-        (Channel::Carrying("2.0.0-rc1"), "/releases --paginate"),
-        (Channel::Carrying("2.0.0-rc1"), "/releases/tags/"),
-        (Channel::Carrying("2.0.0-rc1"), "release download"),
+    for (state, failing, said) in [
+        (
+            Channel::Carrying("2.0.0-rc1"),
+            "/releases --paginate",
+            "releases could not be listed",
+        ),
+        (
+            Channel::Carrying("2.0.0-rc1"),
+            "/releases/tags/",
+            "its assets could not be read",
+        ),
+        (
+            Channel::Carrying("2.0.0-rc1"),
+            "release download",
+            "manifest could not be downloaded",
+        ),
     ] {
-        let run = point_channel(state, "1.0.0-rc1", &[failing], &[]);
+        let run = point_channel(state, "1.0.0-rc1", &[failing]);
         assert_ne!(run.code, 0, "{failing} was survivable: {:?}", run.calls);
         assert!(
             run.ran("release upload").is_none(),
             "{failing} still uploaded: {:?}",
             run.calls
         );
+        assert!(
+            run.output.contains(said),
+            "{failing} was reported as something else: {}",
+            run.output
+        );
     }
 
     // A manifest that names no version is the same answer: nothing here
     // can tell whether this tag is ahead of what is published.
-    let run = point_channel(Channel::Unreadable, "1.0.0-rc1", &[], &[]);
+    let run = point_channel(Channel::Unreadable, "1.0.0-rc1", &[]);
     assert_ne!(run.code, 0, "an unreadable manifest was survivable");
     assert!(run.ran("release upload").is_none(), "{:?}", run.calls);
 }
@@ -322,7 +319,7 @@ fn a_channel_version_that_is_not_a_version_stops_the_write() {
             !core_can_read(carried),
             "{carried} reads, so it is not an example of anything"
         );
-        let run = point_channel(Channel::Carrying(carried), "1.0.0-rc2", &[], &[]);
+        let run = point_channel(Channel::Carrying(carried), "1.0.0-rc2", &[]);
         assert_ne!(run.code, 0, "{carried} was survivable: {:?}", run.calls);
         assert!(
             run.ran("release upload").is_none(),
@@ -344,7 +341,7 @@ fn every_candidate_replaces_both_manifests_on_the_channel() {
         Channel::Empty,
         Channel::Carrying("1.0.0-rc1"),
     ] {
-        let run = point_channel(state, "1.0.0-rc2", &[], &[]);
+        let run = point_channel(state, "1.0.0-rc2", &[]);
         assert_eq!(run.code, 0, "{state:?}: {:?}", run.calls);
         assert_eq!(
             run.ran("release create").is_some(),
@@ -398,219 +395,12 @@ fn every_candidate_replaces_both_manifests_on_the_channel() {
 #[cfg(unix)]
 #[test]
 fn a_run_handed_no_manifests_writes_nothing() {
-    let run = point_channel_staging(Channel::Carrying("1.0.0-rc1"), "1.0.0-rc2", &[], &[], &[]);
+    let run = point_channel_staging(Channel::Carrying("1.0.0-rc1"), "1.0.0-rc2", &[], &[]);
     assert_ne!(run.code, 0, "{:?}", run.calls);
     assert!(
         run.ran("release upload").is_none(),
         "an empty dist still uploaded: {:?}",
         run.calls
-    );
-}
-
-/// `gh release upload --clobber` deletes an asset before uploading its
-/// replacement, and says in its own help that a failed upload loses the
-/// original. A candidate reading a channel with no `latest.json` sees no
-/// update at all, so an upload that fell over halfway would break every
-/// candidate machine until somebody re-ran a tag. What came down goes back
-/// up. Not an atomic swap — there is no such thing here — but a failure
-/// that leaves the channel as it found it.
-#[cfg(unix)]
-#[test]
-fn a_failed_upload_puts_back_what_the_channel_had() {
-    let run = point_channel(
-        Channel::CarryingSigned("1.0.0-rc1"),
-        "1.0.0-rc2",
-        &["dist/latest.json"],
-        &[],
-    );
-    assert_ne!(
-        run.code, 0,
-        "a failed upload was survivable: {:?}",
-        run.calls
-    );
-    let restored = run
-        .calls
-        .iter()
-        .filter(|c| c.starts_with("release upload"))
-        .nth(1)
-        .unwrap_or_else(|| panic!("nothing was put back: {:?}", run.calls));
-    // Every name, and from the copies on disk: the shell expanded the glob
-    // against what the download actually wrote, so an asset that never came
-    // down could not appear here. The signature is in the list because a
-    // digests document without it refuses every update, which is a channel
-    // reported as repaired and broken for every candidate.
-    for name in STAGED {
-        assert!(
-            restored.contains(&format!("saved/{name}")),
-            "saved/{name} not restored: {restored}"
-        );
-    }
-    assert!(restored.contains("--clobber"), "{restored}");
-    let mut had: Vec<String> = STAGED.iter().map(|name| (*name).to_owned()).collect();
-    had.sort();
-    assert_eq!(
-        run.after,
-        Some(had),
-        "the channel is not carrying what it was: {:?}",
-        run.calls
-    );
-    assert!(
-        run.output.contains("is back as this run found it"),
-        "{}",
-        run.output
-    );
-}
-
-/// A channel this run created, and could not then write, is a channel that
-/// was not there before this run. There is nothing to put back on it: the
-/// copies the case above restores from are of manifests the channel already
-/// carried, and a fresh one carried none. So the release goes, and what a
-/// half-populated channel would have said — that a candidate is up to date
-/// on manifests naming downloads that were never uploaded — is not said at
-/// all. The tag it was created on stays: `gh release create` reuses one, so
-/// a run cannot tell a tag it made from a tag that was already there, and a
-/// tag carrying no release publishes nothing either way.
-#[cfg(unix)]
-#[test]
-fn a_failed_upload_removes_a_channel_this_run_created() {
-    let run = point_channel(
-        Channel::Absent,
-        "1.0.0-rc2",
-        &["dist/feed.json"],
-        &["latest.json"],
-    );
-    assert_ne!(
-        run.code, 0,
-        "a failed upload was survivable: {:?}",
-        run.calls
-    );
-    assert_eq!(
-        run.after, None,
-        "the channel this run created was left behind: {:?}",
-        run.calls
-    );
-    assert!(
-        run.ran(&format!("release delete {}", channel_step_env("CHANNEL")))
-            .is_some(),
-        "nothing removed the channel: {:?}",
-        run.calls
-    );
-    assert!(run.output.contains("has been removed"), "{}", run.output);
-}
-
-/// A channel published but carrying nothing is the other fresh state, and
-/// the one the case above leaves behind. Nothing comes back here either,
-/// because nothing was there — what has to go is whatever this run put on
-/// it, so the next tag finds the empty channel the last one found.
-#[cfg(unix)]
-#[test]
-fn a_failed_upload_takes_back_what_it_put_on_an_empty_channel() {
-    let run = point_channel(
-        Channel::Empty,
-        "1.0.0-rc2",
-        &["dist/feed.json"],
-        &["latest.json"],
-    );
-    assert_ne!(
-        run.code, 0,
-        "a failed upload was survivable: {:?}",
-        run.calls
-    );
-    assert_eq!(
-        run.after,
-        Some(Vec::new()),
-        "the channel kept what this run put on it: {:?}",
-        run.calls
-    );
-    assert!(
-        run.output.contains("is back as this run found it"),
-        "{}",
-        run.output
-    );
-}
-
-/// The restore is `gh` calls too, and they fail the way every other call
-/// here can. What must not happen then is the run reporting a channel it did
-/// not put back: a half-written channel that announces itself as repaired is
-/// what stops anyone looking at it. So the message says it could not, and
-/// names what is on the channel for whoever has to repair it.
-#[cfg(unix)]
-#[test]
-fn a_restore_that_could_not_finish_says_what_the_channel_carries() {
-    let run = point_channel(
-        Channel::Carrying("1.0.0-rc1"),
-        "1.0.0-rc2",
-        &["dist/feed.json", "saved/"],
-        &["latest.json"],
-    );
-    assert_ne!(
-        run.code, 0,
-        "a failed restore was survivable: {:?}",
-        run.calls
-    );
-    assert_eq!(
-        run.after,
-        Some(vec!["latest.json".to_owned()]),
-        "the fixture did not leave a half-written channel: {:?}",
-        run.calls
-    );
-    assert!(
-        run.output.contains("could not be put back")
-            && run.output.contains("It carries latest.json"),
-        "{}",
-        run.output
-    );
-    assert!(
-        !run.output.contains("is back as this run found it"),
-        "a channel that was not put back was reported as put back: {}",
-        run.output
-    );
-}
-
-/// Every command the restore runs changes the asset set on its way to
-/// failing: `--clobber` deletes an asset before uploading its replacement,
-/// and a `delete-asset` only runs once a saved upload has already landed. So
-/// the set as the restore found it is not the set the operator will find,
-/// and naming that one is worse than naming none, because it reads as
-/// current and sends them at the wrong thing.
-#[cfg(unix)]
-#[test]
-fn a_restore_that_changed_the_channel_names_what_is_there_now() {
-    let run = point_channel(
-        Channel::Carrying("1.0.0-rc1"),
-        "1.0.0-rc2",
-        &["dist/latest.json", "delete-asset"],
-        &["digests-x86_64-unknown-linux-gnu.json"],
-    );
-    assert_ne!(
-        run.code, 0,
-        "a failed restore was survivable: {:?}",
-        run.calls
-    );
-    // The two saved manifests are back up, and the digests document this run
-    // added is still there because taking it off is the command that failed.
-    assert_eq!(
-        run.after,
-        Some(vec![
-            "digests-x86_64-unknown-linux-gnu.json".to_owned(),
-            "feed.json".to_owned(),
-            "latest.json".to_owned(),
-        ]),
-        "the restore left the channel unchanged, so this proves nothing: {:?}",
-        run.calls
-    );
-    assert!(
-        run.output
-            .contains("It carries digests-x86_64-unknown-linux-gnu.json feed.json latest.json"),
-        "{}",
-        run.output
-    );
-    // What the channel carried when the restore began, and so what a snapshot
-    // taken before it would have named.
-    assert!(
-        !run.output.contains("It carries feed.json latest.json"),
-        "the message names the channel as the restore found it: {}",
-        run.output
     );
 }
 
@@ -623,7 +413,7 @@ fn a_restore_that_changed_the_channel_names_what_is_there_now() {
 #[cfg(unix)]
 #[test]
 fn a_channel_a_write_did_not_finish_on_stops_the_run() {
-    let run = point_channel(Channel::HalfWritten, "1.0.0-rc2", &[], &[]);
+    let run = point_channel(Channel::HalfWritten, "1.0.0-rc2", &[]);
     assert_ne!(run.code, 0, "{:?}", run.calls);
     assert!(
         run.ran("release upload").is_none(),
@@ -648,8 +438,8 @@ fn a_channel_a_write_did_not_finish_on_stops_the_run() {
 #[cfg(unix)]
 #[test]
 fn a_run_that_stops_leaves_no_channel_behind() {
-    let unorderable = point_channel(Channel::Absent, "not a version", &[], &[]);
-    let empty = point_channel_staging(Channel::Absent, "1.0.0-rc2", &[], &[], &[]);
+    let unorderable = point_channel(Channel::Absent, "not a version", &[]);
+    let empty = point_channel_staging(Channel::Absent, "1.0.0-rc2", &[], &[]);
     for run in [unorderable, empty] {
         assert_ne!(run.code, 0, "{:?}", run.calls);
         assert!(
@@ -703,7 +493,7 @@ fn a_tag_behind_the_channel_leaves_it_alone() {
     ];
     for carried in versions {
         for tagged in versions {
-            let run = point_channel(Channel::Carrying(carried), tagged, &[], &[]);
+            let run = point_channel(Channel::Carrying(carried), tagged, &[]);
             assert_eq!(run.code, 0, "{carried} -> {tagged}: {:?}", run.calls);
             // Equal versions re-run the same tag, which refreshes rather
             // than rolls back, so only a strictly newer carried version

--- a/crates/cli/tests/release_workflow/channel_point.rs
+++ b/crates/cli/tests/release_workflow/channel_point.rs
@@ -457,6 +457,13 @@ fn a_run_handed_no_manifests_writes_nothing() {
         "an empty dist still uploaded: {:?}",
         run.calls
     );
+    // Both names, as a sentence: pasted together they read as a typo in a
+    // CI log, which is the one place this message is ever read.
+    assert!(
+        run.output.contains("handed no latest.json or feed.json"),
+        "{}",
+        run.output
+    );
 }
 
 /// The channel's two manifests are one answer, and either one alone is half
@@ -489,6 +496,69 @@ fn a_run_handed_half_the_manifests_writes_nothing() {
             "the run did not say which half it was missing: {}",
             run.output
         );
+    }
+}
+
+/// The forward-only rule, asked of a channel this guard wrote rather than of
+/// one the fixture posed. The version comes back out of the manifest the
+/// first run uploaded, so the read the whole rule rests on is driven end to
+/// end: a stub that put an empty file up there would leave the second run
+/// with no version and no `hold` to make.
+#[cfg(unix)]
+#[test]
+fn a_channel_this_guard_wrote_holds_against_an_older_tag() {
+    let channel = Fixture::new(Channel::Empty, &STAGED);
+    let wrote = channel.run("1.0.0-rc9", &[], &[]);
+    assert_eq!(wrote.code, 0, "the first run refused: {}", wrote.output);
+
+    let older = channel.run("1.0.0-rc2", &[], &[]);
+    assert_eq!(
+        older.code, 0,
+        "the older tag was an error: {}",
+        older.output
+    );
+    assert!(
+        older.ran("release upload").is_none(),
+        "the older tag rolled the channel back: {:?}",
+        older.calls
+    );
+    assert!(
+        older
+            .output
+            .contains("carries 1.0.0-rc9, ahead of 1.0.0-rc2"),
+        "{}",
+        older.output
+    );
+    assert_eq!(
+        older.after, wrote.after,
+        "the run that held still changed the channel: {:?}",
+        older.calls
+    );
+}
+
+/// The accepting side of the pair rule. Only the two manifests are required,
+/// so a release built for fewer targets still points the channel — a guard
+/// that grew to require a per-target document would refuse every one of them
+/// and hold the channel until somebody read the job log.
+#[cfg(unix)]
+#[test]
+fn a_release_with_no_digests_document_still_points_the_channel() {
+    let run = point_channel_staging(
+        Channel::Carrying("1.0.0-rc1"),
+        "1.0.0-rc2",
+        &[],
+        &["latest.json", "feed.json"],
+    );
+    assert_eq!(
+        run.code, 0,
+        "a release with no digests was refused: {}",
+        run.output
+    );
+    let upload = run
+        .ran("release upload")
+        .unwrap_or_else(|| panic!("nothing was published: {:?}", run.calls));
+    for name in ["dist/latest.json", "dist/feed.json"] {
+        assert!(upload.contains(name), "{name} missing from {upload}");
     }
 }
 

--- a/crates/cli/tests/release_workflow/channel_point_failure.rs
+++ b/crates/cli/tests/release_workflow/channel_point_failure.rs
@@ -2,8 +2,8 @@
 //! changes the channel fails, and what the run after it does with that.
 //! `gh release upload --clobber` deletes an asset before uploading its
 //! replacement and uploads in parallel, so a failure can leave anything from
-//! the whole set to nothing at all, and the run that failed cannot read back
-//! which. Each state below is driven out of that one branch, and each is
+//! the whole set to nothing at all, and the run that failed does not read
+//! back which. Each state below is driven out of that one branch, and each is
 //! answered by the next run rather than by the failure.
 //!
 //! The guard's reads and its verdict are `channel_point.rs`, whose fixture
@@ -21,9 +21,9 @@ use crate::channel_point::{Channel, Fixture, STAGED};
 /// update at all.
 ///
 /// What it says is what this run knows: the upload failed, and the channel
-/// carries whatever landed. It names no post-failure state, because it has
-/// no way to read one — the three tests below drive three different states
-/// out of the same branch.
+/// carries some mixture of what was there and what landed. It names no
+/// post-failure state, because it does not read one — the three tests below
+/// drive three different states out of the same branch.
 #[cfg(unix)]
 #[test]
 fn a_failed_upload_fails_the_job_and_defers_to_the_next_run() {
@@ -48,7 +48,7 @@ fn a_failed_upload_fails_the_job_and_defers_to_the_next_run() {
     let channel = channel_step_env("CHANNEL");
     for said in [
         format!("Uploading to the {channel} channel failed"),
-        "which this run cannot read back".to_owned(),
+        "which this run does not read back".to_owned(),
         "Re-run the tag: that run reads the channel".to_owned(),
     ] {
         assert!(run.output.contains(&said), "{said} missing: {}", run.output);
@@ -96,6 +96,11 @@ fn a_failed_upload_that_kept_latest_json_is_written_by_the_re_run() {
 /// latest.json, so the channel carries assets nothing can read a version off
 /// and every later run refuses it. The tag re-run publishes nothing, and the
 /// message that sent the operator at it is the one that says so.
+///
+/// The two messages are asserted against each other here, because nothing
+/// checking them together is how they drifted the first time: the failure
+/// promises the next run names what has to come off, so the refusal has to
+/// name it.
 #[cfg(unix)]
 #[test]
 fn a_failed_upload_that_lost_latest_json_refuses_every_later_run() {
@@ -112,6 +117,13 @@ fn a_failed_upload_that_lost_latest_json_refuses_every_later_run() {
         "the fixture did not lose latest.json, so this proves nothing: {:?}",
         failed.calls
     );
+    assert!(
+        failed
+            .output
+            .contains("names what has to come off it by hand"),
+        "{}",
+        failed.output
+    );
 
     // The re-run the message sends them on, with nothing failing.
     let again = channel.run("1.0.0-rc2", &[], &[]);
@@ -125,9 +137,13 @@ fn a_failed_upload_that_lost_latest_json_refuses_every_later_run() {
         "the re-run published over the leftovers: {:?}",
         again.calls
     );
+    // The promise kept: the asset by name, and that it has to go.
     assert!(
-        again.output.contains("carries assets but no latest.json"),
-        "{}",
+        again
+            .output
+            .contains("carries feed.json and no latest.json")
+            && again.output.contains("have to come off"),
+        "the refusal did not name what the failure promised: {}",
         again.output
     );
     assert_eq!(

--- a/crates/cli/tests/release_workflow/channel_point_failure.rs
+++ b/crates/cli/tests/release_workflow/channel_point_failure.rs
@@ -98,9 +98,14 @@ fn a_failed_upload_that_kept_latest_json_is_written_by_the_re_run() {
 /// message that sent the operator at it is the one that says so.
 ///
 /// The two messages are asserted against each other here, because nothing
-/// checking them together is how they drifted the first time: the failure
-/// promises the next run names what has to come off, so the refusal has to
-/// name it.
+/// checking them together is how the failure's claim about the next run
+/// outran the refusals twice. What is checked is the claim as the WEAKEST
+/// refusal can keep it: that the run refuses and says what it found. Four
+/// refusals can follow this failure and they differ — two of them fail
+/// because a read failed, so an asset list is not something they could ever
+/// give. `a_read_it_could_not_make_stops_the_write` drives those three; the
+/// asset names below are this one branch's own, not what the failure
+/// promises.
 #[cfg(unix)]
 #[test]
 fn a_failed_upload_that_lost_latest_json_refuses_every_later_run() {
@@ -120,7 +125,7 @@ fn a_failed_upload_that_lost_latest_json_refuses_every_later_run() {
     assert!(
         failed
             .output
-            .contains("names what has to come off it by hand"),
+            .contains("either writes it or refuses, saying what it found"),
         "{}",
         failed.output
     );
@@ -137,13 +142,22 @@ fn a_failed_upload_that_lost_latest_json_refuses_every_later_run() {
         "the re-run published over the leftovers: {:?}",
         again.calls
     );
-    // The promise kept: the asset by name, and that it has to go.
+    // The claim kept, as every refusal has to keep it.
+    assert!(
+        again.output.contains("Nothing was written to the")
+            && again.output.contains("no latest.json"),
+        "the refusal did not say what it found: {}",
+        again.output
+    );
+    // And what this branch can give beyond it, because the read above it
+    // already held the names. Asserted apart from the claim, so a later
+    // change here cannot be read as the failure promising it.
     assert!(
         again
             .output
             .contains("carries feed.json and no latest.json")
             && again.output.contains("have to come off"),
-        "the refusal did not name what the failure promised: {}",
+        "the branch that can name the leftovers did not: {}",
         again.output
     );
     assert_eq!(

--- a/crates/cli/tests/release_workflow/channel_point_failure.rs
+++ b/crates/cli/tests/release_workflow/channel_point_failure.rs
@@ -1,0 +1,221 @@
+//! What `tools/release-channel-point` leaves behind when the one call that
+//! changes the channel fails, and what the run after it does with that.
+//! `gh release upload --clobber` deletes an asset before uploading its
+//! replacement and uploads in parallel, so a failure can leave anything from
+//! the whole set to nothing at all, and the run that failed cannot read back
+//! which. Each state below is driven out of that one branch, and each is
+//! answered by the next run rather than by the failure.
+//!
+//! The guard's reads and its verdict are `channel_point.rs`, whose fixture
+//! these run against.
+
+#[cfg(unix)]
+use crate::channel::channel_step_env;
+#[cfg(unix)]
+use crate::channel_point::{Channel, Fixture, STAGED};
+
+/// The upload is the one call that changes the channel, and the branch that
+/// catches it failing has to fail the job. A guard that printed its error and
+/// then exited 0 would let the release workflow's channel job go green with
+/// the channel short a manifest, which every candidate machine reads as no
+/// update at all.
+///
+/// What it says is what this run knows: the upload failed, and the channel
+/// carries whatever landed. It names no post-failure state, because it has
+/// no way to read one — the three tests below drive three different states
+/// out of the same branch.
+#[cfg(unix)]
+#[test]
+fn a_failed_upload_fails_the_job_and_defers_to_the_next_run() {
+    let run = Fixture::new(Channel::Carrying("1.0.0-rc1"), &STAGED).run(
+        "1.0.0-rc2",
+        &["dist/latest.json"],
+        &["latest.json", "feed.json"],
+    );
+    assert_ne!(
+        run.code, 0,
+        "a failed upload was survivable: {:?}",
+        run.calls
+    );
+    // The fixture reached the upload rather than stopping at an earlier read,
+    // so it is that branch this exercises and not one above it.
+    assert!(
+        run.ran("release upload").is_some(),
+        "the run never got as far as the upload: {:?}",
+        run.calls
+    );
+    // Named off the workflow, like every other channel-named claim here.
+    let channel = channel_step_env("CHANNEL");
+    for said in [
+        format!("Uploading to the {channel} channel failed"),
+        "which this run cannot read back".to_owned(),
+        "Re-run the tag: that run reads the channel".to_owned(),
+    ] {
+        assert!(run.output.contains(&said), "{said} missing: {}", run.output);
+    }
+}
+
+/// One state that branch can leave: the channel kept its latest.json, so the
+/// re-run reads a version off it, takes it, and publishes the whole staged
+/// set. Both runs are against the one channel, so the second reads what the
+/// first actually left rather than a pose of it.
+#[cfg(unix)]
+#[test]
+fn a_failed_upload_that_kept_latest_json_is_written_by_the_re_run() {
+    let channel = Fixture::new(Channel::Carrying("1.0.0-rc1"), &STAGED);
+    let failed = channel.run(
+        "1.0.0-rc2",
+        &["dist/latest.json"],
+        &["latest.json", "feed.json"],
+    );
+    assert_ne!(
+        failed.code, 0,
+        "a failed upload was survivable: {:?}",
+        failed.calls
+    );
+    assert_eq!(
+        failed.after,
+        Some(vec!["feed.json".to_owned(), "latest.json".to_owned()]),
+        "the fixture did not keep latest.json, so this proves nothing: {:?}",
+        failed.calls
+    );
+
+    let again = channel.run("1.0.0-rc2", &[], &[]);
+    assert_eq!(again.code, 0, "the re-run refused: {}", again.output);
+    let mut whole: Vec<String> = STAGED.iter().map(|name| (*name).to_owned()).collect();
+    whole.sort();
+    assert_eq!(
+        again.after,
+        Some(whole),
+        "the re-run did not publish the whole set: {:?}",
+        again.calls
+    );
+}
+
+/// A second state: the upload fell over after `--clobber` deleted
+/// latest.json, so the channel carries assets nothing can read a version off
+/// and every later run refuses it. The tag re-run publishes nothing, and the
+/// message that sent the operator at it is the one that says so.
+#[cfg(unix)]
+#[test]
+fn a_failed_upload_that_lost_latest_json_refuses_every_later_run() {
+    let channel = Fixture::new(Channel::Carrying("1.0.0-rc1"), &STAGED);
+    let failed = channel.run("1.0.0-rc2", &["dist/latest.json"], &["feed.json"]);
+    assert_ne!(
+        failed.code, 0,
+        "a failed upload was survivable: {:?}",
+        failed.calls
+    );
+    assert_eq!(
+        failed.after,
+        Some(vec!["feed.json".to_owned()]),
+        "the fixture did not lose latest.json, so this proves nothing: {:?}",
+        failed.calls
+    );
+
+    // The re-run the message sends them on, with nothing failing.
+    let again = channel.run("1.0.0-rc2", &[], &[]);
+    assert_ne!(
+        again.code, 0,
+        "the re-run wrote over a channel nothing can read: {:?}",
+        again.calls
+    );
+    assert!(
+        again.ran("release upload").is_none(),
+        "the re-run published over the leftovers: {:?}",
+        again.calls
+    );
+    assert!(
+        again.output.contains("carries assets but no latest.json"),
+        "{}",
+        again.output
+    );
+    assert_eq!(
+        again.after,
+        Some(vec!["feed.json".to_owned()]),
+        "the re-run changed the channel it refused: {:?}",
+        again.calls
+    );
+}
+
+/// A third state, and the one that says why the failure must not name any of
+/// them. `gh` deletes every colliding asset before it uploads, so a failure
+/// that is the connection rather than one file lands nothing at all, and the
+/// channel this run published carries nothing. That is not a channel anyone
+/// has to clear: the next run reads it as one no write has landed on and
+/// takes it.
+#[cfg(unix)]
+#[test]
+fn a_failed_upload_that_landed_nothing_leaves_a_channel_the_next_run_takes() {
+    let channel = Fixture::new(Channel::Absent, &STAGED);
+    let failed = channel.run("1.0.0-rc5", &["dist/latest.json"], &[]);
+    assert_ne!(
+        failed.code, 0,
+        "a failed upload was survivable: {:?}",
+        failed.calls
+    );
+    assert!(
+        failed.ran("release create").is_some(),
+        "the fixture did not reach the create: {:?}",
+        failed.calls
+    );
+    assert_eq!(
+        failed.after,
+        Some(Vec::new()),
+        "the fixture left assets, so this proves nothing: {:?}",
+        failed.calls
+    );
+    // The one thing about the channel this run does know, because it is what
+    // this run did rather than what the failure left.
+    assert!(
+        failed
+            .output
+            .contains("This run is what published that channel"),
+        "{}",
+        failed.output
+    );
+
+    let again = channel.run("1.0.0-rc5", &[], &[]);
+    assert_eq!(again.code, 0, "the re-run refused: {}", again.output);
+    assert!(
+        again.ran("release upload").is_some(),
+        "the re-run published nothing: {:?}",
+        again.calls
+    );
+}
+
+/// What an emptied channel allows, pinned rather than described. The
+/// forward-only rule reads the version off the channel, and a channel
+/// carrying nothing has none, so the run after a failure that landed nothing
+/// takes any tag — an older one included. Both shells refuse a downgrade, so
+/// candidates stall on a channel behind them rather than install an older
+/// build, which is why this is pinned here and not repaired.
+#[cfg(unix)]
+#[test]
+fn an_emptied_channel_takes_an_older_tag() {
+    let channel = Fixture::new(Channel::Carrying("1.0.0-rc9"), &STAGED);
+    let failed = channel.run("1.0.0-rc9", &["dist/latest.json"], &[]);
+    assert_ne!(
+        failed.code, 0,
+        "a failed upload was survivable: {:?}",
+        failed.calls
+    );
+    assert_eq!(
+        failed.after,
+        Some(Vec::new()),
+        "the fixture did not empty the channel: {:?}",
+        failed.calls
+    );
+
+    let older = channel.run("1.0.0-rc2", &[], &[]);
+    assert_eq!(
+        older.code, 0,
+        "an emptied channel refused an older tag, so this pin is stale: {}",
+        older.output
+    );
+    assert!(
+        older.ran("release upload").is_some(),
+        "an emptied channel refused an older tag, so this pin is stale: {:?}",
+        older.calls
+    );
+}

--- a/crates/cli/tests/release_workflow/main.rs
+++ b/crates/cli/tests/release_workflow/main.rs
@@ -665,4 +665,5 @@ fn no_lane_triple_is_hardcoded_into_build_or_staging() {
 
 mod channel;
 mod channel_point;
+mod channel_point_failure;
 mod signing;

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -68,22 +68,24 @@ version is a candidate reads its updates from there
 call with their baked version). A shipped `1.0.0` is on the release channel
 and is never offered a candidate; nothing on the machine selects this.
 
-The channel only ever moves forward: `tools/release-channel-point` reads the
-version it already carries and leaves it alone when that is ahead of the tag
-being published, so re-running an older tag cannot roll every candidate back
-to it. Nothing it could not establish counts as permission to write — a
-listing it could not make, a channel carrying assets but no `latest.json`, a
-manifest naming no version, a version that is not SemVer — each of those stops
-the job with the channel as it was.
+The channel only ever moves forward while it carries a version to compare
+against: `tools/release-channel-point` reads that version off its
+`latest.json` and leaves the channel alone when it is ahead of the tag being
+published, so re-running an older tag cannot roll every candidate back to it.
+A channel carrying nothing has no such version, and any tag may take it.
+Nothing the job could not establish counts as permission to write — a listing
+it could not make, a channel carrying assets but no `latest.json`, a manifest
+naming no version, a version that is not SemVer — each of those stops the job
+with the channel as it was.
 
-An upload that fails partway is the one case where something did change, and
-which repair it needs depends on which manifest went with it. The job fails
-either way. A channel still carrying its `latest.json` is one the next tag run
-writes over, so re-running the tag is the whole repair. A channel that lost
-`latest.json` is refused by the rule above on every later run, so a person has
-to delete what is left on it before a tag re-run publishes anything. The job's
-error names both, because nothing it can read off its own failure says which
-one it left.
+A partial upload is the one failure that leaves the channel changed, and the
+job does not repair it. `gh release upload --clobber` deletes an asset before
+uploading its replacement, and uploads in parallel, so what the channel
+carries afterwards is whatever landed and the run that failed cannot read that
+back. The next tag run can, and the rule above is the one it applies: a
+channel it cannot read a version off is refused and needs a person, anything
+else it takes. So the failure says what the run did and sends you at that next
+run, rather than naming a state it has no way to know.
 
 That guard is a job of its own, and the only one holding a concurrency group,
 so two candidates cut close together cannot interleave their read and write of

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -72,11 +72,18 @@ The channel only ever moves forward: `tools/release-channel-point` reads the
 version it already carries and leaves it alone when that is ahead of the tag
 being published, so re-running an older tag cannot roll every candidate back
 to it. Nothing it could not establish counts as permission to write — a
-listing it could not make, a manifest naming no version, a version that is
-not SemVer — each of those stops the job with the channel as it was.
+listing it could not make, a channel carrying assets but no `latest.json`, a
+manifest naming no version, a version that is not SemVer — each of those stops
+the job with the channel as it was.
 
-An upload that fails partway leaves the channel short a manifest; the job
-fails, and re-running the tag writes the whole set again, which repairs it.
+An upload that fails partway is the one case where something did change, and
+which repair it needs depends on which manifest went with it. The job fails
+either way. A channel still carrying its `latest.json` is one the next tag run
+writes over, so re-running the tag is the whole repair. A channel that lost
+`latest.json` is refused by the rule above on every later run, so a person has
+to delete what is left on it before a tag re-run publishes anything. The job's
+error names both, because nothing it can read off its own failure says which
+one it left.
 
 That guard is a job of its own, and the only one holding a concurrency group,
 so two candidates cut close together cannot interleave their read and write of

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -75,12 +75,8 @@ to it. Nothing it could not establish counts as permission to write — a
 listing it could not make, a manifest naming no version, a version that is
 not SemVer — each of those stops the job with the channel as it was.
 
-An upload that fails partway is the one case where something did change, and
-the job puts the channel back: the manifests it found go up again, anything
-it added comes off, and a channel this run created is deleted outright. When
-it cannot finish that, it says so and names what the channel carries, because
-a half-written channel reporting itself as repaired is what stops anyone
-looking at it. Either way the job fails and the fix is to re-run the tag.
+An upload that fails partway leaves the channel short a manifest; the job
+fails, and re-running the tag writes the whole set again, which repairs it.
 
 That guard is a job of its own, and the only one holding a concurrency group,
 so two candidates cut close together cannot interleave their read and write of

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -81,11 +81,12 @@ with the channel as it was.
 A partial upload is the one failure that leaves the channel changed, and the
 job does not repair it. `gh release upload --clobber` deletes an asset before
 uploading its replacement, and uploads in parallel, so what the channel
-carries afterwards is whatever landed and the run that failed cannot read that
-back. The next tag run can, and the rule above is the one it applies: a
-channel it cannot read a version off is refused and needs a person, anything
-else it takes. So the failure says what the run did and sends you at that next
-run, rather than naming a state it has no way to know.
+carries afterwards is some mixture of what was there and what landed, and the
+run that failed does not read that back. The next tag run does, and the rule
+above is the one it applies: a channel carrying assets it cannot read a
+version off is refused and needs a person, anything else it takes. So the
+failure says what the run did and sends you at that next run, rather than
+naming a state it did not establish.
 
 That guard is a job of its own, and the only one holding a concurrency group,
 so two candidates cut close together cannot interleave their read and write of

--- a/tools/release-channel-point
+++ b/tools/release-channel-point
@@ -173,6 +173,6 @@ if ! gh release upload "$CHANNEL" "${publishing[@]}" \
   if [ -n "$absent" ]; then
     published=" This run is what published that channel; there was none before it."
   fi
-  echo "::error::Uploading to the ${CHANNEL} channel failed, and what it carries now is some mixture of what was already there and what landed, which this run does not read back.${published} Re-run the tag: that run reads the channel and either writes it or names what has to come off it by hand."
+  echo "::error::Uploading to the ${CHANNEL} channel failed, and what it carries now is some mixture of what was already there and what landed, which this run does not read back.${published} Re-run the tag: that run reads the channel and either writes it or refuses, saying what it found."
   exit 1
 fi

--- a/tools/release-channel-point
+++ b/tools/release-channel-point
@@ -9,15 +9,11 @@
 # can use come from it. Exit 0 wrote the channel or left it alone on purpose,
 # exit 1 says what stopped it.
 #
-# Only one failure leaves the channel changed, and how it is repaired depends
-# on which manifest went with it. `gh release upload --clobber` deletes an
-# asset before uploading its replacement, so an upload that fell over partway
-# either left latest.json up, in which case re-running the tag writes the
-# whole set again, or took it off, in which case the check below refuses the
-# channel on every later run and a person has to delete what is left on it
-# before a tag re-run can write. Nothing here repairs the second state,
-# because a run that cannot read a version off the channel cannot tell a
-# leftover from a release it would be rolling back.
+# A partial upload is the one failure that leaves the channel changed, and
+# this script does not repair it. The next tag run reads what is there and
+# applies one rule: a channel carrying assets it cannot read a version off is
+# refused and needs a person, anything else it takes. So a failure here says
+# what this run did and sends whoever reads it at that run.
 #
 # One verdict decides the write, and only `write` and `hold` are verdicts.
 # Each read leaves either a channel state this run established or the reason
@@ -29,13 +25,24 @@
 # through.
 set -euo pipefail
 
+# The pair a candidate reads together, named once because every use below is
+# of the pair and not of either name. `manifest_url_for` sends the desktop
+# updater to latest.json and `feed_url_for` sends `kendex update` and the
+# app's own discovery read to feed.json, so publishing one without the other
+# leaves the app on the version the stale one names while `kendex update`
+# follows the other to a new one, with nothing on the channel reporting the
+# two as disagreeing.
+MANIFESTS="dist/latest.json dist/feed.json"
+
 # What this run puts on the channel, read off the files it was handed rather
-# than listed here. The two manifests are fixed, but a digests document
-# carries the target it was built for, so the set is whatever the release
-# published and a build that gains a target needs no edit here.
+# than listed here. The pair is fixed, but a digests document carries the
+# target it was built for, so the rest of the set is whatever the release
+# published and a build that gains a target needs no edit here. A missing
+# digests document is not refused below: a channel with fewer is a release
+# built for fewer targets, not a broken one.
 uploaded() {
   local file
-  for file in dist/latest.json dist/feed.json dist/digests-*; do
+  for file in $MANIFESTS dist/digests-*; do
     [ -f "$file" ] && printf '%s\n' "$file"
   done
   return 0
@@ -133,20 +140,16 @@ publishing=()
 while IFS= read -r file; do
   publishing+=("$file")
 done < <(uploaded)
-if [ "${#publishing[@]}" -eq 0 ]; then
-  echo "::error::Nothing was written to the ${CHANNEL} channel: this run was handed no manifests to publish. Re-run the tag."
+# Neither half goes up alone. A dist holding neither reaches this too, so it
+# is the only emptiness check the write needs.
+short=""
+for file in $MANIFESTS; do
+  [ -f "$file" ] || short="$short ${file#dist/}"
+done
+if [ -n "$short" ]; then
+  echo "::error::Nothing was written to the ${CHANNEL} channel: this run was handed no${short}, and the channel's manifests are published together or not at all. Re-run the tag."
   exit 1
 fi
-# The two manifests are one answer. Publishing feed.json over a latest.json
-# this run was not handed leaves the channel naming one version in the file
-# candidates read and another in the file they check it against, and nothing
-# downstream reports that as wrong.
-case " ${publishing[*]} " in
-  *" dist/latest.json "*) ;;
-  *)
-    echo "::error::Nothing was written to the ${CHANNEL} channel: this run was handed no latest.json, and the channel's manifests are published together or not at all. Re-run the tag."
-    exit 1 ;;
-esac
 # The write begins here, past the verdict and past the list. A channel that
 # did not exist is published now.
 if [ -n "$absent" ]; then
@@ -159,15 +162,14 @@ if [ -n "$absent" ]; then
 fi
 if ! gh release upload "$CHANNEL" "${publishing[@]}" \
      --repo "$GITHUB_REPOSITORY" --clobber; then
-  # Which repair this needs is not something the run can read off its own
-  # failure, so the message names both. A channel still carrying latest.json
-  # is one the next tag run writes over. A channel that lost it is one every
-  # later run refuses at the check above, and the assets left on it have to
-  # go before a tag re-run means anything.
+  # `gh` deletes before it uploads and uploads in parallel, so a failure can
+  # leave anything from the whole set to nothing at all and this run cannot
+  # read back which. The next run can, and its own refusals say what it
+  # found, so this one states what it did and stops there.
   published=""
   if [ -n "$absent" ]; then
-    published=" This run published that channel, so what is on it is what landed before the failure."
+    published=" This run is what published that channel; there was none before it."
   fi
-  echo "::error::Uploading to the ${CHANNEL} channel failed, and it may be short a manifest.${published} Re-run the tag if the channel still carries latest.json: that writes the whole set again. If it does not, every run refuses the channel until someone deletes the assets left on it, and only then does re-running the tag publish anything."
+  echo "::error::Uploading to the ${CHANNEL} channel failed, and what it carries now is whatever landed before that, which this run cannot read back.${published} Re-run the tag: that run reads the channel and either writes it or names what has to come off it by hand."
   exit 1
 fi

--- a/tools/release-channel-point
+++ b/tools/release-channel-point
@@ -7,8 +7,17 @@
 # which name their downloads by the tag that built them. The release workflow's channel job is
 # the only caller; CHANNEL, NEW_VERSION, GITHUB_REPOSITORY and a GH_TOKEN gh
 # can use come from it. Exit 0 wrote the channel or left it alone on purpose,
-# exit 1 says what stopped it, and re-running the tag repairs a channel a
-# failed upload left short a manifest.
+# exit 1 says what stopped it.
+#
+# Only one failure leaves the channel changed, and how it is repaired depends
+# on which manifest went with it. `gh release upload --clobber` deletes an
+# asset before uploading its replacement, so an upload that fell over partway
+# either left latest.json up, in which case re-running the tag writes the
+# whole set again, or took it off, in which case the check below refuses the
+# channel on every later run and a person has to delete what is left on it
+# before a tag re-run can write. Nothing here repairs the second state,
+# because a run that cannot read a version off the channel cannot tell a
+# leftover from a release it would be rolling back.
 #
 # One verdict decides the write, and only `write` and `hold` are verdicts.
 # Each read leaves either a channel state this run established or the reason
@@ -59,10 +68,10 @@ elif ! grep -qxF latest.json <<< "$assets"; then
     state=fresh
   fi
 elif ! gh release download "$CHANNEL" --repo "$GITHUB_REPOSITORY" \
-     --dir saved --pattern latest.json --clobber; then
+     --dir manifest --pattern latest.json --clobber; then
   why="the ${CHANNEL} channel's manifest could not be downloaded"
 else
-  current=$(jq -r '.version // empty' saved/latest.json) || current=""
+  current=$(jq -r '.version // empty' manifest/latest.json) || current=""
   if [ -n "$current" ]; then
     state=carrying
   else
@@ -128,6 +137,16 @@ if [ "${#publishing[@]}" -eq 0 ]; then
   echo "::error::Nothing was written to the ${CHANNEL} channel: this run was handed no manifests to publish. Re-run the tag."
   exit 1
 fi
+# The two manifests are one answer. Publishing feed.json over a latest.json
+# this run was not handed leaves the channel naming one version in the file
+# candidates read and another in the file they check it against, and nothing
+# downstream reports that as wrong.
+case " ${publishing[*]} " in
+  *" dist/latest.json "*) ;;
+  *)
+    echo "::error::Nothing was written to the ${CHANNEL} channel: this run was handed no latest.json, and the channel's manifests are published together or not at all. Re-run the tag."
+    exit 1 ;;
+esac
 # The write begins here, past the verdict and past the list. A channel that
 # did not exist is published now.
 if [ -n "$absent" ]; then
@@ -140,10 +159,15 @@ if [ -n "$absent" ]; then
 fi
 if ! gh release upload "$CHANNEL" "${publishing[@]}" \
      --repo "$GITHUB_REPOSITORY" --clobber; then
-  # `--clobber` deletes an asset before uploading its replacement, so a
-  # failure partway leaves the channel short a manifest and candidates
-  # reading it see no update at all. Re-running the tag writes the whole set
-  # again, which is the repair.
-  echo "::error::Uploading to the ${CHANNEL} channel failed, and it may be short a manifest. Re-run the tag."
+  # Which repair this needs is not something the run can read off its own
+  # failure, so the message names both. A channel still carrying latest.json
+  # is one the next tag run writes over. A channel that lost it is one every
+  # later run refuses at the check above, and the assets left on it have to
+  # go before a tag re-run means anything.
+  published=""
+  if [ -n "$absent" ]; then
+    published=" This run published that channel, so what is on it is what landed before the failure."
+  fi
+  echo "::error::Uploading to the ${CHANNEL} channel failed, and it may be short a manifest.${published} Re-run the tag if the channel still carries latest.json: that writes the whole set again. If it does not, every run refuses the channel until someone deletes the assets left on it, and only then does re-running the tag publish anything."
   exit 1
 fi

--- a/tools/release-channel-point
+++ b/tools/release-channel-point
@@ -70,7 +70,7 @@ elif ! grep -qxF latest.json <<< "$assets"; then
   # fresh, any tag would pass the comparison it exists to face, which is the
   # rollback this guard is here to refuse. Repair is a person's, not a run's.
   if [ -n "$assets" ]; then
-    why="the ${CHANNEL} channel carries assets but no latest.json, so nothing here can say what it holds"
+    why="the ${CHANNEL} channel carries $(paste -sd' ' - <<< "$assets") and no latest.json, so nothing here can say what it holds; those have to come off before a tag re-run publishes anything"
   else
     state=fresh
   fi
@@ -144,10 +144,11 @@ done < <(uploaded)
 # is the only emptiness check the write needs.
 short=""
 for file in $MANIFESTS; do
-  [ -f "$file" ] || short="$short ${file#dist/}"
+  [ -f "$file" ] && continue
+  if [ -z "$short" ]; then short="${file#dist/}"; else short="$short or ${file#dist/}"; fi
 done
 if [ -n "$short" ]; then
-  echo "::error::Nothing was written to the ${CHANNEL} channel: this run was handed no${short}, and the channel's manifests are published together or not at all. Re-run the tag."
+  echo "::error::Nothing was written to the ${CHANNEL} channel: this run was handed no ${short}, and the channel's manifests are published together or not at all. Re-run the tag."
   exit 1
 fi
 # The write begins here, past the verdict and past the list. A channel that
@@ -163,13 +164,15 @@ fi
 if ! gh release upload "$CHANNEL" "${publishing[@]}" \
      --repo "$GITHUB_REPOSITORY" --clobber; then
   # `gh` deletes before it uploads and uploads in parallel, so a failure can
-  # leave anything from the whole set to nothing at all and this run cannot
-  # read back which. The next run can, and its own refusals say what it
-  # found, so this one states what it did and stops there.
+  # leave anything from the whole set to nothing at all, old assets a
+  # cancelled worker never deleted included. This run does not read back
+  # which: a read after a failed call can fail too, and a message naming a
+  # state nobody established is what stops anyone looking. The next run does
+  # read it, and its own refusals say what it found.
   published=""
   if [ -n "$absent" ]; then
     published=" This run is what published that channel; there was none before it."
   fi
-  echo "::error::Uploading to the ${CHANNEL} channel failed, and what it carries now is whatever landed before that, which this run cannot read back.${published} Re-run the tag: that run reads the channel and either writes it or names what has to come off it by hand."
+  echo "::error::Uploading to the ${CHANNEL} channel failed, and what it carries now is some mixture of what was already there and what landed, which this run does not read back.${published} Re-run the tag: that run reads the channel and either writes it or names what has to come off it by hand."
   exit 1
 fi

--- a/tools/release-channel-point
+++ b/tools/release-channel-point
@@ -7,7 +7,8 @@
 # which name their downloads by the tag that built them. The release workflow's channel job is
 # the only caller; CHANNEL, NEW_VERSION, GITHUB_REPOSITORY and a GH_TOKEN gh
 # can use come from it. Exit 0 wrote the channel or left it alone on purpose,
-# exit 1 wrote nothing or says what it left behind.
+# exit 1 says what stopped it, and re-running the tag repairs a channel a
+# failed upload left short a manifest.
 #
 # One verdict decides the write, and only `write` and `hold` are verdicts.
 # Each read leaves either a channel state this run established or the reason
@@ -31,85 +32,9 @@ uploaded() {
   return 0
 }
 
-# The channel's copies of those, and so the ones this run has to be able to
-# put back. `gh release upload --clobber` deletes an asset before uploading
-# its replacement, so a copy taken now is the only copy of what the channel
-# had if that upload then fails. A channel carrying none of them leaves saved/
-# absent, which is that channel's pre-upload set just as truly.
-save_manifests() {
-  local patterns=() file name
-  while IFS= read -r file; do
-    name=$(basename "$file")
-    if grep -qxF "$name" <<< "$assets"; then patterns+=(--pattern "$name"); fi
-  done < <(uploaded)
-  [ ${#patterns[@]} -gt 0 ] || return 0
-  gh release download "$CHANNEL" --repo "$GITHUB_REPOSITORY" \
-    --dir saved "${patterns[@]}" --clobber
-}
-
-# What the channel carries, read at the moment of asking. The one reader of
-# this is an operator standing in front of a broken channel deciding what to
-# repair, and every restore command below changes the asset set on its way to
-# failing, so an answer from before the restore reads as current and sends
-# that operator at the wrong thing. A read this run cannot make says so
-# rather than falling back to one it made earlier.
-carrying_now() {
-  local now
-  if ! now=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${CHANNEL}" --jq '.assets[].name'); then
-    echo "a set this run could not read"
-    return 0
-  fi
-  now=$(paste -sd' ' - <<< "$now")
-  [ -n "$now" ] || now="no manifests"
-  echo "$now"
-}
-
-# Puts the channel back the way this run found it and says which in
-# `restored`: `removed` when the release this run created is gone, `put-back`
-# when the manifests it found are up and the ones it added are off. Anything
-# else is a channel nobody has repaired.
-#
-# Always returns 0. The verdict is `restored`, so a caller under `set -e`
-# reaches its `case` rather than exiting on this function's own status.
-#
-# What the channel carries is read rather than assumed: a failed upload stops
-# partway, and only the channel says how far it got. A read that fails leaves
-# `restored` empty, because a set this run cannot see is one it cannot claim
-# to have put back.
-restored=""
-restore() {
-  local file name now
-  now=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${CHANNEL}" --jq '.assets[].name') || return 0
-  # The tag stays behind. `gh release create` reuses an existing tag, so this
-  # run cannot tell one it made from one that was already there carrying no
-  # release, and deleting the second would destroy something it never
-  # created. A tag with no release on it publishes nothing either way.
-  if [ -n "$created" ]; then
-    if gh release delete "$CHANNEL" --repo "$GITHUB_REPOSITORY" --yes; then
-      restored=removed
-    fi
-    return 0
-  fi
-  if [ -n "$(ls -A saved 2>/dev/null)" ]; then
-    # Every saved asset, not the documents alone. A digests document and the
-    # signature beside it are one answer to a candidate: put half of it back
-    # and the channel reads as repaired while every update is refused.
-    gh release upload "$CHANNEL" saved/* --repo "$GITHUB_REPOSITORY" --clobber || return 0
-  fi
-  while IFS= read -r file; do
-    name=$(basename "$file")
-    if [ ! -f "saved/$name" ] && grep -qxF "$name" <<< "$now"; then
-      gh release delete-asset "$CHANNEL" "$name" --repo "$GITHUB_REPOSITORY" --yes || return 0
-    fi
-  done < <(uploaded)
-  restored=put-back
-  return 0
-}
-
 state=unknown
 why=""
 current=""
-created=""
 absent=""
 if ! tags=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate --jq '.[].tag_name'); then
   why="this repository's releases could not be listed"
@@ -122,8 +47,6 @@ elif ! grep -qxF "$CHANNEL" <<< "$tags"; then
   state=fresh
 elif ! assets=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${CHANNEL}" --jq '.assets[].name'); then
   why="the ${CHANNEL} channel is published but its assets could not be read"
-elif ! save_manifests; then
-  why="the ${CHANNEL} channel carries a manifest that could not be downloaded"
 elif ! grep -qxF latest.json <<< "$assets"; then
   # Carrying nothing is a channel no write has landed on, and this run may
   # take it. Carrying something without a latest.json is a channel a write
@@ -135,6 +58,9 @@ elif ! grep -qxF latest.json <<< "$assets"; then
   else
     state=fresh
   fi
+elif ! gh release download "$CHANNEL" --repo "$GITHUB_REPOSITORY" \
+     --dir saved --pattern latest.json --clobber; then
+  why="the ${CHANNEL} channel's manifest could not be downloaded"
 else
   current=$(jq -r '.version // empty' saved/latest.json) || current=""
   if [ -n "$current" ]; then
@@ -187,10 +113,9 @@ case "$verdict" in
     exit 1 ;;
 esac
 
-# One list, resolved once: what is uploaded is what the restore above knows
-# to take back off. An unmatched glob left literal would name a file that is
-# not there, and a `dist` holding nothing at all would upload nothing while
-# reporting a channel it moved.
+# What `dist` holds, resolved before the write. An unmatched glob left literal
+# would name a file that is not there, and a `dist` holding nothing at all
+# would upload nothing while reporting a channel it moved.
 #
 # Built by reading rather than by `readarray`, which arrived in Bash 4:
 # `crates/cli/tests/release_workflow` runs this script on the macOS lane,
@@ -204,9 +129,7 @@ if [ "${#publishing[@]}" -eq 0 ]; then
   exit 1
 fi
 # The write begins here, past the verdict and past the list. A channel that
-# did not exist is published now, and `created` is what lets the restore take
-# it away again — an empty channel left behind is one candidates read as no
-# update at all.
+# did not exist is published now.
 if [ -n "$absent" ]; then
   if ! gh release create "$CHANNEL" --repo "$GITHUB_REPOSITORY" --prerelease \
        --title "Pre-release channel" \
@@ -214,24 +137,13 @@ if [ -n "$absent" ]; then
     echo "::error::Nothing was written to the ${CHANNEL} channel: it does not exist and could not be created. Re-run the tag."
     exit 1
   fi
-  created=1
 fi
 if ! gh release upload "$CHANNEL" "${publishing[@]}" \
      --repo "$GITHUB_REPOSITORY" --clobber; then
-  # An upload that failed after the delete leaves the channel short a
-  # manifest, and a candidate reading a channel with no latest.json sees no
-  # update at all. Not an atomic swap: the run fails whatever the restore
-  # does. What the restore may not do is report a channel it did not put
-  # back, because a half-written channel that announces itself as repaired is
-  # what stops anyone looking at it.
-  restore
-  case "$restored" in
-    removed)
-      echo "::error::Uploading to the ${CHANNEL} channel failed, and the channel this run created has been removed. Nothing is published there. Re-run the tag." ;;
-    put-back)
-      echo "::error::Uploading to the ${CHANNEL} channel failed; the channel is back as this run found it. Re-run the tag." ;;
-    *)
-      echo "::error::Uploading to the ${CHANNEL} channel failed and the channel could not be put back. It carries $(carrying_now). Candidates read that until a tag re-run repairs the channel." ;;
-  esac
+  # `--clobber` deletes an asset before uploading its replacement, so a
+  # failure partway leaves the channel short a manifest and candidates
+  # reading it see no update at all. Re-running the tag writes the whole set
+  # again, which is the repair.
+  echo "::error::Uploading to the ${CHANNEL} channel failed, and it may be short a manifest. Re-run the tag."
   exit 1
 fi


### PR DESCRIPTION
## Summary

- Drops the restore-after-failed-upload path from `tools/release-channel-point` — `restore()`, `carrying_now()`, `save_manifests()` and the three-way message they picked between are gone, along with the five tests that only existed to drive them.
- The failure path names no channel state. `gh release upload --clobber` deletes before it uploads and uploads in parallel, so a failed run cannot know what the channel is left carrying; it now says what it did and defers to the next run, whose own refusals read the real state. That refusal names the assets that have to come off, from the listing it already made.
- The two manifests are named once as a pair and checked by membership, so a `dist` short either half is refused naming which. That check subsumes the old empty-`dist` check.

## Context

The issue's premise was that re-running the tag already repairs a failed upload. It does not, in the case the restore path existed for: when `--clobber` takes `latest.json` off and the upload then fails, the guard's own half-written check refuses the channel on every later run. Four reviewers reproduced that end to end against the real script. Three further post-failure states turned up the same way — an emptied channel, that channel accepting an older tag, and a GitHub `starter` asset that passes a name check but will not parse.

Rather than enumerate a fourth state, the failure path stopped enumerating. That single change covers all of them and needs no asset-state probing.

**Deviation from the Done-when, recorded deliberately.** KEN-912 asks for `docs/RELEASING.md` to say "re-run the tag" in one line. Three rounds of evidence show that claim is false, so the doc states the rule the guard applies instead. Shipping the literal Done-when would ship a claim the code refutes.

## Completed Issues

- Closes KEN-912 - release-channel-point has no restore path; re-running the tag repairs

## Test Plan

`cargo test -p kendex-cli --test release_workflow` — 16 tests across `channel_point.rs` and the new `channel_point_failure.rs`, covering every post-failure state the guard can meet: a kept `latest.json` re-run writes, a lost `latest.json` is refused until the named assets come off, an emptied channel is taken by the next tag, and a channel this guard wrote holds against an older tag.

Each behaviour is mutation-pinned. Reverting any of these leaves exactly one test failing: the upload-failure `exit 1`, the manifest-pair refusal, the missing-half naming, the refusal's asset names, the fixture's successful-upload content copy, and the digests-document boundary.

Full `tools/guard` clean, including the `x86_64-pc-windows-msvc` and `aarch64-apple-darwin` cross-target checks.
