### PR TITLE
fix(KEN-1058): the pinned key is the one the release secrets sign with

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,6 +2265,7 @@ dependencies = [
 name = "kendex-app"
 version = "5.0.1"
 dependencies = [
+ "base64 0.22.1",
  "ico",
  "kendex-core",
  "rustix",

--- a/changelog.d/changed/KEN-1058.md
+++ b/changelog.d/changed/KEN-1058.md
@@ -1,2 +1,3 @@
 - The updater signing key rotated. An install of an earlier build cannot
-  verify 1.0 artifacts and has to be reinstalled once from kendex.ai.
+  verify releases signed with the new key and has to be reinstalled once
+  from kendex.ai.

--- a/changelog.d/changed/KEN-1058.md
+++ b/changelog.d/changed/KEN-1058.md
@@ -1,0 +1,2 @@
+- The updater signing key rotated. An install of an earlier build cannot
+  verify 1.0 artifacts and has to be reinstalled once from kendex.ai.

--- a/changelog.d/changed/KEN-1058.md
+++ b/changelog.d/changed/KEN-1058.md
@@ -1,3 +1,3 @@
-- The updater signing key rotated. An install of an earlier build cannot
-  verify releases signed with the new key and has to be reinstalled once
-  from kendex.ai.
+- **Breaking:** the updater signing key rotated. An install of an earlier
+  build cannot verify releases signed with the new key — reinstall once from
+  kendex.ai.

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -38,6 +38,10 @@ tauri-plugin-opener = "2.5.4"
 tauri-plugin-updater = "2"
 
 [dev-dependencies]
+# Decodes the pinned updater key back to the minisign key file it is, so the
+# suite can hold the pin to the key id the release is signed with rather than
+# only to core's copy of the same string.
+base64.workspace = true
 # Reads the bundled icons back: asserting what they depict is the only way
 # to catch a stale or wrongly regenerated one. These are the two `tauri icon`
 # writes them with, so the suite reads a container the way its bundler does

--- a/crates/app/tauri.conf.json
+++ b/crates/app/tauri.conf.json
@@ -37,7 +37,7 @@
       "endpoints": [
         "https://github.com/vanillagreencom/kendex/releases/latest/download/latest.json"
       ],
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEJENUIwQjkxMUFGNTJFOTIKUldTU0x2VWFrUXRidmJFQnhKSi9iU3pwTVVJVlhrY3JHbVoyV1BjVmJSdDYzZ2VjVnZzSjlEMDkK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEM5MjJDODkxNzhCN0M2Q0MKUldUTXhyZDRrY2dpeVlJNDJ6VFlmbEFwQ0g5ZlRzOWp0TWNZSFZlSnJDSWtUWGZuZHE3K0ZxSG8K",
       "windows": {
         "installMode": "passive"
       }

--- a/crates/app/tests/tauri_config.rs
+++ b/crates/app/tests/tauri_config.rs
@@ -29,8 +29,9 @@ fn the_window_opens_hidden_so_the_saved_zoom_lands_first() {
 /// assertion. Two keys means one delivery path trusting what the other
 /// would turn away — and two identical pins are still the wrong pin if
 /// nothing names the key, which is how a pin whose private half exists
-/// nowhere shipped. So the decoded minisign key file is held to the key id
-/// the release is signed with as well.
+/// nowhere shipped. So the key id parsed out of the key file's payload —
+/// the half minisign verifies with, not the comment above it — is held to
+/// the key id the release is signed with as well.
 #[test]
 #[allow(clippy::expect_used)]
 fn the_app_and_the_cli_pin_one_updater_key() {
@@ -38,11 +39,30 @@ fn the_app_and_the_cli_pin_one_updater_key() {
         config()["plugins"]["updater"]["pubkey"].as_str(),
         Some(kendex_core::update_feed::UPDATER_PUBLIC_KEY)
     );
-    let decoded = base64::engine::general_purpose::STANDARD
+    let key_file = base64::engine::general_purpose::STANDARD
         .decode(kendex_core::update_feed::UPDATER_PUBLIC_KEY)
         .expect("the pinned key is base64");
-    assert!(
-        String::from_utf8_lossy(&decoded).contains("C922C89178B7C6CC"),
+    let key_file = String::from_utf8(key_file).expect("the pinned key file is text");
+    // Line one is the untrusted comment, which minisign never reads. Line
+    // two is the key: two bytes of algorithm, eight of key id little-endian,
+    // then the thirty-two a signature is checked against.
+    let payload = base64::engine::general_purpose::STANDARD
+        .decode(
+            key_file
+                .lines()
+                .nth(1)
+                .expect("the pinned key file carries a payload line")
+                .trim(),
+        )
+        .expect("the payload line is base64");
+    assert_eq!(payload.len(), 42, "a minisign public key is 42 bytes");
+    let key_id: String = payload[2..10]
+        .iter()
+        .rev()
+        .map(|b| format!("{b:02X}"))
+        .collect();
+    assert_eq!(
+        key_id, "C922C89178B7C6CC",
         "the pin carries a key id the release signing key does not"
     );
 }

--- a/crates/app/tests/tauri_config.rs
+++ b/crates/app/tests/tauri_config.rs
@@ -2,6 +2,7 @@
 //! expects — load-bearing settings that never show up in a compile error
 //! when they go missing.
 
+use base64::Engine;
 use std::path::Path;
 
 #[allow(clippy::expect_used)]
@@ -26,12 +27,23 @@ fn the_window_opens_hidden_so_the_saved_zoom_lands_first() {
 /// The app's updater reads its key from this file at build time, so the
 /// copy core holds for `kendex update` can only be kept honest by an
 /// assertion. Two keys means one delivery path trusting what the other
-/// would turn away.
+/// would turn away — and two identical pins are still the wrong pin if
+/// nothing names the key, which is how a pin whose private half exists
+/// nowhere shipped. So the decoded minisign key file is held to the key id
+/// the release is signed with as well.
 #[test]
+#[allow(clippy::expect_used)]
 fn the_app_and_the_cli_pin_one_updater_key() {
     assert_eq!(
         config()["plugins"]["updater"]["pubkey"].as_str(),
         Some(kendex_core::update_feed::UPDATER_PUBLIC_KEY)
+    );
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(kendex_core::update_feed::UPDATER_PUBLIC_KEY)
+        .expect("the pinned key is base64");
+    assert!(
+        String::from_utf8_lossy(&decoded).contains("C922C89178B7C6CC"),
+        "the pin carries a key id the release signing key does not"
     );
 }
 

--- a/crates/core/src/update_feed.rs
+++ b/crates/core/src/update_feed.rs
@@ -20,7 +20,7 @@ pub const MAX_FEED_BYTES: usize = 64 * 1024;
 /// base64 shape `crates/app/tauri.conf.json` pins for the app's own
 /// updater. `crates/app/tests/tauri_config.rs` holds the two to one string,
 /// so the CLI and the app cannot end up trusting different keys.
-pub const UPDATER_PUBLIC_KEY: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEJENUIwQjkxMUFGNTJFOTIKUldTU0x2VWFrUXRidmJFQnhKSi9iU3pwTVVJVlhrY3JHbVoyV1BjVmJSdDYzZ2VjVnZzSjlEMDkK";
+pub const UPDATER_PUBLIC_KEY: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEM5MjJDODkxNzhCN0M2Q0MKUldUTXhyZDRrY2dpeVlJNDJ6VFlmbEFwQ0g5ZlRzOWp0TWNZSFZlSnJDSWtUWGZuZHE3K0ZxSG8K";
 const MAX_VERSION_BYTES: usize = 128;
 const MAX_ASSETS: usize = 32;
 const MAX_URL_BYTES: usize = 2 * 1024;


### PR DESCRIPTION
## Summary

- Both pinned copies of the updater public key now carry `C922C89178B7C6CC`, the key the repo's `TAURI_SIGNING_PRIVATE_KEY` secret signs releases with. The old pin `BD5B0B911AF52E92` had no private half on any machine, so every 1.0 artifact would have been signed under a key the app refuses.
- The two pins are `crates/app/tauri.conf.json` (`plugins > updater > pubkey`) and `crates/core/src/update_feed.rs` (`UPDATER_PUBLIC_KEY`). A test holds them to one string, so the app and the CLI cannot drift apart.
- A changelog entry says installs of earlier builds have to be reinstalled once.

## Completed Issues

- Closes KEN-1058 - The pinned updater public key is the one the release secrets sign with (C922C89178B7C6CC)

## Test Plan

- `cargo test -p kendex-app --test tauri_config` — 4 passed, including `the_app_and_the_cli_pin_one_updater_key`.
- `cargo test -p kendex-core update_feed` — 14 passed, including `the_pinned_key_is_the_one_a_download_is_held_to`.
- `base64 -d` of the pinned value reads `minisign public key: C922C89178B7C6CC`.
- No occurrence of the old key id or its base64 remains in the tree.
