### PR TITLE
fix(KEN-1112): keep Rust risk flags on diffs past the pipe buffer

### DIFF
--- a/.agents/skills/code-quality/SKILL.md
+++ b/.agents/skills/code-quality/SKILL.md
@@ -53,7 +53,7 @@ A new or modified check, guard, assertion, or test ships with a must-fail contro
 
 - **Rust**: make illegal states unrepresentable; exhaustive matches (no `_ =>` over enums you own); enums over strings/sentinels/booleans-with-meaning. A test that hands a temporary path to code that may resolve symlinks binds its canonical root at creation and passes that binding, never the raw path; platform-only test APIs carry a `cfg` and, when the property is portable, a portable twin.
 - **Bash**: `set -euo pipefail` in every new script; check the result of every effectful substitution; `--` before path arguments sourced from configuration, argv, or the environment (not paths the script built itself, e.g. `mktemp -d`); no `[A-Za-z]`-class assumptions under arbitrary locales.
-- In a `pipefail` suite, never leave a pipeline unguarded when an early-closing `head` or `grep -q` can stop reading while its producer still writes; SIGPIPE can return 141 and exit the suite.
+- In any `pipefail` script, never leave a pipeline unguarded when an early-closing `head` or `grep -q` can stop reading while its producer still writes: the 141 SIGPIPE status aborts the run where `errexit` fires, and in condition position, where it does not, reads as a plain false that drops the result with no error.
 - Measure a commit header with growth-guards' locale-stable `gg_chars`, never raw `awk length` or `wc -c`.
 - **TypeScript/JS**: distinguish missing from present-but-falsy (`""`, `0`) at every guard; no `any` at module boundaries.
 

--- a/.agents/skills/github/scripts/git-diff-summary
+++ b/.agents/skills/github/scripts/git-diff-summary
@@ -221,7 +221,7 @@ DECL_CACHE=""
 SCANNED_DIRS=""
 
 set_contains() {
-    printf '%s' "$2" | grep -Fxq -- "$1"
+    grep -Fxq -- "$1" <<<"$2"
 }
 
 # Scan one declaring module, appending its records to DECL_CACHE. Called
