### PR TITLE
fix(KEN-1060): the supervisor's EXIT trap owns teardown on every exit

### DIFF
--- a/.agents/skills/orch/scripts/lib/merge-queue-supervisor.sh
+++ b/.agents/skills/orch/scripts/lib/merge-queue-supervisor.sh
@@ -73,13 +73,22 @@ merge_queue_supervise() {
         worker_exit_code:$rc,diagnostic_path:$log}' > "$output" || return 1
     publish_output && published=true
   }
+  # An EXIT trap fires when the SHELL exits, after `return` has already popped
+  # this function's locals, so a path that ends in `return` must call cleanup
+  # itself while they are still live. The trap covers only the exits that
+  # happen mid-function — signals and set -e — and cleanup clears it first so
+  # a teardown that already ran cannot run again empty at shell exit. The
+  # terminal file it writes last is the durable sign that teardown, including
+  # the publication fallback, is over.
   cleanup() {
-    local rc=$?
+    local rc="${1-$?}"
+    trap - EXIT TERM HUP INT
     exec 6>&- 7>&- 8>&- 9>&- 2>/dev/null || true
     [[ -z "$watchdog_pid" ]] || { kill "$watchdog_pid" 2>/dev/null || true; wait "$watchdog_pid" 2>/dev/null || true; }
-    stop_worker
+    watchdog_pid=""
+    stop_worker; worker_pid=""
     $published || publish_unknown supervisor_exit "$rc" || true
-    printf '%s\n' "$rc" > "$runtime/terminal" 2>/dev/null || true
+    { printf '%s\n' "$rc" > "$runtime/terminal" && chmod 600 "$runtime/terminal"; } 2>/dev/null || true
   }
   trap cleanup EXIT
   trap 'exit 143' TERM HUP
@@ -105,7 +114,7 @@ merge_queue_supervise() {
     [[ $(date +%s) -lt "$deadline" ]] || printf 'deadline\n' >&7
   ) & watchdog_pid=$!
   printf '%s\n' "$$" > "$runtime/supervisor.pid"; chmod 600 "$runtime/supervisor.pid"
-  attempt_is_current || return 1
+  attempt_is_current || { cleanup 1; return 1; }
   set -m
   (
     exec 7>"$event_fifo"
@@ -116,7 +125,7 @@ merge_queue_supervise() {
     rc=$?; printf '%s\n' "$rc" > "$runtime/worker.status"; printf 'worker\n' >&7; exit "$rc"
   ) & worker_pid=$!
   set +m
-  kill -0 "$worker_pid" 2>/dev/null || return 1
+  kill -0 "$worker_pid" 2>/dev/null || { cleanup 1; return 1; }
   : > "$runtime/ready"; chmod 600 "$runtime/ready"
   IFS= read -r event < "$event_fifo" || true
   exec 6>&- 7>&-
@@ -126,16 +135,16 @@ merge_queue_supervise() {
   if [[ "$event" == home_lost ]] || ! home_present; then
     stop_worker; worker_pid=""; report_home_lost; trap - EXIT TERM HUP INT; return 1
   fi
-  if [[ "$event" == deadline && ! -f "$runtime/worker.status" ]]; then stop_worker; worker_pid=""; publish_unknown supervisor_deadline 124; trap - EXIT TERM HUP INT; return 0; fi
+  if [[ "$event" == deadline && ! -f "$runtime/worker.status" ]]; then stop_worker; worker_pid=""; publish_unknown supervisor_deadline 124; cleanup 0; return 0; fi
   wait "$worker_pid" || worker_rc=$?; worker_pid=""
   if ! jq -e 'type=="object" and (.status|IN("complete","timeout","error")) and
       (.verdict|IN("merged","conflicting","ejected","disarmed","dequeued","closed","queued","not_queued","unknown"))' "$temp" >/dev/null 2>&1; then
-    publish_unknown worker_output_invalid "$worker_rc"; trap - EXIT TERM HUP INT; return 0
+    publish_unknown worker_output_invalid "$worker_rc"; cleanup 0; return 0
   fi
   jq --arg repo "$repo" --argjson pr "$pr" --arg head "$head" --arg watch "$watch_id" --arg attempt "$attempt_id" --arg log "$log" \
     '. + {schema_version:1,repository:$repo,pr_number:$pr,expected_head:$head,
       watch_id:$watch,launch_attempt_id:$attempt,diagnostic_path:$log}' "$temp" > "$output"
-  publish_output || return 1
-  published=true; printf '%s\n' "$worker_rc" > "$runtime/terminal"; chmod 600 "$runtime/terminal"
-  trap - EXIT TERM HUP INT
+  publish_output || { cleanup 1; return 1; }
+  published=true
+  cleanup "$worker_rc"
 }

--- a/.agents/skills/orch/scripts/lib/merge-queue-supervisor.sh
+++ b/.agents/skills/orch/scripts/lib/merge-queue-supervisor.sh
@@ -77,15 +77,18 @@ merge_queue_supervise() {
     publish_output && published=true
   }
   # The one teardown, on every exit (return, set -e, exit, signal), with the
-  # exit status as $?. A home that is gone gets no fallback: there is nothing
-  # left to publish into. The terminal file written last is the durable sign
-  # that teardown, including the publication fallback, is over.
+  # exit status as $?. A home that is gone gets neither the fallback nor the
+  # terminal marker: there is nothing left to publish into, and a runtime
+  # swapped for a symlink would carry the marker to wherever it points. The
+  # terminal file written last is the durable sign that teardown, including
+  # the publication fallback, is over.
   cleanup() {
     local rc=$?
     exec 6>&- 7>&- 8>&- 9>&- 2>/dev/null || true
     [[ -z "$watchdog_pid" ]] || { kill "$watchdog_pid" 2>/dev/null || true; wait "$watchdog_pid" 2>/dev/null || true; }
     stop_worker
-    if ! $published && home_present; then publish_unknown supervisor_exit "$rc" || true; fi
+    home_present || return 0
+    $published || publish_unknown supervisor_exit "$rc" || true
     { printf '%s\n' "$rc" > "$runtime/terminal" && chmod 600 "$runtime/terminal"; } 2>/dev/null || true
   }
   trap cleanup EXIT

--- a/.agents/skills/orch/scripts/lib/merge-queue-supervisor.sh
+++ b/.agents/skills/orch/scripts/lib/merge-queue-supervisor.sh
@@ -14,10 +14,13 @@
 # and consume terminalizes it as watch_lost.
 
 merge_queue_supervise() {
-  local state_file="$1" watch_id="$2" attempt_id="$3" runtime="$4" artifact="$5" deadline="$6"
-  local waiter="$7" poll="$8" max_wait="$9"
-  local repo pr head main_root log temp output worker_pid="" worker_rc=0 event=""
-  local event_fifo owner_fifo watchdog_pid="" published=false process_token="${MERGE_QUEUE_SUPERVISOR_TOKEN:-}"
+  # Process-scoped on purpose, never local: the __supervise process exists
+  # only to run this function, and the EXIT trap that tears it down fires
+  # when the shell exits, after `return` and a set -e failure have both
+  # popped the function's frame. A trap reading locals runs empty on either.
+  state_file="$1" watch_id="$2" attempt_id="$3" runtime="$4" artifact="$5" deadline="$6"
+  waiter="$7" poll="$8" max_wait="$9"
+  worker_pid="" worker_rc=0 event="" watchdog_pid="" published=false process_token="${MERGE_QUEUE_SUPERVISOR_TOKEN:-}"
   repo=$(jq -r .repository "$state_file"); pr=$(jq -r .pr_number "$state_file")
   head=$(jq -r .head_sha "$state_file")
   main_root=$(jq -r .main_repo_root "$state_file")
@@ -73,21 +76,16 @@ merge_queue_supervise() {
         worker_exit_code:$rc,diagnostic_path:$log}' > "$output" || return 1
     publish_output && published=true
   }
-  # An EXIT trap fires when the SHELL exits, after `return` has already popped
-  # this function's locals, so a path that ends in `return` must call cleanup
-  # itself while they are still live. The trap covers only the exits that
-  # happen mid-function — signals and set -e — and cleanup clears it first so
-  # a teardown that already ran cannot run again empty at shell exit. The
-  # terminal file it writes last is the durable sign that teardown, including
-  # the publication fallback, is over.
+  # The one teardown, on every exit (return, set -e, exit, signal), with the
+  # exit status as $?. A home that is gone gets no fallback: there is nothing
+  # left to publish into. The terminal file written last is the durable sign
+  # that teardown, including the publication fallback, is over.
   cleanup() {
-    local rc="${1-$?}"
-    trap - EXIT TERM HUP INT
+    local rc=$?
     exec 6>&- 7>&- 8>&- 9>&- 2>/dev/null || true
     [[ -z "$watchdog_pid" ]] || { kill "$watchdog_pid" 2>/dev/null || true; wait "$watchdog_pid" 2>/dev/null || true; }
-    watchdog_pid=""
-    stop_worker; worker_pid=""
-    $published || publish_unknown supervisor_exit "$rc" || true
+    stop_worker
+    if ! $published && home_present; then publish_unknown supervisor_exit "$rc" || true; fi
     { printf '%s\n' "$rc" > "$runtime/terminal" && chmod 600 "$runtime/terminal"; } 2>/dev/null || true
   }
   trap cleanup EXIT
@@ -114,7 +112,7 @@ merge_queue_supervise() {
     [[ $(date +%s) -lt "$deadline" ]] || printf 'deadline\n' >&7
   ) & watchdog_pid=$!
   printf '%s\n' "$$" > "$runtime/supervisor.pid"; chmod 600 "$runtime/supervisor.pid"
