### PR TITLE
fix(KEN-1137): Problems card names its file by role and reads at body size

### DIFF
--- a/changelog.d/fixed/ken-1137.md
+++ b/changelog.d/fixed/ken-1137.md
@@ -1,0 +1,1 @@
+- A Problems card names the project and the file in plain words above the engine's message, sets that message in the card's own text colour, and reads its steps at body size.

--- a/changelog.d/fixed/ken-1137.md
+++ b/changelog.d/fixed/ken-1137.md
@@ -1,1 +1,1 @@
-- A Problems card names the project and the file in plain words above the engine's message, sets that message in the card's own text colour, and reads its steps at body size.
+- A Problems card names the place and, in plain words, which of its files kendex couldn't read, sets that error in the card's own text colour, and reads its steps at body size.

--- a/changelog.d/fixed/ken-1137.md
+++ b/changelog.d/fixed/ken-1137.md
@@ -1,1 +1,1 @@
-- A Problems card names the place and, in plain words, which of its files kendex couldn't read, sets that error in the card's own text colour, and reads its steps at body size.
+- A Problems card names the place and which of its files kendex couldn't read, stops calling a Personal problem a project's, and sets the error in body colour with its steps at body size.

--- a/ui/src/components/problem-card.dom.test.tsx
+++ b/ui/src/components/problem-card.dom.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+// The card a person reaches when kendex could not read one of its own
+// files. What it says first, and how the two blocks under that read: the
+// engine's message is the longest thing on the card and the only line
+// carrying the path, and the steps are prose a reader works through.
+import { describe, expect, it, vi } from "vitest";
+import type { Scope } from "@/bindings";
+import { ProblemCard } from "@/components/problem-card";
+import { PROBLEM_LEADS } from "@/lib/error-copy";
+import type { Problem } from "@/stores/problems";
+import { mount } from "@/test/dom";
+
+vi.mock("@/bindings", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/bindings")>()),
+  commands: { revealPath: vi.fn(), scanMachine: vi.fn(), auditAll: vi.fn() },
+}));
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+const ACME: Scope = { scope: "project", root: "/work/acme" };
+const MESSAGE =
+  "/work/acme/.kendex-lock.json: this lock file could not be read";
+
+const unreadableLock: Problem = {
+  key: "/work/acme",
+  scope: ACME,
+  kind: "lock-corrupt",
+  message: MESSAGE,
+};
+
+/** The paragraph holding the engine's verbatim message. */
+const errorBlock = (host: HTMLElement) =>
+  [...host.querySelectorAll("p")].find((p) => p.textContent === MESSAGE);
+
+describe("a file kendex could not read", () => {
+  it("says which project and which file before the verbatim error", () => {
+    const host = mount(<ProblemCard problem={unreadableLock} />);
+
+    const lead = PROBLEM_LEADS["lock-corrupt"]?.("acme");
+    expect(lead).toBeDefined();
+    const said = host.textContent ?? "";
+    expect(said).toContain(lead);
+    // Before, not merely present: the plain words are what a reader meets
+    // first, and the terminal sentence explains them.
+    expect(said.indexOf(lead as string)).toBeLessThan(said.indexOf(MESSAGE));
+  });
+
+  // The tint the card's trim wears is not one to set its longest line in.
+  it("sets the error in the card's own text colour", () => {
+    const host = mount(<ProblemCard problem={unreadableLock} />);
+
+    expect(errorBlock(host)?.className).not.toContain("text-muted-foreground");
+  });
+
+  // The steps are prose, so they read at the size the rest of the page
+  // does rather than a notch under it.
+  it("sets the steps at body size", () => {
+    const host = mount(<ProblemCard problem={unreadableLock} />);
+
+    const steps = host.querySelector("ul");
+    expect(steps?.className).toContain("text-sm");
+    expect(steps?.className).not.toContain("text-xs");
+  });
+});
+
+// The one problem about no project at all: nothing to name, so nothing is
+// invented above the message.
+describe("a scan that could not finish", () => {
+  it("leads with the engine's message itself", () => {
+    const host = mount(
+      <ProblemCard
+        problem={{
+          key: "scan",
+          scope: null,
+          kind: "scan-failure",
+          message: "the machine could not be read",
+        }}
+      />,
+    );
+
+    expect(host.textContent).toContain("the machine could not be read");
+    expect(host.textContent).not.toContain("The file is");
+  });
+});

