### PR TITLE
fix(KEN-1184): a rejected command answers where it used to vanish

### DIFF
--- a/changelog.d/fixed/KEN-1184.md
+++ b/changelog.d/fixed/KEN-1184.md
@@ -1,0 +1,1 @@
+- Saving in the editor, installing a package, or applying a repository effect now shows why when the app cannot reach its engine, instead of the button quietly going idle.

--- a/changelog.d/fixed/KEN-1184.md
+++ b/changelog.d/fixed/KEN-1184.md
@@ -1,1 +1,1 @@
-- Saving in the editor, installing a package, or applying a repository effect now shows why when the app cannot reach its engine, instead of the button quietly going idle.
+- Saving in the editor, installing a package, applying a repository effect, or checking your submissions now shows why when the app cannot reach its engine, instead of quietly going idle.

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -44,8 +44,34 @@ fn constants(builder: Builder<tauri::Wry>) -> Builder<tauri::Wry> {
     builder.constant("MANIFEST_SCHEMA", kendex_core::manifest::MANIFEST_SCHEMA)
 }
 
+/// The runtime the generated bindings call every command through, replacing
+/// the one tauri-specta ships. That one rethrows an `Error`, which is what
+/// `__TAURI_INVOKE` rejects with when the transport fails rather than when
+/// the command refuses — so a caller that fires its write and forgets it
+/// dropped the rejection: the busy flag fell, nothing was said, and the
+/// click read as having done nothing. Folded here, a transport failure
+/// lands in the shape every caller already reads a refusal in.
+///
+/// The message alone is not either arm of a shaped refusal such as
+/// `WriteRefused`, so a reader of one goes through `refusalWords` in
+/// `ui/src/lib/refusal.ts` rather than testing `kind`. The words a
+/// rejection with nothing to say falls back to are `NO_REASON_GIVEN` in
+/// `ui/src/lib/settled.ts`, which folds the same failure for work that is
+/// not a command; `ui/src/bindings.test.ts` holds this copy to those words.
+const TYPED_ERROR_IMPL: &str = r#"async function typedError<T, E>(result: Promise<T>): Promise<{ status: "ok"; data: T } | { status: "error"; error: E }> {
+    try {
+        return { status: "ok", data: await result };
+    } catch (e) {
+        if (e instanceof Error) {
+            const message = e.message === "" ? "Something went wrong, but no reason was given" : e.message;
+            return { status: "error", error: message as any };
+        }
+        return { status: "error", error: e as any };
+    }
+}"#;
+
 pub fn specta_builder() -> Builder<tauri::Wry> {
-    constants(Builder::<tauri::Wry>::new()).commands(collect_commands![
+    let builder = constants(Builder::<tauri::Wry>::new()).commands(collect_commands![
         commands::app_version,
         app_update::app_update_check,
         app_update::app_update_channel,
@@ -134,7 +160,8 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         window::window_minimize,
         window::window_toggle_maximize,
         window::window_close,
-    ])
+    ]);
+    builder.typed_error_impl(TYPED_ERROR_IMPL)
 }
 
 /// Everything that must settle before the window opens: an apply the last

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -44,21 +44,31 @@ fn constants(builder: Builder<tauri::Wry>) -> Builder<tauri::Wry> {
     builder.constant("MANIFEST_SCHEMA", kendex_core::manifest::MANIFEST_SCHEMA)
 }
 
-/// The runtime the generated bindings call every command through, replacing
-/// the one tauri-specta ships. That one rethrows an `Error`, which is what
-/// `__TAURI_INVOKE` rejects with when the transport fails rather than when
-/// the command refuses — so a caller that fires its write and forgets it
-/// dropped the rejection: the busy flag fell, nothing was said, and the
-/// click read as having done nothing. Folded here, a transport failure
-/// lands in the shape every caller already reads a refusal in.
+/// The runtime the generated bindings call every `Result`-returning command
+/// through, replacing the one tauri-specta ships. That one rethrows an
+/// `Error`, which is what `__TAURI_INVOKE` rejects with when the transport
+/// fails rather than when the command refuses — so a caller that fires its
+/// write and forgets it dropped the rejection: the busy flag fell, nothing
+/// was said, and the click read as having done nothing. Folded here, a
+/// transport failure lands in the shape every caller already reads a
+/// refusal in.
 ///
-/// The message alone is not either arm of a shaped refusal such as
-/// `WriteRefused`, so a reader of one goes through `refusalWords` in
-/// `ui/src/lib/refusal.ts` rather than testing `kind`. The words a
+/// A command returning a plain value gets no wrapper, tauri-specta emitting
+/// one only where there is a refusal type to name: `app_version`,
+/// `capability_table`, `mine_authoring_doc` and `window_zoom_state` reject
+/// to their callers as before, so a fire-and-forget read of one still drops
+/// its rejection. Nothing in `specta_builder` can reach them.
+///
+/// `E | string` in the signature is what holds a reader honest: the fold
+/// puts a bare message in the `E` slot, and declaring that widening is what
+/// makes `tsc` name every reader branching on a discriminant the runtime no
+/// longer guarantees. Read the refusal through `ui/src/lib/refusal.ts`
+/// rather than off its fields — `refusalKind` still branches on the kind,
+/// it just answers `null` where a shape never arrived. The words a
 /// rejection with nothing to say falls back to are `NO_REASON_GIVEN` in
 /// `ui/src/lib/settled.ts`, which folds the same failure for work that is
 /// not a command; `ui/src/bindings.test.ts` holds this copy to those words.
