### PR TITLE
ci(KEN-1164): cargo fmt and cargo doc run in CI [no-changelog]

### DIFF
--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -535,6 +535,22 @@ jobs:
           RUSTFLAGS: -C debuginfo=0
           CARGO_INCREMENTAL: '0'
         run: cargo clippy --workspace --all-targets --locked -- -D warnings
+      # Same reasoning as clippy above, for the two lanes tools/guard was the
+      # only runner of: a commit made with --no-verify, or on a clone whose
+      # hook chain tools/setup never armed, could land a format regression or
+      # a rustdoc link broken by a rename with every required check green.
+      # --document-private-items is what makes the deny in Cargo.toml's
+      # [workspace.lints.rustdoc] reach a citation of a private item, which is
+      # most of this workspace.
+      - name: cargo fmt
+        if: always()
+        run: cargo fmt --check
+      - name: cargo doc
+        if: always()
+        env:
+          RUSTFLAGS: -C debuginfo=0
+          CARGO_INCREMENTAL: '0'
+        run: cargo doc --no-deps --document-private-items --workspace --locked
 
   # The app ships on macOS. tools/guard checks the core and CLI Apple targets
   # at commit time; this runner executes the tests on the platform.

--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -536,12 +536,12 @@ jobs:
           CARGO_INCREMENTAL: '0'
         run: cargo clippy --workspace --all-targets --locked -- -D warnings
       # Same reasoning as clippy above, for the two lanes tools/guard was the
-      # only runner of: a commit made with --no-verify, or on a clone whose
-      # hook chain tools/setup never armed, could land a format regression or
-      # a rustdoc link broken by a rename with every required check green.
-      # --document-private-items is what makes the deny in Cargo.toml's
-      # [workspace.lints.rustdoc] reach a citation of a private item, which is
-      # most of this workspace.
+      # only runner of. Before this, --no-verify or a clone tools/setup never
+      # armed could land a format regression or a broken rustdoc link with
+      # every required check green. Reach is narrower than clippy's above.
+      # --document-private-items takes the rustdoc deny to a citation of a
+      # private item, but cargo doc builds lib and bin targets and offers no
+      # test-target flag, so the ones under crates/*/tests/ stay unchecked.
       - name: cargo fmt
         if: always()
         run: cargo fmt --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,10 +62,12 @@ unsafe_code = "forbid"
 # A doc citation naming something that no longer exists is worse than none:
 # it sends a reader looking for a symbol the rename already took away. The
 # guard documents private items, so an unresolvable citation is caught
-# whether what it named was public or not. What that leaves is rustdoc
-# saying a public comment's link to a private item would break in a page
-# built without that flag — and these comments are written for whoever is
-# reading the source, not for a page anybody builds.
+# whether what it named was public or not, across the lib and bin targets
+# cargo doc builds. It offers no test-target flag, so the citations under
+# crates/*/tests/ go unchecked. What that leaves is rustdoc saying a public
+# comment's link to a private item would break in a page built without that
+# flag — and these comments are written for whoever is reading the source,
+# not for a page anybody builds.
 [workspace.lints.rustdoc]
 broken_intra_doc_links = "deny"
 private_intra_doc_links = "allow"

--- a/crates/core/src/fs.rs
+++ b/crates/core/src/fs.rs
@@ -212,6 +212,10 @@ fn writable(mode: &fs::Permissions) -> fs::Permissions {
     }
     #[cfg(not(unix))]
     {
+        // The lint's whole warning is the Unix widening the arm above
+        // already avoids. Off Unix a `Permissions` carries the read-only
+        // flag and nothing else, so clearing it relaxes nothing further.
+        #[allow(clippy::permissions_set_readonly_false)]
         relaxed.set_readonly(false);
     }
     relaxed

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -1,5 +1,5 @@
 .github/workflows/review-gate-writer.yml	662
-.github/workflows/skill-tests.yml	594
+.github/workflows/skill-tests.yml	610
 crates/core/src/engine/deps.rs	455
 crates/core/src/engine/detach.rs	417
 crates/core/src/error.rs	480


### PR DESCRIPTION
## Summary

- `cargo fmt --check` and `cargo doc --no-deps --document-private-items --workspace --locked` become steps on the existing `cargo-tests` job, each `if: always()`. That job name is already a required context, so no ruleset edit is needed — the reasoning KEN-454 used to put clippy there. Until now `tools/guard` was their only runner, so a commit made with `--no-verify`, or on a clone whose hook chain `tools/setup` never armed, could land a format regression or a broken rustdoc link with every required check green.
- `crates/core/src/fs.rs` — `#[allow(clippy::permissions_set_readonly_false)]` on the `#[cfg(not(unix))]` arm of `writable()`, clearing the one denial in shipped code. The lint's warning is the Unix widening the `#[cfg(unix)]` arm above it already avoids; off Unix a `Permissions` carries the read-only flag and nothing else.
- Both new comments name the lane's boundary: `cargo doc` builds lib and bin targets and offers no test-target flag, so citations under `crates/*/tests/` stay unchecked. `Cargo.toml`'s `[workspace.lints.rustdoc]` comment stated the same rule more flatly and moves with it.

Scoped to the re-scope comment on KEN-1164, not its description: no Windows or macOS clippy lane and no decision record about one.

## Completed Issues

- Closes KEN-1164 - cargo fmt, cargo doc and non-Linux clippy gate nothing a merge must pass

## Test Plan

Must-fail controls, each red once before its pass was trusted:

- A planted format regression reds `cargo fmt --check` (exit 1) from `crates/core/src/fs.rs`, `crates/core/src/engine/deps.rs`, `crates/core/tests/adopt_many_tools.rs`, `crates/app/src/main.rs`, `crates/app/build.rs` and `crates/cli/build.rs` — the virtual-root invocation reaches every member, nested module, build script and test target.
- A broken intra-doc citation on the private `writable()` reds `cargo doc` (exit 101); the same break exits 0 without `--document-private-items`, so the flag is load-bearing.
- Deleting the new `#[allow]` reproduces `call to set_readonly with argument false` under `cargo clippy -p kendex-core --target x86_64-pc-windows-msvc -- -D warnings`.

All three crates carry `[lints] workspace = true`, so `broken_intra_doc_links = "deny"` reaches each. `cargo-tests` carries no event `if:`, so it runs on `pull_request`, `merge_group` and `push`. Recent runs finished in 3m and 4m36s against `timeout-minutes: 25`.

## Notes

Two Windows-target denials remain, and they are library code rather than the test code the re-scope assumed: `dead_code` on `LockedFile.file` in `crates/core/src/fs/lock.rs` and on `GROUP_GRACE`, both from `#[cfg(unix)]`-only use. No shipped run reaches them while there is no Windows clippy lane, so the cut holds — recorded so the count is not read as complete.

https://claude.ai/code/session_01Ays7PEnTqA8RpAV8Beu3vj
