### PR TITLE
perf(KEN-1070): the settings loader forks no subshell per line

### DIFF
--- a/.agents/skills/decider/scripts/lib/kendex-env.sh
+++ b/.agents/skills/decider/scripts/lib/kendex-env.sh
@@ -85,11 +85,18 @@ kendex_source_env_file() {
 }
 
 # Both helpers assign into a caller-named variable instead of printing.
-# kendex_load_settings_file calls them once or twice per line, and a helper
-# that printed could only be read back through a command substitution — a
-# forked subshell per line of every settings file every skill script reads.
-# Their locals carry a `_kendex_` prefix so an out-variable name cannot
-# shadow one and lose the assignment to the local.
+# kendex_load_settings_file reaches kendex_trim once for every line, and
+# three times on an assignment line — twice directly, for the line and for
+# the key, and once more inside kendex_decode_value. A helper that printed
+# could only be read back through a command substitution, so every one of
+# those was a fork, on every settings file every skill script loads.
+#
+# The assignment is a `printf -v` into a name the CALLER chose, so it is
+# lost to the helper's own local whenever the two spellings meet: never
+# pass `_kendex_trimmed`, `_kendex_decode_raw` or `_kendex_decode_regex` as
+# an out-var. Nothing enforces that — kendex_decode_value is itself such a
+# caller, which is why its scratch names are spelled apart from
+# kendex_trim's rather than sharing a `_kendex_raw`.
 kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
   local _kendex_trimmed="$2"
   _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"
@@ -100,10 +107,10 @@ kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, as
 # Decode one [env] value per the settings contract: a single-line basic
 # string containing no `"` and no `\`, optionally followed by a `#`
 # comment. Anything else is a shape the contract does not carry.
-kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched
-  local _kendex_raw _kendex_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
-  kendex_trim _kendex_raw "$2"
-  [[ "$_kendex_raw" =~ $_kendex_regex ]] || return 1
+kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched; overwrites the caller's BASH_REMATCH, since the match runs in the caller's shell rather than a subshell
+  local _kendex_decode_raw _kendex_decode_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
+  kendex_trim _kendex_decode_raw "$2"
+  [[ "$_kendex_decode_raw" =~ $_kendex_decode_regex ]] || return 1
   printf -v "$1" '%s' "${BASH_REMATCH[1]}"
 }
 

