### PR TITLE
fix(KEN-951): mutation-stability reports a surviving mutant when the test filter selects nothing

### DIFF
--- a/.agents/skills/reviewer/SKILL.md
+++ b/.agents/skills/reviewer/SKILL.md
@@ -71,11 +71,13 @@ right reason. Run both with one command, on a copy, never in the shared
 tree:
 
 ```bash
-.agents/skills/reviewer/scripts/mutation-stability --worktree [WORKTREE_PATH] --sha [SHA] --test '[TEST_CMD]' --mutate '[MUTATE_CMD]'
+.agents/skills/reviewer/scripts/mutation-stability --worktree [WORKTREE_PATH] --sha [SHA] --test '[TEST_CMD]' --build '[BUILD_CMD]' --mutate '[MUTATE_CMD]'
 ```
 
 - Kill the mutant under every selection/invocation mode the changed code
   exposes, not only the default (one call per mode).
+- A kill counts only when the mutated copy compiles. Use the suite's
+  compile-without-running command for `--build`.
 - Copy the printed `mutation: … stability: …` line into your artifact's
   `summary`; that field and `qa_metadata` are the only carriers read as
   your own measurement.

--- a/.agents/skills/reviewer/scripts/mutation-stability
+++ b/.agents/skills/reviewer/scripts/mutation-stability
@@ -71,21 +71,61 @@ positive_integer --threads "$THREADS"
 positive_integer --timeout "$TIMEOUT"
 
 ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX") || exit 2
-ACTIVE_PID="" ACTIVE_GROUP="" WATCHDOG_PID="" WATCHDOG_GROUP=""
+ACTIVE_PID="" ACTIVE_GROUP=""
+
+group_leaves() {
+  group="$1" leader="$2"
+  ps -eo pid=,ppid=,pgid= 2>/dev/null | awk -v group="$group" -v leader="$leader" '
+    $3 == group && $1 != leader {
+      members[$1] = 1
+      has_child[$2] = 1
+    }
+    END {
+      for (pid in members) if (!has_child[pid]) print pid
+    }
+  '
+}
+
+signal_leaves() {
+  signal="$1" group="$2" leader="$3" leaves="" leaf=""
+  leaves=$(group_leaves "$group" "$leader") || return 1
+  [ -n "$leaves" ] || return 2
+  while IFS= read -r leaf; do
+    [ -z "$leaf" ] || kill -s "$signal" "$leaf" 2>/dev/null || :
+  done <<EOF
+$leaves
+EOF
+}
 
 terminate_group() {
-  group="$1"
+  signal="$1" group="$2" leader="$3" grace=0
   [ -n "$group" ] || return 0
-  kill -TERM "-$group" 2>/dev/null || :
+
+  while [ "$grace" -lt 40 ]; do
+    leaf_status=0
+    signal_leaves KILL "$group" "$leader" || leaf_status=$?
+    [ "$leaf_status" -eq 0 ] || break
+    sleep 0.05
+    grace=$((grace + 1))
+  done
+  if [ "$leaf_status" -eq 1 ]; then
+    kill -s "$signal" "-$group" 2>/dev/null || :
+  else
+    [ -z "$leader" ] || kill -s "$signal" "$leader" 2>/dev/null || :
+  fi
+
+  grace=0
+  while [ -n "$leader" ] && kill -0 "$leader" 2>/dev/null && [ "$grace" -lt 20 ]; do
+    sleep 0.05
+    grace=$((grace + 1))
+  done
   kill -KILL "-$group" 2>/dev/null || :
+  [ -z "$leader" ] || wait "$leader" 2>/dev/null || :
 }
 
 cleanup_active() {
-  terminate_group "$WATCHDOG_GROUP"
-  [ -z "$WATCHDOG_PID" ] || wait "$WATCHDOG_PID" 2>/dev/null || :
-  terminate_group "$ACTIVE_GROUP"
-  [ -z "$ACTIVE_PID" ] || wait "$ACTIVE_PID" 2>/dev/null || :
-  ACTIVE_PID="" ACTIVE_GROUP="" WATCHDOG_PID="" WATCHDOG_GROUP=""
+  terminate_group TERM "$ACTIVE_GROUP" "$ACTIVE_PID"
+  ACTIVE_PID="" ACTIVE_GROUP=""
 }
 
 cleanup() {
@@ -116,8 +156,6 @@ extract() { # extract SHA into $1, stamped past the build before it
 
 run_command() { # run $2 in $1, capture output in $3, label it $4
   dir="$1" command="$2" log="$3" label="$4"
-  timed_out="$log.timed-out"
-  rm -f "$timed_out"
 
   set -m
   (
@@ -130,26 +168,23 @@ run_command() { # run $2 in $1, capture output in $3, label it $4
   ACTIVE_GROUP=$ACTIVE_PID
   set +m
 
-  set -m
-  (
-    sleep "$TIMEOUT"
-    : > "$timed_out"
-    kill -TERM "-$ACTIVE_GROUP" 2>/dev/null || exit 0
-    sleep 1
+  status=0 ticks=0 max_ticks=$((10#$TIMEOUT * 10)) timed_out=0
+  while kill -0 "$ACTIVE_PID" 2>/dev/null; do
+    if [ "$ticks" -ge "$max_ticks" ]; then
+      timed_out=1
+      terminate_group TERM "$ACTIVE_GROUP" "$ACTIVE_PID"
+      break
+    fi
+    sleep 0.1
+    ticks=$((ticks + 1))
+  done
+  if [ "$timed_out" -eq 0 ]; then
+    wait "$ACTIVE_PID" || status=$?
     kill -KILL "-$ACTIVE_GROUP" 2>/dev/null || :
-  ) &
-  WATCHDOG_PID=$!
-  WATCHDOG_GROUP=$WATCHDOG_PID
-  set +m
+  fi
+  ACTIVE_PID="" ACTIVE_GROUP=""
 
-  status=0
-  wait "$ACTIVE_PID" || status=$?
-  terminate_group "$WATCHDOG_GROUP"
-  wait "$WATCHDOG_PID" 2>/dev/null || :
-  terminate_group "$ACTIVE_GROUP"
-  ACTIVE_PID="" ACTIVE_GROUP="" WATCHDOG_PID="" WATCHDOG_GROUP=""
-
-  if [ -f "$timed_out" ]; then
+  if [ "$timed_out" -eq 1 ]; then
     echo "$label timed out after ${TIMEOUT}s" >&2
     [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
     exit 2

--- a/.agents/skills/reviewer/scripts/mutation-stability
+++ b/.agents/skills/reviewer/scripts/mutation-stability
@@ -3,43 +3,48 @@
 #
 # Copies WORKTREE at SHA into a fresh temp dir (git archive; the shared tree
 # is never touched), runs TEST there as a control (must pass), applies MUTATE
-# (a shell command run inside the copy), reruns TEST (must now fail = mutant
-# killed), then runs TEST N more times on a clean copy at elevated
+# (a shell command run inside the copy), builds the mutant, reruns TEST (must
+# now fail = mutant killed), then runs TEST N more times on a clean copy at elevated
 # parallelism and prints the one summary line reviewers report:
 #
 #   mutation: killed 1/1; stability: N/N at T threads
 #
 # Exit: 0 killed and stable; 1 mutant survived or a stability run failed;
-# 2 control failure (test red before mutation, bad args, archive failure).
+# 2 instrument failure (control, empty selection, invalid mutant, bad input).
 set -euo pipefail
 
 usage() {
   cat <<'USAGE'
-usage: mutation-stability --worktree PATH --sha SHA --test CMD --mutate CMD
-                          [--stability N] [--threads T] [--keep]
+usage: mutation-stability --worktree PATH --sha SHA --test CMD --build CMD
+                          --mutate CMD [--stability N] [--threads T]
+                          [--timeout S] [--keep]
 
   --test CMD       run via bash -c inside the copy; exit 0 = pass
+  --build CMD      compile the mutated copy without running its tests
   --mutate CMD     run via bash -c inside the copy before the kill check
   --stability N    clean-copy repeat runs (default 10; minimum 1)
   --threads T      exported to TEST as THREADS and RUST_TEST_THREADS
                    (default 2x nproc); a runner that takes a flag must be
-                   given it in TEST, e.g. --test 'cargo test -- --test-threads $THREADS' 
+                   given it in TEST, e.g. --test 'cargo test -- --test-threads $THREADS'
+  --timeout S      deadline for each build or test command (default 300)
   --keep           print the temp dirs instead of deleting them
 USAGE
 }
 
-WORKTREE="" SHA="" TEST="" MUTATE="" N=10 THREADS="" KEEP=0
+WORKTREE="" SHA="" TEST="" BUILD="" MUTATE="" N=10 THREADS="" TIMEOUT=300 KEEP=0
 while [ $# -gt 0 ]; do
   case "$1" in
-    --worktree|--sha|--test|--mutate|--stability|--threads)
+    --worktree|--sha|--test|--build|--mutate|--stability|--threads|--timeout)
       [ $# -ge 2 ] || { echo "$1 needs a value" >&2; usage >&2; exit 2; }
       case "$1" in
         --worktree) WORKTREE="$2" ;;
         --sha) SHA="$2" ;;
         --test) TEST="$2" ;;
+        --build) BUILD="$2" ;;
         --mutate) MUTATE="$2" ;;
         --stability) N="$2" ;;
         --threads) THREADS="$2" ;;
+        --timeout) TIMEOUT="$2" ;;
       esac
       shift ;;
     --keep) KEEP=1 ;;
@@ -48,16 +53,42 @@ while [ $# -gt 0 ]; do
   esac
   shift
 done
-[ -n "$WORKTREE" ] && [ -n "$SHA" ] && [ -n "$TEST" ] && [ -n "$MUTATE" ] || {
+[ -n "$WORKTREE" ] && [ -n "$SHA" ] && [ -n "$TEST" ] && [ -n "$BUILD" ] && [ -n "$MUTATE" ] || {
   usage >&2; exit 2
 }
 case "$N" in *[!0-9]*|'') echo "--stability wants a number" >&2; exit 2 ;; esac
 [ "$N" -ge 1 ] || { echo "--stability 0 is zero samples — instrument failure by the reviewer contract" >&2; exit 2; }
 [ -n "$THREADS" ] || THREADS=$((2 * $(nproc 2>/dev/null || echo 4)))
 case "$THREADS" in *[!0-9]*|''|0) echo "--threads wants a positive integer" >&2; exit 2 ;; esac
+case "$TIMEOUT" in *[!0-9]*|''|0) echo "--timeout wants a positive integer" >&2; exit 2 ;; esac
 
 ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX") || exit 2
-[ "$KEEP" = 1 ] || trap 'rm -rf "$ROOT"' EXIT
+ACTIVE_PID="" ACTIVE_GROUP="" WATCHDOG_PID="" WATCHDOG_GROUP=""
+
+terminate_group() {
+  group="$1"
+  [ -n "$group" ] || return 0
+  kill -TERM "-$group" 2>/dev/null || :
+  kill -KILL "-$group" 2>/dev/null || :
+}
+
+cleanup_active() {
+  terminate_group "$WATCHDOG_GROUP"
+  [ -z "$WATCHDOG_PID" ] || wait "$WATCHDOG_PID" 2>/dev/null || :
+  terminate_group "$ACTIVE_GROUP"
+  [ -z "$ACTIVE_PID" ] || wait "$ACTIVE_PID" 2>/dev/null || :
+  ACTIVE_PID="" ACTIVE_GROUP="" WATCHDOG_PID="" WATCHDOG_GROUP=""
+}
+
+cleanup() {
+  trap - EXIT HUP INT TERM
+  cleanup_active
+  [ "$KEEP" = 1 ] || rm -rf "$ROOT"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 # A build cache keyed on mtimes rebuilds only for a source STRICTLY newer than
 # what it holds, and a filesystem or cache keeping whole seconds rounds two
@@ -75,14 +106,83 @@ extract() { # extract SHA into $1, stamped past the build before it
   git -C "$WORKTREE" archive "$SHA" | tar -x -m -C "$1"
 }
 
-run_test() { # run TEST in dir $1 with threads $2
-  (cd "$1" && THREADS="$2" RUST_TEST_THREADS="$2" bash -c "$TEST") >/dev/null 2>&1
+run_command() { # run $2 in $1, capture output in $3, label it $4
+  dir="$1" command="$2" log="$3" label="$4"
+  timed_out="$log.timed-out"
+  rm -f "$timed_out"
+
+  set -m
+  (
+    cd "$dir" || exit 2
+    RUST_TEST_THREADS="$THREADS"
+    export THREADS RUST_TEST_THREADS
+    exec bash -c "$command"
+  ) >"$log" 2>&1 &
+  ACTIVE_PID=$!
+  ACTIVE_GROUP=$ACTIVE_PID
+  set +m
+
+  set -m
+  (
+    sleep "$TIMEOUT"
+    : > "$timed_out"
+    kill -TERM "-$ACTIVE_GROUP" 2>/dev/null || exit 0
+    sleep 1
+    kill -KILL "-$ACTIVE_GROUP" 2>/dev/null || :
+  ) &
+  WATCHDOG_PID=$!
+  WATCHDOG_GROUP=$WATCHDOG_PID
+  set +m
+
+  status=0
+  wait "$ACTIVE_PID" || status=$?
+  terminate_group "$WATCHDOG_GROUP"
+  wait "$WATCHDOG_PID" 2>/dev/null || :
+  terminate_group "$ACTIVE_GROUP"
+  ACTIVE_PID="" ACTIVE_GROUP="" WATCHDOG_PID="" WATCHDOG_GROUP=""
+
+  if [ -f "$timed_out" ]; then
+    echo "$label timed out after ${TIMEOUT}s" >&2
+    return 124
+  fi
+  return "$status"
+}
+
+run_test() { # run TEST in $1 and capture output in $2
+  run_command "$1" "$TEST" "$2" "test"
+}
+
+cargo_selection_nonempty() {
+  awk '
+    /test result: ok\./ {
+      saw_summary = 1
+      for (i = 1; i < NF; i++) {
+        if ($i ~ /^[0-9]+$/ && $(i + 1) == "passed;" && $i > 0) {
+          saw_pass = 1
+        }
+      }
+    }
+    END {
+      if (!saw_summary) exit 2
+      if (!saw_pass) exit 1
+    }
+  ' "$1"
 }
 
 extract "$ROOT/mutant" || { echo "control: git archive failed for $SHA" >&2; exit 2; }
 
-if ! run_test "$ROOT/mutant" "$THREADS"; then
+control_status=0
+run_test "$ROOT/mutant" "$ROOT/control.log" || control_status=$?
+if [ "$control_status" -ne 0 ]; then
   echo "control: test fails before any mutation — not a usable instrument" >&2
+  [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
+  exit 2
+fi
+
+selection_status=0
+cargo_selection_nonempty "$ROOT/control.log" || selection_status=$?
+if [ "$selection_status" = 1 ]; then
+  echo "control: filter selected no test — not a usable instrument" >&2
   [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
   exit 2
 fi
@@ -90,14 +190,22 @@ fi
 outrank_last_build
 (cd "$ROOT/mutant" && bash -c "$MUTATE") || { echo "mutate command failed" >&2; exit 2; }
 
+build_status=0
+run_command "$ROOT/mutant" "$BUILD" "$ROOT/build.log" "mutant build" || build_status=$?
+if [ "$build_status" -ne 0 ]; then
+  echo "mutation: invalid-mutant; build failed after mutation" >&2
+  [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
+  exit 2
+fi
+
 KILLED=1
-if run_test "$ROOT/mutant" "$THREADS"; then KILLED=0; fi
+if run_test "$ROOT/mutant" "$ROOT/mutant.log"; then KILLED=0; fi
 
 PASSES=0
 extract "$ROOT/clean" || { echo "control: second archive failed" >&2; exit 2; }
 i=0
 while [ "$i" -lt "$N" ]; do
-  if run_test "$ROOT/clean" "$THREADS"; then PASSES=$((PASSES + 1)); fi
+  if run_test "$ROOT/clean" "$ROOT/stability-$i.log"; then PASSES=$((PASSES + 1)); fi
   i=$((i + 1))
 done
 

--- a/.agents/skills/reviewer/scripts/mutation-stability
+++ b/.agents/skills/reviewer/scripts/mutation-stability
@@ -10,7 +10,8 @@
 #   mutation: killed 1/1; stability: N/N at T threads
 #
 # Exit: 0 killed and stable; 1 mutant survived or a stability run failed;
-# 2 instrument failure (control, empty selection, invalid mutant, bad input).
+# 2 instrument failure (control, empty selection, invalid mutant, timed-out run,
+# bad input).
 set -euo pipefail
 
 usage() {
@@ -32,6 +33,7 @@ USAGE
 }
 
 WORKTREE="" SHA="" TEST="" BUILD="" MUTATE="" N=10 THREADS="" TIMEOUT=300 KEEP=0
+THREADS_SET=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --worktree|--sha|--test|--build|--mutate|--stability|--threads|--timeout)
@@ -43,7 +45,7 @@ while [ $# -gt 0 ]; do
         --build) BUILD="$2" ;;
         --mutate) MUTATE="$2" ;;
         --stability) N="$2" ;;
-        --threads) THREADS="$2" ;;
+        --threads) THREADS="$2"; THREADS_SET=1 ;;
         --timeout) TIMEOUT="$2" ;;
       esac
       shift ;;
@@ -56,15 +58,20 @@ done
 [ -n "$WORKTREE" ] && [ -n "$SHA" ] && [ -n "$TEST" ] && [ -n "$BUILD" ] && [ -n "$MUTATE" ] || {
   usage >&2; exit 2
 }
-case "$N" in *[!0-9]*|'') echo "--stability wants a number" >&2; exit 2 ;; esac
-[ "$N" -ge 1 ] || { echo "--stability 0 is zero samples — instrument failure by the reviewer contract" >&2; exit 2; }
-[ -n "$THREADS" ] || THREADS=$((2 * $(nproc 2>/dev/null || echo 4)))
-case "$THREADS" in *[!0-9]*|''|0) echo "--threads wants a positive integer" >&2; exit 2 ;; esac
-case "$TIMEOUT" in *[!0-9]*|''|0) echo "--timeout wants a positive integer" >&2; exit 2 ;; esac
+positive_integer() {
+  option="$1" value="$2"
+  case "$value" in
+    *[!0-9]*|''|0) echo "$option wants a positive integer" >&2; exit 2 ;;
+  esac
+}
+
+[ "$THREADS_SET" = 1 ] || THREADS=$((2 * $(nproc 2>/dev/null || echo 4)))
+positive_integer --stability "$N"
+positive_integer --threads "$THREADS"
+positive_integer --timeout "$TIMEOUT"
 
 ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX") || exit 2
 ACTIVE_PID="" ACTIVE_GROUP="" WATCHDOG_PID="" WATCHDOG_GROUP=""
