### PR TITLE
feat(KEN-1130): one workflow bundle, and bundles that install

### DIFF
--- a/changelog.d/added/KEN-1130.md
+++ b/changelog.d/added/KEN-1130.md
@@ -1,0 +1,1 @@
+- New `workflow` bundle: the 30 agents, skills and hooks a full agent workflow runs on, in one `kendex add --bundle workflow`.

--- a/changelog.d/added/KEN-1130.md
+++ b/changelog.d/added/KEN-1130.md
@@ -1,1 +1,1 @@
-- New `workflow` bundle: the 30 agents, skills and hooks a full agent workflow runs on, in one `kendex add --bundle workflow`.
+- New `workflow` bundle: orchestration, code-review and commit-guards in one `kendex add --bundle workflow`, 30 agents, skills and hooks that carry what each other needs.

--- a/changelog.d/added/KEN-1130.md
+++ b/changelog.d/added/KEN-1130.md
@@ -1,1 +1,1 @@
-- New `workflow` bundle: orchestration, code-review and commit-guards in one `kendex add --bundle workflow`, 30 agents, skills and hooks that carry what each other needs.
+- New `workflow` bundle: orchestration, code-review and commit-guards plus `deep-research` in one `kendex add --bundle workflow`, 30 members that carry what each other needs.

--- a/changelog.d/fixed/KEN-1130.md
+++ b/changelog.d/fixed/KEN-1130.md
@@ -1,0 +1,1 @@
+- The catalog's bundles installed nothing, and `kendex marketplace new` scaffolded the same mistake: members belong under `agents`/`skills`/`hooks` lists, not a `members` key.

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -55,15 +55,20 @@ pub fn run(name: Option<String>, kind: Option<String>) -> CliResult {
     Ok(())
 }
 
-/// What a freshly declared catalog says about itself. The `[bundles]`
-/// lines name the keys `source::bundles::MEMBER_LISTS` reads, which the
-/// test below holds them to: a marker teaching a shape no reader looks at
-/// is how the four kendex bundles shipped installing nothing.
-const CATALOG_MARKER: &str = "# This file marks the folder as a kendex catalog. Items live in\n\
-     # agents/, skills/, hooks/, commands/ and mcp/. Optional tables:\n\
-     # [marketplace] name, description, author, license, tags\n\
-     # [bundles.<name>] description, then agents/skills/commands/hooks/\n\
-     # mcp-servers lists of bare names\n";
+/// What a freshly declared catalog says about itself. The `[bundles]` keys
+/// come from the list that reads them rather than from a copy: a marker
+/// teaching a shape no reader looks at is how the four kendex bundles
+/// shipped installing nothing.
+fn catalog_marker() -> String {
+    format!(
+        "# This file marks the folder as a kendex catalog. Items live in\n\
+         # agents/, skills/, hooks/, commands/ and mcp/. Optional tables:\n\
+         # [marketplace] name, description, author, license, tags\n\
+         # [bundles.<name>] description, then one list of bare names per\n\
+         # kind: {}\n",
+        kendex_core::source::bundles::member_list_keys()
+    )
+}
 
 /// Executable kinds install only from a catalog that declared kendex's
 /// layout — a bare `hooks/` folder is repository tooling. Scaffolding
@@ -74,7 +79,7 @@ fn declare_catalog(cwd: &Path) -> CliResult {
     if control.exists() {
         return Ok(());
     }
-    fs::write(&control, CATALOG_MARKER)?;
+    fs::write(&control, catalog_marker())?;
     say(&format!("declared the catalog ({})", control.display()));
     Ok(())
 }
@@ -88,23 +93,4 @@ fn write_new(path: &Path, content: &str) -> CliResult {
     }
     fs::write(path, content)?;
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::CATALOG_MARKER;
-
-    /// The marker teaches the `[bundles]` grammar in prose, and prose drifts
-    /// from the reader silently. Held against the reader's own list, a key
-    /// renamed there turns this red instead.
-    #[test]
-    fn the_catalog_marker_names_every_member_list_key() {
-        for (key, _) in kendex_core::source::bundles::MEMBER_LISTS {
-            assert!(
-                CATALOG_MARKER.contains(key),
-                "the catalog marker never names `{key}`, a key a set's members are \
-                 written under:\n{CATALOG_MARKER}"
-            );
-        }
-    }
 }

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -55,6 +55,16 @@ pub fn run(name: Option<String>, kind: Option<String>) -> CliResult {
     Ok(())
 }
 
+/// What a freshly declared catalog says about itself. The `[bundles]`
+/// lines name the keys `source::bundles::MEMBER_LISTS` reads, which the
+/// test below holds them to: a marker teaching a shape no reader looks at
+/// is how the four kendex bundles shipped installing nothing.
+const CATALOG_MARKER: &str = "# This file marks the folder as a kendex catalog. Items live in\n\
+     # agents/, skills/, hooks/, commands/ and mcp/. Optional tables:\n\
+     # [marketplace] name, description, author, license, tags\n\
+     # [bundles.<name>] description, then agents/skills/commands/hooks/\n\
+     # mcp-servers lists of bare names\n";
+
 /// Executable kinds install only from a catalog that declared kendex's
 /// layout — a bare `hooks/` folder is repository tooling. Scaffolding
 /// therefore declares the folder, once, and never touches a declaration
@@ -64,14 +74,7 @@ fn declare_catalog(cwd: &Path) -> CliResult {
     if control.exists() {
         return Ok(());
     }
-    fs::write(
-        &control,
-        "# This file marks the folder as a kendex catalog. Items live in\n\
-         # agents/, skills/, hooks/, commands/ and mcp/. Optional tables:\n\
-         # [marketplace] name, description, author, license, tags\n\
-         # [bundles.<name>] description, then agents/skills/commands/hooks/\n\
-         # mcp-servers lists of bare names\n",
-    )?;
+    fs::write(&control, CATALOG_MARKER)?;
     say(&format!("declared the catalog ({})", control.display()));
     Ok(())
 }
@@ -85,4 +88,23 @@ fn write_new(path: &Path, content: &str) -> CliResult {
     }
     fs::write(path, content)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CATALOG_MARKER;
+
+    /// The marker teaches the `[bundles]` grammar in prose, and prose drifts
+    /// from the reader silently. Held against the reader's own list, a key
+    /// renamed there turns this red instead.
+    #[test]
+    fn the_catalog_marker_names_every_member_list_key() {
+        for (key, _) in kendex_core::source::bundles::MEMBER_LISTS {
+            assert!(
+                CATALOG_MARKER.contains(key),
+                "the catalog marker never names `{key}`, a key a set's members are \
+                 written under:\n{CATALOG_MARKER}"
+            );
+        }
+    }
 }

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -69,7 +69,8 @@ fn declare_catalog(cwd: &Path) -> CliResult {
         "# This file marks the folder as a kendex catalog. Items live in\n\
          # agents/, skills/, hooks/, commands/ and mcp/. Optional tables:\n\
          # [marketplace] name, description, author, license, tags\n\
-         # [bundles.<name>] description, members\n",
+         # [bundles.<name>] description, then agents/skills/commands/hooks/\n\
+         # mcp-servers lists of bare names\n",
     )?;
     say(&format!("declared the catalog ({})", control.display()));
     Ok(())

--- a/crates/core/src/author/scaffold.rs
+++ b/crates/core/src/author/scaffold.rs
@@ -225,15 +225,19 @@ fn manifest_text(name: &str, description: &str, author: &str, license: License) 
     if let Some(spdx) = license.spdx() {
         text.push_str(&format!("license = {}\n", toml_string(spdx)));
     }
-    text.push_str(
+    // The `[bundles]` keys come from the list that reads them: a catalog
+    // author following a hand-written copy is how the shape shipped wrong.
+    text.push_str(&format!(
         "\n# Items live in agents/, skills/, hooks/, commands/ and mcp/.\n\
          # Curated sets: [bundles.<name>] with a description and one list of\n\
-         # bare names per kind — agents, skills, commands, hooks, mcp-servers.\n\
+         # bare names per kind: {}.\n\
          # [bundles.starter]\n\
-         # description = \"Everything a new project needs\"\n\
-         # skills = [\"my-skill\"]\n\
-         # agents = [\"my-agent\"]\n",
-    );
+         # description = \"Everything a new project needs\"\n",
+        crate::source::bundles::member_list_keys()
+    ));
+    for line in crate::source::bundles::member_list_example().lines() {
+        text.push_str(&format!("# {line}\n"));
+    }
     text
 }
 

