### PR TITLE
fix(KEN-1129): The kendex report instruction leaves every package; the owner's repos carry it by configuration

### DIFF
--- a/.agents/skills/app-deploy/SKILL.md
+++ b/.agents/skills/app-deploy/SKILL.md
@@ -4,6 +4,12 @@ description: "Load when asked to cut, ship, or release a kendex version."
 summary: "Releases a kendex version: bumps versions, finalizes the changelog, tags per docs/RELEASING.md."
 ---
 
+<!-- kendex:project-instructions:start -->
+## Project Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
+<!-- kendex:project-instructions:end -->
+
 # Release kendex
 
 1. Bump the workspace `version` in `Cargo.toml` and the version in

--- a/.agents/skills/code-quality/SKILL.md
+++ b/.agents/skills/code-quality/SKILL.md
@@ -21,7 +21,7 @@ Problems with a kendex-owned skill go through `kendex report`; check ownership i
 
 # Code Quality
 
-Repo-specific standards live in each repo's `## Project Instructions` section below and add to these rules.
+Repo-specific standards live in each repo's `## Project Instructions` section and add to these rules.
 
 ## Core Principle
 

--- a/.agents/skills/code-quality/SKILL.md
+++ b/.agents/skills/code-quality/SKILL.md
@@ -13,9 +13,13 @@ metadata:
 tags: [review]
 ---
 
-# Code Quality
+<!-- kendex:project-instructions:start -->
+## Project Instructions
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
+<!-- kendex:project-instructions:end -->
+
+# Code Quality
 
 Repo-specific standards live in each repo's `## Project Instructions` section below and add to these rules.
 

--- a/.agents/skills/decider/SKILL.md
+++ b/.agents/skills/decider/SKILL.md
@@ -13,9 +13,13 @@ metadata:
 tags: [planning]
 ---
 
-# Decider
+<!-- kendex:project-instructions:start -->
+## Project Instructions
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
+<!-- kendex:project-instructions:end -->
+
+# Decider
 
 Numbered decision documents indexed in one `INDEX.md` (default `docs/decisions/`), with a search CLI, canonical format, and creation/supersession workflows.
 

--- a/.agents/skills/deep-research/SKILL.md
+++ b/.agents/skills/deep-research/SKILL.md
@@ -16,9 +16,13 @@ metadata:
 tags: [research]
 ---
 
-# Deep Research
+<!-- kendex:project-instructions:start -->
+## Project Instructions
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
+<!-- kendex:project-instructions:end -->
+
+# Deep Research
 
 In Pi with the `web_research` tool active, use that tool, passing `outputPath` when creating a report. In every other harness, run `scripts/deep-research` with `EXA_API_KEY` set.
 

--- a/.agents/skills/dep-radar/SKILL.md
+++ b/.agents/skills/dep-radar/SKILL.md
@@ -16,9 +16,13 @@ metadata:
 tags: [release]
 ---
 
-# dep-radar — pinned-version sweep, safe auto-update, and capability report
+<!-- kendex:project-instructions:start -->
+## Project Instructions
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
+<!-- kendex:project-instructions:end -->
+
+# dep-radar — pinned-version sweep, safe auto-update, and capability report
 
 **inventory → detect → research → classify → upgrade-with-fixes → report the
 owner tier**.

--- a/.agents/skills/dev/SKILL.md
+++ b/.agents/skills/dev/SKILL.md
@@ -16,9 +16,13 @@ metadata:
 tags: [automation]
 ---
 
-# Dev Workflows
+<!-- kendex:project-instructions:start -->
+## Project Instructions
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
+<!-- kendex:project-instructions:end -->
+
+# Dev Workflows
 
 orch is the caller and runtime: it owns delegation format, round acceptance, and every shell-shape rule.
 

--- a/.agents/skills/github/SKILL.md
+++ b/.agents/skills/github/SKILL.md
@@ -13,9 +13,13 @@ metadata:
 tags: [git, integration]
 ---
 
-# GitHub Queries
+<!-- kendex:project-instructions:start -->
+## Project Instructions
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
+<!-- kendex:project-instructions:end -->
+
+# GitHub Queries
 
 ```bash
 .agents/skills/github/scripts/github.sh [-C <path>] <command> [options]

--- a/.agents/skills/growth-guards/SKILL.md
+++ b/.agents/skills/growth-guards/SKILL.md
@@ -29,9 +29,13 @@ repo-effects:
     - "Git does not clone hooks; arm every clone once."
 ---
 
-# Growth Guards
+<!-- kendex:project-instructions:start -->
+## Project Instructions
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
+<!-- kendex:project-instructions:end -->
+
+# Growth Guards
 
 ```bash
 .agents/skills/growth-guards/scripts/growth-guards              # batch: every enabled repo check

--- a/.agents/skills/iced-rs/SKILL.md
+++ b/.agents/skills/iced-rs/SKILL.md
@@ -13,9 +13,13 @@ metadata:
 tags: [ui]
 ---
 
-# Iced 0.14
+<!-- kendex:project-instructions:start -->
+## Project Instructions
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
+<!-- kendex:project-instructions:end -->
+
+# Iced 0.14
 
 ## Workflow
 

--- a/.agents/skills/kendex-issues/SKILL.md
+++ b/.agents/skills/kendex-issues/SKILL.md
@@ -4,6 +4,12 @@ description: "Load to monitor kendex's issue queue continuously or to run one fi
 summary: "Stewards the kendex issue queue on a self-paced loop: watches open PRs, polls Linear, triages, fixes defects through orch, merges, propagates with kendex refresh."
 ---
 
+<!-- kendex:project-instructions:start -->
+## Project Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
+<!-- kendex:project-instructions:end -->
+
 # kendex Issue Steward
 
 watch → poll → triage → fix → merge → propagate → reschedule. One cycle per

--- a/.agents/skills/linear/SKILL.md
+++ b/.agents/skills/linear/SKILL.md
@@ -13,9 +13,13 @@ metadata:
 tags: [integration]
 ---
 
-# Linear CLI
+<!-- kendex:project-instructions:start -->
+## Project Instructions
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
+<!-- kendex:project-instructions:end -->
+
+# Linear CLI
 
 ```bash
 .agents/skills/linear/scripts/linear.sh <resource> <action> [options]

--- a/.agents/skills/orch/SKILL.md
+++ b/.agents/skills/orch/SKILL.md
@@ -16,9 +16,13 @@ metadata:
 tags: [automation]
 ---
 
-# Orchestration
+<!-- kendex:project-instructions:start -->
+## Project Instructions
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
+<!-- kendex:project-instructions:end -->
+
+# Orchestration
 
 Load `github` and `worktree` before anything else; a Linear work item also needs `linear`. The dev and reviewer skills call orch scripts.
 

--- a/.agents/skills/preflight/SKILL.md
+++ b/.agents/skills/preflight/SKILL.md
@@ -13,9 +13,13 @@ metadata:
 tags: [review, testing]
 ---
 
-# Preflight
+<!-- kendex:project-instructions:start -->
+## Project Instructions
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
+<!-- kendex:project-instructions:end -->
+
+# Preflight
 
 Every lane is diff-scoped and fail-only: findings land only on lines this
 change ADDED; a lane that cannot decide reports nothing. There is no

--- a/.agents/skills/price-handling/SKILL.md
+++ b/.agents/skills/price-handling/SKILL.md
@@ -13,9 +13,13 @@ metadata:
 tags: [data]
 ---
 
-# Price Handling Patterns
+<!-- kendex:project-instructions:start -->
+## Project Instructions
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
+<!-- kendex:project-instructions:end -->
+
+# Price Handling Patterns
 
 ## The price type is `f64`
 

--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -16,9 +16,13 @@ metadata:
 tags: [planning]
 ---
 
-# Project Management
+<!-- kendex:project-instructions:start -->
+## Project Instructions
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
+<!-- kendex:project-instructions:end -->
+
+# Project Management
 
 Wrappers run in the primary session: they own the user dialog and every tracker mutation. TPM workflows analyze and return JSON inline; they never mutate the tracker and never write the artifact.
 

--- a/.agents/skills/review-gate/SKILL.md
+++ b/.agents/skills/review-gate/SKILL.md
@@ -13,9 +13,13 @@ metadata:
 tags: [review]
 ---
 
-# Review Gate
+<!-- kendex:project-instructions:start -->
+## Project Instructions
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
+<!-- kendex:project-instructions:end -->
+
+# Review Gate
 
 The gate answers ONE question: **has this exact PR head been reviewed?** It
 posts that answer as a commit status the repo's branch rules require. It does

--- a/.agents/skills/review-gate/references/vendored-paths.md
+++ b/.agents/skills/review-gate/references/vendored-paths.md
@@ -94,8 +94,9 @@ Once per re-vendor train, on ONE consumer PR, collect upstream-remedy findings
 from BOTH surfaces: the review bodies, AND EVERY vendored-path thread a
 location-bound reviewer left.
 
-File the report against the catalog repo through the owner's configured
-route.
+Use the reporting route in this skill's injected `## Project Instructions`.
+If no route is injected, return the defect to the orchestrating agent and
+user without filing.
 
 The lock is the one judge, and it records provenance for every kind — skills,
 agents, hooks and Pi extensions alike. A name routes upstream when the lock
@@ -208,10 +209,12 @@ the catalog repo and to the PR author out of band. Under a flat rule there is
 no on-PR surface left, which also removes the consolidated-comment fallback
 the vendored template gives a location-bound reviewer.
 
