### PR TITLE
refactor(KEN-953): the atomic file write gets its own lib

### DIFF
--- a/.agents/skills/growth-guards/DEVELOPMENT.md
+++ b/.agents/skills/growth-guards/DEVELOPMENT.md
@@ -28,6 +28,11 @@ docs live in README.md.
   `changelog-entries --collate` on the verdict those two just reached: it
   folds the accepted fragments into the record and deletes them, and decides
   nothing about either
+- `scripts/lib/atomic-install.sh` — how the two writing lanes replace a file
+  they own: a rename inside the destination's own directory, so a policy file
+  is never left truncated. Sourced by `suppression-ban` and
+  `changelog-entries` alone; its staging file is declared and removed in
+  `common.sh`, where the reset reaches every guard and the one exit trap lives
 - `scripts/lib/hook-check.sh` — the read-only verdict `install-git-hooks
   --check` returns over the shims this installer writes
 - `scripts/lib/hooks-path.sh` — where git reads hooks from, and whether

--- a/.agents/skills/growth-guards/DEVELOPMENT.md
+++ b/.agents/skills/growth-guards/DEVELOPMENT.md
@@ -32,7 +32,8 @@ docs live in README.md.
   they own: a rename inside the destination's own directory, so a policy file
   is never left truncated. Sourced by `suppression-ban` and
   `changelog-entries` alone; its staging file is declared and removed in
-  `common.sh`, where the reset reaches every guard and the one exit trap lives
+  `common.sh`, where the reset reaches every guard and the one exit handler
+  lives
 - `scripts/lib/hook-check.sh` — the read-only verdict `install-git-hooks
   --check` returns over the shims this installer writes
 - `scripts/lib/hooks-path.sh` — where git reads hooks from, and whether

--- a/.agents/skills/growth-guards/scripts/changelog-entries
+++ b/.agents/skills/growth-guards/scripts/changelog-entries
@@ -64,6 +64,9 @@ source "$SCRIPT_DIR/lib/changelog-grammar.sh"
 source "$SCRIPT_DIR/lib/changelog-record-scope.sh"
 # shellcheck source=lib/changelog-collate.sh
 source "$SCRIPT_DIR/lib/changelog-collate.sh"
+# The --collate lane rewrites the record in place.
+# shellcheck source=lib/atomic-install.sh
+source "$SCRIPT_DIR/lib/atomic-install.sh"
 
 # The sections a fragment's directory may name, and the test for membership
 # in them, are lib/changelog-grammar.sh's GG_SECTIONS and gg_is_section: the

--- a/.agents/skills/growth-guards/scripts/lib/atomic-install.sh
+++ b/.agents/skills/growth-guards/scripts/lib/atomic-install.sh
@@ -1,8 +1,8 @@
 # shellcheck shell=bash
 # atomic-install.sh — how this family REPLACES a file it owns: a policy
 # baseline, a collated changelog record. One helper does the write, and the
-# two beneath it are what it needs to do it safely — the destination's mode,
-# and what a failing step said.
+# two it leans on are what it needs to do that safely — the destination's
+# mode, and what a failing step said.
 #
 # The rule the whole file exists for: a destination is replaced whole or not
 # at all. A truncated policy file reads as a complete one, and for a ratchet
@@ -24,11 +24,13 @@
 
 set -euo pipefail
 
-# The staging file lands beside the DESTINATION, not inside GG_TMP, so
-# gg_tmpdir's trap covers it only by happening to be the same handler.
-# Arming on source says it directly: from the moment this writer exists, the
-# family's one exit handler removes what it stages. gg_cleanup is idempotent
-# and gg_tmpdir arms the same trap, so the two never disagree.
+# The staging file lands beside the DESTINATION, not inside GG_TMP, so it is
+# the one piece of scratch here that gg_tmpdir does not create. Arming on
+# source is what keeps preflight's mktemp-trap lane green over this file, and
+# it is safe for the two callers this family has: both source common.sh, then
+# this file, then arm gg_tmpdir, so nothing of theirs is replaced and the
+# handler is the one gg_tmpdir would set anyway. A caller that arms its OWN
+# EXIT trap before sourcing would lose it, which is why nothing does.
 trap gg_cleanup EXIT
 
 # -L on both spellings: stat lstats by default, so a symlink destination would

--- a/.agents/skills/growth-guards/scripts/lib/atomic-install.sh
+++ b/.agents/skills/growth-guards/scripts/lib/atomic-install.sh
@@ -1,0 +1,108 @@
+# shellcheck shell=bash
+# atomic-install.sh — how this family REPLACES a file it owns: a policy
+# baseline, a collated changelog record. One helper does the write, and the
+# two beneath it are what it needs to do it safely — the destination's mode,
+# and what a failing step said.
+#
+# The rule the whole file exists for: a destination is replaced whole or not
+# at all. A truncated policy file reads as a complete one, and for a ratchet
+# baseline that LOOSENS the gate instead of failing it, so every write goes
+# through a staging file in the destination's own directory and a rename.
+#
+# GG_INSTALL_TMP — the in-flight staging file — is declared and removed in
+# lib/common.sh, not here, and that is deliberate rather than inherited. The
+# declaration resets any value the environment handed this process, and it
+# has to run in EVERY guard, including the ones that never source this file;
+# the removal has to be gg_cleanup, because a process arms one EXIT trap and
+# that is it. So this file's half of the contract is narrow: gg_install_file
+# sets the variable when it stages and clears it when the rename consumes the
+# file, and nothing here ever deletes it.
+#
+# Needs lib/common.sh sourced first — for gg_cleanup, gg_shown, gg_scrubbed
+# and gg_collection_error — and a caller that has armed gg_tmpdir for the
+# scratch the diagnostics are captured into. Sourced, never executed.
+
+set -euo pipefail
+
+# The staging file lands beside the DESTINATION, not inside GG_TMP, so
+# gg_tmpdir's trap covers it only by happening to be the same handler.
+# Arming on source says it directly: from the moment this writer exists, the
+# family's one exit handler removes what it stages. gg_cleanup is idempotent
+# and gg_tmpdir arms the same trap, so the two never disagree.
+trap gg_cleanup EXIT
+
+# -L on both spellings: stat lstats by default, so a symlink destination would
+# answer with the LINK's own 0777 rather than the file behind it, and the chmod
+# below would publish a world-writable ratchet input any local account could
+# lower. The caller tests with `[ -f ]`, which follows; both must mean one file.
+gg_file_mode() { # FILE — its permission bits as octal digits; GNU stat, then BSD
+  stat -L -c '%a' -- "$1" 2>/dev/null || stat -L -f '%Lp' -- "$1" 2>/dev/null
+}
+
+# What a failing install step printed, folded into the guard's own diagnostic
+# rather than left to reach the terminal as a bare `mv:` line ahead of it.
+# gg_scrubbed: another program's bytes on their way to a terminal.
+gg_install_why() { # ERRFILE — " (TEXT)" or nothing
+  local said
+  said="$(head -n 1 -- "$1" 2>/dev/null || true)"
+  [ -n "$said" ] || return 0
+  printf ' (%s)' "$(gg_scrubbed "$said")"
+}
+
+# Replace DEST with SRC's bytes through a rename inside DEST's own directory.
+# A direct redirect onto DEST, or a rename that crosses a filesystem (where mv
+# degrades to copy-then-unlink), leaves DEST TRUNCATED behind an interrupt.
+gg_install_file() { # SRC DEST LABEL
+  local src="$1" dest="$2" label="$3" mode="" err=""
+  # Every caller in this family arms gg_tmpdir; one that has not is a
+  # programming error, and says so rather than capturing each step's stderr to
+  # whatever `$GG_TMP/install.err` means with GG_TMP empty.
+  [ -n "${GG_TMP:-}" ] && [ -d "$GG_TMP" ] \
+    || gg_collection_error "gg_install_file needs gg_tmpdir called first — $label was not replaced"
+  err="$GG_TMP/install.err"
+  # The destination's mode is READ here and applied after the write, never
+  # carried onto the staging file in between: one without owner-write would
+  # otherwise fail the write on a file this process just created.
+  if [ -f "$dest" ]; then
+    # `|| mode=""`, never a bare assignment: errexit exits the whole run on a
+    # failing command substitution in one, with stat's status and no diagnostic
+    # — the fail-silent the case below replaces. Nothing to relay there:
+    # gg_file_mode silences both probes, the first being the one EXPECTED to
+    # fail wherever the second answers. An unreadable mode is not one to guess.
+    mode="$(gg_file_mode "$dest")" || mode=""
+    case "$mode" in
+      "" | *[!0-7]*) gg_collection_error "could not read the mode of $(gg_shown "$dest") — $label was not replaced" ;;
+    esac
+  fi
+  # mktemp, never a name derived from the pid: the staging file lands in a
+  # directory the repository controls, a predictable name can already be
+  # sitting there, and `cp` writes THROUGH a symlink — so a planted
+  # `.gg-install.<pid>.<name>` link would redirect the write anywhere the
+  # user can reach. mktemp creates the file itself, exclusively.
+  GG_INSTALL_TMP="$(mktemp "$dest.gg-install.XXXXXX" 2>"$err")" \
+    || gg_collection_error "could not stage the replacement for $label beside $(gg_shown "$dest")$(gg_install_why "$err")"
+  # Past mktemp the staging file has ONE owner: gg_cleanup, which the EXIT trap
+  # runs and which removes GG_INSTALL_TMP first. gg_collection_error exits, so
+  # every branch below reaches it and none removes the file itself. `2>` goes
+  # BEFORE the output redirect in each: redirections apply left to right, so a
+  # failure of the one onto the staging file would otherwise be reported on the
+  # terminal rather than captured.
+  if ! cat -- "$src" 2>"$err" >"$GG_INSTALL_TMP"; then
+    gg_collection_error "could not stage the replacement for $label beside $(gg_shown "$dest")$(gg_install_why "$err")"
+  fi
+  # No `--` after the mode: chmod's mode is a non-option argument, so a BSD
+  # chmod stops option parsing there and reads the `--` as a file name.
+  if [ -n "$mode" ] && ! chmod "$mode" "$GG_INSTALL_TMP" 2>"$err"; then
+    gg_collection_error "could not give the replacement for $label $(gg_shown "$dest")'s mode ($mode)$(gg_install_why "$err")"
+  fi
+  # -f, so the rename is non-interactive whatever the destination's mode: mv
+  # PROMPTS before replacing one that denies write when stdin is a terminal —
+  # exactly the destination this helper sets out to support, and a gate that
+  # stops for an answer nobody is there to give is a gate that hangs.
+  if ! mv -f -- "$GG_INSTALL_TMP" "$dest" 2>"$err"; then
+    gg_collection_error "could not replace $label at $(gg_shown "$dest")$(gg_install_why "$err") — inspect the file before trusting it"
+  fi
+  # The one assignment that IS load-bearing: the rename consumed the staging
+  # file, so the trap must not go looking for it.
+  GG_INSTALL_TMP=""
+}

