### PR TITLE
test(KEN-1016): the wiring gate names an untested pi package

### DIFF
--- a/pi-extensions/package-policy.test.mjs
+++ b/pi-extensions/package-policy.test.mjs
@@ -177,29 +177,17 @@ test("every Pi extension carries a consumer-facing CHANGELOG.md", () => {
 	}
 });
 
-// A file under tests/ that holds no case is a fixture or a helper, not a suite:
-// `preload.ts`, `harness.ts`, `rpc-harness.mjs` and their kin exist to be
-// imported by the cases beside them. Counting one as coverage is what would let
-// a package carrying nothing but fixtures satisfy the declaration below. Names
-// carry nothing here — pi-caveman's only case file is `unit-instructions.ts`
-// and pi-claude-bridge's are `unit-*.mjs` — so the file's own source is read.
-function holdsCases(source) {
-	return /\b(?:test|it|describe)\s*\(/.test(source);
-}
-
-function caseBearingFiles(dir) {
-	return suiteFiles(dir).filter((file) => holdsCases(readFileSync(file, "utf8")));
-}
-
 function suiteCounts() {
-	return packages().map(({ dir }) => [dir, caseBearingFiles(join(root, dir)).length]);
+	return packages().map(({ dir }) => [dir, suiteFiles(join(root, dir)).length]);
 }
 
-// A package carrying no test case used to drop out of the wiring gate before
-// any of its assertions ran: no suite means no entry point to demand and
+// A package carrying no file under tests/ used to drop out of the wiring gate
+// before any of its assertions ran: no suite means no entry point to demand and
 // nothing for a CI step to invoke, so shipping a package untested looked
 // exactly like shipping one covered. Naming them here is what turns that state
 // into a declaration a reviewer reads rather than an absence nothing reports.
+// What is counted is files under tests/, not cases in them — a package whose
+// tests/ holds only fixtures reads as covered.
 //
 // pi-prompt-stash: the stash behaviour — filterItems, previewText, loadItems,
 // saveItems, stashPrompt, safeFileName — sits unexported inside
@@ -210,7 +198,10 @@ function suiteCounts() {
 // pi-task-panel vendor, and no suite in this tree imports any of the three —
 // pi-codex-minimal-tools/tests/settings.test.ts covers its own `src/settings.ts`,
 // a different file that happens to export a same-named recordProjectTrust
-// (KEN-1016).
+// (KEN-1016). Nothing reds when that reason expires: direction three below
+// fires only once the package gains tests, not when it becomes testable, so
+// exporting one of those functions tomorrow leaves the entry standing. It is
+// reviewed on this comment, not held by the gate.
 const NO_SUITE = ["pi-prompt-stash"];
 
 // Every direction the declaration can drift from the tree, kept separate
@@ -219,16 +210,16 @@ const NO_SUITE = ["pi-prompt-stash"];
 // did — makes a renamed or deleted package report as one that gained tests, a
 // claim about a directory that is not there; `crates/core/src/pi_ext/renames.rs`
 // records prompt-stash -> pi-prompt-stash, so this repo has walked that path.
-// Taking the per-package case counts as an argument is what lets the control
+// Taking the per-package suite counts as an argument is what lets the control
 // below run this exact reader over a mutated tree instead of asserting against
 // a second literal.
 function suiteDeclarationDrift(counts) {
 	const known = counts.map(([dir]) => dir);
-	const bare = counts.filter(([, cases]) => cases === 0).map(([dir]) => dir);
+	const bare = counts.filter(([, files]) => files === 0).map(([dir]) => dir);
 	return [
-		...bare.filter((dir) => !NO_SUITE.includes(dir)).map((dir) => `${dir}: carries no test case and is not declared in NO_SUITE`),
+		...bare.filter((dir) => !NO_SUITE.includes(dir)).map((dir) => `${dir}: carries no test file and is not declared in NO_SUITE`),
 		...NO_SUITE.filter((dir) => !known.includes(dir)).map((dir) => `${dir}: declared in NO_SUITE but is not a package directory — the entry is stale`),
-		...NO_SUITE.filter((dir) => known.includes(dir) && !bare.includes(dir)).map((dir) => `${dir}: declared in NO_SUITE but carries test cases — drop the declaration`),
+		...NO_SUITE.filter((dir) => known.includes(dir) && !bare.includes(dir)).map((dir) => `${dir}: declared in NO_SUITE but carries test files — drop the declaration`),
 	];
 }
 
@@ -250,9 +241,8 @@ test("every Pi extension suite runs in CI under the package's own test script", 
 	const workflow = readFileSync(workflowPath, "utf8");
 	const steps = ciSteps(workflow);
 	const dirs = packages().map(({ dir }) => dir);
-	// `bearing` stays on the broader reader: a package whose tests/ holds only
-	// helpers still declares an entry point CI must invoke.
-	const bearing = packages().filter(({ dir }) => suiteFiles(join(root, dir)).length > 0).map(({ dir }) => dir);
+	const counts = suiteCounts();
+	const bearing = counts.filter(([, files]) => files > 0).map(([dir]) => dir);
 	// Every side is derived from the tree and the workflow, so a reader that
 	// matched nothing would pass this case vacuously — which is the gap it
 	// exists to close. Floor each reader first; a zero here means the reader is
@@ -262,9 +252,9 @@ test("every Pi extension suite runs in CI under the package's own test script", 
 	assert.ok(bearing.length > 0, "no package carries test files — the suite-file walker is broken");
 
 	assert.deepEqual(
-		suiteDeclarationDrift(suiteCounts()),
+		suiteDeclarationDrift(counts),
 		[],
-		"a Pi package carries no test case without NO_SUITE declaring it, or a NO_SUITE entry is stale",
+		"a Pi package carries no test file without NO_SUITE declaring it, or a NO_SUITE entry is stale",
 	);
 
 	assert.deepEqual(
@@ -305,34 +295,22 @@ test("a step conditioned on a shard the matrix does not run is reported, not acc
 // Must-fail control for the declaration above: with every package in the tree
 // either covered or declared, the drift reader returns the same empty list a
 // reader that had stopped looking would, so each direction it reports is
-// mutated here. The case predicate is exercised separately — no count mutation
-// reaches it, and a fixture-only tests/ file is exactly what used to read as
-// coverage.
-test("a package with no test case is reported unless NO_SUITE declares it", () => {
+// mutated here.
+test("a package with no test file is reported unless NO_SUITE declares it", () => {
 	const counts = suiteCounts();
 	assert.deepEqual(suiteDeclarationDrift(counts), [], "precondition: the real tree matches NO_SUITE");
 
-	assert.equal(holdsCases("export const fixture = 1;\n"), false, "a fixture-only file reads as coverage");
-	assert.equal(holdsCases('test("x", () => {});\n'), true, "a file holding a case does not read as one");
-	// And against the tree, so the predicate is not merely agreeing with
-	// strings written beside it: it must reject at least one shipped helper.
-	const shipped = packages().flatMap(({ dir }) => suiteFiles(join(root, dir)));
-	assert.ok(
-		shipped.some((file) => !holdsCases(readFileSync(file, "utf8"))),
-		"no shipped tests/ file is case-free, so the predicate proves nothing about real helpers",
-	);
-
-	const stripped = counts.find(([dir, cases]) => cases > 0 && !NO_SUITE.includes(dir));
+	const stripped = counts.find(([dir, files]) => files > 0 && !NO_SUITE.includes(dir));
 	assert.ok(stripped, "no covered package to strip — this control no longer mutates the tree it reads");
 	assert.deepEqual(
-		suiteDeclarationDrift(counts.map(([dir, cases]) => [dir, dir === stripped[0] ? 0 : cases])),
-		[`${stripped[0]}: carries no test case and is not declared in NO_SUITE`],
+		suiteDeclarationDrift(counts.map(([dir, files]) => [dir, dir === stripped[0] ? 0 : files])),
+		[`${stripped[0]}: carries no test file and is not declared in NO_SUITE`],
 	);
 
 	assert.ok(NO_SUITE.length > 0, "NO_SUITE is empty — the two declaration directions below mutate nothing");
 	assert.deepEqual(
-		suiteDeclarationDrift(counts.map(([dir, cases]) => [dir, NO_SUITE.includes(dir) ? 1 : cases])),
-		NO_SUITE.map((dir) => `${dir}: declared in NO_SUITE but carries test cases — drop the declaration`),
+		suiteDeclarationDrift(counts.map(([dir, files]) => [dir, NO_SUITE.includes(dir) ? 1 : files])),
+		NO_SUITE.map((dir) => `${dir}: declared in NO_SUITE but carries test files — drop the declaration`),
 	);
 	assert.deepEqual(
 		suiteDeclarationDrift(counts.filter(([dir]) => !NO_SUITE.includes(dir))),

--- a/pi-extensions/package-policy.test.mjs
+++ b/pi-extensions/package-policy.test.mjs
@@ -177,26 +177,58 @@ test("every Pi extension carries a consumer-facing CHANGELOG.md", () => {
 	}
 });
 
-// A package carrying no test file used to drop out of the wiring gate before
-// any of its assertions ran: no suite files means no entry point to demand and
+// A file under tests/ that holds no case is a fixture or a helper, not a suite:
+// `preload.ts`, `harness.ts`, `rpc-harness.mjs` and their kin exist to be
+// imported by the cases beside them. Counting one as coverage is what would let
+// a package carrying nothing but fixtures satisfy the declaration below. Names
+// carry nothing here — pi-caveman's only case file is `unit-instructions.ts`
+// and pi-claude-bridge's are `unit-*.mjs` — so the file's own source is read.
+function holdsCases(source) {
+	return /\b(?:test|it|describe)\s*\(/.test(source);
+}
+
+function caseBearingFiles(dir) {
+	return suiteFiles(dir).filter((file) => holdsCases(readFileSync(file, "utf8")));
+}
+
+function suiteCounts() {
+	return packages().map(({ dir }) => [dir, caseBearingFiles(join(root, dir)).length]);
+}
+
+// A package carrying no test case used to drop out of the wiring gate before
+// any of its assertions ran: no suite means no entry point to demand and
 // nothing for a CI step to invoke, so shipping a package untested looked
 // exactly like shipping one covered. Naming them here is what turns that state
-// into a declaration a reviewer reads, and the drift reader below reds on both
-// sides — an undeclared bare package, and a declaration the tree outgrew.
+// into a declaration a reviewer reads rather than an absence nothing reports.
 //
-// pi-prompt-stash: editor shortcut plus popup rendering against pi-tui, with no
-// behaviour extracted behind a testable seam yet (KEN-1016).
+// pi-prompt-stash: the stash behaviour — filterItems, previewText, loadItems,
+// saveItems, stashPrompt, safeFileName — sits unexported inside
+// `extensions/prompt-stash.ts`, which exports only its default entry point, so
+// a suite cannot reach it behind the editor shortcut and the pi-tui popup. The
+// two leaf modules beside it are importable and simply uncovered:
+// `extensions/settings.ts` is byte-identical to the copies pi-questions and
+// pi-task-panel vendor, and no suite in this tree imports any of the three —
+// pi-codex-minimal-tools/tests/settings.test.ts covers its own `src/settings.ts`,
+// a different file that happens to export a same-named recordProjectTrust
+// (KEN-1016).
 const NO_SUITE = ["pi-prompt-stash"];
 
-// Both directions of the NO_SUITE declaration against the tree. Taking the
-// per-package suite counts as an argument is what lets the control below run
-// this exact reader over a mutated tree instead of asserting against a second
-// literal.
+// Every direction the declaration can drift from the tree, kept separate
+// because the remedies differ: write cases, drop a stale entry, or correct a
+// name the tree no longer has. Collapsing the last two — as this reader first
+// did — makes a renamed or deleted package report as one that gained tests, a
+// claim about a directory that is not there; `crates/core/src/pi_ext/renames.rs`
+// records prompt-stash -> pi-prompt-stash, so this repo has walked that path.
+// Taking the per-package case counts as an argument is what lets the control
+// below run this exact reader over a mutated tree instead of asserting against
+// a second literal.
 function suiteDeclarationDrift(counts) {
-	const bare = counts.filter(([, files]) => files === 0).map(([dir]) => dir);
+	const known = counts.map(([dir]) => dir);
+	const bare = counts.filter(([, cases]) => cases === 0).map(([dir]) => dir);
 	return [
-		...bare.filter((dir) => !NO_SUITE.includes(dir)).map((dir) => `${dir}: carries no test file and is not declared in NO_SUITE`),
-		...NO_SUITE.filter((dir) => !bare.includes(dir)).map((dir) => `${dir}: declared in NO_SUITE but carries test files — drop the declaration`),
+		...bare.filter((dir) => !NO_SUITE.includes(dir)).map((dir) => `${dir}: carries no test case and is not declared in NO_SUITE`),
+		...NO_SUITE.filter((dir) => !known.includes(dir)).map((dir) => `${dir}: declared in NO_SUITE but is not a package directory — the entry is stale`),
+		...NO_SUITE.filter((dir) => known.includes(dir) && !bare.includes(dir)).map((dir) => `${dir}: declared in NO_SUITE but carries test cases — drop the declaration`),
 	];
 }
 
@@ -218,8 +250,9 @@ test("every Pi extension suite runs in CI under the package's own test script", 
 	const workflow = readFileSync(workflowPath, "utf8");
 	const steps = ciSteps(workflow);
 	const dirs = packages().map(({ dir }) => dir);
-	const counts = packages().map(({ dir }) => [dir, suiteFiles(join(root, dir)).length]);
-	const bearing = counts.filter(([, files]) => files > 0).map(([dir]) => dir);
+	// `bearing` stays on the broader reader: a package whose tests/ holds only
+	// helpers still declares an entry point CI must invoke.
+	const bearing = packages().filter(({ dir }) => suiteFiles(join(root, dir)).length > 0).map(({ dir }) => dir);
 	// Every side is derived from the tree and the workflow, so a reader that
 	// matched nothing would pass this case vacuously — which is the gap it
 	// exists to close. Floor each reader first; a zero here means the reader is
@@ -228,13 +261,10 @@ test("every Pi extension suite runs in CI under the package's own test script", 
 	assert.ok(steps.length > 0, `no per-package steps found in ${workflowPath} — the workflow reader is broken`);
 	assert.ok(bearing.length > 0, "no package carries test files — the suite-file walker is broken");
 
-	// Before the filter below narrows to packages that carry tests, hold the
-	// ones that carry none against the declaration — that narrowing is where an
-	// untested package used to leave the gate unremarked.
 	assert.deepEqual(
-		suiteDeclarationDrift(counts),
+		suiteDeclarationDrift(suiteCounts()),
 		[],
-		"a Pi package carries no test file without NO_SUITE declaring it, or a NO_SUITE declaration is stale",
+		"a Pi package carries no test case without NO_SUITE declaring it, or a NO_SUITE entry is stale",
 	);
 
 	assert.deepEqual(
@@ -274,21 +304,38 @@ test("a step conditioned on a shard the matrix does not run is reported, not acc
 
 // Must-fail control for the declaration above: with every package in the tree
 // either covered or declared, the drift reader returns the same empty list a
-// reader that had stopped looking would, so both directions are mutated here.
-test("a package carrying no test file is reported unless NO_SUITE declares it", () => {
-	const counts = packages().map(({ dir }) => [dir, suiteFiles(join(root, dir)).length]);
+// reader that had stopped looking would, so each direction it reports is
+// mutated here. The case predicate is exercised separately — no count mutation
+// reaches it, and a fixture-only tests/ file is exactly what used to read as
+// coverage.
+test("a package with no test case is reported unless NO_SUITE declares it", () => {
+	const counts = suiteCounts();
 	assert.deepEqual(suiteDeclarationDrift(counts), [], "precondition: the real tree matches NO_SUITE");
 
-	const stripped = counts.find(([dir, files]) => files > 0 && !NO_SUITE.includes(dir));
-	assert.ok(stripped, "no covered package to strip — this control no longer mutates the tree it reads");
-	assert.deepEqual(
-		suiteDeclarationDrift(counts.map(([dir, files]) => [dir, dir === stripped[0] ? 0 : files])),
-		[`${stripped[0]}: carries no test file and is not declared in NO_SUITE`],
+	assert.equal(holdsCases("export const fixture = 1;\n"), false, "a fixture-only file reads as coverage");
+	assert.equal(holdsCases('test("x", () => {});\n'), true, "a file holding a case does not read as one");
+	// And against the tree, so the predicate is not merely agreeing with
+	// strings written beside it: it must reject at least one shipped helper.
+	const shipped = packages().flatMap(({ dir }) => suiteFiles(join(root, dir)));
+	assert.ok(
+		shipped.some((file) => !holdsCases(readFileSync(file, "utf8"))),
+		"no shipped tests/ file is case-free, so the predicate proves nothing about real helpers",
 	);
 
-	assert.ok(NO_SUITE.length > 0, "NO_SUITE is empty — the stale-declaration direction below mutates nothing");
+	const stripped = counts.find(([dir, cases]) => cases > 0 && !NO_SUITE.includes(dir));
+	assert.ok(stripped, "no covered package to strip — this control no longer mutates the tree it reads");
 	assert.deepEqual(
-		suiteDeclarationDrift(counts.map(([dir, files]) => [dir, NO_SUITE.includes(dir) ? 1 : files])),
-		NO_SUITE.map((dir) => `${dir}: declared in NO_SUITE but carries test files — drop the declaration`),
+		suiteDeclarationDrift(counts.map(([dir, cases]) => [dir, dir === stripped[0] ? 0 : cases])),
+		[`${stripped[0]}: carries no test case and is not declared in NO_SUITE`],
+	);
+
+	assert.ok(NO_SUITE.length > 0, "NO_SUITE is empty — the two declaration directions below mutate nothing");
+	assert.deepEqual(
+		suiteDeclarationDrift(counts.map(([dir, cases]) => [dir, NO_SUITE.includes(dir) ? 1 : cases])),
+		NO_SUITE.map((dir) => `${dir}: declared in NO_SUITE but carries test cases — drop the declaration`),
+	);
+	assert.deepEqual(
+		suiteDeclarationDrift(counts.filter(([dir]) => !NO_SUITE.includes(dir))),
+		NO_SUITE.map((dir) => `${dir}: declared in NO_SUITE but is not a package directory — the entry is stale`),
 	);
 });

--- a/pi-extensions/package-policy.test.mjs
+++ b/pi-extensions/package-policy.test.mjs
@@ -181,13 +181,16 @@ function suiteCounts() {
 	return packages().map(({ dir }) => [dir, suiteFiles(join(root, dir)).length]);
 }
 
-// A package carrying no file under tests/ used to drop out of the wiring gate
-// before any of its assertions ran: no suite means no entry point to demand and
-// nothing for a CI step to invoke, so shipping a package untested looked
-// exactly like shipping one covered. Naming them here is what turns that state
-// into a declaration a reviewer reads rather than an absence nothing reports.
-// What is counted is files under tests/, not cases in them — a package whose
-// tests/ holds only fixtures reads as covered.
+// A package carrying no file `suiteFiles` matches used to drop out of the
+// wiring gate before any of its assertions ran: no suite means no entry point
+// to demand and nothing for a CI step to invoke, so shipping a package untested
+// looked exactly like shipping one covered. Naming them here is what turns that
+// state into a declaration a reviewer reads rather than an absence nothing
+// reports. That reader takes a `tests/`, `test/` or `__tests__/` directory at
+// any depth, so pi-extension-manager's `test/` and pi-questions' and
+// pi-tool-renderer's `extensions/__tests__/` all count. What is counted is
+// those files, not cases in them: a package whose test directory holds only
+// fixtures reads as covered.
 //
 // pi-prompt-stash: the stash behaviour — filterItems, previewText, loadItems,
 // saveItems, stashPrompt, safeFileName — sits unexported inside
@@ -205,7 +208,7 @@ function suiteCounts() {
 const NO_SUITE = ["pi-prompt-stash"];
 
 // Every direction the declaration can drift from the tree, kept separate
-// because the remedies differ: write cases, drop a stale entry, or correct a
+// because the remedies differ: add a suite, drop a stale entry, or correct a
 // name the tree no longer has. Collapsing the last two — as this reader first
 // did — makes a renamed or deleted package report as one that gained tests, a
 // claim about a directory that is not there; `crates/core/src/pi_ext/renames.rs`
@@ -290,7 +293,6 @@ test("a step conditioned on a shard the matrix does not run is reported, not acc
 	assert.notEqual(typo, workflow, "the mutation matched nothing — this control no longer mutates the step it names");
 	assert.deepEqual(unrunPackages(typo), ["pi-claude-bridge: no step on a shard the matrix runs invokes `npm run test:ci`"]);
 });
-
 
 // Must-fail control for the declaration above: with every package in the tree
 // either covered or declared, the drift reader returns the same empty list a

--- a/pi-extensions/package-policy.test.mjs
+++ b/pi-extensions/package-policy.test.mjs
@@ -177,6 +177,29 @@ test("every Pi extension carries a consumer-facing CHANGELOG.md", () => {
 	}
 });
 
+// A package carrying no test file used to drop out of the wiring gate before
+// any of its assertions ran: no suite files means no entry point to demand and
+// nothing for a CI step to invoke, so shipping a package untested looked
+// exactly like shipping one covered. Naming them here is what turns that state
+// into a declaration a reviewer reads, and the drift reader below reds on both
+// sides — an undeclared bare package, and a declaration the tree outgrew.
+//
+// pi-prompt-stash: editor shortcut plus popup rendering against pi-tui, with no
+// behaviour extracted behind a testable seam yet (KEN-1016).
+const NO_SUITE = ["pi-prompt-stash"];
+
+// Both directions of the NO_SUITE declaration against the tree. Taking the
+// per-package suite counts as an argument is what lets the control below run
+// this exact reader over a mutated tree instead of asserting against a second
+// literal.
+function suiteDeclarationDrift(counts) {
+	const bare = counts.filter(([, files]) => files === 0).map(([dir]) => dir);
+	return [
+		...bare.filter((dir) => !NO_SUITE.includes(dir)).map((dir) => `${dir}: carries no test file and is not declared in NO_SUITE`),
+		...NO_SUITE.filter((dir) => !bare.includes(dir)).map((dir) => `${dir}: declared in NO_SUITE but carries test files — drop the declaration`),
+	];
+}
+
 // Packages whose declared CI entry point no enabled step invokes. Taking the
 // workflow source as an argument is what lets the control below run this exact
 // reader over a mutated copy instead of asserting against a second literal.
@@ -195,7 +218,8 @@ test("every Pi extension suite runs in CI under the package's own test script", 
 	const workflow = readFileSync(workflowPath, "utf8");
 	const steps = ciSteps(workflow);
 	const dirs = packages().map(({ dir }) => dir);
-	const bearing = packages().filter(({ dir }) => suiteFiles(join(root, dir)).length > 0).map(({ dir }) => dir);
+	const counts = packages().map(({ dir }) => [dir, suiteFiles(join(root, dir)).length]);
+	const bearing = counts.filter(([, files]) => files > 0).map(([dir]) => dir);
 	// Every side is derived from the tree and the workflow, so a reader that
 	// matched nothing would pass this case vacuously — which is the gap it
 	// exists to close. Floor each reader first; a zero here means the reader is
@@ -203,6 +227,15 @@ test("every Pi extension suite runs in CI under the package's own test script", 
 	// own: a reader that found no entry point fails the next assertion.
 	assert.ok(steps.length > 0, `no per-package steps found in ${workflowPath} — the workflow reader is broken`);
 	assert.ok(bearing.length > 0, "no package carries test files — the suite-file walker is broken");
+
+	// Before the filter below narrows to packages that carry tests, hold the
+	// ones that carry none against the declaration — that narrowing is where an
+	// untested package used to leave the gate unremarked.
+	assert.deepEqual(
+		suiteDeclarationDrift(counts),
+		[],
+		"a Pi package carries no test file without NO_SUITE declaring it, or a NO_SUITE declaration is stale",
+	);
 
 	assert.deepEqual(
 		packages().filter(({ dir, pkg }) => bearing.includes(dir) && !ciEntryPoint(pkg)).map(({ dir }) => dir),
@@ -238,3 +271,24 @@ test("a step conditioned on a shard the matrix does not run is reported, not acc
 	assert.deepEqual(unrunPackages(typo), ["pi-claude-bridge: no step on a shard the matrix runs invokes `npm run test:ci`"]);
 });
 
+
+// Must-fail control for the declaration above: with every package in the tree
+// either covered or declared, the drift reader returns the same empty list a
+// reader that had stopped looking would, so both directions are mutated here.
+test("a package carrying no test file is reported unless NO_SUITE declares it", () => {
+	const counts = packages().map(({ dir }) => [dir, suiteFiles(join(root, dir)).length]);
+	assert.deepEqual(suiteDeclarationDrift(counts), [], "precondition: the real tree matches NO_SUITE");
+
+	const stripped = counts.find(([dir, files]) => files > 0 && !NO_SUITE.includes(dir));
+	assert.ok(stripped, "no covered package to strip — this control no longer mutates the tree it reads");
+	assert.deepEqual(
+		suiteDeclarationDrift(counts.map(([dir, files]) => [dir, dir === stripped[0] ? 0 : files])),
+		[`${stripped[0]}: carries no test file and is not declared in NO_SUITE`],
+	);
+
+	assert.ok(NO_SUITE.length > 0, "NO_SUITE is empty — the stale-declaration direction below mutates nothing");
+	assert.deepEqual(
+		suiteDeclarationDrift(counts.map(([dir, files]) => [dir, NO_SUITE.includes(dir) ? 1 : files])),
+		NO_SUITE.map((dir) => `${dir}: declared in NO_SUITE but carries test files — drop the declaration`),
+	);
+});

--- a/pi-extensions/pi-background-tasks/tests/identity-probe-live.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/identity-probe-live.test.ts
@@ -1,15 +1,18 @@
 // Live integration test for defaultReadProcessIdentity (kendex#15
 // round 5 reviewer-error BLOCK reproducer).
 //
-// Spawn `/bin/bash -lc "sleep 5"` and observe what the kernel reports:
-// bash exec(2)s the sleep binary in place, so /proc/<pid>/comm rotates
-// from "bash" to "sleep" while pid + starttime stay identical. The
-// identity check MUST treat these as the same process — otherwise the
+// Spawn `/bin/bash -c "exec sleep 5"`: bash execve(2)s the sleep binary
+// in place with no fork, so pid + starttime stay identical across the
+// exec while the process image changes underneath them. The identity
+// check MUST treat before and after as the same process — otherwise the
 // orphan watcher false-finalizes a live task on every restore.
 //
-// Requires: Linux /proc OR `ps -o lstart=,comm= -p <pid>` available.
-// Skips cleanly if the probe returns null (sandbox without /proc and
-// without ps).
+// Enforced on Linux only. There, a null from the probe against a pid
+// still present in /proc is a defect in the reader this suite gates, and
+// the case throws. Elsewhere a null logs a skip line and returns: the
+// portable `ps -o lstart=,comm= -p <pid>` path returns null for reader
+// defects too, and nothing here separates those from a host that cannot
+// probe at all, so this suite makes no promise off Linux.
 
 import { afterAll, describe, expect, test } from "bun:test";
 import { spawn } from "node:child_process";

--- a/pi-extensions/pi-background-tasks/tests/identity-probe-live.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/identity-probe-live.test.ts
@@ -13,6 +13,7 @@
 
 import { afterAll, describe, expect, test } from "bun:test";
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
 import { defaultReadProcessIdentity, identityMatches } from "../extensions/snapshot.js";
 
 const children: number[] = [];
@@ -27,7 +28,7 @@ function sleep(ms: number): Promise<void> {
 }
 
 describe("defaultReadProcessIdentity live (bash exec drift)", () => {
-	test("bash -c 'exec sleep N': pid + startToken stable, comm drifts bash->sleep, identityMatches stays true", async () => {
+	test("bash -c 'exec sleep N': pid + startToken stable across the exec, identityMatches stays true whether or not comm rotated", async () => {
 		// `exec sleep N` replaces the bash process image in place
 		// (execve(2) with no fork), so the kernel reports the same pid
 		// + same start time but a new /proc/<pid>/comm. This is the
@@ -42,9 +43,21 @@ describe("defaultReadProcessIdentity live (bash exec drift)", () => {
 
 		const spawnIdentity = defaultReadProcessIdentity(pid);
 		if (spawnIdentity === null) {
-			// /proc + ps both unavailable in this environment; there is
-			// nothing to observe, so the case ends here rather than
-			// asserting something it did not measure.
+			// A null is "the probe failed", not "this host cannot probe":
+			// defaultReadProcessIdentity also returns null on a malformed
+			// /proc/<pid>/stat, an absent starttime field, or a non-zero `ps`
+			// exit — regressions in the reader this case exists to gate. On
+			// Linux with the process still in /proc, the probe path is there,
+			// so a null is that defect and must fail rather than pass quietly.
+			if (process.platform === "linux" && existsSync(`/proc/${pid}`)) {
+				throw new Error(
+					`defaultReadProcessIdentity returned null for live pid ${pid} with /proc/${pid} present — the probe is broken, not the host`,
+				);
+			}
+			// No /proc and no working `ps`: nothing to observe. Say so, so a
+			// suite that has stopped exercising the reproducer is visible in
+			// the log instead of reading like a run that proved the fix.
+			console.log(`skip: no process-identity probe on ${process.platform} — the exec-drift reproducer did not run`);
 			return;
 		}
 

--- a/pi-extensions/pi-background-tasks/tests/identity-probe-live.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/identity-probe-live.test.ts
@@ -42,9 +42,9 @@ describe("defaultReadProcessIdentity live (bash exec drift)", () => {
 
 		const spawnIdentity = defaultReadProcessIdentity(pid);
 		if (spawnIdentity === null) {
-			// /proc + ps both unavailable in this environment; nothing
-			// meaningful to assert.
-			expect(true).toBe(true);
+			// /proc + ps both unavailable in this environment; there is
+			// nothing to observe, so the case ends here rather than
+			// asserting something it did not measure.
 			return;
 		}
 
@@ -60,14 +60,10 @@ describe("defaultReadProcessIdentity live (bash exec drift)", () => {
 		// identityMatches MUST treat them as the same process, even if
 		// comm rotated bash -> sleep. comm is diagnostic-only.
 		expect(identityMatches(spawnIdentity, drifted)).toBe(true);
-		// We expect to observe the drift on this platform; if comm
-		// matches both reads (e.g. the kernel didn't rotate it before
-		// the first probe), the test still passes the identity check
-		// above so the bug is still gated.
-		if (spawnIdentity.comm === "bash" && drifted?.comm === "sleep") {
-			// Drift was observed; identity check survived it.
-			expect(true).toBe(true);
-		}
+		// comm may or may not have rotated by the time of the second
+		// read — the kernel does not promise when. Either way the
+		// identity check above is what gates the bug, so nothing here
+		// depends on observing the rotation.
 	});
 
 	test("identityMatches is false after the process actually exits", async () => {


### PR DESCRIPTION
## Summary

- The wiring gate no longer lets a package with no test files pass unremarked. `NO_SUITE` declares the packages in that state, and a three-way drift reader reds on an undeclared bare package, a declaration the tree outgrew, and an entry naming no package at all — the last matching how `tools/bash32-lint` separates a stale exception from an outgrown one.
- Both `expect(true)` no-ops are gone from the identity-probe live suite. The null-probe branch no longer reports pass when the probe itself regressed: on Linux with `/proc/<pid>` present it throws, and elsewhere it logs a skip line, since the portable `ps` path returns null for reader defects too.
- The escape is closed by declaration, not by coverage. pi-prompt-stash still has no suite; the owner's 2026-09-01 re-scope dropped that requirement, naming no defect.

## Scope

The issue description listed three requirements. The owner's 2026-09-01 comment supersedes it: close the filter escape, delete the two `expect(true)` cases, and drop "a test suite for 770 lines". Only the first two are in this PR.

## Known limitation, stated in the code

The declaration counts files a test directory holds, not cases in them, so a package whose test directory held only fixtures would read as covered. An earlier round of this PR tried to close that with a source-scanning predicate and the predicate was cut again: a regex over source text cannot tell a suite from a fixture. It admitted three inert forms (a `RegExp.prototype.test` call, a comment, a string literal), and it misread three shipped `int-*.mjs` integration suites as helpers — while changing no package's classification on the real tree, so no control could kill it. The comment above `NO_SUITE` states the limit outright rather than implying the stronger guarantee. No package in the tree is in that state.

## Completed Issues

- Closes KEN-1016 - pi package test gaps: policy-filter escape, pi-prompt-stash untested, expect(true) no-ops

## Test Plan

- `node --test pi-extensions/package-policy.test.mjs` — 8/8, including a must-fail control that mutates every direction the drift reader reports.
- `bun test pi-extensions/pi-background-tasks/tests/identity-probe-live.test.ts` — 2 pass, 5 `expect()` calls, down from 7; the two removed asserted nothing the surrounding cases do not already gate.
- Each new direction proven red once against the real gate, not only in-suite: an undeclared bare package, a `NO_SUITE` name the tree lacks, and a declared package that gains a test file.
- A differential harness over all 27 count-array shapes shows the reader identical to its first-commit form except on the nine inputs the new stale-entry direction covers.
- Mutation: 15 of 17 mutants killed; the two survivors are bare assertion deletions. The mutant that re-inserts the original escape — narrowing counts before the declaration — is killed by the stale-entry direction, so the behaviour this issue is about is gated rather than merely asserted.

## Review

Nine reviewers over three cycles, 18 findings applied and 10 declined. External cross-model review did not run: the Codex lane hit its usage limit (resets Sep 8), and the wrapper reported only `exited with code 1` without surfacing that cause.

https://claude.ai/code/session_01EKqQkCBrnrBFfc2bVwjZj8
