### PR TITLE
fix(KEN-796): linear sync names both truncations instead of hiding them

### DIFF
--- a/.agents/skills/linear/scripts/commands/sync.sh
+++ b/.agents/skills/linear/scripts/commands/sync.sh
@@ -109,7 +109,7 @@ sync_issues() {
         if (( page_count >= max_pages )); then
             local issue_count
             issue_count=$(echo "$all_nodes" | jq 'length')
-            echo "Sync warning: issues stopped at the $max_pages-page safety cap after caching $issue_count issues; more pages remain, so the cache is truncated." >&2
+            echo "Sync warning: issues stopped at the $max_pages-page safety cap after fetching $issue_count issues; more pages remain, so this pull is incomplete." >&2
             break
         fi
 

--- a/.agents/skills/linear/scripts/commands/sync.sh
+++ b/.agents/skills/linear/scripts/commands/sync.sh
@@ -102,7 +102,14 @@ sync_issues() {
 
         page_count=$((page_count + 1))
 
-        if [[ "$has_next" != "true" ]] || (( page_count >= max_pages )); then
+        if [[ "$has_next" != "true" ]]; then
+            break
+        fi
+
+        if (( page_count >= max_pages )); then
+            local issue_count
+            issue_count=$(echo "$all_nodes" | jq 'length')
+            echo "Sync warning: issues stopped at the $max_pages-page safety cap after caching $issue_count issues; more pages remain, so the cache is truncated." >&2
             break
         fi
 

--- a/.agents/skills/linear/tests/controls/sync-issues-page-cap.control.sh
+++ b/.agents/skills/linear/tests/controls/sync-issues-page-cap.control.sh
@@ -1,8 +1,13 @@
 control_replace \
   "scripts/commands/sync.sh" \
   1 \
-  '            echo "Sync warning: issues stopped at the $max_pages-page safety cap after caching $issue_count issues; more pages remain, so the cache is truncated." >&2' \
+  '            echo "Sync warning: issues stopped at the $max_pages-page safety cap after fetching $issue_count issues; more pages remain, so this pull is incomplete." >&2' \
   '            :'
+control_replace \
+  "scripts/commands/sync.sh" \
+  1 \
+  '        if (( page_count >= max_pages )); then' \
+  '        if (( page_count >= 2 )); then'
+control_expect "an under-cap pull reaches its terminal page"
+control_expect "a capped pull emits one warning"
 control_expect "a capped pull warns with the page cap"
-control_expect "a capped pull warning names the number of issues cached"
-control_expect "a capped pull warning says the cache is truncated"

--- a/.agents/skills/linear/tests/controls/sync-issues-page-cap.control.sh
+++ b/.agents/skills/linear/tests/controls/sync-issues-page-cap.control.sh
@@ -2,12 +2,21 @@ control_replace \
   "scripts/commands/sync.sh" \
   1 \
   '            echo "Sync warning: issues stopped at the $max_pages-page safety cap after fetching $issue_count issues; more pages remain, so this pull is incomplete." >&2' \
-  '            :'
+  '            echo "Sync warning: issue pull stopped early after fetching $issue_count issues." >&2; echo "Sync warning: duplicate." >&2'
 control_replace \
   "scripts/commands/sync.sh" \
   1 \
   '        if (( page_count >= max_pages )); then' \
-  '        if (( page_count >= 2 )); then'
+  '        if (( page_count < max_pages )); then'
 control_expect "an under-cap pull reaches its terminal page"
+control_expect "an under-cap pull returns every fetched issue"
+control_expect "an under-cap pull does not warn"
+control_expect "a pull completed on page 200 reaches its terminal page"
+control_expect "a pull completed on page 200 returns every fetched issue"
+control_expect "a pull completed on page 200 does not warn"
+control_expect "the page cap stops the pull at 200 requests"
+control_expect "a capped pull returns every fetched issue"
 control_expect "a capped pull emits one warning"
 control_expect "a capped pull warns with the page cap"
+control_expect "a capped pull warning names the number of issues fetched"
+control_expect "a capped pull warning says the pull is incomplete"

--- a/.agents/skills/linear/tests/controls/sync-issues-page-cap.control.sh
+++ b/.agents/skills/linear/tests/controls/sync-issues-page-cap.control.sh
@@ -1,0 +1,8 @@
+control_replace \
+  "scripts/commands/sync.sh" \
+  1 \
+  '            echo "Sync warning: issues stopped at the $max_pages-page safety cap after caching $issue_count issues; more pages remain, so the cache is truncated." >&2' \
+  '            :'
+control_expect "a capped pull warns with the page cap"
+control_expect "a capped pull warning names the number of issues cached"
+control_expect "a capped pull warning says the cache is truncated"

--- a/.agents/skills/linear/tests/sync-issues-page-cap.test.sh
+++ b/.agents/skills/linear/tests/sync-issues-page-cap.test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # An issues pull that reaches its safety cap still returns the rows it fetched,
-# but says that the cache is truncated and how many rows it contains.
+# but says that the pull is incomplete and how many issues it fetched.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -17,16 +17,31 @@ source "$SYNC"
 
 COUNTER="$TMP_ROOT/calls"
 graphql_query() {
-  local n
+  local n has_next=true
   n=$(( $(cat "$COUNTER") + 1 ))
   echo "$n" >"$COUNTER"
 
-  if [[ "$STUB_MODE" == "complete" ]]; then
-    printf '{"issues":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"identifier":"T-1"}]}}'
-    return 0
-  fi
+  case "$STUB_MODE" in
+    complete) has_next=false ;;
+    under-cap)
+      if (( n >= 3 )); then
+        has_next=false
+      fi
+      ;;
+    exact-cap)
+      if (( n >= 200 )); then
+        has_next=false
+      fi
+      ;;
+    capped) ;;
+    *) return 1 ;;
+  esac
 
