### PR TITLE
fix(KEN-808): an amend is judged against the parent it will have

### DIFF
--- a/.agents/skills/growth-guards/CHECKS.md
+++ b/.agents/skills/growth-guards/CHECKS.md
@@ -340,7 +340,7 @@ uppercase issue keys (`fix(ABC-123): ...`) and issue numbers
 longer header is a body sentence on the line every log shows.
 
 **The changelog a commit owes.** When `GROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS`
-(empty by default) names a glob some staged path matches, the commit must also
+(empty by default) names a glob a path the commit changes matches, it must also
 add or modify a path under `GROWTH_GUARDS_CHANGELOG_PATHS` — the fragment
 scope changelog-entries judges, resolved by the same library — or carry
 `[no-changelog]` in the header. Deleting a fragment is not writing one, so
@@ -361,6 +361,19 @@ source loses its content, the destination gains it — and a chmod is a touch
 and nothing else, because its blob did not move. A letter that says only
 "modified" cannot tell a rewrite from a permission bit, and a changelog
 requirement satisfied by one is a requirement satisfied by nothing.
+
+Both lists are read against the parent the commit will HAVE, which is HEAD for
+an ordinary commit and HEAD's own parent for an amend. `--cached` alone shows
+what was staged ON TOP of the commit an amend replaces, so a fragment already
+inside that commit read as no fragment at all and the lane refused a commit
+that satisfied it — with the escape being the flag that skips the whole hook
+chain. git tells a `commit-msg` hook nothing about an amend, so the lane reads
+it off the argv of the `git commit` process it is a descendant of: only when
+`GIT_INDEX_FILE` says this run is a hook git started, and only from the
+nearest `git` ancestor, which is the command doing the committing. Anything
+unreadable — no `/proc`, the process already gone, no `git` in eight
+generations — is not an amend, so the lane widens only where it can prove the
+parent moved.
 
 `GROWTH_GUARDS_CHANGELOG_RECORD` counts as that entry only under
 `GROWTH_GUARDS_CHANGELOG_COLLATE=1`, the same declaration the record scope

--- a/.agents/skills/growth-guards/CHECKS.md
+++ b/.agents/skills/growth-guards/CHECKS.md
@@ -373,15 +373,15 @@ the nearest `git` ancestor, the command doing the committing.
 
 Some of those bytes are the committer's own, so `--amend` counts as the flag
 only where nothing could have been reaching for a value. A value-taking option
-consumes the NEXT argument and nothing further, so the one token that can
-swallow the flag is the one immediately before it: dash-prefixed and not a
-no-value option means it did, with long names matched by prefix the way git
-matches an abbreviation. That refuses `--mess --amend`, `-am --amend`,
-`--message=--amend` and an option a later git ships — refusals the writer
-clears with `[no-changelog]` or a fragment, never a commit excused by an entry
-it does not carry. Anything else never reached for a value, so `git commit -m
-'msg' --amend` is the amend it is. `--no-amend` takes the flag back under the
-same guard; the bare `--` stops the scan.
+consumes the NEXT argument and nothing further, so that one token decides it,
+read by SHAPE and not by content: dash-prefixed and not a no-value option means
+it swallowed the flag. The refusal covers an attached value and a bundle too,
+whatever the token holds — `--mess --amend`, `--message='a real message'
+--amend`, `-am --amend`, `--status --amend` — and the writer clears it with a
+fragment or `[no-changelog]`. Anything else never reached, so `git commit -m
+'msg' --amend` is the amend it is. `--no-amend` is read whatever stands before
+it, since a missed flag costs a refusal but a missed negation leaves a stale
+`--amend` standing; the bare `--` stops the scan.
 
 Nothing readable is nothing to widen on: a process already gone, no `git` in
 eight generations, or no `/proc` at all, which is every macOS host, where an

--- a/.agents/skills/growth-guards/CHECKS.md
+++ b/.agents/skills/growth-guards/CHECKS.md
@@ -340,9 +340,10 @@ uppercase issue keys (`fix(ABC-123): ...`) and issue numbers
 longer header is a body sentence on the line every log shows.
 
 **The changelog a commit owes.** When `GROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS`
-(empty by default) names a glob a path the commit changes matches, it must also
-add or modify a path under `GROWTH_GUARDS_CHANGELOG_PATHS` — the fragment
-scope changelog-entries judges, resolved by the same library — or carry
+(empty by default) names a glob that a path the commit changes matches, the
+commit must also add or modify a path under `GROWTH_GUARDS_CHANGELOG_PATHS`
+— the fragment scope changelog-entries judges, resolved by the same library
+— or carry
 `[no-changelog]` in the header. Deleting a fragment is not writing one, so
 evidence is a path that comes out of the commit carrying content it did not
 carry at that path before: a blob where there was none, a blob that changed,
@@ -352,7 +353,7 @@ there was none), or the destination of a rename. A mode and a sha together
 are what identify a record; either alone lets a transition through. What that path became is changelog-entries'
 judgement, running beside this one.
 
-The staged list comes from `--raw`, the spelling `todo-ban` and
+The commit's file list comes from `--raw`, the spelling `todo-ban` and
 `byte-ceiling` already use, with rename detection pinned rather than
 inherited. A raw record carries the old and new mode and the old and new blob
 for every path, so what the commit did to a file is read off the record
@@ -368,12 +369,29 @@ what was staged ON TOP of the commit an amend replaces, so a fragment already
 inside that commit read as no fragment at all and the lane refused a commit
 that satisfied it — with the escape being the flag that skips the whole hook
 chain. git tells a `commit-msg` hook nothing about an amend, so the lane reads
-it off the argv of the `git commit` process it is a descendant of: only when
-`GIT_INDEX_FILE` says this run is a hook git started, and only from the
-nearest `git` ancestor, which is the command doing the committing. Anything
-unreadable — no `/proc`, the process already gone, no `git` in eight
-generations — is not an amend, so the lane widens only where it can prove the
-parent moved.
+it off the argv of the `git commit` process it is a descendant of, in
+`/proc/<pid>/cmdline`: only when `GIT_INDEX_FILE` says this run is a hook git
+started, and only from the nearest `git` ancestor, which is the command doing
+the committing. That argv is read the way git's own parser reads it — the
+scan stops at the bare `--`, steps over the argument a value-taking option
+consumes, and takes the kernel's NUL delimiters so an argument carrying
+whitespace or a newline stays one argument — so a message or a pathspec
+spelling `--amend` is a message or a pathspec, never the flag.
+
+Anything unreadable is not an amend: the process already gone, no `git` in
+eight generations, or no `/proc` at all — which is every macOS host, where
+argv is not on the filesystem. There the widening never fires and an amend is
+judged against the HEAD it replaces, exactly as before this rule read the
+parent. So the lane widens only where it can prove the parent moved, and a
+`ps` reading is deliberately not the fallback: `ps` joins argv with spaces, so
+a message merely CONTAINING `--amend` would excuse a commit.
+
+A rebase `reword` or `edit` runs `git commit --amend` as a child of the
+rebase, so it is an amend by this reading and judged against the whole
+historical commit. Rewording a commit that changes a required path and
+predates the rule needs `[no-changelog]` in the reworded header. A plain
+all-`pick` rebase and an autosquash fixup are unaffected: the sequencer
+commits those in-process, with no `git commit` ancestor to read.
 
 `GROWTH_GUARDS_CHANGELOG_RECORD` counts as that entry only under
 `GROWTH_GUARDS_CHANGELOG_COLLATE=1`, the same declaration the record scope

--- a/.agents/skills/growth-guards/CHECKS.md
+++ b/.agents/skills/growth-guards/CHECKS.md
@@ -340,10 +340,9 @@ uppercase issue keys (`fix(ABC-123): ...`) and issue numbers
 longer header is a body sentence on the line every log shows.
 
 **The changelog a commit owes.** When `GROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS`
-(empty by default) names a glob that a path the commit changes matches, the
-commit must also add or modify a path under `GROWTH_GUARDS_CHANGELOG_PATHS`
-— the fragment scope changelog-entries judges, resolved by the same library
-— or carry
+(empty by default) names a glob a path the commit changes matches, the commit
+must also add or modify a path under `GROWTH_GUARDS_CHANGELOG_PATHS` — the
+fragment scope changelog-entries judges, resolved by the same library — or carry
 `[no-changelog]` in the header. Deleting a fragment is not writing one, so
 evidence is a path that comes out of the commit carrying content it did not
 carry at that path before: a blob where there was none, a blob that changed,
@@ -363,35 +362,37 @@ and nothing else, because its blob did not move. A letter that says only
 "modified" cannot tell a rewrite from a permission bit, and a changelog
 requirement satisfied by one is a requirement satisfied by nothing.
 
-Both lists are read against the parent the commit will HAVE, which is HEAD for
-an ordinary commit and HEAD's own parent for an amend. `--cached` alone shows
-what was staged ON TOP of the commit an amend replaces, so a fragment already
-inside that commit read as no fragment at all and the lane refused a commit
-that satisfied it — with the escape being the flag that skips the whole hook
-chain. git tells a `commit-msg` hook nothing about an amend, so the lane reads
-it off the argv of the `git commit` process it is a descendant of, in
-`/proc/<pid>/cmdline`: only when `GIT_INDEX_FILE` says this run is a hook git
-started, and only from the nearest `git` ancestor, which is the command doing
-the committing. That argv is read the way git's own parser reads it — the
-scan stops at the bare `--`, steps over the argument a value-taking option
-consumes, and takes the kernel's NUL delimiters so an argument carrying
-whitespace or a newline stays one argument — so a message or a pathspec
-spelling `--amend` is a message or a pathspec, never the flag.
+Both lists are read against the parent the commit will HAVE, HEAD ordinarily
+and HEAD's own parent for an amend. `--cached` alone shows only what was staged
+ON TOP of the commit an amend replaces, so a fragment already inside that
+commit read as no fragment at all and the lane refused a commit that satisfied
+it. git tells a `commit-msg` hook nothing about an amend, so the lane reads it
+off the argv of the `git commit` it descends from, in `/proc/<pid>/cmdline`,
+only when `GIT_INDEX_FILE` says this run is a hook git started and only from
+the nearest `git` ancestor, the command doing the committing.
 
-Anything unreadable is not an amend: the process already gone, no `git` in
-eight generations, or no `/proc` at all — which is every macOS host, where
-argv is not on the filesystem. There the widening never fires and an amend is
-judged against the HEAD it replaces, exactly as before this rule read the
-parent. So the lane widens only where it can prove the parent moved, and a
-`ps` reading is deliberately not the fallback: `ps` joins argv with spaces, so
-a message merely CONTAINING `--amend` would excuse a commit.
+Some of those bytes are the committer's own, so `--amend` counts as the flag
+only where nothing ahead of it could have been reaching for a value: after the
+`commit` subcommand, every token between the two a no-value option, matched by
+prefix the way git matches an abbreviation. `--no-amend` behind the flag takes
+it back and the bare `--` stops the scan, both as git reads them. Everything
+else is not an amend — `-m --amend`, `--mess --amend`, `--message=--amend`,
+`-am`, a pathspec, an option a later git adds — a refusal the writer clears
+with `[no-changelog]` or a fragment, never a commit excused by an entry it does
+not carry. It costs `git commit -m … --amend`, the flag behind the message,
+read as an ordinary commit; put the flag ahead of `-m`.
 
-A rebase `reword` or `edit` runs `git commit --amend` as a child of the
-rebase, so it is an amend by this reading and judged against the whole
-historical commit. Rewording a commit that changes a required path and
-predates the rule needs `[no-changelog]` in the reworded header. A plain
-all-`pick` rebase and an autosquash fixup are unaffected: the sequencer
-commits those in-process, with no `git commit` ancestor to read.
+Nothing readable is nothing to widen on: a process already gone, no `git` in
+eight generations, or no `/proc` at all, which is every macOS host, where an
+amend is judged against the HEAD it replaces as before. `ps` is deliberately
+not the fallback, because it joins argv with spaces and a message merely
+CONTAINING `--amend` would excuse a commit. A rebase `reword` runs `git commit
+--amend --no-gpg-sign -e --allow-empty` as a child of the rebase and an `edit`
+stop spawns no commit at all, the committer amending at the stop; both are
+amends by this reading, so amending a commit that changes a required path and
+predates the rule needs `[no-changelog]`. A plain all-`pick` rebase and an
+autosquash fixup are unaffected: the sequencer commits those in-process, with
+no `git commit` ancestor to read.
 
 `GROWTH_GUARDS_CHANGELOG_RECORD` counts as that entry only under
 `GROWTH_GUARDS_CHANGELOG_COLLATE=1`, the same declaration the record scope

--- a/.agents/skills/growth-guards/CHECKS.md
+++ b/.agents/skills/growth-guards/CHECKS.md
@@ -372,15 +372,16 @@ only when `GIT_INDEX_FILE` says this run is a hook git started and only from
 the nearest `git` ancestor, the command doing the committing.
 
 Some of those bytes are the committer's own, so `--amend` counts as the flag
-only where nothing ahead of it could have been reaching for a value: after the
-`commit` subcommand, every token between the two a no-value option, matched by
-prefix the way git matches an abbreviation. `--no-amend` behind the flag takes
-it back and the bare `--` stops the scan, both as git reads them. Everything
-else is not an amend — `-m --amend`, `--mess --amend`, `--message=--amend`,
-`-am`, a pathspec, an option a later git adds — a refusal the writer clears
-with `[no-changelog]` or a fragment, never a commit excused by an entry it does
-not carry. It costs `git commit -m … --amend`, the flag behind the message,
-read as an ordinary commit; put the flag ahead of `-m`.
+only where nothing could have been reaching for a value. A value-taking option
+consumes the NEXT argument and nothing further, so the one token that can
+swallow the flag is the one immediately before it: dash-prefixed and not a
+no-value option means it did, with long names matched by prefix the way git
+matches an abbreviation. That refuses `--mess --amend`, `-am --amend`,
+`--message=--amend` and an option a later git ships — refusals the writer
+clears with `[no-changelog]` or a fragment, never a commit excused by an entry
+it does not carry. Anything else never reached for a value, so `git commit -m
+'msg' --amend` is the amend it is. `--no-amend` takes the flag back under the
+same guard; the bare `--` stops the scan.
 
 Nothing readable is nothing to widen on: a process already gone, no `git` in
 eight generations, or no `/proc` at all, which is every macOS host, where an

--- a/.agents/skills/growth-guards/DEVELOPMENT.md
+++ b/.agents/skills/growth-guards/DEVELOPMENT.md
@@ -21,10 +21,12 @@ docs live in README.md.
   a commit header and a changelog ARE to this family: the two changelog
   scopes both lanes resolve from, and the grammars each is judged by, kept
   apart from the scans that run them
-- `scripts/lib/commit-parent.sh` — which parent a commit will HAVE, for the
-  lanes that judge a commit rather than an index: HEAD ordinarily, HEAD's own
-  parent for an amend, read off the argv of the `git commit` this hook
-  descends from because git tells a `commit-msg` hook nothing about one
+- `scripts/lib/commit-parent.sh` — which parent a commit will HAVE, for
+  `commit-msg`, the one lane that judges a commit rather than an index: HEAD
+  ordinarily, HEAD's own parent for an amend, read off the argv of the `git
+  commit` this hook descends from — in `/proc/<pid>/cmdline`, because git
+  tells a `commit-msg` hook nothing about one — so a host without `/proc`,
+  macOS above all, keeps the older judgement of HEAD
 - `scripts/lib/changelog-record-scope.sh` — the record half of the
   `changelog-entries` judge: one tracked file against HEAD's copy, kept apart
   from the fragment-tree walk it shares nothing with but a verdict

--- a/.agents/skills/growth-guards/DEVELOPMENT.md
+++ b/.agents/skills/growth-guards/DEVELOPMENT.md
@@ -24,9 +24,8 @@ docs live in README.md.
 - `scripts/lib/commit-parent.sh` — which parent a commit will HAVE, for
   `commit-msg`, the one lane that judges a commit rather than an index: HEAD
   ordinarily, HEAD's own parent for an amend, read off the argv of the `git
-  commit` this hook descends from — in `/proc/<pid>/cmdline`, because git
-  tells a `commit-msg` hook nothing about one — so a host without `/proc`,
-  macOS above all, keeps the older judgement of HEAD
+  commit` this hook descends from in `/proc/<pid>/cmdline`, so a host without
+  it — macOS above all — keeps the older judgement of HEAD
 - `scripts/lib/changelog-record-scope.sh` — the record half of the
   `changelog-entries` judge: one tracked file against HEAD's copy, kept apart
   from the fragment-tree walk it shares nothing with but a verdict

--- a/.agents/skills/growth-guards/DEVELOPMENT.md
+++ b/.agents/skills/growth-guards/DEVELOPMENT.md
@@ -21,6 +21,10 @@ docs live in README.md.
   a commit header and a changelog ARE to this family: the two changelog
   scopes both lanes resolve from, and the grammars each is judged by, kept
   apart from the scans that run them
+- `scripts/lib/commit-parent.sh` — which parent a commit will HAVE, for the
+  lanes that judge a commit rather than an index: HEAD ordinarily, HEAD's own
+  parent for an amend, read off the argv of the `git commit` this hook
+  descends from because git tells a `commit-msg` hook nothing about one
 - `scripts/lib/changelog-record-scope.sh` — the record half of the
   `changelog-entries` judge: one tracked file against HEAD's copy, kept apart
   from the fragment-tree walk it shares nothing with but a verdict

--- a/.agents/skills/growth-guards/scripts/commit-msg
+++ b/.agents/skills/growth-guards/scripts/commit-msg
@@ -226,7 +226,7 @@ if [ -n "$REQUIRED" ]; then
   git -c diff.renames=true diff --cached --raw --no-abbrev -z --find-renames=100% \
     $GG_COMMIT_BASE \
     >"$GG_TMP/raw.z" \
-    || gg_collection_error "could not read the staged file list — the changelog rule could not run"
+    || gg_collection_error "could not read the commit's file list — the changelog rule could not run"
 
   # What "written" MEANS, over the record's full identity: a mode and a sha
   # together, never a sha alone. Equal shas are TWO states, and only the modes
@@ -273,14 +273,14 @@ if [ -n "$REQUIRED" ]; then
   : >"$GG_TMP/written.z"
   while IFS= read -r -d '' meta; do
     IFS= read -r -d '' src \
-      || gg_collection_error "the staged file list ended mid-record after $(gg_shown "$meta") — the changelog rule could not run"
+      || gg_collection_error "the commit's file list ended mid-record after $(gg_shown "$meta") — the changelog rule could not run"
     # Record shape: ":srcmode dstmode srcsha dstsha status". Splitting is safe
     # under the `set -f` at the top of this file — the fields are modes, hex
     # and a letter, and none of them is a path.
     # shellcheck disable=SC2086
     set -- $meta
     [ "$#" -eq 5 ] \
-      || gg_collection_error "the staged file list carried a record of $# field(s), not five: $(gg_shown "$meta") — the changelog rule could not run"
+      || gg_collection_error "the commit's file list carried a record of $# field(s), not five: $(gg_shown "$meta") — the changelog rule could not run"
     srcmode="${1#:}"
     dstmode="$2"
     srcsha="$3"
@@ -292,7 +292,7 @@ if [ -n "$REQUIRED" ]; then
         ;;
       R*)
         IFS= read -r -d '' dest \
-          || gg_collection_error "the staged file list ended before the destination of a $(gg_shown "$status") record — the changelog rule could not run"
+          || gg_collection_error "the commit's file list ended before the destination of a $(gg_shown "$status") record — the changelog rule could not run"
         printf '%s\0' "$src" "$dest" >>"$GG_TMP/staged.z"
         printf '%s\0' "$dest" >>"$GG_TMP/written.z"
         continue

--- a/.agents/skills/growth-guards/scripts/commit-msg
+++ b/.agents/skills/growth-guards/scripts/commit-msg
@@ -38,6 +38,8 @@ source "$SCRIPT_DIR/lib/settings.sh"
 source "$SCRIPT_DIR/lib/commit-header.sh"
 # shellcheck source=lib/changelog-grammar.sh
 source "$SCRIPT_DIR/lib/changelog-grammar.sh"
+# shellcheck source=lib/commit-parent.sh
+source "$SCRIPT_DIR/lib/commit-parent.sh"
 
 usage() {
   cat <<'EOF'
@@ -62,8 +64,11 @@ kendex.settings.toml [env] > default):
   GROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS
                                space-separated globs against the full
                                repo-relative path ('*' crosses '/'); a commit
-                               that stages a matching path must also write a
-                               changelog entry (default empty = rule off)
+                               that changes a matching path must also write a
+                               changelog entry (default empty = rule off).
+                               Both sets are read from the commit as a whole,
+                               so an amend is judged against the parent it
+                               will have, not against the HEAD it replaces
   GROWTH_GUARDS_CHANGELOG_PATHS   what counts as a written entry, with
   GROWTH_GUARDS_CHANGELOG_RECORD  — the same two scopes the changelog-entries
                                check judges (defaults "changelog.d/*/*.md"
@@ -207,8 +212,19 @@ if [ -n "$REQUIRED" ]; then
   # reaches the globs as the bytes git recorded: a quoted name matches no
   # glob, which is a rule that stops seeing the files it is about. Read back
   # from a FILE rather than a pipe, so the loops set variables in this shell.
+  #
+  # The base is the parent the commit will HAVE, which is HEAD for an ordinary
+  # commit and HEAD's own parent for an amend: an amend replaces HEAD rather
+  # than following it, so `--cached` alone shows only what was staged on top
+  # of a fragment the commit already carries, and refuses a commit that
+  # satisfies the rule. GG_COMMIT_BASE is empty in the ordinary case, where
+  # `--cached` already means HEAD, and unquoted for exactly that reason — it
+  # is one revision or no argument at all, never a path and never a glob.
   gg_tmpdir
+  gg_commit_base
+  # shellcheck disable=SC2086
   git -c diff.renames=true diff --cached --raw --no-abbrev -z --find-renames=100% \
+    $GG_COMMIT_BASE \
     >"$GG_TMP/raw.z" \
     || gg_collection_error "could not read the staged file list — the changelog rule could not run"
 

--- a/.agents/skills/growth-guards/scripts/commit-msg
+++ b/.agents/skills/growth-guards/scripts/commit-msg
@@ -67,8 +67,8 @@ kendex.settings.toml [env] > default):
                                that changes a matching path must also write a
                                changelog entry (default empty = rule off).
                                Both sets are read from the commit as a whole,
-                               so an amend is judged against the parent it
-                               will have, not the HEAD it replaces
+                               so where /proc is readable (not macOS) an amend
+                               is judged against the parent it will have
   GROWTH_GUARDS_CHANGELOG_PATHS   what counts as a written entry, with
   GROWTH_GUARDS_CHANGELOG_RECORD  — the same two scopes the changelog-entries
                                check judges (defaults "changelog.d/*/*.md"

--- a/.agents/skills/growth-guards/scripts/commit-msg
+++ b/.agents/skills/growth-guards/scripts/commit-msg
@@ -68,7 +68,7 @@ kendex.settings.toml [env] > default):
                                changelog entry (default empty = rule off).
                                Both sets are read from the commit as a whole,
                                so an amend is judged against the parent it
-                               will have, not against the HEAD it replaces
+                               will have, not the HEAD it replaces
   GROWTH_GUARDS_CHANGELOG_PATHS   what counts as a written entry, with
   GROWTH_GUARDS_CHANGELOG_RECORD  — the same two scopes the changelog-entries
                                check judges (defaults "changelog.d/*/*.md"
@@ -213,13 +213,12 @@ if [ -n "$REQUIRED" ]; then
   # glob, which is a rule that stops seeing the files it is about. Read back
   # from a FILE rather than a pipe, so the loops set variables in this shell.
   #
-  # The base is the parent the commit will HAVE, which is HEAD for an ordinary
-  # commit and HEAD's own parent for an amend: an amend replaces HEAD rather
-  # than following it, so `--cached` alone shows only what was staged on top
-  # of a fragment the commit already carries, and refuses a commit that
-  # satisfies the rule. GG_COMMIT_BASE is empty in the ordinary case, where
-  # `--cached` already means HEAD, and unquoted for exactly that reason — it
-  # is one revision or no argument at all, never a path and never a glob.
+  # The base is the parent the commit will HAVE: HEAD ordinarily, HEAD's own
+  # parent for an amend, which replaces HEAD rather than following it, so
+  # `--cached` alone would show only what was staged on top of a fragment the
+  # commit already carries. GG_COMMIT_BASE is empty in the ordinary case,
+  # where `--cached` already means HEAD, and unquoted for exactly that reason:
+  # one revision or no argument at all, never a path and never a glob.
   gg_tmpdir
   gg_commit_base
   # shellcheck disable=SC2086

--- a/.agents/skills/growth-guards/scripts/lib/commit-parent.sh
+++ b/.agents/skills/growth-guards/scripts/lib/commit-parent.sh
@@ -1,41 +1,28 @@
 # shellcheck shell=bash
 # Which parent a commit will HAVE, for the lane that judges a commit rather
 # than an index — `commit-msg`, its one caller: HEAD for an ordinary commit,
-# and HEAD's own parent for an amend, which replaces HEAD rather than
-# following it. Kept apart from the rules that read it, and sourced, never
-# executed.
-#
-# Needs lib/common.sh sourced first, and runs with the caller cd'd to the
-# repository root.
+# and HEAD's own parent for an amend, which replaces HEAD rather than following
+# it. Sourced, never executed; needs lib/common.sh sourced first and the caller
+# cd'd to the repository root.
 set -euo pipefail
 
-# git tells a commit-msg hook the message and nothing else. It passes no flag,
-# exports no variable and leaves no file behind that says HEAD is about to be
-# REPLACED rather than followed — prepare-commit-msg is the one hook git tells,
-# and this family installs none. So the answer lives in a single place, the
-# argv of the `git commit` this hook is a descendant of, and it is read there
-# under two conditions, because the wrong answer is the dangerous one: a
-# commit judged against a parent it does not have is excused by an entry
-# belonging to a commit it is not amending.
-#
-#   GIT_INDEX_FILE   git sets it for the hooks it runs a commit through, so
-#                    its absence means a DIRECT run — a person, a test, a
-#                    script — whose ancestors say nothing about what it judges
-#   the NEAREST git  git runs a hook as a descendant of the `git commit` doing
-#   ancestor         the committing, so the first git process above this one
-#                    IS that command. The walk stops at it and never reads a
-#                    git further up: a `git rebase` driving the commit would
-#                    be answering for something else
-#
-# Anything unreadable — a process already gone, eight generations carrying no
-# git — is not an amend, which is the judgement this lane made before: HEAD,
-# and a refusal the writer clears by staging the fragment. That covers a whole
-# platform: argv lives in `/proc/<pid>/cmdline`, which macOS does not have, so
-# the widening is Linux-only and an amend there is judged against the HEAD it
-# replaces exactly as it was before. A `ps` reading would reach further and is
-# deliberately not taken: `ps` joins argv with spaces, so a message merely
-# CONTAINING `--amend` would excuse a commit — a fail-open this reading does
-# not have. The lane widens only where it can prove the parent moved.
+# git tells a commit-msg hook the message and nothing else: no flag, no
+# variable, no file saying HEAD is about to be REPLACED rather than followed.
+# So the answer lives in one place, the argv of the `git commit` this hook
+# descends from, read under two conditions, because the wrong answer is the
+# dangerous one — a commit judged against a parent it does not have is excused
+# by an entry belonging to a commit it is not amending. GIT_INDEX_FILE must be
+# set, since git sets it for the hooks it runs a commit through and its absence
+# means a DIRECT run — a person, a test, a script — whose ancestors say nothing
+# about what it judges. And the argv must come from the NEAREST git ancestor,
+# the command doing the committing; the walk stops there rather than reading a
+# `git rebase` further up, answering for something else. Anything unreadable is
+# not an amend — a process already gone, eight generations carrying no git, or
+# no `/proc` at all, which is every macOS host — which is the judgement this
+# lane made before: HEAD, and a refusal the writer clears by staging the
+# fragment. `ps` would reach macOS and is deliberately not the fallback,
+# because it joins argv with spaces and a message merely CONTAINING `--amend`
+# would excuse a commit.
 gg_parent_pid() { # PID — its parent's pid on stdout, empty when unreadable
   local ppid=""
   [ -r "/proc/$1/status" ] || return 0
@@ -43,8 +30,68 @@ gg_parent_pid() { # PID — its parent's pid on stdout, empty when unreadable
   printf '%s' "$ppid"
 }
 
+gg_opt_abbrev() { # ARG NAME — 0 when ARG is `--x…` and NAME begins with it
+  # git's parser takes any unambiguous abbreviation, so a scan matching full
+  # spellings by equality reads `--mess` as a token it has never heard of. ARG
+  # is quoted into the pattern: it matches as bytes, never as a glob.
+  case "$1" in --?*) ;; *) return 1 ;; esac
+  case "$2" in "$1"*) return 0 ;; esac
+  return 1
+}
+
+gg_no_value_opt() { # ARG — 0 when ARG is a `git commit` option taking NO value
+  # The whole vocabulary the scan below understands. Every option that takes a
+  # value is absent by construction, in every spelling, and absence means "not
+  # an amend" — so an omission costs a refusal the writer clears, never a commit
+  # excused by an entry it does not carry. A name added here that git DOES take
+  # a value for would fail open: the one thing an edit to this list is read for.
+  local name
+  case "$1" in
+    -[aeinopqsuvzS]) return 0 ;;
+  esac
+  for name in --all --patch --interactive --include --only --signoff --dry-run \
+    --no-signoff --verify --edit --no-edit --no-post-rewrite --quiet \
+    --allow-empty --allow-empty-message --gpg-sign --no-gpg-sign --verbose \
+    --reset-author --untracked-files --pathspec-file-nul; do
+    if gg_opt_abbrev "$1" "$name"; then return 0; fi
+  done
+  return 1
+}
+
+gg_argv_is_amend() { # FILE — 0 when the NUL-delimited argv in FILE is an amend
+  # Read NUL-delimited, the bytes the kernel holds: what keeps an argument
+  # carrying whitespace or a newline ONE argument rather than several. The
+  # committer chooses some of those bytes, and a value that happens to spell
+  # the flag is not the flag. Rather than name the options whose values to step
+  # over — a list git grows, and one whose every gap is a commit excused
+  # wrongly — `--amend` counts as the flag only where nothing ahead of it could
+  # have been reaching for a value: after the `commit` subcommand, every token
+  # between the two a no-value option. The first token that is anything else
+  # ends the scan at "not an amend", so `-m --amend` is a message, `--templ
+  # --amend` a template path, and `--message=…`, `-am` and an option git has
+  # not shipped yet are all refusals. The bare `--` stops the scan where git
+  # stops; `--no-amend` behind the flag takes it back, git's last-spelling
+  # boolean. The wrapper's arguments, ahead of `commit`, are skipped rather than
+  # judged: the flag cannot be among them, so `git -c user.name=x commit
+  # --amend` reads as the amend it is without `-c` being understood.
+  local arg seen=0 sub=0 amend=1
+  while IFS= read -r -d '' arg; do
+    if [ "$seen" -eq 0 ]; then seen=1; continue; fi
+    if [ "$sub" -eq 0 ]; then
+      case "$arg" in commit) sub=1 ;; esac
+      continue
+    fi
+    case "$arg" in --) break ;; esac
+    if gg_opt_abbrev "$arg" --no-amend; then amend=1; continue; fi
+    if gg_opt_abbrev "$arg" --amend; then amend=0; continue; fi
+    if [ "$amend" -eq 0 ]; then continue; fi
+    if ! gg_no_value_opt "$arg"; then break; fi
+  done <"$1"
+  return "$amend"
+}
+
 gg_is_amend() { # 0 when this run belongs to a `git commit --amend`
-  local pid depth arg rest argv0 seen skip amend
+  local pid depth argv0
   [ -n "${GIT_INDEX_FILE:-}" ] || return 1
   pid="${PPID:-}"
   depth=0
@@ -52,60 +99,15 @@ gg_is_amend() { # 0 when this run belongs to a `git commit --amend`
     depth=$((depth + 1))
     [ -r "/proc/$pid/cmdline" ] || return 1
     argv0=""
-    seen=0
-    skip=0
-    amend=1
-    # NUL-delimited, the bytes the kernel holds: what keeps an argument
-    # carrying whitespace or a newline ONE argument rather than the several a
-    # space-joined command line would split it into.
-    #
-    # The scan reads argv the way git's own option parser does, because the
-    # committer chooses some of these bytes and a value that happens to spell
-    # the flag is not the flag: it stops at the bare `--` where git stops, and
-    # steps over the argument a value-taking option consumes — `-m --amend` is
-    # a message, `--amend` after `--` is a pathspec. Attached forms
-    # (`--author=…`, `-m…`) consume nothing further. The spellings below are
-    # git's full ones; an abbreviation git would still accept (`--mess`) is
-    # not among them, which leaves the flag unseen and the lane refusing —
-    # the judgement it made before this widening, never a commit excused by
-    # an entry it does not carry.
-    while IFS= read -r -d '' arg; do
-      if [ "$seen" -eq 0 ]; then
-        argv0="$arg"
-        seen=1
-        continue
-      fi
-      if [ "$skip" -eq 1 ]; then
-        skip=0
-        continue
-      fi
-      case "$arg" in
-        --) break ;;
-        --amend) amend=0 ;;
-        -m | -F | -t | -c | -C | --message | --file | --template | --reuse-message | --reedit-message | --fixup | --squash | --author | --date | --cleanup | --trailer | --pathspec-from-file) skip=1 ;;
-        -[!-]*)
-          # A short bundle, walked letter by letter the way git walks it: the
-          # first letter taking a value swallows the rest of the token as that
-          # value, or the next argument when the token ends there, so `-am`
-          # makes `--amend` behind it a message. `S` and `u` take an OPTIONAL
-          # value, which git reads only when it is attached — they never reach
-          # for the next argument.
-          rest="${arg#-}"
-          while [ -n "$rest" ]; do
-            case "$rest" in
-              [mFtcC]) skip=1; rest="" ;;
-              [mFtcCSu]*) rest="" ;;
-              *) rest="${rest#?}" ;;
-            esac
-          done
-          ;;
-      esac
-    done <"/proc/$pid/cmdline"
+    IFS= read -r -d '' argv0 <"/proc/$pid/cmdline" || true
     # Both separators: a Windows git under MSYS carries a backslash path in
     # its own argv, and a name still holding one is not `git`.
     argv0="${argv0##*/}"
     case "${argv0##*\\}" in
