### PR TITLE
docs(KEN-1055): four review lenses learn what bots keep catching

### DIFF
--- a/.agents/skills/orch/workflows/review-pr-comments.md
+++ b/.agents/skills/orch/workflows/review-pr-comments.md
@@ -275,6 +275,8 @@ git -C "[WORKTREE_PATH]" log -1 --oneline
 
 Apply the fix-round A×B table in [`dev-fix.md` § 2](dev-fix.md), which is canonical — including exact-commit binding on accept, the bounded git re-read on `accept` with B failing, the report-only tail-reconciliation nudge on `wait` with B passing, and the never-accept `retry` row, which never re-runs the fix. On accept: applied items are marked for reply, items the agent skipped go to the skipped list with their reason, and blocked items become issue candidates in § 6.2.
 
+**Rewrite the PR body before pushing.** Nothing else regenerates the description after round one, so rebuild it from the final diff per [`submit-pr.md` § 2](submit-pr.md) step 3 and post it with `pr-edit-body`.
+
 **Batch per fully-reviewed head.** Push a fix round only after every configured reviewer has reported on the current head. A pass with nothing to push skips this command:
 
 ```bash

--- a/.agents/skills/orch/workflows/review-pr-comments.md
+++ b/.agents/skills/orch/workflows/review-pr-comments.md
@@ -275,13 +275,13 @@ git -C "[WORKTREE_PATH]" log -1 --oneline
 
 Apply the fix-round A×B table in [`dev-fix.md` § 2](dev-fix.md), which is canonical — including exact-commit binding on accept, the bounded git re-read on `accept` with B failing, the report-only tail-reconciliation nudge on `wait` with B passing, and the never-accept `retry` row, which never re-runs the fix. On accept: applied items are marked for reply, items the agent skipped go to the skipped list with their reason, and blocked items become issue candidates in § 6.2.
 
-**Rewrite the PR body before pushing.** Nothing else regenerates the description after round one, so rebuild it from the final diff per [`submit-pr.md` § 2](submit-pr.md) step 3 and post it with `pr-edit-body`; when § 6.2 files issues, post the body again so Created Issues names them.
-
 **Batch per fully-reviewed head.** Push a fix round only after every configured reviewer has reported on the current head. A pass with nothing to push skips this command:
 
 ```bash
 git -C "[WORKTREE_PATH]" push origin HEAD
 ```
+
+**A round ends with the description matching its head.** The PR body describes the commits actually on the PR head and names every issue § 6.2 filed this round; nothing else regenerates it after round one, so rebuild it per [`submit-pr.md` § 2](submit-pr.md) step 3 and post it with `pr-edit-body` until both hold.
 
 ### 6.2 Create Issues
 

--- a/.agents/skills/orch/workflows/review-pr-comments.md
+++ b/.agents/skills/orch/workflows/review-pr-comments.md
@@ -275,7 +275,7 @@ git -C "[WORKTREE_PATH]" log -1 --oneline
 
 Apply the fix-round A×B table in [`dev-fix.md` § 2](dev-fix.md), which is canonical — including exact-commit binding on accept, the bounded git re-read on `accept` with B failing, the report-only tail-reconciliation nudge on `wait` with B passing, and the never-accept `retry` row, which never re-runs the fix. On accept: applied items are marked for reply, items the agent skipped go to the skipped list with their reason, and blocked items become issue candidates in § 6.2.
 
-**Rewrite the PR body before pushing.** Nothing else regenerates the description after round one, so rebuild it from the final diff per [`submit-pr.md` § 2](submit-pr.md) step 3 and post it with `pr-edit-body`.
+**Rewrite the PR body before pushing.** Nothing else regenerates the description after round one, so rebuild it from the final diff per [`submit-pr.md` § 2](submit-pr.md) step 3 and post it with `pr-edit-body`; when § 6.2 files issues, post the body again so Created Issues names them.
 
 **Batch per fully-reviewed head.** Push a fix round only after every configured reviewer has reported on the current head. A pass with nothing to push skips this command:
 

--- a/.claude/agents/reviewer-correctness.md
+++ b/.claude/agents/reviewer-correctness.md
@@ -38,6 +38,7 @@ For each changed predicate, parser, or guard, mentally execute:
 - **Sibling consistency** — two code paths answering the same question with different logic.
 - **Surface enumeration** — when a change adds or edits a check, enumerate the surfaces it must cover (every extension, every directory, every syntactic form) and name each one it skips.
 - **Declarative formats** — a new manifest/grammar/config the code parses gets every field × every malformation (absent, empty, duplicated, extra, non-canonical, wrong type), never a sample; report what the parser silently accepts as one class.
+- **Git plumbing** — probe a consumer of git's machine-readable output with the whole enumeration it claims to handle: every status letter, `core.quotePath` escaping, `:(literal)` against a directory, the `0:` stage prefix, an `--amend` parent.
 - **Pre-steady-state** — behavior while detection is still pending, state is unseeded, or readiness was declared on selection rather than on answerability.
 - **Teardown symmetry** — for every install/enable/claim path, walk uninstall/disable/release under: another worktree still installed, the helper already missing, a partially applied prior run, and a foreign tool owning the same file.
 - **Staged vs worktree** — a `--staged` or index-reading mode reads its policy inputs (baseline, excludes, settings) from the index too, never from the worktree.

--- a/.claude/agents/reviewer-doc.md
+++ b/.claude/agents/reviewer-doc.md
@@ -27,6 +27,7 @@ The method is verification, not proofreading — **open the implementation behin
 - **Citations**: cited paths exist and are tracked; cited symbols and tests exist AND actually exercise what they are cited for; documented settings keys match consumed keys, both directions. (Preflight or a project doc checker may cover path existence deterministically — cite their output, spend your pass on what only reading code can verify.)
 - **Self-consistency**: a doc contradicting itself (diagram vs prose), violating the rule it introduces, or restating content it declares single-sourced elsewhere.
 - **Comments and prose**: changed comments or docs that contradict the code, narrate revision history or provenance, or claim more than the adjacent assertion enforces.
+- **Moved prose**: relocated help text, README, schema, and changelog prose is new prose — verify it sentence by sentence against the code it now describes, never against the file it moved from.
 - **Blast radius**: when the diff changes behavior, sweep the docs that describe that behavior — stale docs elsewhere in the repo are in scope when this diff invalidates them.
 
 ## Output

--- a/.claude/agents/reviewer-error.md
+++ b/.claude/agents/reviewer-error.md
@@ -30,6 +30,7 @@ Recurring shapes:
 
 - A validator/verifier that degrades to "no findings" or "not applicable" when its input, probe, or dependency fails — instead of failing loudly.
 - Unchecked effectful calls: `$(mktemp)`/`readlink`/`git` substitutions whose failure leaves an empty variable and a running script; pipelines whose failure is masked (no `pipefail`); discarded error returns.
+- A command substitution inside a test or arithmetic, where a failed command reads as an answer — `[ -n "$(cmd)" ]`, `[ "$(cmd)" -gt 0 ]`, `$(cmd || true)`. The exit status is checked separately or the site is a finding.
 - An async helper/service asked to start but neither confirmed running nor reported failed — the caller proceeds against a maybe-started dependency and a start failure surfaces nowhere.
 - Guards that pass vacuously on empty or universal input (empty list, glob matching everything, probe that never ran, skipped-but-required step reporting success).
 - One-directional validation: entries checked when present, orphaned/stale entries never checked.

--- a/.codex/agents/reviewer-correctness.toml
+++ b/.codex/agents/reviewer-correctness.toml
@@ -33,6 +33,7 @@ For each changed predicate, parser, or guard, mentally execute:
 - **Sibling consistency** — two code paths answering the same question with different logic.
 - **Surface enumeration** — when a change adds or edits a check, enumerate the surfaces it must cover (every extension, every directory, every syntactic form) and name each one it skips.
 - **Declarative formats** — a new manifest/grammar/config the code parses gets every field × every malformation (absent, empty, duplicated, extra, non-canonical, wrong type), never a sample; report what the parser silently accepts as one class.
+- **Git plumbing** — probe a consumer of git's machine-readable output with the whole enumeration it claims to handle: every status letter, `core.quotePath` escaping, `:(literal)` against a directory, the `0:` stage prefix, an `--amend` parent.
 - **Pre-steady-state** — behavior while detection is still pending, state is unseeded, or readiness was declared on selection rather than on answerability.
 - **Teardown symmetry** — for every install/enable/claim path, walk uninstall/disable/release under: another worktree still installed, the helper already missing, a partially applied prior run, and a foreign tool owning the same file.
 - **Staged vs worktree** — a `--staged` or index-reading mode reads its policy inputs (baseline, excludes, settings) from the index too, never from the worktree.

--- a/.codex/agents/reviewer-doc.toml
+++ b/.codex/agents/reviewer-doc.toml
@@ -22,6 +22,7 @@ The method is verification, not proofreading — **open the implementation behin
 - **Citations**: cited paths exist and are tracked; cited symbols and tests exist AND actually exercise what they are cited for; documented settings keys match consumed keys, both directions. (Preflight or a project doc checker may cover path existence deterministically — cite their output, spend your pass on what only reading code can verify.)
 - **Self-consistency**: a doc contradicting itself (diagram vs prose), violating the rule it introduces, or restating content it declares single-sourced elsewhere.
 - **Comments and prose**: changed comments or docs that contradict the code, narrate revision history or provenance, or claim more than the adjacent assertion enforces.
+- **Moved prose**: relocated help text, README, schema, and changelog prose is new prose — verify it sentence by sentence against the code it now describes, never against the file it moved from.
 - **Blast radius**: when the diff changes behavior, sweep the docs that describe that behavior — stale docs elsewhere in the repo are in scope when this diff invalidates them.
 
 ## Output

--- a/.codex/agents/reviewer-error.toml
+++ b/.codex/agents/reviewer-error.toml
@@ -25,6 +25,7 @@ Recurring shapes:
 
 - A validator/verifier that degrades to "no findings" or "not applicable" when its input, probe, or dependency fails — instead of failing loudly.
 - Unchecked effectful calls: `$(mktemp)`/`readlink`/`git` substitutions whose failure leaves an empty variable and a running script; pipelines whose failure is masked (no `pipefail`); discarded error returns.
+- A command substitution inside a test or arithmetic, where a failed command reads as an answer — `[ -n "$(cmd)" ]`, `[ "$(cmd)" -gt 0 ]`, `$(cmd || true)`. The exit status is checked separately or the site is a finding.
 - An async helper/service asked to start but neither confirmed running nor reported failed — the caller proceeds against a maybe-started dependency and a start failure surfaces nowhere.
 - Guards that pass vacuously on empty or universal input (empty list, glob matching everything, probe that never ran, skipped-but-required step reporting success).
 - One-directional validation: entries checked when present, orphaned/stale entries never checked.

--- a/.pi/agents/reviewer-correctness.md
+++ b/.pi/agents/reviewer-correctness.md
@@ -34,6 +34,7 @@ For each changed predicate, parser, or guard, mentally execute:
 - **Sibling consistency** — two code paths answering the same question with different logic.
 - **Surface enumeration** — when a change adds or edits a check, enumerate the surfaces it must cover (every extension, every directory, every syntactic form) and name each one it skips.
 - **Declarative formats** — a new manifest/grammar/config the code parses gets every field × every malformation (absent, empty, duplicated, extra, non-canonical, wrong type), never a sample; report what the parser silently accepts as one class.
+- **Git plumbing** — probe a consumer of git's machine-readable output with the whole enumeration it claims to handle: every status letter, `core.quotePath` escaping, `:(literal)` against a directory, the `0:` stage prefix, an `--amend` parent.
 - **Pre-steady-state** — behavior while detection is still pending, state is unseeded, or readiness was declared on selection rather than on answerability.
 - **Teardown symmetry** — for every install/enable/claim path, walk uninstall/disable/release under: another worktree still installed, the helper already missing, a partially applied prior run, and a foreign tool owning the same file.
 - **Staged vs worktree** — a `--staged` or index-reading mode reads its policy inputs (baseline, excludes, settings) from the index too, never from the worktree.

--- a/.pi/agents/reviewer-doc.md
+++ b/.pi/agents/reviewer-doc.md
@@ -23,6 +23,7 @@ The method is verification, not proofreading — **open the implementation behin
 - **Citations**: cited paths exist and are tracked; cited symbols and tests exist AND actually exercise what they are cited for; documented settings keys match consumed keys, both directions. (Preflight or a project doc checker may cover path existence deterministically — cite their output, spend your pass on what only reading code can verify.)
 - **Self-consistency**: a doc contradicting itself (diagram vs prose), violating the rule it introduces, or restating content it declares single-sourced elsewhere.
 - **Comments and prose**: changed comments or docs that contradict the code, narrate revision history or provenance, or claim more than the adjacent assertion enforces.
+- **Moved prose**: relocated help text, README, schema, and changelog prose is new prose — verify it sentence by sentence against the code it now describes, never against the file it moved from.
 - **Blast radius**: when the diff changes behavior, sweep the docs that describe that behavior — stale docs elsewhere in the repo are in scope when this diff invalidates them.
 
 ## Output

--- a/.pi/agents/reviewer-error.md
+++ b/.pi/agents/reviewer-error.md
@@ -26,6 +26,7 @@ Recurring shapes:
 
 - A validator/verifier that degrades to "no findings" or "not applicable" when its input, probe, or dependency fails — instead of failing loudly.
 - Unchecked effectful calls: `$(mktemp)`/`readlink`/`git` substitutions whose failure leaves an empty variable and a running script; pipelines whose failure is masked (no `pipefail`); discarded error returns.
+- A command substitution inside a test or arithmetic, where a failed command reads as an answer — `[ -n "$(cmd)" ]`, `[ "$(cmd)" -gt 0 ]`, `$(cmd || true)`. The exit status is checked separately or the site is a finding.
 - An async helper/service asked to start but neither confirmed running nor reported failed — the caller proceeds against a maybe-started dependency and a start failure surfaces nowhere.
 - Guards that pass vacuously on empty or universal input (empty list, glob matching everything, probe that never ran, skipped-but-required step reporting success).
 - One-directional validation: entries checked when present, orphaned/stale entries never checked.

--- a/agents/reviewer-correctness.md
+++ b/agents/reviewer-correctness.md
@@ -34,6 +34,7 @@ For each changed predicate, parser, or guard, mentally execute:
 - **Sibling consistency** — two code paths answering the same question with different logic.
 - **Surface enumeration** — when a change adds or edits a check, enumerate the surfaces it must cover (every extension, every directory, every syntactic form) and name each one it skips.
 - **Declarative formats** — a new manifest/grammar/config the code parses gets every field × every malformation (absent, empty, duplicated, extra, non-canonical, wrong type), never a sample; report what the parser silently accepts as one class.
+- **Git plumbing** — probe a consumer of git's machine-readable output with the whole enumeration it claims to handle: every status letter, `core.quotePath` escaping, `:(literal)` against a directory, the `0:` stage prefix, an `--amend` parent.
 - **Pre-steady-state** — behavior while detection is still pending, state is unseeded, or readiness was declared on selection rather than on answerability.
 - **Teardown symmetry** — for every install/enable/claim path, walk uninstall/disable/release under: another worktree still installed, the helper already missing, a partially applied prior run, and a foreign tool owning the same file.
 - **Staged vs worktree** — a `--staged` or index-reading mode reads its policy inputs (baseline, excludes, settings) from the index too, never from the worktree.

--- a/agents/reviewer-doc.md
+++ b/agents/reviewer-doc.md
@@ -23,6 +23,7 @@ The method is verification, not proofreading — **open the implementation behin
 - **Citations**: cited paths exist and are tracked; cited symbols and tests exist AND actually exercise what they are cited for; documented settings keys match consumed keys, both directions. (Preflight or a project doc checker may cover path existence deterministically — cite their output, spend your pass on what only reading code can verify.)
 - **Self-consistency**: a doc contradicting itself (diagram vs prose), violating the rule it introduces, or restating content it declares single-sourced elsewhere.
 - **Comments and prose**: changed comments or docs that contradict the code, narrate revision history or provenance, or claim more than the adjacent assertion enforces.
+- **Moved prose**: relocated help text, README, schema, and changelog prose is new prose — verify it sentence by sentence against the code it now describes, never against the file it moved from.
 - **Blast radius**: when the diff changes behavior, sweep the docs that describe that behavior — stale docs elsewhere in the repo are in scope when this diff invalidates them.
 
 ## Output

--- a/agents/reviewer-error.md
+++ b/agents/reviewer-error.md
@@ -26,6 +26,7 @@ Recurring shapes:
 
 - A validator/verifier that degrades to "no findings" or "not applicable" when its input, probe, or dependency fails — instead of failing loudly.
 - Unchecked effectful calls: `$(mktemp)`/`readlink`/`git` substitutions whose failure leaves an empty variable and a running script; pipelines whose failure is masked (no `pipefail`); discarded error returns.
+- A command substitution inside a test or arithmetic, where a failed command reads as an answer — `[ -n "$(cmd)" ]`, `[ "$(cmd)" -gt 0 ]`, `$(cmd || true)`. The exit status is checked separately or the site is a finding.
 - An async helper/service asked to start but neither confirmed running nor reported failed — the caller proceeds against a maybe-started dependency and a start failure surfaces nowhere.
 - Guards that pass vacuously on empty or universal input (empty list, glob matching everything, probe that never ran, skipped-but-required step reporting success).
 - One-directional validation: entries checked when present, orphaned/stale entries never checked.

--- a/skills/orch/workflows/review-pr-comments.md
+++ b/skills/orch/workflows/review-pr-comments.md
@@ -275,6 +275,8 @@ git -C "[WORKTREE_PATH]" log -1 --oneline
 
 Apply the fix-round A×B table in [`dev-fix.md` § 2](dev-fix.md), which is canonical — including exact-commit binding on accept, the bounded git re-read on `accept` with B failing, the report-only tail-reconciliation nudge on `wait` with B passing, and the never-accept `retry` row, which never re-runs the fix. On accept: applied items are marked for reply, items the agent skipped go to the skipped list with their reason, and blocked items become issue candidates in § 6.2.
 
+**Rewrite the PR body before pushing.** Nothing else regenerates the description after round one, so rebuild it from the final diff per [`submit-pr.md` § 2](submit-pr.md) step 3 and post it with `pr-edit-body`.
+
 **Batch per fully-reviewed head.** Push a fix round only after every configured reviewer has reported on the current head. A pass with nothing to push skips this command:
 
 ```bash

