### PR TITLE
refactor(KEN-909): guard each fact once

### DIFF
--- a/changelog.d/changed/KEN-909.md
+++ b/changelog.d/changed/KEN-909.md
@@ -1,3 +1,3 @@
 - The `kendex` command an installer records is identified by its path alone, and
-  Update now no longer refuses a command that changed under the card: it goes
-  ahead and says what happened to it.
+  Update now no longer refuses a command that changed under the card: it
+  installs and says what became of it.

--- a/changelog.d/changed/KEN-909.md
+++ b/changelog.d/changed/KEN-909.md
@@ -1,0 +1,3 @@
+- The `kendex` command an installer records is identified by its path alone,
+  and the desktop app no longer refuses Update now when what is beside it
+  changed while the card sat on screen.

--- a/changelog.d/changed/KEN-909.md
+++ b/changelog.d/changed/KEN-909.md
@@ -1,3 +1,3 @@
-- The `kendex` command an installer records is identified by its path alone,
-  and the desktop app no longer refuses Update now when what is beside it
-  changed while the card sat on screen.
+- The `kendex` command an installer records is identified by its path alone, and
+  Update now no longer refuses a command that changed under the card: it goes
+  ahead and says what happened to it.

--- a/changelog.d/fixed/KEN-444-command-changed.md
+++ b/changelog.d/fixed/KEN-444-command-changed.md
@@ -1,3 +1,0 @@
-- **Update now** stops instead of going ahead when the `kendex` command
-  beside the app changed since the notice was drawn; the notice reads again
-  and says what is there.

--- a/crates/app/src/app_update.rs
+++ b/crates/app/src/app_update.rs
@@ -256,24 +256,12 @@ fn not_the_command(install: &AppInstall, running: Option<PathBuf>) -> Vec<PathBu
 
 /// Run the command half off the async runtime: it downloads a release
 /// binary over the network, which is not work to hold a runtime worker on.