-COMMAND_TIMED_OUT=0
 
 terminate_group() {
   group="$1"
@@ -110,7 +117,6 @@ extract() { # extract SHA into $1, stamped past the build before it
 run_command() { # run $2 in $1, capture output in $3, label it $4
   dir="$1" command="$2" log="$3" label="$4"
   timed_out="$log.timed-out"
-  COMMAND_TIMED_OUT=0
   rm -f "$timed_out"
 
   set -m
@@ -144,9 +150,9 @@ run_command() { # run $2 in $1, capture output in $3, label it $4
   ACTIVE_PID="" ACTIVE_GROUP="" WATCHDOG_PID="" WATCHDOG_GROUP=""
 
   if [ -f "$timed_out" ]; then
-    COMMAND_TIMED_OUT=1
     echo "$label timed out after ${TIMEOUT}s" >&2
-    return 124
+    [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
+    exit 2
   fi
   return "$status"
 }
@@ -211,11 +217,6 @@ fi
 
 mutant_status=0
 run_test "$ROOT/mutant" "$ROOT/mutant.log" || mutant_status=$?
-if [ "$COMMAND_TIMED_OUT" = 1 ]; then
-  echo "mutation: instrument-failure; mutant test timed out" >&2
-  [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
-  exit 2
-fi
 KILLED=1
 [ "$mutant_status" -ne 0 ] || KILLED=0
 

--- a/.agents/skills/reviewer/scripts/mutation-stability
+++ b/.agents/skills/reviewer/scripts/mutation-stability
@@ -128,6 +128,8 @@ cleanup_active() {
   ACTIVE_PID="" ACTIVE_GROUP=""
 }
 
+request_cancel() { CANCEL_RC="$1"; }
+
 cleanup() {
   trap - EXIT HUP INT TERM
   cleanup_active
@@ -157,6 +159,12 @@ extract() { # extract SHA into $1, stamped past the build before it
 run_command() { # run $2 in $1, capture output in $3, label it $4
   dir="$1" command="$2" log="$3" label="$4"
 
+  # A handler cannot stop the new group until the fork's pid is assigned.
+  # Record cancellation across that window, then exit once cleanup owns it.
+  CANCEL_RC=""
+  trap 'request_cancel 129' HUP
+  trap 'request_cancel 130' INT
+  trap 'request_cancel 143' TERM
   set -m
   (
     cd "$dir" || exit 2
@@ -167,6 +175,10 @@ run_command() { # run $2 in $1, capture output in $3, label it $4
   ACTIVE_PID=$!
   ACTIVE_GROUP=$ACTIVE_PID
   set +m
+  trap 'exit 129' HUP
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+  [ -z "$CANCEL_RC" ] || exit "$CANCEL_RC"
 
   status=0 ticks=0 max_ticks=$((10#$TIMEOUT * 10)) timed_out=0
   while kill -0 "$ACTIVE_PID" 2>/dev/null; do

--- a/.agents/skills/reviewer/scripts/mutation-stability
+++ b/.agents/skills/reviewer/scripts/mutation-stability
@@ -2,9 +2,9 @@
 # mutation-stability — prove a test can fail, then prove it is stable.
 #
 # Copies WORKTREE at SHA into a fresh temp dir (git archive; the shared tree
-# is never touched), runs TEST there as a control (must pass), applies MUTATE
-# (a shell command run inside the copy), builds the mutant, reruns TEST (must
-# now fail = mutant killed), then runs TEST N more times on a clean copy at elevated
+# is never touched), builds and tests the control copy, applies MUTATE (a shell
+# command run inside the copy), builds the mutant, reruns TEST (must now fail =
+# mutant killed), then runs TEST N more times on a clean copy at elevated
 # parallelism and prints the one summary line reviewers report:
 #
 #   mutation: killed 1/1; stability: N/N at T threads
@@ -20,7 +20,7 @@ usage: mutation-stability --worktree PATH --sha SHA --test CMD --build CMD
                           [--timeout S] [--keep]
 
   --test CMD       run via bash -c inside the copy; exit 0 = pass
-  --build CMD      compile the mutated copy without running its tests
+  --build CMD      compile the copy without running its tests
   --mutate CMD     run via bash -c inside the copy before the kill check
   --stability N    clean-copy repeat runs (default 10; minimum 1)
   --threads T      exported to TEST as THREADS and RUST_TEST_THREADS
@@ -64,6 +64,7 @@ case "$TIMEOUT" in *[!0-9]*|''|0) echo "--timeout wants a positive integer" >&2;
 
 ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX") || exit 2
 ACTIVE_PID="" ACTIVE_GROUP="" WATCHDOG_PID="" WATCHDOG_GROUP=""
+COMMAND_TIMED_OUT=0
 
 terminate_group() {
   group="$1"
@@ -109,6 +110,7 @@ extract() { # extract SHA into $1, stamped past the build before it
 run_command() { # run $2 in $1, capture output in $3, label it $4
   dir="$1" command="$2" log="$3" label="$4"
   timed_out="$log.timed-out"
+  COMMAND_TIMED_OUT=0
   rm -f "$timed_out"
 
   set -m
@@ -142,6 +144,7 @@ run_command() { # run $2 in $1, capture output in $3, label it $4
   ACTIVE_PID="" ACTIVE_GROUP="" WATCHDOG_PID="" WATCHDOG_GROUP=""
 
   if [ -f "$timed_out" ]; then
+    COMMAND_TIMED_OUT=1
     echo "$label timed out after ${TIMEOUT}s" >&2
     return 124
   fi
@@ -171,6 +174,14 @@ cargo_selection_nonempty() {
 
 extract "$ROOT/mutant" || { echo "control: git archive failed for $SHA" >&2; exit 2; }
 
+control_build_status=0
+run_command "$ROOT/mutant" "$BUILD" "$ROOT/control-build.log" "control build" || control_build_status=$?
+if [ "$control_build_status" -ne 0 ]; then
+  echo "control: build fails before any mutation — not a usable instrument" >&2
+  [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
+  exit 2
+fi
+
 control_status=0
 run_test "$ROOT/mutant" "$ROOT/control.log" || control_status=$?
 if [ "$control_status" -ne 0 ]; then
@@ -198,8 +209,15 @@ if [ "$build_status" -ne 0 ]; then
   exit 2
 fi
 
+mutant_status=0
+run_test "$ROOT/mutant" "$ROOT/mutant.log" || mutant_status=$?
+if [ "$COMMAND_TIMED_OUT" = 1 ]; then
+  echo "mutation: instrument-failure; mutant test timed out" >&2
+  [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
+  exit 2
+fi
 KILLED=1
-if run_test "$ROOT/mutant" "$ROOT/mutant.log"; then KILLED=0; fi
+[ "$mutant_status" -ne 0 ] || KILLED=0
 
 PASSES=0
 extract "$ROOT/clean" || { echo "control: second archive failed" >&2; exit 2; }

--- a/.agents/skills/reviewer/tests/mutation-stability.test.sh
+++ b/.agents/skills/reviewer/tests/mutation-stability.test.sh
@@ -17,6 +17,11 @@ cat > "$REPO/check.sh" <<'T'
 . ./lib.sh
 [ "$(add 2 3)" = 5 ]
 T
+cat > "$REPO/hang.sh" <<'T'
+echo $$ > "$HANG_PID_FILE"
+trap '' TERM
+while :; do :; done
+T
 git -C "$REPO" add -A
 git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm x
 SHA=$(git -C "$REPO" rev-parse HEAD)
@@ -45,19 +50,52 @@ if [ "$rc" = 2 ]; then ok "an empty Cargo selection exits 2"; else bad "an empty
 case "$out" in *"filter selected no test"*) ok "an empty selection has its own outcome";; *) bad "an empty selection has its own outcome" "$out";; esac
 case "$out" in *"survived"*) bad "an empty selection is never a surviving mutant" "$out";; *) ok "an empty selection is never a surviving mutant";; esac
 
+rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
+      --test 'grep -q "+" lib.sh && printf "test result: ok. 1 passed; 0 failed; 0 ignored\n"' \
+      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+      --stability 1 --threads 2) || rc=$?
+if [ "$rc" = 0 ]; then ok "a non-empty Cargo selection reaches the verdict"; else bad "a non-empty Cargo selection reaches the verdict" "rc=$rc out=$out"; fi
+case "$out" in "mutation: killed 1/1; stability: 1/1 at 2 threads") ok "a passing Cargo summary is accepted";; *) bad "a passing Cargo summary is accepted" "$out";; esac
+
+rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
+      --build 'false' --mutate 'true' --stability 1 2>&1) || rc=$?
+if [ "$rc" = 2 ]; then ok "a broken control build exits 2"; else bad "a broken control build exits 2" "rc=$rc out=$out"; fi
+case "$out" in *"control: build fails before any mutation"*) ok "a broken build is blamed on the control";; *) bad "a broken build is blamed on the control" "$out";; esac
+case "$out" in *"invalid-mutant"*) bad "a broken control build is not an invalid mutant" "$out";; *) ok "a broken control build is not an invalid mutant";; esac
+
 rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
       --build 'test -f lib.sh' --mutate 'rm lib.sh' --stability 1 2>&1) || rc=$?
 if [ "$rc" = 2 ]; then ok "a non-compiling mutant exits 2"; else bad "a non-compiling mutant exits 2" "rc=$rc out=$out"; fi
 case "$out" in *"invalid-mutant"*) ok "a build failure reports invalid-mutant";; *) bad "a build failure reports invalid-mutant" "$out";; esac
 case "$out" in *"killed"*) bad "a non-compiling mutant is never killed" "$out";; *) ok "a non-compiling mutant is never killed";; esac
 
-export TIMEOUT_PID_FILE="$TMP/timeout-child.pid"
+rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
+      --mutate 'true' --stability 1 2>&1) || rc=$?
+if [ "$rc" = 2 ]; then ok "omitting --build exits 2"; else bad "omitting --build exits 2" "rc=$rc out=$out"; fi
+
+export HANG_PID_FILE="$TMP/mutant-timeout-child.pid"
 rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
-      --test 'echo $$ > "$TIMEOUT_PID_FILE"; trap "" TERM; while :; do :; done' \
+      --test 'grep -q "+" lib.sh || { bash hang.sh & wait; }' \
+      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+      --stability 1 --timeout 1 2>&1) || rc=$?
+if [ "$rc" = 2 ]; then ok "a timed-out mutant exits 2"; else bad "a timed-out mutant exits 2" "rc=$rc out=$out"; fi
+case "$out" in *"mutant test timed out"*) ok "a timed-out mutant is an instrument failure";; *) bad "a timed-out mutant is an instrument failure" "$out";; esac
+case "$out" in *"mutation: killed"*) bad "a timed-out mutant is never killed" "$out";; *) ok "a timed-out mutant is never killed";; esac
+mutant_timeout_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
+if [ -n "$mutant_timeout_child" ] && ! kill -0 "$mutant_timeout_child" 2>/dev/null; then
+  ok "the timed-out mutant process group is reaped"
+else
+  bad "the timed-out mutant process group is reaped" "pid=${mutant_timeout_child:-missing}"
+  [ -z "$mutant_timeout_child" ] || kill -KILL "$mutant_timeout_child" 2>/dev/null || true
+fi
+
+export HANG_PID_FILE="$TMP/timeout-child.pid"
+rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
+      --test 'bash hang.sh & wait' \
       --build 'true' --mutate 'true' --stability 1 --timeout 1 2>&1) || rc=$?
 if [ "$rc" = 2 ]; then ok "a hanging control times out"; else bad "a hanging control times out" "rc=$rc out=$out"; fi
 case "$out" in *"timed out after 1s"*) ok "the timeout is reported";; *) bad "the timeout is reported" "$out";; esac
-timeout_child=$(cat "$TIMEOUT_PID_FILE" 2>/dev/null || true)
+timeout_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
 if [ -n "$timeout_child" ] && ! kill -0 "$timeout_child" 2>/dev/null; then
   ok "the timed-out process is reaped"
 else
@@ -65,14 +103,14 @@ else
   [ -z "$timeout_child" ] || kill -KILL "$timeout_child" 2>/dev/null || true
 fi
 
-export EXIT_PID_FILE="$TMP/exit-child.pid"
+export HANG_PID_FILE="$TMP/exit-child.pid"
 "$MS" --worktree "$REPO" --sha "$SHA" \
-  --test 'echo $$ > "$EXIT_PID_FILE"; trap "" TERM; while :; do :; done' \
+  --test 'bash hang.sh & wait' \
   --build 'true' --mutate 'true' --stability 1 --timeout 30 >/dev/null 2>&1 &
 ms_pid=$!
 i=0
-while [ ! -s "$EXIT_PID_FILE" ] && [ "$i" -lt 50 ]; do sleep 0.1; i=$((i + 1)); done
-exit_child=$(cat "$EXIT_PID_FILE" 2>/dev/null || true)
+while [ ! -s "$HANG_PID_FILE" ] && [ "$i" -lt 50 ]; do sleep 0.1; i=$((i + 1)); done
+exit_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
 kill -TERM "$ms_pid" 2>/dev/null || true
 wait "$ms_pid" 2>/dev/null || true
 if [ -n "$exit_child" ] && ! kill -0 "$exit_child" 2>/dev/null; then

--- a/.agents/skills/reviewer/tests/mutation-stability.test.sh
+++ b/.agents/skills/reviewer/tests/mutation-stability.test.sh
@@ -3,9 +3,22 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MS="$SCRIPT_DIR/../scripts/mutation-stability"
-PASS=0 FAIL=0
+PASS=0 FAIL=0 rc=0 out=""
 ok()  { PASS=$((PASS+1)); echo "  ok    $1"; }
 bad() { FAIL=$((FAIL+1)); echo "  FAIL  $1"; echo "        $2"; }