-      git | git.exe) return "$amend" ;;
+      git | git.exe)
+        if gg_argv_is_amend "/proc/$pid/cmdline"; then return 0; fi
+        return 1
+        ;;
     esac
     pid="$(gg_parent_pid "$pid")"
   done

--- a/.agents/skills/growth-guards/scripts/lib/commit-parent.sh
+++ b/.agents/skills/growth-guards/scripts/lib/commit-parent.sh
@@ -31,9 +31,8 @@ gg_parent_pid() { # PID — its parent's pid on stdout, empty when unreadable
 }
 
 gg_opt_abbrev() { # ARG NAME — 0 when ARG is `--x…` and NAME begins with it
-  # git's parser takes any unambiguous abbreviation, so a scan matching full
-  # spellings by equality reads `--mess` as a token it has never heard of. ARG
-  # is quoted into the pattern: it matches as bytes, never as a glob.
+  # git's parser takes any unambiguous abbreviation, so equality alone reads
+  # `--mess` as an unknown token. ARG is quoted in: bytes, never a glob.
   case "$1" in --?*) ;; *) return 1 ;; esac
   case "$2" in "$1"*) return 0 ;; esac
   return 1
@@ -41,40 +40,38 @@ gg_opt_abbrev() { # ARG NAME — 0 when ARG is `--x…` and NAME begins with it
 
 gg_no_value_opt() { # ARG — 0 when ARG is a `git commit` option taking NO value
   # The whole vocabulary the scan below understands. Every option that takes a
-  # value is absent by construction, in every spelling, and absence means "not
-  # an amend" — so an omission costs a refusal the writer clears, never a commit
-  # excused by an entry it does not carry. A name added here that git DOES take
-  # a value for would fail open: the one thing an edit to this list is read for.
+  # value is absent by construction, in every spelling, and absence means "this
+  # one swallowed the token behind it" — so an omission costs a refusal the
+  # writer clears, never a commit excused by an entry it does not carry. A name
+  # added here that git DOES take a value for would fail open: the one thing an
+  # edit to this list is read for.
   local name
   case "$1" in
     -[aeinopqsuvzS]) return 0 ;;
   esac
   for name in --all --patch --interactive --include --only --signoff --dry-run \
-    --no-signoff --verify --edit --no-edit --no-post-rewrite --quiet \
-    --allow-empty --allow-empty-message --gpg-sign --no-gpg-sign --verbose \
-    --reset-author --untracked-files --pathspec-file-nul; do
+    --no-signoff --verify --edit --no-edit --no-post-rewrite --quiet --amend \
+    --no-amend --allow-empty --allow-empty-message --gpg-sign --no-gpg-sign \
+    --verbose --reset-author --untracked-files --pathspec-file-nul; do
     if gg_opt_abbrev "$1" "$name"; then return 0; fi
   done
   return 1
 }
 
 gg_argv_is_amend() { # FILE — 0 when the NUL-delimited argv in FILE is an amend
-  # Read NUL-delimited, the bytes the kernel holds: what keeps an argument
-  # carrying whitespace or a newline ONE argument rather than several. The
-  # committer chooses some of those bytes, and a value that happens to spell
-  # the flag is not the flag. Rather than name the options whose values to step
-  # over — a list git grows, and one whose every gap is a commit excused
-  # wrongly — `--amend` counts as the flag only where nothing ahead of it could
-  # have been reaching for a value: after the `commit` subcommand, every token
-  # between the two a no-value option. The first token that is anything else
-  # ends the scan at "not an amend", so `-m --amend` is a message, `--templ
-  # --amend` a template path, and `--message=…`, `-am` and an option git has
-  # not shipped yet are all refusals. The bare `--` stops the scan where git
-  # stops; `--no-amend` behind the flag takes it back, git's last-spelling
-  # boolean. The wrapper's arguments, ahead of `commit`, are skipped rather than
-  # judged: the flag cannot be among them, so `git -c user.name=x commit
-  # --amend` reads as the amend it is without `-c` being understood.
-  local arg seen=0 sub=0 amend=1
+  # Read NUL-delimited, the bytes the kernel holds, so an argument carrying
+  # whitespace or a newline stays ONE argument. The committer chooses some of
+  # those bytes, and a value that happens to spell the flag is not the flag.
+  # Rather than name the options whose values to step over — a list git grows,
+  # whose every gap is a commit excused wrongly — the scan reads the token
+  # IMMEDIATELY BEFORE each `--amend`: a value-taking option consumes the next
+  # argument and nothing further, so it is the only token that can swallow the
+  # flag. Dash-prefixed and not a no-value option means it did, refusing `--mess
+  # --amend`, `-am --amend`, `--message=…` and an option git has not shipped
+  # yet; anything else never reached for a value, so `-m msg --amend` is the
+  # amend it is. Same guard for `--no-amend`. The bare `--` stops the scan, and
+  # the wrapper's arguments ahead of `commit` are skipped, so `-c` is never read.
+  local arg prev="" eaten seen=0 sub=0 amend=1
   while IFS= read -r -d '' arg; do
     if [ "$seen" -eq 0 ]; then seen=1; continue; fi
     if [ "$sub" -eq 0 ]; then
@@ -82,10 +79,14 @@ gg_argv_is_amend() { # FILE — 0 when the NUL-delimited argv in FILE is an amen
       continue
     fi
     case "$arg" in --) break ;; esac
-    if gg_opt_abbrev "$arg" --no-amend; then amend=1; continue; fi
-    if gg_opt_abbrev "$arg" --amend; then amend=0; continue; fi
-    if [ "$amend" -eq 0 ]; then continue; fi
-    if ! gg_no_value_opt "$arg"; then break; fi
+    eaten=0
+    case "$prev" in -?*) gg_no_value_opt "$prev" || eaten=1 ;; esac
+    if [ "$eaten" -eq 0 ]; then
+      if gg_opt_abbrev "$arg" --no-amend; then amend=1
+      elif gg_opt_abbrev "$arg" --amend; then amend=0
+      fi
+    fi
+    prev="$arg"
   done <"$1"
   return "$amend"
 }

--- a/.agents/skills/growth-guards/scripts/lib/commit-parent.sh
+++ b/.agents/skills/growth-guards/scripts/lib/commit-parent.sh
@@ -1,0 +1,78 @@
+# shellcheck shell=bash
+# Which parent a commit will HAVE, for the lanes that judge a commit rather
+# than an index: HEAD for an ordinary commit, and HEAD's own parent for an
+# amend, which replaces HEAD rather than following it. Kept apart from the
+# rules that read it, and sourced, never executed.
+#
+# Needs lib/common.sh sourced first, and runs with the caller cd'd to the
+# repository root.
+set -euo pipefail
+
+# git tells a commit-msg hook the message and nothing else. It passes no flag,
+# exports no variable and leaves no file behind that says HEAD is about to be
+# REPLACED rather than followed — prepare-commit-msg is the one hook git tells,
+# and this family installs none. So the answer lives in a single place, the
+# argv of the `git commit` this hook is a descendant of, and it is read there
+# under two conditions, because the wrong answer is the dangerous one: a
+# commit judged against a parent it does not have is excused by an entry
+# belonging to a commit it is not amending.
+#
+#   GIT_INDEX_FILE   git sets it for the hooks it runs a commit through, so
+#                    its absence means a DIRECT run — a person, a test, a
+#                    script — whose ancestors say nothing about what it judges
+#   the NEAREST git  git runs a hook as a descendant of the `git commit` doing
+#   ancestor         the committing, so the first git process above this one
+#                    IS that command. The walk stops at it and never reads a
+#                    git further up: a `git rebase` driving the commit would
+#                    be answering for something else
+#
+# Anything unreadable — a kernel with no /proc, a process already gone, eight
+# generations carrying no git — is not an amend, which is the judgement this
+# lane made before: HEAD, and a refusal the writer clears by staging the
+# fragment. The lane widens only where it can prove the parent moved.
+gg_parent_pid() { # PID — its parent's pid on stdout, empty when unreadable
+  local ppid=""
+  [ -r "/proc/$1/status" ] || return 0
+  ppid="$(awk '/^PPid:/ { print $2; exit }' "/proc/$1/status" 2>/dev/null)" || ppid=""
+  printf '%s' "$ppid"
+}
+
+gg_is_amend() { # 0 when this run belongs to a `git commit --amend`
+  local pid depth arg argv0 seen amend
+  [ -n "${GIT_INDEX_FILE:-}" ] || return 1
+  pid="${PPID:-}"
+  depth=0
+  while [ -n "$pid" ] && [ "$pid" != "0" ] && [ "$depth" -lt 8 ]; do
+    depth=$((depth + 1))
+    [ -r "/proc/$pid/cmdline" ] || return 1
+    argv0=""
+    seen=0
+    amend=1
+    # NUL-delimited, the bytes the kernel holds: an argument carrying a
+    # newline stays one argument, and a message whose own text is `--amend`
+    # is one argument too, never the flag.
+    while IFS= read -r -d '' arg; do
+      [ "$seen" -eq 1 ] || argv0="$arg"
+      seen=1
+      [ "$arg" != "--amend" ] || amend=0
+    done <"/proc/$pid/cmdline"
+    # Both separators: a Windows git under MSYS carries a backslash path in
+    # its own argv, and a name still holding one is not `git`.
+    argv0="${argv0##*/}"
+    case "${argv0##*\\}" in
+      git | git.exe) return "$amend" ;;
+    esac
+    pid="$(gg_parent_pid "$pid")"
+  done
+  return 1
+}
+
+gg_commit_base() { # sets GG_COMMIT_BASE — the revision --cached diffs against
+  GG_COMMIT_BASE=""
+  gg_is_amend || return 0
+  GG_COMMIT_BASE="$(git rev-parse --verify --quiet HEAD^ 2>/dev/null)" && return 0
+  # Amending a repository's first commit: its parent is the empty tree, hashed
+  # rather than spelled out so a repository on any object format gets its own.
+  GG_COMMIT_BASE="$(git hash-object -t tree /dev/null)" \
+    || gg_collection_error "could not name the empty tree — the commit's parent could not be resolved"
+}

--- a/.agents/skills/growth-guards/scripts/lib/commit-parent.sh
+++ b/.agents/skills/growth-guards/scripts/lib/commit-parent.sh
@@ -1,8 +1,9 @@
 # shellcheck shell=bash
-# Which parent a commit will HAVE, for the lanes that judge a commit rather
-# than an index: HEAD for an ordinary commit, and HEAD's own parent for an
-# amend, which replaces HEAD rather than following it. Kept apart from the
-# rules that read it, and sourced, never executed.
+# Which parent a commit will HAVE, for the lane that judges a commit rather
+# than an index — `commit-msg`, its one caller: HEAD for an ordinary commit,
+# and HEAD's own parent for an amend, which replaces HEAD rather than
+# following it. Kept apart from the rules that read it, and sourced, never
+# executed.
 #
 # Needs lib/common.sh sourced first, and runs with the caller cd'd to the
 # repository root.
@@ -26,10 +27,15 @@ set -euo pipefail
 #                    git further up: a `git rebase` driving the commit would
 #                    be answering for something else
 #
-# Anything unreadable — a kernel with no /proc, a process already gone, eight
-# generations carrying no git — is not an amend, which is the judgement this
-# lane made before: HEAD, and a refusal the writer clears by staging the
-# fragment. The lane widens only where it can prove the parent moved.
+# Anything unreadable — a process already gone, eight generations carrying no
+# git — is not an amend, which is the judgement this lane made before: HEAD,
+# and a refusal the writer clears by staging the fragment. That covers a whole
+# platform: argv lives in `/proc/<pid>/cmdline`, which macOS does not have, so
+# the widening is Linux-only and an amend there is judged against the HEAD it
+# replaces exactly as it was before. A `ps` reading would reach further and is
+# deliberately not taken: `ps` joins argv with spaces, so a message merely
+# CONTAINING `--amend` would excuse a commit — a fail-open this reading does
+# not have. The lane widens only where it can prove the parent moved.
 gg_parent_pid() { # PID — its parent's pid on stdout, empty when unreadable
   local ppid=""
   [ -r "/proc/$1/status" ] || return 0
@@ -38,7 +44,7 @@ gg_parent_pid() { # PID — its parent's pid on stdout, empty when unreadable
 }
 
 gg_is_amend() { # 0 when this run belongs to a `git commit --amend`
-  local pid depth arg argv0 seen amend
+  local pid depth arg rest argv0 seen skip amend
   [ -n "${GIT_INDEX_FILE:-}" ] || return 1
   pid="${PPID:-}"
   depth=0
@@ -47,14 +53,53 @@ gg_is_amend() { # 0 when this run belongs to a `git commit --amend`
     [ -r "/proc/$pid/cmdline" ] || return 1
     argv0=""
     seen=0
+    skip=0
     amend=1
-    # NUL-delimited, the bytes the kernel holds: an argument carrying a
-    # newline stays one argument, and a message whose own text is `--amend`
-    # is one argument too, never the flag.
+    # NUL-delimited, the bytes the kernel holds: what keeps an argument
+    # carrying whitespace or a newline ONE argument rather than the several a
+    # space-joined command line would split it into.
+    #
+    # The scan reads argv the way git's own option parser does, because the
+    # committer chooses some of these bytes and a value that happens to spell
+    # the flag is not the flag: it stops at the bare `--` where git stops, and
+    # steps over the argument a value-taking option consumes — `-m --amend` is
+    # a message, `--amend` after `--` is a pathspec. Attached forms
+    # (`--author=…`, `-m…`) consume nothing further. The spellings below are
+    # git's full ones; an abbreviation git would still accept (`--mess`) is
+    # not among them, which leaves the flag unseen and the lane refusing —
+    # the judgement it made before this widening, never a commit excused by
+    # an entry it does not carry.
     while IFS= read -r -d '' arg; do
-      [ "$seen" -eq 1 ] || argv0="$arg"
-      seen=1
-      [ "$arg" != "--amend" ] || amend=0
+      if [ "$seen" -eq 0 ]; then
+        argv0="$arg"
+        seen=1
+        continue
+      fi
+      if [ "$skip" -eq 1 ]; then
+        skip=0
+        continue
+      fi
+      case "$arg" in
+        --) break ;;
+        --amend) amend=0 ;;
+        -m | -F | -t | -c | -C | --message | --file | --template | --reuse-message | --reedit-message | --fixup | --squash | --author | --date | --cleanup | --trailer | --pathspec-from-file) skip=1 ;;
+        -[!-]*)
+          # A short bundle, walked letter by letter the way git walks it: the
+          # first letter taking a value swallows the rest of the token as that
+          # value, or the next argument when the token ends there, so `-am`
+          # makes `--amend` behind it a message. `S` and `u` take an OPTIONAL
+          # value, which git reads only when it is attached — they never reach
+          # for the next argument.
+          rest="${arg#-}"
+          while [ -n "$rest" ]; do
+            case "$rest" in
+              [mFtcC]) skip=1; rest="" ;;
+              [mFtcCSu]*) rest="" ;;
+              *) rest="${rest#?}" ;;
+            esac
+          done
+          ;;
+      esac
     done <"/proc/$pid/cmdline"
     # Both separators: a Windows git under MSYS carries a backslash path in
     # its own argv, and a name still holding one is not `git`.

--- a/.agents/skills/growth-guards/scripts/lib/commit-parent.sh
+++ b/.agents/skills/growth-guards/scripts/lib/commit-parent.sh
@@ -59,18 +59,18 @@ gg_no_value_opt() { # ARG — 0 when ARG is a `git commit` option taking NO valu
 }
 
 gg_argv_is_amend() { # FILE — 0 when the NUL-delimited argv in FILE is an amend
-  # Read NUL-delimited, the bytes the kernel holds, so an argument carrying
-  # whitespace or a newline stays ONE argument. The committer chooses some of
-  # those bytes, and a value that happens to spell the flag is not the flag.
-  # Rather than name the options whose values to step over — a list git grows,
-  # whose every gap is a commit excused wrongly — the scan reads the token
-  # IMMEDIATELY BEFORE each `--amend`: a value-taking option consumes the next
-  # argument and nothing further, so it is the only token that can swallow the
-  # flag. Dash-prefixed and not a no-value option means it did, refusing `--mess
-  # --amend`, `-am --amend`, `--message=…` and an option git has not shipped
-  # yet; anything else never reached for a value, so `-m msg --amend` is the
-  # amend it is. Same guard for `--no-amend`. The bare `--` stops the scan, and
-  # the wrapper's arguments ahead of `commit` are skipped, so `-c` is never read.
+  # Read NUL-delimited, so an argument carrying whitespace or a newline stays
+  # ONE argument, and a value the committer chose that happens to spell the flag
+  # is not the flag. Rather than name the options whose values to step over — a
+  # list git grows, every gap a commit excused wrongly — the scan reads the
+  # token IMMEDIATELY BEFORE each `--amend`: a value-taking option consumes the
+  # next argument and nothing further, so it is the only token that can swallow
+  # it. Dash-prefixed and not a no-value option means it did, refusing `--mess
+  # --amend`, `-am --amend` and `--message=…`; anything else never reached, so
+  # `-m msg --amend` is the amend it is. `--no-amend` stands OUTSIDE that guard:
+  # a missed flag costs a refusal, a missed negation leaves a stale `--amend`
+  # standing. The bare `--` stops the scan, and the wrapper's arguments ahead of
+  # `commit` are skipped, so `-c` is never read.
   local arg prev="" eaten seen=0 sub=0 amend=1
   while IFS= read -r -d '' arg; do
     if [ "$seen" -eq 0 ]; then seen=1; continue; fi
@@ -81,10 +81,8 @@ gg_argv_is_amend() { # FILE — 0 when the NUL-delimited argv in FILE is an amen
     case "$arg" in --) break ;; esac
     eaten=0
     case "$prev" in -?*) gg_no_value_opt "$prev" || eaten=1 ;; esac
-    if [ "$eaten" -eq 0 ]; then
-      if gg_opt_abbrev "$arg" --no-amend; then amend=1
-      elif gg_opt_abbrev "$arg" --amend; then amend=0
-      fi
+    if gg_opt_abbrev "$arg" --no-amend; then amend=1
+    elif [ "$eaten" -eq 0 ] && gg_opt_abbrev "$arg" --amend; then amend=0
     fi
     prev="$arg"
   done <"$1"

--- a/.agents/skills/growth-guards/tests/commit-msg-amend.test.sh
+++ b/.agents/skills/growth-guards/tests/commit-msg-amend.test.sh
@@ -2,12 +2,23 @@
 # Pins for the one commit-msg rule that cannot be judged from an index alone:
 # the changelog a commit owes is read against the parent the commit will HAVE,
 # so an amend is judged against HEAD's parent and not against the HEAD it
-# replaces. These run through a real `git commit`, because which parent the
-# commit will have is read off that process and nowhere else — every other
-# commit-msg pin invokes the script directly and lives in commit-msg.test.sh.
-# Every firing pin is paired with the control that proves the widening is
-# bound to the amend: the next commit, an amend carrying no fragment, and an
-# amend that drops the one it had are all still refused.
+# replaces. The rule pins run through a real `git commit`, because which parent
+# the commit will have is read off that process and nowhere else — every other
+# commit-msg RULE pin invokes the script directly and lives in commit-msg.test.sh
+# (install-git-hooks.test.sh drives a real commit too, but only to prove the
+# installed shim reaches the committer).
+#
+# Every firing pin is paired with the control that proves the widening is bound
+# to the amend: the next commit, an amend carrying no fragment, an amend that
+# drops the one it had, and a commit whose own bytes merely SPELL the flag are
+# all still refused.
+#
+# The last section drives a FAKE `git` ancestor — a copy of bash under that
+# name — because the arms a real `git commit` cannot reach are the ones that
+# decide the answer: the GIT_INDEX_FILE guard (a real commit always sets it),
+# the walk stopping at the NEAREST git ancestor, the depth walk past a
+# generation carrying no git, and the argv scan reading a committer-chosen
+# value that spells `--amend`.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -23,77 +34,286 @@ PASS=0
 FAIL=0
 ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
 bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+skip() { printf '  skip  %s\n' "$1"; }
+
+# The widening is read off /proc/<pid>/cmdline and nowhere else, so a host
+# without procfs — macOS, which this family supports — answers "not an amend"
+# and keeps the judgement the lane made before. A pin asserting the widening
+# can only be measured where that file is readable; it is skipped elsewhere,
+# named, rather than reporting a portability fact as a defect. The refusal
+# controls are NOT gated: what they assert holds on every platform.
+HAVE_PROC=0
+if [ -r "/proc/$$/cmdline" ]; then HAVE_PROC=1; fi
+
+mk_repo() { # DIR — a repo with the commit-msg hook installed and the rule armed
+  mkdir -p "$1/crates/core" "$1/changelog.d/fixed"
+  git -C "$1" -c init.defaultBranch=main init -q
+  git -C "$1" config user.email test@example.com
+  git -C "$1" config user.name test
+  printf '#!/bin/sh\nexec %s "$1"\n' "$CM" >"$1/.git/hooks/commit-msg"
+  chmod +x "$1/.git/hooks/commit-msg"
+  printf '[env]\nGROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS = "crates/* ui/*"\n' >"$1/kendex.settings.toml"
+}
+
+seed_commit() { # DIR — the base commit an amend below sits on
+  printf 'seed\n' >"$1/README.md"
+  git -C "$1" add -A
+  git -C "$1" commit -qm "chore: base [no-changelog]" >/dev/null 2>&1
+}
+
+crate_commit() { # DIR — a commit changing a crate and carrying its fragment
+  printf 'fn one() {}\n' >"$1/crates/core/lib.rs"
+  printf -- '- A fix consumers see.\n' >"$1/changelog.d/fixed/ken-1.md"
+  git -C "$1" add -A
+  commit_in "$1" 'fix(KEN-1): change a crate'
+}
+
+more_code() { # DIR — another crate change, staged
+  printf 'fn two() {}\n' >>"$1/crates/core/lib.rs"
+  git -C "$1" add -A
+}
+
+commit_in() { # DIR MESSAGE [git-commit-arg...] — a real commit; sets OUT and RC
+  OUT=""
+  RC=0
+  OUT="$(git -C "$1" commit -m "$2" "${@:3}" 2>&1)" || RC=$?
+}
+
+# Each pin gets its own fixture: an amend either lands or is refused, and a pin
+# that is skipped for want of /proc must leave nothing for the next one to
+# inherit.
+new_repo() { # NAME — a fresh seeded repo at $TMP/NAME, named by R
+  R="$TMP/$1"
+  mk_repo "$R"
+  seed_commit "$R"
+}
+
+refused_naming_lib() { # 0 when RC/OUT are the refusal that names the crate path
+  [ "$RC" -eq 1 ] || return 1
+  case "$OUT" in *"crates/core/lib.rs changed without a changelog entry"*) return 0 ;; esac
+  return 1
+}
 
 echo "=== an amend is judged against the parent it will HAVE, not the HEAD it replaces ==="
 # `git diff --cached` on an amend shows only what was staged ON TOP of the
 # commit being replaced, so a fragment already inside that commit read as no
 # fragment at all and a commit satisfying the rule was refused — with the
-# obvious escape being the flag that skips the whole hook chain. These run
-# through a real `git commit`, because which parent the commit will have is
-# read off that process and nowhere else.
-AM_REPO="$TMP/repo-amend"
-mkdir -p "$AM_REPO/crates/core" "$AM_REPO/changelog.d/fixed"
-git -C "$AM_REPO" -c init.defaultBranch=main init -q
-git -C "$AM_REPO" config user.email test@example.com
-git -C "$AM_REPO" config user.name test
-printf '#!/bin/sh\nexec %s "$1"\n' "$CM" >"$AM_REPO/.git/hooks/commit-msg"
-chmod +x "$AM_REPO/.git/hooks/commit-msg"
-printf '[env]\nGROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS = "crates/* ui/*"\n' >"$AM_REPO/kendex.settings.toml"
-printf 'seed\n' >"$AM_REPO/README.md"
-git -C "$AM_REPO" add -A
-git -C "$AM_REPO" commit -qm "chore: base [no-changelog]" >/dev/null 2>&1
-
-am_commit() { # MESSAGE [git-commit-arg...] — a real commit; sets OUT and RC
-  OUT=""
-  RC=0
-  OUT="$(git -C "$AM_REPO" commit -m "$1" "${@:2}" 2>&1)" || RC=$?
-}
-
-printf 'fn one() {}\n' >"$AM_REPO/crates/core/lib.rs"
-printf -- '- A fix consumers see.\n' >"$AM_REPO/changelog.d/fixed/ken-1.md"
-git -C "$AM_REPO" add -A
-am_commit 'fix(KEN-1): change a crate'
+# obvious escape being the flag that skips the whole hook chain.
+new_repo repo-fixture
+crate_commit "$R"
 [ "$RC" -eq 0 ] && ok "fixture: the crate change lands with its fragment" \
   || bad "fixture: the crate change lands with its fragment" "rc=$RC out=$OUT"
 
-printf 'fn two() {}\n' >>"$AM_REPO/crates/core/lib.rs"
-git -C "$AM_REPO" add -A
-am_commit 'fix(KEN-1): change a crate' --amend
-[ "$RC" -eq 0 ] && ok "an amend adding more code passes on the fragment the commit already carries" \
-  || bad "an amend passes on the fragment the commit already carries" "rc=$RC out=$OUT"
+new_repo repo-amend
+crate_commit "$R"
+more_code "$R"
+if [ "$HAVE_PROC" -eq 1 ]; then
+  commit_in "$R" 'fix(KEN-1): change a crate' --amend
+  [ "$RC" -eq 0 ] && ok "an amend adding more code passes on the fragment the commit already carries" \
+    || bad "an amend passes on the fragment the commit already carries" "rc=$RC out=$OUT"
+else
+  skip "the amend pin needs /proc/<pid>/cmdline, where the committing argv is read"
+fi
 
 # The control that reds when the amend case goes: the widening is bound to the
-# amend, so the NEXT commit — a new one, whose parent really is that HEAD —
-# is not excused by the fragment sitting in the commit before it.
-printf 'fn three() {}\n' >>"$AM_REPO/crates/core/lib.rs"
-git -C "$AM_REPO" add -A
-am_commit 'fix(KEN-2): change a crate again'
-[ "$RC" -eq 1 ] && case "$OUT" in *"crates/core/lib.rs changed without a changelog entry"*) true ;; *) false ;; esac \
+# amend, so the NEXT commit — a new one, whose parent really is that HEAD — is
+# not excused by the fragment sitting in the commit before it.
+new_repo repo-next
+crate_commit "$R"
+more_code "$R"
+commit_in "$R" 'fix(KEN-2): change a crate again'
+refused_naming_lib \
   && ok "control: the commit AFTER a fragment commit still owes its own entry" \
   || bad "control: the commit after a fragment commit still owes its own entry" "rc=$RC out=$OUT"
-git -C "$AM_REPO" reset -q --hard HEAD
 
 # And an amend of a commit that carries no fragment is refused, naming the
 # path: reading the whole commit is what widened, not the rule.
-git -C "$AM_REPO" commit -q --allow-empty -m 'chore: nothing a consumer sees' >/dev/null 2>&1
-printf 'fn four() {}\n' >>"$AM_REPO/crates/core/lib.rs"
-git -C "$AM_REPO" add -A
-am_commit 'fix(KEN-3): change a crate' --amend
-[ "$RC" -eq 1 ] && case "$OUT" in *"crates/core/lib.rs changed without a changelog entry"*) true ;; *) false ;; esac \
+new_repo repo-fragmentless
+git -C "$R" commit -q --allow-empty -m 'chore: nothing a consumer sees' >/dev/null 2>&1
+more_code "$R"
+commit_in "$R" 'fix(KEN-3): change a crate' --amend
+refused_naming_lib \
   && ok "control: an amend of a fragmentless commit is refused, naming the path" \
   || bad "control: an amend of a fragmentless commit is refused" "rc=$RC out=$OUT"
-git -C "$AM_REPO" reset -q --hard HEAD
-git -C "$AM_REPO" reset -q --hard HEAD~1
 
 # An amend that DROPS the fragment owes one again: what counts is the tree the