-**The report files against the catalog repo**, through the owner's configured
-route and the same lock ownership rule as § The consumer session's half. An
-item rendered from a third-party catalog carries that catalog in its lock
-entries and reports here instead, so open that issue by hand.
+**File against the catalog repo only when this skill's injected `## Project
+Instructions` supplies a reporting route.** Follow that route and the same
+lock ownership rule as § The consumer session's half. With no injected route,
+return the defect to the orchestrating agent and user without filing. An item
+rendered from a third-party catalog carries that catalog in its lock entries
+and reports here instead, so open that issue by hand.
 
 Wire it with the vendored template: copy it, set `applyTo` to the render
 trees, and apply its RENDER VARIANT block, which carries the replacement text

--- a/.agents/skills/review-gate/references/vendored-paths.md
+++ b/.agents/skills/review-gate/references/vendored-paths.md
@@ -94,11 +94,8 @@ Once per re-vendor train, on ONE consumer PR, collect upstream-remedy findings
 from BOTH surfaces: the review bodies, AND EVERY vendored-path thread a
 location-bound reviewer left.
 
-`kendex report --skill [NAME] --title [TITLE] --body-file [PATH]` files the
-report. The command is non-interactive: `--title` is required, and exactly one
-of `--body` or `--body-file` must be given — with neither (or both) it exits
-without filing. `--dry-run` prints the decision and the `gh` command it would
-run.
+File the report against the catalog repo through the owner's configured
+route.
 
 The lock is the one judge, and it records provenance for every kind — skills,
 agents, hooks and Pi extensions alike. A name routes upstream when the lock
@@ -211,7 +208,7 @@ the catalog repo and to the PR author out of band. Under a flat rule there is
 no on-PR surface left, which also removes the consolidated-comment fallback
 the vendored template gives a location-bound reviewer.
 
-**The report files against the catalog repo**, by the same `kendex report`
+**The report files against the catalog repo**, through the owner's configured
 route and the same lock ownership rule as § The consumer session's half. An
 item rendered from a third-party catalog carries that catalog in its lock
 entries and reports here instead, so open that issue by hand.

--- a/.agents/skills/review-gate/scripts/validate-workflow.sh
+++ b/.agents/skills/review-gate/scripts/validate-workflow.sh
@@ -229,7 +229,7 @@ ok "one adopted writer workflow: $adopted"
 # is what Actions runs, and an untracked target is a red writer on every leg.
 exec_target="$(sed -n 's/^[[:space:]]*exec[[:space:]]\{1,\}\([^[:space:]]*review-writer\.sh\)[[:space:]]*$/\1/p' "$adopted" | head -n 1)"
 if [ -z "$exec_target" ]; then
-  bad "$adopted names no exec target — the discovery above matched, so this is a parse gap in this tool rather than a repo fault; report it with \`kendex report\`"
+  bad "$adopted names no exec target — the discovery above matched, so this is a parse gap in this tool rather than a repo fault; report it to the package owner"
 elif [ -L "$exec_target" ]; then
   bad "$adopted execs $exec_target, which is a SYMLINK — CI checks out the link and runs whatever sits at the other end, which is nothing when the target is untracked or outside the repository. Commit the engine at that path"
 elif git ls-files --error-unmatch -- "$exec_target" >/dev/null 2>&1; then

--- a/.agents/skills/review-gate/templates/vendored-paths.instructions.md
+++ b/.agents/skills/review-gate/templates/vendored-paths.instructions.md
@@ -96,9 +96,9 @@ that most often survive and they are the two the flat rule forbids.
 
    - **The fix lands in these rendered bytes**: do not raise it on this PR, on
      any surface. The session that runs the refresh follows the reporting route
-     in this skill's injected `## Project Instructions`. With no injected route,
-     it returns the defect to the orchestrating agent and user without filing.
-     The fix arrives here as a later render.
+     in the review-gate skill's injected `## Project Instructions`. With no
+     injected route, it returns the defect to the orchestrating agent and user
+     without filing. The fix arrives here as a later render.
 
 4. REPLACE the third routing bullet ("[UPSTREAM_REPO]'s own docs …") with:
 

--- a/.agents/skills/review-gate/templates/vendored-paths.instructions.md
+++ b/.agents/skills/review-gate/templates/vendored-paths.instructions.md
@@ -96,8 +96,8 @@ that most often survive and they are the two the flat rule forbids.
 
    - **The fix lands in these rendered bytes**: do not raise it on this PR, on
      any surface. The session that runs the refresh files it against the
-     catalog repo with `kendex report`, and the fix arrives here as a later
-     render.
+     catalog repo through the owner's configured route, and the fix arrives
+     here as a later render.
 
 4. REPLACE the third routing bullet ("[UPSTREAM_REPO]'s own docs …") with:
 

--- a/.agents/skills/review-gate/templates/vendored-paths.instructions.md
+++ b/.agents/skills/review-gate/templates/vendored-paths.instructions.md
@@ -95,9 +95,10 @@ that most often survive and they are the two the flat rule forbids.
    REVIEW SUMMARY BODY) with:
 
    - **The fix lands in these rendered bytes**: do not raise it on this PR, on
-     any surface. The session that runs the refresh files it against the
-     catalog repo through the owner's configured route, and the fix arrives
-     here as a later render.
+     any surface. The session that runs the refresh follows the reporting route
+     in this skill's injected `## Project Instructions`. With no injected route,
+     it returns the defect to the orchestrating agent and user without filing.
+     The fix arrives here as a later render.
 
 4. REPLACE the third routing bullet ("[UPSTREAM_REPO]'s own docs …") with:
 

--- a/.agents/skills/reviewer/SKILL.md
+++ b/.agents/skills/reviewer/SKILL.md
@@ -16,9 +16,13 @@ metadata:
 tags: [review]
 ---
 
-# Reviewer
+<!-- kendex:project-instructions:start -->
+## Project Instructions
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
+<!-- kendex:project-instructions:end -->
+
+# Reviewer
 
 Shared contract for every review specialist; each agent's domain and probes live in its own agent file. These workflows run orch scripts and do not stand alone.
 

--- a/.agents/skills/second-opinion/SKILL.md
+++ b/.agents/skills/second-opinion/SKILL.md
@@ -14,9 +14,13 @@ metadata:
 tags: [review]
 ---
 
-# Second Opinion
+<!-- kendex:project-instructions:start -->
+## Project Instructions
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
+<!-- kendex:project-instructions:end -->
+
+# Second Opinion
 
 Cross-model second opinion via external AI CLI. Every mode walks the `SECOND_OPINION_MODELS` roster in priority order and takes the first target that is available and runs a different model — Codex from a Claude Code session, Claude from a Codex session; when nothing eligible remains the run refuses and says why. The full contract — options, target selection and identity rules, environment keys and defaults, review scope and stamping, output clearing and ownership, option syntax, and exit codes — is `second-opinion --help`.
 

--- a/.agents/skills/size-ratchet/SKILL.md
+++ b/.agents/skills/size-ratchet/SKILL.md
@@ -13,9 +13,13 @@ metadata:
 tags: [automation]
 ---
 
-# Size Ratchet
+<!-- kendex:project-instructions:start -->
+## Project Instructions
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
+<!-- kendex:project-instructions:end -->
+
+# Size Ratchet
 
 **No tracked file gets bigger than its threshold, and files already over
 it only shrink.** Existing offenders are frozen in a baseline at their

--- a/.agents/skills/worktree/SKILL.md
+++ b/.agents/skills/worktree/SKILL.md
@@ -14,9 +14,13 @@ metadata:
 tags: [git]
 ---
 
-# Worktree Management
+<!-- kendex:project-instructions:start -->
+## Project Instructions
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
+<!-- kendex:project-instructions:end -->
+
+# Worktree Management
 
 ```bash
 .agents/skills/worktree/scripts/worktree <command> [options]

--- a/.claude/agents/generalist.md
+++ b/.claude/agents/generalist.md
@@ -16,8 +16,6 @@ skills: code-quality, decider, dep-radar, dev, github, linear, preflight, review
 
 Handles cross-cutting maintenance: documentation accuracy, stale references, broken links and lint, and configuration organization.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Changes whose correctness is settled by reading: doc claims, references, links, file and config organization. Work needing domain judgment — core logic, performance-critical code, architecture decisions — goes back to the caller with what you found, not with a patch.
@@ -30,3 +28,7 @@ Changes whose correctness is settled by reading: doc claims, references, links, 
 ## Output
 
 What changed, what you verified it against, and anything you deliberately left for a domain owner.
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.claude/agents/iced.md
+++ b/.claude/agents/iced.md
@@ -16,8 +16,6 @@ skills: code-quality, decider, dev, github, iced-rs, linear, preflight
 
 Implements the Iced view layer: widget composition, Canvas and Shader rendering, `pane_grid` docking, theming, subscriptions, and Elm-architecture message flow.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 The view and the messages that drive it. Domain logic, data sourcing, and persistence stay with their owners — take the state as given and render it.
@@ -30,3 +28,7 @@ The view and the messages that drive it. Domain logic, data sourcing, and persis
 ## Output
 
 What changed, what you saw or asserted to verify it, and any framework invariant you had to design around.
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -16,8 +16,6 @@ skills: github, linear
 
 Converts requirements, recon findings, and code context into an ordered implementation plan another agent can execute without re-deciding anything.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Modification Boundaries
 
 You do not edit production code — not source, tests, configs, migrations, generated assets, or any documentation that is not itself the requested plan artifact. No dependency installs or lockfile changes. Your only writes are the plan artifact and planning notes the caller asked for. Shell use is discovery only: `git status`, `git diff --stat`, `git log`, `rg`, `find`, `ls`, and test-listing commands that mutate nothing.
@@ -43,3 +41,7 @@ Write a file only when asked. Given no path, a technical plan goes to `docs/plan
 - **Plan** — numbered steps, each naming its files or symbols, the change intent, why it is needed, and the validation that proves it; then files to modify, new files, and the three to five files most critical to executing it.
 - **Consequences** — risks paired with mitigations, the rollback path, and whether a TPM handoff is needed (with the justification and the prompt when it is).
 - **Handoff prompt** — what the calling agent hands the implementer to execute the plan.
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -16,8 +16,6 @@ skills: decider, deep-research, github, linear
 
 Executes delegated research prompts and produces evidence-backed findings reports.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Provider-backed research and the report it produces. Not production code, not architecture decisions beyond the recommendation the evidence supports, not creating or reshaping tracked work unless the delegation instructs it, and never coordinating other agents.
@@ -32,3 +30,7 @@ Provider-backed research and the report it produces. Not production code, not ar
 ## Output
 
 `findings.md` at the exact requested path, raw provider metadata in its sidecar, and exactly one completion message — sent after the report exists and its validation passes.
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.claude/agents/reviewer-arch.md
+++ b/.claude/agents/reviewer-arch.md
@@ -18,8 +18,6 @@ skills: reviewer
 
 Compliance criteria come from the project's architecture docs — do not invent design rules the project never adopted. Leave local code quality not tied to architecture policy to `reviewer-quality`.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 - **Module boundaries and layering**: components respecting documented boundaries; cross-cutting leaks; dependency-rule violations.
