### PR TITLE
docs(KEN-1119): review-gate SKILL.md: 294 lines to 150; the engine and the flag paragraphs move to DEVELOPMENT.md and references

### DIFF
--- a/.agents/skills/review-gate/DEVELOPMENT.md
+++ b/.agents/skills/review-gate/DEVELOPMENT.md
@@ -190,9 +190,14 @@ reads.
 ## Writer mechanics (`.agents/skills/review-gate/scripts/review-writer.sh`)
 
 One workflow, defined on the default branch, is the only writer of the gate
-status. It evaluates the predicate and converges the result.
+status. Its `workflow_dispatch` and `schedule` invocations enumerate every
+open PR, then each recursive single-head invocation evaluates the predicate
+and converges its result.
 
-- Every invocation converges every open PR.
+- The `merge_group` invocation posts unconditional success for one merge-group
+  SHA without evaluating the predicate or enumerating open PRs.
+- `WRITER_READ_ONLY=1` exits before settings resolution and reads or posts
+  nothing.
 - PR-attached legs (`pull_request_target`, `pull_request_review`, `status`, and
   an opted-in `check_run`) do not run the engine. They run a group-less relay
   that dispatches a converge pass. Only `workflow_dispatch` and `schedule`
@@ -206,8 +211,9 @@ status. It evaluates the predicate and converges the result.
 - The `pull_request_target` job never executes PR-controlled code. Every
   checkout pins the default branch with credentials dropped and refuses an
   empty default-branch resolution rather than falling back.
-- The writer no-ops when the current entry already matches and defers a
-  `success` post to a newer run's entry. See § Write ordering.
+- On the converge legs, a single-head evaluation no-ops when the current entry
+  already matches and defers a `success` post to a newer run's entry. See
+  § Write ordering.
 
 ## Evidence reads
 

--- a/.agents/skills/review-gate/DEVELOPMENT.md
+++ b/.agents/skills/review-gate/DEVELOPMENT.md
@@ -130,6 +130,85 @@ The boundary, stated so it is not discovered: comments are compared out. A
 copy whose prose was reworded is still the template — the catalog's own copy
 reworded its header — and a comment gates nothing.
 
+## Decline parsing
+
+A thread's disposition reply fails as `unreasoned-decline` when it declines
+and its reason strips to nothing against the predicate's label vocabulary: an
+empty reason, or only labels such as `frozen`, `out of scope`, `pre-existing`,
+or a bare test count. Two positional name strips ride after that vocabulary
+and the filler words alike. A count takes the non-space run immediately in
+front of it, and a slash-joined token is a path, so `lifecycle 104/104 and the full tools/guard pass`
+strips to nothing too. A name standing anywhere else
+survives. The parser reads the reply by shape, so a decline written without
+the colon counts too; a label beside a real reason is fine. The reach and the
+shapes past it are pinned in `tests/corpus/declines-known-limit.txt`.
+
+## Predicate evidence and trust
+
+Evidence for the current head is any of:
+
+1. **Review object** at the exact head from a non-author, non-dismissed
+   login. `REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS` restricts accepted
+   logins, and `REVIEW_GATE_REVIEW_OBJECT_MIN_STATE = "approved"` restricts
+   accepted states. A later COMMENTED review does not supersede an approval;
+   only a later CHANGES_REQUESTED withdraws it. A row whose body's first line,
+   after leading whitespace and markdown quote markers, contains a
+   `REVIEW_GATE_REVIEW_OBJECT_ERROR_PATTERNS` marker is not evidence, never a
+   failure.
+2. **Trusted clean-analysis check-run or commit status** named by
+   `REVIEW_GATE_TRUSTED_STATUS_CONTEXTS`. A success matching
+   `REVIEW_GATE_CHECKRUN_SKIP_PATTERNS` is not evidence because it does not
+   prove analysis ran. On both surfaces the newest row or run per name decides;
+   an older clean success never outlives its reviewer's newer pending, failed,
+   or skip-marked round.
+3. **Comment-form clean pass** from a `REVIEW_GATE_COMMENT_REVIEWERS` bot,
+   never the PR author even if configured, binding the evidence to this head's
+   SHA at or above `REVIEW_GATE_SHA_PREFIX_FLOOR`.
+4. **Operator override** named by `REVIEW_GATE_OVERRIDE_CONTEXT`, posted by a
+   trusted operator with a non-empty reason. It substitutes only for missing
+   evidence; it never overrides changes requested or an unresolved thread.
+   The gate detail surfaces the enforced reason. Fix findings and resolve
+   threads first, then attest.
+
+With `REVIEW_GATE_CARRY_FORWARD`, evidence at an ancestor carries to head only
+when the delta is in a configured class: docs-only, comment-only, a committed
+kendex render tree, or an identical tree. Carry-forward never creates evidence,
+never carries over code changes outside those classes, and never bypasses a
+fail-closed term.
+
+Changes requested and unresolved threads always fail closed. Every evidence
+read fails loud with exit 2 and no verdict.
+
+Trust keys on names only GitHub controls: the author login of a review or
+comment, or the exact check or status context on repos where every publisher is
+trusted. A comment body establishes no trust; it only binds evidence to a
+commit. Where PR workflows hold `statuses:write`,
+`REVIEW_GATE_STATUS_PUBLISHER_REJECT` rejects statuses minted by a forgeable
+creator, typically `github-actions[bot]`, on both trusted-context and override
+reads.
+
+## Writer mechanics (`.agents/skills/review-gate/scripts/review-writer.sh`)
+
+One workflow, defined on the default branch, is the only writer of the gate
+status. It evaluates the predicate and converges the result.
+
+- Every invocation converges every open PR.
+- PR-attached legs (`pull_request_target`, `pull_request_review`, `status`, and
+  an opted-in `check_run`) do not run the engine. They run a group-less relay
+  that dispatches a converge pass. Only `workflow_dispatch` and `schedule`
+  hold the single-writer group. The relay costs one non-evictable run per
+  PR-attached event; size that before adoption on a capacity-limited runner
+  pool ([references/adoption.md](references/adoption.md) § Updating an
+  already-adopted copy).
+- The relay never exits non-zero and holds no `statuses` scope. Every fault
+  warns and exits 0, every wait is bounded, and a sustained dispatch outage
+  surfaces as gate staleness, healed by the cron floor and `pr-watch --heal`.
+- The `pull_request_target` job never executes PR-controlled code. Every
+  checkout pins the default branch with credentials dropped and refuses an
+  empty default-branch resolution rather than falling back.
+- The writer no-ops when the current entry already matches and defers a
+  `success` post to a newer run's entry. See § Write ordering.
+
 ## Evidence reads
 
 Reads retry in-process up to `REVIEW_GATE_API_ATTEMPTS` (default 1) with

--- a/.agents/skills/review-gate/SKILL.md
+++ b/.agents/skills/review-gate/SKILL.md
@@ -141,7 +141,7 @@ verdict. Evidence, trust, relay, and writer mechanics:
 - `scripts/validate.sh`: validate a consumer installation. `--help`
 - `scripts/validate-workflow.sh`: compare the adopted workflow with the template. `--help`
 - `scripts/review-predicate.sh`: evaluate one head or validate config. `--help`
-- `scripts/review-writer.sh`: converge every open PR's gate status; its header documents the workflow-only contract.
+- `scripts/review-writer.sh`: `workflow_dispatch` and `schedule` evaluate and converge every open PR; `merge_group` posts one queue success, while `WRITER_READ_ONLY=1` is a no-op. Its header documents the workflow-only contract.
 - `scripts/pr-watch.sh`: reduce open PRs to attention lines. `--help`
 
 Engine selftests run in kendex CI ([DEVELOPMENT.md](DEVELOPMENT.md)). Re-vendor

--- a/.agents/skills/review-gate/SKILL.md
+++ b/.agents/skills/review-gate/SKILL.md
@@ -36,18 +36,11 @@ the gate; and merge-group statuses never read the mode, posting green as
 | `threads-open` | `pending` | Evidence exists, but review threads are unresolved. |
 | `changes-requested` | `failure` | A reviewer objects. Red means objection — never a build failure. |
 | `untracked-claim` | `failure` | A thread's disposition reply claims tracking and names no issue. |
