### PR TITLE
refactor(KEN-1043): gh-stub keys are plain words again

### DIFF
--- a/.agents/skills/github/tests/gh-stub-restage.test.sh
+++ b/.agents/skills/github/tests/gh-stub-restage.test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Proof that gh-stub.sh refuses a colliding restage.
+#
+# A verb's key is a file stem, so `api-a/b` and `api-a%b` name one file. The
+# second staging used to overwrite the first without a word, which hands the
+# first verb's answer to a call nobody staged. That is the fail-open a fake
+# exists to prevent, so the second staging is refused instead.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+ok() {
+  PASS=$((PASS + 1))
+  printf '  ok    %s\n' "$1"
+}
+bad() {
+  FAIL=$((FAIL + 1))
+  printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"
+}
+eq() { # eq GOT WANT NAME
+  if [ "$1" = "$2" ]; then ok "$3"; else bad "$3" "wanted [$2], got [$1]"; fi
+}
+
+# shellcheck source=lib/gh-stub.sh
+. "$TEST_DIR/lib/gh-stub.sh"
+
+GH_STUB_DIR="$TMP/stage"
+export GH_STUB_DIR
+gh_stub_install "$TMP/bin" || {
+  echo "gh_stub_install failed" >&2
+  exit 1
+}
+PATH="$TMP/bin:$PATH"
+export PATH
+
+echo "=== a second verb on one key is refused ==="
+
+gh_stub_answer 'api-a/b' 'slashed'
+
+status=0
+err="$TMP/err"
+gh_stub_answer 'api-a%b' 'percent' 2>"$err" || status=$?
+if [ "$status" -ne 0 ]; then
+  ok "must-fail: a second verb on the same key is refused"
+else
+  bad "the colliding staging was accepted" "gh_stub_answer exited 0"
+fi
+if grep -q 'api-a/b' "$err" && grep -q 'api-a%b' "$err"; then
+  ok "the refusal names the key and the verb holding it"
+else
+  bad "the refusal named neither verb" "$(cat "$err")"
+fi
+eq "$(gh api 'a/b')" "slashed" "the first verb keeps its answer"
+
+echo "=== the same verb still restages ==="
+
+# The control: the refusal is about a SECOND verb, not about staging twice.
+# Restaging is how a suite says "from here, this", and the seeded identity
+# answers exist to be overridden that way.
+gh_stub_answer 'api-a/b' 'restaged'
+eq "$(gh api 'a/b')" "restaged" "must-fail control: one verb restages itself"
+gh_stub_answer api-user 'someone-else'
+eq "$(gh api user)" "someone-else" "must-fail control: a seeded answer restages"
+
+echo "=== reset releases the key ==="
+
+# A scenario boundary clears the claim, so the next scenario is free to stage
+# the other spelling.
+gh_stub_reset
+gh_stub_answer 'api-a%b' 'percent'
+eq "$(gh api 'a%b')" "percent" "the other verb stages after a reset"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.agents/skills/github/tests/gh-stub-restage.test.sh
+++ b/.agents/skills/github/tests/gh-stub-restage.test.sh
@@ -91,6 +91,18 @@ else
   ok "must-fail: the claim refuses in both directions"
 fi
 
+echo "=== a foreign claim falls through to the broad key ==="
+
+# Unstaged for this call is not the same as refused. A stem another verb
+# claimed is not KNOWN to this call either, so the one-word `api` staging
+# still answers a path the suite never named one at a time — the fallback
+# is what makes a claim narrow the answer rather than block the call.
+gh_stub_reset
+gh_stub_answer 'api-a/b' 'slashed'
+gh_stub_answer api 'broad'
+eq "$(gh api 'a%b')" "broad" "the foreign spelling falls through to the one-word key"
+eq "$(gh api 'a/b')" "slashed" "the claimant still gets its own answer"
+
 echo "=== @ is reserved for selector slots ==="
 
 # The stub mints `<stem>@<id>` for a selector's slot. A verb or a call

--- a/.agents/skills/github/tests/gh-stub-restage.test.sh
+++ b/.agents/skills/github/tests/gh-stub-restage.test.sh
@@ -103,6 +103,20 @@ gh_stub_answer api 'broad'
 eq "$(gh api 'a%b')" "broad" "the foreign spelling falls through to the one-word key"
 eq "$(gh api 'a/b')" "slashed" "the claimant still gets its own answer"
 
+echo "=== a one-word call does not take a two-word claim ==="
+
+# The join is blind to arity: the two-word `api user` and the one-word
+# command `api-user` both key on `api-user`. The claim is what keeps them
+# apart, and without it a suite goes green after the code under test ran a
+# command gh does not have.
+gh_stub_reset
+eq "$(gh api user)" "test-user" "must-fail control: the two-word call still resolves"
+if out="$(gh api-user 2>&1)"; then
+  bad "the one-word call took the two-word answer" "got: $out"
+else
+  ok "must-fail: a one-word call does not take a two-word claim"
+fi
+
 echo "=== @ is reserved for selector slots ==="
 
 # The stub mints `<stem>@<id>` for a selector's slot. A verb or a call

--- a/.agents/skills/github/tests/gh-stub-restage.test.sh
+++ b/.agents/skills/github/tests/gh-stub-restage.test.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
-# Proof that gh-stub.sh refuses a colliding restage.
+# Proof that gh-stub.sh keeps one stem to one verb.
 #
 # A verb's key is a file stem, so `api-a/b` and `api-a%b` name one file. The
-# second staging used to overwrite the first without a word, which hands the
-# first verb's answer to a call nobody staged. That is the fail-open a fake
-# exists to prevent, so the second staging is refused instead.
+# second staging would overwrite the first without a word, and a call spelled
+# either way would take whichever answer landed there. Both hand a staged
+# answer to a call nobody staged, which is the fail-open a fake exists to
+# prevent, so the second staging is refused and the other spelling's call
+# finds nothing.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -56,6 +58,14 @@ else
 fi
 eq "$(gh api 'a/b')" "slashed" "the first verb keeps its answer"
 
+# The resolution half: the claimed stem is not this call's, so it is unstaged
+# rather than served the claimant's answer.
+if out="$(gh api 'a%b' 2>&1)"; then
+  bad "the other spelling was answered" "with the api-a/b answer: $out"
+else
+  ok "must-fail: the other spelling finds the stem unstaged"
+fi
+
 echo "=== the same verb still restages ==="
 
 # The control: the refusal is about a SECOND verb, not about staging twice.
@@ -73,6 +83,13 @@ echo "=== reset releases the key ==="
 gh_stub_reset
 gh_stub_answer 'api-a%b' 'percent'
 eq "$(gh api 'a%b')" "percent" "the other verb stages after a reset"
+# And the refusal runs the other way round: the claim is whichever verb got
+# there first, not one spelling the stub prefers.
+if out="$(gh api 'a/b' 2>&1)"; then
+  bad "the slashed spelling was answered" "with the api-a%b answer: $out"
+else
+  ok "must-fail: the claim refuses in both directions"
+fi
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/.agents/skills/github/tests/gh-stub-restage.test.sh
+++ b/.agents/skills/github/tests/gh-stub-restage.test.sh
@@ -91,6 +91,31 @@ else
   ok "must-fail: the claim refuses in both directions"
 fi
 
+echo "=== @ is reserved for selector slots ==="
+
+# The stub mints `<stem>@<id>` for a selector's slot. A verb or a call
+# carrying `@` addresses one of those slots without ever having staged it,
+# and the verb claim above cannot see it because the two names have
+# different owners.
+gh_stub_reset
+
+status=0
+gh_stub_answer 'api-x@1' 'LITERAL' 2>"$err" || status=$?
+if [ "$status" -ne 0 ]; then
+  ok "must-fail: a staged verb carrying @ is refused"
+else
+  bad "the reserved verb was staged" "gh_stub_answer exited 0"
+fi
+
+gh_stub_answer 'api-graphql:needle' 'SELECTOR'
+if out="$(gh api 'graphql@1' 2>&1)"; then
+  bad "a call carrying @ reached a selector slot" "got: $out"
+else
+  ok "must-fail: a call carrying @ does not reach a selector slot"
+fi
+# The control: the selector still answers the call it was staged for.
+eq "$(gh api graphql -f q=needle)" "SELECTOR" "must-fail control: the selector still answers"
+
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.agents/skills/github/tests/lib/gh-stub.sh
+++ b/.agents/skills/github/tests/lib/gh-stub.sh
@@ -42,6 +42,16 @@
 # hands a staged answer to a call nobody staged, which is the fail-open a
 # fake exists to prevent.
 #