-  printf '{"issues":{"pageInfo":{"hasNextPage":true,"endCursor":"c%s"},"nodes":[{"identifier":"T-%s"}]}}' "$n" "$n"
+  if [[ "$STUB_MODE" == "capped" ]]; then
+    printf '{"issues":{"pageInfo":{"hasNextPage":%s,"endCursor":"c%s"},"nodes":[{"identifier":"T-%s-a"},{"identifier":"T-%s-b"}]}}' "$has_next" "$n" "$n" "$n"
+  else
+    printf '{"issues":{"pageInfo":{"hasNextPage":%s,"endCursor":"c%s"},"nodes":[{"identifier":"T-%s"}]}}' "$has_next" "$n" "$n"
+  fi
 }
 
 ERR_FILE="$TMP_ROOT/err"
@@ -38,12 +53,29 @@ assert_eq "a complete pull succeeds" "$rc" "0"
 assert_eq "a complete pull returns its issue" "$(printf '%s' "$OUT" | jq 'length')" "1"
 assert_eq "a complete pull does not warn" "$(cat "$ERR_FILE")" ""
 
+STUB_MODE=under-cap
+echo 0 >"$COUNTER"
+run_output OUT rc sync_issues '' 2>"$ERR_FILE"
+assert_eq "an under-cap pull succeeds" "$rc" "0"
+assert_eq "an under-cap pull reaches its terminal page" "$(cat "$COUNTER")" "3"
+assert_eq "an under-cap pull returns every fetched issue" "$(printf '%s' "$OUT" | jq 'length')" "3"
+assert_eq "an under-cap pull does not warn" "$(cat "$ERR_FILE")" ""
+
+STUB_MODE=exact-cap
+echo 0 >"$COUNTER"
+run_output OUT rc sync_issues '' 2>"$ERR_FILE"
+assert_eq "a pull completed on page 200 succeeds" "$rc" "0"
+assert_eq "a pull completed on page 200 reaches its terminal page" "$(cat "$COUNTER")" "200"
+assert_eq "a pull completed on page 200 returns every fetched issue" "$(printf '%s' "$OUT" | jq 'length')" "200"
+assert_eq "a pull completed on page 200 does not warn" "$(cat "$ERR_FILE")" ""
+
 STUB_MODE=capped
 echo 0 >"$COUNTER"
 run_output OUT rc sync_issues '' 2>"$ERR_FILE"
 assert_eq "a capped pull still returns its fetched issues" "$rc" "0"
 assert_eq "the page cap stops the pull at 200 requests" "$(cat "$COUNTER")" "200"
-assert_eq "a capped pull returns every fetched issue" "$(printf '%s' "$OUT" | jq 'length')" "200"
+assert_eq "a capped pull returns every fetched issue" "$(printf '%s' "$OUT" | jq 'length')" "400"
+assert_eq "a capped pull emits one warning" "$(awk '/Sync warning:/ { count++ } END { print count + 0 }' "$ERR_FILE")" "1"
 assert_file_contains "a capped pull warns with the page cap" "$ERR_FILE" "200-page safety cap"