-| `unreasoned-decline` | `failure` | A thread's disposition reply declines and its reason strips to nothing against the predicate's label vocabulary: an empty reason, or only labels such as `frozen`, `out of scope`, `pre-existing`, a bare test count. Two positional name strips ride after that vocabulary and the filler words alike — a count takes the non-space run immediately in front of it, a slash-joined token is a path — so `lifecycle 104/104 and the full tools/guard pass` strips to nothing too; a name standing anywhere else survives. Read by shape, so a decline written without the colon counts too; a label beside a real reason is fine. The reach, and the shapes past it, are pinned in `tests/corpus/declines-known-limit.txt`. |
+| `unreasoned-decline` | `failure` | A decline whose reason strips to nothing against the label vocabulary fails the gate. |
 | (exit 2, no verdict) | *unchanged* | A read failed or config is invalid. Take NO action; retry next pass. |
 
-**Reading the gate's own pending text.** `no review evidence at <sha> yet` is
-the whole of the `awaiting` verdict. It names the head and nothing else: which
-sources can open the gate is the repo's own settings, not a status description
-GitHub keeps 140 characters of — read them in
-[references/settings.md](references/settings.md).
-
-Act on those settings, not on the pending state: where the configured sources
-are bots and one has already reviewed this head, dispatch the writer instead
-of waiting.
+Pending text names the head; which sources open the gate is
+[references/settings.md](references/settings.md) § Reading the pending status.
 
 # Working in a consumer repo
 
@@ -113,171 +106,43 @@ Finish with the repo-side wiring — ruleset, merge queue, bypass actor — and
 delete the local machinery the writer supersedes, in the same PR:
 [references/adoption.md](references/adoption.md).
 
-## 3. The values a repo actually decides
+## 3. Decide and repair
 
-Everything else has a working default. Full table:
-[references/settings.md](references/settings.md).
+Keys a repo decides: [references/adoption.md](references/adoption.md) § Keys a
+repo decides. Repair by verdict line: the same reference's § Repair by verdict
+line.
 
-| Key | Decide |
-|---|---|
-| `REVIEW_GATE_CONTEXT` | The protected commit-status name. Renaming it means updating the ruleset in the same PR. |
-| `REVIEW_GATE_TRUSTED_STATUS_CONTEXTS` | The reviewer contexts whose clean pass counts. Any context to trust needs an explicit entry. |
-| `REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS` | Empty = any non-author. List logins to restrict — do that wherever outside collaborators can review. |
-| `REVIEW_GATE_REVIEW_OBJECT_MIN_STATE` | `any` counts COMMENTED reviews (for bots that never APPROVE); `approved` requires an APPROVED verdict. |
-| `REVIEW_GATE_COMMENT_REVIEWERS` | Only for a comment-form reviewer: `login:binding-prefix`. |
-| `REVIEW_GATE_OVERRIDE_CONTEXT` | The operator override status context. |
-| `REVIEW_GATE_THREADS` | `enforce`, unless a server-side zero-bypass thread ruleset is the enforcement point. |
-| `REVIEW_GATE_CARRY_FORWARD` | Off by default. Turn on `docs`/`comments` where re-review of review-inert deltas is unwanted; `vendored` where `kendex refresh` pushes should carry, with the render trees listed in `REVIEW_GATE_VENDORED_PATHS`. |
-| `REVIEW_GATE_VENDORED_PATHS` | The render trees `vendored` trusts as kendex output, e.g. `.agents/*;.claude/skills/*`. A hand-edit under them rides; keep hook scripts and instruction markdown in `REVIEW_GATE_CARRY_FORWARD_EXCLUDE`, which wins. |
-| `REVIEW_GATE_MODE` | `enforce`. `off` is the one-switch disable, and it attests rather than evaluates. |
+## 4. Operations
 
-## 4. Repair, when validate reports FAIL
+**Watching one or many PRs without stalling.** Never key a hand-rolled monitor on gate-state transitions. Run `.agents/skills/review-gate/scripts/pr-watch.sh` (optionally `--heal`) on the harness's wake-up mechanism: silence + exit 0 means nothing needs you; attention lines name exactly what does. See [references/adoption.md](references/adoption.md) § Watching PRs as an agent.
 
-| Verdict line | What to do |
-|---|---|
-| assigns REVIEW_GATE_* key(s) the engine never reads | Fix the spelling against [references/settings.md](references/settings.md). The written value is being ignored. |
-| a committed setting is not legal | The indented `::error` under it is the engine's own diagnosis; it names the key and the legal values. |
-| carry-exclude … matches no tracked path | Fix the glob, or declare it in `REVIEW_GATE_CARRY_FORWARD_EXCLUDE_PROPHYLACTIC` when it guards paths that do not exist yet. |
-| carry-exclude … anchored with a leading '/' | Drop the anchor: compare filenames are repository-relative. |
-| prophylactic declaration … | Reconcile the ledger — every declaration names an active exclusion that still matches nothing. |
-| no tracked workflow … runs review-writer.sh | Adopt (§2), or `git add` the workflow: Actions runs only what is committed. |
-| has diverged from the shipped template | Re-copy `templates/review-gate-writer.yml` over the adopted file. The template carries no per-repo values, so a copy that differs is a copy someone edited; the line named under the verdict says where. Keep only the `check_run` opt-in's two trigger lines if that opt-in is on. |
-| could not be read | A committed value the loader refuses — the indented diagnostic names the key and the shape it rejected. Fix the assignment; an unreadable value is never an empty one. |
-| is not executable / does not parse | Re-run `kendex refresh` and commit the result. |
+**Reviewers are down / nothing is reviewing.** Run the internal review loop: fix findings, resolve every thread, then post the override status with a real reason. It cannot bypass an objection or an open thread.
 
-## 5. Operations
+**A PR that repairs the gate itself.** The writer always runs the merged engine. Merge the repair PR with the ruleset's bypass actor and say so in the commit message.
 
-**Watching one or many PRs without stalling.** Never key a hand-rolled
-monitor on gate-state transitions. Run
-`.agents/skills/review-gate/scripts/pr-watch.sh` (optionally `--heal`) on
-the harness's wake-up mechanism: silence + exit 0 means nothing needs you;
-attention lines name exactly what does. See adoption.md § Watching PRs as
-an agent.
-
-**Reviewers are down / nothing is reviewing.** Run the internal review loop:
-fix findings, resolve every thread, then post the override status with a real
-reason. It cannot bypass an objection or an open thread.
-
-**A PR that repairs the gate itself.** The writer always runs the merged
-engine. Merge the repair PR with the ruleset's bypass actor and say so in the
-commit message.
-
-**A settings-change PR** is judged by the OLD config — a PR adding a trusted
-login cannot have its own gate honor it. Merge via normal review or the
-bypass actor.
+**A settings-change PR** is judged by the OLD config — a PR adding a trusted login cannot have its own gate honor it. Merge via normal review or the bypass actor.
 
 # The engine
 
-## Evidence sources (`.agents/skills/review-gate/scripts/review-predicate.sh`)
-
 Evidence for the CURRENT head is any of:
 
