### PR TITLE
fix(KEN-1116): A fork skips its access-widening refusal when the renderer cannot answer

### DIFF
--- a/changelog.d/fixed/KEN-1116.md
+++ b/changelog.d/fixed/KEN-1116.md
@@ -1,1 +1,1 @@
-- Refuse agent forks when a harness cannot render their access settings, instead of recording a fork that may widen access.
+- Refuse agent forks and hide fork actions when a harness cannot render their access settings, instead of recording a fork that may widen access.

--- a/changelog.d/fixed/KEN-1116.md
+++ b/changelog.d/fixed/KEN-1116.md
@@ -1,0 +1,1 @@
+- Refuse agent forks when a harness cannot render their access settings, instead of recording a fork that may widen access.

--- a/crates/core/src/engine/fork.rs
+++ b/crates/core/src/engine/fork.rs
@@ -66,20 +66,7 @@ pub fn fork(
             origin: decl.source.clone(),
         });
     }
-    let edited = edited_rendering(env, scope, kind, name, harness)?;
-    let captured = capture(
-        &ForkOf {
-            env,
-            scope,
-            manifest: &manifest,
-            decl: &decl,
-            kind,
-            name,
-            installed_as: name,
-            harness,
-        },
-        &edited,
-    )?;
+    let (edited, captured) = capture_rendering(env, scope, kind, name, harness, &manifest, &decl)?;
     let mut ops = capture_ops(env, scope, kind, name, &edited, captured.files)?;
     let provenance = provenance(env, scope, kind, name, harness, &manifest, &decl)?;
     // The catalog's mapping tables shaped the rendering and the fork stops
@@ -228,6 +215,35 @@ fn capture(of: &ForkOf, edited: &std::path::Path) -> Result<Captured> {
             }
         }
     })
+}
+
+/// Prove that one installed rendering can become a fork, returning the
+/// capture so the direct fork does not repeat the reads behind the proof.
+/// The Updates projection asks this same question and discards the capture.
+fn capture_rendering(
+    env: &Env,
+    scope: &Scope,
+    kind: ItemKind,
+    name: &str,
+    harness: HarnessId,
+    manifest: &manifest::Manifest,
+    decl: &manifest::ItemDecl,
+) -> Result<(PathBuf, Captured)> {
+    let edited = edited_rendering(env, scope, kind, name, harness)?;
+    let captured = capture(
+        &ForkOf {
+            env,
+            scope,
+            manifest,
+            decl,
+            kind,
+            name,
+            installed_as: name,
+            harness,
+        },
+        &edited,
+    )?;
+    Ok((edited, captured))
 }
 
 /// The bytes answering to `name`, refused as a fork's own refusal: bytes

--- a/crates/core/src/engine/fork.rs
+++ b/crates/core/src/engine/fork.rs
@@ -217,9 +217,6 @@ fn capture(of: &ForkOf, edited: &std::path::Path) -> Result<Captured> {
     })
 }
 
-/// Prove that one installed rendering can become a fork, returning the
-/// capture so the direct fork does not repeat the reads behind the proof.
-/// The Updates projection asks this same question and discards the capture.
 fn capture_rendering(
     env: &Env,
     scope: &Scope,

--- a/crates/core/src/engine/fork/agent.rs
+++ b/crates/core/src/engine/fork/agent.rs
@@ -51,15 +51,21 @@ pub(super) fn capture_agent(of: &ForkOf, edited: &Path) -> Result<CapturedAgent>
         hooks: hooks_for_agent(env, scope, harness, manifest, &publisher),
     };
 
-    let edited_text = std::fs::read_to_string(edited).map_err(|e| CoreError::io(edited, e))?;
-    let read = wrapper(scope, &publisher, harness, &around);
-    let bytes = source_form(&published, &edited_text, name, read.as_ref())?;
-    let captured = parse_source_agent(&String::from_utf8_lossy(&bytes))
-        .map_err(|problem| unreadable(name, &decl.source, problem))?;
     let refused = |problem: String| CoreError::ForkWidensAccess {
         name: crate::names::shown(name),
         problem,
     };
