### PR TITLE
fix(KEN-790): the cycles cache is not team-scoped, so say so

### DIFF
--- a/.agents/skills/linear/scripts/commands/cache-query.sh
+++ b/.agents/skills/linear/scripts/commands/cache-query.sh
@@ -932,7 +932,7 @@ cache_get_initiative() {
 # =============================================================================
 
 cache_list_cycles() {
-    local cycle_type="" team="" limit=50
+    local cycle_type="" limit=50
     FORMAT="${DEFAULT_FORMAT}"
 
     while [[ $# -gt 0 ]]; do
@@ -941,10 +941,9 @@ cache_list_cycles() {
             cycle_type="$2"
             shift 2
             ;;
-        --team)
-            team="$2"
-            shift 2
-            ;; # ignored — cache is team-scoped
+        # sync scopes cycles to a team only when one is configured; with none
+        # configured the cache holds every team's cycles.
+        --team) shift 2 ;; # consume but ignore for cache
         --limit)
             limit="$2"
             shift 2

--- a/skills/linear/scripts/commands/cache-query.sh
+++ b/skills/linear/scripts/commands/cache-query.sh
@@ -932,7 +932,7 @@ cache_get_initiative() {
 # =============================================================================
 
 cache_list_cycles() {
-    local cycle_type="" team="" limit=50
+    local cycle_type="" limit=50
     FORMAT="${DEFAULT_FORMAT}"
 
     while [[ $# -gt 0 ]]; do
@@ -941,10 +941,9 @@ cache_list_cycles() {
             cycle_type="$2"
             shift 2
             ;;
-        --team)
-            team="$2"
-            shift 2
-            ;; # ignored — cache is team-scoped
+        # sync scopes cycles to a team only when one is configured; with none
+        # configured the cache holds every team's cycles.
+        --team) shift 2 ;; # consume but ignore for cache
         --limit)
             limit="$2"
             shift 2

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -81,7 +81,7 @@ skills/iced-rs/iced_wgpu/src/lib.rs	960
 skills/iced-rs/iced_wgpu/src/text.rs	649
 skills/iced-rs/iced_wgpu/src/triangle.rs	887
 skills/iced-rs/iced_wgpu/src/window/compositor.rs	427
-skills/linear/scripts/commands/cache-query.sh	1210
+skills/linear/scripts/commands/cache-query.sh	1209
 skills/linear/scripts/commands/initiatives.sh	470
 skills/linear/scripts/commands/issues.sh	3221
 skills/linear/scripts/commands/projects.sh	1366


### PR DESCRIPTION
## Summary

- `cache cycles list --team X` consumed the flag under a comment claiming the cache was team-scoped. It is not: `sync_cycles` filters cycles by team only when `LINEAR_TEAM_TARGET` is set, and caches every team's cycles when none is configured.
- The comment now says what the cache actually holds, in the same `# consume but ignore for cache` form the issues parser two hundred lines up already carries. The flag's assigned-but-never-read `team` local goes with it.
- Behavior is unchanged: `--team` is still consumed, so the flag after it is not swallowed. `reviewer-test` proved this differentially — main's `cache-query.sh` and this branch's, side by side through `linear.sh cache cycles list` against a two-team fixture cache, produce identical output for `--team KEN`, for `--team KEN --type current`, and identical exit 1 for a trailing valueless `--team`.

The `--team` cache filter itself stays deferred: the owner re-scoped this issue on 2026-09-01 to the false comment alone, the filter being a feature with a shipped KEN-779 workaround.

## Completed Issues

- Closes KEN-790 - linear: the issues cache carries no team, so nothing can filter by it

## Created Issues

- KEN-1150 - linear: cached cycle reads ignore `--team` and pick the current cycle across every team — Project: Skills & Agents Library

Review found the honest comment exposes three live defects sharing one cause, all pre-existing and unarmed by this diff. The usage block still advertises `cycles list [--team X]`; the `--type current|past|upcoming` arms carry no team predicate, so a bare `--type current` returns whichever team started most recently; and `session-status.sh` repeats that unscoped selection over the same file, which is the read `cycle-plan` actually consumes. Four reviewers reproduced them independently on two-team fixture caches.

## Test Plan

- All 48 `skills/linear/tests/*.test.sh` suites pass.
- `tools/guard` exit 0 on the restacked head, `preflight` clean.
- `size-ratchet` OK across 2880 tracked files; the baseline row for `cache-query.sh` moves 1210 → 1209, matching `wc -l` on both the source and the `.agents/` render, which are byte-identical.

---
https://claude.ai/code/session_01Bt2PG3mJjR4UEbi88Coc1k
