### PR TITLE
fix(KEN-928): kendex.toml keeps what you wrote through every write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2318,6 +2318,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.20",
  "toml 1.1.4+spec-1.1.0",
+ "toml_edit 0.25.13+spec-1.1.0",
  "unicode-normalization",
  "url",
  "yaml-rust2",
@@ -4761,6 +4762,7 @@ dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
+ "toml_writer",
  "winnow 1.0.4",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ kendex-core = { path = "crates/core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 toml = "1.1"
-# The format-preserving half of the same parser: kendex.toml is the one
-# file in the product the person writes by hand, so a write folds the
-# changed keys into their document instead of re-serializing over it.
+# The format-preserving half of the same parser: kendex.toml is written by
+# hand, so a write folds the changed keys into that document instead of
+# re-serializing over it.
 toml_edit = "0.25"
 dirs = "6"
 thiserror = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ kendex-core = { path = "crates/core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 toml = "1.1"
+# The format-preserving half of the same parser: kendex.toml is the one
+# file in the product the person writes by hand, so a write folds the
+# changed keys into their document instead of re-serializing over it.
+toml_edit = "0.25"
 dirs = "6"
 thiserror = "2"
 clap = { version = "4.6", features = ["derive"] }

--- a/changelog.d/fixed/KEN-928.md
+++ b/changelog.d/fixed/KEN-928.md
@@ -1,1 +1,1 @@
-- `kendex.toml` is edited in place. Adding, forking, adopting and detaching change only the keys they name, so the comments, blank lines and key order you wrote stay where you put them.
+- `kendex.toml` is edited in place. Adding, forking, adopting and detaching change the keys they name, so the comments, blank lines and key order you wrote stay where you put them.

--- a/changelog.d/fixed/KEN-928.md
+++ b/changelog.d/fixed/KEN-928.md
@@ -1,0 +1,1 @@
+- `kendex.toml` is edited in place. Adding, forking, adopting and detaching now change only the keys they name, so your comments, blank lines and key order survive every write.

--- a/changelog.d/fixed/KEN-928.md
+++ b/changelog.d/fixed/KEN-928.md
@@ -1,1 +1,1 @@
-- `kendex.toml` is edited in place. Adding, forking, adopting and detaching change the keys they name, so the comments, blank lines and key order you wrote stay where you put them.
+- `kendex.toml` is edited in place. Adding, forking, adopting and detaching change only the keys they name, so the comments, blank lines and key order you wrote stay where you put them.

--- a/changelog.d/fixed/KEN-928.md
+++ b/changelog.d/fixed/KEN-928.md
@@ -1,1 +1,1 @@
-- `kendex.toml` is edited in place. Adding, forking, adopting and detaching now change only the keys they name, so your comments, blank lines and key order survive every write.
+- `kendex.toml` is edited in place. Adding, forking, adopting and detaching change the keys they name, so the comments, blank lines and key order you wrote stay where you put them.

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 toml.workspace = true
+toml_edit.workspace = true
 dirs.workspace = true
 thiserror.workspace = true
 specta.workspace = true

--- a/crates/core/src/engine/scope_writes.rs
+++ b/crates/core/src/engine/scope_writes.rs
@@ -38,11 +38,11 @@ pub(super) fn manifest_pre(base: Option<&Base>, path: &Path) -> Result<Pre> {
 }
 
 /// The plan's one manifest write, when anything needs it: skills an agent
-/// gained upstream. Nothing else rewrites the file — only the current
+/// gained upstream. Nothing else asks for the file — only the current
 /// schema loads, so there is no upgrade to plan, and a pass that wrote the
-/// manifest for its own sake would take the person's comments with it. One
-/// write whatever put it there: a second manifest write could never run,
-/// its precondition binds to the bytes the first one replaces.
+/// manifest for its own sake would put a write in the plan that changes
+/// nothing. One write whatever put it there: a second manifest write could
+/// never run, its precondition binds to the bytes the first one replaces.
 pub(super) fn plan_manifest_write(
     env: &Env,
     scope: &Scope,

--- a/crates/core/src/engine/scope_writes.rs
+++ b/crates/core/src/engine/scope_writes.rs
@@ -39,12 +39,11 @@ pub(super) fn manifest_pre(base: Option<&Base>, path: &Path) -> Result<Pre> {
 
 /// The plan's one manifest write, when anything needs it: skills an agent
 /// gained upstream. Nothing else asks for the file — only the current
-/// schema loads, so there is no upgrade to plan, and a pass that wrote the
-/// manifest for its own sake would stamp the serializer's declaration
-/// defaults into a file that leaves them out, on a pass nobody asked to
-/// change anything. One write whatever put it there: a second manifest
-/// write could never run, its precondition binds to the bytes the first
-/// one replaces.
+/// schema loads, so there is no upgrade to plan, and a write planned for
+/// its own sake would put a precondition and a plan line in front of the
+/// person for a write that lands nothing. One write whatever put it
+/// there: a second manifest write could never run, its precondition binds
+/// to the bytes the first one replaces.
 pub(super) fn plan_manifest_write(
     env: &Env,
     scope: &Scope,

--- a/crates/core/src/engine/scope_writes.rs
+++ b/crates/core/src/engine/scope_writes.rs
@@ -40,9 +40,11 @@ pub(super) fn manifest_pre(base: Option<&Base>, path: &Path) -> Result<Pre> {
 /// The plan's one manifest write, when anything needs it: skills an agent
 /// gained upstream. Nothing else asks for the file — only the current
 /// schema loads, so there is no upgrade to plan, and a pass that wrote the
-/// manifest for its own sake would put a write in the plan that changes
-/// nothing. One write whatever put it there: a second manifest write could
-/// never run, its precondition binds to the bytes the first one replaces.
+/// manifest for its own sake would stamp the serializer's declaration
+/// defaults into a file that leaves them out, on a pass nobody asked to
+/// change anything. One write whatever put it there: a second manifest
+/// write could never run, its precondition binds to the bytes the first
+/// one replaces.
 pub(super) fn plan_manifest_write(
     env: &Env,
     scope: &Scope,

--- a/crates/core/src/manifest/edit.rs
+++ b/crates/core/src/manifest/edit.rs
@@ -24,11 +24,19 @@
 //! thing, and the walk dispatches on the destination, so neither is
 //! rewritten into the other.
 //!
-//! List entries are paired by what they are, not by where they sit. A
-//! comment above a hook describes that hook, so removing or reordering
-//! hooks has to carry each comment with its own entry.
+//! List entries are paired by what an entry is — a hook by its name, a
+//! scalar by its own value — and by where it sits only for an entry
+//! nothing identifies. What somebody wrote about an entry then travels
+//! with that entry through a removal or a re-sort, rather than staying at
+//! the place it was stored. Which bytes those are is [`layout`]'s
+//! arithmetic: TOML keeps a comment written after a value against the
+//! value below it, so entry and annotation are one apart in the file and
+//! have to be put back together before anything moves.
 
-use toml_edit::{Array, ArrayOfTables, DocumentMut, Item, Table, TableLike, Value};
+use toml_edit::{ArrayOfTables, DocumentMut, Item, Table, TableLike, Value};
+
+mod layout;
+use layout::{brace_run, rebuilt_array, reseat_brace};
 
 /// The text a write should leave behind.
 ///
@@ -85,13 +93,17 @@ fn merge_table(
 /// scalar that already says the right thing is left with its own bytes,
 /// and everything above it is a no-op when nothing under it changed.
 fn merge_item(destination: &mut Item, held: Option<&Item>, target: &Item) {
-    if let Some(wanted) = target.as_table_like()
-        && let Some(item) = destination.as_table_like_mut()
-    {
-        merge_table(item, held.and_then(Item::as_table_like), wanted);
+    if target.as_table_like().is_some() && destination.as_table_like().is_some() {
+        let brace = brace_run(destination);
+        if let Some(wanted) = target.as_table_like()
+            && let Some(item) = destination.as_table_like_mut()
+        {
+            merge_table(item, held.and_then(Item::as_table_like), wanted);
+        }
+        reseat_brace(destination, brace);
         return;
     }
-    if entries(target).is_some() && merge_entries(destination, held, target) {
+    if merge_entries(destination, held, target) {
         return;
     }
     if let (Item::Value(item), Item::Value(wanted)) = (&mut *destination, target) {
@@ -121,35 +133,28 @@ fn merge_entries(destination: &mut Item, held: Option<&Item>, target: &Item) -> 
         return false;
     };
     let held = held.and_then(entries).unwrap_or_default();
-    let merged: Vec<Item> = wanted
+    // Each merged entry keeps the destination place it continues, so the
+    // rebuild can hand it back the writing that was written about it.
+    let merged: Vec<(Option<usize>, Item)> = wanted
         .iter()
         .zip(paired(&standing, &wanted))
         .map(|(wanted, at)| match at {
             Some(at) => {
                 let mut entry = standing[at].clone();
                 merge_item(&mut entry, held.get(at), wanted);
-                entry
+                (Some(at), entry)
             }
-            None => gained(wanted),
+            None => (None, fresh(wanted)),
         })
         .collect();
     match destination {
         Item::ArrayOfTables(tables) => *tables = rebuilt_tables(merged),
         Item::Value(Value::Array(array)) => *array = rebuilt_array(array, merged),
-        _ => return false,
+        // `entries` answered for this item one statement ago, and it
+        // admits exactly the two spellings above.
+        other => unreachable!("a list is a table array or an array, not {other:?}"),
     }
     true
-}
-
-/// An entry the list did not have. It takes the default spacing rather
-/// than the serializer's, because it has no place in the destination's
-/// layout to inherit and the encoder lays out what it is not told about.
-fn gained(target: &Item) -> Item {
-    let mut entry = fresh(target);
-    if let Item::Value(value) = &mut entry {
-        value.decor_mut().clear();
-    }
-    entry
 }
 
 /// Which destination entry each target entry continues, by identity first
@@ -160,11 +165,11 @@ fn paired(standing: &[Item], target: &[Item]) -> Vec<Option<usize>> {
     let mut taken = vec![false; standing.len()];
     let mut pairing = vec![None; target.len()];
     for (index, wanted) in target.iter().enumerate() {
-        let Some(name) = wanted.as_table_like().and_then(identity) else {
+        let Some(name) = identity(wanted) else {
             continue;
         };
         for (at, entry) in standing.iter().enumerate() {
-            if taken[at] || entry.as_table_like().and_then(identity) != Some(name.clone()) {
+            if taken[at] || identity(entry).as_ref() != Some(&name) {
                 continue;
             }
             pairing[index] = Some(at);
@@ -181,17 +186,36 @@ fn paired(standing: &[Item], target: &[Item]) -> Vec<Option<usize>> {
     pairing
 }
 
-/// What makes one entry of a list the same entry across a write.
-/// `[[custom-hooks]]` is the only list of tables a manifest holds, and
-/// `name` is the identity it documents; an entry written by hand before an
-/// editor save stamped one is placed by what it runs instead.
-fn identity(entry: &dyn TableLike) -> Option<String> {
-    if let Some(name) = text(entry, "name") {
-        return Some(format!("name {name}"));
+/// What makes one entry of a list the same entry across a write. Every
+/// entry a manifest list can hold answers here, because the decoration the
+/// merge carries from entry to entry is the person's writing about that
+/// entry: a comment above a harness names that harness, and a comment
+/// above a hook describes that hook.
+///
+/// A scalar is its own identity, so a list that lost an element or was
+/// re-sorted — `Manifest::suppress` sorts on every removal — moves each
+/// annotation with the value it was written against. A table is its
+/// `name`, the identity `[[custom-hooks]]` documents, or what it runs for
+/// an entry written by hand before an editor save stamped one. Duplicates
+/// pair first-unclaimed, which the caller's `taken` sweep already decides.
+fn identity(entry: &Item) -> Option<String> {
+    if let Some(table) = entry.as_table_like() {
+        if let Some(name) = text(table, "name") {
+            return Some(format!("named {name}"));
+        }
+        return match (text(table, "event"), text(table, "command")) {
+            (Some(event), Some(command)) => Some(format!("runs {event}\u{1f}{command}")),
+            _ => None,
+        };
     }
-    match (text(entry, "event"), text(entry, "command")) {
-        (Some(event), Some(command)) => Some(format!("runs {event}\u{1f}{command}")),
-        _ => None,
+    match entry.as_value()? {
+        Value::String(value) => Some(format!("text {}", value.value())),
+        Value::Integer(value) => Some(format!("whole {}", value.value())),
+        Value::Boolean(value) => Some(format!("flag {}", value.value())),
+        // A float has no spelling that compares safely, and a datetime and
+        // an array are not shapes a manifest list holds. Nothing
+        // identifies them, so they pair by position, as they did before.
+        Value::Float(_) | Value::Datetime(_) | Value::Array(_) | Value::InlineTable(_) => None,
     }
 }
 
@@ -207,10 +231,14 @@ fn text(entry: &dyn TableLike, key: &str) -> Option<String> {
 /// entries that changed places have to change positions with them or the
 /// file would come back in the old order; the places are the survivors'
 /// own, so nothing moves past a table that is not part of this list.
-fn rebuilt_tables(merged: Vec<Item>) -> ArrayOfTables {
+fn rebuilt_tables(merged: Vec<(Option<usize>, Item)>) -> ArrayOfTables {
     let mut tables: Vec<Table> = merged
         .into_iter()
-        .filter_map(|entry| entry.into_table().ok())
+        .map(|(_, entry)| {
+            entry
+                .into_table()
+                .unwrap_or_else(|other| unreachable!("a table array holds tables, not {other:?}"))
+        })
         .collect();
     let mut places: Vec<isize> = tables.iter().filter_map(Table::position).collect();
     places.sort_unstable();
@@ -223,24 +251,6 @@ fn rebuilt_tables(merged: Vec<Item>) -> ArrayOfTables {
     let mut rebuilt = ArrayOfTables::new();
     for table in tables {
         rebuilt.push(table);
-    }
-    rebuilt
-}
-
-/// The merged entries as an inline array. A surviving entry keeps the
-/// decoration it was written with, so a multi-line array stays multi-line
-/// and the comments inside it stay where they are; a gained one takes the
-/// default spacing, because it has no place in that layout to inherit.
-fn rebuilt_array(destination: &Array, merged: Vec<Item>) -> Array {
-    let mut rebuilt = Array::new();
-    rebuilt.set_trailing_comma(destination.trailing_comma());
-    rebuilt.set_trailing(destination.trailing().clone());
-    *rebuilt.decor_mut() = destination.decor().clone();
-    for entry in merged {
-        let Ok(value) = entry.into_value() else {
-            continue;
-        };
-        rebuilt.push_formatted(value);
     }
     rebuilt
 }

--- a/crates/core/src/manifest/edit.rs
+++ b/crates/core/src/manifest/edit.rs
@@ -30,7 +30,9 @@
 //! travels with that entry through a removal or a re-sort. The positional
 //! half is what keeps an edit an edit rather than a drop and an append,
 //! and it has a price: an entry paired that way inherits what was written
-//! about whatever stood in its slot.
+//! about whatever stood in its slot, which
+//! `tests::a_value_paired_by_position_keeps_the_note_written_in_its_slot`
+//! holds to.
 //!
 //! Where those bytes are is not where they look. An array of values keeps
 //! them in [`layout`]'s four places, an entry and its annotation always
@@ -207,7 +209,10 @@ fn paired(standing: &[Item], target: &[Item]) -> Vec<Option<usize>> {
 /// a value edited in place is a different value. It pairs by position, so
 /// it lands on the slot it replaced and keeps the note written there —
 /// which is what makes an edit an edit, and what makes `"Write", # no
-/// writing files` read `"WebFetch", # no writing files` afterwards.
+/// writing files` read `"WebFetch", # no writing files` afterwards. Both
+/// halves of that are asserted in
+/// `tests::a_value_paired_by_position_keeps_the_note_written_in_its_slot`,
+/// so the trade is a fixture rather than a sentence.
 fn identity(entry: &Item) -> Option<String> {
     if let Some(table) = entry.as_table_like() {
         if let Some(name) = text(table, "name") {

--- a/crates/core/src/manifest/edit.rs
+++ b/crates/core/src/manifest/edit.rs
@@ -24,9 +24,10 @@
 //! thing, and the walk dispatches on the destination, so neither is
 //! rewritten into the other.
 //!
-//! List entries are paired by what an entry is — a hook by its name, a
-//! scalar by its own value — and what identity could not place takes the
-//! slot it sat in, where identity has not already claimed that slot. What
+//! List entries are paired by what an entry is — a hook by its name, or
+//! by what it runs where only one side has been named, and a scalar by
+//! its own value — and what identity could not place takes the slot it
+//! sat in, where identity has not already claimed that slot. What
 //! somebody wrote about an entry then travels with that entry through a
 //! removal or a re-sort. The positional half is what keeps an edit an
 //! edit rather than a drop and an append, and it has a price: an entry
@@ -166,24 +167,32 @@ fn merge_entries(destination: &mut Item, held: Option<&Item>, target: &Item) -> 
     true
 }
 
-/// Which destination entry each target entry continues, by identity first
-/// and by position for whatever identity could not place. An entry that
-/// pairs with nothing is gained; a destination entry nothing pairs with is
-/// dropped, and the comment written above it goes with it.
+/// Which destination entry each target entry continues: by identity, one
+/// key at a time from the strongest, and by position for whatever no key
+/// could place. An entry that pairs with nothing is gained; a destination
+/// entry nothing pairs with is dropped, and the comment written above it
+/// goes with it.
 fn paired(standing: &[Item], target: &[Item]) -> Vec<Option<usize>> {
+    let standing_keys: Vec<Identity> = standing.iter().map(identity).collect();
+    let target_keys: Vec<Identity> = target.iter().map(identity).collect();
     let mut taken = vec![false; standing.len()];
     let mut pairing = vec![None; target.len()];
-    for (index, wanted) in target.iter().enumerate() {
-        let Some(name) = identity(wanted) else {
-            continue;
-        };
-        for (at, entry) in standing.iter().enumerate() {
-            if taken[at] || identity(entry).as_ref() != Some(&name) {
+    // A rank at a time, so a stronger key never loses a slot to a weaker
+    // one, and like is compared with like: an entry that answers on one
+    // rank and not another is simply absent from that round.
+    for rank in 0..RANKS {
+        for (index, wanted) in target_keys.iter().enumerate() {
+            let (None, Some(key)) = (pairing[index], wanted[rank].as_ref()) else {
                 continue;
+            };
+            for (at, entry) in standing_keys.iter().enumerate() {
+                if taken[at] || entry[rank].as_ref() != Some(key) {
+                    continue;
+                }
+                pairing[index] = Some(at);
+                taken[at] = true;
+                break;
             }
-            pairing[index] = Some(at);
-            taken[at] = true;
-            break;
         }
     }
     for (index, slot) in pairing.iter_mut().enumerate() {
@@ -203,10 +212,18 @@ fn paired(standing: &[Item], target: &[Item]) -> Vec<Option<usize>> {
 ///
 /// A scalar is its own identity, so a list that lost an element or was
 /// re-sorted — `Manifest::suppress` sorts on every removal — moves each
-/// annotation with the value it was written against. A table is its
-/// `name`, the identity `[[custom-hooks]]` documents, or what it runs for
-/// an entry written by hand before an editor save stamped one. Duplicates
-/// pair first-unclaimed, which the caller's `taken` sweep already decides.
+/// annotation with the value it was written against.
+///
+/// A table answers on two keys, because one is not enough to survive the
+/// editor. `name` is the identity `[[custom-hooks]]` documents and the
+/// stronger key: a hook whose command was edited is still that hook. But
+/// `hook::name_custom_hooks` stamps a name onto every hook the editor
+/// saves, so on that path the target is named and the file it is folded
+/// into is not, and nothing about the names can match. What the name was
+/// derived from can: a hook also answers on the event and command it
+/// runs, and `paired` tries that key once the names have placed what they
+/// can. Duplicates pair first-unclaimed, which the caller's `taken` sweep
+/// already decides.
 ///
 /// Nothing here identifies an entry whose value changed, and nothing can:
 /// a value edited in place is a different value. It pairs by the slot it
@@ -223,16 +240,25 @@ fn paired(standing: &[Item], target: &[Item]) -> Vec<Option<usize>> {
 /// `tests::a_value_paired_by_position_keeps_the_note_written_in_its_slot`
 /// and `tests::a_repeated_value_leaves_an_edited_neighbour_unpaired`, so
 /// the trade is a fixture rather than a sentence.
-fn identity(entry: &Item) -> Option<String> {
-    if let Some(table) = entry.as_table_like() {
-        if let Some(name) = text(table, "name") {
-            return Some(format!("named {name}"));
-        }
-        return match (text(table, "event"), text(table, "command")) {
-            (Some(event), Some(command)) => Some(format!("runs {event}\u{1f}{command}")),
-            _ => None,
-        };
-    }
+/// How many keys an entry can be recognized by, strongest first.
+const RANKS: usize = 2;
+
+/// The keys one entry answers on, `None` where it answers on none.
+type Identity = [Option<String>; RANKS];
+
+fn identity(entry: &Item) -> Identity {
+    let Some(table) = entry.as_table_like() else {
+        return [None, scalar(entry)];
+    };
+    let named = text(table, "name").map(|name| format!("named {name}"));
+    let runs = match (text(table, "event"), text(table, "command")) {
+        (Some(event), Some(command)) => Some(format!("runs {event}\u{1f}{command}")),
+        _ => None,
+    };
+    [named, runs]
+}
+
+fn scalar(entry: &Item) -> Option<String> {
     match entry.as_value()? {
         Value::String(value) => Some(format!("text {}", value.value())),
         Value::Integer(value) => Some(format!("whole {}", value.value())),

--- a/crates/core/src/manifest/edit.rs
+++ b/crates/core/src/manifest/edit.rs
@@ -1,0 +1,193 @@
+//! Folding a manifest into the document the person wrote.
+//!
+//! kendex.toml is the one file in the product that is entirely somebody's
+//! own writing, so a write may not re-serialize it. What kendex holds is
+//! serialized on its own, and the two documents are walked together: a key
+//! whose value already says the right thing is not touched at all, a key
+//! that changed keeps its formatting and takes the new value, a key kendex
+//! no longer holds goes, and a key kendex gained is appended where its
+//! neighbours are. Comments, blank lines, key order and the spelling of
+//! every untouched value survive that, because nothing rewrote them.
+//!
+//! The one thing a write still adds where nobody asked is a field serde
+//! spells out at its default — `enabled = true` under a declaration that
+//! omitted it. Skipping those in the serialization would put them on the
+//! other side of this walk, where a key kendex holds and the
+//! serialization does not mention reads as a key kendex dropped: the
+//! `enabled = true` somebody typed by hand would be deleted. A line added
+//! once and stable after is the better of the two.
+
+use toml_edit::{ArrayOfTables, DocumentMut, Item, Table, TableLike, Value};
+
+/// The text a write should leave behind: `desired` — the serialization of
+/// what kendex holds — folded into `current`, the file as it stands.
+///
+/// Both parses are answered rather than assumed: `current` is somebody's
+/// file, and `desired` is this crate's own serializer, so a failure on
+/// either is a refusal and never a rewrite.
+pub(super) fn merged(current: &str, desired: &str) -> Result<String, toml_edit::TomlError> {
+    let mut document: DocumentMut = current.parse()?;
+    let target: DocumentMut = desired.parse()?;
+    merge_table(document.as_table_mut(), target.as_table());
+    Ok(document.to_string())
+}
+
+/// Walk two tables together. Keys are compared by name, so a table spelled
+/// `[a.b]`, `a.b = {}` or `a.b.c = 1` all merge as the same table — the
+/// destination keeps whichever spelling it already had.
+fn merge_table(destination: &mut dyn TableLike, target: &dyn TableLike) {
+    let gone: Vec<String> = destination
+        .iter()
+        .map(|(key, _)| key.to_owned())
+        .filter(|key| target.get(key).is_none())
+        .collect();
+    for key in gone {
+        destination.remove(&key);
+    }
+    for (key, wanted) in target.iter() {
+        match destination.get_mut(key) {
+            Some(held) => merge_item(held, wanted),
+            None => {
+                destination.insert(key, fresh(wanted));
+            }
+        }
+    }
+}
+
+fn merge_item(destination: &mut Item, target: &Item) {
+    if same_item(destination, target) {
+        return;
+    }
+    if let Some(wanted) = target.as_table_like()
+        && let Some(held) = destination.as_table_like_mut()
+    {
+        merge_table(held, wanted);
+        return;
+    }
+    if let (Item::ArrayOfTables(held), Item::ArrayOfTables(wanted)) = (&mut *destination, target) {
+        merge_array_of_tables(held, wanted);
+        return;
+    }
+    // A value that changed keeps its own decoration — the whitespace
+    // before it and any comment after it are the person's, not the old
+    // value's. Anything else is replaced whole, which is only reached
+    // where the two documents disagree about what shape the key is.
+    if let (Item::Value(held), Item::Value(wanted)) = (&mut *destination, target) {
+        let mut replacement = wanted.clone();
+        *replacement.decor_mut() = held.decor().clone();
+        *held = replacement;
+        return;
+    }
+    *destination = fresh(target);
+}
+
+/// `[[custom-hooks]]`: entries are matched by position, so editing one
+/// hook leaves the comments inside every other entry alone.
+fn merge_array_of_tables(destination: &mut ArrayOfTables, target: &ArrayOfTables) {
+    while destination.len() > target.len() {
+        destination.remove(destination.len() - 1);
+    }
+    for (index, wanted) in target.iter().enumerate() {
+        match destination.get_mut(index) {
+            Some(held) => merge_table(held, wanted),
+            None => {
+                let mut table = wanted.clone();
+                unposition_table(&mut table);
+                destination.push(table);
+            }
+        }
+    }
+}
+
+/// A subtree lifted out of the serialized document and ready to land in
+/// somebody else's. The serializer's own table positions come with it and
+/// would place the table by where it sat there; cleared, a table renders
+/// after the one it was inserted behind, which is where its neighbours are.
+fn fresh(item: &Item) -> Item {
+    let mut item = item.clone();
+    unposition(&mut item);
+    item
+}
+
+fn unposition(item: &mut Item) {
+    match item {
+        Item::Table(table) => unposition_table(table),
+        Item::ArrayOfTables(tables) => tables.iter_mut().for_each(unposition_table),
+        Item::Value(_) | Item::None => {}
+    }
+}
+
+fn unposition_table(table: &mut Table) {
+    table.set_position(None);
+    for (_, item) in table.iter_mut() {
+        unposition(item);
+    }
+}
+
+/// Whether these two say the same thing, whatever they look like. This is
+/// what keeps a write off every key it did not change: only a difference
+/// here reaches an edit.
+fn same_item(left: &Item, right: &Item) -> bool {
+    if let (Some(left), Some(right)) = (left.as_table_like(), right.as_table_like()) {
+        return same_table(left, right);
+    }
+    if let (Some(left), Some(right)) = (sequence(left), sequence(right)) {
+        return left.len() == right.len()
+            && left
+                .iter()
+                .zip(&right)
+                .all(|(left, right)| same_item(left, right));
+    }
+    match (left, right) {
+        (Item::Value(left), Item::Value(right)) => same_scalar(left, right),
+        _ => false,
+    }
+}
+
+fn same_table(left: &dyn TableLike, right: &dyn TableLike) -> bool {
+    let held = |table: &dyn TableLike| -> Vec<String> {
+        table
+            .iter()
+            .filter(|(_, item)| !item.is_none())
+            .map(|(key, _)| key.to_owned())
+            .collect()
+    };
+    let keys = held(left);
+    keys.len() == held(right).len()
+        && keys
+            .iter()
+            .all(|key| match (left.get(key), right.get(key)) {
+                (Some(left), Some(right)) => same_item(left, right),
+                _ => false,
+            })
+}
+
+/// The two spellings of a list — `[[table]]` entries and an inline array —
+/// read as one sequence, so neither is rewritten into the other.
+fn sequence(item: &Item) -> Option<Vec<Item>> {
+    match item {
+        Item::ArrayOfTables(tables) => Some(tables.iter().cloned().map(Item::Table).collect()),
+        Item::Value(Value::Array(values)) => {
+            Some(values.iter().cloned().map(Item::Value).collect())
+        }
+        _ => None,
+    }
+}
+
+fn same_scalar(left: &Value, right: &Value) -> bool {
+    match (left, right) {
+        (Value::String(left), Value::String(right)) => left.value() == right.value(),
+        (Value::Integer(left), Value::Integer(right)) => left.value() == right.value(),
+        // By bits: two floats that print the same are the same bytes, and
+        // that is the question here, not numeric equality.
+        (Value::Float(left), Value::Float(right)) => {
+            left.value().to_bits() == right.value().to_bits()
+        }
+        (Value::Boolean(left), Value::Boolean(right)) => left.value() == right.value(),
+        (Value::Datetime(left), Value::Datetime(right)) => left.value() == right.value(),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/manifest/edit.rs
+++ b/crates/core/src/manifest/edit.rs
@@ -10,11 +10,14 @@
 //!
 //! Three things the walk is careful about.
 //!
-//! A key kendex never held is not kendex's to drop. `held` is the same
-//! serialization taken of the manifest read back out of this very file, so
-//! a key the model does not carry — a note somebody left inside a
-//! declaration — is absent from it, and the sweep passes over the key
-//! instead of reading it as one kendex dropped.
+//! What a write may remove is settled by `held`, a third document: the
+//! same serialization taken of the manifest read back out of this very
+//! file. A key it names and the target does not is a key the manifest
+//! really did drop, and the sweep takes it. A key it never names was
+//! never the manifest's — a note somebody left inside a declaration, or a
+//! flag the serializer omits at its default — and the sweep passes over
+//! it. Nothing has to know which keys the model can spell, and nothing
+//! the serializer chooses to leave out reads as a deletion.
 //!
 //! Containers are edited in the shape they were written in. An inline
 //! `custom-hooks = [{ … }]` and a `[[custom-hooks]]` array say the same
@@ -24,12 +27,6 @@
 //! List entries are paired by what they are, not by where they sit. A
 //! comment above a hook describes that hook, so removing or reordering
 //! hooks has to carry each comment with its own entry.
-//!
-//! A write still adds one thing nobody asked for: a declaration field
-//! serde spells out at its default, `enabled = true` under a declaration
-//! that omitted it. Invariant 10 names that exception. Nothing is lost to
-//! it, because `held` is what decides a removal: a field the serialization
-//! leaves out is never read as a field the manifest dropped.
 
 use toml_edit::{Array, ArrayOfTables, DocumentMut, Item, Table, TableLike, Value};
 

--- a/crates/core/src/manifest/edit.rs
+++ b/crates/core/src/manifest/edit.rs
@@ -25,14 +25,17 @@
 //! rewritten into the other.
 //!
 //! List entries are paired by what an entry is — a hook by its name, a
-//! scalar by its own value — and everything identity could not place
-//! pairs by where it sits. What somebody wrote about an entry then
-//! travels with that entry through a removal or a re-sort. The positional
-//! half is what keeps an edit an edit rather than a drop and an append,
-//! and it has a price: an entry paired that way inherits what was written
-//! about whatever stood in its slot, which
+//! scalar by its own value — and what identity could not place takes the
+//! slot it sat in, where identity has not already claimed that slot. What
+//! somebody wrote about an entry then travels with that entry through a
+//! removal or a re-sort. The positional half is what keeps an edit an
+//! edit rather than a drop and an append, and it has a price: an entry
+//! paired that way inherits what was written about whatever stood in its
+//! slot. Where a list holds one value twice, identity claims the earlier
+//! slot first and an edited neighbour is left none, so its own line's
+//! annotation goes with nobody rather than moving. Both are asserted in
 //! `tests::a_value_paired_by_position_keeps_the_note_written_in_its_slot`
-//! holds to.
+//! and `tests::a_repeated_value_leaves_an_edited_neighbour_unpaired`.
 //!
 //! Where those bytes are is not where they look. An array of values keeps
 //! them in [`layout`]'s four places, an entry and its annotation always
@@ -206,13 +209,20 @@ fn paired(standing: &[Item], target: &[Item]) -> Vec<Option<usize>> {
 /// pair first-unclaimed, which the caller's `taken` sweep already decides.
 ///
 /// Nothing here identifies an entry whose value changed, and nothing can:
-/// a value edited in place is a different value. It pairs by position, so
-/// it lands on the slot it replaced and keeps the note written there —
-/// which is what makes an edit an edit, and what makes `"Write", # no
-/// writing files` read `"WebFetch", # no writing files` afterwards. Both
-/// halves of that are asserted in
-/// `tests::a_value_paired_by_position_keeps_the_note_written_in_its_slot`,
-/// so the trade is a fixture rather than a sentence.
+/// a value edited in place is a different value. It pairs by the slot it
+/// sat in, so it keeps the note written there — which is what makes an
+/// edit an edit, and what makes `"Write", # no writing files` read
+/// `"WebFetch", # no writing files` afterwards.
+///
+/// That holds while the slot is still free. Identity runs over the whole
+/// target before position places anything, so where a list holds one
+/// value twice the surviving copy claims the earlier slot, the edited
+/// entry finds none and lands as a gained one, and the annotation on the
+/// slot nobody claimed is dropped rather than moved. Both readings are
+/// asserted, in
+/// `tests::a_value_paired_by_position_keeps_the_note_written_in_its_slot`
+/// and `tests::a_repeated_value_leaves_an_edited_neighbour_unpaired`, so
+/// the trade is a fixture rather than a sentence.
 fn identity(entry: &Item) -> Option<String> {
     if let Some(table) = entry.as_table_like() {
         if let Some(name) = text(table, "name") {

--- a/crates/core/src/manifest/edit.rs
+++ b/crates/core/src/manifest/edit.rs
@@ -1,52 +1,82 @@
 //! Folding a manifest into the document the person wrote.
 //!
-//! kendex.toml is the one file in the product that is entirely somebody's
-//! own writing, so a write may not re-serialize it. What kendex holds is
-//! serialized on its own, and the two documents are walked together: a key
-//! whose value already says the right thing is not touched at all, a key
-//! that changed keeps its formatting and takes the new value, a key kendex
-//! no longer holds goes, and a key kendex gained is appended where its
-//! neighbours are. Comments, blank lines, key order and the spelling of
-//! every untouched value survive that, because nothing rewrote them.
+//! kendex.toml is written by hand, so a write may not re-serialize it.
+//! What kendex holds is serialized on its own, and the two documents are
+//! walked together: a value that already says the right thing is not
+//! touched at all, a value that changed keeps its formatting, a key kendex
+//! dropped goes, and a key kendex gained is appended where its neighbours
+//! are. Comments, blank lines, key order and the spelling of every
+//! untouched value survive that, because nothing rewrote them.
 //!
-//! The one thing a write still adds where nobody asked is a field serde
-//! spells out at its default — `enabled = true` under a declaration that
-//! omitted it. Skipping those in the serialization would put them on the
-//! other side of this walk, where a key kendex holds and the
-//! serialization does not mention reads as a key kendex dropped: the
-//! `enabled = true` somebody typed by hand would be deleted. A line added
-//! once and stable after is the better of the two.
+//! Three things the walk is careful about.
+//!
+//! A key kendex never held is not kendex's to drop. `held` is the same
+//! serialization taken of the manifest read back out of this very file, so
+//! a key the model does not carry — a note somebody left inside a
+//! declaration — is absent from it, and the sweep passes over the key
+//! instead of reading it as one kendex dropped.
+//!
+//! Containers are edited in the shape they were written in. An inline
+//! `custom-hooks = [{ … }]` and a `[[custom-hooks]]` array say the same
+//! thing, and the walk dispatches on the destination, so neither is
+//! rewritten into the other.
+//!
+//! List entries are paired by what they are, not by where they sit. A
+//! comment above a hook describes that hook, so removing or reordering
+//! hooks has to carry each comment with its own entry.
+//!
+//! A write still adds one thing nobody asked for: a declaration field
+//! serde spells out at its default, `enabled = true` under a declaration
+//! that omitted it. Invariant 10 names that exception. Nothing is lost to
+//! it, because `held` is what decides a removal: a field the serialization
+//! leaves out is never read as a field the manifest dropped.
 
-use toml_edit::{ArrayOfTables, DocumentMut, Item, Table, TableLike, Value};
+use toml_edit::{Array, ArrayOfTables, DocumentMut, Item, Table, TableLike, Value};
 
-/// The text a write should leave behind: `desired` — the serialization of
-/// what kendex holds — folded into `current`, the file as it stands.
+/// The text a write should leave behind.
 ///
-/// Both parses are answered rather than assumed: `current` is somebody's
-/// file, and `desired` is this crate's own serializer, so a failure on
-/// either is a refusal and never a rewrite.
-pub(super) fn merged(current: &str, desired: &str) -> Result<String, toml_edit::TomlError> {
+/// `current` is the file as it stands, `held` the serialization of the
+/// manifest that file reads back as, and `desired` the serialization of
+/// the manifest to write. Every parse is answered rather than assumed:
+/// `current` is somebody's file, and the other two are this crate's own
+/// serializer, so a failure on any of them is a refusal and never a
+/// rewrite.
+pub(super) fn merged(
+    current: &str,
+    held: &str,
+    desired: &str,
+) -> Result<String, toml_edit::TomlError> {
     let mut document: DocumentMut = current.parse()?;
+    let held: DocumentMut = held.parse()?;
     let target: DocumentMut = desired.parse()?;
-    merge_table(document.as_table_mut(), target.as_table());
+    merge_table(
+        document.as_table_mut(),
+        Some(held.as_table()),
+        target.as_table(),
+    );
     Ok(document.to_string())
 }
 
 /// Walk two tables together. Keys are compared by name, so a table spelled
 /// `[a.b]`, `a.b = {}` or `a.b.c = 1` all merge as the same table — the
 /// destination keeps whichever spelling it already had.
-fn merge_table(destination: &mut dyn TableLike, target: &dyn TableLike) {
+fn merge_table(
+    destination: &mut dyn TableLike,
+    held: Option<&dyn TableLike>,
+    target: &dyn TableLike,
+) {
     let gone: Vec<String> = destination
         .iter()
         .map(|(key, _)| key.to_owned())
         .filter(|key| target.get(key).is_none())
+        .filter(|key| held.is_some_and(|held| held.get(key).is_some()))
         .collect();
     for key in gone {
         destination.remove(&key);
     }
     for (key, wanted) in target.iter() {
         match destination.get_mut(key) {
-            Some(held) => merge_item(held, wanted),
+            Some(item) => merge_item(item, held.and_then(|held| held.get(key)), wanted),
             None => {
                 destination.insert(key, fresh(wanted));
             }
@@ -54,48 +84,178 @@ fn merge_table(destination: &mut dyn TableLike, target: &dyn TableLike) {
     }
 }
 
-fn merge_item(destination: &mut Item, target: &Item) {
-    if same_item(destination, target) {
-        return;
-    }
+/// The one walk. Containers recurse, and equality lives at the leaf: a
+/// scalar that already says the right thing is left with its own bytes,
+/// and everything above it is a no-op when nothing under it changed.
+fn merge_item(destination: &mut Item, held: Option<&Item>, target: &Item) {
     if let Some(wanted) = target.as_table_like()
-        && let Some(held) = destination.as_table_like_mut()
+        && let Some(item) = destination.as_table_like_mut()
     {
-        merge_table(held, wanted);
+        merge_table(item, held.and_then(Item::as_table_like), wanted);
         return;
     }
-    if let (Item::ArrayOfTables(held), Item::ArrayOfTables(wanted)) = (&mut *destination, target) {
-        merge_array_of_tables(held, wanted);
+    if entries(target).is_some() && merge_entries(destination, held, target) {
         return;
     }
-    // A value that changed keeps its own decoration — the whitespace
-    // before it and any comment after it are the person's, not the old
-    // value's. Anything else is replaced whole, which is only reached
-    // where the two documents disagree about what shape the key is.
-    if let (Item::Value(held), Item::Value(wanted)) = (&mut *destination, target) {
+    if let (Item::Value(item), Item::Value(wanted)) = (&mut *destination, target) {
+        if same_scalar(item, wanted) {
+            return;
+        }
+        // A value that changed keeps its own decoration. The whitespace
+        // before it and any comment after it are the person's, and they
+        // belong to the key rather than to the value that was there.
         let mut replacement = wanted.clone();
-        *replacement.decor_mut() = held.decor().clone();
-        *held = replacement;
+        *replacement.decor_mut() = item.decor().clone();
+        *item = replacement;
         return;
     }
     *destination = fresh(target);
 }
 
-/// `[[custom-hooks]]`: entries are matched by position, so editing one
-/// hook leaves the comments inside every other entry alone.
-fn merge_array_of_tables(destination: &mut ArrayOfTables, target: &ArrayOfTables) {
-    while destination.len() > target.len() {
-        destination.remove(destination.len() - 1);
-    }
-    for (index, wanted) in target.iter().enumerate() {
-        match destination.get_mut(index) {
-            Some(held) => merge_table(held, wanted),
-            None => {
-                let mut table = wanted.clone();
-                unposition_table(&mut table);
-                destination.push(table);
+/// A list, in the shape the destination spells it. `[[custom-hooks]]`
+/// entries and an inline array of tables are the same list, so the one
+/// that is on disk is the one that is edited.
+///
+/// `held` is that list as the model reads it back out of this same file,
+/// so its entries stand one for one against the destination's and each
+/// merge gets the model's view of the entry it is editing.
+fn merge_entries(destination: &mut Item, held: Option<&Item>, target: &Item) -> bool {
+    let (Some(standing), Some(wanted)) = (entries(destination), entries(target)) else {
+        return false;
+    };
+    let held = held.and_then(entries).unwrap_or_default();
+    let merged: Vec<Item> = wanted
+        .iter()
+        .zip(paired(&standing, &wanted))
+        .map(|(wanted, at)| match at {
+            Some(at) => {
+                let mut entry = standing[at].clone();
+                merge_item(&mut entry, held.get(at), wanted);
+                entry
             }
+            None => gained(wanted),
+        })
+        .collect();
+    match destination {
+        Item::ArrayOfTables(tables) => *tables = rebuilt_tables(merged),
+        Item::Value(Value::Array(array)) => *array = rebuilt_array(array, merged),
+        _ => return false,
+    }
+    true
+}
+
+/// An entry the list did not have. It takes the default spacing rather
+/// than the serializer's, because it has no place in the destination's
+/// layout to inherit and the encoder lays out what it is not told about.
+fn gained(target: &Item) -> Item {
+    let mut entry = fresh(target);
+    if let Item::Value(value) = &mut entry {
+        value.decor_mut().clear();
+    }
+    entry
+}
+
+/// Which destination entry each target entry continues, by identity first
+/// and by position for whatever identity could not place. An entry that
+/// pairs with nothing is gained; a destination entry nothing pairs with is
+/// dropped, and the comment written above it goes with it.
+fn paired(standing: &[Item], target: &[Item]) -> Vec<Option<usize>> {
+    let mut taken = vec![false; standing.len()];
+    let mut pairing = vec![None; target.len()];
+    for (index, wanted) in target.iter().enumerate() {
+        let Some(name) = wanted.as_table_like().and_then(identity) else {
+            continue;
+        };
+        for (at, entry) in standing.iter().enumerate() {
+            if taken[at] || entry.as_table_like().and_then(identity) != Some(name.clone()) {
+                continue;
+            }
+            pairing[index] = Some(at);
+            taken[at] = true;
+            break;
         }
+    }
+    for (index, slot) in pairing.iter_mut().enumerate() {
+        if slot.is_none() && taken.get(index) == Some(&false) {
+            *slot = Some(index);
+            taken[index] = true;
+        }
+    }
+    pairing
+}
+
+/// What makes one entry of a list the same entry across a write.
+/// `[[custom-hooks]]` is the only list of tables a manifest holds, and
+/// `name` is the identity it documents; an entry written by hand before an
+/// editor save stamped one is placed by what it runs instead.
+fn identity(entry: &dyn TableLike) -> Option<String> {
+    if let Some(name) = text(entry, "name") {
+        return Some(format!("name {name}"));
+    }
+    match (text(entry, "event"), text(entry, "command")) {
+        (Some(event), Some(command)) => Some(format!("runs {event}\u{1f}{command}")),
+        _ => None,
+    }
+}
+
+fn text(entry: &dyn TableLike, key: &str) -> Option<String> {
+    entry
+        .get(key)
+        .and_then(Item::as_str)
+        .map(std::borrow::ToOwned::to_owned)
+}
+
+/// The merged entries as an array of tables, in the places the surviving
+/// entries already held. A table renders where its position says, so
+/// entries that changed places have to change positions with them or the
+/// file would come back in the old order; the places are the survivors'
+/// own, so nothing moves past a table that is not part of this list.
+fn rebuilt_tables(merged: Vec<Item>) -> ArrayOfTables {
+    let mut tables: Vec<Table> = merged
+        .into_iter()
+        .filter_map(|entry| entry.into_table().ok())
+        .collect();
+    let mut places: Vec<isize> = tables.iter().filter_map(Table::position).collect();
+    places.sort_unstable();
+    let mut places = places.into_iter();
+    for table in &mut tables {
+        if table.position().is_some() {
+            table.set_position(places.next());
+        }
+    }
+    let mut rebuilt = ArrayOfTables::new();
+    for table in tables {
+        rebuilt.push(table);
+    }
+    rebuilt
+}
+
+/// The merged entries as an inline array. A surviving entry keeps the
+/// decoration it was written with, so a multi-line array stays multi-line
+/// and the comments inside it stay where they are; a gained one takes the
+/// default spacing, because it has no place in that layout to inherit.
+fn rebuilt_array(destination: &Array, merged: Vec<Item>) -> Array {
+    let mut rebuilt = Array::new();
+    rebuilt.set_trailing_comma(destination.trailing_comma());
+    rebuilt.set_trailing(destination.trailing().clone());
+    *rebuilt.decor_mut() = destination.decor().clone();
+    for entry in merged {
+        let Ok(value) = entry.into_value() else {
+            continue;
+        };
+        rebuilt.push_formatted(value);
+    }
+    rebuilt
+}
+
+/// A read-only view of a list's entries, whichever way it is spelled.
+fn entries(item: &Item) -> Option<Vec<Item>> {
+    match item {
+        Item::ArrayOfTables(tables) => Some(tables.iter().cloned().map(Item::Table).collect()),
+        Item::Value(Value::Array(values)) => {
+            Some(values.iter().cloned().map(Item::Value).collect())
+        }
+        _ => None,
     }
 }
 
@@ -124,56 +284,9 @@ fn unposition_table(table: &mut Table) {
     }
 }
 
-/// Whether these two say the same thing, whatever they look like. This is
-/// what keeps a write off every key it did not change: only a difference
-/// here reaches an edit.
-fn same_item(left: &Item, right: &Item) -> bool {
-    if let (Some(left), Some(right)) = (left.as_table_like(), right.as_table_like()) {
-        return same_table(left, right);
-    }
-    if let (Some(left), Some(right)) = (sequence(left), sequence(right)) {
-        return left.len() == right.len()
-            && left
-                .iter()
-                .zip(&right)
-                .all(|(left, right)| same_item(left, right));
-    }
-    match (left, right) {
-        (Item::Value(left), Item::Value(right)) => same_scalar(left, right),
-        _ => false,
-    }
-}
-
-fn same_table(left: &dyn TableLike, right: &dyn TableLike) -> bool {
-    let held = |table: &dyn TableLike| -> Vec<String> {
-        table
-            .iter()
-            .filter(|(_, item)| !item.is_none())
-            .map(|(key, _)| key.to_owned())
-            .collect()
-    };
-    let keys = held(left);
-    keys.len() == held(right).len()
-        && keys
-            .iter()
-            .all(|key| match (left.get(key), right.get(key)) {
-                (Some(left), Some(right)) => same_item(left, right),
-                _ => false,
-            })
-}
-
-/// The two spellings of a list — `[[table]]` entries and an inline array —
-/// read as one sequence, so neither is rewritten into the other.
-fn sequence(item: &Item) -> Option<Vec<Item>> {
-    match item {
-        Item::ArrayOfTables(tables) => Some(tables.iter().cloned().map(Item::Table).collect()),
-        Item::Value(Value::Array(values)) => {
-            Some(values.iter().cloned().map(Item::Value).collect())
-        }
-        _ => None,
-    }
-}
-
+/// Whether this leaf already says what kendex holds. Only a difference
+/// here reaches an edit, which is what keeps a write off the spelling of
+/// every value it did not change.
 fn same_scalar(left: &Value, right: &Value) -> bool {
     match (left, right) {
         (Value::String(left), Value::String(right)) => left.value() == right.value(),

--- a/crates/core/src/manifest/edit.rs
+++ b/crates/core/src/manifest/edit.rs
@@ -25,13 +25,17 @@
 //! rewritten into the other.
 //!
 //! List entries are paired by what an entry is — a hook by its name, a
-//! scalar by its own value — and by where it sits only for an entry
-//! nothing identifies. What somebody wrote about an entry then travels
-//! with that entry through a removal or a re-sort, rather than staying at
-//! the place it was stored. Which bytes those are is [`layout`]'s
-//! arithmetic: TOML keeps a comment written after a value against the
-//! value below it, so entry and annotation are one apart in the file and
-//! have to be put back together before anything moves.
+//! scalar by its own value — and everything identity could not place
+//! pairs by where it sits. What somebody wrote about an entry then
+//! travels with that entry through a removal or a re-sort. The positional
+//! half is what keeps an edit an edit rather than a drop and an append,
+//! and it has a price: an entry paired that way inherits what was written
+//! about whatever stood in its slot.
+//!
+//! Where those bytes are is not where they look. An array of values keeps
+//! them in [`layout`]'s four places, an entry and its annotation always
+//! one slot apart; an array of tables keeps a table's annotation on the
+//! table, so [`rebuilt_tables`] carries it by moving the table itself.
 
 use toml_edit::{ArrayOfTables, DocumentMut, Item, Table, TableLike, Value};
 
@@ -198,6 +202,12 @@ fn paired(standing: &[Item], target: &[Item]) -> Vec<Option<usize>> {
 /// `name`, the identity `[[custom-hooks]]` documents, or what it runs for
 /// an entry written by hand before an editor save stamped one. Duplicates
 /// pair first-unclaimed, which the caller's `taken` sweep already decides.
+///
+/// Nothing here identifies an entry whose value changed, and nothing can:
+/// a value edited in place is a different value. It pairs by position, so
+/// it lands on the slot it replaced and keeps the note written there —
+/// which is what makes an edit an edit, and what makes `"Write", # no
+/// writing files` read `"WebFetch", # no writing files` afterwards.
 fn identity(entry: &Item) -> Option<String> {
     if let Some(table) = entry.as_table_like() {
         if let Some(name) = text(table, "name") {
@@ -237,6 +247,9 @@ fn rebuilt_tables(merged: Vec<(Option<usize>, Item)>) -> ArrayOfTables {
         .map(|(_, entry)| {
             entry
                 .into_table()
+                // Refused before the fold rather than here: `held_by_model`
+                // deserializes the file through `Manifest` first, and serde
+                // takes no array of tables for a list of strings.
                 .unwrap_or_else(|other| unreachable!("a table array holds tables, not {other:?}"))
         })
         .collect();

--- a/crates/core/src/manifest/edit/layout.rs
+++ b/crates/core/src/manifest/edit/layout.rs
@@ -1,0 +1,165 @@
+//! Who owns which bytes between one value and the next.
+//!
+//! A TOML document stores the run before a value against that value, so
+//! the writing that sits between two entries of a list — the annotation
+//! somebody put after the first of them — belongs to the entry above the
+//! one holding it. Everything here is the arithmetic that puts each
+//! entry back together with what was written about it, so a list can lose
+//! an entry or change its order without an annotation staying behind.
+
+use toml_edit::{Array, Item, Value};
+
+/// The run an inline table keeps before its closing brace, against the key
+/// it is stored on. That spacing belongs to the brace rather than to
+/// whichever key happens to sit last, so a gained key would otherwise
+/// strand it in the middle: `{ a = 1 , b = 2}`. `None` for a standard
+/// table, where a value's suffix is a trailing comment and stays on the
+/// line it was written on.
+pub(super) fn brace_run(destination: &Item) -> Option<(String, String)> {
+    let Item::Value(Value::InlineTable(table)) = destination else {
+        return None;
+    };
+    let (key, value) = table.iter().last()?;
+    Some((key.to_owned(), decoration(value.decor().suffix(), "")))
+}
+
+/// [`brace_run`], put back on the key that is last now.
+pub(super) fn reseat_brace(destination: &mut Item, brace: Option<(String, String)>) {
+    let Some((was, spacing)) = brace.filter(|(_, spacing)| !spacing.is_empty()) else {
+        return;
+    };
+    let Item::Value(Value::InlineTable(table)) = destination else {
+        return;
+    };
+    let Some(now) = table.iter().last().map(|(key, _)| key.to_owned()) else {
+        return;
+    };
+    if now == was {
+        return;
+    }
+    if let Some(value) = table.get_mut(&was) {
+        value.decor_mut().set_suffix("");
+    }
+    if let Some(value) = table.get_mut(&now) {
+        value.decor_mut().set_suffix(spacing);
+    }
+}
+
+/// The merged entries as an inline array, each carrying the writing that
+/// was written about it. See [`Layout`] for why that is not the same as
+/// keeping each entry's decoration.
+pub(super) fn rebuilt_array(destination: &Array, merged: Vec<(Option<usize>, Item)>) -> Array {
+    let layout = Layout::of(destination);
+    let mut rebuilt = Array::new();
+    rebuilt.set_trailing_comma(destination.trailing_comma());
+    *rebuilt.decor_mut() = destination.decor().clone();
+    let mut leading = layout.opener.clone();
+    for (index, (at, entry)) in merged.into_iter().enumerate() {
+        let mut value = entry
+            .into_value()
+            .unwrap_or_else(|other| unreachable!("an array holds values, not {other:?}"));
+        let (before, after) = layout.around(at, index == 0);
+        value.decor_mut().set_prefix(format!("{leading}{before}"));
+        value.decor_mut().set_suffix("");
+        rebuilt.push_formatted(value);
+        leading = after;
+    }
+    rebuilt.set_trailing(format!("{leading}{}", layout.closer));
+    rebuilt
+}
+
+/// Who owns which bytes inside an array.
+///
+/// toml_edit hangs everything between one value and the next on the later
+/// value's prefix, so a comment written after a value — the common way to
+/// annotate a list — is stored against the value below it, and the last
+/// value's annotation is stored in the array's trailing text. Carrying an
+/// entry's own prefix with it would therefore move every annotation one
+/// entry along on a re-sort, and dropping an entry would delete the
+/// annotation of the entry above it.
+///
+/// So each entry is given what was written *about* it: `before` is its own
+/// prefix from the first line break onward, and `after` is the next
+/// prefix up to and including its first line break — the rest of the line
+/// the entry sat on. What is left over belongs to the brackets: `opener`
+/// is the rest of the line the `[` sat on, `closer` the indentation before
+/// the `]`.
+struct Layout {
+    opener: String,
+    closer: String,
+    around: Vec<(String, String)>,
+    indent: String,
+    broken: bool,
+}
+
+impl Layout {
+    fn of(array: &Array) -> Layout {
+        let prefixes: Vec<String> = array
+            .iter()
+            .enumerate()
+            .map(|(index, value)| {
+                let default = if index == 0 { "" } else { " " };
+                decoration(value.decor().prefix(), default)
+            })
+            .collect();
+        let trailing = decoration(Some(array.trailing()), "");
+        let (opener, first) = split(prefixes.first().map_or("", String::as_str));
+        let heads: Vec<&str> = prefixes
+            .iter()
+            .skip(1)
+            .map(|prefix| split(prefix).0)
+            .chain(std::iter::once(split(&trailing).0))
+            .collect();
+        let tails = std::iter::once(first).chain(prefixes.iter().skip(1).map(|p| split(p).1));
+        let around: Vec<(String, String)> = tails
+            .zip(&heads)
+            .map(|(before, after)| ((*before).to_owned(), (*after).to_owned()))
+            .collect();
+        let broken = prefixes.iter().any(|prefix| prefix.contains('\n'));
+        let indent = prefixes
+            .first()
+            .and_then(|prefix| prefix.rsplit('\n').next())
+            .filter(|_| broken)
+            .unwrap_or("");
+        Layout {
+            opener: opener.to_owned(),
+            closer: split(&trailing).1.to_owned(),
+            around,
+            indent: indent.to_owned(),
+            broken,
+        }
+    }
+
+    /// What was written about the entry that stood at `at`. An entry the
+    /// list did not have has nothing written about it, so it takes the
+    /// indentation the array already uses and a line of its own where the
+    /// array takes lines — a space after the comma where it does not, and
+    /// nothing at all where it opens the array.
+    fn around(&self, at: Option<usize>, first: bool) -> (String, String) {
+        match at.and_then(|at| self.around.get(at)) {
+            Some(around) => around.clone(),
+            None if self.broken => (self.indent.clone(), "\n".to_owned()),
+            None if first => (String::new(), String::new()),
+            None => (" ".to_owned(), String::new()),
+        }
+    }
+}
+
+/// A prefix or trailing run split into the tail of the line before it and
+/// what sits on its own lines after that. A run with no line break is all
+/// tail of the line before, because a comment cannot end without one.
+fn split(text: &str) -> (&str, &str) {
+    match text.find('\n') {
+        Some(at) => text.split_at(at + 1),
+        None => (text, ""),
+    }
+}
+
+/// The bytes a decoration stands for. A parsed document spells every one
+/// of them; `default` is what the encoder would have written for a
+/// decoration nothing set.
+fn decoration(raw: Option<&toml_edit::RawString>, default: &str) -> String {
+    raw.and_then(toml_edit::RawString::as_str)
+        .unwrap_or(default)
+        .to_owned()
+}

--- a/crates/core/src/manifest/edit/layout.rs
+++ b/crates/core/src/manifest/edit/layout.rs
@@ -1,11 +1,17 @@
 //! Who owns which bytes between one value and the next.
 //!
-//! A TOML document stores the run before a value against that value, so
-//! the writing that sits between two entries of a list — the annotation
-//! somebody put after the first of them — belongs to the entry above the
-//! one holding it. Everything here is the arithmetic that puts each
-//! entry back together with what was written about it, so a list can lose
-//! an entry or change its order without an annotation staying behind.
+//! Two places a person's writing hides inside a value's own punctuation.
+//! An array of values: TOML stores the run before a value against that
+//! value, so the annotation somebody put after one entry belongs to the
+//! entry below the one holding it, and [`rebuilt_array`] puts each entry
+//! back together with what was written about it before anything moves.
+//! An inline table: the spacing before its closing brace is stored on
+//! whichever key sits last, which [`reseat_brace`] hands back to the
+//! brace when a gained key takes that place.
+//!
+//! Neither covers an array of tables. A table carries its annotation in
+//! its own decoration, so `edit`'s `rebuilt_tables` moves the table and
+//! the annotation goes with it.
 
 use toml_edit::{Array, Item, Value};
 
@@ -54,42 +60,57 @@ pub(super) fn rebuilt_array(destination: &Array, merged: Vec<(Option<usize>, Ite
     rebuilt.set_trailing_comma(destination.trailing_comma());
     *rebuilt.decor_mut() = destination.decor().clone();
     let mut leading = layout.opener.clone();
+    let last = merged.len().saturating_sub(1);
     for (index, (at, entry)) in merged.into_iter().enumerate() {
         let mut value = entry
             .into_value()
             .unwrap_or_else(|other| unreachable!("an array holds values, not {other:?}"));
-        let (before, after) = layout.around(at, index == 0);
-        value.decor_mut().set_prefix(format!("{leading}{before}"));
-        value.decor_mut().set_suffix("");
+        let owned = layout.around(at, index == 0, index == last);
+        let mut prefix = format!("{leading}{}", owned.before);
+        // An entry the list did not have needs separating from the comma
+        // before it, and the entry it follows may have been last, whose
+        // own trailing run faced the bracket rather than a neighbour.
+        if at.is_none() && index > 0 && prefix.is_empty() {
+            prefix = layout.separator.clone();
+        }
+        value.decor_mut().set_prefix(prefix);
+        value.decor_mut().set_suffix(owned.suffix);
         rebuilt.push_formatted(value);
-        leading = after;
+        leading = owned.after;
     }
     rebuilt.set_trailing(format!("{leading}{}", layout.closer));
     rebuilt
 }
 
-/// Who owns which bytes inside an array.
+/// Who owns which bytes inside an array, across the whole bracket span.
 ///
-/// toml_edit hangs everything between one value and the next on the later
-/// value's prefix, so a comment written after a value — the common way to
-/// annotate a list — is stored against the value below it, and the last
-/// value's annotation is stored in the array's trailing text. Carrying an
-/// entry's own prefix with it would therefore move every annotation one
-/// entry along on a re-sort, and dropping an entry would delete the
-/// annotation of the entry above it.
+/// toml_edit splits the span four ways: each value's prefix, each value's
+/// suffix, the run after the last comma, and — with no trailing comma —
+/// nothing at all, because the bytes before `]` are then the last value's
+/// suffix. A comment written after a value, the common way to annotate a
+/// list, lands in whichever of those the comma's placement decides.
 ///
-/// So each entry is given what was written *about* it: `before` is its own
-/// prefix from the first line break onward, and `after` is the next
-/// prefix up to and including its first line break — the rest of the line
-/// the entry sat on. What is left over belongs to the brackets: `opener`
-/// is the rest of the line the `[` sat on, `closer` the indentation before
-/// the `]`.
+/// So none of them can ride with the slot they are stored in. Each entry
+/// is given what was written *about* it: `before` is its own prefix from
+/// the first line break onward, `suffix` what stood between it and the
+/// comma after it, and `after` the next prefix up to and including its
+/// first line break — the rest of the line the entry sat on. What is left
+/// over belongs to the brackets: `opener` is the rest of the line the `[`
+/// sat on, `closer` what sits on its own lines before the `]`.
 struct Layout {
     opener: String,
     closer: String,
-    around: Vec<(String, String)>,
+    around: Vec<Around>,
     indent: String,
+    separator: String,
     broken: bool,
+}
+
+/// The bytes written about one entry, in the three places TOML keeps them.
+struct Around {
+    before: String,
+    suffix: String,
+    after: String,
 }
 
 impl Layout {
@@ -102,30 +123,64 @@ impl Layout {
                 decoration(value.decor().prefix(), default)
             })
             .collect();
-        let trailing = decoration(Some(array.trailing()), "");
-        let (opener, first) = split(prefixes.first().map_or("", String::as_str));
-        let heads: Vec<&str> = prefixes
+        let suffixes: Vec<String> = array
             .iter()
-            .skip(1)
-            .map(|prefix| split(prefix).0)
-            .chain(std::iter::once(split(&trailing).0))
+            .map(|value| decoration(value.decor().suffix(), ""))
             .collect();
-        let tails = std::iter::once(first).chain(prefixes.iter().skip(1).map(|p| split(p).1));
-        let around: Vec<(String, String)> = tails
-            .zip(&heads)
-            .map(|(before, after)| ((*before).to_owned(), (*after).to_owned()))
+        let trailing = decoration(Some(array.trailing()), "");
+        // Where the run before `]` is kept: the array's trailing text when
+        // it ends with a comma, the last value's suffix when it does not.
+        // An array with no values keeps the whole span in its trailing.
+        let closing = match (array.trailing_comma(), suffixes.last()) {
+            (false, Some(last)) => last.as_str(),
+            _ => trailing.as_str(),
+        };
+        let (closing_head, closer) = split(closing);
+        let opener = split(prefixes.first().map_or(trailing.as_str(), String::as_str)).0;
+
+        let last = prefixes.len().saturating_sub(1);
+        let around: Vec<Around> = prefixes
+            .iter()
+            .enumerate()
+            .map(|(index, prefix)| Around {
+                before: split(prefix).1.to_owned(),
+                suffix: match index == last && !array.trailing_comma() {
+                    true => closing_head.to_owned(),
+                    false => suffixes[index].clone(),
+                },
+                after: match (index == last, array.trailing_comma()) {
+                    (true, true) => split(&trailing).0.to_owned(),
+                    (true, false) => trailing.clone(),
+                    (false, _) => split(&prefixes[index + 1]).0.to_owned(),
+                },
+            })
             .collect();
-        let broken = prefixes.iter().any(|prefix| prefix.contains('\n'));
+
+        let broken = prefixes
+            .iter()
+            .chain(&suffixes)
+            .chain(std::iter::once(&trailing))
+            .any(|run| run.contains('\n'));
+        // What a line of this array is indented by: whatever follows the
+        // last line break of a prefix that takes one, or the whitespace
+        // the closing bracket is held out by where no entry has a prefix.
         let indent = prefixes
-            .first()
+            .iter()
+            .find(|prefix| prefix.contains('\n'))
             .and_then(|prefix| prefix.rsplit('\n').next())
-            .filter(|_| broken)
-            .unwrap_or("");
+            .unwrap_or_else(|| closer.trim_end_matches(|c: char| !c.is_whitespace() && c != ' '));
         Layout {
             opener: opener.to_owned(),
-            closer: split(&trailing).1.to_owned(),
+            closer: closer.to_owned(),
             around,
-            indent: indent.to_owned(),
+            indent: match broken {
+                true => indent
+                    .chars()
+                    .take_while(|c| *c == ' ' || *c == '\t')
+                    .collect(),
+                false => String::new(),
+            },
+            separator: " ".to_owned(),
             broken,
         }
     }
@@ -133,14 +188,29 @@ impl Layout {
     /// What was written about the entry that stood at `at`. An entry the
     /// list did not have has nothing written about it, so it takes the
     /// indentation the array already uses and a line of its own where the
-    /// array takes lines — a space after the comma where it does not, and
-    /// nothing at all where it opens the array.
-    fn around(&self, at: Option<usize>, first: bool) -> (String, String) {
+    /// array takes lines, and otherwise leaves the separating space to
+    /// the entry after it — put before it, it would double the space the
+    /// entry it displaced already carries. Nothing follows the entry that
+    /// ends the list but the bracket, so it leaves no separator at all.
+    fn around(&self, at: Option<usize>, first: bool, last: bool) -> Around {
         match at.and_then(|at| self.around.get(at)) {
-            Some(around) => around.clone(),
-            None if self.broken => (self.indent.clone(), "\n".to_owned()),
-            None if first => (String::new(), String::new()),
-            None => (" ".to_owned(), String::new()),
+            Some(around) => Around {
+                before: around.before.clone(),
+                suffix: around.suffix.clone(),
+                after: around.after.clone(),
+            },
+            None => Around {
+                before: match self.broken {
+                    true => self.indent.clone(),
+                    false => String::new(),
+                },
+                suffix: String::new(),
+                after: match (self.broken, first || last) {
+                    (true, _) => "\n".to_owned(),
+                    (false, true) => String::new(),
+                    (false, false) => self.separator.clone(),
+                },
+            },
         }
     }
 }

--- a/crates/core/src/manifest/edit/tests.rs
+++ b/crates/core/src/manifest/edit/tests.rs
@@ -641,3 +641,35 @@ fn a_repeated_value_leaves_an_edited_neighbour_unpaired() {
         "the surviving copy keeps the earlier slot, and second a's line goes"
     );
 }
+
+/// The editor's path, which is where a hand-written manifest is actually
+/// edited. `hook::name_custom_hooks` stamps a derived name onto every
+/// hook the editor saves, so the target carries names the file does not,
+/// and pairing on names alone places nothing at all — the whole list falls
+/// to position, and dropping the first hook seats the survivor under the
+/// dropped hook's comment.
+///
+/// The names are stamped by the real function rather than written here:
+/// what the target looks like on that path is the thing under test.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_hook_the_editor_has_just_named_pairs_with_the_one_it_names() {
+    let current = "schema = 6\n\n# guards every bash call\n[[custom-hooks]]\nevent = \"PreToolUse\"\ncommand = \"./guard.sh\"\n\n# says we are done\n[[custom-hooks]]\nevent = \"Stop\"\ncommand = \"./done.sh\"\n";
+    let mut manifest: Manifest = toml::from_str(current).unwrap();
+    manifest.custom_hooks.remove(0);
+    assert!(
+        crate::hook::name_custom_hooks(&mut manifest),
+        "the editor names what it saves, and this case is nothing without it"
+    );
+    let desired = toml::to_string_pretty(&manifest).unwrap();
+
+    assert_eq!(
+        fold(current, &desired),
+        format!(
+            "schema = 6\n\n# says we are done\n[[custom-hooks]]\nevent = \"Stop\"\ncommand = \"./done.sh\"\nname = \"{}\"\n",
+            manifest.custom_hooks[0].name.as_deref().unwrap()
+        ),
+        "the hook that survived keeps its own comment, not the deleted one's, \
+         and the name it gained lands under the keys already written"
+    );
+}

--- a/crates/core/src/manifest/edit/tests.rs
+++ b/crates/core/src/manifest/edit/tests.rs
@@ -592,3 +592,29 @@ fn clearing_install_would_take_the_table_written_around_it() {
          can reach this, that is what it costs"
     );
 }
+
+/// What pairing by position costs, and what it buys, on one list. Nothing
+/// identifies a value that changed — a changed value is a different value
+/// — so it pairs by where it sat, lands on the slot it replaced, and
+/// keeps what was written there.
+///
+/// Renaming every entry is the half that earns it: each stays an edit of
+/// its own line rather than three drops and three appends, and each
+/// annotation stays where the person put it. Replacing one entry with
+/// another in the same write is the same mechanism read the other way,
+/// and it costs: the new value stands under a note about the old one.
+/// Neither is a defect the fold can tell apart from the other, so the
+/// behaviour is pinned here rather than described.
+#[test]
+fn a_value_paired_by_position_keeps_the_note_written_in_its_slot() {
+    assert_eq!(
+        suppressing(&["one", "two", "three"]),
+        "schema = 6\n\n[suppressed]\nskill = [\n  \"one\",  # pulled in by gh\n  \"two\",   # pulled in by fmt\n  \"three\",  # pulled in by rev\n]\n",
+        "an edit of every entry is an edit of every line"
+    );
+    assert_eq!(
+        suppressing(&["alpha", "delta", "gamma"]),
+        "schema = 6\n\n[suppressed]\nskill = [\n  \"alpha\",  # pulled in by gh\n  \"delta\",   # pulled in by fmt\n  \"gamma\",  # pulled in by rev\n]\n",
+        "and the price of it: delta stands under what was written about beta"
+    );
+}

--- a/crates/core/src/manifest/edit/tests.rs
+++ b/crates/core/src/manifest/edit/tests.rs
@@ -618,3 +618,26 @@ fn a_value_paired_by_position_keeps_the_note_written_in_its_slot() {
         "and the price of it: delta stands under what was written about beta"
     );
 }
+
+/// The other reading of the same pairing, measured rather than argued.
+/// Identity places every target entry it can before position places any,
+/// so a list holding one value twice hands the earlier slot to the copy
+/// that survived; the entry edited out of that slot finds it taken, lands
+/// as one the list did not have, and the annotation on the slot nobody
+/// claimed goes with nobody.
+///
+/// It is not a defect the fold can see: a value edited in place and a
+/// value that was always there are the same bytes. Pinned here so the
+/// sentence in `identity` has the case it describes under it, and so the
+/// day the pairing changes this reads red rather than surprising
+/// somebody.
+#[test]
+fn a_repeated_value_leaves_an_edited_neighbour_unpaired() {
+    let current = "schema = 6\n\n[suppressed]\nskill = [\n  \"a\",  # first a\n  \"a\",  # second a\n  \"b\",  # only b\n]\n";
+    let desired = "schema = 6\n\n[suppressed]\nskill = [\"pi\", \"a\", \"b\"]\n";
+    assert_eq!(
+        fold(current, desired),
+        "schema = 6\n\n[suppressed]\nskill = [\n  \"pi\",\n  \"a\",  # first a\n  \"b\",  # only b\n]\n",
+        "the surviving copy keeps the earlier slot, and second a's line goes"
+    );
+}

--- a/crates/core/src/manifest/edit/tests.rs
+++ b/crates/core/src/manifest/edit/tests.rs
@@ -127,10 +127,21 @@ fn an_unparsable_document_is_refused() {
     assert!(merged("not = [valid", "schema = 6\n", "schema = 6\n").is_err());
 }
 
-/// A hook as the serializer spells one, so a case says what it is testing
-/// rather than transcribing the model's every field.
+/// A hook as the serializer spells one — taken from the serializer, not
+/// written out here. A fixture that spells the fields by hand certifies
+/// whatever the serializer did on the day it was written and drifts the
+/// next time a field gains or loses a skip, which is how five cases came
+/// to assert an `enabled = true` the fold does not write.
+#[allow(clippy::unwrap_used)]
 fn hook(event: &str, command: &str) -> String {
-    format!("event = \"{event}\"\ncommand = \"{command}\"\nenabled = true\nagents = \"all\"\n")
+    let manifest: Manifest = toml::from_str(&format!(
+        "schema = 6\n\n[[custom-hooks]]\nevent = \"{event}\"\ncommand = \"{command}\"\n"
+    ))
+    .unwrap();
+    let text = toml::to_string_pretty(&manifest).unwrap();
+    const HEADER: &str = "[[custom-hooks]]\n";
+    let block = &text[text.find(HEADER).unwrap() + HEADER.len()..];
+    block[..block.find("\n[").map_or(block.len(), |cut| cut + 1)].to_owned()
 }
 
 /// An inline `custom-hooks` array is edited inline. The comment above it
@@ -145,7 +156,7 @@ fn an_inline_hook_array_is_edited_inline() {
     );
     assert_eq!(
         fold(current, &changed),
-        "schema = 6\n\n# my hooks\ncustom-hooks = [{ event = \"Stop\", command = \"./finished.sh\" , enabled = true, agents = \"all\"}]\n"
+        "schema = 6\n\n# my hooks\ncustom-hooks = [{ event = \"Stop\", command = \"./finished.sh\" }]\n"
     );
 
     let gained = format!(
@@ -155,7 +166,7 @@ fn an_inline_hook_array_is_edited_inline() {
     );
     assert_eq!(
         fold(current, &gained),
-        "schema = 6\n\n# my hooks\ncustom-hooks = [{ event = \"Stop\", command = \"./done.sh\" , enabled = true, agents = \"all\"}, { event = \"PreToolUse\", command = \"./guard.sh\", enabled = true, agents = \"all\" }]\n"
+        "schema = 6\n\n# my hooks\ncustom-hooks = [{ event = \"Stop\", command = \"./done.sh\" }, { event = \"PreToolUse\", command = \"./guard.sh\" }]\n"
     );
 }
 
@@ -170,12 +181,14 @@ fn an_empty_inline_array_gains_its_first_entry_inline() {
     );
     assert_eq!(
         fold(current, &desired),
-        "schema = 6\n\n# my hooks\ncustom-hooks = [{ event = \"Stop\", command = \"./done.sh\", enabled = true, agents = \"all\" }]\n"
+        "schema = 6\n\n# my hooks\ncustom-hooks = [{ event = \"Stop\", command = \"./done.sh\" }]\n"
     );
 }
 
 /// A multi-line array gains an element without losing the layout or the
-/// comment written inside it.
+/// comment written inside it. Gaining is all this case ever exercised,
+/// which is how the positional-pairing class survived one level down: the
+/// four cases below cover losing and re-sorting.
 #[test]
 fn a_multiline_array_keeps_its_shape_and_its_inner_comment() {
     let current = "schema = 6\n\n[install]\nharnesses = [\n  # the one I use\n  \"claude\",\n]\n";
@@ -183,7 +196,7 @@ fn a_multiline_array_keeps_its_shape_and_its_inner_comment() {
         "schema = 6\n\n[install]\nharnesses = [\"claude\", \"codex\"]\nmethod = \"symlink\"\n";
     assert_eq!(
         fold(current, desired),
-        "schema = 6\n\n[install]\nharnesses = [\n  # the one I use\n  \"claude\", \"codex\",\n]\nmethod = \"symlink\"\n"
+        "schema = 6\n\n[install]\nharnesses = [\n  # the one I use\n  \"claude\",\n  \"codex\",\n]\nmethod = \"symlink\"\n"
     );
 }
 
@@ -268,12 +281,9 @@ fn a_hand_written_enabled_flag_survives_a_hook_edit() {
     let mut manifest: Manifest = toml::from_str(current).unwrap();
     manifest.custom_hooks[0].command = "./finished.sh".to_owned();
     let desired = toml::to_string_pretty(&manifest).unwrap();
-    // `[install]` comes with it. That table has no skip of its own, so the
-    // serializer spells it out whether or not the file had one — the one
-    // place a write still lands a table the operation did not name.
     assert_eq!(
         fold(current, &desired),
-        "schema = 6\n\n[[custom-hooks]]\nevent = \"Stop\"\ncommand = \"./finished.sh\"\nenabled = true   # still on\nagents = \"all\"\n\n[install]\nharnesses = []\nmethod = \"symlink\"\n"
+        "schema = 6\n\n[[custom-hooks]]\nevent = \"Stop\"\ncommand = \"./finished.sh\"\nenabled = true   # still on\n"
     );
 }
 
@@ -318,7 +328,7 @@ fn a_declaration_that_omits_enabled_keeps_omitting_it() {
     let current = "schema = 6\n\n# mine\n[skills.gh]\nsource = \"cat\"\n";
     assert_eq!(
         rebound(current, true),
-        "schema = 6\n\n# mine\n[skills.gh]\nsource = \"local\"\n\n[install]\nharnesses = []\nmethod = \"symlink\"\n"
+        "schema = 6\n\n# mine\n[skills.gh]\nsource = \"local\"\n"
     );
 }
 
@@ -330,7 +340,7 @@ fn a_hand_written_enabled_flag_stays_where_it_was_typed() {
     let current = "schema = 6\n\n[skills.gh]\nsource = \"cat\"\nenabled = true   # on purpose\n";
     assert_eq!(
         rebound(current, true),
-        "schema = 6\n\n[skills.gh]\nsource = \"local\"\nenabled = true   # on purpose\n\n[install]\nharnesses = []\nmethod = \"symlink\"\n"
+        "schema = 6\n\n[skills.gh]\nsource = \"local\"\nenabled = true   # on purpose\n"
     );
 }
 
@@ -341,7 +351,7 @@ fn a_disabled_declaration_keeps_its_flag() {
     let current = "schema = 6\n\n[skills.gh]\nsource = \"cat\"\nenabled = false\n";
     assert_eq!(
         rebound(current, false),
-        "schema = 6\n\n[skills.gh]\nsource = \"local\"\nenabled = false\n\n[install]\nharnesses = []\nmethod = \"symlink\"\n"
+        "schema = 6\n\n[skills.gh]\nsource = \"local\"\nenabled = false\n"
     );
 }
 
@@ -354,6 +364,104 @@ fn re_enabling_a_declaration_deletes_the_flag() {
     let current = "schema = 6\n\n[skills.gh]\nsource = \"cat\"\nenabled = false\n";
     assert_eq!(
         rebound(current, true),
-        "schema = 6\n\n[skills.gh]\nsource = \"local\"\n\n[install]\nharnesses = []\nmethod = \"symlink\"\n"
+        "schema = 6\n\n[skills.gh]\nsource = \"local\"\n"
     );
+}
+
+/// A list somebody annotated, in the spelling that annotates one: the
+/// comment sits after the value, on its line. TOML stores each of those
+/// against the value below it, so nothing here works by keeping an
+/// entry's own decoration.
+const ANNOTATED: &str = "schema = 6\n\n[suppressed]\nskill = [\n  \"alpha\",  # pulled in by gh\n  \"beta\",   # pulled in by fmt\n  \"gamma\",  # pulled in by rev\n]\n";
+
+#[allow(clippy::unwrap_used)]
+fn suppressing(names: &[&str]) -> String {
+    let desired = format!(
+        "schema = 6\n\n[suppressed]\nskill = [{}]\n",
+        names
+            .iter()
+            .map(|name| format!("\"{name}\""))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    fold(ANNOTATED, &desired)
+}
+
+/// Losing the first entry takes that entry's own annotation and leaves
+/// every other one where it was written.
+#[test]
+fn losing_the_first_entry_leaves_the_rest_annotated() {
+    assert_eq!(
+        suppressing(&["beta", "gamma"]),
+        "schema = 6\n\n[suppressed]\nskill = [\n  \"beta\",   # pulled in by fmt\n  \"gamma\",  # pulled in by rev\n]\n"
+    );
+}
+
+/// Losing a middle entry closes the gap without sliding the annotations
+/// up with it — by position, `gamma` would inherit what was written about
+/// `beta`.
+#[test]
+fn losing_a_middle_entry_does_not_slide_the_annotations() {
+    assert_eq!(
+        suppressing(&["alpha", "gamma"]),
+        "schema = 6\n\n[suppressed]\nskill = [\n  \"alpha\",  # pulled in by gh\n  \"gamma\",  # pulled in by rev\n]\n"
+    );
+}
+
+/// Losing the LAST entry is the case that stays broken longest: what was
+/// written about the entry above it is stored inside the entry that goes,
+/// so a fold that drops entries by their own bytes deletes an annotation
+/// about something still in the list.
+#[test]
+fn losing_the_last_entry_keeps_the_annotation_above_it() {
+    assert_eq!(
+        suppressing(&["alpha", "beta"]),
+        "schema = 6\n\n[suppressed]\nskill = [\n  \"alpha\",  # pulled in by gh\n  \"beta\",   # pulled in by fmt\n]\n"
+    );
+}
+
+/// `Manifest::suppress` sorts the list on every removal, so an ordinary
+/// `kendex remove` re-sorts a list somebody annotated. Each annotation
+/// moves with the skill it was written about.
+#[test]
+fn re_sorting_a_list_moves_each_annotation_with_its_own_value() {
+    assert_eq!(
+        suppressing(&["gamma", "alpha", "beta"]),
+        "schema = 6\n\n[suppressed]\nskill = [\n  \"gamma\",  # pulled in by rev\n  \"alpha\",  # pulled in by gh\n  \"beta\",   # pulled in by fmt\n]\n"
+    );
+}
+
+/// The security-shaped instance: a denial somebody annotated must not end
+/// up over a tool it no longer denies.
+#[test]
+fn dropping_a_denied_tool_takes_its_own_annotation() {
+    let current = "schema = 6\n\n[agent-frontmatter.claude.rev]\ndeny-tools = [\n  \"Bash\",     # never lets it shell out\n  \"WebFetch\", # never lets it push\n]\n";
+    let desired = "schema = 6\n\n[agent-frontmatter.claude.rev]\ndeny-tools = [\"WebFetch\"]\n";
+    assert_eq!(
+        fold(current, desired),
+        "schema = 6\n\n[agent-frontmatter.claude.rev]\ndeny-tools = [\n  \"WebFetch\", # never lets it push\n]\n"
+    );
+}
+
+/// A key gained inside an inline table lands before the closing brace,
+/// not before the comma above it. The spacing an inline table keeps at its
+/// brace belongs to the brace, and each spelling keeps its own.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_key_gained_inside_an_inline_table_reads_as_one() {
+    for (current, expected) in [
+        (
+            "schema = 6\n\ncustom-hooks = [{ event = \"Stop\", command = \"./done.sh\" }]\n",
+            "schema = 6\n\ncustom-hooks = [{ event = \"Stop\", command = \"./done.sh\", matcher = \"Bash\" }]\n",
+        ),
+        (
+            "schema = 6\n\ncustom-hooks = [{event = \"Stop\", command = \"./done.sh\"}]\n",
+            "schema = 6\n\ncustom-hooks = [{event = \"Stop\", command = \"./done.sh\", matcher = \"Bash\"}]\n",
+        ),
+    ] {
+        let mut manifest: Manifest = toml::from_str(current).unwrap();
+        manifest.custom_hooks[0].matcher = Some("Bash".to_owned());
+        let desired = toml::to_string_pretty(&manifest).unwrap();
+        assert_eq!(fold(current, &desired), expected);
+    }
 }

--- a/crates/core/src/manifest/edit/tests.rs
+++ b/crates/core/src/manifest/edit/tests.rs
@@ -3,10 +3,16 @@
 //! kendex.toml, and the assertion is on the bytes.
 
 use super::merged;
+use crate::manifest::Manifest;
 
+/// A fold with `held` derived the way `manifest::save` derives it: the
+/// manifest this very document reads back as, spelled by the serializer
+/// that spelled the target.
 #[allow(clippy::unwrap_used)]
 fn fold(current: &str, desired: &str) -> String {
-    merged(current, desired).unwrap()
+    let held: Manifest = toml::from_str(current).unwrap();
+    let held = toml::to_string_pretty(&held).unwrap();
+    merged(current, &held, desired).unwrap()
 }
 
 /// The whole point: a document whose values already say what kendex holds
@@ -118,5 +124,174 @@ fn the_files_own_terminator_survives() {
 /// this into the same parse error a read would have raised.
 #[test]
 fn an_unparsable_document_is_refused() {
-    assert!(merged("not = [valid", "schema = 6\n").is_err());
+    assert!(merged("not = [valid", "schema = 6\n", "schema = 6\n").is_err());
+}
+
+/// A hook as the serializer spells one, so a case says what it is testing
+/// rather than transcribing the model's every field.
+fn hook(event: &str, command: &str) -> String {
+    format!("event = \"{event}\"\ncommand = \"{command}\"\nenabled = true\nagents = \"all\"\n")
+}
+
+/// An inline `custom-hooks` array is edited inline. The comment above it
+/// is written once, where it was, and not once per entry the serializer
+/// would have generated.
+#[test]
+fn an_inline_hook_array_is_edited_inline() {
+    let current = "schema = 6\n\n# my hooks\ncustom-hooks = [{ event = \"Stop\", command = \"./done.sh\" }]\n";
+    let changed = format!(
+        "schema = 6\n\n[[custom-hooks]]\n{}",
+        hook("Stop", "./finished.sh")
+    );
+    assert_eq!(
+        fold(current, &changed),
+        "schema = 6\n\n# my hooks\ncustom-hooks = [{ event = \"Stop\", command = \"./finished.sh\" , enabled = true, agents = \"all\"}]\n"
+    );
+
+    let gained = format!(
+        "schema = 6\n\n[[custom-hooks]]\n{}\n[[custom-hooks]]\n{}",
+        hook("Stop", "./done.sh"),
+        hook("PreToolUse", "./guard.sh")
+    );
+    assert_eq!(
+        fold(current, &gained),
+        "schema = 6\n\n# my hooks\ncustom-hooks = [{ event = \"Stop\", command = \"./done.sh\" , enabled = true, agents = \"all\"}, { event = \"PreToolUse\", command = \"./guard.sh\", enabled = true, agents = \"all\" }]\n"
+    );
+}
+
+/// An empty inline array gaining its first entry stays an inline array,
+/// with no header generated out of the key's own decoration.
+#[test]
+fn an_empty_inline_array_gains_its_first_entry_inline() {
+    let current = "schema = 6\n\n# my hooks\ncustom-hooks = []\n";
+    let desired = format!(
+        "schema = 6\n\n[[custom-hooks]]\n{}",
+        hook("Stop", "./done.sh")
+    );
+    assert_eq!(
+        fold(current, &desired),
+        "schema = 6\n\n# my hooks\ncustom-hooks = [{ event = \"Stop\", command = \"./done.sh\", enabled = true, agents = \"all\" }]\n"
+    );
+}
+
+/// A multi-line array gains an element without losing the layout or the
+/// comment written inside it.
+#[test]
+fn a_multiline_array_keeps_its_shape_and_its_inner_comment() {
+    let current = "schema = 6\n\n[install]\nharnesses = [\n  # the one I use\n  \"claude\",\n]\n";
+    let desired =
+        "schema = 6\n\n[install]\nharnesses = [\"claude\", \"codex\"]\nmethod = \"symlink\"\n";
+    assert_eq!(
+        fold(current, desired),
+        "schema = 6\n\n[install]\nharnesses = [\n  # the one I use\n  \"claude\", \"codex\",\n]\nmethod = \"symlink\"\n"
+    );
+}
+
+/// Removing a hook takes that hook's comment and leaves every other
+/// comment over the hook it describes. By position the survivors would
+/// shift up under comments that belong to what was removed.
+#[test]
+fn removing_a_hook_leaves_every_comment_over_its_own_hook() {
+    let two = "schema = 6\n\n# guards every bash call\n[[custom-hooks]]\nevent = \"PreToolUse\"\ncommand = \"./guard.sh\"\n\n# says we are done\n[[custom-hooks]]\nevent = \"Stop\"\ncommand = \"./done.sh\"\n";
+    let keep_second = format!(
+        "schema = 6\n\n[[custom-hooks]]\n{}",
+        hook("Stop", "./done.sh")
+    );
+    assert_eq!(
+        fold(two, &keep_second),
+        format!(
+            "schema = 6\n\n# says we are done\n[[custom-hooks]]\n{}",
+            hook("Stop", "./done.sh")
+        )
+    );
+
+    let three = "schema = 6\n\n# first\n[[custom-hooks]]\nevent = \"Stop\"\ncommand = \"./a.sh\"\n\n# second\n[[custom-hooks]]\nevent = \"Stop\"\ncommand = \"./b.sh\"\n\n# third\n[[custom-hooks]]\nevent = \"Stop\"\ncommand = \"./c.sh\"\n";
+    let drop_middle = format!(
+        "schema = 6\n\n[[custom-hooks]]\n{}\n[[custom-hooks]]\n{}",
+        hook("Stop", "./a.sh"),
+        hook("Stop", "./c.sh")
+    );
+    assert_eq!(
+        fold(three, &drop_middle),
+        format!(
+            "schema = 6\n\n# first\n[[custom-hooks]]\n{}\n# third\n[[custom-hooks]]\n{}",
+            hook("Stop", "./a.sh"),
+            hook("Stop", "./c.sh")
+        )
+    );
+}
+
+/// Reordering hooks moves each comment with the hook it was written
+/// against, and the entries take the places the array already held.
+#[test]
+fn reordering_hooks_carries_every_comment_with_its_hook() {
+    let three = "schema = 6\n\n# one\n[[custom-hooks]]\nevent = \"Stop\"\ncommand = \"./a.sh\"\n\n# two\n[[custom-hooks]]\nevent = \"Stop\"\ncommand = \"./b.sh\"\n\n# three\n[[custom-hooks]]\nevent = \"Stop\"\ncommand = \"./c.sh\"\n";
+    let reversed = format!(
+        "schema = 6\n\n[[custom-hooks]]\n{}\n[[custom-hooks]]\n{}\n[[custom-hooks]]\n{}",
+        hook("Stop", "./c.sh"),
+        hook("Stop", "./b.sh"),
+        hook("Stop", "./a.sh")
+    );
+    assert_eq!(
+        fold(three, &reversed),
+        format!(
+            "schema = 6\n\n# three\n[[custom-hooks]]\n{}\n# two\n[[custom-hooks]]\n{}\n# one\n[[custom-hooks]]\n{}",
+            hook("Stop", "./c.sh"),
+            hook("Stop", "./b.sh"),
+            hook("Stop", "./a.sh")
+        )
+    );
+}
+
+/// A key the manifest model does not carry is not the model's to drop. It
+/// stays exactly where it was written while the keys around it change.
+#[test]
+fn a_key_the_model_does_not_hold_is_left_alone() {
+    let current =
+        "schema = 6\n\n[skills.gh]\nsource = \"cat\"\nnote = \"why I keep this\"\nenabled = true\n";
+    let desired = "schema = 6\n\n[skills.gh]\nsource = \"local\"\nenabled = true\n";
+    assert_eq!(
+        fold(current, desired),
+        "schema = 6\n\n[skills.gh]\nsource = \"local\"\nnote = \"why I keep this\"\nenabled = true\n"
+    );
+}
+
+/// A hand-written `enabled = true` inside a hook survives an edit to the
+/// hook beside it. The target here is the real serializer's, not a
+/// fixture's, because what a declaration field spells out is exactly the
+/// question: a field the serialization leaves out must not read as a field
+/// the manifest dropped.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_hand_written_enabled_flag_survives_a_hook_edit() {
+    let current = "schema = 6\n\n[[custom-hooks]]\nevent = \"Stop\"\ncommand = \"./done.sh\"\nenabled = true   # still on\n";
+    let mut manifest: Manifest = toml::from_str(current).unwrap();
+    manifest.custom_hooks[0].command = "./finished.sh".to_owned();
+    let desired = toml::to_string_pretty(&manifest).unwrap();
+    // `[install]` comes with it: the serializer spells that table out
+    // whether or not the file had one, which is the declaration-default
+    // exception invariant 10 names.
+    assert_eq!(
+        fold(current, &desired),
+        "schema = 6\n\n[[custom-hooks]]\nevent = \"Stop\"\ncommand = \"./finished.sh\"\nenabled = true   # still on\nagents = \"all\"\n\n[install]\nharnesses = []\nmethod = \"symlink\"\n"
+    );
+}
+
+/// A list written in two places with another table between them keeps
+/// those places. Filling the array's entries into the first slots would
+/// pull a surviving hook above a table that has nothing to do with it.
+#[test]
+fn a_split_hook_list_keeps_the_places_it_was_written_in() {
+    let split = "schema = 6\n\n# first\n[[custom-hooks]]\nevent = \"Stop\"\ncommand = \"./a.sh\"\n\n[install]\nmethod = \"copy\"\n\n# second\n[[custom-hooks]]\nevent = \"Stop\"\ncommand = \"./b.sh\"\n";
+    let keep_second = format!(
+        "schema = 6\n\n[[custom-hooks]]\n{}\n[install]\nmethod = \"copy\"\n",
+        hook("Stop", "./b.sh")
+    );
+    assert_eq!(
+        fold(split, &keep_second),
+        format!(
+            "schema = 6\n\n[install]\nmethod = \"copy\"\n\n# second\n[[custom-hooks]]\n{}",
+            hook("Stop", "./b.sh")
+        )
+    );
 }

--- a/crates/core/src/manifest/edit/tests.rs
+++ b/crates/core/src/manifest/edit/tests.rs
@@ -268,9 +268,9 @@ fn a_hand_written_enabled_flag_survives_a_hook_edit() {
     let mut manifest: Manifest = toml::from_str(current).unwrap();
     manifest.custom_hooks[0].command = "./finished.sh".to_owned();
     let desired = toml::to_string_pretty(&manifest).unwrap();
-    // `[install]` comes with it: the serializer spells that table out
-    // whether or not the file had one, which is the declaration-default
-    // exception invariant 10 names.
+    // `[install]` comes with it. That table has no skip of its own, so the
+    // serializer spells it out whether or not the file had one — the one
+    // place a write still lands a table the operation did not name.
     assert_eq!(
         fold(current, &desired),
         "schema = 6\n\n[[custom-hooks]]\nevent = \"Stop\"\ncommand = \"./finished.sh\"\nenabled = true   # still on\nagents = \"all\"\n\n[install]\nharnesses = []\nmethod = \"symlink\"\n"
@@ -293,5 +293,67 @@ fn a_split_hook_list_keeps_the_places_it_was_written_in() {
             "schema = 6\n\n[install]\nmethod = \"copy\"\n\n# second\n[[custom-hooks]]\n{}",
             hook("Stop", "./b.sh")
         )
+    );
+}
+
+/// The four things a declaration's `enabled` flag has to do. Every target
+/// here comes from the real serializer, because what the serialization
+/// spells out is the whole question: a flag reads as true when it is
+/// absent, so writing it out puts a key in somebody's file that says
+/// nothing the file did not already say.
+#[allow(clippy::unwrap_used)]
+fn rebound(current: &str, enabled: bool) -> String {
+    let mut manifest: Manifest = toml::from_str(current).unwrap();
+    let skill = manifest.skills.get_mut("gh").unwrap();
+    skill.source = "local".to_owned();
+    skill.enabled = enabled;
+    let desired = toml::to_string_pretty(&manifest).unwrap();
+    fold(current, &desired)
+}
+
+/// A declaration that left the flag out still leaves it out. This is the
+/// Done-when: a write touches the keys the operation names and no others.
+#[test]
+fn a_declaration_that_omits_enabled_keeps_omitting_it() {
+    let current = "schema = 6\n\n# mine\n[skills.gh]\nsource = \"cat\"\n";
+    assert_eq!(
+        rebound(current, true),
+        "schema = 6\n\n# mine\n[skills.gh]\nsource = \"local\"\n\n[install]\nharnesses = []\nmethod = \"symlink\"\n"
+    );
+}
+
+/// A flag somebody typed by hand stays, comment and spacing included. The
+/// serialization leaves it out, and a key the serialization leaves out is
+/// never read as a key the manifest dropped.
+#[test]
+fn a_hand_written_enabled_flag_stays_where_it_was_typed() {
+    let current = "schema = 6\n\n[skills.gh]\nsource = \"cat\"\nenabled = true   # on purpose\n";
+    assert_eq!(
+        rebound(current, true),
+        "schema = 6\n\n[skills.gh]\nsource = \"local\"\nenabled = true   # on purpose\n\n[install]\nharnesses = []\nmethod = \"symlink\"\n"
+    );
+}
+
+/// A declaration switched off stays switched off: `false` is not the
+/// default, so the serialization says it and the fold leaves it be.
+#[test]
+fn a_disabled_declaration_keeps_its_flag() {
+    let current = "schema = 6\n\n[skills.gh]\nsource = \"cat\"\nenabled = false\n";
+    assert_eq!(
+        rebound(current, false),
+        "schema = 6\n\n[skills.gh]\nsource = \"local\"\nenabled = false\n\n[install]\nharnesses = []\nmethod = \"symlink\"\n"
+    );
+}
+
+/// Switching a disabled declaration back on deletes the line rather than
+/// writing `enabled = true` over it. The flag is a key the manifest really
+/// did hold and really did drop, so the sweep takes it — which is what
+/// keeps the sweep from being a rule that only ever preserves.
+#[test]
+fn re_enabling_a_declaration_deletes_the_flag() {
+    let current = "schema = 6\n\n[skills.gh]\nsource = \"cat\"\nenabled = false\n";
+    assert_eq!(
+        rebound(current, true),
+        "schema = 6\n\n[skills.gh]\nsource = \"local\"\n\n[install]\nharnesses = []\nmethod = \"symlink\"\n"
     );
 }

--- a/crates/core/src/manifest/edit/tests.rs
+++ b/crates/core/src/manifest/edit/tests.rs
@@ -3,7 +3,7 @@
 //! kendex.toml, and the assertion is on the bytes.
 
 use super::merged;
-use crate::manifest::Manifest;
+use crate::manifest::{InstallDefaults, Manifest};
 
 /// A fold with `held` derived the way `manifest::save` derives it: the
 /// manifest this very document reads back as, spelled by the serializer
@@ -188,7 +188,7 @@ fn an_empty_inline_array_gains_its_first_entry_inline() {
 /// A multi-line array gains an element without losing the layout or the
 /// comment written inside it. Gaining is all this case ever exercised,
 /// which is how the positional-pairing class survived one level down: the
-/// four cases below cover losing and re-sorting.
+/// cases below cover losing and re-sorting.
 #[test]
 fn a_multiline_array_keeps_its_shape_and_its_inner_comment() {
     let current = "schema = 6\n\n[install]\nharnesses = [\n  # the one I use\n  \"claude\",\n]\n";
@@ -297,12 +297,12 @@ fn a_split_hook_list_keeps_the_places_it_was_written_in() {
         "schema = 6\n\n[[custom-hooks]]\n{}\n[install]\nmethod = \"copy\"\n",
         hook("Stop", "./b.sh")
     );
+    // Spelled out rather than built from `hook()` again: the helper is
+    // already the target handed to the fold, and a helper on both sides
+    // of one assertion cannot see itself drift.
     assert_eq!(
         fold(split, &keep_second),
-        format!(
-            "schema = 6\n\n[install]\nmethod = \"copy\"\n\n# second\n[[custom-hooks]]\n{}",
-            hook("Stop", "./b.sh")
-        )
+        "schema = 6\n\n[install]\nmethod = \"copy\"\n\n# second\n[[custom-hooks]]\nevent = \"Stop\"\ncommand = \"./b.sh\"\n"
     );
 }
 
@@ -464,4 +464,131 @@ fn a_key_gained_inside_an_inline_table_reads_as_one() {
         let desired = toml::to_string_pretty(&manifest).unwrap();
         assert_eq!(fold(current, &desired), expected);
     }
+}
+
+/// A list somebody wrote, folded against exactly what it already says.
+/// The whole file has to come back byte for byte: a manifest write folds
+/// every array in the file, so a run of bytes this cannot reproduce turns
+/// each `kendex add` into a reformat of arrays nobody touched.
+#[allow(clippy::unwrap_used)]
+fn refolded(list: &str) -> String {
+    rewritten(&format!("schema = 6\n\n[suppressed]\nskill = {list}\n"))
+}
+
+/// The file a write leaves behind when the manifest it carries is the one
+/// this file already reads as. `save` builds exactly these two documents
+/// and writes only where the bytes moved, so anything but the input back
+/// is a key some operation landed without naming it.
+#[allow(clippy::unwrap_used)]
+fn rewritten(current: &str) -> String {
+    let held: Manifest = toml::from_str(current).unwrap();
+    let held = toml::to_string_pretty(&held).unwrap();
+    merged(current, &held, &held).unwrap()
+}
+
+/// Every way a person can hold the bytes between the last value and the
+/// bracket. TOML keeps them in the array's trailing text only when the
+/// list ends with a comma; without one they are the last value's suffix,
+/// and an array with no values keeps the whole span in its trailing.
+#[test]
+fn the_bytes_before_the_bracket_survive_however_they_are_kept() {
+    for list in [
+        // No trailing comma: the line break before `]` is the last
+        // value's suffix, and nothing else in the file knows about it.
+        "[\n  \"alpha\",\n  \"beta\"\n]",
+        // The same, held on one line by spaces.
+        "[ \"alpha\" ]",
+        // An annotation written before the comma rather than after it,
+        // which is the other place a suffix can hold a person's words.
+        "[\n  \"alpha\" # the main one\n  ,\n  \"beta\",\n]",
+        // No values at all, so there is no prefix to read the opening
+        // line from and no suffix to read the closing one.
+        "[\n]",
+        "[\n  # none yet\n]",
+        // The shapes that were already covered, so a fix for the ones
+        // above cannot pay for itself here.
+        "[\n  \"alpha\",\n]",
+        "[\"alpha\", \"beta\"]",
+    ] {
+        assert_eq!(
+            refolded(list),
+            format!("schema = 6\n\n[suppressed]\nskill = {list}\n"),
+            "folding {list} against itself must change nothing"
+        );
+    }
+}
+
+/// Emptying a list reaches its own end state in one write. A second fold
+/// that moved another byte would mean the first left the file in a shape
+/// kendex does not itself write, which invariant 11 does not allow.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn emptying_a_list_settles_in_one_write() {
+    let current = "schema = 6\n\n[suppressed]\nskill = [\n  \"alpha\",\n]\n";
+    let empty = "schema = 6\n\n[suppressed]\nskill = []\n";
+    let once = fold(current, empty);
+    assert_eq!(once, "schema = 6\n\n[suppressed]\nskill = [\n]\n");
+    let held: Manifest = toml::from_str(&once).unwrap();
+    let held = toml::to_string_pretty(&held).unwrap();
+    assert_eq!(merged(&once, &held, empty).unwrap(), once);
+}
+
+/// An entry gained in the middle of a one-line list is separated once,
+/// and takes nothing from the entry it displaced. Appending takes the
+/// separator the same way and leaves none before the bracket.
+#[test]
+fn a_gained_entry_is_separated_once_wherever_it_lands() {
+    let current = "schema = 6\n\n[suppressed]\nskill = [\"alpha\", \"zulu\"]\n";
+    for names in [["alpha", "mike", "zulu"], ["alpha", "zulu", "mike"]] {
+        let desired = format!(
+            "schema = 6\n\n[suppressed]\nskill = [{}]\n",
+            names
+                .iter()
+                .map(|name| format!("\"{name}\""))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        assert_eq!(fold(current, &desired), desired);
+    }
+}
+
+/// A declaration that left a field out gets it back from nobody. Both
+/// shapes here are the only ones in which their field's skip is reachable
+/// at all: `[install]`'s own skip hides the harnesses question whenever
+/// install is wholly default, and a plugin declares nothing else.
+#[test]
+fn a_write_names_no_field_a_declaration_left_out() {
+    for current in [
+        "schema = 6\n\n# how things install here\n[install]\nmethod = \"copy\"\n",
+        "schema = 6\n\n[plugins.\"fmt@mkt\"]\nenabled = true\n",
+    ] {
+        assert_eq!(rewritten(current), current);
+    }
+}
+
+/// A boundary, pinned rather than fixed. `Manifest::install` skips at its
+/// default, so a manifest whose install is default spells no `[install]`
+/// at all — and the sweep reads a table `held` names and the target does
+/// not as a table the manifest dropped. Everything written against it
+/// goes: the comment above the header, and a note left inside it.
+///
+/// Nothing reaches this today. An install goes from non-default to
+/// default only if a write clears every harness or resets the method, and
+/// nothing in the tree does either: the engine only adds harnesses, the
+/// editor only refills them, and nothing writes the method at all. The
+/// day something does, this case turns red here instead of quietly in
+/// somebody's file.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn clearing_install_would_take_the_table_written_around_it() {
+    let current = "schema = 6\n\n# how things install here\n[install]\nmethod = \"copy\"\nnote = \"why I chose copy\"\n";
+    let mut manifest: Manifest = toml::from_str(current).unwrap();
+    manifest.install = InstallDefaults::default();
+    let desired = toml::to_string_pretty(&manifest).unwrap();
+    assert_eq!(
+        fold(current, &desired),
+        "schema = 6\n",
+        "the whole table goes, comment and note with it — the day a writer \
+         can reach this, that is what it costs"
+    );
 }

--- a/crates/core/src/manifest/edit/tests.rs
+++ b/crates/core/src/manifest/edit/tests.rs
@@ -1,0 +1,122 @@
+//! What a fold leaves behind, spelled out on documents rather than on
+//! manifests: every case here is a shape somebody can legally write in
+//! kendex.toml, and the assertion is on the bytes.
+
+use super::merged;
+
+#[allow(clippy::unwrap_used)]
+fn fold(current: &str, desired: &str) -> String {
+    merged(current, desired).unwrap()
+}
+
+/// The whole point: a document whose values already say what kendex holds
+/// comes back byte-identical, comments and spelling included.
+#[test]
+fn a_document_that_already_agrees_is_returned_unchanged() {
+    let current = "# my setup\nschema  =  6\n\n# where it comes from\n[sources.cat]\npath = 'x'   # local\nenabled = true\n\n[skills.gh]\nsource = \"cat\"\n";
+    let desired = "schema = 6\n\n[sources.cat]\npath = \"x\"\nenabled = true\n\n[skills.gh]\nsource = \"cat\"\n";
+    assert_eq!(fold(current, desired), current);
+}
+
+/// A gained table lands after the tables already there, with the blank
+/// line the serializer puts before it, and nothing above it moves.
+#[test]
+fn a_gained_table_is_appended_and_leaves_the_rest_alone() {
+    let current = "# mine\nschema = 6\n\n[skills.gh]\nsource = \"cat\"   # keep\n";
+    let desired = "schema = 6\n\n[skills.gh]\nsource = \"cat\"\n\n[skills.fmt]\nsource = \"cat\"\n";
+    assert_eq!(
+        fold(current, desired),
+        "# mine\nschema = 6\n\n[skills.gh]\nsource = \"cat\"   # keep\n\n[skills.fmt]\nsource = \"cat\"\n"
+    );
+}
+
+/// A gained key lands inside the table it belongs to, under the keys
+/// already there — not at the end of the file, where it would read as a
+/// key of whichever table happens to be last.
+#[test]
+fn a_gained_key_lands_inside_its_own_table() {
+    let current = "schema = 6\n\n[sources.cat]\n# the catalog\npath = \"x\"\n\n[install]\nmethod = \"copy\"\n";
+    let desired = "schema = 6\n\n[sources.cat]\npath = \"x\"\nrev = \"main\"\n\n[install]\nmethod = \"copy\"\n";
+    assert_eq!(
+        fold(current, desired),
+        "schema = 6\n\n[sources.cat]\n# the catalog\npath = \"x\"\nrev = \"main\"\n\n[install]\nmethod = \"copy\"\n"
+    );
+}
+
+/// A changed value keeps the whitespace and the trailing comment that sat
+/// with it; every other line is untouched.
+#[test]
+fn a_changed_value_keeps_its_own_decoration() {
+    let current = "schema = 6\n\n[install]\nmethod   =   \"copy\"   # for now\n";
+    let desired = "schema = 6\n\n[install]\nmethod = \"symlink\"\n";
+    assert_eq!(
+        fold(current, desired),
+        "schema = 6\n\n[install]\nmethod   =   \"symlink\"   # for now\n"
+    );
+}
+
+/// A dropped table takes the comments written against it and nothing else.
+#[test]
+fn a_dropped_table_takes_only_its_own_lines() {
+    let current = "schema = 6\n\n# gh, for github\n[skills.gh]\nsource = \"cat\"\n\n# formatting\n[skills.fmt]\nsource = \"cat\"\n";
+    let desired = "schema = 6\n\n[skills.fmt]\nsource = \"cat\"\n";
+    assert_eq!(
+        fold(current, desired),
+        "schema = 6\n\n# formatting\n[skills.fmt]\nsource = \"cat\"\n"
+    );
+}
+
+/// Inline tables and dotted keys are how a person may have spelled the
+/// same declarations. A fold that agrees with them rewrites neither, and
+/// one that disagrees edits inside the spelling it found.
+#[test]
+fn inline_and_dotted_spellings_are_kept() {
+    let current = "schema = 6\nsources.cat = { path = \"x\", enabled = true }\n\n[skills]\ngh = { source = \"cat\" }\n";
+    let desired = "schema = 6\n\n[sources.cat]\npath = \"x\"\nenabled = true\n\n[skills.gh]\nsource = \"cat\"\n";
+    assert_eq!(fold(current, desired), current);
+
+    let changed = "schema = 6\n\n[sources.cat]\npath = \"y\"\nenabled = true\n\n[skills.gh]\nsource = \"cat\"\n";
+    assert_eq!(
+        fold(current, changed),
+        "schema = 6\nsources.cat = { path = \"y\", enabled = true }\n\n[skills]\ngh = { source = \"cat\" }\n"
+    );
+}
+
+/// An array of tables written inline stays inline while it agrees, and an
+/// entry's untouched keys survive an edit to a neighbouring key.
+#[test]
+fn a_table_array_is_edited_entry_by_entry() {
+    let current = "schema = 6\n\n[[custom-hooks]]\n# runs before every bash call\nevent = \"PreToolUse\"\ncommand = \"./guard.sh\"\n\n[[custom-hooks]]\nevent = \"Stop\"\ncommand = \"./done.sh\"\n";
+    let desired = "schema = 6\n\n[[custom-hooks]]\nevent = \"PreToolUse\"\ncommand = \"./guard.sh\"\n\n[[custom-hooks]]\nevent = \"Stop\"\ncommand = \"./finished.sh\"\n";
+    assert_eq!(
+        fold(current, desired),
+        "schema = 6\n\n[[custom-hooks]]\n# runs before every bash call\nevent = \"PreToolUse\"\ncommand = \"./guard.sh\"\n\n[[custom-hooks]]\nevent = \"Stop\"\ncommand = \"./finished.sh\"\n"
+    );
+
+    let inline = "schema = 6\ncustom-hooks = [{ event = \"Stop\", command = \"./done.sh\" }]\n";
+    let same = "schema = 6\n\n[[custom-hooks]]\nevent = \"Stop\"\ncommand = \"./done.sh\"\n";
+    assert_eq!(fold(inline, same), inline);
+}
+
+/// A file's own terminator is its own: a document ending without one gets
+/// exactly the one its last line needs, and a document ending in a blank
+/// line keeps it.
+#[test]
+fn the_files_own_terminator_survives() {
+    let desired = "schema = 6\n\n[install]\nmethod = \"copy\"\n";
+    assert_eq!(
+        fold("schema = 6\n\n[install]\nmethod = \"copy\"", desired),
+        desired
+    );
+    assert_eq!(
+        fold("schema = 6\n\n[install]\nmethod = \"copy\"\n\n", desired),
+        "schema = 6\n\n[install]\nmethod = \"copy\"\n\n"
+    );
+}
+
+/// A file that is not TOML is refused, never rewritten — the caller turns
+/// this into the same parse error a read would have raised.
+#[test]
+fn an_unparsable_document_is_refused() {
+    assert!(merged("not = [valid", "schema = 6\n").is_err());
+}

--- a/crates/core/src/manifest/file.rs
+++ b/crates/core/src/manifest/file.rs
@@ -121,6 +121,11 @@ pub fn observed(path: &Path) -> Result<Manifest> {
     }
 }
 
+/// Persist a manifest, in place. The file is the person's own writing, so
+/// the serialization below is not what lands: it is folded into the
+/// document already there ([`super::edit::merged`]), and only the keys
+/// whose values changed are touched. A write that changes nothing writes
+/// nothing, the way a structured config edit does.
 pub fn save(path: &Path, manifest: &Manifest) -> Result<()> {
     // Stamped at the write, the way the lock stamps its version: the
     // schema is a fact about the build doing the writing, and two places
@@ -130,10 +135,23 @@ pub fn save(path: &Path, manifest: &Manifest) -> Result<()> {
         schema: MANIFEST_SCHEMA,
         ..manifest.clone()
     };
-    let text = toml::to_string_pretty(manifest).map_err(|e| CoreError::TomlParse {
+    let desired = toml::to_string_pretty(manifest).map_err(|e| CoreError::TomlParse {
         path: path.to_path_buf(),
         message: e.to_string(),
     })?;
+    let current = read_if_exists(path)?;
+    let text = match &current {
+        Some(current) => {
+            super::edit::merged(current, &desired).map_err(|e| CoreError::TomlParse {
+                path: path.to_path_buf(),
+                message: e.to_string(),
+            })?
+        }
+        None => desired,
+    };
+    if current.as_deref() == Some(text.as_str()) {
+        return Ok(());
+    }
     atomic_write(path, &text)
 }
 

--- a/crates/core/src/manifest/file.rs
+++ b/crates/core/src/manifest/file.rs
@@ -121,6 +121,31 @@ pub fn observed(path: &Path) -> Result<Manifest> {
     }
 }
 
+/// The predicates the model's serde attributes skip through. They live
+/// beside the write because that is the whole reason they exist.
+///
+/// Why every field with a default skips at it: an absent key already reads
+/// as that value, and kendex.toml is edited in place, so writing it out
+/// would put a key in somebody's file that says nothing the file did not
+/// already say. What the file does spell is safe either way — a removal is
+/// decided by what the manifest read back out of that same file, never by
+/// what the serializer left out.
+///
+/// Two rules hold that. Every field serde gives a default carries a skip
+/// predicate beside it; a field that gains the one without the other
+/// falsifies ARCHITECTURE invariant 10, and the serde attributes on the
+/// model are where that is read off. And no predicate restates a default: each
+/// asks the same `default_*` or `Default` the field deserializes through,
+/// so changing a default moves the write with it instead of silently
+/// inverting the field.
+pub(super) fn is_default<T: Default + PartialEq>(value: &T) -> bool {
+    *value == T::default()
+}
+
+pub(super) fn is_true(value: &bool) -> bool {
+    *value == super::default_true()
+}
+
 /// Persist a manifest, in place. The file is written by hand, so the
 /// serialization below is not what lands: it is folded into the document
 /// already there ([`super::edit::merged`]), which touches only the keys

--- a/crates/core/src/manifest/file.rs
+++ b/crates/core/src/manifest/file.rs
@@ -121,11 +121,11 @@ pub fn observed(path: &Path) -> Result<Manifest> {
     }
 }
 
-/// Persist a manifest, in place. The file is the person's own writing, so
-/// the serialization below is not what lands: it is folded into the
-/// document already there ([`super::edit::merged`]), and only the keys
-/// whose values changed are touched. A write that changes nothing writes
-/// nothing, the way a structured config edit does.
+/// Persist a manifest, in place. The file is written by hand, so the
+/// serialization below is not what lands: it is folded into the document
+/// already there ([`super::edit::merged`]), which touches only the keys
+/// that changed and the keys the manifest gained or dropped. A write that
+/// changes nothing writes nothing, the way a structured config edit does.
 pub fn save(path: &Path, manifest: &Manifest) -> Result<()> {
     // Stamped at the write, the way the lock stamps its version: the
     // schema is a fact about the build doing the writing, and two places
@@ -142,7 +142,12 @@ pub fn save(path: &Path, manifest: &Manifest) -> Result<()> {
     let current = read_if_exists(path)?;
     let text = match &current {
         Some(current) => {
-            super::edit::merged(current, &desired).map_err(|e| CoreError::TomlParse {
+            // What this file already gives the model, taken the same way
+            // the target was. A key outside it — a note somebody left
+            // inside a declaration — is not kendex's to drop, and the fold
+            // needs that to tell it from a key kendex really did drop.
+            let held = held_by_model(path, current)?;
+            super::edit::merged(current, &held, &desired).map_err(|e| CoreError::TomlParse {
                 path: path.to_path_buf(),
                 message: e.to_string(),
             })?
@@ -153,6 +158,25 @@ pub fn save(path: &Path, manifest: &Manifest) -> Result<()> {
         return Ok(());
     }
     atomic_write(path, &text)
+}
+
+/// The keys this text gives the manifest model, as the same serializer
+/// spells them. Read back and written out again rather than diffed by
+/// hand, so the vocabulary can never drift from the one the target was
+/// written with. The plan read these exact bytes through [`parse_text`]
+/// and the write's precondition holds them, so a refusal here is a file
+/// that stopped being a manifest between the two, and it is refused
+/// rather than written over.
+fn held_by_model(path: &Path, current: &str) -> Result<String> {
+    let held: Manifest =
+        toml::from_str(current).map_err(|e: toml::de::Error| CoreError::TomlParse {
+            path: path.to_path_buf(),
+            message: e.to_string(),
+        })?;
+    toml::to_string_pretty(&held).map_err(|e| CoreError::TomlParse {
+        path: path.to_path_buf(),
+        message: e.to_string(),
+    })
 }
 
 /// Load for mutation. Only the current schema loads at all, so there is

--- a/crates/core/src/manifest/mod.rs
+++ b/crates/core/src/manifest/mod.rs
@@ -67,7 +67,7 @@ pub struct SourceDecl {
     /// repository's default branch.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rev: Option<String>,
-    #[serde(default = "default_true", skip_serializing_if = "is_true")]
+    #[serde(default = "default_true", skip_serializing_if = "file::is_true")]
     pub enabled: bool,
 }
 
@@ -75,29 +75,12 @@ fn default_true() -> bool {
     true
 }
 
-/// Why every field with a default skips at it: an absent key already reads
-/// as that value, and kendex.toml is edited in place, so writing it out
-/// would put a key in somebody's file that says nothing the file did not
-/// already say. What the file does spell is safe either way — a removal is
-/// decided by what the manifest read back out of that same file, never by
-/// what the serializer left out. One predicate per default, each reading
-/// the `default_*` the field deserializes through. A field that gains a
-/// serde default and no skip falsifies ARCHITECTURE invariant 10; the
-/// derivation over this file is in the KEN-928 commit that closed the set.
-fn is_default<T: Default + PartialEq>(value: &T) -> bool {
-    *value == T::default()
-}
-
-fn is_true(value: &bool) -> bool {
-    *value
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, Type)]
 #[serde(rename_all = "kebab-case")]
 pub struct InstallDefaults {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub harnesses: Vec<HarnessId>,
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "file::is_default")]
     pub method: Method,
 }
 
@@ -117,7 +100,7 @@ pub struct ItemDecl {
     /// follows the source.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rev: Option<String>,
-    #[serde(default = "default_true", skip_serializing_if = "is_true")]
+    #[serde(default = "default_true", skip_serializing_if = "file::is_true")]
     pub enabled: bool,
 }
 
@@ -180,7 +163,7 @@ pub struct FrontmatterOverrides {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
 #[serde(rename_all = "kebab-case")]
 pub struct PluginDecl {
-    #[serde(default = "default_true", skip_serializing_if = "is_true")]
+    #[serde(default = "default_true", skip_serializing_if = "file::is_true")]
     pub enabled: bool,
     #[serde(
         default = "default_plugin_harness",
@@ -218,7 +201,7 @@ pub struct CustomHook {
     /// Harness allowlist; `None` = every declared harness.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub harnesses: Option<Vec<String>>,
-    #[serde(default = "default_true", skip_serializing_if = "is_true")]
+    #[serde(default = "default_true", skip_serializing_if = "file::is_true")]
     pub enabled: bool,
     #[serde(
         default = "default_hook_agents",
@@ -268,7 +251,7 @@ pub struct Manifest {
     pub schema: u32,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub sources: BTreeMap<String, SourceDecl>,
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "file::is_default")]
     pub install: InstallDefaults,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub agents: BTreeMap<String, ItemDecl>,

--- a/crates/core/src/manifest/mod.rs
+++ b/crates/core/src/manifest/mod.rs
@@ -194,7 +194,10 @@ pub struct CustomHook {
     /// Harness allowlist; `None` = every declared harness.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub harnesses: Option<Vec<String>>,
-    #[serde(default = "default_true", skip_serializing_if = "is_true")]
+    // Spelled out on every write, the way every other declaration's
+    // `enabled` is: this one used to be skipped at its default, which is
+    // one more spelling of the same field for no gain.
+    #[serde(default = "default_true")]
     pub enabled: bool,
     #[serde(default = "default_hook_agents")]
     pub agents: HookAgents,
@@ -210,10 +213,6 @@ pub enum HookAgents {
 
 fn default_hook_agents() -> HookAgents {
     HookAgents::One("all".to_owned())
-}
-
-fn is_true(value: &bool) -> bool {
-    *value
 }
 
 /// Where a fork came from. A fork keeps the item's installed name — the

--- a/crates/core/src/manifest/mod.rs
+++ b/crates/core/src/manifest/mod.rs
@@ -75,13 +75,19 @@ fn default_true() -> bool {
     true
 }
 
-/// Why every `enabled` skips at its default: the flag reads as true when
-/// it is absent, so writing it out says nothing the file did not already
-/// say, and kendex.toml is edited in place — a key the serialization
-/// spells out is a key the write puts in somebody's file. A hand-written
-/// one is safe either way: what a write may remove is decided by what the
-/// manifest read back out of that same file, never by what the serializer
-/// left out.
+/// Why every field with a default skips at it: an absent key already reads
+/// as that value, and kendex.toml is edited in place, so writing it out
+/// would put a key in somebody's file that says nothing the file did not
+/// already say. What the file does spell is safe either way — a removal is
+/// decided by what the manifest read back out of that same file, never by
+/// what the serializer left out. One predicate per default, each reading
+/// the `default_*` the field deserializes through. A field that gains a
+/// serde default and no skip falsifies ARCHITECTURE invariant 10; the
+/// derivation over this file is in the KEN-928 commit that closed the set.
+fn is_default<T: Default + PartialEq>(value: &T) -> bool {
+    *value == T::default()
+}
+
 fn is_true(value: &bool) -> bool {
     *value
 }
@@ -89,9 +95,9 @@ fn is_true(value: &bool) -> bool {
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, Type)]
 #[serde(rename_all = "kebab-case")]
 pub struct InstallDefaults {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub harnesses: Vec<HarnessId>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_default")]
     pub method: Method,
 }
 
@@ -176,12 +182,19 @@ pub struct FrontmatterOverrides {
 pub struct PluginDecl {
     #[serde(default = "default_true", skip_serializing_if = "is_true")]
     pub enabled: bool,
-    #[serde(default = "default_plugin_harness")]
+    #[serde(
+        default = "default_plugin_harness",
+        skip_serializing_if = "is_default_plugin_harness"
+    )]
     pub harness: HarnessId,
 }
 
 fn default_plugin_harness() -> HarnessId {
     HarnessId::Claude
+}
+
+fn is_default_plugin_harness(value: &HarnessId) -> bool {
+    *value == default_plugin_harness()
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Type)]
@@ -207,7 +220,10 @@ pub struct CustomHook {
     pub harnesses: Option<Vec<String>>,
     #[serde(default = "default_true", skip_serializing_if = "is_true")]
     pub enabled: bool,
-    #[serde(default = "default_hook_agents")]
+    #[serde(
+        default = "default_hook_agents",
+        skip_serializing_if = "is_default_hook_agents"
+    )]
     pub agents: HookAgents,
 }
 
@@ -221,6 +237,10 @@ pub enum HookAgents {
 
 fn default_hook_agents() -> HookAgents {
     HookAgents::One("all".to_owned())
+}
+
+fn is_default_hook_agents(value: &HookAgents) -> bool {
+    *value == default_hook_agents()
 }
 
 /// Where a fork came from. A fork keeps the item's installed name — the
@@ -248,7 +268,7 @@ pub struct Manifest {
     pub schema: u32,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub sources: BTreeMap<String, SourceDecl>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_default")]
     pub install: InstallDefaults,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub agents: BTreeMap<String, ItemDecl>,

--- a/crates/core/src/manifest/mod.rs
+++ b/crates/core/src/manifest/mod.rs
@@ -5,6 +5,7 @@ use specta::Type;
 
 use crate::model::HarnessId;
 
+mod edit;
 mod file;
 mod validate;
 pub use file::{

--- a/crates/core/src/manifest/mod.rs
+++ b/crates/core/src/manifest/mod.rs
@@ -159,7 +159,9 @@ pub struct FrontmatterOverrides {
 ///
 /// A declaration written before the harness was part of it belongs to Claude
 /// Code — the only tool whose plugin switch kendex ever wrote — so that is
-/// what an older manifest reads back as, and the next write records it.
+/// what an older manifest reads back as. A write leaves the omission where
+/// it found it: Claude is the default the key skips at, and spelling it out
+/// would put a key in the file that says what the file already said.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
 #[serde(rename_all = "kebab-case")]
 pub struct PluginDecl {

--- a/crates/core/src/manifest/mod.rs
+++ b/crates/core/src/manifest/mod.rs
@@ -67,12 +67,23 @@ pub struct SourceDecl {
     /// repository's default branch.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rev: Option<String>,
-    #[serde(default = "default_true")]
+    #[serde(default = "default_true", skip_serializing_if = "is_true")]
     pub enabled: bool,
 }
 
 fn default_true() -> bool {
     true
+}
+
+/// Why every `enabled` skips at its default: the flag reads as true when
+/// it is absent, so writing it out says nothing the file did not already
+/// say, and kendex.toml is edited in place — a key the serialization
+/// spells out is a key the write puts in somebody's file. A hand-written
+/// one is safe either way: what a write may remove is decided by what the
+/// manifest read back out of that same file, never by what the serializer
+/// left out.
+fn is_true(value: &bool) -> bool {
+    *value
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, Type)]
@@ -100,7 +111,7 @@ pub struct ItemDecl {
     /// follows the source.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rev: Option<String>,
-    #[serde(default = "default_true")]
+    #[serde(default = "default_true", skip_serializing_if = "is_true")]
     pub enabled: bool,
 }
 
@@ -163,7 +174,7 @@ pub struct FrontmatterOverrides {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
 #[serde(rename_all = "kebab-case")]
 pub struct PluginDecl {
-    #[serde(default = "default_true")]
+    #[serde(default = "default_true", skip_serializing_if = "is_true")]
     pub enabled: bool,
     #[serde(default = "default_plugin_harness")]
     pub harness: HarnessId,
@@ -194,10 +205,7 @@ pub struct CustomHook {
     /// Harness allowlist; `None` = every declared harness.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub harnesses: Option<Vec<String>>,
-    // Spelled out on every write, the way every other declaration's
-    // `enabled` is: this one used to be skipped at its default, which is
-    // one more spelling of the same field for no gain.
-    #[serde(default = "default_true")]
+    #[serde(default = "default_true", skip_serializing_if = "is_true")]
     pub enabled: bool,
     #[serde(default = "default_hook_agents")]
     pub agents: HookAgents,

--- a/crates/core/tests/byte_faithful.rs
+++ b/crates/core/tests/byte_faithful.rs
@@ -5,7 +5,7 @@
 
 #[path = "../../test_util.rs"]
 mod test_util;
-use test_util::source_path;
+use test_util::{rooted, source_path};
 
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
@@ -193,4 +193,192 @@ fn a_written_tree_keeps_shebang_files_executable() {
         doc.permissions().mode() & 0o100 == 0,
         "a plain document must not"
     );
+}
+
+/// The manifest as somebody keeps it: a header comment, comments against
+/// two of the tables, hand spacing, a trailing comment on a value, and a
+/// key order no serializer would choose. Every case below asserts the
+/// whole file, so any byte a write disturbs shows up.
+fn kept_manifest(source: &std::path::Path) -> String {
+    format!(
+        "# what this project installs\nschema = 6\n\n# the catalog we read\n[sources.cat]\nenabled = true\n{}\n\n[install]\nmethod   = \"symlink\"\nharnesses = [\"claude\"]\n\n# the one we actually use\n[skills.gh]\nsource = \"cat\"   # from the catalog\nenabled = true\n",
+        source_path(source)
+    )
+}
+
+struct Kept {
+    _tmp: tempfile::TempDir,
+    env: Env,
+    scope: Scope,
+    project: std::path::PathBuf,
+    manifest: std::path::PathBuf,
+    original: String,
+}
+
+#[allow(clippy::unwrap_used)]
+fn kept() -> Kept {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let env = Env::fake(&home, FakeOs::Linux);
+    let project = home.join("dev/app");
+    fs::create_dir_all(project.join(".claude")).unwrap();
+    let source = home.join("catalog");
+    for name in ["gh", "fmt"] {
+        fs::create_dir_all(source.join("skills").join(name)).unwrap();
+        fs::write(
+            source.join("skills").join(name).join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: about {name}\n---\nBody.\n"),
+        )
+        .unwrap();
+    }
+    let manifest = project.join("kendex.toml");
+    let original = kept_manifest(&source);
+    fs::write(&manifest, &original).unwrap();
+    let scope = Scope::Project {
+        root: project.clone(),
+    };
+    let report = audit(&env, &scope).unwrap();
+    apply::execute(&env, &report.plan).unwrap();
+    assert_eq!(
+        fs::read_to_string(&manifest).unwrap(),
+        original,
+        "installing what the file already declares writes nothing"
+    );
+    Kept {
+        env,
+        scope,
+        project,
+        manifest,
+        original,
+        _tmp: tmp,
+    }
+}
+
+/// `add` declares one more skill and leaves every other byte where it was
+/// (invariant 10): the comments, the blank lines, the hand spacing, the
+/// key order inside `[sources.cat]`, and the trailing comment on the
+/// declaration it did not touch.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn adding_a_skill_edits_kendex_toml_in_place() {
+    let k = kept();
+    let report = kendex_core::engine::ops::add(
+        &k.env,
+        &k.scope,
+        &kendex_core::engine::ops::AddRequest {
+            source: Some("cat".into()),
+            skills: vec!["fmt".into()],
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    apply::execute(&k.env, &report.plan).unwrap();
+
+    assert_eq!(
+        fs::read_to_string(&k.manifest).unwrap(),
+        format!(
+            "{}\n[skills.fmt]\nsource = \"cat\"\nenabled = true\n",
+            k.original
+        )
+    );
+}
+
+/// `fork` rebinds the declaration it names and records the provenance.
+/// The value it rewrites keeps the comment that sat beside it.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn forking_a_skill_edits_kendex_toml_in_place() {
+    let k = kept();
+    fs::write(
+        k.project.join(".agents/skills/gh/SKILL.md"),
+        "---\nname: gh\ndescription: about gh\n---\nMine now.\n",
+    )
+    .unwrap();
+    let plan = kendex_core::engine::fork::fork(
+        &k.env,
+        &k.scope,
+        kendex_core::model::ItemKind::Skill,
+        "gh",
+        kendex_core::model::HarnessId::Claude,
+    )
+    .unwrap();
+    apply::execute(&k.env, &plan).unwrap();
+
+    let written = fs::read_to_string(&k.manifest).unwrap();
+    assert_eq!(
+        written,
+        rebound(&k.original) + &forks_table(&written),
+        "{written}"
+    );
+}
+
+/// `adopt` takes an unmanaged skill into the manifest; the file it appends
+/// to is otherwise untouched.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn adopting_a_skill_edits_kendex_toml_in_place() {
+    let k = kept();
+    let mine = k.project.join(".claude/skills/mine");
+    fs::create_dir_all(&mine).unwrap();
+    fs::write(
+        mine.join("SKILL.md"),
+        "---\nname: mine\ndescription: my own\n---\nMine.\n",
+    )
+    .unwrap();
+    let plan = kendex_core::engine::adopt::adopt(
+        &k.env,
+        &k.scope,
+        kendex_core::model::ItemKind::Skill,
+        "mine",
+        &[kendex_core::model::HarnessId::Claude],
+    )
+    .unwrap();
+    apply::execute(&k.env, &plan).unwrap();
+
+    assert_eq!(
+        fs::read_to_string(&k.manifest).unwrap(),
+        format!(
+            "{}\n[skills.mine]\nsource = \"in-place\"\nenabled = true\n",
+            k.original
+        )
+    );
+}
+
+/// `detach` drops the source declaration and rebinds what read from it.
+/// The comment written against the table that goes leaves with it, and
+/// nothing above or below it moves.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn detaching_a_source_edits_kendex_toml_in_place() {
+    let k = kept();
+    let plan = kendex_core::engine::detach::source(&k.env, &k.scope, "cat").unwrap();
+    apply::execute(&k.env, &plan).unwrap();
+
+    let written = fs::read_to_string(&k.manifest).unwrap();
+    let source_block = &k.original[k.original.find("# the catalog we read").unwrap_or_default()
+        ..k.original.find("[install]").unwrap_or_default()];
+    assert_eq!(
+        written,
+        rebound(&k.original.replace(source_block, "")) + &forks_table(&written),
+        "{written}"
+    );
+}
+
+/// The declaration after a verb rebinds it to the person's own copy: the
+/// one value changed, the comment beside it untouched.
+fn rebound(manifest: &str) -> String {
+    manifest.replace(
+        "source = \"cat\"   # from the catalog",
+        "source = \"local\"   # from the catalog",
+    )
+}
+
+/// The `[forks.skill.gh]` block as written, so a case can assert the whole
+/// file without transcribing a timestamp it cannot know.
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+fn forks_table(written: &str) -> String {
+    let at = written
+        .find("\n[forks.skill.gh]\n")
+        .expect("the fork is recorded");
+    written[at..].to_owned()
 }

--- a/crates/core/tests/byte_faithful.rs
+++ b/crates/core/tests/byte_faithful.rs
@@ -196,14 +196,16 @@ fn a_written_tree_keeps_shebang_files_executable() {
 }
 
 /// The manifest as somebody keeps it: a header comment, comments against
-/// three of the tables, hand spacing, a trailing comment on a value, a key
-/// order no serializer would choose, a hook carrying a hand-written
-/// `enabled` flag, and `note`, a key the manifest model does not hold at
-/// all. Every case below asserts the whole file, so any byte a write
-/// disturbs shows up.
+/// the tables, a trailing comment on a value, a key order no serializer
+/// would choose, and `note`, a key the manifest model does not hold at
+/// all. Every key with a default is left out — `[install]` names only the
+/// harnesses, which pins the fan-out this fixture installs under and is
+/// not a default; the hooks name neither `agents` nor, for the second,
+/// `enabled`. So a write that lands any of them shows up here. Every case
+/// below asserts the whole file.
 fn kept_manifest(source: &std::path::Path) -> String {
     format!(
-        "# what this project installs\nschema = 6\n\n# the catalog we read\n[sources.cat]\nenabled = true\n{}\n\n[install]\nmethod   = \"symlink\"\nharnesses = [\"claude\"]\n\n# the one we actually use\n[skills.gh]\nsource = \"cat\"   # from the catalog\nnote = \"why I keep this\"\nenabled = true\n\n# guards every bash call\n[[custom-hooks]]\nevent = \"PreToolUse\"\ncommand = \"./guard.sh\"\nenabled = true   # still on\nagents = \"all\"\n",
+        "# what this project installs\nschema = 6\n\n# the catalog we read\n[sources.cat]\nenabled = true\n{}\n\n[install]\nharnesses = [\"claude\"]\n\n# the one we actually use\n[skills.gh]\nsource = \"cat\"   # from the catalog\nnote = \"why I keep this\"\nenabled = true\n\n# guards every bash call\n[[custom-hooks]]\nevent = \"PreToolUse\"\ncommand = \"./guard.sh\"\nenabled = true   # still on\n\n[[custom-hooks]]\nevent = \"Stop\"\ncommand = \"./done.sh\"\n",
         source_path(source)
     )
 }

--- a/crates/core/tests/byte_faithful.rs
+++ b/crates/core/tests/byte_faithful.rs
@@ -290,10 +290,7 @@ fn adding_a_skill_edits_kendex_toml_in_place() {
 
     assert_eq!(
         fs::read_to_string(&k.manifest).unwrap(),
-        declaring(
-            &k.original,
-            "[skills.fmt]\nsource = \"cat\"\nenabled = true\n"
-        )
+        declaring(&k.original, "[skills.fmt]\nsource = \"cat\"\n")
     );
 }
 
@@ -351,10 +348,7 @@ fn adopting_a_skill_edits_kendex_toml_in_place() {
 
     assert_eq!(
         fs::read_to_string(&k.manifest).unwrap(),
-        declaring(
-            &k.original,
-            "[skills.mine]\nsource = \"in-place\"\nenabled = true\n"
-        )
+        declaring(&k.original, "[skills.mine]\nsource = \"in-place\"\n")
     );
 }
 

--- a/crates/core/tests/byte_faithful.rs
+++ b/crates/core/tests/byte_faithful.rs
@@ -8,7 +8,7 @@ mod test_util;
 use test_util::{rooted, source_path};
 
 use std::fs;
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
 use kendex_core::apply;
 use kendex_core::configedit::ConfigEdit;
@@ -196,12 +196,14 @@ fn a_written_tree_keeps_shebang_files_executable() {
 }
 
 /// The manifest as somebody keeps it: a header comment, comments against
-/// two of the tables, hand spacing, a trailing comment on a value, and a
-/// key order no serializer would choose. Every case below asserts the
-/// whole file, so any byte a write disturbs shows up.
+/// three of the tables, hand spacing, a trailing comment on a value, a key
+/// order no serializer would choose, a hook carrying a hand-written
+/// `enabled` flag, and `note`, a key the manifest model does not hold at
+/// all. Every case below asserts the whole file, so any byte a write
+/// disturbs shows up.
 fn kept_manifest(source: &std::path::Path) -> String {
     format!(
-        "# what this project installs\nschema = 6\n\n# the catalog we read\n[sources.cat]\nenabled = true\n{}\n\n[install]\nmethod   = \"symlink\"\nharnesses = [\"claude\"]\n\n# the one we actually use\n[skills.gh]\nsource = \"cat\"   # from the catalog\nenabled = true\n",
+        "# what this project installs\nschema = 6\n\n# the catalog we read\n[sources.cat]\nenabled = true\n{}\n\n[install]\nmethod   = \"symlink\"\nharnesses = [\"claude\"]\n\n# the one we actually use\n[skills.gh]\nsource = \"cat\"   # from the catalog\nnote = \"why I keep this\"\nenabled = true\n\n# guards every bash call\n[[custom-hooks]]\nevent = \"PreToolUse\"\ncommand = \"./guard.sh\"\nenabled = true   # still on\nagents = \"all\"\n",
         source_path(source)
     )
 }
@@ -237,12 +239,24 @@ fn kept() -> Kept {
     let scope = Scope::Project {
         root: project.clone(),
     };
+    // Identity, not just content: `save` claims a write that changes
+    // nothing writes nothing, and content alone cannot tell that from a
+    // write that replaced the file with the same bytes. atomic_write
+    // renames a fresh file into place, so the inode moves and the mtime
+    // moves with it.
+    let before = fs::metadata(&manifest).unwrap();
     let report = audit(&env, &scope).unwrap();
     apply::execute(&env, &report.plan).unwrap();
+    let after = fs::metadata(&manifest).unwrap();
     assert_eq!(
         fs::read_to_string(&manifest).unwrap(),
         original,
         "installing what the file already declares writes nothing"
+    );
+    assert_eq!(
+        (before.ino(), before.modified().unwrap()),
+        (after.ino(), after.modified().unwrap()),
+        "the file itself is untouched, not rewritten with the same bytes"
     );
     Kept {
         env,
@@ -276,9 +290,9 @@ fn adding_a_skill_edits_kendex_toml_in_place() {
 
     assert_eq!(
         fs::read_to_string(&k.manifest).unwrap(),
-        format!(
-            "{}\n[skills.fmt]\nsource = \"cat\"\nenabled = true\n",
-            k.original
+        declaring(
+            &k.original,
+            "[skills.fmt]\nsource = \"cat\"\nenabled = true\n"
         )
     );
 }
@@ -337,9 +351,9 @@ fn adopting_a_skill_edits_kendex_toml_in_place() {
 
     assert_eq!(
         fs::read_to_string(&k.manifest).unwrap(),
-        format!(
-            "{}\n[skills.mine]\nsource = \"in-place\"\nenabled = true\n",
-            k.original
+        declaring(
+            &k.original,
+            "[skills.mine]\nsource = \"in-place\"\nenabled = true\n"
         )
     );
 }
@@ -355,14 +369,28 @@ fn detaching_a_source_edits_kendex_toml_in_place() {
     apply::execute(&k.env, &plan).unwrap();
 
     let written = fs::read_to_string(&k.manifest).unwrap();
-    let source_block = &k.original[k.original.find("# the catalog we read").unwrap_or_default()
-        ..k.original.find("[install]").unwrap_or_default()];
+    let source_block = &k.original[k
+        .original
+        .find("# the catalog we read")
+        .expect("the fixture comments its source table")
+        ..k.original
+            .find("[install]")
+            .expect("the fixture declares install defaults")];
     assert_eq!(
         written,
         rebound(&k.original.replace(source_block, "")) + &forks_table(&written),
         "{written}"
     );
 }
+
+/// The fixture with one more declaration in it, where a gained table
+/// lands: under the last of its own kind, not at the end of the file where
+/// it would read as more of whatever table is last.
+fn declaring(manifest: &str, block: &str) -> String {
+    manifest.replace(HOOK_COMMENT, &format!("{block}\n{HOOK_COMMENT}"))
+}
+
+const HOOK_COMMENT: &str = "# guards every bash call";
 
 /// The declaration after a verb rebinds it to the person's own copy: the
 /// one value changed, the comment beside it untouched.
@@ -373,12 +401,81 @@ fn rebound(manifest: &str) -> String {
     )
 }
 
-/// The `[forks.skill.gh]` block as written, so a case can assert the whole
-/// file without transcribing a timestamp it cannot know.
+/// The `[forks.skill.gh]` block a fork records. Checked rather than
+/// copied: a case cannot transcribe a timestamp it does not know, but it
+/// can say what every other byte of the block is and that the file ends
+/// there. Returned so the caller can put it back into its own expectation.
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 fn forks_table(written: &str) -> String {
     let at = written
         .find("\n[forks.skill.gh]\n")
         .expect("the fork is recorded");
-    written[at..].to_owned()
+    let block = &written[at..];
+    let lines: Vec<&str> = block.split('\n').collect();
+    let stamp = lines
+        .get(3)
+        .and_then(|line| line.strip_prefix("forked-at = \""))
+        .and_then(|value| value.strip_suffix('"'))
+        .expect("the block records when the fork was made");
+    assert!(
+        stamp.parse::<toml::value::Datetime>().is_ok(),
+        "forked-at is a timestamp: {stamp}"
+    );
+    assert_eq!(
+        (lines.first(), lines.get(1), lines.get(2)),
+        (
+            Some(&""),
+            Some(&"[forks.skill.gh]"),
+            Some(&"source = \"cat\"")
+        ),
+        "{block}"
+    );
+    assert_eq!(
+        lines.get(4..),
+        Some([""].as_slice()),
+        "the block is the end of the file: {block}"
+    );
+    block.to_owned()
+}
+
+/// A planned write whose result is the file that is already there does not
+/// touch the file. Asking again for a skill this scope already declares
+/// plans a manifest write like any other mutation; what it would land is
+/// byte for byte what is on disk, and `save` stops before the write rather
+/// than replacing the file with its own contents.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_write_that_changes_nothing_leaves_the_file_alone() {
+    let k = kept();
+    let before = fs::metadata(&k.manifest).unwrap();
+    let report = kendex_core::engine::ops::add(
+        &k.env,
+        &k.scope,
+        &kendex_core::engine::ops::AddRequest {
+            source: Some("cat".into()),
+            skills: vec!["gh".into()],
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert!(
+        report
+            .plan
+            .ops
+            .iter()
+            .any(|op| matches!(op.op, apply::Op::WriteManifest { .. })),
+        "the case only means something while the plan really does carry a manifest write"
+    );
+    apply::execute(&k.env, &report.plan).unwrap();
+
+    let after = fs::metadata(&k.manifest).unwrap();
+    assert_eq!(fs::read_to_string(&k.manifest).unwrap(), k.original);
+    // Identity, not content: atomic_write renames a fresh file into place,
+    // so a write that landed the same bytes still moves the inode and the
+    // mtime, and only these can tell the two apart.
+    assert_eq!(
+        (before.ino(), before.modified().unwrap()),
+        (after.ino(), after.modified().unwrap()),
+        "the file itself is untouched, not rewritten with the same bytes"
+    );
 }

--- a/crates/core/tests/structural_claims.rs
+++ b/crates/core/tests/structural_claims.rs
@@ -106,8 +106,8 @@ fn refresh_reads_each_installs_own_recorded_source_across_scopes() {
 /// grows one. A file with none gets the one its last line needs, and every
 /// pass after that leaves the bytes alone. A repair that ran on every pass
 /// is how the file grew a blank line per apply. What a file already ends
-/// in is its own — `byte_faithful.rs` covers the blank line a person
-/// leaves there.
+/// in is its own — the blank line a person leaves there is covered by
+/// `manifest::edit`'s the_files_own_terminator_survives.
 ///
 /// The fixture carries a comment because it must survive: a write folds
 /// the changed keys into the document that is there rather than

--- a/crates/core/tests/structural_claims.rs
+++ b/crates/core/tests/structural_claims.rs
@@ -102,16 +102,19 @@ fn refresh_reads_each_installs_own_recorded_source_across_scopes() {
     assert!(project_body.contains("B, revised."), "{project_body}");
 }
 
-/// The #1308 class on kendex.toml: the file a write leaves behind ends in
-/// exactly one terminator, and every pass after it leaves the bytes alone.
-/// A repair that ran on every pass is how the file grew a blank line per
-/// apply.
+/// The #1308 class on kendex.toml: a write neither adds a terminator nor
+/// grows one. A file with none gets the one its last line needs, and every
+/// pass after that leaves the bytes alone. A repair that ran on every pass
+/// is how the file grew a blank line per apply. What a file already ends
+/// in is its own — `byte_faithful.rs` covers the blank line a person
+/// leaves there.
 ///
 /// The fixture carries a comment because it must survive: a write folds
 /// the changed keys into the document that is there rather than
 /// serializing over it, which is what invariant 10 asks of every file
-/// kendex edits. `byte_faithful.rs` holds that claim across the four
-/// verbs that write; here it is the terminator that is under test.
+/// kendex edits in place. `byte_faithful.rs` holds that claim on the
+/// verbs a person reaches for; `git grep -n 'Op::WriteManifest {' crates`
+/// lists every site that plans one. Here it is the terminator under test.
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_manifest_write_ends_in_one_terminator_and_settles() {

--- a/crates/core/tests/structural_claims.rs
+++ b/crates/core/tests/structural_claims.rs
@@ -102,16 +102,16 @@ fn refresh_reads_each_installs_own_recorded_source_across_scopes() {
     assert!(project_body.contains("B, revised."), "{project_body}");
 }
 
-/// The half of the #1308 class kendex.toml still keeps: the file a write
-/// leaves behind ends in exactly one terminator, and every pass after it
-/// leaves the bytes alone. A repair that ran on every pass is how the file
-/// grew a blank line per apply.
+/// The #1308 class on kendex.toml: the file a write leaves behind ends in
+/// exactly one terminator, and every pass after it leaves the bytes alone.
+/// A repair that ran on every pass is how the file grew a blank line per
+/// apply.
 ///
-/// Not byte-faithfulness, which kendex.toml does not get. Every write of
-/// it serializes the manifest kendex read (`Op::WriteManifest` ->
-/// `manifest::save`), so comments and key order go, on an add as much as
-/// on any other write — invariant 10 says so. A fixture with a comment in
-/// it would fail here rather than test anything.
+/// The fixture carries a comment because it must survive: a write folds
+/// the changed keys into the document that is there rather than
+/// serializing over it, which is what invariant 10 asks of every file
+/// kendex edits. `byte_faithful.rs` holds that claim across the four
+/// verbs that write; here it is the terminator that is under test.
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_manifest_write_ends_in_one_terminator_and_settles() {
@@ -126,7 +126,7 @@ fn a_manifest_write_ends_in_one_terminator_and_settles() {
     fs::write(
         &manifest_path,
         format!(
-            "schema = 6\n\n[sources.cat]\n{}\n\n[install]\nharnesses = [\"claude\"]\nmethod = \"symlink\"",
+            "# mine\nschema = 6\n\n[sources.cat]\n{}\n\n[install]\nharnesses = [\"claude\"]\nmethod = \"symlink\"",
             source_path(&w.home.join("cat"))
         ),
     )
@@ -146,6 +146,7 @@ fn a_manifest_write_ends_in_one_terminator_and_settles() {
 
     let written = fs::read_to_string(&manifest_path).unwrap();
     assert!(written.contains("[skills.gh]"), "{written}");
+    assert!(written.starts_with("# mine\n"), "{written}");
     assert!(
         written.ends_with('\n') && !written.ends_with("\n\n"),
         "exactly one terminator: {written:?}"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -133,11 +133,10 @@ lives in one capability table read by core and UI.
    the only writable surface; kendex never stages, commits, or resets in
    a repository it did not create. Work that must produce a commit runs
    in a disposable clone.
-10. Writes are byte-faithful where kendex edits in place: a structured
-    edit changes the keys it names and nothing else, newline included,
-    and a file it cannot read is refused, not rewritten. Change detection
-    compares exact bytes. kendex.toml is not edited in place: a write
-    serializes the manifest kendex read, losing comments and key order.
+10. Writes are byte-faithful: every file kendex writes it edits in place,
+    kendex.toml included — a write changes the keys it names and nothing
+    else, newline included, and a file it cannot read is refused, not
+    rewritten. Change detection compares exact bytes.
 11. Validation precedes mutation. Every input check for an operation runs
     before its first durable write, and a rejected operation leaves
     manifest, lock, and install tree byte-identical. Every rendering is

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -133,10 +133,11 @@ lives in one capability table read by core and UI.
    the only writable surface; kendex never stages, commits, or resets in
    a repository it did not create. Work that must produce a commit runs
    in a disposable clone.
-10. Writes are byte-faithful: every file kendex writes it edits in place,
-    kendex.toml included — a write changes the keys it names and nothing
-    else, newline included, and a file it cannot read is refused, not
-    rewritten. Change detection compares exact bytes.
+10. Writes are byte-faithful where kendex edits in place, kendex.toml now
+    among them: an edit changes the keys it names, plus the declaration
+    defaults the manifest's own serializer spells out, and nothing else,
+    newline included; a file it cannot read is refused, not rewritten.
+    Change detection compares exact bytes.
 11. Validation precedes mutation. Every input check for an operation runs
     before its first durable write, and a rejected operation leaves
     manifest, lock, and install tree byte-identical. Every rendering is

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -133,11 +133,10 @@ lives in one capability table read by core and UI.
    the only writable surface; kendex never stages, commits, or resets in
    a repository it did not create. Work that must produce a commit runs
    in a disposable clone.
-10. Writes are byte-faithful where kendex edits in place, kendex.toml now
-    among them: an edit changes the keys it names, plus the declaration
-    defaults the manifest's own serializer spells out, and nothing else,
-    newline included; a file it cannot read is refused, not rewritten.
-    Change detection compares exact bytes.
+10. Writes are byte-faithful where kendex edits in place, kendex.toml
+    among them: an edit changes the keys it names and nothing else,
+    newline included, and a file it cannot read is refused, not
+    rewritten. Change detection compares exact bytes.
 11. Validation precedes mutation. Every input check for an operation runs
     before its first durable write, and a rejected operation leaves
     manifest, lock, and install tree byte-identical. Every rendering is

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -133,10 +133,10 @@ lives in one capability table read by core and UI.
    the only writable surface; kendex never stages, commits, or resets in
    a repository it did not create. Work that must produce a commit runs
    in a disposable clone.
-10. Writes are byte-faithful where kendex edits in place, kendex.toml
-    among them: an edit changes the keys it names and nothing else,
-    newline included, and a file it cannot read is refused, not
-    rewritten. Change detection compares exact bytes.
+10. Writes are byte-faithful where kendex edits in place: an edit changes
+    the keys it names and nothing else, newline included, and a file it
+    cannot read is refused, not rewritten. kendex.toml is edited that way
+    too, minus its line endings. Change detection compares exact bytes.
 11. Validation precedes mutation. Every input check for an operation runs
     before its first durable write, and a rejected operation leaves
     manifest, lock, and install tree byte-identical. Every rendering is

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -1007,7 +1007,7 @@ export type CustomHook_Serialize = {
 	/**  Harness allowlist; `None` = every declared harness. */
 	harnesses?: string[] | null,
 	enabled?: boolean,
-	agents: HookAgents,
+	agents?: HookAgents,
 };
 
 /**
@@ -1590,7 +1590,14 @@ export type InstallChannel =
  */
 { kind: "unknown" };
 
-export type InstallDefaults = {
+export type InstallDefaults = InstallDefaults_Serialize | InstallDefaults_Deserialize;
+
+export type InstallDefaults_Deserialize = {
+	harnesses?: HarnessId[],
+	method?: Method,
+};
+
+export type InstallDefaults_Serialize = {
 	harnesses?: HarnessId[],
 	method?: Method,
 };
@@ -1868,7 +1875,7 @@ export type ManifestRead_Serialize = {
 export type Manifest_Deserialize = {
 	schema: number,
 	sources?: { [key in string]: SourceDecl_Deserialize },
-	install?: InstallDefaults,
+	install?: InstallDefaults_Deserialize,
 	agents?: { [key in string]: ItemDecl_Deserialize },
 	skills?: { [key in string]: ItemDecl_Deserialize },
 	hooks?: { [key in string]: ItemDecl_Deserialize },
@@ -1918,7 +1925,7 @@ export type Manifest_Deserialize = {
 export type Manifest_Serialize = {
 	schema: number,
 	sources?: { [key in string]: SourceDecl_Serialize },
-	install: InstallDefaults,
+	install?: InstallDefaults_Serialize,
 	agents?: { [key in string]: ItemDecl_Serialize },
 	skills?: { [key in string]: ItemDecl_Serialize },
 	hooks?: { [key in string]: ItemDecl_Serialize },
@@ -2399,7 +2406,7 @@ export type PluginDecl_Deserialize = {
  */
 export type PluginDecl_Serialize = {
 	enabled?: boolean,
-	harness: HarnessId,
+	harness?: HarnessId,
 };
 
 /**

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -2375,7 +2375,9 @@ export type PackagesUpdate_Serialize = {
  * 
  *  A declaration written before the harness was part of it belongs to Claude
  *  Code — the only tool whose plugin switch kendex ever wrote — so that is
- *  what an older manifest reads back as, and the next write records it.
+ *  what an older manifest reads back as. A write leaves the omission where
+ *  it found it: Claude is the default the key skips at, and spelling it out
+ *  would put a key in the file that says what the file already said.
  */
 export type PluginDecl = PluginDecl_Serialize | PluginDecl_Deserialize;
 
@@ -2387,7 +2389,9 @@ export type PluginDecl = PluginDecl_Serialize | PluginDecl_Deserialize;
  * 
  *  A declaration written before the harness was part of it belongs to Claude
  *  Code — the only tool whose plugin switch kendex ever wrote — so that is
- *  what an older manifest reads back as, and the next write records it.
+ *  what an older manifest reads back as. A write leaves the omission where
+ *  it found it: Claude is the default the key skips at, and spelling it out
+ *  would put a key in the file that says what the file already said.
  */
 export type PluginDecl_Deserialize = {
 	enabled?: boolean,
@@ -2402,7 +2406,9 @@ export type PluginDecl_Deserialize = {
  * 
  *  A declaration written before the harness was part of it belongs to Claude
  *  Code — the only tool whose plugin switch kendex ever wrote — so that is
- *  what an older manifest reads back as, and the next write records it.
+ *  what an older manifest reads back as. A write leaves the omission where
+ *  it found it: Claude is the default the key skips at, and spelling it out
+ *  would put a key in the file that says what the file already said.
  */
 export type PluginDecl_Serialize = {
 	enabled?: boolean,

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -1006,7 +1006,7 @@ export type CustomHook_Serialize = {
 	timeout?: number | null,
 	/**  Harness allowlist; `None` = every declared harness. */
 	harnesses?: string[] | null,
-	enabled: boolean,
+	enabled?: boolean,
 	agents: HookAgents,
 };
 
@@ -1695,7 +1695,7 @@ export type ItemDecl_Serialize = {
 	 *  follows the source.
 	 */
 	rev?: string | null,
-	enabled: boolean,
+	enabled?: boolean,
 };
 
 export type ItemKind = "agent" | "skill" | "hook" | "command" | "mcp-server" | "plugin" | "pi-extension";
@@ -1878,7 +1878,7 @@ export type Manifest_Deserialize = {
 	 *  Plugins are observe + enable/disable only; the key is
 	 *  `name@marketplace`, provenance lives in the lock.
 	 */
-	plugins?: { [key in string]: PluginDecl },
+	plugins?: { [key in string]: PluginDecl_Deserialize },
 	/**
 	 *  Installed bundles: a curated set the catalog offers under one name.
 	 *  What the set holds is the catalog's to say and derives on every plan;
@@ -1928,7 +1928,7 @@ export type Manifest_Serialize = {
 	 *  Plugins are observe + enable/disable only; the key is
 	 *  `name@marketplace`, provenance lives in the lock.
 	 */
-	plugins?: { [key in string]: PluginDecl },
+	plugins?: { [key in string]: PluginDecl_Serialize },
 	/**
 	 *  Installed bundles: a curated set the catalog offers under one name.
 	 *  What the set holds is the catalog's to say and derives on every plan;
@@ -2370,9 +2370,36 @@ export type PackagesUpdate_Serialize = {
  *  Code — the only tool whose plugin switch kendex ever wrote — so that is
  *  what an older manifest reads back as, and the next write records it.
  */
-export type PluginDecl = {
+export type PluginDecl = PluginDecl_Serialize | PluginDecl_Deserialize;
+
+/**
+ *  One declared plugin. The harness is part of the declaration because more
+ *  than one tool reads an `enabledPlugins` map of its own: without it, a
+ *  plugin meant for one tool would be switched on in every tool's settings,
+ *  which is a claim about software the user never installed there.
+ * 
+ *  A declaration written before the harness was part of it belongs to Claude
+ *  Code — the only tool whose plugin switch kendex ever wrote — so that is
+ *  what an older manifest reads back as, and the next write records it.
+ */
+export type PluginDecl_Deserialize = {
 	enabled?: boolean,
 	harness?: HarnessId,
+};
+
+/**
+ *  One declared plugin. The harness is part of the declaration because more
+ *  than one tool reads an `enabledPlugins` map of its own: without it, a
+ *  plugin meant for one tool would be switched on in every tool's settings,
+ *  which is a claim about software the user never installed there.
+ * 
+ *  A declaration written before the harness was part of it belongs to Claude
+ *  Code — the only tool whose plugin switch kendex ever wrote — so that is
+ *  what an older manifest reads back as, and the next write records it.
+ */
+export type PluginDecl_Serialize = {
+	enabled?: boolean,
+	harness: HarnessId,
 };
 
 /**
@@ -2689,7 +2716,7 @@ export type SourceDecl_Serialize = {
 	 *  repository's default branch.
 	 */
 	rev?: string | null,
-	enabled: boolean,
+	enabled?: boolean,
 };
 
 /**  Everything the Sources page shows for one declared source in one scope. */

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -1006,7 +1006,7 @@ export type CustomHook_Serialize = {
 	timeout?: number | null,
 	/**  Harness allowlist; `None` = every declared harness. */
 	harnesses?: string[] | null,
-	enabled?: boolean,
+	enabled: boolean,
 	agents: HookAgents,
 };
 

--- a/ui/src/dev/mock-audit.ts
+++ b/ui/src/dev/mock-audit.ts
@@ -165,7 +165,7 @@ export const auditHandlers: Record<string, Handler> = {
       availableSkills: AVAILABLE_SKILLS,
       automaticSkills: AUTOMATIC_SKILLS,
       declaredSkillRows: declaredSkillRows(m),
-      harnesses: m?.install.harnesses ?? ["claude"],
+      harnesses: m?.install?.harnesses ?? ["claude"],
       hookEvents: HOOK_EVENTS,
     };
   },
@@ -179,7 +179,7 @@ export const auditHandlers: Record<string, Handler> = {
     hooks: unknown[];
   }) => {
     const m = store.state.manifests[label(scope)];
-    const harnesses = m?.install.harnesses ?? ["claude"];
+    const harnesses = m?.install?.harnesses ?? ["claude"];
     return hooks.map(() =>
       harnesses.map((harness) => ({ harness, mode: "runs", note: null })),
     );

--- a/ui/src/lib/editor-draft.test.ts
+++ b/ui/src/lib/editor-draft.test.ts
@@ -40,12 +40,7 @@ describe("toDraft", () => {
       agents: { orch: { source: "kendex", enabled: true } },
       "agent-frontmatter": { claude: { orch: { model: "opus" } } },
       "custom-hooks": [
-        {
-          event: "PreToolUse",
-          command: "./g.sh",
-          enabled: true,
-          agents: "all",
-        },
+        { event: "PreToolUse", command: "./g.sh", agents: "all" },
       ],
     });
 

--- a/ui/src/lib/editor-draft.test.ts
+++ b/ui/src/lib/editor-draft.test.ts
@@ -40,7 +40,12 @@ describe("toDraft", () => {
       agents: { orch: { source: "kendex", enabled: true } },
       "agent-frontmatter": { claude: { orch: { model: "opus" } } },
       "custom-hooks": [
-        { event: "PreToolUse", command: "./g.sh", agents: "all" },
+        {
+          event: "PreToolUse",
+          command: "./g.sh",
+          enabled: true,
+          agents: "all",
+        },
       ],
     });
 


### PR DESCRIPTION
`kendex.toml` is the one file in the product a person writes by hand, and every write threw that writing away. `manifest::save` serialized the whole `Manifest` with `toml::to_string_pretty`, so `add`, `fork`, `adopt` and `detach` each rewrote the file from the parsed struct and dropped the comments, blank lines and key order somebody chose. Nothing said so; you found out by opening the file.

## What changed

A write now folds into the document that is there instead of replacing it. `save` builds three documents — the file's own bytes, what the file gives the model (`held_by_model`), and the serialization it wants — and edits only where they disagree. A value that already says the right thing is untouched, a changed value keeps its spacing and trailing comment, and a key kendex genuinely dropped goes. `held` is what separates the two: a key it never names is not kendex's to delete, so a `note` left inside a declaration survives. A write that changes nothing writes nothing, and a file that does not parse is refused rather than replaced.

Every field with a serde default now carries a skip predicate, so a write no longer stamps `enabled = true`, `agents = "all"`, `harness = "claude"` or an `[install]` table into a file that omitted them. `docs/ARCHITECTURE.md` invariant 10 loses its `kendex.toml` exception.

## Evidence

Measured by driving the real `manifest::save`, not by reading the code — every finding on this branch that held up was found that way, and every one that did not was read.

| | before | after |
|---|---|---|
| no-op saves changing bytes | 171/376 | 24/376 (all CRLF, see KEN-1079) |
| comments lost on a non-removing write | 243/1880 | 8/1880 (duplicate elements only) |
| non-idempotent folds | 726/3760 | 0/3760 |
| writes losing meaning | — | 0/3760 |
| unparsable output | — | 0/3760 |

A separate 684-fold differential across 38 array spellings × 9 operations found 0 semantic drift and 0 fixed-point failures, and 80,000 randomized fold rounds show the rebuild never reorders, drops or duplicates an element.

## Tests

`byte_faithful.rs` asserts whole files across `add`, `fork`, `adopt` and `detach`; the fold's own cases cover each shape it edits. Each was verified red against the code it guards rather than assumed to be — including the case that only fails when a list loses its *last* entry, which is the one a positional-only implementation passes while broken.

## Known gaps, tracked

- **KEN-1078** (P3) — an array with no trailing comma gets an orphan comma when a different entry ends up last. Valid TOML, semantically correct, idempotent, and inside a key the operation names.
- **KEN-1079** (P2) — a save rewrites a CRLF `kendex.toml` to LF. Predates this change (`toml_edit`'s own round trip drops `\r`); invariant 10 is worded to admit it rather than assert otherwise.

Closes KEN-928
