### PR TITLE
feat(KEN-1104): the bash 3.2 lint reads hooks, two reviewer probes

### DIFF
--- a/.agents/skills/growth-guards/tests/bsd-argv-install.test.sh
+++ b/.agents/skills/growth-guards/tests/bsd-argv-install.test.sh
@@ -13,8 +13,8 @@
 # macOS would. The merge-group macOS lane stays the platform proof; this is
 # what every Linux run can say on its own.
 #
-# Bash 4 syntax in the shipped scripts is `tools/bash32-lint`, run over every
-# skill's scripts/ and tests/ at once.
+# Bash 4 syntax in the shipped scripts is `tools/bash32-lint`, run over the
+# roster `tools/bash32-lint --list` prints.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/.claude/agents/reviewer-correctness.md
+++ b/.claude/agents/reviewer-correctness.md
@@ -42,6 +42,7 @@ For each changed predicate, parser, or guard, mentally execute:
 - **Pre-steady-state** — behavior while detection is still pending, state is unseeded, or readiness was declared on selection rather than on answerability.
 - **Teardown symmetry** — for every install/enable/claim path, walk uninstall/disable/release under: another worktree still installed, the helper already missing, a partially applied prior run, and a foreign tool owning the same file.
 - **Staged vs worktree** — a `--staged` or index-reading mode reads its policy inputs (baseline, excludes, settings) from the index too, never from the worktree.
+- **Workflow order** — a `→ §N` route, a `Skip if`, or a `[PLACEHOLDER]` the diff adds to a workflow is executed in document order; name the section that runs it and the line that binds the placeholder, or the route is a finding.
 
 ## Removed Behavior
 

--- a/.claude/agents/reviewer-test.md
+++ b/.claude/agents/reviewer-test.md
@@ -31,6 +31,7 @@ Coverage of changed paths (branches, error paths, boundaries), test quality, det
 - **Assertion tightness**: matchers loose enough to also match a skip note, a shared suffix, or a wrong-cause message; assertions on source text that survive logic inversion.
 - **Wiring**: a new test file is only real if a runner invokes it — verify CI/run-all wiring for every added suite.
 - **Environment**: assumptions that break under root, another locale, or elevated parallelism.
+- **Clock**: a test that bounds a duration with `sleep`, `setTimeout`, or `date` proves nothing on a loaded runner; the boundary is staged or the clock is injected.
 - Any test you mutation-validate follows the reviewer skill's § Mutation-Stability Pairing.
 
 ## Output

--- a/.claude/hooks/block-unsafe-rm.sh
+++ b/.claude/hooks/block-unsafe-rm.sh
@@ -74,7 +74,7 @@ SEGMENTS=$(printf '%s\n' "$COMMAND" \
         # an empty segment between two newlines, which matches nothing. A
         # closing paren separates too, so a case-arm body (`x) rm …;;`) and
         # a subshell tail become their own segments.
-        gsub(/[;|&)]/, "\n", blob)
+        gsub(/[;)&|]/, "\n", blob)
         printf "%s", blob
       }')
 

--- a/.codex/agents/reviewer-correctness.toml
+++ b/.codex/agents/reviewer-correctness.toml
@@ -37,6 +37,7 @@ For each changed predicate, parser, or guard, mentally execute:
 - **Pre-steady-state** — behavior while detection is still pending, state is unseeded, or readiness was declared on selection rather than on answerability.
 - **Teardown symmetry** — for every install/enable/claim path, walk uninstall/disable/release under: another worktree still installed, the helper already missing, a partially applied prior run, and a foreign tool owning the same file.
 - **Staged vs worktree** — a `--staged` or index-reading mode reads its policy inputs (baseline, excludes, settings) from the index too, never from the worktree.
+- **Workflow order** — a `→ §N` route, a `Skip if`, or a `[PLACEHOLDER]` the diff adds to a workflow is executed in document order; name the section that runs it and the line that binds the placeholder, or the route is a finding.
 
 ## Removed Behavior
 

--- a/.codex/agents/reviewer-test.toml
+++ b/.codex/agents/reviewer-test.toml
@@ -26,6 +26,7 @@ Coverage of changed paths (branches, error paths, boundaries), test quality, det
 - **Assertion tightness**: matchers loose enough to also match a skip note, a shared suffix, or a wrong-cause message; assertions on source text that survive logic inversion.
 - **Wiring**: a new test file is only real if a runner invokes it — verify CI/run-all wiring for every added suite.
 - **Environment**: assumptions that break under root, another locale, or elevated parallelism.
