### PR TITLE
feat(KEN-1005): one doctrine source, five bots' own files

### DIFF
--- a/skills/bot-instructions/README.md
+++ b/skills/bot-instructions/README.md
@@ -86,13 +86,12 @@ bot output has to do about it.
 
 ## Adding a repo
 
-Write `bot-instructions.toml` at the repo root, moving each existing bot file's
-repo-specific claims into it and letting doctrine carry the rest. Add the
-`## Code Review Rules` heading to `AGENTS.md` by hand if `codex` is on, since
-the generator never adds it. Run `adopt`, which takes that region and every
-existing bot file over, and read what it names against the TOML. Render, read
-the diff, then work the settings. A bot whose install or enablement step is
-skipped reviews nothing while every file in the repo looks correct.
+The sequence is [references/checklist.md](references/checklist.md) § Adding a
+repo, and it is not a preference: `toml-schema`'s cross-flag clauses and
+`adopt`'s own rule fix the order, so that file derives it from them rather than
+asserting it. Two passes — a repo-wide TOML with every bot off, then one pass
+per capability that enables it, adopts its paths and renders them.
 
-The six steps in full, and the settings that follow them:
-[references/checklist.md](references/checklist.md).
+What a reader coming here for the shape needs: nothing that depends on a flag
+is written before the flag, and a bot whose install or enablement step is
+skipped reviews nothing while every file in the repo looks correct.

--- a/skills/bot-instructions/README.md
+++ b/skills/bot-instructions/README.md
@@ -9,10 +9,15 @@ the contract the generator will be built against.
 
 Five bots read four incompatible surfaces. Codex reads `AGENTS.md` § Code
 Review Rules and nothing else. Copilot code review reads
-`.github/copilot-instructions.md` and path-scoped
-`.github/instructions/*.instructions.md`. CodeRabbit reads a single
-`.coderabbit.yaml` that outranks its dashboard. Qodo reads `.pr_agent.toml` and
-`best_practices.md`. Macroscope reads a `.macroscope/` tree. Written by hand,
+`.github/copilot-instructions.md`, path-scoped
+`.github/instructions/*.instructions.md`, and `AGENTS.md`. CodeRabbit reads a
+single `.coderabbit.yaml` that outranks its dashboard, plus `AGENTS.md` where
+that file points it. Qodo reads `.pr_agent.toml` and `best_practices.md`.
+Macroscope reads a `.macroscope/` tree.
+
+Three of the five reach that `AGENTS.md` section, which is why it is the
+doctrine root and why a TOML turning `codex` off with `copilot` or `coderabbit`
+on is a schema error rather than a supported configuration. Written by hand,
 one repo's review doctrine drifts from the next repo's, and an exclusion list
 falls behind the tree it excludes without anything saying so.
 

--- a/skills/bot-instructions/README.md
+++ b/skills/bot-instructions/README.md
@@ -1,0 +1,79 @@
+# bot-instructions
+
+Standardized instruction files for the GitHub review bots, generated from one
+doctrine source plus a per-repo TOML rather than hand-written five times.
+
+Five bots read four incompatible surfaces. Codex reads `AGENTS.md` § Code
+Review Rules and nothing else. Copilot code review reads
+`.github/copilot-instructions.md` and path-scoped
+`.github/instructions/*.instructions.md`. CodeRabbit reads a single
+`.coderabbit.yaml` that outranks its dashboard. Qodo reads `.pr_agent.toml` and
+`best_practices.md`. Macroscope reads a `.macroscope/` tree. Written by hand,
+one repo's review doctrine drifts from the next repo's, and an exclusion list
+falls behind the tree it excludes without anything saying so.
+
+```
+doctrine (SKILL.md § Doctrine)  +  bot-instructions.toml
+                    │
+                    ▼ render
+   AGENTS.md § Code Review Rules      .coderabbit.yaml
+   .github/copilot-instructions.md    .pr_agent.toml + best_practices.md
+   .github/instructions/*.md          .macroscope/
+```
+
+A `[[surface]]` in the TOML is written once and reaches Copilot, CodeRabbit and
+Macroscope in each one's own dialect. An exclusion is written once and reaches
+every bot that has an exclusion mechanism. Doctrine is written once, in this
+package, for every repo.
+
+## Three verbs
+
+`render` builds and validates in a scratch tree, then writes. `check`
+re-renders and reports any file that differs, plus any generated file the TOML
+no longer produces. `adopt` is the one-time verb for a repo whose bot files
+were written by hand: `render` refuses to replace a file that does not carry
+this package's marker, and `adopt` takes one over while printing what it
+replaced.
+
+Generated files are outputs. A hand edit is erased at the next render, and
+`check` reds before that happens. There is no overwrite prompt and no merge of
+hand edits back into the source.
+
+## Why validators
+
+Every bot in this set fails silently. An over-limit `.coderabbit.yaml` is
+discarded whole and the review runs with defaults, saying nothing. A
+`path_filters` entry missing its `!` turns the list into an allowlist and
+un-reviews the repo. An `excludeAgent` typo loads reviewer doctrine into the
+working agent. In each case the pull request looks reviewed.
+
+Each validator names the silent failure it catches and ships a fixture that
+carries exactly that defect, asserted red. What no validator can reach, because
+it lives in a vendor's web UI, is the settings checklist instead.
+
+## What this does not solve
+
+Copilot, CodeRabbit and Macroscope read their instruction files from the pull
+request's head, so a pull request can weaken the review it is about to get and
+re-render until every check passes. No repo file closes that. SKILL.md § A pull
+request changing its own review states what a repo whose merge gate consumes
+bot output has to do about it.
+
+## Reading order
+
+| File | What it settles |
+|------|-----------------|
+| [SKILL.md](SKILL.md) | The doctrine text, which bot reads what, and the trust boundary |
+| [schemas/repo-toml.md](schemas/repo-toml.md) | Every key of `bot-instructions.toml`, and the glob dialect |
+| [schemas/renders.md](schemas/renders.md) | Per-surface render rules, ordering and escaping |
+| [schemas/validators.md](schemas/validators.md) | Each validator's silent failure and what it rejects |
+| [references/limits.md](references/limits.md) | Vendor caps, enums and read semantics, each with its source |
+| [references/checklist.md](references/checklist.md) | The per-repo settings no file can configure |
+
+## Adding a repo
+
+Write `bot-instructions.toml` at the repo root, moving each existing bot file's
+repo-specific claims into it and letting doctrine carry the rest. Run `adopt`
+and read the list of files it is taking over against the TOML. Render, read the
+diff, then work the settings checklist. A bot whose install or enablement step
+is skipped reviews nothing while every file in the repo looks correct.

--- a/skills/bot-instructions/README.md
+++ b/skills/bot-instructions/README.md
@@ -87,10 +87,11 @@ bot output has to do about it.
 ## Adding a repo
 
 The sequence is [references/checklist.md](references/checklist.md) § Adding a
-repo, and it is not a preference: `toml-schema`'s cross-flag clauses and
-`adopt`'s own rule fix the order, so that file derives it from them rather than
-asserting it. Two passes — a repo-wide TOML with every bot off, then one pass
-per capability that enables it, adopts its paths and renders them.
+repo, and it is not a preference: `toml-schema`'s cross-flag clauses, `adopt`'s
+own rule, and `agents-section`'s ungated nested-`AGENTS.md` clause fix the
+order, so that file derives it from them rather than asserting it. Two passes —
+a repo-wide TOML with every bot off, then one pass per capability that enables
+it, adopts its paths and renders them.
 
 What a reader coming here for the shape needs: nothing that depends on a flag
 is written before the flag, and a bot whose install or enablement step is

--- a/skills/bot-instructions/README.md
+++ b/skills/bot-instructions/README.md
@@ -29,12 +29,14 @@ lands in which file, in what order, and why each omission is deliberate.
 
 ## Three verbs
 
-`render` builds and validates in a scratch tree, then writes. `check`
+`render` builds and validates in a scratch tree, then writes — and the checks
+that judge repository state rather than emitted bytes read the repo before the
+write, since a scratch tree is the one place they cannot fail. `check`
 re-renders and reports any file that differs, plus anything carrying the
-package's marker that the TOML no longer produces. `adopt` is the one-time verb for a repo whose bot files
-were written by hand: `render` refuses to replace a file that does not carry
-this package's marker, and `adopt` takes one over while printing what it
-replaced.
+package's marker that the TOML no longer produces. `adopt` is the one-time verb
+for a repo whose bot files were written by hand: `render` refuses to replace a
+file that does not carry this package's marker, and `adopt` takes one over while
+printing what it replaced.
 
 Generated files are outputs. A hand edit is erased at the next render, and
 `check` reds before that happens. There is no overwrite prompt and no merge of
@@ -48,8 +50,10 @@ discarded whole and the review runs with defaults, saying nothing. A
 un-reviews the repo. An `excludeAgent` typo loads reviewer doctrine into the
 working agent. In each case the pull request looks reviewed.
 
-Each validator names the silent failure it catches and ships a fixture that
-carries exactly that defect, asserted red. What no validator can reach, because
+Each validator names the silent failure it catches, and each rejection clause it
+names ships a fixture carrying exactly that defect, asserted red on the
+validator's own message — plus one canonical render asserted green, so a
+validator that rejects everything fails the suite. What no validator can reach, because
 it lives in a vendor's web UI, is the settings checklist instead.
 
 ## What this does not solve

--- a/skills/bot-instructions/README.md
+++ b/skills/bot-instructions/README.md
@@ -24,13 +24,14 @@ doctrine (SKILL.md § Doctrine)  +  bot-instructions.toml
 A `[[surface]]` in the TOML is written once and reaches Copilot, CodeRabbit and
 Macroscope in each one's own dialect. An exclusion is written once and reaches
 every bot that has an exclusion mechanism. Doctrine is written once, in this
-package, for every repo.
+package, for every repo, and one table in `schemas/renders.md` says which block
+lands in which file, in what order, and why each omission is deliberate.
 
 ## Three verbs
 
 `render` builds and validates in a scratch tree, then writes. `check`
-re-renders and reports any file that differs, plus any generated file the TOML
-no longer produces. `adopt` is the one-time verb for a repo whose bot files
+re-renders and reports any file that differs, plus anything carrying the
+package's marker that the TOML no longer produces. `adopt` is the one-time verb for a repo whose bot files
 were written by hand: `render` refuses to replace a file that does not carry
 this package's marker, and `adopt` takes one over while printing what it
 replaced.

--- a/skills/bot-instructions/README.md
+++ b/skills/bot-instructions/README.md
@@ -3,6 +3,10 @@
 Standardized instruction files for the GitHub review bots, generated from one
 doctrine source plus a per-repo TOML rather than hand-written five times.
 
+**This is the specification, not working software.** The package ships no
+`scripts/` directory and none of the verbs below exist yet; everything here is
+the contract the generator will be built against.
+
 Five bots read four incompatible surfaces. Codex reads `AGENTS.md` § Code
 Review Rules and nothing else. Copilot code review reads
 `.github/copilot-instructions.md` and path-scoped
@@ -27,7 +31,7 @@ every bot that has an exclusion mechanism. Doctrine is written once, in this
 package, for every repo, and one table in `schemas/renders.md` says which block
 lands in which file, in what order, and why each omission is deliberate.
 
-## Three verbs
+## Three verbs, once there is a generator
 
 `render` builds and validates in a scratch tree, then writes — and the checks
 that judge repository state rather than emitted bytes read the repo before the

--- a/skills/bot-instructions/README.md
+++ b/skills/bot-instructions/README.md
@@ -82,12 +82,17 @@ bot output has to do about it.
 | [schemas/renders.md](schemas/renders.md) | Per-surface render rules, ordering and escaping |
 | [schemas/validators.md](schemas/validators.md) | Each validator's silent failure and what it rejects |
 | [references/limits.md](references/limits.md) | Vendor caps, enums and read semantics, each with its source |
-| [references/checklist.md](references/checklist.md) | The per-repo settings no file can configure |
+| [references/checklist.md](references/checklist.md) | How to add a repo, and the per-repo settings no file can configure |
 
 ## Adding a repo
 
 Write `bot-instructions.toml` at the repo root, moving each existing bot file's
-repo-specific claims into it and letting doctrine carry the rest. Run `adopt`
-and read the list of files it is taking over against the TOML. Render, read the
-diff, then work the settings checklist. A bot whose install or enablement step
-is skipped reviews nothing while every file in the repo looks correct.
+repo-specific claims into it and letting doctrine carry the rest. Add the
+`## Code Review Rules` heading to `AGENTS.md` by hand if `codex` is on, since
+the generator never adds it. Run `adopt`, which takes that region and every
+existing bot file over, and read what it names against the TOML. Render, read
+the diff, then work the settings. A bot whose install or enablement step is
+skipped reviews nothing while every file in the repo looks correct.
+
+The six steps in full, and the settings that follow them:
+[references/checklist.md](references/checklist.md).

--- a/skills/bot-instructions/SKILL.md
+++ b/skills/bot-instructions/SKILL.md
@@ -102,10 +102,12 @@ The generator offers three verbs.
 - `render` writes every enabled surface from doctrine plus the repo TOML, after
   validating what it built. It builds and validates in a scratch tree first, so
   a validator failure leaves the repo untouched; a failure during the write
-  phase is reported naming every path already replaced. `AGENTS.md` is the
-  exception to scratch-then-replace, because it is the one output whose
-  non-owned bytes belong to the repo: what the build produces is the region's
-  body, and the write splices it into the file's bytes read at write time.
+  phase is reported naming every path already replaced, each of which holds
+  either its old bytes or its new ones — every replacement is atomic, so an
+  interrupt never leaves a truncated file. `AGENTS.md` is the exception to
+  scratch-then-replace, because it is the one output whose non-owned bytes
+  belong to the repo: what the build produces is the region's body, and the
+  write splices it into the file's bytes read at write time.
   The validators that judge repository state rather than emitted bytes read the
   repo, before the write, so a render that would orphan a file fails instead of
   reporting a clean pass and then orphaning it. `schemas/validators.md` § Where
@@ -116,7 +118,9 @@ The generator offers three verbs.
   finding naming the path and the differing region.
 - `adopt` is the one-time verb for a repo that already has hand-written bot
   files. `render` refuses to replace a file at a generated path that does not
-  carry this package's marker; `adopt` takes such a file over, printing what it
+  carry this package's marker, and it reads that marker on the file it has
+  opened to replace rather than on some prior pass over the repo, so nothing
+  can slip into the gap; `adopt` takes such a file over, printing what it
   replaced so the diff shows the content that has to survive in the TOML.
 
 There is no install-time placement step, no overwrite prompt, and no merge of

--- a/skills/bot-instructions/SKILL.md
+++ b/skills/bot-instructions/SKILL.md
@@ -194,6 +194,24 @@ This repo's own convention is the precedent for the no-follow half — it opens
 without following and re-checks the opened file's type rather than the name. The
 walk from a root descriptor is the part it does not have.
 
+## Every rendered config excludes the render trees
+
+**A render-only diff opens no bot rounds.** That is the requirement, and it is
+what the exclusion set is for: a tracked tree this repo renders from an upstream
+package is not its code, so a finding on one costs a round nobody here can
+spend. Every config this package renders excludes those trees, and a surface
+with no file-based review exclusion carries the paths as prose, so the
+instruction names something rather than gesturing at it.
+
+**Two of the five subtract for real; three are asked.** CodeRabbit's
+`path_filters` and Macroscope's `ignore.md` remove the files from review. Codex,
+Copilot and Qodo receive the paths as prose, and **a bot asked to skip a path
+may still comment on it** — none of the three has a file-based review exclusion
+this package can reach. Naming the paths there makes the instruction actionable;
+it is not enforcement. `schemas/renders.md` § Doctrine routing says which
+surface gets which mechanism, and `references/checklist.md` says where
+enforcement for the three has to come from instead.
+
 ## A pull request changing its own review
 
 Copilot, CodeRabbit and Macroscope read their instruction files from the pull
@@ -372,8 +390,8 @@ nothing but a label it knows.
 A tracked tree this repo renders from an upstream package is not this repo's
 code. A review comment on it cannot be acted on here: the fix lands upstream
 and arrives by re-render, and an in-repo edit is erased. Report nothing on
-those paths, on any surface, in any round. The repo's own instruction file
-names which trees these are.
+those paths, on any surface, in any round. The paths themselves follow this
+block wherever a surface has no other way to receive them.
 
 ### trust-model
 

--- a/skills/bot-instructions/SKILL.md
+++ b/skills/bot-instructions/SKILL.md
@@ -44,12 +44,15 @@ and the drift validator reds before that happens.
 | Qodo | `.pr_agent.toml`, `best_practices.md`, `REVIEW.md` | the default branch root |
 | Macroscope | `.macroscope/ignore.md`, `.macroscope/correctness/*.md`, plus `.macroscope/check-run-agents/**` and `.macroscope/approvability.md`, which this package never writes | the pull request's most recent commit, or the default branch for a fork |
 
-Three of the five reach the `AGENTS.md` section, which is why it is the
-doctrine root and why `[bots] codex = false` with `copilot` or `coderabbit` on
-is a `toml-schema` error. Codex and Macroscope are the two that do not: neither
-reads an `AGENTS.md` at all, so a block left out of the one surface this package
-writes for each reaches that bot nowhere, and both carry every block. The
-routing table in
+Three of the five reach the `AGENTS.md` section — Codex, Copilot and
+CodeRabbit — which is why it is the doctrine root and why `[bots] codex = false`
+with `copilot` or `coderabbit` on is a `toml-schema` error. Qodo and Macroscope
+are the two that do not.
+
+A separate count decides which surfaces carry every block: Codex and Macroscope
+each read exactly one surface this package writes, so a block left out of that
+one reaches the bot nowhere. That is why `AGENTS.md` and
+`.macroscope/correctness/doctrine.md` carry all eight. The routing table in
 [schemas/renders.md](schemas/renders.md) is where that lives, one row per block
 and one column per destination.
 
@@ -217,16 +220,26 @@ whose merge gate consumes bot output has to do instead:
   that a tampered generator cannot report a clean render. It does not and cannot
   stop a policy change, which is what the approval rule above is for.
 
-**The render inputs**, which is every path a render reads. This is the one
-statement of the set: the marker names them, `check --staged` reads each from
-the index, every one is under the open rule above, and the policy set below
-contains them.
+**The render inputs**, which is every path a render reads to produce bytes. This
+is the one statement of the set: the marker names them, `check --staged` reads
+each from the index, every one is under the open rule above, and the policy set
+below contains them.
 
 - `bot-instructions.toml`.
 - The spec copy's doctrine source and routing table.
 - `.bot-instructions/coderabbit-schema.json`, when `[bots] coderabbit` is true.
 - The resolved install manifest, when `[exclusions] derive_render` is true.
 - The existing `AGENTS.md`, when `[bots] codex` is true.
+
+What a repo-state validator walks is deliberately not in that set: `orphan`'s
+sweep of `.github/instructions/**` and `.macroscope/correctness/**`, and
+`agents-section`'s walk for nested `AGENTS.md`. Those enumerate paths rather
+than reading a fixed input, so the marker could not name them and no render
+consumes their bytes. They are covered twice over anyway — every open is under
+the rule above, and a repo-state validator reads whichever tree `check`
+selected, the worktree by default and the index under `--staged`, so the staged
+lane still judges one coherent state. The policy set below does contain the
+trees they walk.
 
 **The policy set**, which is every path whose bytes decide what a bot is told or
 whether a render validates. This list is the one statement of it; the checklist

--- a/skills/bot-instructions/SKILL.md
+++ b/skills/bot-instructions/SKILL.md
@@ -410,7 +410,9 @@ recommend parsing them.
 
 The procedure is [references/checklist.md](references/checklist.md) § Adding a
 repo, beside the settings work it runs into, and it derives its order from
-`toml-schema`'s cross-flag clauses and `adopt`'s rule rather than restating one.
-The shape worth knowing before you start: nothing that depends on a flag is
-written before the flag, so a capability's surfaces, `adopt` and `render` all
-happen in the pass that turns it on.
+`toml-schema`'s cross-flag clauses, `adopt`'s rule and `agents-section`'s
+ungated nested-`AGENTS.md` clause rather than restating one. The shape worth
+knowing before you start: nothing that depends on a flag is written before the
+flag, so a capability's surfaces, `adopt` and `render` all happen in the pass
+that turns it on — and the one constraint no flag carries, a nested
+`## Code Review Rules` section, is cleared before the first render of all.

--- a/skills/bot-instructions/SKILL.md
+++ b/skills/bot-instructions/SKILL.md
@@ -93,10 +93,15 @@ The generator offers three verbs.
 - `render` writes every enabled surface from doctrine plus the repo TOML, after
   validating what it built. It builds and validates in a scratch tree first, so
   a validator failure leaves the repo untouched; a failure during the write
-  phase is reported naming every path already replaced.
-- `check` re-renders and compares. It reads the working tree by default and the
-  index under `--staged`. Any difference is a finding naming the path and the
-  differing region.
+  phase is reported naming every path already replaced. The validators that
+  judge repository state rather than emitted bytes read the repo, before the
+  write, so a render that would orphan a file fails instead of reporting a
+  clean pass and then orphaning it. `schemas/validators.md` § Where these run
+  is the split.
+- `check` re-renders and compares. It reads the working tree by default; under
+  `--staged` it reads the index, for every render input as well as the outputs,
+  so a pre-commit lane judges one coherent staged state. Any difference is a
+  finding naming the path and the differing region.
 - `adopt` is the one-time verb for a repo that already has hand-written bot
   files. `render` refuses to replace a file at a generated path that does not
   carry this package's marker; `adopt` takes such a file over, printing what it

--- a/skills/bot-instructions/SKILL.md
+++ b/skills/bot-instructions/SKILL.md
@@ -124,7 +124,9 @@ The generator offers three verbs.
   carry this package's marker, and it reads that marker on the file it has
   opened to replace rather than on some prior pass over the repo, so nothing
   can slip into the gap; `adopt` takes such a file over, printing what it
-  replaced so the diff shows the content that has to survive in the TOML.
+  replaced so the diff shows the content that has to survive in the TOML. It
+  takes a region over the same way, which is how a hand-added `AGENTS.md`
+  heading becomes managed.
 
 There is no install-time placement step, no overwrite prompt, and no merge of
 hand edits back into doctrine. A generated file is either byte-identical to its
@@ -141,7 +143,9 @@ generator owns exactly the slice from the `## Code Review Rules` heading to the
 next heading at that level or above, and never the rest, and it opens that slice
 with the marker so the region is as identifiable as a whole file. It never
 creates `AGENTS.md` and never adds the heading: a repo without that section is
-an error telling the author to add the heading and render again.
+an error telling the author to add the heading, `adopt`, then render. The
+`adopt` step is not optional there — a hand-added heading is an unmarked region
+at a generated path, which is exactly what `render` refuses.
 
 Codex also reads the nearest nested `AGENTS.md` covering each changed file. The
 generator writes only the root section, so a nested `AGENTS.md` carrying a
@@ -285,8 +289,8 @@ line points here rather than repeating it, so the two cannot drift.
   as a generated one, and nothing else here judges it. The last two this package
   never writes at all, which makes them unmanaged surfaces rather than
   unmanaged files.
-- Any repo-wide reviewer file the repo keeps by hand. § Adding a repo says what
-  becomes of one.
+- Any repo-wide reviewer file the repo keeps by hand.
+  `references/checklist.md` § Adding a repo says what becomes of one.
 
 Two asymmetries are worth knowing. Macroscope reads the default branch for a
 fork pull request, so a fork cannot weaken its own review the way a branch
@@ -402,28 +406,8 @@ recommend parsing them.
 
 ## Adding a repo
 
-1. Write `bot-instructions.toml` at the repo root per
-   [schemas/repo-toml.md](schemas/repo-toml.md). An existing hand-written bot
-   file is the source for its `[[surface]]` blocks and exclusions: read it,
-   move its repo-specific claims into the TOML, and let doctrine carry the
-   rest.
-2. Run `adopt`, which names every existing file it is taking over, and every
-   repo-root or `.github/` markdown file those files point at. That second list
-   is where a repo-wide hand-written reviewer file shows up — the kind that
-   restates doctrine and carries an accepted-trade-off list, reached only
-   because `AGENTS.md` and the Copilot file name it. Fold what it holds into
-   `[doctrine.append]` and `[[surface]]`; what will not fold stays hand-written
-   and is a policy path. Read both lists against the TOML: a claim in one of
-   those files that the TOML does not carry is about to be deleted, or to go on
-   steering reviews from outside the package.
-3. If `[bots] coderabbit` is true, put CodeRabbit's published schema at
-   `.bot-instructions/coderabbit-schema.json`. No verb writes it and
-   `coderabbit-schema` fails without it, deliberately: a validator that skipped
-   on a missing schema would be silent for the life of the repo, which is the
-   failure it exists to catch.
-4. Run `render`, then read the diff. Doctrine text appearing for the first time
-   is expected; a repo-specific claim disappearing means it never made it into
-   the TOML.
-5. Work [references/checklist.md](references/checklist.md). Every bot has at
-   least one setting no file can express, and a bot whose install or enablement
-   step is skipped reviews nothing while every file below looks correct.
+The procedure is [references/checklist.md](references/checklist.md) § Adding a
+repo, beside the settings work it runs into. It is six steps, and the two worth
+knowing before you start are that a repo with `[bots] codex` adds the
+`## Code Review Rules` heading by hand before `adopt`, and that `adopt` is what
+makes both that region and any existing bot file managed.

--- a/skills/bot-instructions/SKILL.md
+++ b/skills/bot-instructions/SKILL.md
@@ -246,6 +246,13 @@ whether a render validates. This list is the one statement of it; the checklist
 line points here rather than repeating it, so the two cannot drift.
 
 - Every render input above.
+- This package's own installed tree: the generator and the validators, not only
+  the doctrine source and routing table the render inputs already name. They
+  decide whether a render validates, which is half the definition above. The
+  trusted CI checkout is why an edit to them cannot fool `check` in CI — that
+  lane runs the default branch's copy — but the local verbs run the head's, and
+  a policy path is about what a push invalidates rather than about what one
+  lane happens to read.
 - Every generated path.
 - Every `AGENTS.md` in the repo. Codex reads the nearest nested one, so a file
   the root render never touches still reaches it.

--- a/skills/bot-instructions/SKILL.md
+++ b/skills/bot-instructions/SKILL.md
@@ -42,12 +42,14 @@ and the drift validator reds before that happens.
 | Copilot code review | `.github/copilot-instructions.md`, `.github/instructions/**/*.instructions.md`, `AGENTS.md` | the pull request head |
 | CodeRabbit | `.coderabbit.yaml`, whole-file, beneath any organization or workspace global override, plus `AGENTS.md` through `knowledge_base.code_guidelines.filePatterns` | the pull request head |
 | Qodo | `.pr_agent.toml`, `best_practices.md`, `REVIEW.md` | the default branch root |
-| Macroscope | `.macroscope/ignore.md`, `.macroscope/correctness/*.md`, and nothing else | the pull request's most recent commit, or the default branch for a fork |
+| Macroscope | `.macroscope/ignore.md`, `.macroscope/correctness/*.md`, plus `.macroscope/check-run-agents/**` and `.macroscope/approvability.md`, which this package never writes | the pull request's most recent commit, or the default branch for a fork |
 
 Three of the five reach the `AGENTS.md` section, which is why it is the
 doctrine root and why `[bots] codex = false` with `copilot` or `coderabbit` on
-is a `toml-schema` error. Codex and Macroscope each read one surface and nothing
-else, so both carry every doctrine block; the routing table in
+is a `toml-schema` error. Codex and Macroscope are the two that do not: neither
+reads an `AGENTS.md` at all, so a block left out of the one surface this package
+writes for each reaches that bot nowhere, and both carry every block. The
+routing table in
 [schemas/renders.md](schemas/renders.md) is where that lives, one row per block
 and one column per destination.
 
@@ -143,11 +145,15 @@ Codex without passing through doctrine. `check` reports one.
 files beside generated ones. The generator writes only the names the TOML's
 surfaces produce and reads nothing else. Telling the two apart is what the
 marker comment is for, and it is the only test: anything carrying the marker
-that the current TOML does not produce is an orphan, and `check` reports it.
-That is a retired surface's file, a retired bot's, and the `AGENTS.md` region
-when `codex` goes false. An unmarked file at one of those paths is the repo's
-own, whatever the flags say, and `adopt` is how one becomes managed. Retiring a
-surface or a bot otherwise leaves a file every bot keeps loading.
+that the current TOML does not produce is an orphan. That is a retired surface's
+file, a retired bot's, and the `AGENTS.md` region when `codex` goes false. An
+unmarked file at one of those paths is the repo's own, whatever the flags say,
+and `adopt` is how one becomes managed.
+
+**Retiring one is delete-then-render, in that order**, because `render` fails on
+an orphan rather than creating one. `check` catches a retirement that skipped
+the render; it is not the normal path. `validators.md` § `orphan` carries the
+order and what deleting the `AGENTS.md` region means.
 
 **Every open is contained, and the rule is about opens rather than about
 outputs.** Resolving a path, checking it, then opening it proves the property
@@ -201,31 +207,37 @@ whose merge gate consumes bot output has to do instead:
 - Run `check` in CI from the default branch's copy of this package, never from
   the pull request's checkout: a workflow that checks out the default branch
   for the generator and validators, then points them at the pull request's
-  tree, passing `--doctrine` for the doctrine source in that tree. Inputs come
+  tree, passing `--spec` for the package copy in that tree. Inputs come
   from the tree under judgment, because a legitimate doctrine or TOML change has
   to be able to land; the trusted checkout supplies the code. What that buys is
   that a tampered generator cannot report a clean render. It does not and cannot
   stop a policy change, which is what the approval rule above is for.
 
+**The render inputs**, which is every path a render reads. This is the one
+statement of the set: the marker names them, `check --staged` reads each from
+the index, every one is under the open rule above, and the policy set below
+contains them.
+
+- `bot-instructions.toml`.
+- The spec copy's doctrine source and routing table.
+- `.bot-instructions/coderabbit-schema.json`, when `[bots] coderabbit` is true.
+- The resolved install manifest, when `[exclusions] derive_render` is true.
+- The existing `AGENTS.md`, when `[bots] codex` is true.
+
 **The policy set**, which is every path whose bytes decide what a bot is told or
 whether a render validates. This list is the one statement of it; the checklist
 line points here rather than repeating it, so the two cannot drift.
 
-- `bot-instructions.toml`.
-- The doctrine source.
+- Every render input above.
 - Every generated path.
 - Every `AGENTS.md` in the repo. Codex reads the nearest nested one, so a file
   the root render never touches still reaches it.
-- `.bot-instructions/coderabbit-schema.json`, the vendored CodeRabbit schema.
-  Loosening it — dropping the `tone_instructions` cap, dropping the root
-  `additionalProperties: false` — turns `coderabbit-schema` green on a file
-  CodeRabbit discards whole, and it stays green on every later pull request.
-- The resolved install manifest when `[exclusions] derive_render` is true. It
-  decides which trees leave review scope, and `exclusion-consistency` derives
-  both sides of its comparison from it.
-- Every file under `.github/instructions/` and `.macroscope/correctness/`,
-  marked or not. Copilot and Macroscope load an unmarked file from the head just
-  as readily as a generated one, and nothing else here judges it.
+- Every file under `.github/instructions/`, `.macroscope/correctness/`,
+  `.macroscope/check-run-agents/`, and `.macroscope/approvability.md`, marked or
+  not. Copilot and Macroscope load an unmarked file from those just as readily
+  as a generated one, and nothing else here judges it. The last two this package
+  never writes at all, which makes them unmanaged surfaces rather than
+  unmanaged files.
 - Any repo-wide reviewer file the repo keeps by hand. § Adding a repo says what
   becomes of one.
 
@@ -255,13 +267,16 @@ and it is the reason the version is in the marker at all.
 
 ## Doctrine
 
-The generator reads doctrine from a **doctrine source**: a SKILL.md carrying
-this section. It defaults to the running copy's own, and `--doctrine <path>`
-names another, which is what lets a trusted checkout render a tree whose
-doctrine has moved. The marker records the version from the doctrine source's
-frontmatter, not the running copy's, and a doctrine source with no readable
-version is an error — otherwise a doctrine change would land under a stamp
-naming doctrine it does not carry.
+The generator reads doctrine from a **spec copy**: a copy of this package, whose
+`SKILL.md` carries this section and whose `schemas/renders.md` carries the
+routing table. It defaults to the running copy, and `--spec <path>` names
+another, which is what lets a trusted checkout render a tree whose doctrine has
+moved. One flag for both files because they are one set: `doctrine-routing`
+holds the headings here to the rows there, so reading them from different
+copies would red on every legitimate doctrine change. The marker records the
+version from the spec copy's frontmatter, not the running copy's, and a spec
+copy with no readable version is an error — otherwise a doctrine change would
+land under a stamp naming doctrine it does not carry.
 
 The generator locates exactly one `## Doctrine` section in the doctrine source.
 Zero sections, or more than one, is an error rather than a guess. Blocks are the
@@ -354,9 +369,14 @@ recommend parsing them.
    and is a policy path. Read both lists against the TOML: a claim in one of
    those files that the TOML does not carry is about to be deleted, or to go on
    steering reviews from outside the package.
-3. Run `render`, then read the diff. Doctrine text appearing for the first time
+3. If `[bots] coderabbit` is true, put CodeRabbit's published schema at
+   `.bot-instructions/coderabbit-schema.json`. No verb writes it and
+   `coderabbit-schema` fails without it, deliberately: a validator that skipped
+   on a missing schema would be silent for the life of the repo, which is the
+   failure it exists to catch.
+4. Run `render`, then read the diff. Doctrine text appearing for the first time
    is expected; a repo-specific claim disappearing means it never made it into
    the TOML.
-4. Work [references/checklist.md](references/checklist.md). Every bot has at
+5. Work [references/checklist.md](references/checklist.md). Every bot has at
    least one setting no file can express, and a bot whose install or enablement
    step is skipped reviews nothing while every file below looks correct.

--- a/skills/bot-instructions/SKILL.md
+++ b/skills/bot-instructions/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: bot-instructions
-description: "Load to change what the GitHub review bots are told, or to add, render, or validate a repo's bot-instruction files."
-summary: "One doctrine source plus a per-repo TOML renders every GitHub review bot's native instruction file: AGENTS.md § Code Review Rules for Codex, Copilot repo-wide and path-scoped instructions, a full-state .coderabbit.yaml, .pr_agent.toml with best_practices.md, and a .macroscope tree. Validators cover the surfaces that fail silently."
+description: "Load to read the bot-instructions specification: the shared review doctrine, the per-repo TOML schema, the per-surface render rules, and the validators. The generator these describe is not built yet."
+summary: "Specification for a package that renders every GitHub review bot's native instruction file from one doctrine source plus a per-repo TOML: AGENTS.md § Code Review Rules for Codex, Copilot repo-wide and path-scoped instructions, a full-state .coderabbit.yaml, .pr_agent.toml with best_practices.md, and a .macroscope tree, with validators for the surfaces that fail silently. The generator is not built yet."
 license: MIT
-user-invocable: true
+user-invocable: false
 metadata:
   author: vanillagreen
   source: kendex
@@ -16,6 +16,13 @@ tags: [review]
 # Bot Instructions
 
 > **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
+
+> **This package is a specification, not working software.** There is no
+> `scripts/` directory and none of the verbs below exist yet. Every command,
+> validator and render rule here is the contract the generator will be built
+> against. Until it lands, loading this skill tells you what the files should
+> say; it does not give you anything to run, which is why the package is not
+> user-invocable.
 
 Five review bots read four incompatible instruction files, and no two of them
 agree on where guidance goes. Written by hand, one repo's doctrine drifts from
@@ -93,11 +100,14 @@ The generator offers three verbs.
 - `render` writes every enabled surface from doctrine plus the repo TOML, after
   validating what it built. It builds and validates in a scratch tree first, so
   a validator failure leaves the repo untouched; a failure during the write
-  phase is reported naming every path already replaced. The validators that
-  judge repository state rather than emitted bytes read the repo, before the
-  write, so a render that would orphan a file fails instead of reporting a
-  clean pass and then orphaning it. `schemas/validators.md` § Where these run
-  is the split.
+  phase is reported naming every path already replaced. `AGENTS.md` is the
+  exception to scratch-then-replace, because it is the one output whose
+  non-owned bytes belong to the repo: what the build produces is the region's
+  body, and the write splices it into the file's bytes read at write time.
+  The validators that judge repository state rather than emitted bytes read the
+  repo, before the write, so a render that would orphan a file fails instead of
+  reporting a clean pass and then orphaning it. `schemas/validators.md` § Where
+  these run is the split.
 - `check` re-renders and compares. It reads the working tree by default; under
   `--staged` it reads the index, for every render input as well as the outputs,
   so a pre-commit lane judges one coherent staged state. Any difference is a
@@ -139,8 +149,17 @@ when `codex` goes false. An unmarked file at one of those paths is the repo's
 own, whatever the flags say, and `adopt` is how one becomes managed. Retiring a
 surface or a bot otherwise leaves a file every bot keeps loading.
 
-Every output path is resolved before it is written and refused when any
-component is a symlink or when the resolved path leaves the repo root.
+**Symlinks are refused at open time, not before it.** Resolving a path, checking
+it, then opening it proves the property about the path and not about the file
+the write lands on. So every output is created or replaced without following a
+final symlink, with containment inside the repo root re-checked on the file that
+was actually opened, and every input is read the same way:
+`bot-instructions.toml`, the doctrine source, the resolved install manifest, the
+vendored schema, and the existing `AGENTS.md`. Inputs matter as much as outputs
+here, because the posture this package prescribes points a trusted generator at
+an untrusted tree, and an input's contents reach rendered output and a `check`
+finding. This repo's own convention is the precedent: it opens without following
+and re-checks the opened file rather than the name.
 
 ## A pull request changing its own review
 
@@ -153,8 +172,7 @@ the change in the diff is not a trust boundary.
 No repo file can close that, and this package does not claim to. What a repo
 whose merge gate consumes bot output has to do instead:
 
-- Treat `bot-instructions.toml`, the doctrine source, every generated path, and
-  every `AGENTS.md` in the repo as policy paths. A push touching one
+- Treat every path in the policy set below as a policy path. A push touching one
   invalidates review evidence gathered before it, so the deciding review is the
   one that ran after the policy change was visible.
 - Require a trusted human approval on a pull request that touches a policy
@@ -163,11 +181,33 @@ whose merge gate consumes bot output has to do instead:
 - Run `check` in CI from the default branch's copy of this package, never from
   the pull request's checkout: a workflow that checks out the default branch
   for the generator and validators, then points them at the pull request's
