### PR TITLE
fix(KEN-1161): a write's rescan runs whatever the apply answered

### DIFF
--- a/changelog.d/changed/KEN-1161-refusal-timing.md
+++ b/changelog.d/changed/KEN-1161-refusal-timing.md
@@ -1,0 +1,1 @@
+- Install beside shows its "that name is taken" refusal as soon as the engine answers, rather than after the scan and audit behind the write.

--- a/changelog.d/fixed/KEN-1161.md
+++ b/changelog.d/fixed/KEN-1161.md
@@ -1,0 +1,1 @@
+- An update, discard, fork or install-beside whose apply fails re-reads the machine like one that landed, so Home's inventory and the audit scores stop counting copies its uninstallers removed.

--- a/changelog.d/fixed/KEN-1161.md
+++ b/changelog.d/fixed/KEN-1161.md
@@ -1,1 +1,1 @@
-- An update, discard, fork or install-beside whose apply fails re-reads the machine like one that landed, so Home's inventory and the audit scores stop counting copies its uninstallers removed.
+- An update, discard, fork or install-beside whose apply fails re-reads the machine like one that landed, so Home and the audit stop counting copies its uninstallers removed.

--- a/ui/src/components/install-as-new-dialog.tsx
+++ b/ui/src/components/install-as-new-dialog.tsx
@@ -45,7 +45,12 @@ export function InstallAsNewDialog({
 
   const submit = () => {
     if (trimmed === "") return;
-    void installAsNew(row, harness, trimmed).then((failure) => {
+    // The callback lands at the engine's answer, not at the reads behind
+    // it: the refusal is what the person retypes over, so it must not wait
+    // out a machine-wide scan. The promise covers those reads, and nothing
+    // here needs them — `busy` is what keeps the buttons down until they
+    // land.
+    void installAsNew(row, harness, trimmed, (failure) => {
       if (failure === null) onOpenChange(false);
       else setError(failure);
     });

--- a/ui/src/components/package/package-version-actions.ts
+++ b/ui/src/components/package/package-version-actions.ts
@@ -40,8 +40,8 @@ export function packageVersionActions(
   const afterChange = () => {
     reload();
     // The package's own reads, then the two the whole app derives from —
-    // the same call the updates store's own apply makes, which is where the
-    // reasoning for reading both back lives.
+    // the same call the updates store's own apply makes, on the rule
+    // `rescan.ts`'s header states.
     void rescanEverything();
   };
   // Every one of these applies a plan that can refuse a rendering, so
@@ -75,10 +75,12 @@ export function packageVersionActions(
       setBusy(false);
       if (response.status === "error") {
         showError(response.error);
-        // An error is not proof that nothing changed: `package_set_rev`
-        // persists the revision and only then applies, so a failed apply
-        // answers over a manifest that already moved. The page reads back
-        // either way, or it shows the old version as settled.
+        // An error is not proof that nothing changed: the write runs the
+        // leaving packages' uninstallers before the plan, and an error over
+        // those comes back with what they did standing. The manifest save is
+        // op 0 of the same journaled plan and rolls back with it, so the
+        // version this page shows as settled is the engine's answer to give.
+        // The page reads back either way.
         afterChange();
         return;
       }

--- a/ui/src/components/package/package-version-actions.ts
+++ b/ui/src/components/package/package-version-actions.ts
@@ -75,12 +75,10 @@ export function packageVersionActions(
       setBusy(false);
       if (response.status === "error") {
         showError(response.error);
-        // An error is not proof that nothing changed: the write runs the
-        // leaving packages' uninstallers before the plan, and an error over
-        // those comes back with what they did standing. The manifest save is
-        // op 0 of the same journaled plan and rolls back with it, so the
-        // version this page shows as settled is the engine's answer to give.
-        // The page reads back either way.
+        // An error is not proof that nothing changed — `lib/rescan.ts`'s
+        // header says what does and does not survive a failed apply — so
+        // the version this page shows as settled is the engine's answer to
+        // give. The page reads back either way.
         afterChange();
         return;
       }

--- a/ui/src/components/package/use-package-data.test.ts
+++ b/ui/src/components/package/use-package-data.test.ts
@@ -138,10 +138,11 @@ describe("packageVersionActions", () => {
   });
 
   // A refused write is not a write that changed nothing. `package_set_rev`
-  // persists the revision through `set_rev_with` and only then runs the
-  // apply, so an apply that fails answers with an error over a manifest
-  // that already moved. A page that returned on the error would go on
-  // showing the version it read before the click as the settled one.
+  // runs the leaving packages' uninstallers before the plan, and an error
+  // over those comes back with what they did standing; the manifest save is
+  // op 0 of the same journaled plan and rolls back with it. A page that
+  // returned on the error would go on showing the version it read before
+  // the click as the settled one, whichever of the two happened.
   it("reads the package back when the write is refused", async () => {
     const reload = vi.fn();
     vi.mocked(commands.packageSetRev).mockResolvedValue({

--- a/ui/src/components/package/use-package-data.test.ts
+++ b/ui/src/components/package/use-package-data.test.ts
@@ -137,12 +137,10 @@ describe("packageVersionActions", () => {
     expect(toast.info).toHaveBeenCalledWith(HELD_IN_CLAUDE);
   });
 
-  // A refused write is not a write that changed nothing. `package_set_rev`
-  // runs the leaving packages' uninstallers before the plan, and an error
-  // over those comes back with what they did standing; the manifest save is
-  // op 0 of the same journaled plan and rolls back with it. A page that
+  // A refused write is not a write that changed nothing — `lib/rescan.ts`'s
+  // header says what does and does not survive a failed apply. A page that
   // returned on the error would go on showing the version it read before
-  // the click as the settled one, whichever of the two happened.
+  // the click as the settled one.
   it("reads the package back when the write is refused", async () => {
     const reload = vi.fn();
     vi.mocked(commands.packageSetRev).mockResolvedValue({

--- a/ui/src/components/update-follow.dom.test.tsx
+++ b/ui/src/components/update-follow.dom.test.tsx
@@ -291,12 +291,13 @@ describe("the Follow source switch", () => {
   });
 
   // A refused write is not a write that changed nothing. `package_set_rev`
-  // persists the revision through `set_rev_with` and only then runs the
-  // apply, so an apply that fails answers with an error over a manifest
-  // that already moved. Restoring the switch from the row the click read
-  // would show that as settled and re-open every action against it — so
-  // the standing is read again, and the engine's own answer decides where
-  // the switch sits.
+  // runs the leaving packages' uninstallers before the plan, and an error
+  // over those comes back with what they did standing; the manifest save is
+  // op 0 of the same journaled plan and rolls back with it. Either way the
+  // click has no account of where the switch belongs — restoring it from
+  // the row the click read would show that as settled and re-open every
+  // action against it — so the standing is read again, and the engine's own
+  // answer decides where the switch sits.
   it("reads the standing back when the write is refused", async () => {
     vi.mocked(commands.packageSetRev).mockResolvedValue({
       status: "error",

--- a/ui/src/components/update-follow.dom.test.tsx
+++ b/ui/src/components/update-follow.dom.test.tsx
@@ -290,22 +290,22 @@ describe("the Follow source switch", () => {
     await settle();
   });
 
-  // A refused write is not a write that changed nothing. `package_set_rev`
-  // runs the leaving packages' uninstallers before the plan, and an error
-  // over those comes back with what they did standing; the manifest save is
-  // op 0 of the same journaled plan and rolls back with it. Either way the
-  // click has no account of where the switch belongs — restoring it from
-  // the row the click read would show that as settled and re-open every
-  // action against it — so the standing is read again, and the engine's own
-  // answer decides where the switch sits.
+  // A refused write is not a write that changed nothing — `lib/rescan.ts`'s
+  // header says what does and does not survive a failed apply. So the click
+  // has no account of where the switch belongs: restoring it from the row
+  // the click read would show that as settled and re-open every action
+  // against it. The standing is read again, and the engine's own answer
+  // decides where the switch sits.
   it("reads the standing back when the write is refused", async () => {
     vi.mocked(commands.packageSetRev).mockResolvedValue({
       status: "error",
       error: "manifest busy",
     });
-    // What the engine turns out to hold: the revision the failed apply
-    // had already persisted.
-    const persisted = [
+    // What the engine turns out to hold once it is asked — held, against a
+    // click that asked to follow. Which way it went is the read's to say,
+    // not the click's; the fixture makes the two disagree so the assertion
+    // below can tell them apart.
+    const heldByEngine = [
       { ...rows[0], pinned: true, holdOwner: { kind: "package" as const } },
       rows[1],
       rows[2],
@@ -313,7 +313,7 @@ describe("the Follow source switch", () => {
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",
       data: {
-        rows: persisted,
+        rows: heldByEngine,
         warnings: [],
         unreadable: [],
         lastFetched: null,
@@ -328,9 +328,8 @@ describe("the Follow source switch", () => {
     await settle();
 
     expect(commands.updatesOverview).toHaveBeenCalled();
-    // And so are the scan and the audit: the error came back over an apply
-    // that had already persisted the revision, so it is no account of what
-    // is on disk.
+    // And so are the scan and the audit: the error is no account of what is
+    // on disk, on `rescan.ts`'s rule.
     expect(commands.scanMachine).toHaveBeenCalled();
     expect(commands.auditAll).toHaveBeenCalled();
     // The flip is retired before that read, so the rows come back as the

--- a/ui/src/lib/package-places.ts
+++ b/ui/src/lib/package-places.ts
@@ -89,11 +89,12 @@ export const placeKey = (kind: ItemKind, name: string, scope: Scope): string =>
 /** These counts with one more write recorded against every place in `rows`.
  *
  *  Handed every place a run ATTEMPTED, not only those whose command answered
- *  ok. An error is not proof that nothing changed: `insert_manifest_save`
- *  leads a plan with the manifest write, so an apply that fails after it
- *  leaves the new hold on disk with nothing else moved, and a refusal ran a
- *  plan led the same way. A refresh that was not needed costs one re-read of
- *  a page already on screen; one that was needed and skipped is the stale
+ *  ok. An error is not proof that nothing changed: the apply behind these
+ *  writes runs the leaving packages' uninstallers before the plan, and an
+ *  error over those comes back with what they did to the repository
+ *  standing — `lib/rescan.ts`'s header is the account. A refresh that was
+ *  not needed costs one re-read of a page already on screen; one that was
+ *  needed and skipped is the stale
  *  Overview this whole record exists to remove — so this deliberately
  *  over-covers, and is not to be tightened back to what a plan moved. */
 export const countingWrites = (

--- a/ui/src/lib/rescan.ts
+++ b/ui/src/lib/rescan.ts
@@ -23,6 +23,17 @@
 // same apply an update does, so the bytes both reads answer for move under
 // it — and calls this once its own standing has landed.
 //
+// A write that calls this calls it whatever the write answered, and no
+// caller gates on the answer. A refusal is no account of what is on disk:
+// `repo_effects::execute` runs the leaving packages' uninstallers before
+// the plan, and an `Undo` error comes back with what they did to the
+// repository standing. Neither is an answer that landed — `moved` covers
+// the two states `moving` counts, `removed` the other destructive one, and
+// a dropped rendering can answer with all three fields empty, so no
+// predicate over the response is complete. A write that turns out to have
+// moved nothing pays what every other one pays — the page held for a
+// machine-wide scan and a forced audit — rather than a page left dated.
+//
 // Adding a project, dropping one, or moving a harness's folder changes
 // which scopes the audit reads, and a scope with no view of its own counts
 // zero unmanaged items — which is how a project card ends up hiding the

--- a/ui/src/lib/rescan.ts
+++ b/ui/src/lib/rescan.ts
@@ -30,23 +30,22 @@
 // rather than at each of them.
 //
 // A refusal is no account of what is on disk. `repo_effects::execute` runs
-// the leaving packages' uninstallers before the plan, and an `Undo` error
-// comes back with what they did to the repository standing; a command that
-// applies a bare plan instead can still fail in its enrichment read, after
-// the write committed. What does NOT survive is the manifest: its save is
-// part of the same journaled plan, so `run_journaled` rolls it back with
-// everything else the plan touched.
+// the leaving packages' uninstallers before the plan, so an `Undo` error
+// comes back with what they did standing and the plan — manifest save
+// included — never run; a plan that does run and then fails rolls back
+// whole, `run_journaled` restoring every path it touched; and an error can
+// come back over a write that committed in full. The answer does not say
+// which happened.
 //
-// Neither is an answer that landed a complete account — `moved` covers the
-// two states `moving` counts, `removed` the other destructive one, and a
-// dropped rendering can answer with all three fields empty, so no predicate
-// over the response decides this. A write that turns out to have moved
-// nothing costs one machine-wide scan and one forced audit, which is
-// cheaper than the dated page the alternative leaves.
+// Nor is a success a complete account: `moved` covers the two states
+// `moving` counts, `removed` the other destructive one, and a dropped
+// rendering can answer with all three fields empty. So no predicate over
+// the response decides this, and a write that moved nothing pays one scan
+// and one forced audit rather than leaving a dated page.
 //
 // This speaks only for those five. The marketplace, source-toggle and
 // settings callers still return on the error before reaching here; whether
-// that is right is their own question, not one this paragraph answers.
+// that is right is their own question.
 //
 // Adding a project, dropping one, or moving a harness's folder changes
 // which scopes the audit reads, and a scope with no view of its own counts

--- a/ui/src/lib/rescan.ts
+++ b/ui/src/lib/rescan.ts
@@ -23,16 +23,30 @@
 // same apply an update does, so the bytes both reads answer for move under
 // it — and calls this once its own standing has landed.
 //
-// A write that calls this calls it whatever the write answered, and no
-// caller gates on the answer. A refusal is no account of what is on disk:
-// `repo_effects::execute` runs the leaving packages' uninstallers before
-// the plan, and an `Undo` error comes back with what they did to the
-// repository standing. Neither is an answer that landed — `moved` covers
-// the two states `moving` counts, `removed` the other destructive one, and
-// a dropped rendering can answer with all three fields empty, so no
-// predicate over the response is complete. A write that turns out to have
-// moved nothing pays what every other one pays — the page held for a
-// machine-wide scan and a forced audit — rather than a page left dated.
+// The writes on the Updates page and the package page call this whatever
+// their write answered: `updates.ts`'s [`updateOne`] and [`updateRows`],
+// `updates-edits.ts`'s `run`, `updates-follow.ts`'s [`followSwitch`], and
+// `package-version-actions.ts`'s `afterChange`. The reasoning lives here
+// rather than at each of them.
+//
+// A refusal is no account of what is on disk. `repo_effects::execute` runs
+// the leaving packages' uninstallers before the plan, and an `Undo` error
+// comes back with what they did to the repository standing; a command that
+// applies a bare plan instead can still fail in its enrichment read, after
+// the write committed. What does NOT survive is the manifest: its save is
+// part of the same journaled plan, so `run_journaled` rolls it back with
+// everything else the plan touched.
+//
+// Neither is an answer that landed a complete account — `moved` covers the
+// two states `moving` counts, `removed` the other destructive one, and a
+// dropped rendering can answer with all three fields empty, so no predicate
+// over the response decides this. A write that turns out to have moved
+// nothing costs one machine-wide scan and one forced audit, which is
+// cheaper than the dated page the alternative leaves.
+//
+// This speaks only for those five. The marketplace, source-toggle and
+// settings callers still return on the error before reaching here; whether
+// that is right is their own question, not one this paragraph answers.
 //
 // Adding a project, dropping one, or moving a harness's folder changes
 // which scopes the audit reads, and a scope with no view of its own counts

--- a/ui/src/pages/package-refresh.test.tsx
+++ b/ui/src/pages/package-refresh.test.tsx
@@ -329,16 +329,12 @@ describe("the package page after an update started from its Projects tab", () =>
     expect(header(host)).not.toContain(UPDATE_LABEL);
   });
 
-  // An apply that answers an error is not proof that nothing changed: the
-  // uninstallers run before the plan and their effects stand, and a write
-  // that committed can still fail in the read that enriches its answer
-  // (`lib/rescan.ts`'s header is the account). Reading the error as
-  // "nothing moved" is what leaves a page on screen the machine no longer
-  // matches.
+  // An error is no account of what is on disk — `lib/rescan.ts`'s header
+  // is the reasoning. Reading it as "nothing moved" is what leaves a page
+  // on screen the machine no longer matches.
   it("re-reads them when the write answers an error", async () => {
     const write = engineWrites();
-    // The write landed and the command answered an error over it — the
-    // shape an enrichment read failing after the commit makes reachable.
+    // The write landed and the command answered an error over it.
     vi.mocked(commands.packageUpdate).mockImplementation(() => {
       write.landed = true;
       return Promise.resolve({ status: "error", error: "the apply stopped" });

--- a/ui/src/pages/package-refresh.test.tsx
+++ b/ui/src/pages/package-refresh.test.tsx
@@ -329,15 +329,16 @@ describe("the package page after an update started from its Projects tab", () =>
     expect(header(host)).not.toContain(UPDATE_LABEL);
   });
 
-  // An apply that answers an error is not proof that nothing changed:
-  // `insert_manifest_save` leads a plan with the manifest write, so an op
-  // failing after it leaves the new hold on disk. Reading the error as
-  // "nothing moved" is what leaves a rev on screen the manifest no longer
-  // has.
+  // An apply that answers an error is not proof that nothing changed: the
+  // uninstallers run before the plan and their effects stand, and a write
+  // that committed can still fail in the read that enriches its answer
+  // (`lib/rescan.ts`'s header is the account). Reading the error as
+  // "nothing moved" is what leaves a page on screen the machine no longer
+  // matches.
   it("re-reads them when the write answers an error", async () => {
     const write = engineWrites();
-    // The manifest moved and the apply then failed, which is the shape the
-    // plan's leading write makes reachable.
+    // The write landed and the command answered an error over it — the
+    // shape an enrichment read failing after the commit makes reachable.
     vi.mocked(commands.packageUpdate).mockImplementation(() => {
       write.landed = true;
       return Promise.resolve({ status: "error", error: "the apply stopped" });

--- a/ui/src/stores/updates-edits.test.ts
+++ b/ui/src/stores/updates-edits.test.ts
@@ -1,6 +1,6 @@
 import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { UpdateRow } from "@/bindings";
+import type { HarnessId, UpdateRow } from "@/bindings";
 import { commands } from "@/bindings";
 import { ADOPTABLE } from "@/lib/adoptable";
 import { UPDATE_NEEDS_CHECK_NOTE } from "@/lib/copy-updates";
@@ -59,6 +59,20 @@ function row(overrides: Partial<UpdateRow>): UpdateRow {
     ...overrides,
   };
 }
+
+/** `installAsNew` hands its refusal to a callback at the engine's answer,
+ *  ahead of the reads behind it. A case about that answer reads the way it
+ *  always did through this: it waits for the reads too, then reports what
+ *  the callback was given. */
+const refusalFrom = async (
+  ...args: [UpdateRow, HarnessId, string]
+): Promise<string | null | undefined> => {
+  let refusal: string | null | undefined;
+  await installAsNew(...args, (failure) => {
+    refusal = failure;
+  });
+  return refusal;
+};
 
 describe("updates store: edited places", () => {
   beforeEach(() => {
@@ -279,7 +293,7 @@ describe("updates store: installing beside an edited place", () => {
     });
 
     expect(
-      await installAsNew(row({ ...edited, pinned: true }), "claude", "gh-mine"),
+      await refusalFrom(row({ ...edited, pinned: true }), "claude", "gh-mine"),
     ).toBeNull();
     expect(commands.packageForkBeside).toHaveBeenLastCalledWith(
       { scope: "global" },
@@ -290,7 +304,7 @@ describe("updates store: installing beside an edited place", () => {
       "b".repeat(40),
     );
 
-    expect(await installAsNew(row(edited), "claude", "gh-mine")).toBeNull();
+    expect(await refusalFrom(row(edited), "claude", "gh-mine")).toBeNull();
     expect(commands.packageForkBeside).toHaveBeenLastCalledWith(
       { scope: "global" },
       "skill",
@@ -314,16 +328,62 @@ describe("updates store: installing beside an edited place", () => {
       error: { phase: "refused", message: "'docs' already installed" },
     });
 
-    expect(await installAsNew(row(edited), "claude", "docs")).toBe(
+    expect(await refusalFrom(row(edited), "claude", "docs")).toBe(
       "'docs' already installed",
     );
     expect(useProblemsStore.getState().dialog.open).toBe(false);
     expect(toast.success).not.toHaveBeenCalled();
     expect(toast.info).not.toHaveBeenCalled();
-    // Refused for this name, but the write ran the leaving packages'
-    // uninstallers before its plan — the machine is read whatever it
-    // answered, on `rescan.ts`'s rule.
+    // Read anyway, on `rescan.ts`'s rule. Not because this phase disarmed
+    // anything: `package_fork_beside` answers Refused for a failed `env()`,
+    // a plan it could not build, or an `apply::execute` that rolled back —
+    // none of which is proof the rollback itself landed. Its sibling phase,
+    // Recorded, is the one that runs uninstallers, and no predicate here
+    // tells the two apart before the read.
     expect(commands.auditAll).toHaveBeenCalled();
+  });
+
+  // The refusal is the dialog's inline "pick another name", so it lands at
+  // the engine's answer and not behind the reads: a forced audit skips its
+  // freshness window on purpose, and the person would sit over a disabled
+  // dialog for that whole span before being told to retype. The scan is
+  // left hanging here so nothing but the answer can have resolved.
+  it("hands back the refusal before the reads behind it finish", async () => {
+    vi.mocked(commands.packageForkBeside).mockResolvedValue({
+      status: "error",
+      error: { phase: "refused", message: "'docs' already installed" },
+    });
+    vi.mocked(commands.updatesOverview).mockResolvedValue({
+      status: "ok",
+      data: { rows: [], warnings: [], unreadable: [], lastFetched: null },
+    });
+    // Held open until this case says so, then released so the chain — and
+    // the store's busy with it — finishes before the next case.
+    let releaseScan: (answer: never) => void = () => {};
+    vi.mocked(commands.scanMachine).mockReturnValue(
+      new Promise((resolve) => {
+        releaseScan = resolve as (answer: never) => void;
+      }),
+    );
+    vi.mocked(commands.auditAll).mockResolvedValue({ status: "ok", data: [] });
+
+    let refusal: string | null | undefined;
+    const reads = installAsNew(row(edited), "claude", "docs", (failure) => {
+      refusal = failure;
+    });
+
+    await vi.waitFor(() => expect(refusal).toBeDefined());
+    expect(refusal).toBe("'docs' already installed");
+    // The reads are still out — this is the wait the person no longer sits
+    // through, and `busy` is what proves they are inside the window.
+    expect(useUpdatesStore.getState().busy).toBe(true);
+
+    releaseScan({
+      status: "ok",
+      data: { harnesses: [], items: [], missingProjects: [], warnings: [] },
+    } as never);
+    await reads;
+    expect(useUpdatesStore.getState().busy).toBe(false);
   });
 
   // An error in neither phase — Tauri rejecting an unknown command or bad
@@ -335,7 +395,7 @@ describe("updates store: installing beside an edited place", () => {
       error: "invalid args `newName`" as never,
     });
 
-    expect(await installAsNew(row(edited), "claude", "gh-mine")).toBe(
+    expect(await refusalFrom(row(edited), "claude", "gh-mine")).toBe(
       "invalid args `newName`",
     );
     expect(toast.success).not.toHaveBeenCalled();
@@ -353,7 +413,7 @@ describe("updates store: installing beside an edited place", () => {
       error: { phase: "recorded", message: "render refused: disk full" },
     });
 
-    expect(await installAsNew(row(edited), "claude", "gh-mine")).toBeNull();
+    expect(await refusalFrom(row(edited), "claude", "gh-mine")).toBeNull();
     expect(toast.info).toHaveBeenCalledWith(
       "Your edited copy is now gh-mine, but gh didn't install: render refused: disk full.",
     );
@@ -370,7 +430,7 @@ describe("updates store: installing beside an edited place", () => {
       status: "error",
       error: { phase: "refused", message: "nope" },
     });
-    await installAsNew(
+    await refusalFrom(
       row({ ...edited, pinned: true, canTakeLatest: false }),
       "claude",
       "gh-mine",
@@ -387,7 +447,7 @@ describe("updates store: installing beside an edited place", () => {
 
   it("refuses rows a failed check left behind, before any call", async () => {
     useUpdatesStore.setState({ read: READ_PENDING });
-    expect(await installAsNew(row(edited), "claude", "gh-mine")).toBe(
+    expect(await refusalFrom(row(edited), "claude", "gh-mine")).toBe(
       UPDATE_NEEDS_CHECK_NOTE,
     );
     expect(commands.packageForkBeside).not.toHaveBeenCalled();
@@ -422,7 +482,7 @@ describe("updates store: installing beside an edited place", () => {
     expect(useProblemsStore.getState().dialog.message).toBe(
       UPDATE_NEEDS_CHECK_NOTE,
     );
-    expect(await installAsNew(edited, "claude", "gh-mine")).toBe(
+    expect(await refusalFrom(edited, "claude", "gh-mine")).toBe(
       UPDATE_NEEDS_CHECK_NOTE,
     );
     expect(commands.packageForkBeside).not.toHaveBeenCalled();

--- a/ui/src/stores/updates-edits.test.ts
+++ b/ui/src/stores/updates-edits.test.ts
@@ -110,9 +110,8 @@ describe("updates store: edited places", () => {
 
     expect(useProblemsStore.getState().dialog.open).toBe(true);
     expect(useProblemsStore.getState().dialog.message).toBe("ipc down");
-    // The failure is reported, and the machine is read anyway: a rejection
-    // is the answer that accounts for least, and the uninstallers the write
-    // runs before its plan may already have moved what these two read.
+    // The machine is read anyway: a rejection is the answer that accounts
+    // for least, on `rescan.ts`'s rule.
     expect(commands.auditAll).toHaveBeenCalled();
   });
 
@@ -334,12 +333,7 @@ describe("updates store: installing beside an edited place", () => {
     expect(useProblemsStore.getState().dialog.open).toBe(false);
     expect(toast.success).not.toHaveBeenCalled();
     expect(toast.info).not.toHaveBeenCalled();
-    // Read anyway, on `rescan.ts`'s rule. Not because this phase disarmed
-    // anything: `package_fork_beside` answers Refused for a failed `env()`,
-    // a plan it could not build, or an `apply::execute` that rolled back —
-    // none of which is proof the rollback itself landed. Its sibling phase,
-    // Recorded, is the one that runs uninstallers, and no predicate here
-    // tells the two apart before the read.
+    // Read anyway, on `rescan.ts`'s rule.
     expect(commands.auditAll).toHaveBeenCalled();
   });
 
@@ -349,40 +343,33 @@ describe("updates store: installing beside an edited place", () => {
   // dialog for that whole span before being told to retype. The scan is
   // left hanging here so nothing but the answer can have resolved.
   it("hands back the refusal before the reads behind it finish", async () => {
+    // Recorded rather than raced: a clock-based wait cannot tell the answer
+    // beating the standing read from the answer trailing it by one
+    // round-trip, and that round-trip is the whole cost.
+    const order: string[] = [];
     vi.mocked(commands.packageForkBeside).mockResolvedValue({
       status: "error",
       error: { phase: "refused", message: "'docs' already installed" },
     });
-    vi.mocked(commands.updatesOverview).mockResolvedValue({
-      status: "ok",
-      data: { rows: [], warnings: [], unreadable: [], lastFetched: null },
+    vi.mocked(commands.updatesOverview).mockImplementation(async () => {
+      order.push("overview");
+      return {
+        status: "ok",
+        data: { rows: [], warnings: [], unreadable: [], lastFetched: null },
+      };
     });
-    // Held open until this case says so, then released so the chain — and
-    // the store's busy with it — finishes before the next case.
-    let releaseScan: (answer: never) => void = () => {};
-    vi.mocked(commands.scanMachine).mockReturnValue(
-      new Promise((resolve) => {
-        releaseScan = resolve as (answer: never) => void;
-      }),
-    );
-    vi.mocked(commands.auditAll).mockResolvedValue({ status: "ok", data: [] });
 
     let refusal: string | null | undefined;
-    const reads = installAsNew(row(edited), "claude", "docs", (failure) => {
+    await installAsNew(row(edited), "claude", "docs", (failure) => {
+      order.push("answered");
       refusal = failure;
     });
 
-    await vi.waitFor(() => expect(refusal).toBeDefined());
     expect(refusal).toBe("'docs' already installed");
-    // The reads are still out — this is the wait the person no longer sits
-    // through, and `busy` is what proves they are inside the window.
-    expect(useUpdatesStore.getState().busy).toBe(true);
-
-    releaseScan({
-      status: "ok",
-      data: { harnesses: [], items: [], missingProjects: [], warnings: [] },
-    } as never);
-    await reads;
+    // Ahead of the standing read — the one a reload-first regression would
+    // put in front of it — and the busy window closed only after both reads.
+    expect(order).toEqual(["answered", "overview"]);
+    expect(commands.auditAll).toHaveBeenCalled();
     expect(useUpdatesStore.getState().busy).toBe(false);
   });
 

--- a/ui/src/stores/updates-edits.test.ts
+++ b/ui/src/stores/updates-edits.test.ts
@@ -110,8 +110,8 @@ describe("updates store: edited places", () => {
 
     expect(useProblemsStore.getState().dialog.open).toBe(true);
     expect(useProblemsStore.getState().dialog.message).toBe("ipc down");
-    // The machine is read anyway: a rejection is the answer that accounts
-    // for least, on `rescan.ts`'s rule.
+    // The machine is read anyway: the call never answered, so nothing says
+    // whether the apply ran.
     expect(commands.auditAll).toHaveBeenCalled();
   });
 

--- a/ui/src/stores/updates-edits.test.ts
+++ b/ui/src/stores/updates-edits.test.ts
@@ -96,8 +96,10 @@ describe("updates store: edited places", () => {
 
     expect(useProblemsStore.getState().dialog.open).toBe(true);
     expect(useProblemsStore.getState().dialog.message).toBe("ipc down");
-    // run() stops at the failure instead of refreshing as if it landed.
-    expect(commands.auditAll).not.toHaveBeenCalled();
+    // The failure is reported, and the machine is read anyway: a rejection
+    // is the answer that accounts for least, and the uninstallers the write
+    // runs before its plan may already have moved what these two read.
+    expect(commands.auditAll).toHaveBeenCalled();
   });
 
   it("a discard whose transport failed surfaces the failure", async () => {
@@ -118,7 +120,7 @@ describe("updates store: edited places", () => {
 
     expect(useProblemsStore.getState().dialog.open).toBe(true);
     expect(useProblemsStore.getState().dialog.message).toBe("ipc down");
-    expect(commands.auditAll).not.toHaveBeenCalled();
+    expect(commands.auditAll).toHaveBeenCalled();
   });
 
   // The action boundary owns the guarantee: a confirmation opened before
@@ -318,7 +320,10 @@ describe("updates store: installing beside an edited place", () => {
     expect(useProblemsStore.getState().dialog.open).toBe(false);
     expect(toast.success).not.toHaveBeenCalled();
     expect(toast.info).not.toHaveBeenCalled();
-    expect(commands.auditAll).not.toHaveBeenCalled();
+    // Refused for this name, but the write ran the leaving packages'
+    // uninstallers before its plan — the machine is read whatever it
+    // answered, on `rescan.ts`'s rule.
+    expect(commands.auditAll).toHaveBeenCalled();
   });
 
   // An error in neither phase — Tauri rejecting an unknown command or bad
@@ -335,7 +340,7 @@ describe("updates store: installing beside an edited place", () => {
     );
     expect(toast.success).not.toHaveBeenCalled();
     expect(toast.info).not.toHaveBeenCalled();
-    expect(commands.auditAll).not.toHaveBeenCalled();
+    expect(commands.auditAll).toHaveBeenCalled();
     expect(useUpdatesStore.getState().busy).toBe(false);
   });
 

--- a/ui/src/stores/updates-edits.ts
+++ b/ui/src/stores/updates-edits.ts
@@ -18,22 +18,17 @@ import { holdingBusy, useUpdatesStore } from "./updates";
 /** The ways out of an edited place, run under the updates store's busy
  *  flag so every control on the page waits on the same one — a fork, a
  *  discard, or an install beside rewrites the scope's manifest like any
- *  update does. Each returns the failure, or what the work answered once
- *  the follow-up refreshes have landed. */
+ *  update does. Each hands its outcome to a callback at the engine's
+ *  answer and returns a promise covering the reads behind it. */
 
 type Outcome<T> = { error: string } | { ok: T };
 
-/** Run one way out of an edited place under the updates store's busy, and
- *  hand `say` the outcome the moment the engine answers — ahead of the two
- *  reads behind it. The returned promise covers those reads, which run on
- *  inside the same busy window so no other control acts over them.
- *
- *  Answering first is the point. The engine's word is final by then, and
- *  the reads take seconds: a forced audit deliberately skips its freshness
- *  window. `installAsNew`'s refusal is the dialog's own inline "that name
- *  will not go through" — reported after a machine-wide scan, it is
- *  seconds of a silent dialog over an answer that was already in hand. The
- *  siblings on this path all report first and read after. */
+/** `say` takes the outcome the moment the engine answers, ahead of the two
+ *  reads the returned promise covers — those stay inside the busy window,
+ *  so no other control acts over them. Answering first is the point: the
+ *  reads take seconds, a forced audit skipping its freshness window on
+ *  purpose, and `installAsNew`'s refusal is the dialog's own inline "pick
+ *  another name". */
 const run = <T>(
   work: () => Promise<Outcome<T>>,
   say: (outcome: Outcome<T>) => void,
@@ -125,18 +120,14 @@ export const takeNewVersion = async (row: UpdateRow): Promise<void> => {
 
 /** Keep an edited place's files as the user's own package under `own`,
  *  and let the source's newest version back in under the original name.
- *  `harness` is the edited rendering the row named as forkable.
- *
- *  `answered` is handed the refusal — nothing written, another name may go
- *  through — for the dialog to show at the point of action, or null when
- *  the dialog should close. It fires at the engine's answer, ahead of the
- *  reads the returned promise covers, because the person's next move is to
- *  retype the name over it. A fork the scope recorded but could not render
- *  is not a refusal: the dialog closes, the toast says what landed, and the
- *  refreshed rows carry the rest. An error in neither phase — a transport
- *  rejection, a binary older than this UI — must never read as a recorded
- *  fork: it is presented as a refusal, the shape that claims nothing
- *  happened. */
+ *  `harness` is the edited rendering the row named as forkable. `answered`
+ *  takes the refusal — nothing written, another name may go through — for
+ *  the dialog to show at the point of action, or null. A fork the scope
+ *  recorded but could not render is not a refusal: the dialog closes, the
+ *  toast says what landed, and the refreshed rows carry the rest. An
+ *  error in neither phase — a transport rejection, a binary older than
+ *  this UI — must never read as a recorded fork: it is presented as a
+ *  refusal, the shape that claims nothing happened. */
 export const installAsNew = async (
   row: UpdateRow,
   harness: HarnessId,
@@ -146,42 +137,32 @@ export const installAsNew = async (
   if (running()) return answered(UPDATES_ONE_AT_A_TIME_NOTE);
   if (stale(row)) return answered(UPDATE_NEEDS_CHECK_NOTE);
   const name = packageDisplayName(row);
-  await run<string | null>(
-    async () => {
-      const response = saying(
-        await commands.packageForkBeside(
-          row.scope,
-          row.kind,
-          row.name,
-          harness,
-          own,
-          // The same rule as discarding: a held place moves to the newest when
-          // that hold is its own to move.
-          row.pinned && row.canTakeLatest ? (row.latest?.commit ?? null) : null,
-        ),
-      );
-      if (response.status === "ok") return { ok: null };
-      const failure: unknown = response.error;
-      if (
-        typeof failure === "object" &&
-        failure !== null &&
-        "phase" in failure
-      ) {
-        const { phase, message } = failure as {
-          phase: string;
-          message: string;
-        };
-        if (phase === "recorded") return { ok: message };
-        if (phase === "refused") return { error: message };
-      }
-      return { error: String(failure) };
-    },
-    (outcome) => {
-      if ("error" in outcome) return answered(outcome.error);
-      if (outcome.ok === null)
-        toast.success(installedAsNewToastLabel(name, own));
-      else toast.info(installedBesideUnfinishedToast(name, own, outcome.ok));
-      answered(null);
-    },
-  );
+  const fork = async (): Promise<Outcome<string | null>> => {
+    const response = saying(
+      await commands.packageForkBeside(
+        row.scope,
+        row.kind,
+        row.name,
+        harness,
+        own,
+        // The same rule as discarding: a held place moves to the newest when
+        // that hold is its own to move.
+        row.pinned && row.canTakeLatest ? (row.latest?.commit ?? null) : null,
+      ),
+    );
+    if (response.status === "ok") return { ok: null };
+    const failure: unknown = response.error;
+    if (typeof failure === "object" && failure !== null && "phase" in failure) {
+      const { phase, message } = failure as { phase: string; message: string };
+      if (phase === "recorded") return { ok: message };
+      if (phase === "refused") return { error: message };
+    }
+    return { error: String(failure) };
+  };
+  await run(fork, (outcome) => {
+    if ("error" in outcome) return answered(outcome.error);
+    if (outcome.ok === null) toast.success(installedAsNewToastLabel(name, own));
+    else toast.info(installedBesideUnfinishedToast(name, own, outcome.ok));
+    answered(null);
+  });
 };

--- a/ui/src/stores/updates-edits.ts
+++ b/ui/src/stores/updates-edits.ts
@@ -32,8 +32,10 @@ const run = <T>(work: () => Promise<Outcome<T>>): Promise<Outcome<T>> =>
     // committed and then failed, and the rows on screen must be what
     // actually landed.
     await useUpdatesStore.getState().reload();
+    // Then the machine, on `rescan.ts`'s rule: asked whatever the work
+    // answered, and inside the busy this wrapper holds.
+    await rescanEverything();
     if (answer.status === "error") return { error: answer.error };
-    if (!("error" in answer.data)) await rescanEverything();
     return answer.data;
   });
 

--- a/ui/src/stores/updates-edits.ts
+++ b/ui/src/stores/updates-edits.ts
@@ -23,11 +23,26 @@ import { holdingBusy, useUpdatesStore } from "./updates";
 
 type Outcome<T> = { error: string } | { ok: T };
 
-const run = <T>(work: () => Promise<Outcome<T>>): Promise<Outcome<T>> =>
+/** Run one way out of an edited place under the updates store's busy, and
+ *  hand `say` the outcome the moment the engine answers — ahead of the two
+ *  reads behind it. The returned promise covers those reads, which run on
+ *  inside the same busy window so no other control acts over them.
+ *
+ *  Answering first is the point. The engine's word is final by then, and
+ *  the reads take seconds: a forced audit deliberately skips its freshness
+ *  window. `installAsNew`'s refusal is the dialog's own inline "that name
+ *  will not go through" — reported after a machine-wide scan, it is
+ *  seconds of a silent dialog over an answer that was already in hand. The
+ *  siblings on this path all report first and read after. */
+const run = <T>(
+  work: () => Promise<Outcome<T>>,
+  say: (outcome: Outcome<T>) => void,
+): Promise<void> =>
   holdingBusy(async () => {
     // A transport failure rejects rather than refusing; caught here it is
     // presented as the refusal shape, which claims nothing happened.
     const answer = await caught(work());
+    say(answer.status === "error" ? { error: answer.error } : answer.data);
     // Whatever the work answered, the standing is read again: it may have
     // committed and then failed, and the rows on screen must be what
     // actually landed.
@@ -35,8 +50,6 @@ const run = <T>(work: () => Promise<Outcome<T>>): Promise<Outcome<T>> =>
     // Then the machine, on `rescan.ts`'s rule: asked whatever the work
     // answered, and inside the busy this wrapper holds.
     await rescanEverything();
-    if (answer.status === "error") return { error: answer.error };
-    return answer.data;
   });
 
 const report = (outcome: Outcome<unknown>) => {
@@ -71,16 +84,14 @@ export const keepAsOwn = async (row: UpdateRow): Promise<void> => {
     report({ error: UPDATES_ONE_AT_A_TIME_NOTE });
     return;
   }
-  report(
-    await run(async () => {
-      const response = saying(
-        await commands.packageFork(row.scope, row.kind, row.name, harness),
-      );
-      if (response.status === "error") return { error: response.error };
-      toast.success(forkedToastLabel(packageDisplayName(row)));
-      return { ok: null };
-    }),
-  );
+  await run(async () => {
+    const response = saying(
+      await commands.packageFork(row.scope, row.kind, row.name, harness),
+    );
+    if (response.status === "error") return { error: response.error };
+    toast.success(forkedToastLabel(packageDisplayName(row)));
+    return { ok: null };
+  }, report);
 };
 
 /** Drop an edited place's edits and take the newest version — moving the
@@ -94,68 +105,83 @@ export const takeNewVersion = async (row: UpdateRow): Promise<void> => {
     report({ error: UPDATE_NEEDS_CHECK_NOTE });
     return;
   }
-  report(
-    await run(async () => {
-      const response = saying(
-        await commands.applyDiscardEdits(
-          row.scope,
-          row.kind,
-          row.name,
-          // A held place moves to the newest only when that is its own hold
-          // to move and the newest is known; otherwise the discard restores
-          // what is resolved now.
-          row.pinned && row.canTakeLatest ? (row.latest?.commit ?? null) : null,
-        ),
-      );
-      return response.status === "error"
-        ? { error: response.error }
-        : { ok: null };
-    }),
-  );
+  await run(async () => {
+    const response = saying(
+      await commands.applyDiscardEdits(
+        row.scope,
+        row.kind,
+        row.name,
+        // A held place moves to the newest only when that is its own hold
+        // to move and the newest is known; otherwise the discard restores
+        // what is resolved now.
+        row.pinned && row.canTakeLatest ? (row.latest?.commit ?? null) : null,
+      ),
+    );
+    return response.status === "error"
+      ? { error: response.error }
+      : { ok: null };
+  }, report);
 };
 
 /** Keep an edited place's files as the user's own package under `own`,
  *  and let the source's newest version back in under the original name.
- *  `harness` is the edited rendering the row named as forkable. Returns a
- *  refusal — nothing written, another name may go through — for the
- *  dialog to show at the point of action, or null. A fork the scope
- *  recorded but could not render is not a refusal: the dialog closes, the
- *  toast says what landed, and the refreshed rows carry the rest. An
- *  error in neither phase — a transport rejection, a binary older than
- *  this UI — must never read as a recorded fork: it is presented as a
- *  refusal, the shape that claims nothing happened. */
+ *  `harness` is the edited rendering the row named as forkable.
+ *
+ *  `answered` is handed the refusal — nothing written, another name may go
+ *  through — for the dialog to show at the point of action, or null when
+ *  the dialog should close. It fires at the engine's answer, ahead of the
+ *  reads the returned promise covers, because the person's next move is to
+ *  retype the name over it. A fork the scope recorded but could not render
+ *  is not a refusal: the dialog closes, the toast says what landed, and the
+ *  refreshed rows carry the rest. An error in neither phase — a transport
+ *  rejection, a binary older than this UI — must never read as a recorded
+ *  fork: it is presented as a refusal, the shape that claims nothing
+ *  happened. */
 export const installAsNew = async (
   row: UpdateRow,
   harness: HarnessId,
   own: string,
-): Promise<string | null> => {
-  if (running()) return UPDATES_ONE_AT_A_TIME_NOTE;
-  if (stale(row)) return UPDATE_NEEDS_CHECK_NOTE;
+  answered: (refusal: string | null) => void,
+): Promise<void> => {
+  if (running()) return answered(UPDATES_ONE_AT_A_TIME_NOTE);
+  if (stale(row)) return answered(UPDATE_NEEDS_CHECK_NOTE);
   const name = packageDisplayName(row);
-  const outcome = await run<string | null>(async () => {
-    const response = saying(
-      await commands.packageForkBeside(
-        row.scope,
-        row.kind,
-        row.name,
-        harness,
-        own,
-        // The same rule as discarding: a held place moves to the newest when
-        // that hold is its own to move.
-        row.pinned && row.canTakeLatest ? (row.latest?.commit ?? null) : null,
-      ),
-    );
-    if (response.status === "ok") return { ok: null };
-    const failure: unknown = response.error;
-    if (typeof failure === "object" && failure !== null && "phase" in failure) {
-      const { phase, message } = failure as { phase: string; message: string };
-      if (phase === "recorded") return { ok: message };
-      if (phase === "refused") return { error: message };
-    }
-    return { error: String(failure) };
-  });
-  if ("error" in outcome) return outcome.error;
-  if (outcome.ok === null) toast.success(installedAsNewToastLabel(name, own));
-  else toast.info(installedBesideUnfinishedToast(name, own, outcome.ok));
-  return null;
+  await run<string | null>(
+    async () => {
+      const response = saying(
+        await commands.packageForkBeside(
+          row.scope,
+          row.kind,
+          row.name,
+          harness,
+          own,
+          // The same rule as discarding: a held place moves to the newest when
+          // that hold is its own to move.
+          row.pinned && row.canTakeLatest ? (row.latest?.commit ?? null) : null,
+        ),
+      );
+      if (response.status === "ok") return { ok: null };
+      const failure: unknown = response.error;
+      if (
+        typeof failure === "object" &&
+        failure !== null &&
+        "phase" in failure
+      ) {
+        const { phase, message } = failure as {
+          phase: string;
+          message: string;
+        };
+        if (phase === "recorded") return { ok: message };
+        if (phase === "refused") return { error: message };
+      }
+      return { error: String(failure) };
+    },
+    (outcome) => {
+      if ("error" in outcome) return answered(outcome.error);
+      if (outcome.ok === null)
+        toast.success(installedAsNewToastLabel(name, own));
+      else toast.info(installedBesideUnfinishedToast(name, own, outcome.ok));
+      answered(null);
+    },
+  );
 };

--- a/ui/src/stores/updates-exclusion.test.ts
+++ b/ui/src/stores/updates-exclusion.test.ts
@@ -78,7 +78,10 @@ const WRITES = [
   [commands.packageSetRev, () => store().setAutoUpdate(row(), false)],
   [commands.packageFork, () => keepAsOwn(EDITED)],
   [commands.applyDiscardEdits, () => takeNewVersion(row())],
-  [commands.packageForkBeside, () => installAsNew(EDITED, "claude", "mine")],
+  [
+    commands.packageForkBeside,
+    () => installAsNew(EDITED, "claude", "mine", () => {}),
+  ],
   [commands.packageUpdate, () => store().updateOne(row())],
   [commands.packageUpdateMany, () => store().updateRows([row()])],
   [commands.packageUpdate, fromPackagePage],

--- a/ui/src/stores/updates-follow.ts
+++ b/ui/src/stores/updates-follow.ts
@@ -163,27 +163,19 @@ export function followSwitch({
           ),
         });
         // Read again whichever way the write answered. An error is not proof
-        // that nothing changed: `package_set_rev` persists the revision
-        // through `set_rev_with` and only then runs the apply, so a failed
-        // apply returns an error over a manifest that already moved. Putting
-        // the switch back from the click's own row would show that as
-        // settled and re-open every action against it.
+        // that nothing changed: `package_set_rev` runs the leaving packages'
+        // uninstallers before the plan (`repo_effects::execute`), and an
+        // error over those comes back with what they did standing. The
+        // manifest itself does not survive a failed apply — the save is op 0
+        // of the same journaled plan and `run_journaled` rolls it back — so
+        // where the switch sits is the engine's answer to give, not the
+        // click's: putting it back from the click's own row would show that
+        // as settled and re-open every action against it.
         await get().reload();
         // Then the scan and the audit, which the standing does not cover:
         // the flip runs an apply, and an apply moves the installed bytes
-        // the scan lists and the audit scores.
-        //
-        // Asked whatever the write answered and whichever way the switch
-        // went. A refusal is no account of what is on disk — the write
-        // runs the leaving packages' uninstallers before the plan
-        // (`repo_effects::execute`), and an error over those leaves what
-        // they did to the repository standing. Nor is an answer that
-        // landed: `moved` covers the two states `moving` counts, `removed`
-        // the other destructive one, and a dropped rendering can answer
-        // with all three fields empty, so no predicate over the response
-        // is complete. A flip that turns out to have written nothing pays
-        // what every other write pays — the page held for a machine-wide
-        // scan and a forced audit — rather than a page left dated.
+        // the scan lists and the audit scores. Asked whatever the write
+        // answered and whichever way the switch went, on `rescan.ts`'s rule.
         await rescanEverything();
       }
     });

--- a/ui/src/stores/updates-follow.ts
+++ b/ui/src/stores/updates-follow.ts
@@ -163,19 +163,16 @@ export function followSwitch({
           ),
         });
         // Read again whichever way the write answered. An error is not proof
-        // that nothing changed: `package_set_rev` runs the leaving packages'
-        // uninstallers before the plan (`repo_effects::execute`), and an
-        // error over those comes back with what they did standing. The
-        // manifest itself does not survive a failed apply — the save is op 0
-        // of the same journaled plan and `run_journaled` rolls it back — so
-        // where the switch sits is the engine's answer to give, not the
-        // click's: putting it back from the click's own row would show that
-        // as settled and re-open every action against it.
+        // that nothing changed — `lib/rescan.ts`'s header says what does and
+        // does not survive a failed apply — so where the switch sits is the
+        // engine's answer to give, not the click's: putting it back from the
+        // click's own row would show that as settled and re-open every
+        // action against it.
         await get().reload();
         // Then the scan and the audit, which the standing does not cover:
         // the flip runs an apply, and an apply moves the installed bytes
         // the scan lists and the audit scores. Asked whatever the write
-        // answered and whichever way the switch went, on `rescan.ts`'s rule.
+        // answered and whichever way the switch went, on that same rule.
         await rescanEverything();
       }
     });

--- a/ui/src/stores/updates.test.ts
+++ b/ui/src/stores/updates.test.ts
@@ -548,50 +548,37 @@ describe("updates store", () => {
   // The machine reads are owed whichever way the apply answered, on
   // `lib/rescan.ts`'s rule. Gated on the answer, Home's inventory and the
   // audit scores went on reporting copies already taken off disk until
-  // something else forced a read.
-  it("reads the machine back when an update answers with an error", async () => {
-    useProblemsStore.setState({
-      dialog: { open: false, title: "", steps: [], actions: [] },
-    });
-    machineAnswers();
-    vi.mocked(commands.packageUpdate).mockResolvedValue({
-      status: "error",
-      error: "the apply could not finish",
-    });
-    useUpdatesStore.setState({ rows: [row({})], read: READ_LANDED });
+  // something else forced a read. Both arms of the choice `applyRow` makes
+  // between the two single-package commands, since a held row moves its
+  // hold through the other one.
+  it.each([
+    ["a follower", row({}), commands.packageUpdate, "the apply stopped"],
+    [
+      "a held row",
+      row({ pinned: true }),
+      commands.packageSetRev,
+      "manifest busy",
+    ],
+  ])(
+    "reads the machine back when %s answers with an error",
+    async (_what, subject, command, error) => {
+      useProblemsStore.setState({
+        dialog: { open: false, title: "", steps: [], actions: [] },
+      });
+      machineAnswers();
+      vi.mocked(command).mockResolvedValue({ status: "error", error } as never);
+      useUpdatesStore.setState({ rows: [subject], read: READ_LANDED });
 
-    await useUpdatesStore.getState().updateOne(row({}));
+      await useUpdatesStore.getState().updateOne(subject);
 
-    expect(commands.scanMachine).toHaveBeenCalled();
-    expect(commands.auditAll).toHaveBeenCalled();
-    // The refusal is still the person's to see, and nothing claims a move.
-    expect(useProblemsStore.getState().dialog.message).toBe(
-      "the apply could not finish",
-    );
-    expect(toast.success).not.toHaveBeenCalled();
-  });
-
-  // A held row moves its hold through the other command, so the gate had
-  // to come off both arms of the choice `applyRow` makes.
-  it("reads the machine back when a held row's write answers with an error", async () => {
-    useProblemsStore.setState({
-      dialog: { open: false, title: "", steps: [], actions: [] },
-    });
-    machineAnswers();
-    vi.mocked(commands.packageSetRev).mockResolvedValue({
-      status: "error",
-      error: "manifest busy",
-    });
-    const held = row({ pinned: true });
-    useUpdatesStore.setState({ rows: [held], read: READ_LANDED });
-
-    await useUpdatesStore.getState().updateOne(held);
-
-    expect(commands.packageSetRev).toHaveBeenCalled();
-    expect(commands.scanMachine).toHaveBeenCalled();
-    expect(commands.auditAll).toHaveBeenCalled();
-    expect(useProblemsStore.getState().dialog.message).toBe("manifest busy");
-  });
+      expect(command).toHaveBeenCalled();
+      expect(commands.scanMachine).toHaveBeenCalled();
+      expect(commands.auditAll).toHaveBeenCalled();
+      // The refusal is still the person's to see, and nothing claims a move.
+      expect(useProblemsStore.getState().dialog.message).toBe(error);
+      expect(toast.success).not.toHaveBeenCalled();
+    },
+  );
 
   // The backend can persist the preference and then fail building its
   // overview: the reconciling read lands what actually committed instead

--- a/ui/src/stores/updates.test.ts
+++ b/ui/src/stores/updates.test.ts
@@ -426,6 +426,12 @@ describe("updates store", () => {
     expect(useProblemsStore.getState().dialog.open).toBe(true);
     expect(useProblemsStore.getState().dialog.message).toBe("ipc down");
     expect(toast.success).not.toHaveBeenCalled();
+    // The rejection arm reads the machine too, and it is the arm that
+    // accounts for least: the call never answered, so nothing says whether
+    // the apply ran. Left unstubbed, the scan and the audit land as failed
+    // reads, which is all this pins — that they were asked.
+    expect(commands.scanMachine).toHaveBeenCalled();
+    expect(commands.auditAll).toHaveBeenCalled();
   });
 
   it("surfaces a follow switch whose transport failed", async () => {
@@ -539,12 +545,10 @@ describe("updates store", () => {
     });
   };
 
-  // An apply that answers with an error has already run the leaving
-  // packages' uninstallers — `repo_effects::execute` runs them before the
-  // plan, and an `Undo` error comes back with what they did standing — so
-  // the machine reads are owed whichever way it answered. Gated on the
-  // answer, Home's inventory and the audit scores went on reporting copies
-  // already taken off disk until something else forced a read.
+  // The machine reads are owed whichever way the apply answered, on
+  // `lib/rescan.ts`'s rule. Gated on the answer, Home's inventory and the
+  // audit scores went on reporting copies already taken off disk until
+  // something else forced a read.
   it("reads the machine back when an update answers with an error", async () => {
     useProblemsStore.setState({
       dialog: { open: false, title: "", steps: [], actions: [] },

--- a/ui/src/stores/updates.test.ts
+++ b/ui/src/stores/updates.test.ts
@@ -526,6 +526,69 @@ describe("updates store", () => {
     expect(useUpdatesStore.getState().read.error).toBe("overview wedged");
   });
 
+  /** The three reads a write's follow-up makes, all answering. */
+  const machineAnswers = () => {
+    vi.mocked(commands.scanMachine).mockResolvedValue({
+      status: "ok",
+      data: { harnesses: [], items: [], missingProjects: [], warnings: [] },
+    });
+    vi.mocked(commands.auditAll).mockResolvedValue({ status: "ok", data: [] });
+    vi.mocked(commands.updatesOverview).mockResolvedValue({
+      status: "ok",
+      data: { rows: [], warnings: [], unreadable: [], lastFetched: null },
+    });
+  };
+
+  // An apply that answers with an error has already run the leaving
+  // packages' uninstallers — `repo_effects::execute` runs them before the
+  // plan, and an `Undo` error comes back with what they did standing — so
+  // the machine reads are owed whichever way it answered. Gated on the
+  // answer, Home's inventory and the audit scores went on reporting copies
+  // already taken off disk until something else forced a read.
+  it("reads the machine back when an update answers with an error", async () => {
+    useProblemsStore.setState({
+      dialog: { open: false, title: "", steps: [], actions: [] },
+    });
+    machineAnswers();
+    vi.mocked(commands.packageUpdate).mockResolvedValue({
+      status: "error",
+      error: "the apply could not finish",
+    });
+    useUpdatesStore.setState({ rows: [row({})], read: READ_LANDED });
+
+    await useUpdatesStore.getState().updateOne(row({}));
+
+    expect(commands.scanMachine).toHaveBeenCalled();
+    expect(commands.auditAll).toHaveBeenCalled();
+    // The refusal is still the person's to see, and nothing claims a move.
+    expect(useProblemsStore.getState().dialog.message).toBe(
+      "the apply could not finish",
+    );
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  // A held row moves its hold through the other command, so the gate had
+  // to come off both arms of the choice `applyRow` makes.
+  it("reads the machine back when a held row's write answers with an error", async () => {
+    useProblemsStore.setState({
+      dialog: { open: false, title: "", steps: [], actions: [] },
+    });
+    machineAnswers();
+    vi.mocked(commands.packageSetRev).mockResolvedValue({
+      status: "error",
+      error: "manifest busy",
+    });
+    const held = row({ pinned: true });
+    useUpdatesStore.setState({ rows: [held], read: READ_LANDED });
+
+    await useUpdatesStore.getState().updateOne(held);
+
+    expect(commands.packageSetRev).toHaveBeenCalled();
+    expect(commands.scanMachine).toHaveBeenCalled();
+    expect(commands.auditAll).toHaveBeenCalled();
+    expect(useProblemsStore.getState().dialog.message).toBe("manifest busy");
+  });
+
   // The backend can persist the preference and then fail building its
   // overview: the reconciling read lands what actually committed instead
   // of leaving the old row marked current.

--- a/ui/src/stores/updates.ts
+++ b/ui/src/stores/updates.ts
@@ -139,7 +139,6 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
       if (rowUnsettled(get(), row)) return needsCheck();
       await holdingBusy(async () => {
         const answer = await caught(applyRow(row, reportUpdate));
-        let applied = false;
         if (answer.status === "error") {
           // A transport failure rejects rather than refusing, and only
           // this catch sees it: unreported it would read as an update
@@ -151,7 +150,6 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
           // is the whole point of asking the command what it did.
           // One package's apply, so a removal it reports is that package's.
           sayApply(updatedToastLabel(row.name), answer.data.update, 1);
-          applied = true;
         }
         // Whatever it answered, the standing is read again: the work can
         // commit and then fail, and the rows must be what landed.
@@ -159,7 +157,9 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
         // why an error is not proof that nothing changed.
         wrote([row]);
         await reload();
-        if (applied) await rescanEverything();
+        // Then the machine, on `rescan.ts`'s rule: asked whatever the apply
+        // answered, and inside the busy the write holds.
+        await rescanEverything();
       });
     },
 


### PR DESCRIPTION
## Summary

- `updateOne` gated its rescan on the apply having landed, and `updates-edits.ts` `run` gated on the answer carrying no error. Neither answer accounts for the machine: `repo_effects::execute` runs the leaving packages' uninstallers before `apply::execute`, and an `Undo` error returns with what they did standing. Both gates are gone, and both rescans stay inside `holdingBusy`.
- The rule is stated once in `ui/src/lib/rescan.ts`'s header, naming the five writes it speaks for; the marketplace, source-toggle and settings callers still gate and the header says so rather than claiming them.
- `run` hands its outcome to a callback at the engine's answer, ahead of the two reads behind it, so a refused fork, discard or install-beside reports at the answer instead of after a machine-wide scan and a forced audit.
- The comments claiming `package_set_rev` persists the revision and only then applies were false — the manifest save is part of the same journaled plan and rolls back with it. They now name what does survive an error, with no per-command phase mapping on top.

## Completed Issues

- Closes KEN-1161 - Rescan skipped when a write answers with an error

## Created Issues

- KEN-1168 - Rescan skipped on the marketplace, editor and audit-item write paths — Project: Tech Debt & Bugs

Five write paths reach the same executor and still gate their rescan. Cut from this PR as outside its Done-when; `rescan.ts`'s header is scoped to what this change covers rather than claiming them. KEN-1162 (scan store drops a rescan requested during an in-flight scan) was already open and covers the other half — raised to P2 here.

## Test Plan

- `ui/src/stores/updates.test.ts` covers both answer arms of `updateOne`: a resolved refusal and a transport rejection, each asserting `scanMachine` and `auditAll` ran. Re-gating either arm reddens the suite.
- `ui/src/stores/updates-edits.test.ts` pins the answer-before-the-reads ordering by recording call order (`["answered", "overview"]`) rather than racing a clock, so moving the answer behind the standing read reddens it — a mutation the earlier pending-`scanMachine` shape did not catch.
- Full UI suite green across three consecutive runs: 141 files, 1124 tests.
- `preflight` clean, `size-ratchet` OK, `tools/guard` exit 0.

## Review

Two review rounds over a nine-reviewer panel, then a cut round. Nine of nine reviewers verified the engine claims these comments rest on against `crates/`; four ran the touched suites independently. The final round surfaced no behavioural defect — every remaining finding was comment text, and the recurring class (prose crediting a command with a failure shape it cannot produce) was closed structurally by cutting the per-command mapping rather than correcting it a third time.

External cross-model review was unavailable this session (codex CLI exited non-zero); it is advisory and blocks nothing. Performance review ran undermeasured — the repository ships no benchmark harness and the diff is TypeScript only, so no latency numbers were produced.

https://claude.ai/code/session_01HzQCw57Qjxkj5BrdmGHJFa
