### PR TITLE
fix(KEN-989): a Follow flip re-reads the scan and the audit it moved

### DIFF
--- a/changelog.d/fixed/KEN-989.md
+++ b/changelog.d/fixed/KEN-989.md
@@ -1,0 +1,1 @@
+- Switching Follow back on now re-reads the scan and the audit behind its own apply, so the machine inventory and the scores stop answering for the bytes the flip replaced.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -532,9 +532,11 @@ lives in one capability table read by core and UI.
   the click, pending until every scope's standing is read again — every
   landing wears it, so a read cannot bounce it — over its own scope's rows
   only (`lib/updates-read-state.ts::rowUnsettled`), the apply reaching only
-  what is installed there. A refused write says so at once and puts the
-  switch back where the click moved it from; the next landing carries the
-  engine's own answer. An edited place is never updated over:
+  what is installed there. A refused write says so at once and leaves the
+  switch where the click moved it; the next landing carries the engine's
+  own answer, which is what decides where it sits. Every flip re-reads the
+  machine scan and the audit behind that landing, the way an update does:
+  the apply moves the bytes both of them answer for. An edited place is never updated over:
   its row says so and offers the install beside it where a newer version
   the source still carries can land, and a
   link to the package page otherwise; the fork-or-discard choice lives on

--- a/ui/src/components/update-follow.dom.test.tsx
+++ b/ui/src/components/update-follow.dom.test.tsx
@@ -95,6 +95,23 @@ const okMoved: { status: "ok"; data: PackageUpdate_Serialize } = {
   data: { view, heldBack: [], removed: [], moved: [wrote] },
 };
 
