### PR TITLE
docs(dev): two pointers the 06:45Z scan found false [no-changelog]

### DIFF
--- a/.agents/skills/dev/workflows/dev-fix.md
+++ b/.agents/skills/dev/workflows/dev-fix.md
@@ -6,7 +6,7 @@ The workflow for a dev agent receiving a review-fix delegation. Every path is wo
 
 ## 1. Read Context
 
-Confirm the shell's real working directory is the delegation's `Worktree:` path before any repo-relative command, by the check [dev-implement.md § 1](./dev-implement.md#1-environment-setup) states.
+Confirm the shell's real working directory is the delegation's `Worktree:` path before any repo-relative command, by the check at the top of [dev-implement.md](./dev-implement.md).
 
 Verify possession before reading or writing anything else. **Skip if** the delegation carries no `Worktree Lease:` line.
 

--- a/skills/dev/workflows/dev-fix.md
+++ b/skills/dev/workflows/dev-fix.md
@@ -6,7 +6,7 @@ The workflow for a dev agent receiving a review-fix delegation. Every path is wo
 
 ## 1. Read Context
 
-Confirm the shell's real working directory is the delegation's `Worktree:` path before any repo-relative command, by the check [dev-implement.md § 1](./dev-implement.md#1-environment-setup) states.
+Confirm the shell's real working directory is the delegation's `Worktree:` path before any repo-relative command, by the check at the top of [dev-implement.md](./dev-implement.md).
 
 Verify possession before reading or writing anything else. **Skip if** the delegation carries no `Worktree Lease:` line.
 

--- a/ui/src/stores/marketplaces-shared.ts
+++ b/ui/src/stores/marketplaces-shared.ts
@@ -35,8 +35,8 @@ export interface CatalogCaches {
   readErrors: Record<string, string>;
 }
 
-/** Bumped once by [droppedSetCaches] and [dropCatalogCaches], the only two
- * places a drop is declared. A read that began before one describes a
+/** Bumped by [droppedSetCaches], the one place a drop is declared;
+ * [dropCatalogCaches] spreads that result and bumps nothing itself. A read that began before one describes a
  * checkout that may no longer be the one installed from, and every derived
  * cache keys on presence rather than freshness — a stale answer landing in
  * the emptied slot would pin the commit before the change for the session,


### PR DESCRIPTION
Two pointers the 06:45Z overseer PR scan found false on main after #1993 and #2001 merged. Overseer PR, no issue: introduced defects are fixed, not filed.

- `skills/dev/workflows/dev-fix.md:9` pointed at dev-implement.md § 1 for the working-directory check; #1993's amend moved that sentence above the delegation table, and § 1 now points back up at it. The pointer follows; render moves with the source.
- `ui/src/stores/marketplaces-shared.ts:38` said `catalogDrops` is bumped by two functions; since #2001 `dropCatalogCaches` spreads `droppedSetCaches()` and bumps nothing itself. #2001's own completion comment called the line stale. `[no-changelog]`: a comment.

https://claude.ai/code/session_01RkDwSMxGaqnL1HN8evRn91