--- a/.agents/skills/growth-guards/scripts/lib/atomic-install.sh
+++ b/.agents/skills/growth-guards/scripts/lib/atomic-install.sh
@@ -24,15 +24,6 @@
 
 set -euo pipefail
 
-# The staging file lands beside the DESTINATION, not inside GG_TMP, so it is
-# the one piece of scratch here that gg_tmpdir does not create. Arming on
-# source is what keeps preflight's mktemp-trap lane green over this file, and
-# it is safe for the two callers this family has: both source common.sh, then
-# this file, then arm gg_tmpdir, so nothing of theirs is replaced and the
-# handler is the one gg_tmpdir would set anyway. A caller that arms its OWN
-# EXIT trap before sourcing would lose it, which is why nothing does.
-trap gg_cleanup EXIT
-
 # -L on both spellings: stat lstats by default, so a symlink destination would
 # answer with the LINK's own 0777 rather than the file behind it, and the chmod
 # below would publish a world-writable ratchet input any local account could
@@ -81,6 +72,15 @@ gg_install_file() { # SRC DEST LABEL
   # sitting there, and `cp` writes THROUGH a symlink — so a planted
   # `.gg-install.<pid>.<name>` link would redirect the write anywhere the
   # user can reach. mktemp creates the file itself, exclusively.
+  #
+  # A bash trap is process-wide wherever it is armed, so the arming belongs
+  # here rather than at file scope: the handler exists exactly when there is
+  # something for it to remove, and merely SOURCING this file leaves a
+  # caller's own EXIT trap alone. gg_tmpdir armed the same handler already,
+  # which the precondition above proves it ran, so the two never disagree.
+  # The staging file is the one piece of scratch here that gg_tmpdir did not
+  # create: it lands beside the DESTINATION, not inside GG_TMP.
+  trap gg_cleanup EXIT
   GG_INSTALL_TMP="$(mktemp "$dest.gg-install.XXXXXX" 2>"$err")" \
     || gg_collection_error "could not stage the replacement for $label beside $(gg_shown "$dest")$(gg_install_why "$err")"
   # Past mktemp the staging file has ONE owner: gg_cleanup, which the EXIT trap

--- a/.agents/skills/growth-guards/scripts/lib/changelog-collate.sh
+++ b/.agents/skills/growth-guards/scripts/lib/changelog-collate.sh
@@ -30,7 +30,8 @@
 # carrying the staging file to the exit trap so an interrupt leaves nothing
 # behind.
 #
-# Needs lib/common.sh and lib/changelog-grammar.sh sourced first, and runs on
+# Needs lib/common.sh, lib/changelog-grammar.sh and lib/atomic-install.sh
+# sourced first, and runs on
 # the state the walk and the record scope filled in: GG_TMP/frags.z, RECORD,
 # RECORD_SHA, RECORD_NOTE and the GG_RECORD_* bounds.
 #

--- a/.agents/skills/growth-guards/scripts/lib/changelog-collate.sh
+++ b/.agents/skills/growth-guards/scripts/lib/changelog-collate.sh
@@ -30,10 +30,11 @@
 # carrying the staging file to the exit trap so an interrupt leaves nothing
 # behind.
 #
-# Needs lib/common.sh, lib/changelog-grammar.sh and lib/atomic-install.sh
-# sourced first, and runs on
+# Needs lib/common.sh and lib/changelog-grammar.sh sourced first, and runs on
 # the state the walk and the record scope filled in: GG_TMP/frags.z, RECORD,
-# RECORD_SHA, RECORD_NOTE and the GG_RECORD_* bounds.
+# RECORD_SHA, RECORD_NOTE and the GG_RECORD_* bounds. gg_install_file comes
+# from lib/atomic-install.sh, and resolution is at call time, so that one has
+# only to be sourced before gg_changelog_collate runs.
 #
 # Sourced, never executed.
 

--- a/.agents/skills/growth-guards/scripts/lib/common.sh
+++ b/.agents/skills/growth-guards/scripts/lib/common.sh
@@ -37,7 +37,10 @@ GG_VIOLATIONS=0
 GG_TMP=""
 GG_SETTINGS_INDEX_OWNED=0
 # In-flight staging file for gg_install_file, so an interrupt between its
-# creation and its rename leaves nothing beside the destination.
+# creation and its rename leaves nothing beside the destination. The helper
+# that sets it lives in lib/atomic-install.sh, which only the two writing
+# lanes source; the declaration and the removal below stay here on purpose,
+# because the reset has to reach every guard and one process arms one trap.
 GG_INSTALL_TMP=""
 # Extra `git grep` flags for the index lanes below, set by a check before it
 # calls one and empty for every check that does not. Case sensitivity is the one
@@ -208,84 +211,6 @@ gg_resolve_path() { # FLAG-VALUE KEY DEFAULT LABEL — normalized path on stdout
   local raw="$1"
   [ -n "$raw" ] || raw="$(gg_setting "$2" "$3")" || return 1
   gg_config_path "$raw" "$4"
-}
-
-# -L on both spellings: stat lstats by default, so a symlink destination would
-# answer with the LINK's own 0777 rather than the file behind it, and the chmod
-# below would publish a world-writable ratchet input any local account could
-# lower. The caller tests with `[ -f ]`, which follows; both must mean one file.
-gg_file_mode() { # FILE — its permission bits as octal digits; GNU stat, then BSD
-  stat -L -c '%a' -- "$1" 2>/dev/null || stat -L -f '%Lp' -- "$1" 2>/dev/null
-}
-
-# What a failing install step printed, folded into the guard's own diagnostic
-# rather than left to reach the terminal as a bare `mv:` line ahead of it.
-# gg_scrubbed: another program's bytes on their way to a terminal.
-gg_install_why() { # ERRFILE — " (TEXT)" or nothing
-  local said
-  said="$(head -n 1 -- "$1" 2>/dev/null || true)"
-  [ -n "$said" ] || return 0
-  printf ' (%s)' "$(gg_scrubbed "$said")"
-}
-
-# Replace DEST with SRC's bytes through a rename inside DEST's own directory.
-# A direct redirect onto DEST, or a rename that crosses a filesystem (where mv
-# degrades to copy-then-unlink), leaves DEST TRUNCATED behind an interrupt —
-# and a truncated policy file is read as a complete one, which for a ratchet
-# baseline loosens the gate instead of failing it.
-gg_install_file() { # SRC DEST LABEL
-  local src="$1" dest="$2" label="$3" mode="" err=""
-  # Every caller in this family arms gg_tmpdir; one that has not is a
-  # programming error, and says so rather than capturing each step's stderr to
-  # whatever `$GG_TMP/install.err` means with GG_TMP empty.
-  [ -n "${GG_TMP:-}" ] && [ -d "$GG_TMP" ] \
-    || gg_collection_error "gg_install_file needs gg_tmpdir called first — $label was not replaced"
-  err="$GG_TMP/install.err"
-  # The destination's mode is READ here and applied after the write, never
-  # carried onto the staging file in between: one without owner-write would
-  # otherwise fail the write on a file this process just created.
-  if [ -f "$dest" ]; then
-    # `|| mode=""`, never a bare assignment: errexit exits the whole run on a
-    # failing command substitution in one, with stat's status and no diagnostic
-    # — the fail-silent the case below replaces. Nothing to relay there:
-    # gg_file_mode silences both probes, the first being the one EXPECTED to
-    # fail wherever the second answers. An unreadable mode is not one to guess.
-    mode="$(gg_file_mode "$dest")" || mode=""
-    case "$mode" in
-      "" | *[!0-7]*) gg_collection_error "could not read the mode of $(gg_shown "$dest") — $label was not replaced" ;;
-    esac
-  fi
-  # mktemp, never a name derived from the pid: the staging file lands in a
-  # directory the repository controls, a predictable name can already be
-  # sitting there, and `cp` writes THROUGH a symlink — so a planted
-  # `.gg-install.<pid>.<name>` link would redirect the write anywhere the
-  # user can reach. mktemp creates the file itself, exclusively.
-  GG_INSTALL_TMP="$(mktemp "$dest.gg-install.XXXXXX" 2>"$err")" \
-    || gg_collection_error "could not stage the replacement for $label beside $(gg_shown "$dest")$(gg_install_why "$err")"
-  # Past mktemp the staging file has ONE owner: gg_cleanup, which the EXIT trap
-  # runs and which removes GG_INSTALL_TMP first. gg_collection_error exits, so
-  # every branch below reaches it and none removes the file itself. `2>` goes
-  # BEFORE the output redirect in each: redirections apply left to right, so a
-  # failure of the one onto the staging file would otherwise be reported on the
-  # terminal rather than captured.
-  if ! cat -- "$src" 2>"$err" >"$GG_INSTALL_TMP"; then
-    gg_collection_error "could not stage the replacement for $label beside $(gg_shown "$dest")$(gg_install_why "$err")"
-  fi
-  # No `--` after the mode: chmod's mode is a non-option argument, so a BSD
-  # chmod stops option parsing there and reads the `--` as a file name.
-  if [ -n "$mode" ] && ! chmod "$mode" "$GG_INSTALL_TMP" 2>"$err"; then
-    gg_collection_error "could not give the replacement for $label $(gg_shown "$dest")'s mode ($mode)$(gg_install_why "$err")"
-  fi
-  # -f, so the rename is non-interactive whatever the destination's mode: mv
-  # PROMPTS before replacing one that denies write when stdin is a terminal —
-  # exactly the destination this helper sets out to support, and a gate that
-  # stops for an answer nobody is there to give is a gate that hangs.
-  if ! mv -f -- "$GG_INSTALL_TMP" "$dest" 2>"$err"; then
-    gg_collection_error "could not replace $label at $(gg_shown "$dest")$(gg_install_why "$err") — inspect the file before trusting it"
-  fi
-  # The one assignment that IS load-bearing: the rename consumed the staging
-  # file, so the trap must not go looking for it.
-  GG_INSTALL_TMP=""
 }
 
 # `git grep --cached` SKIPS an unmerged index entry entirely: it spends no