-1. **Review object** at the exact head from a non-author, non-dismissed
-   login — restricted to `REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS` when set,
-   and to APPROVED reviews when `REVIEW_GATE_REVIEW_OBJECT_MIN_STATE =
-   "approved"`. An approval is never superseded by a later COMMENTED from the
-   same reviewer; only a later CHANGES_REQUESTED withdraws it. A row whose
-   body's first line (after trimming leading whitespace and markdown quote
-   markers) contains a `REVIEW_GATE_REVIEW_OBJECT_ERROR_PATTERNS` marker is
-   NOT-EVIDENCE, never a failure.
-2. **Trusted clean-analysis check-run or commit status**
-   (`REVIEW_GATE_TRUSTED_STATUS_CONTEXTS`) succeeding on this head — but a
-   pass must prove analysis RAN: a success matching
-   `REVIEW_GATE_CHECKRUN_SKIP_PATTERNS` (e.g. "rate limited") is
-   NOT-EVIDENCE, never a failure. On BOTH surfaces the NEWEST row/run per
-   name decides: an older clean success never outlives its reviewer's newer
-   pending/failed/skip-marked round.
-3. **Comment-form clean pass** (`REVIEW_GATE_COMMENT_REVIEWERS`): an issue
-   comment by a trusted bot login — never the PR author, even if configured —
-   binding the evidence to this head's sha (floor
-   `REVIEW_GATE_SHA_PREFIX_FLOOR`).
-4. **Operator override** (`REVIEW_GATE_OVERRIDE_CONTEXT`): a trusted
-   operator's status carrying a NON-EMPTY reason, which is enforced and surfaced in the gate detail.
-   Substitutes for MISSING evidence ONLY — it never overrides a
-   changes-requested or an unresolved thread; fix findings and resolve
-   threads first, then attest.
+1. A non-author review object accepted by the configured trust and state rules.
+2. A trusted clean-analysis check-run or commit status that proves analysis ran.
+3. A trusted comment-form pass bound to this head's SHA.
+4. A trusted operator override with a reason, for missing evidence only.
 
-With `REVIEW_GATE_CARRY_FORWARD` (off by default), evidence at an ancestor
-carries to head when the delta is provably in a class review would not
-re-examine — docs-only, comment-only, a committed kendex render tree,
-identical tree. Never a waiver: real evidence must exist, code changes
-outside those classes always require fresh evidence, and the fail-closed
-terms still apply.
-
-Changes-requested and unresolved threads always fail closed. Every evidence
-read fails LOUD (exit 2, no verdict). Read bounds, retry budget and thread
-pagination: [DEVELOPMENT.md](DEVELOPMENT.md) § Evidence reads.
-
-**Trust model.** Trust keys on names only GitHub controls: the author login
-of a review or comment, or the exact check/status context on repos where
-every publisher is trusted. A comment body never establishes trust — it is
-read only to BIND evidence to a commit. Where PR workflows hold
-`statuses:write`, the opt-in `REVIEW_GATE_STATUS_PUBLISHER_REJECT` list
-rejects statuses minted by a forgeable creator (typically
-`github-actions[bot]`) on both the trusted-context and override reads.
-
-## The writer (`.agents/skills/review-gate/scripts/review-writer.sh`)
-
-One workflow, defined on the default branch, is the only thing that writes
-the gate status. It evaluates the predicate and converges the status —
-nothing else.
-
-- **Converge-all on every leg.** Every invocation converges EVERY open PR.
-- **Relay / converge split.** PR-attached legs (`pull_request_target`,
-  `pull_request_review`, `status`, an opted-in `check_run`) do NOT run the
-  engine: they run a group-less relay job that dispatches a converge pass and
-  exits. Only `workflow_dispatch` and `schedule` hold the single-writer
-  group. The relay costs one non-evictable run per PR-attached event — size
-  that before adopting on a capacity-limited runner pool
-  ([references/adoption.md](references/adoption.md) § Updating an
-  already-adopted copy).
-- **The relay never exits non-zero — a pinned invariant.** It holds no
-  `statuses` scope. Every fault warns and exits 0, and every wait is bounded;
-  a sustained dispatch outage surfaces as **gate staleness**, healed by the
-  cron floor and `pr-watch --heal`.
-- **`pull_request_target` safety**: the job never executes PR-controlled
-  code. Every checkout pins the default branch with credentials dropped and
-  refuses an empty default-branch resolution rather than falling back.
-- **Idempotent, and ordered.** It no-ops when the current entry already
-  matches, and defers a `success` post to any newer run's entry. Mechanics:
-  [DEVELOPMENT.md](DEVELOPMENT.md) § Write ordering.
+Carry-forward never creates evidence or bypasses a fail-closed term. Objections
+and unresolved threads fail closed; an evidence-read failure exits 2 with no
+verdict. Evidence, trust, relay, and writer mechanics:
+[DEVELOPMENT.md](DEVELOPMENT.md) § Predicate evidence and trust.
 
 ## Scripts
 
-```bash
-# validate THIS repo's installation (env: none) — the consumer's CI step
-.agents/skills/review-gate/scripts/validate.sh
+- `scripts/validate.sh`: validate a consumer installation. `--help`
+- `scripts/validate-workflow.sh`: compare the adopted workflow with the template. `--help`
+- `scripts/review-predicate.sh`: evaluate one head or validate config. `--help`
+- `scripts/review-writer.sh`: converge every open PR's gate status; its header documents the workflow-only contract.
+- `scripts/pr-watch.sh`: reduce open PRs to attention lines. `--help`
 
-# is the adopted workflow still the shipped template? (equality, not
-# re-derivation) — usable alone when only the workflow copy changed
-.agents/skills/review-gate/scripts/validate-workflow.sh
-
-# verdict for one head (env: GH_REPO, PR_NUMBER, HEAD_SHA[, PR_AUTHOR])
-.agents/skills/review-gate/scripts/review-predicate.sh
-
-# validate settings values alone, no evidence read, no PR required
-.agents/skills/review-gate/scripts/review-predicate.sh --check-config
-
-# converge every open PR's gate status (env: GH_REPO)
-.agents/skills/review-gate/scripts/review-writer.sh
-
-# needs-attention reducer over open PRs (env: GH_REPO) — exit 0 nothing,
-# 1 attention lines on stdout, 2 read errors. Flags: --heal (one writer
-# dispatch on gate-stale, reported as an informational heal-dispatched
-# line), --no-evaluate (predicate-skipping mode: thread,
-# queue, and gate-status reads still run, so threads-open, disarmed, and
-# the threads-driven gate-stale form all fire; verdict-driven forms need
-# the predicate), --awaiting-after SECS (default: PR_REVIEW_WAIT_SECS)
-.agents/skills/review-gate/scripts/pr-watch.sh [PR# ...]
-```
-
-The offline decision-table selftest and the suites under tests/ are the
-ENGINE's proofs and run in the kendex repo, not in a consumer's CI:
-[DEVELOPMENT.md](DEVELOPMENT.md).
-
-For re-vendor PRs, suppress duplicate findings with the remedy-locus reviewer
-instruction, never a reviewer path exclusion:
-[references/vendored-paths.md](references/vendored-paths.md). A committed
-`kendex refresh` tree is the same problem with no pin over it, and its § The
-harness-render variant routes every finding over the render upstream with no
-carve-out.
+Engine selftests run in kendex CI ([DEVELOPMENT.md](DEVELOPMENT.md)). Re-vendor
+PRs: [references/vendored-paths.md](references/vendored-paths.md).

--- a/.agents/skills/review-gate/references/adoption.md
+++ b/.agents/skills/review-gate/references/adoption.md
@@ -68,8 +68,8 @@ run. It answers repo-own questions only — the engine is installed and
 runnable here, the committed `REVIEW_GATE_*` values are legal, the
 carry-forward exclusions still match tracked paths, and the adopted workflow
 still meets this template's contract. It re-runs no engine test suite: the
-selftest and the suites under tests/ are the ENGINE's proofs and run in the
-kendex repo on every change to it.
+selftest and the wrapper suites are the ENGINE's proofs and run in the kendex
+repo on every change to it.
 
 Value rules come from the engine, not from a copy of it: the settings half
 calls `review-predicate.sh --check-config`, which resolves and validates
@@ -156,26 +156,42 @@ Verify after adopting — run both:
    confirm `gh pr checks` shows no cancelled writer entry and
    `gh pr view --json mergeStateStatus` is not `UNSTABLE` on that account.
 
-## Per-repo settings — decision axes
+## Keys a repo decides
 
 Concrete per-consumer values are tracked on the org adoption issue, not
-here. Full key table: [settings.md](settings.md).
+here. Everything else has a working default. Full key table:
+[settings.md](settings.md).
 
