### PR TITLE
docs(KEN-1114): reviewer findings name the producer

### DIFF
--- a/.claude/agents/reviewer-arch.md
+++ b/.claude/agents/reviewer-arch.md
@@ -27,6 +27,8 @@ Compliance criteria come from the project's architecture docs — do not invent 
 - **Spec/proposal review** — when the change is a design document, audit the proposed mechanism itself: race windows (TOCTOU between pin and use), trust-boundary holes (who can alter the inputs a decision reads), enforcement-surface coverage (does the path/tier map reach every surface that can weaken a guard), and failure semantics (does a persistently missing dependency stay green forever).
 - **Technical debt**: accumulated debt worth naming, prioritized by impact; architecture docs drifting from actual structure.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Output
 
 Architecture violations, boundary breaches, spec holes → `blockers[]`. Tech debt observations, minor improvements → `suggestions[]`.

--- a/.claude/agents/reviewer-arch.md
+++ b/.claude/agents/reviewer-arch.md
@@ -27,7 +27,7 @@ Compliance criteria come from the project's architecture docs — do not invent 
 - **Spec/proposal review** — when the change is a design document, audit the proposed mechanism itself: race windows (TOCTOU between pin and use), trust-boundary holes (who can alter the inputs a decision reads), enforcement-surface coverage (does the path/tier map reach every surface that can weaken a guard), and failure semantics (does a persistently missing dependency stay green forever).
 - **Technical debt**: accumulated debt worth naming, prioritized by impact; architecture docs drifting from actual structure.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Output
 

--- a/.claude/agents/reviewer-arch.md
+++ b/.claude/agents/reviewer-arch.md
@@ -27,7 +27,7 @@ Compliance criteria come from the project's architecture docs — do not invent 
 - **Spec/proposal review** — when the change is a design document, audit the proposed mechanism itself: race windows (TOCTOU between pin and use), trust-boundary holes (who can alter the inputs a decision reads), enforcement-surface coverage (does the path/tier map reach every surface that can weaken a guard), and failure semantics (does a persistently missing dependency stay green forever).
 - **Technical debt**: accumulated debt worth naming, prioritized by impact; architecture docs drifting from actual structure.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Output
 

