### PR TITLE
docs(code-quality): a store selector returns a stable reference

### DIFF
--- a/.agents/skills/code-quality/SKILL.md
+++ b/.agents/skills/code-quality/SKILL.md
@@ -55,7 +55,7 @@ A new or modified check, guard, assertion, or test ships with a must-fail contro
 - **Bash**: `set -euo pipefail` in every new script; check the result of every effectful substitution; `--` before path arguments sourced from configuration, argv, or the environment (not paths the script built itself, e.g. `mktemp -d`); no `[A-Za-z]`-class assumptions under arbitrary locales.
 - In any `pipefail` script, never leave a pipeline unguarded when an early-closing `head` or `grep -q` can stop reading while its producer still writes: the 141 SIGPIPE status aborts the run where `errexit` fires, and in condition position, where it does not, reads as a plain false that drops the result with no error.
 - Measure a commit header with growth-guards' locale-stable `gg_chars`, never raw `awk length` or `wc -c`.
-- **TypeScript/JS**: distinguish missing from present-but-falsy (`""`, `0`) at every guard; no `any` at module boundaries.
+- **TypeScript/JS**: distinguish missing from present-but-falsy (`""`, `0`) at every guard; no `any` at module boundaries. A store selector returns a stable reference: never mint an array, object or Set inside one (a fresh value re-renders forever and blanks the page).
 
 ## Comments and Prose
 

--- a/skills/code-quality/SKILL.md
+++ b/skills/code-quality/SKILL.md
@@ -49,7 +49,7 @@ A new or modified check, guard, assertion, or test ships with a must-fail contro
 - **Bash**: `set -euo pipefail` in every new script; check the result of every effectful substitution; `--` before path arguments sourced from configuration, argv, or the environment (not paths the script built itself, e.g. `mktemp -d`); no `[A-Za-z]`-class assumptions under arbitrary locales.
 - In any `pipefail` script, never leave a pipeline unguarded when an early-closing `head` or `grep -q` can stop reading while its producer still writes: the 141 SIGPIPE status aborts the run where `errexit` fires, and in condition position, where it does not, reads as a plain false that drops the result with no error.
 - Measure a commit header with growth-guards' locale-stable `gg_chars`, never raw `awk length` or `wc -c`.
-- **TypeScript/JS**: distinguish missing from present-but-falsy (`""`, `0`) at every guard; no `any` at module boundaries.
+- **TypeScript/JS**: distinguish missing from present-but-falsy (`""`, `0`) at every guard; no `any` at module boundaries. A store selector returns a stable reference: never mint an array, object or Set inside one (a fresh value re-renders forever and blanks the page).
 
 ## Comments and Prose
 


### PR DESCRIPTION
One sentence in code-quality SKILL.md. Three shipped React pages went blank this session on the same defect: a store selector that minted a fresh array, object or Set on every call (KEN-1132 destination picker; KEN-987 subscribe dialog and Customize page). A recurring class changes the file whose role produced it, so the rule joins the TypeScript bullet; no lint, no lane (the KEN-987 review proposed one and it was declined). Overseer PR, no issue. Render moves with the source.

https://claude.ai/code/session_01RkDwSMxGaqnL1HN8evRn91
