### PR TITLE
test(KEN-1011): each proof runs on the cheapest driver that shows it

### DIFF
--- a/.agents/skills/review-gate/DEVELOPMENT.md
+++ b/.agents/skills/review-gate/DEVELOPMENT.md
@@ -104,7 +104,8 @@ What it therefore never answers is what the TEMPLATE says. Both sides of the
 diff come from that one file, so an edit re-copied into every consumer is
 invisible here by construction. One instrument upstream reads the template's
 content — the relay battery in `tests/review-writer-template.test.sh`, which
-extracts the relay step and EXECUTES it against a gh stub, over both copies.
+extracts the relay step from both copies, EXECUTES it against a gh stub once,
+and proves the two extracted steps byte-identical.
 Everything else the template says is unasserted — an expression, a trigger, a
 `permissions:` scope, a concurrency group — with one exception: this tool
 refuses to run at all when the template stops carrying the COMMENTED

--- a/.agents/skills/review-gate/tests/lib/sandbox.sh
+++ b/.agents/skills/review-gate/tests/lib/sandbox.sh
@@ -5,6 +5,12 @@
 #
 # Contract with the caller: it sets SKILL_DIR and TMP, and defines nothing
 # this file also defines. Sourcing it builds the pristine sandbox once.
+#
+# DRIVER_REL is the one exception — the entry point run_validate drives. A
+# caller may set it either side of the source line: the default below yields
+# to a value already set, so the ordering cannot silently cost a suite its
+# driver. Assigning it after sourcing changes the driver for every case that
+# follows, which is how a suite switches back mid-file.
 
 # The verdict counters and their two writers: every helper below reports
 # through these, and each suite prints the totals itself.
