### PR TITLE
docs(KEN-1170): em dashes leave the two in-place project skills

### DIFF
--- a/.agents/skills/app-deploy/SKILL.md
+++ b/.agents/skills/app-deploy/SKILL.md
@@ -15,7 +15,7 @@ Problems with a kendex-owned skill go through `kendex report`; check ownership i
 # Release kendex
 
 1. Bump the workspace `version` in `Cargo.toml` and the version in
-   `crates/app/tauri.conf.json` — both must equal the tag minus the `v`,
+   `crates/app/tauri.conf.json`. Both must equal the tag minus the `v`,
    or the update feed no-ops or loops.
 2. Run `.agents/skills/growth-guards/scripts/changelog-entries --collate` to
    fold the `changelog.d` fragments into `CHANGELOG.md`'s `Unreleased`. A
@@ -24,14 +24,14 @@ Problems with a kendex-owned skill go through `kendex report`; check ownership i
    entries under a new `## [<version>] - <date>` heading, leaving an empty
    `## [Unreleased]` above it; confirm every breaking change carries its
    **Breaking** call-out and migration note.
-3. Commit with `GROWTH_GUARDS_CHANGELOG_COLLATE=1` — that declaration is
+3. Commit with `GROWTH_GUARDS_CHANGELOG_COLLATE=1`. That declaration is
    what makes `CHANGELOG.md` count as the entry this commit owes for the
    version bump under `crates/`, whose fragments the collator just deleted,
    and the `commit-msg` lane refuses the commit without it. Then tag
    `v<version>` and push the tag. CI builds each target and publishes a draft
    GitHub Release with CLI binaries, app bundles, and `feed.json` (details:
    `docs/RELEASING.md`).
-4. Review the draft, then publish it — publishing is what makes the
+4. Review the draft, then publish it. Publishing is what makes the
    version "latest" for self-update.
 
 Distro packaging (Arch, Fedora, Ubuntu…) would hook in after the draft

--- a/.agents/skills/kendex-issues/SKILL.md
+++ b/.agents/skills/kendex-issues/SKILL.md
@@ -29,18 +29,18 @@ are a defect.
 
 ## Loop (one turn)
 
-1. **PR watch** — `GH_REPO=vanillagreencom/kendex .agents/skills/review-gate/scripts/pr-watch.sh`.
+1. **PR watch**: `GH_REPO=vanillagreencom/kendex .agents/skills/review-gate/scripts/pr-watch.sh`.
    Silence + exit 0 = nothing needs you. Attention lines → act through the
    github skill. After a gate-green, also check `isInMergeQueue` +
    `autoMergeRequest` (GraphQL). Queue ejection is silent: re-arm once; a
-   second ejection is a flaky required suite — quarantine, never re-arm loops.
-2. **Poll Linear** — `linear.sh sync --reconcile`, then
+   second ejection is a flaky required suite. Quarantine, never re-arm loops.
+2. **Poll Linear**: `linear.sh sync --reconcile`, then
    `linear.sh cache issues list --state "Triage,Backlog,Todo,In Progress" --max`.
    Linear is the complete queue (GitHub→Linear sync is one-way); Triage holds
    the GitHub-synced arrivals. Cross-check `gh issue list --repo vanillagreencom/kendex --state open`:
-   an open GH issue whose Linear mirror is Done is residue — close it naming
-   the PR; one with no mirror means the sync broke — triage it from GitHub
-   and say so. Nothing on either surface → reschedule.
+   an open GH issue whose Linear mirror is Done is residue, so close it
+   naming the PR; one with no mirror means the sync broke, so triage it
+   from GitHub and say so. Nothing on either surface → reschedule.
 3. **Triage** each issue (below); run the fix cycle for each valid defect.
    Mutate on the issue's home surface: GH-mirrored issues (Linear body links
    the GH issue) are closed/commented on GitHub; Linear-native ones through
@@ -70,34 +70,34 @@ are a defect.
   never existed is a typo: close with the evidence; never ship a shim.
 - **Empty body** → ask for the concrete repro; leave open.
 
-## Fix cycle — load orch
+## Fix cycle: load orch
 
 orch owns every step. kendex-specific parameters:
 
 - **Delegate to**: `generalist` (shell/docs/skills), `rust` (crates/),
   `iced` (iced-rs). Tests required; relevant suite green
   (`bash skills/orch/tests/run-all.sh`, per-skill `tests/*.sh`, `cargo test --workspace`).