+run_ms() {
+  sha="$1"; shift; rc=0
+  out=$("$MS" --worktree "$REPO" --sha "$sha" "$@" 2>&1) || rc=$?
+}
+is_rc() {
+  if [ "$rc" = "$1" ]; then ok "$2"; else bad "$2" "rc=$rc out=$out"; fi
+}
+has() {
+  case "$out" in *"$1"*) ok "$2";; *) bad "$2" "$out";; esac
+}
+lacks() {
+  case "$out" in *"$1"*) bad "$2" "$out";; *) ok "$2";; esac
+}
 stopped() {
   pid="$1" attempts=0
   while kill -0 "$pid" 2>/dev/null && [ "$attempts" -lt 20 ]; do
@@ -53,6 +66,40 @@ git -C "$REPO" add -A
 git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm x
 SHA=$(git -C "$REPO" rev-parse HEAD)
 
+run_ms "$SHA" --test 'bash check.sh' --build 'true' \
+  --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+  --stability 2 --threads 2
+is_rc 0 "killed mutant exits 0"
+if [ "$out" = "mutation: killed 1/1; stability: 2/2 at 2 threads" ]; then ok "summary line is the exact format"; else bad "summary line is the exact format" "$out"; fi
+
+run_ms "$SHA" --test 'bash check.sh' --build 'true' \
+  --mutate 'echo "# decoy: still says +" >> lib.sh' --stability 1
+is_rc 1 "surviving decoy mutant exits 1"
+has "mutation: killed 0/1;" "survivor reported as killed 0/1"
+
+run_ms "$SHA" --test 'false' --build 'true' --mutate 'true' --stability 1
+is_rc 2 "red-before-mutation control exits 2"
+has "before any mutation" "control names the instrument failure"
+
+run_ms "$SHA" \
+  --test 'printf "test result: ok. 0 passed; 0 failed; 0 ignored\n"' \
+  --build 'true' --mutate 'true' --stability 1
+is_rc 2 "an empty Cargo selection exits 2"
+has "filter selected no test" "an empty selection has its own outcome"
+lacks "survived" "an empty selection is never a surviving mutant"
+
+run_ms "$SHA" --test 'true' --build 'test -f lib.sh' \
+  --mutate 'rm lib.sh' --stability 1
+is_rc 2 "a non-compiling mutant exits 2"
+has "invalid-mutant" "a build failure reports invalid-mutant"
+lacks "killed" "a non-compiling mutant is never killed"
+
+# One invalid input proves the shared positive-integer validator.
+run_ms "$SHA" --test 'true' --build 'true' --mutate 'true' --timeout 0
+is_rc 2 "the numeric validator rejects zero"
+
+# KEN-999: one timeout control also checks adoption under a non-reaping PID 1.
+export HANG_PID_FILE="$TMP/timeout-child.pid"
 if command -v unshare >/dev/null 2>&1 \
   && command -v python3 >/dev/null 2>&1 \
   && unshare --user --map-root-user --pid --fork --mount-proc true 2>/dev/null; then
@@ -61,7 +108,6 @@ if command -v unshare >/dev/null 2>&1 \
     python3 -c '
 import glob, os, subprocess, sys, time
 env = os.environ.copy()
-env["HANG_PID_FILE"] = sys.argv[4]
 run = subprocess.run([
     sys.argv[1], "--worktree", sys.argv[2], "--sha", sys.argv[3],
     "--test", "true", "--build", "bash hang.sh & wait",
@@ -78,179 +124,45 @@ for path in glob.glob("/proc/[0-9]*/stat"):
         pass
 if run.returncode != 2:
     print("timeout exit: expected 2, got %s" % run.returncode)
+if "timed out after 1s" not in run.stderr:
+    print("missing timeout diagnostic: %s" % run.stderr)
 if zombies:
     print("non-reaping PID 1 adopted zombies: %r" % (zombies,))
-sys.exit(0 if run.returncode == 2 and not zombies else 1)
-' "$MS" "$REPO" "$SHA" "$TMP/nonreaping-timeout-child.pid" 2>&1) || rc=$?
-  if [ "$rc" = 0 ]; then
-    ok "a non-reaping PID 1 adopts no timed-out descendants"
+sys.exit(0 if run.returncode == 2 and "timed out after 1s" in run.stderr and not zombies else 1)
+' "$MS" "$REPO" "$SHA" 2>&1) || rc=$?
+  is_rc 0 "a timed-out child leaves no zombies under non-reaping PID 1"
+else
+  run_ms "$SHA" --test 'true' --build 'bash hang.sh & wait' \
+    --mutate 'true' --stability 1 --timeout 1
+  is_rc 2 "a hanging child times out"
+  has "timed out after 1s" "the timeout is reported"
+  child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
+  if [ -n "$child" ] && stopped "$child"; then
+    ok "the timed-out child is reaped"
   else
-    bad "a non-reaping PID 1 adopts no timed-out descendants" "$out"
+    bad "the timed-out child is reaped" "pid=${child:-missing}"
+    [ -z "$child" ] || kill -KILL "$child" 2>/dev/null || true
   fi
 fi
 
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'bash check.sh' \
-      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-      --stability 2 --threads 2) || rc=$?
-if [ "$rc" = 0 ]; then ok "killed mutant exits 0"; else bad "killed mutant exits 0" "rc=$rc out=$out"; fi
-case "$out" in "mutation: killed 1/1; stability: 2/2 at 2 threads") ok "summary line is the exact format";; *) bad "summary line is the exact format" "$out";; esac
-
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'bash check.sh' \
-      --build 'true' --mutate 'echo "# decoy: still says +" >> lib.sh' \
-      --stability 1) || rc=$?
-if [ "$rc" = 1 ]; then ok "surviving decoy mutant exits 1"; else bad "surviving decoy mutant exits 1" "rc=$rc out=$out"; fi
-case "$out" in "mutation: killed 0/1;"*) ok "survivor reported as killed 0/1";; *) bad "survivor reported as killed 0/1" "$out";; esac
-
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'false' \
-      --build 'true' --mutate 'true' --stability 1 2>&1) || rc=$?
-if [ "$rc" = 2 ]; then ok "red-before-mutation control exits 2"; else bad "red-before-mutation control exits 2" "rc=$rc"; fi
-case "$out" in *"before any mutation"*) ok "control names the instrument failure";; *) bad "control names the instrument failure" "$out";; esac
-
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
-      --test 'printf "test result: ok. 0 passed; 0 failed; 0 ignored\n"' \
-      --build 'true' --mutate 'true' --stability 1 2>&1) || rc=$?
-if [ "$rc" = 2 ]; then ok "an empty Cargo selection exits 2"; else bad "an empty Cargo selection exits 2" "rc=$rc out=$out"; fi
-case "$out" in *"filter selected no test"*) ok "an empty selection has its own outcome";; *) bad "an empty selection has its own outcome" "$out";; esac
-case "$out" in *"survived"*) bad "an empty selection is never a surviving mutant" "$out";; *) ok "an empty selection is never a surviving mutant";; esac
-
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
-      --test 'grep -q "+" lib.sh && printf "test result: ok. 1 passed; 0 failed; 0 ignored\n"' \
-      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-      --stability 1 --threads 2) || rc=$?
-if [ "$rc" = 0 ]; then ok "a non-empty Cargo selection reaches the verdict"; else bad "a non-empty Cargo selection reaches the verdict" "rc=$rc out=$out"; fi
-case "$out" in "mutation: killed 1/1; stability: 1/1 at 2 threads") ok "a passing Cargo summary is accepted";; *) bad "a passing Cargo summary is accepted" "$out";; esac
-
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
-      --build 'false' --mutate 'true' --stability 1 2>&1) || rc=$?
-if [ "$rc" = 2 ]; then ok "a broken control build exits 2"; else bad "a broken control build exits 2" "rc=$rc out=$out"; fi
-case "$out" in *"control: build fails before any mutation"*) ok "a broken build is blamed on the control";; *) bad "a broken build is blamed on the control" "$out";; esac
-case "$out" in *"invalid-mutant"*) bad "a broken control build is not an invalid mutant" "$out";; *) ok "a broken control build is not an invalid mutant";; esac
-
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
-      --build 'test -f lib.sh' --mutate 'rm lib.sh' --stability 1 2>&1) || rc=$?
-if [ "$rc" = 2 ]; then ok "a non-compiling mutant exits 2"; else bad "a non-compiling mutant exits 2" "rc=$rc out=$out"; fi
-case "$out" in *"invalid-mutant"*) ok "a build failure reports invalid-mutant";; *) bad "a build failure reports invalid-mutant" "$out";; esac
-case "$out" in *"killed"*) bad "a non-compiling mutant is never killed" "$out";; *) ok "a non-compiling mutant is never killed";; esac
-
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
-      --mutate 'true' --stability 1 2>&1) || rc=$?
-if [ "$rc" = 2 ]; then ok "omitting --build exits 2"; else bad "omitting --build exits 2" "rc=$rc out=$out"; fi
-
-for option in --stability --threads --timeout; do
-  for value in 0 nope ""; do
-    rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
-          --build 'true' --mutate 'true' "$option" "$value" 2>&1) || rc=$?
-    if [ "$rc" = 2 ]; then
-      ok "$option rejects '${value:-empty}'"
-    else
-      bad "$option rejects '${value:-empty}'" "rc=$rc out=$out"
-    fi
-  done
-done
-
-export HANG_PID_FILE="$TMP/control-build-timeout-child.pid"
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
-      --build 'bash hang.sh & wait' --mutate 'true' --stability 1 \
-      --timeout 1 2>&1) || rc=$?
-if [ "$rc" = 2 ]; then ok "a timed-out control build exits 2"; else bad "a timed-out control build exits 2" "rc=$rc out=$out"; fi
-case "$out" in *"control build timed out after 1s"*) ok "the control-build timeout is reported";; *) bad "the control-build timeout is reported" "$out";; esac
-case "$out" in *"build fails"*) bad "a control-build timeout is not a build failure" "$out";; *) ok "a control-build timeout is not a build failure";; esac
-control_build_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
-if [ -n "$control_build_child" ] && stopped "$control_build_child"; then
-  ok "the timed-out control build is reaped"
-else
-  bad "the timed-out control build is reaped" "pid=${control_build_child:-missing}"
-  [ -z "$control_build_child" ] || kill -KILL "$control_build_child" 2>/dev/null || true
-fi
-
-export HANG_PID_FILE="$TMP/mutant-build-timeout-child.pid"
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
-      --build 'grep -q "+" lib.sh || { bash hang.sh & wait; }' \
-      --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-      --stability 1 --timeout 1 2>&1) || rc=$?
-if [ "$rc" = 2 ]; then ok "a timed-out mutant build exits 2"; else bad "a timed-out mutant build exits 2" "rc=$rc out=$out"; fi
-case "$out" in *"mutant build timed out after 1s"*) ok "the mutant-build timeout is reported";; *) bad "the mutant-build timeout is reported" "$out";; esac
-case "$out" in *"invalid-mutant"*) bad "a mutant-build timeout is not an invalid mutant" "$out";; *) ok "a mutant-build timeout is not an invalid mutant";; esac
-mutant_build_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
-if [ -n "$mutant_build_child" ] && stopped "$mutant_build_child"; then
-  ok "the timed-out mutant build is reaped"
-else
-  bad "the timed-out mutant build is reaped" "pid=${mutant_build_child:-missing}"
-  [ -z "$mutant_build_child" ] || kill -KILL "$mutant_build_child" 2>/dev/null || true
-fi
-
-export HANG_PID_FILE="$TMP/mutant-timeout-child.pid"
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
-      --test 'grep -q "+" lib.sh || { bash hang.sh & wait; }' \
-      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-      --stability 1 --timeout 1 2>&1) || rc=$?
-if [ "$rc" = 2 ]; then ok "a timed-out mutant exits 2"; else bad "a timed-out mutant exits 2" "rc=$rc out=$out"; fi
-case "$out" in *"test timed out after 1s"*) ok "a timed-out mutant is an instrument failure";; *) bad "a timed-out mutant is an instrument failure" "$out";; esac
-case "$out" in *"mutation: killed"*) bad "a timed-out mutant is never killed" "$out";; *) ok "a timed-out mutant is never killed";; esac
-mutant_timeout_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
-if [ -n "$mutant_timeout_child" ] && stopped "$mutant_timeout_child"; then
-  ok "the timed-out mutant process group is reaped"
-else
-  bad "the timed-out mutant process group is reaped" "pid=${mutant_timeout_child:-missing}"
-  [ -z "$mutant_timeout_child" ] || kill -KILL "$mutant_timeout_child" 2>/dev/null || true
-fi
-
-export HANG_PID_FILE="$TMP/timeout-child.pid"
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
-      --test 'bash hang.sh & wait' \
-      --build 'true' --mutate 'true' --stability 1 --timeout 1 2>&1) || rc=$?
-if [ "$rc" = 2 ]; then ok "a hanging control times out"; else bad "a hanging control times out" "rc=$rc out=$out"; fi
-case "$out" in *"timed out after 1s"*) ok "the timeout is reported";; *) bad "the timeout is reported" "$out";; esac
-timeout_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
-if [ -n "$timeout_child" ] && stopped "$timeout_child"; then
-  ok "the timed-out process is reaped"
-else
-  bad "the timed-out process is reaped" "pid=${timeout_child:-missing}"
-  [ -z "$timeout_child" ] || kill -KILL "$timeout_child" 2>/dev/null || true
-fi
-
-export HANG_PID_FILE="$TMP/exit-child.pid"
-"$MS" --worktree "$REPO" --sha "$SHA" \
-  --test 'bash hang.sh & wait' \
-  --build 'true' --mutate 'true' --stability 1 --timeout 30 >/dev/null 2>&1 &
-ms_pid=$!
-i=0
-while [ ! -s "$HANG_PID_FILE" ] && [ "$i" -lt 50 ]; do sleep 0.1; i=$((i + 1)); done
-exit_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
-kill -TERM "$ms_pid" 2>/dev/null || true
-wait "$ms_pid" 2>/dev/null || true
-if [ -n "$exit_child" ] && stopped "$exit_child"; then
-  ok "exit cleanup reaps the active test process"
-else
-  bad "exit cleanup reaps the active test process" "pid=${exit_child:-missing}"
-  [ -z "$exit_child" ] || kill -KILL "$exit_child" 2>/dev/null || true
-fi
-
+# One signal-gap control covers cancellation before process ownership lands.
 export HANG_PID_FILE="$TMP/launch-window-child.pid"
 export LAUNCH_WINDOW_SIGNALLED="$TMP/launch-window-signalled"
 rc=0
 BASH_ENV="$TMP/launch-window.bashenv" "$MS" --worktree "$REPO" --sha "$SHA" \
   --test 'true' --build 'bash hang.sh & wait' --mutate 'true' \
   --stability 1 --timeout 2 >/dev/null 2>&1 || rc=$?
-if [ "$rc" = 143 ]; then
-  ok "a launch-window TERM exits 143"
+child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
+if [ "$rc" = 143 ] && [ -f "$LAUNCH_WINDOW_SIGNALLED" ] \
+  && [ -n "$child" ] && stopped "$child"; then
+  ok "launch-window cancellation records ownership and reaps the command"
 else
-  bad "a launch-window TERM exits 143" "rc=$rc"
-fi
-if [ -f "$LAUNCH_WINDOW_SIGNALLED" ]; then
-  ok "the fixture signals before process ownership is recorded"
-else
-  bad "the fixture signals before process ownership is recorded" "DEBUG trap did not fire"
-fi
-launch_window_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
-if [ -n "$launch_window_child" ] && stopped "$launch_window_child"; then
-  ok "launch-window cancellation reaps the command process"
-else
-  bad "launch-window cancellation reaps the command process" "pid=${launch_window_child:-missing}"
-  [ -z "$launch_window_child" ] || kill -KILL "$launch_window_child" 2>/dev/null || true
+  bad "launch-window cancellation records ownership and reaps the command" \
+    "rc=$rc signal_file=$LAUNCH_WINDOW_SIGNALLED pid=${child:-missing}"
+  [ -z "$child" ] || kill -KILL "$child" 2>/dev/null || true
 fi
 
-# flaky test: passes only on its first run in a copy (state file marks reruns)
+# A rerun that fails only after the first clean pass reports partial stability.
 cat > "$REPO/check.sh" <<'T'
 . ./lib.sh
 [ "$(add 2 3)" = 5 ] || exit 1
@@ -260,37 +172,13 @@ T
 git -C "$REPO" add -A
 git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm flaky
 SHA2=$(git -C "$REPO" rev-parse HEAD)
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA2" --test 'bash check.sh' \
-      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-      --stability 3 --threads 2) || rc=$?
-if [ "$rc" = 1 ]; then ok "stability failure exits 1 even with the mutant killed"; else bad "stability failure exits 1 even with the mutant killed" "rc=$rc out=$out"; fi
-case "$out" in *"stability: 1/3 at 2 threads") ok "partial stability is reported as Y/N";; *) bad "partial stability is reported as Y/N" "$out";; esac
+run_ms "$SHA2" --test 'bash check.sh' --build 'true' \
+  --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+  --stability 3 --threads 2
+is_rc 1 "stability failure exits 1 even with the mutant killed"
+has "stability: 1/3 at 2 threads" "partial stability is reported as Y/N"
 
-export HANG_PID_FILE="$TMP/stability-timeout-child.pid"
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
-      --test 'if grep -q "-" lib.sh; then exit 1; fi; if [ -f .ran ]; then bash hang.sh & wait; fi; touch .ran' \
-      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-      --stability 2 --timeout 1 2>&1) || rc=$?
-if [ "$rc" = 2 ]; then ok "a timed-out stability run exits 2"; else bad "a timed-out stability run exits 2" "rc=$rc out=$out"; fi
-case "$out" in *"test timed out after 1s"*) ok "the stability timeout is an instrument failure";; *) bad "the stability timeout is an instrument failure" "$out";; esac
-case "$out" in *"mutation: killed"*) bad "a stability timeout prints no trusted summary" "$out";; *) ok "a stability timeout prints no trusted summary";; esac
-stability_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
-if [ -n "$stability_child" ] && stopped "$stability_child"; then
-  ok "the timed-out stability run is reaped"
-else
-  bad "the timed-out stability run is reaped" "pid=${stability_child:-missing}"
-  [ -z "$stability_child" ] || kill -KILL "$stability_child" 2>/dev/null || true
-fi
-
-rc=0; "$MS" --worktree "$REPO" --sha "$SHA" --test 'true' --build 'true' --mutate 2>/dev/null || rc=$?
-if [ "$rc" = 2 ]; then ok "a value-less option exits 2"; else bad "a value-less option exits 2" "rc=$rc"; fi
-
-# A build cache the caller shares across both copies must answer neither run
-# with the other's artifact. check.sh is that cache, keyed the way cargo's
-# target dir is: it rebuilds for a source strictly newer than what it holds,
-# in whole seconds, the coarsest granularity a filesystem or cache keeps. Both
-# ways it can be wrong are here — the mutant reusing the control's build and
-# surviving, the clean copy reusing the mutant's and failing.
+# Shared whole-second caches must rebuild for mutant and clean copies.
 export CACHE="$TMP/build-cache"
 mkdir -p "$CACHE"
 cat > "$REPO/check.sh" <<'T'
@@ -303,26 +191,23 @@ T
 git -C "$REPO" add -A
 git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm cached
 SHA3=$(git -C "$REPO" rev-parse HEAD)
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA3" --test 'bash check.sh' \
-      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-      --stability 3 --threads 2) || rc=$?
-if [ "$rc" = 0 ]; then ok "a shared whole-second build cache reaches the right verdict"; else bad "a shared whole-second build cache reaches the right verdict" "rc=$rc out=$out"; fi
-case "$out" in "mutation: killed 1/1"*) ok "the mutant build rebuilds instead of reusing the control";; *) bad "the mutant build rebuilds instead of reusing the control" "$out";; esac
-case "$out" in *"stability: 3/3 at 2 threads") ok "the clean copy rebuilds instead of reusing the mutant";; *) bad "the clean copy rebuilds instead of reusing the mutant" "$out";; esac
+run_ms "$SHA3" --test 'bash check.sh' --build 'true' \
+  --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+  --stability 3 --threads 2
+is_rc 0 "a shared whole-second build cache reaches the right verdict"
+has "mutation: killed 1/1" "the mutant build rebuilds instead of reusing the control"
+has "stability: 3/3 at 2 threads" "the clean copy rebuilds instead of reusing the mutant"
 
-# A filesystem or cache that keeps whole seconds rounds an extraction and the
-# build before it to the same second, and a cache rebuilds on a strictly newer
-# source, not an equal one. Each copy is stamped a full second past the last.
 kept=$("$MS" --worktree "$REPO" --sha "$SHA3" --test 'bash check.sh' \
-      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-      --stability 1 --threads 2 --keep 2>&1 >/dev/null || true)
+  --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+  --stability 1 --threads 2 --keep 2>&1 >/dev/null || true)
 root=$(printf '%s\n' "$kept" | sed -n 's/^kept: //p')
 if [ -d "$root/clean" ]; then
   gap=$(( $(stat -c %Y "$root/clean/check.sh") - $(stat -c %Y "$root/mutant/check.sh") ))
   rm -rf "$root"
-  if [ "$gap" -ge 1 ]; then ok "each copy is stamped a whole second past the one before"; else bad "each copy is stamped a whole second past the one before" "gap=${gap}s"; fi
+  if [ "$gap" -ge 1 ]; then ok "each copy outranks the one before"; else bad "each copy outranks the one before" "gap=${gap}s"; fi
 else
-  bad "each copy is stamped a whole second past the one before" "--keep printed no temp dir: $kept"
+  bad "each copy outranks the one before" "--keep printed no temp dir: $kept"
 fi
 
 echo "$PASS passed, $FAIL failed"

--- a/.agents/skills/reviewer/tests/mutation-stability.test.sh
+++ b/.agents/skills/reviewer/tests/mutation-stability.test.sh
@@ -30,6 +30,25 @@ echo $$ > "$HANG_PID_FILE"
 trap '' TERM
 while :; do :; done
 T
+cat > "$TMP/launch-window.bashenv" <<'T'
+case "$0" in
+  *mutation-stability)
+    set -T
+    trap '
+      if [ "$BASH_COMMAND" = "ACTIVE_PID=\$!" ]; then
+        trap - DEBUG
+        tries=0
+        while [ ! -s "$HANG_PID_FILE" ] && [ "$tries" -lt 100 ]; do
+          sleep 0.01
+          tries=$((tries + 1))
+        done
+        : > "$LAUNCH_WINDOW_SIGNALLED"
+        kill -TERM "$$"
+      fi
+    ' DEBUG
+    ;;
+esac
+T
 git -C "$REPO" add -A
 git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm x
 SHA=$(git -C "$REPO" rev-parse HEAD)
@@ -205,6 +224,30 @@ if [ -n "$exit_child" ] && stopped "$exit_child"; then
 else
   bad "exit cleanup reaps the active test process" "pid=${exit_child:-missing}"
   [ -z "$exit_child" ] || kill -KILL "$exit_child" 2>/dev/null || true
+fi
+
+export HANG_PID_FILE="$TMP/launch-window-child.pid"
+export LAUNCH_WINDOW_SIGNALLED="$TMP/launch-window-signalled"
+rc=0
+BASH_ENV="$TMP/launch-window.bashenv" "$MS" --worktree "$REPO" --sha "$SHA" \
+  --test 'true' --build 'bash hang.sh & wait' --mutate 'true' \
+  --stability 1 --timeout 2 >/dev/null 2>&1 || rc=$?
+if [ "$rc" = 143 ]; then
+  ok "a launch-window TERM exits 143"
+else
+  bad "a launch-window TERM exits 143" "rc=$rc"
+fi
+if [ -f "$LAUNCH_WINDOW_SIGNALLED" ]; then
+  ok "the fixture signals before process ownership is recorded"
+else
+  bad "the fixture signals before process ownership is recorded" "DEBUG trap did not fire"
+fi
+launch_window_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
+if [ -n "$launch_window_child" ] && stopped "$launch_window_child"; then
+  ok "launch-window cancellation reaps the command process"
+else
+  bad "launch-window cancellation reaps the command process" "pid=${launch_window_child:-missing}"
+  [ -z "$launch_window_child" ] || kill -KILL "$launch_window_child" 2>/dev/null || true
 fi
 
 # flaky test: passes only on its first run in a copy (state file marks reruns)

--- a/.agents/skills/reviewer/tests/mutation-stability.test.sh
+++ b/.agents/skills/reviewer/tests/mutation-stability.test.sh
@@ -6,6 +6,14 @@ MS="$SCRIPT_DIR/../scripts/mutation-stability"
 PASS=0 FAIL=0
 ok()  { PASS=$((PASS+1)); echo "  ok    $1"; }
 bad() { FAIL=$((FAIL+1)); echo "  FAIL  $1"; echo "        $2"; }
