### PR TITLE
fix(KEN-708): excludes lists carve a tree back into the scan

### DIFF
--- a/.agents/skills/growth-guards/DEVELOPMENT.md
+++ b/.agents/skills/growth-guards/DEVELOPMENT.md
@@ -418,9 +418,9 @@ wildcard is the only maintainable way to name a rendered install, and a repo
 keeping hand-written source inside that tree — a skill declared `source =
 "in-place"` — otherwise has no way to say so, while enumerating the rendered
 siblings by hand is a defect generator. A bare `!` with no pattern after it
-is a config error; `!` is not escapable, so a path literally beginning with
-it cannot be excluded by a row naming it and is scanned instead — the safe
-direction, and the reason no second dialect is worth carrying.
+is a config error. A row that must name a path literally beginning with `!`
+escapes it: `\!foo` never reaches the carve arm and matches that path, so
+one dialect covers both meanings.
 **Baseline format**: `path<TAB>count`, `LC_ALL=C` sorted, unique
 paths, positive counts; malformed, unsorted, or duplicated rows are config
 errors (exit 2), never repaired silently. **Path-globs format**

--- a/.agents/skills/growth-guards/DEVELOPMENT.md
+++ b/.agents/skills/growth-guards/DEVELOPMENT.md
@@ -411,7 +411,17 @@ so all relative paths are repo-root-relative.
 **Excludes format** (all four lists): `pattern<TAB>reason` per line — shell
 glob matched against the full repo-relative path (`*` crosses `/`); blank
 lines and `#` comments ignored; a pattern without a reason is a config