-  tree. It reads the pull request's TOML and doctrine source, because a
-  legitimate doctrine change has to be able to land. What the trusted checkout
-  buys is that a tampered generator cannot report a clean render; it does not
-  and cannot stop a policy change, which is what the approval rule above is
-  for.
+  tree, passing `--doctrine` for the doctrine source in that tree. Inputs come
+  from the tree under judgment, because a legitimate doctrine or TOML change has
+  to be able to land; the trusted checkout supplies the code. What that buys is
+  that a tampered generator cannot report a clean render. It does not and cannot
+  stop a policy change, which is what the approval rule above is for.
+
+**The policy set**, which is every path whose bytes decide what a bot is told or
+whether a render validates. This list is the one statement of it; the checklist
+line points here rather than repeating it, so the two cannot drift.
+
+- `bot-instructions.toml`.
+- The doctrine source.
+- Every generated path.
+- Every `AGENTS.md` in the repo. Codex reads the nearest nested one, so a file
+  the root render never touches still reaches it.
+- `.bot-instructions/coderabbit-schema.json`, the vendored CodeRabbit schema.
+  Loosening it — dropping the `tone_instructions` cap, dropping the root
+  `additionalProperties: false` — turns `coderabbit-schema` green on a file
+  CodeRabbit discards whole, and it stays green on every later pull request.
+- The resolved install manifest when `[exclusions] derive_render` is true. It
+  decides which trees leave review scope, and `exclusion-consistency` derives
+  both sides of its comparison from it.
+- Every file under `.github/instructions/` and `.macroscope/correctness/`,
+  marked or not. Copilot and Macroscope load an unmarked file from the head just
+  as readily as a generated one, and nothing else here judges it.
+- Any repo-wide reviewer file the repo keeps by hand. § Adding a repo says what
+  becomes of one.
 
 Two asymmetries are worth knowing. Macroscope reads the default branch for a
 fork pull request, so a fork cannot weaken its own review the way a branch
@@ -195,8 +235,16 @@ and it is the reason the version is in the marker at all.
 
 ## Doctrine
 
-The generator locates exactly one `## Doctrine` section in this file. Zero
-sections, or more than one, is an error rather than a guess. Blocks are the
+The generator reads doctrine from a **doctrine source**: a SKILL.md carrying
+this section. It defaults to the running copy's own, and `--doctrine <path>`
+names another, which is what lets a trusted checkout render a tree whose
+doctrine has moved. The marker records the version from the doctrine source's
+frontmatter, not the running copy's, and a doctrine source with no readable
+version is an error — otherwise a doctrine change would land under a stamp
+naming doctrine it does not carry.
+
+The generator locates exactly one `## Doctrine` section in the doctrine source.
+Zero sections, or more than one, is an error rather than a guess. Blocks are the
 `###` headings inside that section, each sliced from its heading to the next
 heading at that level or above, still inside the section. A repeated block id
 inside the section is an error, and a heading found outside the section is not
@@ -277,9 +325,15 @@ recommend parsing them.
    file is the source for its `[[surface]]` blocks and exclusions: read it,
    move its repo-specific claims into the TOML, and let doctrine carry the
    rest.
-2. Run `adopt`, which names every existing file it is taking over. Read that
-   list against the TOML: a claim in one of those files that the TOML does not
-   carry is about to be deleted.
+2. Run `adopt`, which names every existing file it is taking over, and every
+   repo-root or `.github/` markdown file those files point at. That second list
+   is where a repo-wide hand-written reviewer file shows up — the kind that
+   restates doctrine and carries an accepted-trade-off list, reached only
+   because `AGENTS.md` and the Copilot file name it. Fold what it holds into
+   `[doctrine.append]` and `[[surface]]`; what will not fold stays hand-written
+   and is a policy path. Read both lists against the TOML: a claim in one of
+   those files that the TOML does not carry is about to be deleted, or to go on
+   steering reviews from outside the package.
 3. Run `render`, then read the diff. Doctrine text appearing for the first time
    is expected; a repo-specific claim disappearing means it never made it into
    the TOML.

--- a/skills/bot-instructions/SKILL.md
+++ b/skills/bot-instructions/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: bot-instructions
+description: "Load to change what the GitHub review bots are told, or to add, render, or validate a repo's bot-instruction files."
+summary: "One doctrine source plus a per-repo TOML renders every GitHub review bot's native instruction file: AGENTS.md § Code Review Rules for Codex, Copilot repo-wide and path-scoped instructions, a full-state .coderabbit.yaml, .pr_agent.toml with best_practices.md, and a .macroscope tree. Validators cover the surfaces that fail silently."
+license: MIT
+user-invocable: true
+metadata:
+  author: vanillagreen
+  source: kendex
+  repository: "https://github.com/vanillagreencom/kendex"
+  bugs: "https://github.com/vanillagreencom/kendex/issues"
+  version: "0.1.0"
+tags: [review]
+---
+
+# Bot Instructions
+
+> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
+
+Five review bots read four incompatible instruction files, and no two of them
+agree on where guidance goes. Written by hand, one repo's doctrine drifts from
+the next repo's, and an exclusion list falls behind the tree it excludes
+without anything saying so.
+
+This package holds the doctrine once. A per-repo TOML says what is true about
+that repo, and the generator writes each bot's native file from the pair. The
+rendered files are outputs: a hand edit to one is erased by the next render,
+and the drift validator reds before that happens.
+
+## What reads what
+
+| Bot | Reads | Reads from |
+|-----|-------|-----------|
+| Codex | `AGENTS.md` § Code Review Rules, root plus nearest nested | undocumented |
+| Copilot code review | `.github/copilot-instructions.md`, `.github/instructions/**/*.instructions.md`, `AGENTS.md` | the pull request head |
+| CodeRabbit | `.coderabbit.yaml`, whole-file, beneath any organization or workspace global override | the pull request head |
+| Qodo | `.pr_agent.toml`, `best_practices.md`, `REVIEW.md` | the default branch root |
+| Macroscope | `.macroscope/ignore.md`, `.macroscope/correctness/*.md` | the pull request's most recent commit, or the default branch for a fork |
+
+Verified caps, enum values and read semantics are in
+[references/limits.md](references/limits.md), each with the vendor page that
+states it, and each claim resting on fleet experience rather than a vendor page
+is labeled there as such. Nothing in the generator holds a limit that file does
+not carry.
+
+## The pieces
+
+```
+doctrine (§ Doctrine below)     the rules that must reach two or more bots
+bot-instructions.toml           one per repo, at the repo root
+  ├─ [repo]                     what this repo is, in the bots' own words
+  ├─ [bots]                     which bot capabilities are live here
+  ├─ [cadence]                  when each bot re-reviews
+  ├─ [exclusions]               what is not this repo's code to fix
+  ├─ [[surface]]                a path set and what a reviewer must know there
+  └─ [doctrine]                 per-repo additions to a doctrine block
+        │
+        ▼  render
+AGENTS.md § Code Review Rules   .coderabbit.yaml
+.github/copilot-instructions.md .pr_agent.toml + best_practices.md
+.github/instructions/*.md       .macroscope/
+```
+
+A `[[surface]]` is authored once and reaches three bots: a Copilot
+`.instructions.md` file scoped by `applyTo`, a CodeRabbit `path_instructions`
+entry, and a Macroscope `correctness/` file scoped by `include`. Qodo has no
+per-path instruction mechanism, so surface text reaches it through
+`best_practices.md`.
+
+Authored once does not mean matched identically. Only Macroscope has a
+subtraction key, so `exclude_globs` is real scoping there and prose everywhere
+else. Where exact scoping matters, narrow `globs` rather than relying on
+`exclude_globs`. [schemas/renders.md](schemas/renders.md) states which
+mechanism each surface actually gets.
+
+The per-file render rules, including every escaping and ordering decision, are
+in [schemas/renders.md](schemas/renders.md). The TOML's keys and their types
+are in [schemas/repo-toml.md](schemas/repo-toml.md). What each validator
+rejects, and the silent failure it exists to catch, is in
+[schemas/validators.md](schemas/validators.md).
+
+## Commands
+
+The generator offers three verbs.
+
+- `render` writes every enabled surface from doctrine plus the repo TOML, after
+  validating what it built. It builds and validates in a scratch tree first, so
+  a validator failure leaves the repo untouched; a failure during the write
+  phase is reported naming every path already replaced.
+- `check` re-renders and compares. It reads the working tree by default and the
+  index under `--staged`. Any difference is a finding naming the path and the
+  differing region.
+- `adopt` is the one-time verb for a repo that already has hand-written bot
+  files. `render` refuses to replace a file at a generated path that does not
+  carry this package's marker; `adopt` takes such a file over, printing what it
+  replaced so the diff shows the content that has to survive in the TOML.
+
+There is no install-time placement step, no overwrite prompt, and no merge of
+hand edits back into doctrine. A generated file is either byte-identical to its
+render or a `check` finding.
+
+A render holds a lock file for its duration and a second concurrent render
+refuses, because two renders interleaving their writes produce a tree neither
+validated.
+
+## Rendering into a file this package does not own
+
+`AGENTS.md` is the repo's own instruction file, written for working agents. The
+generator owns exactly the slice from the `## Code Review Rules` heading to the
+next heading at that level or above, and never the rest, and it opens that slice
+with the marker so the region is as identifiable as a whole file. It never
+creates `AGENTS.md` and never adds the heading: a repo without that section is
+an error telling the author to add the heading and render again.
+
+Codex also reads the nearest nested `AGENTS.md` covering each changed file. The
+generator writes only the root section, so a nested `AGENTS.md` carrying a
+`## Code Review Rules` section is an unmanaged instruction surface that reaches
+Codex without passing through doctrine. `check` reports one.
+
+`.github/instructions/` and `.macroscope/correctness/` may hold hand-written
+files beside generated ones. The generator writes only the names the TOML's
+surfaces produce and reads nothing else. Telling the two apart is what the
+marker comment is for: a file at a generated path carrying the marker but
+produced by no current surface, or belonging to a bot the TOML has switched
+off, is an orphan, and `check` reports it. Retiring a surface or a bot
+otherwise leaves a file every bot keeps loading.
+
+Every output path is resolved before it is written and refused when any
+component is a symlink or when the resolved path leaves the repo root.
+
+## A pull request changing its own review
+
+Copilot, CodeRabbit and Macroscope read their instruction files from the pull
+request's own head. A pull request that edits a generated file, the doctrine
+source, the TOML, or the generator changes the review that pull request
+receives, and a re-render makes `check` pass on the weakened policy. Showing
+the change in the diff is not a trust boundary.
+
+No repo file can close that, and this package does not claim to. What a repo
+whose merge gate consumes bot output has to do instead:
+
+- Treat `bot-instructions.toml`, the doctrine source, every generated path, and
+  every `AGENTS.md` in the repo as policy paths. A push touching one
+  invalidates review evidence gathered before it, so the deciding review is the
+  one that ran after the policy change was visible.
+- Require a trusted human approval on a pull request that touches a policy
+  path. Bot evidence gathered under head-branch policy the same pull request
+  wrote is not evidence.
+- Run `check` in CI from the default branch's copy of this package, never from
+  the pull request's checkout: a workflow that checks out the default branch
+  for the generator and validators, then points them at the pull request's
+  tree. It reads the pull request's TOML and doctrine source, because a
+  legitimate doctrine change has to be able to land. What the trusted checkout
+  buys is that a tampered generator cannot report a clean render; it does not
+  and cannot stop a policy change, which is what the approval rule above is
+  for.
+
+Two asymmetries are worth knowing. Macroscope reads the default branch for a
+fork pull request, so a fork cannot weaken its own review the way a branch
+pull request can. And an organization or workspace CodeRabbit override outranks
+the repo file entirely, which is the same problem from the other side: a
+setting the repo cannot see decides what the repo's file means.
+
+## What "shared doctrine" does and does not mean
+
+The generator reads the doctrine source from this package as installed in the
+consuming repo, so a repo running an older installed copy renders older
+doctrine, and both `render` and `check` pass. Nothing here compares one repo's
+doctrine against another's.
+
+What makes the staleness visible is the marker: it names this package and its
+version, so a version bump re-renders every file in that repo and the diff says
+which doctrine the repo is now on. A fleet-wide doctrine change is therefore an
+update of this package in each repo followed by a render, and the repos that
+have not done it are the ones whose marker still names the old version.
+
+That only works if a doctrine edit ships a version bump. Nothing in a consuming
+repo can check it, because a consumer sees one version and has nothing to
+compare it against; the rule belongs to the repo that publishes this package,
+and it is the reason the version is in the marker at all.
+
+## Doctrine
+
+The generator locates exactly one `## Doctrine` section in this file. Zero
+sections, or more than one, is an error rather than a guess. Blocks are the
+`###` headings inside that section, each sliced from its heading to the next
+heading at that level or above, still inside the section. A repeated block id
+inside the section is an error, and a heading found outside the section is not
+doctrine whatever it is named. That rule is what makes the parse safe against a
+project-instructions block a harness injected after the frontmatter.
+
+Block ids are frozen: `schemas/renders.md` names blocks by id, and a rename is
+a breaking change to every render.
+
+A block reaches a surface as prose. Nothing in a block may carry markdown a
+YAML or TOML scalar cannot hold verbatim, and nothing in it names a repo, a
+path, or an issue. Repo-specific text belongs in the TOML.
+
+### scope
+
+Raise a defect in the lines this pull request changed, or one those lines
+directly break. Correctness, security, data loss, and a fail-open path in gate,
+guard, or CI code are the classes that matter. Anything outside the diff and
+its direct blast radius is out of scope, including a scope observation about a
+file the pull request body already names as deliberate.
+
+### rounds
+
+Surface everything you have about the current diff in one round. A finding held
+back for the next round costs a full re-review cycle, and these pull requests
+are pushed at agent speed. One comment per root cause, naming every affected
+site in that comment, rather than one comment per site.
+
+### severity
+
+Mark a finding blocking only if you would stop a colleague's merge for it.
+Everything else is a suggestion. Batch suggestions, and omit them on a
+re-review round whose diff is a one-line fix. Naming a finding's severity
+honestly is worth more than raising it: a confident wrong finding costs more
+than a hedged one.
+
+### no-preferences
+
+Style, wording, naming, and comment phrasing are not findings here. Neither is
+speculative hardening on a path that already fails closed. Formatting and lint
+belong to CI. Ask for test coverage only where the diff changes behavior no
+test exercises, and then say which behavior, in one comment.
+
+### declined
+
+A finding class answered on this pull request with a stated decline is settled.
+Do not raise it again on a later round unless the relevant code changed since.
+The same holds for a class the repo has recorded as an accepted trade-off in
+its own instruction files: read those before asserting a rule.
+
+### reply-contract
+
+Author replies are `Fixed in <sha>`, `Declined: <reason>`, or
+`Tracked: <issue>`. A decline names the passing state or the false premise it
+disproves, and a label alone is not a reason. A merge gate reading these
+replies rejects a tracking claim naming no issue, and a decline whose reason is
+nothing but a label it knows.
+
+### render-out-of-scope
+
+A tracked tree this repo renders from an upstream package is not this repo's
+code. A review comment on it cannot be acted on here: the fix lands upstream
+and arrives by re-render, and an in-repo edit is erased. Report nothing on
+those paths, on any surface, in any round. The repo's own instruction file
+names which trees these are.
+
+### trust-model
+
+Review evidence is a formal review object from a trusted login, or another
+evidence form the repo's gate configuration names. Comment text, emoji
+reactions, and approvals spelled in prose are never approval, by design. Do not
+recommend parsing them.
+
+## Adding a repo
+
+1. Write `bot-instructions.toml` at the repo root per
+   [schemas/repo-toml.md](schemas/repo-toml.md). An existing hand-written bot
+   file is the source for its `[[surface]]` blocks and exclusions: read it,
+   move its repo-specific claims into the TOML, and let doctrine carry the
+   rest.
+2. Run `adopt`, which names every existing file it is taking over. Read that
+   list against the TOML: a claim in one of those files that the TOML does not
+   carry is about to be deleted.
+3. Run `render`, then read the diff. Doctrine text appearing for the first time
+   is expected; a repo-specific claim disappearing means it never made it into
+   the TOML.
+4. Work [references/checklist.md](references/checklist.md). Every bot has at
+   least one setting no file can express, and a bot whose install or enablement
+   step is skipped reviews nothing while every file below looks correct.

--- a/skills/bot-instructions/SKILL.md
+++ b/skills/bot-instructions/SKILL.md
@@ -143,9 +143,11 @@ generator owns exactly the slice from the `## Code Review Rules` heading to the
 next heading at that level or above, and never the rest, and it opens that slice
 with the marker so the region is as identifiable as a whole file. It never
 creates `AGENTS.md` and never adds the heading: a repo without that section is
-an error telling the author to add the heading, `adopt`, then render. The
-`adopt` step is not optional there — a hand-added heading is an unmarked region
-at a generated path, which is exactly what `render` refuses.
+an error telling the author to add the heading, set `[bots] codex`, `adopt`,
+then render. The flag comes before the `adopt` because `adopt` takes a region
+over only for a capability that is on, and the `adopt` is not optional because a
+hand-added heading is an unmarked region at a generated path, which is exactly
+what `render` refuses.
 
 Codex also reads the nearest nested `AGENTS.md` covering each changed file. The
 generator writes only the root section, so a nested `AGENTS.md` carrying a
@@ -407,7 +409,8 @@ recommend parsing them.
 ## Adding a repo
 
 The procedure is [references/checklist.md](references/checklist.md) § Adding a
-repo, beside the settings work it runs into. It is six steps, and the two worth
-knowing before you start are that a repo with `[bots] codex` adds the
-`## Code Review Rules` heading by hand before `adopt`, and that `adopt` is what
-makes both that region and any existing bot file managed.
+repo, beside the settings work it runs into, and it derives its order from
+`toml-schema`'s cross-flag clauses and `adopt`'s rule rather than restating one.
+The shape worth knowing before you start: nothing that depends on a flag is
+written before the flag, so a capability's surfaces, `adopt` and `render` all
+happen in the pass that turns it on.

--- a/skills/bot-instructions/SKILL.md
+++ b/skills/bot-instructions/SKILL.md
@@ -33,9 +33,16 @@ and the drift validator reds before that happens.
 |-----|-------|-----------|
 | Codex | `AGENTS.md` § Code Review Rules, root plus nearest nested | undocumented |
 | Copilot code review | `.github/copilot-instructions.md`, `.github/instructions/**/*.instructions.md`, `AGENTS.md` | the pull request head |
-| CodeRabbit | `.coderabbit.yaml`, whole-file, beneath any organization or workspace global override | the pull request head |
+| CodeRabbit | `.coderabbit.yaml`, whole-file, beneath any organization or workspace global override, plus `AGENTS.md` through `knowledge_base.code_guidelines.filePatterns` | the pull request head |
 | Qodo | `.pr_agent.toml`, `best_practices.md`, `REVIEW.md` | the default branch root |
-| Macroscope | `.macroscope/ignore.md`, `.macroscope/correctness/*.md` | the pull request's most recent commit, or the default branch for a fork |
+| Macroscope | `.macroscope/ignore.md`, `.macroscope/correctness/*.md`, and nothing else | the pull request's most recent commit, or the default branch for a fork |
+
+Three of the five reach the `AGENTS.md` section, which is why it is the
+doctrine root and why `[bots] codex = false` with `copilot` or `coderabbit` on
+is a `toml-schema` error. Codex and Macroscope each read one surface and nothing
+else, so both carry every doctrine block; the routing table in
+[schemas/renders.md](schemas/renders.md) is where that lives, one row per block
+and one column per destination.
 
 Verified caps, enum values and read semantics are in
 [references/limits.md](references/limits.md), each with the vendor page that
@@ -120,10 +127,12 @@ Codex without passing through doctrine. `check` reports one.
 `.github/instructions/` and `.macroscope/correctness/` may hold hand-written
 files beside generated ones. The generator writes only the names the TOML's
 surfaces produce and reads nothing else. Telling the two apart is what the
-marker comment is for: a file at a generated path carrying the marker but
-produced by no current surface, or belonging to a bot the TOML has switched
-off, is an orphan, and `check` reports it. Retiring a surface or a bot
-otherwise leaves a file every bot keeps loading.
+marker comment is for, and it is the only test: anything carrying the marker
+that the current TOML does not produce is an orphan, and `check` reports it.
+That is a retired surface's file, a retired bot's, and the `AGENTS.md` region
+when `codex` goes false. An unmarked file at one of those paths is the repo's
+own, whatever the flags say, and `adopt` is how one becomes managed. Retiring a
+surface or a bot otherwise leaves a file every bot keeps loading.
 
 Every output path is resolved before it is written and refused when any
 component is a symlink or when the resolved path leaves the repo root.

--- a/skills/bot-instructions/SKILL.md
+++ b/skills/bot-instructions/SKILL.md
@@ -149,17 +149,37 @@ when `codex` goes false. An unmarked file at one of those paths is the repo's
 own, whatever the flags say, and `adopt` is how one becomes managed. Retiring a
 surface or a bot otherwise leaves a file every bot keeps loading.
 
-**Symlinks are refused at open time, not before it.** Resolving a path, checking
-it, then opening it proves the property about the path and not about the file
-the write lands on. So every output is created or replaced without following a
-final symlink, with containment inside the repo root re-checked on the file that
-was actually opened, and every input is read the same way:
-`bot-instructions.toml`, the doctrine source, the resolved install manifest, the
-vendored schema, and the existing `AGENTS.md`. Inputs matter as much as outputs
-here, because the posture this package prescribes points a trusted generator at
-an untrusted tree, and an input's contents reach rendered output and a `check`
-finding. This repo's own convention is the precedent: it opens without following
-and re-checks the opened file rather than the name.
+**Every open is contained, and the rule is about opens rather than about
+outputs.** Resolving a path, checking it, then opening it proves the property
+about the name and not about the file the open lands on, so the property is held
+at the open. Two halves, and both are needed:
+
+- **No component may redirect.** Walking from a repo-root descriptor, each
+  component is opened relative to the previous one with directory and no-follow
+  flags. A symlink anywhere in the path fails, not only a final one: with
+  `.github/instructions` a symlink out of the tree, refusing only the last
+  component creates or truncates a file outside the repo root and any check
+  after that fires too late. Containment is then a property of how the
+  descriptor was reached rather than something re-derived from the opened file,
+  which is what makes it checkable at all — re-deriving a path from a descriptor
+  needs a different mechanism on each platform this repo targets.
+- **Every open, not every write.** `render` writes, but `check` mostly reads:
+  `drift` opens each path the TOML produces, `orphan` walks
+  `.github/instructions/**` and `.macroscope/correctness/**` testing each file
+  for the marker, `agents-section` walks the repo for nested `AGENTS.md`, and
+  `adopt` opens the markdown files the ones it takes over point at. Those sets
+  are named by the tree under judgment. A symlink at any of those paths is
+  followed by a trusted reader, and its bytes are quoted into a `check` finding
+  in a CI log — a disclosure route no write-side rule covers, because nothing is
+  written.
+
+A path that fails is a finding naming the path, and a `check` finding never
+quotes a region out of a file that failed the open: what gets reported is the
+containment failure, not the contents.
+
+This repo's own convention is the precedent for the no-follow half — it opens
+without following and re-checks the opened file's type rather than the name. The
+walk from a root descriptor is the part it does not have.
 
 ## A pull request changing its own review
 

--- a/skills/bot-instructions/SKILL.md
+++ b/skills/bot-instructions/SKILL.md
@@ -228,7 +228,12 @@ below contains them.
 - `bot-instructions.toml`.
 - The spec copy's doctrine source and routing table.
 - `.bot-instructions/coderabbit-schema.json`, when `[bots] coderabbit` is true.
-- The resolved install manifest, when `[exclusions] derive_render` is true.
+- Both install manifests, when `[exclusions] derive_render` is true. It is a pair
+  rather than one file: the root `kendex.toml` is always read, because whether
+  it declares `is_source_catalog` is what decides where install state lives, and
+  `kendex-local.toml` is read as well when it does. Naming only the resolved one
+  would leave a staged lane reading routing bytes from the worktree and install
+  state from the index, judging a state nobody is committing.
 - The existing `AGENTS.md`, when `[bots] codex` is true.
 
 What a repo-state validator walks is deliberately not in that set: `orphan`'s

--- a/skills/bot-instructions/references/checklist.md
+++ b/skills/bot-instructions/references/checklist.md
@@ -63,8 +63,8 @@ doctrine block rather than a subset.
 - [ ] `@coderabbitai configuration` has been run once on a pull request and its
       resolved output matches the committed file. This is the only way to
       confirm the file was accepted rather than discarded.
-- [ ] The vendored schema copy the validator reads is current, and the repo
-      knows where it came from and how to refresh it. A stale copy rejects a
+- [ ] `.bot-instructions/coderabbit-schema.json` is current, and the repo knows
+      where it came from and how to refresh it. A stale copy rejects a
       newly valid file, and a copy carrying a JSON Schema keyword the validator
       does not implement blocks every render until the validator is updated.
 - [ ] Integrations the repo wants (Linear, Jira) are authorized. The file names
@@ -109,6 +109,14 @@ can still change what the file means.
       line inside an HTML comment on the assumption that anything else would be
       read as a pattern. Confirm once that the exclusions took effect.
 
+## If the repo's kendex.toml is a source catalog
+
+- [ ] `[exclusions] derive_render` reads the manifest kendex resolves, which in
+      a repo whose `kendex.toml` declares `is_source_catalog = true` is the
+      sibling `kendex-local.toml`. Confirm the rendered exclusion list actually
+      names the repo's rendered skill trees. An empty list here is the failure
+      this line exists to catch, not a repo with nothing to exclude.
+
 ## Glob dialect
 
 - [ ] An exclusion took effect on Copilot, on Qodo and on Macroscope. The
@@ -135,9 +143,13 @@ can still change what the file means.
 
 ## If the repo's gate reads bot output
 
-- [ ] `bot-instructions.toml`, the doctrine source, and every generated path
-      are policy paths in the repo's gate: a push touching one invalidates
-      review evidence gathered before it.
+- [ ] Every path in SKILL.md § A pull request changing its own review's policy
+      set is a policy path in the repo's gate: a push touching one invalidates
+      review evidence gathered before it. Work from that list rather than from a
+      copy of it — it is longer than the obvious four, and a copy here would
+      drift from it. In this repo it is what feeds
+      `REVIEW_GATE_CARRY_FORWARD_EXCLUDE`, which the gate reads from the default
+      branch and so cannot be widened by the pull request under judgment.
 - [ ] A pull request touching a policy path needs a trusted human approval. Bot
       evidence gathered under head-branch policy that same pull request wrote is
       not evidence.

--- a/skills/bot-instructions/references/checklist.md
+++ b/skills/bot-instructions/references/checklist.md
@@ -2,54 +2,74 @@
 
 ## Adding a repo
 
-Two passes, and the first one deliberately renders nothing.
+Two passes. The order is not a preference — `toml-schema`'s cross-flag clauses
+and `adopt`'s own rule fix it, and a sequence that ignores them writes a TOML
+that does not validate.
 
-**Pass one, staging.** The `[bots]` flags start false, so this pass produces a
-committed `bot-instructions.toml` and no instruction files. That is the point:
-a repo commits its intent before any vendor setting exists to honour it, and a
-flag turned on ahead of its settings work renders a file the bot is not yet
-reading.
+**What those clauses require, since everything below follows from them.** A
+`[[surface]]` set needs at least one of `copilot`, `coderabbit`, `macroscope` or
+`qodo_best_practices` on, because those four are every route surface text has.
+`copilot` or `coderabbit` needs `codex`, because the `AGENTS.md` section is
+where both get most of their doctrine. `qodo_best_practices` and
+`qodo_review_md` need `qodo`. And `adopt` takes a file or region over only for a
+capability that is on. So **capability-dependent content lands with its
+capability**, and nothing that depends on a flag is written before the flag.
 
-1. Write `bot-instructions.toml` at the repo root per
-   [schemas/repo-toml.md](../schemas/repo-toml.md). An existing hand-written bot
-   file is the source for its `[[surface]]` blocks and exclusions: read it,
-   move its repo-specific claims into the TOML, and let doctrine carry the
-   rest. Leave every `[bots]` flag false.
-2. Run `adopt`, which names every existing file and region it is taking over,
-   and every repo-root or `.github/` markdown file those files point at. That
-   second list is where a repo-wide hand-written reviewer file shows up — one
-   that restates doctrine and carries an accepted-trade-off list, reached only
-   because `AGENTS.md` and the Copilot file name it. Fold what it holds into
-   `[doctrine.append]` and `[[surface]]`; what will not fold stays hand-written
-   and is a policy path. Read both lists against the TOML: a claim in one of
-   those files that the TOML does not carry is about to be deleted, or to go on
-   steering reviews from outside the package.
-3. Run `render`. It writes nothing and says so, because every flag is off. A
-   no-op here is the staging point, not a finished install.
+**Pass one, the repo-wide TOML.** `[repo]`, `[exclusions]`, `[cadence]`,
+`[tone]`, `[budgets]` and any `[doctrine.*]` overrides, with every `[bots]` flag
+false and no `[[surface]]` entries.
 
-**Pass two, per capability.** Work one bot at a time, and finish each before
-starting the next, so a failure names the bot that caused it.
+1. Read the repo's existing hand-written bot files now and plan where their
+   claims go: which become `[[surface]]` entries, which become
+   `[doctrine.append]`, which will not fold and stay hand-written as policy
+   paths. Write the repo-wide tables; leave the surfaces for the pass that turns
+   on a bot able to read them.
+2. Do not run `adopt` here. Nothing can be adopted for a capability that is off,
+   so it would report nothing on exactly the repo this planning is for.
+3. Run `render`. It writes nothing and says so, because every flag is off. The
+   no-op is the staging point, not a finished install — the existing bot files
+   are still the repo's own and still what the bots read.
 
-4. Work that capability's settings below. Every bot has at least one setting no
-   file can express, and a bot whose install or enablement step is skipped
-   reviews nothing while every file in the repo looks correct.
-5. Do the flag's own prerequisite, where it has one. `codex` needs a
-   `## Code Review Rules` heading added to `AGENTS.md` by hand, since the
-   generator never adds it. `coderabbit` needs CodeRabbit's published schema at
+**Pass two, per capability.** Enable `codex` first if this repo wants `copilot`
+or `coderabbit`, and `qodo` before its two sub-flags. Then, one capability at a
+time, finishing each before starting the next so a failure names the bot that
+caused it:
+
+4. Work that capability's settings section below.
+5. Do its prerequisite, where it has one. `codex` needs a `## Code Review Rules`
+   heading added to `AGENTS.md` by hand, since the generator never adds it.
+   `coderabbit` needs CodeRabbit's published schema at
    `.bot-instructions/coderabbit-schema.json`; no verb writes it and
    `coderabbit-schema` fails without it, deliberately, because a validator that
    skipped on a missing schema would be silent for the life of the repo.
    `qodo_review_md` needs the portal toggle already on.
-6. Set the flag, then run `adopt` again if that capability's prerequisite left
-   an unmarked region or the repo already had a file at one of its generated
-   paths, then `render`.
-7. Read the diff. Doctrine text appearing for the first time is expected; a
-   repo-specific claim disappearing means it never made it into the TOML.
-8. Run `check`. Then repeat from step 4 for the next capability.
+6. Set the flag. With the first of `copilot`, `coderabbit`, `macroscope` or
+   `qodo_best_practices`, add the `[[surface]]` entries planned in step 1 — they
+   are legal from that moment and were not before.
+7. Run `adopt`. It can now take over that capability's generated paths, the
+   `AGENTS.md` region the heading opened included, and it names every file and
+   region it takes plus every repo-root or `.github/` markdown file those files
+   point at. That second list is where a repo-wide hand-written reviewer file
+   shows up. Read both against the TOML: a claim in one of those files that the
+   TOML does not carry is about to be deleted, or to go on steering reviews from
+   outside the package.
+8. Run `render`, then read the diff. Doctrine text appearing for the first time
+   is expected; a repo-specific claim disappearing means it never made it into
+   the TOML.
+9. Run `check`. Then repeat from step 4 for the next capability.
 
-The install is finished when every capability the repo wants is on, `check` is
-clean, and the smoke test at the end of this file has seen each enabled bot
-comment. A repo that stops after pass one has staged the work, not done it.
+**Walked end to end, for a repo that arrives with hand-written bot files.**
+Pass one commits a TOML that validates, renders nothing, and leaves those files
+untouched and still authoritative. The first capability's pass sets `codex`,
+opens the `AGENTS.md` region, adopts it, and renders the section. The next sets
+`copilot`, adds the surfaces, and adopts `.github/copilot-instructions.md` and
+the `.instructions.md` names those surfaces produce — a hand-written file in
+that directory under a name no surface produces is left alone, which is correct
+and stays the repo's own. Each later capability adopts and renders only its own
+paths. The install is finished when every capability the repo wants is on,
+`check` is clean, and the smoke test at the end of this file has seen each
+enabled bot comment. A repo that stops after pass one has staged the work, not
+done it.
 
 ## The settings
 

--- a/skills/bot-instructions/references/checklist.md
+++ b/skills/bot-instructions/references/checklist.md
@@ -142,6 +142,19 @@ can still change what the file means.
       `.github/copilot-instructions.md` is absent, so `[bots] copilot = false`
       there means moving what that guard reads before removing the file.
 
+## Excluding the render trees
+
+- [ ] The exclusion set actually covers this repo's render trees. `render` fails
+      when it does not, but only where `[exclusions] derive_render` is on, so a
+      repo deriving nothing checks this by reading the rendered `path_filters`
+      against `.agents/`.
+- [ ] Enforcement for Codex, Copilot and Qodo comes from the merge gate, not
+      from here. Those three receive the paths as an instruction and may comment
+      on them anyway; a gate that passes a render-only diff needs no bot to
+      cooperate, which is the only thing that makes "a render-only diff opens no
+      bot rounds" true rather than requested. CodeRabbit and Macroscope subtract
+      for real and need nothing from the gate.
+
 ## If the repo's gate reads bot output
 
 - [ ] Every path in SKILL.md § A pull request changing its own review's policy

--- a/skills/bot-instructions/references/checklist.md
+++ b/skills/bot-instructions/references/checklist.md
@@ -2,15 +2,20 @@
 
 ## Adding a repo
 
+Two passes, and the first one deliberately renders nothing.
+
+**Pass one, staging.** The `[bots]` flags start false, so this pass produces a
+committed `bot-instructions.toml` and no instruction files. That is the point:
+a repo commits its intent before any vendor setting exists to honour it, and a
+flag turned on ahead of its settings work renders a file the bot is not yet
+reading.
+
 1. Write `bot-instructions.toml` at the repo root per
-   [schemas/repo-toml.md](schemas/repo-toml.md). An existing hand-written bot
+   [schemas/repo-toml.md](../schemas/repo-toml.md). An existing hand-written bot
    file is the source for its `[[surface]]` blocks and exclusions: read it,
    move its repo-specific claims into the TOML, and let doctrine carry the
-   rest.
-2. If `[bots] codex` is true, add a `## Code Review Rules` heading to
-   `AGENTS.md` by hand. The generator never adds it, and `adopt` in the next
-   step is what takes the region it opens.
-3. Run `adopt`, which names every existing file and region it is taking over,
+   rest. Leave every `[bots]` flag false.
+2. Run `adopt`, which names every existing file and region it is taking over,
    and every repo-root or `.github/` markdown file those files point at. That
    second list is where a repo-wide hand-written reviewer file shows up — one
    that restates doctrine and carries an accepted-trade-off list, reached only
@@ -19,17 +24,32 @@
    and is a policy path. Read both lists against the TOML: a claim in one of
    those files that the TOML does not carry is about to be deleted, or to go on
    steering reviews from outside the package.
-4. If `[bots] coderabbit` is true, put CodeRabbit's published schema at
-   `.bot-instructions/coderabbit-schema.json`. No verb writes it and
-   `coderabbit-schema` fails without it, deliberately: a validator that skipped
-   on a missing schema would be silent for the life of the repo, which is the
-   failure it exists to catch.
-5. Run `render`, then read the diff. Doctrine text appearing for the first time
-   is expected; a repo-specific claim disappearing means it never made it into
-   the TOML.
-6. Work the settings below. Every bot has at least one setting no file can
-   express, and a bot whose install or enablement step is skipped reviews
-   nothing while every file in the repo looks correct.
+3. Run `render`. It writes nothing and says so, because every flag is off. A
+   no-op here is the staging point, not a finished install.
+
+**Pass two, per capability.** Work one bot at a time, and finish each before
+starting the next, so a failure names the bot that caused it.
+
+4. Work that capability's settings below. Every bot has at least one setting no
+   file can express, and a bot whose install or enablement step is skipped
+   reviews nothing while every file in the repo looks correct.
+5. Do the flag's own prerequisite, where it has one. `codex` needs a
+   `## Code Review Rules` heading added to `AGENTS.md` by hand, since the
+   generator never adds it. `coderabbit` needs CodeRabbit's published schema at
+   `.bot-instructions/coderabbit-schema.json`; no verb writes it and
+   `coderabbit-schema` fails without it, deliberately, because a validator that
+   skipped on a missing schema would be silent for the life of the repo.
+   `qodo_review_md` needs the portal toggle already on.
+6. Set the flag, then run `adopt` again if that capability's prerequisite left
+   an unmarked region or the repo already had a file at one of its generated
+   paths, then `render`.
+7. Read the diff. Doctrine text appearing for the first time is expected; a
+   repo-specific claim disappearing means it never made it into the TOML.
+8. Run `check`. Then repeat from step 4 for the next capability.
+
+The install is finished when every capability the repo wants is on, `check` is
+clean, and the smoke test at the end of this file has seen each enabled bot
+comment. A repo that stops after pass one has staged the work, not done it.
 
 ## The settings
 
@@ -38,14 +58,14 @@ expressed in any file the repo contains. Skip one and the repo looks fully
 configured while a bot reviews nothing, or reviews with the wrong scope, and no
 render or validator can tell.
 
-Work this once per repo, in the pull request that adds
-`bot-instructions.toml`. Record the outcome of each line in that repo, next to
-the TOML, so the next person can tell a deliberate `false` from an unanswered
-question.
+Work one capability's section at a time, as step 4 of the sequence above, and
+record each line's outcome in the repo beside the TOML so the next person can
+tell a deliberate `false` from an unanswered question.
 
-A bot capability whose row here is unanswered should be `false` in `[bots]`. A
+A capability whose section here is unanswered stays `false` in `[bots]`. A
 `true` flag renders files that reach nothing, which is worse than no files at
-all.
+all — and a section answered but never followed by step 6 leaves the reverse,
+a bot enabled at the vendor reading nothing this package wrote.
 
 None of this state is machine-readable from the repo, and an administrator can
 change any of it without touching the repo. Every check here can keep passing

--- a/skills/bot-instructions/references/checklist.md
+++ b/skills/bot-instructions/references/checklist.md
@@ -2,18 +2,30 @@
 
 ## Adding a repo
 
-Two passes. The order is not a preference — `toml-schema`'s cross-flag clauses
-and `adopt`'s own rule fix it, and a sequence that ignores them writes a TOML
-that does not validate.
+Two passes. The order is not a preference — three rules fix it, and a sequence
+that ignores them writes a TOML that does not validate or a render that stops.
 
-**What those clauses require, since everything below follows from them.** A
-`[[surface]]` set needs at least one of `copilot`, `coderabbit`, `macroscope` or
-`qodo_best_practices` on, because those four are every route surface text has.
-`copilot` or `coderabbit` needs `codex`, because the `AGENTS.md` section is
-where both get most of their doctrine. `qodo_best_practices` and
-`qodo_review_md` need `qodo`. And `adopt` takes a file or region over only for a
-capability that is on. So **capability-dependent content lands with its
-capability**, and nothing that depends on a flag is written before the flag.
+**What those rules require, since everything below follows from them.**
+
+*From `toml-schema`'s cross-flag clauses.* A `[[surface]]` set needs at least
+one of `copilot`, `coderabbit`, `macroscope` or `qodo_best_practices` on,
+because those four are every route surface text has. `copilot` or `coderabbit`
+needs `codex`, because the `AGENTS.md` section is where both get most of their
+doctrine. `qodo_best_practices` and `qodo_review_md` need `qodo`.
+
+*From `adopt`'s own rule.* It takes a file or region over only for a capability
+that is on.
+
+Those two give **capability-dependent content lands with its capability**, and
+nothing that depends on a flag is written before the flag.
+
+*From `agents-section`'s nested-`AGENTS.md` clause.* It rejects a nested
+`AGENTS.md` carrying a `## Code Review Rules` section, it is the one clause no
+flag gates, and it runs against the repo before every write. So it is invisible
+to the flag reasoning above and constrains the sequence anyway: a repo holding
+such a section cannot complete **any** render, including a pass-one render with
+every flag off. Clearing it is therefore a pass-one prerequisite rather than
+part of the `codex` capability's own pass.
 
 **Pass one, the repo-wide TOML.** `[repo]`, `[exclusions]`, `[cadence]`,
 `[tone]`, `[budgets]` and any `[doctrine.*]` overrides, with every `[bots]` flag