@@ -32,3 +30,7 @@ A finding in a class `.agents/skills/orch/references/finding-disposition.md` Ste
 ## Output
 
 Architecture violations, boundary breaches, spec holes → `blockers[]`. Tech debt observations, minor improvements → `suggestions[]`.
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.claude/agents/reviewer-correctness.md
+++ b/.claude/agents/reviewer-correctness.md
@@ -18,8 +18,6 @@ skills: reviewer
 
 Does the changed code still do what the product intends — for every input, caller, and consumer? Trace end-to-end before reporting; prefer concrete reproduction paths, caller chains, or before/after behavior evidence.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Behavior regressions; API/CLI/contract compatibility (including two components implementing one contract — validator pairs, writer/reader conventions — drifting apart); cross-module side effects; feature-gate leaks; data/migration/state semantics, including idempotency of interrupted-then-retried flows; developer-workflow breakage (report only changes to how contributors build, run, configure, or connect — not routine dependency bumps). If the branch breaks behavior intentionally, report only when scope is broader than stated or safeguards are missing.
@@ -64,3 +62,7 @@ Never refute a finding as "speculative" or "depends on runtime state" when the s
 ## Output
 
 Regressions, boundary defects, compatibility/contract breaks, feature leaks, state/migration issues → `blockers[]`. Non-blocking risks and follow-up hardening → `suggestions[]`.
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.claude/agents/reviewer-doc.md
+++ b/.claude/agents/reviewer-doc.md
@@ -18,8 +18,6 @@ skills: reviewer
 
 The method is verification, not proofreading — **open the implementation behind every checkable claim in the changed docs.** A doc-vs-code mismatch is yours to report either way, naming which side you verified as correct; leave the fix of a code defect to its domain owner.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Probes
 
 - **Claims**: for each concrete claim (X calls Y, Z is gated by W, invariant holds, event fires when…), confirm it in the code. Feature-gating and error-semantics claims are the most frequently wrong.
@@ -35,3 +33,7 @@ A finding in a class `.agents/skills/orch/references/finding-disposition.md` Ste
 ## Output
 
 Wrong claims, wrong values, dead citations, contradicted invariants → `blockers[]`. Minor improvements → `suggestions[]`.
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.claude/agents/reviewer-error.md
+++ b/.claude/agents/reviewer-error.md
@@ -18,8 +18,6 @@ skills: reviewer
 
 Error paths that quietly convert failure into success. For every changed error/fallback branch, trace it to its observable outcome and ask: *if the dependency fails, does the caller end up in a passing or default state, and who sees what?* "Nobody sees anything and the run continues" is a finding.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Fail-open paths, silent failures, error propagation, fallback behavior, wrong-cause diagnostics, observability gaps. Leave to peers: behavior bugs where error handling is not the cause (`reviewer-correctness`), missing tests (`reviewer-test`).
@@ -43,3 +41,7 @@ Recurring shapes:
 ## Output
 
 Fail-open paths, silent failures, swallowed errors, wrong-cause diagnostics → `blockers[]`. Logging/observability improvements → `suggestions[]`.
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.claude/agents/reviewer-perf.md
+++ b/.claude/agents/reviewer-perf.md
@@ -18,8 +18,6 @@ skills: reviewer
 
 Validate performance with evidence: benchmarks against baselines, project-defined thresholds and budgets, percentiles over averages. Thresholds and hot/cold-path definitions come from the project's docs — never fabricate budgets; when docs are silent, report evidence-based risk instead. Classify every regression — silent omission is forbidden. Leave style and architecture to their owners unless perf impact is demonstrated.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 - **Benchmark execution and regression detection** against baselines, classified by path criticality (hot vs cold). Operational rules — recording, feature-gated lanes, zero-result and fail-closed recorder handling: `.agents/skills/reviewer/references/perf-qa.md` (read before running or recording any benchmark).
@@ -31,3 +29,7 @@ A finding in a class `.agents/skills/orch/references/finding-disposition.md` Ste
 ## Output
 
 Budget exceedances, classified regressions, hot-path cost introductions → `blockers[]`. Minor observations → `suggestions[]`.
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.claude/agents/reviewer-quality.md
+++ b/.claude/agents/reviewer-quality.md
@@ -18,8 +18,6 @@ skills: reviewer
 
 Is the changed implementation simple, direct, easy to reason about, and aligned with the codebase? Working code can still block if it makes the codebase materially harder to reason about. Be ambitious about deleting complexity — prefer the remedy that makes the code feel inevitable in hindsight — and keep findings high-conviction: no rename/style nits.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Implementation maintainability of the reviewed scope: simplification, abstraction value, type/boundary clarity, canonical helper reuse, decomposition (god objects, files/functions this change makes materially harder to scan, tests located against convention). Raw file-size thresholds are deterministic (size-ratchet) — don't re-enforce them. Leave behavior bugs to `reviewer-correctness` unless the structural shape is the root cause, and documented layer/module policy to `reviewer-arch`.
@@ -38,3 +36,7 @@ A finding in a class `.agents/skills/orch/references/finding-disposition.md` Ste
 ## Output
 
 Maintainability regressions, avoidable complexity, mechanism-level misses, god objects → `blockers[]`. Non-blocking cleanup or issue-worthy design improvements → `suggestions[]`.
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.claude/agents/reviewer-safety.md
+++ b/.claude/agents/reviewer-safety.md
@@ -18,8 +18,6 @@ skills: reviewer
 
 Memory and thread safety in compiled code, AND concurrency of processes and files — scripts and orchestration race too. Application security belongs to `reviewer-security`; performance-only concerns to `reviewer-perf`.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 - **Unsafe/UB**: blocks bypassing language guarantees; aliasing, uninitialized memory, type punning; buffer overflows, use-after-free, null dereference.
@@ -38,3 +36,7 @@ A finding in a class `.agents/skills/orch/references/finding-disposition.md` Ste
 ## Output
 
 Safety violations, races, UB → `blockers[]`. Missing safety annotations, minor improvements → `suggestions[]`.
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.claude/agents/reviewer-security.md
+++ b/.claude/agents/reviewer-security.md
@@ -18,8 +18,6 @@ skills: reviewer
 
 Application security and trust boundaries (memory/thread safety belongs to `reviewer-safety`; general correctness to `reviewer-correctness` unless security impact is central). Project security policies outrank generic standards; include a CWE reference when applicable.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Vulnerability classes (injection, broken auth/authz, data exposure, XSS/CSRF, privilege escalation), input validation at boundaries, API security. Plus:
@@ -34,3 +32,7 @@ A finding in a class `.agents/skills/orch/references/finding-disposition.md` Ste
 ## Output
 
 Vulnerabilities, gating gaps, containment escapes, secret exposure → `blockers[]`. Hardening → `suggestions[]`.
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.claude/agents/reviewer-test.md
+++ b/.claude/agents/reviewer-test.md
@@ -18,8 +18,6 @@ skills: reviewer
 
 The highest-value question is not "is there a test?" but "**can this test still fail?**" — hunt for tests that stay green when the behavior they guard is weakened, inverted, or deleted.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Coverage of changed paths (branches, error paths, boundaries), test quality, determinism, environment assumptions. Leave the underlying product bug to `reviewer-correctness` — you report the missing or weak test. Demand tests that catch real bugs, not coverage theater.
@@ -39,3 +37,7 @@ A finding in a class `.agents/skills/orch/references/finding-disposition.md` Ste
 ## Output
 
 Coverage gaps, vacuous tests, missing must-fail controls, unwired suites → `blockers[]`. Quality improvements, nice-to-have tests → `suggestions[]`.
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.claude/agents/rust.md
+++ b/.claude/agents/rust.md
@@ -16,8 +16,6 @@ skills: code-quality, decider, dev, github, linear, preflight
 
 Implements performance-critical Rust: zero-allocation hot paths, lock-free data structures, SIMD, and measurable latency targets.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Systems-level implementation and the benchmarks that justify it. Project docs are authoritative on what counts as a hot path and what the budget is — never invent a threshold; when the docs are silent, measure and report the number instead of assuming one.
@@ -33,3 +31,7 @@ Systems-level implementation and the benchmarks that justify it. Project docs ar
 ## Output
 
 The change, the measurement behind any performance claim, and every `unsafe` or ordering invariant a reviewer has to check by hand.
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.claude/agents/scout.md
+++ b/.claude/agents/scout.md
@@ -16,8 +16,6 @@ skills: github, linear
 
 Reconnaissance specialist. Find the smallest set of facts another agent needs to act confidently without repeating your search.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Report-Only Contract
 
 You explore; you do not change the workspace. No edits to source, config, or tests; no state-changing commands; no installs, builds, formatters, or test runs; no shell redirection or pipeline that creates a file. Shell use is discovery only — `ls`, `find`, `rg`, `git log`, `git diff`, and their kin. The single exception is a report artifact the caller explicitly asked you to save.
@@ -40,3 +38,7 @@ Set by the caller; default **medium**.
 ## Output
 
 Answer four things: where the relevant code lives, how the key types and functions connect, which constraints — tests, docs, conventions — the next agent must respect, and what remains unknown or risky. Close with the one file or function to open first, and why. This is context for another agent, not a document: compress accordingly.
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.claude/agents/tpm.md
+++ b/.claude/agents/tpm.md
@@ -16,8 +16,6 @@ skills: decider, dev, github, linear, project-management
 
 Analyzes roadmaps, cycles, backlogs, and cross-project dependencies. Recommends; never executes.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 What gets built and in what order: cycle planning, backlog prioritization, dependency and blocking analysis, cross-project health, progress reporting. Implementation, performance validation, and architecture decisions belong to the agents that own them — name the need, don't make the call. You do not mutate tracker state; the calling agent acts on your output.
@@ -31,3 +29,7 @@ What gets built and in what order: cycle planning, backlog prioritization, depen
 ## Output
 
 Findings the caller can act on without re-deriving them, structured as JSON when the delegated workflow defines a schema.
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.codex/agents/generalist.toml
+++ b/.codex/agents/generalist.toml
@@ -11,8 +11,6 @@ developer_instructions = '''
 
 Handles cross-cutting maintenance: documentation accuracy, stale references, broken links and lint, and configuration organization.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Changes whose correctness is settled by reading: doc claims, references, links, file and config organization. Work needing domain judgment — core logic, performance-critical code, architecture decisions — goes back to the caller with what you found, not with a patch.
@@ -37,4 +35,8 @@ Read each before acting:
 - linear: .agents/skills/linear/SKILL.md
 - preflight: .agents/skills/preflight/SKILL.md
 - review-gate: .agents/skills/review-gate/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
 '''

--- a/.codex/agents/iced.toml
+++ b/.codex/agents/iced.toml
@@ -11,8 +11,6 @@ developer_instructions = '''
 
 Implements the Iced view layer: widget composition, Canvas and Shader rendering, `pane_grid` docking, theming, subscriptions, and Elm-architecture message flow.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 The view and the messages that drive it. Domain logic, data sourcing, and persistence stay with their owners — take the state as given and render it.
@@ -36,4 +34,8 @@ Read each before acting:
 - iced-rs: .agents/skills/iced-rs/SKILL.md
 - linear: .agents/skills/linear/SKILL.md
 - preflight: .agents/skills/preflight/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
 '''