-# commit will have, never that HEAD once held an entry.
-git -C "$AM_REPO" rm -q --cached changelog.d/fixed/ken-1.md
-rm -f "$AM_REPO/changelog.d/fixed/ken-1.md"
-am_commit 'fix(KEN-1): change a crate' --amend
-[ "$RC" -eq 1 ] && case "$OUT" in *"crates/core/lib.rs changed without a changelog entry"*) true ;; *) false ;; esac \
-  && ok "control: an amend that drops the fragment owes one again" \
-  || bad "control: an amend that drops the fragment owes one again" "rc=$RC out=$OUT"
-git -C "$AM_REPO" reset -q --hard HEAD
+# commit will have, never that HEAD once held an entry. Gated, because without
+# the widening the base is HEAD and the dropped fragment is the only change the
+# diff shows — no required path in it, and nothing to refuse.
+new_repo repo-dropped
+crate_commit "$R"
+if [ "$HAVE_PROC" -eq 1 ]; then
+  git -C "$R" rm -q --cached changelog.d/fixed/ken-1.md
+  rm -f "$R/changelog.d/fixed/ken-1.md"
+  commit_in "$R" 'fix(KEN-1): change a crate' --amend
+  refused_naming_lib \
+    && ok "control: an amend that drops the fragment owes one again" \
+    || bad "control: an amend that drops the fragment owes one again" "rc=$RC out=$OUT"
+else
+  skip "the dropped-fragment pin needs /proc/<pid>/cmdline: without it the base is HEAD and no required path moved"
+fi
+
+echo "=== a commit whose own bytes SPELL the flag is not an amend ==="
+# The committer chooses some of the bytes in that argv. A message or a pathspec
+# equal to `--amend` reached the scan as the flag before it read argv the way
+# git's parser does, and the previous commit's fragment then excused a commit
+# that carries none. These are refusals, so they hold on every platform.
+new_repo repo-spelled
+: >"$R/--amend"
+git -C "$R" add -A
+git -C "$R" commit -qm 'chore: a tracked file named for the flag [no-changelog]' >/dev/null 2>&1
+crate_commit "$R"
+more_code "$R"
+commit_in "$R" 'fix(KEN-2): change a crate again' -m '--amend'
+refused_naming_lib \
+  && ok "control: the flag text as a -m body paragraph is a message, not the flag" \
+  || bad "control: the flag text as a -m body paragraph is a message" "rc=$RC out=$OUT"
+
+new_repo repo-pathspec
+: >"$R/--amend"
+git -C "$R" add -A
+git -C "$R" commit -qm 'chore: a tracked file named for the flag [no-changelog]' >/dev/null 2>&1
+crate_commit "$R"
+printf 'fn two() {}\n' >>"$R/crates/core/lib.rs"
+commit_in "$R" 'fix(KEN-2): change a crate again' -- crates/core/lib.rs --amend
+refused_naming_lib \
+  && ok "control: a --amend PATHSPEC after the bare -- is a path, not the flag" \
+  || bad "control: a --amend pathspec after the bare -- is a path" "rc=$RC out=$OUT"
+
+echo "=== amending a repository's first commit: the parent is the empty tree ==="
+# HEAD^ does not resolve there, so the base is the hashed empty tree. Same
+# branch on the tip of a `git clone --depth 1` shallow clone, where git writes
+# a parentless commit.
+R="$TMP/repo-root"
+mk_repo "$R"
+crate_commit "$R"
+if [ "$HAVE_PROC" -eq 1 ]; then
+  more_code "$R"
+  commit_in "$R" 'fix(KEN-1): change a crate' --amend
+  [ "$RC" -eq 0 ] && [ -z "$(git -C "$R" rev-parse --verify --quiet HEAD^ 2>/dev/null)" ] \
+    && ok "an amend of the ROOT commit passes on the fragment it carries" \
+    || bad "an amend of the root commit passes on the fragment it carries" "rc=$RC out=$OUT"
+
+  git -C "$R" rm -q --cached changelog.d/fixed/ken-1.md
+  rm -f "$R/changelog.d/fixed/ken-1.md"
+  commit_in "$R" 'fix(KEN-1): change a crate' --amend
+  refused_naming_lib \
+    && ok "control: the same root amend is refused once the fragment is dropped" \
+    || bad "control: the root amend is refused once the fragment is dropped" "rc=$RC out=$OUT"
+else
+  skip "the root-commit amend pins need /proc/<pid>/cmdline, where the committing argv is read"
+fi
+
+echo "=== what the walk reads, through a FAKE git ancestor ==="
+# A real `git commit` cannot put these shapes on the tree: it always sets
+# GIT_INDEX_FILE, it is always the nearest git ancestor, and it rejects an
+# argv git itself would not parse. A copy of bash named `git` can, and the
+# hook is invoked directly beneath it.
+#
+# The fixture stands still: HEAD carries the crate change and its fragment,
+# HEAD^ carries neither, and the index holds HEAD's tree plus more code. Judged
+# against HEAD^ the fragment is in the diff and the run passes; judged against
+# HEAD only the crate change is, and the run is refused. One bit, either way.
+if [ "$HAVE_PROC" -eq 0 ]; then
+  skip "the ancestor-walk pins need /proc/<pid>/cmdline: with no procfs there is no argv to read"
+else
+  FK_REPO="$TMP/repo-fake"
+  mk_repo "$FK_REPO"
+  rm -f "$FK_REPO/.git/hooks/commit-msg"
+  seed_commit "$FK_REPO"
+  crate_commit "$FK_REPO"
+  more_code "$FK_REPO"
+  FK_MSG="$TMP/fake-message.txt"
+  printf 'fix(KEN-1): change a crate\n' >"$FK_MSG"
+
+  FAKE_BIN="$TMP/fake-bin"
+  mkdir -p "$FAKE_BIN"
+  cp -- "${BASH:-$(command -v bash)}" "$FAKE_BIN/git"
+  # The fake ancestor reads these out of the environment: it is bash, and its
+  # `-c` script is the only thing it is given.
+  export CM FK_MSG FAKE_BIN
+  # `sleep 0; exit $s` is load-bearing. bash EXECS a lone `-c` command, which
+  # would replace the fake ancestor with commit-msg itself and erase the very
+  # process the scan is about.
+  FAKE_RUN='"$CM" "$FK_MSG"; s=$?; sleep 0; exit $s'
+  export FAKE_RUN
+
+  fake_git() { # ARG... — commit-msg under a `git` ancestor whose argv is ARG...
+    OUT=""
+    RC=0
+    OUT="$(cd "$FK_REPO" && GIT_INDEX_FILE="$FK_REPO/.git/index" \
+      "$FAKE_BIN/git" -c "$FAKE_RUN" "$@" 2>&1)" || RC=$?
+  }
+
+  # MUST-FAIL: git sets GIT_INDEX_FILE for the hooks it runs a commit through,
+  # so its absence means a DIRECT run — a person, a script, one of this
+  # family's own suites under a developer's `git commit --amend` — whose
+  # ancestors say nothing about what it judges. Drop the guard and this run is
+  # excused by a fragment the commit does not carry.
+  OUT=""
+  RC=0
+  OUT="$(cd "$FK_REPO" && "$FAKE_BIN/git" -c "$FAKE_RUN" --amend 2>&1)" || RC=$?
+  refused_naming_lib \
+    && ok "must-fail: a git ancestor with the flag but no GIT_INDEX_FILE is not this run's commit" \
+    || bad "a git ancestor with no GIT_INDEX_FILE must not widen" "rc=$RC out=$OUT"
+
+  fake_git --amend
+  [ "$RC" -eq 0 ] && ok "the walk finds the flag on the nearest git ancestor and widens" \
+    || bad "the walk finds the flag on the nearest git ancestor" "rc=$RC out=$OUT"
+
+  # MUST-FAIL: the walk stops at the NEAREST git ancestor, which is the command
+  # doing the committing. A `git rebase` above it would be answering for
+  # something else, so a climb past the inner git is a commit judged against a
+  # parent it does not have.
+  OUT=""
+  RC=0
+  NEST_RUN='"$FAKE_BIN/git" -c "$FAKE_RUN" commit; s=$?; sleep 0; exit $s'
+  OUT="$(cd "$FK_REPO" && GIT_INDEX_FILE="$FK_REPO/.git/index" \
+    "$FAKE_BIN/git" -c "$NEST_RUN" --amend 2>&1)" || RC=$?
+  refused_naming_lib \
+    && ok "must-fail: an inner git WITHOUT the flag answers, not an outer git with it" \
+    || bad "the walk must stop at the nearest git ancestor" "rc=$RC out=$OUT"
+
+  # The depth walk: a generation carrying no git sits between the committing
+  # process and the hook, so a cap of one generation reads only that generation
+  # and never reaches the git above it.
+  OUT=""
+  RC=0
+  DEPTH_RUN='bash -c "$FAKE_RUN"; s=$?; sleep 0; exit $s'
+  OUT="$(cd "$FK_REPO" && GIT_INDEX_FILE="$FK_REPO/.git/index" \
+    "$FAKE_BIN/git" -c "$DEPTH_RUN" --amend 2>&1)" || RC=$?
+  [ "$RC" -eq 0 ] && ok "the walk climbs past a generation carrying no git" \
+    || bad "the walk climbs past a generation carrying no git" "rc=$RC out=$OUT"
+
+  # MUST-FAIL, the argv scan itself: a value the committer chose is not the
+  # flag. git's own parser stops at the bare `--` and hands a value-taking
+  # option the argument behind it, and the scan reads argv the same way.
+  fake_git -m --amend
+  refused_naming_lib \
+    && ok "must-fail: the argument -m consumes is a message, not the flag" \
+    || bad "the argument -m consumes must not read as the flag" "rc=$RC out=$OUT"
+
+  fake_git --message --amend
+  refused_naming_lib \
+    && ok "must-fail: the argument a LONG value-taking option consumes is a message too" \
+    || bad "the argument a long value-taking option consumes must not read as the flag" "rc=$RC out=$OUT"
+
+  fake_git -am --amend
+  refused_naming_lib \
+    && ok "must-fail: the argument a SHORT BUNDLE's -m consumes is a message too" \
+    || bad "the argument a short bundle's -m consumes must not read as the flag" "rc=$RC out=$OUT"
+
+  fake_git commit -- --amend
+  refused_naming_lib \
+    && ok "must-fail: an argument after the bare -- is a pathspec, not the flag" \
+    || bad "an argument after the bare -- must not read as the flag" "rc=$RC out=$OUT"
+
+  # The control that keeps those three honest: the flag itself, in the same
+  # argv shapes, still widens.
+  fake_git --amend -m 'fix(KEN-1): change a crate'
+  [ "$RC" -eq 0 ] && ok "control: the flag BEFORE a value-taking option is still the flag" \
+    || bad "control: the flag before a value-taking option is still the flag" "rc=$RC out=$OUT"
+fi
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.agents/skills/growth-guards/tests/commit-msg-amend.test.sh
+++ b/.agents/skills/growth-guards/tests/commit-msg-amend.test.sh
@@ -1,31 +1,20 @@
 #!/usr/bin/env bash
 # Pins for the one commit-msg rule that cannot be judged from an index alone:
 # the changelog a commit owes is read against the parent the commit will HAVE,
-# so an amend is judged against HEAD's parent and not against the HEAD it
-# replaces. The rule pins run through a real `git commit`, because which parent
-# the commit will have is read off that process and nowhere else — every other
-# commit-msg RULE pin invokes the script directly and lives in commit-msg.test.sh
-# (install-git-hooks.test.sh drives a real commit too, but only to prove the
-# installed shim reaches the committer).
-#
-# Every firing pin is paired with the control that proves the widening is bound
-# to the amend: the next commit, an amend carrying no fragment, an amend that
-# drops the one it had, and a commit whose own bytes merely SPELL the flag are
-# all still refused.
-#
-# The last section drives a FAKE `git` ancestor — a copy of bash under that
-# name — because the arms a real `git commit` cannot reach are the ones that
-# decide the answer: the GIT_INDEX_FILE guard (a real commit always sets it),
-# the walk stopping at the NEAREST git ancestor, the depth walk past a
-# generation carrying no git, and the argv scan reading a committer-chosen
-# value that spells `--amend`.
+# so an amend is judged against HEAD's parent, not the HEAD it replaces. Three
+# kinds of pin, because the answer is read off a process — a real `git commit`
+# for the rule end to end, each firing pin against the control that reds when
+# the widening stops being bound to the amend; an argv FILE for which argv IS
+# an amend, one spelling per line; and a FAKE `git`, a copy of bash under that
+# name, for the arms that need a process.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 CM="$SKILL_DIR/scripts/commit-msg"
 . "$TEST_DIR/lib/harness.bash"
-
+# shellcheck source=../scripts/lib/commit-parent.sh
+source "$SKILL_DIR/scripts/lib/commit-parent.sh"
 unset GROWTH_GUARDS_COMMIT_TYPES GROWTH_GUARDS_SUBJECT_MAX \
   GROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS GROWTH_GUARDS_CHANGELOG_PATHS \
   GROWTH_GUARDS_CHANGELOG_RECORD GROWTH_GUARDS_SETTINGS_FILE 2>/dev/null || true
@@ -37,11 +26,9 @@ bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
 skip() { printf '  skip  %s\n' "$1"; }
 
 # The widening is read off /proc/<pid>/cmdline and nowhere else, so a host
-# without procfs — macOS, which this family supports — answers "not an amend"
-# and keeps the judgement the lane made before. A pin asserting the widening
-# can only be measured where that file is readable; it is skipped elsewhere,
-# named, rather than reporting a portability fact as a defect. The refusal
-# controls are NOT gated: what they assert holds on every platform.
+# without procfs — macOS, which this family supports — answers "not an amend".
+# A pin asserting the widening is skipped there, named, rather than reporting a
+# portability fact as a defect; the refusal controls and argv pins are not.
 HAVE_PROC=0
 if [ -r "/proc/$$/cmdline" ]; then HAVE_PROC=1; fi
 
@@ -54,40 +41,33 @@ mk_repo() { # DIR — a repo with the commit-msg hook installed and the rule arm
   chmod +x "$1/.git/hooks/commit-msg"
   printf '[env]\nGROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS = "crates/* ui/*"\n' >"$1/kendex.settings.toml"
 }
-
 seed_commit() { # DIR — the base commit an amend below sits on
   printf 'seed\n' >"$1/README.md"
   git -C "$1" add -A
   git -C "$1" commit -qm "chore: base [no-changelog]" >/dev/null 2>&1
 }
-
 crate_commit() { # DIR — a commit changing a crate and carrying its fragment
   printf 'fn one() {}\n' >"$1/crates/core/lib.rs"
   printf -- '- A fix consumers see.\n' >"$1/changelog.d/fixed/ken-1.md"
   git -C "$1" add -A
   commit_in "$1" 'fix(KEN-1): change a crate'
 }
-
 more_code() { # DIR — another crate change, staged
   printf 'fn two() {}\n' >>"$1/crates/core/lib.rs"
   git -C "$1" add -A
 }
-
 commit_in() { # DIR MESSAGE [git-commit-arg...] — a real commit; sets OUT and RC
-  OUT=""
-  RC=0
-  OUT="$(git -C "$1" commit -m "$2" "${@:3}" 2>&1)" || RC=$?
+  # The flag goes AHEAD of `-m`, which is where the scan reads it: `-m` is a
+  # token the scan does not understand, because the argument behind it is the
+  # committer's to choose, and one of those ends the scan at "not an amend".
+  OUT=""; RC=0
+  OUT="$(git -C "$1" commit "${@:3}" -m "$2" 2>&1)" || RC=$?
 }
-
-# Each pin gets its own fixture: an amend either lands or is refused, and a pin
-# that is skipped for want of /proc must leave nothing for the next one to
-# inherit.
-new_repo() { # NAME — a fresh seeded repo at $TMP/NAME, named by R
-  R="$TMP/$1"
-  mk_repo "$R"
+new_repo() { # NAME — a fresh seeded repo at $TMP/NAME, named by R; one fixture
+  R="$TMP/$1"          # per pin, so a pin skipped for want of /proc leaves
+  mk_repo "$R"         # nothing for the next to inherit
   seed_commit "$R"
 }
-
 refused_naming_lib() { # 0 when RC/OUT are the refusal that names the crate path
   [ "$RC" -eq 1 ] || return 1
   case "$OUT" in *"crates/core/lib.rs changed without a changelog entry"*) return 0 ;; esac
@@ -97,27 +77,10 @@ refused_naming_lib() { # 0 when RC/OUT are the refusal that names the crate path
 echo "=== an amend is judged against the parent it will HAVE, not the HEAD it replaces ==="
 # `git diff --cached` on an amend shows only what was staged ON TOP of the
 # commit being replaced, so a fragment already inside that commit read as no
-# fragment at all and a commit satisfying the rule was refused — with the
-# obvious escape being the flag that skips the whole hook chain.
-new_repo repo-fixture
-crate_commit "$R"
-[ "$RC" -eq 0 ] && ok "fixture: the crate change lands with its fragment" \
-  || bad "fixture: the crate change lands with its fragment" "rc=$RC out=$OUT"
-
-new_repo repo-amend
-crate_commit "$R"
-more_code "$R"
-if [ "$HAVE_PROC" -eq 1 ]; then
-  commit_in "$R" 'fix(KEN-1): change a crate' --amend
-  [ "$RC" -eq 0 ] && ok "an amend adding more code passes on the fragment the commit already carries" \
-    || bad "an amend passes on the fragment the commit already carries" "rc=$RC out=$OUT"
-else
-  skip "the amend pin needs /proc/<pid>/cmdline, where the committing argv is read"
-fi
-
-# The control that reds when the amend case goes: the widening is bound to the
-# amend, so the NEXT commit — a new one, whose parent really is that HEAD — is
-# not excused by the fragment sitting in the commit before it.
+# fragment at all and a commit satisfying the rule was refused, the obvious
+# escape being the flag that skips the whole hook chain. The control that reds
+# when that goes, and the one pin here needing no /proc: the NEXT commit, whose
+# parent really is that HEAD, is not excused by the fragment in the one before.
 new_repo repo-next
 crate_commit "$R"
 more_code "$R"
@@ -126,90 +89,73 @@ refused_naming_lib \
   && ok "control: the commit AFTER a fragment commit still owes its own entry" \
   || bad "control: the commit after a fragment commit still owes its own entry" "rc=$RC out=$OUT"
 
-# And an amend of a commit that carries no fragment is refused, naming the
-# path: reading the whole commit is what widened, not the rule.
-new_repo repo-fragmentless
-git -C "$R" commit -q --allow-empty -m 'chore: nothing a consumer sees' >/dev/null 2>&1
-more_code "$R"
-commit_in "$R" 'fix(KEN-3): change a crate' --amend
-refused_naming_lib \
-  && ok "control: an amend of a fragmentless commit is refused, naming the path" \
-  || bad "control: an amend of a fragmentless commit is refused" "rc=$RC out=$OUT"
+if [ "$HAVE_PROC" -eq 0 ]; then
+  skip "the widening pins need /proc/<pid>/cmdline, where the committing argv is read"
+else
+  new_repo repo-amend
+  crate_commit "$R"
+  more_code "$R"
+  commit_in "$R" 'fix(KEN-1): change a crate' --amend
+  [ "$RC" -eq 0 ] && ok "an amend adding more code passes on the fragment the commit already carries" \
+    || bad "an amend passes on the fragment the commit already carries" "rc=$RC out=$OUT"
 
-# An amend that DROPS the fragment owes one again: what counts is the tree the
-# commit will have, never that HEAD once held an entry. Gated, because without
-# the widening the base is HEAD and the dropped fragment is the only change the
-# diff shows — no required path in it, and nothing to refuse.
-new_repo repo-dropped
-crate_commit "$R"
-if [ "$HAVE_PROC" -eq 1 ]; then
+  # What counts is the tree the commit will have, never that HEAD once held an
+  # entry. Gated too: without the widening the base is HEAD, the dropped
+  # fragment is the only change the diff shows, and no required path is in it.
+  new_repo repo-dropped
+  crate_commit "$R"
   git -C "$R" rm -q --cached changelog.d/fixed/ken-1.md
   rm -f "$R/changelog.d/fixed/ken-1.md"
   commit_in "$R" 'fix(KEN-1): change a crate' --amend
   refused_naming_lib \
     && ok "control: an amend that drops the fragment owes one again" \
     || bad "control: an amend that drops the fragment owes one again" "rc=$RC out=$OUT"
-else
-  skip "the dropped-fragment pin needs /proc/<pid>/cmdline: without it the base is HEAD and no required path moved"
-fi
 
-echo "=== a commit whose own bytes SPELL the flag is not an amend ==="
-# The committer chooses some of the bytes in that argv. A message or a pathspec
-# equal to `--amend` reached the scan as the flag before it read argv the way
-# git's parser does, and the previous commit's fragment then excused a commit
-# that carries none. These are refusals, so they hold on every platform.
-new_repo repo-spelled
-: >"$R/--amend"
-git -C "$R" add -A
-git -C "$R" commit -qm 'chore: a tracked file named for the flag [no-changelog]' >/dev/null 2>&1
-crate_commit "$R"
-more_code "$R"
-commit_in "$R" 'fix(KEN-2): change a crate again' -m '--amend'
-refused_naming_lib \
-  && ok "control: the flag text as a -m body paragraph is a message, not the flag" \
-  || bad "control: the flag text as a -m body paragraph is a message" "rc=$RC out=$OUT"
-
-new_repo repo-pathspec
-: >"$R/--amend"
-git -C "$R" add -A
-git -C "$R" commit -qm 'chore: a tracked file named for the flag [no-changelog]' >/dev/null 2>&1
-crate_commit "$R"
-printf 'fn two() {}\n' >>"$R/crates/core/lib.rs"
-commit_in "$R" 'fix(KEN-2): change a crate again' -- crates/core/lib.rs --amend
-refused_naming_lib \
-  && ok "control: a --amend PATHSPEC after the bare -- is a path, not the flag" \
-  || bad "control: a --amend pathspec after the bare -- is a path" "rc=$RC out=$OUT"
-
-echo "=== amending a repository's first commit: the parent is the empty tree ==="
-# HEAD^ does not resolve there, so the base is the hashed empty tree. Same
-# branch on the tip of a `git clone --depth 1` shallow clone, where git writes
-# a parentless commit.
-R="$TMP/repo-root"
-mk_repo "$R"
-crate_commit "$R"
-if [ "$HAVE_PROC" -eq 1 ]; then
+  # Amending a repository's FIRST commit: HEAD^ does not resolve, so the base
+  # is the hashed empty tree. Same branch on the tip of a shallow clone.
+  R="$TMP/repo-root"
+  mk_repo "$R"
+  crate_commit "$R"
   more_code "$R"
   commit_in "$R" 'fix(KEN-1): change a crate' --amend
   [ "$RC" -eq 0 ] && [ -z "$(git -C "$R" rev-parse --verify --quiet HEAD^ 2>/dev/null)" ] \
     && ok "an amend of the ROOT commit passes on the fragment it carries" \
     || bad "an amend of the root commit passes on the fragment it carries" "rc=$RC out=$OUT"
-
-  git -C "$R" rm -q --cached changelog.d/fixed/ken-1.md
-  rm -f "$R/changelog.d/fixed/ken-1.md"
-  commit_in "$R" 'fix(KEN-1): change a crate' --amend
-  refused_naming_lib \
-    && ok "control: the same root amend is refused once the fragment is dropped" \
-    || bad "control: the root amend is refused once the fragment is dropped" "rc=$RC out=$OUT"
-else
-  skip "the root-commit amend pins need /proc/<pid>/cmdline, where the committing argv is read"
 fi
 
-echo "=== what the walk reads, through a FAKE git ancestor ==="
-# A real `git commit` cannot put these shapes on the tree: it always sets
-# GIT_INDEX_FILE, it is always the nearest git ancestor, and it rejects an
-# argv git itself would not parse. A copy of bash named `git` can, and the
-# hook is invoked directly beneath it.
-#
+echo '=== which argv is an amend ==='
+# One spelling per pin, as the NUL-delimited bytes the kernel would hold. git
+# takes any unambiguous ABBREVIATION and resolves a boolean to its LAST
+# spelling, so the refusals below are what a scan matching full names by
+# equality got wrong in the FAIL-OPEN direction: it read the flag out of a
+# value the committer chose, and the previous commit's fragment excused a
+# commit carrying none.
+ARGV="$TMP/argv"
+argv_pin() { # LABEL WANT ARG... — WANT is `amend` or `plain`
+  local label="$1" want="$2" got=plain
+  shift 2
+  printf '%s\0' "$@" >"$ARGV"
+  if gg_argv_is_amend "$ARGV"; then got=amend; fi
+  [ "$got" = "$want" ] && ok "$label" || bad "$label" "read as $got, wanted $want"
+}
+argv_pin "the flag itself is the flag" amend git commit --amend
+argv_pin "--am is git's abbreviation of it, an amend this lane must widen for" amend git commit --am
+argv_pin "a no-value option ahead of the flag is stepped over" amend git commit --no-edit --amend
+argv_pin "a rebase reword's own argv widens" amend git commit --amend --no-gpg-sign -e --allow-empty
+argv_pin "the wrapper's arguments, ahead of the subcommand, are not the commit's" amend git -c user.name=x commit --amend --no-edit
+argv_pin "the flag BEFORE a value-taking option is still the flag" amend git commit --amend -m 'fix(KEN-1): change a crate'
+argv_pin "must-fail: the argument -m consumes is a message" plain git commit -m --amend
+argv_pin "must-fail: --mess is that same option, abbreviated" plain git commit --mess --amend
+argv_pin "must-fail: --templ takes a template path" plain git commit --templ --amend
+argv_pin "must-fail: --trail takes a trailer" plain git commit --trail --amend
+argv_pin "must-fail: --fil takes a message file" plain git commit --fil --amend
+argv_pin "must-fail: an attached --message=… carries its value in the token" plain git commit --message=--amend
+argv_pin "must-fail: a short BUNDLE's -m consumes the argument behind it" plain git commit -am --amend
+argv_pin "must-fail: an argument after the bare -- is a pathspec" plain git commit -- --amend
+argv_pin "must-fail: --no-amend behind the flag is git's last-spelling boolean" plain git commit --amend --no-amend -m 'fix(KEN-2): change a crate'
+argv_pin "must-fail: an argv that never reaches the commit subcommand is not one" plain git rebase --amend
+
+echo "=== what the WALK reads, through a FAKE git ancestor ==="
 # The fixture stands still: HEAD carries the crate change and its fragment,
 # HEAD^ carries neither, and the index holds HEAD's tree plus more code. Judged
 # against HEAD^ the fragment is in the diff and the run passes; judged against
@@ -225,22 +171,19 @@ else
   more_code "$FK_REPO"
   FK_MSG="$TMP/fake-message.txt"
   printf 'fix(KEN-1): change a crate\n' >"$FK_MSG"
-
   FAKE_BIN="$TMP/fake-bin"
   mkdir -p "$FAKE_BIN"
   cp -- "${BASH:-$(command -v bash)}" "$FAKE_BIN/git"
-  # The fake ancestor reads these out of the environment: it is bash, and its
-  # `-c` script is the only thing it is given.
+  # The fake ancestor is bash, and its `-c` script is all it is given, so it
+  # reads these out of the environment. `exit $s` LAST is load-bearing: bash
+  # execs the final command of a `-c` script, which for a lone `"$CM" …` would
+  # replace the fake ancestor with commit-msg and erase the very process the
+  # scan is about. A builtin is the one ending it cannot exec away.
   export CM FK_MSG FAKE_BIN
-  # `sleep 0; exit $s` is load-bearing. bash EXECS a lone `-c` command, which
-  # would replace the fake ancestor with commit-msg itself and erase the very
-  # process the scan is about.
-  FAKE_RUN='"$CM" "$FK_MSG"; s=$?; sleep 0; exit $s'
+  FAKE_RUN='"$CM" "$FK_MSG"; s=$?; exit $s'
   export FAKE_RUN
-
   fake_git() { # ARG... — commit-msg under a `git` ancestor whose argv is ARG...
-    OUT=""
-    RC=0
+    OUT=""; RC=0
     OUT="$(cd "$FK_REPO" && GIT_INDEX_FILE="$FK_REPO/.git/index" \
       "$FAKE_BIN/git" -c "$FAKE_RUN" "$@" 2>&1)" || RC=$?
   }
@@ -248,71 +191,39 @@ else
   # MUST-FAIL: git sets GIT_INDEX_FILE for the hooks it runs a commit through,
   # so its absence means a DIRECT run — a person, a script, one of this
   # family's own suites under a developer's `git commit --amend` — whose
-  # ancestors say nothing about what it judges. Drop the guard and this run is
-  # excused by a fragment the commit does not carry.
-  OUT=""
-  RC=0
-  OUT="$(cd "$FK_REPO" && "$FAKE_BIN/git" -c "$FAKE_RUN" --amend 2>&1)" || RC=$?
+  # ancestors say nothing about what it judges.
+  OUT=""; RC=0
+  OUT="$(cd "$FK_REPO" && "$FAKE_BIN/git" -c "$FAKE_RUN" commit --amend 2>&1)" || RC=$?
   refused_naming_lib \
     && ok "must-fail: a git ancestor with the flag but no GIT_INDEX_FILE is not this run's commit" \
     || bad "a git ancestor with no GIT_INDEX_FILE must not widen" "rc=$RC out=$OUT"
 
-  fake_git --amend
+  fake_git commit --amend
   [ "$RC" -eq 0 ] && ok "the walk finds the flag on the nearest git ancestor and widens" \
     || bad "the walk finds the flag on the nearest git ancestor" "rc=$RC out=$OUT"
 
-  # MUST-FAIL: the walk stops at the NEAREST git ancestor, which is the command
-  # doing the committing. A `git rebase` above it would be answering for
-  # something else, so a climb past the inner git is a commit judged against a
-  # parent it does not have.
+  # MUST-FAIL: the walk stops at the NEAREST git ancestor, the command doing
+  # the committing. A `git rebase` above it answers for something else, so a
+  # climb past the inner git judges a commit against a parent it does not have.
   OUT=""
   RC=0
-  NEST_RUN='"$FAKE_BIN/git" -c "$FAKE_RUN" commit; s=$?; sleep 0; exit $s'
+  NEST_RUN='"$FAKE_BIN/git" -c "$FAKE_RUN" commit; s=$?; exit $s'
   OUT="$(cd "$FK_REPO" && GIT_INDEX_FILE="$FK_REPO/.git/index" \
-    "$FAKE_BIN/git" -c "$NEST_RUN" --amend 2>&1)" || RC=$?
+    "$FAKE_BIN/git" -c "$NEST_RUN" commit --amend 2>&1)" || RC=$?
   refused_naming_lib \
     && ok "must-fail: an inner git WITHOUT the flag answers, not an outer git with it" \
     || bad "the walk must stop at the nearest git ancestor" "rc=$RC out=$OUT"
 
   # The depth walk: a generation carrying no git sits between the committing
-  # process and the hook, so a cap of one generation reads only that generation
-  # and never reaches the git above it.
+  # process and the hook, so a cap of one generation would never reach the git
+  # above it.
   OUT=""
   RC=0
-  DEPTH_RUN='bash -c "$FAKE_RUN"; s=$?; sleep 0; exit $s'
+  DEPTH_RUN='bash -c "$FAKE_RUN"; s=$?; exit $s'
   OUT="$(cd "$FK_REPO" && GIT_INDEX_FILE="$FK_REPO/.git/index" \
-    "$FAKE_BIN/git" -c "$DEPTH_RUN" --amend 2>&1)" || RC=$?
+    "$FAKE_BIN/git" -c "$DEPTH_RUN" commit --amend 2>&1)" || RC=$?
   [ "$RC" -eq 0 ] && ok "the walk climbs past a generation carrying no git" \
     || bad "the walk climbs past a generation carrying no git" "rc=$RC out=$OUT"
-
-  # MUST-FAIL, the argv scan itself: a value the committer chose is not the
-  # flag. git's own parser stops at the bare `--` and hands a value-taking
-  # option the argument behind it, and the scan reads argv the same way.
-  fake_git -m --amend
-  refused_naming_lib \
-    && ok "must-fail: the argument -m consumes is a message, not the flag" \
-    || bad "the argument -m consumes must not read as the flag" "rc=$RC out=$OUT"
-
-  fake_git --message --amend
-  refused_naming_lib \
-    && ok "must-fail: the argument a LONG value-taking option consumes is a message too" \
-    || bad "the argument a long value-taking option consumes must not read as the flag" "rc=$RC out=$OUT"
-
-  fake_git -am --amend
-  refused_naming_lib \
-    && ok "must-fail: the argument a SHORT BUNDLE's -m consumes is a message too" \
-    || bad "the argument a short bundle's -m consumes must not read as the flag" "rc=$RC out=$OUT"
-
-  fake_git commit -- --amend
-  refused_naming_lib \
-    && ok "must-fail: an argument after the bare -- is a pathspec, not the flag" \
-    || bad "an argument after the bare -- must not read as the flag" "rc=$RC out=$OUT"
-
-  # The control that keeps those three honest: the flag itself, in the same
-  # argv shapes, still widens.
-  fake_git --amend -m 'fix(KEN-1): change a crate'
-  [ "$RC" -eq 0 ] && ok "control: the flag BEFORE a value-taking option is still the flag" \
-    || bad "control: the flag before a value-taking option is still the flag" "rc=$RC out=$OUT"
 fi
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"

