### PR TITLE
docs(KEN-1128): code-quality states where each kind of markdown content lives, as five refusals

### DIFF
--- a/.agents/skills/code-quality/SKILL.md
+++ b/.agents/skills/code-quality/SKILL.md
@@ -65,7 +65,15 @@ Don't:
 - Claims broader than what the adjacent code or assertion actually enforces.
 - A numeral counting things outside the sentence. State the property and the command that enumerates it. A numeral bound to something adjacent — a list in the same paragraph, a constant a check compares against, one a ratchet owns — stays.
 
-Same rules for docs, READMEs, and skill/agent files: state the rule or behavior, never its provenance or justification. Their reader is an agent — write the shortest unambiguous rule and delete sentences nothing acts on. Plain words over jargon, in code and prose alike: name things by what they do. Commit bodies explain intent, never narrate the diff.
+Markdown placement rules:
+
+- Never state a rule twice within or across package files; make later statements point to the first.
+- Never put mechanics, rationale, or history in `SKILL.md` or agent files; keep rules and commands there.
+- Never put development internals, reasons, invariants, or test instructions outside `DEVELOPMENT.md`.
+- Never put anything but purpose, high-level behavior, features, user settings, and installation in a package `README.md`.
+- Never keep content in `references/*.md` unless a named workflow loads it on demand.
+
+Write the shortest unambiguous rule and delete sentences nothing acts on. Use plain words over jargon. Commit bodies explain intent, never narrate the diff.
 
 ## Over-Engineering
 

--- a/.agents/skills/code-quality/SKILL.md
+++ b/.agents/skills/code-quality/SKILL.md
@@ -69,7 +69,7 @@ Markdown placement rules:
 
 - Never state a rule twice within or across package files; make later statements point to the first.
 - Never put mechanics, rationale, or history in `SKILL.md` or agent files; keep rules and commands there.
-- Never put development internals, reasons, invariants, or test instructions outside `DEVELOPMENT.md`.
+- Never put internal explanations, rationale, invariant details, or test mechanics outside `DEVELOPMENT.md`; keep actionable rules and commands loaded.
 - Never put anything but purpose, high-level behavior, features, user settings, and installation in a package `README.md`.
 - Never keep content in `references/*.md` unless a named workflow loads it on demand.
 

--- a/.agents/skills/reviewer/SKILL.md
+++ b/.agents/skills/reviewer/SKILL.md
@@ -35,6 +35,7 @@ Shared contract for every review specialist; each agent's domain and probes live
 - **Report the class, not the instance.** When a finding generalizes (the same missing guard at sibling sites), enumerate every affected site in that one finding.
 - **Duplicated judgment is a finding.** Logic the diff introduces or arms that re-answers a question implemented elsewhere in the repo is raised even when both copies agree, and so is a rule it restates that another file owns, in prose, config or a table; name the surviving copy.
 - **A claim needs the line that makes it true.** For every sentence the diff adds to a `--help`, SKILL.md, CHANGELOG entry, comment, or diagnostic that states an order, a source set, an exit code, or a guarantee, find the code that makes it true. None found is a blocker; the claim is the defect, not the code.