--- a/.claude/agents/reviewer-correctness.md
+++ b/.claude/agents/reviewer-correctness.md
@@ -26,7 +26,7 @@ Behavior regressions; API/CLI/contract compatibility (including two components i
 
 Leave to peers: exploitability (`reviewer-security`), error-path causes (`reviewer-error`), missing tests (`reviewer-test` — you report the bug, not the absent test), maintainability, perf, docs.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Boundary Probes
 

--- a/.claude/agents/reviewer-correctness.md
+++ b/.claude/agents/reviewer-correctness.md
@@ -26,7 +26,7 @@ Behavior regressions; API/CLI/contract compatibility (including two components i
 
 Leave to peers: exploitability (`reviewer-security`), error-path causes (`reviewer-error`), missing tests (`reviewer-test` — you report the bug, not the absent test), maintainability, perf, docs.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Boundary Probes
 

--- a/.claude/agents/reviewer-correctness.md
+++ b/.claude/agents/reviewer-correctness.md
@@ -26,6 +26,8 @@ Behavior regressions; API/CLI/contract compatibility (including two components i
 
 Leave to peers: exploitability (`reviewer-security`), error-path causes (`reviewer-error`), missing tests (`reviewer-test` — you report the bug, not the absent test), maintainability, perf, docs.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Boundary Probes
 
 For each changed predicate, parser, or guard, mentally execute:
@@ -57,7 +59,7 @@ When a change adds or modifies a type wrapping another (cache, proxy, decorator,
 
 ## Plausible by Default
 
-Never refute a finding as "speculative" or "depends on runtime state" when the state is realistic: a concurrency race; nil/undefined on a rare-but-reachable path (error handler, cold cache, missing optional field); a falsy zero treated as missing; an off-by-one on a boundary the code does not exclude; retry storms and partial failures; a regex or allowlist that lost an anchor. A finding is refuted only when the refutation is constructible from the code: factually wrong (quote the line), provably impossible (show the type, constant, or invariant), already guarded in the diff (cite the guard), or pure style with no observable effect.
+Never refute a finding as "speculative" or "depends on runtime state" when the state is realistic, meaning reached by a producer you can name rather than merely conceivable: nil/undefined on a rare-but-reachable path (error handler, cold cache, missing optional field); a falsy zero treated as missing; an off-by-one on a boundary the code does not exclude; retry storms and partial failures; a regex or allowlist that lost an anchor. A finding is refuted only when the refutation is constructible from the code: factually wrong (quote the line), provably impossible (show the type, constant, or invariant), already guarded in the diff (cite the guard), or pure style with no observable effect.
 
 ## Output
 

--- a/.claude/agents/reviewer-doc.md
+++ b/.claude/agents/reviewer-doc.md
@@ -30,7 +30,7 @@ The method is verification, not proofreading — **open the implementation behin
 - **Moved prose**: relocated help text, README, schema, and changelog prose is new prose — verify it sentence by sentence against the code it now describes, never against the file it moved from.
 - **Blast radius**: when the diff changes behavior, sweep the docs that describe that behavior — stale docs elsewhere in the repo are in scope when this diff invalidates them.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Output
 

--- a/.claude/agents/reviewer-doc.md
+++ b/.claude/agents/reviewer-doc.md
@@ -30,7 +30,7 @@ The method is verification, not proofreading — **open the implementation behin
 - **Moved prose**: relocated help text, README, schema, and changelog prose is new prose — verify it sentence by sentence against the code it now describes, never against the file it moved from.
 - **Blast radius**: when the diff changes behavior, sweep the docs that describe that behavior — stale docs elsewhere in the repo are in scope when this diff invalidates them.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Output
 

--- a/.claude/agents/reviewer-doc.md
+++ b/.claude/agents/reviewer-doc.md
@@ -30,6 +30,8 @@ The method is verification, not proofreading — **open the implementation behin
 - **Moved prose**: relocated help text, README, schema, and changelog prose is new prose — verify it sentence by sentence against the code it now describes, never against the file it moved from.
 - **Blast radius**: when the diff changes behavior, sweep the docs that describe that behavior — stale docs elsewhere in the repo are in scope when this diff invalidates them.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Output
 
 Wrong claims, wrong values, dead citations, contradicted invariants → `blockers[]`. Minor improvements → `suggestions[]`.

--- a/.claude/agents/reviewer-error.md
+++ b/.claude/agents/reviewer-error.md
@@ -24,7 +24,7 @@ Error paths that quietly convert failure into success. For every changed error/f
 
 Fail-open paths, silent failures, error propagation, fallback behavior, wrong-cause diagnostics, observability gaps. Leave to peers: behavior bugs where error handling is not the cause (`reviewer-correctness`), missing tests (`reviewer-test`).
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Fail-Open Catalogue
 

--- a/.claude/agents/reviewer-error.md
+++ b/.claude/agents/reviewer-error.md
@@ -24,7 +24,7 @@ Error paths that quietly convert failure into success. For every changed error/f
 
 Fail-open paths, silent failures, error propagation, fallback behavior, wrong-cause diagnostics, observability gaps. Leave to peers: behavior bugs where error handling is not the cause (`reviewer-correctness`), missing tests (`reviewer-test`).
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Fail-Open Catalogue
 

--- a/.claude/agents/reviewer-error.md
+++ b/.claude/agents/reviewer-error.md
@@ -24,6 +24,8 @@ Error paths that quietly convert failure into success. For every changed error/f
 
 Fail-open paths, silent failures, error propagation, fallback behavior, wrong-cause diagnostics, observability gaps. Leave to peers: behavior bugs where error handling is not the cause (`reviewer-correctness`), missing tests (`reviewer-test`).
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Fail-Open Catalogue
 
 Recurring shapes:

--- a/.claude/agents/reviewer-perf.md
+++ b/.claude/agents/reviewer-perf.md
@@ -26,7 +26,7 @@ Validate performance with evidence: benchmarks against baselines, project-define
 - **Hot-path cost review** of the diff: per-event work introduced on hot paths — synchronous I/O or re-parsing inside stream/event handlers, config re-read where a snapshot belongs, allocation churn in loops.
 - **Budget validation** against documented targets.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Output
 

--- a/.claude/agents/reviewer-perf.md
+++ b/.claude/agents/reviewer-perf.md
@@ -26,6 +26,8 @@ Validate performance with evidence: benchmarks against baselines, project-define
 - **Hot-path cost review** of the diff: per-event work introduced on hot paths — synchronous I/O or re-parsing inside stream/event handlers, config re-read where a snapshot belongs, allocation churn in loops.
 - **Budget validation** against documented targets.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Output
 
 Budget exceedances, classified regressions, hot-path cost introductions → `blockers[]`. Minor observations → `suggestions[]`.

--- a/.claude/agents/reviewer-perf.md
+++ b/.claude/agents/reviewer-perf.md
@@ -26,7 +26,7 @@ Validate performance with evidence: benchmarks against baselines, project-define
 - **Hot-path cost review** of the diff: per-event work introduced on hot paths — synchronous I/O or re-parsing inside stream/event handlers, config re-read where a snapshot belongs, allocation churn in loops.
 - **Budget validation** against documented targets.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Output
 

--- a/.claude/agents/reviewer-quality.md
+++ b/.claude/agents/reviewer-quality.md
@@ -24,7 +24,7 @@ Is the changed implementation simple, direct, easy to reason about, and aligned 
 
 Implementation maintainability of the reviewed scope: simplification, abstraction value, type/boundary clarity, canonical helper reuse, decomposition (god objects, files/functions this change makes materially harder to scan, tests located against convention). Raw file-size thresholds are deterministic (size-ratchet) — don't re-enforce them. Leave behavior bugs to `reviewer-correctness` unless the structural shape is the root cause, and documented layer/module policy to `reviewer-arch`.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Probes
 

--- a/.claude/agents/reviewer-quality.md
+++ b/.claude/agents/reviewer-quality.md
@@ -24,7 +24,7 @@ Is the changed implementation simple, direct, easy to reason about, and aligned 
 
 Implementation maintainability of the reviewed scope: simplification, abstraction value, type/boundary clarity, canonical helper reuse, decomposition (god objects, files/functions this change makes materially harder to scan, tests located against convention). Raw file-size thresholds are deterministic (size-ratchet) — don't re-enforce them. Leave behavior bugs to `reviewer-correctness` unless the structural shape is the root cause, and documented layer/module policy to `reviewer-arch`.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Probes
 

--- a/.claude/agents/reviewer-quality.md
+++ b/.claude/agents/reviewer-quality.md
@@ -24,6 +24,8 @@ Is the changed implementation simple, direct, easy to reason about, and aligned 
 
 Implementation maintainability of the reviewed scope: simplification, abstraction value, type/boundary clarity, canonical helper reuse, decomposition (god objects, files/functions this change makes materially harder to scan, tests located against convention). Raw file-size thresholds are deterministic (size-ratchet) — don't re-enforce them. Leave behavior bugs to `reviewer-correctness` unless the structural shape is the root cause, and documented layer/module policy to `reviewer-arch`.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Probes
 
 - **Mechanism over shapes**: a fix that patches the Nth instance of a pattern instead of the mechanism producing them. Recommend the structural fix that closes the class.

--- a/.claude/agents/reviewer-safety.md
+++ b/.claude/agents/reviewer-safety.md
@@ -27,7 +27,7 @@ Memory and thread safety in compiled code, AND concurrency of processes and file
 - **File/process races**: TOCTOU (existence check separate from the effectful operation), non-atomic multi-file updates, signals to possibly-reused PIDs, teardown awaits without deadlines that can hang exit. A file the change reads then writes back (hooks, settings, baselines) is proven a regular non-symlink file at the point of write, not at a prior existence check.
 - **Lock-free**: atomic ordering, ABA, memory reclamation.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Rust Rules
 

--- a/.claude/agents/reviewer-safety.md
+++ b/.claude/agents/reviewer-safety.md
@@ -27,7 +27,7 @@ Memory and thread safety in compiled code, AND concurrency of processes and file
 - **File/process races**: TOCTOU (existence check separate from the effectful operation), non-atomic multi-file updates, signals to possibly-reused PIDs, teardown awaits without deadlines that can hang exit. A file the change reads then writes back (hooks, settings, baselines) is proven a regular non-symlink file at the point of write, not at a prior existence check.
 - **Lock-free**: atomic ordering, ABA, memory reclamation.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Rust Rules
 

--- a/.claude/agents/reviewer-safety.md
+++ b/.claude/agents/reviewer-safety.md
@@ -24,8 +24,10 @@ Memory and thread safety in compiled code, AND concurrency of processes and file
 
 - **Unsafe/UB**: blocks bypassing language guarantees; aliasing, uninitialized memory, type punning; buffer overflows, use-after-free, null dereference.
 - **Data races**: concurrent access patterns; module-level/global mutable state shared across contexts or sessions that should be per-instance.
-- **File/process races**: TOCTOU (existence check separate from the effectful operation; check-then-`mv` where a concurrent writer silently wins), non-atomic multi-file updates, signals to possibly-reused PIDs, teardown awaits without deadlines that can hang exit. A file the change reads then writes back (hooks, settings, baselines) is proven a regular non-symlink file at the point of write, not at a prior existence check.
+- **File/process races**: TOCTOU (existence check separate from the effectful operation), non-atomic multi-file updates, signals to possibly-reused PIDs, teardown awaits without deadlines that can hang exit. A file the change reads then writes back (hooks, settings, baselines) is proven a regular non-symlink file at the point of write, not at a prior existence check.
 - **Lock-free**: atomic ordering, ABA, memory reclamation.
+
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
 
 ## Rust Rules
 

--- a/.claude/agents/reviewer-security.md
+++ b/.claude/agents/reviewer-security.md
@@ -29,6 +29,8 @@ Vulnerability classes (injection, broken auth/authz, data exposure, XSS/CSRF, pr
 - **Secret exposure**: credentials or userinfo-bearing URLs reaching logs, diagnostics, or error output; automation that can sweep uncontrolled local edits (and their secrets) into commits.
 - **Untrusted input in control position**: attacker-controlled filenames/branches/settings echoed into shells, workflow commands, or evaluated config; code or config loaded from a reviewed-but-untrusted tree.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Output
 
 Vulnerabilities, gating gaps, containment escapes, secret exposure → `blockers[]`. Hardening → `suggestions[]`.

--- a/.claude/agents/reviewer-security.md
+++ b/.claude/agents/reviewer-security.md
@@ -29,7 +29,7 @@ Vulnerability classes (injection, broken auth/authz, data exposure, XSS/CSRF, pr
 - **Secret exposure**: credentials or userinfo-bearing URLs reaching logs, diagnostics, or error output; automation that can sweep uncontrolled local edits (and their secrets) into commits.
 - **Untrusted input in control position**: attacker-controlled filenames/branches/settings echoed into shells, workflow commands, or evaluated config; code or config loaded from a reviewed-but-untrusted tree.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Output
 

--- a/.claude/agents/reviewer-security.md
+++ b/.claude/agents/reviewer-security.md
@@ -29,7 +29,7 @@ Vulnerability classes (injection, broken auth/authz, data exposure, XSS/CSRF, pr
 - **Secret exposure**: credentials or userinfo-bearing URLs reaching logs, diagnostics, or error output; automation that can sweep uncontrolled local edits (and their secrets) into commits.
 - **Untrusted input in control position**: attacker-controlled filenames/branches/settings echoed into shells, workflow commands, or evaluated config; code or config loaded from a reviewed-but-untrusted tree.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Output
 

--- a/.claude/agents/reviewer-test.md
+++ b/.claude/agents/reviewer-test.md
@@ -24,7 +24,7 @@ The highest-value question is not "is there a test?" but "**can this test still 
 
 Coverage of changed paths (branches, error paths, boundaries), test quality, determinism, environment assumptions. Leave the underlying product bug to `reviewer-correctness` — you report the missing or weak test. Demand tests that catch real bugs, not coverage theater.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Probes
 

--- a/.claude/agents/reviewer-test.md
+++ b/.claude/agents/reviewer-test.md
@@ -24,7 +24,7 @@ The highest-value question is not "is there a test?" but "**can this test still 
 
 Coverage of changed paths (branches, error paths, boundaries), test quality, determinism, environment assumptions. Leave the underlying product bug to `reviewer-correctness` — you report the missing or weak test. Demand tests that catch real bugs, not coverage theater.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Probes
 

--- a/.claude/agents/reviewer-test.md
+++ b/.claude/agents/reviewer-test.md
@@ -24,6 +24,8 @@ The highest-value question is not "is there a test?" but "**can this test still 
 
 Coverage of changed paths (branches, error paths, boundaries), test quality, determinism, environment assumptions. Leave the underlying product bug to `reviewer-correctness` — you report the missing or weak test. Demand tests that catch real bugs, not coverage theater.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Probes
 
 - **Must-fail control**: every NEW test, guard arm, or verdict path must be shown able to fail — a planted-defect fixture, red-first evidence, or a mutation check. A guard nobody has seen fail is unverified. A control that deletes the code under test only proves the assertion runs; for any guard matching source text, the required control is the inverse — keep the matched text, remove the behavior — and the guard must still fail. Plant every satisfied-but-inert form the scanned language allows: a comment, a string or template-literal interior, a nested occurrence, alternate quoting, a braceless statement, a dead `&& false` branch, a discarded result, and a textually earlier but unrelated conditional. Authoring copy: `.agents/skills/code-quality/SKILL.md` § Prove Your Guards.

--- a/.codex/agents/reviewer-arch.toml
+++ b/.codex/agents/reviewer-arch.toml
@@ -22,6 +22,8 @@ Compliance criteria come from the project's architecture docs — do not invent 
 - **Spec/proposal review** — when the change is a design document, audit the proposed mechanism itself: race windows (TOCTOU between pin and use), trust-boundary holes (who can alter the inputs a decision reads), enforcement-surface coverage (does the path/tier map reach every surface that can weaken a guard), and failure semantics (does a persistently missing dependency stay green forever).
 - **Technical debt**: accumulated debt worth naming, prioritized by impact; architecture docs drifting from actual structure.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Output
 
 Architecture violations, boundary breaches, spec holes → `blockers[]`. Tech debt observations, minor improvements → `suggestions[]`.

--- a/.codex/agents/reviewer-arch.toml
+++ b/.codex/agents/reviewer-arch.toml
@@ -22,7 +22,7 @@ Compliance criteria come from the project's architecture docs — do not invent 
 - **Spec/proposal review** — when the change is a design document, audit the proposed mechanism itself: race windows (TOCTOU between pin and use), trust-boundary holes (who can alter the inputs a decision reads), enforcement-surface coverage (does the path/tier map reach every surface that can weaken a guard), and failure semantics (does a persistently missing dependency stay green forever).
 - **Technical debt**: accumulated debt worth naming, prioritized by impact; architecture docs drifting from actual structure.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Output
 

--- a/.codex/agents/reviewer-arch.toml
+++ b/.codex/agents/reviewer-arch.toml
@@ -22,7 +22,7 @@ Compliance criteria come from the project's architecture docs — do not invent 
 - **Spec/proposal review** — when the change is a design document, audit the proposed mechanism itself: race windows (TOCTOU between pin and use), trust-boundary holes (who can alter the inputs a decision reads), enforcement-surface coverage (does the path/tier map reach every surface that can weaken a guard), and failure semantics (does a persistently missing dependency stay green forever).
 - **Technical debt**: accumulated debt worth naming, prioritized by impact; architecture docs drifting from actual structure.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Output
 

--- a/.codex/agents/reviewer-correctness.toml
+++ b/.codex/agents/reviewer-correctness.toml
@@ -21,6 +21,8 @@ Behavior regressions; API/CLI/contract compatibility (including two components i
 
 Leave to peers: exploitability (`reviewer-security`), error-path causes (`reviewer-error`), missing tests (`reviewer-test` — you report the bug, not the absent test), maintainability, perf, docs.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Boundary Probes
 
 For each changed predicate, parser, or guard, mentally execute:
@@ -52,7 +54,7 @@ When a change adds or modifies a type wrapping another (cache, proxy, decorator,
 
 ## Plausible by Default
 
-Never refute a finding as "speculative" or "depends on runtime state" when the state is realistic: a concurrency race; nil/undefined on a rare-but-reachable path (error handler, cold cache, missing optional field); a falsy zero treated as missing; an off-by-one on a boundary the code does not exclude; retry storms and partial failures; a regex or allowlist that lost an anchor. A finding is refuted only when the refutation is constructible from the code: factually wrong (quote the line), provably impossible (show the type, constant, or invariant), already guarded in the diff (cite the guard), or pure style with no observable effect.
+Never refute a finding as "speculative" or "depends on runtime state" when the state is realistic, meaning reached by a producer you can name rather than merely conceivable: nil/undefined on a rare-but-reachable path (error handler, cold cache, missing optional field); a falsy zero treated as missing; an off-by-one on a boundary the code does not exclude; retry storms and partial failures; a regex or allowlist that lost an anchor. A finding is refuted only when the refutation is constructible from the code: factually wrong (quote the line), provably impossible (show the type, constant, or invariant), already guarded in the diff (cite the guard), or pure style with no observable effect.
 
 ## Output
 

--- a/.codex/agents/reviewer-correctness.toml
+++ b/.codex/agents/reviewer-correctness.toml
@@ -21,7 +21,7 @@ Behavior regressions; API/CLI/contract compatibility (including two components i
 
 Leave to peers: exploitability (`reviewer-security`), error-path causes (`reviewer-error`), missing tests (`reviewer-test` — you report the bug, not the absent test), maintainability, perf, docs.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Boundary Probes
 

--- a/.codex/agents/reviewer-correctness.toml
+++ b/.codex/agents/reviewer-correctness.toml
@@ -21,7 +21,7 @@ Behavior regressions; API/CLI/contract compatibility (including two components i
 
 Leave to peers: exploitability (`reviewer-security`), error-path causes (`reviewer-error`), missing tests (`reviewer-test` — you report the bug, not the absent test), maintainability, perf, docs.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Boundary Probes
 

--- a/.codex/agents/reviewer-doc.toml
+++ b/.codex/agents/reviewer-doc.toml
@@ -25,6 +25,8 @@ The method is verification, not proofreading — **open the implementation behin
 - **Moved prose**: relocated help text, README, schema, and changelog prose is new prose — verify it sentence by sentence against the code it now describes, never against the file it moved from.
 - **Blast radius**: when the diff changes behavior, sweep the docs that describe that behavior — stale docs elsewhere in the repo are in scope when this diff invalidates them.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Output
 
 Wrong claims, wrong values, dead citations, contradicted invariants → `blockers[]`. Minor improvements → `suggestions[]`.

--- a/.codex/agents/reviewer-doc.toml
+++ b/.codex/agents/reviewer-doc.toml
@@ -25,7 +25,7 @@ The method is verification, not proofreading — **open the implementation behin
 - **Moved prose**: relocated help text, README, schema, and changelog prose is new prose — verify it sentence by sentence against the code it now describes, never against the file it moved from.
 - **Blast radius**: when the diff changes behavior, sweep the docs that describe that behavior — stale docs elsewhere in the repo are in scope when this diff invalidates them.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Output
 

--- a/.codex/agents/reviewer-doc.toml
+++ b/.codex/agents/reviewer-doc.toml
@@ -25,7 +25,7 @@ The method is verification, not proofreading — **open the implementation behin
 - **Moved prose**: relocated help text, README, schema, and changelog prose is new prose — verify it sentence by sentence against the code it now describes, never against the file it moved from.
 - **Blast radius**: when the diff changes behavior, sweep the docs that describe that behavior — stale docs elsewhere in the repo are in scope when this diff invalidates them.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Output
 

--- a/.codex/agents/reviewer-error.toml
+++ b/.codex/agents/reviewer-error.toml
@@ -19,7 +19,7 @@ Error paths that quietly convert failure into success. For every changed error/f
 
 Fail-open paths, silent failures, error propagation, fallback behavior, wrong-cause diagnostics, observability gaps. Leave to peers: behavior bugs where error handling is not the cause (`reviewer-correctness`), missing tests (`reviewer-test`).
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Fail-Open Catalogue
 

--- a/.codex/agents/reviewer-error.toml
+++ b/.codex/agents/reviewer-error.toml
@@ -19,6 +19,8 @@ Error paths that quietly convert failure into success. For every changed error/f
 
 Fail-open paths, silent failures, error propagation, fallback behavior, wrong-cause diagnostics, observability gaps. Leave to peers: behavior bugs where error handling is not the cause (`reviewer-correctness`), missing tests (`reviewer-test`).
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Fail-Open Catalogue
 
 Recurring shapes:

--- a/.codex/agents/reviewer-error.toml
+++ b/.codex/agents/reviewer-error.toml
@@ -19,7 +19,7 @@ Error paths that quietly convert failure into success. For every changed error/f
 
 Fail-open paths, silent failures, error propagation, fallback behavior, wrong-cause diagnostics, observability gaps. Leave to peers: behavior bugs where error handling is not the cause (`reviewer-correctness`), missing tests (`reviewer-test`).
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Fail-Open Catalogue
 

--- a/.codex/agents/reviewer-perf.toml
+++ b/.codex/agents/reviewer-perf.toml
@@ -21,6 +21,8 @@ Validate performance with evidence: benchmarks against baselines, project-define
 - **Hot-path cost review** of the diff: per-event work introduced on hot paths — synchronous I/O or re-parsing inside stream/event handlers, config re-read where a snapshot belongs, allocation churn in loops.
 - **Budget validation** against documented targets.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Output
 
 Budget exceedances, classified regressions, hot-path cost introductions → `blockers[]`. Minor observations → `suggestions[]`.

--- a/.codex/agents/reviewer-perf.toml
+++ b/.codex/agents/reviewer-perf.toml
@@ -21,7 +21,7 @@ Validate performance with evidence: benchmarks against baselines, project-define
 - **Hot-path cost review** of the diff: per-event work introduced on hot paths — synchronous I/O or re-parsing inside stream/event handlers, config re-read where a snapshot belongs, allocation churn in loops.
 - **Budget validation** against documented targets.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Output
 

--- a/.codex/agents/reviewer-perf.toml
+++ b/.codex/agents/reviewer-perf.toml
@@ -21,7 +21,7 @@ Validate performance with evidence: benchmarks against baselines, project-define
 - **Hot-path cost review** of the diff: per-event work introduced on hot paths — synchronous I/O or re-parsing inside stream/event handlers, config re-read where a snapshot belongs, allocation churn in loops.
 - **Budget validation** against documented targets.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Output
 

--- a/.codex/agents/reviewer-quality.toml
+++ b/.codex/agents/reviewer-quality.toml
@@ -19,6 +19,8 @@ Is the changed implementation simple, direct, easy to reason about, and aligned 
 
 Implementation maintainability of the reviewed scope: simplification, abstraction value, type/boundary clarity, canonical helper reuse, decomposition (god objects, files/functions this change makes materially harder to scan, tests located against convention). Raw file-size thresholds are deterministic (size-ratchet) — don't re-enforce them. Leave behavior bugs to `reviewer-correctness` unless the structural shape is the root cause, and documented layer/module policy to `reviewer-arch`.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Probes
 
 - **Mechanism over shapes**: a fix that patches the Nth instance of a pattern instead of the mechanism producing them. Recommend the structural fix that closes the class.

--- a/.codex/agents/reviewer-quality.toml
+++ b/.codex/agents/reviewer-quality.toml
@@ -19,7 +19,7 @@ Is the changed implementation simple, direct, easy to reason about, and aligned 
 
 Implementation maintainability of the reviewed scope: simplification, abstraction value, type/boundary clarity, canonical helper reuse, decomposition (god objects, files/functions this change makes materially harder to scan, tests located against convention). Raw file-size thresholds are deterministic (size-ratchet) — don't re-enforce them. Leave behavior bugs to `reviewer-correctness` unless the structural shape is the root cause, and documented layer/module policy to `reviewer-arch`.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Probes
 

--- a/.codex/agents/reviewer-quality.toml
+++ b/.codex/agents/reviewer-quality.toml
@@ -19,7 +19,7 @@ Is the changed implementation simple, direct, easy to reason about, and aligned 
 
 Implementation maintainability of the reviewed scope: simplification, abstraction value, type/boundary clarity, canonical helper reuse, decomposition (god objects, files/functions this change makes materially harder to scan, tests located against convention). Raw file-size thresholds are deterministic (size-ratchet) — don't re-enforce them. Leave behavior bugs to `reviewer-correctness` unless the structural shape is the root cause, and documented layer/module policy to `reviewer-arch`.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Probes
 

--- a/.codex/agents/reviewer-safety.toml
+++ b/.codex/agents/reviewer-safety.toml
@@ -22,7 +22,7 @@ Memory and thread safety in compiled code, AND concurrency of processes and file
 - **File/process races**: TOCTOU (existence check separate from the effectful operation), non-atomic multi-file updates, signals to possibly-reused PIDs, teardown awaits without deadlines that can hang exit. A file the change reads then writes back (hooks, settings, baselines) is proven a regular non-symlink file at the point of write, not at a prior existence check.
 - **Lock-free**: atomic ordering, ABA, memory reclamation.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Rust Rules
 

--- a/.codex/agents/reviewer-safety.toml
+++ b/.codex/agents/reviewer-safety.toml
@@ -19,8 +19,10 @@ Memory and thread safety in compiled code, AND concurrency of processes and file
 
 - **Unsafe/UB**: blocks bypassing language guarantees; aliasing, uninitialized memory, type punning; buffer overflows, use-after-free, null dereference.
 - **Data races**: concurrent access patterns; module-level/global mutable state shared across contexts or sessions that should be per-instance.
-- **File/process races**: TOCTOU (existence check separate from the effectful operation; check-then-`mv` where a concurrent writer silently wins), non-atomic multi-file updates, signals to possibly-reused PIDs, teardown awaits without deadlines that can hang exit. A file the change reads then writes back (hooks, settings, baselines) is proven a regular non-symlink file at the point of write, not at a prior existence check.
+- **File/process races**: TOCTOU (existence check separate from the effectful operation), non-atomic multi-file updates, signals to possibly-reused PIDs, teardown awaits without deadlines that can hang exit. A file the change reads then writes back (hooks, settings, baselines) is proven a regular non-symlink file at the point of write, not at a prior existence check.
 - **Lock-free**: atomic ordering, ABA, memory reclamation.
+
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
 
 ## Rust Rules
 

--- a/.codex/agents/reviewer-safety.toml
+++ b/.codex/agents/reviewer-safety.toml
@@ -22,7 +22,7 @@ Memory and thread safety in compiled code, AND concurrency of processes and file
 - **File/process races**: TOCTOU (existence check separate from the effectful operation), non-atomic multi-file updates, signals to possibly-reused PIDs, teardown awaits without deadlines that can hang exit. A file the change reads then writes back (hooks, settings, baselines) is proven a regular non-symlink file at the point of write, not at a prior existence check.
 - **Lock-free**: atomic ordering, ABA, memory reclamation.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Rust Rules
 

--- a/.codex/agents/reviewer-security.toml
+++ b/.codex/agents/reviewer-security.toml
@@ -24,7 +24,7 @@ Vulnerability classes (injection, broken auth/authz, data exposure, XSS/CSRF, pr
 - **Secret exposure**: credentials or userinfo-bearing URLs reaching logs, diagnostics, or error output; automation that can sweep uncontrolled local edits (and their secrets) into commits.
 - **Untrusted input in control position**: attacker-controlled filenames/branches/settings echoed into shells, workflow commands, or evaluated config; code or config loaded from a reviewed-but-untrusted tree.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Output
 

--- a/.codex/agents/reviewer-security.toml
+++ b/.codex/agents/reviewer-security.toml
@@ -24,7 +24,7 @@ Vulnerability classes (injection, broken auth/authz, data exposure, XSS/CSRF, pr
 - **Secret exposure**: credentials or userinfo-bearing URLs reaching logs, diagnostics, or error output; automation that can sweep uncontrolled local edits (and their secrets) into commits.
 - **Untrusted input in control position**: attacker-controlled filenames/branches/settings echoed into shells, workflow commands, or evaluated config; code or config loaded from a reviewed-but-untrusted tree.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Output
 

--- a/.codex/agents/reviewer-security.toml
+++ b/.codex/agents/reviewer-security.toml
@@ -24,6 +24,8 @@ Vulnerability classes (injection, broken auth/authz, data exposure, XSS/CSRF, pr
 - **Secret exposure**: credentials or userinfo-bearing URLs reaching logs, diagnostics, or error output; automation that can sweep uncontrolled local edits (and their secrets) into commits.
 - **Untrusted input in control position**: attacker-controlled filenames/branches/settings echoed into shells, workflow commands, or evaluated config; code or config loaded from a reviewed-but-untrusted tree.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Output
 
 Vulnerabilities, gating gaps, containment escapes, secret exposure → `blockers[]`. Hardening → `suggestions[]`.

--- a/.codex/agents/reviewer-test.toml
+++ b/.codex/agents/reviewer-test.toml
@@ -19,6 +19,8 @@ The highest-value question is not "is there a test?" but "**can this test still 
 
 Coverage of changed paths (branches, error paths, boundaries), test quality, determinism, environment assumptions. Leave the underlying product bug to `reviewer-correctness` — you report the missing or weak test. Demand tests that catch real bugs, not coverage theater.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Probes
 
 - **Must-fail control**: every NEW test, guard arm, or verdict path must be shown able to fail — a planted-defect fixture, red-first evidence, or a mutation check. A guard nobody has seen fail is unverified. A control that deletes the code under test only proves the assertion runs; for any guard matching source text, the required control is the inverse — keep the matched text, remove the behavior — and the guard must still fail. Plant every satisfied-but-inert form the scanned language allows: a comment, a string or template-literal interior, a nested occurrence, alternate quoting, a braceless statement, a dead `&& false` branch, a discarded result, and a textually earlier but unrelated conditional. Authoring copy: `.agents/skills/code-quality/SKILL.md` § Prove Your Guards.

--- a/.codex/agents/reviewer-test.toml
+++ b/.codex/agents/reviewer-test.toml
@@ -19,7 +19,7 @@ The highest-value question is not "is there a test?" but "**can this test still 
 
 Coverage of changed paths (branches, error paths, boundaries), test quality, determinism, environment assumptions. Leave the underlying product bug to `reviewer-correctness` — you report the missing or weak test. Demand tests that catch real bugs, not coverage theater.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Probes
 

--- a/.codex/agents/reviewer-test.toml
+++ b/.codex/agents/reviewer-test.toml
@@ -19,7 +19,7 @@ The highest-value question is not "is there a test?" but "**can this test still 
 
 Coverage of changed paths (branches, error paths, boundaries), test quality, determinism, environment assumptions. Leave the underlying product bug to `reviewer-correctness` — you report the missing or weak test. Demand tests that catch real bugs, not coverage theater.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Probes
 

--- a/.pi/agents/reviewer-arch.md
+++ b/.pi/agents/reviewer-arch.md
@@ -23,7 +23,7 @@ Compliance criteria come from the project's architecture docs — do not invent 
 - **Spec/proposal review** — when the change is a design document, audit the proposed mechanism itself: race windows (TOCTOU between pin and use), trust-boundary holes (who can alter the inputs a decision reads), enforcement-surface coverage (does the path/tier map reach every surface that can weaken a guard), and failure semantics (does a persistently missing dependency stay green forever).
 - **Technical debt**: accumulated debt worth naming, prioritized by impact; architecture docs drifting from actual structure.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Output
 

--- a/.pi/agents/reviewer-arch.md
+++ b/.pi/agents/reviewer-arch.md
@@ -23,6 +23,8 @@ Compliance criteria come from the project's architecture docs — do not invent 
 - **Spec/proposal review** — when the change is a design document, audit the proposed mechanism itself: race windows (TOCTOU between pin and use), trust-boundary holes (who can alter the inputs a decision reads), enforcement-surface coverage (does the path/tier map reach every surface that can weaken a guard), and failure semantics (does a persistently missing dependency stay green forever).
 - **Technical debt**: accumulated debt worth naming, prioritized by impact; architecture docs drifting from actual structure.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Output
 
 Architecture violations, boundary breaches, spec holes → `blockers[]`. Tech debt observations, minor improvements → `suggestions[]`.

--- a/.pi/agents/reviewer-arch.md
+++ b/.pi/agents/reviewer-arch.md
@@ -23,7 +23,7 @@ Compliance criteria come from the project's architecture docs — do not invent 
 - **Spec/proposal review** — when the change is a design document, audit the proposed mechanism itself: race windows (TOCTOU between pin and use), trust-boundary holes (who can alter the inputs a decision reads), enforcement-surface coverage (does the path/tier map reach every surface that can weaken a guard), and failure semantics (does a persistently missing dependency stay green forever).
 - **Technical debt**: accumulated debt worth naming, prioritized by impact; architecture docs drifting from actual structure.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Output
 

--- a/.pi/agents/reviewer-correctness.md
+++ b/.pi/agents/reviewer-correctness.md
@@ -22,7 +22,7 @@ Behavior regressions; API/CLI/contract compatibility (including two components i
 
 Leave to peers: exploitability (`reviewer-security`), error-path causes (`reviewer-error`), missing tests (`reviewer-test` — you report the bug, not the absent test), maintainability, perf, docs.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Boundary Probes
 

--- a/.pi/agents/reviewer-correctness.md
+++ b/.pi/agents/reviewer-correctness.md
@@ -22,6 +22,8 @@ Behavior regressions; API/CLI/contract compatibility (including two components i
 
 Leave to peers: exploitability (`reviewer-security`), error-path causes (`reviewer-error`), missing tests (`reviewer-test` — you report the bug, not the absent test), maintainability, perf, docs.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Boundary Probes
 
 For each changed predicate, parser, or guard, mentally execute:
@@ -53,7 +55,7 @@ When a change adds or modifies a type wrapping another (cache, proxy, decorator,
 
 ## Plausible by Default
 
-Never refute a finding as "speculative" or "depends on runtime state" when the state is realistic: a concurrency race; nil/undefined on a rare-but-reachable path (error handler, cold cache, missing optional field); a falsy zero treated as missing; an off-by-one on a boundary the code does not exclude; retry storms and partial failures; a regex or allowlist that lost an anchor. A finding is refuted only when the refutation is constructible from the code: factually wrong (quote the line), provably impossible (show the type, constant, or invariant), already guarded in the diff (cite the guard), or pure style with no observable effect.
+Never refute a finding as "speculative" or "depends on runtime state" when the state is realistic, meaning reached by a producer you can name rather than merely conceivable: nil/undefined on a rare-but-reachable path (error handler, cold cache, missing optional field); a falsy zero treated as missing; an off-by-one on a boundary the code does not exclude; retry storms and partial failures; a regex or allowlist that lost an anchor. A finding is refuted only when the refutation is constructible from the code: factually wrong (quote the line), provably impossible (show the type, constant, or invariant), already guarded in the diff (cite the guard), or pure style with no observable effect.
 
 ## Output
 

--- a/.pi/agents/reviewer-correctness.md
+++ b/.pi/agents/reviewer-correctness.md
@@ -22,7 +22,7 @@ Behavior regressions; API/CLI/contract compatibility (including two components i
 
 Leave to peers: exploitability (`reviewer-security`), error-path causes (`reviewer-error`), missing tests (`reviewer-test` — you report the bug, not the absent test), maintainability, perf, docs.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Boundary Probes
 

--- a/.pi/agents/reviewer-doc.md
+++ b/.pi/agents/reviewer-doc.md
@@ -26,7 +26,7 @@ The method is verification, not proofreading — **open the implementation behin
 - **Moved prose**: relocated help text, README, schema, and changelog prose is new prose — verify it sentence by sentence against the code it now describes, never against the file it moved from.
 - **Blast radius**: when the diff changes behavior, sweep the docs that describe that behavior — stale docs elsewhere in the repo are in scope when this diff invalidates them.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Output
 

--- a/.pi/agents/reviewer-doc.md
+++ b/.pi/agents/reviewer-doc.md
@@ -26,7 +26,7 @@ The method is verification, not proofreading — **open the implementation behin
 - **Moved prose**: relocated help text, README, schema, and changelog prose is new prose — verify it sentence by sentence against the code it now describes, never against the file it moved from.
 - **Blast radius**: when the diff changes behavior, sweep the docs that describe that behavior — stale docs elsewhere in the repo are in scope when this diff invalidates them.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Output
 

--- a/.pi/agents/reviewer-doc.md
+++ b/.pi/agents/reviewer-doc.md
@@ -26,6 +26,8 @@ The method is verification, not proofreading — **open the implementation behin
 - **Moved prose**: relocated help text, README, schema, and changelog prose is new prose — verify it sentence by sentence against the code it now describes, never against the file it moved from.
 - **Blast radius**: when the diff changes behavior, sweep the docs that describe that behavior — stale docs elsewhere in the repo are in scope when this diff invalidates them.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Output
 
 Wrong claims, wrong values, dead citations, contradicted invariants → `blockers[]`. Minor improvements → `suggestions[]`.

--- a/.pi/agents/reviewer-error.md
+++ b/.pi/agents/reviewer-error.md
@@ -20,6 +20,8 @@ Error paths that quietly convert failure into success. For every changed error/f
 
 Fail-open paths, silent failures, error propagation, fallback behavior, wrong-cause diagnostics, observability gaps. Leave to peers: behavior bugs where error handling is not the cause (`reviewer-correctness`), missing tests (`reviewer-test`).
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Fail-Open Catalogue
 
 Recurring shapes:

--- a/.pi/agents/reviewer-error.md
+++ b/.pi/agents/reviewer-error.md
@@ -20,7 +20,7 @@ Error paths that quietly convert failure into success. For every changed error/f
 
 Fail-open paths, silent failures, error propagation, fallback behavior, wrong-cause diagnostics, observability gaps. Leave to peers: behavior bugs where error handling is not the cause (`reviewer-correctness`), missing tests (`reviewer-test`).
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Fail-Open Catalogue
 

--- a/.pi/agents/reviewer-error.md
+++ b/.pi/agents/reviewer-error.md
@@ -20,7 +20,7 @@ Error paths that quietly convert failure into success. For every changed error/f
 
 Fail-open paths, silent failures, error propagation, fallback behavior, wrong-cause diagnostics, observability gaps. Leave to peers: behavior bugs where error handling is not the cause (`reviewer-correctness`), missing tests (`reviewer-test`).
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Fail-Open Catalogue
 

--- a/.pi/agents/reviewer-perf.md
+++ b/.pi/agents/reviewer-perf.md
@@ -22,6 +22,8 @@ Validate performance with evidence: benchmarks against baselines, project-define
 - **Hot-path cost review** of the diff: per-event work introduced on hot paths — synchronous I/O or re-parsing inside stream/event handlers, config re-read where a snapshot belongs, allocation churn in loops.
 - **Budget validation** against documented targets.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Output
 
 Budget exceedances, classified regressions, hot-path cost introductions → `blockers[]`. Minor observations → `suggestions[]`.

--- a/.pi/agents/reviewer-perf.md
+++ b/.pi/agents/reviewer-perf.md
@@ -22,7 +22,7 @@ Validate performance with evidence: benchmarks against baselines, project-define
 - **Hot-path cost review** of the diff: per-event work introduced on hot paths — synchronous I/O or re-parsing inside stream/event handlers, config re-read where a snapshot belongs, allocation churn in loops.
 - **Budget validation** against documented targets.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Output
 

--- a/.pi/agents/reviewer-perf.md
+++ b/.pi/agents/reviewer-perf.md
@@ -22,7 +22,7 @@ Validate performance with evidence: benchmarks against baselines, project-define
 - **Hot-path cost review** of the diff: per-event work introduced on hot paths — synchronous I/O or re-parsing inside stream/event handlers, config re-read where a snapshot belongs, allocation churn in loops.
 - **Budget validation** against documented targets.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Output
 

--- a/.pi/agents/reviewer-quality.md
+++ b/.pi/agents/reviewer-quality.md
@@ -20,6 +20,8 @@ Is the changed implementation simple, direct, easy to reason about, and aligned 
 
 Implementation maintainability of the reviewed scope: simplification, abstraction value, type/boundary clarity, canonical helper reuse, decomposition (god objects, files/functions this change makes materially harder to scan, tests located against convention). Raw file-size thresholds are deterministic (size-ratchet) — don't re-enforce them. Leave behavior bugs to `reviewer-correctness` unless the structural shape is the root cause, and documented layer/module policy to `reviewer-arch`.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Probes
 
 - **Mechanism over shapes**: a fix that patches the Nth instance of a pattern instead of the mechanism producing them. Recommend the structural fix that closes the class.

--- a/.pi/agents/reviewer-quality.md
+++ b/.pi/agents/reviewer-quality.md
@@ -20,7 +20,7 @@ Is the changed implementation simple, direct, easy to reason about, and aligned 
 
 Implementation maintainability of the reviewed scope: simplification, abstraction value, type/boundary clarity, canonical helper reuse, decomposition (god objects, files/functions this change makes materially harder to scan, tests located against convention). Raw file-size thresholds are deterministic (size-ratchet) — don't re-enforce them. Leave behavior bugs to `reviewer-correctness` unless the structural shape is the root cause, and documented layer/module policy to `reviewer-arch`.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Probes
 

--- a/.pi/agents/reviewer-quality.md
+++ b/.pi/agents/reviewer-quality.md
@@ -20,7 +20,7 @@ Is the changed implementation simple, direct, easy to reason about, and aligned 
 
 Implementation maintainability of the reviewed scope: simplification, abstraction value, type/boundary clarity, canonical helper reuse, decomposition (god objects, files/functions this change makes materially harder to scan, tests located against convention). Raw file-size thresholds are deterministic (size-ratchet) — don't re-enforce them. Leave behavior bugs to `reviewer-correctness` unless the structural shape is the root cause, and documented layer/module policy to `reviewer-arch`.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Probes
 

--- a/.pi/agents/reviewer-safety.md
+++ b/.pi/agents/reviewer-safety.md
@@ -23,7 +23,7 @@ Memory and thread safety in compiled code, AND concurrency of processes and file
 - **File/process races**: TOCTOU (existence check separate from the effectful operation), non-atomic multi-file updates, signals to possibly-reused PIDs, teardown awaits without deadlines that can hang exit. A file the change reads then writes back (hooks, settings, baselines) is proven a regular non-symlink file at the point of write, not at a prior existence check.
 - **Lock-free**: atomic ordering, ABA, memory reclamation.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Rust Rules
 

--- a/.pi/agents/reviewer-safety.md
+++ b/.pi/agents/reviewer-safety.md
@@ -20,8 +20,10 @@ Memory and thread safety in compiled code, AND concurrency of processes and file
 
 - **Unsafe/UB**: blocks bypassing language guarantees; aliasing, uninitialized memory, type punning; buffer overflows, use-after-free, null dereference.
 - **Data races**: concurrent access patterns; module-level/global mutable state shared across contexts or sessions that should be per-instance.
-- **File/process races**: TOCTOU (existence check separate from the effectful operation; check-then-`mv` where a concurrent writer silently wins), non-atomic multi-file updates, signals to possibly-reused PIDs, teardown awaits without deadlines that can hang exit. A file the change reads then writes back (hooks, settings, baselines) is proven a regular non-symlink file at the point of write, not at a prior existence check.
+- **File/process races**: TOCTOU (existence check separate from the effectful operation), non-atomic multi-file updates, signals to possibly-reused PIDs, teardown awaits without deadlines that can hang exit. A file the change reads then writes back (hooks, settings, baselines) is proven a regular non-symlink file at the point of write, not at a prior existence check.
 - **Lock-free**: atomic ordering, ABA, memory reclamation.
+
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
 
 ## Rust Rules
 

--- a/.pi/agents/reviewer-safety.md
+++ b/.pi/agents/reviewer-safety.md
@@ -23,7 +23,7 @@ Memory and thread safety in compiled code, AND concurrency of processes and file
 - **File/process races**: TOCTOU (existence check separate from the effectful operation), non-atomic multi-file updates, signals to possibly-reused PIDs, teardown awaits without deadlines that can hang exit. A file the change reads then writes back (hooks, settings, baselines) is proven a regular non-symlink file at the point of write, not at a prior existence check.
 - **Lock-free**: atomic ordering, ABA, memory reclamation.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Rust Rules
 

--- a/.pi/agents/reviewer-security.md
+++ b/.pi/agents/reviewer-security.md
@@ -25,7 +25,7 @@ Vulnerability classes (injection, broken auth/authz, data exposure, XSS/CSRF, pr
 - **Secret exposure**: credentials or userinfo-bearing URLs reaching logs, diagnostics, or error output; automation that can sweep uncontrolled local edits (and their secrets) into commits.
 - **Untrusted input in control position**: attacker-controlled filenames/branches/settings echoed into shells, workflow commands, or evaluated config; code or config loaded from a reviewed-but-untrusted tree.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Output
 

--- a/.pi/agents/reviewer-security.md
+++ b/.pi/agents/reviewer-security.md
@@ -25,6 +25,8 @@ Vulnerability classes (injection, broken auth/authz, data exposure, XSS/CSRF, pr
 - **Secret exposure**: credentials or userinfo-bearing URLs reaching logs, diagnostics, or error output; automation that can sweep uncontrolled local edits (and their secrets) into commits.
 - **Untrusted input in control position**: attacker-controlled filenames/branches/settings echoed into shells, workflow commands, or evaluated config; code or config loaded from a reviewed-but-untrusted tree.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Output
 
 Vulnerabilities, gating gaps, containment escapes, secret exposure → `blockers[]`. Hardening → `suggestions[]`.

--- a/.pi/agents/reviewer-security.md
+++ b/.pi/agents/reviewer-security.md
@@ -25,7 +25,7 @@ Vulnerability classes (injection, broken auth/authz, data exposure, XSS/CSRF, pr
 - **Secret exposure**: credentials or userinfo-bearing URLs reaching logs, diagnostics, or error output; automation that can sweep uncontrolled local edits (and their secrets) into commits.
 - **Untrusted input in control position**: attacker-controlled filenames/branches/settings echoed into shells, workflow commands, or evaluated config; code or config loaded from a reviewed-but-untrusted tree.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Output
 

--- a/.pi/agents/reviewer-test.md
+++ b/.pi/agents/reviewer-test.md
@@ -20,6 +20,8 @@ The highest-value question is not "is there a test?" but "**can this test still 
 
 Coverage of changed paths (branches, error paths, boundaries), test quality, determinism, environment assumptions. Leave the underlying product bug to `reviewer-correctness` — you report the missing or weak test. Demand tests that catch real bugs, not coverage theater.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Probes
 
 - **Must-fail control**: every NEW test, guard arm, or verdict path must be shown able to fail — a planted-defect fixture, red-first evidence, or a mutation check. A guard nobody has seen fail is unverified. A control that deletes the code under test only proves the assertion runs; for any guard matching source text, the required control is the inverse — keep the matched text, remove the behavior — and the guard must still fail. Plant every satisfied-but-inert form the scanned language allows: a comment, a string or template-literal interior, a nested occurrence, alternate quoting, a braceless statement, a dead `&& false` branch, a discarded result, and a textually earlier but unrelated conditional. Authoring copy: `.agents/skills/code-quality/SKILL.md` § Prove Your Guards.

--- a/.pi/agents/reviewer-test.md
+++ b/.pi/agents/reviewer-test.md
@@ -20,7 +20,7 @@ The highest-value question is not "is there a test?" but "**can this test still 
 
 Coverage of changed paths (branches, error paths, boundaries), test quality, determinism, environment assumptions. Leave the underlying product bug to `reviewer-correctness` — you report the missing or weak test. Demand tests that catch real bugs, not coverage theater.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Probes
 

--- a/.pi/agents/reviewer-test.md
+++ b/.pi/agents/reviewer-test.md
@@ -20,7 +20,7 @@ The highest-value question is not "is there a test?" but "**can this test still 
 
 Coverage of changed paths (branches, error paths, boundaries), test quality, determinism, environment assumptions. Leave the underlying product bug to `reviewer-correctness` — you report the missing or weak test. Demand tests that catch real bugs, not coverage theater.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Probes
 

--- a/agents/reviewer-arch.md
+++ b/agents/reviewer-arch.md
@@ -23,7 +23,7 @@ Compliance criteria come from the project's architecture docs — do not invent 
 - **Spec/proposal review** — when the change is a design document, audit the proposed mechanism itself: race windows (TOCTOU between pin and use), trust-boundary holes (who can alter the inputs a decision reads), enforcement-surface coverage (does the path/tier map reach every surface that can weaken a guard), and failure semantics (does a persistently missing dependency stay green forever).
 - **Technical debt**: accumulated debt worth naming, prioritized by impact; architecture docs drifting from actual structure.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Output
 

--- a/agents/reviewer-arch.md
+++ b/agents/reviewer-arch.md
@@ -23,6 +23,8 @@ Compliance criteria come from the project's architecture docs — do not invent 
 - **Spec/proposal review** — when the change is a design document, audit the proposed mechanism itself: race windows (TOCTOU between pin and use), trust-boundary holes (who can alter the inputs a decision reads), enforcement-surface coverage (does the path/tier map reach every surface that can weaken a guard), and failure semantics (does a persistently missing dependency stay green forever).
 - **Technical debt**: accumulated debt worth naming, prioritized by impact; architecture docs drifting from actual structure.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Output
 
 Architecture violations, boundary breaches, spec holes → `blockers[]`. Tech debt observations, minor improvements → `suggestions[]`.

--- a/agents/reviewer-arch.md
+++ b/agents/reviewer-arch.md
@@ -23,7 +23,7 @@ Compliance criteria come from the project's architecture docs — do not invent 
 - **Spec/proposal review** — when the change is a design document, audit the proposed mechanism itself: race windows (TOCTOU between pin and use), trust-boundary holes (who can alter the inputs a decision reads), enforcement-surface coverage (does the path/tier map reach every surface that can weaken a guard), and failure semantics (does a persistently missing dependency stay green forever).
 - **Technical debt**: accumulated debt worth naming, prioritized by impact; architecture docs drifting from actual structure.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Output
 

--- a/agents/reviewer-correctness.md
+++ b/agents/reviewer-correctness.md
@@ -22,7 +22,7 @@ Behavior regressions; API/CLI/contract compatibility (including two components i
 
 Leave to peers: exploitability (`reviewer-security`), error-path causes (`reviewer-error`), missing tests (`reviewer-test` — you report the bug, not the absent test), maintainability, perf, docs.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Boundary Probes
 

--- a/agents/reviewer-correctness.md
+++ b/agents/reviewer-correctness.md
@@ -22,6 +22,8 @@ Behavior regressions; API/CLI/contract compatibility (including two components i
 
 Leave to peers: exploitability (`reviewer-security`), error-path causes (`reviewer-error`), missing tests (`reviewer-test` — you report the bug, not the absent test), maintainability, perf, docs.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Boundary Probes
 
 For each changed predicate, parser, or guard, mentally execute:
@@ -53,7 +55,7 @@ When a change adds or modifies a type wrapping another (cache, proxy, decorator,
 
 ## Plausible by Default
 
-Never refute a finding as "speculative" or "depends on runtime state" when the state is realistic: a concurrency race; nil/undefined on a rare-but-reachable path (error handler, cold cache, missing optional field); a falsy zero treated as missing; an off-by-one on a boundary the code does not exclude; retry storms and partial failures; a regex or allowlist that lost an anchor. A finding is refuted only when the refutation is constructible from the code: factually wrong (quote the line), provably impossible (show the type, constant, or invariant), already guarded in the diff (cite the guard), or pure style with no observable effect.
+Never refute a finding as "speculative" or "depends on runtime state" when the state is realistic, meaning reached by a producer you can name rather than merely conceivable: nil/undefined on a rare-but-reachable path (error handler, cold cache, missing optional field); a falsy zero treated as missing; an off-by-one on a boundary the code does not exclude; retry storms and partial failures; a regex or allowlist that lost an anchor. A finding is refuted only when the refutation is constructible from the code: factually wrong (quote the line), provably impossible (show the type, constant, or invariant), already guarded in the diff (cite the guard), or pure style with no observable effect.
 
 ## Output
 

--- a/agents/reviewer-correctness.md
+++ b/agents/reviewer-correctness.md
@@ -22,7 +22,7 @@ Behavior regressions; API/CLI/contract compatibility (including two components i
 
 Leave to peers: exploitability (`reviewer-security`), error-path causes (`reviewer-error`), missing tests (`reviewer-test` — you report the bug, not the absent test), maintainability, perf, docs.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Boundary Probes
 

--- a/agents/reviewer-doc.md
+++ b/agents/reviewer-doc.md
@@ -26,7 +26,7 @@ The method is verification, not proofreading — **open the implementation behin
 - **Moved prose**: relocated help text, README, schema, and changelog prose is new prose — verify it sentence by sentence against the code it now describes, never against the file it moved from.
 - **Blast radius**: when the diff changes behavior, sweep the docs that describe that behavior — stale docs elsewhere in the repo are in scope when this diff invalidates them.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Output
 

--- a/agents/reviewer-doc.md
+++ b/agents/reviewer-doc.md
@@ -26,7 +26,7 @@ The method is verification, not proofreading — **open the implementation behin
 - **Moved prose**: relocated help text, README, schema, and changelog prose is new prose — verify it sentence by sentence against the code it now describes, never against the file it moved from.
 - **Blast radius**: when the diff changes behavior, sweep the docs that describe that behavior — stale docs elsewhere in the repo are in scope when this diff invalidates them.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Output
 

--- a/agents/reviewer-doc.md
+++ b/agents/reviewer-doc.md
@@ -26,6 +26,8 @@ The method is verification, not proofreading — **open the implementation behin
 - **Moved prose**: relocated help text, README, schema, and changelog prose is new prose — verify it sentence by sentence against the code it now describes, never against the file it moved from.
 - **Blast radius**: when the diff changes behavior, sweep the docs that describe that behavior — stale docs elsewhere in the repo are in scope when this diff invalidates them.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Output
 
 Wrong claims, wrong values, dead citations, contradicted invariants → `blockers[]`. Minor improvements → `suggestions[]`.

--- a/agents/reviewer-error.md
+++ b/agents/reviewer-error.md
@@ -20,6 +20,8 @@ Error paths that quietly convert failure into success. For every changed error/f
 
 Fail-open paths, silent failures, error propagation, fallback behavior, wrong-cause diagnostics, observability gaps. Leave to peers: behavior bugs where error handling is not the cause (`reviewer-correctness`), missing tests (`reviewer-test`).
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Fail-Open Catalogue
 
 Recurring shapes:

--- a/agents/reviewer-error.md
+++ b/agents/reviewer-error.md
@@ -20,7 +20,7 @@ Error paths that quietly convert failure into success. For every changed error/f
 
 Fail-open paths, silent failures, error propagation, fallback behavior, wrong-cause diagnostics, observability gaps. Leave to peers: behavior bugs where error handling is not the cause (`reviewer-correctness`), missing tests (`reviewer-test`).
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Fail-Open Catalogue
 

--- a/agents/reviewer-error.md
+++ b/agents/reviewer-error.md
@@ -20,7 +20,7 @@ Error paths that quietly convert failure into success. For every changed error/f
 
 Fail-open paths, silent failures, error propagation, fallback behavior, wrong-cause diagnostics, observability gaps. Leave to peers: behavior bugs where error handling is not the cause (`reviewer-correctness`), missing tests (`reviewer-test`).
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Fail-Open Catalogue
 

--- a/agents/reviewer-perf.md
+++ b/agents/reviewer-perf.md
@@ -22,6 +22,8 @@ Validate performance with evidence: benchmarks against baselines, project-define
 - **Hot-path cost review** of the diff: per-event work introduced on hot paths — synchronous I/O or re-parsing inside stream/event handlers, config re-read where a snapshot belongs, allocation churn in loops.
 - **Budget validation** against documented targets.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Output
 
 Budget exceedances, classified regressions, hot-path cost introductions → `blockers[]`. Minor observations → `suggestions[]`.

--- a/agents/reviewer-perf.md
+++ b/agents/reviewer-perf.md
@@ -22,7 +22,7 @@ Validate performance with evidence: benchmarks against baselines, project-define
 - **Hot-path cost review** of the diff: per-event work introduced on hot paths — synchronous I/O or re-parsing inside stream/event handlers, config re-read where a snapshot belongs, allocation churn in loops.
 - **Budget validation** against documented targets.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Output
 

--- a/agents/reviewer-perf.md
+++ b/agents/reviewer-perf.md
@@ -22,7 +22,7 @@ Validate performance with evidence: benchmarks against baselines, project-define
 - **Hot-path cost review** of the diff: per-event work introduced on hot paths — synchronous I/O or re-parsing inside stream/event handlers, config re-read where a snapshot belongs, allocation churn in loops.
 - **Budget validation** against documented targets.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Output
 

--- a/agents/reviewer-quality.md
+++ b/agents/reviewer-quality.md
@@ -20,6 +20,8 @@ Is the changed implementation simple, direct, easy to reason about, and aligned 
 
 Implementation maintainability of the reviewed scope: simplification, abstraction value, type/boundary clarity, canonical helper reuse, decomposition (god objects, files/functions this change makes materially harder to scan, tests located against convention). Raw file-size thresholds are deterministic (size-ratchet) — don't re-enforce them. Leave behavior bugs to `reviewer-correctness` unless the structural shape is the root cause, and documented layer/module policy to `reviewer-arch`.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Probes
 
 - **Mechanism over shapes**: a fix that patches the Nth instance of a pattern instead of the mechanism producing them. Recommend the structural fix that closes the class.

--- a/agents/reviewer-quality.md
+++ b/agents/reviewer-quality.md
@@ -20,7 +20,7 @@ Is the changed implementation simple, direct, easy to reason about, and aligned 
 
 Implementation maintainability of the reviewed scope: simplification, abstraction value, type/boundary clarity, canonical helper reuse, decomposition (god objects, files/functions this change makes materially harder to scan, tests located against convention). Raw file-size thresholds are deterministic (size-ratchet) — don't re-enforce them. Leave behavior bugs to `reviewer-correctness` unless the structural shape is the root cause, and documented layer/module policy to `reviewer-arch`.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Probes
 

--- a/agents/reviewer-quality.md
+++ b/agents/reviewer-quality.md
@@ -20,7 +20,7 @@ Is the changed implementation simple, direct, easy to reason about, and aligned 
 
 Implementation maintainability of the reviewed scope: simplification, abstraction value, type/boundary clarity, canonical helper reuse, decomposition (god objects, files/functions this change makes materially harder to scan, tests located against convention). Raw file-size thresholds are deterministic (size-ratchet) — don't re-enforce them. Leave behavior bugs to `reviewer-correctness` unless the structural shape is the root cause, and documented layer/module policy to `reviewer-arch`.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Probes
 

--- a/agents/reviewer-safety.md
+++ b/agents/reviewer-safety.md
@@ -23,7 +23,7 @@ Memory and thread safety in compiled code, AND concurrency of processes and file
 - **File/process races**: TOCTOU (existence check separate from the effectful operation), non-atomic multi-file updates, signals to possibly-reused PIDs, teardown awaits without deadlines that can hang exit. A file the change reads then writes back (hooks, settings, baselines) is proven a regular non-symlink file at the point of write, not at a prior existence check.
 - **Lock-free**: atomic ordering, ABA, memory reclamation.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Rust Rules
 

--- a/agents/reviewer-safety.md
+++ b/agents/reviewer-safety.md
@@ -20,8 +20,10 @@ Memory and thread safety in compiled code, AND concurrency of processes and file
 
 - **Unsafe/UB**: blocks bypassing language guarantees; aliasing, uninitialized memory, type punning; buffer overflows, use-after-free, null dereference.
 - **Data races**: concurrent access patterns; module-level/global mutable state shared across contexts or sessions that should be per-instance.
-- **File/process races**: TOCTOU (existence check separate from the effectful operation; check-then-`mv` where a concurrent writer silently wins), non-atomic multi-file updates, signals to possibly-reused PIDs, teardown awaits without deadlines that can hang exit. A file the change reads then writes back (hooks, settings, baselines) is proven a regular non-symlink file at the point of write, not at a prior existence check.
+- **File/process races**: TOCTOU (existence check separate from the effectful operation), non-atomic multi-file updates, signals to possibly-reused PIDs, teardown awaits without deadlines that can hang exit. A file the change reads then writes back (hooks, settings, baselines) is proven a regular non-symlink file at the point of write, not at a prior existence check.
 - **Lock-free**: atomic ordering, ABA, memory reclamation.
+
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
 
 ## Rust Rules
 

--- a/agents/reviewer-safety.md
+++ b/agents/reviewer-safety.md
@@ -23,7 +23,7 @@ Memory and thread safety in compiled code, AND concurrency of processes and file
 - **File/process races**: TOCTOU (existence check separate from the effectful operation), non-atomic multi-file updates, signals to possibly-reused PIDs, teardown awaits without deadlines that can hang exit. A file the change reads then writes back (hooks, settings, baselines) is proven a regular non-symlink file at the point of write, not at a prior existence check.
 - **Lock-free**: atomic ordering, ABA, memory reclamation.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Rust Rules
 

--- a/agents/reviewer-security.md
+++ b/agents/reviewer-security.md
@@ -25,7 +25,7 @@ Vulnerability classes (injection, broken auth/authz, data exposure, XSS/CSRF, pr
 - **Secret exposure**: credentials or userinfo-bearing URLs reaching logs, diagnostics, or error output; automation that can sweep uncontrolled local edits (and their secrets) into commits.
 - **Untrusted input in control position**: attacker-controlled filenames/branches/settings echoed into shells, workflow commands, or evaluated config; code or config loaded from a reviewed-but-untrusted tree.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Output
 

--- a/agents/reviewer-security.md
+++ b/agents/reviewer-security.md
@@ -25,6 +25,8 @@ Vulnerability classes (injection, broken auth/authz, data exposure, XSS/CSRF, pr
 - **Secret exposure**: credentials or userinfo-bearing URLs reaching logs, diagnostics, or error output; automation that can sweep uncontrolled local edits (and their secrets) into commits.
 - **Untrusted input in control position**: attacker-controlled filenames/branches/settings echoed into shells, workflow commands, or evaluated config; code or config loaded from a reviewed-but-untrusted tree.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Output
 
 Vulnerabilities, gating gaps, containment escapes, secret exposure → `blockers[]`. Hardening → `suggestions[]`.

--- a/agents/reviewer-security.md
+++ b/agents/reviewer-security.md
@@ -25,7 +25,7 @@ Vulnerability classes (injection, broken auth/authz, data exposure, XSS/CSRF, pr
 - **Secret exposure**: credentials or userinfo-bearing URLs reaching logs, diagnostics, or error output; automation that can sweep uncontrolled local edits (and their secrets) into commits.
 - **Untrusted input in control position**: attacker-controlled filenames/branches/settings echoed into shells, workflow commands, or evaluated config; code or config loaded from a reviewed-but-untrusted tree.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Output
 

--- a/agents/reviewer-test.md
+++ b/agents/reviewer-test.md
@@ -20,6 +20,8 @@ The highest-value question is not "is there a test?" but "**can this test still 
 
 Coverage of changed paths (branches, error paths, boundaries), test quality, determinism, environment assumptions. Leave the underlying product bug to `reviewer-correctness` — you report the missing or weak test. Demand tests that catch real bugs, not coverage theater.
 
+A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+
 ## Probes
 
 - **Must-fail control**: every NEW test, guard arm, or verdict path must be shown able to fail — a planted-defect fixture, red-first evidence, or a mutation check. A guard nobody has seen fail is unverified. A control that deletes the code under test only proves the assertion runs; for any guard matching source text, the required control is the inverse — keep the matched text, remove the behavior — and the guard must still fail. Plant every satisfied-but-inert form the scanned language allows: a comment, a string or template-literal interior, a nested occurrence, alternate quoting, a braceless statement, a dead `&& false` branch, a discarded result, and a textually earlier but unrelated conditional. Authoring copy: `.agents/skills/code-quality/SKILL.md` § Prove Your Guards.

--- a/agents/reviewer-test.md
+++ b/agents/reviewer-test.md
@@ -20,7 +20,7 @@ The highest-value question is not "is there a test?" but "**can this test still 
 
 Coverage of changed paths (branches, error paths, boundaries), test quality, determinism, environment assumptions. Leave the underlying product bug to `reviewer-correctness` — you report the missing or weak test. Demand tests that catch real bugs, not coverage theater.
 
-A race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when you name the shipped producer or user action that reaches it. Without that name, do not write the finding.
+A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
 
 ## Probes
 

--- a/agents/reviewer-test.md
+++ b/agents/reviewer-test.md
@@ -20,7 +20,7 @@ The highest-value question is not "is there a test?" but "**can this test still 
 
 Coverage of changed paths (branches, error paths, boundaries), test quality, determinism, environment assumptions. Leave the underlying product bug to `reviewer-correctness` — you report the missing or weak test. Demand tests that catch real bugs, not coverage theater.
 
-A same-machine race, or a second writer with the user's privileges, is never a finding. A symlink, `..`, or malformed input is one only when you name the shipped producer emitting it. Security, data-loss and fail-open defects are exempt.
+A finding in a class `.agents/skills/orch/references/finding-disposition.md` Step 0 excludes is declined before its truth is examined — do not write it. For a symlink, `..`, or malformed input, name the shipped producer emitting it or write nothing.
 
 ## Probes
 


### PR DESCRIPTION
## Summary

- Every `agents/reviewer-*.md` gains one sentence beside its finding categories: a race, a concurrent writer, a symlink or `..` shape, or a malformed input is a finding only when the reviewer names the shipped producer or user action that reaches it. Without that name the finding is not written.
- Two sentences that invited the excluded classes go: `reviewer-correctness` listed "a concurrency race" among realistic states, and `reviewer-safety` named check-then-`mv` where a concurrent writer silently wins. "Realistic" now means reached by a producer you can name rather than merely conceivable.
- Renders for `.claude`, `.codex` and `.pi` move in the same commit.

Panels were writing findings that `skills/orch/references/finding-disposition.md` Step 0 declines, and devs hardened their own mechanism to satisfy them before the orchestrator saw the round — #1958 grew +564 lines from its internal panel with zero bot threads. The reviewer skill's existing verify-before-reporting rule is the enforcer; no new lint, schema, or test.

## Completed Issues

- Closes KEN-1114 - Reviewer agents ask for defences the filing bar declines; each names the producer or writes nothing

## Test Plan

Done-when, run from the repo root:

- `grep -n 'concurrency race\|concurrent writer silently wins' agents/reviewer-*.md` prints nothing.
- Each `agents/reviewer-*.md` carries the producer sentence once, at 38 words.
- `tools/guard` covers render parity; every source has its `.claude`, `.codex` and `.pi` copy in this commit.

https://claude.ai/code/session_01RRYM9WB3aaadzpcdwohbYw
