### PR TITLE
perf(KEN-1012): the shell shard stops waiting on itself

### DIFF
--- a/.agents/skills/github/README.md
+++ b/.agents/skills/github/README.md
@@ -47,6 +47,10 @@ Run `./scripts/github.sh --help` for the command list, or
 | `KENDEX_GITHUB_PR_VIEW_TIMEOUT` | Seconds allowed for `gh pr view` | `30` |
 | `KENDEX_GITHUB_GIT_HTTPS_FALLBACK` | `auto`, `never`, or `always` for `git-https-auth` | `auto` |
 
+The three `KENDEX_GITHUB_*_TIMEOUT` bounds are read to one decimal place, so
+`0.5` is half a second and `0` means no bound. A figure finer than a tenth is
+refused rather than rounded, and the command does not run.
+
 Values already set in the parent process win over project files. Tokens may be
 literal (`ghp_*`, `github_pat_*`, …) or `op://vault/item/field` references;
 keep them in `.env.local` rather than committed settings.

--- a/.agents/skills/github/kendex.settings.toml.example
+++ b/.agents/skills/github/kendex.settings.toml.example
@@ -23,11 +23,14 @@ GH_ISSUE_PATTERN = ""
 # project-root `verify.sh`, then to auto-detected build stacks.
 GH_VERIFY_CMD = ""
 
-# Seconds a 1Password token resolution may take.
+# Seconds a 1Password token resolution may take. Read to one decimal
+# place: 0 means no bound, and anything finer than a tenth is refused.
 KENDEX_GITHUB_OP_TIMEOUT = "10"
 
-# Seconds the `gh` auth preflight may take.
+# Seconds the `gh` auth preflight may take. Read to one decimal place:
+# 0 means no bound, and anything finer than a tenth is refused.
 KENDEX_GITHUB_AUTH_TIMEOUT = "10"
 
-# Seconds a single `pr-view` read may take.
+# Seconds a single `pr-view` read may take. Read to one decimal place:
+# 0 means no bound, and anything finer than a tenth is refused.
 KENDEX_GITHUB_PR_VIEW_TIMEOUT = "30"

--- a/.agents/skills/github/scripts/commands/pr-view.sh
+++ b/.agents/skills/github/scripts/commands/pr-view.sh
@@ -75,10 +75,11 @@ Errors:
   Emits structured JSON on stdout ({"status":..., "error":..., "detail":...,
   "exit_code":..., "number":...}) and exits nonzero. status is one of no_pr,
   auth_error, token_resolution_failed, token_resolution_timeout,
-  token_resolution_unavailable, auth_timeout, gh_timeout, bad_timeout, or
-  gh_error. bad_timeout exits 2 and names the KENDEX_GITHUB_*_TIMEOUT setting
-  whose value is not a number of seconds to one decimal place; nothing ran.
-  Raw gh/op detail is preserved in stderr and the JSON detail field.
+  token_resolution_unavailable, auth_timeout, gh_timeout, bad_timeout,
+  unsupported_flag, or gh_error. bad_timeout exits 2 and names the
+  KENDEX_GITHUB_*_TIMEOUT setting whose value is not a number of seconds to
+  one decimal place; nothing ran. Raw gh/op detail is preserved in stderr and
+  the JSON detail field.
 
 Examples:
   github.sh pr-view              # View PR for current branch

--- a/.agents/skills/github/scripts/commands/pr-view.sh
+++ b/.agents/skills/github/scripts/commands/pr-view.sh
@@ -75,8 +75,10 @@ Errors:
   Emits structured JSON on stdout ({"status":..., "error":..., "detail":...,
   "exit_code":..., "number":...}) and exits nonzero. status is one of no_pr,
   auth_error, token_resolution_failed, token_resolution_timeout,
-  token_resolution_unavailable, auth_timeout, gh_timeout, or gh_error. Raw
-  gh/op detail is preserved in stderr and the JSON detail field.
+  token_resolution_unavailable, auth_timeout, gh_timeout, bad_timeout, or
+  gh_error. bad_timeout exits 2 and names the KENDEX_GITHUB_*_TIMEOUT setting
+  whose value is not a number of seconds to one decimal place; nothing ran.
+  Raw gh/op detail is preserved in stderr and the JSON detail field.
 
 Examples:
   github.sh pr-view              # View PR for current branch
@@ -119,6 +121,24 @@ main() {
                 shift
                 ;;
         esac
+    done
+
+    # A bound the runner cannot read stops the command before it runs and
+    # comes back as 125 — with no output, because nothing ran, so at the call
+    # site it is indistinguishable from the command's own failure and an
+    # operator debugging a typo in their own setting is pointed at GitHub
+    # auth. Refused here by name, ahead of any request. The grammar is asked
+    # of the runner's own reader rather than restated.
+    local bound_name bound_value
+    for bound_name in KENDEX_GITHUB_AUTH_TIMEOUT KENDEX_GITHUB_OP_TIMEOUT \
+        KENDEX_GITHUB_PR_VIEW_TIMEOUT; do
+        bound_value="${!bound_name:-}"
+        [ -n "$bound_value" ] || continue
+        kendex_github_bound_ticks "$bound_value" >/dev/null && continue
+        emit_error_result "bad_timeout" \
+            "$bound_name is not a number of seconds to one decimal place" \
+            "$bound_value" 2
+        exit 2
     done
 
     local auth_out auth_err pr_out pr_err

--- a/.agents/skills/github/scripts/github.sh
+++ b/.agents/skills/github/scripts/github.sh
@@ -101,6 +101,7 @@ Configuration:
       Seconds allowed for GitHub auth preflight. Default: 10.
   KENDEX_GITHUB_PR_VIEW_TIMEOUT
       Seconds allowed for gh pr view in pr-view. Default: 30.
+      Every bound above is read to one decimal place; 0 means no bound.
   KENDEX_GITHUB_GIT_HTTPS_FALLBACK
       git-https-auth mode: auto, never, or always. Default: auto.
 

--- a/.agents/skills/github/scripts/github.sh
+++ b/.agents/skills/github/scripts/github.sh
@@ -101,7 +101,10 @@ Configuration:
       Seconds allowed for GitHub auth preflight. Default: 10.
   KENDEX_GITHUB_PR_VIEW_TIMEOUT
       Seconds allowed for gh pr view in pr-view. Default: 30.
-      Every bound above is read to one decimal place; 0 means no bound.
+
+  All three bounds above are read to one decimal place; 0 means no bound, and
+  a figure finer than a tenth is refused rather than rounded.
+
   KENDEX_GITHUB_GIT_HTTPS_FALLBACK
       git-https-auth mode: auto, never, or always. Default: auto.
 

--- a/.agents/skills/github/scripts/lib/bounded.sh
+++ b/.agents/skills/github/scripts/lib/bounded.sh
@@ -79,6 +79,11 @@ kendex_github_bound_ticks() { # SECONDS — tenths on stdout; 1 when unreadable
     *) whole="$seconds" frac=0 ;;
   esac
   case "$whole" in '' | *[!0-9]*) return 1 ;; esac
+  # Ten times an 18-digit whole part is past what signed 64-bit shell
+  # arithmetic holds, and the wrap lands on 0 for one such value in ten, which
+  # the runner below reads as "no bound" and then waits on forever. Refused on
+  # width here, before the multiply, so no call site inherits the wrap.
+  [ "${#whole}" -le 17 ] || return 1
   case "$frac" in [0-9]) ;; *) return 1 ;; esac
   printf '%s' "$(((10#$whole) * 10 + frac))"
 }

--- a/.agents/skills/github/scripts/lib/bounded.sh
+++ b/.agents/skills/github/scripts/lib/bounded.sh
@@ -88,7 +88,16 @@ kendex_github_run_bounded() {
   shift
 
   local restore_monitor=0 pid="" ticks=0 max_ticks status=0 target=""
-  max_ticks="$(kendex_github_bound_ticks "$seconds")" || return 125
+  if ! max_ticks="$(kendex_github_bound_ticks "$seconds")"; then
+    # 125 arrives having run nothing, so there is no output to explain it and
+    # most callers can only pass it upward — an auth check that never ran, a
+    # token that never resolved, and no name for the setting behind either.
+    # Said once, here, where the grammar is read: no call site can go quiet
+    # again by forgetting to say it.
+    printf "bounded: '%s' is not a number of seconds to one decimal place; nothing ran\n" \
+      "$seconds" >&2
+    return 125
+  fi
   if [ "$max_ticks" -eq 0 ]; then
     "$@"
     return

--- a/.agents/skills/github/scripts/lib/bounded.sh
+++ b/.agents/skills/github/scripts/lib/bounded.sh
@@ -63,23 +63,32 @@ _kendex_github_forward_bounded_signal() {
   case "$signal" in HUP) return 129 ;; INT) return 130 ;; TERM) return 143 ;; esac
 }
 
-kendex_github_run_bounded() {
-  local seconds="$1"
-  shift
-
-  # The bound is polled on a 0.1s tick below, so it is read to one decimal
-  # place and no finer: a figure the poll could not honour is junk, not a
-  # tighter bound. A leading zero is decimal, never octal.
-  local whole frac
+# The one reading of the bound grammar. The bound is polled on a 0.1s tick
+# below, so it is read to one decimal place and no finer: a figure the poll
+# could not honour is junk, not a tighter bound. A leading zero is decimal,
+# never octal.
+#
+# Separate from the runner because a caller has to be able to tell a bound it
+# cannot read from a command that failed, and it may not ask by running the
+# command: 125 arrives after the command did not run, so there is no output to
+# explain it. Asking here keeps one judge of the grammar.
+kendex_github_bound_ticks() { # SECONDS — tenths on stdout; 1 when unreadable
+  local seconds="$1" whole frac
   case "$seconds" in
     *.*) whole="${seconds%.*}" frac="${seconds#*.}" ;;
     *) whole="$seconds" frac=0 ;;
   esac