@@ -399,10 +399,10 @@ main() {
     scan_diff rust_diff_added "risk flags" "$diff_ref" -- '*.rs'
     rust_diff_added=$(printf '%s\n' "$rust_diff_added" | grep -E '^\+' || true)
 
-    if echo "$rust_diff_added" | grep -qE '^\+.*unsafe '; then flags+=("unsafe_code_added"); fi
-    if echo "$rust_diff_added" | grep -qE '^\+.*#\[repr\(C\)\]'; then flags+=("repr_c_struct_changed"); fi
-    if echo "$rust_diff_added" | grep -qE '^\+.*extern "C"'; then flags+=("extern_c_changed"); fi
-    if echo "$rust_diff_added" | grep -qE '^\+.*(Atomic|atomic::)'; then flags+=("atomics_modified"); fi
+    if grep -qE '^\+.*unsafe ' <<<"$rust_diff_added"; then flags+=("unsafe_code_added"); fi
+    if grep -qE '^\+.*#\[repr\(C\)\]' <<<"$rust_diff_added"; then flags+=("repr_c_struct_changed"); fi
+    if grep -qE '^\+.*extern "C"' <<<"$rust_diff_added"; then flags+=("extern_c_changed"); fi
+    if grep -qE '^\+.*(Atomic|atomic::)' <<<"$rust_diff_added"; then flags+=("atomics_modified"); fi
 
     # panic/unwrap in production source is the `panic_path_added` risk flag.
     # The same patterns whose enclosing context is a test surface — tests/
@@ -518,7 +518,7 @@ main() {
         local test_diff=""
         scan_diff test_diff "test panic paths" "$diff_ref" -- "${test_path_args[@]}"
         test_diff=$(printf '%s\n' "$test_diff" | grep -E '^\+' || true)
-        if echo "$test_diff" | grep -qE '^\+.*(panic!|unwrap\(\))'; then test_panic=1; fi
+        if grep -qE '^\+.*(panic!|unwrap\(\))' <<<"$test_diff"; then test_panic=1; fi
     fi
     if [ "$test_panic" -eq 1 ]; then flags+=("test_panic_path_added"); fi
 

--- a/.agents/skills/github/scripts/git-diff-summary
+++ b/.agents/skills/github/scripts/git-diff-summary
@@ -29,8 +29,8 @@ Risk flags:
   unsafe_code_added, repr_c_struct_changed, extern_c_changed,
   atomics_modified
                  Rust-specific flags; each scans ADDED lines in .rs diffs
-                 only (unsafe blocks, #[repr(C)] structs, extern "C" items,
-                 atomics use)
+                 only, for a line containing `unsafe ` (fn/impl/trait/block),
+                 `#[repr(C)]`, `extern "C"`, or `Atomic`/`atomic::`
   panic_path_added
                  panic patterns (panic!/unwrap()) added to production source
   test_panic_path_added

--- a/.agents/skills/github/tests/git-diff-summary-risk-flags.test.sh
+++ b/.agents/skills/github/tests/git-diff-summary-risk-flags.test.sh
@@ -93,9 +93,13 @@ assert_eq "Rust source still emits Rust risk flags" '["unsafe_code_added","repr_
 assert_eq "Rust source is production scope" "production" "$(jq -r '.scope' <<<"$rust_json")"
 
 # An early match must survive an input large enough for grep -q to close its
-# pipe while the producer is still writing. Under one 64 KB pipe buffer the
-# whole diff is buffered before grep reads, so the producer never blocks and
-# the bug cannot appear; two buffers' worth keeps git writing past the match.
+# pipe while its producer is still writing. git is not that producer:
+# scan_diff drains git diff to EOF into a shell variable, so the pipeline's
+# writer is the shell replaying that captured, ^+-filtered string. Under one
+# 64 KB pipe buffer the whole string fits and the writer never blocks, so the
+# bug cannot appear; two buffers' worth keeps it writing past the match.
+# wc -c measures the file, a conservative lower bound on the piped string,
+# which carries a + per line on top of it.
 large_repo="$SANDBOX/large-early-match"
 init_repo "$large_repo"
 mkdir -p "$large_repo/tests"

--- a/.agents/skills/github/tests/git-diff-summary-risk-flags.test.sh
+++ b/.agents/skills/github/tests/git-diff-summary-risk-flags.test.sh
@@ -87,6 +87,24 @@ rust_json="$($SUMMARY -C "$rust_repo" --staged)"
 assert_eq "Rust source still emits Rust risk flags" '["unsafe_code_added","repr_c_struct_changed","extern_c_changed","atomics_modified"]' "$(jq -c '.risk_flags' <<<"$rust_json")"
 assert_eq "Rust source is production scope" "production" "$(jq -r '.scope' <<<"$rust_json")"
 
+# An early match must survive an input large enough for grep -q to close its
+# pipe while the producer is still writing.
+large_repo="$SANDBOX/large-early-match"
+init_repo "$large_repo"
+mkdir -p "$large_repo/tests"
+{
+    printf 'pub unsafe fn first() { panic!("boom"); }\n'
+    awk 'BEGIN { line = "// "; for (i = 0; i < 500; i++) line = line "x"; for (i = 0; i < 800; i++) print line }'
+} > "$large_repo/tests/large.rs"
+large_bytes=$(wc -c < "$large_repo/tests/large.rs")
+if [ "$large_bytes" -le 300000 ]; then
+    printf '  FAIL: large early-match fixture is only %s bytes\n' "$large_bytes" >&2
+    exit 1
+fi
+git -C "$large_repo" add tests/large.rs
+large_json="$($SUMMARY -C "$large_repo" --staged)"
+assert_eq "large diff keeps first-line Rust and test-panic flags" '["unsafe_code_added","test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$large_json")"
+
 # kendex#944: panic patterns in #[cfg(test)] modules inside production files
 cfg_test_repo="$SANDBOX/cfg-test"
 init_repo "$cfg_test_repo"

--- a/.agents/skills/github/tests/git-diff-summary-risk-flags.test.sh
+++ b/.agents/skills/github/tests/git-diff-summary-risk-flags.test.sh
@@ -12,6 +12,11 @@
 # Run: bash skills/github/tests/git-diff-summary-risk-flags.test.sh
 set -euo pipefail
 
+# A suite running from inside a git hook inherits GIT_DIR, GIT_COMMON_DIR,
+# GIT_WORK_TREE and GIT_INDEX_FILE, which take precedence over `git -C` and
+# would stage fixture blobs into the real repository.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
 SUMMARY="$REPO_ROOT/skills/github/scripts/git-diff-summary"
@@ -88,22 +93,31 @@ assert_eq "Rust source still emits Rust risk flags" '["unsafe_code_added","repr_
 assert_eq "Rust source is production scope" "production" "$(jq -r '.scope' <<<"$rust_json")"
 
 # An early match must survive an input large enough for grep -q to close its
-# pipe while the producer is still writing.
+# pipe while the producer is still writing. Under one 64 KB pipe buffer the
+# whole diff is buffered before grep reads, so the producer never blocks and
+# the bug cannot appear; two buffers' worth keeps git writing past the match.
 large_repo="$SANDBOX/large-early-match"
 init_repo "$large_repo"
 mkdir -p "$large_repo/tests"
 {
+    printf 'use std::sync::atomic::AtomicUsize;\n'
+    printf '#[repr(C)]\n'
+    printf 'pub struct Early { value: AtomicUsize }\n'
+    printf 'extern "C" { fn ffi_entry(); }\n'
     printf 'pub unsafe fn first() { panic!("boom"); }\n'
-    awk 'BEGIN { line = "// "; for (i = 0; i < 500; i++) line = line "x"; for (i = 0; i < 800; i++) print line }'
+    awk 'BEGIN { line = "// "; for (i = 0; i < 500; i++) line = line "x"; for (i = 0; i < 264; i++) print line }'
 } > "$large_repo/tests/large.rs"
 large_bytes=$(wc -c < "$large_repo/tests/large.rs")
-if [ "$large_bytes" -le 300000 ]; then
-    printf '  FAIL: large early-match fixture is only %s bytes\n' "$large_bytes" >&2
-    exit 1
+large_min_bytes=$((2 * 65536))
+if [ "$large_bytes" -ge "$large_min_bytes" ]; then
+    large_size="ok"
+else
+    large_size="$large_bytes bytes"
 fi
+assert_eq "large early-match fixture outruns two 64 KB pipe buffers" "ok" "$large_size"
 git -C "$large_repo" add tests/large.rs
 large_json="$($SUMMARY -C "$large_repo" --staged)"
-assert_eq "large diff keeps first-line Rust and test-panic flags" '["unsafe_code_added","test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$large_json")"
+assert_eq "large diff keeps every early-line risk flag" '["unsafe_code_added","repr_c_struct_changed","extern_c_changed","atomics_modified","test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$large_json")"
 
 # kendex#944: panic patterns in #[cfg(test)] modules inside production files
 cfg_test_repo="$SANDBOX/cfg-test"

--- a/changelog.d/fixed/KEN-1112.md
+++ b/changelog.d/fixed/KEN-1112.md
@@ -1,0 +1,1 @@
+- The GitHub skill's diff summary now keeps Rust risk flags on large diffs instead of dropping early matches under `pipefail`.

--- a/skills/code-quality/SKILL.md
+++ b/skills/code-quality/SKILL.md
@@ -47,7 +47,7 @@ A new or modified check, guard, assertion, or test ships with a must-fail contro
 
 - **Rust**: make illegal states unrepresentable; exhaustive matches (no `_ =>` over enums you own); enums over strings/sentinels/booleans-with-meaning. A test that hands a temporary path to code that may resolve symlinks binds its canonical root at creation and passes that binding, never the raw path; platform-only test APIs carry a `cfg` and, when the property is portable, a portable twin.
 - **Bash**: `set -euo pipefail` in every new script; check the result of every effectful substitution; `--` before path arguments sourced from configuration, argv, or the environment (not paths the script built itself, e.g. `mktemp -d`); no `[A-Za-z]`-class assumptions under arbitrary locales.
-- In a `pipefail` suite, never leave a pipeline unguarded when an early-closing `head` or `grep -q` can stop reading while its producer still writes; SIGPIPE can return 141 and exit the suite.
+- In any `pipefail` script, never leave a pipeline unguarded when an early-closing `head` or `grep -q` can stop reading while its producer still writes: the 141 SIGPIPE status aborts the run where `errexit` fires, and in condition position, where it does not, reads as a plain false that drops the result with no error.
 - Measure a commit header with growth-guards' locale-stable `gg_chars`, never raw `awk length` or `wc -c`.
 - **TypeScript/JS**: distinguish missing from present-but-falsy (`""`, `0`) at every guard; no `any` at module boundaries.
 

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -221,7 +221,7 @@ DECL_CACHE=""
 SCANNED_DIRS=""
 
 set_contains() {
-    printf '%s' "$2" | grep -Fxq -- "$1"
+    grep -Fxq -- "$1" <<<"$2"
 }
 
 # Scan one declaring module, appending its records to DECL_CACHE. Called
@@ -399,10 +399,10 @@ main() {
     scan_diff rust_diff_added "risk flags" "$diff_ref" -- '*.rs'
     rust_diff_added=$(printf '%s\n' "$rust_diff_added" | grep -E '^\+' || true)
 
-    if echo "$rust_diff_added" | grep -qE '^\+.*unsafe '; then flags+=("unsafe_code_added"); fi
-    if echo "$rust_diff_added" | grep -qE '^\+.*#\[repr\(C\)\]'; then flags+=("repr_c_struct_changed"); fi
-    if echo "$rust_diff_added" | grep -qE '^\+.*extern "C"'; then flags+=("extern_c_changed"); fi
-    if echo "$rust_diff_added" | grep -qE '^\+.*(Atomic|atomic::)'; then flags+=("atomics_modified"); fi
+    if grep -qE '^\+.*unsafe ' <<<"$rust_diff_added"; then flags+=("unsafe_code_added"); fi
+    if grep -qE '^\+.*#\[repr\(C\)\]' <<<"$rust_diff_added"; then flags+=("repr_c_struct_changed"); fi
+    if grep -qE '^\+.*extern "C"' <<<"$rust_diff_added"; then flags+=("extern_c_changed"); fi
+    if grep -qE '^\+.*(Atomic|atomic::)' <<<"$rust_diff_added"; then flags+=("atomics_modified"); fi
 
     # panic/unwrap in production source is the `panic_path_added` risk flag.
     # The same patterns whose enclosing context is a test surface — tests/
@@ -518,7 +518,7 @@ main() {
         local test_diff=""
         scan_diff test_diff "test panic paths" "$diff_ref" -- "${test_path_args[@]}"
         test_diff=$(printf '%s\n' "$test_diff" | grep -E '^\+' || true)
-        if echo "$test_diff" | grep -qE '^\+.*(panic!|unwrap\(\))'; then test_panic=1; fi
+        if grep -qE '^\+.*(panic!|unwrap\(\))' <<<"$test_diff"; then test_panic=1; fi
     fi
     if [ "$test_panic" -eq 1 ]; then flags+=("test_panic_path_added"); fi
 

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -29,8 +29,8 @@ Risk flags:
   unsafe_code_added, repr_c_struct_changed, extern_c_changed,
   atomics_modified
                  Rust-specific flags; each scans ADDED lines in .rs diffs
-                 only (unsafe blocks, #[repr(C)] structs, extern "C" items,
-                 atomics use)
+                 only, for a line containing `unsafe ` (fn/impl/trait/block),
+                 `#[repr(C)]`, `extern "C"`, or `Atomic`/`atomic::`
   panic_path_added
                  panic patterns (panic!/unwrap()) added to production source
   test_panic_path_added

--- a/skills/github/tests/git-diff-summary-risk-flags.test.sh
+++ b/skills/github/tests/git-diff-summary-risk-flags.test.sh
@@ -93,9 +93,13 @@ assert_eq "Rust source still emits Rust risk flags" '["unsafe_code_added","repr_
 assert_eq "Rust source is production scope" "production" "$(jq -r '.scope' <<<"$rust_json")"
 
 # An early match must survive an input large enough for grep -q to close its
-# pipe while the producer is still writing. Under one 64 KB pipe buffer the
-# whole diff is buffered before grep reads, so the producer never blocks and
-# the bug cannot appear; two buffers' worth keeps git writing past the match.
+# pipe while its producer is still writing. git is not that producer:
+# scan_diff drains git diff to EOF into a shell variable, so the pipeline's
+# writer is the shell replaying that captured, ^+-filtered string. Under one
+# 64 KB pipe buffer the whole string fits and the writer never blocks, so the
+# bug cannot appear; two buffers' worth keeps it writing past the match.
+# wc -c measures the file, a conservative lower bound on the piped string,
+# which carries a + per line on top of it.
 large_repo="$SANDBOX/large-early-match"
 init_repo "$large_repo"
 mkdir -p "$large_repo/tests"

--- a/skills/github/tests/git-diff-summary-risk-flags.test.sh
+++ b/skills/github/tests/git-diff-summary-risk-flags.test.sh
@@ -87,6 +87,24 @@ rust_json="$($SUMMARY -C "$rust_repo" --staged)"
 assert_eq "Rust source still emits Rust risk flags" '["unsafe_code_added","repr_c_struct_changed","extern_c_changed","atomics_modified"]' "$(jq -c '.risk_flags' <<<"$rust_json")"
 assert_eq "Rust source is production scope" "production" "$(jq -r '.scope' <<<"$rust_json")"
 
+# An early match must survive an input large enough for grep -q to close its
+# pipe while the producer is still writing.
+large_repo="$SANDBOX/large-early-match"
+init_repo "$large_repo"
+mkdir -p "$large_repo/tests"
+{
+    printf 'pub unsafe fn first() { panic!("boom"); }\n'
+    awk 'BEGIN { line = "// "; for (i = 0; i < 500; i++) line = line "x"; for (i = 0; i < 800; i++) print line }'
+} > "$large_repo/tests/large.rs"
+large_bytes=$(wc -c < "$large_repo/tests/large.rs")
+if [ "$large_bytes" -le 300000 ]; then
+    printf '  FAIL: large early-match fixture is only %s bytes\n' "$large_bytes" >&2
+    exit 1
+fi
+git -C "$large_repo" add tests/large.rs
+large_json="$($SUMMARY -C "$large_repo" --staged)"
+assert_eq "large diff keeps first-line Rust and test-panic flags" '["unsafe_code_added","test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$large_json")"
+
 # kendex#944: panic patterns in #[cfg(test)] modules inside production files
 cfg_test_repo="$SANDBOX/cfg-test"
 init_repo "$cfg_test_repo"

--- a/skills/github/tests/git-diff-summary-risk-flags.test.sh
+++ b/skills/github/tests/git-diff-summary-risk-flags.test.sh
@@ -12,6 +12,11 @@
 # Run: bash skills/github/tests/git-diff-summary-risk-flags.test.sh
 set -euo pipefail
 
+# A suite running from inside a git hook inherits GIT_DIR, GIT_COMMON_DIR,
+# GIT_WORK_TREE and GIT_INDEX_FILE, which take precedence over `git -C` and
+# would stage fixture blobs into the real repository.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
 SUMMARY="$REPO_ROOT/skills/github/scripts/git-diff-summary"
@@ -88,22 +93,31 @@ assert_eq "Rust source still emits Rust risk flags" '["unsafe_code_added","repr_
 assert_eq "Rust source is production scope" "production" "$(jq -r '.scope' <<<"$rust_json")"
 
 # An early match must survive an input large enough for grep -q to close its
-# pipe while the producer is still writing.
+# pipe while the producer is still writing. Under one 64 KB pipe buffer the
+# whole diff is buffered before grep reads, so the producer never blocks and
+# the bug cannot appear; two buffers' worth keeps git writing past the match.
 large_repo="$SANDBOX/large-early-match"
 init_repo "$large_repo"
 mkdir -p "$large_repo/tests"
 {
+    printf 'use std::sync::atomic::AtomicUsize;\n'
+    printf '#[repr(C)]\n'
+    printf 'pub struct Early { value: AtomicUsize }\n'
+    printf 'extern "C" { fn ffi_entry(); }\n'
     printf 'pub unsafe fn first() { panic!("boom"); }\n'
-    awk 'BEGIN { line = "// "; for (i = 0; i < 500; i++) line = line "x"; for (i = 0; i < 800; i++) print line }'
+    awk 'BEGIN { line = "// "; for (i = 0; i < 500; i++) line = line "x"; for (i = 0; i < 264; i++) print line }'
 } > "$large_repo/tests/large.rs"
 large_bytes=$(wc -c < "$large_repo/tests/large.rs")
-if [ "$large_bytes" -le 300000 ]; then
-    printf '  FAIL: large early-match fixture is only %s bytes\n' "$large_bytes" >&2
-    exit 1
+large_min_bytes=$((2 * 65536))
+if [ "$large_bytes" -ge "$large_min_bytes" ]; then
+    large_size="ok"
+else
+    large_size="$large_bytes bytes"
 fi
+assert_eq "large early-match fixture outruns two 64 KB pipe buffers" "ok" "$large_size"
 git -C "$large_repo" add tests/large.rs
 large_json="$($SUMMARY -C "$large_repo" --staged)"
-assert_eq "large diff keeps first-line Rust and test-panic flags" '["unsafe_code_added","test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$large_json")"
+assert_eq "large diff keeps every early-line risk flag" '["unsafe_code_added","repr_c_struct_changed","extern_c_changed","atomics_modified","test_panic_path_added"]' "$(jq -c '.risk_flags' <<<"$large_json")"
 
 # kendex#944: panic patterns in #[cfg(test)] modules inside production files
 cfg_test_repo="$SANDBOX/cfg-test"


### PR DESCRIPTION
## Summary
- `git-diff-summary` dropped Rust risk flags on any diff past the 64KB pipe buffer. Under `set -euo pipefail`, `grep -q` exits on its first match, the shell replaying the captured diff then dies of SIGPIPE, and `pipefail` turns the pipeline status into 141. The `if` reads that as false and the flag vanishes even though the pattern matched. Five sites now feed `grep` by here-string, plus `set_contains`, which had the same shape.
- A regression fixture larger than two pipe buffers, with the match on its early lines, asserts all five flags. Each converted site has a must-fail control: revert any one to the pipe form and the suite reddens.
- The `--help` gloss and the code-quality `pipefail` rule both described the mechanism too narrowly to catch this bug. Both now say what the code does.

## Completed Issues
- Closes KEN-1112 - git-diff-summary: SIGPIPE under pipefail drops Rust risk flags on diffs past the pipe buffer

## Created Issues
- KEN-1143 - ci-wait's transient retry and verify-lib's failure report die of SIGPIPE under pipefail — Project: Skills & Agents Library

## QA Metrics
Performance (reviewer-perf, 25 samples per arm, interleaved against `main`'s script over the branch's own 133,216-byte fixture): p50 174.1ms to 176.3ms, p95 177.8ms to 178.6ms. That 1.3% sits inside run-to-run drift, and the branch does strictly more work here, since `main`'s version returns `[]`, which is the bug. The added test case costs about 0.2s, down from 2.0s before the fixture was resized.

Mutation controls (reviewer-test, reverting each converted site to the pipe form): all five killed 1/1 at stability 10/10, 64 threads. Three of them were 0/1 before the fixture was widened.

## Test Plan
- `bash skills/github/tests/git-diff-summary-risk-flags.test.sh` gives 10 pass, 0 fail.
- Must-fail control: the same suite against the pre-fix script fails the large-diff case with `risk_flags []`.
- The `unset GIT_*` line has its own control. Remove it, run under a hook-shaped `GIT_DIR` and `GIT_INDEX_FILE`, and the suite stages fixture blobs into the host repository's index. With the line present it writes nothing.
- `tools/guard` and `preflight` are green. The `skills/` and `.agents/` copies are byte-identical.

https://claude.ai/code/session_01QDNvUqVU5tJu6xwgkny3fA