+stopped() {
+  pid="$1" attempts=0
+  while kill -0 "$pid" 2>/dev/null && [ "$attempts" -lt 20 ]; do
+    sleep 0.05
+    attempts=$((attempts + 1))
+  done
+  ! kill -0 "$pid" 2>/dev/null
+}
 
 TMP=$(mktemp -d "${TMPDIR:-/tmp}/ms-test.XXXXXX") || exit 2
 trap 'rm -rf "$TMP"' EXIT
@@ -73,16 +81,59 @@ rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
       --mutate 'true' --stability 1 2>&1) || rc=$?
 if [ "$rc" = 2 ]; then ok "omitting --build exits 2"; else bad "omitting --build exits 2" "rc=$rc out=$out"; fi
 
+for option in --stability --threads --timeout; do
+  for value in 0 nope ""; do
+    rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
+          --build 'true' --mutate 'true' "$option" "$value" 2>&1) || rc=$?
+    if [ "$rc" = 2 ]; then
+      ok "$option rejects '${value:-empty}'"
+    else
+      bad "$option rejects '${value:-empty}'" "rc=$rc out=$out"
+    fi
+  done
+done
+
+export HANG_PID_FILE="$TMP/control-build-timeout-child.pid"
+rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
+      --build 'bash hang.sh & wait' --mutate 'true' --stability 1 \
+      --timeout 1 2>&1) || rc=$?
+if [ "$rc" = 2 ]; then ok "a timed-out control build exits 2"; else bad "a timed-out control build exits 2" "rc=$rc out=$out"; fi
+case "$out" in *"control build timed out after 1s"*) ok "the control-build timeout is reported";; *) bad "the control-build timeout is reported" "$out";; esac
+case "$out" in *"build fails"*) bad "a control-build timeout is not a build failure" "$out";; *) ok "a control-build timeout is not a build failure";; esac
+control_build_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
+if [ -n "$control_build_child" ] && stopped "$control_build_child"; then
+  ok "the timed-out control build is reaped"
+else
+  bad "the timed-out control build is reaped" "pid=${control_build_child:-missing}"
+  [ -z "$control_build_child" ] || kill -KILL "$control_build_child" 2>/dev/null || true
+fi
+
+export HANG_PID_FILE="$TMP/mutant-build-timeout-child.pid"
+rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
+      --build 'grep -q "+" lib.sh || { bash hang.sh & wait; }' \
+      --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+      --stability 1 --timeout 1 2>&1) || rc=$?
+if [ "$rc" = 2 ]; then ok "a timed-out mutant build exits 2"; else bad "a timed-out mutant build exits 2" "rc=$rc out=$out"; fi
+case "$out" in *"mutant build timed out after 1s"*) ok "the mutant-build timeout is reported";; *) bad "the mutant-build timeout is reported" "$out";; esac
+case "$out" in *"invalid-mutant"*) bad "a mutant-build timeout is not an invalid mutant" "$out";; *) ok "a mutant-build timeout is not an invalid mutant";; esac
+mutant_build_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
+if [ -n "$mutant_build_child" ] && stopped "$mutant_build_child"; then
+  ok "the timed-out mutant build is reaped"
+else
+  bad "the timed-out mutant build is reaped" "pid=${mutant_build_child:-missing}"
+  [ -z "$mutant_build_child" ] || kill -KILL "$mutant_build_child" 2>/dev/null || true
+fi
+
 export HANG_PID_FILE="$TMP/mutant-timeout-child.pid"
 rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
       --test 'grep -q "+" lib.sh || { bash hang.sh & wait; }' \
       --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
       --stability 1 --timeout 1 2>&1) || rc=$?
 if [ "$rc" = 2 ]; then ok "a timed-out mutant exits 2"; else bad "a timed-out mutant exits 2" "rc=$rc out=$out"; fi
-case "$out" in *"mutant test timed out"*) ok "a timed-out mutant is an instrument failure";; *) bad "a timed-out mutant is an instrument failure" "$out";; esac
+case "$out" in *"test timed out after 1s"*) ok "a timed-out mutant is an instrument failure";; *) bad "a timed-out mutant is an instrument failure" "$out";; esac
 case "$out" in *"mutation: killed"*) bad "a timed-out mutant is never killed" "$out";; *) ok "a timed-out mutant is never killed";; esac
 mutant_timeout_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
-if [ -n "$mutant_timeout_child" ] && ! kill -0 "$mutant_timeout_child" 2>/dev/null; then
+if [ -n "$mutant_timeout_child" ] && stopped "$mutant_timeout_child"; then
   ok "the timed-out mutant process group is reaped"
 else
   bad "the timed-out mutant process group is reaped" "pid=${mutant_timeout_child:-missing}"
@@ -96,7 +147,7 @@ rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
 if [ "$rc" = 2 ]; then ok "a hanging control times out"; else bad "a hanging control times out" "rc=$rc out=$out"; fi
 case "$out" in *"timed out after 1s"*) ok "the timeout is reported";; *) bad "the timeout is reported" "$out";; esac
 timeout_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
-if [ -n "$timeout_child" ] && ! kill -0 "$timeout_child" 2>/dev/null; then
+if [ -n "$timeout_child" ] && stopped "$timeout_child"; then
   ok "the timed-out process is reaped"
 else
   bad "the timed-out process is reaped" "pid=${timeout_child:-missing}"
@@ -113,7 +164,7 @@ while [ ! -s "$HANG_PID_FILE" ] && [ "$i" -lt 50 ]; do sleep 0.1; i=$((i + 1)); 
 exit_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
 kill -TERM "$ms_pid" 2>/dev/null || true
 wait "$ms_pid" 2>/dev/null || true
-if [ -n "$exit_child" ] && ! kill -0 "$exit_child" 2>/dev/null; then
+if [ -n "$exit_child" ] && stopped "$exit_child"; then
   ok "exit cleanup reaps the active test process"
 else
   bad "exit cleanup reaps the active test process" "pid=${exit_child:-missing}"
@@ -136,9 +187,22 @@ rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA2" --test 'bash check.sh' \
 if [ "$rc" = 1 ]; then ok "stability failure exits 1 even with the mutant killed"; else bad "stability failure exits 1 even with the mutant killed" "rc=$rc out=$out"; fi
 case "$out" in *"stability: 1/3 at 2 threads") ok "partial stability is reported as Y/N";; *) bad "partial stability is reported as Y/N" "$out";; esac
 
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'bash check.sh' \
-      --build 'true' --mutate 'true' --stability 0 2>&1) || rc=$?
-if [ "$rc" = 2 ]; then ok "--stability 0 is refused as zero samples"; else bad "--stability 0 is refused as zero samples" "rc=$rc"; fi
+export HANG_PID_FILE="$TMP/stability-timeout-child.pid"
+rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
+      --test 'if grep -q "-" lib.sh; then exit 1; fi; if [ -f .ran ]; then bash hang.sh & wait; fi; touch .ran' \
+      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+      --stability 2 --timeout 1 2>&1) || rc=$?
+if [ "$rc" = 2 ]; then ok "a timed-out stability run exits 2"; else bad "a timed-out stability run exits 2" "rc=$rc out=$out"; fi
+case "$out" in *"test timed out after 1s"*) ok "the stability timeout is an instrument failure";; *) bad "the stability timeout is an instrument failure" "$out";; esac
+case "$out" in *"mutation: killed"*) bad "a stability timeout prints no trusted summary" "$out";; *) ok "a stability timeout prints no trusted summary";; esac
+stability_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
+if [ -n "$stability_child" ] && stopped "$stability_child"; then
+  ok "the timed-out stability run is reaped"
+else
+  bad "the timed-out stability run is reaped" "pid=${stability_child:-missing}"
+  [ -z "$stability_child" ] || kill -KILL "$stability_child" 2>/dev/null || true
+fi
+
 rc=0; "$MS" --worktree "$REPO" --sha "$SHA" --test 'true' --build 'true' --mutate 2>/dev/null || rc=$?
 if [ "$rc" = 2 ]; then ok "a value-less option exits 2"; else bad "a value-less option exits 2" "rc=$rc"; fi
 

--- a/.agents/skills/reviewer/tests/mutation-stability.test.sh
+++ b/.agents/skills/reviewer/tests/mutation-stability.test.sh
@@ -34,6 +34,42 @@ git -C "$REPO" add -A
 git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm x
 SHA=$(git -C "$REPO" rev-parse HEAD)
 
+if command -v unshare >/dev/null 2>&1 \
+  && command -v python3 >/dev/null 2>&1 \
+  && unshare --user --map-root-user --pid --fork --mount-proc true 2>/dev/null; then
+  rc=0
+  out=$(unshare --user --map-root-user --pid --fork --mount-proc \
+    python3 -c '
+import glob, os, subprocess, sys, time
+env = os.environ.copy()
+env["HANG_PID_FILE"] = sys.argv[4]
+run = subprocess.run([
+    sys.argv[1], "--worktree", sys.argv[2], "--sha", sys.argv[3],
+    "--test", "true", "--build", "bash hang.sh & wait",
+    "--mutate", "true", "--stability", "1", "--timeout", "1",
+], env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+time.sleep(0.1)
+zombies = []
+for path in glob.glob("/proc/[0-9]*/stat"):
+    try:
+        fields = open(path).read().split()
+        if fields[2] == "Z" and fields[3] == "1":
+            zombies.append((fields[0], fields[1], fields[4]))
+    except (IndexError, OSError):
+        pass
+if run.returncode != 2:
+    print("timeout exit: expected 2, got %s" % run.returncode)
+if zombies:
+    print("non-reaping PID 1 adopted zombies: %r" % (zombies,))
+sys.exit(0 if run.returncode == 2 and not zombies else 1)
+' "$MS" "$REPO" "$SHA" "$TMP/nonreaping-timeout-child.pid" 2>&1) || rc=$?
+  if [ "$rc" = 0 ]; then
+    ok "a non-reaping PID 1 adopts no timed-out descendants"
+  else
+    bad "a non-reaping PID 1 adopts no timed-out descendants" "$out"
+  fi
+fi
+
 rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'bash check.sh' \
       --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
       --stability 2 --threads 2) || rc=$?

--- a/.agents/skills/reviewer/tests/mutation-stability.test.sh
+++ b/.agents/skills/reviewer/tests/mutation-stability.test.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-# Behavioral suite for scripts/mutation-stability: a killed mutant passes,
-# a surviving (decoy) mutant fails, a red-before-mutation control refuses,
-# and the summary line is the exact reported format.
+# Behavioral suite for scripts/mutation-stability.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MS="$SCRIPT_DIR/../scripts/mutation-stability"
@@ -24,19 +22,65 @@ git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm x
 SHA=$(git -C "$REPO" rev-parse HEAD)
 
 rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'bash check.sh' \
-      --mutate 'sed -i "s/+/-/" lib.sh' --stability 2 --threads 2) || rc=$?
+      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+      --stability 2 --threads 2) || rc=$?
 if [ "$rc" = 0 ]; then ok "killed mutant exits 0"; else bad "killed mutant exits 0" "rc=$rc out=$out"; fi
 case "$out" in "mutation: killed 1/1; stability: 2/2 at 2 threads") ok "summary line is the exact format";; *) bad "summary line is the exact format" "$out";; esac
 
 rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'bash check.sh' \
-      --mutate 'echo "# decoy: still says +" >> lib.sh' --stability 1) || rc=$?
+      --build 'true' --mutate 'echo "# decoy: still says +" >> lib.sh' \
+      --stability 1) || rc=$?
 if [ "$rc" = 1 ]; then ok "surviving decoy mutant exits 1"; else bad "surviving decoy mutant exits 1" "rc=$rc out=$out"; fi
 case "$out" in "mutation: killed 0/1;"*) ok "survivor reported as killed 0/1";; *) bad "survivor reported as killed 0/1" "$out";; esac
 
 rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'false' \
-      --mutate 'true' --stability 1 2>&1) || rc=$?
+      --build 'true' --mutate 'true' --stability 1 2>&1) || rc=$?
 if [ "$rc" = 2 ]; then ok "red-before-mutation control exits 2"; else bad "red-before-mutation control exits 2" "rc=$rc"; fi
 case "$out" in *"before any mutation"*) ok "control names the instrument failure";; *) bad "control names the instrument failure" "$out";; esac
+
+rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
+      --test 'printf "test result: ok. 0 passed; 0 failed; 0 ignored\n"' \
+      --build 'true' --mutate 'true' --stability 1 2>&1) || rc=$?
+if [ "$rc" = 2 ]; then ok "an empty Cargo selection exits 2"; else bad "an empty Cargo selection exits 2" "rc=$rc out=$out"; fi
+case "$out" in *"filter selected no test"*) ok "an empty selection has its own outcome";; *) bad "an empty selection has its own outcome" "$out";; esac
+case "$out" in *"survived"*) bad "an empty selection is never a surviving mutant" "$out";; *) ok "an empty selection is never a surviving mutant";; esac
+
+rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
+      --build 'test -f lib.sh' --mutate 'rm lib.sh' --stability 1 2>&1) || rc=$?
+if [ "$rc" = 2 ]; then ok "a non-compiling mutant exits 2"; else bad "a non-compiling mutant exits 2" "rc=$rc out=$out"; fi
+case "$out" in *"invalid-mutant"*) ok "a build failure reports invalid-mutant";; *) bad "a build failure reports invalid-mutant" "$out";; esac
+case "$out" in *"killed"*) bad "a non-compiling mutant is never killed" "$out";; *) ok "a non-compiling mutant is never killed";; esac
+
+export TIMEOUT_PID_FILE="$TMP/timeout-child.pid"
+rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
+      --test 'echo $$ > "$TIMEOUT_PID_FILE"; trap "" TERM; while :; do :; done' \
+      --build 'true' --mutate 'true' --stability 1 --timeout 1 2>&1) || rc=$?
+if [ "$rc" = 2 ]; then ok "a hanging control times out"; else bad "a hanging control times out" "rc=$rc out=$out"; fi
+case "$out" in *"timed out after 1s"*) ok "the timeout is reported";; *) bad "the timeout is reported" "$out";; esac
+timeout_child=$(cat "$TIMEOUT_PID_FILE" 2>/dev/null || true)
+if [ -n "$timeout_child" ] && ! kill -0 "$timeout_child" 2>/dev/null; then
+  ok "the timed-out process is reaped"
+else
+  bad "the timed-out process is reaped" "pid=${timeout_child:-missing}"
+  [ -z "$timeout_child" ] || kill -KILL "$timeout_child" 2>/dev/null || true
+fi
+
+export EXIT_PID_FILE="$TMP/exit-child.pid"
+"$MS" --worktree "$REPO" --sha "$SHA" \
+  --test 'echo $$ > "$EXIT_PID_FILE"; trap "" TERM; while :; do :; done' \
+  --build 'true' --mutate 'true' --stability 1 --timeout 30 >/dev/null 2>&1 &
+ms_pid=$!
+i=0
+while [ ! -s "$EXIT_PID_FILE" ] && [ "$i" -lt 50 ]; do sleep 0.1; i=$((i + 1)); done
+exit_child=$(cat "$EXIT_PID_FILE" 2>/dev/null || true)
+kill -TERM "$ms_pid" 2>/dev/null || true
+wait "$ms_pid" 2>/dev/null || true
+if [ -n "$exit_child" ] && ! kill -0 "$exit_child" 2>/dev/null; then
+  ok "exit cleanup reaps the active test process"
+else
+  bad "exit cleanup reaps the active test process" "pid=${exit_child:-missing}"
+  [ -z "$exit_child" ] || kill -KILL "$exit_child" 2>/dev/null || true
+fi
 
 # flaky test: passes only on its first run in a copy (state file marks reruns)
 cat > "$REPO/check.sh" <<'T'
@@ -49,14 +93,15 @@ git -C "$REPO" add -A
 git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm flaky
 SHA2=$(git -C "$REPO" rev-parse HEAD)
 rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA2" --test 'bash check.sh' \
-      --mutate 'sed -i "s/+/-/" lib.sh' --stability 3 --threads 2) || rc=$?
+      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+      --stability 3 --threads 2) || rc=$?
 if [ "$rc" = 1 ]; then ok "stability failure exits 1 even with the mutant killed"; else bad "stability failure exits 1 even with the mutant killed" "rc=$rc out=$out"; fi
 case "$out" in *"stability: 1/3 at 2 threads") ok "partial stability is reported as Y/N";; *) bad "partial stability is reported as Y/N" "$out";; esac
 
 rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'bash check.sh' \
-      --mutate 'true' --stability 0 2>&1) || rc=$?
+      --build 'true' --mutate 'true' --stability 0 2>&1) || rc=$?
 if [ "$rc" = 2 ]; then ok "--stability 0 is refused as zero samples"; else bad "--stability 0 is refused as zero samples" "rc=$rc"; fi
-rc=0; "$MS" --worktree "$REPO" --sha "$SHA" --test 'true' --mutate 2>/dev/null || rc=$?
+rc=0; "$MS" --worktree "$REPO" --sha "$SHA" --test 'true' --build 'true' --mutate 2>/dev/null || rc=$?
 if [ "$rc" = 2 ]; then ok "a value-less option exits 2"; else bad "a value-less option exits 2" "rc=$rc"; fi
 
 # A build cache the caller shares across both copies must answer neither run
@@ -78,7 +123,8 @@ git -C "$REPO" add -A
 git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm cached
 SHA3=$(git -C "$REPO" rev-parse HEAD)
 rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA3" --test 'bash check.sh' \
-      --mutate 'sed -i "s/+/-/" lib.sh' --stability 3 --threads 2) || rc=$?
+      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+      --stability 3 --threads 2) || rc=$?
 if [ "$rc" = 0 ]; then ok "a shared whole-second build cache reaches the right verdict"; else bad "a shared whole-second build cache reaches the right verdict" "rc=$rc out=$out"; fi
 case "$out" in "mutation: killed 1/1"*) ok "the mutant build rebuilds instead of reusing the control";; *) bad "the mutant build rebuilds instead of reusing the control" "$out";; esac
 case "$out" in *"stability: 3/3 at 2 threads") ok "the clean copy rebuilds instead of reusing the mutant";; *) bad "the clean copy rebuilds instead of reusing the mutant" "$out";; esac
@@ -87,7 +133,8 @@ case "$out" in *"stability: 3/3 at 2 threads") ok "the clean copy rebuilds inste
 # build before it to the same second, and a cache rebuilds on a strictly newer
 # source, not an equal one. Each copy is stamped a full second past the last.
 kept=$("$MS" --worktree "$REPO" --sha "$SHA3" --test 'bash check.sh' \
-      --mutate 'sed -i "s/+/-/" lib.sh' --stability 1 --threads 2 --keep 2>&1 >/dev/null || true)
+      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+      --stability 1 --threads 2 --keep 2>&1 >/dev/null || true)
 root=$(printf '%s\n' "$kept" | sed -n 's/^kept: //p')
 if [ -d "$root/clean" ]; then
   gap=$(( $(stat -c %Y "$root/clean/check.sh") - $(stat -c %Y "$root/mutant/check.sh") ))

--- a/changelog.d/fixed/KEN-951.md
+++ b/changelog.d/fixed/KEN-951.md
@@ -1,0 +1,1 @@
+- **Breaking:** Mutation checks now require `--build CMD` and reject empty selections, non-compiling mutants, and timed-out runs instead of reporting misleading verdicts.