--- a/skills/orch/workflows/review-pr-comments.md
+++ b/skills/orch/workflows/review-pr-comments.md
@@ -275,13 +275,13 @@ git -C "[WORKTREE_PATH]" log -1 --oneline
 
 Apply the fix-round A×B table in [`dev-fix.md` § 2](dev-fix.md), which is canonical — including exact-commit binding on accept, the bounded git re-read on `accept` with B failing, the report-only tail-reconciliation nudge on `wait` with B passing, and the never-accept `retry` row, which never re-runs the fix. On accept: applied items are marked for reply, items the agent skipped go to the skipped list with their reason, and blocked items become issue candidates in § 6.2.
 
-**Rewrite the PR body before pushing.** Nothing else regenerates the description after round one, so rebuild it from the final diff per [`submit-pr.md` § 2](submit-pr.md) step 3 and post it with `pr-edit-body`; when § 6.2 files issues, post the body again so Created Issues names them.
-
 **Batch per fully-reviewed head.** Push a fix round only after every configured reviewer has reported on the current head. A pass with nothing to push skips this command:
 
 ```bash
 git -C "[WORKTREE_PATH]" push origin HEAD
 ```
+
+**A round ends with the description matching its head.** The PR body describes the commits actually on the PR head and names every issue § 6.2 filed this round; nothing else regenerates it after round one, so rebuild it per [`submit-pr.md` § 2](submit-pr.md) step 3 and post it with `pr-edit-body` until both hold.
 
 ### 6.2 Create Issues
 