--- a/.agents/skills/growth-guards/scripts/suppression-ban
+++ b/.agents/skills/growth-guards/scripts/suppression-ban
@@ -23,6 +23,9 @@ GG_CHECK="suppression-ban"
 source "$SCRIPT_DIR/lib/common.sh"
 # shellcheck source=lib/settings.sh
 source "$SCRIPT_DIR/lib/settings.sh"
+# The --update lane rewrites the baseline in place.
+# shellcheck source=lib/atomic-install.sh
+source "$SCRIPT_DIR/lib/atomic-install.sh"
 
 usage() {
   cat <<'EOF'

--- a/.agents/skills/growth-guards/tests/index-reads.test.sh
+++ b/.agents/skills/growth-guards/tests/index-reads.test.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
-# Pins for lib/common.sh's index reads and lib/atomic-install.sh's policy
-# writes: a probe git could not answer never becomes an answer, a configured
-# path is matched literally, a --cached scan refuses an unmerged index, and a
-# policy file is replaced by a same-directory rename or not at all. Every clean assertion is paired with
-# a control that proves it can fail.
+# Pins for three libs the checks share: lib/common.sh's index reads,
+# lib/atomic-install.sh's policy writes, and the settings cache
+# lib/settings.sh materializes. A probe git could not answer never becomes an
+# answer, a configured path is matched literally, a --cached scan refuses an
+# unmerged index, a policy file is replaced by a same-directory rename or not
+# at all, and no partial cache file survives a resolve. Every clean assertion
+# is paired with a control that proves it can fail.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -18,7 +20,8 @@ SCRIPTS="$SKILL_DIR/scripts"
 COMMON="$SCRIPTS/lib/common.sh"
 # The writer lives beside common.sh rather than inside it, and reaches back
 # across that boundary for the staging file common.sh declares and its exit
-# trap removes. So every probe below sources the pair, in that order.
+# trap removes. So every probe below sources the pair, in that order, except
+# the settings-cache probes at the end, which pair common.sh with SETTINGS.
 INSTALL="$SCRIPTS/lib/atomic-install.sh"
 SETTINGS="$SCRIPTS/lib/settings.sh"
 ROOT="$TMP"

--- a/.agents/skills/growth-guards/tests/index-reads.test.sh
+++ b/.agents/skills/growth-guards/tests/index-reads.test.sh
@@ -18,10 +18,10 @@ TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 SCRIPTS="$SKILL_DIR/scripts"
 COMMON="$SCRIPTS/lib/common.sh"
-# The writer lives beside common.sh rather than inside it, and reaches back
-# across that boundary for the staging file common.sh declares and its exit
-# trap removes. So every probe below sources the pair, in that order, except
-# the settings-cache probes at the end, which pair common.sh with SETTINGS.
+# The lib holding the install helpers, which a probe exercising them sources
+# alongside COMMON: the writer lives beside common.sh rather than inside it,
+# and reaches back across that boundary for the staging file common.sh
+# declares and its exit trap removes.
 INSTALL="$SCRIPTS/lib/atomic-install.sh"
 SETTINGS="$SCRIPTS/lib/settings.sh"
 ROOT="$TMP"

--- a/.agents/skills/growth-guards/tests/index-reads.test.sh
+++ b/.agents/skills/growth-guards/tests/index-reads.test.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# Pins for lib/common.sh's index reads and policy writes: a probe git could
-# not answer never becomes an answer, a configured path is matched literally,
-# a --cached scan refuses an unmerged index, and a policy file is replaced by
-# a same-directory rename or not at all. Every clean assertion is paired with
+# Pins for lib/common.sh's index reads and lib/atomic-install.sh's policy
+# writes: a probe git could not answer never becomes an answer, a configured
+# path is matched literally, a --cached scan refuses an unmerged index, and a
+# policy file is replaced by a same-directory rename or not at all. Every clean assertion is paired with
 # a control that proves it can fail.
 set -euo pipefail
 
@@ -16,6 +16,10 @@ TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 SCRIPTS="$SKILL_DIR/scripts"
 COMMON="$SCRIPTS/lib/common.sh"
+# The writer lives beside common.sh rather than inside it, and reaches back
+# across that boundary for the staging file common.sh declares and its exit
+# trap removes. So every probe below sources the pair, in that order.
+INSTALL="$SCRIPTS/lib/atomic-install.sh"
 SETTINGS="$SCRIPTS/lib/settings.sh"
 ROOT="$TMP"
 
@@ -35,7 +39,7 @@ new_repo() { # NAME — fresh fixture repo in $R, cwd unchanged
   git -C "$R" config user.name test
 }
 
-# Run a snippet with common.sh sourced, inside $R. OUT captures stdout+stderr,
+# Run a snippet with the libs sourced, inside $R. OUT captures stdout+stderr,
 # RC the exit status — a collection error is exit 2 and must be observable.
 call() { # SNIPPET
   OUT=""
@@ -43,9 +47,10 @@ call() { # SNIPPET
   OUT="$(cd "$R" && GG_CHECK=probe bash -c '
     set -euo pipefail
     . "$1"
-    shift
+    . "$2"
+    shift 2
     eval "$1"
-  ' _ "$COMMON" "$1" 2>&1)" || RC=$?
+  ' _ "$COMMON" "$INSTALL" "$1" 2>&1)" || RC=$?
 }
 
 echo "=== gg_policy_content: the index governs, and a probe that failed is not an answer ==="
@@ -421,9 +426,10 @@ RC=0
 OUT="$(cd "$R" && PATH="$ROOT/nostat:$PATH" GG_CHECK=probe bash -c '
   set -euo pipefail
   . "$1"
+  . "$2"
   gg_tmpdir
-  gg_install_file "$2" tools/dest.tsv "the fixture"
-' _ "$COMMON" "$ROOT/src.tsv" 2>&1)" || RC=$?
+  gg_install_file "$3" tools/dest.tsv "the fixture"
+' _ "$COMMON" "$INSTALL" "$ROOT/src.tsv" 2>&1)" || RC=$?
 [ "$RC" -eq 2 ] && case "$OUT" in *"could not read the mode of tools/dest.tsv"*) true ;; *) false ;; esac \
   && ok "an unreadable mode is a loud refusal, not a narrowing rename" \
   || bad "an unreadable mode is a loud refusal, not a narrowing rename" "rc=$RC out=$OUT"