--- a/crates/core/src/author/scaffold.rs
+++ b/crates/core/src/author/scaffold.rs
@@ -16,7 +16,7 @@ use crate::error::{CoreError, Result};
 use super::status::MineRow;
 
 /// Part of the golden contract: bump when any emitted byte changes shape.
-pub const SCAFFOLD_VERSION: u32 = 1;
+pub const SCAFFOLD_VERSION: u32 = 2;
 
 const MIT_TEXT: &str = include_str!("assets/mit.txt");
 const APACHE_TEXT: &str = include_str!("assets/apache-2.0.txt");
@@ -227,10 +227,12 @@ fn manifest_text(name: &str, description: &str, author: &str, license: License) 
     }
     text.push_str(
         "\n# Items live in agents/, skills/, hooks/, commands/ and mcp/.\n\
-         # Curated sets: [bundles.<name>] with description and members, e.g.\n\
+         # Curated sets: [bundles.<name>] with a description and one list of\n\
+         # bare names per kind — agents, skills, commands, hooks, mcp-servers.\n\
          # [bundles.starter]\n\
          # description = \"Everything a new project needs\"\n\
-         # members = [\"skill/my-skill\", \"agent/my-agent\"]\n",
+         # skills = [\"my-skill\"]\n\
+         # agents = [\"my-agent\"]\n",
     );
     text
 }

--- a/crates/core/src/source/bundles.rs
+++ b/crates/core/src/source/bundles.rs
@@ -19,18 +19,39 @@ use crate::source_read::SealedSource;
 use super::SourceConfig;
 
 /// The kinds a set may carry, under the list name a catalog writes for each.
-///
-/// Public because the texts that teach catalog authors this shape are
-/// written elsewhere — the `kendex marketplace new` scaffold, the
-/// `kendex init` marker — and each has to be held against this list rather
-/// than against a copy of it. A copy is how the shape shipped wrong.
-pub const MEMBER_LISTS: [(&str, ItemKind); 5] = [
+const MEMBER_LISTS: [(&str, ItemKind); 5] = [
     ("agents", ItemKind::Agent),
     ("skills", ItemKind::Skill),
     ("commands", ItemKind::Command),
     ("hooks", ItemKind::Hook),
     ("mcp-servers", ItemKind::McpServer),
 ];
+
+/// The list keys a set's members are written under, in reading order.
+///
+/// The texts that teach catalog authors this shape are written elsewhere —
+/// the `kendex init` marker, the `kendex marketplace new` scaffold — and
+/// they build their sentence from this rather than spelling the keys again.
+/// A hand-written copy is how the shape shipped wrong, and a copy cannot be
+/// held to the original by searching it for words.
+pub fn member_list_keys() -> String {
+    MEMBER_LISTS
+        .iter()
+        .map(|(key, _)| *key)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// A set's member lists, one kind per line with a placeholder name, as the
+/// TOML a scaffold writes commented out. Generated for the same reason the
+/// sentence is, and it carries every kind so the round trip back through
+/// [`declared`] covers all of them.
+pub fn member_list_example() -> String {
+    MEMBER_LISTS
+        .iter()
+        .map(|(key, kind)| format!("{key} = [\"my-{}\"]\n", kind.name()))
+        .collect()
+}
 
 /// One item a set carries.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -136,214 +157,7 @@ fn from_plugin(sealed: &SealedSource, entry: &super::PluginEntry) -> Result<Cata
     })
 }
 
-/// This repository's own catalog, read through the same reader every
-/// consumer install reads it through.
-///
-/// The four sets this file's reader has always defined were declared with a
-/// `members = ["skill/orch", ...]` list instead, which no reader has ever
-/// looked at: `kendex add --bundle` recorded the set and installed nothing,
-/// with every check green. A set is only ever as real as what
-/// [`super::declared`] gets out of it, so that is what is asserted here.
-///
-/// A set also has to carry what its members load, because installing one
-/// switches the agent-to-skill expansion off (`engine::ops::add`, gated by
-/// `request.no_auto_skills`). Whatever an agent member's mapping names
-/// arrives only if the set names it too.
+/// What this catalog says about itself, held to what this reader gets
+/// out of it. Its own file: the assertions outgrew this one.
 #[cfg(test)]
-mod own_catalog {
-    use std::path::{Path, PathBuf};
-
-    use crate::model::ItemKind;
-    use crate::source::{SourceConfig, find_item, list_items, source_config};
-    use crate::source_read::SealedSource;
-
-    /// The set that is orchestration, code-review and commit-guards in one
-    /// install. A partial set leans on dependency expansion to complete
-    /// itself; this one promises to carry what it needs.
-    const WHOLE: &str = "workflow";
-
-    /// The sets [`WHOLE`] is the union of. `research` is deliberately not
-    /// among them: it is the partial install that sits beside it.
-    const DRAWN_FROM: [&str; 3] = ["orchestration", "code-review", "commit-guards"];
-
-    /// One requirement and one mapping each walk below must observe. Both
-    /// reads answer an unreadable file with nothing rather than an error, so
-    /// a renamed frontmatter key would otherwise leave every closure
-    /// assertion unreached and the whole test green.
-    const A_REQUIREMENT: (&str, &str) = ("orch", "dev");
-    /// Named through `[agent-skills]` rather than by prefix: `reviewer-arch`
-    /// would still reach `reviewer` with the whole mapping table gone.
-    const A_MAPPING: (&str, &str) = ("researcher", "deep-research");
-
-    fn repo_root() -> PathBuf {
-        let guess = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
-        guess.canonicalize().unwrap_or_else(|error| {
-            panic!(
-                "{} is not a readable directory, so this crate is not sitting in the \
-                 kendex checkout: {error}",
-                guess.display()
-            )
-        })
-    }
-
-    fn open() -> (SealedSource, SourceConfig) {
-        let root = repo_root();
-        let sealed = SealedSource::open(&root).unwrap_or_else(|error| {
-            panic!("{} does not open as a catalog: {error}", root.display())
-        });
-        let config = source_config(&sealed, "kendex").unwrap_or_else(|error| {
-            panic!("{}/kendex.toml does not read: {error}", root.display())
-        });
-        (sealed, config)
-    }
-
-    fn set(sealed: &SealedSource, config: &SourceConfig, name: &str) -> super::CatalogBundle {
-        super::find(sealed, config, name)
-            .expect("its sets read")
-            .unwrap_or_else(|| panic!("kendex.toml offers no set called '{name}'"))
-    }
-
-    fn carries(bundle: &super::CatalogBundle, kind: ItemKind, name: &str) -> bool {
-        bundle
-            .members
-            .iter()
-            .any(|member| member.kind == kind && member.name == name)
-    }
-
-    /// Every set this catalog offers carries members, and each member is an
-    /// item this same catalog offers.
-    #[test]
-    fn every_bundle_carries_members_this_catalog_offers() {
-        let (sealed, config) = open();
-        let bundles = super::offered(&sealed, &config).expect("its sets read");
-        assert!(!bundles.is_empty(), "kendex.toml declares no sets at all");
-
-        for bundle in &bundles {
-            assert!(
-                !bundle.members.is_empty(),
-                "the set '{}' carries no members — list them under `agents`, `skills`, \
-                 `commands`, `hooks` or `mcp-servers`, the keys the reader looks at",
-                bundle.name
-            );
-            for member in &bundle.members {
-                assert!(
-                    find_item(&sealed, &config, member.kind, &member.name).is_some(),
-                    "the set '{}' carries {} '{}', which this catalog does not offer",
-                    bundle.name,
-                    member.kind.name(),
-                    member.name
-                );
-            }
-        }
-    }
-
-    /// Every set carries the skills its agent members load. The mapping is
-    /// resolved the way an install resolves it, so a set whose agent points
-    /// at a skill it does not carry installs an agent that reads a file
-    /// nothing wrote.
-    #[test]
-    fn every_bundle_carries_the_skills_its_agent_members_load() {
-        let (sealed, config) = open();
-        let available = list_items(&sealed, &config, ItemKind::Skill);
-        let bundles = super::offered(&sealed, &config).expect("its sets read");
-        let mut seen: Vec<(String, String)> = Vec::new();
-
-        for bundle in &bundles {
-            for member in &bundle.members {
-                if member.kind != ItemKind::Agent {
-                    continue;
-                }
-                let path = find_item(&sealed, &config, member.kind, &member.name)
-                    .unwrap_or_else(|| panic!("the catalog offers agent '{}'", member.name));
-                let text = sealed
-                    .read_if_exists(&path)
-                    .unwrap_or_else(|error| panic!("agent '{}' reads: {error}", member.name))
-                    .unwrap_or_else(|| panic!("agent '{}' is a file", member.name));
-                let parsed = crate::render::agent::parse_source_agent(&text)
-                    .unwrap_or_else(|error| panic!("agent '{}' parses: {error}", member.name));
-                for skill in
-                    crate::mapping::upstream_skills(&member.name, parsed.role, &config, &available)
-                {
-                    seen.push((member.name.clone(), skill.clone()));
-                    assert!(
-                        carries(bundle, ItemKind::Skill, &skill),
-                        "the set '{}' carries agent '{}', which loads skill '{skill}' — \
-                         installing a set skips agent-to-skill expansion, so add '{skill}' \
-                         to the set",
-                        bundle.name,
-                        member.name
-                    );
-                }
-            }
-        }
-
-        let anchor = (A_MAPPING.0.to_owned(), A_MAPPING.1.to_owned());
-        assert!(
-            seen.contains(&anchor),
-            "the walk never saw agent '{}' load skill '{}', so the mapping read is \
-             answering with nothing and the assertions above were never reached",
-            A_MAPPING.0,
-            A_MAPPING.1
-        );
-    }
-
-    /// The whole-workflow set carries every skill its skill members require,
-    /// so installing it alone is the whole loop rather than a set plus
-    /// whatever dependency expansion happened to drag along.
-    #[test]
-    fn the_whole_workflow_set_carries_what_its_members_require() {
-        let (sealed, config) = open();
-        let bundle = set(&sealed, &config, WHOLE);
-        let mut seen: Vec<(String, String)> = Vec::new();
-
-        for member in &bundle.members {
-            if member.kind != ItemKind::Skill {
-                continue;
-            }
-            let dir = find_item(&sealed, &config, member.kind, &member.name)
-                .unwrap_or_else(|| panic!("the catalog offers skill '{}'", member.name));
-            let declared = crate::engine::deps::declared_dependencies(&sealed, &dir)
-                .expect("a member skill's frontmatter reads");
-            for required in &declared.required {
-                seen.push((member.name.clone(), required.clone()));
-                assert!(
-                    carries(&bundle, ItemKind::Skill, required),
-                    "the set '{WHOLE}' carries skill '{}', which requires skill \
-                     '{required}' — add '{required}' to the set",
-                    member.name
-                );
-            }
-        }
-
-        let anchor = (A_REQUIREMENT.0.to_owned(), A_REQUIREMENT.1.to_owned());
-        assert!(
-            seen.contains(&anchor),
-            "the walk never saw skill '{}' require skill '{}', so the frontmatter read \
-             is answering with nothing and the assertions above were never reached",
-            A_REQUIREMENT.0,
-            A_REQUIREMENT.1
-        );
-    }
-
-    /// The whole-workflow set is the union of the three it is drawn from.
-    /// Nothing else holds that: a member added to one of them later would
-    /// otherwise leave `workflow` silently short.
-    #[test]
-    fn the_whole_workflow_set_contains_the_sets_it_is_drawn_from() {
-        let (sealed, config) = open();
-        let whole = set(&sealed, &config, WHOLE);
-
-        for name in DRAWN_FROM {
-            let part = set(&sealed, &config, name);
-            for member in &part.members {
-                assert!(
-                    carries(&whole, member.kind, &member.name),
-                    "the set '{name}' carries {} '{}' and '{WHOLE}' does not — '{WHOLE}' \
-                     is the union of {DRAWN_FROM:?}",
-                    member.kind.name(),
-                    member.name
-                );
-            }
-        }
-    }
-}
+mod own_catalog;

