### PR TITLE
refactor(KEN-913): setup, sync and install-git-hooks carry no compat

### DIFF
--- a/.agents/skills/growth-guards/DEVELOPMENT.md
+++ b/.agents/skills/growth-guards/DEVELOPMENT.md
@@ -74,17 +74,23 @@ would leave an appended guard unreachable. Ours runs, blocks on any nonzero,
 and then falls through to whatever the hook already did — whose own exit
 status still decides.
 
-Repeat runs are no-ops, and repairs. A hook counts as current only when it
-carries the EXACT delegating line on a line of its own — a line that was
-commented out, truncated, or left behind by an older version is rewritten,
-not trusted — and a hook whose executable bit was cleared gets it back,
-because git silently ignores a hook it cannot execute. An existing
-`pre-commit`/`commit-msg` keeps its content and its own exit status; a hook
-that is symlinked, deliberately disabled (not executable), or whose shebang
-names an interpreter that is not a POSIX-compatible shell is left alone
-entirely (reported, and the install exits 1). A file at the helper path that
-this installer did not write is never overwritten. A bare repository is
-refused — there is no work tree to guard.
+Repeat runs are no-ops, and repairs. A consumer's own hook counts as current
+only when it carries the EXACT delegating line on a line of its own — a line
+that was commented out, truncated, or left behind by an older version is
+rewritten, not trusted. A hook this installer CREATED is owned whole, the way
+`--uninstall` deletes such a file outright: it is current only when its bytes
+are exactly the shebang, the delegating line and the created marker, and
+anything else in it is rewritten away rather than repaired around. A hook
+whose executable bit was cleared gets it back, because git silently ignores a
+hook it cannot execute. An existing `pre-commit`/`commit-msg` keeps its
+content, its shebang and its own exit status; a hook that is symlinked,
+deliberately disabled (not executable), whose shebang names an interpreter
+that is not a POSIX-compatible shell, or whose shebang names a shell outside
+the trusted full paths under `/bin` and `/usr/bin`, is left alone entirely
+(reported, and the install exits 1). That trusted-path rule holds at install
+exactly as it does at `--check`, whoever wrote the hook. A file at the helper
+path that this installer did not write is never overwritten. A bare
+repository is refused — there is no work tree to guard.
 
 Linked worktrees share the install, since git resolves their hooks to the
 main checkout's hooks directory. The same sharing governs removal, and it

--- a/.agents/skills/growth-guards/DEVELOPMENT.md
+++ b/.agents/skills/growth-guards/DEVELOPMENT.md
@@ -74,23 +74,20 @@ would leave an appended guard unreachable. Ours runs, blocks on any nonzero,
 and then falls through to whatever the hook already did — whose own exit
 status still decides.
 
-Repeat runs are no-ops, and repairs. A consumer's own hook counts as current
-only when it carries the EXACT delegating line on a line of its own — a line
-that was commented out, truncated, or left behind by an older version is
-rewritten, not trusted. A hook this installer CREATED is owned whole, the way
-`--uninstall` deletes such a file outright: it is current only when its bytes
-are exactly the shebang, the delegating line and the created marker, and
-anything else in it is rewritten away rather than repaired around. A hook
-whose executable bit was cleared gets it back, because git silently ignores a
-hook it cannot execute. An existing `pre-commit`/`commit-msg` keeps its
-content, its shebang and its own exit status; a hook that is symlinked,
-deliberately disabled (not executable), whose shebang names an interpreter
-that is not a POSIX-compatible shell, or whose shebang names a shell outside
-the trusted full paths under `/bin` and `/usr/bin`, is left alone entirely
-(reported, and the install exits 1). That trusted-path rule holds at install
-exactly as it does at `--check`, whoever wrote the hook. A file at the helper
-path that this installer did not write is never overwritten. A bare
-repository is refused — there is no work tree to guard.
+Repeat runs are no-ops, and repairs. A hook counts as current only when it
+carries the EXACT delegating line on a line of its own — a line that was
+commented out, truncated, or left behind by an older version is rewritten,
+not trusted — and a hook whose executable bit was cleared gets it back,
+because git silently ignores a hook it cannot execute. An existing
+`pre-commit`/`commit-msg` keeps its content, its shebang and its own exit
+status; a hook that is symlinked, deliberately disabled (not executable),
+whose shebang names an interpreter that is not a POSIX-compatible shell, or
+whose shebang names a shell outside the trusted full paths under `/bin` and
+`/usr/bin`, is left alone entirely (reported, and the install exits 1). That
+trusted-path rule holds at install exactly as it does at `--check`, whoever
+wrote the hook. A file at the helper path that this installer did not write
+is never overwritten. A bare repository is refused — there is no work tree to
+guard.
 
 Linked worktrees share the install, since git resolves their hooks to the
 main checkout's hooks directory. The same sharing governs removal, and it