--- a/.codex/agents/planner.toml
+++ b/.codex/agents/planner.toml
@@ -11,8 +11,6 @@ developer_instructions = '''
 
 Converts requirements, recon findings, and code context into an ordered implementation plan another agent can execute without re-deciding anything.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Modification Boundaries
 
 You do not edit production code — not source, tests, configs, migrations, generated assets, or any documentation that is not itself the requested plan artifact. No dependency installs or lockfile changes. Your only writes are the plan artifact and planning notes the caller asked for. Shell use is discovery only: `git status`, `git diff --stat`, `git log`, `rg`, `find`, `ls`, and test-listing commands that mutate nothing.
@@ -44,4 +42,8 @@ Write a file only when asked. Given no path, a technical plan goes to `docs/plan
 Read each before acting:
 - github: .agents/skills/github/SKILL.md
 - linear: .agents/skills/linear/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
 '''

--- a/.codex/agents/researcher.toml
+++ b/.codex/agents/researcher.toml
@@ -11,8 +11,6 @@ developer_instructions = '''
 
 Executes delegated research prompts and produces evidence-backed findings reports.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Provider-backed research and the report it produces. Not production code, not architecture decisions beyond the recommendation the evidence supports, not creating or reshaping tracked work unless the delegation instructs it, and never coordinating other agents.
@@ -35,4 +33,8 @@ Read each before acting:
 - deep-research: .agents/skills/deep-research/SKILL.md
 - github: .agents/skills/github/SKILL.md
 - linear: .agents/skills/linear/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
 '''

--- a/.codex/agents/reviewer-arch.toml
+++ b/.codex/agents/reviewer-arch.toml
@@ -13,8 +13,6 @@ developer_instructions = '''
 
 Compliance criteria come from the project's architecture docs — do not invent design rules the project never adopted. Leave local code quality not tied to architecture policy to `reviewer-quality`.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 - **Module boundaries and layering**: components respecting documented boundaries; cross-cutting leaks; dependency-rule violations.
@@ -32,4 +30,8 @@ Architecture violations, boundary breaches, spec holes → `blockers[]`. Tech de
 
 Read each before acting:
 - reviewer: .agents/skills/reviewer/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
 '''

--- a/.codex/agents/reviewer-correctness.toml
+++ b/.codex/agents/reviewer-correctness.toml
@@ -13,8 +13,6 @@ developer_instructions = '''
 
 Does the changed code still do what the product intends — for every input, caller, and consumer? Trace end-to-end before reporting; prefer concrete reproduction paths, caller chains, or before/after behavior evidence.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Behavior regressions; API/CLI/contract compatibility (including two components implementing one contract — validator pairs, writer/reader conventions — drifting apart); cross-module side effects; feature-gate leaks; data/migration/state semantics, including idempotency of interrupted-then-retried flows; developer-workflow breakage (report only changes to how contributors build, run, configure, or connect — not routine dependency bumps). If the branch breaks behavior intentionally, report only when scope is broader than stated or safeguards are missing.
@@ -64,4 +62,8 @@ Regressions, boundary defects, compatibility/contract breaks, feature leaks, sta
 
 Read each before acting:
 - reviewer: .agents/skills/reviewer/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
 '''

--- a/.codex/agents/reviewer-doc.toml
+++ b/.codex/agents/reviewer-doc.toml
@@ -13,8 +13,6 @@ developer_instructions = '''
 
 The method is verification, not proofreading — **open the implementation behind every checkable claim in the changed docs.** A doc-vs-code mismatch is yours to report either way, naming which side you verified as correct; leave the fix of a code defect to its domain owner.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Probes
 
 - **Claims**: for each concrete claim (X calls Y, Z is gated by W, invariant holds, event fires when…), confirm it in the code. Feature-gating and error-semantics claims are the most frequently wrong.
@@ -35,4 +33,8 @@ Wrong claims, wrong values, dead citations, contradicted invariants → `blocker
 
 Read each before acting:
 - reviewer: .agents/skills/reviewer/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
 '''

--- a/.codex/agents/reviewer-error.toml
+++ b/.codex/agents/reviewer-error.toml
@@ -13,8 +13,6 @@ developer_instructions = '''
 
 Error paths that quietly convert failure into success. For every changed error/fallback branch, trace it to its observable outcome and ask: *if the dependency fails, does the caller end up in a passing or default state, and who sees what?* "Nobody sees anything and the run continues" is a finding.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Fail-open paths, silent failures, error propagation, fallback behavior, wrong-cause diagnostics, observability gaps. Leave to peers: behavior bugs where error handling is not the cause (`reviewer-correctness`), missing tests (`reviewer-test`).
@@ -43,4 +41,8 @@ Fail-open paths, silent failures, swallowed errors, wrong-cause diagnostics → 
 
 Read each before acting:
 - reviewer: .agents/skills/reviewer/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
 '''

--- a/.codex/agents/reviewer-perf.toml
+++ b/.codex/agents/reviewer-perf.toml
@@ -13,8 +13,6 @@ developer_instructions = '''
 
 Validate performance with evidence: benchmarks against baselines, project-defined thresholds and budgets, percentiles over averages. Thresholds and hot/cold-path definitions come from the project's docs — never fabricate budgets; when docs are silent, report evidence-based risk instead. Classify every regression — silent omission is forbidden. Leave style and architecture to their owners unless perf impact is demonstrated.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 - **Benchmark execution and regression detection** against baselines, classified by path criticality (hot vs cold). Operational rules — recording, feature-gated lanes, zero-result and fail-closed recorder handling: `.agents/skills/reviewer/references/perf-qa.md` (read before running or recording any benchmark).
@@ -31,4 +29,8 @@ Budget exceedances, classified regressions, hot-path cost introductions → `blo
 
 Read each before acting:
 - reviewer: .agents/skills/reviewer/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
 '''

--- a/.codex/agents/reviewer-quality.toml
+++ b/.codex/agents/reviewer-quality.toml
@@ -13,8 +13,6 @@ developer_instructions = '''
 
 Is the changed implementation simple, direct, easy to reason about, and aligned with the codebase? Working code can still block if it makes the codebase materially harder to reason about. Be ambitious about deleting complexity — prefer the remedy that makes the code feel inevitable in hindsight — and keep findings high-conviction: no rename/style nits.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Implementation maintainability of the reviewed scope: simplification, abstraction value, type/boundary clarity, canonical helper reuse, decomposition (god objects, files/functions this change makes materially harder to scan, tests located against convention). Raw file-size thresholds are deterministic (size-ratchet) — don't re-enforce them. Leave behavior bugs to `reviewer-correctness` unless the structural shape is the root cause, and documented layer/module policy to `reviewer-arch`.
@@ -38,4 +36,8 @@ Maintainability regressions, avoidable complexity, mechanism-level misses, god o
 
 Read each before acting:
 - reviewer: .agents/skills/reviewer/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
 '''

--- a/.codex/agents/reviewer-safety.toml
+++ b/.codex/agents/reviewer-safety.toml
@@ -13,8 +13,6 @@ developer_instructions = '''
 
 Memory and thread safety in compiled code, AND concurrency of processes and files — scripts and orchestration race too. Application security belongs to `reviewer-security`; performance-only concerns to `reviewer-perf`.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 - **Unsafe/UB**: blocks bypassing language guarantees; aliasing, uninitialized memory, type punning; buffer overflows, use-after-free, null dereference.
@@ -38,4 +36,8 @@ Safety violations, races, UB → `blockers[]`. Missing safety annotations, minor
 
 Read each before acting:
 - reviewer: .agents/skills/reviewer/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
 '''

--- a/.codex/agents/reviewer-security.toml
+++ b/.codex/agents/reviewer-security.toml
@@ -13,8 +13,6 @@ developer_instructions = '''
 
 Application security and trust boundaries (memory/thread safety belongs to `reviewer-safety`; general correctness to `reviewer-correctness` unless security impact is central). Project security policies outrank generic standards; include a CWE reference when applicable.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Vulnerability classes (injection, broken auth/authz, data exposure, XSS/CSRF, privilege escalation), input validation at boundaries, API security. Plus:
@@ -34,4 +32,8 @@ Vulnerabilities, gating gaps, containment escapes, secret exposure → `blockers
 
 Read each before acting:
 - reviewer: .agents/skills/reviewer/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
 '''

--- a/.codex/agents/reviewer-test.toml
+++ b/.codex/agents/reviewer-test.toml
@@ -13,8 +13,6 @@ developer_instructions = '''
 
 The highest-value question is not "is there a test?" but "**can this test still fail?**" — hunt for tests that stay green when the behavior they guard is weakened, inverted, or deleted.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Coverage of changed paths (branches, error paths, boundaries), test quality, determinism, environment assumptions. Leave the underlying product bug to `reviewer-correctness` — you report the missing or weak test. Demand tests that catch real bugs, not coverage theater.
@@ -39,4 +37,8 @@ Coverage gaps, vacuous tests, missing must-fail controls, unwired suites → `bl
 
 Read each before acting:
 - reviewer: .agents/skills/reviewer/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
 '''

--- a/.codex/agents/rust.toml
+++ b/.codex/agents/rust.toml
@@ -11,8 +11,6 @@ developer_instructions = '''
 
 Implements performance-critical Rust: zero-allocation hot paths, lock-free data structures, SIMD, and measurable latency targets.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Systems-level implementation and the benchmarks that justify it. Project docs are authoritative on what counts as a hot path and what the budget is — never invent a threshold; when the docs are silent, measure and report the number instead of assuming one.
@@ -38,4 +36,8 @@ Read each before acting:
 - github: .agents/skills/github/SKILL.md
 - linear: .agents/skills/linear/SKILL.md
 - preflight: .agents/skills/preflight/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
 '''

--- a/.codex/agents/scout.toml
+++ b/.codex/agents/scout.toml
@@ -11,8 +11,6 @@ developer_instructions = '''
 
 Reconnaissance specialist. Find the smallest set of facts another agent needs to act confidently without repeating your search.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Report-Only Contract
 
 You explore; you do not change the workspace. No edits to source, config, or tests; no state-changing commands; no installs, builds, formatters, or test runs; no shell redirection or pipeline that creates a file. Shell use is discovery only — `ls`, `find`, `rg`, `git log`, `git diff`, and their kin. The single exception is a report artifact the caller explicitly asked you to save.
@@ -41,4 +39,8 @@ Answer four things: where the relevant code lives, how the key types and functio
 Read each before acting:
 - github: .agents/skills/github/SKILL.md
 - linear: .agents/skills/linear/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
 '''