-const TYPED_ERROR_IMPL: &str = r#"async function typedError<T, E>(result: Promise<T>): Promise<{ status: "ok"; data: T } | { status: "error"; error: E }> {
+const TYPED_ERROR_IMPL: &str = r#"async function typedError<T, E>(result: Promise<T>): Promise<{ status: "ok"; data: T } | { status: "error"; error: E | string }> {
     try {
         return { status: "ok", data: await result };
     } catch (e) {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -45,9 +45,16 @@ Observation (scanner truth) · Drift. Core modules mirror the verbs: `model`, `s
 both scores, disjoint from render and engine. `crates/app` — Tauri
 commands, one module per page domain.
 `crates/cli` — thin verbs over the same core. `ui/` — React 19 + Tailwind v4 +
-shadcn/ui + zustand over generated bindings (tauri-specta). Adapters in
-`core/harness/` own paths and rendering only; what each harness supports
-lives in one capability table read by core and UI.
+shadcn/ui + zustand over generated bindings (tauri-specta). Those bindings
+are exported and byte-checked by `crates/app/tests/bindings.rs`, so anything
+about them — the command surface, the constants the UI reads instead of
+copying, the runtime every command answers through — is changed in
+`specta_builder` and regenerated, never edited in `ui/src/bindings.ts`. That
+runtime folds a rejected invoke into the same `{ status: "error" }` a refusal
+answers with, so a caller that fires a write and forgets it cannot drop a
+transport failure in silence. Adapters in `core/harness/` own paths and
+rendering only; what each harness supports lives in one capability table read
+by core and UI.
 
 ## Invariants — what the product guarantees
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -48,11 +48,15 @@ commands, one module per page domain.
 shadcn/ui + zustand over generated bindings (tauri-specta). Those bindings
 are exported and byte-checked by `crates/app/tests/bindings.rs`, so anything
 about them — the command surface, the constants the UI reads instead of
-copying, the runtime every command answers through — is changed in
-`specta_builder` and regenerated, never edited in `ui/src/bindings.ts`. That
-runtime folds a rejected invoke into the same `{ status: "error" }` a refusal
-answers with, so a caller that fires a write and forgets it cannot drop a
-transport failure in silence. Adapters in `core/harness/` own paths and
+copying, the runtime every `Result`-returning command answers through — is
+changed in `specta_builder` and regenerated, never edited in
+`ui/src/bindings.ts`. That runtime folds a rejected invoke into the same
+`{ status: "error" }` a refusal answers with, declared as `E | string`, so a
+caller that fires such a write and forgets it cannot drop a transport failure
+in silence and a reader that goes off the refusal's fields rather than
+through `ui/src/lib/refusal.ts` is a type error. A command returning a plain
+value gets no wrapper and still rejects to its caller. Adapters in
+`core/harness/` own paths and
 rendering only; what each harness supports lives in one capability table read
 by core and UI.
 

--- a/ui/src/bindings.test.ts
+++ b/ui/src/bindings.test.ts
@@ -3,13 +3,19 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { commands } from "@/bindings";
 import { NO_REASON_GIVEN } from "@/lib/settled";
 
-// The seam every command answers through. The transport rejects with an
-// `Error` when it fails rather than when the command refuses, and the runtime
-// tauri-specta ships rethrows that — so the write paths that fire their
-// command and forget it dropped the rejection: the busy flag fell and nothing
-// was said. `typedError` is replaced at generation time (`specta_builder` in
-// `crates/app/src/lib.rs`) to fold the rejection into the refusal shape
-// instead, and this is what holds the replacement in place. Regenerate with
+// The seam every `Result`-returning command answers through — tauri-specta
+// emits the runtime only where there is a refusal type to name, so the four
+// commands returning a plain value reject to their callers as before. The
+// transport rejects with an `Error` when it fails rather than when the
+// command refuses, and the runtime tauri-specta ships rethrows that — so the
+// write paths that fire their command and forget it dropped the rejection:
+// the busy flag fell and nothing was said. `typedError` is replaced at
+// generation time (`specta_builder` in `crates/app/src/lib.rs`) to fold the
+// rejection into the refusal shape instead, and this is what holds the
+// replacement in place. The fold puts a bare message where a shaped refusal
+// is declared, which the signature admits as `E | string`: that is what makes
+// `tsc` name a reader branching on a discriminant the runtime no longer
+// guarantees. Regenerate with
 // `cargo test -p kendex-app -- --ignored regenerate_bindings`.
 //
 // Driven through the transport the app really has — the bridge Tauri reads
@@ -59,5 +65,26 @@ describe("a command whose transport rejected", () => {
     await expect(
       commands.saveCustomize({ scope: "global" }, null, null),
     ).resolves.toEqual({ status: "error", error: { kind: "stale" } });
+  });
+});
+
+// The other half of the same runtime: folding a failure is only right if a
+// command that works still answers what it returned. Without this a runtime
+// that broke the `ok` arm would pass the file that exists to hold it honest.
+describe("a command whose transport answered", () => {
+  beforeEach(() => {
+    delete bridged.__TAURI_INTERNALS__;
+  });
+
+  it("answers with the value the command returned", async () => {
+    const returned = { harnesses: ["claude"] };
+    bridged.__TAURI_INTERNALS__ = {
+      invoke: () => Promise.resolve(returned),
+    };
+
+    await expect(commands.scanMachine()).resolves.toEqual({
+      status: "ok",
+      data: returned,
+    });
   });
 });

--- a/ui/src/bindings.test.ts
+++ b/ui/src/bindings.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+import { commands } from "@/bindings";
+import { NO_REASON_GIVEN } from "@/lib/settled";
+
+// The seam every command answers through. The transport rejects with an
+// `Error` when it fails rather than when the command refuses, and the runtime
+// tauri-specta ships rethrows that — so the write paths that fire their
+// command and forget it dropped the rejection: the busy flag fell and nothing
+// was said. `typedError` is replaced at generation time (`specta_builder` in
+// `crates/app/src/lib.rs`) to fold the rejection into the refusal shape
+// instead, and this is what holds the replacement in place. Regenerate with
+// `cargo test -p kendex-app -- --ignored regenerate_bindings`.
+//
+// Driven through the transport the app really has — the bridge Tauri reads
+// off the window — rather than a mocked module: no UI file may import
+// `@tauri-apps` but the generated bindings, and nothing else reaches the
+// generated runtime, because every store test stubs `commands` above it.
+type Bridge = { invoke: (cmd: string, args: unknown) => Promise<unknown> };
+const bridged = window as unknown as { __TAURI_INTERNALS__?: Bridge };
+
+/** The bridge answering every command with this rejection. */
+function rejectingWith(thrown: unknown): void {
+  bridged.__TAURI_INTERNALS__ = { invoke: () => Promise.reject(thrown) };
+}
+
+describe("a command whose transport rejected", () => {
+  beforeEach(() => {
+    delete bridged.__TAURI_INTERNALS__;
+  });
+
+  it("answers with the refusal shape and the rejection's message", async () => {
+    rejectingWith(new Error("the channel is gone"));
+
+    await expect(commands.scanMachine()).resolves.toEqual({
+      status: "error",
+      error: "the channel is gone",
+    });
+  });
+
+  // A blank message renders as blank under whatever title shows it, and a
+  // caller testing it by truthiness reads the failure as no failure — the
+  // same silence the fold exists to end. `lib/settled.ts` owns the words,
+  // and this holds the generated copy of them to it.
+  it("stands words in for a rejection that says nothing", async () => {
+    rejectingWith(new Error(""));
+
+    await expect(commands.scanMachine()).resolves.toEqual({
+      status: "error",
+      error: NO_REASON_GIVEN,
+    });
+  });
+
+  // The engine's own refusal arrives as the rejected value itself, never as
+  // an `Error`, and it must keep the shape its type promises.
+  it("passes an engine refusal through as the value it rejected with", async () => {
+    rejectingWith({ kind: "stale" });
+
+    await expect(
+      commands.saveCustomize({ scope: "global" }, null, null),
+    ).resolves.toEqual({ status: "error", error: { kind: "stale" } });
+  });
+});

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -3372,8 +3372,13 @@ async function typedError<T, E>(result: Promise<T>): Promise<{ status: "ok"; dat
     try {
         return { status: "ok", data: await result };
     } catch (e) {
-        if (e instanceof Error) throw e;
+        if (e instanceof Error) {
+            const message = e.message === "" ? "Something went wrong, but no reason was given" : e.message;
+            return { status: "error", error: message as any };
+        }
         return { status: "error", error: e as any };
     }
 }
+
+const _assertTypedErrorFollowsContract: <T, E>(result: Promise<T>) => Promise<any> = typedError;
 

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -3368,7 +3368,7 @@ export type ZoomState = {
 };
 
 /* Tauri Specta runtime */
-async function typedError<T, E>(result: Promise<T>): Promise<{ status: "ok"; data: T } | { status: "error"; error: E }> {
+async function typedError<T, E>(result: Promise<T>): Promise<{ status: "ok"; data: T } | { status: "error"; error: E | string }> {
     try {
         return { status: "ok", data: await result };
     } catch (e) {

--- a/ui/src/components/marketplaces/mine-submit-dialog.dom.test.tsx
+++ b/ui/src/components/marketplaces/mine-submit-dialog.dom.test.tsx
@@ -191,6 +191,38 @@ describe("a submit that meets an expired sign-in", () => {
   });
 });
 
+// A transport failure folds into the refusal's place as the message alone,
+// which is neither arm of `AccountCallRefused`. Read for a `message` field
+// it answers `undefined`, the alert renders nothing, and the click reads as
+// having done nothing at all — the silence this seam exists to end. It is
+// also news about the channel rather than the credential, so it must not
+// take the account down with it.
+describe("a submit whose transport failed", () => {
+  const GONE = "the channel is gone";
+
+  beforeEach(() => {
+    readyToSubmit();
+    vi.mocked(commands.mineSubmit).mockResolvedValue({
+      status: "error",
+      error: GONE,
+    } as never);
+  });
+
+  it("shows the transport's own words and leaves the account signed in", async () => {
+    showDialog();
+    await settle();
+    await userEvent.click(button("Submit") as HTMLButtonElement);
+    await settle();
+
+    expect(document.body.querySelector('[role="alert"]')?.textContent).toBe(
+      GONE,
+    );
+    expect(useAccountStore.getState().account).not.toEqual({
+      kind: "expired",
+    });
+  });
+});
+
 // The refusal offers a sign-in, and the sign-in can fail in its own
 // right. Two sentences then want the one alert, and the expiry is the
 // wrong one: it has been acted on, its remedy is the button just

--- a/ui/src/components/marketplaces/mine-submit-dialog.tsx
+++ b/ui/src/components/marketplaces/mine-submit-dialog.tsx
@@ -11,6 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { refusalWords } from "@/lib/refusal";
 import { hasCredential, useAccountStore } from "@/stores/account";
 
 /** The preflight checklist and the submit itself. The server has the last
@@ -72,7 +73,7 @@ export function MineSubmitDialog({
         // The refusal answers the submit this person pressed, so it is
         // shown either way. Whether it is also news about the account is
         // the store's to decide.
-        setError(answer.error.message);
+        setError(refusalWords(answer.error));
         // An expired sign-in takes the offer away with it: the footer
         // reads the account, so this dialog stops offering a submit
         // nothing can carry and offers the sign-in that fixes it.

--- a/ui/src/components/marketplaces/mine-submit-dialog.tsx
+++ b/ui/src/components/marketplaces/mine-submit-dialog.tsx
@@ -11,7 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { refusalWords } from "@/lib/refusal";
+import { isShapedRefusal, refusalWords } from "@/lib/refusal";
 import { hasCredential, useAccountStore } from "@/stores/account";
 
 /** The preflight checklist and the submit itself. The server has the last
@@ -76,8 +76,10 @@ export function MineSubmitDialog({
         setError(refusalWords(answer.error));
         // An expired sign-in takes the offer away with it: the footer
         // reads the account, so this dialog stops offering a submit
-        // nothing can carry and offers the sign-in that fixes it.
-        refused(answer.error, since);
+        // nothing can carry and offers the sign-in that fixes it. A
+        // transport failure is news about the channel, not the credential,
+        // so it never reaches that decision.
+        if (isShapedRefusal(answer.error)) refused(answer.error, since);
         return;
       }
       setSubmitted(answer.data.status);

--- a/ui/src/components/package/delete-dialog.dom.test.tsx
+++ b/ui/src/components/package/delete-dialog.dom.test.tsx
@@ -156,10 +156,10 @@ describe("the read behind the note", () => {
     expect(said).not.toContain(REINSTALL_OWN);
   });
 
-  // The generated wrapper rethrows a transport failure, which is the same
-  // failed read and must not come out as an unhandled rejection. The note
-  // is where to get the package again, not what the deletion does, so its
-  // absence leaves Delete live.
+  // A read that rejects rather than answering is the same failed read and
+  // must not come out as an unhandled rejection. The note is where to get
+  // the package again, not what the deletion does, so its absence leaves
+  // Delete live.
   it("leaves Delete live when the read never answers", async () => {
     vi.mocked(commands.libraryProvenance).mockRejectedValue(
       new Error("the channel is gone"),

--- a/ui/src/components/package/package-projects.dom.test.tsx
+++ b/ui/src/components/package/package-projects.dom.test.tsx
@@ -352,9 +352,9 @@ describe("the age a card shows as time passes", () => {
   });
 });
 
-// The generated command wrapper rethrows a transport failure rather than
-// answering with an error status, so one unreachable place must not take
-// the whole read with it.
+// A read that rejects rather than answering must not take the whole read
+// with it: one unreachable place would throw away every place that did
+// answer.
 describe("a place whose record could not be read", () => {
   it("draws every other place and stops loading", async () => {
     vi.mocked(commands.packageMeta).mockImplementation((scope) =>

--- a/ui/src/components/package/package-version-actions.ts
+++ b/ui/src/components/package/package-version-actions.ts
@@ -67,10 +67,11 @@ export function packageVersionActions(
       return showError(UPDATES_ONE_AT_A_TIME_NOTE);
     setBusy(true);
     return holdingBusy(async () => {
-      // A transport failure rejects rather than refusing. Unwrapped it
-      // would skip the report, leave `setBusy` up for the life of the view
-      // and skip the read-back this promises either way. `saying` because
-      // a hold move can take a declaring package away with it.
+      // A promise that rejects here rather than answering would skip the
+      // report, leave `setBusy` up for the life of the view and skip the
+      // read-back this promises either way; `settled` also stands words in
+      // for a refusal that says nothing. `saying` because a hold move can
+      // take a declaring package away with it.
       const response = saying(await settled(call()));
       setBusy(false);
       if (response.status === "error") {

--- a/ui/src/components/package/use-package-data.test.ts
+++ b/ui/src/components/package/use-package-data.test.ts
@@ -154,8 +154,8 @@ describe("packageVersionActions", () => {
     expect(toast.success).not.toHaveBeenCalled();
   });
 
-  // A transport failure rejects rather than refusing, and only a wrapper
-  // sees it. Unwrapped it said nothing to the person, left the page's own
+  // A write that rejects rather than refusing is only ever seen by a
+  // wrapper. Unwrapped it said nothing to the person, left the page's own
   // flag up for the life of the view, and skipped the read-back the
   // refusal path above promises happens either way.
   it("answers a rejected write the way it answers a refusal", async () => {

--- a/ui/src/components/package/use-package-data.ts
+++ b/ui/src/components/package/use-package-data.ts
@@ -107,11 +107,11 @@ export function usePackageData(ref: PackageRef | null): {
       if (left === 0) setReading(false);
       return true;
     };
-    // `settled` on all three: the generated wrapper rethrows a transport
-    // failure rather than answering with one, and left raw the landing never
-    // ran at all — the read stayed pending for the life of the view, the
-    // note that says a read failed never appeared, and the rejection went
-    // out unhandled.
+    // `settled` on all three: it normalizes a refusal that says nothing,
+    // and it is the last guard behind the wrapper's own fold. A landing that
+    // never ran leaves the read pending for the life of the view, the note
+    // that says a read failed never appears, and the rejection goes out
+    // unhandled.
     void settled(commands.packageMeta(ref.scope, ref.kind, ref.name)).then(
       (response) => {
         if (!lands()) return;

--- a/ui/src/components/package/use-package-places.ts
+++ b/ui/src/components/package/use-package-places.ts
@@ -92,11 +92,12 @@ export function usePackagePlaces(
               response.status === "ok" ? response.data : null,
             ] as const;
           } catch {
-            // The generated wrapper rethrows a transport failure, and one
-            // rejection would take the whole `Promise.all` with it: the
-            // places that answered would be thrown away and the tab would
-            // load forever. A place nobody could reach is a dateless card,
-            // the same as one whose record did not read.
+            // The wrapper folds a rejected command into an error status, so
+            // this is the last guard rather than the first: one rejection
+            // that did get out would take the whole `Promise.all` with it,
+            // the places that answered thrown away and the tab loading
+            // forever. A place nobody could reach is a dateless card, the
+            // same as one whose record did not read.
             return [scopeKey(scope), null] as const;
           }
         }),

--- a/ui/src/components/sidebar-notice.dom.test.tsx
+++ b/ui/src/components/sidebar-notice.dom.test.tsx
@@ -23,6 +23,7 @@ import {
   appUpdateCommandDownloadNote,
   appUpdateCommandManagedNote,
   appUpdateCommandPrivilegeNote,
+  SETTINGS_MOVED_MESSAGE,
 } from "@/lib/copy";
 import { useNoticeStore } from "@/stores/notice";
 import { mount, settle } from "@/test/dom";
@@ -511,6 +512,22 @@ describe("hiding this version", () => {
     const container = await show();
     await press(container, APP_UPDATE_DISMISS_LABEL);
     expect(container.textContent).toContain("the settings file is read-only");
+    expect(container.textContent).toContain(APP_UPDATE_TITLE);
+  });
+
+  // A transport failure folds into the refusal's place as the message
+  // alone. Read by `kind` it misses `failed`, and the moved-file wording
+  // that stands in for the stale arm would report a dead channel as the
+  // settings file having changed underneath.
+  it("shows the transport's own words, not the moved-file wording", async () => {
+    vi.mocked(commands.updateSettings).mockResolvedValue({
+      status: "error",
+      error: "the channel is gone",
+    } as Awaited<ReturnType<typeof commands.updateSettings>>);
+    const container = await show();
+    await press(container, APP_UPDATE_DISMISS_LABEL);
+    expect(container.textContent).toContain("the channel is gone");
+    expect(container.textContent).not.toContain(SETTINGS_MOVED_MESSAGE);
     expect(container.textContent).toContain(APP_UPDATE_TITLE);
   });
 });

--- a/ui/src/lib/refusal.test.ts
+++ b/ui/src/lib/refusal.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import type { WriteRefused } from "@/bindings";
+import { refusalKind, refusalWords } from "./refusal";
+
+// A transport failure folds to its message alone (`bindings.test.ts`), which
+// is neither arm of `WriteRefused`. Read by `kind` it answers as whichever
+// arm the reader tests for last: the editor would offer a reload for a broken
+// pipe, and the settings write would report a file that moved. These two are
+// what every reader of a shaped refusal asks instead.
+describe("a refusal the engine shaped", () => {
+  it("answers with its own kind and the words that go with it", () => {
+    const failed: WriteRefused = { kind: "failed", message: "disk is full" };
+    expect(refusalKind(failed)).toBe("failed");
+    expect(refusalWords(failed)).toBe("disk is full");
+  });
+
+  it("answers with no words where its kind carries none", () => {
+    const stale: WriteRefused = { kind: "stale" };
+    expect(refusalKind(stale)).toBe("stale");
+    expect(refusalWords(stale)).toBeNull();
+  });
+});
+
+describe("a transport failure folded into a refusal's place", () => {
+  // Cast because no refusal type admits it: the fold has no shape it could
+  // invent that fits every command's refusal, so it leaves the message.
+  const folded = "the channel is gone" as unknown as WriteRefused;
+
+  it("claims no kind of its own", () => {
+    expect(refusalKind(folded)).toBeNull();
+  });
+
+  it("answers with the message as the words", () => {
+    expect(refusalWords(folded)).toBe("the channel is gone");
+  });
+});

--- a/ui/src/lib/refusal.test.ts
+++ b/ui/src/lib/refusal.test.ts
@@ -3,10 +3,11 @@ import type { WriteRefused } from "@/bindings";
 import { refusalKind, refusalWords } from "./refusal";
 
 // A transport failure folds to its message alone (`bindings.test.ts`), which
-// is neither arm of `WriteRefused`. Read by `kind` it answers as whichever
-// arm the reader tests for last: the editor would offer a reload for a broken
-// pipe, and the settings write would report a file that moved. These two are
-// what every reader of a shaped refusal asks instead.
+// is neither arm of `WriteRefused`. Read by `kind` it misses every arm and
+// lands in whatever the reader does last: the editor tests `stale` first, so
+// a broken pipe falls past it to a blank error, and the settings write tests
+// `failed` first, so the same pipe is reported as a file that moved. These
+// two are what every reader of a shaped refusal asks instead.
 describe("a refusal the engine shaped", () => {
   it("answers with its own kind and the words that go with it", () => {
     const failed: WriteRefused = { kind: "failed", message: "disk is full" };

--- a/ui/src/lib/refusal.ts
+++ b/ui/src/lib/refusal.ts
@@ -2,25 +2,40 @@
 // stopped through a `kind` its reader branches on. A transport failure has no
 // kind: `typedError` in the generated bindings folds it into the message
 // alone, because there is no shape it could invent that fits every command's
-// refusal type. Read by `kind`, that message answers as whichever arm the
-// reader tests for last — a reload offered for a broken pipe, or nothing shown
-// at all. These two are how a reader asks its questions so both land.
+// refusal type. The bindings declare that widening as `E | string`, so a
+// reader that goes off the fields rather than through here is a type error
+// rather than a silence found later.
+//
+// Read by `kind`, the folded message misses every arm and lands in whatever
+// the reader does last: the editor tests `stale` first, so a broken pipe
+// falls past it and shows a blank error (`ui/src/stores/editor.ts`), and the
+// settings notice tests `failed` first, so the same pipe is reported as the
+// settings file having moved (`ui/src/stores/notice.ts`). These two are how a
+// reader asks its questions so both land.
 
-/** Any refusal shape the commands answer with: a kind, and the words that go
- *  with it where that kind has any. */
+/** A refusal the commands answer with through a `kind`: `WriteRefused` and
+ *  `AccountCallRefused`. `ForkBesideError` discriminates on `phase` instead
+ *  and is outside these two — `ui/src/stores/updates-edits.ts` reads it. */
 type Shaped = { kind: string; message?: string };
 
 /** The refusal's own kind, or null where the transport failed and left a
- *  message with no shape around it. */
-export function refusalKind(refusal: Shaped): string | null {
-  return typeof (refusal as unknown) === "string" ? null : refusal.kind;
+ *  message with no shape around it — a kindless shape answers null too. */
+export function refusalKind(refusal: Shaped | string): string | null {
+  return typeof refusal === "string" ? null : (refusal.kind ?? null);
 }
 
 /** What stopped the write, in the words the person gets — null only where the
  *  refusal is a kind that carries none, such as a file that moved. */
-export function refusalWords(refusal: Shaped): string | null {
-  if (typeof (refusal as unknown) === "string") {
-    return refusal as unknown as string;
-  }
-  return refusal.message ?? null;
+export function refusalWords(refusal: Shaped | string): string | null {
+  return typeof refusal === "string" ? refusal : (refusal.message ?? null);
+}
+
+/** Whether the refusal is the engine's own shape rather than a folded
+ *  transport failure. For a reader that needs the shape itself, not its
+ *  words: a transport failure is news about the channel, never about what
+ *  the command was refusing. */
+export function isShapedRefusal<T extends Shaped>(
+  refusal: T | string,
+): refusal is T {
+  return typeof refusal !== "string";
 }

--- a/ui/src/lib/refusal.ts
+++ b/ui/src/lib/refusal.ts
@@ -1,0 +1,26 @@
+// A shaped refusal — `WriteRefused`, `AccountCallRefused` — says why a write
+// stopped through a `kind` its reader branches on. A transport failure has no
+// kind: `typedError` in the generated bindings folds it into the message
+// alone, because there is no shape it could invent that fits every command's
+// refusal type. Read by `kind`, that message answers as whichever arm the
+// reader tests for last — a reload offered for a broken pipe, or nothing shown
+// at all. These two are how a reader asks its questions so both land.
+
+/** Any refusal shape the commands answer with: a kind, and the words that go
+ *  with it where that kind has any. */
+type Shaped = { kind: string; message?: string };
+
+/** The refusal's own kind, or null where the transport failed and left a
+ *  message with no shape around it. */
+export function refusalKind(refusal: Shaped): string | null {
+  return typeof (refusal as unknown) === "string" ? null : refusal.kind;
+}
+
+/** What stopped the write, in the words the person gets — null only where the
+ *  refusal is a kind that carries none, such as a file that moved. */
+export function refusalWords(refusal: Shaped): string | null {
+  if (typeof (refusal as unknown) === "string") {
+    return refusal as unknown as string;
+  }
+  return refusal.message ?? null;
+}

--- a/ui/src/stores/account-read.ts
+++ b/ui/src/stores/account-read.ts
@@ -8,6 +8,7 @@ import {
   type AccountStatus,
   commands,
 } from "@/bindings";
+import { isShapedRefusal } from "@/lib/refusal";
 import type { SettledAccount } from "./account";
 
 /** What a read of the account answers: the state it settled on, or why it
@@ -42,8 +43,15 @@ const settled = (wire: AccountStatus["state"]): SettledAccount => {
  * and with the rejection when the credential is dead. */
 const fromBridge: ReadAccount = async () => {
   const status = await commands.accountStatus();
-  if (status.status === "error")
+  if (status.status === "error") {
+    // A transport failure folds to the message alone, so the command never
+    // ran and kendex.ai was never asked — nothing was learned about whether
+    // it is reachable. That is `local`, a read that failed, rather than the
+    // `unreachable` that would age the last good name into offline.
+    if (!isShapedRefusal(status.error))
+      return { error: status.error, kind: "local" };
     return { error: status.error.message, kind: status.error.kind };
+  }
   return { ok: settled(status.data.state) };
 };
 

--- a/ui/src/stores/account-refused.test.ts
+++ b/ui/src/stores/account-refused.test.ts
@@ -309,15 +309,22 @@ describe("a submissions read the server could not answer", () => {
     expect(useAccountStore.getState().submissionsError).toBeNull();
   });
 
-  // A rejected call is a read that failed, not an exception for the poll's
+  // A failed call is a read that failed, not an exception for the poll's
   // `void` caller to drop on the floor. It says nothing about the
   // credential, so the account stays where it is and the rows say why they
   // are not current.
-  it("lands a rejected poll as a failed read, not a thrown one", async () => {
+  //
+  // The transport folds its own failure into the error arm as the message
+  // alone, so that — not a rejection — is what the poll now meets. Left
+  // read by `kind` the message answers `undefined`, the write falls to the
+  // arm that writes nothing, and an empty tab offers a first submit over
+  // work already in review.
+  it("lands a failed poll as a failed read, with the words it came with", async () => {
     useAccountStore.setState({ account: signedIn, submissions: [ROW] });
-    vi.mocked(commands.mineSubmissions).mockRejectedValue(
-      new Error("the bridge is gone"),
-    );
+    vi.mocked(commands.mineSubmissions).mockResolvedValue({
+      status: "error",
+      error: "the bridge is gone",
+    } as Awaited<ReturnType<typeof commands.mineSubmissions>>);
 
     await expect(
       useAccountStore.getState().loadSubmissions(),

--- a/ui/src/stores/account-submissions.ts
+++ b/ui/src/stores/account-submissions.ts
@@ -7,7 +7,7 @@ import {
   type SubmissionRow,
 } from "@/bindings";
 import { readOrder } from "@/lib/read-state";
-import { caught } from "@/lib/settled";
+import { isShapedRefusal } from "@/lib/refusal";
 
 /** The submissions half of the account store. */
 export interface Submissions {
@@ -50,10 +50,10 @@ export const readSubmissions = async (
 ): Promise<void> => {
   const ticket = order.begin();
   const before = handovers();
-  // A transport rejection is a read that failed, not an exception for a
+  // A transport failure is a read that failed, not an exception for a
   // `void` caller to drop: it lands as the same refusal shape the server
   // returns, under the same guards.
-  const answer = asRefusal(await caught(commands.mineSubmissions()));
+  const answer = asRefusal(await commands.mineSubmissions());
   if (!order.lands(ticket) || before !== handovers()) return;
   if (answer.status === "error") refused(answer.error, before);
   write(fromSubmissionsRead(answer));
@@ -64,17 +64,27 @@ type SubmissionsRead =
   | { status: "ok"; data: SubmissionRow[] }
   | { status: "error"; error: AccountCallRefused };
 
-/** A rejected call in the shape the guards and the writer already read. It
- *  says nothing about the credential, only that this read did not happen,
- *  so it takes the `failed` kind rather than `expired`. */
+/** A transport failure in the shape the guards and the writer already read.
+ *  The bindings fold one into the message alone, so it arrives where an
+ *  `AccountCallRefused` is declared and answers no `kind` at all. It says
+ *  nothing about the credential, only that this read did not happen, so it
+ *  takes the `failed` kind rather than `expired`. Every reader downstream
+ *  branches on that kind, so the shape is restored here rather than at each
+ *  of them. */
 const asRefusal = (
   answer:
-    | { status: "ok"; data: SubmissionsRead }
-    | { status: "error"; error: string },
-): SubmissionsRead =>
-  answer.status === "ok"
-    ? answer.data
-    : { status: "error", error: { kind: "failed", message: answer.error } };
+    | { status: "ok"; data: SubmissionRow[] }
+    | { status: "error"; error: AccountCallRefused | string },
+): SubmissionsRead => {
+  if (answer.status === "ok") return answer;
+  if (isShapedRefusal(answer.error)) {
+    return { status: "error", error: answer.error };
+  }
+  return {
+    status: "error",
+    error: { kind: "failed", message: answer.error },
+  };
+};
 
 /** What a read's answer writes.
  *

--- a/ui/src/stores/account.test.ts
+++ b/ui/src/stores/account.test.ts
@@ -171,8 +171,8 @@ describe("a read that could not be made", () => {
     expect(useAccountStore.getState().readError).toBeNull();
   });
 
-  // typedError rethrows an Error the transport raised, so a bridge that
-  // throws never reaches the Result path at all.
+  // A bridge that throws rather than replying never reaches the Result
+  // path at all, and the record has to say so either way.
   it("records a bridge that threw the same as one that said no", async () => {
     vi.mocked(commands.accountStatus).mockRejectedValue(
       new Error("ipc channel closed"),

--- a/ui/src/stores/account.test.ts
+++ b/ui/src/stores/account.test.ts
@@ -183,6 +183,23 @@ describe("a read that could not be made", () => {
     );
   });
 
+  // A transport failure folds to the message alone, so the command never ran
+  // and kendex.ai was never asked. That is a failure on this machine, not
+  // evidence the directory is away: the name already in hand must stay as it
+  // is rather than ageing into offline, which is what `unreachable` would do.
+  it("leaves a signed-in name standing when the transport folded", async () => {
+    useAccountStore.setState({
+      account: { kind: "signed-in", identity: ADA },
+    });
+    vi.mocked(commands.accountStatus).mockResolvedValue({
+      status: "error",
+      error: "the bridge is gone",
+    } as Awaited<ReturnType<typeof commands.accountStatus>>);
+    await load();
+    expect(account()).toEqual({ kind: "signed-in", identity: ADA });
+    expect(useAccountStore.getState().readError).toBe("the bridge is gone");
+  });
+
   // The seam every reader passes through is what holds them to the answer
   // their type promises. A reader that throws instead would otherwise leave
   // the read with nothing recorded, nothing to retry from, and a rejection

--- a/ui/src/stores/editor.test.ts
+++ b/ui/src/stores/editor.test.ts
@@ -468,8 +468,8 @@ describe("editor store", () => {
   /// transport failure that escaped here left the busy flag falling with
   /// nothing shown. It folds into the refusal's place as the message alone
   /// (`bindings.test.ts`), which is neither arm of `WriteRefused`: read by
-  /// `kind` it would answer as the stale arm and offer a reload for a
-  /// broken pipe.
+  /// `kind` it misses the stale arm this reader tests first and falls to the
+  /// else, showing a blank error — the same silence by another route.
   it("shows the message when the transport failed rather than the engine refusing", async () => {
     useEditorStore.setState({ draft: emptyDraft(), base: "b1" });
     vi.mocked(commands.saveCustomize).mockResolvedValue({

--- a/ui/src/stores/editor.test.ts
+++ b/ui/src/stores/editor.test.ts
@@ -5,6 +5,7 @@ import type {
   EditorInventory,
   Scope,
   ScopeSettings,
+  WriteRefused,
 } from "@/bindings";
 import { commands } from "@/bindings";
 import { placeFacts, placesSource } from "@/lib/customized-places";
@@ -461,6 +462,25 @@ describe("editor store", () => {
     await useEditorStore.getState().save();
     expect(useEditorStore.getState().stale).toBe(false);
     expect(useEditorStore.getState().error).toBe("disk is full");
+  });
+
+  /// Save is fired and forgotten — `onSave={() => void save()}` — so a
+  /// transport failure that escaped here left the busy flag falling with
+  /// nothing shown. It folds into the refusal's place as the message alone
+  /// (`bindings.test.ts`), which is neither arm of `WriteRefused`: read by
+  /// `kind` it would answer as the stale arm and offer a reload for a
+  /// broken pipe.
+  it("shows the message when the transport failed rather than the engine refusing", async () => {
+    useEditorStore.setState({ draft: emptyDraft(), base: "b1" });
+    vi.mocked(commands.saveCustomize).mockResolvedValue({
+      status: "error",
+      error: "the channel is gone" as unknown as WriteRefused,
+    });
+
+    await useEditorStore.getState().save();
+
+    expect(useEditorStore.getState().error).toBe("the channel is gone");
+    expect(useEditorStore.getState().stale).toBe(false);
   });
 
   /// The reload is the way out of a stale refusal: it replaces the copy

--- a/ui/src/stores/editor.ts
+++ b/ui/src/stores/editor.ts
@@ -7,6 +7,7 @@ import {
   type SettingsEdit,
 } from "@/bindings";
 import { type Draft, emptyDraft } from "@/lib/editor-draft";
+import { refusalKind, refusalWords } from "@/lib/refusal";
 
 import { writingRepo } from "@/lib/rescan";
 import { everyPlace, sameScope } from "@/lib/scope";
@@ -153,10 +154,10 @@ export const useEditorStore = create<EditorState>((set, get) => {
         // rather than taking the person's edits on its own. A refusal with
         // something to say about the packages leaving answers `failed`
         // instead, so nothing it said is dropped for the reload.
-        if (response.error.kind === "stale") {
+        if (refusalKind(response.error) === "stale") {
           set({ stale: true, error: null });
         } else {
-          set({ error: response.error.message, stale: false });
+          set({ error: refusalWords(response.error), stale: false });
         }
         return;
       }

--- a/ui/src/stores/notice.ts
+++ b/ui/src/stores/notice.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { type CommandNotice, commands, type InstallChannel } from "@/bindings";
 import { SETTINGS_MOVED_MESSAGE } from "@/lib/copy";
+import { refusalWords } from "@/lib/refusal";
 import { settled } from "@/lib/settled";
 
 /** The two versions the card names. Null until a check has found this
@@ -51,18 +52,15 @@ interface NoticeState {
 async function mute(version: string): Promise<string | null> {
   const read = await settled(commands.getSettings());
   if (read.status === "error") return read.error;
-  try {
-    const written = await commands.updateSettings(
-      { ...read.data.settings, "muted-app-notice": version },
-      read.data.base,
-    );
-    if (written.status === "ok") return null;
-    return written.error.kind === "failed"
-      ? written.error.message
-      : SETTINGS_MOVED_MESSAGE;
-  } catch (thrown) {
-    return thrown instanceof Error ? thrown.message : String(thrown);
-  }
+  const written = await commands.updateSettings(
+    { ...read.data.settings, "muted-app-notice": version },
+    read.data.base,
+  );
+  if (written.status === "ok") return null;
+  // The stale arm carries no words of its own, so the moved-file wording
+  // stands in for it alone — a transport failure has its own message and
+  // must not be reported as the file having moved.
+  return refusalWords(written.error) ?? SETTINGS_MOVED_MESSAGE;
 }
 
 /**

--- a/ui/src/stores/provenance.ts
+++ b/ui/src/stores/provenance.ts
@@ -44,9 +44,10 @@ export const useProvenanceStore = create<ProvenanceState>((set, get) => ({
       set({ rows: response.data, loaded: true });
       return true;
     } catch {
-      // The generated wrapper rethrows a transport failure rather than
-      // answering with an error status. A read that never answered is a
-      // failed read, not a rejection for every caller to catch.
+      // The wrapper folds a rejected command into an error status, so this
+      // is the last guard rather than the first: a read that never answered
+      // at all is still a failed read, not a rejection for every caller of
+      // this store to catch.
       return false;
     }
   },

--- a/ui/src/stores/settings.test.ts
+++ b/ui/src/stores/settings.test.ts
@@ -77,6 +77,27 @@ describe("settings store", () => {
     expect(useSettingsStore.getState().settings).toBe(settings);
   });
 
+  /// A transport failure folds into the refusal's place as the message
+  /// alone, which is neither arm of `WriteRefused`. Read by `kind` it misses
+  /// `failed`, falls to the stale-recovery arm, and reports a broken pipe as
+  /// the settings having changed in another window — while spending a
+  /// `getSettings` read to say it.
+  it("shows the message when the transport failed rather than the engine refusing", async () => {
+    useSettingsStore.setState({ settings });
+    vi.mocked(commands.updateSettings).mockResolvedValue({
+      status: "error",
+      error: "the channel is gone",
+    } as Awaited<ReturnType<typeof commands.updateSettings>>);
+
+    await useSettingsStore.getState().setAppearance("dark");
+
+    const dialog = useProblemsStore.getState().dialog;
+    expect(dialog.open).toBe(true);
+    expect(dialog.message).toBe("the channel is gone");
+    expect(commands.getSettings).not.toHaveBeenCalled();
+    expect(useSettingsStore.getState().settings).toBe(settings);
+  });
+
   it("saves settings silently on success — no toast, no modal for an instant, visible change", async () => {
     const updated = { ...settings, appearance: "dark" as const };
     useSettingsStore.setState({ settings });

--- a/ui/src/stores/settings.ts
+++ b/ui/src/stores/settings.ts
@@ -7,6 +7,7 @@ import {
   type SettingsRead,
   ZOOM,
 } from "@/bindings";
+import { refusalKind, refusalWords } from "@/lib/refusal";
 import { rescanEverything } from "@/lib/rescan";
 import { useProblemsStore } from "./problems";
 import { type ProjectsSlice, projectActions } from "./settings-projects";
@@ -63,7 +64,10 @@ export const useSettingsStore = create<SettingsState>((set, get) => {
       return { ok: false, message: "Your settings haven't loaded yet." };
     let at = ticket();
     let response = await commands.updateSettings(change(settings), base);
-    if (response.status === "error" && response.error.kind === "stale") {
+    if (
+      response.status === "error" &&
+      refusalKind(response.error) === "stale"
+    ) {
       const reread = ticket();
       const fresh = await commands.getSettings();
       // The re-read is the way out of a stale refusal. Failing, the fault
@@ -86,8 +90,8 @@ export const useSettingsStore = create<SettingsState>((set, get) => {
       hold(response.data, at);
       return { ok: true };
     }
-    if (response.error.kind === "failed")
-      return { ok: false, message: response.error.message };
+    const said = refusalWords(response.error);
+    if (said !== null) return { ok: false, message: said };
     // A second stale refusal means the file moved again after the re-read,
     // so the copy in hand is behind it. One read-only refresh earns the
     // claim that the latest settings are shown; when even that read fails,


### PR DESCRIPTION
## Summary

- `typedError` in the generated bindings rethrew the `Error` `__TAURI_INVOKE` rejects with, so a caller that fired a write and forgot it dropped the rejection: the busy flag fell, nothing was said, and the click read as having done nothing. The runtime now folds that rejection into the `{ status: "error" }` every caller already reads a refusal in. The fix is one place — `TYPED_ERROR_IMPL` handed to `Builder::typed_error_impl` in `crates/app/src/lib.rs` — not a catch at each of the five sites.
- The fold widens every shaped command's runtime error type, so the declared type is widened with it: `error: E | string`. That is the enforcement surface. A reader that branches on `.error.kind` or `.error.message` directly is now a `tsc` error, and `ui/src/lib/refusal.ts` (`refusalKind`, `refusalWords`, `isShapedRefusal`) is how a reader asks instead.
- Six shaped-refusal readers were converted, five found by the compiler rather than by hand. The sixth arrived during the rebase: main's KEN-1160 added `AccountReadFailed`, and `account-read.ts` read its fields raw — the widening turned that into a TS2339 on first contact instead of a silence found in production.

## Completed Issues

- Closes KEN-1184 - Transport rejections escape the repo_effects write paths with nothing shown

## Created Issues

- KEN-1196 - Four plain-value commands sit outside the transport fold, and three callers drop the rejection — Project: Tech Debt & Bugs

`tauri-specta` emits the runtime only for `Result`-returning commands, so `app_version`, `capability_table`, `mine_authoring_doc` and `window_zoom_state` (4 of 88) stay outside it and reject to their callers as before. Pre-existing and unarmed by this change; the prose here names them rather than claiming universal coverage.

## Test Plan

- `tools/guard` clean end to end: `tsc`, biome, all cargo lanes, 145 files / 1157 UI tests, size-ratchet, preflight.
- `crates/app/tests/bindings.rs` byte-checks `ui/src/bindings.ts` against what `specta_builder` emits, so the committed bindings cannot drift from the Rust constant.
- Controls, each proved by reverting the line it guards: the runtime's error and success arms (`ui/src/bindings.test.ts`), both string branches of `refusal.ts`, and one per converted reader — `editor.ts`, `settings.ts`, `notice.ts`, `mine-submit-dialog.tsx`, `account-submissions.ts`, `account-read.ts`.
- The enforcement itself is controlled, not assumed: reverting a reader to a raw `.kind`/`.message` read reds `tsc` with TS2339, and removing `| string` while keeping those readers drops TS2339 to zero — so a green typecheck is evidence that no unconverted reader remains, and `// @ts-nocheck` in `bindings.ts` does not defeat it.

Reviewed by nine reviewers across two cycles plus a focused verification pass over the rebase; 9 blockers found and fixed, 0 outstanding.

https://claude.ai/code/session_0146Dt87i8GAoSiW4Dp5f3WL