--- a/crates/core/src/source/bundles.rs
+++ b/crates/core/src/source/bundles.rs
@@ -130,3 +130,101 @@ fn from_plugin(sealed: &SealedSource, entry: &super::PluginEntry) -> Result<Cata
             .collect(),
     })
 }
+
+/// This repository's own catalog, read through the same reader every
+/// consumer install reads it through.
+///
+/// The four sets this file's reader has always defined were declared with a
+/// `members = ["skill/orch", ...]` list instead, which no reader has ever
+/// looked at: `kendex add --bundle` recorded the set and installed nothing,
+/// with every check green. A set is only ever as real as what [`declared`]
+/// gets out of it, so that is what is asserted here.
+#[cfg(test)]
+mod own_catalog {
+    use std::path::{Path, PathBuf};
+
+    use crate::model::ItemKind;
+    use crate::source::{find_item, source_config};
+    use crate::source_read::SealedSource;
+
+    /// The set that is the whole agent workflow in one install. A partial
+    /// set leans on dependency expansion to complete itself; this one
+    /// promises to carry what it needs.
+    const WHOLE: &str = "workflow";
+
+    fn repo_root() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .canonicalize()
+            .expect("the repository root is two levels above crates/core")
+    }
+
+    fn open() -> (SealedSource, crate::source::SourceConfig) {
+        let root = repo_root();
+        let sealed = SealedSource::open(&root).expect("this repository opens as a catalog");
+        let config = source_config(&sealed, "kendex").expect("its kendex.toml reads");
+        (sealed, config)
+    }
+
+    /// Every set this catalog offers carries members, and each member is an
+    /// item this same catalog offers.
+    #[test]
+    fn every_bundle_carries_members_this_catalog_offers() {
+        let (sealed, config) = open();
+        let bundles = super::offered(&sealed, &config).expect("its sets read");
+        assert!(!bundles.is_empty(), "kendex.toml declares no sets at all");
+
+        for bundle in &bundles {
+            assert!(
+                !bundle.members.is_empty(),
+                "the set '{}' carries no members — list them under `agents`, `skills`, \
+                 `commands`, `hooks` or `mcp-servers`, the keys the reader looks at",
+                bundle.name
+            );
+            for member in &bundle.members {
+                assert!(
+                    find_item(&sealed, &config, member.kind, &member.name).is_some(),
+                    "the set '{}' carries {} '{}', which this catalog does not offer",
+                    bundle.name,
+                    member.kind.name(),
+                    member.name
+                );
+            }
+        }
+    }
+
+    /// The whole-workflow set carries every skill its members require, so
+    /// installing it alone is the whole workflow rather than a set plus
+    /// whatever dependency expansion happened to drag along.
+    #[test]
+    fn the_whole_workflow_set_carries_what_its_members_require() {
+        let (sealed, config) = open();
+        let bundle = super::find(&sealed, &config, WHOLE)
+            .expect("its sets read")
+            .unwrap_or_else(|| panic!("kendex.toml offers no set called '{WHOLE}'"));
+
+        let carried = |name: &str| {
+            bundle
+                .members
+                .iter()
+                .any(|member| member.kind == ItemKind::Skill && member.name == name)
+        };
+        for member in &bundle.members {
+            if member.kind != ItemKind::Skill {
+                continue;
+            }
+            let dir = find_item(&sealed, &config, member.kind, &member.name)
+                .unwrap_or_else(|| panic!("the catalog offers skill '{}'", member.name));
+            let declared = crate::engine::deps::declared_dependencies(&sealed, &dir)
+                .expect("a member skill's frontmatter reads");
+            for required in &declared.required {
+                assert!(
+                    carried(required),
+                    "the set '{WHOLE}' carries skill '{}', which requires skill '{required}' \
+                     — add '{required}' to the set",
+                    member.name
+                );
+            }
+        }
+    }
+}

--- a/crates/core/src/source/bundles.rs
+++ b/crates/core/src/source/bundles.rs
@@ -19,7 +19,12 @@ use crate::source_read::SealedSource;
 use super::SourceConfig;
 
 /// The kinds a set may carry, under the list name a catalog writes for each.