--- a/skills/reviewer/SKILL.md
+++ b/skills/reviewer/SKILL.md
@@ -71,11 +71,13 @@ right reason. Run both with one command, on a copy, never in the shared
 tree:
 
 ```bash
-.agents/skills/reviewer/scripts/mutation-stability --worktree [WORKTREE_PATH] --sha [SHA] --test '[TEST_CMD]' --mutate '[MUTATE_CMD]'
+.agents/skills/reviewer/scripts/mutation-stability --worktree [WORKTREE_PATH] --sha [SHA] --test '[TEST_CMD]' --build '[BUILD_CMD]' --mutate '[MUTATE_CMD]'
 ```
 
 - Kill the mutant under every selection/invocation mode the changed code
   exposes, not only the default (one call per mode).
+- A kill counts only when the mutated copy compiles. Use the suite's
+  compile-without-running command for `--build`.
 - Copy the printed `mutation: … stability: …` line into your artifact's
   `summary`; that field and `qa_metadata` are the only carriers read as
   your own measurement.

--- a/skills/reviewer/scripts/mutation-stability
+++ b/skills/reviewer/scripts/mutation-stability
@@ -71,21 +71,61 @@ positive_integer --threads "$THREADS"
 positive_integer --timeout "$TIMEOUT"
 
 ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX") || exit 2
-ACTIVE_PID="" ACTIVE_GROUP="" WATCHDOG_PID="" WATCHDOG_GROUP=""
+ACTIVE_PID="" ACTIVE_GROUP=""
+
+group_leaves() {
+  group="$1" leader="$2"
+  ps -eo pid=,ppid=,pgid= 2>/dev/null | awk -v group="$group" -v leader="$leader" '
+    $3 == group && $1 != leader {
+      members[$1] = 1
+      has_child[$2] = 1
+    }
+    END {
+      for (pid in members) if (!has_child[pid]) print pid
+    }
+  '
+}
+
+signal_leaves() {
+  signal="$1" group="$2" leader="$3" leaves="" leaf=""
+  leaves=$(group_leaves "$group" "$leader") || return 1
+  [ -n "$leaves" ] || return 2
+  while IFS= read -r leaf; do
+    [ -z "$leaf" ] || kill -s "$signal" "$leaf" 2>/dev/null || :
+  done <<EOF
+$leaves
+EOF
+}
 
 terminate_group() {
-  group="$1"
+  signal="$1" group="$2" leader="$3" grace=0
   [ -n "$group" ] || return 0
-  kill -TERM "-$group" 2>/dev/null || :
+
+  while [ "$grace" -lt 40 ]; do
+    leaf_status=0
+    signal_leaves KILL "$group" "$leader" || leaf_status=$?
+    [ "$leaf_status" -eq 0 ] || break
+    sleep 0.05
+    grace=$((grace + 1))
+  done
+  if [ "$leaf_status" -eq 1 ]; then
+    kill -s "$signal" "-$group" 2>/dev/null || :
+  else
+    [ -z "$leader" ] || kill -s "$signal" "$leader" 2>/dev/null || :
+  fi
+
+  grace=0
+  while [ -n "$leader" ] && kill -0 "$leader" 2>/dev/null && [ "$grace" -lt 20 ]; do
+    sleep 0.05
+    grace=$((grace + 1))
+  done
   kill -KILL "-$group" 2>/dev/null || :
+  [ -z "$leader" ] || wait "$leader" 2>/dev/null || :
 }
 
 cleanup_active() {
-  terminate_group "$WATCHDOG_GROUP"
-  [ -z "$WATCHDOG_PID" ] || wait "$WATCHDOG_PID" 2>/dev/null || :
-  terminate_group "$ACTIVE_GROUP"
-  [ -z "$ACTIVE_PID" ] || wait "$ACTIVE_PID" 2>/dev/null || :
-  ACTIVE_PID="" ACTIVE_GROUP="" WATCHDOG_PID="" WATCHDOG_GROUP=""
+  terminate_group TERM "$ACTIVE_GROUP" "$ACTIVE_PID"
+  ACTIVE_PID="" ACTIVE_GROUP=""
 }
 
 cleanup() {
@@ -116,8 +156,6 @@ extract() { # extract SHA into $1, stamped past the build before it
 
 run_command() { # run $2 in $1, capture output in $3, label it $4
   dir="$1" command="$2" log="$3" label="$4"
-  timed_out="$log.timed-out"
-  rm -f "$timed_out"
 
   set -m
   (
@@ -130,26 +168,23 @@ run_command() { # run $2 in $1, capture output in $3, label it $4
   ACTIVE_GROUP=$ACTIVE_PID
   set +m
 
-  set -m
-  (
-    sleep "$TIMEOUT"
-    : > "$timed_out"
-    kill -TERM "-$ACTIVE_GROUP" 2>/dev/null || exit 0
-    sleep 1
+  status=0 ticks=0 max_ticks=$((10#$TIMEOUT * 10)) timed_out=0
+  while kill -0 "$ACTIVE_PID" 2>/dev/null; do
+    if [ "$ticks" -ge "$max_ticks" ]; then
+      timed_out=1
+      terminate_group TERM "$ACTIVE_GROUP" "$ACTIVE_PID"
+      break
+    fi
+    sleep 0.1
+    ticks=$((ticks + 1))
+  done
+  if [ "$timed_out" -eq 0 ]; then
+    wait "$ACTIVE_PID" || status=$?
     kill -KILL "-$ACTIVE_GROUP" 2>/dev/null || :
-  ) &
-  WATCHDOG_PID=$!
-  WATCHDOG_GROUP=$WATCHDOG_PID
-  set +m
+  fi
+  ACTIVE_PID="" ACTIVE_GROUP=""
 
-  status=0
-  wait "$ACTIVE_PID" || status=$?
-  terminate_group "$WATCHDOG_GROUP"
-  wait "$WATCHDOG_PID" 2>/dev/null || :
-  terminate_group "$ACTIVE_GROUP"
-  ACTIVE_PID="" ACTIVE_GROUP="" WATCHDOG_PID="" WATCHDOG_GROUP=""
-
-  if [ -f "$timed_out" ]; then
+  if [ "$timed_out" -eq 1 ]; then
     echo "$label timed out after ${TIMEOUT}s" >&2
     [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
     exit 2

--- a/skills/reviewer/scripts/mutation-stability
+++ b/skills/reviewer/scripts/mutation-stability
@@ -3,43 +3,48 @@
 #
 # Copies WORKTREE at SHA into a fresh temp dir (git archive; the shared tree
 # is never touched), runs TEST there as a control (must pass), applies MUTATE
-# (a shell command run inside the copy), reruns TEST (must now fail = mutant
-# killed), then runs TEST N more times on a clean copy at elevated
+# (a shell command run inside the copy), builds the mutant, reruns TEST (must
+# now fail = mutant killed), then runs TEST N more times on a clean copy at elevated
 # parallelism and prints the one summary line reviewers report:
 #
 #   mutation: killed 1/1; stability: N/N at T threads
 #
 # Exit: 0 killed and stable; 1 mutant survived or a stability run failed;
-# 2 control failure (test red before mutation, bad args, archive failure).
+# 2 instrument failure (control, empty selection, invalid mutant, bad input).
 set -euo pipefail
 
 usage() {
   cat <<'USAGE'
-usage: mutation-stability --worktree PATH --sha SHA --test CMD --mutate CMD
-                          [--stability N] [--threads T] [--keep]
+usage: mutation-stability --worktree PATH --sha SHA --test CMD --build CMD
+                          --mutate CMD [--stability N] [--threads T]
+                          [--timeout S] [--keep]
 
   --test CMD       run via bash -c inside the copy; exit 0 = pass
+  --build CMD      compile the mutated copy without running its tests
   --mutate CMD     run via bash -c inside the copy before the kill check
   --stability N    clean-copy repeat runs (default 10; minimum 1)
   --threads T      exported to TEST as THREADS and RUST_TEST_THREADS
                    (default 2x nproc); a runner that takes a flag must be
-                   given it in TEST, e.g. --test 'cargo test -- --test-threads $THREADS' 
+                   given it in TEST, e.g. --test 'cargo test -- --test-threads $THREADS'
+  --timeout S      deadline for each build or test command (default 300)
   --keep           print the temp dirs instead of deleting them
 USAGE
 }
 
-WORKTREE="" SHA="" TEST="" MUTATE="" N=10 THREADS="" KEEP=0
+WORKTREE="" SHA="" TEST="" BUILD="" MUTATE="" N=10 THREADS="" TIMEOUT=300 KEEP=0
 while [ $# -gt 0 ]; do
   case "$1" in
-    --worktree|--sha|--test|--mutate|--stability|--threads)
+    --worktree|--sha|--test|--build|--mutate|--stability|--threads|--timeout)
       [ $# -ge 2 ] || { echo "$1 needs a value" >&2; usage >&2; exit 2; }
       case "$1" in
         --worktree) WORKTREE="$2" ;;
         --sha) SHA="$2" ;;
         --test) TEST="$2" ;;
+        --build) BUILD="$2" ;;
         --mutate) MUTATE="$2" ;;
         --stability) N="$2" ;;
         --threads) THREADS="$2" ;;
+        --timeout) TIMEOUT="$2" ;;
       esac
       shift ;;
     --keep) KEEP=1 ;;
@@ -48,16 +53,42 @@ while [ $# -gt 0 ]; do
   esac
   shift
 done
-[ -n "$WORKTREE" ] && [ -n "$SHA" ] && [ -n "$TEST" ] && [ -n "$MUTATE" ] || {
+[ -n "$WORKTREE" ] && [ -n "$SHA" ] && [ -n "$TEST" ] && [ -n "$BUILD" ] && [ -n "$MUTATE" ] || {
   usage >&2; exit 2
 }
 case "$N" in *[!0-9]*|'') echo "--stability wants a number" >&2; exit 2 ;; esac
 [ "$N" -ge 1 ] || { echo "--stability 0 is zero samples — instrument failure by the reviewer contract" >&2; exit 2; }
 [ -n "$THREADS" ] || THREADS=$((2 * $(nproc 2>/dev/null || echo 4)))
 case "$THREADS" in *[!0-9]*|''|0) echo "--threads wants a positive integer" >&2; exit 2 ;; esac
+case "$TIMEOUT" in *[!0-9]*|''|0) echo "--timeout wants a positive integer" >&2; exit 2 ;; esac
 
 ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX") || exit 2
-[ "$KEEP" = 1 ] || trap 'rm -rf "$ROOT"' EXIT
+ACTIVE_PID="" ACTIVE_GROUP="" WATCHDOG_PID="" WATCHDOG_GROUP=""
+
+terminate_group() {
+  group="$1"
+  [ -n "$group" ] || return 0
+  kill -TERM "-$group" 2>/dev/null || :
+  kill -KILL "-$group" 2>/dev/null || :
+}
+
+cleanup_active() {
+  terminate_group "$WATCHDOG_GROUP"
+  [ -z "$WATCHDOG_PID" ] || wait "$WATCHDOG_PID" 2>/dev/null || :
+  terminate_group "$ACTIVE_GROUP"
+  [ -z "$ACTIVE_PID" ] || wait "$ACTIVE_PID" 2>/dev/null || :
+  ACTIVE_PID="" ACTIVE_GROUP="" WATCHDOG_PID="" WATCHDOG_GROUP=""
+}
+
+cleanup() {
+  trap - EXIT HUP INT TERM
+  cleanup_active
+  [ "$KEEP" = 1 ] || rm -rf "$ROOT"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 # A build cache keyed on mtimes rebuilds only for a source STRICTLY newer than
 # what it holds, and a filesystem or cache keeping whole seconds rounds two
@@ -75,14 +106,83 @@ extract() { # extract SHA into $1, stamped past the build before it
   git -C "$WORKTREE" archive "$SHA" | tar -x -m -C "$1"
 }
 
-run_test() { # run TEST in dir $1 with threads $2
-  (cd "$1" && THREADS="$2" RUST_TEST_THREADS="$2" bash -c "$TEST") >/dev/null 2>&1
+run_command() { # run $2 in $1, capture output in $3, label it $4
+  dir="$1" command="$2" log="$3" label="$4"
+  timed_out="$log.timed-out"
+  rm -f "$timed_out"
+
+  set -m
+  (
+    cd "$dir" || exit 2
+    RUST_TEST_THREADS="$THREADS"
+    export THREADS RUST_TEST_THREADS
+    exec bash -c "$command"
+  ) >"$log" 2>&1 &
+  ACTIVE_PID=$!
+  ACTIVE_GROUP=$ACTIVE_PID
+  set +m
+
+  set -m
+  (
+    sleep "$TIMEOUT"
+    : > "$timed_out"
+    kill -TERM "-$ACTIVE_GROUP" 2>/dev/null || exit 0
+    sleep 1
+    kill -KILL "-$ACTIVE_GROUP" 2>/dev/null || :
+  ) &
+  WATCHDOG_PID=$!
+  WATCHDOG_GROUP=$WATCHDOG_PID
+  set +m
+
+  status=0
+  wait "$ACTIVE_PID" || status=$?
+  terminate_group "$WATCHDOG_GROUP"
+  wait "$WATCHDOG_PID" 2>/dev/null || :
+  terminate_group "$ACTIVE_GROUP"
+  ACTIVE_PID="" ACTIVE_GROUP="" WATCHDOG_PID="" WATCHDOG_GROUP=""
+
+  if [ -f "$timed_out" ]; then
+    echo "$label timed out after ${TIMEOUT}s" >&2
+    return 124
+  fi
+  return "$status"
+}
+
+run_test() { # run TEST in $1 and capture output in $2
+  run_command "$1" "$TEST" "$2" "test"
+}
+
+cargo_selection_nonempty() {
+  awk '
+    /test result: ok\./ {
+      saw_summary = 1
+      for (i = 1; i < NF; i++) {
+        if ($i ~ /^[0-9]+$/ && $(i + 1) == "passed;" && $i > 0) {
+          saw_pass = 1
+        }
+      }
+    }
+    END {
+      if (!saw_summary) exit 2
+      if (!saw_pass) exit 1
+    }
+  ' "$1"
 }
 
 extract "$ROOT/mutant" || { echo "control: git archive failed for $SHA" >&2; exit 2; }
 
-if ! run_test "$ROOT/mutant" "$THREADS"; then
+control_status=0
+run_test "$ROOT/mutant" "$ROOT/control.log" || control_status=$?
+if [ "$control_status" -ne 0 ]; then
   echo "control: test fails before any mutation — not a usable instrument" >&2
+  [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
+  exit 2
+fi
+
+selection_status=0
+cargo_selection_nonempty "$ROOT/control.log" || selection_status=$?
+if [ "$selection_status" = 1 ]; then
+  echo "control: filter selected no test — not a usable instrument" >&2
   [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
   exit 2
 fi
@@ -90,14 +190,22 @@ fi
 outrank_last_build
 (cd "$ROOT/mutant" && bash -c "$MUTATE") || { echo "mutate command failed" >&2; exit 2; }
 
+build_status=0
+run_command "$ROOT/mutant" "$BUILD" "$ROOT/build.log" "mutant build" || build_status=$?
+if [ "$build_status" -ne 0 ]; then
+  echo "mutation: invalid-mutant; build failed after mutation" >&2
+  [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
+  exit 2
+fi
+
 KILLED=1
-if run_test "$ROOT/mutant" "$THREADS"; then KILLED=0; fi
+if run_test "$ROOT/mutant" "$ROOT/mutant.log"; then KILLED=0; fi
 
 PASSES=0
 extract "$ROOT/clean" || { echo "control: second archive failed" >&2; exit 2; }
 i=0
 while [ "$i" -lt "$N" ]; do
-  if run_test "$ROOT/clean" "$THREADS"; then PASSES=$((PASSES + 1)); fi
+  if run_test "$ROOT/clean" "$ROOT/stability-$i.log"; then PASSES=$((PASSES + 1)); fi
   i=$((i + 1))
 done
 

--- a/skills/reviewer/scripts/mutation-stability
+++ b/skills/reviewer/scripts/mutation-stability
@@ -10,7 +10,8 @@
 #   mutation: killed 1/1; stability: N/N at T threads
 #
 # Exit: 0 killed and stable; 1 mutant survived or a stability run failed;
-# 2 instrument failure (control, empty selection, invalid mutant, bad input).
+# 2 instrument failure (control, empty selection, invalid mutant, timed-out run,
+# bad input).
 set -euo pipefail
 
 usage() {
@@ -32,6 +33,7 @@ USAGE
 }
 
 WORKTREE="" SHA="" TEST="" BUILD="" MUTATE="" N=10 THREADS="" TIMEOUT=300 KEEP=0
+THREADS_SET=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --worktree|--sha|--test|--build|--mutate|--stability|--threads|--timeout)
@@ -43,7 +45,7 @@ while [ $# -gt 0 ]; do
         --build) BUILD="$2" ;;
         --mutate) MUTATE="$2" ;;
         --stability) N="$2" ;;
-        --threads) THREADS="$2" ;;
+        --threads) THREADS="$2"; THREADS_SET=1 ;;
         --timeout) TIMEOUT="$2" ;;
       esac
       shift ;;
@@ -56,15 +58,20 @@ done
 [ -n "$WORKTREE" ] && [ -n "$SHA" ] && [ -n "$TEST" ] && [ -n "$BUILD" ] && [ -n "$MUTATE" ] || {
   usage >&2; exit 2
 }
-case "$N" in *[!0-9]*|'') echo "--stability wants a number" >&2; exit 2 ;; esac
-[ "$N" -ge 1 ] || { echo "--stability 0 is zero samples — instrument failure by the reviewer contract" >&2; exit 2; }
-[ -n "$THREADS" ] || THREADS=$((2 * $(nproc 2>/dev/null || echo 4)))
-case "$THREADS" in *[!0-9]*|''|0) echo "--threads wants a positive integer" >&2; exit 2 ;; esac
-case "$TIMEOUT" in *[!0-9]*|''|0) echo "--timeout wants a positive integer" >&2; exit 2 ;; esac
+positive_integer() {
+  option="$1" value="$2"
+  case "$value" in
+    *[!0-9]*|''|0) echo "$option wants a positive integer" >&2; exit 2 ;;
+  esac
+}
+
+[ "$THREADS_SET" = 1 ] || THREADS=$((2 * $(nproc 2>/dev/null || echo 4)))
+positive_integer --stability "$N"
+positive_integer --threads "$THREADS"
+positive_integer --timeout "$TIMEOUT"
 
 ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX") || exit 2
 ACTIVE_PID="" ACTIVE_GROUP="" WATCHDOG_PID="" WATCHDOG_GROUP=""