-  attempt_is_current || { cleanup 1; return 1; }
+  attempt_is_current || return 1
   set -m
   (
     exec 7>"$event_fifo"
@@ -125,26 +123,23 @@ merge_queue_supervise() {
     rc=$?; printf '%s\n' "$rc" > "$runtime/worker.status"; printf 'worker\n' >&7; exit "$rc"
   ) & worker_pid=$!
   set +m
-  kill -0 "$worker_pid" 2>/dev/null || { cleanup 1; return 1; }
+  kill -0 "$worker_pid" 2>/dev/null || return 1
   : > "$runtime/ready"; chmod 600 "$runtime/ready"
   IFS= read -r event < "$event_fifo" || true
   exec 6>&- 7>&-
   wait "$watchdog_pid" 2>/dev/null || true; watchdog_pid=""
-  # Named refusal, and nothing published: once the home is gone there is
-  # nothing left to publish into.
-  if [[ "$event" == home_lost ]] || ! home_present; then
-    stop_worker; worker_pid=""; report_home_lost; trap - EXIT TERM HUP INT; return 1
-  fi
-  if [[ "$event" == deadline && ! -f "$runtime/worker.status" ]]; then stop_worker; worker_pid=""; publish_unknown supervisor_deadline 124; cleanup 0; return 0; fi
+  # Named refusal; the teardown reaps the worker and, with the home gone,
+  # publishes nothing.
+  if [[ "$event" == home_lost ]] || ! home_present; then report_home_lost; return 1; fi
+  if [[ "$event" == deadline && ! -f "$runtime/worker.status" ]]; then stop_worker; worker_pid=""; publish_unknown supervisor_deadline 124; return 0; fi
   wait "$worker_pid" || worker_rc=$?; worker_pid=""
   if ! jq -e 'type=="object" and (.status|IN("complete","timeout","error")) and
       (.verdict|IN("merged","conflicting","ejected","disarmed","dequeued","closed","queued","not_queued","unknown"))' "$temp" >/dev/null 2>&1; then
-    publish_unknown worker_output_invalid "$worker_rc"; cleanup 0; return 0
+    publish_unknown worker_output_invalid "$worker_rc"; return 0
   fi
   jq --arg repo "$repo" --argjson pr "$pr" --arg head "$head" --arg watch "$watch_id" --arg attempt "$attempt_id" --arg log "$log" \
     '. + {schema_version:1,repository:$repo,pr_number:$pr,expected_head:$head,
       watch_id:$watch,launch_attempt_id:$attempt,diagnostic_path:$log}' "$temp" > "$output"
-  publish_output || { cleanup 1; return 1; }
+  publish_output || return 1
   published=true
-  cleanup "$worker_rc"
 }

--- a/.agents/skills/orch/tests/merge_queue_teardown.sh
+++ b/.agents/skills/orch/tests/merge_queue_teardown.sh
@@ -309,10 +309,9 @@ case "$census_err" in *"could not enumerate processes"*) ok "the failed census n
 
 # What the refusal is FOR, read where it lands: a consumer finds nothing to
 # route. Asserted through consume rather than through the artifact file,
