### PR TITLE
fix(KEN-1081): the boundary is written in what gh's engine runs

### DIFF
--- a/.agents/skills/review-gate/DEVELOPMENT.md
+++ b/.agents/skills/review-gate/DEVELOPMENT.md
@@ -19,7 +19,7 @@ Paths are as installed in a consuming repo, under
 | `scripts/validate-workflow.sh` | Is the adopted copy still the shipped template? Equality, not re-derivation: see § Equality, not re-derivation. Usable on its own when only the workflow copy changed. |
 | `scripts/pr-watch.sh` | The agent-side reducer: "does any open PR need attention right now?" Silence on stdout + exit 0 means nothing needs you, which makes it a one-line loop/cron predicate; `--heal` also dispatches the writer once on a stale gate. |
 | `scripts/review-predicate-selftest.sh` | Offline proof of the decision table. An ENGINE proof: it runs here, in the catalog repo, on every change. |
-| `tests/predicate-re2-engine.test.sh` | The predicate's thread jq, run through the engine that actually ships it: the real `gh --jq` (Go's RE2), pointed at a local HTTP stub. Every other proof here runs that program through the local jq, whose Oniguruma accepts lookaround RE2 will not compile. Needs `gh` and `python3`, and refuses rather than skipping without them. |
+| `tests/predicate-re2-engine.test.sh` | The predicate's thread jq, run through the engine that actually ships it: the real `gh --jq` (Go's RE2), pointed at a local HTTP stub. Every proof that runs unattended reads that program through the local jq, whose Oniguruma accepts lookaround RE2 will not compile; the live replay below does reach RE2, but it skips without `E2E_REPO`, so nothing ran it. Needs `gh`, `python3` and `jq`, and refuses rather than skipping without them. |
 | `tests/e2e-sandbox.sh` | Live replay against a throwaway repo — re-run it before changing the engine. |
 
 ## Where each proof runs

--- a/.agents/skills/review-gate/DEVELOPMENT.md
+++ b/.agents/skills/review-gate/DEVELOPMENT.md
@@ -19,6 +19,7 @@ Paths are as installed in a consuming repo, under
 | `scripts/validate-workflow.sh` | Is the adopted copy still the shipped template? Equality, not re-derivation: see § Equality, not re-derivation. Usable on its own when only the workflow copy changed. |
 | `scripts/pr-watch.sh` | The agent-side reducer: "does any open PR need attention right now?" Silence on stdout + exit 0 means nothing needs you, which makes it a one-line loop/cron predicate; `--heal` also dispatches the writer once on a stale gate. |
 | `scripts/review-predicate-selftest.sh` | Offline proof of the decision table. An ENGINE proof: it runs here, in the catalog repo, on every change. |
+| `tests/predicate-re2-engine.test.sh` | The predicate's thread jq, run through the engine that actually ships it: the real `gh --jq` (Go's RE2), pointed at a local HTTP stub. Every other proof here runs that program through the local jq, whose Oniguruma accepts lookaround RE2 will not compile. Needs `gh` and `python3`, and refuses rather than skipping without them. |
 | `tests/e2e-sandbox.sh` | Live replay against a throwaway repo — re-run it before changing the engine. |
 
 ## Where each proof runs

--- a/.agents/skills/review-gate/DEVELOPMENT.md
+++ b/.agents/skills/review-gate/DEVELOPMENT.md
@@ -19,7 +19,7 @@ Paths are as installed in a consuming repo, under
 | `scripts/validate-workflow.sh` | Is the adopted copy still the shipped template? Equality, not re-derivation: see § Equality, not re-derivation. Usable on its own when only the workflow copy changed. |
 | `scripts/pr-watch.sh` | The agent-side reducer: "does any open PR need attention right now?" Silence on stdout + exit 0 means nothing needs you, which makes it a one-line loop/cron predicate; `--heal` also dispatches the writer once on a stale gate. |
 | `scripts/review-predicate-selftest.sh` | Offline proof of the decision table. An ENGINE proof: it runs here, in the catalog repo, on every change. |
-| `tests/predicate-re2-engine.test.sh` | The predicate's thread jq, run through the engine that actually ships it: the real `gh --jq` (Go's RE2), pointed at a local HTTP stub. Every proof that runs unattended reads that program through the local jq, whose Oniguruma accepts lookaround RE2 will not compile; the live replay below does reach RE2, but it skips without `E2E_REPO`, so nothing ran it. Needs `gh`, `python3` and `jq`, and refuses rather than skipping without them. |
+| `tests/predicate-re2-engine.test.sh` | The predicate's thread jq, run through the engine that actually ships it: the real `gh --jq` (Go's RE2), pointed at a local HTTP stub. Every other proof that runs unattended reads that program through the local jq, whose Oniguruma accepts lookaround RE2 will not compile; the live replay below does reach RE2, but it skips without `E2E_REPO`, so nothing ran it. Needs `gh`, `python3` and `jq`, and refuses rather than skipping without them. |
 | `tests/e2e-sandbox.sh` | Live replay against a throwaway repo — re-run it before changing the engine. |
 
 ## Where each proof runs

--- a/.agents/skills/review-gate/scripts/review-predicate.sh
+++ b/.agents/skills/review-gate/scripts/review-predicate.sh
@@ -1423,6 +1423,19 @@ if [ "$THREADS_MODE" = "enforce" ]; then
 # strips: `\b` reads `_` as a word character. The corpus section "two
 # unrelated labels joined by a held separator" is what holds that.
 #
+# THIS PROGRAM RUNS UNDER `gh --jq`, AND THAT ENGINE IS GO'S RE2: no
+# lookaround compiles, and a pattern carrying one aborts the read, which the
+# gate reports as a failure. The local jq is Oniguruma and takes it, so only
+# the engine says so — `(?<!` shipped here once and every PR with a decline
+# stopped converging. So the boundary is spelled by `word_strip`, which
+# consumes the reason in run-aligned pieces — a separator run, a listed word
+# plus the one character ending it, or an unlisted run — leaving every match
+# to start where the last ended, at a run start, which is the set of
+# positions a lookbehind allows. The space padded onto each end is how a word
+# at either edge meets that one-character boundary, and the closing trim
+# takes it back. Anything added here has to compile under both engines;
+# tests/predicate-re2-engine.test.sh is what says so.
+#
 # Position is the only thing that separates a suite name from prose — both
 # are ordinary English, so any SET of names is a word ban on whatever the
 # repo happens to name its files after, and "the guard refuses this path" is