--- a/.agents/skills/growth-guards/scripts/install-git-hooks
+++ b/.agents/skills/growth-guards/scripts/install-git-hooks
@@ -307,12 +307,8 @@ install_hook() { # HOOK
     return 0
   fi
   # The SAME predicate --check applies, so an install cannot report success
-  # that the next `kendex check` calls unverifiable. A hook THIS INSTALLER
-  # WROTE is ours to correct rather than refuse: older versions emitted
-  # `#!/usr/bin/env bash`, and refusing there would strand a working install
-  # reporting NOT installed forever. Its shebang is rewritten below.
-  if ! gg_trusted_interpreter "$(head -n 1 "$path")" \
-    && ! grep -qxF -- "$CREATED_MARKER" "$path" 2>/dev/null; then
+  # that the next `kendex check` calls unverifiable.
+  if ! gg_trusted_interpreter "$(head -n 1 "$path")"; then
     hook_warn "$(gg_shown "$path") runs under an interpreter that cannot be verified ($(gg_shown "$(head -n 1 "$path")")); not modifying it — the $hook guard is NOT installed. Use a #! naming a shell in /bin or /usr/bin directly."
     return 0
   fi
@@ -320,10 +316,7 @@ install_hook() { # HOOK
   # after the shebang. Content alone is not enough: a line that was commented
   # out, truncated, left by an older version, or moved below hook content that
   # exits is not an install, and each is rewritten rather than trusted.
-  # The delegate being current is not enough when the SHEBANG is stale: the
-  # fast path would return before the rewrite that corrects it, leaving a
-  # working install reporting unverifiable forever.
-  if [ "$(sed -n '2p' "$path")" = "$line" ] && gg_trusted_interpreter "$(head -n 1 "$path")"; then
+  if [ "$(sed -n '2p' "$path")" = "$line" ]; then
     ensure_hook_executable "$hook" "$path"
     return 0
   fi
@@ -364,16 +357,10 @@ install_hook() { # HOOK
   }
   # The shebang is re-emitted TERMINATED even when the original file ended at
   # it, or the delegate would run onto the interpreter line. A shebang cannot
-  # contain a newline, so the command substitution is lossless.
-  # A file this installer created carries OUR shebang, so an untrusted one is
-  # a stale spelling from an older version and is corrected here. A file the
-  # consumer wrote keeps its own — it reached this point only by being
-  # trusted already.
+  # contain a newline, so the command substitution is lossless. It is kept as
+  # written: the file reached this point only by being trusted already.
   local shebang=""
   shebang="$(head -n 1 "$path")"
-  if [ "$created" -eq 1 ] && ! gg_trusted_interpreter "$shebang"; then
-    shebang="#!/bin/sh"
-  fi
   if ! cp -p -- "$path" "$tmp" 2>/dev/null || ! {
     printf '%s\n' "$shebang"
     printf '%s\n' "$line"

--- a/.agents/skills/growth-guards/scripts/install-git-hooks
+++ b/.agents/skills/growth-guards/scripts/install-git-hooks
@@ -256,17 +256,6 @@ ends_with_newline() { # FILE — 0 when the last byte is a newline
   [ -z "$(tail -c 1 "$1")" ]
 }
 
-# Whether the hook at PATH already IS this install. A consumer's own hook
-# answers with the delegate at line 2; a hook this installer CREATED answers
-# with the whole file, because uninstall deletes such a file outright and a
-# line drifted in under our own marker would run at every commit unseen.
-hook_is_current() { # PATH DELEGATE-LINE CREATED
-  [ "$(sed -n '2p' "$1")" = "$2" ] || return 1
-  [ "$3" -eq 1 ] || return 0
-  [ "$(wc -l <"$1")" -eq 3 ] \
-    && [ "$(sed -n '3p' "$1")" = "$CREATED_MARKER" ] \
-    && ends_with_newline "$1"
-}
 strip_final_newline() { # FILE — drop one trailing newline byte if present
   local size=0
   ends_with_newline "$1" || return 0
@@ -323,14 +312,11 @@ install_hook() { # HOOK
     hook_warn "$(gg_shown "$path") runs under an interpreter that cannot be verified ($(gg_shown "$(head -n 1 "$path")")); not modifying it — the $hook guard is NOT installed. Use a #! naming a shell in /bin or /usr/bin directly."
     return 0
   fi
-  # Read before the filter strips the marker with our line, re-asserted below:
-  # a repair must not turn a hook we created into one that looks foreign.
-  local created=0
-  grep -qxF -- "$CREATED_MARKER" "$path" 2>/dev/null && created=1
-  # Content alone is not enough: a line that was commented out, truncated,
-  # left by an older version, or moved below hook content that exits is not an
-  # install, and each is rewritten rather than trusted.
-  if hook_is_current "$path" "$line" "$created"; then
+  # Idempotence keys on the EXACT delegate AT ITS POSITION — line 2, straight
+  # after the shebang. Content alone is not enough: a line that was commented
+  # out, truncated, left by an older version, or moved below hook content that
+  # exits is not an install, and each is rewritten rather than trusted.
+  if [ "$(sed -n '2p' "$path")" = "$line" ]; then
     ensure_hook_executable "$hook" "$path"
     return 0
   fi
@@ -338,6 +324,10 @@ install_hook() { # HOOK
     hook_warn "$(gg_shown "$path") exists but is not executable (a disabled hook); not modifying it — the $hook guard is NOT installed"
     return 0
   fi
+  # Read before the filter strips the marker with our line, re-asserted below:
+  # a repair must not turn a hook we created into one that looks foreign.
+  local created=0
+  grep -qxF -- "$CREATED_MARKER" "$path" 2>/dev/null && created=1
   # Everything but the shebang and our own lines, kept in a FILE: a command
   # substitution would strip a missing final newline, and the foreign bytes
   # must come back exactly as they were.
@@ -353,10 +343,7 @@ install_hook() { # HOOK
     hook_warn "could not read $(gg_shown "$path") — the $hook guard is NOT installed"
     return 0
   fi
-  # A created hook is rewritten whole; a consumer's own keeps its bytes.
-  if [ "$created" -eq 1 ]; then
-    : >"$rest"
-  elif ! ends_with_newline "$path" && ! strip_final_newline "$rest"; then
+  if ! ends_with_newline "$path" && ! strip_final_newline "$rest"; then
     rm -f -- "$rest"
     hook_warn "could not preserve the end of $(gg_shown "$path") — the $hook guard is NOT installed"
     return 0

--- a/.agents/skills/growth-guards/scripts/install-git-hooks
+++ b/.agents/skills/growth-guards/scripts/install-git-hooks
@@ -256,6 +256,17 @@ ends_with_newline() { # FILE — 0 when the last byte is a newline
   [ -z "$(tail -c 1 "$1")" ]
 }
 
+# Whether the hook at PATH already IS this install. A consumer's own hook
+# answers with the delegate at line 2; a hook this installer CREATED answers
+# with the whole file, because uninstall deletes such a file outright and a
+# line drifted in under our own marker would run at every commit unseen.
+hook_is_current() { # PATH DELEGATE-LINE CREATED
+  [ "$(sed -n '2p' "$1")" = "$2" ] || return 1
+  [ "$3" -eq 1 ] || return 0
+  [ "$(wc -l <"$1")" -eq 3 ] \
+    && [ "$(sed -n '3p' "$1")" = "$CREATED_MARKER" ] \
+    && ends_with_newline "$1"
+}
 strip_final_newline() { # FILE — drop one trailing newline byte if present
   local size=0
   ends_with_newline "$1" || return 0
@@ -312,11 +323,14 @@ install_hook() { # HOOK
     hook_warn "$(gg_shown "$path") runs under an interpreter that cannot be verified ($(gg_shown "$(head -n 1 "$path")")); not modifying it — the $hook guard is NOT installed. Use a #! naming a shell in /bin or /usr/bin directly."
     return 0
   fi
-  # Idempotence keys on the EXACT delegate AT ITS POSITION — line 2, straight
-  # after the shebang. Content alone is not enough: a line that was commented
-  # out, truncated, left by an older version, or moved below hook content that
-  # exits is not an install, and each is rewritten rather than trusted.
-  if [ "$(sed -n '2p' "$path")" = "$line" ]; then
+  # Read before the filter strips the marker with our line, re-asserted below:
+  # a repair must not turn a hook we created into one that looks foreign.
+  local created=0
+  grep -qxF -- "$CREATED_MARKER" "$path" 2>/dev/null && created=1
+  # Content alone is not enough: a line that was commented out, truncated,
+  # left by an older version, or moved below hook content that exits is not an
+  # install, and each is rewritten rather than trusted.
+  if hook_is_current "$path" "$line" "$created"; then
     ensure_hook_executable "$hook" "$path"
     return 0
   fi
@@ -324,10 +338,6 @@ install_hook() { # HOOK
     hook_warn "$(gg_shown "$path") exists but is not executable (a disabled hook); not modifying it — the $hook guard is NOT installed"
     return 0
   fi
-  # Read before the filter strips the marker with our line, re-asserted below:
-  # a repair must not turn a hook we created into one that looks foreign.
-  local created=0
-  grep -qxF -- "$CREATED_MARKER" "$path" 2>/dev/null && created=1
   # Everything but the shebang and our own lines, kept in a FILE: a command
   # substitution would strip a missing final newline, and the foreign bytes
   # must come back exactly as they were.
@@ -343,7 +353,10 @@ install_hook() { # HOOK
     hook_warn "could not read $(gg_shown "$path") — the $hook guard is NOT installed"
     return 0
   fi
-  if ! ends_with_newline "$path" && ! strip_final_newline "$rest"; then
+  # A created hook is rewritten whole; a consumer's own keeps its bytes.
+  if [ "$created" -eq 1 ]; then
+    : >"$rest"
+  elif ! ends_with_newline "$path" && ! strip_final_newline "$rest"; then
     rm -f -- "$rest"
     hook_warn "could not preserve the end of $(gg_shown "$path") — the $hook guard is NOT installed"
     return 0

--- a/.agents/skills/growth-guards/tests/install-git-hooks-check.test.sh
+++ b/.agents/skills/growth-guards/tests/install-git-hooks-check.test.sh
@@ -75,44 +75,6 @@ else
   ok "unreadable hooks dir wording skipped (running as root)"
 fi
 
-echo "=== install corrects a stale shebang in a hook IT wrote ==="
-# Older versions of this installer emitted `#!/usr/bin/env bash`. Refusing
-# there strands a working install reporting NOT installed forever, so a file
-# carrying the created-marker is corrected rather than refused.
-R44="$(new_repo installstaleshebang)"
-install_in "$R44"
-# Exactly the drovr shape: the file this installer wrote, with only its
-# shebang reverted to what an older version emitted.
-{
-  printf '#!/usr/bin/env bash\n'
-  tail -n +2 "$R44/.git/hooks/pre-commit"
-} >"$TMP/stale" && mv "$TMP/stale" "$R44/.git/hooks/pre-commit"
-chmod +x "$R44/.git/hooks/pre-commit"
-grep -qF -- "kendex_gg_h" "$R44/.git/hooks/pre-commit" \
-  && ok "the fixture really carries the guard line under the stale shebang" \
-  || bad "stale fixture carries the guard line" "$(sed -n '2p' "$R44/.git/hooks/pre-commit")"
-check_in "$R44"
-[ "$RC" -eq 2 ] && ok "and it reads as unverifiable before the fix" \
-  || bad "stale fixture unverifiable first" "rc=$RC out=$OUT"
-install_in "$R44"
-[ "$(head -n 1 "$R44/.git/hooks/pre-commit")" = "#!/bin/sh" ] \
-  && ok "a hook this installer wrote has its stale shebang corrected" \
-  || bad "stale shebang corrected" "line1=$(head -n 1 "$R44/.git/hooks/pre-commit")"
-check_in "$R44"
-[ "$RC" -eq 0 ] && ok "and it checks armed afterwards" \
-  || bad "corrected hook checks armed" "rc=$RC out=$OUT"
-
-# Control: a hook the CONSUMER wrote is still refused and left untouched.
-printf '#!/usr/bin/env bash\necho mine\n' >"$R44/.git/hooks/commit-msg"
-chmod +x "$R44/.git/hooks/commit-msg"
-install_in "$R44"
-[ "$(sed -n '2p' "$R44/.git/hooks/commit-msg")" = "echo mine" ] \
-  && ok "control: a consumer's own hook is refused, not rewritten" \
-  || bad "consumer hook untouched" "line2=$(sed -n '2p' "$R44/.git/hooks/commit-msg")"
-[ "$(head -n 1 "$R44/.git/hooks/commit-msg")" = "#!/usr/bin/env bash" ] \
-  && ok "and its shebang is left alone" \
-  || bad "consumer shebang untouched" "line1=$(head -n 1 "$R44/.git/hooks/commit-msg")"
-
 echo "=== install refuses what --check could not vouch for ==="
 # Installing under a shebang the check calls unverifiable would report a
 # successful install that the very next `kendex check` contradicts.
@@ -131,6 +93,32 @@ esac
 check_in "$R43"
 [ "$RC" -ne 0 ] && ok "and --check agrees rather than contradicting the install" \
   || bad "check agrees with install" "rc=$RC out=$OUT"
+
+# The same refusal for a hook THIS INSTALLER wrote: ownership buys no licence
+# to rewrite the interpreter someone since chose. An install that reported
+# success here would be one `kendex check` calls unverifiable.
+R44="$(new_repo installstaleshebang)"
+install_in "$R44"
+{
+  printf '#!/usr/local/bin/bash\n'
+  tail -n +2 "$R44/.git/hooks/pre-commit"
+} >"$TMP/reshebanged" && mv "$TMP/reshebanged" "$R44/.git/hooks/pre-commit"
+chmod +x "$R44/.git/hooks/pre-commit"
+grep -qF -- "kendex_gg_h" "$R44/.git/hooks/pre-commit" \
+  && ok "control: the fixture is our own shim under an untrusted interpreter" \
+  || bad "fixture carries the guard line" "$(sed -n '2p' "$R44/.git/hooks/pre-commit")"
+BEFORE44="$(cat "$R44/.git/hooks/pre-commit")"
+install_in "$R44"
+case "$OUT" in
+  *"cannot be verified"*) ok "install refuses a shim of ours under an untrusted interpreter" ;;
+  *) bad "install refuses our own untrusted shim" "out=$OUT" ;;
+esac
+[ "$(cat "$R44/.git/hooks/pre-commit")" = "$BEFORE44" ] \
+  && ok "and leaves it byte for byte, shebang included" \
+  || bad "our untrusted shim was rewritten" "$(cat "$R44/.git/hooks/pre-commit")"
+check_in "$R44"
+[ "$RC" -ne 0 ] && ok "and --check agrees it is not armed" \
+  || bad "check agrees on our untrusted shim" "rc=$RC out=$OUT"
 
 echo "=== a shim carrying the guard line elsewhere is unverifiable, not ungated ==="
 # --check writes nothing, so it does not get to assume the shim in front of

--- a/.agents/skills/growth-guards/tests/install-git-hooks-check.test.sh
+++ b/.agents/skills/growth-guards/tests/install-git-hooks-check.test.sh
@@ -117,8 +117,8 @@ esac
   && ok "and leaves it byte for byte, shebang included" \
   || bad "our untrusted shim was rewritten" "$(cat "$R44/.git/hooks/pre-commit")"
 check_in "$R44"
-[ "$RC" -ne 0 ] && ok "and --check agrees it is not armed" \
-  || bad "check agrees on our untrusted shim" "rc=$RC out=$OUT"
+[ "$RC" -eq 2 ] && ok "and --check calls it unverifiable, not merely not armed" \
+  || bad "check calls our untrusted shim unverifiable" "rc=$RC out=$OUT"
 
 echo "=== a shim carrying the guard line elsewhere is unverifiable, not ungated ==="
 # --check writes nothing, so it does not get to assume the shim in front of

--- a/.agents/skills/growth-guards/tests/install-git-hooks.test.sh
+++ b/.agents/skills/growth-guards/tests/install-git-hooks.test.sh
@@ -586,6 +586,53 @@ git -C "$R28" add b.py
 commit_in "$R28" "feat: add b"
 [ "$RC" -ne 0 ] && ok "control: the repositioned delegate blocks again" || bad "repositioned delegate blocks" "rc=$RC out=$OUT"
 
+echo "=== a hook we created is ours whole, not just its line 2 ==="
+# Uninstall deletes a created hook outright, so install owns the same file
+# whole. A line below the delegate runs at every commit under our own marker,
+# and only this install ever reads past line 2 to find it: a fast path keyed
+# on line 2 alone leaves it there and reports the clone armed.
+R55="$(new_repo created-drift)"
+install_in "$R55"
+CANONICAL="$(cat "$R55/.git/hooks/commit-msg")"
+printf 'echo "a line no install wrote"
+' >>"$R55/.git/hooks/commit-msg"
+[ "$(sed -n '2p' "$R55/.git/hooks/commit-msg")" = "$(sed -n '2p' <<<"$CANONICAL")" ] \
+  && ok "control: the drifted hook still carries the delegate at line 2" \
+  || bad "drifted fixture keeps line 2" "$(cat "$R55/.git/hooks/commit-msg")"
+install_in "$R55"
+[ "$(cat "$R55/.git/hooks/commit-msg")" = "$CANONICAL" ] \
+  && ok "a created hook carrying an extra line is rewritten to the canonical body" \
+  || bad "created hook rewritten to canonical" "$(cat "$R55/.git/hooks/commit-msg")"
+printf 'ok\n' >"$R55/drift.txt"
+git -C "$R55" add drift.txt
+commit_in "$R55" "chore: after the rewrite"
+[ "$RC" -eq 0 ] && case "$OUT" in *"a line no install wrote"*) false ;; *) true ;; esac \
+  && ok "and the extra line no longer runs at commit time" \
+  || bad "the rewritten hook still runs the extra line" "rc=$RC out=$OUT"
+
+echo "=== a consumer's own trusted shebang survives the rewrite ==="
+# The rewrite re-emits line 1 as it found it. Hardcoding #!/bin/sh there would
+# be invisible on every other fixture, which all carry that spelling, and would
+# hand a bash-only body to a shell that cannot parse it.
+R56="$(new_repo bash-consumer)"
+FOREIGN_BASH="$R56/.git/hooks/pre-commit"
+printf '#!/bin/bash
+declare -A m=([a]=1)
+echo "consumer ${m[a]}"
+' >"$FOREIGN_BASH"
+chmod +x "$FOREIGN_BASH"
+install_in "$R56"
+[ "$(head -n 1 "$FOREIGN_BASH")" = "#!/bin/bash" ] \
+  && ok "a trusted shebang that is not /bin/sh is left as written" \
+  || bad "the consumer's shebang was rewritten" "$(cat "$FOREIGN_BASH")"
+case "$(sed -n '2p' "$FOREIGN_BASH")" in
+  *"# kendex-guards-hook") ok "and the delegate is installed at line 2 above it" ;;
+  *) bad "delegate not at line 2" "$(cat "$FOREIGN_BASH")" ;;
+esac
+[ "$(tail -n +3 "$FOREIGN_BASH")" = "$(printf 'declare -A m=([a]=1)\necho "consumer ${m[a]}"')" ] \
+  && ok "and the bash-only body below it is byte for byte what it was" \
+  || bad "consumer body altered" "$(cat "$FOREIGN_BASH")"
+
 echo "=== a non-POSIX-shell hook is left alone ==="
 R15="$(new_repo fish)"
 printf '#!/usr/bin/fish\necho hi\n' >"$R15/.git/hooks/pre-commit"

--- a/.agents/skills/growth-guards/tests/install-git-hooks.test.sh
+++ b/.agents/skills/growth-guards/tests/install-git-hooks.test.sh
@@ -27,6 +27,22 @@ grep -qF "installed_scripts='$R/.agents/skills/growth-guards/scripts'" "$R/.git/
   && ok "the helper names the scripts directory it was installed from" || bad "helper names its scripts dir"
 grep -qF 'kendex-guards' "$R/.git/hooks/pre-commit" && ok "pre-commit carries the marked delegating line" \
   || bad "pre-commit carries the marked line"
+# On a fresh repo the installer writes the shims itself, so each is exactly
+# what it emits and nothing more: the current shebang, the delegate at line 2,
+# the created marker. Anything else here is a hook the installer inherited,
+# and it emits no shebang but this one — an install that reported success
+# under another would be one `--check` calls unverifiable.
+for f in pre-commit commit-msg; do
+  [ "$(head -n 1 "$R/.git/hooks/$f")" = "#!/bin/sh" ] \
+    && ok "$f carries the current shebang" \
+    || bad "$f carries the current shebang" "line1=$(head -n 1 "$R/.git/hooks/$f")"
+  [ "$(sed -n '3p' "$R/.git/hooks/$f")" = "# kendex-guards-hook created this file" ] \
+    && ok "$f records that the installer created it" \
+    || bad "$f records that the installer created it" "line3=$(sed -n '3p' "$R/.git/hooks/$f")"
+  [ "$(wc -l <"$R/.git/hooks/$f")" -eq 3 ] \
+    && ok "$f holds those three lines and nothing else" \
+    || bad "$f holds those three lines and nothing else" "$(cat "$R/.git/hooks/$f")"
+done
 [ -z "$(git -C "$R" config --get core.hooksPath || true)" ] && ok "core.hooksPath is left unset" \
   || bad "core.hooksPath is left unset"
 
@@ -490,38 +506,11 @@ OUT="$("$R21M/.agents/skills/growth-guards/scripts/install-git-hooks" --repo "$R
 
 echo "=== a hook that only quotes a marker is not ours ==="
 # The ownership question and the shape question fail in opposite directions,
-# and these are the ownership one. Every site that asks whether a file is
-# ours asks it the same way — the marker CLOSING a line, or the created
-# marker as a line whole — so a consumer hook that mentions either in a
-# sentence is somebody else's file at every one of them.
-QUOTE_CREATED="# kendex-guards-hook created this file"
+# and this is the ownership one: ours is the marker CLOSING a line, so a
+# consumer hook that mentions it in a sentence is somebody else's file.
 QUOTE_SENTINEL="# kendex-guards-hook"
 
-# Install refuses a hook it cannot verify unless THIS installer wrote it.
-# A consumer hook under an interpreter we do not vouch for, mentioning the
-# created marker mid-sentence, is not ours — and rewriting its shebang, as
-# a substring read would, changes which interpreter someone else's hook
-# runs under.
-R52="$(new_repo quoter-shebang)"
-FOREIGN="$R52/.git/hooks/pre-commit"
-# A shell shebang the checker will not vouch for: an interpreter outside
-# /bin and /usr/bin, which is what reaches the created-marker question.
-printf '#!/usr/local/bin/bash\n# not %s, just talking about it\nexit 0\n' \
-  "$QUOTE_CREATED" >"$FOREIGN"
-chmod +x "$FOREIGN"
-BEFORE="$(cat "$FOREIGN")"
-install_in "$R52"
-[ "$(head -n 1 "$FOREIGN")" = "#!/usr/local/bin/bash" ] \
-  && ok "install leaves the shebang of a hook that only quotes the created marker" \
-  || bad "the quoting hook's shebang was rewritten" "$(cat "$FOREIGN")"
-[ "$(cat "$FOREIGN")" = "$BEFORE" ] && ok "and the file is byte for byte what it was" \
-  || bad "the quoting hook was edited" "$(cat "$FOREIGN")"
-case "$OUT" in
-  *"cannot be verified"*) ok "and the install says the guard is NOT installed there" ;;
-  *) bad "install did not announce the refusal" "$OUT" ;;
-esac
-
-# The symlink branch asks the same question of a target it must not edit.
+# The symlink branch asks that question of a target it must not edit.
 R53="$(new_repo quoter-symlink)"
 install_in "$R53"
 printf '#!/bin/sh\n# ours end in %s, this one does not\necho mine\n' \

--- a/.agents/skills/growth-guards/tests/install-git-hooks.test.sh
+++ b/.agents/skills/growth-guards/tests/install-git-hooks.test.sh
@@ -586,30 +586,6 @@ git -C "$R28" add b.py
 commit_in "$R28" "feat: add b"
 [ "$RC" -ne 0 ] && ok "control: the repositioned delegate blocks again" || bad "repositioned delegate blocks" "rc=$RC out=$OUT"
 
-echo "=== a hook we created is ours whole, not just its line 2 ==="
-# Uninstall deletes a created hook outright, so install owns the same file
-# whole. A line below the delegate runs at every commit under our own marker,
-# and only this install ever reads past line 2 to find it: a fast path keyed
-# on line 2 alone leaves it there and reports the clone armed.
-R55="$(new_repo created-drift)"
-install_in "$R55"
-CANONICAL="$(cat "$R55/.git/hooks/commit-msg")"
-printf 'echo "a line no install wrote"
-' >>"$R55/.git/hooks/commit-msg"
-[ "$(sed -n '2p' "$R55/.git/hooks/commit-msg")" = "$(sed -n '2p' <<<"$CANONICAL")" ] \
-  && ok "control: the drifted hook still carries the delegate at line 2" \
-  || bad "drifted fixture keeps line 2" "$(cat "$R55/.git/hooks/commit-msg")"
-install_in "$R55"
-[ "$(cat "$R55/.git/hooks/commit-msg")" = "$CANONICAL" ] \
-  && ok "a created hook carrying an extra line is rewritten to the canonical body" \
-  || bad "created hook rewritten to canonical" "$(cat "$R55/.git/hooks/commit-msg")"
-printf 'ok\n' >"$R55/drift.txt"
-git -C "$R55" add drift.txt
-commit_in "$R55" "chore: after the rewrite"
-[ "$RC" -eq 0 ] && case "$OUT" in *"a line no install wrote"*) false ;; *) true ;; esac \
-  && ok "and the extra line no longer runs at commit time" \
-  || bad "the rewritten hook still runs the extra line" "rc=$RC out=$OUT"
-
 echo "=== a consumer's own trusted shebang survives the rewrite ==="
 # The rewrite re-emits line 1 as it found it. Hardcoding #!/bin/sh there would
 # be invisible on every other fixture, which all carry that spelling, and would

--- a/.agents/skills/linear/scripts/commands/sync.sh
+++ b/.agents/skills/linear/scripts/commands/sync.sh
@@ -172,18 +172,6 @@ sync_comments() {
     echo "$all_nodes"
 }
 
-# A comment cache built before the paginated fetch holds first pages passed off
-# as whole threads. The cache is regenerable state, so it is discarded and
-# refetched rather than repaired: no conversion, no reader for the old shape.
-# meta.json carries the marker, and its absence forces one full comment pull
-# before any incremental sync is allowed to run.
-COMMENTS_SOURCE="paginated"
-
-comments_cache_is_current() {
-    [[ -f "$CACHE_DIR/meta.json" ]] || return 1
-    [[ "$(jq -r '.comments_source // empty' "$CACHE_DIR/meta.json")" == "$COMMENTS_SOURCE" ]]
-}
-
 # Rewrite the per-issue comment files from a complete comment pull. Every
 # issue in the pull's scope is rewritten or removed, so an issue whose last
 # comment was deleted loses its file instead of keeping a stale one.
@@ -654,7 +642,7 @@ main() {
     fi
 
     # Check if sync needed when --if-stale specified
-    if [[ -n "$if_stale" ]] && cache_is_fresh "$if_stale" && comments_cache_is_current; then
+    if [[ -n "$if_stale" ]] && cache_is_fresh "$if_stale"; then
         echo "Cache fresh (< ${if_stale}m), skipped" >&2
         if [[ "$show_stats" == true ]]; then
             cache_status
@@ -819,25 +807,6 @@ main() {
         sync_cycles > "$CACHE_DIR/cycles.json.tmp" && mv "$CACHE_DIR/cycles.json.tmp" "$CACHE_DIR/cycles.json"
         sync_initiatives > "$CACHE_DIR/initiatives.json.tmp" && mv "$CACHE_DIR/initiatives.json.tmp" "$CACHE_DIR/initiatives.json"
         sync_labels > "$CACHE_DIR/labels.json.tmp" && mv "$CACHE_DIR/labels.json.tmp" "$CACHE_DIR/labels.json"
-
-        # A comment cache built before the paginated fetch is rebuilt whole,
-        # as a precondition of the sync completing rather than as part of the
-        # delta. The legacy threads belong to issues that have not changed, so
-        # an empty delta is both the common upgrade case and the one a
-        # delta-borne rebuild would never reach. It runs last so that a merge
-        # that aborts above leaves the comment cache untouched, and it owns the
-        # whole post-merge issue set, which leaves no subset for a newly
-        # created issue's comments to fall out of.
-        if ! comments_cache_is_current; then
-            if ! sync_comments "{}" > "$CACHE_DIR/.comments.json"; then
-                rm -f "$CACHE_DIR/.comments.json"
-                cache_unlock
-                return 1
-            fi
-            write_comments "$CACHE_DIR/.comments.json" "$CACHE_DIR/issues.json"
-            rm -f "$CACHE_DIR/.comments.json"
-            summary_parts+=("comment cache rebuilt")
-        fi
     fi
 
     # Download file attachments/images from issue descriptions and comments
@@ -872,9 +841,6 @@ main() {
         reconciled_at=$(jq -r '.reconciled_at // empty' "$CACHE_DIR/meta.json" 2>/dev/null || echo "")
     fi
 
-    # Reaching here means the comment cache was built by the paginated fetch:
-    # a full sync pulls every comment, and an incremental sync either found the
-    # marker already set or rebuilt above, failing the sync if it could not.
     jq -n \
         --arg ts "$(date -Iseconds)" \
         --arg reconciled "${reconciled_at:-}" \
@@ -883,11 +849,9 @@ main() {
         --argjson cycles "$cycle_count" \
         --argjson initiatives "$initiative_count" \
         --argjson elapsed "$elapsed" \
-        --arg comments_source "$COMMENTS_SOURCE" \
         '{
             synced_at: $ts,
             reconciled_at: (if $reconciled != "" then $reconciled else null end),
-            comments_source: $comments_source,
             elapsed_seconds: $elapsed,
             stats: {issues: $issues, projects: $projects, cycles: $cycles, initiatives: $initiatives}
         }' \

--- a/.agents/skills/linear/tests/sync-merge-abort-error.test.sh
+++ b/.agents/skills/linear/tests/sync-merge-abort-error.test.sh
@@ -31,10 +31,9 @@ make_env() {
   printf '%s' "$existing" > "$root/.cache/linear/issues.json"
   echo '[]' > "$root/.cache/linear/projects.json"
 
-  # Comment files the abort must leave alone. meta.json carries no
-  # comments_source, which is the legacy state and the wider blast radius: an
-  # unmarked cache refetches every comment and scopes the write to the whole
-  # issue set, so a write that ran before the merge would sweep these.
+  # Comment files the abort must leave alone: a comment write that ran before
+  # the merge could reject would rewrite them while the command reports the
+  # cache unchanged.
   printf '[{"id":"c1","body":"kept"}]' > "$root/.cache/linear/comments/PROJ-1.json"
   printf '[{"id":"c3","body":"kept too"}]' > "$root/.cache/linear/comments/PROJ-3.json"
   # Old synced_at forces an issues delta; fresh reconciled_at skips reconcile
@@ -45,10 +44,6 @@ make_env() {
 
   local delta_nodes="$delta_node"
   [[ -n "$extra_node" ]] && delta_nodes="$delta_node,$extra_node"
-  # "none" is the empty delta: nothing changed since synced_at. It is the
-  # ordinary state of a machine that syncs regularly, and the upgrade case a
-  # rebuild carried by the delta would never reach.
-  [[ "$delta_id" == "none" ]] && delta_nodes=""
 
   cat >"$root/bin/curl" <<SH
 #!/usr/bin/env bash
@@ -146,84 +141,31 @@ assert_eq "the healthy merge applied the delta update" \
   "$(jq -r '[.[] | select(.id == "id-1")] | first | .title' "$OK_ROOT/.cache/linear/issues.json")" "updated"
 assert_ne "a successful sync advances synced_at" \
   "$(jq -r '.synced_at' "$OK_ROOT/.cache/linear/meta.json")" "$OLD_SYNC"
-# The marker is what stops the next incremental sync refetching every comment,
-# and what stops --if-stale skipping the sync that would write it.
-assert_eq "a successful sync records how the comment cache was built" \
-  "$(jq -r '.comments_source // empty' "$OK_ROOT/.cache/linear/meta.json")" "paginated"
-# PROJ-3 is not in the delta. A cache with no marker holds first-page-only
-# threads for exactly the issues a delta never revisits, so an unmarked sync
-# refetches every comment and scopes the write to the whole issue set. Scoped
-# to the delta instead, PROJ-3 would keep its seeded file forever.
-assert_eq "an unmarked cache refetches comments for an issue outside the delta" \
-  "$(jq -r '.[0].id' "$OK_ROOT/.cache/linear/comments/PROJ-3.json")" "c3-new"
 # PROJ-9 is created BY this delta, so it is absent from the issue set until the
 # merge lands. Scope the write from a pre-merge issues.json and its comments are
-# filtered out, the marker is stamped anyway, and no later delta revisits an
-# issue that never changes again — the permanent empty thread this whole change
-# exists to remove, reintroduced for exactly the newly created issue.
+# filtered out, and no later delta revisits an issue that never changes again —
+# a permanently empty thread for exactly the newly created issue.
 assert_eq "comments for an issue created by this delta are kept" \
   "$(jq -r '.[0].id' "$OK_ROOT/.cache/linear/comments/PROJ-9.json" 2>/dev/null)" "c9"
-
-# --- freshness must not skip the sync that would mark the cache ------------------
-# OK_ROOT is now both fresh and marked, so a read-only caller skips. Strip the
-# marker and the same call has to run: a cache whose comments are legacy is not
-# usable however recently it was synced, and skipping here is how a machine
-# keeps first-page threads indefinitely.
-marked_rc=0
-run_sync_if_stale "$OK_ROOT" >/dev/null 2>"$TMP_BASE/stale-marked" || marked_rc=$?
-assert_eq "--if-stale on a fresh, marked cache exits zero" "$marked_rc" 0
-assert "--if-stale skips a fresh, marked cache" \
-  grep -q "Cache fresh" "$TMP_BASE/stale-marked"
-
-jq 'del(.comments_source)' "$OK_ROOT/.cache/linear/meta.json" > "$TMP_BASE/meta-unmarked"
-mv "$TMP_BASE/meta-unmarked" "$OK_ROOT/.cache/linear/meta.json"
-unmarked_rc=0
-run_sync_if_stale "$OK_ROOT" >/dev/null 2>"$TMP_BASE/stale-unmarked" || unmarked_rc=$?
-assert_eq "--if-stale on an unmarked cache exits zero" "$unmarked_rc" 0
-assert_not "--if-stale re-syncs an unmarked cache rather than leaving legacy comments" \
-  grep -q "Cache fresh" "$TMP_BASE/stale-unmarked"
-assert_eq "the forced sync marks the cache" \
-  "$(jq -r '.comments_source // empty' "$OK_ROOT/.cache/linear/meta.json")" "paginated"
-
-# --- upgrade case: an unmarked cache with an EMPTY delta -------------------------
-# The legacy threads belong to issues that have not changed, so the delta that
-# would carry a rebuild is empty precisely when the rebuild is needed. The
-# rebuild is a precondition of syncing, not part of the delta, so it runs here.
-EMPTY_ROOT="$TMP_BASE/empty"
-make_env "$EMPTY_ROOT" \
-  '[{"id":"id-1","identifier":"PROJ-1","title":"a"},{"id":"id-3","identifier":"PROJ-3","title":"c"}]' \
-  "none"
-
-rc=0
-run_sync "$EMPTY_ROOT" >/dev/null 2>"$TMP_BASE/empty-err" || rc=$?
-assert_eq "sync succeeds on an unmarked cache with an empty delta" \
-  $rc 0
-assert_eq "an empty delta still rebuilds the legacy comment cache" \
-  "$(jq -r '.[0].id' "$EMPTY_ROOT/.cache/linear/comments/PROJ-3.json" 2>/dev/null)" "c3-new"
-assert_not "the rebuild owns the whole issue set, so PROJ-1 keeps no file the pull did not carry" \
-  test -f "$EMPTY_ROOT/.cache/linear/comments/PROJ-1.json"
-assert_eq "the rebuild marks the cache" \
-  "$(jq -r '.comments_source // empty' "$EMPTY_ROOT/.cache/linear/meta.json")" "paginated"
-
-# --- steady state: a MARKED cache takes the delta path only ---------------------
-# Every case above starts unmarked, where the rebuild owns the whole issue set
-# and would mask a wrong delta scope. This is the path every sync after the
-# upgrade takes: no rebuild, and the write scoped to the delta alone.
-MARKED_ROOT="$TMP_BASE/marked"
-make_env "$MARKED_ROOT" \
-  '[{"id":"id-1","identifier":"PROJ-1","title":"a"},{"id":"id-3","identifier":"PROJ-3","title":"c"}]' \
-  "id-1"
-jq '. + {comments_source: "paginated"}' "$MARKED_ROOT/.cache/linear/meta.json" > "$TMP_BASE/marked-meta"
-mv "$TMP_BASE/marked-meta" "$MARKED_ROOT/.cache/linear/meta.json"
-
-rc=0
-run_sync "$MARKED_ROOT" >/dev/null 2>"$TMP_BASE/marked-err" || rc=$?
-assert_eq "sync succeeds on a marked cache" \
-  $rc 0
-assert_not "a marked cache is not rebuilt" \
-  grep -q "comment cache rebuilt" "$TMP_BASE/marked-err"
 # PROJ-3 is outside this delta. The pull carries a comment for it, and only a
 # write scoped past the delta would let that land.
 assert_eq "the delta write stays inside its own scope" \
-  "$(jq -r '.[0].id' "$MARKED_ROOT/.cache/linear/comments/PROJ-3.json" 2>/dev/null)" "c3"
+  "$(jq -r '.[0].id' "$OK_ROOT/.cache/linear/comments/PROJ-3.json" 2>/dev/null)" "c3"
+
+# --- freshness: a fresh cache skips the sync entirely ---------------------------
+fresh_rc=0
+run_sync_if_stale "$OK_ROOT" >/dev/null 2>"$TMP_BASE/stale-fresh" || fresh_rc=$?
+assert_eq "--if-stale on a fresh cache exits zero" "$fresh_rc" 0
+assert "--if-stale skips a fresh cache" \
+  grep -q "Cache fresh" "$TMP_BASE/stale-fresh"
+
+# Must-fail control for the skip above: the same call on a cache older than the
+# window has to run rather than report it fresh.
+jq --arg s "$OLD_SYNC" '.synced_at = $s' "$OK_ROOT/.cache/linear/meta.json" > "$TMP_BASE/meta-stale"
+mv "$TMP_BASE/meta-stale" "$OK_ROOT/.cache/linear/meta.json"
+stale_rc=0
+run_sync_if_stale "$OK_ROOT" >/dev/null 2>"$TMP_BASE/stale-old" || stale_rc=$?
+assert_eq "--if-stale on a stale cache exits zero" "$stale_rc" 0
+assert_not "--if-stale re-syncs a cache older than the window" \
+  grep -q "Cache fresh" "$TMP_BASE/stale-old"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Repo-specific rules:
 - `ui/` installs with `npm ci --prefix ui`, in the main checkout only.
 - Some required checks run only in the merge queue, so a green PR does not prove them; the fast/full split in `.github/workflows/skill-tests.yml`'s header comment says which jobs and shards those are. A change under a surface whose job or shard is merge-queue-only runs that suite locally before the PR.
 
-`tools/guard` enforces the rest — read the script; it is the list. It is the last lane of the package's commit chain, named by `GROWTH_GUARDS_PRE_COMMIT_LOCAL`; `tools/setup` arms that chain in a fresh clone and wires `tools/commit-msg` beside it. That lane holds the two rules only a commit message can carry: the subject caps at 72 characters, and a change under `crates/` or `ui/` ships a changelog fragment or says `[no-changelog]` in the subject.
+`tools/guard` enforces the rest — read the script; it is the list. It is the last lane of the package's commit chain, named by `GROWTH_GUARDS_PRE_COMMIT_LOCAL`; `tools/setup` arms that chain in a fresh clone, beside the package's own commit-msg gate. That gate holds the two rules only a commit message can carry: the subject caps at 72 characters, and a change under `crates/` or `ui/` ships a changelog fragment or says `[no-changelog]` in the subject.
 
 ## Code Review Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Repo-specific rules:
 - `ui/` installs with `npm ci --prefix ui`, in the main checkout only.
 - Some required checks run only in the merge queue, so a green PR does not prove them; the fast/full split in `.github/workflows/skill-tests.yml`'s header comment says which jobs and shards those are. A change under a surface whose job or shard is merge-queue-only runs that suite locally before the PR.
 
-`tools/guard` enforces the rest — read the script; it is the list. It is the last lane of the package's commit chain, named by `GROWTH_GUARDS_PRE_COMMIT_LOCAL`; `tools/setup` arms that chain in a fresh clone, beside the package's own commit-msg gate. That gate holds the two rules only a commit message can carry: the subject caps at 72 characters, and a change under `crates/` or `ui/` ships a changelog fragment or says `[no-changelog]` in the subject.
+`tools/guard` enforces the rest — read the script; it is the list. It is the last lane of the package's commit chain, named by `GROWTH_GUARDS_PRE_COMMIT_LOCAL`; `tools/setup` arms that chain in a fresh clone, beside the package's own commit-msg gate. That gate holds the three rules only a commit message can carry: the header is `type(scope)!: subject`, the whole header line caps at 72 characters, and a change under `crates/` or `ui/` ships a changelog fragment or says `[no-changelog]` in the subject.
 
 ## Code Review Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Repo-specific rules:
 - `ui/` installs with `npm ci --prefix ui`, in the main checkout only.
 - Some required checks run only in the merge queue, so a green PR does not prove them; the fast/full split in `.github/workflows/skill-tests.yml`'s header comment says which jobs and shards those are. A change under a surface whose job or shard is merge-queue-only runs that suite locally before the PR.
 
-`tools/guard` enforces the rest — read the script; it is the list. It is the last lane of the package's commit chain, named by `GROWTH_GUARDS_PRE_COMMIT_LOCAL`; `tools/setup` arms that chain in a fresh clone, beside the package's own commit-msg gate. That gate holds the three rules only a commit message can carry: the header is `type(scope)!: subject`, the whole header line caps at 72 characters, and a change under `crates/` or `ui/` ships a changelog fragment or says `[no-changelog]` in the subject.
+`tools/guard` enforces the rest — read the script; it is the list. It is the last lane of the package's commit chain, named by `GROWTH_GUARDS_PRE_COMMIT_LOCAL`; `tools/setup` arms that chain in a fresh clone, beside the package's own commit-msg gate. Neither judges a hook below its delegating line, so a `.git/hooks/commit-msg` calling a repo-local tools/commit-msg lane — which this repo does not have — blocks every commit until you delete that hook and run setup again. That gate holds the three rules only a commit message can carry: the header is `type(scope)!: subject`, the whole header line caps at 72 characters, and a change under `crates/` or `ui/` ships a changelog fragment or says `[no-changelog]` in the subject.
 
 ## Code Review Rules
 

--- a/changelog.d/changed/ken-913-linear-cache.md
+++ b/changelog.d/changed/ken-913-linear-cache.md
@@ -1,0 +1,3 @@
+- A Linear cache built before comment pagination is no longer rebuilt for you;
+  its first-page-only threads stay until you run `linear sync --full` once, or
+  delete `.cache/linear`.

--- a/changelog.d/changed/ken-913-linear-cache.md
+++ b/changelog.d/changed/ken-913-linear-cache.md
@@ -1,3 +1,3 @@
 - A Linear cache built before comment pagination is no longer rebuilt for you;
-  its first-page-only threads stay until you run `linear sync --full` once, or
-  delete `.cache/linear`.
+  its first-page-only threads stay until you run `linear.sh sync --full` once,
+  or delete `.cache/linear`.

--- a/changelog.d/fixed/KEN-795-comment-sync.md
+++ b/changelog.d/fixed/KEN-795-comment-sync.md
@@ -1,3 +1,3 @@
 - Syncing the Linear cache now fetches comments in their own paginated request
-  and pages them to completion, so a long thread is cached whole rather than
-  cut off at its first page.
+  and pages them to completion, so every thread it fetches is cached whole
+  rather than cut off at its first page.

--- a/changelog.d/removed/ken-913.md
+++ b/changelog.d/removed/ken-913.md
@@ -1,0 +1,1 @@
+- `install-git-hooks` no longer rewrites the shebang of a hook it wrote earlier: a hook under an interpreter it cannot verify is refused. **Breaking:** delete that hook and re-run the installer.

--- a/skills/growth-guards/DEVELOPMENT.md
+++ b/skills/growth-guards/DEVELOPMENT.md
@@ -74,17 +74,23 @@ would leave an appended guard unreachable. Ours runs, blocks on any nonzero,
 and then falls through to whatever the hook already did — whose own exit
 status still decides.
 
-Repeat runs are no-ops, and repairs. A hook counts as current only when it
-carries the EXACT delegating line on a line of its own — a line that was
-commented out, truncated, or left behind by an older version is rewritten,
-not trusted — and a hook whose executable bit was cleared gets it back,
-because git silently ignores a hook it cannot execute. An existing
-`pre-commit`/`commit-msg` keeps its content and its own exit status; a hook
-that is symlinked, deliberately disabled (not executable), or whose shebang
-names an interpreter that is not a POSIX-compatible shell is left alone
-entirely (reported, and the install exits 1). A file at the helper path that
-this installer did not write is never overwritten. A bare repository is
-refused — there is no work tree to guard.
+Repeat runs are no-ops, and repairs. A consumer's own hook counts as current
+only when it carries the EXACT delegating line on a line of its own — a line
+that was commented out, truncated, or left behind by an older version is
+rewritten, not trusted. A hook this installer CREATED is owned whole, the way
+`--uninstall` deletes such a file outright: it is current only when its bytes
+are exactly the shebang, the delegating line and the created marker, and
+anything else in it is rewritten away rather than repaired around. A hook
+whose executable bit was cleared gets it back, because git silently ignores a
+hook it cannot execute. An existing `pre-commit`/`commit-msg` keeps its
+content, its shebang and its own exit status; a hook that is symlinked,
+deliberately disabled (not executable), whose shebang names an interpreter
+that is not a POSIX-compatible shell, or whose shebang names a shell outside
+the trusted full paths under `/bin` and `/usr/bin`, is left alone entirely
+(reported, and the install exits 1). That trusted-path rule holds at install
+exactly as it does at `--check`, whoever wrote the hook. A file at the helper
+path that this installer did not write is never overwritten. A bare
+repository is refused — there is no work tree to guard.
 
 Linked worktrees share the install, since git resolves their hooks to the
 main checkout's hooks directory. The same sharing governs removal, and it

--- a/skills/growth-guards/DEVELOPMENT.md
+++ b/skills/growth-guards/DEVELOPMENT.md
@@ -74,23 +74,20 @@ would leave an appended guard unreachable. Ours runs, blocks on any nonzero,
 and then falls through to whatever the hook already did — whose own exit
 status still decides.
 
-Repeat runs are no-ops, and repairs. A consumer's own hook counts as current
-only when it carries the EXACT delegating line on a line of its own — a line
-that was commented out, truncated, or left behind by an older version is
-rewritten, not trusted. A hook this installer CREATED is owned whole, the way
-`--uninstall` deletes such a file outright: it is current only when its bytes
-are exactly the shebang, the delegating line and the created marker, and
-anything else in it is rewritten away rather than repaired around. A hook
-whose executable bit was cleared gets it back, because git silently ignores a
-hook it cannot execute. An existing `pre-commit`/`commit-msg` keeps its
-content, its shebang and its own exit status; a hook that is symlinked,
-deliberately disabled (not executable), whose shebang names an interpreter
-that is not a POSIX-compatible shell, or whose shebang names a shell outside
-the trusted full paths under `/bin` and `/usr/bin`, is left alone entirely
-(reported, and the install exits 1). That trusted-path rule holds at install
-exactly as it does at `--check`, whoever wrote the hook. A file at the helper
-path that this installer did not write is never overwritten. A bare
-repository is refused — there is no work tree to guard.
+Repeat runs are no-ops, and repairs. A hook counts as current only when it
+carries the EXACT delegating line on a line of its own — a line that was
+commented out, truncated, or left behind by an older version is rewritten,
+not trusted — and a hook whose executable bit was cleared gets it back,
+because git silently ignores a hook it cannot execute. An existing
+`pre-commit`/`commit-msg` keeps its content, its shebang and its own exit
+status; a hook that is symlinked, deliberately disabled (not executable),
+whose shebang names an interpreter that is not a POSIX-compatible shell, or
+whose shebang names a shell outside the trusted full paths under `/bin` and
+`/usr/bin`, is left alone entirely (reported, and the install exits 1). That
+trusted-path rule holds at install exactly as it does at `--check`, whoever
+wrote the hook. A file at the helper path that this installer did not write
+is never overwritten. A bare repository is refused — there is no work tree to
+guard.
 
 Linked worktrees share the install, since git resolves their hooks to the
 main checkout's hooks directory. The same sharing governs removal, and it

--- a/skills/growth-guards/scripts/install-git-hooks
+++ b/skills/growth-guards/scripts/install-git-hooks
@@ -307,12 +307,8 @@ install_hook() { # HOOK
     return 0
   fi
   # The SAME predicate --check applies, so an install cannot report success
-  # that the next `kendex check` calls unverifiable. A hook THIS INSTALLER
-  # WROTE is ours to correct rather than refuse: older versions emitted
-  # `#!/usr/bin/env bash`, and refusing there would strand a working install
-  # reporting NOT installed forever. Its shebang is rewritten below.
-  if ! gg_trusted_interpreter "$(head -n 1 "$path")" \
-    && ! grep -qxF -- "$CREATED_MARKER" "$path" 2>/dev/null; then
+  # that the next `kendex check` calls unverifiable.
+  if ! gg_trusted_interpreter "$(head -n 1 "$path")"; then
     hook_warn "$(gg_shown "$path") runs under an interpreter that cannot be verified ($(gg_shown "$(head -n 1 "$path")")); not modifying it — the $hook guard is NOT installed. Use a #! naming a shell in /bin or /usr/bin directly."
     return 0
   fi
@@ -320,10 +316,7 @@ install_hook() { # HOOK
   # after the shebang. Content alone is not enough: a line that was commented
   # out, truncated, left by an older version, or moved below hook content that
   # exits is not an install, and each is rewritten rather than trusted.
-  # The delegate being current is not enough when the SHEBANG is stale: the
-  # fast path would return before the rewrite that corrects it, leaving a
-  # working install reporting unverifiable forever.
-  if [ "$(sed -n '2p' "$path")" = "$line" ] && gg_trusted_interpreter "$(head -n 1 "$path")"; then
+  if [ "$(sed -n '2p' "$path")" = "$line" ]; then
     ensure_hook_executable "$hook" "$path"
     return 0
   fi
@@ -364,16 +357,10 @@ install_hook() { # HOOK
   }
   # The shebang is re-emitted TERMINATED even when the original file ended at
   # it, or the delegate would run onto the interpreter line. A shebang cannot
-  # contain a newline, so the command substitution is lossless.
-  # A file this installer created carries OUR shebang, so an untrusted one is
-  # a stale spelling from an older version and is corrected here. A file the
-  # consumer wrote keeps its own — it reached this point only by being
-  # trusted already.
+  # contain a newline, so the command substitution is lossless. It is kept as
+  # written: the file reached this point only by being trusted already.
   local shebang=""
   shebang="$(head -n 1 "$path")"
-  if [ "$created" -eq 1 ] && ! gg_trusted_interpreter "$shebang"; then
-    shebang="#!/bin/sh"
-  fi
   if ! cp -p -- "$path" "$tmp" 2>/dev/null || ! {
     printf '%s\n' "$shebang"
     printf '%s\n' "$line"

--- a/skills/growth-guards/scripts/install-git-hooks
+++ b/skills/growth-guards/scripts/install-git-hooks
@@ -256,17 +256,6 @@ ends_with_newline() { # FILE — 0 when the last byte is a newline
   [ -z "$(tail -c 1 "$1")" ]
 }
 
-# Whether the hook at PATH already IS this install. A consumer's own hook
-# answers with the delegate at line 2; a hook this installer CREATED answers
-# with the whole file, because uninstall deletes such a file outright and a
-# line drifted in under our own marker would run at every commit unseen.
-hook_is_current() { # PATH DELEGATE-LINE CREATED
-  [ "$(sed -n '2p' "$1")" = "$2" ] || return 1
-  [ "$3" -eq 1 ] || return 0
-  [ "$(wc -l <"$1")" -eq 3 ] \
-    && [ "$(sed -n '3p' "$1")" = "$CREATED_MARKER" ] \
-    && ends_with_newline "$1"
-}
 strip_final_newline() { # FILE — drop one trailing newline byte if present
   local size=0
   ends_with_newline "$1" || return 0
@@ -323,14 +312,11 @@ install_hook() { # HOOK
     hook_warn "$(gg_shown "$path") runs under an interpreter that cannot be verified ($(gg_shown "$(head -n 1 "$path")")); not modifying it — the $hook guard is NOT installed. Use a #! naming a shell in /bin or /usr/bin directly."
     return 0
   fi
-  # Read before the filter strips the marker with our line, re-asserted below:
-  # a repair must not turn a hook we created into one that looks foreign.
-  local created=0
-  grep -qxF -- "$CREATED_MARKER" "$path" 2>/dev/null && created=1
-  # Content alone is not enough: a line that was commented out, truncated,
-  # left by an older version, or moved below hook content that exits is not an
-  # install, and each is rewritten rather than trusted.
-  if hook_is_current "$path" "$line" "$created"; then
+  # Idempotence keys on the EXACT delegate AT ITS POSITION — line 2, straight
+  # after the shebang. Content alone is not enough: a line that was commented
+  # out, truncated, left by an older version, or moved below hook content that
+  # exits is not an install, and each is rewritten rather than trusted.
+  if [ "$(sed -n '2p' "$path")" = "$line" ]; then
     ensure_hook_executable "$hook" "$path"
     return 0
   fi
@@ -338,6 +324,10 @@ install_hook() { # HOOK
     hook_warn "$(gg_shown "$path") exists but is not executable (a disabled hook); not modifying it — the $hook guard is NOT installed"
     return 0
   fi
+  # Read before the filter strips the marker with our line, re-asserted below:
+  # a repair must not turn a hook we created into one that looks foreign.
+  local created=0
+  grep -qxF -- "$CREATED_MARKER" "$path" 2>/dev/null && created=1
   # Everything but the shebang and our own lines, kept in a FILE: a command
   # substitution would strip a missing final newline, and the foreign bytes
   # must come back exactly as they were.
@@ -353,10 +343,7 @@ install_hook() { # HOOK
     hook_warn "could not read $(gg_shown "$path") — the $hook guard is NOT installed"
     return 0
   fi
-  # A created hook is rewritten whole; a consumer's own keeps its bytes.
-  if [ "$created" -eq 1 ]; then
-    : >"$rest"
-  elif ! ends_with_newline "$path" && ! strip_final_newline "$rest"; then
+  if ! ends_with_newline "$path" && ! strip_final_newline "$rest"; then
     rm -f -- "$rest"
     hook_warn "could not preserve the end of $(gg_shown "$path") — the $hook guard is NOT installed"
     return 0

--- a/skills/growth-guards/scripts/install-git-hooks
+++ b/skills/growth-guards/scripts/install-git-hooks
@@ -256,6 +256,17 @@ ends_with_newline() { # FILE — 0 when the last byte is a newline
   [ -z "$(tail -c 1 "$1")" ]
 }
 
+# Whether the hook at PATH already IS this install. A consumer's own hook
+# answers with the delegate at line 2; a hook this installer CREATED answers
+# with the whole file, because uninstall deletes such a file outright and a
+# line drifted in under our own marker would run at every commit unseen.
+hook_is_current() { # PATH DELEGATE-LINE CREATED
+  [ "$(sed -n '2p' "$1")" = "$2" ] || return 1
+  [ "$3" -eq 1 ] || return 0
+  [ "$(wc -l <"$1")" -eq 3 ] \
+    && [ "$(sed -n '3p' "$1")" = "$CREATED_MARKER" ] \
+    && ends_with_newline "$1"
+}
 strip_final_newline() { # FILE — drop one trailing newline byte if present
   local size=0
   ends_with_newline "$1" || return 0
@@ -312,11 +323,14 @@ install_hook() { # HOOK
     hook_warn "$(gg_shown "$path") runs under an interpreter that cannot be verified ($(gg_shown "$(head -n 1 "$path")")); not modifying it — the $hook guard is NOT installed. Use a #! naming a shell in /bin or /usr/bin directly."
     return 0
   fi
-  # Idempotence keys on the EXACT delegate AT ITS POSITION — line 2, straight
-  # after the shebang. Content alone is not enough: a line that was commented
-  # out, truncated, left by an older version, or moved below hook content that
-  # exits is not an install, and each is rewritten rather than trusted.
-  if [ "$(sed -n '2p' "$path")" = "$line" ]; then
+  # Read before the filter strips the marker with our line, re-asserted below:
+  # a repair must not turn a hook we created into one that looks foreign.
+  local created=0
+  grep -qxF -- "$CREATED_MARKER" "$path" 2>/dev/null && created=1
+  # Content alone is not enough: a line that was commented out, truncated,
+  # left by an older version, or moved below hook content that exits is not an
+  # install, and each is rewritten rather than trusted.
+  if hook_is_current "$path" "$line" "$created"; then
     ensure_hook_executable "$hook" "$path"
     return 0
   fi
@@ -324,10 +338,6 @@ install_hook() { # HOOK
     hook_warn "$(gg_shown "$path") exists but is not executable (a disabled hook); not modifying it — the $hook guard is NOT installed"
     return 0
   fi
-  # Read before the filter strips the marker with our line, re-asserted below:
-  # a repair must not turn a hook we created into one that looks foreign.
-  local created=0
-  grep -qxF -- "$CREATED_MARKER" "$path" 2>/dev/null && created=1
   # Everything but the shebang and our own lines, kept in a FILE: a command
   # substitution would strip a missing final newline, and the foreign bytes
   # must come back exactly as they were.
@@ -343,7 +353,10 @@ install_hook() { # HOOK
     hook_warn "could not read $(gg_shown "$path") — the $hook guard is NOT installed"
     return 0
   fi
-  if ! ends_with_newline "$path" && ! strip_final_newline "$rest"; then
+  # A created hook is rewritten whole; a consumer's own keeps its bytes.
+  if [ "$created" -eq 1 ]; then
+    : >"$rest"
+  elif ! ends_with_newline "$path" && ! strip_final_newline "$rest"; then
     rm -f -- "$rest"
     hook_warn "could not preserve the end of $(gg_shown "$path") — the $hook guard is NOT installed"
     return 0

--- a/skills/growth-guards/tests/install-git-hooks-check.test.sh
+++ b/skills/growth-guards/tests/install-git-hooks-check.test.sh
@@ -75,44 +75,6 @@ else
   ok "unreadable hooks dir wording skipped (running as root)"
 fi
 
-echo "=== install corrects a stale shebang in a hook IT wrote ==="
-# Older versions of this installer emitted `#!/usr/bin/env bash`. Refusing
-# there strands a working install reporting NOT installed forever, so a file
-# carrying the created-marker is corrected rather than refused.
-R44="$(new_repo installstaleshebang)"
-install_in "$R44"
-# Exactly the drovr shape: the file this installer wrote, with only its
-# shebang reverted to what an older version emitted.
-{
-  printf '#!/usr/bin/env bash\n'
-  tail -n +2 "$R44/.git/hooks/pre-commit"
-} >"$TMP/stale" && mv "$TMP/stale" "$R44/.git/hooks/pre-commit"
-chmod +x "$R44/.git/hooks/pre-commit"
-grep -qF -- "kendex_gg_h" "$R44/.git/hooks/pre-commit" \
-  && ok "the fixture really carries the guard line under the stale shebang" \
-  || bad "stale fixture carries the guard line" "$(sed -n '2p' "$R44/.git/hooks/pre-commit")"
-check_in "$R44"
-[ "$RC" -eq 2 ] && ok "and it reads as unverifiable before the fix" \
-  || bad "stale fixture unverifiable first" "rc=$RC out=$OUT"
-install_in "$R44"
-[ "$(head -n 1 "$R44/.git/hooks/pre-commit")" = "#!/bin/sh" ] \
-  && ok "a hook this installer wrote has its stale shebang corrected" \
-  || bad "stale shebang corrected" "line1=$(head -n 1 "$R44/.git/hooks/pre-commit")"
-check_in "$R44"
-[ "$RC" -eq 0 ] && ok "and it checks armed afterwards" \
-  || bad "corrected hook checks armed" "rc=$RC out=$OUT"
-
-# Control: a hook the CONSUMER wrote is still refused and left untouched.
-printf '#!/usr/bin/env bash\necho mine\n' >"$R44/.git/hooks/commit-msg"
-chmod +x "$R44/.git/hooks/commit-msg"
-install_in "$R44"
-[ "$(sed -n '2p' "$R44/.git/hooks/commit-msg")" = "echo mine" ] \
-  && ok "control: a consumer's own hook is refused, not rewritten" \
-  || bad "consumer hook untouched" "line2=$(sed -n '2p' "$R44/.git/hooks/commit-msg")"
-[ "$(head -n 1 "$R44/.git/hooks/commit-msg")" = "#!/usr/bin/env bash" ] \
-  && ok "and its shebang is left alone" \
-  || bad "consumer shebang untouched" "line1=$(head -n 1 "$R44/.git/hooks/commit-msg")"
-
 echo "=== install refuses what --check could not vouch for ==="
 # Installing under a shebang the check calls unverifiable would report a
 # successful install that the very next `kendex check` contradicts.
@@ -131,6 +93,32 @@ esac
 check_in "$R43"
 [ "$RC" -ne 0 ] && ok "and --check agrees rather than contradicting the install" \
   || bad "check agrees with install" "rc=$RC out=$OUT"
+
+# The same refusal for a hook THIS INSTALLER wrote: ownership buys no licence
+# to rewrite the interpreter someone since chose. An install that reported
+# success here would be one `kendex check` calls unverifiable.
+R44="$(new_repo installstaleshebang)"
+install_in "$R44"
+{
+  printf '#!/usr/local/bin/bash\n'
+  tail -n +2 "$R44/.git/hooks/pre-commit"
+} >"$TMP/reshebanged" && mv "$TMP/reshebanged" "$R44/.git/hooks/pre-commit"
+chmod +x "$R44/.git/hooks/pre-commit"
+grep -qF -- "kendex_gg_h" "$R44/.git/hooks/pre-commit" \
+  && ok "control: the fixture is our own shim under an untrusted interpreter" \
+  || bad "fixture carries the guard line" "$(sed -n '2p' "$R44/.git/hooks/pre-commit")"
+BEFORE44="$(cat "$R44/.git/hooks/pre-commit")"
+install_in "$R44"
+case "$OUT" in
+  *"cannot be verified"*) ok "install refuses a shim of ours under an untrusted interpreter" ;;
+  *) bad "install refuses our own untrusted shim" "out=$OUT" ;;
+esac
+[ "$(cat "$R44/.git/hooks/pre-commit")" = "$BEFORE44" ] \
+  && ok "and leaves it byte for byte, shebang included" \
+  || bad "our untrusted shim was rewritten" "$(cat "$R44/.git/hooks/pre-commit")"
+check_in "$R44"
+[ "$RC" -ne 0 ] && ok "and --check agrees it is not armed" \
+  || bad "check agrees on our untrusted shim" "rc=$RC out=$OUT"
 
 echo "=== a shim carrying the guard line elsewhere is unverifiable, not ungated ==="
 # --check writes nothing, so it does not get to assume the shim in front of

--- a/skills/growth-guards/tests/install-git-hooks-check.test.sh
+++ b/skills/growth-guards/tests/install-git-hooks-check.test.sh
@@ -117,8 +117,8 @@ esac
   && ok "and leaves it byte for byte, shebang included" \
   || bad "our untrusted shim was rewritten" "$(cat "$R44/.git/hooks/pre-commit")"
 check_in "$R44"
-[ "$RC" -ne 0 ] && ok "and --check agrees it is not armed" \
-  || bad "check agrees on our untrusted shim" "rc=$RC out=$OUT"
+[ "$RC" -eq 2 ] && ok "and --check calls it unverifiable, not merely not armed" \
+  || bad "check calls our untrusted shim unverifiable" "rc=$RC out=$OUT"
 
 echo "=== a shim carrying the guard line elsewhere is unverifiable, not ungated ==="
 # --check writes nothing, so it does not get to assume the shim in front of

--- a/skills/growth-guards/tests/install-git-hooks.test.sh
+++ b/skills/growth-guards/tests/install-git-hooks.test.sh
@@ -586,6 +586,53 @@ git -C "$R28" add b.py
 commit_in "$R28" "feat: add b"
 [ "$RC" -ne 0 ] && ok "control: the repositioned delegate blocks again" || bad "repositioned delegate blocks" "rc=$RC out=$OUT"
 
+echo "=== a hook we created is ours whole, not just its line 2 ==="
+# Uninstall deletes a created hook outright, so install owns the same file
+# whole. A line below the delegate runs at every commit under our own marker,
+# and only this install ever reads past line 2 to find it: a fast path keyed
+# on line 2 alone leaves it there and reports the clone armed.
+R55="$(new_repo created-drift)"
+install_in "$R55"
+CANONICAL="$(cat "$R55/.git/hooks/commit-msg")"
+printf 'echo "a line no install wrote"
+' >>"$R55/.git/hooks/commit-msg"
+[ "$(sed -n '2p' "$R55/.git/hooks/commit-msg")" = "$(sed -n '2p' <<<"$CANONICAL")" ] \
+  && ok "control: the drifted hook still carries the delegate at line 2" \
+  || bad "drifted fixture keeps line 2" "$(cat "$R55/.git/hooks/commit-msg")"
+install_in "$R55"
+[ "$(cat "$R55/.git/hooks/commit-msg")" = "$CANONICAL" ] \
+  && ok "a created hook carrying an extra line is rewritten to the canonical body" \
+  || bad "created hook rewritten to canonical" "$(cat "$R55/.git/hooks/commit-msg")"
+printf 'ok\n' >"$R55/drift.txt"
+git -C "$R55" add drift.txt
+commit_in "$R55" "chore: after the rewrite"
+[ "$RC" -eq 0 ] && case "$OUT" in *"a line no install wrote"*) false ;; *) true ;; esac \
+  && ok "and the extra line no longer runs at commit time" \
+  || bad "the rewritten hook still runs the extra line" "rc=$RC out=$OUT"
+
+echo "=== a consumer's own trusted shebang survives the rewrite ==="
+# The rewrite re-emits line 1 as it found it. Hardcoding #!/bin/sh there would
+# be invisible on every other fixture, which all carry that spelling, and would
+# hand a bash-only body to a shell that cannot parse it.
+R56="$(new_repo bash-consumer)"
+FOREIGN_BASH="$R56/.git/hooks/pre-commit"
+printf '#!/bin/bash
+declare -A m=([a]=1)
+echo "consumer ${m[a]}"
+' >"$FOREIGN_BASH"
+chmod +x "$FOREIGN_BASH"
+install_in "$R56"
+[ "$(head -n 1 "$FOREIGN_BASH")" = "#!/bin/bash" ] \
+  && ok "a trusted shebang that is not /bin/sh is left as written" \
+  || bad "the consumer's shebang was rewritten" "$(cat "$FOREIGN_BASH")"
+case "$(sed -n '2p' "$FOREIGN_BASH")" in
+  *"# kendex-guards-hook") ok "and the delegate is installed at line 2 above it" ;;
+  *) bad "delegate not at line 2" "$(cat "$FOREIGN_BASH")" ;;
+esac
+[ "$(tail -n +3 "$FOREIGN_BASH")" = "$(printf 'declare -A m=([a]=1)\necho "consumer ${m[a]}"')" ] \
+  && ok "and the bash-only body below it is byte for byte what it was" \
+  || bad "consumer body altered" "$(cat "$FOREIGN_BASH")"
+
 echo "=== a non-POSIX-shell hook is left alone ==="
 R15="$(new_repo fish)"
 printf '#!/usr/bin/fish\necho hi\n' >"$R15/.git/hooks/pre-commit"

--- a/skills/growth-guards/tests/install-git-hooks.test.sh
+++ b/skills/growth-guards/tests/install-git-hooks.test.sh
@@ -27,6 +27,22 @@ grep -qF "installed_scripts='$R/.agents/skills/growth-guards/scripts'" "$R/.git/
   && ok "the helper names the scripts directory it was installed from" || bad "helper names its scripts dir"
 grep -qF 'kendex-guards' "$R/.git/hooks/pre-commit" && ok "pre-commit carries the marked delegating line" \
   || bad "pre-commit carries the marked line"
+# On a fresh repo the installer writes the shims itself, so each is exactly
+# what it emits and nothing more: the current shebang, the delegate at line 2,
+# the created marker. Anything else here is a hook the installer inherited,
+# and it emits no shebang but this one — an install that reported success
+# under another would be one `--check` calls unverifiable.
+for f in pre-commit commit-msg; do
+  [ "$(head -n 1 "$R/.git/hooks/$f")" = "#!/bin/sh" ] \
+    && ok "$f carries the current shebang" \
+    || bad "$f carries the current shebang" "line1=$(head -n 1 "$R/.git/hooks/$f")"
+  [ "$(sed -n '3p' "$R/.git/hooks/$f")" = "# kendex-guards-hook created this file" ] \
+    && ok "$f records that the installer created it" \
+    || bad "$f records that the installer created it" "line3=$(sed -n '3p' "$R/.git/hooks/$f")"
+  [ "$(wc -l <"$R/.git/hooks/$f")" -eq 3 ] \
+    && ok "$f holds those three lines and nothing else" \
+    || bad "$f holds those three lines and nothing else" "$(cat "$R/.git/hooks/$f")"
+done
 [ -z "$(git -C "$R" config --get core.hooksPath || true)" ] && ok "core.hooksPath is left unset" \
   || bad "core.hooksPath is left unset"
 
@@ -490,38 +506,11 @@ OUT="$("$R21M/.agents/skills/growth-guards/scripts/install-git-hooks" --repo "$R
 
 echo "=== a hook that only quotes a marker is not ours ==="
 # The ownership question and the shape question fail in opposite directions,
-# and these are the ownership one. Every site that asks whether a file is
-# ours asks it the same way — the marker CLOSING a line, or the created
-# marker as a line whole — so a consumer hook that mentions either in a
-# sentence is somebody else's file at every one of them.
-QUOTE_CREATED="# kendex-guards-hook created this file"
+# and this is the ownership one: ours is the marker CLOSING a line, so a
+# consumer hook that mentions it in a sentence is somebody else's file.
 QUOTE_SENTINEL="# kendex-guards-hook"
 
-# Install refuses a hook it cannot verify unless THIS installer wrote it.
-# A consumer hook under an interpreter we do not vouch for, mentioning the
-# created marker mid-sentence, is not ours — and rewriting its shebang, as
-# a substring read would, changes which interpreter someone else's hook
-# runs under.
-R52="$(new_repo quoter-shebang)"
-FOREIGN="$R52/.git/hooks/pre-commit"
-# A shell shebang the checker will not vouch for: an interpreter outside
-# /bin and /usr/bin, which is what reaches the created-marker question.
-printf '#!/usr/local/bin/bash\n# not %s, just talking about it\nexit 0\n' \
-  "$QUOTE_CREATED" >"$FOREIGN"
-chmod +x "$FOREIGN"
-BEFORE="$(cat "$FOREIGN")"
-install_in "$R52"
-[ "$(head -n 1 "$FOREIGN")" = "#!/usr/local/bin/bash" ] \
-  && ok "install leaves the shebang of a hook that only quotes the created marker" \
-  || bad "the quoting hook's shebang was rewritten" "$(cat "$FOREIGN")"
-[ "$(cat "$FOREIGN")" = "$BEFORE" ] && ok "and the file is byte for byte what it was" \
-  || bad "the quoting hook was edited" "$(cat "$FOREIGN")"
-case "$OUT" in
-  *"cannot be verified"*) ok "and the install says the guard is NOT installed there" ;;
-  *) bad "install did not announce the refusal" "$OUT" ;;
-esac
-
-# The symlink branch asks the same question of a target it must not edit.
+# The symlink branch asks that question of a target it must not edit.
 R53="$(new_repo quoter-symlink)"
 install_in "$R53"
 printf '#!/bin/sh\n# ours end in %s, this one does not\necho mine\n' \

--- a/skills/growth-guards/tests/install-git-hooks.test.sh
+++ b/skills/growth-guards/tests/install-git-hooks.test.sh
@@ -586,30 +586,6 @@ git -C "$R28" add b.py
 commit_in "$R28" "feat: add b"
 [ "$RC" -ne 0 ] && ok "control: the repositioned delegate blocks again" || bad "repositioned delegate blocks" "rc=$RC out=$OUT"
 
-echo "=== a hook we created is ours whole, not just its line 2 ==="
-# Uninstall deletes a created hook outright, so install owns the same file
-# whole. A line below the delegate runs at every commit under our own marker,
-# and only this install ever reads past line 2 to find it: a fast path keyed
-# on line 2 alone leaves it there and reports the clone armed.
-R55="$(new_repo created-drift)"
-install_in "$R55"
-CANONICAL="$(cat "$R55/.git/hooks/commit-msg")"
-printf 'echo "a line no install wrote"
-' >>"$R55/.git/hooks/commit-msg"
-[ "$(sed -n '2p' "$R55/.git/hooks/commit-msg")" = "$(sed -n '2p' <<<"$CANONICAL")" ] \
-  && ok "control: the drifted hook still carries the delegate at line 2" \
-  || bad "drifted fixture keeps line 2" "$(cat "$R55/.git/hooks/commit-msg")"
-install_in "$R55"
-[ "$(cat "$R55/.git/hooks/commit-msg")" = "$CANONICAL" ] \
-  && ok "a created hook carrying an extra line is rewritten to the canonical body" \
-  || bad "created hook rewritten to canonical" "$(cat "$R55/.git/hooks/commit-msg")"
-printf 'ok\n' >"$R55/drift.txt"
-git -C "$R55" add drift.txt
-commit_in "$R55" "chore: after the rewrite"
-[ "$RC" -eq 0 ] && case "$OUT" in *"a line no install wrote"*) false ;; *) true ;; esac \
-  && ok "and the extra line no longer runs at commit time" \
-  || bad "the rewritten hook still runs the extra line" "rc=$RC out=$OUT"
-
 echo "=== a consumer's own trusted shebang survives the rewrite ==="
 # The rewrite re-emits line 1 as it found it. Hardcoding #!/bin/sh there would
 # be invisible on every other fixture, which all carry that spelling, and would

--- a/skills/linear/scripts/commands/sync.sh
+++ b/skills/linear/scripts/commands/sync.sh
@@ -172,18 +172,6 @@ sync_comments() {
     echo "$all_nodes"
 }
 
-# A comment cache built before the paginated fetch holds first pages passed off
-# as whole threads. The cache is regenerable state, so it is discarded and
-# refetched rather than repaired: no conversion, no reader for the old shape.
-# meta.json carries the marker, and its absence forces one full comment pull
-# before any incremental sync is allowed to run.
-COMMENTS_SOURCE="paginated"
-
-comments_cache_is_current() {
-    [[ -f "$CACHE_DIR/meta.json" ]] || return 1
-    [[ "$(jq -r '.comments_source // empty' "$CACHE_DIR/meta.json")" == "$COMMENTS_SOURCE" ]]
-}
-
 # Rewrite the per-issue comment files from a complete comment pull. Every
 # issue in the pull's scope is rewritten or removed, so an issue whose last
 # comment was deleted loses its file instead of keeping a stale one.
@@ -654,7 +642,7 @@ main() {
     fi
 
     # Check if sync needed when --if-stale specified
-    if [[ -n "$if_stale" ]] && cache_is_fresh "$if_stale" && comments_cache_is_current; then
+    if [[ -n "$if_stale" ]] && cache_is_fresh "$if_stale"; then
         echo "Cache fresh (< ${if_stale}m), skipped" >&2
         if [[ "$show_stats" == true ]]; then
             cache_status
@@ -819,25 +807,6 @@ main() {
         sync_cycles > "$CACHE_DIR/cycles.json.tmp" && mv "$CACHE_DIR/cycles.json.tmp" "$CACHE_DIR/cycles.json"
         sync_initiatives > "$CACHE_DIR/initiatives.json.tmp" && mv "$CACHE_DIR/initiatives.json.tmp" "$CACHE_DIR/initiatives.json"
         sync_labels > "$CACHE_DIR/labels.json.tmp" && mv "$CACHE_DIR/labels.json.tmp" "$CACHE_DIR/labels.json"
-
-        # A comment cache built before the paginated fetch is rebuilt whole,
-        # as a precondition of the sync completing rather than as part of the
-        # delta. The legacy threads belong to issues that have not changed, so
-        # an empty delta is both the common upgrade case and the one a
-        # delta-borne rebuild would never reach. It runs last so that a merge
-        # that aborts above leaves the comment cache untouched, and it owns the
-        # whole post-merge issue set, which leaves no subset for a newly
-        # created issue's comments to fall out of.
-        if ! comments_cache_is_current; then
-            if ! sync_comments "{}" > "$CACHE_DIR/.comments.json"; then
-                rm -f "$CACHE_DIR/.comments.json"
-                cache_unlock
-                return 1
-            fi
-            write_comments "$CACHE_DIR/.comments.json" "$CACHE_DIR/issues.json"
-            rm -f "$CACHE_DIR/.comments.json"
-            summary_parts+=("comment cache rebuilt")
-        fi
     fi
 
     # Download file attachments/images from issue descriptions and comments
@@ -872,9 +841,6 @@ main() {
         reconciled_at=$(jq -r '.reconciled_at // empty' "$CACHE_DIR/meta.json" 2>/dev/null || echo "")
     fi
 
-    # Reaching here means the comment cache was built by the paginated fetch:
-    # a full sync pulls every comment, and an incremental sync either found the
-    # marker already set or rebuilt above, failing the sync if it could not.
     jq -n \
         --arg ts "$(date -Iseconds)" \
         --arg reconciled "${reconciled_at:-}" \
@@ -883,11 +849,9 @@ main() {
         --argjson cycles "$cycle_count" \
         --argjson initiatives "$initiative_count" \
         --argjson elapsed "$elapsed" \
-        --arg comments_source "$COMMENTS_SOURCE" \
         '{
             synced_at: $ts,
             reconciled_at: (if $reconciled != "" then $reconciled else null end),
-            comments_source: $comments_source,
             elapsed_seconds: $elapsed,
             stats: {issues: $issues, projects: $projects, cycles: $cycles, initiatives: $initiatives}
         }' \

--- a/skills/linear/tests/sync-merge-abort-error.test.sh
+++ b/skills/linear/tests/sync-merge-abort-error.test.sh
@@ -31,10 +31,9 @@ make_env() {
   printf '%s' "$existing" > "$root/.cache/linear/issues.json"
   echo '[]' > "$root/.cache/linear/projects.json"
 
-  # Comment files the abort must leave alone. meta.json carries no
-  # comments_source, which is the legacy state and the wider blast radius: an
-  # unmarked cache refetches every comment and scopes the write to the whole
-  # issue set, so a write that ran before the merge would sweep these.
+  # Comment files the abort must leave alone: a comment write that ran before
+  # the merge could reject would rewrite them while the command reports the
+  # cache unchanged.
   printf '[{"id":"c1","body":"kept"}]' > "$root/.cache/linear/comments/PROJ-1.json"
   printf '[{"id":"c3","body":"kept too"}]' > "$root/.cache/linear/comments/PROJ-3.json"
   # Old synced_at forces an issues delta; fresh reconciled_at skips reconcile
@@ -45,10 +44,6 @@ make_env() {
 
   local delta_nodes="$delta_node"
   [[ -n "$extra_node" ]] && delta_nodes="$delta_node,$extra_node"
-  # "none" is the empty delta: nothing changed since synced_at. It is the
-  # ordinary state of a machine that syncs regularly, and the upgrade case a
-  # rebuild carried by the delta would never reach.
-  [[ "$delta_id" == "none" ]] && delta_nodes=""
 
   cat >"$root/bin/curl" <<SH
 #!/usr/bin/env bash
@@ -146,84 +141,31 @@ assert_eq "the healthy merge applied the delta update" \
   "$(jq -r '[.[] | select(.id == "id-1")] | first | .title' "$OK_ROOT/.cache/linear/issues.json")" "updated"
 assert_ne "a successful sync advances synced_at" \
   "$(jq -r '.synced_at' "$OK_ROOT/.cache/linear/meta.json")" "$OLD_SYNC"
-# The marker is what stops the next incremental sync refetching every comment,
-# and what stops --if-stale skipping the sync that would write it.
-assert_eq "a successful sync records how the comment cache was built" \
-  "$(jq -r '.comments_source // empty' "$OK_ROOT/.cache/linear/meta.json")" "paginated"
-# PROJ-3 is not in the delta. A cache with no marker holds first-page-only
-# threads for exactly the issues a delta never revisits, so an unmarked sync
-# refetches every comment and scopes the write to the whole issue set. Scoped
-# to the delta instead, PROJ-3 would keep its seeded file forever.
-assert_eq "an unmarked cache refetches comments for an issue outside the delta" \
-  "$(jq -r '.[0].id' "$OK_ROOT/.cache/linear/comments/PROJ-3.json")" "c3-new"
 # PROJ-9 is created BY this delta, so it is absent from the issue set until the
 # merge lands. Scope the write from a pre-merge issues.json and its comments are
-# filtered out, the marker is stamped anyway, and no later delta revisits an
-# issue that never changes again — the permanent empty thread this whole change
-# exists to remove, reintroduced for exactly the newly created issue.
+# filtered out, and no later delta revisits an issue that never changes again —
+# a permanently empty thread for exactly the newly created issue.
 assert_eq "comments for an issue created by this delta are kept" \
   "$(jq -r '.[0].id' "$OK_ROOT/.cache/linear/comments/PROJ-9.json" 2>/dev/null)" "c9"
-
-# --- freshness must not skip the sync that would mark the cache ------------------
-# OK_ROOT is now both fresh and marked, so a read-only caller skips. Strip the
-# marker and the same call has to run: a cache whose comments are legacy is not
-# usable however recently it was synced, and skipping here is how a machine
-# keeps first-page threads indefinitely.
-marked_rc=0
-run_sync_if_stale "$OK_ROOT" >/dev/null 2>"$TMP_BASE/stale-marked" || marked_rc=$?
-assert_eq "--if-stale on a fresh, marked cache exits zero" "$marked_rc" 0
-assert "--if-stale skips a fresh, marked cache" \
-  grep -q "Cache fresh" "$TMP_BASE/stale-marked"
-
-jq 'del(.comments_source)' "$OK_ROOT/.cache/linear/meta.json" > "$TMP_BASE/meta-unmarked"
-mv "$TMP_BASE/meta-unmarked" "$OK_ROOT/.cache/linear/meta.json"
-unmarked_rc=0
-run_sync_if_stale "$OK_ROOT" >/dev/null 2>"$TMP_BASE/stale-unmarked" || unmarked_rc=$?
-assert_eq "--if-stale on an unmarked cache exits zero" "$unmarked_rc" 0
-assert_not "--if-stale re-syncs an unmarked cache rather than leaving legacy comments" \
-  grep -q "Cache fresh" "$TMP_BASE/stale-unmarked"
-assert_eq "the forced sync marks the cache" \
-  "$(jq -r '.comments_source // empty' "$OK_ROOT/.cache/linear/meta.json")" "paginated"
-
-# --- upgrade case: an unmarked cache with an EMPTY delta -------------------------
-# The legacy threads belong to issues that have not changed, so the delta that
-# would carry a rebuild is empty precisely when the rebuild is needed. The
-# rebuild is a precondition of syncing, not part of the delta, so it runs here.
-EMPTY_ROOT="$TMP_BASE/empty"
-make_env "$EMPTY_ROOT" \
-  '[{"id":"id-1","identifier":"PROJ-1","title":"a"},{"id":"id-3","identifier":"PROJ-3","title":"c"}]' \
-  "none"
-
-rc=0
-run_sync "$EMPTY_ROOT" >/dev/null 2>"$TMP_BASE/empty-err" || rc=$?
-assert_eq "sync succeeds on an unmarked cache with an empty delta" \
-  $rc 0
-assert_eq "an empty delta still rebuilds the legacy comment cache" \
-  "$(jq -r '.[0].id' "$EMPTY_ROOT/.cache/linear/comments/PROJ-3.json" 2>/dev/null)" "c3-new"
-assert_not "the rebuild owns the whole issue set, so PROJ-1 keeps no file the pull did not carry" \
-  test -f "$EMPTY_ROOT/.cache/linear/comments/PROJ-1.json"
-assert_eq "the rebuild marks the cache" \
-  "$(jq -r '.comments_source // empty' "$EMPTY_ROOT/.cache/linear/meta.json")" "paginated"
-
-# --- steady state: a MARKED cache takes the delta path only ---------------------
-# Every case above starts unmarked, where the rebuild owns the whole issue set
-# and would mask a wrong delta scope. This is the path every sync after the
-# upgrade takes: no rebuild, and the write scoped to the delta alone.
-MARKED_ROOT="$TMP_BASE/marked"
-make_env "$MARKED_ROOT" \
-  '[{"id":"id-1","identifier":"PROJ-1","title":"a"},{"id":"id-3","identifier":"PROJ-3","title":"c"}]' \
-  "id-1"
-jq '. + {comments_source: "paginated"}' "$MARKED_ROOT/.cache/linear/meta.json" > "$TMP_BASE/marked-meta"
-mv "$TMP_BASE/marked-meta" "$MARKED_ROOT/.cache/linear/meta.json"
-
-rc=0
-run_sync "$MARKED_ROOT" >/dev/null 2>"$TMP_BASE/marked-err" || rc=$?
-assert_eq "sync succeeds on a marked cache" \
-  $rc 0
-assert_not "a marked cache is not rebuilt" \
-  grep -q "comment cache rebuilt" "$TMP_BASE/marked-err"
 # PROJ-3 is outside this delta. The pull carries a comment for it, and only a
 # write scoped past the delta would let that land.
 assert_eq "the delta write stays inside its own scope" \
-  "$(jq -r '.[0].id' "$MARKED_ROOT/.cache/linear/comments/PROJ-3.json" 2>/dev/null)" "c3"
+  "$(jq -r '.[0].id' "$OK_ROOT/.cache/linear/comments/PROJ-3.json" 2>/dev/null)" "c3"
+
+# --- freshness: a fresh cache skips the sync entirely ---------------------------
+fresh_rc=0
+run_sync_if_stale "$OK_ROOT" >/dev/null 2>"$TMP_BASE/stale-fresh" || fresh_rc=$?
+assert_eq "--if-stale on a fresh cache exits zero" "$fresh_rc" 0
+assert "--if-stale skips a fresh cache" \
+  grep -q "Cache fresh" "$TMP_BASE/stale-fresh"
+
+# Must-fail control for the skip above: the same call on a cache older than the
+# window has to run rather than report it fresh.
+jq --arg s "$OLD_SYNC" '.synced_at = $s' "$OK_ROOT/.cache/linear/meta.json" > "$TMP_BASE/meta-stale"
+mv "$TMP_BASE/meta-stale" "$OK_ROOT/.cache/linear/meta.json"
+stale_rc=0
+run_sync_if_stale "$OK_ROOT" >/dev/null 2>"$TMP_BASE/stale-old" || stale_rc=$?
+assert_eq "--if-stale on a stale cache exits zero" "$stale_rc" 0
+assert_not "--if-stale re-syncs a cache older than the window" \
+  grep -q "Cache fresh" "$TMP_BASE/stale-old"
 

--- a/tools/setup
+++ b/tools/setup
@@ -35,8 +35,14 @@ INSTALLER=.agents/skills/growth-guards/scripts/install-git-hooks
 # and a hooks path git reads elsewhere all reach here, and deleting a hook is
 # the fix for none of them. The report may name one hook of the two, so the
 # hand-delete points at what it named rather than at both paths.
+#
+# The two steps are keyed on what the hook still HOLDS, not on who wrote it.
+# --uninstall drops a hook file only when kendex's own lines were all of it;
+# over one carrying a lane of the consumer's it strips our lines, reports
+# success and leaves the rest. Keyed on authorship, the message would send
+# somebody who ran it round the same refusal with nothing left to try.
 not_armed() {
-  echo "setup: the guard shims are not armed; the report above names the reason for each hook, and the remedy follows from it. Where the reason is an interpreter the installer will not vouch for: a hook kendex itself wrote comes out with $INSTALLER --uninstall, and one you wrote yourself you delete by hand — only the hook the report named — and then run this again. Every other reason the report gives is fixed where it says, not by deleting a hook." >&2
+  echo "setup: the guard shims are not armed; the report above names the reason for each hook, and the remedy follows from it. Where the reason is an interpreter the installer will not vouch for: $INSTALLER --uninstall takes out a hook holding nothing but kendex's own lines, and a hook still there after that run holds lines of your own — delete that one by hand, only the hook the report named — then run this again. Every other reason the report gives is fixed where it says, not by deleting a hook." >&2
   exit 1
 }
 

--- a/tools/setup
+++ b/tools/setup
@@ -7,6 +7,12 @@
 # commit-message rule this repo has. There is no repo-local commit-msg lane
 # to splice in beside it.
 #
+# Nothing here judges a hook below its delegating line at line 2. A
+# .git/hooks/commit-msg carrying a spliced call to a repo-local
+# tools/commit-msg lane — which this repo does not have — therefore survives
+# this run, which reports the clone armed while every commit in it dies on
+# `No such file or directory`. Delete that hook and run this again.
+#
 # Whether the shims are armed is the installer's verdict to give, not this
 # script's to infer from a file that exists: git may be reading hooks from
 # somewhere else entirely.
@@ -26,10 +32,11 @@ INSTALLER=.agents/skills/growth-guards/scripts/install-git-hooks
 # The installer has already reported, per hook, WHY it did not arm. That report
 # is the only thing that knows which refusal this was, so this points back at
 # it rather than asserting one cause: a symlinked hook, a cleared execute bit
-# and a hooks path git reads elsewhere all reach here, and deleting two hooks
-# is the fix for none of them.
+# and a hooks path git reads elsewhere all reach here, and deleting a hook is
+# the fix for none of them. The report may name one hook of the two, so the
+# hand-delete points at what it named rather than at both paths.
 not_armed() {
-  echo "setup: the guard shims are not armed; the report above names the reason for each hook, and the remedy follows from it. Where the reason is an interpreter the installer will not vouch for: a hook kendex itself wrote comes out with $INSTALLER --uninstall, and one you wrote yourself you delete by hand — .git/hooks/pre-commit AND .git/hooks/commit-msg — and then run this again. Every other reason the report gives is fixed where it says, not by deleting a hook." >&2
+  echo "setup: the guard shims are not armed; the report above names the reason for each hook, and the remedy follows from it. Where the reason is an interpreter the installer will not vouch for: a hook kendex itself wrote comes out with $INSTALLER --uninstall, and one you wrote yourself you delete by hand — only the hook the report named — and then run this again. Every other reason the report gives is fixed where it says, not by deleting a hook." >&2
   exit 1
 }
 

--- a/tools/setup
+++ b/tools/setup
@@ -23,8 +23,13 @@ cd "$ROOT" || { echo "setup: could not enter $ROOT — the guards could not be a
 
 INSTALLER=.agents/skills/growth-guards/scripts/install-git-hooks
 
+# The installer has already reported, per hook, WHY it did not arm. That report
+# is the only thing that knows which refusal this was, so this points back at
+# it rather than asserting one cause: a symlinked hook, a cleared execute bit
+# and a hooks path git reads elsewhere all reach here, and deleting two hooks
+# is the fix for none of them.
 not_armed() {
-  echo "setup: the guard shims are not armed (the report above says why). Where a hook already at .git/hooks runs under an interpreter the installer will not vouch for, it refuses rather than rewrite it: delete .git/hooks/pre-commit AND .git/hooks/commit-msg, then run this again." >&2
+  echo "setup: the guard shims are not armed; the report above names the reason for each hook, and the remedy follows from it. Where the reason is an interpreter the installer will not vouch for: a hook kendex itself wrote comes out with $INSTALLER --uninstall, and one you wrote yourself you delete by hand — .git/hooks/pre-commit AND .git/hooks/commit-msg — and then run this again. Every other reason the report gives is fixed where it says, not by deleting a hook." >&2
   exit 1
 }
 

--- a/tools/setup
+++ b/tools/setup
@@ -7,100 +7,27 @@
 # commit-message rule this repo has. There is no repo-local commit-msg lane
 # to splice in beside it.
 #
-# A clone armed before that consolidation carries a spliced call to
-# tools/commit-msg, which no longer exists, so every commit there fails
-# closed. This run takes that line back out — hooks live in the shared
-# .git of the checkout and all its work trees, so one run repairs them all.
-#
 # Whether the shims are armed is the installer's verdict to give, not this
 # script's to infer from a file that exists: git may be reading hooks from
 # somewhere else entirely.
 set -euo pipefail
 
-# Every probe here answers a question this repair acts on, so each one is
-# read for whether it RAN before it is read for what it said. A `$(...)` that
-# failed hands back an empty string, which spells a plausible answer at each
-# of these sites — a change of directory that stays put, a hooks path of
-# `/hooks/commit-msg` that no clone has — and the run goes on to report
-# `hooks armed` over a repair it never made.
+# The first probe of all, and it is read for whether it RAN before it is read
+# for what it said. A `$(...)` that failed hands back an empty string, which
+# spells a plausible answer here — a change of directory that stays put — and
+# the run would go on to arm hooks in whatever clone it happened to be in.
 ROOT=""
 ROOT="$(git rev-parse --show-toplevel)" \
   || { echo "setup: not inside a git work tree — the guards could not be armed" >&2; exit 1; }
 cd "$ROOT" || { echo "setup: could not enter $ROOT — the guards could not be armed" >&2; exit 1; }
 
 INSTALLER=.agents/skills/growth-guards/scripts/install-git-hooks
-# The line older clones carry, matched whole so nothing else is touched.
-STALE_LANE='"$(git rev-parse --show-toplevel)/tools/commit-msg" "$@" || exit $?'
 
 not_armed() {
-  echo "setup: the guard shims are not armed (the report above says why). A clone armed by the old tools/setup carries hooks the installer will not rewrite, because it refuses an interpreter it cannot verify: delete .git/hooks/pre-commit AND .git/hooks/commit-msg, then run this again." >&2
+  echo "setup: the guard shims are not armed (the report above says why). Where a hook already at .git/hooks runs under an interpreter the installer will not vouch for, it refuses rather than rewrite it: delete .git/hooks/pre-commit AND .git/hooks/commit-msg, then run this again." >&2
   exit 1
 }
 
 "$INSTALLER" || not_armed
 "$INSTALLER" --check || not_armed
-
-# Drop the retired lane, byte for byte, and leave a hook that never had it
-# untouched. The bytes after it are the hook's own, final newline included.
-#
-# The replacement is built beside the hook and renamed into place. Writing
-# back over the live file would truncate a script git executes on every
-# commit, in the .git every work tree of this checkout shares, and an
-# interrupt or a full disk between the truncate and the last write would
-# leave a partial one there.
-drop_stale_lane() { # HOOK-FILE
-  local hook="$1" tmp="" body="" found=0
-  local ends_nl=1 last="" tail_status=0
-  [ -f "$hook" ] || return 0
-  # grep spends 1 on "not found" and 2 on "could not read it". Reading the
-  # second as the first is this repair concluding there is nothing to do from
-  # a probe that never ran, and then reporting the clone armed.
-  grep -Fxq -- "$STALE_LANE" "$hook" || found=$?
-  case "$found" in
-    0) ;;
-    1) return 0 ;;
-    *)
-      echo "setup: could not read $hook to look for the retired tools/commit-msg lane (grep exit $found) — the hook is unchanged and may still call it" >&2
-      exit 1
-      ;;
-  esac
-  # The same rule as the grep above, one probe further on: tail spends its
-  # status on whether it could READ the hook, and `[ -n "$(...)" ]` throws
-  # that away. An unreadable hook would look like one ending in a newline,
-  # and this repair would rewrite it and report the clone armed.
-  last="$(tail -c 1 -- "$hook")" || tail_status=$?
-  if [ "$tail_status" -ne 0 ]; then
-    echo "setup: could not read the last byte of $hook (tail exit $tail_status) — the hook is unchanged and may still call the retired tools/commit-msg lane" >&2
-    exit 1
-  fi
-  [ -n "$last" ] && ends_nl=0
-  tmp="$(mktemp -- "$hook.tmp.XXXXXX")"
-  # cp -p first, for the mode git needs on a hook; the redirect below then
-  # replaces the content it just copied. chmod --reference is not portable.
-  cp -p -- "$hook" "$tmp" || {
-    rm -f -- "$tmp"
-    echo "setup: could not take $hook's mode — the hook is unchanged" >&2
-    exit 1
-  }
-  awk -v lane="$STALE_LANE" '$0 == lane { next } { print }' "$hook" >"$tmp" || {
-    rm -f -- "$tmp"
-    echo "setup: $hook could not be rewritten to drop the retired tools/commit-msg lane" >&2
-    exit 1
-  }
-  if [ "$ends_nl" -eq 0 ]; then
-    body="$(cat -- "$tmp")"
-    printf '%s' "$body" >"$tmp"
-  fi
-  mv -- "$tmp" "$hook" || {
-    rm -f -- "$tmp"
-    echo "setup: could not replace $hook — inspect it before trusting it" >&2
-    exit 1
-  }
-  echo "setup: dropped the retired tools/commit-msg lane from $hook"
-}
-
-COMMON_DIR=""
-COMMON_DIR="$(git rev-parse --git-common-dir)" \
-  || { echo "setup: could not locate the shared .git directory — the hooks were not inspected" >&2; exit 1; }
-drop_stale_lane "$COMMON_DIR/hooks/commit-msg"
 echo "hooks armed"

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -68,7 +68,7 @@ skills/github/scripts/lib/gh-auth.sh	494
 skills/github/scripts/lib/github-api.sh	897
 skills/github/scripts/lib/verify-lib.sh	415
 skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh	2128
-skills/growth-guards/scripts/install-git-hooks	548
+skills/growth-guards/scripts/install-git-hooks	535
 skills/growth-guards/scripts/lib/settings.sh	467
 skills/iced-rs/examples/changelog/src/changelog.rs	418
 skills/iced-rs/examples/color_palette/src/main.rs	479
@@ -92,7 +92,7 @@ skills/linear/scripts/commands/initiatives.sh	492
 skills/linear/scripts/commands/issues.sh	3376
 skills/linear/scripts/commands/projects.sh	1364
 skills/linear/scripts/commands/session-status.sh	430
-skills/linear/scripts/commands/sync.sh	918
+skills/linear/scripts/commands/sync.sh	882
 skills/linear/scripts/lib/attachments.sh	527
 skills/linear/scripts/lib/cache.sh	618
 skills/linear/scripts/lib/common.sh	780

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -68,7 +68,7 @@ skills/github/scripts/lib/gh-auth.sh	494
 skills/github/scripts/lib/github-api.sh	897
 skills/github/scripts/lib/verify-lib.sh	415
 skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh	2128
-skills/growth-guards/scripts/install-git-hooks	548
+skills/growth-guards/scripts/install-git-hooks	535
 skills/growth-guards/scripts/lib/settings.sh	467
 skills/iced-rs/examples/changelog/src/changelog.rs	418
 skills/iced-rs/examples/color_palette/src/main.rs	479

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -68,7 +68,7 @@ skills/github/scripts/lib/gh-auth.sh	494
 skills/github/scripts/lib/github-api.sh	897
 skills/github/scripts/lib/verify-lib.sh	415
 skills/github/tests/git-diff-summary-cfg-test-declaration.test.sh	2128
-skills/growth-guards/scripts/install-git-hooks	535
+skills/growth-guards/scripts/install-git-hooks	548
 skills/growth-guards/scripts/lib/settings.sh	467
 skills/iced-rs/examples/changelog/src/changelog.rs	418
 skills/iced-rs/examples/color_palette/src/main.rs	479

--- a/tools/tests/setup.test.sh
+++ b/tools/tests/setup.test.sh
@@ -221,10 +221,11 @@ OUT="$(git -C "$R" commit -m "fixup! $(printf 'x%.0s' $(seq 1 70))" 2>&1)" || RC
 [ "$RC" -eq 0 ] && ok "a long fixup! subject passes — the exemption is the package's whole list" \
   || bad "a long fixup! subject passes — the exemption is the package's whole list" "rc=$RC out=$OUT"
 
-echo "=== hooks the installer will not vouch for name both to delete ==="
+echo "=== hooks the installer will not vouch for are each named ==="
 # It refuses an interpreter it cannot verify rather than rewriting somebody
-# else's hook, so the remedy setup prints has to name every hook in the way,
-# not the first one it tripped over.
+# else's hook. setup's remedy points back at that report rather than naming a
+# cause of its own, so the report has to name every hook in the way and why —
+# the first one it tripped over is not the whole answer.
 new_fixture foreign
 for hook in pre-commit commit-msg; do
   printf '#!/usr/bin/env bash\necho "%s ran"\n' "$hook" >"$HOOKS/$hook"
@@ -232,15 +233,20 @@ for hook in pre-commit commit-msg; do
 done
 RC=0
 OUT="$(cd "$R" && ./tools/setup 2>&1)" || RC=$?
-[ "$RC" -ne 0 ] \
-  && case "$OUT" in *".git/hooks/pre-commit AND .git/hooks/commit-msg"*) true ;; *) false ;; esac \
-  && ok "setup stops and names both refused hooks, not just pre-commit" \
-  || bad "setup stops and names both refused hooks, not just pre-commit" "rc=$RC out=$OUT"
-# The remedy prints for every refusal, so matching it alone passes on a
-# wrong-cause message. The installer's own reason is asserted separately.
+[ "$RC" -ne 0 ] && ok "setup stops instead of reporting the clone armed" \
+  || bad "setup stops instead of reporting the clone armed" "rc=$RC out=$OUT"
+# Cause and remedy are asserted apart: the remedy prints for every refusal, so
+# matching it alone would pass on a message naming the wrong cause.
+for hook in pre-commit commit-msg; do
+  case "$OUT" in
+    *"hooks/$hook runs under an interpreter that cannot be verified"*)
+      ok "the report names $hook and why it was refused" ;;
+    *) bad "the report names $hook and why it was refused" "out=$OUT" ;;
+  esac
+done
 case "$OUT" in
-  *"cannot be verified"*) ok "and the installer's own reason reaches the operator" ;;
-  *) bad "the installer's reason reaches the operator" "out=$OUT" ;;
+  *"--uninstall"*) ok "and setup's remedy names the way out for a hook kendex wrote" ;;
+  *) bad "setup's remedy names the way out" "out=$OUT" ;;
 esac
 rm -f "$HOOKS/pre-commit"
 RC=0

--- a/tools/tests/setup.test.sh
+++ b/tools/tests/setup.test.sh
@@ -244,10 +244,56 @@ for hook in pre-commit commit-msg; do
     *) bad "the report names $hook and why it was refused" "out=$OUT" ;;
   esac
 done
-case "$OUT" in
-  *"--uninstall"*) ok "and setup's remedy names the way out for a hook kendex wrote" ;;
-  *) bad "setup's remedy names the way out" "out=$OUT" ;;
-esac
+
+echo "=== following the printed remedy through arms the clone ==="
+# The remedy is keyed on what a hook still HOLDS, not on who wrote it, and
+# only walking it end to end proves that: --uninstall reports success over a
+# hook this installer created that carries a lane of the consumer's, and
+# leaves the file exactly where it was. A message keyed on authorship stops
+# there and sends the operator round the same refusal with nothing to try.
+new_fixture remedy
+(cd "$R" && ./tools/setup >/dev/null 2>&1)
+# The shipped case: a hook this installer wrote, its shebang swapped for one
+# the installer will not vouch for, with a lane of the consumer's below it.
+{
+  printf '#!/usr/bin/env bash\n'
+  tail -n +2 "$HOOKS/commit-msg"
+  printf 'echo "my own lane"\n'
+} >"$HOOKS/commit-msg.new"
+mv "$HOOKS/commit-msg.new" "$HOOKS/commit-msg"
+chmod +x "$HOOKS/commit-msg"
+RC=0
+OUT="$(cd "$R" && ./tools/setup 2>&1)" || RC=$?
+[ "$RC" -ne 0 ] && case "$OUT" in *"--uninstall"*) true ;; *) false ;; esac \
+  && ok "control: setup refuses that clone and prints the remedy" \
+  || bad "control: setup refuses that clone and prints the remedy" "rc=$RC out=$OUT"
+# Step one, exactly as the message spells it.
+(cd "$R" && ./.agents/skills/growth-guards/scripts/install-git-hooks --uninstall >/dev/null 2>&1) || true
+[ -e "$HOOKS/commit-msg" ] && grep -qF 'my own lane' "$HOOKS/commit-msg" \
+  && ok "--uninstall leaves a hook still holding the consumer's lane" \
+  || bad "--uninstall leaves that hook" "$(cat "$HOOKS/commit-msg" 2>&1)"
+RC=0
+OUT="$(cd "$R" && ./tools/setup 2>&1)" || RC=$?
+[ "$RC" -ne 0 ] \
+  && ok "must-fail: step one alone does not clear the refusal" \
+  || bad "must-fail: step one alone does not clear the refusal" "rc=$RC out=$OUT"
+# Step two, which the message keys on that hook still being there.
+rm -f "$HOOKS/commit-msg"
+RC=0
+OUT="$(cd "$R" && ./tools/setup 2>&1)" || RC=$?
+[ "$RC" -eq 0 ] && case "$OUT" in *"hooks armed"*) true ;; *) false ;; esac \
+  && ok "and the remedy walked through leaves the clone armed" \
+  || bad "the remedy walked through arms the clone" "rc=$RC out=$OUT"
+{ grep -qF "$SENTINEL" "$HOOKS/commit-msg" && grep -qF "$SENTINEL" "$HOOKS/pre-commit"; } \
+  && ok "with both shims back in place" \
+  || bad "both shims back in place" "$(ls -1 "$HOOKS" 2>&1)"
+
+echo "=== the refused clone, hook by hook, resolves one at a time ==="
+new_fixture foreign2
+for hook in pre-commit commit-msg; do
+  printf '#!/usr/bin/env bash\necho "%s ran"\n' "$hook" >"$HOOKS/$hook"
+  chmod +x "$HOOKS/$hook"
+done
 rm -f "$HOOKS/pre-commit"
 RC=0
 OUT="$(cd "$R" && ./tools/setup 2>&1)" || RC=$?