-# because the file's absence is not something this code could get wrong — a
-# refusal that returns leaves the cleanup trap without any of its locals, so
-# no artifact appears whether or not the trap was cleared. What can go wrong
-# is the refusal publishing on its way out, and consume is where that shows.
+# because the refusal skips the publishing teardown by design — its home is
+# gone, so there is nothing to publish into. What can go wrong is the refusal
+# publishing on its way out, and consume is where that shows.
 consume_after_refusal() {
   local sb="$1" issue="$2"
   (
@@ -344,6 +343,130 @@ if [[ "$(jq -r '.diagnostic.cause' <<<"$publishing_consume")" != watch_lost ]]; 
   ok "a refusal that publishes routes the consumer somewhere else"
 else bad "the publishing mutant still consumed as watch_lost"; fi
 mq_reap "$publishing" || bad "reaper reported survivors under the publishing sandbox"
+
+echo "=== a supervisor that returns still runs its teardown ==="
+
+# An EXIT trap fires when the shell exits, after `return` has popped the
+# supervisor's locals — so a path that ends in `return` must run cleanup
+# itself while they are live (KEN-1060). The worker-liveness check is forced
+# false with a real worker running, so the supervisor takes its `return 1`
+# path holding everything teardown exists to retire: a live worker, an open
+# runtime, and the promise of a consumable artifact.
+workers_under() {
+  ps -e -ww -o pid=,args= > "$TMP/ps.worker.snapshot" 2>/dev/null || true
+  awk -v root="$1" 'index($0, "queue-wait") && index($0, root) { print $1 }' "$TMP/ps.worker.snapshot"
+}
+count_workers() { workers_under "$1" | grep -c . || true; }
+
+# $1 sandbox, $2 issue: launch under the sandbox's supervisor copy. The caller
+# arranges for the supervisor to exit or be held before the worker-liveness
+# marker, so the launch command itself must fail; on that failure, print
+# "runtime<TAB>artifact" for the attempt.
+launch_return_path() {
+  local sb="$1" issue="$2" scripts main rc=0
+  scripts="$sb/orch/scripts"; main="$sb/main"
+  (
+    export PATH="$sb/bin:$SEALED:$PATH"
+    unset GH_TOKEN GITHUB_TOKEN GH_BOT_TOKEN GH_REPO GITHUB_REPOSITORY
+    "$scripts/merge-queue-watch" init --worktree "$main" --issue "$issue" \
+      --branch "$(git -C "$main" branch --show-current)" >/dev/null
+    prep=$("$scripts/merge-queue-watch" prepare --worktree "$main" --issue "$issue" \
+      --repo owner/repo --pr 42 --head "$HEAD" --root "$main" --gate-mode off \
+      --recovery-count 0 --cleanup-worktree false)
+    "$scripts/merge-queue-watch" launch --root "$main" --issue "$issue" \
+      --watch-id "$(jq -r .watch_id <<<"$prep")" --poll 1 --max-wait 600 >/dev/null 2>&1
+  ) || rc=$?
+  [[ "$rc" -ne 0 ]] || return 1
+  "$scripts/merge-queue-watch" inspect --root "$main" --issue "$issue" \
+    | jq -r '[.runtime_dir, .artifact_path] | @tsv'
+}
+
+retpath="$TMP/return-path"
+build_sandbox "$retpath"
+edit_once "$ORCH/scripts/lib/merge-queue-supervisor.sh" \
+  "$retpath/orch/scripts/lib/merge-queue-supervisor.sh" \
+  'kill -0 "$worker_pid" 2>/dev/null || { cleanup 1; return 1; }' \
+  'false || { cleanup 1; return 1; }' \
+  || { bad "return-path mutation did not apply"; exit 1; }
+rp_runtime="" rp_artifact=""
+if IFS=$'\t' read -r rp_runtime rp_artifact < <(launch_return_path "$retpath" KEN-1060-return); then
+  ok "the worker-liveness return path fails the launch"
+else
+  bad "the forced return path did not fail the launch; the assertions below prove nothing"
+fi
+if [[ -n "$rp_runtime" ]]; then
+  wait_exists "$rp_runtime/terminal" && ok "the return path writes the runtime terminal file" \
+    || bad "the return path left no terminal file"
+  eq "$(jq -r '.verdict // "missing"' "$rp_artifact" 2>/dev/null || echo missing)" unknown "the return path publishes the unknown fallback"
+  eq "$(jq -r '.cause // "missing"' "$rp_artifact" 2>/dev/null || echo missing)" supervisor_exit "the fallback names the supervisor exit"
+  for ((i=0;i<100;i++)); do [[ "$(count_workers "$retpath")" -eq 0 && "$(count_supervisors "$retpath")" -eq 0 ]] && break; sleep 0.05; done
+  eq "$(count_workers "$retpath")" 0 "the return path reaps its live worker"
+  eq "$(count_supervisors "$retpath")" 0 "no supervisor outlives the return path"
+fi
+
+# Control: the same forced path with the explicit call cut leaves only the
+# EXIT trap, which fires after the locals are gone — no terminal, no fallback,
+# a leaked worker. This is the silent no-op the assertions above must catch.
+noclean="$TMP/return-path-noclean"
+build_sandbox "$noclean"
+edit_once "$ORCH/scripts/lib/merge-queue-supervisor.sh" \
+  "$noclean/orch/scripts/lib/merge-queue-supervisor.sh" \
+  'kill -0 "$worker_pid" 2>/dev/null || { cleanup 1; return 1; }' \
+  'false || return 1' \
+  || { bad "return-path control mutation did not apply"; exit 1; }
+nc_runtime="" nc_artifact=""
+if IFS=$'\t' read -r nc_runtime nc_artifact < <(launch_return_path "$noclean" KEN-1060-noclean); then
+  ok "the control's forced return path fails the launch"
+else
+  bad "the control launch did not fail; the control proves nothing"
+fi
+if [[ -n "$nc_runtime" ]]; then
+  [[ ! -e "$nc_runtime/terminal" ]] && ok "without the explicit call the empty trap writes no terminal" \
+    || bad "the control wrote a terminal; the terminal assertion above is free"
+  [[ ! -e "$nc_artifact" ]] && ok "without the explicit call no fallback is published" \
+    || bad "the control published a fallback; the fallback assertion above is free"
+  [[ "$(count_workers "$noclean")" -gt 0 ]] && ok "without the explicit call the worker leaks" \
+    || bad "the control leaked no worker; the reap assertion above is free"
+fi
+mq_reap "$noclean" || bad "reaper reported survivors under the control sandbox"
+
+# The other guarded return: the post-registration currency recheck, driven
+# with no mutation. The supervisor is held at its event fifo, so the launch
+# command times out waiting for worker liveness and claims launch_failed;
+# released, the supervisor's recheck refuses and returns 1. That launch_failed
+# state still admits the unknown fallback — the reason publish accepts it.
+regate="$TMP/recheck"
+build_sandbox "$regate"
+TD_REAL_MKFIFO="$(command -v mkfifo)"
+export TD_MKFIFO_GATE="$TMP/recheck-mkfifo-gate" TD_REAL_MKFIFO
+cat > "$regate/bin/mkfifo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ -f "$TD_MKFIFO_GATE.enabled" && "$*" == *"/events"* ]]; then
+  touch "$TD_MKFIFO_GATE.entered"
+  while [[ ! -f "$TD_MKFIFO_GATE.release" ]]; do sleep 0.05; done
+fi
+exec "$TD_REAL_MKFIFO" "$@"
+EOF
+chmod +x "$regate/bin/mkfifo"
+touch "$TD_MKFIFO_GATE.enabled"
+rg_runtime="" rg_artifact=""
+if IFS=$'\t' read -r rg_runtime rg_artifact < <(launch_return_path "$regate" KEN-1060-recheck); then
+  ok "the held supervisor's launch claims its failure"
+else
+  bad "the held launch did not fail; the recheck assertions below prove nothing"
+fi
+wait_exists "$TD_MKFIFO_GATE.entered" || bad "the supervisor never reached its event fifo"
+touch "$TD_MKFIFO_GATE.release"
+if [[ -n "$rg_runtime" ]]; then
+  wait_exists "$rg_runtime/terminal" && ok "the refused recheck still runs its teardown" \
+    || bad "the refused recheck left no terminal file"
+  eq "$(jq -r '.verdict // "missing"' "$rg_artifact" 2>/dev/null || echo missing)" unknown "the refused recheck publishes the unknown fallback"
+  eq "$(jq -r '.cause // "missing"' "$rg_artifact" 2>/dev/null || echo missing)" supervisor_exit "the recheck fallback names the supervisor exit"
+  for ((i=0;i<100;i++)); do [[ "$(count_supervisors "$regate")" -eq 0 ]] && break; sleep 0.05; done
+  eq "$(count_supervisors "$regate")" 0 "no supervisor outlives the refused recheck"
+fi
+rm -f -- "$TD_MKFIFO_GATE.enabled" "$TD_MKFIFO_GATE.entered" "$TD_MKFIFO_GATE.release"
 
 echo "=== a wait whose repository is deleted refuses to keep polling ==="
 QW="$TMP/qw"

--- a/.agents/skills/orch/tests/merge_queue_teardown.sh
+++ b/.agents/skills/orch/tests/merge_queue_teardown.sh
@@ -309,9 +309,9 @@ case "$census_err" in *"could not enumerate processes"*) ok "the failed census n
 
 # What the refusal is FOR, read where it lands: a consumer finds nothing to
 # route. Asserted through consume rather than through the artifact file,
-# because the refusal skips the publishing teardown by design — its home is
-# gone, so there is nothing to publish into. What can go wrong is the refusal
-# publishing on its way out, and consume is where that shows.
+# because the teardown publishes no fallback once the home is gone: there is
+# nothing to publish into. What can go wrong is the refusal publishing on its
+# way out, and consume is where that shows.
 consume_after_refusal() {
   local sb="$1" issue="$2"
   (
@@ -332,8 +332,8 @@ build_sandbox "$publishing"
 mkdir -p "$publishing/main/altroot"
 edit_once "$ORCH/scripts/lib/merge-queue-supervisor.sh" \
   "$publishing/orch/scripts/lib/merge-queue-supervisor.sh" \
-  'report_home_lost; trap - EXIT TERM HUP INT; return 1' \
-  'publish_unknown home_lost 1; report_home_lost; trap - EXIT TERM HUP INT; return 1' \
+  'then report_home_lost; return 1; fi' \
+  'then publish_unknown home_lost 1; report_home_lost; return 1; fi' \
   || { bad "publishing-refusal mutation did not apply"; exit 1; }
 IFS=$'\t' read -r ppid _prt _part _plog _pstate pmain < <(launch_supervisor "$publishing" KEN-995-publishing "$publishing/main/altroot")
 break_repository "" "" "$pmain" "$publishing"
@@ -344,19 +344,39 @@ if [[ "$(jq -r '.diagnostic.cause' <<<"$publishing_consume")" != watch_lost ]]; 
 else bad "the publishing mutant still consumed as watch_lost"; fi
 mq_reap "$publishing" || bad "reaper reported survivors under the publishing sandbox"
 
-echo "=== a supervisor that returns still runs its teardown ==="
+echo "=== every supervisor exit runs its teardown ==="
 
-# An EXIT trap fires when the shell exits, after `return` has popped the
-# supervisor's locals — so a path that ends in `return` must run cleanup
-# itself while they are live (KEN-1060). The worker-liveness check is forced
-# false with a real worker running, so the supervisor takes its `return 1`
-# path holding everything teardown exists to retire: a live worker, an open
-# runtime, and the promise of a consumable artifact.
+# The teardown is an EXIT trap reading state the function once declared
+# local. An EXIT trap fires when the shell exits, after `return` and a set -e
+# failure have both popped the function's frame, so the trap ran empty on
+# every such exit: no worker reaped, no unknown fallback, no terminal file
+# (KEN-1060). The state is process-scoped now. Each case below forces one
+# exit kind while the supervisor holds everything teardown exists to retire
+# (a live worker, an open runtime, the promise of a consumable artifact) and
+# asserts the teardown ran; its control re-plants `local` on the worker's
+# pid, which is the original defect, and asserts the same teardown did not.
+
+# The worker alone: the process whose executed script is the sandbox's
+# queue-wait. The supervisor's own argv carries that path too (the waiter is
+# its seventh argument), and so does the worker subshell forked from it, so a
+# substring census would count them both as workers.
 workers_under() {
   ps -e -ww -o pid=,args= > "$TMP/ps.worker.snapshot" 2>/dev/null || true
-  awk -v root="$1" 'index($0, "queue-wait") && index($0, root) { print $1 }' "$TMP/ps.worker.snapshot"
+  awk -v script="$1/orch/scripts/queue-wait" '$3 == script { print $1 }' "$TMP/ps.worker.snapshot"
 }
 count_workers() { workers_under "$1" | grep -c . || true; }
+
+# $1 sandbox, then needle/replacement pairs applied in order to the sandbox's
+# supervisor copy; each must apply exactly once.
+plant() {
+  local sb="$1" src="$ORCH/scripts/lib/merge-queue-supervisor.sh" dst
+  dst="$sb/orch/scripts/lib/merge-queue-supervisor.sh"; shift
+  build_sandbox "$sb"
+  while (($# >= 2)); do
+    edit_once "$src" "$dst.next" "$1" "$2" || return 1
+    mv -- "$dst.next" "$dst"; src="$dst"; shift 2
+  done
+}
 
 # $1 sandbox, $2 issue: launch under the sandbox's supervisor copy. The caller
 # arranges for the supervisor to exit or be held before the worker-liveness
@@ -381,60 +401,64 @@ launch_return_path() {
     | jq -r '[.runtime_dir, .artifact_path] | @tsv'
 }
 
-retpath="$TMP/return-path"
-build_sandbox "$retpath"
-edit_once "$ORCH/scripts/lib/merge-queue-supervisor.sh" \
-  "$retpath/orch/scripts/lib/merge-queue-supervisor.sh" \
-  'kill -0 "$worker_pid" 2>/dev/null || { cleanup 1; return 1; }' \
-  'false || { cleanup 1; return 1; }' \
+# $1 sandbox, $2 runtime, $3 artifact, $4 label.
+assert_teardown_ran() {
+  local i
+  wait_exists "$2/terminal" && ok "$4: the terminal file is written" || bad "$4: no terminal file"
+  eq "$(jq -r '.verdict // "missing"' "$3" 2>/dev/null || echo missing)" unknown "$4: the unknown fallback is published"
+  eq "$(jq -r '.cause // "missing"' "$3" 2>/dev/null || echo missing)" supervisor_exit "$4: the fallback names the supervisor exit"
+  for ((i=0;i<100;i++)); do [[ "$(count_workers "$1")" -eq 0 && "$(count_supervisors "$1")" -eq 0 ]] && break; sleep 0.05; done
+  eq "$(count_workers "$1")" 0 "$4: the worker is reaped"
+  eq "$(count_supervisors "$1")" 0 "$4: no supervisor outlives the exit"
+}
+# The same four facts, negated: this is the silent no-op the assertions
+# above must catch, so a control that fails any of them frees an assertion.
+assert_teardown_skipped() {
+  [[ ! -e "$2/terminal" ]] && ok "$4: the empty trap writes no terminal" || bad "$4: the control wrote a terminal; that assertion is free"
+  [[ ! -e "$3" ]] && ok "$4: the empty trap publishes no fallback" || bad "$4: the control published a fallback; that assertion is free"
+  [[ "$(count_workers "$1")" -gt 0 ]] && ok "$4: the empty trap leaks the worker" || bad "$4: the control leaked no worker; that assertion is free"
+  mq_reap "$1" || bad "$4: reaper reported survivors under the control sandbox"
+}
+# $1 sandbox, $2 issue, $3 label, $4 ran|skipped: launch, then assert.
+teardown_case() {
+  local sb="$1" issue="$2" label="$3" expect="$4" runtime="" artifact=""
+  if IFS=$'\t' read -r runtime artifact < <(launch_return_path "$sb" "$issue"); then
+    ok "$label: the launch fails"
+  else
+    bad "$label: the launch did not fail; the assertions below prove nothing"; return 0
+  fi
+  case "$expect" in
+    ran) assert_teardown_ran "$sb" "$runtime" "$artifact" "$label" ;;
+    skipped) assert_teardown_skipped "$sb" "$runtime" "$artifact" "$label" ;;
+  esac
+}
+
+RETURN_SITE='kill -0 "$worker_pid" 2>/dev/null || return 1'
+SET_E_SITE=': > "$runtime/ready"; chmod 600 "$runtime/ready"'
+LOCAL_PID='  worker_pid="" worker_rc=0 event="" watchdog_pid=""'
+
+# A `return` after the worker is forked: the liveness check forced false.
+plant "$TMP/return-path" "$RETURN_SITE" 'false || return 1' \
   || { bad "return-path mutation did not apply"; exit 1; }
-rp_runtime="" rp_artifact=""
-if IFS=$'\t' read -r rp_runtime rp_artifact < <(launch_return_path "$retpath" KEN-1060-return); then
-  ok "the worker-liveness return path fails the launch"
-else
-  bad "the forced return path did not fail the launch; the assertions below prove nothing"
-fi
-if [[ -n "$rp_runtime" ]]; then
-  wait_exists "$rp_runtime/terminal" && ok "the return path writes the runtime terminal file" \
-    || bad "the return path left no terminal file"
-  eq "$(jq -r '.verdict // "missing"' "$rp_artifact" 2>/dev/null || echo missing)" unknown "the return path publishes the unknown fallback"
-  eq "$(jq -r '.cause // "missing"' "$rp_artifact" 2>/dev/null || echo missing)" supervisor_exit "the fallback names the supervisor exit"
-  for ((i=0;i<100;i++)); do [[ "$(count_workers "$retpath")" -eq 0 && "$(count_supervisors "$retpath")" -eq 0 ]] && break; sleep 0.05; done
-  eq "$(count_workers "$retpath")" 0 "the return path reaps its live worker"
-  eq "$(count_supervisors "$retpath")" 0 "no supervisor outlives the return path"
-fi
-
-# Control: the same forced path with the explicit call cut leaves only the
-# EXIT trap, which fires after the locals are gone — no terminal, no fallback,
-# a leaked worker. This is the silent no-op the assertions above must catch.
-noclean="$TMP/return-path-noclean"
-build_sandbox "$noclean"
-edit_once "$ORCH/scripts/lib/merge-queue-supervisor.sh" \
-  "$noclean/orch/scripts/lib/merge-queue-supervisor.sh" \
-  'kill -0 "$worker_pid" 2>/dev/null || { cleanup 1; return 1; }' \
-  'false || return 1' \
+teardown_case "$TMP/return-path" KEN-1060-return "return" ran
+plant "$TMP/return-path-local" "$RETURN_SITE" 'false || return 1' "$LOCAL_PID" "  local$LOCAL_PID" \
   || { bad "return-path control mutation did not apply"; exit 1; }
-nc_runtime="" nc_artifact=""
-if IFS=$'\t' read -r nc_runtime nc_artifact < <(launch_return_path "$noclean" KEN-1060-noclean); then
-  ok "the control's forced return path fails the launch"
-else
-  bad "the control launch did not fail; the control proves nothing"
-fi
-if [[ -n "$nc_runtime" ]]; then
-  [[ ! -e "$nc_runtime/terminal" ]] && ok "without the explicit call the empty trap writes no terminal" \
-    || bad "the control wrote a terminal; the terminal assertion above is free"
-  [[ ! -e "$nc_artifact" ]] && ok "without the explicit call no fallback is published" \
-    || bad "the control published a fallback; the fallback assertion above is free"
-  [[ "$(count_workers "$noclean")" -gt 0 ]] && ok "without the explicit call the worker leaks" \
-    || bad "the control leaked no worker; the reap assertion above is free"
-fi
-mq_reap "$noclean" || bad "reaper reported survivors under the control sandbox"
+teardown_case "$TMP/return-path-local" KEN-1060-return-local "return control" skipped
 
-# The other guarded return: the post-registration currency recheck, driven
-# with no mutation. The supervisor is held at its event fifo, so the launch
-# command times out waiting for worker liveness and claims launch_failed;
-# released, the supervisor's recheck refuses and returns 1. That launch_failed
-# state still admits the unknown fallback — the reason publish accepts it.
+# A set -e exit after the worker is forked: the ready marker's write fails.
+plant "$TMP/set-e" "$SET_E_SITE" ': > "$runtime/missing/ready"; chmod 600 "$runtime/ready"' \
+  || { bad "set -e mutation did not apply"; exit 1; }
+teardown_case "$TMP/set-e" KEN-1060-set-e "set -e" ran
+plant "$TMP/set-e-local" "$SET_E_SITE" ': > "$runtime/missing/ready"; chmod 600 "$runtime/ready"' "$LOCAL_PID" "  local$LOCAL_PID" \
+  || { bad "set -e control mutation did not apply"; exit 1; }
+teardown_case "$TMP/set-e-local" KEN-1060-set-e-local "set -e control" skipped
+
+# The `return` before the worker is forked, driven with no mutation: the
+# post-registration currency recheck. The supervisor is held at its event
+# fifo, so the launch command times out waiting for worker liveness and
+# claims launch_failed; released, the supervisor's recheck refuses and
+# returns 1. That launch_failed state still admits the unknown fallback,
+# which is the reason publish accepts it.
 regate="$TMP/recheck"
 build_sandbox "$regate"
 TD_REAL_MKFIFO="$(command -v mkfifo)"
@@ -452,20 +476,13 @@ chmod +x "$regate/bin/mkfifo"
 touch "$TD_MKFIFO_GATE.enabled"
 rg_runtime="" rg_artifact=""
 if IFS=$'\t' read -r rg_runtime rg_artifact < <(launch_return_path "$regate" KEN-1060-recheck); then
-  ok "the held supervisor's launch claims its failure"
+  ok "recheck: the held supervisor's launch claims its failure"
 else
-  bad "the held launch did not fail; the recheck assertions below prove nothing"
+  bad "recheck: the held launch did not fail; the assertions below prove nothing"
 fi
-wait_exists "$TD_MKFIFO_GATE.entered" || bad "the supervisor never reached its event fifo"
+wait_exists "$TD_MKFIFO_GATE.entered" || bad "recheck: the supervisor never reached its event fifo"
 touch "$TD_MKFIFO_GATE.release"
-if [[ -n "$rg_runtime" ]]; then
-  wait_exists "$rg_runtime/terminal" && ok "the refused recheck still runs its teardown" \
-    || bad "the refused recheck left no terminal file"
-  eq "$(jq -r '.verdict // "missing"' "$rg_artifact" 2>/dev/null || echo missing)" unknown "the refused recheck publishes the unknown fallback"
-  eq "$(jq -r '.cause // "missing"' "$rg_artifact" 2>/dev/null || echo missing)" supervisor_exit "the recheck fallback names the supervisor exit"
-  for ((i=0;i<100;i++)); do [[ "$(count_supervisors "$regate")" -eq 0 ]] && break; sleep 0.05; done
-  eq "$(count_supervisors "$regate")" 0 "no supervisor outlives the refused recheck"
-fi
+[[ -z "$rg_runtime" ]] || assert_teardown_ran "$regate" "$rg_runtime" "$rg_artifact" "recheck"
 rm -f -- "$TD_MKFIFO_GATE.enabled" "$TD_MKFIFO_GATE.entered" "$TD_MKFIFO_GATE.release"
 
 echo "=== a wait whose repository is deleted refuses to keep polling ==="

--- a/.agents/skills/orch/tests/merge_queue_teardown.sh
+++ b/.agents/skills/orch/tests/merge_queue_teardown.sh
@@ -252,6 +252,11 @@ home_clause_case() {
 
 home_clause_case runtime-deleted break_runtime
 home_clause_case runtime-swapped-for-a-symlink break_symlink
+# The teardown's own marker follows the same rule as its fallback: a runtime
+# swapped for a symlink gets no terminal file at the symlink's target.
+[[ ! -e "$TMP/home-runtime-swapped-for-a-symlink/main/terminal" ]] \
+  && ok "runtime-swapped-for-a-symlink: no terminal marker lands at the symlink target" \
+  || bad "runtime-swapped-for-a-symlink: the teardown wrote through the symlink"
 home_clause_case state-file-deleted break_state
 home_clause_case repository-deleted break_repository altroot
 
@@ -290,6 +295,11 @@ edit_once() {
 
 home_clause_control without-runtime-clause '-d "$runtime" && ' break_runtime
 home_clause_control without-symlink-clause '! -L "$runtime" && ' break_symlink
+# The reaper's TERM runs that mutant's teardown, which no longer sees the
+# symlink and so writes its marker through it: the assertion above is not free.
+[[ -e "$TMP/mutant-without-symlink-clause/main/terminal" ]] \
+  && ok "without-symlink-clause: cutting the clause writes the marker through the symlink" \
+  || bad "without-symlink-clause: no marker at the symlink target; the symlink-target assertion above is free"
 home_clause_control without-state-clause '-f "$state_file" && ' break_state
 home_clause_control without-repository-clause ' && -d "$main_root"' break_repository altroot
 

--- a/.agents/skills/orch/tests/merge_queue_watch.sh
+++ b/.agents/skills/orch/tests/merge_queue_watch.sh
@@ -493,18 +493,18 @@ export WATCH_RELEASE="$old_release"
 prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
 launch_bounded "$watch"
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
-stale_supervisor_pid=$(jq -r .supervisor_pid "$state_path")
+stale_runtime=$(jq -r .runtime_dir "$state_path")
 jq '.status="launch_failed"|.action="launch"|.supervisor_pid=null' "$state_path" > "$TMP/publication-state.json"
 chmod 600 "$TMP/publication-state.json"; mv "$TMP/publication-state.json" "$state_path"
 export WATCH_RELEASE="$new_release"
 launch_bounded "$watch"
 publication_replacement=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .artifact_path)
 touch "$new_release"; wait_file "$publication_replacement" || bad "publication-fence replacement verdict missing"
-# The stale supervisor sits on its worker until this release, then makes the one
-# publication attempt this fence has to refuse and exits, so waiting for that
-# process is waiting for exactly that attempt to be over.
+# The stale supervisor sits on its worker until this release, then makes the
+# publication attempts this fence has to refuse; its teardown writes the
+# runtime terminal file after the last of them, so that file ends the attempt.
 touch "$old_release"
-wait_gone "$stale_supervisor_pid" || bad "stale started supervisor never finished its publication attempt"
+wait_file "$stale_runtime/terminal" || bad "stale started supervisor never finished its publication attempt"
 [[ ! -e "$artifact" ]] && ok "stale started supervisor cannot publish after replacement" || bad "publication fence admitted the stale started supervisor"
 eq "$(jq -r .verdict "$publication_replacement")" ejected "stale publication leaves the replacement verdict intact"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)

--- a/skills/orch/scripts/lib/merge-queue-supervisor.sh
+++ b/skills/orch/scripts/lib/merge-queue-supervisor.sh
@@ -73,13 +73,22 @@ merge_queue_supervise() {
         worker_exit_code:$rc,diagnostic_path:$log}' > "$output" || return 1
     publish_output && published=true
   }
+  # An EXIT trap fires when the SHELL exits, after `return` has already popped
+  # this function's locals, so a path that ends in `return` must call cleanup
+  # itself while they are still live. The trap covers only the exits that
+  # happen mid-function — signals and set -e — and cleanup clears it first so
+  # a teardown that already ran cannot run again empty at shell exit. The
+  # terminal file it writes last is the durable sign that teardown, including
+  # the publication fallback, is over.
   cleanup() {
-    local rc=$?
+    local rc="${1-$?}"
+    trap - EXIT TERM HUP INT
     exec 6>&- 7>&- 8>&- 9>&- 2>/dev/null || true
     [[ -z "$watchdog_pid" ]] || { kill "$watchdog_pid" 2>/dev/null || true; wait "$watchdog_pid" 2>/dev/null || true; }
-    stop_worker
+    watchdog_pid=""
+    stop_worker; worker_pid=""
     $published || publish_unknown supervisor_exit "$rc" || true
-    printf '%s\n' "$rc" > "$runtime/terminal" 2>/dev/null || true
+    { printf '%s\n' "$rc" > "$runtime/terminal" && chmod 600 "$runtime/terminal"; } 2>/dev/null || true
   }
   trap cleanup EXIT
   trap 'exit 143' TERM HUP
@@ -105,7 +114,7 @@ merge_queue_supervise() {
     [[ $(date +%s) -lt "$deadline" ]] || printf 'deadline\n' >&7
   ) & watchdog_pid=$!
   printf '%s\n' "$$" > "$runtime/supervisor.pid"; chmod 600 "$runtime/supervisor.pid"
-  attempt_is_current || return 1
+  attempt_is_current || { cleanup 1; return 1; }
   set -m
   (
     exec 7>"$event_fifo"
@@ -116,7 +125,7 @@ merge_queue_supervise() {
     rc=$?; printf '%s\n' "$rc" > "$runtime/worker.status"; printf 'worker\n' >&7; exit "$rc"
   ) & worker_pid=$!
   set +m
-  kill -0 "$worker_pid" 2>/dev/null || return 1
+  kill -0 "$worker_pid" 2>/dev/null || { cleanup 1; return 1; }
   : > "$runtime/ready"; chmod 600 "$runtime/ready"
   IFS= read -r event < "$event_fifo" || true
   exec 6>&- 7>&-
@@ -126,16 +135,16 @@ merge_queue_supervise() {
   if [[ "$event" == home_lost ]] || ! home_present; then
     stop_worker; worker_pid=""; report_home_lost; trap - EXIT TERM HUP INT; return 1
   fi
-  if [[ "$event" == deadline && ! -f "$runtime/worker.status" ]]; then stop_worker; worker_pid=""; publish_unknown supervisor_deadline 124; trap - EXIT TERM HUP INT; return 0; fi
+  if [[ "$event" == deadline && ! -f "$runtime/worker.status" ]]; then stop_worker; worker_pid=""; publish_unknown supervisor_deadline 124; cleanup 0; return 0; fi
   wait "$worker_pid" || worker_rc=$?; worker_pid=""
   if ! jq -e 'type=="object" and (.status|IN("complete","timeout","error")) and
       (.verdict|IN("merged","conflicting","ejected","disarmed","dequeued","closed","queued","not_queued","unknown"))' "$temp" >/dev/null 2>&1; then
-    publish_unknown worker_output_invalid "$worker_rc"; trap - EXIT TERM HUP INT; return 0
+    publish_unknown worker_output_invalid "$worker_rc"; cleanup 0; return 0
   fi
   jq --arg repo "$repo" --argjson pr "$pr" --arg head "$head" --arg watch "$watch_id" --arg attempt "$attempt_id" --arg log "$log" \
     '. + {schema_version:1,repository:$repo,pr_number:$pr,expected_head:$head,
       watch_id:$watch,launch_attempt_id:$attempt,diagnostic_path:$log}' "$temp" > "$output"
-  publish_output || return 1
-  published=true; printf '%s\n' "$worker_rc" > "$runtime/terminal"; chmod 600 "$runtime/terminal"
-  trap - EXIT TERM HUP INT
+  publish_output || { cleanup 1; return 1; }
+  published=true
+  cleanup "$worker_rc"
 }

--- a/skills/orch/scripts/lib/merge-queue-supervisor.sh
+++ b/skills/orch/scripts/lib/merge-queue-supervisor.sh
@@ -77,15 +77,18 @@ merge_queue_supervise() {
     publish_output && published=true
   }
   # The one teardown, on every exit (return, set -e, exit, signal), with the
-  # exit status as $?. A home that is gone gets no fallback: there is nothing
-  # left to publish into. The terminal file written last is the durable sign
-  # that teardown, including the publication fallback, is over.
+  # exit status as $?. A home that is gone gets neither the fallback nor the
+  # terminal marker: there is nothing left to publish into, and a runtime
+  # swapped for a symlink would carry the marker to wherever it points. The
+  # terminal file written last is the durable sign that teardown, including
+  # the publication fallback, is over.
   cleanup() {
     local rc=$?
     exec 6>&- 7>&- 8>&- 9>&- 2>/dev/null || true
     [[ -z "$watchdog_pid" ]] || { kill "$watchdog_pid" 2>/dev/null || true; wait "$watchdog_pid" 2>/dev/null || true; }
     stop_worker
-    if ! $published && home_present; then publish_unknown supervisor_exit "$rc" || true; fi
+    home_present || return 0
+    $published || publish_unknown supervisor_exit "$rc" || true
     { printf '%s\n' "$rc" > "$runtime/terminal" && chmod 600 "$runtime/terminal"; } 2>/dev/null || true
   }
   trap cleanup EXIT

--- a/skills/orch/scripts/lib/merge-queue-supervisor.sh
+++ b/skills/orch/scripts/lib/merge-queue-supervisor.sh
@@ -14,10 +14,13 @@
 # and consume terminalizes it as watch_lost.
 
 merge_queue_supervise() {
-  local state_file="$1" watch_id="$2" attempt_id="$3" runtime="$4" artifact="$5" deadline="$6"
-  local waiter="$7" poll="$8" max_wait="$9"
-  local repo pr head main_root log temp output worker_pid="" worker_rc=0 event=""
-  local event_fifo owner_fifo watchdog_pid="" published=false process_token="${MERGE_QUEUE_SUPERVISOR_TOKEN:-}"
+  # Process-scoped on purpose, never local: the __supervise process exists
+  # only to run this function, and the EXIT trap that tears it down fires
+  # when the shell exits, after `return` and a set -e failure have both
+  # popped the function's frame. A trap reading locals runs empty on either.
+  state_file="$1" watch_id="$2" attempt_id="$3" runtime="$4" artifact="$5" deadline="$6"
+  waiter="$7" poll="$8" max_wait="$9"
+  worker_pid="" worker_rc=0 event="" watchdog_pid="" published=false process_token="${MERGE_QUEUE_SUPERVISOR_TOKEN:-}"
   repo=$(jq -r .repository "$state_file"); pr=$(jq -r .pr_number "$state_file")
   head=$(jq -r .head_sha "$state_file")
   main_root=$(jq -r .main_repo_root "$state_file")
@@ -73,21 +76,16 @@ merge_queue_supervise() {
         worker_exit_code:$rc,diagnostic_path:$log}' > "$output" || return 1
     publish_output && published=true
   }
-  # An EXIT trap fires when the SHELL exits, after `return` has already popped
-  # this function's locals, so a path that ends in `return` must call cleanup
-  # itself while they are still live. The trap covers only the exits that
-  # happen mid-function — signals and set -e — and cleanup clears it first so
-  # a teardown that already ran cannot run again empty at shell exit. The
-  # terminal file it writes last is the durable sign that teardown, including
-  # the publication fallback, is over.
+  # The one teardown, on every exit (return, set -e, exit, signal), with the
+  # exit status as $?. A home that is gone gets no fallback: there is nothing
+  # left to publish into. The terminal file written last is the durable sign
+  # that teardown, including the publication fallback, is over.
   cleanup() {
-    local rc="${1-$?}"
-    trap - EXIT TERM HUP INT
+    local rc=$?
     exec 6>&- 7>&- 8>&- 9>&- 2>/dev/null || true
     [[ -z "$watchdog_pid" ]] || { kill "$watchdog_pid" 2>/dev/null || true; wait "$watchdog_pid" 2>/dev/null || true; }
-    watchdog_pid=""
-    stop_worker; worker_pid=""
-    $published || publish_unknown supervisor_exit "$rc" || true
+    stop_worker
+    if ! $published && home_present; then publish_unknown supervisor_exit "$rc" || true; fi
     { printf '%s\n' "$rc" > "$runtime/terminal" && chmod 600 "$runtime/terminal"; } 2>/dev/null || true
   }
   trap cleanup EXIT
@@ -114,7 +112,7 @@ merge_queue_supervise() {
     [[ $(date +%s) -lt "$deadline" ]] || printf 'deadline\n' >&7
   ) & watchdog_pid=$!
   printf '%s\n' "$$" > "$runtime/supervisor.pid"; chmod 600 "$runtime/supervisor.pid"
-  attempt_is_current || { cleanup 1; return 1; }
+  attempt_is_current || return 1
   set -m
   (
     exec 7>"$event_fifo"
@@ -125,26 +123,23 @@ merge_queue_supervise() {
     rc=$?; printf '%s\n' "$rc" > "$runtime/worker.status"; printf 'worker\n' >&7; exit "$rc"
   ) & worker_pid=$!
   set +m
-  kill -0 "$worker_pid" 2>/dev/null || { cleanup 1; return 1; }
+  kill -0 "$worker_pid" 2>/dev/null || return 1
   : > "$runtime/ready"; chmod 600 "$runtime/ready"
   IFS= read -r event < "$event_fifo" || true
   exec 6>&- 7>&-
   wait "$watchdog_pid" 2>/dev/null || true; watchdog_pid=""
-  # Named refusal, and nothing published: once the home is gone there is
-  # nothing left to publish into.
-  if [[ "$event" == home_lost ]] || ! home_present; then
-    stop_worker; worker_pid=""; report_home_lost; trap - EXIT TERM HUP INT; return 1
-  fi
-  if [[ "$event" == deadline && ! -f "$runtime/worker.status" ]]; then stop_worker; worker_pid=""; publish_unknown supervisor_deadline 124; cleanup 0; return 0; fi
+  # Named refusal; the teardown reaps the worker and, with the home gone,
+  # publishes nothing.
+  if [[ "$event" == home_lost ]] || ! home_present; then report_home_lost; return 1; fi
+  if [[ "$event" == deadline && ! -f "$runtime/worker.status" ]]; then stop_worker; worker_pid=""; publish_unknown supervisor_deadline 124; return 0; fi
   wait "$worker_pid" || worker_rc=$?; worker_pid=""
   if ! jq -e 'type=="object" and (.status|IN("complete","timeout","error")) and
       (.verdict|IN("merged","conflicting","ejected","disarmed","dequeued","closed","queued","not_queued","unknown"))' "$temp" >/dev/null 2>&1; then
-    publish_unknown worker_output_invalid "$worker_rc"; cleanup 0; return 0
+    publish_unknown worker_output_invalid "$worker_rc"; return 0
   fi
   jq --arg repo "$repo" --argjson pr "$pr" --arg head "$head" --arg watch "$watch_id" --arg attempt "$attempt_id" --arg log "$log" \
     '. + {schema_version:1,repository:$repo,pr_number:$pr,expected_head:$head,
       watch_id:$watch,launch_attempt_id:$attempt,diagnostic_path:$log}' "$temp" > "$output"
-  publish_output || { cleanup 1; return 1; }
+  publish_output || return 1
   published=true
-  cleanup "$worker_rc"
 }

--- a/skills/orch/tests/merge_queue_teardown.sh
+++ b/skills/orch/tests/merge_queue_teardown.sh
@@ -309,10 +309,9 @@ case "$census_err" in *"could not enumerate processes"*) ok "the failed census n
 
 # What the refusal is FOR, read where it lands: a consumer finds nothing to
 # route. Asserted through consume rather than through the artifact file,