--- a/.codex/agents/tpm.toml
+++ b/.codex/agents/tpm.toml
@@ -11,8 +11,6 @@ developer_instructions = '''
 
 Analyzes roadmaps, cycles, backlogs, and cross-project dependencies. Recommends; never executes.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 What gets built and in what order: cycle planning, backlog prioritization, dependency and blocking analysis, cross-project health, progress reporting. Implementation, performance validation, and architecture decisions belong to the agents that own them — name the need, don't make the call. You do not mutate tracker state; the calling agent acts on your output.
@@ -35,4 +33,8 @@ Read each before acting:
 - github: .agents/skills/github/SKILL.md
 - linear: .agents/skills/linear/SKILL.md
 - project-management: .agents/skills/project-management/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.
 '''

--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -131,22 +131,6 @@ jobs:
         if: always() && matrix.shard == 'rest'
         run: skills/growth-guards/scripts/todo-ban
 
-      # Every skill must route problem reports through `kendex report`: a
-      # skill carrying only a `bugs:` URL sends agents to hand-file in this
-      # repo regardless of who owns the asset.
-      - name: skills point reports at `kendex report`
-        if: matrix.shard == 'rest'
-        run: |
-          set -u
-          fail=0
-          while IFS= read -r f; do
-            if ! grep -qF 'kendex report' "$f"; then
-              echo "missing \`kendex report\` guidance: $f"
-              fail=1
-            fi
-          done < <(git ls-files -- 'skills/*/SKILL.md')
-          exit "$fail"
-
       # One scan for Bash 4+ syntax over the roster `tools/bash32-lint --list`
       # prints. bash32-lint.test.sh proves its teeth.
       - name: bash32-lint (Bash 3.2 portability across the roster)

--- a/.pi/agents/generalist.md
+++ b/.pi/agents/generalist.md
@@ -14,8 +14,6 @@ pane: true
 
 Handles cross-cutting maintenance: documentation accuracy, stale references, broken links and lint, and configuration organization.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Changes whose correctness is settled by reading: doc claims, references, links, file and config organization. Work needing domain judgment — core logic, performance-critical code, architecture decisions — goes back to the caller with what you found, not with a patch.
@@ -40,3 +38,7 @@ Read each before acting:
 - linear: .agents/skills/linear/SKILL.md
 - preflight: .agents/skills/preflight/SKILL.md
 - review-gate: .agents/skills/review-gate/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.pi/agents/iced.md
+++ b/.pi/agents/iced.md
@@ -14,8 +14,6 @@ pane: true
 
 Implements the Iced view layer: widget composition, Canvas and Shader rendering, `pane_grid` docking, theming, subscriptions, and Elm-architecture message flow.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 The view and the messages that drive it. Domain logic, data sourcing, and persistence stay with their owners — take the state as given and render it.
@@ -39,3 +37,7 @@ Read each before acting:
 - iced-rs: .agents/skills/iced-rs/SKILL.md
 - linear: .agents/skills/linear/SKILL.md
 - preflight: .agents/skills/preflight/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.pi/agents/planner.md
+++ b/.pi/agents/planner.md
@@ -13,8 +13,6 @@ pane: true
 
 Converts requirements, recon findings, and code context into an ordered implementation plan another agent can execute without re-deciding anything.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Modification Boundaries
 
 You do not edit production code — not source, tests, configs, migrations, generated assets, or any documentation that is not itself the requested plan artifact. No dependency installs or lockfile changes. Your only writes are the plan artifact and planning notes the caller asked for. Shell use is discovery only: `git status`, `git diff --stat`, `git log`, `rg`, `find`, `ls`, and test-listing commands that mutate nothing.
@@ -46,3 +44,7 @@ Write a file only when asked. Given no path, a technical plan goes to `docs/plan
 Read each before acting:
 - github: .agents/skills/github/SKILL.md
 - linear: .agents/skills/linear/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.pi/agents/researcher.md
+++ b/.pi/agents/researcher.md
@@ -12,8 +12,6 @@ color: purple
 
 Executes delegated research prompts and produces evidence-backed findings reports.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Provider-backed research and the report it produces. Not production code, not architecture decisions beyond the recommendation the evidence supports, not creating or reshaping tracked work unless the delegation instructs it, and never coordinating other agents.
@@ -36,3 +34,7 @@ Read each before acting:
 - deep-research: .agents/skills/deep-research/SKILL.md
 - github: .agents/skills/github/SKILL.md
 - linear: .agents/skills/linear/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.pi/agents/reviewer-arch.md
+++ b/.pi/agents/reviewer-arch.md
@@ -14,8 +14,6 @@ color: yellow
 
 Compliance criteria come from the project's architecture docs — do not invent design rules the project never adopted. Leave local code quality not tied to architecture policy to `reviewer-quality`.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 - **Module boundaries and layering**: components respecting documented boundaries; cross-cutting leaks; dependency-rule violations.
@@ -33,3 +31,7 @@ Architecture violations, boundary breaches, spec holes → `blockers[]`. Tech de
 
 Read each before acting:
 - reviewer: .agents/skills/reviewer/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.pi/agents/reviewer-correctness.md
+++ b/.pi/agents/reviewer-correctness.md
@@ -14,8 +14,6 @@ color: red
 
 Does the changed code still do what the product intends — for every input, caller, and consumer? Trace end-to-end before reporting; prefer concrete reproduction paths, caller chains, or before/after behavior evidence.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Behavior regressions; API/CLI/contract compatibility (including two components implementing one contract — validator pairs, writer/reader conventions — drifting apart); cross-module side effects; feature-gate leaks; data/migration/state semantics, including idempotency of interrupted-then-retried flows; developer-workflow breakage (report only changes to how contributors build, run, configure, or connect — not routine dependency bumps). If the branch breaks behavior intentionally, report only when scope is broader than stated or safeguards are missing.
@@ -65,3 +63,7 @@ Regressions, boundary defects, compatibility/contract breaks, feature leaks, sta
 
 Read each before acting:
 - reviewer: .agents/skills/reviewer/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.pi/agents/reviewer-doc.md
+++ b/.pi/agents/reviewer-doc.md
@@ -14,8 +14,6 @@ color: yellow
 
 The method is verification, not proofreading — **open the implementation behind every checkable claim in the changed docs.** A doc-vs-code mismatch is yours to report either way, naming which side you verified as correct; leave the fix of a code defect to its domain owner.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Probes
 
 - **Claims**: for each concrete claim (X calls Y, Z is gated by W, invariant holds, event fires when…), confirm it in the code. Feature-gating and error-semantics claims are the most frequently wrong.
@@ -36,3 +34,7 @@ Wrong claims, wrong values, dead citations, contradicted invariants → `blocker
 
 Read each before acting:
 - reviewer: .agents/skills/reviewer/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.pi/agents/reviewer-error.md
+++ b/.pi/agents/reviewer-error.md
@@ -14,8 +14,6 @@ color: orange
 
 Error paths that quietly convert failure into success. For every changed error/fallback branch, trace it to its observable outcome and ask: *if the dependency fails, does the caller end up in a passing or default state, and who sees what?* "Nobody sees anything and the run continues" is a finding.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Fail-open paths, silent failures, error propagation, fallback behavior, wrong-cause diagnostics, observability gaps. Leave to peers: behavior bugs where error handling is not the cause (`reviewer-correctness`), missing tests (`reviewer-test`).
@@ -44,3 +42,7 @@ Fail-open paths, silent failures, swallowed errors, wrong-cause diagnostics → 
 
 Read each before acting:
 - reviewer: .agents/skills/reviewer/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.pi/agents/reviewer-perf.md
+++ b/.pi/agents/reviewer-perf.md
@@ -14,8 +14,6 @@ color: red
 
 Validate performance with evidence: benchmarks against baselines, project-defined thresholds and budgets, percentiles over averages. Thresholds and hot/cold-path definitions come from the project's docs — never fabricate budgets; when docs are silent, report evidence-based risk instead. Classify every regression — silent omission is forbidden. Leave style and architecture to their owners unless perf impact is demonstrated.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 - **Benchmark execution and regression detection** against baselines, classified by path criticality (hot vs cold). Operational rules — recording, feature-gated lanes, zero-result and fail-closed recorder handling: `.agents/skills/reviewer/references/perf-qa.md` (read before running or recording any benchmark).
@@ -32,3 +30,7 @@ Budget exceedances, classified regressions, hot-path cost introductions → `blo
 
 Read each before acting:
 - reviewer: .agents/skills/reviewer/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.pi/agents/reviewer-quality.md
+++ b/.pi/agents/reviewer-quality.md
@@ -14,8 +14,6 @@ color: purple
 
 Is the changed implementation simple, direct, easy to reason about, and aligned with the codebase? Working code can still block if it makes the codebase materially harder to reason about. Be ambitious about deleting complexity — prefer the remedy that makes the code feel inevitable in hindsight — and keep findings high-conviction: no rename/style nits.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Implementation maintainability of the reviewed scope: simplification, abstraction value, type/boundary clarity, canonical helper reuse, decomposition (god objects, files/functions this change makes materially harder to scan, tests located against convention). Raw file-size thresholds are deterministic (size-ratchet) — don't re-enforce them. Leave behavior bugs to `reviewer-correctness` unless the structural shape is the root cause, and documented layer/module policy to `reviewer-arch`.
@@ -39,3 +37,7 @@ Maintainability regressions, avoidable complexity, mechanism-level misses, god o
 
 Read each before acting:
 - reviewer: .agents/skills/reviewer/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.pi/agents/reviewer-safety.md
+++ b/.pi/agents/reviewer-safety.md
@@ -14,8 +14,6 @@ color: red
 
 Memory and thread safety in compiled code, AND concurrency of processes and files — scripts and orchestration race too. Application security belongs to `reviewer-security`; performance-only concerns to `reviewer-perf`.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 - **Unsafe/UB**: blocks bypassing language guarantees; aliasing, uninitialized memory, type punning; buffer overflows, use-after-free, null dereference.
@@ -39,3 +37,7 @@ Safety violations, races, UB → `blockers[]`. Missing safety annotations, minor
 
 Read each before acting:
 - reviewer: .agents/skills/reviewer/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.pi/agents/reviewer-security.md
+++ b/.pi/agents/reviewer-security.md
@@ -14,8 +14,6 @@ color: red
 
 Application security and trust boundaries (memory/thread safety belongs to `reviewer-safety`; general correctness to `reviewer-correctness` unless security impact is central). Project security policies outrank generic standards; include a CWE reference when applicable.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Vulnerability classes (injection, broken auth/authz, data exposure, XSS/CSRF, privilege escalation), input validation at boundaries, API security. Plus:
@@ -35,3 +33,7 @@ Vulnerabilities, gating gaps, containment escapes, secret exposure → `blockers
 
 Read each before acting:
 - reviewer: .agents/skills/reviewer/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.pi/agents/reviewer-test.md
