### PR TITLE
fix(KEN-709): the window disarms a repository before its scripts go

### DIFF
--- a/changelog.d/fixed/ken-709.md
+++ b/changelog.d/fixed/ken-709.md
@@ -1,0 +1,3 @@
+- Removing a package from the app now runs its declared uninstaller first, so
+  the repository is disarmed before its scripts go, and the action says what
+  ran.

--- a/crates/app/src/app_settings.rs
+++ b/crates/app/src/app_settings.rs
@@ -268,7 +268,7 @@ mod tests {
         };
         let refused = update_settings_at(&env, stale, &held).unwrap_err();
 
-        assert!(matches!(refused, WriteRefused::Stale), "{refused:?}");
+        assert!(matches!(refused, WriteRefused::Stale { .. }), "{refused:?}");
         let stored = settings::load(&env).unwrap();
         assert_eq!(stored.zoom, 150);
         assert_eq!(stored.appearance, kendex_core::settings::Appearance::System);

--- a/crates/app/src/audit.rs
+++ b/crates/app/src/audit.rs
@@ -61,6 +61,14 @@ pub struct AuditView {
     /// it never works them out from the cause, which is how one surface
     /// ends up offering an action the plan rejects.
     pub exits: Vec<engine::exits::RowExits>,
+    /// What a removal in this action did about the repository effects of
+    /// the packages that left with it: the same lines the terminal prints,
+    /// so the window says what ran rather than leaving a repository armed
+    /// against scripts that are gone. Empty on a plain read and on every
+    /// action that took no declaring package away — and left off the wire
+    /// entirely when it is empty, which is almost every read.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub undone: Vec<String>,
     /// Set when this one scope couldn't be read at all — a corrupt or
     /// future-version lock or manifest. Carried as data so one scope's
     /// failure never blanks every other scope's audit (drift/plan/notes/
@@ -96,6 +104,7 @@ impl AuditView {
             safety: Vec::new(),
             adoptable: adoptable(),
             exits: Vec::new(),
+            undone: Vec::new(),
             error: Some(ScopeError::from(error)),
         }
     }
@@ -127,8 +136,24 @@ pub fn view(env: &Env, scope: &Scope) -> AuditView {
         warnings: report.warnings,
         safety,
         adoptable: adoptable(),
+        undone: Vec::new(),
         error: None,
     }
+}
+
+/// Execute a report and answer with the scope's standing beside what the
+/// removal did about any repository effect leaving with it — the one way a
+/// command here writes a report it holds.
+pub(crate) fn settle_report(
+    env: &Env,
+    scope: &Scope,
+    report: &engine::EngineReport,
+) -> Result<AuditView, String> {
+    let undone = crate::repo_effects::write(env, report)?;
+    Ok(AuditView {
+        undone,
+        ..view(env, scope)
+    })
 }
 
 #[tauri::command(async)]
@@ -167,8 +192,7 @@ pub fn apply_scope(env: &Env, scope: &Scope, remove_orphans: bool) -> Result<Aud
         ..PlanOptions::default()
     };
     let report = engine::plan_apply(env, scope, &options).map_err(|e| e.to_string())?;
-    apply::execute(env, &report.plan).map_err(|e| e.to_string())?;
-    Ok(view(env, scope))
+    settle_report(env, scope, &report)
 }
 
 #[tauri::command(async)]
@@ -193,8 +217,7 @@ pub fn adopt_item(
         engine::adopt::adopt(&env, &scope, kind, &name, &harnesses).map_err(|e| e.to_string())?;
     apply::execute(&env, &move_plan).map_err(|e| e.to_string())?;
     let report = engine::audit(&env, &scope).map_err(|e| e.to_string())?;
-    apply::execute(&env, &report.plan).map_err(|e| e.to_string())?;
-    Ok(view(&env, &scope))
+    settle_report(&env, &scope, &report)
 }
 
 /// Install what the manifest declares over the files already sitting where
@@ -225,8 +248,7 @@ pub fn replace_unmanaged(
         },
     )
     .map_err(|e| e.to_string())?;
-    apply::execute(env, &report.plan).map_err(|e| e.to_string())?;
-    Ok(view(env, scope))
+    settle_report(env, scope, &report)
 }
 
 #[tauri::command(async)]
@@ -256,21 +278,24 @@ pub fn toggle_item(
         enabled,
     )
     .map_err(|e| e.to_string())?;
-    apply::execute(&env, &report.plan).map_err(|e| e.to_string())?;
-    Ok(view(&env, &scope))
+    settle_report(&env, &scope, &report)
+}
+
+/// Take one item out of a scope, against the environment it is given.
+///
+/// Removing one item never takes its unneeded leftovers with it here: the
+/// page has nowhere to preview that yet, and a sweep the user did not see
+/// is exactly the surprise the preview step exists to stop.
+pub fn remove(env: &Env, scope: &Scope, kind: ItemKind, name: &str) -> Result<AuditView, String> {
+    let report = ops::remove(env, scope, &[name.to_owned()], Some(kind), false)
+        .map_err(|e| e.to_string())?;
+    settle_report(env, scope, &report)
 }
 
 #[tauri::command(async)]
 #[specta::specta]
 pub fn remove_item(scope: Scope, kind: ItemKind, name: String) -> Result<AuditView, String> {
-    let env = env()?;
-    // Removing one item never takes its unneeded leftovers with it here:
-    // the page has nowhere to preview that yet, and a sweep the user did
-    // not see is exactly the surprise the preview step exists to stop.
-    let report = ops::remove(&env, &scope, std::slice::from_ref(&name), Some(kind), false)
-        .map_err(|e| e.to_string())?;
-    apply::execute(&env, &report.plan).map_err(|e| e.to_string())?;
-    Ok(view(&env, &scope))
+    remove(&env()?, &scope, kind, &name)
 }
 
 #[cfg(test)]

--- a/crates/app/src/commands.rs
+++ b/crates/app/src/commands.rs
@@ -46,7 +46,11 @@ pub fn install_drift_hook(scope: kendex_core::model::Scope) -> Result<bool, Stri
     }
     let report =
         kendex_core::engine::plan_apply(&env, &scope, &options).map_err(|e| e.to_string())?;
-    kendex_core::apply::execute(&env, &report.plan).map_err(|e| e.to_string())?;
+    // Through the one executor, like every other report. Nothing was
+    // pending when this started, so the lock this plan writes is the one
+    // the scope already carries: no package leaves here, and the account of
+    // a removal is empty.
+    crate::repo_effects::write(&env, &report)?;
     Ok(true)
 }
 

--- a/crates/app/src/commands.rs
+++ b/crates/app/src/commands.rs
@@ -48,9 +48,11 @@ pub fn install_drift_hook(scope: kendex_core::model::Scope) -> Result<bool, Stri
         kendex_core::engine::plan_apply(&env, &scope, &options).map_err(|e| e.to_string())?;
     // Through the one executor, like every other report. Nothing was
     // pending when this started, so the lock this plan writes is the one
-    // the scope already carries: no package leaves here, and the account of
-    // a removal is empty.
-    crate::repo_effects::write(&env, &report)?;
+    // the scope already carries and no package leaves with it — which is
+    // what makes it safe to run a whole-scope plan off a yes given about a
+    // drift report. Checked rather than claimed: this command answers a
+    // bool and has nowhere to say what an uninstaller did.
+    crate::repo_effects::write_nothing_leaving(&env, &report)?;
     Ok(true)
 }
 

--- a/crates/app/src/editor/save.rs
+++ b/crates/app/src/editor/save.rs
@@ -15,7 +15,7 @@
 //! write that follows it. A second write would bind to bytes the first one
 //! had already replaced.
 
-use kendex_core::apply::{self, Op, PlannedOp, Pre};
+use kendex_core::apply::{Op, PlannedOp, Pre};
 use kendex_core::base::Base;
 use kendex_core::engine::{self, PlanOptions, ops};
 use kendex_core::env::Env;
@@ -29,6 +29,7 @@ use specta::Type;
 
 use super::env;
 use crate::audit::{AuditView, view};
+use crate::repo_effects::ExecuteError;
 use crate::whole_file::{WriteRefused, refusal, stale_at};
 
 /// A place's manifest and what the file it came from was at that moment.