--- a/.agents/skills/growth-guards/tests/commit-msg-amend.test.sh
+++ b/.agents/skills/growth-guards/tests/commit-msg-amend.test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Pins for the one commit-msg rule that cannot be judged from an index alone:
+# the changelog a commit owes is read against the parent the commit will HAVE,
+# so an amend is judged against HEAD's parent and not against the HEAD it
+# replaces. These run through a real `git commit`, because which parent the
+# commit will have is read off that process and nowhere else — every other
+# commit-msg pin invokes the script directly and lives in commit-msg.test.sh.
+# Every firing pin is paired with the control that proves the widening is
+# bound to the amend: the next commit, an amend carrying no fragment, and an
+# amend that drops the one it had are all still refused.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+CM="$SKILL_DIR/scripts/commit-msg"
+. "$TEST_DIR/lib/harness.bash"
+
+unset GROWTH_GUARDS_COMMIT_TYPES GROWTH_GUARDS_SUBJECT_MAX \
+  GROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS GROWTH_GUARDS_CHANGELOG_PATHS \
+  GROWTH_GUARDS_CHANGELOG_RECORD GROWTH_GUARDS_SETTINGS_FILE 2>/dev/null || true
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+
+echo "=== an amend is judged against the parent it will HAVE, not the HEAD it replaces ==="
+# `git diff --cached` on an amend shows only what was staged ON TOP of the
+# commit being replaced, so a fragment already inside that commit read as no
+# fragment at all and a commit satisfying the rule was refused — with the
+# obvious escape being the flag that skips the whole hook chain. These run
+# through a real `git commit`, because which parent the commit will have is
+# read off that process and nowhere else.
+AM_REPO="$TMP/repo-amend"
+mkdir -p "$AM_REPO/crates/core" "$AM_REPO/changelog.d/fixed"
+git -C "$AM_REPO" -c init.defaultBranch=main init -q
+git -C "$AM_REPO" config user.email test@example.com
+git -C "$AM_REPO" config user.name test
+printf '#!/bin/sh\nexec %s "$1"\n' "$CM" >"$AM_REPO/.git/hooks/commit-msg"
+chmod +x "$AM_REPO/.git/hooks/commit-msg"
+printf '[env]\nGROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS = "crates/* ui/*"\n' >"$AM_REPO/kendex.settings.toml"
+printf 'seed\n' >"$AM_REPO/README.md"
+git -C "$AM_REPO" add -A
+git -C "$AM_REPO" commit -qm "chore: base [no-changelog]" >/dev/null 2>&1
+
+am_commit() { # MESSAGE [git-commit-arg...] — a real commit; sets OUT and RC
+  OUT=""
+  RC=0
+  OUT="$(git -C "$AM_REPO" commit -m "$1" "${@:2}" 2>&1)" || RC=$?
+}
+
+printf 'fn one() {}\n' >"$AM_REPO/crates/core/lib.rs"
+printf -- '- A fix consumers see.\n' >"$AM_REPO/changelog.d/fixed/ken-1.md"
+git -C "$AM_REPO" add -A
+am_commit 'fix(KEN-1): change a crate'
+[ "$RC" -eq 0 ] && ok "fixture: the crate change lands with its fragment" \
+  || bad "fixture: the crate change lands with its fragment" "rc=$RC out=$OUT"
+
+printf 'fn two() {}\n' >>"$AM_REPO/crates/core/lib.rs"
+git -C "$AM_REPO" add -A
+am_commit 'fix(KEN-1): change a crate' --amend
+[ "$RC" -eq 0 ] && ok "an amend adding more code passes on the fragment the commit already carries" \
+  || bad "an amend passes on the fragment the commit already carries" "rc=$RC out=$OUT"
+
+# The control that reds when the amend case goes: the widening is bound to the
+# amend, so the NEXT commit — a new one, whose parent really is that HEAD —
+# is not excused by the fragment sitting in the commit before it.
+printf 'fn three() {}\n' >>"$AM_REPO/crates/core/lib.rs"
+git -C "$AM_REPO" add -A
+am_commit 'fix(KEN-2): change a crate again'
+[ "$RC" -eq 1 ] && case "$OUT" in *"crates/core/lib.rs changed without a changelog entry"*) true ;; *) false ;; esac \
+  && ok "control: the commit AFTER a fragment commit still owes its own entry" \
+  || bad "control: the commit after a fragment commit still owes its own entry" "rc=$RC out=$OUT"
+git -C "$AM_REPO" reset -q --hard HEAD
+
+# And an amend of a commit that carries no fragment is refused, naming the
+# path: reading the whole commit is what widened, not the rule.
+git -C "$AM_REPO" commit -q --allow-empty -m 'chore: nothing a consumer sees' >/dev/null 2>&1
+printf 'fn four() {}\n' >>"$AM_REPO/crates/core/lib.rs"
+git -C "$AM_REPO" add -A
+am_commit 'fix(KEN-3): change a crate' --amend
+[ "$RC" -eq 1 ] && case "$OUT" in *"crates/core/lib.rs changed without a changelog entry"*) true ;; *) false ;; esac \
+  && ok "control: an amend of a fragmentless commit is refused, naming the path" \
+  || bad "control: an amend of a fragmentless commit is refused" "rc=$RC out=$OUT"
+git -C "$AM_REPO" reset -q --hard HEAD
+git -C "$AM_REPO" reset -q --hard HEAD~1
+
+# An amend that DROPS the fragment owes one again: what counts is the tree the
+# commit will have, never that HEAD once held an entry.
+git -C "$AM_REPO" rm -q --cached changelog.d/fixed/ken-1.md
+rm -f "$AM_REPO/changelog.d/fixed/ken-1.md"
+am_commit 'fix(KEN-1): change a crate' --amend
+[ "$RC" -eq 1 ] && case "$OUT" in *"crates/core/lib.rs changed without a changelog entry"*) true ;; *) false ;; esac \
+  && ok "control: an amend that drops the fragment owes one again" \
+  || bad "control: an amend that drops the fragment owes one again" "rc=$RC out=$OUT"
+git -C "$AM_REPO" reset -q --hard HEAD
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.agents/skills/growth-guards/tests/commit-msg-amend.test.sh
+++ b/.agents/skills/growth-guards/tests/commit-msg-amend.test.sh
@@ -3,10 +3,8 @@
 # the changelog a commit owes is read against the parent the commit will HAVE,
 # so an amend is judged against HEAD's parent, not the HEAD it replaces. Three
 # kinds of pin, because the answer is read off a process — a real `git commit`
-# for the rule end to end, each firing pin against the control that reds when
-# the widening stops being bound to the amend; an argv FILE for which argv IS
-# an amend, one spelling per line; and a FAKE `git`, a copy of bash under that
-# name, for the arms that need a process.
+# for the rule end to end, each firing pin against its control; an argv FILE for
+# which argv IS an amend; and a FAKE `git`, for the arms that need a process.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -26,11 +24,18 @@ bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
 skip() { printf '  skip  %s\n' "$1"; }
 
 # The widening is read off /proc/<pid>/cmdline and nowhere else, so a host
-# without procfs — macOS, which this family supports — answers "not an amend".
-# A pin asserting the widening is skipped there, named, rather than reporting a
-# portability fact as a defect; the refusal controls and argv pins are not.
+# without procfs — macOS, which this family supports — answers "not an amend",
+# and a pin asserting the widening is SKIPPED there rather than reporting a
+# portability fact as a defect. On Linux it is not a portability fact: a
+# hardened kernel or a break in the detection would hide every widening pin
+# below behind a green run, so that pair REDS rather than skipping.
 HAVE_PROC=0
 if [ -r "/proc/$$/cmdline" ]; then HAVE_PROC=1; fi