-| Key | Decision axis |
+| Key | Decide |
 |---|---|
-| `REVIEW_GATE_CONTEXT` | The repo's protected commit-status name. Renaming means updating rulesets in the same adoption. |
-| `REVIEW_GATE_TRUSTED_STATUS_CONTEXTS` | The repo's trusted clean-analysis reviewer context(s). Any context to trust needs an explicit entry here. |
+| `REVIEW_GATE_CONTEXT` | The protected commit-status name. Renaming it means updating the ruleset in the same PR. |
+| `REVIEW_GATE_TRUSTED_STATUS_CONTEXTS` | The reviewer contexts whose clean pass counts. Any context to trust needs an explicit entry. |
 | `REVIEW_GATE_CHECKRUN_SKIP_PATTERNS` | Default closes the rate-limited-pass gap everywhere; empty is an explicit opt-out. |
-| `REVIEW_GATE_COMMENT_REVIEWERS` | Only for repos with a comment-form reviewer (login + binding prefix); empty otherwise. |
-| `REVIEW_GATE_SHA_PREFIX_FLOOR` | Only where a comment-form reviewer binds by SHA prefix. |
-| `REVIEW_GATE_OVERRIDE_CONTEXT` | The operator override context. Empty disables the source. |
-| `REVIEW_GATE_STATUS_PUBLISHER_REJECT` | Set `github-actions[bot]` wherever PR workflows hold `statuses: write`. Requires the override to be posted by a non-Actions identity (operator PAT). Empty disables. |
-| `REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS` | Empty = any non-author. List trusted reviewer logins to restrict. |
+| `REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS` | Empty = any non-author. List logins to restrict — do that wherever outside collaborators can review. |
 | `REVIEW_GATE_REVIEW_OBJECT_MIN_STATE` | `any` counts COMMENTED reviews (for bots that never APPROVE); `approved` requires an APPROVED verdict. |
+| `REVIEW_GATE_COMMENT_REVIEWERS` | Only for a comment-form reviewer: `login:binding-prefix`. |
+| `REVIEW_GATE_SHA_PREFIX_FLOOR` | Only where a comment-form reviewer binds by SHA prefix. |
+| `REVIEW_GATE_OVERRIDE_CONTEXT` | The operator override status context. |
+| `REVIEW_GATE_STATUS_PUBLISHER_REJECT` | Set `github-actions[bot]` wherever PR workflows hold `statuses: write`. Requires the override to be posted by a non-Actions identity (operator PAT). Empty disables. |
 | `REVIEW_GATE_REVIEW_OBJECT_ERROR_PATTERNS` | Default closes the errored-auto-review gap; override where a repo's reviewer words its attestation differently; empty is an explicit opt-out. |
-| `REVIEW_GATE_THREADS` | `enforce` unless the server-side zero-bypass thread ruleset is the enforcement point and CI-side latency is unwanted. |
-| `REVIEW_GATE_CARRY_FORWARD` | Off by default. Enable `docs`/`comments` classes where re-review of provably review-inert deltas is not wanted, and `vendored` where a `kendex refresh` push should carry. |
-| `REVIEW_GATE_VENDORED_PATHS` | With `vendored`: the render trees to trust as kendex output (`.agents/*;.claude/skills/*` and the harness dirs kendex writes). Bytes under them are not reviewed on carry, so hook scripts and instruction markdown stay in `REVIEW_GATE_CARRY_FORWARD_EXCLUDE`. |
+| `REVIEW_GATE_THREADS` | `enforce`, unless a server-side zero-bypass thread ruleset is the enforcement point. |
+| `REVIEW_GATE_CARRY_FORWARD` | Off by default. Turn on `docs`/`comments` where re-review of review-inert deltas is unwanted; `vendored` where `kendex refresh` pushes should carry, with the render trees listed in `REVIEW_GATE_VENDORED_PATHS`. |
+| `REVIEW_GATE_VENDORED_PATHS` | The render trees `vendored` trusts as kendex output, e.g. `.agents/*;.claude/skills/*`. A hand-edit under them rides; keep hook scripts and instruction markdown in `REVIEW_GATE_CARRY_FORWARD_EXCLUDE`, which wins. |
+| `REVIEW_GATE_MODE` | `enforce`. `off` is the one-switch disable, and it attests rather than evaluates. |
+
+## Repair by verdict line
+
+| Verdict line | What to do |
+|---|---|
+| assigns REVIEW_GATE_* key(s) the engine never reads | Fix the spelling against [settings.md](settings.md). The written value is being ignored. |
+| a committed setting is not legal | The indented `::error` under it is the engine's own diagnosis; it names the key and the legal values. |
+| carry-exclude … matches no tracked path | Fix the glob, or declare it in `REVIEW_GATE_CARRY_FORWARD_EXCLUDE_PROPHYLACTIC` when it guards paths that do not exist yet. |
+| carry-exclude … anchored with a leading '/' | Drop the anchor: compare filenames are repository-relative. |
+| prophylactic declaration … | Reconcile the ledger — every declaration names an active exclusion that still matches nothing. |
+| no tracked workflow … runs review-writer.sh | Adopt (§ What an adoption PR contains), or `git add` the workflow: Actions runs only what is committed. |
+| has diverged from the shipped template | Re-copy `templates/review-gate-writer.yml` over the adopted file. The template carries no per-repo values, so a copy that differs is a copy someone edited; the line named under the verdict says where. Keep only the `check_run` opt-in's two trigger lines if that opt-in is on. |
+| could not be read | A committed value the loader refuses — the indented diagnostic names the key and the shape it rejected. Fix the assignment; an unreadable value is never an empty one. |
+| is not executable / does not parse | Re-run `kendex refresh` and commit the result. |
 
 ## Migrating a v1 consumer (rerun/sweep-era wiring)
 
@@ -210,9 +226,14 @@ triage — queued PRs annotated with the dequeue-first warning — objections,
 a stale gate, a disarmed mergeable PR, reviewer silence past the quiet
 period, or `head-moved` when a push landed mid-reduction — re-run); exit 2
 = a PR could not be read (fail loud, never skipped).
-`--heal` bounds itself to one writer dispatch per invocation. The orch
-skill's waiters are the single-PR *foreground* waits; pr-watch is the
-multi-PR *background* reducer, over OPEN PRs only.
+`--heal` bounds itself to one writer dispatch per invocation and reports it as
+an informational `heal-dispatched` line. The orch skill's waiters are the
+single-PR *foreground* waits; pr-watch is the multi-PR *background* reducer over OPEN PRs only.
+
+`--no-evaluate` skips the predicate but still reads threads, queue state, and
+gate status, so `threads-open`, `disarmed`, and the threads-driven
+`gate-stale` form still fire; verdict-driven forms need the predicate.
+`--awaiting-after SECS` replaces the `PR_REVIEW_WAIT_SECS` threshold.
 
 ## Verification
 

--- a/.agents/skills/review-gate/references/settings.md
+++ b/.agents/skills/review-gate/references/settings.md
@@ -24,6 +24,14 @@ out. `review-predicate.sh --check-config` is the value-rule half
 alone: it validates every key below and exits without reading evidence or
 needing a PR.
 
+## Reading the pending status
+
+`no review evidence at <sha> yet` is the whole `awaiting` verdict. It names the
+head and nothing else; a GitHub status description has only 140 characters,
+so this file names the sources that can open the gate. Act on those settings,
+not on the pending state. Where the configured sources are bots and one has
+already reviewed this head, dispatch the writer instead of waiting.
+
 Script-consumed keys are read from the `[env]` table only: an assignment
 under any other table (or above the first header) is ignored, and
 `validate.sh` reports it. Values are single-line double-quoted strings with

--- a/skills/review-gate/DEVELOPMENT.md
+++ b/skills/review-gate/DEVELOPMENT.md
@@ -190,9 +190,14 @@ reads.
 ## Writer mechanics (`.agents/skills/review-gate/scripts/review-writer.sh`)
 
 One workflow, defined on the default branch, is the only writer of the gate
