### PR TITLE
fix(KEN-958): install.sh's elevated write works on macOS

### DIFF
--- a/changelog.d/fixed/KEN-958.md
+++ b/changelog.d/fixed/KEN-958.md
@@ -1,0 +1,1 @@
+- `install.sh` installs the kendex command on macOS again. Its elevated write passed `install -D`, a flag the mac's `install` reads as taking an operand, so the install exited instead.

--- a/changelog.d/fixed/KEN-958.md
+++ b/changelog.d/fixed/KEN-958.md
@@ -1,1 +1,1 @@
-- `install.sh` installs the kendex command on macOS again. Its elevated write passed `install -D`, a flag the mac's `install` reads as taking an operand, so the install exited instead.
+- `install.sh` installs the kendex command on macOS. Its elevated write passed `install -D`, a flag the mac's `install` reads as taking an operand, so the install exited instead.

--- a/crates/cli/tests/install_script.rs
+++ b/crates/cli/tests/install_script.rs
@@ -35,14 +35,14 @@ fn requested_urls(os: &str, arch: &str) -> String {
 #[allow(clippy::unwrap_used)]
 fn run_install(os: &str, arch: &str, fail: Option<(&str, i32)>) -> (std::process::Output, String) {
     let tmp = tempfile::tempdir().unwrap();
-    run_install_in(os, arch, fail, tmp.path(), &[], SUDO_STUB)
+    run_install_in(os, arch, fail, tmp.path(), &[], SUDO_STUB, BinDir::Made)
 }
 
 /// The same run against a home the caller keeps, for a test that reads what
 /// the script left behind rather than only what it fetched.
 #[allow(clippy::unwrap_used)]
 fn run_install_at(os: &str, arch: &str, home: &Path) -> (std::process::Output, String) {
-    run_install_in(os, arch, None, home, &[], SUDO_STUB)
+    run_install_in(os, arch, None, home, &[], SUDO_STUB, BinDir::Made)
 }
 
 /// What `uname -s` answers on the machine running these tests.
@@ -59,6 +59,15 @@ const HOST_UNAME: &str = match cfg!(target_os = "macos") {
     false => "Linux",
 };
 
+/// Whether the fixture makes the directory `install.sh` installs into
+/// before the run. `Absent` leaves it to the script, which is the case its
+/// elevated `mkdir` exists for.
+#[derive(Clone, Copy, PartialEq)]
+enum BinDir {
+    Made,
+    Absent,
+}
+
 #[allow(clippy::unwrap_used)]
 fn run_install_in(
     os: &str,
@@ -67,11 +76,14 @@ fn run_install_in(
     home: &Path,
     path_ahead: &[&str],
     sudo: &str,
+    make_bindir: BinDir,
 ) -> (std::process::Output, String) {
     let fake = home.join("fake-bin");
     let bindir = home.join(".local/bin");
     fs::create_dir_all(&fake).unwrap();
-    fs::create_dir_all(&bindir).unwrap();
+    if make_bindir == BinDir::Made {
+        fs::create_dir_all(&bindir).unwrap();
+    }
     write_exe(
         &fake.join("uname"),
         &format!("#!/bin/sh\ncase \"$1\" in -s) echo {os} ;; -m) echo {arch} ;; esac\n"),
@@ -370,6 +382,7 @@ fn path_order_does_not_decide_where_a_re_run_lands() {
         &home,
         &["/usr/local/bin"],
         SUDO_STUB,
+        BinDir::Made,
     );
     // Asked first, because it is the answer a drifted script gives: a run
     // that chose the system directory stops at the stub, and reading the
@@ -501,39 +514,63 @@ fn install_sh_says_when_it_cannot_record_the_command() {
     );
 }
 
-/// A `sudo` that stands in for root, and only over the fixture: it lifts
-/// the write bit off the destination's directory the way root's write
-/// ignores it, runs the command, and puts the bit back. The directory the
-/// fixture made unwritable is what sends the script down its privileged
-/// branch, so the refusing stub every other case here uses could never
-/// reach the invocation that branch makes. Where the destination's
-/// directory is already writable this is `"$@"` and nothing else, and every
-/// destination stays the install stub's to refuse, so nothing reaches past
-/// the temp home either way.
-const SUDO_AS_ROOT: &str = r#"#!/bin/sh
+/// A `sudo` that stands in for root over the fixture, and refuses to be
+/// anything else.
+///
+/// Root's write ignores a directory's mode, and the fixture's unwritable
+/// directory is the whole reason the script takes its privileged branch,
+/// so the refusing stub every other case here uses could never reach the
+/// invocation that branch makes. This one lifts the write bit, runs the
+/// command, and puts the directory back the way it found it.
+///
+/// The guard is the last argument, which is where both commands the
+/// script escalates write: outside the fixture root it refuses before it
+/// chmods or runs anything. `install_stub`'s own guard covers only the
+/// destination of an `install`, so a `sudo mkdir` would otherwise reach
+/// the host's real `mkdir` with nothing checking where. The source it
+/// copies from is not checked, and cannot be: `install.sh` downloads into
+/// a `mktemp -d` of its own.
+#[allow(
+    clippy::unwrap_used,
+    reason = "a fixture root always renders, as install_stub's does"
+)]
+fn sudo_as_root(root: &Path) -> String {
+    format!(
+        r#"#!/bin/sh
 for arg in "$@"; do dest="$arg"; done
+case "$dest" in
+  {root}/*) ;;
+  *) echo "installer test tried to escalate outside its fixture: $dest" >&2; exit 1 ;;
+esac
 dir="$(dirname "$dest")"
+saved=""
 if [ -d "$dir" ] && [ ! -w "$dir" ]; then
+  saved="$(stat -c %a "$dir" 2>/dev/null || stat -f %Lp "$dir")"
+  [ -n "$saved" ] || {{ echo "installer test could not read the mode of $dir" >&2; exit 1; }}
   chmod u+w "$dir"
-  "$@"; rc=$?
-  chmod a-w "$dir"
-else
-  "$@"; rc=$?
 fi
+"$@"
+rc=$?
+[ -n "$saved" ] && chmod "$saved" "$dir"
 exit $rc
-"#;
+"#,
+        root = root.display()
+    )
+}
 
-/// The branch `install.sh` takes when the directory it chose is not
-/// writable, which on macOS is the ordinary one: `/usr/local/bin` is on
-/// PATH there whether or not it exists, and root owns it, so the elevated
-/// write is what a mac install runs. What that branch hands `install` has
-/// to be flags the mac's `install` reads the same way — GNU's `-D` is an
-/// operand-taking flag there and swallows the `-m` behind it, and a run
+/// The flags the elevated branch hands `install`, which have to be ones
+/// the mac's `install` reads the same way: GNU's `-D` is an
+/// operand-taking flag there and swallows the `-m` behind it, so a run
 /// that passes the pair installs nothing at all.
 ///
-/// The refusal is the stub's, not this test's: `install_stub` reads the
-/// flags and rejects the ones it does not model, so this case only has to
-/// reach the branch and let the run say whether it worked.
+/// The branch itself is taken on the write bit, not on the platform. It is
+/// where the default macOS layout lands, because `/etc/paths` puts
+/// root-owned `/usr/local/bin` on PATH, and where any machine lands whose
+/// chosen directory the account cannot write.
+///
+/// The refusal is the stub's, not this case's: `install_stub` reads the
+/// flags and rejects the ones it does not model, so this only has to reach
+/// the branch and let the run say whether it worked.
 #[test]
 #[allow(clippy::unwrap_used)]
 fn the_privileged_branch_installs_with_flags_bsd_install_reads_alike() {
@@ -550,7 +587,15 @@ fn the_privileged_branch_installs_with_flags_bsd_install_reads_alike() {
     fs::create_dir_all(&bindir).unwrap();
     fs::set_permissions(&bindir, fs::Permissions::from_mode(0o555)).unwrap();
 
-    let (output, _) = run_install_in(HOST_UNAME, "x86_64", None, &home, &[], SUDO_AS_ROOT);
+    let (output, _) = run_install_in(
+        HOST_UNAME,
+        "x86_64",
+        None,
+        &home,
+        &[],
+        &sudo_as_root(&home),
+        BinDir::Made,
+    );
     // Writable again before any assertion can fail: a directory left 0555
     // is one the temp dir cannot clean up.
     fs::set_permissions(&bindir, fs::Permissions::from_mode(0o755)).unwrap();
@@ -585,5 +630,55 @@ fn the_privileged_branch_installs_with_flags_bsd_install_reads_alike() {
         0o755,
         "the elevated branch installed {} with the wrong mode",
         installed.display()
+    );
+}
+
+/// The other half of what `install -D` did: make the directory. The
+/// unprivileged `mkdir -p` a few lines earlier cannot, because the parent
+/// belongs to root — `/usr/local` on a stock mac, and here a `.local` the
+/// fixture made unwritable — so without an elevated `mkdir` the elevated
+/// `install` has nowhere to land.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn the_privileged_branch_makes_the_bindir_it_could_not_make_unprivileged() {
+    // As above: root makes the directory through the mode bit and the
+    // script never reaches this branch.
+    if rustix::process::geteuid().is_root() {
+        eprintln!("skipped: root makes the directory this case needs it to be refused");
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    // The data directory is made first and stays writable: the script
+    // installs the app and records the command under it, and this case is
+    // about the bindir alone.
+    fs::create_dir_all(home.join(".local/share")).unwrap();
+    let parent = home.join(".local");
+    fs::set_permissions(&parent, fs::Permissions::from_mode(0o555)).unwrap();
+
+    let (output, _) = run_install_in(
+        HOST_UNAME,
+        "x86_64",
+        None,
+        &home,
+        &[],
+        &sudo_as_root(&home),
+        BinDir::Absent,
+    );
+    fs::set_permissions(&parent, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let said = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        said.contains("needs elevated permissions."),
+        "install.sh did not take the branch that needs privilege:\n{said}{stderr}"
+    );
+    assert!(
+        output.status.success(),
+        "install.sh failed on a bindir only the elevated branch could make:\n{stderr}"
+    );
+    assert!(
+        home.join(".local/bin/kendex").is_file(),
+        "the elevated branch made no directory to install into:\n{said}{stderr}"
     );
 }

--- a/crates/cli/tests/install_script.rs
+++ b/crates/cli/tests/install_script.rs
@@ -35,14 +35,14 @@ fn requested_urls(os: &str, arch: &str) -> String {
 #[allow(clippy::unwrap_used)]
 fn run_install(os: &str, arch: &str, fail: Option<(&str, i32)>) -> (std::process::Output, String) {
     let tmp = tempfile::tempdir().unwrap();
-    run_install_in(os, arch, fail, tmp.path(), &[], SUDO_STUB, BinDir::Made)
+    run_install_in(os, arch, fail, tmp.path(), &[], SUDO_STUB)
 }
 
 /// The same run against a home the caller keeps, for a test that reads what
 /// the script left behind rather than only what it fetched.
 #[allow(clippy::unwrap_used)]
 fn run_install_at(os: &str, arch: &str, home: &Path) -> (std::process::Output, String) {
-    run_install_in(os, arch, None, home, &[], SUDO_STUB, BinDir::Made)
+    run_install_in(os, arch, None, home, &[], SUDO_STUB)
 }
 
 /// What `uname -s` answers on the machine running these tests.
@@ -59,15 +59,6 @@ const HOST_UNAME: &str = match cfg!(target_os = "macos") {
     false => "Linux",
 };
 
-/// Whether the fixture makes the directory `install.sh` installs into
-/// before the run. `Absent` leaves it to the script, which is the case its
-/// elevated `mkdir` exists for.
-#[derive(Clone, Copy, PartialEq)]
-enum BinDir {
-    Made,
-    Absent,
-}
-
 #[allow(clippy::unwrap_used)]
 fn run_install_in(
     os: &str,
@@ -76,14 +67,10 @@ fn run_install_in(
     home: &Path,
     path_ahead: &[&str],
     sudo: &str,
-    make_bindir: BinDir,
 ) -> (std::process::Output, String) {
     let fake = home.join("fake-bin");
     let bindir = home.join(".local/bin");
     fs::create_dir_all(&fake).unwrap();
-    if make_bindir == BinDir::Made {
-        fs::create_dir_all(&bindir).unwrap();
-    }
     write_exe(
         &fake.join("uname"),
         &format!("#!/bin/sh\ncase \"$1\" in -s) echo {os} ;; -m) echo {arch} ;; esac\n"),
@@ -382,7 +369,6 @@ fn path_order_does_not_decide_where_a_re_run_lands() {
         &home,
         &["/usr/local/bin"],
         SUDO_STUB,
-        BinDir::Made,
     );
     // Asked first, because it is the answer a drifted script gives: a run
     // that chose the system directory stops at the stub, and reading the
@@ -530,6 +516,14 @@ fn install_sh_says_when_it_cannot_record_the_command() {
 /// the host's real `mkdir` with nothing checking where. The source it
 /// copies from is not checked, and cannot be: `install.sh` downloads into
 /// a `mktemp -d` of its own.
+///
+/// The `umask 0` is what makes the mode flags on this branch observable at
+/// all. Under the runner's own 022 a `mkdir` yields 0755 whether or not the
+/// script asked for it, so an assertion about the mode reads the fixture
+/// back rather than the script, and dropping the flag kills nothing. Clear
+/// it and every mode on an escalated command is the one the script named.
+/// It is set here, in the escalated child, because a `umask()` on the test
+/// process would leak into every other case in this binary.
 #[allow(
     clippy::unwrap_used,
     reason = "a fixture root always renders, as install_stub's does"
@@ -549,6 +543,7 @@ if [ -d "$dir" ] && [ ! -w "$dir" ]; then
   [ -n "$saved" ] || {{ echo "installer test could not read the mode of $dir" >&2; exit 1; }}
   chmod u+w "$dir"
 fi
+umask 0
 "$@"
 rc=$?
 [ -n "$saved" ] && chmod "$saved" "$dir"
@@ -587,15 +582,7 @@ fn the_privileged_branch_installs_with_flags_bsd_install_reads_alike() {
     fs::create_dir_all(&bindir).unwrap();
     fs::set_permissions(&bindir, fs::Permissions::from_mode(0o555)).unwrap();
 
-    let (output, _) = run_install_in(
-        HOST_UNAME,
-        "x86_64",
-        None,
-        &home,
-        &[],
-        &sudo_as_root(&home),
-        BinDir::Made,
-    );
+    let (output, _) = run_install_in(HOST_UNAME, "x86_64", None, &home, &[], &sudo_as_root(&home));
     // Writable again before any assertion can fail: a directory left 0555
     // is one the temp dir cannot clean up.
     fs::set_permissions(&bindir, fs::Permissions::from_mode(0o755)).unwrap();
@@ -656,15 +643,7 @@ fn the_privileged_branch_makes_the_bindir_it_could_not_make_unprivileged() {
     let parent = home.join(".local");
     fs::set_permissions(&parent, fs::Permissions::from_mode(0o555)).unwrap();
 
-    let (output, _) = run_install_in(
-        HOST_UNAME,
-        "x86_64",
-        None,
-        &home,
-        &[],
-        &sudo_as_root(&home),
-        BinDir::Absent,
-    );
+    let (output, _) = run_install_in(HOST_UNAME, "x86_64", None, &home, &[], &sudo_as_root(&home));
     fs::set_permissions(&parent, fs::Permissions::from_mode(0o755)).unwrap();
 
     let said = String::from_utf8_lossy(&output.stdout);
@@ -680,5 +659,16 @@ fn the_privileged_branch_makes_the_bindir_it_could_not_make_unprivileged() {
     assert!(
         home.join(".local/bin/kendex").is_file(),
         "the elevated branch made no directory to install into:\n{said}{stderr}"
+    );
+    // The mode the script named, not the one root's umask would have left:
+    // `sudo_as_root` clears the umask, so 0755 here can only be the -m.
+    assert_eq!(
+        fs::metadata(home.join(".local/bin"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777,
+        0o755,
+        "the elevated branch made the bindir with the wrong mode:\n{said}{stderr}"
     );
 }

--- a/crates/cli/tests/install_script.rs
+++ b/crates/cli/tests/install_script.rs
@@ -35,14 +35,14 @@ fn requested_urls(os: &str, arch: &str) -> String {
 #[allow(clippy::unwrap_used)]
 fn run_install(os: &str, arch: &str, fail: Option<(&str, i32)>) -> (std::process::Output, String) {
     let tmp = tempfile::tempdir().unwrap();
-    run_install_in(os, arch, fail, tmp.path(), &[])
+    run_install_in(os, arch, fail, tmp.path(), &[], SUDO_STUB)
 }
 
 /// The same run against a home the caller keeps, for a test that reads what
 /// the script left behind rather than only what it fetched.
 #[allow(clippy::unwrap_used)]
 fn run_install_at(os: &str, arch: &str, home: &Path) -> (std::process::Output, String) {
-    run_install_in(os, arch, None, home, &[])
+    run_install_in(os, arch, None, home, &[], SUDO_STUB)
 }
 
 /// What `uname -s` answers on the machine running these tests.
@@ -66,6 +66,7 @@ fn run_install_in(
     fail: Option<(&str, i32)>,
     home: &Path,
     path_ahead: &[&str],
+    sudo: &str,
 ) -> (std::process::Output, String) {
     let fake = home.join("fake-bin");
     let bindir = home.join(".local/bin");
@@ -77,7 +78,7 @@ fn run_install_in(
     );
     // The host's own `PATH` is appended below, so both commands the script
     // writes through resolve outside the fixture. Neither may reach past it.
-    write_exe(&fake.join("sudo"), SUDO_STUB);
+    write_exe(&fake.join("sudo"), sudo);
     write_exe(&fake.join("install"), &install_stub(home));
     // Logs the URL; `-o FILE` gets a runnable stand-in for the download,
     // and the release lookup gets a tag.
@@ -362,7 +363,14 @@ fn path_order_does_not_decide_where_a_re_run_lands() {
 
     let tmp = tempfile::tempdir().unwrap();
     let home = rooted(&tmp);
-    let (output, _) = run_install_in(HOST_UNAME, "x86_64", None, &home, &["/usr/local/bin"]);
+    let (output, _) = run_install_in(
+        HOST_UNAME,
+        "x86_64",
+        None,
+        &home,
+        &["/usr/local/bin"],
+        SUDO_STUB,
+    );
     // Asked first, because it is the answer a drifted script gives: a run
     // that chose the system directory stops at the stub, and reading the
     // destination first would report only that it never said one.
@@ -490,5 +498,92 @@ fn install_sh_says_when_it_cannot_record_the_command() {
         kendex_core::command_update::recorded_command(&env),
         None,
         "the app was handed a record install.sh never wrote"
+    );
+}
+
+/// A `sudo` that stands in for root, and only over the fixture: it lifts
+/// the write bit off the destination's directory the way root's write
+/// ignores it, runs the command, and puts the bit back. The directory the
+/// fixture made unwritable is what sends the script down its privileged
+/// branch, so the refusing stub every other case here uses could never
+/// reach the invocation that branch makes. Where the destination's
+/// directory is already writable this is `"$@"` and nothing else, and every
+/// destination stays the install stub's to refuse, so nothing reaches past
+/// the temp home either way.
+const SUDO_AS_ROOT: &str = r#"#!/bin/sh
+for arg in "$@"; do dest="$arg"; done
+dir="$(dirname "$dest")"
+if [ -d "$dir" ] && [ ! -w "$dir" ]; then
+  chmod u+w "$dir"
+  "$@"; rc=$?
+  chmod a-w "$dir"
+else
+  "$@"; rc=$?
+fi
+exit $rc
+"#;
+
+/// The branch `install.sh` takes when the directory it chose is not
+/// writable, which on macOS is the ordinary one: `/usr/local/bin` is on
+/// PATH there whether or not it exists, and root owns it, so the elevated
+/// write is what a mac install runs. What that branch hands `install` has
+/// to be flags the mac's `install` reads the same way — GNU's `-D` is an
+/// operand-taking flag there and swallows the `-m` behind it, and a run
+/// that passes the pair installs nothing at all.
+///
+/// The refusal is the stub's, not this test's: `install_stub` reads the
+/// flags and rejects the ones it does not model, so this case only has to
+/// reach the branch and let the run say whether it worked.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn the_privileged_branch_installs_with_flags_bsd_install_reads_alike() {
+    // Root writes through a mode bit, so `[ -w "$bindir" ]` answers true
+    // for it and the script takes the unprivileged branch instead. Nothing
+    // this case is about happens on such a runner.
+    if rustix::process::geteuid().is_root() {
+        eprintln!("skipped: root writes through the unwritable bindir this case needs");
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let bindir = home.join(".local/bin");
+    fs::create_dir_all(&bindir).unwrap();
+    fs::set_permissions(&bindir, fs::Permissions::from_mode(0o555)).unwrap();
+
+    let (output, _) = run_install_in(HOST_UNAME, "x86_64", None, &home, &[], SUDO_AS_ROOT);
+    // Writable again before any assertion can fail: a directory left 0555
+    // is one the temp dir cannot clean up.
+    fs::set_permissions(&bindir, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let said = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // Asked first: a run that took the writable branch would install
+    // perfectly well and prove nothing about the one under test.
+    assert!(
+        said.contains(&format!(
+            "Installing to {} needs elevated permissions.",
+            bindir.display()
+        )),
+        "install.sh did not take the branch that needs privilege:\n{said}{stderr}"
+    );
+    assert!(
+        output.status.success(),
+        "install.sh failed on the branch it takes when the bindir needs privilege:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("this stub does not model"),
+        "install.sh passed the elevated write a flag macOS reads differently:\n{stderr}"
+    );
+    let installed = bindir.join("kendex");
+    assert!(
+        installed.is_file(),
+        "the elevated branch installed nothing at {}",
+        installed.display()
+    );
+    assert_eq!(
+        fs::metadata(&installed).unwrap().permissions().mode() & 0o777,
+        0o755,
+        "the elevated branch installed {} with the wrong mode",
+        installed.display()
     );
 }

--- a/crates/test_util.rs
+++ b/crates/test_util.rs
@@ -115,6 +115,11 @@ pub const SUDO_STUB: &str = "#!/bin/sh\necho 'installer test tried to escalate' 
 /// this does not model reds here whether or not it is portable: teach it
 /// that flag, or drop the flag if the mac reads it differently.
 ///
+/// The mode it falls back to is one `install.sh` never passes, so a
+/// caller that dropped its `-m` is distinguishable from one that asked for
+/// 0755. Answering an absent flag with the mode the script happens to want
+/// would make every assertion about that mode pass without it.
+///
 /// The destination is unlinked rather than written through, because that
 /// is what `install` does and `cp` does not: over a read-only file in a
 /// writable directory the real tool replaces and `cp` fails. Writing
@@ -128,7 +133,7 @@ pub const SUDO_STUB: &str = "#!/bin/sh\necho 'installer test tried to escalate' 
 pub fn install_stub(root: &Path) -> String {
     format!(
         "#!/bin/sh\n\
-         mode=0755\n\
+         mode=0600\n\
          while [ $# -gt 2 ]; do\n\
          \x20 case \"$1\" in\n\
          \x20   -m) mode=\"$2\"; shift 2 ;;\n\

--- a/crates/test_util.rs
+++ b/crates/test_util.rs
@@ -101,9 +101,19 @@ pub const SUDO_STUB: &str = "#!/bin/sh\necho 'installer test tried to escalate' 
 /// script's ordinary write goes through it, and the run under test is the
 /// one that succeeds.
 ///
-/// Reads the flags `install.sh` passes — `-D`, and `-m MODE` — and treats
-/// the last two arguments as source and destination, which is the only
-/// form the script uses.
+/// Reads the one flag `install.sh` passes, `-m MODE`, and treats the last
+/// two arguments as source and destination, which is the only form the
+/// script uses.
+///
+/// Every other option is refused rather than shrugged off. BSD `install`
+/// on macOS takes a different flag set from GNU coreutils', and the
+/// overlap is not even where the spelling matches: `-D` makes missing
+/// directories on GNU and takes an operand on BSD, so GNU's
+/// `-D -m 0755 src dst` is read there as `-D -m` and exits 64. A stub that
+/// skipped what it did not recognise would accept such an invocation over
+/// the very branch macOS takes by default. Refusing instead means a flag
+/// this does not model reds here whether or not it is portable: teach it
+/// that flag, or drop the flag if the mac reads it differently.
 ///
 /// The destination is unlinked rather than written through, because that
 /// is what `install` does and `cp` does not: over a read-only file in a
@@ -122,7 +132,7 @@ pub fn install_stub(root: &Path) -> String {
          while [ $# -gt 2 ]; do\n\
          \x20 case \"$1\" in\n\
          \x20   -m) mode=\"$2\"; shift 2 ;;\n\
-         \x20   -*) shift ;;\n\
+         \x20   -*) echo \"installer test passed install an option this stub does not model: $1\" >&2; exit 1 ;;\n\
          \x20   *) break ;;\n\
          \x20 esac\n\
          done\n\

--- a/install.sh
+++ b/install.sh
@@ -119,21 +119,20 @@ install_cli() {
     # made the directory itself: -D makes directories on GNU coreutils
     # only, and BSD install on macOS spells its own -D "-D dest" and takes
     # an operand, so it reads the "-m" behind it as that operand and exits
-    # 64 on the usage it is left with. The mkdir is what keeps the pair
-    # equivalent to that -D, for the machine where the directory is not
-    # there yet and the unprivileged mkdir above could not make it. -m
-    # means the same thing to both tools, and stating it here is what the
-    # replaced command did: root's umask decides the mode otherwise.
+    # 64 on the usage it is left with. The mkdir covers the one case -D
+    # covered, the directory the unprivileged mkdir above could not make,
+    # and its -m sets the mode of that directory rather than leaving it to
+    # root's umask. It is not the general equivalent of -D, which modes
+    # every leading directory it makes where -m modes only the last.
+    #
+    # Both run bare under set -eu, so a refused escalation stops the run
+    # here rather than reaching the line that says the command installed.
     #
     # The default macOS layout comes here: /etc/paths puts root-owned
     # /usr/local/bin on PATH. A mac whose /usr/local Homebrew chowned to
     # the account takes the writable branch above instead.
-    if ! { [ -d "$bindir" ] || sudo mkdir -m 0755 -p "$bindir"; } \
-       || ! sudo install -m 0755 "$work/kendex" "$bindir/kendex"; then
-      echo "install.sh: the elevated install to $bindir did not complete" >&2
-      echo "  install into a directory you own instead, such as $HOME/.local/bin on your PATH" >&2
-      exit 1
-    fi
+    [ -d "$bindir" ] || sudo mkdir -m 0755 -p "$bindir"
+    sudo install -m 0755 "$work/kendex" "$bindir/kendex"
   fi
   echo "Installed the kendex command to $bindir/kendex"
   # What this script installed, so the desktop app can tell this file from

--- a/install.sh
+++ b/install.sh
@@ -114,7 +114,16 @@ install_cli() {
     install -m 0755 "$work/kendex" "$bindir/kendex"
   else
     echo "Installing to $bindir needs elevated permissions."
-    sudo install -D -m 0755 "$work/kendex" "$bindir/kendex"
+    # Two commands rather than `install -D`, which would make the missing
+    # directory itself. That flag makes directories on GNU coreutils only:
+    # BSD install on macOS spells its own -D "-D dest" and takes an
+    # operand, so it reads "-m" as that operand and exits 64 on the usage
+    # it is left with. This is macOS's usual branch — /usr/local/bin is on
+    # PATH there whether or not it exists, and root owns it either way, so
+    # the mkdir above is the one that fails and leaves nothing to write
+    # into. -m means the same thing to both.
+    sudo mkdir -p "$bindir"
+    sudo install -m 0755 "$work/kendex" "$bindir/kendex"
   fi
   echo "Installed the kendex command to $bindir/kendex"
   # What this script installed, so the desktop app can tell this file from

--- a/install.sh
+++ b/install.sh
@@ -114,16 +114,26 @@ install_cli() {
     install -m 0755 "$work/kendex" "$bindir/kendex"
   else
     echo "Installing to $bindir needs elevated permissions."
-    # Two commands rather than `install -D`, which would make the missing
-    # directory itself. That flag makes directories on GNU coreutils only:
-    # BSD install on macOS spells its own -D "-D dest" and takes an
-    # operand, so it reads "-m" as that operand and exits 64 on the usage
-    # it is left with. This is macOS's usual branch — /usr/local/bin is on
-    # PATH there whether or not it exists, and root owns it either way, so
-    # the mkdir above is the one that fails and leaves nothing to write
-    # into. -m means the same thing to both.
-    sudo mkdir -p "$bindir"
-    sudo install -m 0755 "$work/kendex" "$bindir/kendex"
+    # The branch is taken because the directory is not writable, whether or
+    # not it exists. Two commands rather than the one `install -D` that
+    # made the directory itself: -D makes directories on GNU coreutils
+    # only, and BSD install on macOS spells its own -D "-D dest" and takes
+    # an operand, so it reads the "-m" behind it as that operand and exits
+    # 64 on the usage it is left with. The mkdir is what keeps the pair
+    # equivalent to that -D, for the machine where the directory is not
+    # there yet and the unprivileged mkdir above could not make it. -m
+    # means the same thing to both tools, and stating it here is what the
+    # replaced command did: root's umask decides the mode otherwise.
+    #
+    # The default macOS layout comes here: /etc/paths puts root-owned
+    # /usr/local/bin on PATH. A mac whose /usr/local Homebrew chowned to
+    # the account takes the writable branch above instead.
+    if ! { [ -d "$bindir" ] || sudo mkdir -m 0755 -p "$bindir"; } \
+       || ! sudo install -m 0755 "$work/kendex" "$bindir/kendex"; then
+      echo "install.sh: the elevated install to $bindir did not complete" >&2
+      echo "  install into a directory you own instead, such as $HOME/.local/bin on your PATH" >&2
+      exit 1
+    fi
   fi
   echo "Installed the kendex command to $bindir/kendex"
   # What this script installed, so the desktop app can tell this file from


### PR DESCRIPTION
## Summary

- `install.sh`'s elevated write no longer passes `install -D`. On macOS that flag is `-D dest` and takes an operand, so the elevated branch read `-m` as that operand and exited 64 without installing anything — and that branch is the default there, since `/etc/paths` puts root-owned `/usr/local/bin` on PATH. The pair is now `[ -d "$bindir" ] || sudo mkdir -m 0755 -p "$bindir"` followed by `sudo install -m 0755`, both bare under `set -eu`.
- `install_stub` refuses any flag it does not model instead of shrugging non-`-m` flags off through a catch-all arm, and it falls back to a mode `install.sh` never passes, so an elevated write that drops `-m 0755` now reds instead of matching the stub's own default.
- `sudo_as_root` guards its destination against the fixture root before it chmods or runs anything, and clears its umask so the mode on that branch is the one `install.sh` named rather than the runner's.

## Context

The issue filed this as a GNU-only flag. Measured on macOS 26.5.2, that premise was wrong in its reason but not its effect: BSD `install` does have `-D`, spelled `-D dest`, and it consumes the following `-m` as its operand. Same failure, same fix; the code comments and changelog state the measured mechanism.

## Completed Issues

- Closes KEN-958 - install.sh's privileged branch passes a GNU-only install flag and fails on macOS

## Test Plan

Four mutations, each red against the committed tree and reverted after:

| Mutation | Result |
|---|---|
| `install -D` restored in place of the pair | FAILED, 2 tests |
| elevated `mkdir` line removed | FAILED, 1 test |
| `-m 0755` dropped from the elevated `install` | FAILED, 1 test |
| `-m 0755` dropped from the elevated `mkdir` | FAILED, 1 test |

The last one is the point of the `umask 0` in `sudo_as_root`: before it, the fixture supplied 0755 under the runner's 022 umask whether or not the script asked for it, so the flag was unobservable.

Fail-closed direction was measured rather than argued, since the bare `[ -d … ] || sudo mkdir …` form relies on `set -e` treating the command after the final `||` as fatal: verified in dash, bash, `bash --posix`, macOS `sh` and zsh sh-emulation, each against a succeeding-list control that must proceed. With a refusing sudo the run exits 1, installs nothing, and never prints the success line.

`install_script` 13 tests, `installer` 9 tests, preflight, size-ratchet and `tools/guard` all green.