+- For Markdown findings, cite [code-quality § Comments and Prose](../code-quality/SKILL.md#comments-and-prose); never restate its rules.
 - Fewer high-conviction findings beat lists of nits.
 - Project decisions and architecture docs outrank generic heuristics. Do not contradict or re-litigate the decisions the delegation lists.
 - Do not re-verify what deterministic gates already enforce (preflight, size-ratchet, project lint/CI); cite gate output instead of re-deriving it.

--- a/changelog.d/changed/KEN-1128.md
+++ b/changelog.d/changed/KEN-1128.md
@@ -1,0 +1,1 @@
+- Clarified where code-quality and reviewer skills require package Markdown content to live.

--- a/skills/code-quality/SKILL.md
+++ b/skills/code-quality/SKILL.md
@@ -65,7 +65,15 @@ Don't:
 - Claims broader than what the adjacent code or assertion actually enforces.
 - A numeral counting things outside the sentence. State the property and the command that enumerates it. A numeral bound to something adjacent — a list in the same paragraph, a constant a check compares against, one a ratchet owns — stays.
 
-Same rules for docs, READMEs, and skill/agent files: state the rule or behavior, never its provenance or justification. Their reader is an agent — write the shortest unambiguous rule and delete sentences nothing acts on. Plain words over jargon, in code and prose alike: name things by what they do. Commit bodies explain intent, never narrate the diff.
+Markdown placement rules:
+
+- Never state a rule twice within or across package files; make later statements point to the first.
+- Never put mechanics, rationale, or history in `SKILL.md` or agent files; keep rules and commands there.
+- Never put development internals, reasons, invariants, or test instructions outside `DEVELOPMENT.md`.
+- Never put anything but purpose, high-level behavior, features, user settings, and installation in a package `README.md`.
+- Never keep content in `references/*.md` unless a named workflow loads it on demand.
+
+Write the shortest unambiguous rule and delete sentences nothing acts on. Use plain words over jargon. Commit bodies explain intent, never narrate the diff.
 
 ## Over-Engineering
 

--- a/skills/code-quality/SKILL.md
+++ b/skills/code-quality/SKILL.md
@@ -69,7 +69,7 @@ Markdown placement rules:
 
 - Never state a rule twice within or across package files; make later statements point to the first.
 - Never put mechanics, rationale, or history in `SKILL.md` or agent files; keep rules and commands there.
-- Never put development internals, reasons, invariants, or test instructions outside `DEVELOPMENT.md`.
+- Never put internal explanations, rationale, invariant details, or test mechanics outside `DEVELOPMENT.md`; keep actionable rules and commands loaded.
 - Never put anything but purpose, high-level behavior, features, user settings, and installation in a package `README.md`.
 - Never keep content in `references/*.md` unless a named workflow loads it on demand.
 

--- a/skills/reviewer/SKILL.md
+++ b/skills/reviewer/SKILL.md
@@ -35,6 +35,7 @@ Shared contract for every review specialist; each agent's domain and probes live
 - **Report the class, not the instance.** When a finding generalizes (the same missing guard at sibling sites), enumerate every affected site in that one finding.
 - **Duplicated judgment is a finding.** Logic the diff introduces or arms that re-answers a question implemented elsewhere in the repo is raised even when both copies agree, and so is a rule it restates that another file owns, in prose, config or a table; name the surviving copy.
 - **A claim needs the line that makes it true.** For every sentence the diff adds to a `--help`, SKILL.md, CHANGELOG entry, comment, or diagnostic that states an order, a source set, an exit code, or a guarantee, find the code that makes it true. None found is a blocker; the claim is the defect, not the code.
+- For Markdown findings, cite [code-quality § Comments and Prose](../code-quality/SKILL.md#comments-and-prose); never restate its rules.
 - Fewer high-conviction findings beat lists of nits.
 - Project decisions and architecture docs outrank generic heuristics. Do not contradict or re-litigate the decisions the delegation lists.
 - Do not re-verify what deterministic gates already enforce (preflight, size-ratchet, project lint/CI); cite gate output instead of re-deriving it.


### PR DESCRIPTION
## Summary
- Define one canonical home for rules, development details, package README content, and workflow-loaded references.
- Keep actionable test rules and commands in loaded skills while moving explanatory test mechanics to development docs.
- Point markdown review findings to the code-quality rule instead of restating it.
- Update the tracked skill renders and consumer changelog fragment.

## Context
- **Research**: Instruction-markdown hygiene audit at `tmp/md-hygiene-2026-09-02.md`

## Completed Issues
- Closes KEN-1128 - code-quality states where each kind of markdown content lives, as five refusals

## Test Plan
- `.agents/skills/preflight/scripts/preflight --base origin/main --repo /home/method/dev/.worktrees/kendex/ken-1128`
- `tools/guard`