-const MEMBER_LISTS: [(&str, ItemKind); 5] = [
+///
+/// Public because the texts that teach catalog authors this shape are
+/// written elsewhere — the `kendex marketplace new` scaffold, the
+/// `kendex init` marker — and each has to be held against this list rather
+/// than against a copy of it. A copy is how the shape shipped wrong.
+pub const MEMBER_LISTS: [(&str, ItemKind); 5] = [
     ("agents", ItemKind::Agent),
     ("skills", ItemKind::Skill),
     ("commands", ItemKind::Command),
@@ -137,33 +142,72 @@ fn from_plugin(sealed: &SealedSource, entry: &super::PluginEntry) -> Result<Cata
 /// The four sets this file's reader has always defined were declared with a
 /// `members = ["skill/orch", ...]` list instead, which no reader has ever
 /// looked at: `kendex add --bundle` recorded the set and installed nothing,
-/// with every check green. A set is only ever as real as what [`declared`]
-/// gets out of it, so that is what is asserted here.
+/// with every check green. A set is only ever as real as what
+/// [`super::declared`] gets out of it, so that is what is asserted here.
+///
+/// A set also has to carry what its members load, because installing one
+/// switches the agent-to-skill expansion off (`engine::ops::add`, gated by
+/// `request.no_auto_skills`). Whatever an agent member's mapping names
+/// arrives only if the set names it too.
 #[cfg(test)]
 mod own_catalog {
     use std::path::{Path, PathBuf};
 
     use crate::model::ItemKind;
-    use crate::source::{find_item, source_config};
+    use crate::source::{SourceConfig, find_item, list_items, source_config};
     use crate::source_read::SealedSource;
 
-    /// The set that is the whole agent workflow in one install. A partial
-    /// set leans on dependency expansion to complete itself; this one
-    /// promises to carry what it needs.
+    /// The set that is orchestration, code-review and commit-guards in one
+    /// install. A partial set leans on dependency expansion to complete
+    /// itself; this one promises to carry what it needs.
     const WHOLE: &str = "workflow";
 
+    /// The sets [`WHOLE`] is the union of. `research` is deliberately not
+    /// among them: it is the partial install that sits beside it.
+    const DRAWN_FROM: [&str; 3] = ["orchestration", "code-review", "commit-guards"];
+
+    /// One requirement and one mapping each walk below must observe. Both
+    /// reads answer an unreadable file with nothing rather than an error, so
+    /// a renamed frontmatter key would otherwise leave every closure
+    /// assertion unreached and the whole test green.
+    const A_REQUIREMENT: (&str, &str) = ("orch", "dev");
+    /// Named through `[agent-skills]` rather than by prefix: `reviewer-arch`
+    /// would still reach `reviewer` with the whole mapping table gone.
+    const A_MAPPING: (&str, &str) = ("researcher", "deep-research");
+
     fn repo_root() -> PathBuf {
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../..")
-            .canonicalize()
-            .expect("the repository root is two levels above crates/core")
+        let guess = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        guess.canonicalize().unwrap_or_else(|error| {
+            panic!(
+                "{} is not a readable directory, so this crate is not sitting in the \
+                 kendex checkout: {error}",
+                guess.display()
+            )
+        })
     }
 
-    fn open() -> (SealedSource, crate::source::SourceConfig) {
+    fn open() -> (SealedSource, SourceConfig) {
         let root = repo_root();
-        let sealed = SealedSource::open(&root).expect("this repository opens as a catalog");
-        let config = source_config(&sealed, "kendex").expect("its kendex.toml reads");
+        let sealed = SealedSource::open(&root).unwrap_or_else(|error| {
+            panic!("{} does not open as a catalog: {error}", root.display())
+        });
+        let config = source_config(&sealed, "kendex").unwrap_or_else(|error| {
+            panic!("{}/kendex.toml does not read: {error}", root.display())
+        });
         (sealed, config)
+    }
+
+    fn set(sealed: &SealedSource, config: &SourceConfig, name: &str) -> super::CatalogBundle {
+        super::find(sealed, config, name)
+            .expect("its sets read")
+            .unwrap_or_else(|| panic!("kendex.toml offers no set called '{name}'"))
+    }
+
+    fn carries(bundle: &super::CatalogBundle, kind: ItemKind, name: &str) -> bool {
+        bundle
+            .members
+            .iter()
+            .any(|member| member.kind == kind && member.name == name)
     }
 
     /// Every set this catalog offers carries members, and each member is an
@@ -193,22 +237,65 @@ mod own_catalog {
         }
     }
 
-    /// The whole-workflow set carries every skill its members require, so
-    /// installing it alone is the whole workflow rather than a set plus
+    /// Every set carries the skills its agent members load. The mapping is
+    /// resolved the way an install resolves it, so a set whose agent points
+    /// at a skill it does not carry installs an agent that reads a file
+    /// nothing wrote.
+    #[test]
+    fn every_bundle_carries_the_skills_its_agent_members_load() {
+        let (sealed, config) = open();
+        let available = list_items(&sealed, &config, ItemKind::Skill);
+        let bundles = super::offered(&sealed, &config).expect("its sets read");
+        let mut seen: Vec<(String, String)> = Vec::new();
+
+        for bundle in &bundles {
+            for member in &bundle.members {
+                if member.kind != ItemKind::Agent {
+                    continue;
+                }
+                let path = find_item(&sealed, &config, member.kind, &member.name)
+                    .unwrap_or_else(|| panic!("the catalog offers agent '{}'", member.name));
+                let text = sealed
+                    .read_if_exists(&path)
+                    .unwrap_or_else(|error| panic!("agent '{}' reads: {error}", member.name))
+                    .unwrap_or_else(|| panic!("agent '{}' is a file", member.name));
+                let parsed = crate::render::agent::parse_source_agent(&text)
+                    .unwrap_or_else(|error| panic!("agent '{}' parses: {error}", member.name));
+                for skill in
+                    crate::mapping::upstream_skills(&member.name, parsed.role, &config, &available)
+                {
+                    seen.push((member.name.clone(), skill.clone()));
+                    assert!(
+                        carries(bundle, ItemKind::Skill, &skill),
+                        "the set '{}' carries agent '{}', which loads skill '{skill}' — \
+                         installing a set skips agent-to-skill expansion, so add '{skill}' \
+                         to the set",
+                        bundle.name,
+                        member.name
+                    );
+                }
+            }
+        }
+
+        let anchor = (A_MAPPING.0.to_owned(), A_MAPPING.1.to_owned());
+        assert!(
+            seen.contains(&anchor),
+            "the walk never saw agent '{}' load skill '{}', so the mapping read is \
+             answering with nothing and the assertions above were never reached",
+            A_MAPPING.0,
+            A_MAPPING.1
+        );
+    }
+
+    /// The whole-workflow set carries every skill its skill members require,
+    /// so installing it alone is the whole loop rather than a set plus
     /// whatever dependency expansion happened to drag along.
     #[test]
     fn the_whole_workflow_set_carries_what_its_members_require() {
         let (sealed, config) = open();
-        let bundle = super::find(&sealed, &config, WHOLE)
-            .expect("its sets read")
-            .unwrap_or_else(|| panic!("kendex.toml offers no set called '{WHOLE}'"));
+        let bundle = set(&sealed, &config, WHOLE);
+        let mut seen: Vec<(String, String)> = Vec::new();
 
-        let carried = |name: &str| {
-            bundle
-                .members
-                .iter()
-                .any(|member| member.kind == ItemKind::Skill && member.name == name)
-        };
         for member in &bundle.members {
             if member.kind != ItemKind::Skill {
                 continue;
@@ -218,10 +305,42 @@ mod own_catalog {
             let declared = crate::engine::deps::declared_dependencies(&sealed, &dir)
                 .expect("a member skill's frontmatter reads");
             for required in &declared.required {
+                seen.push((member.name.clone(), required.clone()));
                 assert!(
-                    carried(required),
-                    "the set '{WHOLE}' carries skill '{}', which requires skill '{required}' \
-                     — add '{required}' to the set",
+                    carries(&bundle, ItemKind::Skill, required),
+                    "the set '{WHOLE}' carries skill '{}', which requires skill \
+                     '{required}' — add '{required}' to the set",
+                    member.name
+                );
+            }
+        }
+
+        let anchor = (A_REQUIREMENT.0.to_owned(), A_REQUIREMENT.1.to_owned());
+        assert!(
+            seen.contains(&anchor),
+            "the walk never saw skill '{}' require skill '{}', so the frontmatter read \
+             is answering with nothing and the assertions above were never reached",
+            A_REQUIREMENT.0,
+            A_REQUIREMENT.1
+        );
+    }
+
+    /// The whole-workflow set is the union of the three it is drawn from.
+    /// Nothing else holds that: a member added to one of them later would
+    /// otherwise leave `workflow` silently short.
+    #[test]
+    fn the_whole_workflow_set_contains_the_sets_it_is_drawn_from() {
+        let (sealed, config) = open();
+        let whole = set(&sealed, &config, WHOLE);
+
+        for name in DRAWN_FROM {
+            let part = set(&sealed, &config, name);
+            for member in &part.members {
+                assert!(
+                    carries(&whole, member.kind, &member.name),
+                    "the set '{name}' carries {} '{}' and '{WHOLE}' does not — '{WHOLE}' \
+                     is the union of {DRAWN_FROM:?}",
+                    member.kind.name(),
                     member.name
                 );
             }

--- a/crates/core/src/source/bundles/own_catalog.rs
+++ b/crates/core/src/source/bundles/own_catalog.rs
@@ -38,6 +38,17 @@ const DRAWN_FROM: [&str; 3] = ["orchestration", "code-review", "commit-guards"];
 /// one, which is how deep-research came to be undescribed.
 const BEYOND: [(ItemKind, &str); 1] = [(ItemKind::Skill, "deep-research")];
 
+/// One member per kind these sets carry, each of which has to read back.
+/// [`super::declared`] skips a list key it does not know, so a `hooks` list
+/// misspelt `hook` in kendex.toml leaves the set carrying its other kinds
+/// and nothing says the hooks went missing — the same silence, in the same
+/// file, as the `members = [...]` lists this whole issue is about.
+const A_MEMBER: [(&str, ItemKind, &str); 3] = [
+    ("workflow", ItemKind::Agent, "reviewer-arch"),
+    ("workflow", ItemKind::Skill, "orch"),
+    ("commit-guards", ItemKind::Hook, "block-bare-cd"),
+];
+
 /// One requirement and one mapping each walk below must observe. Both
 /// reads answer an unreadable file with nothing rather than an error, so
 /// a renamed frontmatter key would otherwise leave every closure
@@ -82,13 +93,25 @@ fn carries(bundle: &super::CatalogBundle, kind: ItemKind, name: &str) -> bool {
         .any(|member| member.kind == kind && member.name == name)
 }
 
-/// Every set this catalog offers carries members, and each member is an
-/// item this same catalog offers.
+/// Every set this catalog offers carries members, each member is an item
+/// this same catalog offers, and [`A_MEMBER`] names one of every kind that
+/// has to read back. Emptiness is what this walk cannot see on its own: a
+/// list key the reader does not know is a list that was never there.
 #[test]
 fn every_bundle_carries_members_this_catalog_offers() {
     let (sealed, config) = open();
     let bundles = super::offered(&sealed, &config).expect("its sets read");
     assert!(!bundles.is_empty(), "kendex.toml declares no sets at all");
+
+    for (name, kind, member) in A_MEMBER {
+        assert!(
+            carries(&set(&sealed, &config, name), kind, member),
+            "the set '{name}' does not read back {} '{member}' — check the list key \
+             its kendex.toml entry writes that kind under, since a key the reader \
+             does not know is a list it never sees",
+            kind.name()
+        );
+    }
 
     for bundle in &bundles {
         assert!(

--- a/crates/core/src/source/bundles/own_catalog.rs
+++ b/crates/core/src/source/bundles/own_catalog.rs
@@ -1,0 +1,275 @@
+//! This repository's own catalog, read through the same reader every
+//! consumer install reads it through.
+//!
+//! The four sets this catalog offers were declared with a
+//! `members = ["skill/orch", ...]` list, which the reader beside this file
+//! has never looked at: `kendex add --bundle` recorded the set and installed
+//! nothing, with every check green. A set is only ever as real as what
+//! [`super::declared`] gets out of it, so that is what is asserted here.
+//!
+//! A set also has to carry what its agent members load. The agent-to-skill
+//! expansion in `engine::ops::add` walks `request.agents` — the agents asked
+//! for by name — and a set's members never join that list: they derive at
+//! plan time in `engine::bundles::installable`, after the expansion has run.
+//! So whatever an agent member's mapping names arrives only if the set names
+//! it too, on every path. (Skill-to-skill dependency expansion is a separate
+//! pass and does reach a set's members, which is why the requirement walk
+//! below is about completeness rather than about anything breaking.)
+
+use std::path::{Path, PathBuf};
+
+use crate::model::ItemKind;
+use crate::source::{SourceConfig, find_item, list_items, source_config};
+use crate::source_read::SealedSource;
+
+/// The set that is orchestration, code-review and commit-guards plus
+/// deep-research in one install. A partial set leans on dependency
+/// expansion to complete itself; this one promises to carry what it
+/// needs.
+const WHOLE: &str = "workflow";
+
+/// The sets [`WHOLE`] contains. `research` is deliberately not among
+/// them: it is the partial install that sits beside it.
+const DRAWN_FROM: [&str; 3] = ["orchestration", "code-review", "commit-guards"];
+
+/// What [`WHOLE`] carries beyond those three. Written down so the
+/// containment check runs both ways: a member added to `workflow` and to
+/// nothing else has to be a deliberate entry here rather than a quiet
+/// one, which is how deep-research came to be undescribed.
+const BEYOND: [(ItemKind, &str); 1] = [(ItemKind::Skill, "deep-research")];
+
+/// One requirement and one mapping each walk below must observe. Both
+/// reads answer an unreadable file with nothing rather than an error, so
+/// a renamed frontmatter key would otherwise leave every closure
+/// assertion unreached and the whole test green.
+const A_REQUIREMENT: (&str, &str) = ("orch", "dev");
+/// Named through `[agent-skills]` and reachable no other way, so it
+/// anchors a read of that table. `reviewer-arch` could not: it carries
+/// `role: reviewer`, which `[role-skills]` maps to `reviewer` with the
+/// whole `[agent-skills]` table gone.
+const A_MAPPING: (&str, &str) = ("researcher", "deep-research");
+
+fn repo_root() -> PathBuf {
+    let guess = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    guess.canonicalize().unwrap_or_else(|error| {
+        panic!(
+            "{} is not a readable directory, so this crate is not sitting in the \
+             kendex checkout: {error}",
+            guess.display()
+        )
+    })
+}
+
+fn open() -> (SealedSource, SourceConfig) {
+    let root = repo_root();
+    let sealed = SealedSource::open(&root)
+        .unwrap_or_else(|error| panic!("{} does not open as a catalog: {error}", root.display()));
+    let config = source_config(&sealed, "kendex")
+        .unwrap_or_else(|error| panic!("{}/kendex.toml does not read: {error}", root.display()));
+    (sealed, config)
+}
+
+fn set(sealed: &SealedSource, config: &SourceConfig, name: &str) -> super::CatalogBundle {
+    super::find(sealed, config, name)
+        .expect("its sets read")
+        .unwrap_or_else(|| panic!("kendex.toml offers no set called '{name}'"))
+}
+
+fn carries(bundle: &super::CatalogBundle, kind: ItemKind, name: &str) -> bool {
+    bundle
+        .members
+        .iter()
+        .any(|member| member.kind == kind && member.name == name)
+}
+
+/// Every set this catalog offers carries members, and each member is an
+/// item this same catalog offers.
+#[test]
+fn every_bundle_carries_members_this_catalog_offers() {
+    let (sealed, config) = open();
+    let bundles = super::offered(&sealed, &config).expect("its sets read");
+    assert!(!bundles.is_empty(), "kendex.toml declares no sets at all");
+
+    for bundle in &bundles {
+        assert!(
+            !bundle.members.is_empty(),
+            "the set '{}' carries no members — list them under `agents`, `skills`, \
+             `commands`, `hooks` or `mcp-servers`, the keys the reader looks at",
+            bundle.name
+        );
+        for member in &bundle.members {
+            assert!(
+                find_item(&sealed, &config, member.kind, &member.name).is_some(),
+                "the set '{}' carries {} '{}', which this catalog does not offer",
+                bundle.name,
+                member.kind.name(),
+                member.name
+            );
+        }
+    }
+}
+
+/// Every set carries the skills its agent members load. The mapping is
+/// resolved the way an install resolves it, so a set whose agent points
+/// at a skill it does not carry installs an agent that reads a file
+/// nothing wrote.
+#[test]
+fn every_bundle_carries_the_skills_its_agent_members_load() {
+    let (sealed, config) = open();
+    let available = list_items(&sealed, &config, ItemKind::Skill);
+    let bundles = super::offered(&sealed, &config).expect("its sets read");
+    let mut seen: Vec<(String, String)> = Vec::new();
+
+    for bundle in &bundles {
+        for member in &bundle.members {
+            if member.kind != ItemKind::Agent {
+                continue;
+            }
+            let path = find_item(&sealed, &config, member.kind, &member.name)
+                .unwrap_or_else(|| panic!("the catalog offers agent '{}'", member.name));
+            let text = sealed
+                .read_if_exists(&path)
+                .unwrap_or_else(|error| panic!("agent '{}' reads: {error}", member.name))
+                .unwrap_or_else(|| panic!("agent '{}' is a file", member.name));
+            let parsed = crate::render::agent::parse_source_agent(&text)
+                .unwrap_or_else(|error| panic!("agent '{}' parses: {error}", member.name));
+
+            // `upstream_skills` drops a mapped name the catalog does not
+            // offer, so a typo in either table resolves to silence rather
+            // than to a name the loop below could fail on. Both tables are
+            // read here, where the two sides are already in hand.
+            let mapped = config
+                .agent_skills
+                .get(&member.name)
+                .or_else(|| {
+                    config
+                        .agent_skills
+                        .get(crate::mapping::skill_match_prefix(&member.name))
+                })
+                .into_iter()
+                .flatten()
+                .map(|skill| ("[agent-skills]", skill))
+                .chain(
+                    parsed
+                        .role
+                        .and_then(|role| config.role_skills.get(role.name()))
+                        .into_iter()
+                        .flatten()
+                        .map(|skill| ("[role-skills]", skill)),
+                );
+            for (table, skill) in mapped {
+                assert!(
+                    available.contains(skill),
+                    "{table} maps agent '{}' to skill '{skill}', which this catalog \
+                     does not offer — the mapping resolves it to nothing, so the agent \
+                     installs with that skill unmapped and no set can carry it",
+                    member.name
+                );
+            }
+
+            for skill in
+                crate::mapping::upstream_skills(&member.name, parsed.role, &config, &available)
+            {
+                seen.push((member.name.clone(), skill.clone()));
+                assert!(
+                    carries(bundle, ItemKind::Skill, &skill),
+                    "the set '{}' carries agent '{}', which loads skill '{skill}' — \
+                     installing a set skips agent-to-skill expansion, so add '{skill}' \
+                     to the set",
+                    bundle.name,
+                    member.name
+                );
+            }
+        }
+    }
+
+    let anchor = (A_MAPPING.0.to_owned(), A_MAPPING.1.to_owned());
+    assert!(
+        seen.contains(&anchor),
+        "the walk never saw agent '{}' load skill '{}', so the mapping read is \
+         answering with nothing and the assertions above were never reached",
+        A_MAPPING.0,
+        A_MAPPING.1
+    );
+}
+
+/// The whole-workflow set carries every skill its skill members require,
+/// so installing it alone is the whole loop rather than a set plus
+/// whatever dependency expansion happened to drag along.
+#[test]
+fn the_whole_workflow_set_carries_what_its_members_require() {
+    let (sealed, config) = open();
+    let bundle = set(&sealed, &config, WHOLE);
+    let mut seen: Vec<(String, String)> = Vec::new();
+
+    for member in &bundle.members {
+        if member.kind != ItemKind::Skill {
+            continue;
+        }
+        let dir = find_item(&sealed, &config, member.kind, &member.name)
+            .unwrap_or_else(|| panic!("the catalog offers skill '{}'", member.name));
+        let declared = crate::engine::deps::declared_dependencies(&sealed, &dir)
+            .expect("a member skill's frontmatter reads");
+        for required in &declared.required {
+            seen.push((member.name.clone(), required.clone()));
+            assert!(
+                carries(&bundle, ItemKind::Skill, required),
+                "the set '{WHOLE}' carries skill '{}', which requires skill \
+                 '{required}' — add '{required}' to the set",
+                member.name
+            );
+        }
+    }
+
+    let anchor = (A_REQUIREMENT.0.to_owned(), A_REQUIREMENT.1.to_owned());
+    assert!(
+        seen.contains(&anchor),
+        "the walk never saw skill '{}' require skill '{}', so the frontmatter read \
+         is answering with nothing and the assertions above were never reached",
+        A_REQUIREMENT.0,
+        A_REQUIREMENT.1
+    );
+}
+
+/// The whole-workflow set is the three sets it is drawn from plus
+/// [`BEYOND`], read both ways. A member added to one of the three would
+/// otherwise leave `workflow` silently short, and a member added to
+/// `workflow` alone would leave every description of it silently wrong —
+/// which is how deep-research came to be a member nothing mentioned.
+#[test]
+fn the_whole_workflow_set_is_the_sets_it_is_drawn_from_plus_what_is_written_down() {
+    let (sealed, config) = open();
+    let whole = set(&sealed, &config, WHOLE);
+    let parts: Vec<super::CatalogBundle> = DRAWN_FROM
+        .iter()
+        .map(|name| set(&sealed, &config, name))
+        .collect();
+
+    for (name, part) in DRAWN_FROM.iter().zip(&parts) {
+        for member in &part.members {
+            assert!(
+                carries(&whole, member.kind, &member.name),
+                "the set '{name}' carries {} '{}' and '{WHOLE}' does not — '{WHOLE}' \
+                 is {DRAWN_FROM:?} plus {BEYOND:?}",
+                member.kind.name(),
+                member.name
+            );
+        }
+    }
+
+    for member in &whole.members {
+        let drawn = parts
+            .iter()
+            .any(|part| carries(part, member.kind, &member.name));
+        let written = BEYOND
+            .iter()
+            .any(|(kind, name)| *kind == member.kind && *name == member.name);
+        assert!(
+            drawn || written,
+            "'{WHOLE}' carries {} '{}', which none of {DRAWN_FROM:?} carries — add it \
+             to BEYOND and to what kendex.toml and the changelog say the set is",
+            member.kind.name(),
+            member.name
+        );
+    }
+}

--- a/crates/core/tests/authoring.rs
+++ b/crates/core/tests/authoring.rs
@@ -7,6 +7,10 @@ use std::path::{Path, PathBuf};
 use kendex_core::author::{self, CreateRequest, License};
 use kendex_core::env::{Env, FakeOs};
 
+#[path = "../../test_util.rs"]
+mod test_util;
+use test_util::rooted;
+
 #[allow(clippy::unwrap_used)]
 fn fake() -> (tempfile::TempDir, Env) {
     let tmp = tempfile::tempdir().unwrap();
@@ -139,6 +143,62 @@ fn the_scaffold_writes_the_licence_evidence() {
         .unwrap()
         .1;
     assert!(manifest.contains("license = \"MIT\""));
+}
+
+/// The scaffold teaches the `[bundles]` grammar in a commented-out example,
+/// and the only other check over it pins bytes. Bytes are happy to pin a
+/// shape no reader looks at, which is how kendex's own four sets shipped
+/// installing nothing. So the example is held two ways: it names every key
+/// the reader reads, and uncommented it is a set the reader gets members
+/// out of.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn the_scaffolded_bundle_example_is_a_set_the_reader_accepts() {
+    let files = author::plan(&request(Path::new("/x"), License::Mit)).unwrap();
+    let manifest = &files
+        .iter()
+        .find(|(rel, _)| rel == "kendex.toml")
+        .unwrap()
+        .1;
+
+    for (key, _) in kendex_core::source::bundles::MEMBER_LISTS {
+        assert!(
+            manifest.contains(key),
+            "the scaffold never names `{key}`, a key a set's members are written under"
+        );
+    }
+
+    let example: String = manifest
+        .lines()
+        .skip_while(|line| !line.starts_with("# [bundles."))
+        .map(|line| format!("{}\n", line.trim_start_matches('#').trim_start()))
+        .collect();
+    assert!(
+        !example.is_empty(),
+        "the scaffold writes no [bundles.<name>] example:\n{manifest}"
+    );
+
+    let tmp = tempfile::tempdir().unwrap();
+    let root = rooted(&tmp);
+    fs::write(root.join("kendex.toml"), &example).unwrap();
+    let sealed = kendex_core::source_read::SealedSource::open(&root).unwrap();
+    let config = kendex_core::source::source_config(&sealed, "scaffolded").unwrap();
+    let sets = kendex_core::source::bundles::offered(&sealed, &config).unwrap();
+
+    let members: Vec<(kendex_core::model::ItemKind, &str)> = sets
+        .iter()
+        .flat_map(|set| set.members.iter())
+        .map(|member| (member.kind, member.name.as_str()))
+        .collect();
+    assert_eq!(
+        members,
+        [
+            (kendex_core::model::ItemKind::Agent, "my-agent"),
+            (kendex_core::model::ItemKind::Skill, "my-skill"),
+        ],
+        "the scaffolded example, uncommented, is not a set the reader gets members \
+         out of:\n{example}"
+    );
 }
 
 #[test]

--- a/crates/core/tests/authoring.rs
+++ b/crates/core/tests/authoring.rs
@@ -197,6 +197,22 @@ fn the_scaffolded_bundle_example_is_a_set_the_reader_accepts() {
             format!("{} {name}", name.trim_start_matches("my-"))
         })
         .collect();
+    // Both sides come out of the same generator, so both go empty together
+    // and compare equal. The grammar sentence is the third party: one member
+    // per key it lists, or the example is not the example it describes.
+    let keys = kendex_core::source::bundles::member_list_keys();
+    let listed = keys.split(", ").count();
+    assert!(
+        !keys.is_empty(),
+        "the grammar sentence lists no keys at all"
+    );
+    assert_eq!(
+        expected.len(),
+        listed,
+        "the example carries {} member(s) and the grammar sentence lists {listed} \
+         key(s) ({keys})",
+        expected.len()
+    );
     assert_eq!(
         members, expected,
         "the scaffolded example, uncommented, is not a set the reader gets every kind \

--- a/crates/core/tests/authoring.rs
+++ b/crates/core/tests/authoring.rs
@@ -148,9 +148,9 @@ fn the_scaffold_writes_the_licence_evidence() {
 /// The scaffold teaches the `[bundles]` grammar in a commented-out example,
 /// and the only other check over it pins bytes. Bytes are happy to pin a
 /// shape no reader looks at, which is how kendex's own four sets shipped
-/// installing nothing. So the example is held two ways: it names every key
-/// the reader reads, and uncommented it is a set the reader gets members
-/// out of.
+/// installing nothing. The example is generated from the reader's own list,
+/// so the question left is whether the round trip closes: uncomment what the
+/// scaffold wrote and the reader has to get every kind back out of it.
 #[test]
 #[allow(clippy::unwrap_used)]
 fn the_scaffolded_bundle_example_is_a_set_the_reader_accepts() {
@@ -160,13 +160,6 @@ fn the_scaffolded_bundle_example_is_a_set_the_reader_accepts() {
         .find(|(rel, _)| rel == "kendex.toml")
         .unwrap()
         .1;
-
-    for (key, _) in kendex_core::source::bundles::MEMBER_LISTS {
-        assert!(
-            manifest.contains(key),
-            "the scaffold never names `{key}`, a key a set's members are written under"
-        );
-    }
 
     let example: String = manifest
         .lines()
@@ -185,18 +178,28 @@ fn the_scaffolded_bundle_example_is_a_set_the_reader_accepts() {
     let config = kendex_core::source::source_config(&sealed, "scaffolded").unwrap();
     let sets = kendex_core::source::bundles::offered(&sealed, &config).unwrap();
 
-    let members: Vec<(kendex_core::model::ItemKind, &str)> = sets
+    let members: Vec<String> = sets
         .iter()
         .flat_map(|set| set.members.iter())
-        .map(|member| (member.kind, member.name.as_str()))
+        .map(|member| format!("{} {}", member.kind.name(), member.name))
+        .collect();
+    // What the example is expected to yield is the example itself, read back
+    // through the reader: every kind, under the name the scaffold wrote for
+    // it. A kind added to the grammar extends both sides at once, and a kind
+    // the reader stops seeing shortens only one.
+    let expected: Vec<String> = kendex_core::source::bundles::member_list_example()
+        .lines()
+        .map(|line| {
+            let name = line
+                .split('"')
+                .nth(1)
+                .unwrap_or_else(|| panic!("the example line '{line}' names a member"));
+            format!("{} {name}", name.trim_start_matches("my-"))
+        })
         .collect();
     assert_eq!(
-        members,
-        [
-            (kendex_core::model::ItemKind::Agent, "my-agent"),
-            (kendex_core::model::ItemKind::Skill, "my-skill"),
-        ],
-        "the scaffolded example, uncommented, is not a set the reader gets members \
+        members, expected,
+        "the scaffolded example, uncommented, is not a set the reader gets every kind \
          out of:\n{example}"
     );
 }
@@ -561,15 +564,15 @@ fn the_scaffold_matches_its_checked_in_golden_digest() {
     for (license, expected) in [
         (
             License::Mit,
-            "3314ea3c24efa01b4f5d6b0693b72788348d63db49ab2af9fb2b68c6e8f8da18",
+            "98a5e948dac921d6cba4cae5b07e514a9e6cba1a638fa6c45ce30ff45aa55f79",
         ),
         (
             License::Apache2,
-            "ba340037e1eeae2b72f17b9b8ed5d8f7619012ad146ab71d877debe2ce41d289",
+            "4e63fd7bba05248e94e5247a5749c9ff51d5cbfd791468bd2b0f0838b99c0deb",
         ),
         (
             License::NoneYet,
-            "4038839a19299791a402f451394fb457b0b913b6ed73cc23041ccd685d7f7958",
+            "171067bedea26065af8967fb445f306fb97e322c989325d2d97e52e404d19741",
         ),
     ] {
         let files: Vec<(std::path::PathBuf, Vec<u8>)> =

--- a/crates/core/tests/authoring.rs
+++ b/crates/core/tests/authoring.rs
@@ -497,19 +497,19 @@ fn only_a_github_url_is_a_candidate_to_submit() {
 #[test]
 #[allow(clippy::unwrap_used)]
 fn the_scaffold_matches_its_checked_in_golden_digest() {
-    assert_eq!(kendex_core::author::scaffold::SCAFFOLD_VERSION, 1);
+    assert_eq!(kendex_core::author::scaffold::SCAFFOLD_VERSION, 2);
     for (license, expected) in [
         (
             License::Mit,
-            "df65c4e972e7fcf85459c2030b2933ecf5d9af06f26f321f663d1843a6ea1ded",
+            "3314ea3c24efa01b4f5d6b0693b72788348d63db49ab2af9fb2b68c6e8f8da18",
         ),
         (
             License::Apache2,
-            "7f8703f6999631efc692e1bfe9db21dfa5636e96a930177f74ba1ecf957093e8",
+            "ba340037e1eeae2b72f17b9b8ed5d8f7619012ad146ab71d877debe2ce41d289",
         ),
         (
             License::NoneYet,
-            "f99f2b34f98f9a480b34e1b3b543d2ddf731dc27c783c61aaa109d61b5c1116e",
+            "4038839a19299791a402f451394fb457b0b913b6ed73cc23041ccd685d7f7958",
         ),
     ] {
         let files: Vec<(std::path::PathBuf, Vec<u8>)> =

--- a/docs/authoring/README.md
+++ b/docs/authoring/README.md
@@ -61,10 +61,12 @@ tags = ["rust", "review"]
 skills = ["skills", "extra-skills"]
 agents = ["agents"]
 
-# Optional: curated sets people install with one click.
+# Optional: curated sets people install with one click. Members are bare
+# names, in one list per kind: agents, skills, commands, hooks, mcp-servers.
 [bundles.starter]
 description = "Everything a new project needs"
-members = ["skill/review", "agent/scout"]
+skills = ["review"]
+agents = ["scout"]
 ```
 
 Everything is optional. A missing `[marketplace]` table means the directory

--- a/kendex.toml
+++ b/kendex.toml
@@ -19,10 +19,10 @@ tags = ["agents", "skills", "hooks", "official"]
 # Curated sets, drawn from how these packages depend on one another. Install
 # a whole set with one preview, or pick from it. Members are bare names in
 # one list per kind, the shape `[bundles]` is read in. `workflow` is
-# orchestration, code-review and commit-guards in one install; those three
-# stay for partial installs, and research sits beside it.
+# orchestration, code-review and commit-guards plus deep-research, in one
+# install; those three stay for partial installs, and research sits beside it.
 [bundles.workflow]
-description = "The agents, skills and hooks the orchestration, review and commit-guard loop runs on"
+description = "Orchestration, code review and commit guards in one install, with deep-research"
 agents = [
   "reviewer-arch",
   "reviewer-correctness",

--- a/kendex.toml
+++ b/kendex.toml
@@ -18,11 +18,11 @@ tags = ["agents", "skills", "hooks", "official"]
 
 # Curated sets, drawn from how these packages depend on one another. Install
 # a whole set with one preview, or pick from it. Members are bare names in
-# one list per kind — the shape `[bundles]` is read in. `workflow` is the
-# whole agent workflow in one install; the four sets under it are the
-# partial installs it is drawn from.
+# one list per kind, the shape `[bundles]` is read in. `workflow` is
+# orchestration, code-review and commit-guards in one install; those three
+# stay for partial installs, and research sits beside it.
 [bundles.workflow]
-description = "Every agent, skill and hook a full agent workflow runs on"
+description = "The agents, skills and hooks the orchestration, review and commit-guard loop runs on"
 agents = [
   "reviewer-arch",
   "reviewer-correctness",
@@ -103,6 +103,8 @@ agents = [
 skills = [
   "deep-research",
   "decider",
+  "github",
+  "linear",
 ]
 
 [bundles.commit-guards]

--- a/kendex.toml
+++ b/kendex.toml
@@ -17,60 +17,108 @@ homepage = "https://kendex.ai"
 tags = ["agents", "skills", "hooks", "official"]
 
 # Curated sets, drawn from how these packages depend on one another. Install
-# a whole set with one preview, or pick from it.
+# a whole set with one preview, or pick from it. Members are bare names in
+# one list per kind — the shape `[bundles]` is read in. `workflow` is the
+# whole agent workflow in one install; the four sets under it are the
+# partial installs it is drawn from.
+[bundles.workflow]
+description = "Every agent, skill and hook a full agent workflow runs on"
+agents = [
+  "reviewer-arch",
+  "reviewer-correctness",
+  "reviewer-doc",
+  "reviewer-error",
+  "reviewer-perf",
+  "reviewer-quality",
+  "reviewer-safety",
+  "reviewer-security",
+  "reviewer-test",
+]
+skills = [
+  "orch",
+  "dev",
+  "github",
+  "worktree",
+  "project-management",
+  "decider",
+  "reviewer",
+  "linear",
+  "review-gate",
+  "second-opinion",
+  "code-quality",
+  "deep-research",
+  "growth-guards",
+  "size-ratchet",
+  "preflight",
+]
+hooks = [
+  "block-bare-cd",
+  "block-repo-copy",
+  "block-unsafe-rm",
+  "pre-commit-check",
+  "session-drift-check",
+  "task-completed-check",
+]
+
 [bundles.orchestration]
 description = "Multi-agent workflow orchestration and the skills it drives"
-members = [
-  "skill/orch",
-  "skill/dev",
-  "skill/github",
-  "skill/worktree",
-  "skill/project-management",
-  "skill/decider",
-  "skill/reviewer",
-  "skill/linear",
+skills = [
+  "orch",
+  "dev",
+  "github",
+  "worktree",
+  "project-management",
+  "decider",
+  "reviewer",
+  "linear",
 ]
 
 [bundles.code-review]
 description = "The review agents and the skills that run a review"
-members = [
-  "agent/reviewer-arch",
-  "agent/reviewer-correctness",
-  "agent/reviewer-doc",
-  "agent/reviewer-error",
-  "agent/reviewer-perf",
-  "agent/reviewer-quality",
-  "agent/reviewer-safety",
-  "agent/reviewer-security",
-  "agent/reviewer-test",
-  "skill/reviewer",
-  "skill/review-gate",
-  "skill/second-opinion",
-  "skill/code-quality",
+agents = [
+  "reviewer-arch",
+  "reviewer-correctness",
+  "reviewer-doc",
+  "reviewer-error",
+  "reviewer-perf",
+  "reviewer-quality",
+  "reviewer-safety",
+  "reviewer-security",
+  "reviewer-test",
+]
+skills = [
+  "reviewer",
+  "review-gate",
+  "second-opinion",
+  "code-quality",
 ]
 
 [bundles.research]
 description = "Research and planning agents with the deep-research skill"
-members = [
-  "agent/researcher",
-  "agent/scout",
-  "agent/planner",
-  "skill/deep-research",
-  "skill/decider",
+agents = [
+  "researcher",
+  "scout",
+  "planner",
+]
+skills = [
+  "deep-research",
+  "decider",
 ]
 
 [bundles.commit-guards]
 description = "Hooks and skills that guard what gets committed"
-members = [
-  "hook/block-bare-cd",
-  "hook/block-repo-copy",
-  "hook/block-unsafe-rm",
-  "hook/pre-commit-check",
-  "hook/session-drift-check",
-  "hook/task-completed-check",
-  "skill/growth-guards",
-  "skill/size-ratchet",
-  "skill/preflight",
+hooks = [
+  "block-bare-cd",
+  "block-repo-copy",
+  "block-unsafe-rm",
+  "pre-commit-check",
+  "session-drift-check",
+  "task-completed-check",
+]
+skills = [
+  "growth-guards",
+  "size-ratchet",
+  "preflight",
 ]
 
 # Skill mappings per agent — always loaded into context.


### PR DESCRIPTION
One `workflow` bundle a repo can install to get the whole agent workflow, and — found while writing it — bundles that install anything at all.

Closes KEN-1130

## What changed

**`[bundles.workflow]`** in `kendex.toml`: 9 agents, 15 skills, 6 hooks. The union of orchestration, code-review and commit-guards plus `deep-research`, with every skill a member requires itself a member (`dev` → `code-quality` is the one that mattered).

**The four existing bundles had never installed anything.** `[bundles.<name>]` is read by `source::bundles::declared` as one list of bare names per kind — `agents`, `skills`, `commands`, `hooks`, `mcp-servers`. All four sets declared `members = ["skill/orch", …]` instead, a key no reader looks at, added in 72b4ad45c. So `kendex add --bundle research` recorded the set, installed zero packages, and every check stayed green. All five sets are now in the shape the reader accepts.

The producer was the scaffold: `kendex marketplace new` wrote the broken shape into every catalog it created, and `kendex init` said the same in its marker comment. Both now build the `[bundles]` grammar from `MEMBER_LISTS` itself, so no hand-written copy is left to drift.

`[bundles.research]` gained `github` and `linear`: a set install skips agent-to-skill expansion, so its three agents were rendering "read each before acting" pointers to skills the set never carried.

## Done when

- `kendex marketplace` and the app's bundle page list `workflow` with its members — verified in a scratch repo: `--bundle workflow` installs 50 changes, `kendex verify` reads 30 checked / 30 OK / 0 failed
- `--bundle research` now installs 5, previously 0
- `kendex check --catalog . --strict` clean, exit 0
- `tools/guard` green end to end

## Guards

Six tests hold the line, each shown red against the defect it catches:

| Guard | Reddens on |
|-------|-----------|
| every set carries members this catalog offers | a set in the old `members` shape; a member the catalog does not offer |
| every set carries the skills its agent members load | an agent whose mapping the set omits; a typo in `[agent-skills]` or `[role-skills]` |
| the workflow set carries what its members require | a dropped required skill; a frontmatter key rename that makes the read silent |
| the workflow set is the sets it is drawn from plus what is written down | a member added to a drawn-from set alone, or to `workflow` alone outside `BEYOND` |
| the scaffolded bundle example is a set the reader accepts | an emitter that stops emitting a kind; a hand-written example |
| `A_MEMBER` anchors | `hook = […]` written for `hooks = […]` in `kendex.toml` — a data typo, no code change |

Each walk that reads through a path returning empty on failure carries an anchor, so "nothing there" and "nothing read" are no longer the same green.

## Notes for review

**Size tripwire.** `dev-round-write` refused round 3 at 556 branch lines against a 247 baseline (cap 494). 432 of those lines are the `own_catalog` module move: the round-2 assertions took `crates/core/src/source/bundles.rs` to 438 lines against the size ratchet's 400, so the module moved to `crates/core/src/source/bundles/own_catalog.rs`. A move counts twice in a diffstat — deletions from one file, insertions in another — while adding no surface. On the overseer's ruling the baseline was re-recorded 247 → 463 (the original baseline plus the 216 duplicated lines), with the reason in workflow state, so the original 494-line allowance for real surface is preserved and still enforced. Net of the forced move the branch is ~124 lines.

**Review.** Nine reviewers over three fix rounds and three re-review cycles; 15 findings fixed, 0 escalated. The cross-model external lane failed to run both times it was launched (`codex exited with code 1`) and is not counted as a pass. One follow-up is filed separately: `kendex check --catalog --strict` still passes a bundle that installs nothing, for every catalog but this one — the issue said "No new catalog check", so it is out of scope here.

**Residual, deliberate.** `A_MEMBER` anchors agent, skill and hook only, because no set carries a `commands` or `mcp-servers` list. Whoever adds the first such list should add its anchor beside it.

https://claude.ai/code/session_01YQ1eBtVorTX4MhT921kQYs