-COMMAND_TIMED_OUT=0
 
 terminate_group() {
   group="$1"
@@ -110,7 +117,6 @@ extract() { # extract SHA into $1, stamped past the build before it
 run_command() { # run $2 in $1, capture output in $3, label it $4
   dir="$1" command="$2" log="$3" label="$4"
   timed_out="$log.timed-out"
-  COMMAND_TIMED_OUT=0
   rm -f "$timed_out"
 
   set -m
@@ -144,9 +150,9 @@ run_command() { # run $2 in $1, capture output in $3, label it $4
   ACTIVE_PID="" ACTIVE_GROUP="" WATCHDOG_PID="" WATCHDOG_GROUP=""
 
   if [ -f "$timed_out" ]; then
-    COMMAND_TIMED_OUT=1
     echo "$label timed out after ${TIMEOUT}s" >&2
-    return 124
+    [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
+    exit 2
   fi
   return "$status"
 }
@@ -211,11 +217,6 @@ fi
 
 mutant_status=0
 run_test "$ROOT/mutant" "$ROOT/mutant.log" || mutant_status=$?
-if [ "$COMMAND_TIMED_OUT" = 1 ]; then
-  echo "mutation: instrument-failure; mutant test timed out" >&2
-  [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
-  exit 2
-fi
 KILLED=1
 [ "$mutant_status" -ne 0 ] || KILLED=0
 

--- a/skills/reviewer/scripts/mutation-stability
+++ b/skills/reviewer/scripts/mutation-stability
@@ -128,6 +128,8 @@ cleanup_active() {
   ACTIVE_PID="" ACTIVE_GROUP=""
 }
 
+request_cancel() { CANCEL_RC="$1"; }
+
 cleanup() {
   trap - EXIT HUP INT TERM
   cleanup_active
@@ -157,6 +159,12 @@ extract() { # extract SHA into $1, stamped past the build before it
 run_command() { # run $2 in $1, capture output in $3, label it $4
   dir="$1" command="$2" log="$3" label="$4"
 
+  # A handler cannot stop the new group until the fork's pid is assigned.
+  # Record cancellation across that window, then exit once cleanup owns it.
+  CANCEL_RC=""
+  trap 'request_cancel 129' HUP
+  trap 'request_cancel 130' INT
+  trap 'request_cancel 143' TERM
   set -m
   (
     cd "$dir" || exit 2
@@ -167,6 +175,10 @@ run_command() { # run $2 in $1, capture output in $3, label it $4
   ACTIVE_PID=$!
   ACTIVE_GROUP=$ACTIVE_PID
   set +m
+  trap 'exit 129' HUP
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+  [ -z "$CANCEL_RC" ] || exit "$CANCEL_RC"
 
   status=0 ticks=0 max_ticks=$((10#$TIMEOUT * 10)) timed_out=0
   while kill -0 "$ACTIVE_PID" 2>/dev/null; do

--- a/skills/reviewer/scripts/mutation-stability
+++ b/skills/reviewer/scripts/mutation-stability
@@ -2,9 +2,9 @@
 # mutation-stability — prove a test can fail, then prove it is stable.
 #
 # Copies WORKTREE at SHA into a fresh temp dir (git archive; the shared tree
-# is never touched), runs TEST there as a control (must pass), applies MUTATE
-# (a shell command run inside the copy), builds the mutant, reruns TEST (must
-# now fail = mutant killed), then runs TEST N more times on a clean copy at elevated
+# is never touched), builds and tests the control copy, applies MUTATE (a shell
+# command run inside the copy), builds the mutant, reruns TEST (must now fail =
+# mutant killed), then runs TEST N more times on a clean copy at elevated
 # parallelism and prints the one summary line reviewers report:
 #
 #   mutation: killed 1/1; stability: N/N at T threads
@@ -20,7 +20,7 @@ usage: mutation-stability --worktree PATH --sha SHA --test CMD --build CMD
                           [--timeout S] [--keep]
 
   --test CMD       run via bash -c inside the copy; exit 0 = pass
-  --build CMD      compile the mutated copy without running its tests
+  --build CMD      compile the copy without running its tests
   --mutate CMD     run via bash -c inside the copy before the kill check
   --stability N    clean-copy repeat runs (default 10; minimum 1)
   --threads T      exported to TEST as THREADS and RUST_TEST_THREADS
@@ -64,6 +64,7 @@ case "$TIMEOUT" in *[!0-9]*|''|0) echo "--timeout wants a positive integer" >&2;
 
 ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX") || exit 2
 ACTIVE_PID="" ACTIVE_GROUP="" WATCHDOG_PID="" WATCHDOG_GROUP=""
+COMMAND_TIMED_OUT=0
 
 terminate_group() {
   group="$1"
@@ -109,6 +110,7 @@ extract() { # extract SHA into $1, stamped past the build before it
 run_command() { # run $2 in $1, capture output in $3, label it $4
   dir="$1" command="$2" log="$3" label="$4"
   timed_out="$log.timed-out"
+  COMMAND_TIMED_OUT=0
   rm -f "$timed_out"
 
   set -m
@@ -142,6 +144,7 @@ run_command() { # run $2 in $1, capture output in $3, label it $4
   ACTIVE_PID="" ACTIVE_GROUP="" WATCHDOG_PID="" WATCHDOG_GROUP=""
 
   if [ -f "$timed_out" ]; then
+    COMMAND_TIMED_OUT=1
     echo "$label timed out after ${TIMEOUT}s" >&2
     return 124
   fi
@@ -171,6 +174,14 @@ cargo_selection_nonempty() {
 
 extract "$ROOT/mutant" || { echo "control: git archive failed for $SHA" >&2; exit 2; }
 
+control_build_status=0
+run_command "$ROOT/mutant" "$BUILD" "$ROOT/control-build.log" "control build" || control_build_status=$?
+if [ "$control_build_status" -ne 0 ]; then
+  echo "control: build fails before any mutation — not a usable instrument" >&2
+  [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
+  exit 2
+fi
+
 control_status=0
 run_test "$ROOT/mutant" "$ROOT/control.log" || control_status=$?
 if [ "$control_status" -ne 0 ]; then
@@ -198,8 +209,15 @@ if [ "$build_status" -ne 0 ]; then
   exit 2
 fi
 
+mutant_status=0
+run_test "$ROOT/mutant" "$ROOT/mutant.log" || mutant_status=$?
+if [ "$COMMAND_TIMED_OUT" = 1 ]; then
+  echo "mutation: instrument-failure; mutant test timed out" >&2
+  [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
+  exit 2
+fi
 KILLED=1
-if run_test "$ROOT/mutant" "$ROOT/mutant.log"; then KILLED=0; fi
+[ "$mutant_status" -ne 0 ] || KILLED=0
 
 PASSES=0
 extract "$ROOT/clean" || { echo "control: second archive failed" >&2; exit 2; }

--- a/skills/reviewer/tests/mutation-stability.test.sh
+++ b/skills/reviewer/tests/mutation-stability.test.sh
@@ -17,6 +17,11 @@ cat > "$REPO/check.sh" <<'T'
 . ./lib.sh
 [ "$(add 2 3)" = 5 ]
 T
+cat > "$REPO/hang.sh" <<'T'
+echo $$ > "$HANG_PID_FILE"
+trap '' TERM
+while :; do :; done
+T
 git -C "$REPO" add -A
 git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm x
 SHA=$(git -C "$REPO" rev-parse HEAD)
@@ -45,19 +50,52 @@ if [ "$rc" = 2 ]; then ok "an empty Cargo selection exits 2"; else bad "an empty
 case "$out" in *"filter selected no test"*) ok "an empty selection has its own outcome";; *) bad "an empty selection has its own outcome" "$out";; esac
 case "$out" in *"survived"*) bad "an empty selection is never a surviving mutant" "$out";; *) ok "an empty selection is never a surviving mutant";; esac
 
+rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
+      --test 'grep -q "+" lib.sh && printf "test result: ok. 1 passed; 0 failed; 0 ignored\n"' \
+      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+      --stability 1 --threads 2) || rc=$?
+if [ "$rc" = 0 ]; then ok "a non-empty Cargo selection reaches the verdict"; else bad "a non-empty Cargo selection reaches the verdict" "rc=$rc out=$out"; fi
+case "$out" in "mutation: killed 1/1; stability: 1/1 at 2 threads") ok "a passing Cargo summary is accepted";; *) bad "a passing Cargo summary is accepted" "$out";; esac
+
+rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
+      --build 'false' --mutate 'true' --stability 1 2>&1) || rc=$?
+if [ "$rc" = 2 ]; then ok "a broken control build exits 2"; else bad "a broken control build exits 2" "rc=$rc out=$out"; fi
+case "$out" in *"control: build fails before any mutation"*) ok "a broken build is blamed on the control";; *) bad "a broken build is blamed on the control" "$out";; esac
+case "$out" in *"invalid-mutant"*) bad "a broken control build is not an invalid mutant" "$out";; *) ok "a broken control build is not an invalid mutant";; esac
+
 rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
       --build 'test -f lib.sh' --mutate 'rm lib.sh' --stability 1 2>&1) || rc=$?
 if [ "$rc" = 2 ]; then ok "a non-compiling mutant exits 2"; else bad "a non-compiling mutant exits 2" "rc=$rc out=$out"; fi
 case "$out" in *"invalid-mutant"*) ok "a build failure reports invalid-mutant";; *) bad "a build failure reports invalid-mutant" "$out";; esac
 case "$out" in *"killed"*) bad "a non-compiling mutant is never killed" "$out";; *) ok "a non-compiling mutant is never killed";; esac
 
-export TIMEOUT_PID_FILE="$TMP/timeout-child.pid"
+rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
+      --mutate 'true' --stability 1 2>&1) || rc=$?
+if [ "$rc" = 2 ]; then ok "omitting --build exits 2"; else bad "omitting --build exits 2" "rc=$rc out=$out"; fi
+
+export HANG_PID_FILE="$TMP/mutant-timeout-child.pid"
 rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
-      --test 'echo $$ > "$TIMEOUT_PID_FILE"; trap "" TERM; while :; do :; done' \
+      --test 'grep -q "+" lib.sh || { bash hang.sh & wait; }' \
+      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+      --stability 1 --timeout 1 2>&1) || rc=$?
+if [ "$rc" = 2 ]; then ok "a timed-out mutant exits 2"; else bad "a timed-out mutant exits 2" "rc=$rc out=$out"; fi
+case "$out" in *"mutant test timed out"*) ok "a timed-out mutant is an instrument failure";; *) bad "a timed-out mutant is an instrument failure" "$out";; esac
+case "$out" in *"mutation: killed"*) bad "a timed-out mutant is never killed" "$out";; *) ok "a timed-out mutant is never killed";; esac
+mutant_timeout_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
+if [ -n "$mutant_timeout_child" ] && ! kill -0 "$mutant_timeout_child" 2>/dev/null; then
+  ok "the timed-out mutant process group is reaped"
+else
+  bad "the timed-out mutant process group is reaped" "pid=${mutant_timeout_child:-missing}"
+  [ -z "$mutant_timeout_child" ] || kill -KILL "$mutant_timeout_child" 2>/dev/null || true
+fi
+
+export HANG_PID_FILE="$TMP/timeout-child.pid"
+rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
+      --test 'bash hang.sh & wait' \
       --build 'true' --mutate 'true' --stability 1 --timeout 1 2>&1) || rc=$?
 if [ "$rc" = 2 ]; then ok "a hanging control times out"; else bad "a hanging control times out" "rc=$rc out=$out"; fi
 case "$out" in *"timed out after 1s"*) ok "the timeout is reported";; *) bad "the timeout is reported" "$out";; esac
-timeout_child=$(cat "$TIMEOUT_PID_FILE" 2>/dev/null || true)
+timeout_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
 if [ -n "$timeout_child" ] && ! kill -0 "$timeout_child" 2>/dev/null; then
   ok "the timed-out process is reaped"
 else
@@ -65,14 +103,14 @@ else
   [ -z "$timeout_child" ] || kill -KILL "$timeout_child" 2>/dev/null || true
 fi
 
-export EXIT_PID_FILE="$TMP/exit-child.pid"
+export HANG_PID_FILE="$TMP/exit-child.pid"
 "$MS" --worktree "$REPO" --sha "$SHA" \
-  --test 'echo $$ > "$EXIT_PID_FILE"; trap "" TERM; while :; do :; done' \
+  --test 'bash hang.sh & wait' \
   --build 'true' --mutate 'true' --stability 1 --timeout 30 >/dev/null 2>&1 &
 ms_pid=$!
 i=0
-while [ ! -s "$EXIT_PID_FILE" ] && [ "$i" -lt 50 ]; do sleep 0.1; i=$((i + 1)); done
-exit_child=$(cat "$EXIT_PID_FILE" 2>/dev/null || true)
+while [ ! -s "$HANG_PID_FILE" ] && [ "$i" -lt 50 ]; do sleep 0.1; i=$((i + 1)); done
+exit_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
 kill -TERM "$ms_pid" 2>/dev/null || true
 wait "$ms_pid" 2>/dev/null || true
 if [ -n "$exit_child" ] && ! kill -0 "$exit_child" 2>/dev/null; then

--- a/skills/reviewer/tests/mutation-stability.test.sh
+++ b/skills/reviewer/tests/mutation-stability.test.sh
@@ -3,9 +3,22 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MS="$SCRIPT_DIR/../scripts/mutation-stability"
-PASS=0 FAIL=0
+PASS=0 FAIL=0 rc=0 out=""
 ok()  { PASS=$((PASS+1)); echo "  ok    $1"; }
 bad() { FAIL=$((FAIL+1)); echo "  FAIL  $1"; echo "        $2"; }
