### PR TITLE
docs(skills): bot-instructions pointers, companion note [no-changelog]

### DIFF
--- a/.agents/skills/growth-guards/SKILL.md
+++ b/.agents/skills/growth-guards/SKILL.md
@@ -24,7 +24,7 @@ repo-effects:
     - "size-ratchet"
     - "preflight"
   notes:
-    - "A missing companion is announced and skipped; every installed companion or guard failure blocks the commit."
+    - "A missing companion is announced and skipped, as is a repo-local size-ratchet that rejects --staged and preflight on a first commit; every other companion or guard failure blocks the commit."
     - "Both hooks block on nonzero results; Git's no-verify flag bypasses both for one commit."
     - "Git does not clone hooks; arm every clone once."
 ---

--- a/crates/app/tests/repo_effects.rs
+++ b/crates/app/tests/repo_effects.rs
@@ -110,14 +110,7 @@ fn a_companion_already_here_reads_as_installed() {
     };
     assert!(companion(offer, "size-ratchet").installed);
     assert!(!companion(offer, "preflight").installed);
-    assert!(
-        offer
-            .notes
-            .iter()
-            .any(|note| note.contains("missing companion"))
-    );
-    assert!(offer.notes.iter().any(|note| note.contains("no-verify")));
-    assert!(offer.notes.iter().any(|note| note.contains("every clone")));
+    assert!(!offer.notes.is_empty());
 }
 
 /// A set that carries a declaring package brings the same offer an

--- a/skills/bot-instructions/references/checklist.md
+++ b/skills/bot-instructions/references/checklist.md
@@ -290,8 +290,8 @@ which ones this repo does not actually have.
 
 ## If the repo's gate reads bot output
 
-- [ ] Every path in SKILL.md § A pull request changing its own review's policy
-      set is a policy path in the repo's gate: a push touching one invalidates
+- [ ] Every path in SKILL.md § The render inputs (the "Policy set:" list)
+      is a policy path in the repo's gate: a push touching one invalidates
       review evidence gathered before it. Work from that list rather than from a
       copy of it — it is longer than the obvious four, and a copy here would
       drift from it. In this repo it is what feeds

--- a/skills/bot-instructions/schemas/renders.md
+++ b/skills/bot-instructions/schemas/renders.md
@@ -236,9 +236,9 @@ What that buys, per surface, since the five do not get the same thing:
 The three unenforced rows are why the paths are rendered at all. Codex has no
 file-based exclusion, Copilot's is a settings page no repo file reaches, and
 Qodo's `[ignore]` governs `/improve` analysis rather than review content. Naming
-the paths makes the instruction actionable; SKILL.md § Every rendered config
-excludes the render trees carries the requirement and the plain statement that
-those three may comment anyway.
+the paths makes the instruction actionable; those three may comment on render
+paths anyway, and SKILL.md § Every rendered config excludes the render trees
+carries the requirement.
 
 **(a) `.coderabbit.yaml` carries one block.** CodeRabbit reaches the rest
 through `knowledge_base.code_guidelines.filePatterns` naming `AGENTS.md`.

--- a/skills/growth-guards/SKILL.md
+++ b/skills/growth-guards/SKILL.md
@@ -24,7 +24,7 @@ repo-effects:
     - "size-ratchet"
     - "preflight"
   notes:
-    - "A missing companion is announced and skipped; every installed companion or guard failure blocks the commit."
+    - "A missing companion is announced and skipped, as is a repo-local size-ratchet that rejects --staged and preflight on a first commit; every other companion or guard failure blocks the commit."
     - "Both hooks block on nonzero results; Git's no-verify flag bypasses both for one commit."
     - "Git does not clone hooks; arm every clone once."
 ---


### PR DESCRIPTION
Three claims the 05:00Z overseer PR scan found false on main after #1982 and #1983 merged, plus the three prose pins #1982 added. Overseer PR, no issue: each is a defect the merged PR introduced, and introduced defects are fixed rather than filed.

- `skills/growth-guards/SKILL.md` `notes:` (the text a person reads in the hooks consent offer) said every installed companion failure blocks the commit. `scripts/pre-commit:167` and `:189` skip two: a repo-local size-ratchet that rejects `--staged`, and preflight on a first commit. The note now names them. Render moves with the source.
- `skills/bot-instructions/references/checklist.md:293` pointed adopters at "§ A pull request changing its own review's policy set" for the policy-path list; on main that section holds three rules and the "Policy set:" list sits under § The render inputs.
- `skills/bot-instructions/schemas/renders.md:239-241` said SKILL.md § Every rendered config excludes the render trees carries the statement that Codex, Copilot and Qodo may comment anyway; that section is one line pointing back here. renders.md owns the statement.
- `crates/app/tests/repo_effects.rs` pinned three note substrings. A test that pins prose is not a test (KEN-918); one non-empty assertion stays. `[no-changelog]`: test-only.

https://claude.ai/code/session_01RkDwSMxGaqnL1HN8evRn91
