### PR TITLE
test(KEN-1124): release_workflow's staged CLI races a sibling's fork and fails guard with ETXTBSY

### DIFF
--- a/crates/cli/tests/release_workflow/channel_point.rs
+++ b/crates/cli/tests/release_workflow/channel_point.rs
@@ -117,7 +117,7 @@ pub(crate) struct Fixture {
 #[allow(clippy::unwrap_used)]
 impl Fixture {
     pub(crate) fn new(channel: Channel, staged: &[&str]) -> Fixture {
-        use std::os::unix::fs::PermissionsExt;
+        use std::os::unix::fs::{PermissionsExt, symlink};
         let dir = tempfile::tempdir().unwrap();
         let root = rooted(&dir);
         let dist = root.join("dist");
@@ -125,12 +125,14 @@ impl Fixture {
         for name in staged {
             fs::write(dist.join(name), "{}").unwrap();
         }
-        // The release stages its own CLI beside the manifests, and the
-        // guard orders the two versions by running it. This is that binary
-        // — the one these tests were built from — so the ordering under
-        // test is the parser candidates read their feed with rather than a
-        // stub posed to agree with it.
-        fs::copy(env!("CARGO_BIN_EXE_kendex"), dist.join(compare_binary())).unwrap();
+        // The release stages its own CLI beside the manifests, and the guard
+        // orders the two versions by running it. Linking the finished binary
+        // never opens the staged inode for writing, so a sibling's fork cannot
+        // inherit the descriptor that makes the guard's exec fail with
+        // ETXTBSY. This is the binary these tests were built from, so the
+        // ordering under test is the parser candidates read their feed with.
+        let cli = fs::canonicalize(env!("CARGO_BIN_EXE_kendex")).unwrap();
+        symlink(cli, dist.join(compare_binary())).unwrap();
         let bin = root.join("bin");
         fs::create_dir_all(&bin).unwrap();
         fs::write(
@@ -292,6 +294,31 @@ impl Fixture {
             after,
         }
     }
+}
+
+/// The fixture links Cargo's finished executable into `dist` instead of
+/// copying it. A copy opens the staged inode for writing, and a sibling's
+/// fork can inherit that descriptor before the guard execs the same inode.
+#[cfg(unix)]
+#[test]
+#[allow(clippy::unwrap_used)]
+fn fixture_stages_the_built_cli_as_a_symbolic_link() {
+    let fixture = Fixture::new(Channel::Empty, &STAGED);
+    let staged = fixture.root.join("dist").join(compare_binary());
+
+    assert!(
+        fs::symlink_metadata(&staged)
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "the staged CLI is not a symbolic link: {}",
+        staged.display()
+    );
+    assert_eq!(
+        fs::canonicalize(staged).unwrap(),
+        fs::canonicalize(env!("CARGO_BIN_EXE_kendex")).unwrap(),
+        "the staged CLI does not resolve to Cargo's built executable"
+    );
 }
 
 /// One run against a channel in this state, with the release's whole output


### PR DESCRIPTION
## Summary
- Stage the release-workflow comparison CLI through an absolute symbolic link, so fixture setup never opens the executable inode for writing.
- Add a regression test that proves the fixture points at Cargo's built CLI.

## Completed Issues
- Closes KEN-1124 - release_workflow's staged CLI races a sibling's fork and fails guard with ETXTBSY

## Test Plan
- `cargo test -p kendex-cli --test release_workflow` passed 45/45 three consecutive times.
- The inverse implementation was killed once, then the test passed 10/10 at 64 threads.
- `tools/guard` passed after review.
