### PR TITLE
docs(KEN-1169): the background verdict is the exit code, not a marker

### DIFF
--- a/.agents/skills/dev/SKILL.md
+++ b/.agents/skills/dev/SKILL.md
@@ -68,7 +68,7 @@ Deterministic gate findings are fixed here, never carried into review. Fix what 
 
 **Invariant, every harness:** the completion tail (commit → QA labels → summary → artifact → return) is never dropped, and an interrupted run is never success. Re-check its real outcome and resume the tail. How you wait is your harness's:
 
-- **Claude Code.** Background the BARE command with output redirected to a log via `run_in_background`, never piped or chained; the log's `END OF OUTPUT — exit status: N` block is the authoritative verdict. Then end your turn. **Idling after backgrounding is normal, not a stall.** The orchestrator's watchdog closes the round. Never poll.
+- **Claude Code.** Background the BARE command with output redirected to a log via `run_in_background`, never piped or chained. The verdict is the exit code the harness reports when the task ends, in the completion notification and in the `[exited with code N]` line that closes the task's own output file. The log you redirected to holds command output and never an exit status. Then end your turn. **Idling after backgrounding is normal, not a stall.** The orchestrator's watchdog closes the round. Never poll.
 - **Codex.** Foreground and block.
 - **Pi.** Run it in the foreground.
 

--- a/skills/dev/SKILL.md
+++ b/skills/dev/SKILL.md
@@ -60,7 +60,7 @@ Deterministic gate findings are fixed here, never carried into review. Fix what 
 
 **Invariant, every harness:** the completion tail (commit → QA labels → summary → artifact → return) is never dropped, and an interrupted run is never success. Re-check its real outcome and resume the tail. How you wait is your harness's:
 
-- **Claude Code.** Background the BARE command with output redirected to a log via `run_in_background`, never piped or chained; the log's `END OF OUTPUT — exit status: N` block is the authoritative verdict. Then end your turn. **Idling after backgrounding is normal, not a stall.** The orchestrator's watchdog closes the round. Never poll.
+- **Claude Code.** Background the BARE command with output redirected to a log via `run_in_background`, never piped or chained. The verdict is the exit code the harness reports when the task ends, in the completion notification and in the `[exited with code N]` line that closes the task's own output file. The log you redirected to holds command output and never an exit status. Then end your turn. **Idling after backgrounding is normal, not a stall.** The orchestrator's watchdog closes the round. Never poll.
 - **Codex.** Foreground and block.
 - **Pi.** Run it in the foreground.
 


### PR DESCRIPTION
## Summary

- dev SKILL.md § Validation told a Claude Code dev agent that a backgrounded run's log ends in an `END OF OUTPUT — exit status: N` block. The harness writes no such block anywhere, so an agent that followed the rule searched a log for a verdict that file can never hold, and a failed validation could be reported as passing.
- The bullet now names the two places the harness does report the exit code: the completion notification, and the `[exited with code N]` line closing the task's own output file. It also says the redirected log holds command output and no exit status.
- The surrounding rules are unchanged: bare command, output redirected, never piped, end the turn, never poll. Codex and Pi run in the foreground, so the question does not arise for them.

## Completed Issues

- Closes KEN-1169 - dev SKILL.md names a background-log verdict marker Claude Code never writes

## Test Plan

`tools/guard` passes on this head, with preflight and size-ratchet clean. Behaviour was established by probing three `run_in_background` runs on this machine (`exit 7`, `exit 9` with output redirected to a log, `exit 0`): the task output file ends `[exited with code N]`, the completion notification carries the code, and the redirected log holds only the command's output.

## Note for whoever lands second

PR #2044 (KEN-1122) rewrites this same line as part of its em dash sweep, and its commit message records `END OF OUTPUT — exit status: N` as a quoted string it deliberately kept. This change deletes that literal. Whichever PR merges second resolves by taking the new sentence and dropping the exemption note.

https://claude.ai/code/session_01XeQG9xgvrYaJgPjWyxRn3p
