### PR TITLE
chore(orch): drop the orch-drill benchmarking instruction

### DIFF
--- a/.agents/skills/orch/SKILL.md
+++ b/.agents/skills/orch/SKILL.md
@@ -16,19 +16,6 @@ metadata:
 tags: [automation]
 ---
 
-<!-- kendex:project-instructions:start -->
-## Project Instructions
-
-## Benchmarking orchestration changes
-
-The orch-drill ablation rig A/B-benchmarks orchestration changes: launch a
-drill per its README and compare wall clock and phase timings against the
-recorded baselines before shipping a workflow change. It is a separate
-repository, `bmethod/orch-drill`, not part of this checkout. Clone it wherever
-you keep repositories and run the drill from there.
-
-<!-- kendex:project-instructions:end -->
-
 # Orchestration
 
 > **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.

--- a/kendex-local.toml
+++ b/kendex-local.toml
@@ -399,17 +399,6 @@ harnesses = [
 ]
 enabled = true
 
-[skill-instructions]
-orch = """
-## Benchmarking orchestration changes
-
-The orch-drill ablation rig A/B-benchmarks orchestration changes: launch a
-drill per its README and compare wall clock and phase timings against the
-recorded baselines before shipping a workflow change. It is a separate
-repository, `bmethod/orch-drill`, not part of this checkout. Clone it wherever
-you keep repositories and run the drill from there.
-"""
-
 [agent-frontmatter.claude.generalist]
 color = "green"
 model = "inherit"


### PR DESCRIPTION
Owner decision (2026-09-01): the orch-drill A/B benchmarking requirement is retired. The `bmethod/orch-drill` repository no longer exists, no local clone remains, and no consumer repo or Linear issue references it.

This removes the `[skill-instructions] orch` block from `kendex-local.toml` and the block it injected into `.agents/skills/orch/SKILL.md`. After the removal the orch render's head matches its source line for line. `git grep -i orch-drill` is empty.

Closes #1940

https://claude.ai/code/session_01PP5cxGjxdMFNH2fBGiaTwm