+# THE CLAIM RECORDS WORDS, NOT THE JOINED TEXT. The join is lossy about
+# arity: the two-word `api user` and the one-word command `api-user` both
+# spell `api-user`, and a claim holding that string would hand the seeded
+# `api user` answer to a call that ran the wrong command. So the record
+# separates the words by a byte no gh argv word carries, and a call rebuilds
+# the same form from its own argv — two words when it took `$2`, one word
+# otherwise. A staged verb splits at its FIRST `-`, which is where the join
+# put it. Arity is therefore part of the claim, and the two spellings, which
+# still share a stem, cannot take each other's answers.
+#
 # `@` IS RESERVED. The stub mints `<stem>@<id>` for a selector's slot, so a
 # verb or a call carrying `@` in its own text would address a slot nobody
 # staged under it — the same fail-open, one layer down, and one the verb
@@ -95,15 +105,26 @@ set -uo pipefail
 
 printf '%s\n' "$*" >>"$STUB_DIR/gh.calls"
 
+# SEP joins the claim's words. It is not in any gh argv word, so a claim
+# built from two words never reads as one word that happens to contain it.
+SEP="$(printf '\034')"
+
 # The verb: the first word, plus the second when it is not flag-shaped. The
 # first word alone is the fallback, so `api` can answer every api path a
-# suite did not name one at a time.
+# suite did not name one at a time. `claim` is the same words unjoined —
+# what the staging helpers recorded — so a one-word `gh api-user` and the
+# two-word `gh api user`, which share the stem `api-user`, differ here.
 verb="${1:-}"
 fallback="${1:-}"
+claim="${1:-}"
+fallback_claim="${1:-}"
 if [ "$#" -gt 1 ]; then
   case "${2:-}" in
   -*) ;;
-  *) verb="$verb-$2" ;;
+  *)
+    verb="$verb-$2"
+    claim="$claim$SEP$2"
+    ;;
   esac
 fi
 
@@ -113,13 +134,16 @@ slug() { printf '%s' "$1" | tr '/' '%'; }
 
 argv="$*"
 
-# ours STEM VERB — false when STEM is not this call's to read. `/` cannot
-# appear in a file name, so `api a/b` and `api 'a%b'` reach one stem. The
-# staging helpers record which verb claimed it, and a call spelled the other
-# way is UNSTAGED here, never served the claimant's answer. A stem carrying
-# `@` belongs to no verb at all: `@` is minted below for a selector's slot,
-# and the staging helpers refuse it in a verb, so a call that spells one is
-# reaching for a slot rather than for anything staged under its own name.
+# ours STEM CLAIM — false when STEM is not this call's to read. Several verbs
+# reach one stem: `/` cannot appear in a file name, so `api a/b` and `api
+# 'a%b'` both key on `api-a%b`, and the join is blind to arity, so the
+# one-word `api-user` keys where `api user` does. The staging helpers record
+# the claimant's words, and a call whose own words differ — a different
+# spelling, or a different number of them — is UNSTAGED here, never served
+# the claimant's answer. A stem carrying `@` belongs to no verb at all: `@`
+# is minted below for a selector's slot, and the staging helpers refuse it in
+# a verb, so a call that spells one is reaching for a slot rather than for
+# anything staged under its own name.
 ours() {
   case "$1" in
   *@*) return 1 ;;
@@ -127,8 +151,8 @@ ours() {
   [ ! -f "$STUB_DIR/$1.verb" ] || [ "$(cat "$STUB_DIR/$1.verb")" = "$2" ]
 }
 
-# resolve BASE VERB — the staged stem for BASE, or empty when BASE holds
-# nothing VERB staged. A selector wins over the plain key, in staging order:
+# resolve BASE CLAIM — the staged stem for BASE, or empty when BASE holds
+# nothing CLAIM's words staged. A selector wins over the plain key, in staging order:
 # the index holds one `id<TAB>text` line per selector, and the first whose
 # text occurs in this call's argv names the answer. The call ordinal is
 # counted per resolved stem, so a sequence answers each call once; `.0` is
@@ -159,11 +183,12 @@ resolve() {
   fi
 }
 
-# known KEY VERB — true when VERB staged anything at all under KEY. A key
+# known KEY CLAIM — true when CLAIM's words staged anything at all under
+# KEY. A key
 # that is known but has no answer left is a REFUSAL, never a fall-through: a
 # sequence that ran out means the code polled once more than the suite said
 # it would, and answering that from a broad one-word key would hide it. A key