+- **Clock**: a test that bounds a duration with `sleep`, `setTimeout`, or `date` proves nothing on a loaded runner; the boundary is staged or the clock is injected.
 - Any test you mutation-validate follows the reviewer skill's § Mutation-Stability Pairing.
 
 ## Output

--- a/.codex/hooks/block-unsafe-rm.sh
+++ b/.codex/hooks/block-unsafe-rm.sh
@@ -74,7 +74,7 @@ SEGMENTS=$(printf '%s\n' "$COMMAND" \
         # an empty segment between two newlines, which matches nothing. A
         # closing paren separates too, so a case-arm body (`x) rm …;;`) and
         # a subshell tail become their own segments.
-        gsub(/[;|&)]/, "\n", blob)
+        gsub(/[;)&|]/, "\n", blob)
         printf "%s", blob
       }')
 

--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -151,7 +151,7 @@ jobs:
 
       # One scan for Bash 4+ syntax over the roster `tools/bash32-lint --list`
       # prints. bash32-lint.test.sh proves its teeth.
-      - name: bash32-lint (Bash 3.2 portability across the skill tree)
+      - name: bash32-lint (Bash 3.2 portability across the roster)
         if: matrix.shard == 'rest'
         run: tools/bash32-lint
 

--- a/.pi/agents/reviewer-correctness.md
+++ b/.pi/agents/reviewer-correctness.md
@@ -38,6 +38,7 @@ For each changed predicate, parser, or guard, mentally execute:
 - **Pre-steady-state** — behavior while detection is still pending, state is unseeded, or readiness was declared on selection rather than on answerability.
 - **Teardown symmetry** — for every install/enable/claim path, walk uninstall/disable/release under: another worktree still installed, the helper already missing, a partially applied prior run, and a foreign tool owning the same file.
 - **Staged vs worktree** — a `--staged` or index-reading mode reads its policy inputs (baseline, excludes, settings) from the index too, never from the worktree.
+- **Workflow order** — a `→ §N` route, a `Skip if`, or a `[PLACEHOLDER]` the diff adds to a workflow is executed in document order; name the section that runs it and the line that binds the placeholder, or the route is a finding.
 
 ## Removed Behavior
 

--- a/.pi/agents/reviewer-test.md
+++ b/.pi/agents/reviewer-test.md
@@ -27,6 +27,7 @@ Coverage of changed paths (branches, error paths, boundaries), test quality, det
 - **Assertion tightness**: matchers loose enough to also match a skip note, a shared suffix, or a wrong-cause message; assertions on source text that survive logic inversion.
 - **Wiring**: a new test file is only real if a runner invokes it — verify CI/run-all wiring for every added suite.
 - **Environment**: assumptions that break under root, another locale, or elevated parallelism.
+- **Clock**: a test that bounds a duration with `sleep`, `setTimeout`, or `date` proves nothing on a loaded runner; the boundary is staged or the clock is injected.
 - Any test you mutation-validate follows the reviewer skill's § Mutation-Stability Pairing.
 
 ## Output

--- a/agents/reviewer-correctness.md
+++ b/agents/reviewer-correctness.md
@@ -38,6 +38,7 @@ For each changed predicate, parser, or guard, mentally execute:
 - **Pre-steady-state** — behavior while detection is still pending, state is unseeded, or readiness was declared on selection rather than on answerability.
 - **Teardown symmetry** — for every install/enable/claim path, walk uninstall/disable/release under: another worktree still installed, the helper already missing, a partially applied prior run, and a foreign tool owning the same file.
 - **Staged vs worktree** — a `--staged` or index-reading mode reads its policy inputs (baseline, excludes, settings) from the index too, never from the worktree.
+- **Workflow order** — a `→ §N` route, a `Skip if`, or a `[PLACEHOLDER]` the diff adds to a workflow is executed in document order; name the section that runs it and the line that binds the placeholder, or the route is a finding.
 
 ## Removed Behavior
 

--- a/agents/reviewer-test.md
+++ b/agents/reviewer-test.md
@@ -27,6 +27,7 @@ Coverage of changed paths (branches, error paths, boundaries), test quality, det
 - **Assertion tightness**: matchers loose enough to also match a skip note, a shared suffix, or a wrong-cause message; assertions on source text that survive logic inversion.
 - **Wiring**: a new test file is only real if a runner invokes it — verify CI/run-all wiring for every added suite.
 - **Environment**: assumptions that break under root, another locale, or elevated parallelism.
