### PR TITLE
refactor(KEN-1065): a delegation carries the check, not its reasons

### DIFF
--- a/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -495,24 +495,20 @@ else
 fi
 
 # b.12, b.16, b.17 and b.21 — four forms the canonical sentence replaced,
-# each of which stays red. A remedy resting on a bare `cd`: a harness that
-# spawns a fresh shell per tool call drops it and the agent resumes work in
-# the wrong tree believing it recovered. A remedy resting on an absolute
-# path: `tools/guard` re-derives the repo from the process cwd on its own
-# first line, so the path it is invoked by never reaches that decision. A
-# bare `pwd`: it prints the logical path, and the delegated path is physical
-# (`git rev-parse --show-toplevel`), so it halts a correct delegate whose
-# shell entered the checkout through a symlink. And the long form, this
-# sentence with the rationale for it appended — the rationale is not
-# something the agent runs, it cost kilobytes inside every delegation, and it
-# lives in this file's header instead. Equality is what keeps all four out;
-# each is named on its own so a form that stops being caught says which.
+# each named on its own so a form that stops being caught says which. A `cd`
+# remedy: a harness spawning a fresh shell per tool call drops it, and the
+# agent resumes work in the wrong tree believing it recovered. An
+# absolute-path remedy: `tools/guard` re-derives the repo from the process
+# cwd on its own first line, so the path it is invoked by never reaches that
+# decision. A bare `pwd`: it prints the logical path while the delegated path
+# is physical, so it halts a correct delegate reached through a symlink. The
+# long form: this sentence with the rationale appended, which the agent does
+# not run and this file's header holds instead. Equality keeps all four out.
 RETIRED_CD='Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.'
 RETIRED_ABS='Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]. Any other path — give every later command an absolute path under [WORKTREE_PATH].'
 RETIRED_LOGICAL="${CHECK//pwd -P/pwd}"
 RETIRED_LONG='Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane'"'"'s worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.'
-for retired in "cd remedy:$RETIRED_CD" "absolute-path remedy:$RETIRED_ABS" \
-               "logical pwd:$RETIRED_LOGICAL" "long form:$RETIRED_LONG"; do
+for retired in "cd remedy:$RETIRED_CD" "absolute-path remedy:$RETIRED_ABS" "logical pwd:$RETIRED_LOGICAL" "long form:$RETIRED_LONG"; do
   if reports "$(scan_worktree_precondition "$(probe retired "Worktree: [WORKTREE_PATH]\n${retired#*:}")")" "$UNCANON"; then
     pass "lint flags a check written as the retired ${retired%%:*}"
   else
@@ -750,15 +746,14 @@ else
   fail "lint false-flagged the canonical fill line"
 fi
 
-# e.3 and e.9 — two fill lines the canonical sentence replaced. One resolves
-# the delegated path to the current directory: `pwd -P` prints an absolute
-# physical path and can never equal a relative one, so it halts every correct
-# delegate. The other is the long form, the same command with the reason for
-# it appended — that reason belongs to rule 3 above, not to every delegating
-# workflow. Each is named on its own so a form that stops being caught says
-# which.
-RETIRED_RELFILL='Fill `Worktree:` and `Worktree Check:` with the current directory.'
-RETIRED_LONGFILL='Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.'
+# e.3 and e.9 — two fill lines this change retired, in the bytes the file
+# carried before it: a resolution to the current directory, the defect rule 3
+# was written for, and the long form, the command with the reason for it
+# appended (that reason belongs to rule 3 above, not to every delegating
+# workflow). Neither opens with the current $CANON_FILL_OPEN, so each draws
+# rule 3 alone and f.2 is what exercises rule 4. Each is named on its own.
+RETIRED_RELFILL='Fill `Worktree:` and its `Worktree Check:` with the current directory. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.'
+RETIRED_LONGFILL='Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.'
 RETIRED_FILL="$TMP_ROOT/probe-retired-fill.md"
 for fill in "current directory:$RETIRED_RELFILL" "long form:$RETIRED_LONGFILL"; do
   printf '%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' "${fill#*:}" "$CHECK" > "$RETIRED_FILL"
@@ -851,6 +846,11 @@ case "$CANON_FILL" in
     ;;
   *) fail "the opening clause is not a prefix of \$CANON_FILL — rule 4 matches nothing" ;;
 esac
+
+# f.4 — the sentences stay short enough to ship inside a delegation. Every
+# site is byte-equal to them, so a rewrite here reaches all 42 blocks in one
+# commit with nothing else red; the budget is today's length rounded up.
+if [ "${#CANON}" -le 160 ] && [ "${#CANON_FILL}" -le 100 ]; then pass "the canonical sentences fit the delegation-line budget"; else fail "a canonical sentence outgrew its budget: check ${#CANON}/160, fill ${#CANON_FILL}/100"; fi
 
 CONFLICT_FILL='Fill `Worktree:` and `Worktree Check:` with whichever directory this workflow is running in.'
 

--- a/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/.agents/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -178,11 +178,11 @@ fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 # The canonical check line, with @TOKEN@ standing in for the block's own
 # placeholder name. This is the single source of truth for the sentence;
 # the shipped docs must match it character for character.
-CANON='Worktree Check: `pwd -P` before any repo-relative command. It must print [@TOKEN@]; your shell can start in another lane'"'"'s worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.'
+CANON='Worktree Check: `pwd -P` before any repo-relative command; it must print [@TOKEN@]. On any other path, stop and report where the shell started.'
 
 # The canonical fill line, verbatim. It carries no per-block token: `[DIR]`
 # is literal in every doc, so the whole line is compared as it stands.
-CANON_FILL='Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.'
+CANON_FILL='Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.'
 
 # The fill line's opening clause: the part that names the two fields being
 # filled, before it says where the value comes from. A line opening with it
@@ -190,7 +190,7 @@ CANON_FILL='Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-
 # contradicting instruction. Held as its own literal and asserted a PROPER
 # prefix of $CANON_FILL by f.1 — rewording the sentence without rewording
 # this reds there, rather than leaving rule 4 matching nothing in silence.
-CANON_FILL_OPEN='Fill `Worktree:` and its `Worktree Check:`'
+CANON_FILL_OPEN='Fill `Worktree:` and `Worktree Check:`'
 
 # scan_worktree_precondition <file>
 # Emits one "file:line: ..." line per defect, per rules 1, 2 and 5 above.
@@ -494,38 +494,31 @@ else
   fail "lint MISSED an unbackticked pwd"
 fi
 