@@ -24,43 +36,53 @@ false and no `[[surface]]` entries.
    `[doctrine.append]`, which will not fold and stay hand-written as policy
    paths. Write the repo-wide tables; leave the surfaces for the pass that turns
    on a bot able to read them.
-2. Do not run `adopt` here. Nothing can be adopted for a capability that is off,
+2. Clear any nested `AGENTS.md` carrying a `## Code Review Rules` section. Fold
+   what it holds into `[doctrine.append]` or a `[[surface]]` and delete the
+   section, or move the section out of an `AGENTS.md`. The generator writes only
+   the root one, and `agents-section` rejects a nested one unconditionally, so
+   this is what a pass-one render stops on if it is skipped. Its content is not
+   lost: it lands in the TOML written in step 1.
+3. Do not run `adopt` here. Nothing can be adopted for a capability that is off,
    so it would report nothing on exactly the repo this planning is for.
-3. Run `render`. It writes nothing and says so, because every flag is off. The
-   no-op is the staging point, not a finished install — the existing bot files
-   are still the repo's own and still what the bots read.
+4. Run `render`. With step 2 done it writes nothing and says so, because every
+   flag is off; that no-op is the staging point, not a finished install, and the
+   existing bot files are still the repo's own and still what the bots read.
+   With step 2 skipped it does not write nothing — it stops on the nested
+   section before the write and names the file, which is the clause doing its
+   job rather than a failure of the sequence.
 
 **Pass two, per capability.** Enable `codex` first if this repo wants `copilot`
 or `coderabbit`, and `qodo` before its two sub-flags. Then, one capability at a
 time, finishing each before starting the next so a failure names the bot that
 caused it:
 
-4. Work that capability's settings section below.
-5. Do its prerequisite, where it has one. `codex` needs a `## Code Review Rules`
+5. Work that capability's settings section below.
+6. Do its prerequisite, where it has one. `codex` needs a `## Code Review Rules`
    heading added to `AGENTS.md` by hand, since the generator never adds it.
    `coderabbit` needs CodeRabbit's published schema at
    `.bot-instructions/coderabbit-schema.json`; no verb writes it and
    `coderabbit-schema` fails without it, deliberately, because a validator that
    skipped on a missing schema would be silent for the life of the repo.
    `qodo_review_md` needs the portal toggle already on.
-6. Set the flag. With the first of `copilot`, `coderabbit`, `macroscope` or
+7. Set the flag. With the first of `copilot`, `coderabbit`, `macroscope` or
    `qodo_best_practices`, add the `[[surface]]` entries planned in step 1 — they
    are legal from that moment and were not before.
-7. Run `adopt`. It can now take over that capability's generated paths, the
+8. Run `adopt`. It can now take over that capability's generated paths, the
    `AGENTS.md` region the heading opened included, and it names every file and
    region it takes plus every repo-root or `.github/` markdown file those files
    point at. That second list is where a repo-wide hand-written reviewer file
    shows up. Read both against the TOML: a claim in one of those files that the
    TOML does not carry is about to be deleted, or to go on steering reviews from
    outside the package.
-8. Run `render`, then read the diff. Doctrine text appearing for the first time
+9. Run `render`, then read the diff. Doctrine text appearing for the first time
    is expected; a repo-specific claim disappearing means it never made it into
    the TOML.
-9. Run `check`. Then repeat from step 4 for the next capability.
+10. Run `check`. Then repeat from step 5 for the next capability.
 
 **Walked end to end, for a repo that arrives with hand-written bot files.**
-Pass one commits a TOML that validates, renders nothing, and leaves those files
-untouched and still authoritative. The first capability's pass sets `codex`,
+Pass one clears any nested `## Code Review Rules` section into the TOML, then
+commits a TOML that validates and a render that writes nothing, leaving those
+files untouched and still authoritative. The first capability's pass sets `codex`,
 opens the `AGENTS.md` region, adopts it, and renders the section. The next sets
 `copilot`, adds the surfaces, and adopts `.github/copilot-instructions.md` and
 the `.instructions.md` names those surfaces produce — a hand-written file in
@@ -78,14 +100,14 @@ expressed in any file the repo contains. Skip one and the repo looks fully
 configured while a bot reviews nothing, or reviews with the wrong scope, and no
 render or validator can tell.
 
-Work one capability's section at a time, as step 4 of the sequence above, and
-record each line's outcome in the repo beside the TOML so the next person can
-tell a deliberate `false` from an unanswered question.
+Work one capability's section at a time, as the settings step of the sequence
+above, and record each line's outcome in the repo beside the TOML so the next
+person can tell a deliberate `false` from an unanswered question.
 
 A capability whose section here is unanswered stays `false` in `[bots]`. A
 `true` flag renders files that reach nothing, which is worse than no files at
-all — and a section answered but never followed by step 6 leaves the reverse,
-a bot enabled at the vendor reading nothing this package wrote.
+all — and a section answered but never followed by setting the flag leaves the
+reverse, a bot enabled at the vendor reading nothing this package wrote.
 
 None of this state is machine-readable from the repo, and an administrator can
 change any of it without touching the repo. Every check here can keep passing

--- a/skills/bot-instructions/references/checklist.md
+++ b/skills/bot-instructions/references/checklist.md
@@ -86,9 +86,10 @@ can still change what the file means.
       and to the generator.
 - [ ] No `pr-agent-settings` repository exists at the organization or project
       level carrying settings this repo does not expect.
-- [ ] No other best-practices source is loaded for this repo. Qodo caps
-      accumulated best-practices content at 2,000 lines across every source,
-      and the generator can only see the one file it writes.
+- [ ] What other best-practices sources Qodo loads for this repo is known.
+      Organization and mapped-repository files layer above the generated one and
+      the generator cannot see them. Qodo documents 800 lines per file and no
+      cap on the total, so nothing checks the total.
 - [ ] Before setting `[bots] qodo_review_md`: the portal toggle under
       Configurations → Context, "REVIEW.md instructions", is on. Without it the
       file is inert, which is why the flag is set by hand after this line
@@ -107,6 +108,14 @@ can still change what the file means.
       documents no grammar for that file, so the render keeps every non-pattern
       line inside an HTML comment on the assumption that anything else would be
       read as a pattern. Confirm once that the exclusions took effect.
+
+## Glob dialect
+
+- [ ] An exclusion took effect on Copilot, on Qodo and on Macroscope. The
+      dialect claims five engines read its patterns alike, and only two can be
+      tested from a repo: CodeRabbit's minimatch and real `git sparse-checkout`.
+      The `applyTo`, `[ignore]` and `include` matchers are unpublished, so this
+      line is the only confirmation those three ever get.
 
 ## If the repo has its own guard over these files
 

--- a/skills/bot-instructions/references/checklist.md
+++ b/skills/bot-instructions/references/checklist.md
@@ -88,8 +88,9 @@ can still change what the file means.
       level carrying settings this repo does not expect.
 - [ ] What other best-practices sources Qodo loads for this repo is known.
       Organization and mapped-repository files layer above the generated one and
-      the generator cannot see them. Qodo documents 800 lines per file and no
-      cap on the total, so nothing checks the total.
+      the generator cannot see them. Qodo recommends 800 lines per file and
+      documents no limit on the total, so nothing here checks the total and the
+      per-file number is this package's budget rather than a vendor cap.
 - [ ] Before setting `[bots] qodo_review_md`: the portal toggle under
       Configurations → Context, "REVIEW.md instructions", is on. Without it the
       file is inert, which is why the flag is set by hand after this line

--- a/skills/bot-instructions/references/checklist.md
+++ b/skills/bot-instructions/references/checklist.md
@@ -1,0 +1,128 @@
+# Per-repo settings checklist
+
+Every bot here has at least one setting that lives in a web UI and cannot be
+expressed in any file the repo contains. Skip one and the repo looks fully
+configured while a bot reviews nothing, or reviews with the wrong scope, and no
+render or validator can tell.
+
+Work this once per repo, in the pull request that adds
+`bot-instructions.toml`. Record the outcome of each line in that repo, next to
+the TOML, so the next person can tell a deliberate `false` from an unanswered
+question.
+
+A bot capability whose row here is unanswered should be `false` in `[bots]`. A
+`true` flag renders files that reach nothing, which is worse than no files at
+all.
+
+None of this state is machine-readable from the repo, and an administrator can
+change any of it without touching the repo. Every check here can keep passing
+after a bot has been switched off in a settings page nobody looked at, so the
+last section's smoke test is what actually confirms the set.
+
+## GitHub Copilot code review
+
+- [ ] Copilot is enabled for the repository, under an org or enterprise plan
+      that covers code review.
+- [ ] Automatic review is enabled, either per repository or through an
+      organization ruleset requiring Copilot as a reviewer. Without it the
+      instruction files load only when someone requests a review by hand.
+- [ ] Custom instructions are enabled for code review in the repository's
+      Copilot settings. The files exist regardless; this toggle decides whether
+      review reads them.
+- [ ] Content exclusion paths are set, if any are wanted. Settings → Copilot →
+      Content exclusion, in YAML fnmatch form. This is the only exclusion
+      mechanism Copilot has, and it is not a repo file. Anything in
+      `[[exclusions.path]]` that must also be invisible to Copilot is entered
+      here by hand.
+- [ ] The organization's runner-type setting is understood. An org admin can
+      set a default runner type across all repositories and lock it, overriding
+      per-repo configuration.
+
+## Codex code review
+
+- [ ] The Codex GitHub app is installed on the repository.
+- [ ] Code review is enabled for this repository at
+      <https://chatgpt.com/codex/settings/code-review>. Requires push or admin
+      permission on the repo.
+- [ ] Automatic reviews are on, or the team knows reviews come only from an
+      `@codex review` comment.
+- [ ] Security-review scope is set, if the repo wants it.
+
+Nothing else about Codex is configurable from the repo. `AGENTS.md` § Code
+Review Rules is its entire instruction surface, and it has no file-based
+exclusion mechanism at all, which is why the rendered section carries every
+doctrine block rather than a subset.
+
+## CodeRabbit
+
+- [ ] The CodeRabbit app is installed and the repository is enabled in the
+      organization.
+- [ ] No organization or workspace global override is set. Those outrank the
+      repo file, and a repo cannot see them. If one exists, everything in
+      `.coderabbit.yaml` is advisory and the render is misleading.
+- [ ] `@coderabbitai configuration` has been run once on a pull request and its
+      resolved output matches the committed file. This is the only way to
+      confirm the file was accepted rather than discarded.
+- [ ] The vendored schema copy the validator reads is current, and the repo
+      knows where it came from and how to refresh it. A stale copy rejects a
+      newly valid file, and a copy carrying a JSON Schema keyword the validator
+      does not implement blocks every render until the validator is updated.
+- [ ] Integrations the repo wants (Linear, Jira) are authorized. The file names
+      the tracker; the authorization is a UI step.
+
+Once the file lands, everything the file controls moves into it. The dashboard
+is documentation at best, and a global override above it is the one thing that
+can still change what the file means.
+
+## Qodo
+
+- [ ] The Qodo app is installed on the repository and seats cover it.
+- [ ] Which Qodo product this repo is on is known. `best_practices.md` is
+      loaded automatically by Qodo Merge, the commercial product, and not by
+      open-source PR-Agent; `[bots] qodo_best_practices` should be `false`
+      where the file would be inert.
+- [ ] No `.pr_agent.toml` page exists in the repository wiki. A wiki page of
+      that name applies without a commit and is invisible to version control
+      and to the generator.
+- [ ] No `pr-agent-settings` repository exists at the organization or project
+      level carrying settings this repo does not expect.
+- [ ] No other best-practices source is loaded for this repo. Qodo caps
+      accumulated best-practices content at 2,000 lines across every source,
+      and the generator can only see the one file it writes.
+- [ ] Before setting `[bots] qodo_review_md`: the portal toggle under
+      Configurations → Context, "REVIEW.md instructions", is on. Without it the
+      file is inert, which is why the flag is set by hand after this line
+      rather than inferred.
+
+## Macroscope
+
+- [ ] The Macroscope app is installed on the repository.
+- [ ] Correctness review is enabled, and its detection mode and minimum comment
+      severity are set. These have no repo-file equivalent.
+- [ ] Maximum automatic runs per pull request is set.
+- [ ] Spend caps are set: monthly, per pull request, and per review. Macroscope
+      bills per review, and this package's exclusion list is what keeps a
+      vendored tree from being paid for repeatedly.
+- [ ] The generated `.macroscope/ignore.md` excludes what it names. Macroscope
+      documents no grammar for that file, so the render keeps every non-pattern
+      line inside an HTML comment on the assumption that anything else would be
+      read as a pattern. Confirm once that the exclusions took effect.
+
+## If the repo's gate reads bot output
+
+- [ ] `bot-instructions.toml`, the doctrine source, and every generated path
+      are policy paths in the repo's gate: a push touching one invalidates
+      review evidence gathered before it.
+- [ ] A pull request touching a policy path needs a trusted human approval. Bot
+      evidence gathered under head-branch policy that same pull request wrote is
+      not evidence.
+- [ ] The CI lane running `check` uses this package's copy from the default
+      branch, not the pull request's checkout.
+
+## After the checklist
+
+Open one pull request that touches a file each bot should comment on, and
+confirm each enabled bot posts. A bot that stays silent on a deliberately
+imperfect diff has a settings problem, not an instructions problem, and no
+amount of re-rendering fixes it. This is the only step that tests the settings
+above rather than trusting the record of them.

--- a/skills/bot-instructions/references/checklist.md
+++ b/skills/bot-instructions/references/checklist.md
@@ -1,5 +1,38 @@
 # Per-repo settings checklist
 
+## Adding a repo
+
+1. Write `bot-instructions.toml` at the repo root per
+   [schemas/repo-toml.md](schemas/repo-toml.md). An existing hand-written bot
+   file is the source for its `[[surface]]` blocks and exclusions: read it,
+   move its repo-specific claims into the TOML, and let doctrine carry the
+   rest.
+2. If `[bots] codex` is true, add a `## Code Review Rules` heading to
+   `AGENTS.md` by hand. The generator never adds it, and `adopt` in the next
+   step is what takes the region it opens.
+3. Run `adopt`, which names every existing file and region it is taking over,
+   and every repo-root or `.github/` markdown file those files point at. That
+   second list is where a repo-wide hand-written reviewer file shows up — one
+   that restates doctrine and carries an accepted-trade-off list, reached only
+   because `AGENTS.md` and the Copilot file name it. Fold what it holds into
+   `[doctrine.append]` and `[[surface]]`; what will not fold stays hand-written
+   and is a policy path. Read both lists against the TOML: a claim in one of
+   those files that the TOML does not carry is about to be deleted, or to go on
+   steering reviews from outside the package.
+4. If `[bots] coderabbit` is true, put CodeRabbit's published schema at
+   `.bot-instructions/coderabbit-schema.json`. No verb writes it and
+   `coderabbit-schema` fails without it, deliberately: a validator that skipped
+   on a missing schema would be silent for the life of the repo, which is the
+   failure it exists to catch.
+5. Run `render`, then read the diff. Doctrine text appearing for the first time
+   is expected; a repo-specific claim disappearing means it never made it into
+   the TOML.
+6. Work the settings below. Every bot has at least one setting no file can
+   express, and a bot whose install or enablement step is skipped reviews
+   nothing while every file in the repo looks correct.
+
+## The settings
+
 Every bot here has at least one setting that lives in a web UI and cannot be
 expressed in any file the repo contains. Skip one and the repo looks fully
 configured while a bot reviews nothing, or reviews with the wrong scope, and no

--- a/skills/bot-instructions/references/checklist.md
+++ b/skills/bot-instructions/references/checklist.md
@@ -108,6 +108,22 @@ can still change what the file means.
       line inside an HTML comment on the assumption that anything else would be
       read as a pattern. Confirm once that the exclusions took effect.
 
+## If the repo has its own guard over these files
+
+- [ ] Every predicate that guard uses is at least as loose as the render's.
+      A guard slicing `AGENTS.md` on `^## Code Review Rules$`, or matching a
+      pointer sentence on one line of `.github/copilot-instructions.md`, is
+      reading bytes this package writes; the render spec pins both, and a repo
+      adding a third predicate reconciles it before rendering rather than at
+      adoption time.
+- [ ] `[repo] tracker` is set wherever a guard pins the tracked reply form.
+      Without it the render leaves the generic placeholder and the guard reads
+      the form as gone.
+- [ ] Retiring a bot whose file another check requires is a pointer move first,
+      then the deletion. kendex's guard fails when
+      `.github/copilot-instructions.md` is absent, so `[bots] copilot = false`
+      there means moving what that guard reads before removing the file.
+
 ## If the repo's gate reads bot output
 
 - [ ] `bot-instructions.toml`, the doctrine source, and every generated path

--- a/skills/bot-instructions/references/limits.md
+++ b/skills/bot-instructions/references/limits.md
@@ -116,15 +116,26 @@ govern." One-off steering happens in the trigger comment, not in a file.
 
 ## Qodo
 
-<https://docs.qodo.ai/code-review/get-started/configuration-overview/configuration-file>,
-<https://docs.qodo.ai/code-review/tools/improve>
+Qodo's docs are split by product line, and a row's line decides whether it
+applies here. Qodo Review is the current product, under
+`docs.qodo.ai/...`; Qodo Merge is the legacy one, under `docs.qodo.ai/v1/...`.
+This package's `[review_agent]` keys are Review and its `[pr_reviewer]` keys are
+Merge, which is why the render writes both.
 
-| What | Value |
-|------|-------|
-| `best_practices.md` | "Keep each file relatively short, under 800 lines" |
-| Accumulated best-practices content | "limited to 2000 lines" |
-| Automatic `best_practices.md` loading | a Qodo Merge (commercial) feature, absent from open-source PR-Agent |
-| Open-source PR-Agent equivalent | `config.repo_context_files`, limited by `config.repo_context_max_lines`, default 500 |
+<https://docs.qodo.ai/install-and-configure/configuration-overview/configuration-file>,
+<https://docs.qodo.ai/governance/rule-enforcement/without-rule-system/best-practices>
+
+| What | Value | Line |
+|------|-------|------|
+| `best_practices.md` per file | "Keep files relatively short (under ~800 lines)" | Review, and the same cap on the Merge page at `/v1/features/best-practices` |
+| Automatic `best_practices.md` loading | a Qodo Merge (commercial) feature, absent from open-source PR-Agent | Merge |
+
+800 lines per file is the only best-practices cap on a live vendor page. An
+accumulated cap across every source Qodo loads, and an open-source PR-Agent
+`repo_context_max_lines` default, both appeared in material that is now gone:
+the page they came from returns 404 and neither number is on any page that
+replaced it. They are not enforced anywhere in this package, because a number
+this file cannot cite is a number the generator does not hold.
 
 **Configuration locations.** Repo root `.pr_agent.toml`, documented as the root
 of the default branch, a repo wiki page of the same name, a

--- a/skills/bot-instructions/references/limits.md
+++ b/skills/bot-instructions/references/limits.md
@@ -127,8 +127,9 @@ govern." One-off steering happens in the trigger comment, not in a file.
 | Open-source PR-Agent equivalent | `config.repo_context_files`, limited by `config.repo_context_max_lines`, default 500 |
 
 **Configuration locations.** Repo root `.pr_agent.toml`, documented as the root
-of the default branch, a repo wiki page of the same name, a `pr-agent-settings` repository at project or organization
-level, and the Qodo portal.
+of the default branch, a repo wiki page of the same name, a
+`pr-agent-settings` repository at project or organization level, and the Qodo
+portal.
 
 **Precedence.** The docs state that project-level settings take precedence over
 organization-level, and that "a repository's local configuration always
@@ -144,8 +145,9 @@ confirms no wiki page exists.
 `smart_router_extra_instructions` for the agent deciding review depth.
 <https://docs.qodo.ai/code-review/extra-instructions>
 
-**Exclusions.** `[ignore]` globs plus pull-request-level keys (`ignore_pr_labels`, `ignore_pr_authors`,
-`ignore_pr_title`, branch filters) and `allow_only_specific_folders`. There is
+**Exclusions.** `[ignore]` globs plus pull-request-level keys
+(`ignore_pr_labels`, `ignore_pr_authors`, `ignore_pr_title`, branch filters)
+and `allow_only_specific_folders`. There is
 no per-path instruction mechanism.
 
 **`REVIEW.md`.** A root file of plain-markdown review guidelines all Qodo review
@@ -162,13 +164,17 @@ product functionality, not an open-source PR-Agent guarantee.
 |------|-------|
 | Instruction files | `.macroscope/correctness/**/*.md`, `*.md` only, `README.md` ignored |
 | Reserved names at `.macroscope/` root | `ignore.md`, `approvability.md` |
+| Governing file | `.macroscope/correctness/correctness.md`, "at the top level of the directory, spelled exactly that way" |
+| Governing-file frontmatter | `waitsFor`, `requires`, `waitsForTimeout` (default 20 minutes), `waitsForDiscoveryTimeout` (default 1 minute), configuring the whole correctness check |
 | Frontmatter on a correctness file | `include`, `exclude`, both optional glob arrays |
 | Evaluation order | `exclude` after `include`; omitted frontmatter applies repo-wide |
 | Check-run agent `title` | 60 characters |
 | Check-run agent enums | `reasoning`: `off`, `low`, `medium`, `high`, `xhigh`. `effort`: `low`, `medium`, `high`. `input`: `full_diff`, `code_object`, `pr_metadata`. `conclusion`: `neutral`, `failure` |
 
 Subdirectories are organizational only. Multiple instruction files matching one
-changed file stack.
+changed file stack. The governing file is the exception to "a correctness file
+is just instructions": its four fields set the check run's prerequisites and
+timeouts, and no other file can carry them.
 
 **`ignore.md` scope.** Repository-wide exclusion, applying to every check run.
 An agent's own `include` patterns override it, which is a reason not to give an

--- a/skills/bot-instructions/references/limits.md
+++ b/skills/bot-instructions/references/limits.md
@@ -1,0 +1,184 @@
+# Vendor limits and read semantics
+
+Every number the generator enforces is here with the page that states it. A
+limit the generator holds that this file does not carry is a defect: the
+generator's job is to encode what a vendor documents, not what someone
+remembers.
+
+Vendor caps move. When a render fails on a limit that looks wrong, re-read the
+cited page before raising the number in code.
+
+## CodeRabbit
+
+Source of truth is the published schema itself,
+`https://coderabbit.ai/integrations/schema.v2.json`, which every repo vendors
+rather than fetching at check time. Prose reference:
+<https://docs.coderabbit.ai/reference/configuration>.
+
+| What | Value | Where |
+|------|-------|-------|
+| `tone_instructions` | 250 characters | schema `maxLength` |
+| `reviews.path_instructions[].instructions` | 20,000 characters | schema `maxLength` |
+| `reviews.labeling_instructions[].instructions` | 3,000 characters | schema `maxLength` |
+| `reviews.finishing_touches.custom[].instructions` | 10,000 characters, 5 entries | schema `maxLength`, `maxItems` |
+| `reviews.pre_merge_checks.custom_checks[].instructions` | 10,000 characters, 50 entries | schema `maxLength`, `maxItems` |
+| `reviews.profile` | `quiet`, `chill`, `assertive` | schema `enum` |
+| Unknown top-level key | rejected | root `additionalProperties: false` |
+
+Only the first two are reachable from this package's renders. The rest are
+listed because a future render that reaches them inherits a real cap.
+
+**Precedence.** Workspace global overrides, then organization global overrides,
+then the repo's `.coderabbit.yaml`, then central repository configuration, then
+repository dashboard, organization dashboard, workspace settings, defaults. An
+unset key resolves down that ladder per setting rather than falling straight to
+the schema default, which is why the render writes full state: every layer
+below the file is unversioned.
+<https://docs.coderabbit.ai/guides/configuration-overview>
+
+**Read semantics.** The file is read from the pull request's head branch, so a
+pull request can change its own review configuration.
+
+**`base_branches`.** Setting `reviews.auto_review.base_branches` to `[".*"]`
+rather than naming the default branch is fleet experience, not documented
+behavior: naming the branch has been observed to skip pull requests targeting
+it. The wildcard also covers stacked pull requests.
+
+**Invalid file.** CodeRabbit does not document what it does with a config that
+fails its schema. Fleet experience is that it discards the file whole and
+reviews with resolved settings, saying nothing on the pull request. The
+`coderabbit-schema` validator assumes that, because the assumption costs a
+validator and the alternative costs an inert config nobody notices.
+
+**`path_filters` and sparse-checkout.** The schema's own description states
+these patterns also apply to `git sparse-checkout` when cloning. Plain globs
+only. Extglob and brace patterns pass minimatch and match nothing in
+sparse-checkout.
+
+## GitHub Copilot code review
+
+<https://docs.github.com/en/copilot/reference/custom-instructions-support> and
+<https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions>
+
+| What | Value |
+|------|-------|
+| Character cap on instruction files | none is documented. Third-party writeups still cite a 4,000-character cut-off on `copilot-instructions.md` and `*.instructions.md`; GitHub removed it |
+| Size guidance | "Instructions must be no longer than 2 pages" |
+| `excludeAgent` values | `code-review`, `cloud-agent` |
+| `applyTo` on an empty or absent value | the file matches nothing and never loads |
+| `applyTo` | a single string holding comma-separated globs |
+
+**What code review reads.** On GitHub.com: `.github/copilot-instructions.md`,
+`.github/instructions/**/*.instructions.md`, agent instructions (`AGENTS.md`),
+and organization instructions. Personal instructions are not read by code
+review. Path-specific instructions are supported by code review on GitHub.com,
+JetBrains and Xcode, but not in VS Code or Visual Studio, where only the
+repo-wide file applies.
+
+`cloud-agent` is the current spelling, quoted from the page above: "Use either
+`"code-review"` or `"cloud-agent"`." Older material spells the same agent
+`coding-agent`, from before the rename, and material predating both calls it
+the coding agent in prose. A change to that value belongs to a re-read of the
+cited page, not to a recollection.
+
+That AGENTS.md row is worth reading twice. Copilot code review does read it,
+which is a reason to keep reviewer-only doctrine out of `AGENTS.md` and in a
+file carrying `excludeAgent`, rather than a reason to consolidate everything
+into one file.
+
+**Read semantics.** "When reviewing a pull request, Copilot reads repository
+custom instructions, agent instructions, and agent skills from the head branch
+(the branch with your changes), not the base branch."
+
+**Precedence.** Personal, then repository, then organization.
+
+**Content exclusion.** Code review honors repository, organization and
+enterprise content-exclusion settings. Exclusion itself is a settings-UI
+feature and cannot be expressed in any repo file, which is why it is a
+checklist item.
+<https://docs.github.com/en/copilot/how-tos/configure-content-exclusion/exclude-content-from-copilot>
+
+## Codex code review
+
+<https://learn.chatgpt.com/docs/third-party/github>
+
+| What | Value |
+|------|-------|
+| Instruction file | `AGENTS.md`, and nothing else |
+| Read from which branch | not documented |
+| Section | `## Code Review Rules` |
+| Nesting | root guidance combines with the nearest nested `AGENTS.md` covering each changed file |
+| Documented size limit | none |
+| File-based exclusion | none exists |
+
+"Add a `## Code Review Rules` section to the file closest to the code the rules
+govern." One-off steering happens in the trigger comment, not in a file.
+
+## Qodo
+
+<https://docs.qodo.ai/code-review/get-started/configuration-overview/configuration-file>,
+<https://docs.qodo.ai/code-review/tools/improve>
+
+| What | Value |
+|------|-------|
+| `best_practices.md` | "Keep each file relatively short, under 800 lines" |
+| Accumulated best-practices content | "limited to 2000 lines" |
+| Automatic `best_practices.md` loading | a Qodo Merge (commercial) feature, absent from open-source PR-Agent |
+| Open-source PR-Agent equivalent | `config.repo_context_files`, limited by `config.repo_context_max_lines`, default 500 |
+
+**Configuration locations.** Repo root `.pr_agent.toml`, documented as the root
+of the default branch, a repo wiki page of the same name, a `pr-agent-settings` repository at project or organization
+level, and the Qodo portal.
+
+**Precedence.** The docs state that project-level settings take precedence over
+organization-level, and that "a repository's local configuration always
+overrides both". They do not rank the repo root against the repo wiki. The
+package ships the root file and treats the wiki as a channel to keep empty,
+which is correct under either ranking; the checklist carries the step that
+confirms no wiki page exists.
+
+**Sections that matter.** `/review` reads `[pr_reviewer] extra_instructions`.
+`/agentic_review` reads `[review_agent]`, which carries one key per agent:
+`issues_user_guidelines` for bug, security and performance detection,
+`compliance_user_guidelines` for rule checking, and
+`smart_router_extra_instructions` for the agent deciding review depth.
+<https://docs.qodo.ai/code-review/extra-instructions>
+
+**Exclusions.** `[ignore]` globs plus pull-request-level keys (`ignore_pr_labels`, `ignore_pr_authors`,
+`ignore_pr_title`, branch filters) and `allow_only_specific_folders`. There is
+no per-path instruction mechanism.
+
+**`REVIEW.md`.** A root file of plain-markdown review guidelines all Qodo review
+agents follow, enabled once in the portal under Configurations → Context. Qodo
+product functionality, not an open-source PR-Agent guarantee.
+<https://docs.qodo.ai/governance/use-review-md>
+
+## Macroscope
+
+<https://docs.macroscope.com/custom-instructions>,
+<https://docs.macroscope.com/check-run-agents>
+
+| What | Value |
+|------|-------|
+| Instruction files | `.macroscope/correctness/**/*.md`, `*.md` only, `README.md` ignored |
+| Reserved names at `.macroscope/` root | `ignore.md`, `approvability.md` |
+| Frontmatter on a correctness file | `include`, `exclude`, both optional glob arrays |
+| Evaluation order | `exclude` after `include`; omitted frontmatter applies repo-wide |
+| Check-run agent `title` | 60 characters |
+| Check-run agent enums | `reasoning`: `off`, `low`, `medium`, `high`, `xhigh`. `effort`: `low`, `medium`, `high`. `input`: `full_diff`, `code_object`, `pr_metadata`. `conclusion`: `neutral`, `failure` |
+
+Subdirectories are organizational only. Multiple instruction files matching one
+changed file stack.
+
+**`ignore.md` scope.** Repository-wide exclusion, applying to every check run.
+An agent's own `include` patterns override it, which is a reason not to give an
+agent a broad `include`.
+
+**Read semantics.** Configuration is read from the most recent commit on the
+pull request, so an edit takes effect on that pull request immediately. A pull
+request from an external fork always reads configuration from the default
+branch.
+
+**Settings-only.** Whether correctness review runs, detection mode, minimum
+severity to comment, maximum automatic runs, and spend caps are dashboard
+settings with no repo-file equivalent.

--- a/skills/bot-instructions/references/limits.md
+++ b/skills/bot-instructions/references/limits.md
@@ -5,6 +5,14 @@ limit the generator holds that this file does not carry is a defect: the
 generator's job is to encode what a vendor documents, not what someone
 remembers.
 
+**Two kinds of number, and a row says which it is.** A **cap** is a boundary the
+vendor rejects on: exceed it and the vendor discards or refuses the input, so
+the generator holds it because the alternative is a silent failure. A
+**recommendation** is writing guidance the vendor gives with no stated
+consequence; where the generator holds one, it is this package's own budget
+taken from that guidance, and the row says so. Presenting a recommendation as a
+cap would tell a reader a render was rejected for a reason no vendor states.
+
 Vendor caps move. When a render fails on a limit that looks wrong, re-read the
 cited page before raising the number in code.
 
@@ -64,7 +72,7 @@ sparse-checkout.
 |------|-------|
 | Character cap on instruction files | none is documented. Third-party writeups still cite a 4,000-character cut-off on `copilot-instructions.md` and `*.instructions.md`; GitHub removed it |
 | Size guidance | "Instructions must be no longer than 2 pages" |
-| `excludeAgent` values | `code-review`, `cloud-agent` |
+| `excludeAgent` values | `code-review`, `cloud-agent`. The value names the agent the file is hidden **from**, so `cloud-agent` keeps a file from the working agent and leaves code review reading it, and `code-review` does the reverse. They are not interchangeable |
 | `applyTo` on an empty or absent value | the file matches nothing and never loads |
 | `applyTo` | a single string holding comma-separated globs |
 
@@ -125,17 +133,24 @@ Merge, which is why the render writes both.
 <https://docs.qodo.ai/install-and-configure/configuration-overview/configuration-file>,
 <https://docs.qodo.ai/governance/rule-enforcement/without-rule-system/best-practices>
 
-| What | Value | Line |
-|------|-------|------|
-| `best_practices.md` per file | "Keep files relatively short (under ~800 lines)" | Review, and the same cap on the Merge page at `/v1/features/best-practices` |
-| Automatic `best_practices.md` loading | a Qodo Merge (commercial) feature, absent from open-source PR-Agent | Merge |
+| What | Value | Kind | Line |
+|------|-------|------|------|
+| `best_practices.md` per file | "Keep files relatively short (under ~800 lines)" | recommendation | Review, and the same words on the Merge page at `/v1/features/best-practices` |
+| Automatic `best_practices.md` loading | a Qodo Merge (commercial) feature, absent from open-source PR-Agent | — | Merge |
 
-800 lines per file is the only best-practices cap on a live vendor page. An
-accumulated cap across every source Qodo loads, and an open-source PR-Agent
-`repo_context_max_lines` default, both appeared in material that is now gone:
-the page they came from returns 404 and neither number is on any page that
-replaced it. They are not enforced anywhere in this package, because a number
-this file cannot cite is a number the generator does not hold.
+**The 800 is a recommendation, and the budget built on it is this package's.**
+Qodo gives it as writing guidance — long files are processed less effectively
+and tend to repeat what the model already knows — and states no rejection or
+truncation at any length. `qodo-best-practices` still fails over it, for the
+same reason `copilot-budget` fails over a two-page reading: an unbounded
+generated file is a render nobody reviews, and a budget someone can see beats a
+length nobody chose. What it must not claim is that Qodo refused the file.
+
+Both numbers that would have been caps are gone. An accumulated limit across
+every source Qodo loads, and an open-source PR-Agent `repo_context_max_lines`
+default, appeared in material that now 404s and are on no page that replaced it.
+Neither is enforced here, because a number this file cannot cite is a number the
+generator does not hold.
 
 **Configuration locations.** Repo root `.pr_agent.toml`, documented as the root
 of the default branch, a repo wiki page of the same name, a

--- a/skills/bot-instructions/references/limits.md
+++ b/skills/bot-instructions/references/limits.md
@@ -1,17 +1,25 @@
 # Vendor limits and read semantics
 
-Every number the generator enforces is here with the page that states it. A
-limit the generator holds that this file does not carry is a defect: the
-generator's job is to encode what a vendor documents, not what someone
-remembers.
+Every number the generator enforces that comes from a vendor is here with the
+page that states it. One the generator holds and this file does not carry is a
+defect: the generator's job is to encode what a vendor documents, not what
+someone remembers.
+
+A number the package derives from a file format rather than from a vendor is
+out of scope here and lives with the rule it belongs to. There is one: the
+heading predicate's three-or-fewer leading spaces, which is markdown's, and
+which `schemas/repo-toml.md` § The content refusals states once for every reader
+of it.
 
 **Two kinds of number, and a row says which it is.** A **cap** is a boundary the
 vendor rejects on: exceed it and the vendor discards or refuses the input, so
 the generator holds it because the alternative is a silent failure. A
 **recommendation** is writing guidance the vendor gives with no stated
-consequence; where the generator holds one, it is this package's own budget
-taken from that guidance, and the row says so. Presenting a recommendation as a
-cap would tell a reader a render was rejected for a reason no vendor states.
+consequence. Where the generator holds a number taken from one, that is a
+**package budget** and gets its own row saying so, beside the recommendation it
+came from, so a reader meeting the number in a failure message can find both.
+Presenting a recommendation as a cap would tell a reader a render was rejected
+for a reason no vendor states.
 
 Vendor caps move. When a render fails on a limit that looks wrong, re-read the
 cited page before raising the number in code.
@@ -23,15 +31,15 @@ Source of truth is the published schema itself,
 rather than fetching at check time. Prose reference:
 <https://docs.coderabbit.ai/reference/configuration>.
 
-| What | Value | Where |
-|------|-------|-------|
-| `tone_instructions` | 250 characters | schema `maxLength` |
-| `reviews.path_instructions[].instructions` | 20,000 characters | schema `maxLength` |
-| `reviews.labeling_instructions[].instructions` | 3,000 characters | schema `maxLength` |
-| `reviews.finishing_touches.custom[].instructions` | 10,000 characters, 5 entries | schema `maxLength`, `maxItems` |
-| `reviews.pre_merge_checks.custom_checks[].instructions` | 10,000 characters, 50 entries | schema `maxLength`, `maxItems` |
-| `reviews.profile` | `quiet`, `chill`, `assertive` | schema `enum` |
-| Unknown top-level key | rejected | root `additionalProperties: false` |
+| What | Value | Where | Kind |
+|------|-------|-------|------|
+| `tone_instructions` | 250 characters | schema `maxLength` | cap |
+| `reviews.path_instructions[].instructions` | 20,000 characters | schema `maxLength` | cap |
+| `reviews.labeling_instructions[].instructions` | 3,000 characters | schema `maxLength` | cap |
+| `reviews.finishing_touches.custom[].instructions` | 10,000 characters, 5 entries | schema `maxLength`, `maxItems` | cap |
+| `reviews.pre_merge_checks.custom_checks[].instructions` | 10,000 characters, 50 entries | schema `maxLength`, `maxItems` | cap |
+| `reviews.profile` | `quiet`, `chill`, `assertive` | schema `enum` | cap |
+| Unknown top-level key | rejected | root `additionalProperties: false` | cap |
 
 Only the first two are reachable from this package's renders. The rest are
 listed because a future render that reaches them inherits a real cap.
@@ -68,13 +76,14 @@ sparse-checkout.
 <https://docs.github.com/en/copilot/reference/custom-instructions-support> and
 <https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions>
 
-| What | Value |
-|------|-------|
-| Character cap on instruction files | none is documented. Third-party writeups still cite a 4,000-character cut-off on `copilot-instructions.md` and `*.instructions.md`; GitHub removed it |
-| Size guidance | "Instructions must be no longer than 2 pages" |
-| `excludeAgent` values | `code-review`, `cloud-agent`. The value names the agent the file is hidden **from**, so `cloud-agent` keeps a file from the working agent and leaves code review reading it, and `code-review` does the reverse. They are not interchangeable |
-| `applyTo` on an empty or absent value | the file matches nothing and never loads |
-| `applyTo` | a single string holding comma-separated globs |
+| What | Value | Kind |
+|------|-------|------|
+| Character cap on instruction files | none is documented. Third-party writeups still cite a 4,000-character cut-off on `copilot-instructions.md` and `*.instructions.md`; GitHub removed it | — |
+| Size guidance | "Instructions must be no longer than 2 pages" | recommendation |
+| `[budgets] copilot_chars` | 6000 characters, this package's reading of two pages, and the default a repo may raise | package budget |
+| `excludeAgent` values | `code-review`, `cloud-agent`. The value names the agent the file is hidden **from**, so `cloud-agent` keeps a file from the working agent and leaves code review reading it, and `code-review` does the reverse. They are not interchangeable | — |
+| `applyTo` on an empty or absent value | the file matches nothing and never loads | — |
+| `applyTo` | a single string holding comma-separated globs | — |
 
 **What code review reads.** On GitHub.com: `.github/copilot-instructions.md`,
 `.github/instructions/**/*.instructions.md`, agent instructions (`AGENTS.md`),