@@ -22,8 +28,13 @@ bad() {
 # the only shape either script has to work in.
 VALIDATE_REL=".agents/skills/review-gate/scripts/validate.sh"
 WORKFLOW_REL=".agents/skills/review-gate/scripts/validate-workflow.sh"
-# Built once and copied per case: a fresh `cp -R` of the skill plus a `git
-# init` for every one of the cases below is the bulk of this suite's runtime.
+# Built once — the `git init` is paid here, not per case — and copied per
+# case. The copies are NOT shareable at any price: cases chmod and overwrite
+# the vendored scripts inside their own sandbox, so a reflinked or symlinked
+# tree would let one case corrupt the next. What a suite can change is the
+# entry point each case runs, which is DRIVER_REL below; the two entry points
+# differ by an order of magnitude, and the copy's share of a case varies with
+# the driver and with whether TMPDIR is tmpfs, so measure before assuming.
 PRISTINE="$TMP/pristine"
 mkdir -p "$PRISTINE/.agents/skills" "$PRISTINE/.github/workflows" "$PRISTINE/docs"
 cp -R "$SKILL_DIR" "$PRISTINE/.agents/skills/review-gate"
@@ -55,12 +66,21 @@ commit() { # DIR — re-commit whatever the case mutated
   (cd "$1" && git add -A && git commit -q -m "case" --allow-empty)
 }
 
+# The entry point every expectation below drives. It defaults to the full
+# driver and YIELDS to a caller that set it first, so a suite may name its
+# driver either side of the source line; a suite whose subject is the workflow
+# half points it at that tool and proves the driver's fold of the peer's
+# verdicts in its own cases rather than re-proving it under every one of them.
+# Both tools print `FAIL` at the start of a verdict line and exit 1 on a
+# finding, which is the only shape expect_clean and expect_fail read.
+DRIVER_REL="${DRIVER_REL:-$VALIDATE_REL}"
+
 OUT=""
 RC=0
 run_validate() { # DIR
   OUT=""
   RC=0
-  OUT="$(cd "$1" && "./$VALIDATE_REL" 2>&1)" || RC=$?
+  OUT="$(cd "$1" && "./$DRIVER_REL" 2>&1)" || RC=$?
 }
 
 # `settings` NAME VALUE — append one assignment to the sandbox settings file

--- a/.agents/skills/review-gate/tests/lib/sandbox.sh
+++ b/.agents/skills/review-gate/tests/lib/sandbox.sh
@@ -29,12 +29,17 @@ bad() {
 VALIDATE_REL=".agents/skills/review-gate/scripts/validate.sh"
 WORKFLOW_REL=".agents/skills/review-gate/scripts/validate-workflow.sh"
 # Built once — the `git init` is paid here, not per case — and copied per
-# case. The copies are NOT shareable at any price: cases chmod and overwrite
-# the vendored scripts inside their own sandbox, so a reflinked or symlinked
-# tree would let one case corrupt the next. What a suite can change is the
-# entry point each case runs, which is DRIVER_REL below; the two entry points
-# differ by an order of magnitude, and the copy's share of a case varies with
-# the driver and with whether TMPDIR is tmpfs, so measure before assuming.
+# case. A symlinked tree would not do: cases chmod and overwrite the vendored
+# scripts inside their own sandbox, and through a symlink those writes land on
+# the original. A reflink is isolated, since copy-on-write gives each case its
+# own inode, but it is unavailable where this suite runs. `cp --reflink=always`
+# fails with "Operation not supported" on tmpfs, a common TMPDIR, and the shard
+# runs on ubuntu-latest, whose ext4 disk has no reflink either; `--reflink=auto`
+# then falls back to a full copy without saying so. It would also buy little,
+# since the copies are not the bulk of this suite's runtime. What a suite can
+# change is the entry point each case runs, which is DRIVER_REL below; the two
+# entry points differ by an order of magnitude, and the copy's share of a case
+# varies with the driver and with whether TMPDIR is tmpfs, so measure first.
 PRISTINE="$TMP/pristine"
 mkdir -p "$PRISTINE/.agents/skills" "$PRISTINE/.github/workflows" "$PRISTINE/docs"
 cp -R "$SKILL_DIR" "$PRISTINE/.agents/skills/review-gate"

--- a/.agents/skills/review-gate/tests/predicate-unknown-arg.test.sh
+++ b/.agents/skills/review-gate/tests/predicate-unknown-arg.test.sh
@@ -93,6 +93,9 @@ config_reject "a comment-reviewer pair with an empty login" REVIEW_GATE_COMMENT_
 config_reject "an exclusion anchored with a leading '/'" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "/AGENTS.md"
 config_reject "a parent-relative exclusion" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "../future/*"
 config_reject "a dot-relative exclusion" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "./future/*"
+# The rule is REACHABILITY, not a list of anchors: a '.' component is
+# unreachable wherever it sits, not only at the front.
+config_reject "an embedded dot component" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "docs/./guide.md"
 config_reject "an exclusion with an empty path component" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "docs//guide.md"
 config_reject "an exclusion ending in '/'" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "docs/"
 config_reject "an unreachable PROPHYLACTIC declaration" REVIEW_GATE_CARRY_FORWARD_EXCLUDE_PROPHYLACTIC "../future/*"

--- a/.agents/skills/review-gate/tests/review-writer-template.test.sh
+++ b/.agents/skills/review-gate/tests/review-writer-template.test.sh
@@ -280,10 +280,16 @@ relay_run() { # step-path, read_only, workflow_ref, gh_codes, event_name, header
   done
 }
 
+# The extracted steps, and the copy each one CAME FROM. Two arrays because
+# RELAY_STEPS only grows on a successful extraction while WORKFLOW_LABELS is
+# populated for every discovered copy — so indexing the labels by a step's
+# position would, the moment one extraction failed, print the surviving copy's
+# results under the failed copy's name, in the log a maintainer is reading to
+# diagnose that failure.
 RELAY_STEPS=()
-relay_battery() { # file, label
+RELAY_STEP_LABELS=()
+relay_extract() { # file, label — appends the step and its label, on success
   local wf="$1" tag="$2" step="$TMP_ROOT/relay-step-${#RELAY_STEPS[@]}.sh"
-  local ref="o/r/.github/workflows/review-gate-writer.yml@refs/heads/main"
   awk '
     /^      - name: Request a converge pass$/ { found = 1; next }
     found && !inblock && /^        run: \|$/ { inblock = 1; next }
@@ -294,11 +300,16 @@ relay_battery() { # file, label
   ' "$wf" > "$step"
   if [[ -s "$step" ]] && grep -qF -- "/dispatches" "$step"; then
     RELAY_STEPS+=("$step")
+    RELAY_STEP_LABELS+=("$tag")
     PASS=$((PASS + 1)); printf '  ok    [%s] %s\n' "$tag" "relay: the step script extracted from the workflow (non-empty, dispatches)"
   else
-    FAIL=$((FAIL + 1)); printf '  FAIL  [%s] %s\n' "$tag" "relay: could NOT extract the step script — every case below would prove nothing"
-    return
+    FAIL=$((FAIL + 1)); printf '  FAIL  [%s] %s\n' "$tag" "relay: could NOT extract the step script — the battery and the cross-copy identity check below both lose this copy"
   fi
+}
+
+relay_battery() { # step script, label
+  local step="$1" tag="$2"
+  local ref="o/r/.github/workflows/review-gate-writer.yml@refs/heads/main"
   # Read from the step, not hardcoded: every wait assertion below is stated as
   # an exact clamp plus this bound, so a retuned jitter must move them with it.
   RELAY_JITTER_MAX="$(grep -oE '^jitter_max=[0-9]+' "$step" | head -n 1 | cut -d= -f2 || true)"
@@ -556,13 +567,27 @@ $rl_ok"
 
 echo "=== relay step behavior (request-converge, VST-210) ==="
 for i in "${!WORKFLOWS[@]}"; do
-  relay_battery "${WORKFLOWS[$i]}" "${WORKFLOW_LABELS[$i]}"
+  relay_extract "${WORKFLOWS[$i]}" "${WORKFLOW_LABELS[$i]}"
 done
 
-# The battery above proves each copy's step behaves; this proves they are the
-# SAME step. Behavior equivalence under the cases we thought to write is
-# weaker than byte-identity for a script that exists in two hand-maintained
-# places — a divergence the cases do not happen to probe would otherwise ship.
+# The battery runs ONCE, against the first copy that EXTRACTED — which is the
+# template unless its extraction failed, so the label travels with the step
+# rather than being re-derived from a position. It is 40 cases run under both
+# entries of RELAY_SHELLS, 80 step executions and 221 checks, and the
+# byte-identity check below proves the other copy's step is the SAME BYTES —
+# so a second battery would execute one script twice and call the agreement a
+# result. Identity is the stronger claim of the two, and it is the one that
+# must not be skipped: if extraction lost a copy, relay_extract has already
+# reddened above.
+if [[ "${#RELAY_STEPS[@]}" -ge 1 ]]; then
+  relay_battery "${RELAY_STEPS[0]}" "${RELAY_STEP_LABELS[0]}"
+fi
+
+# The battery above proves one copy's step behaves; this proves the other is
+# the SAME step, which is what carries that behavior across to it. Behavior
+# equivalence under the cases we thought to write is weaker than byte-identity
+# for a script that exists in two hand-maintained places — a divergence the
+# cases do not happen to probe would otherwise ship.
 # The step is pure logic with no vendored paths in it, so unlike the rest of
 # the file it has no legitimate reason to differ in any copy.
 # WHOLE-FILE drift, not just the relay step: a cross-copy tooth covering only

--- a/.agents/skills/review-gate/tests/validate-workflow.test.sh
+++ b/.agents/skills/review-gate/tests/validate-workflow.test.sh
@@ -18,6 +18,14 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck source=lib/sandbox.sh
 . "$TEST_DIR/lib/sandbox.sh"
 
+# The template cases below judge validate-workflow.sh, so they run IT and not
+# the full driver: the verdict lines are the peer's own, relayed verbatim, and
+# the driver costs an order of magnitude more per case for the same answer.
+# That the driver still runs the peer and folds its counts in is proven where
+# it belongs — the `stands alone` section at the bottom, which restores
+# DRIVER_REL first.
+DRIVER_REL="$WORKFLOW_REL"
+
 echo "=== the adopted workflow is the template ==="
 
 mutate() { # DIR SED-EXPR
@@ -309,6 +317,10 @@ expect_fail "the opt-in allowance does not cover a second edit" "$dir" "has dive
 
 
 echo "=== the workflow half stands alone ==="
+
+# Back to the full driver: the cases from here down are about the SEAM — the
+# peer's own exit codes, and the driver's fold of them.
+DRIVER_REL="$VALIDATE_REL"
 
 sandbox
 dir="$DIR"

--- a/.agents/skills/review-gate/tests/validate.test.sh
+++ b/.agents/skills/review-gate/tests/validate.test.sh
@@ -344,51 +344,26 @@ expect_clean "live exclusion globs pass" "$dir"
 
 setting_fails "a glob matching no tracked path is dead config" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "no-such-directory/*.md" "matches no tracked path"
 
-# Pattern SPELLING is the engine's call, relayed through --check-config: one
-# grammar, in the matcher's own file, so this tool cannot drift from it.
-setting_fails "a leading-'/' anchor is refused by the engine and relayed" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "/AGENTS.md" "a committed setting is not legal"
+# Pattern SPELLING is the engine's call, and this tool has no copy of the
+# grammar to test: it makes ONE `--check-config` call and relays whatever
+# comes back. So the spellings are enumerated where the matcher lives —
+# predicate-unknown-arg.test.sh, `--check-config` direct and ~11x cheaper per
+# case — and what is proven HERE is the relay itself: the refusal becomes a
+# finding, and the engine's own reason survives into the verdict.
+setting_fails "a refused spelling is relayed as a finding" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "/AGENTS.md" "a committed setting is not legal"
 printf '%s' "$OUT" | grep -qF "is not supported" &&
   ok "the engine's own reason rides out in the verdict" ||
   bad "the engine's own reason rides out in the verdict" "$OUT"
 
-# Parent-relative is dead the same way, and so not waivable: a declaration
-# says "no tracked match TODAY", and this one cannot match on any day.
-setting_fails "a parent-relative glob is refused by the engine" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "../future/*" "a committed setting is not legal"
-
+# A PROPHYLACTIC declaration cannot rescue a refused spelling: the relay above
+# runs before the declaration loop and is unconditional, so an unreachable
+# pattern is a finding whether or not it is declared. One case pins that
+# ordering; the spellings themselves are the engine's business, above.
 sandbox
 dir="$DIR"
 settings "$dir" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "../future/*"
 settings "$dir" REVIEW_GATE_CARRY_FORWARD_EXCLUDE_PROPHYLACTIC "../future/*"
 expect_fail "declaring an unreachable pattern prophylactic does not rescue it" "$dir" "a committed setting is not legal"
-
-# The rule is REACHABILITY, not a list of anchors: a dot-relative glob and an
-# embedded dot component are unreachable for the same reason.
-setting_fails "a dot-relative glob is refused by the engine" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "./future/*" "a committed setting is not legal"
-
-setting_fails "an embedded dot component is refused by the engine" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "docs/./guide.md" "a committed setting is not legal"
-
-# The grammar is closed in the ENGINE and every spelling outside it is
-# refused there and relayed here: refusing the spelling is what leaves no
-# equivalence to enumerate.
-setting_fails "a bracket-class glob is refused by the engine's grammar" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "[.]/future/*" "a committed setting is not legal"
-
-sandbox
-dir="$DIR"
-settings "$dir" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "[.]/future/*"
-settings "$dir" REVIEW_GATE_CARRY_FORWARD_EXCLUDE_PROPHYLACTIC "[.]/future/*"
-expect_fail "declaring a refused spelling prophylactic does not rescue it" "$dir" "a committed setting is not legal"
-
-setting_fails "a backslash escape is refused by the engine's grammar" REVIEW_GATE_CARRY_FORWARD_EXCLUDE 'docs/\.md' "a committed setting is not legal"
-
-# An EMPTY component is unreachable for the same reason a '.' one is: git
-# names carry neither. A trailing '/' is the same thing spelt at the end.
-setting_fails "an empty path component is refused by the engine" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "docs//guide.md" "a committed setting is not legal"
-
-sandbox
-dir="$DIR"
-settings "$dir" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "docs/"
-settings "$dir" REVIEW_GATE_CARRY_FORWARD_EXCLUDE_PROPHYLACTIC "docs/"
-expect_fail "a trailing '/' is refused, declaration or not" "$dir" "a committed setting is not legal"
 
 # ...and an ordinary glob with a dot in a NAME is reachable and stays so.
 setting_clean "a dot inside a filename is not a dot component" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "docs/*.md"

--- a/skills/review-gate/DEVELOPMENT.md
+++ b/skills/review-gate/DEVELOPMENT.md
@@ -104,7 +104,8 @@ What it therefore never answers is what the TEMPLATE says. Both sides of the
 diff come from that one file, so an edit re-copied into every consumer is
 invisible here by construction. One instrument upstream reads the template's
 content — the relay battery in `tests/review-writer-template.test.sh`, which
-extracts the relay step and EXECUTES it against a gh stub, over both copies.
+extracts the relay step from both copies, EXECUTES it against a gh stub once,
+and proves the two extracted steps byte-identical.
 Everything else the template says is unasserted — an expression, a trigger, a
 `permissions:` scope, a concurrency group — with one exception: this tool
 refuses to run at all when the template stops carrying the COMMENTED

--- a/skills/review-gate/tests/lib/sandbox.sh
+++ b/skills/review-gate/tests/lib/sandbox.sh
@@ -5,6 +5,12 @@
 #
 # Contract with the caller: it sets SKILL_DIR and TMP, and defines nothing
 # this file also defines. Sourcing it builds the pristine sandbox once.
+#
+# DRIVER_REL is the one exception — the entry point run_validate drives. A
+# caller may set it either side of the source line: the default below yields
+# to a value already set, so the ordering cannot silently cost a suite its
+# driver. Assigning it after sourcing changes the driver for every case that
+# follows, which is how a suite switches back mid-file.
 
 # The verdict counters and their two writers: every helper below reports
 # through these, and each suite prints the totals itself.
@@ -22,8 +28,13 @@ bad() {
 # the only shape either script has to work in.
 VALIDATE_REL=".agents/skills/review-gate/scripts/validate.sh"
 WORKFLOW_REL=".agents/skills/review-gate/scripts/validate-workflow.sh"
-# Built once and copied per case: a fresh `cp -R` of the skill plus a `git
-# init` for every one of the cases below is the bulk of this suite's runtime.
+# Built once — the `git init` is paid here, not per case — and copied per
+# case. The copies are NOT shareable at any price: cases chmod and overwrite
+# the vendored scripts inside their own sandbox, so a reflinked or symlinked
+# tree would let one case corrupt the next. What a suite can change is the
+# entry point each case runs, which is DRIVER_REL below; the two entry points
+# differ by an order of magnitude, and the copy's share of a case varies with
+# the driver and with whether TMPDIR is tmpfs, so measure before assuming.
 PRISTINE="$TMP/pristine"
 mkdir -p "$PRISTINE/.agents/skills" "$PRISTINE/.github/workflows" "$PRISTINE/docs"
 cp -R "$SKILL_DIR" "$PRISTINE/.agents/skills/review-gate"
@@ -55,12 +66,21 @@ commit() { # DIR — re-commit whatever the case mutated
   (cd "$1" && git add -A && git commit -q -m "case" --allow-empty)
 }
 
+# The entry point every expectation below drives. It defaults to the full
+# driver and YIELDS to a caller that set it first, so a suite may name its
+# driver either side of the source line; a suite whose subject is the workflow
+# half points it at that tool and proves the driver's fold of the peer's
+# verdicts in its own cases rather than re-proving it under every one of them.
+# Both tools print `FAIL` at the start of a verdict line and exit 1 on a
+# finding, which is the only shape expect_clean and expect_fail read.
+DRIVER_REL="${DRIVER_REL:-$VALIDATE_REL}"
+
 OUT=""
 RC=0
 run_validate() { # DIR
   OUT=""
   RC=0
-  OUT="$(cd "$1" && "./$VALIDATE_REL" 2>&1)" || RC=$?
+  OUT="$(cd "$1" && "./$DRIVER_REL" 2>&1)" || RC=$?
 }
 
 # `settings` NAME VALUE — append one assignment to the sandbox settings file

--- a/skills/review-gate/tests/lib/sandbox.sh
+++ b/skills/review-gate/tests/lib/sandbox.sh
@@ -29,12 +29,17 @@ bad() {
 VALIDATE_REL=".agents/skills/review-gate/scripts/validate.sh"
 WORKFLOW_REL=".agents/skills/review-gate/scripts/validate-workflow.sh"
 # Built once — the `git init` is paid here, not per case — and copied per
-# case. The copies are NOT shareable at any price: cases chmod and overwrite
-# the vendored scripts inside their own sandbox, so a reflinked or symlinked
-# tree would let one case corrupt the next. What a suite can change is the
-# entry point each case runs, which is DRIVER_REL below; the two entry points
-# differ by an order of magnitude, and the copy's share of a case varies with
-# the driver and with whether TMPDIR is tmpfs, so measure before assuming.
+# case. A symlinked tree would not do: cases chmod and overwrite the vendored
+# scripts inside their own sandbox, and through a symlink those writes land on
+# the original. A reflink is isolated, since copy-on-write gives each case its
+# own inode, but it is unavailable where this suite runs. `cp --reflink=always`
+# fails with "Operation not supported" on tmpfs, a common TMPDIR, and the shard
+# runs on ubuntu-latest, whose ext4 disk has no reflink either; `--reflink=auto`
+# then falls back to a full copy without saying so. It would also buy little,
+# since the copies are not the bulk of this suite's runtime. What a suite can
+# change is the entry point each case runs, which is DRIVER_REL below; the two
+# entry points differ by an order of magnitude, and the copy's share of a case
+# varies with the driver and with whether TMPDIR is tmpfs, so measure first.
 PRISTINE="$TMP/pristine"
 mkdir -p "$PRISTINE/.agents/skills" "$PRISTINE/.github/workflows" "$PRISTINE/docs"
 cp -R "$SKILL_DIR" "$PRISTINE/.agents/skills/review-gate"

--- a/skills/review-gate/tests/predicate-unknown-arg.test.sh
+++ b/skills/review-gate/tests/predicate-unknown-arg.test.sh
@@ -93,6 +93,9 @@ config_reject "a comment-reviewer pair with an empty login" REVIEW_GATE_COMMENT_
 config_reject "an exclusion anchored with a leading '/'" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "/AGENTS.md"
 config_reject "a parent-relative exclusion" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "../future/*"
 config_reject "a dot-relative exclusion" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "./future/*"
+# The rule is REACHABILITY, not a list of anchors: a '.' component is
+# unreachable wherever it sits, not only at the front.
+config_reject "an embedded dot component" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "docs/./guide.md"
 config_reject "an exclusion with an empty path component" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "docs//guide.md"
 config_reject "an exclusion ending in '/'" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "docs/"
 config_reject "an unreachable PROPHYLACTIC declaration" REVIEW_GATE_CARRY_FORWARD_EXCLUDE_PROPHYLACTIC "../future/*"

--- a/skills/review-gate/tests/review-writer-template.test.sh
+++ b/skills/review-gate/tests/review-writer-template.test.sh
@@ -280,10 +280,16 @@ relay_run() { # step-path, read_only, workflow_ref, gh_codes, event_name, header
   done
 }
 
+# The extracted steps, and the copy each one CAME FROM. Two arrays because
+# RELAY_STEPS only grows on a successful extraction while WORKFLOW_LABELS is
+# populated for every discovered copy — so indexing the labels by a step's
+# position would, the moment one extraction failed, print the surviving copy's
+# results under the failed copy's name, in the log a maintainer is reading to
+# diagnose that failure.
 RELAY_STEPS=()
-relay_battery() { # file, label
+RELAY_STEP_LABELS=()
+relay_extract() { # file, label — appends the step and its label, on success
   local wf="$1" tag="$2" step="$TMP_ROOT/relay-step-${#RELAY_STEPS[@]}.sh"
-  local ref="o/r/.github/workflows/review-gate-writer.yml@refs/heads/main"
   awk '
     /^      - name: Request a converge pass$/ { found = 1; next }
     found && !inblock && /^        run: \|$/ { inblock = 1; next }
@@ -294,11 +300,16 @@ relay_battery() { # file, label
   ' "$wf" > "$step"
   if [[ -s "$step" ]] && grep -qF -- "/dispatches" "$step"; then
     RELAY_STEPS+=("$step")
+    RELAY_STEP_LABELS+=("$tag")
     PASS=$((PASS + 1)); printf '  ok    [%s] %s\n' "$tag" "relay: the step script extracted from the workflow (non-empty, dispatches)"
   else
-    FAIL=$((FAIL + 1)); printf '  FAIL  [%s] %s\n' "$tag" "relay: could NOT extract the step script — every case below would prove nothing"
-    return
+    FAIL=$((FAIL + 1)); printf '  FAIL  [%s] %s\n' "$tag" "relay: could NOT extract the step script — the battery and the cross-copy identity check below both lose this copy"
   fi
+}
+
+relay_battery() { # step script, label
+  local step="$1" tag="$2"
+  local ref="o/r/.github/workflows/review-gate-writer.yml@refs/heads/main"
   # Read from the step, not hardcoded: every wait assertion below is stated as
   # an exact clamp plus this bound, so a retuned jitter must move them with it.
   RELAY_JITTER_MAX="$(grep -oE '^jitter_max=[0-9]+' "$step" | head -n 1 | cut -d= -f2 || true)"
@@ -556,13 +567,27 @@ $rl_ok"
 
 echo "=== relay step behavior (request-converge, VST-210) ==="
 for i in "${!WORKFLOWS[@]}"; do
-  relay_battery "${WORKFLOWS[$i]}" "${WORKFLOW_LABELS[$i]}"
+  relay_extract "${WORKFLOWS[$i]}" "${WORKFLOW_LABELS[$i]}"
 done
 
-# The battery above proves each copy's step behaves; this proves they are the
-# SAME step. Behavior equivalence under the cases we thought to write is
-# weaker than byte-identity for a script that exists in two hand-maintained
-# places — a divergence the cases do not happen to probe would otherwise ship.
+# The battery runs ONCE, against the first copy that EXTRACTED — which is the
+# template unless its extraction failed, so the label travels with the step
+# rather than being re-derived from a position. It is 40 cases run under both
+# entries of RELAY_SHELLS, 80 step executions and 221 checks, and the
+# byte-identity check below proves the other copy's step is the SAME BYTES —
+# so a second battery would execute one script twice and call the agreement a
+# result. Identity is the stronger claim of the two, and it is the one that
+# must not be skipped: if extraction lost a copy, relay_extract has already
+# reddened above.
+if [[ "${#RELAY_STEPS[@]}" -ge 1 ]]; then
+  relay_battery "${RELAY_STEPS[0]}" "${RELAY_STEP_LABELS[0]}"
+fi
+
+# The battery above proves one copy's step behaves; this proves the other is
+# the SAME step, which is what carries that behavior across to it. Behavior
+# equivalence under the cases we thought to write is weaker than byte-identity
+# for a script that exists in two hand-maintained places — a divergence the
+# cases do not happen to probe would otherwise ship.
 # The step is pure logic with no vendored paths in it, so unlike the rest of
 # the file it has no legitimate reason to differ in any copy.
 # WHOLE-FILE drift, not just the relay step: a cross-copy tooth covering only

--- a/skills/review-gate/tests/validate-workflow.test.sh
+++ b/skills/review-gate/tests/validate-workflow.test.sh
@@ -18,6 +18,14 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck source=lib/sandbox.sh
 . "$TEST_DIR/lib/sandbox.sh"
 
+# The template cases below judge validate-workflow.sh, so they run IT and not
+# the full driver: the verdict lines are the peer's own, relayed verbatim, and
+# the driver costs an order of magnitude more per case for the same answer.
+# That the driver still runs the peer and folds its counts in is proven where
+# it belongs — the `stands alone` section at the bottom, which restores
+# DRIVER_REL first.
+DRIVER_REL="$WORKFLOW_REL"
+
 echo "=== the adopted workflow is the template ==="
 
 mutate() { # DIR SED-EXPR
@@ -309,6 +317,10 @@ expect_fail "the opt-in allowance does not cover a second edit" "$dir" "has dive
 
 
 echo "=== the workflow half stands alone ==="
+
+# Back to the full driver: the cases from here down are about the SEAM — the
+# peer's own exit codes, and the driver's fold of them.
+DRIVER_REL="$VALIDATE_REL"
 
 sandbox
 dir="$DIR"

--- a/skills/review-gate/tests/validate.test.sh
+++ b/skills/review-gate/tests/validate.test.sh
@@ -344,51 +344,26 @@ expect_clean "live exclusion globs pass" "$dir"
 
 setting_fails "a glob matching no tracked path is dead config" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "no-such-directory/*.md" "matches no tracked path"
 
-# Pattern SPELLING is the engine's call, relayed through --check-config: one
-# grammar, in the matcher's own file, so this tool cannot drift from it.
-setting_fails "a leading-'/' anchor is refused by the engine and relayed" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "/AGENTS.md" "a committed setting is not legal"
+# Pattern SPELLING is the engine's call, and this tool has no copy of the
+# grammar to test: it makes ONE `--check-config` call and relays whatever
+# comes back. So the spellings are enumerated where the matcher lives —
+# predicate-unknown-arg.test.sh, `--check-config` direct and ~11x cheaper per
+# case — and what is proven HERE is the relay itself: the refusal becomes a
+# finding, and the engine's own reason survives into the verdict.
+setting_fails "a refused spelling is relayed as a finding" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "/AGENTS.md" "a committed setting is not legal"
 printf '%s' "$OUT" | grep -qF "is not supported" &&
   ok "the engine's own reason rides out in the verdict" ||
   bad "the engine's own reason rides out in the verdict" "$OUT"
 
-# Parent-relative is dead the same way, and so not waivable: a declaration
-# says "no tracked match TODAY", and this one cannot match on any day.
-setting_fails "a parent-relative glob is refused by the engine" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "../future/*" "a committed setting is not legal"
-
+# A PROPHYLACTIC declaration cannot rescue a refused spelling: the relay above
+# runs before the declaration loop and is unconditional, so an unreachable
+# pattern is a finding whether or not it is declared. One case pins that
+# ordering; the spellings themselves are the engine's business, above.
 sandbox
 dir="$DIR"
 settings "$dir" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "../future/*"
 settings "$dir" REVIEW_GATE_CARRY_FORWARD_EXCLUDE_PROPHYLACTIC "../future/*"
 expect_fail "declaring an unreachable pattern prophylactic does not rescue it" "$dir" "a committed setting is not legal"
-
-# The rule is REACHABILITY, not a list of anchors: a dot-relative glob and an
-# embedded dot component are unreachable for the same reason.
-setting_fails "a dot-relative glob is refused by the engine" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "./future/*" "a committed setting is not legal"
-
-setting_fails "an embedded dot component is refused by the engine" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "docs/./guide.md" "a committed setting is not legal"
-
-# The grammar is closed in the ENGINE and every spelling outside it is
-# refused there and relayed here: refusing the spelling is what leaves no
-# equivalence to enumerate.
-setting_fails "a bracket-class glob is refused by the engine's grammar" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "[.]/future/*" "a committed setting is not legal"
-
-sandbox
-dir="$DIR"
-settings "$dir" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "[.]/future/*"
-settings "$dir" REVIEW_GATE_CARRY_FORWARD_EXCLUDE_PROPHYLACTIC "[.]/future/*"
-expect_fail "declaring a refused spelling prophylactic does not rescue it" "$dir" "a committed setting is not legal"
-
-setting_fails "a backslash escape is refused by the engine's grammar" REVIEW_GATE_CARRY_FORWARD_EXCLUDE 'docs/\.md' "a committed setting is not legal"
-
-# An EMPTY component is unreachable for the same reason a '.' one is: git
-# names carry neither. A trailing '/' is the same thing spelt at the end.
-setting_fails "an empty path component is refused by the engine" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "docs//guide.md" "a committed setting is not legal"
-
-sandbox
-dir="$DIR"
-settings "$dir" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "docs/"
-settings "$dir" REVIEW_GATE_CARRY_FORWARD_EXCLUDE_PROPHYLACTIC "docs/"
-expect_fail "a trailing '/' is refused, declaration or not" "$dir" "a committed setting is not legal"
 
 # ...and an ordinary glob with a dot in a NAME is reachable and stays so.
 setting_clean "a dot inside a filename is not a dot component" REVIEW_GATE_CARRY_FORWARD_EXCLUDE "docs/*.md"


### PR DESCRIPTION
## Summary

- `validate-workflow.test.sh` drove the full `validate.sh` for every template case, though `validate.sh` only runs `validate-workflow.sh` and relays its lines verbatim. `lib/sandbox.sh` grows a `DRIVER_REL` seam; the template cases point it at the peer tool, and the `stands alone` section restores the driver for the cases about the fold itself.
- `validate.test.sh` re-proved eight exclusion-glob spellings through that same full driver, when `validate.sh` holds no copy of the grammar — one `--check-config` call, relayed. The spellings now live only in `predicate-unknown-arg.test.sh`, where the matcher does. What stays is the relay itself and the ordering a `PROPHYLACTIC` declaration cannot jump.
- `review-writer-template.test.sh` ran the relay battery against both workflow copies, then proved the two extracted steps byte-identical — so the second run executed the same bytes. Extraction splits out of the battery, both copies are still extracted (identity unchanged and still fail-closed), and the battery runs once.

## Measured

Full review-gate shard, base vs head, interleaved from isolated copies (reviewer-perf, n=3 pairs): **29.3s → 21.9s p50, −25%**, zero failures either side. Per-suite p50 at n=11: `validate-workflow` 6639 → 1974ms, `validate` 10141 → 8528ms, `review-writer-template` 1297 → 666ms.

`predicate-unknown-arg` is **+11ms (+3.9%)** — one `--check-config` invocation, the honest cost of the case this change adds there. That proof previously cost a 163ms `validate.sh` case, and this removes eight of them. Accepted, non-blocking, classified in the perf artifact rather than dropped.

## Scope

Two of the issue's five requirements were not implemented, deliberately:

1. **Selftest layer seam for the 217-case battery** — superseded. `9a7b498e6` (KEN-1092, #1958) deleted `review-predicate-selftest.test.sh` outright the day after the audit that filed this issue. There is nothing to seam.
2. **Reflink or share the 62 sandbox copies.** Not implemented, because reflink is not available where this suite runs. `cp --reflink=always` fails on tmpfs, a common `TMPDIR`, and `--reflink=auto` quietly falls back to a full copy; the shard runs on `ubuntu-latest`, whose ext4 disk has no reflink either. The copies are also a small share of the suite's runtime, measured above, so a clone would save little even on btrfs. Reflink itself is safe: `cp --reflink` gives each copy its own inode over copy-on-write extents, so a case's `chmod` and overwrites stay inside its own sandbox. Only a symlinked or hardlinked tree would let one case corrupt the next. The comment in `lib/sandbox.sh` now says this, replacing two wrong claims, that the copies were "the bulk of this suite's runtime" and that they are unshareable at any price.

Requirement 3 was eight duplicate spellings, not nine — `validate.test.sh` never carried a `?`-wildcard case.

## Completed Issues

- Closes KEN-1011 - review-gate shard: selftest seam, shared sandboxes, single-run writer template

## Test Plan

Every guard this change leans on was verified able to fail, each control run on an isolated copy:

- `validate-workflow.sh` with `bad()` rewritten to `ok()`: 16 pass / 35 fail, identically before and after the driver swap — no coverage lost to the retarget.
- `validate.sh`'s `--check-config` relay forced to pass: both surviving exclusion cases red.
- The adopted workflow's relay step, code edit and comment-only edit, in catalog and consumer shapes: whole-file drift red on the first, byte-identity red on both — the identity tooth is reachable and is the only cover in the consumer shape.
- The template's step hardcoding its own workflow file: `relay2`, `relay4`, `relay22` red, so the once-run battery still catches behavior.
- Template step renamed so only its extraction fails: 0 `[template]` ok lines, against 61 before the label fix.
- A bogus `DRIVER_REL` set before the source line: 38 red, against 51/0 silently green before the defensive default.

Full review-gate shard green, all 13 suites. `tools/guard` exit 0, preflight clean, size-ratchet OK, both source and `.agents` render trees green.

Case counts: `validate` 80 → 72, `validate-workflow` 51 → 51, `predicate-unknown-arg` 70 → 72, `review-writer-template` 446 → 225. The last is a deliberate 221-assertion reduction — dropping the second battery run — carried by the byte-identity check, which proves the same bytes rather than the same behavior under cases we thought to write.

https://claude.ai/code/session_01YFpUtJHJmzRjbBkDrKhmHq