-  case "$whole" in '' | *[!0-9]*) return 125 ;; esac
-  case "$frac" in [0-9]) ;; *) return 125 ;; esac
+  case "$whole" in '' | *[!0-9]*) return 1 ;; esac
+  case "$frac" in [0-9]) ;; *) return 1 ;; esac
+  printf '%s' "$(((10#$whole) * 10 + frac))"
+}
+
+kendex_github_run_bounded() {
+  local seconds="$1"
+  shift
 
   local restore_monitor=0 pid="" ticks=0 max_ticks status=0 target=""
-  max_ticks=$(((10#$whole) * 10 + frac))
+  max_ticks="$(kendex_github_bound_ticks "$seconds")" || return 125
   if [ "$max_ticks" -eq 0 ]; then
     "$@"
     return

--- a/.agents/skills/github/scripts/lib/bounded.sh
+++ b/.agents/skills/github/scripts/lib/bounded.sh
@@ -67,16 +67,24 @@ kendex_github_run_bounded() {
   local seconds="$1"
   shift
 
+  # The bound is polled on a 0.1s tick below, so it is read to one decimal
+  # place and no finer: a figure the poll could not honour is junk, not a
+  # tighter bound. A leading zero is decimal, never octal.
+  local whole frac
   case "$seconds" in
-    ''|*[!0-9]*) return 125 ;;
+    *.*) whole="${seconds%.*}" frac="${seconds#*.}" ;;
+    *) whole="$seconds" frac=0 ;;
   esac
-  seconds=$((10#$seconds))
-  if [ "$seconds" -eq 0 ]; then
+  case "$whole" in '' | *[!0-9]*) return 125 ;; esac
+  case "$frac" in [0-9]) ;; *) return 125 ;; esac
+
+  local restore_monitor=0 pid="" ticks=0 max_ticks status=0 target=""
+  max_ticks=$(((10#$whole) * 10 + frac))
+  if [ "$max_ticks" -eq 0 ]; then
     "$@"
     return
   fi
 
-  local restore_monitor=0 pid="" ticks=0 max_ticks status=0 target=""
   local old_hup old_int old_term
   old_hup="$(trap -p HUP)"
   old_int="$(trap -p INT)"
@@ -96,7 +104,6 @@ kendex_github_run_bounded() {
   if ! kill -0 -- "$target" 2>/dev/null; then
     target="$pid"
   fi
-  max_ticks=$((seconds * 10))
 
   while kill -0 "$pid" 2>/dev/null; do
     if [ "$ticks" -ge "$max_ticks" ]; then

--- a/.agents/skills/github/scripts/lib/gh-auth.sh
+++ b/.agents/skills/github/scripts/lib/gh-auth.sh
@@ -87,6 +87,15 @@ kendex_github_resolve_op_reference_to_var() {
       export KENDEX_GITHUB_TOKEN_ERROR_TYPE="token_resolution_timeout"
       export KENDEX_GITHUB_TOKEN_ERROR="Timed out resolving ${label} 1Password reference after ${op_timeout}s"
       ;;
+    125)
+      # op never ran, so this is a resolution that was never attempted, not
+      # one that failed. The capture above folded the runner's own line into
+      # op_output, and both callers take the failure as || true: the token is
+      # dropped and the command runs unauthenticated with nothing said.
+      echo "Warning: KENDEX_GITHUB_OP_TIMEOUT is '${op_timeout}', not a number of seconds to one decimal place; ${label} was never resolved." >&2
+      export KENDEX_GITHUB_TOKEN_ERROR_TYPE="token_resolution_unavailable"
+      export KENDEX_GITHUB_TOKEN_ERROR="KENDEX_GITHUB_OP_TIMEOUT is '${op_timeout}', not a number of seconds to one decimal place, so ${label} was never resolved"
+      ;;
     *)
       export KENDEX_GITHUB_TOKEN_ERROR_TYPE="token_resolution_failed"
       export KENDEX_GITHUB_TOKEN_ERROR="Failed to resolve ${label} 1Password reference"
@@ -106,6 +115,16 @@ kendex_github_sanitize_gh_env() {
     return 0
   else
     auth_status=$?
+  fi
+  # 124 is the bound expiring, 125 a bound the runner could not read: neither
+  # check reached gh, and the keyring probe below runs under the same bound,
+  # so falling through spends that probe and then returns 0 as if the token
+  # had been judged sound. The runner names an unreadable bound on its own
+  # stderr, but these checks discard that with gh's chatter, and this prologue
+  # runs ahead of every subcommand — so the 125 arm says it again here.
+  if [[ "$auth_status" -eq 125 ]]; then
+    echo "Warning: KENDEX_GITHUB_AUTH_TIMEOUT is '${KENDEX_GITHUB_AUTH_TIMEOUT:-10}', not a number of seconds to one decimal place; GH_TOKEN/GITHUB_TOKEN went unchecked." >&2
+    return 0
   fi
   [[ "$auth_status" -eq 124 ]] && return 0
   if [[ "${KENDEX_GITHUB_SELECTED_TOKEN_SOURCE:-}" == "GH_BOT_TOKEN" ]]; then

--- a/.agents/skills/github/scripts/lib/gh-auth.sh
+++ b/.agents/skills/github/scripts/lib/gh-auth.sh
@@ -21,7 +21,7 @@ kendex_github_has_env_token() {
 kendex_github_token_auth_status() {
   kendex_github_has_env_token || return 1
   local auth_timeout="${KENDEX_GITHUB_AUTH_TIMEOUT:-10}"
-  kendex_github_run_bounded "$auth_timeout" gh api user --jq '.login' >/dev/null
+  kendex_github_run_bounded "$auth_timeout" gh api user --jq '.login' >/dev/null 2>&1
 }
 
 kendex_github_token_auth_status_capture() {
@@ -59,7 +59,7 @@ kendex_github_auth_status_capture() {
 
 kendex_github_keyring_auth_status() {
   local auth_timeout="${KENDEX_GITHUB_AUTH_TIMEOUT:-10}"
-  kendex_github_run_bounded "$auth_timeout" env -u GH_TOKEN -u GITHUB_TOKEN gh auth status >/dev/null
+  kendex_github_run_bounded "$auth_timeout" env -u GH_TOKEN -u GITHUB_TOKEN gh auth status >/dev/null 2>&1
 }
 
 kendex_github_resolve_op_reference_to_var() {

--- a/.agents/skills/github/scripts/lib/gh-auth.sh
+++ b/.agents/skills/github/scripts/lib/gh-auth.sh
@@ -75,6 +75,20 @@ kendex_github_resolve_op_reference_to_var() {
     return 1
   fi
 
+  # Asked of the runner's own reader before anything runs: the runner hands
+  # back the wrapped command's status unchanged, so an op exiting 125 under a
+  # good bound is indistinguishable from a bound it could not read. Nothing is
+  # invoked here, so this is a resolution never attempted, and it carries its
+  # own status because token_resolution_unavailable means op is absent and
+  # github-api.sh branches on that to say install it. Three call sites read it:
+  # two here, both dropping the token silently, and github-api.sh.
+  if ! kendex_github_bound_ticks "$op_timeout" >/dev/null; then
+    echo "Warning: KENDEX_GITHUB_OP_TIMEOUT is '${op_timeout}', not a number of seconds to one decimal place; ${label} was never resolved." >&2
+    export KENDEX_GITHUB_TOKEN_ERROR_TYPE="token_resolution_bad_timeout"
+    export KENDEX_GITHUB_TOKEN_ERROR="KENDEX_GITHUB_OP_TIMEOUT is '${op_timeout}', not a number of seconds to one decimal place, so ${label} was never resolved"
+    return 1
+  fi
+
   op_output=$(kendex_github_run_bounded "$op_timeout" op read "$ref" 2>&1) || op_status=$?
 
   if [[ "$op_status" -eq 0 && -n "$op_output" ]]; then
@@ -86,18 +100,6 @@ kendex_github_resolve_op_reference_to_var() {
     124)
       export KENDEX_GITHUB_TOKEN_ERROR_TYPE="token_resolution_timeout"
       export KENDEX_GITHUB_TOKEN_ERROR="Timed out resolving ${label} 1Password reference after ${op_timeout}s"
-      ;;
-    125)
-      # op never ran, so this is a resolution that was never attempted, not
-      # one that failed and not one 1Password was missing for. Its own status,
-      # because token_resolution_unavailable means the op binary is absent and
-      # github-api.sh branches on that to tell the operator to install it.
-      # Three call sites: two here, both under || true, where the capture above
-      # folded the runner's own line into op_output and the token is dropped
-      # silently; and github-api.sh, which reads the status.
-      echo "Warning: KENDEX_GITHUB_OP_TIMEOUT is '${op_timeout}', not a number of seconds to one decimal place; ${label} was never resolved." >&2
-      export KENDEX_GITHUB_TOKEN_ERROR_TYPE="token_resolution_bad_timeout"
-      export KENDEX_GITHUB_TOKEN_ERROR="KENDEX_GITHUB_OP_TIMEOUT is '${op_timeout}', not a number of seconds to one decimal place, so ${label} was never resolved"
       ;;
     *)
       export KENDEX_GITHUB_TOKEN_ERROR_TYPE="token_resolution_failed"
@@ -114,26 +116,24 @@ kendex_github_sanitize_gh_env() {
   command -v gh >/dev/null 2>&1 || return 0
   [[ -z "${GH_TOKEN:-}${GITHUB_TOKEN:-}" ]] && return 0
   local auth_status=0
+  # A bound the runner cannot read means gh is never asked, and the check then
+  # says nothing about the token. Asked of the reader here, not inferred from
+  # a 125, which is the wrapped command's own status just as often.
+  #
+  # It reports and leaves the trust decision where it was: a diagnostic, not a
+  # fail-closed control. The keyring probe below runs under the same unreadable
+  # bound and could not have succeeded, and refusing outright would break all
+  # 24 subcommands on a typo. What it adds is which setting went unchecked.
+  if ! kendex_github_bound_ticks "${KENDEX_GITHUB_AUTH_TIMEOUT:-10}" >/dev/null; then
+    echo "Warning: KENDEX_GITHUB_AUTH_TIMEOUT is '${KENDEX_GITHUB_AUTH_TIMEOUT:-10}', not a number of seconds to one decimal place; GH_TOKEN/GITHUB_TOKEN went unchecked." >&2
+    return 0
+  fi
   if kendex_github_auth_status; then
     return 0
   else
     auth_status=$?
   fi
-  # 124 and 125 are not the same answer. 124 is gh started and killed at the
-  # deadline, which is the one status here that proves gh was invoked; 125 is
-  # a bound the runner could not read, so gh was never asked and the check
-  # says nothing about the token.
-  #
-  # This arm reports that and leaves the trust decision exactly where it was:
-  # a diagnostic, not a fail-closed control. The keyring probe below runs
-  # under the same unreadable bound and could not have succeeded, and refusing
-  # outright would break all 24 subcommands on a typo. What it adds to the
-  # runner's own line is which setting carried the value and what went
-  # unchecked because of it.
-  if [[ "$auth_status" -eq 125 ]]; then
-    echo "Warning: KENDEX_GITHUB_AUTH_TIMEOUT is '${KENDEX_GITHUB_AUTH_TIMEOUT:-10}', not a number of seconds to one decimal place; GH_TOKEN/GITHUB_TOKEN went unchecked." >&2
-    return 0
-  fi
+  # 124 is gh invoked and killed at the deadline: nothing against the token.
   [[ "$auth_status" -eq 124 ]] && return 0
   if [[ "${KENDEX_GITHUB_SELECTED_TOKEN_SOURCE:-}" == "GH_BOT_TOKEN" ]]; then
     return 0

--- a/.agents/skills/github/scripts/lib/gh-auth.sh
+++ b/.agents/skills/github/scripts/lib/gh-auth.sh
@@ -21,7 +21,7 @@ kendex_github_has_env_token() {
 kendex_github_token_auth_status() {
   kendex_github_has_env_token || return 1
   local auth_timeout="${KENDEX_GITHUB_AUTH_TIMEOUT:-10}"
-  kendex_github_run_bounded "$auth_timeout" gh api user --jq '.login' >/dev/null 2>&1
+  kendex_github_run_bounded "$auth_timeout" gh api user --jq '.login' >/dev/null
 }
 
 kendex_github_token_auth_status_capture() {
@@ -41,7 +41,7 @@ kendex_github_auth_status() {
     return $?
   fi
 
-  kendex_github_run_bounded "$auth_timeout" gh auth status >/dev/null 2>&1
+  kendex_github_run_bounded "$auth_timeout" gh auth status >/dev/null
 }
 
 kendex_github_auth_status_capture() {
@@ -59,7 +59,7 @@ kendex_github_auth_status_capture() {
 
 kendex_github_keyring_auth_status() {
   local auth_timeout="${KENDEX_GITHUB_AUTH_TIMEOUT:-10}"
-  kendex_github_run_bounded "$auth_timeout" env -u GH_TOKEN -u GITHUB_TOKEN gh auth status >/dev/null 2>&1
+  kendex_github_run_bounded "$auth_timeout" env -u GH_TOKEN -u GITHUB_TOKEN gh auth status >/dev/null
 }
 
 kendex_github_resolve_op_reference_to_var() {
@@ -89,11 +89,14 @@ kendex_github_resolve_op_reference_to_var() {
       ;;
     125)
       # op never ran, so this is a resolution that was never attempted, not
-      # one that failed. The capture above folded the runner's own line into
-      # op_output, and both callers take the failure as || true: the token is
-      # dropped and the command runs unauthenticated with nothing said.
+      # one that failed and not one 1Password was missing for. Its own status,
+      # because token_resolution_unavailable means the op binary is absent and
+      # github-api.sh branches on that to tell the operator to install it.
+      # Three call sites: two here, both under || true, where the capture above
+      # folded the runner's own line into op_output and the token is dropped
+      # silently; and github-api.sh, which reads the status.
       echo "Warning: KENDEX_GITHUB_OP_TIMEOUT is '${op_timeout}', not a number of seconds to one decimal place; ${label} was never resolved." >&2
-      export KENDEX_GITHUB_TOKEN_ERROR_TYPE="token_resolution_unavailable"
+      export KENDEX_GITHUB_TOKEN_ERROR_TYPE="token_resolution_bad_timeout"
       export KENDEX_GITHUB_TOKEN_ERROR="KENDEX_GITHUB_OP_TIMEOUT is '${op_timeout}', not a number of seconds to one decimal place, so ${label} was never resolved"
       ;;
     *)
@@ -116,12 +119,17 @@ kendex_github_sanitize_gh_env() {
   else
     auth_status=$?
   fi
-  # 124 is the bound expiring, 125 a bound the runner could not read: neither
-  # check reached gh, and the keyring probe below runs under the same bound,
-  # so falling through spends that probe and then returns 0 as if the token
-  # had been judged sound. The runner names an unreadable bound on its own
-  # stderr, but these checks discard that with gh's chatter, and this prologue
-  # runs ahead of every subcommand — so the 125 arm says it again here.
+  # 124 and 125 are not the same answer. 124 is gh started and killed at the
+  # deadline, which is the one status here that proves gh was invoked; 125 is
+  # a bound the runner could not read, so gh was never asked and the check
+  # says nothing about the token.
+  #
+  # This arm reports that and leaves the trust decision exactly where it was:
+  # a diagnostic, not a fail-closed control. The keyring probe below runs
+  # under the same unreadable bound and could not have succeeded, and refusing
+  # outright would break all 24 subcommands on a typo. What it adds to the
+  # runner's own line is which setting carried the value and what went
+  # unchecked because of it.
   if [[ "$auth_status" -eq 125 ]]; then
     echo "Warning: KENDEX_GITHUB_AUTH_TIMEOUT is '${KENDEX_GITHUB_AUTH_TIMEOUT:-10}', not a number of seconds to one decimal place; GH_TOKEN/GITHUB_TOKEN went unchecked." >&2
     return 0

--- a/.agents/skills/github/scripts/lib/github-api.sh
+++ b/.agents/skills/github/scripts/lib/github-api.sh
@@ -312,6 +312,10 @@ load_bot_token() {
             echo "Warning: GH_BOT_TOKEN is a 1Password reference but 'op' CLI not found" >&2
             echo "  Install: https://developer.1password.com/docs/cli/get-started/" >&2
             return 0
+        elif [ "${KENDEX_GITHUB_TOKEN_ERROR_TYPE:-}" = "token_resolution_bad_timeout" ]; then
+            # op was never asked, so neither install advice nor a sign-in
+            # prompt applies; the resolver already named the setting.
+            return 0
         else
             echo "Warning: Failed to resolve 1Password reference. Run: op signin" >&2
             return 0

--- a/.agents/skills/github/tests/bounded-signal.test.sh
+++ b/.agents/skills/github/tests/bounded-signal.test.sh
@@ -109,5 +109,37 @@ check_signal HUP 129
 check_signal INT 130
 check_signal TERM 143
 
+# The bound is enforced on a 0.1s tick, so a caller may ask for tenths. Junk
+# is refused with 125 rather than run unbounded: a bound that silently stops
+# bounding is how a hung `gh` becomes a hung lane.
+check_bound() { # LABEL BOUND EXPECTED-RC [COMMAND...]
+  local label="$1" bound="$2" expected="$3" rc=0
+  shift 3
+  [ "$#" -gt 0 ] || set -- sleep 30
+  BOUNDED="$BOUNDED" BOUND="$bound" bash -c '
+    source "$BOUNDED"
+    kendex_github_run_bounded "$BOUND" "$@"
+  ' bash "$@" >/dev/null 2>&1 || rc=$?
+  if [[ "$rc" -eq "$expected" ]]; then
+    PASS=$((PASS + 1)); printf '  ok    %s\n' "$label"
+  else
+    FAIL=$((FAIL + 1)); printf '  FAIL  %s: expected %s, got %s\n' "$label" "$expected" "$rc"
+  fi
+}
+
+echo "=== bounded runner bound parsing ==="
+check_bound "a tenth-of-a-second bound times out" 0.2 124
+check_bound "a whole-second bound times out" 1 124
+# Under octal arithmetic 08 is not a number at all, so a command that finishes
+# well inside the bound separates the two readings without waiting out either.
+check_bound "a leading-zero bound is decimal, not octal" 08 0 true
+check_bound "a two-place bound is refused" 0.25 125
+check_bound "a bare decimal point is refused" . 125
+check_bound "a trailing decimal point is refused" 5. 125
+check_bound "a non-numeric bound is refused" soon 125
+# Sub-second bounds must not have become "no bound at all": a zero bound is
+# the documented way to ask for that, and nothing else may reach it.
+check_bound "a zero bound runs the command unbounded" 0.0 0 true
+
 printf '\npass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/.agents/skills/github/tests/bounded-signal.test.sh
+++ b/.agents/skills/github/tests/bounded-signal.test.sh
@@ -137,6 +137,9 @@ check_bound "a two-place bound is refused" 0.25 125
 check_bound "a bare decimal point is refused" . 125
 check_bound "a trailing decimal point is refused" 5. 125
 check_bound "a non-numeric bound is refused" soon 125
+# Width is part of the grammar: this one multiplies out to exactly 0 in signed
+# 64-bit arithmetic, and 0 is the documented way to ask for no bound at all.
+check_bound "a bound too wide for the arithmetic is refused" 1844674407370955161.6 125 true
 # Sub-second bounds must not have become "no bound at all": a zero bound is
 # the documented way to ask for that, and nothing else may reach it.
 check_bound "a zero bound runs the command unbounded" 0.0 0 true

--- a/.agents/skills/github/tests/env-first-auth.sh
+++ b/.agents/skills/github/tests/env-first-auth.sh
@@ -25,6 +25,17 @@ assert_eq() {
   fi
 }
 
+assert_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        wanted: %s\n        got:    %s\n' "$name" "$needle" "$haystack"
+  fi
+}
+
 assert_file_missing() {
   local path="$1" name="$2"
   if [[ ! -e "$path" ]]; then
@@ -54,6 +65,8 @@ chmod +x "$TMP_ROOT/bin/op"
 cat > "$TMP_ROOT/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+
+[[ -z "${STUB_GH_CALLS:-}" ]] || printf '%s\n' "$*" >>"$STUB_GH_CALLS"
 
 _token_ok() {
   local tok="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
@@ -323,6 +336,34 @@ else
   printf '  FAIL  the refusal names the identity fallback it is preventing\n        stderr: %s\n' "$(cat "$TMP_ROOT/partial-bot.err")"
 fi
 rm -f "$TMP_ROOT/repo/kendex.settings.toml" "$TMP_ROOT/repo/.env.local"
+
+# The prologue sanitizer runs ahead of every subcommand, and its checks are
+# bounded. A bound the runner cannot read answers 125 having invoked nothing —
+# not the 124 the timeout arm reads — and the keyring probe under the same
+# bound answers 125 too, so the function used to reach its unconditional
+# `return 0` with gh never called: an auth guard reporting a token sound
+# having looked at nothing, and a bad token surviving into every later call.
+sanitize_run() { # env-assignment... — writes sanitize.calls and sanitize.err
+  : >"$TMP_ROOT/sanitize.calls"
+  (cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" \
+    env STUB_GH_CALLS="$TMP_ROOT/sanitize.calls" STUB_KEYRING_OK=1 \
+      GH_TOKEN=ghp_BADENV "$@" bash -c '
+        source "'"$REPO_ROOT"'/skills/github/scripts/lib/gh-auth.sh"
+        kendex_github_sanitize_gh_env
+      ') 2>"$TMP_ROOT/sanitize.err"
+}
+gh_reached() { [[ -s "$TMP_ROOT/sanitize.calls" ]] && echo invoked || echo silent; }
+
+sanitize_run
+assert_eq "$(gh_reached)" "invoked" "a readable bound puts the token in front of gh"
+assert_contains "$(cat "$TMP_ROOT/sanitize.err")" \
+  "unsetting them and using gh keyring auth" \
+  "and a token gh rejects is dropped for the keyring, out loud"
+
+sanitize_run KENDEX_GITHUB_AUTH_TIMEOUT=2.55
+assert_eq "$(gh_reached)" "silent" "an unreadable bound reaches no gh call at all"
+assert_contains "$(cat "$TMP_ROOT/sanitize.err")" "'2.55'" \
+  "and the run names the bound it could not read rather than passing silently"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/.agents/skills/github/tests/env-first-auth.sh
+++ b/.agents/skills/github/tests/env-first-auth.sh
@@ -54,6 +54,8 @@ cat > "$TMP_ROOT/bin/op" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
 printf 'op called: %s\n' "\$*" >>"$TMP_ROOT/op.calls"
+# Lets a case give op an exit status of its own, 125 included.
+[[ -z "\${STUB_OP_EXIT:-}" ]] || exit "\$STUB_OP_EXIT"
 if [[ "\${1:-}" == "read" && "\${2:-}" == "op://vault/github/bot" ]]; then
   printf '%s\n' 'ghs_RESOLVED123'
   exit 0
@@ -67,6 +69,13 @@ cat > "$TMP_ROOT/bin/gh" <<'EOF'
 set -euo pipefail
 
 [[ -z "${STUB_GH_CALLS:-}" ]] || printf '%s\n' "$*" >>"$STUB_GH_CALLS"
+
+# Lets a case give gh an exit status of its own, 125 included, for the calls
+# that carry a token. The keyring probe runs with both names unset and is
+# unaffected, so a case can fail the token check and still reach it.
+if [[ -n "${STUB_GH_TOKEN_EXIT:-}" && -n "${GH_TOKEN:-}${GITHUB_TOKEN:-}" ]]; then
+  exit "$STUB_GH_TOKEN_EXIT"
+fi
 
 _token_ok() {
   local tok="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
@@ -364,6 +373,31 @@ sanitize_run KENDEX_GITHUB_AUTH_TIMEOUT=2.55
 assert_eq "$(gh_reached)" "silent" "an unreadable bound reaches no gh call at all"
 assert_contains "$(cat "$TMP_ROOT/sanitize.err")" "'2.55'" \
   "and the run names the bound it could not read rather than passing silently"
+
+# 125 is also gh's own to return. The runner hands the wrapped command's
+# status back unchanged, so reading 125 as proof the bound was unreadable
+# tells an operator to fix a setting that is fine and leaves the token
+# unchecked on a failure that was really gh's.
+sanitize_run STUB_GH_TOKEN_EXIT=125
+assert_contains "$(cat "$TMP_ROOT/sanitize.err")" \
+  "unsetting them and using gh keyring auth" \
+  "a gh that exits 125 under a readable bound is an ordinary auth failure"
+
+# The same collision on the op side. The status is what github-api.sh branches
+# on, so calling op's own 125 a bad setting suppresses the "Run: op signin"
+# advice for a resolution that really was attempted and really did fail.
+op_error_type() { # env-assignment... — the resolver's error type on stdout
+  (cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" env "$@" bash -c '
+      source "'"$REPO_ROOT"'/skills/github/scripts/lib/gh-auth.sh"
+      kendex_github_resolve_op_reference_to_var "op://vault/github/bot" "GitHub token" tok || true
+      printf "%s" "${KENDEX_GITHUB_TOKEN_ERROR_TYPE:-}"
+    ') 2>/dev/null
+}
+
+assert_eq "$(op_error_type STUB_OP_EXIT=125)" "token_resolution_failed" \
+  "an op that exits 125 under a readable bound is an ordinary resolution failure"
+assert_eq "$(op_error_type KENDEX_GITHUB_OP_TIMEOUT=2.55)" "token_resolution_bad_timeout" \
+  "and an unreadable KENDEX_GITHUB_OP_TIMEOUT still names the setting it named before"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/.agents/skills/github/tests/git-https-auth.sh
+++ b/.agents/skills/github/tests/git-https-auth.sh
@@ -134,6 +134,20 @@ assert_not_contains "$disabled" "!gh auth git-credential" "fallback can be disab
 unauthenticated="$(STUB_GH_AUTH_OK=0 run_helper -C "$ssh_repo" config --get-all credential.helper || true)"
 assert_not_contains "$unauthenticated" "!gh auth git-credential" "invalid gh auth leaves SSH path unchanged"
 
+# A bound the runner cannot read is not an answer about auth: gh is never
+# asked, and this wrapper falls through to plain git with the rewrite it
+# exists for skipped. Driven with no env token, which is the ordinary
+# `gh auth login` shape and the one kendex_github_sanitize_gh_env returns from
+# before its own arm can speak — so if the probe does not say it here, the
+# rewrite goes missing on every stream with nothing said anywhere.
+bad_bound_err="$TMP_ROOT/bad-bound.err"
+bad_bound="$(GH_TOKEN= GITHUB_TOKEN= KENDEX_GITHUB_AUTH_TIMEOUT=2.55 \
+  run_helper -C "$ssh_repo" config --get-all credential.helper 2>"$bad_bound_err" || true)"
+assert_not_contains "$bad_bound" "!gh auth git-credential" \
+  "an unreadable auth bound leaves the SSH path unchanged"
+assert_contains "$(cat "$bad_bound_err")" "2.55" \
+  "and the skipped rewrite names the bound rather than passing in silence"
+
 explicit="$(
   source "$REPO_ROOT/skills/github/scripts/lib/gh-auth.sh"
   if kendex_github_git_should_use_https_fallback ls-remote git@github.com:owner/repo.git; then

--- a/.agents/skills/github/tests/pr-view.sh
+++ b/.agents/skills/github/tests/pr-view.sh
@@ -63,7 +63,7 @@ case "${1:-}" in
   auth)
     if [[ "${2:-}" == "status" ]]; then
       if [[ "${STUB_AUTH_SLEEP:-0}" == "1" ]]; then
-        sleep 5
+        sleep 2
       fi
       if [[ "${STUB_AUTH_STATUS_FAIL:-0}" == "1" ]]; then
         echo "keyring default failed" >&2
@@ -80,7 +80,7 @@ case "${1:-}" in
   api)
     if [[ "${2:-}" == "user" ]]; then
       if [[ "${STUB_API_USER_SLEEP:-0}" == "1" ]]; then
-        sleep 5
+        sleep 2
       fi
       _auth_ok || { echo "HTTP 401: Bad credentials" >&2; exit 1; }
       echo "test-user"
@@ -100,7 +100,7 @@ case "${1:-}" in
           exit 1
           ;;
         hang)
-          sleep 5
+          sleep 2
           ;;
         *)
           echo '{"number":42,"state":"OPEN"}'
@@ -121,7 +121,7 @@ set -euo pipefail
 printf 'op called: %s\n' "$*" >>"${STUB_OP_CALLS:?}"
 case "${STUB_OP_MODE:-fail}" in
   slow)
-    sleep 5
+    sleep 2
     ;;
   ok)
     echo "ghs_VALIDBOT123"
@@ -223,7 +223,7 @@ assert_contains "$(jq -r .detail <<<"$output")" "no pull requests found" "no PR 
 
 stderr="$TMP_ROOT/auth-timeout.err"
 set +e
-output=$(run_pr_view STUB_AUTH_SLEEP=1 KENDEX_GITHUB_AUTH_TIMEOUT=1 2>"$stderr")
+output=$(run_pr_view STUB_AUTH_SLEEP=1 KENDEX_GITHUB_AUTH_TIMEOUT=0.2 2>"$stderr")
 rc=$?
 set -e
 assert_eq "$rc" "124" "auth preflight timeout exits 124" "$stderr"
@@ -232,7 +232,7 @@ assert_eq "$(jq -r .status <<<"$output")" "auth_timeout" "auth timeout emits str
 stderr="$TMP_ROOT/auth-timeout-no-utility.err"
 set +e
 output=$(without_timeout_utility run_pr_view \
-  STUB_AUTH_SLEEP=1 KENDEX_GITHUB_AUTH_TIMEOUT=1 2>"$stderr")
+  STUB_AUTH_SLEEP=1 KENDEX_GITHUB_AUTH_TIMEOUT=0.2 2>"$stderr")
 rc=$?
 set -e
 assert_eq "$rc" "124" "auth timeout works without the timeout utility" "$stderr"
@@ -251,7 +251,7 @@ assert_eq "$(jq -r .number <<<"$output")" "42" \
 
 stderr="$TMP_ROOT/api-user-auth-timeout.err"
 set +e
-output=$(run_pr_view GH_TOKEN=ghs_VALIDBOT123 STUB_API_USER_SLEEP=1 KENDEX_GITHUB_AUTH_TIMEOUT=1 2>"$stderr")
+output=$(run_pr_view GH_TOKEN=ghs_VALIDBOT123 STUB_API_USER_SLEEP=1 KENDEX_GITHUB_AUTH_TIMEOUT=0.2 2>"$stderr")
 rc=$?
 set -e
 assert_eq "$rc" "124" "env-token auth preflight timeout exits 124" "$stderr"
@@ -267,7 +267,7 @@ assert_eq "$(jq -r .number <<<"$output")" "42" "valid selected token preserves g
 
 stderr="$TMP_ROOT/pr-view-timeout.err"
 set +e
-output=$(run_pr_view STUB_PR_MODE=hang KENDEX_GITHUB_PR_VIEW_TIMEOUT=1 2>"$stderr")
+output=$(run_pr_view STUB_PR_MODE=hang KENDEX_GITHUB_PR_VIEW_TIMEOUT=0.2 2>"$stderr")
 rc=$?
 set -e
 assert_eq "$rc" "124" "gh pr view timeout exits 124" "$stderr"
@@ -276,7 +276,7 @@ assert_eq "$(jq -r .status <<<"$output")" "gh_timeout" "gh timeout emits structu
 stderr="$TMP_ROOT/pr-view-timeout-no-utility.err"
 set +e
 output=$(without_timeout_utility run_pr_view \
-  STUB_PR_MODE=hang KENDEX_GITHUB_PR_VIEW_TIMEOUT=1 2>"$stderr")
+  STUB_PR_MODE=hang KENDEX_GITHUB_PR_VIEW_TIMEOUT=0.2 2>"$stderr")
 rc=$?
 set -e
 assert_eq "$rc" "124" "gh pr view timeout works without the timeout utility" "$stderr"
@@ -337,7 +337,7 @@ assert_eq "$(jq -r .status <<<"$output")" "token_resolution_failed" "token failu
 
 stderr="$TMP_ROOT/op-timeout.err"
 set +e
-output=$(run_pr_view STUB_AUTH_OK=0 STUB_OP_MODE=slow KENDEX_GITHUB_OP_TIMEOUT=1 2>"$stderr")
+output=$(run_pr_view STUB_AUTH_OK=0 STUB_OP_MODE=slow KENDEX_GITHUB_OP_TIMEOUT=0.2 2>"$stderr")
 rc=$?
 set -e
 assert_eq "$rc" "3" "token resolution timeout exits auth code" "$stderr"
@@ -346,7 +346,7 @@ assert_eq "$(jq -r .status <<<"$output")" "token_resolution_timeout" "token time
 stderr="$TMP_ROOT/op-timeout-no-utility.err"
 set +e
 output=$(without_timeout_utility run_pr_view \
-  STUB_AUTH_OK=0 STUB_OP_MODE=slow KENDEX_GITHUB_OP_TIMEOUT=1 2>"$stderr")
+  STUB_AUTH_OK=0 STUB_OP_MODE=slow KENDEX_GITHUB_OP_TIMEOUT=0.2 2>"$stderr")
 rc=$?
 set -e
 assert_eq "$rc" "3" "op timeout works without the timeout utility" "$stderr"

--- a/.agents/skills/github/tests/pr-view.sh
+++ b/.agents/skills/github/tests/pr-view.sh
@@ -293,6 +293,32 @@ assert_eq "$rc" "0" "gh timeout accepts a leading-zero decimal" "$stderr"
 assert_eq "$(jq -r .number <<<"$output")" "42" \
   "leading-zero gh bound returns PR JSON" "$stderr"
 
+# A bound outside the grammar the help advertises. The runner refuses it with
+# 125 having run nothing, so without a mapping here the caller reads a
+# configuration typo as a GitHub auth failure or as gh itself failing — the
+# one surface an operator debugging their own setting actually sees. Every
+# name the loop checks is driven, because a name dropped from it would fail
+# exactly this way again.
+for bound in KENDEX_GITHUB_AUTH_TIMEOUT KENDEX_GITHUB_OP_TIMEOUT \
+  KENDEX_GITHUB_PR_VIEW_TIMEOUT; do
+  stderr="$TMP_ROOT/bad-bound-$bound.err"
+  calls="$TMP_ROOT/bad-bound-$bound.calls"
+  : >"$calls"
+  set +e
+  output=$(run_pr_view "$bound=2.55" STUB_GH_CALLS="$calls" 2>"$stderr")
+  rc=$?
+  set -e
+  assert_eq "$rc" "2" "an unreadable $bound exits 2" "$stderr"
+  assert_eq "$(jq -r .status <<<"$output")" "bad_timeout" \
+    "an unreadable $bound emits the configuration status" "$stderr"
+  assert_contains "$(jq -r .error <<<"$output")" "$bound" \
+    "the refusal names $bound" "$stderr"
+  assert_eq "$(jq -r .detail <<<"$output")" "2.55" \
+    "the refusal carries the value it rejected for $bound" "$stderr"
+  assert_eq "$(wc -c <"$calls")" "0" \
+    "an unreadable $bound reaches no gh call" "$stderr"
+done
+
 rm -f "$TMP_ROOT/op.calls"
 stderr="$TMP_ROOT/inherited-gh-token-op.err"
 set +e

--- a/.agents/skills/growth-guards/tests/commit-msg.test.sh
+++ b/.agents/skills/growth-guards/tests/commit-msg.test.sh
@@ -28,10 +28,18 @@ git -C "$R" -c init.defaultBranch=main init -q
 git -C "$R" config user.email test@example.com
 git -C "$R" config user.name test
 
+# Most runs below settle a rule the script carries itself and configure it
+# through the environment, so they resolve no setting from a file — and the
+# sentinel spends none of the walk that would find nothing. The blocks that
+# do put a file in front of the script clear NO_SETTINGS around themselves;
+# a caller's own assignment comes last, so it still wins.
+NO_SETTINGS=1
+
 run_stdin() { # MESSAGE [env-assignment] — feed via stdin; sets OUT and RC
   OUT=""
   RC=0
-  OUT="$(cd "$R" && printf '%s\n' "$1" | env ${2:+"$2"} "$CM" 2>&1)" || RC=$?
+  OUT="$(cd "$R" && printf '%s\n' "$1" |
+    env ${NO_SETTINGS:+GROWTH_GUARDS_SETTINGS_FILE=/dev/null} ${2:+"$2"} "$CM" 2>&1)" || RC=$?
 }
 
 expect_pass() { # HEADER DESC [env]
@@ -97,6 +105,7 @@ run_stdin 'feat: x' "GROWTH_GUARDS_COMMIT_TYPES=Feat"
 run_stdin 'feat: x' "GROWTH_GUARDS_COMMIT_TYPES= "
 [ "$RC" -eq 2 ] && ok "an empty type list is exit 2" || bad "empty type list is exit 2" "rc=$RC out=$OUT"
 
+NO_SETTINGS=""
 echo "=== settings file resolution ==="
 printf '[env]\nGROWTH_GUARDS_COMMIT_TYPES = "docs"\n' >"$R/kendex.settings.toml"
 run_stdin 'docs: settings-admitted type'
@@ -128,6 +137,7 @@ run_stdin 'feat: base type' "GROWTH_GUARDS_SETTINGS_FILE=/dev/null"
 [ "$RC" -eq 0 ] && ok "the sentinel skips .env.local (read BEFORE the settings file) too" \
   || bad "sentinel skips .env.local" "rc=$RC out=$OUT"
 rm -f "$R/.env.local"
+NO_SETTINGS=1
 
 echo "=== a failing index probe never loosens the committed type list ==="
 # The hook lane resolves tracked settings from the INDEX so a commit is judged
@@ -266,7 +276,7 @@ run_stdin 'fix: x' "GROWTH_GUARDS_SUBJECT_MAX=0"
 # git hook inherits that environment, so a message measured in bytes is
 # accepted in one shell and refused in another.
 MULTI="fix(KEN-1): $(rep 'é' 55)" # 67 characters, 122 bytes
-for loc in C C.UTF-8 en_US.UTF-8; do
+for loc in C C.UTF-8; do
   run_stdin "$MULTI" "LC_ALL=$loc"
   [ "$RC" -eq 0 ] && ok "a 67-character multibyte header passes under $loc" \
     || bad "a 67-character multibyte header passes under $loc" "rc=$RC out=$OUT"
@@ -274,7 +284,7 @@ done
 # The control: one character more is over the cap in every one of them, so
 # the passes above are the count and not the rule declining to look.
 MULTI_OVER="fix(KEN-1): $(rep 'é' 61)" # 73 characters
-for loc in C C.UTF-8 en_US.UTF-8; do
+for loc in C C.UTF-8; do
   run_stdin "$MULTI_OVER" "LC_ALL=$loc"
   [ "$RC" -eq 1 ] && case "$OUT" in *"header is 73 characters (max 72)"*) true ;; *) false ;; esac \
     && ok "and 73 of them is 73 characters under $loc, not its byte count" \
@@ -286,7 +296,7 @@ done
 # here unless the match is pinned. These bytes sit in the scope, which is the
 # only part of the ERE a locale changes; the length fixtures above carry
 # theirs in the subject and reach none of it.
-for loc in C C.UTF-8 en_US.UTF-8; do
+for loc in C C.UTF-8; do
   run_stdin 'fix(café): tighten the gate' "LC_ALL=$loc"
   [ "$RC" -eq 1 ] && case "$OUT" in *"non-conventional header"*) true ;; *) false ;; esac \
     && ok "an accented scope is outside the documented class under $loc" \
@@ -298,7 +308,7 @@ done
 # And bytes that are not valid UTF-8 at all decide the same way everywhere:
 # the subject class is "not whitespace", which they are.
 BADBYTES="$(printf 'fix: \377\376 bad bytes')"
-for loc in C C.UTF-8 en_US.UTF-8; do
+for loc in C C.UTF-8; do
   run_stdin "$BADBYTES" "LC_ALL=$loc"
   [ "$RC" -eq 0 ] && ok "a subject carrying invalid UTF-8 is judged the same under $loc" \
     || bad "a subject carrying invalid UTF-8 is judged the same under $loc" "rc=$RC out=$OUT"

--- a/.agents/skills/growth-guards/tests/commit-msg.test.sh
+++ b/.agents/skills/growth-guards/tests/commit-msg.test.sh
@@ -292,10 +292,12 @@ for loc in C C.UTF-8; do
 done
 # The SHAPE rule answers under the same rules. Its scope class is ASCII in
 # every surface that documents it, and a bracket range is a COLLATION range
-# under a UTF-8 locale — so an accented scope is admitted there and refused
-# here unless the match is pinned. These bytes sit in the scope, which is the
-# only part of the ERE a locale changes; the length fixtures above carry
-# theirs in the subject and reach none of it.
+# under a UTF-8 locale, which is the one thing that could admit an accented
+# scope. C and C.UTF-8 are what the hosts this suite runs on carry, so what
+# these arms prove is that the verdict does not vary across them — not that
+# collation cannot bite on some other glibc or grep. These bytes sit in the
+# scope, which is the only part of the ERE a locale changes; the length
+# fixtures above carry theirs in the subject and reach none of it.
 for loc in C C.UTF-8; do
   run_stdin 'fix(café): tighten the gate' "LC_ALL=$loc"
   [ "$RC" -eq 1 ] && case "$OUT" in *"non-conventional header"*) true ;; *) false ;; esac \

--- a/.agents/skills/growth-guards/tests/install-git-hooks-scope.test.sh
+++ b/.agents/skills/growth-guards/tests/install-git-hooks-scope.test.sh
@@ -11,6 +11,12 @@ TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/install-hooks.bash
 . "$TEST_DIR/lib/install-hooks.bash"
 
+# The subject is which scripts the shim reaches and which lanes run beside
+# them, never the composition of the batch itself — size-ratchet and preflight
+# are chain lanes, not members of it. So the batch runs one check, and each
+# check keeps its own suite.
+export GROWTH_GUARDS_CHECKS=todo-ban
+
 echo "=== a copy-method install is rediscovered ==="
 R19="$(new_repo copymethod)"
 install_in "$R19"

--- a/.agents/skills/growth-guards/tests/install-git-hooks.test.sh
+++ b/.agents/skills/growth-guards/tests/install-git-hooks.test.sh
@@ -176,6 +176,13 @@ case "$OUT" in
   *) bad "blocked commit names the blob" "out=$OUT" ;;
 esac
 
+# Everything from here down is hook PLUMBING: what the shims delegate to, what
+# survives an install, what an uninstall gives back. The batch's composition is
+# not the subject and each check has its own suite, so the chain runs one of
+# them — the same commits, a sixth of the work. The blocks above keep the full
+# batch: they are the ones that judge what the chain reads and what it runs.
+export GROWTH_GUARDS_CHECKS=todo-ban
+
 echo "=== the repo-local entry runs last and blocks ==="
 mkdir -p "$R/tools"
 printf '#!/bin/sh\necho "repo-local check ran"\nexit 0\n' >"$R/tools/local-check"
@@ -450,7 +457,6 @@ install_in "$R10"
 BEFORE_HELPER="$(cat "$R10/.git/hooks/kendex-guards")"
 BEFORE_PRE="$(cat "$R10/.git/hooks/pre-commit")"
 BEFORE_MSG="$(cat "$R10/.git/hooks/commit-msg")"
-install_in "$R10"
 install_in "$R10"
 [ "$RC" -eq 0 ] && ok "a repeat install exits 0" || bad "repeat install exits 0" "rc=$RC out=$OUT"
 [ "$BEFORE_HELPER" = "$(cat "$R10/.git/hooks/kendex-guards")" ] && ok "the helper is unchanged" || bad "helper unchanged"

--- a/.agents/skills/growth-guards/tests/lib/install-hooks.bash
+++ b/.agents/skills/growth-guards/tests/lib/install-hooks.bash
@@ -9,7 +9,10 @@
 
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 INSTALL="$SKILL_DIR/scripts/install-git-hooks"
-GG_SKILL_TEMPLATE="$TMP/gg-skill-template"
+# Outside the namespace new_repo allocates fixtures from: a fixture named for
+# the template would satisfy the build guard below and be copied into the skill
+# slot as a git repository, with nothing checking the shape.
+GG_SKILL_TEMPLATE="$TMP/.templates/growth-guards"
 
 unset GROWTH_GUARDS_CHECKS GROWTH_GUARDS_PRE_COMMIT_LOCAL GROWTH_GUARDS_SETTINGS_FILE \
   GROWTH_GUARDS_COMMIT_TYPES SIZE_RATCHET_THRESHOLD 2>/dev/null || true
@@ -40,6 +43,7 @@ new_repo() { # NAME -> repo path on stdout
   # that subtree is more than half the skill and nothing a consumer install
   # reaches, and these suites build dozens of fixtures.
   if [ ! -d "$GG_SKILL_TEMPLATE" ]; then
+    mkdir -p "$(dirname "$GG_SKILL_TEMPLATE")"
     cp -R "$SKILL_DIR" "$GG_SKILL_TEMPLATE"
     rm -rf -- "${GG_SKILL_TEMPLATE:?}/tests"
   fi

--- a/.agents/skills/growth-guards/tests/lib/install-hooks.bash
+++ b/.agents/skills/growth-guards/tests/lib/install-hooks.bash
@@ -9,6 +9,7 @@
 
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 INSTALL="$SKILL_DIR/scripts/install-git-hooks"
+GG_SKILL_TEMPLATE="$TMP/gg-skill-template"
 
 unset GROWTH_GUARDS_CHECKS GROWTH_GUARDS_PRE_COMMIT_LOCAL GROWTH_GUARDS_SETTINGS_FILE \
   GROWTH_GUARDS_COMMIT_TYPES SIZE_RATCHET_THRESHOLD 2>/dev/null || true
@@ -34,7 +35,15 @@ new_repo() { # NAME -> repo path on stdout
   git -C "$r" config user.name test
   # A real directory, the shape a project install has: path resolution and
   # the shared-worktree check both key on where the copy physically is.
-  cp -R "$SKILL_DIR" "$r/.agents/skills/growth-guards"
+  #
+  # The copy is cloned from a template built once per suite, with tests/ cut:
+  # that subtree is more than half the skill and nothing a consumer install
+  # reaches, and these suites build dozens of fixtures.
+  if [ ! -d "$GG_SKILL_TEMPLATE" ]; then
+    cp -R "$SKILL_DIR" "$GG_SKILL_TEMPLATE"
+    rm -rf -- "${GG_SKILL_TEMPLATE:?}/tests"
+  fi
+  cp -R "$GG_SKILL_TEMPLATE" "$r/.agents/skills/growth-guards"
   ln -s "$SKILL_DIR/../size-ratchet" "$r/.agents/skills/size-ratchet"
   printf '%s' "$r"
 }

--- a/.agents/skills/linear/SKILL.md
+++ b/.agents/skills/linear/SKILL.md
@@ -81,6 +81,7 @@ In a linked worktree whose `.cache` should be a `WORKTREE_SYMLINKS`-managed syml
 | `LINEAR_TEAM_PREFIX` | Issue identifier prefix | `PROJ` |
 | `LINEAR_AGENT_LABELS` | Declared `agent:*` taxonomy; non-empty makes `issues create` refuse unrouted creates | none (unset = off) |
 | `LINEAR_REQUIRE_REACH` | Non-empty makes `issues create` refuse a body with no `Reached by:` line | none (unset = off) |
+| `LINEAR_RETRY_BASE_DELAY` | Seconds before the first retry of a rate-limited or failed GraphQL call, doubling per attempt | `1` |
 
 `LINEAR_API_KEY` belongs in `.env.local`; non-secret defaults in committed `kendex.settings.toml` `[env]`. A key from project files beats one inherited from the environment, and `auth-check` warns (fingerprints only) when it shadows a differing inherited key.
 

--- a/.agents/skills/linear/kendex.settings.toml.example
+++ b/.agents/skills/linear/kendex.settings.toml.example
@@ -28,3 +28,8 @@ LINEAR_REQUIRE_REACH = ""
 
 # Default output format for read commands: safe, table, ids, raw.
 LINEAR_FORMAT = "safe"
+
+# Seconds before the first retry of a rate-limited or failed GraphQL call,
+# doubling on each further attempt. A whole number of seconds; 0 retries
+# without waiting at all.
+LINEAR_RETRY_BASE_DELAY = "1"

--- a/.agents/skills/linear/scripts/lib/common.sh
+++ b/.agents/skills/linear/scripts/lib/common.sh
@@ -11,18 +11,6 @@ LINEAR_API="https://api.linear.app/graphql"
 LINEAR_LIMIT_SHORT_DESC=255    # Initiatives, projects, milestones, labels
 LINEAR_LIMIT_ISSUE_DESC=100000 # Issues have no practical limit
 
-# Seconds before the first retry of a rate-limited or failed GraphQL call;
-# each further attempt doubles it. Overridable so a suite driving the retry
-# path against a stubbed curl does not spend the real backoff — the wait is
-# for Linear's benefit, and there is no Linear on the other end of a stub.
-LINEAR_RETRY_BASE_DELAY="${LINEAR_RETRY_BASE_DELAY:-1}"
-case "$LINEAR_RETRY_BASE_DELAY" in
-*[!0-9]* | "")
-    echo '{"error": "LINEAR_RETRY_BASE_DELAY must be a whole number of seconds"}' >&2
-    exit 1
-    ;;
-esac
-
 # Internal lib directory (underscore prefix avoids overwriting caller's SCRIPT_DIR)
 _LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -76,6 +64,24 @@ _CALLER_LINEAR_TEAM="${LINEAR_TEAM:-}"
 # shellcheck source=kendex-env.sh
 source "$_LIB_DIR/kendex-env.sh"
 kendex_load_project_env "$PROJECT_ROOT"
+
+# Seconds before the first retry of a rate-limited or failed GraphQL call;
+# each further attempt doubles it. Overridable so a suite driving the retry
+# path against a stubbed curl does not spend the real backoff — the wait is
+# for Linear's benefit, and there is no Linear on the other end of a stub.
+#
+# Below the project load, where every LINEAR_* value resolves:
+# kendex_load_project_env snapshots only EXPORTED names, so a default assigned
+# above it is a plain variable the settings files overwrite unvalidated. Base
+# ten at the seed, so a leading zero is decimal and not the octal 08 rejects.
+LINEAR_RETRY_BASE_DELAY="${LINEAR_RETRY_BASE_DELAY:-1}"
+case "$LINEAR_RETRY_BASE_DELAY" in
+*[!0-9]* | "")
+    echo '{"error": "LINEAR_RETRY_BASE_DELAY must be a whole number of seconds"}' >&2
+    exit 1
+    ;;
+esac
+LINEAR_RETRY_BASE_DELAY=$((10#$LINEAR_RETRY_BASE_DELAY))
 
 # Where each target-selecting value came from: override (LINEAR_API_KEY_OVERRIDE),
 # project-config (kendex.settings.toml / .env.local), environment (process

--- a/.agents/skills/linear/scripts/lib/common.sh
+++ b/.agents/skills/linear/scripts/lib/common.sh
@@ -74,13 +74,13 @@ kendex_load_project_env "$PROJECT_ROOT"
 # kendex_load_project_env snapshots only EXPORTED names, so a default assigned
 # above it is a plain variable the settings files overwrite unvalidated. Base
 # ten at the seed, so a leading zero is decimal and not the octal 08 rejects.
+# Bounded on width too, and 18 digits survives all three doublings: past that
+# the arithmetic wraps and the backoff is a negative sleep, not a refusal.
 LINEAR_RETRY_BASE_DELAY="${LINEAR_RETRY_BASE_DELAY:-1}"
-case "$LINEAR_RETRY_BASE_DELAY" in
-*[!0-9]* | "")
+if ! [[ "$LINEAR_RETRY_BASE_DELAY" =~ ^[0-9]{1,18}$ ]]; then
     echo '{"error": "LINEAR_RETRY_BASE_DELAY must be a whole number of seconds"}' >&2
     exit 1
-    ;;
-esac
+fi
 LINEAR_RETRY_BASE_DELAY=$((10#$LINEAR_RETRY_BASE_DELAY))
 
 # Where each target-selecting value came from: override (LINEAR_API_KEY_OVERRIDE),

--- a/.agents/skills/linear/scripts/lib/common.sh
+++ b/.agents/skills/linear/scripts/lib/common.sh
@@ -11,6 +11,18 @@ LINEAR_API="https://api.linear.app/graphql"
 LINEAR_LIMIT_SHORT_DESC=255    # Initiatives, projects, milestones, labels
 LINEAR_LIMIT_ISSUE_DESC=100000 # Issues have no practical limit
 
+# Seconds before the first retry of a rate-limited or failed GraphQL call;
+# each further attempt doubles it. Overridable so a suite driving the retry
+# path against a stubbed curl does not spend the real backoff — the wait is
+# for Linear's benefit, and there is no Linear on the other end of a stub.
+LINEAR_RETRY_BASE_DELAY="${LINEAR_RETRY_BASE_DELAY:-1}"
+case "$LINEAR_RETRY_BASE_DELAY" in
+*[!0-9]* | "")
+    echo '{"error": "LINEAR_RETRY_BASE_DELAY must be a whole number of seconds"}' >&2
+    exit 1
+    ;;
+esac
+
 # Internal lib directory (underscore prefix avoids overwriting caller's SCRIPT_DIR)
 _LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -232,7 +244,7 @@ graphql_query() {
         variables='{}'
     fi
     local max_retries=3
-    local retry_delay=1
+    local retry_delay="$LINEAR_RETRY_BASE_DELAY"
     local attempt=1
 
     # Single choke point for writes: no mutation leaves this process without a

--- a/.agents/skills/linear/tests/must-fail-controls.sh
+++ b/.agents/skills/linear/tests/must-fail-controls.sh
@@ -18,6 +18,10 @@ SKILL_DIR="$(cd "$TESTS_DIR/.." && pwd)"
 CONTROLS_DIR="$TESTS_DIR/controls"
 SUITE_TIMEOUT="${CONTROL_TIMEOUT:-60}"
 
+# Controls run concurrently: each one mutates its own copy of the skill and
+# runs the suite out of that copy, so no two of them share anything writable.
+CONTROL_JOBS="${CONTROL_JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)}"
+
 WORK="$(mktemp -d)"
 trap 'rm -rf -- "${WORK:?}"' EXIT
 
@@ -31,6 +35,10 @@ die() {
 	printf 'must-fail-controls: %s\n' "$*" >&2
 	exit 2
 }
+
+# A junk width would otherwise launch every control at once, or none.
+[[ "$CONTROL_JOBS" =~ ^[1-9][0-9]*$ ]] ||
+	die "CONTROL_JOBS must be a positive integer, got: $CONTROL_JOBS"
 
 control_die() {
 	printf 'control %s: %s\n' "$CONTROL_NAME" "$*" >&2
@@ -83,6 +91,20 @@ control_write() {
 }
 
 # --- runner -----------------------------------------------------------------
+
+PIDS=()
+FAILURES=0
+
+# Wait out the launched batch, scoring one failure per control that reported
+# one. `wait -n` would keep the pipe full, but these suites must start under
+# the Bash 3.2 in /bin on macOS, which does not have it.
+reap() {
+	local pid
+	for pid in ${PIDS[@]+"${PIDS[@]}"}; do
+		wait "$pid" || FAILURES=$((FAILURES + 1))
+	done
+	PIDS=()
+}
 
 run_one() {
 	local suite="$1" stem="$2"
@@ -155,8 +177,8 @@ run_one() {
 }
 
 main() {
-	local -a wanted=("$@") stems=()
-	local suite_path control_path suite stem want failures=0 total=0 orphans=0
+	local -a wanted=("$@") stems=() ran=()
+	local suite_path control_path suite stem want total=0 orphans=0
 
 	for suite_path in "$TESTS_DIR"/*.test.sh; do
 		stems+=("$(basename "$suite_path" .test.sh)")
@@ -189,14 +211,24 @@ main() {
 			continue
 		fi
 		total=$((total + 1))
-		run_one "$suite" "$stem" || failures=$((failures + 1))
+		ran+=("$stem")
+		run_one "$suite" "$stem" >"$WORK/$stem.log" 2>&1 &
+		PIDS+=("$!")
+		[[ ${#PIDS[@]} -lt "$CONTROL_JOBS" ]] || reap
 	done
+	reap
 
 	[[ "$total" -gt 0 ]] || die "selection matched no suites"
 
+	# Roster order, not finish order: the report reads the same whatever the
+	# machine's width.
+	for stem in "${ran[@]}"; do
+		cat "$WORK/$stem.log"
+	done
+
 	printf '\n%d controls, %d failing, %d orphaned\n' \
-		"$total" "$failures" "$orphans"
-	[[ "$failures" -eq 0 && "$orphans" -eq 0 ]]
+		"$total" "$FAILURES" "$orphans"
+	[[ "$FAILURES" -eq 0 && "$orphans" -eq 0 ]]
 }
 
 main "$@"

--- a/.agents/skills/linear/tests/must-fail-controls.sh
+++ b/.agents/skills/linear/tests/must-fail-controls.sh
@@ -31,7 +31,10 @@ trap 'rm -rf -- "${WORK:?}"' EXIT
 # so Ctrl-C never reaches them on its own; TERM does. The `timeout` child each
 # control spawned is a grandchild this does not reach; it retires itself
 # within SUITE_TIMEOUT.
-trap 'kill -TERM ${PIDS[@]+"${PIDS[@]}"} 2>/dev/null; exit 130' INT TERM
+# One trap each, so the code a wrapper reads says which signal arrived: an
+# interrupt and a kill are the same cleanup but not the same event.
+trap 'kill -TERM ${PIDS[@]+"${PIDS[@]}"} 2>/dev/null; exit 130' INT
+trap 'kill -TERM ${PIDS[@]+"${PIDS[@]}"} 2>/dev/null; exit 143' TERM
 
 # --- control vocabulary -----------------------------------------------------
 # A control script runs with CONTROL_ROOT pointing at its own copy of the

--- a/.agents/skills/linear/tests/must-fail-controls.sh
+++ b/.agents/skills/linear/tests/must-fail-controls.sh
@@ -24,11 +24,13 @@ CONTROL_JOBS="${CONTROL_JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)
 
 WORK="$(mktemp -d)"
 trap 'rm -rf -- "${WORK:?}"' EXIT
-# An interrupted run takes its controls with it. Only the pids this script
-# recorded when it launched them: every lane on this machine runs these same
-# suites out of its own worktree, so an argv match would reach theirs too.
-# Bash ignores INT in the async children of a shell without job control, so
-# Ctrl-C never reaches them on its own; TERM does.
+# An interrupted run signals the control jobs it launched, and only the pids
+# it recorded when it launched them: every lane on this machine runs these
+# same suites out of its own worktree, so an argv match would reach theirs
+# too. Bash ignores INT in the async children of a shell without job control,
+# so Ctrl-C never reaches them on its own; TERM does. The `timeout` child each
+# control spawned is a grandchild this does not reach; it retires itself
+# within SUITE_TIMEOUT.
 trap 'kill -TERM ${PIDS[@]+"${PIDS[@]}"} 2>/dev/null; exit 130' INT TERM
 
 # --- control vocabulary -----------------------------------------------------
@@ -42,7 +44,9 @@ die() {
 	exit 2
 }
 
-# A junk width would otherwise launch every control at once, or none.
+# A junk width otherwise reaches the batching predicate, where Bash 4.4 and
+# newer abort on the unbound name mid-roster and 4.0 through 4.2 read it as 0
+# and run every control one at a time.
 [[ "$CONTROL_JOBS" =~ ^[1-9][0-9]*$ ]] ||
 	die "CONTROL_JOBS must be a positive integer, got: $CONTROL_JOBS"
 

--- a/.agents/skills/linear/tests/must-fail-controls.sh
+++ b/.agents/skills/linear/tests/must-fail-controls.sh
@@ -46,8 +46,11 @@ die() {
 
 # A junk width otherwise reaches the batching predicate, where Bash 4.4 and
 # newer abort on the unbound name mid-roster and 4.0 through 4.2 read it as 0
-# and run every control one at a time.
-[[ "$CONTROL_JOBS" =~ ^[1-9][0-9]*$ ]] ||
+# and run every control one at a time. The digit count is part of the grammar:
+# 19 digits or more is past what signed 64-bit shell arithmetic holds, and the
+# predicate compares against the wrap, which reaps every iteration when it
+# lands at or below zero.
+[[ "$CONTROL_JOBS" =~ ^[1-9][0-9]{0,17}$ ]] ||
 	die "CONTROL_JOBS must be a positive integer, got: $CONTROL_JOBS"
 
 control_die() {

--- a/.agents/skills/linear/tests/must-fail-controls.sh
+++ b/.agents/skills/linear/tests/must-fail-controls.sh
@@ -24,6 +24,12 @@ CONTROL_JOBS="${CONTROL_JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)
 
 WORK="$(mktemp -d)"
 trap 'rm -rf -- "${WORK:?}"' EXIT
+# An interrupted run takes its controls with it. Only the pids this script
+# recorded when it launched them: every lane on this machine runs these same
+# suites out of its own worktree, so an argv match would reach theirs too.
+# Bash ignores INT in the async children of a shell without job control, so
+# Ctrl-C never reaches them on its own; TERM does.
+trap 'kill -TERM ${PIDS[@]+"${PIDS[@]}"} 2>/dev/null; exit 130' INT TERM
 
 # --- control vocabulary -----------------------------------------------------
 # A control script runs with CONTROL_ROOT pointing at its own copy of the
@@ -93,17 +99,28 @@ control_write() {
 # --- runner -----------------------------------------------------------------
 
 PIDS=()
+BATCH=()
 FAILURES=0
 
-# Wait out the launched batch, scoring one failure per control that reported
-# one. `wait -n` would keep the pipe full, but these suites must start under
-# the Bash 3.2 in /bin on macOS, which does not have it.
+# Wait out the launched batch, score one failure per control that reported
+# one, then print what that batch found. `wait -n` would keep the pipe full
+# instead of draining it in batches, but this skill supports Bash 4.0 and
+# newer (README § Setup) and `wait -n` arrived in 4.3.
+#
+# Printing here rather than after the last batch is what a run killed by CI,
+# a wrapper timeout or Ctrl-C leaves behind: the verdicts already reached.
+# A batch's pids are in roster order and the batches are too, so incremental
+# output is the same order the whole run would have printed.
 reap() {
-	local pid
+	local pid stem
 	for pid in ${PIDS[@]+"${PIDS[@]}"}; do
 		wait "$pid" || FAILURES=$((FAILURES + 1))
 	done
+	for stem in ${BATCH[@]+"${BATCH[@]}"}; do
+		cat "$WORK/$stem.log"
+	done
 	PIDS=()
+	BATCH=()
 }
 
 run_one() {
@@ -177,7 +194,7 @@ run_one() {
 }
 
 main() {
-	local -a wanted=("$@") stems=() ran=()
+	local -a wanted=("$@") stems=()
 	local suite_path control_path suite stem want total=0 orphans=0
 
 	for suite_path in "$TESTS_DIR"/*.test.sh; do
@@ -211,20 +228,14 @@ main() {
 			continue
 		fi
 		total=$((total + 1))
-		ran+=("$stem")
 		run_one "$suite" "$stem" >"$WORK/$stem.log" 2>&1 &
 		PIDS+=("$!")
+		BATCH+=("$stem")
 		[[ ${#PIDS[@]} -lt "$CONTROL_JOBS" ]] || reap
 	done
 	reap
 
 	[[ "$total" -gt 0 ]] || die "selection matched no suites"
-
-	# Roster order, not finish order: the report reads the same whatever the
-	# machine's width.
-	for stem in "${ran[@]}"; do
-		cat "$WORK/$stem.log"
-	done
 
 	printf '\n%d controls, %d failing, %d orphaned\n' \
 		"$total" "$FAILURES" "$orphans"

--- a/.agents/skills/linear/tests/rate-limited-http-400.test.sh
+++ b/.agents/skills/linear/tests/rate-limited-http-400.test.sh
@@ -48,8 +48,11 @@ GENERIC_BODY='{"errors":[{"message":"Argument Validation Error","extensions":{"c
 # assertion made inside would be recorded where the suite cannot see it.
 run_linear() { # root, args...
   local root="$1"; shift
+  # No backoff: every response here comes from the curl stub two lines up, so
+  # the retry wait would be spent on nothing.
   (cd "$root" && env PATH="$root/bin:$PATH" \
     LINEAR_API_KEY_OVERRIDE="lin_api_test" LINEAR_TEAM="Claude" \
+    LINEAR_RETRY_BASE_DELAY=0 \
     "$root/.agents/skills/linear/scripts/linear.sh" "$@" 2>&1)
 }
 
@@ -63,7 +66,8 @@ assert_contains "rate-limited 400 reports the rate limit" "$out" "Rate limited. 
 assert_not_contains "rate-limited 400 is not a generic HTTP error" "$out" "HTTP error: 400"
 echo "=== failed team lookup propagates the API failure ==="
 unit_rc=0
-unit="$(cd "$TMP_BASE/rl" && env PATH="$TMP_BASE/rl/bin:$PATH" bash -c '
+unit="$(cd "$TMP_BASE/rl" && env PATH="$TMP_BASE/rl/bin:$PATH" \
+  LINEAR_RETRY_BASE_DELAY=0 bash -c '
   set -u
   LINEAR_API="https://api.linear.app/graphql"
   LINEAR_API_KEY="lin_api_test"
@@ -82,3 +86,35 @@ out="$(run_linear "$TMP_BASE/gen" statuses list)" || gen_rc=$?
 
 assert_ne "a generic non-200 fails the call" "$gen_rc" 0
 assert_contains "generic 400 includes the body message" "$out" "HTTP error: 400: Argument Validation Error"
+
+echo "=== the retry backoff is overridable ==="
+# What the retry actually waited is read off a sleep stub, not off the clock:
+# a wall-time assertion would pass on a slow host that never honoured the
+# override. Every arm below runs against the same stubbed curl, so the only
+# variable is the delay the library asks for.
+cat >"$TMP_BASE/rl/bin/sleep" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$1" >>"$TMP_BASE/rl/slept"
+SH
+chmod +x "$TMP_BASE/rl/bin/sleep"
+
+: >"$TMP_BASE/rl/slept"
+run_linear "$TMP_BASE/rl" statuses list >/dev/null 2>&1 || true
+assert_eq "an overridden base delay is what the retry sleeps" \
+  "$(tr '\n' ' ' <"$TMP_BASE/rl/slept")" "0 0 "
+
+: >"$TMP_BASE/rl/slept"
+(cd "$TMP_BASE/rl" && env PATH="$TMP_BASE/rl/bin:$PATH" \
+  LINEAR_API_KEY_OVERRIDE="lin_api_test" LINEAR_TEAM="Claude" \
+  "$TMP_BASE/rl/.agents/skills/linear/scripts/linear.sh" statuses list) >/dev/null 2>&1 || true
+assert_eq "the default backoff still doubles from one second" \
+  "$(tr '\n' ' ' <"$TMP_BASE/rl/slept")" "1 2 "
+
+junk_rc=0
+junk="$(cd "$TMP_BASE/rl" && env PATH="$TMP_BASE/rl/bin:$PATH" \
+  LINEAR_API_KEY_OVERRIDE="lin_api_test" LINEAR_TEAM="Claude" \
+  LINEAR_RETRY_BASE_DELAY="soon" \
+  "$TMP_BASE/rl/.agents/skills/linear/scripts/linear.sh" statuses list 2>&1)" || junk_rc=$?
+assert_ne "a non-numeric base delay fails the call" "$junk_rc" 0
+assert_contains "a non-numeric base delay names the setting" \
+  "$junk" "LINEAR_RETRY_BASE_DELAY must be a whole number of seconds"

--- a/.agents/skills/linear/tests/rate-limited-http-400.test.sh
+++ b/.agents/skills/linear/tests/rate-limited-http-400.test.sh
@@ -118,3 +118,33 @@ junk="$(cd "$TMP_BASE/rl" && env PATH="$TMP_BASE/rl/bin:$PATH" \
 assert_ne "a non-numeric base delay fails the call" "$junk_rc" 0
 assert_contains "a non-numeric base delay names the setting" \
   "$junk" "LINEAR_RETRY_BASE_DELAY must be a whole number of seconds"
+
+# The process environment is not the only way this value arrives: SKILL.md
+# points non-secret defaults at the project's committed settings, and every
+# other LINEAR_* key resolves from there. A guard the settings file can walk
+# past is no guard — the bad value reaches `sleep` and the run dies mid-flight,
+# after the request has already gone out.
+printf '[env]\nLINEAR_RETRY_BASE_DELAY = "soon"\n' >"$TMP_BASE/rl/kendex.settings.toml"
+settings_rc=0
+settings_out="$(cd "$TMP_BASE/rl" && env PATH="$TMP_BASE/rl/bin:$PATH" \
+  LINEAR_API_KEY_OVERRIDE="lin_api_test" LINEAR_TEAM="Claude" \
+  "$TMP_BASE/rl/.agents/skills/linear/scripts/linear.sh" statuses list 2>&1)" || settings_rc=$?
+assert_ne "a non-numeric base delay in kendex.settings.toml fails the call" "$settings_rc" 0
+assert_contains "a settings-file base delay reaches the same named refusal" \
+  "$settings_out" "LINEAR_RETRY_BASE_DELAY must be a whole number of seconds"
+rm -f "$TMP_BASE/rl/kendex.settings.toml"
+
+# A leading zero is a decimal figure. Read in the shell's default base it is
+# octal, and 08 is not a number at all: the run would die on an arithmetic
+# error where the caller expects the structured rate-limit answer.
+: >"$TMP_BASE/rl/slept"
+zero_out="$(cd "$TMP_BASE/rl" && env PATH="$TMP_BASE/rl/bin:$PATH" \
+  LINEAR_API_KEY_OVERRIDE="lin_api_test" LINEAR_TEAM="Claude" \
+  LINEAR_RETRY_BASE_DELAY=08 \
+  "$TMP_BASE/rl/.agents/skills/linear/scripts/linear.sh" statuses list 2>&1)" || true
+assert_eq "a leading-zero base delay is read in base ten" \
+  "$(tr '\n' ' ' <"$TMP_BASE/rl/slept")" "8 16 "
+assert_contains "a leading-zero base delay still answers with the rate limit" \
+  "$zero_out" "Rate limited. Try again later."
+assert_not_contains "a leading-zero base delay is never an arithmetic error" \
+  "$zero_out" "value too great for base"

--- a/.agents/skills/linear/tests/rate-limited-http-400.test.sh
+++ b/.agents/skills/linear/tests/rate-limited-http-400.test.sh
@@ -119,6 +119,18 @@ assert_ne "a non-numeric base delay fails the call" "$junk_rc" 0
 assert_contains "a non-numeric base delay names the setting" \
   "$junk" "LINEAR_RETRY_BASE_DELAY must be a whole number of seconds"
 
+# Width is part of the grammar too: 19 digits is outside signed 64-bit
+# arithmetic, and the wrap is a negative backoff `sleep` refuses once the
+# request has already gone out.
+wide_rc=0
+wide="$(cd "$TMP_BASE/rl" && env PATH="$TMP_BASE/rl/bin:$PATH" \
+  LINEAR_API_KEY_OVERRIDE="lin_api_test" LINEAR_TEAM="Claude" \
+  LINEAR_RETRY_BASE_DELAY=9999999999999999999 \
+  "$TMP_BASE/rl/.agents/skills/linear/scripts/linear.sh" statuses list 2>&1)" || wide_rc=$?
+assert_ne "a base delay too wide for the arithmetic fails the call" "$wide_rc" 0
+assert_contains "an over-wide base delay names the setting" \
+  "$wide" "LINEAR_RETRY_BASE_DELAY must be a whole number of seconds"
+
 # The process environment is not the only way this value arrives: SKILL.md
 # points non-secret defaults at the project's committed settings, and every
 # other LINEAR_* key resolves from there. A guard the settings file can walk

--- a/.agents/skills/linear/tests/roster-orphan.test.sh
+++ b/.agents/skills/linear/tests/roster-orphan.test.sh
@@ -122,9 +122,12 @@ assert_file_contains "the failing control is counted, not just printed" \
     "$TMP/green.log" "1 controls, 1 failing, 0 orphaned"
 
 # --- a junk job width is refused ------------------------------------------
-# Not clamped and not defaulted: a width the runner cannot read would either
-# launch every control at once or launch none, and a run that launched none
-# reports "0 failing" like a clean one.
+# Not clamped and not defaulted. Left to reach the batching predicate, a width
+# outside the grammar decides two ways and neither is the one the caller asked
+# for: on Bash 4.4 and newer arithmetic honours set -u, so the unbound name
+# aborts the run with controls already launched, and on 4.0 through 4.2 the
+# same name reads as 0, the batch collapses to one, and the whole roster runs
+# serially.
 jobs_log="$TMP/jobs.log"
 CONTROL_JOBS=some bash "$matched/tests/must-fail-controls.sh" >"$jobs_log" 2>&1
 rc=$?

--- a/.agents/skills/linear/tests/roster-orphan.test.sh
+++ b/.agents/skills/linear/tests/roster-orphan.test.sh
@@ -1,17 +1,22 @@
 #!/usr/bin/env bash
-# The roster contract of tests/must-fail-controls.sh, both directions, driven
-# against a synthetic one-suite skill rather than this one.
+# The verdict contract of tests/must-fail-controls.sh, driven against a
+# synthetic one-suite skill rather than this one.
 #
-# Why a fixture and not this skill's own roster: that roster is matched, so
-# the orphan branch is never taken by a run over skills/linear and deleting it
-# would leave every committed suite green. The fixture is the only place the
-# condition is constructible.
+# Why a fixture and not this skill's own roster: that roster is matched and
+# every one of its controls works, so neither the orphan branch nor the
+# failing-control branch is ever taken by a run over skills/linear, and
+# deleting either would leave every committed suite green. The fixture is the
+# only place those conditions are constructible.
 #
 #   - a matched suite/control pair exits 0 and prints no ORPHAN line, so a
 #     case here cannot pass by always reporting a failure
 #   - a control no suite owns exits non-zero and the diagnostic names it
 #   - a targeted single-stem run reads the roster too: a selection cannot
 #     hide an orphan
+#   - a control that does not red its suite is counted and fails the run,
+#     which is the whole regime: without it the 50 controls over this skill
+#     could all rot and the runner would still exit 0
+#   - a junk job width is refused rather than run at some silent default
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -92,3 +97,38 @@ assert_file_contains "the targeted run names the orphaned control" \
     "$TMP/orphan-one.log" "ORPHAN   controls/ghost.control.sh"
 assert_file_contains "the targeted run counts the orphan" \
     "$TMP/orphan-one.log" "1 controls, 0 failing, 1 orphaned"
+
+# --- a control that does not red its suite is a failure --------------------
+# The runner judges each control in a background job and turns its status into
+# the verdict when that batch is reaped. Nothing above reaches that path: every
+# control there works, so the count is always "0 failing" and the line could be
+# deleted with all of it still green. Here the mutation lands (the tree really
+# changes, so it is not NOOP) on a file the suite never reads, which leaves the
+# suite passing over its own broken subject — GREEN, the case the whole regime
+# exists to catch.
+green="$TMP/green"
+fixture "$green"
+printf 'INERT=1\n' >"$green/scripts/inert.sh"
+cat >"$green/tests/controls/alpha.control.sh" <<'CONTROL'
+control_expect "the value is green"
+control_replace scripts/inert.sh 1 'INERT=1' 'INERT=2'
+CONTROL
+
+rc="$(run_roster "$TMP/green.log" "$green")"
+assert_ne "a control that leaves its suite passing fails the run" "$rc" 0
+assert_file_contains "the diagnostic names the suite that stayed green" \
+    "$TMP/green.log" "GREEN    alpha.test.sh"
+assert_file_contains "the failing control is counted, not just printed" \
+    "$TMP/green.log" "1 controls, 1 failing, 0 orphaned"
+
+# --- a junk job width is refused ------------------------------------------
+# Not clamped and not defaulted: a width the runner cannot read would either
+# launch every control at once or launch none, and a run that launched none
+# reports "0 failing" like a clean one.
+jobs_log="$TMP/jobs.log"
+CONTROL_JOBS=some bash "$matched/tests/must-fail-controls.sh" >"$jobs_log" 2>&1
+rc=$?
+assert_eq "a non-numeric CONTROL_JOBS exits 2" "$rc" 2
+assert_file_contains "the refusal names the setting and the value" \
+    "$jobs_log" "CONTROL_JOBS must be a positive integer, got: some"
+assert_file_lacks "a refused width judges nothing" "$jobs_log" "controls, "

--- a/.agents/skills/linear/tests/roster-orphan.test.sh
+++ b/.agents/skills/linear/tests/roster-orphan.test.sh
@@ -135,3 +135,13 @@ assert_eq "a non-numeric CONTROL_JOBS exits 2" "$rc" 2
 assert_file_contains "the refusal names the setting and the value" \
     "$jobs_log" "CONTROL_JOBS must be a positive integer, got: some"
 assert_file_lacks "a refused width judges nothing" "$jobs_log" "controls, "
+
+# A width outside signed 64-bit arithmetic is junk of the same kind: the
+# batching predicate compares against the wrap, reads 2^64 as zero, and reaps
+# after every launch, so the roster runs one control at a time.
+wide_log="$TMP/jobs-wide.log"
+CONTROL_JOBS=18446744073709551616 bash "$matched/tests/must-fail-controls.sh" >"$wide_log" 2>&1
+rc=$?
+assert_eq "a CONTROL_JOBS too wide for the arithmetic exits 2" "$rc" 2
+assert_file_contains "the refusal names the setting and the over-wide value" \
+    "$wide_log" "CONTROL_JOBS must be a positive integer, got: 18446744073709551616"

--- a/.agents/skills/preflight/tests/precision.test.sh
+++ b/.agents/skills/preflight/tests/precision.test.sh
@@ -46,8 +46,12 @@ seed() { # NAME — fixture in $R: committed baseline, origin/main, feature bran
   git -C "$R" remote set-url origin "$R.git"
 }
 
+# Local R: this builds the template and nothing else, and run_pf cd's into
+# whatever R holds. Left global it would be an out-parameter no signature
+# names, and any call from outside seed would run the next case against the
+# shared template.
 build_seed_template() {
-  R="$SEED_TEMPLATE"
+  local R="$SEED_TEMPLATE"
   mkdir -p "$R/docs" "$R/scripts" "$R/hooks" "$R/tests" "$R/data" "$R/store/migrations" \
     "$R/src/main/resources/db/migration"
   git -C "$R" -c init.defaultBranch=main init -q

--- a/.agents/skills/preflight/tests/precision.test.sh
+++ b/.agents/skills/preflight/tests/precision.test.sh
@@ -29,8 +29,25 @@ skipped() {
   printf '  skip  %s (%s)\n' "$1" "$2"
 }
 
+SEED_TEMPLATE="$TMP/.seed-template"
+
+# Every fixture below starts from the same committed baseline, so it is built
+# once and copied. Rebuilding it per case costs a git init, a commit, a bare
+# clone and a fetch each, and there are dozens of cases.
 seed() { # NAME — fixture in $R: committed baseline, origin/main, feature branch
+  if [ ! -d "$SEED_TEMPLATE" ]; then
+    build_seed_template
+  fi
   R="$TMP/$1"
+  cp -a "$SEED_TEMPLATE" "$R"
+  cp -a "$SEED_TEMPLATE.git" "$R.git"
+  # The origin URL the template recorded points at the template's own bare
+  # copy; every fixture must fetch from its own.
+  git -C "$R" remote set-url origin "$R.git"
+}
+
+build_seed_template() {
+  R="$SEED_TEMPLATE"
   mkdir -p "$R/docs" "$R/scripts" "$R/hooks" "$R/tests" "$R/data" "$R/store/migrations" \
     "$R/src/main/resources/db/migration"
   git -C "$R" -c init.defaultBranch=main init -q

--- a/.agents/skills/reviewer/scripts/mutation-stability
+++ b/.agents/skills/reviewer/scripts/mutation-stability
@@ -74,13 +74,16 @@ positive_integer --stability "$N"
 positive_integer --threads "$THREADS"
 positive_integer --timeout "$TIMEOUT"
 
+# Bounded on width as well as grammar: 19 digits or more is outside what the
+# shell's arithmetic holds, so every test below it reads the figure as an
+# error rather than a count. The run then prints the skipped-boundary warning
+# it has no business printing and hands the same figure to sleep, which waits
+# out the run on the first write to a copy.
 SETTLE="${MUTATION_STABILITY_SETTLE:-1}"
-case "$SETTLE" in
-  *[!0-9]* | '')
-    echo "MUTATION_STABILITY_SETTLE wants a whole number of seconds" >&2
-    exit 2
-    ;;
-esac
+if ! [[ "$SETTLE" =~ ^[0-9]{1,18}$ ]]; then
+  echo "MUTATION_STABILITY_SETTLE wants a whole number of seconds" >&2
+  exit 2
+fi
 # The precondition for skipping the boundary — that BUILD keeps no cache the
 # copies could share — is the caller's to know and this script cannot check
 # it. When it does not hold the mutant reuses the clean run's binary and reads

--- a/.agents/skills/reviewer/scripts/mutation-stability
+++ b/.agents/skills/reviewer/scripts/mutation-stability
@@ -29,6 +29,10 @@ usage: mutation-stability --worktree PATH --sha SHA --test CMD --build CMD
                    given it in TEST, e.g. --test 'cargo test -- --test-threads $THREADS'
   --timeout S      deadline for each build or test command (default 300)
   --keep           print the temp dirs instead of deleting them
+
+  MUTATION_STABILITY_SETTLE  seconds each write to a copy waits so a shared
+                   mtime-keyed build cache cannot answer it with the previous
+                   run's binary (default 1; 0 when BUILD shares no cache)
 USAGE
 }
 
@@ -69,6 +73,14 @@ positive_integer() {
 positive_integer --stability "$N"
 positive_integer --threads "$THREADS"
 positive_integer --timeout "$TIMEOUT"
+
+SETTLE="${MUTATION_STABILITY_SETTLE:-1}"
+case "$SETTLE" in
+  *[!0-9]* | '')
+    echo "MUTATION_STABILITY_SETTLE wants a whole number of seconds" >&2
+    exit 2
+    ;;
+esac
 
 ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX") || exit 2
 ACTIVE_PID="" ACTIVE_GROUP=""
@@ -146,7 +158,11 @@ trap 'exit 143' TERM
 # a source tree waits that boundary out first, so what it wrote always outranks
 # the build before it. Without that, the cache the caller shares — usually
 # CARGO_TARGET_DIR — answers the next run with the last run's test binary.
-outrank_last_build() { sleep 1; }
+#
+# A caller whose --build shares no cache has nothing to outrank, and
+# tests/mutation-stability.test.sh is one: it drives every case with a stub
+# build. MUTATION_STABILITY_SETTLE=0 is how such a caller says so.
+outrank_last_build() { [ "$SETTLE" -eq 0 ] || sleep "$SETTLE"; }
 
 extract() { # extract SHA into $1, stamped past the build before it
   mkdir -p "$1" || return 1

--- a/.agents/skills/reviewer/scripts/mutation-stability
+++ b/.agents/skills/reviewer/scripts/mutation-stability
@@ -81,6 +81,13 @@ case "$SETTLE" in
     exit 2
     ;;
 esac
+# The precondition for skipping the boundary — that BUILD keeps no cache the
+# copies could share — is the caller's to know and this script cannot check
+# it. When it does not hold the mutant reuses the clean run's binary and reads
+# as survived, and nothing about that verdict looks wrong afterwards. Say it
+# once, so a transcript shows which verdicts were produced without it.
+[ "$SETTLE" -ne 0 ] ||
+  echo "settle: 0 — copies are not mtime-separated; verdicts assume BUILD shares no cache" >&2
 
 ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX") || exit 2
 ACTIVE_PID="" ACTIVE_GROUP=""

--- a/.agents/skills/reviewer/tests/mutation-stability.test.sh
+++ b/.agents/skills/reviewer/tests/mutation-stability.test.sh
@@ -28,6 +28,12 @@ stopped() {
   ! kill -0 "$pid" 2>/dev/null
 }
 
+# Every case up to the shared-cache block below builds with `true` or a `test`
+# — nothing that keeps a cache, so nothing the copy's mtime has to outrank.
+# The two blocks that DO put a whole-second cache behind the build clear this
+# again and spend the real wait.
+export MUTATION_STABILITY_SETTLE=0
+
 TMP=$(mktemp -d "${TMPDIR:-/tmp}/ms-test.XXXXXX") || exit 2
 trap 'rm -rf "$TMP"' EXIT
 REPO="$TMP/repo"
@@ -97,6 +103,42 @@ lacks "killed" "a non-compiling mutant is never killed"
 # One invalid input proves the shared positive-integer validator.
 run_ms "$SHA" --test 'true' --build 'true' --mutate 'true' --timeout 0
 is_rc 2 "the numeric validator rejects zero"
+
+# The settle has its own validator: it admits the 0 the shared one refuses,
+# and refuses everything that is not a count of seconds.
+rc=0
+out=$(MUTATION_STABILITY_SETTLE=soon "$MS" --worktree "$REPO" --sha "$SHA" \
+  --test 'true' --build 'true' --mutate 'true' --stability 1 2>&1) || rc=$?
+is_rc 2 "a settle that is not a number of seconds exits 2"
+has "MUTATION_STABILITY_SETTLE wants a whole number of seconds" "the rejected settle is named"
+
+# And 0 really skips the wait rather than merely shortening it. What the run
+# asked for is read off a sleep stub: the settle is the only whole-second
+# sleeper in the script, and the sub-second waits are its own polls, which the
+# stub still performs so the run behaves normally.
+mkdir -p "$TMP/sleepbin"
+cat >"$TMP/sleepbin/sleep" <<SH
+#!/bin/sh
+printf '%s\n' "\$1" >>"$TMP/slept"
+case "\$1" in *.*) exec $(command -v sleep) "\$@" ;; esac
+SH
+chmod +x "$TMP/sleepbin/sleep"
+settle_arm() { # DESC EXPECTATION(present|absent) env-argument...
+  desc="$1"; want="$2"; shift 2
+  : >"$TMP/slept"
+  rc=0
+  out=$(env "$@" PATH="$TMP/sleepbin:$PATH" "$MS" \
+    --worktree "$REPO" --sha "$SHA" --test 'bash check.sh' --build 'true' \
+    --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+    --stability 1 --threads 2 2>&1) || rc=$?
+  is_rc 0 "control: $desc still reaches its verdict"
+  if grep -qxE '[0-9]+' "$TMP/slept"; then found=present; else found=absent; fi
+  if [ "$found" = "$want" ]; then ok "$desc"; else
+    bad "$desc" "whole-second wait $found; slept: $(tr '\n' ' ' <"$TMP/slept")"
+  fi
+}
+settle_arm "the default settle waits a whole second" present -u MUTATION_STABILITY_SETTLE
+settle_arm "a zero settle asks for no wait at all" absent MUTATION_STABILITY_SETTLE=0
 
 # KEN-999: one timeout control also checks adoption under a non-reaping PID 1.
 export HANG_PID_FILE="$TMP/timeout-child.pid"
@@ -178,7 +220,9 @@ run_ms "$SHA2" --test 'bash check.sh' --build 'true' \
 is_rc 1 "stability failure exits 1 even with the mutant killed"
 has "stability: 1/3 at 2 threads" "partial stability is reported as Y/N"
 
-# Shared whole-second caches must rebuild for mutant and clean copies.
+# Shared whole-second caches must rebuild for mutant and clean copies. This is
+# the wait's whole reason, so from here the default settle is what runs.
+unset MUTATION_STABILITY_SETTLE
 export CACHE="$TMP/build-cache"
 mkdir -p "$CACHE"
 cat > "$REPO/check.sh" <<'T'

--- a/.agents/skills/reviewer/tests/mutation-stability.test.sh
+++ b/.agents/skills/reviewer/tests/mutation-stability.test.sh
@@ -76,7 +76,10 @@ run_ms "$SHA" --test 'bash check.sh' --build 'true' \
   --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
   --stability 2 --threads 2
 is_rc 0 "killed mutant exits 0"
-if [ "$out" = "mutation: killed 1/1; stability: 2/2 at 2 threads" ]; then ok "summary line is the exact format"; else bad "summary line is the exact format" "$out"; fi
+# The LAST line, not the whole stream: the run may say something on stderr
+# first — a skipped settle boundary does — and the claim here is the shape of
+# the verdict this script ends on.
+if [ "${out##*$'\n'}" = "mutation: killed 1/1; stability: 2/2 at 2 threads" ]; then ok "summary line is the exact format"; else bad "summary line is the exact format" "$out"; fi
 
 run_ms "$SHA" --test 'bash check.sh' --build 'true' \
   --mutate 'echo "# decoy: still says +" >> lib.sh' --stability 1
@@ -138,7 +141,13 @@ settle_arm() { # DESC EXPECTATION(present|absent) env-argument...
   fi
 }
 settle_arm "the default settle waits a whole second" present -u MUTATION_STABILITY_SETTLE
+lacks "settle: 0" "the default run says nothing about a skipped boundary"
 settle_arm "a zero settle asks for no wait at all" absent MUTATION_STABILITY_SETTLE=0
+# A verdict reached without the boundary has to be identifiable afterwards:
+# where BUILD does share a cache, a reused binary reads as a survivor and
+# nothing else in the output says why.
+has "settle: 0 — copies are not mtime-separated" \
+  "a skipped boundary is named in the run's own output"
 
 # KEN-999: one timeout control also checks adoption under a non-reaping PID 1.
 export HANG_PID_FILE="$TMP/timeout-child.pid"

--- a/.agents/skills/reviewer/tests/mutation-stability.test.sh
+++ b/.agents/skills/reviewer/tests/mutation-stability.test.sh
@@ -126,7 +126,10 @@ printf '%s\n' "\$1" >>"$TMP/slept"
 case "\$1" in *.*) exec $(command -v sleep) "\$@" ;; esac
 SH
 chmod +x "$TMP/sleepbin/sleep"
-settle_arm() { # DESC EXPECTATION(present|absent) env-argument...
+# WANT is the number of seconds the run should have asked for, or `absent` for
+# no whole-second wait at all. The figure and not just its shape: a default
+# silently changed from 1 to 30 is still a whole number, and would read green.
+settle_arm() { # DESC EXPECTATION(seconds|absent) env-argument...
   desc="$1"; want="$2"; shift 2
   : >"$TMP/slept"
   rc=0
@@ -135,12 +138,13 @@ settle_arm() { # DESC EXPECTATION(present|absent) env-argument...
     --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
     --stability 1 --threads 2 2>&1) || rc=$?
   is_rc 0 "control: $desc still reaches its verdict"
-  if grep -qxE '[0-9]+' "$TMP/slept"; then found=present; else found=absent; fi
+  found="$(grep -xE '[0-9]+' "$TMP/slept" | head -1 || true)"
+  [ -n "$found" ] || found=absent
   if [ "$found" = "$want" ]; then ok "$desc"; else
     bad "$desc" "whole-second wait $found; slept: $(tr '\n' ' ' <"$TMP/slept")"
   fi
 }
-settle_arm "the default settle waits a whole second" present -u MUTATION_STABILITY_SETTLE
+settle_arm "the default settle waits one whole second" 1 -u MUTATION_STABILITY_SETTLE
 lacks "settle: 0" "the default run says nothing about a skipped boundary"
 settle_arm "a zero settle asks for no wait at all" absent MUTATION_STABILITY_SETTLE=0
 # A verdict reached without the boundary has to be identifiable afterwards:

--- a/.agents/skills/reviewer/tests/mutation-stability.test.sh
+++ b/.agents/skills/reviewer/tests/mutation-stability.test.sh
@@ -115,6 +115,15 @@ out=$(MUTATION_STABILITY_SETTLE=soon "$MS" --worktree "$REPO" --sha "$SHA" \
 is_rc 2 "a settle that is not a number of seconds exits 2"
 has "MUTATION_STABILITY_SETTLE wants a whole number of seconds" "the rejected settle is named"
 
+# Width is part of that grammar: unrefused, this figure is one the shell's
+# tests read as an error and sleep waits out, so the run hangs on its first
+# write to a copy instead of reporting the setting.
+rc=0
+out=$(MUTATION_STABILITY_SETTLE=18446744073709551616 "$MS" --worktree "$REPO" --sha "$SHA" \
+  --test 'true' --build 'true' --mutate 'true' --stability 1 2>&1) || rc=$?
+is_rc 2 "a settle too wide for the arithmetic exits 2"
+has "MUTATION_STABILITY_SETTLE wants a whole number of seconds" "the over-wide settle is named"
+
 # And 0 really skips the wait rather than merely shortening it. What the run
 # asked for is read off a sleep stub: the settle is the only whole-second
 # sleeper in the script, and the sub-second waits are its own polls, which the

--- a/.agents/skills/second-opinion/tests/cli-failure-gate.test.sh
+++ b/.agents/skills/second-opinion/tests/cli-failure-gate.test.sh
@@ -27,6 +27,8 @@ export SECOND_OPINION_CURRENT_MODEL=none
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 SECOND_OPINION="$REPO_ROOT/skills/second-opinion/scripts/second-opinion"
+# shellcheck source=lib/path-farm.bash
+. "$SCRIPT_DIR/lib/path-farm.bash"
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
@@ -1003,16 +1005,7 @@ echo "=== scenario 10n: without jq the sibling sweep is skipped, and says so ===
 # it from siblings that are still there. Built by mirroring the real PATH minus
 # jq, so the fixture cannot rot as the script's command set changes.
 s10n_bin="$TMP_ROOT/nojq"
-mkdir -p "$s10n_bin"
-while IFS= read -r s10n_dir; do
-  [[ -d "$s10n_dir" ]] || continue
-  for s10n_f in "$s10n_dir"/*; do
-    [[ -f "$s10n_f" && -x "$s10n_f" ]] || continue
-    s10n_b="${s10n_f##*/}"
-    [[ "$s10n_b" == jq ]] && continue
-    [[ -e "$s10n_bin/$s10n_b" ]] || ln -sf "$s10n_f" "$s10n_bin/$s10n_b" 2>/dev/null || true
-  done
-done < <(printf '%s\n' "$PATH" | tr ':' '\n')
+path_farm_without "$s10n_bin" jq
 if PATH="$s10n_bin" command -v jq >/dev/null 2>&1 || ! PATH="$s10n_bin" command -v git >/dev/null 2>&1; then
   skip "no-jq sweep: could not build a PATH with git but without jq"
 else

--- a/.agents/skills/second-opinion/tests/lib/path-farm.bash
+++ b/.agents/skills/second-opinion/tests/lib/path-farm.bash
@@ -1,0 +1,32 @@
+# shellcheck shell=bash
+# A PATH with named commands hidden, for the cases that must run as a host
+# without them. Sourced, never run as a suite: the runners glob tests/*.sh,
+# so both the subdirectory and the .bash name keep this file out of every run.
+#
+# Mirroring the caller's own PATH rather than listing what to keep is what
+# makes the fixture rot-proof: a script that grows a new dependency still
+# finds it here, and only what was named is missing.
+
+# One `ln` per source directory, not one per file — /usr/bin alone is a few
+# thousand forks. A name already staged is skipped, which is PATH's own
+# first-directory-wins rule. Nothing sets nullglob: a directory with no
+# entries yields the unmatched pattern, which is not a file and is dropped by
+# the same test that drops a non-executable one.
+path_farm_without() { # DIR NAME... — stage DIR as a PATH missing every NAME
+  local dir="$1" hidden="" src="" f="" base=""
+  shift
+  hidden=" $* "
+  mkdir -p "$dir" || return 1
+  while IFS= read -r src; do
+    [ -d "$src" ] || continue
+    local staged=()
+    for f in "$src"/*; do
+      { [ -f "$f" ] && [ -x "$f" ]; } || continue
+      base="${f##*/}"
+      case "$hidden" in *" $base "*) continue ;; esac
+      [ ! -e "$dir/$base" ] || continue
+      staged+=("$f")
+    done
+    [ "${#staged[@]}" -eq 0 ] || ln -s -- "${staged[@]}" "$dir/" 2>/dev/null || true
+  done < <(printf '%s\n' "$PATH" | tr ':' '\n')
+}

--- a/.agents/skills/second-opinion/tests/process-tree.test.sh
+++ b/.agents/skills/second-opinion/tests/process-tree.test.sh
@@ -114,7 +114,7 @@ cat >/dev/null
 sleep 120 &
 printf '%s\n' "$!" > "$CLI_KID_FILE"
 printf 'started\n' > "$CLI_READY_FILE"
-sleep 1
+sleep 0.2
 printf 'leader done\n'
 SH
 chmod +x "$TMP_ROOT/bin/orphan-codex"
@@ -150,15 +150,15 @@ else
 start=$(date +%s)
 rc=0
 captured=$(CLI_READY_FILE="$TMP_ROOT/tree.ready" CLI_KID_FILE="$TMP_ROOT/tree.kid" \
-  SECOND_OPINION_CODEX_CMD=treeish-codex SECOND_OPINION_TIMEOUT=2 \
+  SECOND_OPINION_CODEX_CMD=treeish-codex SECOND_OPINION_TIMEOUT=1 \
   "$SECOND_OPINION" quick question --cwd "$TMP_ROOT/work" \
   2> "$TMP_ROOT/tree.stderr") || rc=$?
 elapsed=$(( $(date +%s) - start ))
 kid="$(read_pid "$TMP_ROOT/tree.kid" "the timed-out CLI")"
 STRAYS+=("$kid")
 [[ $elapsed -lt 60 ]] \
-  || fail "the caller waited ${elapsed}s for a 2s timeout — a survivor held the pipe open"
-ok "the capturing caller returns promptly (${elapsed}s) after a 2s timeout"
+  || fail "the caller waited ${elapsed}s for a 1s timeout — a survivor held the pipe open"
+ok "the capturing caller returns promptly (${elapsed}s) after a 1s timeout"
 await_gone "$kid" || fail "the CLI's child $kid survived the timeout"
 ok "the timeout took the CLI's child with it"
 [[ $rc -ne 0 ]] || fail "a timed-out CLI must not read as success"
@@ -215,7 +215,10 @@ capture_group_run() { # RUNTIME LABEL -> "rc", 124 when the capture outran the b
     bash -c 'out=$("$1" group-run "$2" orphan-codex < /dev/null); printf %s "$out" > "$3"' \
     _ "$runtime" "$TMP_ROOT/$label.stderr" "$TMP_ROOT/$label.out" &
   job=$!
-  end=$(($(date +%s) + 8))
+  # 3s: the shipped runtime releases the capture as soon as the orphan CLI's
+  # leader exits (0.2s in), and the leader-probe control never releases it at
+  # all, so anything above the leader's own life only lengthens the control.
+  end=$(($(date +%s) + 3))
   while kill -0 "$job" 2>/dev/null; do
     if [[ $(date +%s) -ge $end ]]; then
       kill -KILL "$job" 2>/dev/null || true
@@ -278,7 +281,7 @@ CLI_READY_FILE="$TMP_ROOT/dl.ready" CLI_KID_FILE="$TMP_ROOT/dl.kid" \
   SECOND_OPINION_LAUNCH_MODEL=claude \
   SECOND_OPINION_CODEX_CMD=treeish-codex \
   "$RUNTIME" launch "$SECOND_OPINION" "$TMP_ROOT/dl-answer" "$TMP_ROOT/dl-runtime" \
-  6 false 10 quick question --target=codex --cwd "$TMP_ROOT/work" --timeout 600 \
+  4 false 10 quick question --target=codex --cwd "$TMP_ROOT/work" --timeout 600 \
   > "$TMP_ROOT/dl-launch.stdout" 2> "$TMP_ROOT/dl-launch.stderr"
 dl_wait="$(sed -n 's/^wait: //p' "$TMP_ROOT/dl-launch.stdout")"
 dl_pid="$(read_pid "$TMP_ROOT/dl-runtime/pid" "the detached launcher")"

--- a/.agents/skills/second-opinion/tests/timeout-defaults.test.sh
+++ b/.agents/skills/second-opinion/tests/timeout-defaults.test.sh
@@ -14,6 +14,8 @@ export SECOND_OPINION_CURRENT_MODEL=none
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+# shellcheck source=lib/path-farm.bash
+. "$SCRIPT_DIR/lib/path-farm.bash"
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
@@ -137,15 +139,7 @@ assert_contains "$zero_stderr" "must be a positive integer" "--timeout 0 is refu
 # warning, not a refusal. Hide both binaries behind a symlink farm of the rest
 # of PATH.
 NOTIMEOUT="$TMP_ROOT/notimeout"
-mkdir -p "$NOTIMEOUT"
-IFS=: read -ra _path_dirs <<< "$PATH"
-for _d in "${_path_dirs[@]}"; do
-  for _f in "$_d"/*; do
-    _b="${_f##*/}"
-    [[ "$_b" == timeout || "$_b" == gtimeout ]] && continue
-    [[ -e "$NOTIMEOUT/$_b" ]] || ln -s "$_f" "$NOTIMEOUT/$_b" 2>/dev/null || true
-  done
-done
+path_farm_without "$NOTIMEOUT" timeout gtimeout
 
 notimeout_stderr="$TMP_ROOT/notimeout.stderr"
 PATH="$TMP_ROOT/bin:$NOTIMEOUT" \

--- a/.agents/skills/size-ratchet/DEVELOPMENT.md
+++ b/.agents/skills/size-ratchet/DEVELOPMENT.md
@@ -67,15 +67,17 @@ still governs unless the rewrite lands.
 ## Trusted reference snapshot
 
 `resolve_head_baseline_file` sets the settings library's HEAD mode and calls
-`sr_setting`. `sr_settings_source` owns source names, precedence, historical
-materialization, and tracked-symlink traversal. `git ls-tree` answers for a
-complete path only, so before it may report a source absent from HEAD,
-`sr_settings_head_absence_real` classifies each ancestor: absent ends the
-walk, a tree continues it, and anything else — a symlink above all — is a
-lookup that could not be performed and refuses. Materialized copies are named
-`settings.file.<encoded path>`, a namespace the `settings.absent` sentinel
-cannot occupy, so no source name can materialize onto the path that means "not
-there". The main script handles only the flag and process-key overrides, then
+`sr_setting`. `sr_settings_resolve` owns source names, precedence, historical
+materialization, and tracked-symlink traversal; `sr_settings_source` is the
+memo front over it, recording each answer beside the snapshot it came from.
+`git ls-tree` answers for a complete path only, so before it may report a
+source absent from HEAD, `sr_settings_head_absence_real` classifies each
+ancestor: absent ends the walk, a tree continues it, and anything else — a
+symlink above all — is a lookup that could not be performed and refuses.
+Materialized copies are named `settings.file.<encoded path>` and the memos
+`settings.resolved.<encoded path>`, two namespaces the `settings.absent`
+sentinel cannot occupy, so no source name can materialize onto the path that
+means "not there". The main script handles only the flag and process-key overrides, then
 reads the baseline at the returned path. `rows_raised` consumes only those rows. The behavioral rule is
 [README.md § Trusted HEAD baseline](README.md#trusted-head-baseline).
 

--- a/.agents/skills/size-ratchet/DEVELOPMENT.md
+++ b/.agents/skills/size-ratchet/DEVELOPMENT.md
@@ -77,7 +77,9 @@ symlink above all — is a lookup that could not be performed and refuses.
 Materialized copies are named `settings.file.<encoded path>` and the memos
 `settings.resolved.<encoded path>`, two namespaces the `settings.absent`
 sentinel cannot occupy, so no source name can materialize onto the path that
-means "not there". The main script handles only the flag and process-key overrides, then
+means "not there". A memo is only a cache, so one whose name will not fit as a
+single filesystem component is not written and that source resolves uncached.
+The main script handles only the flag and process-key overrides, then
 reads the baseline at the returned path. `rows_raised` consumes only those rows. The behavioral rule is
 [README.md § Trusted HEAD baseline](README.md#trusted-head-baseline).
 

--- a/.agents/skills/size-ratchet/scripts/lib/settings.sh
+++ b/.agents/skills/size-ratchet/scripts/lib/settings.sh
@@ -196,10 +196,10 @@ sr_settings_source() { # FILE — the path to actually read; nonzero + ::error o
       return 0
       ;;
   esac
-  printf '%s\n' "$resolved" >"$memo" || {
-    echo "::error::$1: could not record the resolved settings source at $memo" >&2
-    return 1
-  }
+  # The memo is only a cache, and a slug spends three characters on `/` and
+  # `.`, so a legal path can encode past NAME_MAX. A write that cannot land
+  # costs a re-resolve, not an answer; stderr first silences bash's error.
+  printf '%s\n' "$resolved" 2>/dev/null >"$memo" || :
   printf '%s' "$resolved"
 }
 

--- a/.agents/skills/size-ratchet/scripts/lib/settings.sh
+++ b/.agents/skills/size-ratchet/scripts/lib/settings.sh
@@ -172,14 +172,8 @@ sr_settings_source() { # FILE — the path to actually read; nonzero + ::error o
   elif [ "${SR_SETTINGS_FROM_INDEX:-0}" = "1" ]; then
     dir="${SR_SETTINGS_INDEX_DIR:-}"
   fi
-  # No snapshot, or a name that cannot round-trip through a one-line memo:
-  # resolve it the long way rather than record an answer that reads back wrong.
-  case "$dir$SR_SETTINGS_NL$1" in
-    "$SR_SETTINGS_NL"* | *"$SR_SETTINGS_NL"*"$SR_SETTINGS_NL"*)
-      sr_settings_resolve "$1"
-      return
-      ;;
-  esac
+  # No snapshot: nothing to memoize, and nowhere to put it.
+  [ -n "$dir" ] || { sr_settings_resolve "$1"; return; }
   sr_settings_slug "$1"
   memo="$dir/settings.resolved.$SR_SETTINGS_SLUG"
   if [ -f "$memo" ]; then
@@ -192,6 +186,16 @@ sr_settings_source() { # FILE — the path to actually read; nonzero + ::error o
     fi
   fi
   resolved="$(sr_settings_resolve "$1")" || return 1
+  # A memo holds one line, so a resolution carrying a newline cannot come back
+  # out: the read above would return its first line, which names no file, and
+  # the key would fall back to its default with nothing said. Guarded on the
+  # value, not on what built it, so a new return path cannot reopen this.
+  case "$resolved" in
+    *"$SR_SETTINGS_NL"*)
+      printf '%s' "$resolved"
+      return 0
+      ;;
+  esac
   printf '%s\n' "$resolved" >"$memo" || {
     echo "::error::$1: could not record the resolved settings source at $memo" >&2
     return 1

--- a/.agents/skills/size-ratchet/scripts/lib/settings.sh
+++ b/.agents/skills/size-ratchet/scripts/lib/settings.sh
@@ -144,7 +144,62 @@ sr_settings_head_absence_real() { # NORMALIZED-PATH — 0 = the sentinel is earn
     return 1
   done
 }
+# A flat, reversible name for a repo-relative path, so a snapshot directory
+# holds one entry per source. Parameter expansion rather than sed: this runs
+# for every source of every key read, and a fork here is most of what a small
+# repository spends resolving its settings.
+sr_settings_slug() { # PATH — sets SR_SETTINGS_SLUG
+  local s="$1"
+  s="${s//%/%25}"
+  s="${s//\//%2F}"
+  s="${s//./%2E}"
+  SR_SETTINGS_SLUG="$s"
+}
+
+SR_SETTINGS_NL='
+'
+
+# Resolution against a snapshot is a pure function of the snapshot and the
+# path: nothing in a run rewrites the index or moves HEAD under it. Each key
+# read re-asks for the same two settings files and .env.local, and each ask
+# costs several git probes, so the answer is recorded beside the snapshot it
+# came from. It has to be ON DISK: every caller wraps this in a command
+# substitution, and a shell variable would not survive that subshell.
 sr_settings_source() { # FILE — the path to actually read; nonzero + ::error on failure
+  local dir="" memo="" resolved=""
+  if [ "${SR_SETTINGS_FROM_HEAD:-0}" = "1" ]; then
+    dir="${SR_SETTINGS_HEAD_DIR:-}"
+  elif [ "${SR_SETTINGS_FROM_INDEX:-0}" = "1" ]; then
+    dir="${SR_SETTINGS_INDEX_DIR:-}"
+  fi
+  # No snapshot, or a name that cannot round-trip through a one-line memo:
+  # resolve it the long way rather than record an answer that reads back wrong.
+  case "$dir$SR_SETTINGS_NL$1" in
+    "$SR_SETTINGS_NL"* | *"$SR_SETTINGS_NL"*"$SR_SETTINGS_NL"*)
+      sr_settings_resolve "$1"
+      return
+      ;;
+  esac
+  sr_settings_slug "$1"
+  memo="$dir/settings.resolved.$SR_SETTINGS_SLUG"
+  if [ -f "$memo" ]; then
+    IFS= read -r resolved <"$memo" || resolved=""
+    # A resolution is always a path, so an empty read is a torn or unreadable
+    # memo, never a recorded answer: fall through and resolve it again.
+    if [ -n "$resolved" ]; then
+      printf '%s' "$resolved"
+      return 0
+    fi
+  fi
+  resolved="$(sr_settings_resolve "$1")" || return 1
+  printf '%s\n' "$resolved" >"$memo" || {
+    echo "::error::$1: could not record the resolved settings source at $memo" >&2
+    return 1
+  }
+  printf '%s' "$resolved"
+}
+
+sr_settings_resolve() { # FILE — the path to actually read; nonzero + ::error on failure
   local file="$1" copy="" status=0 entry="" norm="" head_status=0 tree_status=0 target="" base="" depth=0
   if [ "${SR_SETTINGS_FROM_HEAD:-0}" = "1" ]; then
     if [ -z "${SR_SETTINGS_HEAD_DIR:-}" ]; then
@@ -208,7 +263,8 @@ sr_settings_source() { # FILE — the path to actually read; nonzero + ::error o
           ;;
       esac
     done
-    copy="$SR_SETTINGS_HEAD_DIR/settings.file.$(printf '%s' "$file" | sed -e 's/%/%25/g' -e 's|/|%2F|g' -e 's/[.]/%2E/g')"
+    sr_settings_slug "$file"
+    copy="$SR_SETTINGS_HEAD_DIR/settings.file.$SR_SETTINGS_SLUG"
     if [ ! -f "$copy" ] && ! git show "HEAD:$file" >"$copy" 2>/dev/null; then
       rm -f -- "$copy"
       echo "::error::$file: could not read its HEAD settings content" >&2
@@ -281,7 +337,8 @@ sr_settings_source() { # FILE — the path to actually read; nonzero + ::error o
       return 1
       ;;
   esac
-  copy="$SR_SETTINGS_INDEX_DIR/settings.file.$(printf '%s' "$file" | sed -e 's/%/%25/g' -e 's|/|%2F|g' -e 's/[.]/%2E/g')"
+  sr_settings_slug "$file"
+  copy="$SR_SETTINGS_INDEX_DIR/settings.file.$SR_SETTINGS_SLUG"
   if [ ! -f "$copy" ]; then
     if ! git show ":$file" >"$copy" 2>/dev/null; then
       rm -f -- "$copy"

--- a/.agents/skills/size-ratchet/tests/settings-and-config.test.sh
+++ b/.agents/skills/size-ratchet/tests/settings-and-config.test.sh
@@ -294,6 +294,23 @@ run_raw SIZE_RATCHET_SETTINGS_FILE=absent.settings.toml || true
   && ok "an ABSENT plain file still falls back to the built-in default (control)" \
   || bad "an ABSENT plain file still falls back to the built-in default (control)" "rc=$RC out=$OUT"
 
+echo "=== a resolved source carrying a newline is never memoized ==="
+# Under --staged the library resolves against a snapshot and records each
+# answer in a one-line memo. A resolution with a newline in it cannot come
+# back out of one: the read returns its first line, which names no file, so
+# every key after the first falls to its default with nothing said. The memo
+# is what makes this reachable, and a settings path is the resolution, so an
+# untracked file whose name carries a newline is the whole condition.
+new_repo memo
+mkfile notes.md 40
+git -C "$R" add -A
+NL_SETTINGS="$(printf 'two\nlines.settings.toml')"
+printf '[env]\nSIZE_RATCHET_THRESHOLD = "12"\nSIZE_RATCHET_CLASSES = "*.md=5"\n' >"$R/$NL_SETTINGS"
+run_raw SIZE_RATCHET_SETTINGS_FILE="$NL_SETTINGS" -- --staged || true
+case "$OUT" in *"threshold 12"*"*.md=5"*) true ;; *) false ;; esac \
+  && ok "the configured threshold and classes still decide a --staged run" \
+  || bad "a newline in the resolved source falls back to the defaults" "rc=$RC out=$OUT"
+
 echo "=== the /dev/null sentinel selects NO settings source, the dotenv layer included ==="
 # It named only the settings file, so .env.local (read before it) kept
 # deciding: a caller asking for built-in defaults got whatever the

--- a/.agents/skills/size-ratchet/tests/settings-and-config.test.sh
+++ b/.agents/skills/size-ratchet/tests/settings-and-config.test.sh
@@ -311,6 +311,22 @@ case "$OUT" in *"threshold 12"*"*.md=5"*) true ;; *) false ;; esac \
   && ok "the configured threshold and classes still decide a --staged run" \
   || bad "a newline in the resolved source falls back to the defaults" "rc=$RC out=$OUT"
 
+echo "=== a source whose memo name will not fit is resolved uncached ==="
+# The memo name flattens the whole settings path into one basename, and the
+# slug spends three characters on every `/` and `.`, so a path every component
+# of which sits far inside NAME_MAX can encode past that limit. The memo is a
+# cache: such a path resolves the pre-memo way rather than refusing the run.
+new_repo longmemo
+mkfile notes.md 40
+git -C "$R" add -A
+DEEP="$(awk 'BEGIN { for (i = 0; i < 60; i++) printf "d/" }')kendex.settings.toml"
+mkdir -p "$R/$(dirname "$DEEP")"
+printf '[env]\nSIZE_RATCHET_THRESHOLD = "12"\nSIZE_RATCHET_CLASSES = "*.md=5"\n' >"$R/$DEEP"
+run_raw SIZE_RATCHET_SETTINGS_FILE="$DEEP" -- --staged || true
+case "$OUT" in *"threshold 12"*"*.md=5"*) true ;; *) false ;; esac \
+  && ok "a settings path too long to memoize still decides a --staged run" \
+  || bad "an unmemoizable settings path refuses the run" "rc=$RC out=$OUT"
+
 echo "=== the /dev/null sentinel selects NO settings source, the dotenv layer included ==="
 # It named only the settings file, so .env.local (read before it) kept
 # deciding: a caller asking for built-in defaults got whatever the

--- a/.agents/skills/worktree/tests/worktree_no_worktree_installs.sh
+++ b/.agents/skills/worktree/tests/worktree_no_worktree_installs.sh
@@ -63,15 +63,17 @@ make_repo() { # ROOT NAME — main checkout with a bare origin
   git -C "$root/$name" push -q -u origin main
 }
 
-assert_no_pm_calls() { # NAME — watch 2s and fail the moment any manager runs
-  local name="$1" deadline=$((SECONDS + 2))
-  while [ "$SECONDS" -lt "$deadline" ]; do
-    if [ -s "$PM_CALL_LOG" ]; then
-      bad "$name" "$(cat "$PM_CALL_LOG")"
-      return 1
-    fi
-    sleep 0.2
-  done
+# The log is cumulative and every caller checks it after the worktree command
+# has already returned, so one read covers everything that ran: a manager the
+# command forked and did not wait for is a defect this suite is not the place
+# to catch — `create` has no such path, and if it grew one the install would
+# be unsequenced against the caller regardless.
+assert_no_pm_calls() { # NAME — fail if any package manager has been invoked
+  local name="$1"
+  if [ -s "$PM_CALL_LOG" ]; then
+    bad "$name" "$(cat "$PM_CALL_LOG")"
+    return 1
+  fi
   ok "$name"
 }
 

--- a/changelog.d/added/KEN-1012.md
+++ b/changelog.d/added/KEN-1012.md
@@ -1,1 +1,1 @@
-- Three settings for callers that stub what they wait on: `LINEAR_RETRY_BASE_DELAY`, `MUTATION_STABILITY_SETTLE`, and one decimal place on the `KENDEX_GITHUB_*_TIMEOUT` bounds.
+- Three waits become callable: `LINEAR_RETRY_BASE_DELAY`, `MUTATION_STABILITY_SETTLE`, and one decimal place on the `KENDEX_GITHUB_*_TIMEOUT` bounds.

--- a/changelog.d/added/KEN-1012.md
+++ b/changelog.d/added/KEN-1012.md
@@ -1,0 +1,1 @@
+- Three settings for callers that stub what they wait on: `LINEAR_RETRY_BASE_DELAY`, `MUTATION_STABILITY_SETTLE`, and one decimal place on the `KENDEX_GITHUB_*_TIMEOUT` bounds.

--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -47,6 +47,10 @@ Run `./scripts/github.sh --help` for the command list, or
 | `KENDEX_GITHUB_PR_VIEW_TIMEOUT` | Seconds allowed for `gh pr view` | `30` |
 | `KENDEX_GITHUB_GIT_HTTPS_FALLBACK` | `auto`, `never`, or `always` for `git-https-auth` | `auto` |
 
+The three `KENDEX_GITHUB_*_TIMEOUT` bounds are read to one decimal place, so
+`0.5` is half a second and `0` means no bound. A figure finer than a tenth is
+refused rather than rounded, and the command does not run.
+
 Values already set in the parent process win over project files. Tokens may be
 literal (`ghp_*`, `github_pat_*`, …) or `op://vault/item/field` references;
 keep them in `.env.local` rather than committed settings.

--- a/skills/github/kendex.settings.toml.example
+++ b/skills/github/kendex.settings.toml.example
@@ -23,11 +23,14 @@ GH_ISSUE_PATTERN = ""
 # project-root `verify.sh`, then to auto-detected build stacks.
 GH_VERIFY_CMD = ""
 
-# Seconds a 1Password token resolution may take.
+# Seconds a 1Password token resolution may take. Read to one decimal
+# place: 0 means no bound, and anything finer than a tenth is refused.
 KENDEX_GITHUB_OP_TIMEOUT = "10"
 
-# Seconds the `gh` auth preflight may take.
+# Seconds the `gh` auth preflight may take. Read to one decimal place:
+# 0 means no bound, and anything finer than a tenth is refused.
 KENDEX_GITHUB_AUTH_TIMEOUT = "10"
 
-# Seconds a single `pr-view` read may take.
+# Seconds a single `pr-view` read may take. Read to one decimal place:
+# 0 means no bound, and anything finer than a tenth is refused.
 KENDEX_GITHUB_PR_VIEW_TIMEOUT = "30"

--- a/skills/github/scripts/commands/pr-view.sh
+++ b/skills/github/scripts/commands/pr-view.sh
@@ -75,10 +75,11 @@ Errors:
   Emits structured JSON on stdout ({"status":..., "error":..., "detail":...,
   "exit_code":..., "number":...}) and exits nonzero. status is one of no_pr,
   auth_error, token_resolution_failed, token_resolution_timeout,
-  token_resolution_unavailable, auth_timeout, gh_timeout, bad_timeout, or
-  gh_error. bad_timeout exits 2 and names the KENDEX_GITHUB_*_TIMEOUT setting
-  whose value is not a number of seconds to one decimal place; nothing ran.
-  Raw gh/op detail is preserved in stderr and the JSON detail field.
+  token_resolution_unavailable, auth_timeout, gh_timeout, bad_timeout,
+  unsupported_flag, or gh_error. bad_timeout exits 2 and names the
+  KENDEX_GITHUB_*_TIMEOUT setting whose value is not a number of seconds to
+  one decimal place; nothing ran. Raw gh/op detail is preserved in stderr and
+  the JSON detail field.
 
 Examples:
   github.sh pr-view              # View PR for current branch

--- a/skills/github/scripts/commands/pr-view.sh
+++ b/skills/github/scripts/commands/pr-view.sh
@@ -75,8 +75,10 @@ Errors:
   Emits structured JSON on stdout ({"status":..., "error":..., "detail":...,
   "exit_code":..., "number":...}) and exits nonzero. status is one of no_pr,
   auth_error, token_resolution_failed, token_resolution_timeout,
-  token_resolution_unavailable, auth_timeout, gh_timeout, or gh_error. Raw
-  gh/op detail is preserved in stderr and the JSON detail field.
+  token_resolution_unavailable, auth_timeout, gh_timeout, bad_timeout, or
+  gh_error. bad_timeout exits 2 and names the KENDEX_GITHUB_*_TIMEOUT setting
+  whose value is not a number of seconds to one decimal place; nothing ran.
+  Raw gh/op detail is preserved in stderr and the JSON detail field.
 
 Examples:
   github.sh pr-view              # View PR for current branch
@@ -119,6 +121,24 @@ main() {
                 shift
                 ;;
         esac
+    done
+
+    # A bound the runner cannot read stops the command before it runs and
+    # comes back as 125 — with no output, because nothing ran, so at the call
+    # site it is indistinguishable from the command's own failure and an
+    # operator debugging a typo in their own setting is pointed at GitHub
+    # auth. Refused here by name, ahead of any request. The grammar is asked
+    # of the runner's own reader rather than restated.
+    local bound_name bound_value
+    for bound_name in KENDEX_GITHUB_AUTH_TIMEOUT KENDEX_GITHUB_OP_TIMEOUT \
+        KENDEX_GITHUB_PR_VIEW_TIMEOUT; do
+        bound_value="${!bound_name:-}"
+        [ -n "$bound_value" ] || continue
+        kendex_github_bound_ticks "$bound_value" >/dev/null && continue
+        emit_error_result "bad_timeout" \
+            "$bound_name is not a number of seconds to one decimal place" \
+            "$bound_value" 2
+        exit 2
     done
 
     local auth_out auth_err pr_out pr_err

--- a/skills/github/scripts/github.sh
+++ b/skills/github/scripts/github.sh
@@ -101,6 +101,7 @@ Configuration:
       Seconds allowed for GitHub auth preflight. Default: 10.
   KENDEX_GITHUB_PR_VIEW_TIMEOUT
       Seconds allowed for gh pr view in pr-view. Default: 30.
+      Every bound above is read to one decimal place; 0 means no bound.
   KENDEX_GITHUB_GIT_HTTPS_FALLBACK
       git-https-auth mode: auto, never, or always. Default: auto.
 

--- a/skills/github/scripts/github.sh
+++ b/skills/github/scripts/github.sh
@@ -101,7 +101,10 @@ Configuration:
       Seconds allowed for GitHub auth preflight. Default: 10.
   KENDEX_GITHUB_PR_VIEW_TIMEOUT
       Seconds allowed for gh pr view in pr-view. Default: 30.
-      Every bound above is read to one decimal place; 0 means no bound.
+
+  All three bounds above are read to one decimal place; 0 means no bound, and
+  a figure finer than a tenth is refused rather than rounded.
+
   KENDEX_GITHUB_GIT_HTTPS_FALLBACK
       git-https-auth mode: auto, never, or always. Default: auto.
 

--- a/skills/github/scripts/lib/bounded.sh
+++ b/skills/github/scripts/lib/bounded.sh
@@ -79,6 +79,11 @@ kendex_github_bound_ticks() { # SECONDS — tenths on stdout; 1 when unreadable
     *) whole="$seconds" frac=0 ;;
   esac
   case "$whole" in '' | *[!0-9]*) return 1 ;; esac
+  # Ten times an 18-digit whole part is past what signed 64-bit shell
+  # arithmetic holds, and the wrap lands on 0 for one such value in ten, which
+  # the runner below reads as "no bound" and then waits on forever. Refused on
+  # width here, before the multiply, so no call site inherits the wrap.
+  [ "${#whole}" -le 17 ] || return 1
   case "$frac" in [0-9]) ;; *) return 1 ;; esac
   printf '%s' "$(((10#$whole) * 10 + frac))"
 }

--- a/skills/github/scripts/lib/bounded.sh
+++ b/skills/github/scripts/lib/bounded.sh
@@ -88,7 +88,16 @@ kendex_github_run_bounded() {
   shift
 
   local restore_monitor=0 pid="" ticks=0 max_ticks status=0 target=""
-  max_ticks="$(kendex_github_bound_ticks "$seconds")" || return 125
+  if ! max_ticks="$(kendex_github_bound_ticks "$seconds")"; then
+    # 125 arrives having run nothing, so there is no output to explain it and
+    # most callers can only pass it upward — an auth check that never ran, a
+    # token that never resolved, and no name for the setting behind either.
+    # Said once, here, where the grammar is read: no call site can go quiet
+    # again by forgetting to say it.
+    printf "bounded: '%s' is not a number of seconds to one decimal place; nothing ran\n" \
+      "$seconds" >&2
+    return 125
+  fi
   if [ "$max_ticks" -eq 0 ]; then
     "$@"
     return

--- a/skills/github/scripts/lib/bounded.sh
+++ b/skills/github/scripts/lib/bounded.sh
@@ -63,23 +63,32 @@ _kendex_github_forward_bounded_signal() {
   case "$signal" in HUP) return 129 ;; INT) return 130 ;; TERM) return 143 ;; esac
 }
 