--- a/skills/orch/workflows/review-pr-comments.md
+++ b/skills/orch/workflows/review-pr-comments.md
@@ -275,7 +275,7 @@ git -C "[WORKTREE_PATH]" log -1 --oneline
 
 Apply the fix-round A×B table in [`dev-fix.md` § 2](dev-fix.md), which is canonical — including exact-commit binding on accept, the bounded git re-read on `accept` with B failing, the report-only tail-reconciliation nudge on `wait` with B passing, and the never-accept `retry` row, which never re-runs the fix. On accept: applied items are marked for reply, items the agent skipped go to the skipped list with their reason, and blocked items become issue candidates in § 6.2.
 
-**Rewrite the PR body before pushing.** Nothing else regenerates the description after round one, so rebuild it from the final diff per [`submit-pr.md` § 2](submit-pr.md) step 3 and post it with `pr-edit-body`.
+**Rewrite the PR body before pushing.** Nothing else regenerates the description after round one, so rebuild it from the final diff per [`submit-pr.md` § 2](submit-pr.md) step 3 and post it with `pr-edit-body`; when § 6.2 files issues, post the body again so Created Issues names them.
 
 **Batch per fully-reviewed head.** Push a fix round only after every configured reviewer has reported on the current head. A pass with nothing to push skips this command:
 