-# because the file's absence is not something this code could get wrong — a
-# refusal that returns leaves the cleanup trap without any of its locals, so
-# no artifact appears whether or not the trap was cleared. What can go wrong
-# is the refusal publishing on its way out, and consume is where that shows.
+# because the refusal skips the publishing teardown by design — its home is
+# gone, so there is nothing to publish into. What can go wrong is the refusal
+# publishing on its way out, and consume is where that shows.
 consume_after_refusal() {
   local sb="$1" issue="$2"
   (
@@ -344,6 +343,130 @@ if [[ "$(jq -r '.diagnostic.cause' <<<"$publishing_consume")" != watch_lost ]]; 
   ok "a refusal that publishes routes the consumer somewhere else"
 else bad "the publishing mutant still consumed as watch_lost"; fi
 mq_reap "$publishing" || bad "reaper reported survivors under the publishing sandbox"
+
+echo "=== a supervisor that returns still runs its teardown ==="
+
+# An EXIT trap fires when the shell exits, after `return` has popped the
+# supervisor's locals — so a path that ends in `return` must run cleanup
+# itself while they are live (KEN-1060). The worker-liveness check is forced
+# false with a real worker running, so the supervisor takes its `return 1`
+# path holding everything teardown exists to retire: a live worker, an open
+# runtime, and the promise of a consumable artifact.
+workers_under() {
+  ps -e -ww -o pid=,args= > "$TMP/ps.worker.snapshot" 2>/dev/null || true
+  awk -v root="$1" 'index($0, "queue-wait") && index($0, root) { print $1 }' "$TMP/ps.worker.snapshot"
+}
+count_workers() { workers_under "$1" | grep -c . || true; }
+
+# $1 sandbox, $2 issue: launch under the sandbox's supervisor copy. The caller
+# arranges for the supervisor to exit or be held before the worker-liveness
+# marker, so the launch command itself must fail; on that failure, print
+# "runtime<TAB>artifact" for the attempt.
+launch_return_path() {
+  local sb="$1" issue="$2" scripts main rc=0
+  scripts="$sb/orch/scripts"; main="$sb/main"
+  (
+    export PATH="$sb/bin:$SEALED:$PATH"
+    unset GH_TOKEN GITHUB_TOKEN GH_BOT_TOKEN GH_REPO GITHUB_REPOSITORY
+    "$scripts/merge-queue-watch" init --worktree "$main" --issue "$issue" \
+      --branch "$(git -C "$main" branch --show-current)" >/dev/null
+    prep=$("$scripts/merge-queue-watch" prepare --worktree "$main" --issue "$issue" \
+      --repo owner/repo --pr 42 --head "$HEAD" --root "$main" --gate-mode off \
+      --recovery-count 0 --cleanup-worktree false)
+    "$scripts/merge-queue-watch" launch --root "$main" --issue "$issue" \
+      --watch-id "$(jq -r .watch_id <<<"$prep")" --poll 1 --max-wait 600 >/dev/null 2>&1
+  ) || rc=$?
+  [[ "$rc" -ne 0 ]] || return 1
+  "$scripts/merge-queue-watch" inspect --root "$main" --issue "$issue" \
+    | jq -r '[.runtime_dir, .artifact_path] | @tsv'
+}
+
+retpath="$TMP/return-path"
+build_sandbox "$retpath"
+edit_once "$ORCH/scripts/lib/merge-queue-supervisor.sh" \
+  "$retpath/orch/scripts/lib/merge-queue-supervisor.sh" \
+  'kill -0 "$worker_pid" 2>/dev/null || { cleanup 1; return 1; }' \
+  'false || { cleanup 1; return 1; }' \
+  || { bad "return-path mutation did not apply"; exit 1; }
+rp_runtime="" rp_artifact=""
+if IFS=$'\t' read -r rp_runtime rp_artifact < <(launch_return_path "$retpath" KEN-1060-return); then
+  ok "the worker-liveness return path fails the launch"
+else
+  bad "the forced return path did not fail the launch; the assertions below prove nothing"
+fi
+if [[ -n "$rp_runtime" ]]; then
+  wait_exists "$rp_runtime/terminal" && ok "the return path writes the runtime terminal file" \
+    || bad "the return path left no terminal file"
+  eq "$(jq -r '.verdict // "missing"' "$rp_artifact" 2>/dev/null || echo missing)" unknown "the return path publishes the unknown fallback"
+  eq "$(jq -r '.cause // "missing"' "$rp_artifact" 2>/dev/null || echo missing)" supervisor_exit "the fallback names the supervisor exit"
+  for ((i=0;i<100;i++)); do [[ "$(count_workers "$retpath")" -eq 0 && "$(count_supervisors "$retpath")" -eq 0 ]] && break; sleep 0.05; done
+  eq "$(count_workers "$retpath")" 0 "the return path reaps its live worker"
+  eq "$(count_supervisors "$retpath")" 0 "no supervisor outlives the return path"
+fi
+
+# Control: the same forced path with the explicit call cut leaves only the
+# EXIT trap, which fires after the locals are gone — no terminal, no fallback,
+# a leaked worker. This is the silent no-op the assertions above must catch.
+noclean="$TMP/return-path-noclean"
+build_sandbox "$noclean"
+edit_once "$ORCH/scripts/lib/merge-queue-supervisor.sh" \
+  "$noclean/orch/scripts/lib/merge-queue-supervisor.sh" \
+  'kill -0 "$worker_pid" 2>/dev/null || { cleanup 1; return 1; }' \
+  'false || return 1' \
+  || { bad "return-path control mutation did not apply"; exit 1; }
+nc_runtime="" nc_artifact=""
+if IFS=$'\t' read -r nc_runtime nc_artifact < <(launch_return_path "$noclean" KEN-1060-noclean); then
+  ok "the control's forced return path fails the launch"
+else
+  bad "the control launch did not fail; the control proves nothing"
+fi
+if [[ -n "$nc_runtime" ]]; then
+  [[ ! -e "$nc_runtime/terminal" ]] && ok "without the explicit call the empty trap writes no terminal" \
+    || bad "the control wrote a terminal; the terminal assertion above is free"
+  [[ ! -e "$nc_artifact" ]] && ok "without the explicit call no fallback is published" \
+    || bad "the control published a fallback; the fallback assertion above is free"
+  [[ "$(count_workers "$noclean")" -gt 0 ]] && ok "without the explicit call the worker leaks" \
+    || bad "the control leaked no worker; the reap assertion above is free"
+fi
+mq_reap "$noclean" || bad "reaper reported survivors under the control sandbox"
+
+# The other guarded return: the post-registration currency recheck, driven
+# with no mutation. The supervisor is held at its event fifo, so the launch
+# command times out waiting for worker liveness and claims launch_failed;
+# released, the supervisor's recheck refuses and returns 1. That launch_failed
+# state still admits the unknown fallback — the reason publish accepts it.
+regate="$TMP/recheck"
+build_sandbox "$regate"
+TD_REAL_MKFIFO="$(command -v mkfifo)"
+export TD_MKFIFO_GATE="$TMP/recheck-mkfifo-gate" TD_REAL_MKFIFO
+cat > "$regate/bin/mkfifo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ -f "$TD_MKFIFO_GATE.enabled" && "$*" == *"/events"* ]]; then
+  touch "$TD_MKFIFO_GATE.entered"
+  while [[ ! -f "$TD_MKFIFO_GATE.release" ]]; do sleep 0.05; done
+fi
+exec "$TD_REAL_MKFIFO" "$@"
+EOF
+chmod +x "$regate/bin/mkfifo"
+touch "$TD_MKFIFO_GATE.enabled"
+rg_runtime="" rg_artifact=""
+if IFS=$'\t' read -r rg_runtime rg_artifact < <(launch_return_path "$regate" KEN-1060-recheck); then
+  ok "the held supervisor's launch claims its failure"
+else
+  bad "the held launch did not fail; the recheck assertions below prove nothing"
+fi
+wait_exists "$TD_MKFIFO_GATE.entered" || bad "the supervisor never reached its event fifo"
+touch "$TD_MKFIFO_GATE.release"
+if [[ -n "$rg_runtime" ]]; then
+  wait_exists "$rg_runtime/terminal" && ok "the refused recheck still runs its teardown" \
+    || bad "the refused recheck left no terminal file"
+  eq "$(jq -r '.verdict // "missing"' "$rg_artifact" 2>/dev/null || echo missing)" unknown "the refused recheck publishes the unknown fallback"
+  eq "$(jq -r '.cause // "missing"' "$rg_artifact" 2>/dev/null || echo missing)" supervisor_exit "the recheck fallback names the supervisor exit"
+  for ((i=0;i<100;i++)); do [[ "$(count_supervisors "$regate")" -eq 0 ]] && break; sleep 0.05; done
+  eq "$(count_supervisors "$regate")" 0 "no supervisor outlives the refused recheck"
+fi
+rm -f -- "$TD_MKFIFO_GATE.enabled" "$TD_MKFIFO_GATE.entered" "$TD_MKFIFO_GATE.release"
 
 echo "=== a wait whose repository is deleted refuses to keep polling ==="
 QW="$TMP/qw"

--- a/skills/orch/tests/merge_queue_teardown.sh
+++ b/skills/orch/tests/merge_queue_teardown.sh
@@ -309,9 +309,9 @@ case "$census_err" in *"could not enumerate processes"*) ok "the failed census n
 
 # What the refusal is FOR, read where it lands: a consumer finds nothing to
 # route. Asserted through consume rather than through the artifact file,
-# because the refusal skips the publishing teardown by design — its home is
-# gone, so there is nothing to publish into. What can go wrong is the refusal
-# publishing on its way out, and consume is where that shows.
+# because the teardown publishes no fallback once the home is gone: there is
+# nothing to publish into. What can go wrong is the refusal publishing on its
+# way out, and consume is where that shows.
 consume_after_refusal() {
   local sb="$1" issue="$2"
   (
@@ -332,8 +332,8 @@ build_sandbox "$publishing"
 mkdir -p "$publishing/main/altroot"
 edit_once "$ORCH/scripts/lib/merge-queue-supervisor.sh" \
   "$publishing/orch/scripts/lib/merge-queue-supervisor.sh" \
-  'report_home_lost; trap - EXIT TERM HUP INT; return 1' \
-  'publish_unknown home_lost 1; report_home_lost; trap - EXIT TERM HUP INT; return 1' \
+  'then report_home_lost; return 1; fi' \
+  'then publish_unknown home_lost 1; report_home_lost; return 1; fi' \
   || { bad "publishing-refusal mutation did not apply"; exit 1; }
 IFS=$'\t' read -r ppid _prt _part _plog _pstate pmain < <(launch_supervisor "$publishing" KEN-995-publishing "$publishing/main/altroot")
 break_repository "" "" "$pmain" "$publishing"
@@ -344,19 +344,39 @@ if [[ "$(jq -r '.diagnostic.cause' <<<"$publishing_consume")" != watch_lost ]]; 
 else bad "the publishing mutant still consumed as watch_lost"; fi
 mq_reap "$publishing" || bad "reaper reported survivors under the publishing sandbox"
 
-echo "=== a supervisor that returns still runs its teardown ==="
+echo "=== every supervisor exit runs its teardown ==="
 
-# An EXIT trap fires when the shell exits, after `return` has popped the
-# supervisor's locals — so a path that ends in `return` must run cleanup
-# itself while they are live (KEN-1060). The worker-liveness check is forced
-# false with a real worker running, so the supervisor takes its `return 1`
-# path holding everything teardown exists to retire: a live worker, an open
-# runtime, and the promise of a consumable artifact.
+# The teardown is an EXIT trap reading state the function once declared
+# local. An EXIT trap fires when the shell exits, after `return` and a set -e
+# failure have both popped the function's frame, so the trap ran empty on
+# every such exit: no worker reaped, no unknown fallback, no terminal file
+# (KEN-1060). The state is process-scoped now. Each case below forces one
+# exit kind while the supervisor holds everything teardown exists to retire
+# (a live worker, an open runtime, the promise of a consumable artifact) and
+# asserts the teardown ran; its control re-plants `local` on the worker's
+# pid, which is the original defect, and asserts the same teardown did not.
+
+# The worker alone: the process whose executed script is the sandbox's
+# queue-wait. The supervisor's own argv carries that path too (the waiter is
+# its seventh argument), and so does the worker subshell forked from it, so a
+# substring census would count them both as workers.
 workers_under() {
   ps -e -ww -o pid=,args= > "$TMP/ps.worker.snapshot" 2>/dev/null || true
-  awk -v root="$1" 'index($0, "queue-wait") && index($0, root) { print $1 }' "$TMP/ps.worker.snapshot"
+  awk -v script="$1/orch/scripts/queue-wait" '$3 == script { print $1 }' "$TMP/ps.worker.snapshot"
 }
 count_workers() { workers_under "$1" | grep -c . || true; }
+
+# $1 sandbox, then needle/replacement pairs applied in order to the sandbox's
+# supervisor copy; each must apply exactly once.
+plant() {
+  local sb="$1" src="$ORCH/scripts/lib/merge-queue-supervisor.sh" dst
+  dst="$sb/orch/scripts/lib/merge-queue-supervisor.sh"; shift
+  build_sandbox "$sb"
+  while (($# >= 2)); do
+    edit_once "$src" "$dst.next" "$1" "$2" || return 1
+    mv -- "$dst.next" "$dst"; src="$dst"; shift 2
+  done
+}
 
 # $1 sandbox, $2 issue: launch under the sandbox's supervisor copy. The caller
 # arranges for the supervisor to exit or be held before the worker-liveness
@@ -381,60 +401,64 @@ launch_return_path() {
     | jq -r '[.runtime_dir, .artifact_path] | @tsv'
 }
 
-retpath="$TMP/return-path"
-build_sandbox "$retpath"
-edit_once "$ORCH/scripts/lib/merge-queue-supervisor.sh" \
-  "$retpath/orch/scripts/lib/merge-queue-supervisor.sh" \
-  'kill -0 "$worker_pid" 2>/dev/null || { cleanup 1; return 1; }' \
-  'false || { cleanup 1; return 1; }' \
+# $1 sandbox, $2 runtime, $3 artifact, $4 label.
+assert_teardown_ran() {
+  local i
+  wait_exists "$2/terminal" && ok "$4: the terminal file is written" || bad "$4: no terminal file"
+  eq "$(jq -r '.verdict // "missing"' "$3" 2>/dev/null || echo missing)" unknown "$4: the unknown fallback is published"
+  eq "$(jq -r '.cause // "missing"' "$3" 2>/dev/null || echo missing)" supervisor_exit "$4: the fallback names the supervisor exit"
+  for ((i=0;i<100;i++)); do [[ "$(count_workers "$1")" -eq 0 && "$(count_supervisors "$1")" -eq 0 ]] && break; sleep 0.05; done
+  eq "$(count_workers "$1")" 0 "$4: the worker is reaped"
+  eq "$(count_supervisors "$1")" 0 "$4: no supervisor outlives the exit"
+}
+# The same four facts, negated: this is the silent no-op the assertions
+# above must catch, so a control that fails any of them frees an assertion.
+assert_teardown_skipped() {
+  [[ ! -e "$2/terminal" ]] && ok "$4: the empty trap writes no terminal" || bad "$4: the control wrote a terminal; that assertion is free"
+  [[ ! -e "$3" ]] && ok "$4: the empty trap publishes no fallback" || bad "$4: the control published a fallback; that assertion is free"
+  [[ "$(count_workers "$1")" -gt 0 ]] && ok "$4: the empty trap leaks the worker" || bad "$4: the control leaked no worker; that assertion is free"
+  mq_reap "$1" || bad "$4: reaper reported survivors under the control sandbox"
+}
+# $1 sandbox, $2 issue, $3 label, $4 ran|skipped: launch, then assert.
+teardown_case() {
+  local sb="$1" issue="$2" label="$3" expect="$4" runtime="" artifact=""
+  if IFS=$'\t' read -r runtime artifact < <(launch_return_path "$sb" "$issue"); then
+    ok "$label: the launch fails"
+  else
+    bad "$label: the launch did not fail; the assertions below prove nothing"; return 0
+  fi
+  case "$expect" in
+    ran) assert_teardown_ran "$sb" "$runtime" "$artifact" "$label" ;;
+    skipped) assert_teardown_skipped "$sb" "$runtime" "$artifact" "$label" ;;
+  esac
+}
+
+RETURN_SITE='kill -0 "$worker_pid" 2>/dev/null || return 1'
+SET_E_SITE=': > "$runtime/ready"; chmod 600 "$runtime/ready"'
+LOCAL_PID='  worker_pid="" worker_rc=0 event="" watchdog_pid=""'
+
+# A `return` after the worker is forked: the liveness check forced false.
+plant "$TMP/return-path" "$RETURN_SITE" 'false || return 1' \
   || { bad "return-path mutation did not apply"; exit 1; }
-rp_runtime="" rp_artifact=""
-if IFS=$'\t' read -r rp_runtime rp_artifact < <(launch_return_path "$retpath" KEN-1060-return); then
-  ok "the worker-liveness return path fails the launch"
-else
-  bad "the forced return path did not fail the launch; the assertions below prove nothing"
-fi
-if [[ -n "$rp_runtime" ]]; then
-  wait_exists "$rp_runtime/terminal" && ok "the return path writes the runtime terminal file" \
-    || bad "the return path left no terminal file"
-  eq "$(jq -r '.verdict // "missing"' "$rp_artifact" 2>/dev/null || echo missing)" unknown "the return path publishes the unknown fallback"
-  eq "$(jq -r '.cause // "missing"' "$rp_artifact" 2>/dev/null || echo missing)" supervisor_exit "the fallback names the supervisor exit"
-  for ((i=0;i<100;i++)); do [[ "$(count_workers "$retpath")" -eq 0 && "$(count_supervisors "$retpath")" -eq 0 ]] && break; sleep 0.05; done
-  eq "$(count_workers "$retpath")" 0 "the return path reaps its live worker"
-  eq "$(count_supervisors "$retpath")" 0 "no supervisor outlives the return path"
-fi
-
-# Control: the same forced path with the explicit call cut leaves only the
-# EXIT trap, which fires after the locals are gone — no terminal, no fallback,
-# a leaked worker. This is the silent no-op the assertions above must catch.
-noclean="$TMP/return-path-noclean"
-build_sandbox "$noclean"
-edit_once "$ORCH/scripts/lib/merge-queue-supervisor.sh" \
-  "$noclean/orch/scripts/lib/merge-queue-supervisor.sh" \
-  'kill -0 "$worker_pid" 2>/dev/null || { cleanup 1; return 1; }' \
-  'false || return 1' \
+teardown_case "$TMP/return-path" KEN-1060-return "return" ran
+plant "$TMP/return-path-local" "$RETURN_SITE" 'false || return 1' "$LOCAL_PID" "  local$LOCAL_PID" \
   || { bad "return-path control mutation did not apply"; exit 1; }
-nc_runtime="" nc_artifact=""
-if IFS=$'\t' read -r nc_runtime nc_artifact < <(launch_return_path "$noclean" KEN-1060-noclean); then
-  ok "the control's forced return path fails the launch"
-else
-  bad "the control launch did not fail; the control proves nothing"
-fi
-if [[ -n "$nc_runtime" ]]; then
-  [[ ! -e "$nc_runtime/terminal" ]] && ok "without the explicit call the empty trap writes no terminal" \
-    || bad "the control wrote a terminal; the terminal assertion above is free"
-  [[ ! -e "$nc_artifact" ]] && ok "without the explicit call no fallback is published" \
-    || bad "the control published a fallback; the fallback assertion above is free"
-  [[ "$(count_workers "$noclean")" -gt 0 ]] && ok "without the explicit call the worker leaks" \
-    || bad "the control leaked no worker; the reap assertion above is free"
-fi
-mq_reap "$noclean" || bad "reaper reported survivors under the control sandbox"
+teardown_case "$TMP/return-path-local" KEN-1060-return-local "return control" skipped
 
-# The other guarded return: the post-registration currency recheck, driven
-# with no mutation. The supervisor is held at its event fifo, so the launch
-# command times out waiting for worker liveness and claims launch_failed;
-# released, the supervisor's recheck refuses and returns 1. That launch_failed
-# state still admits the unknown fallback — the reason publish accepts it.
+# A set -e exit after the worker is forked: the ready marker's write fails.
+plant "$TMP/set-e" "$SET_E_SITE" ': > "$runtime/missing/ready"; chmod 600 "$runtime/ready"' \
+  || { bad "set -e mutation did not apply"; exit 1; }
+teardown_case "$TMP/set-e" KEN-1060-set-e "set -e" ran
+plant "$TMP/set-e-local" "$SET_E_SITE" ': > "$runtime/missing/ready"; chmod 600 "$runtime/ready"' "$LOCAL_PID" "  local$LOCAL_PID" \
+  || { bad "set -e control mutation did not apply"; exit 1; }
+teardown_case "$TMP/set-e-local" KEN-1060-set-e-local "set -e control" skipped
+
+# The `return` before the worker is forked, driven with no mutation: the
+# post-registration currency recheck. The supervisor is held at its event
+# fifo, so the launch command times out waiting for worker liveness and
+# claims launch_failed; released, the supervisor's recheck refuses and
+# returns 1. That launch_failed state still admits the unknown fallback,
+# which is the reason publish accepts it.
 regate="$TMP/recheck"
 build_sandbox "$regate"
 TD_REAL_MKFIFO="$(command -v mkfifo)"
@@ -452,20 +476,13 @@ chmod +x "$regate/bin/mkfifo"
 touch "$TD_MKFIFO_GATE.enabled"
 rg_runtime="" rg_artifact=""
 if IFS=$'\t' read -r rg_runtime rg_artifact < <(launch_return_path "$regate" KEN-1060-recheck); then
-  ok "the held supervisor's launch claims its failure"
+  ok "recheck: the held supervisor's launch claims its failure"
 else
-  bad "the held launch did not fail; the recheck assertions below prove nothing"
+  bad "recheck: the held launch did not fail; the assertions below prove nothing"
 fi
-wait_exists "$TD_MKFIFO_GATE.entered" || bad "the supervisor never reached its event fifo"
+wait_exists "$TD_MKFIFO_GATE.entered" || bad "recheck: the supervisor never reached its event fifo"
 touch "$TD_MKFIFO_GATE.release"
-if [[ -n "$rg_runtime" ]]; then
-  wait_exists "$rg_runtime/terminal" && ok "the refused recheck still runs its teardown" \
-    || bad "the refused recheck left no terminal file"
-  eq "$(jq -r '.verdict // "missing"' "$rg_artifact" 2>/dev/null || echo missing)" unknown "the refused recheck publishes the unknown fallback"
-  eq "$(jq -r '.cause // "missing"' "$rg_artifact" 2>/dev/null || echo missing)" supervisor_exit "the recheck fallback names the supervisor exit"
-  for ((i=0;i<100;i++)); do [[ "$(count_supervisors "$regate")" -eq 0 ]] && break; sleep 0.05; done
-  eq "$(count_supervisors "$regate")" 0 "no supervisor outlives the refused recheck"
-fi
+[[ -z "$rg_runtime" ]] || assert_teardown_ran "$regate" "$rg_runtime" "$rg_artifact" "recheck"
 rm -f -- "$TD_MKFIFO_GATE.enabled" "$TD_MKFIFO_GATE.entered" "$TD_MKFIFO_GATE.release"
 
 echo "=== a wait whose repository is deleted refuses to keep polling ==="

--- a/skills/orch/tests/merge_queue_teardown.sh
+++ b/skills/orch/tests/merge_queue_teardown.sh
@@ -252,6 +252,11 @@ home_clause_case() {
 
 home_clause_case runtime-deleted break_runtime
 home_clause_case runtime-swapped-for-a-symlink break_symlink
+# The teardown's own marker follows the same rule as its fallback: a runtime
+# swapped for a symlink gets no terminal file at the symlink's target.
+[[ ! -e "$TMP/home-runtime-swapped-for-a-symlink/main/terminal" ]] \
+  && ok "runtime-swapped-for-a-symlink: no terminal marker lands at the symlink target" \
+  || bad "runtime-swapped-for-a-symlink: the teardown wrote through the symlink"
 home_clause_case state-file-deleted break_state
 home_clause_case repository-deleted break_repository altroot
 
@@ -290,6 +295,11 @@ edit_once() {
 
 home_clause_control without-runtime-clause '-d "$runtime" && ' break_runtime
 home_clause_control without-symlink-clause '! -L "$runtime" && ' break_symlink
+# The reaper's TERM runs that mutant's teardown, which no longer sees the
+# symlink and so writes its marker through it: the assertion above is not free.
+[[ -e "$TMP/mutant-without-symlink-clause/main/terminal" ]] \
+  && ok "without-symlink-clause: cutting the clause writes the marker through the symlink" \
+  || bad "without-symlink-clause: no marker at the symlink target; the symlink-target assertion above is free"
 home_clause_control without-state-clause '-f "$state_file" && ' break_state
 home_clause_control without-repository-clause ' && -d "$main_root"' break_repository altroot
 

--- a/skills/orch/tests/merge_queue_watch.sh
+++ b/skills/orch/tests/merge_queue_watch.sh
@@ -493,18 +493,18 @@ export WATCH_RELEASE="$old_release"
 prep=$(prepare ejected); watch=$(jq -r .watch_id <<<"$prep"); artifact=$(jq -r .artifact_path <<<"$prep")
 launch_bounded "$watch"
 state_path=$("$SCRIPTS/workflow-state" --state-dir "$WT/tmp" get KEN-829 .merge_queue_watch.state_path)
-stale_supervisor_pid=$(jq -r .supervisor_pid "$state_path")
+stale_runtime=$(jq -r .runtime_dir "$state_path")
 jq '.status="launch_failed"|.action="launch"|.supervisor_pid=null' "$state_path" > "$TMP/publication-state.json"
 chmod 600 "$TMP/publication-state.json"; mv "$TMP/publication-state.json" "$state_path"
 export WATCH_RELEASE="$new_release"
 launch_bounded "$watch"
 publication_replacement=$("$SCRIPTS/merge-queue-watch" inspect --root "$MAIN" --issue KEN-829 | jq -r .artifact_path)
 touch "$new_release"; wait_file "$publication_replacement" || bad "publication-fence replacement verdict missing"
-# The stale supervisor sits on its worker until this release, then makes the one
-# publication attempt this fence has to refuse and exits, so waiting for that
-# process is waiting for exactly that attempt to be over.
+# The stale supervisor sits on its worker until this release, then makes the
+# publication attempts this fence has to refuse; its teardown writes the
+# runtime terminal file after the last of them, so that file ends the attempt.
 touch "$old_release"
-wait_gone "$stale_supervisor_pid" || bad "stale started supervisor never finished its publication attempt"
+wait_file "$stale_runtime/terminal" || bad "stale started supervisor never finished its publication attempt"
 [[ ! -e "$artifact" ]] && ok "stale started supervisor cannot publish after replacement" || bad "publication fence admitted the stale started supervisor"
 eq "$(jq -r .verdict "$publication_replacement")" ejected "stale publication leaves the replacement verdict intact"
 result=$("$SCRIPTS/merge-queue-watch" consume --root "$MAIN" --issue KEN-829)


### PR DESCRIPTION
## Summary
- The merge-queue supervisor's teardown state is process-scoped and the EXIT trap is the sole teardown, so a supervisor that leaves `merge_queue_supervise` by `return`, a `set -e` failure, `exit`, or a signal always reaps its worker, publishes the `unknown` fallback, and writes the runtime `terminal` file.
- The teardown suite forces a return and a planted `set -e` exit after the worker fork, each with a control that re-plants `local` on the worker pid and reds all three assertions; the worker census counts only the executed `queue-wait` script.
- The watch suite's publication fence waits on the runtime `terminal` file instead of the supervisor PID.

## Completed Issues
- Closes KEN-1060 - The supervisor cleanup trap reads popped locals, so it silently no-ops

## Test Plan
- `bash skills/orch/tests/merge_queue_teardown.sh` (105 pass, 0 fail)
- `bash skills/orch/tests/merge_queue_watch.sh` (172 pass, 0 fail)
- `bash skills/orch/tests/run-all.sh` (68 files pass)
- `tools/guard` exit 0; preflight clean; `.agents/skills/orch` render byte-identical to source

https://claude.ai/code/session_01HRUBMUVGkkgbGJiebLgNQj