--- a/.agents/skills/decider/scripts/lib/kendex-env.sh
+++ b/.agents/skills/decider/scripts/lib/kendex-env.sh
@@ -93,10 +93,10 @@ kendex_source_env_file() {
 #
 # The assignment is a `printf -v` into a name the CALLER chose, so it is
 # lost to the helper's own local whenever the two spellings meet: never
-# pass `_kendex_trimmed`, `_kendex_decode_raw` or `_kendex_decode_regex` as
-# an out-var. Nothing enforces that — kendex_decode_value is itself such a
-# caller, which is why its scratch names are spelled apart from
-# kendex_trim's rather than sharing a `_kendex_raw`.
+# pass a helper its own scratch name — `_kendex_trimmed` to kendex_trim,
+# `_kendex_decode_raw` or `_kendex_decode_regex` to kendex_decode_value.
+# Nothing enforces that; the two sets are spelled apart precisely so
+# kendex_decode_value can hand its own scratch to kendex_trim.
 kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
   local _kendex_trimmed="$2"
   _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"

--- a/.agents/skills/decider/scripts/lib/kendex-env.sh
+++ b/.agents/skills/decider/scripts/lib/kendex-env.sh
@@ -84,21 +84,27 @@ kendex_source_env_file() {
   source "$file"
 }
 
-kendex_trim() {
-  local value="$1"
-  value="${value#"${value%%[!$' \t\r\n']*}"}"
-  value="${value%"${value##*[!$' \t\r\n']}"}"
-  printf '%s' "$value"
+# Both helpers assign into a caller-named variable instead of printing.
+# kendex_load_settings_file calls them once or twice per line, and a helper
+# that printed could only be read back through a command substitution — a
+# forked subshell per line of every settings file every skill script reads.
+# Their locals carry a `_kendex_` prefix so an out-variable name cannot
+# shadow one and lose the assignment to the local.
+kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
+  local _kendex_trimmed="$2"
+  _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"
+  _kendex_trimmed="${_kendex_trimmed%"${_kendex_trimmed##*[!$' \t\r\n']}"}"
+  printf -v "$1" '%s' "$_kendex_trimmed"
 }
 
 # Decode one [env] value per the settings contract: a single-line basic
 # string containing no `"` and no `\`, optionally followed by a `#`
 # comment. Anything else is a shape the contract does not carry.
-kendex_decode_value() { # RAW — decoded value on stdout; 1 = not contract shape
-  local value regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
-  value="$(kendex_trim "$1")"
-  [[ "$value" =~ $regex ]] || return 1
-  printf '%s' "${BASH_REMATCH[1]}"
+kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched
+  local _kendex_raw _kendex_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
+  kendex_trim _kendex_raw "$2"
+  [[ "$_kendex_raw" =~ $_kendex_regex ]] || return 1
+  printf -v "$1" '%s' "${BASH_REMATCH[1]}"
 }
 
 kendex_load_settings_file() {
@@ -111,7 +117,7 @@ kendex_load_settings_file() {
   while IFS= read -r line || [[ -n "$line" ]]; do
     lineno=$((lineno + 1))
     line="${line%$'\r'}"
-    line="$(kendex_trim "$line")"
+    kendex_trim line "$line"
     [[ -z "$line" || "$line" == \#* ]] && continue
 
     # A `[`-leading line is a header or an error, never content: `[env] # c`
@@ -128,7 +134,7 @@ kendex_load_settings_file() {
     fi
 
     [[ "$section" == "env" && "$line" == *=* ]] || continue
-    key="$(kendex_trim "${line%%=*}")"
+    kendex_trim key "${line%%=*}"
     [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
     # Which duplicate wins would be an accident of read order, so a re-assigned
     # key is a configuration error — the same ambiguity guard the settings.sh
@@ -139,7 +145,7 @@ kendex_load_settings_file() {
       return 1
     fi
     seen="$seen$key "
-    if ! value="$(kendex_decode_value "${line#*=}")"; then
+    if ! kendex_decode_value value "${line#*=}"; then
       echo "::error::$file: unsupported syntax for $key (expected a single-line basic string with no '\"' and no '\\': $key = \"value\")" >&2
       return 1
     fi

--- a/.agents/skills/github/scripts/lib/kendex-env.sh
+++ b/.agents/skills/github/scripts/lib/kendex-env.sh
@@ -85,11 +85,18 @@ kendex_source_env_file() {
 }
 
 # Both helpers assign into a caller-named variable instead of printing.
-# kendex_load_settings_file calls them once or twice per line, and a helper
-# that printed could only be read back through a command substitution — a
-# forked subshell per line of every settings file every skill script reads.
-# Their locals carry a `_kendex_` prefix so an out-variable name cannot
-# shadow one and lose the assignment to the local.
+# kendex_load_settings_file reaches kendex_trim once for every line, and
+# three times on an assignment line — twice directly, for the line and for
+# the key, and once more inside kendex_decode_value. A helper that printed
+# could only be read back through a command substitution, so every one of
+# those was a fork, on every settings file every skill script loads.
+#
+# The assignment is a `printf -v` into a name the CALLER chose, so it is
+# lost to the helper's own local whenever the two spellings meet: never
+# pass `_kendex_trimmed`, `_kendex_decode_raw` or `_kendex_decode_regex` as
+# an out-var. Nothing enforces that — kendex_decode_value is itself such a
+# caller, which is why its scratch names are spelled apart from
+# kendex_trim's rather than sharing a `_kendex_raw`.
 kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
   local _kendex_trimmed="$2"
   _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"
@@ -100,10 +107,10 @@ kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, as
 # Decode one [env] value per the settings contract: a single-line basic
 # string containing no `"` and no `\`, optionally followed by a `#`
 # comment. Anything else is a shape the contract does not carry.
-kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched
-  local _kendex_raw _kendex_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
-  kendex_trim _kendex_raw "$2"
-  [[ "$_kendex_raw" =~ $_kendex_regex ]] || return 1
+kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched; overwrites the caller's BASH_REMATCH, since the match runs in the caller's shell rather than a subshell
+  local _kendex_decode_raw _kendex_decode_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
+  kendex_trim _kendex_decode_raw "$2"
+  [[ "$_kendex_decode_raw" =~ $_kendex_decode_regex ]] || return 1
   printf -v "$1" '%s' "${BASH_REMATCH[1]}"
 }
 

--- a/.agents/skills/github/scripts/lib/kendex-env.sh
+++ b/.agents/skills/github/scripts/lib/kendex-env.sh
@@ -93,10 +93,10 @@ kendex_source_env_file() {
 #
 # The assignment is a `printf -v` into a name the CALLER chose, so it is
 # lost to the helper's own local whenever the two spellings meet: never
-# pass `_kendex_trimmed`, `_kendex_decode_raw` or `_kendex_decode_regex` as
-# an out-var. Nothing enforces that — kendex_decode_value is itself such a
-# caller, which is why its scratch names are spelled apart from
-# kendex_trim's rather than sharing a `_kendex_raw`.
+# pass a helper its own scratch name — `_kendex_trimmed` to kendex_trim,
+# `_kendex_decode_raw` or `_kendex_decode_regex` to kendex_decode_value.
+# Nothing enforces that; the two sets are spelled apart precisely so
+# kendex_decode_value can hand its own scratch to kendex_trim.
 kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
   local _kendex_trimmed="$2"
   _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"

--- a/.agents/skills/github/scripts/lib/kendex-env.sh
+++ b/.agents/skills/github/scripts/lib/kendex-env.sh
@@ -84,21 +84,27 @@ kendex_source_env_file() {
   source "$file"
 }
 
-kendex_trim() {
-  local value="$1"
-  value="${value#"${value%%[!$' \t\r\n']*}"}"
-  value="${value%"${value##*[!$' \t\r\n']}"}"
-  printf '%s' "$value"
+# Both helpers assign into a caller-named variable instead of printing.
+# kendex_load_settings_file calls them once or twice per line, and a helper
+# that printed could only be read back through a command substitution — a
+# forked subshell per line of every settings file every skill script reads.
+# Their locals carry a `_kendex_` prefix so an out-variable name cannot
+# shadow one and lose the assignment to the local.
+kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
+  local _kendex_trimmed="$2"
+  _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"
+  _kendex_trimmed="${_kendex_trimmed%"${_kendex_trimmed##*[!$' \t\r\n']}"}"
+  printf -v "$1" '%s' "$_kendex_trimmed"
 }
 
 # Decode one [env] value per the settings contract: a single-line basic
 # string containing no `"` and no `\`, optionally followed by a `#`
 # comment. Anything else is a shape the contract does not carry.
-kendex_decode_value() { # RAW — decoded value on stdout; 1 = not contract shape
-  local value regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
-  value="$(kendex_trim "$1")"
-  [[ "$value" =~ $regex ]] || return 1
-  printf '%s' "${BASH_REMATCH[1]}"
+kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched
+  local _kendex_raw _kendex_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
+  kendex_trim _kendex_raw "$2"
+  [[ "$_kendex_raw" =~ $_kendex_regex ]] || return 1
+  printf -v "$1" '%s' "${BASH_REMATCH[1]}"
 }
 
 kendex_load_settings_file() {
@@ -111,7 +117,7 @@ kendex_load_settings_file() {
   while IFS= read -r line || [[ -n "$line" ]]; do
     lineno=$((lineno + 1))
     line="${line%$'\r'}"
-    line="$(kendex_trim "$line")"
+    kendex_trim line "$line"
     [[ -z "$line" || "$line" == \#* ]] && continue
 
     # A `[`-leading line is a header or an error, never content: `[env] # c`
@@ -128,7 +134,7 @@ kendex_load_settings_file() {
     fi
 
     [[ "$section" == "env" && "$line" == *=* ]] || continue
-    key="$(kendex_trim "${line%%=*}")"
+    kendex_trim key "${line%%=*}"
     [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
     # Which duplicate wins would be an accident of read order, so a re-assigned
     # key is a configuration error — the same ambiguity guard the settings.sh
@@ -139,7 +145,7 @@ kendex_load_settings_file() {
       return 1
     fi
     seen="$seen$key "
-    if ! value="$(kendex_decode_value "${line#*=}")"; then
+    if ! kendex_decode_value value "${line#*=}"; then
       echo "::error::$file: unsupported syntax for $key (expected a single-line basic string with no '\"' and no '\\': $key = \"value\")" >&2
       return 1
     fi

--- a/.agents/skills/linear/scripts/commands/issues.sh
+++ b/.agents/skills/linear/scripts/commands/issues.sh
@@ -955,7 +955,7 @@ require_agent_routing_label() {
 
     local supplied declared_name agent_matched=0 unknown_agent=""
     for supplied in ${supplied_names[@]+"${supplied_names[@]}"}; do
-        supplied="$(kendex_trim "$supplied")"
+        kendex_trim supplied "$supplied"
         [ -n "$supplied" ] || continue
         local is_declared=0
         for declared_name in ${declared_names[@]+"${declared_names[@]}"}; do
@@ -1183,7 +1183,7 @@ create_issue() {
         local raw_label_names=()
         IFS=',' read -ra raw_label_names <<<"$labels"
         for raw_label_name in "${raw_label_names[@]}"; do
-            raw_label_name="$(kendex_trim "$raw_label_name")"
+            kendex_trim raw_label_name "$raw_label_name"
             [ -n "$raw_label_name" ] || continue
             normalized_labels="${normalized_labels:+$normalized_labels,}$raw_label_name"
         done

--- a/.agents/skills/linear/scripts/lib/kendex-env.sh
+++ b/.agents/skills/linear/scripts/lib/kendex-env.sh
@@ -85,11 +85,18 @@ kendex_source_env_file() {
 }
 
 # Both helpers assign into a caller-named variable instead of printing.
-# kendex_load_settings_file calls them once or twice per line, and a helper
-# that printed could only be read back through a command substitution — a
-# forked subshell per line of every settings file every skill script reads.
-# Their locals carry a `_kendex_` prefix so an out-variable name cannot
-# shadow one and lose the assignment to the local.
+# kendex_load_settings_file reaches kendex_trim once for every line, and
+# three times on an assignment line — twice directly, for the line and for
+# the key, and once more inside kendex_decode_value. A helper that printed
+# could only be read back through a command substitution, so every one of
+# those was a fork, on every settings file every skill script loads.
+#
+# The assignment is a `printf -v` into a name the CALLER chose, so it is
+# lost to the helper's own local whenever the two spellings meet: never
+# pass `_kendex_trimmed`, `_kendex_decode_raw` or `_kendex_decode_regex` as
+# an out-var. Nothing enforces that — kendex_decode_value is itself such a
+# caller, which is why its scratch names are spelled apart from
+# kendex_trim's rather than sharing a `_kendex_raw`.
 kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
   local _kendex_trimmed="$2"
   _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"
@@ -100,10 +107,10 @@ kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, as
 # Decode one [env] value per the settings contract: a single-line basic
 # string containing no `"` and no `\`, optionally followed by a `#`
 # comment. Anything else is a shape the contract does not carry.
-kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched
-  local _kendex_raw _kendex_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
-  kendex_trim _kendex_raw "$2"
-  [[ "$_kendex_raw" =~ $_kendex_regex ]] || return 1
+kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched; overwrites the caller's BASH_REMATCH, since the match runs in the caller's shell rather than a subshell
+  local _kendex_decode_raw _kendex_decode_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
+  kendex_trim _kendex_decode_raw "$2"
+  [[ "$_kendex_decode_raw" =~ $_kendex_decode_regex ]] || return 1
   printf -v "$1" '%s' "${BASH_REMATCH[1]}"
 }
 

--- a/.agents/skills/linear/scripts/lib/kendex-env.sh
+++ b/.agents/skills/linear/scripts/lib/kendex-env.sh
@@ -93,10 +93,10 @@ kendex_source_env_file() {
 #
 # The assignment is a `printf -v` into a name the CALLER chose, so it is
 # lost to the helper's own local whenever the two spellings meet: never
-# pass `_kendex_trimmed`, `_kendex_decode_raw` or `_kendex_decode_regex` as
-# an out-var. Nothing enforces that — kendex_decode_value is itself such a
-# caller, which is why its scratch names are spelled apart from
-# kendex_trim's rather than sharing a `_kendex_raw`.
+# pass a helper its own scratch name — `_kendex_trimmed` to kendex_trim,
+# `_kendex_decode_raw` or `_kendex_decode_regex` to kendex_decode_value.
+# Nothing enforces that; the two sets are spelled apart precisely so
+# kendex_decode_value can hand its own scratch to kendex_trim.
 kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
   local _kendex_trimmed="$2"
   _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"

--- a/.agents/skills/linear/scripts/lib/kendex-env.sh
+++ b/.agents/skills/linear/scripts/lib/kendex-env.sh
@@ -84,21 +84,27 @@ kendex_source_env_file() {
   source "$file"
 }
 
-kendex_trim() {
-  local value="$1"
-  value="${value#"${value%%[!$' \t\r\n']*}"}"
-  value="${value%"${value##*[!$' \t\r\n']}"}"
-  printf '%s' "$value"
+# Both helpers assign into a caller-named variable instead of printing.
+# kendex_load_settings_file calls them once or twice per line, and a helper
+# that printed could only be read back through a command substitution — a
+# forked subshell per line of every settings file every skill script reads.
+# Their locals carry a `_kendex_` prefix so an out-variable name cannot
+# shadow one and lose the assignment to the local.
+kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
+  local _kendex_trimmed="$2"
+  _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"
+  _kendex_trimmed="${_kendex_trimmed%"${_kendex_trimmed##*[!$' \t\r\n']}"}"
+  printf -v "$1" '%s' "$_kendex_trimmed"
 }
 
 # Decode one [env] value per the settings contract: a single-line basic
 # string containing no `"` and no `\`, optionally followed by a `#`
 # comment. Anything else is a shape the contract does not carry.
-kendex_decode_value() { # RAW — decoded value on stdout; 1 = not contract shape
-  local value regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
-  value="$(kendex_trim "$1")"
-  [[ "$value" =~ $regex ]] || return 1
-  printf '%s' "${BASH_REMATCH[1]}"
+kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched
+  local _kendex_raw _kendex_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
+  kendex_trim _kendex_raw "$2"
+  [[ "$_kendex_raw" =~ $_kendex_regex ]] || return 1
+  printf -v "$1" '%s' "${BASH_REMATCH[1]}"
 }
 
 kendex_load_settings_file() {
@@ -111,7 +117,7 @@ kendex_load_settings_file() {
   while IFS= read -r line || [[ -n "$line" ]]; do
     lineno=$((lineno + 1))
     line="${line%$'\r'}"
-    line="$(kendex_trim "$line")"
+    kendex_trim line "$line"
     [[ -z "$line" || "$line" == \#* ]] && continue
 
     # A `[`-leading line is a header or an error, never content: `[env] # c`
@@ -128,7 +134,7 @@ kendex_load_settings_file() {
     fi
 
     [[ "$section" == "env" && "$line" == *=* ]] || continue
-    key="$(kendex_trim "${line%%=*}")"
+    kendex_trim key "${line%%=*}"
     [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
     # Which duplicate wins would be an accident of read order, so a re-assigned
     # key is a configuration error — the same ambiguity guard the settings.sh
@@ -139,7 +145,7 @@ kendex_load_settings_file() {
       return 1
     fi
     seen="$seen$key "
-    if ! value="$(kendex_decode_value "${line#*=}")"; then
+    if ! kendex_decode_value value "${line#*=}"; then
       echo "::error::$file: unsupported syntax for $key (expected a single-line basic string with no '\"' and no '\\': $key = \"value\")" >&2
       return 1
     fi

--- a/.agents/skills/orch/scripts/lib/kendex-env.sh
+++ b/.agents/skills/orch/scripts/lib/kendex-env.sh
@@ -85,11 +85,18 @@ kendex_source_env_file() {
 }
 
 # Both helpers assign into a caller-named variable instead of printing.
-# kendex_load_settings_file calls them once or twice per line, and a helper
-# that printed could only be read back through a command substitution — a
-# forked subshell per line of every settings file every skill script reads.
-# Their locals carry a `_kendex_` prefix so an out-variable name cannot
-# shadow one and lose the assignment to the local.
+# kendex_load_settings_file reaches kendex_trim once for every line, and
+# three times on an assignment line — twice directly, for the line and for
+# the key, and once more inside kendex_decode_value. A helper that printed
+# could only be read back through a command substitution, so every one of
+# those was a fork, on every settings file every skill script loads.
+#
+# The assignment is a `printf -v` into a name the CALLER chose, so it is
+# lost to the helper's own local whenever the two spellings meet: never
+# pass `_kendex_trimmed`, `_kendex_decode_raw` or `_kendex_decode_regex` as
+# an out-var. Nothing enforces that — kendex_decode_value is itself such a
+# caller, which is why its scratch names are spelled apart from
+# kendex_trim's rather than sharing a `_kendex_raw`.
 kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
   local _kendex_trimmed="$2"
   _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"
@@ -100,10 +107,10 @@ kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, as
 # Decode one [env] value per the settings contract: a single-line basic
 # string containing no `"` and no `\`, optionally followed by a `#`
 # comment. Anything else is a shape the contract does not carry.
-kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched
-  local _kendex_raw _kendex_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
-  kendex_trim _kendex_raw "$2"
-  [[ "$_kendex_raw" =~ $_kendex_regex ]] || return 1
+kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched; overwrites the caller's BASH_REMATCH, since the match runs in the caller's shell rather than a subshell
+  local _kendex_decode_raw _kendex_decode_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
+  kendex_trim _kendex_decode_raw "$2"
+  [[ "$_kendex_decode_raw" =~ $_kendex_decode_regex ]] || return 1
   printf -v "$1" '%s' "${BASH_REMATCH[1]}"
 }
 

--- a/.agents/skills/orch/scripts/lib/kendex-env.sh
+++ b/.agents/skills/orch/scripts/lib/kendex-env.sh
@@ -93,10 +93,10 @@ kendex_source_env_file() {
 #
 # The assignment is a `printf -v` into a name the CALLER chose, so it is
 # lost to the helper's own local whenever the two spellings meet: never
-# pass `_kendex_trimmed`, `_kendex_decode_raw` or `_kendex_decode_regex` as
-# an out-var. Nothing enforces that — kendex_decode_value is itself such a
-# caller, which is why its scratch names are spelled apart from
-# kendex_trim's rather than sharing a `_kendex_raw`.
+# pass a helper its own scratch name — `_kendex_trimmed` to kendex_trim,
+# `_kendex_decode_raw` or `_kendex_decode_regex` to kendex_decode_value.
+# Nothing enforces that; the two sets are spelled apart precisely so
+# kendex_decode_value can hand its own scratch to kendex_trim.
 kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
   local _kendex_trimmed="$2"
   _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"

--- a/.agents/skills/orch/scripts/lib/kendex-env.sh
+++ b/.agents/skills/orch/scripts/lib/kendex-env.sh
@@ -84,21 +84,27 @@ kendex_source_env_file() {
   source "$file"
 }
 
-kendex_trim() {
-  local value="$1"
-  value="${value#"${value%%[!$' \t\r\n']*}"}"
-  value="${value%"${value##*[!$' \t\r\n']}"}"
-  printf '%s' "$value"
+# Both helpers assign into a caller-named variable instead of printing.
+# kendex_load_settings_file calls them once or twice per line, and a helper
+# that printed could only be read back through a command substitution — a
+# forked subshell per line of every settings file every skill script reads.
+# Their locals carry a `_kendex_` prefix so an out-variable name cannot
+# shadow one and lose the assignment to the local.
+kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
+  local _kendex_trimmed="$2"
+  _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"
+  _kendex_trimmed="${_kendex_trimmed%"${_kendex_trimmed##*[!$' \t\r\n']}"}"
+  printf -v "$1" '%s' "$_kendex_trimmed"
 }
 
 # Decode one [env] value per the settings contract: a single-line basic
 # string containing no `"` and no `\`, optionally followed by a `#`
 # comment. Anything else is a shape the contract does not carry.
-kendex_decode_value() { # RAW — decoded value on stdout; 1 = not contract shape
-  local value regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
-  value="$(kendex_trim "$1")"
-  [[ "$value" =~ $regex ]] || return 1
-  printf '%s' "${BASH_REMATCH[1]}"
+kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched
+  local _kendex_raw _kendex_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
+  kendex_trim _kendex_raw "$2"
+  [[ "$_kendex_raw" =~ $_kendex_regex ]] || return 1
+  printf -v "$1" '%s' "${BASH_REMATCH[1]}"
 }
 
 kendex_load_settings_file() {
@@ -111,7 +117,7 @@ kendex_load_settings_file() {
   while IFS= read -r line || [[ -n "$line" ]]; do
     lineno=$((lineno + 1))
     line="${line%$'\r'}"
-    line="$(kendex_trim "$line")"
+    kendex_trim line "$line"
     [[ -z "$line" || "$line" == \#* ]] && continue
 
     # A `[`-leading line is a header or an error, never content: `[env] # c`
@@ -128,7 +134,7 @@ kendex_load_settings_file() {
     fi
 
     [[ "$section" == "env" && "$line" == *=* ]] || continue
-    key="$(kendex_trim "${line%%=*}")"
+    kendex_trim key "${line%%=*}"
     [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
     # Which duplicate wins would be an accident of read order, so a re-assigned
     # key is a configuration error — the same ambiguity guard the settings.sh
@@ -139,7 +145,7 @@ kendex_load_settings_file() {
       return 1
     fi
     seen="$seen$key "
-    if ! value="$(kendex_decode_value "${line#*=}")"; then
+    if ! kendex_decode_value value "${line#*=}"; then
       echo "::error::$file: unsupported syntax for $key (expected a single-line basic string with no '\"' and no '\\': $key = \"value\")" >&2
       return 1
     fi

--- a/.agents/skills/orch/tests/kendex-env-precedence.sh
+++ b/.agents/skills/orch/tests/kendex-env-precedence.sh
@@ -40,11 +40,13 @@ echo "=== kendex-env precedence ==="
 PROJ="$TMP_ROOT/proj"
 mkdir -p "$PROJ/.kendex"
 printf 'FOO="from-dotenv"\nQUX="only-in-dotenv"\n' > "$PROJ/.env"
-cat > "$PROJ/kendex.settings.toml" <<'TOML'
-[env]
-FOO = "from-settings"
-BAR = "bar-settings"
-TOML
+# Indented header, indented key, and trailing spaces on both — a shape the
+# loader accepts only because it trims every line, and the fixture that
+# makes the trim's RESULT load-bearing rather than just its call: lose the
+# assignment (a shadowed out-var, a fork) and `  [env]  ` stops reading as
+# a header, so the whole table is silently dropped and scenario 1's FOO is
+# unset. Written with printf so the trailing runs survive an editor.
+printf '  [env]  \n  FOO = "from-settings"  \nBAR = "bar-settings"\n' > "$PROJ/kendex.settings.toml"
 printf '[env]\nBAR = "bar-nested"\n' > "$PROJ/.kendex/settings.toml"
 printf 'BAZ="from-local"\n' > "$PROJ/.env.local"
 
@@ -242,25 +244,33 @@ else
   s8_case "an UNREADABLE kendex.settings.toml" 'printf "[env]\nX = \"y\"\n" > kendex.settings.toml && chmod 000 kendex.settings.toml' "kendex.settings.toml: source exists but is unreadable"
 fi
 
-# Scenario 9: the per-line path forks no subshell. kendex_trim and
-# kendex_decode_value assign into a caller-named variable, so a counting
-# wrapper around the real helper sees every call the loader makes. Read
-# back through a command substitution instead — a forked subshell per line
-# of every settings file every skill script reads — each increment lands in
-# the forked copy and the count comes back short, 0 when every call site
-# forks. The count is exact so that ONE reverted call site is caught too:
-# three lines trimmed, plus one key trim and one kendex_decode_value trim
-# for each of the two assignments.
+# Scenario 9: the per-line path forks no subshell. A wrapper delegating to
+# the real kendex_trim records two things per call. $BASH_SUBSHELL is the
+# direct measure — a fork raises it, and no variable can carry that back
+# out of the fork, so each call appends its depth relative to the loader's
+# own frame to a file; every recorded depth is 0 or a call ran inside a
+# subshell, wherever in the loop the fork was introduced. The call count is
+# the second: it is exact, so ONE call site reverted to a command
+# substitution is caught by the increment lost with its subshell. Seven for
+# a three-line file — every line trimmed, plus the key trim and the
+# kendex_decode_value trim for each of the two assignments.
 PROJ9="$TMP_ROOT/proj9"
 mkdir -p "$PROJ9"
 printf '[env]\nK1 = "v1"\nK2 = "v2"\n' > "$PROJ9/kendex.settings.toml"
+S9_LEVELS="$TMP_ROOT/s9-subshell-levels"
+: > "$S9_LEVELS"
 set +e
 s9_out=$(
   set -euo pipefail
   source "$LIB"
   trim_body="$(declare -f kendex_trim)"
   eval "_kendex_trim_real${trim_body#kendex_trim}"
-  kendex_trim() { TRIM_CALLS=$((TRIM_CALLS + 1)); _kendex_trim_real "$@"; }
+  S9_BASE=$BASH_SUBSHELL
+  kendex_trim() {
+    TRIM_CALLS=$((TRIM_CALLS + 1))
+    printf '%s\n' "$((BASH_SUBSHELL - S9_BASE))" >> "$S9_LEVELS"
+    _kendex_trim_real "$@"
+  }
   TRIM_CALLS=0
   kendex_load_settings_file "$PROJ9/kendex.settings.toml"
   printf '%s|%s|%s\n' "$TRIM_CALLS" "$K1" "$K2"
@@ -269,6 +279,7 @@ s9_code=$?
 set -e
 assert_eq "$s9_code" "0" "scenario 9 loads without error"
 assert_eq "$s9_out" "7|v1|v2" "scenario 9: every kendex_trim call the loader makes is visible in its own shell, none lost to a command substitution"
+assert_eq "$(sort -u "$S9_LEVELS" | paste -sd, -)" "0" "scenario 9: every kendex_trim call runs at the loader's own subshell depth, none inside a fork"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/.agents/skills/orch/tests/kendex-env-precedence.sh
+++ b/.agents/skills/orch/tests/kendex-env-precedence.sh
@@ -242,6 +242,34 @@ else
   s8_case "an UNREADABLE kendex.settings.toml" 'printf "[env]\nX = \"y\"\n" > kendex.settings.toml && chmod 000 kendex.settings.toml' "kendex.settings.toml: source exists but is unreadable"
 fi
 
+# Scenario 9: the per-line path forks no subshell. kendex_trim and
+# kendex_decode_value assign into a caller-named variable, so a counting
+# wrapper around the real helper sees every call the loader makes. Read
+# back through a command substitution instead — a forked subshell per line
+# of every settings file every skill script reads — each increment lands in
+# the forked copy and the count comes back short, 0 when every call site
+# forks. The count is exact so that ONE reverted call site is caught too:
+# three lines trimmed, plus one key trim and one kendex_decode_value trim
+# for each of the two assignments.
+PROJ9="$TMP_ROOT/proj9"
+mkdir -p "$PROJ9"
+printf '[env]\nK1 = "v1"\nK2 = "v2"\n' > "$PROJ9/kendex.settings.toml"
+set +e
+s9_out=$(
+  set -euo pipefail
+  source "$LIB"
+  trim_body="$(declare -f kendex_trim)"
+  eval "_kendex_trim_real${trim_body#kendex_trim}"
+  kendex_trim() { TRIM_CALLS=$((TRIM_CALLS + 1)); _kendex_trim_real "$@"; }
+  TRIM_CALLS=0
+  kendex_load_settings_file "$PROJ9/kendex.settings.toml"
+  printf '%s|%s|%s\n' "$TRIM_CALLS" "$K1" "$K2"
+)
+s9_code=$?
+set -e
+assert_eq "$s9_code" "0" "scenario 9 loads without error"
+assert_eq "$s9_out" "7|v1|v2" "scenario 9: every kendex_trim call the loader makes is visible in its own shell, none lost to a command substitution"
+
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/.agents/skills/second-opinion/scripts/lib/kendex-env.sh
+++ b/.agents/skills/second-opinion/scripts/lib/kendex-env.sh
@@ -85,11 +85,18 @@ kendex_source_env_file() {
 }
 
 # Both helpers assign into a caller-named variable instead of printing.
-# kendex_load_settings_file calls them once or twice per line, and a helper
-# that printed could only be read back through a command substitution — a
-# forked subshell per line of every settings file every skill script reads.
-# Their locals carry a `_kendex_` prefix so an out-variable name cannot
-# shadow one and lose the assignment to the local.
+# kendex_load_settings_file reaches kendex_trim once for every line, and
+# three times on an assignment line — twice directly, for the line and for
+# the key, and once more inside kendex_decode_value. A helper that printed
+# could only be read back through a command substitution, so every one of
+# those was a fork, on every settings file every skill script loads.
+#
+# The assignment is a `printf -v` into a name the CALLER chose, so it is
+# lost to the helper's own local whenever the two spellings meet: never
+# pass `_kendex_trimmed`, `_kendex_decode_raw` or `_kendex_decode_regex` as
+# an out-var. Nothing enforces that — kendex_decode_value is itself such a
+# caller, which is why its scratch names are spelled apart from
+# kendex_trim's rather than sharing a `_kendex_raw`.
 kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
   local _kendex_trimmed="$2"
   _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"
@@ -100,10 +107,10 @@ kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, as
 # Decode one [env] value per the settings contract: a single-line basic
 # string containing no `"` and no `\`, optionally followed by a `#`
 # comment. Anything else is a shape the contract does not carry.
-kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched
-  local _kendex_raw _kendex_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
-  kendex_trim _kendex_raw "$2"
-  [[ "$_kendex_raw" =~ $_kendex_regex ]] || return 1
+kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched; overwrites the caller's BASH_REMATCH, since the match runs in the caller's shell rather than a subshell
+  local _kendex_decode_raw _kendex_decode_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
+  kendex_trim _kendex_decode_raw "$2"
+  [[ "$_kendex_decode_raw" =~ $_kendex_decode_regex ]] || return 1
   printf -v "$1" '%s' "${BASH_REMATCH[1]}"
 }
 

--- a/.agents/skills/second-opinion/scripts/lib/kendex-env.sh
+++ b/.agents/skills/second-opinion/scripts/lib/kendex-env.sh
@@ -93,10 +93,10 @@ kendex_source_env_file() {
 #
 # The assignment is a `printf -v` into a name the CALLER chose, so it is
 # lost to the helper's own local whenever the two spellings meet: never
-# pass `_kendex_trimmed`, `_kendex_decode_raw` or `_kendex_decode_regex` as
-# an out-var. Nothing enforces that — kendex_decode_value is itself such a
-# caller, which is why its scratch names are spelled apart from
-# kendex_trim's rather than sharing a `_kendex_raw`.
+# pass a helper its own scratch name — `_kendex_trimmed` to kendex_trim,
+# `_kendex_decode_raw` or `_kendex_decode_regex` to kendex_decode_value.
+# Nothing enforces that; the two sets are spelled apart precisely so
+# kendex_decode_value can hand its own scratch to kendex_trim.
 kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
   local _kendex_trimmed="$2"
   _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"

--- a/.agents/skills/second-opinion/scripts/lib/kendex-env.sh
+++ b/.agents/skills/second-opinion/scripts/lib/kendex-env.sh
@@ -84,21 +84,27 @@ kendex_source_env_file() {
   source "$file"
 }
 
-kendex_trim() {
-  local value="$1"
-  value="${value#"${value%%[!$' \t\r\n']*}"}"
-  value="${value%"${value##*[!$' \t\r\n']}"}"
-  printf '%s' "$value"
+# Both helpers assign into a caller-named variable instead of printing.
+# kendex_load_settings_file calls them once or twice per line, and a helper
+# that printed could only be read back through a command substitution — a
+# forked subshell per line of every settings file every skill script reads.
+# Their locals carry a `_kendex_` prefix so an out-variable name cannot
+# shadow one and lose the assignment to the local.
+kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
+  local _kendex_trimmed="$2"
+  _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"
+  _kendex_trimmed="${_kendex_trimmed%"${_kendex_trimmed##*[!$' \t\r\n']}"}"
+  printf -v "$1" '%s' "$_kendex_trimmed"
 }
 
 # Decode one [env] value per the settings contract: a single-line basic
 # string containing no `"` and no `\`, optionally followed by a `#`
 # comment. Anything else is a shape the contract does not carry.
-kendex_decode_value() { # RAW — decoded value on stdout; 1 = not contract shape
-  local value regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
-  value="$(kendex_trim "$1")"
-  [[ "$value" =~ $regex ]] || return 1
-  printf '%s' "${BASH_REMATCH[1]}"
+kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched
+  local _kendex_raw _kendex_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
+  kendex_trim _kendex_raw "$2"
+  [[ "$_kendex_raw" =~ $_kendex_regex ]] || return 1
+  printf -v "$1" '%s' "${BASH_REMATCH[1]}"
 }
 
 kendex_load_settings_file() {
@@ -111,7 +117,7 @@ kendex_load_settings_file() {
   while IFS= read -r line || [[ -n "$line" ]]; do
     lineno=$((lineno + 1))
     line="${line%$'\r'}"
-    line="$(kendex_trim "$line")"
+    kendex_trim line "$line"
     [[ -z "$line" || "$line" == \#* ]] && continue
 
     # A `[`-leading line is a header or an error, never content: `[env] # c`
@@ -128,7 +134,7 @@ kendex_load_settings_file() {
     fi
 
     [[ "$section" == "env" && "$line" == *=* ]] || continue
-    key="$(kendex_trim "${line%%=*}")"
+    kendex_trim key "${line%%=*}"
     [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
     # Which duplicate wins would be an accident of read order, so a re-assigned
     # key is a configuration error — the same ambiguity guard the settings.sh
@@ -139,7 +145,7 @@ kendex_load_settings_file() {
       return 1
     fi
     seen="$seen$key "
-    if ! value="$(kendex_decode_value "${line#*=}")"; then
+    if ! kendex_decode_value value "${line#*=}"; then
       echo "::error::$file: unsupported syntax for $key (expected a single-line basic string with no '\"' and no '\\': $key = \"value\")" >&2
       return 1
     fi

--- a/.agents/skills/second-opinion/scripts/second-opinion
+++ b/.agents/skills/second-opinion/scripts/second-opinion
@@ -671,7 +671,7 @@ detect_current_harness() {
   local ancestor_cmd
   while pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ') && [[ -n "$pid" && "$pid" != "0" && "$pid" != "1" ]]; do
     ancestor_cmd=$(ps -o comm= -p "$pid" 2>/dev/null || echo "")
-    ancestor_cmd="$(kendex_trim "$ancestor_cmd")"
+    kendex_trim ancestor_cmd "$ancestor_cmd"
     ancestor_cmd="${ancestor_cmd##*/}"
     case "$ancestor_cmd" in
       claude)       echo "claude"; return ;;
@@ -737,7 +737,7 @@ canon_identity() {
   # absorbed by the patterns' `*`, so untrimmed the failure looks arbitrary
   # rather than absent.) Every identity passes through here — declared,
   # detected, per-target and roster-derived — so trimming once covers them all.
-  id=$(kendex_trim "$1")
+  kendex_trim id "$1"
   id=$(lower "$id")
   # Provider-qualified ids — openai-codex/gpt-5.6-sol, openai/gpt-5.6-sol,
   # anthropic/claude-opus-4 — are exactly what Pi and OpenCode show an operator,
@@ -815,7 +815,7 @@ file_declares_current_model() {
   # `|| [[ -n "$line" ]]` so a final line with no trailing newline is still read.
   while IFS= read -r line || [[ -n "$line" ]]; do
     lineno=$((lineno + 1))
-    trimmed="$(kendex_trim "$line")"
+    kendex_trim trimmed "$line"
     # Blank and comment lines. No test covers the comment arm on its own: the
     # anchored match below already rejects anything starting with `#`, so this
     # is the guard that keeps that true if the match ever loosens.
@@ -833,7 +833,7 @@ file_declares_current_model() {
     fi
     [[ $in_env -eq 1 ]] || continue
     trimmed="${trimmed#export }"
-    trimmed="$(kendex_trim "$trimmed")"
+    kendex_trim trimmed "$trimmed"
     case "$trimmed" in
       SECOND_OPINION_CURRENT_MODEL=*|SECOND_OPINION_CURRENT_MODEL[[:space:]]*=*) return 0 ;;
     esac

--- a/.agents/skills/worktree/scripts/lib/kendex-env.sh
+++ b/.agents/skills/worktree/scripts/lib/kendex-env.sh
@@ -85,11 +85,18 @@ kendex_source_env_file() {
 }
 
 # Both helpers assign into a caller-named variable instead of printing.
-# kendex_load_settings_file calls them once or twice per line, and a helper
-# that printed could only be read back through a command substitution — a
-# forked subshell per line of every settings file every skill script reads.
-# Their locals carry a `_kendex_` prefix so an out-variable name cannot
-# shadow one and lose the assignment to the local.
+# kendex_load_settings_file reaches kendex_trim once for every line, and
+# three times on an assignment line — twice directly, for the line and for
+# the key, and once more inside kendex_decode_value. A helper that printed
+# could only be read back through a command substitution, so every one of
+# those was a fork, on every settings file every skill script loads.
+#
+# The assignment is a `printf -v` into a name the CALLER chose, so it is
+# lost to the helper's own local whenever the two spellings meet: never
+# pass `_kendex_trimmed`, `_kendex_decode_raw` or `_kendex_decode_regex` as
+# an out-var. Nothing enforces that — kendex_decode_value is itself such a
+# caller, which is why its scratch names are spelled apart from
+# kendex_trim's rather than sharing a `_kendex_raw`.
 kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
   local _kendex_trimmed="$2"
   _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"
@@ -100,10 +107,10 @@ kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, as
 # Decode one [env] value per the settings contract: a single-line basic
 # string containing no `"` and no `\`, optionally followed by a `#`
 # comment. Anything else is a shape the contract does not carry.
-kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched
-  local _kendex_raw _kendex_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
-  kendex_trim _kendex_raw "$2"
-  [[ "$_kendex_raw" =~ $_kendex_regex ]] || return 1
+kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched; overwrites the caller's BASH_REMATCH, since the match runs in the caller's shell rather than a subshell
+  local _kendex_decode_raw _kendex_decode_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
+  kendex_trim _kendex_decode_raw "$2"
+  [[ "$_kendex_decode_raw" =~ $_kendex_decode_regex ]] || return 1
   printf -v "$1" '%s' "${BASH_REMATCH[1]}"
 }
 

--- a/.agents/skills/worktree/scripts/lib/kendex-env.sh
+++ b/.agents/skills/worktree/scripts/lib/kendex-env.sh
@@ -93,10 +93,10 @@ kendex_source_env_file() {
 #
 # The assignment is a `printf -v` into a name the CALLER chose, so it is
 # lost to the helper's own local whenever the two spellings meet: never
-# pass `_kendex_trimmed`, `_kendex_decode_raw` or `_kendex_decode_regex` as
-# an out-var. Nothing enforces that — kendex_decode_value is itself such a
-# caller, which is why its scratch names are spelled apart from
-# kendex_trim's rather than sharing a `_kendex_raw`.
+# pass a helper its own scratch name — `_kendex_trimmed` to kendex_trim,
+# `_kendex_decode_raw` or `_kendex_decode_regex` to kendex_decode_value.
+# Nothing enforces that; the two sets are spelled apart precisely so
+# kendex_decode_value can hand its own scratch to kendex_trim.
 kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
   local _kendex_trimmed="$2"
   _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"

--- a/.agents/skills/worktree/scripts/lib/kendex-env.sh
+++ b/.agents/skills/worktree/scripts/lib/kendex-env.sh
@@ -84,21 +84,27 @@ kendex_source_env_file() {
   source "$file"
 }
 
-kendex_trim() {
-  local value="$1"
-  value="${value#"${value%%[!$' \t\r\n']*}"}"
-  value="${value%"${value##*[!$' \t\r\n']}"}"
-  printf '%s' "$value"
+# Both helpers assign into a caller-named variable instead of printing.
+# kendex_load_settings_file calls them once or twice per line, and a helper
+# that printed could only be read back through a command substitution — a
+# forked subshell per line of every settings file every skill script reads.
+# Their locals carry a `_kendex_` prefix so an out-variable name cannot
+# shadow one and lose the assignment to the local.
+kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
+  local _kendex_trimmed="$2"
+  _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"
+  _kendex_trimmed="${_kendex_trimmed%"${_kendex_trimmed##*[!$' \t\r\n']}"}"
+  printf -v "$1" '%s' "$_kendex_trimmed"
 }
 
 # Decode one [env] value per the settings contract: a single-line basic
 # string containing no `"` and no `\`, optionally followed by a `#`
 # comment. Anything else is a shape the contract does not carry.
-kendex_decode_value() { # RAW — decoded value on stdout; 1 = not contract shape
-  local value regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
-  value="$(kendex_trim "$1")"
-  [[ "$value" =~ $regex ]] || return 1
-  printf '%s' "${BASH_REMATCH[1]}"
+kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched
+  local _kendex_raw _kendex_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
+  kendex_trim _kendex_raw "$2"
+  [[ "$_kendex_raw" =~ $_kendex_regex ]] || return 1
+  printf -v "$1" '%s' "${BASH_REMATCH[1]}"
 }
 
 kendex_load_settings_file() {
@@ -111,7 +117,7 @@ kendex_load_settings_file() {
   while IFS= read -r line || [[ -n "$line" ]]; do
     lineno=$((lineno + 1))
     line="${line%$'\r'}"
-    line="$(kendex_trim "$line")"
+    kendex_trim line "$line"
     [[ -z "$line" || "$line" == \#* ]] && continue
 
     # A `[`-leading line is a header or an error, never content: `[env] # c`
@@ -128,7 +134,7 @@ kendex_load_settings_file() {
     fi
 
     [[ "$section" == "env" && "$line" == *=* ]] || continue
-    key="$(kendex_trim "${line%%=*}")"
+    kendex_trim key "${line%%=*}"
     [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
     # Which duplicate wins would be an accident of read order, so a re-assigned
     # key is a configuration error — the same ambiguity guard the settings.sh
@@ -139,7 +145,7 @@ kendex_load_settings_file() {
       return 1
     fi
     seen="$seen$key "
-    if ! value="$(kendex_decode_value "${line#*=}")"; then
+    if ! kendex_decode_value value "${line#*=}"; then
       echo "::error::$file: unsupported syntax for $key (expected a single-line basic string with no '\"' and no '\\': $key = \"value\")" >&2
       return 1
     fi

--- a/changelog.d/changed/KEN-1070.md
+++ b/changelog.d/changed/KEN-1070.md
@@ -1,0 +1,1 @@
+- kendex skill scripts load project settings without forking a subshell per line: reading the 310-line `kendex.settings.toml` in this repo drops from 272 ms to 22 ms per invocation.

--- a/changelog.d/changed/KEN-1070.md
+++ b/changelog.d/changed/KEN-1070.md
@@ -1,1 +1,1 @@
-- kendex skill scripts load project settings without forking a subshell per line: reading the 310-line `kendex.settings.toml` in this repo drops from 272 ms to 22 ms per invocation.
+- kendex skill scripts load project settings without forking a subshell per line: reading the 310-line `kendex.settings.toml` in this repo gets about 12x faster.

--- a/skills/decider/scripts/lib/kendex-env.sh
+++ b/skills/decider/scripts/lib/kendex-env.sh
@@ -85,11 +85,18 @@ kendex_source_env_file() {
 }
 
 # Both helpers assign into a caller-named variable instead of printing.
-# kendex_load_settings_file calls them once or twice per line, and a helper
-# that printed could only be read back through a command substitution — a
-# forked subshell per line of every settings file every skill script reads.
-# Their locals carry a `_kendex_` prefix so an out-variable name cannot
-# shadow one and lose the assignment to the local.
+# kendex_load_settings_file reaches kendex_trim once for every line, and
+# three times on an assignment line — twice directly, for the line and for
+# the key, and once more inside kendex_decode_value. A helper that printed
+# could only be read back through a command substitution, so every one of
+# those was a fork, on every settings file every skill script loads.
+#
+# The assignment is a `printf -v` into a name the CALLER chose, so it is
+# lost to the helper's own local whenever the two spellings meet: never
+# pass `_kendex_trimmed`, `_kendex_decode_raw` or `_kendex_decode_regex` as
+# an out-var. Nothing enforces that — kendex_decode_value is itself such a
+# caller, which is why its scratch names are spelled apart from
+# kendex_trim's rather than sharing a `_kendex_raw`.
 kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
   local _kendex_trimmed="$2"
   _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"
@@ -100,10 +107,10 @@ kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, as
 # Decode one [env] value per the settings contract: a single-line basic
 # string containing no `"` and no `\`, optionally followed by a `#`
 # comment. Anything else is a shape the contract does not carry.
-kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched
-  local _kendex_raw _kendex_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
-  kendex_trim _kendex_raw "$2"
-  [[ "$_kendex_raw" =~ $_kendex_regex ]] || return 1
+kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched; overwrites the caller's BASH_REMATCH, since the match runs in the caller's shell rather than a subshell
+  local _kendex_decode_raw _kendex_decode_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
+  kendex_trim _kendex_decode_raw "$2"
+  [[ "$_kendex_decode_raw" =~ $_kendex_decode_regex ]] || return 1
   printf -v "$1" '%s' "${BASH_REMATCH[1]}"
 }
 

--- a/skills/decider/scripts/lib/kendex-env.sh
+++ b/skills/decider/scripts/lib/kendex-env.sh
@@ -93,10 +93,10 @@ kendex_source_env_file() {
 #
 # The assignment is a `printf -v` into a name the CALLER chose, so it is
 # lost to the helper's own local whenever the two spellings meet: never
-# pass `_kendex_trimmed`, `_kendex_decode_raw` or `_kendex_decode_regex` as
-# an out-var. Nothing enforces that — kendex_decode_value is itself such a
-# caller, which is why its scratch names are spelled apart from
-# kendex_trim's rather than sharing a `_kendex_raw`.
+# pass a helper its own scratch name — `_kendex_trimmed` to kendex_trim,
+# `_kendex_decode_raw` or `_kendex_decode_regex` to kendex_decode_value.
+# Nothing enforces that; the two sets are spelled apart precisely so
+# kendex_decode_value can hand its own scratch to kendex_trim.
 kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
   local _kendex_trimmed="$2"
   _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"

--- a/skills/decider/scripts/lib/kendex-env.sh
+++ b/skills/decider/scripts/lib/kendex-env.sh
@@ -84,21 +84,27 @@ kendex_source_env_file() {
   source "$file"
 }
 
-kendex_trim() {
-  local value="$1"
-  value="${value#"${value%%[!$' \t\r\n']*}"}"
-  value="${value%"${value##*[!$' \t\r\n']}"}"
-  printf '%s' "$value"
+# Both helpers assign into a caller-named variable instead of printing.
+# kendex_load_settings_file calls them once or twice per line, and a helper
+# that printed could only be read back through a command substitution — a
+# forked subshell per line of every settings file every skill script reads.
+# Their locals carry a `_kendex_` prefix so an out-variable name cannot
+# shadow one and lose the assignment to the local.
+kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
+  local _kendex_trimmed="$2"
+  _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"
+  _kendex_trimmed="${_kendex_trimmed%"${_kendex_trimmed##*[!$' \t\r\n']}"}"
+  printf -v "$1" '%s' "$_kendex_trimmed"
 }
 
 # Decode one [env] value per the settings contract: a single-line basic
 # string containing no `"` and no `\`, optionally followed by a `#`
 # comment. Anything else is a shape the contract does not carry.
-kendex_decode_value() { # RAW — decoded value on stdout; 1 = not contract shape
-  local value regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
-  value="$(kendex_trim "$1")"
-  [[ "$value" =~ $regex ]] || return 1
-  printf '%s' "${BASH_REMATCH[1]}"
+kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched
+  local _kendex_raw _kendex_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
+  kendex_trim _kendex_raw "$2"
+  [[ "$_kendex_raw" =~ $_kendex_regex ]] || return 1
+  printf -v "$1" '%s' "${BASH_REMATCH[1]}"
 }
 
 kendex_load_settings_file() {
@@ -111,7 +117,7 @@ kendex_load_settings_file() {
   while IFS= read -r line || [[ -n "$line" ]]; do
     lineno=$((lineno + 1))
     line="${line%$'\r'}"
-    line="$(kendex_trim "$line")"
+    kendex_trim line "$line"
     [[ -z "$line" || "$line" == \#* ]] && continue
 
     # A `[`-leading line is a header or an error, never content: `[env] # c`
@@ -128,7 +134,7 @@ kendex_load_settings_file() {
     fi
 
     [[ "$section" == "env" && "$line" == *=* ]] || continue
-    key="$(kendex_trim "${line%%=*}")"
+    kendex_trim key "${line%%=*}"
     [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
     # Which duplicate wins would be an accident of read order, so a re-assigned
     # key is a configuration error — the same ambiguity guard the settings.sh
@@ -139,7 +145,7 @@ kendex_load_settings_file() {
       return 1
     fi
     seen="$seen$key "
-    if ! value="$(kendex_decode_value "${line#*=}")"; then
+    if ! kendex_decode_value value "${line#*=}"; then
       echo "::error::$file: unsupported syntax for $key (expected a single-line basic string with no '\"' and no '\\': $key = \"value\")" >&2
       return 1
     fi

--- a/skills/github/scripts/lib/kendex-env.sh
+++ b/skills/github/scripts/lib/kendex-env.sh
@@ -85,11 +85,18 @@ kendex_source_env_file() {
 }
 
 # Both helpers assign into a caller-named variable instead of printing.
-# kendex_load_settings_file calls them once or twice per line, and a helper
-# that printed could only be read back through a command substitution — a
-# forked subshell per line of every settings file every skill script reads.
-# Their locals carry a `_kendex_` prefix so an out-variable name cannot
-# shadow one and lose the assignment to the local.
+# kendex_load_settings_file reaches kendex_trim once for every line, and
+# three times on an assignment line — twice directly, for the line and for
+# the key, and once more inside kendex_decode_value. A helper that printed
+# could only be read back through a command substitution, so every one of
+# those was a fork, on every settings file every skill script loads.
+#
+# The assignment is a `printf -v` into a name the CALLER chose, so it is
+# lost to the helper's own local whenever the two spellings meet: never
+# pass `_kendex_trimmed`, `_kendex_decode_raw` or `_kendex_decode_regex` as
+# an out-var. Nothing enforces that — kendex_decode_value is itself such a
+# caller, which is why its scratch names are spelled apart from
+# kendex_trim's rather than sharing a `_kendex_raw`.
 kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
   local _kendex_trimmed="$2"
   _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"
@@ -100,10 +107,10 @@ kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, as
 # Decode one [env] value per the settings contract: a single-line basic
 # string containing no `"` and no `\`, optionally followed by a `#`
 # comment. Anything else is a shape the contract does not carry.
-kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched
-  local _kendex_raw _kendex_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
-  kendex_trim _kendex_raw "$2"
-  [[ "$_kendex_raw" =~ $_kendex_regex ]] || return 1
+kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched; overwrites the caller's BASH_REMATCH, since the match runs in the caller's shell rather than a subshell
+  local _kendex_decode_raw _kendex_decode_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
+  kendex_trim _kendex_decode_raw "$2"
+  [[ "$_kendex_decode_raw" =~ $_kendex_decode_regex ]] || return 1
   printf -v "$1" '%s' "${BASH_REMATCH[1]}"
 }
 

--- a/skills/github/scripts/lib/kendex-env.sh
+++ b/skills/github/scripts/lib/kendex-env.sh
@@ -93,10 +93,10 @@ kendex_source_env_file() {
 #
 # The assignment is a `printf -v` into a name the CALLER chose, so it is
 # lost to the helper's own local whenever the two spellings meet: never
-# pass `_kendex_trimmed`, `_kendex_decode_raw` or `_kendex_decode_regex` as
-# an out-var. Nothing enforces that — kendex_decode_value is itself such a
-# caller, which is why its scratch names are spelled apart from
-# kendex_trim's rather than sharing a `_kendex_raw`.
+# pass a helper its own scratch name — `_kendex_trimmed` to kendex_trim,
+# `_kendex_decode_raw` or `_kendex_decode_regex` to kendex_decode_value.
+# Nothing enforces that; the two sets are spelled apart precisely so
+# kendex_decode_value can hand its own scratch to kendex_trim.
 kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
   local _kendex_trimmed="$2"
   _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"

--- a/skills/github/scripts/lib/kendex-env.sh
+++ b/skills/github/scripts/lib/kendex-env.sh
@@ -84,21 +84,27 @@ kendex_source_env_file() {
   source "$file"
 }
 
-kendex_trim() {
-  local value="$1"
-  value="${value#"${value%%[!$' \t\r\n']*}"}"
-  value="${value%"${value##*[!$' \t\r\n']}"}"
-  printf '%s' "$value"
+# Both helpers assign into a caller-named variable instead of printing.
+# kendex_load_settings_file calls them once or twice per line, and a helper
+# that printed could only be read back through a command substitution — a
+# forked subshell per line of every settings file every skill script reads.
+# Their locals carry a `_kendex_` prefix so an out-variable name cannot
+# shadow one and lose the assignment to the local.
+kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
+  local _kendex_trimmed="$2"
+  _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"
+  _kendex_trimmed="${_kendex_trimmed%"${_kendex_trimmed##*[!$' \t\r\n']}"}"
+  printf -v "$1" '%s' "$_kendex_trimmed"
 }
 
 # Decode one [env] value per the settings contract: a single-line basic
 # string containing no `"` and no `\`, optionally followed by a `#`
 # comment. Anything else is a shape the contract does not carry.
-kendex_decode_value() { # RAW — decoded value on stdout; 1 = not contract shape
-  local value regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
-  value="$(kendex_trim "$1")"
-  [[ "$value" =~ $regex ]] || return 1
-  printf '%s' "${BASH_REMATCH[1]}"
+kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched
+  local _kendex_raw _kendex_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
+  kendex_trim _kendex_raw "$2"
+  [[ "$_kendex_raw" =~ $_kendex_regex ]] || return 1
+  printf -v "$1" '%s' "${BASH_REMATCH[1]}"
 }
 
 kendex_load_settings_file() {
@@ -111,7 +117,7 @@ kendex_load_settings_file() {
   while IFS= read -r line || [[ -n "$line" ]]; do
     lineno=$((lineno + 1))
     line="${line%$'\r'}"
-    line="$(kendex_trim "$line")"
+    kendex_trim line "$line"
     [[ -z "$line" || "$line" == \#* ]] && continue
 
     # A `[`-leading line is a header or an error, never content: `[env] # c`
@@ -128,7 +134,7 @@ kendex_load_settings_file() {
     fi
 
     [[ "$section" == "env" && "$line" == *=* ]] || continue
-    key="$(kendex_trim "${line%%=*}")"
+    kendex_trim key "${line%%=*}"
     [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
     # Which duplicate wins would be an accident of read order, so a re-assigned
     # key is a configuration error — the same ambiguity guard the settings.sh
@@ -139,7 +145,7 @@ kendex_load_settings_file() {
       return 1
     fi
     seen="$seen$key "
-    if ! value="$(kendex_decode_value "${line#*=}")"; then
+    if ! kendex_decode_value value "${line#*=}"; then
       echo "::error::$file: unsupported syntax for $key (expected a single-line basic string with no '\"' and no '\\': $key = \"value\")" >&2
       return 1
     fi

--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -955,7 +955,7 @@ require_agent_routing_label() {
 
     local supplied declared_name agent_matched=0 unknown_agent=""
     for supplied in ${supplied_names[@]+"${supplied_names[@]}"}; do
-        supplied="$(kendex_trim "$supplied")"
+        kendex_trim supplied "$supplied"
         [ -n "$supplied" ] || continue
         local is_declared=0
         for declared_name in ${declared_names[@]+"${declared_names[@]}"}; do
@@ -1183,7 +1183,7 @@ create_issue() {
         local raw_label_names=()
         IFS=',' read -ra raw_label_names <<<"$labels"
         for raw_label_name in "${raw_label_names[@]}"; do
-            raw_label_name="$(kendex_trim "$raw_label_name")"
+            kendex_trim raw_label_name "$raw_label_name"
             [ -n "$raw_label_name" ] || continue
             normalized_labels="${normalized_labels:+$normalized_labels,}$raw_label_name"
         done

--- a/skills/linear/scripts/lib/kendex-env.sh
+++ b/skills/linear/scripts/lib/kendex-env.sh
@@ -85,11 +85,18 @@ kendex_source_env_file() {
 }
 
 # Both helpers assign into a caller-named variable instead of printing.
-# kendex_load_settings_file calls them once or twice per line, and a helper
-# that printed could only be read back through a command substitution — a
-# forked subshell per line of every settings file every skill script reads.
-# Their locals carry a `_kendex_` prefix so an out-variable name cannot
-# shadow one and lose the assignment to the local.
+# kendex_load_settings_file reaches kendex_trim once for every line, and
+# three times on an assignment line — twice directly, for the line and for
+# the key, and once more inside kendex_decode_value. A helper that printed
+# could only be read back through a command substitution, so every one of
+# those was a fork, on every settings file every skill script loads.
+#
+# The assignment is a `printf -v` into a name the CALLER chose, so it is
+# lost to the helper's own local whenever the two spellings meet: never
+# pass `_kendex_trimmed`, `_kendex_decode_raw` or `_kendex_decode_regex` as
+# an out-var. Nothing enforces that — kendex_decode_value is itself such a
+# caller, which is why its scratch names are spelled apart from
+# kendex_trim's rather than sharing a `_kendex_raw`.
 kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
   local _kendex_trimmed="$2"
   _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"
@@ -100,10 +107,10 @@ kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, as
 # Decode one [env] value per the settings contract: a single-line basic
 # string containing no `"` and no `\`, optionally followed by a `#`
 # comment. Anything else is a shape the contract does not carry.
-kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched
-  local _kendex_raw _kendex_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
-  kendex_trim _kendex_raw "$2"
-  [[ "$_kendex_raw" =~ $_kendex_regex ]] || return 1
+kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched; overwrites the caller's BASH_REMATCH, since the match runs in the caller's shell rather than a subshell
+  local _kendex_decode_raw _kendex_decode_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
+  kendex_trim _kendex_decode_raw "$2"
+  [[ "$_kendex_decode_raw" =~ $_kendex_decode_regex ]] || return 1
   printf -v "$1" '%s' "${BASH_REMATCH[1]}"
 }
 

--- a/skills/linear/scripts/lib/kendex-env.sh
+++ b/skills/linear/scripts/lib/kendex-env.sh
@@ -93,10 +93,10 @@ kendex_source_env_file() {
 #
 # The assignment is a `printf -v` into a name the CALLER chose, so it is
 # lost to the helper's own local whenever the two spellings meet: never
-# pass `_kendex_trimmed`, `_kendex_decode_raw` or `_kendex_decode_regex` as
-# an out-var. Nothing enforces that — kendex_decode_value is itself such a
-# caller, which is why its scratch names are spelled apart from
-# kendex_trim's rather than sharing a `_kendex_raw`.
+# pass a helper its own scratch name — `_kendex_trimmed` to kendex_trim,
+# `_kendex_decode_raw` or `_kendex_decode_regex` to kendex_decode_value.
+# Nothing enforces that; the two sets are spelled apart precisely so
+# kendex_decode_value can hand its own scratch to kendex_trim.
 kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
   local _kendex_trimmed="$2"
   _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"

--- a/skills/linear/scripts/lib/kendex-env.sh
+++ b/skills/linear/scripts/lib/kendex-env.sh
@@ -84,21 +84,27 @@ kendex_source_env_file() {
   source "$file"
 }
 
-kendex_trim() {
-  local value="$1"
-  value="${value#"${value%%[!$' \t\r\n']*}"}"
-  value="${value%"${value##*[!$' \t\r\n']}"}"
-  printf '%s' "$value"
+# Both helpers assign into a caller-named variable instead of printing.
+# kendex_load_settings_file calls them once or twice per line, and a helper
+# that printed could only be read back through a command substitution — a
+# forked subshell per line of every settings file every skill script reads.
+# Their locals carry a `_kendex_` prefix so an out-variable name cannot
+# shadow one and lose the assignment to the local.
+kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
+  local _kendex_trimmed="$2"
+  _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"
+  _kendex_trimmed="${_kendex_trimmed%"${_kendex_trimmed##*[!$' \t\r\n']}"}"
+  printf -v "$1" '%s' "$_kendex_trimmed"
 }
 
 # Decode one [env] value per the settings contract: a single-line basic
 # string containing no `"` and no `\`, optionally followed by a `#`
 # comment. Anything else is a shape the contract does not carry.
-kendex_decode_value() { # RAW — decoded value on stdout; 1 = not contract shape
-  local value regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
-  value="$(kendex_trim "$1")"
-  [[ "$value" =~ $regex ]] || return 1
-  printf '%s' "${BASH_REMATCH[1]}"
+kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched
+  local _kendex_raw _kendex_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
+  kendex_trim _kendex_raw "$2"
+  [[ "$_kendex_raw" =~ $_kendex_regex ]] || return 1
+  printf -v "$1" '%s' "${BASH_REMATCH[1]}"
 }
 
 kendex_load_settings_file() {
@@ -111,7 +117,7 @@ kendex_load_settings_file() {
   while IFS= read -r line || [[ -n "$line" ]]; do
     lineno=$((lineno + 1))
     line="${line%$'\r'}"
-    line="$(kendex_trim "$line")"
+    kendex_trim line "$line"
     [[ -z "$line" || "$line" == \#* ]] && continue
 
     # A `[`-leading line is a header or an error, never content: `[env] # c`
@@ -128,7 +134,7 @@ kendex_load_settings_file() {
     fi
 
     [[ "$section" == "env" && "$line" == *=* ]] || continue
-    key="$(kendex_trim "${line%%=*}")"
+    kendex_trim key "${line%%=*}"
     [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
     # Which duplicate wins would be an accident of read order, so a re-assigned
     # key is a configuration error — the same ambiguity guard the settings.sh
@@ -139,7 +145,7 @@ kendex_load_settings_file() {
       return 1
     fi
     seen="$seen$key "
-    if ! value="$(kendex_decode_value "${line#*=}")"; then
+    if ! kendex_decode_value value "${line#*=}"; then
       echo "::error::$file: unsupported syntax for $key (expected a single-line basic string with no '\"' and no '\\': $key = \"value\")" >&2
       return 1
     fi

--- a/skills/orch/scripts/lib/kendex-env.sh
+++ b/skills/orch/scripts/lib/kendex-env.sh
@@ -85,11 +85,18 @@ kendex_source_env_file() {
 }
 
 # Both helpers assign into a caller-named variable instead of printing.
-# kendex_load_settings_file calls them once or twice per line, and a helper
-# that printed could only be read back through a command substitution — a
-# forked subshell per line of every settings file every skill script reads.
-# Their locals carry a `_kendex_` prefix so an out-variable name cannot
-# shadow one and lose the assignment to the local.
+# kendex_load_settings_file reaches kendex_trim once for every line, and
+# three times on an assignment line — twice directly, for the line and for
+# the key, and once more inside kendex_decode_value. A helper that printed
+# could only be read back through a command substitution, so every one of
+# those was a fork, on every settings file every skill script loads.
+#
+# The assignment is a `printf -v` into a name the CALLER chose, so it is
+# lost to the helper's own local whenever the two spellings meet: never
+# pass `_kendex_trimmed`, `_kendex_decode_raw` or `_kendex_decode_regex` as
+# an out-var. Nothing enforces that — kendex_decode_value is itself such a
+# caller, which is why its scratch names are spelled apart from
+# kendex_trim's rather than sharing a `_kendex_raw`.
 kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
   local _kendex_trimmed="$2"
   _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"
@@ -100,10 +107,10 @@ kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, as
 # Decode one [env] value per the settings contract: a single-line basic
 # string containing no `"` and no `\`, optionally followed by a `#`
 # comment. Anything else is a shape the contract does not carry.
-kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched
-  local _kendex_raw _kendex_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
-  kendex_trim _kendex_raw "$2"
-  [[ "$_kendex_raw" =~ $_kendex_regex ]] || return 1
+kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched; overwrites the caller's BASH_REMATCH, since the match runs in the caller's shell rather than a subshell
+  local _kendex_decode_raw _kendex_decode_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
+  kendex_trim _kendex_decode_raw "$2"
+  [[ "$_kendex_decode_raw" =~ $_kendex_decode_regex ]] || return 1
   printf -v "$1" '%s' "${BASH_REMATCH[1]}"
 }
 

--- a/skills/orch/scripts/lib/kendex-env.sh
+++ b/skills/orch/scripts/lib/kendex-env.sh
@@ -93,10 +93,10 @@ kendex_source_env_file() {
 #
 # The assignment is a `printf -v` into a name the CALLER chose, so it is
 # lost to the helper's own local whenever the two spellings meet: never
-# pass `_kendex_trimmed`, `_kendex_decode_raw` or `_kendex_decode_regex` as
-# an out-var. Nothing enforces that — kendex_decode_value is itself such a
-# caller, which is why its scratch names are spelled apart from
-# kendex_trim's rather than sharing a `_kendex_raw`.
+# pass a helper its own scratch name — `_kendex_trimmed` to kendex_trim,
+# `_kendex_decode_raw` or `_kendex_decode_regex` to kendex_decode_value.
+# Nothing enforces that; the two sets are spelled apart precisely so
+# kendex_decode_value can hand its own scratch to kendex_trim.
 kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
   local _kendex_trimmed="$2"
   _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"

--- a/skills/orch/scripts/lib/kendex-env.sh
+++ b/skills/orch/scripts/lib/kendex-env.sh
@@ -84,21 +84,27 @@ kendex_source_env_file() {
   source "$file"
 }
 
-kendex_trim() {
-  local value="$1"
-  value="${value#"${value%%[!$' \t\r\n']*}"}"
-  value="${value%"${value##*[!$' \t\r\n']}"}"
-  printf '%s' "$value"
+# Both helpers assign into a caller-named variable instead of printing.
+# kendex_load_settings_file calls them once or twice per line, and a helper
+# that printed could only be read back through a command substitution — a
+# forked subshell per line of every settings file every skill script reads.
+# Their locals carry a `_kendex_` prefix so an out-variable name cannot
+# shadow one and lose the assignment to the local.
+kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
+  local _kendex_trimmed="$2"
+  _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"
+  _kendex_trimmed="${_kendex_trimmed%"${_kendex_trimmed##*[!$' \t\r\n']}"}"
+  printf -v "$1" '%s' "$_kendex_trimmed"
 }
 
 # Decode one [env] value per the settings contract: a single-line basic
 # string containing no `"` and no `\`, optionally followed by a `#`
 # comment. Anything else is a shape the contract does not carry.
-kendex_decode_value() { # RAW — decoded value on stdout; 1 = not contract shape
-  local value regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
-  value="$(kendex_trim "$1")"
-  [[ "$value" =~ $regex ]] || return 1
-  printf '%s' "${BASH_REMATCH[1]}"
+kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched
+  local _kendex_raw _kendex_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
+  kendex_trim _kendex_raw "$2"
+  [[ "$_kendex_raw" =~ $_kendex_regex ]] || return 1
+  printf -v "$1" '%s' "${BASH_REMATCH[1]}"
 }
 
 kendex_load_settings_file() {
@@ -111,7 +117,7 @@ kendex_load_settings_file() {
   while IFS= read -r line || [[ -n "$line" ]]; do
     lineno=$((lineno + 1))
     line="${line%$'\r'}"
-    line="$(kendex_trim "$line")"
+    kendex_trim line "$line"
     [[ -z "$line" || "$line" == \#* ]] && continue
 
     # A `[`-leading line is a header or an error, never content: `[env] # c`
@@ -128,7 +134,7 @@ kendex_load_settings_file() {
     fi
 
     [[ "$section" == "env" && "$line" == *=* ]] || continue
-    key="$(kendex_trim "${line%%=*}")"
+    kendex_trim key "${line%%=*}"
     [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
     # Which duplicate wins would be an accident of read order, so a re-assigned
     # key is a configuration error — the same ambiguity guard the settings.sh
@@ -139,7 +145,7 @@ kendex_load_settings_file() {
       return 1
     fi
     seen="$seen$key "
-    if ! value="$(kendex_decode_value "${line#*=}")"; then
+    if ! kendex_decode_value value "${line#*=}"; then
       echo "::error::$file: unsupported syntax for $key (expected a single-line basic string with no '\"' and no '\\': $key = \"value\")" >&2
       return 1
     fi

--- a/skills/orch/tests/kendex-env-precedence.sh
+++ b/skills/orch/tests/kendex-env-precedence.sh
@@ -40,11 +40,13 @@ echo "=== kendex-env precedence ==="
 PROJ="$TMP_ROOT/proj"
 mkdir -p "$PROJ/.kendex"
 printf 'FOO="from-dotenv"\nQUX="only-in-dotenv"\n' > "$PROJ/.env"
-cat > "$PROJ/kendex.settings.toml" <<'TOML'
-[env]
-FOO = "from-settings"
-BAR = "bar-settings"
-TOML
+# Indented header, indented key, and trailing spaces on both — a shape the
+# loader accepts only because it trims every line, and the fixture that
+# makes the trim's RESULT load-bearing rather than just its call: lose the
+# assignment (a shadowed out-var, a fork) and `  [env]  ` stops reading as
+# a header, so the whole table is silently dropped and scenario 1's FOO is
+# unset. Written with printf so the trailing runs survive an editor.
+printf '  [env]  \n  FOO = "from-settings"  \nBAR = "bar-settings"\n' > "$PROJ/kendex.settings.toml"
 printf '[env]\nBAR = "bar-nested"\n' > "$PROJ/.kendex/settings.toml"
 printf 'BAZ="from-local"\n' > "$PROJ/.env.local"
 
@@ -242,25 +244,33 @@ else
   s8_case "an UNREADABLE kendex.settings.toml" 'printf "[env]\nX = \"y\"\n" > kendex.settings.toml && chmod 000 kendex.settings.toml' "kendex.settings.toml: source exists but is unreadable"
 fi
 
-# Scenario 9: the per-line path forks no subshell. kendex_trim and
-# kendex_decode_value assign into a caller-named variable, so a counting
-# wrapper around the real helper sees every call the loader makes. Read
-# back through a command substitution instead — a forked subshell per line
-# of every settings file every skill script reads — each increment lands in
-# the forked copy and the count comes back short, 0 when every call site
-# forks. The count is exact so that ONE reverted call site is caught too:
-# three lines trimmed, plus one key trim and one kendex_decode_value trim
-# for each of the two assignments.
+# Scenario 9: the per-line path forks no subshell. A wrapper delegating to
+# the real kendex_trim records two things per call. $BASH_SUBSHELL is the
+# direct measure — a fork raises it, and no variable can carry that back
+# out of the fork, so each call appends its depth relative to the loader's
+# own frame to a file; every recorded depth is 0 or a call ran inside a
+# subshell, wherever in the loop the fork was introduced. The call count is
+# the second: it is exact, so ONE call site reverted to a command
+# substitution is caught by the increment lost with its subshell. Seven for
+# a three-line file — every line trimmed, plus the key trim and the
+# kendex_decode_value trim for each of the two assignments.
 PROJ9="$TMP_ROOT/proj9"
 mkdir -p "$PROJ9"
 printf '[env]\nK1 = "v1"\nK2 = "v2"\n' > "$PROJ9/kendex.settings.toml"
+S9_LEVELS="$TMP_ROOT/s9-subshell-levels"
+: > "$S9_LEVELS"
 set +e
 s9_out=$(
   set -euo pipefail
   source "$LIB"
   trim_body="$(declare -f kendex_trim)"
   eval "_kendex_trim_real${trim_body#kendex_trim}"
-  kendex_trim() { TRIM_CALLS=$((TRIM_CALLS + 1)); _kendex_trim_real "$@"; }
+  S9_BASE=$BASH_SUBSHELL
+  kendex_trim() {
+    TRIM_CALLS=$((TRIM_CALLS + 1))
+    printf '%s\n' "$((BASH_SUBSHELL - S9_BASE))" >> "$S9_LEVELS"
+    _kendex_trim_real "$@"
+  }
   TRIM_CALLS=0
   kendex_load_settings_file "$PROJ9/kendex.settings.toml"
   printf '%s|%s|%s\n' "$TRIM_CALLS" "$K1" "$K2"
@@ -269,6 +279,7 @@ s9_code=$?
 set -e
 assert_eq "$s9_code" "0" "scenario 9 loads without error"
 assert_eq "$s9_out" "7|v1|v2" "scenario 9: every kendex_trim call the loader makes is visible in its own shell, none lost to a command substitution"
+assert_eq "$(sort -u "$S9_LEVELS" | paste -sd, -)" "0" "scenario 9: every kendex_trim call runs at the loader's own subshell depth, none inside a fork"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/orch/tests/kendex-env-precedence.sh
+++ b/skills/orch/tests/kendex-env-precedence.sh
@@ -242,6 +242,34 @@ else
   s8_case "an UNREADABLE kendex.settings.toml" 'printf "[env]\nX = \"y\"\n" > kendex.settings.toml && chmod 000 kendex.settings.toml' "kendex.settings.toml: source exists but is unreadable"
 fi
 
+# Scenario 9: the per-line path forks no subshell. kendex_trim and
+# kendex_decode_value assign into a caller-named variable, so a counting
+# wrapper around the real helper sees every call the loader makes. Read
+# back through a command substitution instead — a forked subshell per line
+# of every settings file every skill script reads — each increment lands in
+# the forked copy and the count comes back short, 0 when every call site
+# forks. The count is exact so that ONE reverted call site is caught too:
+# three lines trimmed, plus one key trim and one kendex_decode_value trim
+# for each of the two assignments.
+PROJ9="$TMP_ROOT/proj9"
+mkdir -p "$PROJ9"
+printf '[env]\nK1 = "v1"\nK2 = "v2"\n' > "$PROJ9/kendex.settings.toml"
+set +e
+s9_out=$(
+  set -euo pipefail
+  source "$LIB"
+  trim_body="$(declare -f kendex_trim)"
+  eval "_kendex_trim_real${trim_body#kendex_trim}"
+  kendex_trim() { TRIM_CALLS=$((TRIM_CALLS + 1)); _kendex_trim_real "$@"; }
+  TRIM_CALLS=0
+  kendex_load_settings_file "$PROJ9/kendex.settings.toml"
+  printf '%s|%s|%s\n' "$TRIM_CALLS" "$K1" "$K2"
+)
+s9_code=$?
+set -e
+assert_eq "$s9_code" "0" "scenario 9 loads without error"
+assert_eq "$s9_out" "7|v1|v2" "scenario 9: every kendex_trim call the loader makes is visible in its own shell, none lost to a command substitution"
+
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/second-opinion/scripts/lib/kendex-env.sh
+++ b/skills/second-opinion/scripts/lib/kendex-env.sh
@@ -85,11 +85,18 @@ kendex_source_env_file() {
 }
 
 # Both helpers assign into a caller-named variable instead of printing.
-# kendex_load_settings_file calls them once or twice per line, and a helper
-# that printed could only be read back through a command substitution — a
-# forked subshell per line of every settings file every skill script reads.
-# Their locals carry a `_kendex_` prefix so an out-variable name cannot
-# shadow one and lose the assignment to the local.
+# kendex_load_settings_file reaches kendex_trim once for every line, and
+# three times on an assignment line — twice directly, for the line and for
+# the key, and once more inside kendex_decode_value. A helper that printed
+# could only be read back through a command substitution, so every one of
+# those was a fork, on every settings file every skill script loads.
+#
+# The assignment is a `printf -v` into a name the CALLER chose, so it is
+# lost to the helper's own local whenever the two spellings meet: never
+# pass `_kendex_trimmed`, `_kendex_decode_raw` or `_kendex_decode_regex` as
+# an out-var. Nothing enforces that — kendex_decode_value is itself such a
+# caller, which is why its scratch names are spelled apart from
+# kendex_trim's rather than sharing a `_kendex_raw`.
 kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
   local _kendex_trimmed="$2"
   _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"
@@ -100,10 +107,10 @@ kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, as
 # Decode one [env] value per the settings contract: a single-line basic
 # string containing no `"` and no `\`, optionally followed by a `#`
 # comment. Anything else is a shape the contract does not carry.
-kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched
-  local _kendex_raw _kendex_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
-  kendex_trim _kendex_raw "$2"
-  [[ "$_kendex_raw" =~ $_kendex_regex ]] || return 1
+kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched; overwrites the caller's BASH_REMATCH, since the match runs in the caller's shell rather than a subshell
+  local _kendex_decode_raw _kendex_decode_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
+  kendex_trim _kendex_decode_raw "$2"
+  [[ "$_kendex_decode_raw" =~ $_kendex_decode_regex ]] || return 1
   printf -v "$1" '%s' "${BASH_REMATCH[1]}"
 }
 

--- a/skills/second-opinion/scripts/lib/kendex-env.sh
+++ b/skills/second-opinion/scripts/lib/kendex-env.sh
@@ -93,10 +93,10 @@ kendex_source_env_file() {
 #
 # The assignment is a `printf -v` into a name the CALLER chose, so it is
 # lost to the helper's own local whenever the two spellings meet: never
-# pass `_kendex_trimmed`, `_kendex_decode_raw` or `_kendex_decode_regex` as
-# an out-var. Nothing enforces that — kendex_decode_value is itself such a
-# caller, which is why its scratch names are spelled apart from
-# kendex_trim's rather than sharing a `_kendex_raw`.
+# pass a helper its own scratch name — `_kendex_trimmed` to kendex_trim,
+# `_kendex_decode_raw` or `_kendex_decode_regex` to kendex_decode_value.
+# Nothing enforces that; the two sets are spelled apart precisely so
+# kendex_decode_value can hand its own scratch to kendex_trim.
 kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
   local _kendex_trimmed="$2"
   _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"

--- a/skills/second-opinion/scripts/lib/kendex-env.sh
+++ b/skills/second-opinion/scripts/lib/kendex-env.sh
@@ -84,21 +84,27 @@ kendex_source_env_file() {
   source "$file"
 }
 
-kendex_trim() {
-  local value="$1"
-  value="${value#"${value%%[!$' \t\r\n']*}"}"
-  value="${value%"${value##*[!$' \t\r\n']}"}"
-  printf '%s' "$value"
+# Both helpers assign into a caller-named variable instead of printing.
+# kendex_load_settings_file calls them once or twice per line, and a helper
+# that printed could only be read back through a command substitution — a
+# forked subshell per line of every settings file every skill script reads.
+# Their locals carry a `_kendex_` prefix so an out-variable name cannot
+# shadow one and lose the assignment to the local.
+kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
+  local _kendex_trimmed="$2"
+  _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"
+  _kendex_trimmed="${_kendex_trimmed%"${_kendex_trimmed##*[!$' \t\r\n']}"}"
+  printf -v "$1" '%s' "$_kendex_trimmed"
 }
 
 # Decode one [env] value per the settings contract: a single-line basic
 # string containing no `"` and no `\`, optionally followed by a `#`
 # comment. Anything else is a shape the contract does not carry.
-kendex_decode_value() { # RAW — decoded value on stdout; 1 = not contract shape
-  local value regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
-  value="$(kendex_trim "$1")"
-  [[ "$value" =~ $regex ]] || return 1
-  printf '%s' "${BASH_REMATCH[1]}"
+kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched
+  local _kendex_raw _kendex_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
+  kendex_trim _kendex_raw "$2"
+  [[ "$_kendex_raw" =~ $_kendex_regex ]] || return 1
+  printf -v "$1" '%s' "${BASH_REMATCH[1]}"
 }
 
 kendex_load_settings_file() {
@@ -111,7 +117,7 @@ kendex_load_settings_file() {
   while IFS= read -r line || [[ -n "$line" ]]; do
     lineno=$((lineno + 1))
     line="${line%$'\r'}"
-    line="$(kendex_trim "$line")"
+    kendex_trim line "$line"
     [[ -z "$line" || "$line" == \#* ]] && continue
 
     # A `[`-leading line is a header or an error, never content: `[env] # c`
@@ -128,7 +134,7 @@ kendex_load_settings_file() {
     fi
 
     [[ "$section" == "env" && "$line" == *=* ]] || continue
-    key="$(kendex_trim "${line%%=*}")"
+    kendex_trim key "${line%%=*}"
     [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
     # Which duplicate wins would be an accident of read order, so a re-assigned
     # key is a configuration error — the same ambiguity guard the settings.sh
@@ -139,7 +145,7 @@ kendex_load_settings_file() {
       return 1
     fi
     seen="$seen$key "
-    if ! value="$(kendex_decode_value "${line#*=}")"; then
+    if ! kendex_decode_value value "${line#*=}"; then
       echo "::error::$file: unsupported syntax for $key (expected a single-line basic string with no '\"' and no '\\': $key = \"value\")" >&2
       return 1
     fi

--- a/skills/second-opinion/scripts/second-opinion
+++ b/skills/second-opinion/scripts/second-opinion
@@ -671,7 +671,7 @@ detect_current_harness() {
   local ancestor_cmd
   while pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ') && [[ -n "$pid" && "$pid" != "0" && "$pid" != "1" ]]; do
     ancestor_cmd=$(ps -o comm= -p "$pid" 2>/dev/null || echo "")
-    ancestor_cmd="$(kendex_trim "$ancestor_cmd")"
+    kendex_trim ancestor_cmd "$ancestor_cmd"
     ancestor_cmd="${ancestor_cmd##*/}"
     case "$ancestor_cmd" in
       claude)       echo "claude"; return ;;
@@ -737,7 +737,7 @@ canon_identity() {
   # absorbed by the patterns' `*`, so untrimmed the failure looks arbitrary
   # rather than absent.) Every identity passes through here — declared,
   # detected, per-target and roster-derived — so trimming once covers them all.
-  id=$(kendex_trim "$1")
+  kendex_trim id "$1"
   id=$(lower "$id")
   # Provider-qualified ids — openai-codex/gpt-5.6-sol, openai/gpt-5.6-sol,
   # anthropic/claude-opus-4 — are exactly what Pi and OpenCode show an operator,
@@ -815,7 +815,7 @@ file_declares_current_model() {
   # `|| [[ -n "$line" ]]` so a final line with no trailing newline is still read.
   while IFS= read -r line || [[ -n "$line" ]]; do
     lineno=$((lineno + 1))
-    trimmed="$(kendex_trim "$line")"
+    kendex_trim trimmed "$line"
     # Blank and comment lines. No test covers the comment arm on its own: the
     # anchored match below already rejects anything starting with `#`, so this
     # is the guard that keeps that true if the match ever loosens.
@@ -833,7 +833,7 @@ file_declares_current_model() {
     fi
     [[ $in_env -eq 1 ]] || continue
     trimmed="${trimmed#export }"
-    trimmed="$(kendex_trim "$trimmed")"
+    kendex_trim trimmed "$trimmed"
     case "$trimmed" in
       SECOND_OPINION_CURRENT_MODEL=*|SECOND_OPINION_CURRENT_MODEL[[:space:]]*=*) return 0 ;;
     esac

--- a/skills/worktree/scripts/lib/kendex-env.sh
+++ b/skills/worktree/scripts/lib/kendex-env.sh
@@ -85,11 +85,18 @@ kendex_source_env_file() {
 }
 
 # Both helpers assign into a caller-named variable instead of printing.
-# kendex_load_settings_file calls them once or twice per line, and a helper
-# that printed could only be read back through a command substitution — a
-# forked subshell per line of every settings file every skill script reads.
-# Their locals carry a `_kendex_` prefix so an out-variable name cannot
-# shadow one and lose the assignment to the local.
+# kendex_load_settings_file reaches kendex_trim once for every line, and
+# three times on an assignment line — twice directly, for the line and for
+# the key, and once more inside kendex_decode_value. A helper that printed
+# could only be read back through a command substitution, so every one of
+# those was a fork, on every settings file every skill script loads.
+#
+# The assignment is a `printf -v` into a name the CALLER chose, so it is
+# lost to the helper's own local whenever the two spellings meet: never
+# pass `_kendex_trimmed`, `_kendex_decode_raw` or `_kendex_decode_regex` as
+# an out-var. Nothing enforces that — kendex_decode_value is itself such a
+# caller, which is why its scratch names are spelled apart from
+# kendex_trim's rather than sharing a `_kendex_raw`.
 kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
   local _kendex_trimmed="$2"
   _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"
@@ -100,10 +107,10 @@ kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, as
 # Decode one [env] value per the settings contract: a single-line basic
 # string containing no `"` and no `\`, optionally followed by a `#`
 # comment. Anything else is a shape the contract does not carry.
-kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched
-  local _kendex_raw _kendex_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
-  kendex_trim _kendex_raw "$2"
-  [[ "$_kendex_raw" =~ $_kendex_regex ]] || return 1
+kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched; overwrites the caller's BASH_REMATCH, since the match runs in the caller's shell rather than a subshell
+  local _kendex_decode_raw _kendex_decode_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
+  kendex_trim _kendex_decode_raw "$2"
+  [[ "$_kendex_decode_raw" =~ $_kendex_decode_regex ]] || return 1
   printf -v "$1" '%s' "${BASH_REMATCH[1]}"
 }
 

--- a/skills/worktree/scripts/lib/kendex-env.sh
+++ b/skills/worktree/scripts/lib/kendex-env.sh
@@ -93,10 +93,10 @@ kendex_source_env_file() {
 #
 # The assignment is a `printf -v` into a name the CALLER chose, so it is
 # lost to the helper's own local whenever the two spellings meet: never
-# pass `_kendex_trimmed`, `_kendex_decode_raw` or `_kendex_decode_regex` as
-# an out-var. Nothing enforces that — kendex_decode_value is itself such a
-# caller, which is why its scratch names are spelled apart from
-# kendex_trim's rather than sharing a `_kendex_raw`.
+# pass a helper its own scratch name — `_kendex_trimmed` to kendex_trim,
+# `_kendex_decode_raw` or `_kendex_decode_regex` to kendex_decode_value.
+# Nothing enforces that; the two sets are spelled apart precisely so
+# kendex_decode_value can hand its own scratch to kendex_trim.
 kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
   local _kendex_trimmed="$2"
   _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"

--- a/skills/worktree/scripts/lib/kendex-env.sh
+++ b/skills/worktree/scripts/lib/kendex-env.sh
@@ -84,21 +84,27 @@ kendex_source_env_file() {
   source "$file"
 }
 
-kendex_trim() {
-  local value="$1"
-  value="${value#"${value%%[!$' \t\r\n']*}"}"
-  value="${value%"${value##*[!$' \t\r\n']}"}"
-  printf '%s' "$value"
+# Both helpers assign into a caller-named variable instead of printing.
+# kendex_load_settings_file calls them once or twice per line, and a helper
+# that printed could only be read back through a command substitution — a
+# forked subshell per line of every settings file every skill script reads.
+# Their locals carry a `_kendex_` prefix so an out-variable name cannot
+# shadow one and lose the assignment to the local.
+kendex_trim() { # OUT_VAR RAW — RAW without leading or trailing whitespace, assigned to OUT_VAR
+  local _kendex_trimmed="$2"
+  _kendex_trimmed="${_kendex_trimmed#"${_kendex_trimmed%%[!$' \t\r\n']*}"}"
+  _kendex_trimmed="${_kendex_trimmed%"${_kendex_trimmed##*[!$' \t\r\n']}"}"
+  printf -v "$1" '%s' "$_kendex_trimmed"
 }
 
 # Decode one [env] value per the settings contract: a single-line basic
 # string containing no `"` and no `\`, optionally followed by a `#`
 # comment. Anything else is a shape the contract does not carry.
-kendex_decode_value() { # RAW — decoded value on stdout; 1 = not contract shape
-  local value regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
-  value="$(kendex_trim "$1")"
-  [[ "$value" =~ $regex ]] || return 1
-  printf '%s' "${BASH_REMATCH[1]}"
+kendex_decode_value() { # OUT_VAR RAW — decoded value assigned to OUT_VAR; 1 = not contract shape, OUT_VAR untouched
+  local _kendex_raw _kendex_regex='^"([^"\]*)"[[:space:]]*(#.*)?$'
+  kendex_trim _kendex_raw "$2"
+  [[ "$_kendex_raw" =~ $_kendex_regex ]] || return 1
+  printf -v "$1" '%s' "${BASH_REMATCH[1]}"
 }
 
 kendex_load_settings_file() {
@@ -111,7 +117,7 @@ kendex_load_settings_file() {
   while IFS= read -r line || [[ -n "$line" ]]; do
     lineno=$((lineno + 1))
     line="${line%$'\r'}"
-    line="$(kendex_trim "$line")"
+    kendex_trim line "$line"
     [[ -z "$line" || "$line" == \#* ]] && continue
 
     # A `[`-leading line is a header or an error, never content: `[env] # c`
@@ -128,7 +134,7 @@ kendex_load_settings_file() {
     fi
 
     [[ "$section" == "env" && "$line" == *=* ]] || continue
-    key="$(kendex_trim "${line%%=*}")"
+    kendex_trim key "${line%%=*}"
     [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
     # Which duplicate wins would be an accident of read order, so a re-assigned
     # key is a configuration error — the same ambiguity guard the settings.sh
@@ -139,7 +145,7 @@ kendex_load_settings_file() {
       return 1
     fi
     seen="$seen$key "
-    if ! value="$(kendex_decode_value "${line#*=}")"; then
+    if ! kendex_decode_value value "${line#*=}"; then
       echo "::error::$file: unsupported syntax for $key (expected a single-line basic string with no '\"' and no '\\': $key = \"value\")" >&2
       return 1
     fi


### PR DESCRIPTION
## Summary

- `kendex_trim` and `kendex_decode_value` assign into a caller-named variable via `printf -v` instead of printing, so `kendex_load_settings_file` calls them directly. No command substitution remains anywhere in the per-line path — the fork per settings line is gone.
- Every one of the 12 tracked `kendex-env.sh` copies carries the change and stays byte-identical, and all nine call sites across `skills/linear` and `skills/second-opinion` moved to the out-var signature in the same commit.
- Refusal semantics are unchanged: the unsupported-header error, the duplicate-key error, `kendex_decode_value`'s not-contract-shape return status, and the parent-env precedence skip all behave exactly as before.

## Completed Issues

- Closes KEN-1070 - The settings loader forks a subshell per line, so every skill script pays it per invocation

## QA Metrics

Measured independently by three reviewers plus the implementer. Absolute figures move with machine load — this box was running parallel review agents throughout — so the ratio is the durable claim and the changelog entry quotes it rather than a millisecond pair.

| Arm | Before | After |
|---|---|---|
| `orch-env` end-to-end, p50 | 261.1 ms | 28.8 ms |
| `orch-env` end-to-end, p95 | 526.2 ms | 44.3 ms |
| `kendex_load_settings_file` only, p50 | 121.2 ms | 10.6 ms |

89% p50 reduction over 21 samples per arm against a `git archive origin/main` baseline. Four further independent runs measured the ratio at 11.5x, 12x, 15.2x and 15.9x; the empty-settings-file baseline held at ~3 ms/load throughout, so the cost *above* baseline is what collapsed.

Mutation and stability on the loader guard: 6/7 killed, 5/5 stable runs, no flake.

## Test Plan

`skills/orch/tests/kendex-env-precedence.sh` — 29 pass / 0 fail. Two scenarios carry this change:

- **Scenario 1's fixture** is now an indented header and key with trailing whitespace (`  [env]  ` / `  FOO = "from-settings"  `), written with `printf` so the runs survive an editor. This makes the per-line trim's *result* load-bearing: lose the assignment and `  [env]  ` stops reading as a header, the table is silently dropped, and `FOO` goes unset. Must-fail control — a `kendex_trim` local shadowing the `line` out-var — reddens it at 27/2, where it survived at 28/0 before.
- **Scenario 9** pins the fork directly rather than proxying it. A wrapper delegating to the real helper records `$BASH_SUBSHELL` relative to the loader's frame on every call and asserts every recorded depth is 0, alongside an exact call count of 7. Controls: one call site reverted to a command substitution gives depths `0,1`; the pre-fix loader gives `1,2`. It fails closed on zero samples — an empty record yields `""`, not `"0"`. The depth half catches a fork the count alone would miss, and the count half catches a single reverted call site.

Also green: `skills/orch/tests/orch_env.sh` (8/8), `tools/tests/vendored-settings-libs.test.sh` (six copies and renders match), `tools/bash32-lint` (426 files), and the linear and second-opinion suites covering the changed call sites.

Behaviour preservation was proven differentially rather than argued — main's loader against this branch's over the real 310-line `kendex.settings.toml` and adversarial corpora (28, 36 and 59 cases across reviewers: whitespace, CRLF, BOM, missing trailing newline, embedded newlines, quoted/unquoted/single-quoted/array/backslash values, malformed headers, duplicate keys, command-substitution and backtick payloads, printf format strings, non-ASCII). Identical exit codes, exported values and stderr on every case, with live mutant controls confirming the harnesses measure.

## Notes

- The issue's gate list named `skills/linear/tests/controls/kendex-env-precedence.control.sh`, which does not exist. The linear control of that family is `api-key-precedence.control.sh`, which reaches only the parent-env precedence skip through linear's resolver, so the two suites that actually cover the changed `issues.sh` call sites were run as well, plus `bash4-runtime-contract.test.sh` since `printf -v` is the new mechanism.
- `kendex_decode_value`'s regex now runs in the caller's shell rather than a subshell, so it overwrites the caller's `BASH_REMATCH`. No caller depends on it surviving — the loader reads `BASH_REMATCH[1]` at its own header match and `continue`s before any decode — and the docstring records it.
- The rewritten trim at `skills/linear/scripts/commands/issues.sh:958` is a deliberate defensive no-op with no reachable effect: `create_issue` normalizes and trims the label list before calling `require_agent_routing_label`, its only caller. Left in place, intentionally untested.

https://claude.ai/code/session_01S9q9ZbPHCwEiCuX8HibmxY