+if [ "$(uname -s)" = Linux ] && [ "$HAVE_PROC" -eq 0 ]; then
+  bad "the /proc gate is honest" "Linux with /proc/$$/cmdline unreadable: every widening pin would skip"
+else
+  ok "the /proc gate is honest — a skip below means /proc is absent by design"
+fi
 
 mk_repo() { # DIR — a repo with the commit-msg hook installed and the rule armed
   mkdir -p "$1/crates/core" "$1/changelog.d/fixed"

--- a/.agents/skills/growth-guards/tests/commit-msg-amend.test.sh
+++ b/.agents/skills/growth-guards/tests/commit-msg-amend.test.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 # Pins for the one commit-msg rule that cannot be judged from an index alone:
 # the changelog a commit owes is read against the parent the commit will HAVE,
-# so an amend is judged against HEAD's parent, not the HEAD it replaces. Three
-# kinds of pin, because the answer is read off a process — a real `git commit`
-# for the rule end to end, each firing pin against its control; an argv FILE for
-# which argv IS an amend; and a FAKE `git`, for the arms that need a process.
+# so an amend is judged against HEAD's parent, not the HEAD it replaces. Four
+# pins, each firing one against its control: a real `git commit` for the rule
+# end to end, and an argv FILE for which argv IS an amend.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -25,17 +24,10 @@ skip() { printf '  skip  %s\n' "$1"; }
 
 # The widening is read off /proc/<pid>/cmdline and nowhere else, so a host
 # without procfs — macOS, which this family supports — answers "not an amend",
-# and a pin asserting the widening is SKIPPED there rather than reporting a
-# portability fact as a defect. On Linux it is not a portability fact: a
-# hardened kernel or a break in the detection would hide every widening pin
-# below behind a green run, so that pair REDS rather than skipping.
+# and the pair of pins asserting the widening is SKIPPED there rather than
+# reporting a portability fact as a defect.
 HAVE_PROC=0
 if [ -r "/proc/$$/cmdline" ]; then HAVE_PROC=1; fi
-if [ "$(uname -s)" = Linux ] && [ "$HAVE_PROC" -eq 0 ]; then
-  bad "the /proc gate is honest" "Linux with /proc/$$/cmdline unreadable: every widening pin would skip"
-else
-  ok "the /proc gate is honest — a skip below means /proc is absent by design"
-fi
 
 mk_repo() { # DIR — a repo with the commit-msg hook installed and the rule armed
   mkdir -p "$1/crates/core" "$1/changelog.d/fixed"
@@ -46,29 +38,22 @@ mk_repo() { # DIR — a repo with the commit-msg hook installed and the rule arm
   chmod +x "$1/.git/hooks/commit-msg"
   printf '[env]\nGROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS = "crates/* ui/*"\n' >"$1/kendex.settings.toml"
 }
-seed_commit() { # DIR — the base commit an amend below sits on
-  printf 'seed\n' >"$1/README.md"
-  git -C "$1" add -A
-  git -C "$1" commit -qm "chore: base [no-changelog]" >/dev/null 2>&1
-}
-crate_commit() { # DIR — a commit changing a crate and carrying its fragment
-  printf 'fn one() {}\n' >"$1/crates/core/lib.rs"
-  printf -- '- A fix consumers see.\n' >"$1/changelog.d/fixed/ken-1.md"
-  git -C "$1" add -A
-  commit_in "$1" 'fix(KEN-1): change a crate'
-}
-more_code() { # DIR — another crate change, staged
-  printf 'fn two() {}\n' >>"$1/crates/core/lib.rs"
-  git -C "$1" add -A
-}
-commit_in() { # DIR MESSAGE [git-commit-arg...] — a real commit; sets OUT and RC
+commit_in() { # DIR ARG... — a real commit; sets OUT and RC
   OUT=""; RC=0
-  OUT="$(git -C "$1" commit -m "$2" "${@:3}" 2>&1)" || RC=$?
+  OUT="$(git -C "$1" commit "${@:2}" 2>&1)" || RC=$?
 }
-new_repo() { # NAME — a fresh seeded repo at $TMP/NAME, named by R; one fixture
-  R="$TMP/$1"          # per pin, so a pin skipped for want of /proc leaves
-  mk_repo "$R"         # nothing for the next to inherit
-  seed_commit "$R"
+staged_on_fragment() { # NAME — HEAD carries a crate change and its fragment,
+  R="$TMP/$1"          # more crate code is staged on top, and nothing else is.
+  mk_repo "$R"         # One fixture per pin, named by R, so a pin skipped for
+  printf 'seed\n' >"$R/README.md"   # want of /proc leaves nothing behind.
+  git -C "$R" add -A
+  git -C "$R" commit -qm "chore: base [no-changelog]" >/dev/null 2>&1
+  printf 'fn one() {}\n' >"$R/crates/core/lib.rs"
+  printf -- '- A fix consumers see.\n' >"$R/changelog.d/fixed/ken-1.md"
+  git -C "$R" add -A
+  commit_in "$R" -m 'fix(KEN-1): change a crate'
+  printf 'fn two() {}\n' >>"$R/crates/core/lib.rs"
+  git -C "$R" add -A
 }
 refused_naming_lib() { # 0 when RC/OUT are the refusal that names the crate path
   [ "$RC" -eq 1 ] || return 1
@@ -81,12 +66,11 @@ echo "=== an amend is judged against the parent it will HAVE, not the HEAD it re
 # commit being replaced, so a fragment already inside that commit read as no
 # fragment at all and a commit satisfying the rule was refused, the obvious
 # escape being the flag that skips the whole hook chain. The control that reds
-# when that goes, and the one pin here needing no /proc: the NEXT commit, whose
-# parent really is that HEAD, is not excused by the fragment in the one before.
-new_repo repo-next
-crate_commit "$R"
-more_code "$R"
-commit_in "$R" 'fix(KEN-2): change a crate again'
+# when the widening goes too far, and the one pin here needing no /proc: the
+# NEXT commit, whose parent really is that HEAD, is not excused by the fragment
+# in the one before.
+staged_on_fragment repo-next
+commit_in "$R" -m 'fix(KEN-2): change a crate again'
 refused_naming_lib \
   && ok "control: the commit AFTER a fragment commit still owes its own entry" \
   || bad "control: the commit after a fragment commit still owes its own entry" "rc=$RC out=$OUT"
@@ -94,142 +78,32 @@ refused_naming_lib \
 if [ "$HAVE_PROC" -eq 0 ]; then
   skip "the widening pins need /proc/<pid>/cmdline, where the committing argv is read"
 else
-  new_repo repo-amend
-  crate_commit "$R"
-  more_code "$R"
-  commit_in "$R" 'fix(KEN-1): change a crate' --amend
+  staged_on_fragment repo-amend
+  commit_in "$R" --amend --no-edit
   [ "$RC" -eq 0 ] && ok "an amend adding more code passes on the fragment the commit already carries" \
     || bad "an amend passes on the fragment the commit already carries" "rc=$RC out=$OUT"
 
-  # What counts is the tree the commit will have, never that HEAD once held an
-  # entry. Gated too: without the widening the base is HEAD, the dropped
-  # fragment is the only change the diff shows, and no required path is in it.
-  new_repo repo-dropped
-  crate_commit "$R"
-  git -C "$R" rm -q --cached changelog.d/fixed/ken-1.md
-  rm -f "$R/changelog.d/fixed/ken-1.md"
-  commit_in "$R" 'fix(KEN-1): change a crate' --amend
+  # MUST-FAIL: `--mess` is git's abbreviation of `--message`, so the `--amend`
+  # behind it is the committer's message TEXT, not the flag. A scan reading the
+  # flag out of a value fails open, excusing this commit with the fragment the
+  # previous one carries; the widening is what that class attacks, and every
+  # fail-open this lane had came from it.
+  staged_on_fragment repo-value
+  commit_in "$R" --mess '--amend'
   refused_naming_lib \
-    && ok "control: an amend that drops the fragment owes one again" \
-    || bad "control: an amend that drops the fragment owes one again" "rc=$RC out=$OUT"
-
-  # Amending a repository's FIRST commit: HEAD^ does not resolve, so the base
-  # is the hashed empty tree. Same branch on the tip of a shallow clone.
-  R="$TMP/repo-root"
-  mk_repo "$R"
-  crate_commit "$R"
-  more_code "$R"
-  commit_in "$R" 'fix(KEN-1): change a crate' --amend
-  [ "$RC" -eq 0 ] && [ -z "$(git -C "$R" rev-parse --verify --quiet HEAD^ 2>/dev/null)" ] \
-    && ok "an amend of the ROOT commit passes on the fragment it carries" \
-    || bad "an amend of the root commit passes on the fragment it carries" "rc=$RC out=$OUT"
+    && ok "must-fail: a message VALUE spelling the flag does not widen the base" \
+    || bad "a message value spelling the flag must not widen the base" "rc=$RC out=$OUT"
 fi
 
 echo '=== which argv is an amend ==='
-# One spelling per pin, as the NUL-delimited bytes the kernel would hold. git
-# takes any unambiguous ABBREVIATION and resolves a boolean to its LAST
-# spelling, so the refusals below are what a scan matching full names by
-# equality got wrong in the FAIL-OPEN direction: it read the flag out of a
-# value the committer chose, and the previous commit's fragment excused a
-# commit carrying none.
+# The NUL-delimited bytes the kernel would hold. A message is an argument like
+# any other, so the flag BEHIND one is still the flag: nothing dash-prefixed
+# stands before it to have swallowed it.
 ARGV="$TMP/argv"
-argv_pin() { # LABEL WANT ARG... — WANT is `amend` or `plain`
-  local label="$1" want="$2" got=plain
-  shift 2
-  printf '%s\0' "$@" >"$ARGV"
-  if gg_argv_is_amend "$ARGV"; then got=amend; fi
-  [ "$got" = "$want" ] && ok "$label" || bad "$label" "read as $got, wanted $want"
-}
-argv_pin "the flag itself is the flag" amend git commit --amend
-argv_pin "the flag BEHIND a message is the flag: the message is not dash-prefixed" amend git commit -m 'fix(KEN-1): change a crate' --amend
-argv_pin "--am is git's abbreviation of it, an amend this lane must widen for" amend git commit --am
-argv_pin "a no-value option ahead of the flag is stepped over" amend git commit --no-edit --amend
-argv_pin "a no-value SHORT option ahead of the flag is stepped over" amend git commit -a --amend
-argv_pin "a rebase reword's own argv widens" amend git commit --amend --no-gpg-sign -e --allow-empty
-argv_pin "the wrapper's arguments, ahead of the subcommand, are not the commit's" amend git -c user.name=x commit --amend --no-edit
-argv_pin "the flag BEFORE a value-taking option is still the flag" amend git commit --amend -m 'fix(KEN-1): change a crate'
-argv_pin "must-fail: the argument -m consumes IS the message" plain git commit -m --amend
-argv_pin "must-fail: --mess is that same option, abbreviated" plain git commit --mess --amend
-argv_pin "must-fail: --templ takes a template path" plain git commit --templ --amend
-argv_pin "must-fail: --trail takes a trailer" plain git commit --trail --amend
-argv_pin "must-fail: --fil takes a message file" plain git commit --fil --amend
-argv_pin "must-fail: an attached --message=… carries its value in the token" plain git commit --message=--amend
-argv_pin "must-fail: a short BUNDLE's -m consumes the argument behind it" plain git commit -am --amend
-argv_pin "must-fail: an argument after the bare -- is a pathspec" plain git commit -- crates/core/lib.rs --amend
-argv_pin "must-fail: --no-amend behind the flag is git's last-spelling boolean" plain git commit --amend --no-amend -m 'fix(KEN-2): change a crate'
-argv_pin "must-fail: an unknown token cannot swallow the negation git honours" plain git commit --amend --no-status --no-amend -m 'fix(KEN-2): change a crate'
-argv_pin "must-fail: an argv that never reaches the commit subcommand is not one" plain git rebase --amend
-
-echo "=== what the WALK reads, through a FAKE git ancestor ==="
-# The fixture stands still: HEAD carries the crate change and its fragment,
-# HEAD^ carries neither, and the index holds HEAD's tree plus more code. Judged
-# against HEAD^ the fragment is in the diff and the run passes; judged against
-# HEAD only the crate change is, and the run is refused. One bit, either way.
-if [ "$HAVE_PROC" -eq 0 ]; then
-  skip "the ancestor-walk pins need /proc/<pid>/cmdline: with no procfs there is no argv to read"
-else
-  FK_REPO="$TMP/repo-fake"
-  mk_repo "$FK_REPO"
-  rm -f "$FK_REPO/.git/hooks/commit-msg"
-  seed_commit "$FK_REPO"
-  crate_commit "$FK_REPO"
-  more_code "$FK_REPO"
-  FK_MSG="$TMP/fake-message.txt"
-  printf 'fix(KEN-1): change a crate\n' >"$FK_MSG"
-  FAKE_BIN="$TMP/fake-bin"
-  mkdir -p "$FAKE_BIN"
-  cp -- "${BASH:-$(command -v bash)}" "$FAKE_BIN/git"
-  # The fake ancestor is bash, and its `-c` script is all it is given, so it
-  # reads these out of the environment. `exit $s` LAST is load-bearing: bash
-  # execs the final command of a `-c` script, which for a lone `"$CM" …` would
-  # replace the fake ancestor with commit-msg and erase the very process the
-  # scan is about. A builtin is the one ending it cannot exec away.
-  export CM FK_MSG FAKE_BIN
-  FAKE_RUN='"$CM" "$FK_MSG"; s=$?; exit $s'
-  export FAKE_RUN
-  fake_git() { # ARG... — commit-msg under a `git` ancestor whose argv is ARG...
-    OUT=""; RC=0
-    OUT="$(cd "$FK_REPO" && GIT_INDEX_FILE="$FK_REPO/.git/index" \
-      "$FAKE_BIN/git" -c "$FAKE_RUN" "$@" 2>&1)" || RC=$?
-  }
-
-  # MUST-FAIL: git sets GIT_INDEX_FILE for the hooks it runs a commit through,
-  # so its absence means a DIRECT run — a person, a script, one of this
-  # family's own suites under a developer's `git commit --amend` — whose
-  # ancestors say nothing about what it judges.
-  OUT=""; RC=0
-  OUT="$(cd "$FK_REPO" && "$FAKE_BIN/git" -c "$FAKE_RUN" commit --amend 2>&1)" || RC=$?
-  refused_naming_lib \
-    && ok "must-fail: a git ancestor with the flag but no GIT_INDEX_FILE is not this run's commit" \
-    || bad "a git ancestor with no GIT_INDEX_FILE must not widen" "rc=$RC out=$OUT"
-
-  fake_git commit --amend
-  [ "$RC" -eq 0 ] && ok "the walk finds the flag on the nearest git ancestor and widens" \
-    || bad "the walk finds the flag on the nearest git ancestor" "rc=$RC out=$OUT"
-
-  # MUST-FAIL: the walk stops at the NEAREST git ancestor, the command doing
-  # the committing. A `git rebase` above it answers for something else, so a
-  # climb past the inner git judges a commit against a parent it does not have.
-  OUT=""
-  RC=0
-  NEST_RUN='"$FAKE_BIN/git" -c "$FAKE_RUN" commit; s=$?; exit $s'
-  OUT="$(cd "$FK_REPO" && GIT_INDEX_FILE="$FK_REPO/.git/index" \
-    "$FAKE_BIN/git" -c "$NEST_RUN" commit --amend 2>&1)" || RC=$?
-  refused_naming_lib \
-    && ok "must-fail: an inner git WITHOUT the flag answers, not an outer git with it" \
-    || bad "the walk must stop at the nearest git ancestor" "rc=$RC out=$OUT"
-
-  # The depth walk: a generation carrying no git sits between the committing
-  # process and the hook, so a cap of one generation would never reach the git
-  # above it.
-  OUT=""
-  RC=0
-  DEPTH_RUN='bash -c "$FAKE_RUN"; s=$?; exit $s'
-  OUT="$(cd "$FK_REPO" && GIT_INDEX_FILE="$FK_REPO/.git/index" \
-    "$FAKE_BIN/git" -c "$DEPTH_RUN" commit --amend 2>&1)" || RC=$?
-  [ "$RC" -eq 0 ] && ok "the walk climbs past a generation carrying no git" \
-    || bad "the walk climbs past a generation carrying no git" "rc=$RC out=$OUT"
-fi
+printf '%s\0' git commit -m 'fix(KEN-1): change a crate' --amend >"$ARGV"
+gg_argv_is_amend "$ARGV" \
+  && ok "the flag behind a message is the flag" \
+  || bad "the flag behind a message is the flag" "read as plain, wanted amend"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.agents/skills/growth-guards/tests/commit-msg-amend.test.sh
+++ b/.agents/skills/growth-guards/tests/commit-msg-amend.test.sh
@@ -62,11 +62,8 @@ more_code() { # DIR — another crate change, staged
   git -C "$1" add -A
 }
 commit_in() { # DIR MESSAGE [git-commit-arg...] — a real commit; sets OUT and RC
-  # The flag goes AHEAD of `-m`, which is where the scan reads it: `-m` is a
-  # token the scan does not understand, because the argument behind it is the
-  # committer's to choose, and one of those ends the scan at "not an amend".
   OUT=""; RC=0
-  OUT="$(git -C "$1" commit "${@:3}" -m "$2" 2>&1)" || RC=$?
+  OUT="$(git -C "$1" commit -m "$2" "${@:3}" 2>&1)" || RC=$?
 }
 new_repo() { # NAME — a fresh seeded repo at $TMP/NAME, named by R; one fixture
   R="$TMP/$1"          # per pin, so a pin skipped for want of /proc leaves
@@ -144,12 +141,13 @@ argv_pin() { # LABEL WANT ARG... — WANT is `amend` or `plain`
   [ "$got" = "$want" ] && ok "$label" || bad "$label" "read as $got, wanted $want"
 }
 argv_pin "the flag itself is the flag" amend git commit --amend
+argv_pin "the flag BEHIND a message is the flag: the message is not dash-prefixed" amend git commit -m 'fix(KEN-1): change a crate' --amend
 argv_pin "--am is git's abbreviation of it, an amend this lane must widen for" amend git commit --am
 argv_pin "a no-value option ahead of the flag is stepped over" amend git commit --no-edit --amend
 argv_pin "a rebase reword's own argv widens" amend git commit --amend --no-gpg-sign -e --allow-empty
 argv_pin "the wrapper's arguments, ahead of the subcommand, are not the commit's" amend git -c user.name=x commit --amend --no-edit
 argv_pin "the flag BEFORE a value-taking option is still the flag" amend git commit --amend -m 'fix(KEN-1): change a crate'
-argv_pin "must-fail: the argument -m consumes is a message" plain git commit -m --amend
+argv_pin "must-fail: the argument -m consumes IS the message" plain git commit -m --amend
 argv_pin "must-fail: --mess is that same option, abbreviated" plain git commit --mess --amend
 argv_pin "must-fail: --templ takes a template path" plain git commit --templ --amend
 argv_pin "must-fail: --trail takes a trailer" plain git commit --trail --amend

--- a/.agents/skills/growth-guards/tests/commit-msg-amend.test.sh
+++ b/.agents/skills/growth-guards/tests/commit-msg-amend.test.sh
@@ -144,6 +144,7 @@ argv_pin "the flag itself is the flag" amend git commit --amend
 argv_pin "the flag BEHIND a message is the flag: the message is not dash-prefixed" amend git commit -m 'fix(KEN-1): change a crate' --amend
 argv_pin "--am is git's abbreviation of it, an amend this lane must widen for" amend git commit --am
 argv_pin "a no-value option ahead of the flag is stepped over" amend git commit --no-edit --amend
+argv_pin "a no-value SHORT option ahead of the flag is stepped over" amend git commit -a --amend
 argv_pin "a rebase reword's own argv widens" amend git commit --amend --no-gpg-sign -e --allow-empty
 argv_pin "the wrapper's arguments, ahead of the subcommand, are not the commit's" amend git -c user.name=x commit --amend --no-edit
 argv_pin "the flag BEFORE a value-taking option is still the flag" amend git commit --amend -m 'fix(KEN-1): change a crate'
@@ -154,8 +155,9 @@ argv_pin "must-fail: --trail takes a trailer" plain git commit --trail --amend
 argv_pin "must-fail: --fil takes a message file" plain git commit --fil --amend
 argv_pin "must-fail: an attached --message=… carries its value in the token" plain git commit --message=--amend
 argv_pin "must-fail: a short BUNDLE's -m consumes the argument behind it" plain git commit -am --amend
-argv_pin "must-fail: an argument after the bare -- is a pathspec" plain git commit -- --amend
+argv_pin "must-fail: an argument after the bare -- is a pathspec" plain git commit -- crates/core/lib.rs --amend
 argv_pin "must-fail: --no-amend behind the flag is git's last-spelling boolean" plain git commit --amend --no-amend -m 'fix(KEN-2): change a crate'
+argv_pin "must-fail: an unknown token cannot swallow the negation git honours" plain git commit --amend --no-status --no-amend -m 'fix(KEN-2): change a crate'
 argv_pin "must-fail: an argv that never reaches the commit subcommand is not one" plain git rebase --amend
 
 echo "=== what the WALK reads, through a FAKE git ancestor ==="

--- a/changelog.d/fixed/KEN-808.md
+++ b/changelog.d/fixed/KEN-808.md
@@ -1,0 +1,1 @@
+- `git commit --amend` no longer demands a changelog entry the commit already carries: the commit-msg gate judges an amend against the parent it will have.

--- a/changelog.d/fixed/KEN-808.md
+++ b/changelog.d/fixed/KEN-808.md
@@ -1,1 +1,1 @@
-- `git commit --amend` no longer demands a changelog entry the commit already carries: the commit-msg gate judges an amend against the parent it will have.
+- On Linux, `git commit --amend` no longer demands a changelog entry the commit already carries: the commit-msg gate judges an amend against the parent it will have.

--- a/skills/growth-guards/CHECKS.md
+++ b/skills/growth-guards/CHECKS.md
@@ -340,7 +340,7 @@ uppercase issue keys (`fix(ABC-123): ...`) and issue numbers
 longer header is a body sentence on the line every log shows.
 
 **The changelog a commit owes.** When `GROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS`
-(empty by default) names a glob some staged path matches, the commit must also
+(empty by default) names a glob a path the commit changes matches, it must also
 add or modify a path under `GROWTH_GUARDS_CHANGELOG_PATHS` — the fragment
 scope changelog-entries judges, resolved by the same library — or carry
 `[no-changelog]` in the header. Deleting a fragment is not writing one, so
@@ -361,6 +361,19 @@ source loses its content, the destination gains it — and a chmod is a touch
 and nothing else, because its blob did not move. A letter that says only
 "modified" cannot tell a rewrite from a permission bit, and a changelog
 requirement satisfied by one is a requirement satisfied by nothing.
+
+Both lists are read against the parent the commit will HAVE, which is HEAD for
+an ordinary commit and HEAD's own parent for an amend. `--cached` alone shows
+what was staged ON TOP of the commit an amend replaces, so a fragment already
+inside that commit read as no fragment at all and the lane refused a commit
+that satisfied it — with the escape being the flag that skips the whole hook
+chain. git tells a `commit-msg` hook nothing about an amend, so the lane reads
+it off the argv of the `git commit` process it is a descendant of: only when
+`GIT_INDEX_FILE` says this run is a hook git started, and only from the
+nearest `git` ancestor, which is the command doing the committing. Anything
+unreadable — no `/proc`, the process already gone, no `git` in eight
+generations — is not an amend, so the lane widens only where it can prove the
+parent moved.
 
 `GROWTH_GUARDS_CHANGELOG_RECORD` counts as that entry only under
 `GROWTH_GUARDS_CHANGELOG_COLLATE=1`, the same declaration the record scope

--- a/skills/growth-guards/CHECKS.md
+++ b/skills/growth-guards/CHECKS.md
@@ -373,15 +373,15 @@ the nearest `git` ancestor, the command doing the committing.
 
 Some of those bytes are the committer's own, so `--amend` counts as the flag
 only where nothing could have been reaching for a value. A value-taking option
-consumes the NEXT argument and nothing further, so the one token that can
-swallow the flag is the one immediately before it: dash-prefixed and not a
-no-value option means it did, with long names matched by prefix the way git
-matches an abbreviation. That refuses `--mess --amend`, `-am --amend`,
-`--message=--amend` and an option a later git ships — refusals the writer
-clears with `[no-changelog]` or a fragment, never a commit excused by an entry
-it does not carry. Anything else never reached for a value, so `git commit -m
-'msg' --amend` is the amend it is. `--no-amend` takes the flag back under the
-same guard; the bare `--` stops the scan.
+consumes the NEXT argument and nothing further, so that one token decides it,
+read by SHAPE and not by content: dash-prefixed and not a no-value option means
+it swallowed the flag. The refusal covers an attached value and a bundle too,
+whatever the token holds — `--mess --amend`, `--message='a real message'
+--amend`, `-am --amend`, `--status --amend` — and the writer clears it with a
+fragment or `[no-changelog]`. Anything else never reached, so `git commit -m
+'msg' --amend` is the amend it is. `--no-amend` is read whatever stands before
+it, since a missed flag costs a refusal but a missed negation leaves a stale
+`--amend` standing; the bare `--` stops the scan.
 
 Nothing readable is nothing to widen on: a process already gone, no `git` in
 eight generations, or no `/proc` at all, which is every macOS host, where an

--- a/skills/growth-guards/CHECKS.md
+++ b/skills/growth-guards/CHECKS.md
@@ -340,9 +340,10 @@ uppercase issue keys (`fix(ABC-123): ...`) and issue numbers
 longer header is a body sentence on the line every log shows.
 
 **The changelog a commit owes.** When `GROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS`
-(empty by default) names a glob a path the commit changes matches, it must also
-add or modify a path under `GROWTH_GUARDS_CHANGELOG_PATHS` — the fragment
-scope changelog-entries judges, resolved by the same library — or carry
+(empty by default) names a glob that a path the commit changes matches, the
+commit must also add or modify a path under `GROWTH_GUARDS_CHANGELOG_PATHS`
+— the fragment scope changelog-entries judges, resolved by the same library
+— or carry
 `[no-changelog]` in the header. Deleting a fragment is not writing one, so
 evidence is a path that comes out of the commit carrying content it did not
 carry at that path before: a blob where there was none, a blob that changed,
@@ -352,7 +353,7 @@ there was none), or the destination of a rename. A mode and a sha together
 are what identify a record; either alone lets a transition through. What that path became is changelog-entries'
 judgement, running beside this one.
 
-The staged list comes from `--raw`, the spelling `todo-ban` and
+The commit's file list comes from `--raw`, the spelling `todo-ban` and
 `byte-ceiling` already use, with rename detection pinned rather than
 inherited. A raw record carries the old and new mode and the old and new blob
 for every path, so what the commit did to a file is read off the record
@@ -368,12 +369,29 @@ what was staged ON TOP of the commit an amend replaces, so a fragment already
 inside that commit read as no fragment at all and the lane refused a commit
 that satisfied it — with the escape being the flag that skips the whole hook
 chain. git tells a `commit-msg` hook nothing about an amend, so the lane reads
-it off the argv of the `git commit` process it is a descendant of: only when
-`GIT_INDEX_FILE` says this run is a hook git started, and only from the
-nearest `git` ancestor, which is the command doing the committing. Anything
-unreadable — no `/proc`, the process already gone, no `git` in eight
-generations — is not an amend, so the lane widens only where it can prove the
-parent moved.
+it off the argv of the `git commit` process it is a descendant of, in
+`/proc/<pid>/cmdline`: only when `GIT_INDEX_FILE` says this run is a hook git
+started, and only from the nearest `git` ancestor, which is the command doing
+the committing. That argv is read the way git's own parser reads it — the
+scan stops at the bare `--`, steps over the argument a value-taking option
+consumes, and takes the kernel's NUL delimiters so an argument carrying
+whitespace or a newline stays one argument — so a message or a pathspec
+spelling `--amend` is a message or a pathspec, never the flag.
+
+Anything unreadable is not an amend: the process already gone, no `git` in
+eight generations, or no `/proc` at all — which is every macOS host, where
+argv is not on the filesystem. There the widening never fires and an amend is
+judged against the HEAD it replaces, exactly as before this rule read the
+parent. So the lane widens only where it can prove the parent moved, and a
+`ps` reading is deliberately not the fallback: `ps` joins argv with spaces, so
+a message merely CONTAINING `--amend` would excuse a commit.
+
+A rebase `reword` or `edit` runs `git commit --amend` as a child of the
+rebase, so it is an amend by this reading and judged against the whole
+historical commit. Rewording a commit that changes a required path and
+predates the rule needs `[no-changelog]` in the reworded header. A plain
+all-`pick` rebase and an autosquash fixup are unaffected: the sequencer
+commits those in-process, with no `git commit` ancestor to read.
 
 `GROWTH_GUARDS_CHANGELOG_RECORD` counts as that entry only under
 `GROWTH_GUARDS_CHANGELOG_COLLATE=1`, the same declaration the record scope

--- a/skills/growth-guards/CHECKS.md
+++ b/skills/growth-guards/CHECKS.md
@@ -340,10 +340,9 @@ uppercase issue keys (`fix(ABC-123): ...`) and issue numbers
 longer header is a body sentence on the line every log shows.
 
 **The changelog a commit owes.** When `GROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS`
-(empty by default) names a glob that a path the commit changes matches, the
-commit must also add or modify a path under `GROWTH_GUARDS_CHANGELOG_PATHS`
-— the fragment scope changelog-entries judges, resolved by the same library
-— or carry
+(empty by default) names a glob a path the commit changes matches, the commit
+must also add or modify a path under `GROWTH_GUARDS_CHANGELOG_PATHS` — the
+fragment scope changelog-entries judges, resolved by the same library — or carry
 `[no-changelog]` in the header. Deleting a fragment is not writing one, so
 evidence is a path that comes out of the commit carrying content it did not
 carry at that path before: a blob where there was none, a blob that changed,
@@ -363,35 +362,37 @@ and nothing else, because its blob did not move. A letter that says only
 "modified" cannot tell a rewrite from a permission bit, and a changelog
 requirement satisfied by one is a requirement satisfied by nothing.
 
-Both lists are read against the parent the commit will HAVE, which is HEAD for
-an ordinary commit and HEAD's own parent for an amend. `--cached` alone shows
-what was staged ON TOP of the commit an amend replaces, so a fragment already
-inside that commit read as no fragment at all and the lane refused a commit
-that satisfied it — with the escape being the flag that skips the whole hook
-chain. git tells a `commit-msg` hook nothing about an amend, so the lane reads
-it off the argv of the `git commit` process it is a descendant of, in
-`/proc/<pid>/cmdline`: only when `GIT_INDEX_FILE` says this run is a hook git
-started, and only from the nearest `git` ancestor, which is the command doing
-the committing. That argv is read the way git's own parser reads it — the
-scan stops at the bare `--`, steps over the argument a value-taking option
-consumes, and takes the kernel's NUL delimiters so an argument carrying
-whitespace or a newline stays one argument — so a message or a pathspec
-spelling `--amend` is a message or a pathspec, never the flag.
+Both lists are read against the parent the commit will HAVE, HEAD ordinarily
+and HEAD's own parent for an amend. `--cached` alone shows only what was staged
+ON TOP of the commit an amend replaces, so a fragment already inside that
+commit read as no fragment at all and the lane refused a commit that satisfied
+it. git tells a `commit-msg` hook nothing about an amend, so the lane reads it
+off the argv of the `git commit` it descends from, in `/proc/<pid>/cmdline`,
+only when `GIT_INDEX_FILE` says this run is a hook git started and only from
+the nearest `git` ancestor, the command doing the committing.
 
-Anything unreadable is not an amend: the process already gone, no `git` in
-eight generations, or no `/proc` at all — which is every macOS host, where
-argv is not on the filesystem. There the widening never fires and an amend is
-judged against the HEAD it replaces, exactly as before this rule read the
-parent. So the lane widens only where it can prove the parent moved, and a
-`ps` reading is deliberately not the fallback: `ps` joins argv with spaces, so
-a message merely CONTAINING `--amend` would excuse a commit.
+Some of those bytes are the committer's own, so `--amend` counts as the flag
+only where nothing ahead of it could have been reaching for a value: after the
+`commit` subcommand, every token between the two a no-value option, matched by
+prefix the way git matches an abbreviation. `--no-amend` behind the flag takes
+it back and the bare `--` stops the scan, both as git reads them. Everything
+else is not an amend — `-m --amend`, `--mess --amend`, `--message=--amend`,
+`-am`, a pathspec, an option a later git adds — a refusal the writer clears
+with `[no-changelog]` or a fragment, never a commit excused by an entry it does
+not carry. It costs `git commit -m … --amend`, the flag behind the message,
+read as an ordinary commit; put the flag ahead of `-m`.
 
-A rebase `reword` or `edit` runs `git commit --amend` as a child of the
-rebase, so it is an amend by this reading and judged against the whole
-historical commit. Rewording a commit that changes a required path and
-predates the rule needs `[no-changelog]` in the reworded header. A plain
-all-`pick` rebase and an autosquash fixup are unaffected: the sequencer
-commits those in-process, with no `git commit` ancestor to read.
+Nothing readable is nothing to widen on: a process already gone, no `git` in
+eight generations, or no `/proc` at all, which is every macOS host, where an
+amend is judged against the HEAD it replaces as before. `ps` is deliberately
+not the fallback, because it joins argv with spaces and a message merely
+CONTAINING `--amend` would excuse a commit. A rebase `reword` runs `git commit
+--amend --no-gpg-sign -e --allow-empty` as a child of the rebase and an `edit`
+stop spawns no commit at all, the committer amending at the stop; both are
+amends by this reading, so amending a commit that changes a required path and
+predates the rule needs `[no-changelog]`. A plain all-`pick` rebase and an
+autosquash fixup are unaffected: the sequencer commits those in-process, with
+no `git commit` ancestor to read.
 
 `GROWTH_GUARDS_CHANGELOG_RECORD` counts as that entry only under
 `GROWTH_GUARDS_CHANGELOG_COLLATE=1`, the same declaration the record scope

--- a/skills/growth-guards/CHECKS.md
+++ b/skills/growth-guards/CHECKS.md
@@ -372,15 +372,16 @@ only when `GIT_INDEX_FILE` says this run is a hook git started and only from
 the nearest `git` ancestor, the command doing the committing.
 
 Some of those bytes are the committer's own, so `--amend` counts as the flag
-only where nothing ahead of it could have been reaching for a value: after the
-`commit` subcommand, every token between the two a no-value option, matched by
-prefix the way git matches an abbreviation. `--no-amend` behind the flag takes
-it back and the bare `--` stops the scan, both as git reads them. Everything
-else is not an amend — `-m --amend`, `--mess --amend`, `--message=--amend`,
-`-am`, a pathspec, an option a later git adds — a refusal the writer clears
-with `[no-changelog]` or a fragment, never a commit excused by an entry it does
-not carry. It costs `git commit -m … --amend`, the flag behind the message,
-read as an ordinary commit; put the flag ahead of `-m`.
+only where nothing could have been reaching for a value. A value-taking option
+consumes the NEXT argument and nothing further, so the one token that can
+swallow the flag is the one immediately before it: dash-prefixed and not a
+no-value option means it did, with long names matched by prefix the way git
+matches an abbreviation. That refuses `--mess --amend`, `-am --amend`,
+`--message=--amend` and an option a later git ships — refusals the writer
+clears with `[no-changelog]` or a fragment, never a commit excused by an entry
+it does not carry. Anything else never reached for a value, so `git commit -m
+'msg' --amend` is the amend it is. `--no-amend` takes the flag back under the
+same guard; the bare `--` stops the scan.
 
 Nothing readable is nothing to widen on: a process already gone, no `git` in
 eight generations, or no `/proc` at all, which is every macOS host, where an

--- a/skills/growth-guards/DEVELOPMENT.md
+++ b/skills/growth-guards/DEVELOPMENT.md
@@ -21,10 +21,12 @@ docs live in README.md.
   a commit header and a changelog ARE to this family: the two changelog
   scopes both lanes resolve from, and the grammars each is judged by, kept
   apart from the scans that run them
-- `scripts/lib/commit-parent.sh` — which parent a commit will HAVE, for the
-  lanes that judge a commit rather than an index: HEAD ordinarily, HEAD's own
-  parent for an amend, read off the argv of the `git commit` this hook
-  descends from because git tells a `commit-msg` hook nothing about one
+- `scripts/lib/commit-parent.sh` — which parent a commit will HAVE, for
+  `commit-msg`, the one lane that judges a commit rather than an index: HEAD
+  ordinarily, HEAD's own parent for an amend, read off the argv of the `git
+  commit` this hook descends from — in `/proc/<pid>/cmdline`, because git
+  tells a `commit-msg` hook nothing about one — so a host without `/proc`,
+  macOS above all, keeps the older judgement of HEAD
 - `scripts/lib/changelog-record-scope.sh` — the record half of the
   `changelog-entries` judge: one tracked file against HEAD's copy, kept apart
   from the fragment-tree walk it shares nothing with but a verdict

--- a/skills/growth-guards/DEVELOPMENT.md
+++ b/skills/growth-guards/DEVELOPMENT.md
@@ -24,9 +24,8 @@ docs live in README.md.
 - `scripts/lib/commit-parent.sh` — which parent a commit will HAVE, for
   `commit-msg`, the one lane that judges a commit rather than an index: HEAD
   ordinarily, HEAD's own parent for an amend, read off the argv of the `git
-  commit` this hook descends from — in `/proc/<pid>/cmdline`, because git
-  tells a `commit-msg` hook nothing about one — so a host without `/proc`,
-  macOS above all, keeps the older judgement of HEAD
+  commit` this hook descends from in `/proc/<pid>/cmdline`, so a host without
+  it — macOS above all — keeps the older judgement of HEAD
 - `scripts/lib/changelog-record-scope.sh` — the record half of the
   `changelog-entries` judge: one tracked file against HEAD's copy, kept apart
   from the fragment-tree walk it shares nothing with but a verdict

--- a/skills/growth-guards/DEVELOPMENT.md
+++ b/skills/growth-guards/DEVELOPMENT.md
@@ -21,6 +21,10 @@ docs live in README.md.
   a commit header and a changelog ARE to this family: the two changelog
   scopes both lanes resolve from, and the grammars each is judged by, kept
   apart from the scans that run them
+- `scripts/lib/commit-parent.sh` — which parent a commit will HAVE, for the
+  lanes that judge a commit rather than an index: HEAD ordinarily, HEAD's own
+  parent for an amend, read off the argv of the `git commit` this hook
+  descends from because git tells a `commit-msg` hook nothing about one
 - `scripts/lib/changelog-record-scope.sh` — the record half of the
   `changelog-entries` judge: one tracked file against HEAD's copy, kept apart
   from the fragment-tree walk it shares nothing with but a verdict

--- a/skills/growth-guards/scripts/commit-msg
+++ b/skills/growth-guards/scripts/commit-msg
@@ -226,7 +226,7 @@ if [ -n "$REQUIRED" ]; then
   git -c diff.renames=true diff --cached --raw --no-abbrev -z --find-renames=100% \
     $GG_COMMIT_BASE \
     >"$GG_TMP/raw.z" \
-    || gg_collection_error "could not read the staged file list — the changelog rule could not run"
+    || gg_collection_error "could not read the commit's file list — the changelog rule could not run"
 
   # What "written" MEANS, over the record's full identity: a mode and a sha
   # together, never a sha alone. Equal shas are TWO states, and only the modes
@@ -273,14 +273,14 @@ if [ -n "$REQUIRED" ]; then
   : >"$GG_TMP/written.z"
   while IFS= read -r -d '' meta; do
     IFS= read -r -d '' src \
-      || gg_collection_error "the staged file list ended mid-record after $(gg_shown "$meta") — the changelog rule could not run"
+      || gg_collection_error "the commit's file list ended mid-record after $(gg_shown "$meta") — the changelog rule could not run"
     # Record shape: ":srcmode dstmode srcsha dstsha status". Splitting is safe
     # under the `set -f` at the top of this file — the fields are modes, hex
     # and a letter, and none of them is a path.
     # shellcheck disable=SC2086
     set -- $meta
     [ "$#" -eq 5 ] \
-      || gg_collection_error "the staged file list carried a record of $# field(s), not five: $(gg_shown "$meta") — the changelog rule could not run"
+      || gg_collection_error "the commit's file list carried a record of $# field(s), not five: $(gg_shown "$meta") — the changelog rule could not run"
     srcmode="${1#:}"
     dstmode="$2"
     srcsha="$3"
@@ -292,7 +292,7 @@ if [ -n "$REQUIRED" ]; then
         ;;
       R*)
         IFS= read -r -d '' dest \
-          || gg_collection_error "the staged file list ended before the destination of a $(gg_shown "$status") record — the changelog rule could not run"
+          || gg_collection_error "the commit's file list ended before the destination of a $(gg_shown "$status") record — the changelog rule could not run"
         printf '%s\0' "$src" "$dest" >>"$GG_TMP/staged.z"
         printf '%s\0' "$dest" >>"$GG_TMP/written.z"
         continue

--- a/skills/growth-guards/scripts/commit-msg
+++ b/skills/growth-guards/scripts/commit-msg
@@ -38,6 +38,8 @@ source "$SCRIPT_DIR/lib/settings.sh"
 source "$SCRIPT_DIR/lib/commit-header.sh"
 # shellcheck source=lib/changelog-grammar.sh
 source "$SCRIPT_DIR/lib/changelog-grammar.sh"
+# shellcheck source=lib/commit-parent.sh
+source "$SCRIPT_DIR/lib/commit-parent.sh"
 
 usage() {
   cat <<'EOF'
@@ -62,8 +64,11 @@ kendex.settings.toml [env] > default):
   GROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS
                                space-separated globs against the full
                                repo-relative path ('*' crosses '/'); a commit
-                               that stages a matching path must also write a
-                               changelog entry (default empty = rule off)
+                               that changes a matching path must also write a
+                               changelog entry (default empty = rule off).
+                               Both sets are read from the commit as a whole,
+                               so an amend is judged against the parent it
+                               will have, not against the HEAD it replaces
   GROWTH_GUARDS_CHANGELOG_PATHS   what counts as a written entry, with
   GROWTH_GUARDS_CHANGELOG_RECORD  — the same two scopes the changelog-entries
                                check judges (defaults "changelog.d/*/*.md"
@@ -207,8 +212,19 @@ if [ -n "$REQUIRED" ]; then
   # reaches the globs as the bytes git recorded: a quoted name matches no
   # glob, which is a rule that stops seeing the files it is about. Read back
   # from a FILE rather than a pipe, so the loops set variables in this shell.
+  #
+  # The base is the parent the commit will HAVE, which is HEAD for an ordinary
+  # commit and HEAD's own parent for an amend: an amend replaces HEAD rather
+  # than following it, so `--cached` alone shows only what was staged on top
+  # of a fragment the commit already carries, and refuses a commit that
+  # satisfies the rule. GG_COMMIT_BASE is empty in the ordinary case, where
+  # `--cached` already means HEAD, and unquoted for exactly that reason — it
+  # is one revision or no argument at all, never a path and never a glob.
   gg_tmpdir
+  gg_commit_base
+  # shellcheck disable=SC2086
   git -c diff.renames=true diff --cached --raw --no-abbrev -z --find-renames=100% \
+    $GG_COMMIT_BASE \
     >"$GG_TMP/raw.z" \
     || gg_collection_error "could not read the staged file list — the changelog rule could not run"
 

--- a/skills/growth-guards/scripts/commit-msg
+++ b/skills/growth-guards/scripts/commit-msg
@@ -67,8 +67,8 @@ kendex.settings.toml [env] > default):
                                that changes a matching path must also write a
                                changelog entry (default empty = rule off).
                                Both sets are read from the commit as a whole,
-                               so an amend is judged against the parent it
-                               will have, not the HEAD it replaces
+                               so where /proc is readable (not macOS) an amend
+                               is judged against the parent it will have
   GROWTH_GUARDS_CHANGELOG_PATHS   what counts as a written entry, with
   GROWTH_GUARDS_CHANGELOG_RECORD  — the same two scopes the changelog-entries
                                check judges (defaults "changelog.d/*/*.md"

--- a/skills/growth-guards/scripts/commit-msg
+++ b/skills/growth-guards/scripts/commit-msg
@@ -68,7 +68,7 @@ kendex.settings.toml [env] > default):
                                changelog entry (default empty = rule off).
                                Both sets are read from the commit as a whole,
                                so an amend is judged against the parent it
-                               will have, not against the HEAD it replaces
+                               will have, not the HEAD it replaces
   GROWTH_GUARDS_CHANGELOG_PATHS   what counts as a written entry, with
   GROWTH_GUARDS_CHANGELOG_RECORD  — the same two scopes the changelog-entries
                                check judges (defaults "changelog.d/*/*.md"
@@ -213,13 +213,12 @@ if [ -n "$REQUIRED" ]; then
   # glob, which is a rule that stops seeing the files it is about. Read back
   # from a FILE rather than a pipe, so the loops set variables in this shell.
   #
-  # The base is the parent the commit will HAVE, which is HEAD for an ordinary
-  # commit and HEAD's own parent for an amend: an amend replaces HEAD rather
-  # than following it, so `--cached` alone shows only what was staged on top
-  # of a fragment the commit already carries, and refuses a commit that
-  # satisfies the rule. GG_COMMIT_BASE is empty in the ordinary case, where
-  # `--cached` already means HEAD, and unquoted for exactly that reason — it
-  # is one revision or no argument at all, never a path and never a glob.
+  # The base is the parent the commit will HAVE: HEAD ordinarily, HEAD's own
+  # parent for an amend, which replaces HEAD rather than following it, so
+  # `--cached` alone would show only what was staged on top of a fragment the
+  # commit already carries. GG_COMMIT_BASE is empty in the ordinary case,
+  # where `--cached` already means HEAD, and unquoted for exactly that reason:
+  # one revision or no argument at all, never a path and never a glob.
   gg_tmpdir
   gg_commit_base
   # shellcheck disable=SC2086

--- a/skills/growth-guards/scripts/lib/commit-parent.sh
+++ b/skills/growth-guards/scripts/lib/commit-parent.sh
@@ -1,41 +1,28 @@
 # shellcheck shell=bash
 # Which parent a commit will HAVE, for the lane that judges a commit rather
 # than an index — `commit-msg`, its one caller: HEAD for an ordinary commit,
-# and HEAD's own parent for an amend, which replaces HEAD rather than
-# following it. Kept apart from the rules that read it, and sourced, never
-# executed.
-#
-# Needs lib/common.sh sourced first, and runs with the caller cd'd to the
-# repository root.
+# and HEAD's own parent for an amend, which replaces HEAD rather than following
+# it. Sourced, never executed; needs lib/common.sh sourced first and the caller
+# cd'd to the repository root.
 set -euo pipefail
 
-# git tells a commit-msg hook the message and nothing else. It passes no flag,
-# exports no variable and leaves no file behind that says HEAD is about to be
-# REPLACED rather than followed — prepare-commit-msg is the one hook git tells,
-# and this family installs none. So the answer lives in a single place, the
-# argv of the `git commit` this hook is a descendant of, and it is read there
-# under two conditions, because the wrong answer is the dangerous one: a
-# commit judged against a parent it does not have is excused by an entry
-# belonging to a commit it is not amending.
-#
-#   GIT_INDEX_FILE   git sets it for the hooks it runs a commit through, so
-#                    its absence means a DIRECT run — a person, a test, a
-#                    script — whose ancestors say nothing about what it judges
-#   the NEAREST git  git runs a hook as a descendant of the `git commit` doing
-#   ancestor         the committing, so the first git process above this one
-#                    IS that command. The walk stops at it and never reads a
-#                    git further up: a `git rebase` driving the commit would
-#                    be answering for something else
-#
-# Anything unreadable — a process already gone, eight generations carrying no
-# git — is not an amend, which is the judgement this lane made before: HEAD,
-# and a refusal the writer clears by staging the fragment. That covers a whole
-# platform: argv lives in `/proc/<pid>/cmdline`, which macOS does not have, so
-# the widening is Linux-only and an amend there is judged against the HEAD it
-# replaces exactly as it was before. A `ps` reading would reach further and is
-# deliberately not taken: `ps` joins argv with spaces, so a message merely
-# CONTAINING `--amend` would excuse a commit — a fail-open this reading does
-# not have. The lane widens only where it can prove the parent moved.
+# git tells a commit-msg hook the message and nothing else: no flag, no
+# variable, no file saying HEAD is about to be REPLACED rather than followed.
+# So the answer lives in one place, the argv of the `git commit` this hook
+# descends from, read under two conditions, because the wrong answer is the
+# dangerous one — a commit judged against a parent it does not have is excused
+# by an entry belonging to a commit it is not amending. GIT_INDEX_FILE must be
+# set, since git sets it for the hooks it runs a commit through and its absence
+# means a DIRECT run — a person, a test, a script — whose ancestors say nothing
+# about what it judges. And the argv must come from the NEAREST git ancestor,
+# the command doing the committing; the walk stops there rather than reading a
+# `git rebase` further up, answering for something else. Anything unreadable is
+# not an amend — a process already gone, eight generations carrying no git, or
+# no `/proc` at all, which is every macOS host — which is the judgement this
+# lane made before: HEAD, and a refusal the writer clears by staging the
+# fragment. `ps` would reach macOS and is deliberately not the fallback,
+# because it joins argv with spaces and a message merely CONTAINING `--amend`
+# would excuse a commit.
 gg_parent_pid() { # PID — its parent's pid on stdout, empty when unreadable
   local ppid=""
   [ -r "/proc/$1/status" ] || return 0
@@ -43,8 +30,68 @@ gg_parent_pid() { # PID — its parent's pid on stdout, empty when unreadable
   printf '%s' "$ppid"
 }
 
+gg_opt_abbrev() { # ARG NAME — 0 when ARG is `--x…` and NAME begins with it
+  # git's parser takes any unambiguous abbreviation, so a scan matching full
+  # spellings by equality reads `--mess` as a token it has never heard of. ARG
+  # is quoted into the pattern: it matches as bytes, never as a glob.
+  case "$1" in --?*) ;; *) return 1 ;; esac
+  case "$2" in "$1"*) return 0 ;; esac
+  return 1
+}
+
+gg_no_value_opt() { # ARG — 0 when ARG is a `git commit` option taking NO value
+  # The whole vocabulary the scan below understands. Every option that takes a
+  # value is absent by construction, in every spelling, and absence means "not
+  # an amend" — so an omission costs a refusal the writer clears, never a commit
+  # excused by an entry it does not carry. A name added here that git DOES take
+  # a value for would fail open: the one thing an edit to this list is read for.
+  local name
+  case "$1" in
+    -[aeinopqsuvzS]) return 0 ;;
+  esac
+  for name in --all --patch --interactive --include --only --signoff --dry-run \
+    --no-signoff --verify --edit --no-edit --no-post-rewrite --quiet \
+    --allow-empty --allow-empty-message --gpg-sign --no-gpg-sign --verbose \
+    --reset-author --untracked-files --pathspec-file-nul; do
+    if gg_opt_abbrev "$1" "$name"; then return 0; fi
+  done
+  return 1
+}
+
+gg_argv_is_amend() { # FILE — 0 when the NUL-delimited argv in FILE is an amend
+  # Read NUL-delimited, the bytes the kernel holds: what keeps an argument
+  # carrying whitespace or a newline ONE argument rather than several. The
+  # committer chooses some of those bytes, and a value that happens to spell
+  # the flag is not the flag. Rather than name the options whose values to step
+  # over — a list git grows, and one whose every gap is a commit excused
+  # wrongly — `--amend` counts as the flag only where nothing ahead of it could
+  # have been reaching for a value: after the `commit` subcommand, every token
+  # between the two a no-value option. The first token that is anything else
+  # ends the scan at "not an amend", so `-m --amend` is a message, `--templ
+  # --amend` a template path, and `--message=…`, `-am` and an option git has
+  # not shipped yet are all refusals. The bare `--` stops the scan where git
+  # stops; `--no-amend` behind the flag takes it back, git's last-spelling
+  # boolean. The wrapper's arguments, ahead of `commit`, are skipped rather than
+  # judged: the flag cannot be among them, so `git -c user.name=x commit
+  # --amend` reads as the amend it is without `-c` being understood.
+  local arg seen=0 sub=0 amend=1
+  while IFS= read -r -d '' arg; do
+    if [ "$seen" -eq 0 ]; then seen=1; continue; fi
+    if [ "$sub" -eq 0 ]; then
+      case "$arg" in commit) sub=1 ;; esac
+      continue
+    fi
+    case "$arg" in --) break ;; esac
+    if gg_opt_abbrev "$arg" --no-amend; then amend=1; continue; fi
+    if gg_opt_abbrev "$arg" --amend; then amend=0; continue; fi
+    if [ "$amend" -eq 0 ]; then continue; fi
+    if ! gg_no_value_opt "$arg"; then break; fi
+  done <"$1"
+  return "$amend"
+}
+
 gg_is_amend() { # 0 when this run belongs to a `git commit --amend`
-  local pid depth arg rest argv0 seen skip amend
+  local pid depth argv0
   [ -n "${GIT_INDEX_FILE:-}" ] || return 1
   pid="${PPID:-}"
   depth=0
@@ -52,60 +99,15 @@ gg_is_amend() { # 0 when this run belongs to a `git commit --amend`
     depth=$((depth + 1))
     [ -r "/proc/$pid/cmdline" ] || return 1
     argv0=""
-    seen=0
-    skip=0
-    amend=1
-    # NUL-delimited, the bytes the kernel holds: what keeps an argument
-    # carrying whitespace or a newline ONE argument rather than the several a
-    # space-joined command line would split it into.
-    #
-    # The scan reads argv the way git's own option parser does, because the
-    # committer chooses some of these bytes and a value that happens to spell
-    # the flag is not the flag: it stops at the bare `--` where git stops, and
-    # steps over the argument a value-taking option consumes — `-m --amend` is
-    # a message, `--amend` after `--` is a pathspec. Attached forms
-    # (`--author=…`, `-m…`) consume nothing further. The spellings below are
-    # git's full ones; an abbreviation git would still accept (`--mess`) is
-    # not among them, which leaves the flag unseen and the lane refusing —
-    # the judgement it made before this widening, never a commit excused by
-    # an entry it does not carry.
-    while IFS= read -r -d '' arg; do
-      if [ "$seen" -eq 0 ]; then
-        argv0="$arg"
-        seen=1
-        continue
-      fi
-      if [ "$skip" -eq 1 ]; then
-        skip=0
-        continue
-      fi
-      case "$arg" in
-        --) break ;;
-        --amend) amend=0 ;;
-        -m | -F | -t | -c | -C | --message | --file | --template | --reuse-message | --reedit-message | --fixup | --squash | --author | --date | --cleanup | --trailer | --pathspec-from-file) skip=1 ;;
-        -[!-]*)
-          # A short bundle, walked letter by letter the way git walks it: the
-          # first letter taking a value swallows the rest of the token as that
-          # value, or the next argument when the token ends there, so `-am`
-          # makes `--amend` behind it a message. `S` and `u` take an OPTIONAL
-          # value, which git reads only when it is attached — they never reach
-          # for the next argument.
-          rest="${arg#-}"
-          while [ -n "$rest" ]; do
-            case "$rest" in
-              [mFtcC]) skip=1; rest="" ;;
-              [mFtcCSu]*) rest="" ;;
-              *) rest="${rest#?}" ;;
-            esac
-          done
-          ;;
-      esac
-    done <"/proc/$pid/cmdline"
+    IFS= read -r -d '' argv0 <"/proc/$pid/cmdline" || true
     # Both separators: a Windows git under MSYS carries a backslash path in
     # its own argv, and a name still holding one is not `git`.
     argv0="${argv0##*/}"
     case "${argv0##*\\}" in
