### PR TITLE
refactor(KEN-1040): ItemKind drops its slot assert

### DIFF
--- a/crates/core/src/engine/expansion.rs
+++ b/crates/core/src/engine/expansion.rs
@@ -360,10 +360,9 @@ mod tests {
     /// to the enum stops this test compiling until it is classified here.
     /// What this does not hold: the loop walks `ItemKind::ALL`, so a kind
     /// missing from that list is one it never visits, its arm here
-    /// satisfied and unexercised. `model.rs` fails the build for a kind
-    /// dropped from `ALL` or reordered within it, and for a variant never
-    /// added to it neither side catches anything — measured, and the note
-    /// on `ALL` says why closing it is not cheap.
+    /// satisfied and unexercised. `ALL`'s declared `[ItemKind; 7]` reds a
+    /// kind removed outright and `replace_unmanaged.rs` pins Agent, Skill
+    /// and Hook in that relative order; nothing else about `ALL` is held.
     #[test]
     fn only_the_kinds_a_plan_derives_have_a_per_package_update() {
         for kind in ItemKind::ALL {

--- a/crates/core/src/model.rs
+++ b/crates/core/src/model.rs
@@ -86,10 +86,7 @@ pub enum ItemKind {
 impl ItemKind {
     /// Every kind, and the sweep every caller walks to reach them all. A
     /// kind missing from here is one every one of those sweeps skips
-    /// silently, so the assertion under this impl catches one dropped or
-    /// reordered at build time. It cannot catch one never added: a variant
-    /// given its `slot` arm and left out of this list compiles and passes,
-    /// measured. Rust offers no variant count without a derive macro or an
+    /// silently. Rust offers no variant count without a derive macro or an
     /// unstable intrinsic, so adding a kind means adding it here.
     pub const ALL: [ItemKind; 7] = [
         ItemKind::Agent,
@@ -100,21 +97,6 @@ impl ItemKind {
         ItemKind::Plugin,
         ItemKind::PiExtension,
     ];
-
-    /// Where this kind sits in [`Self::ALL`]. Exhaustive, so a variant
-    /// added to the enum has to be given a slot before anything builds —
-    /// which is not the same as being put in `ALL`; see the note there.
-    const fn slot(self) -> usize {
-        match self {
-            ItemKind::Agent => 0,
-            ItemKind::Skill => 1,
-            ItemKind::Hook => 2,
-            ItemKind::Command => 3,
-            ItemKind::McpServer => 4,
-            ItemKind::Plugin => 5,
-            ItemKind::PiExtension => 6,
-        }
-    }
 
     pub fn name(self) -> &'static str {
         match self {
@@ -128,18 +110,6 @@ impl ItemKind {
         }
     }
 }
-
-/// Every kind [`ItemKind::ALL`] holds sits at its own slot. A kind dropped
-/// from `ALL`, or reordered out of step with its slot, fails the build here
-/// rather than quietly shrinking every sweep that walks it. This says
-/// nothing about a kind `ALL` never had — see the note on `ALL`.
-const _: () = {
-    let mut slot = 0;
-    while slot < ItemKind::ALL.len() {
-        assert!(ItemKind::ALL[slot].slot() == slot);
-        slot += 1;
-    }
-};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, Type)]
 #[serde(tag = "scope", rename_all = "kebab-case")]


### PR DESCRIPTION
## Summary

- `ItemKind::slot()` and the `const _` loop over it are gone from `crates/core/src/model.rs`. They caught a kind dropped from `ALL` or reordered within it, a seven-item literal nobody edits, and the doc conceded they could not catch a variant never added, which is how one actually goes missing. `ALL` stays a literal list.
- The test doc on `only_the_kinds_a_plan_derives_have_a_per_package_update` in `crates/core/src/engine/expansion.rs` claimed `model.rs` fails the build for a kind dropped from `ALL` or reordered. Deleting the assert made that false, and the sentence is the one telling a reader which half of the `ItemKind::ALL` completeness question is covered elsewhere. It now states what holds.

## Scope

The TS half named in the issue body (`pageUpdateWithheld`, `unhandledReadState`, the `UpdatesReadStanding` intersection type, `package-update.dom.test.tsx`) is not here. The re-scope comment on KEN-1040 moved it to KEN-1099, which has merged, and those symbols are already absent from the tree. Both Done-when greps were empty before this branch started.

## What still guards `ItemKind::ALL`

Each claim in the rewritten comment was measured on this branch rather than reasoned about:

| Mutation | Result |
|---|---|
| `PiExtension` removed from `ALL` | fails to compile, E0308 against the declared `[ItemKind; 7]` |
| `Agent` and `Skill` swapped | reds `replace_unmanaged.rs` `the_page_is_told_which_kinds_can_be_kept` |
| `Plugin` and `PiExtension` swapped | survives the workspace, 2212 passed |
| `Hook` and `Command` swapped | survives the workspace |

`adoptable()` in `crates/app/src/audit.rs` filters `ALL` in order, so that test pins the relative order of the three adoptable kinds and nothing else. A tail reorder is caught by nothing. No assertion is reinstated: the suite stayed green through the deletion, so nothing was named for restoring, and a reorder is a hypothetical future edit rather than a present defect.

## Completed Issues

- Closes KEN-1040 - ItemKind::slot and the never-typed page gate are gone; the package page reads a plain switch

## Test Plan

- `tools/guard` exit 0 on this base: `tsc --noEmit`, biome, vitest (120 files, 1031 tests), the full cargo workspace suite, preflight, size-ratchet.
- Done-when greps empty: `fn slot` in `crates/core/src/model.rs`, `unhandledReadState` under `ui/src`.
- The KEN-906 regression case still passes: `ui/src/pages/package.test.tsx` "names the kind's own refusal over a read that failed".

https://claude.ai/code/session_01RwSaq3BB3iZMLN5F5k25Pk