@@ -135,7 +144,7 @@ Merge, which is why the render writes both.
 
 | What | Value | Kind | Line |
 |------|-------|------|------|
-| `best_practices.md` per file | "Keep files relatively short (under ~800 lines)" | recommendation | Review, and the same words on the Merge page at `/v1/features/best-practices` |
+| `best_practices.md` per file | "Keep files relatively short (under ~800 lines)" | recommendation, held unchanged as the package budget `qodo-best-practices` fails over | Review, and the same words on the Merge page at `/v1/features/best-practices` |
 | Automatic `best_practices.md` loading | a Qodo Merge (commercial) feature, absent from open-source PR-Agent | — | Merge |
 
 **The 800 is a recommendation, and the budget built on it is this package's.**

--- a/skills/bot-instructions/schemas/renders.md
+++ b/skills/bot-instructions/schemas/renders.md
@@ -377,9 +377,12 @@ them.
 `AGENTS.md` is the only way it reads that file.
 
 **Escaping.** Every string is emitted as a block or folded scalar with explicit
-indentation, never a quoted one-line scalar. Repo text is passed through with
-no escaping, which block scalars make safe. A repo string containing a line
-that would terminate the block is refused.
+indentation, never a quoted one-line scalar. Repo text is passed through with no
+escaping, which block scalars make safe for everything a YAML scalar can hold. A
+repo string containing a line that would terminate the block is refused, and so
+is one carrying a control character, by the same refusal `.pr_agent.toml` relies
+on: a block scalar cannot carry one either, and one predicate covers both
+targets because the values reaching them are the same set.
 
 ## `.pr_agent.toml`
 
@@ -427,9 +430,12 @@ the `!` prefix CodeRabbit needs. This filters what Qodo analyzes for
 exists as well.
 
 **Escaping.** Guidance strings are TOML basic multi-line (`"""`), which is why
-every value reaching one is under the toml-delimiter refusal in `repo-toml.md`
-§ The content refusals — that table marks which, and carries the predicate.
-Backslashes are escaped; TOML basic strings interpret them.
+every value reaching one is under that table's toml-delimiter and control
+refusals in `repo-toml.md` § The content refusals — the table marks which
+values, and carries both predicates. A backslash is escaped, which is the only
+rewriting done here: it is a legal character a format requires escaping, not
+content the render is deciding to change. Everything the format cannot carry is
+refused at input instead.
 
 ## `best_practices.md`
 

--- a/skills/bot-instructions/schemas/renders.md
+++ b/skills/bot-instructions/schemas/renders.md
@@ -4,10 +4,9 @@ One section per output. Each names the exact path, what the generator owns
 inside it, which doctrine blocks it carries and in what order, and how repo
 text from `bot-instructions.toml` is escaped into that file's syntax.
 
-Doctrine block ids are `scope`, `rounds`, `severity`, `no-preferences`,
-`declined`, `reply-contract`, `render-out-of-scope`, `trust-model`. They are
-defined in the skill's SKILL.md § Doctrine, and the parse rule that finds them
-is stated there.
+Doctrine block ids are the `###` headings of the doctrine source, whose parse
+rule is SKILL.md § Doctrine. The routing table below is the only other place
+they are written down, and `doctrine-routing` holds the two to the same set.
 
 ## Common rules
 
@@ -98,9 +97,10 @@ of this knowledge, and two copies drift.
 | `trust-model` | 7 | – (b) | – (a) | – | 3 | 7 | – (c) | 7 |
 | `reply-contract` | 8 | – (b) | – (a) | – | 4 | 8 | 6 | 8 |
 
-`[repo] summary` follows the last block in `copilot-instructions`, both
-`pr_agent` `[review_agent]` keys, `pr_agent extra`, and `macroscope
-doctrine.md`.
+`[repo] summary` placement, since the destinations differ: it opens
+`copilot-instructions`, immediately after the `# <repo name>` line and before
+every block. Everywhere else it follows the last block — both `pr_agent`
+`[review_agent]` keys, `pr_agent extra`, and `macroscope doctrine.md`.
 
 **(a) `.coderabbit.yaml` carries one block.** CodeRabbit reaches the rest
 through `knowledge_base.code_guidelines.filePatterns` naming `AGENTS.md`.
@@ -181,10 +181,10 @@ being gone.
 
 **Escaping.** Markdown, passed through. A line that markdown would read as a
 heading ends the owned region at the next render, so the generator refuses any
-doctrine or repo line whose first non-whitespace character is `#` when it
-follows three or fewer leading spaces. `bot-instructions.toml` refuses the same
-shape at input time; this is the second check because doctrine text does not
-come through that file.
+doctrine or repo line matching the heading predicate in `repo-toml.md` § The
+content refusals. That file refuses the same predicate at input time; this is
+the second check because doctrine text does not come through it, and that table
+records which classes get a second check here and which do not.
 
 ## `.github/copilot-instructions.md`
 
@@ -195,7 +195,8 @@ Read by Copilot code review, repo-wide, from the pull request's head branch.
 **Body.**
 
 1. The marker comment.
-2. `# <repo name>` followed by `[repo] summary`.
+2. `# <repo name>` followed by `[repo] summary`, which the routing table's
+   placement note names as this destination's opening rather than its close.
 3. `# Code review calibration`, then the blocks the `copilot-instructions`
    column of the routing table carries, in its order, as `##` subsections.
 4. `## Reply contract`, one sentence pointing at `AGENTS.md` § Code Review
@@ -213,8 +214,8 @@ the routing table's note (b) says which and why.
 (default 6000). Over it, the render fails naming the character count and the
 budget. GitHub documents no numeric cap here; see `references/limits.md`.
 
-**Escaping.** Markdown, passed through, with the same heading refusal as above
-so a repo string cannot forge a section.
+**Escaping.** Markdown, passed through, with the same heading predicate as
+above so a repo string cannot forge a section.
 
 ## `.github/instructions/<name>.instructions.md`
 
@@ -376,10 +377,10 @@ since a gate reading author replies is a compliance rule. Every block in `extra`
 is in one of the two `[review_agent]` keys and the reverse, which is the
 property `qodo-parity` checks.
 
-`render-out-of-scope` leads all three, and this is the one place doctrine is
-rendered ahead of everything else. Qodo has no per-path exclusion for review
-content: its ignore surface is pull-request level plus
-`allow_only_specific_folders`, an
+`render-out-of-scope` takes position 1 in the two columns that carry it, which
+is the one place doctrine is rendered ahead of everything else; the table says
+which those are. Qodo has no per-path exclusion for review content: its ignore
+surface is pull-request level plus `allow_only_specific_folders`, an
 allowlist gating whether analysis runs at all. Prose is the only exclusion
 mechanism this bot has.
 

--- a/skills/bot-instructions/schemas/renders.md
+++ b/skills/bot-instructions/schemas/renders.md
@@ -26,14 +26,16 @@ at the top of `.coderabbit.yaml`. Ownership is decided by the marker being
 present, never by its offset, so `render`, `adopt` and `orphan` all ask the same
 question of every output.
 
-The marker is a comment in that file's syntax naming this package, its version,
-and its input files:
-`bot-instructions.toml`, the doctrine source, and `kendex.toml` when
-`[exclusions] derive_render` is true. The comment ends with the sentence `Edit
+The marker is a comment in that file's syntax naming this package, the doctrine
+source's version, and its input files: `bot-instructions.toml`, the doctrine
+source, and the resolved install manifest when `[exclusions] derive_render` is
+true, by the path actually read. The comment ends with the sentence `Edit
 bot-instructions.toml or the doctrine source, then re-render.` A markdown
 output uses an HTML comment; YAML and TOML use `#`.
 
-The version in the marker is the one stamp a render carries. It is what makes a
+The version is the doctrine source's, not the running copy's, since
+`--doctrine` can point them at different copies and the stamp has to name the
+doctrine the file carries. It is the one stamp a render carries. It is what makes a
 repo running an older installed copy of this package visible: a version bump
 re-renders every file, and the diff says which doctrine the repo moved to. The
 marker is also how `render`, `adopt` and the `orphan` validator tell a
@@ -45,6 +47,14 @@ A failure part way through leaves the manifest, so re-running `render` finishes
 the set, and `check` reds on every path still carrying the old bytes until it
 does. What the design does not claim is an atomic multi-file replacement: no
 filesystem offers one, and a mixed tree that says so beats one that does not.
+
+`AGENTS.md` is outside that scheme, because it is the one output whose
+non-owned bytes belong to the repo. Carrying a build-phase copy of the whole
+file through validation and writing it back would discard anything written to
+it in that window — an editor, a formatter, another lane of the repo's commit
+chain — silently, in the one file this package says it does not own. So the
+build produces the region's body alone, and § `AGENTS.md` says what the write
+does with it.
 
 **No timestamps and no input hashes** in a rendered file. A render is
 reproducible from its inputs, and either would turn every unrelated re-render
@@ -145,6 +155,14 @@ gets an error naming the byte rather than a render its own guard rejects.
 never adds the heading. Guidance for the repo: add the heading by hand, then
 render.
 
+**The splice happens at write time.** The build phase produces the region's
+body; the write re-reads `AGENTS.md`, locates the owned region in those bytes,
+and replaces it there. Nothing outside the region is ever carried through the
+build, so an edit landing between the build and the write survives instead of
+being overwritten by a copy taken before it. A file whose region cannot be
+located at write time — the heading gone, or duplicated, since the build read it
+— fails naming the path rather than guessing where the region went.
+
 **Body.** The marker as an HTML comment, then a line naming the audience and
 pointing working agents elsewhere, then the blocks the `AGENTS.md` column of
 the routing table carries, as bullets in its order. That this file is also read
@@ -243,6 +261,14 @@ their schema default.
 **Head.** The `yaml-language-server` schema line, then the marker comment, then
 a sentence stating that this file is not a delta and that a global override, if
 one exists, outranks it.
+
+**The vendored schema** `coderabbit-schema` validates against lives at
+`.bot-instructions/coderabbit-schema.json`. The path is fixed by this spec
+rather than configurable, because a configurable one is repointable by the same
+pull request whose file the schema is meant to judge, and it has to be
+enumerable to sit in the policy set at all. A change to it is a policy change:
+loosened, the validator goes green on a file CodeRabbit discards whole, and
+stays green afterwards.
 
 **Keys.** Every top-level property the vendored schema defines, in this order:
 `language`, `tone_instructions`, `early_access`, `enable_free_tier`,

--- a/skills/bot-instructions/schemas/renders.md
+++ b/skills/bot-instructions/schemas/renders.md
@@ -273,10 +273,14 @@ excludeAgent: "cloud-agent"
 <surface.instructions>
 ```
 
-`excludeAgent` is emitted only when `reviewer_only = true`, and its only
-permitted values are `code-review` and `cloud-agent`. `applyTo` is a single
-non-empty string holding a comma-separated glob list, not a YAML array. The
-glob dialect refuses a comma, so the join is unambiguous.
+`excludeAgent` is emitted only when `reviewer_only = true`, and then only as
+`cloud-agent`. The value names the agent the file is hidden from, so
+`cloud-agent` keeps it from the working agent and leaves code review reading it;
+`code-review` is the exact opposite and is never what a reviewer-only surface
+wants. `copilot-frontmatter` requires the key and that value for such a surface
+rather than accepting the enum. `applyTo` is a single non-empty string holding a
+comma-separated glob list, not a YAML array. The glob dialect refuses a comma,
+so the join is unambiguous.
 
 **Escaping.** The frontmatter is YAML. The glob dialect refuses `"`, so no
 escaping is needed and a pattern that would need it is refused at input time.
@@ -447,10 +451,13 @@ file has no column in the routing table.
 orphan, so retiring the last surface says so rather than leaving a
 marker-only file that looks like current guidance.
 
-**Caps.** 800 lines for this file, which is what Qodo documents and all it
-documents; `references/limits.md` carries the page. Organization and
-mapped-repository best-practices files layer above this one and the generator
-cannot see them, so nothing here bounds the total.
+**Budget.** 800 lines for this file. Qodo gives that number as writing guidance
+and states no length at which it rejects or truncates, so the budget is this
+package's own, taken from that guidance the way `[budgets] copilot_chars` is
+taken from a two-page reading; `references/limits.md` marks it a recommendation
+and carries the page. Organization and mapped-repository best-practices files
+layer above this one and the generator cannot see them, so nothing here bounds
+the total.
 
 ## `REVIEW.md`
 

--- a/skills/bot-instructions/schemas/renders.md
+++ b/skills/bot-instructions/schemas/renders.md
@@ -164,18 +164,25 @@ Read by Codex, by Copilot code review on GitHub.com, and by CodeRabbit through
 true, which `toml-schema` requires whenever `copilot` or `coderabbit` is.
 
 **Owned region.** From the heading line through the line before the next
-`^#{1,2} ` heading, or end of file. The heading line matches `^## Code Review
-Rules$` exactly: no trailing whitespace, no CR, no leading BOM. Exactly one such
-heading must exist: zero is an error, and two is an error rather than a guess
-about which one to replace. The generator replaces that region's body and
-touches nothing else in the file.
+heading at level 1 or 2, or end of file. The generator replaces that region's
+body and touches nothing else in the file.
 
-The match is exact rather than forgiving on purpose. kendex's own `tools/guard`
-slices this section with `grep -q '^## Code Review Rules$'` and an awk rule
-keyed the same way, so a heading a looser generator accepted would be a heading
-that repo's guard reports as missing. Where the two predicates differ, the
-stricter one is the contract; a repo whose heading carries trailing whitespace
-gets an error naming the byte rather than a render its own guard rejects.
+The two ends use different predicates, deliberately. The **opening** matches
+`^## Code Review Rules$` exactly — no trailing whitespace, no CR, no leading
+BOM — because kendex's `tools/guard` slices this section the same way, and a
+heading a looser generator accepted would be one that repo's guard reports as
+missing. Exactly one such heading must exist: zero is an error, and two is an
+error rather than a guess about which one to replace. The **terminator** uses
+the wide heading predicate from `repo-toml.md` § The content refusals, at level
+1 or 2. Anything narrower would fail to see a following section whose `#` sits
+after one to three spaces — markdown reads that as a heading, so the repo owns
+it, and a terminator that missed it would let the splice swallow that section
+and everything below it. It is also the predicate the input refusals already
+use, so the two agree.
+
+Where the opening predicates differ, the stricter one is the contract: a repo
+whose heading carries trailing whitespace gets an error naming the byte rather
+than a render its own guard rejects.
 
 **Missing section.** An error. The generator never creates `AGENTS.md` and
 never adds the heading. Guidance for the repo: add the heading by hand, then
@@ -415,9 +422,10 @@ the `!` prefix CodeRabbit needs. This filters what Qodo analyzes for
 `/improve`, not what the review agent reads, which is why the prose above
 exists as well.
 
-**Escaping.** Guidance strings are TOML basic multi-line (`"""`). A repo or
-doctrine string containing `"""` is refused. Backslashes are escaped; TOML
-basic strings interpret them.
+**Escaping.** Guidance strings are TOML basic multi-line (`"""`), which is why
+every value reaching one is under the toml-delimiter refusal in `repo-toml.md`
+§ The content refusals — that table marks which, and carries the predicate.
+Backslashes are escaped; TOML basic strings interpret them.
 
 ## `best_practices.md`
 

--- a/skills/bot-instructions/schemas/renders.md
+++ b/skills/bot-instructions/schemas/renders.md
@@ -25,17 +25,16 @@ at the top of `.coderabbit.yaml`. Ownership is decided by the marker being
 present, never by its offset, so `render`, `adopt` and `orphan` all ask the same
 question of every output.
 
-The marker is a comment in that file's syntax naming this package, the doctrine
-source's version, and its input files: `bot-instructions.toml`, the doctrine
-source, and the resolved install manifest when `[exclusions] derive_render` is
-true, by the path actually read. The comment ends with the sentence `Edit
-bot-instructions.toml or the doctrine source, then re-render.` A markdown
-output uses an HTML comment; YAML and TOML use `#`.
+The marker is a comment in that file's syntax naming this package, the spec
+copy's version, and the paths this render read — SKILL.md § The render inputs
+is the set, and each is named by the path actually read. The comment ends with
+the sentence `Edit bot-instructions.toml or the spec copy, then re-render.` A
+markdown output uses an HTML comment; YAML and TOML use `#`.
 
-The version is the doctrine source's, not the running copy's, since
-`--doctrine` can point them at different copies and the stamp has to name the
-doctrine the file carries. It is the one stamp a render carries. It is what makes a
-repo running an older installed copy of this package visible: a version bump
+The version is the spec copy's, not the running copy's, since `--spec` can point
+them at different copies and the stamp has to name the doctrine the file
+carries. It is the one stamp a render carries, and what makes a repo running an
+older installed copy of this package visible: a version bump
 re-renders every file, and the diff says which doctrine the repo moved to. The
 marker is also how `render`, `adopt` and the `orphan` validator tell a
 generated file from a hand-written one.

--- a/skills/bot-instructions/schemas/renders.md
+++ b/skills/bot-instructions/schemas/renders.md
@@ -215,8 +215,17 @@ whose heading carries trailing whitespace gets an error naming the byte rather
 than a render its own guard rejects.
 
 **Missing section.** An error. The generator never creates `AGENTS.md` and
-never adds the heading. Guidance for the repo: add the heading by hand, then
-render.
+never adds the heading.
+
+**The bootstrap is add-the-heading, then `adopt`, then `render`.** A hand-added
+heading leaves an unmarked region at a generated path, and `render` refuses to
+replace one of those — the rule that stops it destroying hand-written bot
+files. `adopt` is the verb that makes an unmanaged thing managed, and a region
+is no different from a file in that respect, so it takes the region over and
+names it in what it prints. No bootstrap exemption: an exemption would need a
+boundary between a region `render` may write unmarked and a hand-written one it
+must refuse, and every boundary anyone can state there reopens the overwrite the
+marker gate exists to prevent.
 
 **The splice happens at write time.** The build phase produces the region's
 body; the write re-reads `AGENTS.md`, locates the owned region in those bytes,
@@ -543,11 +552,14 @@ eight: `.macroscope/` is Macroscope's only instruction surface, it reads no
 `AGENTS.md`, and a block left out here reaches it nowhere. Its name is reserved,
 as are `correctness` and the two `.macroscope/` root names.
 
-**`.macroscope/correctness/<name>.md`.** One per `[[surface]]`, frontmatter
+**`.macroscope/correctness/<name>.md`.** One per `[[surface]]`: frontmatter
 `include` from `globs` and `exclude` from `exclude_globs`, both as YAML string
-arrays. Macroscope evaluates `exclude` after `include`, which matches the
-TOML's meaning directly, so this is the one surface where the subtraction needs
-no restatement in prose.
+arrays, then the marker, then the surface's `instructions` as the body. The body
+is the point of the file — a marker and frontmatter with no guidance under them
+is a correctness file that tells Macroscope nothing, which is what
+`macroscope-render` rejects. Macroscope evaluates `exclude` after `include`,
+which matches the TOML's meaning directly, so this is the one surface where the
+subtraction needs no restatement in prose.
 
 **Not written.** `.macroscope/check-run-agents/`,
 `.macroscope/approvability.md`, and `.macroscope/correctness/correctness.md`.

--- a/skills/bot-instructions/schemas/renders.md
+++ b/skills/bot-instructions/schemas/renders.md
@@ -39,12 +39,39 @@ re-renders every file, and the diff says which doctrine the repo moved to. The
 marker is also how `render`, `adopt` and the `orphan` validator tell a
 generated file from a hand-written one.
 
+**The marker gate is read on the file opened for the replacement**, never on an
+earlier read of the repo. A path whose marker is absent at that moment fails
+naming the path rather than being replaced — the same form § `AGENTS.md` uses
+for a region that moved between the build and the write, and for the same
+reason. The gate is what stops a render from destroying hand-written bot files,
+so proving it against a copy read before the write phase leaves the whole write
+phase as a window: a hand edit, a marker deletion, or another run landing in it
+would have the render overwrite exactly the content the gate exists to protect,
+silently. `orphan` keeps its pre-write read of the repo, because it reports and
+writes nothing.
+
 **Write phase.** The generator builds and validates a complete scratch tree,
 writes a manifest of every path it is about to replace, then replaces them.
 A failure part way through leaves the manifest, so re-running `render` finishes
 the set, and `check` reds on every path still carrying the old bytes until it
 does. What the design does not claim is an atomic multi-file replacement: no
 filesystem offers one, and a mixed tree that says so beats one that does not.
+
+**Each individual replacement is atomic**, the `AGENTS.md` splice included. An
+interrupted write leaves the old bytes, never a truncated file. That is what
+makes the mixed tree above a recoverable state rather than a lost one: every
+path holds either its old content or its new one, so a recovery render has
+something to compare and `check` has something to report. It matters most for
+`AGENTS.md`, which the splice makes a genuine read-modify-write during the write
+phase — a truncate-then-write interrupted midway would leave the repo's own file
+cut off, and that file is the doctrine root three of the five bots read. This
+repo's own convention is the mechanism: write a temp file and rename it over the
+target, one temp name per write.
+
+The rest of the write path — how the lock is acquired and released, where the
+scratch tree lives and how it is made unique per run, where the manifest lives
+and when it is removed — is the generator's to define. This spec states the
+properties a caller can rely on; KEN-1006 owns the mechanics that hold them.
 
 `AGENTS.md` is outside that scheme, because it is the one output whose
 non-owned bytes belong to the repo. Carrying a build-phase copy of the whole

--- a/skills/bot-instructions/schemas/renders.md
+++ b/skills/bot-instructions/schemas/renders.md
@@ -437,6 +437,8 @@ Read by Qodo from the root of the default branch.
 
 **Owned.** The whole file.
 
+**Head.** The marker comment, before the first section, as `#` lines.
+
 **Sections.**
 
 - `[github_app]`: `pr_commands` from `[cadence] qodo_commands`,
@@ -522,8 +524,11 @@ the file is inert until the portal's "REVIEW.md instructions" toggle is on, and
 nothing in the repo can read the portal: someone works the checklist line, then
 sets the flag.
 
-**Body.** The blocks the `REVIEW.md` column of the routing table carries, in
-its order, as plain markdown. Qodo documents no schema for it.
+**Body.** The marker as an HTML comment, then the blocks the `REVIEW.md` column
+of the routing table carries, in its order, as plain markdown. Qodo documents no
+schema for it, which makes the marker the only thing identifying the file as
+this package's: without it the next render refuses to replace its own output and
+`orphan` cannot tell it from a file the repo wrote.
 
 ## `.macroscope/`
 
@@ -547,9 +552,10 @@ Repository-wide: a check-run agent's own `include` overrides it, which is a
 reason not to give an agent a broad `include`.
 
 **`.macroscope/correctness/doctrine.md`.** No frontmatter, so it applies
-repo-wide. Carries the blocks its routing-table column names, which is all
-eight: `.macroscope/` is Macroscope's only instruction surface, it reads no
-`AGENTS.md`, and a block left out here reaches it nowhere. Its name is reserved,
+repo-wide: the marker as an HTML comment, then the blocks its routing-table
+column names, which is all eight: `.macroscope/` is Macroscope's only
+instruction surface, it reads no `AGENTS.md`, and a block left out here reaches
+it nowhere. Its name is reserved,
 as are `correctness` and the two `.macroscope/` root names.
 
 **`.macroscope/correctness/<name>.md`.** One per `[[surface]]`: frontmatter

--- a/skills/bot-instructions/schemas/renders.md
+++ b/skills/bot-instructions/schemas/renders.md
@@ -18,8 +18,16 @@ the slice; `[doctrine.append]` adds its text as a final paragraph. The
 `[repo] tracker` is set.
 
 **Marker.** Every file the generator owns whole, and the one region it owns
-inside `AGENTS.md`, opens with a comment in that file's syntax naming this
-package, its version, and its input files:
+inside `AGENTS.md`, carries a marker: the file's **first comment**, preceded
+only by a prologue the format requires. There are exactly two such prologues,
+and no output has any other: YAML frontmatter in a `.instructions.md` file,
+which is frontmatter only at byte 0, and the `yaml-language-server` schema line
+at the top of `.coderabbit.yaml`. Ownership is decided by the marker being
+present, never by its offset, so `render`, `adopt` and `orphan` all ask the same
+question of every output.
+
+The marker is a comment in that file's syntax naming this package, its version,
+and its input files:
 `bot-instructions.toml`, the doctrine source, and `kendex.toml` when
 `[exclusions] derive_render` is true. The comment ends with the sentence `Edit
 bot-instructions.toml or the doctrine source, then re-render.` A markdown
@@ -236,8 +244,23 @@ their schema default.
 a sentence stating that this file is not a delta and that a global override, if
 one exists, outranks it.
 
-**Keys.** In this order: `language`, `tone_instructions`, `early_access`,
-`enable_free_tier`, `inheritance`, `reviews`, `chat`, `knowledge_base`.
+**Keys.** Every top-level property the vendored schema defines, in this order:
+`language`, `tone_instructions`, `early_access`, `enable_free_tier`,
+`inheritance`, `reviews`, `chat`, `knowledge_base`, `code_generation`,
+`issue_enrichment`.
+
+The last two are here for the same reason as the rest. Full state means every
+key, or the ones left out keep resolving down the ladder this package does not
+control, and the file's claim about itself stops being true.
+`code_generation` is written with its docstring and unit-test generation off,
+matching the `finishing_touches` posture that never lets a bot push code;
+`issue_enrichment` is written off, since this package configures review and not
+issue triage.
+
+The list is transcribed from a schema that moves, which is the shape that goes
+stale, so `coderabbit-schema` also fails when the render omits a top-level
+property the vendored schema defines. The next schema refresh then reports the
+gap instead of silently widening it.
 
 `inheritance` is written `false` explicitly. It decides whether an unset key
 takes a parent level's value instead of resolving down the ladder, which is the
@@ -363,10 +386,10 @@ file has no column in the routing table.
 orphan, so retiring the last surface says so rather than leaving a
 marker-only file that looks like current guidance.
 
-**Caps.** 800 lines for this file. Qodo also documents a 2,000-line cap across
-every best-practices source it loads, and the other sources are organization
-and mapped-repository files this generator cannot see, so that cap is a
-checklist line rather than a validator.
+**Caps.** 800 lines for this file, which is what Qodo documents and all it
+documents; `references/limits.md` carries the page. Organization and
+mapped-repository best-practices files layer above this one and the generator
+cannot see them, so nothing here bounds the total.
 
 ## `REVIEW.md`
 

--- a/skills/bot-instructions/schemas/renders.md
+++ b/skills/bot-instructions/schemas/renders.md
@@ -60,43 +60,98 @@ rendered as a closing sentence of the instruction text naming the paths the
 rules do not cover. Those bots load the instructions for the excluded files and
 are asked to disregard them. A surface needing exact scoping narrows `globs`.
 
+## Doctrine routing
+
+One table, one row per doctrine block, one column per destination that carries
+doctrine. A number is that block's position in that destination; a dash is a
+deliberate omission with its reason below. Every per-surface section below cites
+this table rather than restating its own list, and the generator reads it as its
+single routing input. A per-surface list written out in prose is a second copy
+of this knowledge, and two copies drift.
+
+| Block | AGENTS.md | copilot-instructions | .coderabbit.yaml | pr_agent issues | pr_agent compliance | pr_agent extra | REVIEW.md | macroscope doctrine.md |
+|-------|-----------|----------------------|------------------|-----------------|---------------------|----------------|-----------|------------------------|
+| `scope` | 1 | 1 | – (a) | 2 | – | 2 | 1 | 2 |
+| `rounds` | 2 | 2 | – (a) | 3 | – | 3 | 2 | 3 |
+| `severity` | 3 | 3 | – (a) | – | 1 | 4 | 3 | 4 |
+| `no-preferences` | 4 | 4 | – (a) | 4 | – | 5 | 4 | 5 |
+| `declined` | 5 | 5 | – (a) | – | 2 | 6 | 5 | 6 |
+| `render-out-of-scope` | 6 | – (b) | 1 | 1 | – | 1 | – (c) | 1 |
+| `trust-model` | 7 | – (b) | – (a) | – | 3 | 7 | – (c) | 7 |
+| `reply-contract` | 8 | – (b) | – (a) | – | 4 | 8 | 6 | 8 |
+
+`[repo] summary` follows the last block in `copilot-instructions`, both
+`pr_agent` `[review_agent]` keys, `pr_agent extra`, and `macroscope
+doctrine.md`.
+
+**(a) `.coderabbit.yaml` carries one block.** CodeRabbit reaches the rest
+through `knowledge_base.code_guidelines.filePatterns` naming `AGENTS.md`.
+`render-out-of-scope` is the exception because it rides the `path: "**"`
+instruction entry, where it is doing scoping work rather than repeating
+doctrine.
+
+**(b) Copilot reaches three blocks through `AGENTS.md`,** which code review
+reads on GitHub.com. The pointer sentence in `copilot-instructions` is what
+sends a reader there.
+
+**(c) `REVIEW.md` omits two.** `render-out-of-scope` names trees whose exclusion
+Qodo already carries in `[ignore]` and in the `[review_agent]` guidance, and
+`trust-model` is about a merge gate's evidence rather than about writing a
+finding. Both reach Qodo through `.pr_agent.toml`.
+
+**`AGENTS.md` carries all eight**, and so does `macroscope doctrine.md`. Each is
+its bot's only surface: neither Codex nor Macroscope reads a second instruction
+file, has a path-scoped mechanism, or has anywhere else a block could arrive. A
+block omitted from one of those two does not reach that bot at all.
+
+**`best_practices.md` carries no doctrine.** It exists to give `[[surface]]`
+text a route to Qodo, and `.pr_agent.toml` already carries every block.
+
+**The `AGENTS.md` section is the doctrine root, not a Codex-only file.**
+CodeRabbit reads it through `code_guidelines`, and Copilot code review reads it
+directly, so `[bots] codex = false` with either of those on would leave
+`.coderabbit.yaml` carrying one block and the Copilot pointer aimed at a section
+that does not exist. `toml-schema` rejects that pair.
+
 ## `AGENTS.md` § Code Review Rules
 
-Read by Codex, and by Copilot code review on GitHub.com.
+Read by Codex, by Copilot code review on GitHub.com, and by CodeRabbit through
+`knowledge_base.code_guidelines.filePatterns`. Rendered when `[bots] codex` is
+true, which `toml-schema` requires whenever `copilot` or `coderabbit` is.
 
 **Owned region.** From the heading line through the line before the next
-`^#{1,2} ` heading, or end of file. The heading line matches `## Code Review
-Rules` with optional trailing whitespace, tolerating CRLF line endings and a
-leading UTF-8 BOM on the file. Exactly one such heading must exist: zero is an
-error, and two is an error rather than a guess about which one to replace. The
-generator replaces that region's body and touches nothing else in the file.
+`^#{1,2} ` heading, or end of file. The heading line matches `^## Code Review
+Rules$` exactly: no trailing whitespace, no CR, no leading BOM. Exactly one such
+heading must exist: zero is an error, and two is an error rather than a guess
+about which one to replace. The generator replaces that region's body and
+touches nothing else in the file.
+
+The match is exact rather than forgiving on purpose. kendex's own `tools/guard`
+slices this section with `grep -q '^## Code Review Rules$'` and an awk rule
+keyed the same way, so a heading a looser generator accepted would be a heading
+that repo's guard reports as missing. Where the two predicates differ, the
+stricter one is the contract; a repo whose heading carries trailing whitespace
+gets an error naming the byte rather than a render its own guard rejects.
 
 **Missing section.** An error. The generator never creates `AGENTS.md` and
 never adds the heading. Guidance for the repo: add the heading by hand, then
 render.
 
 **Body.** The marker as an HTML comment, then a line naming the audience and
-pointing working agents elsewhere, then every doctrine block as a bullet, in
-this order:
-
-1. `scope`
-2. `rounds`
-3. `severity`
-4. `no-preferences`
-5. `declined`
-6. `render-out-of-scope`
-7. `trust-model`
-8. `reply-contract`
-
-All eight, because this is Codex's only surface. A block omitted here does not
-reach Codex at all: it has no other instruction file, no path-scoped
-mechanism, and no file-based exclusion. That this file is also read by working
-agents is a reason to keep doctrine short, not a reason to route part of it
-away from the one bot that reads nothing else.
+pointing working agents elsewhere, then the blocks the `AGENTS.md` column of
+the routing table carries, as bullets in its order. That this file is also read
+by working agents is a reason to keep doctrine short, not a reason to route
+part of it away from the one bot that reads nothing else.
 
 One block renders as exactly one bullet, its paragraphs joined by a space and
 no blank line inside. A repo guard that pins the reply contract reads it as a
 single bullet, and a blank line ends that read.
+
+A repo whose guard pins the tracked reply form needs `[repo] tracker` set.
+kendex's does: it matches `Tracked: KEN-<n>` literally inside the `- Author
+replies are` bullet, and an absent tracker leaves the generic `<issue>`
+placeholder the render substitutes into, which that guard reads as the form
+being gone.
 
 **Escaping.** Markdown, passed through. A line that markdown would read as a
 heading ends the owned region at the next render, so the generator refuses any
@@ -115,13 +170,18 @@ Read by Copilot code review, repo-wide, from the pull request's head branch.
 
 1. The marker comment.
 2. `# <repo name>` followed by `[repo] summary`.
-3. `# Code review calibration`, then `scope`, `rounds`, `severity`,
-   `no-preferences`, `declined` as `##` subsections.
+3. `# Code review calibration`, then the blocks the `copilot-instructions`
+   column of the routing table carries, in its order, as `##` subsections.
 4. `## Reply contract`, one sentence pointing at `AGENTS.md` § Code Review
-   Rules, spelled with that exact file name and section name. A repo whose
-   guard pins that pointer reads this line.
+   Rules, spelled with that exact file name and section name, emitted on one
+   line and never wrapped. kendex's `tools/guard` matches
+   `AGENTS\.md.*§ Code Review Rules` against a single line of this file, so a
+   wrap splits the pointer in two and reds that guard.
 5. `## Path rules`, one sentence naming `.github/instructions/` as where
    per-path rules live, emitted only when at least one `[[surface]]` exists.
+
+Three blocks reach Copilot through `AGENTS.md` rather than through this file;
+the routing table's note (b) says which and why.
 
 **Budget.** The rendered file must not exceed `[budgets] copilot_chars`
 (default 6000). Over it, the render fails naming the character count and the
@@ -259,16 +319,18 @@ extra_instructions`; `/agentic_review` reads `[review_agent]`. Whichever
 command a repo runs, the guidance has to be in the section that command reads,
 so the generator writes the same doctrine into both, split differently.
 
-`[review_agent] issues_user_guidelines` carries `render-out-of-scope`, `scope`,
-`rounds`, `no-preferences`, then `[repo] summary`.
-`compliance_user_guidelines` carries `severity`, `declined` and `trust-model`.
-`[pr_reviewer] extra_instructions` carries all eight blocks plus `[repo]
-summary`, in that same order, because that section is one string with no
-per-agent split.
+The routing table's three `pr_agent` columns say which block goes where and in
+what order: `issues` and `compliance` split the set between the two
+`[review_agent]` keys, and `extra` holds all eight in one string because
+`[pr_reviewer]` has no per-agent split. `reply-contract` sits in `compliance`,
+since a gate reading author replies is a compliance rule. Every block in `extra`
+is in one of the two `[review_agent]` keys and the reverse, which is the
+property `qodo-parity` checks.
 
-`render-out-of-scope` leads, and it is the one place doctrine is rendered ahead
-of everything else. Qodo has no per-path exclusion for review content: its
-ignore surface is pull-request level plus `allow_only_specific_folders`, an
+`render-out-of-scope` leads all three, and this is the one place doctrine is
+rendered ahead of everything else. Qodo has no per-path exclusion for review
+content: its ignore surface is pull-request level plus
+`allow_only_specific_folders`, an
 allowlist gating whether analysis runs at all. Prose is the only exclusion
 mechanism this bot has.
 
@@ -294,6 +356,9 @@ prose, and closing with the same `exclude_globs` sentence the Copilot and
 CodeRabbit renders carry. Surface text has no other route to Qodo, so a
 subtraction dropped here is a subtraction that never reaches it at all.
 
+No doctrine. `.pr_agent.toml` carries every block already, which is why this
+file has no column in the routing table.
+
 **No surfaces.** The file is not written. An existing marked one becomes an
 orphan, so retiring the last surface says so rather than leaving a
 marker-only file that looks like current guidance.
@@ -310,8 +375,8 @@ the file is inert until the portal's "REVIEW.md instructions" toggle is on, and
 nothing in the repo can read the portal: someone works the checklist line, then
 sets the flag.
 
-**Body.** `scope`, `rounds`, `severity`, `no-preferences`, `declined`,
-`reply-contract`, as plain markdown. Qodo documents no schema for it.
+**Body.** The blocks the `REVIEW.md` column of the routing table carries, in
+its order, as plain markdown. Qodo documents no schema for it.
 
 ## `.macroscope/`
 
@@ -335,9 +400,10 @@ Repository-wide: a check-run agent's own `include` overrides it, which is a
 reason not to give an agent a broad `include`.
 
 **`.macroscope/correctness/doctrine.md`.** No frontmatter, so it applies
-repo-wide. Carries `scope`, `rounds`, `severity`, `no-preferences`, `declined`,
-`render-out-of-scope`, then `[repo] summary`. Its name is reserved: no surface
-may be called `doctrine`.
+repo-wide. Carries the blocks its routing-table column names, which is all
+eight: `.macroscope/` is Macroscope's only instruction surface, it reads no
+`AGENTS.md`, and a block left out here reaches it nowhere. Its name is reserved,
+as are `correctness` and the two `.macroscope/` root names.
 
 **`.macroscope/correctness/<name>.md`.** One per `[[surface]]`, frontmatter
 `include` from `globs` and `exclude` from `exclude_globs`, both as YAML string
@@ -345,11 +411,17 @@ arrays. Macroscope evaluates `exclude` after `include`, which matches the
 TOML's meaning directly, so this is the one surface where the subtraction needs
 no restatement in prose.
 
-**Not written.** `.macroscope/check-run-agents/` and
-`.macroscope/approvability.md`. Both create merge-blocking check runs and
-per-run spend, which is a decision a repo owner makes, not one a doctrine
-render makes for eight repos at once. Their names are reserved against a
-surface claiming them anyway.
+**Not written.** `.macroscope/check-run-agents/`,
+`.macroscope/approvability.md`, and `.macroscope/correctness/correctness.md`.
+The first two create merge-blocking check runs and per-run spend, which is a
+decision a repo owner makes, not one a doctrine render makes for eight repos at
+once. The third is Macroscope's governing file: spelled exactly that way at the
+top of `correctness/`, it carries `waitsFor`, `requires`, `waitsForTimeout` and
+`waitsForDiscoveryTimeout` for the whole correctness run. `macroscope-render`
+permits no frontmatter key but `include` and `exclude`, so a render over it
+would drop those four permanently and Macroscope only warns. A repo keeps its
+own governing file, hand-written and unmarked, and no surface may be named
+`correctness`.
 
 **Escaping.** Frontmatter is YAML; globs are emitted as quoted scalars, and the
 glob dialect refuses the one character that would need escaping.

--- a/skills/bot-instructions/schemas/renders.md
+++ b/skills/bot-instructions/schemas/renders.md
@@ -128,6 +128,36 @@ of this knowledge, and two copies drift.
 every block. Everywhere else it follows the last block — both `pr_agent`
 `[review_agent]` keys, `pr_agent extra`, and `macroscope doctrine.md`.
 
+**The exclusion set's placement.** Where it is rendered, it follows the
+`render-out-of-scope` block immediately, in the same bullet or paragraph that
+block renders as, in the exclusion set's own fixed order. Three destinations
+carry it: `AGENTS.md`, `pr_agent issues`, and `pr_agent extra` — the columns
+whose `render-out-of-scope` cell carries a number and whose bot has no
+file-based review exclusion. Copilot needs no fourth, because note (b) already
+routes this block to it through `AGENTS.md`, which it reads.
+
+`.coderabbit.yaml` and `macroscope doctrine.md` carry the block without the
+paths: `path_filters` and `ignore.md` subtract them for real a few keys away,
+and a second copy of a list the same file enforces is the drift this spec spends
+a rule avoiding. `REVIEW.md` omits the block entirely, which note (c) records.
+
+What that buys, per surface, since the five do not get the same thing:
+
+| Surface | Mechanism | Enforced |
+|---------|-----------|----------|
+| CodeRabbit | `reviews.path_filters`, exclusion-only | yes, the files are not reviewed |
+| Macroscope | `.macroscope/ignore.md` | yes, repo-wide across check runs |
+| Codex | the rendered paths in the `AGENTS.md` owned region | no |
+| Copilot | the same rendered paths, since it reads `AGENTS.md` | no |
+| Qodo | the rendered paths in `issues` and `extra` | no |
+
+The three unenforced rows are why the paths are rendered at all. Codex has no
+file-based exclusion, Copilot's is a settings page no repo file reaches, and
+Qodo's `[ignore]` governs `/improve` analysis rather than review content. Naming
+the paths makes the instruction actionable; SKILL.md § Every rendered config
+excludes the render trees carries the requirement and the plain statement that
+those three may comment anyway.
+
 **(a) `.coderabbit.yaml` carries one block.** CodeRabbit reaches the rest
 through `knowledge_base.code_guidelines.filePatterns` naming `AGENTS.md`.
 `render-out-of-scope` is the exception because it rides the `path: "**"`
@@ -205,6 +235,14 @@ part of it away from the one bot that reads nothing else.
 One block renders as exactly one bullet, its paragraphs joined by a space and
 no blank line inside. A repo guard that pins the reply contract reads it as a
 single bullet, and a blank line ends that read.
+
+The `render-out-of-scope` bullet is the one that carries data as well as
+doctrine: the exclusion set follows its text in the same bullet, comma-joined in
+the set's fixed order. It stays inside the owned region like everything else the
+generator writes there, so the region's rules are unchanged — one bullet, no
+blank line, no line a heading predicate would catch — and a path is not a
+heading, so nothing about the region's boundaries moves. This is the only place
+Codex can receive those paths, since it reads no second file.
 
 A repo whose guard pins the tracked reply form needs `[repo] tracker` set.
 kendex's does: it matches `Tracked: KEN-<n>` literally inside the `- Author
