### PR TITLE
fix(KEN-1111): the stub log exists before the port is read

### DIFF
--- a/.agents/skills/review-gate/tests/predicate-re2-engine.test.sh
+++ b/.agents/skills/review-gate/tests/predicate-re2-engine.test.sh
@@ -92,6 +92,14 @@ fi
 # ----------------------------------------------------------------- engines ---
 # Port 0: the kernel picks a free one, so concurrent lanes on one machine do
 # not collide. The port is read back from the server's own banner.
+#
+# The log is created HERE, in the parent. bash performs a background
+# command's redirections in the child, after the fork, so without this line
+# the parent can reach the read below before the child has made the file:
+# `sed` fails, `pipefail` carries that into the assignment, and `set -e`
+# ends the run before the retry loop ever reaches a second pass. The loop
+# covers an empty banner, never an absent file.
+: >"$work/httpd.log"
 python3 -u -m http.server 0 --bind 127.0.0.1 --directory "$srv" >"$work/httpd.log" 2>&1 &
 server_pid=$!
 port=""

--- a/skills/review-gate/tests/predicate-re2-engine.test.sh
+++ b/skills/review-gate/tests/predicate-re2-engine.test.sh
@@ -92,6 +92,14 @@ fi
 # ----------------------------------------------------------------- engines ---
 # Port 0: the kernel picks a free one, so concurrent lanes on one machine do
 # not collide. The port is read back from the server's own banner.
+#
+# The log is created HERE, in the parent. bash performs a background
+# command's redirections in the child, after the fork, so without this line
+# the parent can reach the read below before the child has made the file:
+# `sed` fails, `pipefail` carries that into the assignment, and `set -e`
+# ends the run before the retry loop ever reaches a second pass. The loop
+# covers an empty banner, never an absent file.
+: >"$work/httpd.log"
 python3 -u -m http.server 0 --bind 127.0.0.1 --directory "$srv" >"$work/httpd.log" 2>&1 &
 server_pid=$!
 port=""


### PR DESCRIPTION
## Summary

- The stub server's log file is now created in the parent, before the background launch, so the port read below it can never hit an absent file.
- bash performs a background command's redirections in the child, after the fork. The parent could reach the `sed` that reads the port before the child had made the file. Under `set -euo pipefail` that killed the run outright, which is why the retry loop underneath never got a second pass: it covers an empty banner, never a missing file.
- One line of shell plus the comment naming the invariant, in the source and its `.agents` render.

## Completed Issues

- Closes KEN-1111 - predicate-re2-engine.test.sh reads the stub log before the fork creates it

## Test Plan

- A must-fail control on the read shape, run both directions: the same `sed` pipeline under the suite's `set -euo pipefail` exits 2 with `sed: can't read .../httpd.log: No such file or directory` without the pre-create, and reaches the line past the read with it. That is the reported symptom, reproduced on demand.
- The full `review-gate` shard, the loop from `.github/workflows/skill-tests.yml`, run green repeatedly before the push and once more from a clean tree after it.
- preflight clean, size-ratchet within its baseline, `tools/guard` green.

Declined during review: a committed control that reds when the fix line is deleted. The issue's re-scope comment drops that bullet as a test of a test, leaving a green shard as the Done-when.

https://claude.ai/code/session_015uTnj3w7GCbAcWnFCoZQUV