-assert_file_contains "a capped pull warning names the number of issues cached" "$ERR_FILE" "200 issues"
-assert_file_contains "a capped pull warning says the cache is truncated" "$ERR_FILE" "cache is truncated"
+assert_file_contains "a capped pull warning names the number of issues fetched" "$ERR_FILE" "fetching 400 issues"
+assert_file_contains "a capped pull warning says the pull is incomplete" "$ERR_FILE" "pull is incomplete"

--- a/.agents/skills/linear/tests/sync-issues-page-cap.test.sh
+++ b/.agents/skills/linear/tests/sync-issues-page-cap.test.sh
@@ -10,6 +10,7 @@ SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 SYNC="$SKILL_DIR/scripts/commands/sync.sh"
 assert_tmpdir TMP_ROOT
 
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 git -C "$TMP_ROOT" init -q -b main
 cd "$TMP_ROOT"
 # shellcheck disable=SC1090

--- a/.agents/skills/linear/tests/sync-issues-page-cap.test.sh
+++ b/.agents/skills/linear/tests/sync-issues-page-cap.test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# An issues pull that reaches its safety cap still returns the rows it fetched,
+# but says that the cache is truncated and how many rows it contains.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/assert.sh
+source "$SCRIPT_DIR/lib/assert.sh"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SYNC="$SKILL_DIR/scripts/commands/sync.sh"
+assert_tmpdir TMP_ROOT
+
+git -C "$TMP_ROOT" init -q -b main
+cd "$TMP_ROOT"
+# shellcheck disable=SC1090
+source "$SYNC"
+
+COUNTER="$TMP_ROOT/calls"
+graphql_query() {
+  local n
+  n=$(( $(cat "$COUNTER") + 1 ))
+  echo "$n" >"$COUNTER"
+
+  if [[ "$STUB_MODE" == "complete" ]]; then
+    printf '{"issues":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"identifier":"T-1"}]}}'
+    return 0
+  fi
+
+  printf '{"issues":{"pageInfo":{"hasNextPage":true,"endCursor":"c%s"},"nodes":[{"identifier":"T-%s"}]}}' "$n" "$n"
+}
+
+ERR_FILE="$TMP_ROOT/err"
+
+STUB_MODE=complete
+echo 0 >"$COUNTER"
+run_output OUT rc sync_issues '' 2>"$ERR_FILE"
+assert_eq "a complete pull succeeds" "$rc" "0"
+assert_eq "a complete pull returns its issue" "$(printf '%s' "$OUT" | jq 'length')" "1"
+assert_eq "a complete pull does not warn" "$(cat "$ERR_FILE")" ""
+
+STUB_MODE=capped
+echo 0 >"$COUNTER"
+run_output OUT rc sync_issues '' 2>"$ERR_FILE"
+assert_eq "a capped pull still returns its fetched issues" "$rc" "0"
+assert_eq "the page cap stops the pull at 200 requests" "$(cat "$COUNTER")" "200"
+assert_eq "a capped pull returns every fetched issue" "$(printf '%s' "$OUT" | jq 'length')" "200"
+assert_file_contains "a capped pull warns with the page cap" "$ERR_FILE" "200-page safety cap"
+assert_file_contains "a capped pull warning names the number of issues cached" "$ERR_FILE" "200 issues"
+assert_file_contains "a capped pull warning says the cache is truncated" "$ERR_FILE" "cache is truncated"

--- a/changelog.d/fixed/KEN-796.md
+++ b/changelog.d/fixed/KEN-796.md
@@ -1,0 +1,1 @@
+- Linear sync now warns when its issue pull reaches the page limit and reports how many issues it fetched.

--- a/changelog.d/fixed/KEN-796.md
+++ b/changelog.d/fixed/KEN-796.md
@@ -1,1 +1,1 @@
-- Linear sync now warns when its issue pull reaches the page limit and reports how many issues it fetched.
+- Linear sync now warns when the page limit truncates an issue pull and reports how many issues it fetched.