@@ -419,7 +457,10 @@ property `qodo-parity` checks.
 
 `render-out-of-scope` takes position 1 in the two columns that carry it, which
 is the one place doctrine is rendered ahead of everything else; the table says
-which those are. Qodo has no per-path exclusion for review content: its ignore
+which those are. In `issues` and `extra` it carries the exclusion paths after
+its text, because Qodo's `[ignore]` filters what it analyzes for `/improve`
+rather than what the review agent reads, so prose is the only route those paths
+have to it. Qodo has no per-path exclusion for review content: its ignore
 surface is pull-request level plus `allow_only_specific_folders`, an
 allowlist gating whether analysis runs at all. Prose is the only exclusion
 mechanism this bot has.

--- a/skills/bot-instructions/schemas/renders.md
+++ b/skills/bot-instructions/schemas/renders.md
@@ -217,11 +217,13 @@ than a render its own guard rejects.
 **Missing section.** An error. The generator never creates `AGENTS.md` and
 never adds the heading.
 
-**The bootstrap is add-the-heading, then `adopt`, then `render`.** A hand-added
-heading leaves an unmarked region at a generated path, and `render` refuses to
-replace one of those — the rule that stops it destroying hand-written bot
-files. `adopt` is the verb that makes an unmanaged thing managed, and a region
-is no different from a file in that respect, so it takes the region over and
+**The bootstrap is add-the-heading, set `[bots] codex`, `adopt`, then
+`render`.** The flag precedes the `adopt` because `adopt` takes a region over
+only for a capability that is on. A hand-added heading leaves an unmarked region
+at a generated path, and `render` refuses to replace one of those — the rule
+that stops it destroying hand-written bot files. `adopt` is the verb that makes
+an unmanaged thing managed, and a region is no different from a file in that
+respect, so it takes the region over and
 names it in what it prints. No bootstrap exemption: an exemption would need a
 boundary between a region `render` may write unmarked and a hand-written one it
 must refuse, and every boundary anyone can state there reopens the overwrite the
@@ -400,7 +402,9 @@ requests targeting the default branch, and the wildcard also covers stacked
 pull requests.
 
 **`reviews.path_filters`.** The exclusion set, each entry prefixed `!`, each
-preceded by a comment carrying its `reason`. Exclusion-only: a single entry
+preceded by a comment carrying its reason — the entry's own `reason` where it
+has one, and the fixed string `repo-toml.md` § `[exclusions]` states for a
+derived entry, which has no TOML row to carry one. Exclusion-only: a single entry
 without `!` turns the list into an allowlist and un-reviews every unlisted file
 in the repo. The glob dialect is what keeps these patterns usable by `git
 sparse-checkout`, which CodeRabbit feeds them to. Both rules are enforced by
@@ -537,9 +541,11 @@ commit on the pull request, except for a fork pull request, which reads the
 default branch.
 
 **`.macroscope/ignore.md`.** The marker as an HTML comment, then one glob per
-line and nothing else. Each glob's `reason` is an HTML comment on the line
-above it. Macroscope documents no grammar for this file, so the render assumes
-the strictest reading, that every non-blank line is a pattern, and keeps every
+line and nothing else. Each glob's reason is an HTML comment on the line above
+it, taken from the same two sources `path_filters` uses: the entry's `reason`,
+or the fixed derived string. Macroscope documents no grammar for this file, so
+the render assumes the strictest reading, that every non-blank line is a
+pattern, and keeps every
 non-pattern line inside a comment. Confirming that assumption once per repo is
 a checklist line.
 

--- a/skills/bot-instructions/schemas/renders.md
+++ b/skills/bot-instructions/schemas/renders.md
@@ -1,0 +1,355 @@
+# Render spec
+
+One section per output. Each names the exact path, what the generator owns
+inside it, which doctrine blocks it carries and in what order, and how repo
+text from `bot-instructions.toml` is escaped into that file's syntax.
+
+Doctrine block ids are `scope`, `rounds`, `severity`, `no-preferences`,
+`declined`, `reply-contract`, `render-out-of-scope`, `trust-model`. They are
+defined in the skill's SKILL.md § Doctrine, and the parse rule that finds them
+is stated there.
+
+## Common rules
+
+**Block assembly.** A block's text is its heading's slice with the heading line
+dropped and surrounding blank lines trimmed. `[doctrine.replace]` substitutes
+the slice; `[doctrine.append]` adds its text as a final paragraph. The
+`reply-contract` block's `<issue>` placeholder becomes `<PREFIX>-<n>` when
+`[repo] tracker` is set.
+
+**Marker.** Every file the generator owns whole, and the one region it owns
+inside `AGENTS.md`, opens with a comment in that file's syntax naming this
+package, its version, and its input files:
+`bot-instructions.toml`, the doctrine source, and `kendex.toml` when
+`[exclusions] derive_render` is true. The comment ends with the sentence `Edit
+bot-instructions.toml or the doctrine source, then re-render.` A markdown
+output uses an HTML comment; YAML and TOML use `#`.
+
+The version in the marker is the one stamp a render carries. It is what makes a
+repo running an older installed copy of this package visible: a version bump
+re-renders every file, and the diff says which doctrine the repo moved to. The
+marker is also how `render`, `adopt` and the `orphan` validator tell a
+generated file from a hand-written one.
+
+**Write phase.** The generator builds and validates a complete scratch tree,
+writes a manifest of every path it is about to replace, then replaces them.
+A failure part way through leaves the manifest, so re-running `render` finishes
+the set, and `check` reds on every path still carrying the old bytes until it
+does. What the design does not claim is an atomic multi-file replacement: no
+filesystem offers one, and a mixed tree that says so beats one that does not.
+
+**No timestamps and no input hashes** in a rendered file. A render is
+reproducible from its inputs, and either would turn every unrelated re-render
+into a diff.
+
+**Ordering is fixed, never sorted at render time.** Doctrine blocks appear in
+the order each section below states. `[[surface]]` entries appear in TOML
+declaration order. Exclusion entries appear with the derived render trees
+first, in lexicographic order, then `[[exclusions.path]]` entries in
+declaration order. Stable ordering is what makes a re-render diff readable.
+
+**Repo text is never reflowed.** Line breaks in a TOML multi-line string are
+preserved except where a target's syntax forbids them, which is
+`tone_instructions` alone.
+
+**`exclude_globs` is real on one surface only.** Macroscope has an `exclude`
+frontmatter key evaluated after `include`, so the subtraction is expressed
+there. Copilot's frontmatter has no exclude key and CodeRabbit's
+`path_instructions` entry has no exclude field, so on both the subtraction is
+rendered as a closing sentence of the instruction text naming the paths the
+rules do not cover. Those bots load the instructions for the excluded files and
+are asked to disregard them. A surface needing exact scoping narrows `globs`.
+
+## `AGENTS.md` § Code Review Rules
+
+Read by Codex, and by Copilot code review on GitHub.com.
+
+**Owned region.** From the heading line through the line before the next
+`^#{1,2} ` heading, or end of file. The heading line matches `## Code Review
+Rules` with optional trailing whitespace, tolerating CRLF line endings and a
+leading UTF-8 BOM on the file. Exactly one such heading must exist: zero is an
+error, and two is an error rather than a guess about which one to replace. The
+generator replaces that region's body and touches nothing else in the file.
+
+**Missing section.** An error. The generator never creates `AGENTS.md` and
+never adds the heading. Guidance for the repo: add the heading by hand, then
+render.
+
+**Body.** The marker as an HTML comment, then a line naming the audience and
+pointing working agents elsewhere, then every doctrine block as a bullet, in
+this order:
+
+1. `scope`
+2. `rounds`
+3. `severity`
+4. `no-preferences`
+5. `declined`
+6. `render-out-of-scope`
+7. `trust-model`
+8. `reply-contract`
+
+All eight, because this is Codex's only surface. A block omitted here does not
+reach Codex at all: it has no other instruction file, no path-scoped
+mechanism, and no file-based exclusion. That this file is also read by working
+agents is a reason to keep doctrine short, not a reason to route part of it
+away from the one bot that reads nothing else.
+
+One block renders as exactly one bullet, its paragraphs joined by a space and
+no blank line inside. A repo guard that pins the reply contract reads it as a
+single bullet, and a blank line ends that read.
+
+**Escaping.** Markdown, passed through. A line that markdown would read as a
+heading ends the owned region at the next render, so the generator refuses any
+doctrine or repo line whose first non-whitespace character is `#` when it
+follows three or fewer leading spaces. `bot-instructions.toml` refuses the same
+shape at input time; this is the second check because doctrine text does not
+come through that file.
+
+## `.github/copilot-instructions.md`
+
+Read by Copilot code review, repo-wide, from the pull request's head branch.
+
+**Owned.** The whole file.
+
+**Body.**
+
+1. The marker comment.
+2. `# <repo name>` followed by `[repo] summary`.
+3. `# Code review calibration`, then `scope`, `rounds`, `severity`,
+   `no-preferences`, `declined` as `##` subsections.
+4. `## Reply contract`, one sentence pointing at `AGENTS.md` § Code Review
+   Rules, spelled with that exact file name and section name. A repo whose
+   guard pins that pointer reads this line.
+5. `## Path rules`, one sentence naming `.github/instructions/` as where
+   per-path rules live, emitted only when at least one `[[surface]]` exists.
+
+**Budget.** The rendered file must not exceed `[budgets] copilot_chars`
+(default 6000). Over it, the render fails naming the character count and the
+budget. GitHub documents no numeric cap here; see `references/limits.md`.
+
+**Escaping.** Markdown, passed through, with the same heading refusal as above
+so a repo string cannot forge a section.
+
+## `.github/instructions/<name>.instructions.md`
+
+Read by Copilot code review on GitHub.com, JetBrains and Xcode, scoped by
+`applyTo`.
+
+**Owned.** One whole file per `[[surface]]`, named
+`<surface.name>.instructions.md`. Files in that directory carrying no marker
+are hand-written and are left alone; a marked file no current surface produces
+is an orphan.
+
+**Body.**
+
+```markdown
+---
+applyTo: "<globs joined with a comma and no space>"
+excludeAgent: "cloud-agent"
+---
+
+<!-- generated ... -->
+
+<surface.instructions>
+```
+
+`excludeAgent` is emitted only when `reviewer_only = true`, and its only
+permitted values are `code-review` and `cloud-agent`. `applyTo` is a single
+non-empty string holding a comma-separated glob list, not a YAML array. The
+glob dialect refuses a comma, so the join is unambiguous.
+
+**Escaping.** The frontmatter is YAML. The glob dialect refuses `"`, so no
+escaping is needed and a pattern that would need it is refused at input time.
+
+## `.coderabbit.yaml`
+
+Read by CodeRabbit from the pull request's head branch. The file outranks the
+repository and organization dashboards and is itself outranked by an
+organization or workspace global override, which a repo cannot see. Within what
+the file controls, an unset key resolves down a precedence ladder this package
+does not control, so the render writes full state including keys that match
+their schema default.
+
+**Owned.** The whole file.
+
+**Head.** The `yaml-language-server` schema line, then the marker comment, then
+a sentence stating that this file is not a delta and that a global override, if
+one exists, outranks it.
+
+**Keys.** In this order: `language`, `tone_instructions`, `early_access`,
+`enable_free_tier`, `inheritance`, `reviews`, `chat`, `knowledge_base`.
+
+`inheritance` is written `false` explicitly. It decides whether an unset key
+takes a parent level's value instead of resolving down the ladder, which is the
+one key that changes what "full state" means, so a full-state render states it
+rather than relying on its default.
+
+`tone_instructions` is `[tone] coderabbit` with newlines collapsed to single
+spaces, emitted as a folded scalar, and hard-capped at 250 characters. The
+shipped default when `[tone]` is absent:
+
+> Terse and technical. Give the defect, its triggering input, and the
+> consequence. No praise, diff restatement, or summary. One finding per thread.
+> If unsure, name the part you could not verify.
+
+`reviews` carries the findings-only posture: every summary, decoration,
+labelling, reviewer-suggestion and fortune key false, `collapse_walkthrough`
+true, `review_status` and `commit_status` true because a repo's gate may read
+that status, `request_changes_workflow` true so a changes-requested review
+converges without a human dismissing it, and every `finishing_touches` and
+`pre_merge_checks` entry off because this package never lets a bot push code.
+
+`reviews.auto_review.base_branches` is `[".*"]` rather than the default branch
+by name. This one is fleet experience, not a documented behavior: naming the
+branch has been observed to hit a base-branch mis-detection that skips pull
+requests targeting the default branch, and the wildcard also covers stacked
+pull requests.
+
+**`reviews.path_filters`.** The exclusion set, each entry prefixed `!`, each
+preceded by a comment carrying its `reason`. Exclusion-only: a single entry
+without `!` turns the list into an allowlist and un-reviews every unlisted file
+in the repo. The glob dialect is what keeps these patterns usable by `git
+sparse-checkout`, which CodeRabbit feeds them to. Both rules are enforced by
+`coderabbit-filters` in `validators.md` rather than left to the author.
+
+**`reviews.path_instructions`.** One entry per `[[surface]]`. `path` is the
+surface's globs joined as a brace alternation when there is more than one
+(`{a/**,b/**}`), which minimatch understands and which is safe here because
+`path_instructions` never reaches sparse-checkout. `instructions` is the
+surface text with `exclude_globs`, when present, rendered as a closing sentence
+naming the paths the rules do not cover. Each entry is capped at 20,000
+characters.
+
+A final entry with `path: "**"` carries `render-out-of-scope` when the
+exclusion set is non-empty. The path filters already remove those trees; the
+instruction is what stops a finding arriving through a file that references
+them.
+
+**`knowledge_base`.** `opt_out` false, every learning scope local, and
+`code_guidelines.filePatterns` naming `AGENTS.md`. Pointing CodeRabbit at
+`AGENTS.md` is the only way it reads that file.
+
+**Escaping.** Every string is emitted as a block or folded scalar with explicit
+indentation, never a quoted one-line scalar. Repo text is passed through with
+no escaping, which block scalars make safe. A repo string containing a line
+that would terminate the block is refused.
+
+## `.pr_agent.toml`
+
+Read by Qodo from the root of the default branch.
+
+**Owned.** The whole file.
+
+**Sections.**
+
+- `[github_app]`: `pr_commands` from `[cadence] qodo_commands`,
+  `handle_push_trigger` from `[cadence] qodo_push_trigger`.
+- `[review_agent]`: `comments_location_policy = "inline"`,
+  `issues_user_guidelines`, `compliance_user_guidelines`.
+- `[pr_reviewer]`: `extra_instructions`, plus the noise keys off
+  (`require_tests_review`, `require_security_review`,
+  `require_ticket_analysis_review`, `enable_review_labels_security`,
+  `enable_review_labels_effort`, `require_score_review`,
+  `require_estimate_effort_to_review`, `require_can_be_split_review`,
+  `persistent_comment`, all false).
+- `[pr_description]`: `publish_labels = false`.
+
+**Two sections carry the same guidance.** `/review` reads `[pr_reviewer]
+extra_instructions`; `/agentic_review` reads `[review_agent]`. Whichever
+command a repo runs, the guidance has to be in the section that command reads,
+so the generator writes the same doctrine into both, split differently.
+
+`[review_agent] issues_user_guidelines` carries `render-out-of-scope`, `scope`,
+`rounds`, `no-preferences`, then `[repo] summary`.
+`compliance_user_guidelines` carries `severity`, `declined` and `trust-model`.
+`[pr_reviewer] extra_instructions` carries all eight blocks plus `[repo]
+summary`, in that same order, because that section is one string with no
+per-agent split.
+
+`render-out-of-scope` leads, and it is the one place doctrine is rendered ahead
+of everything else. Qodo has no per-path exclusion for review content: its
+ignore surface is pull-request level plus `allow_only_specific_folders`, an
+allowlist gating whether analysis runs at all. Prose is the only exclusion
+mechanism this bot has.
+
+**`[ignore]`.** `glob` from the exclusion set, each entry as written, without
+the `!` prefix CodeRabbit needs. This filters what Qodo analyzes for
+`/improve`, not what the review agent reads, which is why the prose above
+exists as well.
+
+**Escaping.** Guidance strings are TOML basic multi-line (`"""`). A repo or
+doctrine string containing `"""` is refused. Backslashes are escaped; TOML
+basic strings interpret them.
+
+## `best_practices.md`
+
+Read by Qodo Merge, the commercial product, from the repo root. Rendered only
+when `[bots] qodo_best_practices` is true.
+
+**Owned.** The whole file.
+
+**Body.** The marker comment, then one `##` section per `[[surface]]` holding
+its `instructions`, headed by the surface name and its globs written out as
+prose, and closing with the same `exclude_globs` sentence the Copilot and
+CodeRabbit renders carry. Surface text has no other route to Qodo, so a
+subtraction dropped here is a subtraction that never reaches it at all.
+
+**No surfaces.** The file is not written. An existing marked one becomes an
+orphan, so retiring the last surface says so rather than leaving a
+marker-only file that looks like current guidance.
+
+**Caps.** 800 lines for this file. Qodo also documents a 2,000-line cap across
+every best-practices source it loads, and the other sources are organization
+and mapped-repository files this generator cannot see, so that cap is a
+checklist line rather than a validator.
+
+## `REVIEW.md`
+
+Rendered only when `[bots] qodo_review_md` is true. That flag exists because
+the file is inert until the portal's "REVIEW.md instructions" toggle is on, and
+nothing in the repo can read the portal: someone works the checklist line, then
+sets the flag.
+
+**Body.** `scope`, `rounds`, `severity`, `no-preferences`, `declined`,
+`reply-contract`, as plain markdown. Qodo documents no schema for it.
+
+## `.macroscope/`
+
+Rendered only when `[bots] macroscope` is true. Read from the most recent
+commit on the pull request, except for a fork pull request, which reads the
+default branch.
+
+**`.macroscope/ignore.md`.** The marker as an HTML comment, then one glob per
+line and nothing else. Each glob's `reason` is an HTML comment on the line
+above it. Macroscope documents no grammar for this file, so the render assumes
+the strictest reading, that every non-blank line is a pattern, and keeps every
+non-pattern line inside a comment. Confirming that assumption once per repo is
+a checklist line.
+
+A `reason` is single-line and carries no `-->`, which is what stops a reason
+from closing its own comment and putting a line of the author's choosing into
+a file whose every line is a pattern. `bot-instructions.toml` refuses both at
+input time.
+
+Repository-wide: a check-run agent's own `include` overrides it, which is a
+reason not to give an agent a broad `include`.
+
+**`.macroscope/correctness/doctrine.md`.** No frontmatter, so it applies
+repo-wide. Carries `scope`, `rounds`, `severity`, `no-preferences`, `declined`,
+`render-out-of-scope`, then `[repo] summary`. Its name is reserved: no surface
+may be called `doctrine`.
+
+**`.macroscope/correctness/<name>.md`.** One per `[[surface]]`, frontmatter
+`include` from `globs` and `exclude` from `exclude_globs`, both as YAML string
+arrays. Macroscope evaluates `exclude` after `include`, which matches the
+TOML's meaning directly, so this is the one surface where the subtraction needs
+no restatement in prose.
+
+**Not written.** `.macroscope/check-run-agents/` and
+`.macroscope/approvability.md`. Both create merge-blocking check runs and
+per-run spend, which is a decision a repo owner makes, not one a doctrine
+render makes for eight repos at once. Their names are reserved against a
+surface claiming them anyway.
+
+**Escaping.** Frontmatter is YAML; globs are emitted as quoted scalars, and the
+glob dialect refuses the one character that would need escaping.

--- a/skills/bot-instructions/schemas/repo-toml.md
+++ b/skills/bot-instructions/schemas/repo-toml.md
@@ -1,0 +1,234 @@
+# `bot-instructions.toml`
+
+One file per repo, at the repo root beside `.coderabbit.yaml` and
+`.pr_agent.toml`. It holds everything about a repo that a bot needs and
+doctrine cannot know: what the repo is, which bot capabilities are live here,
+what is not this repo's code to fix, and what a reviewer gets wrong on a given
+path.
+
+The file is hand-written and never generated. It is the one file in the set a
+person edits.
+
+**The schema is closed.** An unknown key, an unknown table, or a value of the
+wrong type is an error naming the key. A typo like `[bot]`, `derive_renders` or
+`review_only` would otherwise be ignored while defaults produced plausible
+output, which is the silent failure this whole package exists to remove.
+
+## Shape
+
+```toml
+schema = 1
+
+[repo]
+name = "kendex"
+summary = """
+kendex is a distribution of agent-stack assets: skills, agent definitions,
+hooks, Pi extensions, a Rust engine and CLI, and a Tauri app. Consumers vendor
+the skills and re-vendor in deliberate batches.
+"""
+tracker = "KEN"
+
+[bots]
+codex = true
+copilot = true
+coderabbit = true
+qodo = true
+qodo_best_practices = true
+qodo_review_md = false
+macroscope = false
+
+[cadence]
+coderabbit_incremental = true
+qodo_commands = ["/agentic_review"]
+qodo_push_trigger = false
+
+[tone]
+coderabbit = """
+Terse and technical. Give the defect, its triggering input, and the
+consequence. No praise, diff restatement, or summary. One finding per thread.
+"""
+
+[budgets]
+copilot_chars = 6000
+
+[exclusions]
+derive_render = true
+
+[[exclusions.path]]
+glob = "testdata/golden/**"
+reason = "benchmark-host captured, never compared in CI"
+
+[[surface]]
+name = "tests"
+globs = ["**/tests/**", "**/*.test.sh"]
+reviewer_only = true
+instructions = """
+A scratch directory the test removes in its own EXIT trap is cleaned up. Do not
+report it as a leak.
+"""
+
+[doctrine.append]
+severity = "A performance claim needs a measurement, not an argument."
+
+[doctrine.replace]
+trust-model = "This repo has no gate. Any review object is advisory."
+```
+
+## The glob dialect
+
+One pattern is written once and handed to Copilot's comma-separated `applyTo`,
+CodeRabbit's minimatch and `git sparse-checkout`, Qodo's `[ignore]`, and
+Macroscope's `include`. Those engines agree on very little, so the file accepts
+only what all of them read the same way.
+
+Allowed: `*`, `**`, `?`, a `[...]` character class, and literal path
+characters. Refused, naming the pattern: a brace (`{`, `}`), extglob (`!(`,
+`@(`, `+(`, `?(`, `*(`), a comma, a leading `/`, a `..` component, a backslash,
+a leading `!`, and a double quote. A comma is refused because Copilot's
+`applyTo` splits on it and CodeRabbit's multi-glob join uses braces; the other
+forms are refused because at least one engine reads them differently from the
+rest, and a pattern that means two things is worse than one that is rejected.
+
+An empty glob list is an error wherever a glob list is required.
+
+## Keys
+
+### `schema`
+
+Integer, required. `1`. The generator refuses a value it does not know rather
+than rendering a partly understood file.
+
+### `[repo]`
+
+| Key | Type | Required | Meaning |
+|-----|------|----------|---------|
+| `name` | string | yes | The repo's own name, used in generated file headers |
+| `summary` | string | yes | What this repo is, in two to six sentences. Rendered near the top of the Copilot and Qodo surfaces, which is the only place a bot learns the shape of the codebase |
+| `tracker` | string | no | Issue prefix, e.g. `KEN`. Substituted into the `reply-contract` block's `<issue>` placeholder. Absent leaves the placeholder generic |
+
+`summary` is prose about this repo, not doctrine. Anything in it that would be
+true of another repo belongs in a doctrine block instead.
+
+### `[bots]`
+
+Booleans, each defaulting to `false`, one per capability rather than one per
+vendor. A vendor name covers products with different file support and different
+portal toggles, and a single flag would render authoritative-looking files that
+reach nothing.
+
+| Key | Renders |
+|-----|---------|
+| `codex` | the `AGENTS.md` section |
+| `copilot` | `.github/copilot-instructions.md` and `.github/instructions/*.instructions.md` |
+| `coderabbit` | `.coderabbit.yaml` |
+| `qodo` | `.pr_agent.toml` |
+| `qodo_best_practices` | `best_practices.md`. Automatic loading of that file is Qodo Merge, the commercial product; open-source PR-Agent does not read it |
+| `qodo_review_md` | `REVIEW.md`. Inert until the portal's "REVIEW.md instructions" toggle is on, which is why it is a flag someone sets after doing the checklist line rather than something the generator infers |
+| `macroscope` | the `.macroscope/` tree |
+
+`qodo_best_practices` or `qodo_review_md` true with `qodo` false is an error.
+
+Turning a capability off renders none of its files and deletes none of them.
+The files it wrote stay active until someone removes them, so `check` reports
+each as an orphan by its marker, in the commit that flipped the flag.
+
+### `[cadence]`
+
+| Key | Type | Default | Renders to |
+|-----|------|---------|------------|
+| `coderabbit_incremental` | bool | `true` | `reviews.auto_review.auto_incremental_review` |
+| `coderabbit_drafts` | bool | `false` | `reviews.auto_review.drafts` |
+| `qodo_commands` | array of string | `["/agentic_review"]` | `[github_app] pr_commands` |
+| `qodo_push_trigger` | bool | `false` | `[github_app] handle_push_trigger` |
+
+First-push-only cadence is `coderabbit_incremental = false` with
+`qodo_push_trigger = false`: neither bot re-reviews on push, and a reviewer is
+summoned by comment at a batch boundary. It is the setting that decides how
+many rounds a pull request costs, so it is a per-repo choice rather than a
+doctrine constant, and no doctrine block asserts what a push triggers.
+
+### `[tone]`
+
+`coderabbit`, string, optional, ASCII only. Renders to `tone_instructions`,
+whose hard cap is 250 characters after the generator strips the newlines a TOML
+multi-line string introduces. Over the cap, CodeRabbit rejects the entire file.
+ASCII is required so that the local count and the vendor's cannot disagree
+about what one character is. Absent, the shipped default is used; see
+`renders.md` for its text.
+
+### `[budgets]`
+
+`copilot_chars`, integer, default `6000`. The rendered
+`.github/copilot-instructions.md` may not exceed it. GitHub documents no
+numeric cap for that file and asks for "no longer than 2 pages", so this is the
+package's reading of two pages rather than a vendor limit. Raise it in a repo
+whose surfaces genuinely need more, and say why in a comment.
+
+### `[exclusions]`
+
+`derive_render`, bool, default `false`. When true, the generator reads the
+repo's own `kendex.toml` and adds every rendered harness tree to the exclusion
+set. What it derives is exactly two things: each `.agents/skills/<name>` whose
+entry does not declare `source = "in-place"`, and each per-harness render
+directory the repo's install declares. A skill declared `in-place` is this
+repo's own file and stays in review scope.
+
+`derive_render` makes `kendex.toml` a render input, so the marker names it too,
+and a missing or unparseable `kendex.toml` is an error that renders nothing,
+including the exclusions declared by hand.
+
+`[[exclusions.path]]` entries add repo-specific paths.
+
+| Key | Type | Required | Meaning |
+|-----|------|----------|---------|
+| `glob` | string | yes | A pattern in the dialect above |
+| `reason` | string | yes | Why this path is not reviewable. Rendered as a comment beside the entry in every surface that supports comments |
+
+A reason is required because an exclusion with no stated reason is
+indistinguishable from a mistake at the next read.
+
+### `[[surface]]`
+
+A path set plus what a reviewer needs to know about it. Zero or more.
+
+| Key | Type | Required | Meaning |
+|-----|------|----------|---------|
+| `name` | string | yes | Lowercase, `[a-z0-9-]`, non-empty, unique. Becomes the generated filenames |
+| `globs` | array of string | yes | Non-empty. Paths this surface covers |
+| `exclude_globs` | array of string | no | Subtracted from `globs`, and real subtraction only on Macroscope |
+| `reviewer_only` | bool | no, default `false` | Renders `excludeAgent: "cloud-agent"` into the Copilot file, keeping reviewer doctrine away from the working agent |
+| `instructions` | string | yes | What a reviewer gets wrong here, and what is true instead |
+
+`name` may not be `doctrine`, `ignore`, or `approvability`: each of those is a
+path this package or Macroscope already writes, and a surface claiming one
+would silently lose a file to write order. A `name` colliding with another
+surface, or producing a path another output already claims, is an error.
+
+`instructions` may not begin a line with `#`, with `---`, or with the marker
+text. Each of those restructures at least one output: a heading ends the
+`AGENTS.md` owned region, `---` opens frontmatter, and the marker decides which
+files this package owns.
+
+Two surfaces may match the same file. Macroscope stacks both, CodeRabbit may
+apply both `path_instructions` entries, and Copilot may load both files. No bot
+resolves a contradiction between them in TOML declaration order, so keeping
+overlapping surfaces consistent is the author's job.
+
+Write `instructions` as claims about this repo that a competent reviewer would
+otherwise get wrong: a convention that looks like a bug, a suggestion that has
+already been made and is wrong, an invariant a test pins. A sentence that would
+be true of any repo is doctrine, and belongs in a doctrine block.
+
+### `[doctrine.append]` and `[doctrine.replace]`
+
+Both are tables keyed by doctrine block id. `append` adds a paragraph to a
+block for this repo; `replace` substitutes the block's whole text. An unknown
+block id is an error, so a doctrine rename cannot leave a repo silently
+carrying an override that reaches nothing. Both are subject to the same
+leading-`#`, `---` and marker refusals as `instructions`.
+
+Prefer `append`. A `replace` means this repo disagrees with doctrine, which is
+worth arguing at the doctrine source rather than in one repo's TOML. A
+`replace` on `trust-model` or `render-out-of-scope` also weakens what every bot
+is told about evidence and scope, so a repo whose gate reads bot output should
+treat one as the policy change it is.

--- a/skills/bot-instructions/schemas/repo-toml.md
+++ b/skills/bot-instructions/schemas/repo-toml.md
@@ -277,7 +277,7 @@ A path set plus what a reviewer needs to know about it. Zero or more.
 | `name` | string | yes | Lowercase, `[a-z0-9-]`, non-empty, unique. Becomes the generated filenames |
 | `globs` | array of string | yes | Non-empty. Paths this surface covers |
 | `exclude_globs` | array of string | no | Subtracted from `globs`, and real subtraction only on Macroscope |
-| `reviewer_only` | bool | no, default `false` | Renders `excludeAgent: "cloud-agent"` into the Copilot file, keeping reviewer doctrine away from the working agent |
+| `reviewer_only` | bool | no, default `false` | Renders `excludeAgent: "cloud-agent"` into the Copilot file, keeping reviewer doctrine away from the working agent. `copilot-frontmatter` requires exactly that key and value when this is true, since the other permitted value hides the file from the reviewer instead |
 | `instructions` | string | yes | What a reviewer gets wrong here, and what is true instead |
 
 `name` may not be `doctrine`, `correctness`, `ignore`, or `approvability`. Each

--- a/skills/bot-instructions/schemas/repo-toml.md
+++ b/skills/bot-instructions/schemas/repo-toml.md
@@ -159,7 +159,19 @@ reach nothing.
 | `qodo_review_md` | `REVIEW.md`. Inert until the portal's "REVIEW.md instructions" toggle is on, which is why it is a flag someone sets after doing the checklist line rather than something the generator infers |
 | `macroscope` | the `.macroscope/` tree |
 
-Three flag combinations are errors, all enforced by `toml-schema`:
+**Every flag false is not an error.** A TOML that enables nothing renders
+nothing, and that is a state worth holding: it is how a repo commits its
+`bot-instructions.toml` at step 1 of `references/checklist.md` § Adding a repo,
+before its settings work has enabled anything, and how a fleet stages a rollout
+one bot at a time. The default being `false` is what makes that the safe
+direction — a minimal TOML
+writes no file the repo did not ask for. `render` says it wrote nothing rather
+than exiting quietly, so an operator who expected files learns the flags are
+off; rendering nothing in silence would be the thing this package exists to
+prevent.
+
+What is an error is a flag combination where something enabled reaches nothing.
+Three of those, all enforced by `toml-schema`:
 
 - `qodo_best_practices` or `qodo_review_md` true with `qodo` false.
 - `copilot` or `coderabbit` true with `codex` false. Both read the `AGENTS.md`

--- a/skills/bot-instructions/schemas/repo-toml.md
+++ b/skills/bot-instructions/schemas/repo-toml.md
@@ -81,13 +81,27 @@ CodeRabbit's minimatch and `git sparse-checkout`, Qodo's `[ignore]`, and
 Macroscope's `include`. Those engines agree on very little, so the file accepts
 only what all of them read the same way.
 
-Allowed: `*`, `**`, `?`, a `[...]` character class, and literal path
-characters. Refused, naming the pattern: a brace (`{`, `}`), extglob (`!(`,
-`@(`, `+(`, `?(`, `*(`), a comma, a leading `/`, a `..` component, a backslash,
-a leading `!`, and a double quote. A comma is refused because Copilot's
-`applyTo` splits on it and CodeRabbit's multi-glob join uses braces; the other
-forms are refused because at least one engine reads them differently from the
-rest, and a pattern that means two things is worse than one that is rejected.
+**Allowed characters, and nothing else:** the printable ASCII path characters
+`A-Z a-z 0-9 . _ - /` plus the four metacharacters `*`, `?`, `[`, `]`. `**` is
+the two-character form of `*`. Every other byte is refused, which covers a
+newline, a tab, any other control character, leading or trailing whitespace,
+and `#`.
+
+Stating the dialect as a character class rather than as a list of banned
+sequences is deliberate. A glob is rendered into files whose grammars are
+line-oriented or comment-bearing: one holding a newline becomes two lines in
+`.macroscope/ignore.md`, where every line is a pattern, so a second line reading
+`**` takes the whole repo out of Macroscope's review while each line on its own
+is a valid glob and every validator passes. One holding `#` becomes a comment in
+`.coderabbit.yaml`. A ban list closes the shapes someone thought of; a character
+class closes the rest.
+
+The metacharacters the class leaves out are worth naming for the error message:
+a brace (`{`, `}`), extglob (`!(`, `@(`, `+(`, `?(`, `*(`), a comma, a leading
+`/`, a `..` component, a backslash, a leading `!`, and a double quote. A comma
+because Copilot's `applyTo` splits on it and CodeRabbit's multi-glob join uses
+braces; the rest because at least one engine reads them differently from the
+others, and a pattern that means two things is worse than one that is rejected.
 
 An empty glob list is an error wherever a glob list is required.
 
@@ -102,12 +116,16 @@ than rendering a partly understood file.
 
 | Key | Type | Required | Meaning |
 |-----|------|----------|---------|
-| `name` | string | yes | The repo's own name, used in generated file headers |
+| `name` | string | yes | The repo's own name, used in generated file headers. One line, `[A-Za-z0-9._-]` only, because it renders as a `#` heading line |
 | `summary` | string | yes | What this repo is, in two to six sentences. Rendered near the top of the Copilot and Qodo surfaces, which is the only place a bot learns the shape of the codebase |
 | `tracker` | string | no | Issue prefix, e.g. `KEN`. Substituted into the `reply-contract` block's `<issue>` placeholder. Absent leaves the placeholder generic, which a repo guard pinning the tracked reply form reads as the form being gone |
 
 `summary` is prose about this repo, not doctrine. Anything in it that would be
-true of another repo belongs in a doctrine block instead.
+true of another repo belongs in a doctrine block instead. It is under the same
+content refusals as `[[surface]] instructions`: no line may begin with `#` or
+`---`, and none may carry the marker text. Every string this package renders
+into a structured file is under those refusals, and the list of which strings
+they are is the one below.
 
 ### `[bots]`
 
@@ -154,6 +172,15 @@ on.
 | `qodo_commands` | array of string | `["/agentic_review"]` | `[github_app] pr_commands` |
 | `qodo_push_trigger` | bool | `false` | `[github_app] handle_push_trigger` |
 
