### PR TITLE
chore(settings): merge autonomy is auto, as in every other repo

### DIFF
--- a/kendex.settings.toml
+++ b/kendex.settings.toml
@@ -97,7 +97,7 @@ ORCH_DECISION_MODE = "ask"
 
 # "ask" presents the merge decision; "auto" merges once every gate is green.
 # MERGE_READY = false never auto-merges.
-ORCH_MERGE_AUTONOMY = "ask"
+ORCH_MERGE_AUTONOMY = "auto"
 
 # Seconds per brief-delivery verification pass on tmux handoff lanes.
 ORCH_TMUX_VERIFY_SECS = "15"


### PR DESCRIPTION
kendex was the only repo with `ORCH_MERGE_AUTONOMY = "ask"`; the other six run `auto`. Lanes run unattended, so the review gate and CI decide and no merge prompt waits. KEN-1139 changes the package default and drops the brief suffix; this is the repo setting only.

https://claude.ai/code/session_01PP5cxGjxdMFNH2fBGiaTwm