+- **Clock**: a test that bounds a duration with `sleep`, `setTimeout`, or `date` proves nothing on a loaded runner; the boundary is staged or the clock is injected.
 - Any test you mutation-validate follows the reviewer skill's § Mutation-Stability Pairing.
 
 ## Output

--- a/hooks/block-unsafe-rm.sh
+++ b/hooks/block-unsafe-rm.sh
@@ -74,7 +74,7 @@ SEGMENTS=$(printf '%s\n' "$COMMAND" \
         # an empty segment between two newlines, which matches nothing. A
         # closing paren separates too, so a case-arm body (`x) rm …;;`) and
         # a subshell tail become their own segments.
-        gsub(/[;|&)]/, "\n", blob)
+        gsub(/[;)&|]/, "\n", blob)
         printf "%s", blob
       }')
 

--- a/skills/growth-guards/tests/bsd-argv-install.test.sh
+++ b/skills/growth-guards/tests/bsd-argv-install.test.sh
@@ -13,8 +13,8 @@
 # macOS would. The merge-group macOS lane stays the platform proof; this is
 # what every Linux run can say on its own.
 #
-# Bash 4 syntax in the shipped scripts is `tools/bash32-lint`, run over every
-# skill's scripts/ and tests/ at once.
+# Bash 4 syntax in the shipped scripts is `tools/bash32-lint`, run over the
+# roster `tools/bash32-lint --list` prints.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/skills/harness-ci/README.md
+++ b/skills/harness-ci/README.md
@@ -116,8 +116,8 @@ There is no flag that turns any of these into a `true`.
 
 Run one locally with `bash skills/harness-ci/tests/path-set.test.sh`.
 
-Bash 4+ syntax in the shipped script is `tools/bash32-lint`, which scans every
-skill's `scripts/` and `tests/` at once — consumer runners include macOS
+Bash 4+ syntax in the shipped script is `tools/bash32-lint`, which scans the
+roster `tools/bash32-lint --list` prints — consumer runners include macOS
 system Bash 3.2.
 
 ## Upgrades

--- a/tools/bash32-lint
+++ b/tools/bash32-lint
@@ -34,10 +34,10 @@ set -uo pipefail
 #
 # tools/ is NOT in the roster. This file defines the pattern set in string
 # literals and explains it in comments that quote the constructs, so the
-# scan reds on the definition it judges by, and respelling that definition
-# would change what it matches. tools/tests/ reds as well, on a construct
-# name a check hands the scan as a narrowed pattern. Clearing tools/ takes
-# more than a respell; `tools/bash32-lint tools` lists what is there now.
+# scan reds on the definition it judges by. tools/tests/ reds as well, on a
+# construct name a check hands the scan as a narrowed pattern. Clearing
+# tools/ therefore takes more than a respell; `tools/bash32-lint tools`
+# lists what is there now.
 #
 # The exceptions are declared, with the reason, because a roster that
 # discovers its members cannot tell a directory that is exempt from one that

--- a/tools/bash32-lint
+++ b/tools/bash32-lint
@@ -30,10 +30,14 @@ set -uo pipefail
 #
 # hooks/ is named rather than discovered: it is one directory, and its
 # scripts run on whatever bash the harness starts them with, which on a Mac
-# is the 3.2 in /bin. tools/ is NOT in the roster. This file defines the
-# pattern set in string literals and explains it in comments that quote the
-# constructs, so a scan of tools/ reds on this file's own text and the fix
-# would be to respell the definition it is judging by.
+# is the 3.2 in /bin.
+#
+# tools/ is NOT in the roster. This file defines the pattern set in string
+# literals and explains it in comments that quote the constructs, so the
+# scan reds on the definition it judges by, and respelling that definition
+# would change what it matches. tools/tests/ reds as well, on a construct
+# name a check hands the scan as a narrowed pattern. Clearing tools/ takes
+# more than a respell; `tools/bash32-lint tools` lists what is there now.
 #
 # The exceptions are declared, with the reason, because a roster that
 # discovers its members cannot tell a directory that is exempt from one that

--- a/tools/bash32-lint
+++ b/tools/bash32-lint
@@ -28,6 +28,13 @@ set -uo pipefail
 # macOS system bash — a Bash 4 construct in a suite, or in the lib a suite
 # sources, breaks the run on a 3.2 host as surely as one in a script.
 #
