### PR TITLE
test(KEN-1015): an unrun control and an unrun verdict both red

### DIFF
--- a/.agents/skills/linear/DEVELOPMENT.md
+++ b/.agents/skills/linear/DEVELOPMENT.md
@@ -77,6 +77,6 @@ The distinction is not a judgement call left to the author: `run_status` refuses
 
 ### Must-fail controls
 
-`tests/controls/<suite>.control.sh` breaks the one behaviour its suite covers, in a copy of the skill, and `tests/must-fail-controls.sh` requires the suite to go red naming the assertion that covers it. A suite with no control fails the run: an untested control is an untested suite.
+`tests/controls/<suite>.control.sh` breaks the one behaviour its suite covers, in a copy of the skill, and `tests/must-fail-controls.sh` requires the suite to go red naming the assertion that covers it. A suite with no control fails the run: an untested control is an untested suite. So does a control no suite owns, reported as `ORPHAN`: nothing runs it, so its mutation is never applied and the behaviour it names is unproven. The roster is read in both directions whatever the selection, so a single-stem run cannot pass while a control sits in the directory unrun.
 
 A control declares what it expects with `control_expect <assertion description>` and mutates with `control_replace <file> <count> <old line> <new line>` — whole-line and literal, so there is no pattern syntax to mis-escape. `control_replace` aborts unless it matches exactly `count` lines, and the runner refuses a control that changed nothing, so a mutation that failed to land can never be read as a passing control. It also refuses a stem that names no suite and a selection that matched none, because a run that measured nothing is not a run that passed.

--- a/.agents/skills/linear/tests/controls/kendex-env-precedence.control.sh
+++ b/.agents/skills/linear/tests/controls/kendex-env-precedence.control.sh
@@ -1,6 +1,0 @@
-# Report every key as already set in the parent environment. Project settings
-# are then skipped wholesale, so a repo's own configuration never applies.
-control_expect "scenario 1: settings apply"
-control_replace scripts/lib/kendex-env.sh 1 \
-    '    [[ "$snapshot_name" == "$name" ]] && return 0' \
-    '    return 0'

--- a/.agents/skills/linear/tests/controls/roster-orphan.control.sh
+++ b/.agents/skills/linear/tests/controls/roster-orphan.control.sh
@@ -1,0 +1,7 @@
+# Disable the reverse-roster loop's body. The runner then walks the controls
+# directory, finds the orphan, and says nothing: every roster case in the
+# fixture reports a clean run.
+control_expect "a control no suite owns fails the full run"
+control_replace tests/must-fail-controls.sh 1 \
+	'		if [[ " ${stems[*]} " != *" $stem "* ]]; then' \
+	'		if false; then'

--- a/.agents/skills/linear/tests/must-fail-controls.sh
+++ b/.agents/skills/linear/tests/must-fail-controls.sh
@@ -5,7 +5,8 @@
 # A control breaks the one behaviour its suite claims to cover, in a copy of
 # the skill, and the suite must go red naming the assertion that covers it. A
 # suite with no control is a failure here: an untested control is an untested
-# suite.
+# suite. So is a control no suite owns: nothing runs it, so the mutation it
+# describes is never applied and the behaviour it claims to prove is unproven.
 #
 #   skills/linear/tests/must-fail-controls.sh                     # all
 #   skills/linear/tests/must-fail-controls.sh estimate-clear      # one, by stem