-status. It evaluates the predicate and converges the result.
+status. Its `workflow_dispatch` and `schedule` invocations enumerate every
+open PR, then each recursive single-head invocation evaluates the predicate
+and converges its result.
 
-- Every invocation converges every open PR.
+- The `merge_group` invocation posts unconditional success for one merge-group
+  SHA without evaluating the predicate or enumerating open PRs.
+- `WRITER_READ_ONLY=1` exits before settings resolution and reads or posts
+  nothing.
 - PR-attached legs (`pull_request_target`, `pull_request_review`, `status`, and
   an opted-in `check_run`) do not run the engine. They run a group-less relay
   that dispatches a converge pass. Only `workflow_dispatch` and `schedule`
@@ -206,8 +211,9 @@ status. It evaluates the predicate and converges the result.
 - The `pull_request_target` job never executes PR-controlled code. Every
   checkout pins the default branch with credentials dropped and refuses an
   empty default-branch resolution rather than falling back.
-- The writer no-ops when the current entry already matches and defers a
-  `success` post to a newer run's entry. See § Write ordering.
+- On the converge legs, a single-head evaluation no-ops when the current entry
+  already matches and defers a `success` post to a newer run's entry. See
+  § Write ordering.
 
 ## Evidence reads
 

--- a/skills/review-gate/DEVELOPMENT.md
+++ b/skills/review-gate/DEVELOPMENT.md
@@ -130,6 +130,85 @@ The boundary, stated so it is not discovered: comments are compared out. A
 copy whose prose was reworded is still the template — the catalog's own copy
 reworded its header — and a comment gates nothing.
 
+## Decline parsing
+
+A thread's disposition reply fails as `unreasoned-decline` when it declines
+and its reason strips to nothing against the predicate's label vocabulary: an
+empty reason, or only labels such as `frozen`, `out of scope`, `pre-existing`,
+or a bare test count. Two positional name strips ride after that vocabulary
+and the filler words alike. A count takes the non-space run immediately in
+front of it, and a slash-joined token is a path, so `lifecycle 104/104 and the full tools/guard pass`
+strips to nothing too. A name standing anywhere else
+survives. The parser reads the reply by shape, so a decline written without
+the colon counts too; a label beside a real reason is fine. The reach and the
+shapes past it are pinned in `tests/corpus/declines-known-limit.txt`.
+
+## Predicate evidence and trust
+
+Evidence for the current head is any of:
+
+1. **Review object** at the exact head from a non-author, non-dismissed
+   login. `REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS` restricts accepted
+   logins, and `REVIEW_GATE_REVIEW_OBJECT_MIN_STATE = "approved"` restricts
+   accepted states. A later COMMENTED review does not supersede an approval;
+   only a later CHANGES_REQUESTED withdraws it. A row whose body's first line,
+   after leading whitespace and markdown quote markers, contains a
+   `REVIEW_GATE_REVIEW_OBJECT_ERROR_PATTERNS` marker is not evidence, never a
+   failure.
+2. **Trusted clean-analysis check-run or commit status** named by
+   `REVIEW_GATE_TRUSTED_STATUS_CONTEXTS`. A success matching
+   `REVIEW_GATE_CHECKRUN_SKIP_PATTERNS` is not evidence because it does not
+   prove analysis ran. On both surfaces the newest row or run per name decides;
+   an older clean success never outlives its reviewer's newer pending, failed,
+   or skip-marked round.
+3. **Comment-form clean pass** from a `REVIEW_GATE_COMMENT_REVIEWERS` bot,
+   never the PR author even if configured, binding the evidence to this head's
+   SHA at or above `REVIEW_GATE_SHA_PREFIX_FLOOR`.
+4. **Operator override** named by `REVIEW_GATE_OVERRIDE_CONTEXT`, posted by a
+   trusted operator with a non-empty reason. It substitutes only for missing
+   evidence; it never overrides changes requested or an unresolved thread.
+   The gate detail surfaces the enforced reason. Fix findings and resolve
+   threads first, then attest.
+
+With `REVIEW_GATE_CARRY_FORWARD`, evidence at an ancestor carries to head only
+when the delta is in a configured class: docs-only, comment-only, a committed
+kendex render tree, or an identical tree. Carry-forward never creates evidence,
+never carries over code changes outside those classes, and never bypasses a
+fail-closed term.
+
+Changes requested and unresolved threads always fail closed. Every evidence
+read fails loud with exit 2 and no verdict.
+
+Trust keys on names only GitHub controls: the author login of a review or
+comment, or the exact check or status context on repos where every publisher is
+trusted. A comment body establishes no trust; it only binds evidence to a
+commit. Where PR workflows hold `statuses:write`,
+`REVIEW_GATE_STATUS_PUBLISHER_REJECT` rejects statuses minted by a forgeable
+creator, typically `github-actions[bot]`, on both trusted-context and override
+reads.
+
+## Writer mechanics (`.agents/skills/review-gate/scripts/review-writer.sh`)
+
+One workflow, defined on the default branch, is the only writer of the gate
+status. It evaluates the predicate and converges the result.
+
+- Every invocation converges every open PR.
+- PR-attached legs (`pull_request_target`, `pull_request_review`, `status`, and
+  an opted-in `check_run`) do not run the engine. They run a group-less relay
+  that dispatches a converge pass. Only `workflow_dispatch` and `schedule`
+  hold the single-writer group. The relay costs one non-evictable run per
+  PR-attached event; size that before adoption on a capacity-limited runner
+  pool ([references/adoption.md](references/adoption.md) § Updating an
+  already-adopted copy).
+- The relay never exits non-zero and holds no `statuses` scope. Every fault
+  warns and exits 0, every wait is bounded, and a sustained dispatch outage
+  surfaces as gate staleness, healed by the cron floor and `pr-watch --heal`.
+- The `pull_request_target` job never executes PR-controlled code. Every
+  checkout pins the default branch with credentials dropped and refuses an
+  empty default-branch resolution rather than falling back.
+- The writer no-ops when the current entry already matches and defers a
+  `success` post to a newer run's entry. See § Write ordering.
+
 ## Evidence reads
 
 Reads retry in-process up to `REVIEW_GATE_API_ATTEMPTS` (default 1) with

--- a/skills/review-gate/SKILL.md
+++ b/skills/review-gate/SKILL.md
@@ -141,7 +141,7 @@ verdict. Evidence, trust, relay, and writer mechanics:
 - `scripts/validate.sh`: validate a consumer installation. `--help`
 - `scripts/validate-workflow.sh`: compare the adopted workflow with the template. `--help`
 - `scripts/review-predicate.sh`: evaluate one head or validate config. `--help`
-- `scripts/review-writer.sh`: converge every open PR's gate status; its header documents the workflow-only contract.
+- `scripts/review-writer.sh`: `workflow_dispatch` and `schedule` evaluate and converge every open PR; `merge_group` posts one queue success, while `WRITER_READ_ONLY=1` is a no-op. Its header documents the workflow-only contract.
 - `scripts/pr-watch.sh`: reduce open PRs to attention lines. `--help`
 
 Engine selftests run in kendex CI ([DEVELOPMENT.md](DEVELOPMENT.md)). Re-vendor

--- a/skills/review-gate/SKILL.md
+++ b/skills/review-gate/SKILL.md
@@ -36,18 +36,11 @@ the gate; and merge-group statuses never read the mode, posting green as
 | `threads-open` | `pending` | Evidence exists, but review threads are unresolved. |
 | `changes-requested` | `failure` | A reviewer objects. Red means objection — never a build failure. |
 | `untracked-claim` | `failure` | A thread's disposition reply claims tracking and names no issue. |
