### PR TITLE
fix(KEN-1022): a canceled twin no longer wins the project name

### DIFF
--- a/.agents/skills/linear/SKILL.md
+++ b/.agents/skills/linear/SKILL.md
@@ -133,7 +133,7 @@ Normalized issue lists, gets, bulk gets, bundles, recursive children, relation r
 
 Available states: Backlog, Todo, In Progress, In Review, Done, Canceled (not "Cancelled"). Verify with `statuses list`.
 
-A project **name** resolves to the live project when a canceled one shares it: canceled matches lose, and a name matching nothing but canceled projects is refused, naming their UUIDs. Pass a UUID to reach a canceled project.
+Where a **name** selects one project — `issues create` / `issues update --project`, `projects get`, `projects list-dependencies`, `milestones --project`, `initiatives add-project` / `remove-project` — a canceled project sharing that name loses to the live one, and a name with no live match is refused, naming each match and its state; pass a UUID to reach a canceled project. Name **filters** never resolve: `issues list --project`, `cache issues list --project` and `documents list --project` match on the name alone, so their results can mix a live project with its canceled twin.
 
 `--labels` REPLACES the whole issue-label set. Fetch current labels, compute the final set, validate it against `cache labels list --format=safe` (which reports `is_group` so parent/group labels can be rejected), then pass the complete set. A name that does not resolve fails the update; `--clear-labels` is the only way to empty the set.
 

--- a/.agents/skills/linear/SKILL.md
+++ b/.agents/skills/linear/SKILL.md
@@ -133,6 +133,8 @@ Normalized issue lists, gets, bulk gets, bundles, recursive children, relation r
 
 Available states: Backlog, Todo, In Progress, In Review, Done, Canceled (not "Cancelled"). Verify with `statuses list`.
 
+A project **name** resolves to the live project when a canceled one shares it: canceled matches lose, and a name matching nothing but canceled projects is refused, naming their UUIDs. Pass a UUID to reach a canceled project.
+
 `--labels` REPLACES the whole issue-label set. Fetch current labels, compute the final set, validate it against `cache labels list --format=safe` (which reports `is_group` so parent/group labels can be rejected), then pass the complete set. A name that does not resolve fails the update; `--clear-labels` is the only way to empty the set.
 
 - `agent:*` labels are mutually exclusive, one per issue; `issues activate` applies them with the "In Progress" transition (semantics: `issues --help`).

--- a/.agents/skills/linear/SKILL.md
+++ b/.agents/skills/linear/SKILL.md
@@ -133,7 +133,7 @@ Normalized issue lists, gets, bulk gets, bundles, recursive children, relation r
 
 Available states: Backlog, Todo, In Progress, In Review, Done, Canceled (not "Cancelled"). Verify with `statuses list`.
 
-Where a **name** selects one project — `issues create` / `issues update --project`, `projects get`, `projects list-dependencies`, `milestones --project`, `initiatives add-project` / `remove-project` — a canceled project sharing that name loses to the live one, and a name with no live match is refused, naming each match and its state; pass a UUID to reach a canceled project. Name **filters** never resolve: `issues list --project`, `cache issues list --project` and `documents list --project` match on the name alone, so their results can mix a live project with its canceled twin.
+Where a **name** selects one project — `issues create` / `update` / `bulk-update --project`, `projects get`, `projects list-dependencies`, `milestones --project`, `initiatives add-project` / `remove-project` — a canceled project sharing that name loses to the live one, and a name with no live match is refused, naming each match and its state; pass a UUID to reach a canceled project. Name **filters** never resolve: `issues list --project`, `cache issues list --project` and `documents list --project` match on the name alone, so their results can mix a live project with its canceled twin.
 
 `--labels` REPLACES the whole issue-label set. Fetch current labels, compute the final set, validate it against `cache labels list --format=safe` (which reports `is_group` so parent/group labels can be rejected), then pass the complete set. A name that does not resolve fails the update; `--clear-labels` is the only way to empty the set.
 

--- a/.agents/skills/linear/scripts/commands/initiatives.sh
+++ b/.agents/skills/linear/scripts/commands/initiatives.sh
@@ -57,30 +57,6 @@ case "${1:-help}" in help|--help|-h) show_help; exit 0 ;; esac
 
 source "$SCRIPT_DIR/../lib/common.sh"
 