+Each `qodo_commands` entry is a bare verb from the set Qodo documents —
+`/review`, `/agentic_review`, `/describe`, `/improve` — and nothing else. No
+whitespace, no `--`. A `pr_commands` entry carries inline
+`--section.key=value` overrides, which is how Qodo's own examples are written,
+so `/review --pr_reviewer.extra_instructions=""` would null the guidance the
+render just wrote while `qodo-parity` passed: that validator compares the two
+sections against each other and never reads a command line. Refusing the
+override form at input is cheaper than teaching a validator to parse it.
+
 First-push-only cadence is `coderabbit_incremental = false` with
 `qodo_push_trigger = false`: neither bot re-reviews on push, and a reviewer is
 summoned by comment at a batch boundary. It is the setting that decides how
@@ -180,15 +207,29 @@ whose surfaces genuinely need more, and say why in a comment.
 ### `[exclusions]`
 
 `derive_render`, bool, default `false`. When true, the generator reads the
-repo's own `kendex.toml` and adds every rendered harness tree to the exclusion
+repo's install manifest and adds every rendered harness tree to the exclusion
 set. What it derives is exactly two things: each `.agents/skills/<name>` whose
 entry does not declare `source = "in-place"`, and each per-harness render
 directory the repo's install declares. A skill declared `in-place` is this
 repo's own file and stays in review scope.
 
-`derive_render` makes `kendex.toml` a render input, so the marker names it too,
-and a missing or unparseable `kendex.toml` is an error that renders nothing,
-including the exclusions declared by hand.
+**The manifest is the one kendex resolves, never a hardcoded filename.** That
+is `kendex.toml`, except in a repo whose `kendex.toml` declares
+`is_source_catalog = true`, where install state routes to the sibling
+`kendex-local.toml` and `kendex.toml` holds the published catalog with no
+install tables at all. kendex's own repo is such a catalog. A generator that
+opened `kendex.toml` by name there would parse a present, valid file, derive an
+empty set, exclude none of the rendered trees, and pass its own consistency
+check comparing empty against empty — the exact silent failure this package
+exists to remove.
+
+**A resolved manifest that declares no install is an error**, not an empty
+derivation. So is a missing or unparseable one. Either way the render produces
+nothing, the hand-written exclusions included, because a repo the generator
+cannot derive from should say so rather than ship a short list.
+
+`derive_render` makes the resolved manifest a render input, so the marker names
+it by the path actually read.
 
 `[[exclusions.path]]` entries add repo-specific paths.
 
@@ -226,6 +267,15 @@ surface, or producing a path another output already claims, is an error.
 text. Each of those restructures at least one output: a heading ends the
 `AGENTS.md` owned region, `---` opens frontmatter, and the marker decides which
 files this package owns.
+
+**The content refusals, in one place.** They apply to `[repo] summary`,
+`[[surface]] instructions`, and every `[doctrine.append]` and
+`[doctrine.replace]` value: no line beginning `#`, `---`, or the marker text.
+`[[exclusions.path]] reason` carries its own pair, refusing a newline and
+`-->`, because it renders inside an HTML comment. `[repo] name` and every glob
+are under their character classes above. `toml-schema` lists all of them, so
+each ships a red control; a refusal stated here and absent from that list would
+ship with nothing proving it fires.
 
 Two surfaces may match the same file. Macroscope stacks both, CodeRabbit may
 apply both `path_instructions` entries, and Copilot may load both files. No bot

--- a/skills/bot-instructions/schemas/repo-toml.md
+++ b/skills/bot-instructions/schemas/repo-toml.md
@@ -322,7 +322,7 @@ here is the only predicate.
 | doctrine block text | yes | yes | yes | – | yes | yes | – |
 | `[[exclusions.path]] reason` | – | – | yes | yes | – | yes | single line |
 | `[[surface]] globs`, `exclude_globs`, `[[exclusions.path]] glob` | – | – | – | – | – | – | non-empty, the glob dialect above, and its path-shape rule |
-| `[tone] coderabbit` | – | – | – | – | – | – | ASCII only |
+| `[tone] coderabbit` | – | – | – | – | – | yes | ASCII only |
 | `[cadence] qodo_commands` entries | – | – | – | – | – | – | a verb from the set above, no whitespace, no `--` |
 
 The predicates, written once:
@@ -349,14 +349,27 @@ The predicates, written once:
   reaching them are the same set: a TOML basic multi-line string permits tab
   and newline and no other control, and so does a YAML scalar. TOML's own
   escapes are how one arrives — `summary = "\u0000"` parses cleanly and yields
-  a literal NUL — so the value is already decoded by the time this sees it, and
-  the four rows with a character class need no mark because their classes admit
-  no control to begin with.
-- **character class** — as stated for `[repo] name`, for globs, for `[tone]
-  coderabbit` and for `qodo_commands` above. `[tone]` is ASCII so the local
-  length count and the vendor's cannot disagree about what one character is,
-  which matters there and nowhere else: `tone_instructions` is the cap
-  CodeRabbit discards the whole file over.
+  a literal NUL — so the value is already decoded by the time this sees it.
+
+  A character class exempts a row from this mark only when it **enumerates the
+  permitted characters**, because then no control is among them. A class that
+  names an encoding does not: ASCII contains NUL and every C0 control, so
+  `[tone] coderabbit` carries the mark despite having a class. Neither does a
+  class constraining one dimension only: `single line` says nothing about the
+  controls that are not newlines, which is why `[[exclusions.path]] reason`
+  carries it too. Read the test against each class rather than counting the
+  rows that have one.
+- **character class** — as stated per row above. Three enumerate their
+  permitted characters and so need no `control` mark: `[repo] name` and
+  `[repo] tracker` take `[A-Za-z0-9._-]`, the globs take the dialect's own
+  class, and `qodo_commands` takes a verb from a closed literal set. `[tone]
+  coderabbit` is ASCII so the local length count and the vendor's cannot
+  disagree about what one character is — which matters there and nowhere else,
+  since `tone_instructions` is the cap CodeRabbit discards the whole file over —
+  and ASCII is an encoding rather than an enumeration, so that row is marked
+  `control` as well. Tab and newline stay legal there: the documented way to
+  author a tone is a TOML multi-line string, and the render collapses its
+  newlines to single spaces.
 
 **Refusals, not escapes.** Every class here is refused at input. The render
 escapes only what a format requires of text already known to be legal — a

--- a/skills/bot-instructions/schemas/repo-toml.md
+++ b/skills/bot-instructions/schemas/repo-toml.md
@@ -163,12 +163,14 @@ Three flag combinations are errors, all enforced by `toml-schema`:
   `qodo_best_practices` all false. Those four are every route surface text has,
   so the surfaces would be instructions nothing reads.
 
-Turning a capability off renders none of its files and deletes none of them.
-The files this package wrote stay active until someone removes them, so `check`
-reports each as an orphan by its marker, in the commit that flipped the flag. A
-file at one of those paths that this package never wrote is the repo's own and
-is not judged: `adopt` is how one becomes managed, and it needs the capability
-on.
+Turning a capability off renders none of its files and deletes none of them, so
+the files this package wrote stay active until someone removes them. Deleting
+them is the same commit's work and it comes first: `render` fails on an orphan
+rather than creating one, so the order is delete, then flip the flag and render.
+`check` is what catches a retirement that skipped the render.
+`validators.md` § `orphan` carries the order. A file at one of those paths that
+this package never wrote is the repo's own and is not judged: `adopt` is how one
+becomes managed, and it needs the capability on.
 
 ### `[cadence]`
 
@@ -179,13 +181,25 @@ on.
 | `qodo_commands` | array of string | `["/agentic_review"]` | `[github_app] pr_commands` |
 | `qodo_push_trigger` | bool | `false` | `[github_app] handle_push_trigger` |
 
-Each `qodo_commands` entry is a bare verb, and the set is `/review` and
-`/agentic_review`. Those are the two review commands, and the two whose sections
-this render writes guidance into; `qodo-parity` rejects a `pr_commands` entry
-whose section carries no guidance, so admitting `/describe` or `/improve` here
-would document a value that renders and then fails its own validator with no fix
-available inside the TOML. A repo wanting either configures it outside this
-package.
+Each `qodo_commands` entry is a bare verb from this set, which is the one
+statement of it — `qodo-parity` reads the review half rather than carrying a
+copy:
+
+| Verb | Line | Role |
+|------|------|------|
+| `/agentic_review` | Review | review |
+| `/review` | Merge | review |
+| `/agentic_describe` | Review | not review |
+| `/describe` | Merge | not review |
+| `/improve` | Merge | not review |
+
+`qodo-parity` requires guidance in the section a **review** verb reads, and this
+render writes it for both. A verb in the other half reads a section this render
+leaves alone by design — `/agentic_describe` and `/describe` write the pull
+request body, `/improve` reads `[pr_code_suggestions]` — so the parity clause
+does not apply to it and its presence is not a finding. Splitting by role rather
+than narrowing the set is what keeps the vendor's own documented default,
+`["/agentic_describe", "/agentic_review"]`, from being a schema error.
 
 No whitespace and no `--` in an entry. A `pr_commands` entry carries inline
 `--section.key=value` overrides, which is how Qodo's own examples are written,
@@ -296,7 +310,9 @@ here is the only predicate.
 | `[doctrine.append]` / `[doctrine.replace]` values | yes | yes | yes | – | – |
 | doctrine block text | yes | yes | yes | – | – |
 | `[[exclusions.path]] reason` | – | – | yes | yes | single line |
-| `[[surface]] globs`, `exclude_globs`, `[[exclusions.path]] glob` | – | – | – | – | the glob dialect above |
+| `[[surface]] globs`, `exclude_globs`, `[[exclusions.path]] glob` | – | – | – | – | the glob dialect above, plus its path-shape rule |
+| `[tone] coderabbit` | – | – | – | – | ASCII only |
+| `[cadence] qodo_commands` entries | – | – | – | – | a verb from the set above, no whitespace, no `--` |
 
 The predicates, written once:
 
@@ -311,7 +327,11 @@ The predicates, written once:
   files this package owns.
 - **comment-close** — `-->`, which would end the HTML comment a `reason` is
   rendered inside and put the rest of the value on a line of its own.
-- **character class** — as stated for `[repo] name` and for globs above.
+- **character class** — as stated for `[repo] name`, for globs, for `[tone]
+  coderabbit` and for `qodo_commands` above. `[tone]` is ASCII so the local
+  length count and the vendor's cannot disagree about what one character is,
+  which matters there and nowhere else: `tone_instructions` is the cap
+  CodeRabbit discards the whole file over.
 
 **Render-side second checks.** `renders.md` re-checks the heading class when it
 assembles the `AGENTS.md` region and the Copilot file, because doctrine text
@@ -322,7 +342,9 @@ doctrine without also reaching a `.instructions.md` file, where the frontmatter
 the generator emits is fixed and the marker is written by the generator itself.
 
 Every row is one clause with one control, and § Controls' count is checkable
-against this table.
+against this table. `toml-schema` carries no list of its own: it names this
+table and adds the one clause that is a path shape rather than a content
+refusal.
 
 Two surfaces may match the same file. Macroscope stacks both, CodeRabbit may
 apply both `path_instructions` entries, and Copilot may load both files. No bot

--- a/skills/bot-instructions/schemas/repo-toml.md
+++ b/skills/bot-instructions/schemas/repo-toml.md
@@ -96,12 +96,21 @@ is a valid glob and every validator passes. One holding `#` becomes a comment in
 `.coderabbit.yaml`. A ban list closes the shapes someone thought of; a character
 class closes the rest.
 
+**Path shape, on top of the class.** Refused: a leading `/`, a trailing `/`, a
+`..` component, and an empty component. The class does not cover these — `.`
+and `/` are both allowed characters, so `../**` and `/src/**` are made of
+nothing but permitted bytes — and they are the two shapes that matter most:
+`path_filters` hands these patterns to `git sparse-checkout`, and a `..` there
+is a path-escape in the one place this package gives its own strings to a
+checkout tool. Leading `/` is refused because it is an anchoring form the
+engines read differently.
+
 The metacharacters the class leaves out are worth naming for the error message:
-a brace (`{`, `}`), extglob (`!(`, `@(`, `+(`, `?(`, `*(`), a comma, a leading
-`/`, a `..` component, a backslash, a leading `!`, and a double quote. A comma
-because Copilot's `applyTo` splits on it and CodeRabbit's multi-glob join uses
-braces; the rest because at least one engine reads them differently from the
-others, and a pattern that means two things is worse than one that is rejected.
+a brace (`{`, `}`), extglob (`!(`, `@(`, `+(`, `?(`, `*(`), a comma, a
+backslash, a leading `!`, and a double quote. A comma because Copilot's
+`applyTo` splits on it and CodeRabbit's multi-glob join uses braces; the rest
+because at least one engine reads them differently from the others, and a
+pattern that means two things is worse than one that is rejected.
 
 An empty glob list is an error wherever a glob list is required.
 
@@ -122,10 +131,8 @@ than rendering a partly understood file.
 
 `summary` is prose about this repo, not doctrine. Anything in it that would be
 true of another repo belongs in a doctrine block instead. It is under the same
-content refusals as `[[surface]] instructions`: no line may begin with `#` or
-`---`, and none may carry the marker text. Every string this package renders
-into a structured file is under those refusals, and the list of which strings
-they are is the one below.
+content refusals as `[[surface]] instructions`; the table below says which
+those are, for every string this package renders into a structured file.
 
 ### `[bots]`
 
@@ -172,9 +179,15 @@ on.
 | `qodo_commands` | array of string | `["/agentic_review"]` | `[github_app] pr_commands` |
 | `qodo_push_trigger` | bool | `false` | `[github_app] handle_push_trigger` |
 
-Each `qodo_commands` entry is a bare verb from the set Qodo documents —
-`/review`, `/agentic_review`, `/describe`, `/improve` — and nothing else. No
-whitespace, no `--`. A `pr_commands` entry carries inline
+Each `qodo_commands` entry is a bare verb, and the set is `/review` and
+`/agentic_review`. Those are the two review commands, and the two whose sections
+this render writes guidance into; `qodo-parity` rejects a `pr_commands` entry
+whose section carries no guidance, so admitting `/describe` or `/improve` here
+would document a value that renders and then fails its own validator with no fix
+available inside the TOML. A repo wanting either configures it outside this
+package.
+
+No whitespace and no `--` in an entry. A `pr_commands` entry carries inline
 `--section.key=value` overrides, which is how Qodo's own examples are written,
 so `/review --pr_reviewer.extra_instructions=""` would null the guidance the
 render just wrote while `qodo-parity` passed: that validator compares the two
@@ -263,19 +276,53 @@ frontmatter key but `include` and `exclude`, so an `adopt` over it would drop a
 repo's check prerequisites for good. A `name` colliding with another
 surface, or producing a path another output already claims, is an error.
 
-`instructions` may not begin a line with `#`, with `---`, or with the marker
-text. Each of those restructures at least one output: a heading ends the
-`AGENTS.md` owned region, `---` opens frontmatter, and the marker decides which
-files this package owns.
+`instructions` is under the heading, frontmatter and marker refusals below.
+Each restructures at least one output: a heading ends the `AGENTS.md` owned
+region, `---` opens frontmatter, and the marker decides which files this package
+owns.
 
-**The content refusals, in one place.** They apply to `[repo] summary`,
-`[[surface]] instructions`, and every `[doctrine.append]` and
-`[doctrine.replace]` value: no line beginning `#`, `---`, or the marker text.
-`[[exclusions.path]] reason` carries its own pair, refusing a newline and
-`-->`, because it renders inside an HTML comment. `[repo] name` and every glob
-are under their character classes above. `toml-schema` lists all of them, so
-each ships a red control; a refusal stated here and absent from that list would
-ship with nothing proving it fires.
+## The content refusals
+
+One row per input string, one column per refusal class. Everything that judges
+these — `toml-schema`, `agents-section`, and the Escaping paragraphs in
+`renders.md` — cites this table rather than restating it, so a predicate written
+here is the only predicate.
+
+| Input string | heading | frontmatter | marker | comment-close | character class |
+|--------------|---------|-------------|--------|---------------|-----------------|
+| `[repo] name` | – | – | – | – | single line, `[A-Za-z0-9._-]` |
+| `[repo] summary` | yes | yes | yes | – | – |
+| `[[surface]] instructions` | yes | yes | yes | – | – |
+| `[doctrine.append]` / `[doctrine.replace]` values | yes | yes | yes | – | – |
+| doctrine block text | yes | yes | yes | – | – |
+| `[[exclusions.path]] reason` | – | – | yes | yes | single line |
+| `[[surface]] globs`, `exclude_globs`, `[[exclusions.path]] glob` | – | – | – | – | the glob dialect above |
+
+The predicates, written once:
+
+- **heading** — a line whose first non-whitespace character is `#` after three
+  or fewer leading spaces. That is what markdown reads as a heading, and the
+  wide form is the one the outputs need: a line indented two spaces before `#`
+  ends the `AGENTS.md` owned region just as surely as one in column zero, so a
+  narrower input rule would pass a value the render then refuses.
+- **frontmatter** — a line that is exactly `---`, which opens or closes YAML
+  frontmatter in a `.instructions.md` file.
+- **marker** — a line carrying the marker text, which is what decides which
+  files this package owns.
+- **comment-close** — `-->`, which would end the HTML comment a `reason` is
+  rendered inside and put the rest of the value on a line of its own.
+- **character class** — as stated for `[repo] name` and for globs above.
+
+**Render-side second checks.** `renders.md` re-checks the heading class when it
+assembles the `AGENTS.md` region and the Copilot file, because doctrine text
+does not come through this file at all and so is not covered by any input
+refusal. It does not re-check frontmatter or marker there, and that is a
+decision rather than an omission: neither can reach those two outputs from
+doctrine without also reaching a `.instructions.md` file, where the frontmatter
+the generator emits is fixed and the marker is written by the generator itself.
+
+Every row is one clause with one control, and § Controls' count is checkable
+against this table.
 
 Two surfaces may match the same file. Macroscope stacks both, CodeRabbit may
 apply both `path_instructions` entries, and Copilot may load both files. No bot

--- a/skills/bot-instructions/schemas/repo-toml.md
+++ b/skills/bot-instructions/schemas/repo-toml.md
@@ -127,7 +127,7 @@ than rendering a partly understood file.
 |-----|------|----------|---------|
 | `name` | string | yes | The repo's own name, used in generated file headers. One line, `[A-Za-z0-9._-]` only, because it renders as a `#` heading line |
 | `summary` | string | yes | What this repo is, in two to six sentences. Rendered near the top of the Copilot and Qodo surfaces, which is the only place a bot learns the shape of the codebase |
-| `tracker` | string | no | Issue prefix, e.g. `KEN`. Substituted into the `reply-contract` block's `<issue>` placeholder. Absent leaves the placeholder generic, which a repo guard pinning the tracked reply form reads as the form being gone |
+| `tracker` | string | no | Issue prefix, e.g. `KEN`. Substituted into the `reply-contract` block's `<issue>` placeholder, so it reaches every destination that block does, `.pr_agent.toml` included. Its character class in the table below is what keeps it safe in all of them. Absent leaves the placeholder generic, which a repo guard pinning the tracked reply form reads as the form being gone |
 
 `summary` is prose about this repo, not doctrine. Anything in it that would be
 true of another repo belongs in a doctrine block instead. It is under the same
@@ -302,14 +302,15 @@ these — `toml-schema`, `agents-section`, and the Escaping paragraphs in
 `renders.md` — cites this table rather than restating it, so a predicate written
 here is the only predicate.
 
-| Input string | heading | frontmatter | marker | comment-close | character class |
-|--------------|---------|-------------|--------|---------------|-----------------|
-| `[repo] name` | – | – | – | – | single line, `[A-Za-z0-9._-]` |
-| `[repo] summary` | yes | yes | yes | – | – |
-| `[[surface]] instructions` | yes | yes | yes | – | – |
-| `[doctrine.append]` / `[doctrine.replace]` values | yes | yes | yes | – | – |
-| doctrine block text | yes | yes | yes | – | – |
-| `[[exclusions.path]] reason` | – | – | yes | yes | single line |
+| Input string | heading | frontmatter | marker | comment-close | toml-delimiter | character class |
+|--------------|---------|-------------|--------|---------------|----------------|-----------------|
+| `[repo] name` | – | – | – | – | – | single line, `[A-Za-z0-9._-]` |
+| `[repo] tracker` | – | – | – | – | – | single line, `[A-Za-z0-9._-]` |
+| `[repo] summary` | yes | yes | yes | – | yes | – |
+| `[[surface]] instructions` | yes | yes | yes | – | – | – |
+| `[doctrine.append]` / `[doctrine.replace]` values | yes | yes | yes | – | yes | – |
+| doctrine block text | yes | yes | yes | – | yes | – |
+| `[[exclusions.path]] reason` | – | – | yes | yes | – | single line |
 | `[[surface]] globs`, `exclude_globs`, `[[exclusions.path]] glob` | – | – | – | – | the glob dialect above, plus its path-shape rule |
 | `[tone] coderabbit` | – | – | – | – | ASCII only |
 | `[cadence] qodo_commands` entries | – | – | – | – | a verb from the set above, no whitespace, no `--` |
@@ -327,6 +328,12 @@ The predicates, written once:
   files this package owns.
 - **comment-close** — `-->`, which would end the HTML comment a `reason` is
   rendered inside and put the rest of the value on a line of its own.
+- **toml-delimiter** — `"""`, which would end the TOML multi-line string the
+  value is rendered inside. `.pr_agent.toml` carries every doctrine block and
+  `[repo] summary` as basic multi-line strings, so a value holding the delimiter
+  closes its own string and the rest of it becomes TOML. Marked on exactly the
+  values that reach a TOML string; `[[surface]] instructions` reaches Qodo
+  through `best_practices.md`, which is markdown.
 - **character class** — as stated for `[repo] name`, for globs, for `[tone]
   coderabbit` and for `qodo_commands` above. `[tone]` is ASCII so the local
   length count and the vendor's cannot disagree about what one character is,

--- a/skills/bot-instructions/schemas/repo-toml.md
+++ b/skills/bot-instructions/schemas/repo-toml.md
@@ -104,7 +104,7 @@ than rendering a partly understood file.
 |-----|------|----------|---------|
 | `name` | string | yes | The repo's own name, used in generated file headers |
 | `summary` | string | yes | What this repo is, in two to six sentences. Rendered near the top of the Copilot and Qodo surfaces, which is the only place a bot learns the shape of the codebase |
-| `tracker` | string | no | Issue prefix, e.g. `KEN`. Substituted into the `reply-contract` block's `<issue>` placeholder. Absent leaves the placeholder generic |
+| `tracker` | string | no | Issue prefix, e.g. `KEN`. Substituted into the `reply-contract` block's `<issue>` placeholder. Absent leaves the placeholder generic, which a repo guard pinning the tracked reply form reads as the form being gone |
 
 `summary` is prose about this repo, not doctrine. Anything in it that would be
 true of another repo belongs in a doctrine block instead.
@@ -118,7 +118,7 @@ reach nothing.
 
 | Key | Renders |
 |-----|---------|
-| `codex` | the `AGENTS.md` section |
+| `codex` | the `AGENTS.md` section, which is the doctrine root rather than a Codex-only file |
 | `copilot` | `.github/copilot-instructions.md` and `.github/instructions/*.instructions.md` |
 | `coderabbit` | `.coderabbit.yaml` |
 | `qodo` | `.pr_agent.toml` |
@@ -126,11 +126,24 @@ reach nothing.
 | `qodo_review_md` | `REVIEW.md`. Inert until the portal's "REVIEW.md instructions" toggle is on, which is why it is a flag someone sets after doing the checklist line rather than something the generator infers |
 | `macroscope` | the `.macroscope/` tree |
 
-`qodo_best_practices` or `qodo_review_md` true with `qodo` false is an error.
+Three flag combinations are errors, all enforced by `toml-schema`:
+
+- `qodo_best_practices` or `qodo_review_md` true with `qodo` false.
+- `copilot` or `coderabbit` true with `codex` false. Both read the `AGENTS.md`
+  section: CodeRabbit through `knowledge_base.code_guidelines.filePatterns`,
+  Copilot code review directly on GitHub.com. Without it, `.coderabbit.yaml`
+  carries one doctrine block and the Copilot file's reply-contract pointer aims
+  at a section that does not exist, and both render clean.
+- A non-empty `[[surface]]` set with `copilot`, `coderabbit`, `macroscope` and
+  `qodo_best_practices` all false. Those four are every route surface text has,
+  so the surfaces would be instructions nothing reads.
 
 Turning a capability off renders none of its files and deletes none of them.
-The files it wrote stay active until someone removes them, so `check` reports
-each as an orphan by its marker, in the commit that flipped the flag.
+The files this package wrote stay active until someone removes them, so `check`
+reports each as an orphan by its marker, in the commit that flipped the flag. A
+file at one of those paths that this package never wrote is the repo's own and
+is not judged: `adopt` is how one becomes managed, and it needs the capability
+on.
 
 ### `[cadence]`
 
@@ -199,9 +212,14 @@ A path set plus what a reviewer needs to know about it. Zero or more.
 | `reviewer_only` | bool | no, default `false` | Renders `excludeAgent: "cloud-agent"` into the Copilot file, keeping reviewer doctrine away from the working agent |
 | `instructions` | string | yes | What a reviewer gets wrong here, and what is true instead |
 
-`name` may not be `doctrine`, `ignore`, or `approvability`: each of those is a
-path this package or Macroscope already writes, and a surface claiming one
-would silently lose a file to write order. A `name` colliding with another
+`name` may not be `doctrine`, `correctness`, `ignore`, or `approvability`. Each
+is a path this package or Macroscope already governs, and a surface claiming one
+would silently lose a file to write order.
+`.macroscope/correctness/correctness.md` is the one worth naming: it is
+Macroscope's governing file, carrying `waitsFor`, `requires` and their two
+timeouts for the whole correctness run, and `macroscope-render` permits no
+frontmatter key but `include` and `exclude`, so an `adopt` over it would drop a
+repo's check prerequisites for good. A `name` colliding with another
 surface, or producing a path another output already claims, is an error.
 
 `instructions` may not begin a line with `#`, with `---`, or with the marker

--- a/skills/bot-instructions/schemas/repo-toml.md
+++ b/skills/bot-instructions/schemas/repo-toml.md
@@ -310,18 +310,18 @@ these — `toml-schema`, `agents-section`, and the Escaping paragraphs in
 `renders.md` — cites this table rather than restating it, so a predicate written
 here is the only predicate.
 
-| Input string | heading | frontmatter | marker | comment-close | toml-delimiter | character class |
-|--------------|---------|-------------|--------|---------------|----------------|-----------------|
-| `[repo] name` | – | – | – | – | – | single line, `[A-Za-z0-9._-]` |
-| `[repo] tracker` | – | – | – | – | – | single line, `[A-Za-z0-9._-]` |
-| `[repo] summary` | yes | yes | yes | – | yes | – |
-| `[[surface]] instructions` | yes | yes | yes | – | – | – |
-| `[doctrine.append]` / `[doctrine.replace]` values | yes | yes | yes | – | yes | – |
-| doctrine block text | yes | yes | yes | – | yes | – |
-| `[[exclusions.path]] reason` | – | – | yes | yes | – | single line |
-| `[[surface]] globs`, `exclude_globs`, `[[exclusions.path]] glob` | – | – | – | – | – | non-empty, the glob dialect above, and its path-shape rule |
-| `[tone] coderabbit` | – | – | – | – | – | ASCII only |
-| `[cadence] qodo_commands` entries | – | – | – | – | – | a verb from the set above, no whitespace, no `--` |
+| Input string | heading | frontmatter | marker | comment-close | toml-delimiter | control | character class |
+|--------------|---------|-------------|--------|---------------|----------------|---------|-----------------|
+| `[repo] name` | – | – | – | – | – | – | single line, `[A-Za-z0-9._-]` |
+| `[repo] tracker` | – | – | – | – | – | – | single line, `[A-Za-z0-9._-]` |
+| `[repo] summary` | yes | yes | yes | – | yes | yes | – |
+| `[[surface]] instructions` | yes | yes | yes | – | – | yes | – |
+| `[doctrine.append]` / `[doctrine.replace]` values | yes | yes | yes | – | yes | yes | – |
+| doctrine block text | yes | yes | yes | – | yes | yes | – |
+| `[[exclusions.path]] reason` | – | – | yes | yes | – | yes | single line |
+| `[[surface]] globs`, `exclude_globs`, `[[exclusions.path]] glob` | – | – | – | – | – | – | non-empty, the glob dialect above, and its path-shape rule |
+| `[tone] coderabbit` | – | – | – | – | – | – | ASCII only |
+| `[cadence] qodo_commands` entries | – | – | – | – | – | – | a verb from the set above, no whitespace, no `--` |
 
 The predicates, written once:
 
@@ -342,11 +342,25 @@ The predicates, written once:
   closes its own string and the rest of it becomes TOML. Marked on exactly the
   values that reach a TOML string; `[[surface]] instructions` reaches Qodo
   through `best_practices.md`, which is markdown.
+- **control** — any C0 control character other than tab and newline, and DEL
+  (`U+007F`). One predicate for both structured targets, because the values
+  reaching them are the same set: a TOML basic multi-line string permits tab
+  and newline and no other control, and so does a YAML scalar. TOML's own
+  escapes are how one arrives — `summary = "\u0000"` parses cleanly and yields
+  a literal NUL — so the value is already decoded by the time this sees it, and
+  the four rows with a character class need no mark because their classes admit
+  no control to begin with.
 - **character class** — as stated for `[repo] name`, for globs, for `[tone]
   coderabbit` and for `qodo_commands` above. `[tone]` is ASCII so the local
   length count and the vendor's cannot disagree about what one character is,
   which matters there and nowhere else: `tone_instructions` is the cap
   CodeRabbit discards the whole file over.
+
+**Refusals, not escapes.** Every class here is refused at input. The render
+escapes only what a format requires of text already known to be legal — a
+backslash in a TOML basic string — and rewrites nothing else. An escape for one
+of these would mean the generator silently altering an author's words to make
+them fit a file, which is worse than telling the author the words do not fit.
 
 **Render-side second checks.** `renders.md` re-checks the heading class when it
 assembles the `AGENTS.md` region and the Copilot file, because doctrine text

--- a/skills/bot-instructions/schemas/repo-toml.md
+++ b/skills/bot-instructions/schemas/repo-toml.md
@@ -263,8 +263,10 @@ derivation. So is a missing or unparseable one. Either way the render produces
 nothing, the hand-written exclusions included, because a repo the generator
 cannot derive from should say so rather than ship a short list.
 
-`derive_render` makes the resolved manifest a render input, so the marker names
-it by the path actually read.
+`derive_render` makes both manifests render inputs, because the root file is
+read to decide where the install state lives and the sibling only when it says
+so. SKILL.md § The render inputs states the pair; the marker names each by the
+path actually read.
 
 `[[exclusions.path]]` entries add repo-specific paths.
 

--- a/skills/bot-instructions/schemas/repo-toml.md
+++ b/skills/bot-instructions/schemas/repo-toml.md
@@ -159,16 +159,19 @@ reach nothing.
 | `qodo_review_md` | `REVIEW.md`. Inert until the portal's "REVIEW.md instructions" toggle is on, which is why it is a flag someone sets after doing the checklist line rather than something the generator infers |
 | `macroscope` | the `.macroscope/` tree |
 
-**Every flag false is not an error.** A TOML that enables nothing renders
-nothing, and that is a state worth holding: it is how a repo commits its
-`bot-instructions.toml` at step 1 of `references/checklist.md` § Adding a repo,
-before its settings work has enabled anything, and how a fleet stages a rollout
-one bot at a time. The default being `false` is what makes that the safe
-direction — a minimal TOML
-writes no file the repo did not ask for. `render` says it wrote nothing rather
-than exiting quietly, so an operator who expected files learns the flags are
-off; rendering nothing in silence would be the thing this package exists to
-prevent.
+**Every flag false is not an error.** A TOML that enables nothing has nothing to
+render, and that is a state worth holding: it is how a repo commits its
+`bot-instructions.toml` in the repo-wide pass of `references/checklist.md`
+§ Adding a repo, before its settings work has enabled anything, and how a fleet
+stages a rollout one bot at a time. The default being `false` is what makes that
+the safe direction — a minimal TOML writes no file the repo did not ask for.
+`render` says it wrote nothing rather than exiting quietly, so an operator who
+expected files learns the flags are off; rendering nothing in silence would be
+the thing this package exists to prevent. Having nothing to render is not the same as a render that cannot stop:
+`agents-section`'s nested-`AGENTS.md` clause is gated by no flag and runs before
+every write, so an all-off render still fails on a repo holding such a section.
+`references/checklist.md` § Adding a repo makes clearing one a pass-one step for
+that reason.
 
 What is an error is a flag combination where something enabled reaches nothing.
 Three of those, all enforced by `toml-schema`:

--- a/skills/bot-instructions/schemas/repo-toml.md
+++ b/skills/bot-instructions/schemas/repo-toml.md
@@ -96,14 +96,21 @@ is a valid glob and every validator passes. One holding `#` becomes a comment in
 `.coderabbit.yaml`. A ban list closes the shapes someone thought of; a character
 class closes the rest.
 
-**Path shape, on top of the class.** Refused: a leading `/`, a trailing `/`, a
-`..` component, and an empty component. The class does not cover these — `.`
-and `/` are both allowed characters, so `../**` and `/src/**` are made of
-nothing but permitted bytes — and they are the two shapes that matter most:
-`path_filters` hands these patterns to `git sparse-checkout`, and a `..` there
-is a path-escape in the one place this package gives its own strings to a
-checkout tool. Leading `/` is refused because it is an anchoring form the
-engines read differently.
+**Path shape, on top of the class.** Refused: an empty glob, a leading `/`, a
+trailing `/`, a `..` component, and an empty component. Each is its own clause,
+so each ships its own control.
+
+The class catches none of them. `.` and `/` are both permitted characters, so
+`../**` and `/src/**` are made of nothing but allowed bytes; and the class
+constrains which characters may appear rather than requiring one to, so `""`
+satisfies it and everything else stated here.
+
+Why each matters. A `..` component is a path escape in the one place this
+package hands its own strings to a checkout tool, since `path_filters` reaches
+`git sparse-checkout`. A leading `/` is an anchoring form the engines read
+differently. An empty glob means something different to each of the five, so it
+renders as a pattern whose effect is undefined and engine-dependent — the silent
+failure this package exists to remove.
 
 The metacharacters the class leaves out are worth naming for the error message:
 a brace (`{`, `}`), extglob (`!(`, `@(`, `+(`, `?(`, `*(`), a comma, a
@@ -112,7 +119,8 @@ backslash, a leading `!`, and a double quote. A comma because Copilot's
 because at least one engine reads them differently from the others, and a
 pattern that means two things is worse than one that is rejected.
 
-An empty glob list is an error wherever a glob list is required.
+An empty glob list is an error wherever a glob list is required, which is the
+list-level counterpart of the empty-glob clause above.
 
 ## Keys
 
@@ -311,9 +319,9 @@ here is the only predicate.
 | `[doctrine.append]` / `[doctrine.replace]` values | yes | yes | yes | – | yes | – |
 | doctrine block text | yes | yes | yes | – | yes | – |
 | `[[exclusions.path]] reason` | – | – | yes | yes | – | single line |
-| `[[surface]] globs`, `exclude_globs`, `[[exclusions.path]] glob` | – | – | – | – | the glob dialect above, plus its path-shape rule |
-| `[tone] coderabbit` | – | – | – | – | ASCII only |
-| `[cadence] qodo_commands` entries | – | – | – | – | a verb from the set above, no whitespace, no `--` |
+| `[[surface]] globs`, `exclude_globs`, `[[exclusions.path]] glob` | – | – | – | – | – | non-empty, the glob dialect above, and its path-shape rule |
+| `[tone] coderabbit` | – | – | – | – | – | ASCII only |
+| `[cadence] qodo_commands` entries | – | – | – | – | – | a verb from the set above, no whitespace, no `--` |
 
 The predicates, written once:
 

--- a/skills/bot-instructions/schemas/repo-toml.md
+++ b/skills/bot-instructions/schemas/repo-toml.md
@@ -280,15 +280,32 @@ read to decide where the install state lives and the sibling only when it says
 so. SKILL.md § The render inputs states the pair; the marker names each by the
 path actually read.
 
+**A derived entry's reason is fixed, and this is the only place it is written:**
+
+> harness render output, owned upstream — a defect here is fixed at the source
+> and arrives by re-render
+
+Every derived entry carries that exact string, because every derived entry is
+excluded for that one reason and nothing about the tree distinguishes them. A
+render rule that wants a reason takes it from here rather than restating it, and
+the string is single-line ASCII with no `-->` and no `#`, so it satisfies every
+constraint a rendered comment is under by construction rather than by check.
+Without it the render rules would demand bytes the schema never supplies:
+`reason` is a required key on `[[exclusions.path]]` entries alone, and a derived
+entry has no TOML row to carry one.
+
 `[[exclusions.path]]` entries add repo-specific paths.
 
 | Key | Type | Required | Meaning |
 |-----|------|----------|---------|
 | `glob` | string | yes | A pattern in the dialect above |
-| `reason` | string | yes | Why this path is not reviewable. Rendered as a comment beside the entry in every surface that supports comments |
+| `reason` | string | yes | Why this path is not reviewable. Rendered as a comment beside the entry on the surfaces whose render rules say so |
 
 A reason is required because an exclusion with no stated reason is
-indistinguishable from a mistake at the next read.
+indistinguishable from a mistake at the next read. That argument covers derived
+entries too, which is why they carry the fixed string above rather than nothing;
+what they do not have is a TOML row, so the required key stays on
+`[[exclusions.path]]` and the generator supplies the rest.
 
 ### `[[surface]]`
 

--- a/skills/bot-instructions/schemas/validators.md
+++ b/skills/bot-instructions/schemas/validators.md
@@ -281,10 +281,12 @@ absent from the union of `[review_agent] issues_user_guidelines` and
 `compliance_user_guidelines`, or the reverse. Blocks are compared by identity
 after the same normalization the render applies, not by whole-string equality:
 the two sections carry the same set of blocks, split differently. It also
-rejects a `[github_app] pr_commands` entry naming a command whose section
-carries no guidance at all. That set is `repo-toml.md` § `[cadence]`'s verb
-set, read rather than restated: the two have to accept the same commands, and
-a second copy here is how they would stop.
+rejects a `[github_app] pr_commands` entry **whose role in `repo-toml.md`
+§ `[cadence]`'s verb table is review** and whose section carries no guidance.
+The clause reads that table's role column rather than restating a set: a
+non-review verb reads a section this render leaves alone by design, so its
+presence is not a finding, and the vendor's own documented default carries
+one.
 
 The set it compares is the routing table's three `pr_agent` columns, read as
 data rather than restated here. That is what keeps this a check on the render
@@ -313,11 +315,21 @@ number.
 Macroscope cannot read is a file it will not apply, and the repo's only signal
 is the absence of a comment it was expecting.
 
-**Rejects.** In a generated correctness file: a frontmatter key other than
-`include` or `exclude`, a value that is not a YAML array of strings, and an
-empty `include`. In the generated `ignore.md`: a non-blank line that is neither
-a glob in the dialect nor a single-line HTML comment, and any line after the
-first `-->` on a comment line.
+**Rejects.** In a generated correctness file for a `[[surface]]`: a frontmatter
+key other than `include` or `exclude`, a value that is not a YAML array of
+strings, and an `include` that is empty **or absent**. Absent is the one that
+matters: omitted frontmatter applies repo-wide, so a renderer bug dropping
+`include` silently widens a path-scoped surface to the whole repository with
+every validator green.
+
+`doctrine.md` is the one generated correctness file that carries no frontmatter,
+and it is deliberate — the routing table gives it every block precisely because
+it applies repo-wide. It is told apart by its name, which is reserved and which
+no surface may take, so the two cases never have to be guessed at.
+
+**Rejects, in the generated `ignore.md`.** A non-blank line that is neither a
+glob in the dialect nor a single-line HTML comment, and any line after the first
+`-->` on a comment line.
 
 The `ignore.md` half holds the render to this package's own conservative
 grammar, not to a vendor rule: Macroscope documents none. The grammar assumes