@@ -155,12 +156,24 @@ run_one() {
 
 main() {
 	local -a wanted=("$@") stems=()
-	local suite_path suite stem want failures=0 total=0
+	local suite_path control_path suite stem want failures=0 total=0 orphans=0
 
 	for suite_path in "$TESTS_DIR"/*.test.sh; do
 		stems+=("$(basename "$suite_path" .test.sh)")
 	done
 	[[ ${#stems[@]} -gt 0 ]] || die "no suites in $TESTS_DIR"
+
+	# The roster is read whole whatever the selection: a targeted run must
+	# not be green while a control sits in the directory unrun.
+	for control_path in "$CONTROLS_DIR"/*.control.sh; do
+		[[ -f "$control_path" ]] || die "no controls in $CONTROLS_DIR"
+		stem="$(basename "$control_path" .control.sh)"
+		if [[ " ${stems[*]} " != *" $stem "* ]]; then
+			printf 'ORPHAN   %-52s no %s.test.sh owns it\n' \
+				"controls/$stem.control.sh" "$stem"
+			orphans=$((orphans + 1))
+		fi
+	done
 
 	# A run that selected nothing is not a clean run: a mistyped stem would
 	# otherwise report "0 controls, 0 failing" and exit 0.
@@ -181,8 +194,9 @@ main() {
 
 	[[ "$total" -gt 0 ]] || die "selection matched no suites"
 
-	printf '\n%d controls, %d failing\n' "$total" "$failures"
-	[[ "$failures" -eq 0 ]]
+	printf '\n%d controls, %d failing, %d orphaned\n' \
+		"$total" "$failures" "$orphans"
+	[[ "$failures" -eq 0 && "$orphans" -eq 0 ]]
 }
 
 main "$@"

--- a/.agents/skills/linear/tests/roster-orphan.test.sh
+++ b/.agents/skills/linear/tests/roster-orphan.test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# The roster contract of tests/must-fail-controls.sh, both directions, driven
+# against a synthetic one-suite skill rather than this one.
+#
+# Why a fixture and not this skill's own roster: that roster is matched, so
+# the orphan branch is never taken by a run over skills/linear and deleting it
+# would leave every committed suite green. The fixture is the only place the
+# condition is constructible.
+#
+#   - a matched suite/control pair exits 0 and prints no ORPHAN line, so a
+#     case here cannot pass by always reporting a failure
+#   - a control no suite owns exits non-zero and the diagnostic names it
+#   - a targeted single-stem run reads the roster too: a selection cannot
+#     hide an orphan
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/assert.sh
+source "$SCRIPT_DIR/lib/assert.sh"
+RUNNER="$SCRIPT_DIR/must-fail-controls.sh"
+assert_tmpdir TMP
+
+# A one-suite skill whose suite reads a value its control flips: enough for the
+# runner to stage, mutate and red, and no more, so what these cases measure is
+# the roster and not the control machinery.
+fixture() {
+    local root="$1"
+    mkdir -p "$root/scripts" "$root/tests/controls"
+    printf 'VALUE=green\n' >"$root/scripts/value.sh"
+    cat >"$root/tests/alpha.test.sh" <<'SUITE'
+#!/usr/bin/env bash
+set -uo pipefail
+D="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$D/../scripts/value.sh"
+if [ "$VALUE" = green ]; then
+    echo "  ok    the value is green"
+    exit 0
+fi
+echo "  FAIL  the value is green"
+exit 1
+SUITE
+    cat >"$root/tests/controls/alpha.control.sh" <<'CONTROL'
+control_expect "the value is green"
+control_replace scripts/value.sh 1 'VALUE=green' 'VALUE=red'
+CONTROL
+    cp "$RUNNER" "$root/tests/must-fail-controls.sh"
+}
+
+# run_roster LOGFILE ROOT [STEM...] — run the fixture's copy of the runner,
+# combined output to LOGFILE. Echoes its status; the caller asserts on that
+# rather than branching, so no assertion runs inside a subshell.
+run_roster() {
+    local log="$1" root="$2"
+    shift 2
+    bash "$root/tests/must-fail-controls.sh" "$@" >"$log" 2>&1
+    echo "$?"
+}
+
+# --- the matched pair is the baseline --------------------------------------
+matched="$TMP/matched"
+fixture "$matched"
+rc="$(run_roster "$TMP/matched.log" "$matched")"
+assert_eq "a roster whose every control owns a suite exits 0" "$rc" 0
+assert_file_lacks "a matched roster prints no ORPHAN line" "$TMP/matched.log" "ORPHAN"
+assert_file_contains "the matched run reports no orphan" \
+    "$TMP/matched.log" "1 controls, 0 failing, 0 orphaned"
+
+# --- a control no suite owns fails the full run ----------------------------
+orphaned="$TMP/orphaned"
+fixture "$orphaned"
+printf 'control_expect "nothing runs this"\n' \
+    >"$orphaned/tests/controls/ghost.control.sh"
+
+rc="$(run_roster "$TMP/orphan-full.log" "$orphaned")"
+assert_ne "a control no suite owns fails the full run" "$rc" 0
+assert_file_contains "the full run names the orphaned control" \
+    "$TMP/orphan-full.log" "ORPHAN   controls/ghost.control.sh"
+assert_file_contains "the diagnostic names the suite that would own it" \
+    "$TMP/orphan-full.log" "no ghost.test.sh owns it"
+assert_file_contains "the full run counts the orphan" \
+    "$TMP/orphan-full.log" "1 controls, 0 failing, 1 orphaned"
+assert_file_contains "the orphan is what failed: the matched pair still passed" \
+    "$TMP/orphan-full.log" "ok       alpha.test.sh"
+
+# --- and fails a targeted single-stem run too ------------------------------
+# The case a selection-scoped roster read would have missed: with the orphan
+# check inside the per-suite loop, naming a stem would walk past it.
+rc="$(run_roster "$TMP/orphan-one.log" "$orphaned" alpha)"
+assert_ne "a targeted run fails on an orphan outside its selection" "$rc" 0
+assert_file_contains "the targeted run names the orphaned control" \
+    "$TMP/orphan-one.log" "ORPHAN   controls/ghost.control.sh"
+assert_file_contains "the targeted run counts the orphan" \
+    "$TMP/orphan-one.log" "1 controls, 0 failing, 1 orphaned"

--- a/.agents/skills/review-gate/tests/review-writer.test.sh
+++ b/.agents/skills/review-gate/tests/review-writer.test.sh
@@ -25,6 +25,10 @@
 #                                               description
 #   w8b. unreasoned-decline over a NEWER     -> posts failure directly
 #        success entry
+#   w9.  untracked-claim                     -> posts failure, remedy in the
+#                                               description
+#   w9b. untracked-claim over a NEWER        -> posts failure directly
+#        success entry
 # Write discipline (VST-65 ordering guard, success posts only):
 #   w10. guard re-read shows a non-success   -> defers (exit 0, no POST)
 #        entry at/after evaluated_at

--- a/.agents/skills/review-gate/tests/review-writer.test.sh
+++ b/.agents/skills/review-gate/tests/review-writer.test.sh
@@ -243,6 +243,8 @@ CR="verdict=changes-requested detail=standing review changes requested (persists
 THREADS="verdict=threads-open detail=2 unresolved review thread(s)"
 UNREASONED_DETAIL="1 decline(s) name no mechanism — give a passing state, a false premise, or an excluded class with the fact that puts it there"
 UNREASONED="verdict=unreasoned-decline detail=$UNREASONED_DETAIL"
+UNTRACKED_DETAIL="1 tracking claim(s) name no issue — write Declined: <reason>, or add the tracker/#id"
+UNTRACKED="verdict=untracked-claim detail=$UNTRACKED_DETAIL"
 
 # created_at anchors: OLD predates every stub run's start (RUN_START =
 # 2020-06-01) and every evaluation instant; LATE lands after RUN_START but
@@ -296,6 +298,21 @@ rc=0; out=$(run_writer STUB_VERDICT_LINE="$UNREASONED" \
 assert_eq "$rc" "0" "w8b: unreasoned-decline over a newer success exits 0"
 assert_contains "$(cat "$POST_LOG")" "state=failure" "w8b: posts failure over it — a downward post never defers"
 assert_not_contains "$out" "deferring" "w8b: no deferral on the downward path"
+
+# w9: a reply claiming tracking that names no issue is the other red verdict.
+# Driven through the writer for the same reason w8 is: the mapping line reads
+# the same whether the verdict is spelled right or not, and an unmapped
+# verdict exits 1 on "unknown verdict" instead of posting anything.
+rc=0; out=$(run_writer STUB_VERDICT_LINE="$UNTRACKED" STUB_GATE_HISTORY='[]') || rc=$?
+assert_eq "$rc" "0" "w9: untracked-claim exits 0"
+assert_contains "$(cat "$POST_LOG")" "state=failure" "w9: untracked-claim posts failure"
+assert_contains "$(cat "$POST_LOG")" "$UNTRACKED_DETAIL" "w9: the remedy reaches the status description"
+
+rc=0; out=$(run_writer STUB_VERDICT_LINE="$UNTRACKED" \
+  STUB_GATE_HISTORY='[{"context":"Review gate","state":"success","description":"ok","created_at":"'"$FUTURE"'"}]') || rc=$?
+assert_eq "$rc" "0" "w9b: untracked-claim over a newer success exits 0"
+assert_contains "$(cat "$POST_LOG")" "state=failure" "w9b: posts failure over it — a downward post never defers"
+assert_not_contains "$out" "deferring" "w9b: no deferral on the downward path"
 
 echo "=== approved converges to success ==="
 

--- a/.agents/skills/review-gate/tests/untracked-claim.test.sh
+++ b/.agents/skills/review-gate/tests/untracked-claim.test.sh
@@ -5,11 +5,11 @@
 # carries a track-word: a claim with no issue id counts, such a reply
 # never does, later replies of any other kind, bot replies, and resolving
 # the thread do not move it. A comments page it cannot finish fails closed.
-# The writer maps the verdict to a failure status.
+# The watcher surfaces the verdict. Its mapping to a failure status is
+# review-writer.test.sh w9, driven through the writer itself.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PRED="$SCRIPT_DIR/../scripts/review-predicate.sh"
-WRITER="$SCRIPT_DIR/../scripts/review-writer.sh"
 PASS=0 FAIL=0
 ok()  { PASS=$((PASS+1)); echo "  ok    $1"; }
 bad() { FAIL=$((FAIL+1)); echo "  FAIL  $1"; echo "        got: $2"; }
@@ -74,9 +74,6 @@ case "$out" in "1 0 "*) ok "unresolved counting unchanged";; *) bad "unresolved 
 out=$(page "$(thread true "$(human 'Tracked: KEN-1')" true)")
 case "$out" in malformed) ok "a 50+-comment thread fails closed as malformed";; *) bad "a 50+-comment thread fails closed as malformed" "$out";; esac
 
-grep -q 'untracked-claim)       desired="failure"' "$WRITER" \
-  && ok "writer maps untracked-claim to failure" \
-  || bad "writer maps untracked-claim to failure" "mapping line missing"
 grep -q 'untracked-claim' "$SCRIPT_DIR/../scripts/pr-watch.sh" \
   && ok "pr-watch accepts and surfaces the verdict" \
   || bad "pr-watch accepts and surfaces the verdict" "not referenced"

--- a/.agents/skills/review-gate/tests/untracked-claim.test.sh
+++ b/.agents/skills/review-gate/tests/untracked-claim.test.sh
@@ -5,8 +5,7 @@
 # carries a track-word: a claim with no issue id counts, such a reply
 # never does, later replies of any other kind, bot replies, and resolving
 # the thread do not move it. A comments page it cannot finish fails closed.
-# The watcher surfaces the verdict. Its mapping to a failure status is
-# review-writer.test.sh w9, driven through the writer itself.
+# The verdict's mapping to a failure status is review-writer.test.sh w9.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PRED="$SCRIPT_DIR/../scripts/review-predicate.sh"
@@ -73,20 +72,6 @@ case "$out" in "1 0 "*) ok "unresolved counting unchanged";; *) bad "unresolved 
 
 out=$(page "$(thread true "$(human 'Tracked: KEN-1')" true)")
 case "$out" in malformed) ok "a 50+-comment thread fails closed as malformed";; *) bad "a 50+-comment thread fails closed as malformed" "$out";; esac
-
-# The routing arm, not any mention of the verdict: the help text and the
-# verdict allow-list both carry the string, so a bare grep for it stays green
-# with the arm renamed away. Anchored on the arm's own label line, whose next
-# line must emit the verdict.
-watch_arm="$(grep -A 1 '^    untracked-claim)$' \
-  "$SCRIPT_DIR/../scripts/pr-watch.sh" | tail -n 1 || true)"
-case "$watch_arm" in
-  *'emit "$number" "$head" untracked-claim'*)
-    ok "pr-watch routes the verdict to its own emit arm";;
-  *)
-    bad "pr-watch routes the verdict to its own emit arm" \
-      "${watch_arm:-no untracked-claim) arm}";;
-esac
 
 echo "$PASS passed, $FAIL failed"
 [ "$FAIL" = 0 ] || exit 1

--- a/.agents/skills/review-gate/tests/untracked-claim.test.sh
+++ b/.agents/skills/review-gate/tests/untracked-claim.test.sh
@@ -74,9 +74,19 @@ case "$out" in "1 0 "*) ok "unresolved counting unchanged";; *) bad "unresolved 
 out=$(page "$(thread true "$(human 'Tracked: KEN-1')" true)")
 case "$out" in malformed) ok "a 50+-comment thread fails closed as malformed";; *) bad "a 50+-comment thread fails closed as malformed" "$out";; esac
 
-grep -q 'untracked-claim' "$SCRIPT_DIR/../scripts/pr-watch.sh" \
-  && ok "pr-watch accepts and surfaces the verdict" \
-  || bad "pr-watch accepts and surfaces the verdict" "not referenced"
+# The routing arm, not any mention of the verdict: the help text and the
+# verdict allow-list both carry the string, so a bare grep for it stays green
+# with the arm renamed away. Anchored on the arm's own label line, whose next
+# line must emit the verdict.
+watch_arm="$(grep -A 1 '^    untracked-claim)$' \
+  "$SCRIPT_DIR/../scripts/pr-watch.sh" | tail -n 1 || true)"
+case "$watch_arm" in
+  *'emit "$number" "$head" untracked-claim'*)
+    ok "pr-watch routes the verdict to its own emit arm";;
+  *)
+    bad "pr-watch routes the verdict to its own emit arm" \
+      "${watch_arm:-no untracked-claim) arm}";;
+esac
 
 echo "$PASS passed, $FAIL failed"
 [ "$FAIL" = 0 ] || exit 1

--- a/skills/linear/DEVELOPMENT.md
+++ b/skills/linear/DEVELOPMENT.md
@@ -77,6 +77,6 @@ The distinction is not a judgement call left to the author: `run_status` refuses
 
 ### Must-fail controls
 
-`tests/controls/<suite>.control.sh` breaks the one behaviour its suite covers, in a copy of the skill, and `tests/must-fail-controls.sh` requires the suite to go red naming the assertion that covers it. A suite with no control fails the run: an untested control is an untested suite.
+`tests/controls/<suite>.control.sh` breaks the one behaviour its suite covers, in a copy of the skill, and `tests/must-fail-controls.sh` requires the suite to go red naming the assertion that covers it. A suite with no control fails the run: an untested control is an untested suite. So does a control no suite owns, reported as `ORPHAN`: nothing runs it, so its mutation is never applied and the behaviour it names is unproven. The roster is read in both directions whatever the selection, so a single-stem run cannot pass while a control sits in the directory unrun.
 
 A control declares what it expects with `control_expect <assertion description>` and mutates with `control_replace <file> <count> <old line> <new line>` — whole-line and literal, so there is no pattern syntax to mis-escape. `control_replace` aborts unless it matches exactly `count` lines, and the runner refuses a control that changed nothing, so a mutation that failed to land can never be read as a passing control. It also refuses a stem that names no suite and a selection that matched none, because a run that measured nothing is not a run that passed.

--- a/skills/linear/tests/controls/kendex-env-precedence.control.sh
+++ b/skills/linear/tests/controls/kendex-env-precedence.control.sh
@@ -1,6 +1,0 @@
-# Report every key as already set in the parent environment. Project settings
-# are then skipped wholesale, so a repo's own configuration never applies.
-control_expect "scenario 1: settings apply"
-control_replace scripts/lib/kendex-env.sh 1 \
-    '    [[ "$snapshot_name" == "$name" ]] && return 0' \
-    '    return 0'

--- a/skills/linear/tests/controls/roster-orphan.control.sh
+++ b/skills/linear/tests/controls/roster-orphan.control.sh
@@ -1,0 +1,7 @@
+# Disable the reverse-roster loop's body. The runner then walks the controls
+# directory, finds the orphan, and says nothing: every roster case in the
+# fixture reports a clean run.
+control_expect "a control no suite owns fails the full run"
+control_replace tests/must-fail-controls.sh 1 \
+	'		if [[ " ${stems[*]} " != *" $stem "* ]]; then' \
+	'		if false; then'

--- a/skills/linear/tests/must-fail-controls.sh
+++ b/skills/linear/tests/must-fail-controls.sh
@@ -5,7 +5,8 @@
 # A control breaks the one behaviour its suite claims to cover, in a copy of
 # the skill, and the suite must go red naming the assertion that covers it. A
 # suite with no control is a failure here: an untested control is an untested
-# suite.
+# suite. So is a control no suite owns: nothing runs it, so the mutation it
+# describes is never applied and the behaviour it claims to prove is unproven.
 #
 #   skills/linear/tests/must-fail-controls.sh                     # all
 #   skills/linear/tests/must-fail-controls.sh estimate-clear      # one, by stem
@@ -155,12 +156,24 @@ run_one() {
 
 main() {
 	local -a wanted=("$@") stems=()
-	local suite_path suite stem want failures=0 total=0
+	local suite_path control_path suite stem want failures=0 total=0 orphans=0
 
 	for suite_path in "$TESTS_DIR"/*.test.sh; do
 		stems+=("$(basename "$suite_path" .test.sh)")
 	done
 	[[ ${#stems[@]} -gt 0 ]] || die "no suites in $TESTS_DIR"
+
+	# The roster is read whole whatever the selection: a targeted run must
+	# not be green while a control sits in the directory unrun.
+	for control_path in "$CONTROLS_DIR"/*.control.sh; do
+		[[ -f "$control_path" ]] || die "no controls in $CONTROLS_DIR"
+		stem="$(basename "$control_path" .control.sh)"
+		if [[ " ${stems[*]} " != *" $stem "* ]]; then
+			printf 'ORPHAN   %-52s no %s.test.sh owns it\n' \
+				"controls/$stem.control.sh" "$stem"
+			orphans=$((orphans + 1))
+		fi
+	done
 
 	# A run that selected nothing is not a clean run: a mistyped stem would
 	# otherwise report "0 controls, 0 failing" and exit 0.
@@ -181,8 +194,9 @@ main() {
 
 	[[ "$total" -gt 0 ]] || die "selection matched no suites"
 
-	printf '\n%d controls, %d failing\n' "$total" "$failures"
-	[[ "$failures" -eq 0 ]]
+	printf '\n%d controls, %d failing, %d orphaned\n' \
+		"$total" "$failures" "$orphans"
+	[[ "$failures" -eq 0 && "$orphans" -eq 0 ]]
 }
 
 main "$@"

--- a/skills/linear/tests/roster-orphan.test.sh
+++ b/skills/linear/tests/roster-orphan.test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# The roster contract of tests/must-fail-controls.sh, both directions, driven
+# against a synthetic one-suite skill rather than this one.
+#
+# Why a fixture and not this skill's own roster: that roster is matched, so
+# the orphan branch is never taken by a run over skills/linear and deleting it
+# would leave every committed suite green. The fixture is the only place the
+# condition is constructible.
+#
+#   - a matched suite/control pair exits 0 and prints no ORPHAN line, so a
+#     case here cannot pass by always reporting a failure
+#   - a control no suite owns exits non-zero and the diagnostic names it
+#   - a targeted single-stem run reads the roster too: a selection cannot
+#     hide an orphan
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/assert.sh
+source "$SCRIPT_DIR/lib/assert.sh"
+RUNNER="$SCRIPT_DIR/must-fail-controls.sh"
+assert_tmpdir TMP
+
+# A one-suite skill whose suite reads a value its control flips: enough for the
+# runner to stage, mutate and red, and no more, so what these cases measure is
+# the roster and not the control machinery.
+fixture() {
+    local root="$1"
+    mkdir -p "$root/scripts" "$root/tests/controls"
+    printf 'VALUE=green\n' >"$root/scripts/value.sh"
+    cat >"$root/tests/alpha.test.sh" <<'SUITE'
+#!/usr/bin/env bash
+set -uo pipefail
+D="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$D/../scripts/value.sh"
+if [ "$VALUE" = green ]; then
+    echo "  ok    the value is green"
+    exit 0
+fi
+echo "  FAIL  the value is green"
+exit 1
+SUITE
+    cat >"$root/tests/controls/alpha.control.sh" <<'CONTROL'
+control_expect "the value is green"
+control_replace scripts/value.sh 1 'VALUE=green' 'VALUE=red'
+CONTROL
+    cp "$RUNNER" "$root/tests/must-fail-controls.sh"
+}
+
+# run_roster LOGFILE ROOT [STEM...] — run the fixture's copy of the runner,
+# combined output to LOGFILE. Echoes its status; the caller asserts on that
+# rather than branching, so no assertion runs inside a subshell.
+run_roster() {
+    local log="$1" root="$2"
+    shift 2
+    bash "$root/tests/must-fail-controls.sh" "$@" >"$log" 2>&1
+    echo "$?"
+}
+
+# --- the matched pair is the baseline --------------------------------------
+matched="$TMP/matched"
+fixture "$matched"
+rc="$(run_roster "$TMP/matched.log" "$matched")"
+assert_eq "a roster whose every control owns a suite exits 0" "$rc" 0
+assert_file_lacks "a matched roster prints no ORPHAN line" "$TMP/matched.log" "ORPHAN"
+assert_file_contains "the matched run reports no orphan" \
+    "$TMP/matched.log" "1 controls, 0 failing, 0 orphaned"
+
+# --- a control no suite owns fails the full run ----------------------------
+orphaned="$TMP/orphaned"
+fixture "$orphaned"
+printf 'control_expect "nothing runs this"\n' \
+    >"$orphaned/tests/controls/ghost.control.sh"
+
+rc="$(run_roster "$TMP/orphan-full.log" "$orphaned")"
+assert_ne "a control no suite owns fails the full run" "$rc" 0
+assert_file_contains "the full run names the orphaned control" \
+    "$TMP/orphan-full.log" "ORPHAN   controls/ghost.control.sh"
+assert_file_contains "the diagnostic names the suite that would own it" \
+    "$TMP/orphan-full.log" "no ghost.test.sh owns it"
+assert_file_contains "the full run counts the orphan" \
+    "$TMP/orphan-full.log" "1 controls, 0 failing, 1 orphaned"
+assert_file_contains "the orphan is what failed: the matched pair still passed" \
+    "$TMP/orphan-full.log" "ok       alpha.test.sh"
+
+# --- and fails a targeted single-stem run too ------------------------------
+# The case a selection-scoped roster read would have missed: with the orphan
+# check inside the per-suite loop, naming a stem would walk past it.
+rc="$(run_roster "$TMP/orphan-one.log" "$orphaned" alpha)"
+assert_ne "a targeted run fails on an orphan outside its selection" "$rc" 0
+assert_file_contains "the targeted run names the orphaned control" \
+    "$TMP/orphan-one.log" "ORPHAN   controls/ghost.control.sh"
+assert_file_contains "the targeted run counts the orphan" \
+    "$TMP/orphan-one.log" "1 controls, 0 failing, 1 orphaned"

--- a/skills/review-gate/tests/review-writer.test.sh
+++ b/skills/review-gate/tests/review-writer.test.sh
@@ -25,6 +25,10 @@
 #                                               description
 #   w8b. unreasoned-decline over a NEWER     -> posts failure directly
 #        success entry
+#   w9.  untracked-claim                     -> posts failure, remedy in the
+#                                               description
+#   w9b. untracked-claim over a NEWER        -> posts failure directly
+#        success entry
 # Write discipline (VST-65 ordering guard, success posts only):
 #   w10. guard re-read shows a non-success   -> defers (exit 0, no POST)
 #        entry at/after evaluated_at

--- a/skills/review-gate/tests/review-writer.test.sh
+++ b/skills/review-gate/tests/review-writer.test.sh
@@ -243,6 +243,8 @@ CR="verdict=changes-requested detail=standing review changes requested (persists
 THREADS="verdict=threads-open detail=2 unresolved review thread(s)"
 UNREASONED_DETAIL="1 decline(s) name no mechanism — give a passing state, a false premise, or an excluded class with the fact that puts it there"
 UNREASONED="verdict=unreasoned-decline detail=$UNREASONED_DETAIL"
+UNTRACKED_DETAIL="1 tracking claim(s) name no issue — write Declined: <reason>, or add the tracker/#id"
+UNTRACKED="verdict=untracked-claim detail=$UNTRACKED_DETAIL"
 
 # created_at anchors: OLD predates every stub run's start (RUN_START =
 # 2020-06-01) and every evaluation instant; LATE lands after RUN_START but
@@ -296,6 +298,21 @@ rc=0; out=$(run_writer STUB_VERDICT_LINE="$UNREASONED" \
 assert_eq "$rc" "0" "w8b: unreasoned-decline over a newer success exits 0"
 assert_contains "$(cat "$POST_LOG")" "state=failure" "w8b: posts failure over it — a downward post never defers"
 assert_not_contains "$out" "deferring" "w8b: no deferral on the downward path"
+
+# w9: a reply claiming tracking that names no issue is the other red verdict.
+# Driven through the writer for the same reason w8 is: the mapping line reads
+# the same whether the verdict is spelled right or not, and an unmapped
+# verdict exits 1 on "unknown verdict" instead of posting anything.
+rc=0; out=$(run_writer STUB_VERDICT_LINE="$UNTRACKED" STUB_GATE_HISTORY='[]') || rc=$?
+assert_eq "$rc" "0" "w9: untracked-claim exits 0"
+assert_contains "$(cat "$POST_LOG")" "state=failure" "w9: untracked-claim posts failure"
+assert_contains "$(cat "$POST_LOG")" "$UNTRACKED_DETAIL" "w9: the remedy reaches the status description"
+
+rc=0; out=$(run_writer STUB_VERDICT_LINE="$UNTRACKED" \
+  STUB_GATE_HISTORY='[{"context":"Review gate","state":"success","description":"ok","created_at":"'"$FUTURE"'"}]') || rc=$?
+assert_eq "$rc" "0" "w9b: untracked-claim over a newer success exits 0"
+assert_contains "$(cat "$POST_LOG")" "state=failure" "w9b: posts failure over it — a downward post never defers"
+assert_not_contains "$out" "deferring" "w9b: no deferral on the downward path"
 
 echo "=== approved converges to success ==="
 

--- a/skills/review-gate/tests/untracked-claim.test.sh
+++ b/skills/review-gate/tests/untracked-claim.test.sh
@@ -5,11 +5,11 @@
 # carries a track-word: a claim with no issue id counts, such a reply
 # never does, later replies of any other kind, bot replies, and resolving
 # the thread do not move it. A comments page it cannot finish fails closed.
-# The writer maps the verdict to a failure status.
+# The watcher surfaces the verdict. Its mapping to a failure status is
+# review-writer.test.sh w9, driven through the writer itself.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PRED="$SCRIPT_DIR/../scripts/review-predicate.sh"
-WRITER="$SCRIPT_DIR/../scripts/review-writer.sh"
 PASS=0 FAIL=0
 ok()  { PASS=$((PASS+1)); echo "  ok    $1"; }
 bad() { FAIL=$((FAIL+1)); echo "  FAIL  $1"; echo "        got: $2"; }
@@ -74,9 +74,6 @@ case "$out" in "1 0 "*) ok "unresolved counting unchanged";; *) bad "unresolved 
 out=$(page "$(thread true "$(human 'Tracked: KEN-1')" true)")
 case "$out" in malformed) ok "a 50+-comment thread fails closed as malformed";; *) bad "a 50+-comment thread fails closed as malformed" "$out";; esac
 
-grep -q 'untracked-claim)       desired="failure"' "$WRITER" \
-  && ok "writer maps untracked-claim to failure" \
-  || bad "writer maps untracked-claim to failure" "mapping line missing"
 grep -q 'untracked-claim' "$SCRIPT_DIR/../scripts/pr-watch.sh" \
   && ok "pr-watch accepts and surfaces the verdict" \
   || bad "pr-watch accepts and surfaces the verdict" "not referenced"

--- a/skills/review-gate/tests/untracked-claim.test.sh
+++ b/skills/review-gate/tests/untracked-claim.test.sh
@@ -5,8 +5,7 @@
 # carries a track-word: a claim with no issue id counts, such a reply
 # never does, later replies of any other kind, bot replies, and resolving
 # the thread do not move it. A comments page it cannot finish fails closed.
-# The watcher surfaces the verdict. Its mapping to a failure status is
-# review-writer.test.sh w9, driven through the writer itself.
+# The verdict's mapping to a failure status is review-writer.test.sh w9.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PRED="$SCRIPT_DIR/../scripts/review-predicate.sh"
@@ -73,20 +72,6 @@ case "$out" in "1 0 "*) ok "unresolved counting unchanged";; *) bad "unresolved 
 
 out=$(page "$(thread true "$(human 'Tracked: KEN-1')" true)")
 case "$out" in malformed) ok "a 50+-comment thread fails closed as malformed";; *) bad "a 50+-comment thread fails closed as malformed" "$out";; esac
-
-# The routing arm, not any mention of the verdict: the help text and the
-# verdict allow-list both carry the string, so a bare grep for it stays green
-# with the arm renamed away. Anchored on the arm's own label line, whose next
-# line must emit the verdict.
-watch_arm="$(grep -A 1 '^    untracked-claim)$' \
-  "$SCRIPT_DIR/../scripts/pr-watch.sh" | tail -n 1 || true)"
-case "$watch_arm" in
-  *'emit "$number" "$head" untracked-claim'*)
-    ok "pr-watch routes the verdict to its own emit arm";;
-  *)
-    bad "pr-watch routes the verdict to its own emit arm" \
-      "${watch_arm:-no untracked-claim) arm}";;
-esac
 
 echo "$PASS passed, $FAIL failed"
 [ "$FAIL" = 0 ] || exit 1

--- a/skills/review-gate/tests/untracked-claim.test.sh
+++ b/skills/review-gate/tests/untracked-claim.test.sh
@@ -74,9 +74,19 @@ case "$out" in "1 0 "*) ok "unresolved counting unchanged";; *) bad "unresolved 
 out=$(page "$(thread true "$(human 'Tracked: KEN-1')" true)")
 case "$out" in malformed) ok "a 50+-comment thread fails closed as malformed";; *) bad "a 50+-comment thread fails closed as malformed" "$out";; esac
 
-grep -q 'untracked-claim' "$SCRIPT_DIR/../scripts/pr-watch.sh" \
-  && ok "pr-watch accepts and surfaces the verdict" \
-  || bad "pr-watch accepts and surfaces the verdict" "not referenced"
+# The routing arm, not any mention of the verdict: the help text and the
+# verdict allow-list both carry the string, so a bare grep for it stays green
+# with the arm renamed away. Anchored on the arm's own label line, whose next
+# line must emit the verdict.
+watch_arm="$(grep -A 1 '^    untracked-claim)$' \
+  "$SCRIPT_DIR/../scripts/pr-watch.sh" | tail -n 1 || true)"
+case "$watch_arm" in
+  *'emit "$number" "$head" untracked-claim'*)
+    ok "pr-watch routes the verdict to its own emit arm";;
+  *)
+    bad "pr-watch routes the verdict to its own emit arm" \
+      "${watch_arm:-no untracked-claim) arm}";;
+esac
 
 echo "$PASS passed, $FAIL failed"
 [ "$FAIL" = 0 ] || exit 1


### PR DESCRIPTION
## Summary

- `must-fail-controls.sh` reads the whole controls roster on every run, whatever the selection, and reds on a control no suite owns. Before this it checked only suite → control, so an unowned control sat in the directory unrun and the mutation it describes was never applied.
- The one orphan goes. KEN-898 (`05c2fe975`) deleted the five vendored `kendex-env-precedence` suites and left linear's control behind; the precedence behaviour it named is covered by `skills/orch/tests/kendex-env-precedence.sh`, and linear's `kendex-env.sh` is pinned byte-identical to orch's by `tools/tests/vendored-settings-libs.test.sh`. Full run: 47 controls, 0 failing, 0 orphaned.
- `review-writer.test.sh` drove five of the six verdicts through `run_writer` but never `untracked-claim`, the other one mapping to failure. `w9` and `w9b` add it in the shape of the neighbouring `w8` cases.
- Two source-text greps in `untracked-claim.test.sh` are gone rather than tightened. Both stood in for behavioural coverage: one duplicated `w9`, and the other could not red on the regression it existed to catch.

Three of the issue's five requirements were already resolved by merged work and are not touched here — see Test Plan.

## Completed Issues

- Closes KEN-1015 - Audit defects: orphaned mutation control, fail-open grep, vacuous and cannot-fail checks

## Test Plan

Each new check was proved able to red, not merely observed green.

- Orphan guard: with the deleted control restored, a targeted run exits 1 naming it and a full run reports `47 controls, 0 failing, 1 orphaned`; at HEAD both exit 0 on `0 orphaned`. Independently reproduced by two reviewers, one of them on a synthetic orphan in a fixture skill. Emptying or removing `controls/` dies exit 2, so an empty glob cannot read as "no orphans".
- `w9`/`w9b`: mutating `review-writer.sh`'s `untracked-claim` arm to `desired="pending"` reds exactly those two cases and leaves the other 110 assertions green. `mutation: killed 1/1; stability: 10/10 at 64 threads`.
- The deleted greps: before deleting the writer grep, removing the writer's `untracked-claim` arm was confirmed to red `w9`/`w9b`, so the behaviour is carried. The pr-watch grep was cut rather than replaced — reviewer-test showed both its original and its tightened form stay green while the routing is removed (help text satisfies the first; a commented-out, `false &&`-guarded, or quoted emit satisfies the second).
- Suites at HEAD: `untracked-claim` 16/0, `review-writer` 112/0, `pr-watch` 175/0, `must-fail-controls` 47 controls 0 failing 0 orphaned. `tools/guard` green, `bash32-lint` clean over 440 files.

Three requirements needed no work, verified against the tree:

- `label-preflight-contract.test.sh` and `tracker-routing-contract.test.sh` were deleted by `8292f0088` (KEN-1093, #1954).
- The cannot-fail control in `review-writer-template.test.sh` was removed by `9a7b498e6` (KEN-1092, #1958).

## Known Gap

`pr-watch.sh`'s `untracked-claim` routing has no behavioural coverage — no pin can reach its `attention=1` or its `stale_gate` escalation, which is why the grep standing in for one was cut rather than tightened a third time. Declined rather than filed: the arm works today, so the impact needs a future regression.

https://claude.ai/code/session_01U4st4HmC1adMuaiiR1dA2D