+# hooks/ is named rather than discovered: it is one directory, and its
+# scripts run on whatever bash the harness starts them with, which on a Mac
+# is the 3.2 in /bin. tools/ is NOT in the roster. This file defines the
+# pattern set in string literals and explains it in comments that quote the
+# constructs, so a scan of tools/ reds on this file's own text and the fix
+# would be to respell the definition it is judging by.
+#
 # The exceptions are declared, with the reason, because a roster that
 # discovers its members cannot tell a directory that is exempt from one that
 # quietly emptied out. A stale entry ends the run for any of them, checked
@@ -170,7 +177,7 @@ fi
 ROOT="$(git rev-parse --show-toplevel)" || die "not in a git repository"
 if [ "$#" -eq 0 ]; then
   cd "$ROOT" || die "cannot enter $ROOT"
-  set -- skills/*/scripts skills/*/tests
+  set -- skills/*/scripts skills/*/tests hooks
 fi
 
 at_root() { # at_root PATH — a roster path, read from the toplevel.

--- a/tools/tests/bash32-lint.test.sh
+++ b/tools/tests/bash32-lint.test.sh
@@ -10,10 +10,12 @@
 #
 # EVERY CHECK HERE FAILS CLOSED. No result is read out of an empty string:
 # git, grep and the lint itself are asked for their status, and a command that
-# could not run ends the run instead of scoring a pass. The roster and the
-# pattern set are both ASKED OF THE LINT — `--list` and `--pattern` — rather
-# than restated here or parsed back out of its source, so what is judged below
-# is what the program runs.
+# could not run ends the run instead of scoring a pass. The resolved roster
+# and the pattern set are both ASKED OF THE LINT — `--list` and `--pattern` —
+# rather than restated here, so what is judged below is what the program runs.
+# The roster's hand-named entries have no such question to ask, so they are
+# read out of the roster line; that is still reading the lint rather than
+# keeping a second copy of the list here.
 set -eu -o pipefail
 ROOT="$(git rev-parse --show-toplevel)" || exit 2
 cd "$ROOT" || exit 2

--- a/tools/tests/bash32-lint.test.sh
+++ b/tools/tests/bash32-lint.test.sh
@@ -93,6 +93,25 @@ else
   done
 fi
 
+# The glob entries above answer for themselves: a skills/ directory that
+# left the roster fails the loop. A hand-named entry does not, so it is
+# read out of the roster line and looked for in what --list prints —
+# dropping one from the line reds here. Read, never restated: a second copy
+# of the roster is the staleness this file exists to catch.
+named=""
+status=0
+named="$(sed -n 's#^  set -- \(.*\)$#\1#p' "$LINT" | tr ' ' '\n' | grep -v '[*]')" || status=$?
+if [ "$status" -ne 0 ] || [ -z "$named" ]; then
+  bad "no hand-named roster entry could be read from the lint, so none is proven listed"
+else
+  for d in $named; do
+    case "$NL$ROSTER$NL" in
+    *"$NL$d$NL"*) ok "the hand-named roster entry $d is in what --list prints" ;;
+    *) bad "the roster line names $d, but --list does not print it" ;;
+    esac
+  done
+fi
+
 # --- 2. the tree is clean, which is the assertion the lint exists to make -
 status=0
 out="$("$LINT" 2>&1)" || status=$?

--- a/tools/tests/guard.test.sh
+++ b/tools/tests/guard.test.sh
@@ -87,16 +87,16 @@ printf '%s\n' \
   '    let tmp = tempfile::tempdir().unwrap();' \
   '    drop(tmp);' \
   '}' >"$R/crates/core/tests/existing_temp.rs"
-# The bash32-lint lane runs on every pass and reads its exception entries
-# relative to the repository it runs in, so the fixture carries those
-# directories from the first commit — derived from the lint itself, because
-# a copy of the list here would go stale with it. Beside them, one rendered
-# skill and one agent with a render per harness, in step.
+# The bash32-lint lane runs on every pass and resolves its exception entries
+# and its hand-named roster entries against the repository it runs in, so the
+# fixture derives each rather than copying a list that goes stale with it. An
+# exception directory holds no shell file; a roster one dies without one.
 while IFS= read -r e; do