@@ -1436,13 +1449,17 @@ t_threads_page_jq='def disposition: test("^\\s*(fixed in [0-9a-f]{7,40}\\b|decli
   def replies: [(.comments.nodes // [])[] | select((.author.__typename // "User") != "Bot") | (.body // "")];
   def standing: [replies[] | select(disposition or tracking)] | last // empty;
   def standing_decline: [replies[] | select(disposition or declined or tracking)] | last // empty;
+  def word_strip($list):
+    gsub("(?<s>[^\\p{L}\\p{N}]+)|(?<w>" + $list + ")(?<b>[^\\p{L}\\p{N}])|(?<r>[\\p{L}\\p{N}]+)";
+      if .w != null then " " + .b elif .s != null then .s else .r end);
   def reason_left:
     sub("(?i)^\\s*declined\\b"; "")
     | gsub("[A-Z][A-Z0-9]+-[0-9]+|#[0-9]+"; " ")
     | ascii_downcase
-    | gsub("[^\\p{L}\\p{N}/._-]|(?<![\\p{L}\\p{N}])[._-]|[._-](?![\\p{L}\\p{N}])"; " ")
-    | gsub("(?<![\\p{L}\\p{N}])(frozen|freezes?|freezing|cap|capped|round[ ._-][0-9]+|round|rounds|tests?|suites?|pass|passes|passed|passing|green|count|checks?|checking|ci|runs?|builds?|building|built|compiles?|compiled|pipelines?|lints?|linter|linting|workflows?|jobs?|typechecks?|validation|coverage|everything|fine|clean|out[ ._-]of[ ._-]scope|scope|pre[ ._-]existing|preexisting|existing|flagged[ ._-]separately|flagged|separately|as[ ._-]discussed|discussed|noted|won[ ._-]?t[ ._-]?fix|false[ ._-]positives?|by[ ._-]design|design|not[ ._-]applicable|n[ /._-]a|actionable|no[ ._-]change|nothing[ ._-]to[ ._-]do|later|known|intentional|deliberate|works[ ._-]as[ ._-]intended|as[ ._-]intended|intended|owners?|instruction(s|ed)?|previous|pushe[sd]?|push|last|head|disposition(ed|s)?|findings?|fix(es|ed)?|track(s|ed|ing|er)?|filed|filing|logged)(?![\\p{L}\\p{N}])"; " ")
-    | gsub("(?<![\\p{L}\\p{N}])(a|an|the|this|that|these|those|it|its|is|are|was|were|be|been|for|in|on|at|to|of|and|or|but|so|we|i|you|your|pr|prs|here|now|all|full|whole|entire|complete|still|already|yes|no|not|do|does|did|has|have|had|under|per|within|as|after|rather|than|see|every|set|s|t)(?![\\p{L}\\p{N}])"; " ")
+    | gsub("(?<w>[\\p{L}\\p{N}]+([._-][\\p{L}\\p{N}]+)*)|(?<k>/)|[\\s\\S]"; "\(.w // .k // " ")")
+    | " " + . + " "
+    | word_strip("frozen|freezes?|freezing|cap|capped|round[ ._-][0-9]+|round|rounds|tests?|suites?|pass|passes|passed|passing|green|count|checks?|checking|ci|runs?|builds?|building|built|compiles?|compiled|pipelines?|lints?|linter|linting|workflows?|jobs?|typechecks?|validation|coverage|everything|fine|clean|out[ ._-]of[ ._-]scope|scope|pre[ ._-]existing|preexisting|existing|flagged[ ._-]separately|flagged|separately|as[ ._-]discussed|discussed|noted|won[ ._-]?t[ ._-]?fix|false[ ._-]positives?|by[ ._-]design|design|not[ ._-]applicable|n[ /._-]a|actionable|no[ ._-]change|nothing[ ._-]to[ ._-]do|later|known|intentional|deliberate|works[ ._-]as[ ._-]intended|as[ ._-]intended|intended|owners?|instruction(s|ed)?|previous|pushe[sd]?|push|last|head|disposition(ed|s)?|findings?|fix(es|ed)?|track(s|ed|ing|er)?|filed|filing|logged")
+    | word_strip("a|an|the|this|that|these|those|it|its|is|are|was|were|be|been|for|in|on|at|to|of|and|or|but|so|we|i|you|your|pr|prs|here|now|all|full|whole|entire|complete|still|already|yes|no|not|do|does|did|has|have|had|under|per|within|as|after|rather|than|see|every|set|s|t")
     | gsub("\\S+\\s+[0-9]+\\s*/\\s*[0-9]+"; " ")
     | gsub("[a-z0-9][a-z0-9._-]*(/[a-z0-9][a-z0-9._-]*)+"; " ")
     | gsub("[/._-]"; " ")

--- a/.agents/skills/review-gate/scripts/review-predicate.sh
+++ b/.agents/skills/review-gate/scripts/review-predicate.sh
@@ -1428,12 +1428,12 @@ if [ "$THREADS_MODE" = "enforce" ]; then
 # exits 2, the writer prints "taking no action" and reds without posting a
 # status, and the gate keeps whatever it already held. That is why a decline
 # stopped a PR converging rather than turning it red. The local jq is
-# Oniguruma and takes lookaround, and every proof that runs unattended reads
-# through that jq, so `(?<!` shipped here once and nothing caught it. The
-# boundary is therefore spelled by `word_strip`, which consumes the reason in
-# run-aligned pieces (a separator run, a listed word plus the one character
-# ending it, or an unlisted run), leaving every match to start where the last
-# ended, at a run start, which is the set of positions a lookbehind allows.
+# Oniguruma and takes lookaround, and every other proof that runs unattended
+# reads through that jq, so `(?<!` shipped here once and nothing caught it.
+# The boundary is therefore spelled by `word_strip`, which consumes the
+# reason in run-aligned pieces (a separator run, a listed word plus the one
+# character ending it, or an unlisted run), so every match starts where the
+# last ended, at a run start, the set of positions a lookbehind allows.
 # The space padded onto the END is how a word in the last position meets that
 # one-character boundary; nothing is asked of the left, and the closing trim
 # takes both pads back. Anything added here has to compile under both

--- a/.agents/skills/review-gate/scripts/review-predicate.sh
+++ b/.agents/skills/review-gate/scripts/review-predicate.sh
@@ -1424,17 +1424,20 @@ if [ "$THREADS_MODE" = "enforce" ]; then
 # unrelated labels joined by a held separator" is what holds that.
 #
 # THIS PROGRAM RUNS UNDER `gh --jq`, AND THAT ENGINE IS GO'S RE2: no
-# lookaround compiles, and a pattern carrying one aborts the read, which the
-# gate reports as a failure. The local jq is Oniguruma and takes it, so only
-# the engine says so — `(?<!` shipped here once and every PR with a decline
-# stopped converging. So the boundary is spelled by `word_strip`, which
-# consumes the reason in run-aligned pieces — a separator run, a listed word
-# plus the one character ending it, or an unlisted run — leaving every match
-# to start where the last ended, at a run start, which is the set of
-# positions a lookbehind allows. The space padded onto each end is how a word
-# at either edge meets that one-character boundary, and the closing trim
-# takes it back. Anything added here has to compile under both engines;
-# tests/predicate-re2-engine.test.sh is what says so.
+# lookaround compiles. A pattern carrying one aborts the read, so this script
+# exits 2, the writer prints "taking no action" and reds without posting a
+# status, and the gate keeps whatever it already held. That is why a decline
+# stopped a PR converging rather than turning it red. The local jq is
+# Oniguruma and takes lookaround, and every proof that runs unattended reads
+# through that jq, so `(?<!` shipped here once and nothing caught it. The
+# boundary is therefore spelled by `word_strip`, which consumes the reason in
+# run-aligned pieces (a separator run, a listed word plus the one character
+# ending it, or an unlisted run), leaving every match to start where the last
+# ended, at a run start, which is the set of positions a lookbehind allows.
+# The space padded onto the END is how a word in the last position meets that
+# one-character boundary; nothing is asked of the left, and the closing trim
+# takes both pads back. Anything added here has to compile under both
+# engines, and tests/predicate-re2-engine.test.sh is what says so.
 #
 # Position is the only thing that separates a suite name from prose — both
 # are ordinary English, so any SET of names is a word ban on whatever the

--- a/.agents/skills/review-gate/tests/predicate-re2-engine.test.sh
+++ b/.agents/skills/review-gate/tests/predicate-re2-engine.test.sh
@@ -1,24 +1,28 @@
 #!/usr/bin/env bash
 # The predicate hands its thread jq to `gh --jq`, and gh's regex engine is
-# Go's RE2: no lookaround, at all. Every other suite beside this one runs
-# that same program through the LOCAL jq, whose Oniguruma accepts patterns
-# RE2 refuses to compile — so a green battery proved nothing about the path
-# that actually runs. #1930 shipped a lookbehind on exactly that seam: local
-# jq took it, and every live evaluation of a PR carrying a `Declined:` reply
-# died with `invalid regular expression`, which the gate reports as a read
-# failure and fails closed on.
+# Go's RE2: no lookaround, at all. Every proof that runs unattended puts that
+# same program through the LOCAL jq, whose Oniguruma accepts patterns RE2
+# refuses to compile. One proof here does reach RE2 — e2e-sandbox.sh replays
+# the writer live, and the writer runs the predicate — but it skips without
+# E2E_REPO, so nothing in CI ran it. That is how #1930 shipped a lookbehind:
+# local jq took it, and every live evaluation of a PR carrying a `Declined:`
+# reply died with `invalid regular expression`, leaving the writer to red
+# without posting anything and the gate status frozen where it stood.
 #
 # This suite is the missing half: the SHIPPED program, through the SHIPPED
-# engine. The real `gh` (not the tests' shim) is pointed at a local HTTP
-# stub, so `gh api --jq` runs with no network and no credentials, and its
-# verdict for every corpus reply must equal the local jq's.
+# engine, with no opt-in. The real `gh` (not the tests' shim) is pointed at a
+# local HTTP stub, so `gh api --jq` runs with no network and no credentials,
+# and its verdict for every fixture reply must equal the local jq's.
 #
-# Two controls, because "the outputs matched" is a claim a broken harness
+# Three controls, because "the outputs matched" is a claim a broken harness
 # also makes:
-#   1. a planted `(?<!` must red the RE2 run while local jq stays green —
-#      the #1930 defect, reproduced on demand;
-#   2. a planted word-list edit must make the comparison REPORT a
-#      difference — proof the differ is looking at anything.
+#   1. a planted `(?<!` in the reason pass must red the RE2 run while local
+#      jq stays green — the #1930 defect, reproduced on demand;
+#   2. a planted `(?<!` in the untracked-claim test must red it too — that
+#      regex is only ever compiled if a fixture reply reaches it, and no
+#      corpus reply does;
+#   3. a planted word-list edit must make the SAME comparison the assertion
+#      runs report a difference — proof the differ is looking at anything.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PRED="$SCRIPT_DIR/../scripts/review-predicate.sh"
@@ -27,9 +31,11 @@ PASS=0 FAIL=0
 ok()  { PASS=$((PASS+1)); echo "  ok    $1"; }
 bad() { FAIL=$((FAIL+1)); echo "  FAIL  $1"; echo "        got: $2"; }
 
-# Both are hard requirements, never a skip: this suite exists because the
-# engine that matters was never exercised, and a suite that quietly opts out
-# when a tool is missing recreates that hole with a green tick on it.
+# All three are hard requirements, never a skip: gh is the engine under
+# proof, python3 serves the stub it reads, and jq builds the fixture and is
+# the other half of the comparison. This suite exists because the engine that
+# matters was never exercised, and a suite that quietly opts out when a tool
+# is missing recreates that hole with a green tick on it.
 for tool in gh python3 jq; do
   command -v "$tool" >/dev/null 2>&1 || {
     echo "review-gate predicate-re2-engine: FAIL — $tool is required; this suite proves the shipped jq against gh's RE2 engine and cannot be satisfied without it" >&2
@@ -51,10 +57,22 @@ cleanup() {
 trap cleanup EXIT
 
 # ---------------------------------------------------------------- fixture ---
-# One page envelope per corpus reply, so the comparison is per reply rather
-# than one aggregate count two divergences could cancel inside. The corpus
-# files are the fixtures here as everywhere else in this directory.
-cat "$CORPUS"/*.txt | grep -v '^#' | grep -v '^[[:space:]]*$' \
+# One page envelope per reply, so the comparison is per reply rather than one
+# aggregate count two divergences could cancel inside. The corpus files are
+# the fixtures here as everywhere else in this directory.
+#
+# THE TWO APPENDED REPLIES ARE COVERAGE, NOT VOCABULARY. gojq compiles a
+# regex when the program reaches it, not when it parses, so this suite proves
+# only the patterns a fixture actually drives. Every corpus reply opens with
+# a decline, so `standing` is always a disposition, `select(disposition|not)`
+# drops it, and the untracked-claim `test(...)` behind that filter is never
+# compiled — a lookbehind planted there shipped green through this very
+# suite. A tracking reply with no issue id and one naming an id take the arm
+# in both directions. They belong here rather than in tests/corpus/, which is
+# the unreasoned-decline term's contract and nothing else's.
+{ cat "$CORPUS"/*.txt
+  printf '%s\n' 'Tracking this one for later.' 'Tracked: KEN-1081'
+} | grep -v '^#' | grep -v '^[[:space:]]*$' \
   | jq -R -s '{pages: (split("\n") | map(select(length > 0)) | map(
       {data: {repository: {pullRequest: {reviewThreads: {
         pageInfo: {hasNextPage: false, endCursor: null},
@@ -137,15 +155,22 @@ else
 fi
 
 if [ "$(wc -l <"$work/re2.out")" = "$replies" ]; then
-  ok "RE2 answered every one of the $replies corpus replies"
+  ok "RE2 answered every one of the $replies fixture replies"
 else
-  bad "RE2 answered every one of the $replies corpus replies" "$(wc -l <"$work/re2.out") verdicts"
+  bad "RE2 answered every one of the $replies fixture replies" "$(wc -l <"$work/re2.out") verdicts"
 fi
 
-if diff -u "$work/local.out" "$work/re2.out" >"$work/engine.diff" 2>&1; then
-  ok "both engines return the same verdict for every corpus reply"
+# THE assertion, in a function, because control three has to be able to kill
+# it. A control running its own parallel diff proves the fixture is sensitive
+# and nothing about the line under it: misdirect that line and the control
+# stays green. Control three overwrites re2.out with a mutant's output and
+# calls this, so a comparison that has stopped comparing reds there.
+engines_agree() { diff -u "$work/local.out" "$work/re2.out" >"$work/engine.diff" 2>&1; }
+
+if engines_agree; then
+  ok "both engines return the same verdict for every fixture reply"
 else
-  bad "both engines return the same verdict for every corpus reply" "$(head -20 "$work/engine.diff")"
+  bad "both engines return the same verdict for every fixture reply" "$(head -20 "$work/engine.diff")"
 fi
 
 # ------------------------------------------------------------- control one ---
@@ -178,16 +203,44 @@ else
 fi
 
 # ------------------------------------------------------------- control two ---
-# A compile-time control alone would pass with the comparison above deleted.
-# This one changes a word the corpus exercises, in a way BOTH engines
-# compile, and requires the differ to say so.
+# Control one plants into a pass every reply reaches. This one plants into the
+# untracked-claim test, which sits behind `select(disposition | not)` and is
+# compiled only when a reply reaches it — no corpus reply does, and a
+# lookbehind planted there once passed this suite 9 for 9. The two appended
+# fixture replies are what make it reachable, so this is also the assertion
+# that they still are.
+claimtest="$(printf '%s' "$prog" | plant \
+  'select(test("([A-Z][A-Z0-9]+-[0-9]+' \
+  'select(test("(?<![a-z])([A-Z][A-Z0-9]+-[0-9]+')" || claimtest=""
+if [ -z "$claimtest" ] || [ "$claimtest" = "$prog" ]; then
+  bad "control: a lookbehind can be planted in the untracked-claim test" \
+      "the anchor matched nothing in the extracted program"
+else
+  ok "control: a lookbehind can be planted in the untracked-claim test"
+  if re2 "$claimtest" >/dev/null 2>"$work/ct.re2.err"; then
+    bad "control: RE2 rejects a lookbehind in the untracked-claim test" \
+        "the RE2 run succeeded — no fixture reply reaches that regex, so it is never compiled"
+  elif grep -q 'invalid regular expression' "$work/ct.re2.err"; then
+    ok "control: RE2 rejects a lookbehind in the untracked-claim test"
+  else
+    bad "control: RE2 rejects a lookbehind in the untracked-claim test" \
+        "failed for some other reason: $(head -1 "$work/ct.re2.err")"
+  fi
+fi
+
+# ----------------------------------------------------------- control three ---
+# The compile-time controls would both pass with the comparison above gone or
+# misdirected. This one changes a word the corpus exercises, in a way BOTH
+# engines compile, then re-runs `engines_agree` itself — the same line the
+# assertion runs — and requires it to say no. re2.out is overwritten on
+# purpose; nothing reads it after this.
 worded="$(printf '%s' "$prog" | plant '"frozen|freezes?' '"frozzen|freezes?')" || worded=""
 if [ -z "$worded" ] || [ "$worded" = "$prog" ]; then
   bad "control: a word-list edit can be planted" "the anchor matched nothing in the extracted program"
 else
   ok "control: a word-list edit can be planted"
-  if re2 "$worded" >"$work/worded.out" 2>"$work/worded.err"; then
-    if diff -q "$work/local.out" "$work/worded.out" >/dev/null 2>&1; then
+  if re2 "$worded" >"$work/re2.out" 2>"$work/worded.err"; then
+    if engines_agree; then
       bad "control: the comparison reports a real divergence" \
           "a corpus-visible word-list edit produced identical output — the differ is inert"
     else
@@ -198,6 +251,23 @@ else
         "the mutant did not run under RE2: $(head -1 "$work/worded.err")"
   fi
 fi
+
+# -------------------------------------------------------- no lookaround at all ---
+# Everything above proves ONE program, located by the `t_threads_page_jq`
+# anchor. The mechanism that produced the bug is wider than that program: any
+# regex written against local jq and handed to gh fails the same way, and a
+# second such program would sit outside the proof. This scan costs nothing and
+# reds wherever a lookaround lands in these two scripts. `(?<name>` is a named
+# capture, not lookaround, and gh translates it, so it is not matched here.
+for f in "$PRED" "$SCRIPT_DIR/../scripts/pr-watch.sh"; do
+  hits="$(grep -nE '\(\?<!|\(\?<=|\(\?=|\(\?!' "$f" | grep -vE '^[0-9]+:[[:space:]]*#' || true)"
+  if [ -z "$hits" ]; then
+    ok "no lookaround in ${f##*/}"
+  else
+    bad "no lookaround in ${f##*/}" \
+        "gh's RE2 compiles none of these, and a jq program carrying one aborts the read: $hits"
+  fi
+done
 
 echo "$PASS passed, $FAIL failed"
 [ "$FAIL" = 0 ] || exit 1

--- a/.agents/skills/review-gate/tests/predicate-re2-engine.test.sh
+++ b/.agents/skills/review-gate/tests/predicate-re2-engine.test.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# The predicate hands its thread jq to `gh --jq`, and gh's regex engine is
+# Go's RE2: no lookaround, at all. Every other suite beside this one runs
+# that same program through the LOCAL jq, whose Oniguruma accepts patterns
+# RE2 refuses to compile — so a green battery proved nothing about the path
+# that actually runs. #1930 shipped a lookbehind on exactly that seam: local
+# jq took it, and every live evaluation of a PR carrying a `Declined:` reply
+# died with `invalid regular expression`, which the gate reports as a read
+# failure and fails closed on.
+#
+# This suite is the missing half: the SHIPPED program, through the SHIPPED
+# engine. The real `gh` (not the tests' shim) is pointed at a local HTTP
+# stub, so `gh api --jq` runs with no network and no credentials, and its
+# verdict for every corpus reply must equal the local jq's.
+#
+# Two controls, because "the outputs matched" is a claim a broken harness
+# also makes:
+#   1. a planted `(?<!` must red the RE2 run while local jq stays green —
+#      the #1930 defect, reproduced on demand;
+#   2. a planted word-list edit must make the comparison REPORT a
+#      difference — proof the differ is looking at anything.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRED="$SCRIPT_DIR/../scripts/review-predicate.sh"
+CORPUS="$SCRIPT_DIR/corpus"
+PASS=0 FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ok    $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  FAIL  $1"; echo "        got: $2"; }
+
+# Both are hard requirements, never a skip: this suite exists because the
+# engine that matters was never exercised, and a suite that quietly opts out
+# when a tool is missing recreates that hole with a green tick on it.
+for tool in gh python3 jq; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "review-gate predicate-re2-engine: FAIL — $tool is required; this suite proves the shipped jq against gh's RE2 engine and cannot be satisfied without it" >&2
+    exit 1
+  }
+done
+
+prog="$(sed -n "/^t_threads_page_jq='/,/^  end'/p" "$PRED" | sed "s/^t_threads_page_jq='//; s/^  end'\$/  end/")"
+[ -n "$prog" ] || { echo "FAIL: could not extract t_threads_page_jq"; exit 1; }
+
+work="$(mktemp -d)" || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+srv="$work/srv"
+mkdir -p "$srv" "$work/gh"
+server_pid=""
+cleanup() {
+  if [ -n "$server_pid" ]; then kill "$server_pid" >/dev/null 2>&1 || true; fi
+  rm -rf -- "${work:?}"
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------- fixture ---
+# One page envelope per corpus reply, so the comparison is per reply rather
+# than one aggregate count two divergences could cancel inside. The corpus
+# files are the fixtures here as everywhere else in this directory.
+cat "$CORPUS"/*.txt | grep -v '^#' | grep -v '^[[:space:]]*$' \
+  | jq -R -s '{pages: (split("\n") | map(select(length > 0)) | map(
+      {data: {repository: {pullRequest: {reviewThreads: {
+        pageInfo: {hasNextPage: false, endCursor: null},
+        nodes: [{isResolved: true, comments: {pageInfo: {hasNextPage: false},
+                 nodes: [{body: ., author: {__typename: "User"}}]}}]
+      }}}}}))}' >"$srv/pages.json"
+replies="$(jq -r '.pages | length' "$srv/pages.json")"
+# A floor, not the exact count: the corpus grows by design, and a test that
+# restated its size would red on every added reply. What must never happen
+# is the fixture silently emptying and every assertion below passing over
+# nothing.
+if [ "${replies:-0}" -lt 100 ]; then
+  bad "corpus built a usable fixture" "only ${replies:-0} replies read from $CORPUS"
+  echo "$PASS passed, $FAIL failed"
+  exit 1
+fi
+
+# ----------------------------------------------------------------- engines ---
+# Port 0: the kernel picks a free one, so concurrent lanes on one machine do
+# not collide. The port is read back from the server's own banner.
+python3 -u -m http.server 0 --bind 127.0.0.1 --directory "$srv" >"$work/httpd.log" 2>&1 &
+server_pid=$!
+port=""
+i=0
+while [ "$i" -lt 100 ]; do
+  port="$(sed -n 's/.*port \([0-9][0-9]*\).*/\1/p' "$work/httpd.log" | head -1)"
+  [ -n "$port" ] && break
+  kill -0 "$server_pid" 2>/dev/null || break
+  i=$((i + 1))
+  sleep 0.1
+done
+if [ -z "$port" ]; then
+  bad "local HTTP stub started" "$(cat "$work/httpd.log")"
+  echo "$PASS passed, $FAIL failed"
+  exit 1
+fi
+
+# GH_TOKEN is a placeholder the stub ignores: gh refuses to issue a request
+# with no credential, and a real one must never be needed to run a suite.
+# GH_CONFIG_DIR isolates the run from the developer's own gh config.
+re2() { # re2 PROGRAM -> gh's RE2 engine over the stub
+  GH_TOKEN=x GH_CONFIG_DIR="$work/gh" GH_NO_UPDATE_NOTIFIER=1 \
+    gh api "http://127.0.0.1:$port/pages.json" --jq ".pages[] | ($1)"
+}
+local_jq() { # local_jq PROGRAM -> the Oniguruma engine every other suite uses
+  jq -r ".pages[] | ($1)" "$srv/pages.json"
+}
+
+# A probe rewrites the program's text, and "the text changed" is a contract a
+# WRONG rewrite also satisfies. plant() refuses unless the anchor occurs
+# exactly once, so a drifted anchor reds here instead of leaving the control
+# asserting against a program nobody described.
+plant() { # plant FROM TO   (program on stdin, mutant on stdout)
+  python3 -c '
+import sys
+src = sys.stdin.read()
+frm, to = sys.argv[1], sys.argv[2]
+n = src.count(frm)
+if n != 1:
+    sys.stderr.write("anchor occurs %d times, expected exactly 1: %s\n" % (n, frm))
+    sys.exit(1)
+sys.stdout.write(src.replace(frm, to))
+' "$1" "$2"
+}
+
+# ------------------------------------------------------- the shipped program ---
+if local_jq "$prog" >"$work/local.out" 2>"$work/local.err"; then local_rc=0; else local_rc=$?; fi
+if re2 "$prog" >"$work/re2.out" 2>"$work/re2.err"; then re2_rc=0; else re2_rc=$?; fi
+
+if [ "$local_rc" = 0 ]; then
+  ok "the shipped program runs under local jq"
+else
+  bad "the shipped program runs under local jq" "exit $local_rc: $(head -1 "$work/local.err")"
+fi
+
+if [ "$re2_rc" = 0 ]; then
+  ok "the shipped program runs under gh's RE2 engine"
+else
+  bad "the shipped program runs under gh's RE2 engine" "exit $re2_rc: $(head -1 "$work/re2.err")"
+fi
+
+if [ "$(wc -l <"$work/re2.out")" = "$replies" ]; then
+  ok "RE2 answered every one of the $replies corpus replies"
+else
+  bad "RE2 answered every one of the $replies corpus replies" "$(wc -l <"$work/re2.out") verdicts"
+fi
+
+if diff -u "$work/local.out" "$work/re2.out" >"$work/engine.diff" 2>&1; then
+  ok "both engines return the same verdict for every corpus reply"
+else
+  bad "both engines return the same verdict for every corpus reply" "$(head -20 "$work/engine.diff")"
+fi
+
+# ------------------------------------------------------------- control one ---
+# The #1930 defect, planted back into the line it shipped on: local jq must
+# stay green and RE2 must refuse to compile. A suite that keeps passing here
+# is reading the wrong engine again.
+lookbehind="$(printf '%s' "$prog" | plant \
+  'gsub("(?<w>[\\p{L}\\p{N}]+' \
+  'gsub("(?<![\\p{L}\\p{N}])(?<w>[\\p{L}\\p{N}]+')" || lookbehind=""
+if [ -z "$lookbehind" ] || [ "$lookbehind" = "$prog" ]; then
+  bad "control: a lookbehind can be planted" "the anchor matched nothing in the extracted program"
+else
+  ok "control: a lookbehind can be planted"
+
+  if local_jq "$lookbehind" >/dev/null 2>"$work/lb.local.err"; then
+    ok "control: local jq accepts the planted lookbehind (which is why it hid)"
+  else
+    bad "control: local jq accepts the planted lookbehind (which is why it hid)" \
+        "$(head -1 "$work/lb.local.err")"
+  fi
+
+  if re2 "$lookbehind" >/dev/null 2>"$work/lb.re2.err"; then
+    bad "control: RE2 rejects the planted lookbehind" "the RE2 run succeeded — this suite cannot see the defect it exists for"
+  elif grep -q 'invalid regular expression' "$work/lb.re2.err"; then
+    ok "control: RE2 rejects the planted lookbehind"
+  else
+    bad "control: RE2 rejects the planted lookbehind" \
+        "failed for some other reason: $(head -1 "$work/lb.re2.err")"
+  fi
+fi
+
+# ------------------------------------------------------------- control two ---
+# A compile-time control alone would pass with the comparison above deleted.
+# This one changes a word the corpus exercises, in a way BOTH engines
+# compile, and requires the differ to say so.
+worded="$(printf '%s' "$prog" | plant '"frozen|freezes?' '"frozzen|freezes?')" || worded=""
+if [ -z "$worded" ] || [ "$worded" = "$prog" ]; then
+  bad "control: a word-list edit can be planted" "the anchor matched nothing in the extracted program"
+else
+  ok "control: a word-list edit can be planted"
+  if re2 "$worded" >"$work/worded.out" 2>"$work/worded.err"; then
+    if diff -q "$work/local.out" "$work/worded.out" >/dev/null 2>&1; then
+      bad "control: the comparison reports a real divergence" \
+          "a corpus-visible word-list edit produced identical output — the differ is inert"
+    else
+      ok "control: the comparison reports a real divergence"
+    fi
+  else
+    bad "control: the comparison reports a real divergence" \
+        "the mutant did not run under RE2: $(head -1 "$work/worded.err")"
+  fi
+fi
+
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" = 0 ] || exit 1

--- a/.agents/skills/review-gate/tests/predicate-re2-engine.test.sh
+++ b/.agents/skills/review-gate/tests/predicate-re2-engine.test.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 # The predicate hands its thread jq to `gh --jq`, and gh's regex engine is
-# Go's RE2: no lookaround, at all. Every proof that runs unattended puts that
-# same program through the LOCAL jq, whose Oniguruma accepts patterns RE2
-# refuses to compile. One proof here does reach RE2 — e2e-sandbox.sh replays
-# the writer live, and the writer runs the predicate — but it skips without
-# E2E_REPO, so nothing in CI ran it. That is how #1930 shipped a lookbehind:
-# local jq took it, and every live evaluation of a PR carrying a `Declined:`
-# reply died with `invalid regular expression`, leaving the writer to red
-# without posting anything and the gate status frozen where it stood.
+# Go's RE2: no lookaround, at all. Every OTHER proof that runs unattended
+# puts that same program through the LOCAL jq, whose Oniguruma accepts
+# patterns RE2 refuses to compile. One other proof here does reach RE2 —
+# e2e-sandbox.sh replays the writer live, and the writer runs the predicate —
+# but it skips without E2E_REPO, so nothing in CI ran it. That is how #1930
+# shipped a lookbehind: local jq took it, and every live evaluation of a PR
+# carrying a `Declined:` reply died with `invalid regular expression`,
+# leaving the writer to red without posting anything and the gate status
+# frozen where it stood.
 #
 # This suite is the missing half: the SHIPPED program, through the SHIPPED
 # engine, with no opt-in. The real `gh` (not the tests' shim) is pointed at a
@@ -251,23 +252,6 @@ else
         "the mutant did not run under RE2: $(head -1 "$work/worded.err")"
   fi
 fi
-
-# -------------------------------------------------------- no lookaround at all ---
-# Everything above proves ONE program, located by the `t_threads_page_jq`
-# anchor. The mechanism that produced the bug is wider than that program: any
-# regex written against local jq and handed to gh fails the same way, and a
-# second such program would sit outside the proof. This scan costs nothing and
-# reds wherever a lookaround lands in these two scripts. `(?<name>` is a named
-# capture, not lookaround, and gh translates it, so it is not matched here.
-for f in "$PRED" "$SCRIPT_DIR/../scripts/pr-watch.sh"; do
-  hits="$(grep -nE '\(\?<!|\(\?<=|\(\?=|\(\?!' "$f" | grep -vE '^[0-9]+:[[:space:]]*#' || true)"
-  if [ -z "$hits" ]; then
-    ok "no lookaround in ${f##*/}"
-  else
-    bad "no lookaround in ${f##*/}" \
-        "gh's RE2 compiles none of these, and a jq program carrying one aborts the read: $hits"
-  fi
-done
 
 echo "$PASS passed, $FAIL failed"
 [ "$FAIL" = 0 ] || exit 1

--- a/.agents/skills/review-gate/tests/unreasoned-decline.test.sh
+++ b/.agents/skills/review-gate/tests/unreasoned-decline.test.sh
@@ -365,7 +365,7 @@ echo "--- must-fail probe: the strips moved back in front of the label pass ---"
 # misordering as moving the strips up and is one pass. Matched by literal
 # text rather than a regex over a regex.
 MISORDERED="$(awk '
-  index($0, "(frozen|") { lbl = $0; next }
+  index($0, "\"frozen|") { lbl = $0; next }
   index($0, "(/[a-z0-9]")           { print; print lbl; next }
   { print }' <<<"$prog")"
 if ! planted "the label pass, moved" move "$MISORDERED"; then :
@@ -397,7 +397,7 @@ echo "--- must-fail probe: the filler pass moved back behind the strips ---"
 # is a separate probe rather than a second line in that one so a stranding is
 # attributable to the list it belongs to.
 MISFILLER="$(awk '
-  index($0, "(a|an|the|") { fil = $0; next }
+  index($0, "\"a|an|the|") { fil = $0; next }
   index($0, "(/[a-z0-9]")                { print; print fil; next }
   { print }' <<<"$prog")"
 if ! planted "the filler pass, moved" move "$MISFILLER"; then :
@@ -448,15 +448,16 @@ echo "--- the ordering section covers every entry the derivation names ---"
 # fact about its contents, not a property of it, and the day someone adds a
 # phrase there this reds instead of the suite staying green.
 alt_of() { # alt_of FIRST_ALTERNATIVE -> the alternation that opens with it
-  # Located by the alternation's OWN opening paren, then walked to its match
-  # at depth zero, so neither end reads the anchor around the group: the
-  # boundary the lists carry is a term this suite measures, not one it
-  # transcribes. A nested group like `instruction(s|ed)?` is counted through.
-  awk -v k="$1" '{ p = index($0, "(" k "|"); if (!p) next
-                   d = 0; out = ""
-                   for (i = p; i <= length($0); i++) { ch = substr($0, i, 1)
-                     if (ch == "(") { d++; if (d == 1) continue }
-                     else if (ch == ")") { d--; if (d == 0) { print out; exit } }
+  # Located by the jq string quote the list opens with, then read to the
+  # closing quote: the alternation IS the whole `word_strip` argument, and the
+  # boundary that argument is wrapped in lives in `word_strip` itself, so
+  # nothing here transcribes a term this suite is measuring. A nested group
+  # like `instruction(s|ed)?` is read through, quotes being the only
+  # delimiter the list cannot contain.
+  awk -v k="$1" '{ p = index($0, "\"" k "|"); if (!p) next
+                   out = ""
+                   for (i = p + 1; i <= length($0); i++) { ch = substr($0, i, 1)
+                     if (ch == "\"") { print out; exit }
                      out = out ch } }' <<<"$prog"
 }
 LABEL_ALT="$(alt_of frozen)"

--- a/skills/review-gate/DEVELOPMENT.md
+++ b/skills/review-gate/DEVELOPMENT.md
@@ -19,7 +19,7 @@ Paths are as installed in a consuming repo, under
 | `scripts/validate-workflow.sh` | Is the adopted copy still the shipped template? Equality, not re-derivation: see § Equality, not re-derivation. Usable on its own when only the workflow copy changed. |
 | `scripts/pr-watch.sh` | The agent-side reducer: "does any open PR need attention right now?" Silence on stdout + exit 0 means nothing needs you, which makes it a one-line loop/cron predicate; `--heal` also dispatches the writer once on a stale gate. |
 | `scripts/review-predicate-selftest.sh` | Offline proof of the decision table. An ENGINE proof: it runs here, in the catalog repo, on every change. |
-| `tests/predicate-re2-engine.test.sh` | The predicate's thread jq, run through the engine that actually ships it: the real `gh --jq` (Go's RE2), pointed at a local HTTP stub. Every other proof here runs that program through the local jq, whose Oniguruma accepts lookaround RE2 will not compile. Needs `gh` and `python3`, and refuses rather than skipping without them. |
+| `tests/predicate-re2-engine.test.sh` | The predicate's thread jq, run through the engine that actually ships it: the real `gh --jq` (Go's RE2), pointed at a local HTTP stub. Every proof that runs unattended reads that program through the local jq, whose Oniguruma accepts lookaround RE2 will not compile; the live replay below does reach RE2, but it skips without `E2E_REPO`, so nothing ran it. Needs `gh`, `python3` and `jq`, and refuses rather than skipping without them. |
 | `tests/e2e-sandbox.sh` | Live replay against a throwaway repo — re-run it before changing the engine. |
 
 ## Where each proof runs

--- a/skills/review-gate/DEVELOPMENT.md
+++ b/skills/review-gate/DEVELOPMENT.md
@@ -19,6 +19,7 @@ Paths are as installed in a consuming repo, under
 | `scripts/validate-workflow.sh` | Is the adopted copy still the shipped template? Equality, not re-derivation: see § Equality, not re-derivation. Usable on its own when only the workflow copy changed. |
 | `scripts/pr-watch.sh` | The agent-side reducer: "does any open PR need attention right now?" Silence on stdout + exit 0 means nothing needs you, which makes it a one-line loop/cron predicate; `--heal` also dispatches the writer once on a stale gate. |
 | `scripts/review-predicate-selftest.sh` | Offline proof of the decision table. An ENGINE proof: it runs here, in the catalog repo, on every change. |
+| `tests/predicate-re2-engine.test.sh` | The predicate's thread jq, run through the engine that actually ships it: the real `gh --jq` (Go's RE2), pointed at a local HTTP stub. Every other proof here runs that program through the local jq, whose Oniguruma accepts lookaround RE2 will not compile. Needs `gh` and `python3`, and refuses rather than skipping without them. |
 | `tests/e2e-sandbox.sh` | Live replay against a throwaway repo — re-run it before changing the engine. |
 
 ## Where each proof runs

--- a/skills/review-gate/DEVELOPMENT.md
+++ b/skills/review-gate/DEVELOPMENT.md
@@ -19,7 +19,7 @@ Paths are as installed in a consuming repo, under
 | `scripts/validate-workflow.sh` | Is the adopted copy still the shipped template? Equality, not re-derivation: see § Equality, not re-derivation. Usable on its own when only the workflow copy changed. |
 | `scripts/pr-watch.sh` | The agent-side reducer: "does any open PR need attention right now?" Silence on stdout + exit 0 means nothing needs you, which makes it a one-line loop/cron predicate; `--heal` also dispatches the writer once on a stale gate. |
 | `scripts/review-predicate-selftest.sh` | Offline proof of the decision table. An ENGINE proof: it runs here, in the catalog repo, on every change. |
-| `tests/predicate-re2-engine.test.sh` | The predicate's thread jq, run through the engine that actually ships it: the real `gh --jq` (Go's RE2), pointed at a local HTTP stub. Every proof that runs unattended reads that program through the local jq, whose Oniguruma accepts lookaround RE2 will not compile; the live replay below does reach RE2, but it skips without `E2E_REPO`, so nothing ran it. Needs `gh`, `python3` and `jq`, and refuses rather than skipping without them. |
+| `tests/predicate-re2-engine.test.sh` | The predicate's thread jq, run through the engine that actually ships it: the real `gh --jq` (Go's RE2), pointed at a local HTTP stub. Every other proof that runs unattended reads that program through the local jq, whose Oniguruma accepts lookaround RE2 will not compile; the live replay below does reach RE2, but it skips without `E2E_REPO`, so nothing ran it. Needs `gh`, `python3` and `jq`, and refuses rather than skipping without them. |
 | `tests/e2e-sandbox.sh` | Live replay against a throwaway repo — re-run it before changing the engine. |
 
 ## Where each proof runs

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -1423,6 +1423,19 @@ if [ "$THREADS_MODE" = "enforce" ]; then
 # strips: `\b` reads `_` as a word character. The corpus section "two
 # unrelated labels joined by a held separator" is what holds that.
 #