-      git | git.exe) return "$amend" ;;
+      git | git.exe)
+        if gg_argv_is_amend "/proc/$pid/cmdline"; then return 0; fi
+        return 1
+        ;;
     esac
     pid="$(gg_parent_pid "$pid")"
   done

--- a/skills/growth-guards/scripts/lib/commit-parent.sh
+++ b/skills/growth-guards/scripts/lib/commit-parent.sh
@@ -31,9 +31,8 @@ gg_parent_pid() { # PID — its parent's pid on stdout, empty when unreadable
 }
 
 gg_opt_abbrev() { # ARG NAME — 0 when ARG is `--x…` and NAME begins with it
-  # git's parser takes any unambiguous abbreviation, so a scan matching full
-  # spellings by equality reads `--mess` as a token it has never heard of. ARG
-  # is quoted into the pattern: it matches as bytes, never as a glob.
+  # git's parser takes any unambiguous abbreviation, so equality alone reads
+  # `--mess` as an unknown token. ARG is quoted in: bytes, never a glob.
   case "$1" in --?*) ;; *) return 1 ;; esac
   case "$2" in "$1"*) return 0 ;; esac
   return 1
@@ -41,40 +40,38 @@ gg_opt_abbrev() { # ARG NAME — 0 when ARG is `--x…` and NAME begins with it
 
 gg_no_value_opt() { # ARG — 0 when ARG is a `git commit` option taking NO value
   # The whole vocabulary the scan below understands. Every option that takes a
-  # value is absent by construction, in every spelling, and absence means "not
-  # an amend" — so an omission costs a refusal the writer clears, never a commit
-  # excused by an entry it does not carry. A name added here that git DOES take
-  # a value for would fail open: the one thing an edit to this list is read for.
+  # value is absent by construction, in every spelling, and absence means "this
+  # one swallowed the token behind it" — so an omission costs a refusal the
+  # writer clears, never a commit excused by an entry it does not carry. A name
+  # added here that git DOES take a value for would fail open: the one thing an
+  # edit to this list is read for.
   local name
   case "$1" in
     -[aeinopqsuvzS]) return 0 ;;
   esac
   for name in --all --patch --interactive --include --only --signoff --dry-run \
-    --no-signoff --verify --edit --no-edit --no-post-rewrite --quiet \
-    --allow-empty --allow-empty-message --gpg-sign --no-gpg-sign --verbose \
-    --reset-author --untracked-files --pathspec-file-nul; do
+    --no-signoff --verify --edit --no-edit --no-post-rewrite --quiet --amend \
+    --no-amend --allow-empty --allow-empty-message --gpg-sign --no-gpg-sign \
+    --verbose --reset-author --untracked-files --pathspec-file-nul; do
     if gg_opt_abbrev "$1" "$name"; then return 0; fi
   done
   return 1
 }
 
 gg_argv_is_amend() { # FILE — 0 when the NUL-delimited argv in FILE is an amend
-  # Read NUL-delimited, the bytes the kernel holds: what keeps an argument
-  # carrying whitespace or a newline ONE argument rather than several. The
-  # committer chooses some of those bytes, and a value that happens to spell
-  # the flag is not the flag. Rather than name the options whose values to step
-  # over — a list git grows, and one whose every gap is a commit excused
-  # wrongly — `--amend` counts as the flag only where nothing ahead of it could
-  # have been reaching for a value: after the `commit` subcommand, every token
-  # between the two a no-value option. The first token that is anything else
-  # ends the scan at "not an amend", so `-m --amend` is a message, `--templ
-  # --amend` a template path, and `--message=…`, `-am` and an option git has
-  # not shipped yet are all refusals. The bare `--` stops the scan where git
-  # stops; `--no-amend` behind the flag takes it back, git's last-spelling
-  # boolean. The wrapper's arguments, ahead of `commit`, are skipped rather than
-  # judged: the flag cannot be among them, so `git -c user.name=x commit
-  # --amend` reads as the amend it is without `-c` being understood.
-  local arg seen=0 sub=0 amend=1
+  # Read NUL-delimited, the bytes the kernel holds, so an argument carrying
+  # whitespace or a newline stays ONE argument. The committer chooses some of
+  # those bytes, and a value that happens to spell the flag is not the flag.
+  # Rather than name the options whose values to step over — a list git grows,
+  # whose every gap is a commit excused wrongly — the scan reads the token
+  # IMMEDIATELY BEFORE each `--amend`: a value-taking option consumes the next
+  # argument and nothing further, so it is the only token that can swallow the
+  # flag. Dash-prefixed and not a no-value option means it did, refusing `--mess
+  # --amend`, `-am --amend`, `--message=…` and an option git has not shipped
+  # yet; anything else never reached for a value, so `-m msg --amend` is the
+  # amend it is. Same guard for `--no-amend`. The bare `--` stops the scan, and
+  # the wrapper's arguments ahead of `commit` are skipped, so `-c` is never read.
+  local arg prev="" eaten seen=0 sub=0 amend=1
   while IFS= read -r -d '' arg; do
     if [ "$seen" -eq 0 ]; then seen=1; continue; fi
     if [ "$sub" -eq 0 ]; then
@@ -82,10 +79,14 @@ gg_argv_is_amend() { # FILE — 0 when the NUL-delimited argv in FILE is an amen
       continue
     fi
     case "$arg" in --) break ;; esac
-    if gg_opt_abbrev "$arg" --no-amend; then amend=1; continue; fi
-    if gg_opt_abbrev "$arg" --amend; then amend=0; continue; fi
-    if [ "$amend" -eq 0 ]; then continue; fi
-    if ! gg_no_value_opt "$arg"; then break; fi
+    eaten=0
+    case "$prev" in -?*) gg_no_value_opt "$prev" || eaten=1 ;; esac
+    if [ "$eaten" -eq 0 ]; then
+      if gg_opt_abbrev "$arg" --no-amend; then amend=1
+      elif gg_opt_abbrev "$arg" --amend; then amend=0
+      fi
+    fi
+    prev="$arg"
   done <"$1"
   return "$amend"
 }

--- a/skills/growth-guards/scripts/lib/commit-parent.sh
+++ b/skills/growth-guards/scripts/lib/commit-parent.sh
@@ -1,0 +1,78 @@
+# shellcheck shell=bash
+# Which parent a commit will HAVE, for the lanes that judge a commit rather
+# than an index: HEAD for an ordinary commit, and HEAD's own parent for an
+# amend, which replaces HEAD rather than following it. Kept apart from the
+# rules that read it, and sourced, never executed.
+#
+# Needs lib/common.sh sourced first, and runs with the caller cd'd to the
+# repository root.
+set -euo pipefail
+
+# git tells a commit-msg hook the message and nothing else. It passes no flag,
+# exports no variable and leaves no file behind that says HEAD is about to be
+# REPLACED rather than followed — prepare-commit-msg is the one hook git tells,
+# and this family installs none. So the answer lives in a single place, the
+# argv of the `git commit` this hook is a descendant of, and it is read there
+# under two conditions, because the wrong answer is the dangerous one: a
+# commit judged against a parent it does not have is excused by an entry
+# belonging to a commit it is not amending.
+#
+#   GIT_INDEX_FILE   git sets it for the hooks it runs a commit through, so
+#                    its absence means a DIRECT run — a person, a test, a
+#                    script — whose ancestors say nothing about what it judges
+#   the NEAREST git  git runs a hook as a descendant of the `git commit` doing
+#   ancestor         the committing, so the first git process above this one
+#                    IS that command. The walk stops at it and never reads a
+#                    git further up: a `git rebase` driving the commit would
+#                    be answering for something else
+#
+# Anything unreadable — a kernel with no /proc, a process already gone, eight
+# generations carrying no git — is not an amend, which is the judgement this
+# lane made before: HEAD, and a refusal the writer clears by staging the
+# fragment. The lane widens only where it can prove the parent moved.
+gg_parent_pid() { # PID — its parent's pid on stdout, empty when unreadable
+  local ppid=""
+  [ -r "/proc/$1/status" ] || return 0
+  ppid="$(awk '/^PPid:/ { print $2; exit }' "/proc/$1/status" 2>/dev/null)" || ppid=""
+  printf '%s' "$ppid"
+}
+
+gg_is_amend() { # 0 when this run belongs to a `git commit --amend`
+  local pid depth arg argv0 seen amend
+  [ -n "${GIT_INDEX_FILE:-}" ] || return 1
+  pid="${PPID:-}"
+  depth=0
+  while [ -n "$pid" ] && [ "$pid" != "0" ] && [ "$depth" -lt 8 ]; do
+    depth=$((depth + 1))
+    [ -r "/proc/$pid/cmdline" ] || return 1
+    argv0=""
+    seen=0
+    amend=1
+    # NUL-delimited, the bytes the kernel holds: an argument carrying a
+    # newline stays one argument, and a message whose own text is `--amend`
+    # is one argument too, never the flag.
+    while IFS= read -r -d '' arg; do
+      [ "$seen" -eq 1 ] || argv0="$arg"
+      seen=1
+      [ "$arg" != "--amend" ] || amend=0
+    done <"/proc/$pid/cmdline"
+    # Both separators: a Windows git under MSYS carries a backslash path in
+    # its own argv, and a name still holding one is not `git`.
+    argv0="${argv0##*/}"
+    case "${argv0##*\\}" in
+      git | git.exe) return "$amend" ;;
+    esac
+    pid="$(gg_parent_pid "$pid")"
+  done
+  return 1
+}
+
+gg_commit_base() { # sets GG_COMMIT_BASE — the revision --cached diffs against
+  GG_COMMIT_BASE=""
+  gg_is_amend || return 0
+  GG_COMMIT_BASE="$(git rev-parse --verify --quiet HEAD^ 2>/dev/null)" && return 0
+  # Amending a repository's first commit: its parent is the empty tree, hashed
+  # rather than spelled out so a repository on any object format gets its own.
+  GG_COMMIT_BASE="$(git hash-object -t tree /dev/null)" \
+    || gg_collection_error "could not name the empty tree — the commit's parent could not be resolved"
+}

--- a/skills/growth-guards/scripts/lib/commit-parent.sh
+++ b/skills/growth-guards/scripts/lib/commit-parent.sh
@@ -1,8 +1,9 @@
 # shellcheck shell=bash
-# Which parent a commit will HAVE, for the lanes that judge a commit rather
-# than an index: HEAD for an ordinary commit, and HEAD's own parent for an
-# amend, which replaces HEAD rather than following it. Kept apart from the
-# rules that read it, and sourced, never executed.
+# Which parent a commit will HAVE, for the lane that judges a commit rather
+# than an index — `commit-msg`, its one caller: HEAD for an ordinary commit,
+# and HEAD's own parent for an amend, which replaces HEAD rather than
+# following it. Kept apart from the rules that read it, and sourced, never
+# executed.
 #
 # Needs lib/common.sh sourced first, and runs with the caller cd'd to the
 # repository root.
@@ -26,10 +27,15 @@ set -euo pipefail
 #                    git further up: a `git rebase` driving the commit would
 #                    be answering for something else
 #
-# Anything unreadable — a kernel with no /proc, a process already gone, eight
-# generations carrying no git — is not an amend, which is the judgement this
-# lane made before: HEAD, and a refusal the writer clears by staging the
-# fragment. The lane widens only where it can prove the parent moved.
+# Anything unreadable — a process already gone, eight generations carrying no
+# git — is not an amend, which is the judgement this lane made before: HEAD,
+# and a refusal the writer clears by staging the fragment. That covers a whole
+# platform: argv lives in `/proc/<pid>/cmdline`, which macOS does not have, so
+# the widening is Linux-only and an amend there is judged against the HEAD it
+# replaces exactly as it was before. A `ps` reading would reach further and is
+# deliberately not taken: `ps` joins argv with spaces, so a message merely
+# CONTAINING `--amend` would excuse a commit — a fail-open this reading does
+# not have. The lane widens only where it can prove the parent moved.
 gg_parent_pid() { # PID — its parent's pid on stdout, empty when unreadable
   local ppid=""
   [ -r "/proc/$1/status" ] || return 0
@@ -38,7 +44,7 @@ gg_parent_pid() { # PID — its parent's pid on stdout, empty when unreadable
 }
 
 gg_is_amend() { # 0 when this run belongs to a `git commit --amend`
-  local pid depth arg argv0 seen amend
+  local pid depth arg rest argv0 seen skip amend
   [ -n "${GIT_INDEX_FILE:-}" ] || return 1
   pid="${PPID:-}"
   depth=0
@@ -47,14 +53,53 @@ gg_is_amend() { # 0 when this run belongs to a `git commit --amend`
     [ -r "/proc/$pid/cmdline" ] || return 1
     argv0=""
     seen=0
+    skip=0
     amend=1
-    # NUL-delimited, the bytes the kernel holds: an argument carrying a
-    # newline stays one argument, and a message whose own text is `--amend`
-    # is one argument too, never the flag.
+    # NUL-delimited, the bytes the kernel holds: what keeps an argument
+    # carrying whitespace or a newline ONE argument rather than the several a
+    # space-joined command line would split it into.
+    #
+    # The scan reads argv the way git's own option parser does, because the
+    # committer chooses some of these bytes and a value that happens to spell
+    # the flag is not the flag: it stops at the bare `--` where git stops, and
+    # steps over the argument a value-taking option consumes — `-m --amend` is
+    # a message, `--amend` after `--` is a pathspec. Attached forms
+    # (`--author=…`, `-m…`) consume nothing further. The spellings below are
+    # git's full ones; an abbreviation git would still accept (`--mess`) is
+    # not among them, which leaves the flag unseen and the lane refusing —
+    # the judgement it made before this widening, never a commit excused by
+    # an entry it does not carry.
     while IFS= read -r -d '' arg; do
-      [ "$seen" -eq 1 ] || argv0="$arg"
-      seen=1
-      [ "$arg" != "--amend" ] || amend=0
+      if [ "$seen" -eq 0 ]; then
+        argv0="$arg"
+        seen=1
+        continue
+      fi
+      if [ "$skip" -eq 1 ]; then
+        skip=0
+        continue
+      fi
+      case "$arg" in
+        --) break ;;
+        --amend) amend=0 ;;
+        -m | -F | -t | -c | -C | --message | --file | --template | --reuse-message | --reedit-message | --fixup | --squash | --author | --date | --cleanup | --trailer | --pathspec-from-file) skip=1 ;;
+        -[!-]*)
+          # A short bundle, walked letter by letter the way git walks it: the
+          # first letter taking a value swallows the rest of the token as that
+          # value, or the next argument when the token ends there, so `-am`
+          # makes `--amend` behind it a message. `S` and `u` take an OPTIONAL
+          # value, which git reads only when it is attached — they never reach
+          # for the next argument.
+          rest="${arg#-}"
+          while [ -n "$rest" ]; do
+            case "$rest" in
+              [mFtcC]) skip=1; rest="" ;;
+              [mFtcCSu]*) rest="" ;;
+              *) rest="${rest#?}" ;;
+            esac
+          done
+          ;;
+      esac
     done <"/proc/$pid/cmdline"
     # Both separators: a Windows git under MSYS carries a backslash path in
     # its own argv, and a name still holding one is not `git`.

--- a/skills/growth-guards/scripts/lib/commit-parent.sh
+++ b/skills/growth-guards/scripts/lib/commit-parent.sh
@@ -59,18 +59,18 @@ gg_no_value_opt() { # ARG — 0 when ARG is a `git commit` option taking NO valu
 }
 
 gg_argv_is_amend() { # FILE — 0 when the NUL-delimited argv in FILE is an amend
-  # Read NUL-delimited, the bytes the kernel holds, so an argument carrying
-  # whitespace or a newline stays ONE argument. The committer chooses some of
-  # those bytes, and a value that happens to spell the flag is not the flag.
-  # Rather than name the options whose values to step over — a list git grows,
-  # whose every gap is a commit excused wrongly — the scan reads the token
-  # IMMEDIATELY BEFORE each `--amend`: a value-taking option consumes the next
-  # argument and nothing further, so it is the only token that can swallow the
-  # flag. Dash-prefixed and not a no-value option means it did, refusing `--mess
-  # --amend`, `-am --amend`, `--message=…` and an option git has not shipped
-  # yet; anything else never reached for a value, so `-m msg --amend` is the
-  # amend it is. Same guard for `--no-amend`. The bare `--` stops the scan, and
-  # the wrapper's arguments ahead of `commit` are skipped, so `-c` is never read.
+  # Read NUL-delimited, so an argument carrying whitespace or a newline stays
+  # ONE argument, and a value the committer chose that happens to spell the flag
+  # is not the flag. Rather than name the options whose values to step over — a
+  # list git grows, every gap a commit excused wrongly — the scan reads the
+  # token IMMEDIATELY BEFORE each `--amend`: a value-taking option consumes the
+  # next argument and nothing further, so it is the only token that can swallow
+  # it. Dash-prefixed and not a no-value option means it did, refusing `--mess
+  # --amend`, `-am --amend` and `--message=…`; anything else never reached, so
+  # `-m msg --amend` is the amend it is. `--no-amend` stands OUTSIDE that guard:
+  # a missed flag costs a refusal, a missed negation leaves a stale `--amend`
+  # standing. The bare `--` stops the scan, and the wrapper's arguments ahead of
+  # `commit` are skipped, so `-c` is never read.
   local arg prev="" eaten seen=0 sub=0 amend=1
   while IFS= read -r -d '' arg; do
     if [ "$seen" -eq 0 ]; then seen=1; continue; fi
@@ -81,10 +81,8 @@ gg_argv_is_amend() { # FILE — 0 when the NUL-delimited argv in FILE is an amen
     case "$arg" in --) break ;; esac
     eaten=0
     case "$prev" in -?*) gg_no_value_opt "$prev" || eaten=1 ;; esac
-    if [ "$eaten" -eq 0 ]; then
-      if gg_opt_abbrev "$arg" --no-amend; then amend=1
-      elif gg_opt_abbrev "$arg" --amend; then amend=0
-      fi
+    if gg_opt_abbrev "$arg" --no-amend; then amend=1
+    elif [ "$eaten" -eq 0 ] && gg_opt_abbrev "$arg" --amend; then amend=0
     fi
     prev="$arg"
   done <"$1"

--- a/skills/growth-guards/tests/commit-msg-amend.test.sh
+++ b/skills/growth-guards/tests/commit-msg-amend.test.sh
@@ -2,12 +2,23 @@
 # Pins for the one commit-msg rule that cannot be judged from an index alone:
 # the changelog a commit owes is read against the parent the commit will HAVE,
 # so an amend is judged against HEAD's parent and not against the HEAD it
-# replaces. These run through a real `git commit`, because which parent the
-# commit will have is read off that process and nowhere else — every other
-# commit-msg pin invokes the script directly and lives in commit-msg.test.sh.
-# Every firing pin is paired with the control that proves the widening is
-# bound to the amend: the next commit, an amend carrying no fragment, and an
-# amend that drops the one it had are all still refused.
+# replaces. The rule pins run through a real `git commit`, because which parent
+# the commit will have is read off that process and nowhere else — every other
+# commit-msg RULE pin invokes the script directly and lives in commit-msg.test.sh
+# (install-git-hooks.test.sh drives a real commit too, but only to prove the
+# installed shim reaches the committer).
+#
+# Every firing pin is paired with the control that proves the widening is bound
+# to the amend: the next commit, an amend carrying no fragment, an amend that
+# drops the one it had, and a commit whose own bytes merely SPELL the flag are
+# all still refused.
+#
+# The last section drives a FAKE `git` ancestor — a copy of bash under that
+# name — because the arms a real `git commit` cannot reach are the ones that
+# decide the answer: the GIT_INDEX_FILE guard (a real commit always sets it),
+# the walk stopping at the NEAREST git ancestor, the depth walk past a
+# generation carrying no git, and the argv scan reading a committer-chosen
+# value that spells `--amend`.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -23,77 +34,286 @@ PASS=0
 FAIL=0
 ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
 bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+skip() { printf '  skip  %s\n' "$1"; }
+
+# The widening is read off /proc/<pid>/cmdline and nowhere else, so a host
+# without procfs — macOS, which this family supports — answers "not an amend"
+# and keeps the judgement the lane made before. A pin asserting the widening
+# can only be measured where that file is readable; it is skipped elsewhere,
+# named, rather than reporting a portability fact as a defect. The refusal
+# controls are NOT gated: what they assert holds on every platform.
+HAVE_PROC=0
+if [ -r "/proc/$$/cmdline" ]; then HAVE_PROC=1; fi
+
+mk_repo() { # DIR — a repo with the commit-msg hook installed and the rule armed
+  mkdir -p "$1/crates/core" "$1/changelog.d/fixed"
+  git -C "$1" -c init.defaultBranch=main init -q
+  git -C "$1" config user.email test@example.com
+  git -C "$1" config user.name test
+  printf '#!/bin/sh\nexec %s "$1"\n' "$CM" >"$1/.git/hooks/commit-msg"
+  chmod +x "$1/.git/hooks/commit-msg"
+  printf '[env]\nGROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS = "crates/* ui/*"\n' >"$1/kendex.settings.toml"
+}
+
+seed_commit() { # DIR — the base commit an amend below sits on
+  printf 'seed\n' >"$1/README.md"
+  git -C "$1" add -A
+  git -C "$1" commit -qm "chore: base [no-changelog]" >/dev/null 2>&1
+}
+
+crate_commit() { # DIR — a commit changing a crate and carrying its fragment
+  printf 'fn one() {}\n' >"$1/crates/core/lib.rs"
+  printf -- '- A fix consumers see.\n' >"$1/changelog.d/fixed/ken-1.md"
+  git -C "$1" add -A
+  commit_in "$1" 'fix(KEN-1): change a crate'
+}
+
+more_code() { # DIR — another crate change, staged
+  printf 'fn two() {}\n' >>"$1/crates/core/lib.rs"
+  git -C "$1" add -A
+}
+
+commit_in() { # DIR MESSAGE [git-commit-arg...] — a real commit; sets OUT and RC
+  OUT=""
+  RC=0
+  OUT="$(git -C "$1" commit -m "$2" "${@:3}" 2>&1)" || RC=$?
+}
+
+# Each pin gets its own fixture: an amend either lands or is refused, and a pin
+# that is skipped for want of /proc must leave nothing for the next one to
+# inherit.
+new_repo() { # NAME — a fresh seeded repo at $TMP/NAME, named by R
+  R="$TMP/$1"
+  mk_repo "$R"
+  seed_commit "$R"
+}
+
+refused_naming_lib() { # 0 when RC/OUT are the refusal that names the crate path
+  [ "$RC" -eq 1 ] || return 1
+  case "$OUT" in *"crates/core/lib.rs changed without a changelog entry"*) return 0 ;; esac
+  return 1
+}
 
 echo "=== an amend is judged against the parent it will HAVE, not the HEAD it replaces ==="
 # `git diff --cached` on an amend shows only what was staged ON TOP of the
 # commit being replaced, so a fragment already inside that commit read as no
 # fragment at all and a commit satisfying the rule was refused — with the
-# obvious escape being the flag that skips the whole hook chain. These run
-# through a real `git commit`, because which parent the commit will have is
-# read off that process and nowhere else.
-AM_REPO="$TMP/repo-amend"
-mkdir -p "$AM_REPO/crates/core" "$AM_REPO/changelog.d/fixed"
-git -C "$AM_REPO" -c init.defaultBranch=main init -q
-git -C "$AM_REPO" config user.email test@example.com
-git -C "$AM_REPO" config user.name test
-printf '#!/bin/sh\nexec %s "$1"\n' "$CM" >"$AM_REPO/.git/hooks/commit-msg"
-chmod +x "$AM_REPO/.git/hooks/commit-msg"
-printf '[env]\nGROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS = "crates/* ui/*"\n' >"$AM_REPO/kendex.settings.toml"
-printf 'seed\n' >"$AM_REPO/README.md"
-git -C "$AM_REPO" add -A
-git -C "$AM_REPO" commit -qm "chore: base [no-changelog]" >/dev/null 2>&1
-
-am_commit() { # MESSAGE [git-commit-arg...] — a real commit; sets OUT and RC
-  OUT=""
-  RC=0
-  OUT="$(git -C "$AM_REPO" commit -m "$1" "${@:2}" 2>&1)" || RC=$?
-}
-
-printf 'fn one() {}\n' >"$AM_REPO/crates/core/lib.rs"
-printf -- '- A fix consumers see.\n' >"$AM_REPO/changelog.d/fixed/ken-1.md"
-git -C "$AM_REPO" add -A
-am_commit 'fix(KEN-1): change a crate'
+# obvious escape being the flag that skips the whole hook chain.
+new_repo repo-fixture
+crate_commit "$R"
 [ "$RC" -eq 0 ] && ok "fixture: the crate change lands with its fragment" \
   || bad "fixture: the crate change lands with its fragment" "rc=$RC out=$OUT"
 
-printf 'fn two() {}\n' >>"$AM_REPO/crates/core/lib.rs"
-git -C "$AM_REPO" add -A
-am_commit 'fix(KEN-1): change a crate' --amend
-[ "$RC" -eq 0 ] && ok "an amend adding more code passes on the fragment the commit already carries" \
-  || bad "an amend passes on the fragment the commit already carries" "rc=$RC out=$OUT"
+new_repo repo-amend
+crate_commit "$R"
+more_code "$R"
+if [ "$HAVE_PROC" -eq 1 ]; then
+  commit_in "$R" 'fix(KEN-1): change a crate' --amend
+  [ "$RC" -eq 0 ] && ok "an amend adding more code passes on the fragment the commit already carries" \
+    || bad "an amend passes on the fragment the commit already carries" "rc=$RC out=$OUT"
+else
+  skip "the amend pin needs /proc/<pid>/cmdline, where the committing argv is read"
+fi
 
 # The control that reds when the amend case goes: the widening is bound to the
-# amend, so the NEXT commit — a new one, whose parent really is that HEAD —
-# is not excused by the fragment sitting in the commit before it.
-printf 'fn three() {}\n' >>"$AM_REPO/crates/core/lib.rs"
-git -C "$AM_REPO" add -A
-am_commit 'fix(KEN-2): change a crate again'
-[ "$RC" -eq 1 ] && case "$OUT" in *"crates/core/lib.rs changed without a changelog entry"*) true ;; *) false ;; esac \
+# amend, so the NEXT commit — a new one, whose parent really is that HEAD — is
+# not excused by the fragment sitting in the commit before it.
+new_repo repo-next
+crate_commit "$R"
+more_code "$R"
+commit_in "$R" 'fix(KEN-2): change a crate again'
+refused_naming_lib \
   && ok "control: the commit AFTER a fragment commit still owes its own entry" \
   || bad "control: the commit after a fragment commit still owes its own entry" "rc=$RC out=$OUT"
-git -C "$AM_REPO" reset -q --hard HEAD
 
 # And an amend of a commit that carries no fragment is refused, naming the
 # path: reading the whole commit is what widened, not the rule.
-git -C "$AM_REPO" commit -q --allow-empty -m 'chore: nothing a consumer sees' >/dev/null 2>&1
-printf 'fn four() {}\n' >>"$AM_REPO/crates/core/lib.rs"
-git -C "$AM_REPO" add -A
-am_commit 'fix(KEN-3): change a crate' --amend
-[ "$RC" -eq 1 ] && case "$OUT" in *"crates/core/lib.rs changed without a changelog entry"*) true ;; *) false ;; esac \
+new_repo repo-fragmentless
+git -C "$R" commit -q --allow-empty -m 'chore: nothing a consumer sees' >/dev/null 2>&1
+more_code "$R"
+commit_in "$R" 'fix(KEN-3): change a crate' --amend
+refused_naming_lib \
   && ok "control: an amend of a fragmentless commit is refused, naming the path" \
   || bad "control: an amend of a fragmentless commit is refused" "rc=$RC out=$OUT"
-git -C "$AM_REPO" reset -q --hard HEAD
-git -C "$AM_REPO" reset -q --hard HEAD~1
 
 # An amend that DROPS the fragment owes one again: what counts is the tree the