@@ -440,8 +446,9 @@ RC=0
 OUT="$(cd "$R" && GG_CHECK=probe bash -c '
   set -euo pipefail
   . "$1"
-  gg_install_file "$2" tools/dest.tsv "the fixture"
-' _ "$COMMON" "$ROOT/src.tsv" 2>&1)" || RC=$?
+  . "$2"
+  gg_install_file "$3" tools/dest.tsv "the fixture"
+' _ "$COMMON" "$INSTALL" "$ROOT/src.tsv" 2>&1)" || RC=$?
 [ "$RC" -eq 2 ] && case "$OUT" in *"needs gg_tmpdir called first"*) true ;; *) false ;; esac \
   && ok "an install with no scratch directory refuses rather than writing beside the root" \
   || bad "an install with no scratch directory refuses rather than writing beside the root" "rc=$RC out=$OUT"
@@ -464,9 +471,10 @@ RC=0
 OUT="$(cd "$R" && PATH="$ROOT/nochmod:$PATH" GG_CHECK=probe bash -c '
   set -euo pipefail
   . "$1"
+  . "$2"
   gg_tmpdir
-  gg_install_file "$2" tools/dest.tsv "the fixture"
-' _ "$COMMON" "$ROOT/src.tsv" 2>&1)" || RC=$?
+  gg_install_file "$3" tools/dest.tsv "the fixture"
+' _ "$COMMON" "$INSTALL" "$ROOT/src.tsv" 2>&1)" || RC=$?
 [ "$RC" -eq 2 ] && case "$OUT" in *"could not give the replacement for the fixture tools/dest.tsv's mode (644)"*) true ;; *) false ;; esac \
   && ok "a failed chmod names the mode it could not give" \
   || bad "a failed chmod names the mode it could not give" "rc=$RC out=$OUT"
@@ -494,13 +502,14 @@ rm -f "$pidfile" "$gofile"
 (
   cd "$R" && GG_CHECK=probe bash -c '
     set -euo pipefail
-    echo "$$" >"$2"
+    echo "$$" >"$3"
     i=0
-    while [ ! -e "$3" ] && [ "$i" -lt 200 ]; do i=$((i + 1)); sleep 0.05; done
+    while [ ! -e "$4" ] && [ "$i" -lt 200 ]; do i=$((i + 1)); sleep 0.05; done
     . "$1"
+    . "$2"
     gg_tmpdir
-    gg_install_file "$4" tools/dest.tsv "the fixture"
-  ' _ "$COMMON" "$pidfile" "$gofile" "$ROOT/src.tsv"
+    gg_install_file "$5" tools/dest.tsv "the fixture"
+  ' _ "$COMMON" "$INSTALL" "$pidfile" "$gofile" "$ROOT/src.tsv"
 ) >"$ROOT/writer.out" 2>&1 &
 writer=$!
 i=0
@@ -535,9 +544,10 @@ RC=0
 OUT="$(cd "$R" && PATH="$ROOT/stub:$PATH" GG_CHECK=probe bash -c '
   set -euo pipefail
   . "$1"
+  . "$2"
   gg_tmpdir
-  gg_install_file "$2" tools/dest.tsv "the fixture"
-' _ "$COMMON" "$ROOT/src.tsv" 2>&1)" || RC=$?
+  gg_install_file "$3" tools/dest.tsv "the fixture"
+' _ "$COMMON" "$INSTALL" "$ROOT/src.tsv" 2>&1)" || RC=$?
 [ "$RC" -eq 2 ] && case "$OUT" in *"could not replace the fixture"*) true ;; *) false ;; esac \
   && ok "a failed rename is a loud collection error" \
   || bad "a failed rename is a loud collection error" "rc=$RC out=$OUT"

--- a/skills/growth-guards/DEVELOPMENT.md
+++ b/skills/growth-guards/DEVELOPMENT.md
@@ -28,6 +28,11 @@ docs live in README.md.
   `changelog-entries --collate` on the verdict those two just reached: it
   folds the accepted fragments into the record and deletes them, and decides
   nothing about either
+- `scripts/lib/atomic-install.sh` — how the two writing lanes replace a file
+  they own: a rename inside the destination's own directory, so a policy file
+  is never left truncated. Sourced by `suppression-ban` and
+  `changelog-entries` alone; its staging file is declared and removed in
+  `common.sh`, where the reset reaches every guard and the one exit trap lives
 - `scripts/lib/hook-check.sh` — the read-only verdict `install-git-hooks
   --check` returns over the shims this installer writes
 - `scripts/lib/hooks-path.sh` — where git reads hooks from, and whether