@@ -233,13 +234,20 @@ fn write_customize(
     // The bound preconditions refuse a file that moved between the checks
     // above and the write itself, and that refusal is the same answer the
     // checks give — so it reaches the editor as the same choice.
-    apply::execute(env, &report.plan).map_err(|error| match stale_at(&error, &targets) {
-        true => WriteRefused::Stale,
-        false => WriteRefused::Failed {
-            message: error.to_string(),
+    // Through the one executor: a manifest saved with a package deleted out
+    // of it takes that package away, and its declared uninstaller has to run
+    // while its scripts are still on disk. A stale precondition still reads
+    // as the same refusal — the executor hands core's error on as its text.
+    let undone = crate::repo_effects::execute(env, &report).map_err(|refused| match &refused {
+        ExecuteError::Apply { error, .. } if stale_at(error, &targets) => WriteRefused::Stale,
+        _ => WriteRefused::Failed {
+            message: refused.to_string(),
         },
     })?;
-    Ok(view(env, &scope))
+    Ok(AuditView {
+        undone,
+        ..view(env, &scope)
+    })
 }
 
 /// The project root a settings file would sit in. Global has none: skills

--- a/crates/app/src/editor/save.rs
+++ b/crates/app/src/editor/save.rs
@@ -165,7 +165,9 @@ fn write_customize(
         None => None,
         Some((draft, claimed)) => {
             if now != claimed {
-                return Err(WriteRefused::Stale);
+                // Before anything ran: the copy is refused on the base
+                // check, so there is no account to carry.
+                return Err(WriteRefused::Stale { undone: Vec::new() });
             }
             let mut manifest = match current.is_some() {
                 true => draft,
@@ -236,18 +238,43 @@ fn write_customize(
     // checks give — so it reaches the editor as the same choice.
     // Through the one executor: a manifest saved with a package deleted out
     // of it takes that package away, and its declared uninstaller has to run
-    // while its scripts are still on disk. A stale precondition still reads
-    // as the same refusal — the executor hands core's error on as its text.
-    let undone = crate::repo_effects::execute(env, &report).map_err(|refused| match &refused {
-        ExecuteError::Apply { error, .. } if stale_at(error, &targets) => WriteRefused::Stale,
-        _ => WriteRefused::Failed {
-            message: refused.to_string(),
-        },
-    })?;
+    // while its scripts are still on disk.
+    //
+    // A stale precondition still reads as the same refusal, and it takes
+    // the account with it. The uninstaller ran before the plan wrote
+    // anything, so this is a refusal with a disarmed repository behind it —
+    // the one shape where "nothing happened, reload" is a lie. Which is
+    // also why nothing here reasons about whether this route can remove:
+    // it can, through a refused rendering, whatever the planning options
+    // say about orphans.
+    let undone = crate::repo_effects::execute(env, &report)
+        .map_err(|refused| refused_write(refused, &targets))?;
     Ok(AuditView {
         undone,
         ..view(env, &scope)
     })
+}
+
+/// How a write the executor refused reaches the page.
+///
+/// A precondition that moved is the reload choice the editor already
+/// draws, and it carries whatever the write had already done: the
+/// uninstaller of a leaving package runs before the plan writes anything,
+/// so a refusal landing after that point is a refusal with a disarmed
+/// repository behind it. A bare reload notice there says nothing happened,
+/// which is the one thing that is not true.
+///
+/// Named rather than inlined so the mapping can be driven with a real
+/// stale error rather than inferred from the branch.
+pub(super) fn refused_write(refused: ExecuteError, targets: &[std::path::PathBuf]) -> WriteRefused {
+    match refused {
+        ExecuteError::Apply { said, error } if stale_at(&error, targets) => {
+            WriteRefused::Stale { undone: said }
+        }
+        other => WriteRefused::Failed {
+            message: other.to_string(),
+        },
+    }
 }
 
 /// The project root a settings file would sit in. Global has none: skills

--- a/crates/app/src/editor/save/tests.rs
+++ b/crates/app/src/editor/save/tests.rs
@@ -126,7 +126,7 @@ fn a_writer_landing_after_the_editor_read_is_refused_mid_apply() {
         report.plan.ops
     );
 
-    let error = apply::execute(&env, &report.plan).unwrap_err();
+    let error = kendex_core::apply::execute(&env, &report.plan).unwrap_err();
     assert!(
         stale_at(
             &error,
@@ -176,7 +176,7 @@ fn a_refusal_through_a_symlinked_root_is_still_the_stale_choice() {
     )
     .unwrap();
 
-    let error = apply::execute(&env, &report.plan).unwrap_err();
+    let error = kendex_core::apply::execute(&env, &report.plan).unwrap_err();
     assert!(
         stale_at(
             &error,

--- a/crates/app/src/editor/save/tests.rs
+++ b/crates/app/src/editor/save/tests.rs
@@ -524,3 +524,95 @@ fn a_settings_only_save_carries_no_manifest_draft() {
         "the key arrives with the explainer the template ships: {written}"
     );
 }
+
+/// A project carrying a package that declares an uninstaller, installed
+/// and on disk, with a manifest the editor can save a package out of.
+///
+/// No `writes` inside `.git`, so the disclosure's git stand-down does not
+/// apply and no work tree is needed to prove what the removal runs.
+#[cfg(unix)]
+fn scope_carrying_a_declaring_package() -> (tempfile::TempDir, Env, Scope) {
+    use std::os::unix::fs::PermissionsExt;
+    let tmp = tempfile::tempdir().unwrap();
+    let env = Env::fake(tmp.path(), kendex_core::env::FakeOs::Linux);
+    let project = tmp.path().join("dev/app");
+    std::fs::create_dir_all(project.join(".claude")).unwrap();
+    let catalog = tmp.path().join("catalog");
+    let scripts = catalog.join("skills/guards/scripts");
+    std::fs::create_dir_all(&scripts).unwrap();
+    std::fs::write(
+        catalog.join("skills/guards/SKILL.md"),
+        "---\nname: guards\ndescription: gates the commits\n\
+         repo-effects:\n  summary: \"gates every commit here\"\n  \
+         installer: \"scripts/arm\"\n  uninstaller: \"scripts/arm --uninstall\"\n\
+         ---\nBody.\n",
+    )
+    .unwrap();
+    std::fs::write(
+        scripts.join("arm"),
+        "#!/bin/sh\ncase \" $* \" in *\" --uninstall \"*) echo 'guards: disarmed';; \
+         *) echo 'guards: armed';; esac\n",
+    )
+    .unwrap();
+    std::fs::set_permissions(scripts.join("arm"), std::fs::Permissions::from_mode(0o755)).unwrap();
+    std::fs::write(
+        project.join("kendex.toml"),
+        format!(
+            "schema = {MANIFEST_SCHEMA}\n\n[sources.cat]\n{}\n\n\
+             [install]\nharnesses = [\"claude\"]\n\n[skills.guards]\nsource = \"cat\"\n",
+            source_path(&catalog)
+        ),
+    )
+    .unwrap();
+    // Install it, so the tree whose uninstaller a removal runs is on disk.
+    write_customize(
+        &env,
+        Scope::Project {
+            root: project.clone(),
+        },
+        None,
+        None,
+    )
+    .unwrap();
+    assert!(
+        project.join(".agents/skills/guards/scripts/arm").is_file(),
+        "the fixture did not install the package"
+    );
+    (tmp, env, Scope::Project { root: project })
+}
+
+/// What the editor's own save does about a package the draft deletes.
+///
+/// The reason `ExecuteError::Apply` carries the lines already said is that
+/// a repository disarmed before a failed write is a fact somebody is owed.
+/// This route plans with `PlanOptions::default()`, so orphan removal is
+/// off and a package dropped from the manifest keeps its lock entry — the
+/// save reconciles the declaration away and takes nothing off disk. That
+/// makes the account empty here, and the assertion is what holds it that
+/// way: if this route ever starts removing, the doc on the stale arm has
+/// to carry `said` through rather than discard it.
+#[cfg(unix)]
+#[test]
+fn a_save_that_drops_a_package_removes_nothing_and_so_accounts_for_nothing() {
+    let (tmp, env, scope) = scope_carrying_a_declaring_package();
+    let manifest_path = manifest::manifest_path(&env, &scope);
+    let (current, base) = manifest::read_for_mutation(&manifest_path).unwrap();
+    let mut edited = current.unwrap();
+    edited.skills.remove("guards");
+
+    let view = write_customize(&env, scope, Some((edited, base)), None).unwrap();
+
+    assert!(
+        view.undone.is_empty(),
+        "the editor's save reported a removal it does not make: {:?}",
+        view.undone
+    );
+    // And it really did leave the package's files alone — an empty account
+    // over a removal that happened would be the defect, not the state.
+    assert!(
+        tmp.path()
+            .join("dev/app/.agents/skills/guards/scripts/arm")
+            .is_file(),
+        "the save took the package off disk after all"
+    );
+}

--- a/crates/app/src/editor/save/tests.rs
+++ b/crates/app/src/editor/save/tests.rs
@@ -271,7 +271,7 @@ fn a_save_from_a_stale_copy_is_refused_and_the_newer_file_stands() {
         panic!("a stale save must be refused");
     };
 
-    assert!(matches!(refused, WriteRefused::Stale), "{refused:?}");
+    assert!(matches!(refused, WriteRefused::Stale { .. }), "{refused:?}");
     let (kept, _) = manifest::read_for_mutation(&path).unwrap();
     let kept = kept.unwrap();
     assert_eq!(
@@ -295,7 +295,7 @@ fn a_copy_predating_the_first_save_is_refused_once_a_file_exists() {
     let Err(refused) = write_customize(&env, scope, Some((empty, Base::absent())), None) else {
         panic!("a no-file claim against an existing file must be refused");
     };
-    assert!(matches!(refused, WriteRefused::Stale), "{refused:?}");
+    assert!(matches!(refused, WriteRefused::Stale { .. }), "{refused:?}");
 }
 
 fn manifest() -> Manifest {
@@ -493,7 +493,7 @@ fn a_stale_settings_copy_refuses_and_takes_the_manifest_edit_with_it() {
     ) else {
         panic!("a stale settings copy must be refused");
     };
-    assert!(matches!(refused, WriteRefused::Stale), "{refused:?}");
+    assert!(matches!(refused, WriteRefused::Stale { .. }), "{refused:?}");
     assert_eq!(std::fs::read_to_string(&settings).unwrap(), newer);
     let (kept, _) = manifest::read_for_mutation(&manifest_path).unwrap();
     assert!(kept.unwrap().skill_instructions.is_empty());
@@ -555,11 +555,41 @@ fn scope_carrying_a_declaring_package() -> (tempfile::TempDir, Env, Scope) {
     )
     .unwrap();
     std::fs::set_permissions(scripts.join("arm"), std::fs::Permissions::from_mode(0o755)).unwrap();
+    // An agent whose role gains a skill upstream between the two phases,
+    // so a later plan writes the manifest itself. That write is the one op
+    // binding `manifest_base`, and so the only way to drive a refusal that
+    // lands after the uninstaller has already run.
+    let skill = |name: &str| {
+        std::fs::create_dir_all(catalog.join("skills").join(name)).unwrap();
+        std::fs::write(
+            catalog.join("skills").join(name).join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: skill {name}\n---\nBody.\n"),
+        )
+        .unwrap();
+    };
+    skill("recon");
+    skill("probe");
+    std::fs::create_dir_all(catalog.join("agents")).unwrap();
+    std::fs::write(
+        catalog.join("agents/rev.md"),
+        "---\nname: rev\ndescription: agent rev\nrole: reviewer\n---\nBody.\n",
+    )
+    .unwrap();
+    let role_skills = |carried: &str| {
+        std::fs::write(
+            catalog.join("kendex.toml"),
+            format!("is_source_catalog = true\n\n[role-skills]\nreviewer = [{carried}]\n"),
+        )
+        .unwrap();
+    };
+    role_skills("\"recon\"");
     std::fs::write(
         project.join("kendex.toml"),
         format!(
             "schema = {MANIFEST_SCHEMA}\n\n[sources.cat]\n{}\n\n\
-             [install]\nharnesses = [\"claude\"]\n\n[skills.guards]\nsource = \"cat\"\n",
+             [install]\nharnesses = [\"claude\"]\n\n\
+             [skills.guards]\nsource = \"cat\"\n\n[agents.rev]\nsource = \"cat\"\n\n\
+             [skills.recon]\nsource = \"cat\"\n\n[agent-skills]\nrev = [\"recon\"]\n",
             source_path(&catalog)
         ),
     )
@@ -578,22 +608,25 @@ fn scope_carrying_a_declaring_package() -> (tempfile::TempDir, Env, Scope) {
         project.join(".agents/skills/guards/scripts/arm").is_file(),
         "the fixture did not install the package"
     );
+    // And the role gains its second skill, so the next plan writes the
+    // manifest itself — the one op that binds `manifest_base`, and so the
+    // only way to drive a refusal landing AFTER the uninstaller has run.
+    role_skills("\"recon\", \"probe\"");
     (tmp, env, Scope::Project { root: project })
 }
 
-/// What the editor's own save does about a package the draft deletes.
+/// Dropping a declaration is not the same as removing the package.
 ///
-/// The reason `ExecuteError::Apply` carries the lines already said is that
-/// a repository disarmed before a failed write is a fact somebody is owed.
-/// This route plans with `PlanOptions::default()`, so orphan removal is
-/// off and a package dropped from the manifest keeps its lock entry — the
-/// save reconciles the declaration away and takes nothing off disk. That
-/// makes the account empty here, and the assertion is what holds it that
-/// way: if this route ever starts removing, the doc on the stale arm has
-/// to carry `said` through rather than discard it.
+/// With orphan removal off, a package taken out of the manifest keeps its
+/// lock entry and its files, so this save reconciles the declaration away
+/// and runs nothing. That is a fact about THIS door only — a refused
+/// rendering drops the entry regardless, which
+/// `an_uninstaller_that_ran_before_a_refusal_is_still_reported` proves
+/// below. Both are here because one of them used to stand for the whole
+/// route, and a doc comment rested on it.
 #[cfg(unix)]
 #[test]
-fn a_save_that_drops_a_package_removes_nothing_and_so_accounts_for_nothing() {
+fn dropping_a_declaration_leaves_the_package_and_runs_nothing() {
     let (tmp, env, scope) = scope_carrying_a_declaring_package();
     let manifest_path = manifest::manifest_path(&env, &scope);
     let (current, base) = manifest::read_for_mutation(&manifest_path).unwrap();
@@ -614,5 +647,117 @@ fn a_save_that_drops_a_package_removes_nothing_and_so_accounts_for_nothing() {
             .join("dev/app/.agents/skills/guards/scripts/arm")
             .is_file(),
         "the save took the package off disk after all"
+    );
+}
+
+/// The other door a package leaves by, and the one that makes the account
+/// worth carrying through a refusal.
+///
+/// A refused rendering drops its lock entry whatever `remove_orphans`
+/// says — `plan_refusals` re-inserts the entry on one arm only — so this
+/// route can run an uninstaller without anybody asking for a removal. A
+/// catalog tree carrying both spellings of its skill file is the cheapest
+/// way to make the engine refuse one.
+#[cfg(unix)]
+fn scope_whose_package_stops_rendering(
+    from: &(tempfile::TempDir, Env, Scope),
+) -> std::path::PathBuf {
+    let catalog = from.0.path().join("catalog");
+    let disabled = catalog.join("skills/guards/SKILL.md.disabled");
+    std::fs::write(
+        &disabled,
+        "---\nname: guards\ndescription: gates the commits\n---\n",
+    )
+    .unwrap();
+    disabled
+}
+
+/// A refusal that lands after the uninstaller ran keeps its account.
+///
+/// This is the issue's own end state reached from the other direction: the
+/// repository is disarmed, the write does not land, and a bare reload
+/// notice would tell the person nothing happened. The lines ride on the
+/// refusal instead.
+#[cfg(unix)]
+#[test]
+fn an_uninstaller_that_ran_before_a_refusal_is_still_reported() {
+    let held = scope_carrying_a_declaring_package();
+    let (_tmp, env, scope) = (&held.0, &held.1, &held.2);
+    scope_whose_package_stops_rendering(&held);
+
+    // Planned and applied whole, the way the editor's save does: the
+    // refused rendering drops the package, and its uninstaller runs.
+    let view = crate::audit::apply_scope(env, scope, false).unwrap();
+
+    assert_eq!(
+        view.undone,
+        vec![
+            "guards: running scripts/arm --uninstall".to_owned(),
+            "guards: disarmed".to_owned()
+        ],
+        "a refused rendering removed the package without saying what it ran"
+    );
+}
+
+/// And the account survives the refusal itself.
+///
+/// The uninstaller runs before the plan writes, so a refusal landing after
+/// that point is a refusal with a disarmed repository behind it. Dropping
+/// the lines into a unit variant told the person only to reload, which is
+/// the one shape where "nothing happened" is a lie — and it is this
+/// issue's own end state reached from the other direction.
+///
+/// Driven through the real executor against a real moved precondition:
+/// the manifest the plan binds is rewritten after the report is built, so
+/// the apply rolls back with the uninstaller already run.
+#[cfg(unix)]
+#[test]
+fn a_refusal_after_the_uninstaller_ran_still_carries_the_account() {
+    let held = scope_carrying_a_declaring_package();
+    let (_tmp, env, scope) = (&held.0, &held.1, &held.2);
+    scope_whose_package_stops_rendering(&held);
+    let path = manifest::manifest_path(env, scope);
+    let (read, base) = manifest::read_for_mutation(&path).unwrap();
+    let editor_copy = read.unwrap();
+    let lock = load_lock(&lock_path(env, scope)).unwrap();
+    let report = engine::plan_scope(
+        env,
+        scope,
+        &editor_copy,
+        &lock,
+        &PlanOptions {
+            manifest_base: Some(base),
+            ..PlanOptions::default()
+        },
+    )
+    .unwrap();
+    assert!(
+        !report.repo_effects_leaving.is_empty(),
+        "the fixture built a report with nothing leaving"
+    );
+
+    // The writer in between: lands after the report was built, so the
+    // apply rolls back on the precondition it bound.
+    let original = std::fs::read_to_string(&path).unwrap();
+    std::fs::write(
+        &path,
+        format!("{original}\n[skill-instructions]\nall = \"kept\"\n"),
+    )
+    .unwrap();
+
+    let refused = crate::repo_effects::execute(env, &report).unwrap_err();
+    let refused = refused_write(refused, std::slice::from_ref(&path));
+
+    let undone = match refused {
+        WriteRefused::Stale { undone } => undone,
+        other => panic!("expected a stale refusal, got {other:?}"),
+    };
+    assert_eq!(
+        undone,
+        vec![
+            "guards: running scripts/arm --uninstall".to_owned(),
+            "guards: disarmed".to_owned(),
+        ],
+        "the refusal reported a reload over a repository it had just disarmed"
     );
 }

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -18,7 +18,7 @@ pub mod recovery;
 pub mod repo_effects;
 mod scopes;
 pub mod sources;
-mod unsubscribe;
+pub mod unsubscribe;
 mod update_check;
 mod whole_file;
 mod window;

--- a/crates/app/src/marketplaces.rs
+++ b/crates/app/src/marketplaces.rs
@@ -205,11 +205,10 @@ pub fn marketplace_subscribe(
     let env = env()?;
     let subscribed = source_ops::subscribe(&env, &scope, &reference, name.as_deref())
         .map_err(|e| e.to_string())?;
-    // Through the one executor, like every report. Not because a subscribe
-    // is expected to drop a package — orphan removal is off here, so it
-    // does not — but because that is the invariant: no path reasons about
-    // whether its own plan can take a package away, so none of them has to
-    // be re-reasoned about when its planning options change.
+    // Through the one executor, like every report, precisely because no
+    // path can prove its own plan takes nothing away. Orphan removal being
+    // off does not settle it: a rendering the engine refuses drops the
+    // package's lock entry regardless, and its uninstaller runs.
     let undone = crate::repo_effects::write(&env, &subscribed.report)?;
     let mut notes = subscribed.report.notes;
     // Fetch so counts and browsing land right away; a failure costs the

--- a/crates/app/src/marketplaces.rs
+++ b/crates/app/src/marketplaces.rs
@@ -5,7 +5,6 @@
 //! command here. Reads take a [`Catalog`]: a subscription, or a repository
 //! opened from the Community tab before subscribing.
 
-use kendex_core::apply;
 use kendex_core::env::Env;
 use kendex_core::library::{self, ProvenanceRow};
 use kendex_core::manifest::{Manifest, manifest_path};
@@ -201,8 +200,12 @@ pub fn marketplace_subscribe(
     let env = env()?;
     let subscribed = source_ops::subscribe(&env, &scope, &reference, name.as_deref())
         .map_err(|e| e.to_string())?;
-    apply::execute(&env, &subscribed.report.plan).map_err(|e| e.to_string())?;
+    // The subscription's own plan, through the one executor: a manifest
+    // edited outside the window can leave a package the plan drops, and its
+    // uninstaller has to run while its scripts are still on disk.
+    let undone = crate::repo_effects::write(&env, &subscribed.report)?;
     let mut notes = subscribed.report.notes;
+    notes.extend(undone);
     // Fetch so counts and browsing land right away; a failure costs the
     // counts, never the subscription — the CLI verb behaves the same.
     if let Ok(Some(manifest)) =

--- a/crates/app/src/marketplaces.rs
+++ b/crates/app/src/marketplaces.rs
@@ -186,6 +186,11 @@ pub struct SubscribeOutcome {
     /// opens next, never an identity.
     pub lead: Option<String>,
     pub notes: Vec<String>,
+    /// What a package leaving with this plan had undone, if one did. Its
+    /// own field rather than more notes, so the account a removal owes has
+    /// one name across every command that can make one.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub undone: Vec<String>,
 }
 
 /// Subscribe a scope to a marketplace: `owner/repo[@rev]`, a git URL, a
@@ -200,12 +205,13 @@ pub fn marketplace_subscribe(
     let env = env()?;
     let subscribed = source_ops::subscribe(&env, &scope, &reference, name.as_deref())
         .map_err(|e| e.to_string())?;
-    // The subscription's own plan, through the one executor: a manifest
-    // edited outside the window can leave a package the plan drops, and its
-    // uninstaller has to run while its scripts are still on disk.
+    // Through the one executor, like every report. Not because a subscribe
+    // is expected to drop a package — orphan removal is off here, so it
+    // does not — but because that is the invariant: no path reasons about
+    // whether its own plan can take a package away, so none of them has to
+    // be re-reasoned about when its planning options change.
     let undone = crate::repo_effects::write(&env, &subscribed.report)?;
     let mut notes = subscribed.report.notes;
-    notes.extend(undone);
     // Fetch so counts and browsing land right away; a failure costs the
     // counts, never the subscription — the CLI verb behaves the same.
     if let Ok(Some(manifest)) =
@@ -222,6 +228,7 @@ pub fn marketplace_subscribe(
         rev: subscribed.rev,
         lead: subscribed.lead,
         notes,
+        undone,
     })
 }
 

--- a/crates/app/src/marketplaces/install.rs
+++ b/crates/app/src/marketplaces/install.rs
@@ -174,6 +174,10 @@ pub fn install(
         _ => engine_ops::add(env, &target, &request),
     }
     .map_err(|e| e.to_string())?;
+    // Through the one executor, like every report: no path here reasons
+    // about whether its own plan can take a package away. An add's does
+    // not today — orphan removal is off — and that is a planning option
+    // rather than a property of this command.
     let undone = crate::repo_effects::write(env, &report)?;
     // After the write, because the script an effect runs is the one this
     // install just put on disk.

--- a/crates/app/src/marketplaces/install.rs
+++ b/crates/app/src/marketplaces/install.rs
@@ -181,16 +181,26 @@ pub fn install(
     let undone = crate::repo_effects::write(env, &report)?;
     // After the write, because the script an effect runs is the one this
     // install just put on disk.
-    let repo_effects = kendex_core::repo_effects::offers_for(env, &target, &report.repo_effects)
-        .map_err(|e| e.to_string())?;
-    let packages = browse::packages(
-        env,
-        &Catalog::Subscription {
-            scope: target,
-            source,
-        },
-    )
-    .map_err(|e| e.to_string())?;
+    // Both reads are enrichment past the write, so both carry the account
+    // on their failure rather than through it: the uninstallers have run
+    // and the plan is committed, and a listing error over a repository
+    // that was just disarmed is this issue's own failure mode.
+    let repo_effects = crate::repo_effects::after_writing(
+        &undone,
+        kendex_core::repo_effects::offers_for(env, &target, &report.repo_effects)
+            .map_err(|e| e.to_string()),
+    )?;
+    let packages = crate::repo_effects::after_writing(
+        &undone,
+        browse::packages(
+            env,
+            &Catalog::Subscription {
+                scope: target,
+                source,
+            },
+        )
+        .map_err(|e| e.to_string()),
+    )?;
     Ok(Installed {
         packages,
         repo_effects,

--- a/crates/app/src/marketplaces/install.rs
+++ b/crates/app/src/marketplaces/install.rs
@@ -6,7 +6,6 @@
 //! tool added since the scope was set up is offerable and one removed since
 //! does not read as present.
 
-use kendex_core::apply;
 use kendex_core::engine::ops::{self as engine_ops, AddRequest};
 use kendex_core::env::Env;
 use kendex_core::manifest::Method;
@@ -71,13 +70,16 @@ pub struct InstallItem {
 }
 
 /// What an install hands back: the subscription's packages as they stand
-/// now, and the repository effects the install brought — read and asked
-/// about in the window, because nothing here ran them.
+/// now, the repository effects the install brought — read and asked about
+/// in the window, because nothing here ran them — and what any package the
+/// plan took away had undone, which is not asked about at all.
 #[derive(Debug, Clone, Serialize, Type)]
 #[serde(rename_all = "camelCase")]
 pub struct Installed {
     pub packages: Vec<AvailablePackage>,
     pub repo_effects: Offers,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub undone: Vec<String>,
 }
 
 /// Install packages or a curated set from one subscription. `destination`
@@ -172,7 +174,7 @@ pub fn install(
         _ => engine_ops::add(env, &target, &request),
     }
     .map_err(|e| e.to_string())?;
-    apply::execute(env, &report.plan).map_err(|e| e.to_string())?;
+    let undone = crate::repo_effects::write(env, &report)?;
     // After the write, because the script an effect runs is the one this
     // install just put on disk.
     let repo_effects = kendex_core::repo_effects::offers_for(env, &target, &report.repo_effects)
@@ -188,5 +190,6 @@ pub fn install(
     Ok(Installed {
         packages,
         repo_effects,
+        undone,
     })
 }

--- a/crates/app/src/marketplaces/install.rs
+++ b/crates/app/src/marketplaces/install.rs
@@ -174,10 +174,10 @@ pub fn install(
         _ => engine_ops::add(env, &target, &request),
     }
     .map_err(|e| e.to_string())?;
-    // Through the one executor, like every report: no path here reasons
-    // about whether its own plan can take a package away. An add's does
-    // not today — orphan removal is off — and that is a planning option
-    // rather than a property of this command.
+    // Through the one executor, like every report, because no path here
+    // can prove its own plan takes nothing away. An add is not exempt: a
+    // rendering the engine refuses drops that package's lock entry
+    // whatever the planning options say, and its uninstaller runs.
     let undone = crate::repo_effects::write(env, &report)?;
     // After the write, because the script an effect runs is the one this
     // install just put on disk.

--- a/crates/app/src/packages.rs
+++ b/crates/app/src/packages.rs
@@ -11,7 +11,7 @@ use kendex_core::package::{self, detail, diff};
 use serde::Serialize;
 use specta::Type;
 
-use crate::audit::{AuditView, view};
+use crate::audit::{AuditView, settle_report};
 
 pub mod update;
 
@@ -105,8 +105,7 @@ fn settle(env: &Env, scope: &Scope, plan: &apply::Plan) -> Result<AuditView, Str
 /// standing that leaves.
 fn render_scope(env: &Env, scope: &Scope) -> Result<AuditView, String> {
     let report = engine::audit(env, scope).map_err(|e| e.to_string())?;
-    apply::execute(env, &report.plan).map_err(|e| e.to_string())?;
-    Ok(view(env, scope))
+    settle_report(env, scope, &report)
 }
 
 #[tauri::command(async)]
@@ -138,8 +137,7 @@ pub fn fork_rename(
         },
     )
     .map_err(|e| e.to_string())?;
-    apply::execute(&env, &report.plan).map_err(|e| e.to_string())?;
-    Ok(view(&env, &scope))
+    settle_report(&env, &scope, &report)
 }
 
 /// Discard one package's edits and re-render it — the door back to "the
@@ -169,8 +167,7 @@ pub fn apply_discard_edits(
             &engine::PlanOptions::for_package_discarding_edits(kind, &name),
         )
         .map_err(|e| e.to_string())?;
-        apply::execute(&env, &report.plan).map_err(|e| e.to_string())?;
-        return Ok(view(&env, &scope));
+        return settle_report(&env, &scope, &report);
     }
     let manifest = manifest::load_for_mutation(&manifest::manifest_path(&env, &scope))
         .map_err(|e| e.to_string())?
@@ -185,8 +182,7 @@ pub fn apply_discard_edits(
         &engine::PlanOptions::for_package_discarding_edits(kind, name),
     )
     .map_err(|e| e.to_string())?;
-    apply::execute(&env, &report.plan).map_err(|e| e.to_string())?;
-    Ok(view(&env, &scope))
+    settle_report(&env, &scope, &report)
 }
 
 #[tauri::command(async)]

--- a/crates/app/src/packages/update.rs
+++ b/crates/app/src/packages/update.rs
@@ -3,13 +3,12 @@
 //! never moves that scope's other followers, and both answer with what
 //! the plan wrote and what it refused rather than the view alone.
 
-use kendex_core::apply;
 use kendex_core::engine;
 use kendex_core::env::Env;
 use kendex_core::model::{ItemKind, Scope};
 use kendex_core::package;
 
-use crate::audit::{AuditView, view};
+use crate::audit::{AuditView, settle_report};
 
 use super::env;
 
@@ -121,9 +120,8 @@ fn settle_package(
     report: &engine::EngineReport,
 ) -> Result<PackageUpdate, String> {
     let one = package_outcome(report, kind, name);
-    apply::execute(env, &report.plan).map_err(|e| e.to_string())?;
     Ok(PackageUpdate {
-        view: view(env, scope),
+        view: settle_report(env, scope, report)?,
         held_back: one.held_back,
         removed: one.removed,
         moved: one.moved,
@@ -172,9 +170,8 @@ pub fn package_update_many(
         .iter()
         .map(|target| package_outcome(&report, target.kind, &target.name))
         .collect();
-    apply::execute(&env, &report.plan).map_err(|e| e.to_string())?;
     Ok(PackagesUpdate {
-        view: view(&env, &scope),
+        view: settle_report(&env, &scope, &report)?,
         packages,
     })
 }

--- a/crates/app/src/repo_effects.rs
+++ b/crates/app/src/repo_effects.rs
@@ -8,6 +8,7 @@
 //! run and no other — a refresh repairs files and arms nothing, the same
 //! as the terminal.
 
+use kendex_core::engine::EngineReport;
 use kendex_core::env::Env;
 use kendex_core::model::Scope;
 use kendex_core::repo_effects::{ArmError, DeclaredEffects};
@@ -82,4 +83,82 @@ pub fn apply(env: &Env, scope: &Scope, declared: &DeclaredEffects) -> Result<Sai
 pub fn repo_effects_apply(scope: Scope, declared: DeclaredEffects) -> Result<Said, String> {
     let env = Env::detect().map_err(|error| error.to_string())?;
     apply(&env, &scope, &declared)
+}
+
+/// Why a report did not get written.
+///
+/// Two, because the caller has to be able to tell them apart. The editor
+/// reads a precondition refusal as the reload choice it already draws, and
+/// that reading needs core's own error rather than a sentence about it.
+pub enum ExecuteError {
+    /// A leaving package's uninstaller failed, or could not be run. The
+    /// plan stopped before writing anything: the package's files are still
+    /// in place, and the message carries what was said before the failure.
+    Undo(String),
+    /// The undo did what it had to and the plan itself refused. The lines
+    /// already said ride along — a repository disarmed before a write that
+    /// then failed is a fact the person is still owed. Boxed: a refusal is
+    /// the rare path, and the common `Ok` should not carry its size.
+    Apply {
+        said: Vec<String>,
+        error: Box<kendex_core::error::CoreError>,
+    },
+}
+
+impl std::fmt::Display for ExecuteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExecuteError::Undo(message) => write!(f, "{message}"),
+            ExecuteError::Apply { said, error } => {
+                for line in said {
+                    writeln!(f, "{line}")?;
+                }
+                write!(f, "{error}")
+            }
+        }
+    }
+}
+
+/// Execute a report's plan — the one way a desktop command holding an
+/// `EngineReport` writes it, and the mirror of the terminal's
+/// `apply_report`.
+///
+/// A plan can take a package away whatever the window called it: removing
+/// an item, applying a scope with orphan removal on, unsubscribing, saving
+/// a manifest with a package deleted out of it. The package's declared
+/// uninstaller has to run while the scripts it names are still on disk, so
+/// no command executes `report.plan` itself — every report goes through
+/// here, and only a bare `Plan` with no report behind it, which by
+/// construction drops no package, is executed on its own.
+///
+/// Not a refusal that points at the terminal. Removing the package is the
+/// ask, the same as it is at the prompt; what the window owes is the
+/// account, which comes back as the lines the terminal would have printed
+/// for the action's result to carry.
+///
+/// A package whose uninstaller fails stops the plan with the files still
+/// in place, so the person can run it by hand and remove again. The other
+/// order leaves the repository in the state this exists to prevent.
+pub fn execute(env: &Env, report: &EngineReport) -> Result<Vec<String>, ExecuteError> {
+    let mut said = Vec::new();
+    if let Err(error) = kendex_core::repo_effects::undo(
+        &report.plan.scope,
+        &report.repo_effects_leaving,
+        &mut |spoken| said.push(spoken.into_line()),
+    ) {
+        said.push(error.to_string());
+        return Err(ExecuteError::Undo(said.join("\n")));
+    }
+    match kendex_core::apply::execute(env, &report.plan) {
+        Ok(_) => Ok(said),
+        Err(error) => Err(ExecuteError::Apply {
+            said,
+            error: Box::new(error),
+        }),
+    }
+}
+
+/// The same write for a caller that has no use for the two kinds apart.
+pub fn write(env: &Env, report: &EngineReport) -> Result<Vec<String>, String> {
+    execute(env, report).map_err(|error| error.to_string())
 }

--- a/crates/app/src/repo_effects.rs
+++ b/crates/app/src/repo_effects.rs
@@ -1,5 +1,7 @@
 //! The desktop's half of a package's repository effects: the command that
-//! runs an effect once the window has a yes.
+//! runs an effect once the window has a yes, and the one executor every
+//! command writes a report through, which undoes a leaving package's
+//! effect before the plan takes its scripts away.
 //!
 //! An install is one command that plans and writes. The effect is not in
 //! it: the report's declarations become the offers the window shows, and
@@ -99,6 +101,14 @@ pub enum ExecuteError {
     /// already said ride along — a repository disarmed before a write that
     /// then failed is a fact the person is still owed. Boxed: a refusal is
     /// the rare path, and the common `Ok` should not carry its size.
+    ///
+    /// One caller drops them: the editor maps a stale precondition to the
+    /// reload choice it draws, which is a unit answer with nowhere to put
+    /// a line. Sound there and only there, because that route plans with
+    /// `PlanOptions::default()` and so removes nothing — held by
+    /// `a_save_that_drops_a_package_removes_nothing_and_so_accounts_for_nothing`
+    /// rather than by this sentence. Any other caller that reads this
+    /// variant owes the lines.
     Apply {
         said: Vec<String>,
         error: Box<kendex_core::error::CoreError>,
@@ -144,7 +154,21 @@ pub fn execute(env: &Env, report: &EngineReport) -> Result<Vec<String>, ExecuteE
     if let Err(error) = kendex_core::repo_effects::undo(
         &report.plan.scope,
         &report.repo_effects_leaving,
-        &mut |spoken| said.push(spoken.into_line()),
+        // The package's own two streams go out escaped, the way the
+        // terminal escapes them. This is a departing third party's output
+        // landing in a toast that carries no attribution, so a line of
+        // bidi overrides or one phrased in kendex's voice would read as
+        // kendex talking. core already escapes its own Note lines, and
+        // `shown` over escaped text is the same text.
+        //
+        // The terminal's stdout door stays unescaped for the reason it
+        // exists: those bytes are a pipe's answer. A window has no pipe.
+        &mut |spoken| {
+            said.push(match spoken {
+                kendex_core::repo_effects::Spoken::Note(line) => line,
+                other => kendex_core::names::shown(&other.into_line()),
+            });
+        },
     ) {
         said.push(error.to_string());
         return Err(ExecuteError::Undo(said.join("\n")));
@@ -161,4 +185,31 @@ pub fn execute(env: &Env, report: &EngineReport) -> Result<Vec<String>, ExecuteE
 /// The same write for a caller that has no use for the two kinds apart.
 pub fn write(env: &Env, report: &EngineReport) -> Result<Vec<String>, String> {
     execute(env, report).map_err(|error| error.to_string())
+}
+
+/// The same write for a caller whose plan must take nothing away, and
+/// which has nowhere to say what a removal ran.
+///
+/// The emptiness is checked, not assumed. A caller reaches this because it
+/// proved something about its own plan a moment earlier, and a proof in a
+/// comment is worth what the next edit leaves of it — while the cost of
+/// being wrong is uninstallers running in somebody's repository off an
+/// answer they gave about something else, with nothing said. So it refuses
+/// before the write and names what it would have removed, which is the
+/// direction guard code has to fail.
+pub fn write_nothing_leaving(env: &Env, report: &EngineReport) -> Result<(), String> {
+    let leaving = &report.repo_effects_leaving;
+    if !leaving.is_empty() {
+        let names: Vec<String> = leaving
+            .iter()
+            .map(|declared| kendex_core::names::shown(&declared.name))
+            .collect();
+        return Err(format!(
+            "this would also take {} away, and undoing what it did to this \
+             repository is not something this action can report — apply the \
+             scope from the Audit page, which says what a removal ran",
+            names.join(", ")
+        ));
+    }
+    write(env, report).map(|_| ())
 }

--- a/crates/app/src/repo_effects.rs
+++ b/crates/app/src/repo_effects.rs
@@ -248,6 +248,27 @@ pub fn write(env: &Env, report: &EngineReport) -> Result<Vec<String>, String> {
     execute(env, report).map_err(|error| error.to_string())
 }
 
+/// Fold the account into whatever an enrichment read failed with.
+///
+/// Once `execute` has returned, the uninstallers have run and the plan is
+/// committed. Everything a command does after that — reading back the
+/// sources, the sets, the packages — is enrichment, and a `?` on one of
+/// those discards the account with the answer it was riding on. The person
+/// is then shown a listing error over a repository that was disarmed a
+/// moment earlier, which is this issue's own failure mode reached through
+/// the error path instead of the happy one.
+///
+/// Carried on the error rather than dropped, and never at the cost of the
+/// error itself: an irreversible side effect is not made reversible by
+/// swallowing what came after it. The lines go first because they are what
+/// changed on disk; the failure follows, saying what could not be read.
+pub fn after_writing<T>(undone: &[String], read: Result<T, String>) -> Result<T, String> {
+    read.map_err(|error| match undone.is_empty() {
+        true => error,
+        false => format!("{}\n{error}", undone.join("\n")),
+    })
+}
+
 /// The same write for a caller whose plan must take nothing away, and
 /// which has nowhere to say what a removal ran.
 ///
@@ -273,4 +294,43 @@ pub fn write_nothing_leaving(env: &Env, report: &EngineReport) -> Result<(), Str
         ));
     }
     write(env, report).map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::after_writing;
+
+    /// The shape every post-write read shares: the account rides on the
+    /// failure, and the failure is not swallowed to carry it.
+    #[test]
+    fn a_read_that_fails_after_the_write_carries_the_account_and_the_error() {
+        let undone = ["guards: running scripts/arm --uninstall".to_owned()];
+        let refused: Result<(), String> = Err("the source list could not be read".to_owned());
+
+        let Err(message) = after_writing(&undone, refused) else {
+            panic!("a failed read must stay a failure");
+        };
+
+        assert_eq!(
+            message,
+            "guards: running scripts/arm --uninstall\nthe source list could not be read"
+        );
+    }
+
+    /// Nothing left the scope, so there is nothing to add to the failure.
+    #[test]
+    fn a_read_that_fails_after_a_write_that_removed_nothing_says_only_why() {
+        let refused: Result<(), String> = Err("the source list could not be read".to_owned());
+        let Err(message) = after_writing(&[], refused) else {
+            panic!("a failed read must stay a failure");
+        };
+        assert_eq!(message, "the source list could not be read");
+    }
+
+    /// A read that worked is handed straight back.
+    #[test]
+    fn a_read_that_worked_is_untouched() {
+        let undone = ["guards: running scripts/arm --uninstall".to_owned()];
+        assert_eq!(after_writing(&undone, Ok::<u8, String>(7)), Ok(7));
+    }
 }

--- a/crates/app/src/repo_effects.rs
+++ b/crates/app/src/repo_effects.rs
@@ -54,21 +54,34 @@ pub fn apply(env: &Env, scope: &Scope, declared: &DeclaredEffects) -> Result<Sai
             kendex_core::names::shown(&declared.name)
         ));
     }
+    // Escaped on the way out, both channels and both outcomes. These are a
+    // third party's bytes and the window renders the installer's last
+    // stdout line as a bare toast the moment somebody authorizes an
+    // arming, so a bidi override or a line phrased in kendex's voice would
+    // read as kendex's verdict on what they just approved. The departing
+    // half of this module is held to the same rule; one door each would
+    // mean the rule holds wherever it was last reviewed.
+    let shown = |lines: &[String]| -> Vec<String> {
+        lines
+            .iter()
+            .map(|line| kendex_core::names::shown(line))
+            .collect()
+    };
     match kendex_core::repo_effects::arm(scope, declared) {
         Ok(report) => Ok(Said {
-            stdout: report.stdout,
-            stderr: report.stderr,
+            stdout: shown(&report.stdout),
+            stderr: shown(&report.stderr),
         }),
         // The one wording, with the package's own lines under it where the
         // installer got far enough to say anything — the account of a
         // possibly half-written repository has to reach the person whole.
         Err(error) => {
-            let said: Vec<&str> = match &error {
+            let said: Vec<String> = match &error {
                 ArmError::Failed { report, .. } => report
                     .stderr
                     .iter()
                     .chain(&report.stdout)
-                    .map(String::as_str)
+                    .map(|line| kendex_core::names::shown(line))
                     .collect(),
                 _ => Vec::new(),
             };
@@ -102,13 +115,13 @@ pub enum ExecuteError {
     /// then failed is a fact the person is still owed. Boxed: a refusal is
     /// the rare path, and the common `Ok` should not carry its size.
     ///
-    /// One caller drops them: the editor maps a stale precondition to the
-    /// reload choice it draws, which is a unit answer with nowhere to put
-    /// a line. Sound there and only there, because that route plans with
-    /// `PlanOptions::default()` and so removes nothing — held by
-    /// `a_save_that_drops_a_package_removes_nothing_and_so_accounts_for_nothing`
-    /// rather than by this sentence. Any other caller that reads this
-    /// variant owes the lines.
+    /// Every caller carries them, the editor's stale answer included: its
+    /// `WriteRefused::Stale` holds an `undone` for exactly this. No route
+    /// is exempt on the grounds that its own plan cannot remove anything,
+    /// because none of them can show that — a rendering the engine refuses
+    /// drops the package's lock entry whatever the planning options say
+    /// about orphans, so an uninstaller runs on a path nobody asked for a
+    /// removal on.
     Apply {
         said: Vec<String>,
         error: Box<kendex_core::error::CoreError>,
@@ -127,6 +140,19 @@ impl std::fmt::Display for ExecuteError {
             }
         }
     }
+}
+
+/// What stands in for the lines of one package's output that were not
+/// carried. Said rather than dropped: an account that quietly stops is one
+/// nobody knows to go and read in full.
+fn elided(lines: usize) -> String {
+    format!(
+        "and {lines} more line{} from that package",
+        match lines {
+            1 => "",
+            _ => "s",
+        }
+    )
 }
 
 /// Execute a report's plan — the one way a desktop command holding an
@@ -151,27 +177,62 @@ impl std::fmt::Display for ExecuteError {
 /// order leaves the repository in the state this exists to prevent.
 pub fn execute(env: &Env, report: &EngineReport) -> Result<Vec<String>, ExecuteError> {
     let mut said = Vec::new();
+    // How many lines of one package's own output are carried. A departing
+    // package chooses its own output length and core relays it whole, so
+    // an account with no ceiling is a third party deciding how long the
+    // window is busy. Per package rather than over the whole account,
+    // because the budget is about one program being chatty.
+    const PACKAGE_LINES: usize = 10;
+    let mut spent = 0usize;
+    let mut dropped = 0usize;
     if let Err(error) = kendex_core::repo_effects::undo(
         &report.plan.scope,
         &report.repo_effects_leaving,
+        // Two rules, and both need the tag core attached — which is why
+        // the budget is spent here rather than over the flat list the
+        // window receives.
+        //
+        // Every Note is kept, whatever a neighbour printed. They are
+        // kendex's own account and the ONLY place it says an effect was
+        // left standing and names the manual remedy; a package that
+        // pushed a sibling's stand-down notice past a cap would be
+        // suppressing the one line nothing else can recover. Their count
+        // is bounded by the number of packages leaving, so keeping them
+        // all cannot restore the drain the budget exists to stop.
+        //
         // The package's own two streams go out escaped, the way the
         // terminal escapes them. This is a departing third party's output
         // landing in a toast that carries no attribution, so a line of
         // bidi overrides or one phrased in kendex's voice would read as
-        // kendex talking. core already escapes its own Note lines, and
-        // `shown` over escaped text is the same text.
+        // kendex talking. `shown` over core's already-escaped Note lines
+        // is the same text, so only the streams need it.
         //
         // The terminal's stdout door stays unescaped for the reason it
         // exists: those bytes are a pipe's answer. A window has no pipe.
-        &mut |spoken| {
-            said.push(match spoken {
-                kendex_core::repo_effects::Spoken::Note(line) => line,
-                other => kendex_core::names::shown(&other.into_line()),
-            });
+        &mut |spoken| match spoken {
+            kendex_core::repo_effects::Spoken::Note(line) => {
+                if dropped > 0 {
+                    said.push(elided(dropped));
+                    dropped = 0;
+                }
+                spent = 0;
+                said.push(line);
+            }
+            other if spent < PACKAGE_LINES => {
+                spent += 1;
+                said.push(kendex_core::names::shown(&other.into_line()));
+            }
+            _ => dropped += 1,
         },
     ) {
+        if dropped > 0 {
+            said.push(elided(dropped));
+        }
         said.push(error.to_string());
         return Err(ExecuteError::Undo(said.join("\n")));
+    }
+    if dropped > 0 {
+        said.push(elided(dropped));
     }
     match kendex_core::apply::execute(env, &report.plan) {
         Ok(_) => Ok(said),

--- a/crates/app/src/sources.rs
+++ b/crates/app/src/sources.rs
@@ -31,6 +31,12 @@ pub struct SourcesAfter {
     pub undone: Vec<String>,
 }
 
+/// Write a source action's report and answer with what stands after it.
+///
+/// Through the one executor, like every report. Removing or disabling a
+/// source can take its packages with it; adding one does not. Neither
+/// command has to know which it is, and that is the point of there being
+/// one door.
 fn run_and_list(
     env: &Env,
     report: kendex_core::engine::EngineReport,
@@ -126,6 +132,8 @@ pub fn install_bundle(
         ..AddRequest::default()
     };
     let report = engine_ops::add(env, scope, &request).map_err(|e| e.to_string())?;
+    // The one executor, as everywhere: a set install is an add and takes
+    // nothing away today, and no command here is written to depend on that.
     let undone = crate::repo_effects::write(env, &report)?;
     let repo_effects = kendex_core::repo_effects::offers_for(env, scope, &report.repo_effects)
         .map_err(|e| e.to_string())?;

--- a/crates/app/src/sources.rs
+++ b/crates/app/src/sources.rs
@@ -34,9 +34,10 @@ pub struct SourcesAfter {
 /// Write a source action's report and answer with what stands after it.
 ///
 /// Through the one executor, like every report. Removing or disabling a
-/// source can take its packages with it; adding one does not. Neither
-/// command has to know which it is, and that is the point of there being
-/// one door.
+/// source takes its packages with it, and adding one can too — a rendering
+/// the engine refuses drops that package's lock entry whatever the
+/// planning options say. No command here has to know which it is, and that
+/// is the point of there being one door.
 fn run_and_list(
     env: &Env,
     report: kendex_core::engine::EngineReport,
@@ -132,8 +133,9 @@ pub fn install_bundle(
         ..AddRequest::default()
     };
     let report = engine_ops::add(env, scope, &request).map_err(|e| e.to_string())?;
-    // The one executor, as everywhere: a set install is an add and takes
-    // nothing away today, and no command here is written to depend on that.
+    // The one executor, as everywhere. A set install is an add, which is
+    // not the same as taking nothing away: a refused rendering removes the
+    // package it refused, and nothing here is written to depend otherwise.
     let undone = crate::repo_effects::write(env, &report)?;
     let repo_effects = kendex_core::repo_effects::offers_for(env, scope, &report.repo_effects)
         .map_err(|e| e.to_string())?;

--- a/crates/app/src/sources.rs
+++ b/crates/app/src/sources.rs
@@ -2,7 +2,7 @@ use kendex_core::engine::ops::{self as engine_ops, AddRequest};
 use kendex_core::env::Env;
 use kendex_core::model::Scope;
 use kendex_core::source_ops::{self, BundleRow, SourceRow};
-use kendex_core::{apply, manifest, remote};
+use kendex_core::{manifest, remote};
 
 use crate::scopes::{all as all_scopes, env};
 
@@ -18,17 +18,33 @@ pub fn sources_overview() -> Result<Vec<SourceRow>, String> {
     Ok(rows)
 }
 
+/// What a source action leaves: every declared source across every scope,
+/// and what the removal did about the repository effects of any package
+/// that left with it — the same account the terminal prints, so the window
+/// says what ran rather than leaving a repository armed against scripts
+/// that are gone.
+#[derive(Debug, Clone, serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct SourcesAfter {
+    pub sources: Vec<SourceRow>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub undone: Vec<String>,
+}
+
 fn run_and_list(
     env: &Env,
     report: kendex_core::engine::EngineReport,
-) -> Result<Vec<SourceRow>, String> {
-    apply::execute(env, &report.plan).map_err(|e| e.to_string())?;
-    sources_overview()
+) -> Result<SourcesAfter, String> {
+    let undone = crate::repo_effects::write(env, &report)?;
+    Ok(SourcesAfter {
+        sources: sources_overview()?,
+        undone,
+    })
 }
 
 #[tauri::command(async)]
 #[specta::specta]
-pub fn source_add(scope: Scope, name: String, reference: String) -> Result<Vec<SourceRow>, String> {
+pub fn source_add(scope: Scope, name: String, reference: String) -> Result<SourcesAfter, String> {
     let env = env()?;
     let report =
         source_ops::add_source(&env, &scope, &name, &reference).map_err(|e| e.to_string())?;
@@ -37,7 +53,7 @@ pub fn source_add(scope: Scope, name: String, reference: String) -> Result<Vec<S
 
 #[tauri::command(async)]
 #[specta::specta]
-pub fn source_remove(scope: Scope, name: String) -> Result<Vec<SourceRow>, String> {
+pub fn source_remove(scope: Scope, name: String) -> Result<SourcesAfter, String> {
     let env = env()?;
     let report = source_ops::remove_source(&env, &scope, &name).map_err(|e| e.to_string())?;
     run_and_list(&env, report)
@@ -45,7 +61,7 @@ pub fn source_remove(scope: Scope, name: String) -> Result<Vec<SourceRow>, Strin
 
 #[tauri::command(async)]
 #[specta::specta]
-pub fn source_toggle(scope: Scope, name: String, enabled: bool) -> Result<Vec<SourceRow>, String> {
+pub fn source_toggle(scope: Scope, name: String, enabled: bool) -> Result<SourcesAfter, String> {
     let env = env()?;
     let report =
         source_ops::toggle_source(&env, &scope, &name, enabled).map_err(|e| e.to_string())?;
@@ -68,13 +84,16 @@ pub fn bundles_overview() -> Result<Vec<BundleRow>, String> {
     list_all_bundles(&env()?)
 }
 
-/// What a bundle install hands back: every set as it stands now, and the
-/// repository effects its members brought for the window to ask about.
+/// What a bundle install hands back: every set as it stands now, the
+/// repository effects its members brought for the window to ask about, and
+/// what any package the plan took away had undone.
 #[derive(Debug, Clone, serde::Serialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
 pub struct BundleInstalled {
     pub bundles: Vec<BundleRow>,
     pub repo_effects: kendex_core::repo_effects::Offers,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub undone: Vec<String>,
 }
 
 /// Install a set whole. Its members derive from the catalog, so this declares
@@ -107,12 +126,13 @@ pub fn install_bundle(
         ..AddRequest::default()
     };
     let report = engine_ops::add(env, scope, &request).map_err(|e| e.to_string())?;
-    apply::execute(env, &report.plan).map_err(|e| e.to_string())?;
+    let undone = crate::repo_effects::write(env, &report)?;
     let repo_effects = kendex_core::repo_effects::offers_for(env, scope, &report.repo_effects)
         .map_err(|e| e.to_string())?;
     Ok(BundleInstalled {
         bundles: list_all_bundles(env)?,
         repo_effects,
+        undone,
     })
 }
 

--- a/crates/app/src/sources.rs
+++ b/crates/app/src/sources.rs
@@ -10,10 +10,15 @@ use crate::scopes::{all as all_scopes, env};
 #[tauri::command(async)]
 #[specta::specta]
 pub fn sources_overview() -> Result<Vec<SourceRow>, String> {
-    let env = env()?;
+    list_all_sources(&env()?)
+}
+
+/// The same listing against the environment it is given, for a caller that
+/// already holds one.
+fn list_all_sources(env: &Env) -> Result<Vec<SourceRow>, String> {
     let mut rows = Vec::new();
-    for scope in all_scopes(&env)? {
-        rows.extend(source_ops::list_sources(&env, &scope).map_err(|e| e.to_string())?);
+    for scope in all_scopes(env)? {
+        rows.extend(source_ops::list_sources(env, &scope).map_err(|e| e.to_string())?);
     }
     Ok(rows)
 }
@@ -43,10 +48,10 @@ fn run_and_list(
     report: kendex_core::engine::EngineReport,
 ) -> Result<SourcesAfter, String> {
     let undone = crate::repo_effects::write(env, &report)?;
-    Ok(SourcesAfter {
-        sources: sources_overview()?,
-        undone,
-    })
+    // Everything past the write is enrichment, and the account rides on
+    // its failure rather than through it.
+    let sources = crate::repo_effects::after_writing(&undone, list_all_sources(env))?;
+    Ok(SourcesAfter { sources, undone })
 }
 
 #[tauri::command(async)]
@@ -137,10 +142,16 @@ pub fn install_bundle(
     // not the same as taking nothing away: a refused rendering removes the
     // package it refused, and nothing here is written to depend otherwise.
     let undone = crate::repo_effects::write(env, &report)?;
-    let repo_effects = kendex_core::repo_effects::offers_for(env, scope, &report.repo_effects)
-        .map_err(|e| e.to_string())?;
+    // Both reads are enrichment past the write, so both carry the account
+    // on their failure rather than through it.
+    let repo_effects = crate::repo_effects::after_writing(
+        &undone,
+        kendex_core::repo_effects::offers_for(env, scope, &report.repo_effects)
+            .map_err(|e| e.to_string()),
+    )?;
+    let bundles = crate::repo_effects::after_writing(&undone, list_all_bundles(env))?;
     Ok(BundleInstalled {
-        bundles: list_all_bundles(env)?,
+        bundles,
         repo_effects,
         undone,
     })

--- a/crates/app/src/unsubscribe.rs
+++ b/crates/app/src/unsubscribe.rs
@@ -3,6 +3,7 @@
 
 use kendex_core::apply;
 use kendex_core::engine::ops as engine_ops;
+use kendex_core::env::Env;
 use kendex_core::model::{ItemKind, Scope};
 use kendex_core::source_ops;
 use serde::Serialize;
@@ -55,6 +56,10 @@ pub fn marketplace_unsubscribe_preview(
 /// Unsubscribe, removing or keeping the packages. `keep` converts each
 /// installation to a local fork; otherwise they are uninstalled, and
 /// `discard_edits` takes hand edits along instead of refusing.
+///
+/// Answers with what the removal did about the repository effects of the
+/// packages that left with the source — the same account the terminal
+/// prints, for the window to show.
 #[tauri::command(async)]
 #[specta::specta]
 pub fn marketplace_unsubscribe(
@@ -62,35 +67,49 @@ pub fn marketplace_unsubscribe(
     source: String,
     keep: bool,
     discard_edits: bool,
-) -> Result<(), String> {
-    use kendex_core::engine::detach;
-    let env = env()?;
-    let manifest = engine_ops::manifest_for_mutation(&env, &scope).map_err(|e| e.to_string())?;
-    let closure = detach::closure(&env, &scope, &source, &manifest).map_err(|e| e.to_string())?;
+) -> Result<Vec<String>, String> {
+    unsubscribe(&env()?, &scope, &source, keep, discard_edits)
+}
 
-    let plan = if closure.items.is_empty() {
-        source_ops::remove_source(&env, &scope, &source)
-            .map_err(|e| e.to_string())?
-            .plan
+/// The unsubscribe itself, against the environment it is given.
+pub fn unsubscribe(
+    env: &Env,
+    scope: &Scope,
+    source: &str,
+    keep: bool,
+    discard_edits: bool,
+) -> Result<Vec<String>, String> {
+    use kendex_core::engine::detach;
+    let manifest = engine_ops::manifest_for_mutation(env, scope).map_err(|e| e.to_string())?;
+    let closure = detach::closure(env, scope, source, &manifest).map_err(|e| e.to_string())?;
+
+    let mut undone = if closure.items.is_empty() {
+        let report = source_ops::remove_source(env, scope, source).map_err(|e| e.to_string())?;
+        crate::repo_effects::write(env, &report)?
     } else if keep {
-        detach::source(&env, &scope, &source).map_err(|e| e.to_string())?
+        // A conversion, not a removal: every package stays, under `local`
+        // instead of the source that is going. A bare plan with no report
+        // behind it drops nothing, and the resync below is what carries a
+        // report.
+        let plan = detach::source(env, scope, source).map_err(|e| e.to_string())?;
+        apply::execute(env, &plan).map_err(|e| e.to_string())?;
+        Vec::new()
     } else {
-        detach::remove(&env, &scope, &source, discard_edits)
-            .map_err(|e| e.to_string())?
-            .plan
+        let report =
+            detach::remove(env, scope, source, discard_edits).map_err(|e| e.to_string())?;
+        crate::repo_effects::write(env, &report)?
     };
-    apply::execute(&env, &plan).map_err(|e| e.to_string())?;
     if keep {
         // Keeping moved the catalog's mapping tables into the manifest, so
         // the install records are re-synced here — otherwise every kept
         // agent would read as drifted until the next refresh.
         let resync = kendex_core::engine::plan_apply(
-            &env,
-            &scope,
+            env,
+            scope,
             &kendex_core::engine::PlanOptions::default(),
         )
         .map_err(|e| e.to_string())?;
-        apply::execute(&env, &resync.plan).map_err(|e| e.to_string())?;
+        undone.extend(crate::repo_effects::write(env, &resync)?);
     }
-    Ok(())
+    Ok(undone)
 }

--- a/crates/app/src/unsubscribe.rs
+++ b/crates/app/src/unsubscribe.rs
@@ -53,13 +53,24 @@ pub fn marketplace_unsubscribe_preview(
     })
 }
 
+/// What unsubscribing did about the repository effects of the packages
+/// that left with the source — the same account the terminal prints.
+///
+/// A struct rather than the bare list it used to be, spelling the account
+/// `undone` like every other command that can make one. The window reads
+/// the account off an answer by that name, so a bare list is a shape it
+/// can only be told about by hand, and the day this write goes through
+/// the shared one it would fall silent with nothing going red.
+#[derive(Debug, Clone, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct Unsubscribed {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub undone: Vec<String>,
+}
+
 /// Unsubscribe, removing or keeping the packages. `keep` converts each
 /// installation to a local fork; otherwise they are uninstalled, and
 /// `discard_edits` takes hand edits along instead of refusing.
-///
-/// Answers with what the removal did about the repository effects of the
-/// packages that left with the source — the same account the terminal
-/// prints, for the window to show.
 #[tauri::command(async)]
 #[specta::specta]
 pub fn marketplace_unsubscribe(
@@ -67,7 +78,7 @@ pub fn marketplace_unsubscribe(
     source: String,
     keep: bool,
     discard_edits: bool,
-) -> Result<Vec<String>, String> {
+) -> Result<Unsubscribed, String> {
     unsubscribe(&env()?, &scope, &source, keep, discard_edits)
 }
 
@@ -78,7 +89,7 @@ pub fn unsubscribe(
     source: &str,
     keep: bool,
     discard_edits: bool,
-) -> Result<Vec<String>, String> {
+) -> Result<Unsubscribed, String> {
     use kendex_core::engine::detach;
     let manifest = engine_ops::manifest_for_mutation(env, scope).map_err(|e| e.to_string())?;
     let closure = detach::closure(env, scope, source, &manifest).map_err(|e| e.to_string())?;
@@ -111,5 +122,5 @@ pub fn unsubscribe(
         .map_err(|e| e.to_string())?;
         undone.extend(crate::repo_effects::write(env, &resync)?);
     }
-    Ok(undone)
+    Ok(Unsubscribed { undone })
 }

--- a/crates/app/src/whole_file.rs
+++ b/crates/app/src/whole_file.rs
@@ -22,7 +22,17 @@ pub enum WriteRefused {
     /// The file is no longer the one this copy was read from. Something
     /// else wrote it — a fork, a hold, an install, another window — and
     /// writing this copy would put that back.
-    Stale,
+    ///
+    /// Carries whatever the write already did to the repository before it
+    /// refused. A plan runs a leaving package's uninstaller before it
+    /// touches the files, so a refusal landing after that point is a
+    /// refusal with a disarmed repository behind it — and a reload notice
+    /// on its own would send somebody away believing nothing happened.
+    /// Empty on the base check, which refuses before anything runs.
+    Stale {
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        undone: Vec<String>,
+    },
     Failed {
         message: String,
     },
@@ -43,7 +53,7 @@ impl From<String> for WriteRefused {
 /// went wrong.
 pub fn refusal(error: CoreError) -> WriteRefused {
     match error {
-        CoreError::PlanStale { .. } => WriteRefused::Stale,
+        CoreError::PlanStale { .. } => WriteRefused::Stale { undone: Vec::new() },
         other => WriteRefused::Failed {
             message: other.to_string(),
         },
@@ -72,7 +82,7 @@ mod tests {
         let path = PathBuf::from("/w/app/kendex.toml");
         assert!(matches!(
             refusal(CoreError::PlanStale { path }),
-            WriteRefused::Stale
+            WriteRefused::Stale { .. }
         ));
         assert!(matches!(
             refusal(CoreError::LegacyManifest {

--- a/crates/app/tests/one_executor.rs
+++ b/crates/app/tests/one_executor.rs
@@ -344,7 +344,19 @@ fn passes(args: &str, name: &str) -> bool {
     })
 }
 
-/// Every call under `root` that writes a plan it took off a report.
+/// Every problem under `root`: a call that writes a plan it took off a
+/// report, and any file the scan could not read.
+///
+/// A file it cannot read is a problem, never a clean one. Reading it as an
+/// empty string made an unreadable or non-UTF-8 file scan as blank source,
+/// which retired this rule for that file and said nothing — and this scan
+/// is the only guard eight of the ten rerouted paths have.
+///
+/// Every path is rendered through `paths::slashed`, the same call `exempt`
+/// reads through. Once one side of a comparison is a value from there the
+/// other has to be too, or the two agree only where the platform's own
+/// separator already matches — which is a class of failure only Windows CI
+/// sees, one run per push.
 #[allow(clippy::unwrap_used)]
 fn offenders(root: &Path) -> Vec<String> {
     let mut files = Vec::new();
@@ -353,7 +365,16 @@ fn offenders(root: &Path) -> Vec<String> {
     files.sort();
     let mut found = Vec::new();
     for path in files.iter().filter(|path| !exempt(path, root)) {
-        let text = code_only(&std::fs::read_to_string(path).unwrap_or_default());
+        let shown = kendex_core::paths::slashed(path);
+        let text = match std::fs::read_to_string(path) {
+            Ok(source) => code_only(&source),
+            Err(error) => {
+                found.push(format!(
+                    "{shown}: unread, so the rule went unchecked here: {error}"
+                ));
+                continue;
+            }
+        };
         for (start, body) in functions(&text) {
             let locals = plan_locals(body);
             for (at, args) in calls(body) {
@@ -361,11 +382,7 @@ fn offenders(root: &Path) -> Vec<String> {
                     continue;
                 }
                 let line = text[..start + at].lines().count();
-                found.push(format!(
-                    "{}:{line}: apply::execute({})",
-                    path.display(),
-                    args.trim()
-                ));
+                found.push(format!("{shown}:{line}: apply::execute({})", args.trim()));
             }
         }
     }
@@ -377,8 +394,11 @@ fn no_command_executes_a_report_s_plan_itself() {
     let found = offenders(&src());
     assert!(
         found.is_empty(),
-        "these write a report's plan without running the leaving packages' \
-         uninstallers — call repo_effects::execute instead:\n{}",
+        "the one-executor rule is not held. Each line is either a call that \
+         writes a report's plan without running the leaving packages' \
+         uninstallers — call repo_effects::execute instead — or a file the \
+         scan could not read, which is not the same as a file with nothing \
+         in it:\n{}",
         found.join("\n")
     );
 }
@@ -448,10 +468,15 @@ fn the_scan_names_every_shape_of_a_report_s_plan_and_spares_a_bare_one() {
     );
 
     let found = offenders(&root);
+    // Spelled through the same call the hits are, and anchored at the
+    // path rather than matched anywhere in the line. A literal built with
+    // `/` never matches a hit Windows rendered with `\`, and the
+    // single-segment cases hid it by having no separator to disagree
+    // about — so both sides go through `slashed` over the same root.
     let named = |file: &str, line: usize| {
-        let want = format!("{file}:{line}:");
+        let want = format!("{}:{line}:", kendex_core::paths::slashed(&root.join(file)));
         assert!(
-            found.iter().any(|hit| hit.contains(&want)),
+            found.iter().any(|hit| hit.starts_with(&want)),
             "{want} went uncaught:\n{}",
             found.join("\n")
         );
@@ -461,6 +486,15 @@ fn the_scan_names_every_shape_of_a_report_s_plan_and_spares_a_bare_one() {
     named("audit.rs", 3);
     named("app_update/tests.rs", 2);
     assert_eq!(found.len(), 4, "{found:#?}");
+    // The hits are spelled the way `slashed` spells them, not the way the
+    // platform does. This assertion is vacuous on Unix, where the two
+    // agree, and is the whole guard on Windows, where `display()` writes
+    // `\` and an expectation spelled with `/` then matches nothing. It is
+    // here because that class costs one CI run per push to find.
+    assert!(
+        found.iter().all(|hit| !hit.contains('\\')),
+        "a hit was rendered with the platform separator rather than slashed: {found:#?}"
+    );
 }
 
 /// Nothing that is not code condemns a file, in any of the three ways it
@@ -551,12 +585,42 @@ fn a_statement_is_read_to_its_own_end() {
     .unwrap();
 
     let found = offenders(&root);
-    for want in ["audit.rs:3", "sources.rs:2"] {
+    // Single-segment names, and spelled through `slashed` anyway: this is
+    // where the next multi-segment expectation gets added.
+    for (file, line) in [("audit.rs", 3), ("sources.rs", 2)] {
+        let want = format!("{}:{line}:", kendex_core::paths::slashed(&root.join(file)));
         assert!(
-            found.iter().any(|hit| hit.contains(want)),
+            found.iter().any(|hit| hit.starts_with(&want)),
             "{want} went uncaught:\n{}",
             found.join("\n")
         );
     }
     assert_eq!(found.len(), 2, "{found:#?}");
+}
+
+/// A file the scan cannot read is a problem, not a clean file.
+///
+/// Reading it as an empty string made it scan as blank source, so the rule
+/// went unenforced for that file and nothing said so. This scan is the
+/// only guard eight of the ten rerouted paths have, so a silent read
+/// failure retires the rule for whichever file failed — which is guard
+/// code failing in the one direction that matters.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_file_the_scan_cannot_read_is_named_rather_than_passed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = rooted(&tmp);
+    // Not UTF-8, so `read_to_string` refuses it whatever its permissions,
+    // which is a state every platform reaches the same way.
+    std::fs::write(root.join("packages.rs"), [0x66, 0x6e, 0x20, 0xff, 0xfe]).unwrap();
+
+    let found = offenders(&root);
+
+    let want = kendex_core::paths::slashed(&root.join("packages.rs"));
+    assert_eq!(found.len(), 1, "{found:#?}");
+    assert!(
+        found[0].starts_with(&format!("{want}: unread")),
+        "{found:#?}"
+    );
+    assert!(found[0].contains("went unchecked"), "{found:#?}");
 }

--- a/crates/app/tests/one_executor.rs
+++ b/crates/app/tests/one_executor.rs
@@ -1,0 +1,94 @@
+//! One executor for a report, held by a fixture rather than by a comment.
+//!
+//! `repo_effects::execute` is where a report's plan gets written, because
+//! that is where a leaving package's uninstaller runs while its scripts
+//! are still on disk. A command that reaches past it into
+//! `apply::execute(env, &report.plan)` compiles, previews the same, and
+//! leaves the repository armed against files it just deleted — which is
+//! how every desktop path came to do it. So the rule is read off the
+//! source: nothing here executes a plan it took off a report.
+
+use std::path::{Path, PathBuf};
+
+#[path = "../../test_util.rs"]
+mod test_util;
+use test_util::rooted;
+
+fn src() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+#[allow(clippy::unwrap_used)]
+fn rust_files(dir: &Path, found: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(dir).unwrap() {
+        let path = entry.unwrap().path();
+        if path.is_dir() {
+            rust_files(&path, found);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            found.push(path);
+        }
+    }
+}
+
+/// The executor itself writes the plan — that is what it is for. A file of
+/// tests reaching for core's apply is exercising core, not writing a
+/// command's report.
+fn exempt(path: &Path) -> bool {
+    let stem = path.file_stem().and_then(|stem| stem.to_str());
+    matches!(stem, Some("repo_effects" | "tests"))
+}
+
+/// Every line in `dir` that writes a plan it took off a report.
+fn offenders(dir: &Path) -> Vec<String> {
+    let mut files = Vec::new();
+    rust_files(dir, &mut files);
+    assert!(!files.is_empty(), "no sources found under {dir:?}");
+    let mut found = Vec::new();
+    for path in files.iter().filter(|path| !exempt(path)) {
+        let text = std::fs::read_to_string(path).unwrap_or_default();
+        for (n, line) in text.lines().enumerate() {
+            if line.contains("apply::execute(") && line.contains(".plan") {
+                found.push(format!("{}:{}: {}", path.display(), n + 1, line.trim()));
+            }
+        }
+    }
+    found
+}
+
+#[test]
+fn no_command_executes_a_report_s_plan_itself() {
+    let found = offenders(&src());
+    assert!(
+        found.is_empty(),
+        "these write a report's plan without running the leaving packages' \
+         uninstallers — call repo_effects::execute instead:\n{}",
+        found.join("\n")
+    );
+}
+
+/// The scan run red once, over the shape the bug had — and left alone by
+/// the bare plan a command is allowed to execute on its own.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn the_scan_names_a_report_s_plan_and_spares_a_bare_one() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = rooted(&tmp);
+    let nested = root.join("marketplaces");
+    std::fs::create_dir_all(&nested).unwrap();
+    std::fs::write(
+        nested.join("install.rs"),
+        "fn write(env: &Env, report: &EngineReport) {\n\
+         \x20   apply::execute(env, &report.plan).unwrap();\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("packages.rs"),
+        "fn write(env: &Env, plan: &Plan) {\n\
+         \x20   apply::execute(env, plan).unwrap();\n}\n",
+    )
+    .unwrap();
+
+    let found = offenders(&root);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert!(found[0].contains("install.rs:2"), "{found:?}");
+}

--- a/crates/app/tests/one_executor.rs
+++ b/crates/app/tests/one_executor.rs
@@ -7,7 +7,14 @@
 //! leaves the repository armed against files it just deleted — which is
 //! how every desktop path came to do it. So the rule is read off the
 //! source: nothing here executes a plan it took off a report.
+//!
+//! Read at statement scope rather than per line, because a line-local
+//! match is a rule anybody reformats away by accident. `cargo fmt` wraps a
+//! long call over four lines and does not join it back, and a plan bound
+//! to a local puts the two halves in different statements — both shapes
+//! are the defect, and a scan that misses them is guard code failing open.
 
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 #[path = "../../test_util.rs"]
@@ -30,25 +37,151 @@ fn rust_files(dir: &Path, found: &mut Vec<PathBuf>) {
     }
 }
 
-/// The executor itself writes the plan — that is what it is for. A file of
-/// tests reaching for core's apply is exercising core, not writing a
-/// command's report.
-fn exempt(path: &Path) -> bool {
-    let stem = path.file_stem().and_then(|stem| stem.to_str());
-    matches!(stem, Some("repo_effects" | "tests"))
+/// The two files allowed to write a report's plan: the executor itself,
+/// which is what it is for, and the editor's save tests, which exercise
+/// core's apply rather than a command's report.
+///
+/// Named by path under `src`, never by file stem. A stem of `tests` also
+/// exempted `app_update/tests.rs` and `launch_env/tests.rs`, and a stem of
+/// `repo_effects` would exempt any future `src/**/repo_effects.rs` — an
+/// exemption that widens on its own is the shape this scan exists to stop.
+fn exempt(path: &Path, root: &Path) -> bool {
+    let relative = path.strip_prefix(root).unwrap_or(path);
+    matches!(
+        kendex_core::paths::slashed(relative).as_str(),
+        "repo_effects.rs" | "editor/save/tests.rs"
+    )
 }
 
-/// Every line in `dir` that writes a plan it took off a report.
-fn offenders(dir: &Path) -> Vec<String> {
-    let mut files = Vec::new();
-    rust_files(dir, &mut files);
-    assert!(!files.is_empty(), "no sources found under {dir:?}");
+/// The source with its line comments cut away, so prose describing this
+/// rule cannot trip the scan and a call commented out cannot hide from it.
+/// Quoting is tracked, so a `//` inside a string literal stays put.
+fn without_line_comments(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for line in text.lines() {
+        let bytes = line.as_bytes();
+        let (mut quoted, mut cut, mut i) = (false, line.len(), 0);
+        while i < bytes.len() {
+            match bytes[i] {
+                b'\\' if quoted => i += 1,
+                b'"' => quoted = !quoted,
+                b'/' if !quoted && bytes.get(i + 1) == Some(&b'/') => {
+                    cut = i;
+                    break;
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        out.push_str(&line[..cut]);
+        out.push('\n');
+    }
+    out
+}
+
+fn is_ident(c: char) -> bool {
+    c.is_alphanumeric() || c == '_'
+}
+
+/// Every `apply::execute(...)` in `text`: the line it opens on, and its
+/// whole argument list with continuation lines joined — so a call rustfmt
+/// spread over four lines reads exactly like one written on a single line.
+fn calls(text: &str) -> Vec<(usize, String)> {
+    const NEEDLE: &str = "apply::execute(";
     let mut found = Vec::new();
-    for path in files.iter().filter(|path| !exempt(path)) {
-        let text = std::fs::read_to_string(path).unwrap_or_default();
-        for (n, line) in text.lines().enumerate() {
-            if line.contains("apply::execute(") && line.contains(".plan") {
-                found.push(format!("{}:{}: {}", path.display(), n + 1, line.trim()));
+    let mut from = 0;
+    while let Some(at) = text[from..].find(NEEDLE) {
+        let open = from + at + NEEDLE.len();
+        found.push((text[..open].lines().count(), balanced(&text[open..])));
+        from = open;
+    }
+    found
+}
+
+/// The argument list up to the paren closing the one already open.
+fn balanced(text: &str) -> String {
+    let mut depth = 1usize;
+    let mut out = String::new();
+    for c in text.chars() {
+        match c {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    break;
+                }
+            }
+            _ => {}
+        }
+        out.push(if c == '\n' { ' ' } else { c });
+    }
+    out
+}
+
+/// Locals bound to a report's plan — `let plan = &report.plan;` — whose
+/// call site then names only the local, so the word `plan` never appears
+/// beside `apply::execute` at all.
+fn plan_locals(text: &str) -> BTreeSet<String> {
+    let mut names = BTreeSet::new();
+    let mut from = 0;
+    while let Some(at) = text[from..].find("let ") {
+        let start = from + at;
+        from = start + 4;
+        // A statement's own `let`, not the tail of an identifier.
+        if text[..start].chars().next_back().is_some_and(is_ident) {
+            continue;
+        }
+        let statement = &text[from..];
+        let statement = &statement[..statement.find(';').unwrap_or(statement.len())];
+        let Some((bound, value)) = statement.split_once('=') else {
+            continue;
+        };
+        if !value.contains(".plan") {
+            continue;
+        }
+        // The name alone: a type annotation is not part of it, and a
+        // pattern that is not one plain name binds no local to follow.
+        let name = bound
+            .split(':')
+            .next()
+            .unwrap_or(bound)
+            .trim()
+            .trim_start_matches("mut ")
+            .trim();
+        if !name.is_empty() && name.chars().all(is_ident) {
+            names.insert(name.to_owned());
+        }
+    }
+    names
+}
+
+/// Whether `args` passes `name` as a word of its own rather than as part
+/// of some longer identifier.
+fn passes(args: &str, name: &str) -> bool {
+    args.match_indices(name).any(|(at, _)| {
+        !args[..at].chars().next_back().is_some_and(is_ident)
+            && !args[at + name.len()..].chars().next().is_some_and(is_ident)
+    })
+}
+
+/// Every call under `root` that writes a plan it took off a report.
+#[allow(clippy::unwrap_used)]
+fn offenders(root: &Path) -> Vec<String> {
+    let mut files = Vec::new();
+    rust_files(root, &mut files);
+    assert!(!files.is_empty(), "no sources found under {root:?}");
+    files.sort();
+    let mut found = Vec::new();
+    for path in files.iter().filter(|path| !exempt(path, root)) {
+        let text = without_line_comments(&std::fs::read_to_string(path).unwrap_or_default());
+        let locals = plan_locals(&text);
+        for (line, args) in calls(&text) {
+            if args.contains(".plan") || locals.iter().any(|name| passes(&args, name)) {
+                found.push(format!(
+                    "{}:{line}: apply::execute({})",
+                    path.display(),
+                    args.trim()
+                ));
             }
         }
     }
@@ -66,29 +199,104 @@ fn no_command_executes_a_report_s_plan_itself() {
     );
 }
 
-/// The scan run red once, over the shape the bug had — and left alone by
-/// the bare plan a command is allowed to execute on its own.
+/// The scan run red once over each shape the defect has: written on one
+/// line, wrapped by rustfmt, and split across two statements through a
+/// local. It spares the bare plan a command may execute on its own, and it
+/// spares only the two files named by their path — a stem-shaped exemption
+/// let `app_update/tests.rs` through, which is why that one is planted.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn the_scan_names_a_report_s_plan_and_spares_a_bare_one() {
+fn the_scan_names_every_shape_of_a_report_s_plan_and_spares_a_bare_one() {
     let tmp = tempfile::tempdir().unwrap();
     let root = rooted(&tmp);
-    let nested = root.join("marketplaces");
-    std::fs::create_dir_all(&nested).unwrap();
-    std::fs::write(
-        nested.join("install.rs"),
-        "fn write(env: &Env, report: &EngineReport) {\n\
+    let write = |relative: &str, body: &str| {
+        let path = root.join(relative);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, body).unwrap();
+    };
+
+    // One line, the shape the original defect had.
+    write(
+        "marketplaces/install.rs",
+        "fn go(env: &Env, report: &EngineReport) {\n\
          \x20   apply::execute(env, &report.plan).unwrap();\n}\n",
-    )
-    .unwrap();
-    std::fs::write(
-        root.join("packages.rs"),
-        "fn write(env: &Env, plan: &Plan) {\n\
+    );
+    // Wrapped, the shape `cargo fmt` produces and does not undo.
+    write(
+        "sources.rs",
+        "fn go(env: &Env, report: &EngineReport) {\n\
+         \x20   apply::execute(\n\
+         \x20       env,\n\
+         \x20       &report.plan,\n\
+         \x20   )\n\
+         \x20   .unwrap();\n}\n",
+    );
+    // Two statements, with the plan behind a local.
+    write(
+        "audit.rs",
+        "fn go(env: &Env, report: &EngineReport) {\n\
+         \x20   let plan = &report.plan;\n\
          \x20   apply::execute(env, plan).unwrap();\n}\n",
+    );
+    // A test file that is not the exempt one: a stem-shaped exemption
+    // spared this, and it is a real path under src.
+    write(
+        "app_update/tests.rs",
+        "fn go(env: &Env, report: &EngineReport) {\n\
+         \x20   apply::execute(env, &report.plan).unwrap();\n}\n",
+    );
+    // Spared: a bare plan with no report behind it.
+    write(
+        "packages.rs",
+        "fn go(env: &Env, plan: &Plan) {\n\
+         \x20   apply::execute(env, plan).unwrap();\n}\n",
+    );
+    // Spared by path: the executor, and the editor's save tests.
+    write(
+        "repo_effects.rs",
+        "fn go(env: &Env, report: &EngineReport) {\n\
+         \x20   apply::execute(env, &report.plan).unwrap();\n}\n",
+    );
+    write(
+        "editor/save/tests.rs",
+        "fn go(env: &Env, report: &EngineReport) {\n\
+         \x20   apply::execute(env, &report.plan).unwrap();\n}\n",
+    );
+
+    let found = offenders(&root);
+    let named = |file: &str, line: usize| {
+        let want = format!("{file}:{line}:");
+        assert!(
+            found.iter().any(|hit| hit.contains(&want)),
+            "{want} went uncaught:\n{}",
+            found.join("\n")
+        );
+    };
+    named("marketplaces/install.rs", 2);
+    named("sources.rs", 2);
+    named("audit.rs", 3);
+    named("app_update/tests.rs", 2);
+    assert_eq!(found.len(), 4, "{found:#?}");
+}
+
+/// A `//` inside a string literal is not a comment, and a call the scan
+/// would catch is not hidden by commenting it out.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn comments_are_cut_and_string_literals_are_not() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = rooted(&tmp);
+    std::fs::write(
+        root.join("commented.rs"),
+        "fn go() {\n\
+         \x20   // apply::execute(env, &report.plan);\n\
+         \x20   let url = \"https://example.invalid/x\";\n}\n",
     )
     .unwrap();
 
-    let found = offenders(&root);
-    assert_eq!(found.len(), 1, "{found:?}");
-    assert!(found[0].contains("install.rs:2"), "{found:?}");
+    assert!(offenders(&root).is_empty());
+    assert!(
+        without_line_comments("let url = \"http://a\"; // gone\n").contains("http://a"),
+        "the scheme's slashes were read as a comment"
+    );
 }

--- a/crates/app/tests/one_executor.rs
+++ b/crates/app/tests/one_executor.rs
@@ -13,6 +13,16 @@
 //! long call over four lines and does not join it back, and a plan bound
 //! to a local puts the two halves in different statements — both shapes
 //! are the defect, and a scan that misses them is guard code failing open.
+//!
+//! What it rests on, said plainly so nobody mistakes it for total: the
+//! call is found by the literal text `apply::execute(`. An unqualified
+//! `use kendex_core::apply::execute;` followed by a bare `execute(env,
+//! &report.plan)`, or a function pointer bound to it, passes unseen.
+//! Neither exists anywhere in `crates/app/src` or `crates/cli/src`, and
+//! module-path style is the house convention, so evading this takes a
+//! deliberate import rather than an accident — which is why the rule is
+//! written against the shape people actually type and no machinery
+//! chases the other one.
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -53,28 +63,140 @@ fn exempt(path: &Path, root: &Path) -> bool {
     )
 }
 
-/// The source with its line comments cut away, so prose describing this
-/// rule cannot trip the scan and a call commented out cannot hide from it.
-/// Quoting is tracked, so a `//` inside a string literal stays put.
-fn without_line_comments(text: &str) -> String {
+/// The source with everything that is not code blanked out: line comments,
+/// block comments, and the insides of string and character literals.
+///
+/// Blanked rather than deleted, so every byte offset and line number still
+/// points where it did. Comments were the first half of this — prose
+/// describing the rule must not trip a scan of the rule, in either
+/// direction — and literals are the other half, for two reasons. A message
+/// quoting `apply::execute(env, &report.plan)` is exactly what a
+/// diagnostic about this rule looks like, and `write_nothing_leaving`
+/// already names its own rule that way. And a paren or a semicolon inside
+/// a string is not one this parser should be counting.
+fn code_only(text: &str) -> String {
+    #[derive(PartialEq)]
+    enum In {
+        Code,
+        Line,
+        Block(usize),
+        Str,
+        Raw(usize),
+        Chr,
+    }
+    let mut state = In::Code;
     let mut out = String::with_capacity(text.len());
-    for line in text.lines() {
-        let bytes = line.as_bytes();
-        let (mut quoted, mut cut, mut i) = (false, line.len(), 0);
-        while i < bytes.len() {
-            match bytes[i] {
-                b'\\' if quoted => i += 1,
-                b'"' => quoted = !quoted,
-                b'/' if !quoted && bytes.get(i + 1) == Some(&b'/') => {
-                    cut = i;
-                    break;
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    // Kept verbatim only in `Code`; everywhere else a byte becomes a space
+    // and a newline stays a newline.
+    let keep = |out: &mut String, byte: u8, verbatim: bool| {
+        match (byte, verbatim) {
+            (b'\n', _) => out.push('\n'),
+            (_, true) => out.push(byte as char),
+            (_, false) => out.push(' '),
+        };
+    };
+    while i < bytes.len() {
+        let byte = bytes[i];
+        let next = bytes.get(i + 1).copied();
+        match state {
+            In::Code => {
+                // A raw string: `r`, any number of `#`, then the quote.
+                let raw = byte == b'r' && {
+                    let mut j = i + 1;
+                    while bytes.get(j) == Some(&b'#') {
+                        j += 1;
+                    }
+                    bytes.get(j) == Some(&b'"')
+                        && !text[..i].chars().next_back().is_some_and(is_ident)
+                };
+                if raw {
+                    let mut hashes = 0;
+                    while bytes.get(i + 1 + hashes) == Some(&b'#') {
+                        hashes += 1;
+                    }
+                    for _ in 0..=hashes + 1 {
+                        keep(&mut out, b' ', false);
+                    }
+                    i += hashes + 2;
+                    state = In::Raw(hashes);
+                    continue;
                 }
-                _ => {}
+                match (byte, next) {
+                    (b'/', Some(b'/')) => state = In::Line,
+                    (b'/', Some(b'*')) => state = In::Block(1),
+                    (b'"', _) => state = In::Str,
+                    // A character literal, not a lifetime: `'a'` and
+                    // `'\n'` close, `'a` in `&'a str` never does.
+                    (b'\'', Some(b'\\')) => state = In::Chr,
+                    (b'\'', _) if bytes.get(i + 2) == Some(&b'\'') => state = In::Chr,
+                    _ => {}
+                }
+                keep(&mut out, byte, state == In::Code);
+                i += 1;
             }
-            i += 1;
+            In::Line => {
+                keep(&mut out, byte, false);
+                if byte == b'\n' {
+                    state = In::Code;
+                }
+                i += 1;
+            }
+            In::Block(depth) => {
+                if (byte, next) == (b'/', Some(b'*')) {
+                    state = In::Block(depth + 1);
+                    keep(&mut out, byte, false);
+                    keep(&mut out, b' ', false);
+                    i += 2;
+                    continue;
+                }
+                if (byte, next) == (b'*', Some(b'/')) {
+                    state = match depth {
+                        1 => In::Code,
+                        _ => In::Block(depth - 1),
+                    };
+                    keep(&mut out, byte, false);
+                    keep(&mut out, b' ', false);
+                    i += 2;
+                    continue;
+                }
+                keep(&mut out, byte, false);
+                i += 1;
+            }
+            In::Str | In::Chr => {
+                let closing = match state {
+                    In::Str => b'"',
+                    _ => b'\'',
+                };
+                if byte == b'\\' {
+                    keep(&mut out, byte, false);
+                    if let Some(escaped) = next {
+                        keep(&mut out, escaped, false);
+                    }
+                    i += 2;
+                    continue;
+                }
+                if byte == closing {
+                    state = In::Code;
+                }
+                keep(&mut out, byte, false);
+                i += 1;
+            }
+            In::Raw(hashes) => {
+                let closes =
+                    byte == b'"' && (0..hashes).all(|n| bytes.get(i + 1 + n) == Some(&b'#'));
+                keep(&mut out, byte, false);
+                i += 1;
+                if closes {
+                    for _ in 0..hashes {
+                        keep(&mut out, b' ', false);
+                    }
+                    i += hashes;
+                    state = In::Code;
+                }
+            }
         }
-        out.push_str(&line[..cut]);
-        out.push('\n');
     }
     out
 }
@@ -83,16 +205,49 @@ fn is_ident(c: char) -> bool {
     c.is_alphanumeric() || c == '_'
 }
 
-/// Every `apply::execute(...)` in `text`: the line it opens on, and its
-/// whole argument list with continuation lines joined — so a call rustfmt
-/// spread over four lines reads exactly like one written on a single line.
+/// Whether `text` names a report's `plan` field rather than some longer
+/// name that merely begins with it — `planned_at`, `plans`, `plan_b`.
+fn names_a_plan(text: &str) -> bool {
+    text.match_indices(".plan").any(|(at, _)| {
+        !text[at + ".plan".len()..]
+            .chars()
+            .next()
+            .is_some_and(is_ident)
+    })
+}
+
+/// The file split at each `fn`, so a local bound in one function cannot
+/// explain a call in another. Everything before the first `fn` is a span
+/// of its own, so nothing at module scope is skipped.
+fn functions(text: &str) -> Vec<(usize, &str)> {
+    let mut bounds = vec![0usize];
+    let mut from = 0;
+    while let Some(at) = text[from..].find("fn ") {
+        let at = from + at;
+        from = at + 3;
+        if text[..at].chars().next_back().is_some_and(is_ident) {
+            continue;
+        }
+        bounds.push(at);
+    }
+    bounds.push(text.len());
+    bounds.dedup();
+    bounds
+        .windows(2)
+        .map(|pair| (pair[0], &text[pair[0]..pair[1]]))
+        .collect()
+}
+
+/// Every `apply::execute(...)` in `text`: where it opens, and its whole
+/// argument list with continuation lines joined — so a call rustfmt spread
+/// over four lines reads exactly like one written on a single line.
 fn calls(text: &str) -> Vec<(usize, String)> {
     const NEEDLE: &str = "apply::execute(";
     let mut found = Vec::new();
     let mut from = 0;
     while let Some(at) = text[from..].find(NEEDLE) {
         let open = from + at + NEEDLE.len();
-        found.push((text[..open].lines().count(), balanced(&text[open..])));
+        found.push((from + at, balanced(&text[open..])));
         from = open;
     }
     found
@@ -118,9 +273,34 @@ fn balanced(text: &str) -> String {
     out
 }
 
+/// Where the statement beginning at `text` ends: the first `;` outside any
+/// bracket.
+///
+/// The first `;` of any depth is a different thing, and taking it read
+/// `let plan = match kind { A => &a.plan, B => { warn(); &b.plan } };` as
+/// ending inside the block — so the local went unrecorded and the call
+/// that passed it went unnamed.
+fn statement_end(text: &str) -> usize {
+    let mut depth = 0i32;
+    for (at, c) in text.char_indices() {
+        match c {
+            '{' | '[' | '(' => depth += 1,
+            '}' | ']' | ')' => depth -= 1,
+            ';' if depth <= 0 => return at,
+            _ => {}
+        }
+    }
+    text.len()
+}
+
 /// Locals bound to a report's plan — `let plan = &report.plan;` — whose
 /// call site then names only the local, so the word `plan` never appears
 /// beside `apply::execute` at all.
+///
+/// Read per function, never per file. File-scoped, a `let plan =
+/// row.planned_at();` in one function condemned a legitimately bare
+/// `apply::execute(env, plan)` in another, which `commands.rs` is one
+/// rename away from today.
 fn plan_locals(text: &str) -> BTreeSet<String> {
     let mut names = BTreeSet::new();
     let mut from = 0;
@@ -132,11 +312,11 @@ fn plan_locals(text: &str) -> BTreeSet<String> {
             continue;
         }
         let statement = &text[from..];
-        let statement = &statement[..statement.find(';').unwrap_or(statement.len())];
+        let statement = &statement[..statement_end(statement)];
         let Some((bound, value)) = statement.split_once('=') else {
             continue;
         };
-        if !value.contains(".plan") {
+        if !names_a_plan(value) {
             continue;
         }
         // The name alone: a type annotation is not part of it, and a
@@ -173,10 +353,14 @@ fn offenders(root: &Path) -> Vec<String> {
     files.sort();
     let mut found = Vec::new();
     for path in files.iter().filter(|path| !exempt(path, root)) {
-        let text = without_line_comments(&std::fs::read_to_string(path).unwrap_or_default());
-        let locals = plan_locals(&text);
-        for (line, args) in calls(&text) {
-            if args.contains(".plan") || locals.iter().any(|name| passes(&args, name)) {
+        let text = code_only(&std::fs::read_to_string(path).unwrap_or_default());
+        for (start, body) in functions(&text) {
+            let locals = plan_locals(body);
+            for (at, args) in calls(body) {
+                if !names_a_plan(&args) && !locals.iter().any(|name| passes(&args, name)) {
+                    continue;
+                }
+                let line = text[..start + at].lines().count();
                 found.push(format!(
                     "{}:{line}: apply::execute({})",
                     path.display(),
@@ -279,24 +463,100 @@ fn the_scan_names_every_shape_of_a_report_s_plan_and_spares_a_bare_one() {
     assert_eq!(found.len(), 4, "{found:#?}");
 }
 
-/// A `//` inside a string literal is not a comment, and a call the scan
-/// would catch is not hidden by commenting it out.
+/// Nothing that is not code condemns a file, in any of the three ways it
+/// can look like code.
+///
+/// Guard code that cries wolf is guard code somebody turns off. The
+/// rule-quoting string is not hypothetical: `write_nothing_leaving` names
+/// its own rule in its own refusal message, and a diagnostic about THIS
+/// rule would be spelled exactly like the one planted here.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn comments_are_cut_and_string_literals_are_not() {
+fn nothing_outside_code_is_read_as_code() {
     let tmp = tempfile::tempdir().unwrap();
     let root = rooted(&tmp);
     std::fs::write(
-        root.join("commented.rs"),
+        root.join("innocent.rs"),
         "fn go() {\n\
          \x20   // apply::execute(env, &report.plan);\n\
-         \x20   let url = \"https://example.invalid/x\";\n}\n",
+         \x20   /* and again:\n\
+         \x20      apply::execute(env, &report.plan);\n\
+         \x20   */\n\
+         \x20   let msg = \"call apply::execute(env, &report.plan) never\";\n\
+         \x20   let url = \"https://example.invalid/x\";\n\
+         \x20   let raw = r#\"apply::execute(env, &report.plan)\"#;\n}\n",
     )
     .unwrap();
 
-    assert!(offenders(&root).is_empty());
-    assert!(
-        without_line_comments("let url = \"http://a\"; // gone\n").contains("http://a"),
-        "the scheme's slashes were read as a comment"
-    );
+    assert!(offenders(&root).is_empty(), "{:?}", offenders(&root));
+    // And the blanking leaves code alone: a scheme's slashes are not a
+    // comment, and the file still parses as the statements it holds.
+    let kept = code_only("let url = \"http://a\"; // gone\nlet n = 1;\n");
+    assert!(kept.contains("let url ="), "{kept:?}");
+    assert!(kept.contains("let n = 1;"), "{kept:?}");
+    assert!(!kept.contains("gone"), "{kept:?}");
+    assert!(!kept.contains("http://a"), "{kept:?}");
+}
+
+/// A local bound to a plan in one function does not condemn a bare call in
+/// another, and a name that merely starts with `plan` binds nothing.
+///
+/// Both have live reach: `commands.rs` holds a `.plan`-derived local and a
+/// legitimately bare `apply::execute` in the same file today, kept apart
+/// only by their names.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_plan_local_condemns_only_its_own_function() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = rooted(&tmp);
+    std::fs::write(
+        root.join("commands.rs"),
+        // The same NAME in both functions: one bound off a report, one a
+        // plain parameter. File-scoped, the first condemns the second.
+        "fn peek(report: &EngineReport) -> Plan {\n\
+         \x20   let plan = report.plan.clone();\n\
+         \x20   plan\n}\n\
+         fn go(env: &Env, plan: &Plan) {\n\
+         \x20   apply::execute(env, plan).unwrap();\n}\n\
+         fn later(env: &Env, row: &Row) {\n\
+         \x20   let plan = row.planned_at();\n\
+         \x20   apply::execute(env, plan).unwrap();\n}\n\
+         fn beside(env: &Env, row: &Row) {\n\
+         \x20   apply::execute(env, &row.planned).unwrap();\n}\n",
+    )
+    .unwrap();
+
+    assert!(offenders(&root).is_empty(), "{:?}", offenders(&root));
+}
+
+/// The two shapes that used to slip past: a semicolon inside the value a
+/// local is bound to, and a paren inside a string in the argument list.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_statement_is_read_to_its_own_end() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = rooted(&tmp);
+    std::fs::write(
+        root.join("audit.rs"),
+        "fn go(env: &Env, report: &EngineReport, kind: Kind) {\n\
+         \x20   let plan = match kind { A => { warn(); &a.plan }, B => &b.plan };\n\
+         \x20   apply::execute(env, plan).unwrap();\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("sources.rs"),
+        "fn go(env: &Env, report: &EngineReport) {\n\
+         \x20   apply::execute(env, closer(\")\"), &report.plan).unwrap();\n}\n",
+    )
+    .unwrap();
+
+    let found = offenders(&root);
+    for want in ["audit.rs:3", "sources.rs:2"] {
+        assert!(
+            found.iter().any(|hit| hit.contains(want)),
+            "{want} went uncaught:\n{}",
+            found.join("\n")
+        );
+    }
+    assert_eq!(found.len(), 2, "{found:#?}");
 }

--- a/crates/app/tests/repo_effects.rs
+++ b/crates/app/tests/repo_effects.rs
@@ -1,201 +1,18 @@
-//! The desktop's account of what a package does to the repository, and the
-//! yes that is separate from installing it.
+//! The desktop's account of what a package does to the repository, and
+//! the yes that is separate from installing it.
 //!
 //! An install from the window is one command that plans and writes. The
 //! effect a package declares must come back out of it unrun, with what a
-//! person needs in order to decide — and arming is a second command, so a
-//! window that closes the dialog leaves the repository as it was.
+//! person needs in order to decide — and arming is a second command, so
+//! a window that closes the dialog leaves the repository as it was.
+//!
+//! What either half of the module does to a third party's own output is
+//! `repo_effects_escaping.rs`.
 #![cfg(unix)]
 
-#[path = "../../test_util.rs"]
-mod test_util;
-use test_util::source_path;
-
-use std::fs;
-use std::os::unix::fs::PermissionsExt;
-use std::path::{Path, PathBuf};
-
-use kendex_app::marketplaces::install::{InstallItem, Installed, install};
-use kendex_core::env::{Env, FakeOs};
-use kendex_core::model::{ItemKind, Scope};
-
-struct Fixture {
-    _tmp: tempfile::TempDir,
-    env: Env,
-    scope: Scope,
-    project: PathBuf,
-}
-
-/// One empty git configuration for this whole test binary, global and
-/// system alike.
-///
-/// Not the developer's. A maintainer's own config decides what a git this
-/// file runs does — `commit.gpgsign` reds every case here on a fixture
-/// with no signing key — and none of that has anything to do with this
-/// code.
-///
-/// Named on each command this file builds. It does NOT reach the installer
-/// kendex spawns, whose argv belongs to core and whose environment is
-/// whatever this process hands down; covering that one means writing the
-/// variables onto the process, and the workspace forbids `unsafe`, which
-/// `std::env::set_var` now requires. So a maintainer who has configured a
-/// hooks path still sees the arming cases stand down — the same shape
-/// `crates/cli/tests/install_ux/guarding.rs` has, and a suite-wide
-/// property rather than anything this file introduced.
-fn empty_git_config() -> &'static Path {
-    static PATH: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
-    PATH.get_or_init(|| {
-        let path = std::env::temp_dir().join("kendex-app-repo-effects-empty.gitconfig");
-        let _ = fs::write(&path, "");
-        path
-    })
-    .as_path()
-}
-
-/// The fixture's own git: as little of the developer's as reaches it.
-///
-/// Three variables and two config files. A pre-commit hook exports
-/// `GIT_DIR`, `GIT_WORK_TREE` and `GIT_INDEX_FILE` at the repository being
-/// committed to, so a child that clears only the first writes its staged
-/// entries into that repository's index. The config files are the empty
-/// pair above.
-fn own_git(args: &[&str], dir: &Path) -> std::process::Command {
-    let mut command = std::process::Command::new("git");
-    command
-        .env("GIT_CONFIG_GLOBAL", empty_git_config())
-        .env("GIT_CONFIG_SYSTEM", empty_git_config())
-        .env_remove("GIT_DIR")
-        .env_remove("GIT_WORK_TREE")
-        .env_remove("GIT_INDEX_FILE")
-        .args(["-c", "user.email=t@t", "-c", "user.name=t"])
-        .args(args)
-        .current_dir(dir);
-    command
-}
-
-#[allow(clippy::unwrap_used)]
-fn git(dir: &Path, args: &[&str]) {
-    let output = own_git(args, dir).output().unwrap();
-    assert!(
-        output.status.success(),
-        "git {args:?}: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
-
-#[allow(clippy::unwrap_used)]
-fn copy_tree(from: &Path, to: &Path) {
-    fs::create_dir_all(to).unwrap();
-    for entry in fs::read_dir(from).unwrap() {
-        let entry = entry.unwrap();
-        let target = to.join(entry.file_name());
-        if entry.file_type().unwrap().is_dir() {
-            copy_tree(&entry.path(), &target);
-        } else {
-            fs::copy(entry.path(), &target).unwrap();
-        }
-    }
-}
-
-/// A git project subscribed to a catalog that offers the repository's own
-/// growth-guards and size-ratchet packages beside an inert one, plus a
-/// bundle carrying growth-guards, with Claude on the machine.
-#[allow(clippy::unwrap_used)]
-fn fixture() -> Fixture {
-    empty_git_config();
-    let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path().canonicalize().unwrap();
-    let project = home.join("dev/app");
-    let catalog = home.join("catalog");
-    let shipped = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../../skills")
-        .canonicalize()
-        .unwrap();
-    for skill in ["growth-guards", "size-ratchet"] {
-        copy_tree(&shipped.join(skill), &catalog.join("skills").join(skill));
-    }
-    fs::create_dir_all(catalog.join("skills/deploy")).unwrap();
-    fs::write(
-        catalog.join("skills/deploy/SKILL.md"),
-        "---\nname: deploy\ndescription: ship the service\n---\nRun the deploy.\n",
-    )
-    .unwrap();
-    // A package whose installer exits clean and writes to both channels —
-    // the shipped shape of growth-guards skipping its work: the summary on
-    // stdout, the reason and the remedy on stderr.
-    let noisy = catalog.join("skills/noisy/scripts");
-    fs::create_dir_all(&noisy).unwrap();
-    fs::write(
-        catalog.join("skills/noisy/SKILL.md"),
-        "---\nname: noisy\ndescription: says something on both channels\n\
-         repo-effects:\n  summary: \"arms nothing here\"\n  \
-         installer: \"scripts/arm\"\n---\nBody.\n",
-    )
-    .unwrap();
-    fs::write(
-        noisy.join("arm"),
-        "#!/bin/sh\necho 'core.hooksPath is set; unset it and run this again' >&2\n\
-         echo 'hooks: skipped'\n",
-    )
-    .unwrap();
-    fs::set_permissions(noisy.join("arm"), fs::Permissions::from_mode(0o755)).unwrap();
-    fs::write(
-        catalog.join("kendex.toml"),
-        "[bundles.guards]\ndescription = \"the commit gate\"\nskills = [\"growth-guards\"]\n",
-    )
-    .unwrap();
-    fs::create_dir_all(home.join(".claude")).unwrap();
-    fs::create_dir_all(project.join(".agents")).unwrap();
-    git(&project, &["init", "--quiet", "-b", "main"]);
-    fs::write(project.join("README.md"), "the app\n").unwrap();
-    git(&project, &["add", "."]);
-    git(&project, &["commit", "--quiet", "-m", "start"]);
-    fs::write(
-        project.join("kendex.toml"),
-        format!("schema = 6\n\n[sources.cat]\n{}\n", source_path(&catalog)),
-    )
-    .unwrap();
-    Fixture {
-        env: Env::fake(&home, FakeOs::Linux),
-        scope: Scope::Project {
-            root: project.clone(),
-        },
-        project,
-        _tmp: tmp,
-    }
-}
-
-fn install_skills(f: &Fixture, names: &[&str], bundle: Option<&str>) -> Installed {
-    install(
-        &f.env,
-        f.scope.clone(),
-        "cat".to_owned(),
-        names
-            .iter()
-            .map(|name| InstallItem {
-                kind: ItemKind::Skill,
-                name: (*name).to_owned(),
-            })
-            .collect(),
-        bundle.map(str::to_owned),
-        None,
-        false,
-        None,
-        None,
-    )
-    .unwrap_or_else(|error| panic!("install {names:?} {bundle:?}: {error}"))
-}
-
-fn companion<'a>(
-    offer: &'a kendex_core::repo_effects::Disclosure,
-    name: &str,
-) -> &'a kendex_core::repo_effects::Companion {
-    offer
-        .companions
-        .iter()
-        .find(|c| c.name == name)
-        .unwrap_or_else(|| panic!("no companion {name}: {:?}", offer.companions))
-}
+#[path = "repo_effects/fixture.rs"]
+mod fixture;
+use fixture::*;
 
 /// Installing writes the package and hands back its account — what
 /// changes, where it writes, which companions are here, how to undo it —
@@ -277,37 +94,6 @@ fn a_clean_exit_carries_both_channels() {
     assert_eq!(
         said.stderr,
         vec!["core.hooksPath is set; unset it and run this again".to_owned()]
-    );
-}
-
-/// The yes is for the package the window was shown, not for whatever root
-/// comes back with it. Arming confines a program to the root it is handed,
-/// so a root the caller chose would confine nothing.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_root_this_scope_never_installed_is_refused() {
-    let f = fixture();
-    let installed = install_skills(&f, &["growth-guards"], None);
-    let [offer] = installed.repo_effects.shown.as_slice() else {
-        panic!("one offer: {:?}", installed.repo_effects);
-    };
-
-    let forged = kendex_core::repo_effects::DeclaredEffects {
-        root: PathBuf::from("/"),
-        effects: kendex_core::repo_effects::RepoEffects {
-            installer: Some("bin/sh -c id".to_owned()),
-            ..offer.declared.effects.clone()
-        },
-        ..offer.declared.clone()
-    };
-    let error = kendex_app::repo_effects::apply(&f.env, &f.scope, &forged).unwrap_err();
-    assert!(
-        error.contains("no record of installing it there"),
-        "{error}"
-    );
-    assert!(
-        !f.project.join(".git/hooks/kendex-guards").exists(),
-        "the forged root armed the hooks"
     );
 }
 
@@ -458,6 +244,7 @@ fn unsubscribing_disarms_the_packages_that_leave_with_the_source() {
     );
     assert!(
         undone
+            .undone
             .iter()
             .any(|line| line.starts_with("growth-guards: running")),
         "{undone:?}"
@@ -575,53 +362,6 @@ fn removing_an_inert_package_says_nothing() {
     assert!(view.undone.is_empty(), "{:?}", view.undone);
 }
 
-/// A departing package's own output reaches the window escaped.
-///
-/// The lines land in a toast carrying no attribution, so a package that
-/// writes a bidi override or a line phrased in kendex's voice would be
-/// read as kendex talking. The terminal escapes them; this proves the
-/// window does too, which is what makes the three places claiming both
-/// surfaces show the same lines true.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_departing_package_s_output_reaches_the_window_escaped() {
-    let f = fixture();
-    let scripts = f.project.join(".agents/skills/loud/scripts");
-    let catalog_scripts = f.env.home.join("catalog/skills/loud/scripts");
-    fs::create_dir_all(&catalog_scripts).unwrap();
-    fs::write(
-        f.env.home.join("catalog/skills/loud/SKILL.md"),
-        "---\nname: loud\ndescription: writes a deceptive line\n\
-         repo-effects:\n  summary: \"says something on the way out\"\n  \
-         uninstaller: \"scripts/out\"\n---\nBody.\n",
-    )
-    .unwrap();
-    // U+202E, the override that reverses everything printed after it.
-    fs::write(
-        catalog_scripts.join("out"),
-        "#!/bin/sh\nprintf 'loud: \\342\\200\\256done\\n'\n",
-    )
-    .unwrap();
-    fs::set_permissions(
-        catalog_scripts.join("out"),
-        fs::Permissions::from_mode(0o755),
-    )
-    .unwrap();
-    install_skills(&f, &["loud"], None);
-    assert!(scripts.join("out").is_file(), "the fixture did not install");
-
-    let view = kendex_app::audit::remove(&f.env, &f.scope, ItemKind::Skill, "loud")
-        .unwrap_or_else(|error| panic!("remove: {error}"));
-
-    let said = view.undone.join("\n");
-    assert!(said.contains("loud: running"), "{said:?}");
-    assert!(
-        !said.contains('\u{202E}'),
-        "the override reached the window raw: {said:?}"
-    );
-    assert!(said.contains("\\u{202e}"), "{said:?}");
-}
-
 /// A write that must take nothing away refuses when it would, rather than
 /// running an uninstaller whose account nobody would see.
 #[test]
@@ -660,4 +400,82 @@ fn a_write_that_must_remove_nothing_refuses_when_it_would() {
         f.project.join(".git/hooks/kendex-guards").is_file(),
         "the refusal ran the uninstaller anyway"
     );
+}
+
+/// A chatty package cannot bury the notice its neighbour is owed.
+///
+/// The account interleaves kendex's own lines with unbounded output from
+/// each departing package, in name order. A budget spent across the whole
+/// list lets the first package's chatter push the second's notice off the
+/// end — and "declares no uninstaller — what it changed stays" is the only
+/// place kendex says an effect was left standing and names the manual
+/// remedy. A verbose uninstaller does that by accident; an installed
+/// package can do it on purpose.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_chatty_package_cannot_bury_a_neighbour_s_stand_down() {
+    let f = fixture();
+    let catalog = f.env.home.join("catalog");
+    // Sorted first, so its output is emitted before the other's notice.
+    let loud = catalog.join("skills/aaa-loud/scripts");
+    fs::create_dir_all(&loud).unwrap();
+    fs::write(
+        catalog.join("skills/aaa-loud/SKILL.md"),
+        "---\nname: aaa-loud\ndescription: says a great deal on the way out\n\
+         repo-effects:\n  summary: \"talks\"\n  uninstaller: \"scripts/out\"\n---\nBody.\n",
+    )
+    .unwrap();
+    fs::write(
+        loud.join("out"),
+        "#!/bin/sh\ni=0\nwhile [ $i -lt 200 ]; do echo \"chatter $i\"; i=$((i+1)); done\n",
+    )
+    .unwrap();
+    fs::set_permissions(loud.join("out"), fs::Permissions::from_mode(0o755)).unwrap();
+    // Sorted second, and it declares no uninstaller — so its one line is
+    // the only word anybody gets about what it left behind.
+    fs::create_dir_all(catalog.join("skills/zzz-quiet")).unwrap();
+    fs::write(
+        catalog.join("skills/zzz-quiet/SKILL.md"),
+        "---\nname: zzz-quiet\ndescription: leaves something standing\n\
+         repo-effects:\n  summary: \"changes the repository\"\n  \
+         removal: \"undo it by hand\"\n---\nBody.\n",
+    )
+    .unwrap();
+    install_skills(&f, &["aaa-loud", "zzz-quiet"], None);
+
+    // Both leave together: the manifest stops declaring either.
+    let manifest = f.project.join("kendex.toml");
+    let text = fs::read_to_string(&manifest).unwrap();
+    let kept: String = text
+        .split("\n[")
+        .enumerate()
+        .filter(|(n, block)| {
+            *n == 0
+                || !(block.starts_with("skills.aaa-loud]")
+                    || block.starts_with("skills.zzz-quiet]"))
+        })
+        .map(|(n, block)| match n {
+            0 => block.to_owned(),
+            _ => format!("\n[{block}"),
+        })
+        .collect();
+    fs::write(&manifest, kept).unwrap();
+
+    let view = kendex_app::audit::apply_scope(&f.env, &f.scope, true)
+        .unwrap_or_else(|error| panic!("apply_scope: {error}"));
+
+    let said = view.undone.join("\n");
+    assert!(
+        said.contains("zzz-quiet: declares no uninstaller"),
+        "the chatty package buried its neighbour's stand-down:\n{said}"
+    );
+    assert!(said.contains("to undo: undo it by hand"), "{said}");
+    // And the chatter itself is still bounded, with the count said rather
+    // than the tail dropped in silence.
+    assert!(
+        view.undone.len() < 40,
+        "the account carried {} lines",
+        view.undone.len()
+    );
+    assert!(said.contains("more lines from that package"), "{said}");
 }

--- a/crates/app/tests/repo_effects.rs
+++ b/crates/app/tests/repo_effects.rs
@@ -332,3 +332,214 @@ fn an_inert_package_brings_no_offer() {
     );
     assert!(installed.packages.iter().any(|p| p.name == "deploy"));
 }
+
+/// Arm the repository from the window, the way an install's second yes
+/// does, and prove the hooks are live.
+#[allow(clippy::unwrap_used)]
+fn arm(f: &Fixture) {
+    let installed = install_skills(f, &["growth-guards"], None);
+    let [offer] = installed.repo_effects.shown.as_slice() else {
+        panic!("one offer: {:?}", installed.repo_effects);
+    };
+    kendex_app::repo_effects::apply(&f.env, &f.scope, &offer.declared).unwrap();
+    assert!(
+        f.project.join(".git/hooks/kendex-guards").is_file(),
+        "the yes did not arm the hooks"
+    );
+}
+
+/// A commit in the project, with no kendex in the picture — what a shim
+/// pointing at a script that is gone costs.
+fn commit(f: &Fixture, message: &str) -> std::process::Output {
+    #[allow(clippy::unwrap_used)]
+    {
+        fs::write(f.project.join("late.txt"), message).unwrap();
+    }
+    #[allow(clippy::unwrap_used)]
+    std::process::Command::new("git")
+        .args(["-c", "user.email=t@t", "-c", "user.name=t"])
+        .args(["commit", "--quiet", "-a", "-m", message])
+        .current_dir(&f.project)
+        // All three, like `git` above: a pre-commit hook exports every one
+        // of them pointing at the repository being committed to, so a
+        // fixture that clears only GIT_DIR still inherits GIT_INDEX_FILE
+        // and writes its own staged entries into that repository's index.
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .output()
+        .unwrap()
+}
+
+/// Removing the package from the window disarms the repository first, and
+/// the action's own result says what ran.
+///
+/// The terminal has done this since the uninstaller was declared; the
+/// window called `apply::execute` on the plan and dropped the report, so
+/// the scripts went and the shims stayed — and every commit in that
+/// repository failed closed until somebody found two files under
+/// `.git/hooks` by hand.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn removing_a_package_disarms_the_repository_and_says_so() {
+    let f = fixture();
+    arm(&f);
+    git(&f.project, &["add", "."]);
+
+    let view = kendex_app::audit::remove(&f.env, &f.scope, ItemKind::Skill, "growth-guards")
+        .unwrap_or_else(|error| panic!("remove: {error}"));
+
+    assert!(
+        !f.project.join(".git/hooks/kendex-guards").exists(),
+        "the removal left the shim behind"
+    );
+    assert!(
+        view.undone
+            .iter()
+            .any(|line| line == "growth-guards: running scripts/install-git-hooks --uninstall"),
+        "{:?}",
+        view.undone
+    );
+    git(&f.project, &["add", "-A"]);
+    let after = commit(&f, "after removal");
+    assert!(
+        after.status.success(),
+        "the repository could not commit: {}",
+        String::from_utf8_lossy(&after.stderr)
+    );
+}
+
+/// Unsubscribing takes the source's packages with it, so it disarms them
+/// the same way and hands the account back for the window to show.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn unsubscribing_disarms_the_packages_that_leave_with_the_source() {
+    let f = fixture();
+    arm(&f);
+    git(&f.project, &["add", "."]);
+
+    let undone = kendex_app::unsubscribe::unsubscribe(&f.env, &f.scope, "cat", false, false)
+        .unwrap_or_else(|error| panic!("unsubscribe: {error}"));
+
+    assert!(
+        !f.project.join(".git/hooks/kendex-guards").exists(),
+        "the unsubscribe left the shim behind"
+    );
+    assert!(
+        undone
+            .iter()
+            .any(|line| line.starts_with("growth-guards: running")),
+        "{undone:?}"
+    );
+}
+
+/// A whole-scope apply takes a package away when the manifest no longer
+/// declares it — the shape a hand edit and the built-in editor both
+/// arrive at — and that removal disarms first too.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn applying_a_manifest_without_the_package_disarms_first() {
+    let f = fixture();
+    arm(&f);
+    let manifest = f.project.join("kendex.toml");
+    let text = fs::read_to_string(&manifest).unwrap();
+    assert!(text.contains("[skills.growth-guards]"), "{text}");
+    fs::write(
+        &manifest,
+        text.replace("[skills.growth-guards]\nsource = \"cat\"\n", ""),
+    )
+    .unwrap();
+
+    let view = kendex_app::audit::apply_scope(&f.env, &f.scope, true)
+        .unwrap_or_else(|error| panic!("apply_scope: {error}"));
+
+    assert!(
+        !f.project.join(".git/hooks/kendex-guards").exists(),
+        "the apply left the shim behind"
+    );
+    assert!(
+        view.undone
+            .iter()
+            .any(|line| line.starts_with("growth-guards: running")),
+        "{:?}",
+        view.undone
+    );
+}
+
+/// An uninstaller that refuses stops the removal with the package's files
+/// still in place, and the refusal carries the package's own words.
+///
+/// The other order is the state this exists to prevent: files gone, shims
+/// still delegating to them, and nobody able to commit.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_refusing_uninstaller_stops_the_removal() {
+    let f = fixture();
+    arm(&f);
+    // The installed copy's script, wrapped: everything passes through
+    // except the uninstall, which refuses.
+    let installer = f
+        .project
+        .join(".agents/skills/growth-guards/scripts/install-git-hooks");
+    let real = installer.with_file_name("install-git-hooks.real");
+    fs::rename(&installer, &real).unwrap();
+    fs::write(
+        &installer,
+        "#!/usr/bin/env bash\ncase \" $* \" in *\" --uninstall \"*) \
+         echo 'refusing to disarm' >&2; exit 1;; esac\n\
+         exec \"$(dirname \"$0\")/install-git-hooks.real\" \"$@\"\n",
+    )
+    .unwrap();
+    fs::set_permissions(&installer, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let error = match kendex_app::audit::remove(&f.env, &f.scope, ItemKind::Skill, "growth-guards")
+    {
+        Err(error) => error,
+        Ok(_) => panic!("the removal went ahead"),
+    };
+
+    assert!(error.contains("refusing to disarm"), "{error}");
+    assert!(error.contains("its files stay in place"), "{error}");
+    assert!(
+        installer.is_file(),
+        "the package's files went despite the refusal"
+    );
+    assert!(
+        f.project.join(".git/hooks/kendex-guards").is_file(),
+        "the shim went with a removal that refused"
+    );
+}
+
+/// A package that declares no uninstaller is removed with that said, and
+/// nothing is run.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_package_with_no_uninstaller_is_removed_with_that_said() {
+    let f = fixture();
+    install_skills(&f, &["noisy"], None);
+
+    let view = kendex_app::audit::remove(&f.env, &f.scope, ItemKind::Skill, "noisy")
+        .unwrap_or_else(|error| panic!("remove: {error}"));
+
+    assert!(
+        view.undone
+            .iter()
+            .any(|line| line.contains("noisy: declares no uninstaller")),
+        "{:?}",
+        view.undone
+    );
+}
+
+/// An inert package's removal has nothing to account for, so the window is
+/// told nothing — a line per removal would bury the one that matters.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn removing_an_inert_package_says_nothing() {
+    let f = fixture();
+    install_skills(&f, &["deploy"], None);
+
+    let view = kendex_app::audit::remove(&f.env, &f.scope, ItemKind::Skill, "deploy")
+        .unwrap_or_else(|error| panic!("remove: {error}"));
+
+    assert!(view.undone.is_empty(), "{:?}", view.undone);
+}

--- a/crates/app/tests/repo_effects.rs
+++ b/crates/app/tests/repo_effects.rs
@@ -479,3 +479,67 @@ fn a_chatty_package_cannot_bury_a_neighbour_s_stand_down() {
     );
     assert!(said.contains("more lines from that package"), "{said}");
 }
+
+/// A project registered beside the fixture's own, carrying a manifest that
+/// will not parse — so the whole-machine listing every source action ends
+/// with fails, after the write.
+#[allow(clippy::unwrap_used)]
+fn a_second_project_that_cannot_be_listed(f: &Fixture) {
+    let broken = f.env.home.join("dev/broken");
+    fs::create_dir_all(&broken).unwrap();
+    fs::write(broken.join("kendex.toml"), "schema = 6\n[sources.x\n").unwrap();
+    let settings = f.env.settings_file();
+    fs::create_dir_all(settings.parent().unwrap()).unwrap();
+    fs::write(
+        &settings,
+        format!(
+            "schema = 1\nprojects = [{}, {}]\n",
+            toml::Value::from(kendex_core::paths::slashed(&f.project)),
+            toml::Value::from(kendex_core::paths::slashed(&broken)),
+        ),
+    )
+    .unwrap();
+}
+
+/// A read that fails after the write still says what the write ran.
+///
+/// By the time a source action reads back what stands, the uninstallers
+/// have run and the plan is committed. A `?` on that read used to discard
+/// the account with the answer it was riding on, leaving the person a
+/// listing error over a repository that had just been disarmed — this
+/// issue's own failure mode, reached through the error path.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_listing_that_fails_after_the_write_still_says_what_ran() {
+    let f = fixture();
+    arm(&f);
+    // The package stops rendering, so the plan drops its lock entry and
+    // runs its uninstaller whatever the verb was asked to do.
+    fs::write(
+        f.env
+            .home
+            .join("catalog/skills/growth-guards/SKILL.md.disabled"),
+        "---\nname: growth-guards\ndescription: gates the commits\n---\n",
+    )
+    .unwrap();
+    a_second_project_that_cannot_be_listed(&f);
+
+    let refused = kendex_app::sources::install_bundle(
+        &f.env,
+        &f.scope,
+        "cat".to_owned(),
+        "guards".to_owned(),
+        false,
+    )
+    .unwrap_err();
+
+    assert!(
+        !f.project.join(".git/hooks/kendex-guards").exists(),
+        "the fixture did not actually remove the package"
+    );
+    assert!(
+        refused.contains("growth-guards: running scripts/install-git-hooks --uninstall"),
+        "the account was dropped with the failed listing: {refused}"
+    );
+    assert!(refused.contains("invalid TOML"), "{refused}");
+}

--- a/crates/app/tests/repo_effects.rs
+++ b/crates/app/tests/repo_effects.rs
@@ -26,17 +26,56 @@ struct Fixture {
     project: PathBuf,
 }
 
-#[allow(clippy::unwrap_used)]
-fn git(dir: &Path, args: &[&str]) {
-    let output = std::process::Command::new("git")
-        .args(["-c", "user.email=t@t", "-c", "user.name=t"])
-        .args(args)
-        .current_dir(dir)
+/// One empty git configuration for this whole test binary, global and
+/// system alike.
+///
+/// Not the developer's. A maintainer's own config decides what a git this
+/// file runs does — `commit.gpgsign` reds every case here on a fixture
+/// with no signing key — and none of that has anything to do with this
+/// code.
+///
+/// Named on each command this file builds. It does NOT reach the installer
+/// kendex spawns, whose argv belongs to core and whose environment is
+/// whatever this process hands down; covering that one means writing the
+/// variables onto the process, and the workspace forbids `unsafe`, which
+/// `std::env::set_var` now requires. So a maintainer who has configured a
+/// hooks path still sees the arming cases stand down — the same shape
+/// `crates/cli/tests/install_ux/guarding.rs` has, and a suite-wide
+/// property rather than anything this file introduced.
+fn empty_git_config() -> &'static Path {
+    static PATH: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+    PATH.get_or_init(|| {
+        let path = std::env::temp_dir().join("kendex-app-repo-effects-empty.gitconfig");
+        let _ = fs::write(&path, "");
+        path
+    })
+    .as_path()
+}
+
+/// The fixture's own git: as little of the developer's as reaches it.
+///
+/// Three variables and two config files. A pre-commit hook exports
+/// `GIT_DIR`, `GIT_WORK_TREE` and `GIT_INDEX_FILE` at the repository being
+/// committed to, so a child that clears only the first writes its staged
+/// entries into that repository's index. The config files are the empty
+/// pair above.
+fn own_git(args: &[&str], dir: &Path) -> std::process::Command {
+    let mut command = std::process::Command::new("git");
+    command
+        .env("GIT_CONFIG_GLOBAL", empty_git_config())
+        .env("GIT_CONFIG_SYSTEM", empty_git_config())
         .env_remove("GIT_DIR")
         .env_remove("GIT_WORK_TREE")
         .env_remove("GIT_INDEX_FILE")
-        .output()
-        .unwrap();
+        .args(["-c", "user.email=t@t", "-c", "user.name=t"])
+        .args(args)
+        .current_dir(dir);
+    command
+}
+
+#[allow(clippy::unwrap_used)]
+fn git(dir: &Path, args: &[&str]) {
+    let output = own_git(args, dir).output().unwrap();
     assert!(
         output.status.success(),
         "git {args:?}: {}",
@@ -63,6 +102,7 @@ fn copy_tree(from: &Path, to: &Path) {
 /// bundle carrying growth-guards, with Claude on the machine.
 #[allow(clippy::unwrap_used)]
 fn fixture() -> Fixture {
+    empty_git_config();
     let tmp = tempfile::tempdir().unwrap();
     let home = tmp.path().canonicalize().unwrap();
     let project = home.join("dev/app");
@@ -209,11 +249,13 @@ fn the_effect_comes_back_unrun_and_a_separate_yes_arms_it() {
         f.project.join(".git/hooks/kendex-guards").is_file(),
         "the yes did not arm the hooks"
     );
-    // The installer's own last word is what the window shows.
+    // The installer's own last word is what the window shows — its
+    // success wording, not the substring its failures share with it:
+    // every "NOT armed" line the installer can print contains "armed".
     assert!(
         said.stdout
             .last()
-            .is_some_and(|line| line.contains("armed")),
+            .is_some_and(|line| line.contains("pre-commit and commit-msg armed in")),
         "{said:?}"
     );
 }
@@ -354,21 +396,10 @@ fn commit(f: &Fixture, message: &str) -> std::process::Output {
     #[allow(clippy::unwrap_used)]
     {
         fs::write(f.project.join("late.txt"), message).unwrap();
+        own_git(&["commit", "--quiet", "-a", "-m", message], &f.project)
+            .output()
+            .unwrap()
     }
-    #[allow(clippy::unwrap_used)]
-    std::process::Command::new("git")
-        .args(["-c", "user.email=t@t", "-c", "user.name=t"])
-        .args(["commit", "--quiet", "-a", "-m", message])
-        .current_dir(&f.project)
-        // All three, like `git` above: a pre-commit hook exports every one
-        // of them pointing at the repository being committed to, so a
-        // fixture that clears only GIT_DIR still inherits GIT_INDEX_FILE
-        // and writes its own staged entries into that repository's index.
-        .env_remove("GIT_DIR")
-        .env_remove("GIT_WORK_TREE")
-        .env_remove("GIT_INDEX_FILE")
-        .output()
-        .unwrap()
 }
 
 /// Removing the package from the window disarms the repository first, and
@@ -542,4 +573,91 @@ fn removing_an_inert_package_says_nothing() {
         .unwrap_or_else(|error| panic!("remove: {error}"));
 
     assert!(view.undone.is_empty(), "{:?}", view.undone);
+}
+
+/// A departing package's own output reaches the window escaped.
+///
+/// The lines land in a toast carrying no attribution, so a package that
+/// writes a bidi override or a line phrased in kendex's voice would be
+/// read as kendex talking. The terminal escapes them; this proves the
+/// window does too, which is what makes the three places claiming both
+/// surfaces show the same lines true.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_departing_package_s_output_reaches_the_window_escaped() {
+    let f = fixture();
+    let scripts = f.project.join(".agents/skills/loud/scripts");
+    let catalog_scripts = f.env.home.join("catalog/skills/loud/scripts");
+    fs::create_dir_all(&catalog_scripts).unwrap();
+    fs::write(
+        f.env.home.join("catalog/skills/loud/SKILL.md"),
+        "---\nname: loud\ndescription: writes a deceptive line\n\
+         repo-effects:\n  summary: \"says something on the way out\"\n  \
+         uninstaller: \"scripts/out\"\n---\nBody.\n",
+    )
+    .unwrap();
+    // U+202E, the override that reverses everything printed after it.
+    fs::write(
+        catalog_scripts.join("out"),
+        "#!/bin/sh\nprintf 'loud: \\342\\200\\256done\\n'\n",
+    )
+    .unwrap();
+    fs::set_permissions(
+        catalog_scripts.join("out"),
+        fs::Permissions::from_mode(0o755),
+    )
+    .unwrap();
+    install_skills(&f, &["loud"], None);
+    assert!(scripts.join("out").is_file(), "the fixture did not install");
+
+    let view = kendex_app::audit::remove(&f.env, &f.scope, ItemKind::Skill, "loud")
+        .unwrap_or_else(|error| panic!("remove: {error}"));
+
+    let said = view.undone.join("\n");
+    assert!(said.contains("loud: running"), "{said:?}");
+    assert!(
+        !said.contains('\u{202E}'),
+        "the override reached the window raw: {said:?}"
+    );
+    assert!(said.contains("\\u{202e}"), "{said:?}");
+}
+
+/// A write that must take nothing away refuses when it would, rather than
+/// running an uninstaller whose account nobody would see.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_write_that_must_remove_nothing_refuses_when_it_would() {
+    let f = fixture();
+    arm(&f);
+    // The report a whole-scope apply builds once the manifest no longer
+    // declares the package: a real removal, with the effect leaving.
+    let manifest = f.project.join("kendex.toml");
+    let text = fs::read_to_string(&manifest).unwrap();
+    fs::write(
+        &manifest,
+        text.replace("[skills.growth-guards]\nsource = \"cat\"\n", ""),
+    )
+    .unwrap();
+    let report = kendex_core::engine::plan_apply(
+        &f.env,
+        &f.scope,
+        &kendex_core::engine::PlanOptions {
+            remove_orphans: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert!(
+        !report.repo_effects_leaving.is_empty(),
+        "the fixture built a report with nothing leaving"
+    );
+
+    let refused = kendex_app::repo_effects::write_nothing_leaving(&f.env, &report).unwrap_err();
+
+    assert!(refused.contains("growth-guards"), "{refused}");
+    assert!(refused.contains("Audit page"), "{refused}");
+    assert!(
+        f.project.join(".git/hooks/kendex-guards").is_file(),
+        "the refusal ran the uninstaller anyway"
+    );
 }

--- a/crates/app/tests/repo_effects/fixture.rs
+++ b/crates/app/tests/repo_effects/fixture.rs
@@ -186,6 +186,10 @@ pub fn install_skills(f: &Fixture, names: &[&str], bundle: Option<&str>) -> Inst
     .unwrap_or_else(|error| panic!("install {names:?} {bundle:?}: {error}"))
 }
 
+#[allow(
+    dead_code,
+    reason = "the shared fixture serves two suites and each uses the part it needs"
+)]
 pub fn companion<'a>(
     offer: &'a kendex_core::repo_effects::Disclosure,
     name: &str,

--- a/crates/app/tests/repo_effects/fixture.rs
+++ b/crates/app/tests/repo_effects/fixture.rs
@@ -1,0 +1,198 @@
+//! The fixture both repo-effects suites are built on: a project, a
+//! catalog, and the helpers that install from it and commit in it.
+//!
+//! An install from the window is one command that plans and writes. The
+//! effect a package declares must come back out of it unrun, with what a
+//! person needs in order to decide — and arming is a second command, so a
+//! window that closes the dialog leaves the repository as it was.
+#![cfg(unix)]
+
+#[path = "../../../test_util.rs"]
+mod test_util;
+pub use test_util::{rooted, source_path};
+
+pub use std::fs;
+pub use std::os::unix::fs::PermissionsExt;
+pub use std::path::{Path, PathBuf};
+
+pub use kendex_app::marketplaces::install::{InstallItem, Installed, install};
+pub use kendex_core::env::{Env, FakeOs};
+pub use kendex_core::model::{ItemKind, Scope};
+
+pub struct Fixture {
+    pub _tmp: tempfile::TempDir,
+    pub env: Env,
+    pub scope: Scope,
+    pub project: PathBuf,
+}
+
+/// One empty git configuration for this whole test binary, global and
+/// system alike.
+///
+/// Not the developer's. A maintainer's own config decides what a git this
+/// file runs does — `commit.gpgsign` reds every case here on a fixture
+/// with no signing key — and none of that has anything to do with this
+/// code.
+///
+/// Named on each command this file builds. It does NOT reach the installer
+/// kendex spawns, whose argv belongs to core and whose environment is
+/// whatever this process hands down; covering that one means writing the
+/// variables onto the process, and the workspace forbids `unsafe`, which
+/// `std::env::set_var` now requires. So a maintainer who has configured a
+/// hooks path still sees the arming cases stand down — the same shape
+/// `crates/cli/tests/install_ux/guarding.rs` has, and a suite-wide
+/// property rather than anything this file introduced.
+pub fn empty_git_config() -> &'static Path {
+    static PATH: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+    PATH.get_or_init(|| {
+        let path = std::env::temp_dir().join("kendex-app-repo-effects-empty.gitconfig");
+        let _ = fs::write(&path, "");
+        path
+    })
+    .as_path()
+}
+
+/// The fixture's own git: as little of the developer's as reaches it.
+///
+/// Three variables and two config files. A pre-commit hook exports
+/// `GIT_DIR`, `GIT_WORK_TREE` and `GIT_INDEX_FILE` at the repository being
+/// committed to, so a child that clears only the first writes its staged
+/// entries into that repository's index. The config files are the empty
+/// pair above.
+pub fn own_git(args: &[&str], dir: &Path) -> std::process::Command {
+    let mut command = std::process::Command::new("git");
+    command
+        .env("GIT_CONFIG_GLOBAL", empty_git_config())
+        .env("GIT_CONFIG_SYSTEM", empty_git_config())
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .args(["-c", "user.email=t@t", "-c", "user.name=t"])
+        .args(args)
+        .current_dir(dir);
+    command
+}
+
+#[allow(clippy::unwrap_used)]
+pub fn git(dir: &Path, args: &[&str]) {
+    let output = own_git(args, dir).output().unwrap();
+    assert!(
+        output.status.success(),
+        "git {args:?}: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[allow(clippy::unwrap_used)]
+pub fn copy_tree(from: &Path, to: &Path) {
+    fs::create_dir_all(to).unwrap();
+    for entry in fs::read_dir(from).unwrap() {
+        let entry = entry.unwrap();
+        let target = to.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_tree(&entry.path(), &target);
+        } else {
+            fs::copy(entry.path(), &target).unwrap();
+        }
+    }
+}
+
+/// A git project subscribed to a catalog that offers the repository's own
+/// growth-guards and size-ratchet packages beside an inert one, plus a
+/// bundle carrying growth-guards, with Claude on the machine.
+#[allow(clippy::unwrap_used)]
+pub fn fixture() -> Fixture {
+    empty_git_config();
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let project = home.join("dev/app");
+    let catalog = home.join("catalog");
+    let shipped = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../skills")
+        .canonicalize()
+        .unwrap();
+    for skill in ["growth-guards", "size-ratchet"] {
+        copy_tree(&shipped.join(skill), &catalog.join("skills").join(skill));
+    }
+    fs::create_dir_all(catalog.join("skills/deploy")).unwrap();
+    fs::write(
+        catalog.join("skills/deploy/SKILL.md"),
+        "---\nname: deploy\ndescription: ship the service\n---\nRun the deploy.\n",
+    )
+    .unwrap();
+    // A package whose installer exits clean and writes to both channels —
+    // the shipped shape of growth-guards skipping its work: the summary on
+    // stdout, the reason and the remedy on stderr.
+    let noisy = catalog.join("skills/noisy/scripts");
+    fs::create_dir_all(&noisy).unwrap();
+    fs::write(
+        catalog.join("skills/noisy/SKILL.md"),
+        "---\nname: noisy\ndescription: says something on both channels\n\
+         repo-effects:\n  summary: \"arms nothing here\"\n  \
+         installer: \"scripts/arm\"\n---\nBody.\n",
+    )
+    .unwrap();
+    fs::write(
+        noisy.join("arm"),
+        "#!/bin/sh\necho 'core.hooksPath is set; unset it and run this again' >&2\n\
+         echo 'hooks: skipped'\n",
+    )
+    .unwrap();
+    fs::set_permissions(noisy.join("arm"), fs::Permissions::from_mode(0o755)).unwrap();
+    fs::write(
+        catalog.join("kendex.toml"),
+        "[bundles.guards]\ndescription = \"the commit gate\"\nskills = [\"growth-guards\"]\n",
+    )
+    .unwrap();
+    fs::create_dir_all(home.join(".claude")).unwrap();
+    fs::create_dir_all(project.join(".agents")).unwrap();
+    git(&project, &["init", "--quiet", "-b", "main"]);
+    fs::write(project.join("README.md"), "the app\n").unwrap();
+    git(&project, &["add", "."]);
+    git(&project, &["commit", "--quiet", "-m", "start"]);
+    fs::write(
+        project.join("kendex.toml"),
+        format!("schema = 6\n\n[sources.cat]\n{}\n", source_path(&catalog)),
+    )
+    .unwrap();
+    Fixture {
+        env: Env::fake(&home, FakeOs::Linux),
+        scope: Scope::Project {
+            root: project.clone(),
+        },
+        project,
+        _tmp: tmp,
+    }
+}
+
+pub fn install_skills(f: &Fixture, names: &[&str], bundle: Option<&str>) -> Installed {
+    install(
+        &f.env,
+        f.scope.clone(),
+        "cat".to_owned(),
+        names
+            .iter()
+            .map(|name| InstallItem {
+                kind: ItemKind::Skill,
+                name: (*name).to_owned(),
+            })
+            .collect(),
+        bundle.map(str::to_owned),
+        None,
+        false,
+        None,
+        None,
+    )
+    .unwrap_or_else(|error| panic!("install {names:?} {bundle:?}: {error}"))
+}
+
+pub fn companion<'a>(
+    offer: &'a kendex_core::repo_effects::Disclosure,
+    name: &str,
+) -> &'a kendex_core::repo_effects::Companion {
+    offer
+        .companions
+        .iter()
+        .find(|c| c.name == name)
+        .unwrap_or_else(|| panic!("no companion {name}: {:?}", offer.companions))
+}

--- a/crates/app/tests/repo_effects_escaping.rs
+++ b/crates/app/tests/repo_effects_escaping.rs
@@ -1,0 +1,160 @@
+//! What a package's own output is allowed to do to the window.
+//!
+//! Both halves of `repo_effects` hand a third party's bytes to a surface
+//! that renders them without attribution: an installer's last stdout
+//! line becomes a toast the moment somebody authorizes a disclosure, and
+//! a departing package's lines become the account of what its removal
+//! ran. A bidi override or a line phrased in kendex's voice reads as
+//! kendex talking in either. Both directions are held here together,
+//! because one door hardened is a rule that holds only where it was
+//! last reviewed.
+#![cfg(unix)]
+
+#[path = "repo_effects/fixture.rs"]
+mod fixture;
+use fixture::*;
+
+/// A departing package's own output reaches the window escaped.
+///
+/// The lines land in a toast carrying no attribution, so a package that
+/// writes a bidi override or a line phrased in kendex's voice would be
+/// read as kendex talking. The terminal escapes them; this proves the
+/// window does too, which is what makes the three places claiming both
+/// surfaces show the same lines true.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_departing_package_s_output_reaches_the_window_escaped() {
+    let f = fixture();
+    let scripts = f.project.join(".agents/skills/loud/scripts");
+    let catalog_scripts = f.env.home.join("catalog/skills/loud/scripts");
+    fs::create_dir_all(&catalog_scripts).unwrap();
+    fs::write(
+        f.env.home.join("catalog/skills/loud/SKILL.md"),
+        "---\nname: loud\ndescription: writes a deceptive line\n\
+         repo-effects:\n  summary: \"says something on the way out\"\n  \
+         uninstaller: \"scripts/out\"\n---\nBody.\n",
+    )
+    .unwrap();
+    // U+202E, the override that reverses everything printed after it.
+    fs::write(
+        catalog_scripts.join("out"),
+        "#!/bin/sh\nprintf 'loud: \\342\\200\\256done\\n'\n",
+    )
+    .unwrap();
+    fs::set_permissions(
+        catalog_scripts.join("out"),
+        fs::Permissions::from_mode(0o755),
+    )
+    .unwrap();
+    install_skills(&f, &["loud"], None);
+    assert!(scripts.join("out").is_file(), "the fixture did not install");
+
+    let view = kendex_app::audit::remove(&f.env, &f.scope, ItemKind::Skill, "loud")
+        .unwrap_or_else(|error| panic!("remove: {error}"));
+
+    let said = view.undone.join("\n");
+    assert!(said.contains("loud: running"), "{said:?}");
+    assert!(
+        !said.contains('\u{202E}'),
+        "the override reached the window raw: {said:?}"
+    );
+    assert!(said.contains("\\u{202e}"), "{said:?}");
+}
+/// The arriving half of this module escapes what a package says, like the
+/// departing half.
+///
+/// The window renders an installer's last stdout line as a bare toast the
+/// moment somebody authorizes a disclosure, so a bidi override or a line
+/// phrased in kendex's voice reads there as kendex's verdict on the thing
+/// they just approved. Both directions are held by a fixture rather than
+/// by whichever one was last reviewed.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_installer_s_output_reaches_the_window_escaped() {
+    let f = fixture();
+    let catalog = f.env.home.join("catalog");
+    let scripts = catalog.join("skills/sneaky/scripts");
+    fs::create_dir_all(&scripts).unwrap();
+    fs::write(
+        catalog.join("skills/sneaky/SKILL.md"),
+        "---\nname: sneaky\ndescription: writes a deceptive line\n\
+         repo-effects:\n  summary: \"arms something\"\n  \
+         installer: \"scripts/arm\"\n---\nBody.\n",
+    )
+    .unwrap();
+    // U+202E on stdout, and again on the channel a failure would use.
+    fs::write(
+        scripts.join("arm"),
+        "#!/bin/sh\nprintf 'sneaky: \\342\\200\\256armed\\n'\n\
+         printf 'sneaky: \\342\\200\\256warned\\n' >&2\n",
+    )
+    .unwrap();
+    fs::set_permissions(scripts.join("arm"), fs::Permissions::from_mode(0o755)).unwrap();
+    let installed = install_skills(&f, &["sneaky"], None);
+    let [offer] = installed.repo_effects.shown.as_slice() else {
+        panic!("one offer: {:?}", installed.repo_effects);
+    };
+
+    let said = kendex_app::repo_effects::apply(&f.env, &f.scope, &offer.declared).unwrap();
+
+    let spoke = format!("{:?}{:?}", said.stdout, said.stderr);
+    assert!(
+        !said
+            .stdout
+            .iter()
+            .chain(&said.stderr)
+            .any(|line| line.contains('\u{202E}')),
+        "the override reached the window raw: {spoke}"
+    );
+    assert!(spoke.contains("\\u{202e}"), "{spoke}");
+
+    // And the failure branch, which folds the same two streams into the
+    // error a person reads: an installer that exits nonzero still gets
+    // its words shown rather than rendered.
+    let refusing = f.project.join(".agents/skills/sneaky/scripts/arm");
+    fs::write(
+        &refusing,
+        "#!/bin/sh\nprintf 'sneaky: \\342\\200\\256refused\\n' >&2\nexit 1\n",
+    )
+    .unwrap();
+    fs::set_permissions(&refusing, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let failed = kendex_app::repo_effects::apply(&f.env, &f.scope, &offer.declared).unwrap_err();
+
+    assert!(
+        !failed.contains('\u{202E}'),
+        "the override reached the window raw: {failed}"
+    );
+    assert!(failed.contains("\\u{202e}refused"), "{failed}");
+}
+
+/// The yes is for the package the window was shown, not for whatever root
+/// comes back with it. Arming confines a program to the root it is handed,
+/// so a root the caller chose would confine nothing.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_root_this_scope_never_installed_is_refused() {
+    let f = fixture();
+    let installed = install_skills(&f, &["growth-guards"], None);
+    let [offer] = installed.repo_effects.shown.as_slice() else {
+        panic!("one offer: {:?}", installed.repo_effects);
+    };
+
+    let forged = kendex_core::repo_effects::DeclaredEffects {
+        root: PathBuf::from("/"),
+        effects: kendex_core::repo_effects::RepoEffects {
+            installer: Some("bin/sh -c id".to_owned()),
+            ..offer.declared.effects.clone()
+        },
+        ..offer.declared.clone()
+    };
+    let error = kendex_app::repo_effects::apply(&f.env, &f.scope, &forged).unwrap_err();
+    assert!(
+        error.contains("no record of installing it there"),
+        "{error}"
+    );
+    assert!(
+        !f.project.join(".git/hooks/kendex-guards").exists(),
+        "the forged root armed the hooks"
+    );
+}

--- a/crates/cli/src/commands/repo_effects.rs
+++ b/crates/cli/src/commands/repo_effects.rs
@@ -36,7 +36,7 @@ use std::io::IsTerminal;
 use kendex_core::engine::EngineReport;
 use kendex_core::env::Env;
 use kendex_core::model::Scope;
-use kendex_core::repo_effects::{DeclaredEffects, Disclosure};
+use kendex_core::repo_effects::{DeclaredEffects, Disclosure, Spoken};
 
 use super::{CliResult, answer, say};
 
@@ -165,94 +165,21 @@ fn relay(report: &kendex_core::guard::GuardReport) {
     }
 }
 
-/// Run one of a package's declared scripts and hand its words on as they
-/// came. The verdict is the caller's to read; what it means differs by
-/// which script ran — `arm` settles the installer's in core, because a
-/// half-written repository has one account to give, and a caller undoing
-/// an effect reads the same exit against a plan it can still stop.
-fn run(
-    scope: &Scope,
-    declared: &DeclaredEffects,
-    spec: &str,
-) -> Result<kendex_core::guard::GuardReport, Box<dyn std::error::Error>> {
-    let report = kendex_core::repo_effects::run_script(scope, &declared.root, spec)?;
-    relay(&report);
-    Ok(report)
-}
-
 /// Run the uninstaller of every package this plan takes away, before the
-/// plan takes it.
+/// plan takes it, and say what ran.
 ///
-/// Before, because the uninstaller is one of the files going: after the
-/// plan there is nothing to run, and the effect outlives its package as
-/// shims that exec a script that is not there and fail every commit
-/// closed. Not asked about — removing the package is the ask — and said
-/// out loud, so the person knows what ran in their repository.
-///
-/// A package whose uninstaller fails stays installed: the plan stops here
-/// with the files still in place and the package's own words on the
-/// failure, so the person can run it by hand and remove again. The other
-/// order leaves the repository in the state this exists to prevent.
-///
-/// A package that declares no uninstaller has nothing to run, and the
-/// removal goes ahead with that said — its files were going either way,
-/// and the disclosure named this the day it was installed.
-///
-/// The same stand-down as the disclosure's: an effect that writes into
-/// `.git` was never offered where the project has no git work tree, so
-/// there is nothing armed to undo and the uninstaller — which exits 2
-/// outside a repository — is not run. Otherwise removing a package from a
-/// plain directory failed every time, over hooks it could never have had.
+/// The loop and its wording are core's, because the window owes the same
+/// account. This side is only which channel each line goes out on: the
+/// package's stdout is what a caller pipes for, so those bytes are relayed
+/// as they came, and everything else is a line to read.
 pub fn undo(scope: &Scope, report: &EngineReport) -> CliResult {
-    let Scope::Project { root } = scope else {
-        return Ok(());
-    };
-    let leaving = &report.repo_effects_leaving;
-    // Asked once, and only when something leaving would need the answer:
-    // the probe is git processes, and a package that writes nowhere near
-    // `.git` never asks. `touches_git` is core's, the same reading the
-    // disclosure was made under, so an effect is armed and disarmed on one
-    // answer rather than two spellings of one.
-    //
-    // `probe`, not the disclosure's `at`: that one withholds an offer where
-    // git will not answer, because it is about to ask somebody to authorize
-    // a path it cannot name. This side only asks whether the work tree that
-    // could have been armed is here.
-    let git_here = leaving
-        .iter()
-        .any(|declared| kendex_core::repo_effects::touches_git(&declared.effects))
-        && kendex_core::guard::Repo::probe(root)?.is_some();
-    for declared in leaving {
-        let name = &declared.name;
-        if kendex_core::repo_effects::touches_git(&declared.effects) && !git_here {
-            say(&format!(
-                "{name}: not inside a git work tree, so nothing it armed is here to undo"
-            ));
-            continue;
-        }
-        let Some(uninstaller) = &declared.effects.uninstaller else {
-            say(&format!(
-                "{name}: declares no uninstaller — what it changed about this repository stays{}",
-                match &declared.effects.removal {
-                    Some(removal) => format!("; to undo: {}", removal),
-                    None => String::new(),
-                }
-            ));
-            continue;
-        };
-        say(&format!("{name}: running {}", uninstaller));
-        let report = run(scope, declared, uninstaller)?;
-        if report.code != 0 {
-            // No verb named: under an apply or a refresh the package is
-            // already out of the manifest, and "remove it again" would
-            // answer "Nothing removed".
-            return Err(format!(
-                "{name}: {} exited {} — its files stay in place; \
-                 fix what it reported and run this again",
-                uninstaller, report.code
-            )
-            .into());
-        }
-    }
-    Ok(())
+    kendex_core::repo_effects::undo(
+        scope,
+        &report.repo_effects_leaving,
+        &mut |spoken| match spoken {
+            Spoken::Stdout(line) => answer(&line),
+            Spoken::Note(line) | Spoken::Stderr(line) => say(&line),
+        },
+    )
+    .map_err(|error| error.to_string().into())
 }

--- a/crates/core/src/repo_effects.rs
+++ b/crates/core/src/repo_effects.rs
@@ -24,12 +24,14 @@
 //! notice they most need to read.
 mod declaration;
 pub mod disclosure;
+mod undo;
 use declaration::split_script;
 pub use declaration::{Declaration, RepoEffects, declaration, declared};
 pub use disclosure::{
     Companion, Disclosure, Offers, Withheld, Written, installed_skills, offers, offers_for,
     touches_git,
 };
+pub use undo::{Spoken, UndoError, undo};
 
 use serde::{Deserialize, Serialize};
 use specta::Type;

--- a/crates/core/src/repo_effects/undo.rs
+++ b/crates/core/src/repo_effects/undo.rs
@@ -7,12 +7,15 @@
 
 use super::{DeclaredEffects, run_script, touches_git};
 
-/// A line an undo produced, on the channel it belongs to.
+/// A line an undo produced, tagged with where it came from.
 ///
-/// Three, because the surfaces do three different things with them. A
-/// terminal escapes its own account, relays the package's stderr as a line
-/// like any other, and hands its stdout on byte for byte for whatever is
-/// piping it; a window shows all three to a person.
+/// Three tags rather than one stream, because two distinctions matter and
+/// neither surface can recover them afterwards. kendex's own account is
+/// told from the package's, so a surface knows which lines are already
+/// escaped and which are a third party's to escape. And the package's
+/// stdout is told from its stderr, so a terminal can hand the summary on
+/// byte for byte for whatever is piping it while everything else goes out
+/// as a line to read. A window has no pipe and escapes both.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Spoken {
     /// kendex's account of what it did about one package's effect.

--- a/crates/core/src/repo_effects/undo.rs
+++ b/crates/core/src/repo_effects/undo.rs
@@ -1,0 +1,166 @@
+//! Undoing a package's repository effect when the package leaves.
+//!
+//! One loop for both surfaces. The terminal writes its lines as it goes and
+//! the window shows them beside the action's result, but they owe the same
+//! account — a second spelling of this would be a second answer to "was
+//! that repository disarmed".
+
+use super::{DeclaredEffects, run_script, touches_git};
+
+/// A line an undo produced, on the channel it belongs to.
+///
+/// Three, because the surfaces do three different things with them. A
+/// terminal escapes its own account, relays the package's stderr as a line
+/// like any other, and hands its stdout on byte for byte for whatever is
+/// piping it; a window shows all three to a person.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Spoken {
+    /// kendex's account of what it did about one package's effect.
+    Note(String),
+    /// A line the package's uninstaller wrote for a person to read.
+    Stderr(String),
+    /// A line the package's uninstaller wrote as its answer.
+    Stdout(String),
+}
+
+impl Spoken {
+    /// The line itself, for a surface that shows all three the same way.
+    pub fn into_line(self) -> String {
+        match self {
+            Spoken::Note(line) | Spoken::Stderr(line) | Spoken::Stdout(line) => line,
+        }
+    }
+}
+
+/// Why a plan's removal stopped before it took anything away.
+#[derive(Debug)]
+pub enum UndoError {
+    /// The uninstaller ran and exited nonzero. The package stays installed:
+    /// the plan is stopped here with its files in place, so the person can
+    /// fix what the script reported and remove again. The other order
+    /// leaves a repository armed against scripts that are gone.
+    Failed {
+        name: String,
+        uninstaller: String,
+        code: u8,
+    },
+    /// The uninstaller could not be run at all.
+    Run(Box<crate::error::CoreError>),
+}
+
+impl std::fmt::Display for UndoError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use crate::names::shown;
+        match self {
+            UndoError::Failed {
+                name,
+                uninstaller,
+                code,
+            } => write!(
+                f,
+                "{}: {} exited {code} — its files stay in place; \
+                 fix what it reported and run this again",
+                shown(name),
+                shown(uninstaller)
+            ),
+            UndoError::Run(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for UndoError {}
+
+impl From<crate::error::CoreError> for UndoError {
+    fn from(error: crate::error::CoreError) -> Self {
+        UndoError::Run(Box::new(error))
+    }
+}
+
+/// Run the uninstaller of every package a plan takes away, before the plan
+/// takes it, and hand each line to `spoke`.
+///
+/// Before, because the uninstaller is one of the files going: after the
+/// plan there is nothing to run, and the effect outlives its package as
+/// shims that exec a script that is not there and fail every commit
+/// closed. Not asked about — removing the package is the ask — and said
+/// out loud, so the person knows what ran in their repository.
+///
+/// Here rather than at a surface, because both of them owe the same
+/// account: the terminal writes the lines as it goes and a window shows
+/// them beside the action's result, and a second spelling of this loop is
+/// a second answer to "was that repository disarmed".
+///
+/// A package that declares no uninstaller has nothing to run, and the
+/// removal goes ahead with that said — its files were going either way,
+/// and the disclosure named this the day it was installed.
+///
+/// The same stand-down as the disclosure's: an effect that writes into
+/// `.git` was never offered where the project has no git work tree, so
+/// there is nothing armed to undo and the uninstaller — which exits 2
+/// outside a repository — is not run. Otherwise removing a package from a
+/// plain directory failed every time, over hooks it could never have had.
+pub fn undo(
+    scope: &crate::model::Scope,
+    leaving: &[DeclaredEffects],
+    spoke: &mut dyn FnMut(Spoken),
+) -> std::result::Result<(), UndoError> {
+    use crate::names::shown;
+    let crate::model::Scope::Project { root } = scope else {
+        return Ok(());
+    };
+    // Asked once, and only when something leaving would need the answer:
+    // the probe is git processes, and a package that writes nowhere near
+    // `.git` never asks. `touches_git` is the same reading the disclosure
+    // was made under, so an effect is armed and disarmed on one answer
+    // rather than two spellings of one.
+    //
+    // `probe`, not the disclosure's `at`: that one withholds an offer where
+    // git will not answer, because it is about to ask somebody to authorize
+    // a path it cannot name. This side only asks whether the work tree that
+    // could have been armed is here.
+    let git_here = leaving
+        .iter()
+        .any(|declared| touches_git(&declared.effects))
+        && crate::guard::Repo::probe(root)?.is_some();
+    for declared in leaving {
+        let name = shown(&declared.name);
+        if touches_git(&declared.effects) && !git_here {
+            spoke(Spoken::Note(format!(
+                "{name}: not inside a git work tree, so nothing it armed is here to undo"
+            )));
+            continue;
+        }
+        let Some(uninstaller) = &declared.effects.uninstaller else {
+            spoke(Spoken::Note(format!(
+                "{name}: declares no uninstaller — what it changed about this repository stays{}",
+                match &declared.effects.removal {
+                    Some(removal) => format!("; to undo: {}", shown(removal)),
+                    None => String::new(),
+                }
+            )));
+            continue;
+        };
+        spoke(Spoken::Note(format!(
+            "{name}: running {}",
+            shown(uninstaller)
+        )));
+        let report = run_script(scope, &declared.root, uninstaller)?;
+        for line in report.stderr {
+            spoke(Spoken::Stderr(line));
+        }
+        for line in report.stdout {
+            spoke(Spoken::Stdout(line));
+        }
+        if report.code != 0 {
+            // No verb named: under an apply or a refresh the package is
+            // already out of the manifest, and "remove it again" would
+            // answer "Nothing removed".
+            return Err(UndoError::Failed {
+                name: declared.name.clone(),
+                uninstaller: uninstaller.clone(),
+                code: report.code,
+            });
+        }
+    }
+    Ok(())
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -388,10 +388,10 @@ lives in one capability table read by core and UI.
   `.agents/skills` — size-ratchet, todo-ban, byte-ceiling, suppression-ban, conflict-markers, changelog-entries,
   prose, commit-msg, and preflight's staged lanes. git's own `.git/hooks` shims run them: no kendex binary is in the
   path at commit time, and since git clones no hooks, a clone carries the scripts and one `guard install`
-  arms them. kendex implements no check — `guard install`/`guard uninstall` run the installer, every CLI verb
-  that drops a package runs its declared uninstaller before the files go (`engine_common::apply_report`, the one
-  executor of an `EngineReport`), and `guard run <hook>` execs its script with git's redirects passed through, the
-  one child not scrubbed because it is a hook body naming the snapshot judged. `guard check` asks the package too.
+  arms them. kendex implements no check — `guard install`/`guard uninstall` run the installer, either surface's
+  removal runs the leaving package's declared uninstaller before the files go (`repo_effects::undo`, behind their
+  one `EngineReport` executor), and `guard run <hook>` execs its script with git's redirects passed through, the one
+  child not scrubbed because it is a hook body naming the snapshot judged. `guard check` asks the package too.
   `kendex check` relays that same `--check`: the package's sentence and exit where it has something to report, a
   clean result folding into kendex's own all-clear. It asks only where a project's lock enables the skill AND the
   helper is already in `.git/hooks` — git clones none, so that file is the local arming that licenses the run.

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -110,7 +110,7 @@ export const commands = {
 	 *  window — would put the older file back over it. A copy of a file that
 	 *  is no longer there is refused, never applied.
 	 */
-	updateSettings: (settings: AppSettings, base: string | null) => typedError<SettingsRead, WriteRefused>(__TAURI_INVOKE("update_settings", { settings, base })),
+	updateSettings: (settings: AppSettings, base: string | null) => typedError<SettingsRead, WriteRefused_Serialize>(__TAURI_INVOKE("update_settings", { settings, base })),
 	/**
 	 *  The size on screen, written on its own. Nothing else in the file moves
 	 *  with it, and nothing else can move it: a size the person is looking at
@@ -181,7 +181,7 @@ export const commands = {
 } | null, settings: {
 	edits: SettingsEdit[],
 	base: string | null,
-} | null) => typedError<AuditView_Serialize, WriteRefused>(__TAURI_INVOKE("save_customize", { scope, manifest, settings })),
+} | null) => typedError<AuditView_Serialize, WriteRefused_Serialize>(__TAURI_INVOKE("save_customize", { scope, manifest, settings })),
 	editorInventory: (scope: Scope) => typedError<EditorInventory, string>(__TAURI_INVOKE("editor_inventory", { scope })),
 	/**
 	 *  Per-hook, per-harness delivery for the hooks as currently drafted in the
@@ -298,12 +298,8 @@ export const commands = {
 	 *  Unsubscribe, removing or keeping the packages. `keep` converts each
 	 *  installation to a local fork; otherwise they are uninstalled, and
 	 *  `discard_edits` takes hand edits along instead of refusing.
-	 * 
-	 *  Answers with what the removal did about the repository effects of the
-	 *  packages that left with the source — the same account the terminal
-	 *  prints, for the window to show.
 	 */
-	marketplaceUnsubscribe: (scope: Scope, source: string, keep: boolean, discardEdits: boolean) => typedError<string[], string>(__TAURI_INVOKE("marketplace_unsubscribe", { scope, source, keep, discardEdits })),
+	marketplaceUnsubscribe: (scope: Scope, source: string, keep: boolean, discardEdits: boolean) => typedError<Unsubscribed_Serialize, string>(__TAURI_INVOKE("marketplace_unsubscribe", { scope, source, keep, discardEdits })),
 	/**
 	 *  The directory as the tab shows it. `refresh` forces a revalidation;
 	 *  otherwise the cached list is served within its TTL.
@@ -2887,6 +2883,46 @@ export type UnsubscribePreview = {
 	bundles: string[],
 };
 
+/**
+ *  What unsubscribing did about the repository effects of the packages
+ *  that left with the source — the same account the terminal prints.
+ * 
+ *  A struct rather than the bare list it used to be, spelling the account
+ *  `undone` like every other command that can make one. The window reads
+ *  the account off an answer by that name, so a bare list is a shape it
+ *  can only be told about by hand, and the day this write goes through
+ *  the shared one it would fall silent with nothing going red.
+ */
+export type Unsubscribed = Unsubscribed_Serialize | Unsubscribed_Deserialize;
+
+/**
+ *  What unsubscribing did about the repository effects of the packages
+ *  that left with the source — the same account the terminal prints.
+ * 
+ *  A struct rather than the bare list it used to be, spelling the account
+ *  `undone` like every other command that can make one. The window reads
+ *  the account off an answer by that name, so a bare list is a shape it
+ *  can only be told about by hand, and the day this write goes through
+ *  the shared one it would fall silent with nothing going red.
+ */
+export type Unsubscribed_Deserialize = {
+	undone: string[],
+};
+
+/**
+ *  What unsubscribing did about the repository effects of the packages
+ *  that left with the source — the same account the terminal prints.
+ * 
+ *  A struct rather than the bare list it used to be, spelling the account
+ *  `undone` like every other command that can make one. The window reads
+ *  the account off an answer by that name, so a bare list is a shape it
+ *  can only be told about by hand, and the day this write goes through
+ *  the shared one it would fall silent with nothing going red.
+ */
+export type Unsubscribed_Serialize = {
+	undone?: string[],
+};
+
 /**  One declared package's update standing. */
 export type UpdateRow = {
 	scope: Scope,
@@ -3081,13 +3117,47 @@ export type Withheld = {
  *  here, not a failure, so it is a shape the page can act on rather than
  *  a message it would have to recognise by its words.
  */
-export type WriteRefused = 
+export type WriteRefused = WriteRefused_Serialize | WriteRefused_Deserialize;
+
+/**
+ *  Why a whole-file write did not happen. Refusing is a normal answer
+ *  here, not a failure, so it is a shape the page can act on rather than
+ *  a message it would have to recognise by its words.
+ */
+export type WriteRefused_Deserialize = 
 /**
  *  The file is no longer the one this copy was read from. Something
  *  else wrote it — a fork, a hold, an install, another window — and
  *  writing this copy would put that back.
+ * 
+ *  Carries whatever the write already did to the repository before it
+ *  refused. A plan runs a leaving package's uninstaller before it
+ *  touches the files, so a refusal landing after that point is a
+ *  refusal with a disarmed repository behind it — and a reload notice
+ *  on its own would send somebody away believing nothing happened.
+ *  Empty on the base check, which refuses before anything runs.
  */
-{ kind: "stale" } | { kind: "failed"; message: string };
+({ kind: "stale"; undone: string[] }) & { message?: never } | ({ kind: "failed"; message: string }) & { undone?: never };
+
+/**
+ *  Why a whole-file write did not happen. Refusing is a normal answer
+ *  here, not a failure, so it is a shape the page can act on rather than
+ *  a message it would have to recognise by its words.
+ */
+export type WriteRefused_Serialize = 
+/**
+ *  The file is no longer the one this copy was read from. Something
+ *  else wrote it — a fork, a hold, an install, another window — and
+ *  writing this copy would put that back.
+ * 
+ *  Carries whatever the write already did to the repository before it
+ *  refused. A plan runs a leaving package's uninstaller before it
+ *  touches the files, so a refusal landing after that point is a
+ *  refusal with a disarmed repository behind it — and a reload notice
+ *  on its own would send somebody away believing nothing happened.
+ *  Empty on the base check, which refuses before anything runs.
+ */
+({ kind: "stale"; undone?: string[] }) & { message?: never } | ({ kind: "failed"; message: string }) & { undone?: never };
 
 /**  One path the package writes, where it actually lands. */
 export type Written = {

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -288,7 +288,7 @@ export const commands = {
 	 *  Subscribe a scope to a marketplace: `owner/repo[@rev]`, a git URL, a
 	 *  GitHub tree URL, a skills.sh package URL, or a local folder.
 	 */
-	marketplaceSubscribe: (scope: Scope, reference: string, name: string | null) => typedError<SubscribeOutcome, string>(__TAURI_INVOKE("marketplace_subscribe", { scope, reference, name })),
+	marketplaceSubscribe: (scope: Scope, reference: string, name: string | null) => typedError<SubscribeOutcome_Serialize, string>(__TAURI_INVOKE("marketplace_subscribe", { scope, reference, name })),
 	/**
 	 *  The dialog's preview: the closure partitioned into removable, edited, and
 	 *  the bundles that go. Refuses (as an error) while the source cannot be read.
@@ -2784,7 +2784,10 @@ export type SubmittedView = {
 };
 
 /**  What subscribing declared, after the plan ran. */
-export type SubscribeOutcome = {
+export type SubscribeOutcome = SubscribeOutcome_Serialize | SubscribeOutcome_Deserialize;
+
+/**  What subscribing declared, after the plan ran. */
+export type SubscribeOutcome_Deserialize = {
 	name: string,
 	/**  The declared repository or path. */
 	reference: string,
@@ -2795,6 +2798,32 @@ export type SubscribeOutcome = {
 	 */
 	lead: string | null,
 	notes: string[],
+	/**
+	 *  What a package leaving with this plan had undone, if one did. Its
+	 *  own field rather than more notes, so the account a removal owes has
+	 *  one name across every command that can make one.
+	 */
+	undone: string[],
+};
+
+/**  What subscribing declared, after the plan ran. */
+export type SubscribeOutcome_Serialize = {
+	name: string,
+	/**  The declared repository or path. */
+	reference: string,
+	rev: string | null,
+	/**
+	 *  The package a tree or skills.sh URL was leading to — where the app
+	 *  opens next, never an identity.
+	 */
+	lead: string | null,
+	notes: string[],
+	/**
+	 *  What a package leaving with this plan had undone, if one did. Its
+	 *  own field rather than more notes, so the account a removal owes has
+	 *  one name across every command that can make one.
+	 */
+	undone?: string[],
 };
 
 /**

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -225,9 +225,9 @@ export const commands = {
 	openUrl: (url: string) => typedError<null, string>(__TAURI_INVOKE("open_url", { url })),
 	/**  Every declared source in every scope — the Sources page's one query. */
 	sourcesOverview: () => typedError<SourceRow[], string>(__TAURI_INVOKE("sources_overview")),
-	sourceAdd: (scope: Scope, name: string, reference: string) => typedError<SourceRow[], string>(__TAURI_INVOKE("source_add", { scope, name, reference })),
-	sourceRemove: (scope: Scope, name: string) => typedError<SourceRow[], string>(__TAURI_INVOKE("source_remove", { scope, name })),
-	sourceToggle: (scope: Scope, name: string, enabled: boolean) => typedError<SourceRow[], string>(__TAURI_INVOKE("source_toggle", { scope, name, enabled })),
+	sourceAdd: (scope: Scope, name: string, reference: string) => typedError<SourcesAfter_Serialize, string>(__TAURI_INVOKE("source_add", { scope, name, reference })),
+	sourceRemove: (scope: Scope, name: string) => typedError<SourcesAfter_Serialize, string>(__TAURI_INVOKE("source_remove", { scope, name })),
+	sourceToggle: (scope: Scope, name: string, enabled: boolean) => typedError<SourcesAfter_Serialize, string>(__TAURI_INVOKE("source_toggle", { scope, name, enabled })),
 	/**
 	 *  Re-resolve every enabled remote across every scope. Returns warnings
 	 *  (offline caches keep serving); hard failures surface as the error.
@@ -239,7 +239,7 @@ export const commands = {
 	 *  Install a set whole. Its members derive from the catalog, so this declares
 	 *  one name and applies the plan that follows from it.
 	 */
-	bundleInstall: (scope: Scope, source: string, name: string, hold: boolean) => typedError<BundleInstalled, string>(__TAURI_INVOKE("bundle_install", { scope, source, name, hold })),
+	bundleInstall: (scope: Scope, source: string, name: string, hold: boolean) => typedError<BundleInstalled_Serialize, string>(__TAURI_INVOKE("bundle_install", { scope, source, name, hold })),
 	/**
 	 *  Every subscription across every scope — the Marketplaces page's one
 	 *  query.
@@ -272,7 +272,7 @@ export const commands = {
 	 *  carry the picker's answer; absent, the scope's own install defaults
 	 *  decide, brought up to date against this machine by the add itself.
 	 */
-	marketplaceInstall: (scope: Scope, source: string, items: InstallItem[], bundle: string | null, destination: { scope: "global" } | { scope: "project"; root: string } | null, hold: boolean, harnesses: HarnessId[] | null, method: "symlink" | "copy" | null) => typedError<Installed, string>(__TAURI_INVOKE("marketplace_install", { scope, source, items, bundle, destination, hold, harnesses, method })),
+	marketplaceInstall: (scope: Scope, source: string, items: InstallItem[], bundle: string | null, destination: { scope: "global" } | { scope: "project"; root: string } | null, hold: boolean, harnesses: HarnessId[] | null, method: "symlink" | "copy" | null) => typedError<Installed_Serialize, string>(__TAURI_INVOKE("marketplace_install", { scope, source, items, bundle, destination, hold, harnesses, method })),
 	/**
 	 *  Where an install of these kinds could land, for the picker the install
 	 *  flow draws. Two filters, both read from core: which tools can take the
@@ -298,8 +298,12 @@ export const commands = {
 	 *  Unsubscribe, removing or keeping the packages. `keep` converts each
 	 *  installation to a local fork; otherwise they are uninstalled, and
 	 *  `discard_edits` takes hand edits along instead of refusing.
+	 * 
+	 *  Answers with what the removal did about the repository effects of the
+	 *  packages that left with the source — the same account the terminal
+	 *  prints, for the window to show.
 	 */
-	marketplaceUnsubscribe: (scope: Scope, source: string, keep: boolean, discardEdits: boolean) => typedError<null, string>(__TAURI_INVOKE("marketplace_unsubscribe", { scope, source, keep, discardEdits })),
+	marketplaceUnsubscribe: (scope: Scope, source: string, keep: boolean, discardEdits: boolean) => typedError<string[], string>(__TAURI_INVOKE("marketplace_unsubscribe", { scope, source, keep, discardEdits })),
 	/**
 	 *  The directory as the tab shows it. `refresh` forces a revalidation;
 	 *  otherwise the cached list is served within its TTL.
@@ -602,6 +606,15 @@ export type AuditView_Deserialize = {
 	 */
 	exits: RowExits[],
 	/**
+	 *  What a removal in this action did about the repository effects of
+	 *  the packages that left with it: the same lines the terminal prints,
+	 *  so the window says what ran rather than leaving a repository armed
+	 *  against scripts that are gone. Empty on a plain read and on every
+	 *  action that took no declaring package away — and left off the wire
+	 *  entirely when it is empty, which is almost every read.
+	 */
+	undone: string[],
+	/**
 	 *  Set when this one scope couldn't be read at all — a corrupt or
 	 *  future-version lock or manifest. Carried as data so one scope's
 	 *  failure never blanks every other scope's audit (drift/plan/notes/
@@ -641,6 +654,15 @@ export type AuditView_Serialize = {
 	 *  ends up offering an action the plan rejects.
 	 */
 	exits: RowExits[],
+	/**
+	 *  What a removal in this action did about the repository effects of
+	 *  the packages that left with it: the same lines the terminal prints,
+	 *  so the window says what ran rather than leaving a repository armed
+	 *  against scripts that are gone. Empty on a plain read and on every
+	 *  action that took no declaring package away — and left off the wire
+	 *  entirely when it is empty, which is almost every read.
+	 */
+	undone?: string[],
 	/**
 	 *  Set when this one scope couldn't be read at all — a corrupt or
 	 *  future-version lock or manifest. Carried as data so one scope's
@@ -703,12 +725,32 @@ export type BundleDetail = {
 };
 
 /**
- *  What a bundle install hands back: every set as it stands now, and the
- *  repository effects its members brought for the window to ask about.
+ *  What a bundle install hands back: every set as it stands now, the
+ *  repository effects its members brought for the window to ask about, and
+ *  what any package the plan took away had undone.
  */
-export type BundleInstalled = {
+export type BundleInstalled = BundleInstalled_Serialize | BundleInstalled_Deserialize;
+
+/**
+ *  What a bundle install hands back: every set as it stands now, the
+ *  repository effects its members brought for the window to ask about, and
+ *  what any package the plan took away had undone.
+ */
+export type BundleInstalled_Deserialize = {
 	bundles: BundleRow[],
 	repoEffects: Offers,
+	undone: string[],
+};
+
+/**
+ *  What a bundle install hands back: every set as it stands now, the
+ *  repository effects its members brought for the window to ask about, and
+ *  what any package the plan took away had undone.
+ */
+export type BundleInstalled_Serialize = {
+	bundles: BundleRow[],
+	repoEffects: Offers,
+	undone?: string[],
 };
 
 /**  One member of a curated set, with where it stands here. */
@@ -1595,12 +1637,34 @@ export type InstallTarget = {
 
 /**
  *  What an install hands back: the subscription's packages as they stand
- *  now, and the repository effects the install brought — read and asked
- *  about in the window, because nothing here ran them.
+ *  now, the repository effects the install brought — read and asked about
+ *  in the window, because nothing here ran them — and what any package the
+ *  plan took away had undone, which is not asked about at all.
  */
-export type Installed = {
+export type Installed = Installed_Serialize | Installed_Deserialize;
+
+/**
+ *  What an install hands back: the subscription's packages as they stand
+ *  now, the repository effects the install brought — read and asked about
+ *  in the window, because nothing here ran them — and what any package the
+ *  plan took away had undone, which is not asked about at all.
+ */
+export type Installed_Deserialize = {
 	packages: AvailablePackage[],
 	repoEffects: Offers,
+	undone: string[],
+};
+
+/**
+ *  What an install hands back: the subscription's packages as they stand
+ *  now, the repository effects the install brought — read and asked about
+ *  in the window, because nothing here ran them — and what any package the
+ *  plan took away had undone, which is not asked about at all.
+ */
+export type Installed_Serialize = {
+	packages: AvailablePackage[],
+	repoEffects: Offers,
+	undone?: string[],
 };
 
 /**  One declared item: `[agents.<name>]` / `[skills.<name>]`. */
@@ -2642,6 +2706,39 @@ export type SourceRow = {
 	/**  Cache HEAD for remotes — freshness display. */
 	head: string | null,
 	declaredItems: string[],
+};
+
+/**
+ *  What a source action leaves: every declared source across every scope,
+ *  and what the removal did about the repository effects of any package
+ *  that left with it — the same account the terminal prints, so the window
+ *  says what ran rather than leaving a repository armed against scripts
+ *  that are gone.
+ */
+export type SourcesAfter = SourcesAfter_Serialize | SourcesAfter_Deserialize;
+
+/**
+ *  What a source action leaves: every declared source across every scope,
+ *  and what the removal did about the repository effects of any package
+ *  that left with it — the same account the terminal prints, so the window
+ *  says what ran rather than leaving a repository armed against scripts
+ *  that are gone.
+ */
+export type SourcesAfter_Deserialize = {
+	sources: SourceRow[],
+	undone: string[],
+};
+
+/**
+ *  What a source action leaves: every declared source across every scope,
+ *  and what the removal did about the repository effects of any package
+ *  that left with it — the same account the terminal prints, so the window
+ *  says what ran rather than leaving a repository armed against scripts
+ *  that are gone.
+ */
+export type SourcesAfter_Serialize = {
+	sources: SourceRow[],
+	undone?: string[],
 };
 
 /**  One check finding shaped for a screen with an Open button. */

--- a/ui/src/lib/undone.test.ts
+++ b/ui/src/lib/undone.test.ts
@@ -17,27 +17,31 @@ describe("saying what a removal ran", () => {
     expect(toast.message).not.toHaveBeenCalled();
   });
 
-  // A departing package's uninstaller is a third party writing as much as
-  // it likes, and sonner shows three toasts at a time for four seconds
-  // each — so an uncapped account is a minutes-long drain over whatever
-  // the person does next. The lines that name the package and what ran
-  // come first; the tail is the script talking.
-  it("shows the first ten lines and counts the rest", () => {
+  // The account interleaves kendex's own notes with each departing
+  // package's output, in name order. Cutting it by position spends the
+  // budget on whoever talks first — which is the party kendex does not
+  // control — and the line it ate was the second package's stand-down
+  // notice, the only place kendex says an effect was left standing and
+  // names the manual remedy. The bound belongs where the source of each
+  // line is still known, and that is Rust.
+  it("says a later package's stand-down after a chatty one", () => {
+    const account = [
+      "aaa-loud: running scripts/out",
+      ...Array.from({ length: 9 }, (_, n) => `chatter ${n}`),
+      "zzz-quiet: declares no uninstaller — what it changed about this " +
+        "repository stays; to undo: undo it by hand",
+    ];
+
+    sayUndone(account);
+
+    expect(toast.message).toHaveBeenCalledTimes(account.length);
+    expect(toast.message).toHaveBeenLastCalledWith(account.at(-1));
+  });
+
+  it("says every line it is handed, however many that is", () => {
     sayUndone(Array.from({ length: 26 }, (_, n) => `line ${n}`));
-
-    expect(toast.message).toHaveBeenCalledTimes(11);
-    expect(toast.message).toHaveBeenNthCalledWith(10, "line 9");
-    expect(toast.message).toHaveBeenLastCalledWith("and 16 more lines");
-  });
-
-  it("counts one leftover line in the singular", () => {
-    sayUndone(Array.from({ length: 11 }, (_, n) => `line ${n}`));
-    expect(toast.message).toHaveBeenLastCalledWith("and 1 more line");
-  });
-
-  it("says exactly ten lines without a tally after them", () => {
-    sayUndone(Array.from({ length: 10 }, (_, n) => `line ${n}`));
-    expect(toast.message).toHaveBeenCalledTimes(10);
+    expect(toast.message).toHaveBeenCalledTimes(26);
+    expect(toast.message).toHaveBeenLastCalledWith("line 25");
   });
 });
 

--- a/ui/src/lib/undone.test.ts
+++ b/ui/src/lib/undone.test.ts
@@ -1,0 +1,73 @@
+import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { saying, sayUndone } from "./undone";
+
+vi.mock("sonner", () => ({
+  toast: { message: vi.fn() },
+}));
+
+beforeEach(() => {
+  vi.mocked(toast.message).mockClear();
+});
+
+describe("saying what a removal ran", () => {
+  it("says nothing when nothing was armed", () => {
+    sayUndone([]);
+    sayUndone(undefined);
+    expect(toast.message).not.toHaveBeenCalled();
+  });
+
+  // A departing package's uninstaller is a third party writing as much as
+  // it likes, and sonner shows three toasts at a time for four seconds
+  // each — so an uncapped account is a minutes-long drain over whatever
+  // the person does next. The lines that name the package and what ran
+  // come first; the tail is the script talking.
+  it("shows the first ten lines and counts the rest", () => {
+    sayUndone(Array.from({ length: 26 }, (_, n) => `line ${n}`));
+
+    expect(toast.message).toHaveBeenCalledTimes(11);
+    expect(toast.message).toHaveBeenNthCalledWith(10, "line 9");
+    expect(toast.message).toHaveBeenLastCalledWith("and 16 more lines");
+  });
+
+  it("counts one leftover line in the singular", () => {
+    sayUndone(Array.from({ length: 11 }, (_, n) => `line ${n}`));
+    expect(toast.message).toHaveBeenLastCalledWith("and 1 more line");
+  });
+
+  it("says exactly ten lines without a tally after them", () => {
+    sayUndone(Array.from({ length: 10 }, (_, n) => `line ${n}`));
+    expect(toast.message).toHaveBeenCalledTimes(10);
+  });
+});
+
+describe("the account a write's answer carries", () => {
+  const RAN = "guards: running scripts/arm --uninstall";
+
+  it("reads it off the answer itself", () => {
+    saying({ status: "ok", data: { undone: [RAN] } });
+    expect(toast.message).toHaveBeenCalledWith(RAN);
+  });
+
+  it("reads it off the standing the answer nests", () => {
+    saying({ status: "ok", data: { view: { undone: [RAN] } } });
+    expect(toast.message).toHaveBeenCalledWith(RAN);
+  });
+
+  it("says nothing for a refusal, which accounts for nothing", () => {
+    saying({ status: "error", error: "the plan was refused" });
+    expect(toast.message).not.toHaveBeenCalled();
+  });
+
+  it("says nothing for an answer that carries no account", () => {
+    saying({ status: "ok", data: { ignored: true } });
+    saying({ status: "ok", data: null });
+    saying(undefined);
+    expect(toast.message).not.toHaveBeenCalled();
+  });
+
+  it("hands the answer straight back", () => {
+    const answer = { status: "ok" as const, data: { undone: [RAN] } };
+    expect(saying(answer)).toBe(answer);
+  });
+});

--- a/ui/src/lib/undone.ts
+++ b/ui/src/lib/undone.ts
@@ -21,16 +21,33 @@ export function sayUndone(undone: string[] | undefined) {
   if (rest > 0) toast.message(`and ${rest} more line${rest === 1 ? "" : "s"}`);
 }
 
-/** The account an answer carries, wherever the command puts it: on the
- *  answer itself, or on the standing that answer nests. Read here rather
- *  than at each call site, so a command added later is announced by the
- *  write it goes through instead of by somebody remembering. */
+/** The lines of `value`, or nothing if it is not a list of them. */
+function lines(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((line): line is string => typeof line === "string");
+}
+
+/** The account an answer carries, wherever the command puts it: as the
+ *  answer itself, on the answer, or on the standing the answer nests. Read
+ *  here rather than at each call site, so a command added later is
+ *  announced by the write it goes through instead of by somebody
+ *  remembering.
+ *
+ *  First NON-EMPTY, not first non-nullish. `??` prefers an outer empty
+ *  list over a populated nested one, which would silence exactly the
+ *  answers that carry both. A shape with no account anywhere returns
+ *  nothing, and that branch is written out so the silence is a decision
+ *  rather than a fall-through. */
 function accountIn(data: unknown): string[] {
+  const bare = lines(data);
+  if (bare.length > 0) return bare;
   if (typeof data !== "object" || data === null) return [];
   const held = data as { undone?: unknown; view?: { undone?: unknown } | null };
-  const found = held.undone ?? held.view?.undone;
-  if (!Array.isArray(found)) return [];
-  return found.filter((line): line is string => typeof line === "string");
+  const own = lines(held.undone);
+  if (own.length > 0) return own;
+  const nested = lines(held.view?.undone);
+  if (nested.length > 0) return nested;
+  return [];
 }
 
 /** Say what a write's answer accounts for, and hand the answer straight

--- a/ui/src/lib/undone.ts
+++ b/ui/src/lib/undone.ts
@@ -4,21 +4,18 @@
 // only puts them on the screen.
 import { toast } from "sonner";
 
-/** How many lines are shown before the rest are counted instead. An
- *  uninstaller is a third party and its output is uncapped, and sonner
- *  shows three toasts at a time for four seconds each — so a chatty one
- *  becomes a minutes-long drain that buries whatever the person does
- *  next. The first lines are the ones that name the package and what ran;
- *  the tail is the script talking. */
-const SHOWN = 10;
-
-/** Show a removal's account, one line at a time. Silent when the removal
- *  took no declaring package away, which is almost every removal. */
+/** Show a removal's account, every line of it. Silent when the removal
+ *  took no declaring package away, which is almost every removal.
+ *
+ *  No cut here. A departing package's output is bounded already, per
+ *  package, by `repo_effects::execute` — which is the layer that can still
+ *  tell kendex's own lines from the package's and so keeps every one of
+ *  kendex's. Cutting again by position cannot make that distinction, and
+ *  the account it ate first was a later package's "declares no
+ *  uninstaller" notice, which is the only place kendex says an effect was
+ *  left standing and names the manual remedy. */
 export function sayUndone(undone: string[] | undefined) {
-  const lines = undone ?? [];
-  for (const line of lines.slice(0, SHOWN)) toast.message(line);
-  const rest = lines.length - SHOWN;
-  if (rest > 0) toast.message(`and ${rest} more line${rest === 1 ? "" : "s"}`);
+  for (const line of undone ?? []) toast.message(line);
 }
 
 /** The lines of `value`, or nothing if it is not a list of them. */

--- a/ui/src/lib/undone.ts
+++ b/ui/src/lib/undone.ts
@@ -4,8 +4,47 @@
 // only puts them on the screen.
 import { toast } from "sonner";
 
+/** How many lines are shown before the rest are counted instead. An
+ *  uninstaller is a third party and its output is uncapped, and sonner
+ *  shows three toasts at a time for four seconds each — so a chatty one
+ *  becomes a minutes-long drain that buries whatever the person does
+ *  next. The first lines are the ones that name the package and what ran;
+ *  the tail is the script talking. */
+const SHOWN = 10;
+
 /** Show a removal's account, one line at a time. Silent when the removal
  *  took no declaring package away, which is almost every removal. */
 export function sayUndone(undone: string[] | undefined) {
-  for (const line of undone ?? []) toast.message(line);
+  const lines = undone ?? [];
+  for (const line of lines.slice(0, SHOWN)) toast.message(line);
+  const rest = lines.length - SHOWN;
+  if (rest > 0) toast.message(`and ${rest} more line${rest === 1 ? "" : "s"}`);
+}
+
+/** The account an answer carries, wherever the command puts it: on the
+ *  answer itself, or on the standing that answer nests. Read here rather
+ *  than at each call site, so a command added later is announced by the
+ *  write it goes through instead of by somebody remembering. */
+function accountIn(data: unknown): string[] {
+  if (typeof data !== "object" || data === null) return [];
+  const held = data as { undone?: unknown; view?: { undone?: unknown } | null };
+  const found = held.undone ?? held.view?.undone;
+  if (!Array.isArray(found)) return [];
+  return found.filter((line): line is string => typeof line === "string");
+}
+
+/** Say what a write's answer accounts for, and hand the answer straight
+ *  back. Takes the whole result, so a refusal says nothing and a landed
+ *  write is read wherever it keeps its account.
+ *
+ *  This is the announcement riding on the write. The alternative — a call
+ *  beside each command — is a rule every new mutation has to remember, and
+ *  the module this serves records that rule being forgotten for a whole
+ *  round with one of five paths wired. */
+export function saying<T>(answer: T): T {
+  const it = answer as { status?: unknown; data?: unknown };
+  if (typeof it === "object" && it !== null && it.status === "ok") {
+    sayUndone(accountIn(it.data));
+  }
+  return answer;
 }

--- a/ui/src/lib/undone.ts
+++ b/ui/src/lib/undone.ts
@@ -1,0 +1,11 @@
+// What a removal did about the repository the packages leaving with it had
+// armed. The lines are Rust's, the same ones the terminal prints, so the
+// window and the terminal say one thing about one repository — this side
+// only puts them on the screen.
+import { toast } from "sonner";
+
+/** Show a removal's account, one line at a time. Silent when the removal
+ *  took no declaring package away, which is almost every removal. */
+export function sayUndone(undone: string[] | undefined) {
+  for (const line of undone ?? []) toast.message(line);
+}

--- a/ui/src/stores/audit-items.ts
+++ b/ui/src/stores/audit-items.ts
@@ -8,6 +8,7 @@ import {
 } from "@/bindings";
 import { adoptedToastLabel } from "@/lib/copy";
 import { replacedToastLabel } from "@/lib/copy-in-the-way";
+import { sayUndone } from "@/lib/undone";
 import { replaceView } from "./audit-fold";
 import { type ErrorAction, useProblemsStore } from "./problems";
 import { useScanStore } from "./scan";
@@ -101,6 +102,11 @@ export function auditRunner(
         error: null,
       });
       if (opts.successMessage) toast.success(opts.successMessage);
+      // What the removal ran in the repository, said whatever the action
+      // was called: every command here answers with the same view.
+      sayUndone(response.data.undone);
+      // What the removal ran in the repository, said whatever the action
+      // was called: every command here answers with the same view.
       await useScanStore.getState().refresh();
       return true;
     }

--- a/ui/src/stores/audit-items.ts
+++ b/ui/src/stores/audit-items.ts
@@ -105,8 +105,6 @@ export function auditRunner(
       // What the removal ran in the repository, said whatever the action
       // was called: every command here answers with the same view.
       sayUndone(response.data.undone);
-      // What the removal ran in the repository, said whatever the action
-      // was called: every command here answers with the same view.
       await useScanStore.getState().refresh();
       return true;
     }

--- a/ui/src/stores/audit.test.ts
+++ b/ui/src/stores/audit.test.ts
@@ -17,7 +17,7 @@ vi.mock("@/bindings", () => ({
 }));
 
 vi.mock("sonner", () => ({
-  toast: { error: vi.fn(), success: vi.fn() },
+  toast: { error: vi.fn(), success: vi.fn(), message: vi.fn() },
 }));
 
 vi.mock("./scan", () => ({
@@ -298,6 +298,38 @@ describe("audit store run() actions", () => {
     await useAuditStore.getState().toggle(globalScope, "hook", "lint", false);
 
     expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  // Removing a package that armed the repository runs its uninstaller
+  // first, and what ran is the removal's own account — a removal that
+  // said nothing left people hunting for shims under `.git/hooks`.
+  it("says what the removal ran in the repository", async () => {
+    vi.mocked(commands.removeItem).mockResolvedValue({
+      status: "ok",
+      data: {
+        ...emptyView,
+        undone: [
+          "growth-guards: running scripts/install-git-hooks --uninstall",
+        ],
+      },
+    });
+
+    await useAuditStore.getState().removeItem(globalScope, "skill", "guards");
+
+    expect(toast.message).toHaveBeenCalledWith(
+      "growth-guards: running scripts/install-git-hooks --uninstall",
+    );
+  });
+
+  it("stays quiet when the removal had no repository effect to undo", async () => {
+    vi.mocked(commands.removeItem).mockResolvedValue({
+      status: "ok",
+      data: emptyView,
+    });
+
+    await useAuditStore.getState().removeItem(globalScope, "skill", "deploy");
+
+    expect(toast.message).not.toHaveBeenCalled();
   });
 
   it("a refused action surfaces as an error, never a silent success", async () => {

--- a/ui/src/stores/editor.test.ts
+++ b/ui/src/stores/editor.test.ts
@@ -1,3 +1,4 @@
+import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   AuditView_Serialize,
@@ -26,6 +27,9 @@ vi.mock("@/bindings", async (importOriginal) => ({
   },
 }));
 
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn(), message: vi.fn() },
+}));
 vi.mock("./audit", () => ({
   useAuditStore: { getState: () => ({ refresh: vi.fn() }) },
 }));
@@ -124,6 +128,56 @@ describe("editor store", () => {
       },
       null,
     );
+  });
+
+  /// A manifest saved with a package deleted out of it takes that package
+  /// away, so this route runs the leaving package's uninstaller like any
+  /// other removal — and the editor is the one write that does not go
+  /// through the update commands, so it says so itself.
+  it("says what a save that dropped a package ran in the repository", async () => {
+    vi.mocked(commands.getManifest).mockResolvedValue({
+      status: "ok",
+      data: { manifest: null, base: "b1" },
+    });
+    await useEditorStore.getState().load();
+    vi.mocked(commands.saveCustomize).mockResolvedValue({
+      status: "ok",
+      data: {
+        ...({} as AuditView_Serialize),
+        undone: [
+          "growth-guards: running scripts/install-git-hooks --uninstall",
+        ],
+      },
+    });
+    useEditorStore
+      .getState()
+      .edit((draft) => setInstruction(draft, "skill-instructions", "gh", "x"));
+
+    await useEditorStore.getState().save();
+
+    expect(toast.message).toHaveBeenCalledWith(
+      "growth-guards: running scripts/install-git-hooks --uninstall",
+    );
+  });
+
+  it("stays quiet when a save took no armed package away", async () => {
+    vi.mocked(toast.message).mockClear();
+    vi.mocked(commands.getManifest).mockResolvedValue({
+      status: "ok",
+      data: { manifest: null, base: "b1" },
+    });
+    await useEditorStore.getState().load();
+    vi.mocked(commands.saveCustomize).mockResolvedValue({
+      status: "ok",
+      data: {} as AuditView_Serialize,
+    });
+    useEditorStore
+      .getState()
+      .edit((draft) => setInstruction(draft, "skill-instructions", "gh", "x"));
+
+    await useEditorStore.getState().save();
+
+    expect(toast.message).not.toHaveBeenCalled();
   });
 
   /// The manifest is not the settings file: a settings change reconciles

--- a/ui/src/stores/editor.test.ts
+++ b/ui/src/stores/editor.test.ts
@@ -180,6 +180,57 @@ describe("editor store", () => {
     expect(toast.message).not.toHaveBeenCalled();
   });
 
+  /// A refusal is not always "nothing happened": the uninstaller of a
+  /// leaving package runs before the plan writes, so a save that refused
+  /// after that point left the repository disarmed. The reload notice on
+  /// its own would say the opposite.
+  it("says what a refused save had already undone", async () => {
+    vi.mocked(toast.message).mockClear();
+    vi.mocked(commands.getManifest).mockResolvedValue({
+      status: "ok",
+      data: { manifest: null, base: "b1" },
+    });
+    await useEditorStore.getState().load();
+    vi.mocked(commands.saveCustomize).mockResolvedValue({
+      status: "error",
+      error: {
+        kind: "stale",
+        undone: ["guards: running scripts/arm --uninstall"],
+      },
+    });
+    useEditorStore
+      .getState()
+      .edit((draft) => setInstruction(draft, "skill-instructions", "gh", "x"));
+
+    await useEditorStore.getState().save();
+
+    expect(useEditorStore.getState().stale).toBe(true);
+    expect(toast.message).toHaveBeenCalledWith(
+      "guards: running scripts/arm --uninstall",
+    );
+  });
+
+  it("stays quiet when a refused save had undone nothing", async () => {
+    vi.mocked(toast.message).mockClear();
+    vi.mocked(commands.getManifest).mockResolvedValue({
+      status: "ok",
+      data: { manifest: null, base: "b1" },
+    });
+    await useEditorStore.getState().load();
+    vi.mocked(commands.saveCustomize).mockResolvedValue({
+      status: "error",
+      error: { kind: "stale" },
+    });
+    useEditorStore
+      .getState()
+      .edit((draft) => setInstruction(draft, "skill-instructions", "gh", "x"));
+
+    await useEditorStore.getState().save();
+
+    expect(useEditorStore.getState().stale).toBe(true);
+    expect(toast.message).not.toHaveBeenCalled();
+  });
+
   /// The manifest is not the settings file: a settings change reconciles
   /// the scope against the manifest on disk, and sending the copy on
   /// screen back would rewrite a kendex.toml nobody touched.

--- a/ui/src/stores/editor.ts
+++ b/ui/src/stores/editor.ts
@@ -10,6 +10,7 @@ import { type Draft, emptyDraft } from "@/lib/editor-draft";
 
 import { everyPlace, sameScope } from "@/lib/scope";
 import { settingsDraft, withEdit } from "@/lib/settings-rows";
+import { saying } from "@/lib/undone";
 import { useAuditStore } from "./audit";
 import {
   mergedPlaces,
@@ -155,6 +156,11 @@ export const useEditorStore = create<EditorState>((set, get) => {
       return;
     }
     set({ error: null, stale: false });
+    // Saving a manifest with a package deleted out of it takes that package
+    // away, so this save owes the same account a removal does. Wired here
+    // rather than by the write the update commands share: the editor
+    // answers a refusal shape of its own and never goes through it.
+    saying(response);
     await load();
     // Forced: a save rewrote the manifest this scope renders from, so an
     // audit inside its freshness window would keep every score answering

--- a/ui/src/stores/editor.ts
+++ b/ui/src/stores/editor.ts
@@ -10,7 +10,7 @@ import { type Draft, emptyDraft } from "@/lib/editor-draft";
 
 import { everyPlace, sameScope } from "@/lib/scope";
 import { settingsDraft, withEdit } from "@/lib/settings-rows";
-import { saying } from "@/lib/undone";
+import { saying, sayUndone } from "@/lib/undone";
 import { useAuditStore } from "./audit";
 import {
   mergedPlaces,
@@ -150,16 +150,21 @@ export const useEditorStore = create<EditorState>((set, get) => {
       // rather than taking the person's edits on its own.
       if (response.error.kind === "stale") {
         set({ stale: true, error: null });
+        // A refusal is not always "nothing happened". The plan runs a
+        // leaving package's uninstaller before it writes, so a save that
+        // refused after that point left the repository disarmed — and the
+        // reload notice on its own would say the opposite.
+        sayUndone(response.error.undone);
       } else {
         set({ error: response.error.message, stale: false });
       }
       return;
     }
     set({ error: null, stale: false });
-    // Saving a manifest with a package deleted out of it takes that package
-    // away, so this save owes the same account a removal does. Wired here
-    // rather than by the write the update commands share: the editor
-    // answers a refusal shape of its own and never goes through it.
+    // Saving a manifest that takes a package away owes the same account a
+    // removal does. Wired here rather than by the write the update commands
+    // share: the editor answers a refusal shape of its own and never goes
+    // through it — which is also why the stale branch above says it too.
     saying(response);
     await load();
     // Forced: a save rewrote the manifest this scope renders from, so an

--- a/ui/src/stores/marketplaces-install.test.ts
+++ b/ui/src/stores/marketplaces-install.test.ts
@@ -2,6 +2,7 @@
 // the repository — and the store is where that question lives: queued
 // from the install's answer, asked one package at a time, and spent on
 // the answer it gets.
+import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { commands, type Disclosure, type Scope } from "@/bindings";
 import {
@@ -21,7 +22,7 @@ vi.mock("@/bindings", () => ({
   },
 }));
 vi.mock("sonner", () => ({
-  toast: { success: vi.fn(), info: vi.fn(), error: vi.fn() },
+  toast: { success: vi.fn(), info: vi.fn(), error: vi.fn(), message: vi.fn() },
 }));
 vi.mock("./audit", () => ({
   useAuditStore: { getState: () => ({ refresh: vi.fn() }) },
@@ -235,5 +236,37 @@ describe("answering", () => {
     expect(useMarketplacesStore.getState().pendingEffects?.queue).toEqual([
       disclosure("linter"),
     ]);
+  });
+});
+
+// An install plans the whole scope, so its plan can take a package away
+// as well as bring one — and a package that leaves has its uninstaller run
+// before its scripts go. That is not the second question the dialog asks;
+// it already happened, and the window says so.
+describe("what an install says about a package that left with it", () => {
+  const RAN = "growth-guards: running scripts/install-git-hooks --uninstall";
+
+  it("says what the install ran in the repository", async () => {
+    vi.mocked(commands.marketplaceInstall).mockResolvedValue({
+      status: "ok",
+      data: {
+        packages: [],
+        repoEffects: { shown: [], withheld: [] },
+        undone: [RAN],
+      },
+    });
+
+    await install();
+
+    expect(toast.message).toHaveBeenCalledWith(RAN);
+  });
+
+  it("stays quiet when the install took no armed package away", async () => {
+    vi.mocked(toast.message).mockClear();
+    vi.mocked(commands.marketplaceInstall).mockResolvedValue(installed([]));
+
+    await install();
+
+    expect(toast.message).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/stores/marketplaces-install.ts
+++ b/ui/src/stores/marketplaces-install.ts
@@ -19,6 +19,7 @@ import {
   repoEffectsWithheldToast,
 } from "@/lib/copy-repo-effects";
 import { rescanEverything } from "@/lib/rescan";
+import { sayUndone } from "@/lib/undone";
 import { catalogKey, subscription } from "./marketplaces-shared";
 import { useProblemsStore } from "./problems";
 
@@ -136,6 +137,10 @@ export function installActions(set: Set, get: Get): InstallActions {
           ? items[0].name
           : `${items.length} packages`;
       toast.success(`Installed ${what}`);
+      // An install can still take a package away — a manifest edited
+      // outside the window leaves one the plan drops — and what its
+      // uninstaller ran is said here, not asked about.
+      sayUndone(response.data.undone);
       for (const held of withheld) {
         toast.info(repoEffectsWithheldToast(held.name, held.reason));
       }

--- a/ui/src/stores/marketplaces-install.ts
+++ b/ui/src/stores/marketplaces-install.ts
@@ -137,9 +137,9 @@ export function installActions(set: Set, get: Get): InstallActions {
           ? items[0].name
           : `${items.length} packages`;
       toast.success(`Installed ${what}`);
-      // An install can still take a package away — a manifest edited
-      // outside the window leaves one the plan drops — and what its
-      // uninstaller ran is said here, not asked about.
+      // Whatever an install's plan took away, and what its uninstaller
+      // ran on the way out. Said, never asked about: the second question
+      // this dialog exists for is about arming, and this already happened.
       sayUndone(response.data.undone);
       for (const held of withheld) {
         toast.info(repoEffectsWithheldToast(held.name, held.reason));

--- a/ui/src/stores/marketplaces-sources.ts
+++ b/ui/src/stores/marketplaces-sources.ts
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import type { Scope } from "@/bindings";
 import { commands } from "@/bindings";
 import { rescanEverything } from "@/lib/rescan";
+import { sayUndone } from "@/lib/undone";
 import { dropCatalogCaches } from "./marketplaces-shared";
 
 /** What these actions need back from the store. */
@@ -22,6 +23,7 @@ export function sourceActions(set: Set, get: () => Sources) {
         toast.error(response.error);
         return;
       }
+      sayUndone(response.data.undone);
       // Turning a holder on or off changes which subscription a repository
       // page carries on as, so every derived read goes.
       dropCatalogCaches(set);

--- a/ui/src/stores/marketplaces-subscribed.test.ts
+++ b/ui/src/stores/marketplaces-subscribed.test.ts
@@ -1,3 +1,4 @@
+import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { commands, type DirectoryRow, type MarketplaceRow } from "@/bindings";
 import { READ_LANDED, READ_PENDING } from "@/lib/read-state";
@@ -147,6 +148,54 @@ describe("a Community row's Subscribed marker", () => {
     const live = subscribedKeys(useMarketplacesStore.getState().rows);
     // The snapshot still says subscribed; the live list outranks it.
     expect(rowSubscribed({ ...listed, subscribed: true }, live)).toBe(false);
+  });
+
+  // The one reason marketplace_unsubscribe stopped answering with nothing:
+  // a package leaving with its source may have armed this repository, and
+  // its uninstaller ran. Rust proves it produces the lines; this proves
+  // the window shows them.
+  it("says what the unsubscribe ran in the repository", async () => {
+    useMarketplacesStore.setState({
+      rows: [row("Acme/Kit", "acme/kit")],
+      read: READ_LANDED,
+    });
+    vi.mocked(commands.marketplaceUnsubscribe).mockResolvedValue({
+      status: "ok",
+      data: ["growth-guards: running scripts/install-git-hooks --uninstall"],
+    });
+    vi.mocked(commands.marketplacesOverview).mockResolvedValue({
+      status: "ok",
+      data: [],
+    });
+
+    await useMarketplacesStore
+      .getState()
+      .unsubscribe({ scope: "global" }, "kit", false, false);
+
+    expect(toast.message).toHaveBeenCalledWith(
+      "growth-guards: running scripts/install-git-hooks --uninstall",
+    );
+  });
+
+  it("stays quiet when the unsubscribe took no armed package away", async () => {
+    useMarketplacesStore.setState({
+      rows: [row("Acme/Kit", "acme/kit")],
+      read: READ_LANDED,
+    });
+    vi.mocked(commands.marketplaceUnsubscribe).mockResolvedValue({
+      status: "ok",
+      data: [],
+    });
+    vi.mocked(commands.marketplacesOverview).mockResolvedValue({
+      status: "ok",
+      data: [],
+    });
+
+    await useMarketplacesStore
+      .getState()
+      .unsubscribe({ scope: "global" }, "kit", false, false);
+
+    expect(toast.message).not.toHaveBeenCalled();
   });
 
   it("falls back to the snapshot only before the live list has loaded", () => {

--- a/ui/src/stores/marketplaces-subscribed.test.ts
+++ b/ui/src/stores/marketplaces-subscribed.test.ts
@@ -132,7 +132,7 @@ describe("a Community row's Subscribed marker", () => {
     });
     vi.mocked(commands.marketplaceUnsubscribe).mockResolvedValue({
       status: "ok",
-      data: null,
+      data: [],
     });
     vi.mocked(commands.marketplacesOverview).mockResolvedValue({
       status: "ok",

--- a/ui/src/stores/marketplaces-subscribed.test.ts
+++ b/ui/src/stores/marketplaces-subscribed.test.ts
@@ -90,6 +90,60 @@ describe("a Community row's Subscribed marker", () => {
     expect(listed.repoKey !== null && held.has(listed.repoKey)).toBe(true);
   });
 
+  // A subscribe plans the whole scope, so its plan can take a package away
+  // as well as bring one — a rendering the engine refuses drops that
+  // package whatever the planning options say. What its uninstaller ran is
+  // the subscribe's own account to give.
+  it("says what a subscribe ran in the repository", async () => {
+    vi.mocked(commands.marketplaceSubscribe).mockResolvedValue({
+      status: "ok",
+      data: {
+        name: "kit",
+        reference: "https://github.com/Acme/Kit.git",
+        rev: null,
+        lead: null,
+        notes: [],
+        undone: ["guards: running scripts/arm --uninstall"],
+      },
+    });
+    vi.mocked(commands.marketplacesOverview).mockResolvedValue({
+      status: "ok",
+      data: [],
+    });
+
+    await useMarketplacesStore
+      .getState()
+      .subscribe({ scope: "global" }, "https://github.com/Acme/Kit.git", null);
+
+    expect(toast.message).toHaveBeenCalledWith(
+      "guards: running scripts/arm --uninstall",
+    );
+  });
+
+  it("stays quiet when a subscribe took no armed package away", async () => {
+    vi.mocked(toast.message).mockClear();
+    vi.mocked(commands.marketplaceSubscribe).mockResolvedValue({
+      status: "ok",
+      data: {
+        name: "kit",
+        reference: "https://github.com/Acme/Kit.git",
+        rev: null,
+        lead: null,
+        notes: [],
+      },
+    });
+    vi.mocked(commands.marketplacesOverview).mockResolvedValue({
+      status: "ok",
+      data: [],
+    });
+
+    await useMarketplacesStore
+      .getState()
+      .subscribe({ scope: "global" }, "https://github.com/Acme/Kit.git", null);
+
+    expect(toast.message).not.toHaveBeenCalled();
+  });
+
   it("ignores path subscriptions, which are no repository", () => {
     expect(subscribedKeys([row("", null)]).size).toBe(0);
   });
@@ -133,7 +187,7 @@ describe("a Community row's Subscribed marker", () => {
     });
     vi.mocked(commands.marketplaceUnsubscribe).mockResolvedValue({
       status: "ok",
-      data: [],
+      data: {},
     });
     vi.mocked(commands.marketplacesOverview).mockResolvedValue({
       status: "ok",
@@ -161,7 +215,11 @@ describe("a Community row's Subscribed marker", () => {
     });
     vi.mocked(commands.marketplaceUnsubscribe).mockResolvedValue({
       status: "ok",
-      data: ["growth-guards: running scripts/install-git-hooks --uninstall"],
+      data: {
+        undone: [
+          "growth-guards: running scripts/install-git-hooks --uninstall",
+        ],
+      },
     });
     vi.mocked(commands.marketplacesOverview).mockResolvedValue({
       status: "ok",
@@ -184,7 +242,7 @@ describe("a Community row's Subscribed marker", () => {
     });
     vi.mocked(commands.marketplaceUnsubscribe).mockResolvedValue({
       status: "ok",
-      data: [],
+      data: {},
     });
     vi.mocked(commands.marketplacesOverview).mockResolvedValue({
       status: "ok",

--- a/ui/src/stores/marketplaces-toggle.test.ts
+++ b/ui/src/stores/marketplaces-toggle.test.ts
@@ -1,5 +1,6 @@
 // A bare repository page's action and what toggling its holder does to
 // the summaries that decide which subscription the page carries on as.
+import { toast } from "sonner";
 import { describe, expect, it, vi } from "vitest";
 import { commands, type MarketplaceRow } from "@/bindings";
 import { READ_LANDED, READ_PENDING, readFailed } from "@/lib/read-state";
@@ -89,6 +90,50 @@ describe("a bare repository page's action", () => {
     );
     expect(held?.enabled).toBe(false);
     expect(held?.name).toBe("kit");
+  });
+
+  // Turning a source off drops the packages it carried, so the toggle can
+  // run a departing package's uninstaller — and the window has to say so.
+  it("says what turning a source off ran in the repository", async () => {
+    vi.mocked(commands.sourceToggle).mockResolvedValue({
+      status: "ok",
+      data: {
+        sources: [],
+        undone: [
+          "growth-guards: running scripts/install-git-hooks --uninstall",
+        ],
+      },
+    });
+    vi.mocked(commands.marketplacesOverview).mockResolvedValue({
+      status: "ok",
+      data: [],
+    });
+
+    await useMarketplacesStore
+      .getState()
+      .toggle({ scope: "global" }, "kit", false);
+
+    expect(toast.message).toHaveBeenCalledWith(
+      "growth-guards: running scripts/install-git-hooks --uninstall",
+    );
+  });
+
+  it("stays quiet when the toggle took no armed package away", async () => {
+    vi.mocked(toast.message).mockClear();
+    vi.mocked(commands.sourceToggle).mockResolvedValue({
+      status: "ok",
+      data: { sources: [] },
+    });
+    vi.mocked(commands.marketplacesOverview).mockResolvedValue({
+      status: "ok",
+      data: [],
+    });
+
+    await useMarketplacesStore
+      .getState()
+      .toggle({ scope: "global" }, "kit", true);
+
+    expect(toast.message).not.toHaveBeenCalled();
   });
 
   it("stays neutral until the canonical key is known, then matches by it", () => {

--- a/ui/src/stores/marketplaces-toggle.test.ts
+++ b/ui/src/stores/marketplaces-toggle.test.ts
@@ -73,7 +73,7 @@ describe("a bare repository page's action", () => {
     // the live list is what says a (disabled) subscription still holds it.
     vi.mocked(commands.sourceToggle).mockResolvedValue({
       status: "ok",
-      data: [],
+      data: { sources: [] },
     });
     vi.mocked(commands.marketplacesOverview).mockResolvedValue({
       status: "ok",
@@ -170,7 +170,7 @@ describe("a repository page carried on as a subscription", () => {
     });
     vi.mocked(commands.sourceToggle).mockResolvedValue({
       status: "ok",
-      data: [],
+      data: { sources: [] },
     });
     vi.mocked(commands.marketplacesOverview).mockResolvedValue({
       status: "ok",
@@ -206,7 +206,7 @@ describe("a repository page carried on as a subscription", () => {
     });
     vi.mocked(commands.sourceToggle).mockResolvedValue({
       status: "ok",
-      data: [],
+      data: { sources: [] },
     });
     vi.mocked(commands.marketplacesOverview).mockResolvedValue({
       status: "ok",
@@ -240,7 +240,7 @@ describe("a repository page carried on as a subscription", () => {
     });
     vi.mocked(commands.sourceToggle).mockResolvedValue({
       status: "ok",
-      data: [],
+      data: { sources: [] },
     });
     vi.mocked(commands.marketplacesOverview).mockResolvedValue({
       status: "ok",

--- a/ui/src/stores/marketplaces.ts
+++ b/ui/src/stores/marketplaces.ts
@@ -127,6 +127,7 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
     set({ error: null });
     toast.success(`Subscribed to '${response.data.name}'`);
     for (const note of response.data.notes) toast.message(note);
+    sayUndone(response.data.undone);
     // A repository page may now have a subscription to carry on as, under
     // whatever spelling the dialog was submitted with; the dropped summaries
     // re-read and the page picks it up.

--- a/ui/src/stores/marketplaces.ts
+++ b/ui/src/stores/marketplaces.ts
@@ -18,7 +18,7 @@ import {
 } from "@/lib/read-state";
 import { rescanEverything } from "@/lib/rescan";
 import { settled } from "@/lib/settled";
-import { sayUndone } from "@/lib/undone";
+import { saying, sayUndone } from "@/lib/undone";
 import { catalogReads } from "./marketplaces-catalog-reads";
 import { type InstallActions, installActions } from "./marketplaces-install";
 import { dropCatalogCaches, openLead } from "./marketplaces-shared";
@@ -162,7 +162,7 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
         ? `Unsubscribed from '${source}' — its packages are yours now`
         : `Unsubscribed from '${source}'`,
     );
-    sayUndone(response.data);
+    saying(response);
     // A page carried on as this subscription must stop pointing at it, and
     // every other derived read goes with it.
     dropCatalogCaches(set);

--- a/ui/src/stores/marketplaces.ts
+++ b/ui/src/stores/marketplaces.ts
@@ -18,6 +18,7 @@ import {
 } from "@/lib/read-state";
 import { rescanEverything } from "@/lib/rescan";
 import { settled } from "@/lib/settled";
+import { sayUndone } from "@/lib/undone";
 import { catalogReads } from "./marketplaces-catalog-reads";
 import { type InstallActions, installActions } from "./marketplaces-install";
 import { dropCatalogCaches, openLead } from "./marketplaces-shared";
@@ -160,6 +161,7 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
         ? `Unsubscribed from '${source}' — its packages are yours now`
         : `Unsubscribed from '${source}'`,
     );
+    sayUndone(response.data);
     // A page carried on as this subscription must stop pointing at it, and
     // every other derived read goes with it.
     dropCatalogCaches(set);

--- a/ui/src/stores/updates-apply.ts
+++ b/ui/src/stores/updates-apply.ts
@@ -15,6 +15,7 @@ import {
 } from "@/bindings";
 import { unansweredPackageError } from "@/lib/copy-updates";
 import { scopeKey } from "@/lib/scope";
+import { sayUndone } from "@/lib/undone";
 import { type BulkOutcome, outcomeOf } from "@/lib/update-outcome";
 
 type Report = (error: string) => void;
@@ -50,6 +51,7 @@ export const applyRow = async (
     report(response.error);
     return { ok: false };
   }
+  sayUndone(response.data.view.undone);
   return { ok: true, update: response.data };
 };
 
@@ -111,6 +113,7 @@ export const applyRows = async (
       outcome.ok = false;
       continue;
     }
+    sayUndone(response.data.view.undone);
     const answered = new Map(
       response.data.packages.map((one) => [targetKey(one), one]),
     );

--- a/ui/src/stores/updates-commit-order.test.ts
+++ b/ui/src/stores/updates-commit-order.test.ts
@@ -11,16 +11,21 @@
 // One case per path that can commit, because the announcement is the thing
 // that can be forgotten: it was, for a whole round, with four of five
 // paths unwired behind a return message that said otherwise.
+import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { commands, type UpdateRow } from "@/bindings";
 import { updateRow } from "@/components/updates-test-rows";
 import { ADOPTABLE } from "@/lib/adoptable";
 import { READ_LANDED } from "@/lib/read-state";
+import { startBulk } from "@/lib/update-outcome";
 import { useUpdatesStore } from "./updates";
 import {
   writeDiscardEdits,
   writeFork,
   writeForkBeside,
+  writeRev,
+  writeRow,
+  writeRows,
   writeUpdate,
 } from "./updates-writes";
 
@@ -42,7 +47,7 @@ vi.mock("@/bindings", async (importOriginal) => ({
 }));
 
 vi.mock("sonner", () => ({
-  toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
+  toast: { error: vi.fn(), success: vi.fn(), info: vi.fn(), message: vi.fn() },
 }));
 
 /** The scope's view a single-package apply answers with; nothing here reads
@@ -289,5 +294,83 @@ describe("a write that answered with an error", () => {
 
     expect(commands.updatesOverview).toHaveBeenCalled();
     expect(useUpdatesStore.getState().rows).toEqual(after);
+  });
+});
+
+// A write that took a package away may have run its uninstaller in the
+// person's repository, and that is the write's own account to give. Wired
+// the way the commit announcement above is — on the write rather than
+// beside each command — for the reason this module's header records: a
+// rule each new mutation has to remember is one that gets forgotten.
+describe("what a write says about the repository it changed", () => {
+  const RAN = "growth-guards: running scripts/install-git-hooks --uninstall";
+
+  /** A single-package answer carrying an account on the standing it nests. */
+  const update = (undone: string[]) => ({
+    status: "ok" as const,
+    data: {
+      view: { ...VIEW, undone },
+      heldBack: [],
+      removed: [],
+      moved: [],
+    },
+  });
+
+  it("says it whichever of the five write commands took the package", async () => {
+    for (const [start, mock] of [
+      [() => writeUpdate(GLOBAL, "skill", "gh"), commands.packageUpdate],
+      [() => writeRev(GLOBAL, "skill", "gh", "c0"), commands.packageSetRev],
+      [() => writeFork(GLOBAL, "skill", "gh", "claude"), commands.packageFork],
+      [
+        () => writeDiscardEdits(GLOBAL, "skill", "gh", null),
+        commands.applyDiscardEdits,
+      ],
+      [
+        () => writeForkBeside(GLOBAL, "skill", "gh", "claude", "mine", null),
+        commands.packageForkBeside,
+      ],
+    ] as [() => Promise<unknown>, () => unknown][]) {
+      vi.mocked(toast.message).mockClear();
+      // biome-ignore lint/suspicious/noExplicitAny: one shape per command
+      vi.mocked(mock as any).mockResolvedValue(update([RAN]));
+
+      await start();
+
+      expect(toast.message).toHaveBeenCalledWith(RAN);
+    }
+  });
+
+  it("stays quiet when the write took no armed package away", async () => {
+    vi.mocked(toast.message).mockClear();
+    vi.mocked(commands.packageUpdate).mockResolvedValue(update([]));
+
+    await writeUpdate(GLOBAL, "skill", "gh");
+
+    expect(toast.message).not.toHaveBeenCalled();
+  });
+
+  // The batched apply is one plan for a whole place, so its account covers
+  // every package that left with it and is said once.
+  it("says it on the batched apply", async () => {
+    vi.mocked(toast.message).mockClear();
+    vi.mocked(commands.packageUpdateMany).mockResolvedValue({
+      status: "ok",
+      data: { view: { ...VIEW, undone: [RAN] }, packages: [] },
+    });
+
+    await writeRows([row()], () => {}, startBulk(0));
+
+    expect(toast.message).toHaveBeenCalledWith(RAN);
+  });
+
+  // The per-row apply is the other way `package_update` is reached, and it
+  // answers through its own outcome rather than through the write's shape.
+  it("says it on the per-row apply too", async () => {
+    vi.mocked(toast.message).mockClear();
+    vi.mocked(commands.packageUpdate).mockResolvedValue(update([RAN]));
+
+    await writeRow(row(), () => {});
+
+    expect(toast.message).toHaveBeenCalledWith(RAN);
   });
 });

--- a/ui/src/stores/updates-writes.ts
+++ b/ui/src/stores/updates-writes.ts
@@ -18,6 +18,7 @@ import {
   type UpdateRow,
 } from "@/bindings";
 import { invalidations } from "@/lib/read-state";
+import { saying } from "@/lib/undone";
 import type { BulkOutcome } from "@/lib/update-outcome";
 import { type ApplyOutcome, applyRow, applyRows } from "./updates-apply";
 
@@ -34,7 +35,12 @@ export const commits = invalidations();
  *  lets a stale report overwrite a commit. */
 const committing = async <T>(work: Promise<T>): Promise<T> => {
   try {
-    return await work;
+    // Said on the write for the same reason the commit is announced on it:
+    // a removal that ran an uninstaller in somebody's repository has to be
+    // reported by whatever command took the package away, and a rule each
+    // new mutation remembers is the rule this module already watched get
+    // forgotten. A write whose answer carries no account says nothing.
+    return saying(await work);
   } finally {
     commits.moved();
   }


### PR DESCRIPTION
Removing a package from the desktop ran `apply::execute` on the bare plan and dropped the report, so a leaving package's scripts went while the shims it had installed under `.git/hooks` stayed — and every commit in that repository failed closed until somebody found the files by hand. The terminal had run the declared uninstaller since it was declarable; the window dropped the report that names it.

The window now mirrors the terminal rather than refusing and pointing at it: removing the package is the ask. The loop that decides what to run moved into `crates/core/src/repo_effects/undo.rs`, so both surfaces give one account of one repository and the CLI's `undo` becomes a channel adapter over it, keeping its exact wording. `crates/app/src/repo_effects.rs::execute` is the one way a desktop command writes a report, and every report-executing path routes through it. What ran comes back on the action's result and reaches the person as toasts. An uninstaller that fails stops the plan with the files still in place.

## Commits

| SHA | What |
|---|---|
| `c6533f11c` | One executor, every path routed through it, the rule held by a source-scan fixture |
| `834b26131` | Review round 1 — guard reads statements, announcement sites asserted, fixture leak fixed |
| `c4903b20f` | Review round 2 — refusals carry the account, the cap keeps kendex's own lines |

## What review changed

Fourteen reviewer passes across two rounds (nine reviewers, then five scoped to the fix diff) produced 18 fixes and 7 declines. The three that mattered:

**A refusal could disarm a repository silently.** `execute` runs the uninstaller first, then `apply::execute`. Reviewers initially read the editor's save path as safe because it plans with `PlanOptions::default()` — and that premise is false. `plan_pass::plan_refusals` re-inserts a refused item's lock entry only on the `edit_holds` arm, so a refused rendering drops the entry whatever `remove_orphans` says. A reviewer proved it with a probe: control `undone = []`; with a `SKILL.md.disabled` beside its `SKILL.md`, `undone = ["guards: running scripts/arm --uninstall", "guards: disarmed"]` and the tree gone. `WriteRefused::Stale` was a unit variant, so those lines were discarded and the window said only "the file changed, reload" — KEN-709's own end state, reached from the other direction. `Stale` now carries the account, and two tests hold it: one reproducing the probe, one driving the real executor against a real moved precondition.

**The guard was failing open.** `crates/app/tests/one_executor.rs` is the only guard for eight of the ten rerouted paths, and it matched `apply::execute(` and `.plan` on one physical line. A two-statement bound local, rustfmt-stable, walked past it — mutation killed 0/1. It now blanks comments, strings, raw strings and char literals, cuts statements at their own closing semicolon, requires `.plan` at a word boundary, and scopes locals per function. All three shapes kill 1/1 on the real source, and the parser itself carries a must-fail control per capability.

**A test corrupted the developer's own index.** A new helper cleared `GIT_DIR` but not `GIT_WORK_TREE` or `GIT_INDEX_FILE`. A pre-commit hook exports all three at the repository being committed to, so the helper's `git commit -a` wrote its fixture's index over the real one — invisible to a standalone `cargo test`, because only a hook sets `GIT_INDEX_FILE`. Left in the tree it would have hit every developer on their next commit.

## Known limits

- **Git config isolation is partial.** `git()` and `commit()` now point `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` at an empty file (14 red → 14 green under a global `commit.gpgsign`). The installer kendex spawns is not covered: reaching it needs the variables on the process, and `std::env::set_var` requires `unsafe`, which the workspace forbids. A maintainer with a configured `core.hooksPath` still sees the arming cases stand down. Documented at the helper.
- **The scan keys on `apply::execute(` as literal text.** An unqualified `use kendex_core::apply::execute;` followed by a bare `execute(...)` passes unseen. Nothing in `crates/app/src` or `crates/cli/src` imports that way and module-path style is the house convention, so evading it takes a deliberate import. Named in the module doc.
- **The editor's save removes nothing today** via the orphan door, pinned by a test asserting both the empty account and that the package's files remain — so it reds if that route ever starts removing.

## Size

39 files, +2909/−393. About 80% is test code. The figure is inflated by a forced split: `crates/app/tests/repo_effects.rs` crossed the 800-line test ratchet and split into `repo_effects/fixture.rs` and `repo_effects_escaping.rs` rather than taking a baseline row, and a diffstat counts a moved line twice — 302 of the added test lines are relocation, confined to those three files.

Closes KEN-709
