### PR TITLE
test(KEN-1071): A needs-completion test races a 25 ms timer and reds on a loaded runner

### DIFF
--- a/pi-extensions/pi-agents-tmux/tests/needs-completion-cwd-snapshot.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/needs-completion-cwd-snapshot.test.ts
@@ -229,10 +229,7 @@ describe("needs_completion cwd snapshots", () => {
 				return new EventEmitter() as any;
 			}) as any);
 
-			const result = await Promise.race([
-				markTaskNeedsCompletion(runtimeRoot, "rust", "task-slow", { cwd, diagnostic: "missing completion" }),
-				new Promise<"timed-out">((resolve) => setTimeout(() => resolve("timed-out"), 25)),
-			]);
+			const result = await markTaskNeedsCompletion(runtimeRoot, "rust", "task-slow", { cwd, diagnostic: "missing completion" });
 			const persisted = (await readTaskRegistry(runtimeRoot))["task-slow"]!;
 
 			expect(result).not.toBe("timed-out");


### PR DESCRIPTION
## Summary

- Remove the 25 ms wall-clock race from the needs-completion test.
- Await `markTaskNeedsCompletion` directly and use Bun's test timeout as the hang bound.

## Completed Issues

- Closes KEN-1071 - A needs-completion test races a 25 ms timer and reds on a loaded runner

## QA Metrics

- Mutation killed 1/1: making `markTaskNeedsCompletion` await the never-settling git snapshot makes the test fail by timeout.
- Stability passed 10/10 at 64 threads.

## Test Plan

- `.agents/skills/preflight/scripts/preflight --base origin/main --repo /home/method/dev/.worktrees/kendex/ken-1071`
- `tools/guard`