-| `unreasoned-decline` | `failure` | A thread's disposition reply declines and its reason strips to nothing against the predicate's label vocabulary: an empty reason, or only labels such as `frozen`, `out of scope`, `pre-existing`, a bare test count. Two positional name strips ride after that vocabulary and the filler words alike — a count takes the non-space run immediately in front of it, a slash-joined token is a path — so `lifecycle 104/104 and the full tools/guard pass` strips to nothing too; a name standing anywhere else survives. Read by shape, so a decline written without the colon counts too; a label beside a real reason is fine. The reach, and the shapes past it, are pinned in `tests/corpus/declines-known-limit.txt`. |
+| `unreasoned-decline` | `failure` | A decline whose reason strips to nothing against the label vocabulary fails the gate. |
 | (exit 2, no verdict) | *unchanged* | A read failed or config is invalid. Take NO action; retry next pass. |
 
-**Reading the gate's own pending text.** `no review evidence at <sha> yet` is
-the whole of the `awaiting` verdict. It names the head and nothing else: which
-sources can open the gate is the repo's own settings, not a status description
-GitHub keeps 140 characters of — read them in
-[references/settings.md](references/settings.md).
-
-Act on those settings, not on the pending state: where the configured sources
-are bots and one has already reviewed this head, dispatch the writer instead
-of waiting.
+Pending text names the head; which sources open the gate is
+[references/settings.md](references/settings.md) § Reading the pending status.
 
 # Working in a consumer repo
 
@@ -113,171 +106,43 @@ Finish with the repo-side wiring — ruleset, merge queue, bypass actor — and
 delete the local machinery the writer supersedes, in the same PR:
 [references/adoption.md](references/adoption.md).
 
-## 3. The values a repo actually decides
+## 3. Decide and repair
 
-Everything else has a working default. Full table:
-[references/settings.md](references/settings.md).
+Keys a repo decides: [references/adoption.md](references/adoption.md) § Keys a
+repo decides. Repair by verdict line: the same reference's § Repair by verdict
+line.
 
-| Key | Decide |
-|---|---|
-| `REVIEW_GATE_CONTEXT` | The protected commit-status name. Renaming it means updating the ruleset in the same PR. |
-| `REVIEW_GATE_TRUSTED_STATUS_CONTEXTS` | The reviewer contexts whose clean pass counts. Any context to trust needs an explicit entry. |
-| `REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS` | Empty = any non-author. List logins to restrict — do that wherever outside collaborators can review. |
-| `REVIEW_GATE_REVIEW_OBJECT_MIN_STATE` | `any` counts COMMENTED reviews (for bots that never APPROVE); `approved` requires an APPROVED verdict. |
-| `REVIEW_GATE_COMMENT_REVIEWERS` | Only for a comment-form reviewer: `login:binding-prefix`. |
-| `REVIEW_GATE_OVERRIDE_CONTEXT` | The operator override status context. |
-| `REVIEW_GATE_THREADS` | `enforce`, unless a server-side zero-bypass thread ruleset is the enforcement point. |
-| `REVIEW_GATE_CARRY_FORWARD` | Off by default. Turn on `docs`/`comments` where re-review of review-inert deltas is unwanted; `vendored` where `kendex refresh` pushes should carry, with the render trees listed in `REVIEW_GATE_VENDORED_PATHS`. |
-| `REVIEW_GATE_VENDORED_PATHS` | The render trees `vendored` trusts as kendex output, e.g. `.agents/*;.claude/skills/*`. A hand-edit under them rides; keep hook scripts and instruction markdown in `REVIEW_GATE_CARRY_FORWARD_EXCLUDE`, which wins. |
-| `REVIEW_GATE_MODE` | `enforce`. `off` is the one-switch disable, and it attests rather than evaluates. |
+## 4. Operations
 
-## 4. Repair, when validate reports FAIL
+**Watching one or many PRs without stalling.** Never key a hand-rolled monitor on gate-state transitions. Run `.agents/skills/review-gate/scripts/pr-watch.sh` (optionally `--heal`) on the harness's wake-up mechanism: silence + exit 0 means nothing needs you; attention lines name exactly what does. See [references/adoption.md](references/adoption.md) § Watching PRs as an agent.
 
-| Verdict line | What to do |
-|---|---|
-| assigns REVIEW_GATE_* key(s) the engine never reads | Fix the spelling against [references/settings.md](references/settings.md). The written value is being ignored. |
-| a committed setting is not legal | The indented `::error` under it is the engine's own diagnosis; it names the key and the legal values. |
-| carry-exclude … matches no tracked path | Fix the glob, or declare it in `REVIEW_GATE_CARRY_FORWARD_EXCLUDE_PROPHYLACTIC` when it guards paths that do not exist yet. |
-| carry-exclude … anchored with a leading '/' | Drop the anchor: compare filenames are repository-relative. |
-| prophylactic declaration … | Reconcile the ledger — every declaration names an active exclusion that still matches nothing. |
-| no tracked workflow … runs review-writer.sh | Adopt (§2), or `git add` the workflow: Actions runs only what is committed. |
-| has diverged from the shipped template | Re-copy `templates/review-gate-writer.yml` over the adopted file. The template carries no per-repo values, so a copy that differs is a copy someone edited; the line named under the verdict says where. Keep only the `check_run` opt-in's two trigger lines if that opt-in is on. |
-| could not be read | A committed value the loader refuses — the indented diagnostic names the key and the shape it rejected. Fix the assignment; an unreadable value is never an empty one. |
-| is not executable / does not parse | Re-run `kendex refresh` and commit the result. |
+**Reviewers are down / nothing is reviewing.** Run the internal review loop: fix findings, resolve every thread, then post the override status with a real reason. It cannot bypass an objection or an open thread.
 
-## 5. Operations
+**A PR that repairs the gate itself.** The writer always runs the merged engine. Merge the repair PR with the ruleset's bypass actor and say so in the commit message.
 
-**Watching one or many PRs without stalling.** Never key a hand-rolled
-monitor on gate-state transitions. Run
-`.agents/skills/review-gate/scripts/pr-watch.sh` (optionally `--heal`) on
-the harness's wake-up mechanism: silence + exit 0 means nothing needs you;
-attention lines name exactly what does. See adoption.md § Watching PRs as
-an agent.
-
-**Reviewers are down / nothing is reviewing.** Run the internal review loop:
-fix findings, resolve every thread, then post the override status with a real
-reason. It cannot bypass an objection or an open thread.
-
-**A PR that repairs the gate itself.** The writer always runs the merged
-engine. Merge the repair PR with the ruleset's bypass actor and say so in the
-commit message.
-
-**A settings-change PR** is judged by the OLD config — a PR adding a trusted
-login cannot have its own gate honor it. Merge via normal review or the
-bypass actor.
+**A settings-change PR** is judged by the OLD config — a PR adding a trusted login cannot have its own gate honor it. Merge via normal review or the bypass actor.
 
 # The engine
 
-## Evidence sources (`.agents/skills/review-gate/scripts/review-predicate.sh`)
-
 Evidence for the CURRENT head is any of:
 
-1. **Review object** at the exact head from a non-author, non-dismissed
-   login — restricted to `REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS` when set,
-   and to APPROVED reviews when `REVIEW_GATE_REVIEW_OBJECT_MIN_STATE =
-   "approved"`. An approval is never superseded by a later COMMENTED from the
-   same reviewer; only a later CHANGES_REQUESTED withdraws it. A row whose
-   body's first line (after trimming leading whitespace and markdown quote
-   markers) contains a `REVIEW_GATE_REVIEW_OBJECT_ERROR_PATTERNS` marker is
-   NOT-EVIDENCE, never a failure.
-2. **Trusted clean-analysis check-run or commit status**
-   (`REVIEW_GATE_TRUSTED_STATUS_CONTEXTS`) succeeding on this head — but a
-   pass must prove analysis RAN: a success matching
-   `REVIEW_GATE_CHECKRUN_SKIP_PATTERNS` (e.g. "rate limited") is
-   NOT-EVIDENCE, never a failure. On BOTH surfaces the NEWEST row/run per
-   name decides: an older clean success never outlives its reviewer's newer
-   pending/failed/skip-marked round.
-3. **Comment-form clean pass** (`REVIEW_GATE_COMMENT_REVIEWERS`): an issue
-   comment by a trusted bot login — never the PR author, even if configured —
-   binding the evidence to this head's sha (floor
-   `REVIEW_GATE_SHA_PREFIX_FLOOR`).
-4. **Operator override** (`REVIEW_GATE_OVERRIDE_CONTEXT`): a trusted
-   operator's status carrying a NON-EMPTY reason, which is enforced and surfaced in the gate detail.
-   Substitutes for MISSING evidence ONLY — it never overrides a
-   changes-requested or an unresolved thread; fix findings and resolve
-   threads first, then attest.
+1. A non-author review object accepted by the configured trust and state rules.
+2. A trusted clean-analysis check-run or commit status that proves analysis ran.
+3. A trusted comment-form pass bound to this head's SHA.
+4. A trusted operator override with a reason, for missing evidence only.
 
