### PR TITLE
fix(KEN-952): a Pi-extension-only scope keeps its install record

### DIFF
--- a/changelog.d/fixed/KEN-952.md
+++ b/changelog.d/fixed/KEN-952.md
@@ -1,1 +1,1 @@
-- `refresh` and `apply` write back the install record a scope declaring only Pi extensions lost. **Breaking:** `verify` now exits non-zero on a scope that declares packages and has no record.
+- `refresh` and `apply` write back the install record a scope declaring only Pi extensions lost. **Breaking:** `verify` exits non-zero on a scope that declares items and has no install record.

--- a/changelog.d/fixed/KEN-952.md
+++ b/changelog.d/fixed/KEN-952.md
@@ -1,1 +1,1 @@
-- `refresh` and `apply` write back the install record a scope declaring only Pi extensions lost, instead of reading as up to date with no lock; `verify` names declarations the record holds none of.
+- `refresh` and `apply` write back the install record a scope declaring only Pi extensions lost. **Breaking:** `verify` now exits non-zero on a scope that declares packages and has no record.

--- a/changelog.d/fixed/KEN-952.md
+++ b/changelog.d/fixed/KEN-952.md
@@ -1,0 +1,1 @@
+- `refresh` and `apply` write back the install record a scope declaring only Pi extensions lost, instead of reading as up to date with no lock; `verify` names declarations the record holds none of.

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -18,8 +18,7 @@ use crate::ui;
 ///
 /// Two things are named beside the rows without changing the count, which
 /// is a count of lock entries and nothing else: content nothing manages,
-/// and packages of a kind the plan derives no entry for, which `kendex
-/// update-pi` checks and this verb never can.
+/// and what a scope declares that its record does not hold.
 ///
 /// One state closes the run non-zero on its own: a scope whose manifest
 /// asks for items and whose install record is not there. That is the