+/** What the machine scan answers with. Named so a test can hold one
+ *  unanswered and read the page while the rescan is still out. */
+const SCANNED = {
+  status: "ok" as const,
+  data: { harnesses: [], items: [], missingProjects: [], warnings: [] },
+};
+
+/** One place's gh, held at what is installed: `pinned` with a hold this
+ *  declaration owns, which is the only owner whose switch still moves
+ *  (a source's or a parent's locks it). Switching it back on is the
+ *  direction that resolves the package at its source's tip. */
+const heldRows = [
+  row("gh", null, { pinned: true, holdOwner: { kind: "package" } }),
+  rows[1],
+  rows[2],
+];
+
 /** The table drawn from the store, the way the page draws it: a flip that
  *  only reaches `rows` is a flip nobody sees. */
 const Live = () => {
@@ -191,19 +208,21 @@ beforeEach(() => {
     status: "ok",
     data: { rows, warnings: [], unreadable: [], lastFetched: null },
   });
-  // Asked twice over: the page audits on mount, and a landed flip re-reads
-  // the scan and the audit behind its own standing.
+  // The flip is what asks for these: it re-reads the scan and the audit
+  // behind its own standing. `Live` mounts the table, not the page, so
+  // nothing else here calls either.
   vi.mocked(commands.auditAll).mockResolvedValue({ status: "ok", data: [] });
-  vi.mocked(commands.scanMachine).mockResolvedValue({
-    status: "ok",
-    data: { harnesses: [], items: [], missingProjects: [], warnings: [] },
-  });
+  vi.mocked(commands.scanMachine).mockResolvedValue(SCANNED);
 });
 
 describe("the Follow source switch", () => {
   it("moves before the write behind it answers, and holds the page while it does", async () => {
     const write = pending<typeof ok>(ok);
     vi.mocked(commands.packageSetRev).mockReturnValue(write.promise as never);
+    // Held unanswered so the hold can be read while the rescan is still
+    // out: `busy` covers the write, the reload and the rescan alike.
+    const scan = pending<typeof SCANNED>(SCANNED);
+    vi.mocked(commands.scanMachine).mockReturnValue(scan.promise as never);
     mount(<Live />);
     await openPlaces();
     const flipped = followSwitch("gh", USER_LEVEL_PLACE);
@@ -233,9 +252,16 @@ describe("the Follow source switch", () => {
     expect(holding(followSwitch("gh", "app"))).toBe(true);
     expect(holding(followSwitch("orch", "app"))).toBe(true);
 
+    // The write answering does not release the page: the hold covers the
+    // reload and the rescan behind it, and the scan has not answered.
     write.answer(ok);
     await settle();
     expect(commands.updatesOverview).toHaveBeenCalled();
+    expect(commands.scanMachine).toHaveBeenCalled();
+    expect(holding(followSwitch("orch", "app"))).toBe(true);
+
+    scan.answer(SCANNED);
+    await settle();
     expect(holding(followSwitch("orch", "app"))).toBe(false);
   });
 
@@ -319,23 +345,63 @@ describe("the Follow source switch", () => {
     ).toHaveLength(1);
   });
 
-  // What a landed flip refreshes. The apply resolves the package at its
-  // source's tip and moves installed bytes, so the scan that lists them and
-  // the audit that scored them both answer for content that is gone until
-  // they are asked again — the same three reads `updateOne` runs behind the
-  // identical apply.
+  // What a landed flip refreshes, and when. The apply resolves the package
+  // at its source's tip and moves installed bytes, so the scan that lists
+  // them and the audit that scored them both answer for content that is
+  // gone until they are asked again — the same three reads `updateOne` runs
+  // behind the identical apply. Read behind the write, never beside it: a
+  // scan that starts before the apply answers reports the bytes it is about
+  // to replace, which is the staleness itself with an extra call.
   it("reads the standing, the scan and the audit back after a landed flip", async () => {
-    vi.mocked(commands.packageSetRev).mockResolvedValue(okMoved as never);
+    const write = pending<typeof okMoved>(okMoved);
+    vi.mocked(commands.packageSetRev).mockReturnValue(write.promise as never);
     mount(<Live />);
     await openPlaces();
 
     await act(async () => {
       followSwitch("gh", USER_LEVEL_PLACE).click();
     });
-    await settle();
 
     expect(commands.packageSetRev).toHaveBeenCalled();
+    expect(commands.scanMachine).not.toHaveBeenCalled();
+    expect(commands.auditAll).not.toHaveBeenCalled();
+
+    write.answer(okMoved);
+    await settle();
+
     expect(commands.updatesOverview).toHaveBeenCalled();
+    expect(commands.scanMachine).toHaveBeenCalled();
+    expect(commands.auditAll).toHaveBeenCalled();
+  });
+
+  // The direction the flip is for: Follow back ON resolves the package at
+  // its source's tip, which is what moves installed bytes. Every other test
+  // here starts from a following row and switches OFF, so a rescan run only
+  // on the off direction would pass them all.
+  it("reads the scan and the audit back after Follow is switched on", async () => {
+    useUpdatesStore.setState({ rows: heldRows });
+    const write = pending<typeof okMoved>(okMoved);
+    vi.mocked(commands.packageSetRev).mockReturnValue(write.promise as never);
+    mount(<Live />);
+    await openPlaces();
+    expect(following(followSwitch("gh", USER_LEVEL_PLACE))).toBe(false);
+
+    await act(async () => {
+      followSwitch("gh", USER_LEVEL_PLACE).click();
+    });
+
+    // A null revision is the write that lets the package follow again.
+    expect(commands.packageSetRev).toHaveBeenCalledWith(
+      { scope: "global" },
+      "skill",
+      "gh",
+      null,
+    );
+    expect(commands.scanMachine).not.toHaveBeenCalled();
+
+    write.answer(okMoved);
+    await settle();
+
     expect(commands.scanMachine).toHaveBeenCalled();
     expect(commands.auditAll).toHaveBeenCalled();
   });

--- a/ui/src/components/update-follow.dom.test.tsx
+++ b/ui/src/components/update-follow.dom.test.tsx
@@ -191,7 +191,8 @@ beforeEach(() => {
     status: "ok",
     data: { rows, warnings: [], unreadable: [], lastFetched: null },
   });
-  // The page asks for an audit on mount; nothing here reads it.
+  // Asked twice over: the page audits on mount, and a landed flip re-reads
+  // the scan and the audit behind its own standing.
   vi.mocked(commands.auditAll).mockResolvedValue({ status: "ok", data: [] });
   vi.mocked(commands.scanMachine).mockResolvedValue({
     status: "ok",
@@ -300,6 +301,11 @@ describe("the Follow source switch", () => {
     await settle();
 
     expect(commands.updatesOverview).toHaveBeenCalled();
+    // And so are the scan and the audit: the error came back over an apply
+    // that had already persisted the revision, so it is no account of what
+    // is on disk.
+    expect(commands.scanMachine).toHaveBeenCalled();
+    expect(commands.auditAll).toHaveBeenCalled();
     // The flip is retired before that read, so the rows come back as the
     // engine has them rather than wearing a position it never took.
     expect(useUpdatesStore.getState().pendingFollows).toEqual([]);
@@ -313,13 +319,12 @@ describe("the Follow source switch", () => {
     ).toHaveLength(1);
   });
 
-  // What a landed flip refreshes, and what it leaves. The apply resolves
-  // the package at its source's tip and moves installed bytes, so the scan
-  // that lists them and the audit that scored them are both out of date
-  // afterwards — and neither is re-asked. That is how the flip has always
-  // behaved; this holds it as it is, so a change to it is a decision
-  // somebody makes rather than a thing that drifts.
-  it("reads the standing back and leaves the scan and the audit dated", async () => {
+  // What a landed flip refreshes. The apply resolves the package at its
+  // source's tip and moves installed bytes, so the scan that lists them and
+  // the audit that scored them both answer for content that is gone until
+  // they are asked again — the same three reads `updateOne` runs behind the
+  // identical apply.
+  it("reads the standing, the scan and the audit back after a landed flip", async () => {
     vi.mocked(commands.packageSetRev).mockResolvedValue(okMoved as never);
     mount(<Live />);
     await openPlaces();
@@ -331,8 +336,27 @@ describe("the Follow source switch", () => {
 
     expect(commands.packageSetRev).toHaveBeenCalled();
     expect(commands.updatesOverview).toHaveBeenCalled();
-    expect(commands.scanMachine).not.toHaveBeenCalled();
-    expect(commands.auditAll).not.toHaveBeenCalled();
+    expect(commands.scanMachine).toHaveBeenCalled();
+    expect(commands.auditAll).toHaveBeenCalled();
+  });
+
+  // A flip that answers with nothing moved is asked for anyway. No field of
+  // that answer is a complete account of what the apply wrote — `moved`
+  // covers two of the drift states, `removed` the other destructive one,
+  // and a dropped rendering answers with all three empty — so gating the
+  // rescan on any of them is the stale page this reads against.
+  it("reads the scan and the audit back after a flip that moved nothing", async () => {
+    vi.mocked(commands.packageSetRev).mockResolvedValue(ok as never);
+    mount(<Live />);
+    await openPlaces();
+
+    await act(async () => {
+      followSwitch("gh", USER_LEVEL_PLACE).click();
+    });
+    await settle();
+
+    expect(commands.scanMachine).toHaveBeenCalled();
+    expect(commands.auditAll).toHaveBeenCalled();
   });
 
   it("refuses a second flip, in the settling scope or any other", async () => {

--- a/ui/src/lib/rescan.ts
+++ b/ui/src/lib/rescan.ts
@@ -9,12 +9,10 @@
 // package coming current, a registry change. The buttons offering to look
 // again call it because nothing else knows what changed.
 //
-// Two writes do not. The audit's item actions have no need: each answers
-// with the scope's fresh view and refreshes the scan itself. The
-// Follow-source flip does need it and has never had it — it moves
-// installed bytes and reads back its own standing alone, so both of these
-// stay dated until something else asks. `update-follow.dom.test.tsx` holds
-// that as it is, not as it ought to be.
+// The audit's item actions do not: each answers with the scope's fresh view
+// and refreshes the scan itself. The Follow-source flip does — it runs the
+// same apply an update does, so the bytes both reads answer for move under
+// it — and calls this once its own standing has landed.
 //
 // Adding a project, dropping one, or moving a harness's folder changes
 // which scopes the audit reads, and a scope with no view of its own counts

--- a/ui/src/stores/updates-follow.ts
+++ b/ui/src/stores/updates-follow.ts
@@ -171,15 +171,19 @@ export function followSwitch({
         await get().reload();
         // Then the scan and the audit, which the standing does not cover:
         // the flip runs an apply, and an apply moves the installed bytes
-        // the scan lists and the audit scores. Asked whatever the write
-        // answered and whichever way the switch went, for the same reason
-        // the read above is: the apply runs after the revision is
-        // persisted, so an error is not proof that nothing landed, and no
-        // predicate over the answer is complete — `moved` covers the two
-        // states `moving` counts, `removed` the other destructive one, and
-        // a dropped rendering can answer with all three fields empty. A
-        // scan behind a flip that wrote nothing costs a read nobody waits
-        // on.
+        // the scan lists and the audit scores.
+        //
+        // Asked whatever the write answered and whichever way the switch
+        // went. A refusal is no account of what is on disk — the write
+        // runs the leaving packages' uninstallers before the plan
+        // (`repo_effects::execute`), and an error over those leaves what
+        // they did to the repository standing. Nor is an answer that
+        // landed: `moved` covers the two states `moving` counts, `removed`
+        // the other destructive one, and a dropped rendering can answer
+        // with all three fields empty, so no predicate over the response
+        // is complete. A flip that turns out to have written nothing pays
+        // what every other write pays — the page held for a machine-wide
+        // scan and a forced audit — rather than a page left dated.
         await rescanEverything();
       }
     });

--- a/ui/src/stores/updates-follow.ts
+++ b/ui/src/stores/updates-follow.ts
@@ -9,9 +9,10 @@
 // Two different things are scoped and page-wide. What the pending record
 // decides is which ROWS the landing may not be acted on from — an apply
 // moves what is installed in that scope and nowhere else. The write itself
-// raises the store's page-wide `busy` for as long as it and its reload
-// run, because that flag is what a check refuses on, and a write it did
-// not cover is a check running beside a commit its report predates.
+// raises the store's page-wide `busy` for as long as it, its reload and the
+// rescan behind it run, because that flag is what a check refuses on, and a
+// write it did not cover is a check running beside a commit its report
+// predates.
 import {
   commands,
   type ItemKind,
@@ -23,6 +24,7 @@ import {
   UPDATES_ONE_AT_A_TIME_NOTE,
 } from "@/lib/copy-updates";
 import type { ReadState } from "@/lib/read-state";
+import { rescanEverything } from "@/lib/rescan";
 import { sameScope } from "@/lib/scope";
 import { settled } from "@/lib/settled";
 import { saying } from "@/lib/undone";
@@ -166,13 +168,19 @@ export function followSwitch({
         // apply returns an error over a manifest that already moved. Putting
         // the switch back from the click's own row would show that as
         // settled and re-open every action against it.
-        //
-        // The scan and the audit are not re-read. Switching Follow back on
-        // moves installed bytes they both answer for, so both are left dated
-        // until something else asks — how the flip has always behaved, held
-        // by `update-follow.dom.test.tsx` as it is rather than as it ought
-        // to be.
         await get().reload();
+        // Then the scan and the audit, which the standing does not cover:
+        // the flip runs an apply, and an apply moves the installed bytes
+        // the scan lists and the audit scores. Asked whatever the write
+        // answered and whichever way the switch went, for the same reason
+        // the read above is: the apply runs after the revision is
+        // persisted, so an error is not proof that nothing landed, and no
+        // predicate over the answer is complete — `moved` covers the two
+        // states `moving` counts, `removed` the other destructive one, and
+        // a dropped rendering can answer with all three fields empty. A
+        // scan behind a flip that wrote nothing costs a read nobody waits
+        // on.
+        await rescanEverything();
       }
     });
   };


### PR DESCRIPTION
## Summary

- `followSwitch` now calls `rescanEverything()` after its own `reload()`, inside the same `holding` block, so a Follow flip re-reads the scan inventory and the audit scores the apply just moved. `updateOne` already did this; the flip was the gap.
- The rescan is not gated on the write's answer. A refusal is no account of what is on disk — `repo_effects::execute` runs the leaving packages' uninstallers before the plan, and an error over those leaves their effects standing. Nor is an answer that landed: `moved` covers only the two states `moving` counts, `removed` is the other destructive disposition, and a dropped rendering can answer with all three fields empty.
- `update-follow.dom.test.tsx` pins the direction, the order and the hold: a test that switches Follow **on**, `not.toHaveBeenCalled()` guards before the write answers, and a pending `scanMachine` proving `busy` covers the rescan.
- `docs/ARCHITECTURE.md` no longer says a refused flip puts the switch back; the store deliberately leaves it where the click moved it and lets the next landing decide.

## Completed Issues

- Closes KEN-989 - Scan and audit stay stale after a Follow flip moves installed bytes

## Created Issues

- KEN-1161 - Rescan skipped when a write answers with an error — Project: Tech Debt & Bugs
- KEN-1162 - Scan store drops a rescan requested during an in-flight scan — Project: Tech Debt & Bugs
- KEN-1163 - vitest run exits 0 when a worker fails to start — Project: Review Gate & CI

## Test Plan

- `npx vitest run` in `ui/` — 123 files, 1018 tests pass.
- Mutation control on `update-follow.dom.test.tsx`: 7/7 killed. `if (!auto) await rescanEverything()` fails the switched-on test; hoisting the rescan above `commands.packageSetRev` fails three; moving it outside `holding()` fails the hold test; deleting the call fails five.
- `tools/guard` exit 0; preflight clean.

https://claude.ai/code/session_01RkTRDcCF3b3UNFrLM6GrZ4