-With `REVIEW_GATE_CARRY_FORWARD` (off by default), evidence at an ancestor
-carries to head when the delta is provably in a class review would not
-re-examine — docs-only, comment-only, a committed kendex render tree,
-identical tree. Never a waiver: real evidence must exist, code changes
-outside those classes always require fresh evidence, and the fail-closed
-terms still apply.
-
-Changes-requested and unresolved threads always fail closed. Every evidence
-read fails LOUD (exit 2, no verdict). Read bounds, retry budget and thread
-pagination: [DEVELOPMENT.md](DEVELOPMENT.md) § Evidence reads.
-
-**Trust model.** Trust keys on names only GitHub controls: the author login
-of a review or comment, or the exact check/status context on repos where
-every publisher is trusted. A comment body never establishes trust — it is
-read only to BIND evidence to a commit. Where PR workflows hold
-`statuses:write`, the opt-in `REVIEW_GATE_STATUS_PUBLISHER_REJECT` list
-rejects statuses minted by a forgeable creator (typically
-`github-actions[bot]`) on both the trusted-context and override reads.
-
-## The writer (`.agents/skills/review-gate/scripts/review-writer.sh`)
-
-One workflow, defined on the default branch, is the only thing that writes
-the gate status. It evaluates the predicate and converges the status —
-nothing else.
-
-- **Converge-all on every leg.** Every invocation converges EVERY open PR.
-- **Relay / converge split.** PR-attached legs (`pull_request_target`,
-  `pull_request_review`, `status`, an opted-in `check_run`) do NOT run the
-  engine: they run a group-less relay job that dispatches a converge pass and
-  exits. Only `workflow_dispatch` and `schedule` hold the single-writer
-  group. The relay costs one non-evictable run per PR-attached event — size
-  that before adopting on a capacity-limited runner pool
-  ([references/adoption.md](references/adoption.md) § Updating an
-  already-adopted copy).
-- **The relay never exits non-zero — a pinned invariant.** It holds no
-  `statuses` scope. Every fault warns and exits 0, and every wait is bounded;
-  a sustained dispatch outage surfaces as **gate staleness**, healed by the
-  cron floor and `pr-watch --heal`.
-- **`pull_request_target` safety**: the job never executes PR-controlled
-  code. Every checkout pins the default branch with credentials dropped and
-  refuses an empty default-branch resolution rather than falling back.
-- **Idempotent, and ordered.** It no-ops when the current entry already
-  matches, and defers a `success` post to any newer run's entry. Mechanics:
-  [DEVELOPMENT.md](DEVELOPMENT.md) § Write ordering.
+Carry-forward never creates evidence or bypasses a fail-closed term. Objections
+and unresolved threads fail closed; an evidence-read failure exits 2 with no
+verdict. Evidence, trust, relay, and writer mechanics:
+[DEVELOPMENT.md](DEVELOPMENT.md) § Predicate evidence and trust.
 
 ## Scripts
 
-```bash
-# validate THIS repo's installation (env: none) — the consumer's CI step
-.agents/skills/review-gate/scripts/validate.sh
+- `scripts/validate.sh`: validate a consumer installation. `--help`
+- `scripts/validate-workflow.sh`: compare the adopted workflow with the template. `--help`
+- `scripts/review-predicate.sh`: evaluate one head or validate config. `--help`
+- `scripts/review-writer.sh`: converge every open PR's gate status; its header documents the workflow-only contract.
+- `scripts/pr-watch.sh`: reduce open PRs to attention lines. `--help`
 
-# is the adopted workflow still the shipped template? (equality, not
-# re-derivation) — usable alone when only the workflow copy changed
-.agents/skills/review-gate/scripts/validate-workflow.sh
-
-# verdict for one head (env: GH_REPO, PR_NUMBER, HEAD_SHA[, PR_AUTHOR])
-.agents/skills/review-gate/scripts/review-predicate.sh
-
-# validate settings values alone, no evidence read, no PR required
-.agents/skills/review-gate/scripts/review-predicate.sh --check-config
-
-# converge every open PR's gate status (env: GH_REPO)
-.agents/skills/review-gate/scripts/review-writer.sh
-
-# needs-attention reducer over open PRs (env: GH_REPO) — exit 0 nothing,
-# 1 attention lines on stdout, 2 read errors. Flags: --heal (one writer
-# dispatch on gate-stale, reported as an informational heal-dispatched
-# line), --no-evaluate (predicate-skipping mode: thread,
-# queue, and gate-status reads still run, so threads-open, disarmed, and
-# the threads-driven gate-stale form all fire; verdict-driven forms need
-# the predicate), --awaiting-after SECS (default: PR_REVIEW_WAIT_SECS)
-.agents/skills/review-gate/scripts/pr-watch.sh [PR# ...]
-```
-
-The offline decision-table selftest and the suites under tests/ are the
-ENGINE's proofs and run in the kendex repo, not in a consumer's CI:
-[DEVELOPMENT.md](DEVELOPMENT.md).
-
-For re-vendor PRs, suppress duplicate findings with the remedy-locus reviewer
-instruction, never a reviewer path exclusion:
-[references/vendored-paths.md](references/vendored-paths.md). A committed
-`kendex refresh` tree is the same problem with no pin over it, and its § The
-harness-render variant routes every finding over the render upstream with no
-carve-out.
+Engine selftests run in kendex CI ([DEVELOPMENT.md](DEVELOPMENT.md)). Re-vendor
+PRs: [references/vendored-paths.md](references/vendored-paths.md).

--- a/skills/review-gate/references/adoption.md
+++ b/skills/review-gate/references/adoption.md
@@ -68,8 +68,8 @@ run. It answers repo-own questions only — the engine is installed and
 runnable here, the committed `REVIEW_GATE_*` values are legal, the
 carry-forward exclusions still match tracked paths, and the adopted workflow
 still meets this template's contract. It re-runs no engine test suite: the
-selftest and the suites under tests/ are the ENGINE's proofs and run in the
-kendex repo on every change to it.
+selftest and the wrapper suites are the ENGINE's proofs and run in the kendex
+repo on every change to it.
 
 Value rules come from the engine, not from a copy of it: the settings half
 calls `review-predicate.sh --check-config`, which resolves and validates
@@ -156,26 +156,42 @@ Verify after adopting — run both:
    confirm `gh pr checks` shows no cancelled writer entry and
    `gh pr view --json mergeStateStatus` is not `UNSTABLE` on that account.
 
-## Per-repo settings — decision axes
+## Keys a repo decides
 
 Concrete per-consumer values are tracked on the org adoption issue, not
-here. Full key table: [settings.md](settings.md).
+here. Everything else has a working default. Full key table:
+[settings.md](settings.md).
 
-| Key | Decision axis |
+| Key | Decide |
 |---|---|
-| `REVIEW_GATE_CONTEXT` | The repo's protected commit-status name. Renaming means updating rulesets in the same adoption. |
-| `REVIEW_GATE_TRUSTED_STATUS_CONTEXTS` | The repo's trusted clean-analysis reviewer context(s). Any context to trust needs an explicit entry here. |
+| `REVIEW_GATE_CONTEXT` | The protected commit-status name. Renaming it means updating the ruleset in the same PR. |
+| `REVIEW_GATE_TRUSTED_STATUS_CONTEXTS` | The reviewer contexts whose clean pass counts. Any context to trust needs an explicit entry. |
 | `REVIEW_GATE_CHECKRUN_SKIP_PATTERNS` | Default closes the rate-limited-pass gap everywhere; empty is an explicit opt-out. |