+# THIS PROGRAM RUNS UNDER `gh --jq`, AND THAT ENGINE IS GO'S RE2: no
+# lookaround compiles, and a pattern carrying one aborts the read, which the
+# gate reports as a failure. The local jq is Oniguruma and takes it, so only
+# the engine says so — `(?<!` shipped here once and every PR with a decline
+# stopped converging. So the boundary is spelled by `word_strip`, which
+# consumes the reason in run-aligned pieces — a separator run, a listed word
+# plus the one character ending it, or an unlisted run — leaving every match
+# to start where the last ended, at a run start, which is the set of
+# positions a lookbehind allows. The space padded onto each end is how a word
+# at either edge meets that one-character boundary, and the closing trim
+# takes it back. Anything added here has to compile under both engines;
+# tests/predicate-re2-engine.test.sh is what says so.
+#
 # Position is the only thing that separates a suite name from prose — both
 # are ordinary English, so any SET of names is a word ban on whatever the
 # repo happens to name its files after, and "the guard refuses this path" is
@@ -1436,13 +1449,17 @@ t_threads_page_jq='def disposition: test("^\\s*(fixed in [0-9a-f]{7,40}\\b|decli
   def replies: [(.comments.nodes // [])[] | select((.author.__typename // "User") != "Bot") | (.body // "")];
   def standing: [replies[] | select(disposition or tracking)] | last // empty;
   def standing_decline: [replies[] | select(disposition or declined or tracking)] | last // empty;
+  def word_strip($list):
+    gsub("(?<s>[^\\p{L}\\p{N}]+)|(?<w>" + $list + ")(?<b>[^\\p{L}\\p{N}])|(?<r>[\\p{L}\\p{N}]+)";
+      if .w != null then " " + .b elif .s != null then .s else .r end);
   def reason_left:
     sub("(?i)^\\s*declined\\b"; "")
     | gsub("[A-Z][A-Z0-9]+-[0-9]+|#[0-9]+"; " ")
     | ascii_downcase
-    | gsub("[^\\p{L}\\p{N}/._-]|(?<![\\p{L}\\p{N}])[._-]|[._-](?![\\p{L}\\p{N}])"; " ")
-    | gsub("(?<![\\p{L}\\p{N}])(frozen|freezes?|freezing|cap|capped|round[ ._-][0-9]+|round|rounds|tests?|suites?|pass|passes|passed|passing|green|count|checks?|checking|ci|runs?|builds?|building|built|compiles?|compiled|pipelines?|lints?|linter|linting|workflows?|jobs?|typechecks?|validation|coverage|everything|fine|clean|out[ ._-]of[ ._-]scope|scope|pre[ ._-]existing|preexisting|existing|flagged[ ._-]separately|flagged|separately|as[ ._-]discussed|discussed|noted|won[ ._-]?t[ ._-]?fix|false[ ._-]positives?|by[ ._-]design|design|not[ ._-]applicable|n[ /._-]a|actionable|no[ ._-]change|nothing[ ._-]to[ ._-]do|later|known|intentional|deliberate|works[ ._-]as[ ._-]intended|as[ ._-]intended|intended|owners?|instruction(s|ed)?|previous|pushe[sd]?|push|last|head|disposition(ed|s)?|findings?|fix(es|ed)?|track(s|ed|ing|er)?|filed|filing|logged)(?![\\p{L}\\p{N}])"; " ")
-    | gsub("(?<![\\p{L}\\p{N}])(a|an|the|this|that|these|those|it|its|is|are|was|were|be|been|for|in|on|at|to|of|and|or|but|so|we|i|you|your|pr|prs|here|now|all|full|whole|entire|complete|still|already|yes|no|not|do|does|did|has|have|had|under|per|within|as|after|rather|than|see|every|set|s|t)(?![\\p{L}\\p{N}])"; " ")
+    | gsub("(?<w>[\\p{L}\\p{N}]+([._-][\\p{L}\\p{N}]+)*)|(?<k>/)|[\\s\\S]"; "\(.w // .k // " ")")
+    | " " + . + " "
+    | word_strip("frozen|freezes?|freezing|cap|capped|round[ ._-][0-9]+|round|rounds|tests?|suites?|pass|passes|passed|passing|green|count|checks?|checking|ci|runs?|builds?|building|built|compiles?|compiled|pipelines?|lints?|linter|linting|workflows?|jobs?|typechecks?|validation|coverage|everything|fine|clean|out[ ._-]of[ ._-]scope|scope|pre[ ._-]existing|preexisting|existing|flagged[ ._-]separately|flagged|separately|as[ ._-]discussed|discussed|noted|won[ ._-]?t[ ._-]?fix|false[ ._-]positives?|by[ ._-]design|design|not[ ._-]applicable|n[ /._-]a|actionable|no[ ._-]change|nothing[ ._-]to[ ._-]do|later|known|intentional|deliberate|works[ ._-]as[ ._-]intended|as[ ._-]intended|intended|owners?|instruction(s|ed)?|previous|pushe[sd]?|push|last|head|disposition(ed|s)?|findings?|fix(es|ed)?|track(s|ed|ing|er)?|filed|filing|logged")
+    | word_strip("a|an|the|this|that|these|those|it|its|is|are|was|were|be|been|for|in|on|at|to|of|and|or|but|so|we|i|you|your|pr|prs|here|now|all|full|whole|entire|complete|still|already|yes|no|not|do|does|did|has|have|had|under|per|within|as|after|rather|than|see|every|set|s|t")
     | gsub("\\S+\\s+[0-9]+\\s*/\\s*[0-9]+"; " ")
     | gsub("[a-z0-9][a-z0-9._-]*(/[a-z0-9][a-z0-9._-]*)+"; " ")
     | gsub("[/._-]"; " ")

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -1428,12 +1428,12 @@ if [ "$THREADS_MODE" = "enforce" ]; then
 # exits 2, the writer prints "taking no action" and reds without posting a
 # status, and the gate keeps whatever it already held. That is why a decline
 # stopped a PR converging rather than turning it red. The local jq is
-# Oniguruma and takes lookaround, and every proof that runs unattended reads
-# through that jq, so `(?<!` shipped here once and nothing caught it. The
-# boundary is therefore spelled by `word_strip`, which consumes the reason in
-# run-aligned pieces (a separator run, a listed word plus the one character
-# ending it, or an unlisted run), leaving every match to start where the last
-# ended, at a run start, which is the set of positions a lookbehind allows.
+# Oniguruma and takes lookaround, and every other proof that runs unattended
+# reads through that jq, so `(?<!` shipped here once and nothing caught it.
+# The boundary is therefore spelled by `word_strip`, which consumes the
+# reason in run-aligned pieces (a separator run, a listed word plus the one
+# character ending it, or an unlisted run), so every match starts where the
+# last ended, at a run start, the set of positions a lookbehind allows.
 # The space padded onto the END is how a word in the last position meets that
 # one-character boundary; nothing is asked of the left, and the closing trim
 # takes both pads back. Anything added here has to compile under both

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -1424,17 +1424,20 @@ if [ "$THREADS_MODE" = "enforce" ]; then
 # unrelated labels joined by a held separator" is what holds that.
 #
 # THIS PROGRAM RUNS UNDER `gh --jq`, AND THAT ENGINE IS GO'S RE2: no
-# lookaround compiles, and a pattern carrying one aborts the read, which the
-# gate reports as a failure. The local jq is Oniguruma and takes it, so only
-# the engine says so — `(?<!` shipped here once and every PR with a decline
-# stopped converging. So the boundary is spelled by `word_strip`, which
-# consumes the reason in run-aligned pieces — a separator run, a listed word
-# plus the one character ending it, or an unlisted run — leaving every match
-# to start where the last ended, at a run start, which is the set of
-# positions a lookbehind allows. The space padded onto each end is how a word
-# at either edge meets that one-character boundary, and the closing trim
-# takes it back. Anything added here has to compile under both engines;
-# tests/predicate-re2-engine.test.sh is what says so.
+# lookaround compiles. A pattern carrying one aborts the read, so this script
+# exits 2, the writer prints "taking no action" and reds without posting a
+# status, and the gate keeps whatever it already held. That is why a decline
+# stopped a PR converging rather than turning it red. The local jq is
+# Oniguruma and takes lookaround, and every proof that runs unattended reads
+# through that jq, so `(?<!` shipped here once and nothing caught it. The
+# boundary is therefore spelled by `word_strip`, which consumes the reason in
+# run-aligned pieces (a separator run, a listed word plus the one character
+# ending it, or an unlisted run), leaving every match to start where the last
+# ended, at a run start, which is the set of positions a lookbehind allows.
+# The space padded onto the END is how a word in the last position meets that
+# one-character boundary; nothing is asked of the left, and the closing trim
+# takes both pads back. Anything added here has to compile under both
+# engines, and tests/predicate-re2-engine.test.sh is what says so.
 #
 # Position is the only thing that separates a suite name from prose — both
 # are ordinary English, so any SET of names is a word ban on whatever the

--- a/skills/review-gate/tests/predicate-re2-engine.test.sh
+++ b/skills/review-gate/tests/predicate-re2-engine.test.sh
@@ -1,24 +1,28 @@
 #!/usr/bin/env bash
 # The predicate hands its thread jq to `gh --jq`, and gh's regex engine is
-# Go's RE2: no lookaround, at all. Every other suite beside this one runs
-# that same program through the LOCAL jq, whose Oniguruma accepts patterns
-# RE2 refuses to compile — so a green battery proved nothing about the path
-# that actually runs. #1930 shipped a lookbehind on exactly that seam: local
-# jq took it, and every live evaluation of a PR carrying a `Declined:` reply
-# died with `invalid regular expression`, which the gate reports as a read
-# failure and fails closed on.
+# Go's RE2: no lookaround, at all. Every proof that runs unattended puts that
+# same program through the LOCAL jq, whose Oniguruma accepts patterns RE2
+# refuses to compile. One proof here does reach RE2 — e2e-sandbox.sh replays
+# the writer live, and the writer runs the predicate — but it skips without
+# E2E_REPO, so nothing in CI ran it. That is how #1930 shipped a lookbehind:
+# local jq took it, and every live evaluation of a PR carrying a `Declined:`
+# reply died with `invalid regular expression`, leaving the writer to red
+# without posting anything and the gate status frozen where it stood.
 #
 # This suite is the missing half: the SHIPPED program, through the SHIPPED
-# engine. The real `gh` (not the tests' shim) is pointed at a local HTTP
-# stub, so `gh api --jq` runs with no network and no credentials, and its
-# verdict for every corpus reply must equal the local jq's.
+# engine, with no opt-in. The real `gh` (not the tests' shim) is pointed at a
+# local HTTP stub, so `gh api --jq` runs with no network and no credentials,
+# and its verdict for every fixture reply must equal the local jq's.
 #
-# Two controls, because "the outputs matched" is a claim a broken harness
+# Three controls, because "the outputs matched" is a claim a broken harness
 # also makes:
-#   1. a planted `(?<!` must red the RE2 run while local jq stays green —
-#      the #1930 defect, reproduced on demand;
-#   2. a planted word-list edit must make the comparison REPORT a
-#      difference — proof the differ is looking at anything.
+#   1. a planted `(?<!` in the reason pass must red the RE2 run while local
+#      jq stays green — the #1930 defect, reproduced on demand;
+#   2. a planted `(?<!` in the untracked-claim test must red it too — that
+#      regex is only ever compiled if a fixture reply reaches it, and no
+#      corpus reply does;
+#   3. a planted word-list edit must make the SAME comparison the assertion
+#      runs report a difference — proof the differ is looking at anything.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PRED="$SCRIPT_DIR/../scripts/review-predicate.sh"
@@ -27,9 +31,11 @@ PASS=0 FAIL=0
 ok()  { PASS=$((PASS+1)); echo "  ok    $1"; }
 bad() { FAIL=$((FAIL+1)); echo "  FAIL  $1"; echo "        got: $2"; }
 
-# Both are hard requirements, never a skip: this suite exists because the
-# engine that matters was never exercised, and a suite that quietly opts out
-# when a tool is missing recreates that hole with a green tick on it.
+# All three are hard requirements, never a skip: gh is the engine under
+# proof, python3 serves the stub it reads, and jq builds the fixture and is
+# the other half of the comparison. This suite exists because the engine that
+# matters was never exercised, and a suite that quietly opts out when a tool
+# is missing recreates that hole with a green tick on it.
 for tool in gh python3 jq; do
   command -v "$tool" >/dev/null 2>&1 || {
     echo "review-gate predicate-re2-engine: FAIL — $tool is required; this suite proves the shipped jq against gh's RE2 engine and cannot be satisfied without it" >&2
@@ -51,10 +57,22 @@ cleanup() {
 trap cleanup EXIT
 
 # ---------------------------------------------------------------- fixture ---
-# One page envelope per corpus reply, so the comparison is per reply rather
-# than one aggregate count two divergences could cancel inside. The corpus
-# files are the fixtures here as everywhere else in this directory.
-cat "$CORPUS"/*.txt | grep -v '^#' | grep -v '^[[:space:]]*$' \
+# One page envelope per reply, so the comparison is per reply rather than one
+# aggregate count two divergences could cancel inside. The corpus files are
+# the fixtures here as everywhere else in this directory.
+#
+# THE TWO APPENDED REPLIES ARE COVERAGE, NOT VOCABULARY. gojq compiles a
+# regex when the program reaches it, not when it parses, so this suite proves
+# only the patterns a fixture actually drives. Every corpus reply opens with
+# a decline, so `standing` is always a disposition, `select(disposition|not)`
+# drops it, and the untracked-claim `test(...)` behind that filter is never
+# compiled — a lookbehind planted there shipped green through this very
+# suite. A tracking reply with no issue id and one naming an id take the arm
+# in both directions. They belong here rather than in tests/corpus/, which is
+# the unreasoned-decline term's contract and nothing else's.
+{ cat "$CORPUS"/*.txt
+  printf '%s\n' 'Tracking this one for later.' 'Tracked: KEN-1081'
+} | grep -v '^#' | grep -v '^[[:space:]]*$' \
   | jq -R -s '{pages: (split("\n") | map(select(length > 0)) | map(
       {data: {repository: {pullRequest: {reviewThreads: {
         pageInfo: {hasNextPage: false, endCursor: null},
@@ -137,15 +155,22 @@ else
 fi
 
 if [ "$(wc -l <"$work/re2.out")" = "$replies" ]; then
-  ok "RE2 answered every one of the $replies corpus replies"
+  ok "RE2 answered every one of the $replies fixture replies"
 else
-  bad "RE2 answered every one of the $replies corpus replies" "$(wc -l <"$work/re2.out") verdicts"
+  bad "RE2 answered every one of the $replies fixture replies" "$(wc -l <"$work/re2.out") verdicts"
 fi
 
-if diff -u "$work/local.out" "$work/re2.out" >"$work/engine.diff" 2>&1; then
-  ok "both engines return the same verdict for every corpus reply"
+# THE assertion, in a function, because control three has to be able to kill
+# it. A control running its own parallel diff proves the fixture is sensitive
+# and nothing about the line under it: misdirect that line and the control
+# stays green. Control three overwrites re2.out with a mutant's output and
+# calls this, so a comparison that has stopped comparing reds there.
+engines_agree() { diff -u "$work/local.out" "$work/re2.out" >"$work/engine.diff" 2>&1; }
+
+if engines_agree; then
+  ok "both engines return the same verdict for every fixture reply"
 else
-  bad "both engines return the same verdict for every corpus reply" "$(head -20 "$work/engine.diff")"
+  bad "both engines return the same verdict for every fixture reply" "$(head -20 "$work/engine.diff")"
 fi
 
 # ------------------------------------------------------------- control one ---
@@ -178,16 +203,44 @@ else
 fi
 
 # ------------------------------------------------------------- control two ---
-# A compile-time control alone would pass with the comparison above deleted.
-# This one changes a word the corpus exercises, in a way BOTH engines
-# compile, and requires the differ to say so.
+# Control one plants into a pass every reply reaches. This one plants into the
+# untracked-claim test, which sits behind `select(disposition | not)` and is
+# compiled only when a reply reaches it — no corpus reply does, and a
+# lookbehind planted there once passed this suite 9 for 9. The two appended
+# fixture replies are what make it reachable, so this is also the assertion
+# that they still are.
+claimtest="$(printf '%s' "$prog" | plant \
+  'select(test("([A-Z][A-Z0-9]+-[0-9]+' \
+  'select(test("(?<![a-z])([A-Z][A-Z0-9]+-[0-9]+')" || claimtest=""
+if [ -z "$claimtest" ] || [ "$claimtest" = "$prog" ]; then
+  bad "control: a lookbehind can be planted in the untracked-claim test" \
+      "the anchor matched nothing in the extracted program"
+else
+  ok "control: a lookbehind can be planted in the untracked-claim test"
+  if re2 "$claimtest" >/dev/null 2>"$work/ct.re2.err"; then
+    bad "control: RE2 rejects a lookbehind in the untracked-claim test" \
+        "the RE2 run succeeded — no fixture reply reaches that regex, so it is never compiled"
+  elif grep -q 'invalid regular expression' "$work/ct.re2.err"; then
+    ok "control: RE2 rejects a lookbehind in the untracked-claim test"
+  else
+    bad "control: RE2 rejects a lookbehind in the untracked-claim test" \
+        "failed for some other reason: $(head -1 "$work/ct.re2.err")"
+  fi
+fi
+
+# ----------------------------------------------------------- control three ---
+# The compile-time controls would both pass with the comparison above gone or
+# misdirected. This one changes a word the corpus exercises, in a way BOTH
+# engines compile, then re-runs `engines_agree` itself — the same line the
+# assertion runs — and requires it to say no. re2.out is overwritten on
+# purpose; nothing reads it after this.
 worded="$(printf '%s' "$prog" | plant '"frozen|freezes?' '"frozzen|freezes?')" || worded=""
 if [ -z "$worded" ] || [ "$worded" = "$prog" ]; then
   bad "control: a word-list edit can be planted" "the anchor matched nothing in the extracted program"
 else
   ok "control: a word-list edit can be planted"
-  if re2 "$worded" >"$work/worded.out" 2>"$work/worded.err"; then
-    if diff -q "$work/local.out" "$work/worded.out" >/dev/null 2>&1; then
+  if re2 "$worded" >"$work/re2.out" 2>"$work/worded.err"; then
+    if engines_agree; then
       bad "control: the comparison reports a real divergence" \
           "a corpus-visible word-list edit produced identical output — the differ is inert"
     else
@@ -198,6 +251,23 @@ else
         "the mutant did not run under RE2: $(head -1 "$work/worded.err")"
   fi
 fi
+
+# -------------------------------------------------------- no lookaround at all ---
+# Everything above proves ONE program, located by the `t_threads_page_jq`
+# anchor. The mechanism that produced the bug is wider than that program: any
+# regex written against local jq and handed to gh fails the same way, and a
+# second such program would sit outside the proof. This scan costs nothing and
+# reds wherever a lookaround lands in these two scripts. `(?<name>` is a named
+# capture, not lookaround, and gh translates it, so it is not matched here.
+for f in "$PRED" "$SCRIPT_DIR/../scripts/pr-watch.sh"; do
+  hits="$(grep -nE '\(\?<!|\(\?<=|\(\?=|\(\?!' "$f" | grep -vE '^[0-9]+:[[:space:]]*#' || true)"
+  if [ -z "$hits" ]; then
+    ok "no lookaround in ${f##*/}"
+  else
+    bad "no lookaround in ${f##*/}" \
+        "gh's RE2 compiles none of these, and a jq program carrying one aborts the read: $hits"
+  fi
+done
 
 echo "$PASS passed, $FAIL failed"
 [ "$FAIL" = 0 ] || exit 1

--- a/skills/review-gate/tests/predicate-re2-engine.test.sh
+++ b/skills/review-gate/tests/predicate-re2-engine.test.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# The predicate hands its thread jq to `gh --jq`, and gh's regex engine is
+# Go's RE2: no lookaround, at all. Every other suite beside this one runs
+# that same program through the LOCAL jq, whose Oniguruma accepts patterns
+# RE2 refuses to compile — so a green battery proved nothing about the path
+# that actually runs. #1930 shipped a lookbehind on exactly that seam: local
+# jq took it, and every live evaluation of a PR carrying a `Declined:` reply
+# died with `invalid regular expression`, which the gate reports as a read
+# failure and fails closed on.
+#
+# This suite is the missing half: the SHIPPED program, through the SHIPPED
+# engine. The real `gh` (not the tests' shim) is pointed at a local HTTP
+# stub, so `gh api --jq` runs with no network and no credentials, and its
+# verdict for every corpus reply must equal the local jq's.
+#
+# Two controls, because "the outputs matched" is a claim a broken harness
+# also makes:
+#   1. a planted `(?<!` must red the RE2 run while local jq stays green —
+#      the #1930 defect, reproduced on demand;
+#   2. a planted word-list edit must make the comparison REPORT a
+#      difference — proof the differ is looking at anything.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRED="$SCRIPT_DIR/../scripts/review-predicate.sh"
+CORPUS="$SCRIPT_DIR/corpus"
+PASS=0 FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ok    $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  FAIL  $1"; echo "        got: $2"; }
+
+# Both are hard requirements, never a skip: this suite exists because the
+# engine that matters was never exercised, and a suite that quietly opts out
+# when a tool is missing recreates that hole with a green tick on it.
+for tool in gh python3 jq; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "review-gate predicate-re2-engine: FAIL — $tool is required; this suite proves the shipped jq against gh's RE2 engine and cannot be satisfied without it" >&2
+    exit 1
+  }
+done
+
+prog="$(sed -n "/^t_threads_page_jq='/,/^  end'/p" "$PRED" | sed "s/^t_threads_page_jq='//; s/^  end'\$/  end/")"
+[ -n "$prog" ] || { echo "FAIL: could not extract t_threads_page_jq"; exit 1; }
+
+work="$(mktemp -d)" || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+srv="$work/srv"
+mkdir -p "$srv" "$work/gh"
+server_pid=""
+cleanup() {
+  if [ -n "$server_pid" ]; then kill "$server_pid" >/dev/null 2>&1 || true; fi
+  rm -rf -- "${work:?}"
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------- fixture ---
+# One page envelope per corpus reply, so the comparison is per reply rather
+# than one aggregate count two divergences could cancel inside. The corpus
+# files are the fixtures here as everywhere else in this directory.
+cat "$CORPUS"/*.txt | grep -v '^#' | grep -v '^[[:space:]]*$' \
+  | jq -R -s '{pages: (split("\n") | map(select(length > 0)) | map(
+      {data: {repository: {pullRequest: {reviewThreads: {
+        pageInfo: {hasNextPage: false, endCursor: null},
+        nodes: [{isResolved: true, comments: {pageInfo: {hasNextPage: false},
+                 nodes: [{body: ., author: {__typename: "User"}}]}}]
+      }}}}}))}' >"$srv/pages.json"
+replies="$(jq -r '.pages | length' "$srv/pages.json")"
+# A floor, not the exact count: the corpus grows by design, and a test that
+# restated its size would red on every added reply. What must never happen
+# is the fixture silently emptying and every assertion below passing over
+# nothing.
+if [ "${replies:-0}" -lt 100 ]; then
+  bad "corpus built a usable fixture" "only ${replies:-0} replies read from $CORPUS"
+  echo "$PASS passed, $FAIL failed"
+  exit 1
+fi
+
+# ----------------------------------------------------------------- engines ---
+# Port 0: the kernel picks a free one, so concurrent lanes on one machine do
+# not collide. The port is read back from the server's own banner.
+python3 -u -m http.server 0 --bind 127.0.0.1 --directory "$srv" >"$work/httpd.log" 2>&1 &
+server_pid=$!
+port=""
+i=0
+while [ "$i" -lt 100 ]; do
+  port="$(sed -n 's/.*port \([0-9][0-9]*\).*/\1/p' "$work/httpd.log" | head -1)"
+  [ -n "$port" ] && break
+  kill -0 "$server_pid" 2>/dev/null || break
+  i=$((i + 1))
+  sleep 0.1
+done
+if [ -z "$port" ]; then
+  bad "local HTTP stub started" "$(cat "$work/httpd.log")"
+  echo "$PASS passed, $FAIL failed"
+  exit 1
+fi
+
+# GH_TOKEN is a placeholder the stub ignores: gh refuses to issue a request
+# with no credential, and a real one must never be needed to run a suite.
+# GH_CONFIG_DIR isolates the run from the developer's own gh config.
+re2() { # re2 PROGRAM -> gh's RE2 engine over the stub
+  GH_TOKEN=x GH_CONFIG_DIR="$work/gh" GH_NO_UPDATE_NOTIFIER=1 \
+    gh api "http://127.0.0.1:$port/pages.json" --jq ".pages[] | ($1)"
+}
+local_jq() { # local_jq PROGRAM -> the Oniguruma engine every other suite uses
+  jq -r ".pages[] | ($1)" "$srv/pages.json"
+}
+
+# A probe rewrites the program's text, and "the text changed" is a contract a
+# WRONG rewrite also satisfies. plant() refuses unless the anchor occurs
+# exactly once, so a drifted anchor reds here instead of leaving the control
+# asserting against a program nobody described.
+plant() { # plant FROM TO   (program on stdin, mutant on stdout)
+  python3 -c '
+import sys
+src = sys.stdin.read()
+frm, to = sys.argv[1], sys.argv[2]
+n = src.count(frm)
+if n != 1:
+    sys.stderr.write("anchor occurs %d times, expected exactly 1: %s\n" % (n, frm))
+    sys.exit(1)
+sys.stdout.write(src.replace(frm, to))
+' "$1" "$2"
+}
+
+# ------------------------------------------------------- the shipped program ---
+if local_jq "$prog" >"$work/local.out" 2>"$work/local.err"; then local_rc=0; else local_rc=$?; fi
+if re2 "$prog" >"$work/re2.out" 2>"$work/re2.err"; then re2_rc=0; else re2_rc=$?; fi
+
+if [ "$local_rc" = 0 ]; then
+  ok "the shipped program runs under local jq"
+else
+  bad "the shipped program runs under local jq" "exit $local_rc: $(head -1 "$work/local.err")"
+fi
+
+if [ "$re2_rc" = 0 ]; then
+  ok "the shipped program runs under gh's RE2 engine"
+else
+  bad "the shipped program runs under gh's RE2 engine" "exit $re2_rc: $(head -1 "$work/re2.err")"
+fi
+
+if [ "$(wc -l <"$work/re2.out")" = "$replies" ]; then
+  ok "RE2 answered every one of the $replies corpus replies"
+else
+  bad "RE2 answered every one of the $replies corpus replies" "$(wc -l <"$work/re2.out") verdicts"
+fi
+
+if diff -u "$work/local.out" "$work/re2.out" >"$work/engine.diff" 2>&1; then
+  ok "both engines return the same verdict for every corpus reply"
+else
+  bad "both engines return the same verdict for every corpus reply" "$(head -20 "$work/engine.diff")"
+fi
+
+# ------------------------------------------------------------- control one ---
+# The #1930 defect, planted back into the line it shipped on: local jq must
+# stay green and RE2 must refuse to compile. A suite that keeps passing here
+# is reading the wrong engine again.
+lookbehind="$(printf '%s' "$prog" | plant \
+  'gsub("(?<w>[\\p{L}\\p{N}]+' \
+  'gsub("(?<![\\p{L}\\p{N}])(?<w>[\\p{L}\\p{N}]+')" || lookbehind=""
+if [ -z "$lookbehind" ] || [ "$lookbehind" = "$prog" ]; then
+  bad "control: a lookbehind can be planted" "the anchor matched nothing in the extracted program"
+else
+  ok "control: a lookbehind can be planted"
+
+  if local_jq "$lookbehind" >/dev/null 2>"$work/lb.local.err"; then
+    ok "control: local jq accepts the planted lookbehind (which is why it hid)"
+  else
+    bad "control: local jq accepts the planted lookbehind (which is why it hid)" \
+        "$(head -1 "$work/lb.local.err")"
+  fi
+
+  if re2 "$lookbehind" >/dev/null 2>"$work/lb.re2.err"; then
+    bad "control: RE2 rejects the planted lookbehind" "the RE2 run succeeded — this suite cannot see the defect it exists for"
+  elif grep -q 'invalid regular expression' "$work/lb.re2.err"; then
+    ok "control: RE2 rejects the planted lookbehind"
+  else
+    bad "control: RE2 rejects the planted lookbehind" \
+        "failed for some other reason: $(head -1 "$work/lb.re2.err")"
+  fi
+fi
+
+# ------------------------------------------------------------- control two ---
+# A compile-time control alone would pass with the comparison above deleted.
+# This one changes a word the corpus exercises, in a way BOTH engines
+# compile, and requires the differ to say so.
+worded="$(printf '%s' "$prog" | plant '"frozen|freezes?' '"frozzen|freezes?')" || worded=""
+if [ -z "$worded" ] || [ "$worded" = "$prog" ]; then
+  bad "control: a word-list edit can be planted" "the anchor matched nothing in the extracted program"
+else
+  ok "control: a word-list edit can be planted"
+  if re2 "$worded" >"$work/worded.out" 2>"$work/worded.err"; then
+    if diff -q "$work/local.out" "$work/worded.out" >/dev/null 2>&1; then
+      bad "control: the comparison reports a real divergence" \
+          "a corpus-visible word-list edit produced identical output — the differ is inert"
+    else
+      ok "control: the comparison reports a real divergence"
+    fi
+  else
+    bad "control: the comparison reports a real divergence" \
+        "the mutant did not run under RE2: $(head -1 "$work/worded.err")"
+  fi
+fi
+
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" = 0 ] || exit 1

--- a/skills/review-gate/tests/predicate-re2-engine.test.sh
+++ b/skills/review-gate/tests/predicate-re2-engine.test.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 # The predicate hands its thread jq to `gh --jq`, and gh's regex engine is
-# Go's RE2: no lookaround, at all. Every proof that runs unattended puts that
-# same program through the LOCAL jq, whose Oniguruma accepts patterns RE2
-# refuses to compile. One proof here does reach RE2 — e2e-sandbox.sh replays
-# the writer live, and the writer runs the predicate — but it skips without
-# E2E_REPO, so nothing in CI ran it. That is how #1930 shipped a lookbehind:
-# local jq took it, and every live evaluation of a PR carrying a `Declined:`
-# reply died with `invalid regular expression`, leaving the writer to red
-# without posting anything and the gate status frozen where it stood.
+# Go's RE2: no lookaround, at all. Every OTHER proof that runs unattended
+# puts that same program through the LOCAL jq, whose Oniguruma accepts
+# patterns RE2 refuses to compile. One other proof here does reach RE2 —
+# e2e-sandbox.sh replays the writer live, and the writer runs the predicate —
+# but it skips without E2E_REPO, so nothing in CI ran it. That is how #1930
+# shipped a lookbehind: local jq took it, and every live evaluation of a PR
+# carrying a `Declined:` reply died with `invalid regular expression`,
+# leaving the writer to red without posting anything and the gate status
+# frozen where it stood.
 #
 # This suite is the missing half: the SHIPPED program, through the SHIPPED
 # engine, with no opt-in. The real `gh` (not the tests' shim) is pointed at a
@@ -251,23 +252,6 @@ else
         "the mutant did not run under RE2: $(head -1 "$work/worded.err")"
   fi
 fi
-
-# -------------------------------------------------------- no lookaround at all ---
-# Everything above proves ONE program, located by the `t_threads_page_jq`
-# anchor. The mechanism that produced the bug is wider than that program: any
-# regex written against local jq and handed to gh fails the same way, and a
-# second such program would sit outside the proof. This scan costs nothing and
-# reds wherever a lookaround lands in these two scripts. `(?<name>` is a named
-# capture, not lookaround, and gh translates it, so it is not matched here.
-for f in "$PRED" "$SCRIPT_DIR/../scripts/pr-watch.sh"; do
-  hits="$(grep -nE '\(\?<!|\(\?<=|\(\?=|\(\?!' "$f" | grep -vE '^[0-9]+:[[:space:]]*#' || true)"
-  if [ -z "$hits" ]; then
-    ok "no lookaround in ${f##*/}"
-  else
-    bad "no lookaround in ${f##*/}" \
-        "gh's RE2 compiles none of these, and a jq program carrying one aborts the read: $hits"
-  fi
-done
 
 echo "$PASS passed, $FAIL failed"
 [ "$FAIL" = 0 ] || exit 1

--- a/skills/review-gate/tests/unreasoned-decline.test.sh
+++ b/skills/review-gate/tests/unreasoned-decline.test.sh
@@ -365,7 +365,7 @@ echo "--- must-fail probe: the strips moved back in front of the label pass ---"
 # misordering as moving the strips up and is one pass. Matched by literal
 # text rather than a regex over a regex.
 MISORDERED="$(awk '
-  index($0, "(frozen|") { lbl = $0; next }
+  index($0, "\"frozen|") { lbl = $0; next }
   index($0, "(/[a-z0-9]")           { print; print lbl; next }
   { print }' <<<"$prog")"
 if ! planted "the label pass, moved" move "$MISORDERED"; then :
@@ -397,7 +397,7 @@ echo "--- must-fail probe: the filler pass moved back behind the strips ---"
 # is a separate probe rather than a second line in that one so a stranding is
 # attributable to the list it belongs to.
 MISFILLER="$(awk '
-  index($0, "(a|an|the|") { fil = $0; next }
+  index($0, "\"a|an|the|") { fil = $0; next }
   index($0, "(/[a-z0-9]")                { print; print fil; next }
   { print }' <<<"$prog")"
 if ! planted "the filler pass, moved" move "$MISFILLER"; then :
@@ -448,15 +448,16 @@ echo "--- the ordering section covers every entry the derivation names ---"
 # fact about its contents, not a property of it, and the day someone adds a
 # phrase there this reds instead of the suite staying green.
 alt_of() { # alt_of FIRST_ALTERNATIVE -> the alternation that opens with it
-  # Located by the alternation's OWN opening paren, then walked to its match
-  # at depth zero, so neither end reads the anchor around the group: the
-  # boundary the lists carry is a term this suite measures, not one it
-  # transcribes. A nested group like `instruction(s|ed)?` is counted through.
-  awk -v k="$1" '{ p = index($0, "(" k "|"); if (!p) next
-                   d = 0; out = ""
-                   for (i = p; i <= length($0); i++) { ch = substr($0, i, 1)
-                     if (ch == "(") { d++; if (d == 1) continue }
-                     else if (ch == ")") { d--; if (d == 0) { print out; exit } }
+  # Located by the jq string quote the list opens with, then read to the
+  # closing quote: the alternation IS the whole `word_strip` argument, and the
+  # boundary that argument is wrapped in lives in `word_strip` itself, so
+  # nothing here transcribes a term this suite is measuring. A nested group
+  # like `instruction(s|ed)?` is read through, quotes being the only
+  # delimiter the list cannot contain.
+  awk -v k="$1" '{ p = index($0, "\"" k "|"); if (!p) next
+                   out = ""
+                   for (i = p + 1; i <= length($0); i++) { ch = substr($0, i, 1)
+                     if (ch == "\"") { print out; exit }
                      out = out ch } }' <<<"$prog"
 }
 LABEL_ALT="$(alt_of frozen)"

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -115,7 +115,7 @@ skills/orch/tests/worktree-cwd-precondition-lint.test.sh	940
 skills/preflight/scripts/preflight	1289
 skills/review-gate/scripts/pr-watch.sh	871
 skills/review-gate/scripts/review-predicate-selftest.sh	2514
-skills/review-gate/scripts/review-predicate.sh	1575
+skills/review-gate/scripts/review-predicate.sh	1578
 skills/review-gate/scripts/validate.sh	584
 skills/review-gate/templates/review-gate-writer.yml	658
 skills/review-gate/tests/e2e-sandbox.sh	898

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -115,7 +115,7 @@ skills/orch/tests/worktree-cwd-precondition-lint.test.sh	940
 skills/preflight/scripts/preflight	1289
 skills/review-gate/scripts/pr-watch.sh	871
 skills/review-gate/scripts/review-predicate-selftest.sh	2514
-skills/review-gate/scripts/review-predicate.sh	1558
+skills/review-gate/scripts/review-predicate.sh	1575
 skills/review-gate/scripts/validate.sh	584
 skills/review-gate/templates/review-gate-writer.yml	658
 skills/review-gate/tests/e2e-sandbox.sh	898


### PR DESCRIPTION
## Summary

- `reason_left` in `review-predicate.sh` normalized a decline reason with three `gsub` calls carrying lookbehind and lookahead. The predicate runs that jq through `gh api --jq`, whose engine is Go's RE2, which compiles no lookaround at all — so every PR whose threads carried a `Declined:` reply failed its gate read with `invalid regular expression`, then `could not read review threads`. The gate never posts a status on that path, so those PRs stopped converging rather than turning red.
- The three calls are replaced by a run-aligned `word_strip` that consumes the reason in separator/word/other runs, so every match starts where the last ended — exactly the positions `(?<![\p{L}\p{N}])` allowed. Both word lists are byte-identical to #1930's; no new vocabulary and no new list.
- A new suite runs the shipped jq through the real `gh --jq` against a loopback `python3` stub, requires both engines to agree, and carries controls that red on a planted lookbehind. The suite that guarded this program previously ran only under local jq (Oniguruma), which accepts lookaround — the reason a green battery proved nothing about the path that actually ships.

## Completed Issues

- Closes KEN-1081 - The gate's decline-reason regex uses lookaround that gh's RE2 engine rejects, so every PR with a Declined reply errors

## QA Metrics

Behavior preservation was measured independently by six harnesses, all comparing `origin/main`'s `reason_left` against this branch's through the real entry point. Zero divergence in every one:

| Source | Inputs | Result |
|---|---|---|
| dev | 18,827 (173 corpus + 18,654 generated) | byte-identical |
| reviewer-correctness | 173 corpus + 7,629 ASCII + 9,227 unicode-heavy + 1,500 multi-line | 0 diff lines |
| reviewer-arch | 173 corpus + 4,024 adversarial | 0 divergences |
| reviewer-quality | 173 corpus + 4,000 generated | 0 divergent outputs |
| reviewer-security | 110 adversarial + 2,237 generated | 0/2,347 in every pairing |
| reviewer-error | 173 corpus + ~10k adversarial | byte-identical |

Three of those proved their differ live by planting a word-list edit or dropping the pad, which reported 181, 429 and 11,908 divergent lines respectively. Cross-engine (local jq Oniguruma vs real `gh --jq` RE2) was run on the unicode, multi-line and 10k adversarial sets: 0 diff lines.

Coverage of the shipped program under RE2 was measured, not assumed: a lookbehind planted into each of the 14 regex literals in `t_threads_page_jq` in turn kills the suite 14/14, zero survivors.

Performance, measured on a 100-thread page built from the real corpus: under the engine that ships (gh RE2) the new program answers at p50 70 ms / p95 73 ms, of which ~52 ms is jq work. `origin/main`'s program does not compile under RE2 at all, so no RE2 baseline exists to regress against. Under local jq, which only the suites use, p50 goes 28 ms to 50 ms. Scaling is linear (~n^1.13), and the pathological 20-page worst case is ~76 s against the writer's 12-minute step budget.

## Test Plan

- `skills/review-gate/tests/predicate-re2-engine.test.sh` — 11 passed, 0 failed. Runs the shipped jq through real `gh --jq` against a loopback stub; refuses rather than skips when `gh`, `python3` or `jq` is missing. Controls: a planted lookbehind must red the RE2 leg while local jq stays green, a planted lookbehind in the untracked-claim test must red it, and a planted word-list edit must make the shipped comparison report a divergence.
- Swapping in `origin/main`'s pre-fix predicate reds that suite 3 passed / 5 failed, exit 1, with `invalid regular expression` on the RE2 leg.
- `skills/review-gate/tests/unreasoned-decline.test.sh` — 295 passed, 0 failed (294 on main; the extra is the new `reason_left` line in the pass sweep).
- Full review-gate shard 17/17, `review-predicate-selftest` 258 cases, `preflight` clean, `tools/guard` exit 0.
- Against PR #1928's head, the pre-fix predicate prints `invalid regular expression` then `could not read review threads`, exit 2; this branch prints `verdict=approved`, exit 0.

## Notes

Renders under `.agents/skills/review-gate/` land in the same commit as their sources and are byte-identical.

Left as discovered work, not fixed here: `\b` in the predicate's jq is ASCII-only under RE2 and Unicode-aware under local jq. It reaches `disposition`, `declined`, `tracking` and the sha/number strips, but moves no verdict on the corpus or on 9,227 unicode-heavy replies measured cross-engine — it needs an ASCII word butted directly against a non-ASCII letter. Latent, not live.
