### PR TITLE
fix(KEN-1014): install-git-hooks-scope suite aborts on macOS (bare GNU sed -i)

### DIFF
--- a/.agents/skills/growth-guards/tests/install-git-hooks-scope.test.sh
+++ b/.agents/skills/growth-guards/tests/install-git-hooks-scope.test.sh
@@ -262,7 +262,8 @@ OUT="$("$OUT_DIR/checkout/.agents/skills/growth-guards/scripts/install-git-hooks
 
 HELPER="$OUT_DIR/elsewhere.git/hooks/kendex-guards"
 [ -f "$HELPER" ] || HELPER="$OUT_DIR/checkout/.git/hooks/kendex-guards"
-sed -i "s|^installed_scripts=.*|installed_scripts=''|" "$HELPER"
+sed -i.bak "s|^installed_scripts=.*|installed_scripts=''|" "$HELPER"
+rm -f "$HELPER.bak"
 
 MARK="TO""DO"
 printf '# %s: nope\n' "$MARK" >"$OUT_DIR/checkout/b.py"
@@ -308,7 +309,8 @@ OUT="$("$IN_DIR/.agents/skills/growth-guards/scripts/install-git-hooks" --repo "
 # search under test.
 HELPER2="$IN_DIR/meta/repo.git/hooks/kendex-guards"
 [ -f "$HELPER2" ] || HELPER2="$IN_DIR/.git/hooks/kendex-guards"
-sed -i "s|^installed_scripts=.*|installed_scripts=''|" "$HELPER2"
+sed -i.bak "s|^installed_scripts=.*|installed_scripts=''|" "$HELPER2"
+rm -f "$HELPER2.bak"
 
 MARK2="TO""DO"
 printf '# %s: nope\n' "$MARK2" >"$IN_DIR/b.py"
@@ -331,7 +333,8 @@ printf 'hello\n' >"$R90/a.txt"
 git -C "$R90" add -A
 commit_in "$R90" "feat: base"
 git -C "$R90" worktree add -q "$TMP/wt9" -b wt9b
-sed -i "s|^installed_scripts=.*|installed_scripts=''|" "$R90/.git/hooks/kendex-guards"
+sed -i.bak "s|^installed_scripts=.*|installed_scripts=''|" "$R90/.git/hooks/kendex-guards"
+rm -f "$R90/.git/hooks/kendex-guards.bak"
 printf '# %s: nope\n' "$MARK" >"$TMP/wt9/c.py"
 git -C "$TMP/wt9" add -A
 OUT=""; RC=0

--- a/skills/growth-guards/tests/install-git-hooks-scope.test.sh
+++ b/skills/growth-guards/tests/install-git-hooks-scope.test.sh
@@ -262,7 +262,8 @@ OUT="$("$OUT_DIR/checkout/.agents/skills/growth-guards/scripts/install-git-hooks
 
 HELPER="$OUT_DIR/elsewhere.git/hooks/kendex-guards"
 [ -f "$HELPER" ] || HELPER="$OUT_DIR/checkout/.git/hooks/kendex-guards"
-sed -i "s|^installed_scripts=.*|installed_scripts=''|" "$HELPER"
+sed -i.bak "s|^installed_scripts=.*|installed_scripts=''|" "$HELPER"
+rm -f "$HELPER.bak"
 
 MARK="TO""DO"
 printf '# %s: nope\n' "$MARK" >"$OUT_DIR/checkout/b.py"
@@ -308,7 +309,8 @@ OUT="$("$IN_DIR/.agents/skills/growth-guards/scripts/install-git-hooks" --repo "
 # search under test.
 HELPER2="$IN_DIR/meta/repo.git/hooks/kendex-guards"
 [ -f "$HELPER2" ] || HELPER2="$IN_DIR/.git/hooks/kendex-guards"
-sed -i "s|^installed_scripts=.*|installed_scripts=''|" "$HELPER2"
+sed -i.bak "s|^installed_scripts=.*|installed_scripts=''|" "$HELPER2"
+rm -f "$HELPER2.bak"
 
 MARK2="TO""DO"
 printf '# %s: nope\n' "$MARK2" >"$IN_DIR/b.py"
@@ -331,7 +333,8 @@ printf 'hello\n' >"$R90/a.txt"
 git -C "$R90" add -A
 commit_in "$R90" "feat: base"
 git -C "$R90" worktree add -q "$TMP/wt9" -b wt9b
-sed -i "s|^installed_scripts=.*|installed_scripts=''|" "$R90/.git/hooks/kendex-guards"
+sed -i.bak "s|^installed_scripts=.*|installed_scripts=''|" "$R90/.git/hooks/kendex-guards"
+rm -f "$R90/.git/hooks/kendex-guards.bak"
 printf '# %s: nope\n' "$MARK" >"$TMP/wt9/c.py"
 git -C "$TMP/wt9" add -A
 OUT=""; RC=0


### PR DESCRIPTION
## Summary

- The three bare `sed -i` calls in `install-git-hooks-scope.test.sh` now use `sed -i.bak` plus `rm -f`, the form GNU and BSD sed both accept and the one the suite's own first edit at line 19 already used.
- Under BSD sed the bare form aborted the suite at assertion 35 of 46, so a developer could not run this suite on macOS at all.
- The committed `.agents/` render carries the identical change.

## Completed Issues

- Closes KEN-1014 - install-git-hooks-scope suite aborts on macOS before its assertions (bare GNU sed -i)

## Test Plan

Run on the macOS box (arm64, BSD sed) from an rsync copy of this branch, before and after:

| Run | Result |
|-----|--------|
| Bare `sed -i` restored | Aborts at `sed: 1: "/var/folders/...": invalid command code f`, exit 1, 35 of 46 assertions printed |
| This branch | 46 passed, 0 failed, exit 0 |

Locally on Linux: 46 passed, 0 failed. `tools/guard` clean, preflight clean.

## Note on the issue's premise

The issue said the merge-group macOS lane runs this suite. It does not. `.github/workflows/skill-tests.yml` runs the shell suites only on the ubuntu `skill-suites-shard` matrix, and the one macOS job is `cargo-tests-macos`. Nothing was silently passing in CI. The portability defect is real; the CI-lane framing was not.