-# b.12 — the recovery clause must not rest on a bare `cd`. A harness that
-# spawns a fresh shell per tool call drops it, and the agent resumes
-# repo-relative work in the wrong tree believing it recovered.
-STALE_CD='Worktree: [WORKTREE_PATH]\nWorktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.'
-if reports "$(scan_worktree_precondition "$(probe stalecd "$STALE_CD")")" "$UNCANON"; then
-  pass "lint flags a check whose remedy is a bare cd"
-else
-  fail "lint MISSED a remedy resting on a cd that may not persist"
-fi
-
-# b.16 — nor on an absolute path. `tools/guard` re-derives the repo from
-# the process cwd on its own first line, so the path it is invoked by never
-# reaches that decision and a wrong-tree shell still judges the wrong lane.
-# The canonical sentence halts instead, and any remedy written in its place
-# reds.
-ABS_REMEDY='Worktree: [WORKTREE_PATH]\nWorktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]. Any other path — give every later command an absolute path under [WORKTREE_PATH].'
-if reports "$(scan_worktree_precondition "$(probe absremedy "$ABS_REMEDY")")" "$UNCANON"; then
-  pass "lint flags a remedy resting on an absolute path"
-else
-  fail "lint MISSED a remedy an absolute path cannot deliver"
-fi
-
-# b.17 — the pre-fix sentence, identical but for a bare `pwd`. The delegated
-# path is physical (`git rev-parse --show-toplevel`), so a logical `pwd` halts
-# a correct delegate whose shell reached the checkout through a symlink. The
-# logical form must not come back unnoticed.
-LOGICAL="${CHECK//pwd -P/pwd}"
-if reports "$(scan_worktree_precondition "$(probe logical "Worktree: [WORKTREE_PATH]\n$LOGICAL")")" "$UNCANON"; then
-  pass "lint flags a check measuring the cwd with a bare pwd"
-else
-  fail "lint MISSED a check comparing a logical pwd against a physical path"
-fi
+# b.12, b.16, b.17 and b.21 — four forms the canonical sentence replaced,
+# each of which stays red. A remedy resting on a bare `cd`: a harness that
+# spawns a fresh shell per tool call drops it and the agent resumes work in
+# the wrong tree believing it recovered. A remedy resting on an absolute
+# path: `tools/guard` re-derives the repo from the process cwd on its own
+# first line, so the path it is invoked by never reaches that decision. A
+# bare `pwd`: it prints the logical path, and the delegated path is physical
+# (`git rev-parse --show-toplevel`), so it halts a correct delegate whose
+# shell entered the checkout through a symlink. And the long form, this
+# sentence with the rationale for it appended — the rationale is not
+# something the agent runs, it cost kilobytes inside every delegation, and it
+# lives in this file's header instead. Equality is what keeps all four out;
+# each is named on its own so a form that stops being caught says which.
+RETIRED_CD='Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.'
+RETIRED_ABS='Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]. Any other path — give every later command an absolute path under [WORKTREE_PATH].'
+RETIRED_LOGICAL="${CHECK//pwd -P/pwd}"
+RETIRED_LONG='Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane'"'"'s worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.'
+for retired in "cd remedy:$RETIRED_CD" "absolute-path remedy:$RETIRED_ABS" \
+               "logical pwd:$RETIRED_LOGICAL" "long form:$RETIRED_LONG"; do
+  if reports "$(scan_worktree_precondition "$(probe retired "Worktree: [WORKTREE_PATH]\n${retired#*:}")")" "$UNCANON"; then
+    pass "lint flags a check written as the retired ${retired%%:*}"
+  else
+    fail "lint MISSED a check written as the retired ${retired%%:*}"
+  fi
+done
 
 # b.13 — RULE 2. A block with no Worktree:/Worktree Check: pair at all IS
 # flagged, whatever it hands over: a placeholder the caller fills with a
@@ -757,17 +750,24 @@ else
   fail "lint false-flagged the canonical fill line"
 fi
 
-# e.3 — the shipped defect, spelled out: the fill line resolves the delegated
-# path to the current directory. `pwd -P` prints an absolute physical path
-# and can never equal a relative one, so this halts every correct delegate.
-RELFILL='Fill `Worktree:` and its `Worktree Check:` with the current directory. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.'
-RELATIVE="$TMP_ROOT/probe-relative-fill.md"
-printf '%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' "$RELFILL" "$CHECK" > "$RELATIVE"
-if reports "$(scan_worktree_fill "$RELATIVE")" "$NOFILL"; then
-  pass "lint flags a fill line resolving the delegated path to the current directory"
-else
-  fail "lint MISSED a delegated path resolved to the current directory"
-fi
+# e.3 and e.9 — two fill lines the canonical sentence replaced. One resolves
+# the delegated path to the current directory: `pwd -P` prints an absolute
+# physical path and can never equal a relative one, so it halts every correct
+# delegate. The other is the long form, the same command with the reason for
+# it appended — that reason belongs to rule 3 above, not to every delegating
+# workflow. Each is named on its own so a form that stops being caught says
+# which.
+RETIRED_RELFILL='Fill `Worktree:` and `Worktree Check:` with the current directory.'
+RETIRED_LONGFILL='Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.'
+RETIRED_FILL="$TMP_ROOT/probe-retired-fill.md"
+for fill in "current directory:$RETIRED_RELFILL" "long form:$RETIRED_LONGFILL"; do
+  printf '%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' "${fill#*:}" "$CHECK" > "$RETIRED_FILL"
+  if reports "$(scan_worktree_fill "$RETIRED_FILL")" "$NOFILL"; then
+    pass "lint flags a fill line written as the retired ${fill%%:*}"
+  else
+    fail "lint MISSED a fill line written as the retired ${fill%%:*}"
+  fi
+done
 
 # e.4 — the fill line inside the block does not count: it has to be the
 # doc's instruction to the filler, not a line the delegate reads as content.
@@ -852,7 +852,7 @@ case "$CANON_FILL" in
   *) fail "the opening clause is not a prefix of \$CANON_FILL — rule 4 matches nothing" ;;
 esac
 
-CONFLICT_FILL='Fill `Worktree:` and its `Worktree Check:` with whichever directory this workflow is running in.'
+CONFLICT_FILL='Fill `Worktree:` and `Worktree Check:` with whichever directory this workflow is running in.'
 
 # f.2 — the canonical line, then a byte-different line in the same shape.
 # The block is preceded by the canonical sentence, so rule 3 is satisfied

--- a/.agents/skills/orch/workflows/ci-fix.md
+++ b/.agents/skills/orch/workflows/ci-fix.md
@@ -64,7 +64,7 @@ Stamp the round as separate tool calls immediately before delegating, and arm th
 
 `worktree-claim` exit 75 aborts the delegation (another session holds this worktree; stderr names the holder); exit 1 stops the workflow and is reported. Its printed token is the delegation's `Worktree Lease:` line.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 
 This agent pushes its fix directly and writes **no** dev-return artifact; the round-mode check for this token reports `ok == false`, which is expected. Accept this round on the agent's return message plus the pushed fix commit; on an absent return follow the escalation ladder.
 
@@ -78,7 +78,7 @@ Error output:
 [truncated error logs]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 Worktree Lease: [WORKTREE_LEASE]
 
 1. Verify possession before changing anything: `.agents/skills/orch/scripts/worktree-claim --worktree [WORKTREE_PATH] --issue [ISSUE_ID] --expect-gen [WORKTREE_LEASE]`. Any non-zero exit ends the round here — change nothing and report its stderr verbatim.
@@ -106,7 +106,7 @@ Cross-reference those commits with the original PRs to identify which file faile
 
 For an integration issue, create a worktree from the draft branch (`worktree create [ISSUE_ID] "[DRAFT_BRANCH]" --pr [DRAFT_PR_NUMBER]`) and delegate analysis.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the worktree just created from the draft branch.
 
 <delegation_format>
@@ -114,7 +114,7 @@ Merge queue CI failure — integration issue across stacked PRs.
 
 Draft PR: #[PR_NUMBER]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 Stack: [PRs in the stack with their domains]
 
 Error output:

--- a/.agents/skills/orch/workflows/dev-fix.md
+++ b/.agents/skills/orch/workflows/dev-fix.md
@@ -12,7 +12,7 @@ Delegate fix items to a specialist dev agent. Standalone (user-initiated) or man
 
 **Standalone init** (`lifecycle: "self"`). Use the argument as `ISSUE_ID`, else `git-context issue-from-branch .`. Apply [Worktree Scope](../SKILL.md#workflow-execution) and resolve `WT_PATH` as `git-context repo-root "[DIR]"` (inside a worktree `[DIR]` is `.`; from the main repo, `worktree path [ISSUE_ID]`, asking before creating).
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 
 ## 1. Build Fix Items
 
@@ -112,7 +112,7 @@ Cancel ends the workflow; a selection goes to § 2.
    Source: [SOURCE]
    Issue: [ISSUE_ID]
    Worktree: [WORKTREE_PATH]
-   Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+   Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
    Worktree Lease: [WORKTREE_LEASE]
    Round ID: [DEV_ROUND_ID]
    Artifact Key: [ISSUE_ID]

--- a/.agents/skills/orch/workflows/dev-start.md
+++ b/.agents/skills/orch/workflows/dev-start.md
@@ -29,7 +29,7 @@ Apply the Ancestor gate ([SKILL.md § Coordination](../SKILL.md#coordination)). 
 
 Apply [Worktree Scope](../SKILL.md#workflow-execution) and resolve `WT_PATH` as `git-context repo-root "[DIR]"`. Inside a worktree `[DIR]` is `.`; from the main repo it is `worktree path [ISSUE_ID]` when that exists, and ask the user before creating one when it does not.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 
 Initialize state unless it exists:
 
@@ -88,7 +88,7 @@ Follow workflow: .agents/skills/dev/workflows/dev-implement.md
 
 Issue: [ISSUE_ID]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]
@@ -103,7 +103,7 @@ Group pending sub-issues by `agent:[TYPE]` label and order them per [SKILL.md §
 
 Between groups, read each completed sub-issue's comments for a `Handoff Notes` section and combine them into the next delegation. Re-run all four § 2 stamps immediately before each group's delegation.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 
 <delegation_format>
 Follow workflow: .agents/skills/dev/workflows/dev-implement.md
@@ -115,7 +115,7 @@ Sub-Issues:
 ↳ [SUB_ISSUE_3]: [TITLE] | blocked by: [SUB_ISSUE_2]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]

--- a/.agents/skills/orch/workflows/review-codebase.md
+++ b/.agents/skills/orch/workflows/review-codebase.md
@@ -15,7 +15,7 @@ Ad-hoc whole-codebase reviewer fanout. No PR, no issue, no diff, no fix delegati
 
 Not a git worktree → report `review-codebase requires a git worktree` and **END**. Otherwise use the output as `WT_PATH` and `mkdir -p "$WT_PATH/tmp"`.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the `[PATH_OR_PWD]` § 1 resolves `WT_PATH` from.
 
 ## 2. Delegate
@@ -34,7 +34,7 @@ Resolve the reviewer mode per [SKILL.md § Agent Lifecycle](../SKILL.md#agent-li
 Follow workflow: .agents/skills/reviewer/workflows/codebase-review.md
 
 Worktree: [WT_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WT_PATH]. On any other path, stop and report where the shell started.
 Scope: Whole codebase. Inspect tracked, non-generated project code, plus the tests, configs, and docs relevant to your review domain. Do not sample or restrict to changed files. No PR, no issue, no diff.
 Exclusions: generated artifacts, dependency and vendor directories, build outputs, binary assets, harness mirrors, and lockfiles unless your domain specifically requires them.
 </delegation_format>

--- a/.agents/skills/orch/workflows/review-pr-comments.md
+++ b/.agents/skills/orch/workflows/review-pr-comments.md
@@ -46,7 +46,7 @@ gh api user -q .login
 
 **Issue context.** `issue_id` from the caller, else `git-context issue-from-branch .`; ask the user if nothing matches. Resolve `WT_PATH` as `git-context repo-root "[DIR]"`, `[DIR]` being `worktree exists`/`worktree path` when they match and `.` otherwise.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 
 Then gather decisions:
 
@@ -76,7 +76,7 @@ Analyze these PR review comments for your domain.
 PR: #[PR_NUMBER] - [TITLE]
 Parent Issue: [ISSUE_ID]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 
 Decision context (read before classifying — do NOT suggest changes that contradict these):
 [For each verified decision: "[DECISION_ID]: [ONE_LINE_SUMMARY] — [DECISION_FILE_PATH]"]
@@ -235,7 +235,7 @@ When the list is non-empty, write `[WORKTREE_PATH]/tmp/dev-round-adds-[DEV_ROUND
 
 ⚠ Fill placeholders only ([Format Tags Are Literal](../SKILL.md#format-tags-are-literal)). `Recommendation:` is the technical fix; the agent owns its own process.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 
 <delegation_format>
 Follow workflow: .agents/skills/dev/workflows/dev-fix.md
@@ -244,7 +244,7 @@ Source: pr-comments
 Issue: [ISSUE_ID]
 PR: #[PR_NUMBER]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]

--- a/.agents/skills/orch/workflows/review-pr.md
+++ b/.agents/skills/orch/workflows/review-pr.md
@@ -12,7 +12,7 @@ Pre-submission review: reviewer fan-out, bounded fix rounds, QA checks, and the 
 
 **With a PR number**: `github.sh pr-issue [PR_NUMBER] --format=text` gives `ISSUE`. Apply [Worktree Scope](../SKILL.md#workflow-execution); ask before `worktree create $ISSUE --pr [PR_NUMBER]`. With no argument, `WT_PATH` is `git-context repo-root .`.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the checkout the paragraph above resolves `WT_PATH` from.
 
 **Standalone init** (`lifecycle: "self"`): resolve `ISSUE_ID` with `git-context issue-from-branch .`, then `workflow-state exists --json [ISSUE_ID]`; when absent, initialize with `git-context branch [WT_PATH]` and `workflow-state init`, and resolve `TRACKER`. On this path § 5 derives its QA signals from the diff scan and judgment — there is no dev artifact.
@@ -133,7 +133,7 @@ Delegate to every reviewer in the active set in parallel. When `EXTERNAL_REVIEW_
 Follow workflow: .agents/skills/reviewer/workflows/review.md
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 Branch: [BRANCH]
 Artifact: [ARTIFACT_PATH]
 
@@ -366,7 +366,7 @@ Drop a signal when the triggering code is trivial or test-only; never drop one f
 
 Map each signal to its agent — `needs-safety-audit` → `reviewer-safety`, `needs-perf-test` → `reviewer-perf`, `needs-review` → `reviewer-correctness`; a project may override the mapping in its instructions. For each, delegate and wait.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the checkout the top of this workflow resolves `WT_PATH` from.
 
 <delegation_format>
@@ -376,7 +376,7 @@ Issue: [ISSUE_ID]
 Tracker: [TRACKER] [OWNER/REPO]
 Branch: [BRANCH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 Trigger: [QA signal]
 
 Dev summary:

--- a/.agents/skills/orch/workflows/review.md
+++ b/.agents/skills/orch/workflows/review.md
@@ -19,7 +19,7 @@ On-demand review of local changes: review, present findings, and offer to fix th
 
 Use the outputs as `BRANCH`, `ISSUE_ID` (empty means skip every workflow-state step), and `BASE_BRANCH`; `WT_PATH` is `git-context repo-root .`.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the `.` the line above resolves `WT_PATH` from.
 
 | Argument | `DIFF_RANGE` |
@@ -63,7 +63,7 @@ A failed check omits the path and carries `- decision index lookup failed for [D
 Follow workflow: .agents/skills/reviewer/workflows/review.md
 
 Worktree: [WT_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WT_PATH]. On any other path, stop and report where the shell started.
 Branch: [BRANCH]
 Diff-range: [DIFF_RANGE]
 

--- a/.agents/skills/project-management/workflows/audit-issues.md
+++ b/.agents/skills/project-management/workflows/audit-issues.md
@@ -85,7 +85,7 @@ No sync step. Load project taxonomy the same way as Linear mode; with no declare
 
 Spawn a one-shot `[TPM]` sub-agent (not a teammate — no re-delegation).
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the current repo root; project-order mode takes no input file.
 
 <delegation_format>
@@ -93,7 +93,7 @@ Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
 
 Arguments: --project-order
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 </delegation_format>
 
 ### 2.2 Materialize and Present
@@ -146,7 +146,7 @@ With `TARGET` set, use it. Otherwise take the first `session-status.projects` en
 
 Spawn a one-shot `[TPM]` sub-agent (not a teammate).
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the input file's `worktree` when the invocation supplied one, the current repo root otherwise.
 
 <delegation_format>
@@ -154,7 +154,7 @@ Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
 
 Arguments: --project "[PROJECT_NAME]" | --team | --issues [FILE_PATH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 Tracker: [TRACKER] [OWNER/REPO]
 </delegation_format>
 

--- a/.agents/skills/project-management/workflows/cycle-plan.md
+++ b/.agents/skills/project-management/workflows/cycle-plan.md
@@ -12,13 +12,13 @@ This workflow mutates project state, so it reconciles before anything reads the 
 
 1. **Delegate** to a one-shot `[TPM]` sub-agent.
 
-   Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+   Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
    `[DIR]` is the caller's own checkout, main checkout included.
 
    <delegation_format>
    Follow workflow: .agents/skills/project-management/workflows/tpm-cycle-plan.md
    Worktree: [WORKTREE_PATH]
-   Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+   Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
    </delegation_format>
 
 2. **Materialize the artifact.** The agent returns a `File:` hint and fenced JSON. Write the inline JSON to that path under the current repo root and read it; if inline JSON is missing and the path is not already readable, halt and request a rerun with inline JSON.

--- a/.agents/skills/project-management/workflows/research-complete.md
+++ b/.agents/skills/project-management/workflows/research-complete.md
@@ -53,7 +53,7 @@ With several references, convert to a bulleted list under one `**Research**:` he
 
 Run exactly one flow, unless it escalates. Both flows fill the delegation the same way.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 ### 5.1 Targeted
@@ -64,7 +64,7 @@ Delegate to the domain agent:
 Analyze the impact of these research findings on your domain.
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 
 Read: [RESEARCH_DOCS_PATH]/[ISSUE_ID]/findings.md
 
@@ -88,13 +88,13 @@ List a technical change only when it changes what a user or operator experiences
 
 Delegate the same analysis to every affected domain agent in parallel, minus the cross-domain and scope questions. Then delegate the synthesis to the architecture review agent.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 
 <delegation_format>
 Synthesize the domain reports into a cross-cutting impact analysis.
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 
 Read: [RESEARCH_DOCS_PATH]/[ISSUE_ID]/findings.md
 

--- a/.agents/skills/project-management/workflows/research-issue.md
+++ b/.agents/skills/project-management/workflows/research-issue.md
@@ -82,14 +82,14 @@ Map each domain label to its agent type (project-configurable) and delegate in p
 
 Re-delegate to `[CONSULTATION_AGENT_NAME]` when the caller supplied one, omitting the reading block below. Otherwise start a fresh agent with the full block.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>
 Research: [RESEARCH_ISSUE_ID] - [TOPIC]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 
 Blocked issue: [BLOCKED_ISSUE_ID]
 Read it: `.agents/skills/linear/scripts/linear.sh cache issues get [BLOCKED_ISSUE_ID]`
@@ -156,14 +156,14 @@ Run `[RESEARCH_DOCS_PATH]/[RESEARCH_ISSUE_ID]/run.sh`, or use Pi `web_research` 
 
 Otherwise delegate to `researcher` (or `[RESEARCHER_AGENT_NAME]`).
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>
 Research issue: [RESEARCH_ISSUE_ID] - [TOPIC]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 
 Read:
 - [RESEARCH_DOCS_PATH]/[RESEARCH_ISSUE_ID]/prompt.txt

--- a/.agents/skills/project-management/workflows/roadmap-plan.md
+++ b/.agents/skills/project-management/workflows/roadmap-plan.md
@@ -61,7 +61,7 @@ With no match, ask the user:
 
 Otherwise, match `FEATURE` keywords and component paths to domain agents (project-configurable) to get `RELEVANT_AGENTS[]`, then delegate to each in parallel.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>
@@ -69,7 +69,7 @@ Feature: [FEATURE]
 Research: [RESEARCH_PATH or "None"]
 Spec: [SPEC_PATH or "None"] — when set, its approach and workstreams are binding: do not re-litigate them; cut its phases into PR-sized issues
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 
 List implementation issues for your domain only. Reply as a table with these columns:
 
@@ -95,7 +95,7 @@ Build `PROPOSED_ISSUES[]` per [roadmap-plan-input.md](../schemas/roadmap-plan-in
 
 Write the input file per [roadmap-plan-input.md](../schemas/roadmap-plan-input.md) to `tmp/roadmap-input-YYYYMMDD-HHMMSS.json`, including `origin_issue`, `planner_handoff`, and `spec_path` (each null when absent; `spec_path` is set exactly when the artifact in hand — the `@[path]` input or the § 1 disk match — classified as a SPEC). Delegate to a one-shot `[TPM]` sub-agent.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>
@@ -103,7 +103,7 @@ Follow workflow: .agents/skills/project-management/workflows/tpm-roadmap-plan.md
 
 Arguments: --input [INPUT_FILE_PATH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 </delegation_format>
 
 Materialize the returned artifact the same way as audit-issues § 4.2. Read `hierarchy_recommendation`, `cross_project_findings`, `architecture_gaps[]`, `organized_issues[]`, and `project_placement`.
@@ -114,7 +114,7 @@ Materialize the returned artifact the same way as audit-issues § 4.2. Read `hie
 
 Delegate to the architecture review agent.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>
@@ -123,7 +123,7 @@ Review proposed roadmap for: [FEATURE]
 Proposed project: [project_placement.project_name]
 Spec: [SPEC_PATH or "None"] — when set, the spec's phases bound the roadmap: report anything beyond them as out-of-spec, with why it is needed
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 
 Organized issues:
 [organized_issues]

--- a/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -495,24 +495,20 @@ else
 fi
 
 # b.12, b.16, b.17 and b.21 — four forms the canonical sentence replaced,
-# each of which stays red. A remedy resting on a bare `cd`: a harness that
-# spawns a fresh shell per tool call drops it and the agent resumes work in
-# the wrong tree believing it recovered. A remedy resting on an absolute
-# path: `tools/guard` re-derives the repo from the process cwd on its own
-# first line, so the path it is invoked by never reaches that decision. A
-# bare `pwd`: it prints the logical path, and the delegated path is physical
-# (`git rev-parse --show-toplevel`), so it halts a correct delegate whose
-# shell entered the checkout through a symlink. And the long form, this
-# sentence with the rationale for it appended — the rationale is not
-# something the agent runs, it cost kilobytes inside every delegation, and it
-# lives in this file's header instead. Equality is what keeps all four out;
-# each is named on its own so a form that stops being caught says which.
+# each named on its own so a form that stops being caught says which. A `cd`
+# remedy: a harness spawning a fresh shell per tool call drops it, and the
+# agent resumes work in the wrong tree believing it recovered. An
+# absolute-path remedy: `tools/guard` re-derives the repo from the process
+# cwd on its own first line, so the path it is invoked by never reaches that
+# decision. A bare `pwd`: it prints the logical path while the delegated path
+# is physical, so it halts a correct delegate reached through a symlink. The
+# long form: this sentence with the rationale appended, which the agent does
+# not run and this file's header holds instead. Equality keeps all four out.
 RETIRED_CD='Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.'
 RETIRED_ABS='Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]. Any other path — give every later command an absolute path under [WORKTREE_PATH].'
 RETIRED_LOGICAL="${CHECK//pwd -P/pwd}"
 RETIRED_LONG='Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane'"'"'s worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.'
-for retired in "cd remedy:$RETIRED_CD" "absolute-path remedy:$RETIRED_ABS" \
-               "logical pwd:$RETIRED_LOGICAL" "long form:$RETIRED_LONG"; do
+for retired in "cd remedy:$RETIRED_CD" "absolute-path remedy:$RETIRED_ABS" "logical pwd:$RETIRED_LOGICAL" "long form:$RETIRED_LONG"; do
   if reports "$(scan_worktree_precondition "$(probe retired "Worktree: [WORKTREE_PATH]\n${retired#*:}")")" "$UNCANON"; then
     pass "lint flags a check written as the retired ${retired%%:*}"
   else
@@ -750,15 +746,14 @@ else
   fail "lint false-flagged the canonical fill line"
 fi
 
-# e.3 and e.9 — two fill lines the canonical sentence replaced. One resolves
-# the delegated path to the current directory: `pwd -P` prints an absolute
-# physical path and can never equal a relative one, so it halts every correct
-# delegate. The other is the long form, the same command with the reason for
-# it appended — that reason belongs to rule 3 above, not to every delegating
-# workflow. Each is named on its own so a form that stops being caught says
-# which.
-RETIRED_RELFILL='Fill `Worktree:` and `Worktree Check:` with the current directory.'
-RETIRED_LONGFILL='Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.'
+# e.3 and e.9 — two fill lines this change retired, in the bytes the file
+# carried before it: a resolution to the current directory, the defect rule 3
+# was written for, and the long form, the command with the reason for it
+# appended (that reason belongs to rule 3 above, not to every delegating
+# workflow). Neither opens with the current $CANON_FILL_OPEN, so each draws
+# rule 3 alone and f.2 is what exercises rule 4. Each is named on its own.
+RETIRED_RELFILL='Fill `Worktree:` and its `Worktree Check:` with the current directory. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.'
+RETIRED_LONGFILL='Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.'
 RETIRED_FILL="$TMP_ROOT/probe-retired-fill.md"
 for fill in "current directory:$RETIRED_RELFILL" "long form:$RETIRED_LONGFILL"; do
   printf '%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' "${fill#*:}" "$CHECK" > "$RETIRED_FILL"
@@ -851,6 +846,11 @@ case "$CANON_FILL" in
     ;;
   *) fail "the opening clause is not a prefix of \$CANON_FILL — rule 4 matches nothing" ;;
 esac
+
+# f.4 — the sentences stay short enough to ship inside a delegation. Every
+# site is byte-equal to them, so a rewrite here reaches all 42 blocks in one
+# commit with nothing else red; the budget is today's length rounded up.
+if [ "${#CANON}" -le 160 ] && [ "${#CANON_FILL}" -le 100 ]; then pass "the canonical sentences fit the delegation-line budget"; else fail "a canonical sentence outgrew its budget: check ${#CANON}/160, fill ${#CANON_FILL}/100"; fi
 
 CONFLICT_FILL='Fill `Worktree:` and `Worktree Check:` with whichever directory this workflow is running in.'
 

--- a/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
+++ b/skills/orch/tests/worktree-cwd-precondition-lint.test.sh
@@ -178,11 +178,11 @@ fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 # The canonical check line, with @TOKEN@ standing in for the block's own
 # placeholder name. This is the single source of truth for the sentence;
 # the shipped docs must match it character for character.
-CANON='Worktree Check: `pwd -P` before any repo-relative command. It must print [@TOKEN@]; your shell can start in another lane'"'"'s worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.'
+CANON='Worktree Check: `pwd -P` before any repo-relative command; it must print [@TOKEN@]. On any other path, stop and report where the shell started.'
 
 # The canonical fill line, verbatim. It carries no per-block token: `[DIR]`
 # is literal in every doc, so the whole line is compared as it stands.
-CANON_FILL='Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.'
+CANON_FILL='Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.'
 
 # The fill line's opening clause: the part that names the two fields being
 # filled, before it says where the value comes from. A line opening with it
@@ -190,7 +190,7 @@ CANON_FILL='Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-
 # contradicting instruction. Held as its own literal and asserted a PROPER
 # prefix of $CANON_FILL by f.1 — rewording the sentence without rewording
 # this reds there, rather than leaving rule 4 matching nothing in silence.
-CANON_FILL_OPEN='Fill `Worktree:` and its `Worktree Check:`'
+CANON_FILL_OPEN='Fill `Worktree:` and `Worktree Check:`'
 
 # scan_worktree_precondition <file>
 # Emits one "file:line: ..." line per defect, per rules 1, 2 and 5 above.
@@ -494,38 +494,31 @@ else
   fail "lint MISSED an unbackticked pwd"
 fi
 
-# b.12 — the recovery clause must not rest on a bare `cd`. A harness that
-# spawns a fresh shell per tool call drops it, and the agent resumes
-# repo-relative work in the wrong tree believing it recovered.
-STALE_CD='Worktree: [WORKTREE_PATH]\nWorktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.'
-if reports "$(scan_worktree_precondition "$(probe stalecd "$STALE_CD")")" "$UNCANON"; then
-  pass "lint flags a check whose remedy is a bare cd"
-else
-  fail "lint MISSED a remedy resting on a cd that may not persist"
-fi
-
-# b.16 — nor on an absolute path. `tools/guard` re-derives the repo from
-# the process cwd on its own first line, so the path it is invoked by never
-# reaches that decision and a wrong-tree shell still judges the wrong lane.
-# The canonical sentence halts instead, and any remedy written in its place
-# reds.
-ABS_REMEDY='Worktree: [WORKTREE_PATH]\nWorktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]. Any other path — give every later command an absolute path under [WORKTREE_PATH].'
-if reports "$(scan_worktree_precondition "$(probe absremedy "$ABS_REMEDY")")" "$UNCANON"; then
-  pass "lint flags a remedy resting on an absolute path"
-else
-  fail "lint MISSED a remedy an absolute path cannot deliver"
-fi
-
-# b.17 — the pre-fix sentence, identical but for a bare `pwd`. The delegated
-# path is physical (`git rev-parse --show-toplevel`), so a logical `pwd` halts
-# a correct delegate whose shell reached the checkout through a symlink. The
-# logical form must not come back unnoticed.
-LOGICAL="${CHECK//pwd -P/pwd}"
-if reports "$(scan_worktree_precondition "$(probe logical "Worktree: [WORKTREE_PATH]\n$LOGICAL")")" "$UNCANON"; then
-  pass "lint flags a check measuring the cwd with a bare pwd"
-else
-  fail "lint MISSED a check comparing a logical pwd against a physical path"
-fi
+# b.12, b.16, b.17 and b.21 — four forms the canonical sentence replaced,
+# each of which stays red. A remedy resting on a bare `cd`: a harness that
+# spawns a fresh shell per tool call drops it and the agent resumes work in
+# the wrong tree believing it recovered. A remedy resting on an absolute
+# path: `tools/guard` re-derives the repo from the process cwd on its own
+# first line, so the path it is invoked by never reaches that decision. A
+# bare `pwd`: it prints the logical path, and the delegated path is physical
+# (`git rev-parse --show-toplevel`), so it halts a correct delegate whose
+# shell entered the checkout through a symlink. And the long form, this
+# sentence with the rationale for it appended — the rationale is not
+# something the agent runs, it cost kilobytes inside every delegation, and it
+# lives in this file's header instead. Equality is what keeps all four out;
+# each is named on its own so a form that stops being caught says which.
+RETIRED_CD='Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]. Any other path — `cd "[WORKTREE_PATH]"`, re-run `pwd`, and report where it started.'
+RETIRED_ABS='Worktree Check: `pwd` before any repo-relative command. It must print [WORKTREE_PATH]. Any other path — give every later command an absolute path under [WORKTREE_PATH].'
+RETIRED_LOGICAL="${CHECK//pwd -P/pwd}"
+RETIRED_LONG='Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane'"'"'s worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.'
+for retired in "cd remedy:$RETIRED_CD" "absolute-path remedy:$RETIRED_ABS" \
+               "logical pwd:$RETIRED_LOGICAL" "long form:$RETIRED_LONG"; do
+  if reports "$(scan_worktree_precondition "$(probe retired "Worktree: [WORKTREE_PATH]\n${retired#*:}")")" "$UNCANON"; then
+    pass "lint flags a check written as the retired ${retired%%:*}"
+  else
+    fail "lint MISSED a check written as the retired ${retired%%:*}"
+  fi
+done
 
 # b.13 — RULE 2. A block with no Worktree:/Worktree Check: pair at all IS
 # flagged, whatever it hands over: a placeholder the caller fills with a
@@ -757,17 +750,24 @@ else
   fail "lint false-flagged the canonical fill line"
 fi
 
-# e.3 — the shipped defect, spelled out: the fill line resolves the delegated
-# path to the current directory. `pwd -P` prints an absolute physical path
-# and can never equal a relative one, so this halts every correct delegate.
-RELFILL='Fill `Worktree:` and its `Worktree Check:` with the current directory. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.'
-RELATIVE="$TMP_ROOT/probe-relative-fill.md"
-printf '%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' "$RELFILL" "$CHECK" > "$RELATIVE"
-if reports "$(scan_worktree_fill "$RELATIVE")" "$NOFILL"; then
-  pass "lint flags a fill line resolving the delegated path to the current directory"
-else
-  fail "lint MISSED a delegated path resolved to the current directory"
-fi
+# e.3 and e.9 — two fill lines the canonical sentence replaced. One resolves
+# the delegated path to the current directory: `pwd -P` prints an absolute
+# physical path and can never equal a relative one, so it halts every correct
+# delegate. The other is the long form, the same command with the reason for
+# it appended — that reason belongs to rule 3 above, not to every delegating
+# workflow. Each is named on its own so a form that stops being caught says
+# which.
+RETIRED_RELFILL='Fill `Worktree:` and `Worktree Check:` with the current directory.'
+RETIRED_LONGFILL='Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.'
+RETIRED_FILL="$TMP_ROOT/probe-retired-fill.md"
+for fill in "current directory:$RETIRED_RELFILL" "long form:$RETIRED_LONGFILL"; do
+  printf '%s\n\n<delegation_format>\nWorktree: [WORKTREE_PATH]\n%s\n</delegation_format>\n' "${fill#*:}" "$CHECK" > "$RETIRED_FILL"
+  if reports "$(scan_worktree_fill "$RETIRED_FILL")" "$NOFILL"; then
+    pass "lint flags a fill line written as the retired ${fill%%:*}"
+  else
+    fail "lint MISSED a fill line written as the retired ${fill%%:*}"
+  fi
+done
 
 # e.4 — the fill line inside the block does not count: it has to be the
 # doc's instruction to the filler, not a line the delegate reads as content.
@@ -852,7 +852,7 @@ case "$CANON_FILL" in
   *) fail "the opening clause is not a prefix of \$CANON_FILL — rule 4 matches nothing" ;;
 esac
 
-CONFLICT_FILL='Fill `Worktree:` and its `Worktree Check:` with whichever directory this workflow is running in.'
+CONFLICT_FILL='Fill `Worktree:` and `Worktree Check:` with whichever directory this workflow is running in.'
 
 # f.2 — the canonical line, then a byte-different line in the same shape.
 # The block is preceded by the canonical sentence, so rule 3 is satisfied

--- a/skills/orch/workflows/ci-fix.md
+++ b/skills/orch/workflows/ci-fix.md
@@ -64,7 +64,7 @@ Stamp the round as separate tool calls immediately before delegating, and arm th
 
 `worktree-claim` exit 75 aborts the delegation (another session holds this worktree; stderr names the holder); exit 1 stops the workflow and is reported. Its printed token is the delegation's `Worktree Lease:` line.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 
 This agent pushes its fix directly and writes **no** dev-return artifact; the round-mode check for this token reports `ok == false`, which is expected. Accept this round on the agent's return message plus the pushed fix commit; on an absent return follow the escalation ladder.
 
@@ -78,7 +78,7 @@ Error output:
 [truncated error logs]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 Worktree Lease: [WORKTREE_LEASE]
 
 1. Verify possession before changing anything: `.agents/skills/orch/scripts/worktree-claim --worktree [WORKTREE_PATH] --issue [ISSUE_ID] --expect-gen [WORKTREE_LEASE]`. Any non-zero exit ends the round here — change nothing and report its stderr verbatim.
@@ -106,7 +106,7 @@ Cross-reference those commits with the original PRs to identify which file faile
 
 For an integration issue, create a worktree from the draft branch (`worktree create [ISSUE_ID] "[DRAFT_BRANCH]" --pr [DRAFT_PR_NUMBER]`) and delegate analysis.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the worktree just created from the draft branch.
 
 <delegation_format>
@@ -114,7 +114,7 @@ Merge queue CI failure — integration issue across stacked PRs.
 
 Draft PR: #[PR_NUMBER]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 Stack: [PRs in the stack with their domains]
 
 Error output:

--- a/skills/orch/workflows/dev-fix.md
+++ b/skills/orch/workflows/dev-fix.md
@@ -12,7 +12,7 @@ Delegate fix items to a specialist dev agent. Standalone (user-initiated) or man
 
 **Standalone init** (`lifecycle: "self"`). Use the argument as `ISSUE_ID`, else `git-context issue-from-branch .`. Apply [Worktree Scope](../SKILL.md#workflow-execution) and resolve `WT_PATH` as `git-context repo-root "[DIR]"` (inside a worktree `[DIR]` is `.`; from the main repo, `worktree path [ISSUE_ID]`, asking before creating).
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 
 ## 1. Build Fix Items
 
@@ -112,7 +112,7 @@ Cancel ends the workflow; a selection goes to § 2.
    Source: [SOURCE]
    Issue: [ISSUE_ID]
    Worktree: [WORKTREE_PATH]
-   Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+   Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
    Worktree Lease: [WORKTREE_LEASE]
    Round ID: [DEV_ROUND_ID]
    Artifact Key: [ISSUE_ID]

--- a/skills/orch/workflows/dev-start.md
+++ b/skills/orch/workflows/dev-start.md
@@ -29,7 +29,7 @@ Apply the Ancestor gate ([SKILL.md § Coordination](../SKILL.md#coordination)). 
 
 Apply [Worktree Scope](../SKILL.md#workflow-execution) and resolve `WT_PATH` as `git-context repo-root "[DIR]"`. Inside a worktree `[DIR]` is `.`; from the main repo it is `worktree path [ISSUE_ID]` when that exists, and ask the user before creating one when it does not.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 
 Initialize state unless it exists:
 
@@ -88,7 +88,7 @@ Follow workflow: .agents/skills/dev/workflows/dev-implement.md
 
 Issue: [ISSUE_ID]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]
@@ -103,7 +103,7 @@ Group pending sub-issues by `agent:[TYPE]` label and order them per [SKILL.md §
 
 Between groups, read each completed sub-issue's comments for a `Handoff Notes` section and combine them into the next delegation. Re-run all four § 2 stamps immediately before each group's delegation.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 
 <delegation_format>
 Follow workflow: .agents/skills/dev/workflows/dev-implement.md
@@ -115,7 +115,7 @@ Sub-Issues:
 ↳ [SUB_ISSUE_3]: [TITLE] | blocked by: [SUB_ISSUE_2]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]

--- a/skills/orch/workflows/review-codebase.md
+++ b/skills/orch/workflows/review-codebase.md
@@ -15,7 +15,7 @@ Ad-hoc whole-codebase reviewer fanout. No PR, no issue, no diff, no fix delegati
 
 Not a git worktree → report `review-codebase requires a git worktree` and **END**. Otherwise use the output as `WT_PATH` and `mkdir -p "$WT_PATH/tmp"`.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the `[PATH_OR_PWD]` § 1 resolves `WT_PATH` from.
 
 ## 2. Delegate
@@ -34,7 +34,7 @@ Resolve the reviewer mode per [SKILL.md § Agent Lifecycle](../SKILL.md#agent-li
 Follow workflow: .agents/skills/reviewer/workflows/codebase-review.md
 
 Worktree: [WT_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WT_PATH]. On any other path, stop and report where the shell started.
 Scope: Whole codebase. Inspect tracked, non-generated project code, plus the tests, configs, and docs relevant to your review domain. Do not sample or restrict to changed files. No PR, no issue, no diff.
 Exclusions: generated artifacts, dependency and vendor directories, build outputs, binary assets, harness mirrors, and lockfiles unless your domain specifically requires them.
 </delegation_format>

--- a/skills/orch/workflows/review-pr-comments.md
+++ b/skills/orch/workflows/review-pr-comments.md
@@ -46,7 +46,7 @@ gh api user -q .login
 
 **Issue context.** `issue_id` from the caller, else `git-context issue-from-branch .`; ask the user if nothing matches. Resolve `WT_PATH` as `git-context repo-root "[DIR]"`, `[DIR]` being `worktree exists`/`worktree path` when they match and `.` otherwise.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 
 Then gather decisions:
 
@@ -76,7 +76,7 @@ Analyze these PR review comments for your domain.
 PR: #[PR_NUMBER] - [TITLE]
 Parent Issue: [ISSUE_ID]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 
 Decision context (read before classifying — do NOT suggest changes that contradict these):
 [For each verified decision: "[DECISION_ID]: [ONE_LINE_SUMMARY] — [DECISION_FILE_PATH]"]
@@ -235,7 +235,7 @@ When the list is non-empty, write `[WORKTREE_PATH]/tmp/dev-round-adds-[DEV_ROUND
 
 ⚠ Fill placeholders only ([Format Tags Are Literal](../SKILL.md#format-tags-are-literal)). `Recommendation:` is the technical fix; the agent owns its own process.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 
 <delegation_format>
 Follow workflow: .agents/skills/dev/workflows/dev-fix.md
@@ -244,7 +244,7 @@ Source: pr-comments
 Issue: [ISSUE_ID]
 PR: #[PR_NUMBER]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 Worktree Lease: [WORKTREE_LEASE]
 Round ID: [DEV_ROUND_ID]
 Artifact Key: [ISSUE_ID]

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -12,7 +12,7 @@ Pre-submission review: reviewer fan-out, bounded fix rounds, QA checks, and the 
 
 **With a PR number**: `github.sh pr-issue [PR_NUMBER] --format=text` gives `ISSUE`. Apply [Worktree Scope](../SKILL.md#workflow-execution); ask before `worktree create $ISSUE --pr [PR_NUMBER]`. With no argument, `WT_PATH` is `git-context repo-root .`.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the checkout the paragraph above resolves `WT_PATH` from.
 
 **Standalone init** (`lifecycle: "self"`): resolve `ISSUE_ID` with `git-context issue-from-branch .`, then `workflow-state exists --json [ISSUE_ID]`; when absent, initialize with `git-context branch [WT_PATH]` and `workflow-state init`, and resolve `TRACKER`. On this path § 5 derives its QA signals from the diff scan and judgment — there is no dev artifact.
@@ -133,7 +133,7 @@ Delegate to every reviewer in the active set in parallel. When `EXTERNAL_REVIEW_
 Follow workflow: .agents/skills/reviewer/workflows/review.md
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 Branch: [BRANCH]
 Artifact: [ARTIFACT_PATH]
 
@@ -366,7 +366,7 @@ Drop a signal when the triggering code is trivial or test-only; never drop one f
 
 Map each signal to its agent — `needs-safety-audit` → `reviewer-safety`, `needs-perf-test` → `reviewer-perf`, `needs-review` → `reviewer-correctness`; a project may override the mapping in its instructions. For each, delegate and wait.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the checkout the top of this workflow resolves `WT_PATH` from.
 
 <delegation_format>
@@ -376,7 +376,7 @@ Issue: [ISSUE_ID]
 Tracker: [TRACKER] [OWNER/REPO]
 Branch: [BRANCH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 Trigger: [QA signal]
 
 Dev summary:

--- a/skills/orch/workflows/review.md
+++ b/skills/orch/workflows/review.md
@@ -19,7 +19,7 @@ On-demand review of local changes: review, present findings, and offer to fix th
 
 Use the outputs as `BRANCH`, `ISSUE_ID` (empty means skip every workflow-state step), and `BASE_BRANCH`; `WT_PATH` is `git-context repo-root .`.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the `.` the line above resolves `WT_PATH` from.
 
 | Argument | `DIFF_RANGE` |
@@ -63,7 +63,7 @@ A failed check omits the path and carries `- decision index lookup failed for [D
 Follow workflow: .agents/skills/reviewer/workflows/review.md
 
 Worktree: [WT_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WT_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WT_PATH]. On any other path, stop and report where the shell started.
 Branch: [BRANCH]
 Diff-range: [DIFF_RANGE]
 

--- a/skills/project-management/workflows/audit-issues.md
+++ b/skills/project-management/workflows/audit-issues.md
@@ -85,7 +85,7 @@ No sync step. Load project taxonomy the same way as Linear mode; with no declare
 
 Spawn a one-shot `[TPM]` sub-agent (not a teammate — no re-delegation).
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the current repo root; project-order mode takes no input file.
 
 <delegation_format>
@@ -93,7 +93,7 @@ Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
 
 Arguments: --project-order
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 </delegation_format>
 
 ### 2.2 Materialize and Present
@@ -146,7 +146,7 @@ With `TARGET` set, use it. Otherwise take the first `session-status.projects` en
 
 Spawn a one-shot `[TPM]` sub-agent (not a teammate).
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the input file's `worktree` when the invocation supplied one, the current repo root otherwise.
 
 <delegation_format>
@@ -154,7 +154,7 @@ Follow workflow: .agents/skills/project-management/workflows/tpm-audit.md
 
 Arguments: --project "[PROJECT_NAME]" | --team | --issues [FILE_PATH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 Tracker: [TRACKER] [OWNER/REPO]
 </delegation_format>
 

--- a/skills/project-management/workflows/cycle-plan.md
+++ b/skills/project-management/workflows/cycle-plan.md
@@ -12,13 +12,13 @@ This workflow mutates project state, so it reconciles before anything reads the 
 
 1. **Delegate** to a one-shot `[TPM]` sub-agent.
 
-   Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+   Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
    `[DIR]` is the caller's own checkout, main checkout included.
 
    <delegation_format>
    Follow workflow: .agents/skills/project-management/workflows/tpm-cycle-plan.md
    Worktree: [WORKTREE_PATH]
-   Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+   Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
    </delegation_format>
 
 2. **Materialize the artifact.** The agent returns a `File:` hint and fenced JSON. Write the inline JSON to that path under the current repo root and read it; if inline JSON is missing and the path is not already readable, halt and request a rerun with inline JSON.

--- a/skills/project-management/workflows/research-complete.md
+++ b/skills/project-management/workflows/research-complete.md
@@ -53,7 +53,7 @@ With several references, convert to a bulleted list under one `**Research**:` he
 
 Run exactly one flow, unless it escalates. Both flows fill the delegation the same way.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 ### 5.1 Targeted
@@ -64,7 +64,7 @@ Delegate to the domain agent:
 Analyze the impact of these research findings on your domain.
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 
 Read: [RESEARCH_DOCS_PATH]/[ISSUE_ID]/findings.md
 
@@ -88,13 +88,13 @@ List a technical change only when it changes what a user or operator experiences
 
 Delegate the same analysis to every affected domain agent in parallel, minus the cross-domain and scope questions. Then delegate the synthesis to the architecture review agent.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 
 <delegation_format>
 Synthesize the domain reports into a cross-cutting impact analysis.
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 
 Read: [RESEARCH_DOCS_PATH]/[ISSUE_ID]/findings.md
 

--- a/skills/project-management/workflows/research-issue.md
+++ b/skills/project-management/workflows/research-issue.md
@@ -82,14 +82,14 @@ Map each domain label to its agent type (project-configurable) and delegate in p
 
 Re-delegate to `[CONSULTATION_AGENT_NAME]` when the caller supplied one, omitting the reading block below. Otherwise start a fresh agent with the full block.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>
 Research: [RESEARCH_ISSUE_ID] - [TOPIC]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 
 Blocked issue: [BLOCKED_ISSUE_ID]
 Read it: `.agents/skills/linear/scripts/linear.sh cache issues get [BLOCKED_ISSUE_ID]`
@@ -156,14 +156,14 @@ Run `[RESEARCH_DOCS_PATH]/[RESEARCH_ISSUE_ID]/run.sh`, or use Pi `web_research` 
 
 Otherwise delegate to `researcher` (or `[RESEARCHER_AGENT_NAME]`).
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>
 Research issue: [RESEARCH_ISSUE_ID] - [TOPIC]
 
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 
 Read:
 - [RESEARCH_DOCS_PATH]/[RESEARCH_ISSUE_ID]/prompt.txt

--- a/skills/project-management/workflows/roadmap-plan.md
+++ b/skills/project-management/workflows/roadmap-plan.md
@@ -61,7 +61,7 @@ With no match, ask the user:
 
 Otherwise, match `FEATURE` keywords and component paths to domain agents (project-configurable) to get `RELEVANT_AGENTS[]`, then delegate to each in parallel.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>
@@ -69,7 +69,7 @@ Feature: [FEATURE]
 Research: [RESEARCH_PATH or "None"]
 Spec: [SPEC_PATH or "None"] — when set, its approach and workstreams are binding: do not re-litigate them; cut its phases into PR-sized issues
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 
 List implementation issues for your domain only. Reply as a table with these columns:
 
@@ -95,7 +95,7 @@ Build `PROPOSED_ISSUES[]` per [roadmap-plan-input.md](../schemas/roadmap-plan-in
 
 Write the input file per [roadmap-plan-input.md](../schemas/roadmap-plan-input.md) to `tmp/roadmap-input-YYYYMMDD-HHMMSS.json`, including `origin_issue`, `planner_handoff`, and `spec_path` (each null when absent; `spec_path` is set exactly when the artifact in hand — the `@[path]` input or the § 1 disk match — classified as a SPEC). Delegate to a one-shot `[TPM]` sub-agent.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>
@@ -103,7 +103,7 @@ Follow workflow: .agents/skills/project-management/workflows/tpm-roadmap-plan.md
 
 Arguments: --input [INPUT_FILE_PATH]
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 </delegation_format>
 
 Materialize the returned artifact the same way as audit-issues § 4.2. Read `hierarchy_recommendation`, `cross_project_findings`, `architecture_gaps[]`, `organized_issues[]`, and `project_placement`.
@@ -114,7 +114,7 @@ Materialize the returned artifact the same way as audit-issues § 4.2. Read `hie
 
 Delegate to the architecture review agent.
 
-Fill `Worktree:` and its `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`. The delegate compares that value against `pwd -P`, so a relative or symlinked path halts a correct checkout.
+Fill `Worktree:` and `Worktree Check:` from `git -C "[DIR]" rev-parse --show-toplevel`.
 `[DIR]` is the caller's own checkout, main checkout included.
 
 <delegation_format>
@@ -123,7 +123,7 @@ Review proposed roadmap for: [FEATURE]
 Proposed project: [project_placement.project_name]
 Spec: [SPEC_PATH or "None"] — when set, the spec's phases bound the roadmap: report anything beyond them as out-of-spec, with why it is needed
 Worktree: [WORKTREE_PATH]
-Worktree Check: `pwd -P` before any repo-relative command. It must print [WORKTREE_PATH]; your shell can start in another lane's worktree, and `git status` or `tools/guard` resolves the repo from the process cwd, so an absolute path does not redirect it. On any other path, stop and report where the shell started; do not attempt recovery.
+Worktree Check: `pwd -P` before any repo-relative command; it must print [WORKTREE_PATH]. On any other path, stop and report where the shell started.
 
 Organized issues:
 [organized_issues]


### PR DESCRIPTION
## Summary

- The two canon strings a delegation carries now hold the instruction alone. The check line goes from 339 characters to 149, the fill line from 200 to 87. Every site changed in one commit, because the lint requires byte equality.
- The reasons did not move anywhere new. They already sat in the header of `skills/orch/tests/worktree-cwd-precondition-lint.test.sh`, which maintainers read and delegates do not.
- A new assertion, `f.4`, holds the two sentences to a length budget, so the brevity reds if a later edit grows them back rather than drifting through.

## Completed Issues

- Closes KEN-1065 - Delegation canon strings carry the instruction, not 8 KB of rationale

## Test Plan

- `bash skills/orch/tests/worktree-cwd-precondition-lint.test.sh` runs 49 pass / 0 fail from both the source copy and the `.agents` render.
- Done-when proven directly: planting the long form back into one shipped workflow reds the lint, and restoring it turns the suite green again.
- Every changed `skills/` file is byte-identical to its `.agents/skills/` render.
- `tools/guard` exit 0, preflight clean.
- Reviewers planted mutants rather than trusting the green run: relaxing rule 1 from equality to a prefix match, relaxing rule 3 the same way, and reverting a shipped doc to the retired sentence. All three killed, each naming only its own assertion.