+++ b/.pi/agents/reviewer-test.md
@@ -14,8 +14,6 @@ color: blue
 
 The highest-value question is not "is there a test?" but "**can this test still fail?**" — hunt for tests that stay green when the behavior they guard is weakened, inverted, or deleted.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Coverage of changed paths (branches, error paths, boundaries), test quality, determinism, environment assumptions. Leave the underlying product bug to `reviewer-correctness` — you report the missing or weak test. Demand tests that catch real bugs, not coverage theater.
@@ -40,3 +38,7 @@ Coverage gaps, vacuous tests, missing must-fail controls, unwired suites → `bl
 
 Read each before acting:
 - reviewer: .agents/skills/reviewer/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.pi/agents/rust.md
+++ b/.pi/agents/rust.md
@@ -14,8 +14,6 @@ pane: true
 
 Implements performance-critical Rust: zero-allocation hot paths, lock-free data structures, SIMD, and measurable latency targets.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Systems-level implementation and the benchmarks that justify it. Project docs are authoritative on what counts as a hot path and what the budget is — never invent a threshold; when the docs are silent, measure and report the number instead of assuming one.
@@ -41,3 +39,7 @@ Read each before acting:
 - github: .agents/skills/github/SKILL.md
 - linear: .agents/skills/linear/SKILL.md
 - preflight: .agents/skills/preflight/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.pi/agents/scout.md
+++ b/.pi/agents/scout.md
@@ -13,8 +13,6 @@ color: cyan
 
 Reconnaissance specialist. Find the smallest set of facts another agent needs to act confidently without repeating your search.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Report-Only Contract
 
 You explore; you do not change the workspace. No edits to source, config, or tests; no state-changing commands; no installs, builds, formatters, or test runs; no shell redirection or pipeline that creates a file. Shell use is discovery only — `ls`, `find`, `rg`, `git log`, `git diff`, and their kin. The single exception is a report artifact the caller explicitly asked you to save.
@@ -43,3 +41,7 @@ Answer four things: where the relevant code lives, how the key types and functio
 Read each before acting:
 - github: .agents/skills/github/SKILL.md
 - linear: .agents/skills/linear/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/.pi/agents/tpm.md
+++ b/.pi/agents/tpm.md
@@ -12,8 +12,6 @@ color: blue
 
 Analyzes roadmaps, cycles, backlogs, and cross-project dependencies. Recommends; never executes.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 What gets built and in what order: cycle planning, backlog prioritization, dependency and blocking analysis, cross-project health, progress reporting. Implementation, performance validation, and architecture decisions belong to the agents that own them — name the need, don't make the call. You do not mutate tracker state; the calling agent acts on your output.
@@ -36,3 +34,7 @@ Read each before acting:
 - github: .agents/skills/github/SKILL.md
 - linear: .agents/skills/linear/SKILL.md
 - project-management: .agents/skills/project-management/SKILL.md
+
+## Additional Instructions
+
+Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@ kendex apply --plan                                     # preview the full recon
 | `guard` | Commit-time quality guards and the git hooks that run them |
 | `source add/remove/enable/disable/refresh` | manage catalogs per scope |
 | `project add/remove/list/discover` | the app's project registry |
-| `report` | file an issue, routed to the asset's owner |
 | `index` | Emit the summary of a marketplace directory the community directory consumes (default: the current directory) |
 | `version-compare` | Where the first version stands against the second under SemVer precedence: newer, same, or older |
 | `update`, `update-pi`, `init` | self-update, Pi packages, catalog scaffolding |

--- a/agents/generalist.md
+++ b/agents/generalist.md
@@ -12,8 +12,6 @@ tags: [docs, refactoring]
 
 Handles cross-cutting maintenance: documentation accuracy, stale references, broken links and lint, and configuration organization.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Changes whose correctness is settled by reading: doc claims, references, links, file and config organization. Work needing domain judgment — core logic, performance-critical code, architecture decisions — goes back to the caller with what you found, not with a patch.

--- a/agents/iced.md
+++ b/agents/iced.md
@@ -12,8 +12,6 @@ tags: [ui]
 
 Implements the Iced view layer: widget composition, Canvas and Shader rendering, `pane_grid` docking, theming, subscriptions, and Elm-architecture message flow.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 The view and the messages that drive it. Domain logic, data sourcing, and persistence stay with their owners — take the state as given and render it.

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -12,8 +12,6 @@ tags: [planning, research]
 
 Converts requirements, recon findings, and code context into an ordered implementation plan another agent can execute without re-deciding anything.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Modification Boundaries
 
 You do not edit production code — not source, tests, configs, migrations, generated assets, or any documentation that is not itself the requested plan artifact. No dependency installs or lockfile changes. Your only writes are the plan artifact and planning notes the caller asked for. Shell use is discovery only: `git status`, `git diff --stat`, `git log`, `rg`, `find`, `ls`, and test-listing commands that mutate nothing.

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -12,8 +12,6 @@ tags: [research]
 
 Executes delegated research prompts and produces evidence-backed findings reports.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Provider-backed research and the report it produces. Not production code, not architecture decisions beyond the recommendation the evidence supports, not creating or reshaping tracked work unless the delegation instructs it, and never coordinating other agents.

--- a/agents/reviewer-arch.md
+++ b/agents/reviewer-arch.md
@@ -14,8 +14,6 @@ tags: [review]
 
 Compliance criteria come from the project's architecture docs — do not invent design rules the project never adopted. Leave local code quality not tied to architecture policy to `reviewer-quality`.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 - **Module boundaries and layering**: components respecting documented boundaries; cross-cutting leaks; dependency-rule violations.

--- a/agents/reviewer-correctness.md
+++ b/agents/reviewer-correctness.md
@@ -14,8 +14,6 @@ tags: [review]
 
 Does the changed code still do what the product intends — for every input, caller, and consumer? Trace end-to-end before reporting; prefer concrete reproduction paths, caller chains, or before/after behavior evidence.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Behavior regressions; API/CLI/contract compatibility (including two components implementing one contract — validator pairs, writer/reader conventions — drifting apart); cross-module side effects; feature-gate leaks; data/migration/state semantics, including idempotency of interrupted-then-retried flows; developer-workflow breakage (report only changes to how contributors build, run, configure, or connect — not routine dependency bumps). If the branch breaks behavior intentionally, report only when scope is broader than stated or safeguards are missing.

--- a/agents/reviewer-doc.md
+++ b/agents/reviewer-doc.md
@@ -14,8 +14,6 @@ tags: [review, docs]
 
 The method is verification, not proofreading — **open the implementation behind every checkable claim in the changed docs.** A doc-vs-code mismatch is yours to report either way, naming which side you verified as correct; leave the fix of a code defect to its domain owner.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Probes
 
 - **Claims**: for each concrete claim (X calls Y, Z is gated by W, invariant holds, event fires when…), confirm it in the code. Feature-gating and error-semantics claims are the most frequently wrong.

--- a/agents/reviewer-error.md
+++ b/agents/reviewer-error.md
@@ -14,8 +14,6 @@ tags: [review, debugging]
 
 Error paths that quietly convert failure into success. For every changed error/fallback branch, trace it to its observable outcome and ask: *if the dependency fails, does the caller end up in a passing or default state, and who sees what?* "Nobody sees anything and the run continues" is a finding.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Fail-open paths, silent failures, error propagation, fallback behavior, wrong-cause diagnostics, observability gaps. Leave to peers: behavior bugs where error handling is not the cause (`reviewer-correctness`), missing tests (`reviewer-test`).

--- a/agents/reviewer-perf.md
+++ b/agents/reviewer-perf.md
@@ -14,8 +14,6 @@ tags: [review, performance]
 
 Validate performance with evidence: benchmarks against baselines, project-defined thresholds and budgets, percentiles over averages. Thresholds and hot/cold-path definitions come from the project's docs — never fabricate budgets; when docs are silent, report evidence-based risk instead. Classify every regression — silent omission is forbidden. Leave style and architecture to their owners unless perf impact is demonstrated.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 - **Benchmark execution and regression detection** against baselines, classified by path criticality (hot vs cold). Operational rules — recording, feature-gated lanes, zero-result and fail-closed recorder handling: `.agents/skills/reviewer/references/perf-qa.md` (read before running or recording any benchmark).

--- a/agents/reviewer-quality.md
+++ b/agents/reviewer-quality.md
@@ -14,8 +14,6 @@ tags: [review]
 
 Is the changed implementation simple, direct, easy to reason about, and aligned with the codebase? Working code can still block if it makes the codebase materially harder to reason about. Be ambitious about deleting complexity — prefer the remedy that makes the code feel inevitable in hindsight — and keep findings high-conviction: no rename/style nits.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Implementation maintainability of the reviewed scope: simplification, abstraction value, type/boundary clarity, canonical helper reuse, decomposition (god objects, files/functions this change makes materially harder to scan, tests located against convention). Raw file-size thresholds are deterministic (size-ratchet) — don't re-enforce them. Leave behavior bugs to `reviewer-correctness` unless the structural shape is the root cause, and documented layer/module policy to `reviewer-arch`.

--- a/agents/reviewer-safety.md
+++ b/agents/reviewer-safety.md
@@ -14,8 +14,6 @@ tags: [review, security]
 
 Memory and thread safety in compiled code, AND concurrency of processes and files — scripts and orchestration race too. Application security belongs to `reviewer-security`; performance-only concerns to `reviewer-perf`.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 - **Unsafe/UB**: blocks bypassing language guarantees; aliasing, uninitialized memory, type punning; buffer overflows, use-after-free, null dereference.

--- a/agents/reviewer-security.md
+++ b/agents/reviewer-security.md
@@ -14,8 +14,6 @@ tags: [review, security]
 
 Application security and trust boundaries (memory/thread safety belongs to `reviewer-safety`; general correctness to `reviewer-correctness` unless security impact is central). Project security policies outrank generic standards; include a CWE reference when applicable.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Vulnerability classes (injection, broken auth/authz, data exposure, XSS/CSRF, privilege escalation), input validation at boundaries, API security. Plus:

--- a/agents/reviewer-test.md
+++ b/agents/reviewer-test.md
@@ -14,8 +14,6 @@ tags: [review, testing]
 
 The highest-value question is not "is there a test?" but "**can this test still fail?**" — hunt for tests that stay green when the behavior they guard is weakened, inverted, or deleted.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Coverage of changed paths (branches, error paths, boundaries), test quality, determinism, environment assumptions. Leave the underlying product bug to `reviewer-correctness` — you report the missing or weak test. Demand tests that catch real bugs, not coverage theater.

--- a/agents/rust.md
+++ b/agents/rust.md
@@ -12,8 +12,6 @@ tags: [performance]
 
 Implements performance-critical Rust: zero-allocation hot paths, lock-free data structures, SIMD, and measurable latency targets.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 Systems-level implementation and the benchmarks that justify it. Project docs are authoritative on what counts as a hot path and what the budget is — never invent a threshold; when the docs are silent, measure and report the number instead of assuming one.

--- a/agents/scout.md
+++ b/agents/scout.md
@@ -12,8 +12,6 @@ tags: [research]
 
 Reconnaissance specialist. Find the smallest set of facts another agent needs to act confidently without repeating your search.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Report-Only Contract
 
 You explore; you do not change the workspace. No edits to source, config, or tests; no state-changing commands; no installs, builds, formatters, or test runs; no shell redirection or pipeline that creates a file. Shell use is discovery only — `ls`, `find`, `rg`, `git log`, `git diff`, and their kin. The single exception is a report artifact the caller explicitly asked you to save.

--- a/agents/tpm.md
+++ b/agents/tpm.md
@@ -12,8 +12,6 @@ tags: [planning]
 
 Analyzes roadmaps, cycles, backlogs, and cross-project dependencies. Recommends; never executes.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
-
 ## Scope
 
 What gets built and in what order: cycle planning, backlog prioritization, dependency and blocking analysis, cross-project health, progress reporting. Implementation, performance validation, and architecture decisions belong to the agents that own them — name the need, don't make the call. You do not mutate tracker state; the calling agent acts on your output.

--- a/changelog.d/changed/KEN-1129.md
+++ b/changelog.d/changed/KEN-1129.md
@@ -1,0 +1,1 @@
+- The `report` command no longer appears in general help or bundled package instructions; owners can still invoke it directly.

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -153,6 +153,7 @@ enum Command {
     #[command(subcommand)]
     Guard(commands::guard_cmd::GuardCommand),
     /// File an issue about an installed asset, routed by ownership
+    #[command(hide = true)]
     Report(ReportFlags),
     /// Declare, toggle, and refresh sources
     #[command(subcommand)]

--- a/crates/cli/tests/safety_print.rs
+++ b/crates/cli/tests/safety_print.rs
@@ -9,7 +9,7 @@
 
 #[path = "../../test_util.rs"]
 mod test_util;
-use test_util::source_path;
+use test_util::{rooted, source_path};
 
 use std::fs;
 use std::path::Path;
@@ -291,6 +291,32 @@ fn no_verb_or_help_line_offers_a_review() {
             );
         }
     }
+}
+
+/// Report remains callable for owners who know it exists, but the general
+/// command list does not advertise it to package consumers.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn report_is_hidden_from_root_help_but_keeps_its_own_help() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+
+    let root = kendex(&home, &home, &["--help"]);
+    assert!(root.status.success(), "{root:?}");
+    let root_help = String::from_utf8_lossy(&root.stdout);
+    assert!(
+        !root_help
+            .lines()
+            .any(|line| line.trim_start().starts_with("report ")),
+        "root help still advertises report: {root_help}"
+    );
+
+    let report = kendex(&home, &home, &["report", "--help"]);
+    assert!(report.status.success(), "{report:?}");
+    assert!(
+        !report.stdout.is_empty(),
+        "report --help succeeded without printing help"
+    );
 }
 
 /// A repository that is one skill has no path inside itself, so the score

--- a/crates/cli/tests/safety_print.rs
+++ b/crates/cli/tests/safety_print.rs
@@ -259,7 +259,7 @@ fn no_verb_or_help_line_offers_a_review() {
     assert!(root.status.success(), "{root:?}");
     let root_help = String::from_utf8_lossy(&root.stdout).into_owned();
     // Every subcommand's own help, not just the top-level list.
-    let verbs: Vec<String> = root_help
+    let mut verbs: Vec<String> = root_help
         .lines()
         .skip_while(|line| !line.starts_with("Commands:"))
         .skip(1)
@@ -269,6 +269,8 @@ fn no_verb_or_help_line_offers_a_review() {
         .map(str::to_owned)
         .collect();
     assert!(verbs.len() > 10, "no verbs parsed out of: {root_help}");
+    // Hidden owner commands still belong in the retired-language sweep.
+    verbs.push("report".to_owned());
 
     // `kendex help <verb>` rather than `<verb> --help`: clap's own `help`
     // is in the verb list and takes no `--help` of its own.
@@ -313,9 +315,14 @@ fn report_is_hidden_from_root_help_but_keeps_its_own_help() {
 
     let report = kendex(&home, &home, &["report", "--help"]);
     assert!(report.status.success(), "{report:?}");
+    let report_help = String::from_utf8_lossy(&report.stdout);
     assert!(
-        !report.stdout.is_empty(),
-        "report --help succeeded without printing help"
+        report_help.contains("Usage: kendex report [OPTIONS] --title <TITLE>"),
+        "report --help printed another command's help: {report_help}"
+    );
+    assert!(
+        report_help.contains("--skill <SKILL>") && report_help.contains("--title <TITLE>"),
+        "report --help omitted its selector or required title: {report_help}"
     );
 }
 

--- a/kendex-local.toml
+++ b/kendex-local.toml
@@ -8,6 +8,12 @@ enabled = true
 repo = "vanillagreencom/kendex"
 enabled = true
 
+[skill-instructions]
+all = "Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first."
+
+[agent-additional-instructions]
+all = "Problems with a kendex-owned skill go through `kendex report`; check ownership in the file first."
+
 [install]
 harnesses = [
     "claude",

--- a/skills/bot-instructions/SKILL.md
+++ b/skills/bot-instructions/SKILL.md
@@ -15,8 +15,6 @@ tags: [review]
 
 # Bot Instructions
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
-
 ```bash
 .agents/skills/bot-instructions/scripts/bot-instructions render   # write every enabled surface
 .agents/skills/bot-instructions/scripts/bot-instructions check    # re-render and compare