--- a/tools/tests/setup.test.sh
+++ b/tools/tests/setup.test.sh
@@ -236,6 +236,12 @@ OUT="$(cd "$R" && ./tools/setup 2>&1)" || RC=$?
   && case "$OUT" in *".git/hooks/pre-commit AND .git/hooks/commit-msg"*) true ;; *) false ;; esac \
   && ok "setup stops and names both refused hooks, not just pre-commit" \
   || bad "setup stops and names both refused hooks, not just pre-commit" "rc=$RC out=$OUT"
+# The remedy prints for every refusal, so matching it alone passes on a
+# wrong-cause message. The installer's own reason is asserted separately.
+case "$OUT" in
+  *"cannot be verified"*) ok "and the installer's own reason reaches the operator" ;;
+  *) bad "the installer's reason reaches the operator" "out=$OUT" ;;
+esac
 rm -f "$HOOKS/pre-commit"
 RC=0
 OUT="$(cd "$R" && ./tools/setup 2>&1)" || RC=$?

--- a/tools/tests/setup.test.sh
+++ b/tools/tests/setup.test.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Pins what tools/setup arms: the growth-guards installer writes both shims
-# and nothing is spliced in beside them, a clone armed by the older setup has
-# its call to the deleted tools/commit-msg taken back out, and then it commits
-# through the armed hooks in both directions — the package's header, subject
-# and changelog verdicts have to be reachable from a real commit, or the chain
-# is wired to nothing. The refusing direction runs first in every pair.
+# Pins what tools/setup arms: the growth-guards installer writes both shims,
+# nothing is spliced in beside them, and the clone then commits through the
+# armed hooks in both directions — the package's header, subject and changelog
+# verdicts have to be reachable from a real commit, or the chain is wired to
+# nothing. The refusing direction runs first in every pair.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -45,8 +44,6 @@ new_fixture() { # NAME — a clone-shaped repo carrying the package and these to
 
 new_fixture repo
 SENTINEL="# kendex-guards-hook"