-resolve_project_id() {
-    local project_ref="$1"
-
-    # Check if it's already a UUID
-    if [[ "$project_ref" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
-        echo "$project_ref"
-        return 0
-    fi
-
-    # Look up by name
-    local query='query GetProject($name: String!) { projects(filter: {name: {eq: $name}}) { nodes { id } } }'
-    local result
-    result=$(graphql_query "$query" "{\"name\": \"$project_ref\"}")
-    local project_id
-    project_id=$(echo "$result" | jq -r '.projects.nodes[0].id // empty')
-
-    if [ -z "$project_id" ]; then
-        echo "" >&2
-        return 1
-    fi
-
-    echo "$project_id"
-}
-
 list_initiatives() {
     local status=""
     local first=75
@@ -351,10 +327,10 @@ add_project() {
         return 1
     fi
 
+    # resolve_project_id names the failure itself — not found, only-canceled
+    # matches, or an API failure — so it is not re-reported here.
     local project_id
-    project_id=$(resolve_project_id "$project")
-    if [ -z "$project_id" ]; then
-        echo "{\"error\": \"Project not found: $project\"}" >&2
+    if ! project_id=$(resolve_project_id "$project"); then
         return 1
     fi
 
@@ -396,10 +372,10 @@ remove_project() {
         return 1
     fi
 
+    # resolve_project_id names the failure itself — not found, only-canceled
+    # matches, or an API failure — so it is not re-reported here.
     local project_id
-    project_id=$(resolve_project_id "$project")
-    if [ -z "$project_id" ]; then
-        echo "{\"error\": \"Project not found: $project\"}" >&2
+    if ! project_id=$(resolve_project_id "$project"); then
         return 1
     fi
 

--- a/.agents/skills/linear/scripts/commands/milestones.sh
+++ b/.agents/skills/linear/scripts/commands/milestones.sh
@@ -45,30 +45,6 @@ case "${1:-help}" in help|--help|-h) show_help; exit 0 ;; esac
 
 source "$SCRIPT_DIR/../lib/common.sh"
 
-resolve_project_id() {
-    local project_ref="$1"
-
-    # Check if it's already a UUID
-    if [[ "$project_ref" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
-        echo "$project_ref"
-        return 0
-    fi
-
-    # Look up by name
-    local query='query GetProject($name: String!) { projects(filter: {name: {eq: $name}}) { nodes { id } } }'
-    local result
-    result=$(graphql_query "$query" "{\"name\": \"$project_ref\"}")
-    local project_id
-    project_id=$(echo "$result" | jq -r '.projects.nodes[0].id // empty')
-
-    if [ -z "$project_id" ]; then
-        echo "" >&2
-        return 1
-    fi
-
-    echo "$project_id"
-}
-
 list_milestones() {
     local project=""
     FORMAT="${DEFAULT_FORMAT}"
@@ -104,10 +80,10 @@ list_milestones() {
         }'
         result=$(graphql_query "$query" "{}")
     else
+        # resolve_project_id names the failure itself — not found, only-canceled
+        # matches, or an API failure — so it is not re-reported here.
         local project_id
-        project_id=$(resolve_project_id "$project")
-        if [ -z "$project_id" ]; then
-            echo "{\"error\": \"Project not found: $project\"}" >&2
+        if ! project_id=$(resolve_project_id "$project"); then
             return 1
         fi
 
@@ -226,10 +202,10 @@ create_milestone() {
         validate_length "description" "$description" $LINEAR_LIMIT_SHORT_DESC || return 1
     fi
 
+    # resolve_project_id names the failure itself — not found, only-canceled
+    # matches, or an API failure — so it is not re-reported here.
     local project_id
-    project_id=$(resolve_project_id "$project")
-    if [ -z "$project_id" ]; then
-        echo "{\"error\": \"Project not found: $project\"}" >&2
+    if ! project_id=$(resolve_project_id "$project"); then
         return 1
     fi
 

--- a/.agents/skills/linear/scripts/lib/common.sh
+++ b/.agents/skills/linear/scripts/lib/common.sh
@@ -663,11 +663,14 @@ resolve_project_id() {
         (.projects.nodes // []) as $all
         | ($all | map(select((.state // "" | ascii_downcase) != "canceled"))) as $live
         | ($live[0].id // ""),
-          ($all - $live | map(.id + " (" + (.state // "no state") + ")") | join(", "))')
+          ($all - $live | map(.id + " (" + .state + ")") | join(", "))')
     # Command substitution strips the trailing newline, so with nothing
     # rejected — one live project, the everyday case — the second read hits EOF
     # and returns 1. Under this file's errexit that status ends the function
-    # before it can print the id it just resolved.
+    # before it can print the id it just resolved. Every call site in the skill
+    # spells the call var=$(resolve_project_id ...), where bash does not apply
+    # errexit, so the abort shows up only in a bare call or in a command
+    # substitution under shopt -s inherit_errexit, which sync.sh sets.
     { IFS= read -r project_id; IFS= read -r rejected; } <<<"$selection" || true
 
     if [ -n "$project_id" ]; then

--- a/.agents/skills/linear/scripts/lib/common.sh
+++ b/.agents/skills/linear/scripts/lib/common.sh
@@ -623,6 +623,13 @@ linear_guard_write_action() {
 
 # Resolve project name or UUID to UUID
 # Usage: resolve_project_id "Phase 1" or resolve_project_id "uuid-here"
+#
+# Linear keeps a canceled project under the name a live one reuses, and the
+# name query returns both in no fixed order, so nodes[0] handed writes the
+# canceled one at random and `issues create --project` reported success on an
+# issue nobody could find (KEN-1022). A canceled match loses to every live one;
+# an all-canceled match set is refused, naming its UUIDs so a deliberate read
+# can pass one.
 resolve_project_id() {
     local project_ref="$1"
 
@@ -632,21 +639,40 @@ resolve_project_id() {
         return 0
     fi
 
-    # Look up by name
-    local query='query GetProject($name: String!) { projects(filter: {name: {eq: $name}}) { nodes { id } } }'
+    # `state` is selected, not filtered on: the server-side `state` filter is
+    # broken (see list_projects), and the whole match set is what separates
+    # "no such project" from "only canceled ones".
+    local query='query GetProject($name: String!) { projects(filter: {name: {eq: $name}}) { nodes { id state } } }'
     local variables
     variables=$(jq -nc --arg name "$project_ref" '{name: $name}')
     local result
-    result=$(graphql_query "$query" "$variables")
-    local project_id
-    project_id=$(echo "$result" | jq -r '.projects.nodes[0].id // empty')
-
-    if [ -z "$project_id" ]; then
-        jq -nc --arg message "Project not found: $project_ref" '{error: $message}' >&2
+    # A FAILED query is an API failure (rate limit, outage); "Project not
+    # found" is only true of a lookup that succeeded and matched nothing.
+    if ! result=$(graphql_query "$query" "$variables"); then
+        jq -nc --arg name "$project_ref" \
+            '{error: ("Could not resolve project \"" + $name + "\": Linear API request failed (see previous error)")}' >&2
         return 1
     fi
 
-    echo "$project_id"
+    local project_id
+    project_id=$(echo "$result" | jq -r \
+        '[(.projects.nodes // [])[] | select((.state // "" | ascii_downcase) != "canceled")][0].id // empty')
+
+    if [ -n "$project_id" ]; then
+        echo "$project_id"
+        return 0
+    fi
+
+    local canceled_ids
+    canceled_ids=$(echo "$result" | jq -r '[(.projects.nodes // [])[].id] | join(", ")')
+    if [ -n "$canceled_ids" ]; then
+        jq -nc --arg name "$project_ref" --arg ids "$canceled_ids" \
+            '{error: ("Project not found: " + $name + " (matched only canceled projects: " + $ids + "; pass a project UUID to target one)")}' >&2
+        return 1
+    fi
+
+    jq -nc --arg message "Project not found: $project_ref" '{error: $message}' >&2
+    return 1
 }
 
 # Resolve team name to UUID

--- a/.agents/skills/linear/scripts/lib/common.sh
+++ b/.agents/skills/linear/scripts/lib/common.sh
@@ -664,7 +664,11 @@ resolve_project_id() {
         | ($all | map(select((.state // "" | ascii_downcase) != "canceled"))) as $live
         | ($live[0].id // ""),
           ($all - $live | map(.id + " (" + (.state // "no state") + ")") | join(", "))')
-    { IFS= read -r project_id; IFS= read -r rejected; } <<<"$selection"
+    # Command substitution strips the trailing newline, so with nothing
+    # rejected — one live project, the everyday case — the second read hits EOF
+    # and returns 1. Under this file's errexit that status ends the function
+    # before it can print the id it just resolved.
+    { IFS= read -r project_id; IFS= read -r rejected; } <<<"$selection" || true
 
     if [ -n "$project_id" ]; then
         echo "$project_id"

--- a/.agents/skills/linear/scripts/lib/common.sh
+++ b/.agents/skills/linear/scripts/lib/common.sh
@@ -654,20 +654,26 @@ resolve_project_id() {
         return 1
     fi
 
-    local project_id
-    project_id=$(echo "$result" | jq -r \
-        '[(.projects.nodes // [])[] | select((.state // "" | ascii_downcase) != "canceled")][0].id // empty')
+    # One pass, so the rejected list is the selection's complement rather than
+    # a second predicate that can drift from it: line 1 is the chosen id, line 2
+    # the rejected ones with the state that rejected each. A widened predicate
+    # keeps the message true without being edited.
+    local selection project_id rejected
+    selection=$(echo "$result" | jq -r '
+        (.projects.nodes // []) as $all
+        | ($all | map(select((.state // "" | ascii_downcase) != "canceled"))) as $live
+        | ($live[0].id // ""),
+          ($all - $live | map(.id + " (" + (.state // "no state") + ")") | join(", "))')
+    { IFS= read -r project_id; IFS= read -r rejected; } <<<"$selection"
 
     if [ -n "$project_id" ]; then
         echo "$project_id"
         return 0
     fi
 
-    local canceled_ids
-    canceled_ids=$(echo "$result" | jq -r '[(.projects.nodes // [])[].id] | join(", ")')
-    if [ -n "$canceled_ids" ]; then
-        jq -nc --arg name "$project_ref" --arg ids "$canceled_ids" \
-            '{error: ("Project not found: " + $name + " (matched only canceled projects: " + $ids + "; pass a project UUID to target one)")}' >&2
+    if [ -n "$rejected" ]; then
+        jq -nc --arg name "$project_ref" --arg matches "$rejected" \
+            '{error: ("Project not found: " + $name + " (no live project has this name; matches: " + $matches + "; pass a project UUID to target one)")}' >&2
         return 1
     fi
 

--- a/.agents/skills/linear/tests/controls/project-name-canceled-duplicate.control.sh
+++ b/.agents/skills/linear/tests/controls/project-name-canceled-duplicate.control.sh
@@ -1,7 +1,8 @@
-# Take the first project the name query returns instead of the first live one.
-# A canceled project sharing the name then wins whenever the API lists it
-# first, and the create lands there reporting success.
+# Let every match count as live, so the selection is the first project the name
+# query returned rather than the first live one. A canceled project sharing the
+# name then wins whenever the API lists it first, and the create lands there
+# reporting success.
 control_expect "the issueCreate payload carries the live project id, not the canceled one (canceled-first)"
 control_replace scripts/lib/common.sh 1 \
-    '        '"'"'[(.projects.nodes // [])[] | select((.state // "" | ascii_downcase) != "canceled")][0].id // empty'"'"')' \
-    '        '"'"'(.projects.nodes // [])[0].id // empty'"'"')'
+    '        | ($all | map(select((.state // "" | ascii_downcase) != "canceled"))) as $live' \
+    '        | $all as $live'

--- a/.agents/skills/linear/tests/controls/project-name-canceled-duplicate.control.sh
+++ b/.agents/skills/linear/tests/controls/project-name-canceled-duplicate.control.sh
@@ -1,0 +1,7 @@
+# Take the first project the name query returns instead of the first live one.
+# A canceled project sharing the name then wins whenever the API lists it
+# first, and the create lands there reporting success.
+control_expect "the issueCreate payload carries the live project id, not the canceled one (canceled-first)"
+control_replace scripts/lib/common.sh 1 \
+    '        '"'"'[(.projects.nodes // [])[] | select((.state // "" | ascii_downcase) != "canceled")][0].id // empty'"'"')' \
+    '        '"'"'(.projects.nodes // [])[0].id // empty'"'"')'

--- a/.agents/skills/linear/tests/project-name-canceled-duplicate.test.sh
+++ b/.agents/skills/linear/tests/project-name-canceled-duplicate.test.sh
@@ -16,12 +16,27 @@ source "$SCRIPT_DIR/lib/assert.sh"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 assert_tmpdir TMP_ROOT
 
+# GIT_DIR outranks -C, so a suite that inherits it — every run from inside a
+# git hook does — re-initializes the ambient repository instead of the fixture,
+# and every later `git rev-parse --show-toplevel` (the CLI's own, for CACHE_DIR)
+# answers with the real checkout. The fixture issue would then be written into
+# the developer's real .cache/linear. Unsetting here covers the whole process,
+# git and CLI alike.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
 mkdir -p "$TMP_ROOT/.agents/skills" "$TMP_ROOT/bin" "$TMP_ROOT/.cache/linear"
 cp -R "$SKILL_DIR" "$TMP_ROOT/.agents/skills/linear"
 # Isolate CACHE_DIR resolution (git rev-parse --show-toplevel) to this
 # throwaway root so cache writes from `issues create` stay out of the real
 # project's `.cache/linear` (kendex#43).
 git -C "$TMP_ROOT" init -q -b main
+# Proof the isolation held. Without it the line above re-inits the ambient
+# repository and leaves no fixture repo behind, and the run goes on to write
+# into the real cache — so this one stops the suite rather than recording a
+# failure and continuing.
+assert "the fixture repository is the one git init created" \
+  test -d "$TMP_ROOT/.git"
+[[ -d "$TMP_ROOT/.git" ]] || exit 1
 
 cat >"$TMP_ROOT/bin/curl" <<'SH'
 #!/usr/bin/env bash
@@ -127,10 +142,10 @@ assert_ne "issues create fails when every same-name project is canceled" "$rc" 0
 only_canceled_err="$(cat "$TMP_ROOT/only-canceled.err")"
 assert_contains "the refusal names the project asked for" \
   "$only_canceled_err" "Project not found: Dup"
-assert_contains "the refusal says the matches were canceled" \
-  "$only_canceled_err" "matched only canceled projects"
-assert_contains "the refusal names the canceled uuids so a deliberate read can pass one" \
-  "$only_canceled_err" "dead-uuid, dead-two-uuid"
+assert_contains "the refusal says no live project has the name" \
+  "$only_canceled_err" "no live project has this name"
+assert_contains "the refusal names each rejected uuid with the state that rejected it" \
+  "$only_canceled_err" "dead-uuid (canceled), dead-two-uuid (canceled)"
 
 assert_not "no issue is created against a canceled project" \
   grep -qF 'issueCreate' "$TMP_ROOT/only-canceled-payloads.jsonl"
@@ -166,6 +181,33 @@ assert_not_contains "a failed lookup is not reported as a missing project" \
 # initiatives.sh and milestones.sh each carried a private resolve_project_id
 # that shadowed the shared one after sourcing it, so the fix above would have
 # reached neither.
+#
+# bash spells one definition three ways, and a guard carrying only the first
+# does not stop the regression it exists to stop: `name() {`, `function name {`
+# (parens optional), and either with the opening brace on the next line. The
+# pattern below takes the definition line whole, so a call — `resolve_project_id
+# "$p"` or `$(resolve_project_id ...)` — never matches.
 
-shadowed="$(grep -rlF 'resolve_project_id() {' "$SKILL_DIR/scripts" | grep -vF '/lib/common.sh' || true)"
+definition='^[[:space:]]*(function[[:space:]]+resolve_project_id([[:space:]]*\(\))?|resolve_project_id[[:space:]]*\(\))[[:space:]]*\{?[[:space:]]*$'
+shadowed="$(grep -rlE "$definition" "$SKILL_DIR/scripts" | grep -vF '/lib/common.sh' || true)"
 assert_eq "resolve_project_id is defined once, in lib/common.sh" "$shadowed" ""
+
+# The pattern is only worth as much as its coverage, so each spelling is
+# checked against it here rather than assumed.
+for spelling in \
+  'resolve_project_id() {' \
+  '  resolve_project_id ()' \
+  'function resolve_project_id {' \
+  'function resolve_project_id' \
+  'function resolve_project_id() {'; do
+  assert "the definition pattern matches: $spelling" \
+    grep -qE "$definition" <<<"$spelling"
+done
+
+for call in \
+  '    project_id=$(resolve_project_id "$project")' \
+  '    if ! project_id=$(resolve_project_id "$project"); then' \
+  '# resolve_project_id names the failure itself'; do
+  assert_not "the definition pattern ignores: $call" \
+    grep -qE "$definition" <<<"$call"
+done

--- a/.agents/skills/linear/tests/project-name-canceled-duplicate.test.sh
+++ b/.agents/skills/linear/tests/project-name-canceled-duplicate.test.sh
@@ -6,7 +6,8 @@
 # name query returns both in no fixed order. resolve_project_id took nodes[0],
 # so `issues create --project "<name>"` landed the issue in whichever the API
 # happened to list first — silently, since a create carrying a valid project id
-# succeeds either way.
+# succeeds either way. The fixture lists the canceled twin first, which is the
+# order the old code got wrong.
 
 set -euo pipefail
 
@@ -44,38 +45,14 @@ cat >"$TMP_ROOT/bin/curl" <<'SH'
 config="$(cat)"
 payload="$(sed -n 's/^data = //p' <<<"$config" | jq -r)"
 query="$(jq -r '.query' <<<"$payload")"
-scenario="${LINEAR_PROJECT_TEST_CASE:-canceled-first}"
 printf '%s\n' "$payload" >> "${CURL_PAYLOAD_LOG:?}"
-
-live='{"id":"live-uuid","state":"backlog"}'
-dead='{"id":"dead-uuid","state":"canceled"}'
-other_dead='{"id":"dead-two-uuid","state":"canceled"}'
 
 case "$query" in
 *"teams(filter:"*)
   printf '%s' '{"data":{"teams":{"nodes":[{"id":"team-uuid"}]}}}___HTTP_CODE___200'
   ;;
 *"projects(filter:"*)
-  case "$scenario" in
-  canceled-first)
-    printf '%s' "{\"data\":{\"projects\":{\"nodes\":[$dead,$live]}}}___HTTP_CODE___200"
-    ;;
-  live-first)
-    printf '%s' "{\"data\":{\"projects\":{\"nodes\":[$live,$dead]}}}___HTTP_CODE___200"
-    ;;
-  only-canceled)
-    printf '%s' "{\"data\":{\"projects\":{\"nodes\":[$dead,$other_dead]}}}___HTTP_CODE___200"
-    ;;
-  no-match)
-    printf '%s' '{"data":{"projects":{"nodes":[]}}}___HTTP_CODE___200'
-    ;;
-  api-failure)
-    printf '%s' '{"errors":[{"message":"unauthenticated"}]}___HTTP_CODE___401'
-    ;;
-  *)
-    printf '%s' '{"errors":[{"message":"unknown scenario"}]}___HTTP_CODE___200'
-    ;;
-  esac
+  printf '%s' '{"data":{"projects":{"nodes":[{"id":"dead-uuid","state":"canceled"},{"id":"live-uuid","state":"backlog"}]}}}___HTTP_CODE___200'
   ;;
 *"issueLabels(filter:"*)
   printf '%s' '{"data":{"issueLabels":{"nodes":[{"id":"label-uuid"}]}}}___HTTP_CODE___200'
@@ -90,14 +67,15 @@ esac
 SH
 chmod +x "$TMP_ROOT/bin/curl"
 
+PAYLOAD_LOG="$TMP_ROOT/payloads.jsonl"
+: >"$PAYLOAD_LOG"
+
 run_create() {
-  local scenario="$1"
   (
     cd "$TMP_ROOT" && \
     PATH="$TMP_ROOT/bin:$PATH" \
       LINEAR_API_KEY_OVERRIDE=test-token \
-      CURL_PAYLOAD_LOG="$TMP_ROOT/$scenario-payloads.jsonl" \
-      LINEAR_PROJECT_TEST_CASE="$scenario" \
+      CURL_PAYLOAD_LOG="$PAYLOAD_LOG" \
       bash "$TMP_ROOT/.agents/skills/linear/scripts/linear.sh" issues create \
         --title t \
         --team Claude \
@@ -105,119 +83,15 @@ run_create() {
         --labels agent:rust \
         --priority 3 \
         --description d
-  ) >"$TMP_ROOT/$scenario.out" 2>"$TMP_ROOT/$scenario.err"
+  ) >"$TMP_ROOT/create.out" 2>"$TMP_ROOT/create.err"
 }
 
-# --- a live match wins, whichever order the API lists the duplicates in ------
-
-for scenario in canceled-first live-first; do
-  : >"$TMP_ROOT/$scenario-payloads.jsonl"
-  rc=0
-  run_status rc run_create "$scenario"
-
-  assert_eq "issues create succeeds when a canceled project shares the name ($scenario)" \
-    "$rc" 0
-
-  assert "the issueCreate payload carries the live project id, not the canceled one ($scenario)" \
-    jq -s -e 'any(.[]; (.query | contains("issueCreate")) and .variables.input.projectId == "live-uuid")' \
-    "$TMP_ROOT/$scenario-payloads.jsonl" >/dev/null
-
-  assert_not "no request names the canceled project id ($scenario)" \
-    grep -qF 'dead-uuid' "$TMP_ROOT/$scenario-payloads.jsonl"
-done
-
-# The lookup asks for `state`: without it every match looks live and the
-# selection above cannot be made.
-assert "the project lookup selects state alongside id" \
-  jq -s -e 'any(.[]; (.query | contains("projects(filter:")) and (.query | contains("nodes { id state }")))' \
-  "$TMP_ROOT/canceled-first-payloads.jsonl" >/dev/null
-
-# --- only-canceled matches are refused, not silently used --------------------
-
-: >"$TMP_ROOT/only-canceled-payloads.jsonl"
 rc=0
-run_status rc run_create only-canceled
+run_status rc run_create
 
-assert_ne "issues create fails when every same-name project is canceled" "$rc" 0
+assert_eq "issues create succeeds when a canceled project shares the name (canceled-first)" \
+  "$rc" 0
 
-only_canceled_err="$(cat "$TMP_ROOT/only-canceled.err")"
-assert_contains "the refusal names the project asked for" \
-  "$only_canceled_err" "Project not found: Dup"
-assert_contains "the refusal says no live project has the name" \
-  "$only_canceled_err" "no live project has this name"
-assert_contains "the refusal names each rejected uuid with the state that rejected it" \
-  "$only_canceled_err" "dead-uuid (canceled), dead-two-uuid (canceled)"
-
-assert_not "no issue is created against a canceled project" \
-  grep -qF 'issueCreate' "$TMP_ROOT/only-canceled-payloads.jsonl"
-
-# --- a genuine miss keeps the plain diagnostic -------------------------------
-
-: >"$TMP_ROOT/no-match-payloads.jsonl"
-rc=0
-run_status rc run_create no-match
-
-assert_ne "issues create fails when the name matches nothing" "$rc" 0
-no_match_err="$(cat "$TMP_ROOT/no-match.err")"
-assert_contains "a name that matches nothing reports a plain miss" \
-  "$no_match_err" "Project not found: Dup"
-assert_not_contains "a plain miss does not claim canceled matches" \
-  "$no_match_err" "canceled"
-
-# --- an API failure is not reported as a missing project ---------------------
-
-: >"$TMP_ROOT/api-failure-payloads.jsonl"
-rc=0
-run_status rc run_create api-failure
-
-assert_ne "issues create fails when the project lookup errors" "$rc" 0
-api_failure_err="$(cat "$TMP_ROOT/api-failure.err")"
-assert_contains "a failed lookup is reported as an API failure" \
-  "$api_failure_err" "Linear API request failed"
-assert_not_contains "a failed lookup is not reported as a missing project" \
-  "$api_failure_err" "Project not found"
-
-# --- a lone live match returns rather than aborting --------------------------
-#
-# The resolver reads the selection back as two lines, and with nothing rejected
-# the second read hits EOF. Under the file's own errexit that status ended the
-# function before it printed the id. Every call site here spells the call
-# `var=$(resolve_project_id ...)`, which hides it, so the two shapes that do
-# not are exercised directly: a bare call, and a command substitution under
-# `shopt -s inherit_errexit`, which sync.sh sets.
-
-cat >"$TMP_ROOT/direct.sh" <<'SH'
-#!/bin/bash
-set -euo pipefail
-if [ "${1:-}" = inherit ]; then
-  shopt -s inherit_errexit
-fi
-source "$2/.agents/skills/linear/scripts/lib/common.sh"
-graphql_query() {
-  printf '%s' '{"projects":{"nodes":[{"id":"live-uuid","state":"backlog"}]}}'
-}
-if [ "${1:-}" = inherit ]; then
-  resolved="$(resolve_project_id Dup)"
-  printf '%s\n' "$resolved"
-else
-  resolve_project_id Dup
-fi
-echo reached-the-end
-SH
-
-run_direct() {
-  (
-    cd "$TMP_ROOT" && LINEAR_API_KEY_OVERRIDE=test-token \
-      bash "$TMP_ROOT/direct.sh" "$1" "$TMP_ROOT"
-  ) >"$TMP_ROOT/direct-$1.out" 2>&1
-}
-
-for shape in bare inherit; do
-  rc=0
-  run_status rc run_direct "$shape"
-  assert_eq "a lone live match resolves without aborting ($shape)" "$rc" 0
-  direct_out="$(cat "$TMP_ROOT/direct-$shape.out")"
-  assert_contains "the resolved id is printed ($shape)" "$direct_out" "live-uuid"
-  assert_contains "the caller runs on past the resolve ($shape)" \
-    "$direct_out" "reached-the-end"
-done
+assert "the issueCreate payload carries the live project id, not the canceled one (canceled-first)" \
+  jq -s -e 'any(.[]; (.query | contains("issueCreate")) and .variables.input.projectId == "live-uuid")' \
+  "$PAYLOAD_LOG" >/dev/null

--- a/.agents/skills/linear/tests/project-name-canceled-duplicate.test.sh
+++ b/.agents/skills/linear/tests/project-name-canceled-duplicate.test.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Regression test: a project name that matches both a canceled and a live
+# project must resolve to the live one (KEN-1022).
+#
+# Linear keeps a canceled project under the name a live one reuses, and the
+# name query returns both in no fixed order. resolve_project_id took nodes[0],
+# so `issues create --project "<name>"` landed the issue in whichever the API
+# happened to list first — silently, since a create carrying a valid project id
+# succeeds either way.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/assert.sh
+source "$SCRIPT_DIR/lib/assert.sh"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+assert_tmpdir TMP_ROOT
+
+mkdir -p "$TMP_ROOT/.agents/skills" "$TMP_ROOT/bin" "$TMP_ROOT/.cache/linear"
+cp -R "$SKILL_DIR" "$TMP_ROOT/.agents/skills/linear"
+# Isolate CACHE_DIR resolution (git rev-parse --show-toplevel) to this
+# throwaway root so cache writes from `issues create` stay out of the real
+# project's `.cache/linear` (kendex#43).
+git -C "$TMP_ROOT" init -q -b main
+
+cat >"$TMP_ROOT/bin/curl" <<'SH'
+#!/usr/bin/env bash
+config="$(cat)"
+payload="$(sed -n 's/^data = //p' <<<"$config" | jq -r)"
+query="$(jq -r '.query' <<<"$payload")"
+scenario="${LINEAR_PROJECT_TEST_CASE:-canceled-first}"
+printf '%s\n' "$payload" >> "${CURL_PAYLOAD_LOG:?}"
+
+live='{"id":"live-uuid","state":"backlog"}'
+dead='{"id":"dead-uuid","state":"canceled"}'
+other_dead='{"id":"dead-two-uuid","state":"canceled"}'
+
+case "$query" in
+*"teams(filter:"*)
+  printf '%s' '{"data":{"teams":{"nodes":[{"id":"team-uuid"}]}}}___HTTP_CODE___200'
+  ;;
+*"projects(filter:"*)
+  case "$scenario" in
+  canceled-first)
+    printf '%s' "{\"data\":{\"projects\":{\"nodes\":[$dead,$live]}}}___HTTP_CODE___200"
+    ;;
+  live-first)
+    printf '%s' "{\"data\":{\"projects\":{\"nodes\":[$live,$dead]}}}___HTTP_CODE___200"
+    ;;
+  only-canceled)
+    printf '%s' "{\"data\":{\"projects\":{\"nodes\":[$dead,$other_dead]}}}___HTTP_CODE___200"
+    ;;
+  no-match)
+    printf '%s' '{"data":{"projects":{"nodes":[]}}}___HTTP_CODE___200'
+    ;;
+  api-failure)
+    printf '%s' '{"errors":[{"message":"unauthenticated"}]}___HTTP_CODE___401'
+    ;;
+  *)
+    printf '%s' '{"errors":[{"message":"unknown scenario"}]}___HTTP_CODE___200'
+    ;;
+  esac
+  ;;
+*"issueLabels(filter:"*)
+  printf '%s' '{"data":{"issueLabels":{"nodes":[{"id":"label-uuid"}]}}}___HTTP_CODE___200'
+  ;;
+*"issueCreate(input:"*)
+  printf '%s' '{"data":{"issueCreate":{"success":true,"issue":{"id":"child-uuid","identifier":"CC-900","title":"t","description":"d","state":{"name":"Todo","type":"unstarted"},"assignee":null,"project":{"id":"live-uuid","name":"Dup"},"projectMilestone":null,"cycle":null,"parent":null,"team":{"name":"Claude"},"labels":{"nodes":[{"name":"agent:rust"}]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/test/issue/CC-900","createdAt":"2026-09-02T00:00:00Z","updatedAt":"2026-09-02T00:00:00Z","archivedAt":null,"trashed":null,"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}}}}___HTTP_CODE___200'
+  ;;
+*)
+  printf '%s' '{"errors":[{"message":"unexpected query"}]}___HTTP_CODE___200'
+  ;;
+esac
+SH
+chmod +x "$TMP_ROOT/bin/curl"
+
+run_create() {
+  local scenario="$1"
+  (
+    cd "$TMP_ROOT" && \
+    PATH="$TMP_ROOT/bin:$PATH" \
+      LINEAR_API_KEY_OVERRIDE=test-token \
+      CURL_PAYLOAD_LOG="$TMP_ROOT/$scenario-payloads.jsonl" \
+      LINEAR_PROJECT_TEST_CASE="$scenario" \
+      bash "$TMP_ROOT/.agents/skills/linear/scripts/linear.sh" issues create \
+        --title t \
+        --team Claude \
+        --project Dup \
+        --labels agent:rust \
+        --priority 3 \
+        --description d
+  ) >"$TMP_ROOT/$scenario.out" 2>"$TMP_ROOT/$scenario.err"
+}
+
+# --- a live match wins, whichever order the API lists the duplicates in ------
+
+for scenario in canceled-first live-first; do
+  : >"$TMP_ROOT/$scenario-payloads.jsonl"
+  rc=0
+  run_status rc run_create "$scenario"
+
+  assert_eq "issues create succeeds when a canceled project shares the name ($scenario)" \
+    "$rc" 0
+
+  assert "the issueCreate payload carries the live project id, not the canceled one ($scenario)" \
+    jq -s -e 'any(.[]; (.query | contains("issueCreate")) and .variables.input.projectId == "live-uuid")' \
+    "$TMP_ROOT/$scenario-payloads.jsonl" >/dev/null
+
+  assert_not "no request names the canceled project id ($scenario)" \
+    grep -qF 'dead-uuid' "$TMP_ROOT/$scenario-payloads.jsonl"
+done
+
+# The lookup asks for `state`: without it every match looks live and the
+# selection above cannot be made.
+assert "the project lookup selects state alongside id" \
+  jq -s -e 'any(.[]; (.query | contains("projects(filter:")) and (.query | contains("nodes { id state }")))' \
+  "$TMP_ROOT/canceled-first-payloads.jsonl" >/dev/null
+
+# --- only-canceled matches are refused, not silently used --------------------
+
+: >"$TMP_ROOT/only-canceled-payloads.jsonl"
+rc=0
+run_status rc run_create only-canceled
+
+assert_ne "issues create fails when every same-name project is canceled" "$rc" 0
+
+only_canceled_err="$(cat "$TMP_ROOT/only-canceled.err")"
+assert_contains "the refusal names the project asked for" \
+  "$only_canceled_err" "Project not found: Dup"
+assert_contains "the refusal says the matches were canceled" \
+  "$only_canceled_err" "matched only canceled projects"
+assert_contains "the refusal names the canceled uuids so a deliberate read can pass one" \
+  "$only_canceled_err" "dead-uuid, dead-two-uuid"
+
+assert_not "no issue is created against a canceled project" \
+  grep -qF 'issueCreate' "$TMP_ROOT/only-canceled-payloads.jsonl"
+
+# --- a genuine miss keeps the plain diagnostic -------------------------------
+
+: >"$TMP_ROOT/no-match-payloads.jsonl"
+rc=0
+run_status rc run_create no-match
+
+assert_ne "issues create fails when the name matches nothing" "$rc" 0
+no_match_err="$(cat "$TMP_ROOT/no-match.err")"
+assert_contains "a name that matches nothing reports a plain miss" \
+  "$no_match_err" "Project not found: Dup"
+assert_not_contains "a plain miss does not claim canceled matches" \
+  "$no_match_err" "canceled"
+
+# --- an API failure is not reported as a missing project ---------------------
+
+: >"$TMP_ROOT/api-failure-payloads.jsonl"
+rc=0
+run_status rc run_create api-failure
+
+assert_ne "issues create fails when the project lookup errors" "$rc" 0
+api_failure_err="$(cat "$TMP_ROOT/api-failure.err")"
+assert_contains "a failed lookup is reported as an API failure" \
+  "$api_failure_err" "Linear API request failed"
+assert_not_contains "a failed lookup is not reported as a missing project" \
+  "$api_failure_err" "Project not found"
+
+# --- no command ships its own copy of the resolver ---------------------------
+#
+# initiatives.sh and milestones.sh each carried a private resolve_project_id
+# that shadowed the shared one after sourcing it, so the fix above would have
+# reached neither.
+
+shadowed="$(grep -rlF 'resolve_project_id() {' "$SKILL_DIR/scripts" | grep -vF '/lib/common.sh' || true)"
+assert_eq "resolve_project_id is defined once, in lib/common.sh" "$shadowed" ""

--- a/.agents/skills/linear/tests/project-name-canceled-duplicate.test.sh
+++ b/.agents/skills/linear/tests/project-name-canceled-duplicate.test.sh
@@ -177,42 +177,6 @@ assert_contains "a failed lookup is reported as an API failure" \
 assert_not_contains "a failed lookup is not reported as a missing project" \
   "$api_failure_err" "Project not found"
 
-# --- every command resolves through the shared resolver ----------------------
-#
-# initiatives.sh and milestones.sh each carried a private resolve_project_id
-# that shadowed the shared one after sourcing it, so the fix above would have
-# reached neither.
-#
-# Bash spells one definition several ways, so a source-text match only ever
-# covers the spellings its author thought of. The question goes to bash
-# instead: source each command script, then read back where the function it
-# ended up with was defined. A redefinition in any spelling moves that answer.
-#
-# The probe passes an action no dispatcher knows, so each script falls to its
-# unknown-action branch and exits before any API call, and the EXIT trap reads
-# the answer out of the shell the definitions landed in. A definition placed
-# after the dispatcher is unreachable for the real CLI too.
-
-resolver_source() {
-  (
-    cd "$TMP_ROOT" && LINEAR_API_KEY_OVERRIDE=test-token bash -c '
-      trap "shopt -s extdebug; declare -F resolve_project_id" EXIT
-      source "$1" __kendex_probe__ >/dev/null 2>&1
-    ' probe "$1" 2>/dev/null
-  )
-}
-
-commands_dir="$TMP_ROOT/.agents/skills/linear/scripts/commands"
-for known in initiatives.sh milestones.sh issues.sh projects.sh; do
-  assert "the probe roster holds $known" test -f "$commands_dir/$known"
-done
-
-for script in "$commands_dir"/*.sh; do
-  assert_matches "$(basename "$script") resolves through lib/common.sh" \
-    "$(resolver_source "$script")" \
-    '^resolve_project_id [0-9]+ .*/lib/common\.sh$'
-done
-
 # --- a lone live match returns rather than aborting --------------------------
 #
 # The resolver reads the selection back as two lines, and with nothing rejected

--- a/.agents/skills/linear/tests/project-name-canceled-duplicate.test.sh
+++ b/.agents/skills/linear/tests/project-name-canceled-duplicate.test.sh
@@ -16,12 +16,12 @@ source "$SCRIPT_DIR/lib/assert.sh"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 assert_tmpdir TMP_ROOT
 
-# GIT_DIR outranks -C, so a suite that inherits it — every run from inside a
-# git hook does — re-initializes the ambient repository instead of the fixture,
-# and every later `git rev-parse --show-toplevel` (the CLI's own, for CACHE_DIR)
-# answers with the real checkout. The fixture issue would then be written into
-# the developer's real .cache/linear. Unsetting here covers the whole process,
-# git and CLI alike.
+# GIT_DIR outranks -C, so where it is inherited `git -C "$TMP_ROOT" init` below
+# re-inits the ambient repository and leaves no fixture repo at all. Git sets it
+# for a hook run in a linked worktree; a hook in the main checkout gets
+# GIT_INDEX_FILE instead. Reaching the developer's real cache needs GIT_WORK_TREE
+# or core.worktree inherited as well, so all four go, which is the house rule in
+# .claude/CLAUDE.md. Unsetting at suite scope covers git and the CLI alike.
 unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 mkdir -p "$TMP_ROOT/.agents/skills" "$TMP_ROOT/bin" "$TMP_ROOT/.cache/linear"
@@ -30,13 +30,14 @@ cp -R "$SKILL_DIR" "$TMP_ROOT/.agents/skills/linear"
 # throwaway root so cache writes from `issues create` stay out of the real
 # project's `.cache/linear` (kendex#43).
 git -C "$TMP_ROOT" init -q -b main
-# Proof the isolation held. Without it the line above re-inits the ambient
-# repository and leaves no fixture repo behind, and the run goes on to write
-# into the real cache — so this one stops the suite rather than recording a
-# failure and continuing.
-assert "the fixture repository is the one git init created" \
-  test -d "$TMP_ROOT/.git"
-[[ -d "$TMP_ROOT/.git" ]] || exit 1
+# Proof the isolation held. Without the unset the line above re-inits the
+# ambient repository and leaves no fixture repo behind, and a run that goes on
+# from there is writing somewhere nobody sandboxed, so this stops the suite
+# rather than recording a failure and continuing.
+if [[ ! -d "$TMP_ROOT/.git" ]]; then
+  assert_stop "the fixture repository is the one git init created" \
+    "no repository at $TMP_ROOT/.git: a git environment variable redirected git init"
+fi
 
 cat >"$TMP_ROOT/bin/curl" <<'SH'
 #!/usr/bin/env bash
@@ -176,38 +177,83 @@ assert_contains "a failed lookup is reported as an API failure" \
 assert_not_contains "a failed lookup is not reported as a missing project" \
   "$api_failure_err" "Project not found"
 
-# --- no command ships its own copy of the resolver ---------------------------
+# --- every command resolves through the shared resolver ----------------------
 #
 # initiatives.sh and milestones.sh each carried a private resolve_project_id
 # that shadowed the shared one after sourcing it, so the fix above would have
 # reached neither.
 #
-# bash spells one definition three ways, and a guard carrying only the first
-# does not stop the regression it exists to stop: `name() {`, `function name {`
-# (parens optional), and either with the opening brace on the next line. The
-# pattern below takes the definition line whole, so a call — `resolve_project_id
-# "$p"` or `$(resolve_project_id ...)` — never matches.
+# Bash spells one definition several ways, so a source-text match only ever
+# covers the spellings its author thought of. The question goes to bash
+# instead: source each command script, then read back where the function it
+# ended up with was defined. A redefinition in any spelling moves that answer.
+#
+# The probe passes an action no dispatcher knows, so each script falls to its
+# unknown-action branch and exits before any API call, and the EXIT trap reads
+# the answer out of the shell the definitions landed in. A definition placed
+# after the dispatcher is unreachable for the real CLI too.
 
-definition='^[[:space:]]*(function[[:space:]]+resolve_project_id([[:space:]]*\(\))?|resolve_project_id[[:space:]]*\(\))[[:space:]]*\{?[[:space:]]*$'
-shadowed="$(grep -rlE "$definition" "$SKILL_DIR/scripts" | grep -vF '/lib/common.sh' || true)"
-assert_eq "resolve_project_id is defined once, in lib/common.sh" "$shadowed" ""
+resolver_source() {
+  (
+    cd "$TMP_ROOT" && LINEAR_API_KEY_OVERRIDE=test-token bash -c '
+      trap "shopt -s extdebug; declare -F resolve_project_id" EXIT
+      source "$1" __kendex_probe__ >/dev/null 2>&1
+    ' probe "$1" 2>/dev/null
+  )
+}
 
-# The pattern is only worth as much as its coverage, so each spelling is
-# checked against it here rather than assumed.
-for spelling in \
-  'resolve_project_id() {' \
-  '  resolve_project_id ()' \
-  'function resolve_project_id {' \
-  'function resolve_project_id' \
-  'function resolve_project_id() {'; do
-  assert "the definition pattern matches: $spelling" \
-    grep -qE "$definition" <<<"$spelling"
+commands_dir="$TMP_ROOT/.agents/skills/linear/scripts/commands"
+for known in initiatives.sh milestones.sh issues.sh projects.sh; do
+  assert "the probe roster holds $known" test -f "$commands_dir/$known"
 done
 
-for call in \
-  '    project_id=$(resolve_project_id "$project")' \
-  '    if ! project_id=$(resolve_project_id "$project"); then' \
-  '# resolve_project_id names the failure itself'; do
-  assert_not "the definition pattern ignores: $call" \
-    grep -qE "$definition" <<<"$call"
+for script in "$commands_dir"/*.sh; do
+  assert_matches "$(basename "$script") resolves through lib/common.sh" \
+    "$(resolver_source "$script")" \
+    '^resolve_project_id [0-9]+ .*/lib/common\.sh$'
+done
+
+# --- a lone live match returns rather than aborting --------------------------
+#
+# The resolver reads the selection back as two lines, and with nothing rejected
+# the second read hits EOF. Under the file's own errexit that status ended the
+# function before it printed the id. Every call site here spells the call
+# `var=$(resolve_project_id ...)`, which hides it, so the two shapes that do
+# not are exercised directly: a bare call, and a command substitution under
+# `shopt -s inherit_errexit`, which sync.sh sets.
+
+cat >"$TMP_ROOT/direct.sh" <<'SH'
+#!/bin/bash
+set -euo pipefail
+if [ "${1:-}" = inherit ]; then
+  shopt -s inherit_errexit
+fi
+source "$2/.agents/skills/linear/scripts/lib/common.sh"
+graphql_query() {
+  printf '%s' '{"projects":{"nodes":[{"id":"live-uuid","state":"backlog"}]}}'
+}
+if [ "${1:-}" = inherit ]; then
+  resolved="$(resolve_project_id Dup)"
+  printf '%s\n' "$resolved"
+else
+  resolve_project_id Dup
+fi
+echo reached-the-end
+SH
+
+run_direct() {
+  (
+    cd "$TMP_ROOT" && LINEAR_API_KEY_OVERRIDE=test-token \
+      bash "$TMP_ROOT/direct.sh" "$1" "$TMP_ROOT"
+  ) >"$TMP_ROOT/direct-$1.out" 2>&1
+}
+
+for shape in bare inherit; do
+  rc=0
+  run_status rc run_direct "$shape"
+  assert_eq "a lone live match resolves without aborting ($shape)" "$rc" 0
+  direct_out="$(cat "$TMP_ROOT/direct-$shape.out")"
+  assert_contains "the resolved id is printed ($shape)" "$direct_out" "live-uuid"
+  assert_contains "the caller runs on past the resolve ($shape)" \
+    "$direct_out" "reached-the-end"
 done

--- a/changelog.d/fixed/KEN-1022.md
+++ b/changelog.d/fixed/KEN-1022.md
@@ -1,1 +1,1 @@
-- Linear `--project <name>` resolves to the live project when a canceled one shares the name, rather than whichever the API listed first; an all-canceled match is refused, naming its UUIDs.
+- Linear resolves a project name to the live project when a canceled one shares it, in `--project` writes and in `projects get` / `list-dependencies`; a name with no live match is refused.

--- a/changelog.d/fixed/KEN-1022.md
+++ b/changelog.d/fixed/KEN-1022.md
@@ -1,0 +1,1 @@
+- Linear `--project <name>` resolves to the live project when a canceled one shares the name, rather than whichever the API listed first; an all-canceled match is refused, naming its UUIDs.

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -127,7 +127,7 @@ Normalized issue lists, gets, bulk gets, bundles, recursive children, relation r
 
 Available states: Backlog, Todo, In Progress, In Review, Done, Canceled (not "Cancelled"). Verify with `statuses list`.
 
-Where a **name** selects one project — `issues create` / `issues update --project`, `projects get`, `projects list-dependencies`, `milestones --project`, `initiatives add-project` / `remove-project` — a canceled project sharing that name loses to the live one, and a name with no live match is refused, naming each match and its state; pass a UUID to reach a canceled project. Name **filters** never resolve: `issues list --project`, `cache issues list --project` and `documents list --project` match on the name alone, so their results can mix a live project with its canceled twin.
+Where a **name** selects one project — `issues create` / `update` / `bulk-update --project`, `projects get`, `projects list-dependencies`, `milestones --project`, `initiatives add-project` / `remove-project` — a canceled project sharing that name loses to the live one, and a name with no live match is refused, naming each match and its state; pass a UUID to reach a canceled project. Name **filters** never resolve: `issues list --project`, `cache issues list --project` and `documents list --project` match on the name alone, so their results can mix a live project with its canceled twin.
 
 `--labels` REPLACES the whole issue-label set. Fetch current labels, compute the final set, validate it against `cache labels list --format=safe` (which reports `is_group` so parent/group labels can be rejected), then pass the complete set. A name that does not resolve fails the update; `--clear-labels` is the only way to empty the set.
 

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -127,6 +127,8 @@ Normalized issue lists, gets, bulk gets, bundles, recursive children, relation r
 
 Available states: Backlog, Todo, In Progress, In Review, Done, Canceled (not "Cancelled"). Verify with `statuses list`.
 
+A project **name** resolves to the live project when a canceled one shares it: canceled matches lose, and a name matching nothing but canceled projects is refused, naming their UUIDs. Pass a UUID to reach a canceled project.
+
 `--labels` REPLACES the whole issue-label set. Fetch current labels, compute the final set, validate it against `cache labels list --format=safe` (which reports `is_group` so parent/group labels can be rejected), then pass the complete set. A name that does not resolve fails the update; `--clear-labels` is the only way to empty the set.
 
 - `agent:*` labels are mutually exclusive, one per issue; `issues activate` applies them with the "In Progress" transition (semantics: `issues --help`).

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -127,7 +127,7 @@ Normalized issue lists, gets, bulk gets, bundles, recursive children, relation r
 
 Available states: Backlog, Todo, In Progress, In Review, Done, Canceled (not "Cancelled"). Verify with `statuses list`.
 
-A project **name** resolves to the live project when a canceled one shares it: canceled matches lose, and a name matching nothing but canceled projects is refused, naming their UUIDs. Pass a UUID to reach a canceled project.
+Where a **name** selects one project — `issues create` / `issues update --project`, `projects get`, `projects list-dependencies`, `milestones --project`, `initiatives add-project` / `remove-project` — a canceled project sharing that name loses to the live one, and a name with no live match is refused, naming each match and its state; pass a UUID to reach a canceled project. Name **filters** never resolve: `issues list --project`, `cache issues list --project` and `documents list --project` match on the name alone, so their results can mix a live project with its canceled twin.
 
 `--labels` REPLACES the whole issue-label set. Fetch current labels, compute the final set, validate it against `cache labels list --format=safe` (which reports `is_group` so parent/group labels can be rejected), then pass the complete set. A name that does not resolve fails the update; `--clear-labels` is the only way to empty the set.
 

--- a/skills/linear/scripts/commands/initiatives.sh
+++ b/skills/linear/scripts/commands/initiatives.sh
@@ -57,30 +57,6 @@ case "${1:-help}" in help|--help|-h) show_help; exit 0 ;; esac
 
 source "$SCRIPT_DIR/../lib/common.sh"
 
-resolve_project_id() {
-    local project_ref="$1"
-
-    # Check if it's already a UUID
-    if [[ "$project_ref" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
-        echo "$project_ref"
-        return 0
-    fi
-
-    # Look up by name
-    local query='query GetProject($name: String!) { projects(filter: {name: {eq: $name}}) { nodes { id } } }'
-    local result
-    result=$(graphql_query "$query" "{\"name\": \"$project_ref\"}")
-    local project_id
-    project_id=$(echo "$result" | jq -r '.projects.nodes[0].id // empty')
-
-    if [ -z "$project_id" ]; then
-        echo "" >&2
-        return 1
-    fi
-
-    echo "$project_id"
-}
-
 list_initiatives() {
     local status=""
     local first=75
@@ -351,10 +327,10 @@ add_project() {
         return 1
     fi
 
+    # resolve_project_id names the failure itself — not found, only-canceled
+    # matches, or an API failure — so it is not re-reported here.
     local project_id
-    project_id=$(resolve_project_id "$project")
-    if [ -z "$project_id" ]; then
-        echo "{\"error\": \"Project not found: $project\"}" >&2
+    if ! project_id=$(resolve_project_id "$project"); then
         return 1
     fi
 
@@ -396,10 +372,10 @@ remove_project() {
         return 1
     fi
 
+    # resolve_project_id names the failure itself — not found, only-canceled
+    # matches, or an API failure — so it is not re-reported here.
     local project_id
-    project_id=$(resolve_project_id "$project")
-    if [ -z "$project_id" ]; then
-        echo "{\"error\": \"Project not found: $project\"}" >&2
+    if ! project_id=$(resolve_project_id "$project"); then
         return 1
     fi
 

--- a/skills/linear/scripts/commands/milestones.sh
+++ b/skills/linear/scripts/commands/milestones.sh
@@ -45,30 +45,6 @@ case "${1:-help}" in help|--help|-h) show_help; exit 0 ;; esac
 
 source "$SCRIPT_DIR/../lib/common.sh"
 
-resolve_project_id() {
-    local project_ref="$1"
-
-    # Check if it's already a UUID
-    if [[ "$project_ref" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
-        echo "$project_ref"
-        return 0
-    fi
-
-    # Look up by name
-    local query='query GetProject($name: String!) { projects(filter: {name: {eq: $name}}) { nodes { id } } }'
-    local result
-    result=$(graphql_query "$query" "{\"name\": \"$project_ref\"}")
-    local project_id
-    project_id=$(echo "$result" | jq -r '.projects.nodes[0].id // empty')
-
-    if [ -z "$project_id" ]; then
-        echo "" >&2
-        return 1
-    fi
-
-    echo "$project_id"
-}
-
 list_milestones() {
     local project=""
     FORMAT="${DEFAULT_FORMAT}"
@@ -104,10 +80,10 @@ list_milestones() {
         }'
         result=$(graphql_query "$query" "{}")
     else
+        # resolve_project_id names the failure itself — not found, only-canceled
+        # matches, or an API failure — so it is not re-reported here.
         local project_id
-        project_id=$(resolve_project_id "$project")
-        if [ -z "$project_id" ]; then
-            echo "{\"error\": \"Project not found: $project\"}" >&2
+        if ! project_id=$(resolve_project_id "$project"); then
             return 1
         fi
 
@@ -226,10 +202,10 @@ create_milestone() {
         validate_length "description" "$description" $LINEAR_LIMIT_SHORT_DESC || return 1
     fi
 
+    # resolve_project_id names the failure itself — not found, only-canceled
+    # matches, or an API failure — so it is not re-reported here.
     local project_id
-    project_id=$(resolve_project_id "$project")
-    if [ -z "$project_id" ]; then
-        echo "{\"error\": \"Project not found: $project\"}" >&2
+    if ! project_id=$(resolve_project_id "$project"); then
         return 1
     fi
 

--- a/skills/linear/scripts/lib/common.sh
+++ b/skills/linear/scripts/lib/common.sh
@@ -663,11 +663,14 @@ resolve_project_id() {
         (.projects.nodes // []) as $all
         | ($all | map(select((.state // "" | ascii_downcase) != "canceled"))) as $live
         | ($live[0].id // ""),
-          ($all - $live | map(.id + " (" + (.state // "no state") + ")") | join(", "))')
+          ($all - $live | map(.id + " (" + .state + ")") | join(", "))')
     # Command substitution strips the trailing newline, so with nothing
     # rejected — one live project, the everyday case — the second read hits EOF
     # and returns 1. Under this file's errexit that status ends the function
-    # before it can print the id it just resolved.
+    # before it can print the id it just resolved. Every call site in the skill
+    # spells the call var=$(resolve_project_id ...), where bash does not apply
+    # errexit, so the abort shows up only in a bare call or in a command
+    # substitution under shopt -s inherit_errexit, which sync.sh sets.
     { IFS= read -r project_id; IFS= read -r rejected; } <<<"$selection" || true
 
     if [ -n "$project_id" ]; then

--- a/skills/linear/scripts/lib/common.sh
+++ b/skills/linear/scripts/lib/common.sh
@@ -623,6 +623,13 @@ linear_guard_write_action() {
 
 # Resolve project name or UUID to UUID
 # Usage: resolve_project_id "Phase 1" or resolve_project_id "uuid-here"
+#
+# Linear keeps a canceled project under the name a live one reuses, and the
+# name query returns both in no fixed order, so nodes[0] handed writes the
+# canceled one at random and `issues create --project` reported success on an
+# issue nobody could find (KEN-1022). A canceled match loses to every live one;
+# an all-canceled match set is refused, naming its UUIDs so a deliberate read
+# can pass one.
 resolve_project_id() {
     local project_ref="$1"
 
@@ -632,21 +639,40 @@ resolve_project_id() {
         return 0
     fi
 
-    # Look up by name
-    local query='query GetProject($name: String!) { projects(filter: {name: {eq: $name}}) { nodes { id } } }'
+    # `state` is selected, not filtered on: the server-side `state` filter is
+    # broken (see list_projects), and the whole match set is what separates
+    # "no such project" from "only canceled ones".
+    local query='query GetProject($name: String!) { projects(filter: {name: {eq: $name}}) { nodes { id state } } }'
     local variables
     variables=$(jq -nc --arg name "$project_ref" '{name: $name}')
     local result
-    result=$(graphql_query "$query" "$variables")
-    local project_id
-    project_id=$(echo "$result" | jq -r '.projects.nodes[0].id // empty')
-
-    if [ -z "$project_id" ]; then
-        jq -nc --arg message "Project not found: $project_ref" '{error: $message}' >&2
+    # A FAILED query is an API failure (rate limit, outage); "Project not
+    # found" is only true of a lookup that succeeded and matched nothing.
+    if ! result=$(graphql_query "$query" "$variables"); then
+        jq -nc --arg name "$project_ref" \
+            '{error: ("Could not resolve project \"" + $name + "\": Linear API request failed (see previous error)")}' >&2
         return 1
     fi
 
-    echo "$project_id"
+    local project_id
+    project_id=$(echo "$result" | jq -r \
+        '[(.projects.nodes // [])[] | select((.state // "" | ascii_downcase) != "canceled")][0].id // empty')
+
+    if [ -n "$project_id" ]; then
+        echo "$project_id"
+        return 0
+    fi
+
+    local canceled_ids
+    canceled_ids=$(echo "$result" | jq -r '[(.projects.nodes // [])[].id] | join(", ")')
+    if [ -n "$canceled_ids" ]; then
+        jq -nc --arg name "$project_ref" --arg ids "$canceled_ids" \
+            '{error: ("Project not found: " + $name + " (matched only canceled projects: " + $ids + "; pass a project UUID to target one)")}' >&2
+        return 1
+    fi
+
+    jq -nc --arg message "Project not found: $project_ref" '{error: $message}' >&2
+    return 1
 }
 
 # Resolve team name to UUID

--- a/skills/linear/scripts/lib/common.sh
+++ b/skills/linear/scripts/lib/common.sh
@@ -664,7 +664,11 @@ resolve_project_id() {
         | ($all | map(select((.state // "" | ascii_downcase) != "canceled"))) as $live
         | ($live[0].id // ""),
           ($all - $live | map(.id + " (" + (.state // "no state") + ")") | join(", "))')
-    { IFS= read -r project_id; IFS= read -r rejected; } <<<"$selection"
+    # Command substitution strips the trailing newline, so with nothing
+    # rejected — one live project, the everyday case — the second read hits EOF
+    # and returns 1. Under this file's errexit that status ends the function
+    # before it can print the id it just resolved.
+    { IFS= read -r project_id; IFS= read -r rejected; } <<<"$selection" || true
 
     if [ -n "$project_id" ]; then
         echo "$project_id"

--- a/skills/linear/scripts/lib/common.sh
+++ b/skills/linear/scripts/lib/common.sh
@@ -654,20 +654,26 @@ resolve_project_id() {
         return 1
     fi
 
-    local project_id
-    project_id=$(echo "$result" | jq -r \
-        '[(.projects.nodes // [])[] | select((.state // "" | ascii_downcase) != "canceled")][0].id // empty')
+    # One pass, so the rejected list is the selection's complement rather than
+    # a second predicate that can drift from it: line 1 is the chosen id, line 2
+    # the rejected ones with the state that rejected each. A widened predicate
+    # keeps the message true without being edited.
+    local selection project_id rejected
+    selection=$(echo "$result" | jq -r '
+        (.projects.nodes // []) as $all
+        | ($all | map(select((.state // "" | ascii_downcase) != "canceled"))) as $live
+        | ($live[0].id // ""),
+          ($all - $live | map(.id + " (" + (.state // "no state") + ")") | join(", "))')
+    { IFS= read -r project_id; IFS= read -r rejected; } <<<"$selection"
 
     if [ -n "$project_id" ]; then
         echo "$project_id"
         return 0
     fi
 
-    local canceled_ids
-    canceled_ids=$(echo "$result" | jq -r '[(.projects.nodes // [])[].id] | join(", ")')
-    if [ -n "$canceled_ids" ]; then
-        jq -nc --arg name "$project_ref" --arg ids "$canceled_ids" \
-            '{error: ("Project not found: " + $name + " (matched only canceled projects: " + $ids + "; pass a project UUID to target one)")}' >&2
+    if [ -n "$rejected" ]; then
+        jq -nc --arg name "$project_ref" --arg matches "$rejected" \
+            '{error: ("Project not found: " + $name + " (no live project has this name; matches: " + $matches + "; pass a project UUID to target one)")}' >&2
         return 1
     fi
 

--- a/skills/linear/tests/controls/project-name-canceled-duplicate.control.sh
+++ b/skills/linear/tests/controls/project-name-canceled-duplicate.control.sh
@@ -1,7 +1,8 @@
-# Take the first project the name query returns instead of the first live one.
-# A canceled project sharing the name then wins whenever the API lists it
-# first, and the create lands there reporting success.
+# Let every match count as live, so the selection is the first project the name
+# query returned rather than the first live one. A canceled project sharing the
+# name then wins whenever the API lists it first, and the create lands there
+# reporting success.
 control_expect "the issueCreate payload carries the live project id, not the canceled one (canceled-first)"
 control_replace scripts/lib/common.sh 1 \
-    '        '"'"'[(.projects.nodes // [])[] | select((.state // "" | ascii_downcase) != "canceled")][0].id // empty'"'"')' \
-    '        '"'"'(.projects.nodes // [])[0].id // empty'"'"')'
+    '        | ($all | map(select((.state // "" | ascii_downcase) != "canceled"))) as $live' \
+    '        | $all as $live'

--- a/skills/linear/tests/controls/project-name-canceled-duplicate.control.sh
+++ b/skills/linear/tests/controls/project-name-canceled-duplicate.control.sh
@@ -1,0 +1,7 @@
+# Take the first project the name query returns instead of the first live one.
+# A canceled project sharing the name then wins whenever the API lists it
+# first, and the create lands there reporting success.
+control_expect "the issueCreate payload carries the live project id, not the canceled one (canceled-first)"
+control_replace scripts/lib/common.sh 1 \
+    '        '"'"'[(.projects.nodes // [])[] | select((.state // "" | ascii_downcase) != "canceled")][0].id // empty'"'"')' \
+    '        '"'"'(.projects.nodes // [])[0].id // empty'"'"')'

--- a/skills/linear/tests/project-name-canceled-duplicate.test.sh
+++ b/skills/linear/tests/project-name-canceled-duplicate.test.sh
@@ -16,12 +16,27 @@ source "$SCRIPT_DIR/lib/assert.sh"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 assert_tmpdir TMP_ROOT
 
+# GIT_DIR outranks -C, so a suite that inherits it — every run from inside a
+# git hook does — re-initializes the ambient repository instead of the fixture,
+# and every later `git rev-parse --show-toplevel` (the CLI's own, for CACHE_DIR)
+# answers with the real checkout. The fixture issue would then be written into
+# the developer's real .cache/linear. Unsetting here covers the whole process,
+# git and CLI alike.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
 mkdir -p "$TMP_ROOT/.agents/skills" "$TMP_ROOT/bin" "$TMP_ROOT/.cache/linear"
 cp -R "$SKILL_DIR" "$TMP_ROOT/.agents/skills/linear"
 # Isolate CACHE_DIR resolution (git rev-parse --show-toplevel) to this
 # throwaway root so cache writes from `issues create` stay out of the real
 # project's `.cache/linear` (kendex#43).
 git -C "$TMP_ROOT" init -q -b main
+# Proof the isolation held. Without it the line above re-inits the ambient
+# repository and leaves no fixture repo behind, and the run goes on to write
+# into the real cache — so this one stops the suite rather than recording a
+# failure and continuing.
+assert "the fixture repository is the one git init created" \
+  test -d "$TMP_ROOT/.git"
+[[ -d "$TMP_ROOT/.git" ]] || exit 1
 
 cat >"$TMP_ROOT/bin/curl" <<'SH'
 #!/usr/bin/env bash
@@ -127,10 +142,10 @@ assert_ne "issues create fails when every same-name project is canceled" "$rc" 0
 only_canceled_err="$(cat "$TMP_ROOT/only-canceled.err")"
 assert_contains "the refusal names the project asked for" \
   "$only_canceled_err" "Project not found: Dup"
-assert_contains "the refusal says the matches were canceled" \
-  "$only_canceled_err" "matched only canceled projects"
-assert_contains "the refusal names the canceled uuids so a deliberate read can pass one" \
-  "$only_canceled_err" "dead-uuid, dead-two-uuid"
+assert_contains "the refusal says no live project has the name" \
+  "$only_canceled_err" "no live project has this name"
+assert_contains "the refusal names each rejected uuid with the state that rejected it" \
+  "$only_canceled_err" "dead-uuid (canceled), dead-two-uuid (canceled)"
 
 assert_not "no issue is created against a canceled project" \
   grep -qF 'issueCreate' "$TMP_ROOT/only-canceled-payloads.jsonl"
@@ -166,6 +181,33 @@ assert_not_contains "a failed lookup is not reported as a missing project" \
 # initiatives.sh and milestones.sh each carried a private resolve_project_id
 # that shadowed the shared one after sourcing it, so the fix above would have
 # reached neither.
+#
+# bash spells one definition three ways, and a guard carrying only the first
+# does not stop the regression it exists to stop: `name() {`, `function name {`
+# (parens optional), and either with the opening brace on the next line. The
+# pattern below takes the definition line whole, so a call — `resolve_project_id
+# "$p"` or `$(resolve_project_id ...)` — never matches.
 
-shadowed="$(grep -rlF 'resolve_project_id() {' "$SKILL_DIR/scripts" | grep -vF '/lib/common.sh' || true)"
+definition='^[[:space:]]*(function[[:space:]]+resolve_project_id([[:space:]]*\(\))?|resolve_project_id[[:space:]]*\(\))[[:space:]]*\{?[[:space:]]*$'
+shadowed="$(grep -rlE "$definition" "$SKILL_DIR/scripts" | grep -vF '/lib/common.sh' || true)"
 assert_eq "resolve_project_id is defined once, in lib/common.sh" "$shadowed" ""
+
+# The pattern is only worth as much as its coverage, so each spelling is
+# checked against it here rather than assumed.
+for spelling in \
+  'resolve_project_id() {' \
+  '  resolve_project_id ()' \
+  'function resolve_project_id {' \
+  'function resolve_project_id' \
+  'function resolve_project_id() {'; do
+  assert "the definition pattern matches: $spelling" \
+    grep -qE "$definition" <<<"$spelling"
+done
+
+for call in \
+  '    project_id=$(resolve_project_id "$project")' \
+  '    if ! project_id=$(resolve_project_id "$project"); then' \
+  '# resolve_project_id names the failure itself'; do
+  assert_not "the definition pattern ignores: $call" \
+    grep -qE "$definition" <<<"$call"
+done

--- a/skills/linear/tests/project-name-canceled-duplicate.test.sh
+++ b/skills/linear/tests/project-name-canceled-duplicate.test.sh
@@ -6,7 +6,8 @@
 # name query returns both in no fixed order. resolve_project_id took nodes[0],
 # so `issues create --project "<name>"` landed the issue in whichever the API
 # happened to list first — silently, since a create carrying a valid project id
-# succeeds either way.
+# succeeds either way. The fixture lists the canceled twin first, which is the
+# order the old code got wrong.
 
 set -euo pipefail
 
@@ -44,38 +45,14 @@ cat >"$TMP_ROOT/bin/curl" <<'SH'
 config="$(cat)"
 payload="$(sed -n 's/^data = //p' <<<"$config" | jq -r)"
 query="$(jq -r '.query' <<<"$payload")"
-scenario="${LINEAR_PROJECT_TEST_CASE:-canceled-first}"
 printf '%s\n' "$payload" >> "${CURL_PAYLOAD_LOG:?}"
-
-live='{"id":"live-uuid","state":"backlog"}'
-dead='{"id":"dead-uuid","state":"canceled"}'
-other_dead='{"id":"dead-two-uuid","state":"canceled"}'
 
 case "$query" in
 *"teams(filter:"*)
   printf '%s' '{"data":{"teams":{"nodes":[{"id":"team-uuid"}]}}}___HTTP_CODE___200'
   ;;
 *"projects(filter:"*)
-  case "$scenario" in
-  canceled-first)
-    printf '%s' "{\"data\":{\"projects\":{\"nodes\":[$dead,$live]}}}___HTTP_CODE___200"
-    ;;
-  live-first)
-    printf '%s' "{\"data\":{\"projects\":{\"nodes\":[$live,$dead]}}}___HTTP_CODE___200"
-    ;;
-  only-canceled)
-    printf '%s' "{\"data\":{\"projects\":{\"nodes\":[$dead,$other_dead]}}}___HTTP_CODE___200"
-    ;;
-  no-match)
-    printf '%s' '{"data":{"projects":{"nodes":[]}}}___HTTP_CODE___200'
-    ;;
-  api-failure)
-    printf '%s' '{"errors":[{"message":"unauthenticated"}]}___HTTP_CODE___401'
-    ;;
-  *)
-    printf '%s' '{"errors":[{"message":"unknown scenario"}]}___HTTP_CODE___200'
-    ;;
-  esac
+  printf '%s' '{"data":{"projects":{"nodes":[{"id":"dead-uuid","state":"canceled"},{"id":"live-uuid","state":"backlog"}]}}}___HTTP_CODE___200'
   ;;
 *"issueLabels(filter:"*)
   printf '%s' '{"data":{"issueLabels":{"nodes":[{"id":"label-uuid"}]}}}___HTTP_CODE___200'
@@ -90,14 +67,15 @@ esac
 SH
 chmod +x "$TMP_ROOT/bin/curl"
 
+PAYLOAD_LOG="$TMP_ROOT/payloads.jsonl"
+: >"$PAYLOAD_LOG"
+
 run_create() {
-  local scenario="$1"
   (
     cd "$TMP_ROOT" && \
     PATH="$TMP_ROOT/bin:$PATH" \
       LINEAR_API_KEY_OVERRIDE=test-token \
-      CURL_PAYLOAD_LOG="$TMP_ROOT/$scenario-payloads.jsonl" \
-      LINEAR_PROJECT_TEST_CASE="$scenario" \
+      CURL_PAYLOAD_LOG="$PAYLOAD_LOG" \
       bash "$TMP_ROOT/.agents/skills/linear/scripts/linear.sh" issues create \
         --title t \
         --team Claude \
@@ -105,119 +83,15 @@ run_create() {
         --labels agent:rust \
         --priority 3 \
         --description d
-  ) >"$TMP_ROOT/$scenario.out" 2>"$TMP_ROOT/$scenario.err"
+  ) >"$TMP_ROOT/create.out" 2>"$TMP_ROOT/create.err"
 }
 
-# --- a live match wins, whichever order the API lists the duplicates in ------
-
-for scenario in canceled-first live-first; do
-  : >"$TMP_ROOT/$scenario-payloads.jsonl"
-  rc=0
-  run_status rc run_create "$scenario"
-
-  assert_eq "issues create succeeds when a canceled project shares the name ($scenario)" \
-    "$rc" 0
-
-  assert "the issueCreate payload carries the live project id, not the canceled one ($scenario)" \
-    jq -s -e 'any(.[]; (.query | contains("issueCreate")) and .variables.input.projectId == "live-uuid")' \
-    "$TMP_ROOT/$scenario-payloads.jsonl" >/dev/null
-
-  assert_not "no request names the canceled project id ($scenario)" \
-    grep -qF 'dead-uuid' "$TMP_ROOT/$scenario-payloads.jsonl"
-done
-
-# The lookup asks for `state`: without it every match looks live and the
-# selection above cannot be made.
-assert "the project lookup selects state alongside id" \
-  jq -s -e 'any(.[]; (.query | contains("projects(filter:")) and (.query | contains("nodes { id state }")))' \
-  "$TMP_ROOT/canceled-first-payloads.jsonl" >/dev/null
-
-# --- only-canceled matches are refused, not silently used --------------------
-
-: >"$TMP_ROOT/only-canceled-payloads.jsonl"
 rc=0
-run_status rc run_create only-canceled
+run_status rc run_create
 
-assert_ne "issues create fails when every same-name project is canceled" "$rc" 0
+assert_eq "issues create succeeds when a canceled project shares the name (canceled-first)" \
+  "$rc" 0
 
-only_canceled_err="$(cat "$TMP_ROOT/only-canceled.err")"
-assert_contains "the refusal names the project asked for" \
-  "$only_canceled_err" "Project not found: Dup"
-assert_contains "the refusal says no live project has the name" \
-  "$only_canceled_err" "no live project has this name"
-assert_contains "the refusal names each rejected uuid with the state that rejected it" \
-  "$only_canceled_err" "dead-uuid (canceled), dead-two-uuid (canceled)"
-
-assert_not "no issue is created against a canceled project" \
-  grep -qF 'issueCreate' "$TMP_ROOT/only-canceled-payloads.jsonl"
-
-# --- a genuine miss keeps the plain diagnostic -------------------------------
-
-: >"$TMP_ROOT/no-match-payloads.jsonl"
-rc=0
-run_status rc run_create no-match
-
-assert_ne "issues create fails when the name matches nothing" "$rc" 0
-no_match_err="$(cat "$TMP_ROOT/no-match.err")"
-assert_contains "a name that matches nothing reports a plain miss" \
-  "$no_match_err" "Project not found: Dup"
-assert_not_contains "a plain miss does not claim canceled matches" \
-  "$no_match_err" "canceled"
-
-# --- an API failure is not reported as a missing project ---------------------
-
-: >"$TMP_ROOT/api-failure-payloads.jsonl"
-rc=0
-run_status rc run_create api-failure
-
-assert_ne "issues create fails when the project lookup errors" "$rc" 0
-api_failure_err="$(cat "$TMP_ROOT/api-failure.err")"
-assert_contains "a failed lookup is reported as an API failure" \
-  "$api_failure_err" "Linear API request failed"
-assert_not_contains "a failed lookup is not reported as a missing project" \
-  "$api_failure_err" "Project not found"
-
-# --- a lone live match returns rather than aborting --------------------------
-#
-# The resolver reads the selection back as two lines, and with nothing rejected
-# the second read hits EOF. Under the file's own errexit that status ended the
-# function before it printed the id. Every call site here spells the call
-# `var=$(resolve_project_id ...)`, which hides it, so the two shapes that do
-# not are exercised directly: a bare call, and a command substitution under
-# `shopt -s inherit_errexit`, which sync.sh sets.
-
-cat >"$TMP_ROOT/direct.sh" <<'SH'
-#!/bin/bash
-set -euo pipefail
-if [ "${1:-}" = inherit ]; then
-  shopt -s inherit_errexit
-fi
-source "$2/.agents/skills/linear/scripts/lib/common.sh"
-graphql_query() {
-  printf '%s' '{"projects":{"nodes":[{"id":"live-uuid","state":"backlog"}]}}'
-}
-if [ "${1:-}" = inherit ]; then
-  resolved="$(resolve_project_id Dup)"
-  printf '%s\n' "$resolved"
-else
-  resolve_project_id Dup
-fi
-echo reached-the-end
-SH
-
-run_direct() {
-  (
-    cd "$TMP_ROOT" && LINEAR_API_KEY_OVERRIDE=test-token \
-      bash "$TMP_ROOT/direct.sh" "$1" "$TMP_ROOT"
-  ) >"$TMP_ROOT/direct-$1.out" 2>&1
-}
-
-for shape in bare inherit; do
-  rc=0
-  run_status rc run_direct "$shape"
-  assert_eq "a lone live match resolves without aborting ($shape)" "$rc" 0
-  direct_out="$(cat "$TMP_ROOT/direct-$shape.out")"
-  assert_contains "the resolved id is printed ($shape)" "$direct_out" "live-uuid"
-  assert_contains "the caller runs on past the resolve ($shape)" \
-    "$direct_out" "reached-the-end"
-done
+assert "the issueCreate payload carries the live project id, not the canceled one (canceled-first)" \
+  jq -s -e 'any(.[]; (.query | contains("issueCreate")) and .variables.input.projectId == "live-uuid")' \
+  "$PAYLOAD_LOG" >/dev/null

--- a/skills/linear/tests/project-name-canceled-duplicate.test.sh
+++ b/skills/linear/tests/project-name-canceled-duplicate.test.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Regression test: a project name that matches both a canceled and a live
+# project must resolve to the live one (KEN-1022).
+#
+# Linear keeps a canceled project under the name a live one reuses, and the
+# name query returns both in no fixed order. resolve_project_id took nodes[0],
+# so `issues create --project "<name>"` landed the issue in whichever the API
+# happened to list first — silently, since a create carrying a valid project id
+# succeeds either way.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/assert.sh
+source "$SCRIPT_DIR/lib/assert.sh"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+assert_tmpdir TMP_ROOT
+
+mkdir -p "$TMP_ROOT/.agents/skills" "$TMP_ROOT/bin" "$TMP_ROOT/.cache/linear"
+cp -R "$SKILL_DIR" "$TMP_ROOT/.agents/skills/linear"
+# Isolate CACHE_DIR resolution (git rev-parse --show-toplevel) to this
+# throwaway root so cache writes from `issues create` stay out of the real
+# project's `.cache/linear` (kendex#43).
+git -C "$TMP_ROOT" init -q -b main
+
+cat >"$TMP_ROOT/bin/curl" <<'SH'
+#!/usr/bin/env bash
+config="$(cat)"
+payload="$(sed -n 's/^data = //p' <<<"$config" | jq -r)"
+query="$(jq -r '.query' <<<"$payload")"
+scenario="${LINEAR_PROJECT_TEST_CASE:-canceled-first}"
+printf '%s\n' "$payload" >> "${CURL_PAYLOAD_LOG:?}"
+
+live='{"id":"live-uuid","state":"backlog"}'
+dead='{"id":"dead-uuid","state":"canceled"}'
+other_dead='{"id":"dead-two-uuid","state":"canceled"}'
+
+case "$query" in
+*"teams(filter:"*)
+  printf '%s' '{"data":{"teams":{"nodes":[{"id":"team-uuid"}]}}}___HTTP_CODE___200'
+  ;;
+*"projects(filter:"*)
+  case "$scenario" in
+  canceled-first)
+    printf '%s' "{\"data\":{\"projects\":{\"nodes\":[$dead,$live]}}}___HTTP_CODE___200"
+    ;;
+  live-first)
+    printf '%s' "{\"data\":{\"projects\":{\"nodes\":[$live,$dead]}}}___HTTP_CODE___200"
+    ;;
+  only-canceled)
+    printf '%s' "{\"data\":{\"projects\":{\"nodes\":[$dead,$other_dead]}}}___HTTP_CODE___200"
+    ;;
+  no-match)
+    printf '%s' '{"data":{"projects":{"nodes":[]}}}___HTTP_CODE___200'
+    ;;
+  api-failure)
+    printf '%s' '{"errors":[{"message":"unauthenticated"}]}___HTTP_CODE___401'
+    ;;
+  *)
+    printf '%s' '{"errors":[{"message":"unknown scenario"}]}___HTTP_CODE___200'
+    ;;
+  esac
+  ;;
+*"issueLabels(filter:"*)
+  printf '%s' '{"data":{"issueLabels":{"nodes":[{"id":"label-uuid"}]}}}___HTTP_CODE___200'
+  ;;
+*"issueCreate(input:"*)
+  printf '%s' '{"data":{"issueCreate":{"success":true,"issue":{"id":"child-uuid","identifier":"CC-900","title":"t","description":"d","state":{"name":"Todo","type":"unstarted"},"assignee":null,"project":{"id":"live-uuid","name":"Dup"},"projectMilestone":null,"cycle":null,"parent":null,"team":{"name":"Claude"},"labels":{"nodes":[{"name":"agent:rust"}]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/test/issue/CC-900","createdAt":"2026-09-02T00:00:00Z","updatedAt":"2026-09-02T00:00:00Z","archivedAt":null,"trashed":null,"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}}}}___HTTP_CODE___200'
+  ;;
+*)
+  printf '%s' '{"errors":[{"message":"unexpected query"}]}___HTTP_CODE___200'
+  ;;
+esac
+SH
+chmod +x "$TMP_ROOT/bin/curl"
+
+run_create() {
+  local scenario="$1"
+  (
+    cd "$TMP_ROOT" && \
+    PATH="$TMP_ROOT/bin:$PATH" \
+      LINEAR_API_KEY_OVERRIDE=test-token \
+      CURL_PAYLOAD_LOG="$TMP_ROOT/$scenario-payloads.jsonl" \
+      LINEAR_PROJECT_TEST_CASE="$scenario" \
+      bash "$TMP_ROOT/.agents/skills/linear/scripts/linear.sh" issues create \
+        --title t \
+        --team Claude \
+        --project Dup \
+        --labels agent:rust \
+        --priority 3 \
+        --description d
+  ) >"$TMP_ROOT/$scenario.out" 2>"$TMP_ROOT/$scenario.err"
+}
+
+# --- a live match wins, whichever order the API lists the duplicates in ------
+
+for scenario in canceled-first live-first; do
+  : >"$TMP_ROOT/$scenario-payloads.jsonl"
+  rc=0
+  run_status rc run_create "$scenario"
+
+  assert_eq "issues create succeeds when a canceled project shares the name ($scenario)" \
+    "$rc" 0
+
+  assert "the issueCreate payload carries the live project id, not the canceled one ($scenario)" \
+    jq -s -e 'any(.[]; (.query | contains("issueCreate")) and .variables.input.projectId == "live-uuid")' \
+    "$TMP_ROOT/$scenario-payloads.jsonl" >/dev/null
+
+  assert_not "no request names the canceled project id ($scenario)" \
+    grep -qF 'dead-uuid' "$TMP_ROOT/$scenario-payloads.jsonl"
+done
+
+# The lookup asks for `state`: without it every match looks live and the
+# selection above cannot be made.
+assert "the project lookup selects state alongside id" \
+  jq -s -e 'any(.[]; (.query | contains("projects(filter:")) and (.query | contains("nodes { id state }")))' \
+  "$TMP_ROOT/canceled-first-payloads.jsonl" >/dev/null
+
+# --- only-canceled matches are refused, not silently used --------------------
+
+: >"$TMP_ROOT/only-canceled-payloads.jsonl"
+rc=0
+run_status rc run_create only-canceled
+
+assert_ne "issues create fails when every same-name project is canceled" "$rc" 0
+
+only_canceled_err="$(cat "$TMP_ROOT/only-canceled.err")"
+assert_contains "the refusal names the project asked for" \
+  "$only_canceled_err" "Project not found: Dup"
+assert_contains "the refusal says the matches were canceled" \
+  "$only_canceled_err" "matched only canceled projects"
+assert_contains "the refusal names the canceled uuids so a deliberate read can pass one" \
+  "$only_canceled_err" "dead-uuid, dead-two-uuid"
+
+assert_not "no issue is created against a canceled project" \
+  grep -qF 'issueCreate' "$TMP_ROOT/only-canceled-payloads.jsonl"
+
+# --- a genuine miss keeps the plain diagnostic -------------------------------
+
+: >"$TMP_ROOT/no-match-payloads.jsonl"
+rc=0
+run_status rc run_create no-match
+
+assert_ne "issues create fails when the name matches nothing" "$rc" 0
+no_match_err="$(cat "$TMP_ROOT/no-match.err")"
+assert_contains "a name that matches nothing reports a plain miss" \
+  "$no_match_err" "Project not found: Dup"
+assert_not_contains "a plain miss does not claim canceled matches" \
+  "$no_match_err" "canceled"
+
+# --- an API failure is not reported as a missing project ---------------------
+
+: >"$TMP_ROOT/api-failure-payloads.jsonl"
+rc=0
+run_status rc run_create api-failure
+
+assert_ne "issues create fails when the project lookup errors" "$rc" 0
+api_failure_err="$(cat "$TMP_ROOT/api-failure.err")"
+assert_contains "a failed lookup is reported as an API failure" \
+  "$api_failure_err" "Linear API request failed"
+assert_not_contains "a failed lookup is not reported as a missing project" \
+  "$api_failure_err" "Project not found"
+
+# --- no command ships its own copy of the resolver ---------------------------
+#
+# initiatives.sh and milestones.sh each carried a private resolve_project_id
+# that shadowed the shared one after sourcing it, so the fix above would have
+# reached neither.
+
+shadowed="$(grep -rlF 'resolve_project_id() {' "$SKILL_DIR/scripts" | grep -vF '/lib/common.sh' || true)"
+assert_eq "resolve_project_id is defined once, in lib/common.sh" "$shadowed" ""

--- a/skills/linear/tests/project-name-canceled-duplicate.test.sh
+++ b/skills/linear/tests/project-name-canceled-duplicate.test.sh
@@ -177,42 +177,6 @@ assert_contains "a failed lookup is reported as an API failure" \
 assert_not_contains "a failed lookup is not reported as a missing project" \
   "$api_failure_err" "Project not found"
 
-# --- every command resolves through the shared resolver ----------------------
-#
-# initiatives.sh and milestones.sh each carried a private resolve_project_id
-# that shadowed the shared one after sourcing it, so the fix above would have
-# reached neither.
-#
-# Bash spells one definition several ways, so a source-text match only ever
-# covers the spellings its author thought of. The question goes to bash
-# instead: source each command script, then read back where the function it
-# ended up with was defined. A redefinition in any spelling moves that answer.
-#
-# The probe passes an action no dispatcher knows, so each script falls to its
-# unknown-action branch and exits before any API call, and the EXIT trap reads
-# the answer out of the shell the definitions landed in. A definition placed
-# after the dispatcher is unreachable for the real CLI too.
-
-resolver_source() {
-  (
-    cd "$TMP_ROOT" && LINEAR_API_KEY_OVERRIDE=test-token bash -c '
-      trap "shopt -s extdebug; declare -F resolve_project_id" EXIT
-      source "$1" __kendex_probe__ >/dev/null 2>&1
-    ' probe "$1" 2>/dev/null
-  )
-}
-
-commands_dir="$TMP_ROOT/.agents/skills/linear/scripts/commands"
-for known in initiatives.sh milestones.sh issues.sh projects.sh; do
-  assert "the probe roster holds $known" test -f "$commands_dir/$known"
-done
-
-for script in "$commands_dir"/*.sh; do
-  assert_matches "$(basename "$script") resolves through lib/common.sh" \
-    "$(resolver_source "$script")" \
-    '^resolve_project_id [0-9]+ .*/lib/common\.sh$'
-done
-
 # --- a lone live match returns rather than aborting --------------------------
 #
 # The resolver reads the selection back as two lines, and with nothing rejected

--- a/skills/linear/tests/project-name-canceled-duplicate.test.sh
+++ b/skills/linear/tests/project-name-canceled-duplicate.test.sh
@@ -16,12 +16,12 @@ source "$SCRIPT_DIR/lib/assert.sh"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 assert_tmpdir TMP_ROOT
 
-# GIT_DIR outranks -C, so a suite that inherits it — every run from inside a
-# git hook does — re-initializes the ambient repository instead of the fixture,
-# and every later `git rev-parse --show-toplevel` (the CLI's own, for CACHE_DIR)
-# answers with the real checkout. The fixture issue would then be written into
-# the developer's real .cache/linear. Unsetting here covers the whole process,
-# git and CLI alike.
+# GIT_DIR outranks -C, so where it is inherited `git -C "$TMP_ROOT" init` below
+# re-inits the ambient repository and leaves no fixture repo at all. Git sets it
+# for a hook run in a linked worktree; a hook in the main checkout gets
+# GIT_INDEX_FILE instead. Reaching the developer's real cache needs GIT_WORK_TREE
+# or core.worktree inherited as well, so all four go, which is the house rule in
+# .claude/CLAUDE.md. Unsetting at suite scope covers git and the CLI alike.
 unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 mkdir -p "$TMP_ROOT/.agents/skills" "$TMP_ROOT/bin" "$TMP_ROOT/.cache/linear"
@@ -30,13 +30,14 @@ cp -R "$SKILL_DIR" "$TMP_ROOT/.agents/skills/linear"
 # throwaway root so cache writes from `issues create` stay out of the real
 # project's `.cache/linear` (kendex#43).
 git -C "$TMP_ROOT" init -q -b main
-# Proof the isolation held. Without it the line above re-inits the ambient
-# repository and leaves no fixture repo behind, and the run goes on to write
-# into the real cache — so this one stops the suite rather than recording a
-# failure and continuing.
-assert "the fixture repository is the one git init created" \
-  test -d "$TMP_ROOT/.git"
-[[ -d "$TMP_ROOT/.git" ]] || exit 1
+# Proof the isolation held. Without the unset the line above re-inits the
+# ambient repository and leaves no fixture repo behind, and a run that goes on
+# from there is writing somewhere nobody sandboxed, so this stops the suite
+# rather than recording a failure and continuing.
+if [[ ! -d "$TMP_ROOT/.git" ]]; then
+  assert_stop "the fixture repository is the one git init created" \
+    "no repository at $TMP_ROOT/.git: a git environment variable redirected git init"
+fi
 
 cat >"$TMP_ROOT/bin/curl" <<'SH'
 #!/usr/bin/env bash
@@ -176,38 +177,83 @@ assert_contains "a failed lookup is reported as an API failure" \
 assert_not_contains "a failed lookup is not reported as a missing project" \
   "$api_failure_err" "Project not found"
 
-# --- no command ships its own copy of the resolver ---------------------------
+# --- every command resolves through the shared resolver ----------------------
 #
 # initiatives.sh and milestones.sh each carried a private resolve_project_id
 # that shadowed the shared one after sourcing it, so the fix above would have
 # reached neither.
 #
-# bash spells one definition three ways, and a guard carrying only the first
-# does not stop the regression it exists to stop: `name() {`, `function name {`
-# (parens optional), and either with the opening brace on the next line. The
-# pattern below takes the definition line whole, so a call — `resolve_project_id
-# "$p"` or `$(resolve_project_id ...)` — never matches.
+# Bash spells one definition several ways, so a source-text match only ever
+# covers the spellings its author thought of. The question goes to bash
+# instead: source each command script, then read back where the function it
+# ended up with was defined. A redefinition in any spelling moves that answer.
+#
+# The probe passes an action no dispatcher knows, so each script falls to its
+# unknown-action branch and exits before any API call, and the EXIT trap reads
+# the answer out of the shell the definitions landed in. A definition placed
+# after the dispatcher is unreachable for the real CLI too.
 
-definition='^[[:space:]]*(function[[:space:]]+resolve_project_id([[:space:]]*\(\))?|resolve_project_id[[:space:]]*\(\))[[:space:]]*\{?[[:space:]]*$'
-shadowed="$(grep -rlE "$definition" "$SKILL_DIR/scripts" | grep -vF '/lib/common.sh' || true)"
-assert_eq "resolve_project_id is defined once, in lib/common.sh" "$shadowed" ""
+resolver_source() {
+  (
+    cd "$TMP_ROOT" && LINEAR_API_KEY_OVERRIDE=test-token bash -c '
+      trap "shopt -s extdebug; declare -F resolve_project_id" EXIT
+      source "$1" __kendex_probe__ >/dev/null 2>&1
+    ' probe "$1" 2>/dev/null
+  )
+}
 
-# The pattern is only worth as much as its coverage, so each spelling is
-# checked against it here rather than assumed.
-for spelling in \
-  'resolve_project_id() {' \
-  '  resolve_project_id ()' \
-  'function resolve_project_id {' \
-  'function resolve_project_id' \
-  'function resolve_project_id() {'; do
-  assert "the definition pattern matches: $spelling" \
-    grep -qE "$definition" <<<"$spelling"
+commands_dir="$TMP_ROOT/.agents/skills/linear/scripts/commands"
+for known in initiatives.sh milestones.sh issues.sh projects.sh; do
+  assert "the probe roster holds $known" test -f "$commands_dir/$known"
 done
 
-for call in \
-  '    project_id=$(resolve_project_id "$project")' \
-  '    if ! project_id=$(resolve_project_id "$project"); then' \
-  '# resolve_project_id names the failure itself'; do
-  assert_not "the definition pattern ignores: $call" \
-    grep -qE "$definition" <<<"$call"
+for script in "$commands_dir"/*.sh; do
+  assert_matches "$(basename "$script") resolves through lib/common.sh" \
+    "$(resolver_source "$script")" \
+    '^resolve_project_id [0-9]+ .*/lib/common\.sh$'
+done
+
+# --- a lone live match returns rather than aborting --------------------------
+#
+# The resolver reads the selection back as two lines, and with nothing rejected
+# the second read hits EOF. Under the file's own errexit that status ended the
+# function before it printed the id. Every call site here spells the call
+# `var=$(resolve_project_id ...)`, which hides it, so the two shapes that do
+# not are exercised directly: a bare call, and a command substitution under
+# `shopt -s inherit_errexit`, which sync.sh sets.
+
+cat >"$TMP_ROOT/direct.sh" <<'SH'
+#!/bin/bash
+set -euo pipefail
+if [ "${1:-}" = inherit ]; then
+  shopt -s inherit_errexit
+fi
+source "$2/.agents/skills/linear/scripts/lib/common.sh"
+graphql_query() {
+  printf '%s' '{"projects":{"nodes":[{"id":"live-uuid","state":"backlog"}]}}'
+}
+if [ "${1:-}" = inherit ]; then
+  resolved="$(resolve_project_id Dup)"
+  printf '%s\n' "$resolved"
+else
+  resolve_project_id Dup
+fi
+echo reached-the-end
+SH
+
+run_direct() {
+  (
+    cd "$TMP_ROOT" && LINEAR_API_KEY_OVERRIDE=test-token \
+      bash "$TMP_ROOT/direct.sh" "$1" "$TMP_ROOT"
+  ) >"$TMP_ROOT/direct-$1.out" 2>&1
+}
+
+for shape in bare inherit; do
+  rc=0
+  run_status rc run_direct "$shape"
+  assert_eq "a lone live match resolves without aborting ($shape)" "$rc" 0
+  direct_out="$(cat "$TMP_ROOT/direct-$shape.out")"
+  assert_contains "the resolved id is printed ($shape)" "$direct_out" "live-uuid"
+  assert_contains "the caller runs on past the resolve ($shape)" \
+    "$direct_out" "reached-the-end"
 done

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -89,7 +89,7 @@ skills/linear/scripts/commands/session-status.sh	431
 skills/linear/scripts/commands/sync.sh	883
 skills/linear/scripts/lib/attachments.sh	499
 skills/linear/scripts/lib/cache.sh	553
-skills/linear/scripts/lib/common.sh	816
+skills/linear/scripts/lib/common.sh	819
 skills/linear/scripts/lib/formatters.sh	631
 skills/orch/scripts/approval-wait	948
 skills/orch/scripts/ci-wait	669

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -89,7 +89,7 @@ skills/linear/scripts/commands/session-status.sh	431
 skills/linear/scripts/commands/sync.sh	883
 skills/linear/scripts/lib/attachments.sh	499
 skills/linear/scripts/lib/cache.sh	553
-skills/linear/scripts/lib/common.sh	812
+skills/linear/scripts/lib/common.sh	816
 skills/linear/scripts/lib/formatters.sh	631
 skills/orch/scripts/approval-wait	948
 skills/orch/scripts/ci-wait	669

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -89,7 +89,7 @@ skills/linear/scripts/commands/session-status.sh	431
 skills/linear/scripts/commands/sync.sh	883
 skills/linear/scripts/lib/attachments.sh	499
 skills/linear/scripts/lib/cache.sh	553
-skills/linear/scripts/lib/common.sh	806
+skills/linear/scripts/lib/common.sh	812
 skills/linear/scripts/lib/formatters.sh	631
 skills/orch/scripts/approval-wait	948
 skills/orch/scripts/ci-wait	669

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -82,14 +82,14 @@ skills/iced-rs/iced_wgpu/src/text.rs	649
 skills/iced-rs/iced_wgpu/src/triangle.rs	887
 skills/iced-rs/iced_wgpu/src/window/compositor.rs	427
 skills/linear/scripts/commands/cache-query.sh	1210
-skills/linear/scripts/commands/initiatives.sh	494
+skills/linear/scripts/commands/initiatives.sh	470
 skills/linear/scripts/commands/issues.sh	3221
 skills/linear/scripts/commands/projects.sh	1366
 skills/linear/scripts/commands/session-status.sh	431
 skills/linear/scripts/commands/sync.sh	883
 skills/linear/scripts/lib/attachments.sh	499
 skills/linear/scripts/lib/cache.sh	553
-skills/linear/scripts/lib/common.sh	780
+skills/linear/scripts/lib/common.sh	806
 skills/linear/scripts/lib/formatters.sh	631
 skills/orch/scripts/approval-wait	948
 skills/orch/scripts/ci-wait	669


### PR DESCRIPTION
## Summary

- `resolve_project_id` took `nodes[0]` of an unfiltered name query. Linear keeps a canceled project under a name a live one reuses (team KEN has two "Review Gate & CI"), so a name resolved to whichever the API listed first and a create carrying that id reported success on an issue filed where nobody would look for it. A canceled match now loses to every live one; a name matching only canceled projects is refused, naming each rejected UUID and its state so a deliberate read can pass one.
- A failed lookup is now reported as an API failure instead of collapsing into "Project not found".
- `initiatives.sh` and `milestones.sh` each carried a private `resolve_project_id` that shadowed the shared one after sourcing it — so the fix would have reached neither. Both are deleted; they also spliced the project name straight into the request JSON, where the shared resolver parameterises it with `jq --arg`.

Scope note: the three reroutes in the report all passed an explicit `--project <UUID>`, which never reaches this resolver. Per the 2026-09-01 overseer re-scope, their cause is Linear-side label automation that is the owner's to turn off; this is the code half of that ruling and closes the coin flip on the name path.

## Completed Issues

- Closes KEN-1022 - issues create silently loses --project when the label set carries skills/harness

## Test Plan

- New suite `skills/linear/tests/project-name-canceled-duplicate.test.sh` holds one Done-when control plus the must-fail control that reddens it: with a canceled project sharing the live one's name, `issues create` succeeds and the `issueCreate` payload carries the *live* project id.
- Fixture clears `GIT_DIR`, `GIT_COMMON_DIR`, `GIT_WORK_TREE` and `GIT_INDEX_FILE` together per the house rule, and stops the suite unless the fixture repository is the one `git init` created — before any cache write.
- 49 linear suites green, must-fail controls green, `tools/guard` clean.

Per an overseer cut ruling on this PR, the suite was reduced from 223 lines to 97: tests never outgrow the change, and this is a 57-line change in `lib/common.sh`. The refusal, API-failure and errexit assertions were dropped with it.

## Review Notes

Four review rounds ran against this branch. One disposition is worth recording: the suite carried an anti-shadowing guard asserting `resolve_project_id` is defined once. It failed three consecutive rounds — a literal grep too narrow, then a regex anchored at end-of-line that missed every one-line spelling, then a runtime `declare -F` probe that sourced all sixteen `commands/*.sh` and ran `sync.sh` and `session-status.sh` for real, POSTing to `api.linear.app` on every suite run while still missing shadows nested inside command functions. It was cut rather than repaired a fourth time: it is defence in depth this issue's Done-when does not require, the shadow copies it guarded against are deleted by this same change, and the behavioural assertions cover the resolver those commands actually reach.

Pre-existing defects found during review and left for follow-up, none introduced or armed by this diff: name-filtered surfaces (`issues list --project`, `cache issues list --project`, `documents list --project`) have no canceled preference; two *live* projects sharing a name still resolve to an arbitrary `[0]`, and the query is workspace-wide with no team scoping; `resolve_milestone_id` carries the same `nodes[0]` shape plus an unchecked `graphql_query` status; and `cache-query.sh` redefines `cache_get_issue` and `cache_get_project` after sourcing `lib/cache.sh`.

https://claude.ai/code/session_01JZboRHqWPByK4CYokdShXp
