### PR TITLE
fix(KEN-762): a keychain that refuses names itself, not the directory

### DIFF
--- a/changelog.d/fixed/KEN-762.md
+++ b/changelog.d/fixed/KEN-762.md
@@ -1,3 +1,3 @@
-- A keychain that will not release the sign-in now says so. It used to
-  report the community directory as unreachable, sending you to check a
-  network that was working.
+- A keychain that will not release the sign-in now says so, in the app and
+  in `kendex login`. It used to report the community directory as
+  unreachable, sending you to check a working network.

--- a/changelog.d/fixed/KEN-762.md
+++ b/changelog.d/fixed/KEN-762.md
@@ -1,0 +1,3 @@
+- A keychain that will not release the sign-in now says so. It used to
+  report the community directory as unreachable, sending you to check a
+  network that was working.

--- a/crates/cli/src/commands/login.rs
+++ b/crates/cli/src/commands/login.rs
@@ -13,7 +13,10 @@ use kendex_core::registry::{CurlFetch, base_url};
 pub fn login() -> Result<()> {
     let fetch = CurlFetch;
     let store = KeyringStore;
-    if let Ok(Some(_)) = store.load() {
+    // A store that refuses the read is not a machine with no credential:
+    // starting the device flow would spend the user's approval on a
+    // sign-in the keychain has already said it will not hold.
+    if store.load()?.is_some() {
         say(&format!(
             "Already signed in to {} — run `kendex logout` first to switch.",
             base_url()

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -155,6 +155,13 @@ pub enum CoreError {
     #[error("credential refresh is busy: another kendex process holds {lock}")]
     CredentialRefreshBusy { lock: PathBuf },
 
+    /// The OS keychain would not serve the sign-in: locked, denied at the
+    /// prompt, or unreachable from this session. Separate from
+    /// `RegistryUnavailable` because nothing here is remote — reported as a
+    /// directory outage, it sends the user to check a working network.
+    #[error("the credential store on this machine could not be used: {why}")]
+    CredentialStoreUnavailable { why: String },
+
     #[error("app update check is busy: another kendex process holds {lock}")]
     AppUpdateBusy { lock: PathBuf },
 

--- a/crates/core/src/registry/credentials.rs
+++ b/crates/core/src/registry/credentials.rs
@@ -82,13 +82,43 @@ fn transaction_lock_file(
         .join(format!(".kendex-credential-{digest}.lock"))
 }
 
+/// Which keychain call would not answer. Every arm reports the credential
+/// store as the cause, because that is what failed: a locked keyring, a
+/// denied prompt, or a session that cannot reach the keychain. None of them
+/// is the community directory, and a user told otherwise checks a network
+/// that is working.
+#[derive(Clone, Copy, Debug)]
+enum StoreRefusal {
+    /// No keychain answered, so no entry could be opened.
+    NoStore,
+    /// The sign-in could not be written.
+    Save,
+    /// The stored sign-in could not be read back.
+    Load,
+    /// The stored sign-in could not be removed.
+    Clear,
+}
+
+impl StoreRefusal {
+    fn refused(self, error: &keyring::Error) -> CoreError {
+        CoreError::CredentialStoreUnavailable {
+            why: match self {
+                Self::NoStore => format!("no keychain answered: {error}"),
+                Self::Save => format!(
+                    "the sign-in was refused: {error}. Nothing was written anywhere \
+                     else — there is no plaintext fallback."
+                ),
+                Self::Load => format!("the stored sign-in could not be read: {error}"),
+                Self::Clear => format!("the removal was refused: {error}"),
+            },
+        }
+    }
+}
+
 fn entry() -> Result<keyring::Entry> {
     let identity = active_identity();
-    keyring::Entry::new(identity.service, &identity.endpoint).map_err(|error| {
-        CoreError::RegistryUnavailable {
-            why: format!("no usable credential store: {error}"),
-        }
-    })
+    keyring::Entry::new(identity.service, &identity.endpoint)
+        .map_err(|error| StoreRefusal::NoStore.refused(&error))
 }
 
 impl CredentialStore for KeyringStore {
@@ -99,12 +129,7 @@ impl CredentialStore for KeyringStore {
             })?;
         entry()?
             .set_password(&json)
-            .map_err(|error| CoreError::RegistryUnavailable {
-                why: format!(
-                    "the credential store refused to hold the sign-in: {error}. \
-                     Nothing was written anywhere else — there is no plaintext fallback."
-                ),
-            })
+            .map_err(|error| StoreRefusal::Save.refused(&error))
     }
 
     fn load(&self) -> Result<Option<Credential>> {
@@ -121,18 +146,14 @@ impl CredentialStore for KeyringStore {
                 Ok(Some(credential))
             }
             Err(keyring::Error::NoEntry) => Ok(None),
-            Err(error) => Err(CoreError::RegistryUnavailable {
-                why: format!("the credential store could not be read: {error}"),
-            }),
+            Err(error) => Err(StoreRefusal::Load.refused(&error)),
         }
     }
 
     fn clear(&self) -> Result<()> {
         match entry()?.delete_credential() {
             Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
-            Err(error) => Err(CoreError::RegistryUnavailable {
-                why: format!("the credential store refused the removal: {error}"),
-            }),
+            Err(error) => Err(StoreRefusal::Clear.refused(&error)),
         }
     }
 
@@ -173,6 +194,37 @@ mod tests {
             serde_json::from_str(stored).expect("a stored credential still reads");
         assert_eq!(credential.refresh_token, "kxr");
         assert!(credential.sign_in.is_empty());
+    }
+
+    /// The keychain is local, so its failures must not read as the
+    /// community directory being down: a user sent to check their network
+    /// never finds the locked keyring that actually refused.
+    #[test]
+    fn every_keychain_refusal_names_the_credential_store() {
+        for refusal in [
+            StoreRefusal::NoStore,
+            StoreRefusal::Save,
+            StoreRefusal::Load,
+            StoreRefusal::Clear,
+        ] {
+            let shown = refusal
+                .refused(&keyring::Error::NoStorageAccess(Box::new(
+                    std::io::Error::other("the keyring is locked"),
+                )))
+                .to_string();
+            assert!(
+                shown.contains("the credential store on this machine"),
+                "{refusal:?} names the store that refused: {shown}"
+            );
+            assert!(
+                !shown.contains("community directory"),
+                "{refusal:?} sends the user to the network instead: {shown}"
+            );
+            assert!(
+                shown.contains("the keyring is locked"),
+                "{refusal:?} drops the reason the OS gave: {shown}"
+            );
+        }
     }
 
     #[test]

--- a/crates/core/src/registry/credentials.rs
+++ b/crates/core/src/registry/credentials.rs
@@ -4,7 +4,7 @@
 //! credential says where it is from, and a build kept off the real machine
 //! can neither spend nor delete the sign-in the installed app holds. No
 //! silent plaintext fallback exists: where no store answers, the caller
-//! says so and offers session-only auth.
+//! says so.
 
 use crate::error::{CoreError, Result};
 use crate::fs::LockedFile;
@@ -82,12 +82,8 @@ fn transaction_lock_file(
         .join(format!(".kendex-credential-{digest}.lock"))
 }
 
-/// Which keychain call would not answer. Every arm reports the credential
-/// store as the cause, because that is what failed: a locked keyring, a
-/// denied prompt, or a session that cannot reach the keychain. None of them
-/// is the community directory, and a user told otherwise checks a network
-/// that is working.
-#[derive(Clone, Copy, Debug)]
+/// Which keychain call would not answer. Every arm answers with
+/// `CoreError::CredentialStoreUnavailable`, whose doc holds why.
 enum StoreRefusal {
     /// No keychain answered, so no entry could be opened.
     NoStore,
@@ -194,37 +190,6 @@ mod tests {
             serde_json::from_str(stored).expect("a stored credential still reads");
         assert_eq!(credential.refresh_token, "kxr");
         assert!(credential.sign_in.is_empty());
-    }
-
-    /// The keychain is local, so its failures must not read as the
-    /// community directory being down: a user sent to check their network
-    /// never finds the locked keyring that actually refused.
-    #[test]
-    fn every_keychain_refusal_names_the_credential_store() {
-        for refusal in [
-            StoreRefusal::NoStore,
-            StoreRefusal::Save,
-            StoreRefusal::Load,
-            StoreRefusal::Clear,
-        ] {
-            let shown = refusal
-                .refused(&keyring::Error::NoStorageAccess(Box::new(
-                    std::io::Error::other("the keyring is locked"),
-                )))
-                .to_string();
-            assert!(
-                shown.contains("the credential store on this machine"),
-                "{refusal:?} names the store that refused: {shown}"
-            );
-            assert!(
-                !shown.contains("community directory"),
-                "{refusal:?} sends the user to the network instead: {shown}"
-            );
-            assert!(
-                shown.contains("the keyring is locked"),
-                "{refusal:?} drops the reason the OS gave: {shown}"
-            );
-        }
     }
 
     #[test]

--- a/crates/core/src/registry/me.rs
+++ b/crates/core/src/registry/me.rs
@@ -52,12 +52,15 @@ struct WireMe {
 /// Ask who is signed in. An absent credential is `SignedOut`; a dead credential is
 /// `Expired` and its cached identity is dropped; an unreachable or
 /// misbehaving server serves the cached identity as `Offline`, and errors
-/// only with nothing cached to serve. A keychain that refuses is none of
-/// those: it is local, so it errors with its own sentence however warm the
-/// cache is. The cache key names the sign-in this read opened with rather
-/// than either token, so a refresh rotation leaves it readable. The store gets no final read after the authenticated call:
-/// a sign-out or account switch landing in that final request window does
-/// not change this call's answer.
+/// only with nothing cached to serve. A keychain refusal that reaches this
+/// call on its own is none of those: it is local, so it errors with its own
+/// sentence however warm the cache is. One that refused the removal behind
+/// the server's rejection rides in that `SignInExpired`'s `why` and still
+/// answers `Expired`. The cache key names the sign-in this read opened with
+/// rather than either token, so a refresh rotation leaves it readable. The
+/// store gets no final read after the authenticated call: a sign-out or
+/// account switch landing in that final request window does not change this
+/// call's answer.
 pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<AccountState> {
     let Some(credential) = store.load()? else {
         return Ok(AccountState::SignedOut);
@@ -87,10 +90,9 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
             cache.forget()?;
             return Ok(AccountState::Expired);
         }
-        // The keychain refused a read, a write or the transaction lock
-        // somewhere inside the call. Serving the cache as `Offline` would
-        // tell the user the directory was last reached, when the machine
-        // never asked it anything.
+        // The keychain refused a read or a write somewhere inside the call.
+        // Serving the cache as `Offline` would tell the user the directory
+        // was last reached, when the machine never asked it anything.
         Err(refused @ CoreError::CredentialStoreUnavailable { .. }) => return Err(refused),
         fetched => fetched,
     };

--- a/crates/core/src/registry/me.rs
+++ b/crates/core/src/registry/me.rs
@@ -52,9 +52,10 @@ struct WireMe {
 /// Ask who is signed in. An absent credential is `SignedOut`; a dead credential is
 /// `Expired` and its cached identity is dropped; an unreachable or
 /// misbehaving server serves the cached identity as `Offline`, and errors
-/// only with nothing cached to serve. The cache key names the sign-in this
-/// read opened with rather than either token, so a refresh rotation leaves
-/// it readable. The store gets no final read after the authenticated call:
+/// only with nothing cached to serve. A keychain that refuses is none of
+/// those: it is local, so it errors with its own sentence however warm the
+/// cache is. The cache key names the sign-in this read opened with rather
+/// than either token, so a refresh rotation leaves it readable. The store gets no final read after the authenticated call:
 /// a sign-out or account switch landing in that final request window does
 /// not change this call's answer.
 pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<AccountState> {
@@ -86,6 +87,11 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
             cache.forget()?;
             return Ok(AccountState::Expired);
         }
+        // The keychain refused a read, a write or the transaction lock
+        // somewhere inside the call. Serving the cache as `Offline` would
+        // tell the user the directory was last reached, when the machine
+        // never asked it anything.
+        Err(refused @ CoreError::CredentialStoreUnavailable { .. }) => return Err(refused),
         fetched => fetched,
     };
     let loaded = cache.settle(cached, fetched, parse, |response| {

--- a/crates/core/tests/credential_store_refusals.rs
+++ b/crates/core/tests/credential_store_refusals.rs
@@ -1,0 +1,160 @@
+//! What the real `KeyringStore` reports when the OS keychain refuses.
+//!
+//! The keychain is replaced through keyring's own builder seam rather than
+//! faked at the `CredentialStore` trait, so the four call sites in
+//! `credentials.rs` are the code under test. `set_default_credential_builder`
+//! is process-global, which is why this is its own test binary and why the
+//! cases hold `BACKEND` across the swap.
+
+use std::any::Any;
+use std::sync::{Mutex, MutexGuard};
+
+use kendex_core::error::CoreError;
+use kendex_core::registry::credentials::{Credential as SignIn, CredentialStore, KeyringStore};
+use keyring::credential::{Credential, CredentialApi, CredentialBuilderApi, CredentialPersistence};
+
+/// Serializes the swap of the process-global builder with the call that
+/// reads it. Poisoning is ignored: a failed case has already reported
+/// itself, and blocking the rest behind it would hide theirs.
+static BACKEND: Mutex<()> = Mutex::new(());
+
+fn held() -> MutexGuard<'static, ()> {
+    BACKEND.lock().unwrap_or_else(|held| held.into_inner())
+}
+
+/// What a locked keyring answers. Every case uses it, so the assertion
+/// that the message still carries the OS reason has one string to look for.
+fn locked() -> keyring::Error {
+    keyring::Error::NoStorageAccess(Box::new(std::io::Error::other("the keyring is locked")))
+}
+
+/// A keychain that refuses. `at_build` refuses before an entry exists,
+/// which is the only way to reach `entry()`; otherwise the entry is built
+/// and every call on it refuses.
+struct Refusing {
+    at_build: bool,
+}
+
+impl CredentialBuilderApi for Refusing {
+    fn build(
+        &self,
+        _target: Option<&str>,
+        _service: &str,
+        _user: &str,
+    ) -> keyring::Result<Box<Credential>> {
+        match self.at_build {
+            true => Err(locked()),
+            false => Ok(Box::new(RefusingEntry)),
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn persistence(&self) -> CredentialPersistence {
+        CredentialPersistence::EntryOnly
+    }
+}
+
+struct RefusingEntry;
+
+impl CredentialApi for RefusingEntry {
+    fn set_secret(&self, _secret: &[u8]) -> keyring::Result<()> {
+        Err(locked())
+    }
+
+    fn get_secret(&self) -> keyring::Result<Vec<u8>> {
+        Err(locked())
+    }
+
+    fn delete_credential(&self) -> keyring::Result<()> {
+        Err(locked())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+fn install(at_build: bool) {
+    keyring::set_default_credential_builder(Box::new(Refusing { at_build }));
+}
+
+fn stored() -> SignIn {
+    SignIn {
+        endpoint: "https://kendex.ai".to_owned(),
+        access_token: "kxa".to_owned(),
+        refresh_token: "kxr".to_owned(),
+        capabilities: Vec::new(),
+        sign_in: "sign-in-ada".to_owned(),
+    }
+}
+
+#[track_caller]
+fn names_the_store(error: &CoreError, cause: &str) {
+    assert!(
+        matches!(error, CoreError::CredentialStoreUnavailable { .. }),
+        "a keychain refusal is not a registry outage: {error:?}"
+    );
+    let shown = error.to_string();
+    assert!(
+        !shown.contains("community directory"),
+        "the user is sent to check a working network: {shown}"
+    );
+    assert!(
+        shown.contains(cause),
+        "the call that refused is unnamed: {shown}"
+    );
+    assert!(
+        shown.contains("the keyring is locked"),
+        "the reason the OS gave is dropped: {shown}"
+    );
+}
+
+#[test]
+fn no_keychain_at_all_refuses_every_call_as_the_store() {
+    let _held = held();
+    install(true);
+
+    for error in [
+        KeyringStore.save(&stored()).expect_err("save refuses"),
+        KeyringStore.load().expect_err("load refuses"),
+        KeyringStore.clear().expect_err("clear refuses"),
+    ] {
+        names_the_store(&error, "no keychain answered");
+    }
+}
+
+#[test]
+fn a_refused_write_names_the_store() {
+    let _held = held();
+    install(false);
+
+    names_the_store(
+        &KeyringStore.save(&stored()).expect_err("save refuses"),
+        "the sign-in was refused",
+    );
+}
+
+#[test]
+fn a_refused_read_names_the_store() {
+    let _held = held();
+    install(false);
+
+    names_the_store(
+        &KeyringStore.load().expect_err("load refuses"),
+        "the stored sign-in could not be read",
+    );
+}
+
+#[test]
+fn a_refused_removal_names_the_store() {
+    let _held = held();
+    install(false);
+
+    names_the_store(
+        &KeyringStore.clear().expect_err("clear refuses"),
+        "the removal was refused",
+    );
+}

--- a/crates/core/tests/credential_store_refusals.rs
+++ b/crates/core/tests/credential_store_refusals.rs
@@ -29,8 +29,8 @@ fn locked() -> keyring::Error {
 }
 
 /// A keychain that refuses. `at_build` refuses before an entry exists,
-/// which is the only way to reach `entry()`; otherwise the entry is built
-/// and every call on it refuses.
+/// which is the only way to reach `entry()`'s refusal; otherwise the entry
+/// is built and every call on it refuses.
 struct Refusing {
     at_build: bool,
 }

--- a/crates/core/tests/credential_transactions.rs
+++ b/crates/core/tests/credential_transactions.rs
@@ -71,8 +71,10 @@ impl CredentialStore for Store {
 
     fn clear(&self) -> Result<()> {
         if self.delete_refused {
-            return Err(CoreError::RegistryUnavailable {
-                why: "the credential store refused the removal".to_owned(),
+            // The shape `KeyringStore::clear` returns when the OS keychain
+            // will not give the sign-in up.
+            return Err(CoreError::CredentialStoreUnavailable {
+                why: "the removal was refused: the keyring is locked".to_owned(),
             });
         }
         *self.credential.lock().map_err(|_| lock_error())? = None;
@@ -413,8 +415,12 @@ fn a_store_that_will_not_delete_still_answers_expired() {
         "the user learns the credential is still installed: {refused}"
     );
     assert!(
-        refused.contains("the credential store refused the removal"),
+        refused.contains("the credential store on this machine"),
         "the user learns what refused it: {refused}"
+    );
+    assert!(
+        !refused.contains("community directory"),
+        "a local keychain failure must not read as a directory outage: {refused}"
     );
     assert!(
         !refused.contains("— run `kendex login` again"),

--- a/crates/core/tests/credential_transactions.rs
+++ b/crates/core/tests/credential_transactions.rs
@@ -71,8 +71,10 @@ impl CredentialStore for Store {
 
     fn clear(&self) -> Result<()> {
         if self.delete_refused {
-            // The shape `KeyringStore::clear` returns when the OS keychain
-            // will not give the sign-in up.
+            // A stand-in for a keychain that will not give the sign-in up.
+            // What `KeyringStore::clear` really builds is pinned by
+            // tests/credential_store_refusals.rs; this literal only feeds
+            // `expired()`.
             return Err(CoreError::CredentialStoreUnavailable {
                 why: "the removal was refused: the keyring is locked".to_owned(),
             });
@@ -416,11 +418,7 @@ fn a_store_that_will_not_delete_still_answers_expired() {
     );
     assert!(
         refused.contains("the credential store on this machine"),
-        "the user learns what refused it: {refused}"
-    );
-    assert!(
-        !refused.contains("community directory"),
-        "a local keychain failure must not read as a directory outage: {refused}"
+        "expired() replaced the store's refusal instead of composing it: {refused}"
     );
     assert!(
         !refused.contains("— run `kendex login` again"),

--- a/crates/core/tests/me_client/main.rs
+++ b/crates/core/tests/me_client/main.rs
@@ -6,8 +6,12 @@
 //! of kendex-web's `contracts/api/v1/me.json` — drift between the repos
 //! is a `cmp` away.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::path::Path;
+
+#[path = "../../../test_util.rs"]
+mod test_util;
+use test_util::rooted;
 
 use kendex_core::env::{Env, FakeOs};
 use kendex_core::error::{CoreError, Result};
@@ -86,34 +90,65 @@ fn away() -> Result<FetchResponse> {
     })
 }
 
-struct MemoryStore(RefCell<Option<Credential>>);
+struct MemoryStore {
+    credential: RefCell<Option<Credential>>,
+    /// Which read starts refusing, counting from one: a keychain that locks
+    /// after `load` has taken the sign-in and before the authenticated call
+    /// takes it again.
+    refuses_from: Option<u32>,
+    reads: Cell<u32>,
+}
 
 impl MemoryStore {
+    fn holding(credential: Option<Credential>) -> MemoryStore {
+        MemoryStore {
+            credential: RefCell::new(credential),
+            refuses_from: None,
+            reads: Cell::new(0),
+        }
+    }
+
     fn signed_in() -> MemoryStore {
-        MemoryStore(RefCell::new(Some(Credential {
+        MemoryStore::holding(Some(Credential {
             endpoint: "https://kendex.ai".to_owned(),
             access_token: "kxa_old".to_owned(),
             refresh_token: "kxr_old".to_owned(),
             capabilities: vec!["submission:write".to_owned()],
             sign_in: ADA.to_owned(),
-        })))
+        }))
     }
 
     fn signed_out() -> MemoryStore {
-        MemoryStore(RefCell::new(None))
+        MemoryStore::holding(None)
+    }
+
+    fn refusing_from(read: u32) -> MemoryStore {
+        MemoryStore {
+            refuses_from: Some(read),
+            ..MemoryStore::signed_in()
+        }
     }
 }
 
 impl CredentialStore for MemoryStore {
     fn save(&self, credential: &Credential) -> Result<()> {
-        *self.0.borrow_mut() = Some(credential.clone());
+        *self.credential.borrow_mut() = Some(credential.clone());
         Ok(())
     }
     fn load(&self) -> Result<Option<Credential>> {
-        Ok(self.0.borrow().clone())
+        let read = self.reads.get() + 1;
+        self.reads.set(read);
+        if self.refuses_from.is_some_and(|first| read >= first) {
+            // The shape `KeyringStore::load` answers with; its wording is
+            // pinned by tests/credential_store_refusals.rs.
+            return Err(CoreError::CredentialStoreUnavailable {
+                why: "the stored sign-in could not be read: the keyring is locked".to_owned(),
+            });
+        }
+        Ok(self.credential.borrow().clone())
     }
     fn clear(&self) -> Result<()> {
-        *self.0.borrow_mut() = None;
+        *self.credential.borrow_mut() = None;
         Ok(())
     }
     fn refresh_guard(&self) -> Result<Box<dyn CredentialRefreshGuard + '_>> {
@@ -233,6 +268,36 @@ fn network_away_serves_the_cached_identity_as_offline() {
         AccountState::Offline { identity, .. } => assert_eq!(identity.name, "Ada Lovelace"),
         other => panic!("expected offline, got {other:?}"),
     }
+}
+
+/// A warm cache answers for a directory that will not talk. It must not
+/// answer for a keychain that will not talk: the machine never asked the
+/// directory anything, so "when kendex.ai was last reached" is a lie about
+/// what failed.
+#[test]
+fn a_refusing_keychain_is_not_served_as_offline() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = rooted(&dir);
+    let env = env_in(&root);
+    let warm = MemoryStore::signed_in();
+    let first = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
+    me::load(&env, &first, &warm).expect("first load");
+
+    // The second read is the one inside the authenticated call: the sign-in
+    // check ahead of it must still pass, or nothing reaches the seam.
+    let store = MemoryStore::refusing_from(2);
+    let unused = Canned::new(vec![]);
+    let refused = me::load(&env, &unused, &store).expect_err("a refusing keychain errors");
+
+    assert!(
+        matches!(refused, CoreError::CredentialStoreUnavailable { .. }),
+        "the cache stood in for the keychain: {refused:?}"
+    );
+    assert!(
+        !refused.to_string().contains("community directory"),
+        "the user is sent to check a working network: {refused}"
+    );
+    assert_eq!(*unused.calls.borrow(), 0, "the directory was never asked");
 }
 
 #[test]

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -2,7 +2,7 @@
 .github/workflows/skill-tests.yml	530
 crates/core/src/engine/deps.rs	455
 crates/core/src/engine/detach.rs	417
-crates/core/src/error.rs	473
+crates/core/src/error.rs	480
 crates/core/src/mapping.rs	411
 crates/core/src/settings_file.rs	408
 pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts	650


### PR DESCRIPTION
## Summary
- A keychain that refuses now names the credential store. New `CoreError::CredentialStoreUnavailable` ("the credential store on this machine could not be used: {why}") replaces `RegistryUnavailable` at all four `KeyringStore` sites — `entry`, `save`, `load`, `clear` — held in one exhaustive `StoreRefusal` match so they cannot drift apart. `RegistryUnavailable` keeps its community-directory prose for the client, cache, login, me, collections and skillssh callers that really are the directory.
- The refusal reaches the user on both surfaces. `me::load` matches `CredentialStoreUnavailable` out ahead of `cache.settle`, beside `NotSignedIn` and `SignInExpired`, so a locked keyring is no longer served as a stale `Offline` identity tipped "when kendex.ai was last reached"; and `kendex login` propagates the store read instead of discarding it, so a refusing keychain stops before the device flow spends a browser approval.
- `crates/core/tests/credential_store_refusals.rs` drives the real `KeyringStore` through an injected keyring `CredentialBuilderApi`, so the four production call sites are under test rather than the mapping table alone.

## Completed Issues
- Closes KEN-762 - A keychain failure is reported as the community directory being unreachable

## Created Issues
- KEN-1160 - A local failure still reads as a directory outage — Project: Tech Debt & Bugs

## Test Plan
`tools/guard` exits 0 with no `guard:` lines.

Must-fail controls, each run red before green and independently reproduced by the reviewer:

- Reverting all four `KeyringStore` sites to the pre-fix `RegistryUnavailable` reddens all four cases in `credential_store_refusals.rs`; reverting `save` alone reddens only `a_refused_write_names_the_store`.
- Deleting the `CredentialStoreUnavailable` arm from `me::load` reddens `a_refusing_keychain_is_not_served_as_offline`, and the panic shows the warm cache being served as `Offline { identity }` — the defect itself.
- Rewriting the `CredentialStoreUnavailable` display text reddens `a_store_that_will_not_delete_still_answers_expired`, so the message prefix stays pinned.

`credential_store_refusals` is its own test binary because `set_default_credential_builder` is process-global; it ran 25/25 clean at `--test-threads 64`.

## Notes
- `crates/core/src/error.rs` grew 473 → 480 lines for the new variant. The `tools/size-ratchet-baseline.tsv` row is raised and every commit on this branch needs `RATCHET_RAISE=1`; the reason is in the first commit's body.
- Reviewed by nine internal reviewers over three cycles. Three blockers found and fixed; three findings declined with reasons recorded; the residual class — a local failure still reaching the user as a directory outage through unnamed variants and through the TypeScript `asOffline` — is filed as KEN-1160 rather than patched here, since this diff neither introduces nor arms it.
- The cross-model external review could not run (the codex CLI exited 1), so this carries internal review only.