-# The line clones armed before the consolidation carry.
-STALE_LANE='"$(git rev-parse --show-toplevel)/tools/commit-msg" "$@" || exit $?'
 
 echo "=== a fresh clone is not armed until setup runs ==="
 { [ ! -e "$HOOKS/pre-commit" ] && [ ! -e "$HOOKS/commit-msg" ]; } \
@@ -224,145 +221,21 @@ OUT="$(git -C "$R" commit -m "fixup! $(printf 'x%.0s' $(seq 1 70))" 2>&1)" || RC
 [ "$RC" -eq 0 ] && ok "a long fixup! subject passes — the exemption is the package's whole list" \
   || bad "a long fixup! subject passes — the exemption is the package's whole list" "rc=$RC out=$OUT"
 
-echo "=== a clone armed by the older setup loses its call to the deleted lane ==="
-new_fixture stale
-(cd "$R" && ./tools/setup >/dev/null 2>&1)
-# Put the retired line back where the older setup spliced it, plus a body of
-# the consumer's own below it, written with no final newline.
-awk -v sentinel="$SENTINEL" -v lane="$STALE_LANE" \
-  '{ print } index($0, sentinel) && !placed { print lane; placed = 1 }' \
-  "$HOOKS/commit-msg" >"$HOOKS/commit-msg.new"
-printf 'echo "consumer hook ran"' >>"$HOOKS/commit-msg.new"
-cat "$HOOKS/commit-msg.new" >"$HOOKS/commit-msg"
-rm -f "$HOOKS/commit-msg.new"
-grep -qxF "$STALE_LANE" "$HOOKS/commit-msg" \
-  && ok "control: the fixture really carries the retired lane" \
-  || bad "control: the fixture really carries the retired lane" "$(cat "$HOOKS/commit-msg")"
-RC=0
-OUT="$(cd "$R" && ./tools/setup 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && case "$OUT" in *"dropped the retired tools/commit-msg lane"*) true ;; *) false ;; esac \
-  && ok "setup says it dropped the retired lane" \
-  || bad "setup says it dropped the retired lane" "rc=$RC out=$OUT"
-grep -qF "tools/commit-msg" "$HOOKS/commit-msg" \
-  && bad "the retired lane is gone" "$(cat "$HOOKS/commit-msg")" \
-  || ok "the retired lane is gone"
-[ "$(tail -1 "$HOOKS/commit-msg")" = 'echo "consumer hook ran"' ] \
-  && ok "the consumer's own body is left alone" \
-  || bad "the consumer's own body is left alone" "$(cat "$HOOKS/commit-msg")"
-[ -n "$(tail -c 1 "$HOOKS/commit-msg")" ] \
-  && ok "the missing final newline is preserved" \
-  || bad "the missing final newline is preserved" "the rewrite added one"
-git -C "$R" add -A
-RC=0
-OUT="$(git -C "$R" commit -m "chore: fixture" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && case "$OUT" in *"consumer hook ran"*) true ;; *) false ;; esac \
-  && ok "the repaired hook commits, and still hands back to the consumer's body" \
-  || bad "the repaired hook commits, and still hands back to the consumer's body" "rc=$RC out=$OUT"
-RC=0
-OUT="$(cd "$R" && ./tools/setup 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && case "$OUT" in *"dropped the retired"*) false ;; *) true ;; esac \
-  && ok "a hook that never had the lane is not rewritten" \
-  || bad "a hook that never had the lane is not rewritten" "rc=$RC out=$OUT"
-
-[ -x "$HOOKS/commit-msg" ] \
-  && ok "the repaired hook keeps the execute bit git needs" \
-  || bad "the repaired hook keeps the execute bit git needs" "$(ls -l "$HOOKS/commit-msg")"
-# A probe the repair cannot complete must stop the run, not report the clone
-# armed while the hook still calls a script that is gone. grep spends 1 on
-# "not found" and 2 on "could not read it"; a shim ahead of PATH is what
-# separates the two branches, since the installer that runs first would refuse
-# a hook the filesystem really had made unreadable.
-awk -v sentinel="$SENTINEL" -v lane="$STALE_LANE" \
-  '{ print } index($0, sentinel) && !placed { print lane; placed = 1 }' \
-  "$HOOKS/commit-msg" >"$HOOKS/commit-msg.new"
-cat "$HOOKS/commit-msg.new" >"$HOOKS/commit-msg"
-rm -f "$HOOKS/commit-msg.new"
-GREP_SHIM="$TMP/grep-shim"
-mkdir -p "$GREP_SHIM"
-{
-  printf '#!/usr/bin/env bash\n'
-  printf 'if [ "${1:-}" = "-Fxq" ]; then\n'
-  printf '  echo "grep: simulated read failure" >&2\n'
-  printf '  exit 2\n'
-  printf 'fi\n'
-  printf 'exec %s "$@"\n' "$(command -v grep)"
-} >"$GREP_SHIM/grep"
-chmod +x "$GREP_SHIM/grep"
-RC=0
-OUT="$(cd "$R" && PATH="$GREP_SHIM:$PATH" ./tools/setup 2>&1)" || RC=$?
-[ "$RC" -ne 0 ] && case "$OUT" in *"hooks armed"*) false ;; *"grep exit 2"*) true ;; *) false ;; esac \
-  && ok "a probe that could not run stops setup instead of reporting the clone armed" \
-  || bad "a probe that could not run stops setup" "rc=$RC out=$OUT"
-grep -qxF "$STALE_LANE" "$HOOKS/commit-msg" \
-  && ok "control: that hook really did still carry the retired lane" \
-  || bad "control: that hook really did still carry the retired lane" "$(cat "$HOOKS/commit-msg")"
-# The next probe down the same repair, and the same rule: tail spends its
-# status on whether it could READ the hook, and a discarded status would make
-# an unreadable hook look like one ending in a newline. The lane is still in
-# the hook here, so the run reaches tail at all.
-TAIL_SHIM="$TMP/tail-shim"
-mkdir -p "$TAIL_SHIM"
-{
-  printf '#!/usr/bin/env bash\n'
-  printf 'if [ "${1:-}" = "-c" ]; then\n'
-  printf '  echo "tail: simulated read failure" >&2\n'
-  printf '  exit 1\n'
-  printf 'fi\n'
-  printf 'exec %s "$@"\n' "$(command -v tail)"
-} >"$TAIL_SHIM/tail"
-chmod +x "$TAIL_SHIM/tail"
-RC=0
-OUT="$(cd "$R" && PATH="$TAIL_SHIM:$PATH" ./tools/setup 2>&1)" || RC=$?
-[ "$RC" -ne 0 ] && case "$OUT" in *"hooks armed"*) false ;; *"tail exit 1"*) true ;; *) false ;; esac \
-  && ok "a final-byte probe that could not run stops setup too" \
-  || bad "a final-byte probe that could not run stops setup too" "rc=$RC out=$OUT"
-grep -qxF "$STALE_LANE" "$HOOKS/commit-msg" \
-  && ok "control: that hook is unchanged, retired lane and all" \
-  || bad "control: that hook is unchanged, retired lane and all" "$(cat "$HOOKS/commit-msg")"
-
-# The hooks path itself is a probe. Failed, it hands back an empty string,
-# `/hooks/commit-msg` is a file no clone has, and the repair would find
-# nothing to do and report the clone armed. The shim fails only the bare
-# `rev-parse --git-common-dir` this script runs: every call the installer
-# makes carries -C, so the verdict it gives first is its own.
-GIT_SHIM="$TMP/git-shim"
-mkdir -p "$GIT_SHIM"
-{
-  printf '#!/usr/bin/env bash\n'
-  printf 'if [ "${1:-}" = "rev-parse" ] && [ "${2:-}" = "--git-common-dir" ]; then\n'
-  printf '  echo "git: simulated failure" >&2\n'
-  printf '  exit 128\n'
-  printf 'fi\n'
-  printf 'exec %s "$@"\n' "$(command -v git)"
-} >"$GIT_SHIM/git"
-chmod +x "$GIT_SHIM/git"
-RC=0
-OUT="$(cd "$R" && PATH="$GIT_SHIM:$PATH" ./tools/setup 2>&1)" || RC=$?
-[ "$RC" -ne 0 ] && case "$OUT" in *"hooks armed"*) false ;; *"could not locate the shared .git directory"*) true ;; *) false ;; esac \
-  && ok "a hooks path that could not be resolved stops setup" \
-  || bad "a hooks path that could not be resolved stops setup" "rc=$RC out=$OUT"
-grep -qxF "$STALE_LANE" "$HOOKS/commit-msg" \
-  && ok "control: that hook is unchanged there too" \
-  || bad "control: that hook is unchanged there too" "$(cat "$HOOKS/commit-msg")"
-
-RC=0
-OUT="$(cd "$R" && ./tools/setup 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "with a working probe the same hook is repaired" \
-  || bad "with a working probe the same hook is repaired" "rc=$RC out=$OUT"
-
-echo "=== a clone armed by the old setup names both hooks to delete ==="
-new_fixture legacy
-for pair in pre-commit:guard commit-msg:commit-msg; do
-  printf '#!/usr/bin/env bash\nexec "$(git rev-parse --show-toplevel)/tools/%s" "$@"\n' \
-    "${pair##*:}" >"$HOOKS/${pair%%:*}"
-  chmod +x "$HOOKS/${pair%%:*}"
+echo "=== hooks the installer will not vouch for name both to delete ==="
+# It refuses an interpreter it cannot verify rather than rewriting somebody
+# else's hook, so the remedy setup prints has to name every hook in the way,
+# not the first one it tripped over.
+new_fixture foreign
+for hook in pre-commit commit-msg; do
+  printf '#!/usr/bin/env bash\necho "%s ran"\n' "$hook" >"$HOOKS/$hook"
+  chmod +x "$HOOKS/$hook"
 done
 RC=0
 OUT="$(cd "$R" && ./tools/setup 2>&1)" || RC=$?
 [ "$RC" -ne 0 ] \
   && case "$OUT" in *".git/hooks/pre-commit AND .git/hooks/commit-msg"*) true ;; *) false ;; esac \
