### PR TITLE
fix(KEN-1084): no window opens at a directory that is gone

### DIFF
--- a/.agents/skills/growth-guards/DEVELOPMENT.md
+++ b/.agents/skills/growth-guards/DEVELOPMENT.md
@@ -83,11 +83,14 @@ Two rules hold, and a probe that drops either is worse than no probe:
   answered by EOF the moment it is written and the session returns instead of
   waiting for a person who is not there. What it returns differs by platform,
   which is why a case asserts on the destination.
-- **A time cap.** After `CAP` seconds the session's process group is killed,
-  the spawner's after it. `script` puts the session in a group of its own, so
-  killing the spawner alone leaves the stuck child behind. A probe that HANGS
-  yields no measurement at all, so a mutation run scores it as not killed and
-  prints a silent miss rather than a wedge.
+- **A time cap, held on both sides.** After `CAP` seconds the caller kills the
+  session's process group, the spawner's after it: `script` puts the session in
+  a group of its own, so killing the spawner alone leaves the stuck child
+  behind. The session holds the same deadline over ITSELF a few seconds later,
+  because a suite killed mid-run takes the caller's poll loop with it and
+  leaves a setsid'd session nothing can reach. A probe that HANGS yields no
+  measurement at all, so a mutation run scores it as not killed and prints a
+  silent miss rather than a wedge.
 
 Three things to assert, and `terminal-paths.test.sh` is the worked example —
 its `pty_call` is the wrapper shape a new case copies:

--- a/.agents/skills/growth-guards/tests/lib/pty.bash
+++ b/.agents/skills/growth-guards/tests/lib/pty.bash
@@ -57,6 +57,18 @@ printf '%s\n' "$gg_pgid" >"$GG_PTY_SID_FILE"
 # down the moment the session it guards is gone, so it can neither become the
 # leak it exists to prevent nor signal a process group that was recycled after
 # this one ended. On a healthy run the caller's cap fires first.
+#
+# `kill -9 "-PGID"`, with no `--`. This runs under /bin/sh, which is dash on
+# every Debian-family host including the CI runner, and dash's kill builtin
+# takes the word after the signal as a pid: `--` becomes number('-'), it prints
+# `Illegal number: -`, exits 2 and reaps nothing. Measured in ubuntu:24.04. The
+# bare form is a process-group target in dash, bash 3.2.57 and bash 5 alike.
+# The caller-side kills below run in bash and keep their `--`.
+#
+# The marker beside the body file is what makes the kill provable: the caller's
+# cap leaves none, so a case that finds one knows the SESSION's deadline fired
+# rather than something upstream. It sits beside a path the caller chose, since
+# this scratch directory is the caller's to remove and it does not survive.
 gg_session=$$
 if [ -n "$gg_pgid" ]; then
   (
@@ -65,7 +77,10 @@ if [ -n "$gg_pgid" ]; then
       sleep 1
       i=$((i + 1))
     done
-    [ "$i" -lt "$GG_PTY_DEADLINE" ] || kill -9 -- "-$gg_pgid"
+    if [ "$i" -ge "$GG_PTY_DEADLINE" ]; then
+      printf 'fired\n' >"$GG_PTY_BODY_FILE.watchdog"
+      kill -9 "-$gg_pgid"
+    fi
   ) >/dev/null 2>&1 &
 fi
 echo GG-PTY-BEGIN

--- a/.agents/skills/growth-guards/tests/lib/pty.bash
+++ b/.agents/skills/growth-guards/tests/lib/pty.bash
@@ -44,16 +44,43 @@ gg_pty_run() { # CAP_SECONDS SCRIPT_FILE
   # then stop the session starting. Passing the paths as values rather than
   # as syntax removes the question instead of answering it.
   cat >"$dir/session.sh" <<'SESSION'
-ps -o pgid= -p $$ >"$GG_PTY_SID_FILE" 2>/dev/null || true
+gg_pgid="$(ps -o pgid= -p $$ 2>/dev/null | tr -dc '0-9')"
+printf '%s\n' "$gg_pgid" >"$GG_PTY_SID_FILE"
+# The deadline the session holds over ITSELF. The poll loop below is the normal
+# cap, but a suite killed mid-run takes that loop with it, and `script` has
+# already setsid'd this session out of every group the suite's killer could
+# name — so with the cap living only on the far side, a body that never returns
+# outlives the run that started it. Two such keepalives from a dead session ran
+# for sixteen hours before they were killed by hand.
+#
+# The watchdog traps no signal, is bounded by one tick per second, and stands
+# down the moment the session it guards is gone, so it can neither become the
+# leak it exists to prevent nor signal a process group that was recycled after
+# this one ended. On a healthy run the caller's cap fires first.
+gg_session=$$
+if [ -n "$gg_pgid" ]; then
+  (
+    i=0
+    while [ "$i" -lt "$GG_PTY_DEADLINE" ] && kill -0 "$gg_session" 2>/dev/null; do
+      sleep 1
+      i=$((i + 1))
+    done
+    [ "$i" -lt "$GG_PTY_DEADLINE" ] || kill -9 -- "-$gg_pgid"
+  ) >/dev/null 2>&1 &
+fi
 echo GG-PTY-BEGIN
 bash "$GG_PTY_BODY_FILE"
 printf '%s\n' "$?" >"$GG_PTY_RC_FILE"
 SESSION
   cmd='/bin/sh "$GG_PTY_SESSION_FILE"'
   # Exported, not prefixed onto the spawn: the two grammars below would
-  # otherwise carry four assignments each. Every call overwrites them.
+  # otherwise carry five assignments each. Every call overwrites them. The
+  # self-deadline sits PAST the caller's cap, so the poll loop stays the normal
+  # path and still reports `capped`; the session's own watchdog is only what is
+  # left when there is no poll loop any more.
   export GG_PTY_SESSION_FILE="$dir/session.sh" GG_PTY_SID_FILE="$dir/sid" \
-    GG_PTY_BODY_FILE="$body" GG_PTY_RC_FILE="$dir/rc"
+    GG_PTY_BODY_FILE="$body" GG_PTY_RC_FILE="$dir/rc" \
+    GG_PTY_DEADLINE="$((cap + 5))"
   # The grammar is SELECTED, not probed: util-linux takes the command through
   # -e -c, BSD (macOS) after the typescript file. `set -m` gives the spawner a
   # process group of its own where the platform provides one, and </dev/null

--- a/.agents/skills/growth-guards/tests/terminal-paths.test.sh
+++ b/.agents/skills/growth-guards/tests/terminal-paths.test.sh
@@ -208,12 +208,10 @@ orphan="$(cat "$ROOT/orphan.pid" 2>/dev/null || true)"
   || bad "control: and the cap left no process of it behind" "pid $orphan is still running; state=$GG_PTY_STATE err=$GG_PTY_ERR"
 
 # A suite killed mid-run takes the poll loop above with it, and `script` has
-# already setsid'd the session out of every group that killer could name — so
-# the cap on this side simply stops existing. What is left is the deadline the
-# session holds over itself, and it is the difference between a probe that ends
-# and the pair of keepalives from a dead session that ran for sixteen hours
-# before they were killed by hand (KEN-1084). The body here traps TERM away, as
-# those did, so nothing short of the SIGKILL that deadline sends can end it.
+# already setsid'd the session out of every group that killer could name, so the
+# cap on this side stops existing. What is left is the deadline the session
+# holds over itself (KEN-1084). The body traps TERM away, so nothing short of
+# the SIGKILL that deadline sends can end it.
 cat >"$ROOT/abandon-runner.sh" <<'RUNNER'
 set -euo pipefail
 . "$1"
@@ -221,17 +219,12 @@ gg_pty_run 2 "$2" || true
 RUNNER
 
 # abandon PTY_LIB CASE_FILE PIDFILE — run a case under PTY_LIB, kill the runner
-# the moment the session has a child to leave behind, and report what it left:
+# once the session has a child to leave behind, and report what it left:
 # ABANDONED is that child's pid, ABANDONED_GROUP the session's own process
-# group. Killing the runner is what a load reaper or a usage wall does to a
-# suite; the session and its spawner survive it either way.
-#
-# The GROUP is the handle cleanup uses, not the pid. A run that timed out
-# waiting for the pidfile leaves ABANDONED empty, and that is precisely the run
-# that started a session and has no child handle to reap it by — reaping by pid
-# would skip the one case that needs it. gg_pty_run writes the group into
-# `sid` under its own scratch directory, so the runner gets a TMPDIR this
-# function owns and reads it back from there.
+# group. Cleanup reaps by the GROUP, not the pid: a run that timed out waiting
+# for the pidfile leaves ABANDONED empty, and that is exactly the run with no
+# child handle to reap by. gg_pty_run writes the group into `sid` under its own
+# scratch directory, so the runner gets a TMPDIR this function owns.
 abandon() {
   local lib="$1" case_file="$2" pidfile="$3" runner i=0 scratch
   scratch="$(mktemp -d "$ROOT/abandon.XXXXXX")"
@@ -273,19 +266,15 @@ printf 'trap "" HUP TERM\necho STARTED\nsleep 300 &\necho "$!" >%q\nwait\n' \
 rm -f "$ROOT/abandon-case.sh.watchdog"
 abandon "$TEST_DIR/lib/pty.bash" "$ROOT/abandon-case.sh" "$ROOT/abandoned.pid"
 real_group="$ABANDONED_GROUP"
-[ -n "$ABANDONED" ] \
-  && ok "an abandoned session really did start the child its own deadline must take" \
-  || bad "an abandoned session really did start the child its own deadline must take" "no pid recorded"
 # The cap is 2 and the session's deadline sits five seconds past it; 20 is slack
 # for a loaded box, not a second budget.
 [ -n "$ABANDONED" ] && gone_within "$ABANDONED" 20 \
   && ok "and the session ends itself once the run that started it is gone" \
   || bad "and the session ends itself once the run that started it is gone" "pid $ABANDONED is still running"
-# WHICH kill ended it. A dead child is also what a spawner collapsing or a
-# hostile reaper leaves, and the session-side kill runs under /bin/sh — dash on
-# the CI runner, where a mis-parsed argument fails silently and reaps nothing.
-# The marker is written by the watchdog and by nothing else, so on that runner
-# this line is the dash measurement rather than an assumption about it.
+# WHICH kill ended it: a dead child is also what a collapsing spawner leaves.
+# The session-side kill runs under /bin/sh — dash on the CI runner, where a
+# mis-parsed argument reaps nothing in silence — and the marker is written by
+# that watchdog alone, so this line is the dash measurement.
 [ -f "$ROOT/abandon-case.sh.watchdog" ] \
   && ok "and it was the session's own deadline that fired, not something upstream" \
   || bad "and it was the session's own deadline that fired, not something upstream" "no watchdog marker: the in-session kill did not run (dash argument parsing?)"
@@ -303,20 +292,16 @@ printf 'trap "" HUP TERM\necho STARTED\nsleep 300 &\necho "$!" >%q\nwait\n' \
 abandon "$NO_DEADLINE" "$ROOT/abandon-mutant-case.sh" "$ROOT/abandoned-mutant.pid"
 mutant_group="$ABANDONED_GROUP"
 mutant_pid="$ABANDONED"
-# The leak this control deliberately creates is reaped BEFORE the assertion,
-# by the group the session recorded for itself: reaping after would be skipped
-# on any path that reports bad and returns early, and reaping by the child's pid
-# would be skipped exactly when no pid was captured. The pid is read once, into
-# a variable of its own, so the next abandon cannot overwrite what is asserted.
+# The leak this control creates is reaped BEFORE the assertion, by the group the
+# session recorded: reaping after would be skipped on any path reporting bad and
+# returning early. The pid is read once into a variable of its own, so a later
+# abandon cannot overwrite what is asserted.
 [ -n "$mutant_pid" ] && ! gone_within "$mutant_pid" 12 \
   && mutant_survived=yes || mutant_survived=no
 reap_group "$mutant_group"
 [ "$mutant_survived" = yes ] \
   && ok "control: without that deadline the abandoned session is still running" \
   || bad "control: without that deadline the abandoned session is still running" "pid ${mutant_pid:-none} ended anyway, so the case above proves nothing"
-[ ! -f "$ROOT/abandon-mutant-case.sh.watchdog" ] \
-  && ok "control: and the mutant wrote no watchdog marker, so the marker names that kill alone" \
-  || bad "control: and the mutant wrote no watchdog marker, so the marker names that kill alone" "a watchdog fired in a copy whose watchdog never starts"
 
 # The status is the SESSION's own, read from the file it wrote rather than
 # from the spawner, which reports on its own account.

--- a/.agents/skills/growth-guards/tests/terminal-paths.test.sh
+++ b/.agents/skills/growth-guards/tests/terminal-paths.test.sh
@@ -207,6 +207,80 @@ orphan="$(cat "$ROOT/orphan.pid" 2>/dev/null || true)"
   && ok "control: and the cap left no process of it behind" \
   || bad "control: and the cap left no process of it behind" "pid $orphan is still running; state=$GG_PTY_STATE err=$GG_PTY_ERR"
 
+# A suite killed mid-run takes the poll loop above with it, and `script` has
+# already setsid'd the session out of every group that killer could name — so
+# the cap on this side simply stops existing. What is left is the deadline the
+# session holds over itself, and it is the difference between a probe that ends
+# and the pair of keepalives from a dead session that ran for sixteen hours
+# before they were killed by hand (KEN-1084). The body here traps TERM away, as
+# those did, so nothing short of the SIGKILL that deadline sends can end it.
+cat >"$ROOT/abandon-runner.sh" <<'RUNNER'
+set -euo pipefail
+. "$1"
+gg_pty_run 2 "$2" || true
+RUNNER
+
+# abandon PTY_LIB CASE_FILE PIDFILE — run a case under PTY_LIB, kill the runner
+# the moment the session has a child to leave behind, and set ABANDONED to that
+# child's pid. Killing the runner is what a load reaper or a usage wall does to
+# a suite; the session and its spawner survive it either way.
+abandon() {
+  local lib="$1" case_file="$2" pidfile="$3" runner i=0
+  rm -f "$pidfile"
+  bash "$ROOT/abandon-runner.sh" "$lib" "$case_file" >/dev/null 2>&1 &
+  runner=$!
+  while [ "$i" -lt 60 ] && [ ! -s "$pidfile" ]; do
+    sleep 0.25
+    i=$((i + 1))
+  done
+  kill -9 "$runner" 2>/dev/null || true
+  wait "$runner" 2>/dev/null || true
+  ABANDONED="$(cat "$pidfile" 2>/dev/null || true)"
+}
+
+# gone_within PID SECONDS
+gone_within() {
+  local i=0
+  while [ "$i" -lt "$2" ]; do
+    kill -0 "$1" 2>/dev/null || return 0
+    sleep 1
+    i=$((i + 1))
+  done
+  return 1
+}
+
+printf 'trap "" HUP TERM\necho STARTED\nsleep 300 &\necho "$!" >%q\nwait\n' \
+  "$ROOT/abandoned.pid" >"$ROOT/abandon-case.sh"
+abandon "$TEST_DIR/lib/pty.bash" "$ROOT/abandon-case.sh" "$ROOT/abandoned.pid"
+[ -n "$ABANDONED" ] \
+  && ok "an abandoned session really did start the child its own deadline must take" \
+  || bad "an abandoned session really did start the child its own deadline must take" "no pid recorded"
+# The cap is 2 and the session's deadline sits five seconds past it; 20 is slack
+# for a loaded box, not a second budget.
+[ -n "$ABANDONED" ] && gone_within "$ABANDONED" 20 \
+  && ok "and the session ends itself once the run that started it is gone" \
+  || bad "and the session ends itself once the run that started it is gone" "pid $ABANDONED is still running"
+
+# The must-fail control: the same abandonment against a copy whose watchdog
+# never starts. Without it the session outlives the run, which is the leak.
+NO_DEADLINE="$ROOT/pty-no-deadline.bash"
+sed 's/if \[ -n "$gg_pgid" \]; then/if false; then/' "$TEST_DIR/lib/pty.bash" >"$NO_DEADLINE"
+cmp -s "$TEST_DIR/lib/pty.bash" "$NO_DEADLINE" \
+  && bad "control: the mutant really drops the session's own deadline" "the copy is byte-identical to pty.bash" \
+  || ok "control: the mutant really drops the session's own deadline"
+printf 'trap "" HUP TERM\necho STARTED\nsleep 300 &\necho "$!" >%q\nwait\n' \
+  "$ROOT/abandoned-mutant.pid" >"$ROOT/abandon-mutant-case.sh"
+abandon "$NO_DEADLINE" "$ROOT/abandon-mutant-case.sh" "$ROOT/abandoned-mutant.pid"
+[ -n "$ABANDONED" ] && ! gone_within "$ABANDONED" 12 \
+  && ok "control: without that deadline the abandoned session is still running" \
+  || bad "control: without that deadline the abandoned session is still running" "pid ${ABANDONED:-none} ended anyway, so the case above proves nothing"
+# The leak this control deliberately creates is reaped here, by the group the
+# session recorded for itself — the suite must not become the thing it pins.
+if [ -n "$ABANDONED" ]; then
+  leaked_group="$(ps -o pgid= -p "$ABANDONED" 2>/dev/null | tr -dc '0-9' || true)"
+  [ -z "$leaked_group" ] || kill -9 -- "-$leaked_group" 2>/dev/null || true
+fi
+
 # The status is the SESSION's own, read from the file it wrote rather than
 # from the spawner, which reports on its own account.
 printf 'exit 7\n' >"$ROOT/status-case.sh"

--- a/.agents/skills/growth-guards/tests/terminal-paths.test.sh
+++ b/.agents/skills/growth-guards/tests/terminal-paths.test.sh
@@ -221,13 +221,24 @@ gg_pty_run 2 "$2" || true
 RUNNER
 
 # abandon PTY_LIB CASE_FILE PIDFILE — run a case under PTY_LIB, kill the runner
-# the moment the session has a child to leave behind, and set ABANDONED to that
-# child's pid. Killing the runner is what a load reaper or a usage wall does to
-# a suite; the session and its spawner survive it either way.
+# the moment the session has a child to leave behind, and report what it left:
+# ABANDONED is that child's pid, ABANDONED_GROUP the session's own process
+# group. Killing the runner is what a load reaper or a usage wall does to a
+# suite; the session and its spawner survive it either way.
+#
+# The GROUP is the handle cleanup uses, not the pid. A run that timed out
+# waiting for the pidfile leaves ABANDONED empty, and that is precisely the run
+# that started a session and has no child handle to reap it by — reaping by pid
+# would skip the one case that needs it. gg_pty_run writes the group into
+# `sid` under its own scratch directory, so the runner gets a TMPDIR this
+# function owns and reads it back from there.
 abandon() {
-  local lib="$1" case_file="$2" pidfile="$3" runner i=0
+  local lib="$1" case_file="$2" pidfile="$3" runner i=0 scratch
+  scratch="$(mktemp -d "$ROOT/abandon.XXXXXX")"
+  ABANDONED=""
+  ABANDONED_GROUP=""
   rm -f "$pidfile"
-  bash "$ROOT/abandon-runner.sh" "$lib" "$case_file" >/dev/null 2>&1 &
+  TMPDIR="$scratch" bash "$ROOT/abandon-runner.sh" "$lib" "$case_file" >/dev/null 2>&1 &
   runner=$!
   while [ "$i" -lt 60 ] && [ ! -s "$pidfile" ]; do
     sleep 0.25
@@ -236,6 +247,14 @@ abandon() {
   kill -9 "$runner" 2>/dev/null || true
   wait "$runner" 2>/dev/null || true
   ABANDONED="$(cat "$pidfile" 2>/dev/null || true)"
+  ABANDONED_GROUP="$(cat "$scratch"/gg-pty.*/sid 2>/dev/null | tr -dc '0-9' || true)"
+}
+
+# reap_group GROUP — bash, so `--` guards a group id that begins with `-`. The
+# session-side kill in pty.bash cannot use it and says why.
+reap_group() {
+  [ -n "${1:-}" ] || return 0
+  kill -9 -- "-$1" 2>/dev/null || true
 }
 
 # gone_within PID SECONDS
@@ -251,7 +270,9 @@ gone_within() {
 
 printf 'trap "" HUP TERM\necho STARTED\nsleep 300 &\necho "$!" >%q\nwait\n' \
   "$ROOT/abandoned.pid" >"$ROOT/abandon-case.sh"
+rm -f "$ROOT/abandon-case.sh.watchdog"
 abandon "$TEST_DIR/lib/pty.bash" "$ROOT/abandon-case.sh" "$ROOT/abandoned.pid"
+real_group="$ABANDONED_GROUP"
 [ -n "$ABANDONED" ] \
   && ok "an abandoned session really did start the child its own deadline must take" \
   || bad "an abandoned session really did start the child its own deadline must take" "no pid recorded"
@@ -260,6 +281,15 @@ abandon "$TEST_DIR/lib/pty.bash" "$ROOT/abandon-case.sh" "$ROOT/abandoned.pid"
 [ -n "$ABANDONED" ] && gone_within "$ABANDONED" 20 \
   && ok "and the session ends itself once the run that started it is gone" \
   || bad "and the session ends itself once the run that started it is gone" "pid $ABANDONED is still running"
+# WHICH kill ended it. A dead child is also what a spawner collapsing or a
+# hostile reaper leaves, and the session-side kill runs under /bin/sh — dash on
+# the CI runner, where a mis-parsed argument fails silently and reaps nothing.
+# The marker is written by the watchdog and by nothing else, so on that runner
+# this line is the dash measurement rather than an assumption about it.
+[ -f "$ROOT/abandon-case.sh.watchdog" ] \
+  && ok "and it was the session's own deadline that fired, not something upstream" \
+  || bad "and it was the session's own deadline that fired, not something upstream" "no watchdog marker: the in-session kill did not run (dash argument parsing?)"
+reap_group "$real_group"
 
 # The must-fail control: the same abandonment against a copy whose watchdog
 # never starts. Without it the session outlives the run, which is the leak.
@@ -271,15 +301,22 @@ cmp -s "$TEST_DIR/lib/pty.bash" "$NO_DEADLINE" \
 printf 'trap "" HUP TERM\necho STARTED\nsleep 300 &\necho "$!" >%q\nwait\n' \
   "$ROOT/abandoned-mutant.pid" >"$ROOT/abandon-mutant-case.sh"
 abandon "$NO_DEADLINE" "$ROOT/abandon-mutant-case.sh" "$ROOT/abandoned-mutant.pid"
-[ -n "$ABANDONED" ] && ! gone_within "$ABANDONED" 12 \
+mutant_group="$ABANDONED_GROUP"
+mutant_pid="$ABANDONED"
+# The leak this control deliberately creates is reaped BEFORE the assertion,
+# by the group the session recorded for itself: reaping after would be skipped
+# on any path that reports bad and returns early, and reaping by the child's pid
+# would be skipped exactly when no pid was captured. The pid is read once, into
+# a variable of its own, so the next abandon cannot overwrite what is asserted.
+[ -n "$mutant_pid" ] && ! gone_within "$mutant_pid" 12 \
+  && mutant_survived=yes || mutant_survived=no
+reap_group "$mutant_group"
+[ "$mutant_survived" = yes ] \
   && ok "control: without that deadline the abandoned session is still running" \
-  || bad "control: without that deadline the abandoned session is still running" "pid ${ABANDONED:-none} ended anyway, so the case above proves nothing"
-# The leak this control deliberately creates is reaped here, by the group the
-# session recorded for itself — the suite must not become the thing it pins.
-if [ -n "$ABANDONED" ]; then
-  leaked_group="$(ps -o pgid= -p "$ABANDONED" 2>/dev/null | tr -dc '0-9' || true)"
-  [ -z "$leaked_group" ] || kill -9 -- "-$leaked_group" 2>/dev/null || true
-fi
+  || bad "control: without that deadline the abandoned session is still running" "pid ${mutant_pid:-none} ended anyway, so the case above proves nothing"
+[ ! -f "$ROOT/abandon-mutant-case.sh.watchdog" ] \
+  && ok "control: and the mutant wrote no watchdog marker, so the marker names that kill alone" \
+  || bad "control: and the mutant wrote no watchdog marker, so the marker names that kill alone" "a watchdog fired in a copy whose watchdog never starts"
 
 # The status is the SESSION's own, read from the file it wrote rather than
 # from the spawner, which reports on its own account.

--- a/.agents/skills/orch/scripts/open-terminal
+++ b/.agents/skills/orch/scripts/open-terminal
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Launch one or more work item worktrees in a separate terminal/window.
 # This is a handoff helper only; it does not monitor spawned sessions.
-# In-app harnesses (Codex app, Claude desktop, drovr) never use this script:
-# they hand off through the harness's own tooling — oversee.md § 1.
+# This is the tmux surface's launcher (oversee.md § 1). Where $TMUX is unset and
+# the harness ships its own session or thread launching, the handoff goes
+# through that instead.
 
 set -euo pipefail
 
@@ -145,6 +146,14 @@ export SKILLS_DIR
 # Writing where the readers do not look would silently defeat the claims.
 CLAIM_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 export CLAIM_ROOT
+# open_gui EXECUTES $TERMINAL, so it belongs with the names above rather than
+# with the settings a project may state: the loader below assigns any name a
+# kendex.settings.toml [env] table carries, and a repo choosing which binary a
+# handoff runs is code execution, not a changed answer. Pinning it to the
+# environment — empty when the operator set nothing — makes the loader skip the
+# key while the operator's own value still decides.
+TERMINAL="${TERMINAL:-}"
+export TERMINAL
 # shellcheck source=lib/kendex-env.sh
 source "$SCRIPT_DIR/lib/kendex-env.sh"
 kendex_load_project_env "$PROJECT_ROOT"
@@ -524,19 +533,53 @@ open_tmux() {
 # explicit choice, xdg-terminal-exec the desktop's, and ghostty only where a
 # desktop names neither. Nothing is hardcoded ahead of what the user set.
 open_gui() {
-  local dir="$1" title="$2" cmd="$3"
-  local shell_cmd="cd '$dir' && $cmd"
+  local dir="$1" title="$2" cmd="$3" chosen=""
+  # The title is written from inside the launched shell, so it survives whichever
+  # launcher runs: only the ghostty arm carries --title, and it is tried last.
+  # The title is the item id, validated against GH_ISSUE_PATTERN before it
+  # reaches here — the premise `cd '$dir'` already rests on.
+  local shell_cmd="printf '\033]0;%s\007' '$title'; cd '$dir' && $cmd"
   launchable_dir "$dir" "$title" || return 1
+  local -a launcher=()
   if [[ -n "${TERMINAL:-}" ]] && command -v "$TERMINAL" >/dev/null 2>&1; then
-    setsid env -u CLAUDECODE "$TERMINAL" -e bash -lc "$shell_cmd" </dev/null >/dev/null 2>&1 &
+    chosen="$TERMINAL"
+    launcher=(env -u CLAUDECODE "$TERMINAL" -e bash -lc "$shell_cmd")
   elif command -v xdg-terminal-exec >/dev/null 2>&1; then
-    setsid env -u CLAUDECODE xdg-terminal-exec bash -lc "$shell_cmd" </dev/null >/dev/null 2>&1 &
+    chosen="xdg-terminal-exec"
+    launcher=(env -u CLAUDECODE xdg-terminal-exec bash -lc "$shell_cmd")
   elif command -v ghostty >/dev/null 2>&1; then
-    setsid env -u CLAUDECODE ghostty --working-directory="$dir" --title="$title" -e bash -lc "$shell_cmd" </dev/null >/dev/null 2>&1 &
+    chosen="ghostty"
+    launcher=(env -u CLAUDECODE ghostty --working-directory="$dir" --title="$title" -e bash -lc "$shell_cmd")
   else
     echo "Error: no GUI terminal found; set \$TERMINAL to one, or install xdg-terminal-exec" >&2
     return 1
   fi
+  # A $TERMINAL naming nothing on PATH — a typo, an uninstalled terminal, a value
+  # carrying arguments — is otherwise substituted in silence.
+  [[ -z "${TERMINAL:-}" || "$chosen" == "$TERMINAL" ]] ||
+    echo "Warning: \$TERMINAL '$TERMINAL' does not resolve to an executable; launching '$title' with $chosen instead" >&2
+  # A launch nothing observed is not a launch to report: this exit code is the
+  # orchestrator's only signal that a lane started, and `-e bash -lc CMD` is
+  # ghostty/xterm grammar the GTK family and wezterm do not take. The job gets a
+  # beat — alive means the window is up, exit 0 means the launcher handed off,
+  # any other status is this item's failure carrying the launcher's own words.
+  # setsid execs rather than forks here (a backgrounded job in a shell without
+  # job control is no group leader), so $! is the launcher itself.
+  local err gui_pid gui_rc=0 said
+  err="$(mktemp)" || { echo "Error: no scratch file for '$title'; not launching" >&2; return 1; }
+  setsid "${launcher[@]}" </dev/null >/dev/null 2>"$err" &
+  gui_pid=$!
+  sleep 1
+  if ! kill -0 "$gui_pid" 2>/dev/null; then
+    wait "$gui_pid" || gui_rc=$?
+    if [[ "$gui_rc" -ne 0 ]]; then
+      said="$(tr '\n' ' ' <"$err" 2>/dev/null || true)"
+      rm -f "$err"
+      echo "Error: $chosen exited $gui_rc launching '$title'${said:+: $said}" >&2
+      return 1
+    fi
+  fi
+  rm -f "$err"
   echo "Opened terminal '$title' in $dir"
 }
 

--- a/.agents/skills/orch/scripts/open-terminal
+++ b/.agents/skills/orch/scripts/open-terminal
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Launch one or more work item worktrees in a separate terminal/window.
 # This is a handoff helper only; it does not monitor spawned sessions.
+# In-app harnesses (Codex app, Claude desktop, drovr) never use this script:
+# they hand off through the harness's own tooling — oversee.md § 1.
 
 set -euo pipefail
 
@@ -14,7 +16,7 @@ Usage: open-terminal [--tracker linear|github] [--repo OWNER/REPO] ITEM... [opti
 Options:
   --harness <name>  claude, codex, opencode, pi
   --tmux            Open tmux windows in the current session
-  --ghostty         Open Ghostty/GUI terminals
+  --ghostty         Open GUI terminals ($TERMINAL, xdg-terminal-exec, ghostty)
   --cmd "..."       Custom command; {issue}, {item}, and {repo} are replaced
   --lane <spec>     Launch under a chosen harness account. `auto` picks the
                     qualifying account with the fewest launches in flight for
@@ -439,6 +441,17 @@ tmux_wait_composer() {
   return 1
 }
 
+# The last layer before any window opens. A launch whose working directory is
+# gone opens a terminal that cannot start, so every path refuses here by name —
+# whatever produced it: a worktree deleted under a running lane, or a stubbed
+# CLI that exits 0 printing nothing. The empty path is the same: `-d ""` is
+# false.
+launchable_dir() { # DIR TITLE
+  [[ -d "$1" ]] && return 0
+  echo "Error: refusing to launch '$2': working directory '$1' does not exist" >&2
+  return 1
+}
+
 open_tmux() {
   local dir="$1" title="$2" cmd="$3" brief="${4:-}"
   # Called on the left of `||` at the launch loop, which suspends errexit for
@@ -447,6 +460,7 @@ open_tmux() {
   # return (most visibly on briefless lanes, whose early return would
   # otherwise count a broken window as launched).
   [[ -n "${TMUX:-}" ]] || { echo "Error: not inside tmux" >&2; return 1; }
+  launchable_dir "$dir" "$title" || return 1
   local last_idx pane spec server
   if ! last_idx=$(tmux list-windows -F '#{window_index}' | tail -1) || [[ -z "$last_idx" ]]; then
     echo "Error: tmux list-windows failed; cannot place window '$title'" >&2
@@ -506,15 +520,21 @@ open_tmux() {
   return 1
 }
 
+# Outside tmux the user's own terminal opens the lane: $TERMINAL is the
+# explicit choice, xdg-terminal-exec the desktop's, and ghostty only where a
+# desktop names neither. Nothing is hardcoded ahead of what the user set.
 open_gui() {
   local dir="$1" title="$2" cmd="$3"
   local shell_cmd="cd '$dir' && $cmd"
-  if command -v ghostty >/dev/null 2>&1; then
-    setsid env -u CLAUDECODE ghostty --working-directory="$dir" --title="$title" -e bash -lc "$shell_cmd" </dev/null >/dev/null 2>&1 &
+  launchable_dir "$dir" "$title" || return 1
+  if [[ -n "${TERMINAL:-}" ]] && command -v "$TERMINAL" >/dev/null 2>&1; then
+    setsid env -u CLAUDECODE "$TERMINAL" -e bash -lc "$shell_cmd" </dev/null >/dev/null 2>&1 &
   elif command -v xdg-terminal-exec >/dev/null 2>&1; then
     setsid env -u CLAUDECODE xdg-terminal-exec bash -lc "$shell_cmd" </dev/null >/dev/null 2>&1 &
+  elif command -v ghostty >/dev/null 2>&1; then
+    setsid env -u CLAUDECODE ghostty --working-directory="$dir" --title="$title" -e bash -lc "$shell_cmd" </dev/null >/dev/null 2>&1 &
   else
-    echo "Error: no supported GUI terminal found" >&2
+    echo "Error: no GUI terminal found; set \$TERMINAL to one, or install xdg-terminal-exec" >&2
     return 1
   fi
   echo "Opened terminal '$title' in $dir"

--- a/.agents/skills/orch/scripts/open-terminal
+++ b/.agents/skills/orch/scripts/open-terminal
@@ -146,14 +146,6 @@ export SKILLS_DIR
 # Writing where the readers do not look would silently defeat the claims.
 CLAIM_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 export CLAIM_ROOT
-# open_gui EXECUTES $TERMINAL, so it belongs with the names above rather than
-# with the settings a project may state: the loader below assigns any name a
-# kendex.settings.toml [env] table carries, and a repo choosing which binary a
-# handoff runs is code execution, not a changed answer. Pinning it to the
-# environment — empty when the operator set nothing — makes the loader skip the
-# key while the operator's own value still decides.
-TERMINAL="${TERMINAL:-}"
-export TERMINAL
 # shellcheck source=lib/kendex-env.sh
 source "$SCRIPT_DIR/lib/kendex-env.sh"
 kendex_load_project_env "$PROJECT_ROOT"

--- a/.agents/skills/orch/scripts/open-terminal
+++ b/.agents/skills/orch/scripts/open-terminal
@@ -558,28 +558,7 @@ open_gui() {
   # carrying arguments — is otherwise substituted in silence.
   [[ -z "${TERMINAL:-}" || "$chosen" == "$TERMINAL" ]] ||
     echo "Warning: \$TERMINAL '$TERMINAL' does not resolve to an executable; launching '$title' with $chosen instead" >&2
-  # A launch nothing observed is not a launch to report: this exit code is the
-  # orchestrator's only signal that a lane started, and `-e bash -lc CMD` is
-  # ghostty/xterm grammar the GTK family and wezterm do not take. The job gets a
-  # beat — alive means the window is up, exit 0 means the launcher handed off,
-  # any other status is this item's failure carrying the launcher's own words.
-  # setsid execs rather than forks here (a backgrounded job in a shell without
-  # job control is no group leader), so $! is the launcher itself.
-  local err gui_pid gui_rc=0 said
-  err="$(mktemp)" || { echo "Error: no scratch file for '$title'; not launching" >&2; return 1; }
-  setsid "${launcher[@]}" </dev/null >/dev/null 2>"$err" &
-  gui_pid=$!
-  sleep 1
-  if ! kill -0 "$gui_pid" 2>/dev/null; then
-    wait "$gui_pid" || gui_rc=$?
-    if [[ "$gui_rc" -ne 0 ]]; then
-      said="$(tr '\n' ' ' <"$err" 2>/dev/null || true)"
-      rm -f "$err"
-      echo "Error: $chosen exited $gui_rc launching '$title'${said:+: $said}" >&2
-      return 1
-    fi
-  fi
-  rm -f "$err"
+  setsid "${launcher[@]}" </dev/null >/dev/null 2>&1 &
   echo "Opened terminal '$title' in $dir"
 }
 

--- a/.agents/skills/orch/tests/lanes.sh
+++ b/.agents/skills/orch/tests/lanes.sh
@@ -13,6 +13,8 @@ set -uo pipefail
 # (.agents/skills/orch/tests/...), where a `<root>/skills/orch/...` path does not
 # exist. Same reason the sibling open-terminal test does it this way.
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/sealed-bin.sh
+. "$TEST_DIR/lib/sealed-bin.sh"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 LANES="$SCRIPTS_DIR/lanes"
 OPEN_TERMINAL="$SCRIPTS_DIR/open-terminal"
@@ -538,7 +540,7 @@ chmod +x "$OT_STUB_BIN/worktree" "$OT_STUB_BIN/gh" "$OT_STUB_BIN/tmux"
 # the repository: a test must never write into the checkout it is testing.
 OT_STATE="$TMP_ROOT/ot-state"
 OT_TMUX_PANES="$TMP_ROOT/ot-panes"
-run_ot() { TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "$@"; }
+run_ot() { TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "$@"; }
 
 # Assert against what a user actually sees, not against a parse of the source.
 # --help must work with no git repository in sight. It used to die with git's
@@ -546,7 +548,7 @@ run_ot() { TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_T
 # failed under `set -e` before argument parsing ever ran.
 NOREPO="$TMP_ROOT/norepo"; mkdir -p "$NOREPO"
 help_rc=0
-HELP_OUT="$( (cd "$NOREPO" && PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
+HELP_OUT="$( (cd "$NOREPO" && PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
   "$OPEN_TERMINAL" --help) 2>&1 )" || help_rc=$?
 assert_eq "$help_rc" "0" "open-terminal --help exits 0 outside a git repository"
 assert_contains "$HELP_OUT" "--lane <spec>" "open-terminal --help documents --lane"
@@ -587,7 +589,7 @@ fi
 # than whatever issue convention the surrounding checkout happens to configure.
 run_ot_aliased() { LANES_HOME="$H" ORCH_LANE_ALIASES="$1" ORCH_LANES_FETCH_CMD="$FETCHER" \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "${@:2}"; }
+  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "${@:2}"; }
 
 set +e
 alias_out=$(run_ot_aliased "eclaude=work" --harness claude --lane work --cmd "true" CC-1 2>&1)
@@ -614,7 +616,7 @@ set +e
 collide_out=$( (cd "$COLLIDE" && LANES_HOME="$H" ORCH_LANE_ALIASES="eclaude=work" \
   ORCH_LANES_FETCH_CMD="$FETCHER" GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' \
   TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
+  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
   "$OPEN_TERMINAL" --harness claude --lane work --cmd "true" CC-1) 2>&1 )
 collide_rc=$?
 set -e
@@ -635,7 +637,7 @@ set +e
 bare_out=$( (cd "$BARE" && LANES_HOME="$H" ORCH_LANE_ALIASES="eclaude=work" \
   ORCH_LANES_FETCH_CMD="$FETCHER" GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' \
   TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
+  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
   "$OPEN_TERMINAL" --harness claude --lane somelane --cmd "true" CC-1) 2>&1 )
 bare_rc=$?
 set -e
@@ -658,20 +660,18 @@ assert_eq "$(cat "$OT_STATE"/claims/*.claim 2>/dev/null | cut -f2)" "%1" \
 rm -rf "$OT_STATE"
 noclaim_out=$(OVERSEE_WATCH_STATE_DIR="$OT_STATE" GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' \
   TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" \
-  PATH="$OT_STUB_BIN:$PATH" \
+  PATH="$OT_STUB_BIN:$SEALED:$PATH" \
   WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" --harness claude --cmd "true" CC-3 2>&1)
 assert_contains "$noclaim_out" "Opened tmux window" "the laneless launch still opened its window"
 assert_eq "$(ls -1 "$OT_STATE/claims" 2>/dev/null | wc -l | tr -d '[:space:]')" "0" \
   "a launch with no --lane records no claim"
 
-# `--lane auto` over a batch: the claim each launch records must move the
-# next item off that account, or one invocation puts the fleet on one lane.
-# $TERMINAL pins the stub open_gui reaches for first: no window opens here.
+# `--lane auto` over a batch: each recorded claim must move the next item off that lane.
 rm -rf "$OT_STATE"; rm -f "$OT_TMUX_PANES"
 run_ot_auto() { LANES_HOME="$H" ORCH_LANES_FETCH_CMD="$FETCHER" \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" \
   OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$PATH" TERMINAL=ghostty WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "$@"; }
+  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "$@"; }
 set +e
 auto_out=$(run_ot_auto --harness claude --lane auto --cmd "true" CC-4 CC-5 2>&1)
 auto_rc=$?
@@ -759,7 +759,7 @@ owned_out=$(LANES_HOME="$H" ORCH_LANES_FETCH_CMD="$FETCHER" OWNED_COUNT="$TMP_RO
   OWNED_ROOT="$TMP_ROOT" \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" \
   OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OWNED_STUB" \
+  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OWNED_STUB" \
   "$OPEN_TERMINAL" --harness claude --lane auto --cmd "true" CC-17 CC-18 2>&1)
 set -e
 assert_contains "$owned_out" "on lane CLAUDE_CONFIG_DIR=$H/.claude" \
@@ -798,7 +798,7 @@ set +e
 tabpick_out=$(LANES_HOME="$H9" FIXTURE_DIR="$TABFIX" ORCH_LANES_FETCH_CMD="$FETCHER" \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" \
   OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
+  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
   "$OPEN_TERMINAL" --harness claude --lane auto --cmd "true" CC-22 CC-23 2>&1)
 tabpick_rc=$?
 set -e
@@ -821,7 +821,7 @@ set +e
 ( cd "$CALLERREPO" && LANES_HOME="$H" ORCH_LANES_FETCH_CMD="$FETCHER" \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" \
   OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" \
-  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
+  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
   "$SCRIPTREPO/scripts/open-terminal" --harness claude --lane auto --cmd "true" CC-20 ) >/dev/null 2>&1
 set -e
 assert_eq "$(ls -1 "$CALLERREPO"/tmp/oversee-watch/claims 2>/dev/null | wc -l | tr -d '[:space:]')" "1" \
@@ -835,7 +835,7 @@ cat > "$OT_STUB_BIN/ghostty" <<'STUBEOF'
 #!/usr/bin/env bash
 exit 0
 STUBEOF
-chmod +x "$OT_STUB_BIN/ghostty"
+chmod +x "$OT_STUB_BIN/ghostty"; export TERMINAL=ghostty  # open_gui reads it first
 rm -rf "$OT_STATE"; rm -f "$OT_TMUX_PANES"
 set +e
 gui_out=$(run_ot_auto --ghostty --harness claude --lane auto --cmd "true" CC-10 CC-11 2>&1)
@@ -868,7 +868,7 @@ stop_out=$(LANES_HOME="$H" ORCH_LANES_FETCH_CMD="$TMP_ROOT/fetch-flaky" \
   FLAKY_COUNT="$TMP_ROOT/flaky-count" FLAKY_OK=3 \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" \
   OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
+  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
   "$OPEN_TERMINAL" --harness claude --lane auto --cmd "true" CC-6 CC-7 2>&1)
 stop_rc=$?
 set -e

--- a/.agents/skills/orch/tests/lanes.sh
+++ b/.agents/skills/orch/tests/lanes.sh
@@ -13,8 +13,6 @@ set -uo pipefail
 # (.agents/skills/orch/tests/...), where a `<root>/skills/orch/...` path does not
 # exist. Same reason the sibling open-terminal test does it this way.
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=lib/sealed-bin.sh
-. "$TEST_DIR/lib/sealed-bin.sh"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 LANES="$SCRIPTS_DIR/lanes"
 OPEN_TERMINAL="$SCRIPTS_DIR/open-terminal"
@@ -540,7 +538,7 @@ chmod +x "$OT_STUB_BIN/worktree" "$OT_STUB_BIN/gh" "$OT_STUB_BIN/tmux"
 # the repository: a test must never write into the checkout it is testing.
 OT_STATE="$TMP_ROOT/ot-state"
 OT_TMUX_PANES="$TMP_ROOT/ot-panes"
-run_ot() { TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "$@"; }
+run_ot() { TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "$@"; }
 
 # Assert against what a user actually sees, not against a parse of the source.
 # --help must work with no git repository in sight. It used to die with git's
@@ -548,7 +546,7 @@ run_ot() { TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_T
 # failed under `set -e` before argument parsing ever ran.
 NOREPO="$TMP_ROOT/norepo"; mkdir -p "$NOREPO"
 help_rc=0
-HELP_OUT="$( (cd "$NOREPO" && PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
+HELP_OUT="$( (cd "$NOREPO" && PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
   "$OPEN_TERMINAL" --help) 2>&1 )" || help_rc=$?
 assert_eq "$help_rc" "0" "open-terminal --help exits 0 outside a git repository"
 assert_contains "$HELP_OUT" "--lane <spec>" "open-terminal --help documents --lane"
@@ -589,7 +587,7 @@ fi
 # than whatever issue convention the surrounding checkout happens to configure.
 run_ot_aliased() { LANES_HOME="$H" ORCH_LANE_ALIASES="$1" ORCH_LANES_FETCH_CMD="$FETCHER" \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "${@:2}"; }
+  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "${@:2}"; }
 
 set +e
 alias_out=$(run_ot_aliased "eclaude=work" --harness claude --lane work --cmd "true" CC-1 2>&1)
@@ -616,7 +614,7 @@ set +e
 collide_out=$( (cd "$COLLIDE" && LANES_HOME="$H" ORCH_LANE_ALIASES="eclaude=work" \
   ORCH_LANES_FETCH_CMD="$FETCHER" GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' \
   TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
+  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
   "$OPEN_TERMINAL" --harness claude --lane work --cmd "true" CC-1) 2>&1 )
 collide_rc=$?
 set -e
@@ -637,7 +635,7 @@ set +e
 bare_out=$( (cd "$BARE" && LANES_HOME="$H" ORCH_LANE_ALIASES="eclaude=work" \
   ORCH_LANES_FETCH_CMD="$FETCHER" GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' \
   TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
+  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
   "$OPEN_TERMINAL" --harness claude --lane somelane --cmd "true" CC-1) 2>&1 )
 bare_rc=$?
 set -e
@@ -660,7 +658,7 @@ assert_eq "$(cat "$OT_STATE"/claims/*.claim 2>/dev/null | cut -f2)" "%1" \
 rm -rf "$OT_STATE"
 noclaim_out=$(OVERSEE_WATCH_STATE_DIR="$OT_STATE" GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' \
   TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" \
-  PATH="$OT_STUB_BIN:$SEALED:$PATH" \
+  PATH="$OT_STUB_BIN:$PATH" \
   WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" --harness claude --cmd "true" CC-3 2>&1)
 assert_contains "$noclaim_out" "Opened tmux window" "the laneless launch still opened its window"
 assert_eq "$(ls -1 "$OT_STATE/claims" 2>/dev/null | wc -l | tr -d '[:space:]')" "0" \
@@ -671,7 +669,7 @@ rm -rf "$OT_STATE"; rm -f "$OT_TMUX_PANES"
 run_ot_auto() { LANES_HOME="$H" ORCH_LANES_FETCH_CMD="$FETCHER" \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" \
   OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "$@"; }
+  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "$@"; }
 set +e
 auto_out=$(run_ot_auto --harness claude --lane auto --cmd "true" CC-4 CC-5 2>&1)
 auto_rc=$?
@@ -759,7 +757,7 @@ owned_out=$(LANES_HOME="$H" ORCH_LANES_FETCH_CMD="$FETCHER" OWNED_COUNT="$TMP_RO
   OWNED_ROOT="$TMP_ROOT" \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" \
   OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OWNED_STUB" \
+  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OWNED_STUB" \
   "$OPEN_TERMINAL" --harness claude --lane auto --cmd "true" CC-17 CC-18 2>&1)
 set -e
 assert_contains "$owned_out" "on lane CLAUDE_CONFIG_DIR=$H/.claude" \
@@ -798,7 +796,7 @@ set +e
 tabpick_out=$(LANES_HOME="$H9" FIXTURE_DIR="$TABFIX" ORCH_LANES_FETCH_CMD="$FETCHER" \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" \
   OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
+  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
   "$OPEN_TERMINAL" --harness claude --lane auto --cmd "true" CC-22 CC-23 2>&1)
 tabpick_rc=$?
 set -e
@@ -821,7 +819,7 @@ set +e
 ( cd "$CALLERREPO" && LANES_HOME="$H" ORCH_LANES_FETCH_CMD="$FETCHER" \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" \
   OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" \
-  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
+  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
   "$SCRIPTREPO/scripts/open-terminal" --harness claude --lane auto --cmd "true" CC-20 ) >/dev/null 2>&1
 set -e
 assert_eq "$(ls -1 "$CALLERREPO"/tmp/oversee-watch/claims 2>/dev/null | wc -l | tr -d '[:space:]')" "1" \
@@ -868,7 +866,7 @@ stop_out=$(LANES_HOME="$H" ORCH_LANES_FETCH_CMD="$TMP_ROOT/fetch-flaky" \
   FLAKY_COUNT="$TMP_ROOT/flaky-count" FLAKY_OK=3 \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" \
   OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
+  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
   "$OPEN_TERMINAL" --harness claude --lane auto --cmd "true" CC-6 CC-7 2>&1)
 stop_rc=$?
 set -e

--- a/.agents/skills/orch/tests/lanes.sh
+++ b/.agents/skills/orch/tests/lanes.sh
@@ -664,14 +664,14 @@ assert_contains "$noclaim_out" "Opened tmux window" "the laneless launch still o
 assert_eq "$(ls -1 "$OT_STATE/claims" 2>/dev/null | wc -l | tr -d '[:space:]')" "0" \
   "a launch with no --lane records no claim"
 
-# `--lane auto` over a batch: the claim each launch records must move the next
-# item off that account, or one invocation puts the whole fleet on one lane —
-# the failure the claims exist to prevent.
+# `--lane auto` over a batch: the claim each launch records must move the
+# next item off that account, or one invocation puts the fleet on one lane.
+# $TERMINAL pins the stub open_gui reaches for first: no window opens here.
 rm -rf "$OT_STATE"; rm -f "$OT_TMUX_PANES"
 run_ot_auto() { LANES_HOME="$H" ORCH_LANES_FETCH_CMD="$FETCHER" \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" \
   OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "$@"; }
+  PATH="$OT_STUB_BIN:$PATH" TERMINAL=ghostty WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "$@"; }
 set +e
 auto_out=$(run_ot_auto --harness claude --lane auto --cmd "true" CC-4 CC-5 2>&1)
 auto_rc=$?

--- a/.agents/skills/orch/tests/lib/sealed-bin.sh
+++ b/.agents/skills/orch/tests/lib/sealed-bin.sh
@@ -1,0 +1,19 @@
+# shellcheck shell=bash
+# Resolves SEALED: the committed refusal fixture at tools/tests/lib/sealed-bin.
+# A suite appends it to PATH AFTER its own stub directory — the stubs answer
+# while they exist, the seal refuses once the temp tree behind them is gone.
+# Which names it covers, and why, are in that directory's `refuse`.
+#
+# Sourced rather than repeated. Three suites carried byte-identical copies of
+# this block, and a rule spelled once per adopter is a rule the next adopter
+# gets to forget.
+#
+# Relative first, so an exported tree that is no git checkout still runs these
+# suites — the mutation harness extracts one with git archive. git's own failure
+# must not become the caller's: in a non-git tree the substitution exits 128,
+# and under set -e that would end the run before the named error below printed.
+SEALED="$(cd "${BASH_SOURCE[0]%/*}/../../../.." && pwd)/tools/tests/lib/sealed-bin"
+if [[ ! -x "$SEALED/gh" ]]; then
+  SEALED="$(git -C "${BASH_SOURCE[0]%/*}" rev-parse --show-toplevel 2>/dev/null || true)/tools/tests/lib/sealed-bin"
+fi
+[[ -x "$SEALED/gh" ]] || { echo "${0##*/}: sealed-bin fixture is missing: $SEALED" >&2; exit 1; }

--- a/.agents/skills/orch/tests/merge_queue_rearm_e2e.sh
+++ b/.agents/skills/orch/tests/merge_queue_rearm_e2e.sh
@@ -9,17 +9,8 @@ set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ORCH="$(cd "$TEST_DIR/.." && pwd)"
-# Relative first, so an exported tree that is no git checkout still runs
-# these suites — the mutation harness extracts one with git archive.
-SEALED="$(cd "$TEST_DIR/../../.." && pwd)/tools/tests/lib/sealed-bin"
-# git's own failure must not become this script's: in a non-git tree the
-# substitution exits 128, and under set -e that would end the run before the
-# named error below ever printed.
-if [[ ! -x "$SEALED/gh" ]]; then
-  REPO_TOP="$(git -C "$TEST_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
-  SEALED="$REPO_TOP/tools/tests/lib/sealed-bin"
-fi
-[[ -x "$SEALED/gh" ]] || { echo "merge_queue_rearm_e2e: sealed-bin fixture is missing: $SEALED" >&2; exit 1; }
+# shellcheck source=lib/sealed-bin.sh
+. "$TEST_DIR/lib/sealed-bin.sh"
 TMP="$(mktemp -d)"
 # This suite launches real detached supervisors; teardown owns their pids.
 # shellcheck source=lib/merge-queue-reaper.sh

--- a/.agents/skills/orch/tests/merge_queue_teardown.sh
+++ b/.agents/skills/orch/tests/merge_queue_teardown.sh
@@ -22,17 +22,8 @@ set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ORCH="$(cd "$TEST_DIR/.." && pwd)"
-# Relative first, so an exported tree that is no git checkout still runs
-# these suites — the mutation harness extracts one with git archive.
-SEALED="$(cd "$TEST_DIR/../../.." && pwd)/tools/tests/lib/sealed-bin"
-# git's own failure must not become this script's: in a non-git tree the
-# substitution exits 128, and under set -e that would end the run before the
-# named error below ever printed.
-if [[ ! -x "$SEALED/gh" ]]; then
-  REPO_TOP="$(git -C "$TEST_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
-  SEALED="$REPO_TOP/tools/tests/lib/sealed-bin"
-fi
-[[ -x "$SEALED/gh" ]] || { echo "merge_queue_teardown: sealed-bin fixture is missing: $SEALED" >&2; exit 1; }
+# shellcheck source=lib/sealed-bin.sh
+. "$TEST_DIR/lib/sealed-bin.sh"
 TMP="$(mktemp -d)"
 # shellcheck source=lib/merge-queue-reaper.sh
 . "$TEST_DIR/lib/merge-queue-reaper.sh"
@@ -664,10 +655,15 @@ suite_arms_teardown() {
   traps=$(exit_traps_in "$1") || return 2
   [[ "$traps" == 'trap mq_reap_teardown EXIT' ]]
 }
+# Either spelling of obtaining SEALED counts — the directory named outright, or
+# lib/sealed-bin.sh sourced, which is where that name now resolves. What the
+# check is FOR is the second half: obtaining it and never putting it behind the
+# stubs on PATH seals nothing.
 suite_seals_path() {
   local body
   body=$(grep -v '^[[:space:]]*#' "$1") || return 1
-  grep -q 'tools/tests/lib/sealed-bin' <<<"$body" && grep -qF '$SEALED:$PATH' <<<"$body"
+  grep -qE 'tools/tests/lib/sealed-bin|lib/sealed-bin\.sh' <<<"$body" \
+    && grep -qF '$SEALED:$PATH' <<<"$body"
 }
 
 roster=$(launching_suites "$TEST_DIR")
@@ -751,6 +747,12 @@ trap mq_reap_teardown EXIT
 cat > /dev/null <<NEVERCLOSED
 UNTERM
 printf '#!/usr/bin/env bash\n# trap mq_reap_teardown EXIT\n# tools/tests/lib/sealed-bin and "$SEALED:$PATH"\n' > "$planted/comment_decoy.sh"
+# The two halves of the sealing check, each planted without the other: a suite
+# that sources the helper and never reaches PATH, and one that builds a PATH
+# from a SEALED it never obtained.
+printf '#!/usr/bin/env bash\n. "$TEST_DIR/lib/sealed-bin.sh"\nPATH="$BIN:$PATH"\n' > "$planted/sourced_unsealed_suite.sh"
+printf '#!/usr/bin/env bash\nPATH="$BIN:$SEALED:$PATH"\n' > "$planted/pathed_unsourced_suite.sh"
+printf '#!/usr/bin/env bash\n. "$TEST_DIR/lib/sealed-bin.sh"\nPATH="$BIN:$SEALED:$PATH"\n' > "$planted/sourced_sealed_suite.sh"
 
 if suite_arms_teardown "$planted/armed_suite.sh"; then ok "a suite that installs the reaping teardown passes the arming check"
 else bad "the arming check rejects a suite that is armed"; fi
@@ -771,6 +773,12 @@ case "$unterm_err" in *"could not complete"*) ok "the incomplete scan names the 
   *) bad "the incomplete scan is unnamed: $unterm_err" ;; esac
 if suite_seals_path "$planted/comment_decoy.sh"; then bad "a comment naming the sealed directory passed the sealing check"
 else ok "a comment naming the sealed directory does not pass for a statement"; fi
+if suite_seals_path "$planted/sourced_sealed_suite.sh"; then ok "sourcing lib/sealed-bin.sh and sealing PATH passes the check"
+else bad "a suite that sources the helper and seals its PATH was rejected"; fi
+for half in sourced_unsealed_suite pathed_unsourced_suite; do
+  if suite_seals_path "$planted/$half.sh"; then bad "$half passed the sealing check with only half of it"
+  else ok "the sealing check rejects $half"; fi
+done
 
 printf 'merge-queue-teardown: %d pass, %d fail\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/.agents/skills/orch/tests/merge_queue_watch.sh
+++ b/.agents/skills/orch/tests/merge_queue_watch.sh
@@ -3,17 +3,8 @@ set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ORCH="$(cd "$TEST_DIR/.." && pwd)"
-# Relative first, so an exported tree that is no git checkout still runs
-# these suites — the mutation harness extracts one with git archive.
-SEALED="$(cd "$TEST_DIR/../../.." && pwd)/tools/tests/lib/sealed-bin"
-# git's own failure must not become this script's: in a non-git tree the
-# substitution exits 128, and under set -e that would end the run before the
-# named error below ever printed.
-if [[ ! -x "$SEALED/gh" ]]; then
-  REPO_TOP="$(git -C "$TEST_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
-  SEALED="$REPO_TOP/tools/tests/lib/sealed-bin"
-fi
-[[ -x "$SEALED/gh" ]] || { echo "merge_queue_watch: sealed-bin fixture is missing: $SEALED" >&2; exit 1; }
+# shellcheck source=lib/sealed-bin.sh
+. "$TEST_DIR/lib/sealed-bin.sh"
 TMP_ROOT="$(mktemp -d)"; TMP="$TMP_ROOT/watch path"
 mkdir "$TMP"
 # This suite launches real detached supervisors; teardown owns their pids.

--- a/.agents/skills/orch/tests/open-terminal-claude-handoff.sh
+++ b/.agents/skills/orch/tests/open-terminal-claude-handoff.sh
@@ -115,6 +115,11 @@ exit 0
 EOF
 chmod +x "$BIN/ghostty" "$BIN/gh" "$BIN/tmux"
 
+# $TERMINAL is what open_gui reaches for first, so it is PINNED to the stub on
+# PATH here: unset, the branch below it would resolve whatever terminal the
+# developer's desktop provides and this suite would open real windows.
+export TERMINAL=ghostty
+
 # Stub worktree CLI: `create <item>` makes and prints a temp dir.
 STUB="$TMP_ROOT/worktree-stub"
 cat > "$STUB" <<EOF

--- a/.agents/skills/orch/tests/open-terminal-claude-handoff.sh
+++ b/.agents/skills/orch/tests/open-terminal-claude-handoff.sh
@@ -28,8 +28,6 @@ set -euo pipefail
 TC=" — complete means the PR is MERGED and the worktree cleaned up, not merely opened"
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=lib/sealed-bin.sh
-. "$TEST_DIR/lib/sealed-bin.sh"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 SRC_OT="$SCRIPTS_DIR/open-terminal"
 SRC_LIB_DIR="$SCRIPTS_DIR/lib"
@@ -117,8 +115,9 @@ exit 0
 EOF
 chmod +x "$BIN/ghostty" "$BIN/gh" "$BIN/tmux"
 
-# open_gui reaches for $TERMINAL first, so it names the stub rather than the
-# developer's own terminal. $SEALED is what answers once the stub tree is gone.
+# $TERMINAL is what open_gui reaches for first, so it is PINNED to the stub on
+# PATH here: unset, the branch below it would resolve whatever terminal the
+# developer's desktop provides and this suite would open real windows.
 export TERMINAL=ghostty
 
 # Stub worktree CLI: `create <item>` makes and prints a temp dir.
@@ -209,7 +208,7 @@ echo "=== open-terminal claude handoff: per-task launch flags ==="
 # Case 1: linear:claude renders the autonomy flag by default.
 CAP1="$TMP_ROOT/cap1"
 set +e
-c1_out=$(OT_CAPTURE="$CAP1" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--model opus[1m] --effort max --dangerously-skip-permissions" cc-737 2>"$TMP_ROOT/c1.err")
+c1_out=$(OT_CAPTURE="$CAP1" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--model opus[1m] --effort max --dangerously-skip-permissions" cc-737 2>"$TMP_ROOT/c1.err")
 c1_code=$?
 set -e
 assert_eq "$c1_code" "0" "linear:claude launch succeeds"
@@ -227,7 +226,7 @@ assert_not_contains "$(cat "$TMP_ROOT/c1.err")" "WARNING" \
 # Case 2: github:claude renders the same flag.
 CAP2="$TMP_ROOT/cap2"
 set +e
-c2_out=$(OT_CAPTURE="$CAP2" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tracker github --repo acme/widgets --ghostty --harness claude --launch-flags "--effort max --dangerously-skip-permissions" 42 2>"$TMP_ROOT/c2.err")
+c2_out=$(OT_CAPTURE="$CAP2" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tracker github --repo acme/widgets --ghostty --harness claude --launch-flags "--effort max --dangerously-skip-permissions" 42 2>"$TMP_ROOT/c2.err")
 c2_code=$?
 set -e
 assert_eq "$c2_code" "0" "github:claude launch succeeds"
@@ -245,7 +244,7 @@ fi
 # settings file participates.
 CAP3="$TMP_ROOT/cap3"
 set +e
-c3_out=$(OT_CAPTURE="$CAP3" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--model sonnet --permission-mode bypassPermissions" cc-737 2>"$TMP_ROOT/c3.err")
+c3_out=$(OT_CAPTURE="$CAP3" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--model sonnet --permission-mode bypassPermissions" cc-737 2>"$TMP_ROOT/c3.err")
 c3_code=$?
 set -e
 assert_eq "$c3_code" "0" "a second launch with different flags succeeds"
@@ -266,7 +265,7 @@ assert_not_contains "$(cat "$TMP_ROOT/c3.err")" "WARNING" \
 # would type — no stored model, effort, or permission default appears.
 CAP3B="$TMP_ROOT/cap3b"
 set +e
-OT_CAPTURE="$CAP3B" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude cc-737 2>"$TMP_ROOT/c3b.err"
+OT_CAPTURE="$CAP3B" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude cc-737 2>"$TMP_ROOT/c3b.err"
 set -e
 if wait_capture "$CAP3B"; then
   c3b_cmd="$(cat "$CAP3B")"
@@ -285,7 +284,7 @@ assert_contains "$(cat "$TMP_ROOT/c3b.err")" "handoff autonomy is void" \
 # autonomy is void.
 CAP4="$TMP_ROOT/cap4"
 set +e
-c4_out=$(OT_CAPTURE="$CAP4" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--permission-mode plan" cc-737 2>"$TMP_ROOT/c4.err")
+c4_out=$(OT_CAPTURE="$CAP4" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--permission-mode plan" cc-737 2>"$TMP_ROOT/c4.err")
 c4_code=$?
 set -e
 assert_eq "$c4_code" "0" "prompting flags still launch"
@@ -305,7 +304,7 @@ echo "=== open-terminal claude handoff: tmux brief delivery ==="
 new_tmux_state c5
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c5_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude --launch-flags "--dangerously-skip-permissions" cc-737 2>"$TMP_ROOT/c5.err")
+c5_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude --launch-flags "--dangerously-skip-permissions" cc-737 2>"$TMP_ROOT/c5.err")
 c5_code=$?
 set -e
 assert_eq "$c5_code" "0" "tmux delivered-first-pass exits 0"
@@ -328,7 +327,7 @@ printf '%s\n' "$ECHO_SCREEN" > "$OT_TMUX_CAPTURES/1"
 printf '%s\n' "$READY_SCREEN" > "$OT_TMUX_CAPTURES/2"
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/3"
 set +e
-c6_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c6.err")
+c6_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c6.err")
 c6_code=$?
 set -e
 assert_eq "$c6_code" "0" "tmux re-delivery path exits 0"
@@ -350,7 +349,7 @@ printf '%s\n' "$ECHO_SCREEN" > "$OT_TMUX_CAPTURES/3"
 printf '%s\n' "$READY_SCREEN" > "$OT_TMUX_CAPTURES/4"
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/5"
 set +e
-c6b_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=2 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c6b.err")
+c6b_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=2 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c6b.err")
 c6b_code=$?
 set -e
 assert_eq "$c6b_code" "0" "dialog-then-ready path exits 0"
@@ -371,7 +370,7 @@ printf '%s\n' "$ECHO_SCREEN" > "$OT_TMUX_CAPTURES/1"
 printf '%s\n' "$READY_SCREEN" > "$OT_TMUX_CAPTURES/2"
 printf '%s\n' "$READY_SCREEN" > "$OT_TMUX_CAPTURES/3"
 set +e
-c7_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c7.err")
+c7_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c7.err")
 c7_code=$?
 set -e
 assert_eq "$c7_code" "1" "undelivered brief exits nonzero"
@@ -388,7 +387,7 @@ assert_eq "$c7_resends" "1" "re-send is attempted exactly once before failing"
 new_tmux_state c8
 printf '%s\n' "$COMPOSER_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c8_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c8.err")
+c8_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c8.err")
 c8_code=$?
 set -e
 assert_eq "$c8_code" "1" "composer-only screen exits nonzero"
@@ -406,7 +405,7 @@ assert_eq "$c8_resends" "1" "composer-only screen still gets exactly one re-send
 new_tmux_state c8b
 { printf '%s\n' "$DELIVERED_SCREEN"; awk 'BEGIN { for (i = 0; i < 20000; i++) print "transcript filler line" }'; } > "$OT_TMUX_CAPTURES/1"
 set +e
-c8b_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c8b.err")
+c8b_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c8b.err")
 c8b_code=$?
 set -e
 assert_eq "$c8b_code" "0" "huge scrollback with an early delivered brief exits 0"
@@ -421,7 +420,7 @@ echo "=== open-terminal claude handoff: tmux failure detection ==="
 new_tmux_state c9
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c9_out=$(TMUX=stub,1,0 OT_TMUX_FAIL=new-window ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c9.err")
+c9_out=$(TMUX=stub,1,0 OT_TMUX_FAIL=new-window ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c9.err")
 c9_code=$?
 set -e
 assert_eq "$c9_code" "1" "new-window failure exits nonzero"
@@ -434,7 +433,7 @@ assert_not_contains "$c9_out" "Done: launched 1" \
 # early return must not count a window whose launch keystrokes failed.
 new_tmux_state c10
 set +e
-c10_out=$(TMUX=stub,1,0 OT_TMUX_FAIL=send-keys ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness codex cc-737 2>"$TMP_ROOT/c10.err")
+c10_out=$(TMUX=stub,1,0 OT_TMUX_FAIL=send-keys ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness codex cc-737 2>"$TMP_ROOT/c10.err")
 c10_code=$?
 set -e
 assert_eq "$c10_code" "1" "send-keys failure exits nonzero on a briefless lane"
@@ -449,7 +448,7 @@ echo "=== open-terminal claude handoff: config validation ==="
 # command, so it must never pass through unvalidated.
 CAP11="$TMP_ROOT/cap11"
 set +e
-c11_out=$(OT_CAPTURE="$CAP11" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--flag; touch $TMP_ROOT/pwned" cc-737 2>"$TMP_ROOT/c11.err")
+c11_out=$(OT_CAPTURE="$CAP11" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--flag; touch $TMP_ROOT/pwned" cc-737 2>"$TMP_ROOT/c11.err")
 c11_code=$?
 set -e
 assert_eq "$c11_code" "1" "metacharacter launch flags refuse to launch"
@@ -466,7 +465,7 @@ fi
 # Case 11b: a bracketed model id is an ordinary flag value, not a shell hazard.
 CAP11B="$TMP_ROOT/cap11b"
 set +e
-OT_CAPTURE="$CAP11B" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--model opus[1m] --dangerously-skip-permissions" cc-737 2>"$TMP_ROOT/c11b.err"
+OT_CAPTURE="$CAP11B" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--model opus[1m] --dangerously-skip-permissions" cc-737 2>"$TMP_ROOT/c11b.err"
 c11b_code=$?
 set -e
 assert_eq "$c11b_code" "0" "a bracketed model id is accepted"
@@ -487,7 +486,7 @@ printf '%s\n' "$@" > "$OT_ARGV_CAPTURE"
 EOF
   chmod +x "$BIN/claude"
   c11c_argv="$TMP_ROOT/c11c.argv"
-  (cd "$c11c_dir" && OT_ARGV_CAPTURE="$c11c_argv" PATH="$BIN:$SEALED:$PATH" bash -lc "${c11c_cmd##*&& }") >/dev/null 2>&1 || true
+  (cd "$c11c_dir" && OT_ARGV_CAPTURE="$c11c_argv" PATH="$BIN:$PATH" bash -lc "${c11c_cmd##*&& }") >/dev/null 2>&1 || true
   assert_contains "$(cat "$c11c_argv" 2>/dev/null || true)" "opus[1m]" \
     "the bracketed model id survives the shell that runs the launch command"
   assert_not_contains "$(cat "$c11c_argv" 2>/dev/null || true)" "opus1" \
@@ -503,7 +502,7 @@ fi
 new_tmux_state c12
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c12_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=abc PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c12.err")
+c12_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=abc PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c12.err")
 c12_code=$?
 set -e
 assert_eq "$c12_code" "1" "non-integer verify secs exits nonzero"
@@ -516,7 +515,7 @@ assert_not_contains "$(cat "$TMP_ROOT/c12.err")" "brief undelivered" \
 new_tmux_state c13
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c13_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=0 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c13.err")
+c13_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=0 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c13.err")
 c13_code=$?
 set -e
 assert_eq "$c13_code" "1" "zero verify secs exits nonzero"
@@ -528,7 +527,7 @@ assert_contains "$(cat "$TMP_ROOT/c13.err")" "ORCH_TMUX_VERIFY_SECS" \
 new_tmux_state c13b
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c13b_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=08 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c13b.err")
+c13b_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=08 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c13b.err")
 c13b_code=$?
 set -e
 assert_eq "$c13b_code" "0" "leading-zero verify secs is base-10 and launches"
@@ -540,7 +539,7 @@ assert_not_contains "$(cat "$TMP_ROOT/c13b.err")" "value too great" \
 new_tmux_state c13c
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c13c_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=10000000000000000000 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c13c.err")
+c13c_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=10000000000000000000 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c13c.err")
 c13c_code=$?
 set -e
 assert_eq "$c13c_code" "0" "overflow-sized verify secs still launches (clamped)"
@@ -553,7 +552,7 @@ assert_eq "$c13c_resends" "0" "no instant resend from a zero-pass verify loop"
 # never reads it.
 CAP13D="$TMP_ROOT/cap13d"
 set +e
-c13d_out=$(ORCH_TMUX_VERIFY_SECS=abc OT_CAPTURE="$CAP13D" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude cc-737 2>"$TMP_ROOT/c13d.err")
+c13d_out=$(ORCH_TMUX_VERIFY_SECS=abc OT_CAPTURE="$CAP13D" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude cc-737 2>"$TMP_ROOT/c13d.err")
 c13d_code=$?
 set -e
 assert_eq "$c13d_code" "0" "invalid verify secs does not abort a GUI launch"
@@ -564,7 +563,7 @@ assert_not_contains "$(cat "$TMP_ROOT/c13d.err")" "ORCH_TMUX_VERIFY_SECS" \
 # only Claude verification lanes read the timeout.
 new_tmux_state c13e
 set +e
-c13e_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=abc PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness codex cc-737 2>"$TMP_ROOT/c13e.err")
+c13e_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=abc PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness codex cc-737 2>"$TMP_ROOT/c13e.err")
 c13e_code=$?
 set -e
 assert_eq "$c13e_code" "0" "invalid verify secs does not abort a tmux codex launch"
@@ -576,7 +575,7 @@ assert_not_contains "$(cat "$TMP_ROOT/c13e.err")" "ORCH_TMUX_VERIFY_SECS" \
 new_tmux_state c14
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c14_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=99999 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c14.err")
+c14_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=99999 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c14.err")
 c14_code=$?
 set -e
 assert_eq "$c14_code" "0" "clamped verify secs still launches"

--- a/.agents/skills/orch/tests/open-terminal-claude-handoff.sh
+++ b/.agents/skills/orch/tests/open-terminal-claude-handoff.sh
@@ -28,6 +28,8 @@ set -euo pipefail
 TC=" — complete means the PR is MERGED and the worktree cleaned up, not merely opened"
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/sealed-bin.sh
+. "$TEST_DIR/lib/sealed-bin.sh"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 SRC_OT="$SCRIPTS_DIR/open-terminal"
 SRC_LIB_DIR="$SCRIPTS_DIR/lib"
@@ -115,9 +117,8 @@ exit 0
 EOF
 chmod +x "$BIN/ghostty" "$BIN/gh" "$BIN/tmux"
 
-# $TERMINAL is what open_gui reaches for first, so it is PINNED to the stub on
-# PATH here: unset, the branch below it would resolve whatever terminal the
-# developer's desktop provides and this suite would open real windows.
+# open_gui reaches for $TERMINAL first, so it names the stub rather than the
+# developer's own terminal. $SEALED is what answers once the stub tree is gone.
 export TERMINAL=ghostty
 
 # Stub worktree CLI: `create <item>` makes and prints a temp dir.
@@ -208,7 +209,7 @@ echo "=== open-terminal claude handoff: per-task launch flags ==="
 # Case 1: linear:claude renders the autonomy flag by default.
 CAP1="$TMP_ROOT/cap1"
 set +e
-c1_out=$(OT_CAPTURE="$CAP1" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--model opus[1m] --effort max --dangerously-skip-permissions" cc-737 2>"$TMP_ROOT/c1.err")
+c1_out=$(OT_CAPTURE="$CAP1" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--model opus[1m] --effort max --dangerously-skip-permissions" cc-737 2>"$TMP_ROOT/c1.err")
 c1_code=$?
 set -e
 assert_eq "$c1_code" "0" "linear:claude launch succeeds"
@@ -226,7 +227,7 @@ assert_not_contains "$(cat "$TMP_ROOT/c1.err")" "WARNING" \
 # Case 2: github:claude renders the same flag.
 CAP2="$TMP_ROOT/cap2"
 set +e
-c2_out=$(OT_CAPTURE="$CAP2" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tracker github --repo acme/widgets --ghostty --harness claude --launch-flags "--effort max --dangerously-skip-permissions" 42 2>"$TMP_ROOT/c2.err")
+c2_out=$(OT_CAPTURE="$CAP2" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tracker github --repo acme/widgets --ghostty --harness claude --launch-flags "--effort max --dangerously-skip-permissions" 42 2>"$TMP_ROOT/c2.err")
 c2_code=$?
 set -e
 assert_eq "$c2_code" "0" "github:claude launch succeeds"
@@ -244,7 +245,7 @@ fi
 # settings file participates.
 CAP3="$TMP_ROOT/cap3"
 set +e
-c3_out=$(OT_CAPTURE="$CAP3" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--model sonnet --permission-mode bypassPermissions" cc-737 2>"$TMP_ROOT/c3.err")
+c3_out=$(OT_CAPTURE="$CAP3" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--model sonnet --permission-mode bypassPermissions" cc-737 2>"$TMP_ROOT/c3.err")
 c3_code=$?
 set -e
 assert_eq "$c3_code" "0" "a second launch with different flags succeeds"
@@ -265,7 +266,7 @@ assert_not_contains "$(cat "$TMP_ROOT/c3.err")" "WARNING" \
 # would type — no stored model, effort, or permission default appears.
 CAP3B="$TMP_ROOT/cap3b"
 set +e
-OT_CAPTURE="$CAP3B" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude cc-737 2>"$TMP_ROOT/c3b.err"
+OT_CAPTURE="$CAP3B" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude cc-737 2>"$TMP_ROOT/c3b.err"
 set -e
 if wait_capture "$CAP3B"; then
   c3b_cmd="$(cat "$CAP3B")"
@@ -284,7 +285,7 @@ assert_contains "$(cat "$TMP_ROOT/c3b.err")" "handoff autonomy is void" \
 # autonomy is void.
 CAP4="$TMP_ROOT/cap4"
 set +e
-c4_out=$(OT_CAPTURE="$CAP4" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--permission-mode plan" cc-737 2>"$TMP_ROOT/c4.err")
+c4_out=$(OT_CAPTURE="$CAP4" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--permission-mode plan" cc-737 2>"$TMP_ROOT/c4.err")
 c4_code=$?
 set -e
 assert_eq "$c4_code" "0" "prompting flags still launch"
@@ -304,7 +305,7 @@ echo "=== open-terminal claude handoff: tmux brief delivery ==="
 new_tmux_state c5
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c5_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude --launch-flags "--dangerously-skip-permissions" cc-737 2>"$TMP_ROOT/c5.err")
+c5_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude --launch-flags "--dangerously-skip-permissions" cc-737 2>"$TMP_ROOT/c5.err")
 c5_code=$?
 set -e
 assert_eq "$c5_code" "0" "tmux delivered-first-pass exits 0"
@@ -327,7 +328,7 @@ printf '%s\n' "$ECHO_SCREEN" > "$OT_TMUX_CAPTURES/1"
 printf '%s\n' "$READY_SCREEN" > "$OT_TMUX_CAPTURES/2"
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/3"
 set +e
-c6_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c6.err")
+c6_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c6.err")
 c6_code=$?
 set -e
 assert_eq "$c6_code" "0" "tmux re-delivery path exits 0"
@@ -349,7 +350,7 @@ printf '%s\n' "$ECHO_SCREEN" > "$OT_TMUX_CAPTURES/3"
 printf '%s\n' "$READY_SCREEN" > "$OT_TMUX_CAPTURES/4"
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/5"
 set +e
-c6b_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=2 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c6b.err")
+c6b_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=2 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c6b.err")
 c6b_code=$?
 set -e
 assert_eq "$c6b_code" "0" "dialog-then-ready path exits 0"
@@ -370,7 +371,7 @@ printf '%s\n' "$ECHO_SCREEN" > "$OT_TMUX_CAPTURES/1"
 printf '%s\n' "$READY_SCREEN" > "$OT_TMUX_CAPTURES/2"
 printf '%s\n' "$READY_SCREEN" > "$OT_TMUX_CAPTURES/3"
 set +e
-c7_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c7.err")
+c7_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c7.err")
 c7_code=$?
 set -e
 assert_eq "$c7_code" "1" "undelivered brief exits nonzero"
@@ -387,7 +388,7 @@ assert_eq "$c7_resends" "1" "re-send is attempted exactly once before failing"
 new_tmux_state c8
 printf '%s\n' "$COMPOSER_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c8_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c8.err")
+c8_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c8.err")
 c8_code=$?
 set -e
 assert_eq "$c8_code" "1" "composer-only screen exits nonzero"
@@ -405,7 +406,7 @@ assert_eq "$c8_resends" "1" "composer-only screen still gets exactly one re-send
 new_tmux_state c8b
 { printf '%s\n' "$DELIVERED_SCREEN"; awk 'BEGIN { for (i = 0; i < 20000; i++) print "transcript filler line" }'; } > "$OT_TMUX_CAPTURES/1"
 set +e
-c8b_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c8b.err")
+c8b_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c8b.err")
 c8b_code=$?
 set -e
 assert_eq "$c8b_code" "0" "huge scrollback with an early delivered brief exits 0"
@@ -420,7 +421,7 @@ echo "=== open-terminal claude handoff: tmux failure detection ==="
 new_tmux_state c9
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c9_out=$(TMUX=stub,1,0 OT_TMUX_FAIL=new-window ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c9.err")
+c9_out=$(TMUX=stub,1,0 OT_TMUX_FAIL=new-window ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c9.err")
 c9_code=$?
 set -e
 assert_eq "$c9_code" "1" "new-window failure exits nonzero"
@@ -433,7 +434,7 @@ assert_not_contains "$c9_out" "Done: launched 1" \
 # early return must not count a window whose launch keystrokes failed.
 new_tmux_state c10
 set +e
-c10_out=$(TMUX=stub,1,0 OT_TMUX_FAIL=send-keys ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness codex cc-737 2>"$TMP_ROOT/c10.err")
+c10_out=$(TMUX=stub,1,0 OT_TMUX_FAIL=send-keys ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness codex cc-737 2>"$TMP_ROOT/c10.err")
 c10_code=$?
 set -e
 assert_eq "$c10_code" "1" "send-keys failure exits nonzero on a briefless lane"
@@ -448,7 +449,7 @@ echo "=== open-terminal claude handoff: config validation ==="
 # command, so it must never pass through unvalidated.
 CAP11="$TMP_ROOT/cap11"
 set +e
-c11_out=$(OT_CAPTURE="$CAP11" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--flag; touch $TMP_ROOT/pwned" cc-737 2>"$TMP_ROOT/c11.err")
+c11_out=$(OT_CAPTURE="$CAP11" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--flag; touch $TMP_ROOT/pwned" cc-737 2>"$TMP_ROOT/c11.err")
 c11_code=$?
 set -e
 assert_eq "$c11_code" "1" "metacharacter launch flags refuse to launch"
@@ -465,7 +466,7 @@ fi
 # Case 11b: a bracketed model id is an ordinary flag value, not a shell hazard.
 CAP11B="$TMP_ROOT/cap11b"
 set +e
-OT_CAPTURE="$CAP11B" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--model opus[1m] --dangerously-skip-permissions" cc-737 2>"$TMP_ROOT/c11b.err"
+OT_CAPTURE="$CAP11B" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--model opus[1m] --dangerously-skip-permissions" cc-737 2>"$TMP_ROOT/c11b.err"
 c11b_code=$?
 set -e
 assert_eq "$c11b_code" "0" "a bracketed model id is accepted"
@@ -486,7 +487,7 @@ printf '%s\n' "$@" > "$OT_ARGV_CAPTURE"
 EOF
   chmod +x "$BIN/claude"
   c11c_argv="$TMP_ROOT/c11c.argv"
-  (cd "$c11c_dir" && OT_ARGV_CAPTURE="$c11c_argv" PATH="$BIN:$PATH" bash -lc "${c11c_cmd##*&& }") >/dev/null 2>&1 || true
+  (cd "$c11c_dir" && OT_ARGV_CAPTURE="$c11c_argv" PATH="$BIN:$SEALED:$PATH" bash -lc "${c11c_cmd##*&& }") >/dev/null 2>&1 || true
   assert_contains "$(cat "$c11c_argv" 2>/dev/null || true)" "opus[1m]" \
     "the bracketed model id survives the shell that runs the launch command"
   assert_not_contains "$(cat "$c11c_argv" 2>/dev/null || true)" "opus1" \
@@ -502,7 +503,7 @@ fi
 new_tmux_state c12
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c12_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=abc PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c12.err")
+c12_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=abc PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c12.err")
 c12_code=$?
 set -e
 assert_eq "$c12_code" "1" "non-integer verify secs exits nonzero"
@@ -515,7 +516,7 @@ assert_not_contains "$(cat "$TMP_ROOT/c12.err")" "brief undelivered" \
 new_tmux_state c13
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c13_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=0 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c13.err")
+c13_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=0 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c13.err")
 c13_code=$?
 set -e
 assert_eq "$c13_code" "1" "zero verify secs exits nonzero"
@@ -527,7 +528,7 @@ assert_contains "$(cat "$TMP_ROOT/c13.err")" "ORCH_TMUX_VERIFY_SECS" \
 new_tmux_state c13b
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c13b_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=08 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c13b.err")
+c13b_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=08 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c13b.err")
 c13b_code=$?
 set -e
 assert_eq "$c13b_code" "0" "leading-zero verify secs is base-10 and launches"
@@ -539,7 +540,7 @@ assert_not_contains "$(cat "$TMP_ROOT/c13b.err")" "value too great" \
 new_tmux_state c13c
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c13c_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=10000000000000000000 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c13c.err")
+c13c_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=10000000000000000000 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c13c.err")
 c13c_code=$?
 set -e
 assert_eq "$c13c_code" "0" "overflow-sized verify secs still launches (clamped)"
@@ -552,7 +553,7 @@ assert_eq "$c13c_resends" "0" "no instant resend from a zero-pass verify loop"
 # never reads it.
 CAP13D="$TMP_ROOT/cap13d"
 set +e
-c13d_out=$(ORCH_TMUX_VERIFY_SECS=abc OT_CAPTURE="$CAP13D" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude cc-737 2>"$TMP_ROOT/c13d.err")
+c13d_out=$(ORCH_TMUX_VERIFY_SECS=abc OT_CAPTURE="$CAP13D" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude cc-737 2>"$TMP_ROOT/c13d.err")
 c13d_code=$?
 set -e
 assert_eq "$c13d_code" "0" "invalid verify secs does not abort a GUI launch"
@@ -563,7 +564,7 @@ assert_not_contains "$(cat "$TMP_ROOT/c13d.err")" "ORCH_TMUX_VERIFY_SECS" \
 # only Claude verification lanes read the timeout.
 new_tmux_state c13e
 set +e
-c13e_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=abc PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness codex cc-737 2>"$TMP_ROOT/c13e.err")
+c13e_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=abc PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness codex cc-737 2>"$TMP_ROOT/c13e.err")
 c13e_code=$?
 set -e
 assert_eq "$c13e_code" "0" "invalid verify secs does not abort a tmux codex launch"
@@ -575,7 +576,7 @@ assert_not_contains "$(cat "$TMP_ROOT/c13e.err")" "ORCH_TMUX_VERIFY_SECS" \
 new_tmux_state c14
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c14_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=99999 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c14.err")
+c14_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=99999 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c14.err")
 c14_code=$?
 set -e
 assert_eq "$c14_code" "0" "clamped verify secs still launches"

--- a/.agents/skills/orch/tests/open-terminal-codex-prompt.sh
+++ b/.agents/skills/orch/tests/open-terminal-codex-prompt.sh
@@ -80,6 +80,11 @@ exit 1
 EOF
 chmod +x "$BIN/ghostty" "$BIN/gh"
 
+# $TERMINAL is what open_gui reaches for first, so it is PINNED to the stub on
+# PATH here: unset, the branch below it would resolve whatever terminal the
+# developer's desktop provides and this suite would open real windows.
+export TERMINAL=ghostty
+
 # Stub worktree CLI: `create <item>` makes and prints a temp dir.
 STUB="$TMP_ROOT/worktree-stub"
 cat > "$STUB" <<EOF

--- a/.agents/skills/orch/tests/open-terminal-codex-prompt.sh
+++ b/.agents/skills/orch/tests/open-terminal-codex-prompt.sh
@@ -21,6 +21,8 @@ set -euo pipefail
 TC=" — complete means the PR is MERGED and the worktree cleaned up, not merely opened"
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/sealed-bin.sh
+. "$TEST_DIR/lib/sealed-bin.sh"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 SRC_OT="$SCRIPTS_DIR/open-terminal"
 SRC_LIB_DIR="$SCRIPTS_DIR/lib"
@@ -80,9 +82,8 @@ exit 1
 EOF
 chmod +x "$BIN/ghostty" "$BIN/gh"
 
-# $TERMINAL is what open_gui reaches for first, so it is PINNED to the stub on
-# PATH here: unset, the branch below it would resolve whatever terminal the
-# developer's desktop provides and this suite would open real windows.
+# open_gui reaches for $TERMINAL first, so it names the stub rather than the
+# developer's own terminal. $SEALED is what answers once the stub tree is gone.
 export TERMINAL=ghostty
 
 # Stub worktree CLI: `create <item>` makes and prints a temp dir.
@@ -128,7 +129,7 @@ echo "=== open-terminal codex kickoff prompt ==="
 # downstream shell layer could expand.
 CAP1="$TMP_ROOT/cap1"
 set +e
-c1_out=$(OT_CAPTURE="$CAP1" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness codex cc-737 2>"$TMP_ROOT/c1.err")
+c1_out=$(OT_CAPTURE="$CAP1" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness codex cc-737 2>"$TMP_ROOT/c1.err")
 c1_code=$?
 set -e
 assert_eq "$c1_code" "0" "linear:codex launch succeeds"
@@ -146,7 +147,7 @@ fi
 # Case 2: github:codex — same prose shape carrying repo#item.
 CAP2="$TMP_ROOT/cap2"
 set +e
-c2_out=$(OT_CAPTURE="$CAP2" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tracker github --repo acme/widgets --ghostty --harness codex 42 2>"$TMP_ROOT/c2.err")
+c2_out=$(OT_CAPTURE="$CAP2" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tracker github --repo acme/widgets --ghostty --harness codex 42 2>"$TMP_ROOT/c2.err")
 c2_code=$?
 set -e
 assert_eq "$c2_code" "0" "github:codex launch succeeds"

--- a/.agents/skills/orch/tests/open-terminal-codex-prompt.sh
+++ b/.agents/skills/orch/tests/open-terminal-codex-prompt.sh
@@ -21,8 +21,6 @@ set -euo pipefail
 TC=" — complete means the PR is MERGED and the worktree cleaned up, not merely opened"
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=lib/sealed-bin.sh
-. "$TEST_DIR/lib/sealed-bin.sh"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 SRC_OT="$SCRIPTS_DIR/open-terminal"
 SRC_LIB_DIR="$SCRIPTS_DIR/lib"
@@ -82,8 +80,9 @@ exit 1
 EOF
 chmod +x "$BIN/ghostty" "$BIN/gh"
 
-# open_gui reaches for $TERMINAL first, so it names the stub rather than the
-# developer's own terminal. $SEALED is what answers once the stub tree is gone.
+# $TERMINAL is what open_gui reaches for first, so it is PINNED to the stub on
+# PATH here: unset, the branch below it would resolve whatever terminal the
+# developer's desktop provides and this suite would open real windows.
 export TERMINAL=ghostty
 
 # Stub worktree CLI: `create <item>` makes and prints a temp dir.
@@ -129,7 +128,7 @@ echo "=== open-terminal codex kickoff prompt ==="
 # downstream shell layer could expand.
 CAP1="$TMP_ROOT/cap1"
 set +e
-c1_out=$(OT_CAPTURE="$CAP1" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness codex cc-737 2>"$TMP_ROOT/c1.err")
+c1_out=$(OT_CAPTURE="$CAP1" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness codex cc-737 2>"$TMP_ROOT/c1.err")
 c1_code=$?
 set -e
 assert_eq "$c1_code" "0" "linear:codex launch succeeds"
@@ -147,7 +146,7 @@ fi
 # Case 2: github:codex — same prose shape carrying repo#item.
 CAP2="$TMP_ROOT/cap2"
 set +e
-c2_out=$(OT_CAPTURE="$CAP2" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tracker github --repo acme/widgets --ghostty --harness codex 42 2>"$TMP_ROOT/c2.err")
+c2_out=$(OT_CAPTURE="$CAP2" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tracker github --repo acme/widgets --ghostty --harness codex 42 2>"$TMP_ROOT/c2.err")
 c2_code=$?
 set -e
 assert_eq "$c2_code" "0" "github:codex launch succeeds"

--- a/.agents/skills/orch/tests/open-terminal-issue-id.sh
+++ b/.agents/skills/orch/tests/open-terminal-issue-id.sh
@@ -57,6 +57,11 @@ exit 1
 EOF
 chmod +x "$BIN/ghostty" "$BIN/gh"
 
+# $TERMINAL is what open_gui reaches for first, so it is PINNED to the stub on
+# PATH here: unset, the branch below it would resolve whatever terminal the
+# developer's desktop provides and this suite would open real windows.
+export TERMINAL=ghostty
+
 # Stub worktree CLI: `create <item>` makes and prints a temp dir.
 STUB="$TMP_ROOT/worktree-stub"
 cat > "$STUB" <<EOF

--- a/.agents/skills/orch/tests/open-terminal-issue-id.sh
+++ b/.agents/skills/orch/tests/open-terminal-issue-id.sh
@@ -12,8 +12,6 @@
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=lib/sealed-bin.sh
-. "$TEST_DIR/lib/sealed-bin.sh"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 SRC_OT="$SCRIPTS_DIR/open-terminal"
 SRC_LIB_DIR="$SCRIPTS_DIR/lib"
@@ -59,8 +57,9 @@ exit 1
 EOF
 chmod +x "$BIN/ghostty" "$BIN/gh"
 
-# open_gui reaches for $TERMINAL first, so it names the stub rather than the
-# developer's own terminal. $SEALED is what answers once the stub tree is gone.
+# $TERMINAL is what open_gui reaches for first, so it is PINNED to the stub on
+# PATH here: unset, the branch below it would resolve whatever terminal the
+# developer's desktop provides and this suite would open real windows.
 export TERMINAL=ghostty
 
 # Stub worktree CLI: `create <item>` makes and prints a temp dir.
@@ -102,14 +101,14 @@ OT_A="$(make_ot_repo "$REPO_A")"
 
 # Case 1: default pattern normalizes lowercase and uppercase input to uppercase.
 set +e
-c1a_out=$(PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' cc-737 2>"$TMP_ROOT/c1a.err")
+c1a_out=$(PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' cc-737 2>"$TMP_ROOT/c1a.err")
 c1a_code=$?
 set -e
 assert_eq "$c1a_code" "0" "default pattern: lowercase input accepted"
 assert_contains "$c1a_out" "Opened terminal 'CC-737'" "default pattern: cc-737 normalizes to CC-737"
 
 set +e
-c1b_out=$(PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' CC-737 2>"$TMP_ROOT/c1b.err")
+c1b_out=$(PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' CC-737 2>"$TMP_ROOT/c1b.err")
 c1b_code=$?
 set -e
 assert_eq "$c1b_code" "0" "default pattern: uppercase input accepted"
@@ -125,14 +124,14 @@ GH_ISSUE_PATTERN = "ZZ-[0-9]+"')"
 
 # Case 2: lowercase pattern normalizes uppercase and lowercase input to lowercase.
 set +e
-c2a_out=$(GH_ISSUE_PATTERN='cc-[0-9]+' PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT_B" --ghostty --cmd 'echo {item}' CC-737 2>"$TMP_ROOT/c2a.err")
+c2a_out=$(GH_ISSUE_PATTERN='cc-[0-9]+' PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_B" --ghostty --cmd 'echo {item}' CC-737 2>"$TMP_ROOT/c2a.err")
 c2a_code=$?
 set -e
 assert_eq "$c2a_code" "0" "lowercase pattern (parent env wins over settings): uppercase input accepted"
 assert_contains "$c2a_out" "Opened terminal 'cc-737'" "lowercase pattern: CC-737 normalizes to cc-737"
 
 set +e
-c2b_out=$(GH_ISSUE_PATTERN='cc-[0-9]+' PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT_B" --ghostty --cmd 'echo {item}' cc-737 2>"$TMP_ROOT/c2b.err")
+c2b_out=$(GH_ISSUE_PATTERN='cc-[0-9]+' PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_B" --ghostty --cmd 'echo {item}' cc-737 2>"$TMP_ROOT/c2b.err")
 c2b_code=$?
 set -e
 assert_eq "$c2b_code" "0" "lowercase pattern: lowercase input accepted"
@@ -140,7 +139,7 @@ assert_contains "$c2b_out" "Opened terminal 'cc-737'" "lowercase pattern: cc-737
 
 # Case 3: an id that matches no case of the default pattern is rejected.
 set +e
-c3_out=$(PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' 12ab 2>"$TMP_ROOT/c3.err")
+c3_out=$(PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' 12ab 2>"$TMP_ROOT/c3.err")
 c3_code=$?
 set -e
 assert_eq "$c3_code" "1" "invalid id exits nonzero"

--- a/.agents/skills/orch/tests/open-terminal-issue-id.sh
+++ b/.agents/skills/orch/tests/open-terminal-issue-id.sh
@@ -12,6 +12,8 @@
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/sealed-bin.sh
+. "$TEST_DIR/lib/sealed-bin.sh"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 SRC_OT="$SCRIPTS_DIR/open-terminal"
 SRC_LIB_DIR="$SCRIPTS_DIR/lib"
@@ -57,9 +59,8 @@ exit 1
 EOF
 chmod +x "$BIN/ghostty" "$BIN/gh"
 
-# $TERMINAL is what open_gui reaches for first, so it is PINNED to the stub on
-# PATH here: unset, the branch below it would resolve whatever terminal the
-# developer's desktop provides and this suite would open real windows.
+# open_gui reaches for $TERMINAL first, so it names the stub rather than the
+# developer's own terminal. $SEALED is what answers once the stub tree is gone.
 export TERMINAL=ghostty
 
 # Stub worktree CLI: `create <item>` makes and prints a temp dir.
@@ -101,14 +102,14 @@ OT_A="$(make_ot_repo "$REPO_A")"
 
 # Case 1: default pattern normalizes lowercase and uppercase input to uppercase.
 set +e
-c1a_out=$(PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' cc-737 2>"$TMP_ROOT/c1a.err")
+c1a_out=$(PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' cc-737 2>"$TMP_ROOT/c1a.err")
 c1a_code=$?
 set -e
 assert_eq "$c1a_code" "0" "default pattern: lowercase input accepted"
 assert_contains "$c1a_out" "Opened terminal 'CC-737'" "default pattern: cc-737 normalizes to CC-737"
 
 set +e
-c1b_out=$(PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' CC-737 2>"$TMP_ROOT/c1b.err")
+c1b_out=$(PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' CC-737 2>"$TMP_ROOT/c1b.err")
 c1b_code=$?
 set -e
 assert_eq "$c1b_code" "0" "default pattern: uppercase input accepted"
@@ -124,14 +125,14 @@ GH_ISSUE_PATTERN = "ZZ-[0-9]+"')"
 
 # Case 2: lowercase pattern normalizes uppercase and lowercase input to lowercase.
 set +e
-c2a_out=$(GH_ISSUE_PATTERN='cc-[0-9]+' PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_B" --ghostty --cmd 'echo {item}' CC-737 2>"$TMP_ROOT/c2a.err")
+c2a_out=$(GH_ISSUE_PATTERN='cc-[0-9]+' PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT_B" --ghostty --cmd 'echo {item}' CC-737 2>"$TMP_ROOT/c2a.err")
 c2a_code=$?
 set -e
 assert_eq "$c2a_code" "0" "lowercase pattern (parent env wins over settings): uppercase input accepted"
 assert_contains "$c2a_out" "Opened terminal 'cc-737'" "lowercase pattern: CC-737 normalizes to cc-737"
 
 set +e
-c2b_out=$(GH_ISSUE_PATTERN='cc-[0-9]+' PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_B" --ghostty --cmd 'echo {item}' cc-737 2>"$TMP_ROOT/c2b.err")
+c2b_out=$(GH_ISSUE_PATTERN='cc-[0-9]+' PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT_B" --ghostty --cmd 'echo {item}' cc-737 2>"$TMP_ROOT/c2b.err")
 c2b_code=$?
 set -e
 assert_eq "$c2b_code" "0" "lowercase pattern: lowercase input accepted"
@@ -139,7 +140,7 @@ assert_contains "$c2b_out" "Opened terminal 'cc-737'" "lowercase pattern: cc-737
 
 # Case 3: an id that matches no case of the default pattern is rejected.
 set +e
-c3_out=$(PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' 12ab 2>"$TMP_ROOT/c3.err")
+c3_out=$(PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' 12ab 2>"$TMP_ROOT/c3.err")
 c3_code=$?
 set -e
 assert_eq "$c3_code" "1" "invalid id exits nonzero"

--- a/.agents/skills/orch/tests/open-terminal-launch-guard.sh
+++ b/.agents/skills/orch/tests/open-terminal-launch-guard.sh
@@ -16,8 +16,6 @@
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=lib/sealed-bin.sh
-. "$TEST_DIR/lib/sealed-bin.sh"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 SRC_OT="${OPEN_TERMINAL_UNDER_TEST:-$SCRIPTS_DIR/open-terminal}"
 SRC_LIB_DIR="$SCRIPTS_DIR/lib"
@@ -61,11 +59,9 @@ EOF
 chmod +x "$BIN/term" "$BIN/xdg-terminal-exec" "$BIN/tmux" "$BIN/gh"
 
 # $TERMINAL is the terminal open_gui reaches for first — the owner's ruling
-# that a GUI launch honours the user's own choice — so each run names a stub
-# and pins the branch, $OT_TERMINAL choosing which. A BARE name, never a path
-# into this mktemp tree: a path bypasses PATH resolution, and with it the seal
-# that answers once the tree is gone. On fallthrough the seal takes the branch
-# below instead.
+# that a GUI launch honours the user's own choice — so each run names a stub on
+# PATH and pins the branch, $OT_TERMINAL choosing which. Every rung below it is
+# stubbed here too, so no case can resolve the developer's own terminal.
 
 # Stub worktree CLI, one shape per $STUB_MODE:
 #   empty    exits 0 printing nothing (a stub that escaped its fixture)
@@ -106,7 +102,7 @@ run() {
   : > "$term_log"
   : > "$tmux_log"
   set +e
-  PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" STUB_MODE="$mode" \
+  PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" STUB_MODE="$mode" \
     OT_TERM_LOG="$term_log" OT_TMUX_LOG="$tmux_log" TMUX="${OT_TMUX_VALUE:-}" \
     TERMINAL="${OT_TERMINAL:-term}" \
     "$ot" --cmd 'echo {item}' "$@" >"$TMP_ROOT/$name.out" 2>"$TMP_ROOT/$name.err"

--- a/.agents/skills/orch/tests/open-terminal-launch-guard.sh
+++ b/.agents/skills/orch/tests/open-terminal-launch-guard.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # The last layer before a window opens: a launch whose working directory does
-# not exist is refused by name, on every launch path.
+# not exist is refused by name.
 #
 # The class this closes was reached repeatedly in the real fleet (KEN-1084). A
 # suite that drives `open-terminal` with a stubbed worktree CLI gets an empty
@@ -12,7 +12,7 @@
 # whatever produced the launch, without asking who did.
 #
 # Everything external is stubbed: the GUI terminal (invocations logged, so a
-# refusal that still launched is visible), tmux, gh, and the worktree CLI.
+# refusal that still launched is visible), gh, and the worktree CLI.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -34,6 +34,8 @@ assert_contains() {
 
 # Stub bin. The GUI terminal APPENDS rather than truncating, so a case that
 # expects no launch fails loudly on a stray one instead of overwriting it.
+# Every run names this stub in $TERMINAL, which open_gui reaches for first, so
+# no case can resolve the developer's own terminal.
 BIN="$TMP_ROOT/bin"
 mkdir -p "$BIN"
 cat > "$BIN/term" <<'EOF'
@@ -41,32 +43,15 @@ cat > "$BIN/term" <<'EOF'
 printf 'term %s\n' "$*" >> "$OT_TERM_LOG"
 exit 0
 EOF
-# The desktop's launcher, for the case where $TERMINAL names nothing.
-cat > "$BIN/xdg-terminal-exec" <<'EOF'
-#!/usr/bin/env bash
-printf 'xdg %s\n' "$*" >> "$OT_TERM_LOG"
-exit 0
-EOF
-cat > "$BIN/tmux" <<'EOF'
-#!/usr/bin/env bash
-printf 'tmux %s\n' "$*" >> "$OT_TMUX_LOG"
-exit 1
-EOF
 cat > "$BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 exit 1
 EOF
-chmod +x "$BIN/term" "$BIN/xdg-terminal-exec" "$BIN/tmux" "$BIN/gh"
-
-# $TERMINAL is the terminal open_gui reaches for first — the owner's ruling
-# that a GUI launch honours the user's own choice — so each run names a stub on
-# PATH and pins the branch, $OT_TERMINAL choosing which. Every rung below it is
-# stubbed here too, so no case can resolve the developer's own terminal.
+chmod +x "$BIN/term" "$BIN/gh"
 
 # Stub worktree CLI, one shape per $STUB_MODE:
 #   empty    exits 0 printing nothing (a stub that escaped its fixture)
 #   missing  prints a path that was never created (a tree removed under a lane)
-#   real     makes the directory and prints it
 STUB="$TMP_ROOT/worktree-stub"
 cat > "$STUB" <<EOF
 #!/usr/bin/env bash
@@ -75,7 +60,6 @@ set -euo pipefail
 case "\$STUB_MODE" in
   empty)   exit 0 ;;
   missing) printf '%s\n' "$TMP_ROOT/gone/\${2:-item}"; exit 0 ;;
-  real)    mkdir -p "$TMP_ROOT/wt/\${2:-item}"; printf '%s\n' "$TMP_ROOT/wt/\${2:-item}"; exit 0 ;;
 esac
 exit 1
 EOF
@@ -94,17 +78,15 @@ stage() {
 REPO="$TMP_ROOT/repo"
 stage "$REPO" "$SRC_OT"
 
-# run NAME OT MODE ARGS... — sets RC, ERR, TERM_LOG_TEXT and TMUX_LOG_TEXT.
+# run NAME OT MODE ARGS... — sets RC, ERR and TERM_LOG_TEXT.
 run() {
   local name="$1" ot="$2" mode="$3"
   shift 3
-  local term_log="$TMP_ROOT/$name.term" tmux_log="$TMP_ROOT/$name.tmux"
+  local term_log="$TMP_ROOT/$name.term"
   : > "$term_log"
-  : > "$tmux_log"
   set +e
   PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" STUB_MODE="$mode" \
-    OT_TERM_LOG="$term_log" OT_TMUX_LOG="$tmux_log" TMUX="${OT_TMUX_VALUE:-}" \
-    TERMINAL="${OT_TERMINAL:-term}" \
+    OT_TERM_LOG="$term_log" TMUX="" TERMINAL=term \
     "$ot" --cmd 'echo {item}' "$@" >"$TMP_ROOT/$name.out" 2>"$TMP_ROOT/$name.err"
   RC=$?
   set -e
@@ -125,7 +107,6 @@ run() {
     sleep 1
   fi
   TERM_LOG_TEXT="$(cat "$term_log")"
-  TMUX_LOG_TEXT="$(cat "$tmux_log")"
 }
 
 echo "=== open-terminal: a launch at a working directory that is gone is refused ==="
@@ -141,42 +122,6 @@ assert_eq "$RC" "1" "a GUI launch at a deleted worktree fails the item"
 assert_contains "$ERR" "Error: refusing to launch 'CC-1': working directory '$TMP_ROOT/gone/CC-1' does not exist" \
   "the refusal names the directory that is gone"
 assert_eq "$TERM_LOG_TEXT" "" "no terminal was launched at the deleted directory"
-
-# The tmux path refuses at the same layer, before the first tmux call: a window
-# created with `-c` at a missing directory is the same broken lane.
-# TMUX travels through the run helper, never as an assignment prefixed onto a
-# function call: bash keeps such an assignment in the shell after the call, and
-# it would then decide the mode of every case below.
-OT_TMUX_VALUE=stub,1,0
-run tmux_missing "$REPO/scripts/open-terminal" missing --tmux CC-1
-OT_TMUX_VALUE=""
-assert_eq "$RC" "1" "a tmux launch at a deleted worktree fails the item"
-assert_contains "$ERR" "Error: refusing to launch 'CC-1': working directory '$TMP_ROOT/gone/CC-1' does not exist" \
-  "the tmux path refuses in the same words"
-assert_eq "$TMUX_LOG_TEXT" "" "tmux was never called for the deleted directory"
-
-# The premise: with a directory that IS there the same harness launches, and it
-# launches $TERMINAL. Without this the refusals above would pass on a harness
-# that could not launch anything at all.
-run real "$REPO/scripts/open-terminal" real --ghostty CC-1
-assert_eq "$RC" "0" "premise: a launch at a real directory succeeds"
-assert_contains "$TERM_LOG_TEXT" "term -e bash -lc" "premise: and \$TERMINAL is the terminal it launched"
-# Only the ghostty arm has a --title flag and it is the last one tried, so the
-# title is written from inside the launched shell or it is not written at all.
-assert_contains "$TERM_LOG_TEXT" "printf '\033]0;%s\007' 'CC-1'" \
-  "the launched shell sets the window title to the item"
-
-# A $TERMINAL naming nothing on PATH is substituted; saying so is the difference
-# between an operator's choice being honoured and being quietly overridden.
-OT_TERMINAL=no-such-terminal-anywhere
-run unresolved "$REPO/scripts/open-terminal" real --ghostty CC-1
-OT_TERMINAL=""
-assert_eq "$RC" "0" "an unresolvable \$TERMINAL still launches through the fallback"
-assert_contains "$ERR" "Warning: \$TERMINAL 'no-such-terminal-anywhere' does not resolve to an executable; launching 'CC-1' with xdg-terminal-exec instead" \
-  "the substitution names the value and the terminal used instead"
-assert_contains "$TERM_LOG_TEXT" "xdg bash -lc" "and the fallback launcher is the one that ran"
-assert_contains "$TERM_LOG_TEXT" "printf '\033]0;%s\007' 'CC-1'" \
-  "the title survives the fallback branch too"
 
 echo
 echo "=== the refusal can fail: with the guard gone the window opens ==="

--- a/.agents/skills/orch/tests/open-terminal-launch-guard.sh
+++ b/.agents/skills/orch/tests/open-terminal-launch-guard.sh
@@ -102,6 +102,21 @@ run() {
   RC=$?
   set -e
   ERR="$(cat "$TMP_ROOT/$name.err")"
+  # open_gui detaches the launch (`setsid ... &`), so the stub's line can land
+  # after open-terminal has already exited — on a loaded box it did, and the
+  # case read an empty log. Which wait to take is DERIVED from the script's own
+  # report rather than from a flag each call site remembers: an exit 0 says a
+  # launch was started, so wait for its line; any other status says none was, so
+  # watch a real interval and prove none appears.
+  local i=0
+  if [[ "$RC" -eq 0 ]]; then
+    while [ "$i" -lt 100 ] && [ ! -s "$term_log" ]; do
+      sleep 0.1
+      i=$((i + 1))
+    done
+  else
+    sleep 1
+  fi
   TERM_LOG_TEXT="$(cat "$term_log")"
   TMUX_LOG_TEXT="$(cat "$tmux_log")"
 }
@@ -143,9 +158,10 @@ assert_contains "$TERM_LOG_TEXT" "term -e bash -lc" "premise: and \$TERMINAL is 
 echo
 echo "=== the refusal can fail: with the guard gone the window opens ==="
 
-# The must-fail control. `launchable_dir` is the whole protection, so the
-# mutation is its one test — with that gone the function returns 0 for every
-# path and the launch proceeds exactly as it did before this guard existed.
+# The must-fail control, run over BOTH shapes the guard refuses. `launchable_dir`
+# is the whole protection, so the mutation is its one test — with that gone the
+# function returns 0 for every path and each launch proceeds exactly as it did
+# before this guard existed.
 MUTANT="$TMP_ROOT/mutant"
 mkdir -p "$MUTANT"
 sed 's/\[\[ -d "$1" \]\] && return 0/return 0/' "$SRC_OT" > "$MUTANT/open-terminal"
@@ -158,9 +174,17 @@ MUTANT_REPO="$TMP_ROOT/mutant-repo"
 stage "$MUTANT_REPO" "$MUTANT/open-terminal"
 
 run mutant "$MUTANT_REPO/scripts/open-terminal" missing --ghostty CC-1
-assert_eq "$RC" "0" "control: without the guard the launch is reported as successful"
+assert_eq "$RC" "0" "control: without the guard the deleted-path launch is reported as successful"
 assert_contains "$TERM_LOG_TEXT" "term -e bash -lc" \
   "control: and a terminal really is opened at the directory that is gone"
+
+# The empty path is the shape the leak actually took, so it carries its own
+# control rather than riding on the deleted one: a guard written as a stat of a
+# non-empty path would refuse the case above and still launch this one.
+run mutant_empty "$MUTANT_REPO/scripts/open-terminal" empty --ghostty CC-1
+assert_eq "$RC" "0" "control: without the guard the empty-path launch is reported as successful"
+assert_contains "$TERM_LOG_TEXT" "term -e bash -lc" \
+  "control: and a terminal really is opened for the empty working directory"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/.agents/skills/orch/tests/open-terminal-launch-guard.sh
+++ b/.agents/skills/orch/tests/open-terminal-launch-guard.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# The last layer before a window opens: a launch whose working directory does
+# not exist is refused by name, on every launch path.
+#
+# The class this closes was reached repeatedly in the real fleet (KEN-1084). A
+# suite that drives `open-terminal` with a stubbed worktree CLI gets an empty
+# path back the moment the stub exits 0 without printing one — the shape a
+# PATH stub leaves when its fixture tree is deleted under it — and open_gui
+# then handed that empty path to a real GUI terminal, which opened a window on
+# the operator's desktop at a directory that was gone. The same is true of any
+# lane whose worktree was removed while it ran. Refusing here closes it
+# whatever produced the launch, without asking who did.
+#
+# Everything external is stubbed: the GUI terminal (invocations logged, so a
+# refusal that still launched is visible), tmux, gh, and the worktree CLI.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
+SRC_OT="${OPEN_TERMINAL_UNDER_TEST:-$SCRIPTS_DIR/open-terminal}"
+SRC_LIB_DIR="$SCRIPTS_DIR/lib"
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+assert_eq() { [[ "$1" == "$2" ]] && ok "$3" || bad "$3" "expected: $2   got: $1"; }
+assert_contains() {
+  grep -qF -- "$2" <<<"$1" && ok "$3" || bad "$3" "wanted substring: $2
+        in: $1"
+}
+
+# Stub bin. The GUI terminal APPENDS rather than truncating, so a case that
+# expects no launch fails loudly on a stray one instead of overwriting it.
+BIN="$TMP_ROOT/bin"
+mkdir -p "$BIN"
+cat > "$BIN/term" <<'EOF'
+#!/usr/bin/env bash
+printf 'term %s\n' "$*" >> "$OT_TERM_LOG"
+exit 0
+EOF
+cat > "$BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+printf 'tmux %s\n' "$*" >> "$OT_TMUX_LOG"
+exit 1
+EOF
+cat > "$BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$BIN/term" "$BIN/tmux" "$BIN/gh"
+
+# $TERMINAL is the terminal open_gui reaches for first — the owner's ruling
+# that a GUI launch honours the user's own choice — so pointing it at the stub
+# both pins the branch and keeps every case in this file off the real desktop.
+export TERMINAL="$BIN/term"
+
+# Stub worktree CLI, one shape per $STUB_MODE:
+#   empty    exits 0 printing nothing (a stub that escaped its fixture)
+#   missing  prints a path that was never created (a tree removed under a lane)
+#   real     makes the directory and prints it
+STUB="$TMP_ROOT/worktree-stub"
+cat > "$STUB" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "\${1:-}" == "create" ]] || { echo "unexpected worktree stub call: \$*" >&2; exit 1; }
+case "\$STUB_MODE" in
+  empty)   exit 0 ;;
+  missing) printf '%s\n' "$TMP_ROOT/gone/\${2:-item}"; exit 0 ;;
+  real)    mkdir -p "$TMP_ROOT/wt/\${2:-item}"; printf '%s\n' "$TMP_ROOT/wt/\${2:-item}"; exit 0 ;;
+esac
+exit 1
+EOF
+chmod +x "$STUB"
+
+# stage DIR SRC — a copy of open-terminal in a git repo of its own, so
+# PROJECT_ROOT resolves hermetically.
+stage() {
+  mkdir -p "$1/scripts/lib"
+  cp "$2" "$1/scripts/open-terminal"
+  cp "$SRC_LIB_DIR"/*.sh "$1/scripts/lib/"
+  chmod +x "$1/scripts/open-terminal"
+  git -C "$1" init -q
+}
+
+REPO="$TMP_ROOT/repo"
+stage "$REPO" "$SRC_OT"
+
+# run NAME OT MODE ARGS... — sets RC, ERR, TERM_LOG_TEXT and TMUX_LOG_TEXT.
+run() {
+  local name="$1" ot="$2" mode="$3"
+  shift 3
+  local term_log="$TMP_ROOT/$name.term" tmux_log="$TMP_ROOT/$name.tmux"
+  : > "$term_log"
+  : > "$tmux_log"
+  set +e
+  PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" STUB_MODE="$mode" \
+    OT_TERM_LOG="$term_log" OT_TMUX_LOG="$tmux_log" TMUX="${OT_TMUX_VALUE:-}" \
+    "$ot" --cmd 'echo {item}' "$@" >"$TMP_ROOT/$name.out" 2>"$TMP_ROOT/$name.err"
+  RC=$?
+  set -e
+  ERR="$(cat "$TMP_ROOT/$name.err")"
+  TERM_LOG_TEXT="$(cat "$term_log")"
+  TMUX_LOG_TEXT="$(cat "$tmux_log")"
+}
+
+echo "=== open-terminal: a launch at a working directory that is gone is refused ==="
+
+run empty "$REPO/scripts/open-terminal" empty --ghostty CC-1
+assert_eq "$RC" "1" "a GUI launch with no worktree path fails the item"
+assert_contains "$ERR" "Error: refusing to launch 'CC-1': working directory '' does not exist" \
+  "the refusal names the item and the empty directory"
+assert_eq "$TERM_LOG_TEXT" "" "no terminal was launched for the empty path"
+
+run missing "$REPO/scripts/open-terminal" missing --ghostty CC-1
+assert_eq "$RC" "1" "a GUI launch at a deleted worktree fails the item"
+assert_contains "$ERR" "Error: refusing to launch 'CC-1': working directory '$TMP_ROOT/gone/CC-1' does not exist" \
+  "the refusal names the directory that is gone"
+assert_eq "$TERM_LOG_TEXT" "" "no terminal was launched at the deleted directory"
+
+# The tmux path refuses at the same layer, before the first tmux call: a window
+# created with `-c` at a missing directory is the same broken lane.
+# TMUX travels through the run helper, never as an assignment prefixed onto a
+# function call: bash keeps such an assignment in the shell after the call, and
+# it would then decide the mode of every case below.
+OT_TMUX_VALUE=stub,1,0
+run tmux_missing "$REPO/scripts/open-terminal" missing --tmux CC-1
+OT_TMUX_VALUE=""
+assert_eq "$RC" "1" "a tmux launch at a deleted worktree fails the item"
+assert_contains "$ERR" "Error: refusing to launch 'CC-1': working directory '$TMP_ROOT/gone/CC-1' does not exist" \
+  "the tmux path refuses in the same words"
+assert_eq "$TMUX_LOG_TEXT" "" "tmux was never called for the deleted directory"
+
+# The premise: with a directory that IS there the same harness launches, and it
+# launches $TERMINAL. Without this the refusals above would pass on a harness
+# that could not launch anything at all.
+run real "$REPO/scripts/open-terminal" real --ghostty CC-1
+assert_eq "$RC" "0" "premise: a launch at a real directory succeeds"
+assert_contains "$TERM_LOG_TEXT" "term -e bash -lc" "premise: and \$TERMINAL is the terminal it launched"
+
+echo
+echo "=== the refusal can fail: with the guard gone the window opens ==="
+
+# The must-fail control. `launchable_dir` is the whole protection, so the
+# mutation is its one test — with that gone the function returns 0 for every
+# path and the launch proceeds exactly as it did before this guard existed.
+MUTANT="$TMP_ROOT/mutant"
+mkdir -p "$MUTANT"
+sed 's/\[\[ -d "$1" \]\] && return 0/return 0/' "$SRC_OT" > "$MUTANT/open-terminal"
+if cmp -s "$SRC_OT" "$MUTANT/open-terminal"; then
+  bad "control: the mutant really drops the directory test" "the copy is byte-identical to open-terminal"
+else
+  ok "control: the mutant really drops the directory test"
+fi
+MUTANT_REPO="$TMP_ROOT/mutant-repo"
+stage "$MUTANT_REPO" "$MUTANT/open-terminal"
+
+run mutant "$MUTANT_REPO/scripts/open-terminal" missing --ghostty CC-1
+assert_eq "$RC" "0" "control: without the guard the launch is reported as successful"
+assert_contains "$TERM_LOG_TEXT" "term -e bash -lc" \
+  "control: and a terminal really is opened at the directory that is gone"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/.agents/skills/orch/tests/open-terminal-launch-guard.sh
+++ b/.agents/skills/orch/tests/open-terminal-launch-guard.sh
@@ -11,8 +11,9 @@
 # lane whose worktree was removed while it ran. Refusing here closes it
 # whatever produced the launch, without asking who did.
 #
-# Everything external is stubbed: the GUI terminal (invocations logged, so a
-# refusal that still launched is visible), gh, and the worktree CLI.
+# Everything external is stubbed: the GUI terminal and tmux (invocations
+# logged, so a refusal that still launched is visible), gh, and the worktree
+# CLI.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -43,11 +44,16 @@ cat > "$BIN/term" <<'EOF'
 printf 'term %s\n' "$*" >> "$OT_TERM_LOG"
 exit 0
 EOF
+cat > "$BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+printf 'tmux %s\n' "$*" >> "$OT_TMUX_LOG"
+exit 1
+EOF
 cat > "$BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 exit 1
 EOF
-chmod +x "$BIN/term" "$BIN/gh"
+chmod +x "$BIN/term" "$BIN/tmux" "$BIN/gh"
 
 # Stub worktree CLI, one shape per $STUB_MODE:
 #   empty    exits 0 printing nothing (a stub that escaped its fixture)
@@ -78,15 +84,17 @@ stage() {
 REPO="$TMP_ROOT/repo"
 stage "$REPO" "$SRC_OT"
 
-# run NAME OT MODE ARGS... — sets RC, ERR and TERM_LOG_TEXT.
+# run NAME OT MODE ARGS... — sets RC, ERR, TERM_LOG_TEXT and TMUX_LOG_TEXT.
 run() {
   local name="$1" ot="$2" mode="$3"
   shift 3
-  local term_log="$TMP_ROOT/$name.term"
+  local term_log="$TMP_ROOT/$name.term" tmux_log="$TMP_ROOT/$name.tmux"
   : > "$term_log"
+  : > "$tmux_log"
   set +e
   PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" STUB_MODE="$mode" \
-    OT_TERM_LOG="$term_log" TMUX="" TERMINAL=term \
+    OT_TERM_LOG="$term_log" OT_TMUX_LOG="$tmux_log" \
+    TMUX="${OT_TMUX_VALUE:-}" TERMINAL=term \
     "$ot" --cmd 'echo {item}' "$@" >"$TMP_ROOT/$name.out" 2>"$TMP_ROOT/$name.err"
   RC=$?
   set -e
@@ -107,6 +115,7 @@ run() {
     sleep 1
   fi
   TERM_LOG_TEXT="$(cat "$term_log")"
+  TMUX_LOG_TEXT="$(cat "$tmux_log")"
 }
 
 echo "=== open-terminal: a launch at a working directory that is gone is refused ==="
@@ -122,6 +131,19 @@ assert_eq "$RC" "1" "a GUI launch at a deleted worktree fails the item"
 assert_contains "$ERR" "Error: refusing to launch 'CC-1': working directory '$TMP_ROOT/gone/CC-1' does not exist" \
   "the refusal names the directory that is gone"
 assert_eq "$TERM_LOG_TEXT" "" "no terminal was launched at the deleted directory"
+
+# The tmux path refuses at the same layer, before the first tmux call: a window
+# created with `-c` at a missing directory is the same broken lane. TMUX travels
+# through the run helper, never as an assignment prefixed onto a function call:
+# bash keeps such an assignment in the shell after the call, and it would then
+# decide the mode of every case below.
+OT_TMUX_VALUE=stub,1,0
+run tmux_missing "$REPO/scripts/open-terminal" missing --tmux CC-1
+OT_TMUX_VALUE=""
+assert_eq "$RC" "1" "a tmux launch at a deleted worktree fails the item"
+assert_contains "$ERR" "Error: refusing to launch 'CC-1': working directory '$TMP_ROOT/gone/CC-1' does not exist" \
+  "the tmux path refuses in the same words"
+assert_eq "$TMUX_LOG_TEXT" "" "tmux was never called for the deleted directory"
 
 echo
 echo "=== the refusal can fail: with the guard gone the window opens ==="
@@ -153,6 +175,17 @@ run mutant_empty "$MUTANT_REPO/scripts/open-terminal" empty --ghostty CC-1
 assert_eq "$RC" "0" "control: without the guard the empty-path launch is reported as successful"
 assert_contains "$TERM_LOG_TEXT" "term -e bash -lc" \
   "control: and a terminal really is opened for the empty working directory"
+
+# The tmux path carries the same control. The stub tmux exits 1, so the item
+# fails either way and the LOG is what separates the two: refused means tmux was
+# never reached, and this case proves the tmux row above reds the moment its
+# `launchable_dir` call goes, rather than passing on a harness that could not
+# reach tmux at all.
+OT_TMUX_VALUE=stub,1,0
+run mutant_tmux "$MUTANT_REPO/scripts/open-terminal" missing --tmux CC-1
+OT_TMUX_VALUE=""
+assert_contains "$TMUX_LOG_TEXT" "tmux list-windows" \
+  "control: without the guard the tmux path really does place a window at the deleted directory"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/.agents/skills/orch/tests/open-terminal-launch-guard.sh
+++ b/.agents/skills/orch/tests/open-terminal-launch-guard.sh
@@ -16,6 +16,8 @@
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/sealed-bin.sh
+. "$TEST_DIR/lib/sealed-bin.sh"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 SRC_OT="${OPEN_TERMINAL_UNDER_TEST:-$SCRIPTS_DIR/open-terminal}"
 SRC_LIB_DIR="$SCRIPTS_DIR/lib"
@@ -27,6 +29,10 @@ FAIL=0
 ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
 bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
 assert_eq() { [[ "$1" == "$2" ]] && ok "$3" || bad "$3" "expected: $2   got: $1"; }
+assert_not_contains() {
+  grep -qF -- "$2" <<<"$1" && bad "$3" "forbidden substring: $2
+        in: $1" || ok "$3"
+}
 assert_contains() {
   grep -qF -- "$2" <<<"$1" && ok "$3" || bad "$3" "wanted substring: $2
         in: $1"
@@ -41,6 +47,18 @@ cat > "$BIN/term" <<'EOF'
 printf 'term %s\n' "$*" >> "$OT_TERM_LOG"
 exit 0
 EOF
+# The desktop's launcher, for the case where $TERMINAL names nothing, and a
+# launcher that refuses its arguments the way the GTK family refuses -e bash -lc.
+cat > "$BIN/xdg-terminal-exec" <<'EOF'
+#!/usr/bin/env bash
+printf 'xdg %s\n' "$*" >> "$OT_TERM_LOG"
+exit 0
+EOF
+cat > "$BIN/badterm" <<'EOF'
+#!/usr/bin/env bash
+echo "badterm: unrecognised option -lc" >&2
+exit 3
+EOF
 cat > "$BIN/tmux" <<'EOF'
 #!/usr/bin/env bash
 printf 'tmux %s\n' "$*" >> "$OT_TMUX_LOG"
@@ -50,12 +68,14 @@ cat > "$BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 exit 1
 EOF
-chmod +x "$BIN/term" "$BIN/tmux" "$BIN/gh"
+chmod +x "$BIN/term" "$BIN/xdg-terminal-exec" "$BIN/badterm" "$BIN/tmux" "$BIN/gh"
 
 # $TERMINAL is the terminal open_gui reaches for first — the owner's ruling
-# that a GUI launch honours the user's own choice — so pointing it at the stub
-# both pins the branch and keeps every case in this file off the real desktop.
-export TERMINAL="$BIN/term"
+# that a GUI launch honours the user's own choice — so each run names a stub
+# and pins the branch, $OT_TERMINAL choosing which. A BARE name, never a path
+# into this mktemp tree: a path bypasses PATH resolution, and with it the seal
+# that answers once the tree is gone. On fallthrough the seal takes the branch
+# below instead.
 
 # Stub worktree CLI, one shape per $STUB_MODE:
 #   empty    exits 0 printing nothing (a stub that escaped its fixture)
@@ -96,12 +116,14 @@ run() {
   : > "$term_log"
   : > "$tmux_log"
   set +e
-  PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" STUB_MODE="$mode" \
+  PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" STUB_MODE="$mode" \
     OT_TERM_LOG="$term_log" OT_TMUX_LOG="$tmux_log" TMUX="${OT_TMUX_VALUE:-}" \
+    TERMINAL="${OT_TERMINAL:-term}" \
     "$ot" --cmd 'echo {item}' "$@" >"$TMP_ROOT/$name.out" 2>"$TMP_ROOT/$name.err"
   RC=$?
   set -e
   ERR="$(cat "$TMP_ROOT/$name.err")"
+  OUT_TEXT="$(cat "$TMP_ROOT/$name.out")"
   # open_gui detaches the launch (`setsid ... &`), so the stub's line can land
   # after open-terminal has already exited — on a loaded box it did, and the
   # case read an empty log. Which wait to take is DERIVED from the script's own
@@ -154,6 +176,37 @@ assert_eq "$TMUX_LOG_TEXT" "" "tmux was never called for the deleted directory"
 run real "$REPO/scripts/open-terminal" real --ghostty CC-1
 assert_eq "$RC" "0" "premise: a launch at a real directory succeeds"
 assert_contains "$TERM_LOG_TEXT" "term -e bash -lc" "premise: and \$TERMINAL is the terminal it launched"
+# Only the ghostty arm has a --title flag and it is the last one tried, so the
+# title is written from inside the launched shell or it is not written at all.
+assert_contains "$TERM_LOG_TEXT" "printf '\033]0;%s\007' 'CC-1'" \
+  "the launched shell sets the window title to the item"
+
+echo
+echo "=== a launcher nothing observed is not a launch to report ==="
+
+# The exit code is the orchestrator's only signal that a lane started, so a
+# launcher that refuses its arguments must fail the item rather than be counted.
+OT_TERMINAL=badterm
+run badterm "$REPO/scripts/open-terminal" real --ghostty CC-1
+OT_TERMINAL=""
+assert_eq "$RC" "1" "a launcher that exits non-zero fails the item"
+assert_contains "$ERR" "Error: badterm exited 3 launching 'CC-1'" \
+  "the failure names the launcher and its status"
+assert_contains "$ERR" "unrecognised option -lc" "and carries the launcher's own words"
+assert_contains "$ERR" "1 handoff lane(s) failed" "the batch summary counts it as failed"
+assert_not_contains "$OUT_TEXT" "Opened terminal" "and no success line is printed for it"
+
+# A $TERMINAL naming nothing on PATH is substituted; saying so is the difference
+# between an operator's choice being honoured and being quietly overridden.
+OT_TERMINAL=no-such-terminal-anywhere
+run unresolved "$REPO/scripts/open-terminal" real --ghostty CC-1
+OT_TERMINAL=""
+assert_eq "$RC" "0" "an unresolvable \$TERMINAL still launches through the fallback"
+assert_contains "$ERR" "Warning: \$TERMINAL 'no-such-terminal-anywhere' does not resolve to an executable; launching 'CC-1' with xdg-terminal-exec instead" \
+  "the substitution names the value and the terminal used instead"
+assert_contains "$TERM_LOG_TEXT" "xdg bash -lc" "and the fallback launcher is the one that ran"
+assert_contains "$TERM_LOG_TEXT" "printf '\033]0;%s\007' 'CC-1'" \
+  "the title survives the fallback branch too"
 
 echo
 echo "=== the refusal can fail: with the guard gone the window opens ==="

--- a/.agents/skills/orch/tests/open-terminal-launch-guard.sh
+++ b/.agents/skills/orch/tests/open-terminal-launch-guard.sh
@@ -29,10 +29,6 @@ FAIL=0
 ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
 bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
 assert_eq() { [[ "$1" == "$2" ]] && ok "$3" || bad "$3" "expected: $2   got: $1"; }
-assert_not_contains() {
-  grep -qF -- "$2" <<<"$1" && bad "$3" "forbidden substring: $2
-        in: $1" || ok "$3"
-}
 assert_contains() {
   grep -qF -- "$2" <<<"$1" && ok "$3" || bad "$3" "wanted substring: $2
         in: $1"
@@ -47,17 +43,11 @@ cat > "$BIN/term" <<'EOF'
 printf 'term %s\n' "$*" >> "$OT_TERM_LOG"
 exit 0
 EOF
-# The desktop's launcher, for the case where $TERMINAL names nothing, and a
-# launcher that refuses its arguments the way the GTK family refuses -e bash -lc.
+# The desktop's launcher, for the case where $TERMINAL names nothing.
 cat > "$BIN/xdg-terminal-exec" <<'EOF'
 #!/usr/bin/env bash
 printf 'xdg %s\n' "$*" >> "$OT_TERM_LOG"
 exit 0
-EOF
-cat > "$BIN/badterm" <<'EOF'
-#!/usr/bin/env bash
-echo "badterm: unrecognised option -lc" >&2
-exit 3
 EOF
 cat > "$BIN/tmux" <<'EOF'
 #!/usr/bin/env bash
@@ -68,7 +58,7 @@ cat > "$BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 exit 1
 EOF
-chmod +x "$BIN/term" "$BIN/xdg-terminal-exec" "$BIN/badterm" "$BIN/tmux" "$BIN/gh"
+chmod +x "$BIN/term" "$BIN/xdg-terminal-exec" "$BIN/tmux" "$BIN/gh"
 
 # $TERMINAL is the terminal open_gui reaches for first — the owner's ruling
 # that a GUI launch honours the user's own choice — so each run names a stub
@@ -123,7 +113,6 @@ run() {
   RC=$?
   set -e
   ERR="$(cat "$TMP_ROOT/$name.err")"
-  OUT_TEXT="$(cat "$TMP_ROOT/$name.out")"
   # open_gui detaches the launch (`setsid ... &`), so the stub's line can land
   # after open-terminal has already exited — on a loaded box it did, and the
   # case read an empty log. Which wait to take is DERIVED from the script's own
@@ -180,21 +169,6 @@ assert_contains "$TERM_LOG_TEXT" "term -e bash -lc" "premise: and \$TERMINAL is 
 # title is written from inside the launched shell or it is not written at all.
 assert_contains "$TERM_LOG_TEXT" "printf '\033]0;%s\007' 'CC-1'" \
   "the launched shell sets the window title to the item"
-
-echo
-echo "=== a launcher nothing observed is not a launch to report ==="
-
-# The exit code is the orchestrator's only signal that a lane started, so a
-# launcher that refuses its arguments must fail the item rather than be counted.
-OT_TERMINAL=badterm
-run badterm "$REPO/scripts/open-terminal" real --ghostty CC-1
-OT_TERMINAL=""
-assert_eq "$RC" "1" "a launcher that exits non-zero fails the item"
-assert_contains "$ERR" "Error: badterm exited 3 launching 'CC-1'" \
-  "the failure names the launcher and its status"
-assert_contains "$ERR" "unrecognised option -lc" "and carries the launcher's own words"
-assert_contains "$ERR" "1 handoff lane(s) failed" "the batch summary counts it as failed"
-assert_not_contains "$OUT_TEXT" "Opened terminal" "and no success line is printed for it"
 
 # A $TERMINAL naming nothing on PATH is substituted; saying so is the difference
 # between an operator's choice being honoured and being quietly overridden.

--- a/.agents/skills/orch/tests/open-terminal-owned-skip.sh
+++ b/.agents/skills/orch/tests/open-terminal-owned-skip.sh
@@ -76,6 +76,11 @@ exit 1
 EOF
 chmod +x "$BIN/ghostty" "$BIN/gh"
 
+# $TERMINAL is what open_gui reaches for first, so it is PINNED to the stub on
+# PATH here: unset, the branch below it would resolve whatever terminal the
+# developer's desktop provides and this suite would open real windows.
+export TERMINAL=ghostty
+
 # Stub worktree CLI:
 #   exists <item>          "true" when $STUB_EXISTS_DIR/<item> is present
 #   create <item>          logs "<item>", exits per $STUB_EXIT_DIR/<item>

--- a/.agents/skills/orch/tests/open-terminal-owned-skip.sh
+++ b/.agents/skills/orch/tests/open-terminal-owned-skip.sh
@@ -20,6 +20,8 @@
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/sealed-bin.sh
+. "$TEST_DIR/lib/sealed-bin.sh"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 SRC_OT="${OPEN_TERMINAL_UNDER_TEST:-$SCRIPTS_DIR/open-terminal}"
 SRC_LIB_DIR="$SCRIPTS_DIR/lib"
@@ -76,9 +78,8 @@ exit 1
 EOF
 chmod +x "$BIN/ghostty" "$BIN/gh"
 
-# $TERMINAL is what open_gui reaches for first, so it is PINNED to the stub on
-# PATH here: unset, the branch below it would resolve whatever terminal the
-# developer's desktop provides and this suite would open real windows.
+# open_gui reaches for $TERMINAL first, so it names the stub rather than the
+# developer's own terminal. $SEALED is what answers once the stub tree is gone.
 export TERMINAL=ghostty
 
 # Stub worktree CLI:
@@ -131,7 +132,7 @@ run_case() {
   : "${EXISTS_DIR:=$TMP_ROOT/exists-none}"
   mkdir -p "$EXISTS_DIR"
   set +e
-  OUT=$(PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" STUB_CALL_LOG="$CALL_LOG" STUB_EXIT_DIR="$EXIT_DIR" \
+  OUT=$(PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" STUB_CALL_LOG="$CALL_LOG" STUB_EXIT_DIR="$EXIT_DIR" \
     STUB_EXISTS_DIR="$EXISTS_DIR" \
     "$OT" --ghostty --cmd 'echo {item}' "$@" 2>"$TMP_ROOT/$name.err")
   RC=$?

--- a/.agents/skills/orch/tests/open-terminal-owned-skip.sh
+++ b/.agents/skills/orch/tests/open-terminal-owned-skip.sh
@@ -20,8 +20,6 @@
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=lib/sealed-bin.sh
-. "$TEST_DIR/lib/sealed-bin.sh"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 SRC_OT="${OPEN_TERMINAL_UNDER_TEST:-$SCRIPTS_DIR/open-terminal}"
 SRC_LIB_DIR="$SCRIPTS_DIR/lib"
@@ -78,8 +76,9 @@ exit 1
 EOF
 chmod +x "$BIN/ghostty" "$BIN/gh"
 
-# open_gui reaches for $TERMINAL first, so it names the stub rather than the
-# developer's own terminal. $SEALED is what answers once the stub tree is gone.
+# $TERMINAL is what open_gui reaches for first, so it is PINNED to the stub on
+# PATH here: unset, the branch below it would resolve whatever terminal the
+# developer's desktop provides and this suite would open real windows.
 export TERMINAL=ghostty
 
 # Stub worktree CLI:
@@ -132,7 +131,7 @@ run_case() {
   : "${EXISTS_DIR:=$TMP_ROOT/exists-none}"
   mkdir -p "$EXISTS_DIR"
   set +e
-  OUT=$(PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" STUB_CALL_LOG="$CALL_LOG" STUB_EXIT_DIR="$EXIT_DIR" \
+  OUT=$(PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" STUB_CALL_LOG="$CALL_LOG" STUB_EXIT_DIR="$EXIT_DIR" \
     STUB_EXISTS_DIR="$EXISTS_DIR" \
     "$OT" --ghostty --cmd 'echo {item}' "$@" 2>"$TMP_ROOT/$name.err")
   RC=$?

--- a/.agents/skills/orch/tests/parser-defaults-not-configurable.sh
+++ b/.agents/skills/orch/tests/parser-defaults-not-configurable.sh
@@ -42,23 +42,38 @@ bad() {
 
 # A stub gh so no case reaches the network; every command here fails before or
 # at auth, and none of them may decide the outcome by talking to GitHub.
+#
+# And a stub for every terminal open_gui can resolve. No assertion in this file
+# measures a launch, but the SKILLS_DIR leak control below drops the very export
+# it is proving, so its stubbed worktree CLI exits 0 printing no path and the
+# launch that follows used to reach the real ghostty on PATH — a window on the
+# operator's desktop at a directory that was already deleted (KEN-1084). A test
+# that proves a parser property must not be able to open one while doing it.
 mkdir -p "$TMP_ROOT/bin" "$TMP_ROOT/no-lanes"
 printf '#!/bin/sh\nexit 1\n' >"$TMP_ROOT/bin/gh"
-chmod +x "$TMP_ROOT/bin/gh"
+for stub in ghostty xdg-terminal-exec stub-terminal; do
+  printf '#!/bin/sh\nexit 0\n' >"$TMP_ROOT/bin/$stub"
+done
+chmod +x "$TMP_ROOT/bin/gh" "$TMP_ROOT/bin/ghostty" \
+  "$TMP_ROOT/bin/xdg-terminal-exec" "$TMP_ROOT/bin/stub-terminal"
 
 # run SCRIPT DIR ARGS... — one hermetic invocation, combined output.
 #
 # TMUX is unset because oversee-watch's lane-window check only fires outside
 # tmux, and this suite must not pass merely because the developer ran it from a
-# tmux pane. ORCH_LANE_DIRS points at an empty directory so `lanes` never reads
-# the real accounts on this machine.
+# tmux pane. That also makes every open-terminal case here a GUI launch, so
+# TERMINAL names the stub above: it is the first thing open_gui resolves, and
+# pinning it is what keeps a case off the real desktop whatever PATH holds.
+# ORCH_LANE_DIRS points at an empty directory so `lanes` never reads the real
+# accounts on this machine.
 run() {
   local script="$1" dir="$2"
   shift 2
   # The command's own status is returned, not swallowed: the empty-value sweep
   # below asserts on it. Callers that only read the output append `|| true`.
   (cd "$dir" && PATH="$TMP_ROOT/bin:$PATH" \
-    env -u TMUX ORCH_LANES_FETCH_CMD=true ORCH_LANE_DIRS="$TMP_ROOT/no-lanes" \
+    env -u TMUX TERMINAL=stub-terminal ORCH_LANES_FETCH_CMD=true \
+      ORCH_LANE_DIRS="$TMP_ROOT/no-lanes" \
       "$dir/.agents/skills/orch/scripts/$script" "$@") 2>&1
 }
 

--- a/.agents/skills/orch/tests/parser-defaults-not-configurable.sh
+++ b/.agents/skills/orch/tests/parser-defaults-not-configurable.sh
@@ -42,35 +42,23 @@ bad() {
 
 # A stub gh so no case reaches the network; every command here fails before or
 # at auth, and none of them may decide the outcome by talking to GitHub.
-#
-# And a stub for every terminal open_gui can resolve BELOW $TERMINAL. The rows
-# further down leave TERMINAL unset, because it is a name they measure, so the
-# ladder falls to these two — unstubbed they are the developer's own desktop,
-# and this file's fixtures reach a real GUI launch (KEN-1084). A test that
-# proves a parser property must not be able to open a window while doing it.
 mkdir -p "$TMP_ROOT/bin" "$TMP_ROOT/no-lanes"
 printf '#!/bin/sh\nexit 1\n' >"$TMP_ROOT/bin/gh"
-for stub in ghostty xdg-terminal-exec; do
-  printf '#!/bin/sh\nexit 0\n' >"$TMP_ROOT/bin/$stub"
-done
-chmod +x "$TMP_ROOT/bin/gh" "$TMP_ROOT/bin/ghostty" "$TMP_ROOT/bin/xdg-terminal-exec"
+chmod +x "$TMP_ROOT/bin/gh"
 
 # run SCRIPT DIR ARGS... — one hermetic invocation, combined output.
 #
 # TMUX is unset because oversee-watch's lane-window check only fires outside
 # tmux, and this suite must not pass merely because the developer ran it from a
-# tmux pane. TERMINAL is unset for a second reason: it is a name the TERMINAL
-# rows below measure, and the developer's own value would decide them.
-# ORCH_LANE_DIRS points at an empty directory so `lanes` never reads the real
-# accounts on this machine.
+# tmux pane. ORCH_LANE_DIRS points at an empty directory so `lanes` never reads
+# the real accounts on this machine.
 run() {
   local script="$1" dir="$2"
   shift 2
   # The command's own status is returned, not swallowed: the empty-value sweep
   # below asserts on it. Callers that only read the output append `|| true`.
   (cd "$dir" && PATH="$TMP_ROOT/bin:$PATH" \
-    env -u TMUX -u TERMINAL ORCH_LANES_FETCH_CMD=true \
-      ORCH_LANE_DIRS="$TMP_ROOT/no-lanes" \
+    env -u TMUX ORCH_LANES_FETCH_CMD=true ORCH_LANE_DIRS="$TMP_ROOT/no-lanes" \
       "$dir/.agents/skills/orch/scripts/$script" "$@") 2>&1
 }
 
@@ -222,44 +210,6 @@ for exe in worktree/scripts/worktree review-gate/scripts/pr-watch.sh; do
   printf '#!/bin/sh\necho "EXECUTED FROM THE CONFIGURED SKILLS_DIR" >&2\nexit 0\n' >"$evil/$exe"
   chmod +x "$evil/$exe"
 done
-# TERMINAL is the third name of this shape: open_gui EXECUTES it. Its rows read
-# a FILE rather than the run's output, because open_gui sends a launcher's
-# streams to /dev/null — a marker printed on either would be discarded, and the
-# rows would then pass because nothing was heard rather than because the name
-# was refused, which is the vacuous shape this file plants controls to prevent.
-printf '#!/bin/sh\nprintf ran >%s\nexit 0\n' "$evil/terminal-ran" >"$evil/evilterm"
-chmod +x "$evil/evilterm"
-
-# ran_terminal DIR ARGS... — 0 when the configured terminal really executed. The
-# launch is detached, so the marker can land after open-terminal has exited: a
-# row expecting one waits for it, and a row expecting none has watched a real
-# interval rather than the instant after the exit.
-ran_terminal() {
-  local dir="$1" i=0
-  shift
-  rm -f "$evil/terminal-ran"
-  run open-terminal "$dir" "$@" >/dev/null 2>&1 || true
-  while [ "$i" -lt 20 ] && [ ! -f "$evil/terminal-ran" ]; do
-    sleep 0.1
-    i=$((i + 1))
-  done
-  [ -f "$evil/terminal-ran" ]
-}
-
-# terminal_fixture DIR — a fixture whose worktree CLI succeeds, so a case can
-# REACH the GUI launch. The generic rows never get that far: the real CLI
-# refuses an empty repository, and a TERMINAL row that stopped there would pass
-# without executing anything.
-terminal_fixture() {
-  local wt="$1/.agents/skills/worktree/scripts/worktree"
-  fixture "$1"
-  cat >"$wt" <<EOF
-#!/bin/sh
-[ "\$1" = create ] || exit 1
-mkdir -p "$1/wt" && printf '%s\n' "$1/wt"
-EOF
-  chmod +x "$wt"
-}
 
 # name_cases NAME MARKER — SCRIPT|ARGS rows for one injected name.
 script_dir_cases='
@@ -311,14 +261,6 @@ for source_kind in dotenv settings; do
 $rows
 EOF
   done
-done
-
-for source_kind in dotenv settings; do
-  dir="$TMP_ROOT/own-TERMINAL-$source_kind"
-  terminal_fixture "$dir"
-  write_config "$dir" "$source_kind" TERMINAL "$evil/evilterm"
-  label="open-terminal: a TERMINAL in $source_kind never chooses which terminal is executed"
-  if ran_terminal "$dir" --cmd true KEN-1; then bad "$label" "the configured terminal was executed"; else ok "$label"; fi
 done
 
 # approval-wait is the one CLI holding parse state across its load, and it is
@@ -398,17 +340,6 @@ if drop_export "$leak_skills" open-terminal SKILLS_DIR; then
     "$leak_skills" open-terminal "EXECUTED FROM THE CONFIGURED SKILLS_DIR" --harness claude KEN-1
 else
   bad "the export SKILLS_DIR mutation did not land, so it proves nothing"
-fi
-
-leak_term="$TMP_ROOT/leak-terminal"
-terminal_fixture "$leak_term"
-write_config "$leak_term" settings TERMINAL "$evil/evilterm"
-if drop_export "$leak_term" open-terminal TERMINAL; then
-  leak_label="dropping export TERMINAL lets open-terminal execute the configured one"
-  if ran_terminal "$leak_term" --cmd true KEN-1; then ok "$leak_label"
-  else bad "$leak_label" "the row would have passed with the protection gone"; fi
-else
-  bad "the export TERMINAL mutation did not land, so it proves nothing"
 fi
 
 # approval-wait has no export to drop: what protects it is that the branch

--- a/.agents/skills/orch/tests/parser-defaults-not-configurable.sh
+++ b/.agents/skills/orch/tests/parser-defaults-not-configurable.sh
@@ -25,6 +25,8 @@
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/sealed-bin.sh
+. "$TEST_DIR/lib/sealed-bin.sh"
 SKILLS_SRC="$(cd "$TEST_DIR/../.." && pwd)"
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
@@ -41,29 +43,19 @@ bad() {
 }
 
 # A stub gh so no case reaches the network; every command here fails before or
-# at auth, and none of them may decide the outcome by talking to GitHub.
-#
-# And a stub for every terminal open_gui can resolve. No assertion in this file
-# measures a launch, but the SKILLS_DIR leak control below drops the very export
-# it is proving, so its stubbed worktree CLI exits 0 printing no path and the
-# launch that follows used to reach the real ghostty on PATH — a window on the
-# operator's desktop at a directory that was already deleted (KEN-1084). A test
-# that proves a parser property must not be able to open one while doing it.
+# at auth, and none of them may decide the outcome by talking to GitHub. Every
+# other name a case could reach for is answered by $SEALED, which is why this
+# file stubs no terminal of its own.
 mkdir -p "$TMP_ROOT/bin" "$TMP_ROOT/no-lanes"
 printf '#!/bin/sh\nexit 1\n' >"$TMP_ROOT/bin/gh"
-for stub in ghostty xdg-terminal-exec stub-terminal; do
-  printf '#!/bin/sh\nexit 0\n' >"$TMP_ROOT/bin/$stub"
-done
-chmod +x "$TMP_ROOT/bin/gh" "$TMP_ROOT/bin/ghostty" \
-  "$TMP_ROOT/bin/xdg-terminal-exec" "$TMP_ROOT/bin/stub-terminal"
+chmod +x "$TMP_ROOT/bin/gh"
 
 # run SCRIPT DIR ARGS... — one hermetic invocation, combined output.
 #
 # TMUX is unset because oversee-watch's lane-window check only fires outside
 # tmux, and this suite must not pass merely because the developer ran it from a
-# tmux pane. That also makes every open-terminal case here a GUI launch, so
-# TERMINAL names the stub above: it is the first thing open_gui resolves, and
-# pinning it is what keeps a case off the real desktop whatever PATH holds.
+# tmux pane. TERMINAL is unset for a second reason: it is a name the TERMINAL
+# rows below measure, and the developer's own value would decide them.
 # ORCH_LANE_DIRS points at an empty directory so `lanes` never reads the real
 # accounts on this machine.
 run() {
@@ -71,8 +63,8 @@ run() {
   shift 2
   # The command's own status is returned, not swallowed: the empty-value sweep
   # below asserts on it. Callers that only read the output append `|| true`.
-  (cd "$dir" && PATH="$TMP_ROOT/bin:$PATH" \
-    env -u TMUX TERMINAL=stub-terminal ORCH_LANES_FETCH_CMD=true \
+  (cd "$dir" && PATH="$TMP_ROOT/bin:$SEALED:$PATH" \
+    env -u TMUX -u TERMINAL ORCH_LANES_FETCH_CMD=true \
       ORCH_LANE_DIRS="$TMP_ROOT/no-lanes" \
       "$dir/.agents/skills/orch/scripts/$script" "$@") 2>&1
 }
@@ -225,6 +217,27 @@ for exe in worktree/scripts/worktree review-gate/scripts/pr-watch.sh; do
   printf '#!/bin/sh\necho "EXECUTED FROM THE CONFIGURED SKILLS_DIR" >&2\nexit 0\n' >"$evil/$exe"
   chmod +x "$evil/$exe"
 done
+# TERMINAL is the third name of this shape: open_gui EXECUTES it. It exits
+# non-zero so open-terminal relays its words — a launcher's stdout and stderr
+# go to a scratch file that is only printed when the launch failed, which is
+# also the only way a marker written here can reach the assertion.
+printf '#!/bin/sh\necho "EXECUTED FROM THE CONFIGURED TERMINAL" >&2\nexit 3\n' >"$evil/evilterm"
+chmod +x "$evil/evilterm"
+
+# terminal_fixture DIR — a fixture whose worktree CLI succeeds, so a case can
+# REACH the GUI launch. The generic rows never get that far: the real CLI
+# refuses an empty repository, and a TERMINAL row that stopped there would pass
+# without executing anything.
+terminal_fixture() {
+  local wt="$1/.agents/skills/worktree/scripts/worktree"
+  fixture "$1"
+  cat >"$wt" <<EOF
+#!/bin/sh
+[ "\$1" = create ] || exit 1
+mkdir -p "$1/wt" && printf '%s\n' "$1/wt"
+EOF
+  chmod +x "$wt"
+}
 
 # name_cases NAME MARKER — SCRIPT|ARGS rows for one injected name.
 script_dir_cases='
@@ -276,6 +289,14 @@ for source_kind in dotenv settings; do
 $rows
 EOF
   done
+done
+
+for source_kind in dotenv settings; do
+  dir="$TMP_ROOT/own-TERMINAL-$source_kind"
+  terminal_fixture "$dir"
+  write_config "$dir" "$source_kind" TERMINAL "$evil/evilterm"
+  refute "open-terminal: a TERMINAL in $source_kind never chooses which terminal is executed" \
+    "$dir" open-terminal "EXECUTED FROM THE CONFIGURED TERMINAL" --cmd true KEN-1
 done
 
 # approval-wait is the one CLI holding parse state across its load, and it is
@@ -355,6 +376,16 @@ if drop_export "$leak_skills" open-terminal SKILLS_DIR; then
     "$leak_skills" open-terminal "EXECUTED FROM THE CONFIGURED SKILLS_DIR" --harness claude KEN-1
 else
   bad "the export SKILLS_DIR mutation did not land, so it proves nothing"
+fi
+
+leak_term="$TMP_ROOT/leak-terminal"
+terminal_fixture "$leak_term"
+write_config "$leak_term" settings TERMINAL "$evil/evilterm"
+if drop_export "$leak_term" open-terminal TERMINAL; then
+  must_leak "dropping export TERMINAL lets open-terminal execute the configured one" \
+    "$leak_term" open-terminal "EXECUTED FROM THE CONFIGURED TERMINAL" --cmd true KEN-1
+else
+  bad "the export TERMINAL mutation did not land, so it proves nothing"
 fi
 
 # approval-wait has no export to drop: what protects it is that the branch

--- a/.agents/skills/orch/tests/parser-defaults-not-configurable.sh
+++ b/.agents/skills/orch/tests/parser-defaults-not-configurable.sh
@@ -217,12 +217,29 @@ for exe in worktree/scripts/worktree review-gate/scripts/pr-watch.sh; do
   printf '#!/bin/sh\necho "EXECUTED FROM THE CONFIGURED SKILLS_DIR" >&2\nexit 0\n' >"$evil/$exe"
   chmod +x "$evil/$exe"
 done
-# TERMINAL is the third name of this shape: open_gui EXECUTES it. It exits
-# non-zero so open-terminal relays its words — a launcher's stdout and stderr
-# go to a scratch file that is only printed when the launch failed, which is
-# also the only way a marker written here can reach the assertion.
-printf '#!/bin/sh\necho "EXECUTED FROM THE CONFIGURED TERMINAL" >&2\nexit 3\n' >"$evil/evilterm"
+# TERMINAL is the third name of this shape: open_gui EXECUTES it. Its rows read
+# a FILE rather than the run's output, because open_gui sends a launcher's
+# streams to /dev/null — a marker printed on either would be discarded, and the
+# rows would then pass because nothing was heard rather than because the name
+# was refused, which is the vacuous shape this file plants controls to prevent.
+printf '#!/bin/sh\nprintf ran >%s\nexit 0\n' "$evil/terminal-ran" >"$evil/evilterm"
 chmod +x "$evil/evilterm"
+
+# ran_terminal DIR ARGS... — 0 when the configured terminal really executed. The
+# launch is detached, so the marker can land after open-terminal has exited: a
+# row expecting one waits for it, and a row expecting none has watched a real
+# interval rather than the instant after the exit.
+ran_terminal() {
+  local dir="$1" i=0
+  shift
+  rm -f "$evil/terminal-ran"
+  run open-terminal "$dir" "$@" >/dev/null 2>&1 || true
+  while [ "$i" -lt 20 ] && [ ! -f "$evil/terminal-ran" ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -f "$evil/terminal-ran" ]
+}
 
 # terminal_fixture DIR — a fixture whose worktree CLI succeeds, so a case can
 # REACH the GUI launch. The generic rows never get that far: the real CLI
@@ -295,8 +312,8 @@ for source_kind in dotenv settings; do
   dir="$TMP_ROOT/own-TERMINAL-$source_kind"
   terminal_fixture "$dir"
   write_config "$dir" "$source_kind" TERMINAL "$evil/evilterm"
-  refute "open-terminal: a TERMINAL in $source_kind never chooses which terminal is executed" \
-    "$dir" open-terminal "EXECUTED FROM THE CONFIGURED TERMINAL" --cmd true KEN-1
+  label="open-terminal: a TERMINAL in $source_kind never chooses which terminal is executed"
+  if ran_terminal "$dir" --cmd true KEN-1; then bad "$label" "the configured terminal was executed"; else ok "$label"; fi
 done
 
 # approval-wait is the one CLI holding parse state across its load, and it is
@@ -382,8 +399,9 @@ leak_term="$TMP_ROOT/leak-terminal"
 terminal_fixture "$leak_term"
 write_config "$leak_term" settings TERMINAL "$evil/evilterm"
 if drop_export "$leak_term" open-terminal TERMINAL; then
-  must_leak "dropping export TERMINAL lets open-terminal execute the configured one" \
-    "$leak_term" open-terminal "EXECUTED FROM THE CONFIGURED TERMINAL" --cmd true KEN-1
+  leak_label="dropping export TERMINAL lets open-terminal execute the configured one"
+  if ran_terminal "$leak_term" --cmd true KEN-1; then ok "$leak_label"
+  else bad "$leak_label" "the row would have passed with the protection gone"; fi
 else
   bad "the export TERMINAL mutation did not land, so it proves nothing"
 fi

--- a/.agents/skills/orch/tests/parser-defaults-not-configurable.sh
+++ b/.agents/skills/orch/tests/parser-defaults-not-configurable.sh
@@ -25,8 +25,6 @@
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=lib/sealed-bin.sh
-. "$TEST_DIR/lib/sealed-bin.sh"
 SKILLS_SRC="$(cd "$TEST_DIR/../.." && pwd)"
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
@@ -43,12 +41,19 @@ bad() {
 }
 
 # A stub gh so no case reaches the network; every command here fails before or
-# at auth, and none of them may decide the outcome by talking to GitHub. Every
-# other name a case could reach for is answered by $SEALED, which is why this
-# file stubs no terminal of its own.
+# at auth, and none of them may decide the outcome by talking to GitHub.
+#
+# And a stub for every terminal open_gui can resolve BELOW $TERMINAL. The rows
+# further down leave TERMINAL unset, because it is a name they measure, so the
+# ladder falls to these two — unstubbed they are the developer's own desktop,
+# and this file's fixtures reach a real GUI launch (KEN-1084). A test that
+# proves a parser property must not be able to open a window while doing it.
 mkdir -p "$TMP_ROOT/bin" "$TMP_ROOT/no-lanes"
 printf '#!/bin/sh\nexit 1\n' >"$TMP_ROOT/bin/gh"
-chmod +x "$TMP_ROOT/bin/gh"
+for stub in ghostty xdg-terminal-exec; do
+  printf '#!/bin/sh\nexit 0\n' >"$TMP_ROOT/bin/$stub"
+done
+chmod +x "$TMP_ROOT/bin/gh" "$TMP_ROOT/bin/ghostty" "$TMP_ROOT/bin/xdg-terminal-exec"
 
 # run SCRIPT DIR ARGS... — one hermetic invocation, combined output.
 #
@@ -63,7 +68,7 @@ run() {
   shift 2
   # The command's own status is returned, not swallowed: the empty-value sweep
   # below asserts on it. Callers that only read the output append `|| true`.
-  (cd "$dir" && PATH="$TMP_ROOT/bin:$SEALED:$PATH" \
+  (cd "$dir" && PATH="$TMP_ROOT/bin:$PATH" \
     env -u TMUX -u TERMINAL ORCH_LANES_FETCH_CMD=true \
       ORCH_LANE_DIRS="$TMP_ROOT/no-lanes" \
       "$dir/.agents/skills/orch/scripts/$script" "$@") 2>&1

--- a/changelog.d/fixed/KEN-1084.md
+++ b/changelog.d/fixed/KEN-1084.md
@@ -1,1 +1,1 @@
-- `open-terminal` refuses a launch whose working directory is gone, honours `$TERMINAL` then `xdg-terminal-exec` ahead of ghostty, and fails an item whose launcher fails instead of reporting it.
+- `open-terminal` refuses a launch whose working directory is gone, and honours `$TERMINAL` then `xdg-terminal-exec` ahead of ghostty.

--- a/changelog.d/fixed/KEN-1084.md
+++ b/changelog.d/fixed/KEN-1084.md
@@ -1,1 +1,1 @@
-- `open-terminal` refuses a launch whose working directory no longer exists instead of opening a broken window, and a GUI launch now honours `$TERMINAL` and `xdg-terminal-exec` ahead of ghostty.
+- `open-terminal` refuses a launch whose working directory is gone, honours `$TERMINAL` then `xdg-terminal-exec` ahead of ghostty, and fails an item whose launcher fails instead of reporting it.

--- a/changelog.d/fixed/KEN-1084.md
+++ b/changelog.d/fixed/KEN-1084.md
@@ -1,0 +1,1 @@
+- `open-terminal` refuses a launch whose working directory no longer exists instead of opening a broken window, and a GUI launch now honours `$TERMINAL` and `xdg-terminal-exec` ahead of ghostty.

--- a/skills/growth-guards/DEVELOPMENT.md
+++ b/skills/growth-guards/DEVELOPMENT.md
@@ -83,11 +83,14 @@ Two rules hold, and a probe that drops either is worse than no probe:
   answered by EOF the moment it is written and the session returns instead of
   waiting for a person who is not there. What it returns differs by platform,
   which is why a case asserts on the destination.
-- **A time cap.** After `CAP` seconds the session's process group is killed,
-  the spawner's after it. `script` puts the session in a group of its own, so
-  killing the spawner alone leaves the stuck child behind. A probe that HANGS
-  yields no measurement at all, so a mutation run scores it as not killed and
-  prints a silent miss rather than a wedge.
+- **A time cap, held on both sides.** After `CAP` seconds the caller kills the
+  session's process group, the spawner's after it: `script` puts the session in
+  a group of its own, so killing the spawner alone leaves the stuck child
+  behind. The session holds the same deadline over ITSELF a few seconds later,
+  because a suite killed mid-run takes the caller's poll loop with it and
+  leaves a setsid'd session nothing can reach. A probe that HANGS yields no
+  measurement at all, so a mutation run scores it as not killed and prints a
+  silent miss rather than a wedge.
 
 Three things to assert, and `terminal-paths.test.sh` is the worked example —
 its `pty_call` is the wrapper shape a new case copies:

--- a/skills/growth-guards/tests/lib/pty.bash
+++ b/skills/growth-guards/tests/lib/pty.bash
@@ -57,6 +57,18 @@ printf '%s\n' "$gg_pgid" >"$GG_PTY_SID_FILE"
 # down the moment the session it guards is gone, so it can neither become the
 # leak it exists to prevent nor signal a process group that was recycled after
 # this one ended. On a healthy run the caller's cap fires first.
+#
+# `kill -9 "-PGID"`, with no `--`. This runs under /bin/sh, which is dash on
+# every Debian-family host including the CI runner, and dash's kill builtin
+# takes the word after the signal as a pid: `--` becomes number('-'), it prints
+# `Illegal number: -`, exits 2 and reaps nothing. Measured in ubuntu:24.04. The
+# bare form is a process-group target in dash, bash 3.2.57 and bash 5 alike.
+# The caller-side kills below run in bash and keep their `--`.
+#
+# The marker beside the body file is what makes the kill provable: the caller's
+# cap leaves none, so a case that finds one knows the SESSION's deadline fired
+# rather than something upstream. It sits beside a path the caller chose, since
+# this scratch directory is the caller's to remove and it does not survive.
 gg_session=$$
 if [ -n "$gg_pgid" ]; then
   (
@@ -65,7 +77,10 @@ if [ -n "$gg_pgid" ]; then
       sleep 1
       i=$((i + 1))
     done
-    [ "$i" -lt "$GG_PTY_DEADLINE" ] || kill -9 -- "-$gg_pgid"
+    if [ "$i" -ge "$GG_PTY_DEADLINE" ]; then
+      printf 'fired\n' >"$GG_PTY_BODY_FILE.watchdog"
+      kill -9 "-$gg_pgid"
+    fi
   ) >/dev/null 2>&1 &
 fi
 echo GG-PTY-BEGIN

--- a/skills/growth-guards/tests/lib/pty.bash
+++ b/skills/growth-guards/tests/lib/pty.bash
@@ -44,16 +44,43 @@ gg_pty_run() { # CAP_SECONDS SCRIPT_FILE
   # then stop the session starting. Passing the paths as values rather than
   # as syntax removes the question instead of answering it.
   cat >"$dir/session.sh" <<'SESSION'
-ps -o pgid= -p $$ >"$GG_PTY_SID_FILE" 2>/dev/null || true
+gg_pgid="$(ps -o pgid= -p $$ 2>/dev/null | tr -dc '0-9')"
+printf '%s\n' "$gg_pgid" >"$GG_PTY_SID_FILE"
+# The deadline the session holds over ITSELF. The poll loop below is the normal
+# cap, but a suite killed mid-run takes that loop with it, and `script` has
+# already setsid'd this session out of every group the suite's killer could
+# name — so with the cap living only on the far side, a body that never returns
+# outlives the run that started it. Two such keepalives from a dead session ran
+# for sixteen hours before they were killed by hand.
+#
+# The watchdog traps no signal, is bounded by one tick per second, and stands
+# down the moment the session it guards is gone, so it can neither become the
+# leak it exists to prevent nor signal a process group that was recycled after
+# this one ended. On a healthy run the caller's cap fires first.
+gg_session=$$
+if [ -n "$gg_pgid" ]; then
+  (
+    i=0
+    while [ "$i" -lt "$GG_PTY_DEADLINE" ] && kill -0 "$gg_session" 2>/dev/null; do
+      sleep 1
+      i=$((i + 1))
+    done
+    [ "$i" -lt "$GG_PTY_DEADLINE" ] || kill -9 -- "-$gg_pgid"
+  ) >/dev/null 2>&1 &
+fi
 echo GG-PTY-BEGIN
 bash "$GG_PTY_BODY_FILE"
 printf '%s\n' "$?" >"$GG_PTY_RC_FILE"
 SESSION
   cmd='/bin/sh "$GG_PTY_SESSION_FILE"'
   # Exported, not prefixed onto the spawn: the two grammars below would
-  # otherwise carry four assignments each. Every call overwrites them.
+  # otherwise carry five assignments each. Every call overwrites them. The
+  # self-deadline sits PAST the caller's cap, so the poll loop stays the normal
+  # path and still reports `capped`; the session's own watchdog is only what is
+  # left when there is no poll loop any more.
   export GG_PTY_SESSION_FILE="$dir/session.sh" GG_PTY_SID_FILE="$dir/sid" \
-    GG_PTY_BODY_FILE="$body" GG_PTY_RC_FILE="$dir/rc"
+    GG_PTY_BODY_FILE="$body" GG_PTY_RC_FILE="$dir/rc" \
+    GG_PTY_DEADLINE="$((cap + 5))"
   # The grammar is SELECTED, not probed: util-linux takes the command through
   # -e -c, BSD (macOS) after the typescript file. `set -m` gives the spawner a
   # process group of its own where the platform provides one, and </dev/null

--- a/skills/growth-guards/tests/terminal-paths.test.sh
+++ b/skills/growth-guards/tests/terminal-paths.test.sh
@@ -208,12 +208,10 @@ orphan="$(cat "$ROOT/orphan.pid" 2>/dev/null || true)"
   || bad "control: and the cap left no process of it behind" "pid $orphan is still running; state=$GG_PTY_STATE err=$GG_PTY_ERR"
 
 # A suite killed mid-run takes the poll loop above with it, and `script` has
-# already setsid'd the session out of every group that killer could name — so
-# the cap on this side simply stops existing. What is left is the deadline the
-# session holds over itself, and it is the difference between a probe that ends
-# and the pair of keepalives from a dead session that ran for sixteen hours
-# before they were killed by hand (KEN-1084). The body here traps TERM away, as
-# those did, so nothing short of the SIGKILL that deadline sends can end it.
+# already setsid'd the session out of every group that killer could name, so the
+# cap on this side stops existing. What is left is the deadline the session
+# holds over itself (KEN-1084). The body traps TERM away, so nothing short of
+# the SIGKILL that deadline sends can end it.
 cat >"$ROOT/abandon-runner.sh" <<'RUNNER'
 set -euo pipefail
 . "$1"
@@ -221,17 +219,12 @@ gg_pty_run 2 "$2" || true
 RUNNER
 
 # abandon PTY_LIB CASE_FILE PIDFILE — run a case under PTY_LIB, kill the runner
-# the moment the session has a child to leave behind, and report what it left:
+# once the session has a child to leave behind, and report what it left:
 # ABANDONED is that child's pid, ABANDONED_GROUP the session's own process
-# group. Killing the runner is what a load reaper or a usage wall does to a
-# suite; the session and its spawner survive it either way.
-#
-# The GROUP is the handle cleanup uses, not the pid. A run that timed out
-# waiting for the pidfile leaves ABANDONED empty, and that is precisely the run
-# that started a session and has no child handle to reap it by — reaping by pid
-# would skip the one case that needs it. gg_pty_run writes the group into
-# `sid` under its own scratch directory, so the runner gets a TMPDIR this
-# function owns and reads it back from there.
+# group. Cleanup reaps by the GROUP, not the pid: a run that timed out waiting
+# for the pidfile leaves ABANDONED empty, and that is exactly the run with no
+# child handle to reap by. gg_pty_run writes the group into `sid` under its own
+# scratch directory, so the runner gets a TMPDIR this function owns.
 abandon() {
   local lib="$1" case_file="$2" pidfile="$3" runner i=0 scratch
   scratch="$(mktemp -d "$ROOT/abandon.XXXXXX")"
@@ -273,19 +266,15 @@ printf 'trap "" HUP TERM\necho STARTED\nsleep 300 &\necho "$!" >%q\nwait\n' \
 rm -f "$ROOT/abandon-case.sh.watchdog"
 abandon "$TEST_DIR/lib/pty.bash" "$ROOT/abandon-case.sh" "$ROOT/abandoned.pid"
 real_group="$ABANDONED_GROUP"
-[ -n "$ABANDONED" ] \
-  && ok "an abandoned session really did start the child its own deadline must take" \
-  || bad "an abandoned session really did start the child its own deadline must take" "no pid recorded"
 # The cap is 2 and the session's deadline sits five seconds past it; 20 is slack
 # for a loaded box, not a second budget.
 [ -n "$ABANDONED" ] && gone_within "$ABANDONED" 20 \
   && ok "and the session ends itself once the run that started it is gone" \
   || bad "and the session ends itself once the run that started it is gone" "pid $ABANDONED is still running"
-# WHICH kill ended it. A dead child is also what a spawner collapsing or a
-# hostile reaper leaves, and the session-side kill runs under /bin/sh — dash on
-# the CI runner, where a mis-parsed argument fails silently and reaps nothing.
-# The marker is written by the watchdog and by nothing else, so on that runner
-# this line is the dash measurement rather than an assumption about it.
+# WHICH kill ended it: a dead child is also what a collapsing spawner leaves.
+# The session-side kill runs under /bin/sh — dash on the CI runner, where a
+# mis-parsed argument reaps nothing in silence — and the marker is written by
+# that watchdog alone, so this line is the dash measurement.
 [ -f "$ROOT/abandon-case.sh.watchdog" ] \
   && ok "and it was the session's own deadline that fired, not something upstream" \
   || bad "and it was the session's own deadline that fired, not something upstream" "no watchdog marker: the in-session kill did not run (dash argument parsing?)"
@@ -303,20 +292,16 @@ printf 'trap "" HUP TERM\necho STARTED\nsleep 300 &\necho "$!" >%q\nwait\n' \
 abandon "$NO_DEADLINE" "$ROOT/abandon-mutant-case.sh" "$ROOT/abandoned-mutant.pid"
 mutant_group="$ABANDONED_GROUP"
 mutant_pid="$ABANDONED"
-# The leak this control deliberately creates is reaped BEFORE the assertion,
-# by the group the session recorded for itself: reaping after would be skipped
-# on any path that reports bad and returns early, and reaping by the child's pid
-# would be skipped exactly when no pid was captured. The pid is read once, into
-# a variable of its own, so the next abandon cannot overwrite what is asserted.
+# The leak this control creates is reaped BEFORE the assertion, by the group the
+# session recorded: reaping after would be skipped on any path reporting bad and
+# returning early. The pid is read once into a variable of its own, so a later
+# abandon cannot overwrite what is asserted.
 [ -n "$mutant_pid" ] && ! gone_within "$mutant_pid" 12 \
   && mutant_survived=yes || mutant_survived=no
 reap_group "$mutant_group"
 [ "$mutant_survived" = yes ] \
   && ok "control: without that deadline the abandoned session is still running" \
   || bad "control: without that deadline the abandoned session is still running" "pid ${mutant_pid:-none} ended anyway, so the case above proves nothing"
-[ ! -f "$ROOT/abandon-mutant-case.sh.watchdog" ] \
-  && ok "control: and the mutant wrote no watchdog marker, so the marker names that kill alone" \
-  || bad "control: and the mutant wrote no watchdog marker, so the marker names that kill alone" "a watchdog fired in a copy whose watchdog never starts"
 
 # The status is the SESSION's own, read from the file it wrote rather than
 # from the spawner, which reports on its own account.

--- a/skills/growth-guards/tests/terminal-paths.test.sh
+++ b/skills/growth-guards/tests/terminal-paths.test.sh
@@ -207,6 +207,80 @@ orphan="$(cat "$ROOT/orphan.pid" 2>/dev/null || true)"
   && ok "control: and the cap left no process of it behind" \
   || bad "control: and the cap left no process of it behind" "pid $orphan is still running; state=$GG_PTY_STATE err=$GG_PTY_ERR"
 
+# A suite killed mid-run takes the poll loop above with it, and `script` has
+# already setsid'd the session out of every group that killer could name — so
+# the cap on this side simply stops existing. What is left is the deadline the
+# session holds over itself, and it is the difference between a probe that ends
+# and the pair of keepalives from a dead session that ran for sixteen hours
+# before they were killed by hand (KEN-1084). The body here traps TERM away, as
+# those did, so nothing short of the SIGKILL that deadline sends can end it.
+cat >"$ROOT/abandon-runner.sh" <<'RUNNER'
+set -euo pipefail
+. "$1"
+gg_pty_run 2 "$2" || true
+RUNNER
+
+# abandon PTY_LIB CASE_FILE PIDFILE — run a case under PTY_LIB, kill the runner
+# the moment the session has a child to leave behind, and set ABANDONED to that
+# child's pid. Killing the runner is what a load reaper or a usage wall does to
+# a suite; the session and its spawner survive it either way.
+abandon() {
+  local lib="$1" case_file="$2" pidfile="$3" runner i=0
+  rm -f "$pidfile"
+  bash "$ROOT/abandon-runner.sh" "$lib" "$case_file" >/dev/null 2>&1 &
+  runner=$!
+  while [ "$i" -lt 60 ] && [ ! -s "$pidfile" ]; do
+    sleep 0.25
+    i=$((i + 1))
+  done
+  kill -9 "$runner" 2>/dev/null || true
+  wait "$runner" 2>/dev/null || true
+  ABANDONED="$(cat "$pidfile" 2>/dev/null || true)"
+}
+
+# gone_within PID SECONDS
+gone_within() {
+  local i=0
+  while [ "$i" -lt "$2" ]; do
+    kill -0 "$1" 2>/dev/null || return 0
+    sleep 1
+    i=$((i + 1))
+  done
+  return 1
+}
+
+printf 'trap "" HUP TERM\necho STARTED\nsleep 300 &\necho "$!" >%q\nwait\n' \
+  "$ROOT/abandoned.pid" >"$ROOT/abandon-case.sh"
+abandon "$TEST_DIR/lib/pty.bash" "$ROOT/abandon-case.sh" "$ROOT/abandoned.pid"
+[ -n "$ABANDONED" ] \
+  && ok "an abandoned session really did start the child its own deadline must take" \
+  || bad "an abandoned session really did start the child its own deadline must take" "no pid recorded"
+# The cap is 2 and the session's deadline sits five seconds past it; 20 is slack
+# for a loaded box, not a second budget.
+[ -n "$ABANDONED" ] && gone_within "$ABANDONED" 20 \
+  && ok "and the session ends itself once the run that started it is gone" \
+  || bad "and the session ends itself once the run that started it is gone" "pid $ABANDONED is still running"
+
+# The must-fail control: the same abandonment against a copy whose watchdog
+# never starts. Without it the session outlives the run, which is the leak.
+NO_DEADLINE="$ROOT/pty-no-deadline.bash"
+sed 's/if \[ -n "$gg_pgid" \]; then/if false; then/' "$TEST_DIR/lib/pty.bash" >"$NO_DEADLINE"
+cmp -s "$TEST_DIR/lib/pty.bash" "$NO_DEADLINE" \
+  && bad "control: the mutant really drops the session's own deadline" "the copy is byte-identical to pty.bash" \
+  || ok "control: the mutant really drops the session's own deadline"
+printf 'trap "" HUP TERM\necho STARTED\nsleep 300 &\necho "$!" >%q\nwait\n' \
+  "$ROOT/abandoned-mutant.pid" >"$ROOT/abandon-mutant-case.sh"
+abandon "$NO_DEADLINE" "$ROOT/abandon-mutant-case.sh" "$ROOT/abandoned-mutant.pid"
+[ -n "$ABANDONED" ] && ! gone_within "$ABANDONED" 12 \
+  && ok "control: without that deadline the abandoned session is still running" \
+  || bad "control: without that deadline the abandoned session is still running" "pid ${ABANDONED:-none} ended anyway, so the case above proves nothing"
+# The leak this control deliberately creates is reaped here, by the group the
+# session recorded for itself — the suite must not become the thing it pins.
+if [ -n "$ABANDONED" ]; then
+  leaked_group="$(ps -o pgid= -p "$ABANDONED" 2>/dev/null | tr -dc '0-9' || true)"
+  [ -z "$leaked_group" ] || kill -9 -- "-$leaked_group" 2>/dev/null || true
+fi
+
 # The status is the SESSION's own, read from the file it wrote rather than
 # from the spawner, which reports on its own account.
 printf 'exit 7\n' >"$ROOT/status-case.sh"

--- a/skills/growth-guards/tests/terminal-paths.test.sh
+++ b/skills/growth-guards/tests/terminal-paths.test.sh
@@ -221,13 +221,24 @@ gg_pty_run 2 "$2" || true
 RUNNER
 
 # abandon PTY_LIB CASE_FILE PIDFILE — run a case under PTY_LIB, kill the runner
-# the moment the session has a child to leave behind, and set ABANDONED to that
-# child's pid. Killing the runner is what a load reaper or a usage wall does to
-# a suite; the session and its spawner survive it either way.
+# the moment the session has a child to leave behind, and report what it left:
+# ABANDONED is that child's pid, ABANDONED_GROUP the session's own process
+# group. Killing the runner is what a load reaper or a usage wall does to a
+# suite; the session and its spawner survive it either way.
+#
+# The GROUP is the handle cleanup uses, not the pid. A run that timed out
+# waiting for the pidfile leaves ABANDONED empty, and that is precisely the run
+# that started a session and has no child handle to reap it by — reaping by pid
+# would skip the one case that needs it. gg_pty_run writes the group into
+# `sid` under its own scratch directory, so the runner gets a TMPDIR this
+# function owns and reads it back from there.
 abandon() {
-  local lib="$1" case_file="$2" pidfile="$3" runner i=0
+  local lib="$1" case_file="$2" pidfile="$3" runner i=0 scratch
+  scratch="$(mktemp -d "$ROOT/abandon.XXXXXX")"
+  ABANDONED=""
+  ABANDONED_GROUP=""
   rm -f "$pidfile"
-  bash "$ROOT/abandon-runner.sh" "$lib" "$case_file" >/dev/null 2>&1 &
+  TMPDIR="$scratch" bash "$ROOT/abandon-runner.sh" "$lib" "$case_file" >/dev/null 2>&1 &
   runner=$!
   while [ "$i" -lt 60 ] && [ ! -s "$pidfile" ]; do
     sleep 0.25
@@ -236,6 +247,14 @@ abandon() {
   kill -9 "$runner" 2>/dev/null || true
   wait "$runner" 2>/dev/null || true
   ABANDONED="$(cat "$pidfile" 2>/dev/null || true)"
+  ABANDONED_GROUP="$(cat "$scratch"/gg-pty.*/sid 2>/dev/null | tr -dc '0-9' || true)"
+}
+
+# reap_group GROUP — bash, so `--` guards a group id that begins with `-`. The
+# session-side kill in pty.bash cannot use it and says why.
+reap_group() {
+  [ -n "${1:-}" ] || return 0
+  kill -9 -- "-$1" 2>/dev/null || true
 }
 
 # gone_within PID SECONDS
@@ -251,7 +270,9 @@ gone_within() {
 
 printf 'trap "" HUP TERM\necho STARTED\nsleep 300 &\necho "$!" >%q\nwait\n' \
   "$ROOT/abandoned.pid" >"$ROOT/abandon-case.sh"
+rm -f "$ROOT/abandon-case.sh.watchdog"
 abandon "$TEST_DIR/lib/pty.bash" "$ROOT/abandon-case.sh" "$ROOT/abandoned.pid"
+real_group="$ABANDONED_GROUP"
 [ -n "$ABANDONED" ] \
   && ok "an abandoned session really did start the child its own deadline must take" \
   || bad "an abandoned session really did start the child its own deadline must take" "no pid recorded"
@@ -260,6 +281,15 @@ abandon "$TEST_DIR/lib/pty.bash" "$ROOT/abandon-case.sh" "$ROOT/abandoned.pid"
 [ -n "$ABANDONED" ] && gone_within "$ABANDONED" 20 \
   && ok "and the session ends itself once the run that started it is gone" \
   || bad "and the session ends itself once the run that started it is gone" "pid $ABANDONED is still running"
+# WHICH kill ended it. A dead child is also what a spawner collapsing or a
+# hostile reaper leaves, and the session-side kill runs under /bin/sh — dash on
+# the CI runner, where a mis-parsed argument fails silently and reaps nothing.
+# The marker is written by the watchdog and by nothing else, so on that runner
+# this line is the dash measurement rather than an assumption about it.
+[ -f "$ROOT/abandon-case.sh.watchdog" ] \
+  && ok "and it was the session's own deadline that fired, not something upstream" \
+  || bad "and it was the session's own deadline that fired, not something upstream" "no watchdog marker: the in-session kill did not run (dash argument parsing?)"
+reap_group "$real_group"
 
 # The must-fail control: the same abandonment against a copy whose watchdog
 # never starts. Without it the session outlives the run, which is the leak.
@@ -271,15 +301,22 @@ cmp -s "$TEST_DIR/lib/pty.bash" "$NO_DEADLINE" \
 printf 'trap "" HUP TERM\necho STARTED\nsleep 300 &\necho "$!" >%q\nwait\n' \
   "$ROOT/abandoned-mutant.pid" >"$ROOT/abandon-mutant-case.sh"
 abandon "$NO_DEADLINE" "$ROOT/abandon-mutant-case.sh" "$ROOT/abandoned-mutant.pid"
-[ -n "$ABANDONED" ] && ! gone_within "$ABANDONED" 12 \
+mutant_group="$ABANDONED_GROUP"
+mutant_pid="$ABANDONED"
+# The leak this control deliberately creates is reaped BEFORE the assertion,
+# by the group the session recorded for itself: reaping after would be skipped
+# on any path that reports bad and returns early, and reaping by the child's pid
+# would be skipped exactly when no pid was captured. The pid is read once, into
+# a variable of its own, so the next abandon cannot overwrite what is asserted.
+[ -n "$mutant_pid" ] && ! gone_within "$mutant_pid" 12 \
+  && mutant_survived=yes || mutant_survived=no
+reap_group "$mutant_group"
+[ "$mutant_survived" = yes ] \
   && ok "control: without that deadline the abandoned session is still running" \
-  || bad "control: without that deadline the abandoned session is still running" "pid ${ABANDONED:-none} ended anyway, so the case above proves nothing"
-# The leak this control deliberately creates is reaped here, by the group the
-# session recorded for itself — the suite must not become the thing it pins.
-if [ -n "$ABANDONED" ]; then
-  leaked_group="$(ps -o pgid= -p "$ABANDONED" 2>/dev/null | tr -dc '0-9' || true)"
-  [ -z "$leaked_group" ] || kill -9 -- "-$leaked_group" 2>/dev/null || true
-fi
+  || bad "control: without that deadline the abandoned session is still running" "pid ${mutant_pid:-none} ended anyway, so the case above proves nothing"
+[ ! -f "$ROOT/abandon-mutant-case.sh.watchdog" ] \
+  && ok "control: and the mutant wrote no watchdog marker, so the marker names that kill alone" \
+  || bad "control: and the mutant wrote no watchdog marker, so the marker names that kill alone" "a watchdog fired in a copy whose watchdog never starts"
 
 # The status is the SESSION's own, read from the file it wrote rather than
 # from the spawner, which reports on its own account.

--- a/skills/orch/scripts/open-terminal
+++ b/skills/orch/scripts/open-terminal
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Launch one or more work item worktrees in a separate terminal/window.
 # This is a handoff helper only; it does not monitor spawned sessions.
-# In-app harnesses (Codex app, Claude desktop, drovr) never use this script:
-# they hand off through the harness's own tooling — oversee.md § 1.
+# This is the tmux surface's launcher (oversee.md § 1). Where $TMUX is unset and
+# the harness ships its own session or thread launching, the handoff goes
+# through that instead.
 
 set -euo pipefail
 
@@ -145,6 +146,14 @@ export SKILLS_DIR
 # Writing where the readers do not look would silently defeat the claims.
 CLAIM_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 export CLAIM_ROOT
+# open_gui EXECUTES $TERMINAL, so it belongs with the names above rather than
+# with the settings a project may state: the loader below assigns any name a
+# kendex.settings.toml [env] table carries, and a repo choosing which binary a
+# handoff runs is code execution, not a changed answer. Pinning it to the
+# environment — empty when the operator set nothing — makes the loader skip the
+# key while the operator's own value still decides.
+TERMINAL="${TERMINAL:-}"
+export TERMINAL
 # shellcheck source=lib/kendex-env.sh
 source "$SCRIPT_DIR/lib/kendex-env.sh"
 kendex_load_project_env "$PROJECT_ROOT"
@@ -524,19 +533,53 @@ open_tmux() {
 # explicit choice, xdg-terminal-exec the desktop's, and ghostty only where a
 # desktop names neither. Nothing is hardcoded ahead of what the user set.
 open_gui() {
-  local dir="$1" title="$2" cmd="$3"
-  local shell_cmd="cd '$dir' && $cmd"
+  local dir="$1" title="$2" cmd="$3" chosen=""
+  # The title is written from inside the launched shell, so it survives whichever
+  # launcher runs: only the ghostty arm carries --title, and it is tried last.
+  # The title is the item id, validated against GH_ISSUE_PATTERN before it
+  # reaches here — the premise `cd '$dir'` already rests on.
+  local shell_cmd="printf '\033]0;%s\007' '$title'; cd '$dir' && $cmd"
   launchable_dir "$dir" "$title" || return 1
+  local -a launcher=()
   if [[ -n "${TERMINAL:-}" ]] && command -v "$TERMINAL" >/dev/null 2>&1; then
-    setsid env -u CLAUDECODE "$TERMINAL" -e bash -lc "$shell_cmd" </dev/null >/dev/null 2>&1 &
+    chosen="$TERMINAL"
+    launcher=(env -u CLAUDECODE "$TERMINAL" -e bash -lc "$shell_cmd")
   elif command -v xdg-terminal-exec >/dev/null 2>&1; then
-    setsid env -u CLAUDECODE xdg-terminal-exec bash -lc "$shell_cmd" </dev/null >/dev/null 2>&1 &
+    chosen="xdg-terminal-exec"
+    launcher=(env -u CLAUDECODE xdg-terminal-exec bash -lc "$shell_cmd")
   elif command -v ghostty >/dev/null 2>&1; then
-    setsid env -u CLAUDECODE ghostty --working-directory="$dir" --title="$title" -e bash -lc "$shell_cmd" </dev/null >/dev/null 2>&1 &
+    chosen="ghostty"
+    launcher=(env -u CLAUDECODE ghostty --working-directory="$dir" --title="$title" -e bash -lc "$shell_cmd")
   else
     echo "Error: no GUI terminal found; set \$TERMINAL to one, or install xdg-terminal-exec" >&2
     return 1
   fi
+  # A $TERMINAL naming nothing on PATH — a typo, an uninstalled terminal, a value
+  # carrying arguments — is otherwise substituted in silence.
+  [[ -z "${TERMINAL:-}" || "$chosen" == "$TERMINAL" ]] ||
+    echo "Warning: \$TERMINAL '$TERMINAL' does not resolve to an executable; launching '$title' with $chosen instead" >&2
+  # A launch nothing observed is not a launch to report: this exit code is the
+  # orchestrator's only signal that a lane started, and `-e bash -lc CMD` is
+  # ghostty/xterm grammar the GTK family and wezterm do not take. The job gets a
+  # beat — alive means the window is up, exit 0 means the launcher handed off,
+  # any other status is this item's failure carrying the launcher's own words.
+  # setsid execs rather than forks here (a backgrounded job in a shell without
+  # job control is no group leader), so $! is the launcher itself.
+  local err gui_pid gui_rc=0 said
+  err="$(mktemp)" || { echo "Error: no scratch file for '$title'; not launching" >&2; return 1; }
+  setsid "${launcher[@]}" </dev/null >/dev/null 2>"$err" &
+  gui_pid=$!
+  sleep 1
+  if ! kill -0 "$gui_pid" 2>/dev/null; then
+    wait "$gui_pid" || gui_rc=$?
+    if [[ "$gui_rc" -ne 0 ]]; then
+      said="$(tr '\n' ' ' <"$err" 2>/dev/null || true)"
+      rm -f "$err"
+      echo "Error: $chosen exited $gui_rc launching '$title'${said:+: $said}" >&2
+      return 1
+    fi
+  fi
+  rm -f "$err"
   echo "Opened terminal '$title' in $dir"
 }
 

--- a/skills/orch/scripts/open-terminal
+++ b/skills/orch/scripts/open-terminal
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Launch one or more work item worktrees in a separate terminal/window.
 # This is a handoff helper only; it does not monitor spawned sessions.
+# In-app harnesses (Codex app, Claude desktop, drovr) never use this script:
+# they hand off through the harness's own tooling — oversee.md § 1.
 
 set -euo pipefail
 
@@ -14,7 +16,7 @@ Usage: open-terminal [--tracker linear|github] [--repo OWNER/REPO] ITEM... [opti
 Options:
   --harness <name>  claude, codex, opencode, pi
   --tmux            Open tmux windows in the current session
-  --ghostty         Open Ghostty/GUI terminals
+  --ghostty         Open GUI terminals ($TERMINAL, xdg-terminal-exec, ghostty)
   --cmd "..."       Custom command; {issue}, {item}, and {repo} are replaced
   --lane <spec>     Launch under a chosen harness account. `auto` picks the
                     qualifying account with the fewest launches in flight for
@@ -439,6 +441,17 @@ tmux_wait_composer() {
   return 1
 }
 
+# The last layer before any window opens. A launch whose working directory is
+# gone opens a terminal that cannot start, so every path refuses here by name —
+# whatever produced it: a worktree deleted under a running lane, or a stubbed
+# CLI that exits 0 printing nothing. The empty path is the same: `-d ""` is
+# false.
+launchable_dir() { # DIR TITLE
+  [[ -d "$1" ]] && return 0
+  echo "Error: refusing to launch '$2': working directory '$1' does not exist" >&2
+  return 1
+}
+
 open_tmux() {
   local dir="$1" title="$2" cmd="$3" brief="${4:-}"
   # Called on the left of `||` at the launch loop, which suspends errexit for
@@ -447,6 +460,7 @@ open_tmux() {
   # return (most visibly on briefless lanes, whose early return would
   # otherwise count a broken window as launched).
   [[ -n "${TMUX:-}" ]] || { echo "Error: not inside tmux" >&2; return 1; }
+  launchable_dir "$dir" "$title" || return 1
   local last_idx pane spec server
   if ! last_idx=$(tmux list-windows -F '#{window_index}' | tail -1) || [[ -z "$last_idx" ]]; then
     echo "Error: tmux list-windows failed; cannot place window '$title'" >&2
@@ -506,15 +520,21 @@ open_tmux() {
   return 1
 }
 
+# Outside tmux the user's own terminal opens the lane: $TERMINAL is the
+# explicit choice, xdg-terminal-exec the desktop's, and ghostty only where a
+# desktop names neither. Nothing is hardcoded ahead of what the user set.
 open_gui() {
   local dir="$1" title="$2" cmd="$3"
   local shell_cmd="cd '$dir' && $cmd"
-  if command -v ghostty >/dev/null 2>&1; then
-    setsid env -u CLAUDECODE ghostty --working-directory="$dir" --title="$title" -e bash -lc "$shell_cmd" </dev/null >/dev/null 2>&1 &
+  launchable_dir "$dir" "$title" || return 1
+  if [[ -n "${TERMINAL:-}" ]] && command -v "$TERMINAL" >/dev/null 2>&1; then
+    setsid env -u CLAUDECODE "$TERMINAL" -e bash -lc "$shell_cmd" </dev/null >/dev/null 2>&1 &
   elif command -v xdg-terminal-exec >/dev/null 2>&1; then
     setsid env -u CLAUDECODE xdg-terminal-exec bash -lc "$shell_cmd" </dev/null >/dev/null 2>&1 &
+  elif command -v ghostty >/dev/null 2>&1; then
+    setsid env -u CLAUDECODE ghostty --working-directory="$dir" --title="$title" -e bash -lc "$shell_cmd" </dev/null >/dev/null 2>&1 &
   else
-    echo "Error: no supported GUI terminal found" >&2
+    echo "Error: no GUI terminal found; set \$TERMINAL to one, or install xdg-terminal-exec" >&2
     return 1
   fi
   echo "Opened terminal '$title' in $dir"

--- a/skills/orch/scripts/open-terminal
+++ b/skills/orch/scripts/open-terminal
@@ -146,14 +146,6 @@ export SKILLS_DIR
 # Writing where the readers do not look would silently defeat the claims.
 CLAIM_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 export CLAIM_ROOT
-# open_gui EXECUTES $TERMINAL, so it belongs with the names above rather than
-# with the settings a project may state: the loader below assigns any name a
-# kendex.settings.toml [env] table carries, and a repo choosing which binary a
-# handoff runs is code execution, not a changed answer. Pinning it to the
-# environment — empty when the operator set nothing — makes the loader skip the
-# key while the operator's own value still decides.
-TERMINAL="${TERMINAL:-}"
-export TERMINAL
 # shellcheck source=lib/kendex-env.sh
 source "$SCRIPT_DIR/lib/kendex-env.sh"
 kendex_load_project_env "$PROJECT_ROOT"

--- a/skills/orch/scripts/open-terminal
+++ b/skills/orch/scripts/open-terminal
@@ -558,28 +558,7 @@ open_gui() {
   # carrying arguments — is otherwise substituted in silence.
   [[ -z "${TERMINAL:-}" || "$chosen" == "$TERMINAL" ]] ||
     echo "Warning: \$TERMINAL '$TERMINAL' does not resolve to an executable; launching '$title' with $chosen instead" >&2
-  # A launch nothing observed is not a launch to report: this exit code is the
-  # orchestrator's only signal that a lane started, and `-e bash -lc CMD` is
-  # ghostty/xterm grammar the GTK family and wezterm do not take. The job gets a
-  # beat — alive means the window is up, exit 0 means the launcher handed off,
-  # any other status is this item's failure carrying the launcher's own words.
-  # setsid execs rather than forks here (a backgrounded job in a shell without
-  # job control is no group leader), so $! is the launcher itself.
-  local err gui_pid gui_rc=0 said
-  err="$(mktemp)" || { echo "Error: no scratch file for '$title'; not launching" >&2; return 1; }
-  setsid "${launcher[@]}" </dev/null >/dev/null 2>"$err" &
-  gui_pid=$!
-  sleep 1
-  if ! kill -0 "$gui_pid" 2>/dev/null; then
-    wait "$gui_pid" || gui_rc=$?
-    if [[ "$gui_rc" -ne 0 ]]; then
-      said="$(tr '\n' ' ' <"$err" 2>/dev/null || true)"
-      rm -f "$err"
-      echo "Error: $chosen exited $gui_rc launching '$title'${said:+: $said}" >&2
-      return 1
-    fi
-  fi
-  rm -f "$err"
+  setsid "${launcher[@]}" </dev/null >/dev/null 2>&1 &
   echo "Opened terminal '$title' in $dir"
 }
 

--- a/skills/orch/tests/lanes.sh
+++ b/skills/orch/tests/lanes.sh
@@ -13,6 +13,8 @@ set -uo pipefail
 # (.agents/skills/orch/tests/...), where a `<root>/skills/orch/...` path does not
 # exist. Same reason the sibling open-terminal test does it this way.
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/sealed-bin.sh
+. "$TEST_DIR/lib/sealed-bin.sh"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 LANES="$SCRIPTS_DIR/lanes"
 OPEN_TERMINAL="$SCRIPTS_DIR/open-terminal"
@@ -538,7 +540,7 @@ chmod +x "$OT_STUB_BIN/worktree" "$OT_STUB_BIN/gh" "$OT_STUB_BIN/tmux"
 # the repository: a test must never write into the checkout it is testing.
 OT_STATE="$TMP_ROOT/ot-state"
 OT_TMUX_PANES="$TMP_ROOT/ot-panes"
-run_ot() { TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "$@"; }
+run_ot() { TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "$@"; }
 
 # Assert against what a user actually sees, not against a parse of the source.
 # --help must work with no git repository in sight. It used to die with git's
@@ -546,7 +548,7 @@ run_ot() { TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_T
 # failed under `set -e` before argument parsing ever ran.
 NOREPO="$TMP_ROOT/norepo"; mkdir -p "$NOREPO"
 help_rc=0
-HELP_OUT="$( (cd "$NOREPO" && PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
+HELP_OUT="$( (cd "$NOREPO" && PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
   "$OPEN_TERMINAL" --help) 2>&1 )" || help_rc=$?
 assert_eq "$help_rc" "0" "open-terminal --help exits 0 outside a git repository"
 assert_contains "$HELP_OUT" "--lane <spec>" "open-terminal --help documents --lane"
@@ -587,7 +589,7 @@ fi
 # than whatever issue convention the surrounding checkout happens to configure.
 run_ot_aliased() { LANES_HOME="$H" ORCH_LANE_ALIASES="$1" ORCH_LANES_FETCH_CMD="$FETCHER" \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "${@:2}"; }
+  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "${@:2}"; }
 
 set +e
 alias_out=$(run_ot_aliased "eclaude=work" --harness claude --lane work --cmd "true" CC-1 2>&1)
@@ -614,7 +616,7 @@ set +e
 collide_out=$( (cd "$COLLIDE" && LANES_HOME="$H" ORCH_LANE_ALIASES="eclaude=work" \
   ORCH_LANES_FETCH_CMD="$FETCHER" GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' \
   TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
+  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
   "$OPEN_TERMINAL" --harness claude --lane work --cmd "true" CC-1) 2>&1 )
 collide_rc=$?
 set -e
@@ -635,7 +637,7 @@ set +e
 bare_out=$( (cd "$BARE" && LANES_HOME="$H" ORCH_LANE_ALIASES="eclaude=work" \
   ORCH_LANES_FETCH_CMD="$FETCHER" GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' \
   TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
+  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
   "$OPEN_TERMINAL" --harness claude --lane somelane --cmd "true" CC-1) 2>&1 )
 bare_rc=$?
 set -e
@@ -658,20 +660,18 @@ assert_eq "$(cat "$OT_STATE"/claims/*.claim 2>/dev/null | cut -f2)" "%1" \
 rm -rf "$OT_STATE"
 noclaim_out=$(OVERSEE_WATCH_STATE_DIR="$OT_STATE" GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' \
   TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" \
-  PATH="$OT_STUB_BIN:$PATH" \
+  PATH="$OT_STUB_BIN:$SEALED:$PATH" \
   WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" --harness claude --cmd "true" CC-3 2>&1)
 assert_contains "$noclaim_out" "Opened tmux window" "the laneless launch still opened its window"
 assert_eq "$(ls -1 "$OT_STATE/claims" 2>/dev/null | wc -l | tr -d '[:space:]')" "0" \
   "a launch with no --lane records no claim"
 
-# `--lane auto` over a batch: the claim each launch records must move the
-# next item off that account, or one invocation puts the fleet on one lane.
-# $TERMINAL pins the stub open_gui reaches for first: no window opens here.
+# `--lane auto` over a batch: each recorded claim must move the next item off that lane.
 rm -rf "$OT_STATE"; rm -f "$OT_TMUX_PANES"
 run_ot_auto() { LANES_HOME="$H" ORCH_LANES_FETCH_CMD="$FETCHER" \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" \
   OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$PATH" TERMINAL=ghostty WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "$@"; }
+  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "$@"; }
 set +e
 auto_out=$(run_ot_auto --harness claude --lane auto --cmd "true" CC-4 CC-5 2>&1)
 auto_rc=$?
@@ -759,7 +759,7 @@ owned_out=$(LANES_HOME="$H" ORCH_LANES_FETCH_CMD="$FETCHER" OWNED_COUNT="$TMP_RO
   OWNED_ROOT="$TMP_ROOT" \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" \
   OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OWNED_STUB" \
+  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OWNED_STUB" \
   "$OPEN_TERMINAL" --harness claude --lane auto --cmd "true" CC-17 CC-18 2>&1)
 set -e
 assert_contains "$owned_out" "on lane CLAUDE_CONFIG_DIR=$H/.claude" \
@@ -798,7 +798,7 @@ set +e
 tabpick_out=$(LANES_HOME="$H9" FIXTURE_DIR="$TABFIX" ORCH_LANES_FETCH_CMD="$FETCHER" \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" \
   OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
+  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
   "$OPEN_TERMINAL" --harness claude --lane auto --cmd "true" CC-22 CC-23 2>&1)
 tabpick_rc=$?
 set -e
@@ -821,7 +821,7 @@ set +e
 ( cd "$CALLERREPO" && LANES_HOME="$H" ORCH_LANES_FETCH_CMD="$FETCHER" \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" \
   OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" \
-  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
+  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
   "$SCRIPTREPO/scripts/open-terminal" --harness claude --lane auto --cmd "true" CC-20 ) >/dev/null 2>&1
 set -e
 assert_eq "$(ls -1 "$CALLERREPO"/tmp/oversee-watch/claims 2>/dev/null | wc -l | tr -d '[:space:]')" "1" \
@@ -835,7 +835,7 @@ cat > "$OT_STUB_BIN/ghostty" <<'STUBEOF'
 #!/usr/bin/env bash
 exit 0
 STUBEOF
-chmod +x "$OT_STUB_BIN/ghostty"
+chmod +x "$OT_STUB_BIN/ghostty"; export TERMINAL=ghostty  # open_gui reads it first
 rm -rf "$OT_STATE"; rm -f "$OT_TMUX_PANES"
 set +e
 gui_out=$(run_ot_auto --ghostty --harness claude --lane auto --cmd "true" CC-10 CC-11 2>&1)
@@ -868,7 +868,7 @@ stop_out=$(LANES_HOME="$H" ORCH_LANES_FETCH_CMD="$TMP_ROOT/fetch-flaky" \
   FLAKY_COUNT="$TMP_ROOT/flaky-count" FLAKY_OK=3 \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" \
   OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
+  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
   "$OPEN_TERMINAL" --harness claude --lane auto --cmd "true" CC-6 CC-7 2>&1)
 stop_rc=$?
 set -e

--- a/skills/orch/tests/lanes.sh
+++ b/skills/orch/tests/lanes.sh
@@ -13,8 +13,6 @@ set -uo pipefail
 # (.agents/skills/orch/tests/...), where a `<root>/skills/orch/...` path does not
 # exist. Same reason the sibling open-terminal test does it this way.
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=lib/sealed-bin.sh
-. "$TEST_DIR/lib/sealed-bin.sh"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 LANES="$SCRIPTS_DIR/lanes"
 OPEN_TERMINAL="$SCRIPTS_DIR/open-terminal"
@@ -540,7 +538,7 @@ chmod +x "$OT_STUB_BIN/worktree" "$OT_STUB_BIN/gh" "$OT_STUB_BIN/tmux"
 # the repository: a test must never write into the checkout it is testing.
 OT_STATE="$TMP_ROOT/ot-state"
 OT_TMUX_PANES="$TMP_ROOT/ot-panes"
-run_ot() { TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "$@"; }
+run_ot() { TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "$@"; }
 
 # Assert against what a user actually sees, not against a parse of the source.
 # --help must work with no git repository in sight. It used to die with git's
@@ -548,7 +546,7 @@ run_ot() { TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_T
 # failed under `set -e` before argument parsing ever ran.
 NOREPO="$TMP_ROOT/norepo"; mkdir -p "$NOREPO"
 help_rc=0
-HELP_OUT="$( (cd "$NOREPO" && PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
+HELP_OUT="$( (cd "$NOREPO" && PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
   "$OPEN_TERMINAL" --help) 2>&1 )" || help_rc=$?
 assert_eq "$help_rc" "0" "open-terminal --help exits 0 outside a git repository"
 assert_contains "$HELP_OUT" "--lane <spec>" "open-terminal --help documents --lane"
@@ -589,7 +587,7 @@ fi
 # than whatever issue convention the surrounding checkout happens to configure.
 run_ot_aliased() { LANES_HOME="$H" ORCH_LANE_ALIASES="$1" ORCH_LANES_FETCH_CMD="$FETCHER" \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "${@:2}"; }
+  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "${@:2}"; }
 
 set +e
 alias_out=$(run_ot_aliased "eclaude=work" --harness claude --lane work --cmd "true" CC-1 2>&1)
@@ -616,7 +614,7 @@ set +e
 collide_out=$( (cd "$COLLIDE" && LANES_HOME="$H" ORCH_LANE_ALIASES="eclaude=work" \
   ORCH_LANES_FETCH_CMD="$FETCHER" GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' \
   TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
+  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
   "$OPEN_TERMINAL" --harness claude --lane work --cmd "true" CC-1) 2>&1 )
 collide_rc=$?
 set -e
@@ -637,7 +635,7 @@ set +e
 bare_out=$( (cd "$BARE" && LANES_HOME="$H" ORCH_LANE_ALIASES="eclaude=work" \
   ORCH_LANES_FETCH_CMD="$FETCHER" GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' \
   TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
+  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
   "$OPEN_TERMINAL" --harness claude --lane somelane --cmd "true" CC-1) 2>&1 )
 bare_rc=$?
 set -e
@@ -660,7 +658,7 @@ assert_eq "$(cat "$OT_STATE"/claims/*.claim 2>/dev/null | cut -f2)" "%1" \
 rm -rf "$OT_STATE"
 noclaim_out=$(OVERSEE_WATCH_STATE_DIR="$OT_STATE" GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' \
   TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" \
-  PATH="$OT_STUB_BIN:$SEALED:$PATH" \
+  PATH="$OT_STUB_BIN:$PATH" \
   WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" --harness claude --cmd "true" CC-3 2>&1)
 assert_contains "$noclaim_out" "Opened tmux window" "the laneless launch still opened its window"
 assert_eq "$(ls -1 "$OT_STATE/claims" 2>/dev/null | wc -l | tr -d '[:space:]')" "0" \
@@ -671,7 +669,7 @@ rm -rf "$OT_STATE"; rm -f "$OT_TMUX_PANES"
 run_ot_auto() { LANES_HOME="$H" ORCH_LANES_FETCH_CMD="$FETCHER" \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" \
   OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "$@"; }
+  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "$@"; }
 set +e
 auto_out=$(run_ot_auto --harness claude --lane auto --cmd "true" CC-4 CC-5 2>&1)
 auto_rc=$?
@@ -759,7 +757,7 @@ owned_out=$(LANES_HOME="$H" ORCH_LANES_FETCH_CMD="$FETCHER" OWNED_COUNT="$TMP_RO
   OWNED_ROOT="$TMP_ROOT" \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" \
   OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OWNED_STUB" \
+  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OWNED_STUB" \
   "$OPEN_TERMINAL" --harness claude --lane auto --cmd "true" CC-17 CC-18 2>&1)
 set -e
 assert_contains "$owned_out" "on lane CLAUDE_CONFIG_DIR=$H/.claude" \
@@ -798,7 +796,7 @@ set +e
 tabpick_out=$(LANES_HOME="$H9" FIXTURE_DIR="$TABFIX" ORCH_LANES_FETCH_CMD="$FETCHER" \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" \
   OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
+  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
   "$OPEN_TERMINAL" --harness claude --lane auto --cmd "true" CC-22 CC-23 2>&1)
 tabpick_rc=$?
 set -e
@@ -821,7 +819,7 @@ set +e
 ( cd "$CALLERREPO" && LANES_HOME="$H" ORCH_LANES_FETCH_CMD="$FETCHER" \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" \
   OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" \
-  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
+  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
   "$SCRIPTREPO/scripts/open-terminal" --harness claude --lane auto --cmd "true" CC-20 ) >/dev/null 2>&1
 set -e
 assert_eq "$(ls -1 "$CALLERREPO"/tmp/oversee-watch/claims 2>/dev/null | wc -l | tr -d '[:space:]')" "1" \
@@ -868,7 +866,7 @@ stop_out=$(LANES_HOME="$H" ORCH_LANES_FETCH_CMD="$TMP_ROOT/fetch-flaky" \
   FLAKY_COUNT="$TMP_ROOT/flaky-count" FLAKY_OK=3 \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" \
   OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$SEALED:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
+  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" \
   "$OPEN_TERMINAL" --harness claude --lane auto --cmd "true" CC-6 CC-7 2>&1)
 stop_rc=$?
 set -e

--- a/skills/orch/tests/lanes.sh
+++ b/skills/orch/tests/lanes.sh
@@ -664,14 +664,14 @@ assert_contains "$noclaim_out" "Opened tmux window" "the laneless launch still o
 assert_eq "$(ls -1 "$OT_STATE/claims" 2>/dev/null | wc -l | tr -d '[:space:]')" "0" \
   "a launch with no --lane records no claim"
 
-# `--lane auto` over a batch: the claim each launch records must move the next
-# item off that account, or one invocation puts the whole fleet on one lane —
-# the failure the claims exist to prevent.
+# `--lane auto` over a batch: the claim each launch records must move the
+# next item off that account, or one invocation puts the fleet on one lane.
+# $TERMINAL pins the stub open_gui reaches for first: no window opens here.
 rm -rf "$OT_STATE"; rm -f "$OT_TMUX_PANES"
 run_ot_auto() { LANES_HOME="$H" ORCH_LANES_FETCH_CMD="$FETCHER" \
   GH_ISSUE_PATTERN='[A-Z]+-[0-9]+' TMUX=stub,1,0 OT_TMUX_LOG="$OT_TMUX_LOG" \
   OT_TMUX_SERVER_PID="$$" OT_TMUX_PANES="$OT_TMUX_PANES" OVERSEE_WATCH_STATE_DIR="$OT_STATE" \
-  PATH="$OT_STUB_BIN:$PATH" WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "$@"; }
+  PATH="$OT_STUB_BIN:$PATH" TERMINAL=ghostty WORKTREE_CLI="$OT_STUB_BIN/worktree" "$OPEN_TERMINAL" "$@"; }
 set +e
 auto_out=$(run_ot_auto --harness claude --lane auto --cmd "true" CC-4 CC-5 2>&1)
 auto_rc=$?

--- a/skills/orch/tests/lib/sealed-bin.sh
+++ b/skills/orch/tests/lib/sealed-bin.sh
@@ -1,0 +1,19 @@
+# shellcheck shell=bash
+# Resolves SEALED: the committed refusal fixture at tools/tests/lib/sealed-bin.
+# A suite appends it to PATH AFTER its own stub directory — the stubs answer
+# while they exist, the seal refuses once the temp tree behind them is gone.
+# Which names it covers, and why, are in that directory's `refuse`.
+#
+# Sourced rather than repeated. Three suites carried byte-identical copies of
+# this block, and a rule spelled once per adopter is a rule the next adopter
+# gets to forget.
+#
+# Relative first, so an exported tree that is no git checkout still runs these
+# suites — the mutation harness extracts one with git archive. git's own failure
+# must not become the caller's: in a non-git tree the substitution exits 128,
+# and under set -e that would end the run before the named error below printed.
+SEALED="$(cd "${BASH_SOURCE[0]%/*}/../../../.." && pwd)/tools/tests/lib/sealed-bin"
+if [[ ! -x "$SEALED/gh" ]]; then
+  SEALED="$(git -C "${BASH_SOURCE[0]%/*}" rev-parse --show-toplevel 2>/dev/null || true)/tools/tests/lib/sealed-bin"
+fi
+[[ -x "$SEALED/gh" ]] || { echo "${0##*/}: sealed-bin fixture is missing: $SEALED" >&2; exit 1; }

--- a/skills/orch/tests/merge_queue_rearm_e2e.sh
+++ b/skills/orch/tests/merge_queue_rearm_e2e.sh
@@ -9,17 +9,8 @@ set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ORCH="$(cd "$TEST_DIR/.." && pwd)"
-# Relative first, so an exported tree that is no git checkout still runs
-# these suites — the mutation harness extracts one with git archive.
-SEALED="$(cd "$TEST_DIR/../../.." && pwd)/tools/tests/lib/sealed-bin"
-# git's own failure must not become this script's: in a non-git tree the
-# substitution exits 128, and under set -e that would end the run before the
-# named error below ever printed.
-if [[ ! -x "$SEALED/gh" ]]; then
-  REPO_TOP="$(git -C "$TEST_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
-  SEALED="$REPO_TOP/tools/tests/lib/sealed-bin"
-fi
-[[ -x "$SEALED/gh" ]] || { echo "merge_queue_rearm_e2e: sealed-bin fixture is missing: $SEALED" >&2; exit 1; }
+# shellcheck source=lib/sealed-bin.sh
+. "$TEST_DIR/lib/sealed-bin.sh"
 TMP="$(mktemp -d)"
 # This suite launches real detached supervisors; teardown owns their pids.
 # shellcheck source=lib/merge-queue-reaper.sh

--- a/skills/orch/tests/merge_queue_teardown.sh
+++ b/skills/orch/tests/merge_queue_teardown.sh
@@ -22,17 +22,8 @@ set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ORCH="$(cd "$TEST_DIR/.." && pwd)"
-# Relative first, so an exported tree that is no git checkout still runs
-# these suites — the mutation harness extracts one with git archive.
-SEALED="$(cd "$TEST_DIR/../../.." && pwd)/tools/tests/lib/sealed-bin"
-# git's own failure must not become this script's: in a non-git tree the
-# substitution exits 128, and under set -e that would end the run before the
-# named error below ever printed.
-if [[ ! -x "$SEALED/gh" ]]; then
-  REPO_TOP="$(git -C "$TEST_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
-  SEALED="$REPO_TOP/tools/tests/lib/sealed-bin"
-fi
-[[ -x "$SEALED/gh" ]] || { echo "merge_queue_teardown: sealed-bin fixture is missing: $SEALED" >&2; exit 1; }
+# shellcheck source=lib/sealed-bin.sh
+. "$TEST_DIR/lib/sealed-bin.sh"
 TMP="$(mktemp -d)"
 # shellcheck source=lib/merge-queue-reaper.sh
 . "$TEST_DIR/lib/merge-queue-reaper.sh"
@@ -664,10 +655,15 @@ suite_arms_teardown() {
   traps=$(exit_traps_in "$1") || return 2
   [[ "$traps" == 'trap mq_reap_teardown EXIT' ]]
 }
+# Either spelling of obtaining SEALED counts — the directory named outright, or
+# lib/sealed-bin.sh sourced, which is where that name now resolves. What the
+# check is FOR is the second half: obtaining it and never putting it behind the
+# stubs on PATH seals nothing.
 suite_seals_path() {
   local body
   body=$(grep -v '^[[:space:]]*#' "$1") || return 1
-  grep -q 'tools/tests/lib/sealed-bin' <<<"$body" && grep -qF '$SEALED:$PATH' <<<"$body"
+  grep -qE 'tools/tests/lib/sealed-bin|lib/sealed-bin\.sh' <<<"$body" \
+    && grep -qF '$SEALED:$PATH' <<<"$body"
 }
 
 roster=$(launching_suites "$TEST_DIR")
@@ -751,6 +747,12 @@ trap mq_reap_teardown EXIT
 cat > /dev/null <<NEVERCLOSED
 UNTERM
 printf '#!/usr/bin/env bash\n# trap mq_reap_teardown EXIT\n# tools/tests/lib/sealed-bin and "$SEALED:$PATH"\n' > "$planted/comment_decoy.sh"
+# The two halves of the sealing check, each planted without the other: a suite
+# that sources the helper and never reaches PATH, and one that builds a PATH
+# from a SEALED it never obtained.
+printf '#!/usr/bin/env bash\n. "$TEST_DIR/lib/sealed-bin.sh"\nPATH="$BIN:$PATH"\n' > "$planted/sourced_unsealed_suite.sh"
+printf '#!/usr/bin/env bash\nPATH="$BIN:$SEALED:$PATH"\n' > "$planted/pathed_unsourced_suite.sh"
+printf '#!/usr/bin/env bash\n. "$TEST_DIR/lib/sealed-bin.sh"\nPATH="$BIN:$SEALED:$PATH"\n' > "$planted/sourced_sealed_suite.sh"
 
 if suite_arms_teardown "$planted/armed_suite.sh"; then ok "a suite that installs the reaping teardown passes the arming check"
 else bad "the arming check rejects a suite that is armed"; fi
@@ -771,6 +773,12 @@ case "$unterm_err" in *"could not complete"*) ok "the incomplete scan names the 
   *) bad "the incomplete scan is unnamed: $unterm_err" ;; esac
 if suite_seals_path "$planted/comment_decoy.sh"; then bad "a comment naming the sealed directory passed the sealing check"
 else ok "a comment naming the sealed directory does not pass for a statement"; fi
+if suite_seals_path "$planted/sourced_sealed_suite.sh"; then ok "sourcing lib/sealed-bin.sh and sealing PATH passes the check"
+else bad "a suite that sources the helper and seals its PATH was rejected"; fi
+for half in sourced_unsealed_suite pathed_unsourced_suite; do
+  if suite_seals_path "$planted/$half.sh"; then bad "$half passed the sealing check with only half of it"
+  else ok "the sealing check rejects $half"; fi
+done
 
 printf 'merge-queue-teardown: %d pass, %d fail\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/orch/tests/merge_queue_watch.sh
+++ b/skills/orch/tests/merge_queue_watch.sh
@@ -3,17 +3,8 @@ set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ORCH="$(cd "$TEST_DIR/.." && pwd)"
-# Relative first, so an exported tree that is no git checkout still runs
-# these suites — the mutation harness extracts one with git archive.
-SEALED="$(cd "$TEST_DIR/../../.." && pwd)/tools/tests/lib/sealed-bin"
-# git's own failure must not become this script's: in a non-git tree the
-# substitution exits 128, and under set -e that would end the run before the
-# named error below ever printed.
-if [[ ! -x "$SEALED/gh" ]]; then
-  REPO_TOP="$(git -C "$TEST_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
-  SEALED="$REPO_TOP/tools/tests/lib/sealed-bin"
-fi
-[[ -x "$SEALED/gh" ]] || { echo "merge_queue_watch: sealed-bin fixture is missing: $SEALED" >&2; exit 1; }
+# shellcheck source=lib/sealed-bin.sh
+. "$TEST_DIR/lib/sealed-bin.sh"
 TMP_ROOT="$(mktemp -d)"; TMP="$TMP_ROOT/watch path"
 mkdir "$TMP"
 # This suite launches real detached supervisors; teardown owns their pids.

--- a/skills/orch/tests/open-terminal-claude-handoff.sh
+++ b/skills/orch/tests/open-terminal-claude-handoff.sh
@@ -115,6 +115,11 @@ exit 0
 EOF
 chmod +x "$BIN/ghostty" "$BIN/gh" "$BIN/tmux"
 
+# $TERMINAL is what open_gui reaches for first, so it is PINNED to the stub on
+# PATH here: unset, the branch below it would resolve whatever terminal the
+# developer's desktop provides and this suite would open real windows.
+export TERMINAL=ghostty
+
 # Stub worktree CLI: `create <item>` makes and prints a temp dir.
 STUB="$TMP_ROOT/worktree-stub"
 cat > "$STUB" <<EOF

--- a/skills/orch/tests/open-terminal-claude-handoff.sh
+++ b/skills/orch/tests/open-terminal-claude-handoff.sh
@@ -28,8 +28,6 @@ set -euo pipefail
 TC=" — complete means the PR is MERGED and the worktree cleaned up, not merely opened"
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=lib/sealed-bin.sh
-. "$TEST_DIR/lib/sealed-bin.sh"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 SRC_OT="$SCRIPTS_DIR/open-terminal"
 SRC_LIB_DIR="$SCRIPTS_DIR/lib"
@@ -117,8 +115,9 @@ exit 0
 EOF
 chmod +x "$BIN/ghostty" "$BIN/gh" "$BIN/tmux"
 
-# open_gui reaches for $TERMINAL first, so it names the stub rather than the
-# developer's own terminal. $SEALED is what answers once the stub tree is gone.
+# $TERMINAL is what open_gui reaches for first, so it is PINNED to the stub on
+# PATH here: unset, the branch below it would resolve whatever terminal the
+# developer's desktop provides and this suite would open real windows.
 export TERMINAL=ghostty
 
 # Stub worktree CLI: `create <item>` makes and prints a temp dir.
@@ -209,7 +208,7 @@ echo "=== open-terminal claude handoff: per-task launch flags ==="
 # Case 1: linear:claude renders the autonomy flag by default.
 CAP1="$TMP_ROOT/cap1"
 set +e
-c1_out=$(OT_CAPTURE="$CAP1" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--model opus[1m] --effort max --dangerously-skip-permissions" cc-737 2>"$TMP_ROOT/c1.err")
+c1_out=$(OT_CAPTURE="$CAP1" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--model opus[1m] --effort max --dangerously-skip-permissions" cc-737 2>"$TMP_ROOT/c1.err")
 c1_code=$?
 set -e
 assert_eq "$c1_code" "0" "linear:claude launch succeeds"
@@ -227,7 +226,7 @@ assert_not_contains "$(cat "$TMP_ROOT/c1.err")" "WARNING" \
 # Case 2: github:claude renders the same flag.
 CAP2="$TMP_ROOT/cap2"
 set +e
-c2_out=$(OT_CAPTURE="$CAP2" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tracker github --repo acme/widgets --ghostty --harness claude --launch-flags "--effort max --dangerously-skip-permissions" 42 2>"$TMP_ROOT/c2.err")
+c2_out=$(OT_CAPTURE="$CAP2" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tracker github --repo acme/widgets --ghostty --harness claude --launch-flags "--effort max --dangerously-skip-permissions" 42 2>"$TMP_ROOT/c2.err")
 c2_code=$?
 set -e
 assert_eq "$c2_code" "0" "github:claude launch succeeds"
@@ -245,7 +244,7 @@ fi
 # settings file participates.
 CAP3="$TMP_ROOT/cap3"
 set +e
-c3_out=$(OT_CAPTURE="$CAP3" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--model sonnet --permission-mode bypassPermissions" cc-737 2>"$TMP_ROOT/c3.err")
+c3_out=$(OT_CAPTURE="$CAP3" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--model sonnet --permission-mode bypassPermissions" cc-737 2>"$TMP_ROOT/c3.err")
 c3_code=$?
 set -e
 assert_eq "$c3_code" "0" "a second launch with different flags succeeds"
@@ -266,7 +265,7 @@ assert_not_contains "$(cat "$TMP_ROOT/c3.err")" "WARNING" \
 # would type — no stored model, effort, or permission default appears.
 CAP3B="$TMP_ROOT/cap3b"
 set +e
-OT_CAPTURE="$CAP3B" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude cc-737 2>"$TMP_ROOT/c3b.err"
+OT_CAPTURE="$CAP3B" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude cc-737 2>"$TMP_ROOT/c3b.err"
 set -e
 if wait_capture "$CAP3B"; then
   c3b_cmd="$(cat "$CAP3B")"
@@ -285,7 +284,7 @@ assert_contains "$(cat "$TMP_ROOT/c3b.err")" "handoff autonomy is void" \
 # autonomy is void.
 CAP4="$TMP_ROOT/cap4"
 set +e
-c4_out=$(OT_CAPTURE="$CAP4" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--permission-mode plan" cc-737 2>"$TMP_ROOT/c4.err")
+c4_out=$(OT_CAPTURE="$CAP4" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--permission-mode plan" cc-737 2>"$TMP_ROOT/c4.err")
 c4_code=$?
 set -e
 assert_eq "$c4_code" "0" "prompting flags still launch"
@@ -305,7 +304,7 @@ echo "=== open-terminal claude handoff: tmux brief delivery ==="
 new_tmux_state c5
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c5_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude --launch-flags "--dangerously-skip-permissions" cc-737 2>"$TMP_ROOT/c5.err")
+c5_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude --launch-flags "--dangerously-skip-permissions" cc-737 2>"$TMP_ROOT/c5.err")
 c5_code=$?
 set -e
 assert_eq "$c5_code" "0" "tmux delivered-first-pass exits 0"
@@ -328,7 +327,7 @@ printf '%s\n' "$ECHO_SCREEN" > "$OT_TMUX_CAPTURES/1"
 printf '%s\n' "$READY_SCREEN" > "$OT_TMUX_CAPTURES/2"
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/3"
 set +e
-c6_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c6.err")
+c6_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c6.err")
 c6_code=$?
 set -e
 assert_eq "$c6_code" "0" "tmux re-delivery path exits 0"
@@ -350,7 +349,7 @@ printf '%s\n' "$ECHO_SCREEN" > "$OT_TMUX_CAPTURES/3"
 printf '%s\n' "$READY_SCREEN" > "$OT_TMUX_CAPTURES/4"
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/5"
 set +e
-c6b_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=2 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c6b.err")
+c6b_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=2 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c6b.err")
 c6b_code=$?
 set -e
 assert_eq "$c6b_code" "0" "dialog-then-ready path exits 0"
@@ -371,7 +370,7 @@ printf '%s\n' "$ECHO_SCREEN" > "$OT_TMUX_CAPTURES/1"
 printf '%s\n' "$READY_SCREEN" > "$OT_TMUX_CAPTURES/2"
 printf '%s\n' "$READY_SCREEN" > "$OT_TMUX_CAPTURES/3"
 set +e
-c7_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c7.err")
+c7_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c7.err")
 c7_code=$?
 set -e
 assert_eq "$c7_code" "1" "undelivered brief exits nonzero"
@@ -388,7 +387,7 @@ assert_eq "$c7_resends" "1" "re-send is attempted exactly once before failing"
 new_tmux_state c8
 printf '%s\n' "$COMPOSER_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c8_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c8.err")
+c8_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c8.err")
 c8_code=$?
 set -e
 assert_eq "$c8_code" "1" "composer-only screen exits nonzero"
@@ -406,7 +405,7 @@ assert_eq "$c8_resends" "1" "composer-only screen still gets exactly one re-send
 new_tmux_state c8b
 { printf '%s\n' "$DELIVERED_SCREEN"; awk 'BEGIN { for (i = 0; i < 20000; i++) print "transcript filler line" }'; } > "$OT_TMUX_CAPTURES/1"
 set +e
-c8b_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c8b.err")
+c8b_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c8b.err")
 c8b_code=$?
 set -e
 assert_eq "$c8b_code" "0" "huge scrollback with an early delivered brief exits 0"
@@ -421,7 +420,7 @@ echo "=== open-terminal claude handoff: tmux failure detection ==="
 new_tmux_state c9
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c9_out=$(TMUX=stub,1,0 OT_TMUX_FAIL=new-window ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c9.err")
+c9_out=$(TMUX=stub,1,0 OT_TMUX_FAIL=new-window ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c9.err")
 c9_code=$?
 set -e
 assert_eq "$c9_code" "1" "new-window failure exits nonzero"
@@ -434,7 +433,7 @@ assert_not_contains "$c9_out" "Done: launched 1" \
 # early return must not count a window whose launch keystrokes failed.
 new_tmux_state c10
 set +e
-c10_out=$(TMUX=stub,1,0 OT_TMUX_FAIL=send-keys ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness codex cc-737 2>"$TMP_ROOT/c10.err")
+c10_out=$(TMUX=stub,1,0 OT_TMUX_FAIL=send-keys ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness codex cc-737 2>"$TMP_ROOT/c10.err")
 c10_code=$?
 set -e
 assert_eq "$c10_code" "1" "send-keys failure exits nonzero on a briefless lane"
@@ -449,7 +448,7 @@ echo "=== open-terminal claude handoff: config validation ==="
 # command, so it must never pass through unvalidated.
 CAP11="$TMP_ROOT/cap11"
 set +e
-c11_out=$(OT_CAPTURE="$CAP11" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--flag; touch $TMP_ROOT/pwned" cc-737 2>"$TMP_ROOT/c11.err")
+c11_out=$(OT_CAPTURE="$CAP11" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--flag; touch $TMP_ROOT/pwned" cc-737 2>"$TMP_ROOT/c11.err")
 c11_code=$?
 set -e
 assert_eq "$c11_code" "1" "metacharacter launch flags refuse to launch"
@@ -466,7 +465,7 @@ fi
 # Case 11b: a bracketed model id is an ordinary flag value, not a shell hazard.
 CAP11B="$TMP_ROOT/cap11b"
 set +e
-OT_CAPTURE="$CAP11B" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--model opus[1m] --dangerously-skip-permissions" cc-737 2>"$TMP_ROOT/c11b.err"
+OT_CAPTURE="$CAP11B" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--model opus[1m] --dangerously-skip-permissions" cc-737 2>"$TMP_ROOT/c11b.err"
 c11b_code=$?
 set -e
 assert_eq "$c11b_code" "0" "a bracketed model id is accepted"
@@ -487,7 +486,7 @@ printf '%s\n' "$@" > "$OT_ARGV_CAPTURE"
 EOF
   chmod +x "$BIN/claude"
   c11c_argv="$TMP_ROOT/c11c.argv"
-  (cd "$c11c_dir" && OT_ARGV_CAPTURE="$c11c_argv" PATH="$BIN:$SEALED:$PATH" bash -lc "${c11c_cmd##*&& }") >/dev/null 2>&1 || true
+  (cd "$c11c_dir" && OT_ARGV_CAPTURE="$c11c_argv" PATH="$BIN:$PATH" bash -lc "${c11c_cmd##*&& }") >/dev/null 2>&1 || true
   assert_contains "$(cat "$c11c_argv" 2>/dev/null || true)" "opus[1m]" \
     "the bracketed model id survives the shell that runs the launch command"
   assert_not_contains "$(cat "$c11c_argv" 2>/dev/null || true)" "opus1" \
@@ -503,7 +502,7 @@ fi
 new_tmux_state c12
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c12_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=abc PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c12.err")
+c12_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=abc PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c12.err")
 c12_code=$?
 set -e
 assert_eq "$c12_code" "1" "non-integer verify secs exits nonzero"
@@ -516,7 +515,7 @@ assert_not_contains "$(cat "$TMP_ROOT/c12.err")" "brief undelivered" \
 new_tmux_state c13
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c13_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=0 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c13.err")
+c13_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=0 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c13.err")
 c13_code=$?
 set -e
 assert_eq "$c13_code" "1" "zero verify secs exits nonzero"
@@ -528,7 +527,7 @@ assert_contains "$(cat "$TMP_ROOT/c13.err")" "ORCH_TMUX_VERIFY_SECS" \
 new_tmux_state c13b
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c13b_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=08 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c13b.err")
+c13b_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=08 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c13b.err")
 c13b_code=$?
 set -e
 assert_eq "$c13b_code" "0" "leading-zero verify secs is base-10 and launches"
@@ -540,7 +539,7 @@ assert_not_contains "$(cat "$TMP_ROOT/c13b.err")" "value too great" \
 new_tmux_state c13c
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c13c_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=10000000000000000000 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c13c.err")
+c13c_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=10000000000000000000 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c13c.err")
 c13c_code=$?
 set -e
 assert_eq "$c13c_code" "0" "overflow-sized verify secs still launches (clamped)"
@@ -553,7 +552,7 @@ assert_eq "$c13c_resends" "0" "no instant resend from a zero-pass verify loop"
 # never reads it.
 CAP13D="$TMP_ROOT/cap13d"
 set +e
-c13d_out=$(ORCH_TMUX_VERIFY_SECS=abc OT_CAPTURE="$CAP13D" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude cc-737 2>"$TMP_ROOT/c13d.err")
+c13d_out=$(ORCH_TMUX_VERIFY_SECS=abc OT_CAPTURE="$CAP13D" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude cc-737 2>"$TMP_ROOT/c13d.err")
 c13d_code=$?
 set -e
 assert_eq "$c13d_code" "0" "invalid verify secs does not abort a GUI launch"
@@ -564,7 +563,7 @@ assert_not_contains "$(cat "$TMP_ROOT/c13d.err")" "ORCH_TMUX_VERIFY_SECS" \
 # only Claude verification lanes read the timeout.
 new_tmux_state c13e
 set +e
-c13e_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=abc PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness codex cc-737 2>"$TMP_ROOT/c13e.err")
+c13e_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=abc PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness codex cc-737 2>"$TMP_ROOT/c13e.err")
 c13e_code=$?
 set -e
 assert_eq "$c13e_code" "0" "invalid verify secs does not abort a tmux codex launch"
@@ -576,7 +575,7 @@ assert_not_contains "$(cat "$TMP_ROOT/c13e.err")" "ORCH_TMUX_VERIFY_SECS" \
 new_tmux_state c14
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c14_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=99999 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c14.err")
+c14_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=99999 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c14.err")
 c14_code=$?
 set -e
 assert_eq "$c14_code" "0" "clamped verify secs still launches"

--- a/skills/orch/tests/open-terminal-claude-handoff.sh
+++ b/skills/orch/tests/open-terminal-claude-handoff.sh
@@ -28,6 +28,8 @@ set -euo pipefail
 TC=" — complete means the PR is MERGED and the worktree cleaned up, not merely opened"
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/sealed-bin.sh
+. "$TEST_DIR/lib/sealed-bin.sh"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 SRC_OT="$SCRIPTS_DIR/open-terminal"
 SRC_LIB_DIR="$SCRIPTS_DIR/lib"
@@ -115,9 +117,8 @@ exit 0
 EOF
 chmod +x "$BIN/ghostty" "$BIN/gh" "$BIN/tmux"
 
-# $TERMINAL is what open_gui reaches for first, so it is PINNED to the stub on
-# PATH here: unset, the branch below it would resolve whatever terminal the
-# developer's desktop provides and this suite would open real windows.
+# open_gui reaches for $TERMINAL first, so it names the stub rather than the
+# developer's own terminal. $SEALED is what answers once the stub tree is gone.
 export TERMINAL=ghostty
 
 # Stub worktree CLI: `create <item>` makes and prints a temp dir.
@@ -208,7 +209,7 @@ echo "=== open-terminal claude handoff: per-task launch flags ==="
 # Case 1: linear:claude renders the autonomy flag by default.
 CAP1="$TMP_ROOT/cap1"
 set +e
-c1_out=$(OT_CAPTURE="$CAP1" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--model opus[1m] --effort max --dangerously-skip-permissions" cc-737 2>"$TMP_ROOT/c1.err")
+c1_out=$(OT_CAPTURE="$CAP1" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--model opus[1m] --effort max --dangerously-skip-permissions" cc-737 2>"$TMP_ROOT/c1.err")
 c1_code=$?
 set -e
 assert_eq "$c1_code" "0" "linear:claude launch succeeds"
@@ -226,7 +227,7 @@ assert_not_contains "$(cat "$TMP_ROOT/c1.err")" "WARNING" \
 # Case 2: github:claude renders the same flag.
 CAP2="$TMP_ROOT/cap2"
 set +e
-c2_out=$(OT_CAPTURE="$CAP2" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tracker github --repo acme/widgets --ghostty --harness claude --launch-flags "--effort max --dangerously-skip-permissions" 42 2>"$TMP_ROOT/c2.err")
+c2_out=$(OT_CAPTURE="$CAP2" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tracker github --repo acme/widgets --ghostty --harness claude --launch-flags "--effort max --dangerously-skip-permissions" 42 2>"$TMP_ROOT/c2.err")
 c2_code=$?
 set -e
 assert_eq "$c2_code" "0" "github:claude launch succeeds"
@@ -244,7 +245,7 @@ fi
 # settings file participates.
 CAP3="$TMP_ROOT/cap3"
 set +e
-c3_out=$(OT_CAPTURE="$CAP3" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--model sonnet --permission-mode bypassPermissions" cc-737 2>"$TMP_ROOT/c3.err")
+c3_out=$(OT_CAPTURE="$CAP3" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--model sonnet --permission-mode bypassPermissions" cc-737 2>"$TMP_ROOT/c3.err")
 c3_code=$?
 set -e
 assert_eq "$c3_code" "0" "a second launch with different flags succeeds"
@@ -265,7 +266,7 @@ assert_not_contains "$(cat "$TMP_ROOT/c3.err")" "WARNING" \
 # would type — no stored model, effort, or permission default appears.
 CAP3B="$TMP_ROOT/cap3b"
 set +e
-OT_CAPTURE="$CAP3B" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude cc-737 2>"$TMP_ROOT/c3b.err"
+OT_CAPTURE="$CAP3B" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude cc-737 2>"$TMP_ROOT/c3b.err"
 set -e
 if wait_capture "$CAP3B"; then
   c3b_cmd="$(cat "$CAP3B")"
@@ -284,7 +285,7 @@ assert_contains "$(cat "$TMP_ROOT/c3b.err")" "handoff autonomy is void" \
 # autonomy is void.
 CAP4="$TMP_ROOT/cap4"
 set +e
-c4_out=$(OT_CAPTURE="$CAP4" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--permission-mode plan" cc-737 2>"$TMP_ROOT/c4.err")
+c4_out=$(OT_CAPTURE="$CAP4" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--permission-mode plan" cc-737 2>"$TMP_ROOT/c4.err")
 c4_code=$?
 set -e
 assert_eq "$c4_code" "0" "prompting flags still launch"
@@ -304,7 +305,7 @@ echo "=== open-terminal claude handoff: tmux brief delivery ==="
 new_tmux_state c5
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c5_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude --launch-flags "--dangerously-skip-permissions" cc-737 2>"$TMP_ROOT/c5.err")
+c5_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude --launch-flags "--dangerously-skip-permissions" cc-737 2>"$TMP_ROOT/c5.err")
 c5_code=$?
 set -e
 assert_eq "$c5_code" "0" "tmux delivered-first-pass exits 0"
@@ -327,7 +328,7 @@ printf '%s\n' "$ECHO_SCREEN" > "$OT_TMUX_CAPTURES/1"
 printf '%s\n' "$READY_SCREEN" > "$OT_TMUX_CAPTURES/2"
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/3"
 set +e
-c6_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c6.err")
+c6_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c6.err")
 c6_code=$?
 set -e
 assert_eq "$c6_code" "0" "tmux re-delivery path exits 0"
@@ -349,7 +350,7 @@ printf '%s\n' "$ECHO_SCREEN" > "$OT_TMUX_CAPTURES/3"
 printf '%s\n' "$READY_SCREEN" > "$OT_TMUX_CAPTURES/4"
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/5"
 set +e
-c6b_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=2 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c6b.err")
+c6b_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=2 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c6b.err")
 c6b_code=$?
 set -e
 assert_eq "$c6b_code" "0" "dialog-then-ready path exits 0"
@@ -370,7 +371,7 @@ printf '%s\n' "$ECHO_SCREEN" > "$OT_TMUX_CAPTURES/1"
 printf '%s\n' "$READY_SCREEN" > "$OT_TMUX_CAPTURES/2"
 printf '%s\n' "$READY_SCREEN" > "$OT_TMUX_CAPTURES/3"
 set +e
-c7_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c7.err")
+c7_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c7.err")
 c7_code=$?
 set -e
 assert_eq "$c7_code" "1" "undelivered brief exits nonzero"
@@ -387,7 +388,7 @@ assert_eq "$c7_resends" "1" "re-send is attempted exactly once before failing"
 new_tmux_state c8
 printf '%s\n' "$COMPOSER_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c8_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c8.err")
+c8_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c8.err")
 c8_code=$?
 set -e
 assert_eq "$c8_code" "1" "composer-only screen exits nonzero"
@@ -405,7 +406,7 @@ assert_eq "$c8_resends" "1" "composer-only screen still gets exactly one re-send
 new_tmux_state c8b
 { printf '%s\n' "$DELIVERED_SCREEN"; awk 'BEGIN { for (i = 0; i < 20000; i++) print "transcript filler line" }'; } > "$OT_TMUX_CAPTURES/1"
 set +e
-c8b_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c8b.err")
+c8b_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c8b.err")
 c8b_code=$?
 set -e
 assert_eq "$c8b_code" "0" "huge scrollback with an early delivered brief exits 0"
@@ -420,7 +421,7 @@ echo "=== open-terminal claude handoff: tmux failure detection ==="
 new_tmux_state c9
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c9_out=$(TMUX=stub,1,0 OT_TMUX_FAIL=new-window ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c9.err")
+c9_out=$(TMUX=stub,1,0 OT_TMUX_FAIL=new-window ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c9.err")
 c9_code=$?
 set -e
 assert_eq "$c9_code" "1" "new-window failure exits nonzero"
@@ -433,7 +434,7 @@ assert_not_contains "$c9_out" "Done: launched 1" \
 # early return must not count a window whose launch keystrokes failed.
 new_tmux_state c10
 set +e
-c10_out=$(TMUX=stub,1,0 OT_TMUX_FAIL=send-keys ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness codex cc-737 2>"$TMP_ROOT/c10.err")
+c10_out=$(TMUX=stub,1,0 OT_TMUX_FAIL=send-keys ORCH_TMUX_VERIFY_SECS=1 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness codex cc-737 2>"$TMP_ROOT/c10.err")
 c10_code=$?
 set -e
 assert_eq "$c10_code" "1" "send-keys failure exits nonzero on a briefless lane"
@@ -448,7 +449,7 @@ echo "=== open-terminal claude handoff: config validation ==="
 # command, so it must never pass through unvalidated.
 CAP11="$TMP_ROOT/cap11"
 set +e
-c11_out=$(OT_CAPTURE="$CAP11" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--flag; touch $TMP_ROOT/pwned" cc-737 2>"$TMP_ROOT/c11.err")
+c11_out=$(OT_CAPTURE="$CAP11" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--flag; touch $TMP_ROOT/pwned" cc-737 2>"$TMP_ROOT/c11.err")
 c11_code=$?
 set -e
 assert_eq "$c11_code" "1" "metacharacter launch flags refuse to launch"
@@ -465,7 +466,7 @@ fi
 # Case 11b: a bracketed model id is an ordinary flag value, not a shell hazard.
 CAP11B="$TMP_ROOT/cap11b"
 set +e
-OT_CAPTURE="$CAP11B" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--model opus[1m] --dangerously-skip-permissions" cc-737 2>"$TMP_ROOT/c11b.err"
+OT_CAPTURE="$CAP11B" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude --launch-flags "--model opus[1m] --dangerously-skip-permissions" cc-737 2>"$TMP_ROOT/c11b.err"
 c11b_code=$?
 set -e
 assert_eq "$c11b_code" "0" "a bracketed model id is accepted"
@@ -486,7 +487,7 @@ printf '%s\n' "$@" > "$OT_ARGV_CAPTURE"
 EOF
   chmod +x "$BIN/claude"
   c11c_argv="$TMP_ROOT/c11c.argv"
-  (cd "$c11c_dir" && OT_ARGV_CAPTURE="$c11c_argv" PATH="$BIN:$PATH" bash -lc "${c11c_cmd##*&& }") >/dev/null 2>&1 || true
+  (cd "$c11c_dir" && OT_ARGV_CAPTURE="$c11c_argv" PATH="$BIN:$SEALED:$PATH" bash -lc "${c11c_cmd##*&& }") >/dev/null 2>&1 || true
   assert_contains "$(cat "$c11c_argv" 2>/dev/null || true)" "opus[1m]" \
     "the bracketed model id survives the shell that runs the launch command"
   assert_not_contains "$(cat "$c11c_argv" 2>/dev/null || true)" "opus1" \
@@ -502,7 +503,7 @@ fi
 new_tmux_state c12
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c12_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=abc PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c12.err")
+c12_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=abc PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c12.err")
 c12_code=$?
 set -e
 assert_eq "$c12_code" "1" "non-integer verify secs exits nonzero"
@@ -515,7 +516,7 @@ assert_not_contains "$(cat "$TMP_ROOT/c12.err")" "brief undelivered" \
 new_tmux_state c13
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c13_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=0 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c13.err")
+c13_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=0 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c13.err")
 c13_code=$?
 set -e
 assert_eq "$c13_code" "1" "zero verify secs exits nonzero"
@@ -527,7 +528,7 @@ assert_contains "$(cat "$TMP_ROOT/c13.err")" "ORCH_TMUX_VERIFY_SECS" \
 new_tmux_state c13b
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c13b_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=08 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c13b.err")
+c13b_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=08 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c13b.err")
 c13b_code=$?
 set -e
 assert_eq "$c13b_code" "0" "leading-zero verify secs is base-10 and launches"
@@ -539,7 +540,7 @@ assert_not_contains "$(cat "$TMP_ROOT/c13b.err")" "value too great" \
 new_tmux_state c13c
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c13c_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=10000000000000000000 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c13c.err")
+c13c_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=10000000000000000000 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c13c.err")
 c13c_code=$?
 set -e
 assert_eq "$c13c_code" "0" "overflow-sized verify secs still launches (clamped)"
@@ -552,7 +553,7 @@ assert_eq "$c13c_resends" "0" "no instant resend from a zero-pass verify loop"
 # never reads it.
 CAP13D="$TMP_ROOT/cap13d"
 set +e
-c13d_out=$(ORCH_TMUX_VERIFY_SECS=abc OT_CAPTURE="$CAP13D" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude cc-737 2>"$TMP_ROOT/c13d.err")
+c13d_out=$(ORCH_TMUX_VERIFY_SECS=abc OT_CAPTURE="$CAP13D" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness claude cc-737 2>"$TMP_ROOT/c13d.err")
 c13d_code=$?
 set -e
 assert_eq "$c13d_code" "0" "invalid verify secs does not abort a GUI launch"
@@ -563,7 +564,7 @@ assert_not_contains "$(cat "$TMP_ROOT/c13d.err")" "ORCH_TMUX_VERIFY_SECS" \
 # only Claude verification lanes read the timeout.
 new_tmux_state c13e
 set +e
-c13e_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=abc PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness codex cc-737 2>"$TMP_ROOT/c13e.err")
+c13e_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=abc PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness codex cc-737 2>"$TMP_ROOT/c13e.err")
 c13e_code=$?
 set -e
 assert_eq "$c13e_code" "0" "invalid verify secs does not abort a tmux codex launch"
@@ -575,7 +576,7 @@ assert_not_contains "$(cat "$TMP_ROOT/c13e.err")" "ORCH_TMUX_VERIFY_SECS" \
 new_tmux_state c14
 printf '%s\n' "$DELIVERED_SCREEN" > "$OT_TMUX_CAPTURES/1"
 set +e
-c14_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=99999 PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c14.err")
+c14_out=$(TMUX=stub,1,0 ORCH_TMUX_VERIFY_SECS=99999 PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tmux --harness claude cc-737 2>"$TMP_ROOT/c14.err")
 c14_code=$?
 set -e
 assert_eq "$c14_code" "0" "clamped verify secs still launches"

--- a/skills/orch/tests/open-terminal-codex-prompt.sh
+++ b/skills/orch/tests/open-terminal-codex-prompt.sh
@@ -80,6 +80,11 @@ exit 1
 EOF
 chmod +x "$BIN/ghostty" "$BIN/gh"
 
+# $TERMINAL is what open_gui reaches for first, so it is PINNED to the stub on
+# PATH here: unset, the branch below it would resolve whatever terminal the
+# developer's desktop provides and this suite would open real windows.
+export TERMINAL=ghostty
+
 # Stub worktree CLI: `create <item>` makes and prints a temp dir.
 STUB="$TMP_ROOT/worktree-stub"
 cat > "$STUB" <<EOF

--- a/skills/orch/tests/open-terminal-codex-prompt.sh
+++ b/skills/orch/tests/open-terminal-codex-prompt.sh
@@ -21,6 +21,8 @@ set -euo pipefail
 TC=" — complete means the PR is MERGED and the worktree cleaned up, not merely opened"
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/sealed-bin.sh
+. "$TEST_DIR/lib/sealed-bin.sh"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 SRC_OT="$SCRIPTS_DIR/open-terminal"
 SRC_LIB_DIR="$SCRIPTS_DIR/lib"
@@ -80,9 +82,8 @@ exit 1
 EOF
 chmod +x "$BIN/ghostty" "$BIN/gh"
 
-# $TERMINAL is what open_gui reaches for first, so it is PINNED to the stub on
-# PATH here: unset, the branch below it would resolve whatever terminal the
-# developer's desktop provides and this suite would open real windows.
+# open_gui reaches for $TERMINAL first, so it names the stub rather than the
+# developer's own terminal. $SEALED is what answers once the stub tree is gone.
 export TERMINAL=ghostty
 
 # Stub worktree CLI: `create <item>` makes and prints a temp dir.
@@ -128,7 +129,7 @@ echo "=== open-terminal codex kickoff prompt ==="
 # downstream shell layer could expand.
 CAP1="$TMP_ROOT/cap1"
 set +e
-c1_out=$(OT_CAPTURE="$CAP1" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness codex cc-737 2>"$TMP_ROOT/c1.err")
+c1_out=$(OT_CAPTURE="$CAP1" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness codex cc-737 2>"$TMP_ROOT/c1.err")
 c1_code=$?
 set -e
 assert_eq "$c1_code" "0" "linear:codex launch succeeds"
@@ -146,7 +147,7 @@ fi
 # Case 2: github:codex — same prose shape carrying repo#item.
 CAP2="$TMP_ROOT/cap2"
 set +e
-c2_out=$(OT_CAPTURE="$CAP2" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tracker github --repo acme/widgets --ghostty --harness codex 42 2>"$TMP_ROOT/c2.err")
+c2_out=$(OT_CAPTURE="$CAP2" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tracker github --repo acme/widgets --ghostty --harness codex 42 2>"$TMP_ROOT/c2.err")
 c2_code=$?
 set -e
 assert_eq "$c2_code" "0" "github:codex launch succeeds"

--- a/skills/orch/tests/open-terminal-codex-prompt.sh
+++ b/skills/orch/tests/open-terminal-codex-prompt.sh
@@ -21,8 +21,6 @@ set -euo pipefail
 TC=" — complete means the PR is MERGED and the worktree cleaned up, not merely opened"
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=lib/sealed-bin.sh
-. "$TEST_DIR/lib/sealed-bin.sh"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 SRC_OT="$SCRIPTS_DIR/open-terminal"
 SRC_LIB_DIR="$SCRIPTS_DIR/lib"
@@ -82,8 +80,9 @@ exit 1
 EOF
 chmod +x "$BIN/ghostty" "$BIN/gh"
 
-# open_gui reaches for $TERMINAL first, so it names the stub rather than the
-# developer's own terminal. $SEALED is what answers once the stub tree is gone.
+# $TERMINAL is what open_gui reaches for first, so it is PINNED to the stub on
+# PATH here: unset, the branch below it would resolve whatever terminal the
+# developer's desktop provides and this suite would open real windows.
 export TERMINAL=ghostty
 
 # Stub worktree CLI: `create <item>` makes and prints a temp dir.
@@ -129,7 +128,7 @@ echo "=== open-terminal codex kickoff prompt ==="
 # downstream shell layer could expand.
 CAP1="$TMP_ROOT/cap1"
 set +e
-c1_out=$(OT_CAPTURE="$CAP1" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness codex cc-737 2>"$TMP_ROOT/c1.err")
+c1_out=$(OT_CAPTURE="$CAP1" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --ghostty --harness codex cc-737 2>"$TMP_ROOT/c1.err")
 c1_code=$?
 set -e
 assert_eq "$c1_code" "0" "linear:codex launch succeeds"
@@ -147,7 +146,7 @@ fi
 # Case 2: github:codex — same prose shape carrying repo#item.
 CAP2="$TMP_ROOT/cap2"
 set +e
-c2_out=$(OT_CAPTURE="$CAP2" PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT" --tracker github --repo acme/widgets --ghostty --harness codex 42 2>"$TMP_ROOT/c2.err")
+c2_out=$(OT_CAPTURE="$CAP2" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" --tracker github --repo acme/widgets --ghostty --harness codex 42 2>"$TMP_ROOT/c2.err")
 c2_code=$?
 set -e
 assert_eq "$c2_code" "0" "github:codex launch succeeds"

--- a/skills/orch/tests/open-terminal-issue-id.sh
+++ b/skills/orch/tests/open-terminal-issue-id.sh
@@ -57,6 +57,11 @@ exit 1
 EOF
 chmod +x "$BIN/ghostty" "$BIN/gh"
 
+# $TERMINAL is what open_gui reaches for first, so it is PINNED to the stub on
+# PATH here: unset, the branch below it would resolve whatever terminal the
+# developer's desktop provides and this suite would open real windows.
+export TERMINAL=ghostty
+
 # Stub worktree CLI: `create <item>` makes and prints a temp dir.
 STUB="$TMP_ROOT/worktree-stub"
 cat > "$STUB" <<EOF

--- a/skills/orch/tests/open-terminal-issue-id.sh
+++ b/skills/orch/tests/open-terminal-issue-id.sh
@@ -12,8 +12,6 @@
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=lib/sealed-bin.sh
-. "$TEST_DIR/lib/sealed-bin.sh"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 SRC_OT="$SCRIPTS_DIR/open-terminal"
 SRC_LIB_DIR="$SCRIPTS_DIR/lib"
@@ -59,8 +57,9 @@ exit 1
 EOF
 chmod +x "$BIN/ghostty" "$BIN/gh"
 
-# open_gui reaches for $TERMINAL first, so it names the stub rather than the
-# developer's own terminal. $SEALED is what answers once the stub tree is gone.
+# $TERMINAL is what open_gui reaches for first, so it is PINNED to the stub on
+# PATH here: unset, the branch below it would resolve whatever terminal the
+# developer's desktop provides and this suite would open real windows.
 export TERMINAL=ghostty
 
 # Stub worktree CLI: `create <item>` makes and prints a temp dir.
@@ -102,14 +101,14 @@ OT_A="$(make_ot_repo "$REPO_A")"
 
 # Case 1: default pattern normalizes lowercase and uppercase input to uppercase.
 set +e
-c1a_out=$(PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' cc-737 2>"$TMP_ROOT/c1a.err")
+c1a_out=$(PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' cc-737 2>"$TMP_ROOT/c1a.err")
 c1a_code=$?
 set -e
 assert_eq "$c1a_code" "0" "default pattern: lowercase input accepted"
 assert_contains "$c1a_out" "Opened terminal 'CC-737'" "default pattern: cc-737 normalizes to CC-737"
 
 set +e
-c1b_out=$(PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' CC-737 2>"$TMP_ROOT/c1b.err")
+c1b_out=$(PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' CC-737 2>"$TMP_ROOT/c1b.err")
 c1b_code=$?
 set -e
 assert_eq "$c1b_code" "0" "default pattern: uppercase input accepted"
@@ -125,14 +124,14 @@ GH_ISSUE_PATTERN = "ZZ-[0-9]+"')"
 
 # Case 2: lowercase pattern normalizes uppercase and lowercase input to lowercase.
 set +e
-c2a_out=$(GH_ISSUE_PATTERN='cc-[0-9]+' PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT_B" --ghostty --cmd 'echo {item}' CC-737 2>"$TMP_ROOT/c2a.err")
+c2a_out=$(GH_ISSUE_PATTERN='cc-[0-9]+' PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_B" --ghostty --cmd 'echo {item}' CC-737 2>"$TMP_ROOT/c2a.err")
 c2a_code=$?
 set -e
 assert_eq "$c2a_code" "0" "lowercase pattern (parent env wins over settings): uppercase input accepted"
 assert_contains "$c2a_out" "Opened terminal 'cc-737'" "lowercase pattern: CC-737 normalizes to cc-737"
 
 set +e
-c2b_out=$(GH_ISSUE_PATTERN='cc-[0-9]+' PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT_B" --ghostty --cmd 'echo {item}' cc-737 2>"$TMP_ROOT/c2b.err")
+c2b_out=$(GH_ISSUE_PATTERN='cc-[0-9]+' PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_B" --ghostty --cmd 'echo {item}' cc-737 2>"$TMP_ROOT/c2b.err")
 c2b_code=$?
 set -e
 assert_eq "$c2b_code" "0" "lowercase pattern: lowercase input accepted"
@@ -140,7 +139,7 @@ assert_contains "$c2b_out" "Opened terminal 'cc-737'" "lowercase pattern: cc-737
 
 # Case 3: an id that matches no case of the default pattern is rejected.
 set +e
-c3_out=$(PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' 12ab 2>"$TMP_ROOT/c3.err")
+c3_out=$(PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' 12ab 2>"$TMP_ROOT/c3.err")
 c3_code=$?
 set -e
 assert_eq "$c3_code" "1" "invalid id exits nonzero"

--- a/skills/orch/tests/open-terminal-issue-id.sh
+++ b/skills/orch/tests/open-terminal-issue-id.sh
@@ -12,6 +12,8 @@
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/sealed-bin.sh
+. "$TEST_DIR/lib/sealed-bin.sh"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 SRC_OT="$SCRIPTS_DIR/open-terminal"
 SRC_LIB_DIR="$SCRIPTS_DIR/lib"
@@ -57,9 +59,8 @@ exit 1
 EOF
 chmod +x "$BIN/ghostty" "$BIN/gh"
 
-# $TERMINAL is what open_gui reaches for first, so it is PINNED to the stub on
-# PATH here: unset, the branch below it would resolve whatever terminal the
-# developer's desktop provides and this suite would open real windows.
+# open_gui reaches for $TERMINAL first, so it names the stub rather than the
+# developer's own terminal. $SEALED is what answers once the stub tree is gone.
 export TERMINAL=ghostty
 
 # Stub worktree CLI: `create <item>` makes and prints a temp dir.
@@ -101,14 +102,14 @@ OT_A="$(make_ot_repo "$REPO_A")"
 
 # Case 1: default pattern normalizes lowercase and uppercase input to uppercase.
 set +e
-c1a_out=$(PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' cc-737 2>"$TMP_ROOT/c1a.err")
+c1a_out=$(PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' cc-737 2>"$TMP_ROOT/c1a.err")
 c1a_code=$?
 set -e
 assert_eq "$c1a_code" "0" "default pattern: lowercase input accepted"
 assert_contains "$c1a_out" "Opened terminal 'CC-737'" "default pattern: cc-737 normalizes to CC-737"
 
 set +e
-c1b_out=$(PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' CC-737 2>"$TMP_ROOT/c1b.err")
+c1b_out=$(PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' CC-737 2>"$TMP_ROOT/c1b.err")
 c1b_code=$?
 set -e
 assert_eq "$c1b_code" "0" "default pattern: uppercase input accepted"
@@ -124,14 +125,14 @@ GH_ISSUE_PATTERN = "ZZ-[0-9]+"')"
 
 # Case 2: lowercase pattern normalizes uppercase and lowercase input to lowercase.
 set +e
-c2a_out=$(GH_ISSUE_PATTERN='cc-[0-9]+' PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_B" --ghostty --cmd 'echo {item}' CC-737 2>"$TMP_ROOT/c2a.err")
+c2a_out=$(GH_ISSUE_PATTERN='cc-[0-9]+' PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT_B" --ghostty --cmd 'echo {item}' CC-737 2>"$TMP_ROOT/c2a.err")
 c2a_code=$?
 set -e
 assert_eq "$c2a_code" "0" "lowercase pattern (parent env wins over settings): uppercase input accepted"
 assert_contains "$c2a_out" "Opened terminal 'cc-737'" "lowercase pattern: CC-737 normalizes to cc-737"
 
 set +e
-c2b_out=$(GH_ISSUE_PATTERN='cc-[0-9]+' PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_B" --ghostty --cmd 'echo {item}' cc-737 2>"$TMP_ROOT/c2b.err")
+c2b_out=$(GH_ISSUE_PATTERN='cc-[0-9]+' PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT_B" --ghostty --cmd 'echo {item}' cc-737 2>"$TMP_ROOT/c2b.err")
 c2b_code=$?
 set -e
 assert_eq "$c2b_code" "0" "lowercase pattern: lowercase input accepted"
@@ -139,7 +140,7 @@ assert_contains "$c2b_out" "Opened terminal 'cc-737'" "lowercase pattern: cc-737
 
 # Case 3: an id that matches no case of the default pattern is rejected.
 set +e
-c3_out=$(PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' 12ab 2>"$TMP_ROOT/c3.err")
+c3_out=$(PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" "$OT_A" --ghostty --cmd 'echo {item}' 12ab 2>"$TMP_ROOT/c3.err")
 c3_code=$?
 set -e
 assert_eq "$c3_code" "1" "invalid id exits nonzero"

--- a/skills/orch/tests/open-terminal-launch-guard.sh
+++ b/skills/orch/tests/open-terminal-launch-guard.sh
@@ -16,8 +16,6 @@
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=lib/sealed-bin.sh
-. "$TEST_DIR/lib/sealed-bin.sh"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 SRC_OT="${OPEN_TERMINAL_UNDER_TEST:-$SCRIPTS_DIR/open-terminal}"
 SRC_LIB_DIR="$SCRIPTS_DIR/lib"
@@ -61,11 +59,9 @@ EOF
 chmod +x "$BIN/term" "$BIN/xdg-terminal-exec" "$BIN/tmux" "$BIN/gh"
 
 # $TERMINAL is the terminal open_gui reaches for first — the owner's ruling
-# that a GUI launch honours the user's own choice — so each run names a stub
-# and pins the branch, $OT_TERMINAL choosing which. A BARE name, never a path
-# into this mktemp tree: a path bypasses PATH resolution, and with it the seal
-# that answers once the tree is gone. On fallthrough the seal takes the branch
-# below instead.
+# that a GUI launch honours the user's own choice — so each run names a stub on
+# PATH and pins the branch, $OT_TERMINAL choosing which. Every rung below it is
+# stubbed here too, so no case can resolve the developer's own terminal.
 
 # Stub worktree CLI, one shape per $STUB_MODE:
 #   empty    exits 0 printing nothing (a stub that escaped its fixture)
@@ -106,7 +102,7 @@ run() {
   : > "$term_log"
   : > "$tmux_log"
   set +e
-  PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" STUB_MODE="$mode" \
+  PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" STUB_MODE="$mode" \
     OT_TERM_LOG="$term_log" OT_TMUX_LOG="$tmux_log" TMUX="${OT_TMUX_VALUE:-}" \
     TERMINAL="${OT_TERMINAL:-term}" \
     "$ot" --cmd 'echo {item}' "$@" >"$TMP_ROOT/$name.out" 2>"$TMP_ROOT/$name.err"

--- a/skills/orch/tests/open-terminal-launch-guard.sh
+++ b/skills/orch/tests/open-terminal-launch-guard.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # The last layer before a window opens: a launch whose working directory does
-# not exist is refused by name, on every launch path.
+# not exist is refused by name.
 #
 # The class this closes was reached repeatedly in the real fleet (KEN-1084). A
 # suite that drives `open-terminal` with a stubbed worktree CLI gets an empty
@@ -12,7 +12,7 @@
 # whatever produced the launch, without asking who did.
 #
 # Everything external is stubbed: the GUI terminal (invocations logged, so a
-# refusal that still launched is visible), tmux, gh, and the worktree CLI.
+# refusal that still launched is visible), gh, and the worktree CLI.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -34,6 +34,8 @@ assert_contains() {
 
 # Stub bin. The GUI terminal APPENDS rather than truncating, so a case that
 # expects no launch fails loudly on a stray one instead of overwriting it.
+# Every run names this stub in $TERMINAL, which open_gui reaches for first, so
+# no case can resolve the developer's own terminal.
 BIN="$TMP_ROOT/bin"
 mkdir -p "$BIN"
 cat > "$BIN/term" <<'EOF'
@@ -41,32 +43,15 @@ cat > "$BIN/term" <<'EOF'
 printf 'term %s\n' "$*" >> "$OT_TERM_LOG"
 exit 0
 EOF
-# The desktop's launcher, for the case where $TERMINAL names nothing.
-cat > "$BIN/xdg-terminal-exec" <<'EOF'
-#!/usr/bin/env bash
-printf 'xdg %s\n' "$*" >> "$OT_TERM_LOG"
-exit 0
-EOF
-cat > "$BIN/tmux" <<'EOF'
-#!/usr/bin/env bash
-printf 'tmux %s\n' "$*" >> "$OT_TMUX_LOG"
-exit 1
-EOF
 cat > "$BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 exit 1
 EOF
-chmod +x "$BIN/term" "$BIN/xdg-terminal-exec" "$BIN/tmux" "$BIN/gh"
-
-# $TERMINAL is the terminal open_gui reaches for first — the owner's ruling
-# that a GUI launch honours the user's own choice — so each run names a stub on
-# PATH and pins the branch, $OT_TERMINAL choosing which. Every rung below it is
-# stubbed here too, so no case can resolve the developer's own terminal.
+chmod +x "$BIN/term" "$BIN/gh"
 
 # Stub worktree CLI, one shape per $STUB_MODE:
 #   empty    exits 0 printing nothing (a stub that escaped its fixture)
 #   missing  prints a path that was never created (a tree removed under a lane)
-#   real     makes the directory and prints it
 STUB="$TMP_ROOT/worktree-stub"
 cat > "$STUB" <<EOF
 #!/usr/bin/env bash
@@ -75,7 +60,6 @@ set -euo pipefail
 case "\$STUB_MODE" in
   empty)   exit 0 ;;
   missing) printf '%s\n' "$TMP_ROOT/gone/\${2:-item}"; exit 0 ;;
-  real)    mkdir -p "$TMP_ROOT/wt/\${2:-item}"; printf '%s\n' "$TMP_ROOT/wt/\${2:-item}"; exit 0 ;;
 esac
 exit 1
 EOF
@@ -94,17 +78,15 @@ stage() {
 REPO="$TMP_ROOT/repo"
 stage "$REPO" "$SRC_OT"
 
-# run NAME OT MODE ARGS... — sets RC, ERR, TERM_LOG_TEXT and TMUX_LOG_TEXT.
+# run NAME OT MODE ARGS... — sets RC, ERR and TERM_LOG_TEXT.
 run() {
   local name="$1" ot="$2" mode="$3"
   shift 3
-  local term_log="$TMP_ROOT/$name.term" tmux_log="$TMP_ROOT/$name.tmux"
+  local term_log="$TMP_ROOT/$name.term"
   : > "$term_log"
-  : > "$tmux_log"
   set +e
   PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" STUB_MODE="$mode" \
-    OT_TERM_LOG="$term_log" OT_TMUX_LOG="$tmux_log" TMUX="${OT_TMUX_VALUE:-}" \
-    TERMINAL="${OT_TERMINAL:-term}" \
+    OT_TERM_LOG="$term_log" TMUX="" TERMINAL=term \
     "$ot" --cmd 'echo {item}' "$@" >"$TMP_ROOT/$name.out" 2>"$TMP_ROOT/$name.err"
   RC=$?
   set -e
@@ -125,7 +107,6 @@ run() {
     sleep 1
   fi
   TERM_LOG_TEXT="$(cat "$term_log")"
-  TMUX_LOG_TEXT="$(cat "$tmux_log")"
 }
 
 echo "=== open-terminal: a launch at a working directory that is gone is refused ==="
@@ -141,42 +122,6 @@ assert_eq "$RC" "1" "a GUI launch at a deleted worktree fails the item"
 assert_contains "$ERR" "Error: refusing to launch 'CC-1': working directory '$TMP_ROOT/gone/CC-1' does not exist" \
   "the refusal names the directory that is gone"
 assert_eq "$TERM_LOG_TEXT" "" "no terminal was launched at the deleted directory"
-
-# The tmux path refuses at the same layer, before the first tmux call: a window
-# created with `-c` at a missing directory is the same broken lane.
-# TMUX travels through the run helper, never as an assignment prefixed onto a
-# function call: bash keeps such an assignment in the shell after the call, and
-# it would then decide the mode of every case below.
-OT_TMUX_VALUE=stub,1,0
-run tmux_missing "$REPO/scripts/open-terminal" missing --tmux CC-1
-OT_TMUX_VALUE=""
-assert_eq "$RC" "1" "a tmux launch at a deleted worktree fails the item"
-assert_contains "$ERR" "Error: refusing to launch 'CC-1': working directory '$TMP_ROOT/gone/CC-1' does not exist" \
-  "the tmux path refuses in the same words"
-assert_eq "$TMUX_LOG_TEXT" "" "tmux was never called for the deleted directory"
-
-# The premise: with a directory that IS there the same harness launches, and it
-# launches $TERMINAL. Without this the refusals above would pass on a harness
-# that could not launch anything at all.
-run real "$REPO/scripts/open-terminal" real --ghostty CC-1
-assert_eq "$RC" "0" "premise: a launch at a real directory succeeds"
-assert_contains "$TERM_LOG_TEXT" "term -e bash -lc" "premise: and \$TERMINAL is the terminal it launched"
-# Only the ghostty arm has a --title flag and it is the last one tried, so the
-# title is written from inside the launched shell or it is not written at all.
-assert_contains "$TERM_LOG_TEXT" "printf '\033]0;%s\007' 'CC-1'" \
-  "the launched shell sets the window title to the item"
-
-# A $TERMINAL naming nothing on PATH is substituted; saying so is the difference
-# between an operator's choice being honoured and being quietly overridden.
-OT_TERMINAL=no-such-terminal-anywhere
-run unresolved "$REPO/scripts/open-terminal" real --ghostty CC-1
-OT_TERMINAL=""
-assert_eq "$RC" "0" "an unresolvable \$TERMINAL still launches through the fallback"
-assert_contains "$ERR" "Warning: \$TERMINAL 'no-such-terminal-anywhere' does not resolve to an executable; launching 'CC-1' with xdg-terminal-exec instead" \
-  "the substitution names the value and the terminal used instead"
-assert_contains "$TERM_LOG_TEXT" "xdg bash -lc" "and the fallback launcher is the one that ran"
-assert_contains "$TERM_LOG_TEXT" "printf '\033]0;%s\007' 'CC-1'" \
-  "the title survives the fallback branch too"
 
 echo
 echo "=== the refusal can fail: with the guard gone the window opens ==="

--- a/skills/orch/tests/open-terminal-launch-guard.sh
+++ b/skills/orch/tests/open-terminal-launch-guard.sh
@@ -102,6 +102,21 @@ run() {
   RC=$?
   set -e
   ERR="$(cat "$TMP_ROOT/$name.err")"
+  # open_gui detaches the launch (`setsid ... &`), so the stub's line can land
+  # after open-terminal has already exited — on a loaded box it did, and the
+  # case read an empty log. Which wait to take is DERIVED from the script's own
+  # report rather than from a flag each call site remembers: an exit 0 says a
+  # launch was started, so wait for its line; any other status says none was, so
+  # watch a real interval and prove none appears.
+  local i=0
+  if [[ "$RC" -eq 0 ]]; then
+    while [ "$i" -lt 100 ] && [ ! -s "$term_log" ]; do
+      sleep 0.1
+      i=$((i + 1))
+    done
+  else
+    sleep 1
+  fi
   TERM_LOG_TEXT="$(cat "$term_log")"
   TMUX_LOG_TEXT="$(cat "$tmux_log")"
 }
@@ -143,9 +158,10 @@ assert_contains "$TERM_LOG_TEXT" "term -e bash -lc" "premise: and \$TERMINAL is 
 echo
 echo "=== the refusal can fail: with the guard gone the window opens ==="
 
-# The must-fail control. `launchable_dir` is the whole protection, so the
-# mutation is its one test — with that gone the function returns 0 for every
-# path and the launch proceeds exactly as it did before this guard existed.
+# The must-fail control, run over BOTH shapes the guard refuses. `launchable_dir`
+# is the whole protection, so the mutation is its one test — with that gone the
+# function returns 0 for every path and each launch proceeds exactly as it did
+# before this guard existed.
 MUTANT="$TMP_ROOT/mutant"
 mkdir -p "$MUTANT"
 sed 's/\[\[ -d "$1" \]\] && return 0/return 0/' "$SRC_OT" > "$MUTANT/open-terminal"
@@ -158,9 +174,17 @@ MUTANT_REPO="$TMP_ROOT/mutant-repo"
 stage "$MUTANT_REPO" "$MUTANT/open-terminal"
 
 run mutant "$MUTANT_REPO/scripts/open-terminal" missing --ghostty CC-1
-assert_eq "$RC" "0" "control: without the guard the launch is reported as successful"
+assert_eq "$RC" "0" "control: without the guard the deleted-path launch is reported as successful"
 assert_contains "$TERM_LOG_TEXT" "term -e bash -lc" \
   "control: and a terminal really is opened at the directory that is gone"
+
+# The empty path is the shape the leak actually took, so it carries its own
+# control rather than riding on the deleted one: a guard written as a stat of a
+# non-empty path would refuse the case above and still launch this one.
+run mutant_empty "$MUTANT_REPO/scripts/open-terminal" empty --ghostty CC-1
+assert_eq "$RC" "0" "control: without the guard the empty-path launch is reported as successful"
+assert_contains "$TERM_LOG_TEXT" "term -e bash -lc" \
+  "control: and a terminal really is opened for the empty working directory"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/orch/tests/open-terminal-launch-guard.sh
+++ b/skills/orch/tests/open-terminal-launch-guard.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# The last layer before a window opens: a launch whose working directory does
+# not exist is refused by name, on every launch path.
+#
+# The class this closes was reached repeatedly in the real fleet (KEN-1084). A
+# suite that drives `open-terminal` with a stubbed worktree CLI gets an empty
+# path back the moment the stub exits 0 without printing one — the shape a
+# PATH stub leaves when its fixture tree is deleted under it — and open_gui
+# then handed that empty path to a real GUI terminal, which opened a window on
+# the operator's desktop at a directory that was gone. The same is true of any
+# lane whose worktree was removed while it ran. Refusing here closes it
+# whatever produced the launch, without asking who did.
+#
+# Everything external is stubbed: the GUI terminal (invocations logged, so a
+# refusal that still launched is visible), tmux, gh, and the worktree CLI.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
+SRC_OT="${OPEN_TERMINAL_UNDER_TEST:-$SCRIPTS_DIR/open-terminal}"
+SRC_LIB_DIR="$SCRIPTS_DIR/lib"
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+assert_eq() { [[ "$1" == "$2" ]] && ok "$3" || bad "$3" "expected: $2   got: $1"; }
+assert_contains() {
+  grep -qF -- "$2" <<<"$1" && ok "$3" || bad "$3" "wanted substring: $2
+        in: $1"
+}
+
+# Stub bin. The GUI terminal APPENDS rather than truncating, so a case that
+# expects no launch fails loudly on a stray one instead of overwriting it.
+BIN="$TMP_ROOT/bin"
+mkdir -p "$BIN"
+cat > "$BIN/term" <<'EOF'
+#!/usr/bin/env bash
+printf 'term %s\n' "$*" >> "$OT_TERM_LOG"
+exit 0
+EOF
+cat > "$BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+printf 'tmux %s\n' "$*" >> "$OT_TMUX_LOG"
+exit 1
+EOF
+cat > "$BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$BIN/term" "$BIN/tmux" "$BIN/gh"
+
+# $TERMINAL is the terminal open_gui reaches for first — the owner's ruling
+# that a GUI launch honours the user's own choice — so pointing it at the stub
+# both pins the branch and keeps every case in this file off the real desktop.
+export TERMINAL="$BIN/term"
+
+# Stub worktree CLI, one shape per $STUB_MODE:
+#   empty    exits 0 printing nothing (a stub that escaped its fixture)
+#   missing  prints a path that was never created (a tree removed under a lane)
+#   real     makes the directory and prints it
+STUB="$TMP_ROOT/worktree-stub"
+cat > "$STUB" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "\${1:-}" == "create" ]] || { echo "unexpected worktree stub call: \$*" >&2; exit 1; }
+case "\$STUB_MODE" in
+  empty)   exit 0 ;;
+  missing) printf '%s\n' "$TMP_ROOT/gone/\${2:-item}"; exit 0 ;;
+  real)    mkdir -p "$TMP_ROOT/wt/\${2:-item}"; printf '%s\n' "$TMP_ROOT/wt/\${2:-item}"; exit 0 ;;
+esac
+exit 1
+EOF
+chmod +x "$STUB"
+
+# stage DIR SRC — a copy of open-terminal in a git repo of its own, so
+# PROJECT_ROOT resolves hermetically.
+stage() {
+  mkdir -p "$1/scripts/lib"
+  cp "$2" "$1/scripts/open-terminal"
+  cp "$SRC_LIB_DIR"/*.sh "$1/scripts/lib/"
+  chmod +x "$1/scripts/open-terminal"
+  git -C "$1" init -q
+}
+
+REPO="$TMP_ROOT/repo"
+stage "$REPO" "$SRC_OT"
+
+# run NAME OT MODE ARGS... — sets RC, ERR, TERM_LOG_TEXT and TMUX_LOG_TEXT.
+run() {
+  local name="$1" ot="$2" mode="$3"
+  shift 3
+  local term_log="$TMP_ROOT/$name.term" tmux_log="$TMP_ROOT/$name.tmux"
+  : > "$term_log"
+  : > "$tmux_log"
+  set +e
+  PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" STUB_MODE="$mode" \
+    OT_TERM_LOG="$term_log" OT_TMUX_LOG="$tmux_log" TMUX="${OT_TMUX_VALUE:-}" \
+    "$ot" --cmd 'echo {item}' "$@" >"$TMP_ROOT/$name.out" 2>"$TMP_ROOT/$name.err"
+  RC=$?
+  set -e
+  ERR="$(cat "$TMP_ROOT/$name.err")"
+  TERM_LOG_TEXT="$(cat "$term_log")"
+  TMUX_LOG_TEXT="$(cat "$tmux_log")"
+}
+
+echo "=== open-terminal: a launch at a working directory that is gone is refused ==="
+
+run empty "$REPO/scripts/open-terminal" empty --ghostty CC-1
+assert_eq "$RC" "1" "a GUI launch with no worktree path fails the item"
+assert_contains "$ERR" "Error: refusing to launch 'CC-1': working directory '' does not exist" \
+  "the refusal names the item and the empty directory"
+assert_eq "$TERM_LOG_TEXT" "" "no terminal was launched for the empty path"
+
+run missing "$REPO/scripts/open-terminal" missing --ghostty CC-1
+assert_eq "$RC" "1" "a GUI launch at a deleted worktree fails the item"
+assert_contains "$ERR" "Error: refusing to launch 'CC-1': working directory '$TMP_ROOT/gone/CC-1' does not exist" \
+  "the refusal names the directory that is gone"
+assert_eq "$TERM_LOG_TEXT" "" "no terminal was launched at the deleted directory"
+
+# The tmux path refuses at the same layer, before the first tmux call: a window
+# created with `-c` at a missing directory is the same broken lane.
+# TMUX travels through the run helper, never as an assignment prefixed onto a
+# function call: bash keeps such an assignment in the shell after the call, and
+# it would then decide the mode of every case below.
+OT_TMUX_VALUE=stub,1,0
+run tmux_missing "$REPO/scripts/open-terminal" missing --tmux CC-1
+OT_TMUX_VALUE=""
+assert_eq "$RC" "1" "a tmux launch at a deleted worktree fails the item"
+assert_contains "$ERR" "Error: refusing to launch 'CC-1': working directory '$TMP_ROOT/gone/CC-1' does not exist" \
+  "the tmux path refuses in the same words"
+assert_eq "$TMUX_LOG_TEXT" "" "tmux was never called for the deleted directory"
+
+# The premise: with a directory that IS there the same harness launches, and it
+# launches $TERMINAL. Without this the refusals above would pass on a harness
+# that could not launch anything at all.
+run real "$REPO/scripts/open-terminal" real --ghostty CC-1
+assert_eq "$RC" "0" "premise: a launch at a real directory succeeds"
+assert_contains "$TERM_LOG_TEXT" "term -e bash -lc" "premise: and \$TERMINAL is the terminal it launched"
+
+echo
+echo "=== the refusal can fail: with the guard gone the window opens ==="
+
+# The must-fail control. `launchable_dir` is the whole protection, so the
+# mutation is its one test — with that gone the function returns 0 for every
+# path and the launch proceeds exactly as it did before this guard existed.
+MUTANT="$TMP_ROOT/mutant"
+mkdir -p "$MUTANT"
+sed 's/\[\[ -d "$1" \]\] && return 0/return 0/' "$SRC_OT" > "$MUTANT/open-terminal"
+if cmp -s "$SRC_OT" "$MUTANT/open-terminal"; then
+  bad "control: the mutant really drops the directory test" "the copy is byte-identical to open-terminal"
+else
+  ok "control: the mutant really drops the directory test"
+fi
+MUTANT_REPO="$TMP_ROOT/mutant-repo"
+stage "$MUTANT_REPO" "$MUTANT/open-terminal"
+
+run mutant "$MUTANT_REPO/scripts/open-terminal" missing --ghostty CC-1
+assert_eq "$RC" "0" "control: without the guard the launch is reported as successful"
+assert_contains "$TERM_LOG_TEXT" "term -e bash -lc" \
+  "control: and a terminal really is opened at the directory that is gone"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/orch/tests/open-terminal-launch-guard.sh
+++ b/skills/orch/tests/open-terminal-launch-guard.sh
@@ -11,8 +11,9 @@
 # lane whose worktree was removed while it ran. Refusing here closes it
 # whatever produced the launch, without asking who did.
 #
-# Everything external is stubbed: the GUI terminal (invocations logged, so a
-# refusal that still launched is visible), gh, and the worktree CLI.
+# Everything external is stubbed: the GUI terminal and tmux (invocations
+# logged, so a refusal that still launched is visible), gh, and the worktree
+# CLI.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -43,11 +44,16 @@ cat > "$BIN/term" <<'EOF'
 printf 'term %s\n' "$*" >> "$OT_TERM_LOG"
 exit 0
 EOF
+cat > "$BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+printf 'tmux %s\n' "$*" >> "$OT_TMUX_LOG"
+exit 1
+EOF
 cat > "$BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 exit 1
 EOF
-chmod +x "$BIN/term" "$BIN/gh"
+chmod +x "$BIN/term" "$BIN/tmux" "$BIN/gh"
 
 # Stub worktree CLI, one shape per $STUB_MODE:
 #   empty    exits 0 printing nothing (a stub that escaped its fixture)
@@ -78,15 +84,17 @@ stage() {
 REPO="$TMP_ROOT/repo"
 stage "$REPO" "$SRC_OT"
 
-# run NAME OT MODE ARGS... — sets RC, ERR and TERM_LOG_TEXT.
+# run NAME OT MODE ARGS... — sets RC, ERR, TERM_LOG_TEXT and TMUX_LOG_TEXT.
 run() {
   local name="$1" ot="$2" mode="$3"
   shift 3
-  local term_log="$TMP_ROOT/$name.term"
+  local term_log="$TMP_ROOT/$name.term" tmux_log="$TMP_ROOT/$name.tmux"
   : > "$term_log"
+  : > "$tmux_log"
   set +e
   PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" STUB_MODE="$mode" \
-    OT_TERM_LOG="$term_log" TMUX="" TERMINAL=term \
+    OT_TERM_LOG="$term_log" OT_TMUX_LOG="$tmux_log" \
+    TMUX="${OT_TMUX_VALUE:-}" TERMINAL=term \
     "$ot" --cmd 'echo {item}' "$@" >"$TMP_ROOT/$name.out" 2>"$TMP_ROOT/$name.err"
   RC=$?
   set -e
@@ -107,6 +115,7 @@ run() {
     sleep 1
   fi
   TERM_LOG_TEXT="$(cat "$term_log")"
+  TMUX_LOG_TEXT="$(cat "$tmux_log")"
 }
 
 echo "=== open-terminal: a launch at a working directory that is gone is refused ==="
@@ -122,6 +131,19 @@ assert_eq "$RC" "1" "a GUI launch at a deleted worktree fails the item"
 assert_contains "$ERR" "Error: refusing to launch 'CC-1': working directory '$TMP_ROOT/gone/CC-1' does not exist" \
   "the refusal names the directory that is gone"
 assert_eq "$TERM_LOG_TEXT" "" "no terminal was launched at the deleted directory"
+
+# The tmux path refuses at the same layer, before the first tmux call: a window
+# created with `-c` at a missing directory is the same broken lane. TMUX travels
+# through the run helper, never as an assignment prefixed onto a function call:
+# bash keeps such an assignment in the shell after the call, and it would then
+# decide the mode of every case below.
+OT_TMUX_VALUE=stub,1,0
+run tmux_missing "$REPO/scripts/open-terminal" missing --tmux CC-1
+OT_TMUX_VALUE=""
+assert_eq "$RC" "1" "a tmux launch at a deleted worktree fails the item"
+assert_contains "$ERR" "Error: refusing to launch 'CC-1': working directory '$TMP_ROOT/gone/CC-1' does not exist" \
+  "the tmux path refuses in the same words"
+assert_eq "$TMUX_LOG_TEXT" "" "tmux was never called for the deleted directory"
 
 echo
 echo "=== the refusal can fail: with the guard gone the window opens ==="
@@ -153,6 +175,17 @@ run mutant_empty "$MUTANT_REPO/scripts/open-terminal" empty --ghostty CC-1
 assert_eq "$RC" "0" "control: without the guard the empty-path launch is reported as successful"
 assert_contains "$TERM_LOG_TEXT" "term -e bash -lc" \
   "control: and a terminal really is opened for the empty working directory"
+
+# The tmux path carries the same control. The stub tmux exits 1, so the item
+# fails either way and the LOG is what separates the two: refused means tmux was
+# never reached, and this case proves the tmux row above reds the moment its
+# `launchable_dir` call goes, rather than passing on a harness that could not
+# reach tmux at all.
+OT_TMUX_VALUE=stub,1,0
+run mutant_tmux "$MUTANT_REPO/scripts/open-terminal" missing --tmux CC-1
+OT_TMUX_VALUE=""
+assert_contains "$TMUX_LOG_TEXT" "tmux list-windows" \
+  "control: without the guard the tmux path really does place a window at the deleted directory"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/orch/tests/open-terminal-launch-guard.sh
+++ b/skills/orch/tests/open-terminal-launch-guard.sh
@@ -16,6 +16,8 @@
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/sealed-bin.sh
+. "$TEST_DIR/lib/sealed-bin.sh"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 SRC_OT="${OPEN_TERMINAL_UNDER_TEST:-$SCRIPTS_DIR/open-terminal}"
 SRC_LIB_DIR="$SCRIPTS_DIR/lib"
@@ -27,6 +29,10 @@ FAIL=0
 ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
 bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
 assert_eq() { [[ "$1" == "$2" ]] && ok "$3" || bad "$3" "expected: $2   got: $1"; }
+assert_not_contains() {
+  grep -qF -- "$2" <<<"$1" && bad "$3" "forbidden substring: $2
+        in: $1" || ok "$3"
+}
 assert_contains() {
   grep -qF -- "$2" <<<"$1" && ok "$3" || bad "$3" "wanted substring: $2
         in: $1"
@@ -41,6 +47,18 @@ cat > "$BIN/term" <<'EOF'
 printf 'term %s\n' "$*" >> "$OT_TERM_LOG"
 exit 0
 EOF
+# The desktop's launcher, for the case where $TERMINAL names nothing, and a
+# launcher that refuses its arguments the way the GTK family refuses -e bash -lc.
+cat > "$BIN/xdg-terminal-exec" <<'EOF'
+#!/usr/bin/env bash
+printf 'xdg %s\n' "$*" >> "$OT_TERM_LOG"
+exit 0
+EOF
+cat > "$BIN/badterm" <<'EOF'
+#!/usr/bin/env bash
+echo "badterm: unrecognised option -lc" >&2
+exit 3
+EOF
 cat > "$BIN/tmux" <<'EOF'
 #!/usr/bin/env bash
 printf 'tmux %s\n' "$*" >> "$OT_TMUX_LOG"
@@ -50,12 +68,14 @@ cat > "$BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 exit 1
 EOF
-chmod +x "$BIN/term" "$BIN/tmux" "$BIN/gh"
+chmod +x "$BIN/term" "$BIN/xdg-terminal-exec" "$BIN/badterm" "$BIN/tmux" "$BIN/gh"
 
 # $TERMINAL is the terminal open_gui reaches for first — the owner's ruling
-# that a GUI launch honours the user's own choice — so pointing it at the stub
-# both pins the branch and keeps every case in this file off the real desktop.
-export TERMINAL="$BIN/term"
+# that a GUI launch honours the user's own choice — so each run names a stub
+# and pins the branch, $OT_TERMINAL choosing which. A BARE name, never a path
+# into this mktemp tree: a path bypasses PATH resolution, and with it the seal
+# that answers once the tree is gone. On fallthrough the seal takes the branch
+# below instead.
 
 # Stub worktree CLI, one shape per $STUB_MODE:
 #   empty    exits 0 printing nothing (a stub that escaped its fixture)
@@ -96,12 +116,14 @@ run() {
   : > "$term_log"
   : > "$tmux_log"
   set +e
-  PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" STUB_MODE="$mode" \
+  PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" STUB_MODE="$mode" \
     OT_TERM_LOG="$term_log" OT_TMUX_LOG="$tmux_log" TMUX="${OT_TMUX_VALUE:-}" \
+    TERMINAL="${OT_TERMINAL:-term}" \
     "$ot" --cmd 'echo {item}' "$@" >"$TMP_ROOT/$name.out" 2>"$TMP_ROOT/$name.err"
   RC=$?
   set -e
   ERR="$(cat "$TMP_ROOT/$name.err")"
+  OUT_TEXT="$(cat "$TMP_ROOT/$name.out")"
   # open_gui detaches the launch (`setsid ... &`), so the stub's line can land
   # after open-terminal has already exited — on a loaded box it did, and the
   # case read an empty log. Which wait to take is DERIVED from the script's own
@@ -154,6 +176,37 @@ assert_eq "$TMUX_LOG_TEXT" "" "tmux was never called for the deleted directory"
 run real "$REPO/scripts/open-terminal" real --ghostty CC-1
 assert_eq "$RC" "0" "premise: a launch at a real directory succeeds"
 assert_contains "$TERM_LOG_TEXT" "term -e bash -lc" "premise: and \$TERMINAL is the terminal it launched"
+# Only the ghostty arm has a --title flag and it is the last one tried, so the
+# title is written from inside the launched shell or it is not written at all.
+assert_contains "$TERM_LOG_TEXT" "printf '\033]0;%s\007' 'CC-1'" \
+  "the launched shell sets the window title to the item"
+
+echo
+echo "=== a launcher nothing observed is not a launch to report ==="
+
+# The exit code is the orchestrator's only signal that a lane started, so a
+# launcher that refuses its arguments must fail the item rather than be counted.
+OT_TERMINAL=badterm
+run badterm "$REPO/scripts/open-terminal" real --ghostty CC-1
+OT_TERMINAL=""
+assert_eq "$RC" "1" "a launcher that exits non-zero fails the item"
+assert_contains "$ERR" "Error: badterm exited 3 launching 'CC-1'" \
+  "the failure names the launcher and its status"
+assert_contains "$ERR" "unrecognised option -lc" "and carries the launcher's own words"
+assert_contains "$ERR" "1 handoff lane(s) failed" "the batch summary counts it as failed"
+assert_not_contains "$OUT_TEXT" "Opened terminal" "and no success line is printed for it"
+
+# A $TERMINAL naming nothing on PATH is substituted; saying so is the difference
+# between an operator's choice being honoured and being quietly overridden.
+OT_TERMINAL=no-such-terminal-anywhere
+run unresolved "$REPO/scripts/open-terminal" real --ghostty CC-1
+OT_TERMINAL=""
+assert_eq "$RC" "0" "an unresolvable \$TERMINAL still launches through the fallback"
+assert_contains "$ERR" "Warning: \$TERMINAL 'no-such-terminal-anywhere' does not resolve to an executable; launching 'CC-1' with xdg-terminal-exec instead" \
+  "the substitution names the value and the terminal used instead"
+assert_contains "$TERM_LOG_TEXT" "xdg bash -lc" "and the fallback launcher is the one that ran"
+assert_contains "$TERM_LOG_TEXT" "printf '\033]0;%s\007' 'CC-1'" \
+  "the title survives the fallback branch too"
 
 echo
 echo "=== the refusal can fail: with the guard gone the window opens ==="

--- a/skills/orch/tests/open-terminal-launch-guard.sh
+++ b/skills/orch/tests/open-terminal-launch-guard.sh
@@ -29,10 +29,6 @@ FAIL=0
 ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
 bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
 assert_eq() { [[ "$1" == "$2" ]] && ok "$3" || bad "$3" "expected: $2   got: $1"; }
-assert_not_contains() {
-  grep -qF -- "$2" <<<"$1" && bad "$3" "forbidden substring: $2
-        in: $1" || ok "$3"
-}
 assert_contains() {
   grep -qF -- "$2" <<<"$1" && ok "$3" || bad "$3" "wanted substring: $2
         in: $1"
@@ -47,17 +43,11 @@ cat > "$BIN/term" <<'EOF'
 printf 'term %s\n' "$*" >> "$OT_TERM_LOG"
 exit 0
 EOF
-# The desktop's launcher, for the case where $TERMINAL names nothing, and a
-# launcher that refuses its arguments the way the GTK family refuses -e bash -lc.
+# The desktop's launcher, for the case where $TERMINAL names nothing.
 cat > "$BIN/xdg-terminal-exec" <<'EOF'
 #!/usr/bin/env bash
 printf 'xdg %s\n' "$*" >> "$OT_TERM_LOG"
 exit 0
-EOF
-cat > "$BIN/badterm" <<'EOF'
-#!/usr/bin/env bash
-echo "badterm: unrecognised option -lc" >&2
-exit 3
 EOF
 cat > "$BIN/tmux" <<'EOF'
 #!/usr/bin/env bash
@@ -68,7 +58,7 @@ cat > "$BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 exit 1
 EOF
-chmod +x "$BIN/term" "$BIN/xdg-terminal-exec" "$BIN/badterm" "$BIN/tmux" "$BIN/gh"
+chmod +x "$BIN/term" "$BIN/xdg-terminal-exec" "$BIN/tmux" "$BIN/gh"
 
 # $TERMINAL is the terminal open_gui reaches for first — the owner's ruling
 # that a GUI launch honours the user's own choice — so each run names a stub
@@ -123,7 +113,6 @@ run() {
   RC=$?
   set -e
   ERR="$(cat "$TMP_ROOT/$name.err")"
-  OUT_TEXT="$(cat "$TMP_ROOT/$name.out")"
   # open_gui detaches the launch (`setsid ... &`), so the stub's line can land
   # after open-terminal has already exited — on a loaded box it did, and the
   # case read an empty log. Which wait to take is DERIVED from the script's own
@@ -180,21 +169,6 @@ assert_contains "$TERM_LOG_TEXT" "term -e bash -lc" "premise: and \$TERMINAL is 
 # title is written from inside the launched shell or it is not written at all.
 assert_contains "$TERM_LOG_TEXT" "printf '\033]0;%s\007' 'CC-1'" \
   "the launched shell sets the window title to the item"
-
-echo
-echo "=== a launcher nothing observed is not a launch to report ==="
-
-# The exit code is the orchestrator's only signal that a lane started, so a
-# launcher that refuses its arguments must fail the item rather than be counted.
-OT_TERMINAL=badterm
-run badterm "$REPO/scripts/open-terminal" real --ghostty CC-1
-OT_TERMINAL=""
-assert_eq "$RC" "1" "a launcher that exits non-zero fails the item"
-assert_contains "$ERR" "Error: badterm exited 3 launching 'CC-1'" \
-  "the failure names the launcher and its status"
-assert_contains "$ERR" "unrecognised option -lc" "and carries the launcher's own words"
-assert_contains "$ERR" "1 handoff lane(s) failed" "the batch summary counts it as failed"
-assert_not_contains "$OUT_TEXT" "Opened terminal" "and no success line is printed for it"
 
 # A $TERMINAL naming nothing on PATH is substituted; saying so is the difference
 # between an operator's choice being honoured and being quietly overridden.

--- a/skills/orch/tests/open-terminal-owned-skip.sh
+++ b/skills/orch/tests/open-terminal-owned-skip.sh
@@ -76,6 +76,11 @@ exit 1
 EOF
 chmod +x "$BIN/ghostty" "$BIN/gh"
 
+# $TERMINAL is what open_gui reaches for first, so it is PINNED to the stub on
+# PATH here: unset, the branch below it would resolve whatever terminal the
+# developer's desktop provides and this suite would open real windows.
+export TERMINAL=ghostty
+
 # Stub worktree CLI:
 #   exists <item>          "true" when $STUB_EXISTS_DIR/<item> is present
 #   create <item>          logs "<item>", exits per $STUB_EXIT_DIR/<item>

--- a/skills/orch/tests/open-terminal-owned-skip.sh
+++ b/skills/orch/tests/open-terminal-owned-skip.sh
@@ -20,6 +20,8 @@
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/sealed-bin.sh
+. "$TEST_DIR/lib/sealed-bin.sh"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 SRC_OT="${OPEN_TERMINAL_UNDER_TEST:-$SCRIPTS_DIR/open-terminal}"
 SRC_LIB_DIR="$SCRIPTS_DIR/lib"
@@ -76,9 +78,8 @@ exit 1
 EOF
 chmod +x "$BIN/ghostty" "$BIN/gh"
 
-# $TERMINAL is what open_gui reaches for first, so it is PINNED to the stub on
-# PATH here: unset, the branch below it would resolve whatever terminal the
-# developer's desktop provides and this suite would open real windows.
+# open_gui reaches for $TERMINAL first, so it names the stub rather than the
+# developer's own terminal. $SEALED is what answers once the stub tree is gone.
 export TERMINAL=ghostty
 
 # Stub worktree CLI:
@@ -131,7 +132,7 @@ run_case() {
   : "${EXISTS_DIR:=$TMP_ROOT/exists-none}"
   mkdir -p "$EXISTS_DIR"
   set +e
-  OUT=$(PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" STUB_CALL_LOG="$CALL_LOG" STUB_EXIT_DIR="$EXIT_DIR" \
+  OUT=$(PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" STUB_CALL_LOG="$CALL_LOG" STUB_EXIT_DIR="$EXIT_DIR" \
     STUB_EXISTS_DIR="$EXISTS_DIR" \
     "$OT" --ghostty --cmd 'echo {item}' "$@" 2>"$TMP_ROOT/$name.err")
   RC=$?

--- a/skills/orch/tests/open-terminal-owned-skip.sh
+++ b/skills/orch/tests/open-terminal-owned-skip.sh
@@ -20,8 +20,6 @@
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=lib/sealed-bin.sh
-. "$TEST_DIR/lib/sealed-bin.sh"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 SRC_OT="${OPEN_TERMINAL_UNDER_TEST:-$SCRIPTS_DIR/open-terminal}"
 SRC_LIB_DIR="$SCRIPTS_DIR/lib"
@@ -78,8 +76,9 @@ exit 1
 EOF
 chmod +x "$BIN/ghostty" "$BIN/gh"
 
-# open_gui reaches for $TERMINAL first, so it names the stub rather than the
-# developer's own terminal. $SEALED is what answers once the stub tree is gone.
+# $TERMINAL is what open_gui reaches for first, so it is PINNED to the stub on
+# PATH here: unset, the branch below it would resolve whatever terminal the
+# developer's desktop provides and this suite would open real windows.
 export TERMINAL=ghostty
 
 # Stub worktree CLI:
@@ -132,7 +131,7 @@ run_case() {
   : "${EXISTS_DIR:=$TMP_ROOT/exists-none}"
   mkdir -p "$EXISTS_DIR"
   set +e
-  OUT=$(PATH="$BIN:$SEALED:$PATH" WORKTREE_CLI="$STUB" STUB_CALL_LOG="$CALL_LOG" STUB_EXIT_DIR="$EXIT_DIR" \
+  OUT=$(PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" STUB_CALL_LOG="$CALL_LOG" STUB_EXIT_DIR="$EXIT_DIR" \
     STUB_EXISTS_DIR="$EXISTS_DIR" \
     "$OT" --ghostty --cmd 'echo {item}' "$@" 2>"$TMP_ROOT/$name.err")
   RC=$?

--- a/skills/orch/tests/parser-defaults-not-configurable.sh
+++ b/skills/orch/tests/parser-defaults-not-configurable.sh
@@ -42,23 +42,38 @@ bad() {
 
 # A stub gh so no case reaches the network; every command here fails before or
 # at auth, and none of them may decide the outcome by talking to GitHub.
+#
+# And a stub for every terminal open_gui can resolve. No assertion in this file
+# measures a launch, but the SKILLS_DIR leak control below drops the very export
+# it is proving, so its stubbed worktree CLI exits 0 printing no path and the
+# launch that follows used to reach the real ghostty on PATH — a window on the
+# operator's desktop at a directory that was already deleted (KEN-1084). A test
+# that proves a parser property must not be able to open one while doing it.
 mkdir -p "$TMP_ROOT/bin" "$TMP_ROOT/no-lanes"
 printf '#!/bin/sh\nexit 1\n' >"$TMP_ROOT/bin/gh"
-chmod +x "$TMP_ROOT/bin/gh"
+for stub in ghostty xdg-terminal-exec stub-terminal; do
+  printf '#!/bin/sh\nexit 0\n' >"$TMP_ROOT/bin/$stub"
+done
+chmod +x "$TMP_ROOT/bin/gh" "$TMP_ROOT/bin/ghostty" \
+  "$TMP_ROOT/bin/xdg-terminal-exec" "$TMP_ROOT/bin/stub-terminal"
 
 # run SCRIPT DIR ARGS... — one hermetic invocation, combined output.
 #
 # TMUX is unset because oversee-watch's lane-window check only fires outside
 # tmux, and this suite must not pass merely because the developer ran it from a
-# tmux pane. ORCH_LANE_DIRS points at an empty directory so `lanes` never reads
-# the real accounts on this machine.
+# tmux pane. That also makes every open-terminal case here a GUI launch, so
+# TERMINAL names the stub above: it is the first thing open_gui resolves, and
+# pinning it is what keeps a case off the real desktop whatever PATH holds.
+# ORCH_LANE_DIRS points at an empty directory so `lanes` never reads the real
+# accounts on this machine.
 run() {
   local script="$1" dir="$2"
   shift 2
   # The command's own status is returned, not swallowed: the empty-value sweep
   # below asserts on it. Callers that only read the output append `|| true`.
   (cd "$dir" && PATH="$TMP_ROOT/bin:$PATH" \
-    env -u TMUX ORCH_LANES_FETCH_CMD=true ORCH_LANE_DIRS="$TMP_ROOT/no-lanes" \
+    env -u TMUX TERMINAL=stub-terminal ORCH_LANES_FETCH_CMD=true \
+      ORCH_LANE_DIRS="$TMP_ROOT/no-lanes" \
       "$dir/.agents/skills/orch/scripts/$script" "$@") 2>&1
 }
 

--- a/skills/orch/tests/parser-defaults-not-configurable.sh
+++ b/skills/orch/tests/parser-defaults-not-configurable.sh
@@ -42,35 +42,23 @@ bad() {
 
 # A stub gh so no case reaches the network; every command here fails before or
 # at auth, and none of them may decide the outcome by talking to GitHub.
-#
-# And a stub for every terminal open_gui can resolve BELOW $TERMINAL. The rows
-# further down leave TERMINAL unset, because it is a name they measure, so the
-# ladder falls to these two — unstubbed they are the developer's own desktop,
-# and this file's fixtures reach a real GUI launch (KEN-1084). A test that
-# proves a parser property must not be able to open a window while doing it.
 mkdir -p "$TMP_ROOT/bin" "$TMP_ROOT/no-lanes"
 printf '#!/bin/sh\nexit 1\n' >"$TMP_ROOT/bin/gh"
-for stub in ghostty xdg-terminal-exec; do
-  printf '#!/bin/sh\nexit 0\n' >"$TMP_ROOT/bin/$stub"
-done
-chmod +x "$TMP_ROOT/bin/gh" "$TMP_ROOT/bin/ghostty" "$TMP_ROOT/bin/xdg-terminal-exec"
+chmod +x "$TMP_ROOT/bin/gh"
 
 # run SCRIPT DIR ARGS... — one hermetic invocation, combined output.
 #
 # TMUX is unset because oversee-watch's lane-window check only fires outside
 # tmux, and this suite must not pass merely because the developer ran it from a
-# tmux pane. TERMINAL is unset for a second reason: it is a name the TERMINAL
-# rows below measure, and the developer's own value would decide them.
-# ORCH_LANE_DIRS points at an empty directory so `lanes` never reads the real
-# accounts on this machine.
+# tmux pane. ORCH_LANE_DIRS points at an empty directory so `lanes` never reads
+# the real accounts on this machine.
 run() {
   local script="$1" dir="$2"
   shift 2
   # The command's own status is returned, not swallowed: the empty-value sweep
   # below asserts on it. Callers that only read the output append `|| true`.
   (cd "$dir" && PATH="$TMP_ROOT/bin:$PATH" \
-    env -u TMUX -u TERMINAL ORCH_LANES_FETCH_CMD=true \
-      ORCH_LANE_DIRS="$TMP_ROOT/no-lanes" \
+    env -u TMUX ORCH_LANES_FETCH_CMD=true ORCH_LANE_DIRS="$TMP_ROOT/no-lanes" \
       "$dir/.agents/skills/orch/scripts/$script" "$@") 2>&1
 }
 
@@ -222,44 +210,6 @@ for exe in worktree/scripts/worktree review-gate/scripts/pr-watch.sh; do
   printf '#!/bin/sh\necho "EXECUTED FROM THE CONFIGURED SKILLS_DIR" >&2\nexit 0\n' >"$evil/$exe"
   chmod +x "$evil/$exe"
 done
-# TERMINAL is the third name of this shape: open_gui EXECUTES it. Its rows read
-# a FILE rather than the run's output, because open_gui sends a launcher's
-# streams to /dev/null — a marker printed on either would be discarded, and the
-# rows would then pass because nothing was heard rather than because the name
-# was refused, which is the vacuous shape this file plants controls to prevent.
-printf '#!/bin/sh\nprintf ran >%s\nexit 0\n' "$evil/terminal-ran" >"$evil/evilterm"
-chmod +x "$evil/evilterm"
-
-# ran_terminal DIR ARGS... — 0 when the configured terminal really executed. The
-# launch is detached, so the marker can land after open-terminal has exited: a
-# row expecting one waits for it, and a row expecting none has watched a real
-# interval rather than the instant after the exit.
-ran_terminal() {
-  local dir="$1" i=0
-  shift
-  rm -f "$evil/terminal-ran"
-  run open-terminal "$dir" "$@" >/dev/null 2>&1 || true
-  while [ "$i" -lt 20 ] && [ ! -f "$evil/terminal-ran" ]; do
-    sleep 0.1
-    i=$((i + 1))
-  done
-  [ -f "$evil/terminal-ran" ]
-}
-
-# terminal_fixture DIR — a fixture whose worktree CLI succeeds, so a case can
-# REACH the GUI launch. The generic rows never get that far: the real CLI
-# refuses an empty repository, and a TERMINAL row that stopped there would pass
-# without executing anything.
-terminal_fixture() {
-  local wt="$1/.agents/skills/worktree/scripts/worktree"
-  fixture "$1"
-  cat >"$wt" <<EOF
-#!/bin/sh
-[ "\$1" = create ] || exit 1
-mkdir -p "$1/wt" && printf '%s\n' "$1/wt"
-EOF
-  chmod +x "$wt"
-}
 
 # name_cases NAME MARKER — SCRIPT|ARGS rows for one injected name.
 script_dir_cases='
@@ -311,14 +261,6 @@ for source_kind in dotenv settings; do
 $rows
 EOF
   done
-done
-
-for source_kind in dotenv settings; do
-  dir="$TMP_ROOT/own-TERMINAL-$source_kind"
-  terminal_fixture "$dir"
-  write_config "$dir" "$source_kind" TERMINAL "$evil/evilterm"
-  label="open-terminal: a TERMINAL in $source_kind never chooses which terminal is executed"
-  if ran_terminal "$dir" --cmd true KEN-1; then bad "$label" "the configured terminal was executed"; else ok "$label"; fi
 done
 
 # approval-wait is the one CLI holding parse state across its load, and it is
@@ -398,17 +340,6 @@ if drop_export "$leak_skills" open-terminal SKILLS_DIR; then
     "$leak_skills" open-terminal "EXECUTED FROM THE CONFIGURED SKILLS_DIR" --harness claude KEN-1
 else
   bad "the export SKILLS_DIR mutation did not land, so it proves nothing"
-fi
-
-leak_term="$TMP_ROOT/leak-terminal"
-terminal_fixture "$leak_term"
-write_config "$leak_term" settings TERMINAL "$evil/evilterm"
-if drop_export "$leak_term" open-terminal TERMINAL; then
-  leak_label="dropping export TERMINAL lets open-terminal execute the configured one"
-  if ran_terminal "$leak_term" --cmd true KEN-1; then ok "$leak_label"
-  else bad "$leak_label" "the row would have passed with the protection gone"; fi
-else
-  bad "the export TERMINAL mutation did not land, so it proves nothing"
 fi
 
 # approval-wait has no export to drop: what protects it is that the branch

--- a/skills/orch/tests/parser-defaults-not-configurable.sh
+++ b/skills/orch/tests/parser-defaults-not-configurable.sh
@@ -25,6 +25,8 @@
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/sealed-bin.sh
+. "$TEST_DIR/lib/sealed-bin.sh"
 SKILLS_SRC="$(cd "$TEST_DIR/../.." && pwd)"
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
@@ -41,29 +43,19 @@ bad() {
 }
 
 # A stub gh so no case reaches the network; every command here fails before or
-# at auth, and none of them may decide the outcome by talking to GitHub.
-#
-# And a stub for every terminal open_gui can resolve. No assertion in this file
-# measures a launch, but the SKILLS_DIR leak control below drops the very export
-# it is proving, so its stubbed worktree CLI exits 0 printing no path and the
-# launch that follows used to reach the real ghostty on PATH — a window on the
-# operator's desktop at a directory that was already deleted (KEN-1084). A test
-# that proves a parser property must not be able to open one while doing it.
+# at auth, and none of them may decide the outcome by talking to GitHub. Every
+# other name a case could reach for is answered by $SEALED, which is why this
+# file stubs no terminal of its own.
 mkdir -p "$TMP_ROOT/bin" "$TMP_ROOT/no-lanes"
 printf '#!/bin/sh\nexit 1\n' >"$TMP_ROOT/bin/gh"
-for stub in ghostty xdg-terminal-exec stub-terminal; do
-  printf '#!/bin/sh\nexit 0\n' >"$TMP_ROOT/bin/$stub"
-done
-chmod +x "$TMP_ROOT/bin/gh" "$TMP_ROOT/bin/ghostty" \
-  "$TMP_ROOT/bin/xdg-terminal-exec" "$TMP_ROOT/bin/stub-terminal"
+chmod +x "$TMP_ROOT/bin/gh"
 
 # run SCRIPT DIR ARGS... — one hermetic invocation, combined output.
 #
 # TMUX is unset because oversee-watch's lane-window check only fires outside
 # tmux, and this suite must not pass merely because the developer ran it from a
-# tmux pane. That also makes every open-terminal case here a GUI launch, so
-# TERMINAL names the stub above: it is the first thing open_gui resolves, and
-# pinning it is what keeps a case off the real desktop whatever PATH holds.
+# tmux pane. TERMINAL is unset for a second reason: it is a name the TERMINAL
+# rows below measure, and the developer's own value would decide them.
 # ORCH_LANE_DIRS points at an empty directory so `lanes` never reads the real
 # accounts on this machine.
 run() {
@@ -71,8 +63,8 @@ run() {
   shift 2
   # The command's own status is returned, not swallowed: the empty-value sweep
   # below asserts on it. Callers that only read the output append `|| true`.
-  (cd "$dir" && PATH="$TMP_ROOT/bin:$PATH" \
-    env -u TMUX TERMINAL=stub-terminal ORCH_LANES_FETCH_CMD=true \
+  (cd "$dir" && PATH="$TMP_ROOT/bin:$SEALED:$PATH" \
+    env -u TMUX -u TERMINAL ORCH_LANES_FETCH_CMD=true \
       ORCH_LANE_DIRS="$TMP_ROOT/no-lanes" \
       "$dir/.agents/skills/orch/scripts/$script" "$@") 2>&1
 }
@@ -225,6 +217,27 @@ for exe in worktree/scripts/worktree review-gate/scripts/pr-watch.sh; do
   printf '#!/bin/sh\necho "EXECUTED FROM THE CONFIGURED SKILLS_DIR" >&2\nexit 0\n' >"$evil/$exe"
   chmod +x "$evil/$exe"
 done
+# TERMINAL is the third name of this shape: open_gui EXECUTES it. It exits
+# non-zero so open-terminal relays its words — a launcher's stdout and stderr
+# go to a scratch file that is only printed when the launch failed, which is
+# also the only way a marker written here can reach the assertion.
+printf '#!/bin/sh\necho "EXECUTED FROM THE CONFIGURED TERMINAL" >&2\nexit 3\n' >"$evil/evilterm"
+chmod +x "$evil/evilterm"
+
+# terminal_fixture DIR — a fixture whose worktree CLI succeeds, so a case can
+# REACH the GUI launch. The generic rows never get that far: the real CLI
+# refuses an empty repository, and a TERMINAL row that stopped there would pass
+# without executing anything.
+terminal_fixture() {
+  local wt="$1/.agents/skills/worktree/scripts/worktree"
+  fixture "$1"
+  cat >"$wt" <<EOF
+#!/bin/sh
+[ "\$1" = create ] || exit 1
+mkdir -p "$1/wt" && printf '%s\n' "$1/wt"
+EOF
+  chmod +x "$wt"
+}
 
 # name_cases NAME MARKER — SCRIPT|ARGS rows for one injected name.
 script_dir_cases='
@@ -276,6 +289,14 @@ for source_kind in dotenv settings; do
 $rows
 EOF
   done
+done
+
+for source_kind in dotenv settings; do
+  dir="$TMP_ROOT/own-TERMINAL-$source_kind"
+  terminal_fixture "$dir"
+  write_config "$dir" "$source_kind" TERMINAL "$evil/evilterm"
+  refute "open-terminal: a TERMINAL in $source_kind never chooses which terminal is executed" \
+    "$dir" open-terminal "EXECUTED FROM THE CONFIGURED TERMINAL" --cmd true KEN-1
 done
 
 # approval-wait is the one CLI holding parse state across its load, and it is
@@ -355,6 +376,16 @@ if drop_export "$leak_skills" open-terminal SKILLS_DIR; then
     "$leak_skills" open-terminal "EXECUTED FROM THE CONFIGURED SKILLS_DIR" --harness claude KEN-1
 else
   bad "the export SKILLS_DIR mutation did not land, so it proves nothing"
+fi
+
+leak_term="$TMP_ROOT/leak-terminal"
+terminal_fixture "$leak_term"
+write_config "$leak_term" settings TERMINAL "$evil/evilterm"
+if drop_export "$leak_term" open-terminal TERMINAL; then
+  must_leak "dropping export TERMINAL lets open-terminal execute the configured one" \
+    "$leak_term" open-terminal "EXECUTED FROM THE CONFIGURED TERMINAL" --cmd true KEN-1
+else
+  bad "the export TERMINAL mutation did not land, so it proves nothing"
 fi
 
 # approval-wait has no export to drop: what protects it is that the branch

--- a/skills/orch/tests/parser-defaults-not-configurable.sh
+++ b/skills/orch/tests/parser-defaults-not-configurable.sh
@@ -217,12 +217,29 @@ for exe in worktree/scripts/worktree review-gate/scripts/pr-watch.sh; do
   printf '#!/bin/sh\necho "EXECUTED FROM THE CONFIGURED SKILLS_DIR" >&2\nexit 0\n' >"$evil/$exe"
   chmod +x "$evil/$exe"
 done
-# TERMINAL is the third name of this shape: open_gui EXECUTES it. It exits
-# non-zero so open-terminal relays its words — a launcher's stdout and stderr
-# go to a scratch file that is only printed when the launch failed, which is
-# also the only way a marker written here can reach the assertion.
-printf '#!/bin/sh\necho "EXECUTED FROM THE CONFIGURED TERMINAL" >&2\nexit 3\n' >"$evil/evilterm"
+# TERMINAL is the third name of this shape: open_gui EXECUTES it. Its rows read
+# a FILE rather than the run's output, because open_gui sends a launcher's
+# streams to /dev/null — a marker printed on either would be discarded, and the
+# rows would then pass because nothing was heard rather than because the name
+# was refused, which is the vacuous shape this file plants controls to prevent.
+printf '#!/bin/sh\nprintf ran >%s\nexit 0\n' "$evil/terminal-ran" >"$evil/evilterm"
 chmod +x "$evil/evilterm"
+
+# ran_terminal DIR ARGS... — 0 when the configured terminal really executed. The
+# launch is detached, so the marker can land after open-terminal has exited: a
+# row expecting one waits for it, and a row expecting none has watched a real
+# interval rather than the instant after the exit.
+ran_terminal() {
+  local dir="$1" i=0
+  shift
+  rm -f "$evil/terminal-ran"
+  run open-terminal "$dir" "$@" >/dev/null 2>&1 || true
+  while [ "$i" -lt 20 ] && [ ! -f "$evil/terminal-ran" ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -f "$evil/terminal-ran" ]
+}
 
 # terminal_fixture DIR — a fixture whose worktree CLI succeeds, so a case can
 # REACH the GUI launch. The generic rows never get that far: the real CLI
@@ -295,8 +312,8 @@ for source_kind in dotenv settings; do
   dir="$TMP_ROOT/own-TERMINAL-$source_kind"
   terminal_fixture "$dir"
   write_config "$dir" "$source_kind" TERMINAL "$evil/evilterm"
-  refute "open-terminal: a TERMINAL in $source_kind never chooses which terminal is executed" \
-    "$dir" open-terminal "EXECUTED FROM THE CONFIGURED TERMINAL" --cmd true KEN-1
+  label="open-terminal: a TERMINAL in $source_kind never chooses which terminal is executed"
+  if ran_terminal "$dir" --cmd true KEN-1; then bad "$label" "the configured terminal was executed"; else ok "$label"; fi
 done
 
 # approval-wait is the one CLI holding parse state across its load, and it is
@@ -382,8 +399,9 @@ leak_term="$TMP_ROOT/leak-terminal"
 terminal_fixture "$leak_term"
 write_config "$leak_term" settings TERMINAL "$evil/evilterm"
 if drop_export "$leak_term" open-terminal TERMINAL; then
-  must_leak "dropping export TERMINAL lets open-terminal execute the configured one" \
-    "$leak_term" open-terminal "EXECUTED FROM THE CONFIGURED TERMINAL" --cmd true KEN-1
+  leak_label="dropping export TERMINAL lets open-terminal execute the configured one"
+  if ran_terminal "$leak_term" --cmd true KEN-1; then ok "$leak_label"
+  else bad "$leak_label" "the row would have passed with the protection gone"; fi
 else
   bad "the export TERMINAL mutation did not land, so it proves nothing"
 fi

--- a/skills/orch/tests/parser-defaults-not-configurable.sh
+++ b/skills/orch/tests/parser-defaults-not-configurable.sh
@@ -25,8 +25,6 @@
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=lib/sealed-bin.sh
-. "$TEST_DIR/lib/sealed-bin.sh"
 SKILLS_SRC="$(cd "$TEST_DIR/../.." && pwd)"
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
@@ -43,12 +41,19 @@ bad() {
 }
 
 # A stub gh so no case reaches the network; every command here fails before or
-# at auth, and none of them may decide the outcome by talking to GitHub. Every
-# other name a case could reach for is answered by $SEALED, which is why this
-# file stubs no terminal of its own.
+# at auth, and none of them may decide the outcome by talking to GitHub.
+#
+# And a stub for every terminal open_gui can resolve BELOW $TERMINAL. The rows
+# further down leave TERMINAL unset, because it is a name they measure, so the
+# ladder falls to these two — unstubbed they are the developer's own desktop,
+# and this file's fixtures reach a real GUI launch (KEN-1084). A test that
+# proves a parser property must not be able to open a window while doing it.
 mkdir -p "$TMP_ROOT/bin" "$TMP_ROOT/no-lanes"
 printf '#!/bin/sh\nexit 1\n' >"$TMP_ROOT/bin/gh"
-chmod +x "$TMP_ROOT/bin/gh"
+for stub in ghostty xdg-terminal-exec; do
+  printf '#!/bin/sh\nexit 0\n' >"$TMP_ROOT/bin/$stub"
+done
+chmod +x "$TMP_ROOT/bin/gh" "$TMP_ROOT/bin/ghostty" "$TMP_ROOT/bin/xdg-terminal-exec"
 
 # run SCRIPT DIR ARGS... — one hermetic invocation, combined output.
 #
@@ -63,7 +68,7 @@ run() {
   shift 2
   # The command's own status is returned, not swallowed: the empty-value sweep
   # below asserts on it. Callers that only read the output append `|| true`.
-  (cd "$dir" && PATH="$TMP_ROOT/bin:$SEALED:$PATH" \
+  (cd "$dir" && PATH="$TMP_ROOT/bin:$PATH" \
     env -u TMUX -u TERMINAL ORCH_LANES_FETCH_CMD=true \
       ORCH_LANE_DIRS="$TMP_ROOT/no-lanes" \
       "$dir/.agents/skills/orch/scripts/$script" "$@") 2>&1

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -100,7 +100,7 @@ skills/orch/scripts/dev-artifact-check	730
 skills/orch/scripts/dev-return-write	444
 skills/orch/scripts/lanes	622
 skills/orch/scripts/merge-queue-watch	556
-skills/orch/scripts/open-terminal	669
+skills/orch/scripts/open-terminal	689
 skills/orch/scripts/oversee-watch	678
 skills/orch/scripts/queue-wait	1067
 skills/orch/scripts/review-artifact-check	413

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -100,7 +100,7 @@ skills/orch/scripts/dev-artifact-check	730
 skills/orch/scripts/dev-return-write	444
 skills/orch/scripts/lanes	622
 skills/orch/scripts/merge-queue-watch	556
-skills/orch/scripts/open-terminal	732
+skills/orch/scripts/open-terminal	711
 skills/orch/scripts/oversee-watch	678
 skills/orch/scripts/queue-wait	1067
 skills/orch/scripts/review-artifact-check	413

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -100,7 +100,7 @@ skills/orch/scripts/dev-artifact-check	730
 skills/orch/scripts/dev-return-write	444
 skills/orch/scripts/lanes	622
 skills/orch/scripts/merge-queue-watch	556
-skills/orch/scripts/open-terminal	711
+skills/orch/scripts/open-terminal	703
 skills/orch/scripts/oversee-watch	678
 skills/orch/scripts/queue-wait	1067
 skills/orch/scripts/review-artifact-check	413

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -108,7 +108,7 @@ skills/orch/scripts/workflow-state	704
 skills/orch/scripts/worktree-push	421
 skills/orch/tests/approval_wait.sh	1557
 skills/orch/tests/dev_artifact_check.sh	815
-skills/orch/tests/lanes.sh	890
+skills/orch/tests/lanes.sh	888
 skills/orch/tests/oversee_watch_lanes.sh	815
 skills/orch/tests/queue_wait.sh	896
 skills/orch/tests/worktree-cwd-precondition-lint.test.sh	940

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -100,7 +100,7 @@ skills/orch/scripts/dev-artifact-check	730
 skills/orch/scripts/dev-return-write	444
 skills/orch/scripts/lanes	622
 skills/orch/scripts/merge-queue-watch	556
-skills/orch/scripts/open-terminal	689
+skills/orch/scripts/open-terminal	732
 skills/orch/scripts/oversee-watch	678
 skills/orch/scripts/queue-wait	1067
 skills/orch/scripts/review-artifact-check	413


### PR DESCRIPTION
Ghostty windows kept opening on the operator's desktop during fleet work, every one pointed at a directory that no longer existed.

## What ships

- **`open-terminal` refuses a launch whose working directory is gone.** One `launchable_dir` helper on both launch paths, `open_tmux` and `open_gui`, before either opens anything. The empty path is the same case: `-d ""` is false. That closes the class whatever spawns it, including lanes still running pre-KEN-995 worktree code.
- **Outside tmux, `$TERMINAL` is honoured first**, then `xdg-terminal-exec`, then ghostty. No mode gate and no refusal outside tmux.
- **The tty probe's session holds its own deadline.** The cap previously lived only in the caller's poll loop, so a suite killed mid-run took the cap with it and left a `setsid`'d session nothing could reach — the shape of two `gg-ptyform` keepalives that ran for sixteen hours before being killed by hand.

## The residual spawner, with a reproduction

Not a merge-queue supervisor. It is the `SKILLS_DIR` `must_leak` case in `skills/orch/tests/parser-defaults-not-configurable.sh`: the case drops the `export` it is proving, so the fixture's stub worktree CLI runs, exits 0 and prints nothing, and `open_gui ""` handed the empty path to the real ghostty on PATH. Running the pre-change script against an empty-path stub emits the argv the sweeper recorded:

```
ghostty --working-directory= --title=KEN-1 -e bash -lc cd '' && ...
```

matching `sweep-provenance.log`'s entry for pid 3841851, cwd `/var/tmp/agents/tmp.PSSHezx7tZ/leak-skills-dir (deleted)`. KEN-1060 is a real defect but a different one — its trap leaves *workers* unreaped, and neither `merge-queue-supervisor.sh`, `merge-queue-watch` nor `queue-wait` names a terminal at all.

The suites that drive `open-terminal` now put the committed `tools/tests/lib/sealed-bin` fixture on PATH behind their own stubs, so a leaked process finds a loud refusal instead of a real terminal.

## Controls

`open-terminal-launch-guard.sh` reds with the directory test removed, on both the deleted and the empty shape — a guard written as a stat of a non-empty path would refuse one and launch the other. `terminal-paths.test.sh` reds with the session watchdog removed, and its assertion is a real dash measurement on the CI runner rather than a claim about one.

## Scope

Cut to the Done-when by overseer ruling: `launchable_dir`, the `$TERMINAL` ladder, the deleted-cwd control, and the pty self-deadline. A launch beat that observed the launcher, a sealing lint over test-file bodies, and a no-terminal PATH mirror were built during review and deleted. A GUI launch is detached and unobserved, so an item whose launcher exits non-zero is still reported as opened.

The Done-when's last clause — a full day of sweeper aggregates showing zero real-ghostty kills — can only be read after this lands.

Closes KEN-1084