+run_ms() {
+  sha="$1"; shift; rc=0
+  out=$("$MS" --worktree "$REPO" --sha "$sha" "$@" 2>&1) || rc=$?
+}
+is_rc() {
+  if [ "$rc" = "$1" ]; then ok "$2"; else bad "$2" "rc=$rc out=$out"; fi
+}
+has() {
+  case "$out" in *"$1"*) ok "$2";; *) bad "$2" "$out";; esac
+}
+lacks() {
+  case "$out" in *"$1"*) bad "$2" "$out";; *) ok "$2";; esac
+}
 stopped() {
   pid="$1" attempts=0
   while kill -0 "$pid" 2>/dev/null && [ "$attempts" -lt 20 ]; do
@@ -53,6 +66,40 @@ git -C "$REPO" add -A
 git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm x
 SHA=$(git -C "$REPO" rev-parse HEAD)
 
+run_ms "$SHA" --test 'bash check.sh' --build 'true' \
+  --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+  --stability 2 --threads 2
+is_rc 0 "killed mutant exits 0"
+if [ "$out" = "mutation: killed 1/1; stability: 2/2 at 2 threads" ]; then ok "summary line is the exact format"; else bad "summary line is the exact format" "$out"; fi
+
+run_ms "$SHA" --test 'bash check.sh' --build 'true' \
+  --mutate 'echo "# decoy: still says +" >> lib.sh' --stability 1
+is_rc 1 "surviving decoy mutant exits 1"
+has "mutation: killed 0/1;" "survivor reported as killed 0/1"
+
+run_ms "$SHA" --test 'false' --build 'true' --mutate 'true' --stability 1
+is_rc 2 "red-before-mutation control exits 2"
+has "before any mutation" "control names the instrument failure"
+
+run_ms "$SHA" \
+  --test 'printf "test result: ok. 0 passed; 0 failed; 0 ignored\n"' \
+  --build 'true' --mutate 'true' --stability 1
+is_rc 2 "an empty Cargo selection exits 2"
+has "filter selected no test" "an empty selection has its own outcome"
+lacks "survived" "an empty selection is never a surviving mutant"
+
+run_ms "$SHA" --test 'true' --build 'test -f lib.sh' \
+  --mutate 'rm lib.sh' --stability 1
+is_rc 2 "a non-compiling mutant exits 2"
+has "invalid-mutant" "a build failure reports invalid-mutant"
+lacks "killed" "a non-compiling mutant is never killed"
+
+# One invalid input proves the shared positive-integer validator.
+run_ms "$SHA" --test 'true' --build 'true' --mutate 'true' --timeout 0
+is_rc 2 "the numeric validator rejects zero"
+
+# KEN-999: one timeout control also checks adoption under a non-reaping PID 1.
+export HANG_PID_FILE="$TMP/timeout-child.pid"
 if command -v unshare >/dev/null 2>&1 \
   && command -v python3 >/dev/null 2>&1 \
   && unshare --user --map-root-user --pid --fork --mount-proc true 2>/dev/null; then
@@ -61,7 +108,6 @@ if command -v unshare >/dev/null 2>&1 \
     python3 -c '
 import glob, os, subprocess, sys, time
 env = os.environ.copy()
-env["HANG_PID_FILE"] = sys.argv[4]
 run = subprocess.run([
     sys.argv[1], "--worktree", sys.argv[2], "--sha", sys.argv[3],
     "--test", "true", "--build", "bash hang.sh & wait",
@@ -78,179 +124,45 @@ for path in glob.glob("/proc/[0-9]*/stat"):
         pass
 if run.returncode != 2:
     print("timeout exit: expected 2, got %s" % run.returncode)
+if "timed out after 1s" not in run.stderr:
+    print("missing timeout diagnostic: %s" % run.stderr)
 if zombies:
     print("non-reaping PID 1 adopted zombies: %r" % (zombies,))
-sys.exit(0 if run.returncode == 2 and not zombies else 1)
-' "$MS" "$REPO" "$SHA" "$TMP/nonreaping-timeout-child.pid" 2>&1) || rc=$?
-  if [ "$rc" = 0 ]; then
-    ok "a non-reaping PID 1 adopts no timed-out descendants"
+sys.exit(0 if run.returncode == 2 and "timed out after 1s" in run.stderr and not zombies else 1)
+' "$MS" "$REPO" "$SHA" 2>&1) || rc=$?
+  is_rc 0 "a timed-out child leaves no zombies under non-reaping PID 1"
+else
+  run_ms "$SHA" --test 'true' --build 'bash hang.sh & wait' \
+    --mutate 'true' --stability 1 --timeout 1
+  is_rc 2 "a hanging child times out"
+  has "timed out after 1s" "the timeout is reported"
+  child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
+  if [ -n "$child" ] && stopped "$child"; then
+    ok "the timed-out child is reaped"
   else
-    bad "a non-reaping PID 1 adopts no timed-out descendants" "$out"
+    bad "the timed-out child is reaped" "pid=${child:-missing}"
+    [ -z "$child" ] || kill -KILL "$child" 2>/dev/null || true
   fi
 fi
 
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'bash check.sh' \
-      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-      --stability 2 --threads 2) || rc=$?
-if [ "$rc" = 0 ]; then ok "killed mutant exits 0"; else bad "killed mutant exits 0" "rc=$rc out=$out"; fi
-case "$out" in "mutation: killed 1/1; stability: 2/2 at 2 threads") ok "summary line is the exact format";; *) bad "summary line is the exact format" "$out";; esac
-
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'bash check.sh' \
-      --build 'true' --mutate 'echo "# decoy: still says +" >> lib.sh' \
-      --stability 1) || rc=$?
-if [ "$rc" = 1 ]; then ok "surviving decoy mutant exits 1"; else bad "surviving decoy mutant exits 1" "rc=$rc out=$out"; fi
-case "$out" in "mutation: killed 0/1;"*) ok "survivor reported as killed 0/1";; *) bad "survivor reported as killed 0/1" "$out";; esac
-
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'false' \
-      --build 'true' --mutate 'true' --stability 1 2>&1) || rc=$?
-if [ "$rc" = 2 ]; then ok "red-before-mutation control exits 2"; else bad "red-before-mutation control exits 2" "rc=$rc"; fi
-case "$out" in *"before any mutation"*) ok "control names the instrument failure";; *) bad "control names the instrument failure" "$out";; esac
-
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
-      --test 'printf "test result: ok. 0 passed; 0 failed; 0 ignored\n"' \
-      --build 'true' --mutate 'true' --stability 1 2>&1) || rc=$?
-if [ "$rc" = 2 ]; then ok "an empty Cargo selection exits 2"; else bad "an empty Cargo selection exits 2" "rc=$rc out=$out"; fi
-case "$out" in *"filter selected no test"*) ok "an empty selection has its own outcome";; *) bad "an empty selection has its own outcome" "$out";; esac
-case "$out" in *"survived"*) bad "an empty selection is never a surviving mutant" "$out";; *) ok "an empty selection is never a surviving mutant";; esac
-
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
-      --test 'grep -q "+" lib.sh && printf "test result: ok. 1 passed; 0 failed; 0 ignored\n"' \
-      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-      --stability 1 --threads 2) || rc=$?
-if [ "$rc" = 0 ]; then ok "a non-empty Cargo selection reaches the verdict"; else bad "a non-empty Cargo selection reaches the verdict" "rc=$rc out=$out"; fi
-case "$out" in "mutation: killed 1/1; stability: 1/1 at 2 threads") ok "a passing Cargo summary is accepted";; *) bad "a passing Cargo summary is accepted" "$out";; esac
-
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
-      --build 'false' --mutate 'true' --stability 1 2>&1) || rc=$?
-if [ "$rc" = 2 ]; then ok "a broken control build exits 2"; else bad "a broken control build exits 2" "rc=$rc out=$out"; fi
-case "$out" in *"control: build fails before any mutation"*) ok "a broken build is blamed on the control";; *) bad "a broken build is blamed on the control" "$out";; esac
-case "$out" in *"invalid-mutant"*) bad "a broken control build is not an invalid mutant" "$out";; *) ok "a broken control build is not an invalid mutant";; esac
-
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
-      --build 'test -f lib.sh' --mutate 'rm lib.sh' --stability 1 2>&1) || rc=$?
-if [ "$rc" = 2 ]; then ok "a non-compiling mutant exits 2"; else bad "a non-compiling mutant exits 2" "rc=$rc out=$out"; fi
-case "$out" in *"invalid-mutant"*) ok "a build failure reports invalid-mutant";; *) bad "a build failure reports invalid-mutant" "$out";; esac
-case "$out" in *"killed"*) bad "a non-compiling mutant is never killed" "$out";; *) ok "a non-compiling mutant is never killed";; esac
-
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
-      --mutate 'true' --stability 1 2>&1) || rc=$?
-if [ "$rc" = 2 ]; then ok "omitting --build exits 2"; else bad "omitting --build exits 2" "rc=$rc out=$out"; fi
-
-for option in --stability --threads --timeout; do
-  for value in 0 nope ""; do
-    rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
-          --build 'true' --mutate 'true' "$option" "$value" 2>&1) || rc=$?
-    if [ "$rc" = 2 ]; then
-      ok "$option rejects '${value:-empty}'"
-    else
-      bad "$option rejects '${value:-empty}'" "rc=$rc out=$out"
-    fi
-  done
-done
-
-export HANG_PID_FILE="$TMP/control-build-timeout-child.pid"
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
-      --build 'bash hang.sh & wait' --mutate 'true' --stability 1 \
-      --timeout 1 2>&1) || rc=$?
-if [ "$rc" = 2 ]; then ok "a timed-out control build exits 2"; else bad "a timed-out control build exits 2" "rc=$rc out=$out"; fi
-case "$out" in *"control build timed out after 1s"*) ok "the control-build timeout is reported";; *) bad "the control-build timeout is reported" "$out";; esac
-case "$out" in *"build fails"*) bad "a control-build timeout is not a build failure" "$out";; *) ok "a control-build timeout is not a build failure";; esac
-control_build_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
-if [ -n "$control_build_child" ] && stopped "$control_build_child"; then
-  ok "the timed-out control build is reaped"
-else
-  bad "the timed-out control build is reaped" "pid=${control_build_child:-missing}"
-  [ -z "$control_build_child" ] || kill -KILL "$control_build_child" 2>/dev/null || true
-fi
-
-export HANG_PID_FILE="$TMP/mutant-build-timeout-child.pid"
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
-      --build 'grep -q "+" lib.sh || { bash hang.sh & wait; }' \
-      --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-      --stability 1 --timeout 1 2>&1) || rc=$?
-if [ "$rc" = 2 ]; then ok "a timed-out mutant build exits 2"; else bad "a timed-out mutant build exits 2" "rc=$rc out=$out"; fi
-case "$out" in *"mutant build timed out after 1s"*) ok "the mutant-build timeout is reported";; *) bad "the mutant-build timeout is reported" "$out";; esac
-case "$out" in *"invalid-mutant"*) bad "a mutant-build timeout is not an invalid mutant" "$out";; *) ok "a mutant-build timeout is not an invalid mutant";; esac
-mutant_build_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
-if [ -n "$mutant_build_child" ] && stopped "$mutant_build_child"; then
-  ok "the timed-out mutant build is reaped"
-else
-  bad "the timed-out mutant build is reaped" "pid=${mutant_build_child:-missing}"
-  [ -z "$mutant_build_child" ] || kill -KILL "$mutant_build_child" 2>/dev/null || true
-fi
-
-export HANG_PID_FILE="$TMP/mutant-timeout-child.pid"
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
-      --test 'grep -q "+" lib.sh || { bash hang.sh & wait; }' \
-      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-      --stability 1 --timeout 1 2>&1) || rc=$?
-if [ "$rc" = 2 ]; then ok "a timed-out mutant exits 2"; else bad "a timed-out mutant exits 2" "rc=$rc out=$out"; fi
-case "$out" in *"test timed out after 1s"*) ok "a timed-out mutant is an instrument failure";; *) bad "a timed-out mutant is an instrument failure" "$out";; esac
-case "$out" in *"mutation: killed"*) bad "a timed-out mutant is never killed" "$out";; *) ok "a timed-out mutant is never killed";; esac
-mutant_timeout_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
-if [ -n "$mutant_timeout_child" ] && stopped "$mutant_timeout_child"; then
-  ok "the timed-out mutant process group is reaped"
-else
-  bad "the timed-out mutant process group is reaped" "pid=${mutant_timeout_child:-missing}"
-  [ -z "$mutant_timeout_child" ] || kill -KILL "$mutant_timeout_child" 2>/dev/null || true
-fi
-
-export HANG_PID_FILE="$TMP/timeout-child.pid"
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
-      --test 'bash hang.sh & wait' \
-      --build 'true' --mutate 'true' --stability 1 --timeout 1 2>&1) || rc=$?
-if [ "$rc" = 2 ]; then ok "a hanging control times out"; else bad "a hanging control times out" "rc=$rc out=$out"; fi
-case "$out" in *"timed out after 1s"*) ok "the timeout is reported";; *) bad "the timeout is reported" "$out";; esac
-timeout_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
-if [ -n "$timeout_child" ] && stopped "$timeout_child"; then
-  ok "the timed-out process is reaped"
-else
-  bad "the timed-out process is reaped" "pid=${timeout_child:-missing}"
-  [ -z "$timeout_child" ] || kill -KILL "$timeout_child" 2>/dev/null || true
-fi
-
-export HANG_PID_FILE="$TMP/exit-child.pid"
-"$MS" --worktree "$REPO" --sha "$SHA" \
-  --test 'bash hang.sh & wait' \
-  --build 'true' --mutate 'true' --stability 1 --timeout 30 >/dev/null 2>&1 &
-ms_pid=$!
-i=0
-while [ ! -s "$HANG_PID_FILE" ] && [ "$i" -lt 50 ]; do sleep 0.1; i=$((i + 1)); done
-exit_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
-kill -TERM "$ms_pid" 2>/dev/null || true
-wait "$ms_pid" 2>/dev/null || true
-if [ -n "$exit_child" ] && stopped "$exit_child"; then
-  ok "exit cleanup reaps the active test process"
-else
-  bad "exit cleanup reaps the active test process" "pid=${exit_child:-missing}"
-  [ -z "$exit_child" ] || kill -KILL "$exit_child" 2>/dev/null || true
-fi
-
+# One signal-gap control covers cancellation before process ownership lands.
 export HANG_PID_FILE="$TMP/launch-window-child.pid"
 export LAUNCH_WINDOW_SIGNALLED="$TMP/launch-window-signalled"
 rc=0
 BASH_ENV="$TMP/launch-window.bashenv" "$MS" --worktree "$REPO" --sha "$SHA" \
   --test 'true' --build 'bash hang.sh & wait' --mutate 'true' \
   --stability 1 --timeout 2 >/dev/null 2>&1 || rc=$?
-if [ "$rc" = 143 ]; then
-  ok "a launch-window TERM exits 143"
+child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
+if [ "$rc" = 143 ] && [ -f "$LAUNCH_WINDOW_SIGNALLED" ] \
+  && [ -n "$child" ] && stopped "$child"; then
+  ok "launch-window cancellation records ownership and reaps the command"
 else
-  bad "a launch-window TERM exits 143" "rc=$rc"
-fi
-if [ -f "$LAUNCH_WINDOW_SIGNALLED" ]; then
-  ok "the fixture signals before process ownership is recorded"
-else
-  bad "the fixture signals before process ownership is recorded" "DEBUG trap did not fire"
-fi
-launch_window_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
-if [ -n "$launch_window_child" ] && stopped "$launch_window_child"; then
-  ok "launch-window cancellation reaps the command process"
-else
-  bad "launch-window cancellation reaps the command process" "pid=${launch_window_child:-missing}"
-  [ -z "$launch_window_child" ] || kill -KILL "$launch_window_child" 2>/dev/null || true
+  bad "launch-window cancellation records ownership and reaps the command" \
+    "rc=$rc signal_file=$LAUNCH_WINDOW_SIGNALLED pid=${child:-missing}"
+  [ -z "$child" ] || kill -KILL "$child" 2>/dev/null || true
 fi
 
-# flaky test: passes only on its first run in a copy (state file marks reruns)
+# A rerun that fails only after the first clean pass reports partial stability.
 cat > "$REPO/check.sh" <<'T'
 . ./lib.sh
 [ "$(add 2 3)" = 5 ] || exit 1
@@ -260,37 +172,13 @@ T
 git -C "$REPO" add -A
 git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm flaky
 SHA2=$(git -C "$REPO" rev-parse HEAD)
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA2" --test 'bash check.sh' \
-      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-      --stability 3 --threads 2) || rc=$?
-if [ "$rc" = 1 ]; then ok "stability failure exits 1 even with the mutant killed"; else bad "stability failure exits 1 even with the mutant killed" "rc=$rc out=$out"; fi
-case "$out" in *"stability: 1/3 at 2 threads") ok "partial stability is reported as Y/N";; *) bad "partial stability is reported as Y/N" "$out";; esac
+run_ms "$SHA2" --test 'bash check.sh' --build 'true' \
+  --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+  --stability 3 --threads 2
+is_rc 1 "stability failure exits 1 even with the mutant killed"
+has "stability: 1/3 at 2 threads" "partial stability is reported as Y/N"
 
-export HANG_PID_FILE="$TMP/stability-timeout-child.pid"
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
-      --test 'if grep -q "-" lib.sh; then exit 1; fi; if [ -f .ran ]; then bash hang.sh & wait; fi; touch .ran' \
-      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-      --stability 2 --timeout 1 2>&1) || rc=$?
-if [ "$rc" = 2 ]; then ok "a timed-out stability run exits 2"; else bad "a timed-out stability run exits 2" "rc=$rc out=$out"; fi
-case "$out" in *"test timed out after 1s"*) ok "the stability timeout is an instrument failure";; *) bad "the stability timeout is an instrument failure" "$out";; esac
-case "$out" in *"mutation: killed"*) bad "a stability timeout prints no trusted summary" "$out";; *) ok "a stability timeout prints no trusted summary";; esac
-stability_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
-if [ -n "$stability_child" ] && stopped "$stability_child"; then
-  ok "the timed-out stability run is reaped"
-else
-  bad "the timed-out stability run is reaped" "pid=${stability_child:-missing}"
-  [ -z "$stability_child" ] || kill -KILL "$stability_child" 2>/dev/null || true
-fi
-
-rc=0; "$MS" --worktree "$REPO" --sha "$SHA" --test 'true' --build 'true' --mutate 2>/dev/null || rc=$?
-if [ "$rc" = 2 ]; then ok "a value-less option exits 2"; else bad "a value-less option exits 2" "rc=$rc"; fi
-
-# A build cache the caller shares across both copies must answer neither run
-# with the other's artifact. check.sh is that cache, keyed the way cargo's
-# target dir is: it rebuilds for a source strictly newer than what it holds,
-# in whole seconds, the coarsest granularity a filesystem or cache keeps. Both
-# ways it can be wrong are here — the mutant reusing the control's build and
-# surviving, the clean copy reusing the mutant's and failing.
+# Shared whole-second caches must rebuild for mutant and clean copies.
 export CACHE="$TMP/build-cache"
 mkdir -p "$CACHE"
 cat > "$REPO/check.sh" <<'T'
@@ -303,26 +191,23 @@ T
 git -C "$REPO" add -A
 git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm cached
 SHA3=$(git -C "$REPO" rev-parse HEAD)
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA3" --test 'bash check.sh' \
-      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-      --stability 3 --threads 2) || rc=$?
-if [ "$rc" = 0 ]; then ok "a shared whole-second build cache reaches the right verdict"; else bad "a shared whole-second build cache reaches the right verdict" "rc=$rc out=$out"; fi
-case "$out" in "mutation: killed 1/1"*) ok "the mutant build rebuilds instead of reusing the control";; *) bad "the mutant build rebuilds instead of reusing the control" "$out";; esac
-case "$out" in *"stability: 3/3 at 2 threads") ok "the clean copy rebuilds instead of reusing the mutant";; *) bad "the clean copy rebuilds instead of reusing the mutant" "$out";; esac
+run_ms "$SHA3" --test 'bash check.sh' --build 'true' \
+  --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+  --stability 3 --threads 2
+is_rc 0 "a shared whole-second build cache reaches the right verdict"
+has "mutation: killed 1/1" "the mutant build rebuilds instead of reusing the control"
+has "stability: 3/3 at 2 threads" "the clean copy rebuilds instead of reusing the mutant"
 
-# A filesystem or cache that keeps whole seconds rounds an extraction and the
-# build before it to the same second, and a cache rebuilds on a strictly newer
-# source, not an equal one. Each copy is stamped a full second past the last.
 kept=$("$MS" --worktree "$REPO" --sha "$SHA3" --test 'bash check.sh' \
-      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
-      --stability 1 --threads 2 --keep 2>&1 >/dev/null || true)
+  --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+  --stability 1 --threads 2 --keep 2>&1 >/dev/null || true)
 root=$(printf '%s\n' "$kept" | sed -n 's/^kept: //p')
 if [ -d "$root/clean" ]; then
   gap=$(( $(stat -c %Y "$root/clean/check.sh") - $(stat -c %Y "$root/mutant/check.sh") ))
   rm -rf "$root"
-  if [ "$gap" -ge 1 ]; then ok "each copy is stamped a whole second past the one before"; else bad "each copy is stamped a whole second past the one before" "gap=${gap}s"; fi
+  if [ "$gap" -ge 1 ]; then ok "each copy outranks the one before"; else bad "each copy outranks the one before" "gap=${gap}s"; fi
 else
-  bad "each copy is stamped a whole second past the one before" "--keep printed no temp dir: $kept"
+  bad "each copy outranks the one before" "--keep printed no temp dir: $kept"
 fi
 
 echo "$PASS passed, $FAIL failed"

--- a/skills/reviewer/tests/mutation-stability.test.sh
+++ b/skills/reviewer/tests/mutation-stability.test.sh
@@ -30,6 +30,25 @@ echo $$ > "$HANG_PID_FILE"
 trap '' TERM
 while :; do :; done
 T
+cat > "$TMP/launch-window.bashenv" <<'T'
+case "$0" in
+  *mutation-stability)
+    set -T
+    trap '
+      if [ "$BASH_COMMAND" = "ACTIVE_PID=\$!" ]; then
+        trap - DEBUG
+        tries=0
+        while [ ! -s "$HANG_PID_FILE" ] && [ "$tries" -lt 100 ]; do
+          sleep 0.01
+          tries=$((tries + 1))
+        done
+        : > "$LAUNCH_WINDOW_SIGNALLED"
+        kill -TERM "$$"
+      fi
+    ' DEBUG
+    ;;
+esac
+T
 git -C "$REPO" add -A
 git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm x
 SHA=$(git -C "$REPO" rev-parse HEAD)
@@ -205,6 +224,30 @@ if [ -n "$exit_child" ] && stopped "$exit_child"; then
 else
   bad "exit cleanup reaps the active test process" "pid=${exit_child:-missing}"
   [ -z "$exit_child" ] || kill -KILL "$exit_child" 2>/dev/null || true
+fi
+
+export HANG_PID_FILE="$TMP/launch-window-child.pid"
+export LAUNCH_WINDOW_SIGNALLED="$TMP/launch-window-signalled"
+rc=0
+BASH_ENV="$TMP/launch-window.bashenv" "$MS" --worktree "$REPO" --sha "$SHA" \
+  --test 'true' --build 'bash hang.sh & wait' --mutate 'true' \
+  --stability 1 --timeout 2 >/dev/null 2>&1 || rc=$?
+if [ "$rc" = 143 ]; then
+  ok "a launch-window TERM exits 143"
+else
+  bad "a launch-window TERM exits 143" "rc=$rc"
+fi
+if [ -f "$LAUNCH_WINDOW_SIGNALLED" ]; then
+  ok "the fixture signals before process ownership is recorded"
+else
+  bad "the fixture signals before process ownership is recorded" "DEBUG trap did not fire"
+fi
+launch_window_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
+if [ -n "$launch_window_child" ] && stopped "$launch_window_child"; then
+  ok "launch-window cancellation reaps the command process"
+else
+  bad "launch-window cancellation reaps the command process" "pid=${launch_window_child:-missing}"
+  [ -z "$launch_window_child" ] || kill -KILL "$launch_window_child" 2>/dev/null || true
 fi
 
 # flaky test: passes only on its first run in a copy (state file marks reruns)

--- a/skills/reviewer/tests/mutation-stability.test.sh
+++ b/skills/reviewer/tests/mutation-stability.test.sh
@@ -6,6 +6,14 @@ MS="$SCRIPT_DIR/../scripts/mutation-stability"
 PASS=0 FAIL=0
 ok()  { PASS=$((PASS+1)); echo "  ok    $1"; }
 bad() { FAIL=$((FAIL+1)); echo "  FAIL  $1"; echo "        $2"; }
+stopped() {
+  pid="$1" attempts=0
+  while kill -0 "$pid" 2>/dev/null && [ "$attempts" -lt 20 ]; do
+    sleep 0.05
+    attempts=$((attempts + 1))
+  done
+  ! kill -0 "$pid" 2>/dev/null
+}
 
 TMP=$(mktemp -d "${TMPDIR:-/tmp}/ms-test.XXXXXX") || exit 2
 trap 'rm -rf "$TMP"' EXIT