--- a/skills/linear/scripts/commands/sync.sh
+++ b/skills/linear/scripts/commands/sync.sh
@@ -109,7 +109,7 @@ sync_issues() {
         if (( page_count >= max_pages )); then
             local issue_count
             issue_count=$(echo "$all_nodes" | jq 'length')
-            echo "Sync warning: issues stopped at the $max_pages-page safety cap after caching $issue_count issues; more pages remain, so the cache is truncated." >&2
+            echo "Sync warning: issues stopped at the $max_pages-page safety cap after fetching $issue_count issues; more pages remain, so this pull is incomplete." >&2
             break
         fi
 

--- a/skills/linear/scripts/commands/sync.sh
+++ b/skills/linear/scripts/commands/sync.sh
@@ -102,7 +102,14 @@ sync_issues() {
 
         page_count=$((page_count + 1))
 
-        if [[ "$has_next" != "true" ]] || (( page_count >= max_pages )); then
+        if [[ "$has_next" != "true" ]]; then
+            break
+        fi
+
+        if (( page_count >= max_pages )); then
+            local issue_count
+            issue_count=$(echo "$all_nodes" | jq 'length')
+            echo "Sync warning: issues stopped at the $max_pages-page safety cap after caching $issue_count issues; more pages remain, so the cache is truncated." >&2
             break
         fi
 

--- a/skills/linear/tests/controls/sync-issues-page-cap.control.sh
+++ b/skills/linear/tests/controls/sync-issues-page-cap.control.sh
@@ -1,8 +1,13 @@
 control_replace \
   "scripts/commands/sync.sh" \
   1 \
-  '            echo "Sync warning: issues stopped at the $max_pages-page safety cap after caching $issue_count issues; more pages remain, so the cache is truncated." >&2' \
+  '            echo "Sync warning: issues stopped at the $max_pages-page safety cap after fetching $issue_count issues; more pages remain, so this pull is incomplete." >&2' \
   '            :'
+control_replace \
+  "scripts/commands/sync.sh" \
+  1 \
+  '        if (( page_count >= max_pages )); then' \
+  '        if (( page_count >= 2 )); then'
+control_expect "an under-cap pull reaches its terminal page"
+control_expect "a capped pull emits one warning"
 control_expect "a capped pull warns with the page cap"
-control_expect "a capped pull warning names the number of issues cached"
-control_expect "a capped pull warning says the cache is truncated"

--- a/skills/linear/tests/controls/sync-issues-page-cap.control.sh
+++ b/skills/linear/tests/controls/sync-issues-page-cap.control.sh
@@ -2,12 +2,21 @@ control_replace \
   "scripts/commands/sync.sh" \
   1 \
   '            echo "Sync warning: issues stopped at the $max_pages-page safety cap after fetching $issue_count issues; more pages remain, so this pull is incomplete." >&2' \
-  '            :'
+  '            echo "Sync warning: issue pull stopped early after fetching $issue_count issues." >&2; echo "Sync warning: duplicate." >&2'
 control_replace \
   "scripts/commands/sync.sh" \
   1 \
   '        if (( page_count >= max_pages )); then' \
-  '        if (( page_count >= 2 )); then'
+  '        if (( page_count < max_pages )); then'
 control_expect "an under-cap pull reaches its terminal page"
+control_expect "an under-cap pull returns every fetched issue"
+control_expect "an under-cap pull does not warn"
+control_expect "a pull completed on page 200 reaches its terminal page"
+control_expect "a pull completed on page 200 returns every fetched issue"
+control_expect "a pull completed on page 200 does not warn"
+control_expect "the page cap stops the pull at 200 requests"
+control_expect "a capped pull returns every fetched issue"
 control_expect "a capped pull emits one warning"
 control_expect "a capped pull warns with the page cap"
+control_expect "a capped pull warning names the number of issues fetched"
+control_expect "a capped pull warning says the pull is incomplete"

--- a/skills/linear/tests/controls/sync-issues-page-cap.control.sh
+++ b/skills/linear/tests/controls/sync-issues-page-cap.control.sh
@@ -1,0 +1,8 @@
+control_replace \
+  "scripts/commands/sync.sh" \
+  1 \
+  '            echo "Sync warning: issues stopped at the $max_pages-page safety cap after caching $issue_count issues; more pages remain, so the cache is truncated." >&2' \
+  '            :'
+control_expect "a capped pull warns with the page cap"
+control_expect "a capped pull warning names the number of issues cached"
+control_expect "a capped pull warning says the cache is truncated"

--- a/skills/linear/tests/sync-issues-page-cap.test.sh
+++ b/skills/linear/tests/sync-issues-page-cap.test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # An issues pull that reaches its safety cap still returns the rows it fetched,
-# but says that the cache is truncated and how many rows it contains.
+# but says that the pull is incomplete and how many issues it fetched.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -17,16 +17,31 @@ source "$SYNC"
 
 COUNTER="$TMP_ROOT/calls"
 graphql_query() {
-  local n
+  local n has_next=true
   n=$(( $(cat "$COUNTER") + 1 ))
   echo "$n" >"$COUNTER"
 
-  if [[ "$STUB_MODE" == "complete" ]]; then
-    printf '{"issues":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"identifier":"T-1"}]}}'
-    return 0
-  fi
+  case "$STUB_MODE" in
+    complete) has_next=false ;;
+    under-cap)
+      if (( n >= 3 )); then
+        has_next=false
+      fi
+      ;;
+    exact-cap)
+      if (( n >= 200 )); then
+        has_next=false
+      fi
+      ;;
+    capped) ;;
+    *) return 1 ;;
+  esac
 