-- **Scope is the reported symptom** (dev skill § Engineering Rules: its two
-  exceptions — mechanical enablers ride, an armed defect is in scope). Expect
-  the fix to be about the size of its first commit.
-- **Fix direction**: determinism and tooling first — a deletion, a
-  short-circuit, or a script; added prose last. Skills are instructions,
+- **Scope is the reported symptom** (dev skill § Engineering Rules, plus its
+  two exceptions: mechanical enablers ride, an armed defect is in scope).
+  Expect the fix to be about the size of its first commit.
+- **Fix direction**: determinism and tooling first, meaning a deletion, a
+  short-circuit, or a script. Added prose last. Skills are instructions,
   not explanations; `tools/guard` refuses history and reasons in them.
 - **Size ratchet**: split at a seam. `RATCHET_RAISE=1` only when the added
-  lines are the fix itself and no seam exists — never for tests, docs,
+  lines are the fix itself and no seam exists, never for tests, docs,
   comments, or lines a review round asked for; the frozen classes (markdown
   and tests) refuse a raise whatever it says.
 - **Review must converge** (orch SKILL.md): a recurring defect class is
   fixed at its source, never per comment. A round that is only scope,
   test-coverage, or wording asks ends the review: reply, resolve, push
   nothing, merge through the gate. Replies are `Fixed in <sha>`,
-  `Declined: <reason>`, or `Tracked: KEN-<n>` (issue created first — the
-  gate rejects a tracking claim naming no issue). Never `--admin`.
-- **Review the diff yourself** before submit — the actual root cause, not a
-  plausible one. A stalled delegate: inspect its worktree, nudge once.
+  `Declined: <reason>`, or `Tracked: KEN-<n>` (issue created first, since
+  the gate rejects a tracking claim naming no issue). Never `--admin`.
+- **Review the diff yourself** before submit, finding the actual root cause,
+  not a plausible one. A stalled delegate: inspect its worktree, nudge once.
 - Findings and coupled defects disposition per orch
-  `references/finding-disposition.md` — the excluded classes ahead of the
-  defect fork, one reply form per thread.
+  `references/finding-disposition.md`. The excluded classes come ahead of
+  the defect fork, one reply form per thread.
 - Disjoint files → parallel; same file → sequence or bundle.
 - A required check that cannot be rerun gets a fresh head
   (`commit --amend --no-edit` + `push --force-with-lease`, never-shared
@@ -132,13 +132,13 @@ for a fail-open defect in a consumer gate or an owner ask.
 
 ### This skill's home
 
-Source: `.agents/skills/kendex-issues/SKILL.md` in the kendex checkout — the
+Source: `.agents/skills/kendex-issues/SKILL.md` in the kendex checkout, the
 real directory, declared `source = "in-place"` and installed project-scoped
 only. `git rev-parse --show-toplevel` prints that checkout's root from anywhere
 inside it. Edit it there; the per-harness links already point at it. Then
 run `kendex apply` from the root so the install record matches the edit;
 until you do, `kendex verify` reports the skill as changed since install.
-A `~/.agents/skills/kendex-issues` link is a collision — delete it.
+A `~/.agents/skills/kendex-issues` link is a collision. Delete it.
 
 ## Guardrails
 


### PR DESCRIPTION
## Summary
- Clears every em dash from `.agents/skills/app-deploy/SKILL.md` and `.agents/skills/kendex-issues/SKILL.md`, the two `source = "in-place"` project skills that sat outside KEN-1122's glob.
- Substitution follows KEN-1122's rule: a colon for section headings and bold list labels, a period or comma elsewhere. Two clauses were reordered where a bare comma would have read as a list.
- Both skills are in-place with no `skills/<name>/` source, so no render sync applies.

## Completed Issues
- Closes KEN-1170 - Em dashes go from the two in-place project skills

## Test Plan
- `grep -n '—'` over both files returns nothing.
- `tools/guard` exits 0 with no `guard:` lines.
- `preflight --base origin/main` reports clean.

Counts: the issue estimated 3 + 12 occurrences; the files held 3 + 14.

https://claude.ai/code/session_01QfFTtxwkaigK7NZPEyCQNN