-///
-/// `shown` is what the card said about this command when it was drawn, and
-/// the lookup runs again here, so the two can disagree: a card is on screen
-/// for as long as a person leaves it there, and what is at a path in that
-/// time is not this app's to control. Disagreeing, nothing is written —
-/// see [`still_as_shown`].
-async fn move_the_command(
-    install: AppInstall,
-    release: String,
-    shown: Option<CommandNotice>,
-) -> Result<CommandHalf, String> {
+async fn move_the_command(install: AppInstall, release: String) -> Result<CommandHalf, String> {
     let feed = feed_url();
     tauri::async_runtime::spawn_blocking(move || {
         let env = Env::detect().map_err(|error| error.to_string())?;
         let beside = command_beside(&env, &install, std::env::var_os("PATH").as_deref());
-        still_as_shown(&beside, shown.as_ref())?;
         bring_command_across(
-            &env,
             &beside,
             &feed,
             &release,
@@ -283,34 +271,6 @@ async fn move_the_command(
     })
     .await
     .map_err(|error| format!("the kendex command half did not run: {error}"))?
-}
-
-/// Whether the command beside the app is still the one the card described.
-///
-/// The card is the whole of what a person is told about that command,
-/// because Update now restarts the app and takes the card with it. A
-/// disposition that changed while the card sat on screen is therefore a
-/// sentence that was never said: an app that went ahead anyway would
-/// replace itself, restart, and leave behind a command nothing had warned
-/// about — the silent split this flow exists to prevent, reached by
-/// another road.
-///
-/// Compared as what was *said*, not as what was found. Two `Ours` at
-/// different paths say the same nothing to a person and are the same
-/// answer here; `Ours` become `NotOurs` says something new, and so does
-/// the reverse, which would touch a file the card promised to leave alone.
-///
-/// Refused before the app half runs, so nothing is written and the card is
-/// still on screen to carry the refusal.
-fn still_as_shown(beside: &CommandBeside, shown: Option<&CommandNotice>) -> Result<(), String> {
-    if CommandNotice::for_card(beside).as_ref() == shown {
-        return Ok(());
-    }
-    Err(
-        "the kendex command beside this app is no longer the one the notice \
-         described, so nothing was updated; the notice now says what is there"
-            .to_owned(),
-    )
 }
 
 /// What to say when the app half would not land. A command already across
@@ -329,11 +289,9 @@ fn app_half_failed(release: &str, half: CommandHalf, error: &str) -> String {
 /// Replace this install with the latest release and relaunch into it,
 /// carrying across a `kendex` command that is kendex's to replace. One
 /// another installer owns stays where it is, named on the card before this
-/// runs; `shown` is what that card said, so a command that changed since is
-/// refused rather than acted on in silence. The manifest names a download
-/// and the signature over it, the release's own digests document names what
-/// this release published for this target, and the app's bytes are held to
-/// both. The discovery feed never supplies an install URL, and the command's
+/// runs. The manifest names a download and the signature over it, the
+/// release's own digests document names what this release published for
+/// this target, and the app's bytes are held to both. The discovery feed never supplies an install URL, and the command's
 /// bytes are held to the key the CLI holds them to. A failure leaves the
 /// running app untouched and usable.
 ///
@@ -346,10 +304,7 @@ fn app_half_failed(release: &str, half: CommandHalf, error: &str) -> String {
 /// would report itself current and never come back for the command.
 #[tauri::command]
 #[specta::specta]
-pub async fn app_update_install(
-    app: tauri::AppHandle,
-    shown: Option<CommandNotice>,
-) -> Result<(), String> {
+pub async fn app_update_install(app: tauri::AppHandle) -> Result<(), String> {
     // The notice offers this on no other channel; the command asks anyway,
     // so nothing a caller gets wrong can overwrite a package manager's files.
     let install = app_install()?;
@@ -366,7 +321,7 @@ pub async fn app_update_install(
         .await
         .map_err(|error| error.to_string())?
         .ok_or_else(|| "this build is already the latest release".to_owned())?;
-    let half = move_the_command(install, update.version.clone(), shown).await?;
+    let half = move_the_command(install, update.version.clone()).await?;
     // Downloaded, then judged, then installed: the plugin's own check runs
     // on the way down, and what this release published for this target says
     // those bytes are the version being installed. The read is blocking, so

--- a/crates/app/src/app_update.rs
+++ b/crates/app/src/app_update.rs
@@ -306,9 +306,11 @@ fn app_half_failed(release: &str, half: CommandHalf, error: &str) -> String {
 /// release published for this target, and the app's bytes are held to both.
 /// The discovery feed never supplies an install URL, and the command's
 /// bytes are held to the key the CLI holds them to. A failure leaves the
-/// running app untouched and usable; the one error that is not a failure is
-/// that report, answered after both halves have landed and in place of the
-/// restart.
+/// running app untouched and usable, and is the `Err` half alone: the
+/// report is `Ok(Some(_))`, answered after both halves have landed and in
+/// place of the restart, so a card carrying it is not calling a finished
+/// update a failure. `Ok(None)` is the restart, which no caller lives to
+/// read.
 ///
 /// The command moves first. What this flow's notice card reads is the
 /// app's own baked version, so the app is the state marker here and is
@@ -322,7 +324,7 @@ fn app_half_failed(release: &str, half: CommandHalf, error: &str) -> String {
 pub async fn app_update_install(
     app: tauri::AppHandle,
     shown: Option<CommandNotice>,
-) -> Result<(), String> {
+) -> Result<Option<String>, String> {
     // The notice offers this on no other channel; the command asks anyway,
     // so nothing a caller gets wrong can overwrite a package manager's files.
     let install = app_install()?;
@@ -359,11 +361,13 @@ pub async fn app_update_install(
     install_published(&digests, bytes, &update)
         .map_err(|error| app_half_failed(&update.version, half, &error))?;
     // Both halves have landed. The restart is what takes the card away, so
-    // anything still owed about the command is owed before it.
+    // anything still owed about the command is owed before it — and the
+    // card is left standing to carry it rather than restarting into a
+    // version with nowhere left to say it.
     if let Some(unsaid) =
         CommandNotice::not_as_shown(&update.version, half, found.as_ref(), shown.as_ref())
     {
-        return Err(unsaid);
+        return Ok(Some(unsaid));
     }
     app.restart()
 }

--- a/crates/app/src/app_update.rs
+++ b/crates/app/src/app_update.rs
@@ -256,18 +256,28 @@ fn not_the_command(install: &AppInstall, running: Option<PathBuf>) -> Vec<PathBu
 
 /// Run the command half off the async runtime: it downloads a release
 /// binary over the network, which is not work to hold a runtime worker on.
-async fn move_the_command(install: AppInstall, release: String) -> Result<CommandHalf, String> {
+///
+/// Answers what the card would say about the command this run found, so
+/// the caller can hold it against what the card said when it was drawn.
+/// The lookup runs again here, so the two can disagree: a card is on
+/// screen for as long as a person leaves it there, and what is at a path
+/// in that time is not this app's to control.
+async fn move_the_command(
+    install: AppInstall,
+    release: String,
+) -> Result<(CommandHalf, Option<CommandNotice>), String> {
     let feed = feed_url();
     tauri::async_runtime::spawn_blocking(move || {
         let env = Env::detect().map_err(|error| error.to_string())?;
         let beside = command_beside(&env, &install, std::env::var_os("PATH").as_deref());
-        bring_command_across(
+        let half = bring_command_across(
             &beside,
             &feed,
             &release,
             env!("KENDEX_TARGET"),
             UPDATER_PUBLIC_KEY,
-        )
+        )?;
+        Ok((half, CommandNotice::for_card(&beside)))
     })
     .await
     .map_err(|error| format!("the kendex command half did not run: {error}"))?
@@ -289,11 +299,16 @@ fn app_half_failed(release: &str, half: CommandHalf, error: &str) -> String {
 /// Replace this install with the latest release and relaunch into it,
 /// carrying across a `kendex` command that is kendex's to replace. One
 /// another installer owns stays where it is, named on the card before this
-/// runs. The manifest names a download and the signature over it, the
-/// release's own digests document names what this release published for
-/// this target, and the app's bytes are held to both. The discovery feed never supplies an install URL, and the command's
+/// runs; `shown` is what that card said, so a command that changed since is
+/// reported rather than acted on in silence — see
+/// [`CommandNotice::not_as_shown`]. The manifest names a download and the
+/// signature over it, the release's own digests document names what this
+/// release published for this target, and the app's bytes are held to both.
+/// The discovery feed never supplies an install URL, and the command's
 /// bytes are held to the key the CLI holds them to. A failure leaves the
-/// running app untouched and usable.
+/// running app untouched and usable; the one error that is not a failure is
+/// that report, answered after both halves have landed and in place of the
+/// restart.
 ///
 /// The command moves first. What this flow's notice card reads is the
 /// app's own baked version, so the app is the state marker here and is
@@ -304,7 +319,10 @@ fn app_half_failed(release: &str, half: CommandHalf, error: &str) -> String {
 /// would report itself current and never come back for the command.
 #[tauri::command]
 #[specta::specta]
-pub async fn app_update_install(app: tauri::AppHandle) -> Result<(), String> {
+pub async fn app_update_install(
+    app: tauri::AppHandle,
+    shown: Option<CommandNotice>,
+) -> Result<(), String> {
     // The notice offers this on no other channel; the command asks anyway,
     // so nothing a caller gets wrong can overwrite a package manager's files.
     let install = app_install()?;
@@ -321,7 +339,7 @@ pub async fn app_update_install(app: tauri::AppHandle) -> Result<(), String> {
         .await
         .map_err(|error| error.to_string())?
         .ok_or_else(|| "this build is already the latest release".to_owned())?;
-    let half = move_the_command(install, update.version.clone()).await?;
+    let (half, found) = move_the_command(install, update.version.clone()).await?;
     // Downloaded, then judged, then installed: the plugin's own check runs
     // on the way down, and what this release published for this target says
     // those bytes are the version being installed. The read is blocking, so
@@ -340,6 +358,13 @@ pub async fn app_update_install(app: tauri::AppHandle) -> Result<(), String> {
     let digests = read.map_err(|error| app_half_failed(&update.version, half, &error))?;
     install_published(&digests, bytes, &update)
         .map_err(|error| app_half_failed(&update.version, half, &error))?;
+    // Both halves have landed. The restart is what takes the card away, so
+    // anything still owed about the command is owed before it.
+    if let Some(unsaid) =
+        CommandNotice::not_as_shown(&update.version, half, found.as_ref(), shown.as_ref())
+    {
+        return Err(unsaid);
+    }
     app.restart()
 }
 

--- a/crates/app/src/app_update/tests.rs
+++ b/crates/app/src/app_update/tests.rs
@@ -211,12 +211,6 @@ impl kendex_core::install_channel::HostProbe for OnlyWritable {
         path.to_owned()
     }
 
-    /// Nothing routed through this fake asks either: `for_app` judges a
-    /// path, never the bytes at it.
-    fn digest(&self, _: &std::path::Path) -> Option<String> {
-        None
-    }
-
     fn on_path(&self, _: &str) -> bool {
         false
     }
@@ -319,7 +313,7 @@ fn the_app_s_own_image_is_never_the_command_it_carries() {
     // `AppImage(None)` rather than `WindowsInstaller`, because on Windows
     // this process's own executable is excluded too and a test binary is
     // not the app.
-    kendex_core::command_update::record_installed(&env, &image).unwrap();
+    kendex_core::command_update::record_command(&env, &image).unwrap();
     assert_eq!(
         command_beside(&env, &AppInstall::AppImage(None), Some(&path_var)),
         ours
@@ -352,93 +346,4 @@ fn the_running_executable_is_excluded_where_the_updater_names_no_path() {
         vec![inside, image],
         "neither the mounted executable nor the image it came from is the command"
     );
-}
-
-/// One machine with a `kendex` command an installer recorded, and the
-/// notice the card would have drawn for it.
-#[allow(clippy::unwrap_used)]
-fn a_recorded_command(dir: &tempfile::TempDir) -> (Env, std::ffi::OsString, PathBuf) {
-    let bin = dir.path().join("bin");
-    std::fs::create_dir_all(&bin).unwrap();
-    let command = bin.join("kendex");
-    std::fs::write(&command, b"the kendex command an installer put here").unwrap();
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&command, std::fs::Permissions::from_mode(0o755)).unwrap();
-    }
-    let env = Env::host_rooted(dir.path());
-    kendex_core::command_update::record_installed(&env, &command).unwrap();
-    (env, std::ffi::OsString::from(&bin), command)
-}
-
-/// A card is on screen for as long as a person leaves it there, and what
-/// is at a path in that time is not this app's to control. The lookup runs
-/// again when Update now is pressed, so it can answer differently from the
-/// card — and going ahead on the new answer replaces the app, restarts it,
-/// and takes away the only surface that could have said the command was
-/// left behind. So the install is refused instead, before anything is
-/// written.
-///
-/// Driven through the real lookup rather than a described state: the file
-/// at the recorded path is replaced between the two reads, which is the
-/// finding's own scenario.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_command_that_changed_under_the_card_refuses_the_install() {
-    if no_record_on_this_runner() {
-        return;
-    }
-    let dir = tempfile::tempdir().unwrap();
-    let (env, path_var, command) = a_recorded_command(&dir);
-    let install = AppInstall::AppImage(None);
-    let drawn = command_beside(&env, &install, Some(&path_var));
-    let card = CommandNotice::for_card(&drawn);
-
-    // The control: unchanged, the install goes ahead exactly as before.
-    assert_eq!(card, None, "a recorded command is the app's to carry");
-    still_as_shown(&drawn, card.as_ref()).unwrap();
-
-    // Someone replaces the recorded binary with a wrapper of their own.
-    std::fs::write(&command, b"#!/bin/sh\nexec /opt/kendex/kendex \"$@\"\n").unwrap();
-    let now = command_beside(&env, &install, Some(&path_var));
-    assert_eq!(
-        CommandNotice::for_card(&now),
-        Some(CommandNotice::Unknown),
-        "the fixture only means something if the answer actually changed"
-    );
-
-    let refused = still_as_shown(&now, card.as_ref()).unwrap_err();
-    assert!(
-        refused.contains("no longer the one the notice"),
-        "{refused}"
-    );
-    assert!(refused.contains("nothing was updated"), "{refused}");
-}
-
-/// The other direction, and why it is refused too: the card said the app
-/// moves alone, and the command has since become one this app would
-/// replace. Going ahead would write over a file the person was told would
-/// be left where it is.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_command_that_became_ours_under_the_card_refuses_too() {
-    if no_record_on_this_runner() {
-        return;
-    }
-    let dir = tempfile::tempdir().unwrap();
-    let (env, path_var, command) = a_recorded_command(&dir);
-    let install = AppInstall::AppImage(None);
-    // Nothing recorded yet, as far as this card knows.
-    let card = Some(CommandNotice::Unknown);
-
-    let now = command_beside(&env, &install, Some(&path_var));
-
-    assert_eq!(
-        now,
-        CommandBeside::Ours(Host.resolve(&command)),
-        "the fixture only means something if the answer actually changed"
-    );
-    let refused = still_as_shown(&now, card.as_ref()).unwrap_err();
-    assert!(refused.contains("nothing was updated"), "{refused}");
 }

--- a/crates/app/src/app_update/tests.rs
+++ b/crates/app/src/app_update/tests.rs
@@ -347,3 +347,80 @@ fn the_running_executable_is_excluded_where_the_updater_names_no_path() {
         "neither the mounted executable nor the image it came from is the command"
     );
 }
+
+/// One machine with a `kendex` command an installer recorded, and the
+/// notice the card would have drawn for it.
+#[allow(clippy::unwrap_used)]
+fn a_recorded_command(dir: &tempfile::TempDir) -> (Env, std::ffi::OsString, PathBuf) {
+    let bin = dir.path().join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    let command = bin.join("kendex");
+    std::fs::write(&command, b"the kendex command an installer put here").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&command, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    let env = Env::host_rooted(dir.path());
+    kendex_core::command_update::record_command(&env, &command).unwrap();
+    (env, std::ffi::OsString::from(&bin), command)
+}
+
+/// A card is on screen for as long as a person leaves it there, and what
+/// is beside the app in that time is not this app's to control. The lookup
+/// runs again when Update now is pressed, so it can answer differently
+/// from the card — and the command half then acts on the new answer, which
+/// here means leaving behind a command the card offered to carry across.
+/// The restart takes the card away, so the split is spoken before it.
+///
+/// Driven through the real lookup rather than a described state: a second
+/// install records its own `kendex` between the two reads, and the command
+/// beside this app is one nothing vouches for any more.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_command_that_changed_under_the_card_is_reported_before_the_restart() {
+    if no_record_on_this_runner() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let (env, path_var, _) = a_recorded_command(&dir);
+    let install = AppInstall::AppImage(None);
+    let card = CommandNotice::for_card(&command_beside(&env, &install, Some(&path_var)));
+
+    // The control: unchanged, both halves land and nothing is owed.
+    assert_eq!(card, None, "a recorded command is the app's to carry");
+    assert_eq!(
+        CommandNotice::not_as_shown("5.1.0", CommandHalf::Moved, card.as_ref(), card.as_ref()),
+        None
+    );
+
+    kendex_core::command_update::record_command(&env, &dir.path().join("other/kendex")).unwrap();
+    let now = CommandNotice::for_card(&command_beside(&env, &install, Some(&path_var)));
+    assert_eq!(
+        now,
+        Some(CommandNotice::Unknown),
+        "the fixture only means something if the answer actually changed"
+    );
+
+    let told =
+        CommandNotice::not_as_shown("5.1.0", CommandHalf::Untouched, now.as_ref(), card.as_ref())
+            .expect("a command the card offered to carry across, left behind, has to be said");
+    assert!(told.contains("kendex 5.1.0 is installed"), "{told}");
+    assert!(told.contains("left on the release it is on"), "{told}");
+}
+
+/// The other direction, and why it is said too: the card offered no
+/// command, and the app replaced one anyway. A person told the file would
+/// be left alone hears that it was not.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_command_that_became_ours_under_the_card_is_reported_too() {
+    let told = CommandNotice::not_as_shown(
+        "5.1.0",
+        CommandHalf::Moved,
+        None,
+        Some(&CommandNotice::Unknown),
+    )
+    .expect("a command the card promised to leave alone, replaced, has to be said");
+    assert!(told.contains("carried across"), "{told}");
+}

--- a/crates/app/src/app_update/tests.rs
+++ b/crates/app/src/app_update/tests.rs
@@ -1,9 +1,11 @@
+#[cfg(unix)]
 use kendex_core::install_channel::HostProbe as _;
 
 use super::*;
 
 #[path = "../../../test_util.rs"]
 mod test_util;
+#[cfg(unix)]
 use test_util::no_record_on_this_runner;
 
 #[test]
@@ -279,6 +281,13 @@ fn a_failed_app_half_says_whether_the_command_went_ahead_of_it() {
 /// never inside it. Read as a difference rather than an absolute, because
 /// the candidate list ends with a system path this machine may well have a
 /// kendex in.
+///
+/// Unix only, because there is no command beside the app on Windows: the
+/// installer carries the app alone, so the name there only ever fails to
+/// exist and every lookup below would answer `Absent` — which the first
+/// assertion, a difference, would pass without reaching the exclusion it
+/// is about.
+#[cfg(unix)]
 #[test]
 fn the_app_s_own_image_is_never_the_command_it_carries() {
     if no_record_on_this_runner() {
@@ -350,6 +359,7 @@ fn the_running_executable_is_excluded_where_the_updater_names_no_path() {
 
 /// One machine with a `kendex` command an installer recorded, and the
 /// notice the card would have drawn for it.
+#[cfg(unix)]
 #[allow(clippy::unwrap_used)]
 fn a_recorded_command(dir: &tempfile::TempDir) -> (Env, std::ffi::OsString, PathBuf) {
     let bin = dir.path().join("bin");
@@ -375,6 +385,11 @@ fn a_recorded_command(dir: &tempfile::TempDir) -> (Env, std::ffi::OsString, Path
 /// Driven through the real lookup rather than a described state: a second
 /// install records its own `kendex` between the two reads, and the command
 /// beside this app is one nothing vouches for any more.
+///
+/// Unix only, for the same reason: the second answer is a command found by
+/// name on `PATH` and vouched for by nobody, and Windows has no command
+/// beside the app to find.
+#[cfg(unix)]
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_command_that_changed_under_the_card_answers_differently() {

--- a/crates/app/src/app_update/tests.rs
+++ b/crates/app/src/app_update/tests.rs
@@ -369,16 +369,15 @@ fn a_recorded_command(dir: &tempfile::TempDir) -> (Env, std::ffi::OsString, Path
 /// A card is on screen for as long as a person leaves it there, and what
 /// is beside the app in that time is not this app's to control. The lookup
 /// runs again when Update now is pressed, so it can answer differently
-/// from the card — and the command half then acts on the new answer, which
-/// here means leaving behind a command the card offered to carry across.
-/// The restart takes the card away, so the split is spoken before it.
+/// from the card — which is what [`CommandNotice::not_as_shown`] is handed,
+/// and what the notice tests then hold each sentence against.
 ///
 /// Driven through the real lookup rather than a described state: a second
 /// install records its own `kendex` between the two reads, and the command
 /// beside this app is one nothing vouches for any more.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn a_command_that_changed_under_the_card_is_reported_before_the_restart() {
+fn a_command_that_changed_under_the_card_answers_differently() {
     if no_record_on_this_runner() {
         return;
     }
@@ -386,41 +385,13 @@ fn a_command_that_changed_under_the_card_is_reported_before_the_restart() {
     let (env, path_var, _) = a_recorded_command(&dir);
     let install = AppInstall::AppImage(None);
     let card = CommandNotice::for_card(&command_beside(&env, &install, Some(&path_var)));
-
-    // The control: unchanged, both halves land and nothing is owed.
     assert_eq!(card, None, "a recorded command is the app's to carry");
-    assert_eq!(
-        CommandNotice::not_as_shown("5.1.0", CommandHalf::Moved, card.as_ref(), card.as_ref()),
-        None
-    );
 
     kendex_core::command_update::record_command(&env, &dir.path().join("other/kendex")).unwrap();
-    let now = CommandNotice::for_card(&command_beside(&env, &install, Some(&path_var)));
+
     assert_eq!(
-        now,
+        CommandNotice::for_card(&command_beside(&env, &install, Some(&path_var))),
         Some(CommandNotice::Unknown),
-        "the fixture only means something if the answer actually changed"
+        "a second install recorded its own kendex and this one still reads as ours"
     );
-
-    let told =
-        CommandNotice::not_as_shown("5.1.0", CommandHalf::Untouched, now.as_ref(), card.as_ref())
-            .expect("a command the card offered to carry across, left behind, has to be said");
-    assert!(told.contains("kendex 5.1.0 is installed"), "{told}");
-    assert!(told.contains("left on the release it is on"), "{told}");
-}
-
-/// The other direction, and why it is said too: the card offered no
-/// command, and the app replaced one anyway. A person told the file would
-/// be left alone hears that it was not.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_command_that_became_ours_under_the_card_is_reported_too() {
-    let told = CommandNotice::not_as_shown(
-        "5.1.0",
-        CommandHalf::Moved,
-        None,
-        Some(&CommandNotice::Unknown),
-    )
-    .expect("a command the card promised to leave alone, replaced, has to be said");
-    assert!(told.contains("carried across"), "{told}");
 }

--- a/crates/cli/src/commands/update.rs
+++ b/crates/cli/src/commands/update.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use kendex_core::command_update::{fetch, record_command, record_installed, replace_executable};
+use kendex_core::command_update::{fetch, record_command, replace_executable};
 use kendex_core::env::Env;
 use kendex_core::install_channel::{Host, HostProbe, InstallChannel, for_cli};
 use kendex_core::names::shown;
@@ -96,7 +96,7 @@ fn run_on(
     // is fetched, so a machine that installed before this record existed
     // gains it from any run — including one that finds nothing to do — and
     // the desktop app can carry the command across from then on.
-    if let Err(why) = record_installed(env, current_exe) {
+    if let Err(why) = record_command(env, current_exe) {
         say(&format!(
             "the desktop app will not update this command until it can be recorded: {why}"
         ));
@@ -158,15 +158,6 @@ fn run_on(
     });
     if let Err(error) = installed {
         return Err(command_failure(latest, app_replaced, &error).into());
-    }
-    // The record above named the bytes that were here; these are the bytes
-    // that replaced them. Left stale it stops matching, and the app then
-    // refuses a command it does own — the safe direction, and one the next
-    // run of this command undoes either way.
-    if let Err(why) = record_command(env, current_exe, &binary) {
-        say(&format!(
-            "the desktop app will not update this command until it can be recorded: {why}"
-        ));
     }
     out(&format!("updated to {latest}"));
     Ok(())

--- a/crates/cli/src/commands/update/tests.rs
+++ b/crates/cli/src/commands/update/tests.rs
@@ -447,12 +447,6 @@ fn missing_asset_message_never_calls_current_or_older_available() {
 /// run is the one place that knows. So it records the path, on a run that
 /// updated and on one that found nothing to do, which is how an install
 /// made before the record existed gains one.
-///
-/// And it records what is at that path, not only the path: a name outlives
-/// whatever answered to it, so the digest is what tells this binary from
-/// the next file to arrive under its name. Which means the record has to
-/// follow the write — left naming the bytes this run replaced, it would
-/// refuse the app the command it just brought current.
 #[test]
 fn an_update_records_the_command_it_is_running_as() {
     if no_record_on_this_runner() {
@@ -482,21 +476,14 @@ fn an_update_records_the_command_it_is_running_as() {
             kendex_core::command_update::recorded_command(&env),
             Some(kendex_core::command_update::InstalledCommand {
                 path: installed.clone(),
-                digest: kendex_core::hash::sha256_hex(OFFERED),
             }),
             "force: {force}"
-        );
-        assert_ne!(
-            kendex_core::hash::sha256_hex(OFFERED),
-            kendex_core::hash::sha256_hex(INSTALLED),
-            "the two digests have to differ or the assertion above proves nothing"
         );
     }
 }
 
-/// A run that finds nothing to do still records, and records the bytes
-/// that are there — the path is what an install made before this record
-/// existed is missing, and the digest is what makes it usable.
+/// A run that finds nothing to do still records: the path is what an
+/// install made before this record existed is missing.
 #[test]
 fn a_run_with_nothing_to_do_records_the_bytes_already_installed() {
     if no_record_on_this_runner() {
@@ -530,10 +517,7 @@ fn a_run_with_nothing_to_do_records_the_bytes_already_installed() {
     assert_eq!(std::fs::read(&installed).unwrap(), INSTALLED);
     assert_eq!(
         kendex_core::command_update::recorded_command(&env),
-        Some(kendex_core::command_update::InstalledCommand {
-            path: installed,
-            digest: kendex_core::hash::sha256_hex(INSTALLED),
-        })
+        Some(kendex_core::command_update::InstalledCommand { path: installed })
     );
 }
 

--- a/crates/cli/src/commands/update/tests.rs
+++ b/crates/cli/src/commands/update/tests.rs
@@ -485,7 +485,7 @@ fn an_update_records_the_command_it_is_running_as() {
 /// A run that finds nothing to do still records: the path is what an
 /// install made before this record existed is missing.
 #[test]
-fn a_run_with_nothing_to_do_records_the_bytes_already_installed() {
+fn a_run_with_nothing_to_do_still_records_the_command() {
     if no_record_on_this_runner() {
         return;
     }

--- a/crates/cli/tests/command_record.rs
+++ b/crates/cli/tests/command_record.rs
@@ -19,7 +19,7 @@ mod test_util;
 use test_util::{no_record_on_this_runner, rooted};
 
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::{Command, Output};
 
 fn kendex(home: &Path, args: &[&str]) -> Output {
@@ -73,63 +73,6 @@ fn ran_within(home: &Path, args: &[&str], limit: std::time::Duration) -> bool {
     }
 }
 
-/// The time a file was last written.
-#[allow(clippy::expect_used)]
-fn modified(path: &Path) -> std::time::SystemTime {
-    fs::metadata(path)
-        .and_then(|found| found.modified())
-        .unwrap_or_else(|error| panic!("no timestamp on {}: {error}", path.display()))
-}
-
-/// The file this test binary runs the command from, under the one spelling
-/// a run of it reports back: `current_exe` is resolved before it is
-/// recorded, so a fixture naming the unresolved path would compare unequal
-/// on any host whose temporary or target tree runs through a link.
-#[allow(clippy::expect_used)]
-fn the_command_that_runs() -> PathBuf {
-    fs::canonicalize(env!("CARGO_BIN_EXE_kendex")).expect("the built binary canonicalizes")
-}
-
-/// A record written when the command was installed, with the bytes it names
-/// replaced afterwards — the ordering a real install has and a fixture does
-/// not, since it writes both within one millisecond.
-///
-/// A run reads that ordering to decide the bytes may have moved at all, so
-/// a fixture that left the record newer would be answered by the timestamps
-/// and never reach the case it is about.
-#[allow(clippy::expect_used)]
-fn installed_before_the_bytes_were_replaced(record: &Path, bytes: &Path) {
-    let written = fs::metadata(bytes)
-        .and_then(|bytes| bytes.modified())
-        .expect("the fixture command carries a timestamp");
-    fs::File::options()
-        .write(true)
-        .open(record)
-        .and_then(|file| file.set_modified(written - std::time::Duration::from_secs(60)))
-        .expect("the fixture record takes a timestamp");
-}
-
-/// The same ordering for a link, whose own timestamps the standard library
-/// cannot reach: opening one follows it, so `set_modified` would stamp the
-/// file at the other end. `touch -h` reaches them, and the GNU and BSD
-/// builds both carry it.
-#[allow(clippy::expect_used)]
-fn older_than_the_command(link: &Path, command: &Path) {
-    let reference = link
-        .parent()
-        .expect("the fixture link sits in a directory")
-        .join("fixture-timestamp");
-    fs::write(&reference, "").expect("the fixture reference is written");
-    installed_before_the_bytes_were_replaced(&reference, command);
-    let stamped = Command::new("touch")
-        .args(["-h", "-r"])
-        .args([&reference, &link.to_path_buf()])
-        .status()
-        .expect("touch runs");
-    assert!(stamped.success(), "the fixture link took no timestamp");
-    fs::remove_file(&reference).expect("the fixture reference is removed");
-}
-
 /// An install made before the record existed has none, and its owner has
 /// no reason to reach for `update` rather than any other verb. Whichever
 /// they run, the app can carry the command across afterwards.
@@ -161,11 +104,6 @@ fn any_verb_records_the_command_an_install_never_recorded() {
         recorded.path,
         std::fs::canonicalize(env!("CARGO_BIN_EXE_kendex")).unwrap(),
         "the record names a file other than the one that ran"
-    );
-    assert_eq!(
-        recorded.digest,
-        kendex_core::hash::sha256_hex(&fs::read(env!("CARGO_BIN_EXE_kendex")).unwrap()),
-        "the record names bytes other than the ones that ran"
     );
 }
 
@@ -246,61 +184,6 @@ fn a_record_already_there_is_not_written_over_by_a_first_run() {
     );
 }
 
-/// Concurrent first runs leave one whole record and nothing beside it.
-///
-/// Not a proof of the ordering — two threads rarely land inside the window
-/// that would show it, and a version deciding by reading passes this too.
-/// What it does hold is the staging: the file each writer prepares has to
-/// be its own, and a name built from the process id alone is not, which is
-/// how the pair came to overwrite each other's staged copy the first time
-/// this ran.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn concurrent_first_runs_leave_one_whole_record() {
-    if no_record_on_this_runner() {
-        return;
-    }
-    let tmp = tempfile::tempdir().unwrap();
-    let home = rooted(&tmp);
-    let env = kendex_core::env::Env::host_rooted(&home);
-    let theirs = home.join("theirs/kendex");
-    let second = home.join("second/kendex");
-    for (path, bytes) in [
-        (&theirs, b"the kendex they installed".as_slice()),
-        (&second, b"a second copy of kendex".as_slice()),
-    ] {
-        fs::create_dir_all(path.parent().unwrap()).unwrap();
-        fs::write(path, bytes).unwrap();
-    }
-
-    let both = std::thread::scope(|scope| {
-        let a = scope.spawn(|| kendex_core::command_update::record_first_run(&env, &theirs));
-        let b = scope.spawn(|| kendex_core::command_update::record_first_run(&env, &second));
-        (a.join().unwrap(), b.join().unwrap())
-    });
-    assert!(both.0.is_ok() && both.1.is_ok(), "{both:?}");
-
-    // Whichever won, the record names one of them whole and nothing was
-    // left staged beside it.
-    let recorded = kendex_core::command_update::recorded_command(&env).unwrap();
-    assert!(
-        recorded.path == theirs || recorded.path == second,
-        "the record names {}",
-        recorded.path.display()
-    );
-    assert_eq!(
-        recorded.digest,
-        kendex_core::hash::sha256_hex(&fs::read(&recorded.path).unwrap()),
-        "the record names bytes other than the ones at the path it names"
-    );
-    let beside: Vec<_> = fs::read_dir(env.installed_command_file().parent().unwrap())
-        .unwrap()
-        .filter_map(|entry| entry.ok().map(|entry| entry.file_name()))
-        .filter(|name| name.to_string_lossy().starts_with("installed-command."))
-        .collect();
-    assert!(beside.is_empty(), "staged files left behind: {beside:?}");
-}
-
 /// The record a person's install already has is not taken off it by a
 /// second kendex they happen to run once. Left unguarded, the app would
 /// carry across the copy nobody uses and leave the one they do.
@@ -316,7 +199,7 @@ fn a_run_does_not_take_the_record_off_another_install() {
     let theirs = home.join("bin/kendex");
     fs::create_dir_all(theirs.parent().unwrap()).unwrap();
     fs::write(&theirs, b"the kendex install.sh put here").unwrap();
-    kendex_core::command_update::record_installed(&env, &theirs).unwrap();
+    kendex_core::command_update::record_command(&env, &theirs).unwrap();
 
     kendex(&home, &["verify"]);
 
@@ -327,60 +210,17 @@ fn a_run_does_not_take_the_record_off_another_install() {
     );
 }
 
-/// The bytes a record names after the run that replaced them wrote no
-/// record. What an elevated `kendex update` leaves behind: the path is
-/// still the person's command, the digest is a file that is gone, and
-/// `command_beside_app` stops matching the one command the card was
-/// offering.
-const REPLACED: &[u8] = b"the bytes an elevated update replaced";
-
-/// A replacement made with privilege the app lacks writes no record at
-/// all, so this one keeps naming bytes that are gone. The next run from
-/// the recorded path is running those new bytes, which is the same proof
-/// a first run offers, and it says what is there now.
-///
-/// Read back through the resolver rather than off the file: what has to
-/// hold is the answer the app gets, and a test that parses the file itself
-/// would pass for a record the app reads as none.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_run_from_the_recorded_path_says_what_replaced_its_bytes() {
-    if no_record_on_this_runner() {
-        return;
-    }
-    let tmp = tempfile::tempdir().unwrap();
-    let home = rooted(&tmp);
-    let env = kendex_core::env::Env::host_rooted(&home);
-    let installed = the_command_that_runs();
-    kendex_core::command_update::record_command(&env, &installed, REPLACED).unwrap();
-    installed_before_the_bytes_were_replaced(&env.installed_command_file(), &installed);
-
-    kendex(&home, &["verify"]);
-
-    let recorded = kendex_core::command_update::recorded_command(&env)
-        .unwrap_or_else(|| panic!("no record at {}", env.installed_command_file().display()));
-    assert_eq!(
-        recorded.path, installed,
-        "the run moved the record off the path it was installed at"
-    );
-    assert_eq!(
-        recorded.digest,
-        kendex_core::hash::sha256_hex(&fs::read(&installed).unwrap()),
-        "the record still names the bytes the elevated run replaced"
-    );
-}
-
-/// The same, where the data directory is the one `XDG_DATA_HOME` names
-/// rather than the one under `HOME`. The withdrawn fix carried `HOME` onto
-/// a `sudo` line and so was correct only for people who do not set this;
-/// a record written by the person's own run reads their own variable.
+/// The record a run writes is the one `XDG_DATA_HOME` names rather than the
+/// one under `HOME`. The withdrawn fix carried `HOME` onto a `sudo` line and
+/// so was correct only for people who do not set this; a record written by
+/// the person's own run reads their own variable.
 ///
 /// Linux alone: `XDG_DATA_HOME` is the layout `dirs` reads there, and the
 /// macOS layout has no such variable to honour.
 #[test]
 #[cfg(target_os = "linux")]
 #[allow(clippy::unwrap_used)]
-fn the_record_a_run_moves_is_the_one_xdg_data_home_names() {
+fn the_record_a_run_writes_is_the_one_xdg_data_home_names() {
     if no_record_on_this_runner() {
         return;
     }
@@ -392,135 +232,19 @@ fn the_record_a_run_moves_is_the_one_xdg_data_home_names() {
     let elsewhere = home.join("elsewhere");
     let env = kendex_core::env::Env::host_rooted(&elsewhere);
     let data_home = elsewhere.join(".local/share");
-    let installed = the_command_that_runs();
-    kendex_core::command_update::record_command(&env, &installed, REPLACED).unwrap();
-    installed_before_the_bytes_were_replaced(&env.installed_command_file(), &installed);
 
     kendex_with(&home, &[("XDG_DATA_HOME", &data_home)], &["verify"]);
 
-    let recorded = kendex_core::command_update::recorded_command(&env)
-        .unwrap_or_else(|| panic!("no record at {}", env.installed_command_file().display()));
     assert_eq!(
-        recorded.digest,
-        kendex_core::hash::sha256_hex(&fs::read(&installed).unwrap()),
-        "the run read a data directory other than the one it was given"
+        kendex_core::command_update::recorded_command(&env).map(|record| record.path),
+        Some(std::fs::canonicalize(env!("CARGO_BIN_EXE_kendex")).unwrap()),
+        "the run wrote to a data directory other than the one it was given"
     );
     assert!(
         !kendex_core::env::Env::host_rooted(&home)
             .installed_command_file()
             .exists(),
         "the run wrote a second record under HOME, so the assertion above proves nothing"
-    );
-}
-
-/// Only the digest moves, and only for the file the run is executing. A
-/// record naming another install whose bytes have also been replaced is
-/// left exactly as it is: repointing a record by path is what
-/// `record_first_run` refuses, and a version that acted on the mismatch
-/// alone would take a person's record off the copy they run.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_run_does_not_say_what_replaced_another_installs_bytes() {
-    if no_record_on_this_runner() {
-        return;
-    }
-    let tmp = tempfile::tempdir().unwrap();
-    let home = rooted(&tmp);
-    let env = kendex_core::env::Env::host_rooted(&home);
-    let theirs = home.join("bin/kendex");
-    fs::create_dir_all(theirs.parent().unwrap()).unwrap();
-    fs::write(&theirs, b"the kendex install.sh put here").unwrap();
-    kendex_core::command_update::record_command(&env, &theirs, REPLACED).unwrap();
-    // Older than the bytes at both paths, so the timestamps let the run
-    // reach the case and the path is the only thing that can refuse it.
-    installed_before_the_bytes_were_replaced(&env.installed_command_file(), &theirs);
-    let before = fs::read_to_string(env.installed_command_file()).unwrap();
-
-    kendex(&home, &["verify"]);
-
-    assert_eq!(
-        fs::read_to_string(env.installed_command_file()).unwrap(),
-        before,
-        "a run rewrote a record naming a file it was not running from"
-    );
-}
-
-/// A record whose path and digest both still describe the file keeps its
-/// content, and comes out of the run saying which version of the command
-/// it describes.
-///
-/// The content is half the answer. The other half is the timestamp: an
-/// elevated `update --force` installs the same bytes again and leaves the
-/// command newer than a record that already names it, so a run that read,
-/// hashed and then left the timestamp alone would leave that true forever
-/// and every later run would read and hash the whole command for nothing.
-/// Carrying the command's own time onto the record is what closes it, and
-/// the assertion below is that closure rather than a proxy for it: the run
-/// reads on only where the command is strictly newer.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_record_that_still_matches_keeps_its_content_and_stops_being_reread() {
-    if no_record_on_this_runner() {
-        return;
-    }
-    let tmp = tempfile::tempdir().unwrap();
-    let home = rooted(&tmp);
-    let env = kendex_core::env::Env::host_rooted(&home);
-    let installed = the_command_that_runs();
-    let bytes = fs::read(&installed).unwrap();
-    kendex_core::command_update::record_command(&env, &installed, &bytes).unwrap();
-    // Backdated for the same reason the replacement cases are: without it
-    // the timestamps refuse the case and this passes without the digest
-    // ever being compared.
-    installed_before_the_bytes_were_replaced(&env.installed_command_file(), &installed);
-    let written = fs::read_to_string(env.installed_command_file()).unwrap();
-
-    kendex(&home, &["verify"]);
-
-    assert_eq!(
-        fs::read_to_string(env.installed_command_file()).unwrap(),
-        written,
-        "a record naming the bytes that are there was rewritten"
-    );
-    assert_eq!(
-        modified(&env.installed_command_file()),
-        modified(&installed),
-        "the record still reads older than the command, so every later run rereads it"
-    );
-}
-
-/// What a repair leaves behind is the command's own time, not the moment
-/// the record was written.
-///
-/// The difference is a replacement landing between the read and the write.
-/// Stamped with the clock, that record would name the bytes this run read
-/// while claiming to be newer than the ones that replaced them, and no
-/// later run would ever look again: the state this whole change exists to
-/// repair, made permanent. Stamped with the time of the file that was
-/// read, the newer bytes are still newer and the next run repairs them.
-///
-/// The interleaving itself is not driven here. Landing a replacement
-/// inside that window needs a seam in the code under test, and this
-/// asserts the property that makes the window harmless instead.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_repair_leaves_the_record_naming_the_bytes_it_read() {
-    if no_record_on_this_runner() {
-        return;
-    }
-    let tmp = tempfile::tempdir().unwrap();
-    let home = rooted(&tmp);
-    let env = kendex_core::env::Env::host_rooted(&home);
-    let installed = the_command_that_runs();
-    kendex_core::command_update::record_command(&env, &installed, REPLACED).unwrap();
-    installed_before_the_bytes_were_replaced(&env.installed_command_file(), &installed);
-
-    kendex(&home, &["verify"]);
-
-    assert_eq!(
-        modified(&env.installed_command_file()),
-        modified(&installed),
-        "the repaired record was stamped with the clock rather than the command it read"
     );
 }
 
@@ -554,14 +278,9 @@ fn a_pipe_at_the_record_path_does_not_hold_the_command() {
 }
 
 /// A link at the record path is a name somebody else chose, and a write
-/// through it lands on the file at the other end. The record path is only
-/// ever a plain file this install wrote, so a link there is refused and the
+/// through it lands on the file at the other end. A first run creates the
+/// record rather than writing it, so the name is already taken and the
 /// file it points at is left alone.
-///
-/// The link is backdated rather than the file it names: the run reads the
-/// link's own timestamp to decide the command may have moved, so a link
-/// made just now would be refused by the timestamps and this would pass
-/// without the link ever being the reason.
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_link_at_the_record_path_is_not_written_through() {
@@ -573,24 +292,10 @@ fn a_link_at_the_record_path_is_not_written_through() {
     let env = kendex_core::env::Env::host_rooted(&home);
     let file = env.installed_command_file();
     fs::create_dir_all(file.parent().unwrap()).unwrap();
-    let installed = the_command_that_runs();
-    // A whole, valid record naming the running command with bytes that are
-    // gone: follow the link and there is every reason to rewrite it.
     let aimed_at = home.join("someone-elses-file");
-    fs::write(
-        &aimed_at,
-        format!(
-            "{}
-{}
-",
-            installed.display(),
-            kendex_core::hash::sha256_hex(REPLACED)
-        ),
-    )
-    .unwrap();
-    let theirs = fs::read_to_string(&aimed_at).unwrap();
+    let theirs = "whatever they keep here\n";
+    fs::write(&aimed_at, theirs).unwrap();
     std::os::unix::fs::symlink(&aimed_at, &file).unwrap();
-    older_than_the_command(&file, &installed);
 
     kendex(&home, &["verify"]);
 

--- a/crates/cli/tests/command_record.rs
+++ b/crates/cli/tests/command_record.rs
@@ -185,14 +185,16 @@ fn a_record_already_there_is_not_written_over_by_a_first_run() {
     );
 }
 
-/// Concurrent first runs leave one whole record and nothing beside it.
+/// Concurrent first runs both answer `Ok` and leave one readable record,
+/// naming one of the two files that ran.
 ///
-/// Not a proof of the ordering — two threads rarely land inside the window
-/// that would show it, and a version deciding by reading passes this too.
-/// What stands behind it is `create_new`: the name is taken or it is not,
-/// so the run that loses writes nothing at all, and the record reads as
-/// the one line the other put there rather than as two answers over each
-/// other.
+/// Not a proof of the ordering, and not what holds `create_new` either: a
+/// writer that truncated and rewrote would pass this too, because each of
+/// the two writes a whole line. What reds on that is
+/// `a_record_already_there_is_not_written_over_by_a_first_run`, which has
+/// a record it must leave alone. What is left here is the pair — two runs
+/// starting together neither fail nor leave the record unreadable between
+/// them.
 #[test]
 #[allow(clippy::unwrap_used)]
 fn concurrent_first_runs_leave_one_whole_record() {
@@ -230,6 +232,8 @@ fn concurrent_first_runs_leave_one_whole_record() {
         format!("{}\n", recorded.path.display()),
         "the record holds more than the line the run that won wrote"
     );
+    // Nothing writes a name like that today: this guards against a staged
+    // write coming back, not against one a writer here makes.
     let beside: Vec<_> = fs::read_dir(env.installed_command_file().parent().unwrap())
         .unwrap()
         .filter_map(|entry| entry.ok().map(|entry| entry.file_name()))

--- a/crates/cli/tests/command_record.rs
+++ b/crates/cli/tests/command_record.rs
@@ -140,8 +140,9 @@ fn the_forms_clap_answers_itself_record_the_command_too() {
 /// last. Refusing the name that is taken cannot do that.
 ///
 /// The unparseable record itself stays; `kendex update` rewrites it,
-/// because that is the run replacing the bytes. Until then the app reads
-/// no record and refuses the command, which is the safe direction.
+/// because that run records the file it is running from. Until then the
+/// app reads no record and refuses the command, which is the safe
+/// direction.
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_record_already_there_is_not_written_over_by_a_first_run() {
@@ -181,6 +182,62 @@ fn a_record_already_there_is_not_written_over_by_a_first_run() {
     assert!(
         !home.join("no/such/kendex").exists(),
         "the fixture exists, so this proves nothing"
+    );
+}
+
+/// Concurrent first runs leave one whole record and nothing beside it.
+///
+/// Not a proof of the ordering — two threads rarely land inside the window
+/// that would show it, and a version deciding by reading passes this too.
+/// What stands behind it is `create_new`: the name is taken or it is not,
+/// so the run that loses writes nothing at all, and the record reads as
+/// the one line the other put there rather than as two answers over each
+/// other.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn concurrent_first_runs_leave_one_whole_record() {
+    if no_record_on_this_runner() {
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let env = kendex_core::env::Env::host_rooted(&home);
+    let theirs = home.join("theirs/kendex");
+    let second = home.join("second/kendex");
+    for (path, bytes) in [
+        (&theirs, b"the kendex they installed".as_slice()),
+        (&second, b"a second copy of kendex".as_slice()),
+    ] {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, bytes).unwrap();
+    }
+
+    let both = std::thread::scope(|scope| {
+        let a = scope.spawn(|| kendex_core::command_update::record_first_run(&env, &theirs));
+        let b = scope.spawn(|| kendex_core::command_update::record_first_run(&env, &second));
+        (a.join().unwrap(), b.join().unwrap())
+    });
+    assert!(both.0.is_ok() && both.1.is_ok(), "{both:?}");
+
+    let recorded = kendex_core::command_update::recorded_command(&env).unwrap();
+    assert!(
+        recorded.path == theirs || recorded.path == second,
+        "the record names {}",
+        recorded.path.display()
+    );
+    assert_eq!(
+        fs::read_to_string(env.installed_command_file()).unwrap(),
+        format!("{}\n", recorded.path.display()),
+        "the record holds more than the line the run that won wrote"
+    );
+    let beside: Vec<_> = fs::read_dir(env.installed_command_file().parent().unwrap())
+        .unwrap()
+        .filter_map(|entry| entry.ok().map(|entry| entry.file_name()))
+        .filter(|name| name.to_string_lossy().starts_with("installed-command."))
+        .collect();
+    assert!(
+        beside.is_empty(),
+        "files left beside the record: {beside:?}"
     );
 }
 

--- a/crates/cli/tests/command_record.rs
+++ b/crates/cli/tests/command_record.rs
@@ -185,6 +185,38 @@ fn a_record_already_there_is_not_written_over_by_a_first_run() {
     );
 }
 
+/// An empty record is a name a claim published and never filled — the one
+/// state a first run can leave behind, since `create_new` takes the name
+/// before the bytes go in it. Nothing else would repair it: every later
+/// run finds the name taken too, and the app refuses a command it does own
+/// until `kendex update` rewrites the record. So the run that finds it
+/// takes the name back.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_empty_record_is_repaired_by_the_next_first_run() {
+    if no_record_on_this_runner() {
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let env = kendex_core::env::Env::host_rooted(&home);
+    let file = env.installed_command_file();
+    fs::create_dir_all(file.parent().unwrap()).unwrap();
+    // What a claim leaves when the write behind it never lands.
+    fs::write(&file, "").unwrap();
+    let ours = home.join("ours/kendex");
+    fs::create_dir_all(ours.parent().unwrap()).unwrap();
+    fs::write(&ours, b"the kendex that ran").unwrap();
+
+    kendex_core::command_update::record_first_run(&env, &ours).unwrap();
+
+    assert_eq!(
+        kendex_core::command_update::recorded_command(&env).map(|record| record.path),
+        Some(ours),
+        "an empty record is nobody's, and the run that found it left it that way"
+    );
+}
+
 /// Concurrent first runs both answer `Ok` and leave one readable record,
 /// naming one of the two files that ran.
 ///

--- a/crates/cli/tests/compat.rs
+++ b/crates/cli/tests/compat.rs
@@ -371,6 +371,39 @@ fn a_release_that_cannot_be_verified(home: &Path, target: &str) {
     .unwrap();
 }
 
+/// A family update moves the app and the command to one release, and what
+/// says the pair arrived together afterwards is that the app reports the
+/// version `kendex --version` prints. The app bundle carries its version in
+/// `crates/app/tauri.conf.json` and the command bakes its own, so the two
+/// are one release only while this holds.
+///
+/// Read off the built binary rather than off `CARGO_PKG_VERSION`: what the
+/// person sees after the update is what the command prints, and a build
+/// that printed something else would pass a comparison of two constants.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn the_app_version_is_the_one_kendex_version_prints() {
+    let conf: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("../app/tauri.conf.json"))
+            .unwrap(),
+    )
+    .unwrap();
+    let app_version = conf["version"]
+        .as_str()
+        .expect("the app bundle names a version");
+
+    let said = Command::new(env!("CARGO_BIN_EXE_kendex"))
+        .arg("--version")
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        String::from_utf8_lossy(&said.stdout).trim(),
+        format!("kendex {app_version}"),
+        "the app ships {app_version} and the command answers otherwise"
+    );
+}
+
 /// The feed is unsigned text naming a host, so what it offers has to be
 /// held to the release key before it lands on the running command.
 #[test]

--- a/crates/cli/tests/compat.rs
+++ b/crates/cli/tests/compat.rs
@@ -7,6 +7,10 @@
 mod fixture_url;
 use fixture_url::file_url;
 
+#[path = "../../test_util.rs"]
+mod test_util;
+use test_util::rooted;
+
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
@@ -392,10 +396,12 @@ fn the_app_version_is_the_one_kendex_version_prints() {
         .as_str()
         .expect("the app bundle names a version");
 
-    let said = Command::new(env!("CARGO_BIN_EXE_kendex"))
-        .arg("--version")
-        .output()
-        .unwrap();
+    // Through the file's own runner: `--version` bootstraps the installed
+    // command record before clap answers, and that write belongs in this
+    // test's fixture rather than in the account running the suite.
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let said = kendex_in(&home, &home, &["--version"], &[]);
 
     assert_eq!(
         String::from_utf8_lossy(&said.stdout).trim(),

--- a/crates/cli/tests/install_script.rs
+++ b/crates/cli/tests/install_script.rs
@@ -345,3 +345,42 @@ fn install_sh_records_the_command_it_installed() {
     });
     assert_eq!(recorded.path, PathBuf::from(installed));
 }
+
+/// A record the script cannot write costs the app-side update and never
+/// the install: the run says so on stderr and carries on. The branch fires
+/// on either write behind it failing — here the record path is a directory,
+/// so `mkdir -p` finds the state directory already there and the redirect
+/// has nowhere to land. A mode bit would have been the other spelling, and
+/// a run acting as root writes through those.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn install_sh_says_when_it_cannot_record_the_command() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    // Asked of the resolver: the record path differs by platform, and a
+    // second spelling here agrees until it does not.
+    let env = kendex_core::env::Env::host_rooted(&home);
+    fs::create_dir_all(env.installed_command_file()).unwrap();
+
+    let (output, _) = run_install_at(HOST_UNAME, "x86_64", &home);
+    let said = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "a record that would not be written cost the install itself:\n{said}"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("Installed the kendex command to"),
+        "the command was never installed, so the record is not what this proves:\n{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        said.contains("could not record the command's identity"),
+        "the run said nothing about the record it did not write:\n{said}"
+    );
+    assert_eq!(
+        kendex_core::command_update::recorded_command(&env),
+        None,
+        "the app was handed a record install.sh never wrote"
+    );
+}

--- a/crates/cli/tests/install_script.rs
+++ b/crates/cli/tests/install_script.rs
@@ -306,11 +306,9 @@ fn where_a_real_install_puts_the_command_is_a_candidate() {
 
 /// The desktop app carries the command across only when an installer said
 /// which file it is, so `install.sh` has to leave that record where the
-/// app's own resolver looks — at the path it actually installed, and with
-/// the digest of the bytes it put there. A script that installs and
-/// records nothing leaves every app-driven update refusing a command it
-/// really does own; one that records a path alone leaves the app judging
-/// by a name, which the next file to arrive under that name inherits.
+/// app's own resolver looks, at the path it actually installed. A script
+/// that installs and records nothing leaves every app-driven update
+/// refusing a command it really does own.
 ///
 /// Read back through the resolver rather than by hand: what shape the
 /// record takes is core's to say, and a second spelling here agrees until
@@ -346,52 +344,4 @@ fn install_sh_records_the_command_it_installed() {
         )
     });
     assert_eq!(recorded.path, PathBuf::from(installed));
-    assert_eq!(
-        recorded.digest,
-        kendex_core::hash::sha256_hex(&fs::read(installed).unwrap()),
-        "the record names bytes other than the ones install.sh left at {installed}"
-    );
-}
-
-/// No way to compute a digest is a record this build could not check, so
-/// the script writes none and says so. A path on its own is exactly the
-/// record this change exists to stop being enough: written anyway, it
-/// would put the app back to judging a command by its name.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn install_sh_records_nothing_it_cannot_take_a_digest_for() {
-    let tmp = tempfile::tempdir().unwrap();
-    let home = rooted(&tmp);
-    // Every spelling of the digest, ahead of the real ones on `PATH` and
-    // failing. `command -v` finds each, so the script reaches one and gets
-    // nothing back rather than falling through to a tool that works.
-    let fake = home.join("fake-bin");
-    fs::create_dir_all(&fake).unwrap();
-    for tool in ["sha256sum", "shasum", "openssl"] {
-        write_exe(&fake.join(tool), "#!/bin/sh\nexit 1\n");
-    }
-
-    let (output, _) = run_install_at(HOST_UNAME, "x86_64", &home);
-
-    assert!(
-        output.status.success(),
-        "a missing digest tool costs the record, never the install:\n{}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr).contains("could not record the command's identity"),
-        "the run said nothing about the record it did not write:\n{}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let env = kendex_core::env::Env::host_rooted(&home);
-    assert_eq!(
-        kendex_core::command_update::recorded_command(&env),
-        None,
-        "a record with no digest is one the app would judge by name alone"
-    );
-    assert!(
-        !env.installed_command_file().exists(),
-        "nothing half-written at {}",
-        env.installed_command_file().display()
-    );
 }

--- a/crates/core/src/command_update.rs
+++ b/crates/core/src/command_update.rs
@@ -31,7 +31,6 @@ use std::time::Duration;
 
 use semver::Version;
 
-use crate::env::Env;
 use crate::install_channel::{HostProbe, InstallChannel, package_owner};
 use crate::process::Hardened;
 use crate::update_feed::{ReleaseFeed, signature_url, verify_signature};
@@ -40,9 +39,7 @@ mod notice;
 mod record;
 
 pub use notice::CommandNotice;
-pub use record::{
-    InstalledCommand, record_command, record_first_run, record_installed, recorded_command,
-};
+pub use record::{InstalledCommand, record_command, record_first_run, recorded_command};
 
 /// What `install.sh` installs the command as. Windows has no command
 /// beside the app — the installer carries the app alone — so the name
@@ -153,13 +150,10 @@ pub fn command_candidates(home: &Path, path_var: Option<&OsStr>) -> Vec<PathBuf>
 /// the path it judges is the one it is running from; this function found
 /// its path by name, and a name is a guess until something confirms it.
 ///
-/// The record is read from both ends. It is searched as well as checked,
+/// The record is read from both ends: it is searched as well as checked,
 /// so a command installed where neither `PATH` nor `install.sh` would put
 /// it — `~/.cargo/bin/kendex`, under an app a Finder launch hands the four
-/// system directories — is reachable at all; and it is a path *and* a
-/// digest, because a path is a name and names outlive the files that held
-/// them. Remove the recorded binary, drop a wrapper or a retargeted
-/// symlink at that path, and the path still compares equal.
+/// system directories — is reachable at all.
 pub fn command_beside_app(
     probe: &dyn HostProbe,
     candidates: &[PathBuf],
@@ -167,7 +161,7 @@ pub fn command_beside_app(
     installed: Option<&InstalledCommand>,
 ) -> CommandBeside {
     let running: Vec<PathBuf> = running.iter().map(|path| probe.resolve(path)).collect();
-    let record = installed.map(|record| (probe.resolve(&record.path), record.digest.as_str()));
+    let record = installed.map(|record| probe.resolve(&record.path));
     // Last in the search, because everything ahead of it is what a shell
     // resolves first, and that is the copy a person actually runs.
     let searched = candidates.iter().chain(installed.map(|r| &r.path));
@@ -185,10 +179,7 @@ pub fn command_beside_app(
         if let Some(owner) = package_owner(&resolved, probe) {
             return CommandBeside::NotOurs(owner);
         }
-        let ours = record.as_ref().is_some_and(|(path, digest)| {
-            *path == resolved && probe.digest(&resolved).as_deref() == Some(*digest)
-        });
-        if !ours {
+        if record.as_ref() != Some(&resolved) {
             // Nothing proves it ours. Refusing costs a person one command;
             // being wrong costs them their file.
             return CommandBeside::NotOurs(InstallChannel::Unknown);
@@ -218,7 +209,6 @@ pub fn command_beside_app(
 /// included: the app cannot write that directory, and the card named it
 /// before Update now was pressed.
 pub fn bring_command_across(
-    env: &Env,
     beside: &CommandBeside,
     feed_url: &str,
     release: &str,
@@ -247,14 +237,11 @@ pub fn bring_command_across(
     command
         .install_at(path, public_key)
         .map_err(command_half_failed)?;
-    // The record now names bytes that are gone, so it is rewritten for the
-    // bytes that replaced them. A rewrite that fails costs the next
-    // app-driven update, never this one: the record stops matching, the
-    // app then refuses a command it does own rather than replacing one it
-    // does not, and any `kendex update` run restores it. That is why this
-    // is not an error — the command is across, and saying otherwise would
-    // send a person to press a button that has already done its work.
-    let _ = record_command(env, path, &command.bytes);
+    // Nothing is recorded here. The record is what made this command
+    // `Ours` in the first place, and it names the path rather than the
+    // bytes, so a replacement at that path leaves it saying what it
+    // already said — under the spelling the record carries, which a
+    // rewrite from the resolved path would trade for a link's target.
     Ok(CommandHalf::Moved)
 }
 

--- a/crates/core/src/command_update/notice.rs
+++ b/crates/core/src/command_update/notice.rs
@@ -79,7 +79,10 @@ impl CommandNotice {
     /// Compared as what was *said*, not as what was found: two `Ours` at
     /// different paths say the same nothing to a person and are the same
     /// answer here, while `Ours` become `NotOurs` says something new, and
-    /// so does the reverse.
+    /// so does the reverse. A value that prints a path said that path as
+    /// well, so two `NeedsPrivilege` naming different files are two
+    /// different sentences: the person was pointed at one file and another
+    /// is the one left behind, which is a change and is reported.
     ///
     /// Which sentence is `half`'s to decide, with one exception it cannot
     /// tell on its own: nothing there at all also says nothing to a card,

--- a/crates/core/src/command_update/notice.rs
+++ b/crates/core/src/command_update/notice.rs
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 use specta::Type;
 
-use super::CommandBeside;
+use super::{CommandBeside, CommandHalf};
 use crate::install_channel::InstallChannel;
 use crate::names::shown;
 
@@ -62,6 +62,41 @@ impl CommandNotice {
                 Some(Self::Unknown)
             }
         }
+    }
+
+    /// What a person is owed when the command the update found was not the
+    /// one the card described. Answered once both halves have landed.
+    ///
+    /// The card is the whole of what they are told about that command,
+    /// because Update now restarts the app and takes the card with it. A
+    /// disposition that changed while the card sat on screen is a sentence
+    /// that was never said, and the command half then acted on the new
+    /// answer: a command the card offered to carry stays where it is, or
+    /// one it promised to leave alone is replaced. Neither is refused — the
+    /// app is on the new release either way — so this is where they hear
+    /// about it, on a card the restart has not taken away yet.
+    ///
+    /// Compared as what was *said*, not as what was found: two `Ours` at
+    /// different paths say the same nothing to a person and are the same
+    /// answer here, while `Ours` become `NotOurs` says something new, and
+    /// so does the reverse.
+    pub fn not_as_shown(
+        release: &str,
+        half: CommandHalf,
+        found: Option<&Self>,
+        shown: Option<&Self>,
+    ) -> Option<String> {
+        if found == shown {
+            return None;
+        }
+        Some(match half {
+            CommandHalf::Untouched => format!(
+                "kendex {release} is installed and starts on the next launch; the kendex command beside this app is no longer the one the notice described, so it was left on the release it is on — the notice now says what is there"
+            ),
+            CommandHalf::Moved => format!(
+                "kendex {release} is installed and starts on the next launch; the kendex command beside this app is no longer the one the notice described, so it was carried across rather than left where the notice said it would be"
+            ),
+        })
     }
 }
 

--- a/crates/core/src/command_update/notice.rs
+++ b/crates/core/src/command_update/notice.rs
@@ -71,10 +71,9 @@ impl CommandNotice {
     /// because Update now restarts the app and takes the card with it. A
     /// disposition that changed while the card sat on screen is a sentence
     /// that was never said, and the command half then acted on the new
-    /// answer: a command the card offered to carry stays where it is, or
-    /// one it promised to leave alone is replaced. Neither is refused — the
-    /// app is on the new release either way — so this is where they hear
-    /// about it, on a card the restart has not taken away yet.
+    /// answer. Nothing is refused — the app is on the new release either
+    /// way — so this is where they hear about it, on a card the restart has
+    /// not taken away yet.
     ///
     /// Compared as what was *said*, not as what was found: two `Ours` at
     /// different paths say the same nothing to a person and are the same

--- a/crates/core/src/command_update/notice.rs
+++ b/crates/core/src/command_update/notice.rs
@@ -10,10 +10,12 @@ use super::{CommandBeside, CommandHalf};
 use crate::install_channel::InstallChannel;
 use crate::names::shown;
 
-/// What the sidebar card says about the `kendex` command beside the app,
-/// before Update now is pressed — afterwards the app has restarted and
-/// there is no card left to say it on. `None` where there is nothing to
-/// say: no command here, or one Update now carries across itself.
+/// What the sidebar card says about the `kendex` command beside the app.
+/// Read before Update now is pressed, and read again after an install that
+/// answered rather than restarting, which leaves the card up with this the
+/// only thing on it that can still be true. An install that restarts takes
+/// the card with it. `None` where there is nothing to say: no command
+/// here, or one Update now carries across itself.
 ///
 /// Every string is fixed text decided by which arm ran, save the path,
 /// which names one file to a person who may have several — the rule the
@@ -103,7 +105,7 @@ impl CommandNotice {
                 "{installed}; the kendex command the notice described is not beside this app any more, so nothing was carried across"
             ),
             (CommandHalf::Untouched, Some(_)) => format!(
-                "{installed}; the kendex command beside this app is no longer the one the notice described, so it was left on the release it is on — the notice now says what is there"
+                "{installed}; the kendex command beside this app is no longer the one the notice described, so it was left on the release it is on"
             ),
             (CommandHalf::Moved, _) => format!(
                 "{installed}; the kendex command beside this app is no longer the one the notice described, so it was carried across rather than left where the notice said it would be"

--- a/crates/core/src/command_update/notice.rs
+++ b/crates/core/src/command_update/notice.rs
@@ -80,6 +80,12 @@ impl CommandNotice {
     /// different paths say the same nothing to a person and are the same
     /// answer here, while `Ours` become `NotOurs` says something new, and
     /// so does the reverse.
+    ///
+    /// Which sentence is `half`'s to decide, with one exception it cannot
+    /// tell on its own: nothing there at all also says nothing to a card,
+    /// so a lookup answering `None` is either the command this app just
+    /// carried across — that is `Moved` — or no command on the machine,
+    /// which is `Untouched` with nothing left behind to report.
     pub fn not_as_shown(
         release: &str,
         half: CommandHalf,
@@ -89,12 +95,16 @@ impl CommandNotice {
         if found == shown {
             return None;
         }
-        Some(match half {
-            CommandHalf::Untouched => format!(
-                "kendex {release} is installed and starts on the next launch; the kendex command beside this app is no longer the one the notice described, so it was left on the release it is on — the notice now says what is there"
+        let installed = format!("kendex {release} is installed and starts on the next launch");
+        Some(match (half, found) {
+            (CommandHalf::Untouched, None) => format!(
+                "{installed}; the kendex command the notice described is not beside this app any more, so nothing was carried across"
             ),
-            CommandHalf::Moved => format!(
-                "kendex {release} is installed and starts on the next launch; the kendex command beside this app is no longer the one the notice described, so it was carried across rather than left where the notice said it would be"
+            (CommandHalf::Untouched, Some(_)) => format!(
+                "{installed}; the kendex command beside this app is no longer the one the notice described, so it was left on the release it is on — the notice now says what is there"
+            ),
+            (CommandHalf::Moved, _) => format!(
+                "{installed}; the kendex command beside this app is no longer the one the notice described, so it was carried across rather than left where the notice said it would be"
             ),
         })
     }

--- a/crates/core/src/command_update/notice/tests.rs
+++ b/crates/core/src/command_update/notice/tests.rs
@@ -107,3 +107,33 @@ fn a_card_whose_command_moved_is_told_what_became_of_it() {
         }
     }
 }
+
+/// Two `NeedsPrivilege` naming different files are two different
+/// sentences, because that arm prints the path: a person told about
+/// `/usr/local/bin/kendex` was pointed at one file, and a command left
+/// behind somewhere else is not the one they read about. `Ours` is the
+/// contrast and the reason this needs saying at all — it prints nothing,
+/// so two of those at different paths stay silent.
+#[test]
+fn one_privileged_command_is_not_another_at_a_different_path() {
+    let (here, half) = beside(&CommandBeside::NeedsPrivilege(
+        "/usr/local/bin/kendex".into(),
+    ));
+    let (there, _) = beside(&CommandBeside::NeedsPrivilege("/opt/kendex/kendex".into()));
+    assert_ne!(
+        here, there,
+        "the card prints the path, so the path is part of what was said"
+    );
+
+    let told = CommandNotice::not_as_shown("5.1.0", half, there.as_ref(), here.as_ref())
+        .expect("a card naming one file, and a command left at another");
+    assert!(told.contains("left on the release it is on"), "{told}");
+
+    let (one, moved) = beside(&CommandBeside::Ours("/home/pat/.local/bin/kendex".into()));
+    let (other, _) = beside(&CommandBeside::Ours("/usr/bin/kendex".into()));
+    assert_eq!(
+        CommandNotice::not_as_shown("5.1.0", moved, other.as_ref(), one.as_ref()),
+        None,
+        "a command this app carries across names no path on the card"
+    );
+}

--- a/crates/core/src/command_update/notice/tests.rs
+++ b/crates/core/src/command_update/notice/tests.rs
@@ -36,3 +36,74 @@ fn the_card_is_told_what_each_state_owes_a_person() {
         })
     );
 }
+
+/// One machine's answer, and the half that follows from it: `Ours` is the
+/// only one this app carries across, so it is the only one that moves.
+fn beside(state: &CommandBeside) -> (Option<CommandNotice>, CommandHalf) {
+    let half = match state {
+        CommandBeside::Ours(_) => CommandHalf::Moved,
+        _ => CommandHalf::Untouched,
+    };
+    (CommandNotice::for_card(state), half)
+}
+
+/// Every disposition a card can be drawn from, so the table below asks the
+/// whole input space rather than the two pairs the app-side cases reach.
+fn every_state() -> Vec<CommandBeside> {
+    vec![
+        CommandBeside::Ours("/home/pat/.local/bin/kendex".into()),
+        CommandBeside::Absent,
+        CommandBeside::NotOurs(InstallChannel::Unknown),
+        CommandBeside::NotOurs(InstallChannel::Managed {
+            manager: "Homebrew".to_owned(),
+            command: "brew upgrade kendex-cli".to_owned(),
+        }),
+        CommandBeside::NeedsPrivilege("/usr/local/bin/kendex".into()),
+    ]
+}
+
+/// A card that still describes what is there says nothing, whatever it
+/// described. This is the pair almost every real machine presses Update
+/// now on — a Homebrew command named on the card and still named on the
+/// lookup — and a sentence here would be an alarm about nothing.
+#[test]
+fn a_card_that_still_describes_the_command_says_nothing() {
+    for state in every_state() {
+        let (card, half) = beside(&state);
+        assert_eq!(
+            CommandNotice::not_as_shown("5.1.0", half, card.as_ref(), card.as_ref()),
+            None,
+            "{state:?}"
+        );
+    }
+}
+
+/// Every card whose disposition moved, and the sentence each is owed. What
+/// separates them is what became of the command, not what the card said:
+/// one this app carried across, one left where it is on the old release,
+/// and one that is not on the machine at all — which the pair before this
+/// change called left behind, about a file nobody has.
+#[test]
+fn a_card_whose_command_moved_is_told_what_became_of_it() {
+    for state in every_state() {
+        for other in every_state() {
+            let (card, _) = beside(&other);
+            let (found, half) = beside(&state);
+            if found == card {
+                continue;
+            }
+            let told = CommandNotice::not_as_shown("5.1.0", half, found.as_ref(), card.as_ref())
+                .unwrap_or_else(|| panic!("{other:?} became {state:?} and nothing was said"));
+            assert!(told.contains("kendex 5.1.0 is installed"), "{told}");
+            let expected = match (&state, half) {
+                (_, CommandHalf::Moved) => "carried across rather than left",
+                (CommandBeside::Absent, _) => "not beside this app any more",
+                _ => "left on the release it is on",
+            };
+            assert!(
+                told.contains(expected),
+                "{other:?} became {state:?}: {told}"
+            );
+        }
+    }
+}

--- a/crates/core/src/command_update/record.rs
+++ b/crates/core/src/command_update/record.rs
@@ -157,25 +157,75 @@ pub fn record_first_run(env: &Env, running: &Path) -> Result<(), String> {
 /// naming whichever finished last, and anything already at that name —
 /// another install's record, a link somebody else chose, a pipe — is left
 /// exactly as it is rather than opened.
+///
+/// The one taken name that is nobody's record is an empty one, and it is
+/// this function that can leave it: the name is published before the bytes
+/// are in it. Every later run would find that name taken too, so nothing
+/// would ever repair it and the app would refuse a command it does own
+/// until `kendex update` rewrote the record. So a write that fails takes
+/// the name back with it, and a claim found empty is taken back here.
 fn write_the_first_run(env: &Env, running: &Path) -> Result<(), String> {
-    use std::io::Write as _;
     let file = env.installed_command_file();
     let Some(parent) = file.parent() else {
         return Err(format!("{} names no directory", file.display()));
     };
     std::fs::create_dir_all(parent)
         .map_err(|error| format!("{} could not be created: {error}", parent.display()))?;
-    match std::fs::OpenOptions::new()
+    match claim_the_record(&file, running) {
+        // Taken, which is the ordinary answer: every run after the first
+        // gets it.
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+        answered => return answered.map_err(|error| written(&file, &error)),
+    }
+    // Somebody's record, and this run is not the first. Judged by one
+    // `symlink_metadata`, which is the whole read the steady state pays:
+    // a name with bytes in it is left alone — an unreadable one included,
+    // which `kendex update` rewrites — and a link or a fifo is not a
+    // regular file however long it is, so neither is followed or opened.
+    if !an_unfilled_claim(&file) {
+        return Ok(());
+    }
+    // The empty name goes back and is claimed again. A removal that will
+    // not happen, or a name taken again behind this one, leaves the record
+    // as it was found: this run recorded nothing, and the next one makes
+    // the same repair.
+    if std::fs::remove_file(&file).is_err() {
+        return Ok(());
+    }
+    match claim_the_record(&file, running) {
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+        answered => answered.map_err(|error| written(&file, &error)),
+    }
+}
+
+/// Take the name and fill it, or leave nothing at it.
+///
+/// `create_new` is what makes the claim, and it publishes the name before
+/// the bytes are written. A write that fails would strand that name, so it
+/// is given back here and the caller answers the write's own error.
+fn claim_the_record(file: &Path, running: &Path) -> std::io::Result<()> {
+    use std::io::Write as _;
+    let mut handle = std::fs::OpenOptions::new()
         .write(true)
         .create_new(true)
-        .open(&file)
-    {
-        Ok(mut handle) => handle
-            .write_all(format!("{}\n", running.display()).as_bytes())
-            .map_err(|error| format!("{} could not be written: {error}", file.display())),
-        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
-        Err(error) => Err(format!("{} could not be written: {error}", file.display())),
-    }
+        .open(file)?;
+    handle
+        .write_all(format!("{}\n", running.display()).as_bytes())
+        .inspect_err(|_| {
+            let _ = std::fs::remove_file(file);
+        })
+}
+
+/// Whether that name is a claim nothing ever filled in: a regular file
+/// with nothing in it. Read as the name itself rather than as whatever it
+/// leads to, and never opened — a fifo would hold a run that opened it.
+fn an_unfilled_claim(file: &Path) -> bool {
+    std::fs::symlink_metadata(file).is_ok_and(|entry| entry.is_file() && entry.len() == 0)
+}
+
+/// The one sentence for a record that would not be written.
+fn written(file: &Path, error: &std::io::Error) -> String {
+    format!("{} could not be written: {error}", file.display())
 }
 
 #[cfg(test)]

--- a/crates/core/src/command_update/record.rs
+++ b/crates/core/src/command_update/record.rs
@@ -130,16 +130,16 @@ fn write_the_command(env: &Env, path: &Path) -> Result<(), String> {
 /// verb writes the first one.
 ///
 /// Only the first, and first is the filesystem's answer rather than this
-/// function's: a record already here is repointed by the run that replaces
-/// the bytes it names and by nothing else. A second kendex on the machine
-/// would otherwise take the record off the one a person installed merely by
-/// being run once, and the app would then carry the copy nobody uses and
-/// leave the one they do.
+/// function's: a record already here is repointed by `kendex update`, which
+/// records the file it is running from, and by no other verb. A second
+/// kendex on the machine would otherwise take the record off the one a
+/// person installed merely by being run once, and the app would then carry
+/// the copy nobody uses and leave the one they do.
 ///
 /// A record already present but unreadable stays as it is. `recorded_command`
 /// reads it as no record and the app refuses the command, which is the safe
-/// direction; `kendex update` rewrites it, because that is the run replacing
-/// the bytes.
+/// direction; `kendex update` rewrites it, because that run records the
+/// file it is running from.
 ///
 /// A run acting as root writes nothing here either — see [`record_as`].
 pub fn record_first_run(env: &Env, running: &Path) -> Result<(), String> {

--- a/crates/core/src/command_update/record.rs
+++ b/crates/core/src/command_update/record.rs
@@ -2,33 +2,22 @@
 //! command it installed from any other executable carrying that name.
 //!
 //! `install.sh` writes it, `kendex update` refreshes it for the binary it
-//! is running as, and every replacement rewrites it for the bytes that
-//! landed. A replacement made by a privileged run writes no record at all
-//! — see [`acting_as_root`] — so the next run from the recorded path moves
-//! this one to the bytes it finds there. Read by
+//! is running as, and every run records the command an older install never
+//! recorded. A replacement made by a privileged run writes no record at
+//! all — see [`acting_as_root`]. Read by
 //! `command_update::command_beside_app`, which will not replace a file no
 //! record vouches for.
 
 use std::path::{Path, PathBuf};
 
 use crate::env::Env;
-use crate::install_channel::{Host, HostProbe};
 
 /// What an installer recorded about the `kendex` command it installed:
-/// where it put it, and what it put there.
-///
-/// Both halves have to match before those bytes are replaced. The path
-/// alone was the whole record once, and a path is only a name: the file
-/// behind it can be removed and another put in its place, and the wrapper
-/// this record exists to protect is exactly the kind of thing that turns
-/// up at a name kendex used to answer to.
+/// where it put it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InstalledCommand {
     /// Absolute, as the installer wrote it; resolved where it is used.
     pub path: PathBuf,
-    /// Plain SHA-256 of the recorded bytes, hex — what `sha256sum` prints,
-    /// so `install.sh` and this build compute the same value.
-    pub digest: String,
 }
 
 /// Whether this process is acting as root.
@@ -41,11 +30,9 @@ pub struct InstalledCommand {
 /// component of whose name belongs to the invoking account: a link there
 /// is followed, and root writes wherever it points.
 ///
-/// So a run acting as root writes no record. Nothing is lost by that:
-/// [`refresh_the_replaced_bytes`] moves the digest on any later run from
-/// the recorded path, so the person's own next unprivileged run — any
-/// verb, `--version` included — records the bytes the privileged run put
-/// there, into the file their own account owns.
+/// So a run acting as root writes no record. The person's own next
+/// unprivileged run — any verb, `--version` included — writes one into the
+/// file their own account owns.
 ///
 /// The effective uid and nothing else. `sudo`, `su`, `doas` and a root
 /// login are one case here and none of them is distinguishable by a
@@ -64,17 +51,15 @@ fn acting_as_root() -> bool {
     false
 }
 
-/// What a run is asking to record. The three entries below differ only in
+/// What a run is asking to record. The two entries below differ only in
 /// this value, so [`acting_as_root`] is read in one place: a wrapper that
 /// read it for itself would be a second place to get wrong, and only that
 /// wrapper's own test would ever notice.
 pub(super) enum Write<'a> {
-    /// The path a replacement landed at, and the bytes now there.
-    Command(&'a Path, &'a [u8]),
+    /// The path a replacement landed at.
+    Command(&'a Path),
     /// The file this process is running from.
     FirstRun(&'a Path),
-    /// A path whose bytes are still on disk to be read.
-    Installed(&'a Path),
 }
 
 /// Make the write, unless this process is one that may not make it.
@@ -86,21 +71,16 @@ fn record(env: &Env, write: Write<'_>) -> Result<(), String> {
 /// uid it is running under. Every caller outside a test comes through
 /// [`record`], which asks the process.
 ///
-/// Guarded here and nowhere below, ahead of every read and every
-/// `create_dir_all`: a root run does nothing at all, rather than part of it
-/// into a tree the invoking account named.
+/// Guarded here and nowhere below, ahead of every `create_dir_all`: a root
+/// run does nothing at all, rather than part of it into a tree the invoking
+/// account named.
 pub(super) fn record_as(env: &Env, write: Write<'_>, root: bool) -> Result<(), String> {
     if root {
         return Ok(());
     }
     match write {
-        Write::Command(path, bytes) => write_the_command(env, path, bytes),
+        Write::Command(path) => write_the_command(env, path),
         Write::FirstRun(running) => write_the_first_run(env, running),
-        Write::Installed(path) => {
-            let bytes = std::fs::read(path)
-                .map_err(|error| format!("{} could not be read: {error}", path.display()))?;
-            write_the_command(env, path, &bytes)
-        }
     }
 }
 
@@ -108,85 +88,36 @@ pub(super) fn record_as(env: &Env, write: Write<'_>, root: bool) -> Result<(), S
 ///
 /// Absent where nothing has been recorded — an install older than this
 /// record, or one made some other way — and absent for anything that is
-/// not one absolute path and one SHA-256, because a record this build
-/// cannot read is not a record it should act on.
+/// not one absolute path, because a record this build cannot read is not a
+/// record it should act on.
 pub fn recorded_command(env: &Env) -> Option<InstalledCommand> {
     let recorded = std::fs::read_to_string(env.installed_command_file()).ok()?;
-    let mut lines = recorded.lines();
-    let path = PathBuf::from(lines.next()?.trim());
-    let digest = lines.next()?.trim().to_owned();
-    let sha256 = digest.len() == 64 && digest.bytes().all(|b| b.is_ascii_hexdigit());
-    (path.is_absolute() && sha256).then_some(InstalledCommand { path, digest })
+    let path = PathBuf::from(recorded.lines().next()?.trim());
+    path.is_absolute().then_some(InstalledCommand { path })
 }
 
-/// Record `path`, holding `bytes`, as the `kendex` command this install
-/// owns, so the desktop app can carry it across. Written by whatever put
-/// the command there, and rewritten by whatever replaces it: a record left
-/// naming bytes that are gone is a record that stops matching, which
-/// refuses a command kendex does own rather than replacing one it does not.
+/// Record `path` as the `kendex` command this install owns, so the desktop
+/// app can carry it across. Written by whatever put the command there —
+/// `install.sh` at install, `kendex update` for the binary it is running
+/// as — and it repoints a record already here, which is the difference
+/// from [`record_first_run`].
 ///
 /// A run acting as root writes nothing and says so with success — see
 /// [`record_as`].
-pub fn record_command(env: &Env, path: &Path, bytes: &[u8]) -> Result<(), String> {
-    record(env, Write::Command(path, bytes))
+pub fn record_command(env: &Env, path: &Path) -> Result<(), String> {
+    record(env, Write::Command(path))
 }
 
 /// The write itself. Reached only through [`record_as`], which has already
 /// established this process may make it.
-fn write_the_command(env: &Env, path: &Path, bytes: &[u8]) -> Result<(), String> {
+fn write_the_command(env: &Env, path: &Path) -> Result<(), String> {
     let file = env.installed_command_file();
     if let Some(parent) = file.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|error| format!("{} could not be created: {error}", parent.display()))?;
     }
-    let digest = crate::hash::sha256_hex(bytes);
-    std::fs::write(&file, format!("{}\n{digest}\n", path.display()))
+    std::fs::write(&file, format!("{}\n", path.display()))
         .map_err(|error| format!("{} could not be written: {error}", file.display()))
-}
-
-/// How many names a staging write will try before giving up. Reaching the
-/// end means every name this process could offer was taken, which is a
-/// directory full of leftovers rather than a race worth waiting out.
-const STAGING_ATTEMPTS: usize = 64;
-
-/// Write `contents` to a name `name` supplies that nothing holds yet.
-///
-/// Created rather than written: a name left behind by a run that died
-/// between the link and the unlink is a second name for the record itself,
-/// so writing to it truncates the record and fills it in with another
-/// command's path. Refusing a name already taken is what keeps this a
-/// staging write and not a blind one, and the caller's `name` hands over
-/// another on each call.
-fn stage(
-    contents: &str,
-    name: impl Fn() -> std::path::PathBuf,
-) -> Result<std::path::PathBuf, String> {
-    use std::io::Write;
-    let mut last = String::new();
-    for _ in 0..STAGING_ATTEMPTS {
-        let path = name();
-        match std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&path)
-        {
-            Ok(mut handle) => {
-                return handle
-                    .write_all(contents.as_bytes())
-                    .map(|()| path.clone())
-                    .map_err(|error| format!("{} could not be written: {error}", path.display()));
-            }
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-                last = path.display().to_string();
-            }
-            Err(error) => {
-                return Err(format!("{} could not be written: {error}", path.display()));
-            }
-        }
-    }
-    Err(format!(
-        "no name was free to stage the record under, {STAGING_ATTEMPTS} tried, the last {last}"
-    ))
 }
 
 /// Record the running command where nothing has been recorded yet.
@@ -205,9 +136,6 @@ fn stage(
 /// being run once, and the app would then carry the copy nobody uses and
 /// leave the one they do.
 ///
-/// A record already here goes to [`refresh_the_replaced_bytes`], which
-/// holds that rule and moves the digest alone.
-///
 /// A record already present but unreadable stays as it is. `recorded_command`
 /// reads it as no record and the app refuses the command, which is the safe
 /// direction; `kendex update` rewrites it, because that is the run replacing
@@ -221,175 +149,33 @@ pub fn record_first_run(env: &Env, running: &Path) -> Result<(), String> {
 /// The bootstrap itself. Reached only through [`record_as`], which refuses
 /// a root run ahead of the `create_dir_all` below: that call is already
 /// root writing into a tree the invoking account named.
+///
+/// Created rather than written, so first is decided by the filesystem and
+/// not by a read that answered "nothing here yet": `create_new` fails on a
+/// name that is taken, which is the whole test. Two copies starting
+/// together cannot both believe they are the first and leave the record
+/// naming whichever finished last, and anything already at that name —
+/// another install's record, a link somebody else chose, a pipe — is left
+/// exactly as it is rather than opened.
 fn write_the_first_run(env: &Env, running: &Path) -> Result<(), String> {
+    use std::io::Write as _;
     let file = env.installed_command_file();
     let Some(parent) = file.parent() else {
         return Err(format!("{} names no directory", file.display()));
     };
-    // Asked before anything is read. Every run reaches here, `--version`
-    // and `--help` included, and the answer after the first is always the
-    // same one — so the steady state costs a look at one name rather than
-    // a staging file made and unmade beside it, and the arm below buys the
-    // read and the hash of the whole executable out of it too.
-    // `symlink_metadata`, so a link occupying the name counts as occupying
-    // it.
-    //
-    // Only a plain file is read on. Anything else at that name is where
-    // this function has always stopped, and it has to stay that way: a
-    // pipe there blocks the read below and holds every run of every verb
-    // before its arguments are parsed, and a link there is a name someone
-    // else chose for a write kendex would then aim at whatever it points
-    // at. Neither is a record, and the app reads no record until the run
-    // that replaces the command writes one.
-    //
-    // Not the arbiter, only the cheap answer. Two runs can both see
-    // nothing here; the link below is what decides which of them was
-    // first.
-    if let Ok(here) = std::fs::symlink_metadata(&file) {
-        return match here.is_file() {
-            true => refresh_the_replaced_bytes(env, running, &here),
-            false => Ok(()),
-        };
-    }
     std::fs::create_dir_all(parent)
         .map_err(|error| format!("{} could not be created: {error}", parent.display()))?;
-    let bytes = std::fs::read(running)
-        .map_err(|error| format!("{} could not be read: {error}", running.display()))?;
-    // Named for this writer and no other. The process id alone is not one:
-    // two threads of one process share it, and the pair would then stage
-    // over each other and link a file the other was still writing.
-    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    let contents = format!(
-        "{}\n{}\n",
-        running.display(),
-        crate::hash::sha256_hex(&bytes)
-    );
-    let staged = stage(&contents, || {
-        parent.join(format!(
-            "installed-command.{}.{}",
-            std::process::id(),
-            NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-        ))
-    })?;
-    // Linked rather than written in place, so first is decided by the
-    // filesystem and not by two reads that both answered "nothing here
-    // yet". `link` fails when the name is taken, which is the whole test:
-    // two copies starting together cannot both believe they are the first
-    // and leave the record naming whichever finished last. The staged file
-    // carries its whole content before the name exists, so no reader ever
-    // sees a record half written.
-    let first = std::fs::hard_link(&staged, &file);
-    let _ = std::fs::remove_file(&staged);
-    match first {
-        Ok(()) => Ok(()),
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&file)
+    {
+        Ok(mut handle) => handle
+            .write_all(format!("{}\n", running.display()).as_bytes())
+            .map_err(|error| format!("{} could not be written: {error}", file.display())),
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
         Err(error) => Err(format!("{} could not be written: {error}", file.display())),
     }
-}
-
-/// Move the digest of a record that names the file this process is running
-/// from, where the bytes at that file are no longer the ones it names.
-///
-/// An update run with the privilege the desktop app lacks writes no record
-/// at all — see [`acting_as_root`] — so the record here keeps naming the
-/// bytes that run replaced. `command_beside_app` then stops matching a
-/// command kendex does own, and the card that offered the one command out
-/// of that state falls to the arm that names nobody. The person is left
-/// with a current command the app will never offer to move again.
-///
-/// What licenses the write is what licenses a first run, and it is the same
-/// file: a process running from the recorded path is the recorded command,
-/// whatever bytes it now holds, and executing them is the proof no lookup
-/// by name can offer. So the digest moves and the path does not. A record
-/// naming any other file is left alone — repointing a record by path is
-/// what `record_first_run` refuses, and it still refuses it.
-///
-/// Nothing here is privileged and nothing crosses an account. The process
-/// is the person's own, the file is the one their own [`Env`] names, and
-/// the bytes hashed are the ones this process was loaded from.
-///
-/// The record's modified time is read here as which version of the command
-/// it describes, and left saying that on the way out. `record_file` is the
-/// caller's `symlink_metadata`, which has already established this is a
-/// plain file rather than a link or a pipe.
-fn refresh_the_replaced_bytes(
-    env: &Env,
-    running: &Path,
-    record_file: &std::fs::Metadata,
-) -> Result<(), String> {
-    let file = env.installed_command_file();
-    let Some(record) = recorded_command(env) else {
-        return Ok(());
-    };
-    if Host.resolve(&record.path) != Host.resolve(running) {
-        return Ok(());
-    }
-    // The record's own timestamp says which version of the file it
-    // describes, so bytes no newer than that are bytes it already names.
-    // Every run of every verb reaches here, and that comparison is what
-    // keeps the steady state off a read and a hash of the whole
-    // executable. Where either timestamp cannot be read the record stays
-    // as it is, which is this function's answer to everything it cannot
-    // establish; a replacement landing on the same timestamp or an older
-    // one is missed the same way, and the record then stays exactly where
-    // it was before this arm existed.
-    let (Ok(recorded_at), Ok(written_at)) = (
-        record_file.modified(),
-        std::fs::metadata(running).and_then(|bytes| bytes.modified()),
-    ) else {
-        return Ok(());
-    };
-    if written_at <= recorded_at {
-        return Ok(());
-    }
-    let bytes = std::fs::read(running)
-        .map_err(|error| format!("{} could not be read: {error}", running.display()))?;
-    // A record already naming these bytes is left as it is rather than
-    // rewritten with what it already holds. No reader can tell the two
-    // apart afterwards, and that is the point: `record_command` truncates
-    // before it writes, so rewriting would open a window where a reader
-    // sees half a record where there was a whole one.
-    if crate::hash::sha256_hex(&bytes) != record.digest {
-        // Written back under the path the record already spells, not the
-        // resolved one: the two name the same file, and a record rewritten
-        // as a link's target stops describing the name a later release
-        // replaces.
-        record_command(env, &record.path, &bytes)?;
-    }
-    // Read before the bytes were, and stamped whether or not the digest
-    // moved. Both halves matter.
-    //
-    // Stamped even where nothing was written, or a replacement installing
-    // the same bytes again leaves the file newer than a record that
-    // already names it and every later run pays the read and the hash for
-    // nothing.
-    //
-    // Stamped with the file's own time rather than this moment, so the
-    // record never claims to describe bytes this run did not read. A
-    // replacement landing between that read and this write is then still
-    // newer than the record, and the next run repairs it. Taking the clock
-    // instead would leave the record naming bytes that are gone with a
-    // timestamp that says otherwise, which is this defect made permanent.
-    stamp(&file, written_at)
-}
-
-/// Say which version of a file a record describes, by giving the record
-/// that file's own modified time.
-fn stamp(file: &Path, written_at: std::time::SystemTime) -> Result<(), String> {
-    std::fs::File::options()
-        .write(true)
-        .open(file)
-        .and_then(|handle| handle.set_modified(written_at))
-        .map_err(|error| format!("{} could not be stamped: {error}", file.display()))
-}
-
-/// The same record, taken from a file already on disk — the running
-/// command identifying itself, where the bytes are not in hand.
-///
-/// A run acting as root writes nothing here either, and does not read the
-/// file to find that out — see [`record_as`].
-pub fn record_installed(env: &Env, path: &Path) -> Result<(), String> {
-    record(env, Write::Installed(path))
 }
 
 #[cfg(test)]

--- a/crates/core/src/command_update/record/tests.rs
+++ b/crates/core/src/command_update/record/tests.rs
@@ -16,12 +16,10 @@ use super::*;
 const WRAPPER: &[u8] = b"#!/bin/sh\nexec /opt/kendex/kendex \"$@\"\n";
 
 /// A record this build cannot read is not a record it acts on. The file
-/// carries two lines and both have to be what they claim: one absolute
-/// path, and one SHA-256. A half-written record, a relative path, or a
-/// digest that is not one reads as no record rather than as a record with
-/// a field to work around.
+/// carries one absolute path, so nothing written and a relative path both
+/// read as no record rather than as a record with a field to work around.
 #[test]
-fn a_record_that_is_not_a_path_and_a_digest_is_no_record() {
+fn a_record_that_is_not_an_absolute_path_is_no_record() {
     let dir = tempfile::tempdir().unwrap();
     let env = Env::host_rooted(dir.path());
     let file = env.installed_command_file();
@@ -36,30 +34,18 @@ fn a_record_that_is_not_a_path_and_a_digest_is_no_record() {
         true => r"C:\Program Files\kendex\kendex.exe",
         false => "/usr/local/bin/kendex",
     };
-    let digest = crate::hash::sha256_hex(WRAPPER);
-    for written in [
-        String::new(),
-        "  \n".to_owned(),
-        // The path alone: the whole of the record before the digest
-        // existed, and a build that acted on it would replace by name.
-        format!("{installed}\n"),
-        format!("bin/kendex\n{digest}\n"),
-        format!("{installed}\n{}\n", &digest[..63]),
-        format!("{installed}\n{}z\n", &digest[..63]),
-        format!("{installed}\n{digest}{digest}\n"),
-    ] {
+    for written in [String::new(), "  \n".to_owned(), "bin/kendex\n".to_owned()] {
         std::fs::write(&file, &written).unwrap();
         assert_eq!(recorded_command(&env), None, "{written:?}");
     }
 
     // The control: the same file, well formed, is read. Without it every
     // assertion above passes for a reader that returns `None` always.
-    record_as(&env, Write::Command(Path::new(installed), WRAPPER), false).unwrap();
+    record_as(&env, Write::Command(Path::new(installed)), false).unwrap();
     assert_eq!(
         recorded_command(&env),
         Some(InstalledCommand {
             path: PathBuf::from(installed),
-            digest,
         })
     );
 }
@@ -101,65 +87,6 @@ fn a_first_run_vouches_for_its_own_file_and_no_other() {
     );
 }
 
-/// A staging name left behind by a run that died between the link and the
-/// unlink is a second name for the record itself. Written to rather than
-/// created, the record is truncated and filled in with whatever the next
-/// run was staging — the first-writer contract undone by its own cleanup
-/// not having happened.
-///
-/// Driven through the name supply rather than through a real crash: what
-/// varies is which name a staging write is offered, and the case is the
-/// one where the first offer is taken.
-#[test]
-fn a_staging_name_left_behind_is_never_written_through() {
-    let dir = tempfile::tempdir().unwrap();
-    let record = dir.path().join("installed-command");
-    std::fs::write(&record, "the record already here\n").unwrap();
-    // What a crash leaves: the staging name still pointing at the record.
-    let leftover = dir.path().join("installed-command.stale");
-    std::fs::hard_link(&record, &leftover).unwrap();
-    let free = dir.path().join("installed-command.free");
-
-    let offers = std::sync::atomic::AtomicUsize::new(0);
-    let staged = stage("the next run's record\n", || {
-        match offers.fetch_add(1, std::sync::atomic::Ordering::Relaxed) {
-            0 => leftover.clone(),
-            _ => free.clone(),
-        }
-    })
-    .unwrap();
-
-    assert_eq!(staged, free, "the taken name was staged under");
-    assert_eq!(
-        std::fs::read_to_string(&record).unwrap(),
-        "the record already here\n",
-        "the record was written through its other name"
-    );
-    assert_eq!(
-        std::fs::read_to_string(&free).unwrap(),
-        "the next run's record\n"
-    );
-}
-
-/// Every name taken is a failure, not a silent overwrite of the last one
-/// offered. The message names how many were tried, because the state it
-/// describes is a directory nobody has swept.
-#[test]
-fn a_staging_write_with_no_free_name_fails() {
-    let dir = tempfile::tempdir().unwrap();
-    let taken = dir.path().join("installed-command.taken");
-    std::fs::write(&taken, "someone else's\n").unwrap();
-
-    let why = stage("mine\n", || taken.clone()).unwrap_err();
-
-    assert!(why.contains(&STAGING_ATTEMPTS.to_string()), "{why}");
-    assert_eq!(
-        std::fs::read_to_string(&taken).unwrap(),
-        "someone else's\n",
-        "the taken name was written anyway"
-    );
-}
-
 /// A run acting as root writes no record, wherever `HOME` points it.
 ///
 /// The case: `sudoers` carrying `env_keep HOME`, so an elevated `kendex
@@ -189,7 +116,7 @@ fn a_run_acting_as_root_writes_no_record() {
     std::fs::write(&running, WRAPPER).unwrap();
 
     record_as(&env, Write::FirstRun(&running), true).unwrap();
-    record_as(&env, Write::Command(&running, WRAPPER), true).unwrap();
+    record_as(&env, Write::Command(&running), true).unwrap();
     assert!(
         !file.exists(),
         "{} was written by a root run",
@@ -208,15 +135,14 @@ fn a_run_acting_as_root_writes_no_record() {
         recorded_command(&env),
         Some(InstalledCommand {
             path: running.clone(),
-            digest: crate::hash::sha256_hex(WRAPPER),
         }),
         "the bootstrap did not write where the root arm was asked not to"
     );
-    let replaced = b"the bytes that replaced it";
-    record_as(&env, Write::Command(&running, replaced), false).unwrap();
+    let elsewhere = dir.path().join("bin/kendex");
+    record_as(&env, Write::Command(&elsewhere), false).unwrap();
     assert_eq!(
-        recorded_command(&env).unwrap().digest,
-        crate::hash::sha256_hex(replaced),
+        recorded_command(&env).map(|record| record.path),
+        Some(elsewhere),
         "the update write did not land where the root arm was asked not to"
     );
 }
@@ -230,7 +156,7 @@ fn a_run_acting_as_root_writes_no_record() {
 /// from the syscall, not from [`acting_as_root`], which is the function
 /// whose wiring is in question.
 ///
-/// All three, because the seam takes the identity as an argument and an
+/// Both, because the seam takes the identity as an argument and an
 /// argument can be a literal. One entry passing its process's answer says
 /// nothing about the next: `record_command` is the write `kendex update`
 /// makes after the bytes land, and a constant there is this defect back
@@ -246,12 +172,9 @@ fn a_run_acting_as_root_writes_no_record() {
 #[cfg(unix)]
 fn every_public_write_follows_this_process_uid() {
     let privileged = rustix::process::geteuid().is_root();
-    let entries: [(&str, &dyn Fn(&Env, &Path) -> Result<(), String>); 3] = [
-        ("record_command", &|env, path| {
-            record_command(env, path, WRAPPER)
-        }),
+    let entries: [(&str, &dyn Fn(&Env, &Path) -> Result<(), String>); 2] = [
+        ("record_command", &record_command),
         ("record_first_run", &record_first_run),
-        ("record_installed", &record_installed),
     ];
 
     // A home of its own for each: a record already there is what
@@ -267,8 +190,8 @@ fn every_public_write_follows_this_process_uid() {
         write(&env, &running).unwrap();
 
         assert_eq!(
-            recorded_command(&env).map(|record| record.digest),
-            (!privileged).then(|| crate::hash::sha256_hex(WRAPPER)),
+            recorded_command(&env).map(|record| record.path),
+            (!privileged).then(|| running.clone()),
             "{entry} did not follow this process's uid (root: {privileged})"
         );
     }
@@ -284,8 +207,8 @@ fn every_public_write_follows_this_process_uid() {
     record_as(&env, Write::FirstRun(&running), !privileged).unwrap();
 
     assert_eq!(
-        recorded_command(&env).map(|record| record.digest),
-        privileged.then(|| crate::hash::sha256_hex(WRAPPER)),
+        recorded_command(&env).map(|record| record.path),
+        privileged.then(|| running.clone()),
         "the write does the same thing whichever identity it is told"
     );
 }

--- a/crates/core/src/command_update/tests.rs
+++ b/crates/core/src/command_update/tests.rs
@@ -7,6 +7,7 @@
 //! record that was never written.
 
 use super::*;
+use crate::env::Env;
 use crate::install_channel::Host;
 use record::{Write, record_as};
 
@@ -63,20 +64,9 @@ fn a_release_is_out_under(home: &Path) -> (String, PathBuf) {
     (file_url(&home.join("feed.json")), installed)
 }
 
-/// The command half, against a record store this test owns. Most arms
-/// never read it; the one that does is the refresh after a write.
+/// The command half, under this suite's release key and target.
 fn across(beside: &CommandBeside, feed: &str, release: &str) -> Result<CommandHalf, String> {
-    let store = tempfile::tempdir().unwrap();
-    across_in(&Env::host_rooted(store.path()), beside, feed, release)
-}
-
-fn across_in(
-    env: &Env,
-    beside: &CommandBeside,
-    feed: &str,
-    release: &str,
-) -> Result<CommandHalf, String> {
-    bring_command_across(env, beside, feed, release, TARGET, TEST_KEY)
+    bring_command_across(beside, feed, release, TARGET, TEST_KEY)
 }
 
 /// The whole point of the family update: the command a person runs ends
@@ -150,9 +140,7 @@ fn a_release_with_no_command_for_this_target_stops_the_family() {
     let dir = tempfile::tempdir().unwrap();
     let (feed_url, installed) = a_release_is_out(&dir);
 
-    let store = tempfile::tempdir().unwrap();
     let refused = bring_command_across(
-        &Env::host_rooted(store.path()),
         &CommandBeside::Ours(installed.clone()),
         &feed_url,
         RELEASE,
@@ -267,13 +255,6 @@ impl HostProbe for Machine {
             .map_or_else(|| path.to_owned(), |(_, to)| to.clone())
     }
 
-    /// One file, one digest: what a path holds stands in for the bytes at
-    /// it, so two different files never carry one identity.
-    fn digest(&self, path: &Path) -> Option<String> {
-        self.is_command(path)
-            .then(|| crate::hash::sha256_hex(path.display().to_string().as_bytes()))
-    }
-
     fn on_path(&self, _: &str) -> bool {
         false
     }
@@ -292,20 +273,13 @@ fn candidates(paths: &[&str]) -> Vec<PathBuf> {
 /// and the found path is a different file, which reads `NotOurs` and fails
 /// the assertion just as loudly.
 fn located(machine: &Machine, probed: &[PathBuf], installed: &str) -> CommandBeside {
-    command_beside_app(machine, probed, &[], Some(&recorded(machine, installed)))
+    command_beside_app(machine, probed, &[], Some(&recorded(installed)))
 }
 
-/// The record an installer would have left for a file on this machine:
-/// where it installed, and the digest of what is there now.
-fn recorded(machine: &Machine, path: &str) -> InstalledCommand {
-    let path = PathBuf::from(path);
+/// The record an installer would have left for a file on this machine.
+fn recorded(path: &str) -> InstalledCommand {
     InstalledCommand {
-        digest: machine
-            .digest(&machine.resolve(&path))
-            // Nothing at that path to take an identity from — a record of
-            // a file this machine does not have.
-            .unwrap_or_else(|| "0".repeat(64)),
-        path,
+        path: PathBuf::from(path),
     }
 }
 
@@ -422,9 +396,9 @@ fn a_command_no_installer_recorded_is_never_replaced() {
 /// record is what refused the wrapper, and not a fixture that could never
 /// have been carried in the first place.
 ///
-/// The record is rewritten for what landed, too: leave it naming the bytes
-/// that were replaced and the next release finds a command it owns and
-/// cannot prove, which refuses an update nobody had to be refused.
+/// The record is rewritten for what landed, too: it has to keep naming the
+/// command the app just replaced, or the next release finds one it cannot
+/// prove and refuses an update nobody had to be refused.
 #[test]
 fn the_command_an_installer_recorded_is_carried_across() {
     // The rewrite this asserts is `across_in`'s own, through the entry
@@ -437,7 +411,7 @@ fn the_command_an_installer_recorded_is_carried_across() {
     }
     let dir = tempfile::tempdir().unwrap();
     let (env, command) = a_kendex_on_this_machine(&dir);
-    record_as(&env, Write::Installed(&command), false).unwrap();
+    record_as(&env, Write::Command(&command), false).unwrap();
     let probed = vec![command.clone()];
 
     let beside = command_beside_app(&Host, &probed, &[], recorded_command(&env).as_ref());
@@ -445,14 +419,14 @@ fn the_command_an_installer_recorded_is_carried_across() {
 
     let (feed_url, _) = a_release_is_out(&dir);
     assert_eq!(
-        across_in(&env, &beside, &feed_url, RELEASE).unwrap(),
+        across(&beside, &feed_url, RELEASE).unwrap(),
         CommandHalf::Moved
     );
     assert_eq!(std::fs::read(&command).unwrap(), OFFERED);
     assert_eq!(
-        recorded_command(&env).unwrap().digest,
-        crate::hash::sha256_hex(OFFERED),
-        "the record still names the bytes that were replaced"
+        recorded_command(&env).map(|record| record.path),
+        Some(command.clone()),
+        "the record stopped naming the command that was replaced"
     );
     assert_eq!(
         command_beside_app(&Host, &probed, &[], recorded_command(&env).as_ref()),
@@ -460,42 +434,6 @@ fn the_command_an_installer_recorded_is_carried_across() {
         "a release the app just installed is not one it has to refuse next time"
     );
 }
-
-/// The harm the record exists to stop, arrived at through the record
-/// itself: a path is a name, and the file behind a name can be replaced.
-/// Remove what kendex installed, put a wrapper of your own at that path,
-/// and every question about the path answers yes — so the digest is what
-/// has to answer no, and the wrapper is left as its author wrote it.
-#[test]
-fn a_different_file_at_the_recorded_path_is_not_the_recorded_command() {
-    let dir = tempfile::tempdir().unwrap();
-    let (env, command) = a_kendex_on_this_machine(&dir);
-    record_as(&env, Write::Installed(&command), false).unwrap();
-    let probed = vec![command.clone()];
-
-    // The control: what the same lookup says while the recorded bytes are
-    // still there. Without it, an assertion below passes for a fixture
-    // that was never carried in the first place.
-    assert_eq!(
-        command_beside_app(&Host, &probed, &[], recorded_command(&env).as_ref()),
-        CommandBeside::Ours(Host.resolve(&command))
-    );
-
-    std::fs::write(&command, SOMEONE_ELSES).unwrap();
-    let beside = command_beside_app(&Host, &probed, &[], recorded_command(&env).as_ref());
-
-    assert_eq!(beside, CommandBeside::NotOurs(InstallChannel::Unknown));
-    let (feed_url, _) = a_release_is_out(&dir);
-    assert_eq!(
-        across(&beside, &feed_url, RELEASE).unwrap(),
-        CommandHalf::Untouched
-    );
-    assert_eq!(std::fs::read(&command).unwrap(), SOMEONE_ELSES);
-}
-
-/// A second wrapper, written where the first one was: the bytes differ,
-/// so the digest differs, and the path they share proves nothing.
-const SOMEONE_ELSES: &[u8] = b"#!/bin/sh\nexec /opt/other/kendex \"$@\"\n";
 
 /// A record naming one command says nothing about another. Someone with
 /// an install.sh kendex and a wrapper of their own on `PATH` ahead of it
@@ -505,12 +443,12 @@ fn a_record_of_one_command_does_not_vouch_for_another() {
     let dir = tempfile::tempdir().unwrap();
     let (env, wrapper) = a_kendex_on_this_machine(&dir);
     let theirs = Path::new("/home/pat/.local/bin/kendex");
-    record_as(&env, Write::Command(theirs, WRAPPER), false).unwrap();
+    record_as(&env, Write::Command(theirs), false).unwrap();
 
     assert_eq!(
         command_beside_app(&Host, &[wrapper], &[], recorded_command(&env).as_ref()),
         CommandBeside::NotOurs(InstallChannel::Unknown),
-        "the digest matches the bytes and the path does not"
+        "a record of another path vouched for this one"
     );
 }
 
@@ -546,8 +484,7 @@ fn a_recorded_command_no_other_route_reaches_is_still_found() {
 /// `install.sh` writes `/usr/local/bin` with `sudo` whenever that is the
 /// first of its two directories on `PATH`, and the desktop app runs
 /// unprivileged. The command there is kendex's — an installer recorded
-/// it, digest and all — and what is missing is the privilege to replace
-/// it. Called not ours, that reads as a command kendex has no claim on and
+/// it — and what is missing is the privilege to replace it. Called not ours, that reads as a command kendex has no claim on and
 /// names nothing a person can do; called what it is, the card can name the
 /// one command that moves it.
 #[test]

--- a/crates/core/src/command_update/tests.rs
+++ b/crates/core/src/command_update/tests.rs
@@ -13,10 +13,6 @@ use record::{Write, record_as};
 
 mod described;
 
-#[path = "../../../test_util.rs"]
-mod test_util;
-use test_util::no_record_on_this_runner;
-
 #[path = "../../../fixture_url.rs"]
 mod fixture_url;
 use fixture_url::file_url;
@@ -396,19 +392,12 @@ fn a_command_no_installer_recorded_is_never_replaced() {
 /// record is what refused the wrapper, and not a fixture that could never
 /// have been carried in the first place.
 ///
-/// The record is rewritten for what landed, too: it has to keep naming the
-/// command the app just replaced, or the next release finds one it cannot
-/// prove and refuses an update nobody had to be refused.
+/// The record is left exactly as it was, too: it names a path, so the
+/// bytes that land at that path are still the command it names, and the
+/// next release finds a command it can prove rather than one it has to
+/// refuse.
 #[test]
 fn the_command_an_installer_recorded_is_carried_across() {
-    // The rewrite this asserts is `across_in`'s own, through the entry
-    // point that asks the process — the one write here that is not a
-    // fixture, and so the one that cannot be told a different identity.
-    // A root runner suppresses it, correctly: the record is repaired by
-    // the person's next unprivileged run, which is not this process.
-    if no_record_on_this_runner() {
-        return;
-    }
     let dir = tempfile::tempdir().unwrap();
     let (env, command) = a_kendex_on_this_machine(&dir);
     record_as(&env, Write::Command(&command), false).unwrap();
@@ -418,15 +407,17 @@ fn the_command_an_installer_recorded_is_carried_across() {
     assert_eq!(beside, CommandBeside::Ours(Host.resolve(&command)));
 
     let (feed_url, _) = a_release_is_out(&dir);
+    let record = env.installed_command_file();
+    let written = std::fs::read(&record).unwrap();
     assert_eq!(
         across(&beside, &feed_url, RELEASE).unwrap(),
         CommandHalf::Moved
     );
     assert_eq!(std::fs::read(&command).unwrap(), OFFERED);
     assert_eq!(
-        recorded_command(&env).map(|record| record.path),
-        Some(command.clone()),
-        "the record stopped naming the command that was replaced"
+        std::fs::read(&record).unwrap(),
+        written,
+        "the command half rewrote a record that already named the path it replaced"
     );
     assert_eq!(
         command_beside_app(&Host, &probed, &[], recorded_command(&env).as_ref()),

--- a/crates/core/src/command_update/tests/described.rs
+++ b/crates/core/src/command_update/tests/described.rs
@@ -96,7 +96,7 @@ fn nothing_installed_and_the_running_app_both_read_absent() {
             &only_the_app,
             &probed,
             &[image.clone()],
-            Some(&recorded(&only_the_app, &image.display().to_string()))
+            Some(&recorded(&image.display().to_string()))
         ),
         CommandBeside::Absent
     );
@@ -124,7 +124,7 @@ fn a_windows_app_on_path_is_never_taken_for_the_command() {
             &machine,
             &probed,
             &[],
-            Some(&recorded(&machine, &exe.display().to_string()))
+            Some(&recorded(&exe.display().to_string()))
         ),
         CommandBeside::Ours(exe.clone()),
         "the fixture has to reach the app before the exclusion can be what stops it"
@@ -134,7 +134,7 @@ fn a_windows_app_on_path_is_never_taken_for_the_command() {
             &machine,
             &probed,
             &[exe.clone()],
-            Some(&recorded(&machine, &exe.display().to_string()))
+            Some(&recorded(&exe.display().to_string()))
         ),
         CommandBeside::Absent
     );

--- a/crates/core/src/env.rs
+++ b/crates/core/src/env.rs
@@ -184,14 +184,12 @@ impl Env {
     }
 
     /// Where an installer records the `kendex` command it installed: one
-    /// absolute path, then the SHA-256 of the bytes it put there, a line
-    /// each.
+    /// absolute path, on one line.
     ///
     /// Being executable and being named `kendex` is not being kendex, so
-    /// the desktop app carries a command across only when it is the file
-    /// written here — the path says where and the digest says which, since
-    /// a name outlives whatever answered to it. `install.sh` writes both,
-    /// and every replacement rewrites them for the bytes that landed.
+    /// the desktop app carries a command across only when it is at the path
+    /// written here. `install.sh` writes it, and a replacement at that path
+    /// is still the command it names, so the record is left as it is.
     pub fn installed_command_file(&self) -> PathBuf {
         self.data_dir.join(APP_DIR).join("installed-command")
     }

--- a/crates/core/src/hash.rs
+++ b/crates/core/src/hash.rs
@@ -131,18 +131,6 @@ pub fn hash_bytes(bytes: &[u8]) -> String {
     hex(&hasher.finalize())
 }
 
-/// Plain SHA-256 over these bytes, hex, with nothing framed in — the
-/// digest `sha256sum` and `shasum -a 256` print for a file holding them.
-///
-/// [`hash_bytes`] is kendex's own encoding and only kendex can produce it.
-/// This one is what a shell script and this build can both compute over one
-/// file and get the same answer for, which is what the installed-command
-/// record needs: `install.sh` writes the digest of the binary it installed
-/// and the app checks the file it found against it.
-pub fn sha256_hex(bytes: &[u8]) -> String {
-    hex(&Sha256::digest(bytes))
-}
-
 /// The hash an in-memory rendered tree will have once written — mirrors
 /// `hash_tree` so plans can compare desired vs. disk without materializing.
 pub fn hash_files(files: &[(std::path::PathBuf, Vec<u8>)]) -> String {

--- a/crates/core/src/install_channel.rs
+++ b/crates/core/src/install_channel.rs
@@ -181,10 +181,6 @@ pub trait HostProbe {
     /// the path it was exec'd with, symlinks intact.
     fn resolve(&self, path: &Path) -> PathBuf;
 
-    /// The plain SHA-256 of a file's bytes, absent where it cannot be read.
-    /// A name kendex once answered to says nothing about what answers now.
-    fn digest(&self, path: &Path) -> Option<String>;
-
     /// Whether a command is on `PATH`.
     fn on_path(&self, command: &str) -> bool;
 
@@ -224,12 +220,6 @@ impl HostProbe for Host {
 
     fn resolve(&self, path: &Path) -> PathBuf {
         std::fs::canonicalize(path).unwrap_or_else(|_| path.to_owned())
-    }
-
-    fn digest(&self, path: &Path) -> Option<String> {
-        std::fs::read(path)
-            .ok()
-            .map(|b| crate::hash::sha256_hex(&b))
     }
 
     fn on_path(&self, command: &str) -> bool {

--- a/crates/core/src/install_channel/tests.rs
+++ b/crates/core/src/install_channel/tests.rs
@@ -56,8 +56,6 @@ impl HostProbe for Fake {
         self.present.iter().any(|p| Path::new(p) == path)
     }
 
-    /// Nothing routed through this fake asks either: which installer owns
-    /// a path is a question about the path, not about the bytes at it.
     fn on_path(&self, command: &str) -> bool {
         self.on_path.iter().any(|c| c == command)
     }

--- a/crates/core/src/install_channel/tests.rs
+++ b/crates/core/src/install_channel/tests.rs
@@ -58,10 +58,6 @@ impl HostProbe for Fake {
 
     /// Nothing routed through this fake asks either: which installer owns
     /// a path is a question about the path, not about the bytes at it.
-    fn digest(&self, _: &Path) -> Option<String> {
-        None
-    }
-
     fn on_path(&self, command: &str) -> bool {
         self.on_path.iter().any(|c| c == command)
     }

--- a/crates/core/src/registry/client.rs
+++ b/crates/core/src/registry/client.rs
@@ -7,19 +7,6 @@ use crate::registry::credentials::{Credential, CredentialStore};
 use crate::registry::login::TokenPair;
 use crate::registry::{Fetch, FetchResponse, base_url};
 
-/// One answer and the credential it finally went out under.
-///
-/// A call reaches that credential three ways: it answers under what it
-/// opened with, it rotates to a replacement it made itself, or it adopts
-/// one another writer installed while it was in flight. A rotation keeps
-/// `sign_in`; the other two carry whatever sign-in they belong to. So a
-/// caller that read state before the call compares that state's sign-in
-/// against this credential's, and the three routes need no telling apart.
-pub struct Authenticated {
-    pub response: FetchResponse,
-    pub credential: Credential,
-}
-
 /// Run one authenticated call, refreshing a rejected access token once.
 /// Refresh rotation is locked across processes and saved before retry.
 /// Every path that answers `SignInExpired` removes the rejected credential
@@ -32,14 +19,11 @@ pub fn with_access(
     fetch: &dyn Fetch,
     store: &dyn CredentialStore,
     call: impl Fn(&str) -> Result<FetchResponse>,
-) -> Result<Authenticated> {
+) -> Result<FetchResponse> {
     let opened_under = required(store.load()?)?;
     let first = call(&opened_under.access_token)?;
     if first.status != 401 {
-        return Ok(Authenticated {
-            response: first,
-            credential: opened_under,
-        });
+        return Ok(first);
     }
     rotate_after_rejection(fetch, store, &call, opened_under)
 }
@@ -49,7 +33,7 @@ fn rotate_after_rejection(
     store: &dyn CredentialStore,
     call: &impl Fn(&str) -> Result<FetchResponse>,
     mut rejected: Credential,
-) -> Result<Authenticated> {
+) -> Result<FetchResponse> {
     let mut newer_retries = 0;
     loop {
         let refresh_guard = store.refresh_guard()?;
@@ -58,12 +42,7 @@ fn rotate_after_rejection(
             drop(refresh_guard);
             let retried = call(&locked.access_token)?;
             if retried.status != 401 {
-                // Somebody else installed this credential mid-call. The
-                // answer is theirs, and carries their sign-in.
-                return Ok(Authenticated {
-                    response: retried,
-                    credential: locked,
-                });
+                return Ok(retried);
             }
             if newer_retries == 1 {
                 return Err(rejected_access(store, &locked));
@@ -82,7 +61,7 @@ fn rotate_locked(
     call: &impl Fn(&str) -> Result<FetchResponse>,
     credential: Credential,
     refresh_guard: Box<dyn crate::registry::credentials::CredentialRefreshGuard + '_>,
-) -> Result<Authenticated> {
+) -> Result<FetchResponse> {
     let pair = match refresh(fetch, &credential.refresh_token) {
         Ok(pair) => pair,
         Err(Refused::Definitive(why)) => {
@@ -114,10 +93,7 @@ fn rotate_locked(
     if second.status == 401 {
         return Err(rejected_access(store, &rotated));
     }
-    Ok(Authenticated {
-        response: second,
-        credential: rotated,
-    })
+    Ok(second)
 }
 
 /// Commit a completed device login without racing refresh or logout, and
@@ -185,7 +161,8 @@ enum Removal {
     Done,
     /// Another writer's family is installed; nothing was touched.
     Moved,
-    /// It may still be installed: the store refused a read or a delete.
+    /// It may still be installed: the store refused the guard, the read,
+    /// or the delete.
     Failed(CoreError),
 }
 

--- a/crates/core/src/registry/me.rs
+++ b/crates/core/src/registry/me.rs
@@ -68,20 +68,20 @@ struct WireMe {
 /// identity as `Offline`, and errors only with nothing cached to serve. A
 /// credential gone by the time the answer lands is `SignedOut` too, and
 /// nothing is written back over the sign-out. Everything this read
-/// settles belongs to one sign-in: the cache it opens with, the call it
-/// sends, and the answer it caches. That sign-in is named on the
-/// credential, so what is compared is the name and not the tokens, which
-/// move. A rotation keeps the name whichever call performed it, so it
-/// settles as usual and leaves a cache the next read can still use. Only
-/// a different sign-in is refused as retryable, because then the identity
-/// in hand is the previous account's.
+/// settles belongs to one sign-in: the cache it opens with and the
+/// credential still installed when it settles. That sign-in is named on
+/// the credential, so what is compared is the name and not the tokens,
+/// which move. A rotation keeps the name whichever call performed it, so
+/// it settles as usual and leaves a cache the next read can still use.
+/// Only a different sign-in is refused as retryable, because then the
+/// identity in hand is the previous account's.
 pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<AccountState> {
     let Some(credential) = store.load()? else {
         return Ok(AccountState::SignedOut);
     };
     // The sign-in's own name, which a rotation carries and only a new
-    // sign-in changes. The cache read next, the call sent after it, and
-    // the answer settled at the end all have to be this one.
+    // sign-in changes. The cache read next and the credential installed
+    // when this settles both have to be this one.
     let issued_under = credential.sign_in;
     // Keyed to this sign-in, so a generation the previous one left behind
     // is not a cache at all here.
@@ -91,7 +91,7 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
         .as_ref()
         .and_then(|(generation, _)| generation.etag.clone());
     let url = format!("{}/api/v1/me", base_url());
-    let (fetched, answered_for) = match client::with_access(fetch, store, |access| {
+    let fetched = match client::with_access(fetch, store, |access| {
         fetch.get_auth(&url, etag.as_deref(), Some(access))
     }) {
         // Logout won a race with this read: the re-login state without
@@ -107,10 +107,7 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
                 sign_in: issued_under,
             });
         }
-        Ok(authenticated) => (Ok(authenticated.response), authenticated.credential.sign_in),
-        // Nothing came back, so the cache is the whole answer, and it
-        // belongs to whoever was signed in when the read began.
-        Err(error) => (Err(error), issued_under.clone()),
+        fetched => fetched,
     };
     // A sign-out that landed while this read was in flight already forgot
     // the cache; settling now would write the identity straight back. The
@@ -120,13 +117,12 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
     };
     // Existence is not identity: a sign-out followed by a sign-in leaves
     // a credential here too, and nothing here belongs to either of them.
-    // One name over two spans. The answer has to carry the sign-in
-    // `cached` was read under, and that sign-in has to be the one still
+    // The sign-in `cached` was read under has to be the one still
     // installed. A sign-in landing before the call leaves the previous
     // account's identity in hand, which a 304 gives back whole and any
     // failure serves as offline; one landing after settles this answer
     // under a stranger. A rotation is neither, because it keeps the name.
-    if answered_for != issued_under || installed.sign_in != issued_under {
+    if installed.sign_in != issued_under {
         return Err(sign_in_changed("reading your account"));
     }
     let loaded = cache.settle(cached, fetched, parse, |response| {

--- a/crates/core/src/registry/me.rs
+++ b/crates/core/src/registry/me.rs
@@ -74,7 +74,11 @@ struct WireMe {
 /// which move. A rotation keeps the name whichever call performed it, so
 /// it settles as usual and leaves a cache the next read can still use.
 /// Only a different sign-in is refused as retryable, because then the
-/// identity in hand is the previous account's.
+/// identity in hand is the previous account's. An expiry ends the read
+/// ahead of that comparison and is named for the sign-in it opened under:
+/// `client.rs` removes the credential the rejected call authenticated as,
+/// and answers a retryable refusal instead where the sign-in installed by
+/// then is another writer's.
 pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<AccountState> {
     let Some(credential) = store.load()? else {
         return Ok(AccountState::SignedOut);

--- a/crates/core/src/registry/me.rs
+++ b/crates/core/src/registry/me.rs
@@ -76,9 +76,10 @@ struct WireMe {
 /// Only a different sign-in is refused as retryable, because then the
 /// identity in hand is the previous account's. An expiry ends the read
 /// ahead of that comparison and is named for the sign-in it opened under:
-/// `client.rs` removes the family its own call was refused under and no
-/// other, answering a retryable refusal instead where the sign-in
-/// installed by then is another writer's.
+/// `client.rs` removes the credential the refusal belongs to, and where
+/// the server's own rejection lands on a sign-in another writer installed
+/// in the moment the refresh guard was down, it answers a retryable
+/// refusal and removes nothing.
 pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<AccountState> {
     let Some(credential) = store.load()? else {
         return Ok(AccountState::SignedOut);

--- a/crates/core/src/registry/me.rs
+++ b/crates/core/src/registry/me.rs
@@ -76,9 +76,9 @@ struct WireMe {
 /// Only a different sign-in is refused as retryable, because then the
 /// identity in hand is the previous account's. An expiry ends the read
 /// ahead of that comparison and is named for the sign-in it opened under:
-/// `client.rs` removes the credential the rejected call authenticated as,
-/// and answers a retryable refusal instead where the sign-in installed by
-/// then is another writer's.
+/// `client.rs` removes the family its own call was refused under and no
+/// other, answering a retryable refusal instead where the sign-in
+/// installed by then is another writer's.
 pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<AccountState> {
     let Some(credential) = store.load()? else {
         return Ok(AccountState::SignedOut);

--- a/crates/core/src/registry/submit.rs
+++ b/crates/core/src/registry/submit.rs
@@ -106,8 +106,7 @@ pub fn submit(fetch: &dyn Fetch, store: &dyn CredentialStore, repo: &str) -> Res
     let url = format!("{}/api/v1/submissions", base_url());
     let response = with_access(fetch, store, |access| {
         fetch.post_json_auth(&url, &body, Some(access))
-    })?
-    .response;
+    })?;
     if response.status == 201 {
         return serde_json::from_slice(&response.body).map_err(|error| {
             CoreError::RegistryMalformed {
@@ -122,8 +121,7 @@ pub fn submissions(fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<Vec
     let url = format!("{}/api/v1/submissions", base_url());
     let response = with_access(fetch, store, |access| {
         fetch.get_auth(&url, None, Some(access))
-    })?
-    .response;
+    })?;
     if response.status == 200 {
         let wire: WireSubmissions = serde_json::from_slice(&response.body).map_err(|error| {
             CoreError::RegistryMalformed {

--- a/crates/core/tests/credential_transactions.rs
+++ b/crates/core/tests/credential_transactions.rs
@@ -196,8 +196,6 @@ fn an_older_logout_during_revoke_stays_signed_out() {
 /// flight, in the window neither producer holds the refresh guard across.
 enum Race {
     None,
-    /// A login installing this family.
-    Install(&'static str),
     /// A logout, leaving nothing installed.
     LogOut,
 }
@@ -206,7 +204,6 @@ impl Race {
     fn run(&self, store: &Store) -> Result<()> {
         match self {
             Race::None => Ok(()),
-            Race::Install(name) => store.save(&credential(name)),
             Race::LogOut => store.clear(),
         }
     }
@@ -292,28 +289,6 @@ fn two_rejected_concurrent_tokens_end_the_bounded_retry() {
     );
 }
 
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_login_landing_during_the_bounded_retry_is_never_cleared() {
-    let store = Arc::new(Store::signed_in());
-    let fetch = RejectingNewerTokens {
-        store: Arc::clone(&store),
-        bearers: Mutex::new(Vec::new()),
-        refresh_calls: AtomicUsize::new(0),
-        race_on_last: Race::Install("newest"),
-    };
-
-    let refused = submit(&fetch, store.as_ref(), "jane/skills")
-        .unwrap_err()
-        .to_string();
-
-    assert!(
-        refused.contains("the sign-in changed while authenticating"),
-        "{refused}"
-    );
-    assert_eq!(store.load().unwrap().unwrap().access_token, "kxa_newest");
-}
-
 /// Rotates once and rejects the fresh token too, optionally letting another
 /// writer reach the store while that rejection is in flight.
 struct RejectingRotation {
@@ -385,26 +360,6 @@ fn a_rotation_the_server_still_rejects_clears_the_sign_in() {
         store.load().unwrap().is_none(),
         "the freshly rotated family the server refused is not left installed"
     );
-}
-
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_login_landing_after_rotation_is_never_cleared() {
-    let store = Arc::new(Store::signed_in());
-    let fetch = RejectingRotation {
-        store: Arc::clone(&store),
-        race_on_rotated: Race::Install("newest"),
-    };
-
-    let refused = submit(&fetch, store.as_ref(), "jane/skills")
-        .unwrap_err()
-        .to_string();
-
-    assert!(
-        refused.contains("the sign-in changed while authenticating"),
-        "{refused}"
-    );
-    assert_eq!(store.load().unwrap().unwrap().access_token, "kxa_newest");
 }
 
 #[test]

--- a/crates/core/tests/credential_transactions.rs
+++ b/crates/core/tests/credential_transactions.rs
@@ -196,6 +196,8 @@ fn an_older_logout_during_revoke_stays_signed_out() {
 /// flight, in the window neither producer holds the refresh guard across.
 enum Race {
     None,
+    /// A login installing this family.
+    Install(&'static str),
     /// A logout, leaving nothing installed.
     LogOut,
 }
@@ -204,6 +206,7 @@ impl Race {
     fn run(&self, store: &Store) -> Result<()> {
         match self {
             Race::None => Ok(()),
+            Race::Install(name) => store.save(&credential(name)),
             Race::LogOut => store.clear(),
         }
     }
@@ -289,6 +292,32 @@ fn two_rejected_concurrent_tokens_end_the_bounded_retry() {
     );
 }
 
+/// A `kendex login` completing while the last rejection is in flight needs
+/// only the refresh guard, which this window does not hold. The credential
+/// it installed was never refused, so it stays, and the caller is told the
+/// sign-in moved rather than that their account expired.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_login_landing_during_the_bounded_retry_is_never_cleared() {
+    let store = Arc::new(Store::signed_in());
+    let fetch = RejectingNewerTokens {
+        store: Arc::clone(&store),
+        bearers: Mutex::new(Vec::new()),
+        refresh_calls: AtomicUsize::new(0),
+        race_on_last: Race::Install("newest"),
+    };
+
+    let refused = submit(&fetch, store.as_ref(), "jane/skills")
+        .unwrap_err()
+        .to_string();
+
+    assert!(
+        refused.contains("the sign-in changed while authenticating"),
+        "{refused}"
+    );
+    assert_eq!(store.load().unwrap().unwrap().access_token, "kxa_newest");
+}
+
 /// Rotates once and rejects the fresh token too, optionally letting another
 /// writer reach the store while that rejection is in flight.
 struct RejectingRotation {
@@ -360,6 +389,29 @@ fn a_rotation_the_server_still_rejects_clears_the_sign_in() {
         store.load().unwrap().is_none(),
         "the freshly rotated family the server refused is not left installed"
     );
+}
+
+/// The same window on the other producer: the rotated token is rejected
+/// with the guard already dropped, so a login that landed by then owns the
+/// store and its credential is not this rejection's to delete.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_login_landing_after_rotation_is_never_cleared() {
+    let store = Arc::new(Store::signed_in());
+    let fetch = RejectingRotation {
+        store: Arc::clone(&store),
+        race_on_rotated: Race::Install("newest"),
+    };
+
+    let refused = submit(&fetch, store.as_ref(), "jane/skills")
+        .unwrap_err()
+        .to_string();
+
+    assert!(
+        refused.contains("the sign-in changed while authenticating"),
+        "{refused}"
+    );
+    assert_eq!(store.load().unwrap().unwrap().access_token, "kxa_newest");
 }
 
 #[test]

--- a/crates/core/tests/me_client/sign_in_binding.rs
+++ b/crates/core/tests/me_client/sign_in_binding.rs
@@ -194,36 +194,6 @@ impl CredentialStore for JammingStore<'_> {
     }
 }
 
-/// A store where somebody signs in again between every read: each load
-/// hands back a credential no earlier read saw. It drives the branch that
-/// gives up after two retries under newer tokens.
-struct RestlessStore {
-    reads: Cell<u32>,
-}
-
-impl CredentialStore for RestlessStore {
-    fn save(&self, _credential: &Credential) -> Result<()> {
-        Ok(())
-    }
-    fn load(&self) -> Result<Option<Credential>> {
-        let read = self.reads.get() + 1;
-        self.reads.set(read);
-        Ok(Some(Credential {
-            endpoint: "https://kendex.ai".to_owned(),
-            access_token: format!("kxa_{read}"),
-            refresh_token: format!("kxr_{read}"),
-            capabilities: vec![],
-            sign_in: format!("sign-in-{read}"),
-        }))
-    }
-    fn clear(&self) -> Result<()> {
-        Ok(())
-    }
-    fn refresh_guard(&self) -> Result<Box<dyn CredentialRefreshGuard + '_>> {
-        Ok(Box::new(MemoryGuard))
-    }
-}
-
 fn other_account() -> Credential {
     Credential {
         endpoint: "https://kendex.ai".to_owned(),
@@ -256,33 +226,6 @@ fn logout_winning_the_race_reads_as_signed_out() {
         *fetch.calls.borrow(),
         1,
         "no refresh is attempted once logout won"
-    );
-}
-
-#[test]
-fn a_sign_out_landing_mid_read_is_never_written_back() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let env = env_in(dir.path());
-    // The opening check and with_access both still see the credential; by
-    // the time the answer is settled, sign-out has cleared it.
-    let store = VanishingStore {
-        loads_before_gone: RefCell::new(2),
-        credential: Credential {
-            endpoint: "https://kendex.ai".to_owned(),
-            access_token: "kxa_old".to_owned(),
-            refresh_token: "kxr_old".to_owned(),
-            capabilities: vec![],
-            sign_in: ADA.to_owned(),
-        },
-    };
-    let fetch = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
-    assert_eq!(
-        me::load(&env, &fetch, &store).expect("load"),
-        AccountState::SignedOut
-    );
-    assert!(
-        !env.registry_cache_dir().join("me.cache.json").exists(),
-        "a read finishing after sign-out must leave no identity on disk"
     );
 }
 
@@ -545,55 +488,6 @@ fn a_sign_in_that_cannot_clear_the_cache_still_reports_success() {
             .refresh_token,
         "kxr_other",
         "the sign-in this call reported is the one the machine holds"
-    );
-}
-
-#[test]
-fn a_rejection_after_a_rotation_is_not_the_next_account_s_expiry() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let env = env_in(dir.path());
-    // Four reads carry this sign-in: the read's own, the call's, the
-    // locked re-read, and the check before the rotation is saved. The
-    // fifth is the one that decides whether the rejection is an expiry,
-    // and by then somebody else is signed in.
-    let store = SwitchingStore::after(4);
-    let fetch = Canned::new(vec![
-        ok(401, None, r#"{"error":"invalid_token"}"#),
-        ok(
-            200,
-            None,
-            r#"{"access_token":"kxa_new","refresh_token":"kxr_new","capabilities":[]}"#,
-        ),
-        ok(401, None, r#"{"error":"invalid_token"}"#),
-    ]);
-    let refused = me::load(&env, &fetch, &store)
-        .expect_err("one account's rejection is not another account's expiry");
-    assert!(
-        matches!(refused, CoreError::RegistryUnavailable { .. }),
-        "the sign-in moved under this call, so the read is retryable: got {refused:?}"
-    );
-}
-
-#[test]
-fn a_rejection_under_a_newer_token_is_not_the_next_account_s_expiry() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let env = env_in(dir.path());
-    // Every read finds a newer credential, so the call keeps retrying
-    // under somebody else's token until it gives up. Whoever is signed in
-    // by then never had a request rejected.
-    let store = RestlessStore {
-        reads: Cell::new(0),
-    };
-    let fetch = Canned::new(vec![
-        ok(401, None, r#"{"error":"invalid_token"}"#),
-        ok(401, None, r#"{"error":"invalid_token"}"#),
-        ok(401, None, r#"{"error":"invalid_token"}"#),
-    ]);
-    let refused = me::load(&env, &fetch, &store)
-        .expect_err("a rejection under a token that keeps moving is nobody's expiry");
-    assert!(
-        matches!(refused, CoreError::RegistryUnavailable { .. }),
-        "the sign-in moved under this call, so the read is retryable: got {refused:?}"
     );
 }
 

--- a/install.sh
+++ b/install.sh
@@ -123,36 +123,10 @@ install_cli() {
   # would otherwise write a release binary over it. Failing to record it
   # costs the app-side update, never the install, so it is reported and the
   # run continues.
-  #
-  # The path and the digest of the bytes at it, one per line. A path is a
-  # name, and the file behind a name can be replaced: without the digest a
-  # wrapper written where this command used to be reads as this command.
   state="$(kendex_data)"
-  digest="$(sha256_of "$bindir/kendex")" || digest=""
-  if [ -n "$digest" ] && mkdir -p "$state" 2>/dev/null \
-     && printf '%s\n%s\n' "$bindir/kendex" "$digest" > "$state/installed-command"; then
-    :
-  else
+  if ! { mkdir -p "$state" 2>/dev/null \
+     && printf '%s\n' "$bindir/kendex" > "$state/installed-command"; }; then
     echo "install.sh: could not record the command's identity in $state; the desktop app will not update it." >&2
-  fi
-}
-
-# The SHA-256 of a file, hex and nothing else, however this machine spells
-# it. Linux ships `sha256sum` with coreutils — which this script already
-# needs for `install` — and macOS ships `shasum`; `openssl` covers a machine
-# with neither. Every one of them prints the digest first and the filename
-# after, so one `cut` reads all three. No tool means no digest, which the
-# caller reports rather than recording a line the app cannot check.
-sha256_of() {
-  if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "$1" | cut -d' ' -f1
-  elif command -v shasum >/dev/null 2>&1; then
-    shasum -a 256 "$1" | cut -d' ' -f1
-  elif command -v openssl >/dev/null 2>&1; then
-    # `-r` for the same "digest filename" shape the other two print.
-    openssl dgst -sha256 -r "$1" | cut -d' ' -f1
-  else
-    return 1
   fi
 }
 

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -1,6 +1,5 @@
 .github/workflows/review-gate-writer.yml	662
 .github/workflows/skill-tests.yml	533
-crates/app/src/app_update.rs	403
 crates/core/src/engine/detach.rs	424
 crates/core/src/error.rs	503
 crates/core/src/settings_file.rs	408

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -55,9 +55,11 @@ export const commands = {
 	 *  release published for this target, and the app's bytes are held to both.
 	 *  The discovery feed never supplies an install URL, and the command's
 	 *  bytes are held to the key the CLI holds them to. A failure leaves the
-	 *  running app untouched and usable; the one error that is not a failure is
-	 *  that report, answered after both halves have landed and in place of the
-	 *  restart.
+	 *  running app untouched and usable, and is the `Err` half alone: the
+	 *  report is `Ok(Some(_))`, answered after both halves have landed and in
+	 *  place of the restart, so a card carrying it is not calling a finished
+	 *  update a failure. `Ok(None)` is the restart, which no caller lives to
+	 *  read.
 	 * 
 	 *  The command moves first. What this flow's notice card reads is the
 	 *  app's own baked version, so the app is the state marker here and is
@@ -82,7 +84,7 @@ export const commands = {
  *  Kendex's own command, where this app cannot write. `command` is
  *  what carries it across with the privilege the app lacks.
  */
-{ kind: "needsPrivilege"; path: string; command: string } | null) => typedError<null, string>(__TAURI_INVOKE("app_update_install", { shown })),
+{ kind: "needsPrivilege"; path: string; command: string } | null) => typedError<string | null, string>(__TAURI_INVOKE("app_update_install", { shown })),
 	scanMachine: () => typedError<ScanResult, string>(__TAURI_INVOKE("scan_machine")),
 	getSettings: () => typedError<SettingsRead, string>(__TAURI_INVOKE("get_settings")),
 	/**

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -48,11 +48,16 @@ export const commands = {
 	 *  Replace this install with the latest release and relaunch into it,
 	 *  carrying across a `kendex` command that is kendex's to replace. One
 	 *  another installer owns stays where it is, named on the card before this
-	 *  runs. The manifest names a download and the signature over it, the
-	 *  release's own digests document names what this release published for
-	 *  this target, and the app's bytes are held to both. The discovery feed never supplies an install URL, and the command's
+	 *  runs; `shown` is what that card said, so a command that changed since is
+	 *  reported rather than acted on in silence — see
+	 *  [`CommandNotice::not_as_shown`]. The manifest names a download and the
+	 *  signature over it, the release's own digests document names what this
+	 *  release published for this target, and the app's bytes are held to both.
+	 *  The discovery feed never supplies an install URL, and the command's
 	 *  bytes are held to the key the CLI holds them to. A failure leaves the
-	 *  running app untouched and usable.
+	 *  running app untouched and usable; the one error that is not a failure is
+	 *  that report, answered after both halves have landed and in place of the
+	 *  restart.
 	 * 
 	 *  The command moves first. What this flow's notice card reads is the
 	 *  app's own baked version, so the app is the state marker here and is
@@ -62,7 +67,22 @@ export const commands = {
 	 *  still offering the release, where an app already replaced and relaunched
 	 *  would report itself current and never come back for the command.
 	 */
-	appUpdateInstall: () => typedError<null, string>(__TAURI_INVOKE("app_update_install")),
+	appUpdateInstall: (shown: 
+/**
+ *  Another installer owns the command; `manager` names it and
+ *  `command` brings it current.
+ */
+{ kind: "managed"; manager: string; command: string } | 
+/**
+ *  Nothing names an owner and no record proves the file is kendex's,
+ *  so there is no name to print and no command to offer.
+ */
+{ kind: "unknown" } | 
+/**
+ *  Kendex's own command, where this app cannot write. `command` is
+ *  what carries it across with the privilege the app lacks.
+ */
+{ kind: "needsPrivilege"; path: string; command: string } | null) => typedError<null, string>(__TAURI_INVOKE("app_update_install", { shown })),
 	scanMachine: () => typedError<ScanResult, string>(__TAURI_INVOKE("scan_machine")),
 	getSettings: () => typedError<SettingsRead, string>(__TAURI_INVOKE("get_settings")),
 	/**

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -865,10 +865,12 @@ export type CatalogSummary = {
 };
 
 /**
- *  What the sidebar card says about the `kendex` command beside the app,
- *  before Update now is pressed — afterwards the app has restarted and
- *  there is no card left to say it on. `None` where there is nothing to
- *  say: no command here, or one Update now carries across itself.
+ *  What the sidebar card says about the `kendex` command beside the app.
+ *  Read before Update now is pressed, and read again after an install that
+ *  answered rather than restarting, which leaves the card up with this the
+ *  only thing on it that can still be true. An install that restarts takes
+ *  the card with it. `None` where there is nothing to say: no command
+ *  here, or one Update now carries across itself.
  * 
  *  Every string is fixed text decided by which arm ran, save the path,
  *  which names one file to a person who may have several — the rule the

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -48,11 +48,9 @@ export const commands = {
 	 *  Replace this install with the latest release and relaunch into it,
 	 *  carrying across a `kendex` command that is kendex's to replace. One
 	 *  another installer owns stays where it is, named on the card before this
-	 *  runs; `shown` is what that card said, so a command that changed since is
-	 *  refused rather than acted on in silence. The manifest names a download
-	 *  and the signature over it, the release's own digests document names what
-	 *  this release published for this target, and the app's bytes are held to
-	 *  both. The discovery feed never supplies an install URL, and the command's
+	 *  runs. The manifest names a download and the signature over it, the
+	 *  release's own digests document names what this release published for
+	 *  this target, and the app's bytes are held to both. The discovery feed never supplies an install URL, and the command's
 	 *  bytes are held to the key the CLI holds them to. A failure leaves the
 	 *  running app untouched and usable.
 	 * 
@@ -64,22 +62,7 @@ export const commands = {
 	 *  still offering the release, where an app already replaced and relaunched
 	 *  would report itself current and never come back for the command.
 	 */
-	appUpdateInstall: (shown: 
-/**
- *  Another installer owns the command; `manager` names it and
- *  `command` brings it current.
- */
-{ kind: "managed"; manager: string; command: string } | 
-/**
- *  Nothing names an owner and no record proves the file is kendex's,
- *  so there is no name to print and no command to offer.
- */
-{ kind: "unknown" } | 
-/**
- *  Kendex's own command, where this app cannot write. `command` is
- *  what carries it across with the privilege the app lacks.
- */
-{ kind: "needsPrivilege"; path: string; command: string } | null) => typedError<null, string>(__TAURI_INVOKE("app_update_install", { shown })),
+	appUpdateInstall: () => typedError<null, string>(__TAURI_INVOKE("app_update_install")),
 	scanMachine: () => typedError<ScanResult, string>(__TAURI_INVOKE("scan_machine")),
 	getSettings: () => typedError<SettingsRead, string>(__TAURI_INVOKE("get_settings")),
 	/**

--- a/ui/src/components/sidebar-notice.dom.test.tsx
+++ b/ui/src/components/sidebar-notice.dom.test.tsx
@@ -327,6 +327,9 @@ describe("a replacement that went through", () => {
     );
     expect(said).toBeDefined();
     expect(said?.className).not.toContain("text-critical");
+    // It arrives in the render that takes the button away, so nothing
+    // reads it unless the paragraph is a live region.
+    expect(said?.getAttribute("role")).toBe("status");
     expect(useNoticeStore.getState().error).toBeNull();
     // And the action is gone rather than disabled: there is nothing left
     // to run, and the card now says what is beside the app.

--- a/ui/src/components/sidebar-notice.dom.test.tsx
+++ b/ui/src/components/sidebar-notice.dom.test.tsx
@@ -302,33 +302,14 @@ describe("the action each channel allows", () => {
 });
 
 describe("a replacement that did not happen", () => {
-  // The engine refuses an install whose command changed since the card was
-  // drawn, and it can only tell that if it is handed what the card said.
-  // Handing it nothing would leave every such install going ahead on an
-  // answer the person never saw.
-  it("hands the engine the note the card is showing", async () => {
-    vi.mocked(commands.appUpdateInstall).mockResolvedValue({
-      status: "ok",
-      data: null,
-    });
-    const showing: CommandNotice = {
-      kind: "managed",
-      manager: "Homebrew",
-      command: "brew upgrade kendex-cli",
-    };
-    const container = await show({ kind: "direct" }, showing);
-    await press(container, APP_UPDATE_INSTALL_LABEL);
-    expect(commands.appUpdateInstall).toHaveBeenCalledWith(showing);
-  });
-
-  // The refusal tells the person the notice now says what is there, so the
-  // card has to read again — otherwise the sentence is false and pressing
-  // Update now again meets the same refusal forever.
-  it("reads the command again after a refusal, so the note is true", async () => {
+  // The card is the only surface left saying what happens to the command
+  // beside the app, and a failed install is where that answer is most
+  // likely to have moved. Left unread, the card the person is looking at
+  // describes a machine that has since changed.
+  it("reads the command again after a failure, so the note is true", async () => {
     vi.mocked(commands.appUpdateInstall).mockResolvedValue({
       status: "error",
-      error:
-        "the kendex command beside this app is no longer the one the notice described",
+      error: "the release could not be verified",
     });
     const changed: CommandNotice = { kind: "unknown" };
     const container = await show({ kind: "direct" }, null);
@@ -342,7 +323,7 @@ describe("a replacement that did not happen", () => {
 
     expect(useNoticeStore.getState().commandChannel).toEqual(changed);
     expect(container.textContent).toContain(APP_UPDATE_COMMAND_UNKNOWN_NOTE);
-    expect(container.textContent).toContain("no longer the one the notice");
+    expect(container.textContent).toContain("could not be verified");
   });
 
   it("says why on the card and leaves the action to try again", async () => {

--- a/ui/src/components/sidebar-notice.dom.test.tsx
+++ b/ui/src/components/sidebar-notice.dom.test.tsx
@@ -333,6 +333,33 @@ describe("a replacement that went through", () => {
     expect(() => offer(container, APP_UPDATE_INSTALL_LABEL)).toThrow();
     expect(container.textContent).toContain(APP_UPDATE_COMMAND_UNKNOWN_NOTE);
   });
+
+  // A read that failed says nothing rather than guessing, which is the
+  // rule the first read follows too. Kept, the description on the card
+  // would be the one drawn before the install — a machine as it no longer
+  // is, with the action gone so nobody can ask again.
+  it("drops the command description it could not read again", async () => {
+    const left = "kendex 5.1.0 is installed and starts on the next launch";
+    vi.mocked(commands.appUpdateInstall).mockResolvedValue({
+      status: "ok",
+      data: left,
+    });
+    const container = await show({ kind: "direct" }, { kind: "unknown" });
+    expect(container.textContent).toContain(APP_UPDATE_COMMAND_UNKNOWN_NOTE);
+    vi.mocked(commands.appUpdateCommandChannel).mockResolvedValue({
+      status: "error",
+      error: "the command beside this app could not be read",
+    });
+
+    await press(container, APP_UPDATE_INSTALL_LABEL);
+    await settle();
+
+    expect(container.textContent).toContain(left);
+    expect(useNoticeStore.getState().commandChannel).toBeNull();
+    expect(container.textContent).not.toContain(
+      APP_UPDATE_COMMAND_UNKNOWN_NOTE,
+    );
+  });
 });
 
 describe("what pressing Update now hands the engine", () => {

--- a/ui/src/components/sidebar-notice.dom.test.tsx
+++ b/ui/src/components/sidebar-notice.dom.test.tsx
@@ -106,6 +106,7 @@ beforeEach(() => {
     channel: { kind: "unknown" },
     installing: false,
     error: null,
+    note: null,
   });
   vi.mocked(commands.appVersion).mockResolvedValue(RUNNING);
   vi.mocked(commands.appUpdateCheck).mockResolvedValue(available());
@@ -298,6 +299,39 @@ describe("the action each channel allows", () => {
     await settle();
     expect(container.textContent).toContain(APP_UPDATE_UNKNOWN_NOTE);
     expect(container.textContent).not.toContain(APP_UPDATE_INSTALL_LABEL);
+  });
+});
+
+describe("a replacement that went through", () => {
+  // The install answered, so it did not restart, and what came back is the
+  // sentence it still owed about the command beside the app. The release
+  // is on disk: saying so in the failure colour and offering the action
+  // again would send a person to re-download what they already have.
+  it("says what is left over without calling the update a failure", async () => {
+    const left = "kendex 5.1.0 is installed and starts on the next launch";
+    vi.mocked(commands.appUpdateInstall).mockResolvedValue({
+      status: "ok",
+      data: left,
+    });
+    const container = await show({ kind: "direct" }, null);
+    vi.mocked(commands.appUpdateCommandChannel).mockResolvedValue({
+      status: "ok",
+      data: { kind: "unknown" },
+    });
+
+    await press(container, APP_UPDATE_INSTALL_LABEL);
+    await settle();
+
+    const said = [...container.querySelectorAll("p")].find(
+      (node) => node.textContent === left,
+    );
+    expect(said).toBeDefined();
+    expect(said?.className).not.toContain("text-critical");
+    expect(useNoticeStore.getState().error).toBeNull();
+    // And the action is gone rather than disabled: there is nothing left
+    // to run, and the card now says what is beside the app.
+    expect(() => offer(container, APP_UPDATE_INSTALL_LABEL)).toThrow();
+    expect(container.textContent).toContain(APP_UPDATE_COMMAND_UNKNOWN_NOTE);
   });
 });
 

--- a/ui/src/components/sidebar-notice.dom.test.tsx
+++ b/ui/src/components/sidebar-notice.dom.test.tsx
@@ -302,6 +302,25 @@ describe("the action each channel allows", () => {
 });
 
 describe("a replacement that did not happen", () => {
+  // The engine says when the command it found was not the one the card
+  // described, and it can only tell that if it is handed what the card
+  // said. Handing it nothing would leave every such install going ahead on
+  // an answer the person never saw, and never hearing about it.
+  it("hands the engine the note the card is showing", async () => {
+    vi.mocked(commands.appUpdateInstall).mockResolvedValue({
+      status: "ok",
+      data: null,
+    });
+    const showing: CommandNotice = {
+      kind: "managed",
+      manager: "Homebrew",
+      command: "brew upgrade kendex-cli",
+    };
+    const container = await show({ kind: "direct" }, showing);
+    await press(container, APP_UPDATE_INSTALL_LABEL);
+    expect(commands.appUpdateInstall).toHaveBeenCalledWith(showing);
+  });
+
   // The card is the only surface left saying what happens to the command
   // beside the app, and a failed install is where that answer is most
   // likely to have moved. Left unread, the card the person is looking at

--- a/ui/src/components/sidebar-notice.dom.test.tsx
+++ b/ui/src/components/sidebar-notice.dom.test.tsx
@@ -335,7 +335,7 @@ describe("a replacement that went through", () => {
   });
 });
 
-describe("a replacement that did not happen", () => {
+describe("what pressing Update now hands the engine", () => {
   // The engine says when the command it found was not the one the card
   // described, and it can only tell that if it is handed what the card
   // said. Handing it nothing would leave every such install going ahead on
@@ -354,7 +354,9 @@ describe("a replacement that did not happen", () => {
     await press(container, APP_UPDATE_INSTALL_LABEL);
     expect(commands.appUpdateInstall).toHaveBeenCalledWith(showing);
   });
+});
 
+describe("a replacement that did not happen", () => {
   // The card is the only surface left saying what happens to the command
   // beside the app, and a failed install is where that answer is most
   // likely to have moved. Left unread, the card the person is looking at

--- a/ui/src/components/sidebar-notice.tsx
+++ b/ui/src/components/sidebar-notice.tsx
@@ -89,8 +89,9 @@ export function SidebarNotice() {
           )}
           {/* The app is kendex's to replace and the command beside it is
               not, so Update now moves one and leaves the other. Said
-              before the button is pressed, because afterwards the app has
-              restarted and the card is gone. */}
+              before the button is pressed, because an install that
+              restarts takes the card with it; an install that answers
+              instead leaves the card up and this is read again for it. */}
           {commandChannel === null ? null : commandChannel.kind ===
             "unknown" ? (
             // Nothing named the installer, so there is no name to print

--- a/ui/src/components/sidebar-notice.tsx
+++ b/ui/src/components/sidebar-notice.tsx
@@ -28,6 +28,7 @@ export function SidebarNotice() {
   const commandChannel = useNoticeStore((s) => s.commandChannel);
   const installing = useNoticeStore((s) => s.installing);
   const error = useNoticeStore((s) => s.error);
+  const note = useNoticeStore((s) => s.note);
   const install = useNoticeStore((s) => s.install);
   const openNotes = useNoticeStore((s) => s.openNotes);
   const dismiss = useNoticeStore((s) => s.dismiss);
@@ -66,21 +67,26 @@ export function SidebarNotice() {
 
       {channel.kind === "direct" ? (
         <>
-          <Button
-            size="sm"
-            className="mt-2.5 w-full"
-            disabled={installing}
-            onClick={() => void install()}
-          >
-            {installing ? (
-              <>
-                <Loader2 className="animate-spin" />
-                {APP_UPDATE_INSTALLING_LABEL}
-              </>
-            ) : (
-              APP_UPDATE_INSTALL_LABEL
-            )}
-          </Button>
+          {/* Once the release is installed there is nothing left to press:
+              the next launch is what completes it, and offering the action
+              again would download and write a release already on disk. */}
+          {note !== null ? null : (
+            <Button
+              size="sm"
+              className="mt-2.5 w-full"
+              disabled={installing}
+              onClick={() => void install()}
+            >
+              {installing ? (
+                <>
+                  <Loader2 className="animate-spin" />
+                  {APP_UPDATE_INSTALLING_LABEL}
+                </>
+              ) : (
+                APP_UPDATE_INSTALL_LABEL
+              )}
+            </Button>
+          )}
           {/* The app is kendex's to replace and the command beside it is
               not, so Update now moves one and leaves the other. Said
               before the button is pressed, because afterwards the app has
@@ -131,6 +137,13 @@ export function SidebarNotice() {
           app is untouched and still usable either way. */}
       {error === null ? null : (
         <p className="mt-2 break-words text-xs text-critical">{error}</p>
+      )}
+
+      {/* What an install that went through still owed the person. The
+          release is on disk and the next launch runs it, so this is a
+          sentence about the command beside the app and not a failure. */}
+      {note === null ? null : (
+        <p className="mt-2 break-words text-xs text-muted-foreground">{note}</p>
       )}
 
       <button

--- a/ui/src/components/sidebar-notice.tsx
+++ b/ui/src/components/sidebar-notice.tsx
@@ -142,9 +142,20 @@ export function SidebarNotice() {
 
       {/* What an install that went through still owed the person. The
           release is on disk and the next launch runs it, so this is a
-          sentence about the command beside the app and not a failure. */}
+          sentence about the command beside the app and not a failure.
+
+          `role="status"` because it arrives after the press, in the same
+          render that takes away the button the person was on: unannounced,
+          the only sentence saying what happened to their command is one
+          nothing reads out. The role carries a polite `aria-live` and
+          `aria-atomic` of its own, so neither is spelled again here. */}
       {note === null ? null : (
-        <p className="mt-2 break-words text-xs text-muted-foreground">{note}</p>
+        <p
+          role="status"
+          className="mt-2 break-words text-xs text-muted-foreground"
+        >
+          {note}
+        </p>
       )}
 
       <button

--- a/ui/src/stores/notice.ts
+++ b/ui/src/stores/notice.ts
@@ -105,16 +105,23 @@ export const useNoticeStore = create<NoticeState>((set, get) => ({
   install: async () => {
     if (get().installing) return;
     set({ installing: true, error: null });
-    const response = await settled(commands.appUpdateInstall());
+    // What the card is showing about the command beside the app, handed
+    // over so the engine can say when the command it found was not the one
+    // this card described. The card is the only place that sentence could
+    // be read, and a successful install takes the card away with the
+    // restart.
+    const response = await settled(
+      commands.appUpdateInstall(get().commandChannel),
+    );
     // A replacement that worked does not come back: the app restarts into
     // the new version. So only a failure ends the in-flight state, and it
     // leaves the action on the card to try again.
     if (response.status === "error") {
       set({ installing: false, error: response.error });
-      // The card is the only surface left saying what happens to the
-      // command beside the app, and a failed install is where that answer
-      // is most likely to have moved. Read it again so the card the person
-      // is left looking at says what is there.
+      // One of those answers is that the command was not what this card
+      // says, and it points the person at the card for what is there. Read
+      // again so that is true, and so pressing Update now again acts on
+      // the answer rather than repeating the same sentence.
       const fresh = await settled(commands.appUpdateCommandChannel());
       if (fresh.status === "ok") set({ commandChannel: fresh.data });
     }

--- a/ui/src/stores/notice.ts
+++ b/ui/src/stores/notice.ts
@@ -133,12 +133,14 @@ export const useNoticeStore = create<NoticeState>((set, get) => ({
         ? { installing: false, note: response.data }
         : { installing: false, error: response.error },
     );
-    // Either answer is about a command that may have moved, and both point
-    // the person at this card for what is there. Read again so that is
-    // true, and so a retry acts on the answer rather than repeating the
-    // same sentence.
+    // Either answer is about a command that may have moved, so what the
+    // card says about it is read again — and a read that failed says
+    // nothing rather than guessing, the same rule the first read follows.
+    // Kept, the description would be the one drawn before the install, and
+    // the card would be describing a machine as it no longer is with no
+    // action left on it to ask again.
     const fresh = await settled(commands.appUpdateCommandChannel());
-    if (fresh.status === "ok") set({ commandChannel: fresh.data });
+    set({ commandChannel: fresh.status === "ok" ? fresh.data : null });
   },
 
   openNotes: async () => {

--- a/ui/src/stores/notice.ts
+++ b/ui/src/stores/notice.ts
@@ -32,6 +32,11 @@ interface NoticeState {
   /** Why the last action on the card did not happen, shown on the card
    *  with the app still usable. */
   error: string | null;
+  /** What an install that went through still owed the person about the
+   *  `kendex` command beside the app. Not a failure: the release is
+   *  installed and the next launch is what completes it, so the card says
+   *  this and stops offering to run the update again. */
+  note: string | null;
   load: () => Promise<void>;
   install: () => Promise<void>;
   openNotes: () => Promise<void>;
@@ -74,6 +79,7 @@ export const useNoticeStore = create<NoticeState>((set, get) => ({
   commandChannel: null,
   installing: false,
   error: null,
+  note: null,
 
   load: async () => {
     const [view, channel, commandChannel, current] = await Promise.all([
@@ -99,12 +105,14 @@ export const useNoticeStore = create<NoticeState>((set, get) => ({
       // send a person to a package manager that does not own it.
       commandChannel:
         commandChannel.status === "ok" ? commandChannel.data : null,
+      // A card being drawn again says nothing about an install before it.
+      note: null,
     });
   },
 
   install: async () => {
     if (get().installing) return;
-    set({ installing: true, error: null });
+    set({ installing: true, error: null, note: null });
     // What the card is showing about the command beside the app, handed
     // over so the engine can say when the command it found was not the one
     // this card described. The card is the only place that sentence could
@@ -113,18 +121,24 @@ export const useNoticeStore = create<NoticeState>((set, get) => ({
     const response = await settled(
       commands.appUpdateInstall(get().commandChannel),
     );
-    // A replacement that worked does not come back: the app restarts into
-    // the new version. So only a failure ends the in-flight state, and it
-    // leaves the action on the card to try again.
-    if (response.status === "error") {
-      set({ installing: false, error: response.error });
-      // One of those answers is that the command was not what this card
-      // says, and it points the person at the card for what is there. Read
-      // again so that is true, and so pressing Update now again acts on
-      // the answer rather than repeating the same sentence.
-      const fresh = await settled(commands.appUpdateCommandChannel());
-      if (fresh.status === "ok") set({ commandChannel: fresh.data });
-    }
+    // A replacement that restarts does not come back: the app relaunches
+    // into the new version. What does come back is an install that failed,
+    // or one that went through with something still to say about the
+    // command beside the app — told apart here rather than read out of the
+    // sentence, because a person whose update worked must not be shown a
+    // failure and invited to run it again.
+    if (response.status === "ok" && response.data === null) return;
+    set(
+      response.status === "ok"
+        ? { installing: false, note: response.data }
+        : { installing: false, error: response.error },
+    );
+    // Either answer is about a command that may have moved, and both point
+    // the person at this card for what is there. Read again so that is
+    // true, and so a retry acts on the answer rather than repeating the
+    // same sentence.
+    const fresh = await settled(commands.appUpdateCommandChannel());
+    if (fresh.status === "ok") set({ commandChannel: fresh.data });
   },
 
   openNotes: async () => {
@@ -142,7 +156,7 @@ export const useNoticeStore = create<NoticeState>((set, get) => ({
     // the old build with nothing to say so and no second offer.
     if (notice === null || get().installing) return;
     const refused = await mute(notice.latest);
-    if (refused === null) set({ notice: null, error: null });
+    if (refused === null) set({ notice: null, error: null, note: null });
     else set({ error: refused });
   },
 }));

--- a/ui/src/stores/notice.ts
+++ b/ui/src/stores/notice.ts
@@ -105,22 +105,16 @@ export const useNoticeStore = create<NoticeState>((set, get) => ({
   install: async () => {
     if (get().installing) return;
     set({ installing: true, error: null });
-    // What the card is showing about the command beside the app, handed
-    // over so the engine can refuse an install whose command changed since
-    // the card was drawn. The card is the only place that warning could
-    // have been read, and Update now takes the card away with the restart.
-    const response = await settled(
-      commands.appUpdateInstall(get().commandChannel),
-    );
+    const response = await settled(commands.appUpdateInstall());
     // A replacement that worked does not come back: the app restarts into
     // the new version. So only a failure ends the in-flight state, and it
     // leaves the action on the card to try again.
     if (response.status === "error") {
       set({ installing: false, error: response.error });
-      // One of those failures is that the command is no longer what this
-      // card says, and the refusal tells the person the card now shows
-      // what is there. Read again so that is true, and so pressing Update
-      // now again acts on the answer rather than meeting the same refusal.
+      // The card is the only surface left saying what happens to the
+      // command beside the app, and a failed install is where that answer
+      // is most likely to have moved. Read it again so the card the person
+      // is left looking at says what is there.
       const fresh = await settled(commands.appUpdateCommandChannel());
       if (fresh.status === "ok") set({ commandChannel: fresh.data });
     }


### PR DESCRIPTION
## Summary

- The installed-command record is a path. The SHA-256 half, `HostProbe::digest`, `refresh_the_replaced_bytes`, the record's timestamp stamp and `install.sh`'s `sha256_of` are gone. A first run is now one `create_new(true)` write with `AlreadyExists => Ok(())`, in place of the 64-attempt staging ladder, its `AtomicU64` and its hard link. `record_installed` was `record_command` under another name and is gone.
- The registry guards each fact once. `Authenticated`, `answered_for`, and `rejected_access`'s post-fetch store recheck are removed. One installed check survives in `me::load`, and every destructive credential path re-reads through a single `remove_rejected` under the credential transaction.
- The app no longer refuses **Update now** when the command beside it changed under the card. It installs both halves and then says what became of the command, rather than stopping.
- Net 623 lines removed across 32 files.

## Context

Review found a defect the first commit introduced, and this PR fixes it. `remove_rejected` had been cut down to an unconditional `store.clear()`, so a `kendex login` that completed while another call's token was being refused had its credential deleted, and its owner was told the sign-in expired. `origin/main` already re-read on that path, so the branch had removed a guard rather than declined to add one. Six reviewers reached it independently. Three proved it by restoring the deleted tests onto the branch and watching them fail.

## Completed Issues

- Closes KEN-909 - Registry and command-update guard each fact once; the mid-read rechecks, sha256 ladder, and 64-attempt stage are gone

## Follow-ups not fixed here

- `remove_rejected` compares the stored refresh token and clears in two operations, so a writer that never takes the refresh guard could save between them. `origin/main` has the same non-atomic compare-then-clear, so this PR restores that shape rather than opening the window. It belongs with KEN-893's mixed-version row, whose removal deletes the compare along with it.

## Test Plan

- `./tools/guard` green. 2220 Rust tests passed, 0 failed. 1074 UI tests passed. Size-ratchet and preflight clean.
- Restored with the credential fix: `a_login_landing_during_the_bounded_retry_is_never_cleared`, `a_login_landing_after_rotation_is_never_cleared`, `a_mixed_version_login_survives_a_refused_old_refresh`.
- Added: `the_app_version_is_the_one_kendex_version_prints`, the assertion KEN-444's Done-when names, read off the built binary rather than two constants. Also `install_sh_says_when_it_cannot_record_the_command`, `one_privileged_command_is_not_another_at_a_different_path`, a `not_as_shown` table over the whole `CommandBeside` input space, and two app cases driving an `Ours` to `NotOurs` flip through the real lookup.
- Every behavioural claim in the diff has a control that reds when the code stops matching it. Each was checked by mutation at 64 threads: the `create_new` refusal, the installed-credential comparison, the `not_as_shown` guard and its absent-command arm, the `moved_while` stage word, and the three note-state UI controls.