@@ -40,15 +39,10 @@ pub fn run(
     // the end: a count of installations is only honest beside the content
     // that was never one.
     let mut unmanaged: Vec<DriftRow> = Vec::new();
-    // Packages of a kind the plan derives no lock entry for, gathered on
-    // every scope whatever its record holds. No run of this verb checks
-    // one, so a scope's count covers less than the scope does, and only
-    // saying so makes the count readable.
-    let mut outside: Vec<(Scope, Vec<(ItemKind, String)>)> = Vec::new();
-    // Scopes holding a record with nothing in it while asking for packages
-    // the plan does derive entries for. An apply resolves this; the lines
-    // above cannot be resolved and are not meant to be.
-    let mut unrecorded: Vec<(Scope, Vec<(ItemKind, String)>)> = Vec::new();
+    // What each scope declares that its record does not hold. The count is
+    // of lock entries, so none of this reaches it, and a count printed
+    // without them covers less than the scope does.
+    let mut gaps: Vec<(Scope, Vec<(ItemKind, String)>)> = Vec::new();
     // Whether any scope's record was gone. Read at the end for the exit
     // code alone — the run already said which scope it was, where it found
     // it.
@@ -130,17 +124,18 @@ pub fn run(
                 .filter(|row| names.is_empty() || names.contains(&row.name))
                 .cloned(),
         );
-        let (recordable, unrecordable): (Vec<_>, Vec<_>) = declared
+        // A kind the plan derives no entry for is missing from the record
+        // whatever else it holds; one the plan does derive is missing only
+        // while the record holds nothing at all.
+        let gap: Vec<(ItemKind, String)> = declared
             .into_iter()
             .filter(|(_, name)| names.is_empty() || names.contains(name))
-            .partition(|(kind, _)| recorded_by_the_plan(*kind));
-        if !unrecordable.is_empty() {
-            outside.push((scope.clone(), unrecordable));
+            .filter(|(kind, _)| !recorded_by_the_plan(*kind) || lock.entries.is_empty())
+            .collect();
+        if !gap.is_empty() {
+            gaps.push((scope.clone(), gap));
         }
         if lock.entries.is_empty() {
-            if !recordable.is_empty() {
-                unrecorded.push((scope.clone(), recordable));
-            }
             continue;
         }
         for entry in lock.entries.values() {
@@ -153,22 +148,8 @@ pub fn run(
     }
 
     print_unmanaged(&unmanaged);
-    print_declared(
-        &outside,
-        "the install record never holds — kendex update-pi checks those",
-    );
-    print_declared(
-        &unrecorded,
-        "declared and none in the install record — kendex apply writes it",
-    );
-    ui::ledger(
-        &head(
-            checked,
-            failed,
-            !unrecorded.is_empty() || !outside.is_empty(),
-        ),
-        &[],
-    );
+    print_gaps(&gaps);
+    ui::ledger(&head(checked, failed, !gaps.is_empty()), &[]);
     Ok(match failed > 0 || recordless {
         true => ExitCode::FAILURE,
         false => ExitCode::SUCCESS,
@@ -246,27 +227,39 @@ fn declares_items(manifest: &Manifest) -> bool {
         || !manifest.plugins.is_empty()
 }
 
-/// A scope's declarations said once at the end beside the unmanaged rows,
-/// under a headline that names what is true of them. Not a verdict: the
-/// count above is of lock entries, and neither of these lines has one to
-/// contribute.
+/// What each scope declares that its record does not hold, said once at
+/// the end beside the unmanaged rows. Not a verdict: the count above is of
+/// lock entries and none of this is one.
+///
+/// One headline, because both kinds of gap are the same fact — a
+/// declaration with no entry behind it — and what to do about each is not.
+/// A Pi extension has no entry by design and no `apply` gives it one;
+/// anything else is waiting on an `apply` that has not run. Each name
+/// carries which it is, so the headline stays true of the whole list and
+/// the reader still knows what to do with a row.
 ///
 /// Every name, uncapped, and the cap rule stays stated in the one place
-/// `print_unmanaged` states it. The Pi-extension line is one name per
-/// typed declaration. The unrecorded line is the expanded closure, so one
-/// `[bundles.x]` prints every member and everything those members
-/// require, and a large set makes a long list; the names are what a reader
-/// looking at an empty record came for.
-fn print_declared(scopes: &[(Scope, Vec<(ItemKind, String)>)], tail: &str) {
+/// `print_unmanaged` states it. The list is the expanded closure, so one
+/// `[bundles.x]` prints every member and everything those members require,
+/// and a large set makes a long list; the names are what a reader looking
+/// at an empty record came for.
+fn print_gaps(scopes: &[(Scope, Vec<(ItemKind, String)>)]) {
     for (scope, items) in scopes {
         note(&format!(
-            "{}: {} item{} {tail}",
+            "{}: {} item{} declared and not in the install record",
             scope_label(scope),
             items.len(),
             if items.len() == 1 { "" } else { "s" }
         ));
         for (kind, name) in items {
-            say(&format!("  - {} {name}", kind.name()));
+            say(&format!(
+                "  - {} {name} — {}",
+                kind.name(),
+                match recorded_by_the_plan(*kind) {
+                    true => "kendex apply records it",
+                    false => "no record ever holds one; kendex update-pi checks it",
+                }
+            ));
         }
     }
 }

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -199,6 +199,17 @@ fn head(checked: usize, failed: usize, named: bool) -> String {
 /// bundle is not read as asking for nothing. It costs one expansion pass,
 /// which is less than the `audit` this verb already runs on every scope.
 ///
+/// It does not answer for plugins, and the plugin table is added here
+/// rather than there. A `PlannedDeclaration` carries an `ItemDecl`, which
+/// names the source a package is read from; a plugin declares through
+/// `[plugins.<key>]` with an enabled flag and a harness, and has no source
+/// at all. Emitting one would mean inventing that field, and
+/// `package::updates` feeds every planned declaration through an
+/// evaluation built on it — the source's pin, the declaration's rev, the
+/// package reference — so an invented source would put a row on the
+/// Updates surface for a package that is not updated one at a time. The
+/// engine's set stays what it is; this one is what `verify` asks about.
+///
 /// A declaration switched off is still a declaration. `enabled` rides on
 /// the lock entry rather than deciding whether one exists — a disabled
 /// agent installs and stays tracked — so the flag is not this function's
@@ -208,6 +219,12 @@ fn declared_packages(env: &Env, scope: &Scope, manifest: &Manifest) -> Vec<(Item
     planned_declarations(env, scope, manifest)
         .into_iter()
         .map(|declared| (declared.kind, declared.name))
+        .chain(
+            manifest
+                .plugins
+                .keys()
+                .map(|name| (ItemKind::Plugin, name.clone())),
+        )
         .collect()
 }
 

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -5,7 +5,7 @@ use kendex_core::engine::{
 };
 use kendex_core::env::Env;
 use kendex_core::lock::{Lock, LockFile, load_file as load_lock_file, lock_path};
-use kendex_core::manifest::{ManifestFile, load as load_manifest, manifest_path};
+use kendex_core::manifest::{Manifest, ManifestFile, load as load_manifest, manifest_path};
 use kendex_core::model::{ItemKind, Scope};
 
 use super::engine_common::print_unmanaged;
@@ -21,10 +21,13 @@ use crate::ui;
 /// and packages of a kind the plan derives no entry for, which `kendex
 /// update-pi` checks and this verb never can.
 ///
-/// A scope asking for packages with no record at all is the third case and
-/// it does close the run, non-zero. There is nothing there to weigh a
-/// declaration against, and a count that leaves such a scope out reads as
-/// a pass to the pipeline that composed it.
+/// One state closes the run non-zero on its own: a scope whose manifest
+/// asks for items and whose install record is not there. That is the
+/// state the lock version floor's move-it-aside remedy leaves, there is
+/// nothing on disk to weigh a declaration against, and a count that leaves
+/// such a scope out reads as a pass to the pipeline that composed it. A
+/// record that is present and empty is a judged scope: it says nothing is
+/// installed, and this verb agrees with it.
 pub fn run(
     env: &Env,
     names: Vec<String>,
@@ -46,21 +49,32 @@ pub fn run(
     // the plan does derive entries for. An apply resolves this; the lines
     // above cannot be resolved and are not meant to be.
     let mut unrecorded: Vec<(Scope, Vec<(ItemKind, String)>)> = Vec::new();
-    // Whether any scope's record was gone. Set once, read at the end: the
-    // run says which scope it was where it found it, and the exit code
-    // carries it out.
-    let mut unjudged = false;
+    // Whether any scope's record was gone. Read at the end for the exit
+    // code alone — the run already said which scope it was, where it found
+    // it.
+    let mut recordless = false;
 
     for scope in resolve_scopes(env, filter)? {
         let path = lock_path(env, &scope);
-        // Absent and empty read alike through `load`, and this is the one
-        // place the difference decides something.
+        // Absent and empty read alike through `load`, and here the
+        // difference decides the verdict.
         let record = load_lock_file(&path)?;
         let absent = matches!(record, LockFile::Absent);
         let lock = match record {
             LockFile::Current(lock) => lock,
             LockFile::Absent => Lock::default(),
         };
+        // The one state this run refuses, read off the manifest itself so
+        // no source, catalog or expansion can change the answer.
+        if absent && manifest_declares_items(env, &scope) {
+            fail(&format!(
+                "! {}: no install record at {} — this scope was not checked",
+                scope_label(&scope),
+                path.display()
+            ));
+            recordless = true;
+            continue;
+        }
         // A scope with nothing installed has nothing to verify, and this
         // run reaches it only to name content nothing manages. That errand
         // never costs the run: a manifest this build cannot plan against
@@ -87,20 +101,6 @@ pub fn run(
         // Read after the door above, so a manifest this build refuses still
         // leaves by that door rather than by this function's error.
         let declared = declared_packages(env, &scope)?;
-        // Nothing on disk says what this scope should be holding, so every
-        // count below would be a count of a scope this run never looked at.
-        // A scope asking for nothing is not that — there is no record
-        // because none was ever owed.
-        if absent && !declared.is_empty() {
-            fail(&format!(
-                "! {}: no install record at {} — nothing in this scope was checked",
-                scope_label(&scope),
-                path.display()
-            ));
-            say("  to write one: kendex apply");
-            unjudged = true;
-            continue;
-        }
         unmanaged.extend(
             report
                 .drift
@@ -142,10 +142,10 @@ pub fn run(
     );
     ui::ledger(
         &match checked {
-            // A scope that asked for something is not a machine with
-            // nothing installed on it, and saying so would close the run on
-            // the one reading the reader came for.
-            0 => match unjudged || !unrecorded.is_empty() || !outside.is_empty() {
+            // A scope whose declarations were named above is not a machine
+            // with nothing installed on it, and saying so would close the
+            // run on the one reading the reader came for.
+            0 => match !unrecorded.is_empty() || !outside.is_empty() {
                 true => "nothing checked".to_owned(),
                 false => "nothing installed".to_owned(),
             },
@@ -156,7 +156,7 @@ pub fn run(
         },
         &[],
     );
-    Ok(match failed > 0 || unjudged {
+    Ok(match failed > 0 || recordless {
         true => ExitCode::FAILURE,
         false => ExitCode::SUCCESS,
     })
@@ -182,22 +182,37 @@ fn declared_packages(
     let ManifestFile::Current(manifest) = load_manifest(&manifest_path(env, scope))? else {
         return Ok(Vec::new());
     };
-    let mut declared: Vec<(ItemKind, String)> = planned_declarations(env, scope, &manifest)
+    Ok(planned_declarations(env, scope, &manifest)
         .into_iter()
         .map(|declared| (declared.kind, declared.name))
-        .collect();
-    // Plugins declare through `[plugins.<key>]` with only an enabled flag,
-    // so `Manifest::declared` has no map to hand back for them and
-    // `planned_declarations` has no closure to walk. The plan still derives
-    // the toggle and records it, which makes a scope declaring only plugins
-    // a scope asking for something.
-    declared.extend(
-        manifest
-            .plugins
-            .keys()
-            .map(|name| (ItemKind::Plugin, name.clone())),
-    );
-    Ok(declared)
+        .collect())
+}
+
+/// Whether the scope's manifest asks for anything at all — every
+/// declaration table, read as it sits.
+///
+/// The refusal above binds to this rather than to the expanded plan. An
+/// expansion asks a catalog what a bundle holds and what a skill requires,
+/// and every way that read can come back short is a way the refusal would
+/// stop firing on a scope that is still missing its record. A manifest
+/// this build cannot read answers no here and leaves by the audit door
+/// instead, which names the break; this gate never speaks for a file it
+/// could not open.
+fn manifest_declares_items(env: &Env, scope: &Scope) -> bool {
+    matches!(
+        load_manifest(&manifest_path(env, scope)),
+        Ok(ManifestFile::Current(manifest)) if declares_items(&manifest)
+    )
+}
+
+/// `Manifest::declared` covers six kinds; bundles and plugins each declare
+/// through a table of their own and are asked for here.
+fn declares_items(manifest: &Manifest) -> bool {
+    ItemKind::ALL
+        .iter()
+        .any(|kind| !manifest.declared(*kind).is_empty())
+        || !manifest.bundles.is_empty()
+        || !manifest.plugins.is_empty()
 }
 
 /// A scope's declarations said once at the end beside the unmanaged rows,
@@ -205,10 +220,12 @@ fn declared_packages(
 /// count above is of lock entries, and neither of these lines has one to
 /// contribute.
 ///
-/// Every name, uncapped. What a person wrote in a manifest is bounded by
-/// what they were willing to type, unlike the unmanaged content
-/// `print_unmanaged` caps, and the cap rule stays stated in that one
-/// place.
+/// Every name, uncapped, and the cap rule stays stated in the one place
+/// `print_unmanaged` states it. The Pi-extension line is one name per
+/// typed declaration. The unrecorded line is the expanded closure, so one
+/// `[bundles.x]` prints every member and everything those members
+/// require, and a large set makes a long list; the names are what a reader
+/// looking at an empty record came for.
 fn print_declared(scopes: &[(Scope, Vec<(ItemKind, String)>)], tail: &str) {
     for (scope, items) in scopes {
         note(&format!(

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -64,9 +64,29 @@ pub fn run(
             LockFile::Current(lock) => lock,
             LockFile::Absent => Lock::default(),
         };
+        // One read of the manifest per scope, so the gate below and the
+        // declarations printed at the end are one answer about one file.
+        // Read twice, the two can disagree: a read that fails and then
+        // succeeds on the retry left the gate saying the scope asked for
+        // nothing while the line under it named what the scope asked for,
+        // and the run closed green having checked none of it.
+        let manifest = match load_manifest(&manifest_path(env, &scope)) {
+            Ok(ManifestFile::Current(manifest)) => Some(manifest),
+            Ok(ManifestFile::Absent) => None,
+            // A file this build could not open is not a file declaring
+            // nothing, and the gate never answers for one. It leaves by
+            // the door a manifest break already leaves by, on that door's
+            // terms: a line where there is nothing installed to misreport,
+            // and the run's own error where there is.
+            Err(error) if lock.entries.is_empty() => {
+                fail_refusal(&format!("! {} not checked: ", scope_label(&scope)), &error);
+                continue;
+            }
+            Err(error) => return Err(error.into()),
+        };
         // The one state this run refuses, read off the manifest itself so
         // no source, catalog or expansion can change the answer.
-        if absent && manifest_declares_items(env, &scope) {
+        if absent && manifest.as_deref().is_some_and(declares_items) {
             fail(&format!(
                 "! {}: no install record at {} — this scope was not checked",
                 scope_label(&scope),
@@ -98,9 +118,10 @@ pub fn run(
             }
             (Err(error), false) => return Err(error.into()),
         };
-        // Read after the door above, so a manifest this build refuses still
-        // leaves by that door rather than by this function's error.
-        let declared = declared_packages(env, &scope)?;
+        let declared = manifest
+            .as_deref()
+            .map(|manifest| declared_packages(env, &scope, manifest))
+            .unwrap_or_default();
         unmanaged.extend(
             report
                 .drift
@@ -141,25 +162,33 @@ pub fn run(
         "declared and none in the install record — kendex apply writes it",
     );
     ui::ledger(
-        &match checked {
-            // A scope whose declarations were named above is not a machine
-            // with nothing installed on it, and saying so would close the
-            // run on the one reading the reader came for.
-            0 => match !unrecorded.is_empty() || !outside.is_empty() {
-                true => "nothing checked".to_owned(),
-                false => "nothing installed".to_owned(),
-            },
-            _ => format!(
-                "{checked} checked, {} OK, {failed} failed",
-                checked - failed
-            ),
-        },
+        &head(
+            checked,
+            failed,
+            !unrecorded.is_empty() || !outside.is_empty(),
+        ),
         &[],
     );
     Ok(match failed > 0 || recordless {
         true => ExitCode::FAILURE,
         false => ExitCode::SUCCESS,
     })
+}
+
+/// The line that closes the run: the count, or why there was none.
+///
+/// A scope whose declarations were named above is not a machine with
+/// nothing installed on it, and saying so would close the run on the one
+/// reading the reader came for.
+fn head(checked: usize, failed: usize, named: bool) -> String {
+    match (checked, named) {
+        (0, true) => "nothing checked".to_owned(),
+        (0, false) => "nothing installed".to_owned(),
+        _ => format!(
+            "{checked} checked, {} OK, {failed} failed",
+            checked - failed
+        ),
+    }
 }
 
 /// What a scope asks to have installed, by kind and name.
@@ -175,36 +204,21 @@ pub fn run(
 /// agent installs and stays tracked — so the flag is not this function's
 /// to read, and the engine's own predicate for keeping a record does not
 /// read it either.
-fn declared_packages(
-    env: &Env,
-    scope: &Scope,
-) -> Result<Vec<(ItemKind, String)>, Box<dyn std::error::Error>> {
-    let ManifestFile::Current(manifest) = load_manifest(&manifest_path(env, scope))? else {
-        return Ok(Vec::new());
-    };
-    Ok(planned_declarations(env, scope, &manifest)
+fn declared_packages(env: &Env, scope: &Scope, manifest: &Manifest) -> Vec<(ItemKind, String)> {
+    planned_declarations(env, scope, manifest)
         .into_iter()
         .map(|declared| (declared.kind, declared.name))
-        .collect())
+        .collect()
 }
 
 /// Whether the scope's manifest asks for anything at all — every
 /// declaration table, read as it sits.
 ///
-/// The refusal above binds to this rather than to the expanded plan. An
+/// The refusal binds to this rather than to the expanded plan. An
 /// expansion asks a catalog what a bundle holds and what a skill requires,
 /// and every way that read can come back short is a way the refusal would
-/// stop firing on a scope that is still missing its record. A manifest
-/// this build cannot read answers no here and leaves by the audit door
-/// instead, which names the break; this gate never speaks for a file it
-/// could not open.
-fn manifest_declares_items(env: &Env, scope: &Scope) -> bool {
-    matches!(
-        load_manifest(&manifest_path(env, scope)),
-        Ok(ManifestFile::Current(manifest)) if declares_items(&manifest)
-    )
-}
-
+/// stop firing on a scope that is still missing its record.
+///
 /// `Manifest::declared` covers six kinds; bundles and plugins each declare
 /// through a table of their own and are asked for here.
 fn declares_items(manifest: &Manifest) -> bool {

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -3,15 +3,18 @@ use std::process::ExitCode;
 use kendex_core::engine::{DriftRow, DriftState, audit};
 use kendex_core::env::Env;
 use kendex_core::lock::{load as load_lock, lock_path};
+use kendex_core::manifest::{ManifestFile, load as load_manifest, manifest_path};
+use kendex_core::model::{ItemKind, Scope};
 
 use super::engine_common::print_unmanaged;
-use super::{fail, fail_refusal, resolve_scopes, say, scope_label};
+use super::{fail, fail_refusal, note, resolve_scopes, say, scope_label};
 use crate::scope::ScopeFilter;
 use crate::ui;
 
 /// Drift check over lock entries; non-zero exit on any failing row — this
 /// is the signal consuming repos compose in shell pipelines. Content
-/// nothing manages is named beside the rows, and never changes the count:
+/// nothing manages is named beside the rows, and so is a scope declaring
+/// packages its install record holds none of; neither changes the count:
 /// the count is the verdict and closes the run.
 pub fn run(
     env: &Env,
@@ -25,6 +28,11 @@ pub fn run(
     // the end: a count of installations is only honest beside the content
     // that was never one.
     let mut unmanaged: Vec<DriftRow> = Vec::new();
+    // Scopes whose manifest asks for packages while their install record
+    // holds none. Every check this run makes is a lock entry, so these
+    // contribute nothing to the count, and a count printed without them
+    // reports a smaller installation than the one on disk.
+    let mut unrecorded: Vec<(Scope, Vec<(ItemKind, String)>)> = Vec::new();
 
     for scope in resolve_scopes(env, filter)? {
         let lock = load_lock(&lock_path(env, &scope))?;
@@ -60,6 +68,10 @@ pub fn run(
                 .cloned(),
         );
         if lock.entries.is_empty() {
+            let declared = declared_packages(env, &scope, &names)?;
+            if !declared.is_empty() {
+                unrecorded.push((scope.clone(), declared));
+            }
             continue;
         }
         for entry in lock.entries.values() {
@@ -73,10 +85,21 @@ pub fn run(
 
     if checked == 0 {
         print_unmanaged(&unmanaged);
-        ui::ledger("nothing installed", &[]);
+        print_unrecorded(&unrecorded);
+        // A scope declaring packages it could not check is not a machine
+        // with nothing installed on it, and saying so would close the run
+        // on the one reading the reader came for.
+        ui::ledger(
+            match unrecorded.is_empty() {
+                true => "nothing installed",
+                false => "nothing checked",
+            },
+            &[],
+        );
         return Ok(ExitCode::SUCCESS);
     }
     print_unmanaged(&unmanaged);
+    print_unrecorded(&unrecorded);
     ui::ledger(
         &format!(
             "{checked} checked, {} OK, {failed} failed",
@@ -89,6 +112,58 @@ pub fn run(
     } else {
         ExitCode::SUCCESS
     })
+}
+
+/// What a scope's manifest asks to have installed, by kind and name, held
+/// to the names the run was asked about. Read for a scope whose install
+/// record holds nothing: the audit above says nothing about a declaration
+/// no entry covers, and a Pi extension never gets an entry at all.
+///
+/// A declaration switched off asks for no installation, so its absence
+/// from the record is the record being right.
+fn declared_packages(
+    env: &Env,
+    scope: &Scope,
+    names: &[String],
+) -> Result<Vec<(ItemKind, String)>, Box<dyn std::error::Error>> {
+    let ManifestFile::Current(manifest) = load_manifest(&manifest_path(env, scope))? else {
+        return Ok(Vec::new());
+    };
+    let mut declared = Vec::new();
+    for kind in ItemKind::ALL {
+        for (name, decl) in manifest.declared(kind) {
+            if !decl.enabled || (!names.is_empty() && !names.contains(name)) {
+                continue;
+            }
+            declared.push((kind, name.clone()));
+        }
+    }
+    Ok(declared)
+}
+
+/// Enough to recognise what went unchecked without burying the rows above
+/// it.
+const UNRECORDED_SHOWN: usize = 10;
+
+/// The scopes that declare packages and have no install record to check
+/// them against, said once at the end beside the unmanaged rows. Not a
+/// verdict: the exit code answers about drift, and there is no drift to
+/// read where there is nothing recorded to compare against.
+fn print_unrecorded(scopes: &[(Scope, Vec<(ItemKind, String)>)]) {
+    for (scope, items) in scopes {
+        note(&format!(
+            "{}: {} item{} declared, none in the install record and none checked",
+            scope_label(scope),
+            items.len(),
+            if items.len() == 1 { "" } else { "s" }
+        ));
+        for (kind, name) in items.iter().take(UNRECORDED_SHOWN) {
+            say(&format!("  - {} {name}", kind.name()));
+        }
+        if items.len() > UNRECORDED_SHOWN {
+            say(&format!("  … and {} more", items.len() - UNRECORDED_SHOWN));
+        }
+    }
 }
 
 /// One locked installation's row, and whether it failed the run. The

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -1,8 +1,10 @@
 use std::process::ExitCode;
 
-use kendex_core::engine::{DriftRow, DriftState, audit};
+use kendex_core::engine::{
+    DriftRow, DriftState, audit, planned_declarations, recorded_by_the_plan,
+};
 use kendex_core::env::Env;
-use kendex_core::lock::{load as load_lock, lock_path};
+use kendex_core::lock::{Lock, LockFile, load_file as load_lock_file, lock_path};
 use kendex_core::manifest::{ManifestFile, load as load_manifest, manifest_path};
 use kendex_core::model::{ItemKind, Scope};
 
@@ -12,10 +14,17 @@ use crate::scope::ScopeFilter;
 use crate::ui;
 
 /// Drift check over lock entries; non-zero exit on any failing row — this
-/// is the signal consuming repos compose in shell pipelines. Content
-/// nothing manages is named beside the rows, and so is a scope declaring
-/// packages its install record holds none of; neither changes the count:
-/// the count is the verdict and closes the run.
+/// is the signal consuming repos compose in shell pipelines.
+///
+/// Two things are named beside the rows without changing the count, which
+/// is a count of lock entries and nothing else: content nothing manages,
+/// and packages of a kind the plan derives no entry for, which `kendex
+/// update-pi` checks and this verb never can.
+///
+/// A scope asking for packages with no record at all is the third case and
+/// it does close the run, non-zero. There is nothing there to weigh a
+/// declaration against, and a count that leaves such a scope out reads as
+/// a pass to the pipeline that composed it.
 pub fn run(
     env: &Env,
     names: Vec<String>,
@@ -28,14 +37,30 @@ pub fn run(
     // the end: a count of installations is only honest beside the content
     // that was never one.
     let mut unmanaged: Vec<DriftRow> = Vec::new();
-    // Scopes whose manifest asks for packages while their install record
-    // holds none. Every check this run makes is a lock entry, so these
-    // contribute nothing to the count, and a count printed without them
-    // reports a smaller installation than the one on disk.
+    // Packages of a kind the plan derives no lock entry for, gathered on
+    // every scope whatever its record holds. No run of this verb checks
+    // one, so a scope's count covers less than the scope does, and only
+    // saying so makes the count readable.
+    let mut outside: Vec<(Scope, Vec<(ItemKind, String)>)> = Vec::new();
+    // Scopes holding a record with nothing in it while asking for packages
+    // the plan does derive entries for. An apply resolves this; the lines
+    // above cannot be resolved and are not meant to be.
     let mut unrecorded: Vec<(Scope, Vec<(ItemKind, String)>)> = Vec::new();
+    // Whether any scope's record was gone. Set once, read at the end: the
+    // run says which scope it was where it found it, and the exit code
+    // carries it out.
+    let mut unjudged = false;
 
     for scope in resolve_scopes(env, filter)? {
-        let lock = load_lock(&lock_path(env, &scope))?;
+        let path = lock_path(env, &scope);
+        // Absent and empty read alike through `load`, and this is the one
+        // place the difference decides something.
+        let record = load_lock_file(&path)?;
+        let absent = matches!(record, LockFile::Absent);
+        let lock = match record {
+            LockFile::Current(lock) => lock,
+            LockFile::Absent => Lock::default(),
+        };
         // A scope with nothing installed has nothing to verify, and this
         // run reaches it only to name content nothing manages. That errand
         // never costs the run: a manifest this build cannot plan against
@@ -59,6 +84,23 @@ pub fn run(
             }
             (Err(error), false) => return Err(error.into()),
         };
+        // Read after the door above, so a manifest this build refuses still
+        // leaves by that door rather than by this function's error.
+        let declared = declared_packages(env, &scope)?;
+        // Nothing on disk says what this scope should be holding, so every
+        // count below would be a count of a scope this run never looked at.
+        // A scope asking for nothing is not that — there is no record
+        // because none was ever owed.
+        if absent && !declared.is_empty() {
+            fail(&format!(
+                "! {}: no install record at {} — nothing in this scope was checked",
+                scope_label(&scope),
+                path.display()
+            ));
+            say("  to write one: kendex apply");
+            unjudged = true;
+            continue;
+        }
         unmanaged.extend(
             report
                 .drift
@@ -67,10 +109,16 @@ pub fn run(
                 .filter(|row| names.is_empty() || names.contains(&row.name))
                 .cloned(),
         );
+        let (recordable, unrecordable): (Vec<_>, Vec<_>) = declared
+            .into_iter()
+            .filter(|(_, name)| names.is_empty() || names.contains(name))
+            .partition(|(kind, _)| recorded_by_the_plan(*kind));
+        if !unrecordable.is_empty() {
+            outside.push((scope.clone(), unrecordable));
+        }
         if lock.entries.is_empty() {
-            let declared = declared_packages(env, &scope, &names)?;
-            if !declared.is_empty() {
-                unrecorded.push((scope.clone(), declared));
+            if !recordable.is_empty() {
+                unrecorded.push((scope.clone(), recordable));
             }
             continue;
         }
@@ -83,85 +131,94 @@ pub fn run(
         }
     }
 
-    if checked == 0 {
-        print_unmanaged(&unmanaged);
-        print_unrecorded(&unrecorded);
-        // A scope declaring packages it could not check is not a machine
-        // with nothing installed on it, and saying so would close the run
-        // on the one reading the reader came for.
-        ui::ledger(
-            match unrecorded.is_empty() {
-                true => "nothing installed",
-                false => "nothing checked",
-            },
-            &[],
-        );
-        return Ok(ExitCode::SUCCESS);
-    }
     print_unmanaged(&unmanaged);
-    print_unrecorded(&unrecorded);
+    print_declared(
+        &outside,
+        "the install record never holds — kendex update-pi checks those",
+    );
+    print_declared(
+        &unrecorded,
+        "declared and none in the install record — kendex apply writes it",
+    );
     ui::ledger(
-        &format!(
-            "{checked} checked, {} OK, {failed} failed",
-            checked - failed
-        ),
+        &match checked {
+            // A scope that asked for something is not a machine with
+            // nothing installed on it, and saying so would close the run on
+            // the one reading the reader came for.
+            0 => match unjudged || !unrecorded.is_empty() || !outside.is_empty() {
+                true => "nothing checked".to_owned(),
+                false => "nothing installed".to_owned(),
+            },
+            _ => format!(
+                "{checked} checked, {} OK, {failed} failed",
+                checked - failed
+            ),
+        },
         &[],
     );
-    Ok(if failed > 0 {
-        ExitCode::FAILURE
-    } else {
-        ExitCode::SUCCESS
+    Ok(match failed > 0 || unjudged {
+        true => ExitCode::FAILURE,
+        false => ExitCode::SUCCESS,
     })
 }
 
-/// What a scope's manifest asks to have installed, by kind and name, held
-/// to the names the run was asked about. Read for a scope whose install
-/// record holds nothing: the audit above says nothing about a declaration
-/// no entry covers, and a Pi extension never gets an entry at all.
+/// What a scope asks to have installed, by kind and name.
 ///
-/// A declaration switched off asks for no installation, so its absence
-/// from the record is the record being right.
+/// [`planned_declarations`] is the engine's own answer to that question,
+/// so a bundle counts as the members it brings in rather than as a name
+/// the manifest happens to hold, and a scope whose only declaration is a
+/// bundle is not read as asking for nothing. It costs one expansion pass,
+/// which is less than the `audit` this verb already runs on every scope.
+///
+/// A declaration switched off is still a declaration. `enabled` rides on
+/// the lock entry rather than deciding whether one exists — a disabled
+/// agent installs and stays tracked — so the flag is not this function's
+/// to read, and the engine's own predicate for keeping a record does not
+/// read it either.
 fn declared_packages(
     env: &Env,
     scope: &Scope,
-    names: &[String],
 ) -> Result<Vec<(ItemKind, String)>, Box<dyn std::error::Error>> {
     let ManifestFile::Current(manifest) = load_manifest(&manifest_path(env, scope))? else {
         return Ok(Vec::new());
     };
-    let mut declared = Vec::new();
-    for kind in ItemKind::ALL {
-        for (name, decl) in manifest.declared(kind) {
-            if !decl.enabled || (!names.is_empty() && !names.contains(name)) {
-                continue;
-            }
-            declared.push((kind, name.clone()));
-        }
-    }
+    let mut declared: Vec<(ItemKind, String)> = planned_declarations(env, scope, &manifest)
+        .into_iter()
+        .map(|declared| (declared.kind, declared.name))
+        .collect();
+    // Plugins declare through `[plugins.<key>]` with only an enabled flag,
+    // so `Manifest::declared` has no map to hand back for them and
+    // `planned_declarations` has no closure to walk. The plan still derives
+    // the toggle and records it, which makes a scope declaring only plugins
+    // a scope asking for something.
+    declared.extend(
+        manifest
+            .plugins
+            .keys()
+            .map(|name| (ItemKind::Plugin, name.clone())),
+    );
     Ok(declared)
 }
 
-/// Enough to recognise what went unchecked without burying the rows above
-/// it.
-const UNRECORDED_SHOWN: usize = 10;
-
-/// The scopes that declare packages and have no install record to check
-/// them against, said once at the end beside the unmanaged rows. Not a
-/// verdict: the exit code answers about drift, and there is no drift to
-/// read where there is nothing recorded to compare against.
-fn print_unrecorded(scopes: &[(Scope, Vec<(ItemKind, String)>)]) {
+/// A scope's declarations said once at the end beside the unmanaged rows,
+/// under a headline that names what is true of them. Not a verdict: the
+/// count above is of lock entries, and neither of these lines has one to
+/// contribute.
+///
+/// Every name, uncapped. What a person wrote in a manifest is bounded by
+/// what they were willing to type, unlike the unmanaged content
+/// `print_unmanaged` caps, and the cap rule stays stated in that one
+/// place.
+fn print_declared(scopes: &[(Scope, Vec<(ItemKind, String)>)], tail: &str) {
     for (scope, items) in scopes {
         note(&format!(
-            "{}: {} item{} declared, none in the install record and none checked",
+            "{}: {} item{} {tail}",
             scope_label(scope),
             items.len(),
             if items.len() == 1 { "" } else { "s" }
         ));
-        for (kind, name) in items.iter().take(UNRECORDED_SHOWN) {
+        for (kind, name) in items {
             say(&format!("  - {} {name}", kind.name()));
-        }
-        if items.len() > UNRECORDED_SHOWN {
-            say(&format!("  … and {} more", items.len() - UNRECORDED_SHOWN));
         }
     }
 }

--- a/crates/cli/tests/pi_extension_only_lock.rs
+++ b/crates/cli/tests/pi_extension_only_lock.rs
@@ -243,6 +243,49 @@ fn verify_refuses_a_scope_with_no_install_record() {
     );
 }
 
+/// A bundle declares through a table of its own and is not an `ItemKind`,
+/// so it reaches the gate through neither `Manifest::declared` nor, once
+/// the record is gone, anything else. Its catalog here is readable and
+/// offers the set — `apply` on this fixture installs `alpha` — so what the
+/// refusal answers to is the declaration, not a catalog that came back
+/// short.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn verify_refuses_a_bundle_only_scope_with_no_install_record() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let project = home.join("dev/app");
+    fs::create_dir_all(project.join(".claude")).unwrap();
+    write(
+        &project.join("catalog/skills/alpha/SKILL.md"),
+        "---\nname: alpha\ndescription: the alpha skill\n---\nBody.\n",
+    );
+    write(
+        &project.join("catalog/kendex.toml"),
+        "[bundles.starter]\ndescription = \"the starter set\"\nskills = [\"alpha\"]\n",
+    );
+    write(
+        &project.join("kendex.toml"),
+        "schema = 6\n\n[sources.cat]\npath = \"catalog\"\n\n[install]\nharnesses = [\"claude\"]\nmethod = \"copy\"\n\n[bundles.starter]\nsource = \"cat\"\n",
+    );
+    assert!(!project.join(".kendex-lock.json").exists());
+
+    let output = kendex(&home, &project, &["verify"]);
+
+    assert!(!output.status.success(), "{output:?}");
+    assert_eq!(
+        said(&output).lines().next(),
+        Some(
+            format!(
+                "! {}: no install record at {} — this scope was not checked",
+                kendex_core::paths::slashed(&project),
+                project.join(".kendex-lock.json").display()
+            )
+            .as_str()
+        )
+    );
+}
+
 /// A plugin declares through a table of its own, carrying an enabled flag
 /// and nothing else, so it reaches the gate through neither
 /// `Manifest::declared` nor the expanded plan. It is still a scope asking

--- a/crates/cli/tests/pi_extension_only_lock.rs
+++ b/crates/cli/tests/pi_extension_only_lock.rs
@@ -1,0 +1,192 @@
+//! A scope that declares only Pi extensions still keeps an install record.
+//!
+//! Nothing about a Pi extension is planned, so this scope's plan derives no
+//! lock entries at all. The record still has to land: it is what `verify`,
+//! edit detection and the sweep read, and the version floor's remedy for an
+//! older lock is to move the file aside, which leaves exactly this shape.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+#[path = "../../test_util.rs"]
+mod test_util;
+use test_util::rooted;
+
+// Integration-test helpers sit outside #[test] fns, so clippy's
+// allow-unwrap-in-tests does not reach them.
+#[allow(clippy::expect_used)]
+fn kendex(home: &Path, cwd: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_kendex"))
+        .args(args)
+        .current_dir(cwd)
+        .env_clear()
+        .env("HOME", home)
+        .env("KENDEX_REAL_HOME", "1")
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .output()
+        .expect("kendex binary runs")
+}
+
+#[allow(clippy::unwrap_used)]
+fn write(path: &Path, text: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, text).unwrap();
+}
+
+/// A project whose manifest declares one Pi extension and nothing else, with
+/// the package already installed and no lock file anywhere. Handed back with
+/// the home the run reads, so a case never spells the root a second time.
+#[allow(clippy::unwrap_used)]
+fn fixture() -> (tempfile::TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let project = home.join("dev/app");
+    write(
+        &project.join("kendex.toml"),
+        "schema = 6\n\n[sources.cat]\npath = \"catalog\"\n\n[pi-extensions.pi-widgets]\nsource = \"cat\"\n",
+    );
+    let package = "{\n  \"name\": \"pi-widgets\",\n  \"version\": \"1.0.0\",\n  \"pi\": { \"extensions\": [\"index.js\"] }\n}\n";
+    write(
+        &project.join("catalog/pi-extensions/pi-widgets/package.json"),
+        package,
+    );
+    write(
+        &project.join("catalog/pi-extensions/pi-widgets/index.js"),
+        "export const version = 1;\n",
+    );
+    write(
+        &project.join(".pi/packages/pi-widgets/package.json"),
+        package,
+    );
+    write(
+        &project.join(".pi/packages/pi-widgets/index.js"),
+        "export const version = 1;\n",
+    );
+    write(
+        &project.join(".pi/settings.json"),
+        "{\"packages\": [\"./packages/pi-widgets\"]}\n",
+    );
+    assert!(!project.join(".kendex-lock.json").exists());
+    (tmp, home)
+}
+
+/// The version every record this build writes carries, read from the crate
+/// rather than typed here: a floor bump is what strands a scope in the first
+/// place, and a number copied into a test would go on asserting the old one.
+const LOCK_VERSION: u32 = kendex_core::lock::LOCK_VERSION;
+
+#[allow(clippy::unwrap_used)]
+fn assert_record_landed(project: &Path) {
+    let lock = project.join(".kendex-lock.json");
+    assert!(lock.is_file(), "no install record at {}", lock.display());
+    let text = fs::read_to_string(&lock).unwrap();
+    let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(
+        value.get("version").and_then(serde_json::Value::as_u64),
+        Some(u64::from(LOCK_VERSION)),
+        "{text}"
+    );
+}
+
+#[test]
+fn apply_writes_the_record_for_a_pi_extension_only_scope() {
+    let (_tmp, home) = fixture();
+    let project = home.join("dev/app");
+
+    let output = kendex(&home, &project, &["apply", "--yes"]);
+
+    assert!(output.status.success(), "{output:?}");
+    let said = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!said.contains("up to date"), "{said}");
+    assert_record_landed(&project);
+}
+
+#[test]
+fn refresh_writes_the_record_for_a_pi_extension_only_scope() {
+    let (_tmp, home) = fixture();
+    let project = home.join("dev/app");
+
+    let output = kendex(&home, &project, &["refresh", "--yes"]);
+
+    assert!(output.status.success(), "{output:?}");
+    let said = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!said.contains("up to date"), "{said}");
+    assert_record_landed(&project);
+}
+
+#[test]
+fn verify_names_declarations_the_record_does_not_hold() {
+    let (_tmp, home) = fixture();
+    let project = home.join("dev/app");
+
+    let output = kendex(&home, &project, &["verify"]);
+
+    assert!(output.status.success(), "{output:?}");
+    let said = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(said.contains("pi-widgets"), "{said}");
+    assert!(said.contains("none in the install record"), "{said}");
+    assert!(!said.contains("nothing installed"), "{said}");
+}
+
+/// The global scope is the shape the bug was found on: Pi extensions
+/// declared in `~/.config/kendex/kendex.toml`, and a lock the version
+/// floor's remedy had moved aside. Its record sits under the app's own
+/// directory and names no root, so it is a second path through the write,
+/// not a second spelling of the same one.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn apply_writes_the_global_record_for_a_pi_extension_only_scope() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    // The layout this machine's build writes, asked for rather than spelled:
+    // the global scope's directory is one the platform moves.
+    let env = kendex_core::env::Env::host_rooted(&home);
+    let manifest = env.global_manifest_file();
+    let lock = env.global_lock_file();
+    let global = manifest.parent().unwrap().to_path_buf();
+    write(
+        &manifest,
+        "schema = 6\n\n[sources.cat]\npath = \"catalog\"\n\n[pi-extensions.pi-widgets]\nsource = \"cat\"\n",
+    );
+    write(
+        &global.join("catalog/pi-extensions/pi-widgets/package.json"),
+        "{\n  \"name\": \"pi-widgets\",\n  \"version\": \"1.0.0\",\n  \"pi\": { \"extensions\": [\"index.js\"] }\n}\n",
+    );
+    write(
+        &global.join("catalog/pi-extensions/pi-widgets/index.js"),
+        "export const version = 1;\n",
+    );
+    assert!(!lock.exists());
+
+    let output = kendex(&home, &home, &["apply", "-g", "--yes"]);
+
+    assert!(output.status.success(), "{output:?}");
+    let said = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!said.contains("up to date"), "{said}");
+    let text = fs::read_to_string(&lock).unwrap();
+    let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(
+        value.get("version").and_then(serde_json::Value::as_u64),
+        Some(u64::from(LOCK_VERSION)),
+        "{text}"
+    );
+}

--- a/crates/cli/tests/pi_extension_only_lock.rs
+++ b/crates/cli/tests/pi_extension_only_lock.rs
@@ -156,11 +156,43 @@ fn refresh_writes_the_record_for_a_pi_extension_only_scope() {
     assert_record_landed(&project);
 }
 
+/// A record that is present and holds nothing is a judged scope, and this
+/// run passes it. It says nothing is installed, `verify` agrees, and the
+/// declaration `apply` has yet to record is named rather than counted.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_empty_record_names_what_apply_has_not_written() {
+    let (_tmp, home) = fixture();
+    let project = home.join("dev/app");
+    assert!(
+        kendex(&home, &project, &["apply", "--yes"])
+            .status
+            .success()
+    );
+
+    write(
+        &project.join("catalog/skills/deploy/SKILL.md"),
+        "---\nname: deploy\ndescription: ship it\n---\nUpstream.\n",
+    );
+    let manifest = fs::read_to_string(project.join("kendex.toml")).unwrap();
+    write(
+        &project.join("kendex.toml"),
+        &format!("{manifest}\n[skills.deploy]\nsource = \"cat\"\n"),
+    );
+
+    let checked = kendex(&home, &project, &["verify"]);
+    assert!(checked.status.success(), "{checked:?}");
+    let printed = said(&checked);
+    assert!(
+        printed.contains("1 item declared and none in the install record — kendex apply writes it"),
+        "{printed}"
+    );
+    assert!(printed.contains("  - skill deploy"), "{printed}");
+}
+
 /// A declaration switched off is still a declaration. `enabled` rides on
 /// the lock entry rather than deciding whether one exists, so the flag
-/// decides nothing here — and the engine and `verify` have to agree about
-/// that, which before the predicate was unified they did not: the record
-/// was written and the verb reported the scope had nothing installed.
+/// decides nothing here, and the engine and `verify` agree about that.
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_disabled_pi_extension_is_still_a_declaration() {
@@ -198,9 +230,17 @@ fn verify_refuses_a_scope_with_no_install_record() {
     let output = kendex(&home, &project, &["verify"]);
 
     assert!(!output.status.success(), "{output:?}");
-    let printed = said(&output);
-    assert!(printed.contains("no install record"), "{printed}");
-    assert!(!printed.contains("nothing installed"), "{printed}");
+    assert_eq!(
+        said(&output).lines().next(),
+        Some(
+            format!(
+                "! {}: no install record at {} — this scope was not checked",
+                kendex_core::paths::slashed(&project),
+                project.join(".kendex-lock.json").display()
+            )
+            .as_str()
+        )
+    );
 }
 
 /// The global scope is the shape the bug was found on: Pi extensions

--- a/crates/cli/tests/pi_extension_only_lock.rs
+++ b/crates/cli/tests/pi_extension_only_lock.rs
@@ -1,11 +1,12 @@
-//! A scope that declares only Pi extensions still keeps an install record.
+//! The install record a scope keeps when the plan derives no entry for what
+//! it declares, and what `verify` says about the gap.
 //!
-//! A Pi extension derives no lock entry, so this scope's plan derives none
-//! at all. The record still has to land: without it the verb reports the
-//! scope up to date, nothing marks the project root for the walk-up that
-//! prefers it, and nothing on disk states which build wrote the record. The
-//! version floor's remedy for an older lock is to move the file aside,
-//! which leaves exactly this shape.
+//! A Pi extension derives no lock entry, so a scope declaring only those
+//! derives none at all. The record still has to land: without it the verb
+//! reports the scope up to date, nothing marks the project root for the
+//! walk-up that prefers it, and nothing on disk states which build wrote the
+//! record. The version floor's remedy for an older lock is to move the file
+//! aside, which leaves exactly this shape.
 
 #![cfg(unix)]
 
@@ -48,6 +49,22 @@ fn write(path: &Path, text: &str) {
     fs::write(path, text).unwrap();
 }
 
+const MANIFEST: &str = "schema = 6\n\n[sources.cat]\npath = \"catalog\"\n\n[pi-extensions.pi-widgets]\nsource = \"cat\"\n";
+const PACKAGE: &str = "{\n  \"name\": \"pi-widgets\",\n  \"version\": \"1.0.0\",\n  \"pi\": { \"extensions\": [\"index.js\"] }\n}\n";
+const INDEX: &str = "export const version = 1;\n";
+
+/// The catalog a Pi declaration reads, laid out under `root`.
+fn catalog(root: &Path) {
+    write(
+        &root.join("catalog/pi-extensions/pi-widgets/package.json"),
+        PACKAGE,
+    );
+    write(
+        &root.join("catalog/pi-extensions/pi-widgets/index.js"),
+        INDEX,
+    );
+}
+
 /// A project whose manifest declares one Pi extension and nothing else, with
 /// the package already installed and no lock file anywhere. Handed back with
 /// the home the run reads, so a case never spells the root a second time.
@@ -56,27 +73,13 @@ fn fixture() -> (tempfile::TempDir, PathBuf) {
     let tmp = tempfile::tempdir().unwrap();
     let home = rooted(&tmp);
     let project = home.join("dev/app");
-    write(
-        &project.join("kendex.toml"),
-        "schema = 6\n\n[sources.cat]\npath = \"catalog\"\n\n[pi-extensions.pi-widgets]\nsource = \"cat\"\n",
-    );
-    let package = "{\n  \"name\": \"pi-widgets\",\n  \"version\": \"1.0.0\",\n  \"pi\": { \"extensions\": [\"index.js\"] }\n}\n";
-    write(
-        &project.join("catalog/pi-extensions/pi-widgets/package.json"),
-        package,
-    );
-    write(
-        &project.join("catalog/pi-extensions/pi-widgets/index.js"),
-        "export const version = 1;\n",
-    );
+    write(&project.join("kendex.toml"), MANIFEST);
+    catalog(&project);
     write(
         &project.join(".pi/packages/pi-widgets/package.json"),
-        package,
+        PACKAGE,
     );
-    write(
-        &project.join(".pi/packages/pi-widgets/index.js"),
-        "export const version = 1;\n",
-    );
+    write(&project.join(".pi/packages/pi-widgets/index.js"), INDEX);
     write(
         &project.join(".pi/settings.json"),
         "{\"packages\": [\"./packages/pi-widgets\"]}\n",
@@ -85,34 +88,37 @@ fn fixture() -> (tempfile::TempDir, PathBuf) {
     (tmp, home)
 }
 
-/// The version every record this build writes carries, read from the crate
-/// rather than typed here: a floor bump is what strands a scope in the first
-/// place, and a number copied into a test would go on asserting the old one.
-const LOCK_VERSION: u32 = kendex_core::lock::LOCK_VERSION;
-
+/// A record at `lock`, carrying the version this build writes — read from
+/// the crate rather than typed here, because a floor bump is what strands a
+/// scope in the first place and a number copied into a test would go on
+/// asserting the old one.
 #[allow(clippy::unwrap_used)]
-fn assert_record_landed(project: &Path) {
-    let lock = project.join(".kendex-lock.json");
+fn assert_record_landed(lock: &Path) {
     assert!(lock.is_file(), "no install record at {}", lock.display());
-    let text = fs::read_to_string(&lock).unwrap();
+    let text = fs::read_to_string(lock).unwrap();
     let value: serde_json::Value = serde_json::from_str(&text).unwrap();
     assert_eq!(
         value.get("version").and_then(serde_json::Value::as_u64),
-        Some(u64::from(LOCK_VERSION)),
+        Some(u64::from(kendex_core::lock::LOCK_VERSION)),
         "{text}"
     );
 }
 
-/// Both halves of the write, and the state a person is actually left in.
+/// Both halves of the write, both spellings of the scope, and the state a
+/// person is left in.
 ///
-/// The first run has to plan the record. The second has to plan nothing:
-/// the restraint in `plan_lock_write` is the only thing between a scope
-/// declaring a Pi extension and an "Update the install record" on every
-/// run it ever gets, and a case that only ever drives a virgin fixture
-/// cannot tell the two apart. `verify` closes it: the record is there, so
-/// the run does not refuse, and the one declaration is named as what no
-/// run of that verb checks.
+/// The first run has to plan the record. The second has to plan nothing: the
+/// restraint in `plan_lock_write` is the only thing between a scope
+/// declaring a Pi extension and an "Update the install record" on every run
+/// it ever gets, and a case that only ever drives a virgin fixture cannot
+/// tell the two apart. `verify` closes it — the record is there, so the run
+/// does not refuse, and the declaration is named as one no record holds.
+///
+/// The global scope is where this was found and is a second path through the
+/// write, its record sitting under the app's own directory and naming no
+/// root, so it is driven here rather than left to the project spelling.
 #[test]
+#[allow(clippy::unwrap_used)]
 fn apply_writes_the_record_once_for_a_pi_extension_only_scope() {
     let (_tmp, home) = fixture();
     let project = home.join("dev/app");
@@ -120,155 +126,59 @@ fn apply_writes_the_record_once_for_a_pi_extension_only_scope() {
     let first = said(&kendex(&home, &project, &["apply", "--yes"]));
     assert!(first.contains("Update the install record"), "{first}");
     assert!(!first.contains("up to date"), "{first}");
-    assert_record_landed(&project);
+    assert_record_landed(&project.join(".kendex-lock.json"));
 
     let second = said(&kendex(&home, &project, &["apply", "--yes"]));
     assert!(second.contains("up to date"), "{second}");
     assert!(!second.contains("Update the install record"), "{second}");
-    assert_record_landed(&project);
 
-    let checked = kendex(&home, &project, &["verify"]);
+    let checked = kendex(&home, &project, &["verify", "--scope", "project"]);
     assert!(checked.status.success(), "{checked:?}");
     assert_eq!(
         said(&checked).lines().collect::<Vec<_>>(),
         vec![
             format!(
-                "{}: 1 item the install record never holds — kendex update-pi checks those",
+                "{}: 1 item declared and not in the install record",
                 kendex_core::paths::slashed(&project)
             )
             .as_str(),
-            "  - pi-extension pi-widgets",
+            "  - pi-extension pi-widgets — no record ever holds one; kendex update-pi checks it",
             "nothing checked",
         ]
     );
+
+    let env = kendex_core::env::Env::host_rooted(&home);
+    let manifest = env.global_manifest_file();
+    write(&manifest, MANIFEST);
+    catalog(manifest.parent().unwrap());
+    assert!(!env.global_lock_file().exists());
+
+    let global = kendex(&home, &home, &["apply", "-g", "--yes"]);
+    assert!(global.status.success(), "{global:?}");
+    assert_record_landed(&env.global_lock_file());
 }
 
-#[test]
-fn refresh_writes_the_record_for_a_pi_extension_only_scope() {
-    let (_tmp, home) = fixture();
-    let project = home.join("dev/app");
-
-    let output = kendex(&home, &project, &["refresh", "--yes"]);
-
-    assert!(output.status.success(), "{output:?}");
-    let printed = said(&output);
-    assert!(!printed.contains("up to date"), "{printed}");
-    assert_record_landed(&project);
-}
-
-/// A record that is present and holds nothing is a judged scope, and this
-/// run passes it. It says nothing is installed, `verify` agrees, and the
-/// declaration `apply` has yet to record is named rather than counted.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn an_empty_record_names_what_apply_has_not_written() {
-    let (_tmp, home) = fixture();
-    let project = home.join("dev/app");
-    assert!(
-        kendex(&home, &project, &["apply", "--yes"])
-            .status
-            .success()
-    );
-
-    write(
-        &project.join("catalog/skills/deploy/SKILL.md"),
-        "---\nname: deploy\ndescription: ship it\n---\nUpstream.\n",
-    );
-    let manifest = fs::read_to_string(project.join("kendex.toml")).unwrap();
-    write(
-        &project.join("kendex.toml"),
-        &format!("{manifest}\n[skills.deploy]\nsource = \"cat\"\n"),
-    );
-
-    let checked = kendex(&home, &project, &["verify"]);
-    assert!(checked.status.success(), "{checked:?}");
-    let printed = said(&checked);
-    assert!(
-        printed.contains("1 item declared and none in the install record — kendex apply writes it"),
-        "{printed}"
-    );
-    assert!(printed.contains("  - skill deploy"), "{printed}");
-}
-
-/// A declaration switched off is still a declaration. `enabled` rides on
-/// the lock entry rather than deciding whether one exists, so the flag
-/// decides nothing here, and the engine and `verify` agree about that.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_disabled_pi_extension_is_still_a_declaration() {
-    let (_tmp, home) = fixture();
-    let project = home.join("dev/app");
-    let manifest = fs::read_to_string(project.join("kendex.toml")).unwrap();
-    write(
-        &project.join("kendex.toml"),
-        &format!("{manifest}enabled = false\n"),
-    );
-
-    let first = said(&kendex(&home, &project, &["apply", "--yes"]));
-    assert!(first.contains("Update the install record"), "{first}");
-    assert_record_landed(&project);
-
-    let second = said(&kendex(&home, &project, &["apply", "--yes"]));
-    assert!(second.contains("up to date"), "{second}");
-
-    let checked = kendex(&home, &project, &["verify"]);
-    assert!(checked.status.success(), "{checked:?}");
-    let printed = said(&checked);
-    assert!(printed.contains("  - pi-extension pi-widgets"), "{printed}");
-    assert!(!printed.contains("nothing installed"), "{printed}");
-}
-
-/// The scope asks for a package and has no record to weigh it against, so
-/// the run closes on that rather than reporting a machine with nothing
-/// installed on it. A pipeline running `kendex verify && deploy` after the
-/// version floor's move-it-aside remedy reads the refusal, not a pass.
-#[test]
-fn verify_refuses_a_scope_with_no_install_record() {
-    let (_tmp, home) = fixture();
-    let project = home.join("dev/app");
-
-    let output = kendex(&home, &project, &["verify"]);
-
-    assert!(!output.status.success(), "{output:?}");
-    assert_eq!(
-        said(&output).lines().next(),
-        Some(
-            format!(
-                "! {}: no install record at {} — this scope was not checked",
-                kendex_core::paths::slashed(&project),
-                project.join(".kendex-lock.json").display()
-            )
-            .as_str()
-        )
-    );
-}
-
-/// A plugin is recorded when the plan derives its toggle, and skipped when
+/// The gap line, with both kinds of gap under the one headline it has.
+///
+/// A plugin is recorded when the plan derives its toggle and skipped when
 /// the harness cannot take one — here an older machine keeping Copilot's
 /// settings in `config.json`. The Pi declaration beside it still writes the
-/// record, so the file lands holding nothing while the scope is still
-/// asking for the plugin `apply` will record once that machine migrates.
-/// Naming it is the whole of this verb's second job.
+/// record, so the file lands holding nothing while the scope asks for both:
+/// a package no record ever holds, and one `apply` will record once that
+/// machine migrates. The headline is true of the pair and each name says
+/// which it is.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn verify_names_a_plugin_the_record_does_not_hold() {
+fn verify_names_what_the_record_does_not_hold() {
     let tmp = tempfile::tempdir().unwrap();
     let home = rooted(&tmp);
     let env = kendex_core::env::Env::host_rooted(&home);
     let manifest = env.global_manifest_file();
-    let global = manifest.parent().unwrap().to_path_buf();
     write(
         &manifest,
-        "schema = 6\n\n[sources.cat]\npath = \"catalog\"\n\n[pi-extensions.pi-widgets]\nsource = \"cat\"\n\n[plugins.\"fmt@main\"]\nenabled = true\nharness = \"copilot\"\n",
+        &format!("{MANIFEST}\n[plugins.\"fmt@main\"]\nenabled = true\nharness = \"copilot\"\n"),
     );
-    write(
-        &global.join("catalog/pi-extensions/pi-widgets/package.json"),
-        "{\n  \"name\": \"pi-widgets\",\n  \"version\": \"1.0.0\",\n  \"pi\": { \"extensions\": [\"index.js\"] }\n}\n",
-    );
-    write(
-        &global.join("catalog/pi-extensions/pi-widgets/index.js"),
-        "export const version = 1;\n",
-    );
+    catalog(manifest.parent().unwrap());
     write(&home.join(".copilot/config.json"), "{}\n");
 
     assert!(
@@ -290,54 +200,14 @@ fn verify_names_a_plugin_the_record_does_not_hold() {
     let checked = kendex(&home, &home, &["verify", "-g"]);
 
     assert!(checked.status.success(), "{checked:?}");
-    let printed = said(&checked);
-    assert!(
-        printed.contains("1 item declared and none in the install record — kendex apply writes it"),
-        "{printed}"
-    );
-    assert!(printed.contains("  - plugin fmt@main"), "{printed}");
-}
-
-/// A bundle declares through a table of its own and is not an `ItemKind`,
-/// so it reaches the gate through neither `Manifest::declared` nor, once
-/// the record is gone, anything else. Its catalog here is readable and
-/// offers the set — `apply` on this fixture installs `alpha` — so what the
-/// refusal answers to is the declaration, not a catalog that came back
-/// short.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn verify_refuses_a_bundle_only_scope_with_no_install_record() {
-    let tmp = tempfile::tempdir().unwrap();
-    let home = rooted(&tmp);
-    let project = home.join("dev/app");
-    fs::create_dir_all(project.join(".claude")).unwrap();
-    write(
-        &project.join("catalog/skills/alpha/SKILL.md"),
-        "---\nname: alpha\ndescription: the alpha skill\n---\nBody.\n",
-    );
-    write(
-        &project.join("catalog/kendex.toml"),
-        "[bundles.starter]\ndescription = \"the starter set\"\nskills = [\"alpha\"]\n",
-    );
-    write(
-        &project.join("kendex.toml"),
-        "schema = 6\n\n[sources.cat]\npath = \"catalog\"\n\n[install]\nharnesses = [\"claude\"]\nmethod = \"copy\"\n\n[bundles.starter]\nsource = \"cat\"\n",
-    );
-    assert!(!project.join(".kendex-lock.json").exists());
-
-    let output = kendex(&home, &project, &["verify"]);
-
-    assert!(!output.status.success(), "{output:?}");
     assert_eq!(
-        said(&output).lines().next(),
-        Some(
-            format!(
-                "! {}: no install record at {} — this scope was not checked",
-                kendex_core::paths::slashed(&project),
-                project.join(".kendex-lock.json").display()
-            )
-            .as_str()
-        )
+        said(&checked).lines().collect::<Vec<_>>(),
+        vec![
+            "global: 2 items declared and not in the install record",
+            "  - pi-extension pi-widgets — no record ever holds one; kendex update-pi checks it",
+            "  - plugin fmt@main — kendex apply records it",
+            "nothing checked",
+        ]
     );
 }
 
@@ -372,49 +242,5 @@ fn verify_refuses_a_plugin_only_scope_with_no_install_record() {
             )
             .as_str()
         )
-    );
-}
-
-/// The global scope is the shape the bug was found on: Pi extensions
-/// declared in `~/.config/kendex/kendex.toml`, and a lock the version
-/// floor's remedy had moved aside. Its record sits under the app's own
-/// directory and names no root, so it is a second path through the write,
-/// not a second spelling of the same one.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn apply_writes_the_global_record_for_a_pi_extension_only_scope() {
-    let tmp = tempfile::tempdir().unwrap();
-    let home = rooted(&tmp);
-    // The layout this machine's build writes, asked for rather than spelled:
-    // the global scope's directory is one the platform moves.
-    let env = kendex_core::env::Env::host_rooted(&home);
-    let manifest = env.global_manifest_file();
-    let lock = env.global_lock_file();
-    let global = manifest.parent().unwrap().to_path_buf();
-    write(
-        &manifest,
-        "schema = 6\n\n[sources.cat]\npath = \"catalog\"\n\n[pi-extensions.pi-widgets]\nsource = \"cat\"\n",
-    );
-    write(
-        &global.join("catalog/pi-extensions/pi-widgets/package.json"),
-        "{\n  \"name\": \"pi-widgets\",\n  \"version\": \"1.0.0\",\n  \"pi\": { \"extensions\": [\"index.js\"] }\n}\n",
-    );
-    write(
-        &global.join("catalog/pi-extensions/pi-widgets/index.js"),
-        "export const version = 1;\n",
-    );
-    assert!(!lock.exists());
-
-    let output = kendex(&home, &home, &["apply", "-g", "--yes"]);
-
-    assert!(output.status.success(), "{output:?}");
-    let printed = said(&output);
-    assert!(!printed.contains("up to date"), "{printed}");
-    let text = fs::read_to_string(&lock).unwrap();
-    let value: serde_json::Value = serde_json::from_str(&text).unwrap();
-    assert_eq!(
-        value.get("version").and_then(serde_json::Value::as_u64),
-        Some(u64::from(LOCK_VERSION)),
-        "{text}"
     );
 }

--- a/crates/cli/tests/pi_extension_only_lock.rs
+++ b/crates/cli/tests/pi_extension_only_lock.rs
@@ -1,9 +1,11 @@
 //! A scope that declares only Pi extensions still keeps an install record.
 //!
-//! Nothing about a Pi extension is planned, so this scope's plan derives no
-//! lock entries at all. The record still has to land: it is what `verify`,
-//! edit detection and the sweep read, and the version floor's remedy for an
-//! older lock is to move the file aside, which leaves exactly this shape.
+//! A Pi extension derives no lock entry, so this scope's plan derives none
+//! at all. The record still has to land: without it the verb reports the
+//! scope up to date, nothing marks the project root for the walk-up that
+//! prefers it, and nothing on disk states which build wrote the record. The
+//! version floor's remedy for an older lock is to move the file aside,
+//! which leaves exactly this shape.
 
 #![cfg(unix)]
 
@@ -125,21 +127,24 @@ fn refresh_writes_the_record_for_a_pi_extension_only_scope() {
     assert_record_landed(&project);
 }
 
+/// The scope asks for a package and has no record to weigh it against, so
+/// the run closes on that rather than reporting a machine with nothing
+/// installed on it. A pipeline running `kendex verify && deploy` after the
+/// version floor's move-it-aside remedy reads the refusal, not a pass.
 #[test]
-fn verify_names_declarations_the_record_does_not_hold() {
+fn verify_refuses_a_scope_with_no_install_record() {
     let (_tmp, home) = fixture();
     let project = home.join("dev/app");
 
     let output = kendex(&home, &project, &["verify"]);
 
-    assert!(output.status.success(), "{output:?}");
+    assert!(!output.status.success(), "{output:?}");
     let said = format!(
         "{}{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    assert!(said.contains("pi-widgets"), "{said}");
-    assert!(said.contains("none in the install record"), "{said}");
+    assert!(said.contains("no install record"), "{said}");
     assert!(!said.contains("nothing installed"), "{said}");
 }
 

--- a/crates/cli/tests/pi_extension_only_lock.rs
+++ b/crates/cli/tests/pi_extension_only_lock.rs
@@ -243,6 +243,61 @@ fn verify_refuses_a_scope_with_no_install_record() {
     );
 }
 
+/// A plugin is recorded when the plan derives its toggle, and skipped when
+/// the harness cannot take one — here an older machine keeping Copilot's
+/// settings in `config.json`. The Pi declaration beside it still writes the
+/// record, so the file lands holding nothing while the scope is still
+/// asking for the plugin `apply` will record once that machine migrates.
+/// Naming it is the whole of this verb's second job.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn verify_names_a_plugin_the_record_does_not_hold() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let env = kendex_core::env::Env::host_rooted(&home);
+    let manifest = env.global_manifest_file();
+    let global = manifest.parent().unwrap().to_path_buf();
+    write(
+        &manifest,
+        "schema = 6\n\n[sources.cat]\npath = \"catalog\"\n\n[pi-extensions.pi-widgets]\nsource = \"cat\"\n\n[plugins.\"fmt@main\"]\nenabled = true\nharness = \"copilot\"\n",
+    );
+    write(
+        &global.join("catalog/pi-extensions/pi-widgets/package.json"),
+        "{\n  \"name\": \"pi-widgets\",\n  \"version\": \"1.0.0\",\n  \"pi\": { \"extensions\": [\"index.js\"] }\n}\n",
+    );
+    write(
+        &global.join("catalog/pi-extensions/pi-widgets/index.js"),
+        "export const version = 1;\n",
+    );
+    write(&home.join(".copilot/config.json"), "{}\n");
+
+    assert!(
+        kendex(&home, &home, &["apply", "-g", "--yes"])
+            .status
+            .success()
+    );
+    let text = fs::read_to_string(env.global_lock_file()).unwrap();
+    let record: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(
+        record
+            .get("entries")
+            .and_then(serde_json::Value::as_object)
+            .map(serde_json::Map::len),
+        Some(0),
+        "the record has to be there and hold nothing: {text}"
+    );
+
+    let checked = kendex(&home, &home, &["verify", "-g"]);
+
+    assert!(checked.status.success(), "{checked:?}");
+    let printed = said(&checked);
+    assert!(
+        printed.contains("1 item declared and none in the install record — kendex apply writes it"),
+        "{printed}"
+    );
+    assert!(printed.contains("  - plugin fmt@main"), "{printed}");
+}
+
 /// A bundle declares through a table of its own and is not an `ItemKind`,
 /// so it reaches the gate through neither `Manifest::declared` nor, once
 /// the record is gone, anything else. Its catalog here is readable and

--- a/crates/cli/tests/pi_extension_only_lock.rs
+++ b/crates/cli/tests/pi_extension_only_lock.rs
@@ -32,6 +32,16 @@ fn kendex(home: &Path, cwd: &Path, args: &[&str]) -> Output {
         .expect("kendex binary runs")
 }
 
+/// Everything one run said, both streams, in the order a person reading a
+/// terminal sees them.
+fn said(output: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
 #[allow(clippy::unwrap_used)]
 fn write(path: &Path, text: &str) {
     fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -93,21 +103,44 @@ fn assert_record_landed(project: &Path) {
     );
 }
 
+/// Both halves of the write, and the state a person is actually left in.
+///
+/// The first run has to plan the record. The second has to plan nothing:
+/// the restraint in `plan_lock_write` is the only thing between a scope
+/// declaring a Pi extension and an "Update the install record" on every
+/// run it ever gets, and a case that only ever drives a virgin fixture
+/// cannot tell the two apart. `verify` closes it: the record is there, so
+/// the run does not refuse, and the one declaration is named as what no
+/// run of that verb checks.
 #[test]
-fn apply_writes_the_record_for_a_pi_extension_only_scope() {
+fn apply_writes_the_record_once_for_a_pi_extension_only_scope() {
     let (_tmp, home) = fixture();
     let project = home.join("dev/app");
 
-    let output = kendex(&home, &project, &["apply", "--yes"]);
-
-    assert!(output.status.success(), "{output:?}");
-    let said = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(!said.contains("up to date"), "{said}");
+    let first = said(&kendex(&home, &project, &["apply", "--yes"]));
+    assert!(first.contains("Update the install record"), "{first}");
+    assert!(!first.contains("up to date"), "{first}");
     assert_record_landed(&project);
+
+    let second = said(&kendex(&home, &project, &["apply", "--yes"]));
+    assert!(second.contains("up to date"), "{second}");
+    assert!(!second.contains("Update the install record"), "{second}");
+    assert_record_landed(&project);
+
+    let checked = kendex(&home, &project, &["verify"]);
+    assert!(checked.status.success(), "{checked:?}");
+    assert_eq!(
+        said(&checked).lines().collect::<Vec<_>>(),
+        vec![
+            format!(
+                "{}: 1 item the install record never holds — kendex update-pi checks those",
+                kendex_core::paths::slashed(&project)
+            )
+            .as_str(),
+            "  - pi-extension pi-widgets",
+            "nothing checked",
+        ]
+    );
 }
 
 #[test]
@@ -118,13 +151,39 @@ fn refresh_writes_the_record_for_a_pi_extension_only_scope() {
     let output = kendex(&home, &project, &["refresh", "--yes"]);
 
     assert!(output.status.success(), "{output:?}");
-    let said = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(!said.contains("up to date"), "{said}");
+    let printed = said(&output);
+    assert!(!printed.contains("up to date"), "{printed}");
     assert_record_landed(&project);
+}
+
+/// A declaration switched off is still a declaration. `enabled` rides on
+/// the lock entry rather than deciding whether one exists, so the flag
+/// decides nothing here — and the engine and `verify` have to agree about
+/// that, which before the predicate was unified they did not: the record
+/// was written and the verb reported the scope had nothing installed.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_disabled_pi_extension_is_still_a_declaration() {
+    let (_tmp, home) = fixture();
+    let project = home.join("dev/app");
+    let manifest = fs::read_to_string(project.join("kendex.toml")).unwrap();
+    write(
+        &project.join("kendex.toml"),
+        &format!("{manifest}enabled = false\n"),
+    );
+
+    let first = said(&kendex(&home, &project, &["apply", "--yes"]));
+    assert!(first.contains("Update the install record"), "{first}");
+    assert_record_landed(&project);
+
+    let second = said(&kendex(&home, &project, &["apply", "--yes"]));
+    assert!(second.contains("up to date"), "{second}");
+
+    let checked = kendex(&home, &project, &["verify"]);
+    assert!(checked.status.success(), "{checked:?}");
+    let printed = said(&checked);
+    assert!(printed.contains("  - pi-extension pi-widgets"), "{printed}");
+    assert!(!printed.contains("nothing installed"), "{printed}");
 }
 
 /// The scope asks for a package and has no record to weigh it against, so
@@ -139,13 +198,9 @@ fn verify_refuses_a_scope_with_no_install_record() {
     let output = kendex(&home, &project, &["verify"]);
 
     assert!(!output.status.success(), "{output:?}");
-    let said = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(said.contains("no install record"), "{said}");
-    assert!(!said.contains("nothing installed"), "{said}");
+    let printed = said(&output);
+    assert!(printed.contains("no install record"), "{printed}");
+    assert!(!printed.contains("nothing installed"), "{printed}");
 }
 
 /// The global scope is the shape the bug was found on: Pi extensions
@@ -181,12 +236,8 @@ fn apply_writes_the_global_record_for_a_pi_extension_only_scope() {
     let output = kendex(&home, &home, &["apply", "-g", "--yes"]);
 
     assert!(output.status.success(), "{output:?}");
-    let said = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(!said.contains("up to date"), "{said}");
+    let printed = said(&output);
+    assert!(!printed.contains("up to date"), "{printed}");
     let text = fs::read_to_string(&lock).unwrap();
     let value: serde_json::Value = serde_json::from_str(&text).unwrap();
     assert_eq!(

--- a/crates/cli/tests/pi_extension_only_lock.rs
+++ b/crates/cli/tests/pi_extension_only_lock.rs
@@ -243,6 +243,40 @@ fn verify_refuses_a_scope_with_no_install_record() {
     );
 }
 
+/// A plugin declares through a table of its own, carrying an enabled flag
+/// and nothing else, so it reaches the gate through neither
+/// `Manifest::declared` nor the expanded plan. It is still a scope asking
+/// for something, and a scope asking for something with no record is the
+/// state this verb refuses.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn verify_refuses_a_plugin_only_scope_with_no_install_record() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let project = home.join("dev/app");
+    fs::create_dir_all(project.join(".claude")).unwrap();
+    write(
+        &project.join("kendex.toml"),
+        "schema = 6\n\n[plugins.\"fmt@main\"]\nenabled = true\n",
+    );
+    assert!(!project.join(".kendex-lock.json").exists());
+
+    let output = kendex(&home, &project, &["verify"]);
+
+    assert!(!output.status.success(), "{output:?}");
+    assert_eq!(
+        said(&output).lines().next(),
+        Some(
+            format!(
+                "! {}: no install record at {} — this scope was not checked",
+                kendex_core::paths::slashed(&project),
+                project.join(".kendex-lock.json").display()
+            )
+            .as_str()
+        )
+    );
+}
+
 /// The global scope is the shape the bug was found on: Pi extensions
 /// declared in `~/.config/kendex/kendex.toml`, and a lock the version
 /// floor's remedy had moved aside. Its record sits under the app's own

--- a/crates/cli/tests/presentation/snapshots.rs
+++ b/crates/cli/tests/presentation/snapshots.rs
@@ -107,9 +107,11 @@ fn add() {
 /// The verdict closes the run, and the footnote about content nothing
 /// manages stands above it rather than after it.
 ///
-/// A scope that declares packages and has no record of any of them is not
-/// a machine with nothing installed on it: the declarations are named and
-/// the head says what the run checked, which was none of them.
+/// A scope that asks for packages and has no record of any of them is not
+/// a machine with nothing installed on it. There is nothing there to weigh
+/// a declaration against, so the run says which scope and where the record
+/// should be, and closes non-zero rather than counting a scope it never
+/// looked at.
 #[test]
 fn verify() {
     expect(
@@ -126,9 +128,8 @@ fn verify() {
     expect(
         shape(&[], &["verify", "--scope", "project"]),
         vec![
-            "<project>: 2 items declared, none in the install record and none checked",
-            "  - skill growth-guards",
-            "  - skill tidy",
+            "! <project>: no install record at <project>/.kendex-lock.json — nothing in this scope was checked",
+            "  to write one: kendex apply",
             "nothing checked",
         ],
     );

--- a/crates/cli/tests/presentation/snapshots.rs
+++ b/crates/cli/tests/presentation/snapshots.rs
@@ -107,11 +107,11 @@ fn add() {
 /// The verdict closes the run, and the footnote about content nothing
 /// manages stands above it rather than after it.
 ///
-/// A scope that asks for packages and has no record of any of them is not
-/// a machine with nothing installed on it. There is nothing there to weigh
-/// a declaration against, so the run says which scope and where the record
-/// should be, and closes non-zero rather than counting a scope it never
-/// looked at.
+/// A scope whose manifest asks for items and whose install record is not
+/// there closes the run non-zero. There is nothing to weigh a declaration
+/// against, so the run says which scope and where the record should be,
+/// and the count below it is of the lock entries this run read, which
+/// were none.
 #[test]
 fn verify() {
     expect(
@@ -128,9 +128,8 @@ fn verify() {
     expect(
         shape(&[], &["verify", "--scope", "project"]),
         vec![
-            "! <project>: no install record at <project>/.kendex-lock.json — nothing in this scope was checked",
-            "  to write one: kendex apply",
-            "nothing checked",
+            "! <project>: no install record at <project>/.kendex-lock.json — this scope was not checked",
+            "nothing installed",
         ],
     );
 }

--- a/crates/cli/tests/presentation/snapshots.rs
+++ b/crates/cli/tests/presentation/snapshots.rs
@@ -106,6 +106,10 @@ fn add() {
 
 /// The verdict closes the run, and the footnote about content nothing
 /// manages stands above it rather than after it.
+///
+/// A scope that declares packages and has no record of any of them is not
+/// a machine with nothing installed on it: the declarations are named and
+/// the head says what the run checked, which was none of them.
 #[test]
 fn verify() {
     expect(
@@ -121,7 +125,12 @@ fn verify() {
     );
     expect(
         shape(&[], &["verify", "--scope", "project"]),
-        vec!["nothing installed"],
+        vec![
+            "<project>: 2 items declared, none in the install record and none checked",
+            "  - skill growth-guards",
+            "  - skill tidy",
+            "nothing checked",
+        ],
     );
 }
 

--- a/crates/cli/tests/unmanaged.rs
+++ b/crates/cli/tests/unmanaged.rs
@@ -143,6 +143,14 @@ fn content_nothing_declares_is_named_by_apply_and_by_verify() {
     assert!(planned.contains("not managed:"), "{planned}");
     assert!(planned.contains("shadcn"), "{planned}");
 
+    // Installed first, so the exit code below answers about the unmanaged
+    // tree and nothing else: verify refuses a scope that asks for packages
+    // and has no install record, and that refusal would stand in for this
+    // one. `--replace-unmanaged` clears the declaration `deploy` is blocked
+    // on and leaves the tree nothing declares exactly where it is.
+    let installed = kendex(home, &project, &["apply", "-y", "--replace-unmanaged"]);
+    assert!(installed.status.success(), "{installed:?}");
+
     let verified = kendex(home, &project, &["verify"]);
     assert!(verified.status.success(), "unmanaged content is not drift");
     let printed = said(&verified);

--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -62,7 +62,7 @@ pub(crate) use desired_agent::contributes_to_agent;
 pub use expansion::{NO_PER_PACKAGE_UPDATE, plans_per_package};
 pub use item_source::ItemSource;
 pub use observed::observed_rows;
-pub use planned::{PlannedDeclaration, planned_declarations};
+pub use planned::{PlannedDeclaration, planned_declarations, recorded_by_the_plan};
 pub use scoring::{ItemSafety, SafetyTarget};
 
 /// The conservative "cannot prove these bytes are our render" hold.

--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -186,7 +186,7 @@ pub fn plan_scope(
     let set_changes = set_changes(lock, &new_lock);
     let kept = kept_members(lock, &new_lock, &options.uninstalled_bundles);
     let repo_effects_leaving = repo_effects::leaving(env, scope, lock, &new_lock)?;
-    plan_lock_write(env, scope, disk_lock, new_lock, &mut ops)?;
+    plan_lock_write(env, scope, declared, disk_lock, new_lock, &mut ops)?;
     scope_notes.extend(scope_wide(scope, &mut ops)?);
 
     let mut report = EngineReport {

--- a/crates/core/src/engine/planned.rs
+++ b/crates/core/src/engine/planned.rs
@@ -77,38 +77,6 @@ fn held_by_requirer(
 /// derives from this graph: a pin that reaches an install through a bundle
 /// or a dependency parent is a hold on the member, and reading only the
 /// item's own `rev` would report a held package as unpinned drift.
-/// Whether a scope plan derives a lock entry for this kind, and so whether
-/// the record can ever hold one.
-///
-/// The same list as [`expansion::plans_per_package`], asked about the
-/// record rather than about updating one package on its own, and stated
-/// once for the reason that one is: the list never leaves this crate, and
-/// a surface holding its own copy is a second account of the same rule.
-/// It sits here because [`planned_declarations`] below is where the
-/// divergence shows — the walk covers `PLANNED_KINDS`, and Pi extensions
-/// are added after it by hand.
-///
-/// A Pi extension is the kind that answers no: `kendex update-pi` compares
-/// installed bytes against the source and writes the package itself, so no
-/// pass derives an entry for one however many the manifest declares. A
-/// plugin carries no content of its own, but the toggle that turns it on
-/// is derived and recorded like any other install.
-///
-/// Exhaustive on purpose: a kind added to the enum has to be classified
-/// here before this compiles, and a kind whose plan participation moves is
-/// one whose scope would otherwise lose its record.
-pub fn recorded_by_the_plan(kind: ItemKind) -> bool {
-    match kind {
-        ItemKind::PiExtension => false,
-        ItemKind::Skill
-        | ItemKind::Agent
-        | ItemKind::Hook
-        | ItemKind::Command
-        | ItemKind::McpServer
-        | ItemKind::Plugin => true,
-    }
-}
-
 pub fn planned_declarations(
     env: &Env,
     scope: &Scope,
@@ -149,4 +117,30 @@ pub fn planned_declarations(
         });
     }
     out
+}
+
+/// Whether a scope plan derives a lock entry for this kind, and so whether
+/// the record can ever hold one.
+///
+/// [`expansion::plans_per_package`] plus `Plugin`: a plugin toggle is
+/// derived and recorded like any other install, and is still not something
+/// one package of can be brought current on its own. A Pi extension is the
+/// kind that answers no here — `kendex update-pi` compares installed bytes
+/// against the source and writes the package itself, so no pass derives an
+/// entry for one however many the manifest declares.
+///
+/// Exhaustive on purpose. `PLANNED_KINDS` is an array, so a match is the
+/// only thing that makes a kind added to the enum fail to compile until it
+/// is classified, and a kind whose plan participation moves is one whose
+/// scope would otherwise lose its record.
+pub fn recorded_by_the_plan(kind: ItemKind) -> bool {
+    match kind {
+        ItemKind::PiExtension => false,
+        ItemKind::Skill
+        | ItemKind::Agent
+        | ItemKind::Hook
+        | ItemKind::Command
+        | ItemKind::McpServer
+        | ItemKind::Plugin => true,
+    }
 }

--- a/crates/core/src/engine/planned.rs
+++ b/crates/core/src/engine/planned.rs
@@ -77,6 +77,38 @@ fn held_by_requirer(
 /// derives from this graph: a pin that reaches an install through a bundle
 /// or a dependency parent is a hold on the member, and reading only the
 /// item's own `rev` would report a held package as unpinned drift.
+/// Whether a scope plan derives a lock entry for this kind, and so whether
+/// the record can ever hold one.
+///
+/// The same list as [`expansion::plans_per_package`], asked about the
+/// record rather than about updating one package on its own, and stated
+/// once for the reason that one is: the list never leaves this crate, and
+/// a surface holding its own copy is a second account of the same rule.
+/// It sits here because [`planned_declarations`] below is where the
+/// divergence shows — the walk covers `PLANNED_KINDS`, and Pi extensions
+/// are added after it by hand.
+///
+/// A Pi extension is the kind that answers no: `kendex update-pi` compares
+/// installed bytes against the source and writes the package itself, so no
+/// pass derives an entry for one however many the manifest declares. A
+/// plugin carries no content of its own, but the toggle that turns it on
+/// is derived and recorded like any other install.
+///
+/// Exhaustive on purpose: a kind added to the enum has to be classified
+/// here before this compiles, and a kind whose plan participation moves is
+/// one whose scope would otherwise lose its record.
+pub fn recorded_by_the_plan(kind: ItemKind) -> bool {
+    match kind {
+        ItemKind::PiExtension => false,
+        ItemKind::Skill
+        | ItemKind::Agent
+        | ItemKind::Hook
+        | ItemKind::Command
+        | ItemKind::McpServer
+        | ItemKind::Plugin => true,
+    }
+}
+
 pub fn planned_declarations(
     env: &Env,
     scope: &Scope,

--- a/crates/core/src/engine/planned.rs
+++ b/crates/core/src/engine/planned.rs
@@ -72,11 +72,19 @@ fn held_by_requirer(
         .then(|| by.name.clone())
 }
 
-/// The full planned set — declared items plus derived members and
-/// dependencies — with the revision each one effectively reads. Held-ness
-/// derives from this graph: a pin that reaches an install through a bundle
-/// or a dependency parent is a hold on the member, and reading only the
-/// item's own `rev` would report a held package as unpinned drift.
+/// Every package this scope reads from a source — declared items plus the
+/// members and dependencies they derive, plus Pi extensions — with the
+/// revision each one effectively reads. Held-ness derives from this graph:
+/// a pin that reaches an install through a bundle or a dependency parent
+/// is a hold on the member, and reading only the item's own `rev` would
+/// report a held package as unpinned drift.
+///
+/// Plugins are not in it, though [`recorded_by_the_plan`] says one is
+/// recorded. Every row here carries an `ItemDecl` naming the source it
+/// came from, and a plugin has no source: it is a switch in a settings
+/// file, declared with an enabled flag and a harness. A caller that wants
+/// the declarations rather than the packages reads the plugin table
+/// itself.
 pub fn planned_declarations(
     env: &Env,
     scope: &Scope,

--- a/crates/core/src/engine/scope_writes.rs
+++ b/crates/core/src/engine/scope_writes.rs
@@ -167,15 +167,15 @@ pub(super) fn source_revisions(
 }
 
 /// Whether the scope declares packages this pass derives no lock entry
-/// for, by the one account of that rule, [`recorded_by_the_plan`].
+/// for, asked through [`recorded_by_the_plan`].
 ///
-/// Their scope still needs the file. `verify`, edit detection and the
-/// sweep all read an absent record as an empty one and cannot tell the
-/// two apart, so none of them is the reason; what the file changes is
-/// that the verb stops reporting the scope up to date, that
-/// `discover::project_root_from` finds the marker it prefers when it
-/// resolves a project root, and that something on disk states which build
-/// wrote the record.
+/// Their scope still needs the file. Edit detection and the sweep read an
+/// absent record as an empty one and cannot tell the two apart, so neither
+/// of them is the reason. What the file changes is that the verb stops
+/// reporting the scope up to date, that `verify` stops refusing a scope it
+/// has no record of, that `discover::project_root_from` finds the marker
+/// it prefers when it resolves a project root, and that something on disk
+/// states which build wrote the record.
 ///
 /// A declaration switched off is still a declaration here. `enabled` is
 /// carried on the lock entry rather than deciding whether one exists —

--- a/crates/core/src/engine/scope_writes.rs
+++ b/crates/core/src/engine/scope_writes.rs
@@ -11,7 +11,7 @@ use crate::env::Env;
 use crate::error::Result;
 use crate::lock::{BundleRev, Lock, SourceRev, lock_path};
 use crate::manifest::Manifest;
-use crate::model::Scope;
+use crate::model::{ItemKind, Scope};
 use crate::source::SourceState;
 
 use super::config_edits;
@@ -165,30 +165,87 @@ pub(super) fn source_revisions(
     revisions
 }
 
+/// Whether installs of this kind happen outside the scope plan, so no
+/// entry for one can ever land in the record this pass builds.
+///
+/// Exhaustive on purpose: a kind added to the enum has to be classified
+/// here before this compiles, and a kind whose installs move out of the
+/// plan is one whose scope would otherwise lose its record.
+fn installs_outside_the_plan(kind: ItemKind) -> bool {
+    match kind {
+        // `kendex update-pi` compares installed bytes against the source
+        // and writes the package itself. Nothing about one is derived,
+        // planned or recorded here.
+        ItemKind::PiExtension => true,
+        // A plugin carries no content of its own, but the toggle that
+        // turns it on is planned and recorded like any other install.
+        ItemKind::Plugin => false,
+        ItemKind::Skill
+        | ItemKind::Agent
+        | ItemKind::Hook
+        | ItemKind::Command
+        | ItemKind::McpServer => false,
+    }
+}
+
+/// Whether the scope declares packages no plan can put in the record.
+/// Their scope still needs the file: it is what says which build wrote
+/// the record, and what verify, edit detection and the sweep key off.
+fn declares_unplanned_installs(manifest: &Manifest) -> bool {
+    ItemKind::ALL
+        .iter()
+        .any(|kind| installs_outside_the_plan(*kind) && !manifest.declared(*kind).is_empty())
+}
+
 /// An old-version lock rewrites even when its entries are unchanged — the
 /// version bump is itself the change. So does a source that now resolves to
 /// another commit, once there are installations to reproduce: with nothing
 /// installed there is no record to keep, and no lock file is created for
 /// one.
+///
+/// A scope declaring packages the plan never records gets the file back
+/// whatever its entries come out as. Nothing about a Pi extension is
+/// planned, so a scope declaring only those derives an empty record,
+/// which matches the empty one an absent file reads as: without this the
+/// plan is empty, the verb says the scope is up to date, and no file
+/// lands for verify, edit detection or the sweep to key off. That is the
+/// state the version floor leaves behind once a person moves an older
+/// lock aside.
+///
+/// An install this pass refused is not one of those. Its kind is planned
+/// and would be recorded; there is simply nothing to record yet, and the
+/// run closes on the conflict rather than on a write.
 pub(super) fn plan_lock_write(
     env: &Env,
     scope: &Scope,
+    manifest: &Manifest,
     lock: &Lock,
     new_lock: Lock,
     ops: &mut Vec<PlannedOp>,
 ) -> Result<()> {
-    if new_lock.entries == lock.entries
+    let unchanged = new_lock.entries == lock.entries
         && (new_lock.sources == lock.sources || new_lock.entries.is_empty())
         && (new_lock.bundles == lock.bundles || new_lock.entries.is_empty())
-        && (lock.version == crate::lock::LOCK_VERSION || lock.entries.is_empty())
-    {
+        && (lock.version == crate::lock::LOCK_VERSION || lock.entries.is_empty());
+    // Whether a file sits at the path is the one question left, and it is
+    // asked only where the answer can change what this does: reading it
+    // hashes the record, and a scope that has nothing to write and
+    // declares no unplanned install is done either way.
+    if unchanged && !declares_unplanned_installs(manifest) {
         return Ok(());
     }
     let path = lock_path(env, scope);
+    // The same read the write below binds to. An absent lock and an empty
+    // one read alike by this point, and only the file still tells them
+    // apart.
+    let pre = Pre::observed(&path)?;
+    if unchanged && !pre.binds_nothing() {
+        return Ok(());
+    }
     ops.push(PlannedOp {
         description: "Update the install record".into(),
         op: Op::WriteLock {
-            pre: crate::apply::Pre::observed(&path)?,
+            pre,
             path,
             lock: Box::new(new_lock),
         },

--- a/crates/core/src/engine/scope_writes.rs
+++ b/crates/core/src/engine/scope_writes.rs
@@ -16,6 +16,7 @@ use crate::source::SourceState;
 
 use super::config_edits;
 use super::desired::DesiredState;
+use super::planned::recorded_by_the_plan;
 
 /// Whether a plan already persists the manifest. A caller about to insert
 /// its own save must know: a second write to the same file binds to bytes
@@ -165,56 +166,45 @@ pub(super) fn source_revisions(
     revisions
 }
 
-/// Whether installs of this kind happen outside the scope plan, so no
-/// entry for one can ever land in the record this pass builds.
+/// Whether the scope declares packages this pass derives no lock entry
+/// for, by the one account of that rule, [`recorded_by_the_plan`].
 ///
-/// Exhaustive on purpose: a kind added to the enum has to be classified
-/// here before this compiles, and a kind whose installs move out of the
-/// plan is one whose scope would otherwise lose its record.
-fn installs_outside_the_plan(kind: ItemKind) -> bool {
-    match kind {
-        // `kendex update-pi` compares installed bytes against the source
-        // and writes the package itself. Nothing about one is derived,
-        // planned or recorded here.
-        ItemKind::PiExtension => true,
-        // A plugin carries no content of its own, but the toggle that
-        // turns it on is planned and recorded like any other install.
-        ItemKind::Plugin => false,
-        ItemKind::Skill
-        | ItemKind::Agent
-        | ItemKind::Hook
-        | ItemKind::Command
-        | ItemKind::McpServer => false,
-    }
-}
-
-/// Whether the scope declares packages no plan can put in the record.
-/// Their scope still needs the file: it is what says which build wrote
-/// the record, and what verify, edit detection and the sweep key off.
-fn declares_unplanned_installs(manifest: &Manifest) -> bool {
+/// Their scope still needs the file. `verify`, edit detection and the
+/// sweep all read an absent record as an empty one and cannot tell the
+/// two apart, so none of them is the reason; what the file changes is
+/// that the verb stops reporting the scope up to date, that
+/// `discover::project_root_from` finds the marker it prefers when it
+/// resolves a project root, and that something on disk states which build
+/// wrote the record.
+///
+/// A declaration switched off is still a declaration here. `enabled` is
+/// carried on the lock entry rather than deciding whether one exists —
+/// a disabled agent installs and stays tracked — so the flag never
+/// decides whether a scope keeps a record.
+fn declares_unrecorded_installs(manifest: &Manifest) -> bool {
     ItemKind::ALL
         .iter()
-        .any(|kind| installs_outside_the_plan(*kind) && !manifest.declared(*kind).is_empty())
+        .any(|kind| !recorded_by_the_plan(*kind) && !manifest.declared(*kind).is_empty())
 }
 
 /// An old-version lock rewrites even when its entries are unchanged — the
 /// version bump is itself the change. So does a source that now resolves to
 /// another commit, once there are installations to reproduce: with nothing
-/// installed there is no record to keep, and no lock file is created for
-/// one.
+/// declared and nothing installed there is no record to keep, and no lock
+/// file is created for one.
 ///
-/// A scope declaring packages the plan never records gets the file back
-/// whatever its entries come out as. Nothing about a Pi extension is
-/// planned, so a scope declaring only those derives an empty record,
-/// which matches the empty one an absent file reads as: without this the
-/// plan is empty, the verb says the scope is up to date, and no file
-/// lands for verify, edit detection or the sweep to key off. That is the
-/// state the version floor leaves behind once a person moves an older
-/// lock aside.
+/// A scope declaring packages this pass derives no entry for gets the file
+/// back whatever its entries come out as. A Pi extension derives no lock
+/// entry, so a scope declaring only those derives an empty record, which
+/// matches the empty one an absent file reads as: without this the plan is
+/// empty, the verb reports the scope up to date, and nothing lands to stop
+/// it saying so, to mark the project root, or to state which build wrote
+/// the record. That is the state the version floor leaves behind once a
+/// person moves an older lock aside.
 ///
-/// An install this pass refused is not one of those. Its kind is planned
-/// and would be recorded; there is simply nothing to record yet, and the
-/// run closes on the conflict rather than on a write.
+/// An install this pass refused is not one of those. Its kind derives an
+/// entry and would be recorded; there is simply nothing to record yet, and
+/// the run closes on the conflict rather than on a write.
 pub(super) fn plan_lock_write(
     env: &Env,
     scope: &Scope,
@@ -230,8 +220,8 @@ pub(super) fn plan_lock_write(
     // Whether a file sits at the path is the one question left, and it is
     // asked only where the answer can change what this does: reading it
     // hashes the record, and a scope that has nothing to write and
-    // declares no unplanned install is done either way.
-    if unchanged && !declares_unplanned_installs(manifest) {
+    // declares nothing the plan leaves unrecorded is done either way.
+    if unchanged && !declares_unrecorded_installs(manifest) {
         return Ok(());
     }
     let path = lock_path(env, scope);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -497,7 +497,9 @@ lives in one capability table read by core and UI.
   A file from an older kendex is refused as unreadable, left byte-for-byte
   as written, with the move-it-aside-and-install-fresh remedy in the
   message; one from a newer kendex refuses to load for the same reason in
-  the other direction.
+  the other direction. The next `refresh` or `apply` writes the record
+  back, a scope whose declarations the plan derives no entry for — Pi
+  extensions — included.
 - **Permission intent is typed and never widens.** A source's tool
   allowlist survives parse, merge, and every renderer as
   `Unspecified | AllowOnly | DenyExtra`; explicit denies survive allowlist

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -497,9 +497,12 @@ lives in one capability table read by core and UI.
   A file from an older kendex is refused as unreadable, left byte-for-byte
   as written, with the move-it-aside-and-install-fresh remedy in the
   message; one from a newer kendex refuses to load for the same reason in
-  the other direction. The next `refresh` or `apply` writes the record
-  back, a scope whose declarations the plan derives no entry for — Pi
-  extensions — included.
+  the other direction. Both verbs error out while the refused file is still
+  at the path. Once an older one is moved aside, the next `refresh` or
+  `apply` writes the record back, a scope whose declarations the plan
+  derives no entry for — Pi extensions — included; `verify` meanwhile
+  refuses a scope that asks for packages and has no record, rather than
+  leaving it out of the count.
 - **Permission intent is typed and never widens.** A source's tool
   allowlist survives parse, merge, and every renderer as
   `Unspecified | AllowOnly | DenyExtra`; explicit denies survive allowlist

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -497,8 +497,8 @@ lives in one capability table read by core and UI.
   A file from an older kendex is refused as unreadable, left byte-for-byte
   as written, with the move-it-aside-and-install-fresh remedy in the
   message; one from a newer kendex refuses to load for the same reason in
-  the other direction. Both verbs error out while the refused file is still
-  at the path. Once an older one is moved aside, the next `refresh` or
+  the other direction. Both `refresh` and `apply` error out while the
+  refused file is still at the path. Once an older one is moved aside, the next `refresh` or
   `apply` writes the record back, a scope whose declarations the plan
   derives no entry for — Pi extensions — included; `verify` meanwhile
   refuses a scope that asks for packages and has no record, rather than


### PR DESCRIPTION
A scope declaring only Pi extensions lost its install record and every verb said it was fine. The documented v8→v9 remedy moves the old lock aside; on a scope whose declarations the engine plans, the next refresh rebuilds it. On the global scope's 17 Pi extensions, nothing ever did — `apply` printed "up to date", `refresh` skipped it, and `verify` dropped it from the checked count with no line naming the loss.

Closes KEN-952

## Done-when → what serves it

| Done-when | Files |
|---|---|
| A scope with declared items regains a version-9 lock on the next `refresh` / `apply`, or the verb refuses loudly — never "up to date" or a silent skip | `crates/core/src/engine/scope_writes.rs` (`plan_lock_write`, `declares_unrecorded_installs`), `crates/core/src/engine/planned.rs` (`recorded_by_the_plan`) |
| `verify` on a scope whose manifest declares items but whose record holds no entries names the gap instead of dropping the scope | `crates/cli/src/commands/verify.rs` (`run`, `declared_packages`, `print_gaps`) |
| A test covers the Pi-extension-only scope in both its project and global spellings | `crates/cli/tests/pi_extension_only_lock.rs`, `crates/cli/tests/presentation/snapshots.rs` |

## How it works

`plan_lock_write` used to early-return whenever the derived record matched the one it read, and an absent record reads as an empty one — so a scope whose every declaration is a kind the plan derives no entry for planned nothing and looked current. It now observes the lock path once and writes the record when the scope declares such a kind and no file is there. The read binds to the write, so a file appearing in between fails `PlanStale` rather than being clobbered, and once the record lands the scope settles to "up to date" on the next run.

`recorded_by_the_plan` is the single account of which kinds a plan derives an entry for. It is `plans_per_package` plus `Plugin` — a plugin toggle is recorded though it is not updatable one package at a time — and it stays an exhaustive match, so a new `ItemKind` fails to compile until it is classified.

`verify` names, under one headline, what a scope declares that its install record does not hold. The headline states the fact rather than a remedy, because the remedy differs per kind and rides on each name: a Pi extension is never in the record by design and `kendex update-pi` is what checks it, while a declaration the record could hold is one `kendex apply` records. The line does not change the count, which is a count of lock entries.

**Breaking.** `verify` exits non-zero on one state: the scope's lock file is absent while its manifest declares items — the state the version floor's move-it-aside remedy leaves behind. The predicate reads the manifest's declaration tables directly, so no source, catalog, or expansion can empty it, and the gate reads that manifest once per scope rather than separately from the declarations it prints, so a read failure cannot answer "this scope declares nothing" about a file it could not open.

## Review

Two review cycles over nine reviewer domains plus a cross-model lane, then six fix rounds and a cut: 22 items applied, 10 declined with the mechanism that disproves them.

The exit-code behaviour above is narrower than an earlier draft. That draft keyed the refusal on the expanded plan, and reviewers reproduced four causes where `verify` went permanently red with `to write one: kendex apply` while `apply` exited 0 saying "up to date" — a name absent from its source, a harness holding no such kind at the scope, a bundle whose catalog would not open, a catalog offering no set by that name. Rather than detect each, the refusal was cut back to the one state it can answer for, and the surrounding machinery — an unjudged ledger head, an asks-for-nothing versus could-not-enumerate distinction, a name filter on the gate, an unmanaged collection before the gate — was deleted rather than built.

Declined findings and their reasons are recorded on the issue, not carried here.

## Verification

- `cargo test --workspace` — green, run repeatedly across rounds and again after the size cut
- `preflight` clean, `tools/guard` exit 0, size-ratchet OK
- Must-fail controls, each mutation run and reverted: the write's restraint guard (`if unchanged && false` reddens two cases), the gap collection, the per-kind remedy suffixes, and the refusal predicate's plugin arm
- The gate's read-failure path was reproduced by flipping a manifest between mode 000 and 644 during `verify`: 7 fail-opens in 400 runs before the fix, 0 in 400 after

## Known gaps

- The `bundles` arm of the refusal predicate has no control. The branch had one and it was deleted in the size cut: with one control per Done-when surface, the refusal surface holds either the bundle case or the plugin case, and the plugin shape is the one an outside reviewer found. Deleting `|| !manifest.bundles.is_empty()` therefore reddens nothing.
- The `**Breaking:**` changelog entry carries no inline migration note, which `changelog.d/README.md` § Content asks for. Recorded as a decision, not an oversight.
- `--help` and the README still describe `verify`'s exit as drift-only.
- No benchmark harness exists in this repo, so the performance review's numbers are ad-hoc rather than a branch-vs-main baseline. The measured addition is one `expansion::expand` pass at p50 1.54 ms against the audit's 686 ms already paid per scope, and it is a strict subset of that audit's own work.

https://claude.ai/code/session_015UgzGfhBJarQ5h6JzC6xr1