--- a/skills/bot-instructions/schemas/validators.md
+++ b/skills/bot-instructions/schemas/validators.md
@@ -1,0 +1,234 @@
+# Validators
+
+Every bot in this set fails silently. A rejected config, a mistyped enum, an
+exclusion list that fell behind the tree it excludes: in each case the review
+still runs, still posts, and says nothing about the configuration it discarded.
+The pull request looks reviewed. Nobody learns otherwise until a defect ships.
+
+So each validator below names the silent failure it exists to catch, then what
+it rejects. A validator runs on every `render` before the tree is written and
+on every `check`. A failure fails the run; none of them warns.
+
+Each validator ships with a must-fail control: a fixture carrying exactly the
+defect that validator names, asserted red. A validator with no red fixture is
+indistinguishable from one that passes on everything.
+
+The glob dialect gets the same treatment from the other side. It claims a set
+of patterns every target reads alike, which is a claim about five engines and
+not about this code, so it ships conformance vectors: each pattern evaluated
+against each target's own matcher, with a red case for a pattern the dialect
+allows and the engines disagree on. A dialect asserted only in prose is a
+guess.
+
+**What no validator can do.** Each one judges bytes this generator produced.
+None of them observes a bot's actual behavior, and several of the guarantees
+this package wants live outside any file: a Copilot content-exclusion path, an
+organization CodeRabbit override, a portal toggle. Those are
+`references/checklist.md`, and a validator that claimed to cover them would be
+the false confidence this file exists to prevent.
+
+## `toml-schema`
+
+**Silent failure.** `bot-instructions.toml` is hand-written and is the one
+input a person edits. A misspelled key that the reader ignores leaves the
+default in force, and the render is plausible, complete, and wrong.
+
+**Rejects.** Any key or table the schema does not define, any value of the
+wrong type, an empty glob list, a glob outside the dialect in `repo-toml.md`, a
+`reason` that is multi-line or contains `-->`, a surface name that is empty,
+malformed, duplicated or reserved, an unknown doctrine block id in
+`[doctrine.append]` or `[doctrine.replace]`, `qodo_best_practices` or
+`qodo_review_md` true while `qodo` is false, and a `schema` value other
+than `1`.
+
+## `coderabbit-schema`
+
+**Silent failure.** CodeRabbit rejects an invalid `.coderabbit.yaml` whole and
+reviews with resolved defaults instead. The review posts normally, and nothing
+on the pull request says the file was discarded. A repo can carry an inert
+config for as long as nobody re-reads the file. One over-long
+`tone_instructions` does this, and the root schema sets
+`additionalProperties: false`, so a single misspelled top-level key does it too.
+
+**Rejects.** Any deviation of the rendered file from CodeRabbit's published
+schema, validated against a copy vendored in the consuming repo rather than
+fetched at check time: an unknown top-level key, a wrong type, an enum miss
+(`reviews.profile` is `quiet`, `chill` or `assertive`), and every documented
+length cap, of which `tone_instructions` at 250 and
+`reviews.path_instructions[].instructions` at 20,000 are the two this package
+can reach. Lengths count Unicode code points, which is what the schema's
+`maxLength` counts; `[tone] coderabbit` is required to be ASCII so the local
+count and the vendor's cannot disagree.
+
+**Rejects, also.** A schema keyword the validator does not implement. A
+hand-written validator that ignores an unknown constraint under-validates while
+reporting success, which is the same class of failure one level up. Naming the
+keyword and failing is the only safe answer, and it means a schema refresh can
+block renders until the validator catches up: the vendored copy's provenance
+and its refresh step are a checklist line for that reason.
+
+## `coderabbit-filters`
+
+**Silent failure.** Two of them. A `path_filters` list with one entry lacking
+the `!` prefix is an allowlist, and every file in the repo that no entry names
+stops being reviewed. And CodeRabbit feeds these same patterns to `git
+sparse-checkout`, which understands plain globs only, so an extglob or brace
+pattern matches nothing and excludes nothing while reading as an exclusion.
+
+**Rejects.** Any `path_filters` entry not starting with `!`. Any entry whose
+remainder is outside the glob dialect. Both are checked on the rendered file,
+not on the TOML, so a future generator change cannot route around them.
+
+## `exclusion-consistency`
+
+**Silent failure.** A harness refresh renders a new skill into the repo. The
+exclusion lists name the skills that existed when someone last wrote them, so
+the new tree is reviewed as if it were this repo's code. Findings arrive on
+files nobody here can fix, and the only signal is reviewer noise.
+
+**Rejects.** A mismatch between the derived part of the rendered exclusion set
+and the set derived fresh from the repo's own `kendex.toml`: every rendered
+`.agents/skills/<name>`, no tree declared `in-place`, plus the per-harness
+render directories the install declares. The comparison is over the derived
+part alone, because the rendered set also holds every `[[exclusions.path]]`
+entry and whole-set equality would fail on the first hand-written exclusion.
+Runs only when `[exclusions] derive_render` is true.
+
+**Rejects, also.** An exclusion entry present in one rendered surface and
+absent from another, where both surfaces have an exclusion mechanism.
+
+**What it does not establish.** That the bots exclude the same files. Codex has
+no exclusion mechanism at all, Copilot's lives in a settings page no repo file
+can read, Qodo's `[ignore]` governs `/improve` rather than what the review
+agent reads, and a Macroscope agent's own `include` overrides `ignore.md`. This
+validator compares the strings the generator emitted. Effective parity across
+five bots is not a property any repo-side check can assert.
+
+## `copilot-frontmatter`
+
+**Silent failure.** A `.instructions.md` file with no `applyTo`, or an empty
+one, matches nothing and is never loaded. An `excludeAgent` value outside the
+two GitHub accepts is not an error either; the file simply loads for every
+agent, and reviewer doctrine reaches the working agent the flag was meant to
+keep it from.
+
+**Rejects.** A generated `.instructions.md` with no `applyTo`, an `applyTo`
+that is empty or whitespace, an `applyTo` emitted as a YAML array rather than a
+single comma-separated string, and an `excludeAgent` value other than
+`code-review` or `cloud-agent`.
+
+## `copilot-budget`
+
+**Silent failure.** GitHub asks for "no longer than 2 pages" and documents no
+numeric cap, so an over-long file has no error to produce. What happens past
+that length is undocumented, which is itself the reason to hold a budget.
+
+**Rejects.** A rendered `.github/copilot-instructions.md` over `[budgets]
+copilot_chars`, naming the count, the budget, and the sections by size so the
+author can see what to cut.
+
+## `qodo-parity`
+
+**Silent failure.** `/review` reads `[pr_reviewer] extra_instructions`.
+`/agentic_review` reads `[review_agent]`. Guidance written into one section is
+absent from the other command's path, and the review runs with less context
+while the file looks configured.
+
+**Rejects.** A doctrine block present in `[pr_reviewer] extra_instructions` and
+absent from the union of `[review_agent] issues_user_guidelines` and
+`compliance_user_guidelines`, or the reverse. Blocks are compared by identity
+after the same normalization the render applies, not by whole-string equality:
+the two sections carry the same set of blocks, split differently. It also
+rejects a `[github_app] pr_commands` entry naming a command whose section
+carries no guidance at all.
+
+## `macroscope-render`
+
+**Silent failure.** A `.macroscope/correctness/` file whose frontmatter
+Macroscope cannot read is a file it will not apply, and the repo's only signal
+is the absence of a comment it was expecting.
+
+**Rejects.** In a generated correctness file: a frontmatter key other than
+`include` or `exclude`, a value that is not a YAML array of strings, and an
+empty `include`. In the generated `ignore.md`: a non-blank line that is neither
+a glob in the dialect nor a single-line HTML comment, and any line after the
+first `-->` on a comment line.
+
+The `ignore.md` half holds the render to this package's own conservative
+grammar, not to a vendor rule: Macroscope documents none. The grammar assumes
+every non-blank line is a pattern and keeps everything else inside a comment,
+which is the safe direction to be wrong in. Whether Macroscope agrees is a
+checklist line, not something this validator can answer.
+
+Check-run agent frontmatter is not validated, because this package writes no
+check-run agents. A validator for keys nothing emits passes vacuously.
+
+## `agents-section`
+
+**Silent failure.** Codex reads `AGENTS.md` § Code Review Rules and nothing
+else. Rename the heading, move the section, or delete the file, and Codex
+reviews every pull request with no repo rules at all, posting normally
+throughout.
+
+**Rejects.** A nested `AGENTS.md` anywhere below the root carrying a `## Code
+Review Rules` section. Codex reads the nearest nested file covering each
+changed path, so such a section reaches it without passing through doctrine,
+and the generator writes only the root one. A root `AGENTS.md` with no `## Code
+Review Rules` heading, or with more than one. An owned region whose bytes
+differ from the render. A doctrine
+or repo line whose first non-whitespace character is `#` after three or fewer
+leading spaces, which markdown reads as a heading and which would end the owned
+region at the next render, taking the rest of the section with it.
+
+## `orphan`
+
+**Silent failure.** A `[[surface]]` is removed from the TOML, or a bot
+capability is switched off. The generator writes nothing for it and deletes
+nothing, so the file it wrote is still there and the bot still loads it. The
+repo's source says one thing and its bots read another, and no render will ever
+touch that file again.
+
+**Rejects.** Any file at a path this package can generate that carries the
+marker and that the current TOML does not produce, and any file at the
+generated paths of a bot capability the TOML sets `false`, marker or not. The
+second case has no marker requirement because the TOML says that bot is off
+while a file at its path says otherwise, and which hand wrote the file does not
+change that. That covers a retired
+surface's `.instructions.md` and `correctness/*.md`, and it covers the
+root-level files of a bot whose flag went false: `.coderabbit.yaml`,
+`.pr_agent.toml`, `best_practices.md`, `REVIEW.md`,
+`.github/copilot-instructions.md`, and the `.macroscope/` tree. Files at those
+paths with no marker, for a capability that is on, are hand-written, are not
+judged here, and are what `adopt` exists to take over.
+
+The fix is a deletion in the commit that retired the surface or the bot, which
+is why the generator reports rather than deletes: removing a file is a decision
+the commit's author makes.
+
+## `drift`
+
+**Silent failure.** A hand edit to a generated file survives until the next
+render, then vanishes. Between those two moments the repo's behavior does not
+match its source, and the edit's author has no reason to suspect it.
+
+**Rejects.** Any generated path whose bytes differ from a fresh render, naming
+the path and the differing region. `check` reads the working tree by default
+and the index under `--staged`, so a pre-commit lane judges what is about to be
+committed rather than what happens to be on disk.
+
+## Where these run
+
+`render` runs all of them against the scratch tree before writing, and writes
+nothing when one fails. `check` runs all of them against the repo.
+
+A repo wires `check` into whatever runs its other repo guards. This package
+ships no hook of its own, because a repo that already has a commit chain does
+not need a second one.
+
+**In CI, run this package's copy from the default branch, not the pull
+request's.** Three of the five bots read their instruction files from the head,
+and the generator, the validators and the doctrine source are all files a pull
+request can edit. A `check` run out of the head checkout proves that
+head-controlled inputs agree with head-controlled code, which is not the
+question. The repo-side rules that go with this are in SKILL.md § A pull
+request changing its own review.

--- a/skills/bot-instructions/schemas/validators.md
+++ b/skills/bot-instructions/schemas/validators.md
@@ -102,10 +102,11 @@ The clauses are the cells of `repo-toml.md` § The content refusals: every marke
 cell is one clause with one control, and the predicates are that table's. That
 table carries every one of them, `[tone] coderabbit`'s ASCII rule and the
 `qodo_commands` verb set included, so neither list has anything the other lacks.
-One clause lives outside it, because it is a shape rather than a content
-refusal: a glob with a leading or trailing `/`, a `..` component, or an empty
-one, none of which the character class can catch since every byte in them is
-permitted.
+The glob row's path-shape rule is the one entry whose clauses that table names
+rather than marks, because they are shapes rather than content refusals: an
+empty glob, a leading or trailing `/`, a `..` component, and an empty component,
+each its own clause with its own control. The character class catches none of
+them — every byte in them is permitted, and an empty glob has no bytes at all.
 
 Reading the table's marked cells is how the control count is checked, which is
 what a validator restating its own copy of the predicates would defeat.

--- a/skills/bot-instructions/schemas/validators.md
+++ b/skills/bot-instructions/schemas/validators.md
@@ -249,6 +249,12 @@ would otherwise derive nothing and pass.
 **Rejects, also.** An exclusion entry present in one rendered surface and
 absent from another, where both surfaces have an exclusion mechanism.
 
+**Rejects, also.** A non-empty exclusion set that a destination the routing
+table marks as carrying the paths does not carry: `AGENTS.md`, `pr_agent
+issues`, `pr_agent extra`. That is what holds the requirement in SKILL.md
+§ Every rendered config excludes the render trees — without it a render could
+drop the paths from the one surface Codex reads and violate nothing checkable.
+
 **What it does not establish.** That the bots exclude the same files. Codex has
 no exclusion mechanism at all, Copilot's lives in a settings page no repo file
 can read, Qodo's `[ignore]` governs `/improve` rather than what the review
@@ -511,8 +517,9 @@ failing on bytes nobody is committing.
 **Controls.** The hand-edit fixture, a fixture whose only change is a deleted
 marker line, and one pair per render input for the mode. Per input — the TOML,
 the spec copy, the vendored schema, each install manifest read — a staged,
-consistent set with a divergent worktree copy of that input, asserted green; and a staged
-copy of that input that its staged outputs are stale against, asserted red. Plus
+consistent set with a divergent worktree copy of that input, asserted green;
+and a staged copy of that input that its staged outputs are stale against,
+asserted red. Plus
 one for absence: an input staged as absent, asserted on the absence rather than
 on its worktree copy.
 

--- a/skills/bot-instructions/schemas/validators.md
+++ b/skills/bot-instructions/schemas/validators.md
@@ -184,6 +184,15 @@ can reach. Lengths count Unicode code points, which is what the schema's
 `maxLength` counts; `[tone] coderabbit` is required to be ASCII so the local
 count and the vendor's cannot disagree.
 
+**Rejects, the completeness clause.** A top-level property the vendored schema
+defines that the render does not carry. Schema validation alone judges what is
+present and says nothing about what is absent, so a render that dropped a
+property would validate while that setting silently resumed resolving down the
+unversioned ladder — which is the whole thing full state exists to stop.
+`renders.md` promises every top-level property; this is what holds the promise,
+and it is what makes the next schema refresh report a newly added property
+instead of quietly widening the gap.
+
 **Rejects, also.** A missing, unreadable or unparseable
 `.bot-instructions/coderabbit-schema.json`, whenever `[bots] coderabbit` is
 true, on both verbs. Never a skipped validator: no verb writes that file, so

--- a/skills/bot-instructions/schemas/validators.md
+++ b/skills/bot-instructions/schemas/validators.md
@@ -69,12 +69,31 @@ the false confidence this file exists to prevent.
 input a person edits. A misspelled key that the reader ignores leaves the
 default in force, and the render is plausible, complete, and wrong.
 
-**Rejects.** Any key or table the schema does not define, any value of the
-wrong type, an empty glob list, a glob outside the dialect in `repo-toml.md`, a
-`reason` that is multi-line or contains `-->`, a surface name that is empty,
+**Rejects, the shape set.** Any key or table the schema does not define, any
+value of the wrong type, an empty glob list, a surface name that is empty,
 malformed, duplicated or reserved, an unknown doctrine block id in
-`[doctrine.append]` or `[doctrine.replace]`, and a `schema` value other
-than `1`.
+`[doctrine.append]` or `[doctrine.replace]`, and a `schema` value other than
+`1`.
+
+**Rejects, the content set.** Closure over keys and types leaves the contents of
+values that land in a control position, and those are where an injection goes.
+Each of these is its own clause with its own control:
+
+- A glob holding any byte outside the dialect's character class, which covers a
+  newline, a tab, another control character, leading or trailing whitespace, and
+  `#`, as well as the metacharacters the class leaves out.
+- A `[repo] name` that is multi-line or outside `[A-Za-z0-9._-]`.
+- A line beginning `#`, `---`, or the marker text in `[repo] summary`, in a
+  `[[surface]] instructions`, or in a `[doctrine.append]` or
+  `[doctrine.replace]` value.
+- A `[[exclusions.path]] reason` that is multi-line or contains `-->`.
+- A `[cadence] qodo_commands` entry outside the documented verb set, or carrying
+  whitespace or `--`.
+
+Every content refusal `repo-toml.md` states is in that list. A refusal stated
+there and missing here would ship with nothing proving it fires, which is what
+the per-clause control rule exists to make checkable by reading one paragraph
+against the other.
 
 **Rejects, the cross-flag set.** `qodo_best_practices` or `qodo_review_md` true
 while `qodo` is false. `copilot` or `coderabbit` true while `codex` is false,
@@ -98,8 +117,9 @@ config for as long as nobody re-reads the file. One over-long
 `additionalProperties: false`, so a single misspelled top-level key does it too.
 
 **Rejects.** Any deviation of the rendered file from CodeRabbit's published
-schema, validated against a copy vendored in the consuming repo rather than
-fetched at check time: an unknown top-level key, a wrong type, an enum miss
+schema, validated against the copy vendored at
+`.bot-instructions/coderabbit-schema.json` rather than fetched at check
+time: an unknown top-level key, a wrong type, an enum miss
 (`reviews.profile` is `quiet`, `chill` or `assertive`), and every documented
 length cap, of which `tone_instructions` at 250 and
 `reviews.path_instructions[].instructions` at 20,000 are the two this package
@@ -112,7 +132,9 @@ hand-written validator that ignores an unknown constraint under-validates while
 reporting success, which is the same class of failure one level up. Naming the
 keyword and failing is the only safe answer, and it means a schema refresh can
 block renders until the validator catches up: the vendored copy's provenance
-and its refresh step are a checklist line for that reason.
+and its refresh step are a checklist line for that reason. That copy is also a
+policy path, since a loosened schema turns this validator green on a file
+CodeRabbit discards whole and keeps it green afterwards.
 
 ## `coderabbit-filters`
 
@@ -134,12 +156,20 @@ the new tree is reviewed as if it were this repo's code. Findings arrive on
 files nobody here can fix, and the only signal is reviewer noise.
 
 **Rejects.** A mismatch between the derived part of the rendered exclusion set
-and the set derived fresh from the repo's own `kendex.toml`: every rendered
-`.agents/skills/<name>`, no tree declared `in-place`, plus the per-harness
-render directories the install declares. The comparison is over the derived
-part alone, because the rendered set also holds every `[[exclusions.path]]`
-entry and whole-set equality would fail on the first hand-written exclusion.
-Runs only when `[exclusions] derive_render` is true.
+and the set derived fresh from the repo's resolved install manifest: every
+rendered `.agents/skills/<name>`, no tree declared `in-place`, plus the
+per-harness render directories the install declares. The comparison is over the
+derived part alone, because the rendered set also holds every
+`[[exclusions.path]]` entry and whole-set equality would fail on the first
+hand-written exclusion. Runs only when `[exclusions] derive_render` is true.
+
+**Rejects, also.** A resolved manifest that declares no install. Reading the
+wrong file and finding nothing to exclude is indistinguishable from a repo with
+nothing to exclude, and this comparison cannot tell them apart on its own: both
+sides come back empty and agree. So emptiness is the finding. One of this
+validator's controls is a source-catalog repo, where `kendex.toml` carries the
+published catalog and `kendex-local.toml` carries the install — the shape that
+would otherwise derive nothing and pass.
 
 **Rejects, also.** An exclusion entry present in one rendered surface and
 absent from another, where both surfaces have an exclusion mechanism.
@@ -322,10 +352,10 @@ a path the TOML does not produce and that this package never wrote is neither.
 
 **Which tree.** `check` reads the working tree by default. Under `--staged` it
 reads the index — and the index for **every render input**, not only the
-outputs: `bot-instructions.toml`, the doctrine source, and `kendex.toml` when
-`derive_render` is on. A file absent from the index is that absence, not its
-worktree copy. Outputs-only would be wrong in both directions in the pre-commit
-lane this mode exists for: a commit staging a TOML change with its re-rendered
+outputs: `bot-instructions.toml`, the doctrine source, the vendored schema,
+and the resolved install manifest when `derive_render` is on. A file absent
+from the index is that absence, not its worktree copy. Outputs-only would be
+wrong in both directions in the pre-commit lane this mode exists for: a commit staging a TOML change with its re-rendered
 outputs would red, because the outputs came from the index while the render was
 built from a worktree TOML that may have moved on; and an unstaged doctrine edit
 would silently decide what the staged outputs were compared against, passing or
@@ -352,7 +382,7 @@ place they cannot fail. `orphan` looks for what the current TOML does not
 produce, and the scratch tree holds only what it does produce. `drift` compares
 a path's bytes against a fresh render, which in the scratch tree are the same
 bytes. `exclusion-consistency`'s derived-set clause compares a set against a
-fresh derivation from the same `kendex.toml` in the same run. `agents-section`'s
+fresh derivation from the same manifest in the same run. `agents-section`'s
 nested-`AGENTS.md` clause searches a repo, which the scratch tree is not. Run
 against a scratch tree, all four pass by construction and report a clean run.
 
@@ -375,7 +405,7 @@ question to answer at render time, and the run says so rather than counting them
 as passed. A render exists to change the bytes `drift` compares, so at render
 time `drift` would red on its own purpose. And `exclusion-consistency`'s derived
 clause compares a derivation against itself. Both have force in `check`, against
-a committed tree whose `kendex.toml` and whose files have moved on since someone
+a committed tree whose manifest and whose files have moved on since someone
 last rendered — which is the question they were written for.
 
 A repo wires `check` into whatever runs its other repo guards. This package

--- a/skills/bot-instructions/schemas/validators.md
+++ b/skills/bot-instructions/schemas/validators.md
@@ -6,19 +6,55 @@ still runs, still posts, and says nothing about the configuration it discarded.
 The pull request looks reviewed. Nobody learns otherwise until a defect ships.
 
 So each validator below names the silent failure it exists to catch, then what
-it rejects. A validator runs on every `render` before the tree is written and
-on every `check`. A failure fails the run; none of them warns.
+it rejects. A failure fails the run; none of them warns. Which tree each one
+reads, and which verb runs it, is § Where these run, and it is not the same
+answer for all of them.
 
-Each validator ships with a must-fail control: a fixture carrying exactly the
-defect that validator names, asserted red. A validator with no red fixture is
-indistinguishable from one that passes on everything.
+## Controls
 
-The glob dialect gets the same treatment from the other side. It claims a set
-of patterns every target reads alike, which is a claim about five engines and
-not about this code, so it ships conformance vectors: each pattern evaluated
-against each target's own matcher, with a red case for a pattern the dialect
-allows and the engines disagree on. A dialect asserted only in prose is a
-guess.
+A validator's Rejects paragraph names several independent clauses. One fixture
+per validator proves the validator can fail once and leaves every other clause
+unproven, and an unproven clause that is dead, unreachable, or matching a decoy
+stays green for good. So the rule is per clause, not per validator:
+
+- **One red control per rejection clause.** Each asserts on that validator's
+  own identity or message, never on the run's exit code. All the validators run
+  together, so a `coderabbit-filters` fixture that also trips `toml-schema`
+  reds for the wrong reason and reads as coverage.
+- **One canonical valid render asserted green.** Without it, a validator that
+  rejects everything satisfies the entire red set.
+- **Two fixtures per numeric bound**, one crossing it and one a single unit
+  inside. A `copilot-budget` fixture that stops short of `[budgets]
+  copilot_chars`, or a `tone_instructions` fixture short of 250 code points,
+  proves the run and not the bound.
+
+A clause with no control is a spec violation, which makes the count checkable
+by reading the Rejects paragraph against the fixture list. A repo-state
+validator's controls are repo fixtures, not scratch-tree ones.
+
+## The glob dialect's vectors
+
+The dialect claims a set of patterns five targets read alike. That is a claim
+about five engines rather than about this code, and only two of the five can be
+asked: CodeRabbit's `path_filters` go through minimatch and through real `git
+sparse-checkout`, both of which a test can run at a pinned version. Copilot's
+`applyTo` matcher, Qodo's `[ignore]` matcher and Macroscope's `include` matcher
+are unpublished — `references/limits.md` documents no grammar for any of them,
+and says outright that Macroscope documents none.
+
+So the vectors cover the two that can be measured, and the other three are a
+one-time confirmation in `references/checklist.md`. Claiming five-engine
+conformance from a harness that can reach two would be the false confidence
+this file exists to prevent.
+
+The harness needs its own control, and it cannot be a pattern the dialect
+allows: if the dialect is right, no such pattern produces disagreement, so that
+control could only be built by first finding a dialect bug. The buildable one
+runs in the other direction. Feed a pattern the dialect **refuses** — a brace
+and an extglob are two the dialect names, and their disagreement is exactly why
+they are refused — through the vector harness with the dialect check bypassed,
+and assert the harness reports the disagreement. That proves the instrument on
+an input the dialect guarantees exists.
 
 **What no validator can do.** Each one judges bytes this generator produced.
 None of them observes a bot's actual behavior, and several of the guarantees
@@ -159,6 +195,21 @@ and not a fourth hand-written copy of the routing: a block moved between the two
 `[review_agent]` keys changes one table cell and nothing else, while a block
 dropped from a column reds this validator.
 
+## `qodo-best-practices`
+
+**Silent failure.** Qodo documents 800 lines per file and does not document what
+it does past that. A repo cannot tell from a review whether its guidance was
+read in full, truncated, or dropped.
+
+**Rejects.** A rendered `best_practices.md` over 800 lines, naming the surfaces
+contributing the most lines so the author can see what to cut.
+
+That is the only best-practices cap on a live vendor page, and so the only one
+enforced. Organization and mapped-repository best-practices files layer above
+the generated one and the generator cannot see them, so nothing here bounds the
+total; `references/checklist.md` carries that as a question rather than a
+number.
+
 ## `macroscope-render`
 
 **Silent failure.** A `.macroscope/correctness/` file whose frontmatter
@@ -251,15 +302,81 @@ copilot` there means moving guard's reply-contract pointer first.
 render, then vanishes. Between those two moments the repo's behavior does not
 match its source, and the edit's author has no reason to suspect it.
 
-**Rejects.** Any generated path whose bytes differ from a fresh render, naming
-the path and the differing region. `check` reads the working tree by default
-and the index under `--staged`, so a pre-commit lane judges what is about to be
-committed rather than what happens to be on disk.
+**Rejects.** Any path the current TOML produces whose bytes differ from a fresh
+render, naming the path and the differing region.
+
+**Marker-agnostic, unlike every other rule here.** `render` refuses to replace
+an unmarked file and `orphan` carves unmarked files out, so a marker-gated
+`drift` would let a one-line deletion — the marker comment — drop a file out of
+all three at once: unmarked for `drift`, carved out of `orphan`, refused by
+`render`. Hand-controlled review policy would then sit at a generated path with
+`check` reporting nothing, and a CI lane never renders in place, so `render`'s
+refusal never fires there. Marker-agnostic makes the deleted marker its own byte
+difference, which reds.
+
+The intended consequence: a repo that has not run `adopt` reds on every
+hand-written file at a path its TOML produces. That is the correct signal, and
+it is what `adopt` clears. The seam with `orphan` is the TOML: `drift` judges
+paths the TOML produces now, `orphan` judges marked files it does not. A file at
+a path the TOML does not produce and that this package never wrote is neither.
+
+**Which tree.** `check` reads the working tree by default. Under `--staged` it
+reads the index — and the index for **every render input**, not only the
+outputs: `bot-instructions.toml`, the doctrine source, and `kendex.toml` when
+`derive_render` is on. A file absent from the index is that absence, not its
+worktree copy. Outputs-only would be wrong in both directions in the pre-commit
+lane this mode exists for: a commit staging a TOML change with its re-rendered
+outputs would red, because the outputs came from the index while the render was
+built from a worktree TOML that may have moved on; and an unstaged doctrine edit
+would silently decide what the staged outputs were compared against, passing or
+failing on bytes nobody is committing.
+
+**Controls.** The hand-edit fixture, a fixture whose only change is a deleted
+marker line, and two for the mode: staged TOML plus staged outputs that agree
+with a divergent worktree TOML, asserted green; and a staged TOML whose outputs
+were not re-rendered, asserted red.
 
 ## Where these run
 
-`render` runs all of them against the scratch tree before writing, and writes
-nothing when one fails. `check` runs all of them against the repo.
+Two kinds, and the difference is what each judges.
+
+**Byte validators** judge one render — its inputs and the bytes it produced —
+and nothing around it, so they read the scratch tree, on both verbs:
+`toml-schema`, `coderabbit-schema`, `coderabbit-filters`,
+`copilot-frontmatter`, `copilot-budget`, `qodo-parity`, `qodo-best-practices`,
+`macroscope-render`, `exclusion-consistency`'s cross-surface clause, and
+`agents-section`'s clauses about the rendered region.
+
+**Repo-state validators** judge the repository, so a scratch tree is the one
+place they cannot fail. `orphan` looks for what the current TOML does not
+produce, and the scratch tree holds only what it does produce. `drift` compares
+a path's bytes against a fresh render, which in the scratch tree are the same
+bytes. `exclusion-consistency`'s derived-set clause compares a set against a
+fresh derivation from the same `kendex.toml` in the same run. `agents-section`'s
+nested-`AGENTS.md` clause searches a repo, which the scratch tree is not. Run
+against a scratch tree, all four pass by construction and report a clean run.
+
+So they read the repo:
+
+| Validator or clause | `render` | `check` |
+|---------------------|----------|---------|
+| `orphan` | the repo, before the write | the repo |
+| `agents-section`, nested-file clause | the repo, before the write | the repo |
+| `drift` | skipped, and named as skipped | the repo |
+| `exclusion-consistency`, derived-set clause | skipped, and named as skipped | the repo |
+
+`orphan` runs before the write because that is the render that creates the
+orphan: retiring a `[[surface]]` or flipping a bot flag is what leaves the file
+behind, and a render that reports a clean pass and then does it is the fail-open
+shape this package exists to remove.
+
+The two skips are not vacuous checks left running; they are checks with no
+question to answer at render time, and the run says so rather than counting them
+as passed. A render exists to change the bytes `drift` compares, so at render
+time `drift` would red on its own purpose. And `exclusion-consistency`'s derived
+clause compares a derivation against itself. Both have force in `check`, against
+a committed tree whose `kendex.toml` and whose files have moved on since someone
+last rendered — which is the question they were written for.
 
 A repo wires `check` into whatever runs its other repo guards. This package
 ships no hook of its own, because a repo that already has a commit chain does

--- a/skills/bot-instructions/schemas/validators.md
+++ b/skills/bot-instructions/schemas/validators.md
@@ -389,15 +389,29 @@ off, while the policy set still counts every `AGENTS.md` as policy-bearing for
 exactly that reason. Its control is independent of the flag.
 
 **Rejects, when `[bots] codex` is true.** A root `AGENTS.md` with no `## Code
-Review Rules` heading, or with more than one. An owned region whose bytes differ
-from the render. A doctrine or repo line matching the heading predicate in
-`repo-toml.md` § The content refusals, which markdown reads as a heading and
-which would end the owned region at the next render, taking the rest of the
-section with it.
+Review Rules` heading, or with more than one. A doctrine or repo line matching
+the heading predicate in `repo-toml.md` § The content refusals, which markdown
+reads as a heading and which would end the owned region at the next render,
+taking the rest of the section with it.
 
-These three judge a rendered region, so with the flag off there is no region to
-judge and rejecting a missing heading would fail a repo that never asked for
-one.
+Both presuppose a managed region, so with the flag off there is none to judge
+and rejecting a missing heading would fail a repo that never asked for one.
+
+**The region's bytes are `drift`'s, not this validator's.** Every clause here is
+structural — does the section exist, is it unique, is there an unmanaged nested
+one, would a line break the region — and none compares anything against a
+render. That is what lets all of them run before the write, which is what makes
+the write-phase splice failure unreachable. A byte comparison could not: before
+the write the repo holds the last render, so any change to doctrine, the TOML or
+the tracker substitution would make it fire and `render` would write nothing,
+leaving the region unable to be updated at all in a repo where `toml-schema`
+requires `codex` true.
+
+One owner also settles the isolation the § Controls rule needs. Two validators
+rejecting the same byte difference means no fixture can red exactly one, and
+`drift` is the owner because a byte comparison against a fresh render is its
+entire subject and it already carries the rule that `AGENTS.md` is compared over
+its region rather than whole.
 
 ## `orphan`
 
@@ -459,11 +473,13 @@ match its source, and the edit's author has no reason to suspect it.
 **Rejects.** Any path the current TOML produces whose bytes differ from a fresh
 render, naming the path and the differing region.
 
-`AGENTS.md` is the one path compared over a region rather than whole. The
-generator never creates that file and never adds its heading, so it always holds
-content the render did not write, and a whole-file comparison would differ on
-every repo. What `drift` compares there is the owned region, which is also all
-the write would have replaced.
+`AGENTS.md` is the one path compared over a region rather than whole, and this
+validator is that comparison's only owner. The generator never creates that file
+and never adds its heading, so it always holds content the render did not write,
+and a whole-file comparison would differ on every repo. What `drift` compares
+there is the owned region, which is also all the write would have replaced.
+`agents-section` judges that region's structure and cites this rule for its
+bytes, so a region fixture reds exactly one validator.
 
 **Marker-agnostic, unlike every other rule here.** `render` refuses to replace
 an unmarked file and `orphan` carves unmarked files out, so a marker-gated
@@ -494,8 +510,8 @@ failing on bytes nobody is committing.
 
 **Controls.** The hand-edit fixture, a fixture whose only change is a deleted
 marker line, and one pair per render input for the mode. Per input — the TOML,
-the spec copy, the vendored schema, the resolved manifest — a staged, consistent
-set with a divergent worktree copy of that input, asserted green; and a staged
+the spec copy, the vendored schema, each install manifest read — a staged,
+consistent set with a divergent worktree copy of that input, asserted green; and a staged
 copy of that input that its staged outputs are stale against, asserted red. Plus
 one for absence: an input staged as absent, asserted on the absence rather than
 on its worktree copy.
@@ -534,7 +550,7 @@ So they read the repo:
 |---------------------|----------|---------|
 | `orphan` | the repo, before the write | the repo |
 | `agents-section`, every clause | the repo, before the write | the repo |
-| `drift` | skipped, and named as skipped | the repo |
+| `drift`, the `AGENTS.md` owned region included | skipped, and named as skipped | the repo |
 | `exclusion-consistency`, derived-set clause | skipped, and named as skipped | the repo |
 
 `orphan` runs before the write because that is the render that creates the
@@ -546,13 +562,17 @@ shape this package exists to remove.
 direction. The write-phase splice fails when the owned region cannot be located,
 and by then other outputs have been replaced — a partial render, against
 SKILL.md's promise that a validator failure leaves the repo untouched. Checking
-the heading before the write is what makes that failure unreachable.
+the heading before the write is what makes that failure unreachable. Every
+clause it has is structural, so none of them compares against a render and none
+needs skipping; the region's bytes belong to `drift`, which is skipped.
 
 The two skips are not vacuous checks left running; they are checks with no
 question to answer at render time, and the run says so rather than counting them
 as passed. A render exists to change the bytes `drift` compares, so at render
-time `drift` would red on its own purpose. And `exclusion-consistency`'s derived
-clause compares a derivation against itself. Both have force in `check`, against
+time `drift` would red on its own purpose — the `AGENTS.md` region most of all,
+where the repo holds the last render and any doctrine, TOML or tracker change
+makes the bytes differ by design. And `exclusion-consistency`'s derived clause
+compares a derivation against itself. Both have force in `check`, against
 a committed tree whose manifest and whose files have moved on since someone
 last rendered — which is the question they were written for.
 

--- a/skills/bot-instructions/schemas/validators.md
+++ b/skills/bot-instructions/schemas/validators.md
@@ -249,15 +249,26 @@ five bots is not a property any repo-side check can assert.
 ## `copilot-frontmatter`
 
 **Silent failure.** A `.instructions.md` file with no `applyTo`, or an empty
-one, matches nothing and is never loaded. An `excludeAgent` value outside the
-two GitHub accepts is not an error either; the file simply loads for every
-agent, and reviewer doctrine reaches the working agent the flag was meant to
-keep it from.
+one, matches nothing and is never loaded. And `excludeAgent` fails in the
+direction that looks fine: the value names the agent the file is hidden from, so
+a missing key or the wrong one of the two leaves reviewer-only instructions
+loading into the working agent — the inverse of what `reviewer_only` asks for,
+with the file present and its frontmatter parsing.
 
 **Rejects.** A generated `.instructions.md` with no `applyTo`, an `applyTo`
-that is empty or whitespace, an `applyTo` emitted as a YAML array rather than a
-single comma-separated string, and an `excludeAgent` value other than
-`code-review` or `cloud-agent`.
+that is empty or whitespace, and an `applyTo` emitted as a YAML array rather
+than a single comma-separated string.
+
+**Rejects, on `excludeAgent`.** For a surface with `reviewer_only = true`: a
+missing `excludeAgent`, and any value other than `cloud-agent`. `code-review` is
+the documented opposite — it hides the file from the reviewer and leaves the
+working agent reading it — so accepting either value here would accept the one
+case the key exists to prevent. For a surface with `reviewer_only = false` the
+render emits no `excludeAgent`; if one is present it must still be one of the
+two values `references/limits.md` documents.
+
+Two controls on that clause, per § Controls: a reviewer-only surface rendered
+with the key missing, and one rendered with `code-review`.
 
 ## `copilot-budget`
 
@@ -296,16 +307,23 @@ dropped from a column reds this validator.
 
 ## `qodo-best-practices`
 
-**Silent failure.** Qodo documents 800 lines per file and does not document what
-it does past that. A repo cannot tell from a review whether its guidance was
-read in full, truncated, or dropped.
+**Silent failure.** A generated file nobody bounded is a file nobody reads.
+Qodo's guidance is that long best-practices files are processed less
+effectively, and it states no length at which it rejects or truncates one, so
+there is no error to wait for and no signal that guidance went unread.
 
 **Rejects.** A rendered `best_practices.md` over 800 lines, naming the surfaces
 contributing the most lines so the author can see what to cut.
 
-That is the only best-practices cap on a live vendor page, and so the only one
-enforced. Organization and mapped-repository best-practices files layer above
-the generated one and the generator cannot see them, so nothing here bounds the
+**That 800 is this package's budget, not a vendor cap.** Qodo documents it as
+writing guidance; `references/limits.md` marks it a recommendation, and this
+validator is where the package chooses to hold it — the same shape as
+`copilot-budget` against a two-page reading. The failure message says so. A
+render stopped here was stopped by this package, and telling an author Qodo
+refused their file would send them to a vendor with nothing to find.
+
+Organization and mapped-repository best-practices files layer above the
+generated one and the generator cannot see them, so nothing here bounds the
 total; `references/checklist.md` carries that as a question rather than a
 number.
 

--- a/skills/bot-instructions/schemas/validators.md
+++ b/skills/bot-instructions/schemas/validators.md
@@ -72,7 +72,9 @@ Its sites, and which answer each takes:
 | Doctrine block ids: the doctrine source's `###` headings against the routing table's rows | `doctrine-routing`, set equality in both directions |
 | Which block reaches which destination, and in what order | Derived. The routing table in `renders.md` is the single source; per-surface sections cite it and state no order of their own |
 | Content refusals: which input string is under which refusal, and what each refusal's predicate is | Derived. The table in `repo-toml.md` § The content refusals is the single source; `toml-schema`, `agents-section` and the Escaping paragraphs cite it |