-  && ok "setup stops and names both legacy hooks, not just pre-commit" \
-  || bad "setup stops and names both legacy hooks, not just pre-commit" "rc=$RC out=$OUT"
+  && ok "setup stops and names both refused hooks, not just pre-commit" \
+  || bad "setup stops and names both refused hooks, not just pre-commit" "rc=$RC out=$OUT"
 rm -f "$HOOKS/pre-commit"
 RC=0
 OUT="$(cd "$R" && ./tools/setup 2>&1)" || RC=$?
@@ -382,18 +255,14 @@ cp -R "$R/.agents/skills/growth-guards" "$E/.agents/skills/growth-guards"
 cp "$TOOLS/setup" "$E/tools/"
 git -C "$E" init -q
 git -C "$E" config core.hooksPath "$E/other-hooks"
-# A leftover file at the path the installer writes, which git no longer reads,
-# carrying the retired lane.
-mkdir -p "$E/.git/hooks"
-printf '#!/bin/sh\n%s\n' "$STALE_LANE" >"$E/.git/hooks/commit-msg"
 RC=0
 OUT="$(cd "$E" && ./tools/setup 2>&1)" || RC=$?
 [ "$RC" -ne 0 ] && case "$OUT" in *"not armed"*) true ;; *) false ;; esac \
   && ok "a configured hooks path stops setup instead of wiring a hook git ignores" \
   || bad "a configured hooks path stops setup instead of wiring a hook git ignores" "rc=$RC out=$OUT"