### PR DESCRIPTION
## Summary

- `reviewer-doc` gets a line on moved prose. Relocated help text, README, schema, and changelog prose is new prose, verified sentence by sentence against the code it now describes rather than against the file it moved from.
- `reviewer-error` gets a line on command substitution inside a test or arithmetic, where a failed command reads as an answer. `[ -n "$(cmd)" ]`, `[ "$(cmd)" -gt 0 ]`, `$(cmd || true)`. The exit status is checked separately or the site is a finding.
- `reviewer-correctness` gets a line on git plumbing. A consumer of git's machine-readable output is probed with the whole enumeration it claims to handle: every status letter, `core.quotePath` escaping, `:(literal)` against a directory, the `0:` stage prefix, an `--amend` parent.
- `review-pr-comments.md` § 6.1 now states a condition rather than a step: a triage round ends with the PR description matching the commits on the head and naming every issue § 6.2 filed. Nothing regenerated it after round one.

Renders land in the same commit for every harness `kendex-local.toml` enables: `.claude/agents/`, `.codex/agents/`, `.pi/agents/`, and `.agents/skills/`.

## Context

From the owner-directed bots-vs-local analysis of 2026-09-01, covering 81 PRs and 592 bot threads, where 445 findings were fixed after a local review had already passed. These four classes account for the bulk of that gap. 43 of the 76 doc-contradicts-code threads were three wholesale prose moves. 15 threads were command substitution read as an answer. 13 were git-plumbing enumeration gaps. 7 were descriptions still describing round one. Each is a judgment call rather than a mechanical check, so each gets one line in the lens that owns it.

## Completed Issues

- Closes KEN-1055 - Four review-lens lines for the classes bots fix after local review passed

## QA Metrics

Docs-only diff, no logic, so the reviewer panel skipped by the trivial-diff rule. `preflight` reports clean. `tools/guard` is green, including 1144 UI tests. Source and render bodies match line for line apart from the renderer's injected header.

Three review rounds. The first two shared one root cause: the § 6.1 line pinned the body rebuild to a position between steps, so one round found it on the wrong side of § 6.2 and the next found it on the wrong side of the push. Patching the position again would have left the next step to be found, so the line was closed structurally in `c26d5a049` and now states the condition a round must end in. The third round was a real miss, not the same cause: the lens lines had landed only in the Claude renders while `kendex-local.toml` enables all three reviewers for Codex and Pi, whose renders are tracked files. Fixed in `c19a1a0d4`, with every copy of each line byte-identical to its source. This description is itself a rebuild under the new rule.