-# another verb claimed is not known to this call, so the one-word fallback
+# another claimant holds is not known to this call, so the one-word fallback
 # still answers a path the suite never named.
 known() {
   local stem="$1"
@@ -174,9 +199,9 @@ known() {
 }
 
 key="$(slug "$verb")"
-pick="$(resolve "$key" "$verb")"
-if [ -z "$pick" ] && [ "$fallback" != "$verb" ] && ! known "$key" "$verb"; then
-  pick="$(resolve "$(slug "$fallback")" "$fallback")"
+pick="$(resolve "$key" "$claim")"
+if [ -z "$pick" ] && [ "$fallback" != "$verb" ] && ! known "$key" "$claim"; then
+  pick="$(resolve "$(slug "$fallback")" "$fallback_claim")"
 fi
 
 if [ -z "$pick" ]; then
@@ -202,8 +227,16 @@ STUB
 # The stem is claimed by the first verb staged under it and refuses a second:
 # `api-a/b` and `api-a%b` are one stem, and letting the second overwrite the
 # first is the fail-open a fake exists to prevent.
+#
+# The record holds the verb's WORDS, split at the first `-` because that is
+# where the join put the boundary, separated by a byte no gh argv word
+# carries. A call rebuilds the same form from its own argv, so the one-word
+# command `api-user` cannot read the two-word `api user`'s answer even
+# though both spell one stem. Replacing the separator with `-` recovers the
+# verb as written, which is how the refusal below names it.
 _gh_stub_key() {
-  local verb="$1" sel="" base id owner
+  local verb="$1" sel="" base id owner claim sep
+  sep="$(printf '\034')"
   case "$verb" in
   *:*)
     sel="${verb#*:}"
@@ -217,14 +250,18 @@ _gh_stub_key() {
     return 1
     ;;
   esac
+  claim="$verb"
+  case "$verb" in
+  *-*) claim="${verb%%-*}$sep${verb#*-}" ;;
+  esac
   base="$(printf '%s' "$verb" | tr '/' '%')"
   owner="${STUB_DIR:?}/$base.verb"
-  if [ -f "$owner" ] && [ "$(cat "$owner")" != "$verb" ]; then
+  if [ -f "$owner" ] && [ "$(cat "$owner")" != "$claim" ]; then
     printf 'gh-stub: %s already keys on %s; %s would overwrite it\n' \
-      "$(cat "$owner")" "$base" "$verb" >&2
+      "$(tr "$sep" '-' <"$owner")" "$base" "$verb" >&2
     return 1
   fi
-  printf '%s' "$verb" >"$owner" || return 1
+  printf '%s' "$claim" >"$owner" || return 1
   [ -n "$sel" ] || {
     printf '%s' "$base"
     return 0

--- a/.agents/skills/github/tests/lib/gh-stub.sh
+++ b/.agents/skills/github/tests/lib/gh-stub.sh
@@ -36,10 +36,11 @@
 #
 # THE KEY a verb names is one file stem: the verb's words as written, with
 # `/` spelled `%` because a stem is a file name. Two verbs can therefore
-# reach one stem — `api-a/b` and `api-a%b` do — and the second staging would
-# overwrite the first, handing a staged answer to a call nobody staged. So a
-# stem records the verb that claimed it, and a staging under a second verb is
-# REFUSED rather than served.
+# reach one stem — `api-a/b` and `api-a%b` do — so a stem records the verb
+# that claimed it. A staging under a second verb is REFUSED, and a call whose
+# own verb is not the claimant's finds the stem UNSTAGED. Either half missing
+# hands a staged answer to a call nobody staged, which is the fail-open a
+# fake exists to prevent.
 #
 # A VERB IS NOT ALWAYS ENOUGH. Two `api graphql` calls carrying different
 # queries are one verb, and answering both the same way would let a suite
@@ -75,7 +76,7 @@ gh_stub_install() {
   STUB_DIR="$(cd "$STUB_DIR" && pwd)" || return 1
   export STUB_DIR
 
-  cat >"$bin/gh" <<'STUB'
+  cat >"$bin/gh" <<'STUB' || return 1
 #!/usr/bin/env bash
 # Written by github/tests/lib/gh-stub.sh. Answers from $STUB_DIR.
 set -uo pipefail
@@ -105,14 +106,23 @@ slug() { printf '%s' "$1" | tr '/' '%'; }
 
 argv="$*"
 
-# resolve BASE — the staged stem for BASE, or empty when nothing is staged
-# under it. A selector wins over the plain key, in staging order: the index
-# holds one `id<TAB>text` line per selector, and the first whose text occurs
-# in this call's argv names the answer. The call ordinal is counted per
-# resolved stem, so a sequence answers each call once; `.0` is the answer
-# for every call and is what gh_stub_answer stages.
+# ours STEM VERB — false when STEM was claimed by a different staged verb.
+# `/` cannot appear in a file name, so `api a/b` and `api 'a%b'` reach one
+# stem. The staging helpers record which verb claimed it, and a call spelled
+# the other way is UNSTAGED here, never served the claimant's answer.
+ours() {
+  [ ! -f "$STUB_DIR/$1.verb" ] || [ "$(cat "$STUB_DIR/$1.verb")" = "$2" ]
+}
+
+# resolve BASE VERB — the staged stem for BASE, or empty when BASE holds
+# nothing VERB staged. A selector wins over the plain key, in staging order:
+# the index holds one `id<TAB>text` line per selector, and the first whose
+# text occurs in this call's argv names the answer. The call ordinal is
+# counted per resolved stem, so a sequence answers each call once; `.0` is
+# the answer for every call and is what gh_stub_answer stages.
 resolve() {
   local key="$1" sel_id sel_text n
+  ours "$key" "$2" || return 0
   if [ -f "$STUB_DIR/$key.selectors" ]; then
     while IFS="$(printf '\t')" read -r sel_id sel_text; do
       [ -n "$sel_id" ] || continue
@@ -136,20 +146,24 @@ resolve() {
   fi
 }
 
-# known KEY — true when a suite staged anything at all under KEY. A key that
-# is known but has no answer left is a REFUSAL, never a fall-through: a
+# known KEY VERB — true when VERB staged anything at all under KEY. A key
+# that is known but has no answer left is a REFUSAL, never a fall-through: a
 # sequence that ran out means the code polled once more than the suite said
-# it would, and answering that from a broad one-word key would hide it.
+# it would, and answering that from a broad one-word key would hide it. A key
+# another verb claimed is not known to this call, so the one-word fallback
+# still answers a path the suite never named.
 known() {
-  [ -f "$STUB_DIR/$1.selectors" ] && return 0
-  set -- "$STUB_DIR/$1".*.out
+  local stem="$1"
+  ours "$stem" "$2" || return 1
+  [ -f "$STUB_DIR/$stem.selectors" ] && return 0
+  set -- "$STUB_DIR/$stem".*.out
   [ -f "$1" ]
 }
 
 key="$(slug "$verb")"
-pick="$(resolve "$key")"
-if [ -z "$pick" ] && [ "$fallback" != "$verb" ] && ! known "$key"; then
-  pick="$(resolve "$(slug "$fallback")")"
+pick="$(resolve "$key" "$verb")"
+if [ -z "$pick" ] && [ "$fallback" != "$verb" ] && ! known "$key" "$verb"; then
+  pick="$(resolve "$(slug "$fallback")" "$fallback")"
 fi
 
 if [ -z "$pick" ]; then
@@ -190,7 +204,7 @@ _gh_stub_key() {
       "$(cat "$owner")" "$base" "$verb" >&2
     return 1
   fi
-  printf '%s' "$verb" >"$owner"
+  printf '%s' "$verb" >"$owner" || return 1
   [ -n "$sel" ] || {
     printf '%s' "$base"
     return 0

--- a/.agents/skills/github/tests/lib/gh-stub.sh
+++ b/.agents/skills/github/tests/lib/gh-stub.sh
@@ -42,6 +42,13 @@
 # hands a staged answer to a call nobody staged, which is the fail-open a
 # fake exists to prevent.
 #
+# `@` IS RESERVED. The stub mints `<stem>@<id>` for a selector's slot, so a
+# verb or a call carrying `@` in its own text would address a slot nobody
+# staged under it — the same fail-open, one layer down, and one the verb
+# claim cannot see because the colliding names have different owners.
+# Staging such a verb is refused, and a call whose stem carries `@` is
+# unstaged. `%` stays legal: it is how a stem spells `/`.
+#
 # A VERB IS NOT ALWAYS ENOUGH. Two `api graphql` calls carrying different
 # queries are one verb, and answering both the same way would let a suite
 # pass with the wrong query on the wire. So a staged verb may carry a
@@ -106,11 +113,17 @@ slug() { printf '%s' "$1" | tr '/' '%'; }
 
 argv="$*"
 
-# ours STEM VERB — false when STEM was claimed by a different staged verb.
-# `/` cannot appear in a file name, so `api a/b` and `api 'a%b'` reach one
-# stem. The staging helpers record which verb claimed it, and a call spelled
-# the other way is UNSTAGED here, never served the claimant's answer.
+# ours STEM VERB — false when STEM is not this call's to read. `/` cannot
+# appear in a file name, so `api a/b` and `api 'a%b'` reach one stem. The
+# staging helpers record which verb claimed it, and a call spelled the other
+# way is UNSTAGED here, never served the claimant's answer. A stem carrying
+# `@` belongs to no verb at all: `@` is minted below for a selector's slot,
+# and the staging helpers refuse it in a verb, so a call that spells one is
+# reaching for a slot rather than for anything staged under its own name.
 ours() {
+  case "$1" in
+  *@*) return 1 ;;
+  esac
   [ ! -f "$STUB_DIR/$1.verb" ] || [ "$(cat "$STUB_DIR/$1.verb")" = "$2" ]
 }
 
@@ -195,6 +208,13 @@ _gh_stub_key() {
   *:*)
     sel="${verb#*:}"
     verb="${verb%%:*}"
+    ;;
+  esac
+  case "$verb" in
+  *@*)
+    printf 'gh-stub: %s cannot be staged; @ is reserved for selector slots\n' \
+      "$verb" >&2
+    return 1
     ;;
   esac
   base="$(printf '%s' "$verb" | tr '/' '%')"

--- a/.agents/skills/github/tests/lib/gh-stub.sh
+++ b/.agents/skills/github/tests/lib/gh-stub.sh
@@ -34,18 +34,12 @@
 # `gh_stub_answer api '[]'` answers every api path a suite did not name one
 # at a time, and staging neither is still a refusal.
 #
-# THE KEY a verb names is one file stem, and a call maps to it injectively:
-# each word is percent-encoded down to `[A-Za-z0-9_]`, and the encoded words
-# are joined by `-`, which no encoded word can hold. So `api user` keys on
-# `api-user` while the one-word `api-user` keys on `api%2Duser`, and `api a/b`
-# keys on `api-a%2Fb` while `api 'a%b'` keys on `api-a%25b`. Anything less
-# than injective hands a staged answer to a call nobody staged, which is the
-# fail-open a fake exists to prevent.
-#
-# A staged verb splits at its FIRST `-`, so a hyphenated word is always the
-# second one — `repo-set-default` is `repo set-default` — and a hyphenated
-# FIRST word cannot be staged at all. Current suites do not stage top-level
-# commands of that shape; the helper refuses them.
+# THE KEY a verb names is one file stem: the verb's words as written, with
+# `/` spelled `%` because a stem is a file name. Two verbs can therefore
+# reach one stem — `api-a/b` and `api-a%b` do — and the second staging would
+# overwrite the first, handing a staged answer to a call nobody staged. So a
+# stem records the verb that claimed it, and a staging under a second verb is
+# REFUSED rather than served.
 #
 # A VERB IS NOT ALWAYS ENOUGH. Two `api graphql` calls carrying different
 # queries are one verb, and answering both the same way would let a suite
@@ -60,38 +54,6 @@
 # filters a command sent, has to see those itself: the assertion is the whole
 # point of that suite, and moving it in here would bury it. Those suites read
 # `gh_stub_calls` and assert on the argv, or keep a bespoke fake.
-
-# _gh_stub_word WORD — WORD as one key component: everything outside
-# `[A-Za-z0-9_]` percent-encoded, `%` itself included so the escape is
-# escaped, and `-` with it so `-` can join two components into one stem no
-# other pair of words can produce. LC_ALL=C makes the pass byte-wise, which is
-# what holds the map injective over anything a gh argv carries.
-_gh_stub_word() {
-  local s="$1" out="" i c
-  local LC_ALL=C
-  for ((i = 0; i < ${#s}; i++)); do
-    c="${s:i:1}"
-    case "$c" in
-    [A-Za-z0-9_]) out="$out$c" ;;
-    *) out="$out$(printf '%%%02X' "'$c")" ;;
-    esac
-  done
-  printf '%s' "$out"
-}
-
-# _gh_stub_stem WORD [WORD] — the staged-file stem for a verb's words.
-#
-# THE ONE DERIVATION. The stub resolves a call through it and the staging
-# helpers write a file through it, and the two agreeing is the whole of the
-# stub's resolution: gh_stub_install writes this function and _gh_stub_word
-# into the stub with `declare -f`, so there is one definition rather than two
-# spellings someone has to keep in step.
-_gh_stub_stem() {
-  local stem
-  stem="$(_gh_stub_word "$1")"
-  [ "$#" -lt 2 ] || stem="$stem-$(_gh_stub_word "$2")"
-  printf '%s' "$stem"
-}
 
 # _gh_stub_seed — stage the three identity answers. Install and reset both
 # start from them, so the seeded owner/repo is written in one place.
@@ -113,16 +75,10 @@ gh_stub_install() {
   STUB_DIR="$(cd "$STUB_DIR" && pwd)" || return 1
   export STUB_DIR
 
-  {
-    cat <<'STUB_HEAD'
+  cat >"$bin/gh" <<'STUB'
 #!/usr/bin/env bash
 # Written by github/tests/lib/gh-stub.sh. Answers from $STUB_DIR.
 set -uo pipefail
-STUB_HEAD
-    # The key derivation, copied out of this library rather than restated, so
-    # the stem a call resolves to is the stem the staging helpers wrote.
-    declare -f _gh_stub_word _gh_stub_stem
-    cat <<'STUB'
 
 [ -n "${STUB_DIR:-}" ] || {
   printf 'gh-stub: STUB_DIR is unset, so nothing could be staged\n' >&2
@@ -133,16 +89,19 @@ printf '%s\n' "$*" >>"$STUB_DIR/gh.calls"
 
 # The verb: the first word, plus the second when it is not flag-shaped. The
 # first word alone is the fallback, so `api` can answer every api path a
-# suite did not name one at a time. Both go through _gh_stub_stem, which is
-# also what the staging helpers wrote their files under.
-fallback_key="$(_gh_stub_stem "${1:-}")"
-key="$fallback_key"
+# suite did not name one at a time.
+verb="${1:-}"
+fallback="${1:-}"
 if [ "$#" -gt 1 ]; then
   case "${2:-}" in
   -*) ;;
-  *) key="$(_gh_stub_stem "$1" "$2")" ;;
+  *) verb="$verb-$2" ;;
   esac
 fi
+
+# `/` cannot appear in a staged file's name; the staging helpers spell it the
+# same way, so `api repos/o/r/labels` keys on `api-repos%o%r%labels`.
+slug() { printf '%s' "$1" | tr '/' '%'; }
 
 argv="$*"
 
@@ -187,9 +146,10 @@ known() {
   [ -f "$1" ]
 }
 
+key="$(slug "$verb")"
 pick="$(resolve "$key")"
-if [ -z "$pick" ] && [ "$key" != "$fallback_key" ] && ! known "$key"; then
-  pick="$(resolve "$fallback_key")"
+if [ -z "$pick" ] && [ "$fallback" != "$verb" ] && ! known "$key"; then
+  pick="$(resolve "$(slug "$fallback")")"
 fi
 
 if [ -z "$pick" ]; then
@@ -203,7 +163,6 @@ status=0
 [ -f "$pick.status" ] && status="$(cat "$pick.status")"
 exit "$status"
 STUB
-  } >"$bin/gh" || return 1
   chmod +x "$bin/gh" || return 1
 
   : >"$STUB_DIR/gh.calls"
@@ -212,20 +171,26 @@ STUB
 
 # _gh_stub_key VERB — the staged-file stem for VERB, registering a selector
 # when VERB carries one. Prints the stem.
+#
+# The stem is claimed by the first verb staged under it and refuses a second:
+# `api-a/b` and `api-a%b` are one stem, and letting the second overwrite the
+# first is the fail-open a fake exists to prevent.
 _gh_stub_key() {
-  local verb="$1" sel="" base id
+  local verb="$1" sel="" base id owner
   case "$verb" in
   *:*)
     sel="${verb#*:}"
     verb="${verb%%:*}"
     ;;
   esac
-  # The verb's words: it splits at its FIRST `-`, so a path or a subcommand
-  # carrying one stays whole as the second word.
-  case "$verb" in
-  *-*) base="$(_gh_stub_stem "${verb%%-*}" "${verb#*-}")" ;;
-  *) base="$(_gh_stub_stem "$verb")" ;;
-  esac
+  base="$(printf '%s' "$verb" | tr '/' '%')"
+  owner="${STUB_DIR:?}/$base.verb"
+  if [ -f "$owner" ] && [ "$(cat "$owner")" != "$verb" ]; then
+    printf 'gh-stub: %s already keys on %s; %s would overwrite it\n' \
+      "$(cat "$owner")" "$base" "$verb" >&2
+    return 1
+  fi
+  printf '%s' "$verb" >"$owner"
   [ -n "$sel" ] || {
     printf '%s' "$base"
     return 0
@@ -296,7 +261,8 @@ gh_stub_calls() { cat "$STUB_DIR/gh.calls" 2>/dev/null; }
 # scenario's leftovers cannot answer the next one's calls.
 gh_stub_reset() {
   rm -f "${STUB_DIR:?}"/*.out "${STUB_DIR:?}"/*.err "${STUB_DIR:?}"/*.status \
-    "${STUB_DIR:?}"/*.count "${STUB_DIR:?}"/*.selectors "${STUB_DIR:?}/gh.calls"
+    "${STUB_DIR:?}"/*.count "${STUB_DIR:?}"/*.selectors "${STUB_DIR:?}"/*.verb \
+    "${STUB_DIR:?}/gh.calls"
   : >"$STUB_DIR/gh.calls"
   _gh_stub_seed
 }

--- a/skills/github/tests/gh-stub-restage.test.sh
+++ b/skills/github/tests/gh-stub-restage.test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Proof that gh-stub.sh refuses a colliding restage.
+#
+# A verb's key is a file stem, so `api-a/b` and `api-a%b` name one file. The
+# second staging used to overwrite the first without a word, which hands the
+# first verb's answer to a call nobody staged. That is the fail-open a fake
+# exists to prevent, so the second staging is refused instead.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+ok() {
+  PASS=$((PASS + 1))
+  printf '  ok    %s\n' "$1"
+}
+bad() {
+  FAIL=$((FAIL + 1))
+  printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"
+}
+eq() { # eq GOT WANT NAME
+  if [ "$1" = "$2" ]; then ok "$3"; else bad "$3" "wanted [$2], got [$1]"; fi
+}
+
+# shellcheck source=lib/gh-stub.sh
+. "$TEST_DIR/lib/gh-stub.sh"
+
+GH_STUB_DIR="$TMP/stage"
+export GH_STUB_DIR
+gh_stub_install "$TMP/bin" || {
+  echo "gh_stub_install failed" >&2
+  exit 1
+}
+PATH="$TMP/bin:$PATH"
+export PATH
+
+echo "=== a second verb on one key is refused ==="
+
+gh_stub_answer 'api-a/b' 'slashed'
+
+status=0
+err="$TMP/err"
+gh_stub_answer 'api-a%b' 'percent' 2>"$err" || status=$?
+if [ "$status" -ne 0 ]; then
+  ok "must-fail: a second verb on the same key is refused"
+else
+  bad "the colliding staging was accepted" "gh_stub_answer exited 0"
+fi
+if grep -q 'api-a/b' "$err" && grep -q 'api-a%b' "$err"; then
+  ok "the refusal names the key and the verb holding it"
+else
+  bad "the refusal named neither verb" "$(cat "$err")"
+fi
+eq "$(gh api 'a/b')" "slashed" "the first verb keeps its answer"
+
+echo "=== the same verb still restages ==="
+
+# The control: the refusal is about a SECOND verb, not about staging twice.
+# Restaging is how a suite says "from here, this", and the seeded identity
+# answers exist to be overridden that way.
+gh_stub_answer 'api-a/b' 'restaged'
+eq "$(gh api 'a/b')" "restaged" "must-fail control: one verb restages itself"
+gh_stub_answer api-user 'someone-else'
+eq "$(gh api user)" "someone-else" "must-fail control: a seeded answer restages"
+
+echo "=== reset releases the key ==="
+
+# A scenario boundary clears the claim, so the next scenario is free to stage
+# the other spelling.
+gh_stub_reset
+gh_stub_answer 'api-a%b' 'percent'
+eq "$(gh api 'a%b')" "percent" "the other verb stages after a reset"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/skills/github/tests/gh-stub-restage.test.sh
+++ b/skills/github/tests/gh-stub-restage.test.sh
@@ -91,6 +91,18 @@ else
   ok "must-fail: the claim refuses in both directions"
 fi
 
+echo "=== a foreign claim falls through to the broad key ==="
+
+# Unstaged for this call is not the same as refused. A stem another verb
+# claimed is not KNOWN to this call either, so the one-word `api` staging
+# still answers a path the suite never named one at a time — the fallback
+# is what makes a claim narrow the answer rather than block the call.
+gh_stub_reset
+gh_stub_answer 'api-a/b' 'slashed'
+gh_stub_answer api 'broad'
+eq "$(gh api 'a%b')" "broad" "the foreign spelling falls through to the one-word key"
+eq "$(gh api 'a/b')" "slashed" "the claimant still gets its own answer"
+
 echo "=== @ is reserved for selector slots ==="
 
 # The stub mints `<stem>@<id>` for a selector's slot. A verb or a call

--- a/skills/github/tests/gh-stub-restage.test.sh
+++ b/skills/github/tests/gh-stub-restage.test.sh
@@ -103,6 +103,20 @@ gh_stub_answer api 'broad'
 eq "$(gh api 'a%b')" "broad" "the foreign spelling falls through to the one-word key"
 eq "$(gh api 'a/b')" "slashed" "the claimant still gets its own answer"
 
+echo "=== a one-word call does not take a two-word claim ==="
+
+# The join is blind to arity: the two-word `api user` and the one-word
+# command `api-user` both key on `api-user`. The claim is what keeps them
+# apart, and without it a suite goes green after the code under test ran a
+# command gh does not have.
+gh_stub_reset
+eq "$(gh api user)" "test-user" "must-fail control: the two-word call still resolves"
+if out="$(gh api-user 2>&1)"; then
+  bad "the one-word call took the two-word answer" "got: $out"
+else
+  ok "must-fail: a one-word call does not take a two-word claim"
+fi
+
 echo "=== @ is reserved for selector slots ==="
 
 # The stub mints `<stem>@<id>` for a selector's slot. A verb or a call

--- a/skills/github/tests/gh-stub-restage.test.sh
+++ b/skills/github/tests/gh-stub-restage.test.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
-# Proof that gh-stub.sh refuses a colliding restage.
+# Proof that gh-stub.sh keeps one stem to one verb.
 #
 # A verb's key is a file stem, so `api-a/b` and `api-a%b` name one file. The
-# second staging used to overwrite the first without a word, which hands the
-# first verb's answer to a call nobody staged. That is the fail-open a fake
-# exists to prevent, so the second staging is refused instead.
+# second staging would overwrite the first without a word, and a call spelled
+# either way would take whichever answer landed there. Both hand a staged
+# answer to a call nobody staged, which is the fail-open a fake exists to
+# prevent, so the second staging is refused and the other spelling's call
+# finds nothing.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -56,6 +58,14 @@ else
 fi
 eq "$(gh api 'a/b')" "slashed" "the first verb keeps its answer"
 
+# The resolution half: the claimed stem is not this call's, so it is unstaged
+# rather than served the claimant's answer.
+if out="$(gh api 'a%b' 2>&1)"; then
+  bad "the other spelling was answered" "with the api-a/b answer: $out"
+else
+  ok "must-fail: the other spelling finds the stem unstaged"
+fi
+
 echo "=== the same verb still restages ==="
 
 # The control: the refusal is about a SECOND verb, not about staging twice.
@@ -73,6 +83,13 @@ echo "=== reset releases the key ==="
 gh_stub_reset
 gh_stub_answer 'api-a%b' 'percent'
 eq "$(gh api 'a%b')" "percent" "the other verb stages after a reset"
+# And the refusal runs the other way round: the claim is whichever verb got
+# there first, not one spelling the stub prefers.
+if out="$(gh api 'a/b' 2>&1)"; then
+  bad "the slashed spelling was answered" "with the api-a%b answer: $out"
+else
+  ok "must-fail: the claim refuses in both directions"
+fi
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/github/tests/gh-stub-restage.test.sh
+++ b/skills/github/tests/gh-stub-restage.test.sh
@@ -91,6 +91,31 @@ else
   ok "must-fail: the claim refuses in both directions"
 fi
 
+echo "=== @ is reserved for selector slots ==="
+
+# The stub mints `<stem>@<id>` for a selector's slot. A verb or a call
+# carrying `@` addresses one of those slots without ever having staged it,
+# and the verb claim above cannot see it because the two names have
+# different owners.
+gh_stub_reset
+
+status=0
+gh_stub_answer 'api-x@1' 'LITERAL' 2>"$err" || status=$?
+if [ "$status" -ne 0 ]; then
+  ok "must-fail: a staged verb carrying @ is refused"
+else
+  bad "the reserved verb was staged" "gh_stub_answer exited 0"
+fi
+
+gh_stub_answer 'api-graphql:needle' 'SELECTOR'
+if out="$(gh api 'graphql@1' 2>&1)"; then
+  bad "a call carrying @ reached a selector slot" "got: $out"
+else
+  ok "must-fail: a call carrying @ does not reach a selector slot"
+fi
+# The control: the selector still answers the call it was staged for.
+eq "$(gh api graphql -f q=needle)" "SELECTOR" "must-fail control: the selector still answers"
+
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/github/tests/lib/gh-stub.sh
+++ b/skills/github/tests/lib/gh-stub.sh
@@ -42,6 +42,16 @@
 # hands a staged answer to a call nobody staged, which is the fail-open a
 # fake exists to prevent.
 #
+# THE CLAIM RECORDS WORDS, NOT THE JOINED TEXT. The join is lossy about
+# arity: the two-word `api user` and the one-word command `api-user` both
+# spell `api-user`, and a claim holding that string would hand the seeded
+# `api user` answer to a call that ran the wrong command. So the record
+# separates the words by a byte no gh argv word carries, and a call rebuilds
+# the same form from its own argv — two words when it took `$2`, one word
+# otherwise. A staged verb splits at its FIRST `-`, which is where the join
+# put it. Arity is therefore part of the claim, and the two spellings, which
+# still share a stem, cannot take each other's answers.
+#
 # `@` IS RESERVED. The stub mints `<stem>@<id>` for a selector's slot, so a
 # verb or a call carrying `@` in its own text would address a slot nobody
 # staged under it — the same fail-open, one layer down, and one the verb
@@ -95,15 +105,26 @@ set -uo pipefail
 
 printf '%s\n' "$*" >>"$STUB_DIR/gh.calls"
 
+# SEP joins the claim's words. It is not in any gh argv word, so a claim
+# built from two words never reads as one word that happens to contain it.
+SEP="$(printf '\034')"
+
 # The verb: the first word, plus the second when it is not flag-shaped. The
 # first word alone is the fallback, so `api` can answer every api path a
-# suite did not name one at a time.
+# suite did not name one at a time. `claim` is the same words unjoined —
+# what the staging helpers recorded — so a one-word `gh api-user` and the
+# two-word `gh api user`, which share the stem `api-user`, differ here.
 verb="${1:-}"
 fallback="${1:-}"
+claim="${1:-}"
+fallback_claim="${1:-}"
 if [ "$#" -gt 1 ]; then
   case "${2:-}" in
   -*) ;;
-  *) verb="$verb-$2" ;;
+  *)
+    verb="$verb-$2"
+    claim="$claim$SEP$2"
+    ;;
   esac
 fi
 
@@ -113,13 +134,16 @@ slug() { printf '%s' "$1" | tr '/' '%'; }
 
 argv="$*"
 
-# ours STEM VERB — false when STEM is not this call's to read. `/` cannot
-# appear in a file name, so `api a/b` and `api 'a%b'` reach one stem. The
-# staging helpers record which verb claimed it, and a call spelled the other
-# way is UNSTAGED here, never served the claimant's answer. A stem carrying
-# `@` belongs to no verb at all: `@` is minted below for a selector's slot,
-# and the staging helpers refuse it in a verb, so a call that spells one is
-# reaching for a slot rather than for anything staged under its own name.
+# ours STEM CLAIM — false when STEM is not this call's to read. Several verbs
+# reach one stem: `/` cannot appear in a file name, so `api a/b` and `api
+# 'a%b'` both key on `api-a%b`, and the join is blind to arity, so the
+# one-word `api-user` keys where `api user` does. The staging helpers record
+# the claimant's words, and a call whose own words differ — a different
+# spelling, or a different number of them — is UNSTAGED here, never served
+# the claimant's answer. A stem carrying `@` belongs to no verb at all: `@`
+# is minted below for a selector's slot, and the staging helpers refuse it in
+# a verb, so a call that spells one is reaching for a slot rather than for
+# anything staged under its own name.
 ours() {
   case "$1" in
   *@*) return 1 ;;
@@ -127,8 +151,8 @@ ours() {
   [ ! -f "$STUB_DIR/$1.verb" ] || [ "$(cat "$STUB_DIR/$1.verb")" = "$2" ]
 }
 
-# resolve BASE VERB — the staged stem for BASE, or empty when BASE holds
-# nothing VERB staged. A selector wins over the plain key, in staging order:
+# resolve BASE CLAIM — the staged stem for BASE, or empty when BASE holds
+# nothing CLAIM's words staged. A selector wins over the plain key, in staging order:
 # the index holds one `id<TAB>text` line per selector, and the first whose
 # text occurs in this call's argv names the answer. The call ordinal is
 # counted per resolved stem, so a sequence answers each call once; `.0` is
@@ -159,11 +183,12 @@ resolve() {
   fi
 }
 
-# known KEY VERB — true when VERB staged anything at all under KEY. A key
+# known KEY CLAIM — true when CLAIM's words staged anything at all under
+# KEY. A key
 # that is known but has no answer left is a REFUSAL, never a fall-through: a
 # sequence that ran out means the code polled once more than the suite said
 # it would, and answering that from a broad one-word key would hide it. A key
-# another verb claimed is not known to this call, so the one-word fallback
+# another claimant holds is not known to this call, so the one-word fallback
 # still answers a path the suite never named.
 known() {
   local stem="$1"
@@ -174,9 +199,9 @@ known() {
 }
 
 key="$(slug "$verb")"
-pick="$(resolve "$key" "$verb")"
-if [ -z "$pick" ] && [ "$fallback" != "$verb" ] && ! known "$key" "$verb"; then
-  pick="$(resolve "$(slug "$fallback")" "$fallback")"
+pick="$(resolve "$key" "$claim")"
+if [ -z "$pick" ] && [ "$fallback" != "$verb" ] && ! known "$key" "$claim"; then
+  pick="$(resolve "$(slug "$fallback")" "$fallback_claim")"
 fi
 
 if [ -z "$pick" ]; then
@@ -202,8 +227,16 @@ STUB
 # The stem is claimed by the first verb staged under it and refuses a second:
 # `api-a/b` and `api-a%b` are one stem, and letting the second overwrite the
 # first is the fail-open a fake exists to prevent.
+#
+# The record holds the verb's WORDS, split at the first `-` because that is
+# where the join put the boundary, separated by a byte no gh argv word
+# carries. A call rebuilds the same form from its own argv, so the one-word
+# command `api-user` cannot read the two-word `api user`'s answer even
+# though both spell one stem. Replacing the separator with `-` recovers the
+# verb as written, which is how the refusal below names it.
 _gh_stub_key() {
-  local verb="$1" sel="" base id owner
+  local verb="$1" sel="" base id owner claim sep
+  sep="$(printf '\034')"
   case "$verb" in
   *:*)
     sel="${verb#*:}"
@@ -217,14 +250,18 @@ _gh_stub_key() {
     return 1
     ;;
   esac
+  claim="$verb"
+  case "$verb" in
+  *-*) claim="${verb%%-*}$sep${verb#*-}" ;;
+  esac
   base="$(printf '%s' "$verb" | tr '/' '%')"
   owner="${STUB_DIR:?}/$base.verb"
-  if [ -f "$owner" ] && [ "$(cat "$owner")" != "$verb" ]; then
+  if [ -f "$owner" ] && [ "$(cat "$owner")" != "$claim" ]; then
     printf 'gh-stub: %s already keys on %s; %s would overwrite it\n' \
-      "$(cat "$owner")" "$base" "$verb" >&2
+      "$(tr "$sep" '-' <"$owner")" "$base" "$verb" >&2
     return 1
   fi
-  printf '%s' "$verb" >"$owner" || return 1
+  printf '%s' "$claim" >"$owner" || return 1
   [ -n "$sel" ] || {
     printf '%s' "$base"
     return 0

--- a/skills/github/tests/lib/gh-stub.sh
+++ b/skills/github/tests/lib/gh-stub.sh
@@ -36,10 +36,11 @@
 #
 # THE KEY a verb names is one file stem: the verb's words as written, with
 # `/` spelled `%` because a stem is a file name. Two verbs can therefore
-# reach one stem — `api-a/b` and `api-a%b` do — and the second staging would
-# overwrite the first, handing a staged answer to a call nobody staged. So a
-# stem records the verb that claimed it, and a staging under a second verb is
-# REFUSED rather than served.
+# reach one stem — `api-a/b` and `api-a%b` do — so a stem records the verb
+# that claimed it. A staging under a second verb is REFUSED, and a call whose
+# own verb is not the claimant's finds the stem UNSTAGED. Either half missing
+# hands a staged answer to a call nobody staged, which is the fail-open a
+# fake exists to prevent.
 #
 # A VERB IS NOT ALWAYS ENOUGH. Two `api graphql` calls carrying different
 # queries are one verb, and answering both the same way would let a suite
@@ -75,7 +76,7 @@ gh_stub_install() {
   STUB_DIR="$(cd "$STUB_DIR" && pwd)" || return 1
   export STUB_DIR
 
-  cat >"$bin/gh" <<'STUB'
+  cat >"$bin/gh" <<'STUB' || return 1
 #!/usr/bin/env bash
 # Written by github/tests/lib/gh-stub.sh. Answers from $STUB_DIR.
 set -uo pipefail
@@ -105,14 +106,23 @@ slug() { printf '%s' "$1" | tr '/' '%'; }
 
 argv="$*"
 
-# resolve BASE — the staged stem for BASE, or empty when nothing is staged
-# under it. A selector wins over the plain key, in staging order: the index
-# holds one `id<TAB>text` line per selector, and the first whose text occurs
-# in this call's argv names the answer. The call ordinal is counted per
-# resolved stem, so a sequence answers each call once; `.0` is the answer
-# for every call and is what gh_stub_answer stages.
+# ours STEM VERB — false when STEM was claimed by a different staged verb.
+# `/` cannot appear in a file name, so `api a/b` and `api 'a%b'` reach one
+# stem. The staging helpers record which verb claimed it, and a call spelled
+# the other way is UNSTAGED here, never served the claimant's answer.
+ours() {
+  [ ! -f "$STUB_DIR/$1.verb" ] || [ "$(cat "$STUB_DIR/$1.verb")" = "$2" ]
+}
+
+# resolve BASE VERB — the staged stem for BASE, or empty when BASE holds
+# nothing VERB staged. A selector wins over the plain key, in staging order:
+# the index holds one `id<TAB>text` line per selector, and the first whose
+# text occurs in this call's argv names the answer. The call ordinal is
+# counted per resolved stem, so a sequence answers each call once; `.0` is
+# the answer for every call and is what gh_stub_answer stages.
 resolve() {
   local key="$1" sel_id sel_text n
+  ours "$key" "$2" || return 0
   if [ -f "$STUB_DIR/$key.selectors" ]; then
     while IFS="$(printf '\t')" read -r sel_id sel_text; do
       [ -n "$sel_id" ] || continue
@@ -136,20 +146,24 @@ resolve() {
   fi
 }
 
-# known KEY — true when a suite staged anything at all under KEY. A key that
-# is known but has no answer left is a REFUSAL, never a fall-through: a
+# known KEY VERB — true when VERB staged anything at all under KEY. A key
+# that is known but has no answer left is a REFUSAL, never a fall-through: a
 # sequence that ran out means the code polled once more than the suite said
-# it would, and answering that from a broad one-word key would hide it.
+# it would, and answering that from a broad one-word key would hide it. A key
+# another verb claimed is not known to this call, so the one-word fallback
+# still answers a path the suite never named.
 known() {
-  [ -f "$STUB_DIR/$1.selectors" ] && return 0
-  set -- "$STUB_DIR/$1".*.out
+  local stem="$1"
+  ours "$stem" "$2" || return 1
+  [ -f "$STUB_DIR/$stem.selectors" ] && return 0
+  set -- "$STUB_DIR/$stem".*.out
   [ -f "$1" ]
 }
 
 key="$(slug "$verb")"
-pick="$(resolve "$key")"
-if [ -z "$pick" ] && [ "$fallback" != "$verb" ] && ! known "$key"; then
-  pick="$(resolve "$(slug "$fallback")")"
+pick="$(resolve "$key" "$verb")"
+if [ -z "$pick" ] && [ "$fallback" != "$verb" ] && ! known "$key" "$verb"; then
+  pick="$(resolve "$(slug "$fallback")" "$fallback")"
 fi
 
 if [ -z "$pick" ]; then
@@ -190,7 +204,7 @@ _gh_stub_key() {
       "$(cat "$owner")" "$base" "$verb" >&2
     return 1
   fi
-  printf '%s' "$verb" >"$owner"
+  printf '%s' "$verb" >"$owner" || return 1
   [ -n "$sel" ] || {
     printf '%s' "$base"
     return 0

--- a/skills/github/tests/lib/gh-stub.sh
+++ b/skills/github/tests/lib/gh-stub.sh
@@ -42,6 +42,13 @@
 # hands a staged answer to a call nobody staged, which is the fail-open a
 # fake exists to prevent.
 #
+# `@` IS RESERVED. The stub mints `<stem>@<id>` for a selector's slot, so a
+# verb or a call carrying `@` in its own text would address a slot nobody
+# staged under it — the same fail-open, one layer down, and one the verb
+# claim cannot see because the colliding names have different owners.
+# Staging such a verb is refused, and a call whose stem carries `@` is
+# unstaged. `%` stays legal: it is how a stem spells `/`.
+#
 # A VERB IS NOT ALWAYS ENOUGH. Two `api graphql` calls carrying different
 # queries are one verb, and answering both the same way would let a suite
 # pass with the wrong query on the wire. So a staged verb may carry a
@@ -106,11 +113,17 @@ slug() { printf '%s' "$1" | tr '/' '%'; }
 
 argv="$*"
 
-# ours STEM VERB — false when STEM was claimed by a different staged verb.
-# `/` cannot appear in a file name, so `api a/b` and `api 'a%b'` reach one
-# stem. The staging helpers record which verb claimed it, and a call spelled
-# the other way is UNSTAGED here, never served the claimant's answer.
+# ours STEM VERB — false when STEM is not this call's to read. `/` cannot
+# appear in a file name, so `api a/b` and `api 'a%b'` reach one stem. The
+# staging helpers record which verb claimed it, and a call spelled the other
+# way is UNSTAGED here, never served the claimant's answer. A stem carrying
+# `@` belongs to no verb at all: `@` is minted below for a selector's slot,
+# and the staging helpers refuse it in a verb, so a call that spells one is
+# reaching for a slot rather than for anything staged under its own name.
 ours() {
+  case "$1" in
+  *@*) return 1 ;;
+  esac
   [ ! -f "$STUB_DIR/$1.verb" ] || [ "$(cat "$STUB_DIR/$1.verb")" = "$2" ]
 }
 
@@ -195,6 +208,13 @@ _gh_stub_key() {
   *:*)
     sel="${verb#*:}"
     verb="${verb%%:*}"
+    ;;
+  esac
+  case "$verb" in
+  *@*)
+    printf 'gh-stub: %s cannot be staged; @ is reserved for selector slots\n' \
+      "$verb" >&2
+    return 1
     ;;
   esac
   base="$(printf '%s' "$verb" | tr '/' '%')"

--- a/skills/github/tests/lib/gh-stub.sh
+++ b/skills/github/tests/lib/gh-stub.sh
@@ -34,18 +34,12 @@
 # `gh_stub_answer api '[]'` answers every api path a suite did not name one
 # at a time, and staging neither is still a refusal.
 #
-# THE KEY a verb names is one file stem, and a call maps to it injectively:
-# each word is percent-encoded down to `[A-Za-z0-9_]`, and the encoded words
-# are joined by `-`, which no encoded word can hold. So `api user` keys on
-# `api-user` while the one-word `api-user` keys on `api%2Duser`, and `api a/b`
-# keys on `api-a%2Fb` while `api 'a%b'` keys on `api-a%25b`. Anything less
-# than injective hands a staged answer to a call nobody staged, which is the
-# fail-open a fake exists to prevent.
-#
-# A staged verb splits at its FIRST `-`, so a hyphenated word is always the
-# second one — `repo-set-default` is `repo set-default` — and a hyphenated
-# FIRST word cannot be staged at all. Current suites do not stage top-level
-# commands of that shape; the helper refuses them.
+# THE KEY a verb names is one file stem: the verb's words as written, with
+# `/` spelled `%` because a stem is a file name. Two verbs can therefore
+# reach one stem — `api-a/b` and `api-a%b` do — and the second staging would
+# overwrite the first, handing a staged answer to a call nobody staged. So a
+# stem records the verb that claimed it, and a staging under a second verb is
+# REFUSED rather than served.
 #
 # A VERB IS NOT ALWAYS ENOUGH. Two `api graphql` calls carrying different
 # queries are one verb, and answering both the same way would let a suite
@@ -60,38 +54,6 @@
 # filters a command sent, has to see those itself: the assertion is the whole
 # point of that suite, and moving it in here would bury it. Those suites read
 # `gh_stub_calls` and assert on the argv, or keep a bespoke fake.
-
-# _gh_stub_word WORD — WORD as one key component: everything outside
-# `[A-Za-z0-9_]` percent-encoded, `%` itself included so the escape is
-# escaped, and `-` with it so `-` can join two components into one stem no
-# other pair of words can produce. LC_ALL=C makes the pass byte-wise, which is
-# what holds the map injective over anything a gh argv carries.
-_gh_stub_word() {
-  local s="$1" out="" i c
-  local LC_ALL=C
-  for ((i = 0; i < ${#s}; i++)); do
-    c="${s:i:1}"
-    case "$c" in
-    [A-Za-z0-9_]) out="$out$c" ;;
-    *) out="$out$(printf '%%%02X' "'$c")" ;;
-    esac
-  done
-  printf '%s' "$out"
-}
-
-# _gh_stub_stem WORD [WORD] — the staged-file stem for a verb's words.
-#
-# THE ONE DERIVATION. The stub resolves a call through it and the staging
-# helpers write a file through it, and the two agreeing is the whole of the
-# stub's resolution: gh_stub_install writes this function and _gh_stub_word
-# into the stub with `declare -f`, so there is one definition rather than two
-# spellings someone has to keep in step.
-_gh_stub_stem() {
-  local stem
-  stem="$(_gh_stub_word "$1")"
-  [ "$#" -lt 2 ] || stem="$stem-$(_gh_stub_word "$2")"
-  printf '%s' "$stem"
-}
 
 # _gh_stub_seed — stage the three identity answers. Install and reset both
 # start from them, so the seeded owner/repo is written in one place.
@@ -113,16 +75,10 @@ gh_stub_install() {
   STUB_DIR="$(cd "$STUB_DIR" && pwd)" || return 1
   export STUB_DIR
 
-  {
-    cat <<'STUB_HEAD'
+  cat >"$bin/gh" <<'STUB'
 #!/usr/bin/env bash
 # Written by github/tests/lib/gh-stub.sh. Answers from $STUB_DIR.
 set -uo pipefail
-STUB_HEAD
-    # The key derivation, copied out of this library rather than restated, so
-    # the stem a call resolves to is the stem the staging helpers wrote.
-    declare -f _gh_stub_word _gh_stub_stem
-    cat <<'STUB'
 
 [ -n "${STUB_DIR:-}" ] || {
   printf 'gh-stub: STUB_DIR is unset, so nothing could be staged\n' >&2
@@ -133,16 +89,19 @@ printf '%s\n' "$*" >>"$STUB_DIR/gh.calls"
 
 # The verb: the first word, plus the second when it is not flag-shaped. The
 # first word alone is the fallback, so `api` can answer every api path a
-# suite did not name one at a time. Both go through _gh_stub_stem, which is
-# also what the staging helpers wrote their files under.
-fallback_key="$(_gh_stub_stem "${1:-}")"
-key="$fallback_key"
+# suite did not name one at a time.
+verb="${1:-}"
+fallback="${1:-}"
 if [ "$#" -gt 1 ]; then
   case "${2:-}" in
   -*) ;;
-  *) key="$(_gh_stub_stem "$1" "$2")" ;;
+  *) verb="$verb-$2" ;;
   esac
 fi
+
+# `/` cannot appear in a staged file's name; the staging helpers spell it the
+# same way, so `api repos/o/r/labels` keys on `api-repos%o%r%labels`.
+slug() { printf '%s' "$1" | tr '/' '%'; }
 
 argv="$*"
 
@@ -187,9 +146,10 @@ known() {
   [ -f "$1" ]
 }
 
+key="$(slug "$verb")"
 pick="$(resolve "$key")"
-if [ -z "$pick" ] && [ "$key" != "$fallback_key" ] && ! known "$key"; then
-  pick="$(resolve "$fallback_key")"
+if [ -z "$pick" ] && [ "$fallback" != "$verb" ] && ! known "$key"; then
+  pick="$(resolve "$(slug "$fallback")")"
 fi
 
 if [ -z "$pick" ]; then
@@ -203,7 +163,6 @@ status=0
 [ -f "$pick.status" ] && status="$(cat "$pick.status")"
 exit "$status"
 STUB
-  } >"$bin/gh" || return 1
   chmod +x "$bin/gh" || return 1
 
   : >"$STUB_DIR/gh.calls"
@@ -212,20 +171,26 @@ STUB
 
 # _gh_stub_key VERB — the staged-file stem for VERB, registering a selector
 # when VERB carries one. Prints the stem.
+#
+# The stem is claimed by the first verb staged under it and refuses a second:
+# `api-a/b` and `api-a%b` are one stem, and letting the second overwrite the
+# first is the fail-open a fake exists to prevent.
 _gh_stub_key() {
-  local verb="$1" sel="" base id
+  local verb="$1" sel="" base id owner
   case "$verb" in
   *:*)
     sel="${verb#*:}"
     verb="${verb%%:*}"
     ;;
   esac
-  # The verb's words: it splits at its FIRST `-`, so a path or a subcommand
-  # carrying one stays whole as the second word.
-  case "$verb" in
-  *-*) base="$(_gh_stub_stem "${verb%%-*}" "${verb#*-}")" ;;
-  *) base="$(_gh_stub_stem "$verb")" ;;
-  esac
+  base="$(printf '%s' "$verb" | tr '/' '%')"
+  owner="${STUB_DIR:?}/$base.verb"
+  if [ -f "$owner" ] && [ "$(cat "$owner")" != "$verb" ]; then
+    printf 'gh-stub: %s already keys on %s; %s would overwrite it\n' \
+      "$(cat "$owner")" "$base" "$verb" >&2
+    return 1
+  fi
+  printf '%s' "$verb" >"$owner"
   [ -n "$sel" ] || {
     printf '%s' "$base"
     return 0
@@ -296,7 +261,8 @@ gh_stub_calls() { cat "$STUB_DIR/gh.calls" 2>/dev/null; }
 # scenario's leftovers cannot answer the next one's calls.
 gh_stub_reset() {
   rm -f "${STUB_DIR:?}"/*.out "${STUB_DIR:?}"/*.err "${STUB_DIR:?}"/*.status \
-    "${STUB_DIR:?}"/*.count "${STUB_DIR:?}"/*.selectors "${STUB_DIR:?}/gh.calls"
+    "${STUB_DIR:?}"/*.count "${STUB_DIR:?}"/*.selectors "${STUB_DIR:?}"/*.verb \
+    "${STUB_DIR:?}/gh.calls"
   : >"$STUB_DIR/gh.calls"
   _gh_stub_seed
 }


### PR DESCRIPTION
## Summary

- Deletes the `_gh_stub_word` / `_gh_stub_stem` percent-encoder from `skills/github/tests/lib/gh-stub.sh`. A verb's key is the words as written again, with `/` spelled `%` because a stem is a file name — the derivation the library used before `a8d1599d1`.
- Several verbs can therefore reach one stem, so a stem records its claimant and both surfaces enforce it: a staging under a second claimant is refused, and a call whose own words are not the claimant's finds the stem unstaged and falls through to the broad one-word key.
- The record holds the verb's **words**, not the joined text, so the two-word `api user` and the one-word command `api-user` share a stem but cannot take each other's answers.
- `@` is reserved: it is minted only for a selector's slot, so a verb carrying it is refused and a call carrying it is unstaged.
- Adds `skills/github/tests/gh-stub-restage.test.sh` — 15 assertions covering every refusal above, plus controls that a verb still restages itself, a reset releases the claim, a selector still answers its own call, and a foreign claimant still falls through to the broad key.

## Context

The encoder's premise was a suite staging both `api api-user` and `api api%2Duser`, or `api a/b` alongside `api a%b`. No suite does either, and the issue ordered the encoder deleted on that ground.

Review then surfaced that the plain key's non-injectivity is reachable from the **call** side rather than the staging side, which the issue's premise did not cover, and which `origin/main` refused in every case. Three distinct classes, each reproduced against both revisions before being closed:

| Input | Before | On `origin/main` |
|---|---|---|
| `gh api 'a%b'` with `api-a/b` staged | claimant's answer, exit 0 | refused |
| `gh api 'graphql@1'` with `api-graphql:needle` staged | selector's answer, exit 0 | refused |
| `gh api-user` with `api user` seeded | seeded answer, exit 0 | refused |

All three are closed at the derivation rather than per site, without restoring the encoder and without changing the stem format the issue ordered. The last one was an owner decision, since closing it revisits the issue's own ruling.

The issue estimated about −100 lines. That was not reachable: `21b76ee5f` (KEN-1094) deleted the whole 316-line `tools/tests/gh-stub.test.sh` when it moved the library into `skills/github/`, rather than moving it, so the 54 encoder test lines were already gone — and the stub had no direct proof of anything on main until this branch.

Removing the `declare -f` injection also cuts per-call stub resolution 17–32%; the old path forked up to five subshells per call.

## What "restaging refuses" does and does not cover

The issue's Done-when reads "restaging an existing key refuses instead of overwriting the answer file". Stated plainly, because the two halves differ:

- **A second VERB on an existing stem refuses.** `gh_stub_answer 'api-a/b'` then `gh_stub_answer 'api-a%b'` exits 1 with `api-a/b already keys on api-a%b; api-a%b would overwrite it`, and the first verb keeps its answer. This is the silent overwrite the issue was filed for, and it is closed.
- **The SAME verb restaged still overwrites, deliberately.** `gh_stub_answer 'api-thing' FIRST` then `gh_stub_answer 'api-thing' SECOND` exits 0 and `gh api thing` returns `SECOND`.

The second is not an oversight. Restaging one verb is how a scenario overrides the three seeded identity answers and how `gh_stub_answer_seq` stages a sequence, so a blanket "this stem exists" refusal is not available. Measured on the merged tree: replacing the claimant comparison with a bare `[ -f "$owner" ]` reds `pr-list-ready-rollup`, `pr-threads-raw-filter` and the new `gh-stub-restage` suite. (`git-diff-summary-cfg-test-declaration` reds on any copied tree regardless, so it is not counted.)

So the Done-when is met on the defect it describes — a *colliding* key, which the issue body names — and not on the broader literal reading of "an existing key". Same-verb restaging is intended behaviour with must-fail controls asserting it stays available.

## Completed Issues

- Closes KEN-1043 - gh-stub keys are plain words again, and a colliding restage refuses

## Test Plan

- `skills/github/tests/gh-stub-restage.test.sh` — 15 assertions. Each guard was mutated in isolation and reds only its own case; deleting `known()`'s guard reds exactly the fall-through case (`wanted [broad], got []`, 14 pass / 1 fail).
- All 17 suites sourcing `gh-stub.sh` pass (16 in `skills/github/tests`, plus `skills/orch/tests/merge_queue_oversee.sh`), including the three seeded identity answers every consumer depends on.
- `grep` for `_gh_stub_word` and `_gh_stub_stem` is empty repo-wide.
- `tools/guard` exits 0; both `.agents/` renders byte-identical to their sources.

https://claude.ai/code/session_011GbV4jfMxLG6f949HzUrN6