--- a/skills/growth-guards/DEVELOPMENT.md
+++ b/skills/growth-guards/DEVELOPMENT.md
@@ -32,7 +32,8 @@ docs live in README.md.
   they own: a rename inside the destination's own directory, so a policy file
   is never left truncated. Sourced by `suppression-ban` and
   `changelog-entries` alone; its staging file is declared and removed in
-  `common.sh`, where the reset reaches every guard and the one exit trap lives
+  `common.sh`, where the reset reaches every guard and the one exit handler
+  lives
 - `scripts/lib/hook-check.sh` — the read-only verdict `install-git-hooks
   --check` returns over the shims this installer writes
 - `scripts/lib/hooks-path.sh` — where git reads hooks from, and whether

--- a/skills/growth-guards/scripts/changelog-entries
+++ b/skills/growth-guards/scripts/changelog-entries
@@ -64,6 +64,9 @@ source "$SCRIPT_DIR/lib/changelog-grammar.sh"
 source "$SCRIPT_DIR/lib/changelog-record-scope.sh"
 # shellcheck source=lib/changelog-collate.sh
 source "$SCRIPT_DIR/lib/changelog-collate.sh"
+# The --collate lane rewrites the record in place.
+# shellcheck source=lib/atomic-install.sh
+source "$SCRIPT_DIR/lib/atomic-install.sh"
 
 # The sections a fragment's directory may name, and the test for membership
 # in them, are lib/changelog-grammar.sh's GG_SECTIONS and gg_is_section: the

--- a/skills/growth-guards/scripts/lib/atomic-install.sh
+++ b/skills/growth-guards/scripts/lib/atomic-install.sh
@@ -1,8 +1,8 @@
 # shellcheck shell=bash
 # atomic-install.sh — how this family REPLACES a file it owns: a policy
 # baseline, a collated changelog record. One helper does the write, and the
-# two beneath it are what it needs to do it safely — the destination's mode,
-# and what a failing step said.
+# two it leans on are what it needs to do that safely — the destination's
+# mode, and what a failing step said.
 #
 # The rule the whole file exists for: a destination is replaced whole or not
 # at all. A truncated policy file reads as a complete one, and for a ratchet
@@ -24,11 +24,13 @@
 
 set -euo pipefail
 
-# The staging file lands beside the DESTINATION, not inside GG_TMP, so
-# gg_tmpdir's trap covers it only by happening to be the same handler.
-# Arming on source says it directly: from the moment this writer exists, the
-# family's one exit handler removes what it stages. gg_cleanup is idempotent
-# and gg_tmpdir arms the same trap, so the two never disagree.
+# The staging file lands beside the DESTINATION, not inside GG_TMP, so it is
+# the one piece of scratch here that gg_tmpdir does not create. Arming on
+# source is what keeps preflight's mktemp-trap lane green over this file, and
+# it is safe for the two callers this family has: both source common.sh, then
+# this file, then arm gg_tmpdir, so nothing of theirs is replaced and the
+# handler is the one gg_tmpdir would set anyway. A caller that arms its OWN
+# EXIT trap before sourcing would lose it, which is why nothing does.
 trap gg_cleanup EXIT
 
 # -L on both spellings: stat lstats by default, so a symlink destination would

--- a/skills/growth-guards/scripts/lib/atomic-install.sh
+++ b/skills/growth-guards/scripts/lib/atomic-install.sh
@@ -1,0 +1,108 @@
+# shellcheck shell=bash
+# atomic-install.sh — how this family REPLACES a file it owns: a policy
+# baseline, a collated changelog record. One helper does the write, and the
+# two beneath it are what it needs to do it safely — the destination's mode,
+# and what a failing step said.
+#
+# The rule the whole file exists for: a destination is replaced whole or not
+# at all. A truncated policy file reads as a complete one, and for a ratchet
+# baseline that LOOSENS the gate instead of failing it, so every write goes
+# through a staging file in the destination's own directory and a rename.
+#
+# GG_INSTALL_TMP — the in-flight staging file — is declared and removed in
+# lib/common.sh, not here, and that is deliberate rather than inherited. The
+# declaration resets any value the environment handed this process, and it
+# has to run in EVERY guard, including the ones that never source this file;
+# the removal has to be gg_cleanup, because a process arms one EXIT trap and
+# that is it. So this file's half of the contract is narrow: gg_install_file
+# sets the variable when it stages and clears it when the rename consumes the
+# file, and nothing here ever deletes it.
+#
+# Needs lib/common.sh sourced first — for gg_cleanup, gg_shown, gg_scrubbed
+# and gg_collection_error — and a caller that has armed gg_tmpdir for the
+# scratch the diagnostics are captured into. Sourced, never executed.
+
+set -euo pipefail
+
+# The staging file lands beside the DESTINATION, not inside GG_TMP, so
+# gg_tmpdir's trap covers it only by happening to be the same handler.
+# Arming on source says it directly: from the moment this writer exists, the
+# family's one exit handler removes what it stages. gg_cleanup is idempotent
+# and gg_tmpdir arms the same trap, so the two never disagree.
+trap gg_cleanup EXIT
+
+# -L on both spellings: stat lstats by default, so a symlink destination would
+# answer with the LINK's own 0777 rather than the file behind it, and the chmod
+# below would publish a world-writable ratchet input any local account could
+# lower. The caller tests with `[ -f ]`, which follows; both must mean one file.
+gg_file_mode() { # FILE — its permission bits as octal digits; GNU stat, then BSD
+  stat -L -c '%a' -- "$1" 2>/dev/null || stat -L -f '%Lp' -- "$1" 2>/dev/null
+}
+
+# What a failing install step printed, folded into the guard's own diagnostic
+# rather than left to reach the terminal as a bare `mv:` line ahead of it.
+# gg_scrubbed: another program's bytes on their way to a terminal.
+gg_install_why() { # ERRFILE — " (TEXT)" or nothing
+  local said
+  said="$(head -n 1 -- "$1" 2>/dev/null || true)"
+  [ -n "$said" ] || return 0
+  printf ' (%s)' "$(gg_scrubbed "$said")"
+}
+
+# Replace DEST with SRC's bytes through a rename inside DEST's own directory.
+# A direct redirect onto DEST, or a rename that crosses a filesystem (where mv
+# degrades to copy-then-unlink), leaves DEST TRUNCATED behind an interrupt.
+gg_install_file() { # SRC DEST LABEL
+  local src="$1" dest="$2" label="$3" mode="" err=""
+  # Every caller in this family arms gg_tmpdir; one that has not is a
+  # programming error, and says so rather than capturing each step's stderr to
+  # whatever `$GG_TMP/install.err` means with GG_TMP empty.
+  [ -n "${GG_TMP:-}" ] && [ -d "$GG_TMP" ] \
+    || gg_collection_error "gg_install_file needs gg_tmpdir called first — $label was not replaced"
+  err="$GG_TMP/install.err"
+  # The destination's mode is READ here and applied after the write, never
+  # carried onto the staging file in between: one without owner-write would
+  # otherwise fail the write on a file this process just created.
+  if [ -f "$dest" ]; then
+    # `|| mode=""`, never a bare assignment: errexit exits the whole run on a
+    # failing command substitution in one, with stat's status and no diagnostic
+    # — the fail-silent the case below replaces. Nothing to relay there:
+    # gg_file_mode silences both probes, the first being the one EXPECTED to
+    # fail wherever the second answers. An unreadable mode is not one to guess.
+    mode="$(gg_file_mode "$dest")" || mode=""
+    case "$mode" in
+      "" | *[!0-7]*) gg_collection_error "could not read the mode of $(gg_shown "$dest") — $label was not replaced" ;;
+    esac
+  fi
+  # mktemp, never a name derived from the pid: the staging file lands in a
+  # directory the repository controls, a predictable name can already be
+  # sitting there, and `cp` writes THROUGH a symlink — so a planted
+  # `.gg-install.<pid>.<name>` link would redirect the write anywhere the
+  # user can reach. mktemp creates the file itself, exclusively.
+  GG_INSTALL_TMP="$(mktemp "$dest.gg-install.XXXXXX" 2>"$err")" \
+    || gg_collection_error "could not stage the replacement for $label beside $(gg_shown "$dest")$(gg_install_why "$err")"
+  # Past mktemp the staging file has ONE owner: gg_cleanup, which the EXIT trap
+  # runs and which removes GG_INSTALL_TMP first. gg_collection_error exits, so
+  # every branch below reaches it and none removes the file itself. `2>` goes
+  # BEFORE the output redirect in each: redirections apply left to right, so a
+  # failure of the one onto the staging file would otherwise be reported on the
+  # terminal rather than captured.
+  if ! cat -- "$src" 2>"$err" >"$GG_INSTALL_TMP"; then
+    gg_collection_error "could not stage the replacement for $label beside $(gg_shown "$dest")$(gg_install_why "$err")"
+  fi
+  # No `--` after the mode: chmod's mode is a non-option argument, so a BSD
+  # chmod stops option parsing there and reads the `--` as a file name.
+  if [ -n "$mode" ] && ! chmod "$mode" "$GG_INSTALL_TMP" 2>"$err"; then
+    gg_collection_error "could not give the replacement for $label $(gg_shown "$dest")'s mode ($mode)$(gg_install_why "$err")"
+  fi
+  # -f, so the rename is non-interactive whatever the destination's mode: mv
+  # PROMPTS before replacing one that denies write when stdin is a terminal —
+  # exactly the destination this helper sets out to support, and a gate that
+  # stops for an answer nobody is there to give is a gate that hangs.
+  if ! mv -f -- "$GG_INSTALL_TMP" "$dest" 2>"$err"; then
+    gg_collection_error "could not replace $label at $(gg_shown "$dest")$(gg_install_why "$err") — inspect the file before trusting it"
+  fi
+  # The one assignment that IS load-bearing: the rename consumed the staging
+  # file, so the trap must not go looking for it.
+  GG_INSTALL_TMP=""
+}

