### PR TITLE
fix(KEN-1134): the Bundles tab reads the catalog's declared sets

### DIFF
--- a/changelog.d/fixed/KEN-1134.md
+++ b/changelog.d/fixed/KEN-1134.md
@@ -1,0 +1,1 @@
+- The marketplace Bundles tab lists every curated set the catalog declares, including ones whose members it no longer offers. A pending read shows a loading line and a failed one shows its error.

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -77,6 +77,7 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         marketplaces::marketplace_packages,
         marketplaces::marketplace_summary,
         marketplaces::marketplace_bundle,
+        marketplaces::marketplace_bundles,
         marketplaces::marketplace_package_preview,
         marketplaces::marketplace_package_file,
         marketplaces::install::marketplace_install,

--- a/crates/app/src/marketplaces.rs
+++ b/crates/app/src/marketplaces.rs
@@ -130,6 +130,15 @@ pub fn marketplace_summary(catalog: Catalog) -> Result<CatalogSummary, String> {
     browse::summary(&env, &catalog).map_err(|e| e.to_string())
 }
 
+/// Every curated set a catalog declares, with per-member installed state —
+/// what the marketplace page's Bundles tab lists.
+#[tauri::command(async)]
+#[specta::specta]
+pub fn marketplace_bundles(catalog: Catalog) -> Result<Vec<BundleDetail>, String> {
+    let env = env()?;
+    browse::bundles(&env, &catalog).map_err(|e| e.to_string())
+}
+
 /// One curated set with per-member installed state.
 #[tauri::command(async)]
 #[specta::specta]

--- a/crates/cli/tests/marketplace_cli.rs
+++ b/crates/cli/tests/marketplace_cli.rs
@@ -123,6 +123,14 @@ fn marketplace_browse_lists_a_subscriptions_packages() {
     let project = home.join("dev/app");
     let catalog_arg = home.join("catalog").display().to_string();
 
+    // A set the catalog declares, so the row's `bundles` carries a name
+    // rather than an empty list nothing can tell from a dropped field.
+    fs::write(
+        home.join("catalog/kendex.toml"),
+        "[bundles.starter]\nskills = [\"gh\"]\n",
+    )
+    .unwrap();
+
     let subscribed = kendex(
         home,
         &project,
@@ -158,6 +166,16 @@ fn marketplace_browse_lists_a_subscriptions_packages() {
         .collect();
     assert!(names.contains(&"gh"), "{listed:#}");
     assert!(names.contains(&"helper"), "{listed:#}");
+    // `bundles` is part of this schema-1 envelope: a scripted consumer reads
+    // which curated sets carry a package from here and nowhere else in the
+    // CLI. The app dropped its own use of the field, so this is what pins it.
+    let gh = listed["packages"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["package"]["name"] == "gh")
+        .expect("gh listed");
+    assert_eq!(gh["package"]["bundles"], serde_json::json!(["starter"]));
 
     // The text listing shows each package's summary beside its name, the
     // same line the app's Packages row shows.

--- a/crates/core/src/source/browse.rs
+++ b/crates/core/src/source/browse.rs
@@ -134,12 +134,19 @@ pub fn packages(env: &Env, catalog: &Catalog) -> Result<Vec<AvailablePackage>> {
 /// Every curated set this catalog declares, each with per-member installed
 /// state. What the marketplace page's Bundles tab lists: the catalog's own
 /// declaration, so a set none of whose members are offered still appears.
+///
+/// Sorted by name here rather than by each caller. A plain catalog holds its
+/// sets in a `BTreeMap` and is alphabetical already, but a plugin registry's
+/// are a list in `marketplace.json` file order, and one order for every
+/// consumer is the point of sorting in the read.
 pub fn bundles(env: &Env, catalog: &Catalog) -> Result<Vec<BundleDetail>> {
     let browsed = open(env, catalog)?;
-    Ok(super::bundles::offered(&browsed.sealed, &browsed.config)?
+    let mut out: Vec<BundleDetail> = super::bundles::offered(&browsed.sealed, &browsed.config)?
         .iter()
         .map(|found| detail(&browsed, found))
-        .collect())
+        .collect();
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(out)
 }
 
 /// One curated set with per-member installed state.

--- a/crates/core/src/source/browse.rs
+++ b/crates/core/src/source/browse.rs
@@ -131,6 +131,17 @@ pub fn packages(env: &Env, catalog: &Catalog) -> Result<Vec<AvailablePackage>> {
     Ok(out)
 }
 
+/// Every curated set this catalog declares, each with per-member installed
+/// state. What the marketplace page's Bundles tab lists: the catalog's own
+/// declaration, so a set none of whose members are offered still appears.
+pub fn bundles(env: &Env, catalog: &Catalog) -> Result<Vec<BundleDetail>> {
+    let browsed = open(env, catalog)?;
+    Ok(super::bundles::offered(&browsed.sealed, &browsed.config)?
+        .iter()
+        .map(|found| detail(&browsed, found))
+        .collect())
+}
+
 /// One curated set with per-member installed state.
 pub fn bundle(env: &Env, catalog: &Catalog, bundle_name: &str) -> Result<BundleDetail> {
     let browsed = open(env, catalog)?;
@@ -140,6 +151,12 @@ pub fn bundle(env: &Env, catalog: &Catalog, bundle_name: &str) -> Result<BundleD
             source_name: catalog.label().to_owned(),
         });
     };
+    Ok(detail(&browsed, &found))
+}
+
+/// A declared set joined against this scope: every member's state, and the
+/// installed/total pair derived from them.
+fn detail(browsed: &Browsed, found: &super::bundles::CatalogBundle) -> BundleDetail {
     let mut members = Vec::new();
     for member in &found.members {
         // A member the catalog names but no longer carries is a row, not a
@@ -169,16 +186,16 @@ pub fn bundle(env: &Env, catalog: &Catalog, bundle_name: &str) -> Result<BundleD
         .iter()
         .filter(|member| member.state == InstallState::Installed)
         .count();
-    Ok(BundleDetail {
+    BundleDetail {
         name: names::shown(&found.name),
         description: found.description.as_deref().map(names::shown),
-        version: found.version,
-        category: found.category,
+        version: found.version.clone(),
+        category: found.category.clone(),
         installed_members: installed.min(u32::MAX as usize) as u32,
         total_members: members.len().min(u32::MAX as usize) as u32,
         members,
-        collision: browsed.bundle_collision(bundle_name),
-    })
+        collision: browsed.bundle_collision(&found.name),
+    }
 }
 
 /// The description, summary and tags an item writes in its own header, read

--- a/crates/core/src/source/browse/tests.rs
+++ b/crates/core/src/source/browse/tests.rs
@@ -259,6 +259,63 @@ fn bundle_detail_derives_partly_installed_and_full() {
     );
 }
 
+/// The Bundles tab lists what the catalog declares, not what its offered
+/// packages name. A set whose members the catalog no longer carries names
+/// nothing in the package list, so a derivation over package rows loses it
+/// entirely — the tab then says the marketplace offers no sets while its
+/// `kendex.toml` declares several.
+#[test]
+fn every_declared_set_is_listed_even_when_no_member_is_offered() {
+    let tmp = tempfile::tempdir().unwrap();
+    let catalog = tmp.path().join("catalog");
+    skill(&catalog, "skills", "gh", "body");
+    fs::write(
+        catalog.join("kendex.toml"),
+        "[bundles.starter]\ndescription = \"one real\"\nskills = [\"gh\"]\n\n[bundles.orphaned]\ndescription = \"all gone\"\nskills = [\"gone\"]\n",
+    )
+    .unwrap();
+    let (env, scope) = project(tmp.path(), &sources_decl(&catalog));
+
+    let offered = packages(&env, &cat(&scope)).unwrap();
+    let named: Vec<&str> = offered
+        .iter()
+        .flat_map(|package| package.bundles.iter().map(String::as_str))
+        .collect();
+    assert_eq!(
+        named,
+        vec!["starter"],
+        "package rows name only reachable sets"
+    );
+
+    let listed = bundles(&env, &cat(&scope)).unwrap();
+    let names: Vec<&str> = listed.iter().map(|set| set.name.as_str()).collect();
+    assert_eq!(names, vec!["orphaned", "starter"]);
+    let orphaned = &listed[0];
+    assert_eq!(orphaned.description.as_deref(), Some("all gone"));
+    assert_eq!(orphaned.total_members, 1);
+    assert_eq!(orphaned.installed_members, 0);
+    assert_eq!(orphaned.members[0].state, InstallState::NotOffered);
+}
+
+/// Listing every set joins each against this scope the same way opening one
+/// does — same members, same states, same counts.
+#[test]
+fn listing_sets_agrees_with_opening_one() {
+    let tmp = tempfile::tempdir().unwrap();
+    let catalog = tmp.path().join("catalog");
+    six_member_catalog(&catalog);
+    let manifest = format!(
+        "{}[bundles.starter]\nsource = \"cat\"\n",
+        sources_decl(&catalog)
+    );
+    let (env, scope) = project(tmp.path(), &manifest);
+    save_lock(&env, &scope, &SIX[..2]);
+
+    let listed = bundles(&env, &cat(&scope)).unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0], bundle(&env, &cat(&scope), "starter").unwrap());
+}
+
 /// A bundle member the catalog lists but does not carry — renamed or removed
 /// upstream — is one row saying so, never a dead page. Member lists are
 /// catalog-authored text; one bad entry cannot break the whole read.