-grep -qxF "$STALE_LANE" "$E/.git/hooks/commit-msg" \
-  && ok "the stale hook is left alone — the repair runs only past the installer's verdict" \
-  || bad "the stale hook is left alone" "$(cat "$E/.git/hooks/commit-msg")"
+[ ! -e "$E/.git/hooks/pre-commit" ] && [ ! -e "$E/.git/hooks/commit-msg" ] \
+  && ok "and writes no shim at the path git has stopped reading" \
+  || bad "setup wrote a shim git ignores" "$(ls -1 "$E/.git/hooks" 2>&1)"
 
 echo "=== setup outside a work tree says so, rather than working somewhere else ==="
 # The first probe of all. Unread, its empty answer is a change of directory


### PR DESCRIPTION
## Summary

- Removes the three compat sites named in the issue: `drop_stale_lane` and its `--git-common-dir` probe from `tools/setup`, the `comments_source` cache marker and its `--if-stale` rebuild from the Linear sync, and the vstack-era shebang repair from `install-git-hooks`. A hook under an interpreter the installer cannot verify is now refused rather than rewritten, whoever wrote it.
- Ships the consumer-facing half of each removal instead of migration code: a changelog fragment for the installer refusal, one for the Linear cache (an existing cache needs one `linear.sh sync --full`), and a reworded KEN-795 entry that no longer promises whole threads for a cache the sync will not rebuild.
- Corrects what the docs claimed: `AGENTS.md` now names all three commit-message rules and says the whole header line caps at 72 characters, and `DEVELOPMENT.md` names the trusted-path refusal beside the non-POSIX-shell one.