+    let render_refused = |problem: String| {
+        refused(format!(
+            "its {} renderer refused it: {problem}",
+            harness.display_name()
+        ))
+    };
+    let edited_text = std::fs::read_to_string(edited).map_err(|e| CoreError::io(edited, e))?;
+    let read = wrapper(scope, &publisher, harness, &around).map_err(&render_refused)?;
+    let bytes = source_form(&published, &edited_text, name, read.as_ref())?;
+    let captured = parse_source_agent(&String::from_utf8_lossy(&bytes))
+        .map_err(|problem| unreadable(name, &decl.source, problem))?;
     let on_disk = stated(harness, &edited_text).map_err(|problem| {
         refused(format!(
             "the tool settings its {} file states: its frontmatter cannot be read ({problem})",
@@ -70,13 +76,7 @@ pub(super) fn capture_agent(of: &ForkOf, edited: &Path) -> Result<CapturedAgent>
         name: installed_as.to_owned(),
         ..captured.clone()
     };
-    let Some(rendering) = render(scope, &named, harness, &around) else {
-        return Ok(CapturedAgent {
-            bytes,
-            carry,
-            read_at,
-        });
-    };
+    let rendering = render(scope, &named, harness, &around).map_err(render_refused)?;
     let after = stated(harness, &rendering)
         .map_err(|problem| refused(format!("its own rendering reads back as {problem}")))?;
     if let Some(problem) = dropped(&on_disk, &after, harness) {
@@ -234,16 +234,20 @@ fn wrapper(
     publisher: &SourceAgent,
     harness: HarnessId,
     around: &Around,
-) -> Option<(String, String)> {
+) -> std::result::Result<Option<(String, String)>, String> {
     const STAND_IN: &str = "kendexstandsinfortheagentsownprose";
     let source = SourceAgent {
         body: STAND_IN.to_owned(),
         ..publisher.clone()
     };
     let text = render(scope, &source, harness, around)?;
-    let (_, body) = crate::frontmatter::split(&text).ok()?;
-    let (before, after) = body.split_once(STAND_IN)?;
-    Some((before.to_owned(), after.to_owned()))
+    let Some((_, body)) = crate::frontmatter::split(&text).ok() else {
+        return Ok(None);
+    };
+    let Some((before, after)) = body.split_once(STAND_IN) else {
+        return Ok(None);
+    };
+    Ok(Some((before.to_owned(), after.to_owned())))
 }
 
 fn render(
@@ -251,7 +255,7 @@ fn render(
     source: &SourceAgent,
     harness: HarnessId,
     around: &Around,
-) -> Option<String> {
+) -> std::result::Result<String, String> {
     let permissions = EffectiveAgent::intent(source, &around.overrides);
     let effective = EffectiveAgent {
         source,
@@ -264,7 +268,5 @@ fn render(
         additional_instructions: around.additional.clone(),
         custom_hooks: around.hooks.clone(),
     };
-    crate::render::agent::generate(&effective)
-        .ok()
-        .map(|rendered| rendered.text)
+    crate::render::agent::generate(&effective).map(|rendered| rendered.text)
 }

--- a/crates/core/src/engine/fork/agent.rs
+++ b/crates/core/src/engine/fork/agent.rs
@@ -57,7 +57,7 @@ pub(super) fn capture_agent(of: &ForkOf, edited: &Path) -> Result<CapturedAgent>
     };
     let render_refused = |problem: String| {
         refused(format!(
-            "its {} renderer refused it: {problem}",
+            "the access settings its {} renderer rejected: {problem}",
             harness.display_name()
         ))
     };

--- a/crates/core/src/engine/fork/forkable.rs
+++ b/crates/core/src/engine/fork/forkable.rs
@@ -7,8 +7,6 @@ use crate::env::Env;
 use crate::error::{CoreError, Result};
 use crate::model::{HarnessId, ItemKind, Scope};
 
-use super::skill_content_path;
-
 /// Whether a fork can take this kind at all, or why not. Only a skill and
 /// an agent are stored in the local source in a form the source parser
 /// reads back, so only those two have a fork path — and every question a
@@ -79,10 +77,9 @@ pub(super) fn ambiguous_skill_tree(tree: &std::path::Path) -> bool {
     tree.join("SKILL.md").exists() && tree.join("SKILL.md.disabled").exists()
 }
 
-/// Whether keeping this rendering's edit as a fork can succeed: the kind
-/// and tool allow it, and a skill's tree is unambiguous. The Updates page
-/// asks before it offers the action, so the answer is the one `fork`
-/// enforces.
+/// Whether keeping this rendering's edit as a fork can succeed. The
+/// read-only capture is the same eligibility result `fork` consumes, so
+/// the Updates page offers no action that the engine would refuse.
 pub fn forkable_rendering(
     env: &Env,
     scope: &Scope,
@@ -90,8 +87,16 @@ pub fn forkable_rendering(
     name: &str,
     harness: HarnessId,
 ) -> bool {
-    forkable_harness(kind, harness)
-        && (kind != ItemKind::Skill
-            || skill_content_path(env, scope, name, harness)
-                .is_some_and(|tree| !ambiguous_skill_tree(&tree)))
+    let Ok(manifest) = crate::engine::ops::manifest_for_mutation(env, scope) else {
+        return false;
+    };
+    let Some(decl) = manifest.declared(kind).get(name) else {
+        return false;
+    };
+    if decl.source == crate::manifest::LOCAL_SOURCE_NAME
+        || decl.source == crate::manifest::INPLACE_SOURCE_NAME
+    {
+        return false;
+    }
+    super::capture_rendering(env, scope, kind, name, harness, &manifest, decl).is_ok()
 }

--- a/crates/core/src/engine/fork/forkable.rs
+++ b/crates/core/src/engine/fork/forkable.rs
@@ -38,10 +38,8 @@ pub(crate) fn unsupported_kind(kind: ItemKind, name: &str) -> CoreError {
     }
 }
 
-/// Whether keeping an edit as a fork can capture this rendering: a skill's
-/// canonical tree always round-trips, an agent's only from the tools whose
-/// format the source parser reads back. The Updates page asks before it
-/// offers the action, so the answer is the same one `fork` enforces.
+/// Whether a harness rendering can be parsed as source form. This format check
+/// does not prove capture will succeed.
 pub fn forkable_harness(kind: ItemKind, harness: HarnessId) -> bool {
     match kind {
         ItemKind::Skill => true,
@@ -77,9 +75,8 @@ pub(super) fn ambiguous_skill_tree(tree: &std::path::Path) -> bool {
     tree.join("SKILL.md").exists() && tree.join("SKILL.md.disabled").exists()
 }
 
-/// Whether keeping this rendering's edit as a fork can succeed. The
-/// read-only capture is the same eligibility result `fork` consumes, so
-/// the Updates page offers no action that the engine would refuse.
+/// Full fork eligibility for Updates, using the read-only capture shared with
+/// `fork` so the page offers no action that direct capture would refuse.
 pub fn forkable_rendering(
     env: &Env,
     scope: &Scope,

--- a/crates/core/src/package/updates.rs
+++ b/crates/core/src/package/updates.rs
@@ -73,9 +73,7 @@ pub struct UpdateRow {
     /// canonical tree count once. Keeping the edit as a fork captures one
     /// rendering's bytes — it has to be the one that was changed.
     pub edited_harnesses: Vec<HarnessId>,
-    /// The edited rendering a fork can capture, when one exists — an
-    /// agent edited only in a tool whose format cannot be read back has
-    /// none, and the UI must not offer what the engine will refuse.
+    /// The edited rendering the engine allows the UI to capture, when one exists.
     pub forkable_harness: Option<HarnessId>,
     /// Whether dropping the edits can put the currently resolved content
     /// back in place, without moving any revision — the source content

--- a/crates/core/tests/edits_and_forks/agent_settings.rs
+++ b/crates/core/tests/edits_and_forks/agent_settings.rs
@@ -300,10 +300,7 @@ fn a_deleted_pi_delegation_list_survives_the_fork() {
     );
 }
 
-/// Pi cannot render an allowlist. A person can add that project override
-/// after installation and then ask to keep a hand-tightened rendering as a
-/// fork, so Updates must hide the action and capture must surface Pi's
-/// refusal instead of recording a fork it cannot prove preserves the restriction.
+/// A person can add a Pi allowlist override after tightening the installed file.
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_pi_allowlist_that_cannot_render_refuses_the_fork() {
@@ -315,16 +312,11 @@ fn a_pi_allowlist_that_cannot_render_refuses_the_fork() {
     );
     let file = rendered(&w, HarnessId::Pi, "rev");
     edit_line(&file, "deny-tools:", "deny-tools: Bash,");
-    let path = manifest::manifest_path(&w.env, &w.scope);
-    fs::write(
-        path,
-        format!(
-            "{}\n[agent-frontmatter.pi]\nrev = {{ allow-tools = [\"Read\"] }}\n",
-            manifest_text(&w)
-        ),
-    )
-    .unwrap();
-
+    let manifest = format!(
+        "{}\n[agent-frontmatter.pi]\nrev = {{ allow-tools = [\"Read\"] }}\n",
+        manifest_text(&w)
+    );
+    fs::write(manifest::manifest_path(&w.env, &w.scope), manifest).unwrap();
     let report = kendex_core::package::updates::updates(&w.env, &w.scope).unwrap();
     let row = report
         .rows
@@ -332,21 +324,10 @@ fn a_pi_allowlist_that_cannot_render_refuses_the_fork() {
         .find(|row| row.kind == ItemKind::Agent && row.name == "rev")
         .unwrap();
     assert_eq!(row.forkable_harness, None, "{row:?}");
-
     let refused = fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Pi).unwrap_err();
-    assert!(
-        matches!(refused, CoreError::ForkWidensAccess { .. }),
-        "{refused:?}"
-    );
-    let said = refused.to_string();
-    assert!(
-        said.contains(
-            "cannot carry the access settings its Pi renderer rejected: Pi cannot express a tool allowlist"
-        ),
-        "the refusal names the harness and keeps the renderer's reason: {said}"
-    );
-    assert!(!captured(&w, "rev").exists(), "nothing was written");
-    assert!(!manifest_text(&w).contains("[forks.agent.rev]"));
+    assert!(refused.to_string().contains(
+        "the access settings its Pi renderer rejected: Pi cannot express a tool allowlist"
+    ));
 }
 
 /// A hook written into a Claude agent file gates tool use from inside that

--- a/crates/core/tests/edits_and_forks/agent_settings.rs
+++ b/crates/core/tests/edits_and_forks/agent_settings.rs
@@ -302,8 +302,8 @@ fn a_deleted_pi_delegation_list_survives_the_fork() {
 
 /// Pi cannot render an allowlist. A person can add that project override
 /// after installation and then ask to keep a hand-tightened rendering as a
-/// fork, so capture must surface Pi's refusal instead of recording a fork it
-/// cannot prove preserves the restriction.
+/// fork, so Updates must hide the action and capture must surface Pi's
+/// refusal instead of recording a fork it cannot prove preserves the restriction.
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_pi_allowlist_that_cannot_render_refuses_the_fork() {
@@ -325,16 +325,25 @@ fn a_pi_allowlist_that_cannot_render_refuses_the_fork() {
     )
     .unwrap();
 
+    let report = kendex_core::package::updates::updates(&w.env, &w.scope).unwrap();
+    let row = report
+        .rows
+        .iter()
+        .find(|row| row.kind == ItemKind::Agent && row.name == "rev")
+        .unwrap();
+    assert_eq!(row.forkable_harness, None, "{row:?}");
+
     let refused = fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Pi).unwrap_err();
     assert!(
         matches!(refused, CoreError::ForkWidensAccess { .. }),
         "{refused:?}"
     );
     let said = refused.to_string();
-    assert!(said.contains("Pi"), "the refusal names the harness: {said}");
     assert!(
-        said.contains("cannot express a tool allowlist"),
-        "the refusal keeps the renderer's reason: {said}"
+        said.contains(
+            "cannot carry the access settings its Pi renderer rejected: Pi cannot express a tool allowlist"
+        ),
+        "the refusal names the harness and keeps the renderer's reason: {said}"
     );
     assert!(!captured(&w, "rev").exists(), "nothing was written");
     assert!(!manifest_text(&w).contains("[forks.agent.rev]"));

--- a/crates/core/tests/edits_and_forks/agent_settings.rs
+++ b/crates/core/tests/edits_and_forks/agent_settings.rs
@@ -300,6 +300,46 @@ fn a_deleted_pi_delegation_list_survives_the_fork() {
     );
 }
 
+/// Pi cannot render an allowlist. A person can add that project override
+/// after installation and then ask to keep a hand-tightened rendering as a
+/// fork, so capture must surface Pi's refusal instead of recording a fork it
+/// cannot prove preserves the restriction.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_pi_allowlist_that_cannot_render_refuses_the_fork() {
+    let w = agent_world(
+        "\"pi\"",
+        "---\nname: rev\ndescription: agent rev\n---\nUpstream body.\n",
+        "",
+        "",
+    );
+    let file = rendered(&w, HarnessId::Pi, "rev");
+    edit_line(&file, "deny-tools:", "deny-tools: Bash,");
+    let path = manifest::manifest_path(&w.env, &w.scope);
+    fs::write(
+        path,
+        format!(
+            "{}\n[agent-frontmatter.pi]\nrev = {{ allow-tools = [\"Read\"] }}\n",
+            manifest_text(&w)
+        ),
+    )
+    .unwrap();
+
+    let refused = fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Pi).unwrap_err();
+    assert!(
+        matches!(refused, CoreError::ForkWidensAccess { .. }),
+        "{refused:?}"
+    );
+    let said = refused.to_string();
+    assert!(said.contains("Pi"), "the refusal names the harness: {said}");
+    assert!(
+        said.contains("cannot express a tool allowlist"),
+        "the refusal keeps the renderer's reason: {said}"
+    );
+    assert!(!captured(&w, "rev").exists(), "nothing was written");
+    assert!(!manifest_text(&w).contains("[forks.agent.rev]"));
+}
+
 /// A hook written into a Claude agent file gates tool use from inside that
 /// file. No override table holds one — a hook is a custom-hooks entry with
 /// a selector, not a field — so a hook the fork would not run again is a

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -2944,11 +2944,7 @@ export type UpdateRow = {
 	 *  rendering's bytes — it has to be the one that was changed.
 	 */
 	editedHarnesses: HarnessId[],
-	/**
-	 *  The edited rendering a fork can capture, when one exists — an
-	 *  agent edited only in a tool whose format cannot be read back has
-	 *  none, and the UI must not offer what the engine will refuse.
-	 */
+	/**  The edited rendering the engine allows the UI to capture, when one exists. */
 	forkableHarness: HarnessId | null,
 	/**
 	 *  Whether dropping the edits can put the currently resolved content

--- a/ui/src/components/install-as-new-button.tsx
+++ b/ui/src/components/install-as-new-button.tsx
@@ -7,11 +7,7 @@ import {
   UPDATE_NEEDS_CHECK_NOTE,
 } from "@/lib/copy-updates";
 
-/** Whether an edited place has something to install beside its edits: a
- *  newer version the source still carries, and a rendering the engine can
- *  keep. A package gone from its source, one already at the newest, a
- *  bundle member, an edit spread over several tools, or a tool whose
- *  format cannot be read back settles on the package page instead. */
+/** Whether the engine-projected row permits installing beside an edit. */
 export const installableBeside = (row: UpdateRow): boolean =>
   row.forkableHarness !== null &&
   row.updateAvailable &&

--- a/ui/src/stores/updates-edits.ts
+++ b/ui/src/stores/updates-edits.ts
@@ -55,9 +55,7 @@ const stale = (row: UpdateRow): boolean =>
  *  when nothing is wrong with the row itself. */
 const running = (): boolean => workOut(useUpdatesStore.getState());
 
-/** Keep an edited place's files as a local fork of its own. Only some
- *  tools' renderings read back as source; the row names the edited one a
- *  fork can take, and the button is not offered without it. */
+/** Keep an edited place using the engine-projected forkable rendering. */
 export const keepAsOwn = async (row: UpdateRow): Promise<void> => {
   const harness = row.forkableHarness;
   if (!harness) return;


### PR DESCRIPTION
## Summary

- Refuse agent forks when the target harness cannot render the effective access policy, while preserving the renderer's reason.
- Use the same capture eligibility for update rows so the app does not offer a fork action the engine will reject.
- Cover the Pi allow-tools case and publish the user-facing fix in the changelog.

## Completed Issues

- Closes KEN-1116 - A fork skips its access-widening refusal when the renderer cannot answer

## Test Plan

- `.agents/skills/preflight/scripts/preflight --base origin/main --repo /home/method/dev/.worktrees/kendex/ken-1116`
- `tools/guard`
- Reviewer mutation checks for the static eligibility and renderer fail-open regressions
