### PR TITLE
refactor(KEN-1042): The command record is create_new plus AlreadyExists; the interrupted-write repair is gone

### DIFF
--- a/crates/cli/tests/command_record.rs
+++ b/crates/cli/tests/command_record.rs
@@ -185,38 +185,6 @@ fn a_record_already_there_is_not_written_over_by_a_first_run() {
     );
 }
 
-/// An empty record is a name a claim published and never filled — the one
-/// state a first run can leave behind, since `create_new` takes the name
-/// before the bytes go in it. Nothing else would repair it: every later
-/// run finds the name taken too, and the app refuses a command it does own
-/// until `kendex update` rewrites the record. So the run that finds it
-/// takes the name back.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn an_empty_record_is_repaired_by_the_next_first_run() {
-    if no_record_on_this_runner() {
-        return;
-    }
-    let tmp = tempfile::tempdir().unwrap();
-    let home = rooted(&tmp);
-    let env = kendex_core::env::Env::host_rooted(&home);
-    let file = env.installed_command_file();
-    fs::create_dir_all(file.parent().unwrap()).unwrap();
-    // What a claim leaves when the write behind it never lands.
-    fs::write(&file, "").unwrap();
-    let ours = home.join("ours/kendex");
-    fs::create_dir_all(ours.parent().unwrap()).unwrap();
-    fs::write(&ours, b"the kendex that ran").unwrap();
-
-    kendex_core::command_update::record_first_run(&env, &ours).unwrap();
-
-    assert_eq!(
-        kendex_core::command_update::recorded_command(&env).map(|record| record.path),
-        Some(ours),
-        "an empty record is nobody's, and the run that found it left it that way"
-    );
-}
-
 /// Concurrent first runs both answer `Ok` and leave one readable record,
 /// naming one of the two files that ran.
 ///

--- a/crates/core/src/command_update/record.rs
+++ b/crates/core/src/command_update/record.rs
@@ -157,13 +157,6 @@ pub fn record_first_run(env: &Env, running: &Path) -> Result<(), String> {
 /// naming whichever finished last, and anything already at that name —
 /// another install's record, a link somebody else chose, a pipe — is left
 /// exactly as it is rather than opened.
-///
-/// The one taken name that is nobody's record is an empty one, and it is
-/// this function that can leave it: the name is published before the bytes
-/// are in it. Every later run would find that name taken too, so nothing
-/// would ever repair it and the app would refuse a command it does own
-/// until `kendex update` rewrote the record. So a write that fails takes
-/// the name back with it, and a claim found empty is taken back here.
 fn write_the_first_run(env: &Env, running: &Path) -> Result<(), String> {
     let file = env.installed_command_file();
     let Some(parent) = file.parent() else {
@@ -174,25 +167,6 @@ fn write_the_first_run(env: &Env, running: &Path) -> Result<(), String> {
     match claim_the_record(&file, running) {
         // Taken, which is the ordinary answer: every run after the first
         // gets it.
-        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
-        answered => return answered.map_err(|error| written(&file, &error)),
-    }
-    // Somebody's record, and this run is not the first. Judged by one
-    // `symlink_metadata`, which is the whole read the steady state pays:
-    // a name with bytes in it is left alone — an unreadable one included,
-    // which `kendex update` rewrites — and a link or a fifo is not a
-    // regular file however long it is, so neither is followed or opened.
-    if !an_unfilled_claim(&file) {
-        return Ok(());
-    }
-    // The empty name goes back and is claimed again. A removal that will
-    // not happen, or a name taken again behind this one, leaves the record
-    // as it was found: this run recorded nothing, and the next one makes
-    // the same repair.
-    if std::fs::remove_file(&file).is_err() {
-        return Ok(());
-    }
-    match claim_the_record(&file, running) {
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
         answered => answered.map_err(|error| written(&file, &error)),
     }
@@ -214,13 +188,6 @@ fn claim_the_record(file: &Path, running: &Path) -> std::io::Result<()> {
         .inspect_err(|_| {
             let _ = std::fs::remove_file(file);
         })
-}
-
-/// Whether that name is a claim nothing ever filled in: a regular file
-/// with nothing in it. Read as the name itself rather than as whatever it
-/// leads to, and never opened — a fifo would hold a run that opened it.
-fn an_unfilled_claim(file: &Path) -> bool {
-    std::fs::symlink_metadata(file).is_ok_and(|entry| entry.is_file() && entry.len() == 0)
 }
 
 /// The one sentence for a record that would not be written.

--- a/crates/core/src/command_update/record/tests.rs
+++ b/crates/core/src/command_update/record/tests.rs
@@ -178,9 +178,8 @@ fn every_public_write_follows_this_process_uid() {
     ];
 
     // A home of its own for each: a record already there is what
-    // `record_first_run` reads to decide it is not the first, so one home
-    // shared between them would have an earlier entry answering for a
-    // later one.
+    // `record_first_run` leaves alone, so one home shared between them
+    // would have an earlier entry answering for a later one.
     for (entry, write) in entries {
         let dir = tempfile::tempdir().unwrap();
         let env = Env::host_rooted(dir.path());


### PR DESCRIPTION
## Summary
- Remove recovery for a zero-length command record left by an interrupted first-run write.
- Keep the command record bootstrap as one create-new claim with existing records left untouched.
- Delete the interrupted-write regression coverage while retaining ordinary write-failure cleanup.

## Completed Issues
- Closes KEN-1042 - The command record is create_new plus AlreadyExists; the interrupted-write repair is gone

## Test Plan
- `cargo test --workspace`
- `.agents/skills/preflight/scripts/preflight --base origin/main --repo /home/method/dev/.worktrees/kendex/ken-1042`
- `tools/guard`
