### PR TITLE
fix(KEN-1072): a reviewer's controls live under its own mktemp -d

### DIFF
--- a/.agents/skills/reviewer/SKILL.md
+++ b/.agents/skills/reviewer/SKILL.md
@@ -54,6 +54,8 @@ Findings are a JSON artifact per [`schemas/review-finding.md`](./schemas/review-
 .agents/skills/orch/scripts/review-artifact-check [WORKTREE_PATH] [AGENT] 0
 ```
 
+Write a control's files under a `mktemp -d` of your own, the way [`scripts/mutation-stability`](./scripts/mutation-stability) does: stubs, fixtures, mutants, logs. The scratchpad root is shared with the parallel panel, where a sibling overwrites a fixed name mid-review.
+
 Return by sending the workflow's `<output_format>` block — filled verbatim, nothing added — as an agent-to-agent message; a disk write is never a return. Shell commands follow orch SKILL.md § Harness-Safe Shell.
 
 ## Re-Review Rounds

--- a/skills/reviewer/SKILL.md
+++ b/skills/reviewer/SKILL.md
@@ -54,6 +54,8 @@ Findings are a JSON artifact per [`schemas/review-finding.md`](./schemas/review-
 .agents/skills/orch/scripts/review-artifact-check [WORKTREE_PATH] [AGENT] 0
 ```
 
+Write a control's files under a `mktemp -d` of your own, the way [`scripts/mutation-stability`](./scripts/mutation-stability) does: stubs, fixtures, mutants, logs. The scratchpad root is shared with the parallel panel, where a sibling overwrites a fixed name mid-review.
+
 Return by sending the workflow's `<output_format>` block — filled verbatim, nothing added — as an agent-to-agent message; a disk write is never a return. Shell commands follow orch SKILL.md § Harness-Safe Shell.
 
 ## Re-Review Rounds


### PR DESCRIPTION
## Summary

- The reviewer skill's output contract now says where a control's files go: under a `mktemp -d` of the reviewer's own, never at a fixed name in the scratchpad root the parallel panel shares.
- It names `scripts/mutation-stability` as the pattern, which already does this.
- No new script. The `.agents` render moves in the same commit.

## Context

A reviewer on the ken-958 lane found its stub files replaced mid-review by a sibling reviewer and had to redo every control in a fresh `mktemp -d`. It caught the collision; a reviewer that did not would have reported corrupted evidence as measurement.

## Completed Issues

- Closes KEN-1072 - A reviewer's control files live under its own mktemp -d, never at a fixed name in the shared scratchpad

## Test Plan

- `preflight --base origin/main` clean.
- The render under `.agents/skills/reviewer/SKILL.md` carries the same line as the source, checked by `tools/guard` at commit.