--- a/crates/core/src/source/browse/tests.rs
+++ b/crates/core/src/source/browse/tests.rs
@@ -297,6 +297,29 @@ fn every_declared_set_is_listed_even_when_no_member_is_offered() {
     assert_eq!(orphaned.members[0].state, InstallState::NotOffered);
 }
 
+/// A plugin registry's sets come off a JSON list in file order, so the read
+/// is where one order is decided. Without the sort the cards appear in
+/// whatever order the catalog author happened to write.
+#[test]
+fn plugin_registry_sets_are_listed_alphabetically_not_in_file_order() {
+    let tmp = tempfile::tempdir().unwrap();
+    let catalog = tmp.path().join("catalog");
+    fs::create_dir_all(catalog.join(".claude-plugin")).unwrap();
+    fs::write(
+        catalog.join(".claude-plugin/marketplace.json"),
+        r#"{"name":"reg","owner":{"name":"o"},"plugins":[{"name":"zebra","source":"./plugins/zebra"},{"name":"alpha","source":"./plugins/alpha"},{"name":"middle","source":"./plugins/middle"}]}"#,
+    )
+    .unwrap();
+    for plugin in ["zebra", "alpha", "middle"] {
+        skill(&catalog, &format!("plugins/{plugin}/skills"), "eda", "body");
+    }
+    let (env, scope) = project(tmp.path(), &sources_decl(&catalog));
+
+    let listed = bundles(&env, &cat(&scope)).unwrap();
+    let names: Vec<&str> = listed.iter().map(|set| set.name.as_str()).collect();
+    assert_eq!(names, vec!["alpha", "middle", "zebra"]);
+}
+
 /// Listing every set joins each against this scope the same way opening one
 /// does — same members, same states, same counts.
 #[test]

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -241,6 +241,11 @@ export const commands = {
 	marketplaceSummary: (catalog: Catalog) => typedError<CatalogSummary, string>(__TAURI_INVOKE("marketplace_summary", { catalog })),
 	/**  One curated set with per-member installed state. */
 	marketplaceBundle: (catalog: Catalog, name: string) => typedError<BundleDetail, string>(__TAURI_INVOKE("marketplace_bundle", { catalog, name })),
+	/**
+	 *  Every curated set a catalog declares, with per-member installed state —
+	 *  what the marketplace page's Bundles tab lists.
+	 */
+	marketplaceBundles: (catalog: Catalog) => typedError<BundleDetail[], string>(__TAURI_INVOKE("marketplace_bundles", { catalog })),
 	marketplacePackagePreview: (catalog: Catalog, kind: ItemKind, name: string) => typedError<PackageView, string>(__TAURI_INVOKE("marketplace_package_preview", { catalog, kind, name })),
 	/**
 	 *  One offered file's content before install — the same read an installed

--- a/ui/src/components/marketplaces/bundle-cards.test.tsx
+++ b/ui/src/components/marketplaces/bundle-cards.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import type { BundleDetail, Catalog } from "@/bindings";
+import { mount } from "@/test/dom";
+import { BundleCards } from "./bundle-cards";
+
+const catalog: Catalog = {
+  by: "subscription",
+  scope: { scope: "global" },
+  source: "kit",
+};
+
+const set = (name: string, members: number): BundleDetail => ({
+  name,
+  description: `${name} description`,
+  version: null,
+  category: null,
+  members: Array.from({ length: members }, (_, i) => ({
+    kind: "skill" as const,
+    name: `${name}-${i}`,
+    state: "available" as const,
+  })),
+  installedMembers: 0,
+  totalMembers: members,
+  collision: null,
+});
+
+const text = (node: { textContent: string | null }): string =>
+  node.textContent ?? "";
+
+describe("the Bundles tab", () => {
+  // The bug: a pending read looked the same as a catalog with no sets, so
+  // the tab said the marketplace offers none while its read was still out.
+  it("says it is reading while the read is pending, never that there are none", () => {
+    const host = mount(
+      <BundleCards catalog={catalog} bundles={undefined} error={undefined} />,
+    );
+    expect(text(host)).toContain("Reading its curated sets");
+    expect(text(host)).not.toContain("doesn't offer curated sets");
+  });
+
+  it("shows the read error rather than an empty tab", () => {
+    const host = mount(
+      <BundleCards
+        catalog={catalog}
+        bundles={undefined}
+        error="fetch refused"
+      />,
+    );
+    expect(host.querySelector('[role="alert"]')).not.toBeNull();
+    expect(text(host)).toContain("fetch refused");
+    expect(text(host)).not.toContain("doesn't offer curated sets");
+  });
+
+  it("says the marketplace offers none only for a read that landed empty", () => {
+    const host = mount(
+      <BundleCards catalog={catalog} bundles={[]} error={undefined} />,
+    );
+    expect(text(host)).toContain("doesn't offer curated sets");
+  });
+
+  it("cards every declared set with its description and member counts", () => {
+    const host = mount(
+      <BundleCards
+        catalog={catalog}
+        bundles={[set("starter", 2), set("orphaned", 1)]}
+        error={undefined}
+      />,
+    );
+    const cards = [...host.querySelectorAll("button")].map((button) =>
+      text(button.closest("div.flex.h-full") ?? button),
+    );
+    expect(cards).toHaveLength(2);
+    expect(cards[0]).toContain("starter");
+    expect(cards[0]).toContain("starter description");
+    expect(cards[0]).toContain("2 skills");
+    expect(cards[1]).toContain("orphaned");
+    expect(cards[1]).toContain("1 skill");
+  });
+});

--- a/ui/src/components/marketplaces/bundle-cards.test.tsx
+++ b/ui/src/components/marketplaces/bundle-cards.test.tsx
@@ -10,7 +10,7 @@ const catalog: Catalog = {
   source: "kit",
 };
 
-const set = (name: string, members: number): BundleDetail => ({
+const set = (name: string, members: number, installed = 0): BundleDetail => ({
   name,
   description: `${name} description`,
   version: null,
@@ -18,9 +18,9 @@ const set = (name: string, members: number): BundleDetail => ({
   members: Array.from({ length: members }, (_, i) => ({
     kind: "skill" as const,
     name: `${name}-${i}`,
-    state: "available" as const,
+    state: i < installed ? ("installed" as const) : ("available" as const),
   })),
-  installedMembers: 0,
+  installedMembers: installed,
   totalMembers: members,
   collision: null,
 });
@@ -57,6 +57,23 @@ describe("the Bundles tab", () => {
       <BundleCards catalog={catalog} bundles={[]} error={undefined} />,
     );
     expect(text(host)).toContain("doesn't offer curated sets");
+  });
+
+  // The badge is the only thing on a card that says how much of a set is
+  // already here, and it has three answers, not one.
+  it("badges a set by how much of it is installed", () => {
+    const host = mount(
+      <BundleCards
+        catalog={catalog}
+        bundles={[set("whole", 3, 3), set("some", 3, 1), set("none", 3, 0)]}
+        error={undefined}
+      />,
+    );
+    const badges = [...host.querySelectorAll("button")].map(
+      (button) =>
+        button.parentElement?.querySelector("span")?.textContent ?? "",
+    );
+    expect(badges).toEqual(["Installed", "Partly installed (1 of 3)", ""]);
   });
 
   it("cards every declared set with its description and member counts", () => {

--- a/ui/src/components/marketplaces/bundle-cards.tsx
+++ b/ui/src/components/marketplaces/bundle-cards.tsx
@@ -1,39 +1,42 @@
 import { Package } from "lucide-react";
-import { useEffect, useMemo } from "react";
-import type { AvailablePackage, Catalog, ItemKind } from "@/bindings";
+import type { BundleDetail, Catalog, ItemKind } from "@/bindings";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { kindLabel } from "@/lib/labels";
-import { bundleKey, useMarketplacesStore } from "@/stores/marketplaces";
 import { useNavStore } from "@/stores/nav";
 
 /** The curated sets one marketplace offers, as cards: what each carries and
- * how much of it is already here. The names come off the offered packages —
- * every member names its sets — and each card's counts come from its own
- * bundle read. */
+ * how much of it is already here. The sets are the catalog's own
+ * declaration, so one whose members are not themselves offered still gets a
+ * card, and "offers none" is only ever said about a read that landed. */
 export function BundleCards({
   catalog,
-  offered,
+  bundles,
+  error,
 }: {
   catalog: Catalog;
-  offered: AvailablePackage[];
+  bundles: BundleDetail[] | undefined;
+  error: string | undefined;
 }) {
-  const bundles = useMarketplacesStore((s) => s.bundles);
-  const loadBundle = useMarketplacesStore((s) => s.loadBundle);
   const goToBundle = useNavStore((s) => s.goToBundle);
 
-  const names = useMemo(
-    () => [...new Set(offered.flatMap((pkg) => pkg.bundles))].sort(),
-    [offered],
-  );
+  if (error) {
+    return (
+      <p className="py-16 text-center text-sm text-critical" role="alert">
+        Its curated sets can't be read right now — {error}
+      </p>
+    );
+  }
 
-  useEffect(() => {
-    for (const name of names) {
-      void loadBundle(catalog, name);
-    }
-  }, [names, catalog, loadBundle]);
+  if (!bundles) {
+    return (
+      <p className="py-16 text-center text-sm text-muted-foreground">
+        Reading its curated sets…
+      </p>
+    );
+  }
 
-  if (names.length === 0) {
+  if (bundles.length === 0) {
     return (
       <p className="py-16 text-center text-sm text-muted-foreground">
         This marketplace doesn't offer curated sets — its packages install one
@@ -44,37 +47,37 @@ export function BundleCards({
 
   return (
     <div className="grid grid-cols-[repeat(auto-fill,minmax(18rem,1fr))] gap-4">
-      {names.map((name) => {
-        const detail = bundles[bundleKey(catalog, name)];
-        const state = !detail
-          ? null
-          : detail.installedMembers === detail.totalMembers &&
-              detail.totalMembers > 0
+      {bundles.map((detail) => {
+        const state =
+          detail.installedMembers === detail.totalMembers &&
+          detail.totalMembers > 0
             ? "Installed"
             : detail.installedMembers > 0
               ? `Partly installed (${detail.installedMembers} of ${detail.totalMembers})`
               : null;
         return (
-          <Card key={name}>
+          <Card key={detail.name}>
             <CardContent className="flex h-full flex-col gap-2 p-4">
               <div className="flex items-center gap-2">
                 <Package className="size-4 shrink-0 text-muted-foreground" />
-                <span className="min-w-0 truncate font-medium">{name}</span>
+                <span className="min-w-0 truncate font-medium">
+                  {detail.name}
+                </span>
               </div>
-              {detail?.description ? (
+              {detail.description ? (
                 <p className="line-clamp-2 text-xs text-muted-foreground">
                   {detail.description}
                 </p>
               ) : null}
               <p className="text-xs text-muted-foreground">
-                {detail ? memberSummary(detail.members) : "…"}
+                {memberSummary(detail.members)}
               </p>
               <div className="mt-auto flex items-center justify-between pt-1">
                 <span className="text-xs text-muted-foreground">{state}</span>
                 <Button
                   size="sm"
                   variant="outline"
-                  onClick={() => goToBundle({ catalog, bundle: name })}
+                  onClick={() => goToBundle({ catalog, bundle: detail.name })}
                 >
                   Open
                 </Button>

--- a/ui/src/pages/marketplace-detail.dom.test.tsx
+++ b/ui/src/pages/marketplace-detail.dom.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+// The Bundles tab's read is wiring, not a prop: the page has to ask for the
+// catalog's declared sets and put what comes back on screen. Prop-driven
+// tests of the cards cannot see that the ask was made at all.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BundleDetail } from "@/bindings";
+import { commands } from "@/bindings";
+import { useMarketplacesStore } from "@/stores/marketplaces";
+import { subscription } from "@/stores/marketplaces-shared";
+import { useNavStore } from "@/stores/nav";
+import { mount, settle } from "@/test/dom";
+import { MarketplaceDetailPage } from "./marketplace-detail";
+
+vi.mock("@/bindings", () => ({
+  commands: {
+    marketplacesOverview: vi.fn(),
+    marketplacePackages: vi.fn(),
+    marketplaceBundles: vi.fn(),
+  },
+}));
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+const catalog = subscription({ scope: "global" }, "kit");
+
+const starter: BundleDetail = {
+  name: "starter",
+  description: "the six things to begin with",
+  version: null,
+  category: null,
+  members: [{ kind: "skill", name: "gh", state: "available" }],
+  installedMembers: 0,
+  totalMembers: 1,
+  collision: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(commands.marketplacesOverview).mockResolvedValue({
+    status: "ok",
+    data: [],
+  });
+  vi.mocked(commands.marketplacePackages).mockResolvedValue({
+    status: "ok",
+    data: [],
+  });
+  vi.mocked(commands.marketplaceBundles).mockResolvedValue({
+    status: "ok",
+    data: [starter],
+  });
+  useMarketplacesStore.setState({
+    rows: [],
+    packages: {},
+    bundles: {},
+    catalogBundles: {},
+    summaries: {},
+    readErrors: {},
+  });
+  useNavStore.setState({ marketplaceRef: catalog });
+});
+
+describe("opening a marketplace", () => {
+  it("asks for the catalog's declared sets and shows them in the Bundles tab", async () => {
+    const host = mount(<MarketplaceDetailPage />);
+    await settle();
+
+    expect(commands.marketplaceBundles).toHaveBeenCalledWith(catalog);
+    expect(host.textContent).toContain("starter");
+    expect(host.textContent).toContain("the six things to begin with");
+    expect(host.textContent).not.toContain("doesn't offer curated sets");
+  });
+
+  it("shows the read's own error when the catalog's sets cannot be read", async () => {
+    vi.mocked(commands.marketplaceBundles).mockResolvedValue({
+      status: "error",
+      error: "the catalog is unreadable",
+    });
+
+    const host = mount(<MarketplaceDetailPage />);
+    await settle();
+
+    expect(host.textContent).toContain("the catalog is unreadable");
+    expect(host.textContent).not.toContain("doesn't offer curated sets");
+  });
+});

--- a/ui/src/pages/marketplace-detail.tsx
+++ b/ui/src/pages/marketplace-detail.tsx
@@ -13,6 +13,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PAGE_BODY, PAGE_GUTTER, WIDE_CONTENT_WIDTH } from "@/lib/layout";
 import { cn } from "@/lib/utils";
 import {
+  catalogBundlesErrorKey,
   catalogKey,
   marketKey,
   readErrorKey,
@@ -55,7 +56,7 @@ function MarketplaceDetail({ requested }: { requested: Catalog }) {
     (s) => s.catalogBundles[catalogKey(catalog)],
   );
   const bundlesError = useMarketplacesStore(
-    (s) => s.readErrors[readErrorKey(catalogKey(catalog), "bundles")],
+    (s) => s.readErrors[catalogBundlesErrorKey(catalog)],
   );
 
   useEffect(() => {

--- a/ui/src/pages/marketplace-detail.tsx
+++ b/ui/src/pages/marketplace-detail.tsx
@@ -36,6 +36,7 @@ function MarketplaceDetail({ requested }: { requested: Catalog }) {
   const packages = useMarketplacesStore((s) => s.packages);
   const load = useMarketplacesStore((s) => s.load);
   const loadPackages = useMarketplacesStore((s) => s.loadPackages);
+  const loadCatalogBundles = useMarketplacesStore((s) => s.loadCatalogBundles);
 
   const row =
     catalog.by === "subscription"
@@ -50,6 +51,12 @@ function MarketplaceDetail({ requested }: { requested: Catalog }) {
   const packagesError = useMarketplacesStore(
     (s) => s.readErrors[readErrorKey(catalogKey(catalog), "packages")],
   );
+  const bundles = useMarketplacesStore(
+    (s) => s.catalogBundles[catalogKey(catalog)],
+  );
+  const bundlesError = useMarketplacesStore(
+    (s) => s.readErrors[readErrorKey(catalogKey(catalog), "bundles")],
+  );
 
   useEffect(() => {
     void load();
@@ -59,6 +66,11 @@ function MarketplaceDetail({ requested }: { requested: Catalog }) {
     [loadPackages, catalog],
   );
   useCachedRead(cached !== undefined, !!packagesError, ready, readPackages);
+  const readBundles = useCallback(
+    () => loadCatalogBundles(catalog),
+    [loadCatalogBundles, catalog],
+  );
+  useCachedRead(bundles !== undefined, !!bundlesError, ready, readBundles);
 
   return (
     <div className="flex h-full flex-col">
@@ -111,7 +123,11 @@ function MarketplaceDetail({ requested }: { requested: Catalog }) {
                   </p>
                 ) : null}
                 <TabsContent value="bundles">
-                  <BundleCards catalog={catalog} offered={offered} />
+                  <BundleCards
+                    catalog={catalog}
+                    bundles={bundles}
+                    error={bundlesError}
+                  />
                 </TabsContent>
                 <TabsContent value="packages">
                   {packagesError ? (

--- a/ui/src/stores/marketplaces-catalog-reads.ts
+++ b/ui/src/stores/marketplaces-catalog-reads.ts
@@ -1,34 +1,19 @@
 // The marketplaces store's cached reads: each answer lands under its own
 // key, and each failure under its own error key, so a later success
 // elsewhere never erases why a different read produced nothing.
-import {
-  type AboutView,
-  type AvailablePackage,
-  type BundleDetail,
-  type Catalog,
-  type CatalogSummary,
-  commands,
-} from "@/bindings";
+import { type Catalog, commands } from "@/bindings";
 import { settled } from "@/lib/settled";
 import {
   bundleKey,
+  type CatalogCaches,
+  catalogBundlesErrorKey,
   catalogDrops,
   catalogKey,
   readErrorKey,
   without,
 } from "./marketplaces-shared";
 
-/** The slice of the store these reads write. */
-interface ReadCaches {
-  packages: Record<string, AvailablePackage[]>;
-  summaries: Record<string, CatalogSummary>;
-  about: Record<string, AboutView>;
-  bundles: Record<string, BundleDetail>;
-  catalogBundles: Record<string, BundleDetail[]>;
-  readErrors: Record<string, string>;
-}
-
-type SetReads = (fn: (state: ReadCaches) => Partial<ReadCaches>) => void;
+type SetReads = (fn: (state: CatalogCaches) => Partial<CatalogCaches>) => void;
 
 export function catalogReads(set: SetReads) {
   return {
@@ -51,12 +36,11 @@ export function catalogReads(set: SetReads) {
       );
     },
     loadCatalogBundles: (catalog: Catalog) => {
-      const key = catalogKey(catalog);
       return settle(
         set,
         "catalogBundles",
-        key,
-        readErrorKey(key, "bundles"),
+        catalogKey(catalog),
+        catalogBundlesErrorKey(catalog),
         () => commands.marketplaceBundles(catalog),
       );
     },
@@ -77,13 +61,13 @@ export function catalogReads(set: SetReads) {
  * retry it. The read is asked once more under the new generation rather than
  * only discarded: the slot the drop emptied has no other asker, and every
  * consumer keys on presence, so discarding alone leaves the page blank. */
-async function settle<F extends Exclude<keyof ReadCaches, "readErrors">>(
+async function settle<F extends Exclude<keyof CatalogCaches, "readErrors">>(
   set: SetReads,
   field: F,
   key: string,
   errorKey: string,
   read: () => Promise<
-    | { status: "ok"; data: ReadCaches[F][string] }
+    | { status: "ok"; data: CatalogCaches[F][string] }
     | { status: "error"; error: string }
   >,
 ): Promise<void> {

--- a/ui/src/stores/marketplaces-catalog-reads.ts
+++ b/ui/src/stores/marketplaces-catalog-reads.ts
@@ -24,6 +24,7 @@ interface ReadCaches {
   summaries: Record<string, CatalogSummary>;
   about: Record<string, AboutView>;
   bundles: Record<string, BundleDetail>;
+  catalogBundles: Record<string, BundleDetail[]>;
   readErrors: Record<string, string>;
 }
 
@@ -47,6 +48,16 @@ export function catalogReads(set: SetReads) {
       const key = catalogKey(catalog);
       return settle(set, "about", key, readErrorKey(key, "about"), () =>
         commands.marketplaceAbout(catalog),
+      );
+    },
+    loadCatalogBundles: (catalog: Catalog) => {
+      const key = catalogKey(catalog);
+      return settle(
+        set,
+        "catalogBundles",
+        key,
+        readErrorKey(key, "bundles"),
+        () => commands.marketplaceBundles(catalog),
       );
     },
     loadBundle: (catalog: Catalog, name: string) => {

--- a/ui/src/stores/marketplaces-install.test.ts
+++ b/ui/src/stores/marketplaces-install.test.ts
@@ -13,11 +13,14 @@ import {
   repoEffectsWithheldToast,
 } from "@/lib/copy-repo-effects";
 import { useMarketplacesStore } from "./marketplaces";
+import { catalogKey, subscription } from "./marketplaces-shared";
+import { usePreinstallSafety } from "./preinstall-safety";
 import { useProblemsStore } from "./problems";
 
 vi.mock("@/bindings", () => ({
   commands: {
     marketplaceInstall: vi.fn(),
+    marketplaceBundles: vi.fn(),
     repoEffectsApply: vi.fn(),
   },
 }));
@@ -52,6 +55,18 @@ const disclosure = (name: string): Disclosure => ({
   notes: [],
   undo: null,
 });
+
+const declared = (name: string) =>
+  ({
+    name,
+    description: null,
+    version: null,
+    category: null,
+    members: [],
+    installedMembers: 0,
+    totalMembers: 0,
+    collision: null,
+  }) as never;
 
 const installed = (shown: Disclosure[], withheld = []) => ({
   status: "ok" as const,
@@ -108,6 +123,49 @@ describe("what an install leaves waiting", () => {
 // behind is worse than an empty one: nothing re-reads a slot that is
 // present, so the tab shows pre-install counts for the rest of the session.
 describe("what an install invalidates", () => {
+  // Emptying the slot is only half of it. The answer from a read already in
+  // flight still arrives, and the only thing that can refuse it is the
+  // generation the drop bumps — without that it fills the slot the install
+  // just emptied and presence-based readDue never asks again, so the tab
+  // shows pre-install counts for the rest of the session.
+  it("refuses a curated-sets read that was in flight when it landed", async () => {
+    vi.mocked(commands.marketplaceInstall).mockResolvedValue(installed([]));
+    const catalog = subscription({ scope: "global" }, "cat");
+    const key = catalogKey(catalog);
+    let settleOld: (value: unknown) => void = () => {};
+    vi.mocked(commands.marketplaceBundles)
+      .mockImplementationOnce(
+        () => new Promise((resolve) => (settleOld = resolve)) as never,
+      )
+      .mockResolvedValueOnce({
+        status: "ok",
+        data: [declared("after-install")],
+      });
+
+    const reading = useMarketplacesStore.getState().loadCatalogBundles(catalog);
+    await install();
+    settleOld({ status: "ok", data: [declared("before-install")] });
+    await reading;
+
+    expect(commands.marketplaceBundles).toHaveBeenCalledTimes(2);
+    expect(useMarketplacesStore.getState().catalogBundles[key]?.[0]?.name).toBe(
+      "after-install",
+    );
+  });
+
+  // The bump that refuses the in-flight read also discards a pre-install
+  // scan in flight, and the only thing that clears the `queued` mark such a
+  // discard leaves is this reset. Left out, the row's score is never asked
+  // for again and it reads "Checking…" for the session.
+  it("clears the pre-install scores that hang off the same drop", async () => {
+    vi.mocked(commands.marketplaceInstall).mockResolvedValue(installed([]));
+    usePreinstallSafety.setState({ scores: { "any::gh": "clean" as never } });
+
+    await install();
+
+    expect(usePreinstallSafety.getState().scores).toEqual({});
+  });
+
   it("empties both curated-set caches so the counts are read again", async () => {
     vi.mocked(commands.marketplaceInstall).mockResolvedValue(installed([]));
     useMarketplacesStore.setState({

--- a/ui/src/stores/marketplaces-install.test.ts
+++ b/ui/src/stores/marketplaces-install.test.ts
@@ -103,6 +103,26 @@ describe("what an install leaves waiting", () => {
   });
 });
 
+// Both set caches carry the same per-member InstallState and the counts
+// derived from it, so an install moves what both of them say. A list left
+// behind is worse than an empty one: nothing re-reads a slot that is
+// present, so the tab shows pre-install counts for the rest of the session.
+describe("what an install invalidates", () => {
+  it("empties both curated-set caches so the counts are read again", async () => {
+    vi.mocked(commands.marketplaceInstall).mockResolvedValue(installed([]));
+    useMarketplacesStore.setState({
+      bundles: { "any::starter": { name: "starter" } as never },
+      catalogBundles: { any: [{ name: "starter" } as never] },
+    });
+
+    await install();
+
+    const state = useMarketplacesStore.getState();
+    expect(state.bundles).toEqual({});
+    expect(state.catalogBundles).toEqual({});
+  });
+});
+
 describe("answering", () => {
   beforeEach(() => {
     // The dialog is module state: a case that asserts none opened has to

--- a/ui/src/stores/marketplaces-install.ts
+++ b/ui/src/stores/marketplaces-install.ts
@@ -20,7 +20,11 @@ import {
 } from "@/lib/copy-repo-effects";
 import { rescanEverything } from "@/lib/rescan";
 import { sayUndone } from "@/lib/undone";
-import { catalogKey, setCaches, subscription } from "./marketplaces-shared";
+import {
+  catalogKey,
+  droppedSetCaches,
+  subscription,
+} from "./marketplaces-shared";
 import { useProblemsStore } from "./problems";
 
 /** One install: what to put where, and — when the picker was used — which
@@ -125,7 +129,7 @@ export function installActions(set: Set, get: Get): InstallActions {
         packages: { ...state.packages, [key]: response.data.packages },
         // Member states in every set this install touched moved with it,
         // in the open set and in the list of sets alike.
-        ...setCaches(),
+        ...droppedSetCaches(),
         error: null,
         // The files are in; what a package does to the repository is a
         // second question, asked once the install is reported.

--- a/ui/src/stores/marketplaces-install.ts
+++ b/ui/src/stores/marketplaces-install.ts
@@ -20,7 +20,7 @@ import {
 } from "@/lib/copy-repo-effects";
 import { rescanEverything } from "@/lib/rescan";
 import { sayUndone } from "@/lib/undone";
-import { catalogKey, subscription } from "./marketplaces-shared";
+import { catalogKey, setCaches, subscription } from "./marketplaces-shared";
 import { useProblemsStore } from "./problems";
 
 /** One install: what to put where, and — when the picker was used — which
@@ -123,8 +123,9 @@ export function installActions(set: Set, get: Get): InstallActions {
       const { shown, withheld } = response.data.repoEffects;
       set((state) => ({
         packages: { ...state.packages, [key]: response.data.packages },
-        // Member states in every open set moved with this install.
-        bundles: {},
+        // Member states in every set this install touched moved with it,
+        // in the open set and in the list of sets alike.
+        ...setCaches(),
         error: null,
         // The files are in; what a package does to the repository is a
         // second question, asked once the install is reported.

--- a/ui/src/stores/marketplaces-reads.test.ts
+++ b/ui/src/stores/marketplaces-reads.test.ts
@@ -9,7 +9,7 @@ import {
 } from "./marketplaces-shared";
 
 vi.mock("@/bindings", () => ({
-  commands: { marketplacePackages: vi.fn() },
+  commands: { marketplacePackages: vi.fn(), marketplaceBundles: vi.fn() },
 }));
 vi.mock("sonner", () => ({
   toast: { success: vi.fn(), message: vi.fn(), error: vi.fn() },
@@ -80,6 +80,87 @@ describe("a read that outlives a cache drop", () => {
 
     expect(commands.marketplacePackages).toHaveBeenCalledTimes(2);
     expect(useMarketplacesStore.getState().packages[key]?.[0]?.name).toBe(
+      "after-refresh",
+    );
+  });
+});
+
+const declared = (name: string) => [
+  {
+    name,
+    description: null,
+    version: null,
+    category: null,
+    members: [],
+    installedMembers: 0,
+    totalMembers: 0,
+    collision: null,
+  },
+];
+
+// The page reads the reason under readErrorKey(catalogKey, "bundles"). The
+// store has to fail under that same key, or a failed read renders the
+// pending line for the life of the session with no way to retry.
+describe("a curated-sets read the bridge could not make", () => {
+  beforeEach(() => {
+    useMarketplacesStore.setState({ catalogBundles: {}, readErrors: {} });
+    vi.mocked(commands.marketplaceBundles).mockReset();
+  });
+
+  it("leaves the reason under the key the page subscribes to", async () => {
+    vi.mocked(commands.marketplaceBundles).mockRejectedValue(
+      new Error("the bridge is gone"),
+    );
+
+    await expect(
+      useMarketplacesStore.getState().loadCatalogBundles(catalog),
+    ).resolves.toBeUndefined();
+
+    const state = useMarketplacesStore.getState();
+    expect(state.readErrors[readErrorKey(key, "bundles")]).toBe(
+      "the bridge is gone",
+    );
+    expect(state.catalogBundles[key]).toBeUndefined();
+  });
+});
+
+// A check-for-updates or a changed source can change which sets a catalog
+// declares, so the list goes with every other derived cache. Left behind, it
+// would show one marketplace's sets under another.
+describe("the catalog's curated sets across a cache drop", () => {
+  beforeEach(() => {
+    useMarketplacesStore.setState({ catalogBundles: {}, readErrors: {} });
+    vi.mocked(commands.marketplaceBundles).mockReset();
+  });
+
+  it("is emptied by the drop", () => {
+    useMarketplacesStore.setState({
+      catalogBundles: { [key]: declared("before-refresh") },
+    });
+
+    dropCatalogCaches((partial) => useMarketplacesStore.setState(partial));
+
+    expect(useMarketplacesStore.getState().catalogBundles).toEqual({});
+  });
+
+  it("does not store a read that outlived the drop, and asks again", async () => {
+    let settleOld: (value: unknown) => void = () => {};
+    vi.mocked(commands.marketplaceBundles)
+      .mockImplementationOnce(
+        () => new Promise((resolve) => (settleOld = resolve)) as never,
+      )
+      .mockResolvedValueOnce({
+        status: "ok",
+        data: declared("after-refresh"),
+      });
+
+    const pending = useMarketplacesStore.getState().loadCatalogBundles(catalog);
+    dropCatalogCaches((partial) => useMarketplacesStore.setState(partial));
+    settleOld({ status: "ok", data: declared("old-checkout") });
+    await pending;
+
+    expect(commands.marketplaceBundles).toHaveBeenCalledTimes(2);
+    expect(useMarketplacesStore.getState().catalogBundles[key]?.[0]?.name).toBe(
       "after-refresh",
     );
   });

--- a/ui/src/stores/marketplaces-shared.ts
+++ b/ui/src/stores/marketplaces-shared.ts
@@ -1,16 +1,47 @@
 // The cache vocabulary the marketplaces store and its readers share: the
 // collision-free subscription key, and the invalidation every catalog-moving
 // mutation runs.
-import type { Catalog, MarketplaceRow, Scope } from "@/bindings";
+import type {
+  AboutView,
+  AvailablePackage,
+  BundleDetail,
+  Catalog,
+  CatalogSummary,
+  MarketplaceRow,
+  Scope,
+} from "@/bindings";
 import { invalidations, type ReadState } from "@/lib/read-state";
 import { resetPreinstallSafety } from "./preinstall-safety";
 
-/** Bumped once by [dropCatalogCaches], the one place a drop is declared. A
- * read that began before one describes a checkout that may no longer be the
- * one installed from, and every derived cache keys on presence rather than
- * freshness — a stale answer landing in the emptied slot would pin the
- * commit before the change for the session, with nothing left to ask
- * again. Shared with the pre-install scores, which the same drop clears. */
+/** Every cached catalog read the store holds, declared once here so the
+ * store, the reads that fill it and the drops that empty it cannot disagree
+ * about a field name — a rename lands on all three or on none. */
+export interface CatalogCaches {
+  /** Each opened catalog's offered packages, by [catalogKey]. */
+  packages: Record<string, AvailablePackage[]>;
+  /** Each opened catalog's About report, by [catalogKey]. */
+  about: Record<string, AboutView>;
+  /** Each opened catalog's own account of itself, by [catalogKey] — for a
+   * repository this is the read that fetches it. */
+  summaries: Record<string, CatalogSummary>;
+  /** Each opened curated set, by [bundleKey]. */
+  bundles: Record<string, BundleDetail>;
+  /** Each opened catalog's declared curated sets, by [catalogKey] — what the
+   * Bundles tab lists, straight from the catalog rather than derived from
+   * the packages it offers. */
+  catalogBundles: Record<string, BundleDetail[]>;
+  /** Why a read produced nothing, by the same keys — the page the person is
+   * looking at says it instead of loading forever. */
+  readErrors: Record<string, string>;
+}
+
+/** Bumped once by [droppedSetCaches] and [dropCatalogCaches], the only two
+ * places a drop is declared. A read that began before one describes a
+ * checkout that may no longer be the one installed from, and every derived
+ * cache keys on presence rather than freshness — a stale answer landing in
+ * the emptied slot would pin the commit before the change for the session,
+ * with nothing left to ask again. Shared with the pre-install scores, which
+ * the same drop clears. */
 export const catalogDrops = invalidations();
 
 /** One subscription's cache key: where it lives plus its alias, encoded so
@@ -83,31 +114,44 @@ export function without<T>(
   return rest;
 }
 
-/** Every cache carrying a curated set's member states: the opened set and
- * the list of sets a catalog declares, both holding the same per-member
+/** Both caches carrying a curated set's member states, emptied — the opened
+ * set and the list of sets a catalog declares, holding the same per-member
  * `InstallState` and the counts derived from it. An install moves those
- * states, so the two are emptied together — one of them left behind is a
- * card confidently showing the count from before the install, with no
- * empty slot to make the page ask again. */
-export const setCaches = (): { bundles: object; catalogBundles: object } => ({
-  bundles: {},
-  catalogBundles: {},
-});
+ * states, so the two go together: one left behind is a card confidently
+ * showing the count from before the install.
+ *
+ * Declaring the drop is half of this act, not a separate one a caller can
+ * forget. Emptying a slot only makes the page ask again; a read already in
+ * flight still lands, and `settle` refuses it solely on the generation this
+ * bumps. Without that, the answer from before the install fills the slot
+ * that was just emptied and presence-based `readDue` never asks again. So
+ * the empty caches are only reachable through this call, and the
+ * invalidation comes with them. */
+export const droppedSetCaches = (): Pick<
+  CatalogCaches,
+  "bundles" | "catalogBundles"
+> => {
+  catalogDrops.moved();
+  // Everything keyed to that generation goes with the bump. A pre-install
+  // scan in flight is discarded on it, and only this reset clears the
+  // `queued` mark the discard leaves behind — without it the row's score is
+  // never asked for again and it reads "Checking…" for the session.
+  resetPreinstallSafety();
+  return { bundles: {}, catalogBundles: {} };
+};
 
 /** A mutation that can change what any catalog offers empties every derived
  * cache — the pages re-read, and pre-install scores are re-asked, so nothing
  * keeps describing the commit before the change. Summaries go with them: a
  * summary says which subscription a page carries on as, and a mutation is
  * exactly what changes that answer. */
-export function dropCatalogCaches(set: (partial: object) => void) {
-  // Before anything is emptied, and once for the whole drop: this is where
-  // the invalidation is declared, so it cannot be stubbed out from under
-  // the caches it guards.
-  catalogDrops.moved();
-  resetPreinstallSafety();
+export function dropCatalogCaches(set: (partial: CatalogCaches) => void) {
   set({
     packages: {},
-    ...setCaches(),
+    // Declares the invalidation for the whole drop, and clears what else
+    // hangs off it, before anything is emptied: the object is built before
+    // `set` is called.
+    ...droppedSetCaches(),
     about: {},
     summaries: {},
     readErrors: {},
@@ -118,6 +162,14 @@ export function dropCatalogCaches(set: (partial: object) => void) {
  * reads of the same catalog so a later success elsewhere never erases it. */
 export const readErrorKey = (key: string, read: string): string =>
   `${key}::${read}`;
+
+/** The key a failed catalog-level curated-set read lands under. One
+ * function for the read that writes it and the page that subscribes to it,
+ * the way [bundleKey] already serves the per-name set: spelled twice, the
+ * two ends drift and the page loads forever with the reason under a key
+ * nothing reads. */
+export const catalogBundlesErrorKey = (catalog: Catalog): string =>
+  readErrorKey(catalogKey(catalog), "bundles");
 
 /** A tree or skills.sh URL was pointing at one package; land on it so
  * Install is the next click, with its safety score in view. */

--- a/ui/src/stores/marketplaces-shared.ts
+++ b/ui/src/stores/marketplaces-shared.ts
@@ -83,6 +83,17 @@ export function without<T>(
   return rest;
 }
 
+/** Every cache carrying a curated set's member states: the opened set and
+ * the list of sets a catalog declares, both holding the same per-member
+ * `InstallState` and the counts derived from it. An install moves those
+ * states, so the two are emptied together — one of them left behind is a
+ * card confidently showing the count from before the install, with no
+ * empty slot to make the page ask again. */
+export const setCaches = (): { bundles: object; catalogBundles: object } => ({
+  bundles: {},
+  catalogBundles: {},
+});
+
 /** A mutation that can change what any catalog offers empties every derived
  * cache — the pages re-read, and pre-install scores are re-asked, so nothing
  * keeps describing the commit before the change. Summaries go with them: a
@@ -96,8 +107,7 @@ export function dropCatalogCaches(set: (partial: object) => void) {
   resetPreinstallSafety();
   set({
     packages: {},
-    bundles: {},
-    catalogBundles: {},
+    ...setCaches(),
     about: {},
     summaries: {},
     readErrors: {},

--- a/ui/src/stores/marketplaces-shared.ts
+++ b/ui/src/stores/marketplaces-shared.ts
@@ -97,6 +97,7 @@ export function dropCatalogCaches(set: (partial: object) => void) {
   set({
     packages: {},
     bundles: {},
+    catalogBundles: {},
     about: {},
     summaries: {},
     readErrors: {},

--- a/ui/src/stores/marketplaces.ts
+++ b/ui/src/stores/marketplaces.ts
@@ -48,6 +48,10 @@ interface MarketplacesState extends InstallActions {
   summaries: Record<string, CatalogSummary>;
   /** Each opened curated set, by [catalogKey]::bundle. */
   bundles: Record<string, BundleDetail>;
+  /** Each opened catalog's declared curated sets, by [catalogKey] — what the
+   * Bundles tab lists, straight from the catalog rather than derived from
+   * the packages it offers. */
+  catalogBundles: Record<string, BundleDetail[]>;
   /** Why a read produced nothing, by the same keys — the page the person is
    * looking at says it instead of loading forever. */
   readErrors: Record<string, string>;
@@ -64,6 +68,7 @@ interface MarketplacesState extends InstallActions {
   loadSummary: (catalog: Catalog) => Promise<void>;
   loadAbout: (catalog: Catalog) => Promise<void>;
   loadBundle: (catalog: Catalog, name: string) => Promise<void>;
+  loadCatalogBundles: (catalog: Catalog) => Promise<void>;
   subscribe: (
     scope: Scope,
     reference: string,
@@ -91,6 +96,7 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
   about: {},
   summaries: {},
   bundles: {},
+  catalogBundles: {},
   readErrors: {},
   read: READ_PENDING,
   busy: false,

--- a/ui/src/stores/marketplaces.ts
+++ b/ui/src/stores/marketplaces.ts
@@ -1,11 +1,7 @@
 import { toast } from "sonner";
 import { create } from "zustand";
 import {
-  type AboutView,
-  type AvailablePackage,
-  type BundleDetail,
   type Catalog,
-  type CatalogSummary,
   commands,
   type MarketplaceRow,
   type Scope,
@@ -21,11 +17,16 @@ import { settled } from "@/lib/settled";
 import { saying, sayUndone } from "@/lib/undone";
 import { catalogReads } from "./marketplaces-catalog-reads";
 import { type InstallActions, installActions } from "./marketplaces-install";
-import { dropCatalogCaches, openLead } from "./marketplaces-shared";
+import {
+  type CatalogCaches,
+  dropCatalogCaches,
+  openLead,
+} from "./marketplaces-shared";
 import { sourceActions } from "./marketplaces-sources";
 
 export {
   bundleKey,
+  catalogBundlesErrorKey,
   catalogKey,
   catalogLabel,
   declaredHolder,
@@ -37,24 +38,10 @@ export {
   subscription,
 } from "./marketplaces-shared";
 
-interface MarketplacesState extends InstallActions {
+// The cached reads come from [CatalogCaches], declared once beside the drop
+// that empties them so a field cannot be renamed here alone.
+interface MarketplacesState extends InstallActions, CatalogCaches {
   rows: MarketplaceRow[];
-  /** Each opened catalog's offered packages, by [catalogKey]. */
-  packages: Record<string, AvailablePackage[]>;
-  /** Each opened catalog's About report, by [catalogKey]. */
-  about: Record<string, AboutView>;
-  /** Each opened catalog's own account of itself, by [catalogKey] — for a
-   * repository this is the read that fetches it. */
-  summaries: Record<string, CatalogSummary>;
-  /** Each opened curated set, by [catalogKey]::bundle. */
-  bundles: Record<string, BundleDetail>;
-  /** Each opened catalog's declared curated sets, by [catalogKey] — what the
-   * Bundles tab lists, straight from the catalog rather than derived from
-   * the packages it offers. */
-  catalogBundles: Record<string, BundleDetail[]>;
-  /** Why a read produced nothing, by the same keys — the page the person is
-   * looking at says it instead of loading forever. */
-  readErrors: Record<string, string>;
   /** How the last overview read went. A failed read leaves the rows it had,
    * and nothing may treat them as the truth about what is subscribed until
    * one lands again. Kept apart from `error` below, which

--- a/ui/src/stores/preinstall-safety.ts
+++ b/ui/src/stores/preinstall-safety.ts
@@ -35,7 +35,7 @@ const queue: QueueItem[] = [];
 const queued = new Set<string>();
 let draining = false;
 
-/** Empty the cache and the queue — half of [dropCatalogCaches], which is
+/** Empty the cache and the queue — half of [droppedSetCaches], which is
  * where a drop is declared and where the one [catalogDrops] bump is taken.
  * Call that rather than this: a scan already in flight would otherwise land
  * in the slot this just emptied, and `want` short-circuits on a stored


### PR DESCRIPTION
## Summary

- The marketplace Bundles tab reads the catalog's declared sets through a new `marketplace_bundles` command instead of deriving names from the offered packages' own `bundles` arrays, so a set whose members are not themselves offered is listed, and the tab agrees with the listing count.
- The tab shows a reading line while the read is out and the read's error after it fails, saying the marketplace offers no curated sets only for a read that landed empty.
- `browse::bundle` and the new `browse::bundles` share one `detail()` join and one sort, so a card and the page it opens agree and both catalog shapes list alphabetically.

## Completed Issues

- Closes KEN-1134 - The marketplace Bundles tab reads the catalog's declared bundles; kendex shows four in the listing and none in the tab

## Test Plan

- `tools/guard` clean on the rebased branch: full Rust suites, 996 UI tests across 121 files, `tsc --noEmit` and `biome` green.
- Core: `bundles()` lists every declared set including one with no offered member, and lists a plugin registry's sets alphabetically rather than in `marketplace.json` file order; listing a set and opening it return equal values.
- UI: the page issues the bundles read and renders a returned set; a failed read lands its reason under the key the page subscribes to; an install empties both curated-set caches and a read in flight across the install is discarded and re-asked; the card badges a set by how much of it is installed.
- CLI: `kendex marketplace browse --json` still carries `AvailablePackage.bundles`, pinned as part of the schema-1 envelope.

Every added test was checked with a must-fail control that ran red once.