--- a/skills/code-quality/SKILL.md
+++ b/skills/code-quality/SKILL.md
@@ -15,7 +15,7 @@ tags: [review]
 
 # Code Quality
 
-Repo-specific standards live in each repo's `## Project Instructions` section below and add to these rules.
+Repo-specific standards live in each repo's `## Project Instructions` section and add to these rules.
 
 ## Core Principle
 

--- a/skills/code-quality/SKILL.md
+++ b/skills/code-quality/SKILL.md
@@ -15,8 +15,6 @@ tags: [review]
 
 # Code Quality
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
-
 Repo-specific standards live in each repo's `## Project Instructions` section below and add to these rules.
 
 ## Core Principle

--- a/skills/decider/SKILL.md
+++ b/skills/decider/SKILL.md
@@ -15,8 +15,6 @@ tags: [planning]
 
 # Decider
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
-
 Numbered decision documents indexed in one `INDEX.md` (default `docs/decisions/`), with a search CLI, canonical format, and creation/supersession workflows.
 
 ```bash

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -18,8 +18,6 @@ tags: [research]
 
 # Deep Research
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
-
 In Pi with the `web_research` tool active, use that tool, passing `outputPath` when creating a report. In every other harness, run `scripts/deep-research` with `EXA_API_KEY` set.
 
 ## Rules

--- a/skills/dep-radar/SKILL.md
+++ b/skills/dep-radar/SKILL.md
@@ -18,8 +18,6 @@ tags: [release]
 
 # dep-radar — pinned-version sweep, safe auto-update, and capability report
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
-
 **inventory → detect → research → classify → upgrade-with-fixes → report the
 owner tier**.
 

--- a/skills/dev/SKILL.md
+++ b/skills/dev/SKILL.md
@@ -18,8 +18,6 @@ tags: [automation]
 
 # Dev Workflows
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
-
 orch is the caller and runtime: it owns delegation format, round acceptance, and every shell-shape rule.
 
 | Workflow | Purpose |

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -15,8 +15,6 @@ tags: [git, integration]
 
 # GitHub Queries
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
-
 ```bash
 .agents/skills/github/scripts/github.sh [-C <path>] <command> [options]
 ```

--- a/skills/growth-guards/SKILL.md
+++ b/skills/growth-guards/SKILL.md
@@ -31,8 +31,6 @@ repo-effects:
 
 # Growth Guards
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
-
 ```bash
 .agents/skills/growth-guards/scripts/growth-guards              # batch: every enabled repo check
 .agents/skills/growth-guards/scripts/growth-guards all --staged # the same batch at commit scope

--- a/skills/harness-ci/README.md
+++ b/skills/harness-ci/README.md
@@ -94,7 +94,6 @@ There is no flag that turns any of these into a `true`.
 The script is upstream's. `kendex refresh` rewrites the render tree, and a
 local edit to `.agents/skills/harness-ci/` is drift that the next refresh
 overwrites. Send changes to