-  printf '{"issues":{"pageInfo":{"hasNextPage":true,"endCursor":"c%s"},"nodes":[{"identifier":"T-%s"}]}}' "$n" "$n"
+  if [[ "$STUB_MODE" == "capped" ]]; then
+    printf '{"issues":{"pageInfo":{"hasNextPage":%s,"endCursor":"c%s"},"nodes":[{"identifier":"T-%s-a"},{"identifier":"T-%s-b"}]}}' "$has_next" "$n" "$n" "$n"
+  else
+    printf '{"issues":{"pageInfo":{"hasNextPage":%s,"endCursor":"c%s"},"nodes":[{"identifier":"T-%s"}]}}' "$has_next" "$n" "$n"
+  fi
 }
 
 ERR_FILE="$TMP_ROOT/err"
@@ -38,12 +53,29 @@ assert_eq "a complete pull succeeds" "$rc" "0"
 assert_eq "a complete pull returns its issue" "$(printf '%s' "$OUT" | jq 'length')" "1"
 assert_eq "a complete pull does not warn" "$(cat "$ERR_FILE")" ""
 
+STUB_MODE=under-cap
+echo 0 >"$COUNTER"
+run_output OUT rc sync_issues '' 2>"$ERR_FILE"
+assert_eq "an under-cap pull succeeds" "$rc" "0"
+assert_eq "an under-cap pull reaches its terminal page" "$(cat "$COUNTER")" "3"
+assert_eq "an under-cap pull returns every fetched issue" "$(printf '%s' "$OUT" | jq 'length')" "3"
+assert_eq "an under-cap pull does not warn" "$(cat "$ERR_FILE")" ""
+
+STUB_MODE=exact-cap
+echo 0 >"$COUNTER"
+run_output OUT rc sync_issues '' 2>"$ERR_FILE"
+assert_eq "a pull completed on page 200 succeeds" "$rc" "0"
+assert_eq "a pull completed on page 200 reaches its terminal page" "$(cat "$COUNTER")" "200"
+assert_eq "a pull completed on page 200 returns every fetched issue" "$(printf '%s' "$OUT" | jq 'length')" "200"
+assert_eq "a pull completed on page 200 does not warn" "$(cat "$ERR_FILE")" ""
+
 STUB_MODE=capped
 echo 0 >"$COUNTER"
 run_output OUT rc sync_issues '' 2>"$ERR_FILE"
 assert_eq "a capped pull still returns its fetched issues" "$rc" "0"
 assert_eq "the page cap stops the pull at 200 requests" "$(cat "$COUNTER")" "200"
-assert_eq "a capped pull returns every fetched issue" "$(printf '%s' "$OUT" | jq 'length')" "200"
+assert_eq "a capped pull returns every fetched issue" "$(printf '%s' "$OUT" | jq 'length')" "400"
+assert_eq "a capped pull emits one warning" "$(awk '/Sync warning:/ { count++ } END { print count + 0 }' "$ERR_FILE")" "1"
 assert_file_contains "a capped pull warns with the page cap" "$ERR_FILE" "200-page safety cap"
-assert_file_contains "a capped pull warning names the number of issues cached" "$ERR_FILE" "200 issues"
-assert_file_contains "a capped pull warning says the cache is truncated" "$ERR_FILE" "cache is truncated"
+assert_file_contains "a capped pull warning names the number of issues fetched" "$ERR_FILE" "fetching 400 issues"
+assert_file_contains "a capped pull warning says the pull is incomplete" "$ERR_FILE" "pull is incomplete"

--- a/skills/linear/tests/sync-issues-page-cap.test.sh
+++ b/skills/linear/tests/sync-issues-page-cap.test.sh
@@ -10,6 +10,7 @@ SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 SYNC="$SKILL_DIR/scripts/commands/sync.sh"
 assert_tmpdir TMP_ROOT
 
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 git -C "$TMP_ROOT" init -q -b main
 cd "$TMP_ROOT"
 # shellcheck disable=SC1090

