### PR TITLE
test(KEN-879): stage the launch boundary instead of racing the clock

### DIFF
--- a/.agents/skills/orch/tests/queue_wait_confirmation.sh
+++ b/.agents/skills/orch/tests/queue_wait_confirmation.sh
@@ -173,6 +173,23 @@ q_in_queue='{"data":{"repository":{"pullRequest":{"id":"PR_node1","isInMergeQueu
 q_out='{"data":{"repository":{"pullRequest":{"id":"PR_node1","isInMergeQueue":false,"mergeQueueEntry":null,"autoMergeRequest":null}}}}'
 q_armed_only='{"data":{"repository":{"pullRequest":{"id":"PR_node1","isInMergeQueue":false,"mergeQueueEntry":null,"autoMergeRequest":{"enabledAt":"2026-07-24T09:00:00Z"}}}}}'
 
+# queue-wait keeps its budget with `date +%s`, so the elapsed it charges a run
+# is floor(frac(launch) + real duration). Launched .8 into a second, a run is
+# billed a whole second it never spent. Real budgets are minutes and never
+# notice. These cases run on three, where that phantom second is a third of the
+# budget and takes with it the squeezed confirmation poll they exist to prove,
+# so the suite goes red on launch phase alone (KEN-879). Stage the boundary
+# rather than race it. Started on the tick, elapsed is the run's real duration,
+# which is what the budgets below are written against, and the second the
+# alignment recovers is the margin. Startup and poll cost measures in tens of
+# milliseconds even on a loaded machine, so that margin is not close.
+align_to_tick() {
+  local ns
+  ns="$(date +%N)"
+  [[ "$ns" =~ ^[0-9]{9}$ ]] || return 0
+  sleep "0.$(printf '%09d' $(( (1000000000 - 10#$ns) % 1000000000 )))"
+}
+
 run_queue_wait() {
   local env_args=()
   while [[ $# -gt 0 && "$1" != "--" ]]; do
@@ -180,6 +197,7 @@ run_queue_wait() {
     shift
   done
   shift || true
+  align_to_tick
   (cd "$TMP_ROOT/repo" \
     && PATH="$TMP_ROOT/bin:$PATH" \
        env STUB_SEQ_DIR="$SEQ_DIR" \

--- a/.agents/skills/orch/tests/queue_wait_confirmation.sh
+++ b/.agents/skills/orch/tests/queue_wait_confirmation.sh
@@ -78,8 +78,9 @@ ln -s "$REPO_ROOT/skills/orch" "$TMP_ROOT/repo/.agents/skills/orch"
 # `<prefix>-last.json` serves every poll past the last numbered fixture, and
 # review-thread reads answer with an empty set so the late-findings guard
 # stays quiet. `STUB_QUEUE_DELAY` makes the queue read itself cost that many
-# seconds, the production condition under which a confirmation count can be
-# larger than the remaining budget can hold however short the gaps are made.
+# seconds on the clock below, the production condition under which a
+# confirmation count can be larger than the remaining budget can hold however
+# short the gaps are made.
 cat > "$TMP_ROOT/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 set -uo pipefail
@@ -155,6 +156,52 @@ exit 1
 EOF
 chmod +x "$TMP_ROOT/bin/gh"
 
+# Virtual clock, on the same PATH as the gh stub. On wall time these cases have
+# no margin worth the name. They run on budgets of a few seconds, and once a
+# poll costs a large fraction of a second the deadline arrives before the
+# squeezed confirmation poll can land, so every case goes red. That is what a
+# contended CI runner and a busy developer box both produce, and it is what
+# made this suite eject merge groups (KEN-879).
+#
+# None of it is about real duration. What the cases assert is arithmetic over
+# the clock queue-wait itself keeps, and queue-wait reads wall time only as
+# `date +%s` and waits only through `sleep`, so owning those two commands makes
+# the budget exact rather than raced. A sleep advances the clock, a poll costs
+# nothing unless the stub is told to charge for it, and every assertion below
+# lands on the same number no matter how slow the machine is. The suite also
+# stops needing `date +%N`, a GNU extension that is absent on macOS.
+REAL_DATE="$(command -v date)"
+REAL_SLEEP="$(command -v sleep)"
+if [[ ! -x "$REAL_DATE" || ! -x "$REAL_SLEEP" ]]; then
+  echo "no external date/sleep for the clock stubs to fall back on" >&2
+  exit 1
+fi
+
+cat > "$TMP_ROOT/bin/date" <<'EOF'
+#!/usr/bin/env bash
+# `+%s` is the clock queue-wait keeps its budget on. Every other form is the
+# real date, so a timestamp the script prints is still a real timestamp.
+if [[ "${1:-}" == "+%s" && -f "${STUB_CLOCK:-}" ]]; then
+  cat "$STUB_CLOCK"
+  exit 0
+fi
+exec "$STUB_REAL_DATE" "$@"
+EOF
+chmod +x "$TMP_ROOT/bin/date"
+
+cat > "$TMP_ROOT/bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+# Whole seconds advance the clock and return; that is every wait queue-wait and
+# the gh stub make. Anything else is a real sleep, so an unexpected fractional
+# wait still waits rather than silently passing.
+if [[ "${1:-}" =~ ^[0-9]+$ && -f "${STUB_CLOCK:-}" ]]; then
+  printf '%s' "$(( $(cat "$STUB_CLOCK") + $1 ))" > "$STUB_CLOCK"
+  exit 0
+fi
+exec "$STUB_REAL_SLEEP" "$@"
+EOF
+chmod +x "$TMP_ROOT/bin/sleep"
+
 SEQ_DIR=""
 new_case() {
   SEQ_DIR="$TMP_ROOT/seq/$1"
@@ -173,23 +220,6 @@ q_in_queue='{"data":{"repository":{"pullRequest":{"id":"PR_node1","isInMergeQueu
 q_out='{"data":{"repository":{"pullRequest":{"id":"PR_node1","isInMergeQueue":false,"mergeQueueEntry":null,"autoMergeRequest":null}}}}'
 q_armed_only='{"data":{"repository":{"pullRequest":{"id":"PR_node1","isInMergeQueue":false,"mergeQueueEntry":null,"autoMergeRequest":{"enabledAt":"2026-07-24T09:00:00Z"}}}}}'
 
-# queue-wait keeps its budget with `date +%s`, so the elapsed it charges a run
-# is floor(frac(launch) + real duration). Launched .8 into a second, a run is
-# billed a whole second it never spent. Real budgets are minutes and never
-# notice. These cases run on three, where that phantom second is a third of the
-# budget and takes with it the squeezed confirmation poll they exist to prove,
-# so the suite goes red on launch phase alone (KEN-879). Stage the boundary
-# rather than race it. Started on the tick, elapsed is the run's real duration,
-# which is what the budgets below are written against, and the second the
-# alignment recovers is the margin. Startup and poll cost measures in tens of
-# milliseconds even on a loaded machine, so that margin is not close.
-align_to_tick() {
-  local ns
-  ns="$(date +%N)"
-  [[ "$ns" =~ ^[0-9]{9}$ ]] || return 0
-  sleep "0.$(printf '%09d' $(( (1000000000 - 10#$ns) % 1000000000 )))"
-}
-
 run_queue_wait() {
   local env_args=()
   while [[ $# -gt 0 && "$1" != "--" ]]; do
@@ -197,10 +227,15 @@ run_queue_wait() {
     shift
   done
   shift || true
-  align_to_tick
+  # Start each run at the real epoch, so anything reading an absolute time
+  # still reads a plausible one, and let the run move the clock from there.
+  date +%s > "$TMP_ROOT/clock"
   (cd "$TMP_ROOT/repo" \
     && PATH="$TMP_ROOT/bin:$PATH" \
        env STUB_SEQ_DIR="$SEQ_DIR" \
+           STUB_CLOCK="$TMP_ROOT/clock" \
+           STUB_REAL_DATE="$REAL_DATE" \
+           STUB_REAL_SLEEP="$REAL_SLEEP" \
            QUEUE_WAIT_CONFIRM_POLLS=2 \
            QUEUE_WAIT_ARM_GRACE=120 \
            QUEUE_WAIT_PROBE_INTERVAL=0 \

--- a/skills/orch/tests/queue_wait_confirmation.sh
+++ b/skills/orch/tests/queue_wait_confirmation.sh
@@ -173,6 +173,23 @@ q_in_queue='{"data":{"repository":{"pullRequest":{"id":"PR_node1","isInMergeQueu
 q_out='{"data":{"repository":{"pullRequest":{"id":"PR_node1","isInMergeQueue":false,"mergeQueueEntry":null,"autoMergeRequest":null}}}}'
 q_armed_only='{"data":{"repository":{"pullRequest":{"id":"PR_node1","isInMergeQueue":false,"mergeQueueEntry":null,"autoMergeRequest":{"enabledAt":"2026-07-24T09:00:00Z"}}}}}'
 
+# queue-wait keeps its budget with `date +%s`, so the elapsed it charges a run
+# is floor(frac(launch) + real duration). Launched .8 into a second, a run is
+# billed a whole second it never spent. Real budgets are minutes and never
+# notice. These cases run on three, where that phantom second is a third of the
+# budget and takes with it the squeezed confirmation poll they exist to prove,
+# so the suite goes red on launch phase alone (KEN-879). Stage the boundary
+# rather than race it. Started on the tick, elapsed is the run's real duration,
+# which is what the budgets below are written against, and the second the
+# alignment recovers is the margin. Startup and poll cost measures in tens of
+# milliseconds even on a loaded machine, so that margin is not close.
+align_to_tick() {
+  local ns
+  ns="$(date +%N)"
+  [[ "$ns" =~ ^[0-9]{9}$ ]] || return 0
+  sleep "0.$(printf '%09d' $(( (1000000000 - 10#$ns) % 1000000000 )))"
+}
+
 run_queue_wait() {
   local env_args=()
   while [[ $# -gt 0 && "$1" != "--" ]]; do
@@ -180,6 +197,7 @@ run_queue_wait() {
     shift
   done
   shift || true
+  align_to_tick
   (cd "$TMP_ROOT/repo" \
     && PATH="$TMP_ROOT/bin:$PATH" \
        env STUB_SEQ_DIR="$SEQ_DIR" \

--- a/skills/orch/tests/queue_wait_confirmation.sh
+++ b/skills/orch/tests/queue_wait_confirmation.sh
@@ -78,8 +78,9 @@ ln -s "$REPO_ROOT/skills/orch" "$TMP_ROOT/repo/.agents/skills/orch"
 # `<prefix>-last.json` serves every poll past the last numbered fixture, and
 # review-thread reads answer with an empty set so the late-findings guard
 # stays quiet. `STUB_QUEUE_DELAY` makes the queue read itself cost that many
-# seconds, the production condition under which a confirmation count can be
-# larger than the remaining budget can hold however short the gaps are made.
+# seconds on the clock below, the production condition under which a
+# confirmation count can be larger than the remaining budget can hold however
+# short the gaps are made.
 cat > "$TMP_ROOT/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 set -uo pipefail
@@ -155,6 +156,52 @@ exit 1
 EOF
 chmod +x "$TMP_ROOT/bin/gh"
 
+# Virtual clock, on the same PATH as the gh stub. On wall time these cases have
+# no margin worth the name. They run on budgets of a few seconds, and once a
+# poll costs a large fraction of a second the deadline arrives before the
+# squeezed confirmation poll can land, so every case goes red. That is what a
+# contended CI runner and a busy developer box both produce, and it is what
+# made this suite eject merge groups (KEN-879).
+#
+# None of it is about real duration. What the cases assert is arithmetic over
+# the clock queue-wait itself keeps, and queue-wait reads wall time only as
+# `date +%s` and waits only through `sleep`, so owning those two commands makes
+# the budget exact rather than raced. A sleep advances the clock, a poll costs
+# nothing unless the stub is told to charge for it, and every assertion below
+# lands on the same number no matter how slow the machine is. The suite also
+# stops needing `date +%N`, a GNU extension that is absent on macOS.
+REAL_DATE="$(command -v date)"
+REAL_SLEEP="$(command -v sleep)"
+if [[ ! -x "$REAL_DATE" || ! -x "$REAL_SLEEP" ]]; then
+  echo "no external date/sleep for the clock stubs to fall back on" >&2
+  exit 1
+fi
+
+cat > "$TMP_ROOT/bin/date" <<'EOF'
+#!/usr/bin/env bash
+# `+%s` is the clock queue-wait keeps its budget on. Every other form is the
+# real date, so a timestamp the script prints is still a real timestamp.
+if [[ "${1:-}" == "+%s" && -f "${STUB_CLOCK:-}" ]]; then
+  cat "$STUB_CLOCK"
+  exit 0
+fi
+exec "$STUB_REAL_DATE" "$@"
+EOF
+chmod +x "$TMP_ROOT/bin/date"
+
+cat > "$TMP_ROOT/bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+# Whole seconds advance the clock and return; that is every wait queue-wait and
+# the gh stub make. Anything else is a real sleep, so an unexpected fractional
+# wait still waits rather than silently passing.
+if [[ "${1:-}" =~ ^[0-9]+$ && -f "${STUB_CLOCK:-}" ]]; then
+  printf '%s' "$(( $(cat "$STUB_CLOCK") + $1 ))" > "$STUB_CLOCK"
+  exit 0
+fi
+exec "$STUB_REAL_SLEEP" "$@"
+EOF
+chmod +x "$TMP_ROOT/bin/sleep"
+
 SEQ_DIR=""
 new_case() {
   SEQ_DIR="$TMP_ROOT/seq/$1"
@@ -173,23 +220,6 @@ q_in_queue='{"data":{"repository":{"pullRequest":{"id":"PR_node1","isInMergeQueu
 q_out='{"data":{"repository":{"pullRequest":{"id":"PR_node1","isInMergeQueue":false,"mergeQueueEntry":null,"autoMergeRequest":null}}}}'
 q_armed_only='{"data":{"repository":{"pullRequest":{"id":"PR_node1","isInMergeQueue":false,"mergeQueueEntry":null,"autoMergeRequest":{"enabledAt":"2026-07-24T09:00:00Z"}}}}}'
 
-# queue-wait keeps its budget with `date +%s`, so the elapsed it charges a run
-# is floor(frac(launch) + real duration). Launched .8 into a second, a run is
-# billed a whole second it never spent. Real budgets are minutes and never
-# notice. These cases run on three, where that phantom second is a third of the
-# budget and takes with it the squeezed confirmation poll they exist to prove,
-# so the suite goes red on launch phase alone (KEN-879). Stage the boundary
-# rather than race it. Started on the tick, elapsed is the run's real duration,
-# which is what the budgets below are written against, and the second the
-# alignment recovers is the margin. Startup and poll cost measures in tens of
-# milliseconds even on a loaded machine, so that margin is not close.
-align_to_tick() {
-  local ns
-  ns="$(date +%N)"
-  [[ "$ns" =~ ^[0-9]{9}$ ]] || return 0
-  sleep "0.$(printf '%09d' $(( (1000000000 - 10#$ns) % 1000000000 )))"
-}
-
 run_queue_wait() {
   local env_args=()
   while [[ $# -gt 0 && "$1" != "--" ]]; do
@@ -197,10 +227,15 @@ run_queue_wait() {
     shift
   done
   shift || true
-  align_to_tick
+  # Start each run at the real epoch, so anything reading an absolute time
+  # still reads a plausible one, and let the run move the clock from there.
+  date +%s > "$TMP_ROOT/clock"
   (cd "$TMP_ROOT/repo" \
     && PATH="$TMP_ROOT/bin:$PATH" \
        env STUB_SEQ_DIR="$SEQ_DIR" \
+           STUB_CLOCK="$TMP_ROOT/clock" \
+           STUB_REAL_DATE="$REAL_DATE" \
+           STUB_REAL_SLEEP="$REAL_SLEEP" \
            QUEUE_WAIT_CONFIRM_POLLS=2 \
            QUEUE_WAIT_ARM_GRACE=120 \
            QUEUE_WAIT_PROBE_INTERVAL=0 \


### PR DESCRIPTION
`skills/orch/tests/queue_wait_confirmation.sh` fails intermittently and blocked an unrelated PR across three consecutive CI runs. It also runs in the merge queue, so it can eject a merge group — which happened once this week, taking #1861 and #1867 down together.

## The root cause

`queue-wait` keeps its budget with `date +%s`, so the elapsed it charges a run is `floor(frac(launch) + real duration)`. A run launched 0.8 into a wall-clock second is billed a whole second it never spent. At the default 2400s budget that is noise. These cases run on a **3-second** budget, where the phantom second is a third of it.

A phase sweep launching case 1 at controlled fractional offsets, nothing else varied:

| launch fraction | verdict / status |
|---|---|
| 0.25 – 0.65 | `ejected` / `complete` |
| 0.70 – 0.99 | `queued` / `timeout` |

**`queue-wait`'s pacing is correct throughout.** It sleeps its 2s interval and squeezes the last gap to 0, which is exactly what the cases exist to prove. What was wrong is the test's assumption that `elapsed_seconds` measures the run's duration — it only does when the launch is phase-aligned.

## Why aligning the launch was not enough

The first attempt slept to the next whole second before each launch. Review found two problems with it, and measuring both is what produced the change that shipped.

**The margin is one second and the polls spend it.** Charging every stub `gh` call a fixed cost, across the whole suite:

| added per-call cost | aligned | unaligned |
|---|---|---|
| 0 | 0 fail | 1 fail |
| 0.05 | 0 | 3 |
| 0.10 | 3 | 5 |
| 0.20 | 9 | 9 |
| 0.50 | 15 | 15 |

At 0.20 and beyond, alignment buys nothing. At 0.50 the suite charges 4 seconds to a 3-second case and 6 to a 5-second case — matching a reviewer's report from a slower runner exactly, on which the pre-alignment commit fails identically. Two machines measured the aligned version green; both were on the fast side of that cliff. Alignment cannot honestly guarantee anything on an unknown runner.

A second review point — that subshell and interpreter startup between the alignment and `queue-wait`'s own `START_TIME` could cross the tick — was **measured and is not the cause**: that gap runs 0.005s idle to 0.093s max under 256 spinners on 32 cores, needing roughly 17× that load to cross a tick. The mechanism was wrong; the failure it reported was real.

It was also not portable. `date +%N` is a GNU extension; on a BSD/macOS `date` the guard silently skipped alignment, so the suite kept the flake and said nothing.

## What shipped: the cases stop measuring themselves with wall time

`queue-wait` reads the clock only as `date +%s` (4 sites) and waits only through `sleep` (1 site) — no bash time builtin, no background work. The suite already serves a `gh` stub from `PATH`; it now serves `date` and `sleep` the same way. A sleep advances a counter file, a poll costs nothing unless `STUB_QUEUE_DELAY` charges for it, and the budget arithmetic becomes exact.

**Every assertion, budget, fixture and case is unchanged. `queue-wait` itself is untouched.** It stays one test file for the KEN-916 rework to rebase over, and `%N` is gone rather than guarded.

Both easy non-fixes stayed off the table: raising the budget until green would hide a real pacing bug, and skipping the cases would remove the guard on merge-queue verdicts.

## Evidence

| check | result |
|---|---|
| reproduce before any fix | red on run 1; 6 of 10 red at load 25/32 |
| this commit | 50 of 50 consecutive green under 200 spinners at load 205 |
| this commit at 1.0s added per-call cost | green — 5× past where both earlier versions fail every case |
| against a BSD-style `date` shim | 0 red of 12, where the aligned version was 11 red of 12 |
| must-fail: restore the aligned version | 11 red of 12 under a BSD `date`; 15 assertions down at 0.50s per call |
| **must-fail: delete `set_next_poll_gap`'s squeeze, keep the new clock** | **10 assertions down every run, deterministically** |
| `tools/guard` | exit 0 |
| `skills/orch/tests/run-all.sh` | exit 0, 61 of 61 files |

That last control is the one that matters for a virtual clock: remove what the cases actually test and they still go red. The suite proves what it existed to prove, it just no longer races a real clock to do it.

Verified independently before merge: 8 consecutive runs at 20 pass / 0 fail, and the squeeze mutant reproduced at 10 pass / 10 fail with a clean restore.

The suite also drops from 18s to 1.3s.

## Blast radius was wider than the issue recorded

Under real load the same root also reddened the blip case (`a reading the next poll contradicted is not reported at all`) and the elapsed bound on the unreachable-count case. Same cause, same fix; the issue's list of three assertions was not the full set.

## For KEN-916

The same second-granularity clock sits under **every** compressed-budget `queue-wait` case. Any new case written on a few-second budget needs this treatment or it flakes identically. This lands small and first so that rework rebases over it.

## Not changed

No changelog fragment: test-only, nothing consumer-visible. The rendered copy under `.agents/skills/orch/tests/` moves in the same commit and is `cmp`-identical.

Closes KEN-879