-| `REVIEW_GATE_COMMENT_REVIEWERS` | Only for repos with a comment-form reviewer (login + binding prefix); empty otherwise. |
-| `REVIEW_GATE_SHA_PREFIX_FLOOR` | Only where a comment-form reviewer binds by SHA prefix. |
-| `REVIEW_GATE_OVERRIDE_CONTEXT` | The operator override context. Empty disables the source. |
-| `REVIEW_GATE_STATUS_PUBLISHER_REJECT` | Set `github-actions[bot]` wherever PR workflows hold `statuses: write`. Requires the override to be posted by a non-Actions identity (operator PAT). Empty disables. |
-| `REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS` | Empty = any non-author. List trusted reviewer logins to restrict. |
+| `REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS` | Empty = any non-author. List logins to restrict — do that wherever outside collaborators can review. |
 | `REVIEW_GATE_REVIEW_OBJECT_MIN_STATE` | `any` counts COMMENTED reviews (for bots that never APPROVE); `approved` requires an APPROVED verdict. |
+| `REVIEW_GATE_COMMENT_REVIEWERS` | Only for a comment-form reviewer: `login:binding-prefix`. |
+| `REVIEW_GATE_SHA_PREFIX_FLOOR` | Only where a comment-form reviewer binds by SHA prefix. |
+| `REVIEW_GATE_OVERRIDE_CONTEXT` | The operator override status context. |
+| `REVIEW_GATE_STATUS_PUBLISHER_REJECT` | Set `github-actions[bot]` wherever PR workflows hold `statuses: write`. Requires the override to be posted by a non-Actions identity (operator PAT). Empty disables. |
 | `REVIEW_GATE_REVIEW_OBJECT_ERROR_PATTERNS` | Default closes the errored-auto-review gap; override where a repo's reviewer words its attestation differently; empty is an explicit opt-out. |
-| `REVIEW_GATE_THREADS` | `enforce` unless the server-side zero-bypass thread ruleset is the enforcement point and CI-side latency is unwanted. |
-| `REVIEW_GATE_CARRY_FORWARD` | Off by default. Enable `docs`/`comments` classes where re-review of provably review-inert deltas is not wanted, and `vendored` where a `kendex refresh` push should carry. |
-| `REVIEW_GATE_VENDORED_PATHS` | With `vendored`: the render trees to trust as kendex output (`.agents/*;.claude/skills/*` and the harness dirs kendex writes). Bytes under them are not reviewed on carry, so hook scripts and instruction markdown stay in `REVIEW_GATE_CARRY_FORWARD_EXCLUDE`. |
+| `REVIEW_GATE_THREADS` | `enforce`, unless a server-side zero-bypass thread ruleset is the enforcement point. |
+| `REVIEW_GATE_CARRY_FORWARD` | Off by default. Turn on `docs`/`comments` where re-review of review-inert deltas is unwanted; `vendored` where `kendex refresh` pushes should carry, with the render trees listed in `REVIEW_GATE_VENDORED_PATHS`. |
+| `REVIEW_GATE_VENDORED_PATHS` | The render trees `vendored` trusts as kendex output, e.g. `.agents/*;.claude/skills/*`. A hand-edit under them rides; keep hook scripts and instruction markdown in `REVIEW_GATE_CARRY_FORWARD_EXCLUDE`, which wins. |
+| `REVIEW_GATE_MODE` | `enforce`. `off` is the one-switch disable, and it attests rather than evaluates. |
+
+## Repair by verdict line
+
+| Verdict line | What to do |
+|---|---|
+| assigns REVIEW_GATE_* key(s) the engine never reads | Fix the spelling against [settings.md](settings.md). The written value is being ignored. |
+| a committed setting is not legal | The indented `::error` under it is the engine's own diagnosis; it names the key and the legal values. |
+| carry-exclude … matches no tracked path | Fix the glob, or declare it in `REVIEW_GATE_CARRY_FORWARD_EXCLUDE_PROPHYLACTIC` when it guards paths that do not exist yet. |
+| carry-exclude … anchored with a leading '/' | Drop the anchor: compare filenames are repository-relative. |
+| prophylactic declaration … | Reconcile the ledger — every declaration names an active exclusion that still matches nothing. |
+| no tracked workflow … runs review-writer.sh | Adopt (§ What an adoption PR contains), or `git add` the workflow: Actions runs only what is committed. |
+| has diverged from the shipped template | Re-copy `templates/review-gate-writer.yml` over the adopted file. The template carries no per-repo values, so a copy that differs is a copy someone edited; the line named under the verdict says where. Keep only the `check_run` opt-in's two trigger lines if that opt-in is on. |
+| could not be read | A committed value the loader refuses — the indented diagnostic names the key and the shape it rejected. Fix the assignment; an unreadable value is never an empty one. |
+| is not executable / does not parse | Re-run `kendex refresh` and commit the result. |
 
 ## Migrating a v1 consumer (rerun/sweep-era wiring)
 
@@ -210,9 +226,14 @@ triage — queued PRs annotated with the dequeue-first warning — objections,
 a stale gate, a disarmed mergeable PR, reviewer silence past the quiet
 period, or `head-moved` when a push landed mid-reduction — re-run); exit 2
 = a PR could not be read (fail loud, never skipped).
-`--heal` bounds itself to one writer dispatch per invocation. The orch
-skill's waiters are the single-PR *foreground* waits; pr-watch is the
-multi-PR *background* reducer, over OPEN PRs only.
+`--heal` bounds itself to one writer dispatch per invocation and reports it as
+an informational `heal-dispatched` line. The orch skill's waiters are the
+single-PR *foreground* waits; pr-watch is the multi-PR *background* reducer over OPEN PRs only.
+
+`--no-evaluate` skips the predicate but still reads threads, queue state, and
+gate status, so `threads-open`, `disarmed`, and the threads-driven
+`gate-stale` form still fire; verdict-driven forms need the predicate.
+`--awaiting-after SECS` replaces the `PR_REVIEW_WAIT_SECS` threshold.
 
 ## Verification
 

--- a/skills/review-gate/references/settings.md
+++ b/skills/review-gate/references/settings.md
@@ -24,6 +24,14 @@ out. `review-predicate.sh --check-config` is the value-rule half
 alone: it validates every key below and exits without reading evidence or
 needing a PR.
 
+## Reading the pending status
+
+`no review evidence at <sha> yet` is the whole `awaiting` verdict. It names the
+head and nothing else; a GitHub status description has only 140 characters,
+so this file names the sources that can open the gate. Act on those settings,
+not on the pending state. Where the configured sources are bots and one has
+already reviewed this head, dispatch the writer instead of waiting.
+
 Script-consumed keys are read from the `[env]` table only: an assignment
 under any other table (or above the first header) is ignored, and
 `validate.sh` reports it. Values are single-line double-quoted strings with


### PR DESCRIPTION
## Summary

- Trim `skills/review-gate/SKILL.md` and its tracked render to 148 lines.
- Move engine internals and adoption/settings detail into `DEVELOPMENT.md` and `references/`, preserving the newer removal of `merged-sweep`.
- Replace flag restatements with contract pointers and qualify writer behavior for scheduled, dispatch, merge-group, and read-only runs.

## Completed Issues

- Closes KEN-1119 - review-gate SKILL.md: 294 lines to 150; the engine and the flag paragraphs move to DEVELOPMENT.md and references

## Test Plan

- `.agents/skills/preflight/scripts/preflight --base origin/main --repo /home/method/dev/.worktrees/kendex/ken-1119`
- `tools/guard`
- Confirm source and `.agents` render pairs match and `skills/review-gate/SKILL.md` is 148 lines.