-# commit will have, never that HEAD once held an entry.
-git -C "$AM_REPO" rm -q --cached changelog.d/fixed/ken-1.md
-rm -f "$AM_REPO/changelog.d/fixed/ken-1.md"
-am_commit 'fix(KEN-1): change a crate' --amend
-[ "$RC" -eq 1 ] && case "$OUT" in *"crates/core/lib.rs changed without a changelog entry"*) true ;; *) false ;; esac \
-  && ok "control: an amend that drops the fragment owes one again" \
-  || bad "control: an amend that drops the fragment owes one again" "rc=$RC out=$OUT"
-git -C "$AM_REPO" reset -q --hard HEAD
+# commit will have, never that HEAD once held an entry. Gated, because without
+# the widening the base is HEAD and the dropped fragment is the only change the
+# diff shows — no required path in it, and nothing to refuse.
+new_repo repo-dropped
+crate_commit "$R"
+if [ "$HAVE_PROC" -eq 1 ]; then
+  git -C "$R" rm -q --cached changelog.d/fixed/ken-1.md
+  rm -f "$R/changelog.d/fixed/ken-1.md"
+  commit_in "$R" 'fix(KEN-1): change a crate' --amend
+  refused_naming_lib \
+    && ok "control: an amend that drops the fragment owes one again" \
+    || bad "control: an amend that drops the fragment owes one again" "rc=$RC out=$OUT"
+else
+  skip "the dropped-fragment pin needs /proc/<pid>/cmdline: without it the base is HEAD and no required path moved"
+fi
+
+echo "=== a commit whose own bytes SPELL the flag is not an amend ==="
+# The committer chooses some of the bytes in that argv. A message or a pathspec
+# equal to `--amend` reached the scan as the flag before it read argv the way
+# git's parser does, and the previous commit's fragment then excused a commit
+# that carries none. These are refusals, so they hold on every platform.
+new_repo repo-spelled
+: >"$R/--amend"
+git -C "$R" add -A
+git -C "$R" commit -qm 'chore: a tracked file named for the flag [no-changelog]' >/dev/null 2>&1
+crate_commit "$R"
+more_code "$R"
+commit_in "$R" 'fix(KEN-2): change a crate again' -m '--amend'
+refused_naming_lib \
+  && ok "control: the flag text as a -m body paragraph is a message, not the flag" \
+  || bad "control: the flag text as a -m body paragraph is a message" "rc=$RC out=$OUT"
+
+new_repo repo-pathspec
+: >"$R/--amend"
+git -C "$R" add -A
+git -C "$R" commit -qm 'chore: a tracked file named for the flag [no-changelog]' >/dev/null 2>&1
+crate_commit "$R"
+printf 'fn two() {}\n' >>"$R/crates/core/lib.rs"
+commit_in "$R" 'fix(KEN-2): change a crate again' -- crates/core/lib.rs --amend
+refused_naming_lib \
+  && ok "control: a --amend PATHSPEC after the bare -- is a path, not the flag" \
+  || bad "control: a --amend pathspec after the bare -- is a path" "rc=$RC out=$OUT"
+
+echo "=== amending a repository's first commit: the parent is the empty tree ==="
+# HEAD^ does not resolve there, so the base is the hashed empty tree. Same
+# branch on the tip of a `git clone --depth 1` shallow clone, where git writes
+# a parentless commit.
+R="$TMP/repo-root"
+mk_repo "$R"
+crate_commit "$R"
+if [ "$HAVE_PROC" -eq 1 ]; then
+  more_code "$R"
+  commit_in "$R" 'fix(KEN-1): change a crate' --amend
+  [ "$RC" -eq 0 ] && [ -z "$(git -C "$R" rev-parse --verify --quiet HEAD^ 2>/dev/null)" ] \
+    && ok "an amend of the ROOT commit passes on the fragment it carries" \
+    || bad "an amend of the root commit passes on the fragment it carries" "rc=$RC out=$OUT"
+
+  git -C "$R" rm -q --cached changelog.d/fixed/ken-1.md
+  rm -f "$R/changelog.d/fixed/ken-1.md"
+  commit_in "$R" 'fix(KEN-1): change a crate' --amend
+  refused_naming_lib \
+    && ok "control: the same root amend is refused once the fragment is dropped" \
+    || bad "control: the root amend is refused once the fragment is dropped" "rc=$RC out=$OUT"
+else
+  skip "the root-commit amend pins need /proc/<pid>/cmdline, where the committing argv is read"
+fi
+
+echo "=== what the walk reads, through a FAKE git ancestor ==="
+# A real `git commit` cannot put these shapes on the tree: it always sets
+# GIT_INDEX_FILE, it is always the nearest git ancestor, and it rejects an
+# argv git itself would not parse. A copy of bash named `git` can, and the
+# hook is invoked directly beneath it.
+#
+# The fixture stands still: HEAD carries the crate change and its fragment,
+# HEAD^ carries neither, and the index holds HEAD's tree plus more code. Judged
+# against HEAD^ the fragment is in the diff and the run passes; judged against
+# HEAD only the crate change is, and the run is refused. One bit, either way.
+if [ "$HAVE_PROC" -eq 0 ]; then
+  skip "the ancestor-walk pins need /proc/<pid>/cmdline: with no procfs there is no argv to read"
+else
+  FK_REPO="$TMP/repo-fake"
+  mk_repo "$FK_REPO"
+  rm -f "$FK_REPO/.git/hooks/commit-msg"
+  seed_commit "$FK_REPO"
+  crate_commit "$FK_REPO"
+  more_code "$FK_REPO"
+  FK_MSG="$TMP/fake-message.txt"
+  printf 'fix(KEN-1): change a crate\n' >"$FK_MSG"
+
+  FAKE_BIN="$TMP/fake-bin"
+  mkdir -p "$FAKE_BIN"
+  cp -- "${BASH:-$(command -v bash)}" "$FAKE_BIN/git"
+  # The fake ancestor reads these out of the environment: it is bash, and its
+  # `-c` script is the only thing it is given.
+  export CM FK_MSG FAKE_BIN
+  # `sleep 0; exit $s` is load-bearing. bash EXECS a lone `-c` command, which
+  # would replace the fake ancestor with commit-msg itself and erase the very
+  # process the scan is about.
+  FAKE_RUN='"$CM" "$FK_MSG"; s=$?; sleep 0; exit $s'
+  export FAKE_RUN
+
+  fake_git() { # ARG... — commit-msg under a `git` ancestor whose argv is ARG...
+    OUT=""
+    RC=0
+    OUT="$(cd "$FK_REPO" && GIT_INDEX_FILE="$FK_REPO/.git/index" \
+      "$FAKE_BIN/git" -c "$FAKE_RUN" "$@" 2>&1)" || RC=$?
+  }
+
+  # MUST-FAIL: git sets GIT_INDEX_FILE for the hooks it runs a commit through,
+  # so its absence means a DIRECT run — a person, a script, one of this
+  # family's own suites under a developer's `git commit --amend` — whose
+  # ancestors say nothing about what it judges. Drop the guard and this run is
+  # excused by a fragment the commit does not carry.
+  OUT=""
+  RC=0
+  OUT="$(cd "$FK_REPO" && "$FAKE_BIN/git" -c "$FAKE_RUN" --amend 2>&1)" || RC=$?
+  refused_naming_lib \
+    && ok "must-fail: a git ancestor with the flag but no GIT_INDEX_FILE is not this run's commit" \
+    || bad "a git ancestor with no GIT_INDEX_FILE must not widen" "rc=$RC out=$OUT"
+
+  fake_git --amend
+  [ "$RC" -eq 0 ] && ok "the walk finds the flag on the nearest git ancestor and widens" \
+    || bad "the walk finds the flag on the nearest git ancestor" "rc=$RC out=$OUT"
+
+  # MUST-FAIL: the walk stops at the NEAREST git ancestor, which is the command
+  # doing the committing. A `git rebase` above it would be answering for
+  # something else, so a climb past the inner git is a commit judged against a
+  # parent it does not have.
+  OUT=""
+  RC=0
+  NEST_RUN='"$FAKE_BIN/git" -c "$FAKE_RUN" commit; s=$?; sleep 0; exit $s'
+  OUT="$(cd "$FK_REPO" && GIT_INDEX_FILE="$FK_REPO/.git/index" \
+    "$FAKE_BIN/git" -c "$NEST_RUN" --amend 2>&1)" || RC=$?
+  refused_naming_lib \
+    && ok "must-fail: an inner git WITHOUT the flag answers, not an outer git with it" \
+    || bad "the walk must stop at the nearest git ancestor" "rc=$RC out=$OUT"
+
+  # The depth walk: a generation carrying no git sits between the committing
+  # process and the hook, so a cap of one generation reads only that generation
+  # and never reaches the git above it.
+  OUT=""
+  RC=0
+  DEPTH_RUN='bash -c "$FAKE_RUN"; s=$?; sleep 0; exit $s'
+  OUT="$(cd "$FK_REPO" && GIT_INDEX_FILE="$FK_REPO/.git/index" \
+    "$FAKE_BIN/git" -c "$DEPTH_RUN" --amend 2>&1)" || RC=$?
+  [ "$RC" -eq 0 ] && ok "the walk climbs past a generation carrying no git" \
+    || bad "the walk climbs past a generation carrying no git" "rc=$RC out=$OUT"
+
+  # MUST-FAIL, the argv scan itself: a value the committer chose is not the
+  # flag. git's own parser stops at the bare `--` and hands a value-taking
+  # option the argument behind it, and the scan reads argv the same way.
+  fake_git -m --amend
+  refused_naming_lib \
+    && ok "must-fail: the argument -m consumes is a message, not the flag" \
+    || bad "the argument -m consumes must not read as the flag" "rc=$RC out=$OUT"
+
+  fake_git --message --amend
+  refused_naming_lib \
+    && ok "must-fail: the argument a LONG value-taking option consumes is a message too" \
+    || bad "the argument a long value-taking option consumes must not read as the flag" "rc=$RC out=$OUT"
+
+  fake_git -am --amend
+  refused_naming_lib \
+    && ok "must-fail: the argument a SHORT BUNDLE's -m consumes is a message too" \
+    || bad "the argument a short bundle's -m consumes must not read as the flag" "rc=$RC out=$OUT"
+
+  fake_git commit -- --amend
+  refused_naming_lib \
+    && ok "must-fail: an argument after the bare -- is a pathspec, not the flag" \
+    || bad "an argument after the bare -- must not read as the flag" "rc=$RC out=$OUT"
+
+  # The control that keeps those three honest: the flag itself, in the same
+  # argv shapes, still widens.
+  fake_git --amend -m 'fix(KEN-1): change a crate'
+  [ "$RC" -eq 0 ] && ok "control: the flag BEFORE a value-taking option is still the flag" \
+    || bad "control: the flag before a value-taking option is still the flag" "rc=$RC out=$OUT"
+fi
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/growth-guards/tests/commit-msg-amend.test.sh
+++ b/skills/growth-guards/tests/commit-msg-amend.test.sh
@@ -1,31 +1,20 @@
 #!/usr/bin/env bash
 # Pins for the one commit-msg rule that cannot be judged from an index alone:
 # the changelog a commit owes is read against the parent the commit will HAVE,
-# so an amend is judged against HEAD's parent and not against the HEAD it
-# replaces. The rule pins run through a real `git commit`, because which parent
-# the commit will have is read off that process and nowhere else — every other
-# commit-msg RULE pin invokes the script directly and lives in commit-msg.test.sh
-# (install-git-hooks.test.sh drives a real commit too, but only to prove the
-# installed shim reaches the committer).
-#
-# Every firing pin is paired with the control that proves the widening is bound
-# to the amend: the next commit, an amend carrying no fragment, an amend that
-# drops the one it had, and a commit whose own bytes merely SPELL the flag are
-# all still refused.
-#
-# The last section drives a FAKE `git` ancestor — a copy of bash under that
-# name — because the arms a real `git commit` cannot reach are the ones that
-# decide the answer: the GIT_INDEX_FILE guard (a real commit always sets it),
-# the walk stopping at the NEAREST git ancestor, the depth walk past a
-# generation carrying no git, and the argv scan reading a committer-chosen
-# value that spells `--amend`.
+# so an amend is judged against HEAD's parent, not the HEAD it replaces. Three
+# kinds of pin, because the answer is read off a process — a real `git commit`
+# for the rule end to end, each firing pin against the control that reds when
+# the widening stops being bound to the amend; an argv FILE for which argv IS
+# an amend, one spelling per line; and a FAKE `git`, a copy of bash under that
+# name, for the arms that need a process.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 CM="$SKILL_DIR/scripts/commit-msg"
 . "$TEST_DIR/lib/harness.bash"
-
+# shellcheck source=../scripts/lib/commit-parent.sh
+source "$SKILL_DIR/scripts/lib/commit-parent.sh"
 unset GROWTH_GUARDS_COMMIT_TYPES GROWTH_GUARDS_SUBJECT_MAX \
   GROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS GROWTH_GUARDS_CHANGELOG_PATHS \
   GROWTH_GUARDS_CHANGELOG_RECORD GROWTH_GUARDS_SETTINGS_FILE 2>/dev/null || true
@@ -37,11 +26,9 @@ bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
 skip() { printf '  skip  %s\n' "$1"; }
 
 # The widening is read off /proc/<pid>/cmdline and nowhere else, so a host
-# without procfs — macOS, which this family supports — answers "not an amend"
-# and keeps the judgement the lane made before. A pin asserting the widening
-# can only be measured where that file is readable; it is skipped elsewhere,
-# named, rather than reporting a portability fact as a defect. The refusal
-# controls are NOT gated: what they assert holds on every platform.
+# without procfs — macOS, which this family supports — answers "not an amend".
+# A pin asserting the widening is skipped there, named, rather than reporting a
+# portability fact as a defect; the refusal controls and argv pins are not.
 HAVE_PROC=0
 if [ -r "/proc/$$/cmdline" ]; then HAVE_PROC=1; fi
 
@@ -54,40 +41,33 @@ mk_repo() { # DIR — a repo with the commit-msg hook installed and the rule arm
   chmod +x "$1/.git/hooks/commit-msg"
   printf '[env]\nGROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS = "crates/* ui/*"\n' >"$1/kendex.settings.toml"
 }
-
 seed_commit() { # DIR — the base commit an amend below sits on
   printf 'seed\n' >"$1/README.md"
   git -C "$1" add -A
   git -C "$1" commit -qm "chore: base [no-changelog]" >/dev/null 2>&1
 }
-
 crate_commit() { # DIR — a commit changing a crate and carrying its fragment
   printf 'fn one() {}\n' >"$1/crates/core/lib.rs"
   printf -- '- A fix consumers see.\n' >"$1/changelog.d/fixed/ken-1.md"
   git -C "$1" add -A
   commit_in "$1" 'fix(KEN-1): change a crate'
 }
-
 more_code() { # DIR — another crate change, staged
   printf 'fn two() {}\n' >>"$1/crates/core/lib.rs"
   git -C "$1" add -A
 }
-
 commit_in() { # DIR MESSAGE [git-commit-arg...] — a real commit; sets OUT and RC
-  OUT=""
-  RC=0
-  OUT="$(git -C "$1" commit -m "$2" "${@:3}" 2>&1)" || RC=$?
+  # The flag goes AHEAD of `-m`, which is where the scan reads it: `-m` is a
+  # token the scan does not understand, because the argument behind it is the
+  # committer's to choose, and one of those ends the scan at "not an amend".
+  OUT=""; RC=0
+  OUT="$(git -C "$1" commit "${@:3}" -m "$2" 2>&1)" || RC=$?
 }
-
-# Each pin gets its own fixture: an amend either lands or is refused, and a pin
-# that is skipped for want of /proc must leave nothing for the next one to
-# inherit.
-new_repo() { # NAME — a fresh seeded repo at $TMP/NAME, named by R
-  R="$TMP/$1"
-  mk_repo "$R"
+new_repo() { # NAME — a fresh seeded repo at $TMP/NAME, named by R; one fixture
+  R="$TMP/$1"          # per pin, so a pin skipped for want of /proc leaves
+  mk_repo "$R"         # nothing for the next to inherit
   seed_commit "$R"
 }
-
 refused_naming_lib() { # 0 when RC/OUT are the refusal that names the crate path
   [ "$RC" -eq 1 ] || return 1
   case "$OUT" in *"crates/core/lib.rs changed without a changelog entry"*) return 0 ;; esac
@@ -97,27 +77,10 @@ refused_naming_lib() { # 0 when RC/OUT are the refusal that names the crate path
 echo "=== an amend is judged against the parent it will HAVE, not the HEAD it replaces ==="
 # `git diff --cached` on an amend shows only what was staged ON TOP of the
 # commit being replaced, so a fragment already inside that commit read as no
-# fragment at all and a commit satisfying the rule was refused — with the
-# obvious escape being the flag that skips the whole hook chain.
-new_repo repo-fixture
-crate_commit "$R"
-[ "$RC" -eq 0 ] && ok "fixture: the crate change lands with its fragment" \
-  || bad "fixture: the crate change lands with its fragment" "rc=$RC out=$OUT"
-
-new_repo repo-amend
-crate_commit "$R"
-more_code "$R"
-if [ "$HAVE_PROC" -eq 1 ]; then
-  commit_in "$R" 'fix(KEN-1): change a crate' --amend
-  [ "$RC" -eq 0 ] && ok "an amend adding more code passes on the fragment the commit already carries" \
-    || bad "an amend passes on the fragment the commit already carries" "rc=$RC out=$OUT"
-else
-  skip "the amend pin needs /proc/<pid>/cmdline, where the committing argv is read"
-fi
-
-# The control that reds when the amend case goes: the widening is bound to the
-# amend, so the NEXT commit — a new one, whose parent really is that HEAD — is
-# not excused by the fragment sitting in the commit before it.
+# fragment at all and a commit satisfying the rule was refused, the obvious
+# escape being the flag that skips the whole hook chain. The control that reds
+# when that goes, and the one pin here needing no /proc: the NEXT commit, whose
+# parent really is that HEAD, is not excused by the fragment in the one before.
 new_repo repo-next
 crate_commit "$R"
 more_code "$R"
@@ -126,90 +89,73 @@ refused_naming_lib \
   && ok "control: the commit AFTER a fragment commit still owes its own entry" \
   || bad "control: the commit after a fragment commit still owes its own entry" "rc=$RC out=$OUT"
 
-# And an amend of a commit that carries no fragment is refused, naming the
-# path: reading the whole commit is what widened, not the rule.
-new_repo repo-fragmentless
-git -C "$R" commit -q --allow-empty -m 'chore: nothing a consumer sees' >/dev/null 2>&1
-more_code "$R"
-commit_in "$R" 'fix(KEN-3): change a crate' --amend
-refused_naming_lib \
-  && ok "control: an amend of a fragmentless commit is refused, naming the path" \
-  || bad "control: an amend of a fragmentless commit is refused" "rc=$RC out=$OUT"
+if [ "$HAVE_PROC" -eq 0 ]; then
+  skip "the widening pins need /proc/<pid>/cmdline, where the committing argv is read"
+else
+  new_repo repo-amend
+  crate_commit "$R"
+  more_code "$R"
+  commit_in "$R" 'fix(KEN-1): change a crate' --amend
+  [ "$RC" -eq 0 ] && ok "an amend adding more code passes on the fragment the commit already carries" \
+    || bad "an amend passes on the fragment the commit already carries" "rc=$RC out=$OUT"
 
-# An amend that DROPS the fragment owes one again: what counts is the tree the
-# commit will have, never that HEAD once held an entry. Gated, because without
-# the widening the base is HEAD and the dropped fragment is the only change the
-# diff shows — no required path in it, and nothing to refuse.
-new_repo repo-dropped
-crate_commit "$R"
-if [ "$HAVE_PROC" -eq 1 ]; then
+  # What counts is the tree the commit will have, never that HEAD once held an
+  # entry. Gated too: without the widening the base is HEAD, the dropped
+  # fragment is the only change the diff shows, and no required path is in it.
+  new_repo repo-dropped
+  crate_commit "$R"
   git -C "$R" rm -q --cached changelog.d/fixed/ken-1.md
   rm -f "$R/changelog.d/fixed/ken-1.md"
   commit_in "$R" 'fix(KEN-1): change a crate' --amend
   refused_naming_lib \
     && ok "control: an amend that drops the fragment owes one again" \
     || bad "control: an amend that drops the fragment owes one again" "rc=$RC out=$OUT"
-else
-  skip "the dropped-fragment pin needs /proc/<pid>/cmdline: without it the base is HEAD and no required path moved"
-fi
 
-echo "=== a commit whose own bytes SPELL the flag is not an amend ==="
-# The committer chooses some of the bytes in that argv. A message or a pathspec
-# equal to `--amend` reached the scan as the flag before it read argv the way
-# git's parser does, and the previous commit's fragment then excused a commit
-# that carries none. These are refusals, so they hold on every platform.
-new_repo repo-spelled
-: >"$R/--amend"
-git -C "$R" add -A
-git -C "$R" commit -qm 'chore: a tracked file named for the flag [no-changelog]' >/dev/null 2>&1
-crate_commit "$R"
-more_code "$R"
-commit_in "$R" 'fix(KEN-2): change a crate again' -m '--amend'
-refused_naming_lib \
-  && ok "control: the flag text as a -m body paragraph is a message, not the flag" \
-  || bad "control: the flag text as a -m body paragraph is a message" "rc=$RC out=$OUT"
-
-new_repo repo-pathspec
-: >"$R/--amend"
-git -C "$R" add -A
-git -C "$R" commit -qm 'chore: a tracked file named for the flag [no-changelog]' >/dev/null 2>&1
-crate_commit "$R"
-printf 'fn two() {}\n' >>"$R/crates/core/lib.rs"
-commit_in "$R" 'fix(KEN-2): change a crate again' -- crates/core/lib.rs --amend
-refused_naming_lib \
-  && ok "control: a --amend PATHSPEC after the bare -- is a path, not the flag" \
-  || bad "control: a --amend pathspec after the bare -- is a path" "rc=$RC out=$OUT"
-
-echo "=== amending a repository's first commit: the parent is the empty tree ==="
-# HEAD^ does not resolve there, so the base is the hashed empty tree. Same
-# branch on the tip of a `git clone --depth 1` shallow clone, where git writes
-# a parentless commit.
-R="$TMP/repo-root"
-mk_repo "$R"
-crate_commit "$R"
-if [ "$HAVE_PROC" -eq 1 ]; then
+  # Amending a repository's FIRST commit: HEAD^ does not resolve, so the base
+  # is the hashed empty tree. Same branch on the tip of a shallow clone.
+  R="$TMP/repo-root"
+  mk_repo "$R"
+  crate_commit "$R"
   more_code "$R"
   commit_in "$R" 'fix(KEN-1): change a crate' --amend
   [ "$RC" -eq 0 ] && [ -z "$(git -C "$R" rev-parse --verify --quiet HEAD^ 2>/dev/null)" ] \
     && ok "an amend of the ROOT commit passes on the fragment it carries" \
     || bad "an amend of the root commit passes on the fragment it carries" "rc=$RC out=$OUT"
-
-  git -C "$R" rm -q --cached changelog.d/fixed/ken-1.md
-  rm -f "$R/changelog.d/fixed/ken-1.md"
-  commit_in "$R" 'fix(KEN-1): change a crate' --amend
-  refused_naming_lib \
-    && ok "control: the same root amend is refused once the fragment is dropped" \
-    || bad "control: the root amend is refused once the fragment is dropped" "rc=$RC out=$OUT"
-else
-  skip "the root-commit amend pins need /proc/<pid>/cmdline, where the committing argv is read"
 fi
 
-echo "=== what the walk reads, through a FAKE git ancestor ==="
-# A real `git commit` cannot put these shapes on the tree: it always sets
-# GIT_INDEX_FILE, it is always the nearest git ancestor, and it rejects an
-# argv git itself would not parse. A copy of bash named `git` can, and the
-# hook is invoked directly beneath it.
-#
+echo '=== which argv is an amend ==='
+# One spelling per pin, as the NUL-delimited bytes the kernel would hold. git
+# takes any unambiguous ABBREVIATION and resolves a boolean to its LAST
+# spelling, so the refusals below are what a scan matching full names by
+# equality got wrong in the FAIL-OPEN direction: it read the flag out of a
+# value the committer chose, and the previous commit's fragment excused a
+# commit carrying none.
+ARGV="$TMP/argv"
+argv_pin() { # LABEL WANT ARG... — WANT is `amend` or `plain`
+  local label="$1" want="$2" got=plain
+  shift 2
+  printf '%s\0' "$@" >"$ARGV"
+  if gg_argv_is_amend "$ARGV"; then got=amend; fi
+  [ "$got" = "$want" ] && ok "$label" || bad "$label" "read as $got, wanted $want"
+}
+argv_pin "the flag itself is the flag" amend git commit --amend
+argv_pin "--am is git's abbreviation of it, an amend this lane must widen for" amend git commit --am
+argv_pin "a no-value option ahead of the flag is stepped over" amend git commit --no-edit --amend
+argv_pin "a rebase reword's own argv widens" amend git commit --amend --no-gpg-sign -e --allow-empty
+argv_pin "the wrapper's arguments, ahead of the subcommand, are not the commit's" amend git -c user.name=x commit --amend --no-edit
+argv_pin "the flag BEFORE a value-taking option is still the flag" amend git commit --amend -m 'fix(KEN-1): change a crate'
+argv_pin "must-fail: the argument -m consumes is a message" plain git commit -m --amend
+argv_pin "must-fail: --mess is that same option, abbreviated" plain git commit --mess --amend
+argv_pin "must-fail: --templ takes a template path" plain git commit --templ --amend
+argv_pin "must-fail: --trail takes a trailer" plain git commit --trail --amend
+argv_pin "must-fail: --fil takes a message file" plain git commit --fil --amend
+argv_pin "must-fail: an attached --message=… carries its value in the token" plain git commit --message=--amend
+argv_pin "must-fail: a short BUNDLE's -m consumes the argument behind it" plain git commit -am --amend
+argv_pin "must-fail: an argument after the bare -- is a pathspec" plain git commit -- --amend
+argv_pin "must-fail: --no-amend behind the flag is git's last-spelling boolean" plain git commit --amend --no-amend -m 'fix(KEN-2): change a crate'
+argv_pin "must-fail: an argv that never reaches the commit subcommand is not one" plain git rebase --amend
+
+echo "=== what the WALK reads, through a FAKE git ancestor ==="
 # The fixture stands still: HEAD carries the crate change and its fragment,
 # HEAD^ carries neither, and the index holds HEAD's tree plus more code. Judged
 # against HEAD^ the fragment is in the diff and the run passes; judged against
@@ -225,22 +171,19 @@ else
   more_code "$FK_REPO"
   FK_MSG="$TMP/fake-message.txt"
   printf 'fix(KEN-1): change a crate\n' >"$FK_MSG"
-
   FAKE_BIN="$TMP/fake-bin"
   mkdir -p "$FAKE_BIN"
   cp -- "${BASH:-$(command -v bash)}" "$FAKE_BIN/git"
-  # The fake ancestor reads these out of the environment: it is bash, and its
-  # `-c` script is the only thing it is given.
+  # The fake ancestor is bash, and its `-c` script is all it is given, so it
+  # reads these out of the environment. `exit $s` LAST is load-bearing: bash
+  # execs the final command of a `-c` script, which for a lone `"$CM" …` would
+  # replace the fake ancestor with commit-msg and erase the very process the
+  # scan is about. A builtin is the one ending it cannot exec away.
   export CM FK_MSG FAKE_BIN
-  # `sleep 0; exit $s` is load-bearing. bash EXECS a lone `-c` command, which
-  # would replace the fake ancestor with commit-msg itself and erase the very
-  # process the scan is about.
-  FAKE_RUN='"$CM" "$FK_MSG"; s=$?; sleep 0; exit $s'
+  FAKE_RUN='"$CM" "$FK_MSG"; s=$?; exit $s'
   export FAKE_RUN
-
   fake_git() { # ARG... — commit-msg under a `git` ancestor whose argv is ARG...
-    OUT=""
-    RC=0
+    OUT=""; RC=0
     OUT="$(cd "$FK_REPO" && GIT_INDEX_FILE="$FK_REPO/.git/index" \
       "$FAKE_BIN/git" -c "$FAKE_RUN" "$@" 2>&1)" || RC=$?
   }
@@ -248,71 +191,39 @@ else
   # MUST-FAIL: git sets GIT_INDEX_FILE for the hooks it runs a commit through,
   # so its absence means a DIRECT run — a person, a script, one of this
   # family's own suites under a developer's `git commit --amend` — whose
-  # ancestors say nothing about what it judges. Drop the guard and this run is
-  # excused by a fragment the commit does not carry.
-  OUT=""
-  RC=0
-  OUT="$(cd "$FK_REPO" && "$FAKE_BIN/git" -c "$FAKE_RUN" --amend 2>&1)" || RC=$?
+  # ancestors say nothing about what it judges.
+  OUT=""; RC=0
+  OUT="$(cd "$FK_REPO" && "$FAKE_BIN/git" -c "$FAKE_RUN" commit --amend 2>&1)" || RC=$?
   refused_naming_lib \
     && ok "must-fail: a git ancestor with the flag but no GIT_INDEX_FILE is not this run's commit" \
     || bad "a git ancestor with no GIT_INDEX_FILE must not widen" "rc=$RC out=$OUT"
 
-  fake_git --amend
+  fake_git commit --amend
   [ "$RC" -eq 0 ] && ok "the walk finds the flag on the nearest git ancestor and widens" \
     || bad "the walk finds the flag on the nearest git ancestor" "rc=$RC out=$OUT"
 
-  # MUST-FAIL: the walk stops at the NEAREST git ancestor, which is the command
-  # doing the committing. A `git rebase` above it would be answering for
-  # something else, so a climb past the inner git is a commit judged against a
-  # parent it does not have.
+  # MUST-FAIL: the walk stops at the NEAREST git ancestor, the command doing
+  # the committing. A `git rebase` above it answers for something else, so a
+  # climb past the inner git judges a commit against a parent it does not have.
   OUT=""
   RC=0
-  NEST_RUN='"$FAKE_BIN/git" -c "$FAKE_RUN" commit; s=$?; sleep 0; exit $s'
+  NEST_RUN='"$FAKE_BIN/git" -c "$FAKE_RUN" commit; s=$?; exit $s'
   OUT="$(cd "$FK_REPO" && GIT_INDEX_FILE="$FK_REPO/.git/index" \
-    "$FAKE_BIN/git" -c "$NEST_RUN" --amend 2>&1)" || RC=$?
+    "$FAKE_BIN/git" -c "$NEST_RUN" commit --amend 2>&1)" || RC=$?
   refused_naming_lib \
     && ok "must-fail: an inner git WITHOUT the flag answers, not an outer git with it" \
     || bad "the walk must stop at the nearest git ancestor" "rc=$RC out=$OUT"
 
   # The depth walk: a generation carrying no git sits between the committing
-  # process and the hook, so a cap of one generation reads only that generation
-  # and never reaches the git above it.
+  # process and the hook, so a cap of one generation would never reach the git
+  # above it.
   OUT=""
   RC=0
-  DEPTH_RUN='bash -c "$FAKE_RUN"; s=$?; sleep 0; exit $s'
+  DEPTH_RUN='bash -c "$FAKE_RUN"; s=$?; exit $s'
   OUT="$(cd "$FK_REPO" && GIT_INDEX_FILE="$FK_REPO/.git/index" \
-    "$FAKE_BIN/git" -c "$DEPTH_RUN" --amend 2>&1)" || RC=$?
+    "$FAKE_BIN/git" -c "$DEPTH_RUN" commit --amend 2>&1)" || RC=$?
   [ "$RC" -eq 0 ] && ok "the walk climbs past a generation carrying no git" \
     || bad "the walk climbs past a generation carrying no git" "rc=$RC out=$OUT"
-
-  # MUST-FAIL, the argv scan itself: a value the committer chose is not the
-  # flag. git's own parser stops at the bare `--` and hands a value-taking
-  # option the argument behind it, and the scan reads argv the same way.
-  fake_git -m --amend
-  refused_naming_lib \
-    && ok "must-fail: the argument -m consumes is a message, not the flag" \
-    || bad "the argument -m consumes must not read as the flag" "rc=$RC out=$OUT"
-
-  fake_git --message --amend
-  refused_naming_lib \
-    && ok "must-fail: the argument a LONG value-taking option consumes is a message too" \
-    || bad "the argument a long value-taking option consumes must not read as the flag" "rc=$RC out=$OUT"
-
-  fake_git -am --amend
-  refused_naming_lib \
-    && ok "must-fail: the argument a SHORT BUNDLE's -m consumes is a message too" \
-    || bad "the argument a short bundle's -m consumes must not read as the flag" "rc=$RC out=$OUT"
-
-  fake_git commit -- --amend
-  refused_naming_lib \
-    && ok "must-fail: an argument after the bare -- is a pathspec, not the flag" \
-    || bad "an argument after the bare -- must not read as the flag" "rc=$RC out=$OUT"
-
-  # The control that keeps those three honest: the flag itself, in the same
-  # argv shapes, still widens.
-  fake_git --amend -m 'fix(KEN-1): change a crate'
-  [ "$RC" -eq 0 ] && ok "control: the flag BEFORE a value-taking option is still the flag" \
-    || bad "control: the flag before a value-taking option is still the flag" "rc=$RC out=$OUT"
 fi
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"