-kendex_github_run_bounded() {
-  local seconds="$1"
-  shift
-
-  # The bound is polled on a 0.1s tick below, so it is read to one decimal
-  # place and no finer: a figure the poll could not honour is junk, not a
-  # tighter bound. A leading zero is decimal, never octal.
-  local whole frac
+# The one reading of the bound grammar. The bound is polled on a 0.1s tick
+# below, so it is read to one decimal place and no finer: a figure the poll
+# could not honour is junk, not a tighter bound. A leading zero is decimal,
+# never octal.
+#
+# Separate from the runner because a caller has to be able to tell a bound it
+# cannot read from a command that failed, and it may not ask by running the
+# command: 125 arrives after the command did not run, so there is no output to
+# explain it. Asking here keeps one judge of the grammar.
+kendex_github_bound_ticks() { # SECONDS — tenths on stdout; 1 when unreadable
+  local seconds="$1" whole frac
   case "$seconds" in
     *.*) whole="${seconds%.*}" frac="${seconds#*.}" ;;
     *) whole="$seconds" frac=0 ;;
   esac
-  case "$whole" in '' | *[!0-9]*) return 125 ;; esac
-  case "$frac" in [0-9]) ;; *) return 125 ;; esac
+  case "$whole" in '' | *[!0-9]*) return 1 ;; esac
+  case "$frac" in [0-9]) ;; *) return 1 ;; esac
+  printf '%s' "$(((10#$whole) * 10 + frac))"
+}
+
+kendex_github_run_bounded() {
+  local seconds="$1"
+  shift
 
   local restore_monitor=0 pid="" ticks=0 max_ticks status=0 target=""
-  max_ticks=$(((10#$whole) * 10 + frac))
+  max_ticks="$(kendex_github_bound_ticks "$seconds")" || return 125
   if [ "$max_ticks" -eq 0 ]; then
     "$@"
     return

--- a/skills/github/scripts/lib/bounded.sh
+++ b/skills/github/scripts/lib/bounded.sh
@@ -67,16 +67,24 @@ kendex_github_run_bounded() {
   local seconds="$1"
   shift
 
+  # The bound is polled on a 0.1s tick below, so it is read to one decimal
+  # place and no finer: a figure the poll could not honour is junk, not a
+  # tighter bound. A leading zero is decimal, never octal.
+  local whole frac
   case "$seconds" in
-    ''|*[!0-9]*) return 125 ;;
+    *.*) whole="${seconds%.*}" frac="${seconds#*.}" ;;
+    *) whole="$seconds" frac=0 ;;
   esac
-  seconds=$((10#$seconds))
-  if [ "$seconds" -eq 0 ]; then
+  case "$whole" in '' | *[!0-9]*) return 125 ;; esac
+  case "$frac" in [0-9]) ;; *) return 125 ;; esac
+
+  local restore_monitor=0 pid="" ticks=0 max_ticks status=0 target=""
+  max_ticks=$(((10#$whole) * 10 + frac))
+  if [ "$max_ticks" -eq 0 ]; then
     "$@"
     return
   fi
 
-  local restore_monitor=0 pid="" ticks=0 max_ticks status=0 target=""
   local old_hup old_int old_term
   old_hup="$(trap -p HUP)"
   old_int="$(trap -p INT)"
@@ -96,7 +104,6 @@ kendex_github_run_bounded() {
   if ! kill -0 -- "$target" 2>/dev/null; then
     target="$pid"
   fi
-  max_ticks=$((seconds * 10))
 
   while kill -0 "$pid" 2>/dev/null; do
     if [ "$ticks" -ge "$max_ticks" ]; then

--- a/skills/github/scripts/lib/gh-auth.sh
+++ b/skills/github/scripts/lib/gh-auth.sh
@@ -87,6 +87,15 @@ kendex_github_resolve_op_reference_to_var() {
       export KENDEX_GITHUB_TOKEN_ERROR_TYPE="token_resolution_timeout"
       export KENDEX_GITHUB_TOKEN_ERROR="Timed out resolving ${label} 1Password reference after ${op_timeout}s"
       ;;
+    125)
+      # op never ran, so this is a resolution that was never attempted, not
+      # one that failed. The capture above folded the runner's own line into
+      # op_output, and both callers take the failure as || true: the token is
+      # dropped and the command runs unauthenticated with nothing said.
+      echo "Warning: KENDEX_GITHUB_OP_TIMEOUT is '${op_timeout}', not a number of seconds to one decimal place; ${label} was never resolved." >&2
+      export KENDEX_GITHUB_TOKEN_ERROR_TYPE="token_resolution_unavailable"
+      export KENDEX_GITHUB_TOKEN_ERROR="KENDEX_GITHUB_OP_TIMEOUT is '${op_timeout}', not a number of seconds to one decimal place, so ${label} was never resolved"
+      ;;
     *)
       export KENDEX_GITHUB_TOKEN_ERROR_TYPE="token_resolution_failed"
       export KENDEX_GITHUB_TOKEN_ERROR="Failed to resolve ${label} 1Password reference"
@@ -106,6 +115,16 @@ kendex_github_sanitize_gh_env() {
     return 0
   else
     auth_status=$?
+  fi
+  # 124 is the bound expiring, 125 a bound the runner could not read: neither
+  # check reached gh, and the keyring probe below runs under the same bound,
+  # so falling through spends that probe and then returns 0 as if the token
+  # had been judged sound. The runner names an unreadable bound on its own
+  # stderr, but these checks discard that with gh's chatter, and this prologue
+  # runs ahead of every subcommand — so the 125 arm says it again here.
+  if [[ "$auth_status" -eq 125 ]]; then
+    echo "Warning: KENDEX_GITHUB_AUTH_TIMEOUT is '${KENDEX_GITHUB_AUTH_TIMEOUT:-10}', not a number of seconds to one decimal place; GH_TOKEN/GITHUB_TOKEN went unchecked." >&2
+    return 0
   fi
   [[ "$auth_status" -eq 124 ]] && return 0
   if [[ "${KENDEX_GITHUB_SELECTED_TOKEN_SOURCE:-}" == "GH_BOT_TOKEN" ]]; then

--- a/skills/github/scripts/lib/gh-auth.sh
+++ b/skills/github/scripts/lib/gh-auth.sh
@@ -21,7 +21,7 @@ kendex_github_has_env_token() {
 kendex_github_token_auth_status() {
   kendex_github_has_env_token || return 1
   local auth_timeout="${KENDEX_GITHUB_AUTH_TIMEOUT:-10}"
-  kendex_github_run_bounded "$auth_timeout" gh api user --jq '.login' >/dev/null
+  kendex_github_run_bounded "$auth_timeout" gh api user --jq '.login' >/dev/null 2>&1
 }
 
 kendex_github_token_auth_status_capture() {
@@ -59,7 +59,7 @@ kendex_github_auth_status_capture() {
 
 kendex_github_keyring_auth_status() {
   local auth_timeout="${KENDEX_GITHUB_AUTH_TIMEOUT:-10}"
-  kendex_github_run_bounded "$auth_timeout" env -u GH_TOKEN -u GITHUB_TOKEN gh auth status >/dev/null
+  kendex_github_run_bounded "$auth_timeout" env -u GH_TOKEN -u GITHUB_TOKEN gh auth status >/dev/null 2>&1
 }
 
 kendex_github_resolve_op_reference_to_var() {

--- a/skills/github/scripts/lib/gh-auth.sh
+++ b/skills/github/scripts/lib/gh-auth.sh
@@ -75,6 +75,20 @@ kendex_github_resolve_op_reference_to_var() {
     return 1
   fi
 
+  # Asked of the runner's own reader before anything runs: the runner hands
+  # back the wrapped command's status unchanged, so an op exiting 125 under a
+  # good bound is indistinguishable from a bound it could not read. Nothing is
+  # invoked here, so this is a resolution never attempted, and it carries its
+  # own status because token_resolution_unavailable means op is absent and
+  # github-api.sh branches on that to say install it. Three call sites read it:
+  # two here, both dropping the token silently, and github-api.sh.
+  if ! kendex_github_bound_ticks "$op_timeout" >/dev/null; then
+    echo "Warning: KENDEX_GITHUB_OP_TIMEOUT is '${op_timeout}', not a number of seconds to one decimal place; ${label} was never resolved." >&2
+    export KENDEX_GITHUB_TOKEN_ERROR_TYPE="token_resolution_bad_timeout"
+    export KENDEX_GITHUB_TOKEN_ERROR="KENDEX_GITHUB_OP_TIMEOUT is '${op_timeout}', not a number of seconds to one decimal place, so ${label} was never resolved"
+    return 1
+  fi
+
   op_output=$(kendex_github_run_bounded "$op_timeout" op read "$ref" 2>&1) || op_status=$?
 
   if [[ "$op_status" -eq 0 && -n "$op_output" ]]; then
@@ -86,18 +100,6 @@ kendex_github_resolve_op_reference_to_var() {
     124)
       export KENDEX_GITHUB_TOKEN_ERROR_TYPE="token_resolution_timeout"
       export KENDEX_GITHUB_TOKEN_ERROR="Timed out resolving ${label} 1Password reference after ${op_timeout}s"
-      ;;
-    125)
-      # op never ran, so this is a resolution that was never attempted, not
-      # one that failed and not one 1Password was missing for. Its own status,
-      # because token_resolution_unavailable means the op binary is absent and
-      # github-api.sh branches on that to tell the operator to install it.
-      # Three call sites: two here, both under || true, where the capture above
-      # folded the runner's own line into op_output and the token is dropped
-      # silently; and github-api.sh, which reads the status.
-      echo "Warning: KENDEX_GITHUB_OP_TIMEOUT is '${op_timeout}', not a number of seconds to one decimal place; ${label} was never resolved." >&2
-      export KENDEX_GITHUB_TOKEN_ERROR_TYPE="token_resolution_bad_timeout"
-      export KENDEX_GITHUB_TOKEN_ERROR="KENDEX_GITHUB_OP_TIMEOUT is '${op_timeout}', not a number of seconds to one decimal place, so ${label} was never resolved"
       ;;
     *)
       export KENDEX_GITHUB_TOKEN_ERROR_TYPE="token_resolution_failed"
@@ -114,26 +116,24 @@ kendex_github_sanitize_gh_env() {
   command -v gh >/dev/null 2>&1 || return 0
   [[ -z "${GH_TOKEN:-}${GITHUB_TOKEN:-}" ]] && return 0
   local auth_status=0
+  # A bound the runner cannot read means gh is never asked, and the check then
+  # says nothing about the token. Asked of the reader here, not inferred from
+  # a 125, which is the wrapped command's own status just as often.
+  #
+  # It reports and leaves the trust decision where it was: a diagnostic, not a
+  # fail-closed control. The keyring probe below runs under the same unreadable
+  # bound and could not have succeeded, and refusing outright would break all
+  # 24 subcommands on a typo. What it adds is which setting went unchecked.
+  if ! kendex_github_bound_ticks "${KENDEX_GITHUB_AUTH_TIMEOUT:-10}" >/dev/null; then
+    echo "Warning: KENDEX_GITHUB_AUTH_TIMEOUT is '${KENDEX_GITHUB_AUTH_TIMEOUT:-10}', not a number of seconds to one decimal place; GH_TOKEN/GITHUB_TOKEN went unchecked." >&2
+    return 0
+  fi
   if kendex_github_auth_status; then
     return 0
   else
     auth_status=$?
   fi
-  # 124 and 125 are not the same answer. 124 is gh started and killed at the
-  # deadline, which is the one status here that proves gh was invoked; 125 is
-  # a bound the runner could not read, so gh was never asked and the check
-  # says nothing about the token.
-  #
-  # This arm reports that and leaves the trust decision exactly where it was:
-  # a diagnostic, not a fail-closed control. The keyring probe below runs
-  # under the same unreadable bound and could not have succeeded, and refusing
-  # outright would break all 24 subcommands on a typo. What it adds to the
-  # runner's own line is which setting carried the value and what went
-  # unchecked because of it.
-  if [[ "$auth_status" -eq 125 ]]; then
-    echo "Warning: KENDEX_GITHUB_AUTH_TIMEOUT is '${KENDEX_GITHUB_AUTH_TIMEOUT:-10}', not a number of seconds to one decimal place; GH_TOKEN/GITHUB_TOKEN went unchecked." >&2
-    return 0
-  fi
+  # 124 is gh invoked and killed at the deadline: nothing against the token.
   [[ "$auth_status" -eq 124 ]] && return 0
   if [[ "${KENDEX_GITHUB_SELECTED_TOKEN_SOURCE:-}" == "GH_BOT_TOKEN" ]]; then
     return 0

--- a/skills/github/scripts/lib/gh-auth.sh
+++ b/skills/github/scripts/lib/gh-auth.sh
@@ -21,7 +21,7 @@ kendex_github_has_env_token() {
 kendex_github_token_auth_status() {
   kendex_github_has_env_token || return 1
   local auth_timeout="${KENDEX_GITHUB_AUTH_TIMEOUT:-10}"
-  kendex_github_run_bounded "$auth_timeout" gh api user --jq '.login' >/dev/null 2>&1
+  kendex_github_run_bounded "$auth_timeout" gh api user --jq '.login' >/dev/null
 }
 
 kendex_github_token_auth_status_capture() {
@@ -41,7 +41,7 @@ kendex_github_auth_status() {
     return $?
   fi
 
-  kendex_github_run_bounded "$auth_timeout" gh auth status >/dev/null 2>&1
+  kendex_github_run_bounded "$auth_timeout" gh auth status >/dev/null
 }
 
 kendex_github_auth_status_capture() {
@@ -59,7 +59,7 @@ kendex_github_auth_status_capture() {
 
 kendex_github_keyring_auth_status() {
   local auth_timeout="${KENDEX_GITHUB_AUTH_TIMEOUT:-10}"
-  kendex_github_run_bounded "$auth_timeout" env -u GH_TOKEN -u GITHUB_TOKEN gh auth status >/dev/null 2>&1
+  kendex_github_run_bounded "$auth_timeout" env -u GH_TOKEN -u GITHUB_TOKEN gh auth status >/dev/null
 }
 
 kendex_github_resolve_op_reference_to_var() {
@@ -89,11 +89,14 @@ kendex_github_resolve_op_reference_to_var() {
       ;;
     125)
       # op never ran, so this is a resolution that was never attempted, not
-      # one that failed. The capture above folded the runner's own line into
-      # op_output, and both callers take the failure as || true: the token is
-      # dropped and the command runs unauthenticated with nothing said.
+      # one that failed and not one 1Password was missing for. Its own status,
+      # because token_resolution_unavailable means the op binary is absent and
+      # github-api.sh branches on that to tell the operator to install it.
+      # Three call sites: two here, both under || true, where the capture above
+      # folded the runner's own line into op_output and the token is dropped
+      # silently; and github-api.sh, which reads the status.
       echo "Warning: KENDEX_GITHUB_OP_TIMEOUT is '${op_timeout}', not a number of seconds to one decimal place; ${label} was never resolved." >&2
-      export KENDEX_GITHUB_TOKEN_ERROR_TYPE="token_resolution_unavailable"
+      export KENDEX_GITHUB_TOKEN_ERROR_TYPE="token_resolution_bad_timeout"
       export KENDEX_GITHUB_TOKEN_ERROR="KENDEX_GITHUB_OP_TIMEOUT is '${op_timeout}', not a number of seconds to one decimal place, so ${label} was never resolved"
       ;;
     *)
@@ -116,12 +119,17 @@ kendex_github_sanitize_gh_env() {
   else
     auth_status=$?
   fi
-  # 124 is the bound expiring, 125 a bound the runner could not read: neither
-  # check reached gh, and the keyring probe below runs under the same bound,
-  # so falling through spends that probe and then returns 0 as if the token
-  # had been judged sound. The runner names an unreadable bound on its own
-  # stderr, but these checks discard that with gh's chatter, and this prologue
-  # runs ahead of every subcommand — so the 125 arm says it again here.
+  # 124 and 125 are not the same answer. 124 is gh started and killed at the
+  # deadline, which is the one status here that proves gh was invoked; 125 is
+  # a bound the runner could not read, so gh was never asked and the check
+  # says nothing about the token.
+  #
+  # This arm reports that and leaves the trust decision exactly where it was:
+  # a diagnostic, not a fail-closed control. The keyring probe below runs
+  # under the same unreadable bound and could not have succeeded, and refusing
+  # outright would break all 24 subcommands on a typo. What it adds to the
+  # runner's own line is which setting carried the value and what went
+  # unchecked because of it.
   if [[ "$auth_status" -eq 125 ]]; then
     echo "Warning: KENDEX_GITHUB_AUTH_TIMEOUT is '${KENDEX_GITHUB_AUTH_TIMEOUT:-10}', not a number of seconds to one decimal place; GH_TOKEN/GITHUB_TOKEN went unchecked." >&2
     return 0

--- a/skills/github/scripts/lib/github-api.sh
+++ b/skills/github/scripts/lib/github-api.sh
@@ -312,6 +312,10 @@ load_bot_token() {
             echo "Warning: GH_BOT_TOKEN is a 1Password reference but 'op' CLI not found" >&2
             echo "  Install: https://developer.1password.com/docs/cli/get-started/" >&2
             return 0
+        elif [ "${KENDEX_GITHUB_TOKEN_ERROR_TYPE:-}" = "token_resolution_bad_timeout" ]; then
+            # op was never asked, so neither install advice nor a sign-in
+            # prompt applies; the resolver already named the setting.
+            return 0
         else
             echo "Warning: Failed to resolve 1Password reference. Run: op signin" >&2
             return 0

--- a/skills/github/tests/bounded-signal.test.sh
+++ b/skills/github/tests/bounded-signal.test.sh
@@ -109,5 +109,37 @@ check_signal HUP 129
 check_signal INT 130
 check_signal TERM 143
 
+# The bound is enforced on a 0.1s tick, so a caller may ask for tenths. Junk
+# is refused with 125 rather than run unbounded: a bound that silently stops
+# bounding is how a hung `gh` becomes a hung lane.
+check_bound() { # LABEL BOUND EXPECTED-RC [COMMAND...]
+  local label="$1" bound="$2" expected="$3" rc=0
+  shift 3
+  [ "$#" -gt 0 ] || set -- sleep 30
+  BOUNDED="$BOUNDED" BOUND="$bound" bash -c '
+    source "$BOUNDED"
+    kendex_github_run_bounded "$BOUND" "$@"
+  ' bash "$@" >/dev/null 2>&1 || rc=$?
+  if [[ "$rc" -eq "$expected" ]]; then
+    PASS=$((PASS + 1)); printf '  ok    %s\n' "$label"
+  else
+    FAIL=$((FAIL + 1)); printf '  FAIL  %s: expected %s, got %s\n' "$label" "$expected" "$rc"
+  fi
+}
+
+echo "=== bounded runner bound parsing ==="
+check_bound "a tenth-of-a-second bound times out" 0.2 124
+check_bound "a whole-second bound times out" 1 124
+# Under octal arithmetic 08 is not a number at all, so a command that finishes
+# well inside the bound separates the two readings without waiting out either.
+check_bound "a leading-zero bound is decimal, not octal" 08 0 true
+check_bound "a two-place bound is refused" 0.25 125
+check_bound "a bare decimal point is refused" . 125
+check_bound "a trailing decimal point is refused" 5. 125
+check_bound "a non-numeric bound is refused" soon 125
+# Sub-second bounds must not have become "no bound at all": a zero bound is
+# the documented way to ask for that, and nothing else may reach it.
+check_bound "a zero bound runs the command unbounded" 0.0 0 true
+
 printf '\npass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/github/tests/bounded-signal.test.sh
+++ b/skills/github/tests/bounded-signal.test.sh
@@ -137,6 +137,9 @@ check_bound "a two-place bound is refused" 0.25 125
 check_bound "a bare decimal point is refused" . 125
 check_bound "a trailing decimal point is refused" 5. 125
 check_bound "a non-numeric bound is refused" soon 125
+# Width is part of the grammar: this one multiplies out to exactly 0 in signed
+# 64-bit arithmetic, and 0 is the documented way to ask for no bound at all.
+check_bound "a bound too wide for the arithmetic is refused" 1844674407370955161.6 125 true
 # Sub-second bounds must not have become "no bound at all": a zero bound is
 # the documented way to ask for that, and nothing else may reach it.
 check_bound "a zero bound runs the command unbounded" 0.0 0 true

--- a/skills/github/tests/env-first-auth.sh
+++ b/skills/github/tests/env-first-auth.sh
@@ -25,6 +25,17 @@ assert_eq() {
   fi
 }
 
+assert_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        wanted: %s\n        got:    %s\n' "$name" "$needle" "$haystack"
+  fi
+}
+
 assert_file_missing() {
   local path="$1" name="$2"
   if [[ ! -e "$path" ]]; then
@@ -54,6 +65,8 @@ chmod +x "$TMP_ROOT/bin/op"
 cat > "$TMP_ROOT/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+
+[[ -z "${STUB_GH_CALLS:-}" ]] || printf '%s\n' "$*" >>"$STUB_GH_CALLS"
 
 _token_ok() {
   local tok="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
@@ -323,6 +336,34 @@ else
   printf '  FAIL  the refusal names the identity fallback it is preventing\n        stderr: %s\n' "$(cat "$TMP_ROOT/partial-bot.err")"
 fi
 rm -f "$TMP_ROOT/repo/kendex.settings.toml" "$TMP_ROOT/repo/.env.local"
+
+# The prologue sanitizer runs ahead of every subcommand, and its checks are
+# bounded. A bound the runner cannot read answers 125 having invoked nothing —
+# not the 124 the timeout arm reads — and the keyring probe under the same
+# bound answers 125 too, so the function used to reach its unconditional
+# `return 0` with gh never called: an auth guard reporting a token sound
+# having looked at nothing, and a bad token surviving into every later call.
+sanitize_run() { # env-assignment... — writes sanitize.calls and sanitize.err
+  : >"$TMP_ROOT/sanitize.calls"
+  (cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" \
+    env STUB_GH_CALLS="$TMP_ROOT/sanitize.calls" STUB_KEYRING_OK=1 \
+      GH_TOKEN=ghp_BADENV "$@" bash -c '
+        source "'"$REPO_ROOT"'/skills/github/scripts/lib/gh-auth.sh"
+        kendex_github_sanitize_gh_env
+      ') 2>"$TMP_ROOT/sanitize.err"
+}
+gh_reached() { [[ -s "$TMP_ROOT/sanitize.calls" ]] && echo invoked || echo silent; }
+
+sanitize_run
+assert_eq "$(gh_reached)" "invoked" "a readable bound puts the token in front of gh"
+assert_contains "$(cat "$TMP_ROOT/sanitize.err")" \
+  "unsetting them and using gh keyring auth" \
+  "and a token gh rejects is dropped for the keyring, out loud"
+
+sanitize_run KENDEX_GITHUB_AUTH_TIMEOUT=2.55
+assert_eq "$(gh_reached)" "silent" "an unreadable bound reaches no gh call at all"
+assert_contains "$(cat "$TMP_ROOT/sanitize.err")" "'2.55'" \
+  "and the run names the bound it could not read rather than passing silently"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/github/tests/env-first-auth.sh
+++ b/skills/github/tests/env-first-auth.sh
@@ -54,6 +54,8 @@ cat > "$TMP_ROOT/bin/op" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
 printf 'op called: %s\n' "\$*" >>"$TMP_ROOT/op.calls"
+# Lets a case give op an exit status of its own, 125 included.
+[[ -z "\${STUB_OP_EXIT:-}" ]] || exit "\$STUB_OP_EXIT"
 if [[ "\${1:-}" == "read" && "\${2:-}" == "op://vault/github/bot" ]]; then
   printf '%s\n' 'ghs_RESOLVED123'
   exit 0
@@ -67,6 +69,13 @@ cat > "$TMP_ROOT/bin/gh" <<'EOF'
 set -euo pipefail
 
 [[ -z "${STUB_GH_CALLS:-}" ]] || printf '%s\n' "$*" >>"$STUB_GH_CALLS"
+
+# Lets a case give gh an exit status of its own, 125 included, for the calls
+# that carry a token. The keyring probe runs with both names unset and is
+# unaffected, so a case can fail the token check and still reach it.
+if [[ -n "${STUB_GH_TOKEN_EXIT:-}" && -n "${GH_TOKEN:-}${GITHUB_TOKEN:-}" ]]; then
+  exit "$STUB_GH_TOKEN_EXIT"
+fi
 
 _token_ok() {
   local tok="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
@@ -364,6 +373,31 @@ sanitize_run KENDEX_GITHUB_AUTH_TIMEOUT=2.55
 assert_eq "$(gh_reached)" "silent" "an unreadable bound reaches no gh call at all"
 assert_contains "$(cat "$TMP_ROOT/sanitize.err")" "'2.55'" \
   "and the run names the bound it could not read rather than passing silently"
+
+# 125 is also gh's own to return. The runner hands the wrapped command's
+# status back unchanged, so reading 125 as proof the bound was unreadable
+# tells an operator to fix a setting that is fine and leaves the token
+# unchecked on a failure that was really gh's.
+sanitize_run STUB_GH_TOKEN_EXIT=125
+assert_contains "$(cat "$TMP_ROOT/sanitize.err")" \
+  "unsetting them and using gh keyring auth" \
+  "a gh that exits 125 under a readable bound is an ordinary auth failure"
+
+# The same collision on the op side. The status is what github-api.sh branches
+# on, so calling op's own 125 a bad setting suppresses the "Run: op signin"
+# advice for a resolution that really was attempted and really did fail.
+op_error_type() { # env-assignment... — the resolver's error type on stdout
+  (cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" env "$@" bash -c '
+      source "'"$REPO_ROOT"'/skills/github/scripts/lib/gh-auth.sh"
+      kendex_github_resolve_op_reference_to_var "op://vault/github/bot" "GitHub token" tok || true
+      printf "%s" "${KENDEX_GITHUB_TOKEN_ERROR_TYPE:-}"
+    ') 2>/dev/null
+}
+
+assert_eq "$(op_error_type STUB_OP_EXIT=125)" "token_resolution_failed" \
+  "an op that exits 125 under a readable bound is an ordinary resolution failure"
+assert_eq "$(op_error_type KENDEX_GITHUB_OP_TIMEOUT=2.55)" "token_resolution_bad_timeout" \
+  "and an unreadable KENDEX_GITHUB_OP_TIMEOUT still names the setting it named before"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/github/tests/git-https-auth.sh
+++ b/skills/github/tests/git-https-auth.sh
@@ -134,6 +134,20 @@ assert_not_contains "$disabled" "!gh auth git-credential" "fallback can be disab
 unauthenticated="$(STUB_GH_AUTH_OK=0 run_helper -C "$ssh_repo" config --get-all credential.helper || true)"
 assert_not_contains "$unauthenticated" "!gh auth git-credential" "invalid gh auth leaves SSH path unchanged"
 
+# A bound the runner cannot read is not an answer about auth: gh is never
+# asked, and this wrapper falls through to plain git with the rewrite it
+# exists for skipped. Driven with no env token, which is the ordinary
+# `gh auth login` shape and the one kendex_github_sanitize_gh_env returns from
+# before its own arm can speak — so if the probe does not say it here, the
+# rewrite goes missing on every stream with nothing said anywhere.
+bad_bound_err="$TMP_ROOT/bad-bound.err"
+bad_bound="$(GH_TOKEN= GITHUB_TOKEN= KENDEX_GITHUB_AUTH_TIMEOUT=2.55 \
+  run_helper -C "$ssh_repo" config --get-all credential.helper 2>"$bad_bound_err" || true)"
+assert_not_contains "$bad_bound" "!gh auth git-credential" \
+  "an unreadable auth bound leaves the SSH path unchanged"
+assert_contains "$(cat "$bad_bound_err")" "2.55" \
+  "and the skipped rewrite names the bound rather than passing in silence"
+
 explicit="$(
   source "$REPO_ROOT/skills/github/scripts/lib/gh-auth.sh"
   if kendex_github_git_should_use_https_fallback ls-remote git@github.com:owner/repo.git; then

--- a/skills/github/tests/pr-view.sh
+++ b/skills/github/tests/pr-view.sh
@@ -63,7 +63,7 @@ case "${1:-}" in
   auth)
     if [[ "${2:-}" == "status" ]]; then
       if [[ "${STUB_AUTH_SLEEP:-0}" == "1" ]]; then
-        sleep 5
+        sleep 2
       fi
       if [[ "${STUB_AUTH_STATUS_FAIL:-0}" == "1" ]]; then
         echo "keyring default failed" >&2
@@ -80,7 +80,7 @@ case "${1:-}" in
   api)
     if [[ "${2:-}" == "user" ]]; then
       if [[ "${STUB_API_USER_SLEEP:-0}" == "1" ]]; then
-        sleep 5
+        sleep 2
       fi
       _auth_ok || { echo "HTTP 401: Bad credentials" >&2; exit 1; }
       echo "test-user"
@@ -100,7 +100,7 @@ case "${1:-}" in
           exit 1
           ;;
         hang)
-          sleep 5
+          sleep 2
           ;;
         *)
           echo '{"number":42,"state":"OPEN"}'
@@ -121,7 +121,7 @@ set -euo pipefail
 printf 'op called: %s\n' "$*" >>"${STUB_OP_CALLS:?}"
 case "${STUB_OP_MODE:-fail}" in
   slow)
-    sleep 5
+    sleep 2
     ;;
   ok)
     echo "ghs_VALIDBOT123"
@@ -223,7 +223,7 @@ assert_contains "$(jq -r .detail <<<"$output")" "no pull requests found" "no PR 
 
 stderr="$TMP_ROOT/auth-timeout.err"
 set +e
-output=$(run_pr_view STUB_AUTH_SLEEP=1 KENDEX_GITHUB_AUTH_TIMEOUT=1 2>"$stderr")
+output=$(run_pr_view STUB_AUTH_SLEEP=1 KENDEX_GITHUB_AUTH_TIMEOUT=0.2 2>"$stderr")
 rc=$?
 set -e
 assert_eq "$rc" "124" "auth preflight timeout exits 124" "$stderr"
@@ -232,7 +232,7 @@ assert_eq "$(jq -r .status <<<"$output")" "auth_timeout" "auth timeout emits str
 stderr="$TMP_ROOT/auth-timeout-no-utility.err"
 set +e
 output=$(without_timeout_utility run_pr_view \
-  STUB_AUTH_SLEEP=1 KENDEX_GITHUB_AUTH_TIMEOUT=1 2>"$stderr")
+  STUB_AUTH_SLEEP=1 KENDEX_GITHUB_AUTH_TIMEOUT=0.2 2>"$stderr")
 rc=$?
 set -e
 assert_eq "$rc" "124" "auth timeout works without the timeout utility" "$stderr"
@@ -251,7 +251,7 @@ assert_eq "$(jq -r .number <<<"$output")" "42" \
 
 stderr="$TMP_ROOT/api-user-auth-timeout.err"
 set +e
-output=$(run_pr_view GH_TOKEN=ghs_VALIDBOT123 STUB_API_USER_SLEEP=1 KENDEX_GITHUB_AUTH_TIMEOUT=1 2>"$stderr")
+output=$(run_pr_view GH_TOKEN=ghs_VALIDBOT123 STUB_API_USER_SLEEP=1 KENDEX_GITHUB_AUTH_TIMEOUT=0.2 2>"$stderr")
 rc=$?
 set -e
 assert_eq "$rc" "124" "env-token auth preflight timeout exits 124" "$stderr"
@@ -267,7 +267,7 @@ assert_eq "$(jq -r .number <<<"$output")" "42" "valid selected token preserves g
 
 stderr="$TMP_ROOT/pr-view-timeout.err"
 set +e
-output=$(run_pr_view STUB_PR_MODE=hang KENDEX_GITHUB_PR_VIEW_TIMEOUT=1 2>"$stderr")
+output=$(run_pr_view STUB_PR_MODE=hang KENDEX_GITHUB_PR_VIEW_TIMEOUT=0.2 2>"$stderr")
 rc=$?
 set -e
 assert_eq "$rc" "124" "gh pr view timeout exits 124" "$stderr"
@@ -276,7 +276,7 @@ assert_eq "$(jq -r .status <<<"$output")" "gh_timeout" "gh timeout emits structu
 stderr="$TMP_ROOT/pr-view-timeout-no-utility.err"
 set +e
 output=$(without_timeout_utility run_pr_view \
-  STUB_PR_MODE=hang KENDEX_GITHUB_PR_VIEW_TIMEOUT=1 2>"$stderr")
+  STUB_PR_MODE=hang KENDEX_GITHUB_PR_VIEW_TIMEOUT=0.2 2>"$stderr")
 rc=$?
 set -e
 assert_eq "$rc" "124" "gh pr view timeout works without the timeout utility" "$stderr"
@@ -337,7 +337,7 @@ assert_eq "$(jq -r .status <<<"$output")" "token_resolution_failed" "token failu
 
 stderr="$TMP_ROOT/op-timeout.err"
 set +e
-output=$(run_pr_view STUB_AUTH_OK=0 STUB_OP_MODE=slow KENDEX_GITHUB_OP_TIMEOUT=1 2>"$stderr")
+output=$(run_pr_view STUB_AUTH_OK=0 STUB_OP_MODE=slow KENDEX_GITHUB_OP_TIMEOUT=0.2 2>"$stderr")
 rc=$?
 set -e
 assert_eq "$rc" "3" "token resolution timeout exits auth code" "$stderr"
@@ -346,7 +346,7 @@ assert_eq "$(jq -r .status <<<"$output")" "token_resolution_timeout" "token time
 stderr="$TMP_ROOT/op-timeout-no-utility.err"
 set +e
 output=$(without_timeout_utility run_pr_view \
-  STUB_AUTH_OK=0 STUB_OP_MODE=slow KENDEX_GITHUB_OP_TIMEOUT=1 2>"$stderr")
+  STUB_AUTH_OK=0 STUB_OP_MODE=slow KENDEX_GITHUB_OP_TIMEOUT=0.2 2>"$stderr")
 rc=$?
 set -e
 assert_eq "$rc" "3" "op timeout works without the timeout utility" "$stderr"

--- a/skills/github/tests/pr-view.sh
+++ b/skills/github/tests/pr-view.sh
@@ -293,6 +293,32 @@ assert_eq "$rc" "0" "gh timeout accepts a leading-zero decimal" "$stderr"
 assert_eq "$(jq -r .number <<<"$output")" "42" \
   "leading-zero gh bound returns PR JSON" "$stderr"
 
+# A bound outside the grammar the help advertises. The runner refuses it with
+# 125 having run nothing, so without a mapping here the caller reads a
+# configuration typo as a GitHub auth failure or as gh itself failing — the
+# one surface an operator debugging their own setting actually sees. Every
+# name the loop checks is driven, because a name dropped from it would fail
+# exactly this way again.
+for bound in KENDEX_GITHUB_AUTH_TIMEOUT KENDEX_GITHUB_OP_TIMEOUT \
+  KENDEX_GITHUB_PR_VIEW_TIMEOUT; do
+  stderr="$TMP_ROOT/bad-bound-$bound.err"
+  calls="$TMP_ROOT/bad-bound-$bound.calls"
+  : >"$calls"
+  set +e
+  output=$(run_pr_view "$bound=2.55" STUB_GH_CALLS="$calls" 2>"$stderr")
+  rc=$?
+  set -e
+  assert_eq "$rc" "2" "an unreadable $bound exits 2" "$stderr"
+  assert_eq "$(jq -r .status <<<"$output")" "bad_timeout" \
+    "an unreadable $bound emits the configuration status" "$stderr"
+  assert_contains "$(jq -r .error <<<"$output")" "$bound" \
+    "the refusal names $bound" "$stderr"
+  assert_eq "$(jq -r .detail <<<"$output")" "2.55" \
+    "the refusal carries the value it rejected for $bound" "$stderr"
+  assert_eq "$(wc -c <"$calls")" "0" \
+    "an unreadable $bound reaches no gh call" "$stderr"
+done
+
 rm -f "$TMP_ROOT/op.calls"
 stderr="$TMP_ROOT/inherited-gh-token-op.err"
 set +e

--- a/skills/growth-guards/tests/commit-msg.test.sh
+++ b/skills/growth-guards/tests/commit-msg.test.sh
@@ -28,10 +28,18 @@ git -C "$R" -c init.defaultBranch=main init -q
 git -C "$R" config user.email test@example.com
 git -C "$R" config user.name test
 
+# Most runs below settle a rule the script carries itself and configure it
+# through the environment, so they resolve no setting from a file — and the
+# sentinel spends none of the walk that would find nothing. The blocks that
+# do put a file in front of the script clear NO_SETTINGS around themselves;
+# a caller's own assignment comes last, so it still wins.
+NO_SETTINGS=1
+
 run_stdin() { # MESSAGE [env-assignment] — feed via stdin; sets OUT and RC
   OUT=""
   RC=0
-  OUT="$(cd "$R" && printf '%s\n' "$1" | env ${2:+"$2"} "$CM" 2>&1)" || RC=$?
+  OUT="$(cd "$R" && printf '%s\n' "$1" |
+    env ${NO_SETTINGS:+GROWTH_GUARDS_SETTINGS_FILE=/dev/null} ${2:+"$2"} "$CM" 2>&1)" || RC=$?
 }
 
 expect_pass() { # HEADER DESC [env]
@@ -97,6 +105,7 @@ run_stdin 'feat: x' "GROWTH_GUARDS_COMMIT_TYPES=Feat"
 run_stdin 'feat: x' "GROWTH_GUARDS_COMMIT_TYPES= "
 [ "$RC" -eq 2 ] && ok "an empty type list is exit 2" || bad "empty type list is exit 2" "rc=$RC out=$OUT"
 
+NO_SETTINGS=""
 echo "=== settings file resolution ==="
 printf '[env]\nGROWTH_GUARDS_COMMIT_TYPES = "docs"\n' >"$R/kendex.settings.toml"
 run_stdin 'docs: settings-admitted type'
@@ -128,6 +137,7 @@ run_stdin 'feat: base type' "GROWTH_GUARDS_SETTINGS_FILE=/dev/null"
 [ "$RC" -eq 0 ] && ok "the sentinel skips .env.local (read BEFORE the settings file) too" \
   || bad "sentinel skips .env.local" "rc=$RC out=$OUT"
 rm -f "$R/.env.local"
+NO_SETTINGS=1
 
 echo "=== a failing index probe never loosens the committed type list ==="
 # The hook lane resolves tracked settings from the INDEX so a commit is judged
@@ -266,7 +276,7 @@ run_stdin 'fix: x' "GROWTH_GUARDS_SUBJECT_MAX=0"
 # git hook inherits that environment, so a message measured in bytes is
 # accepted in one shell and refused in another.
 MULTI="fix(KEN-1): $(rep 'é' 55)" # 67 characters, 122 bytes
-for loc in C C.UTF-8 en_US.UTF-8; do
+for loc in C C.UTF-8; do
   run_stdin "$MULTI" "LC_ALL=$loc"
   [ "$RC" -eq 0 ] && ok "a 67-character multibyte header passes under $loc" \
     || bad "a 67-character multibyte header passes under $loc" "rc=$RC out=$OUT"
@@ -274,7 +284,7 @@ done
 # The control: one character more is over the cap in every one of them, so
 # the passes above are the count and not the rule declining to look.
 MULTI_OVER="fix(KEN-1): $(rep 'é' 61)" # 73 characters
-for loc in C C.UTF-8 en_US.UTF-8; do
+for loc in C C.UTF-8; do
   run_stdin "$MULTI_OVER" "LC_ALL=$loc"
   [ "$RC" -eq 1 ] && case "$OUT" in *"header is 73 characters (max 72)"*) true ;; *) false ;; esac \
     && ok "and 73 of them is 73 characters under $loc, not its byte count" \
@@ -286,7 +296,7 @@ done
 # here unless the match is pinned. These bytes sit in the scope, which is the
 # only part of the ERE a locale changes; the length fixtures above carry
 # theirs in the subject and reach none of it.
-for loc in C C.UTF-8 en_US.UTF-8; do
+for loc in C C.UTF-8; do
   run_stdin 'fix(café): tighten the gate' "LC_ALL=$loc"
   [ "$RC" -eq 1 ] && case "$OUT" in *"non-conventional header"*) true ;; *) false ;; esac \
     && ok "an accented scope is outside the documented class under $loc" \
@@ -298,7 +308,7 @@ done
 # And bytes that are not valid UTF-8 at all decide the same way everywhere:
 # the subject class is "not whitespace", which they are.
 BADBYTES="$(printf 'fix: \377\376 bad bytes')"
-for loc in C C.UTF-8 en_US.UTF-8; do
+for loc in C C.UTF-8; do
   run_stdin "$BADBYTES" "LC_ALL=$loc"
   [ "$RC" -eq 0 ] && ok "a subject carrying invalid UTF-8 is judged the same under $loc" \
     || bad "a subject carrying invalid UTF-8 is judged the same under $loc" "rc=$RC out=$OUT"

--- a/skills/growth-guards/tests/commit-msg.test.sh
+++ b/skills/growth-guards/tests/commit-msg.test.sh
@@ -292,10 +292,12 @@ for loc in C C.UTF-8; do
 done
 # The SHAPE rule answers under the same rules. Its scope class is ASCII in
 # every surface that documents it, and a bracket range is a COLLATION range
-# under a UTF-8 locale — so an accented scope is admitted there and refused
-# here unless the match is pinned. These bytes sit in the scope, which is the
-# only part of the ERE a locale changes; the length fixtures above carry
-# theirs in the subject and reach none of it.
+# under a UTF-8 locale, which is the one thing that could admit an accented
+# scope. C and C.UTF-8 are what the hosts this suite runs on carry, so what
+# these arms prove is that the verdict does not vary across them — not that
+# collation cannot bite on some other glibc or grep. These bytes sit in the
+# scope, which is the only part of the ERE a locale changes; the length
+# fixtures above carry theirs in the subject and reach none of it.
 for loc in C C.UTF-8; do
   run_stdin 'fix(café): tighten the gate' "LC_ALL=$loc"
   [ "$RC" -eq 1 ] && case "$OUT" in *"non-conventional header"*) true ;; *) false ;; esac \

--- a/skills/growth-guards/tests/install-git-hooks-scope.test.sh
+++ b/skills/growth-guards/tests/install-git-hooks-scope.test.sh
@@ -11,6 +11,12 @@ TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/install-hooks.bash
 . "$TEST_DIR/lib/install-hooks.bash"
 
+# The subject is which scripts the shim reaches and which lanes run beside
+# them, never the composition of the batch itself — size-ratchet and preflight
+# are chain lanes, not members of it. So the batch runs one check, and each
+# check keeps its own suite.
+export GROWTH_GUARDS_CHECKS=todo-ban
+
 echo "=== a copy-method install is rediscovered ==="
 R19="$(new_repo copymethod)"
 install_in "$R19"

--- a/skills/growth-guards/tests/install-git-hooks.test.sh
+++ b/skills/growth-guards/tests/install-git-hooks.test.sh
@@ -176,6 +176,13 @@ case "$OUT" in
   *) bad "blocked commit names the blob" "out=$OUT" ;;
 esac
 
+# Everything from here down is hook PLUMBING: what the shims delegate to, what
+# survives an install, what an uninstall gives back. The batch's composition is
+# not the subject and each check has its own suite, so the chain runs one of
+# them — the same commits, a sixth of the work. The blocks above keep the full
+# batch: they are the ones that judge what the chain reads and what it runs.
+export GROWTH_GUARDS_CHECKS=todo-ban
+
 echo "=== the repo-local entry runs last and blocks ==="
 mkdir -p "$R/tools"
 printf '#!/bin/sh\necho "repo-local check ran"\nexit 0\n' >"$R/tools/local-check"
@@ -450,7 +457,6 @@ install_in "$R10"
 BEFORE_HELPER="$(cat "$R10/.git/hooks/kendex-guards")"
 BEFORE_PRE="$(cat "$R10/.git/hooks/pre-commit")"
 BEFORE_MSG="$(cat "$R10/.git/hooks/commit-msg")"
-install_in "$R10"
 install_in "$R10"
 [ "$RC" -eq 0 ] && ok "a repeat install exits 0" || bad "repeat install exits 0" "rc=$RC out=$OUT"
 [ "$BEFORE_HELPER" = "$(cat "$R10/.git/hooks/kendex-guards")" ] && ok "the helper is unchanged" || bad "helper unchanged"

--- a/skills/growth-guards/tests/lib/install-hooks.bash
+++ b/skills/growth-guards/tests/lib/install-hooks.bash
@@ -9,7 +9,10 @@
 
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 INSTALL="$SKILL_DIR/scripts/install-git-hooks"
-GG_SKILL_TEMPLATE="$TMP/gg-skill-template"
+# Outside the namespace new_repo allocates fixtures from: a fixture named for
+# the template would satisfy the build guard below and be copied into the skill
+# slot as a git repository, with nothing checking the shape.
+GG_SKILL_TEMPLATE="$TMP/.templates/growth-guards"
 
 unset GROWTH_GUARDS_CHECKS GROWTH_GUARDS_PRE_COMMIT_LOCAL GROWTH_GUARDS_SETTINGS_FILE \
   GROWTH_GUARDS_COMMIT_TYPES SIZE_RATCHET_THRESHOLD 2>/dev/null || true
@@ -40,6 +43,7 @@ new_repo() { # NAME -> repo path on stdout
   # that subtree is more than half the skill and nothing a consumer install
   # reaches, and these suites build dozens of fixtures.
   if [ ! -d "$GG_SKILL_TEMPLATE" ]; then
+    mkdir -p "$(dirname "$GG_SKILL_TEMPLATE")"
     cp -R "$SKILL_DIR" "$GG_SKILL_TEMPLATE"
     rm -rf -- "${GG_SKILL_TEMPLATE:?}/tests"
   fi

--- a/skills/growth-guards/tests/lib/install-hooks.bash
+++ b/skills/growth-guards/tests/lib/install-hooks.bash
@@ -9,6 +9,7 @@
 
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 INSTALL="$SKILL_DIR/scripts/install-git-hooks"
+GG_SKILL_TEMPLATE="$TMP/gg-skill-template"
 
 unset GROWTH_GUARDS_CHECKS GROWTH_GUARDS_PRE_COMMIT_LOCAL GROWTH_GUARDS_SETTINGS_FILE \
   GROWTH_GUARDS_COMMIT_TYPES SIZE_RATCHET_THRESHOLD 2>/dev/null || true
@@ -34,7 +35,15 @@ new_repo() { # NAME -> repo path on stdout
   git -C "$r" config user.name test
   # A real directory, the shape a project install has: path resolution and
   # the shared-worktree check both key on where the copy physically is.
-  cp -R "$SKILL_DIR" "$r/.agents/skills/growth-guards"
+  #
+  # The copy is cloned from a template built once per suite, with tests/ cut:
+  # that subtree is more than half the skill and nothing a consumer install
+  # reaches, and these suites build dozens of fixtures.
+  if [ ! -d "$GG_SKILL_TEMPLATE" ]; then
+    cp -R "$SKILL_DIR" "$GG_SKILL_TEMPLATE"
+    rm -rf -- "${GG_SKILL_TEMPLATE:?}/tests"
+  fi
+  cp -R "$GG_SKILL_TEMPLATE" "$r/.agents/skills/growth-guards"
   ln -s "$SKILL_DIR/../size-ratchet" "$r/.agents/skills/size-ratchet"
   printf '%s' "$r"
 }

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -73,6 +73,7 @@ In a linked worktree whose `.cache` should be a `WORKTREE_SYMLINKS`-managed syml
 | `LINEAR_TEAM_PREFIX` | Issue identifier prefix | `PROJ` |
 | `LINEAR_AGENT_LABELS` | Declared `agent:*` taxonomy; non-empty makes `issues create` refuse unrouted creates | none (unset = off) |
 | `LINEAR_REQUIRE_REACH` | Non-empty makes `issues create` refuse a body with no `Reached by:` line | none (unset = off) |
+| `LINEAR_RETRY_BASE_DELAY` | Seconds before the first retry of a rate-limited or failed GraphQL call, doubling per attempt | `1` |
 
 `LINEAR_API_KEY` belongs in `.env.local`; non-secret defaults in committed `kendex.settings.toml` `[env]`. A key from project files beats one inherited from the environment, and `auth-check` warns (fingerprints only) when it shadows a differing inherited key.
 

--- a/skills/linear/kendex.settings.toml.example
+++ b/skills/linear/kendex.settings.toml.example
@@ -28,3 +28,8 @@ LINEAR_REQUIRE_REACH = ""
 
 # Default output format for read commands: safe, table, ids, raw.
 LINEAR_FORMAT = "safe"
+
+# Seconds before the first retry of a rate-limited or failed GraphQL call,
+# doubling on each further attempt. A whole number of seconds; 0 retries
+# without waiting at all.
+LINEAR_RETRY_BASE_DELAY = "1"

--- a/skills/linear/scripts/lib/common.sh
+++ b/skills/linear/scripts/lib/common.sh
@@ -11,18 +11,6 @@ LINEAR_API="https://api.linear.app/graphql"
 LINEAR_LIMIT_SHORT_DESC=255    # Initiatives, projects, milestones, labels
 LINEAR_LIMIT_ISSUE_DESC=100000 # Issues have no practical limit
 
-# Seconds before the first retry of a rate-limited or failed GraphQL call;
-# each further attempt doubles it. Overridable so a suite driving the retry
-# path against a stubbed curl does not spend the real backoff — the wait is
-# for Linear's benefit, and there is no Linear on the other end of a stub.
-LINEAR_RETRY_BASE_DELAY="${LINEAR_RETRY_BASE_DELAY:-1}"
-case "$LINEAR_RETRY_BASE_DELAY" in
-*[!0-9]* | "")
-    echo '{"error": "LINEAR_RETRY_BASE_DELAY must be a whole number of seconds"}' >&2
-    exit 1
-    ;;
-esac
-
 # Internal lib directory (underscore prefix avoids overwriting caller's SCRIPT_DIR)
 _LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -76,6 +64,24 @@ _CALLER_LINEAR_TEAM="${LINEAR_TEAM:-}"
 # shellcheck source=kendex-env.sh
 source "$_LIB_DIR/kendex-env.sh"
 kendex_load_project_env "$PROJECT_ROOT"
+
+# Seconds before the first retry of a rate-limited or failed GraphQL call;
+# each further attempt doubles it. Overridable so a suite driving the retry
+# path against a stubbed curl does not spend the real backoff — the wait is
+# for Linear's benefit, and there is no Linear on the other end of a stub.
+#
+# Below the project load, where every LINEAR_* value resolves:
+# kendex_load_project_env snapshots only EXPORTED names, so a default assigned
+# above it is a plain variable the settings files overwrite unvalidated. Base
+# ten at the seed, so a leading zero is decimal and not the octal 08 rejects.
+LINEAR_RETRY_BASE_DELAY="${LINEAR_RETRY_BASE_DELAY:-1}"
+case "$LINEAR_RETRY_BASE_DELAY" in
+*[!0-9]* | "")
+    echo '{"error": "LINEAR_RETRY_BASE_DELAY must be a whole number of seconds"}' >&2
+    exit 1
+    ;;
+esac
+LINEAR_RETRY_BASE_DELAY=$((10#$LINEAR_RETRY_BASE_DELAY))
 
 # Where each target-selecting value came from: override (LINEAR_API_KEY_OVERRIDE),
 # project-config (kendex.settings.toml / .env.local), environment (process

--- a/skills/linear/scripts/lib/common.sh
+++ b/skills/linear/scripts/lib/common.sh
@@ -74,13 +74,13 @@ kendex_load_project_env "$PROJECT_ROOT"
 # kendex_load_project_env snapshots only EXPORTED names, so a default assigned
 # above it is a plain variable the settings files overwrite unvalidated. Base
 # ten at the seed, so a leading zero is decimal and not the octal 08 rejects.
+# Bounded on width too, and 18 digits survives all three doublings: past that
+# the arithmetic wraps and the backoff is a negative sleep, not a refusal.
 LINEAR_RETRY_BASE_DELAY="${LINEAR_RETRY_BASE_DELAY:-1}"
-case "$LINEAR_RETRY_BASE_DELAY" in
-*[!0-9]* | "")
+if ! [[ "$LINEAR_RETRY_BASE_DELAY" =~ ^[0-9]{1,18}$ ]]; then
     echo '{"error": "LINEAR_RETRY_BASE_DELAY must be a whole number of seconds"}' >&2
     exit 1
-    ;;
-esac
+fi
 LINEAR_RETRY_BASE_DELAY=$((10#$LINEAR_RETRY_BASE_DELAY))
 
 # Where each target-selecting value came from: override (LINEAR_API_KEY_OVERRIDE),

--- a/skills/linear/scripts/lib/common.sh
+++ b/skills/linear/scripts/lib/common.sh
@@ -11,6 +11,18 @@ LINEAR_API="https://api.linear.app/graphql"
 LINEAR_LIMIT_SHORT_DESC=255    # Initiatives, projects, milestones, labels
 LINEAR_LIMIT_ISSUE_DESC=100000 # Issues have no practical limit
 
+# Seconds before the first retry of a rate-limited or failed GraphQL call;
+# each further attempt doubles it. Overridable so a suite driving the retry
+# path against a stubbed curl does not spend the real backoff — the wait is
+# for Linear's benefit, and there is no Linear on the other end of a stub.
+LINEAR_RETRY_BASE_DELAY="${LINEAR_RETRY_BASE_DELAY:-1}"
+case "$LINEAR_RETRY_BASE_DELAY" in
+*[!0-9]* | "")
+    echo '{"error": "LINEAR_RETRY_BASE_DELAY must be a whole number of seconds"}' >&2
+    exit 1
+    ;;
+esac
+
 # Internal lib directory (underscore prefix avoids overwriting caller's SCRIPT_DIR)
 _LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -232,7 +244,7 @@ graphql_query() {
         variables='{}'
     fi
     local max_retries=3
-    local retry_delay=1
+    local retry_delay="$LINEAR_RETRY_BASE_DELAY"
     local attempt=1
 
     # Single choke point for writes: no mutation leaves this process without a

--- a/skills/linear/tests/must-fail-controls.sh
+++ b/skills/linear/tests/must-fail-controls.sh
@@ -18,6 +18,10 @@ SKILL_DIR="$(cd "$TESTS_DIR/.." && pwd)"
 CONTROLS_DIR="$TESTS_DIR/controls"
 SUITE_TIMEOUT="${CONTROL_TIMEOUT:-60}"
 
+# Controls run concurrently: each one mutates its own copy of the skill and
+# runs the suite out of that copy, so no two of them share anything writable.
+CONTROL_JOBS="${CONTROL_JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)}"
+
 WORK="$(mktemp -d)"
 trap 'rm -rf -- "${WORK:?}"' EXIT
 
@@ -31,6 +35,10 @@ die() {
 	printf 'must-fail-controls: %s\n' "$*" >&2
 	exit 2
 }
+
+# A junk width would otherwise launch every control at once, or none.
+[[ "$CONTROL_JOBS" =~ ^[1-9][0-9]*$ ]] ||
+	die "CONTROL_JOBS must be a positive integer, got: $CONTROL_JOBS"
 
 control_die() {
 	printf 'control %s: %s\n' "$CONTROL_NAME" "$*" >&2
@@ -83,6 +91,20 @@ control_write() {
 }
 
 # --- runner -----------------------------------------------------------------
+
+PIDS=()
+FAILURES=0
+
+# Wait out the launched batch, scoring one failure per control that reported
+# one. `wait -n` would keep the pipe full, but these suites must start under
+# the Bash 3.2 in /bin on macOS, which does not have it.
+reap() {
+	local pid
+	for pid in ${PIDS[@]+"${PIDS[@]}"}; do
+		wait "$pid" || FAILURES=$((FAILURES + 1))
+	done
+	PIDS=()
+}
 
 run_one() {
 	local suite="$1" stem="$2"
@@ -155,8 +177,8 @@ run_one() {
 }
 
 main() {
-	local -a wanted=("$@") stems=()
-	local suite_path control_path suite stem want failures=0 total=0 orphans=0
+	local -a wanted=("$@") stems=() ran=()
+	local suite_path control_path suite stem want total=0 orphans=0
 
 	for suite_path in "$TESTS_DIR"/*.test.sh; do
 		stems+=("$(basename "$suite_path" .test.sh)")
@@ -189,14 +211,24 @@ main() {
 			continue
 		fi
 		total=$((total + 1))
-		run_one "$suite" "$stem" || failures=$((failures + 1))
+		ran+=("$stem")
+		run_one "$suite" "$stem" >"$WORK/$stem.log" 2>&1 &
+		PIDS+=("$!")
+		[[ ${#PIDS[@]} -lt "$CONTROL_JOBS" ]] || reap
 	done
+	reap
 
 	[[ "$total" -gt 0 ]] || die "selection matched no suites"
 
+	# Roster order, not finish order: the report reads the same whatever the
+	# machine's width.
+	for stem in "${ran[@]}"; do
+		cat "$WORK/$stem.log"
+	done
+
 	printf '\n%d controls, %d failing, %d orphaned\n' \
-		"$total" "$failures" "$orphans"
-	[[ "$failures" -eq 0 && "$orphans" -eq 0 ]]
+		"$total" "$FAILURES" "$orphans"
+	[[ "$FAILURES" -eq 0 && "$orphans" -eq 0 ]]
 }
 
 main "$@"

--- a/skills/linear/tests/must-fail-controls.sh
+++ b/skills/linear/tests/must-fail-controls.sh
@@ -31,7 +31,10 @@ trap 'rm -rf -- "${WORK:?}"' EXIT
 # so Ctrl-C never reaches them on its own; TERM does. The `timeout` child each
 # control spawned is a grandchild this does not reach; it retires itself
 # within SUITE_TIMEOUT.
-trap 'kill -TERM ${PIDS[@]+"${PIDS[@]}"} 2>/dev/null; exit 130' INT TERM
+# One trap each, so the code a wrapper reads says which signal arrived: an
+# interrupt and a kill are the same cleanup but not the same event.
+trap 'kill -TERM ${PIDS[@]+"${PIDS[@]}"} 2>/dev/null; exit 130' INT
+trap 'kill -TERM ${PIDS[@]+"${PIDS[@]}"} 2>/dev/null; exit 143' TERM
 
 # --- control vocabulary -----------------------------------------------------
 # A control script runs with CONTROL_ROOT pointing at its own copy of the

--- a/skills/linear/tests/must-fail-controls.sh
+++ b/skills/linear/tests/must-fail-controls.sh
@@ -24,11 +24,13 @@ CONTROL_JOBS="${CONTROL_JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)
 
 WORK="$(mktemp -d)"
 trap 'rm -rf -- "${WORK:?}"' EXIT
-# An interrupted run takes its controls with it. Only the pids this script
-# recorded when it launched them: every lane on this machine runs these same
-# suites out of its own worktree, so an argv match would reach theirs too.
-# Bash ignores INT in the async children of a shell without job control, so
-# Ctrl-C never reaches them on its own; TERM does.
+# An interrupted run signals the control jobs it launched, and only the pids
+# it recorded when it launched them: every lane on this machine runs these
+# same suites out of its own worktree, so an argv match would reach theirs
+# too. Bash ignores INT in the async children of a shell without job control,
+# so Ctrl-C never reaches them on its own; TERM does. The `timeout` child each
+# control spawned is a grandchild this does not reach; it retires itself
+# within SUITE_TIMEOUT.
 trap 'kill -TERM ${PIDS[@]+"${PIDS[@]}"} 2>/dev/null; exit 130' INT TERM
 
 # --- control vocabulary -----------------------------------------------------
@@ -42,7 +44,9 @@ die() {
 	exit 2
 }
 
-# A junk width would otherwise launch every control at once, or none.
+# A junk width otherwise reaches the batching predicate, where Bash 4.4 and
+# newer abort on the unbound name mid-roster and 4.0 through 4.2 read it as 0
+# and run every control one at a time.
 [[ "$CONTROL_JOBS" =~ ^[1-9][0-9]*$ ]] ||
 	die "CONTROL_JOBS must be a positive integer, got: $CONTROL_JOBS"
 

--- a/skills/linear/tests/must-fail-controls.sh
+++ b/skills/linear/tests/must-fail-controls.sh
@@ -46,8 +46,11 @@ die() {
 
 # A junk width otherwise reaches the batching predicate, where Bash 4.4 and
 # newer abort on the unbound name mid-roster and 4.0 through 4.2 read it as 0
-# and run every control one at a time.
-[[ "$CONTROL_JOBS" =~ ^[1-9][0-9]*$ ]] ||
+# and run every control one at a time. The digit count is part of the grammar:
+# 19 digits or more is past what signed 64-bit shell arithmetic holds, and the
+# predicate compares against the wrap, which reaps every iteration when it
+# lands at or below zero.
+[[ "$CONTROL_JOBS" =~ ^[1-9][0-9]{0,17}$ ]] ||
 	die "CONTROL_JOBS must be a positive integer, got: $CONTROL_JOBS"
 
 control_die() {

--- a/skills/linear/tests/must-fail-controls.sh
+++ b/skills/linear/tests/must-fail-controls.sh
@@ -24,6 +24,12 @@ CONTROL_JOBS="${CONTROL_JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)
 
 WORK="$(mktemp -d)"
 trap 'rm -rf -- "${WORK:?}"' EXIT
+# An interrupted run takes its controls with it. Only the pids this script
+# recorded when it launched them: every lane on this machine runs these same
+# suites out of its own worktree, so an argv match would reach theirs too.
+# Bash ignores INT in the async children of a shell without job control, so
+# Ctrl-C never reaches them on its own; TERM does.
+trap 'kill -TERM ${PIDS[@]+"${PIDS[@]}"} 2>/dev/null; exit 130' INT TERM
 
 # --- control vocabulary -----------------------------------------------------
 # A control script runs with CONTROL_ROOT pointing at its own copy of the
@@ -93,17 +99,28 @@ control_write() {
 # --- runner -----------------------------------------------------------------
 
 PIDS=()
+BATCH=()
 FAILURES=0
 
-# Wait out the launched batch, scoring one failure per control that reported
-# one. `wait -n` would keep the pipe full, but these suites must start under
-# the Bash 3.2 in /bin on macOS, which does not have it.
+# Wait out the launched batch, score one failure per control that reported
+# one, then print what that batch found. `wait -n` would keep the pipe full
+# instead of draining it in batches, but this skill supports Bash 4.0 and
+# newer (README § Setup) and `wait -n` arrived in 4.3.
+#
+# Printing here rather than after the last batch is what a run killed by CI,
+# a wrapper timeout or Ctrl-C leaves behind: the verdicts already reached.
+# A batch's pids are in roster order and the batches are too, so incremental
+# output is the same order the whole run would have printed.
 reap() {
-	local pid
+	local pid stem
 	for pid in ${PIDS[@]+"${PIDS[@]}"}; do
 		wait "$pid" || FAILURES=$((FAILURES + 1))
 	done
+	for stem in ${BATCH[@]+"${BATCH[@]}"}; do
+		cat "$WORK/$stem.log"
+	done
 	PIDS=()
+	BATCH=()
 }
 
 run_one() {
@@ -177,7 +194,7 @@ run_one() {
 }
 
 main() {
-	local -a wanted=("$@") stems=() ran=()
+	local -a wanted=("$@") stems=()
 	local suite_path control_path suite stem want total=0 orphans=0
 
 	for suite_path in "$TESTS_DIR"/*.test.sh; do
@@ -211,20 +228,14 @@ main() {
 			continue
 		fi
 		total=$((total + 1))
-		ran+=("$stem")
 		run_one "$suite" "$stem" >"$WORK/$stem.log" 2>&1 &
 		PIDS+=("$!")
+		BATCH+=("$stem")
 		[[ ${#PIDS[@]} -lt "$CONTROL_JOBS" ]] || reap
 	done
 	reap
 
 	[[ "$total" -gt 0 ]] || die "selection matched no suites"
-
-	# Roster order, not finish order: the report reads the same whatever the
-	# machine's width.
-	for stem in "${ran[@]}"; do
-		cat "$WORK/$stem.log"
-	done
 
 	printf '\n%d controls, %d failing, %d orphaned\n' \
 		"$total" "$FAILURES" "$orphans"

--- a/skills/linear/tests/rate-limited-http-400.test.sh
+++ b/skills/linear/tests/rate-limited-http-400.test.sh
@@ -48,8 +48,11 @@ GENERIC_BODY='{"errors":[{"message":"Argument Validation Error","extensions":{"c
 # assertion made inside would be recorded where the suite cannot see it.
 run_linear() { # root, args...
   local root="$1"; shift
+  # No backoff: every response here comes from the curl stub two lines up, so
+  # the retry wait would be spent on nothing.
   (cd "$root" && env PATH="$root/bin:$PATH" \
     LINEAR_API_KEY_OVERRIDE="lin_api_test" LINEAR_TEAM="Claude" \
+    LINEAR_RETRY_BASE_DELAY=0 \
     "$root/.agents/skills/linear/scripts/linear.sh" "$@" 2>&1)
 }
 
@@ -63,7 +66,8 @@ assert_contains "rate-limited 400 reports the rate limit" "$out" "Rate limited. 
 assert_not_contains "rate-limited 400 is not a generic HTTP error" "$out" "HTTP error: 400"
 echo "=== failed team lookup propagates the API failure ==="
 unit_rc=0
-unit="$(cd "$TMP_BASE/rl" && env PATH="$TMP_BASE/rl/bin:$PATH" bash -c '
+unit="$(cd "$TMP_BASE/rl" && env PATH="$TMP_BASE/rl/bin:$PATH" \
+  LINEAR_RETRY_BASE_DELAY=0 bash -c '
   set -u
   LINEAR_API="https://api.linear.app/graphql"
   LINEAR_API_KEY="lin_api_test"
@@ -82,3 +86,35 @@ out="$(run_linear "$TMP_BASE/gen" statuses list)" || gen_rc=$?
 
 assert_ne "a generic non-200 fails the call" "$gen_rc" 0
 assert_contains "generic 400 includes the body message" "$out" "HTTP error: 400: Argument Validation Error"
+
+echo "=== the retry backoff is overridable ==="
+# What the retry actually waited is read off a sleep stub, not off the clock:
+# a wall-time assertion would pass on a slow host that never honoured the
+# override. Every arm below runs against the same stubbed curl, so the only
+# variable is the delay the library asks for.
+cat >"$TMP_BASE/rl/bin/sleep" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$1" >>"$TMP_BASE/rl/slept"
+SH
+chmod +x "$TMP_BASE/rl/bin/sleep"
+
+: >"$TMP_BASE/rl/slept"
+run_linear "$TMP_BASE/rl" statuses list >/dev/null 2>&1 || true
+assert_eq "an overridden base delay is what the retry sleeps" \
+  "$(tr '\n' ' ' <"$TMP_BASE/rl/slept")" "0 0 "
+
+: >"$TMP_BASE/rl/slept"
+(cd "$TMP_BASE/rl" && env PATH="$TMP_BASE/rl/bin:$PATH" \
+  LINEAR_API_KEY_OVERRIDE="lin_api_test" LINEAR_TEAM="Claude" \
+  "$TMP_BASE/rl/.agents/skills/linear/scripts/linear.sh" statuses list) >/dev/null 2>&1 || true
+assert_eq "the default backoff still doubles from one second" \
+  "$(tr '\n' ' ' <"$TMP_BASE/rl/slept")" "1 2 "
+
+junk_rc=0
+junk="$(cd "$TMP_BASE/rl" && env PATH="$TMP_BASE/rl/bin:$PATH" \
+  LINEAR_API_KEY_OVERRIDE="lin_api_test" LINEAR_TEAM="Claude" \
+  LINEAR_RETRY_BASE_DELAY="soon" \
+  "$TMP_BASE/rl/.agents/skills/linear/scripts/linear.sh" statuses list 2>&1)" || junk_rc=$?
+assert_ne "a non-numeric base delay fails the call" "$junk_rc" 0
+assert_contains "a non-numeric base delay names the setting" \
+  "$junk" "LINEAR_RETRY_BASE_DELAY must be a whole number of seconds"

--- a/skills/linear/tests/rate-limited-http-400.test.sh
+++ b/skills/linear/tests/rate-limited-http-400.test.sh
@@ -118,3 +118,33 @@ junk="$(cd "$TMP_BASE/rl" && env PATH="$TMP_BASE/rl/bin:$PATH" \
 assert_ne "a non-numeric base delay fails the call" "$junk_rc" 0
 assert_contains "a non-numeric base delay names the setting" \
   "$junk" "LINEAR_RETRY_BASE_DELAY must be a whole number of seconds"
+
+# The process environment is not the only way this value arrives: SKILL.md
+# points non-secret defaults at the project's committed settings, and every
+# other LINEAR_* key resolves from there. A guard the settings file can walk
+# past is no guard — the bad value reaches `sleep` and the run dies mid-flight,
+# after the request has already gone out.
+printf '[env]\nLINEAR_RETRY_BASE_DELAY = "soon"\n' >"$TMP_BASE/rl/kendex.settings.toml"
+settings_rc=0
+settings_out="$(cd "$TMP_BASE/rl" && env PATH="$TMP_BASE/rl/bin:$PATH" \
+  LINEAR_API_KEY_OVERRIDE="lin_api_test" LINEAR_TEAM="Claude" \
+  "$TMP_BASE/rl/.agents/skills/linear/scripts/linear.sh" statuses list 2>&1)" || settings_rc=$?
+assert_ne "a non-numeric base delay in kendex.settings.toml fails the call" "$settings_rc" 0
+assert_contains "a settings-file base delay reaches the same named refusal" \
+  "$settings_out" "LINEAR_RETRY_BASE_DELAY must be a whole number of seconds"
+rm -f "$TMP_BASE/rl/kendex.settings.toml"
+
+# A leading zero is a decimal figure. Read in the shell's default base it is
+# octal, and 08 is not a number at all: the run would die on an arithmetic
+# error where the caller expects the structured rate-limit answer.
+: >"$TMP_BASE/rl/slept"
+zero_out="$(cd "$TMP_BASE/rl" && env PATH="$TMP_BASE/rl/bin:$PATH" \
+  LINEAR_API_KEY_OVERRIDE="lin_api_test" LINEAR_TEAM="Claude" \
+  LINEAR_RETRY_BASE_DELAY=08 \
+  "$TMP_BASE/rl/.agents/skills/linear/scripts/linear.sh" statuses list 2>&1)" || true
+assert_eq "a leading-zero base delay is read in base ten" \
+  "$(tr '\n' ' ' <"$TMP_BASE/rl/slept")" "8 16 "
+assert_contains "a leading-zero base delay still answers with the rate limit" \
+  "$zero_out" "Rate limited. Try again later."
+assert_not_contains "a leading-zero base delay is never an arithmetic error" \
+  "$zero_out" "value too great for base"

--- a/skills/linear/tests/rate-limited-http-400.test.sh
+++ b/skills/linear/tests/rate-limited-http-400.test.sh
@@ -119,6 +119,18 @@ assert_ne "a non-numeric base delay fails the call" "$junk_rc" 0
 assert_contains "a non-numeric base delay names the setting" \
   "$junk" "LINEAR_RETRY_BASE_DELAY must be a whole number of seconds"
 
+# Width is part of the grammar too: 19 digits is outside signed 64-bit
+# arithmetic, and the wrap is a negative backoff `sleep` refuses once the
+# request has already gone out.
+wide_rc=0
+wide="$(cd "$TMP_BASE/rl" && env PATH="$TMP_BASE/rl/bin:$PATH" \
+  LINEAR_API_KEY_OVERRIDE="lin_api_test" LINEAR_TEAM="Claude" \
+  LINEAR_RETRY_BASE_DELAY=9999999999999999999 \
+  "$TMP_BASE/rl/.agents/skills/linear/scripts/linear.sh" statuses list 2>&1)" || wide_rc=$?
+assert_ne "a base delay too wide for the arithmetic fails the call" "$wide_rc" 0
+assert_contains "an over-wide base delay names the setting" \
+  "$wide" "LINEAR_RETRY_BASE_DELAY must be a whole number of seconds"
+
 # The process environment is not the only way this value arrives: SKILL.md
 # points non-secret defaults at the project's committed settings, and every
 # other LINEAR_* key resolves from there. A guard the settings file can walk

--- a/skills/linear/tests/roster-orphan.test.sh
+++ b/skills/linear/tests/roster-orphan.test.sh
@@ -122,9 +122,12 @@ assert_file_contains "the failing control is counted, not just printed" \
     "$TMP/green.log" "1 controls, 1 failing, 0 orphaned"
 
 # --- a junk job width is refused ------------------------------------------
-# Not clamped and not defaulted: a width the runner cannot read would either
-# launch every control at once or launch none, and a run that launched none
-# reports "0 failing" like a clean one.
+# Not clamped and not defaulted. Left to reach the batching predicate, a width
+# outside the grammar decides two ways and neither is the one the caller asked
+# for: on Bash 4.4 and newer arithmetic honours set -u, so the unbound name
+# aborts the run with controls already launched, and on 4.0 through 4.2 the
+# same name reads as 0, the batch collapses to one, and the whole roster runs
+# serially.
 jobs_log="$TMP/jobs.log"
 CONTROL_JOBS=some bash "$matched/tests/must-fail-controls.sh" >"$jobs_log" 2>&1
 rc=$?

--- a/skills/linear/tests/roster-orphan.test.sh
+++ b/skills/linear/tests/roster-orphan.test.sh
@@ -1,17 +1,22 @@
 #!/usr/bin/env bash
-# The roster contract of tests/must-fail-controls.sh, both directions, driven
-# against a synthetic one-suite skill rather than this one.
+# The verdict contract of tests/must-fail-controls.sh, driven against a
+# synthetic one-suite skill rather than this one.
 #
-# Why a fixture and not this skill's own roster: that roster is matched, so
-# the orphan branch is never taken by a run over skills/linear and deleting it
-# would leave every committed suite green. The fixture is the only place the
-# condition is constructible.
+# Why a fixture and not this skill's own roster: that roster is matched and
+# every one of its controls works, so neither the orphan branch nor the
+# failing-control branch is ever taken by a run over skills/linear, and
+# deleting either would leave every committed suite green. The fixture is the
+# only place those conditions are constructible.
 #
 #   - a matched suite/control pair exits 0 and prints no ORPHAN line, so a
 #     case here cannot pass by always reporting a failure
 #   - a control no suite owns exits non-zero and the diagnostic names it
 #   - a targeted single-stem run reads the roster too: a selection cannot
 #     hide an orphan
+#   - a control that does not red its suite is counted and fails the run,
+#     which is the whole regime: without it the 50 controls over this skill
+#     could all rot and the runner would still exit 0
+#   - a junk job width is refused rather than run at some silent default
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -92,3 +97,38 @@ assert_file_contains "the targeted run names the orphaned control" \
     "$TMP/orphan-one.log" "ORPHAN   controls/ghost.control.sh"
 assert_file_contains "the targeted run counts the orphan" \
     "$TMP/orphan-one.log" "1 controls, 0 failing, 1 orphaned"
+
+# --- a control that does not red its suite is a failure --------------------
+# The runner judges each control in a background job and turns its status into
+# the verdict when that batch is reaped. Nothing above reaches that path: every
+# control there works, so the count is always "0 failing" and the line could be
+# deleted with all of it still green. Here the mutation lands (the tree really
+# changes, so it is not NOOP) on a file the suite never reads, which leaves the
+# suite passing over its own broken subject — GREEN, the case the whole regime
+# exists to catch.
+green="$TMP/green"
+fixture "$green"
+printf 'INERT=1\n' >"$green/scripts/inert.sh"
+cat >"$green/tests/controls/alpha.control.sh" <<'CONTROL'
+control_expect "the value is green"
+control_replace scripts/inert.sh 1 'INERT=1' 'INERT=2'
+CONTROL
+
+rc="$(run_roster "$TMP/green.log" "$green")"
+assert_ne "a control that leaves its suite passing fails the run" "$rc" 0
+assert_file_contains "the diagnostic names the suite that stayed green" \
+    "$TMP/green.log" "GREEN    alpha.test.sh"
+assert_file_contains "the failing control is counted, not just printed" \
+    "$TMP/green.log" "1 controls, 1 failing, 0 orphaned"
+
+# --- a junk job width is refused ------------------------------------------
+# Not clamped and not defaulted: a width the runner cannot read would either
+# launch every control at once or launch none, and a run that launched none
+# reports "0 failing" like a clean one.
+jobs_log="$TMP/jobs.log"
+CONTROL_JOBS=some bash "$matched/tests/must-fail-controls.sh" >"$jobs_log" 2>&1
+rc=$?
+assert_eq "a non-numeric CONTROL_JOBS exits 2" "$rc" 2
+assert_file_contains "the refusal names the setting and the value" \
+    "$jobs_log" "CONTROL_JOBS must be a positive integer, got: some"
+assert_file_lacks "a refused width judges nothing" "$jobs_log" "controls, "

--- a/skills/linear/tests/roster-orphan.test.sh
+++ b/skills/linear/tests/roster-orphan.test.sh
@@ -135,3 +135,13 @@ assert_eq "a non-numeric CONTROL_JOBS exits 2" "$rc" 2
 assert_file_contains "the refusal names the setting and the value" \
     "$jobs_log" "CONTROL_JOBS must be a positive integer, got: some"
 assert_file_lacks "a refused width judges nothing" "$jobs_log" "controls, "
+
+# A width outside signed 64-bit arithmetic is junk of the same kind: the
+# batching predicate compares against the wrap, reads 2^64 as zero, and reaps
+# after every launch, so the roster runs one control at a time.
+wide_log="$TMP/jobs-wide.log"
+CONTROL_JOBS=18446744073709551616 bash "$matched/tests/must-fail-controls.sh" >"$wide_log" 2>&1
+rc=$?
+assert_eq "a CONTROL_JOBS too wide for the arithmetic exits 2" "$rc" 2
+assert_file_contains "the refusal names the setting and the over-wide value" \
+    "$wide_log" "CONTROL_JOBS must be a positive integer, got: 18446744073709551616"

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -46,8 +46,12 @@ seed() { # NAME — fixture in $R: committed baseline, origin/main, feature bran
   git -C "$R" remote set-url origin "$R.git"
 }
 
+# Local R: this builds the template and nothing else, and run_pf cd's into
+# whatever R holds. Left global it would be an out-parameter no signature
+# names, and any call from outside seed would run the next case against the
+# shared template.
 build_seed_template() {
-  R="$SEED_TEMPLATE"
+  local R="$SEED_TEMPLATE"
   mkdir -p "$R/docs" "$R/scripts" "$R/hooks" "$R/tests" "$R/data" "$R/store/migrations" \
     "$R/src/main/resources/db/migration"
   git -C "$R" -c init.defaultBranch=main init -q

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -29,8 +29,25 @@ skipped() {
   printf '  skip  %s (%s)\n' "$1" "$2"
 }
 
+SEED_TEMPLATE="$TMP/.seed-template"
+
+# Every fixture below starts from the same committed baseline, so it is built
+# once and copied. Rebuilding it per case costs a git init, a commit, a bare
+# clone and a fetch each, and there are dozens of cases.
 seed() { # NAME — fixture in $R: committed baseline, origin/main, feature branch
+  if [ ! -d "$SEED_TEMPLATE" ]; then
+    build_seed_template
+  fi
   R="$TMP/$1"
+  cp -a "$SEED_TEMPLATE" "$R"
+  cp -a "$SEED_TEMPLATE.git" "$R.git"
+  # The origin URL the template recorded points at the template's own bare
+  # copy; every fixture must fetch from its own.
+  git -C "$R" remote set-url origin "$R.git"
+}
+
+build_seed_template() {
+  R="$SEED_TEMPLATE"
   mkdir -p "$R/docs" "$R/scripts" "$R/hooks" "$R/tests" "$R/data" "$R/store/migrations" \
     "$R/src/main/resources/db/migration"
   git -C "$R" -c init.defaultBranch=main init -q

--- a/skills/reviewer/scripts/mutation-stability
+++ b/skills/reviewer/scripts/mutation-stability
@@ -74,13 +74,16 @@ positive_integer --stability "$N"
 positive_integer --threads "$THREADS"
 positive_integer --timeout "$TIMEOUT"
 
+# Bounded on width as well as grammar: 19 digits or more is outside what the
+# shell's arithmetic holds, so every test below it reads the figure as an
+# error rather than a count. The run then prints the skipped-boundary warning
+# it has no business printing and hands the same figure to sleep, which waits
+# out the run on the first write to a copy.
 SETTLE="${MUTATION_STABILITY_SETTLE:-1}"
-case "$SETTLE" in
-  *[!0-9]* | '')
-    echo "MUTATION_STABILITY_SETTLE wants a whole number of seconds" >&2
-    exit 2
-    ;;
-esac
+if ! [[ "$SETTLE" =~ ^[0-9]{1,18}$ ]]; then
+  echo "MUTATION_STABILITY_SETTLE wants a whole number of seconds" >&2
+  exit 2
+fi
 # The precondition for skipping the boundary — that BUILD keeps no cache the
 # copies could share — is the caller's to know and this script cannot check
 # it. When it does not hold the mutant reuses the clean run's binary and reads

--- a/skills/reviewer/scripts/mutation-stability
+++ b/skills/reviewer/scripts/mutation-stability
@@ -29,6 +29,10 @@ usage: mutation-stability --worktree PATH --sha SHA --test CMD --build CMD
                    given it in TEST, e.g. --test 'cargo test -- --test-threads $THREADS'
   --timeout S      deadline for each build or test command (default 300)
   --keep           print the temp dirs instead of deleting them
+
+  MUTATION_STABILITY_SETTLE  seconds each write to a copy waits so a shared
+                   mtime-keyed build cache cannot answer it with the previous
+                   run's binary (default 1; 0 when BUILD shares no cache)
 USAGE
 }
 
@@ -69,6 +73,14 @@ positive_integer() {
 positive_integer --stability "$N"
 positive_integer --threads "$THREADS"
 positive_integer --timeout "$TIMEOUT"
+
+SETTLE="${MUTATION_STABILITY_SETTLE:-1}"
+case "$SETTLE" in
+  *[!0-9]* | '')
+    echo "MUTATION_STABILITY_SETTLE wants a whole number of seconds" >&2
+    exit 2
+    ;;
+esac
 
 ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX") || exit 2
 ACTIVE_PID="" ACTIVE_GROUP=""
@@ -146,7 +158,11 @@ trap 'exit 143' TERM
 # a source tree waits that boundary out first, so what it wrote always outranks
 # the build before it. Without that, the cache the caller shares — usually
 # CARGO_TARGET_DIR — answers the next run with the last run's test binary.
-outrank_last_build() { sleep 1; }
+#
+# A caller whose --build shares no cache has nothing to outrank, and
+# tests/mutation-stability.test.sh is one: it drives every case with a stub
+# build. MUTATION_STABILITY_SETTLE=0 is how such a caller says so.
+outrank_last_build() { [ "$SETTLE" -eq 0 ] || sleep "$SETTLE"; }
 
 extract() { # extract SHA into $1, stamped past the build before it
   mkdir -p "$1" || return 1

--- a/skills/reviewer/scripts/mutation-stability
+++ b/skills/reviewer/scripts/mutation-stability
@@ -81,6 +81,13 @@ case "$SETTLE" in
     exit 2
     ;;
 esac
+# The precondition for skipping the boundary — that BUILD keeps no cache the
+# copies could share — is the caller's to know and this script cannot check
+# it. When it does not hold the mutant reuses the clean run's binary and reads
+# as survived, and nothing about that verdict looks wrong afterwards. Say it
+# once, so a transcript shows which verdicts were produced without it.
+[ "$SETTLE" -ne 0 ] ||
+  echo "settle: 0 — copies are not mtime-separated; verdicts assume BUILD shares no cache" >&2
 
 ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX") || exit 2
 ACTIVE_PID="" ACTIVE_GROUP=""

--- a/skills/reviewer/tests/mutation-stability.test.sh
+++ b/skills/reviewer/tests/mutation-stability.test.sh
@@ -28,6 +28,12 @@ stopped() {
   ! kill -0 "$pid" 2>/dev/null
 }
 
+# Every case up to the shared-cache block below builds with `true` or a `test`
+# — nothing that keeps a cache, so nothing the copy's mtime has to outrank.
+# The two blocks that DO put a whole-second cache behind the build clear this
+# again and spend the real wait.
+export MUTATION_STABILITY_SETTLE=0
+
 TMP=$(mktemp -d "${TMPDIR:-/tmp}/ms-test.XXXXXX") || exit 2
 trap 'rm -rf "$TMP"' EXIT
 REPO="$TMP/repo"
@@ -97,6 +103,42 @@ lacks "killed" "a non-compiling mutant is never killed"
 # One invalid input proves the shared positive-integer validator.
 run_ms "$SHA" --test 'true' --build 'true' --mutate 'true' --timeout 0
 is_rc 2 "the numeric validator rejects zero"
+
+# The settle has its own validator: it admits the 0 the shared one refuses,
+# and refuses everything that is not a count of seconds.
+rc=0
+out=$(MUTATION_STABILITY_SETTLE=soon "$MS" --worktree "$REPO" --sha "$SHA" \
+  --test 'true' --build 'true' --mutate 'true' --stability 1 2>&1) || rc=$?
+is_rc 2 "a settle that is not a number of seconds exits 2"
+has "MUTATION_STABILITY_SETTLE wants a whole number of seconds" "the rejected settle is named"
+
+# And 0 really skips the wait rather than merely shortening it. What the run
+# asked for is read off a sleep stub: the settle is the only whole-second
+# sleeper in the script, and the sub-second waits are its own polls, which the
+# stub still performs so the run behaves normally.
+mkdir -p "$TMP/sleepbin"
+cat >"$TMP/sleepbin/sleep" <<SH
+#!/bin/sh
+printf '%s\n' "\$1" >>"$TMP/slept"
+case "\$1" in *.*) exec $(command -v sleep) "\$@" ;; esac
+SH
+chmod +x "$TMP/sleepbin/sleep"
+settle_arm() { # DESC EXPECTATION(present|absent) env-argument...
+  desc="$1"; want="$2"; shift 2
+  : >"$TMP/slept"
+  rc=0
+  out=$(env "$@" PATH="$TMP/sleepbin:$PATH" "$MS" \
+    --worktree "$REPO" --sha "$SHA" --test 'bash check.sh' --build 'true' \
+    --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
+    --stability 1 --threads 2 2>&1) || rc=$?
+  is_rc 0 "control: $desc still reaches its verdict"
+  if grep -qxE '[0-9]+' "$TMP/slept"; then found=present; else found=absent; fi
+  if [ "$found" = "$want" ]; then ok "$desc"; else
+    bad "$desc" "whole-second wait $found; slept: $(tr '\n' ' ' <"$TMP/slept")"
+  fi
+}
+settle_arm "the default settle waits a whole second" present -u MUTATION_STABILITY_SETTLE
+settle_arm "a zero settle asks for no wait at all" absent MUTATION_STABILITY_SETTLE=0
 
 # KEN-999: one timeout control also checks adoption under a non-reaping PID 1.
 export HANG_PID_FILE="$TMP/timeout-child.pid"
@@ -178,7 +220,9 @@ run_ms "$SHA2" --test 'bash check.sh' --build 'true' \
 is_rc 1 "stability failure exits 1 even with the mutant killed"
 has "stability: 1/3 at 2 threads" "partial stability is reported as Y/N"
 
-# Shared whole-second caches must rebuild for mutant and clean copies.
+# Shared whole-second caches must rebuild for mutant and clean copies. This is
+# the wait's whole reason, so from here the default settle is what runs.
+unset MUTATION_STABILITY_SETTLE
 export CACHE="$TMP/build-cache"
 mkdir -p "$CACHE"
 cat > "$REPO/check.sh" <<'T'

--- a/skills/reviewer/tests/mutation-stability.test.sh
+++ b/skills/reviewer/tests/mutation-stability.test.sh
@@ -76,7 +76,10 @@ run_ms "$SHA" --test 'bash check.sh' --build 'true' \
   --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
   --stability 2 --threads 2
 is_rc 0 "killed mutant exits 0"
-if [ "$out" = "mutation: killed 1/1; stability: 2/2 at 2 threads" ]; then ok "summary line is the exact format"; else bad "summary line is the exact format" "$out"; fi
+# The LAST line, not the whole stream: the run may say something on stderr
+# first — a skipped settle boundary does — and the claim here is the shape of
+# the verdict this script ends on.
+if [ "${out##*$'\n'}" = "mutation: killed 1/1; stability: 2/2 at 2 threads" ]; then ok "summary line is the exact format"; else bad "summary line is the exact format" "$out"; fi
 
 run_ms "$SHA" --test 'bash check.sh' --build 'true' \
   --mutate 'echo "# decoy: still says +" >> lib.sh' --stability 1
@@ -138,7 +141,13 @@ settle_arm() { # DESC EXPECTATION(present|absent) env-argument...
   fi
 }
 settle_arm "the default settle waits a whole second" present -u MUTATION_STABILITY_SETTLE
+lacks "settle: 0" "the default run says nothing about a skipped boundary"
 settle_arm "a zero settle asks for no wait at all" absent MUTATION_STABILITY_SETTLE=0
+# A verdict reached without the boundary has to be identifiable afterwards:
+# where BUILD does share a cache, a reused binary reads as a survivor and
+# nothing else in the output says why.
+has "settle: 0 — copies are not mtime-separated" \
+  "a skipped boundary is named in the run's own output"
 
 # KEN-999: one timeout control also checks adoption under a non-reaping PID 1.
 export HANG_PID_FILE="$TMP/timeout-child.pid"

--- a/skills/reviewer/tests/mutation-stability.test.sh
+++ b/skills/reviewer/tests/mutation-stability.test.sh
@@ -126,7 +126,10 @@ printf '%s\n' "\$1" >>"$TMP/slept"
 case "\$1" in *.*) exec $(command -v sleep) "\$@" ;; esac
 SH
 chmod +x "$TMP/sleepbin/sleep"
-settle_arm() { # DESC EXPECTATION(present|absent) env-argument...
+# WANT is the number of seconds the run should have asked for, or `absent` for
+# no whole-second wait at all. The figure and not just its shape: a default
+# silently changed from 1 to 30 is still a whole number, and would read green.
+settle_arm() { # DESC EXPECTATION(seconds|absent) env-argument...
   desc="$1"; want="$2"; shift 2
   : >"$TMP/slept"
   rc=0
@@ -135,12 +138,13 @@ settle_arm() { # DESC EXPECTATION(present|absent) env-argument...
     --mutate 'sed -i.bak "s/+/-/" lib.sh && rm -f lib.sh.bak' \
     --stability 1 --threads 2 2>&1) || rc=$?
   is_rc 0 "control: $desc still reaches its verdict"
-  if grep -qxE '[0-9]+' "$TMP/slept"; then found=present; else found=absent; fi
+  found="$(grep -xE '[0-9]+' "$TMP/slept" | head -1 || true)"
+  [ -n "$found" ] || found=absent
   if [ "$found" = "$want" ]; then ok "$desc"; else
     bad "$desc" "whole-second wait $found; slept: $(tr '\n' ' ' <"$TMP/slept")"
   fi
 }
-settle_arm "the default settle waits a whole second" present -u MUTATION_STABILITY_SETTLE
+settle_arm "the default settle waits one whole second" 1 -u MUTATION_STABILITY_SETTLE
 lacks "settle: 0" "the default run says nothing about a skipped boundary"
 settle_arm "a zero settle asks for no wait at all" absent MUTATION_STABILITY_SETTLE=0
 # A verdict reached without the boundary has to be identifiable afterwards:

--- a/skills/reviewer/tests/mutation-stability.test.sh
+++ b/skills/reviewer/tests/mutation-stability.test.sh
@@ -115,6 +115,15 @@ out=$(MUTATION_STABILITY_SETTLE=soon "$MS" --worktree "$REPO" --sha "$SHA" \
 is_rc 2 "a settle that is not a number of seconds exits 2"
 has "MUTATION_STABILITY_SETTLE wants a whole number of seconds" "the rejected settle is named"
 
+# Width is part of that grammar: unrefused, this figure is one the shell's
+# tests read as an error and sleep waits out, so the run hangs on its first
+# write to a copy instead of reporting the setting.
+rc=0
+out=$(MUTATION_STABILITY_SETTLE=18446744073709551616 "$MS" --worktree "$REPO" --sha "$SHA" \
+  --test 'true' --build 'true' --mutate 'true' --stability 1 2>&1) || rc=$?
+is_rc 2 "a settle too wide for the arithmetic exits 2"
+has "MUTATION_STABILITY_SETTLE wants a whole number of seconds" "the over-wide settle is named"
+
 # And 0 really skips the wait rather than merely shortening it. What the run
 # asked for is read off a sleep stub: the settle is the only whole-second
 # sleeper in the script, and the sub-second waits are its own polls, which the

--- a/skills/second-opinion/tests/cli-failure-gate.test.sh
+++ b/skills/second-opinion/tests/cli-failure-gate.test.sh
@@ -27,6 +27,8 @@ export SECOND_OPINION_CURRENT_MODEL=none
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 SECOND_OPINION="$REPO_ROOT/skills/second-opinion/scripts/second-opinion"
+# shellcheck source=lib/path-farm.bash
+. "$SCRIPT_DIR/lib/path-farm.bash"
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
@@ -1003,16 +1005,7 @@ echo "=== scenario 10n: without jq the sibling sweep is skipped, and says so ===
 # it from siblings that are still there. Built by mirroring the real PATH minus
 # jq, so the fixture cannot rot as the script's command set changes.
 s10n_bin="$TMP_ROOT/nojq"
-mkdir -p "$s10n_bin"
-while IFS= read -r s10n_dir; do
-  [[ -d "$s10n_dir" ]] || continue
-  for s10n_f in "$s10n_dir"/*; do
-    [[ -f "$s10n_f" && -x "$s10n_f" ]] || continue
-    s10n_b="${s10n_f##*/}"
-    [[ "$s10n_b" == jq ]] && continue
-    [[ -e "$s10n_bin/$s10n_b" ]] || ln -sf "$s10n_f" "$s10n_bin/$s10n_b" 2>/dev/null || true
-  done
-done < <(printf '%s\n' "$PATH" | tr ':' '\n')
+path_farm_without "$s10n_bin" jq
 if PATH="$s10n_bin" command -v jq >/dev/null 2>&1 || ! PATH="$s10n_bin" command -v git >/dev/null 2>&1; then
   skip "no-jq sweep: could not build a PATH with git but without jq"
 else

--- a/skills/second-opinion/tests/lib/path-farm.bash
+++ b/skills/second-opinion/tests/lib/path-farm.bash
@@ -1,0 +1,32 @@
+# shellcheck shell=bash
+# A PATH with named commands hidden, for the cases that must run as a host
+# without them. Sourced, never run as a suite: the runners glob tests/*.sh,
+# so both the subdirectory and the .bash name keep this file out of every run.
+#
+# Mirroring the caller's own PATH rather than listing what to keep is what
+# makes the fixture rot-proof: a script that grows a new dependency still
+# finds it here, and only what was named is missing.
+
+# One `ln` per source directory, not one per file — /usr/bin alone is a few
+# thousand forks. A name already staged is skipped, which is PATH's own
+# first-directory-wins rule. Nothing sets nullglob: a directory with no
+# entries yields the unmatched pattern, which is not a file and is dropped by
+# the same test that drops a non-executable one.
+path_farm_without() { # DIR NAME... — stage DIR as a PATH missing every NAME
+  local dir="$1" hidden="" src="" f="" base=""
+  shift
+  hidden=" $* "
+  mkdir -p "$dir" || return 1
+  while IFS= read -r src; do
+    [ -d "$src" ] || continue
+    local staged=()
+    for f in "$src"/*; do
+      { [ -f "$f" ] && [ -x "$f" ]; } || continue
+      base="${f##*/}"
+      case "$hidden" in *" $base "*) continue ;; esac
+      [ ! -e "$dir/$base" ] || continue
+      staged+=("$f")
+    done
+    [ "${#staged[@]}" -eq 0 ] || ln -s -- "${staged[@]}" "$dir/" 2>/dev/null || true
+  done < <(printf '%s\n' "$PATH" | tr ':' '\n')
+}

--- a/skills/second-opinion/tests/process-tree.test.sh
+++ b/skills/second-opinion/tests/process-tree.test.sh
@@ -114,7 +114,7 @@ cat >/dev/null
 sleep 120 &
 printf '%s\n' "$!" > "$CLI_KID_FILE"
 printf 'started\n' > "$CLI_READY_FILE"
-sleep 1
+sleep 0.2
 printf 'leader done\n'
 SH
 chmod +x "$TMP_ROOT/bin/orphan-codex"
@@ -150,15 +150,15 @@ else
 start=$(date +%s)
 rc=0
 captured=$(CLI_READY_FILE="$TMP_ROOT/tree.ready" CLI_KID_FILE="$TMP_ROOT/tree.kid" \
-  SECOND_OPINION_CODEX_CMD=treeish-codex SECOND_OPINION_TIMEOUT=2 \
+  SECOND_OPINION_CODEX_CMD=treeish-codex SECOND_OPINION_TIMEOUT=1 \
   "$SECOND_OPINION" quick question --cwd "$TMP_ROOT/work" \
   2> "$TMP_ROOT/tree.stderr") || rc=$?
 elapsed=$(( $(date +%s) - start ))
 kid="$(read_pid "$TMP_ROOT/tree.kid" "the timed-out CLI")"
 STRAYS+=("$kid")
 [[ $elapsed -lt 60 ]] \
-  || fail "the caller waited ${elapsed}s for a 2s timeout — a survivor held the pipe open"
-ok "the capturing caller returns promptly (${elapsed}s) after a 2s timeout"
+  || fail "the caller waited ${elapsed}s for a 1s timeout — a survivor held the pipe open"
+ok "the capturing caller returns promptly (${elapsed}s) after a 1s timeout"
 await_gone "$kid" || fail "the CLI's child $kid survived the timeout"
 ok "the timeout took the CLI's child with it"
 [[ $rc -ne 0 ]] || fail "a timed-out CLI must not read as success"
@@ -215,7 +215,10 @@ capture_group_run() { # RUNTIME LABEL -> "rc", 124 when the capture outran the b
     bash -c 'out=$("$1" group-run "$2" orphan-codex < /dev/null); printf %s "$out" > "$3"' \
     _ "$runtime" "$TMP_ROOT/$label.stderr" "$TMP_ROOT/$label.out" &
   job=$!
-  end=$(($(date +%s) + 8))
+  # 3s: the shipped runtime releases the capture as soon as the orphan CLI's
+  # leader exits (0.2s in), and the leader-probe control never releases it at
+  # all, so anything above the leader's own life only lengthens the control.
+  end=$(($(date +%s) + 3))
   while kill -0 "$job" 2>/dev/null; do
     if [[ $(date +%s) -ge $end ]]; then
       kill -KILL "$job" 2>/dev/null || true
@@ -278,7 +281,7 @@ CLI_READY_FILE="$TMP_ROOT/dl.ready" CLI_KID_FILE="$TMP_ROOT/dl.kid" \
   SECOND_OPINION_LAUNCH_MODEL=claude \
   SECOND_OPINION_CODEX_CMD=treeish-codex \
   "$RUNTIME" launch "$SECOND_OPINION" "$TMP_ROOT/dl-answer" "$TMP_ROOT/dl-runtime" \
-  6 false 10 quick question --target=codex --cwd "$TMP_ROOT/work" --timeout 600 \
+  4 false 10 quick question --target=codex --cwd "$TMP_ROOT/work" --timeout 600 \
   > "$TMP_ROOT/dl-launch.stdout" 2> "$TMP_ROOT/dl-launch.stderr"
 dl_wait="$(sed -n 's/^wait: //p' "$TMP_ROOT/dl-launch.stdout")"
 dl_pid="$(read_pid "$TMP_ROOT/dl-runtime/pid" "the detached launcher")"

--- a/skills/second-opinion/tests/timeout-defaults.test.sh
+++ b/skills/second-opinion/tests/timeout-defaults.test.sh
@@ -14,6 +14,8 @@ export SECOND_OPINION_CURRENT_MODEL=none
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+# shellcheck source=lib/path-farm.bash
+. "$SCRIPT_DIR/lib/path-farm.bash"
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
@@ -137,15 +139,7 @@ assert_contains "$zero_stderr" "must be a positive integer" "--timeout 0 is refu
 # warning, not a refusal. Hide both binaries behind a symlink farm of the rest
 # of PATH.
 NOTIMEOUT="$TMP_ROOT/notimeout"
-mkdir -p "$NOTIMEOUT"
-IFS=: read -ra _path_dirs <<< "$PATH"
-for _d in "${_path_dirs[@]}"; do
-  for _f in "$_d"/*; do
-    _b="${_f##*/}"
-    [[ "$_b" == timeout || "$_b" == gtimeout ]] && continue
-    [[ -e "$NOTIMEOUT/$_b" ]] || ln -s "$_f" "$NOTIMEOUT/$_b" 2>/dev/null || true
-  done
-done
+path_farm_without "$NOTIMEOUT" timeout gtimeout
 
 notimeout_stderr="$TMP_ROOT/notimeout.stderr"
 PATH="$TMP_ROOT/bin:$NOTIMEOUT" \

--- a/skills/size-ratchet/DEVELOPMENT.md
+++ b/skills/size-ratchet/DEVELOPMENT.md
@@ -67,15 +67,17 @@ still governs unless the rewrite lands.
 ## Trusted reference snapshot
 
 `resolve_head_baseline_file` sets the settings library's HEAD mode and calls
-`sr_setting`. `sr_settings_source` owns source names, precedence, historical
-materialization, and tracked-symlink traversal. `git ls-tree` answers for a
-complete path only, so before it may report a source absent from HEAD,
-`sr_settings_head_absence_real` classifies each ancestor: absent ends the
-walk, a tree continues it, and anything else — a symlink above all — is a
-lookup that could not be performed and refuses. Materialized copies are named
-`settings.file.<encoded path>`, a namespace the `settings.absent` sentinel
-cannot occupy, so no source name can materialize onto the path that means "not
-there". The main script handles only the flag and process-key overrides, then
+`sr_setting`. `sr_settings_resolve` owns source names, precedence, historical
+materialization, and tracked-symlink traversal; `sr_settings_source` is the
+memo front over it, recording each answer beside the snapshot it came from.
+`git ls-tree` answers for a complete path only, so before it may report a
+source absent from HEAD, `sr_settings_head_absence_real` classifies each
+ancestor: absent ends the walk, a tree continues it, and anything else — a
+symlink above all — is a lookup that could not be performed and refuses.
+Materialized copies are named `settings.file.<encoded path>` and the memos
+`settings.resolved.<encoded path>`, two namespaces the `settings.absent`
+sentinel cannot occupy, so no source name can materialize onto the path that
+means "not there". The main script handles only the flag and process-key overrides, then
 reads the baseline at the returned path. `rows_raised` consumes only those rows. The behavioral rule is
 [README.md § Trusted HEAD baseline](README.md#trusted-head-baseline).
 

--- a/skills/size-ratchet/DEVELOPMENT.md
+++ b/skills/size-ratchet/DEVELOPMENT.md
@@ -77,7 +77,9 @@ symlink above all — is a lookup that could not be performed and refuses.
 Materialized copies are named `settings.file.<encoded path>` and the memos
 `settings.resolved.<encoded path>`, two namespaces the `settings.absent`
 sentinel cannot occupy, so no source name can materialize onto the path that
-means "not there". The main script handles only the flag and process-key overrides, then
+means "not there". A memo is only a cache, so one whose name will not fit as a
+single filesystem component is not written and that source resolves uncached.
+The main script handles only the flag and process-key overrides, then
 reads the baseline at the returned path. `rows_raised` consumes only those rows. The behavioral rule is
 [README.md § Trusted HEAD baseline](README.md#trusted-head-baseline).
 

--- a/skills/size-ratchet/scripts/lib/settings.sh
+++ b/skills/size-ratchet/scripts/lib/settings.sh
@@ -196,10 +196,10 @@ sr_settings_source() { # FILE — the path to actually read; nonzero + ::error o
       return 0
       ;;
   esac
-  printf '%s\n' "$resolved" >"$memo" || {
-    echo "::error::$1: could not record the resolved settings source at $memo" >&2
-    return 1
-  }
+  # The memo is only a cache, and a slug spends three characters on `/` and
+  # `.`, so a legal path can encode past NAME_MAX. A write that cannot land
+  # costs a re-resolve, not an answer; stderr first silences bash's error.
+  printf '%s\n' "$resolved" 2>/dev/null >"$memo" || :
   printf '%s' "$resolved"
 }
 

--- a/skills/size-ratchet/scripts/lib/settings.sh
+++ b/skills/size-ratchet/scripts/lib/settings.sh
@@ -172,14 +172,8 @@ sr_settings_source() { # FILE — the path to actually read; nonzero + ::error o
   elif [ "${SR_SETTINGS_FROM_INDEX:-0}" = "1" ]; then
     dir="${SR_SETTINGS_INDEX_DIR:-}"
   fi
-  # No snapshot, or a name that cannot round-trip through a one-line memo:
-  # resolve it the long way rather than record an answer that reads back wrong.
-  case "$dir$SR_SETTINGS_NL$1" in
-    "$SR_SETTINGS_NL"* | *"$SR_SETTINGS_NL"*"$SR_SETTINGS_NL"*)
-      sr_settings_resolve "$1"
-      return
-      ;;
-  esac
+  # No snapshot: nothing to memoize, and nowhere to put it.
+  [ -n "$dir" ] || { sr_settings_resolve "$1"; return; }
   sr_settings_slug "$1"
   memo="$dir/settings.resolved.$SR_SETTINGS_SLUG"
   if [ -f "$memo" ]; then
@@ -192,6 +186,16 @@ sr_settings_source() { # FILE — the path to actually read; nonzero + ::error o
     fi
   fi
   resolved="$(sr_settings_resolve "$1")" || return 1
+  # A memo holds one line, so a resolution carrying a newline cannot come back
+  # out: the read above would return its first line, which names no file, and
+  # the key would fall back to its default with nothing said. Guarded on the
+  # value, not on what built it, so a new return path cannot reopen this.
+  case "$resolved" in
+    *"$SR_SETTINGS_NL"*)
+      printf '%s' "$resolved"
+      return 0
+      ;;
+  esac
   printf '%s\n' "$resolved" >"$memo" || {
     echo "::error::$1: could not record the resolved settings source at $memo" >&2
     return 1

--- a/skills/size-ratchet/scripts/lib/settings.sh
+++ b/skills/size-ratchet/scripts/lib/settings.sh
@@ -144,7 +144,62 @@ sr_settings_head_absence_real() { # NORMALIZED-PATH — 0 = the sentinel is earn
     return 1
   done
 }
+# A flat, reversible name for a repo-relative path, so a snapshot directory
+# holds one entry per source. Parameter expansion rather than sed: this runs
+# for every source of every key read, and a fork here is most of what a small
+# repository spends resolving its settings.
+sr_settings_slug() { # PATH — sets SR_SETTINGS_SLUG
+  local s="$1"
+  s="${s//%/%25}"
+  s="${s//\//%2F}"
+  s="${s//./%2E}"
+  SR_SETTINGS_SLUG="$s"
+}
+
+SR_SETTINGS_NL='
+'
+
+# Resolution against a snapshot is a pure function of the snapshot and the
+# path: nothing in a run rewrites the index or moves HEAD under it. Each key
+# read re-asks for the same two settings files and .env.local, and each ask
+# costs several git probes, so the answer is recorded beside the snapshot it
+# came from. It has to be ON DISK: every caller wraps this in a command
+# substitution, and a shell variable would not survive that subshell.
 sr_settings_source() { # FILE — the path to actually read; nonzero + ::error on failure
+  local dir="" memo="" resolved=""
+  if [ "${SR_SETTINGS_FROM_HEAD:-0}" = "1" ]; then
+    dir="${SR_SETTINGS_HEAD_DIR:-}"
+  elif [ "${SR_SETTINGS_FROM_INDEX:-0}" = "1" ]; then
+    dir="${SR_SETTINGS_INDEX_DIR:-}"
+  fi
+  # No snapshot, or a name that cannot round-trip through a one-line memo:
+  # resolve it the long way rather than record an answer that reads back wrong.
+  case "$dir$SR_SETTINGS_NL$1" in
+    "$SR_SETTINGS_NL"* | *"$SR_SETTINGS_NL"*"$SR_SETTINGS_NL"*)
+      sr_settings_resolve "$1"
+      return
+      ;;
+  esac
+  sr_settings_slug "$1"
+  memo="$dir/settings.resolved.$SR_SETTINGS_SLUG"
+  if [ -f "$memo" ]; then
+    IFS= read -r resolved <"$memo" || resolved=""
+    # A resolution is always a path, so an empty read is a torn or unreadable
+    # memo, never a recorded answer: fall through and resolve it again.
+    if [ -n "$resolved" ]; then
+      printf '%s' "$resolved"
+      return 0
+    fi
+  fi
+  resolved="$(sr_settings_resolve "$1")" || return 1
+  printf '%s\n' "$resolved" >"$memo" || {
+    echo "::error::$1: could not record the resolved settings source at $memo" >&2
+    return 1
+  }
+  printf '%s' "$resolved"
+}
+
+sr_settings_resolve() { # FILE — the path to actually read; nonzero + ::error on failure
   local file="$1" copy="" status=0 entry="" norm="" head_status=0 tree_status=0 target="" base="" depth=0
   if [ "${SR_SETTINGS_FROM_HEAD:-0}" = "1" ]; then
     if [ -z "${SR_SETTINGS_HEAD_DIR:-}" ]; then
@@ -208,7 +263,8 @@ sr_settings_source() { # FILE — the path to actually read; nonzero + ::error o
           ;;
       esac
     done
-    copy="$SR_SETTINGS_HEAD_DIR/settings.file.$(printf '%s' "$file" | sed -e 's/%/%25/g' -e 's|/|%2F|g' -e 's/[.]/%2E/g')"
+    sr_settings_slug "$file"
+    copy="$SR_SETTINGS_HEAD_DIR/settings.file.$SR_SETTINGS_SLUG"
     if [ ! -f "$copy" ] && ! git show "HEAD:$file" >"$copy" 2>/dev/null; then
       rm -f -- "$copy"
       echo "::error::$file: could not read its HEAD settings content" >&2
@@ -281,7 +337,8 @@ sr_settings_source() { # FILE — the path to actually read; nonzero + ::error o
       return 1
       ;;
   esac
-  copy="$SR_SETTINGS_INDEX_DIR/settings.file.$(printf '%s' "$file" | sed -e 's/%/%25/g' -e 's|/|%2F|g' -e 's/[.]/%2E/g')"
+  sr_settings_slug "$file"
+  copy="$SR_SETTINGS_INDEX_DIR/settings.file.$SR_SETTINGS_SLUG"
   if [ ! -f "$copy" ]; then
     if ! git show ":$file" >"$copy" 2>/dev/null; then
       rm -f -- "$copy"

--- a/skills/size-ratchet/tests/settings-and-config.test.sh
+++ b/skills/size-ratchet/tests/settings-and-config.test.sh
@@ -294,6 +294,23 @@ run_raw SIZE_RATCHET_SETTINGS_FILE=absent.settings.toml || true
   && ok "an ABSENT plain file still falls back to the built-in default (control)" \
   || bad "an ABSENT plain file still falls back to the built-in default (control)" "rc=$RC out=$OUT"
 
+echo "=== a resolved source carrying a newline is never memoized ==="
+# Under --staged the library resolves against a snapshot and records each
+# answer in a one-line memo. A resolution with a newline in it cannot come
+# back out of one: the read returns its first line, which names no file, so
+# every key after the first falls to its default with nothing said. The memo
+# is what makes this reachable, and a settings path is the resolution, so an
+# untracked file whose name carries a newline is the whole condition.
+new_repo memo
+mkfile notes.md 40
+git -C "$R" add -A
+NL_SETTINGS="$(printf 'two\nlines.settings.toml')"
+printf '[env]\nSIZE_RATCHET_THRESHOLD = "12"\nSIZE_RATCHET_CLASSES = "*.md=5"\n' >"$R/$NL_SETTINGS"
+run_raw SIZE_RATCHET_SETTINGS_FILE="$NL_SETTINGS" -- --staged || true
+case "$OUT" in *"threshold 12"*"*.md=5"*) true ;; *) false ;; esac \
+  && ok "the configured threshold and classes still decide a --staged run" \
+  || bad "a newline in the resolved source falls back to the defaults" "rc=$RC out=$OUT"
+
 echo "=== the /dev/null sentinel selects NO settings source, the dotenv layer included ==="
 # It named only the settings file, so .env.local (read before it) kept
 # deciding: a caller asking for built-in defaults got whatever the

--- a/skills/size-ratchet/tests/settings-and-config.test.sh
+++ b/skills/size-ratchet/tests/settings-and-config.test.sh
@@ -311,6 +311,22 @@ case "$OUT" in *"threshold 12"*"*.md=5"*) true ;; *) false ;; esac \
   && ok "the configured threshold and classes still decide a --staged run" \
   || bad "a newline in the resolved source falls back to the defaults" "rc=$RC out=$OUT"
 
+echo "=== a source whose memo name will not fit is resolved uncached ==="
+# The memo name flattens the whole settings path into one basename, and the
+# slug spends three characters on every `/` and `.`, so a path every component
+# of which sits far inside NAME_MAX can encode past that limit. The memo is a
+# cache: such a path resolves the pre-memo way rather than refusing the run.
+new_repo longmemo
+mkfile notes.md 40
+git -C "$R" add -A
+DEEP="$(awk 'BEGIN { for (i = 0; i < 60; i++) printf "d/" }')kendex.settings.toml"
+mkdir -p "$R/$(dirname "$DEEP")"
+printf '[env]\nSIZE_RATCHET_THRESHOLD = "12"\nSIZE_RATCHET_CLASSES = "*.md=5"\n' >"$R/$DEEP"
+run_raw SIZE_RATCHET_SETTINGS_FILE="$DEEP" -- --staged || true
+case "$OUT" in *"threshold 12"*"*.md=5"*) true ;; *) false ;; esac \
+  && ok "a settings path too long to memoize still decides a --staged run" \
+  || bad "an unmemoizable settings path refuses the run" "rc=$RC out=$OUT"
+
 echo "=== the /dev/null sentinel selects NO settings source, the dotenv layer included ==="
 # It named only the settings file, so .env.local (read before it) kept
 # deciding: a caller asking for built-in defaults got whatever the

--- a/skills/worktree/tests/worktree_no_worktree_installs.sh
+++ b/skills/worktree/tests/worktree_no_worktree_installs.sh
@@ -63,15 +63,17 @@ make_repo() { # ROOT NAME — main checkout with a bare origin
   git -C "$root/$name" push -q -u origin main
 }
 
-assert_no_pm_calls() { # NAME — watch 2s and fail the moment any manager runs
-  local name="$1" deadline=$((SECONDS + 2))
-  while [ "$SECONDS" -lt "$deadline" ]; do
-    if [ -s "$PM_CALL_LOG" ]; then
-      bad "$name" "$(cat "$PM_CALL_LOG")"
-      return 1
-    fi
-    sleep 0.2
-  done
+# The log is cumulative and every caller checks it after the worktree command
+# has already returned, so one read covers everything that ran: a manager the
+# command forked and did not wait for is a defect this suite is not the place
+# to catch — `create` has no such path, and if it grew one the install would
+# be unsequenced against the caller regardless.
+assert_no_pm_calls() { # NAME — fail if any package manager has been invoked
+  local name="$1"
+  if [ -s "$PM_CALL_LOG" ]; then
+    bad "$name" "$(cat "$PM_CALL_LOG")"
+    return 1
+  fi
   ok "$name"
 }
 

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -89,7 +89,7 @@ skills/linear/scripts/commands/session-status.sh	431
 skills/linear/scripts/commands/sync.sh	902
 skills/linear/scripts/lib/attachments.sh	490
 skills/linear/scripts/lib/cache.sh	590
-skills/linear/scripts/lib/common.sh	819
+skills/linear/scripts/lib/common.sh	831
 skills/linear/scripts/lib/formatters.sh	631
 skills/orch/scripts/approval-wait	947
 skills/orch/scripts/ci-wait	674
@@ -112,10 +112,10 @@ skills/review-gate/scripts/validate.sh	581
 skills/review-gate/templates/review-gate-writer.yml	658
 skills/review-gate/tests/pr-watch.test.sh	1158
 skills/second-opinion/scripts/second-opinion	2683
-skills/second-opinion/tests/cli-failure-gate.test.sh	1211
+skills/second-opinion/tests/cli-failure-gate.test.sh	1204
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
-skills/size-ratchet/scripts/lib/settings.sh	485
+skills/size-ratchet/scripts/lib/settings.sh	542
 skills/size-ratchet/scripts/size-ratchet	996
 skills/worktree/scripts/worktree	4530
 skills/worktree/scripts/worktree-session-guard	442

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -89,7 +89,7 @@ skills/linear/scripts/commands/session-status.sh	431
 skills/linear/scripts/commands/sync.sh	902
 skills/linear/scripts/lib/attachments.sh	490
 skills/linear/scripts/lib/cache.sh	590
-skills/linear/scripts/lib/common.sh	831
+skills/linear/scripts/lib/common.sh	837
 skills/linear/scripts/lib/formatters.sh	631
 skills/orch/scripts/approval-wait	947
 skills/orch/scripts/ci-wait	674
@@ -115,7 +115,7 @@ skills/second-opinion/scripts/second-opinion	2683
 skills/second-opinion/tests/cli-failure-gate.test.sh	1204
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
-skills/size-ratchet/scripts/lib/settings.sh	542
+skills/size-ratchet/scripts/lib/settings.sh	546
 skills/size-ratchet/scripts/size-ratchet	996
 skills/worktree/scripts/worktree	4530
 skills/worktree/scripts/worktree-session-guard	442

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -58,8 +58,8 @@ skills/decider/scripts/decisions	484
 skills/deep-research/scripts/deep-research	529
 skills/github/scripts/commands/pr-merge.sh	714
 skills/github/scripts/git-diff-summary	599
-skills/github/scripts/lib/gh-auth.sh	494
-skills/github/scripts/lib/github-api.sh	612
+skills/github/scripts/lib/gh-auth.sh	502
+skills/github/scripts/lib/github-api.sh	616
 skills/github/scripts/lib/verify-lib.sh	441
 skills/growth-guards/scripts/install-git-hooks	535
 skills/growth-guards/scripts/lib/settings.sh	467

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -58,7 +58,7 @@ skills/decider/scripts/decisions	484
 skills/deep-research/scripts/deep-research	529
 skills/github/scripts/commands/pr-merge.sh	714
 skills/github/scripts/git-diff-summary	599
-skills/github/scripts/lib/gh-auth.sh	475
+skills/github/scripts/lib/gh-auth.sh	494
 skills/github/scripts/lib/github-api.sh	612
 skills/github/scripts/lib/verify-lib.sh	441
 skills/growth-guards/scripts/install-git-hooks	535


### PR DESCRIPTION
## Summary

- The shell test shard stops waiting on things it stubbed. Every sleep cut here was spent on a stub that answers instantly, a command that had already returned, or a settings file re-resolved once per key. Roughly 145s off the shard, against the issue's 70-90s estimate.
- Three waits become settable so a suite driving a stub can skip the backoff meant for the real thing: `LINEAR_RETRY_BASE_DELAY`, `MUTATION_STABILITY_SETTLE`, and one decimal place on the `KENDEX_GITHUB_*_TIMEOUT` bounds. Each ships with its validator, its docs row, and a test that reads the asked-for delay off a `sleep` stub rather than the clock.
- `linear/tests/must-fail-controls.sh` runs its 50 controls concurrently, `CONTROL_JOBS` wide, and replays results in roster order. `growth-guards` fixtures clone one pruned skill template per suite; `preflight` fixtures copy one seeded repository; two PATH farms become one library and one `ln` per directory.

## Measured

Each figure is a real run on this box, before and after.

| Suite | Before | After |
|---|---|---|
| `linear/tests/must-fail-controls.sh` | ~100s | 33.2s |
| `reviewer/tests/mutation-stability.test.sh` | 26.1s | 12.1s |
| `second-opinion/tests/process-tree.test.sh` | 18.4s | 9.3s |
| `growth-guards/tests/install-git-hooks.test.sh` | 17.0s | 8.6s |
| `github/tests/pr-view.sh` | 14.0s | 7.7s |
| `preflight/tests/precision.test.sh` | 13.7s | 5.4s |
| `linear/tests/rate-limited-http-400.test.sh` | 9.6s | 0.4s |
| `worktree/tests/worktree_no_worktree_installs.sh` | ~10s | 0.8s |
| `growth-guards/tests/install-git-hooks-scope.test.sh` | 7.4s | 1.9s |
| `growth-guards/tests/commit-msg.test.sh` | 7.9s | 4.8s |
| `second-opinion/tests/timeout-defaults.test.sh` | 3.6s | 0.3s |
| `growth-guards/tests/install-git-hooks-check.test.sh` | 2.7s | 1.1s |
| `growth-guards/tests/install-git-hooks-hookspath.test.sh` | 1.7s | 0.6s |

`bounded-signal.test.sh` moves the other way, 0.8s to 2.3s, buying coverage for the new bound parsing. `size-ratchet --staged` on a small repository drops from 0.12s to 0.045s per run, 131 git forks to 28, which every growth-guards commit fixture pays dozens of times per suite.

## Review

Four internal review cycles, 31 findings fixed across five commits. The classes that recurred and where they landed:

| Class | Fix |
|---|---|
| A new setting reaching arithmetic unvalidated | `LINEAR_RETRY_BASE_DELAY` gets the same `10#` decimal reading and leading-zero rejection the github bound already had |
| A bound the runner cannot read failing as something else | `pr-view` refuses it by name, `bot-token` and the git HTTPS helper now say so on stderr, and the op resolver gets its own status instead of borrowing "op not installed" |
| A key shipped with no row a consumer can read | `LINEAR_RETRY_BASE_DELAY` in the linear SKILL.md table, the decimal contract in the github README and settings example |
| Parallel controls losing their verdict | the reap loop's failure accounting is now driven by a fixture whose control genuinely fails, and the runner signals its own children on INT and TERM |

## Completed Issues

- Closes KEN-1012 - Mechanical slow-suite fixes: sleeps, double-runs, fork storms

## Test Plan

- `tools/guard`, `preflight --base origin/main`, `tools/bash32-lint`, and `size-ratchet` all clean on the rebased head.
- Every affected skill suite ran green in one batch, and each modified check was reddened once by a planted defect before being accepted.
- `size-ratchet` carries four row raises. Two were declared in the first commit's body: `linear/scripts/lib/common.sh` 819 to 837 and `size-ratchet/scripts/lib/settings.sh` 485 to 546. Both files are one concept with no seam in them, and the added lines are the change itself: a retry knob and its validator, a memo and the fork-free slug it is keyed by.
- The other two accumulated across the review rounds and are declared here rather than in a commit body, which is the gap a reviewer caught. `skills/github/scripts/lib/gh-auth.sh` 475 to 502 is the bound arms the rounds asked for: its own status for a bound that was never read, the 124-versus-125 split, and the pre-validation that replaced inferring a refusal from an exit code the wrapped command can also return. `skills/github/scripts/lib/github-api.sh` 612 to 616 is the four-line arm that stops the new status re-using the "install op" advice. Neither file has a seam to split on: one is the auth resolver, the other the API client.

https://claude.ai/code/session_01DAzVmQgoevMY4Q9fydAGko

