### PR TITLE
fix(KEN-1168): every write that reaches repo_effects reads the machine back

### DIFF
--- a/changelog.d/fixed/KEN-1168.md
+++ b/changelog.d/fixed/KEN-1168.md
@@ -1,1 +1,1 @@
-- A failed marketplace subscribe, install, repository effect, source toggle, unsubscribe, drift-report install, editor save or audit item action re-reads the machine like one that landed.
+- A failed install, subscribe, repository change, source toggle, unsubscribe, editor save or audit action re-reads the machine like one that landed, so Home and the audit stop counting removed copies.

--- a/changelog.d/fixed/KEN-1168.md
+++ b/changelog.d/fixed/KEN-1168.md
@@ -1,1 +1,1 @@
-- A failed marketplace install, source toggle, unsubscribe, editor save or audit item action re-reads the machine like one that landed, so Home and the audit stop counting copies already removed.
+- A failed marketplace subscribe, install, repository effect, source toggle, unsubscribe, drift-report install, editor save or audit item action re-reads the machine like one that landed.

--- a/changelog.d/fixed/KEN-1168.md
+++ b/changelog.d/fixed/KEN-1168.md
@@ -1,0 +1,1 @@
+- A failed marketplace install, source toggle, unsubscribe, editor save or audit item action re-reads the machine like one that landed, so Home and the audit stop counting copies already removed.

--- a/ui/src/components/harnesses/project-list.dom.test.tsx
+++ b/ui/src/components/harnesses/project-list.dom.test.tsx
@@ -67,7 +67,6 @@ beforeEach(() => {
     views: [view({ scope: "global" }, [])],
     auditing: false,
     auditedAt: Date.now(),
-    error: null,
     read: READ_LANDED,
     backgroundFailureAnnounced: false,
   });

--- a/ui/src/components/harnesses/project-list.tsx
+++ b/ui/src/components/harnesses/project-list.tsx
@@ -23,8 +23,8 @@ export function ProjectList() {
   useAuditOnMount();
   const result = useScanStore((s) => s.result);
   const views = useAuditStore((s) => s.views);
-  // The read's own error, not the store's shared `error`: item actions write the
-  // shared field too, and a failed adopt is not a failed audit.
+  // The audit read's own outcome: a failed adopt is not a failed audit, and
+  // says so through the problems dialog rather than this list.
   const auditFailure = useAuditStore((s) => s.read.error);
   const goToLibrary = useNavStore((s) => s.goToLibrary);
   const goToUnmanaged = useNavStore((s) => s.goToUnmanaged);

--- a/ui/src/components/marketplaces/repo-effects-dialog.dom.test.tsx
+++ b/ui/src/components/marketplaces/repo-effects-dialog.dom.test.tsx
@@ -23,7 +23,16 @@ import { mount, settle } from "@/test/dom";
 import { RepoEffectsDialog } from "./repo-effects-dialog";
 
 vi.mock("@/bindings", () => ({
-  commands: { repoEffectsApply: vi.fn() },
+  // The three reads a yes runs behind it: applying an effect runs the
+  // package's installer in the repository, so `lib/rescan.ts` reads the
+  // machine again whatever it answered. Nothing here is about what they
+  // find; unmocked they reject out of a promise nobody awaits.
+  commands: {
+    repoEffectsApply: vi.fn(),
+    scanMachine: vi.fn(),
+    auditAll: vi.fn(),
+    libraryProvenance: vi.fn(),
+  },
 }));
 vi.mock("sonner", () => ({
   toast: { success: vi.fn(), info: vi.fn(), error: vi.fn() },

--- a/ui/src/components/package/delete-dialog.dom.test.tsx
+++ b/ui/src/components/package/delete-dialog.dom.test.tsx
@@ -47,7 +47,6 @@ const openDialog = async (scopes: Scope[]) => {
       kind="skill"
       name="gh"
       scopes={scopes}
-      onGone={() => {}}
     />,
   );
   await settle();

--- a/ui/src/components/package/delete-dialog.tsx
+++ b/ui/src/components/package/delete-dialog.tsx
@@ -14,7 +14,6 @@ import { scopeKey } from "@/lib/scope";
 import { placeName } from "@/lib/update-groups";
 import { useAuditStore } from "@/stores/audit";
 import { originsFor, useProvenanceStore } from "@/stores/provenance";
-import { useScanStore } from "@/stores/scan";
 
 /** Every marketplace a deleted package can be had from again.
  *
@@ -75,22 +74,22 @@ function useReinstallNote(
  *  a reader, so it is one action here, and the dialog names every place it
  *  reaches before it runs. Per-place removal is on the Projects tab.
  *
- *  The page leaves only once the scan agrees the package is gone; a failed
- *  deletion shows its error instead. */
+ *  Whether the page then leaves is the page's own judgment, not this
+ *  dialog's: `package.tsx` navigates once the scan behind the removals
+ *  lands and no longer knows the package. This dialog closes and says what
+ *  a failed removal said, and nothing more. */
 export function DeleteDialog({
   open,
   onOpenChange,
   kind,
   name,
   scopes,
-  onGone,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   kind: ItemKind;
   name: string;
   scopes: Scope[];
-  onGone: () => void;
 }) {
   const { busy, removeItem } = useAuditStore();
   const note = useReinstallNote(kind, name, scopes, open);
@@ -112,12 +111,6 @@ export function DeleteDialog({
             if (!(await removeItem(scope, kind, name))) return;
           }
           onOpenChange(false);
-          const stillHere = useScanStore
-            .getState()
-            .result?.items.some(
-              (item) => item.kind === kind && item.name === name,
-            );
-          if (!stillHere) onGone();
         })();
       }}
     >

--- a/ui/src/components/package/package-safety.dom.test.tsx
+++ b/ui/src/components/package/package-safety.dom.test.tsx
@@ -111,7 +111,6 @@ beforeEach(() => {
     views: [],
     auditing: false,
     auditedAt: null,
-    error: null,
     read: READ_LANDED,
     backgroundFailureAnnounced: false,
   });

--- a/ui/src/lib/rescan.test.ts
+++ b/ui/src/lib/rescan.test.ts
@@ -45,7 +45,6 @@ beforeEach(() => {
     views: [],
     auditing: false,
     auditedAt: null,
-    error: null,
     read: READ_LANDED,
   });
 });

--- a/ui/src/lib/rescan.ts
+++ b/ui/src/lib/rescan.ts
@@ -17,10 +17,8 @@
 // The rule, for every write that reaches `repo_effects`: the machine is read
 // again once the write has been answered for, whatever it answered. No
 // caller carves itself out — a refusal is not an account of the disk, a
-// success is not a complete one, and the two reasons below say why no
-// predicate over the response is allowed to decide it. The buttons offering
-// to look again call [`rescanEverything`] directly, because nothing else
-// knows what changed.
+// success is not a complete one, and the two paragraphs below say why no
+// predicate over the response is allowed to decide it.
 //
 // A refusal is no account of what is on disk. `repo_effects::execute` runs
 // the leaving packages' uninstallers before the plan, so an `Undo` error
@@ -33,33 +31,35 @@
 // Nor is a success a complete account: `moved` covers the two states
 // `moving` counts, `removed` the other destructive one, and a dropped
 // rendering can answer with all three fields empty. So no predicate over
-// the response decides this, and a write that moved nothing pays one scan
-// and one forced audit rather than leaving a dated page.
+// the response decides this, and a write that moved nothing pays one read
+// rather than leaving a dated page.
 //
-// Two spellings carry the rule, and between them they are the set —
-// `grep -rnE "writingRepo\(|rescanEverything\(" ui/src` finds every one.
-// [`writingRepo`] below is the wrapper: it runs the command, hands the
-// answer to the caller, and reads the machine once the caller is done with
-// it — which is how the marketplace install, the source toggle, the
-// unsubscribe, the editor save and the audit's item actions cannot skip it,
-// and how a sixth of them will not either. The Updates page and the package
-// page spell it out instead, calling [`rescanEverything`] as the last step
-// of a `holdingBusy` block that runs whatever the apply answered:
-// `updates.ts`'s [`updateOne`] and [`updateRows`], `updates-edits.ts`'s
-// `run`, `updates-follow.ts`'s [`followSwitch`], and
-// `package-version-actions.ts`'s `afterChange`.
+// [`writingRepo`] carries the rule: a write that reaches `repo_effects` runs
+// its whole body inside it — the marketplace subscribe, install, repository
+// effect, source toggle and unsubscribe, the drift-report install, the
+// editor save, and the audit's item actions — and the read is asked for in a
+// `finally`, so a sixth of them cannot skip it and neither can a throw. The
+// Updates page spells the call out instead, running it whatever the apply
+// answered as the last step inside its own `holdingBusy`: `updates.ts`'s
+// [`updateOne`] and [`updateRows`], `updates-edits.ts`'s `run` and
+// `updates-follow.ts`'s [`followSwitch`]. The package page's
+// `package-version-actions.ts` `afterChange` is the same call unawaited,
+// after its own reload and outside any hold. Between them,
+// `grep -rnE "writingRepo\(|rescanEverything\(" ui/src` is the whole set.
 //
-// `settings.ts`'s [`setHarnessRoot`] is the one write that gates on its
-// answer and is right to: it saves the settings file and never reaches
-// `repo_effects`, so a save that failed left nothing on disk for a stale
-// page to report. It rescans on success because moving a tool's folder
-// changes which files the scan finds, not because a write might have
-// half-landed.
+// The rest of the direct callers are not writes at all, and each is right to
+// ask on its own terms: the Scan again buttons, because nothing else knows
+// what a person changed outside the app; `settings.ts`'s [`setHarnessRoot`]
+// and `settings-projects.ts`'s project register and unregister, because
+// moving a tool's folder or changing which projects are tracked changes
+// which files the scan finds and which scopes the audit reads — not because
+// a write might have half-landed. Those three save the settings file and
+// never reach `repo_effects`, so a save that failed left nothing on disk for
+// a stale page to report, and gating them on the answer is correct.
 //
-// Adding a project, dropping one, or moving a harness's folder changes
-// which scopes the audit reads, and a scope with no view of its own counts
-// zero unmanaged items — which is how a project card ends up hiding the
-// only way to the ones it holds.
+// A scope with no view of its own counts zero unmanaged items, which is how
+// a project card ends up hiding the only way to the ones it holds — the
+// reason the registry writes above rescan at all.
 import { useAuditStore } from "@/stores/audit";
 import { useProvenanceStore } from "@/stores/provenance";
 import { useScanStore } from "@/stores/scan";
@@ -83,29 +83,77 @@ export async function rescanEverything(opts?: {
   ]);
 }
 
-/** Run a write that reaches `repo_effects` and read the machine again once
- *  it has been answered for.
+// The read behind the writes, and how many of them one read answers for.
+//
+// A page of writes goes out one at a time — `adopt-all.ts` over every
+// unmanaged item, the delete dialog over every scope a package lives in,
+// the package page's every-scope toggle — and a machine-wide read per item
+// is seconds of work per item, all of it answering the same question. So
+// one read runs at a time and exactly one waits behind it: a request that
+// arrives under a running read joins the follow-up rather than stacking
+// another identical read. A run of writes then pays for as many reads as
+// finish alongside it, never one per write.
+//
+// The guarantee is not weakened by that. A read already running may have
+// passed the files this write just changed, so it is never handed back as
+// this write's answer — the follow-up it joins starts only once that one
+// has finished, which is after this write landed. Every write is still
+// covered by a read that began after it.
+//
+// The audit store keeps a queue of the same shape for the same reason, and
+// the scan store drops an overlapping request outright. Neither can stand in
+// for this: both are asked by background readers and buttons too, and this
+// is about the writes.
+let running: Promise<void> | null = null;
+let queued: Promise<void> | null = null;
+
+const start = (): Promise<void> => {
+  const run = rescanEverything().finally(() => {
+    if (running === run) running = null;
+  });
+  running = run;
+  return run;
+};
+
+const readBehindWrites = (): Promise<void> => {
+  if (!running) return start();
+  queued ??= running.then(() => {
+    queued = null;
+    return start();
+  });
+  return queued;
+};
+
+/** Run a write that reaches `repo_effects` and read the machine again
+ *  behind it.
  *
- *  `write` makes the call — and holds whatever busy flag its page already
- *  held over it, which is why the flag stays the caller's and is not taken
- *  over here. `answered` gets the answer the moment the engine gives it and
- *  does everything the caller does with it, refusal arm included: the toast,
- *  the state update, its own re-reads. Its value is this call's value, so a
- *  caller reporting a boolean or an outcome object still reports it.
+ *  `body` is the caller's whole action, unchanged: the command, its own
+ *  busy flag, the toast, the state update, the re-reads it does itself, on
+ *  the refusal arm as much as the landing one. Its value is this call's
+ *  value.
  *
- *  Then [`rescanEverything`], on the rule above: after `answered`, so the
- *  person hears the outcome without waiting on three machine-wide reads, and
- *  in a `finally`, so a caller that throws over the answer — or a transport
- *  failure that rejects instead of refusing, leaving nobody able to say what
- *  the engine got as far as — still reads the machine before the throw goes
- *  on up. */
-export async function writingRepo<T, R>(
-  write: () => Promise<T>,
-  answered: (answer: T) => R | Promise<R>,
-): Promise<R> {
+ *  The read is asked for in a `finally` — so a caller that throws over the
+ *  answer, or a transport failure that rejects instead of refusing, leaving
+ *  nobody able to say what the engine got as far as, still reads the machine
+ *  before the throw goes on up.
+ *
+ *  Asked for, not waited on. The caller's promise settles on `body`'s own
+ *  value, because a caller renders from it: the unsubscribe dialog draws its
+ *  refusal beside the button rather than as a toast, and holding that back
+ *  through a forced audit left a destructive button live, re-enabled, with
+ *  nothing under it saying the last press failed. [`rescansSettled`] is how
+ *  a test waits for what no caller waits for. */
+export async function writingRepo<R>(body: () => Promise<R>): Promise<R> {
   try {
-    return await answered(await write());
+    return await body();
   } finally {
-    await rescanEverything();
+    void readBehindWrites();
   }
+}
+
+/** Settle when no read behind a write is left outstanding. For tests: the
+ *  reads are deliberately not on any caller's promise, so nothing else in a
+ *  test can say when they have landed. */
+export async function rescansSettled(): Promise<void> {
+  for (let out = queued ?? running; out; out = queued ?? running) await out;
 }

--- a/ui/src/lib/rescan.ts
+++ b/ui/src/lib/rescan.ts
@@ -14,20 +14,13 @@
 // The join belongs here instead, where every write that already says "read
 // the machine again" refreshes it, including routes nobody has thought of.
 //
-// Call it after a write none of those reads has seen: an install, a
-// package coming current, a registry change. The buttons offering to look
-// again call it because nothing else knows what changed.
-//
-// The audit's item actions do not: each answers with the scope's fresh view
-// and refreshes the scan itself. The Follow-source flip does — it runs the
-// same apply an update does, so the bytes both reads answer for move under
-// it — and calls this once its own standing has landed.
-//
-// The writes on the Updates page and the package page call this whatever
-// their write answered: `updates.ts`'s [`updateOne`] and [`updateRows`],
-// `updates-edits.ts`'s `run`, `updates-follow.ts`'s [`followSwitch`], and
-// `package-version-actions.ts`'s `afterChange`. The reasoning lives here
-// rather than at each of them.
+// The rule, for every write that reaches `repo_effects`: the machine is read
+// again once the write has been answered for, whatever it answered. No
+// caller carves itself out — a refusal is not an account of the disk, a
+// success is not a complete one, and the two reasons below say why no
+// predicate over the response is allowed to decide it. The buttons offering
+// to look again call [`rescanEverything`] directly, because nothing else
+// knows what changed.
 //
 // A refusal is no account of what is on disk. `repo_effects::execute` runs
 // the leaving packages' uninstallers before the plan, so an `Undo` error
@@ -43,9 +36,25 @@
 // the response decides this, and a write that moved nothing pays one scan
 // and one forced audit rather than leaving a dated page.
 //
-// This speaks only for those five. The marketplace, source-toggle and
-// settings callers still return on the error before reaching here; whether
-// that is right is their own question.
+// Two spellings carry the rule, and between them they are the set —
+// `grep -rnE "writingRepo\(|rescanEverything\(" ui/src` finds every one.
+// [`writingRepo`] below is the wrapper: it runs the command, hands the
+// answer to the caller, and reads the machine once the caller is done with
+// it — which is how the marketplace install, the source toggle, the
+// unsubscribe, the editor save and the audit's item actions cannot skip it,
+// and how a sixth of them will not either. The Updates page and the package
+// page spell it out instead, calling [`rescanEverything`] as the last step
+// of a `holdingBusy` block that runs whatever the apply answered:
+// `updates.ts`'s [`updateOne`] and [`updateRows`], `updates-edits.ts`'s
+// `run`, `updates-follow.ts`'s [`followSwitch`], and
+// `package-version-actions.ts`'s `afterChange`.
+//
+// `settings.ts`'s [`setHarnessRoot`] is the one write that gates on its
+// answer and is right to: it saves the settings file and never reaches
+// `repo_effects`, so a save that failed left nothing on disk for a stale
+// page to report. It rescans on success because moving a tool's folder
+// changes which files the scan finds, not because a write might have
+// half-landed.
 //
 // Adding a project, dropping one, or moving a harness's folder changes
 // which scopes the audit reads, and a scope with no view of its own counts
@@ -72,4 +81,31 @@ export async function rescanEverything(opts?: {
     // put, which is what every reader already handles.
     useProvenanceStore.getState().reload(),
   ]);
+}
+
+/** Run a write that reaches `repo_effects` and read the machine again once
+ *  it has been answered for.
+ *
+ *  `write` makes the call — and holds whatever busy flag its page already
+ *  held over it, which is why the flag stays the caller's and is not taken
+ *  over here. `answered` gets the answer the moment the engine gives it and
+ *  does everything the caller does with it, refusal arm included: the toast,
+ *  the state update, its own re-reads. Its value is this call's value, so a
+ *  caller reporting a boolean or an outcome object still reports it.
+ *
+ *  Then [`rescanEverything`], on the rule above: after `answered`, so the
+ *  person hears the outcome without waiting on three machine-wide reads, and
+ *  in a `finally`, so a caller that throws over the answer — or a transport
+ *  failure that rejects instead of refusing, leaving nobody able to say what
+ *  the engine got as far as — still reads the machine before the throw goes
+ *  on up. */
+export async function writingRepo<T, R>(
+  write: () => Promise<T>,
+  answered: (answer: T) => R | Promise<R>,
+): Promise<R> {
+  try {
+    return await answered(await write());
+  } finally {
+    await rescanEverything();
+  }
 }