--- a/skills/growth-guards/tests/commit-msg-amend.test.sh
+++ b/skills/growth-guards/tests/commit-msg-amend.test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Pins for the one commit-msg rule that cannot be judged from an index alone:
+# the changelog a commit owes is read against the parent the commit will HAVE,
+# so an amend is judged against HEAD's parent and not against the HEAD it
+# replaces. These run through a real `git commit`, because which parent the
+# commit will have is read off that process and nowhere else — every other
+# commit-msg pin invokes the script directly and lives in commit-msg.test.sh.
+# Every firing pin is paired with the control that proves the widening is
+# bound to the amend: the next commit, an amend carrying no fragment, and an
+# amend that drops the one it had are all still refused.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+CM="$SKILL_DIR/scripts/commit-msg"
+. "$TEST_DIR/lib/harness.bash"
+
+unset GROWTH_GUARDS_COMMIT_TYPES GROWTH_GUARDS_SUBJECT_MAX \
+  GROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS GROWTH_GUARDS_CHANGELOG_PATHS \
+  GROWTH_GUARDS_CHANGELOG_RECORD GROWTH_GUARDS_SETTINGS_FILE 2>/dev/null || true
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+
+echo "=== an amend is judged against the parent it will HAVE, not the HEAD it replaces ==="
+# `git diff --cached` on an amend shows only what was staged ON TOP of the
+# commit being replaced, so a fragment already inside that commit read as no
+# fragment at all and a commit satisfying the rule was refused — with the
+# obvious escape being the flag that skips the whole hook chain. These run
+# through a real `git commit`, because which parent the commit will have is
+# read off that process and nowhere else.
+AM_REPO="$TMP/repo-amend"
+mkdir -p "$AM_REPO/crates/core" "$AM_REPO/changelog.d/fixed"
+git -C "$AM_REPO" -c init.defaultBranch=main init -q
+git -C "$AM_REPO" config user.email test@example.com
+git -C "$AM_REPO" config user.name test
+printf '#!/bin/sh\nexec %s "$1"\n' "$CM" >"$AM_REPO/.git/hooks/commit-msg"
+chmod +x "$AM_REPO/.git/hooks/commit-msg"
+printf '[env]\nGROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS = "crates/* ui/*"\n' >"$AM_REPO/kendex.settings.toml"
+printf 'seed\n' >"$AM_REPO/README.md"
+git -C "$AM_REPO" add -A
+git -C "$AM_REPO" commit -qm "chore: base [no-changelog]" >/dev/null 2>&1
+
+am_commit() { # MESSAGE [git-commit-arg...] — a real commit; sets OUT and RC
+  OUT=""
+  RC=0
+  OUT="$(git -C "$AM_REPO" commit -m "$1" "${@:2}" 2>&1)" || RC=$?
+}
+
+printf 'fn one() {}\n' >"$AM_REPO/crates/core/lib.rs"
+printf -- '- A fix consumers see.\n' >"$AM_REPO/changelog.d/fixed/ken-1.md"
+git -C "$AM_REPO" add -A
+am_commit 'fix(KEN-1): change a crate'
+[ "$RC" -eq 0 ] && ok "fixture: the crate change lands with its fragment" \
+  || bad "fixture: the crate change lands with its fragment" "rc=$RC out=$OUT"
+
+printf 'fn two() {}\n' >>"$AM_REPO/crates/core/lib.rs"
+git -C "$AM_REPO" add -A
+am_commit 'fix(KEN-1): change a crate' --amend
+[ "$RC" -eq 0 ] && ok "an amend adding more code passes on the fragment the commit already carries" \
+  || bad "an amend passes on the fragment the commit already carries" "rc=$RC out=$OUT"
+
+# The control that reds when the amend case goes: the widening is bound to the
+# amend, so the NEXT commit — a new one, whose parent really is that HEAD —
+# is not excused by the fragment sitting in the commit before it.
+printf 'fn three() {}\n' >>"$AM_REPO/crates/core/lib.rs"
+git -C "$AM_REPO" add -A
+am_commit 'fix(KEN-2): change a crate again'
+[ "$RC" -eq 1 ] && case "$OUT" in *"crates/core/lib.rs changed without a changelog entry"*) true ;; *) false ;; esac \
+  && ok "control: the commit AFTER a fragment commit still owes its own entry" \
+  || bad "control: the commit after a fragment commit still owes its own entry" "rc=$RC out=$OUT"
+git -C "$AM_REPO" reset -q --hard HEAD
+
+# And an amend of a commit that carries no fragment is refused, naming the
+# path: reading the whole commit is what widened, not the rule.
+git -C "$AM_REPO" commit -q --allow-empty -m 'chore: nothing a consumer sees' >/dev/null 2>&1
+printf 'fn four() {}\n' >>"$AM_REPO/crates/core/lib.rs"
+git -C "$AM_REPO" add -A
+am_commit 'fix(KEN-3): change a crate' --amend
+[ "$RC" -eq 1 ] && case "$OUT" in *"crates/core/lib.rs changed without a changelog entry"*) true ;; *) false ;; esac \
+  && ok "control: an amend of a fragmentless commit is refused, naming the path" \
+  || bad "control: an amend of a fragmentless commit is refused" "rc=$RC out=$OUT"
+git -C "$AM_REPO" reset -q --hard HEAD
+git -C "$AM_REPO" reset -q --hard HEAD~1
+
+# An amend that DROPS the fragment owes one again: what counts is the tree the
+# commit will have, never that HEAD once held an entry.
+git -C "$AM_REPO" rm -q --cached changelog.d/fixed/ken-1.md
+rm -f "$AM_REPO/changelog.d/fixed/ken-1.md"
+am_commit 'fix(KEN-1): change a crate' --amend
+[ "$RC" -eq 1 ] && case "$OUT" in *"crates/core/lib.rs changed without a changelog entry"*) true ;; *) false ;; esac \
+  && ok "control: an amend that drops the fragment owes one again" \
+  || bad "control: an amend that drops the fragment owes one again" "rc=$RC out=$OUT"
+git -C "$AM_REPO" reset -q --hard HEAD
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/skills/growth-guards/tests/commit-msg-amend.test.sh
+++ b/skills/growth-guards/tests/commit-msg-amend.test.sh
@@ -3,10 +3,8 @@
 # the changelog a commit owes is read against the parent the commit will HAVE,
 # so an amend is judged against HEAD's parent, not the HEAD it replaces. Three
 # kinds of pin, because the answer is read off a process — a real `git commit`
-# for the rule end to end, each firing pin against the control that reds when
-# the widening stops being bound to the amend; an argv FILE for which argv IS
-# an amend, one spelling per line; and a FAKE `git`, a copy of bash under that
-# name, for the arms that need a process.
+# for the rule end to end, each firing pin against its control; an argv FILE for
+# which argv IS an amend; and a FAKE `git`, for the arms that need a process.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -26,11 +24,18 @@ bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
 skip() { printf '  skip  %s\n' "$1"; }
 
 # The widening is read off /proc/<pid>/cmdline and nowhere else, so a host
-# without procfs — macOS, which this family supports — answers "not an amend".
-# A pin asserting the widening is skipped there, named, rather than reporting a
-# portability fact as a defect; the refusal controls and argv pins are not.
+# without procfs — macOS, which this family supports — answers "not an amend",
+# and a pin asserting the widening is SKIPPED there rather than reporting a
+# portability fact as a defect. On Linux it is not a portability fact: a
+# hardened kernel or a break in the detection would hide every widening pin
+# below behind a green run, so that pair REDS rather than skipping.
 HAVE_PROC=0
 if [ -r "/proc/$$/cmdline" ]; then HAVE_PROC=1; fi
+if [ "$(uname -s)" = Linux ] && [ "$HAVE_PROC" -eq 0 ]; then
+  bad "the /proc gate is honest" "Linux with /proc/$$/cmdline unreadable: every widening pin would skip"
+else
+  ok "the /proc gate is honest — a skip below means /proc is absent by design"
+fi
 
 mk_repo() { # DIR — a repo with the commit-msg hook installed and the rule armed
   mkdir -p "$1/crates/core" "$1/changelog.d/fixed"

--- a/skills/growth-guards/tests/commit-msg-amend.test.sh
+++ b/skills/growth-guards/tests/commit-msg-amend.test.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 # Pins for the one commit-msg rule that cannot be judged from an index alone:
 # the changelog a commit owes is read against the parent the commit will HAVE,
-# so an amend is judged against HEAD's parent, not the HEAD it replaces. Three
-# kinds of pin, because the answer is read off a process — a real `git commit`
-# for the rule end to end, each firing pin against its control; an argv FILE for
-# which argv IS an amend; and a FAKE `git`, for the arms that need a process.
+# so an amend is judged against HEAD's parent, not the HEAD it replaces. Four
+# pins, each firing one against its control: a real `git commit` for the rule
+# end to end, and an argv FILE for which argv IS an amend.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -25,17 +24,10 @@ skip() { printf '  skip  %s\n' "$1"; }
 
 # The widening is read off /proc/<pid>/cmdline and nowhere else, so a host
 # without procfs — macOS, which this family supports — answers "not an amend",
-# and a pin asserting the widening is SKIPPED there rather than reporting a
-# portability fact as a defect. On Linux it is not a portability fact: a
-# hardened kernel or a break in the detection would hide every widening pin
-# below behind a green run, so that pair REDS rather than skipping.
+# and the pair of pins asserting the widening is SKIPPED there rather than
+# reporting a portability fact as a defect.
 HAVE_PROC=0
 if [ -r "/proc/$$/cmdline" ]; then HAVE_PROC=1; fi
-if [ "$(uname -s)" = Linux ] && [ "$HAVE_PROC" -eq 0 ]; then
-  bad "the /proc gate is honest" "Linux with /proc/$$/cmdline unreadable: every widening pin would skip"
-else
-  ok "the /proc gate is honest — a skip below means /proc is absent by design"
-fi
 
 mk_repo() { # DIR — a repo with the commit-msg hook installed and the rule armed
   mkdir -p "$1/crates/core" "$1/changelog.d/fixed"
@@ -46,29 +38,22 @@ mk_repo() { # DIR — a repo with the commit-msg hook installed and the rule arm
   chmod +x "$1/.git/hooks/commit-msg"
   printf '[env]\nGROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS = "crates/* ui/*"\n' >"$1/kendex.settings.toml"
 }
-seed_commit() { # DIR — the base commit an amend below sits on
-  printf 'seed\n' >"$1/README.md"
-  git -C "$1" add -A
-  git -C "$1" commit -qm "chore: base [no-changelog]" >/dev/null 2>&1
-}
-crate_commit() { # DIR — a commit changing a crate and carrying its fragment
-  printf 'fn one() {}\n' >"$1/crates/core/lib.rs"
-  printf -- '- A fix consumers see.\n' >"$1/changelog.d/fixed/ken-1.md"
-  git -C "$1" add -A
-  commit_in "$1" 'fix(KEN-1): change a crate'
-}
-more_code() { # DIR — another crate change, staged
-  printf 'fn two() {}\n' >>"$1/crates/core/lib.rs"
-  git -C "$1" add -A
-}
-commit_in() { # DIR MESSAGE [git-commit-arg...] — a real commit; sets OUT and RC
+commit_in() { # DIR ARG... — a real commit; sets OUT and RC
   OUT=""; RC=0
-  OUT="$(git -C "$1" commit -m "$2" "${@:3}" 2>&1)" || RC=$?
+  OUT="$(git -C "$1" commit "${@:2}" 2>&1)" || RC=$?
 }
-new_repo() { # NAME — a fresh seeded repo at $TMP/NAME, named by R; one fixture
-  R="$TMP/$1"          # per pin, so a pin skipped for want of /proc leaves
-  mk_repo "$R"         # nothing for the next to inherit
-  seed_commit "$R"
+staged_on_fragment() { # NAME — HEAD carries a crate change and its fragment,
+  R="$TMP/$1"          # more crate code is staged on top, and nothing else is.
+  mk_repo "$R"         # One fixture per pin, named by R, so a pin skipped for
+  printf 'seed\n' >"$R/README.md"   # want of /proc leaves nothing behind.
+  git -C "$R" add -A
+  git -C "$R" commit -qm "chore: base [no-changelog]" >/dev/null 2>&1
+  printf 'fn one() {}\n' >"$R/crates/core/lib.rs"
+  printf -- '- A fix consumers see.\n' >"$R/changelog.d/fixed/ken-1.md"
+  git -C "$R" add -A
+  commit_in "$R" -m 'fix(KEN-1): change a crate'
+  printf 'fn two() {}\n' >>"$R/crates/core/lib.rs"
+  git -C "$R" add -A
 }
 refused_naming_lib() { # 0 when RC/OUT are the refusal that names the crate path
   [ "$RC" -eq 1 ] || return 1
@@ -81,12 +66,11 @@ echo "=== an amend is judged against the parent it will HAVE, not the HEAD it re
 # commit being replaced, so a fragment already inside that commit read as no
 # fragment at all and a commit satisfying the rule was refused, the obvious
 # escape being the flag that skips the whole hook chain. The control that reds
-# when that goes, and the one pin here needing no /proc: the NEXT commit, whose
-# parent really is that HEAD, is not excused by the fragment in the one before.
-new_repo repo-next
-crate_commit "$R"
-more_code "$R"
-commit_in "$R" 'fix(KEN-2): change a crate again'
+# when the widening goes too far, and the one pin here needing no /proc: the
+# NEXT commit, whose parent really is that HEAD, is not excused by the fragment
+# in the one before.
+staged_on_fragment repo-next
+commit_in "$R" -m 'fix(KEN-2): change a crate again'
 refused_naming_lib \
   && ok "control: the commit AFTER a fragment commit still owes its own entry" \
   || bad "control: the commit after a fragment commit still owes its own entry" "rc=$RC out=$OUT"
@@ -94,142 +78,32 @@ refused_naming_lib \
 if [ "$HAVE_PROC" -eq 0 ]; then
   skip "the widening pins need /proc/<pid>/cmdline, where the committing argv is read"
 else
-  new_repo repo-amend
-  crate_commit "$R"
-  more_code "$R"
-  commit_in "$R" 'fix(KEN-1): change a crate' --amend
+  staged_on_fragment repo-amend
+  commit_in "$R" --amend --no-edit
   [ "$RC" -eq 0 ] && ok "an amend adding more code passes on the fragment the commit already carries" \
     || bad "an amend passes on the fragment the commit already carries" "rc=$RC out=$OUT"
 
-  # What counts is the tree the commit will have, never that HEAD once held an
-  # entry. Gated too: without the widening the base is HEAD, the dropped
-  # fragment is the only change the diff shows, and no required path is in it.
-  new_repo repo-dropped
-  crate_commit "$R"
-  git -C "$R" rm -q --cached changelog.d/fixed/ken-1.md
-  rm -f "$R/changelog.d/fixed/ken-1.md"
-  commit_in "$R" 'fix(KEN-1): change a crate' --amend
+  # MUST-FAIL: `--mess` is git's abbreviation of `--message`, so the `--amend`
+  # behind it is the committer's message TEXT, not the flag. A scan reading the
+  # flag out of a value fails open, excusing this commit with the fragment the
+  # previous one carries; the widening is what that class attacks, and every
+  # fail-open this lane had came from it.
+  staged_on_fragment repo-value
+  commit_in "$R" --mess '--amend'
   refused_naming_lib \
-    && ok "control: an amend that drops the fragment owes one again" \
-    || bad "control: an amend that drops the fragment owes one again" "rc=$RC out=$OUT"
-
-  # Amending a repository's FIRST commit: HEAD^ does not resolve, so the base
-  # is the hashed empty tree. Same branch on the tip of a shallow clone.
-  R="$TMP/repo-root"
-  mk_repo "$R"
-  crate_commit "$R"
-  more_code "$R"
-  commit_in "$R" 'fix(KEN-1): change a crate' --amend
-  [ "$RC" -eq 0 ] && [ -z "$(git -C "$R" rev-parse --verify --quiet HEAD^ 2>/dev/null)" ] \
-    && ok "an amend of the ROOT commit passes on the fragment it carries" \
-    || bad "an amend of the root commit passes on the fragment it carries" "rc=$RC out=$OUT"
+    && ok "must-fail: a message VALUE spelling the flag does not widen the base" \
+    || bad "a message value spelling the flag must not widen the base" "rc=$RC out=$OUT"
 fi
 
 echo '=== which argv is an amend ==='
-# One spelling per pin, as the NUL-delimited bytes the kernel would hold. git
-# takes any unambiguous ABBREVIATION and resolves a boolean to its LAST
-# spelling, so the refusals below are what a scan matching full names by
-# equality got wrong in the FAIL-OPEN direction: it read the flag out of a
-# value the committer chose, and the previous commit's fragment excused a
-# commit carrying none.
+# The NUL-delimited bytes the kernel would hold. A message is an argument like
+# any other, so the flag BEHIND one is still the flag: nothing dash-prefixed
+# stands before it to have swallowed it.
 ARGV="$TMP/argv"
-argv_pin() { # LABEL WANT ARG... — WANT is `amend` or `plain`
-  local label="$1" want="$2" got=plain
-  shift 2
-  printf '%s\0' "$@" >"$ARGV"
-  if gg_argv_is_amend "$ARGV"; then got=amend; fi
-  [ "$got" = "$want" ] && ok "$label" || bad "$label" "read as $got, wanted $want"
-}
-argv_pin "the flag itself is the flag" amend git commit --amend
-argv_pin "the flag BEHIND a message is the flag: the message is not dash-prefixed" amend git commit -m 'fix(KEN-1): change a crate' --amend
-argv_pin "--am is git's abbreviation of it, an amend this lane must widen for" amend git commit --am
-argv_pin "a no-value option ahead of the flag is stepped over" amend git commit --no-edit --amend
-argv_pin "a no-value SHORT option ahead of the flag is stepped over" amend git commit -a --amend
-argv_pin "a rebase reword's own argv widens" amend git commit --amend --no-gpg-sign -e --allow-empty
-argv_pin "the wrapper's arguments, ahead of the subcommand, are not the commit's" amend git -c user.name=x commit --amend --no-edit
-argv_pin "the flag BEFORE a value-taking option is still the flag" amend git commit --amend -m 'fix(KEN-1): change a crate'
-argv_pin "must-fail: the argument -m consumes IS the message" plain git commit -m --amend
-argv_pin "must-fail: --mess is that same option, abbreviated" plain git commit --mess --amend
-argv_pin "must-fail: --templ takes a template path" plain git commit --templ --amend
-argv_pin "must-fail: --trail takes a trailer" plain git commit --trail --amend
-argv_pin "must-fail: --fil takes a message file" plain git commit --fil --amend
-argv_pin "must-fail: an attached --message=… carries its value in the token" plain git commit --message=--amend
-argv_pin "must-fail: a short BUNDLE's -m consumes the argument behind it" plain git commit -am --amend
-argv_pin "must-fail: an argument after the bare -- is a pathspec" plain git commit -- crates/core/lib.rs --amend
-argv_pin "must-fail: --no-amend behind the flag is git's last-spelling boolean" plain git commit --amend --no-amend -m 'fix(KEN-2): change a crate'
-argv_pin "must-fail: an unknown token cannot swallow the negation git honours" plain git commit --amend --no-status --no-amend -m 'fix(KEN-2): change a crate'
-argv_pin "must-fail: an argv that never reaches the commit subcommand is not one" plain git rebase --amend
-
-echo "=== what the WALK reads, through a FAKE git ancestor ==="
-# The fixture stands still: HEAD carries the crate change and its fragment,
-# HEAD^ carries neither, and the index holds HEAD's tree plus more code. Judged
-# against HEAD^ the fragment is in the diff and the run passes; judged against
-# HEAD only the crate change is, and the run is refused. One bit, either way.
-if [ "$HAVE_PROC" -eq 0 ]; then
-  skip "the ancestor-walk pins need /proc/<pid>/cmdline: with no procfs there is no argv to read"
-else
-  FK_REPO="$TMP/repo-fake"
-  mk_repo "$FK_REPO"
-  rm -f "$FK_REPO/.git/hooks/commit-msg"
-  seed_commit "$FK_REPO"
-  crate_commit "$FK_REPO"
-  more_code "$FK_REPO"
-  FK_MSG="$TMP/fake-message.txt"
-  printf 'fix(KEN-1): change a crate\n' >"$FK_MSG"
-  FAKE_BIN="$TMP/fake-bin"
-  mkdir -p "$FAKE_BIN"
-  cp -- "${BASH:-$(command -v bash)}" "$FAKE_BIN/git"
-  # The fake ancestor is bash, and its `-c` script is all it is given, so it
-  # reads these out of the environment. `exit $s` LAST is load-bearing: bash
-  # execs the final command of a `-c` script, which for a lone `"$CM" …` would
-  # replace the fake ancestor with commit-msg and erase the very process the
-  # scan is about. A builtin is the one ending it cannot exec away.
-  export CM FK_MSG FAKE_BIN
-  FAKE_RUN='"$CM" "$FK_MSG"; s=$?; exit $s'
-  export FAKE_RUN
-  fake_git() { # ARG... — commit-msg under a `git` ancestor whose argv is ARG...
-    OUT=""; RC=0
-    OUT="$(cd "$FK_REPO" && GIT_INDEX_FILE="$FK_REPO/.git/index" \
-      "$FAKE_BIN/git" -c "$FAKE_RUN" "$@" 2>&1)" || RC=$?
-  }
-
-  # MUST-FAIL: git sets GIT_INDEX_FILE for the hooks it runs a commit through,
-  # so its absence means a DIRECT run — a person, a script, one of this
-  # family's own suites under a developer's `git commit --amend` — whose
-  # ancestors say nothing about what it judges.
-  OUT=""; RC=0
-  OUT="$(cd "$FK_REPO" && "$FAKE_BIN/git" -c "$FAKE_RUN" commit --amend 2>&1)" || RC=$?
-  refused_naming_lib \
-    && ok "must-fail: a git ancestor with the flag but no GIT_INDEX_FILE is not this run's commit" \
-    || bad "a git ancestor with no GIT_INDEX_FILE must not widen" "rc=$RC out=$OUT"
-
-  fake_git commit --amend
-  [ "$RC" -eq 0 ] && ok "the walk finds the flag on the nearest git ancestor and widens" \
-    || bad "the walk finds the flag on the nearest git ancestor" "rc=$RC out=$OUT"
-
-  # MUST-FAIL: the walk stops at the NEAREST git ancestor, the command doing
-  # the committing. A `git rebase` above it answers for something else, so a
-  # climb past the inner git judges a commit against a parent it does not have.
-  OUT=""
-  RC=0
-  NEST_RUN='"$FAKE_BIN/git" -c "$FAKE_RUN" commit; s=$?; exit $s'
-  OUT="$(cd "$FK_REPO" && GIT_INDEX_FILE="$FK_REPO/.git/index" \
-    "$FAKE_BIN/git" -c "$NEST_RUN" commit --amend 2>&1)" || RC=$?
-  refused_naming_lib \
-    && ok "must-fail: an inner git WITHOUT the flag answers, not an outer git with it" \
-    || bad "the walk must stop at the nearest git ancestor" "rc=$RC out=$OUT"
-
-  # The depth walk: a generation carrying no git sits between the committing
-  # process and the hook, so a cap of one generation would never reach the git
-  # above it.
-  OUT=""
-  RC=0
-  DEPTH_RUN='bash -c "$FAKE_RUN"; s=$?; exit $s'
-  OUT="$(cd "$FK_REPO" && GIT_INDEX_FILE="$FK_REPO/.git/index" \
-    "$FAKE_BIN/git" -c "$DEPTH_RUN" commit --amend 2>&1)" || RC=$?
-  [ "$RC" -eq 0 ] && ok "the walk climbs past a generation carrying no git" \
-    || bad "the walk climbs past a generation carrying no git" "rc=$RC out=$OUT"
-fi
+printf '%s\0' git commit -m 'fix(KEN-1): change a crate' --amend >"$ARGV"
+gg_argv_is_amend "$ARGV" \
+  && ok "the flag behind a message is the flag" \
+  || bad "the flag behind a message is the flag" "read as plain, wanted amend"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/growth-guards/tests/commit-msg-amend.test.sh
+++ b/skills/growth-guards/tests/commit-msg-amend.test.sh
@@ -62,11 +62,8 @@ more_code() { # DIR — another crate change, staged
   git -C "$1" add -A
 }
 commit_in() { # DIR MESSAGE [git-commit-arg...] — a real commit; sets OUT and RC
-  # The flag goes AHEAD of `-m`, which is where the scan reads it: `-m` is a
-  # token the scan does not understand, because the argument behind it is the
-  # committer's to choose, and one of those ends the scan at "not an amend".
   OUT=""; RC=0
-  OUT="$(git -C "$1" commit "${@:3}" -m "$2" 2>&1)" || RC=$?
+  OUT="$(git -C "$1" commit -m "$2" "${@:3}" 2>&1)" || RC=$?
 }
 new_repo() { # NAME — a fresh seeded repo at $TMP/NAME, named by R; one fixture
   R="$TMP/$1"          # per pin, so a pin skipped for want of /proc leaves
@@ -144,12 +141,13 @@ argv_pin() { # LABEL WANT ARG... — WANT is `amend` or `plain`
   [ "$got" = "$want" ] && ok "$label" || bad "$label" "read as $got, wanted $want"
 }
 argv_pin "the flag itself is the flag" amend git commit --amend
+argv_pin "the flag BEHIND a message is the flag: the message is not dash-prefixed" amend git commit -m 'fix(KEN-1): change a crate' --amend
 argv_pin "--am is git's abbreviation of it, an amend this lane must widen for" amend git commit --am
 argv_pin "a no-value option ahead of the flag is stepped over" amend git commit --no-edit --amend
 argv_pin "a rebase reword's own argv widens" amend git commit --amend --no-gpg-sign -e --allow-empty
 argv_pin "the wrapper's arguments, ahead of the subcommand, are not the commit's" amend git -c user.name=x commit --amend --no-edit
 argv_pin "the flag BEFORE a value-taking option is still the flag" amend git commit --amend -m 'fix(KEN-1): change a crate'
-argv_pin "must-fail: the argument -m consumes is a message" plain git commit -m --amend
+argv_pin "must-fail: the argument -m consumes IS the message" plain git commit -m --amend
 argv_pin "must-fail: --mess is that same option, abbreviated" plain git commit --mess --amend
 argv_pin "must-fail: --templ takes a template path" plain git commit --templ --amend
 argv_pin "must-fail: --trail takes a trailer" plain git commit --trail --amend

--- a/skills/growth-guards/tests/commit-msg-amend.test.sh
+++ b/skills/growth-guards/tests/commit-msg-amend.test.sh
@@ -144,6 +144,7 @@ argv_pin "the flag itself is the flag" amend git commit --amend
 argv_pin "the flag BEHIND a message is the flag: the message is not dash-prefixed" amend git commit -m 'fix(KEN-1): change a crate' --amend
 argv_pin "--am is git's abbreviation of it, an amend this lane must widen for" amend git commit --am
 argv_pin "a no-value option ahead of the flag is stepped over" amend git commit --no-edit --amend
+argv_pin "a no-value SHORT option ahead of the flag is stepped over" amend git commit -a --amend
 argv_pin "a rebase reword's own argv widens" amend git commit --amend --no-gpg-sign -e --allow-empty
 argv_pin "the wrapper's arguments, ahead of the subcommand, are not the commit's" amend git -c user.name=x commit --amend --no-edit
 argv_pin "the flag BEFORE a value-taking option is still the flag" amend git commit --amend -m 'fix(KEN-1): change a crate'
@@ -154,8 +155,9 @@ argv_pin "must-fail: --trail takes a trailer" plain git commit --trail --amend
 argv_pin "must-fail: --fil takes a message file" plain git commit --fil --amend
 argv_pin "must-fail: an attached --message=… carries its value in the token" plain git commit --message=--amend
 argv_pin "must-fail: a short BUNDLE's -m consumes the argument behind it" plain git commit -am --amend
-argv_pin "must-fail: an argument after the bare -- is a pathspec" plain git commit -- --amend
+argv_pin "must-fail: an argument after the bare -- is a pathspec" plain git commit -- crates/core/lib.rs --amend
 argv_pin "must-fail: --no-amend behind the flag is git's last-spelling boolean" plain git commit --amend --no-amend -m 'fix(KEN-2): change a crate'
+argv_pin "must-fail: an unknown token cannot swallow the negation git honours" plain git commit --amend --no-status --no-amend -m 'fix(KEN-2): change a crate'
 argv_pin "must-fail: an argv that never reaches the commit subcommand is not one" plain git rebase --amend
 
 echo "=== what the WALK reads, through a FAKE git ancestor ==="


### PR DESCRIPTION
## Summary

- `commit-msg` read its file set from `git diff --cached`, which on an amend shows only what was staged on top of the commit being replaced — so a fragment already inside that commit read as no fragment at all, and the lane refused a commit that satisfied the rule. Both file lists now come from a diff against the parent the commit will **have**: `HEAD` ordinarily, `HEAD^` on an amend, the empty tree when amending a root commit.
- git tells a `commit-msg` hook nothing about an amend — the environment, the `.git` directory and the hook arguments are byte-identical for a plain commit and an amend (verified). The only signal is the argv of the `git commit` the hook descends from, so `scripts/lib/commit-parent.sh` reads it there, gated twice so every unknown falls back to the old refusal: `GIT_INDEX_FILE` must be set, and only the nearest `git` ancestor decides.
- `--amend` counts as the flag only when the token **immediately before** it cannot have been reaching for a value — a value-taking option consumes only the next argument, so that one token decides it. `--no-amend` is recognised unconditionally, since discarding a negation git honours is the fail-open direction. The enumeration is therefore not a security boundary: a name missing from it costs a refusal, never an excuse.

## Known limit

The widening reads `/proc/<pid>/cmdline`, so it lands on Linux and on Windows under MSYS. **macOS keeps the existing refusal** — `ps -o args=` joins argv with spaces, so a commit message merely *containing* `--amend` would read as the flag and excuse a commit that owes an entry. An old refusal beats a gate that fails open. Every surface states this: `CHECKS.md`, `DEVELOPMENT.md`, the lib header, the `commit-msg --help` text, and the changelog fragment ("On Linux, …").

## Behaviour worth knowing

- A rebase `reword` runs `git commit --amend` as a child of the rebase and is an amend by this reading, so rewording a commit that changes a required path and predates the rule now needs `[no-changelog]` in the reworded header. An `edit` stop spawns no commit; the committer's own amend at the stop is what fires the hook. Plain all-pick rebases and autosquash fixups run the hook zero times.
- Attached-value and bundled forms immediately before the flag (`-m'msg' --amend`, `--message=… --amend`, `-uall --amend`, `--status --amend`) read as **not** an amend and are refused. That is the fail-closed direction, and the writer clears it with a fragment or `[no-changelog]`.
- Prefix matching is safe because every name in the no-value table is still a real `git commit` option, which is what makes a colliding abbreviation ambiguous in git. A future git that *removed* one of those names while shipping a value-taking option under the same prefix would reopen the class; a pure addition cannot.

## Completed Issues

- Closes KEN-808 - An amend is refused for a changelog fragment the commit already carries

## Test Plan

`skills/growth-guards/tests/commit-msg-amend.test.sh` — four controls, cut to that set by an owner scope ruling on the grounds that a 235-line suite against a 124-line library was disproportionate:

- control: the commit **after** a fragment commit still owes its own entry (a real plain `git commit`)
- an amend adding more code passes on the fragment the commit already carries (a real `git commit --amend --no-edit`)
- must-fail: a message **value** spelling the flag does not widen the base (a real `git commit --mess '--amend'` on a `crates/` change with no fragment)
- the flag behind a message is the flag (`-m 'msg' --amend`, an argv fixture)

Non-vacuous, checked by mutation on a scratch copy and reverted: removing the value-swallow guard reds the must-fail and its output shows the commit being excused; forcing `gg_is_amend` to `return 1` reds the amend pin. Neither mutation is in the branch.

`HAVE_PROC` detection gates only the two widening pins, so a host without procfs skips those and still runs the refusal pins live. The shell shards run on `ubuntu-latest`, where `/proc` is readable, so those pins execute on every PR and merge-queue run.

**Deliberately unpinned by the same ruling**, named here rather than left implicit: the `GIT_INDEX_FILE` guard, the stop at the nearest `git` ancestor, the depth cap, the `--no-amend` arm, the bare `--` stop, the short no-value option class, and the `/proc`-gate honesty assertion. Each was pinned earlier in this branch and each fails **closed** when broken except the `--no-amend` arm and the bare `--` stop; the fake-`git` ancestor harness those pins needed went with them.

Validation: all growth-guards suites green, `commit-msg` 123/123, `tools/guard` exit 0 (including `cargo test -p kendex-core --test quality`), `tools/bash32-lint` clean over 426 files, preflight clean, size-ratchet OK.

## Review

Nine reviewers over three rounds plus a five-reviewer verification pass. The argv approach produced three successive fail-opens, each found only adversarially and each reproduced end to end against real git 2.55 before being fixed:

| Round | Fail-open | Closed by |
|---|---|---|
| 1 | `--amend` matched at any argv position (`-m 'header' -m '--amend'`, a `--amend` pathspec after `--`) | positional and `--`-terminator awareness |
| 2 | abbreviated value-taking options (`--mess '--amend'`) and `--amend --no-amend` | the option table deleted; preceding-token rule |
| 3 | `--no-amend` under the same guard, where its safe direction inverts (229 of 557 probed shapes) | the negation taken out from under the guard |

Verification before the suite cut: a 163-spelling differential harness against real `git commit` reported **0 fail-open**, 18 fail-closed divergences (all attached-value forms or omitted no-value names), and mutation coverage killed every arm named above. The library is unchanged since that verification — the final commit is test-only.

https://claude.ai/code/session_01LeDMyUnSGKvHUMdbaMbM6E