-  [ -n "$e" ] || continue
-  mkdir -p "$R/$e"
-  printf 'not shell\n' >"$R/$e/README.md"
-done < <(sed -n 's#^NO_\(SCAN\|SHELL\)="\(.*\)"$#\2#p' "$REPO/tools/bash32-lint" | tr ' ' '\n')
+  mkdir -p "$R/$e" && printf 'not shell\n' >"$R/$e/README.md"
+done < <(sed -n 's#^NO_\(SCAN\|SHELL\)="\(.*\)"$#\2#p' "$REPO/tools/bash32-lint" | tr ' ' '\n' | grep .)
+while IFS= read -r e; do
+  mkdir -p "$R/$e" && printf '#!/usr/bin/env bash\necho rostered\n' >"$R/$e/rostered.sh"
+done < <(sed -n 's#^  set -- \(.*\)$#\1#p' "$REPO/tools/bash32-lint" | tr ' ' '\n' | grep -v '[*]')
 mkdir -p "$R/skills/demo/scripts" "$R/skills/demo/tests" \
   "$R/.agents/skills/demo/scripts" "$R/.agents/skills/demo/tests" \
   "$R/agents" "$R/.claude/agents" "$R/.codex/agents" "$R/.pi/agents"


### PR DESCRIPTION
## Summary

- `tools/bash32-lint` now reads `hooks/` as well. `skills/*/tests` was already in the roster, landed by KEN-1056 before this issue was implemented. The widening reddened one awk bracket expression in `hooks/block-unsafe-rm.sh` spelling a literal `|&`; it is reordered to the same character set, the respell remedy the lint's own header prescribes.
- `reviewer-correctness` gains a **Workflow order** probe and `reviewer-test` a **Clock** probe, each landed with its `.claude`, `.codex` and `.pi` renders.
- `tools/` stays out of the roster, and the file now says why: the lint defines the pattern set in string literals and quotes those constructs in its comments, so a scan of `tools/` reds on the definition it judges by, and on `tools/tests/bash32-lint.test.sh` where a check hands the scan a narrowed pattern. Covering it needs a per-file excludes list, which this issue puts out of scope.

## Not implemented

Item 2 of the issue, the exec-bit glob in `.github/workflows/skill-tests.yml`, is not done. Its premise does not hold, on three independent checks:

- A git pathspec `*` crosses `/`. `git ls-files -- 'skills/*/tests/*.sh'` already returns 61 files nested below `tests/`, so the glob does not stop one directory deep.
- The 46 files under `skills/linear/tests/controls/` are `100644` on purpose. `must-fail-controls.sh` sources each one; none is an entry point. KEN-800 (#1807) excluded controls with that reason written into the step's own comment.
- The step is green on the current tree. Its exact pipeline exits 0.

Implementing it as written would chmod 46 sourced files and reverse a documented decision.

## Review

Ten reviewers plus a cross-model pass. Three blockers, each found independently by two or more, all fixed:

| Blocker | Evidence |
|---|---|
| The `hooks` roster entry reddened `tools/tests/guard.test.sh`, whose fixture repo has no `hooks/` | 48 passed / 25 failed, now 73 / 0 |
| The respell landed in `hooks/block-unsafe-rm.sh` but not in the `.claude` and `.codex` renders the harness executes | all 14 hook source/render pairs byte-identical again |
| The roster arm had no must-fail control | deleting ` hooks` left the suite green; mutation now kills 1/1 |

The fixture takes the roster's hand-named entries from the lint itself rather than a second copy, the way it already derives the exception directories. A reformat of the roster line therefore cannot leave the fixture behind again.

## Completed issues

- Closes KEN-1104 - Four local catches: bash 3.2 lint roster, the exec-bit glob, and two reviewer lens lines

## Created issues

- KEN-1109 - Nothing gates a hook source against its harness renders — Project: Agent Harness Integrations

This PR lands the two stale renders it diverged. What produced the divergence is that `tools/guard`'s render rule has arms for `skills/` and `agents/` only, so a `hooks/` edit owes no render. Closing that is new gate machinery, outside this issue's Done-when.

## Test plan

- `tools/guard` exit 0.
- `tools/bash32-lint` clean over 464 files across 29 directories.
- `tools/tests/guard.test.sh` 73 / 0, `tools/tests/bash32-lint.test.sh` 86 / 0, `hooks/tests/block-unsafe-rm.test.sh` 55 / 0.
- Must-fail control: with ` hooks` deleted from the roster line the suite goes 83 / 1.
- `preflight` clean, `size-ratchet` OK with `tools/tests/guard.test.sh` held at its frozen 810-line baseline.

https://claude.ai/code/session_011o3G65KCk73t7JZ3eW8s78