@@ -73,16 +81,59 @@ rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
       --mutate 'true' --stability 1 2>&1) || rc=$?
 if [ "$rc" = 2 ]; then ok "omitting --build exits 2"; else bad "omitting --build exits 2" "rc=$rc out=$out"; fi
 
+for option in --stability --threads --timeout; do
+  for value in 0 nope ""; do
+    rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
+          --build 'true' --mutate 'true' "$option" "$value" 2>&1) || rc=$?
+    if [ "$rc" = 2 ]; then
+      ok "$option rejects '${value:-empty}'"
+    else
+      bad "$option rejects '${value:-empty}'" "rc=$rc out=$out"
+    fi
+  done
+done
+
+export HANG_PID_FILE="$TMP/control-build-timeout-child.pid"
+rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
+      --build 'bash hang.sh & wait' --mutate 'true' --stability 1 \
+      --timeout 1 2>&1) || rc=$?
+if [ "$rc" = 2 ]; then ok "a timed-out control build exits 2"; else bad "a timed-out control build exits 2" "rc=$rc out=$out"; fi
+case "$out" in *"control build timed out after 1s"*) ok "the control-build timeout is reported";; *) bad "the control-build timeout is reported" "$out";; esac
+case "$out" in *"build fails"*) bad "a control-build timeout is not a build failure" "$out";; *) ok "a control-build timeout is not a build failure";; esac
+control_build_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
+if [ -n "$control_build_child" ] && stopped "$control_build_child"; then
+  ok "the timed-out control build is reaped"
+else
+  bad "the timed-out control build is reaped" "pid=${control_build_child:-missing}"
+  [ -z "$control_build_child" ] || kill -KILL "$control_build_child" 2>/dev/null || true
+fi
+
+export HANG_PID_FILE="$TMP/mutant-build-timeout-child.pid"
+rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
+      --build 'grep -q "+" lib.sh || { bash hang.sh & wait; }' \
+      --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+      --stability 1 --timeout 1 2>&1) || rc=$?
+if [ "$rc" = 2 ]; then ok "a timed-out mutant build exits 2"; else bad "a timed-out mutant build exits 2" "rc=$rc out=$out"; fi
+case "$out" in *"mutant build timed out after 1s"*) ok "the mutant-build timeout is reported";; *) bad "the mutant-build timeout is reported" "$out";; esac
+case "$out" in *"invalid-mutant"*) bad "a mutant-build timeout is not an invalid mutant" "$out";; *) ok "a mutant-build timeout is not an invalid mutant";; esac
+mutant_build_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
+if [ -n "$mutant_build_child" ] && stopped "$mutant_build_child"; then
+  ok "the timed-out mutant build is reaped"
+else
+  bad "the timed-out mutant build is reaped" "pid=${mutant_build_child:-missing}"
+  [ -z "$mutant_build_child" ] || kill -KILL "$mutant_build_child" 2>/dev/null || true
+fi
+
 export HANG_PID_FILE="$TMP/mutant-timeout-child.pid"
 rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
       --test 'grep -q "+" lib.sh || { bash hang.sh & wait; }' \
       --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
       --stability 1 --timeout 1 2>&1) || rc=$?
 if [ "$rc" = 2 ]; then ok "a timed-out mutant exits 2"; else bad "a timed-out mutant exits 2" "rc=$rc out=$out"; fi
-case "$out" in *"mutant test timed out"*) ok "a timed-out mutant is an instrument failure";; *) bad "a timed-out mutant is an instrument failure" "$out";; esac
+case "$out" in *"test timed out after 1s"*) ok "a timed-out mutant is an instrument failure";; *) bad "a timed-out mutant is an instrument failure" "$out";; esac
 case "$out" in *"mutation: killed"*) bad "a timed-out mutant is never killed" "$out";; *) ok "a timed-out mutant is never killed";; esac
 mutant_timeout_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
-if [ -n "$mutant_timeout_child" ] && ! kill -0 "$mutant_timeout_child" 2>/dev/null; then
+if [ -n "$mutant_timeout_child" ] && stopped "$mutant_timeout_child"; then
   ok "the timed-out mutant process group is reaped"
 else
   bad "the timed-out mutant process group is reaped" "pid=${mutant_timeout_child:-missing}"
@@ -96,7 +147,7 @@ rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
 if [ "$rc" = 2 ]; then ok "a hanging control times out"; else bad "a hanging control times out" "rc=$rc out=$out"; fi
 case "$out" in *"timed out after 1s"*) ok "the timeout is reported";; *) bad "the timeout is reported" "$out";; esac
 timeout_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
-if [ -n "$timeout_child" ] && ! kill -0 "$timeout_child" 2>/dev/null; then
+if [ -n "$timeout_child" ] && stopped "$timeout_child"; then
   ok "the timed-out process is reaped"
 else
   bad "the timed-out process is reaped" "pid=${timeout_child:-missing}"
@@ -113,7 +164,7 @@ while [ ! -s "$HANG_PID_FILE" ] && [ "$i" -lt 50 ]; do sleep 0.1; i=$((i + 1)); 
 exit_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
 kill -TERM "$ms_pid" 2>/dev/null || true
 wait "$ms_pid" 2>/dev/null || true
-if [ -n "$exit_child" ] && ! kill -0 "$exit_child" 2>/dev/null; then
+if [ -n "$exit_child" ] && stopped "$exit_child"; then
   ok "exit cleanup reaps the active test process"
 else
   bad "exit cleanup reaps the active test process" "pid=${exit_child:-missing}"
@@ -136,9 +187,22 @@ rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA2" --test 'bash check.sh' \
 if [ "$rc" = 1 ]; then ok "stability failure exits 1 even with the mutant killed"; else bad "stability failure exits 1 even with the mutant killed" "rc=$rc out=$out"; fi
 case "$out" in *"stability: 1/3 at 2 threads") ok "partial stability is reported as Y/N";; *) bad "partial stability is reported as Y/N" "$out";; esac
 
-rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'bash check.sh' \
-      --build 'true' --mutate 'true' --stability 0 2>&1) || rc=$?
-if [ "$rc" = 2 ]; then ok "--stability 0 is refused as zero samples"; else bad "--stability 0 is refused as zero samples" "rc=$rc"; fi
+export HANG_PID_FILE="$TMP/stability-timeout-child.pid"
+rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
+      --test 'if grep -q "-" lib.sh; then exit 1; fi; if [ -f .ran ]; then bash hang.sh & wait; fi; touch .ran' \
+      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+      --stability 2 --timeout 1 2>&1) || rc=$?
+if [ "$rc" = 2 ]; then ok "a timed-out stability run exits 2"; else bad "a timed-out stability run exits 2" "rc=$rc out=$out"; fi
+case "$out" in *"test timed out after 1s"*) ok "the stability timeout is an instrument failure";; *) bad "the stability timeout is an instrument failure" "$out";; esac
+case "$out" in *"mutation: killed"*) bad "a stability timeout prints no trusted summary" "$out";; *) ok "a stability timeout prints no trusted summary";; esac
+stability_child=$(cat "$HANG_PID_FILE" 2>/dev/null || true)
+if [ -n "$stability_child" ] && stopped "$stability_child"; then
+  ok "the timed-out stability run is reaped"
+else
+  bad "the timed-out stability run is reaped" "pid=${stability_child:-missing}"
+  [ -z "$stability_child" ] || kill -KILL "$stability_child" 2>/dev/null || true
+fi
+
 rc=0; "$MS" --worktree "$REPO" --sha "$SHA" --test 'true' --build 'true' --mutate 2>/dev/null || rc=$?
 if [ "$rc" = 2 ]; then ok "a value-less option exits 2"; else bad "a value-less option exits 2" "rc=$rc"; fi
 

--- a/skills/reviewer/tests/mutation-stability.test.sh
+++ b/skills/reviewer/tests/mutation-stability.test.sh
@@ -34,6 +34,42 @@ git -C "$REPO" add -A
 git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm x
 SHA=$(git -C "$REPO" rev-parse HEAD)
 
+if command -v unshare >/dev/null 2>&1 \
+  && command -v python3 >/dev/null 2>&1 \
+  && unshare --user --map-root-user --pid --fork --mount-proc true 2>/dev/null; then
+  rc=0
+  out=$(unshare --user --map-root-user --pid --fork --mount-proc \
+    python3 -c '
+import glob, os, subprocess, sys, time
+env = os.environ.copy()
+env["HANG_PID_FILE"] = sys.argv[4]
+run = subprocess.run([
+    sys.argv[1], "--worktree", sys.argv[2], "--sha", sys.argv[3],
+    "--test", "true", "--build", "bash hang.sh & wait",
+    "--mutate", "true", "--stability", "1", "--timeout", "1",
+], env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+time.sleep(0.1)
+zombies = []
+for path in glob.glob("/proc/[0-9]*/stat"):
+    try:
+        fields = open(path).read().split()
+        if fields[2] == "Z" and fields[3] == "1":
+            zombies.append((fields[0], fields[1], fields[4]))
+    except (IndexError, OSError):
+        pass
+if run.returncode != 2:
+    print("timeout exit: expected 2, got %s" % run.returncode)
+if zombies:
+    print("non-reaping PID 1 adopted zombies: %r" % (zombies,))
+sys.exit(0 if run.returncode == 2 and not zombies else 1)
+' "$MS" "$REPO" "$SHA" "$TMP/nonreaping-timeout-child.pid" 2>&1) || rc=$?
+  if [ "$rc" = 0 ]; then
+    ok "a non-reaping PID 1 adopts no timed-out descendants"
+  else
+    bad "a non-reaping PID 1 adopts no timed-out descendants" "$out"
+  fi
+fi
+
 rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'bash check.sh' \
       --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
       --stability 2 --threads 2) || rc=$?

--- a/skills/reviewer/tests/mutation-stability.test.sh
+++ b/skills/reviewer/tests/mutation-stability.test.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-# Behavioral suite for scripts/mutation-stability: a killed mutant passes,
-# a surviving (decoy) mutant fails, a red-before-mutation control refuses,
-# and the summary line is the exact reported format.
+# Behavioral suite for scripts/mutation-stability.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MS="$SCRIPT_DIR/../scripts/mutation-stability"
@@ -24,19 +22,65 @@ git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm x
 SHA=$(git -C "$REPO" rev-parse HEAD)
 
 rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'bash check.sh' \
-      --mutate 'sed -i "s/+/-/" lib.sh' --stability 2 --threads 2) || rc=$?
+      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+      --stability 2 --threads 2) || rc=$?
 if [ "$rc" = 0 ]; then ok "killed mutant exits 0"; else bad "killed mutant exits 0" "rc=$rc out=$out"; fi
 case "$out" in "mutation: killed 1/1; stability: 2/2 at 2 threads") ok "summary line is the exact format";; *) bad "summary line is the exact format" "$out";; esac
 
 rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'bash check.sh' \
-      --mutate 'echo "# decoy: still says +" >> lib.sh' --stability 1) || rc=$?
+      --build 'true' --mutate 'echo "# decoy: still says +" >> lib.sh' \
+      --stability 1) || rc=$?
 if [ "$rc" = 1 ]; then ok "surviving decoy mutant exits 1"; else bad "surviving decoy mutant exits 1" "rc=$rc out=$out"; fi
 case "$out" in "mutation: killed 0/1;"*) ok "survivor reported as killed 0/1";; *) bad "survivor reported as killed 0/1" "$out";; esac
 
 rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'false' \
-      --mutate 'true' --stability 1 2>&1) || rc=$?
+      --build 'true' --mutate 'true' --stability 1 2>&1) || rc=$?
 if [ "$rc" = 2 ]; then ok "red-before-mutation control exits 2"; else bad "red-before-mutation control exits 2" "rc=$rc"; fi
 case "$out" in *"before any mutation"*) ok "control names the instrument failure";; *) bad "control names the instrument failure" "$out";; esac
+
+rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
+      --test 'printf "test result: ok. 0 passed; 0 failed; 0 ignored\n"' \
+      --build 'true' --mutate 'true' --stability 1 2>&1) || rc=$?
+if [ "$rc" = 2 ]; then ok "an empty Cargo selection exits 2"; else bad "an empty Cargo selection exits 2" "rc=$rc out=$out"; fi
+case "$out" in *"filter selected no test"*) ok "an empty selection has its own outcome";; *) bad "an empty selection has its own outcome" "$out";; esac
+case "$out" in *"survived"*) bad "an empty selection is never a surviving mutant" "$out";; *) ok "an empty selection is never a surviving mutant";; esac
+
+rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'true' \
+      --build 'test -f lib.sh' --mutate 'rm lib.sh' --stability 1 2>&1) || rc=$?
+if [ "$rc" = 2 ]; then ok "a non-compiling mutant exits 2"; else bad "a non-compiling mutant exits 2" "rc=$rc out=$out"; fi
+case "$out" in *"invalid-mutant"*) ok "a build failure reports invalid-mutant";; *) bad "a build failure reports invalid-mutant" "$out";; esac
+case "$out" in *"killed"*) bad "a non-compiling mutant is never killed" "$out";; *) ok "a non-compiling mutant is never killed";; esac
+
+export TIMEOUT_PID_FILE="$TMP/timeout-child.pid"
+rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" \
+      --test 'echo $$ > "$TIMEOUT_PID_FILE"; trap "" TERM; while :; do :; done' \
+      --build 'true' --mutate 'true' --stability 1 --timeout 1 2>&1) || rc=$?
+if [ "$rc" = 2 ]; then ok "a hanging control times out"; else bad "a hanging control times out" "rc=$rc out=$out"; fi
+case "$out" in *"timed out after 1s"*) ok "the timeout is reported";; *) bad "the timeout is reported" "$out";; esac
+timeout_child=$(cat "$TIMEOUT_PID_FILE" 2>/dev/null || true)
+if [ -n "$timeout_child" ] && ! kill -0 "$timeout_child" 2>/dev/null; then
+  ok "the timed-out process is reaped"
+else
+  bad "the timed-out process is reaped" "pid=${timeout_child:-missing}"
+  [ -z "$timeout_child" ] || kill -KILL "$timeout_child" 2>/dev/null || true
+fi
+
+export EXIT_PID_FILE="$TMP/exit-child.pid"
+"$MS" --worktree "$REPO" --sha "$SHA" \
+  --test 'echo $$ > "$EXIT_PID_FILE"; trap "" TERM; while :; do :; done' \
+  --build 'true' --mutate 'true' --stability 1 --timeout 30 >/dev/null 2>&1 &
+ms_pid=$!
+i=0
+while [ ! -s "$EXIT_PID_FILE" ] && [ "$i" -lt 50 ]; do sleep 0.1; i=$((i + 1)); done
+exit_child=$(cat "$EXIT_PID_FILE" 2>/dev/null || true)
+kill -TERM "$ms_pid" 2>/dev/null || true
+wait "$ms_pid" 2>/dev/null || true
+if [ -n "$exit_child" ] && ! kill -0 "$exit_child" 2>/dev/null; then
+  ok "exit cleanup reaps the active test process"
+else
+  bad "exit cleanup reaps the active test process" "pid=${exit_child:-missing}"
+  [ -z "$exit_child" ] || kill -KILL "$exit_child" 2>/dev/null || true
+fi
 
 # flaky test: passes only on its first run in a copy (state file marks reruns)
 cat > "$REPO/check.sh" <<'T'
@@ -49,14 +93,15 @@ git -C "$REPO" add -A
 git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm flaky
 SHA2=$(git -C "$REPO" rev-parse HEAD)
 rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA2" --test 'bash check.sh' \
-      --mutate 'sed -i "s/+/-/" lib.sh' --stability 3 --threads 2) || rc=$?
+      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+      --stability 3 --threads 2) || rc=$?
 if [ "$rc" = 1 ]; then ok "stability failure exits 1 even with the mutant killed"; else bad "stability failure exits 1 even with the mutant killed" "rc=$rc out=$out"; fi
 case "$out" in *"stability: 1/3 at 2 threads") ok "partial stability is reported as Y/N";; *) bad "partial stability is reported as Y/N" "$out";; esac
 
 rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA" --test 'bash check.sh' \
-      --mutate 'true' --stability 0 2>&1) || rc=$?
+      --build 'true' --mutate 'true' --stability 0 2>&1) || rc=$?
 if [ "$rc" = 2 ]; then ok "--stability 0 is refused as zero samples"; else bad "--stability 0 is refused as zero samples" "rc=$rc"; fi
-rc=0; "$MS" --worktree "$REPO" --sha "$SHA" --test 'true' --mutate 2>/dev/null || rc=$?
+rc=0; "$MS" --worktree "$REPO" --sha "$SHA" --test 'true' --build 'true' --mutate 2>/dev/null || rc=$?
 if [ "$rc" = 2 ]; then ok "a value-less option exits 2"; else bad "a value-less option exits 2" "rc=$rc"; fi
 
 # A build cache the caller shares across both copies must answer neither run
@@ -78,7 +123,8 @@ git -C "$REPO" add -A
 git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm cached
 SHA3=$(git -C "$REPO" rev-parse HEAD)
 rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA3" --test 'bash check.sh' \
-      --mutate 'sed -i "s/+/-/" lib.sh' --stability 3 --threads 2) || rc=$?
+      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+      --stability 3 --threads 2) || rc=$?
 if [ "$rc" = 0 ]; then ok "a shared whole-second build cache reaches the right verdict"; else bad "a shared whole-second build cache reaches the right verdict" "rc=$rc out=$out"; fi
 case "$out" in "mutation: killed 1/1"*) ok "the mutant build rebuilds instead of reusing the control";; *) bad "the mutant build rebuilds instead of reusing the control" "$out";; esac
 case "$out" in *"stability: 3/3 at 2 threads") ok "the clean copy rebuilds instead of reusing the mutant";; *) bad "the clean copy rebuilds instead of reusing the mutant" "$out";; esac
@@ -87,7 +133,8 @@ case "$out" in *"stability: 3/3 at 2 threads") ok "the clean copy rebuilds inste
 # build before it to the same second, and a cache rebuilds on a strictly newer
 # source, not an equal one. Each copy is stamped a full second past the last.
 kept=$("$MS" --worktree "$REPO" --sha "$SHA3" --test 'bash check.sh' \
-      --mutate 'sed -i "s/+/-/" lib.sh' --stability 1 --threads 2 --keep 2>&1 >/dev/null || true)
+      --build 'true' --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+      --stability 1 --threads 2 --keep 2>&1 >/dev/null || true)
 root=$(printf '%s\n' "$kept" | sed -n 's/^kept: //p')
 if [ -d "$root/clean" ]; then
   gap=$(( $(stat -c %Y "$root/clean/check.sh") - $(stat -c %Y "$root/mutant/check.sh") ))


### PR DESCRIPTION
## Summary
- Reject empty Cargo test selections before interpreting a mutation result.
- Validate control and mutant builds so compile failures never count as killed mutants.
- Time out and reap hung process groups without turning timeouts into mutation or stability results.
- Keep source and rendered reviewer skill copies in sync.

## Completed Issues
- Closes KEN-951 - mutation-stability reports a surviving mutant when the test filter selects nothing

## Test Plan
- `skills/reviewer/tests/mutation-stability.test.sh`
- `.agents/skills/preflight/scripts/preflight --base origin/main --repo /home/method/dev/.worktrees/kendex/ken-951`
- `tools/guard`