-[vanillagreencom/kendex](https://github.com/vanillagreencom/kendex) via
-`kendex report`.
+[vanillagreencom/kendex](https://github.com/vanillagreencom/kendex).
 
 Maintainer notes: [DEVELOPMENT.md](DEVELOPMENT.md).

--- a/skills/harness-ci/SKILL.md
+++ b/skills/harness-ci/SKILL.md
@@ -15,8 +15,6 @@ tags: [automation]
 
 # Harness CI
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
-
 **One question, one answer: is this diff nothing but kendex render
 output?** The classifier reads a diff's changed-file set and prints
 `harness_only=true` when every path sits under `.agents/`, `.claude/`,

--- a/skills/iced-rs/SKILL.md
+++ b/skills/iced-rs/SKILL.md
@@ -15,8 +15,6 @@ tags: [ui]
 
 # Iced 0.14
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
-
 ## Workflow
 
 1. Classify the surface against `references/guide-surface-selection.md`. Do not skip.

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -15,8 +15,6 @@ tags: [integration]
 
 # Linear CLI
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
-
 ```bash
 .agents/skills/linear/scripts/linear.sh <resource> <action> [options]
 ```

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -18,8 +18,6 @@ tags: [automation]
 
 # Orchestration
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
-
 Load `github` and `worktree` before anything else; a Linear work item also needs `linear`. The dev and reviewer skills call orch scripts.
 
 > **MODE SWITCH**: you are the orchestrator. Delegate every implementation, review, and QA task to a specialist sub-agent. Never edit code unless the user explicitly asks.

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -15,8 +15,6 @@ tags: [review, testing]
 
 # Preflight
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
-
 Every lane is diff-scoped and fail-only: findings land only on lines this
 change ADDED; a lane that cannot decide reports nothing. There is no
 warnings tier. CONTENT decides which lines a lane may read, never an

--- a/skills/price-handling/SKILL.md
+++ b/skills/price-handling/SKILL.md
@@ -15,8 +15,6 @@ tags: [data]
 
 # Price Handling Patterns
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
-
 ## The price type is `f64`
 
 IEEE 754 double precision. No fixed-point, no decimal types.

--- a/skills/project-management/SKILL.md
+++ b/skills/project-management/SKILL.md
@@ -18,8 +18,6 @@ tags: [planning]
 
 # Project Management
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
-
 Wrappers run in the primary session: they own the user dialog and every tracker mutation. TPM workflows analyze and return JSON inline; they never mutate the tracker and never write the artifact.
 
 ## Disposition

--- a/skills/review-gate/SKILL.md
+++ b/skills/review-gate/SKILL.md
@@ -15,8 +15,6 @@ tags: [review]
 
 # Review Gate
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
-
 The gate answers ONE question: **has this exact PR head been reviewed?** It
 posts that answer as a commit status the repo's branch rules require. It does
 not check CI, re-run anything, or reason about jobs.

--- a/skills/review-gate/references/vendored-paths.md
+++ b/skills/review-gate/references/vendored-paths.md
@@ -94,8 +94,9 @@ Once per re-vendor train, on ONE consumer PR, collect upstream-remedy findings
 from BOTH surfaces: the review bodies, AND EVERY vendored-path thread a
 location-bound reviewer left.
 
-File the report against the catalog repo through the owner's configured
-route.
+Use the reporting route in this skill's injected `## Project Instructions`.
+If no route is injected, return the defect to the orchestrating agent and
+user without filing.
 
 The lock is the one judge, and it records provenance for every kind — skills,
 agents, hooks and Pi extensions alike. A name routes upstream when the lock
@@ -208,10 +209,12 @@ the catalog repo and to the PR author out of band. Under a flat rule there is
 no on-PR surface left, which also removes the consolidated-comment fallback
 the vendored template gives a location-bound reviewer.
 
-**The report files against the catalog repo**, through the owner's configured
-route and the same lock ownership rule as § The consumer session's half. An
-item rendered from a third-party catalog carries that catalog in its lock
-entries and reports here instead, so open that issue by hand.
+**File against the catalog repo only when this skill's injected `## Project
+Instructions` supplies a reporting route.** Follow that route and the same
+lock ownership rule as § The consumer session's half. With no injected route,
+return the defect to the orchestrating agent and user without filing. An item
+rendered from a third-party catalog carries that catalog in its lock entries
+and reports here instead, so open that issue by hand.
 
 Wire it with the vendored template: copy it, set `applyTo` to the render
 trees, and apply its RENDER VARIANT block, which carries the replacement text

--- a/skills/review-gate/references/vendored-paths.md
+++ b/skills/review-gate/references/vendored-paths.md
@@ -94,11 +94,8 @@ Once per re-vendor train, on ONE consumer PR, collect upstream-remedy findings
 from BOTH surfaces: the review bodies, AND EVERY vendored-path thread a
 location-bound reviewer left.
 
-`kendex report --skill [NAME] --title [TITLE] --body-file [PATH]` files the
-report. The command is non-interactive: `--title` is required, and exactly one
-of `--body` or `--body-file` must be given — with neither (or both) it exits
-without filing. `--dry-run` prints the decision and the `gh` command it would
-run.
+File the report against the catalog repo through the owner's configured
+route.
 
 The lock is the one judge, and it records provenance for every kind — skills,
 agents, hooks and Pi extensions alike. A name routes upstream when the lock
@@ -211,7 +208,7 @@ the catalog repo and to the PR author out of band. Under a flat rule there is
 no on-PR surface left, which also removes the consolidated-comment fallback
 the vendored template gives a location-bound reviewer.
 
-**The report files against the catalog repo**, by the same `kendex report`
+**The report files against the catalog repo**, through the owner's configured
 route and the same lock ownership rule as § The consumer session's half. An
 item rendered from a third-party catalog carries that catalog in its lock
 entries and reports here instead, so open that issue by hand.

--- a/skills/review-gate/scripts/validate-workflow.sh
+++ b/skills/review-gate/scripts/validate-workflow.sh
@@ -229,7 +229,7 @@ ok "one adopted writer workflow: $adopted"
 # is what Actions runs, and an untracked target is a red writer on every leg.
 exec_target="$(sed -n 's/^[[:space:]]*exec[[:space:]]\{1,\}\([^[:space:]]*review-writer\.sh\)[[:space:]]*$/\1/p' "$adopted" | head -n 1)"
 if [ -z "$exec_target" ]; then
-  bad "$adopted names no exec target — the discovery above matched, so this is a parse gap in this tool rather than a repo fault; report it with \`kendex report\`"
+  bad "$adopted names no exec target — the discovery above matched, so this is a parse gap in this tool rather than a repo fault; report it to the package owner"
 elif [ -L "$exec_target" ]; then
   bad "$adopted execs $exec_target, which is a SYMLINK — CI checks out the link and runs whatever sits at the other end, which is nothing when the target is untracked or outside the repository. Commit the engine at that path"
 elif git ls-files --error-unmatch -- "$exec_target" >/dev/null 2>&1; then

--- a/skills/review-gate/templates/vendored-paths.instructions.md
+++ b/skills/review-gate/templates/vendored-paths.instructions.md
@@ -96,9 +96,9 @@ that most often survive and they are the two the flat rule forbids.
 
    - **The fix lands in these rendered bytes**: do not raise it on this PR, on
      any surface. The session that runs the refresh follows the reporting route
-     in this skill's injected `## Project Instructions`. With no injected route,
-     it returns the defect to the orchestrating agent and user without filing.
-     The fix arrives here as a later render.
+     in the review-gate skill's injected `## Project Instructions`. With no
+     injected route, it returns the defect to the orchestrating agent and user
+     without filing. The fix arrives here as a later render.
 
 4. REPLACE the third routing bullet ("[UPSTREAM_REPO]'s own docs …") with:
 

--- a/skills/review-gate/templates/vendored-paths.instructions.md
+++ b/skills/review-gate/templates/vendored-paths.instructions.md
@@ -96,8 +96,8 @@ that most often survive and they are the two the flat rule forbids.
 
    - **The fix lands in these rendered bytes**: do not raise it on this PR, on
      any surface. The session that runs the refresh files it against the
-     catalog repo with `kendex report`, and the fix arrives here as a later
-     render.
+     catalog repo through the owner's configured route, and the fix arrives
+     here as a later render.
 
 4. REPLACE the third routing bullet ("[UPSTREAM_REPO]'s own docs …") with:
 

--- a/skills/review-gate/templates/vendored-paths.instructions.md
+++ b/skills/review-gate/templates/vendored-paths.instructions.md
@@ -95,9 +95,10 @@ that most often survive and they are the two the flat rule forbids.
    REVIEW SUMMARY BODY) with:
 
    - **The fix lands in these rendered bytes**: do not raise it on this PR, on
-     any surface. The session that runs the refresh files it against the
-     catalog repo through the owner's configured route, and the fix arrives
-     here as a later render.
+     any surface. The session that runs the refresh follows the reporting route
+     in this skill's injected `## Project Instructions`. With no injected route,
+     it returns the defect to the orchestrating agent and user without filing.
+     The fix arrives here as a later render.
 
 4. REPLACE the third routing bullet ("[UPSTREAM_REPO]'s own docs …") with:
 

--- a/skills/reviewer/SKILL.md
+++ b/skills/reviewer/SKILL.md
@@ -18,8 +18,6 @@ tags: [review]
 
 # Reviewer
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
-
 Shared contract for every review specialist; each agent's domain and probes live in its own agent file. These workflows run orch scripts and do not stand alone.
 
 | Workflow | Purpose |

--- a/skills/second-opinion/SKILL.md
+++ b/skills/second-opinion/SKILL.md
@@ -16,8 +16,6 @@ tags: [review]
 
 # Second Opinion
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
-
 Cross-model second opinion via external AI CLI. Every mode walks the `SECOND_OPINION_MODELS` roster in priority order and takes the first target that is available and runs a different model — Codex from a Claude Code session, Claude from a Codex session; when nothing eligible remains the run refuses and says why. The full contract — options, target selection and identity rules, environment keys and defaults, review scope and stamping, output clearing and ownership, option syntax, and exit codes — is `second-opinion --help`.
 
 ```bash

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -15,8 +15,6 @@ tags: [automation]
 
 # Size Ratchet
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
-
 **No tracked file gets bigger than its threshold, and files already over
 it only shrink.** Existing offenders are frozen in a baseline at their
 current sizes; everything else stays at or under its path class's

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -16,8 +16,6 @@ tags: [git]
 
 # Worktree Management
 
-> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
-
 ```bash
 .agents/skills/worktree/scripts/worktree <command> [options]
 ```

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -1,5 +1,5 @@
 .github/workflows/review-gate-writer.yml	662
-.github/workflows/skill-tests.yml	546
+.github/workflows/skill-tests.yml	530
 crates/core/src/engine/detach.rs	417
 crates/core/src/error.rs	473
 crates/core/src/mapping.rs	411


### PR DESCRIPTION
## Summary
- Remove package-wide `kendex report` guidance from all shipped skill and agent sources, with matching harness renders.
- Hide `report` from root CLI help while keeping `kendex report --help` callable; retire the obsolete CI assertion and strengthen the help regression tests.
- Put kendex-owner routing in this repo's `kendex-local.toml`. Other owner repos are not changed here; they can copy this example on their next render refresh.

## Completed Issues
- Closes KEN-1129 - The kendex report instruction leaves every package; the owner's repos carry it by configuration

## Test Plan
- `.agents/skills/preflight/scripts/preflight --base origin/main --repo /home/method/dev/.worktrees/kendex/ken-1129`
- `tools/guard`
- Reviewer mutation checks for hidden root help, direct report help, and the retired-word help sweep
- Fresh scratch consumer render under `tmp/drovr-ken-1129` contains no owner reporting instruction