## Completed Issues

- Closes KEN-913 - tools/setup, linear sync, and install-git-hooks carry no compat for stale clones or caches

## Known Limitation

Nothing judges a hook below its delegating line. A clone armed by an older `tools/setup` carries a `.git/hooks/commit-msg` calling a repo-local `tools/commit-msg` this repo no longer has; setup reports the shims armed — accurately, they are armed and do gate — while every commit dies on `No such file or directory` at that later line. Delete that hook and run setup again. This is documented in `tools/setup`'s header and in `AGENTS.md` rather than detected, per the repo's no-migration rule; detecting it is the compat machinery this issue removes.

## QA Metrics

Reviewed by nine internal reviewers plus a cross-model (Codex) lane over three cycles — 10 blockers and 8 fix suggestions in the first, one regression caught in the second, zero blockers in the third.

Evidence that assertions are not vacuous, measured rather than inspected:

- The shebang pass-through fixture kills the mutant that hardcodes `shebang="#!/bin/sh"` — `killed 1/1`, stability `6/6` at 64 threads. Before the fixture that mutant survived every suite.
- Each new `tools/tests/setup.test.sh` assertion reddens on a mutation of its own subject and nothing else; skipping only `commit-msg` reddens only the `commit-msg` assertion, proving per-hook granularity rather than one string matched twice.
- `install-git-hooks-check.test.sh` R44 requires exit 2, and still kills a mutant that moves the untrusted-interpreter refusal below the idempotence fast path.
- Installer rewrite atomicity re-measured under contention: 480 reader samples across 12 rounds of 8 concurrent installers, 0 torn reads, 0 lost bodies, 0 leaked temp files.

Both size-ratchet rows move down and match `wc -l` exactly: `install-git-hooks` 548 → 535, `sync.sh` 918 → 882. No `RATCHET_RAISE`.

## Test Plan

- `tools/guard` — exit 0 (124 green `test result` lines; UI 1073 tests).
- `skills/growth-guards/tests/install-git-hooks.test.sh`, `install-git-hooks-check.test.sh`, `install-git-hooks-scope.test.sh`, `install-git-hooks-hookspath.test.sh`, `tools/tests/setup.test.sh`, `skills/linear/tests/sync-merge-abort-error.test.sh` — all green.
- `cargo test -p kendex-cli --test guard_hooks --test install_ux` — 34/34 and 45/45. Run locally because the Linux cargo job is merge-queue-only, and `not_armed`'s text changed in this branch.
- Reproduced by hand: a consumer hook keeps its body and its `#!/bin/bash` shebang across a re-install; a pre-existing stale `commit-msg` lane produces the documented failure and is cleared by deleting the hook and re-running setup.
