### PR TITLE
chore(orch): three prose pins go; KEN-1006 changelog counts its checks

### DIFF
--- a/.agents/skills/orch/tests/dev_round_write.sh
+++ b/.agents/skills/orch/tests/dev_round_write.sh
@@ -509,13 +509,9 @@ for workflow in dev-fix review-pr-comments; do
   assert_text_not_matches "$round_block" '(^|[[:space:]])--add([[:space:]]|$)' "$workflow live command carries no repository path argument"
   assert_text_matches "$delegation" '^[[:space:]]*\[If the round may add files: "Adds: \[REPO_RELATIVE_PATHS_JSON_ARRAY\]' "$workflow live delegation carries the JSON Adds line"
   workflow_text="$(<"$workflow_file")"
-  assert_text_matches "$workflow_text" 'Exit 3 is the branch-size refusal' "$workflow routes the size-specific exit"
-  assert_text_matches "$workflow_text" 'Cut required' "$workflow names the required cut response"
 done
 
 disposition_text="$(<"$REPO_ROOT/skills/orch/references/finding-disposition.md")"
-assert_text_matches "$disposition_text" 'Size tripwire, enforced before fix delegation:' \
-  "finding disposition states the live enforcement point"
 
 scope_docs=(
   "$REPO_ROOT/skills/dev/workflows/dev-fix.md"

--- a/changelog.d/added/KEN-1006.md
+++ b/changelog.d/added/KEN-1006.md
@@ -1,3 +1,3 @@
 - `bot-instructions` generator: `render`, `check` and `adopt` write every review
   bot's instruction file from one doctrine source plus a per-repo
-  `bot-instructions.toml`, validated by thirteen checks.
+  `bot-instructions.toml`, validated by ten checks.

--- a/skills/orch/tests/dev_round_write.sh
+++ b/skills/orch/tests/dev_round_write.sh
@@ -509,13 +509,9 @@ for workflow in dev-fix review-pr-comments; do
   assert_text_not_matches "$round_block" '(^|[[:space:]])--add([[:space:]]|$)' "$workflow live command carries no repository path argument"
   assert_text_matches "$delegation" '^[[:space:]]*\[If the round may add files: "Adds: \[REPO_RELATIVE_PATHS_JSON_ARRAY\]' "$workflow live delegation carries the JSON Adds line"
   workflow_text="$(<"$workflow_file")"
-  assert_text_matches "$workflow_text" 'Exit 3 is the branch-size refusal' "$workflow routes the size-specific exit"
-  assert_text_matches "$workflow_text" 'Cut required' "$workflow names the required cut response"
 done
 
 disposition_text="$(<"$REPO_ROOT/skills/orch/references/finding-disposition.md")"
-assert_text_matches "$disposition_text" 'Size tripwire, enforced before fix delegation:' \
-  "finding disposition states the live enforcement point"
 
 scope_docs=(
   "$REPO_ROOT/skills/dev/workflows/dev-fix.md"


### PR DESCRIPTION
From the overseer's PR scan of the last two hours (report: tmp scratch, findings 4 and 8).

- `skills/orch/tests/dev_round_write.sh` pinned three sentences of workflow prose (the exit-3 routing line, the cut response, the enforcement point). The copy-and-sed mutation control in the same suite proves the mechanism; the pins only pinned wording. Render updated in the same commit.
- `changelog.d/added/KEN-1006.md` said thirteen checks; `run.py` registers five byte validators, three repo validators, `toml-schema` and `exclusion-consistency`: ten.

https://claude.ai/code/session_01PP5cxGjxdMFNH2fBGiaTwm