--- a/skills/growth-guards/scripts/lib/atomic-install.sh
+++ b/skills/growth-guards/scripts/lib/atomic-install.sh
@@ -24,15 +24,6 @@
 
 set -euo pipefail
 
-# The staging file lands beside the DESTINATION, not inside GG_TMP, so it is
-# the one piece of scratch here that gg_tmpdir does not create. Arming on
-# source is what keeps preflight's mktemp-trap lane green over this file, and
-# it is safe for the two callers this family has: both source common.sh, then
-# this file, then arm gg_tmpdir, so nothing of theirs is replaced and the
-# handler is the one gg_tmpdir would set anyway. A caller that arms its OWN
-# EXIT trap before sourcing would lose it, which is why nothing does.
-trap gg_cleanup EXIT
-
 # -L on both spellings: stat lstats by default, so a symlink destination would
 # answer with the LINK's own 0777 rather than the file behind it, and the chmod
 # below would publish a world-writable ratchet input any local account could
@@ -81,6 +72,15 @@ gg_install_file() { # SRC DEST LABEL
   # sitting there, and `cp` writes THROUGH a symlink — so a planted
   # `.gg-install.<pid>.<name>` link would redirect the write anywhere the
   # user can reach. mktemp creates the file itself, exclusively.
+  #
+  # A bash trap is process-wide wherever it is armed, so the arming belongs
+  # here rather than at file scope: the handler exists exactly when there is
+  # something for it to remove, and merely SOURCING this file leaves a
+  # caller's own EXIT trap alone. gg_tmpdir armed the same handler already,
+  # which the precondition above proves it ran, so the two never disagree.
+  # The staging file is the one piece of scratch here that gg_tmpdir did not
+  # create: it lands beside the DESTINATION, not inside GG_TMP.
+  trap gg_cleanup EXIT
   GG_INSTALL_TMP="$(mktemp "$dest.gg-install.XXXXXX" 2>"$err")" \
     || gg_collection_error "could not stage the replacement for $label beside $(gg_shown "$dest")$(gg_install_why "$err")"
   # Past mktemp the staging file has ONE owner: gg_cleanup, which the EXIT trap

--- a/skills/growth-guards/scripts/lib/changelog-collate.sh
+++ b/skills/growth-guards/scripts/lib/changelog-collate.sh
@@ -30,7 +30,8 @@
 # carrying the staging file to the exit trap so an interrupt leaves nothing
 # behind.
 #
-# Needs lib/common.sh and lib/changelog-grammar.sh sourced first, and runs on
+# Needs lib/common.sh, lib/changelog-grammar.sh and lib/atomic-install.sh
+# sourced first, and runs on
 # the state the walk and the record scope filled in: GG_TMP/frags.z, RECORD,
 # RECORD_SHA, RECORD_NOTE and the GG_RECORD_* bounds.
 #

--- a/skills/growth-guards/scripts/lib/changelog-collate.sh
+++ b/skills/growth-guards/scripts/lib/changelog-collate.sh
@@ -30,10 +30,11 @@
 # carrying the staging file to the exit trap so an interrupt leaves nothing
 # behind.
 #
-# Needs lib/common.sh, lib/changelog-grammar.sh and lib/atomic-install.sh
-# sourced first, and runs on
+# Needs lib/common.sh and lib/changelog-grammar.sh sourced first, and runs on
 # the state the walk and the record scope filled in: GG_TMP/frags.z, RECORD,
-# RECORD_SHA, RECORD_NOTE and the GG_RECORD_* bounds.
+# RECORD_SHA, RECORD_NOTE and the GG_RECORD_* bounds. gg_install_file comes
+# from lib/atomic-install.sh, and resolution is at call time, so that one has
+# only to be sourced before gg_changelog_collate runs.
 #
 # Sourced, never executed.
 

--- a/skills/growth-guards/scripts/lib/common.sh
+++ b/skills/growth-guards/scripts/lib/common.sh
@@ -37,7 +37,10 @@ GG_VIOLATIONS=0
 GG_TMP=""
 GG_SETTINGS_INDEX_OWNED=0
 # In-flight staging file for gg_install_file, so an interrupt between its
-# creation and its rename leaves nothing beside the destination.
+# creation and its rename leaves nothing beside the destination. The helper
+# that sets it lives in lib/atomic-install.sh, which only the two writing
+# lanes source; the declaration and the removal below stay here on purpose,
+# because the reset has to reach every guard and one process arms one trap.
 GG_INSTALL_TMP=""
 # Extra `git grep` flags for the index lanes below, set by a check before it
 # calls one and empty for every check that does not. Case sensitivity is the one
@@ -208,84 +211,6 @@ gg_resolve_path() { # FLAG-VALUE KEY DEFAULT LABEL — normalized path on stdout
   local raw="$1"
   [ -n "$raw" ] || raw="$(gg_setting "$2" "$3")" || return 1
   gg_config_path "$raw" "$4"
-}
-
-# -L on both spellings: stat lstats by default, so a symlink destination would
-# answer with the LINK's own 0777 rather than the file behind it, and the chmod
-# below would publish a world-writable ratchet input any local account could
-# lower. The caller tests with `[ -f ]`, which follows; both must mean one file.
-gg_file_mode() { # FILE — its permission bits as octal digits; GNU stat, then BSD
-  stat -L -c '%a' -- "$1" 2>/dev/null || stat -L -f '%Lp' -- "$1" 2>/dev/null
-}
-
-# What a failing install step printed, folded into the guard's own diagnostic
-# rather than left to reach the terminal as a bare `mv:` line ahead of it.
-# gg_scrubbed: another program's bytes on their way to a terminal.
-gg_install_why() { # ERRFILE — " (TEXT)" or nothing
-  local said
-  said="$(head -n 1 -- "$1" 2>/dev/null || true)"
-  [ -n "$said" ] || return 0
-  printf ' (%s)' "$(gg_scrubbed "$said")"
-}
-
-# Replace DEST with SRC's bytes through a rename inside DEST's own directory.
-# A direct redirect onto DEST, or a rename that crosses a filesystem (where mv
-# degrades to copy-then-unlink), leaves DEST TRUNCATED behind an interrupt —
-# and a truncated policy file is read as a complete one, which for a ratchet
-# baseline loosens the gate instead of failing it.
-gg_install_file() { # SRC DEST LABEL
-  local src="$1" dest="$2" label="$3" mode="" err=""
-  # Every caller in this family arms gg_tmpdir; one that has not is a
-  # programming error, and says so rather than capturing each step's stderr to
-  # whatever `$GG_TMP/install.err` means with GG_TMP empty.
-  [ -n "${GG_TMP:-}" ] && [ -d "$GG_TMP" ] \
-    || gg_collection_error "gg_install_file needs gg_tmpdir called first — $label was not replaced"
-  err="$GG_TMP/install.err"
-  # The destination's mode is READ here and applied after the write, never
-  # carried onto the staging file in between: one without owner-write would
-  # otherwise fail the write on a file this process just created.
-  if [ -f "$dest" ]; then
-    # `|| mode=""`, never a bare assignment: errexit exits the whole run on a
-    # failing command substitution in one, with stat's status and no diagnostic
-    # — the fail-silent the case below replaces. Nothing to relay there:
-    # gg_file_mode silences both probes, the first being the one EXPECTED to
-    # fail wherever the second answers. An unreadable mode is not one to guess.
-    mode="$(gg_file_mode "$dest")" || mode=""
-    case "$mode" in
-      "" | *[!0-7]*) gg_collection_error "could not read the mode of $(gg_shown "$dest") — $label was not replaced" ;;
-    esac
-  fi
-  # mktemp, never a name derived from the pid: the staging file lands in a
-  # directory the repository controls, a predictable name can already be
-  # sitting there, and `cp` writes THROUGH a symlink — so a planted
-  # `.gg-install.<pid>.<name>` link would redirect the write anywhere the
-  # user can reach. mktemp creates the file itself, exclusively.
-  GG_INSTALL_TMP="$(mktemp "$dest.gg-install.XXXXXX" 2>"$err")" \
-    || gg_collection_error "could not stage the replacement for $label beside $(gg_shown "$dest")$(gg_install_why "$err")"
-  # Past mktemp the staging file has ONE owner: gg_cleanup, which the EXIT trap
-  # runs and which removes GG_INSTALL_TMP first. gg_collection_error exits, so
-  # every branch below reaches it and none removes the file itself. `2>` goes
-  # BEFORE the output redirect in each: redirections apply left to right, so a
-  # failure of the one onto the staging file would otherwise be reported on the
-  # terminal rather than captured.
-  if ! cat -- "$src" 2>"$err" >"$GG_INSTALL_TMP"; then
-    gg_collection_error "could not stage the replacement for $label beside $(gg_shown "$dest")$(gg_install_why "$err")"
-  fi
-  # No `--` after the mode: chmod's mode is a non-option argument, so a BSD
-  # chmod stops option parsing there and reads the `--` as a file name.
-  if [ -n "$mode" ] && ! chmod "$mode" "$GG_INSTALL_TMP" 2>"$err"; then
-    gg_collection_error "could not give the replacement for $label $(gg_shown "$dest")'s mode ($mode)$(gg_install_why "$err")"
-  fi
-  # -f, so the rename is non-interactive whatever the destination's mode: mv
-  # PROMPTS before replacing one that denies write when stdin is a terminal —
-  # exactly the destination this helper sets out to support, and a gate that
-  # stops for an answer nobody is there to give is a gate that hangs.
-  if ! mv -f -- "$GG_INSTALL_TMP" "$dest" 2>"$err"; then
-    gg_collection_error "could not replace $label at $(gg_shown "$dest")$(gg_install_why "$err") — inspect the file before trusting it"
-  fi
-  # The one assignment that IS load-bearing: the rename consumed the staging
-  # file, so the trap must not go looking for it.
-  GG_INSTALL_TMP=""
 }
 
 # `git grep --cached` SKIPS an unmerged index entry entirely: it spends no