-error. **Baseline format**: `path<TAB>count`, `LC_ALL=C` sorted, unique
+error. A pattern opening with `!` is a CARVE: it pulls its matches back into
+the scanned set and beats every exclusion row regardless of order, so the
+list reads as policy rather than as a sequence. It exists because a tree
+wildcard is the only way to name a rendered install, and a repo keeping
+hand-written source inside that tree — a skill declared `source =
+"in-place"` — otherwise has no way to say so, while enumerating the rendered
+siblings by hand is a defect generator. A bare `!` with no pattern after it
+is a config error; `!` is not escapable, so a path literally beginning with
+it cannot be excluded by a row naming it and is scanned instead — the safe
+direction, and the reason no second dialect is worth carrying.
+**Baseline format**: `path<TAB>count`, `LC_ALL=C` sorted, unique
 paths, positive counts; malformed, unsorted, or duplicated rows are config
 errors (exit 2), never repaired silently. **Path-globs format**
 (`GROWTH_GUARDS_CHANGELOG_PATHS`, `GROWTH_GUARDS_PROSE_PATHS`, both loaded

--- a/.agents/skills/growth-guards/DEVELOPMENT.md
+++ b/.agents/skills/growth-guards/DEVELOPMENT.md
@@ -414,8 +414,8 @@ lines and `#` comments ignored; a pattern without a reason is a config
 error. A pattern opening with `!` is a CARVE: it pulls its matches back into
 the scanned set and beats every exclusion row regardless of order, so the
 list reads as policy rather than as a sequence. It exists because a tree
-wildcard is the only way to name a rendered install, and a repo keeping
-hand-written source inside that tree — a skill declared `source =
+wildcard is the only maintainable way to name a rendered install, and a repo
+keeping hand-written source inside that tree — a skill declared `source =
 "in-place"` — otherwise has no way to say so, while enumerating the rendered
 siblings by hand is a defect generator. A bare `!` with no pattern after it
 is a config error; `!` is not escapable, so a path literally beginning with

--- a/.agents/skills/growth-guards/SKILL.md
+++ b/.agents/skills/growth-guards/SKILL.md
@@ -100,7 +100,8 @@ config error. A pattern opening with `!` carves its matches back into the
 scanned set, and wins over every exclusion row whatever the order — that is
 how hand-written source inside an otherwise excluded render tree
 (`.agents/**` plus `!.agents/skills/my-skill/**`) stays governed. `!` is not
-escapable; a path literally beginning with it is scanned.
+escapable, so a path literally beginning with it cannot be excluded by a row
+naming it, and is scanned instead.
 **Baseline format** — `path<TAB>count`, `LC_ALL=C` sorted,
 unique paths, positive counts.
 Seeding a first baseline and CI wiring: [README.md](README.md). Hook install and removal details: [DEVELOPMENT.md](DEVELOPMENT.md).

--- a/.agents/skills/growth-guards/SKILL.md
+++ b/.agents/skills/growth-guards/SKILL.md
@@ -99,9 +99,8 @@ full repo-relative path; `*` crosses `/`); a pattern without a reason is a
 config error. A pattern opening with `!` carves its matches back into the
 scanned set, and wins over every exclusion row whatever the order — that is
 how hand-written source inside an otherwise excluded render tree
-(`.agents/**` plus `!.agents/skills/my-skill/**`) stays governed. `!` is not
-escapable, so a path literally beginning with it cannot be excluded by a row
-naming it, and is scanned instead.
+(`.agents/**` plus `!.agents/skills/my-skill/**`) stays governed. To exclude a
+path that literally begins with `!`, escape it: `\!foo`.
 **Baseline format** — `path<TAB>count`, `LC_ALL=C` sorted,
 unique paths, positive counts.
 Seeding a first baseline and CI wiring: [README.md](README.md). Hook install and removal details: [DEVELOPMENT.md](DEVELOPMENT.md).

--- a/.agents/skills/growth-guards/SKILL.md
+++ b/.agents/skills/growth-guards/SKILL.md
@@ -96,6 +96,11 @@ Settings follow [README.md § Configuration](README.md#configuration).
 
 **Excludes format** — `pattern<TAB>reason` per line (shell glob against the
 full repo-relative path; `*` crosses `/`); a pattern without a reason is a
-config error. **Baseline format** — `path<TAB>count`, `LC_ALL=C` sorted,
+config error. A pattern opening with `!` carves its matches back into the
+scanned set, and wins over every exclusion row whatever the order — that is
+how hand-written source inside an otherwise excluded render tree
+(`.agents/**` plus `!.agents/skills/my-skill/**`) stays governed. `!` is not
+escapable; a path literally beginning with it is scanned.
+**Baseline format** — `path<TAB>count`, `LC_ALL=C` sorted,
 unique paths, positive counts.
 Seeding a first baseline and CI wiring: [README.md](README.md). Hook install and removal details: [DEVELOPMENT.md](DEVELOPMENT.md).

--- a/.agents/skills/growth-guards/scripts/lib/configured-paths.sh
+++ b/.agents/skills/growth-guards/scripts/lib/configured-paths.sh
@@ -325,8 +325,8 @@ gg_policy_content() { # FILE — content on stdout; 1 = the commit has no such f
 # blank lines and `#` comments are ignored; a pattern without a reason is a
 # config error. A missing file is an empty list. A `!` pattern CARVES its
 # matches back into the scanned set and beats every exclusion row whatever the
-# order (DEVELOPMENT.md § Excludes format). `!` is not escapable: a path that
-# literally begins with it is scanned, the safe direction.
+# order (DEVELOPMENT.md § Excludes format). `!` is not escapable, so no row
+# NAMING a path that begins with one can exclude it, the safe direction.
 gg_load_excludes() { # FILE — fills GG_EXCLUDE_PATTERNS and GG_EXCLUDE_CARVES
   local file="$1" line lineno pat reason carve content status=0
   GG_EXCLUDE_PATTERNS=()

--- a/.agents/skills/growth-guards/scripts/lib/configured-paths.sh
+++ b/.agents/skills/growth-guards/scripts/lib/configured-paths.sh
@@ -324,9 +324,23 @@ gg_policy_content() { # FILE — content on stdout; 1 = the commit has no such f
 # Shell glob matched against the full repo-relative path (`*` crosses `/`);
 # blank lines and `#` comments are ignored; a pattern without a reason is a
 # config error. A missing file is an empty list.
-gg_load_excludes() { # FILE — fills GG_EXCLUDE_PATTERNS
-  local file="$1" line lineno pat reason content status=0
+#
+# A row whose pattern opens with `!` CARVES the paths it matches back into the
+# scanned set. It exists because a tree wildcard is the only way to name a
+# rendered install (`.agents/**`) and a repo that keeps hand-written source
+# inside that tree — a skill declared `source = "in-place"` — otherwise has no
+# way to say so, and enumerating the rendered siblings instead is a defect
+# generator. Carving wins over every exclusion row regardless of order, so a
+# list stays readable as policy rather than as a sequence.
+#
+# `!` is not escapable: a repo path that literally begins with `!` therefore
+# cannot be excluded by a row naming it. That direction is the safe one — the
+# path is SCANNED, and the guard says so out loud — where an escape would add
+# a second dialect to every list for a path shape no repo here has.
+gg_load_excludes() { # FILE — fills GG_EXCLUDE_PATTERNS and GG_EXCLUDE_CARVES
+  local file="$1" line lineno pat reason carve content status=0
   GG_EXCLUDE_PATTERNS=()
+  GG_EXCLUDE_CARVES=()
   # The read runs in a command substitution, so a gg_collection_error inside
   # it dies in that SUBSHELL and arrives here as a status. Only status 1 is
   # the answer "the commit has no such file" (an empty list); anything else
@@ -349,12 +363,21 @@ gg_load_excludes() { # FILE — fills GG_EXCLUDE_PATTERNS
     if [ "$pat" = "$line" ] || [ -z "$pat" ] || [ -z "$reason" ]; then
       gg_config_error "$(gg_shown "$file"):$lineno: expected 'pattern<TAB>reason' (every exclusion carries its justification)"
     fi
-    GG_EXCLUDE_PATTERNS+=("$pat")
+    case "$pat" in
+      "!"*)
+        carve="${pat#!}"
+        [ -n "$carve" ] \
+          || gg_config_error "$(gg_shown "$file"):$lineno: '!' carves matching paths back into the scanned set and needs a pattern after it"
+        GG_EXCLUDE_CARVES+=("$carve")
+        ;;
+      *) GG_EXCLUDE_PATTERNS+=("$pat") ;;
+    esac
   done <<<"$content"
 }
 
-gg_is_excluded() { # PATH — 0 when some exclusion glob matches the full path
-  # The loaded list, matched by the one spelling above. Guarded expansion: an
+gg_is_excluded() { # PATH — 0 when an exclusion glob matches and no `!` row carves it back
+  # The loaded lists, matched by the one spelling above. Guarded expansion: an
   # empty array is an unbound variable under Bash 3.2 with set -u.
-  gg_path_matches "$1" ${GG_EXCLUDE_PATTERNS[@]+"${GG_EXCLUDE_PATTERNS[@]}"}
+  gg_path_matches "$1" ${GG_EXCLUDE_PATTERNS[@]+"${GG_EXCLUDE_PATTERNS[@]}"} || return 1
+  ! gg_path_matches "$1" ${GG_EXCLUDE_CARVES[@]+"${GG_EXCLUDE_CARVES[@]}"}
 }

--- a/.agents/skills/growth-guards/scripts/lib/configured-paths.sh
+++ b/.agents/skills/growth-guards/scripts/lib/configured-paths.sh
@@ -325,8 +325,8 @@ gg_policy_content() { # FILE — content on stdout; 1 = the commit has no such f
 # blank lines and `#` comments are ignored; a pattern without a reason is a
 # config error. A missing file is an empty list. A `!` pattern CARVES its
 # matches back into the scanned set and beats every exclusion row whatever the
-# order (DEVELOPMENT.md § Excludes format). `!` is not escapable, so no row
-# NAMING a path that begins with one can exclude it, the safe direction.
+# order (DEVELOPMENT.md § Excludes format). A row naming a path that begins
+# with `!` escapes it as `\!foo`, which stays an exclusion.
 gg_load_excludes() { # FILE — fills GG_EXCLUDE_PATTERNS and GG_EXCLUDE_CARVES
   local file="$1" line lineno pat reason carve content status=0
   GG_EXCLUDE_PATTERNS=()

--- a/.agents/skills/growth-guards/scripts/lib/configured-paths.sh
+++ b/.agents/skills/growth-guards/scripts/lib/configured-paths.sh
@@ -323,20 +323,10 @@ gg_policy_content() { # FILE — content on stdout; 1 = the commit has no such f
 
 # Shell glob matched against the full repo-relative path (`*` crosses `/`);
 # blank lines and `#` comments are ignored; a pattern without a reason is a
-# config error. A missing file is an empty list.
-#
-# A row whose pattern opens with `!` CARVES the paths it matches back into the
-# scanned set. It exists because a tree wildcard is the only way to name a
-# rendered install (`.agents/**`) and a repo that keeps hand-written source
-# inside that tree — a skill declared `source = "in-place"` — otherwise has no
-# way to say so, and enumerating the rendered siblings instead is a defect
-# generator. Carving wins over every exclusion row regardless of order, so a
-# list stays readable as policy rather than as a sequence.
-#
-# `!` is not escapable: a repo path that literally begins with `!` therefore
-# cannot be excluded by a row naming it. That direction is the safe one — the
-# path is SCANNED, and the guard says so out loud — where an escape would add
-# a second dialect to every list for a path shape no repo here has.
+# config error. A missing file is an empty list. A `!` pattern CARVES its
+# matches back into the scanned set and beats every exclusion row whatever the
+# order (DEVELOPMENT.md § Excludes format). `!` is not escapable: a path that
+# literally begins with it is scanned, the safe direction.
 gg_load_excludes() { # FILE — fills GG_EXCLUDE_PATTERNS and GG_EXCLUDE_CARVES
   local file="$1" line lineno pat reason carve content status=0
   GG_EXCLUDE_PATTERNS=()

--- a/.agents/skills/growth-guards/tests/todo-ban.test.sh
+++ b/.agents/skills/growth-guards/tests/todo-ban.test.sh
@@ -236,6 +236,18 @@ run_tb
   && ok "a bare ! row is a config error naming its line" \
   || bad "a bare ! row is a config error naming its line" "rc=$RC out=$OUT"
 
+# `!` is escapable, which is the only way left to name a path that literally
+# begins with one: `\!name` opens with a backslash, so it never reaches the
+# carve arm, and the case matcher reads it as that literal path.
+new_repo bang
+mkdir -p "$R/tools"
+printf '// %s: a marker under a bang-leading name\n' "$TD" >"$R/!bang.rs"
+printf '\\!bang.rs\tan escaped literal bang path\n' >"$R/tools/todo-ban-excludes"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 0 ] && ok "an escaped row excludes the literal bang path rather than carving it" \
+  || bad "an escaped row excludes the literal bang path" "rc=$RC out=$OUT"
+
 echo "=== a URL is not a comment leader ==="
 new_repo url
 printf 'see http://%s:8080/path for the mock\n' "$TD" >"$R/u.md"

--- a/.agents/skills/growth-guards/tests/todo-ban.test.sh
+++ b/.agents/skills/growth-guards/tests/todo-ban.test.sh
@@ -184,6 +184,58 @@ run_tb
   && ok "must-fail control: the crossing shorthand silences the first-party tree too" \
   || bad "the crossing shorthand did not cross" "rc=$RC out=$OUT"
 
+# The one exclusion row that ADDS coverage. A rendered install can only be
+# named by a tree wildcard, so a repo keeping hand-written source inside that
+# tree — a skill declared `source = "in-place"` — has no other way to say so,
+# and the coverage goes silently absent: the fail-open direction for a gate.
+echo "=== excludes: a ! row carves a subtree back into the scanned set ==="
+new_repo carve
+mkdir -p "$R/.agents/skills/rendered" "$R/.agents/skills/in-place" "$R/tools"
+printf '// %s: a marker in the render\n' "$TD" >"$R/.agents/skills/rendered/lib.rs"
+printf '// %s: a marker in the source of record\n' "$TD" >"$R/.agents/skills/in-place/lib.rs"
+printf '.agents/**\tkendex render, governed at its source\n' >"$R/tools/todo-ban-excludes"
+git -C "$R" add -A
+
+# Control: the blanket row alone silences BOTH planted markers.
+run_tb
+[ "$RC" -eq 0 ] && ok "control: the blanket .agents/** row silences both planted markers" \
+  || bad "control: the blanket .agents/** row silences both markers" "rc=$RC out=$OUT"
+
+printf '.agents/**\tkendex render, governed at its source\n!.agents/skills/in-place/**\tin-place skill: this tree IS the source\n' >"$R/tools/todo-ban-excludes"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 1 ] && case "$OUT" in *".agents/skills/in-place/lib.rs:1:"*) true ;; *) false ;; esac \
+  && ok "the carved tree is scanned again and its planted marker fires" \
+  || bad "the carved tree is scanned again" "rc=$RC out=$OUT"
+case "$OUT" in
+  *".agents/skills/rendered/lib.rs"*) bad "the carve must not widen past its own pattern" "$OUT" ;;
+  *) ok "the sibling render under the same blanket row stays silent" ;;
+esac
+
+# Order is not policy: the carve wins whether it precedes or follows the row
+# it cuts into, so a list reads as a set of rules rather than as a sequence.
+printf '!.agents/skills/in-place/**\tin-place skill: this tree IS the source\n.agents/**\tkendex render, governed at its source\n' >"$R/tools/todo-ban-excludes"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 1 ] && case "$OUT" in *".agents/skills/in-place/lib.rs:1:"*) true ;; *) false ;; esac \
+  && ok "a carve above the row it cuts into carves just the same" \
+  || bad "a carve above the row it cuts into carves just the same" "rc=$RC out=$OUT"
+
+# A carve still needs its reason, like every other row, and a bare '!' names
+# nothing — keeping it silently would widen the scanned set by a typo.
+printf '.agents/**\tkendex render\n!.agents/skills/in-place/**\n' >"$R/tools/todo-ban-excludes"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 2 ] && case "$OUT" in *":2: expected 'pattern<TAB>reason'"*) true ;; *) false ;; esac \
+  && ok "a carve row without a reason is the same config error as any other" \
+  || bad "a carve row without a reason is a config error" "rc=$RC out=$OUT"
+printf '.agents/**\tkendex render\n!\ta carve with no pattern\n' >"$R/tools/todo-ban-excludes"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 2 ] && case "$OUT" in *":2: '!' carves"*) true ;; *) false ;; esac \
+  && ok "a bare ! row is a config error naming its line" \
+  || bad "a bare ! row is a config error naming its line" "rc=$RC out=$OUT"
+
 echo "=== a URL is not a comment leader ==="
 new_repo url
 printf 'see http://%s:8080/path for the mock\n' "$TD" >"$R/u.md"

--- a/.agents/skills/size-ratchet/README.md
+++ b/.agents/skills/size-ratchet/README.md
@@ -209,10 +209,11 @@ src/gen/*.rs	generated bindings
 
 A pattern opening with `!` is a CARVE: it pulls its matches back into the
 measured set and beats every exclusion row whatever the order, so the list
-reads as policy rather than as a sequence. A tree wildcard is the only way to
-name a rendered install, and a repo keeping hand-written source inside that
-tree — a skill declared `source = "in-place"` — otherwise has no way to say
-so:
+reads as policy rather than as a sequence. A tree wildcard is the only
+maintainable way to name a rendered install — enumerating its rendered files
+by hand is a defect generator — and a repo keeping hand-written source inside
+that tree, a skill declared `source = "in-place"`, otherwise has no way to
+say so:
 
 ```
 .agents/*	kendex render, governed at its source

--- a/.agents/skills/size-ratchet/README.md
+++ b/.agents/skills/size-ratchet/README.md
@@ -220,9 +220,9 @@ say so:
 !.agents/skills/my-skill/*	in-place skill: this tree IS the source
 ```
 
-A bare `!` with no pattern after it is a config error. `!` is not escapable,
-so a path literally beginning with it cannot be excluded by a row naming it
-and is measured instead — the safe direction. The baseline file is exempt
+A bare `!` with no pattern after it is a config error. A row that must name a
+path literally beginning with `!` escapes it: `\!foo` never reaches the carve
+arm and matches that path. The baseline file is exempt
 ahead of the carve rows, so no `!` row pulls it into its own gate.
 
 ## Configuration

--- a/.agents/skills/size-ratchet/README.md
+++ b/.agents/skills/size-ratchet/README.md
@@ -207,6 +207,23 @@ vendor/*	vendored third-party code
 src/gen/*.rs	generated bindings
 ```
 
+A pattern opening with `!` is a CARVE: it pulls its matches back into the
+measured set and beats every exclusion row whatever the order, so the list
+reads as policy rather than as a sequence. A tree wildcard is the only way to
+name a rendered install, and a repo keeping hand-written source inside that
+tree — a skill declared `source = "in-place"` — otherwise has no way to say
+so:
+
+```
+.agents/*	kendex render, governed at its source
+!.agents/skills/my-skill/*	in-place skill: this tree IS the source
+```
+
+A bare `!` with no pattern after it is a config error. `!` is not escapable,
+so a path literally beginning with it cannot be excluded by a row naming it
+and is measured instead — the safe direction. The baseline file is exempt
+ahead of the carve rows, so no `!` row pulls it into its own gate.
+
 ## Configuration
 
 | Key | Default | Meaning |

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -324,6 +324,7 @@ case "$excludes_state" in
     ;;
 esac
 EXCLUDE_PATTERNS=()
+CARVE_PATTERNS=()
 while IFS= read -r line; do
   [ -n "$line" ] || continue
   EXCLUDE_PATTERNS+=("${line%%"$TAB"*}")
@@ -343,7 +344,19 @@ if [ -f "$EXCLUDES_SOURCE" ]; then
     if [ "$pat" = "$line" ] || [ -z "$pat" ] || [ -z "$reason" ]; then
       config_error "$EXCLUDES_LABEL:$lineno: expected 'pattern<TAB>reason' (every exclusion carries its justification)"
     fi
-    EXCLUDE_PATTERNS+=("$pat")
+    # A `!` pattern CARVES its matches back into the measured set, the only
+    # way to govern hand-written source living inside an excluded render tree
+    # (README.md § Exclusion list). `!` is not escapable: a path that literally
+    # begins with it is measured, the safe direction.
+    case "$pat" in
+      "!"*)
+        carve="${pat#!}"
+        [ -n "$carve" ] \
+          || config_error "$EXCLUDES_LABEL:$lineno: '!' carves matching paths back into the measured set and needs a pattern after it"
+        CARVE_PATTERNS+=("$carve")
+        ;;
+      *) EXCLUDE_PATTERNS+=("$pat") ;;
+    esac
   done <"$EXCLUDES_SOURCE"
 fi
 glob_match() { # PATH PATTERN — 0 when the glob matches the whole path
@@ -353,9 +366,14 @@ glob_match() { # PATH PATTERN — 0 when the glob matches the whole path
   esac
   return 1
 }
-is_excluded() { # PATH — 0 when some exclusion glob matches the full path
+is_excluded() { # PATH — 0 when an exclusion glob matches and no `!` row carves it back
   local pat
+  # The baseline is policy input, never measured content, and sits ahead of
+  # the carve rows so no `!` pattern can pull it into its own gate.
   [ "$1" != "$BASELINE_FILE" ] || return 0
+  for pat in ${CARVE_PATTERNS[@]+"${CARVE_PATTERNS[@]}"}; do
+    glob_match "$1" "$pat" && return 1
+  done
   for pat in ${EXCLUDE_PATTERNS[@]+"${EXCLUDE_PATTERNS[@]}"}; do
     glob_match "$1" "$pat" && return 0
   done

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -346,8 +346,8 @@ if [ -f "$EXCLUDES_SOURCE" ]; then
     fi
     # A `!` pattern CARVES its matches back into the measured set, the only
     # way to govern hand-written source living inside an excluded render tree
-    # (README.md § Exclusion list). `!` is not escapable: a path that literally
-    # begins with it is measured, the safe direction.
+    # (README.md § Exclusion list). `!` is not escapable, so no row NAMING a
+    # path that begins with one can exclude it, the safe direction.
     case "$pat" in
       "!"*)
         carve="${pat#!}"

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -367,17 +367,18 @@ glob_match() { # PATH PATTERN — 0 when the glob matches the whole path
   return 1
 }
 is_excluded() { # PATH — 0 when an exclusion glob matches and no `!` row carves it back
-  local pat
-  # The baseline is policy input, never measured content, and sits ahead of
-  # the carve rows so no `!` pattern can pull it into its own gate.
+  local pat excluded=1
+  # The baseline is policy input and sits ahead of both loops, so no `!` row
+  # pulls it into its own gate; only an excluded path can be carved back.
   [ "$1" != "$BASELINE_FILE" ] || return 0
+  for pat in ${EXCLUDE_PATTERNS[@]+"${EXCLUDE_PATTERNS[@]}"}; do
+    glob_match "$1" "$pat" && excluded=0 && break
+  done
+  [ "$excluded" -eq 0 ] || return 1
   for pat in ${CARVE_PATTERNS[@]+"${CARVE_PATTERNS[@]}"}; do
     glob_match "$1" "$pat" && return 1
   done
-  for pat in ${EXCLUDE_PATTERNS[@]+"${EXCLUDE_PATTERNS[@]}"}; do
-    glob_match "$1" "$pat" && return 0
-  done
-  return 1
+  return 0
 }
 path_threshold() { # PATH
   local i=0 frozen="" shadowed="" skipped="" hit="" s

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -359,26 +359,22 @@ if [ -f "$EXCLUDES_SOURCE" ]; then
     esac
   done <"$EXCLUDES_SOURCE"
 fi
-glob_match() { # PATH PATTERN — 0 when the glob matches the whole path
-  local path="$1" pat="$2"
-  case "$path" in
-    $pat) return 0 ;;
-  esac
+glob_match() { # PATH PATTERN... — 0 when some pattern matches the whole path
+  local path="$1" pat
+  shift
+  for pat in "$@"; do
+    case "$path" in
+      $pat) return 0 ;;
+    esac
+  done
   return 1
 }
 is_excluded() { # PATH — 0 when an exclusion glob matches and no `!` row carves it back
-  local pat excluded=1
-  # The baseline is policy input and sits ahead of both loops, so no `!` row
-  # pulls it into its own gate; only an excluded path can be carved back.
+  # The baseline is policy input and is matched ahead of both lists, so no `!`
+  # row pulls it into its own gate; only an excluded path can be carved back.
   [ "$1" != "$BASELINE_FILE" ] || return 0
-  for pat in ${EXCLUDE_PATTERNS[@]+"${EXCLUDE_PATTERNS[@]}"}; do
-    glob_match "$1" "$pat" && excluded=0 && break
-  done
-  [ "$excluded" -eq 0 ] || return 1
-  for pat in ${CARVE_PATTERNS[@]+"${CARVE_PATTERNS[@]}"}; do
-    glob_match "$1" "$pat" && return 1
-  done
-  return 0
+  glob_match "$1" ${EXCLUDE_PATTERNS[@]+"${EXCLUDE_PATTERNS[@]}"} || return 1
+  ! glob_match "$1" ${CARVE_PATTERNS[@]+"${CARVE_PATTERNS[@]}"}
 }
 path_threshold() { # PATH
   local i=0 frozen="" shadowed="" skipped="" hit="" s

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -346,8 +346,8 @@ if [ -f "$EXCLUDES_SOURCE" ]; then
     fi
     # A `!` pattern CARVES its matches back into the measured set, the only
     # way to govern hand-written source living inside an excluded render tree
-    # (README.md § Exclusion list). `!` is not escapable, so no row NAMING a
-    # path that begins with one can exclude it, the safe direction.
+    # (README.md § Exclusion list). A row naming a path that begins with `!`
+    # escapes it as `\!foo`, which stays an exclusion.
     case "$pat" in
       "!"*)
         carve="${pat#!}"

--- a/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -301,25 +301,37 @@ run_sr
   || bad "a carve above the row it cuts into carves just the same" "rc=$RC out=$OUT"
 
 # A carve cannot pull the baseline into its own gate: the baseline is policy
-# input, and measuring it would make every row it gains a violation. The
-# `tools/*` row excludes both policy files and the `!*` row carves them back,
-# so the carve list really is consulted for them; the baseline stays out only
-# because its exemption is read ahead of both lists. Its own 11 rows put it
-# over this suite's threshold of 10, so a baseline that reached the gate would
-# fail as a new offender — a shorter one would pass whether the exemption held
-# or not. Every row names a measured file over the threshold, none stale.
+# input, and measuring it would make every row it gains a violation. Both runs
+# below share one baseline whose own 11 rows put it over this suite's
+# threshold of 10, so a baseline that reached the gate would fail as a new
+# offender — a shorter one would pass whether the exemption held or not. Every
+# row names a measured file over the threshold, so none reads as stale.
 for i in 1 2 3 4 5 6 7 8 9; do mkfile ".agents/skills/in-place/part$i.txt" 11; done
-printf 'tools/*\tthe policy files themselves\n!*\tcarve everything back in\n' >"$R/tools/size-ratchet-excludes"
 {
   printf '.agents/skills/in-place/big.txt\t50\n'
   for i in 1 2 3 4 5 6 7 8 9; do printf '.agents/skills/in-place/part%s.txt\t11\n' "$i"; done
   printf '.agents/skills/rendered/big.txt\t50\n'
 } >"$R/tools/size-ratchet-baseline.tsv"
+
+# No row here matches the baseline path, so the exemption is the only thing
+# keeping it out ahead of the EXCLUSION match: move the exemption behind that
+# match and the baseline is measured.
+printf '!*\tcarve everything back in\n' >"$R/tools/size-ratchet-excludes"
 git -C "$R" add -A
 run_sr
 [ "$RC" -eq 0 ] && case "$OUT" in *"tools/size-ratchet-baseline.tsv"*) false ;; *) true ;; esac \
-  && ok "the baseline stays exempt ahead of every carve row, at 11 rows over the threshold" \
-  || bad "the baseline stays exempt ahead of every carve row" "rc=$RC out=$OUT"
+  && ok "the baseline stays exempt ahead of the exclusion match, at 11 rows over the threshold" \
+  || bad "the baseline stays exempt ahead of the exclusion match" "rc=$RC out=$OUT"
+
+# `tools/*` excludes both policy files, so the EXCLUDES FILE reaches the carve
+# list and the `!*` row pulls it back. The baseline never reaches that list,
+# because its exemption is read first, which is what this run pins.
+printf 'tools/*\tthe policy files themselves\n!*\tcarve everything back in\n' >"$R/tools/size-ratchet-excludes"
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 0 ] && case "$OUT" in *"tools/size-ratchet-baseline.tsv"*) false ;; *) true ;; esac \
+  && ok "the baseline stays exempt ahead of the carve match the excludes file reaches" \
+  || bad "the baseline stays exempt ahead of the carve match" "rc=$RC out=$OUT"
 
 # A bare '!' names nothing; silently keeping it would widen or narrow the
 # scanned set by a typo.

--- a/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -301,15 +301,24 @@ run_sr
   || bad "a carve above the row it cuts into carves just the same" "rc=$RC out=$OUT"
 
 # A carve cannot pull the baseline into its own gate: the baseline is policy
-# input, and measuring it would make every row it gains a violation.
+# input, and measuring it would make every row it gains a violation. The
+# baseline written here carries 11 rows against this suite's threshold of 10,
+# so the exemption is the only thing keeping it off the offender list — a
+# shorter one would pass whether the exemption held or not. Every row names a
+# file the `!*` row carves back in and that is over the threshold, so no row
+# reads as stale.
+for i in 1 2 3 4 5 6 7 8 9; do mkfile ".agents/skills/in-place/part$i.txt" 11; done
 printf '!*\tcarve everything back in\n' >"$R/tools/size-ratchet-excludes"
-printf '.agents/skills/in-place/big.txt\t50\n.agents/skills/rendered/big.txt\t50\n' >"$R/tools/size-ratchet-baseline.tsv"
+{
+  printf '.agents/skills/in-place/big.txt\t50\n'
+  for i in 1 2 3 4 5 6 7 8 9; do printf '.agents/skills/in-place/part%s.txt\t11\n' "$i"; done
+  printf '.agents/skills/rendered/big.txt\t50\n'
+} >"$R/tools/size-ratchet-baseline.tsv"
 git -C "$R" add -A
 run_sr
-case "$OUT" in
-  *"tools/size-ratchet-baseline.tsv"*) bad "a carve must not make the baseline measured content" "$OUT" ;;
-  *) ok "the baseline stays exempt ahead of every carve row" ;;
-esac
+[ "$RC" -eq 0 ] && case "$OUT" in *"tools/size-ratchet-baseline.tsv"*) false ;; *) true ;; esac \
+  && ok "the baseline stays exempt ahead of every carve row, at 11 rows over the threshold" \
+  || bad "the baseline stays exempt ahead of every carve row" "rc=$RC out=$OUT"
 
 # A bare '!' names nothing; silently keeping it would widen or narrow the
 # scanned set by a typo.

--- a/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -342,6 +342,19 @@ run_sr
   && ok "a bare ! row is a config error naming its line" \
   || bad "a bare ! row is a config error naming its line" "rc=$RC out=$OUT"
 
+# `!` is escapable, which is the only way left to name a path that literally
+# begins with one: `\!name` opens with a backslash, so it never reaches the
+# carve arm, and the case matcher reads it as that literal path.
+new_repo bang
+mkfile '!bang.txt' 11
+mkdir -p "$R/tools"
+printf '\\!bang.txt\tan escaped literal bang path\n' >"$R/tools/size-ratchet-excludes"
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 0 ] && case "$OUT" in *"!bang.txt"*) false ;; *) true ;; esac \
+  && ok "an escaped row excludes the literal bang path rather than carving it" \
+  || bad "an escaped row excludes the literal bang path" "rc=$RC out=$OUT"
+
 echo "=== --baseline flag relocates the baseline ==="
 new_repo flagpath
 mkfile big.txt 15

--- a/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -263,6 +263,63 @@ run_sr
   && ok "a baseline row for an excluded file is stale — excluded files leave the counted set" \
   || bad "a baseline row for an excluded file is stale" "rc=$RC out=$OUT"
 
+echo "=== a ! row carves a subtree back into the measured set ==="
+# A rendered install can only be named by a tree wildcard, and a repo that
+# keeps hand-written source inside that tree — a skill declared
+# `source = "in-place"` — needs a way to say so. Without it the coverage is
+# silently absent, which is the fail-open direction for a gate.
+new_repo carve
+mkfile .agents/skills/rendered/big.txt 50   # a real render: stays excluded
+mkfile .agents/skills/in-place/big.txt 50   # the source of record: carved back
+mkdir -p "$R/tools"
+printf '.agents/*\tkendex render, governed at its source\n' >"$R/tools/size-ratchet-excludes"
+git -C "$R" add -A
+
+# Control: the blanket row alone silences BOTH, which is the defect.
+run_sr
+[ "$RC" -eq 0 ] && ok "control: the blanket .agents/* row silences both trees" \
+  || bad "control: the blanket .agents/* row silences both trees" "rc=$RC out=$OUT"
+
+printf '.agents/*\tkendex render, governed at its source\n!.agents/skills/in-place/*\tin-place skill: this tree IS the source\n' >"$R/tools/size-ratchet-excludes"
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 1 ] && case "$OUT" in *".agents/skills/in-place/big.txt"*) true ;; *) false ;; esac \
+  && ok "the carved tree is measured again and its offender is named" \
+  || bad "the carved tree is measured again" "rc=$RC out=$OUT"
+case "$OUT" in
+  *".agents/skills/rendered/big.txt"*) bad "the carve must not widen past its own pattern" "$OUT" ;;
+  *) ok "the sibling render under the same blanket row stays excluded" ;;
+esac
+
+# Order is not policy: the carve wins whether it precedes or follows the row
+# it cuts into, so a list reads as a set of rules rather than as a sequence.
+printf '!.agents/skills/in-place/*\tin-place skill: this tree IS the source\n.agents/*\tkendex render, governed at its source\n' >"$R/tools/size-ratchet-excludes"
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 1 ] && case "$OUT" in *".agents/skills/in-place/big.txt"*) true ;; *) false ;; esac \
+  && ok "a carve above the row it cuts into carves just the same" \
+  || bad "a carve above the row it cuts into carves just the same" "rc=$RC out=$OUT"
+
+# A carve cannot pull the baseline into its own gate: the baseline is policy
+# input, and measuring it would make every row it gains a violation.
+printf '!*\tcarve everything back in\n' >"$R/tools/size-ratchet-excludes"
+printf '.agents/skills/in-place/big.txt\t50\n.agents/skills/rendered/big.txt\t50\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+run_sr
+case "$OUT" in
+  *"tools/size-ratchet-baseline.tsv"*) bad "a carve must not make the baseline measured content" "$OUT" ;;
+  *) ok "the baseline stays exempt ahead of every carve row" ;;
+esac
+
+# A bare '!' names nothing; silently keeping it would widen or narrow the
+# scanned set by a typo.
+printf '.agents/*\tkendex render\n!\ta carve with no pattern\n' >"$R/tools/size-ratchet-excludes"
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 2 ] && case "$OUT" in *":2: '!' carves"*) true ;; *) false ;; esac \
+  && ok "a bare ! row is a config error naming its line" \
+  || bad "a bare ! row is a config error naming its line" "rc=$RC out=$OUT"
+
 echo "=== --baseline flag relocates the baseline ==="
 new_repo flagpath
 mkfile big.txt 15

--- a/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/.agents/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -302,13 +302,14 @@ run_sr
 
 # A carve cannot pull the baseline into its own gate: the baseline is policy
 # input, and measuring it would make every row it gains a violation. The
-# baseline written here carries 11 rows against this suite's threshold of 10,
-# so the exemption is the only thing keeping it off the offender list — a
-# shorter one would pass whether the exemption held or not. Every row names a
-# file the `!*` row carves back in and that is over the threshold, so no row
-# reads as stale.
+# `tools/*` row excludes both policy files and the `!*` row carves them back,
+# so the carve list really is consulted for them; the baseline stays out only
+# because its exemption is read ahead of both lists. Its own 11 rows put it
+# over this suite's threshold of 10, so a baseline that reached the gate would
+# fail as a new offender — a shorter one would pass whether the exemption held
+# or not. Every row names a measured file over the threshold, none stale.
 for i in 1 2 3 4 5 6 7 8 9; do mkfile ".agents/skills/in-place/part$i.txt" 11; done
-printf '!*\tcarve everything back in\n' >"$R/tools/size-ratchet-excludes"
+printf 'tools/*\tthe policy files themselves\n!*\tcarve everything back in\n' >"$R/tools/size-ratchet-excludes"
 {
   printf '.agents/skills/in-place/big.txt\t50\n'
   for i in 1 2 3 4 5 6 7 8 9; do printf '.agents/skills/in-place/part%s.txt\t11\n' "$i"; done

--- a/changelog.d/fixed/KEN-708.md
+++ b/changelog.d/fixed/KEN-708.md
@@ -1,0 +1,1 @@
+- Growth-guards and size-ratchet exclusion lists take a `!pattern` row that carves matching paths back into the scanned set, so hand-written source inside an excluded render tree stays governed.

--- a/changelog.d/fixed/KEN-708.md
+++ b/changelog.d/fixed/KEN-708.md
@@ -1,1 +1,1 @@
-- Growth-guards and size-ratchet exclusion lists carve a tree back into the scan with a `!pattern` row. **Breaking:** an existing `!`-leading row now carves; no row naming such a path excludes it.
+- Growth-guards and size-ratchet exclusion lists carve a tree back into the scan with a `!pattern` row. **Breaking:** an existing `!`-leading row now carves; escape it as `\!foo` to exclude.

--- a/changelog.d/fixed/KEN-708.md
+++ b/changelog.d/fixed/KEN-708.md
@@ -1,1 +1,1 @@
-- Growth-guards and size-ratchet exclusion lists take a `!pattern` row that carves matching paths back into the scanned set, so hand-written source inside an excluded render tree stays governed.
+- Growth-guards and size-ratchet exclusion lists carve a tree back into the scan with a `!pattern` row. **Breaking:** an existing `!`-leading row now carves; no row naming such a path excludes it.

--- a/skills/growth-guards/DEVELOPMENT.md
+++ b/skills/growth-guards/DEVELOPMENT.md
@@ -418,9 +418,9 @@ wildcard is the only maintainable way to name a rendered install, and a repo
 keeping hand-written source inside that tree — a skill declared `source =
 "in-place"` — otherwise has no way to say so, while enumerating the rendered
 siblings by hand is a defect generator. A bare `!` with no pattern after it
-is a config error; `!` is not escapable, so a path literally beginning with
-it cannot be excluded by a row naming it and is scanned instead — the safe
-direction, and the reason no second dialect is worth carrying.
+is a config error. A row that must name a path literally beginning with `!`
+escapes it: `\!foo` never reaches the carve arm and matches that path, so
+one dialect covers both meanings.
 **Baseline format**: `path<TAB>count`, `LC_ALL=C` sorted, unique
 paths, positive counts; malformed, unsorted, or duplicated rows are config
 errors (exit 2), never repaired silently. **Path-globs format**

--- a/skills/growth-guards/DEVELOPMENT.md
+++ b/skills/growth-guards/DEVELOPMENT.md
@@ -411,7 +411,17 @@ so all relative paths are repo-root-relative.
 **Excludes format** (all four lists): `pattern<TAB>reason` per line — shell
 glob matched against the full repo-relative path (`*` crosses `/`); blank
 lines and `#` comments ignored; a pattern without a reason is a config
-error. **Baseline format**: `path<TAB>count`, `LC_ALL=C` sorted, unique
+error. A pattern opening with `!` is a CARVE: it pulls its matches back into
+the scanned set and beats every exclusion row regardless of order, so the
+list reads as policy rather than as a sequence. It exists because a tree
+wildcard is the only way to name a rendered install, and a repo keeping
+hand-written source inside that tree — a skill declared `source =
+"in-place"` — otherwise has no way to say so, while enumerating the rendered
+siblings by hand is a defect generator. A bare `!` with no pattern after it
+is a config error; `!` is not escapable, so a path literally beginning with
+it cannot be excluded by a row naming it and is scanned instead — the safe
+direction, and the reason no second dialect is worth carrying.
+**Baseline format**: `path<TAB>count`, `LC_ALL=C` sorted, unique
 paths, positive counts; malformed, unsorted, or duplicated rows are config
 errors (exit 2), never repaired silently. **Path-globs format**
 (`GROWTH_GUARDS_CHANGELOG_PATHS`, `GROWTH_GUARDS_PROSE_PATHS`, both loaded

--- a/skills/growth-guards/DEVELOPMENT.md
+++ b/skills/growth-guards/DEVELOPMENT.md
@@ -414,8 +414,8 @@ lines and `#` comments ignored; a pattern without a reason is a config
 error. A pattern opening with `!` is a CARVE: it pulls its matches back into
 the scanned set and beats every exclusion row regardless of order, so the
 list reads as policy rather than as a sequence. It exists because a tree
-wildcard is the only way to name a rendered install, and a repo keeping
-hand-written source inside that tree — a skill declared `source =
+wildcard is the only maintainable way to name a rendered install, and a repo
+keeping hand-written source inside that tree — a skill declared `source =
 "in-place"` — otherwise has no way to say so, while enumerating the rendered
 siblings by hand is a defect generator. A bare `!` with no pattern after it
 is a config error; `!` is not escapable, so a path literally beginning with

--- a/skills/growth-guards/SKILL.md
+++ b/skills/growth-guards/SKILL.md
@@ -88,6 +88,11 @@ Settings follow [README.md § Configuration](README.md#configuration).
 
 **Excludes format** — `pattern<TAB>reason` per line (shell glob against the
 full repo-relative path; `*` crosses `/`); a pattern without a reason is a
-config error. **Baseline format** — `path<TAB>count`, `LC_ALL=C` sorted,
+config error. A pattern opening with `!` carves its matches back into the
+scanned set, and wins over every exclusion row whatever the order — that is
+how hand-written source inside an otherwise excluded render tree
+(`.agents/**` plus `!.agents/skills/my-skill/**`) stays governed. `!` is not
+escapable; a path literally beginning with it is scanned.
+**Baseline format** — `path<TAB>count`, `LC_ALL=C` sorted,
 unique paths, positive counts.
 Seeding a first baseline and CI wiring: [README.md](README.md). Hook install and removal details: [DEVELOPMENT.md](DEVELOPMENT.md).

--- a/skills/growth-guards/SKILL.md
+++ b/skills/growth-guards/SKILL.md
@@ -92,7 +92,8 @@ config error. A pattern opening with `!` carves its matches back into the
 scanned set, and wins over every exclusion row whatever the order — that is
 how hand-written source inside an otherwise excluded render tree
 (`.agents/**` plus `!.agents/skills/my-skill/**`) stays governed. `!` is not
-escapable; a path literally beginning with it is scanned.
+escapable, so a path literally beginning with it cannot be excluded by a row
+naming it, and is scanned instead.
 **Baseline format** — `path<TAB>count`, `LC_ALL=C` sorted,
 unique paths, positive counts.
 Seeding a first baseline and CI wiring: [README.md](README.md). Hook install and removal details: [DEVELOPMENT.md](DEVELOPMENT.md).

--- a/skills/growth-guards/SKILL.md
+++ b/skills/growth-guards/SKILL.md
@@ -91,9 +91,8 @@ full repo-relative path; `*` crosses `/`); a pattern without a reason is a
 config error. A pattern opening with `!` carves its matches back into the
 scanned set, and wins over every exclusion row whatever the order — that is
 how hand-written source inside an otherwise excluded render tree
-(`.agents/**` plus `!.agents/skills/my-skill/**`) stays governed. `!` is not
-escapable, so a path literally beginning with it cannot be excluded by a row
-naming it, and is scanned instead.
+(`.agents/**` plus `!.agents/skills/my-skill/**`) stays governed. To exclude a
+path that literally begins with `!`, escape it: `\!foo`.
 **Baseline format** — `path<TAB>count`, `LC_ALL=C` sorted,
 unique paths, positive counts.
 Seeding a first baseline and CI wiring: [README.md](README.md). Hook install and removal details: [DEVELOPMENT.md](DEVELOPMENT.md).

--- a/skills/growth-guards/scripts/lib/configured-paths.sh
+++ b/skills/growth-guards/scripts/lib/configured-paths.sh
@@ -325,8 +325,8 @@ gg_policy_content() { # FILE — content on stdout; 1 = the commit has no such f
 # blank lines and `#` comments are ignored; a pattern without a reason is a
 # config error. A missing file is an empty list. A `!` pattern CARVES its
 # matches back into the scanned set and beats every exclusion row whatever the
-# order (DEVELOPMENT.md § Excludes format). `!` is not escapable: a path that
-# literally begins with it is scanned, the safe direction.
+# order (DEVELOPMENT.md § Excludes format). `!` is not escapable, so no row
+# NAMING a path that begins with one can exclude it, the safe direction.
 gg_load_excludes() { # FILE — fills GG_EXCLUDE_PATTERNS and GG_EXCLUDE_CARVES
   local file="$1" line lineno pat reason carve content status=0
   GG_EXCLUDE_PATTERNS=()

--- a/skills/growth-guards/scripts/lib/configured-paths.sh
+++ b/skills/growth-guards/scripts/lib/configured-paths.sh
@@ -324,9 +324,23 @@ gg_policy_content() { # FILE — content on stdout; 1 = the commit has no such f
 # Shell glob matched against the full repo-relative path (`*` crosses `/`);
 # blank lines and `#` comments are ignored; a pattern without a reason is a
 # config error. A missing file is an empty list.
-gg_load_excludes() { # FILE — fills GG_EXCLUDE_PATTERNS
-  local file="$1" line lineno pat reason content status=0
+#
+# A row whose pattern opens with `!` CARVES the paths it matches back into the
+# scanned set. It exists because a tree wildcard is the only way to name a
+# rendered install (`.agents/**`) and a repo that keeps hand-written source
+# inside that tree — a skill declared `source = "in-place"` — otherwise has no
+# way to say so, and enumerating the rendered siblings instead is a defect
+# generator. Carving wins over every exclusion row regardless of order, so a
+# list stays readable as policy rather than as a sequence.
+#
+# `!` is not escapable: a repo path that literally begins with `!` therefore
+# cannot be excluded by a row naming it. That direction is the safe one — the
+# path is SCANNED, and the guard says so out loud — where an escape would add
+# a second dialect to every list for a path shape no repo here has.
+gg_load_excludes() { # FILE — fills GG_EXCLUDE_PATTERNS and GG_EXCLUDE_CARVES
+  local file="$1" line lineno pat reason carve content status=0
   GG_EXCLUDE_PATTERNS=()
+  GG_EXCLUDE_CARVES=()
   # The read runs in a command substitution, so a gg_collection_error inside
   # it dies in that SUBSHELL and arrives here as a status. Only status 1 is
   # the answer "the commit has no such file" (an empty list); anything else
@@ -349,12 +363,21 @@ gg_load_excludes() { # FILE — fills GG_EXCLUDE_PATTERNS
     if [ "$pat" = "$line" ] || [ -z "$pat" ] || [ -z "$reason" ]; then
       gg_config_error "$(gg_shown "$file"):$lineno: expected 'pattern<TAB>reason' (every exclusion carries its justification)"
     fi
-    GG_EXCLUDE_PATTERNS+=("$pat")
+    case "$pat" in
+      "!"*)
+        carve="${pat#!}"
+        [ -n "$carve" ] \
+          || gg_config_error "$(gg_shown "$file"):$lineno: '!' carves matching paths back into the scanned set and needs a pattern after it"
+        GG_EXCLUDE_CARVES+=("$carve")
+        ;;
+      *) GG_EXCLUDE_PATTERNS+=("$pat") ;;
+    esac
   done <<<"$content"
 }
 
-gg_is_excluded() { # PATH — 0 when some exclusion glob matches the full path
-  # The loaded list, matched by the one spelling above. Guarded expansion: an
+gg_is_excluded() { # PATH — 0 when an exclusion glob matches and no `!` row carves it back
+  # The loaded lists, matched by the one spelling above. Guarded expansion: an
   # empty array is an unbound variable under Bash 3.2 with set -u.
-  gg_path_matches "$1" ${GG_EXCLUDE_PATTERNS[@]+"${GG_EXCLUDE_PATTERNS[@]}"}
+  gg_path_matches "$1" ${GG_EXCLUDE_PATTERNS[@]+"${GG_EXCLUDE_PATTERNS[@]}"} || return 1
+  ! gg_path_matches "$1" ${GG_EXCLUDE_CARVES[@]+"${GG_EXCLUDE_CARVES[@]}"}
 }

--- a/skills/growth-guards/scripts/lib/configured-paths.sh
+++ b/skills/growth-guards/scripts/lib/configured-paths.sh
@@ -325,8 +325,8 @@ gg_policy_content() { # FILE — content on stdout; 1 = the commit has no such f
 # blank lines and `#` comments are ignored; a pattern without a reason is a
 # config error. A missing file is an empty list. A `!` pattern CARVES its
 # matches back into the scanned set and beats every exclusion row whatever the
-# order (DEVELOPMENT.md § Excludes format). `!` is not escapable, so no row
-# NAMING a path that begins with one can exclude it, the safe direction.
+# order (DEVELOPMENT.md § Excludes format). A row naming a path that begins
+# with `!` escapes it as `\!foo`, which stays an exclusion.
 gg_load_excludes() { # FILE — fills GG_EXCLUDE_PATTERNS and GG_EXCLUDE_CARVES
   local file="$1" line lineno pat reason carve content status=0
   GG_EXCLUDE_PATTERNS=()

--- a/skills/growth-guards/scripts/lib/configured-paths.sh
+++ b/skills/growth-guards/scripts/lib/configured-paths.sh
@@ -323,20 +323,10 @@ gg_policy_content() { # FILE — content on stdout; 1 = the commit has no such f
 
 # Shell glob matched against the full repo-relative path (`*` crosses `/`);
 # blank lines and `#` comments are ignored; a pattern without a reason is a
-# config error. A missing file is an empty list.
-#
-# A row whose pattern opens with `!` CARVES the paths it matches back into the
-# scanned set. It exists because a tree wildcard is the only way to name a
-# rendered install (`.agents/**`) and a repo that keeps hand-written source
-# inside that tree — a skill declared `source = "in-place"` — otherwise has no
-# way to say so, and enumerating the rendered siblings instead is a defect
-# generator. Carving wins over every exclusion row regardless of order, so a
-# list stays readable as policy rather than as a sequence.
-#
-# `!` is not escapable: a repo path that literally begins with `!` therefore
-# cannot be excluded by a row naming it. That direction is the safe one — the
-# path is SCANNED, and the guard says so out loud — where an escape would add
-# a second dialect to every list for a path shape no repo here has.
+# config error. A missing file is an empty list. A `!` pattern CARVES its
+# matches back into the scanned set and beats every exclusion row whatever the
+# order (DEVELOPMENT.md § Excludes format). `!` is not escapable: a path that
+# literally begins with it is scanned, the safe direction.
 gg_load_excludes() { # FILE — fills GG_EXCLUDE_PATTERNS and GG_EXCLUDE_CARVES
   local file="$1" line lineno pat reason carve content status=0
   GG_EXCLUDE_PATTERNS=()

--- a/skills/growth-guards/tests/todo-ban.test.sh
+++ b/skills/growth-guards/tests/todo-ban.test.sh
@@ -236,6 +236,18 @@ run_tb
   && ok "a bare ! row is a config error naming its line" \
   || bad "a bare ! row is a config error naming its line" "rc=$RC out=$OUT"
 
+# `!` is escapable, which is the only way left to name a path that literally
+# begins with one: `\!name` opens with a backslash, so it never reaches the
+# carve arm, and the case matcher reads it as that literal path.
+new_repo bang
+mkdir -p "$R/tools"
+printf '// %s: a marker under a bang-leading name\n' "$TD" >"$R/!bang.rs"
+printf '\\!bang.rs\tan escaped literal bang path\n' >"$R/tools/todo-ban-excludes"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 0 ] && ok "an escaped row excludes the literal bang path rather than carving it" \
+  || bad "an escaped row excludes the literal bang path" "rc=$RC out=$OUT"
+
 echo "=== a URL is not a comment leader ==="
 new_repo url
 printf 'see http://%s:8080/path for the mock\n' "$TD" >"$R/u.md"

--- a/skills/growth-guards/tests/todo-ban.test.sh
+++ b/skills/growth-guards/tests/todo-ban.test.sh
@@ -184,6 +184,58 @@ run_tb
   && ok "must-fail control: the crossing shorthand silences the first-party tree too" \
   || bad "the crossing shorthand did not cross" "rc=$RC out=$OUT"
 
+# The one exclusion row that ADDS coverage. A rendered install can only be
+# named by a tree wildcard, so a repo keeping hand-written source inside that
+# tree — a skill declared `source = "in-place"` — has no other way to say so,
+# and the coverage goes silently absent: the fail-open direction for a gate.
+echo "=== excludes: a ! row carves a subtree back into the scanned set ==="
+new_repo carve
+mkdir -p "$R/.agents/skills/rendered" "$R/.agents/skills/in-place" "$R/tools"
+printf '// %s: a marker in the render\n' "$TD" >"$R/.agents/skills/rendered/lib.rs"
+printf '// %s: a marker in the source of record\n' "$TD" >"$R/.agents/skills/in-place/lib.rs"
+printf '.agents/**\tkendex render, governed at its source\n' >"$R/tools/todo-ban-excludes"
+git -C "$R" add -A
+
+# Control: the blanket row alone silences BOTH planted markers.
+run_tb
+[ "$RC" -eq 0 ] && ok "control: the blanket .agents/** row silences both planted markers" \
+  || bad "control: the blanket .agents/** row silences both markers" "rc=$RC out=$OUT"
+
+printf '.agents/**\tkendex render, governed at its source\n!.agents/skills/in-place/**\tin-place skill: this tree IS the source\n' >"$R/tools/todo-ban-excludes"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 1 ] && case "$OUT" in *".agents/skills/in-place/lib.rs:1:"*) true ;; *) false ;; esac \
+  && ok "the carved tree is scanned again and its planted marker fires" \
+  || bad "the carved tree is scanned again" "rc=$RC out=$OUT"
+case "$OUT" in
+  *".agents/skills/rendered/lib.rs"*) bad "the carve must not widen past its own pattern" "$OUT" ;;
+  *) ok "the sibling render under the same blanket row stays silent" ;;
+esac
+
+# Order is not policy: the carve wins whether it precedes or follows the row
+# it cuts into, so a list reads as a set of rules rather than as a sequence.
+printf '!.agents/skills/in-place/**\tin-place skill: this tree IS the source\n.agents/**\tkendex render, governed at its source\n' >"$R/tools/todo-ban-excludes"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 1 ] && case "$OUT" in *".agents/skills/in-place/lib.rs:1:"*) true ;; *) false ;; esac \
+  && ok "a carve above the row it cuts into carves just the same" \
+  || bad "a carve above the row it cuts into carves just the same" "rc=$RC out=$OUT"
+
+# A carve still needs its reason, like every other row, and a bare '!' names
+# nothing — keeping it silently would widen the scanned set by a typo.
+printf '.agents/**\tkendex render\n!.agents/skills/in-place/**\n' >"$R/tools/todo-ban-excludes"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 2 ] && case "$OUT" in *":2: expected 'pattern<TAB>reason'"*) true ;; *) false ;; esac \
+  && ok "a carve row without a reason is the same config error as any other" \
+  || bad "a carve row without a reason is a config error" "rc=$RC out=$OUT"
+printf '.agents/**\tkendex render\n!\ta carve with no pattern\n' >"$R/tools/todo-ban-excludes"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 2 ] && case "$OUT" in *":2: '!' carves"*) true ;; *) false ;; esac \
+  && ok "a bare ! row is a config error naming its line" \
+  || bad "a bare ! row is a config error naming its line" "rc=$RC out=$OUT"
+
 echo "=== a URL is not a comment leader ==="
 new_repo url
 printf 'see http://%s:8080/path for the mock\n' "$TD" >"$R/u.md"

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -209,10 +209,11 @@ src/gen/*.rs	generated bindings
 
 A pattern opening with `!` is a CARVE: it pulls its matches back into the
 measured set and beats every exclusion row whatever the order, so the list
-reads as policy rather than as a sequence. A tree wildcard is the only way to
-name a rendered install, and a repo keeping hand-written source inside that
-tree — a skill declared `source = "in-place"` — otherwise has no way to say
-so:
+reads as policy rather than as a sequence. A tree wildcard is the only
+maintainable way to name a rendered install — enumerating its rendered files
+by hand is a defect generator — and a repo keeping hand-written source inside
+that tree, a skill declared `source = "in-place"`, otherwise has no way to
+say so:
 
 ```
 .agents/*	kendex render, governed at its source

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -220,9 +220,9 @@ say so:
 !.agents/skills/my-skill/*	in-place skill: this tree IS the source
 ```
 
-A bare `!` with no pattern after it is a config error. `!` is not escapable,
-so a path literally beginning with it cannot be excluded by a row naming it
-and is measured instead — the safe direction. The baseline file is exempt
+A bare `!` with no pattern after it is a config error. A row that must name a
+path literally beginning with `!` escapes it: `\!foo` never reaches the carve
+arm and matches that path. The baseline file is exempt
 ahead of the carve rows, so no `!` row pulls it into its own gate.
 
 ## Configuration

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -207,6 +207,23 @@ vendor/*	vendored third-party code
 src/gen/*.rs	generated bindings
 ```
 
+A pattern opening with `!` is a CARVE: it pulls its matches back into the
+measured set and beats every exclusion row whatever the order, so the list
+reads as policy rather than as a sequence. A tree wildcard is the only way to
+name a rendered install, and a repo keeping hand-written source inside that
+tree — a skill declared `source = "in-place"` — otherwise has no way to say
+so:
+
+```
+.agents/*	kendex render, governed at its source
+!.agents/skills/my-skill/*	in-place skill: this tree IS the source
+```
+
+A bare `!` with no pattern after it is a config error. `!` is not escapable,
+so a path literally beginning with it cannot be excluded by a row naming it
+and is measured instead — the safe direction. The baseline file is exempt
+ahead of the carve rows, so no `!` row pulls it into its own gate.
+
 ## Configuration
 
 | Key | Default | Meaning |

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -324,6 +324,7 @@ case "$excludes_state" in
     ;;
 esac
 EXCLUDE_PATTERNS=()
+CARVE_PATTERNS=()
 while IFS= read -r line; do
   [ -n "$line" ] || continue
   EXCLUDE_PATTERNS+=("${line%%"$TAB"*}")
@@ -343,7 +344,19 @@ if [ -f "$EXCLUDES_SOURCE" ]; then
     if [ "$pat" = "$line" ] || [ -z "$pat" ] || [ -z "$reason" ]; then
       config_error "$EXCLUDES_LABEL:$lineno: expected 'pattern<TAB>reason' (every exclusion carries its justification)"
     fi
-    EXCLUDE_PATTERNS+=("$pat")
+    # A `!` pattern CARVES its matches back into the measured set, the only
+    # way to govern hand-written source living inside an excluded render tree
+    # (README.md § Exclusion list). `!` is not escapable: a path that literally
+    # begins with it is measured, the safe direction.
+    case "$pat" in
+      "!"*)
+        carve="${pat#!}"
+        [ -n "$carve" ] \
+          || config_error "$EXCLUDES_LABEL:$lineno: '!' carves matching paths back into the measured set and needs a pattern after it"
+        CARVE_PATTERNS+=("$carve")
+        ;;
+      *) EXCLUDE_PATTERNS+=("$pat") ;;
+    esac
   done <"$EXCLUDES_SOURCE"
 fi
 glob_match() { # PATH PATTERN — 0 when the glob matches the whole path
@@ -353,9 +366,14 @@ glob_match() { # PATH PATTERN — 0 when the glob matches the whole path
   esac
   return 1
 }
-is_excluded() { # PATH — 0 when some exclusion glob matches the full path
+is_excluded() { # PATH — 0 when an exclusion glob matches and no `!` row carves it back
   local pat
+  # The baseline is policy input, never measured content, and sits ahead of
+  # the carve rows so no `!` pattern can pull it into its own gate.
   [ "$1" != "$BASELINE_FILE" ] || return 0
+  for pat in ${CARVE_PATTERNS[@]+"${CARVE_PATTERNS[@]}"}; do
+    glob_match "$1" "$pat" && return 1
+  done
   for pat in ${EXCLUDE_PATTERNS[@]+"${EXCLUDE_PATTERNS[@]}"}; do
     glob_match "$1" "$pat" && return 0
   done

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -346,8 +346,8 @@ if [ -f "$EXCLUDES_SOURCE" ]; then
     fi
     # A `!` pattern CARVES its matches back into the measured set, the only
     # way to govern hand-written source living inside an excluded render tree
-    # (README.md § Exclusion list). `!` is not escapable: a path that literally
-    # begins with it is measured, the safe direction.
+    # (README.md § Exclusion list). `!` is not escapable, so no row NAMING a
+    # path that begins with one can exclude it, the safe direction.
     case "$pat" in
       "!"*)
         carve="${pat#!}"

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -367,17 +367,18 @@ glob_match() { # PATH PATTERN — 0 when the glob matches the whole path
   return 1
 }
 is_excluded() { # PATH — 0 when an exclusion glob matches and no `!` row carves it back
-  local pat
-  # The baseline is policy input, never measured content, and sits ahead of
-  # the carve rows so no `!` pattern can pull it into its own gate.
+  local pat excluded=1
+  # The baseline is policy input and sits ahead of both loops, so no `!` row
+  # pulls it into its own gate; only an excluded path can be carved back.
   [ "$1" != "$BASELINE_FILE" ] || return 0
+  for pat in ${EXCLUDE_PATTERNS[@]+"${EXCLUDE_PATTERNS[@]}"}; do
+    glob_match "$1" "$pat" && excluded=0 && break
+  done
+  [ "$excluded" -eq 0 ] || return 1
   for pat in ${CARVE_PATTERNS[@]+"${CARVE_PATTERNS[@]}"}; do
     glob_match "$1" "$pat" && return 1
   done
-  for pat in ${EXCLUDE_PATTERNS[@]+"${EXCLUDE_PATTERNS[@]}"}; do
-    glob_match "$1" "$pat" && return 0
-  done
-  return 1
+  return 0
 }
 path_threshold() { # PATH
   local i=0 frozen="" shadowed="" skipped="" hit="" s

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -359,26 +359,22 @@ if [ -f "$EXCLUDES_SOURCE" ]; then
     esac
   done <"$EXCLUDES_SOURCE"
 fi
-glob_match() { # PATH PATTERN — 0 when the glob matches the whole path
-  local path="$1" pat="$2"
-  case "$path" in
-    $pat) return 0 ;;
-  esac
+glob_match() { # PATH PATTERN... — 0 when some pattern matches the whole path
+  local path="$1" pat
+  shift
+  for pat in "$@"; do
+    case "$path" in
+      $pat) return 0 ;;
+    esac
+  done
   return 1
 }
 is_excluded() { # PATH — 0 when an exclusion glob matches and no `!` row carves it back
-  local pat excluded=1
-  # The baseline is policy input and sits ahead of both loops, so no `!` row
-  # pulls it into its own gate; only an excluded path can be carved back.
+  # The baseline is policy input and is matched ahead of both lists, so no `!`
+  # row pulls it into its own gate; only an excluded path can be carved back.
   [ "$1" != "$BASELINE_FILE" ] || return 0
-  for pat in ${EXCLUDE_PATTERNS[@]+"${EXCLUDE_PATTERNS[@]}"}; do
-    glob_match "$1" "$pat" && excluded=0 && break
-  done
-  [ "$excluded" -eq 0 ] || return 1
-  for pat in ${CARVE_PATTERNS[@]+"${CARVE_PATTERNS[@]}"}; do
-    glob_match "$1" "$pat" && return 1
-  done
-  return 0
+  glob_match "$1" ${EXCLUDE_PATTERNS[@]+"${EXCLUDE_PATTERNS[@]}"} || return 1
+  ! glob_match "$1" ${CARVE_PATTERNS[@]+"${CARVE_PATTERNS[@]}"}
 }
 path_threshold() { # PATH
   local i=0 frozen="" shadowed="" skipped="" hit="" s

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -346,8 +346,8 @@ if [ -f "$EXCLUDES_SOURCE" ]; then
     fi
     # A `!` pattern CARVES its matches back into the measured set, the only
     # way to govern hand-written source living inside an excluded render tree
-    # (README.md § Exclusion list). `!` is not escapable, so no row NAMING a
-    # path that begins with one can exclude it, the safe direction.
+    # (README.md § Exclusion list). A row naming a path that begins with `!`
+    # escapes it as `\!foo`, which stays an exclusion.
     case "$pat" in
       "!"*)
         carve="${pat#!}"

--- a/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -301,25 +301,37 @@ run_sr
   || bad "a carve above the row it cuts into carves just the same" "rc=$RC out=$OUT"
 
 # A carve cannot pull the baseline into its own gate: the baseline is policy
-# input, and measuring it would make every row it gains a violation. The
-# `tools/*` row excludes both policy files and the `!*` row carves them back,
-# so the carve list really is consulted for them; the baseline stays out only
-# because its exemption is read ahead of both lists. Its own 11 rows put it
-# over this suite's threshold of 10, so a baseline that reached the gate would
-# fail as a new offender — a shorter one would pass whether the exemption held
-# or not. Every row names a measured file over the threshold, none stale.
+# input, and measuring it would make every row it gains a violation. Both runs
+# below share one baseline whose own 11 rows put it over this suite's
+# threshold of 10, so a baseline that reached the gate would fail as a new
+# offender — a shorter one would pass whether the exemption held or not. Every
+# row names a measured file over the threshold, so none reads as stale.
 for i in 1 2 3 4 5 6 7 8 9; do mkfile ".agents/skills/in-place/part$i.txt" 11; done
-printf 'tools/*\tthe policy files themselves\n!*\tcarve everything back in\n' >"$R/tools/size-ratchet-excludes"
 {
   printf '.agents/skills/in-place/big.txt\t50\n'
   for i in 1 2 3 4 5 6 7 8 9; do printf '.agents/skills/in-place/part%s.txt\t11\n' "$i"; done
   printf '.agents/skills/rendered/big.txt\t50\n'
 } >"$R/tools/size-ratchet-baseline.tsv"
+
+# No row here matches the baseline path, so the exemption is the only thing
+# keeping it out ahead of the EXCLUSION match: move the exemption behind that
+# match and the baseline is measured.
+printf '!*\tcarve everything back in\n' >"$R/tools/size-ratchet-excludes"
 git -C "$R" add -A
 run_sr
 [ "$RC" -eq 0 ] && case "$OUT" in *"tools/size-ratchet-baseline.tsv"*) false ;; *) true ;; esac \
-  && ok "the baseline stays exempt ahead of every carve row, at 11 rows over the threshold" \
-  || bad "the baseline stays exempt ahead of every carve row" "rc=$RC out=$OUT"
+  && ok "the baseline stays exempt ahead of the exclusion match, at 11 rows over the threshold" \
+  || bad "the baseline stays exempt ahead of the exclusion match" "rc=$RC out=$OUT"
+
+# `tools/*` excludes both policy files, so the EXCLUDES FILE reaches the carve
+# list and the `!*` row pulls it back. The baseline never reaches that list,
+# because its exemption is read first, which is what this run pins.
+printf 'tools/*\tthe policy files themselves\n!*\tcarve everything back in\n' >"$R/tools/size-ratchet-excludes"
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 0 ] && case "$OUT" in *"tools/size-ratchet-baseline.tsv"*) false ;; *) true ;; esac \
+  && ok "the baseline stays exempt ahead of the carve match the excludes file reaches" \
+  || bad "the baseline stays exempt ahead of the carve match" "rc=$RC out=$OUT"
 
 # A bare '!' names nothing; silently keeping it would widen or narrow the
 # scanned set by a typo.

--- a/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -301,15 +301,24 @@ run_sr
   || bad "a carve above the row it cuts into carves just the same" "rc=$RC out=$OUT"
 
 # A carve cannot pull the baseline into its own gate: the baseline is policy
-# input, and measuring it would make every row it gains a violation.
+# input, and measuring it would make every row it gains a violation. The
+# baseline written here carries 11 rows against this suite's threshold of 10,
+# so the exemption is the only thing keeping it off the offender list — a
+# shorter one would pass whether the exemption held or not. Every row names a
+# file the `!*` row carves back in and that is over the threshold, so no row
+# reads as stale.
+for i in 1 2 3 4 5 6 7 8 9; do mkfile ".agents/skills/in-place/part$i.txt" 11; done
 printf '!*\tcarve everything back in\n' >"$R/tools/size-ratchet-excludes"
-printf '.agents/skills/in-place/big.txt\t50\n.agents/skills/rendered/big.txt\t50\n' >"$R/tools/size-ratchet-baseline.tsv"
+{
+  printf '.agents/skills/in-place/big.txt\t50\n'
+  for i in 1 2 3 4 5 6 7 8 9; do printf '.agents/skills/in-place/part%s.txt\t11\n' "$i"; done
+  printf '.agents/skills/rendered/big.txt\t50\n'
+} >"$R/tools/size-ratchet-baseline.tsv"
 git -C "$R" add -A
 run_sr
-case "$OUT" in
-  *"tools/size-ratchet-baseline.tsv"*) bad "a carve must not make the baseline measured content" "$OUT" ;;
-  *) ok "the baseline stays exempt ahead of every carve row" ;;
-esac
+[ "$RC" -eq 0 ] && case "$OUT" in *"tools/size-ratchet-baseline.tsv"*) false ;; *) true ;; esac \
+  && ok "the baseline stays exempt ahead of every carve row, at 11 rows over the threshold" \
+  || bad "the baseline stays exempt ahead of every carve row" "rc=$RC out=$OUT"
 
 # A bare '!' names nothing; silently keeping it would widen or narrow the
 # scanned set by a typo.

--- a/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -342,6 +342,19 @@ run_sr
   && ok "a bare ! row is a config error naming its line" \
   || bad "a bare ! row is a config error naming its line" "rc=$RC out=$OUT"
 
+# `!` is escapable, which is the only way left to name a path that literally
+# begins with one: `\!name` opens with a backslash, so it never reaches the
+# carve arm, and the case matcher reads it as that literal path.
+new_repo bang
+mkfile '!bang.txt' 11
+mkdir -p "$R/tools"
+printf '\\!bang.txt\tan escaped literal bang path\n' >"$R/tools/size-ratchet-excludes"
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 0 ] && case "$OUT" in *"!bang.txt"*) false ;; *) true ;; esac \
+  && ok "an escaped row excludes the literal bang path rather than carving it" \
+  || bad "an escaped row excludes the literal bang path" "rc=$RC out=$OUT"
+
 echo "=== --baseline flag relocates the baseline ==="
 new_repo flagpath
 mkfile big.txt 15

--- a/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -263,6 +263,63 @@ run_sr
   && ok "a baseline row for an excluded file is stale — excluded files leave the counted set" \
   || bad "a baseline row for an excluded file is stale" "rc=$RC out=$OUT"
 
+echo "=== a ! row carves a subtree back into the measured set ==="
+# A rendered install can only be named by a tree wildcard, and a repo that
+# keeps hand-written source inside that tree — a skill declared
+# `source = "in-place"` — needs a way to say so. Without it the coverage is
+# silently absent, which is the fail-open direction for a gate.
+new_repo carve
+mkfile .agents/skills/rendered/big.txt 50   # a real render: stays excluded
+mkfile .agents/skills/in-place/big.txt 50   # the source of record: carved back
+mkdir -p "$R/tools"
+printf '.agents/*\tkendex render, governed at its source\n' >"$R/tools/size-ratchet-excludes"
+git -C "$R" add -A
+
+# Control: the blanket row alone silences BOTH, which is the defect.
+run_sr
+[ "$RC" -eq 0 ] && ok "control: the blanket .agents/* row silences both trees" \
+  || bad "control: the blanket .agents/* row silences both trees" "rc=$RC out=$OUT"
+
+printf '.agents/*\tkendex render, governed at its source\n!.agents/skills/in-place/*\tin-place skill: this tree IS the source\n' >"$R/tools/size-ratchet-excludes"
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 1 ] && case "$OUT" in *".agents/skills/in-place/big.txt"*) true ;; *) false ;; esac \
+  && ok "the carved tree is measured again and its offender is named" \
+  || bad "the carved tree is measured again" "rc=$RC out=$OUT"
+case "$OUT" in
+  *".agents/skills/rendered/big.txt"*) bad "the carve must not widen past its own pattern" "$OUT" ;;
+  *) ok "the sibling render under the same blanket row stays excluded" ;;
+esac
+
+# Order is not policy: the carve wins whether it precedes or follows the row
+# it cuts into, so a list reads as a set of rules rather than as a sequence.
+printf '!.agents/skills/in-place/*\tin-place skill: this tree IS the source\n.agents/*\tkendex render, governed at its source\n' >"$R/tools/size-ratchet-excludes"
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 1 ] && case "$OUT" in *".agents/skills/in-place/big.txt"*) true ;; *) false ;; esac \
+  && ok "a carve above the row it cuts into carves just the same" \
+  || bad "a carve above the row it cuts into carves just the same" "rc=$RC out=$OUT"
+
+# A carve cannot pull the baseline into its own gate: the baseline is policy
+# input, and measuring it would make every row it gains a violation.
+printf '!*\tcarve everything back in\n' >"$R/tools/size-ratchet-excludes"
+printf '.agents/skills/in-place/big.txt\t50\n.agents/skills/rendered/big.txt\t50\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+run_sr
+case "$OUT" in
+  *"tools/size-ratchet-baseline.tsv"*) bad "a carve must not make the baseline measured content" "$OUT" ;;
+  *) ok "the baseline stays exempt ahead of every carve row" ;;
+esac
+
+# A bare '!' names nothing; silently keeping it would widen or narrow the
+# scanned set by a typo.
+printf '.agents/*\tkendex render\n!\ta carve with no pattern\n' >"$R/tools/size-ratchet-excludes"
+git -C "$R" add -A
+run_sr
+[ "$RC" -eq 2 ] && case "$OUT" in *":2: '!' carves"*) true ;; *) false ;; esac \
+  && ok "a bare ! row is a config error naming its line" \
+  || bad "a bare ! row is a config error naming its line" "rc=$RC out=$OUT"
+
 echo "=== --baseline flag relocates the baseline ==="
 new_repo flagpath
 mkfile big.txt 15

--- a/skills/size-ratchet/tests/ratchet-directions.test.sh
+++ b/skills/size-ratchet/tests/ratchet-directions.test.sh
@@ -302,13 +302,14 @@ run_sr
 
 # A carve cannot pull the baseline into its own gate: the baseline is policy
 # input, and measuring it would make every row it gains a violation. The
-# baseline written here carries 11 rows against this suite's threshold of 10,
-# so the exemption is the only thing keeping it off the offender list — a
-# shorter one would pass whether the exemption held or not. Every row names a
-# file the `!*` row carves back in and that is over the threshold, so no row
-# reads as stale.
+# `tools/*` row excludes both policy files and the `!*` row carves them back,
+# so the carve list really is consulted for them; the baseline stays out only
+# because its exemption is read ahead of both lists. Its own 11 rows put it
+# over this suite's threshold of 10, so a baseline that reached the gate would
+# fail as a new offender — a shorter one would pass whether the exemption held
+# or not. Every row names a measured file over the threshold, none stale.
 for i in 1 2 3 4 5 6 7 8 9; do mkfile ".agents/skills/in-place/part$i.txt" 11; done
-printf '!*\tcarve everything back in\n' >"$R/tools/size-ratchet-excludes"
+printf 'tools/*\tthe policy files themselves\n!*\tcarve everything back in\n' >"$R/tools/size-ratchet-excludes"
 {
   printf '.agents/skills/in-place/big.txt\t50\n'
   for i in 1 2 3 4 5 6 7 8 9; do printf '.agents/skills/in-place/part%s.txt\t11\n' "$i"; done

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -115,6 +115,6 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/lib/settings.sh	485
-skills/size-ratchet/scripts/size-ratchet	1000
+skills/size-ratchet/scripts/size-ratchet	996
 skills/worktree/scripts/worktree	4530
 skills/worktree/scripts/worktree-session-guard	442

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -115,6 +115,6 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/lib/settings.sh	485
-skills/size-ratchet/scripts/size-ratchet	981
+skills/size-ratchet/scripts/size-ratchet	999
 skills/worktree/scripts/worktree	4530
 skills/worktree/scripts/worktree-session-guard	442

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -115,6 +115,6 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/lib/settings.sh	485
-skills/size-ratchet/scripts/size-ratchet	999
+skills/size-ratchet/scripts/size-ratchet	1000
 skills/worktree/scripts/worktree	4530
 skills/worktree/scripts/worktree-session-guard	442

--- a/tools/size-ratchet-excludes
+++ b/tools/size-ratchet-excludes
@@ -7,6 +7,7 @@
 # lives inside a tree the render rows exclude.
 
 .agents/*	kendex's render of skills/, agents/ and hooks/, whose SOURCE is governed, so governing the mirror doubles every finding and freezes the render
+!.agents/hooks/*	adopted hook scripts: this tree IS the source, so the row above must not cover it
 !.agents/skills/app-deploy/*	in-place skill (kendex-local.toml): this tree IS the source, so the row above must not cover it
 !.agents/skills/kendex-issues/*	in-place skill (kendex-local.toml): this tree IS the source, so the row above must not cover it
 .claude/skills/*	rendered skill links into .agents/skills

--- a/tools/size-ratchet-excludes
+++ b/tools/size-ratchet-excludes
@@ -6,7 +6,7 @@
 # row above or below it — the only way to govern hand-written source that
 # lives inside a tree the render rows exclude.
 
-.agents/*	kendex's render of skills/, agents/ and hooks/, whose SOURCE is governed, so governing the mirror doubles every finding and freezes the render
+.agents/*	kendex's render of skills/, whose SOURCE is governed, so governing the mirror doubles every finding and freezes the render
 !.agents/hooks/*	adopted hook scripts: this tree IS the source, so the row above must not cover it
 !.agents/skills/app-deploy/*	in-place skill (kendex-local.toml): this tree IS the source, so the row above must not cover it
 !.agents/skills/kendex-issues/*	in-place skill (kendex-local.toml): this tree IS the source, so the row above must not cover it

--- a/tools/size-ratchet-excludes
+++ b/tools/size-ratchet-excludes
@@ -2,8 +2,13 @@
 # only. Hand-written source is never excluded; oversized source is frozen in
 # size-ratchet-baseline.tsv.
 # Format: pattern<TAB>reason (shell glob against the full repo-relative path; * crosses /).
+# A `!` pattern carves its matches back into the measured set and beats every
+# row above or below it — the only way to govern hand-written source that
+# lives inside a tree the render rows exclude.
 
-.agents/*	kendex's render of skills/, agents/ and hooks/, whose SOURCE is governed, so governing the mirror doubles every finding and freezes the render; the in-place skill trees here have no source elsewhere, and this dialect cannot carve them back in (KEN-708)
+.agents/*	kendex's render of skills/, agents/ and hooks/, whose SOURCE is governed, so governing the mirror doubles every finding and freezes the render
+!.agents/skills/app-deploy/*	in-place skill (kendex-local.toml): this tree IS the source, so the row above must not cover it
+!.agents/skills/kendex-issues/*	in-place skill (kendex-local.toml): this tree IS the source, so the row above must not cover it
 .claude/skills/*	rendered skill links into .agents/skills
 .claude/agents/*	kendex-rendered agent copies, source in agents/
 .claude/hooks/*	kendex-rendered hook copies, source in hooks/

--- a/tools/suppression-ban-excludes
+++ b/tools/suppression-ban-excludes
@@ -6,6 +6,7 @@
 # lives inside a tree the render rows exclude.
 
 .agents/**	kendex's render of skills/, agents/ and hooks/, whose SOURCE is governed by the rows below
+!.agents/hooks/**	adopted hook scripts: this tree IS the source, so the row above must not cover it
 !.agents/skills/app-deploy/**	in-place skill (kendex-local.toml): this tree IS the source, so the row above must not cover it
 !.agents/skills/kendex-issues/**	in-place skill (kendex-local.toml): this tree IS the source, so the row above must not cover it
 .claude/skills/**	rendered skill links into .agents/skills

--- a/tools/suppression-ban-excludes
+++ b/tools/suppression-ban-excludes
@@ -1,8 +1,13 @@
 # suppression-ban exclusion list — vendored trees only. Hand-written source
 # is never excluded: every lint suppression there states its reason.
 # Format: pattern<TAB>reason (gitignore-style against the repo-relative path; ** crosses /).
+# A `!` pattern carves its matches back into the scanned set and beats every
+# row above or below it — the only way to govern hand-written source that
+# lives inside a tree the render rows exclude.
 
-.agents/**	kendex's render of skills/, agents/ and hooks/, whose SOURCE is governed by the rows below; the in-place skill trees here have no source elsewhere, and this dialect cannot carve them back in (KEN-708)
+.agents/**	kendex's render of skills/, agents/ and hooks/, whose SOURCE is governed by the rows below
+!.agents/skills/app-deploy/**	in-place skill (kendex-local.toml): this tree IS the source, so the row above must not cover it
+!.agents/skills/kendex-issues/**	in-place skill (kendex-local.toml): this tree IS the source, so the row above must not cover it
 .claude/skills/**	rendered skill links into .agents/skills
 .claude/agents/**	kendex-rendered agent copies, source in agents/
 .claude/hooks/**	kendex-rendered hook copies, source in hooks/

--- a/tools/suppression-ban-excludes
+++ b/tools/suppression-ban-excludes
@@ -5,7 +5,7 @@
 # row above or below it — the only way to govern hand-written source that
 # lives inside a tree the render rows exclude.
 
-.agents/**	kendex's render of skills/, agents/ and hooks/, whose SOURCE is governed by the rows below
+.agents/**	kendex's render of skills/, whose SOURCE is governed by the rows below
 !.agents/hooks/**	adopted hook scripts: this tree IS the source, so the row above must not cover it
 !.agents/skills/app-deploy/**	in-place skill (kendex-local.toml): this tree IS the source, so the row above must not cover it
 !.agents/skills/kendex-issues/**	in-place skill (kendex-local.toml): this tree IS the source, so the row above must not cover it


### PR DESCRIPTION
## Summary

- Both exclusion dialects read a `!pattern` row as a carve: the paths it matches go back into the scanned set, and it beats every exclusion row whatever the order, so a list reads as policy rather than as a sequence. A bare `!` is a config error. A row that needs to name a path literally beginning with `!` escapes it, `\!foo`, which never reaches the carve arm and excludes that path.
- `tools/size-ratchet-excludes` and `tools/suppression-ban-excludes` carve back the trees this repo owns under its blanket `.agents` row: the two `source = "in-place"` skills, and the adopted-hook home that `crates/core/src/engine/adopt/hooks.rs` and `docs/ARCHITECTURE.md` both name as project source.
- `size-ratchet`'s `is_excluded` now matches `gg_is_excluded` — one variadic `glob_match`, baseline exemption ahead of both lists — so the two implementations are one dialect rather than two shapes. The carve feature grows the script, so its baseline row is raised 981 to 996 and declared with `RATCHET_RAISE=1`; the variadic form is what keeps that raise to 15 lines rather than 19.

## Completed Issues

- Closes KEN-708 - growth-guards excludes cannot carve an in-place tree out of `.agents/*`

The issue's second Done-when bullet ("hyprtrade drops the coverage caveat from its #612 notes") is a hyprtrade change and cannot land here. KEN-839 owns hyprtrade propagation and now carries that remainder as scope on its hyprtrade leg, so it has an owner rather than being dropped.

## Created Issues

- KEN-1167 - Carve rows drift from the producers that declare in-place trees — Project: Review Gate & CI

**Breaking:** a row whose pattern begins with `!` previously matched the literal path `!…`; it now carves. Rewrite such a row as `\!…` to keep the old meaning. No excludes list in any repo running these packages carries one today, and both directions are fail-closed — a stale row scans more, never less.

## Test Plan

Planted-marker controls in both suites, each paired with the must-fail control that reddens against the unpatched script. `ratchet-directions.test.sh` 50 passed / 0 failed, `todo-ban.test.sh` 69 passed / 0 failed; all ten size-ratchet suites and all 24 growth-guards suites green; `tools/guard` exit 0; preflight clean.

Proved on this repo rather than only in fixtures:

- A planted `#[allow(dead_code)]` under `.agents/skills/app-deploy` makes suppression-ban report a violation with the carve rows present and stay silent without them. A planted `.agents/hooks/probe.py` behaves the same way in both guards.
- The `is_excluded` rewrite is behaviour-preserving by differential, not by argument: the pre-carve, intermediate and final bodies agree on all 2304 (path, exclude-set, carve-set) triples, with a sabotage control confirming the harness fails when it should; `glob_match`'s 2-arg and variadic forms agree 120/120 across empty, spaced, bracket and `!` patterns; and all three versions produce byte-identical output at the real entry point.
- The baseline-exemption arm is a real instrument. One 11-row baseline feeds two runs — a carve-only excludes list, and a `tools/*` plus carve list — so the arm pins the exemption's precedence over both the exclusion match and the carve match. A seven-mutant battery against the final code kills 7/7.

Performance, measured on CPU time over 11 interleaved samples per version (wall clock here is noise-dominated): the carve feature costs +4.5% on a full repo scan before the reorder and +1.8% after it, each version paired with its own committed excludes file.

https://claude.ai/code/session_014E1jWH9o6z98h6XNhLPYEJ
