### PR TITLE
refactor(KEN-916): one reader of queue state, phases earn their place

### DIFF
--- a/.agents/skills/orch/scripts/lib/merge-queue-state.sh
+++ b/.agents/skills/orch/scripts/lib/merge-queue-state.sh
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 
-MERGE_QUEUE_REPORT_FILTER='{issue_id,watch_id,status,action,repository,pr_number,head_sha,worktree_branch,
+MERGE_QUEUE_REPORT_FILTER='{issue_id,watch_id,status,action,repository,pr_number,head_sha,pr_branch,
   gate_mode,recovery_count,launch_attempt,launch_attempt_id,runtime_dir,artifact_path,log_path,deadline,verdict,verdict_cause,
   lane_postmerge,cleanup,diagnostic,error:(.diagnostic.error // null),
   worker_exit_code:(.diagnostic.worker_exit_code // null),
@@ -35,7 +35,7 @@ merge_queue_cleanup_worktree() {
   local worktree helper required expected_branch owner output="" rc=0 diagnostic disposition current_branch
   local expected_common current_common resolved_worktree dirty
   worktree=$(state_value .worktree); helper="$ROOT/.agents/skills/worktree/scripts/worktree"
-  required=$(state_value .cleanup.required); expected_branch=$(state_value .worktree_branch)
+  required=$(state_value .cleanup.required); expected_branch=$(state_value .pr_branch)
   owner="$WATCH_ID-$$-$RANDOM$RANDOM"
   exec 8>"$STATE_FILE.cleanup.lock"
   flock -n 8 || die "cleanup is already owned by another process"
@@ -62,7 +62,7 @@ merge_queue_cleanup_worktree() {
     if [[ -z "$current_common" || "$current_common" != "$expected_common" ]]; then
       output="kept worktree: repository identity changed: $worktree"; disposition=kept
     elif [[ -z "$current_branch" || "$current_branch" != "$expected_branch" ]]; then
-      output="kept worktree: expected branch '$expected_branch', found '${current_branch:-detached HEAD}': $worktree"; disposition=kept
+      output="kept worktree: not on PR branch '$expected_branch' (found '${current_branch:-detached HEAD}'): $worktree"; disposition=kept
     elif [[ -n "$dirty" ]]; then
       output="kept worktree: uncommitted changes are present: $worktree"; disposition=kept
     elif [[ -z "$resolved_worktree" || "$(cd "$resolved_worktree" 2>/dev/null && pwd -P || true)" != "$worktree" ]]; then

--- a/.agents/skills/orch/scripts/lib/merge-queue-supervisor.sh
+++ b/.agents/skills/orch/scripts/lib/merge-queue-supervisor.sh
@@ -1,4 +1,13 @@
 # shellcheck shell=bash
+#
+# Detached supervisor for one merge-queue launch attempt. The named failure
+# it prevents: queue-wait dying without output (crash, signal, logout) or
+# wedging on a hung GitHub read past its own budget would leave a watch
+# nothing is running and a consume that could only time out. The supervisor
+# publishes an `unknown` artifact when its worker exits unreadably and reaps
+# a worker that outlives the deadline, so every launch attempt ends in a
+# consumable artifact — and only while its own generation is still the
+# registered one, so a dead attempt can never publish over its replacement.
 
 merge_queue_supervise() {
   local state_file="$1" watch_id="$2" attempt_id="$3" runtime="$4" artifact="$5" deadline="$6"
@@ -47,7 +56,7 @@ merge_queue_supervise() {
     jq -n --arg repo "$repo" --argjson pr "$pr" --arg head "$head" --arg watch "$watch_id" --arg attempt "$attempt_id" \
       --arg reason "$reason" --argjson rc "$rc" --arg log "$log" \
       '{schema_version:1,status:"error",verdict:"unknown",repository:$repo,pr_number:$pr,
-        expected_head:$head,observed_head:"",watch_id:$watch,launch_attempt_id:$attempt,cause:$reason,
+        expected_head:$head,watch_id:$watch,launch_attempt_id:$attempt,cause:$reason,
         worker_exit_code:$rc,diagnostic_path:$log}' > "$output" || return 1
     publish_output && published=true
   }
@@ -95,7 +104,7 @@ merge_queue_supervise() {
   fi
   jq --arg repo "$repo" --argjson pr "$pr" --arg head "$head" --arg watch "$watch_id" --arg attempt "$attempt_id" --arg log "$log" \
     '. + {schema_version:1,repository:$repo,pr_number:$pr,expected_head:$head,
-      observed_head:"",watch_id:$watch,launch_attempt_id:$attempt,diagnostic_path:$log}' "$temp" > "$output"
+      watch_id:$watch,launch_attempt_id:$attempt,diagnostic_path:$log}' "$temp" > "$output"
   publish_output || return 1
   published=true; printf '%s\n' "$worker_rc" > "$runtime/terminal"; chmod 600 "$runtime/terminal"
   trap - EXIT TERM HUP INT

--- a/.agents/skills/orch/scripts/merge-queue-watch
+++ b/.agents/skills/orch/scripts/merge-queue-watch
@@ -25,7 +25,29 @@ Usage:
 
 The durable lifecycle file lives under the shared git directory, so worktree
 cleanup cannot erase an awaiting lane acknowledgment. `consume` is the only
-verdict classifier and action claimant.
+verdict classifier and action claimant. queue-wait is the only reader of
+queue state; this script only verifies the live PR head and state before
+claiming a verdict, so a stale artifact cannot route actions for a head
+that has since moved.
+
+Phase justifications — the named failure each phase prevents:
+  supervisor (launch/__supervise): queue-wait can die without output (crash,
+    signal, logout) or wedge on a hung GitHub read past its own budget,
+    leaving a watch nothing is running and a consume that could only time
+    out. The detached supervisor publishes an `unknown` artifact when its
+    worker exits unreadably and reaps a worker that outlives the deadline,
+    so every launch attempt ends in a consumable artifact.
+  cleanup: worktree removal after a detached merge acts on state recorded
+    before the merge. Unowned removal can run twice (concurrent lanes), act
+    on a tree no longer holding the PR branch (KEN-888), or die midway and
+    be forgotten. The single-owner claim revalidates repository, PR branch,
+    and cleanliness immediately before removal and persists an interrupted
+    claim as cleanup_pending for resume.
+  acknowledge: a lane that dies after the merge leaves post-merge
+    verification undone with nothing reporting it. The lifecycle
+    terminalizes only on an explicit pass/fail acknowledgment, so oversee
+    keeps surfacing the unfinished item instead of it vanishing with the
+    lane.
 EOF
 }
 
@@ -57,35 +79,6 @@ atomic_update() {
     jq "$@" "$filter" "$STATE_FILE" > "$tmp" || { rm -f -- "$tmp"; exit 1; }
     chmod 600 "$tmp" && mv -f -- "$tmp" "$STATE_FILE"
   ) 9>"$STATE_FILE.lock"
-}
-migrate_legacy_state() {
-  local snapshot status watch artifact runtime watch_dir runtime_root legacy_id
-  snapshot=$(state_snapshot) || die "cannot inspect durable watch generation"
-  status=$(jq -r .status <<<"$snapshot")
-  [[ "$status" == prepared || "$status" == launching || "$status" == watching || "$status" == launch_failed || "$status" == failed ]] || return 0
-  if [[ "$status" == prepared ]]; then
-    [[ "$(jq -r '.watch_dir // empty' <<<"$snapshot")" == "" ||
-       "$(jq -r '.runtime_root // empty' <<<"$snapshot")" == "" ||
-       "$(jq -r '.launch_attempt // empty' <<<"$snapshot")" == "" ]] || return 0
-  else
-    [[ "$(jq -r '.launch_attempt_id // empty' <<<"$snapshot")" == "" ||
-       "$(jq -r '.supervisor_token // empty' <<<"$snapshot")" == "" ||
-       "$(jq -r '.runtime_root // empty' <<<"$snapshot")" == "" ]] || return 0
-  fi
-  watch=$(jq -r .watch_id <<<"$snapshot"); artifact=$(jq -r .artifact_path <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
-  watch_dir="${artifact%/*}"; runtime_root="$watch_dir/runtime-attempts"; legacy_id="$watch-legacy"
-  [[ -n "$watch" && "$watch_dir" != "$artifact" && -d "$watch_dir" && ! -L "$watch_dir" && "$runtime" == "$watch_dir/"* ]] \
-    || die "legacy durable watch paths are invalid"
-  mkdir -p -- "$runtime_root" || die "cannot create migrated runtime root: $runtime_root"
-  chmod 700 "$runtime_root" || die "cannot secure migrated runtime root: $runtime_root"
-  atomic_update 'if (.status=="prepared" and
-      ((.watch_dir // "")=="" or (.runtime_root // "")=="" or (.launch_attempt // null)==null)) or
-      ((.status|IN("launching","watching","launch_failed","failed")) and
-       ((.launch_attempt_id // "")=="" or (.supervisor_token // "")=="" or (.runtime_root // "")=="")) then
-      .watch_dir=$watch_dir|.runtime_root=$runtime_root|.legacy_generation=true|.updated_at=(now|floor)|
-      if .status=="prepared" then .launch_attempt=0|.launch_attempt_id=null|.supervisor_token=null
-      else .launch_attempt=1|.launch_attempt_id=$legacy|.supervisor_token=$legacy end else . end' \
-    --arg watch_dir "$watch_dir" --arg runtime_root "$runtime_root" --arg legacy "$legacy_id"
 }
 fail_state() {
   local cause="$1" detail="$2" attempt_id="${3:-}" artifact="${4:-}"
@@ -144,21 +137,6 @@ supervisor_live() {
   command=$(ps eww -p "$pid" -o command= 2>/dev/null) || return 1
   [[ " $command " == *" __supervise "* && " $command " == *" MERGE_QUEUE_SUPERVISOR_TOKEN=$supervisor_token "* ]]
 }
-legacy_supervisor_live() {
-  local pid="$1" command arg i
-  local argv=()
-  process_running "$pid" || return 1
-  if [[ -r "/proc/$pid/cmdline" ]]; then
-    while IFS= read -r -d '' arg; do argv[${#argv[@]}]="$arg"; done < "/proc/$pid/cmdline"
-    for ((i=0; i+4<${#argv[@]}; i++)); do
-      [[ "${argv[i]}" == "$SELF" && "${argv[i+1]}" == __supervise && "${argv[i+2]}" == "$STATE_FILE" &&
-         "${argv[i+3]}" == "$WATCH_ID" && "${argv[i+4]}" == "$SCRIPT_DIR/queue-wait" ]] && return 0
-    done
-    return 1
-  fi
-  command=$(ps -ww -p "$pid" -o command= 2>/dev/null) || return 1
-  [[ "$command" == *"$SELF __supervise $STATE_FILE $WATCH_ID $SCRIPT_DIR/queue-wait "* ]]
-}
 terminate_supervisor() {
   local pid="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" i
   supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || return 0
@@ -175,18 +153,8 @@ terminate_supervisor() {
   done
   return 1
 }
-terminate_legacy_supervisor() {
-  local pid="$1" i
-  legacy_supervisor_live "$pid" || return 0
-  kill -TERM "$pid" 2>/dev/null || true
-  for ((i=0; i<50; i++)); do legacy_supervisor_live "$pid" || return 0; sleep 0.1; done
-  legacy_supervisor_live "$pid" || return 0
-  kill -KILL "$pid" 2>/dev/null || true
-  for ((i=0; i<20; i++)); do legacy_supervisor_live "$pid" || return 0; sleep 0.1; done
-  return 1
-}
 launch_failure() {
-  local detail="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" pid="${6:-}" legacy="${7:-false}" snapshot
+  local detail="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" pid snapshot
   atomic_update 'if .watch_id!=$watch or .launch_attempt_id!=$attempt or .runtime_dir!=$runtime or .artifact_path!=$artifact or
       .supervisor_token!=$token or
       (.status|IN("launching","watching")|not) then error("launch claim lost") else
@@ -197,8 +165,7 @@ launch_failure() {
     || die "could not claim launch recovery; inspect the active lifecycle before handback"
   snapshot=$(state_snapshot) || die "cannot snapshot claimed launch failure"
   pid=$(supervisor_pid "$runtime" "$(jq -r '.supervisor_pid // empty' <<<"$snapshot")")
-  if [[ -n "$pid" && "$legacy" == true ]]; then terminate_legacy_supervisor "$pid" || true
-  elif [[ -n "$pid" ]]; then terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true; fi
+  [[ -z "$pid" ]] || terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
   atomic_update 'if .watch_id==$watch and .launch_attempt_id==$attempt and .status=="launch_failed"
       then .supervisor_pid=null|.updated_at=(now|floor) else error("launch failure claim changed") end' \
     --arg watch "$WATCH_ID" --arg attempt "$attempt_id"
@@ -230,9 +197,13 @@ prepare() {
   [[ "$gate" =~ ^(approval|review|off)$ && "$recovery" =~ ^[0-9]+$ ]] || die "prepare gate mode or recovery count is malformed"
   [[ "$cleanup" == true || "$cleanup" == false ]] || die "prepare cleanup flag is malformed"
   resolve_state
-  local now watch_dir artifact log runtime_root runtime attempt_id new_state old_status="" pointer worktree_branch
+  local now watch_dir artifact log runtime_root runtime attempt_id new_state old_status="" pointer pr_branch
   now=$(date +%s); WATCH_ID="$now-$$-$RANDOM$RANDOM"
-  worktree_branch=$(git -C "$worktree" branch --show-current 2>/dev/null) || die "cannot read prepared worktree branch"
+  # Cleanup binds to the PR branch recorded at init, never to whatever branch
+  # happens to be checked out when prepare runs (KEN-888): a lane that
+  # switched branches in between must not have that unrelated tree removed.
+  pr_branch=$(cd "$worktree" && "$WORKFLOW_STATE" get "$ISSUE" .branch) || die "cannot read recorded PR branch from workflow state"
+  [[ -n "$pr_branch" && "$pr_branch" != null ]] || die "workflow state records no PR branch for $ISSUE; run init --branch first"
   watch_dir="$STATE_DIR/runs/$ISSUE-$WATCH_ID"
   mkdir -- "$watch_dir" || die "cannot reserve watch directory"
   chmod 700 "$watch_dir"
@@ -243,12 +214,12 @@ prepare() {
   new_state="$watch_dir/prepared.json"
   jq -n --arg issue "$ISSUE" --arg repo "$repo" --argjson pr "$pr" --arg head "$head" \
     --arg watch "$WATCH_ID" --arg gate "$gate" --argjson recovery "$recovery" \
-    --arg root "$ROOT" --arg worktree "$(cd "$worktree" && pwd -P)" --arg worktree_branch "$worktree_branch" \
+    --arg root "$ROOT" --arg worktree "$(cd "$worktree" && pwd -P)" --arg pr_branch "$pr_branch" \
     --arg watch_dir "$watch_dir" --arg artifact "$artifact" --arg log "$log" --arg runtime_root "$runtime_root" --arg runtime "$runtime" \
     --argjson now "$now" --argjson cleanup "$cleanup" \
     '{schema_version:1,issue_id:$issue,repository:$repo,pr_number:$pr,head_sha:$head,
       watch_id:$watch,gate_mode:$gate,recovery_count:$recovery,main_repo_root:$root,
-      worktree:$worktree,worktree_branch:$worktree_branch,watch_dir:$watch_dir,artifact_path:$artifact,log_path:$log,
+      worktree:$worktree,pr_branch:$pr_branch,watch_dir:$watch_dir,artifact_path:$artifact,log_path:$log,
       runtime_root:$runtime_root,runtime_dir:$runtime,prepared_at:$now,launch_attempt:0,launch_attempt_id:null,
       status:"prepared",action:null,terminal:false,
       supervisor_pid:null,supervisor_token:null,launched_at:null,deadline:null,lane_postmerge:null,
@@ -278,7 +249,7 @@ prepare() {
 
 launch() {
   local poll=30 max_wait=2400 method pid deadline now ready log runtime waiter artifact attempt attempt_id supervisor_token
-  local snapshot status prior_attempt head runtime_root watch_dir created=false legacy recorded_pid
+  local snapshot status prior_attempt head runtime_root watch_dir created=false
   while [[ $# -gt 0 ]]; do
     case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;;
       --watch-id) WATCH_ID="${2:-}"; shift 2 ;; --poll) poll="${2:-}"; shift 2 ;;
@@ -290,18 +261,9 @@ launch() {
   snapshot=$(state_snapshot) || die "cannot snapshot prepared lifecycle"
   [[ "$WATCH_ID" =~ ^[A-Za-z0-9._-]+$ && "$WATCH_ID" != *..* ]] || die "watch id is not path-safe: $WATCH_ID"
   [[ "$(jq -r '.watch_id // empty' <<<"$snapshot")" == "$WATCH_ID" ]] || die "watch id does not match active lifecycle"
-  migrate_legacy_state
   [[ "$poll" =~ ^[1-9][0-9]*$ && "$max_wait" =~ ^[1-9][0-9]*$ && "$poll" -le "$max_wait" ]] || die "invalid wait bounds"
-  snapshot=$(state_snapshot) || die "cannot snapshot prepared lifecycle"
-  [[ "$(jq -r '.watch_id // empty' <<<"$snapshot")" == "$WATCH_ID" ]] || die "watch id changed during launch"
   status=$(jq -r .status <<<"$snapshot"); prior_attempt=$(jq -r '.launch_attempt // 0' <<<"$snapshot")
   [[ "$prior_attempt" =~ ^[0-9]+$ && ( "$status" == prepared || "$status" == launch_failed ) ]] || die "prepared claim lost"
-  legacy=$(jq -r '.legacy_generation // false' <<<"$snapshot")
-  if [[ "$status" == launch_failed && "$legacy" == true ]]; then
-    runtime=$(jq -r .runtime_dir <<<"$snapshot"); recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot")
-    pid=$(supervisor_pid "$runtime" "$recorded_pid")
-    [[ -z "$pid" ]] || terminate_legacy_supervisor "$pid" || die "legacy supervisor survived launch recovery teardown"
-  fi
   attempt=$((prior_attempt+1)); attempt_id="$WATCH_ID-attempt-$attempt"; supervisor_token="$attempt_id-$RANDOM$RANDOM"
   head=$(jq -r .head_sha <<<"$snapshot")
   now=$(date +%s); deadline=$((now + max_wait + 90)); log=$(jq -r .log_path <<<"$snapshot")
@@ -316,7 +278,7 @@ launch() {
     die "queue-wait is missing: $waiter; diagnostics: $log"
   fi
   runtime_root=$(jq -r .runtime_root <<<"$snapshot"); watch_dir=$(jq -r .watch_dir <<<"$snapshot")
-  if [[ "$prior_attempt" -eq 0 && "$legacy" != true ]]; then
+  if [[ "$prior_attempt" -eq 0 ]]; then
     runtime=$(jq -r .runtime_dir <<<"$snapshot"); artifact=$(jq -r .artifact_path <<<"$snapshot")
     [[ -d "$runtime" && ! -L "$runtime" && -f "$runtime/token" && "$(cat < "$runtime/token")" == "$attempt_id" ]] \
       || die "prepared attempt runtime is invalid: $runtime"
@@ -337,7 +299,7 @@ launch() {
   if ! atomic_update 'if .watch_id!=$watch or .head_sha!=$head or .status!=$status or (.launch_attempt // 0)!=$prior
       then error("prepared claim lost") else .artifact_path=$artifact|.runtime_dir=$runtime|
       .launch_attempt=$attempt|.launch_attempt_id=$attempt_id|.status="launching"|.action=null|.diagnostic=null|
-      .supervisor_pid=null|.supervisor_token=$token|.legacy_generation=false|.launch_method=$method|.launched_at=$now|
+      .supervisor_pid=null|.supervisor_token=$token|.launch_method=$method|.launched_at=$now|
       .setup_deadline=($now+10)|.deadline=$deadline|.updated_at=$now end' \
     --arg watch "$WATCH_ID" --arg head "$head" --arg status "$status" --argjson prior "$prior_attempt" \
     --arg runtime "$runtime" --arg artifact "$artifact" --arg attempt_id "$attempt_id" --arg token "$supervisor_token" --arg method "$method" \
@@ -407,9 +369,8 @@ claim() {
 
 consume() {
   parse_root_issue "$@"
-  migrate_legacy_state
   local snapshot status artifact runtime attempt_id supervisor_token pid recorded_pid deadline setup_deadline now runtime_token body live live_state
-  local observed expected repo pr verdict result cause action diag error_text exit_code diag_path unconfirmed recovery log legacy
+  local expected repo pr verdict result cause action diag error_text exit_code diag_path unconfirmed recovery log
   snapshot=$(state_snapshot) || die "cannot snapshot active launch attempt"
   WATCH_ID=$(jq -r .watch_id <<<"$snapshot"); status=$(jq -r .status <<<"$snapshot")
   case "$status" in claimed|launch_failed|failed|abandoned|awaiting_lane_postmerge|cleanup_pending|cleanup_complete|complete) consume_report; return ;; esac
@@ -419,18 +380,9 @@ consume() {
   deadline=$(jq -r '.deadline // 0' <<<"$snapshot"); setup_deadline=$(jq -r '.setup_deadline // 0' <<<"$snapshot")
   expected=$(jq -r .head_sha <<<"$snapshot"); repo=$(jq -r .repository <<<"$snapshot"); pr=$(jq -r .pr_number <<<"$snapshot")
   recovery=$(jq -r .recovery_count <<<"$snapshot"); log=$(jq -r .log_path <<<"$snapshot"); now=$(date +%s)
-  legacy=$(jq -r '.legacy_generation // false' <<<"$snapshot")
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
     pid=$(supervisor_pid "$runtime" "$recorded_pid")
-    if [[ "$legacy" == true ]] && legacy_supervisor_live "$pid"; then
-      if [[ "$now" -le "$setup_deadline" ]]; then
-        jq -cn --arg watch "$WATCH_ID" '{status:"launching",watch_id:$watch,action:"pending"}'; return
-      fi
-      atomic_update 'if .watch_id==$watch and .launch_attempt_id==$attempt and .legacy_generation==true and
-          .status=="launching" then .status="watching"|.supervisor_pid=$pid|.updated_at=(now|floor)
-          else error("legacy launch attempt changed") end' --arg watch "$WATCH_ID" --arg attempt "$attempt_id" \
-        --argjson pid "$pid"; status=watching
-    elif supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then
+    if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then
       if [[ "$now" -le "$setup_deadline" ]]; then
         jq -cn --arg watch "$WATCH_ID" '{status:"launching",watch_id:$watch,action:"pending"}'; return
       fi
@@ -442,15 +394,8 @@ consume() {
     elif [[ -z "$pid" && "$now" -le "$setup_deadline" ]]; then
       jq -cn --arg watch "$WATCH_ID" '{status:"launching",watch_id:$watch,action:"pending"}'; return
     else
-      launch_failure "launching supervisor died or missed its setup deadline; see $log" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" "$recorded_pid" "$legacy"
+      launch_failure "launching supervisor died or missed its setup deadline; see $log" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"
       consume_report; return
-    fi
-  fi
-  if [[ "$legacy" == true && "$status" == watching && ! -s "$artifact" ]]; then
-    pid=$(supervisor_pid "$runtime" "$recorded_pid")
-    if [[ "$now" -le "$deadline" ]] && legacy_supervisor_live "$pid"; then
-      jq -cn --arg watch "$WATCH_ID" '{status:"watching",watch_id:$watch,action:"pending"}'
-      return
     fi
   fi
   if [[ ! -s "$artifact" ]]; then
@@ -462,14 +407,13 @@ consume() {
     fi
     fail_state watch_lost "artifact missing and supervisor dead or overdue; see $log" "$attempt_id" "$artifact"
     pid=$(supervisor_pid "$runtime")
-    if [[ -n "$pid" && "$legacy" == true ]]; then terminate_legacy_supervisor "$pid" || true
-    elif [[ -n "$pid" ]]; then terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true; fi
+    [[ -z "$pid" ]] || terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
     json_report; return
   fi
-  if ! jq -e --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg repo "$repo" --arg head "$expected" --argjson pr "$pr" --argjson legacy "$legacy" '
+  if ! jq -e --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg repo "$repo" --arg head "$expected" --argjson pr "$pr" '
       type=="object" and .schema_version==1 and .watch_id==$watch and
-      (.launch_attempt_id==$attempt or ($legacy and (.launch_attempt_id==null))) and .repository==$repo and
-      .pr_number==$pr and .expected_head==$head and (.observed_head|type=="string") and
+      .launch_attempt_id==$attempt and .repository==$repo and
+      .pr_number==$pr and .expected_head==$head and
       (.status|IN("complete","timeout","error")) and (.verdict|IN("merged","conflicting","ejected","disarmed","dequeued","closed","queued","not_queued","unknown"))' "$artifact" >/dev/null; then
     fail_state malformed_artifact "verdict artifact is malformed or belongs to another launch attempt" "$attempt_id" "$artifact"
     json_report; return
@@ -481,13 +425,12 @@ consume() {
   (umask 077; set -C; : > "$diag") || die "cannot create diagnostic binding"
   body=$(live_pr) || body='{"headRefOid":"","state":"UNKNOWN"}'
   live=$(jq -r '.headRefOid // ""' <<<"$body"); live_state=$(jq -r '.state // ""' <<<"$body")
-  observed=$(jq -r .observed_head "$artifact")
   jq -n --arg cause "${cause:-$verdict}" --arg error "$error_text" --arg exit "$exit_code" --arg path "$diag_path" --arg unconfirmed "$unconfirmed" \
-    --arg expected "$expected" --arg observed "$observed" --arg live "$live" --arg state "$live_state" \
+    --arg expected "$expected" --arg live "$live" --arg state "$live_state" \
     '{cause:$cause,error:(if $error=="" then null else $error end),unconfirmed_verdict:(if $unconfirmed=="" then null else $unconfirmed end),worker_exit_code:(if $exit=="" then null else ($exit|tonumber) end),
-      diagnostic_path:$path,head_verification:{expected:$expected,artifact_observed:$observed,live:$live,live_state:$state}}' > "$diag"
+      diagnostic_path:$path,head_verification:{expected:$expected,live:$live,live_state:$state}}' > "$diag"
   if [[ -z "$live" ]]; then claim failed "$verdict" live_pr_unreadable "$diag" "$attempt_id" "$artifact" "$expected" "$recovery"; rm -f -- "$diag"; return; fi
-  if [[ "$live" != "$expected" || ( -n "$observed" && "$observed" != "$expected" ) ]]; then
+  if [[ "$live" != "$expected" ]]; then
     claim failed "$verdict" head_mismatch "$diag" "$attempt_id" "$artifact" "$expected" "$recovery"; rm -f -- "$diag"; return
   fi
   if [[ "$live_state" == MERGED ]]; then claim postmerge merged merged_race "$diag" "$attempt_id" "$artifact" "$expected" "$recovery"; rm -f -- "$diag"; return; fi
@@ -510,8 +453,8 @@ consume() {
 event() {
   while [[ $# -gt 0 ]]; do case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;; *) die "unknown event option: $1" ;; esac; done
   [[ -n "$ROOT" && -n "$ISSUE" ]] || die "--root and --issue are required"
-  resolve_state; [[ -f "$STATE_FILE" ]] || exit 1; migrate_legacy_state
-  local snapshot status artifact runtime attempt_id supervisor_token recorded_pid pid deadline setup_deadline now legacy
+  resolve_state; [[ -f "$STATE_FILE" ]] || exit 1
+  local snapshot status artifact runtime attempt_id supervisor_token recorded_pid pid deadline setup_deadline now
   snapshot=$(state_snapshot) || exit 1; WATCH_ID=$(jq -r .watch_id <<<"$snapshot")
   status=$(jq -r .status <<<"$snapshot"); [[ "$status" == watching || "$status" == launching || "$status" == launch_failed ]] || exit 1
   [[ "$status" == launch_failed ]] && { printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; }
@@ -519,11 +462,8 @@ event() {
   attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot")
   supervisor_token=$(jq -r '.supervisor_token // empty' <<<"$snapshot")
   deadline=$(jq -r '.deadline // 0' <<<"$snapshot"); setup_deadline=$(jq -r '.setup_deadline // 0' <<<"$snapshot")
-  legacy=$(jq -r '.legacy_generation // false' <<<"$snapshot"); now=$(date +%s); pid=$(supervisor_pid "$runtime" "$recorded_pid")
-  if [[ "$legacy" == true && "$status" == watching && ! -s "$artifact" && "$now" -le "$deadline" ]] &&
-      legacy_supervisor_live "$pid"; then exit 1; fi
+  now=$(date +%s); pid=$(supervisor_pid "$runtime" "$recorded_pid")
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
-    if [[ "$legacy" == true ]] && legacy_supervisor_live "$pid"; then [[ "$now" -le "$setup_deadline" ]] && exit 1; printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
     if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then [[ "$now" -le "$setup_deadline" ]] && exit 1; printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
     [[ -z "$pid" && "$now" -le "$setup_deadline" ]] && exit 1
   fi
@@ -570,23 +510,20 @@ acknowledge() {
 }
 
 fail_command() {
-  local cause="" snapshot fresh attempt_id runtime artifact supervisor_token recorded_pid pid i fresh_attempt fresh_artifact legacy
+  local cause="" snapshot fresh attempt_id runtime artifact supervisor_token recorded_pid pid i fresh_attempt fresh_artifact
   while [[ $# -gt 0 ]]; do case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;;
     --watch-id) WATCH_ID="${2:-}"; shift 2 ;; --cause) cause="${2:-}"; shift 2 ;; *) die "unknown fail option: $1" ;; esac; done
   resolve_state; require_state; [[ "$cause" =~ ^(arm_failed|merge_blocked|launch_failed|operator_abandoned)$ ]] || die "invalid failure cause"
-  migrate_legacy_state
   for ((i=0; i<2; i++)); do
     snapshot=$(state_snapshot) || die "cannot snapshot active launch attempt"
     WATCH_ID="${WATCH_ID:-$(jq -r .watch_id <<<"$snapshot")}"
     attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
     artifact=$(jq -r .artifact_path <<<"$snapshot"); supervisor_token=$(jq -r '.supervisor_token // empty' <<<"$snapshot")
-    legacy=$(jq -r '.legacy_generation // false' <<<"$snapshot")
     if fail_state "$cause" "$cause" "$attempt_id" "$artifact"; then
       fresh=$(state_snapshot) || die "cannot snapshot claimed failure"
       recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$fresh")
       pid=$(supervisor_pid "$runtime" "$recorded_pid")
-      if [[ "$legacy" == true ]]; then terminate_legacy_supervisor "$pid" || true
-      else terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true; fi
+      terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
       json_report; return
     fi
     fresh=$(state_snapshot) || die "cannot resnapshot launch attempt after failure claim loss"

--- a/.agents/skills/orch/scripts/merge-queue-watch
+++ b/.agents/skills/orch/scripts/merge-queue-watch
@@ -31,12 +31,9 @@ claiming a verdict, so a stale artifact cannot route actions for a head
 that has since moved.
 
 Phase justifications — the named failure each phase prevents:
-  supervisor (launch/__supervise): queue-wait can die without output (crash,
-    signal, logout) or wedge on a hung GitHub read past its own budget,
-    leaving a watch nothing is running and a consume that could only time
-    out. The detached supervisor publishes an `unknown` artifact when its
-    worker exits unreadably and reaps a worker that outlives the deadline,
-    so every launch attempt ends in a consumable artifact.
+  supervisor (launch/__supervise): queue-wait dying without output or
+    wedging past its budget would leave a watch nothing is running; full
+    rationale in lib/merge-queue-supervisor.sh.
   cleanup: worktree removal after a detached merge acts on state recorded
     before the merge. Unowned removal can run twice (concurrent lanes), act
     on a tree no longer holding the PR branch (KEN-888), or die midway and

--- a/.agents/skills/orch/tests/merge_queue_rearm_e2e.sh
+++ b/.agents/skills/orch/tests/merge_queue_rearm_e2e.sh
@@ -16,7 +16,6 @@ ok() { PASS=$((PASS+1)); printf '  ok    %s\n' "$1"; }
 bad() { FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$1"; }
 eq() { if [[ "$1" == "$2" ]]; then ok "$3"; else bad "$3 (expected $2, got $1)"; fi; }
 wait_file() { local i; for ((i=0;i<300;i++)); do [[ -s "$1" ]] && return 0; sleep 0.05; done; return 1; }
-wait_line() { local i; for ((i=0;i<300;i++)); do [[ -s "$1" ]] && return 0; sleep 0.05; done; return 1; }
 
 MAIN="$TMP/main" BIN="$TMP/bin" SCRIPTS="$TMP/orch/scripts"
 mkdir -p "$MAIN" "$BIN" "$SCRIPTS/lib"
@@ -85,7 +84,7 @@ set +e
 early_event=$("$SCRIPTS/merge-queue-watch" event --root "$MAIN" --issue KEN-916-e2e); early_rc=$?
 set -e
 if [[ "$early_rc" -ne 0 && -z "$early_event" ]]; then ok "queued watch emits no oversee event"; else bad "queued watch woke oversee early"; fi
-wait_line "$QUEUE_LOG" || bad "queue-wait never polled queue state"
+wait_file "$QUEUE_LOG" || bad "queue-wait never polled queue state"
 printf 'ejected\n' > "$PHASE"
 wait_file "$artifact1" || bad "ejection verdict was not published"
 eq "$(jq -r .verdict "$artifact1")" ejected "queue-wait reports the confirmed ejection"
@@ -117,6 +116,16 @@ eq "$(jq -r .action <<<"$result")" postmerge "re-armed merge consumes as postmer
 "$SCRIPTS/merge-queue-watch" acknowledge --root "$MAIN" --issue KEN-916-e2e --watch-id "$watch2" --result pass >/dev/null
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-916-e2e)
 eq "$(jq -r .action <<<"$result")" complete "acknowledged lifecycle finishes complete"
+
+echo "=== prepare refuses workflow state with no PR branch ==="
+(cd "$MAIN" && "$SCRIPTS/workflow-state" init KEN-916-nobranch --worktree "$MAIN" >/dev/null)
+set +e
+nobranch_err=$("$SCRIPTS/merge-queue-watch" prepare --worktree "$MAIN" --issue KEN-916-nobranch \
+  --repo owner/repo --pr 43 --head "$HEAD" --root "$MAIN" --gate-mode off --recovery-count 0 --cleanup-worktree false 2>&1)
+nobranch_rc=$?
+set -e
+[[ "$nobranch_rc" -ne 0 ]] && ok "prepare refuses a branchless workflow state" || bad "prepare accepted workflow state with no PR branch"
+[[ "$nobranch_err" == *"records no PR branch"* ]] && ok "branchless refusal names the missing PR branch" || bad "branchless refusal message wrong: $nobranch_err"
 
 printf 'merge-queue-rearm-e2e: %d pass, %d fail\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/.agents/skills/orch/tests/merge_queue_rearm_e2e.sh
+++ b/.agents/skills/orch/tests/merge_queue_rearm_e2e.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# End-to-end merge-queue lifecycle: arm -> eject -> re-arm -> merge, driven
+# through the real merge-queue-watch, supervisor, and queue-wait against a gh
+# stub — one reader of queue state, end to end. At each step it asserts the
+# `event` output oversee-watch reads. The re-arm path under test is prepare's
+# acceptance of a claimed recovery lifecycle: remove it and the second
+# prepare is refused, turning this suite red.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ORCH="$(cd "$TEST_DIR/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+PASS=0 FAIL=0
+ok() { PASS=$((PASS+1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$1"; }
+eq() { if [[ "$1" == "$2" ]]; then ok "$3"; else bad "$3 (expected $2, got $1)"; fi; }
+wait_file() { local i; for ((i=0;i<300;i++)); do [[ -s "$1" ]] && return 0; sleep 0.05; done; return 1; }
+wait_line() { local i; for ((i=0;i<300;i++)); do [[ -s "$1" ]] && return 0; sleep 0.05; done; return 1; }
+
+MAIN="$TMP/main" BIN="$TMP/bin" SCRIPTS="$TMP/orch/scripts"
+mkdir -p "$MAIN" "$BIN" "$SCRIPTS/lib"
+git -C "$MAIN" init -q
+git -C "$MAIN" config user.email test@example.com
+git -C "$MAIN" config user.name Test
+touch "$MAIN/seed"; printf 'tmp/\n' > "$MAIN/.gitignore"
+git -C "$MAIN" add seed .gitignore; git -C "$MAIN" commit -qm seed
+BR=$(git -C "$MAIN" branch --show-current)
+ln -s "$(cd "$ORCH/.." && pwd)/github" "$TMP/github"
+printf 'GH_BOT_TOKEN=ghp_project\n' > "$MAIN/.env.local"
+cp "$ORCH/scripts/merge-queue-watch" "$ORCH/scripts/workflow-state" "$ORCH/scripts/orch-env" "$ORCH/scripts/queue-wait" "$SCRIPTS/"
+cp "$ORCH/scripts/lib/merge-queue-supervisor.sh" "$ORCH/scripts/lib/merge-queue-state.sh" \
+   "$ORCH/scripts/lib/kendex-env.sh" "$ORCH/scripts/lib/gh-auth.sh" "$SCRIPTS/lib/"
+
+PHASE="$TMP/phase" QUEUE_LOG="$TMP/queue.log"
+HEAD=cccccccccccccccccccccccccccccccccccccccc
+touch "$QUEUE_LOG"
+cat > "$BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+phase=$(cat < "$E2E_PHASE")
+case "${1:-} ${2:-}" in
+  'auth status'|'api user')
+    [[ "${GH_TOKEN:-}" == ghp_project ]] || exit 1
+    echo authenticated; exit 0 ;;
+  'repo view')
+    printf 'owner/repo\n'; exit 0 ;;
+  'pr view')
+    case "$phase" in merged) state=MERGED; merged_at='"2026-08-30T00:00:00Z"' ;; *) state=OPEN; merged_at=null ;; esac
+    if [[ "$*" == *headRefOid* ]]; then
+      printf '{"headRefOid":"%s","state":"%s"}\n' "$E2E_HEAD" "$state"
+    else
+      printf '{"state":"%s","mergedAt":%s,"mergeable":"UNKNOWN"}\n' "$state" "$merged_at"
+    fi
+    exit 0 ;;
+  'api graphql')
+    if [[ "$*" == *reviewThreads* ]]; then
+      printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}\n'
+      exit 0
+    fi
+    printf '%s\n' "$phase" >> "$E2E_QUEUE_LOG"
+    if [[ "$phase" == queued ]]; then
+      printf '{"data":{"repository":{"pullRequest":{"id":"PR_node","isInMergeQueue":true,"mergeQueueEntry":{"state":"QUEUED","position":1,"headCommit":null},"autoMergeRequest":{"enabledAt":"now"}}}}}\n'
+    else
+      printf '{"data":{"repository":{"pullRequest":{"id":"PR_node","isInMergeQueue":false,"mergeQueueEntry":null,"autoMergeRequest":null}}}}\n'
+    fi
+    exit 0 ;;
+esac
+echo "unexpected gh: $*" >&2
+exit 1
+EOF
+chmod +x "$BIN/gh" "$SCRIPTS/merge-queue-watch" "$SCRIPTS/workflow-state" "$SCRIPTS/orch-env" "$SCRIPTS/queue-wait"
+export PATH="$BIN:$PATH" E2E_PHASE="$PHASE" E2E_QUEUE_LOG="$QUEUE_LOG" E2E_HEAD="$HEAD"
+export QUEUE_WAIT_CONFIRM_POLLS=2
+unset GH_TOKEN GITHUB_TOKEN GH_BOT_TOKEN GH_REPO GITHUB_REPOSITORY
+
+echo "=== arm, eject, re-arm through the watcher ==="
+"$SCRIPTS/merge-queue-watch" init --worktree "$MAIN" --issue KEN-916-e2e --branch "$BR" >/dev/null
+printf 'queued\n' > "$PHASE"
+prep=$("$SCRIPTS/merge-queue-watch" prepare --worktree "$MAIN" --issue KEN-916-e2e \
+  --repo owner/repo --pr 42 --head "$HEAD" --root "$MAIN" --gate-mode off --recovery-count 0 --cleanup-worktree false)
+watch1=$(jq -r .watch_id <<<"$prep"); artifact1=$(jq -r .artifact_path <<<"$prep")
+"$SCRIPTS/merge-queue-watch" launch --root "$MAIN" --issue KEN-916-e2e --watch-id "$watch1" --poll 1 --max-wait 60 >/dev/null
+set +e
+early_event=$("$SCRIPTS/merge-queue-watch" event --root "$MAIN" --issue KEN-916-e2e); early_rc=$?
+set -e
+if [[ "$early_rc" -ne 0 && -z "$early_event" ]]; then ok "queued watch emits no oversee event"; else bad "queued watch woke oversee early"; fi
+wait_line "$QUEUE_LOG" || bad "queue-wait never polled queue state"
+printf 'ejected\n' > "$PHASE"
+wait_file "$artifact1" || bad "ejection verdict was not published"
+eq "$(jq -r .verdict "$artifact1")" ejected "queue-wait reports the confirmed ejection"
+event_out=$("$SCRIPTS/merge-queue-watch" event --root "$MAIN" --issue KEN-916-e2e)
+eq "$event_out" "ready KEN-916-e2e $watch1" "ejection wakes oversee with the watch identity"
+result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-916-e2e)
+eq "$(jq -r .action <<<"$result")" recovery "ejection consumes as a recovery claim"
+eq "$(jq -r .verdict <<<"$result")" ejected "recovery claim carries the ejected verdict"
+eq "$(jq -r .recovery_count <<<"$result")" 1 "recovery claim increments the durable count"
+set +e
+"$SCRIPTS/merge-queue-watch" event --root "$MAIN" --issue KEN-916-e2e >/dev/null 2>&1; claimed_rc=$?
+set -e
+[[ "$claimed_rc" -ne 0 ]] && ok "a claimed verdict stops waking oversee" || bad "claimed verdict kept waking oversee"
+
+printf 'merged\n' > "$PHASE"
+prep2=$("$SCRIPTS/merge-queue-watch" prepare --worktree "$MAIN" --issue KEN-916-e2e \
+  --repo owner/repo --pr 42 --head "$HEAD" --root "$MAIN" --gate-mode off --recovery-count 1 --cleanup-worktree false)
+watch2=$(jq -r .watch_id <<<"$prep2"); artifact2=$(jq -r .artifact_path <<<"$prep2")
+[[ "$watch2" != "$watch1" ]] && ok "re-arm claims a fresh watch generation" || bad "re-arm reused the consumed watch"
+"$SCRIPTS/merge-queue-watch" launch --root "$MAIN" --issue KEN-916-e2e --watch-id "$watch2" --poll 1 --max-wait 60 >/dev/null
+wait_file "$artifact2" || bad "re-armed merge verdict was not published"
+eq "$(jq -r .verdict "$artifact2")" merged "re-armed watch reports the merge"
+event_out=$("$SCRIPTS/merge-queue-watch" event --root "$MAIN" --issue KEN-916-e2e)
+eq "$event_out" "ready KEN-916-e2e $watch2" "re-armed verdict wakes oversee with the new watch identity"
+result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-916-e2e)
+eq "$(jq -r .action <<<"$result")" postmerge "re-armed merge consumes as postmerge"
+"$SCRIPTS/merge-queue-watch" merge-pr-complete --root "$MAIN" --issue KEN-916-e2e --watch-id "$watch2" >/dev/null
+"$SCRIPTS/merge-queue-watch" cleanup --root "$MAIN" --issue KEN-916-e2e --watch-id "$watch2" >/dev/null
+"$SCRIPTS/merge-queue-watch" acknowledge --root "$MAIN" --issue KEN-916-e2e --watch-id "$watch2" --result pass >/dev/null
+result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-916-e2e)
+eq "$(jq -r .action <<<"$result")" complete "acknowledged lifecycle finishes complete"
+
+printf 'merge-queue-rearm-e2e: %d pass, %d fail\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/.agents/skills/orch/tests/merge_queue_watch.sh
+++ b/.agents/skills/orch/tests/merge_queue_watch.sh
@@ -330,14 +330,6 @@ if [[ -n "$REAL_SETSID" ]]; then
 else
   ok "launch setup race control skipped without setsid"
 fi
-prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep"); state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path); watch_dir=$(jq -r .watch_dir "$state_path"); legacy_runtime="$watch_dir/legacy-runtime"
-mkdir "$legacy_runtime"; printf '%s\n' "$watch" > "$legacy_runtime/token"
-jq --arg artifact "$watch_dir/verdict.json" --arg runtime "$legacy_runtime" '.artifact_path=$artifact|.runtime_dir=$runtime|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token,.legacy_generation)' "$state_path" > "$TMP/legacy-prepared.json"; chmod 600 "$TMP/legacy-prepared.json"; mv "$TMP/legacy-prepared.json" "$state_path"
-launch_bounded "$watch"
-legacy_state=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829)
-eq "$(jq -r .status <<<"$legacy_state")" watching "legacy prepared lifecycle launches after upgrade"
-[[ "$(jq -r .launch_attempt_id <<<"$legacy_state")" == "$watch-attempt-1" && "$(jq -r .runtime_dir <<<"$legacy_state")" != "$legacy_runtime" && "$(jq -r .watch_dir <<<"$legacy_state")" == "$watch_dir" ]] && ok "legacy prepared migration preserves watch cleanup identity" || bad "legacy prepared migration lost generation or cleanup identity"
-"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
 jq --arg attempt "$watch-attempt-1" --arg token "$watch-attempt-1-test" '.launch_attempt=1|.launch_attempt_id=$attempt|.supervisor_token=$token|.status="launching"|.setup_deadline=0|.deadline=((now|floor)+600)' "$state_path" > "$TMP/orphan.json"
@@ -367,7 +359,7 @@ prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .a
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
 jq --arg attempt "$watch-attempt-1" --arg token "$watch-attempt-1-test" '.launch_attempt=1|.launch_attempt_id=$attempt|.supervisor_token=$token|.status="launching"|.setup_deadline=((now|floor)+10)|.deadline=((now|floor)+600)' "$state_path" > "$TMP/completed-launch.json"
 chmod 600 "$TMP/completed-launch.json"; mv "$TMP/completed-launch.json" "$state_path"
-jq -n --arg watch "$watch" --arg attempt "$watch-attempt-1" --arg head "$HEAD_A" '{schema_version:1,status:"complete",verdict:"merged",repository:"owner/repo",pr_number:42,expected_head:$head,observed_head:"",watch_id:$watch,launch_attempt_id:$attempt}' > "$artifact"
+jq -n --arg watch "$watch" --arg attempt "$watch-attempt-1" --arg head "$HEAD_A" '{schema_version:1,status:"complete",verdict:"merged",repository:"owner/repo",pr_number:42,expected_head:$head,watch_id:$watch,launch_attempt_id:$attempt}' > "$artifact"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .action <<<"$result")" postmerge "completed artifact outranks launching setup state"
 "$SCRIPTS/merge-queue-watch" merge-pr-complete --root "$MAIN" --issue KEN-829 --watch-id "$watch" >/dev/null
@@ -645,63 +637,18 @@ touch "$RELEASE"
 rm -f -- "$WATCH_REGISTRATION_GATE.enabled" "$WATCH_REGISTRATION_GATE.entered" "$WATCH_REGISTRATION_GATE.release"
 
 prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+launch_bounded "$watch"
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
-bash -c 'while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$state_path" "$watch" "$SCRIPTS/queue-wait" 1 10 & legacy_supervisor=$!
-jq --argjson pid "$legacy_supervisor" '.status="launching"|.supervisor_pid=$pid|.setup_deadline=((now|floor)+10)|.deadline=((now|floor)+600)|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-watching.json"
-chmod 600 "$TMP/legacy-watching.json"; mv "$TMP/legacy-watching.json" "$state_path"
-result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
-eq "$(jq -r .action <<<"$result")" pending "live legacy launching remains pending"
-jq '.setup_deadline=0' "$state_path" > "$TMP/legacy-launch-expired.json"; chmod 600 "$TMP/legacy-launch-expired.json"; mv "$TMP/legacy-launch-expired.json" "$state_path"
-result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
-eq "$(jq -r .action <<<"$result")" pending "expired live legacy launch is adopted"
-eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .status)" watching "legacy launch adoption persists watching"
-running "$legacy_supervisor" && ok "legacy watching supervisor is preserved" || bad "legacy watching supervisor was terminated"
-"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
-if ! running "$legacy_supervisor"; then ok "direct legacy failure terminates tokenless supervisor"; else bad "direct legacy failure left tokenless supervisor running"; fi
-kill "$legacy_supervisor" 2>/dev/null || true
-wait "$legacy_supervisor" 2>/dev/null || true
-
-prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
-state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
-bash -c 'while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$state_path" "$watch" "$SCRIPTS/queue-wait" 1 10 & zombie_pid=$!
+bash -c 'while :; do sleep 1; done' zombie-decoy & zombie_pid=$!
 export WATCH_PS_ZOMBIE_PID="$zombie_pid"
-jq --argjson pid "$zombie_pid" '.status="watching"|.supervisor_pid=$pid|.deadline=((now|floor)+600)|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-zombie.json"
-chmod 600 "$TMP/legacy-zombie.json"; mv "$TMP/legacy-zombie.json" "$state_path"
+jq --argjson pid "$zombie_pid" '.supervisor_pid=$pid' "$state_path" > "$TMP/zombie.json"
+chmod 600 "$TMP/zombie.json"; mv "$TMP/zombie.json" "$state_path"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .status <<<"$result")" failed "production liveness treats zombie state as exited"
 if ! running "$zombie_pid"; then ok "test liveness helper treats zombie state as exited"; else bad "test liveness helper accepted zombie state"; fi
 unset WATCH_PS_ZOMBIE_PID
 kill "$zombie_pid" 2>/dev/null || true; wait "$zombie_pid" 2>/dev/null || true
-
-prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
-state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
-jq '.status="launching"|.setup_deadline=0|.deadline=((now|floor)+600)|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-launching.json"
-chmod 600 "$TMP/legacy-launching.json"; mv "$TMP/legacy-launching.json" "$state_path"
-result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
-eq "$(jq -r .action <<<"$result")" resume_launch "orphaned legacy launch enters recovery"
-"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
-
-prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
-state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
-legacy_runtime=$(jq -r .runtime_dir "$state_path")
-printf '%s\n' "$watch" > "$legacy_runtime/token"
-bash -c 'while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$state_path" "$watch" "$SCRIPTS/queue-wait" 1 10 & legacy_retry_supervisor=$!
-jq --argjson pid "$legacy_retry_supervisor" '.status="launch_failed"|.action="launch"|.supervisor_pid=$pid|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-launch-failed.json"
-chmod 600 "$TMP/legacy-launch-failed.json"; mv "$TMP/legacy-launch-failed.json" "$state_path"
-launch_bounded "$watch"
-legacy_retry_state=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829)
-eq "$(jq -r .status <<<"$legacy_retry_state")" watching "legacy launch failure retries on a migrated generation"
-[[ "$(jq -r .runtime_dir <<<"$legacy_retry_state")" != "$legacy_runtime" ]] && ok "legacy retry receives an isolated runtime" || bad "legacy retry reused legacy runtime"
-if ! running "$legacy_retry_supervisor"; then ok "legacy retry terminates old supervisor before replacement"; else bad "legacy retry left old supervisor running"; fi
-kill "$legacy_retry_supervisor" 2>/dev/null || true
-wait "$legacy_retry_supervisor" 2>/dev/null || true
-if [[ "$(jq -r .status <<<"$legacy_retry_state")" == watching ]]; then
-  legacy_retry_artifact=$(jq -r .artifact_path <<<"$legacy_retry_state")
-  touch "$RELEASE"; wait_file "$legacy_retry_artifact" || bad "legacy retry verdict missing"
-  result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
-  eq "$(jq -r .action <<<"$result")" recovery "legacy retry verdict is consumable"
-fi
-"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+touch "$RELEASE"
 
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
 "$SCRIPTS/merge-queue-watch" direct-merged --root "$MAIN" --issue KEN-829 --watch-id "$watch" >/dev/null
@@ -744,6 +691,19 @@ eq "$(jq -r .cleanup.disposition <<<"$state")" kept "cleanup keeps a worktree wh
 "$SCRIPTS/merge-queue-watch" acknowledge --root "$MAIN" --issue KEN-829 --watch-id "$watch" --result pass >/dev/null
 git -C "$WT" switch -q watch-test
 git -C "$MAIN" branch -D foreign-cleanup >/dev/null
+
+git -C "$WT" switch -qc prepare-time-branch
+prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
+eq "$(jq -r .pr_branch <<<"$prep")" watch-test "prepare binds cleanup to the recorded PR branch, not the prepare-time checkout"
+"$SCRIPTS/merge-queue-watch" direct-merged --root "$MAIN" --issue KEN-829 --watch-id "$watch" >/dev/null
+"$SCRIPTS/merge-queue-watch" merge-pr-complete --root "$MAIN" --issue KEN-829 --watch-id "$watch" >/dev/null
+"$SCRIPTS/merge-queue-watch" cleanup --root "$MAIN" --issue KEN-829 --watch-id "$watch" >/dev/null
+state=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829)
+eq "$(jq -r .cleanup.disposition <<<"$state")" kept "cleanup keeps a worktree prepared on a non-PR branch"
+[[ -d "$WT" ]] && ok "non-PR-branch worktree survives cleanup" || bad "cleanup removed a worktree the workflow says to keep"
+"$SCRIPTS/merge-queue-watch" acknowledge --root "$MAIN" --issue KEN-829 --watch-id "$watch" --result pass >/dev/null
+git -C "$WT" switch -q watch-test
+git -C "$MAIN" branch -D prepare-time-branch >/dev/null
 
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
 "$SCRIPTS/merge-queue-watch" direct-merged --root "$MAIN" --issue KEN-829 --watch-id "$watch" >/dev/null

--- a/changelog.d/fixed/KEN-888.md
+++ b/changelog.d/fixed/KEN-888.md
@@ -1,0 +1,1 @@
+- Merge-queue cleanup now binds to the PR branch recorded for the watch; a worktree checked out on any other branch is kept instead of removed.

--- a/skills/orch/scripts/lib/merge-queue-state.sh
+++ b/skills/orch/scripts/lib/merge-queue-state.sh
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 
-MERGE_QUEUE_REPORT_FILTER='{issue_id,watch_id,status,action,repository,pr_number,head_sha,worktree_branch,
+MERGE_QUEUE_REPORT_FILTER='{issue_id,watch_id,status,action,repository,pr_number,head_sha,pr_branch,
   gate_mode,recovery_count,launch_attempt,launch_attempt_id,runtime_dir,artifact_path,log_path,deadline,verdict,verdict_cause,
   lane_postmerge,cleanup,diagnostic,error:(.diagnostic.error // null),
   worker_exit_code:(.diagnostic.worker_exit_code // null),
@@ -35,7 +35,7 @@ merge_queue_cleanup_worktree() {
   local worktree helper required expected_branch owner output="" rc=0 diagnostic disposition current_branch
   local expected_common current_common resolved_worktree dirty
   worktree=$(state_value .worktree); helper="$ROOT/.agents/skills/worktree/scripts/worktree"
-  required=$(state_value .cleanup.required); expected_branch=$(state_value .worktree_branch)
+  required=$(state_value .cleanup.required); expected_branch=$(state_value .pr_branch)
   owner="$WATCH_ID-$$-$RANDOM$RANDOM"
   exec 8>"$STATE_FILE.cleanup.lock"
   flock -n 8 || die "cleanup is already owned by another process"
@@ -62,7 +62,7 @@ merge_queue_cleanup_worktree() {
     if [[ -z "$current_common" || "$current_common" != "$expected_common" ]]; then
       output="kept worktree: repository identity changed: $worktree"; disposition=kept
     elif [[ -z "$current_branch" || "$current_branch" != "$expected_branch" ]]; then
-      output="kept worktree: expected branch '$expected_branch', found '${current_branch:-detached HEAD}': $worktree"; disposition=kept
+      output="kept worktree: not on PR branch '$expected_branch' (found '${current_branch:-detached HEAD}'): $worktree"; disposition=kept
     elif [[ -n "$dirty" ]]; then
       output="kept worktree: uncommitted changes are present: $worktree"; disposition=kept
     elif [[ -z "$resolved_worktree" || "$(cd "$resolved_worktree" 2>/dev/null && pwd -P || true)" != "$worktree" ]]; then

--- a/skills/orch/scripts/lib/merge-queue-supervisor.sh
+++ b/skills/orch/scripts/lib/merge-queue-supervisor.sh
@@ -1,4 +1,13 @@
 # shellcheck shell=bash
+#
+# Detached supervisor for one merge-queue launch attempt. The named failure
+# it prevents: queue-wait dying without output (crash, signal, logout) or
+# wedging on a hung GitHub read past its own budget would leave a watch
+# nothing is running and a consume that could only time out. The supervisor
+# publishes an `unknown` artifact when its worker exits unreadably and reaps
+# a worker that outlives the deadline, so every launch attempt ends in a
+# consumable artifact — and only while its own generation is still the
+# registered one, so a dead attempt can never publish over its replacement.
 
 merge_queue_supervise() {
   local state_file="$1" watch_id="$2" attempt_id="$3" runtime="$4" artifact="$5" deadline="$6"
@@ -47,7 +56,7 @@ merge_queue_supervise() {
     jq -n --arg repo "$repo" --argjson pr "$pr" --arg head "$head" --arg watch "$watch_id" --arg attempt "$attempt_id" \
       --arg reason "$reason" --argjson rc "$rc" --arg log "$log" \
       '{schema_version:1,status:"error",verdict:"unknown",repository:$repo,pr_number:$pr,
-        expected_head:$head,observed_head:"",watch_id:$watch,launch_attempt_id:$attempt,cause:$reason,
+        expected_head:$head,watch_id:$watch,launch_attempt_id:$attempt,cause:$reason,
         worker_exit_code:$rc,diagnostic_path:$log}' > "$output" || return 1
     publish_output && published=true
   }
@@ -95,7 +104,7 @@ merge_queue_supervise() {
   fi
   jq --arg repo "$repo" --argjson pr "$pr" --arg head "$head" --arg watch "$watch_id" --arg attempt "$attempt_id" --arg log "$log" \
     '. + {schema_version:1,repository:$repo,pr_number:$pr,expected_head:$head,
-      observed_head:"",watch_id:$watch,launch_attempt_id:$attempt,diagnostic_path:$log}' "$temp" > "$output"
+      watch_id:$watch,launch_attempt_id:$attempt,diagnostic_path:$log}' "$temp" > "$output"
   publish_output || return 1
   published=true; printf '%s\n' "$worker_rc" > "$runtime/terminal"; chmod 600 "$runtime/terminal"
   trap - EXIT TERM HUP INT

--- a/skills/orch/scripts/merge-queue-watch
+++ b/skills/orch/scripts/merge-queue-watch
@@ -25,7 +25,29 @@ Usage:
 
 The durable lifecycle file lives under the shared git directory, so worktree
 cleanup cannot erase an awaiting lane acknowledgment. `consume` is the only
-verdict classifier and action claimant.
+verdict classifier and action claimant. queue-wait is the only reader of
+queue state; this script only verifies the live PR head and state before
+claiming a verdict, so a stale artifact cannot route actions for a head
+that has since moved.
+
+Phase justifications — the named failure each phase prevents:
+  supervisor (launch/__supervise): queue-wait can die without output (crash,
+    signal, logout) or wedge on a hung GitHub read past its own budget,
+    leaving a watch nothing is running and a consume that could only time
+    out. The detached supervisor publishes an `unknown` artifact when its
+    worker exits unreadably and reaps a worker that outlives the deadline,
+    so every launch attempt ends in a consumable artifact.
+  cleanup: worktree removal after a detached merge acts on state recorded
+    before the merge. Unowned removal can run twice (concurrent lanes), act
+    on a tree no longer holding the PR branch (KEN-888), or die midway and
+    be forgotten. The single-owner claim revalidates repository, PR branch,
+    and cleanliness immediately before removal and persists an interrupted
+    claim as cleanup_pending for resume.
+  acknowledge: a lane that dies after the merge leaves post-merge
+    verification undone with nothing reporting it. The lifecycle
+    terminalizes only on an explicit pass/fail acknowledgment, so oversee
+    keeps surfacing the unfinished item instead of it vanishing with the
+    lane.
 EOF
 }
 
@@ -57,35 +79,6 @@ atomic_update() {
     jq "$@" "$filter" "$STATE_FILE" > "$tmp" || { rm -f -- "$tmp"; exit 1; }
     chmod 600 "$tmp" && mv -f -- "$tmp" "$STATE_FILE"
   ) 9>"$STATE_FILE.lock"
-}
-migrate_legacy_state() {
-  local snapshot status watch artifact runtime watch_dir runtime_root legacy_id
-  snapshot=$(state_snapshot) || die "cannot inspect durable watch generation"
-  status=$(jq -r .status <<<"$snapshot")
-  [[ "$status" == prepared || "$status" == launching || "$status" == watching || "$status" == launch_failed || "$status" == failed ]] || return 0
-  if [[ "$status" == prepared ]]; then
-    [[ "$(jq -r '.watch_dir // empty' <<<"$snapshot")" == "" ||
-       "$(jq -r '.runtime_root // empty' <<<"$snapshot")" == "" ||
-       "$(jq -r '.launch_attempt // empty' <<<"$snapshot")" == "" ]] || return 0
-  else
-    [[ "$(jq -r '.launch_attempt_id // empty' <<<"$snapshot")" == "" ||
-       "$(jq -r '.supervisor_token // empty' <<<"$snapshot")" == "" ||
-       "$(jq -r '.runtime_root // empty' <<<"$snapshot")" == "" ]] || return 0
-  fi
-  watch=$(jq -r .watch_id <<<"$snapshot"); artifact=$(jq -r .artifact_path <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
-  watch_dir="${artifact%/*}"; runtime_root="$watch_dir/runtime-attempts"; legacy_id="$watch-legacy"
-  [[ -n "$watch" && "$watch_dir" != "$artifact" && -d "$watch_dir" && ! -L "$watch_dir" && "$runtime" == "$watch_dir/"* ]] \
-    || die "legacy durable watch paths are invalid"
-  mkdir -p -- "$runtime_root" || die "cannot create migrated runtime root: $runtime_root"
-  chmod 700 "$runtime_root" || die "cannot secure migrated runtime root: $runtime_root"
-  atomic_update 'if (.status=="prepared" and
-      ((.watch_dir // "")=="" or (.runtime_root // "")=="" or (.launch_attempt // null)==null)) or
-      ((.status|IN("launching","watching","launch_failed","failed")) and
-       ((.launch_attempt_id // "")=="" or (.supervisor_token // "")=="" or (.runtime_root // "")=="")) then
-      .watch_dir=$watch_dir|.runtime_root=$runtime_root|.legacy_generation=true|.updated_at=(now|floor)|
-      if .status=="prepared" then .launch_attempt=0|.launch_attempt_id=null|.supervisor_token=null
-      else .launch_attempt=1|.launch_attempt_id=$legacy|.supervisor_token=$legacy end else . end' \
-    --arg watch_dir "$watch_dir" --arg runtime_root "$runtime_root" --arg legacy "$legacy_id"
 }
 fail_state() {
   local cause="$1" detail="$2" attempt_id="${3:-}" artifact="${4:-}"
@@ -144,21 +137,6 @@ supervisor_live() {
   command=$(ps eww -p "$pid" -o command= 2>/dev/null) || return 1
   [[ " $command " == *" __supervise "* && " $command " == *" MERGE_QUEUE_SUPERVISOR_TOKEN=$supervisor_token "* ]]
 }
-legacy_supervisor_live() {
-  local pid="$1" command arg i
-  local argv=()
-  process_running "$pid" || return 1
-  if [[ -r "/proc/$pid/cmdline" ]]; then
-    while IFS= read -r -d '' arg; do argv[${#argv[@]}]="$arg"; done < "/proc/$pid/cmdline"
-    for ((i=0; i+4<${#argv[@]}; i++)); do
-      [[ "${argv[i]}" == "$SELF" && "${argv[i+1]}" == __supervise && "${argv[i+2]}" == "$STATE_FILE" &&
-         "${argv[i+3]}" == "$WATCH_ID" && "${argv[i+4]}" == "$SCRIPT_DIR/queue-wait" ]] && return 0
-    done
-    return 1
-  fi
-  command=$(ps -ww -p "$pid" -o command= 2>/dev/null) || return 1
-  [[ "$command" == *"$SELF __supervise $STATE_FILE $WATCH_ID $SCRIPT_DIR/queue-wait "* ]]
-}
 terminate_supervisor() {
   local pid="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" i
   supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || return 0
@@ -175,18 +153,8 @@ terminate_supervisor() {
   done
   return 1
 }
-terminate_legacy_supervisor() {
-  local pid="$1" i
-  legacy_supervisor_live "$pid" || return 0
-  kill -TERM "$pid" 2>/dev/null || true
-  for ((i=0; i<50; i++)); do legacy_supervisor_live "$pid" || return 0; sleep 0.1; done
-  legacy_supervisor_live "$pid" || return 0
-  kill -KILL "$pid" 2>/dev/null || true
-  for ((i=0; i<20; i++)); do legacy_supervisor_live "$pid" || return 0; sleep 0.1; done
-  return 1
-}
 launch_failure() {
-  local detail="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" pid="${6:-}" legacy="${7:-false}" snapshot
+  local detail="$1" attempt_id="$2" runtime="$3" artifact="$4" supervisor_token="$5" pid snapshot
   atomic_update 'if .watch_id!=$watch or .launch_attempt_id!=$attempt or .runtime_dir!=$runtime or .artifact_path!=$artifact or
       .supervisor_token!=$token or
       (.status|IN("launching","watching")|not) then error("launch claim lost") else
@@ -197,8 +165,7 @@ launch_failure() {
     || die "could not claim launch recovery; inspect the active lifecycle before handback"
   snapshot=$(state_snapshot) || die "cannot snapshot claimed launch failure"
   pid=$(supervisor_pid "$runtime" "$(jq -r '.supervisor_pid // empty' <<<"$snapshot")")
-  if [[ -n "$pid" && "$legacy" == true ]]; then terminate_legacy_supervisor "$pid" || true
-  elif [[ -n "$pid" ]]; then terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true; fi
+  [[ -z "$pid" ]] || terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
   atomic_update 'if .watch_id==$watch and .launch_attempt_id==$attempt and .status=="launch_failed"
       then .supervisor_pid=null|.updated_at=(now|floor) else error("launch failure claim changed") end' \
     --arg watch "$WATCH_ID" --arg attempt "$attempt_id"
@@ -230,9 +197,13 @@ prepare() {
   [[ "$gate" =~ ^(approval|review|off)$ && "$recovery" =~ ^[0-9]+$ ]] || die "prepare gate mode or recovery count is malformed"
   [[ "$cleanup" == true || "$cleanup" == false ]] || die "prepare cleanup flag is malformed"
   resolve_state
-  local now watch_dir artifact log runtime_root runtime attempt_id new_state old_status="" pointer worktree_branch
+  local now watch_dir artifact log runtime_root runtime attempt_id new_state old_status="" pointer pr_branch
   now=$(date +%s); WATCH_ID="$now-$$-$RANDOM$RANDOM"
-  worktree_branch=$(git -C "$worktree" branch --show-current 2>/dev/null) || die "cannot read prepared worktree branch"
+  # Cleanup binds to the PR branch recorded at init, never to whatever branch
+  # happens to be checked out when prepare runs (KEN-888): a lane that
+  # switched branches in between must not have that unrelated tree removed.
+  pr_branch=$(cd "$worktree" && "$WORKFLOW_STATE" get "$ISSUE" .branch) || die "cannot read recorded PR branch from workflow state"
+  [[ -n "$pr_branch" && "$pr_branch" != null ]] || die "workflow state records no PR branch for $ISSUE; run init --branch first"
   watch_dir="$STATE_DIR/runs/$ISSUE-$WATCH_ID"
   mkdir -- "$watch_dir" || die "cannot reserve watch directory"
   chmod 700 "$watch_dir"
@@ -243,12 +214,12 @@ prepare() {
   new_state="$watch_dir/prepared.json"
   jq -n --arg issue "$ISSUE" --arg repo "$repo" --argjson pr "$pr" --arg head "$head" \
     --arg watch "$WATCH_ID" --arg gate "$gate" --argjson recovery "$recovery" \
-    --arg root "$ROOT" --arg worktree "$(cd "$worktree" && pwd -P)" --arg worktree_branch "$worktree_branch" \
+    --arg root "$ROOT" --arg worktree "$(cd "$worktree" && pwd -P)" --arg pr_branch "$pr_branch" \
     --arg watch_dir "$watch_dir" --arg artifact "$artifact" --arg log "$log" --arg runtime_root "$runtime_root" --arg runtime "$runtime" \
     --argjson now "$now" --argjson cleanup "$cleanup" \
     '{schema_version:1,issue_id:$issue,repository:$repo,pr_number:$pr,head_sha:$head,
       watch_id:$watch,gate_mode:$gate,recovery_count:$recovery,main_repo_root:$root,
-      worktree:$worktree,worktree_branch:$worktree_branch,watch_dir:$watch_dir,artifact_path:$artifact,log_path:$log,
+      worktree:$worktree,pr_branch:$pr_branch,watch_dir:$watch_dir,artifact_path:$artifact,log_path:$log,
       runtime_root:$runtime_root,runtime_dir:$runtime,prepared_at:$now,launch_attempt:0,launch_attempt_id:null,
       status:"prepared",action:null,terminal:false,
       supervisor_pid:null,supervisor_token:null,launched_at:null,deadline:null,lane_postmerge:null,
@@ -278,7 +249,7 @@ prepare() {
 
 launch() {
   local poll=30 max_wait=2400 method pid deadline now ready log runtime waiter artifact attempt attempt_id supervisor_token
-  local snapshot status prior_attempt head runtime_root watch_dir created=false legacy recorded_pid
+  local snapshot status prior_attempt head runtime_root watch_dir created=false
   while [[ $# -gt 0 ]]; do
     case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;;
       --watch-id) WATCH_ID="${2:-}"; shift 2 ;; --poll) poll="${2:-}"; shift 2 ;;
@@ -290,18 +261,9 @@ launch() {
   snapshot=$(state_snapshot) || die "cannot snapshot prepared lifecycle"
   [[ "$WATCH_ID" =~ ^[A-Za-z0-9._-]+$ && "$WATCH_ID" != *..* ]] || die "watch id is not path-safe: $WATCH_ID"
   [[ "$(jq -r '.watch_id // empty' <<<"$snapshot")" == "$WATCH_ID" ]] || die "watch id does not match active lifecycle"
-  migrate_legacy_state
   [[ "$poll" =~ ^[1-9][0-9]*$ && "$max_wait" =~ ^[1-9][0-9]*$ && "$poll" -le "$max_wait" ]] || die "invalid wait bounds"
-  snapshot=$(state_snapshot) || die "cannot snapshot prepared lifecycle"
-  [[ "$(jq -r '.watch_id // empty' <<<"$snapshot")" == "$WATCH_ID" ]] || die "watch id changed during launch"
   status=$(jq -r .status <<<"$snapshot"); prior_attempt=$(jq -r '.launch_attempt // 0' <<<"$snapshot")
   [[ "$prior_attempt" =~ ^[0-9]+$ && ( "$status" == prepared || "$status" == launch_failed ) ]] || die "prepared claim lost"
-  legacy=$(jq -r '.legacy_generation // false' <<<"$snapshot")
-  if [[ "$status" == launch_failed && "$legacy" == true ]]; then
-    runtime=$(jq -r .runtime_dir <<<"$snapshot"); recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot")
-    pid=$(supervisor_pid "$runtime" "$recorded_pid")
-    [[ -z "$pid" ]] || terminate_legacy_supervisor "$pid" || die "legacy supervisor survived launch recovery teardown"
-  fi
   attempt=$((prior_attempt+1)); attempt_id="$WATCH_ID-attempt-$attempt"; supervisor_token="$attempt_id-$RANDOM$RANDOM"
   head=$(jq -r .head_sha <<<"$snapshot")
   now=$(date +%s); deadline=$((now + max_wait + 90)); log=$(jq -r .log_path <<<"$snapshot")
@@ -316,7 +278,7 @@ launch() {
     die "queue-wait is missing: $waiter; diagnostics: $log"
   fi
   runtime_root=$(jq -r .runtime_root <<<"$snapshot"); watch_dir=$(jq -r .watch_dir <<<"$snapshot")
-  if [[ "$prior_attempt" -eq 0 && "$legacy" != true ]]; then
+  if [[ "$prior_attempt" -eq 0 ]]; then
     runtime=$(jq -r .runtime_dir <<<"$snapshot"); artifact=$(jq -r .artifact_path <<<"$snapshot")
     [[ -d "$runtime" && ! -L "$runtime" && -f "$runtime/token" && "$(cat < "$runtime/token")" == "$attempt_id" ]] \
       || die "prepared attempt runtime is invalid: $runtime"
@@ -337,7 +299,7 @@ launch() {
   if ! atomic_update 'if .watch_id!=$watch or .head_sha!=$head or .status!=$status or (.launch_attempt // 0)!=$prior
       then error("prepared claim lost") else .artifact_path=$artifact|.runtime_dir=$runtime|
       .launch_attempt=$attempt|.launch_attempt_id=$attempt_id|.status="launching"|.action=null|.diagnostic=null|
-      .supervisor_pid=null|.supervisor_token=$token|.legacy_generation=false|.launch_method=$method|.launched_at=$now|
+      .supervisor_pid=null|.supervisor_token=$token|.launch_method=$method|.launched_at=$now|
       .setup_deadline=($now+10)|.deadline=$deadline|.updated_at=$now end' \
     --arg watch "$WATCH_ID" --arg head "$head" --arg status "$status" --argjson prior "$prior_attempt" \
     --arg runtime "$runtime" --arg artifact "$artifact" --arg attempt_id "$attempt_id" --arg token "$supervisor_token" --arg method "$method" \
@@ -407,9 +369,8 @@ claim() {
 
 consume() {
   parse_root_issue "$@"
-  migrate_legacy_state
   local snapshot status artifact runtime attempt_id supervisor_token pid recorded_pid deadline setup_deadline now runtime_token body live live_state
-  local observed expected repo pr verdict result cause action diag error_text exit_code diag_path unconfirmed recovery log legacy
+  local expected repo pr verdict result cause action diag error_text exit_code diag_path unconfirmed recovery log
   snapshot=$(state_snapshot) || die "cannot snapshot active launch attempt"
   WATCH_ID=$(jq -r .watch_id <<<"$snapshot"); status=$(jq -r .status <<<"$snapshot")
   case "$status" in claimed|launch_failed|failed|abandoned|awaiting_lane_postmerge|cleanup_pending|cleanup_complete|complete) consume_report; return ;; esac
@@ -419,18 +380,9 @@ consume() {
   deadline=$(jq -r '.deadline // 0' <<<"$snapshot"); setup_deadline=$(jq -r '.setup_deadline // 0' <<<"$snapshot")
   expected=$(jq -r .head_sha <<<"$snapshot"); repo=$(jq -r .repository <<<"$snapshot"); pr=$(jq -r .pr_number <<<"$snapshot")
   recovery=$(jq -r .recovery_count <<<"$snapshot"); log=$(jq -r .log_path <<<"$snapshot"); now=$(date +%s)
-  legacy=$(jq -r '.legacy_generation // false' <<<"$snapshot")
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
     pid=$(supervisor_pid "$runtime" "$recorded_pid")
-    if [[ "$legacy" == true ]] && legacy_supervisor_live "$pid"; then
-      if [[ "$now" -le "$setup_deadline" ]]; then
-        jq -cn --arg watch "$WATCH_ID" '{status:"launching",watch_id:$watch,action:"pending"}'; return
-      fi
-      atomic_update 'if .watch_id==$watch and .launch_attempt_id==$attempt and .legacy_generation==true and
-          .status=="launching" then .status="watching"|.supervisor_pid=$pid|.updated_at=(now|floor)
-          else error("legacy launch attempt changed") end' --arg watch "$WATCH_ID" --arg attempt "$attempt_id" \
-        --argjson pid "$pid"; status=watching
-    elif supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then
+    if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then
       if [[ "$now" -le "$setup_deadline" ]]; then
         jq -cn --arg watch "$WATCH_ID" '{status:"launching",watch_id:$watch,action:"pending"}'; return
       fi
@@ -442,15 +394,8 @@ consume() {
     elif [[ -z "$pid" && "$now" -le "$setup_deadline" ]]; then
       jq -cn --arg watch "$WATCH_ID" '{status:"launching",watch_id:$watch,action:"pending"}'; return
     else
-      launch_failure "launching supervisor died or missed its setup deadline; see $log" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" "$recorded_pid" "$legacy"
+      launch_failure "launching supervisor died or missed its setup deadline; see $log" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"
       consume_report; return
-    fi
-  fi
-  if [[ "$legacy" == true && "$status" == watching && ! -s "$artifact" ]]; then
-    pid=$(supervisor_pid "$runtime" "$recorded_pid")
-    if [[ "$now" -le "$deadline" ]] && legacy_supervisor_live "$pid"; then
-      jq -cn --arg watch "$WATCH_ID" '{status:"watching",watch_id:$watch,action:"pending"}'
-      return
     fi
   fi
   if [[ ! -s "$artifact" ]]; then
@@ -462,14 +407,13 @@ consume() {
     fi
     fail_state watch_lost "artifact missing and supervisor dead or overdue; see $log" "$attempt_id" "$artifact"
     pid=$(supervisor_pid "$runtime")
-    if [[ -n "$pid" && "$legacy" == true ]]; then terminate_legacy_supervisor "$pid" || true
-    elif [[ -n "$pid" ]]; then terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true; fi
+    [[ -z "$pid" ]] || terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
     json_report; return
   fi
-  if ! jq -e --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg repo "$repo" --arg head "$expected" --argjson pr "$pr" --argjson legacy "$legacy" '
+  if ! jq -e --arg watch "$WATCH_ID" --arg attempt "$attempt_id" --arg repo "$repo" --arg head "$expected" --argjson pr "$pr" '
       type=="object" and .schema_version==1 and .watch_id==$watch and
-      (.launch_attempt_id==$attempt or ($legacy and (.launch_attempt_id==null))) and .repository==$repo and
-      .pr_number==$pr and .expected_head==$head and (.observed_head|type=="string") and
+      .launch_attempt_id==$attempt and .repository==$repo and
+      .pr_number==$pr and .expected_head==$head and
       (.status|IN("complete","timeout","error")) and (.verdict|IN("merged","conflicting","ejected","disarmed","dequeued","closed","queued","not_queued","unknown"))' "$artifact" >/dev/null; then
     fail_state malformed_artifact "verdict artifact is malformed or belongs to another launch attempt" "$attempt_id" "$artifact"
     json_report; return
@@ -481,13 +425,12 @@ consume() {
   (umask 077; set -C; : > "$diag") || die "cannot create diagnostic binding"
   body=$(live_pr) || body='{"headRefOid":"","state":"UNKNOWN"}'
   live=$(jq -r '.headRefOid // ""' <<<"$body"); live_state=$(jq -r '.state // ""' <<<"$body")
-  observed=$(jq -r .observed_head "$artifact")
   jq -n --arg cause "${cause:-$verdict}" --arg error "$error_text" --arg exit "$exit_code" --arg path "$diag_path" --arg unconfirmed "$unconfirmed" \
-    --arg expected "$expected" --arg observed "$observed" --arg live "$live" --arg state "$live_state" \
+    --arg expected "$expected" --arg live "$live" --arg state "$live_state" \
     '{cause:$cause,error:(if $error=="" then null else $error end),unconfirmed_verdict:(if $unconfirmed=="" then null else $unconfirmed end),worker_exit_code:(if $exit=="" then null else ($exit|tonumber) end),
-      diagnostic_path:$path,head_verification:{expected:$expected,artifact_observed:$observed,live:$live,live_state:$state}}' > "$diag"
+      diagnostic_path:$path,head_verification:{expected:$expected,live:$live,live_state:$state}}' > "$diag"
   if [[ -z "$live" ]]; then claim failed "$verdict" live_pr_unreadable "$diag" "$attempt_id" "$artifact" "$expected" "$recovery"; rm -f -- "$diag"; return; fi
-  if [[ "$live" != "$expected" || ( -n "$observed" && "$observed" != "$expected" ) ]]; then
+  if [[ "$live" != "$expected" ]]; then
     claim failed "$verdict" head_mismatch "$diag" "$attempt_id" "$artifact" "$expected" "$recovery"; rm -f -- "$diag"; return
   fi
   if [[ "$live_state" == MERGED ]]; then claim postmerge merged merged_race "$diag" "$attempt_id" "$artifact" "$expected" "$recovery"; rm -f -- "$diag"; return; fi
@@ -510,8 +453,8 @@ consume() {
 event() {
   while [[ $# -gt 0 ]]; do case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;; *) die "unknown event option: $1" ;; esac; done
   [[ -n "$ROOT" && -n "$ISSUE" ]] || die "--root and --issue are required"
-  resolve_state; [[ -f "$STATE_FILE" ]] || exit 1; migrate_legacy_state
-  local snapshot status artifact runtime attempt_id supervisor_token recorded_pid pid deadline setup_deadline now legacy
+  resolve_state; [[ -f "$STATE_FILE" ]] || exit 1
+  local snapshot status artifact runtime attempt_id supervisor_token recorded_pid pid deadline setup_deadline now
   snapshot=$(state_snapshot) || exit 1; WATCH_ID=$(jq -r .watch_id <<<"$snapshot")
   status=$(jq -r .status <<<"$snapshot"); [[ "$status" == watching || "$status" == launching || "$status" == launch_failed ]] || exit 1
   [[ "$status" == launch_failed ]] && { printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; }
@@ -519,11 +462,8 @@ event() {
   attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$snapshot")
   supervisor_token=$(jq -r '.supervisor_token // empty' <<<"$snapshot")
   deadline=$(jq -r '.deadline // 0' <<<"$snapshot"); setup_deadline=$(jq -r '.setup_deadline // 0' <<<"$snapshot")
-  legacy=$(jq -r '.legacy_generation // false' <<<"$snapshot"); now=$(date +%s); pid=$(supervisor_pid "$runtime" "$recorded_pid")
-  if [[ "$legacy" == true && "$status" == watching && ! -s "$artifact" && "$now" -le "$deadline" ]] &&
-      legacy_supervisor_live "$pid"; then exit 1; fi
+  now=$(date +%s); pid=$(supervisor_pid "$runtime" "$recorded_pid")
   if [[ "$status" == launching && ! -s "$artifact" ]]; then
-    if [[ "$legacy" == true ]] && legacy_supervisor_live "$pid"; then [[ "$now" -le "$setup_deadline" ]] && exit 1; printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
     if supervisor_live "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token"; then [[ "$now" -le "$setup_deadline" ]] && exit 1; printf 'ready %s %s\n' "$ISSUE" "$WATCH_ID"; return 0; fi
     [[ -z "$pid" && "$now" -le "$setup_deadline" ]] && exit 1
   fi
@@ -570,23 +510,20 @@ acknowledge() {
 }
 
 fail_command() {
-  local cause="" snapshot fresh attempt_id runtime artifact supervisor_token recorded_pid pid i fresh_attempt fresh_artifact legacy
+  local cause="" snapshot fresh attempt_id runtime artifact supervisor_token recorded_pid pid i fresh_attempt fresh_artifact
   while [[ $# -gt 0 ]]; do case "$1" in --root) ROOT="${2:-}"; shift 2 ;; --issue) ISSUE="${2:-}"; shift 2 ;;
     --watch-id) WATCH_ID="${2:-}"; shift 2 ;; --cause) cause="${2:-}"; shift 2 ;; *) die "unknown fail option: $1" ;; esac; done
   resolve_state; require_state; [[ "$cause" =~ ^(arm_failed|merge_blocked|launch_failed|operator_abandoned)$ ]] || die "invalid failure cause"
-  migrate_legacy_state
   for ((i=0; i<2; i++)); do
     snapshot=$(state_snapshot) || die "cannot snapshot active launch attempt"
     WATCH_ID="${WATCH_ID:-$(jq -r .watch_id <<<"$snapshot")}"
     attempt_id=$(jq -r '.launch_attempt_id // empty' <<<"$snapshot"); runtime=$(jq -r .runtime_dir <<<"$snapshot")
     artifact=$(jq -r .artifact_path <<<"$snapshot"); supervisor_token=$(jq -r '.supervisor_token // empty' <<<"$snapshot")
-    legacy=$(jq -r '.legacy_generation // false' <<<"$snapshot")
     if fail_state "$cause" "$cause" "$attempt_id" "$artifact"; then
       fresh=$(state_snapshot) || die "cannot snapshot claimed failure"
       recorded_pid=$(jq -r '.supervisor_pid // empty' <<<"$fresh")
       pid=$(supervisor_pid "$runtime" "$recorded_pid")
-      if [[ "$legacy" == true ]]; then terminate_legacy_supervisor "$pid" || true
-      else terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true; fi
+      terminate_supervisor "$pid" "$attempt_id" "$runtime" "$artifact" "$supervisor_token" || true
       json_report; return
     fi
     fresh=$(state_snapshot) || die "cannot resnapshot launch attempt after failure claim loss"

--- a/skills/orch/scripts/merge-queue-watch
+++ b/skills/orch/scripts/merge-queue-watch
@@ -31,12 +31,9 @@ claiming a verdict, so a stale artifact cannot route actions for a head
 that has since moved.
 
 Phase justifications — the named failure each phase prevents:
-  supervisor (launch/__supervise): queue-wait can die without output (crash,
-    signal, logout) or wedge on a hung GitHub read past its own budget,
-    leaving a watch nothing is running and a consume that could only time
-    out. The detached supervisor publishes an `unknown` artifact when its
-    worker exits unreadably and reaps a worker that outlives the deadline,
-    so every launch attempt ends in a consumable artifact.
+  supervisor (launch/__supervise): queue-wait dying without output or
+    wedging past its budget would leave a watch nothing is running; full
+    rationale in lib/merge-queue-supervisor.sh.
   cleanup: worktree removal after a detached merge acts on state recorded
     before the merge. Unowned removal can run twice (concurrent lanes), act
     on a tree no longer holding the PR branch (KEN-888), or die midway and

--- a/skills/orch/tests/merge_queue_rearm_e2e.sh
+++ b/skills/orch/tests/merge_queue_rearm_e2e.sh
@@ -16,7 +16,6 @@ ok() { PASS=$((PASS+1)); printf '  ok    %s\n' "$1"; }
 bad() { FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$1"; }
 eq() { if [[ "$1" == "$2" ]]; then ok "$3"; else bad "$3 (expected $2, got $1)"; fi; }
 wait_file() { local i; for ((i=0;i<300;i++)); do [[ -s "$1" ]] && return 0; sleep 0.05; done; return 1; }
-wait_line() { local i; for ((i=0;i<300;i++)); do [[ -s "$1" ]] && return 0; sleep 0.05; done; return 1; }
 
 MAIN="$TMP/main" BIN="$TMP/bin" SCRIPTS="$TMP/orch/scripts"
 mkdir -p "$MAIN" "$BIN" "$SCRIPTS/lib"
@@ -85,7 +84,7 @@ set +e
 early_event=$("$SCRIPTS/merge-queue-watch" event --root "$MAIN" --issue KEN-916-e2e); early_rc=$?
 set -e
 if [[ "$early_rc" -ne 0 && -z "$early_event" ]]; then ok "queued watch emits no oversee event"; else bad "queued watch woke oversee early"; fi
-wait_line "$QUEUE_LOG" || bad "queue-wait never polled queue state"
+wait_file "$QUEUE_LOG" || bad "queue-wait never polled queue state"
 printf 'ejected\n' > "$PHASE"
 wait_file "$artifact1" || bad "ejection verdict was not published"
 eq "$(jq -r .verdict "$artifact1")" ejected "queue-wait reports the confirmed ejection"
@@ -117,6 +116,16 @@ eq "$(jq -r .action <<<"$result")" postmerge "re-armed merge consumes as postmer
 "$SCRIPTS/merge-queue-watch" acknowledge --root "$MAIN" --issue KEN-916-e2e --watch-id "$watch2" --result pass >/dev/null
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-916-e2e)
 eq "$(jq -r .action <<<"$result")" complete "acknowledged lifecycle finishes complete"
+
+echo "=== prepare refuses workflow state with no PR branch ==="
+(cd "$MAIN" && "$SCRIPTS/workflow-state" init KEN-916-nobranch --worktree "$MAIN" >/dev/null)
+set +e
+nobranch_err=$("$SCRIPTS/merge-queue-watch" prepare --worktree "$MAIN" --issue KEN-916-nobranch \
+  --repo owner/repo --pr 43 --head "$HEAD" --root "$MAIN" --gate-mode off --recovery-count 0 --cleanup-worktree false 2>&1)
+nobranch_rc=$?
+set -e
+[[ "$nobranch_rc" -ne 0 ]] && ok "prepare refuses a branchless workflow state" || bad "prepare accepted workflow state with no PR branch"
+[[ "$nobranch_err" == *"records no PR branch"* ]] && ok "branchless refusal names the missing PR branch" || bad "branchless refusal message wrong: $nobranch_err"
 
 printf 'merge-queue-rearm-e2e: %d pass, %d fail\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/orch/tests/merge_queue_rearm_e2e.sh
+++ b/skills/orch/tests/merge_queue_rearm_e2e.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# End-to-end merge-queue lifecycle: arm -> eject -> re-arm -> merge, driven
+# through the real merge-queue-watch, supervisor, and queue-wait against a gh
+# stub — one reader of queue state, end to end. At each step it asserts the
+# `event` output oversee-watch reads. The re-arm path under test is prepare's
+# acceptance of a claimed recovery lifecycle: remove it and the second
+# prepare is refused, turning this suite red.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ORCH="$(cd "$TEST_DIR/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+PASS=0 FAIL=0
+ok() { PASS=$((PASS+1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$1"; }
+eq() { if [[ "$1" == "$2" ]]; then ok "$3"; else bad "$3 (expected $2, got $1)"; fi; }
+wait_file() { local i; for ((i=0;i<300;i++)); do [[ -s "$1" ]] && return 0; sleep 0.05; done; return 1; }
+wait_line() { local i; for ((i=0;i<300;i++)); do [[ -s "$1" ]] && return 0; sleep 0.05; done; return 1; }
+
+MAIN="$TMP/main" BIN="$TMP/bin" SCRIPTS="$TMP/orch/scripts"
+mkdir -p "$MAIN" "$BIN" "$SCRIPTS/lib"
+git -C "$MAIN" init -q
+git -C "$MAIN" config user.email test@example.com
+git -C "$MAIN" config user.name Test
+touch "$MAIN/seed"; printf 'tmp/\n' > "$MAIN/.gitignore"
+git -C "$MAIN" add seed .gitignore; git -C "$MAIN" commit -qm seed
+BR=$(git -C "$MAIN" branch --show-current)
+ln -s "$(cd "$ORCH/.." && pwd)/github" "$TMP/github"
+printf 'GH_BOT_TOKEN=ghp_project\n' > "$MAIN/.env.local"
+cp "$ORCH/scripts/merge-queue-watch" "$ORCH/scripts/workflow-state" "$ORCH/scripts/orch-env" "$ORCH/scripts/queue-wait" "$SCRIPTS/"
+cp "$ORCH/scripts/lib/merge-queue-supervisor.sh" "$ORCH/scripts/lib/merge-queue-state.sh" \
+   "$ORCH/scripts/lib/kendex-env.sh" "$ORCH/scripts/lib/gh-auth.sh" "$SCRIPTS/lib/"
+
+PHASE="$TMP/phase" QUEUE_LOG="$TMP/queue.log"
+HEAD=cccccccccccccccccccccccccccccccccccccccc
+touch "$QUEUE_LOG"
+cat > "$BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+phase=$(cat < "$E2E_PHASE")
+case "${1:-} ${2:-}" in
+  'auth status'|'api user')
+    [[ "${GH_TOKEN:-}" == ghp_project ]] || exit 1
+    echo authenticated; exit 0 ;;
+  'repo view')
+    printf 'owner/repo\n'; exit 0 ;;
+  'pr view')
+    case "$phase" in merged) state=MERGED; merged_at='"2026-08-30T00:00:00Z"' ;; *) state=OPEN; merged_at=null ;; esac
+    if [[ "$*" == *headRefOid* ]]; then
+      printf '{"headRefOid":"%s","state":"%s"}\n' "$E2E_HEAD" "$state"
+    else
+      printf '{"state":"%s","mergedAt":%s,"mergeable":"UNKNOWN"}\n' "$state" "$merged_at"
+    fi
+    exit 0 ;;
+  'api graphql')
+    if [[ "$*" == *reviewThreads* ]]; then
+      printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}\n'
+      exit 0
+    fi
+    printf '%s\n' "$phase" >> "$E2E_QUEUE_LOG"
+    if [[ "$phase" == queued ]]; then
+      printf '{"data":{"repository":{"pullRequest":{"id":"PR_node","isInMergeQueue":true,"mergeQueueEntry":{"state":"QUEUED","position":1,"headCommit":null},"autoMergeRequest":{"enabledAt":"now"}}}}}\n'
+    else
+      printf '{"data":{"repository":{"pullRequest":{"id":"PR_node","isInMergeQueue":false,"mergeQueueEntry":null,"autoMergeRequest":null}}}}\n'
+    fi
+    exit 0 ;;
+esac
+echo "unexpected gh: $*" >&2
+exit 1
+EOF
+chmod +x "$BIN/gh" "$SCRIPTS/merge-queue-watch" "$SCRIPTS/workflow-state" "$SCRIPTS/orch-env" "$SCRIPTS/queue-wait"
+export PATH="$BIN:$PATH" E2E_PHASE="$PHASE" E2E_QUEUE_LOG="$QUEUE_LOG" E2E_HEAD="$HEAD"
+export QUEUE_WAIT_CONFIRM_POLLS=2
+unset GH_TOKEN GITHUB_TOKEN GH_BOT_TOKEN GH_REPO GITHUB_REPOSITORY
+
+echo "=== arm, eject, re-arm through the watcher ==="
+"$SCRIPTS/merge-queue-watch" init --worktree "$MAIN" --issue KEN-916-e2e --branch "$BR" >/dev/null
+printf 'queued\n' > "$PHASE"
+prep=$("$SCRIPTS/merge-queue-watch" prepare --worktree "$MAIN" --issue KEN-916-e2e \
+  --repo owner/repo --pr 42 --head "$HEAD" --root "$MAIN" --gate-mode off --recovery-count 0 --cleanup-worktree false)
+watch1=$(jq -r .watch_id <<<"$prep"); artifact1=$(jq -r .artifact_path <<<"$prep")
+"$SCRIPTS/merge-queue-watch" launch --root "$MAIN" --issue KEN-916-e2e --watch-id "$watch1" --poll 1 --max-wait 60 >/dev/null
+set +e
+early_event=$("$SCRIPTS/merge-queue-watch" event --root "$MAIN" --issue KEN-916-e2e); early_rc=$?
+set -e
+if [[ "$early_rc" -ne 0 && -z "$early_event" ]]; then ok "queued watch emits no oversee event"; else bad "queued watch woke oversee early"; fi
+wait_line "$QUEUE_LOG" || bad "queue-wait never polled queue state"
+printf 'ejected\n' > "$PHASE"
+wait_file "$artifact1" || bad "ejection verdict was not published"
+eq "$(jq -r .verdict "$artifact1")" ejected "queue-wait reports the confirmed ejection"
+event_out=$("$SCRIPTS/merge-queue-watch" event --root "$MAIN" --issue KEN-916-e2e)
+eq "$event_out" "ready KEN-916-e2e $watch1" "ejection wakes oversee with the watch identity"
+result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-916-e2e)
+eq "$(jq -r .action <<<"$result")" recovery "ejection consumes as a recovery claim"
+eq "$(jq -r .verdict <<<"$result")" ejected "recovery claim carries the ejected verdict"
+eq "$(jq -r .recovery_count <<<"$result")" 1 "recovery claim increments the durable count"
+set +e
+"$SCRIPTS/merge-queue-watch" event --root "$MAIN" --issue KEN-916-e2e >/dev/null 2>&1; claimed_rc=$?
+set -e
+[[ "$claimed_rc" -ne 0 ]] && ok "a claimed verdict stops waking oversee" || bad "claimed verdict kept waking oversee"
+
+printf 'merged\n' > "$PHASE"
+prep2=$("$SCRIPTS/merge-queue-watch" prepare --worktree "$MAIN" --issue KEN-916-e2e \
+  --repo owner/repo --pr 42 --head "$HEAD" --root "$MAIN" --gate-mode off --recovery-count 1 --cleanup-worktree false)
+watch2=$(jq -r .watch_id <<<"$prep2"); artifact2=$(jq -r .artifact_path <<<"$prep2")
+[[ "$watch2" != "$watch1" ]] && ok "re-arm claims a fresh watch generation" || bad "re-arm reused the consumed watch"
+"$SCRIPTS/merge-queue-watch" launch --root "$MAIN" --issue KEN-916-e2e --watch-id "$watch2" --poll 1 --max-wait 60 >/dev/null
+wait_file "$artifact2" || bad "re-armed merge verdict was not published"
+eq "$(jq -r .verdict "$artifact2")" merged "re-armed watch reports the merge"
+event_out=$("$SCRIPTS/merge-queue-watch" event --root "$MAIN" --issue KEN-916-e2e)
+eq "$event_out" "ready KEN-916-e2e $watch2" "re-armed verdict wakes oversee with the new watch identity"
+result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-916-e2e)
+eq "$(jq -r .action <<<"$result")" postmerge "re-armed merge consumes as postmerge"
+"$SCRIPTS/merge-queue-watch" merge-pr-complete --root "$MAIN" --issue KEN-916-e2e --watch-id "$watch2" >/dev/null
+"$SCRIPTS/merge-queue-watch" cleanup --root "$MAIN" --issue KEN-916-e2e --watch-id "$watch2" >/dev/null
+"$SCRIPTS/merge-queue-watch" acknowledge --root "$MAIN" --issue KEN-916-e2e --watch-id "$watch2" --result pass >/dev/null
+result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-916-e2e)
+eq "$(jq -r .action <<<"$result")" complete "acknowledged lifecycle finishes complete"
+
+printf 'merge-queue-rearm-e2e: %d pass, %d fail\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/orch/tests/merge_queue_watch.sh
+++ b/skills/orch/tests/merge_queue_watch.sh
@@ -330,14 +330,6 @@ if [[ -n "$REAL_SETSID" ]]; then
 else
   ok "launch setup race control skipped without setsid"
 fi
-prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep"); state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path); watch_dir=$(jq -r .watch_dir "$state_path"); legacy_runtime="$watch_dir/legacy-runtime"
-mkdir "$legacy_runtime"; printf '%s\n' "$watch" > "$legacy_runtime/token"
-jq --arg artifact "$watch_dir/verdict.json" --arg runtime "$legacy_runtime" '.artifact_path=$artifact|.runtime_dir=$runtime|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token,.legacy_generation)' "$state_path" > "$TMP/legacy-prepared.json"; chmod 600 "$TMP/legacy-prepared.json"; mv "$TMP/legacy-prepared.json" "$state_path"
-launch_bounded "$watch"
-legacy_state=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829)
-eq "$(jq -r .status <<<"$legacy_state")" watching "legacy prepared lifecycle launches after upgrade"
-[[ "$(jq -r .launch_attempt_id <<<"$legacy_state")" == "$watch-attempt-1" && "$(jq -r .runtime_dir <<<"$legacy_state")" != "$legacy_runtime" && "$(jq -r .watch_dir <<<"$legacy_state")" == "$watch_dir" ]] && ok "legacy prepared migration preserves watch cleanup identity" || bad "legacy prepared migration lost generation or cleanup identity"
-"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
 jq --arg attempt "$watch-attempt-1" --arg token "$watch-attempt-1-test" '.launch_attempt=1|.launch_attempt_id=$attempt|.supervisor_token=$token|.status="launching"|.setup_deadline=0|.deadline=((now|floor)+600)' "$state_path" > "$TMP/orphan.json"
@@ -367,7 +359,7 @@ prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .a
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
 jq --arg attempt "$watch-attempt-1" --arg token "$watch-attempt-1-test" '.launch_attempt=1|.launch_attempt_id=$attempt|.supervisor_token=$token|.status="launching"|.setup_deadline=((now|floor)+10)|.deadline=((now|floor)+600)' "$state_path" > "$TMP/completed-launch.json"
 chmod 600 "$TMP/completed-launch.json"; mv "$TMP/completed-launch.json" "$state_path"
-jq -n --arg watch "$watch" --arg attempt "$watch-attempt-1" --arg head "$HEAD_A" '{schema_version:1,status:"complete",verdict:"merged",repository:"owner/repo",pr_number:42,expected_head:$head,observed_head:"",watch_id:$watch,launch_attempt_id:$attempt}' > "$artifact"
+jq -n --arg watch "$watch" --arg attempt "$watch-attempt-1" --arg head "$HEAD_A" '{schema_version:1,status:"complete",verdict:"merged",repository:"owner/repo",pr_number:42,expected_head:$head,watch_id:$watch,launch_attempt_id:$attempt}' > "$artifact"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .action <<<"$result")" postmerge "completed artifact outranks launching setup state"
 "$SCRIPTS/merge-queue-watch" merge-pr-complete --root "$MAIN" --issue KEN-829 --watch-id "$watch" >/dev/null
@@ -645,63 +637,18 @@ touch "$RELEASE"
 rm -f -- "$WATCH_REGISTRATION_GATE.enabled" "$WATCH_REGISTRATION_GATE.entered" "$WATCH_REGISTRATION_GATE.release"
 
 prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
+launch_bounded "$watch"
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
-bash -c 'while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$state_path" "$watch" "$SCRIPTS/queue-wait" 1 10 & legacy_supervisor=$!
-jq --argjson pid "$legacy_supervisor" '.status="launching"|.supervisor_pid=$pid|.setup_deadline=((now|floor)+10)|.deadline=((now|floor)+600)|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-watching.json"
-chmod 600 "$TMP/legacy-watching.json"; mv "$TMP/legacy-watching.json" "$state_path"
-result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
-eq "$(jq -r .action <<<"$result")" pending "live legacy launching remains pending"
-jq '.setup_deadline=0' "$state_path" > "$TMP/legacy-launch-expired.json"; chmod 600 "$TMP/legacy-launch-expired.json"; mv "$TMP/legacy-launch-expired.json" "$state_path"
-result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
-eq "$(jq -r .action <<<"$result")" pending "expired live legacy launch is adopted"
-eq "$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .status)" watching "legacy launch adoption persists watching"
-running "$legacy_supervisor" && ok "legacy watching supervisor is preserved" || bad "legacy watching supervisor was terminated"
-"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
-if ! running "$legacy_supervisor"; then ok "direct legacy failure terminates tokenless supervisor"; else bad "direct legacy failure left tokenless supervisor running"; fi
-kill "$legacy_supervisor" 2>/dev/null || true
-wait "$legacy_supervisor" 2>/dev/null || true
-
-prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
-state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
-bash -c 'while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$state_path" "$watch" "$SCRIPTS/queue-wait" 1 10 & zombie_pid=$!
+bash -c 'while :; do sleep 1; done' zombie-decoy & zombie_pid=$!
 export WATCH_PS_ZOMBIE_PID="$zombie_pid"
-jq --argjson pid "$zombie_pid" '.status="watching"|.supervisor_pid=$pid|.deadline=((now|floor)+600)|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-zombie.json"
-chmod 600 "$TMP/legacy-zombie.json"; mv "$TMP/legacy-zombie.json" "$state_path"
+jq --argjson pid "$zombie_pid" '.supervisor_pid=$pid' "$state_path" > "$TMP/zombie.json"
+chmod 600 "$TMP/zombie.json"; mv "$TMP/zombie.json" "$state_path"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
 eq "$(jq -r .status <<<"$result")" failed "production liveness treats zombie state as exited"
 if ! running "$zombie_pid"; then ok "test liveness helper treats zombie state as exited"; else bad "test liveness helper accepted zombie state"; fi
 unset WATCH_PS_ZOMBIE_PID
 kill "$zombie_pid" 2>/dev/null || true; wait "$zombie_pid" 2>/dev/null || true
-
-prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
-state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
-jq '.status="launching"|.setup_deadline=0|.deadline=((now|floor)+600)|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-launching.json"
-chmod 600 "$TMP/legacy-launching.json"; mv "$TMP/legacy-launching.json" "$state_path"
-result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
-eq "$(jq -r .action <<<"$result")" resume_launch "orphaned legacy launch enters recovery"
-"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
-
-prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep")
-state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
-legacy_runtime=$(jq -r .runtime_dir "$state_path")
-printf '%s\n' "$watch" > "$legacy_runtime/token"
-bash -c 'while :; do sleep 1; done' "$SCRIPTS/merge-queue-watch" __supervise "$state_path" "$watch" "$SCRIPTS/queue-wait" 1 10 & legacy_retry_supervisor=$!
-jq --argjson pid "$legacy_retry_supervisor" '.status="launch_failed"|.action="launch"|.supervisor_pid=$pid|del(.watch_dir,.runtime_root,.launch_attempt,.launch_attempt_id,.supervisor_token)' "$state_path" > "$TMP/legacy-launch-failed.json"
-chmod 600 "$TMP/legacy-launch-failed.json"; mv "$TMP/legacy-launch-failed.json" "$state_path"
-launch_bounded "$watch"
-legacy_retry_state=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829)
-eq "$(jq -r .status <<<"$legacy_retry_state")" watching "legacy launch failure retries on a migrated generation"
-[[ "$(jq -r .runtime_dir <<<"$legacy_retry_state")" != "$legacy_runtime" ]] && ok "legacy retry receives an isolated runtime" || bad "legacy retry reused legacy runtime"
-if ! running "$legacy_retry_supervisor"; then ok "legacy retry terminates old supervisor before replacement"; else bad "legacy retry left old supervisor running"; fi
-kill "$legacy_retry_supervisor" 2>/dev/null || true
-wait "$legacy_retry_supervisor" 2>/dev/null || true
-if [[ "$(jq -r .status <<<"$legacy_retry_state")" == watching ]]; then
-  legacy_retry_artifact=$(jq -r .artifact_path <<<"$legacy_retry_state")
-  touch "$RELEASE"; wait_file "$legacy_retry_artifact" || bad "legacy retry verdict missing"
-  result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)
-  eq "$(jq -r .action <<<"$result")" recovery "legacy retry verdict is consumable"
-fi
-"$SCRIPTS/merge-queue-watch" fail --root "$MAIN" --issue KEN-829 --watch-id "$watch" --cause operator_abandoned >/dev/null
+touch "$RELEASE"
 
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
 "$SCRIPTS/merge-queue-watch" direct-merged --root "$MAIN" --issue KEN-829 --watch-id "$watch" >/dev/null
@@ -744,6 +691,19 @@ eq "$(jq -r .cleanup.disposition <<<"$state")" kept "cleanup keeps a worktree wh
 "$SCRIPTS/merge-queue-watch" acknowledge --root "$MAIN" --issue KEN-829 --watch-id "$watch" --result pass >/dev/null
 git -C "$WT" switch -q watch-test
 git -C "$MAIN" branch -D foreign-cleanup >/dev/null
+
+git -C "$WT" switch -qc prepare-time-branch
+prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
+eq "$(jq -r .pr_branch <<<"$prep")" watch-test "prepare binds cleanup to the recorded PR branch, not the prepare-time checkout"
+"$SCRIPTS/merge-queue-watch" direct-merged --root "$MAIN" --issue KEN-829 --watch-id "$watch" >/dev/null
+"$SCRIPTS/merge-queue-watch" merge-pr-complete --root "$MAIN" --issue KEN-829 --watch-id "$watch" >/dev/null
+"$SCRIPTS/merge-queue-watch" cleanup --root "$MAIN" --issue KEN-829 --watch-id "$watch" >/dev/null
+state=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829)
+eq "$(jq -r .cleanup.disposition <<<"$state")" kept "cleanup keeps a worktree prepared on a non-PR branch"
+[[ -d "$WT" ]] && ok "non-PR-branch worktree survives cleanup" || bad "cleanup removed a worktree the workflow says to keep"
+"$SCRIPTS/merge-queue-watch" acknowledge --root "$MAIN" --issue KEN-829 --watch-id "$watch" --result pass >/dev/null
+git -C "$WT" switch -q watch-test
+git -C "$MAIN" branch -D prepare-time-branch >/dev/null
 
 prep=$(prepare merged); watch=$(jq -r .watch_id <<<"$prep")
 "$SCRIPTS/merge-queue-watch" direct-merged --root "$MAIN" --issue KEN-829 --watch-id "$watch" >/dev/null

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -101,7 +101,7 @@ skills/orch/scripts/ci-wait	669
 skills/orch/scripts/dev-artifact-check	709
 skills/orch/scripts/dev-return-write	430
 skills/orch/scripts/lanes	575
-skills/orch/scripts/merge-queue-watch	546
+skills/orch/scripts/merge-queue-watch	543
 skills/orch/scripts/open-terminal	639
 skills/orch/scripts/oversee-watch	654
 skills/orch/scripts/queue-wait	1127

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -101,7 +101,7 @@ skills/orch/scripts/ci-wait	669
 skills/orch/scripts/dev-artifact-check	709
 skills/orch/scripts/dev-return-write	430
 skills/orch/scripts/lanes	575
-skills/orch/scripts/merge-queue-watch	609
+skills/orch/scripts/merge-queue-watch	546
 skills/orch/scripts/open-terminal	639
 skills/orch/scripts/oversee-watch	654
 skills/orch/scripts/queue-wait	1127


### PR DESCRIPTION
## Summary
- One reader of queue state: the watcher's `observed_head` cross-check (a field the supervisor only ever wrote empty) is gone; queue-wait is the only script reading merge-queue state, and consume verifies the live PR head directly.
- Legacy-migration machinery (`migrate_legacy_state`, legacy supervisor liveness/termination, `legacy_generation` branches) deleted per the no-migration rule; supervisor, cleanup, and acknowledge phases each name the failure they prevent in the script header.
- KEN-888 fixed: cleanup binds worktree removal to the PR branch recorded at init (`pr_branch` in workflow state), failing closed to keeping the worktree on any mismatch. KEN-887's generation-safe retry (#1879) is kept and subsumed, not duplicated.
- New `merge_queue_rearm_e2e.sh` arms, ejects, and re-arms a PR through real prepare/launch/supervisor/queue-wait against a `gh` stub, asserting the events oversee-watch reads at each step; removing the re-arm path reds it. 14 cases; mutation check killed 1/1.

## Completed Issues
- Closes KEN-916 - The merge-queue watcher is right end to end, elegant, and duplicated nowhere
- Closes KEN-888 - Merge-queue cleanup can remove a worktree the workflow says to keep

## Test Plan
- `bash skills/orch/tests/run-all.sh` — 62/62 files green (includes the new e2e suite)
- `tools/guard` green at commit (cargo suites + 1073 vitest)
- Mutation check: reverting prepare's `pr_branch` read to the prepare-time checkout is killed by the suite; stability 2/2 at 64 threads