--- a/skills/growth-guards/scripts/suppression-ban
+++ b/skills/growth-guards/scripts/suppression-ban
@@ -23,6 +23,9 @@ GG_CHECK="suppression-ban"
 source "$SCRIPT_DIR/lib/common.sh"
 # shellcheck source=lib/settings.sh
 source "$SCRIPT_DIR/lib/settings.sh"
+# The --update lane rewrites the baseline in place.
+# shellcheck source=lib/atomic-install.sh
+source "$SCRIPT_DIR/lib/atomic-install.sh"
 
 usage() {
   cat <<'EOF'

--- a/skills/growth-guards/tests/index-reads.test.sh
+++ b/skills/growth-guards/tests/index-reads.test.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
-# Pins for lib/common.sh's index reads and lib/atomic-install.sh's policy
-# writes: a probe git could not answer never becomes an answer, a configured
-# path is matched literally, a --cached scan refuses an unmerged index, and a
-# policy file is replaced by a same-directory rename or not at all. Every clean assertion is paired with
-# a control that proves it can fail.
+# Pins for three libs the checks share: lib/common.sh's index reads,
+# lib/atomic-install.sh's policy writes, and the settings cache
+# lib/settings.sh materializes. A probe git could not answer never becomes an
+# answer, a configured path is matched literally, a --cached scan refuses an
+# unmerged index, a policy file is replaced by a same-directory rename or not
+# at all, and no partial cache file survives a resolve. Every clean assertion
+# is paired with a control that proves it can fail.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -18,7 +20,8 @@ SCRIPTS="$SKILL_DIR/scripts"
 COMMON="$SCRIPTS/lib/common.sh"
 # The writer lives beside common.sh rather than inside it, and reaches back
 # across that boundary for the staging file common.sh declares and its exit
-# trap removes. So every probe below sources the pair, in that order.
+# trap removes. So every probe below sources the pair, in that order, except
+# the settings-cache probes at the end, which pair common.sh with SETTINGS.
 INSTALL="$SCRIPTS/lib/atomic-install.sh"
 SETTINGS="$SCRIPTS/lib/settings.sh"
 ROOT="$TMP"

--- a/skills/growth-guards/tests/index-reads.test.sh
+++ b/skills/growth-guards/tests/index-reads.test.sh
@@ -18,10 +18,10 @@ TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 SCRIPTS="$SKILL_DIR/scripts"
 COMMON="$SCRIPTS/lib/common.sh"
-# The writer lives beside common.sh rather than inside it, and reaches back
-# across that boundary for the staging file common.sh declares and its exit
-# trap removes. So every probe below sources the pair, in that order, except
-# the settings-cache probes at the end, which pair common.sh with SETTINGS.
+# The lib holding the install helpers, which a probe exercising them sources
+# alongside COMMON: the writer lives beside common.sh rather than inside it,
+# and reaches back across that boundary for the staging file common.sh
+# declares and its exit trap removes.
 INSTALL="$SCRIPTS/lib/atomic-install.sh"
 SETTINGS="$SCRIPTS/lib/settings.sh"
 ROOT="$TMP"

--- a/skills/growth-guards/tests/index-reads.test.sh
+++ b/skills/growth-guards/tests/index-reads.test.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# Pins for lib/common.sh's index reads and policy writes: a probe git could
-# not answer never becomes an answer, a configured path is matched literally,
-# a --cached scan refuses an unmerged index, and a policy file is replaced by
-# a same-directory rename or not at all. Every clean assertion is paired with
+# Pins for lib/common.sh's index reads and lib/atomic-install.sh's policy
+# writes: a probe git could not answer never becomes an answer, a configured
+# path is matched literally, a --cached scan refuses an unmerged index, and a
+# policy file is replaced by a same-directory rename or not at all. Every clean assertion is paired with
 # a control that proves it can fail.
 set -euo pipefail
 
@@ -16,6 +16,10 @@ TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 SCRIPTS="$SKILL_DIR/scripts"
 COMMON="$SCRIPTS/lib/common.sh"
+# The writer lives beside common.sh rather than inside it, and reaches back
+# across that boundary for the staging file common.sh declares and its exit
+# trap removes. So every probe below sources the pair, in that order.
+INSTALL="$SCRIPTS/lib/atomic-install.sh"
 SETTINGS="$SCRIPTS/lib/settings.sh"
 ROOT="$TMP"
 
@@ -35,7 +39,7 @@ new_repo() { # NAME — fresh fixture repo in $R, cwd unchanged
   git -C "$R" config user.name test
 }
 
-# Run a snippet with common.sh sourced, inside $R. OUT captures stdout+stderr,
+# Run a snippet with the libs sourced, inside $R. OUT captures stdout+stderr,
 # RC the exit status — a collection error is exit 2 and must be observable.
 call() { # SNIPPET
   OUT=""
@@ -43,9 +47,10 @@ call() { # SNIPPET
   OUT="$(cd "$R" && GG_CHECK=probe bash -c '
     set -euo pipefail
     . "$1"
-    shift
+    . "$2"
+    shift 2
     eval "$1"
-  ' _ "$COMMON" "$1" 2>&1)" || RC=$?
+  ' _ "$COMMON" "$INSTALL" "$1" 2>&1)" || RC=$?
 }
 
 echo "=== gg_policy_content: the index governs, and a probe that failed is not an answer ==="
@@ -421,9 +426,10 @@ RC=0
 OUT="$(cd "$R" && PATH="$ROOT/nostat:$PATH" GG_CHECK=probe bash -c '
   set -euo pipefail
   . "$1"
+  . "$2"
   gg_tmpdir
-  gg_install_file "$2" tools/dest.tsv "the fixture"
-' _ "$COMMON" "$ROOT/src.tsv" 2>&1)" || RC=$?
+  gg_install_file "$3" tools/dest.tsv "the fixture"
+' _ "$COMMON" "$INSTALL" "$ROOT/src.tsv" 2>&1)" || RC=$?
 [ "$RC" -eq 2 ] && case "$OUT" in *"could not read the mode of tools/dest.tsv"*) true ;; *) false ;; esac \
   && ok "an unreadable mode is a loud refusal, not a narrowing rename" \
   || bad "an unreadable mode is a loud refusal, not a narrowing rename" "rc=$RC out=$OUT"