--- a/ui/src/lib/rescan.ts
+++ b/ui/src/lib/rescan.ts
@@ -99,16 +99,10 @@ const start = (): Promise<void> => {
 
 const readBehindWrites = (): Promise<void> => {
   if (!running) return start();
-  queued ??= running
-    // However the one in front ended. Clearing the slot only on fulfilment
-    // would leave a rejection sitting in it for the session: every later
-    // write arriving under a running read would join that dead promise and
-    // schedule no read of its own, silently.
-    .catch(() => {})
-    .then(() => {
-      queued = null;
-      return start();
-    });
+  queued ??= running.then(() => {
+    queued = null;
+    return start();
+  });
   return queued;
 };
 

--- a/ui/src/lib/rescan.ts
+++ b/ui/src/lib/rescan.ts
@@ -38,24 +38,26 @@
 // its whole body inside it — the marketplace subscribe, install, repository
 // effect, source toggle and unsubscribe, the drift-report install, the
 // editor save, and the audit's item actions — and the read is asked for in a
-// `finally`, so a sixth of them cannot skip it and neither can a throw. The
-// Updates page spells the call out instead, running it whatever the apply
-// answered as the last step inside its own `holdingBusy`: `updates.ts`'s
+// `finally`, so a ninth cannot skip it and neither can a throw. The Updates
+// page spells the call out instead, running it whatever the apply answered
+// as the last step inside its own `holdingBusy`: `updates.ts`'s
 // [`updateOne`] and [`updateRows`], `updates-edits.ts`'s `run` and
 // `updates-follow.ts`'s [`followSwitch`]. The package page's
-// `package-version-actions.ts` `afterChange` is the same call unawaited,
-// after its own reload and outside any hold. Between them,
-// `grep -rnE "writingRepo\(|rescanEverything\(" ui/src` is the whole set.
+// `package-version-actions.ts` `afterChange` makes the same call inside its
+// own busy block but does not await it, so nothing holds over the read.
+// Between them, `grep -rnE "writingRepo\(|rescanEverything\(" ui/src` is
+// the whole set.
 //
-// The rest of the direct callers are not writes at all, and each is right to
-// ask on its own terms: the Scan again buttons, because nothing else knows
-// what a person changed outside the app; `settings.ts`'s [`setHarnessRoot`]
-// and `settings-projects.ts`'s project register and unregister, because
-// moving a tool's folder or changing which projects are tracked changes
-// which files the scan finds and which scopes the audit reads — not because
-// a write might have half-landed. Those three save the settings file and
-// never reach `repo_effects`, so a save that failed left nothing on disk for
-// a stale page to report, and gating them on the answer is correct.
+// The rest of the direct callers are not the writes this rule is about —
+// none of them reaches `repo_effects` — and each is right to ask on its own
+// terms: the Scan again buttons, because nothing else knows what a person
+// changed outside the app; `settings.ts`'s [`setHarnessRoot`] and
+// `settings-projects.ts`'s project register and unregister, because moving a
+// tool's folder or changing which projects are tracked changes which files
+// the scan finds and which scopes the audit reads — not because a write
+// might have half-landed. Those three write the settings file and nothing
+// else, so one that failed left nothing on disk for a stale page to report,
+// and gating them on the answer is correct.
 //
 // A scope with no view of its own counts zero unmanaged items, which is how
 // a project card ends up hiding the only way to the ones it holds — the
@@ -94,16 +96,19 @@ export async function rescanEverything(opts?: {
 // another identical read. A run of writes then pays for as many reads as
 // finish alongside it, never one per write.
 //
-// The guarantee is not weakened by that. A read already running may have
-// passed the files this write just changed, so it is never handed back as
-// this write's answer — the follow-up it joins starts only once that one
-// has finished, which is after this write landed. Every write is still
-// covered by a read that began after it.
+// The guarantee survives that. A read already running may have passed the
+// files this write just changed, so it is never handed back as this write's
+// answer — the follow-up it joins starts only once that one has finished,
+// which is after this write landed.
 //
-// The audit store keeps a queue of the same shape for the same reason, and
-// the scan store drops an overlapping request outright. Neither can stand in
-// for this: both are asked by background readers and buttons too, and this
-// is about the writes.
+// It survives one level down too, for two of the three legs: the scan store
+// and the audit store each hold a queue of this same shape, so a leg that
+// finds its own read already out waits and takes a fresh one behind it
+// rather than being served the older answer. The provenance join is the
+// exception — `reload` has no such queue, and an older join can still land
+// over a newer one — tracked as KEN-1183. Neither store's queue can stand in
+// for this one: both are asked by background readers and buttons too, and
+// this is about the writes.
 let running: Promise<void> | null = null;
 let queued: Promise<void> | null = null;
 
@@ -117,10 +122,19 @@ const start = (): Promise<void> => {
 
 const readBehindWrites = (): Promise<void> => {
   if (!running) return start();
-  queued ??= running.then(() => {
-    queued = null;
-    return start();
-  });
+  queued ??= running
+    // However the one in front ended. The three reads each report their own
+    // failures, so there is nothing here to pass on, and no shipped path
+    // rejects at all — both stores go through `settled` and the join
+    // catches. Clearing the slot only on fulfilment would nonetheless
+    // strand the mechanism this whole change rests on: one rejection and
+    // every later write arriving under a running read joins a dead promise
+    // and schedules no read of its own, silently, for the session.
+    .catch(() => {})
+    .then(() => {
+      queued = null;
+      return start();
+    });
   return queued;
 };
 

--- a/ui/src/lib/rescan.ts
+++ b/ui/src/lib/rescan.ts
@@ -16,9 +16,7 @@
 //
 // The rule, for every write that reaches `repo_effects`: the machine is read
 // again once the write has been answered for, whatever it answered. No
-// caller carves itself out — a refusal is not an account of the disk, a
-// success is not a complete one, and the two paragraphs below say why no
-// predicate over the response is allowed to decide it.
+// caller carves itself out, for the two reasons below.
 //
 // A refusal is no account of what is on disk. `repo_effects::execute` runs
 // the leaving packages' uninstallers before the plan, so an `Undo` error
@@ -37,27 +35,23 @@
 // [`writingRepo`] carries the rule: a write that reaches `repo_effects` runs
 // its whole body inside it — the marketplace subscribe, install, repository
 // effect, source toggle and unsubscribe, the drift-report install, the
-// editor save, and the audit's item actions — and the read is asked for in a
-// `finally`, so a ninth cannot skip it and neither can a throw. The Updates
-// page spells the call out instead, running it whatever the apply answered
-// as the last step inside its own `holdingBusy`: `updates.ts`'s
-// [`updateOne`] and [`updateRows`], `updates-edits.ts`'s `run` and
-// `updates-follow.ts`'s [`followSwitch`]. The package page's
-// `package-version-actions.ts` `afterChange` makes the same call inside its
-// own busy block but does not await it, so nothing holds over the read.
-// Between them, `grep -rnE "writingRepo\(|rescanEverything\(" ui/src` is
+// editor save, and the audit's item actions — so a ninth cannot skip it.
+// The Updates page spells the call out instead, as the last step inside its
+// own `holdingBusy`: `updates.ts`'s [`updateOne`] and [`updateRows`],
+// `updates-edits.ts`'s `run` and `updates-follow.ts`'s [`followSwitch`].
+// The package page's `package-version-actions.ts` `afterChange` makes the
+// same call inside its busy block without awaiting it, so nothing holds
+// over the read. `grep -rnE "writingRepo\(|rescanEverything\(" ui/src` is
 // the whole set.
 //
-// The rest of the direct callers are not the writes this rule is about —
-// none of them reaches `repo_effects` — and each is right to ask on its own
-// terms: the Scan again buttons, because nothing else knows what a person
-// changed outside the app; `settings.ts`'s [`setHarnessRoot`] and
-// `settings-projects.ts`'s project register and unregister, because moving a
-// tool's folder or changing which projects are tracked changes which files
-// the scan finds and which scopes the audit reads — not because a write
-// might have half-landed. Those three write the settings file and nothing
-// else, so one that failed left nothing on disk for a stale page to report,
-// and gating them on the answer is correct.
+// The rest of the direct callers are not the writes this rule is about:
+// none of them reaches `repo_effects`. The Scan again buttons ask because
+// nothing else knows what a person changed outside the app;
+// `settings.ts`'s [`setHarnessRoot`] and `settings-projects.ts`'s project
+// register and unregister because moving a tool's folder or changing which
+// projects are tracked changes which files the scan finds and which scopes
+// the audit reads. Those three write the settings file and nothing else, so
+// gating them on the answer is correct.
 //
 // A scope with no view of its own counts zero unmanaged items, which is how
 // a project card ends up hiding the only way to the ones it holds — the
@@ -85,30 +79,13 @@ export async function rescanEverything(opts?: {
   ]);
 }
 
-// The read behind the writes, and how many of them one read answers for.
-//
-// A page of writes goes out one at a time — `adopt-all.ts` over every
-// unmanaged item, the delete dialog over every scope a package lives in,
-// the package page's every-scope toggle — and a machine-wide read per item
-// is seconds of work per item, all of it answering the same question. So
-// one read runs at a time and exactly one waits behind it: a request that
-// arrives under a running read joins the follow-up rather than stacking
-// another identical read. A run of writes then pays for as many reads as
-// finish alongside it, never one per write.
-//
-// The guarantee survives that. A read already running may have passed the
-// files this write just changed, so it is never handed back as this write's
-// answer — the follow-up it joins starts only once that one has finished,
-// which is after this write landed.
-//
-// It survives one level down too, for two of the three legs: the scan store
-// and the audit store each hold a queue of this same shape, so a leg that
-// finds its own read already out waits and takes a fresh one behind it
-// rather than being served the older answer. The provenance join is the
-// exception — `reload` has no such queue, and an older join can still land
-// over a newer one — tracked as KEN-1183. Neither store's queue can stand in
-// for this one: both are asked by background readers and buttons too, and
-// this is about the writes.
+// The read behind the writes. One runs at a time and exactly one waits: a
+// request arriving under a running read joins that follow-up, which starts
+// only once the running one has finished — so every write is answered by a
+// read that began after it, and a page of writes does not pay a whole-machine
+// read each. The scan and audit stores hold a queue of this shape for their
+// own leg; the provenance join has none, so an older join can still land
+// over a newer one — KEN-1183.
 let running: Promise<void> | null = null;
 let queued: Promise<void> | null = null;
 
@@ -123,13 +100,10 @@ const start = (): Promise<void> => {
 const readBehindWrites = (): Promise<void> => {
   if (!running) return start();
   queued ??= running
-    // However the one in front ended. The three reads each report their own
-    // failures, so there is nothing here to pass on, and no shipped path
-    // rejects at all — both stores go through `settled` and the join
-    // catches. Clearing the slot only on fulfilment would nonetheless
-    // strand the mechanism this whole change rests on: one rejection and
-    // every later write arriving under a running read joins a dead promise
-    // and schedules no read of its own, silently, for the session.
+    // However the one in front ended. Clearing the slot only on fulfilment
+    // would leave a rejection sitting in it for the session: every later
+    // write arriving under a running read would join that dead promise and
+    // schedule no read of its own, silently.
     .catch(() => {})
     .then(() => {
       queued = null;
@@ -141,22 +115,18 @@ const readBehindWrites = (): Promise<void> => {
 /** Run a write that reaches `repo_effects` and read the machine again
  *  behind it.
  *
- *  `body` is the caller's whole action, unchanged: the command, its own
- *  busy flag, the toast, the state update, the re-reads it does itself, on
- *  the refusal arm as much as the landing one. Its value is this call's
- *  value.
+ *  `body` is the caller's whole action unchanged — the command, its own busy
+ *  flag, the toast, the state update, its own re-reads — on the refusal arm
+ *  as much as the landing one, and its value is this call's value.
  *
- *  The read is asked for in a `finally` — so a caller that throws over the
- *  answer, or a transport failure that rejects instead of refusing, leaving
- *  nobody able to say what the engine got as far as, still reads the machine
- *  before the throw goes on up.
- *
- *  Asked for, not waited on. The caller's promise settles on `body`'s own
- *  value, because a caller renders from it: the unsubscribe dialog draws its
- *  refusal beside the button rather than as a toast, and holding that back
- *  through a forced audit left a destructive button live, re-enabled, with
- *  nothing under it saying the last press failed. [`rescansSettled`] is how
- *  a test waits for what no caller waits for. */
+ *  The read is asked for in a `finally`, so neither a caller throwing over
+ *  the answer nor a transport failure rejecting instead of refusing can skip
+ *  it. It is not awaited: the caller's promise settles on `body`'s value,
+ *  because a caller renders from it — the unsubscribe dialog draws its
+ *  refusal beside the button, and holding that back through a forced audit
+ *  left a destructive button live with nothing under it. So no hold covers
+ *  the read, and every busy window stays where its caller had it.
+ *  [`rescansSettled`] is how a test waits for what no caller waits for. */
 export async function writingRepo<R>(body: () => Promise<R>): Promise<R> {
   try {
     return await body();

--- a/ui/src/lib/rescan.ts
+++ b/ui/src/lib/rescan.ts
@@ -62,8 +62,8 @@ import { useScanStore } from "@/stores/scan";
 
 export async function rescanEverything(opts?: {
   /** Say so when the scan fails, however many times running. Somebody who
-   *  pressed a button is waiting on an answer and hears about it whatever
-   *  the last background scan already said; a rescan behind a write is not
+   *  pressed a button is waiting on an answer, so a scan this starts speaks
+   *  and one it joins re-opens the notice. A rescan behind a write is not
    *  waited on, and the scan store's own once-only notice covers it. */
   announce?: boolean;
 }): Promise<void> {

--- a/ui/src/pages/overview.test.tsx
+++ b/ui/src/pages/overview.test.tsx
@@ -42,7 +42,6 @@ const { stub, wrap } = vi.hoisted(() => {
     audit: {
       auditedAt: null as number | null,
       read: { status: "landed", error: null } as ReadState,
-      error: null as string | null,
     },
   };
   const wrap = <M extends object>(
@@ -113,7 +112,7 @@ beforeEach(() => {
   stub.scan = { result: null, error: null, scanning: false };
   stub.updates = { read: READ_LANDED, unreadable: [] };
   stub.market = { read: READ_LANDED };
-  stub.audit = { auditedAt: null, read: READ_LANDED, error: null };
+  stub.audit = { auditedAt: null, read: READ_LANDED };
 });
 
 // `result` starting null and staying null used to leave every section on
@@ -178,7 +177,7 @@ describe("Home when a later scan fails", () => {
 describe("Home when the update check fails", () => {
   it("says updates couldn't be checked in the attention list", () => {
     stub.scan = { result: scanned, error: null, scanning: false };
-    stub.audit = { auditedAt: Date.now(), read: READ_LANDED, error: null };
+    stub.audit = { auditedAt: Date.now(), read: READ_LANDED };
     stub.updates = { read: readFailed("no network"), unreadable: [] };
     expect(renderToStaticMarkup(<OverviewPage />)).toContain(
       esc(UPDATES_ATTENTION_TITLE),
@@ -187,7 +186,7 @@ describe("Home when the update check fails", () => {
 
   it("claims nothing when the check answered", () => {
     stub.scan = { result: scanned, error: null, scanning: false };
-    stub.audit = { auditedAt: Date.now(), read: READ_LANDED, error: null };
+    stub.audit = { auditedAt: Date.now(), read: READ_LANDED };
     expect(renderToStaticMarkup(<OverviewPage />)).not.toContain(
       esc(UPDATES_ATTENTION_TITLE),
     );
@@ -201,7 +200,7 @@ describe("Home when the update check fails", () => {
 describe("Home when a place cannot be read at all", () => {
   it("names the place with no update standing in the attention list", () => {
     stub.scan = { result: scanned, error: null, scanning: false };
-    stub.audit = { auditedAt: Date.now(), read: READ_LANDED, error: null };
+    stub.audit = { auditedAt: Date.now(), read: READ_LANDED };
     stub.updates = {
       read: READ_LANDED,
       unreadable: [
@@ -245,7 +244,6 @@ describe("Home when the audit fails", () => {
     stub.audit = {
       auditedAt: null,
       read: readFailed("audit crashed"),
-      error: "audit crashed",
     };
     const html = renderToStaticMarkup(<OverviewPage />);
     expect(html).toContain(esc(AUDIT_ATTENTION_TITLE));
@@ -258,7 +256,6 @@ describe("Home when the audit fails", () => {
     stub.audit = {
       auditedAt: null,
       read: readFailed("audit crashed"),
-      error: "audit crashed",
     };
     stub.updates = { read: readFailed("no network"), unreadable: [] };
     expect(renderToStaticMarkup(<OverviewPage />)).toContain(
@@ -270,22 +267,7 @@ describe("Home when the audit fails", () => {
   // row's gate could be anything at all and the suite would not notice.
   it("claims nothing when the audit answered clean", () => {
     stub.scan = { result: scanned, error: null, scanning: false };
-    stub.audit = { auditedAt: Date.now(), read: READ_LANDED, error: null };
-    expect(renderToStaticMarkup(<OverviewPage />)).not.toContain(
-      esc(AUDIT_ATTENTION_TITLE),
-    );
-  });
-
-  // Item actions write the store's shared `error`; only the read's own
-  // error — written by refresh alone — may put the couldn't-check row on
-  // Home.
-  it("does not blame the audit for a failed item action", () => {
-    stub.scan = { result: scanned, error: null, scanning: false };
-    stub.audit = {
-      auditedAt: Date.now(),
-      read: READ_LANDED,
-      error: "couldn't remove gh",
-    };
+    stub.audit = { auditedAt: Date.now(), read: READ_LANDED };
     expect(renderToStaticMarkup(<OverviewPage />)).not.toContain(
       esc(AUDIT_ATTENTION_TITLE),
     );

--- a/ui/src/pages/overview.tsx
+++ b/ui/src/pages/overview.tsx
@@ -37,9 +37,9 @@ export function OverviewPage() {
   // answer as much as the scan's.
   useAuditOnMount();
   const { result, error, scanning } = useScanStore();
-  // The read's own error, not the store's shared `error`: item actions
-  // write the shared field too, and a failed remove or adopt is not a
-  // failed audit.
+  // The audit read's own outcome, which is the only thing this row may
+  // speak for: a failed remove or adopt is not a failed audit, and reaches
+  // the person through the problems dialog instead.
   const auditError = useAuditStore((s) => s.read.error);
   const auditRefresh = useAuditStore((s) => s.refresh);
   const projectCount = useSettingsStore(

--- a/ui/src/pages/package.test.tsx
+++ b/ui/src/pages/package.test.tsx
@@ -638,6 +638,19 @@ describe("the package page's file actions", () => {
     ).toBe(false);
   });
 
+  // Delete takes every copy at once, and the dialog closes on its own the
+  // moment the removals answer. Leaving the page is this effect's alone to
+  // decide — the dialog used to keep a copy of the judgment, read off a
+  // scan taken before the removals, and it is gone.
+  it("leave with the page once the scan knows the package nowhere", async () => {
+    const back = vi.fn();
+    useNavStore.setState({ back });
+
+    await openPage(VG, [], {});
+
+    expect(back).toHaveBeenCalled();
+  });
+
   it("open the copy in the place the page names", async () => {
     // hyprtrade's copy is listed first, so a page that took the first
     // installation would open the wrong project's files.

--- a/ui/src/pages/package.tsx
+++ b/ui/src/pages/package.tsx
@@ -243,7 +243,6 @@ export function PackagePage() {
         kind={group.kind}
         name={group.name}
         scopes={groupScopes(group)}
-        onGone={back}
       />
     </div>
   );

--- a/ui/src/pages/unmanaged.tsx
+++ b/ui/src/pages/unmanaged.tsx
@@ -29,8 +29,8 @@ export function UnmanagedPage() {
   useAuditOnMount();
   const scope = useNavStore((s) => s.unmanagedScope);
   const views = useAuditStore((s) => s.views);
-  // The read's own error, not the store's shared `error`: item actions write the
-  // shared field too, and a failed adopt is not a failed audit.
+  // The audit read's own outcome: a failed adopt is not a failed audit, and
+  // says so through the problems dialog rather than this row.
   const auditFailure = useAuditStore((s) => s.read.error);
   const busy = useAuditStore((s) => s.busy);
   const adopt = useAuditStore((s) => s.adopt);

--- a/ui/src/stores/audit-items.ts
+++ b/ui/src/stores/audit-items.ts
@@ -82,47 +82,44 @@ export function auditRunner(
    *  re-read, which is the direction with nothing to lose. */
   attempted: () => void,
 ): Run {
+  // Every one of these reaches `repo_effects`, so the machine is read again
+  // whatever the command answered — `lib/rescan.ts` holds the rule, and the
+  // coalescing that keeps a page of them from paying one machine-wide read
+  // each. The fresh view an ok answer carries is this scope's alone, and a
+  // refusal carries none at all.
   const run: Run = (action, opts) =>
-    // Every one of these reaches `repo_effects`, so the machine is read
-    // again whatever the command answered — `lib/rescan.ts` holds the rule
-    // and the reasons. The fresh view an ok answer carries is this scope's
-    // alone, and a refusal carries none at all.
-    writingRepo(
-      async () => {
-        set({ busy: true });
+    writingRepo(async () => {
+      set({ busy: true });
+      attempted();
+      let response: Awaited<ReturnType<typeof action>>;
+      try {
+        response = await action();
+      } finally {
+        set({ busy: false });
         attempted();
-        try {
-          return await action();
-        } finally {
-          set({ busy: false });
-          attempted();
-        }
-      },
-      (response) => {
-        if (response.status === "ok") {
-          set({ views: replaceView(get().views, response.data) });
-          if (opts.successMessage) toast.success(opts.successMessage);
-          // What the removal ran in the repository, said whatever the action
-          // was called: every command here answers with the same view.
-          sayUndone(response.data.undone);
-          return true;
-        }
-        // The dialog and nowhere else. A copy in the store's `error` had no
-        // reader and now has no life either — the audit this call's rescan
-        // forces writes that same slot on its way in or out.
-        const retry: ErrorAction = {
-          label: "Retry",
-          onClick: () => void run(action, opts),
-        };
-        useProblemsStore.getState().showError({
-          title: opts.title,
-          message: response.error,
-          steps: opts.steps,
-          actions: [retry],
-        });
-        return false;
-      },
-    );
+      }
+      if (response.status === "ok") {
+        set({ views: replaceView(get().views, response.data) });
+        if (opts.successMessage) toast.success(opts.successMessage);
+        // What the removal ran in the repository, said whatever the action
+        // was called: every command here answers with the same view.
+        sayUndone(response.data.undone);
+        return true;
+      }
+      // The dialog and nowhere else: the audit store's `error` is gone, and
+      // the read behind this call answers for the machine either way.
+      const retry: ErrorAction = {
+        label: "Retry",
+        onClick: () => void run(action, opts),
+      };
+      useProblemsStore.getState().showError({
+        title: opts.title,
+        message: response.error,
+        steps: opts.steps,
+        actions: [retry],
+      });
+      return false;
+    });
   return run;
 }
 

--- a/ui/src/stores/audit-items.ts
+++ b/ui/src/stores/audit-items.ts
@@ -8,10 +8,10 @@ import {
 } from "@/bindings";
 import { adoptedToastLabel } from "@/lib/copy";
 import { replacedToastLabel } from "@/lib/copy-in-the-way";
+import { writingRepo } from "@/lib/rescan";
 import { sayUndone } from "@/lib/undone";
 import { replaceView } from "./audit-fold";
 import { type ErrorAction, useProblemsStore } from "./problems";
-import { useScanStore } from "./scan";
 
 /** Every action here answers whether it worked. Most callers only need the
  *  state update that comes with it; the ones running several in a row need
@@ -71,11 +71,7 @@ type Run = (action: AuditAction, opts: RunOpts) => Promise<boolean>;
 // for one row can stop at the first that did not instead of carrying on
 // against a page that is now wrong.
 export function auditRunner(
-  set: (partial: {
-    busy?: boolean;
-    views?: AuditView[];
-    error?: string | null;
-  }) => void,
+  set: (partial: { busy?: boolean; views?: AuditView[] }) => void,
   get: () => { views: AuditView[] },
   /** Called at both ends of a command attempt, however it ends. An attempt
    *  is a span, not a moment: each of these runs a plan before a step that
@@ -86,41 +82,47 @@ export function auditRunner(
    *  re-read, which is the direction with nothing to lose. */
   attempted: () => void,
 ): Run {
-  const run: Run = async (action, opts) => {
-    set({ busy: true });
-    attempted();
-    let response: Awaited<ReturnType<typeof action>>;
-    try {
-      response = await action();
-    } finally {
-      set({ busy: false });
-      attempted();
-    }
-    if (response.status === "ok") {
-      set({
-        views: replaceView(get().views, response.data),
-        error: null,
-      });
-      if (opts.successMessage) toast.success(opts.successMessage);
-      // What the removal ran in the repository, said whatever the action
-      // was called: every command here answers with the same view.
-      sayUndone(response.data.undone);
-      await useScanStore.getState().refresh();
-      return true;
-    }
-    set({ error: response.error });
-    const retry: ErrorAction = {
-      label: "Retry",
-      onClick: () => void run(action, opts),
-    };
-    useProblemsStore.getState().showError({
-      title: opts.title,
-      message: response.error,
-      steps: opts.steps,
-      actions: [retry],
-    });
-    return false;
-  };
+  const run: Run = (action, opts) =>
+    // Every one of these reaches `repo_effects`, so the machine is read
+    // again whatever the command answered — `lib/rescan.ts` holds the rule
+    // and the reasons. The fresh view an ok answer carries is this scope's
+    // alone, and a refusal carries none at all.
+    writingRepo(
+      async () => {
+        set({ busy: true });
+        attempted();
+        try {
+          return await action();
+        } finally {
+          set({ busy: false });
+          attempted();
+        }
+      },
+      (response) => {
+        if (response.status === "ok") {
+          set({ views: replaceView(get().views, response.data) });
+          if (opts.successMessage) toast.success(opts.successMessage);
+          // What the removal ran in the repository, said whatever the action
+          // was called: every command here answers with the same view.
+          sayUndone(response.data.undone);
+          return true;
+        }
+        // The dialog and nowhere else. A copy in the store's `error` had no
+        // reader and now has no life either — the audit this call's rescan
+        // forces writes that same slot on its way in or out.
+        const retry: ErrorAction = {
+          label: "Retry",
+          onClick: () => void run(action, opts),
+        };
+        useProblemsStore.getState().showError({
+          title: opts.title,
+          message: response.error,
+          steps: opts.steps,
+          actions: [retry],
+        });
+        return false;
+      },
+    );
   return run;
 }
 

--- a/ui/src/stores/audit.test.ts
+++ b/ui/src/stores/audit.test.ts
@@ -4,6 +4,7 @@ import type { AuditView } from "@/bindings";
 import { commands } from "@/bindings";
 import { ADOPTABLE } from "@/lib/adoptable";
 import { READ_LANDED } from "@/lib/read-state";
+import { rescansSettled } from "@/lib/rescan";
 import { useAuditStore } from "./audit";
 import { useProblemsStore } from "./problems";
 
@@ -42,7 +43,6 @@ describe("audit store refresh", () => {
     useAuditStore.setState({
       views: [],
       auditing: false,
-      error: null,
       read: READ_LANDED,
       busy: false,
       auditedAt: null,
@@ -70,7 +70,6 @@ describe("audit store refresh", () => {
 
     await useAuditStore.getState().refresh();
 
-    expect(useAuditStore.getState().error).toBe("ipc down");
     expect(useAuditStore.getState().read.error).toBe("ipc down");
     expect(useAuditStore.getState().auditing).toBe(false);
   });
@@ -227,7 +226,6 @@ describe("audit store run() actions", () => {
     useAuditStore.setState({
       views: [emptyView],
       auditing: false,
-      error: null,
       read: READ_LANDED,
       busy: false,
       auditedAt: null,
@@ -257,9 +255,9 @@ describe("audit store run() actions", () => {
     expect(dialog.open).toBe(true);
     expect(dialog.title).toBe("Couldn't remove lint");
     expect(dialog.message).toBe("disk is full");
-    // A failed item action is not a failed audit: the audit the rescan
-    // behind it forced answered, so nothing writes the signal Home's
-    // couldn't-check row reads.
+    // A failed item action is not a failed audit. `read` is the one signal
+    // left and only an audit writes it, so the refusal reaches the person
+    // through the dialog above and Home's couldn't-check row stays off.
     expect(useAuditStore.getState().read.error).toBeNull();
     expect(toast.error).not.toHaveBeenCalled();
   });
@@ -367,7 +365,6 @@ describe("an audit that lands after a command it cannot answer for", () => {
       // already holds.
       views: [emptyView],
       auditing: false,
-      error: null,
       read: READ_LANDED,
       busy: false,
       auditedAt: null,
@@ -522,6 +519,9 @@ describe("an audit that lands after a command it cannot answer for", () => {
     overlapping.land({ status: "ok", data: [stale] });
     await forced;
     await acting;
+    // The read behind the command is on no caller's promise, so it is
+    // waited for here rather than through the action.
+    await rescansSettled();
 
     expect(useAuditStore.getState().auditedAt).toBeNull();
 

--- a/ui/src/stores/audit.test.ts
+++ b/ui/src/stores/audit.test.ts
@@ -237,6 +237,12 @@ describe("audit store run() actions", () => {
       dialog: { open: false, title: "", steps: [], actions: [] },
     });
     vi.clearAllMocks();
+    // Every one of these actions reads the machine again behind itself, on
+    // `lib/rescan.ts`'s rule, and that read forces an audit of its own.
+    vi.mocked(commands.auditAll).mockResolvedValue({
+      status: "ok",
+      data: [emptyView],
+    });
   });
 
   it("shows the error modal with the backend message on a failed action, not silently", async () => {
@@ -251,9 +257,9 @@ describe("audit store run() actions", () => {
     expect(dialog.open).toBe(true);
     expect(dialog.title).toBe("Couldn't remove lint");
     expect(dialog.message).toBe("disk is full");
-    expect(useAuditStore.getState().error).toBe("disk is full");
-    // A failed item action is not a failed audit: only refresh may write
-    // the signal Home's couldn't-check row reads.
+    // A failed item action is not a failed audit: the audit the rescan
+    // behind it forced answered, so nothing writes the signal Home's
+    // couldn't-check row reads.
     expect(useAuditStore.getState().read.error).toBeNull();
     expect(toast.error).not.toHaveBeenCalled();
   });
@@ -378,25 +384,38 @@ describe("an audit that lands after a command it cannot answer for", () => {
     return { parked, land: (value: T) => land(value) };
   };
 
+  // Two parked audits, because every one of these commands now asks for one
+  // of its own: the reading that overlapped the attempt, and the forced one
+  // the rescan behind the command queues after it. Landing only the first
+  // is what the assertions are about — the second is landed at the end so
+  // the action can finish.
   it("keeps the command's view rather than putting the row back", async () => {
-    const audit = park<{ status: "ok"; data: AuditView[] }>();
-    vi.mocked(commands.auditAll).mockReturnValue(
-      audit.parked as ReturnType<typeof commands.auditAll>,
-    );
+    const overlapping = park<{ status: "ok"; data: AuditView[] }>();
+    const forced = park<{ status: "ok"; data: AuditView[] }>();
+    vi.mocked(commands.auditAll)
+      .mockReturnValueOnce(
+        overlapping.parked as ReturnType<typeof commands.auditAll>,
+      )
+      .mockReturnValue(forced.parked as ReturnType<typeof commands.auditAll>);
     vi.mocked(commands.removeItem).mockResolvedValue({
       status: "ok",
       data: settled,
     });
 
     const running = useAuditStore.getState().refresh();
-    await useAuditStore.getState().removeItem(globalScope, "hook", "lint");
-    audit.land({ status: "ok", data: [stale] });
+    const acting = useAuditStore
+      .getState()
+      .removeItem(globalScope, "hook", "lint");
+    overlapping.land({ status: "ok", data: [stale] });
     await running;
 
     expect(useAuditStore.getState().views).toEqual([settled]);
-    // Undated, so the next visit pays for a reading that can speak for
-    // what just happened instead of reusing one that cannot.
+    // Undated, so nothing reuses a reading that cannot speak for what just
+    // happened — the forced one behind it is still out.
     expect(useAuditStore.getState().auditedAt).toBeNull();
+
+    forced.land({ status: "ok", data: [settled] });
+    await acting;
   });
 
   // The two orderings the pair of marks exists for, each reachable on its
@@ -410,11 +429,13 @@ describe("an audit that lands after a command it cannot answer for", () => {
   // START of the attempt has fired, and it is what says this reading
   // cannot answer.
   it("drops a reading that landed while an attempt was still running", async () => {
-    const audit = park<{ status: "ok"; data: AuditView[] }>();
+    const overlapping = park<{ status: "ok"; data: AuditView[] }>();
     const command = park<{ status: "ok"; data: AuditView }>();
-    vi.mocked(commands.auditAll).mockReturnValue(
-      audit.parked as ReturnType<typeof commands.auditAll>,
-    );
+    vi.mocked(commands.auditAll)
+      .mockReturnValueOnce(
+        overlapping.parked as ReturnType<typeof commands.auditAll>,
+      )
+      .mockResolvedValue({ status: "ok", data: [settled] });
     vi.mocked(commands.removeItem).mockReturnValue(
       command.parked as ReturnType<typeof commands.removeItem>,
     );
@@ -423,7 +444,7 @@ describe("an audit that lands after a command it cannot answer for", () => {
     const acting = useAuditStore
       .getState()
       .removeItem(globalScope, "hook", "lint");
-    audit.land({ status: "ok", data: [stale] });
+    overlapping.land({ status: "ok", data: [stale] });
     await running;
 
     expect(useAuditStore.getState().views).toEqual([emptyView]);
@@ -437,7 +458,8 @@ describe("an audit that lands after a command it cannot answer for", () => {
   // begins, so that one cannot tell this reading apart. Only the mark at
   // the END of the attempt moves the counter under it.
   it("drops a reading an attempt finished under", async () => {
-    const audit = park<{ status: "ok"; data: AuditView[] }>();
+    const overlapping = park<{ status: "ok"; data: AuditView[] }>();
+    const forced = park<{ status: "ok"; data: AuditView[] }>();
     const command = park<{ status: "ok"; data: AuditView }>();
     vi.mocked(commands.removeItem).mockReturnValue(
       command.parked as ReturnType<typeof commands.removeItem>,
@@ -448,27 +470,32 @@ describe("an audit that lands after a command it cannot answer for", () => {
     // The attempt is under way before the audit is asked for.
     await Promise.resolve();
 
-    vi.mocked(commands.auditAll).mockReturnValue(
-      audit.parked as ReturnType<typeof commands.auditAll>,
-    );
+    vi.mocked(commands.auditAll)
+      .mockReturnValueOnce(
+        overlapping.parked as ReturnType<typeof commands.auditAll>,
+      )
+      .mockReturnValue(forced.parked as ReturnType<typeof commands.auditAll>);
     const running = useAuditStore.getState().refresh();
 
     command.land({ status: "ok", data: settled });
-    await acting;
-    audit.land({ status: "ok", data: [stale] });
+    overlapping.land({ status: "ok", data: [stale] });
     await running;
 
-    // The command's own view stands, undated so the next visit pays for a
-    // reading that can speak for what it did.
+    // The command's own view stands, undated — the forced audit behind the
+    // command is still out, and until it answers nothing may be reused.
     expect(useAuditStore.getState().views).toEqual([settled]);
     expect(useAuditStore.getState().auditedAt).toBeNull();
+
+    forced.land({ status: "ok", data: [settled] });
+    await acting;
   });
 
-  // Dropping the read is only half of it. The command installed its own
-  // scope and nothing re-read the rest, so a stamp left standing would hold
-  // the freshness window open over the very bytes the force was about — an
-  // editor save, say, with every score still quoting the state before it.
-  it("pays for the read it dropped instead of reusing the stamp", async () => {
+  // Dropping the read is only half of it. The audit the command's own rescan
+  // forces re-reads the rest and normally re-stamps — but it can fail, and
+  // then a stamp the dropped reading left standing would hold the freshness
+  // window open over the very bytes the command changed, with every score
+  // still quoting the state before it.
+  it("pays for the read it dropped when the forced one could not answer", async () => {
     vi.mocked(commands.auditAll).mockResolvedValue({
       status: "ok",
       data: [stale],
@@ -476,18 +503,27 @@ describe("an audit that lands after a command it cannot answer for", () => {
     await useAuditStore.getState().refresh();
     expect(useAuditStore.getState().auditedAt).not.toBeNull();
 
-    const audit = park<{ status: "ok"; data: AuditView[] }>();
-    vi.mocked(commands.auditAll).mockReturnValue(
-      audit.parked as ReturnType<typeof commands.auditAll>,
-    );
+    const overlapping = park<{ status: "ok"; data: AuditView[] }>();
+    vi.mocked(commands.auditAll)
+      .mockReturnValueOnce(
+        overlapping.parked as ReturnType<typeof commands.auditAll>,
+      )
+      // The audit the command's rescan forces cannot answer either, so
+      // nothing after the dropped reading re-stamps.
+      .mockResolvedValue({ status: "error", error: "audit crashed" });
     vi.mocked(commands.removeItem).mockResolvedValue({
       status: "ok",
       data: settled,
     });
     const forced = useAuditStore.getState().refresh({ force: true });
-    await useAuditStore.getState().removeItem(globalScope, "hook", "lint");
-    audit.land({ status: "ok", data: [stale] });
+    const acting = useAuditStore
+      .getState()
+      .removeItem(globalScope, "hook", "lint");
+    overlapping.land({ status: "ok", data: [stale] });
     await forced;
+    await acting;
+
+    expect(useAuditStore.getState().auditedAt).toBeNull();
 
     const dropped = vi.mocked(commands.auditAll).mock.calls.length;
     vi.mocked(commands.auditAll).mockResolvedValue({

--- a/ui/src/stores/audit.ts
+++ b/ui/src/stores/audit.ts
@@ -14,11 +14,12 @@ import { auditRunner, type ItemActions, itemActions } from "./audit-items";
 interface AuditState extends ItemActions {
   views: AuditView[];
   auditing: boolean;
-  /** Why the last item action failed, or null. */
+  /** Why the last audit failed, or null. An item action's own refusal goes
+   *  to the problems dialog and never here — the rescan behind every one of
+   *  them forces an audit that writes this slot regardless. */
   error: string | null;
-  /** How the last audit itself went. Kept apart from `error` above, which
-   *  item actions also write, so a failed remove or adopt never reads as a
-   *  machine that could not be checked. */
+  /** How that same audit went, as a read state: what Home's couldn't-check
+   *  row and every score on screen are dated by. */
   read: ReadState;
   busy: boolean;
   /** The startup audit has already toasted its failure — suppresses repeat
@@ -37,9 +38,10 @@ export const useAuditStore = create<AuditState>((set, get) => {
   // The rule, in the one place that can hold it: a reading is kept only
   // when no command attempt started or ended while it ran. Reading every
   // scope takes seconds, a command writes throughout its own run, and it
-  // may have written whatever it went on to answer. No item action forces
-  // an audit of its own — the runner refreshes the scan alone — so nothing
-  // else would correct a reading that put an adopted or removed row back.
+  // may have written whatever it went on to answer. The forced audit the
+  // runner's rescan asks for afterwards corrects a reading that put an
+  // adopted or removed row back; this is what keeps a background one that
+  // landed mid-attempt from being taken as current in the first place.
   const attempts = invalidations();
   const run = auditRunner(set, get, attempts.moved);
 

--- a/ui/src/stores/audit.ts
+++ b/ui/src/stores/audit.ts
@@ -14,10 +14,9 @@ import { auditRunner, type ItemActions, itemActions } from "./audit-items";
 interface AuditState extends ItemActions {
   views: AuditView[];
   auditing: boolean;
-  /** How the last audit went — its failure among the rest, and the only
-   *  signal anywhere for a failed audit: every reader that has to say "this
-   *  could not be checked" reads it and nothing else does. An item action's
-   *  own refusal is not an audit's, and goes to the problems dialog. */
+  /** How the last audit went, and the only signal that the audit itself
+   *  failed — `audit-counts.ts` pairs it with a place's own unreadable view,
+   *  the other channel. An item action's refusal is neither of them. */
   read: ReadState;
   busy: boolean;
   /** The startup audit has already toasted its failure — suppresses repeat

--- a/ui/src/stores/audit.ts
+++ b/ui/src/stores/audit.ts
@@ -14,10 +14,10 @@ import { auditRunner, type ItemActions, itemActions } from "./audit-items";
 interface AuditState extends ItemActions {
   views: AuditView[];
   auditing: boolean;
-  /** How the last audit went — its failure among the rest. The one signal
-   *  for it: Home's couldn't-check row, the Unmanaged and project lists and
-   *  the blocked-places read are all dated by this. An item action's own
-   *  refusal is not an audit's, and goes to the problems dialog instead. */
+  /** How the last audit went — its failure among the rest, and the only
+   *  signal anywhere for a failed audit: every reader that has to say "this
+   *  could not be checked" reads it and nothing else does. An item action's
+   *  own refusal is not an audit's, and goes to the problems dialog. */
   read: ReadState;
   busy: boolean;
   /** The startup audit has already toasted its failure — suppresses repeat

--- a/ui/src/stores/audit.ts
+++ b/ui/src/stores/audit.ts
@@ -14,12 +14,10 @@ import { auditRunner, type ItemActions, itemActions } from "./audit-items";
 interface AuditState extends ItemActions {
   views: AuditView[];
   auditing: boolean;
-  /** Why the last audit failed, or null. An item action's own refusal goes
-   *  to the problems dialog and never here — the rescan behind every one of
-   *  them forces an audit that writes this slot regardless. */
-  error: string | null;
-  /** How that same audit went, as a read state: what Home's couldn't-check
-   *  row and every score on screen are dated by. */
+  /** How the last audit went — its failure among the rest. The one signal
+   *  for it: Home's couldn't-check row, the Unmanaged and project lists and
+   *  the blocked-places read are all dated by this. An item action's own
+   *  refusal is not an audit's, and goes to the problems dialog instead. */
   read: ReadState;
   busy: boolean;
   /** The startup audit has already toasted its failure — suppresses repeat
@@ -38,10 +36,10 @@ export const useAuditStore = create<AuditState>((set, get) => {
   // The rule, in the one place that can hold it: a reading is kept only
   // when no command attempt started or ended while it ran. Reading every
   // scope takes seconds, a command writes throughout its own run, and it
-  // may have written whatever it went on to answer. The forced audit the
-  // runner's rescan asks for afterwards corrects a reading that put an
-  // adopted or removed row back; this is what keeps a background one that
-  // landed mid-attempt from being taken as current in the first place.
+  // may have written whatever it went on to answer. The read behind every
+  // item action forces an audit that corrects such a reading soon after —
+  // but it can fail, and nothing may show a reading that answers for a
+  // machine the command has since changed in the meantime.
   const attempts = invalidations();
   const run = auditRunner(set, get, attempts.moved);
 
@@ -76,11 +74,10 @@ export const useAuditStore = create<AuditState>((set, get) => {
           views: response.data,
           auditedAt: Date.now(),
           read: readOf(response),
-          error: null,
           backgroundFailureAnnounced: false,
         });
       } else {
-        set({ error: response.error, read: readOf(response) });
+        set({ read: readOf(response) });
         if (!get().backgroundFailureAnnounced) {
           toast.error(response.error);
           set({ backgroundFailureAnnounced: true });
@@ -103,7 +100,6 @@ export const useAuditStore = create<AuditState>((set, get) => {
     views: [],
     auditedAt: null,
     auditing: false,
-    error: null,
     read: READ_PENDING,
     busy: false,
     backgroundFailureAnnounced: false,

--- a/ui/src/stores/editor.ts
+++ b/ui/src/stores/editor.ts
@@ -8,10 +8,10 @@ import {
 } from "@/bindings";
 import { type Draft, emptyDraft } from "@/lib/editor-draft";
 
+import { writingRepo } from "@/lib/rescan";
 import { everyPlace, sameScope } from "@/lib/scope";
 import { settingsDraft, withEdit } from "@/lib/settings-rows";
 import { saying } from "@/lib/undone";
-import { useAuditStore } from "./audit";
 import {
   mergedPlaces,
   opening,
@@ -21,7 +21,6 @@ import {
   readPlace,
   recordedRead,
 } from "./editor-cache";
-import { useScanStore } from "./scan";
 import { useSettingsStore } from "./settings";
 
 export { openInventory } from "./editor-cache";
@@ -132,43 +131,45 @@ export const useEditorStore = create<EditorState>((set, get) => {
 
   const write = async (draft: Draft) => {
     const { scope, base, manifestDirty, settingsEdits, settings } = get();
-    set({ saving: true });
-    let response: Awaited<ReturnType<typeof commands.saveCustomize>>;
-    try {
-      response = await commands.saveCustomize(
-        scope,
-        manifestDirty ? { manifest: draft, base } : null,
-        settingsDraft(settingsEdits, settings),
-      );
-    } finally {
-      set({ saving: false });
-    }
-    if (response.status === "error") {
-      // Stale is a refusal, not a failure: the file changed outside this
-      // draft, and writing the draft would put the older file back. The
-      // draft cannot be merged, so the page offers the reload as a choice
-      // rather than taking the person's edits on its own. A refusal with
-      // something to say about the packages leaving answers `failed`
-      // instead, so nothing it said is dropped for the reload.
-      if (response.error.kind === "stale") {
-        set({ stale: true, error: null });
-      } else {
-        set({ error: response.error.message, stale: false });
-      }
-      return;
-    }
-    set({ error: null, stale: false });
-    // Saving a manifest that takes a package away owes the same account a
-    // removal does. Wired here rather than by the write the update commands
-    // share: the editor answers a refusal shape of its own and never goes
-    // through it.
-    saying(response);
-    await load();
-    // Forced: a save rewrote the manifest this scope renders from, so an
-    // audit inside its freshness window would keep every score answering
-    // for the files as they were before the edit.
-    await useAuditStore.getState().refresh({ force: true });
-    await useScanStore.getState().refresh();
+    // A save reaches `repo_effects`, so the machine is read again whatever
+    // it answered — `lib/rescan.ts` holds the rule and the reasons.
+    await writingRepo(
+      async () => {
+        set({ saving: true });
+        try {
+          return await commands.saveCustomize(
+            scope,
+            manifestDirty ? { manifest: draft, base } : null,
+            settingsDraft(settingsEdits, settings),
+          );
+        } finally {
+          set({ saving: false });
+        }
+      },
+      async (response) => {
+        if (response.status === "error") {
+          // Stale is a refusal, not a failure: the file changed outside this
+          // draft, and writing the draft would put the older file back. The
+          // draft cannot be merged, so the page offers the reload as a choice
+          // rather than taking the person's edits on its own. A refusal with
+          // something to say about the packages leaving answers `failed`
+          // instead, so nothing it said is dropped for the reload.
+          if (response.error.kind === "stale") {
+            set({ stale: true, error: null });
+          } else {
+            set({ error: response.error.message, stale: false });
+          }
+          return;
+        }
+        set({ error: null, stale: false });
+        // Saving a manifest that takes a package away owes the same account a
+        // removal does. Wired here rather than by the write the update
+        // commands share: the editor answers a refusal shape of its own and
+        // never goes through it.
+        saying(response);
+        await load();
+      },
+    );
   };
 
   return {

--- a/ui/src/stores/editor.ts
+++ b/ui/src/stores/editor.ts
@@ -132,44 +132,42 @@ export const useEditorStore = create<EditorState>((set, get) => {
   const write = async (draft: Draft) => {
     const { scope, base, manifestDirty, settingsEdits, settings } = get();
     // A save reaches `repo_effects`, so the machine is read again whatever
-    // it answered — `lib/rescan.ts` holds the rule and the reasons.
-    await writingRepo(
-      async () => {
-        set({ saving: true });
-        try {
-          return await commands.saveCustomize(
-            scope,
-            manifestDirty ? { manifest: draft, base } : null,
-            settingsDraft(settingsEdits, settings),
-          );
-        } finally {
-          set({ saving: false });
+    // it answered — `lib/rescan.ts` holds the rule and the reasons, the
+    // provenance join it refreshes included, which this used not to.
+    await writingRepo(async () => {
+      set({ saving: true });
+      let response: Awaited<ReturnType<typeof commands.saveCustomize>>;
+      try {
+        response = await commands.saveCustomize(
+          scope,
+          manifestDirty ? { manifest: draft, base } : null,
+          settingsDraft(settingsEdits, settings),
+        );
+      } finally {
+        set({ saving: false });
+      }
+      if (response.status === "error") {
+        // Stale is a refusal, not a failure: the file changed outside this
+        // draft, and writing the draft would put the older file back. The
+        // draft cannot be merged, so the page offers the reload as a choice
+        // rather than taking the person's edits on its own. A refusal with
+        // something to say about the packages leaving answers `failed`
+        // instead, so nothing it said is dropped for the reload.
+        if (response.error.kind === "stale") {
+          set({ stale: true, error: null });
+        } else {
+          set({ error: response.error.message, stale: false });
         }
-      },
-      async (response) => {
-        if (response.status === "error") {
-          // Stale is a refusal, not a failure: the file changed outside this
-          // draft, and writing the draft would put the older file back. The
-          // draft cannot be merged, so the page offers the reload as a choice
-          // rather than taking the person's edits on its own. A refusal with
-          // something to say about the packages leaving answers `failed`
-          // instead, so nothing it said is dropped for the reload.
-          if (response.error.kind === "stale") {
-            set({ stale: true, error: null });
-          } else {
-            set({ error: response.error.message, stale: false });
-          }
-          return;
-        }
-        set({ error: null, stale: false });
-        // Saving a manifest that takes a package away owes the same account a
-        // removal does. Wired here rather than by the write the update
-        // commands share: the editor answers a refusal shape of its own and
-        // never goes through it.
-        saying(response);
-        await load();
-      },
-    );
+        return;
+      }
+      set({ error: null, stale: false });
+      // Saving a manifest that takes a package away owes the same account a
+      // removal does. Wired here rather than by the write the update commands
+      // share: the editor answers a refusal shape of its own and never goes
+      // through it.
+      saying(response);
+      await load();
+    });
   };
 
   return {

--- a/ui/src/stores/marketplaces-install.ts
+++ b/ui/src/stores/marketplaces-install.ts
@@ -100,66 +100,61 @@ export function installActions(set: Set, get: Get): InstallActions {
       destination,
       delivery,
     }: InstallRequest) =>
-      writingRepo(
-        async () => {
-          set({ busy: true });
-          try {
-            return await commands.marketplaceInstall(
-              scope,
-              source,
-              items,
-              bundle,
-              destination ?? null,
-              false,
-              delivery?.harnesses ?? null,
-              delivery?.method ?? null,
-              // Empty is the answer, not the absence of one: an extra nobody
-              // ticked is not installed.
-              delivery?.optional ?? [],
-            );
-          } finally {
-            set({ busy: false });
-          }
-        },
-        (response) => {
-          if (response.status === "error") {
-            toast.error(response.error);
-            return false;
-          }
-          const target = destination ?? scope;
-          // The command answers with the refreshed package list for this
-          // subscription, so the table flips to Installed without a second
-          // query.
-          const key = catalogKey(subscription(target, source));
-          const { shown, withheld } = response.data.repoEffects;
-          set((state) => ({
-            packages: { ...state.packages, [key]: response.data.packages },
-            // Member states in every set this install touched moved with it,
-            // in the open set and in the list of sets alike.
-            ...droppedSetCaches(),
-            error: null,
-            // The files are in; what a package does to the repository is a
-            // second question, asked once the install is reported.
-            pendingEffects:
-              shown.length > 0 ? { scope: target, queue: shown } : null,
-          }));
-          const what = bundle
-            ? `the ${bundle} bundle`
-            : items.length === 1
-              ? items[0].name
-              : `${items.length} packages`;
-          toast.success(`Installed ${what}`);
-          // Whatever an install's plan took away, and what its uninstaller
-          // ran on the way out. Said, never asked about: the second question
-          // this dialog exists for is about arming, and this already
-          // happened.
-          sayUndone(response.data.undone);
-          for (const held of withheld) {
-            toast.info(repoEffectsWithheldToast(held.name, held.reason));
-          }
-          return true;
-        },
-      ),
+      writingRepo(async () => {
+        set({ busy: true });
+        let response: Awaited<ReturnType<typeof commands.marketplaceInstall>>;
+        try {
+          response = await commands.marketplaceInstall(
+            scope,
+            source,
+            items,
+            bundle,
+            destination ?? null,
+            false,
+            delivery?.harnesses ?? null,
+            delivery?.method ?? null,
+            // Empty is the answer, not the absence of one: an extra nobody
+            // ticked is not installed.
+            delivery?.optional ?? [],
+          );
+        } finally {
+          set({ busy: false });
+        }
+        if (response.status === "error") {
+          toast.error(response.error);
+          return false;
+        }
+        const target = destination ?? scope;
+        // The command answers with the refreshed package list for this
+        // subscription, so the table flips to Installed without a second query.
+        const key = catalogKey(subscription(target, source));
+        const { shown, withheld } = response.data.repoEffects;
+        set((state) => ({
+          packages: { ...state.packages, [key]: response.data.packages },
+          // Member states in every set this install touched moved with it,
+          // in the open set and in the list of sets alike.
+          ...droppedSetCaches(),
+          error: null,
+          // The files are in; what a package does to the repository is a
+          // second question, asked once the install is reported.
+          pendingEffects:
+            shown.length > 0 ? { scope: target, queue: shown } : null,
+        }));
+        const what = bundle
+          ? `the ${bundle} bundle`
+          : items.length === 1
+            ? items[0].name
+            : `${items.length} packages`;
+        toast.success(`Installed ${what}`);
+        // Whatever an install's plan took away, and what its uninstaller
+        // ran on the way out. Said, never asked about: the second question
+        // this dialog exists for is about arming, and this already happened.
+        sayUndone(response.data.undone);
+        for (const held of withheld) {
+          toast.info(repoEffectsWithheldToast(held.name, held.reason));
+        }
+        return true;
+      }),
 
     /** Run the installer of the package at the head of the line, here and
      *  now, and show its own last word: an installer that deliberately
@@ -167,46 +162,51 @@ export function installActions(set: Set, get: Get): InstallActions {
      *  it would tell the person the repository is armed when it is not.
      *  A failure is the one account of a possibly half-written repository,
      *  so it opens the error dialog rather than flashing past in a toast;
-     *  the line moves on either way, the package staying installed. */
+     *  the line moves on either way, the package staying installed. The
+     *  installer runs in the repository, which is a write like any other:
+     *  the machine is read again behind it whatever it said. Not behind an
+     *  empty line, which sends no command. */
     applyRepoEffect: async () => {
       const pending = get().pendingEffects;
       if (!pending) return false;
       const [head] = pending.queue;
-      set({ busy: true });
-      let response: Awaited<ReturnType<typeof commands.repoEffectsApply>>;
-      try {
-        response = await commands.repoEffectsApply(
-          pending.scope,
-          head.declared,
-        );
-      } finally {
-        set({ busy: false });
-      }
-      if (response.status === "error") {
-        useProblemsStore.getState().showError({
-          title: repoEffectsFailedTitle(head.name),
-          message: response.error,
-        });
+      return writingRepo(async () => {
+        set({ busy: true });
+        let response: Awaited<ReturnType<typeof commands.repoEffectsApply>>;
+        try {
+          response = await commands.repoEffectsApply(
+            pending.scope,
+            head.declared,
+          );
+        } finally {
+          set({ busy: false });
+        }
+        if (response.status === "error") {
+          useProblemsStore.getState().showError({
+            title: repoEffectsFailedTitle(head.name),
+            message: response.error,
+          });
+          advance();
+          return false;
+        }
         advance();
-        return false;
-      }
-      advance();
-      const { stdout, stderr } = response.data;
-      // The last line it printed, not the last element: relay keeps the
-      // installer's trailing blank lines, and an empty toast says nothing.
-      const summary = spoken(stdout) ?? spoken(stderr);
-      toast.success(summary ?? repoEffectsAppliedToast(head.name));
-      // An installer can exit clean and still have skipped its work — the
-      // reason, and what to do about it, go to stderr while the summary
-      // goes to stdout. A toast is one line, so the account a person has
-      // to act on gets the dialog the app opens for exactly that.
-      if (spoken(stderr) !== undefined) {
-        useProblemsStore.getState().showError({
-          title: repoEffectsSaidTitle(head.name),
-          message: [...stderr, ...stdout].join("\n"),
-        });
-      }
-      return true;
+        const { stdout, stderr } = response.data;
+        // The last line it printed, not the last element: relay keeps the
+        // installer's trailing blank lines, and an empty toast says nothing.
+        const summary = spoken(stdout) ?? spoken(stderr);
+        toast.success(summary ?? repoEffectsAppliedToast(head.name));
+        // An installer can exit clean and still have skipped its work — the
+        // reason, and what to do about it, go to stderr while the summary
+        // goes to stdout. A toast is one line, so the account a person has
+        // to act on gets the dialog the app opens for exactly that.
+        if (spoken(stderr) !== undefined) {
+          useProblemsStore.getState().showError({
+            title: repoEffectsSaidTitle(head.name),
+            message: [...stderr, ...stdout].join("\n"),
+          });
+        }
+        return true;
+      });
     },
 
     /** Leave the package installed and its effect unapplied — a state,

--- a/ui/src/stores/marketplaces-install.ts
+++ b/ui/src/stores/marketplaces-install.ts
@@ -18,7 +18,7 @@ import {
   repoEffectsSaidTitle,
   repoEffectsWithheldToast,
 } from "@/lib/copy-repo-effects";
-import { rescanEverything } from "@/lib/rescan";
+import { writingRepo } from "@/lib/rescan";
 import { sayUndone } from "@/lib/undone";
 import {
   catalogKey,
@@ -92,69 +92,74 @@ export function installActions(set: Set, get: Get): InstallActions {
   return {
     pendingEffects: null,
 
-    install: async ({
+    install: ({
       scope,
       source,
       items,
       bundle = null,
       destination,
       delivery,
-    }: InstallRequest) => {
-      set({ busy: true });
-      let response: Awaited<ReturnType<typeof commands.marketplaceInstall>>;
-      try {
-        response = await commands.marketplaceInstall(
-          scope,
-          source,
-          items,
-          bundle,
-          destination ?? null,
-          false,
-          delivery?.harnesses ?? null,
-          delivery?.method ?? null,
-          // Empty is the answer, not the absence of one: an extra nobody
-          // ticked is not installed.
-          delivery?.optional ?? [],
-        );
-      } finally {
-        set({ busy: false });
-      }
-      if (response.status === "error") {
-        toast.error(response.error);
-        return false;
-      }
-      const target = destination ?? scope;
-      // The command answers with the refreshed package list for this
-      // subscription, so the table flips to Installed without a second query.
-      const key = catalogKey(subscription(target, source));
-      const { shown, withheld } = response.data.repoEffects;
-      set((state) => ({
-        packages: { ...state.packages, [key]: response.data.packages },
-        // Member states in every set this install touched moved with it,
-        // in the open set and in the list of sets alike.
-        ...droppedSetCaches(),
-        error: null,
-        // The files are in; what a package does to the repository is a
-        // second question, asked once the install is reported.
-        pendingEffects:
-          shown.length > 0 ? { scope: target, queue: shown } : null,
-      }));
-      const what = bundle
-        ? `the ${bundle} bundle`
-        : items.length === 1
-          ? items[0].name
-          : `${items.length} packages`;
-      toast.success(`Installed ${what}`);
-      // Whatever an install's plan took away, and what its uninstaller
-      // ran on the way out. Said, never asked about: the second question
-      // this dialog exists for is about arming, and this already happened.
-      sayUndone(response.data.undone);
-      for (const held of withheld) {
-        toast.info(repoEffectsWithheldToast(held.name, held.reason));
-      }
-      await rescanEverything();
-      return true;
-    },
+    }: InstallRequest) =>
+      writingRepo(
+        async () => {
+          set({ busy: true });
+          try {
+            return await commands.marketplaceInstall(
+              scope,
+              source,
+              items,
+              bundle,
+              destination ?? null,
+              false,
+              delivery?.harnesses ?? null,
+              delivery?.method ?? null,
+              // Empty is the answer, not the absence of one: an extra nobody
+              // ticked is not installed.
+              delivery?.optional ?? [],
+            );
+          } finally {
+            set({ busy: false });
+          }
+        },
+        (response) => {
+          if (response.status === "error") {
+            toast.error(response.error);
+            return false;
+          }
+          const target = destination ?? scope;
+          // The command answers with the refreshed package list for this
+          // subscription, so the table flips to Installed without a second
+          // query.
+          const key = catalogKey(subscription(target, source));
+          const { shown, withheld } = response.data.repoEffects;
+          set((state) => ({
+            packages: { ...state.packages, [key]: response.data.packages },
+            // Member states in every set this install touched moved with it,
+            // in the open set and in the list of sets alike.
+            ...droppedSetCaches(),
+            error: null,
+            // The files are in; what a package does to the repository is a
+            // second question, asked once the install is reported.
+            pendingEffects:
+              shown.length > 0 ? { scope: target, queue: shown } : null,
+          }));
+          const what = bundle
+            ? `the ${bundle} bundle`
+            : items.length === 1
+              ? items[0].name
+              : `${items.length} packages`;
+          toast.success(`Installed ${what}`);
+          // Whatever an install's plan took away, and what its uninstaller
+          // ran on the way out. Said, never asked about: the second question
+          // this dialog exists for is about arming, and this already
+          // happened.
+          sayUndone(response.data.undone);
+          for (const held of withheld) {
+            toast.info(repoEffectsWithheldToast(held.name, held.reason));
+          }
+          return true;
+        },
+      ),
 
     /** Run the installer of the package at the head of the line, here and
      *  now, and show its own last word: an installer that deliberately

--- a/ui/src/stores/marketplaces-load.test.ts
+++ b/ui/src/stores/marketplaces-load.test.ts
@@ -7,6 +7,13 @@ vi.mock("@/bindings", () => ({
   commands: {
     marketplacesOverview: vi.fn(),
     marketplaceSubscribe: vi.fn(),
+    // Subscribing writes its report through `repo_effects`, so
+    // `lib/rescan.ts` reads the machine again behind it whatever it
+    // answered. Nothing here is about what those reads find; unmocked they
+    // reject out of a promise nobody awaits.
+    scanMachine: vi.fn(),
+    auditAll: vi.fn(),
+    libraryProvenance: vi.fn(),
   },
 }));
 vi.mock("sonner", () => ({

--- a/ui/src/stores/marketplaces-sources.ts
+++ b/ui/src/stores/marketplaces-sources.ts
@@ -18,20 +18,18 @@ type Set = (partial: object) => void;
 export function sourceActions(set: Set, get: () => Sources) {
   return {
     toggle: (scope: Scope, source: string, enabled: boolean) =>
-      writingRepo(
-        () => commands.sourceToggle(scope, source, enabled),
-        async (response) => {
-          if (response.status === "error") {
-            toast.error(response.error);
-            return;
-          }
-          sayUndone(response.data.undone);
-          // Turning a holder on or off changes which subscription a
-          // repository page carries on as, so every derived read goes.
-          dropCatalogCaches(set);
-          await get().load();
-        },
-      ),
+      writingRepo(async () => {
+        const response = await commands.sourceToggle(scope, source, enabled);
+        if (response.status === "error") {
+          toast.error(response.error);
+          return;
+        }
+        sayUndone(response.data.undone);
+        // Turning a holder on or off changes which subscription a repository
+        // page carries on as, so every derived read goes.
+        dropCatalogCaches(set);
+        await get().load();
+      }),
 
     checkForUpdates: async () => {
       set({ busy: true });

--- a/ui/src/stores/marketplaces-sources.ts
+++ b/ui/src/stores/marketplaces-sources.ts
@@ -4,7 +4,7 @@
 import { toast } from "sonner";
 import type { Scope } from "@/bindings";
 import { commands } from "@/bindings";
-import { rescanEverything } from "@/lib/rescan";
+import { writingRepo } from "@/lib/rescan";
 import { sayUndone } from "@/lib/undone";
 import { dropCatalogCaches } from "./marketplaces-shared";
 
@@ -17,19 +17,21 @@ type Set = (partial: object) => void;
 
 export function sourceActions(set: Set, get: () => Sources) {
   return {
-    toggle: async (scope: Scope, source: string, enabled: boolean) => {
-      const response = await commands.sourceToggle(scope, source, enabled);
-      if (response.status === "error") {
-        toast.error(response.error);
-        return;
-      }
-      sayUndone(response.data.undone);
-      // Turning a holder on or off changes which subscription a repository
-      // page carries on as, so every derived read goes.
-      dropCatalogCaches(set);
-      await get().load();
-      await rescanEverything();
-    },
+    toggle: (scope: Scope, source: string, enabled: boolean) =>
+      writingRepo(
+        () => commands.sourceToggle(scope, source, enabled),
+        async (response) => {
+          if (response.status === "error") {
+            toast.error(response.error);
+            return;
+          }
+          sayUndone(response.data.undone);
+          // Turning a holder on or off changes which subscription a
+          // repository page carries on as, so every derived read goes.
+          dropCatalogCaches(set);
+          await get().load();
+        },
+      ),
 
     checkForUpdates: async () => {
       set({ busy: true });

--- a/ui/src/stores/marketplaces.ts
+++ b/ui/src/stores/marketplaces.ts
@@ -13,7 +13,7 @@ import {
   readOf,
   readOrder,
 } from "@/lib/read-state";
-import { rescanEverything } from "@/lib/rescan";
+import { writingRepo } from "@/lib/rescan";
 import { settled } from "@/lib/settled";
 import { saying, sayUndone } from "@/lib/undone";
 import { catalogReads } from "./marketplaces-catalog-reads";
@@ -185,37 +185,40 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
     return get().install({ scope, source: outcome.name, items });
   },
 
-  unsubscribe: async (scope, source, keep, discardEdits) => {
-    set({ busy: true });
-    let response: Awaited<ReturnType<typeof commands.marketplaceUnsubscribe>>;
-    try {
-      response = await commands.marketplaceUnsubscribe(
-        scope,
-        source,
-        keep,
-        discardEdits,
-      );
-    } finally {
-      set({ busy: false });
-    }
-    if (response.status === "error") {
-      set({ error: response.error });
-      return { error: response.error };
-    }
-    set({ error: null });
-    toast.success(
-      keep
-        ? `Unsubscribed from '${source}' — its packages are yours now`
-        : `Unsubscribed from '${source}'`,
-    );
-    saying(response);
-    // A page carried on as this subscription must stop pointing at it, and
-    // every other derived read goes with it.
-    dropCatalogCaches(set);
-    await get().load();
-    await rescanEverything();
-    return { done: true };
-  },
+  unsubscribe: (scope, source, keep, discardEdits) =>
+    writingRepo(
+      async () => {
+        set({ busy: true });
+        try {
+          return await commands.marketplaceUnsubscribe(
+            scope,
+            source,
+            keep,
+            discardEdits,
+          );
+        } finally {
+          set({ busy: false });
+        }
+      },
+      async (response): Promise<UnsubscribeOutcome> => {
+        if (response.status === "error") {
+          set({ error: response.error });
+          return { error: response.error };
+        }
+        set({ error: null });
+        toast.success(
+          keep
+            ? `Unsubscribed from '${source}' — its packages are yours now`
+            : `Unsubscribed from '${source}'`,
+        );
+        saying(response);
+        // A page carried on as this subscription must stop pointing at it,
+        // and every other derived read goes with it.
+        dropCatalogCaches(set);
+        await get().load();
+        return { done: true };
+      },
+    ),
 
   ...sourceActions(set, get),
   ...installActions(set, get),

--- a/ui/src/stores/marketplaces.ts
+++ b/ui/src/stores/marketplaces.ts
@@ -133,35 +133,39 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
 
   ...catalogReads(set),
 
-  subscribe: async (scope, reference, name) => {
-    set({ busy: true });
-    let response: Awaited<ReturnType<typeof commands.marketplaceSubscribe>>;
-    try {
-      response = await commands.marketplaceSubscribe(scope, reference, name);
-    } finally {
-      set({ busy: false });
-    }
-    if (response.status === "error") {
-      // The dialog shows the refusal beside the input; no toast on top.
-      // The same words go back to the caller, which is the only way a
-      // caller may have them.
-      set({ error: response.error });
-      return { error: response.error };
-    }
-    set({ error: null });
-    toast.success(`Subscribed to '${response.data.name}'`);
-    for (const note of response.data.notes) toast.message(note);
-    sayUndone(response.data.undone);
-    // A repository page may now have a subscription to carry on as, under
-    // whatever spelling the dialog was submitted with; the dropped summaries
-    // re-read and the page picks it up.
-    dropCatalogCaches(set);
-    await get().load();
-    if (response.data.lead) {
-      await openLead(scope, response.data.name, response.data.lead);
-    }
-    return { name: response.data.name };
-  },
+  // The subscription's own report goes through `repo_effects::write`, which
+  // is why the outcome carries an account to say — so the machine is read
+  // again behind it like any other write. `lib/rescan.ts` holds the rule.
+  subscribe: (scope, reference, name) =>
+    writingRepo(async () => {
+      set({ busy: true });
+      let response: Awaited<ReturnType<typeof commands.marketplaceSubscribe>>;
+      try {
+        response = await commands.marketplaceSubscribe(scope, reference, name);
+      } finally {
+        set({ busy: false });
+      }
+      if (response.status === "error") {
+        // The dialog shows the refusal beside the input; no toast on top.
+        // The same words go back to the caller, which is the only way a
+        // caller may have them.
+        set({ error: response.error });
+        return { error: response.error };
+      }
+      set({ error: null });
+      toast.success(`Subscribed to '${response.data.name}'`);
+      for (const note of response.data.notes) toast.message(note);
+      sayUndone(response.data.undone);
+      // A repository page may now have a subscription to carry on as, under
+      // whatever spelling the dialog was submitted with; the dropped summaries
+      // re-read and the page picks it up.
+      dropCatalogCaches(set);
+      await get().load();
+      if (response.data.lead) {
+        await openLead(scope, response.data.name, response.data.lead);
+      }
+      return { name: response.data.name };
+    }),
 
   subscribeAndInstall: async (repo, items) => {
     // Personal, deliberately: the row that offered this install was not
@@ -186,39 +190,36 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
   },
 
   unsubscribe: (scope, source, keep, discardEdits) =>
-    writingRepo(
-      async () => {
-        set({ busy: true });
-        try {
-          return await commands.marketplaceUnsubscribe(
-            scope,
-            source,
-            keep,
-            discardEdits,
-          );
-        } finally {
-          set({ busy: false });
-        }
-      },
-      async (response): Promise<UnsubscribeOutcome> => {
-        if (response.status === "error") {
-          set({ error: response.error });
-          return { error: response.error };
-        }
-        set({ error: null });
-        toast.success(
-          keep
-            ? `Unsubscribed from '${source}' — its packages are yours now`
-            : `Unsubscribed from '${source}'`,
+    writingRepo(async () => {
+      set({ busy: true });
+      let response: Awaited<ReturnType<typeof commands.marketplaceUnsubscribe>>;
+      try {
+        response = await commands.marketplaceUnsubscribe(
+          scope,
+          source,
+          keep,
+          discardEdits,
         );
-        saying(response);
-        // A page carried on as this subscription must stop pointing at it,
-        // and every other derived read goes with it.
-        dropCatalogCaches(set);
-        await get().load();
-        return { done: true };
-      },
-    ),
+      } finally {
+        set({ busy: false });
+      }
+      if (response.status === "error") {
+        set({ error: response.error });
+        return { error: response.error };
+      }
+      set({ error: null });
+      toast.success(
+        keep
+          ? `Unsubscribed from '${source}' — its packages are yours now`
+          : `Unsubscribed from '${source}'`,
+      );
+      saying(response);
+      // A page carried on as this subscription must stop pointing at it, and
+      // every other derived read goes with it.
+      dropCatalogCaches(set);
+      await get().load();
+      return { done: true };
+    }),
 
   ...sourceActions(set, get),
   ...installActions(set, get),

--- a/ui/src/stores/problems.ts
+++ b/ui/src/stores/problems.ts
@@ -66,8 +66,8 @@ export function useProblems(): Problem[] {
  *  buttons behind these rows write to the filesystem. */
 export function useBlockedPlaces(): BlockedPlace[] | null {
   const views = useAuditStore((s) => s.views);
-  // The shared `error` is written by item actions too, so a failed keep or
-  // take-over must not read as a machine that could not be checked.
+  // The audit read's own outcome. A failed keep or take-over is not a
+  // machine that could not be checked — it opens this store's own dialog.
   const failure = useAuditStore((s) => s.read.error);
   return useMemo(() => blockedPlaces(views, failure), [views, failure]);
 }

--- a/ui/src/stores/scan.test.ts
+++ b/ui/src/stores/scan.test.ts
@@ -21,6 +21,17 @@ const emptyResult: ScanResult = {
   warnings: [],
 };
 
+/** A scan this test answers by hand, to hold one open. */
+const park = () => {
+  let land: (value: ScanAnswer) => void = () => {};
+  const promise = new Promise<ScanAnswer>((resolve) => {
+    land = resolve;
+  });
+  return { promise, land };
+};
+
+type ScanAnswer = Awaited<ReturnType<typeof commands.scanMachine>>;
+
 describe("scan store", () => {
   beforeEach(() => {
     useScanStore.setState({
@@ -85,10 +96,77 @@ describe("scan store", () => {
     expect(state.error).toBe("boom");
   });
 
-  it("ignores refresh while a scan is already running", async () => {
-    useScanStore.setState({ scanning: true });
-    await useScanStore.getState().refresh();
-    expect(commands.scanMachine).not.toHaveBeenCalled();
+  // What this reverses: a request arriving mid-scan used to be dropped
+  // outright — a silent no-op, nothing retrying — so the read behind a
+  // write went missing whenever any background scan was out, and the write
+  // is exactly what the scan already running cannot answer for. Home
+  // renders its inventory from this result.
+  it("takes a re-read behind a scan already running rather than dropping it", async () => {
+    const parked = park();
+    vi.mocked(commands.scanMachine)
+      .mockReturnValueOnce(parked.promise)
+      .mockResolvedValue({ status: "ok", data: emptyResult });
+
+    const running = useScanStore.getState().refresh();
+    const behind = useScanStore.getState().refresh();
+
+    expect(commands.scanMachine).toHaveBeenCalledTimes(1);
+
+    parked.land({ status: "ok", data: emptyResult });
+    await running;
+    await behind;
+
+    expect(commands.scanMachine).toHaveBeenCalledTimes(2);
+  });
+
+  it("queues exactly one re-read however many arrive under the scan", async () => {
+    const parked = park();
+    vi.mocked(commands.scanMachine)
+      .mockReturnValueOnce(parked.promise)
+      .mockResolvedValue({ status: "ok", data: emptyResult });
+
+    const running = useScanStore.getState().refresh();
+    const behind = [
+      useScanStore.getState().refresh(),
+      useScanStore.getState().refresh(),
+      useScanStore.getState().refresh(),
+    ];
+
+    parked.land({ status: "ok", data: emptyResult });
+    await running;
+    await Promise.all(behind);
+
+    // Three arrivals, one re-read: they join it rather than stacking
+    // identical whole-machine reads.
+    expect(commands.scanMachine).toHaveBeenCalledTimes(2);
+  });
+
+  // A scan that could not answer is the state most in need of the one
+  // behind it, and the slot has to be free again afterwards or the next
+  // overlapping request would join a spent promise.
+  it("re-reads behind a scan that failed, and again after that", async () => {
+    const parked = park();
+    vi.mocked(commands.scanMachine)
+      .mockReturnValueOnce(parked.promise)
+      .mockResolvedValue({ status: "ok", data: emptyResult });
+
+    const running = useScanStore.getState().refresh();
+    const behind = useScanStore.getState().refresh();
+    parked.land({ status: "error", error: "ipc closed" });
+    await running;
+    await behind;
+
+    expect(commands.scanMachine).toHaveBeenCalledTimes(2);
+
+    const second = park();
+    vi.mocked(commands.scanMachine).mockReturnValueOnce(second.promise);
+    const again = useScanStore.getState().refresh();
+    const alsoBehind = useScanStore.getState().refresh();
+    second.land({ status: "ok", data: emptyResult });
+    await again;
+    await alsoBehind;
+
+    expect(commands.scanMachine).toHaveBeenCalledTimes(4);
   });
 
   it("toasts a background failure once, then stays quiet on repeat silent retries", async () => {

--- a/ui/src/stores/scan.test.ts
+++ b/ui/src/stores/scan.test.ts
@@ -169,6 +169,21 @@ describe("scan store", () => {
     expect(commands.scanMachine).toHaveBeenCalledTimes(4);
   });
 
+  // The press's own `announce` dies with the slot's first queuer.
+  it("speaks for a press that joined a scan queued by something else", async () => {
+    useScanStore.setState({ backgroundFailureAnnounced: true });
+    const parked = park();
+    vi.mocked(commands.scanMachine)
+      .mockReturnValueOnce(parked.promise)
+      .mockResolvedValue({ status: "error", error: "the scan failed" });
+    const out = useScanStore.getState().refresh();
+    const silent = useScanStore.getState().refresh();
+    const press = useScanStore.getState().refresh({ announce: true });
+    parked.land({ status: "error", error: "the focus scan failed" });
+    await Promise.all([out, silent, press]);
+    expect(toast.error).toHaveBeenCalled();
+  });
+
   it("toasts a background failure once, then stays quiet on repeat silent retries", async () => {
     vi.mocked(commands.scanMachine).mockResolvedValue({
       status: "error",

--- a/ui/src/stores/scan.ts
+++ b/ui/src/stores/scan.ts
@@ -77,16 +77,13 @@ export const useScanStore = create<ScanState>((set, get) => {
     // reads.
     refresh: (opts) => {
       if (!inFlight) return start(opts);
-      queued ??= inFlight
-        // However the one in front ended. A scan that failed is said by
-        // `scan` above and is no reason to leave this request unread, and
-        // clearing the slot only on fulfilment would strand every later
-        // overlapping request for the session.
-        .catch(() => {})
-        .then(() => {
-          queued = null;
-          return start(opts);
-        });
+      // A joining caller gets the slot's opts, not its own, so re-arm the
+      // flag the toast runs on: a press cannot join a read into silence.
+      if (opts?.announce) set({ backgroundFailureAnnounced: false });
+      queued ??= inFlight.then(() => {
+        queued = null;
+        return start(opts);
+      });
       return queued;
     },
   };

--- a/ui/src/stores/scan.ts
+++ b/ui/src/stores/scan.ts
@@ -79,11 +79,9 @@ export const useScanStore = create<ScanState>((set, get) => {
       if (!inFlight) return start(opts);
       queued ??= inFlight
         // However the one in front ended. A scan that failed is said by
-        // `scan` above and is no reason to leave this request unread. No
-        // shipped path rejects — `settled` is what makes that true — and
-        // this covers it anyway, because clearing the slot only on
-        // fulfilment would strand every later overlapping request for the
-        // session, which is the wrong way for a queue to fail.
+        // `scan` above and is no reason to leave this request unread, and
+        // clearing the slot only on fulfilment would strand every later
+        // overlapping request for the session.
         .catch(() => {})
         .then(() => {
           queued = null;

--- a/ui/src/stores/scan.ts
+++ b/ui/src/stores/scan.ts
@@ -12,7 +12,7 @@ interface ScanState {
   lastScanAt: number | null;
   /** A background scan (startup, focus) has already toasted its failure —
    * suppresses repeat toasts on every silent retry until one succeeds. A
-   * user clicking "Scan again" always hears about it regardless. */
+   * press of "Scan again" re-opens it, so its window is said once. */
   backgroundFailureAnnounced: boolean;
   refresh: (opts?: { announce?: boolean }) => Promise<void>;
 }

--- a/ui/src/stores/scan.ts
+++ b/ui/src/stores/scan.ts
@@ -17,14 +17,16 @@ interface ScanState {
   refresh: (opts?: { announce?: boolean }) => Promise<void>;
 }
 
-export const useScanStore = create<ScanState>((set, get) => ({
-  result: null,
-  scanning: false,
-  error: null,
-  lastScanAt: null,
-  backgroundFailureAnnounced: false,
-  refresh: async (opts) => {
-    if (get().scanning) return;
+export const useScanStore = create<ScanState>((set, get) => {
+  // The scan in flight, and the one re-read waiting behind it. These are the
+  // truth about what is running, not the `scanning` flag: the flag says what
+  // to draw, and a request arriving mid-scan has to know whether there is
+  // something real to wait for. The audit store keeps the same pair for the
+  // same reason.
+  let inFlight: Promise<void> | null = null;
+  let queued: Promise<void> | null = null;
+
+  const scan = async (opts?: { announce?: boolean }): Promise<void> => {
     set({ scanning: true });
     // The flag comes down however the call ends: a rejected call that left
     // it up would skip every later scan for the session.
@@ -50,5 +52,44 @@ export const useScanStore = create<ScanState>((set, get) => ({
     } finally {
       set({ scanning: false });
     }
-  },
-}));
+  };
+
+  const start = (opts?: { announce?: boolean }): Promise<void> => {
+    const running = scan(opts).finally(() => {
+      if (inFlight === running) inFlight = null;
+    });
+    inFlight = running;
+    return running;
+  };
+
+  return {
+    result: null,
+    scanning: false,
+    error: null,
+    lastScanAt: null,
+    backgroundFailureAnnounced: false,
+
+    // A scan already out cannot answer for what has happened since it began
+    // reading — which is the whole of what a write behind it needs read. So
+    // an overlapping request is not dropped, as it was: it waits on the one
+    // running and takes a re-read behind it. Exactly one waits, a second
+    // arrival joining that one rather than stacking identical whole-machine
+    // reads.
+    refresh: (opts) => {
+      if (!inFlight) return start(opts);
+      queued ??= inFlight
+        // However the one in front ended. A scan that failed is said by
+        // `scan` above and is no reason to leave this request unread. No
+        // shipped path rejects — `settled` is what makes that true — and
+        // this covers it anyway, because clearing the slot only on
+        // fulfilment would strand every later overlapping request for the
+        // session, which is the wrong way for a queue to fail.
+        .catch(() => {})
+        .then(() => {
+          queued = null;
+          return start(opts);
+        });
+      return queued;
+    },
+  };
+});

--- a/ui/src/stores/settings-projects.ts
+++ b/ui/src/stores/settings-projects.ts
@@ -2,7 +2,7 @@
 // and the actions that add, drop and find them.
 import { toast } from "sonner";
 import { type AppSettings, commands, type SettingsRead } from "@/bindings";
-import { rescanEverything } from "@/lib/rescan";
+import { rescanEverything, writingRepo } from "@/lib/rescan";
 import { useProblemsStore } from "./problems";
 
 interface ProjectFields {
@@ -45,26 +45,30 @@ export function projectActions(
         toast.success(`Added ${path.split("/").pop()}`, {
           action: {
             label: "Add session drift report",
+            // The hook is applied before the command can answer either way,
+            // so a refusal comes back with it already on disk: the machine
+            // is read again whatever it said, on `lib/rescan.ts`'s rule.
             onClick: () => {
-              void commands
-                .installDriftHook({ scope: "project", root })
-                .then((result) => {
-                  if (result.status === "ok") {
-                    // False: the scope had other pending changes, so only the
-                    // declaration landed — nothing is applied unseen.
-                    toast.success(
-                      result.data
-                        ? "Drift report installed"
-                        : "Drift report added — run kendex apply in that project to install it",
-                    );
-                    void rescanEverything();
-                  } else {
-                    useProblemsStore.getState().showError({
-                      title: "Couldn't install the drift report",
-                      message: result.error,
-                    });
-                  }
+              void writingRepo(async () => {
+                const result = await commands.installDriftHook({
+                  scope: "project",
+                  root,
                 });
+                if (result.status === "ok") {
+                  // False: the scope had other pending changes, so only the
+                  // declaration landed — nothing is applied unseen.
+                  toast.success(
+                    result.data
+                      ? "Drift report installed"
+                      : "Drift report added — run kendex apply in that project to install it",
+                  );
+                } else {
+                  useProblemsStore.getState().showError({
+                    title: "Couldn't install the drift report",
+                    message: result.error,
+                  });
+                }
+              });
             },
           },
         });

--- a/ui/src/stores/write-rescan.test.ts
+++ b/ui/src/stores/write-rescan.test.ts
@@ -140,8 +140,11 @@ beforeEach(() => {
   useMarketplacesStore.setState({ busy: false, error: null });
 });
 
-/** What every case below asks: the machine was read again, both halves of
- *  it, behind a command that answered with a refusal. */
+/** What every case below asks: the machine was read again behind a command
+ *  that answered with a refusal. Two of the three reads, not all of them —
+ *  the provenance join answers false rather than throwing and no store
+ *  mocked here would tell a join that ran from one that could not, so it is
+ *  asserted through neither. */
 const readAgain = () => {
   expect(commands.scanMachine).toHaveBeenCalled();
   expect(commands.auditAll).toHaveBeenCalled();
@@ -351,6 +354,52 @@ describe("a write that reaches repo_effects and throws", () => {
     await rescansSettled();
 
     readAgain();
+  });
+});
+
+// The read behind a write is the only one that can answer for it: a scan
+// already out began reading before the write landed. Dropping the write's
+// own scan because one was in flight left Home's inventory — which renders
+// from that result — counting copies the write had just taken off disk,
+// with the footer saying "scanned just now" over it.
+describe("a write under a scan that was already out", () => {
+  it("still gets a scan of its own, behind the one running", async () => {
+    const focus = park<Awaited<ReturnType<typeof commands.scanMachine>>>();
+    vi.mocked(commands.scanMachine)
+      .mockReturnValueOnce(
+        focus.parked as ReturnType<typeof commands.scanMachine>,
+      )
+      .mockResolvedValue({
+        status: "ok",
+        data: {
+          items: [],
+          harnesses: [],
+          warnings: [],
+          missingProjects: [],
+        } as never,
+      });
+    vi.mocked(commands.removeItem).mockResolvedValue({
+      status: "ok",
+      data: view(scope),
+    });
+
+    // What App.tsx fires when the window comes back, unawaited.
+    void useScanStore.getState().refresh();
+    await useAuditStore.getState().removeItem(scope, "hook", "lint");
+
+    focus.land({
+      status: "ok",
+      data: {
+        items: [],
+        harnesses: [],
+        warnings: [],
+        missingProjects: [],
+      } as never,
+    });
+    await rescansSettled();
+
+    // The focus scan, and the write's own behind it.
+    expect(commands.scanMachine).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/ui/src/stores/write-rescan.test.ts
+++ b/ui/src/stores/write-rescan.test.ts
@@ -1,21 +1,15 @@
 // One rule, one wrapper: a command that reaches `repo_effects` reads the
-// machine again whatever it answered. `lib/rescan.ts` holds the rule and the
-// reason — the leaving packages' uninstallers run before the plan, so a
-// refusal comes back with what they did to the disk standing, and Home's
-// inventory and the audit scores would go on counting copies already gone.
+// machine again whatever it answered. `lib/rescan.ts` holds the rule and
+// the reason a refusal is no account of the disk.
 //
 // The refusal arm is what the first cases are about, and the wrapper cannot
 // tell it from the landing one. The landing arm is not where this file's
 // coverage was thin, but it was not whole either: the editor refreshed the
 // audit and the scan without the join, and an item action refreshed the scan
-// alone. `rescanEverything` sends three reads — `scanMachine`,
-// `auditAll` and `libraryProvenance`, the last through the provenance store
-// — so asking whether the first two were called is asking whether the rule
-// held. The join answers false rather than throwing and is asserted through
-// neither.
+// alone. `rescanEverything` sends three reads, and `readAgain` below says
+// which two of them every case asks about.
 //
-// Nothing waits on those reads: the wrapper settles the caller's promise on
-// its own answer, so `rescansSettled` is what a test waits on instead.
+// Nothing waits on those reads, so `rescansSettled` is what a test waits on.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuditView, Disclosure, Scope } from "@/bindings";
 import { commands } from "@/bindings";

--- a/ui/src/stores/write-rescan.test.ts
+++ b/ui/src/stores/write-rescan.test.ts
@@ -1,22 +1,34 @@
-// One rule, five write paths: a command that reaches `repo_effects` reads
-// the machine again whatever it answered. `lib/rescan.ts` holds the rule and
-// the reason — the leaving packages' uninstallers run before the plan, so a
+// One rule, one wrapper: a command that reaches `repo_effects` reads the
+// machine again whatever it answered. `lib/rescan.ts` holds the rule and the
+// reason — the leaving packages' uninstallers run before the plan, so a
 // refusal comes back with what they did to the disk standing, and Home's
 // inventory and the audit scores would go on counting copies already gone.
 //
-// The refusal arm is what this file is about: the landing arm has always
-// rescanned, and the mechanism these five now share cannot tell the two
-// apart. `scanMachine` and `auditAll` are the two commands `rescanEverything`
-// sends, so asking whether they were called is asking whether the rule held.
+// The refusal arm is what the first cases are about, and the wrapper cannot
+// tell it from the landing one. The landing arm is not where this file's
+// coverage was thin, but it was not whole either: the editor refreshed the
+// audit and the scan without the join, and an item action refreshed the scan
+// alone. `rescanEverything` sends three reads — `scanMachine`,
+// `auditAll` and `libraryProvenance`, the last through the provenance store
+// — so asking whether the first two were called is asking whether the rule
+// held. The join answers false rather than throwing and is asserted through
+// neither.
+//
+// Nothing waits on those reads: the wrapper settles the caller's promise on
+// its own answer, so `rescansSettled` is what a test waits on instead.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuditView, Disclosure, Scope } from "@/bindings";
 import { commands } from "@/bindings";
+import { ADOPTABLE } from "@/lib/adoptable";
 import { emptyDraft } from "@/lib/editor-draft";
 import { READ_LANDED } from "@/lib/read-state";
+import { rescansSettled } from "@/lib/rescan";
 import { useAuditStore } from "./audit";
 import { useEditorStore } from "./editor";
 import { useMarketplacesStore } from "./marketplaces";
 import { useProvenanceStore } from "./provenance";
 import { useScanStore } from "./scan";
+import { useSettingsStore } from "./settings";
 
 vi.mock("@/bindings", async (importOriginal) => ({
   // The generated constants stay real — the editor's empty draft is stamped
@@ -24,10 +36,18 @@ vi.mock("@/bindings", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/bindings")>()),
   commands: {
     marketplaceInstall: vi.fn(),
-    sourceToggle: vi.fn(),
+    marketplaceSubscribe: vi.fn(),
     marketplaceUnsubscribe: vi.fn(),
     marketplacesOverview: vi.fn(),
+    repoEffectsApply: vi.fn(),
+    sourceToggle: vi.fn(),
+    installDriftHook: vi.fn(),
+    registerProject: vi.fn(),
     saveCustomize: vi.fn(),
+    getManifest: vi.fn(),
+    editorInventory: vi.fn(),
+    getScopeSettings: vi.fn(),
+    adoptItem: vi.fn(),
     removeItem: vi.fn(),
     scanMachine: vi.fn(),
     auditAll: vi.fn(),
@@ -44,7 +64,47 @@ vi.mock("sonner", () => ({
   },
 }));
 
-const scope = { scope: "global" as const };
+const scope: Scope = { scope: "global" };
+
+const view = (at: Scope): AuditView => ({
+  scope: at,
+  drift: [],
+  plan: [],
+  notes: [],
+  warnings: [],
+  safety: [],
+  adoptable: ADOPTABLE,
+  exits: [],
+});
+
+const disclosure: Disclosure = {
+  declared: {
+    name: "guards",
+    root: "/home/me/app/.agents/skills/guards",
+    summary: "guards arms hooks",
+    writes: [".git/hooks/pre-commit"],
+    installer: "scripts/arm",
+    uninstaller: null,
+    removal: null,
+    notes: [],
+    companions: [],
+  },
+  name: "guards",
+  summary: "guards arms hooks",
+  writes: [{ path: "/home/me/app/.git/hooks/pre-commit", shared: true }],
+  companions: [],
+  notes: [],
+  undo: null,
+};
+
+/** A promise this test lands by hand, to hold a read open across a loop. */
+const park = <T>() => {
+  let land: (value: T) => void = () => {};
+  const parked = new Promise<T>((resolve) => {
+    land = resolve;
+  });
+  return { parked, land: (value: T) => land(value) };
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -72,12 +132,12 @@ beforeEach(() => {
     views: [],
     auditing: false,
     auditedAt: null,
-    error: null,
     read: READ_LANDED,
     busy: false,
     backgroundFailureAnnounced: false,
   });
   useProvenanceStore.setState({ rows: [], loaded: false });
+  useMarketplacesStore.setState({ busy: false, error: null });
 });
 
 /** What every case below asks: the machine was read again, both halves of
@@ -99,8 +159,26 @@ describe("a write that reaches repo_effects and is refused", () => {
       source: "kit",
       items: [{ kind: "skill", name: "gh" }],
     });
+    await rescansSettled();
 
     expect(landed).toBe(false);
+    readAgain();
+  });
+
+  // Subscribing writes its report through the one executor like any other,
+  // which is why the outcome carries an account to say.
+  it("reads the machine again behind a subscribe", async () => {
+    vi.mocked(commands.marketplaceSubscribe).mockResolvedValue({
+      status: "error",
+      error: "already subscribed",
+    });
+
+    const outcome = await useMarketplacesStore
+      .getState()
+      .subscribe(scope, "acme/kit", null);
+    await rescansSettled();
+
+    expect(outcome).toEqual({ error: "already subscribed" });
     readAgain();
   });
 
@@ -111,6 +189,7 @@ describe("a write that reaches repo_effects and is refused", () => {
     });
 
     await useMarketplacesStore.getState().toggle(scope, "kit", false);
+    await rescansSettled();
 
     // The refusal is honoured — the overview is not re-asked behind a write
     // that did not land — and the machine is still read again.
@@ -127,8 +206,59 @@ describe("a write that reaches repo_effects and is refused", () => {
     const outcome = await useMarketplacesStore
       .getState()
       .unsubscribe(scope, "kit", false, false);
+    await rescansSettled();
 
     expect(outcome).toEqual({ error: "the scope is busy" });
+    readAgain();
+  });
+
+  // The package's own installer runs in the repository, and a failure is by
+  // this action's own account a possibly half-written one.
+  it("reads the machine again behind a repository effect", async () => {
+    vi.mocked(commands.repoEffectsApply).mockResolvedValue({
+      status: "error",
+      error: "the installer exited 1",
+    });
+    useMarketplacesStore.setState({
+      pendingEffects: { scope, queue: [disclosure] },
+    });
+
+    const landed = await useMarketplacesStore.getState().applyRepoEffect();
+    await rescansSettled();
+
+    expect(landed).toBe(false);
+    readAgain();
+  });
+
+  // The drift hook is applied before the command can answer either way, so
+  // its refusal comes back with the hook already on disk.
+  it("reads the machine again behind a drift-report install", async () => {
+    const { toast } = await import("sonner");
+    vi.mocked(commands.registerProject).mockResolvedValue({
+      status: "ok",
+      data: { settings: { projects: ["/home/me/app"] }, base: null } as never,
+    });
+    await useSettingsStore.getState().registerProject("/home/me/app");
+    await rescansSettled();
+    // The registration's own read is not what this case is about.
+    vi.mocked(commands.scanMachine).mockClear();
+    vi.mocked(commands.auditAll).mockClear();
+
+    vi.mocked(commands.installDriftHook).mockResolvedValue({
+      status: "error",
+      error: "the hook folder is read-only",
+    });
+    // The offer is the toast's own action: pressed, as a person presses it.
+    const offer = vi.mocked(toast.success).mock.calls.at(-1)?.[1]?.action;
+    if (typeof offer !== "object" || offer === null || !("onClick" in offer))
+      throw new Error("the registration offered no drift report to install");
+    offer.onClick(null as never);
+    // The handler answers nothing to await — a toast action returns void —
+    // so the queue is drained before asking what the reads did.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await rescansSettled();
+
+    expect(commands.installDriftHook).toHaveBeenCalled();
     readAgain();
   });
 
@@ -140,14 +270,17 @@ describe("a write that reaches repo_effects and is refused", () => {
     useEditorStore.setState({ scope, draft: emptyDraft(), base: null });
 
     await useEditorStore.getState().save();
+    await rescansSettled();
 
     expect(useEditorStore.getState().error).toBe("disk is full");
     readAgain();
   });
 
-  // The stale arm is the one refusal that claims nothing was written, and
-  // it is still no account of the disk: the write reaches `repo_effects`
-  // before it reads the file it refuses over.
+  // The stale arm claims nothing was written, and is still no account of the
+  // disk: two routes answer with it — the base check before anything ran,
+  // and a rollback the save decided reads as the reload choice — and from
+  // the UI they are one answer. The read is unconditional rather than argued
+  // from what a stale answer proves.
   it("reads the machine again behind an editor save refused as stale", async () => {
     vi.mocked(commands.saveCustomize).mockResolvedValue({
       status: "error",
@@ -156,6 +289,7 @@ describe("a write that reaches repo_effects and is refused", () => {
     useEditorStore.setState({ scope, draft: emptyDraft(), base: null });
 
     await useEditorStore.getState().save();
+    await rescansSettled();
 
     expect(useEditorStore.getState().stale).toBe(true);
     readAgain();
@@ -170,8 +304,117 @@ describe("a write that reaches repo_effects and is refused", () => {
     const landed = await useAuditStore
       .getState()
       .removeItem(scope, "hook", "lint");
+    await rescansSettled();
 
     expect(landed).toBe(false);
     readAgain();
+  });
+});
+
+// The arm with nobody able to say what the engine got as far as. A refusal
+// is at least an answer; a rejection is the transport failing over a command
+// that may have written throughout — `bindings.ts`'s `typedError` rethrows
+// an Error rather than folding it into a refusal, so this reaches the stores
+// as a rejection and always has.
+describe("a write that reaches repo_effects and throws", () => {
+  it("reads the machine again when the command rejects rather than refuses", async () => {
+    vi.mocked(commands.marketplaceInstall).mockRejectedValue(
+      new Error("ipc closed"),
+    );
+
+    await expect(
+      useMarketplacesStore.getState().install({
+        scope,
+        source: "kit",
+        items: [{ kind: "skill", name: "gh" }],
+      }),
+    ).rejects.toThrow("ipc closed");
+    await rescansSettled();
+
+    readAgain();
+  });
+
+  // Not only the command's own failure: the editor's re-read after a landed
+  // save is three commands under one `Promise.all`, with no `settled` over
+  // it, so a rejection there throws out of the caller's own body.
+  it("reads the machine again when the caller's own re-read throws", async () => {
+    vi.mocked(commands.saveCustomize).mockResolvedValue({
+      status: "ok",
+      data: view(scope) as never,
+    });
+    vi.mocked(commands.getManifest).mockRejectedValue(new Error("ipc closed"));
+    useEditorStore.setState({ scope, draft: emptyDraft(), base: null });
+
+    await expect(useEditorStore.getState().save()).rejects.toThrow(
+      "ipc closed",
+    );
+    await rescansSettled();
+
+    readAgain();
+  });
+});
+
+// A page of writes goes out one at a time and each one asks for the same
+// machine-wide read. Paying for one per write is seconds per item — the
+// audit leg alone measured p50 0.75s over this machine's scopes, never
+// served from its freshness window because the rescan forces it.
+describe("a page of writes, one after another", () => {
+  it("pays one read for a run of adopts rather than one each", async () => {
+    const held = park<{ status: "ok"; data: AuditView[] }>();
+    vi.mocked(commands.auditAll)
+      .mockReturnValueOnce(held.parked as ReturnType<typeof commands.auditAll>)
+      .mockResolvedValue({ status: "ok", data: [] });
+    vi.mocked(commands.adoptItem).mockResolvedValue({
+      status: "ok",
+      data: view(scope),
+    });
+
+    // What "Start managing all" does: one item at a time, each awaited, so
+    // nothing overlaps and nothing coalesces on its own.
+    for (const name of ["gh", "lint", "fmt", "test", "deploy"]) {
+      await useAuditStore.getState().adopt(scope, "hook", name, ["claude"]);
+    }
+
+    expect(commands.adoptItem).toHaveBeenCalledTimes(5);
+    // One read out, and the other four asking joined the one waiting behind
+    // it rather than each starting their own.
+    expect(commands.auditAll).toHaveBeenCalledTimes(1);
+    expect(commands.scanMachine).toHaveBeenCalledTimes(1);
+
+    held.land({ status: "ok", data: [] });
+    await rescansSettled();
+
+    // The waiting one starts only once the first has finished, which is
+    // after the last write landed — so the run is still read for.
+    expect(commands.auditAll).toHaveBeenCalledTimes(2);
+    expect(commands.scanMachine).toHaveBeenCalledTimes(2);
+  });
+
+  it("pays one read for a delete across every scope a package lives in", async () => {
+    const held = park<{ status: "ok"; data: AuditView[] }>();
+    vi.mocked(commands.auditAll)
+      .mockReturnValueOnce(held.parked as ReturnType<typeof commands.auditAll>)
+      .mockResolvedValue({ status: "ok", data: [] });
+    const scopes: Scope[] = [
+      { scope: "global" },
+      { scope: "project", root: "/home/me/app" },
+      { scope: "project", root: "/home/me/other" },
+    ];
+    vi.mocked(commands.removeItem).mockResolvedValue({
+      status: "ok",
+      data: view(scope),
+    });
+
+    for (const at of scopes) {
+      await useAuditStore.getState().removeItem(at, "skill", "gh");
+    }
+
+    expect(commands.removeItem).toHaveBeenCalledTimes(3);
+    expect(commands.auditAll).toHaveBeenCalledTimes(1);
+
+    held.land({ status: "ok", data: [] });
+    await rescansSettled();
+
+    expect(commands.auditAll).toHaveBeenCalledTimes(2);
   });
 });

--- a/ui/src/stores/write-rescan.test.ts
+++ b/ui/src/stores/write-rescan.test.ts
@@ -1,0 +1,177 @@
+// One rule, five write paths: a command that reaches `repo_effects` reads
+// the machine again whatever it answered. `lib/rescan.ts` holds the rule and
+// the reason — the leaving packages' uninstallers run before the plan, so a
+// refusal comes back with what they did to the disk standing, and Home's
+// inventory and the audit scores would go on counting copies already gone.
+//
+// The refusal arm is what this file is about: the landing arm has always
+// rescanned, and the mechanism these five now share cannot tell the two
+// apart. `scanMachine` and `auditAll` are the two commands `rescanEverything`
+// sends, so asking whether they were called is asking whether the rule held.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { commands } from "@/bindings";
+import { emptyDraft } from "@/lib/editor-draft";
+import { READ_LANDED } from "@/lib/read-state";
+import { useAuditStore } from "./audit";
+import { useEditorStore } from "./editor";
+import { useMarketplacesStore } from "./marketplaces";
+import { useProvenanceStore } from "./provenance";
+import { useScanStore } from "./scan";
+
+vi.mock("@/bindings", async (importOriginal) => ({
+  // The generated constants stay real — the editor's empty draft is stamped
+  // with core's own manifest schema through them.
+  ...(await importOriginal<typeof import("@/bindings")>()),
+  commands: {
+    marketplaceInstall: vi.fn(),
+    sourceToggle: vi.fn(),
+    marketplaceUnsubscribe: vi.fn(),
+    marketplacesOverview: vi.fn(),
+    saveCustomize: vi.fn(),
+    removeItem: vi.fn(),
+    scanMachine: vi.fn(),
+    auditAll: vi.fn(),
+    libraryProvenance: vi.fn(),
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    info: vi.fn(),
+    message: vi.fn(),
+  },
+}));
+
+const scope = { scope: "global" as const };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(commands.scanMachine).mockResolvedValue({
+    status: "ok",
+    data: {
+      items: [],
+      harnesses: [],
+      warnings: [],
+      missingProjects: [],
+    } as never,
+  });
+  vi.mocked(commands.auditAll).mockResolvedValue({ status: "ok", data: [] });
+  vi.mocked(commands.libraryProvenance).mockResolvedValue({
+    status: "ok",
+    data: [],
+  });
+  useScanStore.setState({
+    scanning: false,
+    result: null,
+    error: null,
+    backgroundFailureAnnounced: false,
+  });
+  useAuditStore.setState({
+    views: [],
+    auditing: false,
+    auditedAt: null,
+    error: null,
+    read: READ_LANDED,
+    busy: false,
+    backgroundFailureAnnounced: false,
+  });
+  useProvenanceStore.setState({ rows: [], loaded: false });
+});
+
+/** What every case below asks: the machine was read again, both halves of
+ *  it, behind a command that answered with a refusal. */
+const readAgain = () => {
+  expect(commands.scanMachine).toHaveBeenCalled();
+  expect(commands.auditAll).toHaveBeenCalled();
+};
+
+describe("a write that reaches repo_effects and is refused", () => {
+  it("reads the machine again behind a marketplace install", async () => {
+    vi.mocked(commands.marketplaceInstall).mockResolvedValue({
+      status: "error",
+      error: "the scope is busy",
+    });
+
+    const landed = await useMarketplacesStore.getState().install({
+      scope,
+      source: "kit",
+      items: [{ kind: "skill", name: "gh" }],
+    });
+
+    expect(landed).toBe(false);
+    readAgain();
+  });
+
+  it("reads the machine again behind a source toggle", async () => {
+    vi.mocked(commands.sourceToggle).mockResolvedValue({
+      status: "error",
+      error: "the settings file is read-only",
+    });
+
+    await useMarketplacesStore.getState().toggle(scope, "kit", false);
+
+    // The refusal is honoured — the overview is not re-asked behind a write
+    // that did not land — and the machine is still read again.
+    expect(commands.marketplacesOverview).not.toHaveBeenCalled();
+    readAgain();
+  });
+
+  it("reads the machine again behind an unsubscribe", async () => {
+    vi.mocked(commands.marketplaceUnsubscribe).mockResolvedValue({
+      status: "error",
+      error: "the scope is busy",
+    });
+
+    const outcome = await useMarketplacesStore
+      .getState()
+      .unsubscribe(scope, "kit", false, false);
+
+    expect(outcome).toEqual({ error: "the scope is busy" });
+    readAgain();
+  });
+
+  it("reads the machine again behind an editor save", async () => {
+    vi.mocked(commands.saveCustomize).mockResolvedValue({
+      status: "error",
+      error: { kind: "failed", message: "disk is full" },
+    });
+    useEditorStore.setState({ scope, draft: emptyDraft(), base: null });
+
+    await useEditorStore.getState().save();
+
+    expect(useEditorStore.getState().error).toBe("disk is full");
+    readAgain();
+  });
+
+  // The stale arm is the one refusal that claims nothing was written, and
+  // it is still no account of the disk: the write reaches `repo_effects`
+  // before it reads the file it refuses over.
+  it("reads the machine again behind an editor save refused as stale", async () => {
+    vi.mocked(commands.saveCustomize).mockResolvedValue({
+      status: "error",
+      error: { kind: "stale" },
+    });
+    useEditorStore.setState({ scope, draft: emptyDraft(), base: null });
+
+    await useEditorStore.getState().save();
+
+    expect(useEditorStore.getState().stale).toBe(true);
+    readAgain();
+  });
+
+  it("reads the machine again behind an audit item action", async () => {
+    vi.mocked(commands.removeItem).mockResolvedValue({
+      status: "error",
+      error: "permission denied",
+    });
+
+    const landed = await useAuditStore
+      .getState()
+      .removeItem(scope, "hook", "lint");
+
+    expect(landed).toBe(false);
+    readAgain();
+  });
+});


### PR DESCRIPTION
A write that reaches `repo_effects` runs the leaving packages' uninstallers before the plan, so a refusal comes back with those removals already on disk. Seven UI paths returned on the error arm without re-reading the machine, and Home's inventory and the audit scores went on counting copies already gone until a focus event or a manual scan.

## The mechanism

One seam, not seven patches. `writingRepo(body)` in `ui/src/lib/rescan.ts` runs the command, hands the answer back to the caller, and asks for the read in a `finally` — after the answer, so the person hears the outcome ahead of three machine-wide reads, and past a throw or a transport rejection, which is the case with nobody able to say how far the engine got.

Eight writes now go through it: marketplace install, subscribe, repository change, source toggle, unsubscribe, drift-report install, editor save, and the audit's item actions. `rescan.ts`'s header states the rule for every write that reaches `repo_effects` and carries no per-caller carve-out, so a ninth cannot quietly skip it.

Two things the seam needed underneath it:

- **The read coalesces.** Every item action forcing a whole-machine audit turned `adoptAll` over N rows into N serial audits — measured at p50 0.75s each, so ~21s for a 28-item page. One read runs at a time with exactly one waiting behind it, so a run of writes pays for the reads that finish alongside it. A 5-item adopt now costs 2 reads, not 5.
- **The scan store joins instead of dropping.** `useScanStore.refresh` opened with a bare `if (get().scanning) return;`, so a write landing during a window-focus scan lost the one leg Home renders from. It now mirrors the audit store's in-flight/queued handoff. This is KEN-1162's Done-when, so that issue closes with this.

## Known limits

- **The announce re-arm is partial by design.** A "Scan again" press joining an already-queued read re-opens the failure notice, so the failure in its window is spoken for once. It is not a promise that the press hears its own queued scan: whichever scan fails first takes the toast. Carrying the press's own options through to the queued scan would need a second piece of module state. Both docstrings and the control state the achievable claim, not more.
- **The provenance join still has no read ordering**, so an older join can land over a newer one under contention. Tracked as KEN-1183; `rescan.ts`'s header names it as the one leg the rule does not cover.

## Review

Nine reviewers over three cycles, 23 validated artifacts, 14 fixes applied. Two defects were probe-measured rather than argued: the dropped scan leg (`scanMachine` at 1 call where the rule needs 2, with `useScanStore.result` left on the pre-write reading) and the announce loss (`toast.error` at 0 calls for a joining press against 1 for the same press alone). The coalescer and the scan queue are both mutation-verified — restoring the bare early return reds all four of its cases at 10/10 stability.

The branch hit its size tripwire at 1527 lines against a 751-line baseline. `rescan.ts`'s header had accumulated 87 lines of comment for a 35-line mechanism, so the rationale came out and the rule stayed; two guards defending an input nothing shipped produces came out with it.

Filed rather than fixed here, both P2, both outside this issue's Done-when:

- KEN-1183 — the provenance join takes no read-ordering ticket.
- KEN-1184 — transport rejections escape the write paths with nothing shown; `settled.ts` is the existing remedy.

Declined: re-auditing the scope the command just audited, because the fix would reintroduce a predicate over the response, which is the defect this issue exists to remove.

Closes KEN-1168
Closes KEN-1162