--- a/skills/linear/tests/sync-issues-page-cap.test.sh
+++ b/skills/linear/tests/sync-issues-page-cap.test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# An issues pull that reaches its safety cap still returns the rows it fetched,
+# but says that the cache is truncated and how many rows it contains.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/assert.sh
+source "$SCRIPT_DIR/lib/assert.sh"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SYNC="$SKILL_DIR/scripts/commands/sync.sh"
+assert_tmpdir TMP_ROOT
+
+git -C "$TMP_ROOT" init -q -b main
+cd "$TMP_ROOT"
+# shellcheck disable=SC1090
+source "$SYNC"
+
+COUNTER="$TMP_ROOT/calls"
+graphql_query() {
+  local n
+  n=$(( $(cat "$COUNTER") + 1 ))
+  echo "$n" >"$COUNTER"
+
+  if [[ "$STUB_MODE" == "complete" ]]; then
+    printf '{"issues":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"identifier":"T-1"}]}}'
+    return 0
+  fi
+
+  printf '{"issues":{"pageInfo":{"hasNextPage":true,"endCursor":"c%s"},"nodes":[{"identifier":"T-%s"}]}}' "$n" "$n"
+}
+
+ERR_FILE="$TMP_ROOT/err"
+
+STUB_MODE=complete
+echo 0 >"$COUNTER"
+run_output OUT rc sync_issues '' 2>"$ERR_FILE"
+assert_eq "a complete pull succeeds" "$rc" "0"
+assert_eq "a complete pull returns its issue" "$(printf '%s' "$OUT" | jq 'length')" "1"
+assert_eq "a complete pull does not warn" "$(cat "$ERR_FILE")" ""
+
+STUB_MODE=capped
+echo 0 >"$COUNTER"
+run_output OUT rc sync_issues '' 2>"$ERR_FILE"
+assert_eq "a capped pull still returns its fetched issues" "$rc" "0"
+assert_eq "the page cap stops the pull at 200 requests" "$(cat "$COUNTER")" "200"
+assert_eq "a capped pull returns every fetched issue" "$(printf '%s' "$OUT" | jq 'length')" "200"
+assert_file_contains "a capped pull warns with the page cap" "$ERR_FILE" "200-page safety cap"
+assert_file_contains "a capped pull warning names the number of issues cached" "$ERR_FILE" "200 issues"
+assert_file_contains "a capped pull warning says the cache is truncated" "$ERR_FILE" "cache is truncated"

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -86,7 +86,7 @@ skills/linear/scripts/commands/initiatives.sh	494
 skills/linear/scripts/commands/issues.sh	3221
 skills/linear/scripts/commands/projects.sh	1366
 skills/linear/scripts/commands/session-status.sh	431
-skills/linear/scripts/commands/sync.sh	883
+skills/linear/scripts/commands/sync.sh	890
 skills/linear/scripts/lib/attachments.sh	499
 skills/linear/scripts/lib/cache.sh	553
 skills/linear/scripts/lib/common.sh	780


### PR DESCRIPTION
`linear.sh sync` stopped at its 200-page issue cap without saying so, while the live `issues list --max` path warned at the same cap. A truncated pull landed in the cache looking exactly like a whole one.

## What changed

A pull that hits the cap still returns the rows it fetched, but now warns on stderr naming the 200-page cap, how many issues it fetched, and that the pull is incomplete.

The warning fires only when page 200 still reports more pages. A pull whose final page lands exactly on 200 with `hasNextPage: false` is complete and stays silent.

## Scope

Per the owner re-scope on this issue (2026-09-01), this covers the page-cap warning only. Sub-collection paging for `labels`, `relations` and `inverseRelations` was ruled out as hypothetical and is deliberately not here; the two sync race findings recorded on the issue are likewise out of scope.

## Tests

`skills/linear/tests/sync-issues-page-cap.test.sh` covers a complete pull, an under-cap pull, a pull that ends exactly on page 200, and a capped pull, with a must-fail control proving the warning assertions go red when the diagnostic is removed. The suite clears `GIT_DIR`, `GIT_COMMON_DIR`, `GIT_WORK_TREE` and `GIT_INDEX_FILE` before its fixture `git init`, per AGENTS.md; without that it aborts at status 128 when those are exported, as a pre-commit hook exports them.

Closes KEN-796

https://claude.ai/code/session_01YQ19h6TCvn81ejRdsTnmcS