@@ -440,8 +446,9 @@ RC=0
 OUT="$(cd "$R" && GG_CHECK=probe bash -c '
   set -euo pipefail
   . "$1"
-  gg_install_file "$2" tools/dest.tsv "the fixture"
-' _ "$COMMON" "$ROOT/src.tsv" 2>&1)" || RC=$?
+  . "$2"
+  gg_install_file "$3" tools/dest.tsv "the fixture"
+' _ "$COMMON" "$INSTALL" "$ROOT/src.tsv" 2>&1)" || RC=$?
 [ "$RC" -eq 2 ] && case "$OUT" in *"needs gg_tmpdir called first"*) true ;; *) false ;; esac \
   && ok "an install with no scratch directory refuses rather than writing beside the root" \
   || bad "an install with no scratch directory refuses rather than writing beside the root" "rc=$RC out=$OUT"
@@ -464,9 +471,10 @@ RC=0
 OUT="$(cd "$R" && PATH="$ROOT/nochmod:$PATH" GG_CHECK=probe bash -c '
   set -euo pipefail
   . "$1"
+  . "$2"
   gg_tmpdir
-  gg_install_file "$2" tools/dest.tsv "the fixture"
-' _ "$COMMON" "$ROOT/src.tsv" 2>&1)" || RC=$?
+  gg_install_file "$3" tools/dest.tsv "the fixture"
+' _ "$COMMON" "$INSTALL" "$ROOT/src.tsv" 2>&1)" || RC=$?
 [ "$RC" -eq 2 ] && case "$OUT" in *"could not give the replacement for the fixture tools/dest.tsv's mode (644)"*) true ;; *) false ;; esac \
   && ok "a failed chmod names the mode it could not give" \
   || bad "a failed chmod names the mode it could not give" "rc=$RC out=$OUT"
@@ -494,13 +502,14 @@ rm -f "$pidfile" "$gofile"
 (
   cd "$R" && GG_CHECK=probe bash -c '
     set -euo pipefail
-    echo "$$" >"$2"
+    echo "$$" >"$3"
     i=0
-    while [ ! -e "$3" ] && [ "$i" -lt 200 ]; do i=$((i + 1)); sleep 0.05; done
+    while [ ! -e "$4" ] && [ "$i" -lt 200 ]; do i=$((i + 1)); sleep 0.05; done
     . "$1"
+    . "$2"
     gg_tmpdir
-    gg_install_file "$4" tools/dest.tsv "the fixture"
-  ' _ "$COMMON" "$pidfile" "$gofile" "$ROOT/src.tsv"
+    gg_install_file "$5" tools/dest.tsv "the fixture"
+  ' _ "$COMMON" "$INSTALL" "$pidfile" "$gofile" "$ROOT/src.tsv"
 ) >"$ROOT/writer.out" 2>&1 &
 writer=$!
 i=0
@@ -535,9 +544,10 @@ RC=0
 OUT="$(cd "$R" && PATH="$ROOT/stub:$PATH" GG_CHECK=probe bash -c '
   set -euo pipefail
   . "$1"
+  . "$2"
   gg_tmpdir
-  gg_install_file "$2" tools/dest.tsv "the fixture"
-' _ "$COMMON" "$ROOT/src.tsv" 2>&1)" || RC=$?
+  gg_install_file "$3" tools/dest.tsv "the fixture"
+' _ "$COMMON" "$INSTALL" "$ROOT/src.tsv" 2>&1)" || RC=$?
 [ "$RC" -eq 2 ] && case "$OUT" in *"could not replace the fixture"*) true ;; *) false ;; esac \
   && ok "a failed rename is a loud collection error" \
   || bad "a failed rename is a loud collection error" "rc=$RC out=$OUT"


### PR DESCRIPTION
## Summary

- `gg_file_mode`, `gg_install_why` and `gg_install_file` move out of growth-guards' `lib/common.sh` into a new `lib/atomic-install.sh`, sourced by the two lanes that rewrite a file they own: `suppression-ban` and `changelog-entries`. The function bodies are unchanged.
- `common.sh` drops from 400 lines — exactly `SIZE_RATCHET_THRESHOLD`, which is why the next change to it would have been refused — to 325, with no baseline row taken to get there.
- `GG_INSTALL_TMP`'s ownership across the new boundary is settled deliberately and said where the code reads: the declaration and the `gg_cleanup` removal stay in `common.sh`, because the reset must run in every guard including those that never source the writer, and one process arms one EXIT handler. The new lib sets the variable when it stages, clears it when the rename consumes the file, and never deletes it.
- `trap gg_cleanup EXIT` is armed inside `gg_install_file`, immediately before the `mktemp` that stages the replacement — not at file scope, where sourcing the lib would silently replace a caller's own EXIT trap.

## Completed Issues

- Closes KEN-953 - growth-guards common.sh sits on the ratchet threshold, so the next change to it is refused

## Test Plan

- All 22 growth-guards suites green; `tools/guard` exits 0; `tools/bash32-lint` clean over 133 files; `preflight --base origin/main` clean over the 14 changed files; size-ratchet OK.
- `skills/growth-guards` and `.agents/skills/growth-guards` are byte-identical (`diff -r` empty).
- Must-fail controls, each run red once and restored: neutering the `chmod` step reds 7 `index-reads` assertions; dropping either new `source` line reds that lane's suite; deleting the relocated trap makes preflight report `atomic-install.sh:83 mktemp without an EXIT trap`, proving the lane reads it at its new position.
- Boundary coverage: `mutation: killed 1/1; stability: 5/5 at 64 threads` for each caller's source line.

## Created Issues

- KEN-1008 - preflight's mktemp-trap lane steers a sourced lib into clobbering its caller's trap — Project: Review Gate & CI