--- a/ui/src/components/problem-card.dom.test.tsx
+++ b/ui/src/components/problem-card.dom.test.tsx
@@ -2,7 +2,7 @@
 // The card a person reaches when kendex could not read one of its own
 // files. What it says first, and how the two blocks under that read: the
 // engine's message is the longest thing on the card and the only line
-// carrying the path, and the steps are prose a reader works through.
+// naming the file, and the steps are prose a reader works through.
 import { describe, expect, it, vi } from "vitest";
 import type { Scope } from "@/bindings";
 import { ProblemCard } from "@/components/problem-card";
@@ -77,7 +77,12 @@ describe("a scan that could not finish", () => {
       />,
     );
 
-    expect(host.textContent).toContain("the machine could not be read");
-    expect(host.textContent).not.toContain("The file is");
+    // Every paragraph the card holds, in order. Read as a whole rather
+    // than searched for today's wording: a lead invented for this kind is
+    // a paragraph that isn't here, whatever words it were given.
+    expect([...host.querySelectorAll("p")].map((p) => p.textContent)).toEqual([
+      "This machine",
+      "the machine could not be read",
+    ]);
   });
 });

--- a/ui/src/components/problem-card.dom.test.tsx
+++ b/ui/src/components/problem-card.dom.test.tsx
@@ -17,6 +17,7 @@ vi.mock("@/bindings", async (importOriginal) => ({
 vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
 
 const ACME: Scope = { scope: "project", root: "/work/acme" };
+const PERSONAL: Scope = { scope: "global" };
 const MESSAGE =
   "/work/acme/.kendex-lock.json: this lock file could not be read";
 
@@ -30,6 +31,21 @@ const unreadableLock: Problem = {
 /** The paragraph holding the engine's verbatim message. */
 const errorBlock = (host: HTMLElement) =>
   [...host.querySelectorAll("p")].find((p) => p.textContent === MESSAGE);
+
+// The card's own control, by the words it wears.
+const STOP_TRACKING = "Stop tracking this project…";
+
+const stopTracking = (host: HTMLElement) =>
+  [...host.querySelectorAll("button")].find(
+    (el) => el.textContent?.trim() === STOP_TRACKING,
+  );
+
+const failure = (scope: Problem["scope"]): Problem => ({
+  key: "k",
+  scope,
+  kind: "other",
+  message: "something went wrong",
+});
 
 describe("a file kendex could not read", () => {
   it("says which project and which file before the verbatim error", () => {
@@ -84,5 +100,27 @@ describe("a scan that could not finish", () => {
       "This machine",
       "the machine could not be read",
     ]);
+  });
+});
+
+// A failure with no known cause has one step, Rescan to retry. The other
+// way out is this control rather than a line of copy, because Personal has
+// no project to stop tracking and per-kind steps cannot say so.
+describe("a failure with no known cause", () => {
+  it("offers to stop tracking the project it is about", () => {
+    const host = mount(<ProblemCard problem={failure(ACME)} />);
+
+    expect(stopTracking(host)).toBeDefined();
+  });
+
+  // The control moves the reader's own registration, and neither of these
+  // has one to move.
+  it("offers it nowhere there is no project to stop tracking", () => {
+    expect(
+      stopTracking(mount(<ProblemCard problem={failure(PERSONAL)} />)),
+    ).toBeUndefined();
+    expect(
+      stopTracking(mount(<ProblemCard problem={failure(null)} />)),
+    ).toBeUndefined();
   });
 });

--- a/ui/src/components/problem-card.tsx
+++ b/ui/src/components/problem-card.tsx
@@ -3,7 +3,11 @@ import { commands } from "@/bindings";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { PlaceCard } from "@/components/place-card";
 import { Button } from "@/components/ui/button";
-import { PROBLEM_HEADLINES, PROBLEM_STEPS } from "@/lib/error-copy";
+import {
+  PROBLEM_HEADLINES,
+  PROBLEM_LEADS,
+  PROBLEM_STEPS,
+} from "@/lib/error-copy";
 import { scopeName, scopePath } from "@/lib/labels";
 import { rescanEverything } from "@/lib/rescan";
 import type { Problem } from "@/stores/problems";
@@ -19,6 +23,7 @@ export function ProblemCard({ problem }: { problem: Problem }) {
     problem.scope?.scope === "project" ? problem.scope.root : null;
   const name = problem.scope ? scopeName(problem.scope) : "This machine";
   const path = problem.scope ? scopePath(problem.scope) : null;
+  const lead = PROBLEM_LEADS[problem.kind];
 
   return (
     <PlaceCard
@@ -27,10 +32,14 @@ export function ProblemCard({ problem }: { problem: Problem }) {
       name={name}
       path={path}
     >
-      <p className="break-words rounded-md bg-muted/50 p-2 font-mono text-xs text-muted-foreground">
+      {lead ? <p className="text-sm">{lead(name)}</p> : null}
+      {/* The engine's own words, verbatim, and the only line on the card
+          carrying the path. It takes the card's own text colour: muted is
+          for trim, and this is the longest thing here to read. */}
+      <p className="break-words rounded-md bg-muted/50 p-2 font-mono text-xs">
         {problem.message}
       </p>
-      <ul className="list-disc space-y-1 pl-5 text-xs text-muted-foreground">
+      <ul className="list-disc space-y-1 pl-5 text-sm text-muted-foreground">
         {PROBLEM_STEPS[problem.kind].map((step) => (
           <li key={step}>{step}</li>
         ))}

--- a/ui/src/components/problem-card.tsx
+++ b/ui/src/components/problem-card.tsx
@@ -33,9 +33,10 @@ export function ProblemCard({ problem }: { problem: Problem }) {
       path={path}
     >
       {lead ? <p className="text-sm">{lead(name)}</p> : null}
-      {/* The engine's own words, verbatim, and the only line on the card
-          carrying the path. It takes the card's own text colour: muted is
-          for trim, and this is the longest thing here to read. */}
+      {/* The engine's own words, verbatim, and the only line naming the
+          file — the card's own path line above names the folder. It takes
+          the card's own text colour: muted is for trim, and this is the
+          longest thing here to read. */}
       <p className="break-words rounded-md bg-muted/50 p-2 font-mono text-xs">
         {problem.message}
       </p>

--- a/ui/src/lib/error-copy.test.ts
+++ b/ui/src/lib/error-copy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   PROBLEM_HEADLINES,
+  PROBLEM_LEADS,
   PROBLEM_STEPS,
   problemsFooterLabel,
 } from "./error-copy";
@@ -30,9 +31,18 @@ const SCOPE_SPECIFIC = [
   ".cursor",
 ];
 
+// A place name the card would pass in, so a lead line is checked as the
+// reader sees it rather than as a template.
+const PLACE = "acme";
+
+const ALL_LEADS = Object.values(PROBLEM_LEADS)
+  .filter((lead) => lead !== null)
+  .map((lead) => lead(PLACE));
+
 const ALL_COPY = [
   ...Object.values(PROBLEM_HEADLINES),
   ...Object.values(PROBLEM_STEPS).flat(),
+  ...ALL_LEADS,
 ];
 
 describe("problem copy", () => {
@@ -62,5 +72,29 @@ describe("problem copy", () => {
     for (const line of ALL_COPY) {
       expect(line.toLowerCase()).not.toContain("delet");
     }
+  });
+});
+
+// The card's first line, above the verbatim error: it answers "which file,
+// where" before a reader meets a sentence the engine wrote for a terminal.
+describe("the lead line", () => {
+  it("names the place it was given", () => {
+    for (const line of ALL_LEADS) expect(line).toContain(PLACE);
+  });
+
+  it("names the file for every kind that has one to name", () => {
+    expect(PROBLEM_LEADS["lock-corrupt"]?.(PLACE)).toContain("installed in");
+    expect(PROBLEM_LEADS["manifest-outdated"]?.(PLACE)).toContain(
+      "kendex.toml",
+    );
+    expect(PROBLEM_LEADS["manifest-invalid"]?.(PLACE)).toContain("kendex.toml");
+  });
+
+  // A too-new schema can be either file and a scan failure is about no
+  // place at all, so a line naming one would be invented.
+  it("stays silent where there is no one file to name", () => {
+    expect(PROBLEM_LEADS["schema-too-new"]).toBeNull();
+    expect(PROBLEM_LEADS.other).toBeNull();
+    expect(PROBLEM_LEADS["scan-failure"]).toBeNull();
   });
 });

--- a/ui/src/lib/error-copy.test.ts
+++ b/ui/src/lib/error-copy.test.ts
@@ -17,14 +17,20 @@ describe("problemsFooterLabel", () => {
   });
 });
 
-// A problem card renders for Personal as readily as for a project, and the
-// two scopes keep their locks under different names and their harness
-// files under different roots. kendex.toml is absent from this list
-// because both scopes call it that; a name only one scope has is the thing
-// this copy cannot know.
+// A problem card renders for Personal as readily as for a project, and no
+// filename holds across every place a problem arrives from: the two scopes
+// keep their locks under different names and their harness files under
+// different roots, and a source catalog's install state is
+// kendex-local.toml while its kendex.toml is the catalog it publishes
+// (`manifest::file::manifest_path`). kendex.toml sat off this list on the
+// premise that both scopes call it that, which that routing falsifies — a
+// card naming it above an error naming kendex-local.toml points the steps'
+// "move the file named above" at the wrong file.
 const SCOPE_SPECIFIC = [
   ".kendex-lock.json",
   "lock.json",
+  "kendex.toml",
+  "kendex-local.toml",
   ".pi",
   ".claude",
   ".codex",
@@ -63,6 +69,9 @@ describe("problem copy", () => {
     expect(PROBLEM_STEPS["manifest-outdated"].join(" ")).toContain(
       "the file named above",
     );
+    expect(PROBLEM_STEPS["manifest-invalid"].join(" ")).toContain(
+      "the file named above",
+    );
   });
 
   // The same rule the lock's own refusal holds in crates/core: nothing
@@ -82,12 +91,18 @@ describe("the lead line", () => {
     for (const line of ALL_LEADS) expect(line).toContain(PLACE);
   });
 
+  // By role, never by name: the SCOPE_SPECIFIC guard above holds every
+  // filename out, so what is left has to say which file it means.
   it("names the file for every kind that has one to name", () => {
-    expect(PROBLEM_LEADS["lock-corrupt"]?.(PLACE)).toContain("installed in");
-    expect(PROBLEM_LEADS["manifest-outdated"]?.(PLACE)).toContain(
-      "kendex.toml",
+    expect(PROBLEM_LEADS["lock-corrupt"]?.(PLACE)).toContain(
+      "record of what it installed",
     );
-    expect(PROBLEM_LEADS["manifest-invalid"]?.(PLACE)).toContain("kendex.toml");
+    expect(PROBLEM_LEADS["manifest-outdated"]?.(PLACE)).toContain(
+      "declares what it wants installed",
+    );
+    expect(PROBLEM_LEADS["manifest-invalid"]?.(PLACE)).toContain(
+      "declares what it wants installed",
+    );
   });
 
   // A too-new schema can be either file and a scan failure is about no

--- a/ui/src/lib/error-copy.test.ts
+++ b/ui/src/lib/error-copy.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { ProblemKind } from "@/stores/problems";
 import {
   PROBLEM_HEADLINES,
   PROBLEM_LEADS,
@@ -17,15 +18,9 @@ describe("problemsFooterLabel", () => {
   });
 });
 
-// A problem card renders for Personal as readily as for a project, and no
-// filename holds across every place a problem arrives from: the two scopes
-// keep their locks under different names and their harness files under
-// different roots, and a source catalog's install state is
-// kendex-local.toml while its kendex.toml is the catalog it publishes
-// (`manifest::file::manifest_path`). kendex.toml sat off this list on the
-// premise that both scopes call it that, which that routing falsifies — a
-// card naming it above an error naming kendex-local.toml points the steps'
-// "move the file named above" at the wrong file.
+// The filenames no problem copy may name, per error-copy.ts's header: a
+// place's locks, manifests and harness roots, each of which the engine
+// routes by what the place is.
 const SCOPE_SPECIFIC = [
   ".kendex-lock.json",
   "lock.json",
@@ -44,6 +39,19 @@ const PLACE = "acme";
 const ALL_LEADS = Object.values(PROBLEM_LEADS)
   .filter((lead) => lead !== null)
   .map((lead) => lead(PLACE));
+
+// The other half of the same rule: which place this is, is the card's to
+// say and not this copy's. `scan-failure` is exempt because its scope is
+// known — the machine, no place in it.
+const SCOPE_WORDS = ["project", "personal"];
+
+const PLACED_COPY = (Object.keys(PROBLEM_HEADLINES) as ProblemKind[])
+  .filter((kind) => kind !== "scan-failure")
+  .flatMap((kind) => [
+    PROBLEM_HEADLINES[kind],
+    ...PROBLEM_STEPS[kind],
+    ...(PROBLEM_LEADS[kind] ? [PROBLEM_LEADS[kind](PLACE)] : []),
+  ]);
 
 const ALL_COPY = [
   ...Object.values(PROBLEM_HEADLINES),
@@ -74,6 +82,17 @@ describe("problem copy", () => {
     );
   });
 
+  // A kind carrying a scope reaches Personal as readily as a project
+  // (`audit_all` seeds `Scope::Global` before any project), so copy naming
+  // one renders over a card's name line naming the other.
+  it("claims no scope the card's own name line answers", () => {
+    for (const line of PLACED_COPY) {
+      for (const word of SCOPE_WORDS) {
+        expect(line.toLowerCase(), `claims ${word}`).not.toContain(word);
+      }
+    }
+  });
+
   // The same rule the lock's own refusal holds in crates/core: nothing
   // here can establish whose these files are, so nothing here asks for one
   // to be thrown away.
@@ -91,8 +110,8 @@ describe("the lead line", () => {
     for (const line of ALL_LEADS) expect(line).toContain(PLACE);
   });
 
-  // By role, never by name: the SCOPE_SPECIFIC guard above holds every
-  // filename out, so what is left has to say which file it means.
+  // By role, never by name: SCOPE_SPECIFIC holds out the filenames a lead
+  // could reach for, so what is left has to say which file it means.
   it("names the file for every kind that has one to name", () => {
     expect(PROBLEM_LEADS["lock-corrupt"]?.(PLACE)).toContain(
       "record of what it installed",

--- a/ui/src/lib/error-copy.ts
+++ b/ui/src/lib/error-copy.ts
@@ -1,6 +1,15 @@
 // Per-kind copy for the error modal and the persistent problems list — kept
 // out of labels.ts so that file's routine product vocabulary doesn't have to
 // carry this denser, failure-specific prose too.
+//
+// Nothing in this file names a file or a scope. Both are the engine's to
+// know: `manifest::file::manifest_path` and `lock::lock_path` route a
+// place's files by what that place is, and every kind below arrives from
+// Personal as readily as from a project. The card already carries both —
+// the engine's message names the exact path, and PlaceCard's name line
+// under the heading names the place — so copy spelling out either can only
+// contradict what the reader sees beside it. A lead names its file by
+// role; a step points at the file named above.
 import type { ProblemKind } from "@/stores/problems";
 
 // Nothing converts a file from another version of kendex, so "old" and
@@ -8,21 +17,12 @@ import type { ProblemKind } from "@/stores/problems";
 // lock-corrupt either way, and a manifest an older kendex wrote is
 // manifest-outdated. The two are kept apart because the remedies differ —
 // a lock is a cache to throw away, a manifest is what the person wrote.
-//
-// Both kinds arrive from Personal as readily as from a project, and no
-// filename holds across the places they arrive from: the two scopes keep
-// their locks under different names and their pi files under different
-// roots, and a source catalog keeps its install state in kendex-local.toml
-// while its kendex.toml is the catalog it publishes. So this copy names no
-// path of its own: the card prints the error above these steps and the
-// error carries the path, and the card's own heading says which place it
-// is about.
 export const PROBLEM_HEADLINES: Record<ProblemKind, string> = {
   "lock-corrupt": "A kendex file can't be read",
   "manifest-outdated": "This manifest comes from an older version",
-  "schema-too-new": "This project's kendex files come from a newer version",
-  "manifest-invalid": "This project's manifest has a problem",
-  other: "Something went wrong in this project",
+  "schema-too-new": "These kendex files come from a newer version",
+  "manifest-invalid": "This manifest has a problem",
+  other: "Something went wrong here",
   "scan-failure": "kendex couldn't scan this machine",
 };
 
@@ -41,13 +41,13 @@ export const PROBLEM_STEPS: Record<ProblemKind, string[]> = {
     "Rescan once you're up to date",
   ],
   "manifest-invalid": [
-    "Open the file named above and check its syntax",
+    "Open the file named above and make the fix the message names",
     "Rescan once it's fixed",
   ],
-  other: [
-    "Rescan to retry",
-    "If it keeps failing, stop tracking this project and re-add it",
-  ],
+  // Rescanning is the only move this copy can name. The other way out of a
+  // failure with no known cause is the stop-tracking button, which the card
+  // draws only where there is a project to stop tracking.
+  other: ["Rescan to retry"],
   "scan-failure": [
     "Try scanning again",
     "Check that kendex can still read your harness folders",
@@ -56,16 +56,8 @@ export const PROBLEM_STEPS: Record<ProblemKind, string[]> = {
 
 // Which file, and where. The engine's message names the exact path, but it
 // names it inside a sentence written for a terminal; the card says the same
-// thing first, in the words the reader already has for the place.
-//
-// Each lead names the file by what it is and never by its name, the rule
-// the headings and steps above already hold to. No filename here is fixed:
-// a scope's lock is `.kendex-lock.json` or `lock.json` by scope, and its
-// manifest is `kendex.toml` except in a source catalog, where install state
-// goes to `kendex-local.toml` (`manifest::file::manifest_path`) and the
-// published `kendex.toml` is a different file entirely. A lead naming one
-// sits directly above an error naming the other, and the steps then say to
-// move "the file named above" with two candidates under it.
+// thing first, in the words the reader already has for the place. By role,
+// never by name, per the rule in this file's header.
 //
 // Null where there is no one file to name — a scan failure is about no
 // place at all, `other` is whatever the engine couldn't finish, and a

--- a/ui/src/lib/error-copy.ts
+++ b/ui/src/lib/error-copy.ts
@@ -9,11 +9,14 @@ import type { ProblemKind } from "@/stores/problems";
 // manifest-outdated. The two are kept apart because the remedies differ —
 // a lock is a cache to throw away, a manifest is what the person wrote.
 //
-// Both kinds arrive from Personal as readily as from a project, and the
-// two scopes keep their locks under different names and their pi files
-// under different roots. So this copy names no path of its own: the card
-// prints the error above these steps and the error carries the path, and
-// the card's own heading says which place it is about.
+// Both kinds arrive from Personal as readily as from a project, and no
+// filename holds across the places they arrive from: the two scopes keep
+// their locks under different names and their pi files under different
+// roots, and a source catalog keeps its install state in kendex-local.toml
+// while its kendex.toml is the catalog it publishes. So this copy names no
+// path of its own: the card prints the error above these steps and the
+// error carries the path, and the card's own heading says which place it
+// is about.
 export const PROBLEM_HEADLINES: Record<ProblemKind, string> = {
   "lock-corrupt": "A kendex file can't be read",
   "manifest-outdated": "This manifest comes from an older version",
@@ -38,7 +41,7 @@ export const PROBLEM_STEPS: Record<ProblemKind, string[]> = {
     "Rescan once you're up to date",
   ],
   "manifest-invalid": [
-    "Open the project's kendex.toml and check its syntax",
+    "Open the file named above and check its syntax",
     "Rescan once it's fixed",
   ],
   other: [
@@ -53,10 +56,16 @@ export const PROBLEM_STEPS: Record<ProblemKind, string[]> = {
 
 // Which file, and where. The engine's message names the exact path, but it
 // names it inside a sentence written for a terminal; the card says the same
-// thing first, in the words the reader already has for the place. It names
-// no path of its own for the same reason the steps below don't: the two
-// scopes keep their locks under different names, and only the error knows
-// which one this was.
+// thing first, in the words the reader already has for the place.
+//
+// Each lead names the file by what it is and never by its name, the rule
+// the headings and steps above already hold to. No filename here is fixed:
+// a scope's lock is `.kendex-lock.json` or `lock.json` by scope, and its
+// manifest is `kendex.toml` except in a source catalog, where install state
+// goes to `kendex-local.toml` (`manifest::file::manifest_path`) and the
+// published `kendex.toml` is a different file entirely. A lead naming one
+// sits directly above an error naming the other, and the steps then say to
+// move "the file named above" with two candidates under it.
 //
 // Null where there is no one file to name — a scan failure is about no
 // place at all, `other` is whatever the engine couldn't finish, and a
@@ -67,8 +76,10 @@ export const PROBLEM_LEADS: Record<
 > = {
   "lock-corrupt": (place) =>
     `The file is kendex's record of what it installed in ${place}.`,
-  "manifest-outdated": (place) => `The file is the kendex.toml in ${place}.`,
-  "manifest-invalid": (place) => `The file is the kendex.toml in ${place}.`,
+  "manifest-outdated": (place) =>
+    `The file is where ${place} declares what it wants installed.`,
+  "manifest-invalid": (place) =>
+    `The file is where ${place} declares what it wants installed.`,
   "schema-too-new": null,
   other: null,
   "scan-failure": null,

--- a/ui/src/lib/error-copy.ts
+++ b/ui/src/lib/error-copy.ts
@@ -2,14 +2,21 @@
 // out of labels.ts so that file's routine product vocabulary doesn't have to
 // carry this denser, failure-specific prose too.
 //
-// Nothing in this file names a file or a scope. Both are the engine's to
-// know: `manifest::file::manifest_path` and `lock::lock_path` route a
-// place's files by what that place is, and every kind below arrives from
-// Personal as readily as from a project. The card already carries both —
-// the engine's message names the exact path, and PlaceCard's name line
-// under the heading names the place — so copy spelling out either can only
-// contradict what the reader sees beside it. A lead names its file by
-// role; a step points at the file named above.
+// Nothing here names a file whose name varies by place, and nothing here
+// names the place. Both are the engine's to know: `manifest_path` and
+// `lock_path` (crates/core/src/manifest/file.rs, crates/core/src/lock.rs)
+// route a scope's manifest and lock by what that scope is, and every kind
+// carrying a scope arrives from Personal as readily as from a project. The
+// card already carries both — the engine's message names the exact path,
+// and PlaceCard's name line under the heading names the place — so copy
+// spelling out either can only contradict what the reader sees beside it.
+// A lead names its file by role; a step points at the file named above.
+//
+// A name every place spells the same, like a harness's own hooks.json, is
+// not one of those files and is free to appear. And scan-failure is the
+// one kind with no scope to get wrong — it is about the machine rather
+// than a place in it — so the scope half doesn't reach it; the guard in
+// error-copy.test.ts exempts it by name.
 import type { ProblemKind } from "@/stores/problems";
 
 // Nothing converts a file from another version of kendex, so "old" and

--- a/ui/src/lib/error-copy.ts
+++ b/ui/src/lib/error-copy.ts
@@ -51,6 +51,29 @@ export const PROBLEM_STEPS: Record<ProblemKind, string[]> = {
   ],
 };
 
+// Which file, and where. The engine's message names the exact path, but it
+// names it inside a sentence written for a terminal; the card says the same
+// thing first, in the words the reader already has for the place. It names
+// no path of its own for the same reason the steps below don't: the two
+// scopes keep their locks under different names, and only the error knows
+// which one this was.
+//
+// Null where there is no one file to name — a scan failure is about no
+// place at all, `other` is whatever the engine couldn't finish, and a
+// too-new schema can be either file. A lead line there would be a guess.
+export const PROBLEM_LEADS: Record<
+  ProblemKind,
+  ((place: string) => string) | null
+> = {
+  "lock-corrupt": (place) =>
+    `The file is kendex's record of what it installed in ${place}.`,
+  "manifest-outdated": (place) => `The file is the kendex.toml in ${place}.`,
+  "manifest-invalid": (place) => `The file is the kendex.toml in ${place}.`,
+  "schema-too-new": null,
+  other: null,
+  "scan-failure": null,
+};
+
 export const PROBLEMS_SUBTITLE =
   "What kendex can't finish on its own, and what to do about it";
 export const PROBLEMS_EMPTY = "No problems right now.";


### PR DESCRIPTION
## Summary

- The Problems card leads with a plain-words line naming the place and, by role, which of its files kendex couldn't read; the verbatim engine message takes the card's own text colour instead of muted, and the steps read at body size.
- Problem copy names no file whose name the engine routes by place, and no place. Both are the engine's to know — a card that spelled either out could contradict the message printed beside it, and the `manifest-outdated` step's "move the file named above" would gain a second, wrong referent.
- Three headlines stopped calling a Personal problem a project's, and the `manifest-invalid` step stopped asking for a syntax check that is never that kind's cause.

## Context

Review turned up one blocker that five internal reviewers and the external (codex) lane reached independently: the first draft's manifest leads hard-coded `kendex.toml`, but `manifest_path` (`crates/core/src/manifest/file.rs:47`) routes a `is_source_catalog = true` root to `kendex-local.toml` and `Scope::Global` to the app config dir. This repo's own `kendex.toml:9` sets that flag, so the card would have named one file directly above an engine message naming another — under a step telling the reader to move "the file named above" aside. Reproduced against the built CLI.

Two guards now make the class unrepresentable rather than fixed per site: `SCOPE_SPECIFIC` rejects any problem copy naming a place-routed filename, and `SCOPE_WORDS` rejects any copy claiming a scope the card's own name line answers. Both were proven non-vacuous by must-fail controls.

## Completed Issues

- Closes KEN-1137 - Problems card: readable error block and body-size bullets

## QA Metrics

| Check | Result |
|---|---|
| UI suite | 123 files, 1008 tests, passing |
| `tsc --noEmit` | clean |
| preflight | clean |
| Review cycles | 3 internal (10-lane panel + external codex), 0 blockers outstanding |
| Fixes applied | 12 across 4 rounds; 0 escalated |
| Visual QA | lock-corrupt, source-catalog `manifest-invalid`, global `manifest-invalid`, global `other`, project `schema-too-new`, both themes |

## Test Plan

1. `npx vitest run --prefix ui` — 1008 tests.
2. Register a source-catalog project (any root whose `kendex.toml` sets `is_source_catalog = true`, this checkout included) and corrupt its `kendex-local.toml`. The card's lead names the file by role, so it agrees with the engine message below it, and "Open the file named above" has one referent.
3. Corrupt `~/.config/kendex/kendex.toml` and open Problems. The card reads "This manifest has a problem" over a name line reading Personal — not "This project's".
4. Must-fail controls, all verified during review: restoring any of the three old headlines, giving a step or lead a scope word, naming `kendex.toml` or `kendex-local.toml` in any problem copy, or dropping the stop-tracking control each reddens the suite.

Declined during review: extracting the shared engine-message block with `ui/src/components/error-dialog.tsx`. That dialog is a different surface reached by a different flow, this change leaves its rendering byte-identical to what shipped, and the extraction is a cross-component refactor KEN-1137's Done-when does not need.

https://claude.ai/code/session_01UhNk6o8p9CL1kNdK2zghQK