-| The Qodo verbs `[cadence] qodo_commands` accepts | Derived. `repo-toml.md` § `[cadence]` states the set; `qodo-parity` reads it rather than carrying its own |
+| The Qodo verbs `[cadence] qodo_commands` accepts, and which half `qodo-parity` requires guidance for | Derived. `repo-toml.md` § `[cadence]` states the set and the split; `qodo-parity` reads it rather than carrying its own |
+| Which paths a render reads: the marker's input list, `drift`'s `--staged` index set, the policy set, the open rule's coverage | Derived. SKILL.md § The render inputs is the single source; the routing table is one of them, and all four cite it rather than each naming its own set |
+| The routing table's own shape: positions contiguous per column, no duplicates, and every block in the two all-eight columns | `doctrine-routing`, which judges the table as well as comparing it to the doctrine source |
 | Rejection clauses against their controls | Checked by reading, and the one exception. § Controls makes the count checkable by requiring one control per clause, which is why every clause has to be enumerated somewhere a reader can count |
 
 **What no validator can do.** Each one judges bytes this generator produced.
@@ -97,14 +99,13 @@ malformed, duplicated or reserved, an unknown doctrine block id in
 **Rejects, the content set.** Closure over keys and types leaves the contents of
 values that land in a control position, and those are where an injection goes.
 The clauses are the cells of `repo-toml.md` § The content refusals: every marked
-cell is one clause with one control, and the predicates are that table's. Two
-clauses live outside it because they are not content refusals on a string:
-
-- A glob whose path shape is refused — a leading or trailing `/`, a `..`
-  component, or an empty one. The character class admits every byte in those,
-  so the shape is checked separately.
-- A `[cadence] qodo_commands` entry outside the verb set `repo-toml.md`
-  § `[cadence]` states, or carrying whitespace or `--`.
+cell is one clause with one control, and the predicates are that table's. That
+table carries every one of them, `[tone] coderabbit`'s ASCII rule and the
+`qodo_commands` verb set included, so neither list has anything the other lacks.
+One clause lives outside it, because it is a shape rather than a content
+refusal: a glob with a leading or trailing `/`, a `..` component, or an empty
+one, none of which the character class can catch since every byte in them is
+permitted.
 
 Reading the table's marked cells is how the control count is checked, which is
 what a validator restating its own copy of the predicates would defeat.
@@ -129,19 +130,38 @@ source's `###` headings are two hand-kept copies of one set. A heading with no
 row renders into nothing at all; a row naming a heading that does not exist
 renders a hole. Both render clean.
 
-`--doctrine` makes the mismatch designed-in rather than hypothetical: in the CI
-lane this package prescribes, the block set comes from the tree under judgment
-and the routing table comes from the trusted default-branch checkout. A pull
-request adding a doctrine block renders green and the block reaches no bot.
-"Block ids are frozen" is a rule, and this is its enforcer.
+`--spec` makes the mismatch designed-in rather than hypothetical: in the CI
+lane this package prescribes, the spec copy comes from the tree under judgment
+while the code runs from the trusted default-branch checkout, so a pull request
+adding a doctrine block is a pull request changing the routing. "Block ids are
+frozen" is a rule, and this is its enforcer. The one flag naming both files is
+what keeps the two halves of the set arriving together; reading doctrine from
+one copy and routing from another would red every legitimate change.
 
-**Rejects.** A `###` block id in the doctrine source with no row in the routing
-table. A routing-table row naming an id the doctrine source does not define. Set
-equality in both directions: the one-directional half leaves the orphaned row
-unchecked, which is the half `--doctrine` produces.
+**Rejects, the set.** A `###` block id in the doctrine source with no row in the
+routing table — an unrouted block is an error, never a silent drop. A
+routing-table row naming an id the doctrine source does not define. Set equality
+in both directions: the one-directional half leaves the orphaned row unchecked.
 
-A byte validator — both inputs belong to the render. Its controls are a block
-with no row and a row with no block.
+**Rejects, the table's own shape.** Nothing else judges the table, and it is the
+generator's single routing input, so a one-character edit to it is a silent
+policy change:
+
+- A position repeated inside a column.
+- A gap in a column's positions, which must run `1..n`.
+- A missing block in the `AGENTS.md` or `macroscope doctrine.md` column. Both
+  columns carry every block, because neither Codex nor Macroscope reads a second
+  surface, and the table states that as an invariant of itself. Delete the `8`
+  from `reply-contract`'s `AGENTS.md` cell and Codex loses the reply contract
+  with every other validator green.
+
+A byte validator — both inputs belong to the render, and `--spec` names the one
+copy both come from, so they cannot arrive from different checkouts. One control
+per clause above.
+
+`qodo-parity` is the weaker relative and is worth reading as such: it compares a
+render against the table the render was generated from, so only a render bug
+reds it. What holds the table itself is here.
 
 ## `coderabbit-schema`
 
@@ -162,6 +182,15 @@ length cap, of which `tone_instructions` at 250 and
 can reach. Lengths count Unicode code points, which is what the schema's
 `maxLength` counts; `[tone] coderabbit` is required to be ASCII so the local
 count and the vendor's cannot disagree.
+
+**Rejects, also.** A missing, unreadable or unparseable
+`.bot-instructions/coderabbit-schema.json`, whenever `[bots] coderabbit` is
+true, on both verbs. Never a skipped validator: no verb writes that file, so
+every repo starts without one, and a validator that skipped on its absence
+would be silent for the life of a repo that never vendored it — which is the
+failure this validator exists to catch, one level up. SKILL.md § Adding a repo
+carries the step that puts the first copy there, and the absent file is one of
+this validator's controls.
 
 **Rejects, also.** A schema keyword the validator does not implement. A
 hand-written validator that ignores an unknown constraint under-validates while
@@ -306,20 +335,29 @@ else. Rename the heading, move the section, or delete the file, and Codex
 reviews every pull request with no repo rules at all, posting normally
 throughout.
 
-Runs only when `[bots] codex` is true, which `toml-schema` requires whenever
-`copilot` or `coderabbit` is. A repo with every bot off has no rendered section
-for this to judge, and rejecting a missing heading there would fail a repo that
-never asked for one.
+**Rejects, always.** A nested `AGENTS.md` anywhere below the root carrying a
+`## Code Review Rules` section. Codex reads the nearest nested file covering each
+changed path, so such a section reaches it without passing through doctrine, and
+the generator writes only the root one.
 
-**Rejects.** A nested `AGENTS.md` anywhere below the root carrying a `## Code
-Review Rules` section. Codex reads the nearest nested file covering each
-changed path, so such a section reaches it without passing through doctrine,
-and the generator writes only the root one. A root `AGENTS.md` with no `## Code
-Review Rules` heading, or with more than one. An owned region whose bytes
-differ from the render. A doctrine
-or repo line matching the heading predicate in `repo-toml.md` § The content
-refusals, which markdown reads as a heading and which would end the owned region
-at the next render, taking the rest of the section with it.
+Unconditional, and this is the clause the flag does not gate. `[bots] codex =
+false` says this package does not manage the section; it says nothing about
+whether Codex is installed, which an administrator changes without touching the
+repo. A repo running Macroscope and Qodo with `codex` off would otherwise lose
+the only detection of an unmanaged surface reaching a bot the TOML cannot switch
+off, while the policy set still counts every `AGENTS.md` as policy-bearing for
+exactly that reason. Its control is independent of the flag.
+
+**Rejects, when `[bots] codex` is true.** A root `AGENTS.md` with no `## Code
+Review Rules` heading, or with more than one. An owned region whose bytes differ
+from the render. A doctrine or repo line matching the heading predicate in
+`repo-toml.md` § The content refusals, which markdown reads as a heading and
+which would end the owned region at the next render, taking the rest of the
+section with it.
+
+These three judge a rendered region, so with the flag off there is no region to
+judge and rejecting a missing heading would fail a repo that never asked for
+one.
 
 ## `orphan`
 
@@ -356,13 +394,21 @@ Copilot and Macroscope walk those subtrees. A marked file one directory down,
 left by a hand move or a directory rename, is at no path the generator would
 write, so a flat scan would miss it while Copilot kept loading it.
 
-The fix is usually a deletion in the commit that retired the surface or the bot,
-which is why the generator reports rather than deletes: removing a file is a
-decision the commit's author makes. It is not always a deletion. Another check
-in the repo may require the file to exist, in which case the fix is to move what
-that check reads before the file goes. kendex is an example: its `tools/guard`
-fails when `.github/copilot-instructions.md` is absent, so retiring `[bots]
-copilot` there means moving guard's reply-contract pointer first.
+**Retiring one is delete-then-render.** `render` runs this before the write and
+fails on what it finds, so the render that would create the orphan never
+completes; the deletion has to come first, in the same commit. `check` is what
+catches a retirement that skipped the render, not the ordinary route. The
+generator reports rather than deletes because removing a file is a decision the
+commit's author makes, and sometimes the fix is not a deletion at all: another
+check in the repo may require the file, in which case what that check reads
+moves first. kendex is the worked example — its `tools/guard` fails when
+`.github/copilot-instructions.md` is absent, so retiring `[bots] copilot` there
+is move the pointer, delete the file, then render.
+
+**De-orphaning the `AGENTS.md` region** is not a deletion of the file. The
+heading is the repo's and has to survive; what goes is the marker and the body
+below it, leaving the section for the repo to fill or leave empty. Until that
+happens `render` fails, the same as for any other orphan.
 
 ## `drift`
 
@@ -396,9 +442,9 @@ a path the TOML does not produce and that this package never wrote is neither.
 
 **Which tree.** `check` reads the working tree by default. Under `--staged` it
 reads the index — and the index for **every render input**, not only the
-outputs: `bot-instructions.toml`, the doctrine source, the vendored schema,
-and the resolved install manifest when `derive_render` is on. A file absent
-from the index is that absence, not its worktree copy. Outputs-only would be
+outputs: every path in SKILL.md § The render inputs, read from that list rather
+than from a copy of it here. A file absent from the index is that absence, not
+its worktree copy. Outputs-only would be
 wrong in both directions in the pre-commit lane this mode exists for: a commit
 staging a TOML change with its re-rendered outputs would red, because the
 outputs came from the index while the render was built from a worktree TOML
@@ -407,9 +453,17 @@ would silently decide what the staged outputs were compared against, passing or
 failing on bytes nobody is committing.
 
 **Controls.** The hand-edit fixture, a fixture whose only change is a deleted
-marker line, and two for the mode: staged TOML plus staged outputs that agree
-with a divergent worktree TOML, asserted green; and a staged TOML whose outputs
-were not re-rendered, asserted red.
+marker line, and one pair per render input for the mode. Per input — the TOML,
+the spec copy, the vendored schema, the resolved manifest — a staged, consistent
+set with a divergent worktree copy of that input, asserted green; and a staged
+copy of that input that its staged outputs are stale against, asserted red. Plus
+one for absence: an input staged as absent, asserted on the absence rather than
+on its worktree copy.
+
+A TOML-only pair is what a generator reading the index for the TOML and the
+worktree for everything else passes, with the failure § Which tree names shipping
+intact. One clause, one control, applied to the validator whose clause names
+four inputs.
 
 ## Where these run
 

--- a/skills/bot-instructions/schemas/validators.md
+++ b/skills/bot-instructions/schemas/validators.md
@@ -56,6 +56,25 @@ they are refused — through the vector harness with the dialect check bypassed,
 and assert the harness reports the disagreement. That proves the instrument on
 an input the dialect guarantees exists.
 
+## Cross-file sets
+
+A set of ids or predicates written out in two files is two copies, and two
+copies drift. This spec is mostly such sets, so the rule is: **every set of ids
+or predicates that appears in more than one file is either derived from one
+named source, or checked by a validator that reds when the copies diverge.**
+Neither "compare them by reading" nor "keep them in sync" counts; both are what
+the divergence gets past.
+
+Its sites, and which answer each takes:
+
+| Set | Answer |
+|-----|--------|
+| Doctrine block ids: the doctrine source's `###` headings against the routing table's rows | `doctrine-routing`, set equality in both directions |
+| Which block reaches which destination, and in what order | Derived. The routing table in `renders.md` is the single source; per-surface sections cite it and state no order of their own |
+| Content refusals: which input string is under which refusal, and what each refusal's predicate is | Derived. The table in `repo-toml.md` § The content refusals is the single source; `toml-schema`, `agents-section` and the Escaping paragraphs cite it |
+| The Qodo verbs `[cadence] qodo_commands` accepts | Derived. `repo-toml.md` § `[cadence]` states the set; `qodo-parity` reads it rather than carrying its own |
+| Rejection clauses against their controls | Checked by reading, and the one exception. § Controls makes the count checkable by requiring one control per clause, which is why every clause has to be enumerated somewhere a reader can count |
+
 **What no validator can do.** Each one judges bytes this generator produced.
 None of them observes a bot's actual behavior, and several of the guarantees
 this package wants live outside any file: a Copilot content-exclusion path, an
@@ -77,23 +96,18 @@ malformed, duplicated or reserved, an unknown doctrine block id in
 
 **Rejects, the content set.** Closure over keys and types leaves the contents of
 values that land in a control position, and those are where an injection goes.
-Each of these is its own clause with its own control:
+The clauses are the cells of `repo-toml.md` § The content refusals: every marked
+cell is one clause with one control, and the predicates are that table's. Two
+clauses live outside it because they are not content refusals on a string:
 
-- A glob holding any byte outside the dialect's character class, which covers a
-  newline, a tab, another control character, leading or trailing whitespace, and
-  `#`, as well as the metacharacters the class leaves out.
-- A `[repo] name` that is multi-line or outside `[A-Za-z0-9._-]`.
-- A line beginning `#`, `---`, or the marker text in `[repo] summary`, in a
-  `[[surface]] instructions`, or in a `[doctrine.append]` or
-  `[doctrine.replace]` value.
-- A `[[exclusions.path]] reason` that is multi-line or contains `-->`.
-- A `[cadence] qodo_commands` entry outside the documented verb set, or carrying
-  whitespace or `--`.
+- A glob whose path shape is refused — a leading or trailing `/`, a `..`
+  component, or an empty one. The character class admits every byte in those,
+  so the shape is checked separately.
+- A `[cadence] qodo_commands` entry outside the verb set `repo-toml.md`
+  § `[cadence]` states, or carrying whitespace or `--`.
 
-Every content refusal `repo-toml.md` states is in that list. A refusal stated
-there and missing here would ship with nothing proving it fires, which is what
-the per-clause control rule exists to make checkable by reading one paragraph
-against the other.
+Reading the table's marked cells is how the control count is checked, which is
+what a validator restating its own copy of the predicates would defeat.
 
 **Rejects, the cross-flag set.** `qodo_best_practices` or `qodo_review_md` true
 while `qodo` is false. `copilot` or `coderabbit` true while `codex` is false,
@@ -106,6 +120,28 @@ instructions the author wrote and nothing will ever read.
 A flag combination that renders nothing readable is the same defect as a flag
 that renders a file reaching nothing. Both fail here rather than rendering
 clean.
+
+## `doctrine-routing`
+
+**Silent failure.** The routing table is the generator's single routing input, so
+a block reaches a surface only through a cell. The table's rows and the doctrine
+source's `###` headings are two hand-kept copies of one set. A heading with no
+row renders into nothing at all; a row naming a heading that does not exist
+renders a hole. Both render clean.
+
+`--doctrine` makes the mismatch designed-in rather than hypothetical: in the CI
+lane this package prescribes, the block set comes from the tree under judgment
+and the routing table comes from the trusted default-branch checkout. A pull
+request adding a doctrine block renders green and the block reaches no bot.
+"Block ids are frozen" is a rule, and this is its enforcer.
+
+**Rejects.** A `###` block id in the doctrine source with no row in the routing
+table. A routing-table row naming an id the doctrine source does not define. Set
+equality in both directions: the one-directional half leaves the orphaned row
+unchecked, which is the half `--doctrine` produces.
+
+A byte validator — both inputs belong to the render. Its controls are a block
+with no row and a row with no block.
 
 ## `coderabbit-schema`
 
@@ -217,7 +253,9 @@ absent from the union of `[review_agent] issues_user_guidelines` and
 after the same normalization the render applies, not by whole-string equality:
 the two sections carry the same set of blocks, split differently. It also
 rejects a `[github_app] pr_commands` entry naming a command whose section
-carries no guidance at all.
+carries no guidance at all. That set is `repo-toml.md` § `[cadence]`'s verb
+set, read rather than restated: the two have to accept the same commands, and
+a second copy here is how they would stop.
 
 The set it compares is the routing table's three `pr_agent` columns, read as
 data rather than restated here. That is what keeps this a check on the render
@@ -279,9 +317,9 @@ changed path, so such a section reaches it without passing through doctrine,
 and the generator writes only the root one. A root `AGENTS.md` with no `## Code
 Review Rules` heading, or with more than one. An owned region whose bytes
 differ from the render. A doctrine
-or repo line whose first non-whitespace character is `#` after three or fewer
-leading spaces, which markdown reads as a heading and which would end the owned
-region at the next render, taking the rest of the section with it.
+or repo line matching the heading predicate in `repo-toml.md` § The content
+refusals, which markdown reads as a heading and which would end the owned region
+at the next render, taking the rest of the section with it.
 
 ## `orphan`
 
@@ -335,6 +373,12 @@ match its source, and the edit's author has no reason to suspect it.
 **Rejects.** Any path the current TOML produces whose bytes differ from a fresh
 render, naming the path and the differing region.
 
+`AGENTS.md` is the one path compared over a region rather than whole. The
+generator never creates that file and never adds its heading, so it always holds
+content the render did not write, and a whole-file comparison would differ on
+every repo. What `drift` compares there is the owned region, which is also all
+the write would have replaced.
+
 **Marker-agnostic, unlike every other rule here.** `render` refuses to replace
 an unmarked file and `orphan` carves unmarked files out, so a marker-gated
 `drift` would let a one-line deletion — the marker comment — drop a file out of
@@ -355,9 +399,10 @@ reads the index — and the index for **every render input**, not only the
 outputs: `bot-instructions.toml`, the doctrine source, the vendored schema,
 and the resolved install manifest when `derive_render` is on. A file absent
 from the index is that absence, not its worktree copy. Outputs-only would be
-wrong in both directions in the pre-commit lane this mode exists for: a commit staging a TOML change with its re-rendered
-outputs would red, because the outputs came from the index while the render was
-built from a worktree TOML that may have moved on; and an unstaged doctrine edit
+wrong in both directions in the pre-commit lane this mode exists for: a commit
+staging a TOML change with its re-rendered outputs would red, because the
+outputs came from the index while the render was built from a worktree TOML
+that may have moved on; and an unstaged doctrine edit
 would silently decide what the staged outputs were compared against, passing or
 failing on bytes nobody is committing.
 
@@ -374,24 +419,27 @@ Two kinds, and the difference is what each judges.
 and nothing around it, so they read the scratch tree, on both verbs:
 `toml-schema`, `coderabbit-schema`, `coderabbit-filters`,
 `copilot-frontmatter`, `copilot-budget`, `qodo-parity`, `qodo-best-practices`,
-`macroscope-render`, `exclusion-consistency`'s cross-surface clause, and
-`agents-section`'s clauses about the rendered region.
+`macroscope-render`, `doctrine-routing`, and `exclusion-consistency`'s
+cross-surface clause.
 
 **Repo-state validators** judge the repository, so a scratch tree is the one
 place they cannot fail. `orphan` looks for what the current TOML does not
 produce, and the scratch tree holds only what it does produce. `drift` compares
 a path's bytes against a fresh render, which in the scratch tree are the same
 bytes. `exclusion-consistency`'s derived-set clause compares a set against a
-fresh derivation from the same manifest in the same run. `agents-section`'s
-nested-`AGENTS.md` clause searches a repo, which the scratch tree is not. Run
-against a scratch tree, all four pass by construction and report a clean run.
+fresh derivation from the same manifest in the same run. Every `agents-section`
+clause reads the repo: the nested-`AGENTS.md` walk needs a repo to walk, and the
+other two need a file the scratch tree does not hold at all, since `AGENTS.md`
+is the one output the build never assembles whole — the build produces the
+region's body and the write splices it. Comparing that body against itself is
+the vacuity the split exists to remove.
 
 So they read the repo:
 
 | Validator or clause | `render` | `check` |
 |---------------------|----------|---------|
 | `orphan` | the repo, before the write | the repo |
-| `agents-section`, nested-file clause | the repo, before the write | the repo |
+| `agents-section`, every clause | the repo, before the write | the repo |
 | `drift` | skipped, and named as skipped | the repo |
 | `exclusion-consistency`, derived-set clause | skipped, and named as skipped | the repo |
 
@@ -399,6 +447,12 @@ So they read the repo:
 orphan: retiring a `[[surface]]` or flipping a bot flag is what leaves the file
 behind, and a render that reports a clean pass and then does it is the fail-open
 shape this package exists to remove.
+
+`agents-section` runs before the write for the same reason from the other
+direction. The write-phase splice fails when the owned region cannot be located,
+and by then other outputs have been replaced — a partial render, against
+SKILL.md's promise that a validator failure leaves the repo untouched. Checking
+the heading before the write is what makes that failure unreachable.
 
 The two skips are not vacuous checks left running; they are checks with no
 question to answer at render time, and the run says so rather than counting them

--- a/skills/bot-instructions/schemas/validators.md
+++ b/skills/bot-instructions/schemas/validators.md
@@ -288,8 +288,12 @@ case the key exists to prevent. For a surface with `reviewer_only = false` the
 render emits no `excludeAgent`; if one is present it must still be one of the
 two values `references/limits.md` documents.
 
-Two controls on that clause, per § Controls: a reviewer-only surface rendered
-with the key missing, and one rendered with `code-review`.
+Three controls, per § Controls, one per clause: a reviewer-only surface
+rendered with the key missing, one rendered with `code-review`, and an ordinary
+surface rendered with an `excludeAgent` outside the two documented values. The
+third is easy to leave out because the render emits no key there, which is
+exactly why it needs naming — a clause nothing exercises is a clause nothing
+proves.
 
 ## `copilot-budget`
 
@@ -523,19 +527,20 @@ that may have moved on; and an unstaged doctrine edit
 would silently decide what the staged outputs were compared against, passing or
 failing on bytes nobody is committing.
 
-**Controls.** The hand-edit fixture, a fixture whose only change is a deleted
-marker line, and one pair per render input for the mode. Per input — the TOML,
-the spec copy, the vendored schema, each install manifest read — a staged,
-consistent set with a divergent worktree copy of that input, asserted green;
-and a staged copy of that input that its staged outputs are stale against,
-asserted red. Plus
-one for absence: an input staged as absent, asserted on the absence rather than
-on its worktree copy.
+**Controls.** The hand-edit fixture; a fixture whose only change is a deleted
+marker line; a fixture editing the `AGENTS.md` owned region, which reds this
+validator alone and is what proves the region comparison lives here rather than
+in `agents-section`; and one pair per render input for the mode. Per input —
+the TOML, the spec copy, the vendored schema, each install manifest read — a
+staged, consistent set with a divergent worktree copy of that input, asserted
+green, and a staged copy of that input that its staged outputs are stale
+against, asserted red. Plus one for absence: an input staged as absent,
+asserted on the absence rather than on its worktree copy.
 
 A TOML-only pair is what a generator reading the index for the TOML and the
-worktree for everything else passes, with the failure § Which tree names shipping
-intact. One clause, one control, applied to the validator whose clause names
-four inputs.
+worktree for everything else passes, with the failure § Which tree names
+shipping intact. One clause, one control, applied to the validator whose clause
+names four inputs.
 
 ## Where these run
 

--- a/skills/bot-instructions/schemas/validators.md
+++ b/skills/bot-instructions/schemas/validators.md
@@ -119,9 +119,13 @@ set while `copilot`, `coderabbit`, `macroscope` and `qodo_best_practices` are
 all false: surface text has no route to any other bot, so those surfaces are
 instructions the author wrote and nothing will ever read.
 
-A flag combination that renders nothing readable is the same defect as a flag
-that renders a file reaching nothing. Both fail here rather than rendering
-clean.
+Each of those is a flag combination where something enabled reaches nothing —
+a file with no reader, a surface with no route, a bot missing the surface its
+doctrine goes through. That is the shape these clauses catch, and it is
+narrower than "renders nothing readable": **every flag false is a legitimate
+state and passes.** `repo-toml.md` § `[bots]` says why, and `render` reports the
+no-op rather than exiting quietly, since a silent nothing is the failure mode
+this package exists to remove.
 
 ## `doctrine-routing`
 
@@ -198,8 +202,9 @@ instead of quietly widening the gap.
 true, on both verbs. Never a skipped validator: no verb writes that file, so
 every repo starts without one, and a validator that skipped on its absence
 would be silent for the life of a repo that never vendored it — which is the
-failure this validator exists to catch, one level up. SKILL.md § Adding a repo
-carries the step that puts the first copy there, and the absent file is one of
+failure this validator exists to catch, one level up. `references/checklist.md`
+§ Adding a repo carries the step that puts the first copy there, and the absent
+file is one of
 this validator's controls.
 
 **Rejects, also.** A schema keyword the validator does not implement. A
@@ -351,7 +356,11 @@ is the absence of a comment it was expecting.
 
 **Rejects.** In a generated correctness file for a `[[surface]]`: a frontmatter
 key other than `include` or `exclude`, a value that is not a YAML array of
-strings, and an `include` that is empty **or absent**. Absent is the one that
+strings, an `include` that is empty **or absent**, and a body carrying no
+instruction text below the marker. That last one is what makes SKILL.md's
+promise that surface text reaches Macroscope true rather than assumed: without
+it a render could emit frontmatter and a marker, satisfy every other clause
+here, and tell Macroscope nothing. Absent is the one that
 matters: omitted frontmatter applies repo-wide, so a renderer bug dropping
 `include` silently widens a path-scoped surface to the whole repository with
 every validator green.

--- a/skills/bot-instructions/schemas/validators.md
+++ b/skills/bot-instructions/schemas/validators.md
@@ -37,9 +37,20 @@ default in force, and the render is plausible, complete, and wrong.
 wrong type, an empty glob list, a glob outside the dialect in `repo-toml.md`, a
 `reason` that is multi-line or contains `-->`, a surface name that is empty,
 malformed, duplicated or reserved, an unknown doctrine block id in
-`[doctrine.append]` or `[doctrine.replace]`, `qodo_best_practices` or
-`qodo_review_md` true while `qodo` is false, and a `schema` value other
+`[doctrine.append]` or `[doctrine.replace]`, and a `schema` value other
 than `1`.
+
+**Rejects, the cross-flag set.** `qodo_best_practices` or `qodo_review_md` true
+while `qodo` is false. `copilot` or `coderabbit` true while `codex` is false,
+because the `AGENTS.md` section is where both of those bots get most of their
+doctrine and where the Copilot pointer sentence aims. A non-empty `[[surface]]`
+set while `copilot`, `coderabbit`, `macroscope` and `qodo_best_practices` are
+all false: surface text has no route to any other bot, so those surfaces are
+instructions the author wrote and nothing will ever read.
+
+A flag combination that renders nothing readable is the same defect as a flag
+that renders a file reaching nothing. Both fail here rather than rendering
+clean.
 
 ## `coderabbit-schema`
 
@@ -142,6 +153,12 @@ the two sections carry the same set of blocks, split differently. It also
 rejects a `[github_app] pr_commands` entry naming a command whose section
 carries no guidance at all.
 
+The set it compares is the routing table's three `pr_agent` columns, read as
+data rather than restated here. That is what keeps this a check on the render
+and not a fourth hand-written copy of the routing: a block moved between the two
+`[review_agent]` keys changes one table cell and nothing else, while a block
+dropped from a column reds this validator.
+
 ## `macroscope-render`
 
 **Silent failure.** A `.macroscope/correctness/` file whose frontmatter
@@ -170,6 +187,11 @@ else. Rename the heading, move the section, or delete the file, and Codex
 reviews every pull request with no repo rules at all, posting normally
 throughout.
 
+Runs only when `[bots] codex` is true, which `toml-schema` requires whenever
+`copilot` or `coderabbit` is. A repo with every bot off has no rendered section
+for this to judge, and rejecting a missing heading there would fail a repo that
+never asked for one.
+
 **Rejects.** A nested `AGENTS.md` anywhere below the root carrying a `## Code
 Review Rules` section. Codex reads the nearest nested file covering each
 changed path, so such a section reaches it without passing through doctrine,
@@ -188,22 +210,40 @@ nothing, so the file it wrote is still there and the bot still loads it. The
 repo's source says one thing and its bots read another, and no render will ever
 touch that file again.
 
-**Rejects.** Any file at a path this package can generate that carries the
-marker and that the current TOML does not produce, and any file at the
-generated paths of a bot capability the TOML sets `false`, marker or not. The
-second case has no marker requirement because the TOML says that bot is off
-while a file at its path says otherwise, and which hand wrote the file does not
-change that. That covers a retired
-surface's `.instructions.md` and `correctness/*.md`, and it covers the
-root-level files of a bot whose flag went false: `.coderabbit.yaml`,
-`.pr_agent.toml`, `best_practices.md`, `REVIEW.md`,
-`.github/copilot-instructions.md`, and the `.macroscope/` tree. Files at those
-paths with no marker, for a capability that is on, are hand-written, are not
-judged here, and are what `adopt` exists to take over.
+**Rejects.** Anything carrying this package's marker that the current TOML does
+not produce. One rule, and the marker is the whole of it: this package wrote
+every marked byte, so a marked file the TOML no longer accounts for is one it
+abandoned.
 
-The fix is a deletion in the commit that retired the surface or the bot, which
-is why the generator reports rather than deletes: removing a file is a decision
-the commit's author makes.
+That covers a retired surface's `.instructions.md` and `correctness/*.md`, the
+root-level files of a bot whose flag went false (`.coderabbit.yaml`,
+`.pr_agent.toml`, `best_practices.md`, `REVIEW.md`,
+`.github/copilot-instructions.md`, the `.macroscope/` tree), and the marked
+`## Code Review Rules` region inside `AGENTS.md` when `[bots] codex` goes false.
+That last one is why the region carries a marker at all: it is never a whole
+file, so a whole-file rule would leave live doctrine in the one place Codex
+reads, reported by nothing.
+
+**Unmarked files are not judged here, whatever the flags say.** A repo with
+`qodo_review_md = false` and its own hand-written `REVIEW.md`, or `copilot =
+false` and an existing `.github/copilot-instructions.md`, is a repo that owns
+those files; this package never wrote them and does not get to call them stale.
+That is also the state every incoming repo is in before `adopt` runs. Taking one
+over is `adopt`'s job and needs the capability on.
+
+**The scan is recursive, over what each bot reads rather than what the generator
+writes.** `.github/instructions/**` and `.macroscope/correctness/**` both, since
+Copilot and Macroscope walk those subtrees. A marked file one directory down,
+left by a hand move or a directory rename, is at no path the generator would
+write, so a flat scan would miss it while Copilot kept loading it.
+
+The fix is usually a deletion in the commit that retired the surface or the bot,
+which is why the generator reports rather than deletes: removing a file is a
+decision the commit's author makes. It is not always a deletion. Another check
+in the repo may require the file to exist, in which case the fix is to move what
+that check reads before the file goes. kendex is an example: its `tools/guard`
+fails when `.github/copilot-instructions.md` is absent, so retiring `[bots]
+copilot` there means moving guard's reply-contract pointer first.
 
 ## `drift`
 


### PR DESCRIPTION
Designs the `bot-instructions` package: one shared doctrine source plus a per-repo
TOML, rendered into each review bot's native instruction surface. No generator —
KEN-1006 implements against these files, and the package ships `user-invocable:
false` with a status block saying so, since a skill advertising three verbs with
no `scripts/` directory is a dead end for whoever loads it.

Closes KEN-1005

## What landed

```
skills/bot-instructions/
  SKILL.md                 doctrine source, what each bot reads and from which
                           branch, the three verbs, file ownership, trust boundary
  README.md                what the package is and the reading order
  schemas/repo-toml.md     every key of bot-instructions.toml, closed schema,
                           the glob dialect, the content-refusal table
  schemas/renders.md       per-surface render rules and the doctrine routing table
  schemas/validators.md    the validators, each named for the silent failure it
                           catches, with the controls contract
  references/limits.md     every vendor cap, enum and read semantic with its source
  references/checklist.md  the per-repo settings no file can configure
```

Placement is the owner's call, recorded on the issue: `docs/plans/`,
`docs/roadmaps/` and `docs/reviews/` were removed in KEN-883 and `docs/` is
consumer-facing, so the design ships as the package's own contract files rather
than as a separate document.

No changelog fragment. The package ships no generator, so nothing a consumer can
use has changed; KEN-1006 carries the entry when `render` lands.

## Vendor re-verification

Every limit was re-checked against live sources, and three research claims did not
survive:

- Copilot code review **does** read `AGENTS.md` on GitHub.com — the research said
  it does not.
- Copilot reads instructions from the **head branch**, documented, not an unknown.
- The **2,000-line accumulated cap and `repo_context_max_lines` default are on no
  live page** and are gone from the spec. The page they came from 404s. The
  800-line cap holds and is now cited to the two pages that carry it verbatim.

Qodo's verb set was got wrong once and corrected: the set is split by role, not
narrowed by size, so the vendor's own documented default
`["/agentic_describe", "/agentic_review"]` stays legal.

## Adversarial cross-model review

Two rounds against Codex (gpt-5.6-sol), both returning STOP on the round they
judged. Round one raised 25 findings; round two closed 16 and raised 6 new ones.

Declined, with reasons rather than labels:

- **Binding bot review evidence to a policy revision** is a merge-gate mechanism,
  and kendex ships `review-gate` for that question. A second gate inside an
  instruction-file generator is the subsystem the simplicity bound rules out. The
  design states the repo-side requirement; the checklist records it.
- **Enforcing that a doctrine edit ships a version bump** is a guard in the
  publishing repo, not something a consumer can check.

### Re-run at `8d60c975`

The two rounds above judged the pre-fix design, so that evidence went stale as
the fix rounds changed it. The gate was re-run at `8d60c975`, through
`codex exec` directly — `second-opinion review` fails with
`code 143` about 45 seconds in on both its paths, and the exact command the
script prints runs fine, so the kill is in `second-opinion-runtime group-run`
under `/usr/bin/timeout`. That is a real defect in the skill and is not this
package's; it is written up at `tmp/so-report.md` for filing from the main
checkout, since `kendex report` refuses to run from a linked worktree.

That pass returned seven findings. Two were fixed here: `copilot-frontmatter`
not requiring `excludeAgent: "cloud-agent"` for a `reviewer_only` surface, and
the 800-line Qodo figure presented as a vendor cap when the vendor documents it
as writing guidance. Five are dispositioned to KEN-1006 with their reasoning:
reviewer-only doctrine reaching the working agent through `AGENTS.md`;
`render-out-of-scope` naming paths no reviewer surface carried (since fixed by
the ratified exclusion requirement above); `orphan` omitting two Macroscope read
paths; `adopt`'s undefined pointer syntax; and `qodo-parity` being unable to
recover block identity from rendered TOML.

One commit lands after that pass, `6eb2386`, and it was not re-gated. It
carries no design: both changes make the package agree with itself where a
reviewer caught it disagreeing — every statement of the onboarding order now
points at the one place that derives it, and a derived exclusion entry now has
the reason the render rules were already demanding of it. Nothing in it is a
claim the cross-model pass had not already judged.

## Internal review

Nine reviewers, three cycles, six fix rounds. 43 items applied.

| Cycle | Blockers found | Outcome |
|-------|----------------|---------|
| 0 | 24 | all fixed (rounds A–C) |
| 1 | 19, every one introduced by the fixes | all fixed (rounds D–F) |
| 2 (verification) | 13, all in the new text | tracked, see below |

Two of cycle 1's were regressions worth naming, because both read as hardening
while removing a guarantee: the glob character class admitted `../**` and
`/src/**` that the ban list it replaced refused explicitly, and the symlink rule
narrowed refusal from any path component to the final one. Both restored in
`b4933a251`, and every sentence that round replaced was diffed against the
pre-fix text for the same failure.

Recurring classes were closed at their generating surface rather than per site:
the doctrine routing became one table nine prose lists cite, and when the fix
rounds produced two more hand-kept cross-file lists, `validators.md § Cross-file
sets` became a rule plus a table of its sites, with `doctrine-routing` enforcing
set equality against the doctrine source in both directions.

Two changes bind KEN-1006 and were not strictly asked for:

- **`--doctrine` became `--spec`.** Doctrine and the routing table have to arrive
  from one checkout, or `doctrine-routing` reds on every legitimate doctrine
  change in the CI lane the package prescribes.
- **Per-file write atomicity** is stated because this PR's own `AGENTS.md`
  write-time splice armed it — turning that file into a read-modify-write during
  the write phase. It is a defect these fix rounds introduced and closed, not one
  carried in.

## Ratified after review: render-path exclusions

The owner ratified during this PR's review that every rendered bot config
excludes the repo's harness render trees, so a render-only diff opens no bot
rounds. The machinery already existed — `derive_render` derives the trees,
`exclusion-consistency` holds the rendered set to a fresh derivation, and
CodeRabbit's `path_filters` and `.macroscope/ignore.md` carry it as real
subtraction. What was missing was the requirement stated as a rule, and the
paths reaching the bots that could not see them: `render-out-of-scope` told
reviewers to skip paths that no Codex-readable surface named.

The doctrine now states the requirement and is exact about what it buys per
surface rather than implying uniform enforcement: two of the five subtract for
real, three are asked, and a bot asked to skip a path may still comment on it.
Enforcement for the prose surfaces is a merge-gate concern, not an
instruction-file one — a companion review-gate change passing render-only diffs
on green needs no bot cooperation.

## One deferral reversed

The `agents-section` owned-region clause ran pre-write on `render`, where it
reds on every render that changes the region, so `render` could never update the
`AGENTS.md` section in any repo with `codex = true` — which `toml-schema`
requires whenever `copilot` or `coderabbit` is on. It was tracked to KEN-1006
under the internal review cycle limit and then reversed: six independent readers
named it with the same one-line remedy, which made it unbudgeted rather than
uncertain. The fix moved the byte comparison to `drift`, so the split falls
along structure versus bytes, each validator's name describes what it does, and
the isolation `§ Controls` requires follows — a region fixture reds one
validator rather than two.

## Tracked for KEN-1006

Thirteen blockers from the verification pass are recorded and filed rather than
fixed here. Three cycles is the internal limit, and each cycle's fixes introduced
defects at roughly the rate they closed them, so a seventh round was the spiral,
not the cure. They are precisely localized and carry their reviewer analysis; the
sharpest two are `agents-section`'s owned-region clause reddening every render
that changes the region, and temp-and-rename replacing by path while the marker
gate is specified on the opened descriptor. KEN-1006 meets both the moment it
writes the first validator test, with a red test rather than an argument.

Also deferred there, by design rather than omission: lock acquisition and release,
the scratch tree's location and per-run uniqueness, and the manifest's lifecycle.
`renders.md § Write phase` names that list so the omission reads as a decision.

