### PR TITLE
fix(KEN-1140): an install is judged where it would land

### DIFF
--- a/changelog.d/fixed/ken-1140.md
+++ b/changelog.d/fixed/ken-1140.md
@@ -1,1 +1,1 @@
-- An install or subscription is judged against the place it would land in: a broken lock there withholds the button and says why, and a broken one somewhere else no longer blocks it.
+- An install or subscription is judged against the place it lands in: its records, a name already taken there, and that place's added instructions. A problem somewhere else no longer blocks it.

--- a/changelog.d/fixed/ken-1140.md
+++ b/changelog.d/fixed/ken-1140.md
@@ -1,0 +1,1 @@
+- An install or subscription is judged against the place it would land in: a broken lock there withholds the button and says why, and a broken one somewhere else no longer blocks it.

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -121,6 +121,7 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         marketplaces::marketplace_bundle,
         marketplaces::marketplace_bundles,
         marketplaces::marketplace_package_preview,
+        marketplaces::scope_records_unreadable,
         marketplaces::marketplace_package_file,
         marketplaces::install::marketplace_install,
         marketplaces::install::install_targets,

--- a/crates/app/src/marketplaces.rs
+++ b/crates/app/src/marketplaces.rs
@@ -232,7 +232,8 @@ pub fn marketplace_package_preview(
     let env = env()?;
     let preview = browse::package_preview(&env, &catalog, kind, &name, destination.as_ref())
         .map_err(|e| e.to_string())?;
-    let safety = browse::package_safety(&env, &catalog, kind, &name).map_err(|e| e.to_string())?;
+    let safety = browse::package_safety(&env, &catalog, kind, &name, destination.as_ref())
+        .map_err(|e| e.to_string())?;
     Ok(PackageView { preview, safety })
 }
 

--- a/crates/app/src/marketplaces.rs
+++ b/crates/app/src/marketplaces.rs
@@ -156,6 +156,19 @@ pub fn rows(env: &Env, scopes: &[Scope]) -> Result<Vec<MarketplaceRow>, String> 
     Ok(rows)
 }
 
+/// Whether one place's lock is beyond this build, asked for a scope no
+/// catalog was opened for. Subscribing plans against the chosen place's
+/// lock (`source_ops::persist_and_plan`), so a place whose record cannot
+/// be read refuses the write — and the Subscribe dialog says so beside the
+/// place it was chosen at rather than letting the engine's raw refusal
+/// stand in for the reason.
+#[tauri::command(async)]
+#[specta::specta]
+pub fn scope_records_unreadable(scope: Scope) -> Result<bool, String> {
+    let env = env()?;
+    Ok(browse::records_unreadable(&env, &scope))
+}
+
 /// Every package one catalog offers, across kinds, with installed state
 /// joined in.
 #[tauri::command(async)]
@@ -184,12 +197,19 @@ pub fn marketplace_bundles(catalog: Catalog) -> Result<Vec<BundleDetail>, String
     browse::bundles(&env, &catalog).map_err(|e| e.to_string())
 }
 
-/// One curated set with per-member installed state.
+/// One curated set with per-member installed state. `destination`
+/// redirects the install into a project, and every answer about records —
+/// each member's state and the set's own `records_unreadable` — is then
+/// about that project, which is the scope the engine mutates.
 #[tauri::command(async)]
 #[specta::specta]
-pub fn marketplace_bundle(catalog: Catalog, name: String) -> Result<BundleDetail, String> {
+pub fn marketplace_bundle(
+    catalog: Catalog,
+    name: String,
+    destination: Option<Scope>,
+) -> Result<BundleDetail, String> {
     let env = env()?;
-    browse::bundle(&env, &catalog, &name).map_err(|e| e.to_string())
+    browse::bundle(&env, &catalog, &name, destination.as_ref()).map_err(|e| e.to_string())
 }
 
 /// The available-package page's one payload: the preview beside the safety

--- a/crates/core/src/source/browse.rs
+++ b/crates/core/src/source/browse.rs
@@ -59,19 +59,20 @@ pub enum InstallState {
     /// what it found, so nothing installs — but the catalog does carry the
     /// name, and saying it is not offered would be the opposite of true.
     OfferedMoreThanOnce,
-    /// This scope's lock could not be read, so whether the package is
-    /// installed here is unknown. The catalog is still listed — what a
-    /// source offers is a fact about the source — but every standing the
-    /// lock alone could have given becomes this one, decided in
-    /// `Browsed::state` and `Browsed::member_state` and nowhere else. Every
-    /// surface offering an install for one package reads the state: the
-    /// Packages row, a set's member row, and the available-package page
-    /// (through [`PackagePreview::state`]) all say why instead, so none
-    /// offers an install the engine would refuse for the same unreadable
-    /// record. The state answers for the BROWSED scope: an install a page
-    /// redirects into a different scope is not yet judged against that
-    /// destination's record. The set page's Install all is about the set,
-    /// not a package, and reads [`BundleDetail::records_unreadable`].
+    /// The scope this state answers for has a lock that could not be read,
+    /// so whether the package is installed there is unknown. The catalog is
+    /// still listed — what a source offers is a fact about the source — but
+    /// every standing the lock alone could have given becomes this one,
+    /// decided in `Browsed::state` and `Browsed::member_state` and nowhere
+    /// else. Every surface offering an install for one package reads the
+    /// state: the Packages row, a set's member row, and the
+    /// available-package page (through [`PackagePreview::state`]) all say
+    /// why instead, so none offers an install the engine would refuse for
+    /// the same unreadable record. The scope is the one the install would
+    /// land in — the browsed catalog's own, or the destination a page
+    /// redirects into, which is the scope the engine mutates. The set
+    /// page's Install all is about the set, not a package, and reads
+    /// [`BundleDetail::records_unreadable`].
     Unknown,
 }
 
@@ -124,13 +125,14 @@ pub struct BundleDetail {
     pub installed_members: u32,
     pub total_members: u32,
     pub collision: Option<String>,
-    /// This scope's lock could not be read. The set page's Install all asks
-    /// about the set rather than about a member, so it needs the scope's own
-    /// answer: no member row can carry it, because a member the catalog no
-    /// longer offers reads [`InstallState::NotOffered`] with or without a
-    /// lock, and a set whose members were all dropped — or one declared with
-    /// none — would leave the page deriving "readable" from rows that never
-    /// consulted the record.
+    /// The lock of the scope this read answers for — the destination where
+    /// the install is redirected, the browsed scope otherwise — could not be
+    /// read. The set page's Install all asks about the set rather than about
+    /// a member, so it needs that scope's own answer: no member row can
+    /// carry it, because a member the catalog no longer offers reads
+    /// [`InstallState::NotOffered`] with or without a lock, and a set whose
+    /// members were all dropped — or one declared with none — would leave the
+    /// page deriving "readable" from rows that never consulted the record.
     pub records_unreadable: bool,
 }
 
@@ -171,7 +173,7 @@ pub fn packages(env: &Env, catalog: &Catalog) -> Result<Vec<AvailablePackage>> {
         // deceptive characters escaped rather than acted on.
         let bundles: Vec<String> = carried_bundles.iter().map(|b| names::shown(b)).collect();
         out.push(AvailablePackage {
-            state: browsed.state(kind, &name),
+            state: browsed.state(browsed.records(), kind, &name),
             collision: browsed.collision(kind, &name),
             description: header.description.as_deref().map(names::shown),
             summary: header.summary_or_description().map(names::shown),
@@ -181,11 +183,7 @@ pub fn packages(env: &Env, catalog: &Catalog) -> Result<Vec<AvailablePackage>> {
             dependencies: deps::dependencies(
                 &browsed,
                 &offered,
-                &deps::Where {
-                    manifest: &browsed.manifest,
-                    lock: browsed.lock(),
-                    subscription: browsed.subscription(),
-                },
+                browsed.records(),
                 kind,
                 &name,
                 text.as_deref(),
@@ -209,30 +207,47 @@ pub fn bundles(env: &Env, catalog: &Catalog) -> Result<Vec<BundleDetail>> {
     let browsed = open(env, catalog)?;
     let mut out: Vec<BundleDetail> = super::bundles::offered(&browsed.sealed, &browsed.config)?
         .iter()
-        .map(|found| detail(&browsed, found))
+        .map(|found| detail(&browsed, browsed.records(), found))
         .collect();
     out.sort_by(|a, b| a.name.cmp(&b.name));
     Ok(out)
 }
 
-/// One curated set with per-member installed state.
-pub fn bundle(env: &Env, catalog: &Catalog, bundle_name: &str) -> Result<BundleDetail> {
+/// One curated set with per-member installed state. `destination` redirects
+/// the install into a project, exactly as it does for a package's preview:
+/// the members come from the catalog, and every answer about records — each
+/// member's state and the set's own [`BundleDetail::records_unreadable`] —
+/// is about the scope the install would land in.
+pub fn bundle(
+    env: &Env,
+    catalog: &Catalog,
+    bundle_name: &str,
+    destination: Option<&crate::model::Scope>,
+) -> Result<BundleDetail> {
     let browsed = open(env, catalog)?;
+    let redirected = destination
+        .map(|scope| opened::records_of(env, scope))
+        .transpose()?;
     let Some(found) = super::bundles::find(&browsed.sealed, &browsed.config, bundle_name)? else {
         return Err(CoreError::NoSuchBundle {
             name: bundle_name.to_owned(),
             source_name: catalog.label().to_owned(),
         });
     };
-    Ok(detail(&browsed, &found))
+    let landing = redirected.as_ref().unwrap_or(browsed.records());
+    Ok(detail(&browsed, landing, &found))
 }
 
-/// A declared set joined against this scope: every member's state, and the
+/// A declared set joined against `landing`: every member's state, and the
 /// installed/total pair derived from them.
-fn detail(browsed: &Browsed, found: &super::bundles::CatalogBundle) -> BundleDetail {
+fn detail(
+    browsed: &Browsed,
+    landing: &opened::Records,
+    found: &super::bundles::CatalogBundle,
+) -> BundleDetail {
     let mut members = Vec::new();
     for member in &found.members {
-        let state = browsed.member_state(member.kind, &member.name);
+        let state = browsed.member_state(landing, member.kind, &member.name);
         members.push(BundleMemberRow {
             kind: member.kind,
             // Catalog-authored, so shown with any control or deceptive
@@ -254,7 +269,7 @@ fn detail(browsed: &Browsed, found: &super::bundles::CatalogBundle) -> BundleDet
         total_members: members.len().min(u32::MAX as usize) as u32,
         members,
         collision: browsed.bundle_collision(&found.name),
-        records_unreadable: browsed.lock_unreadable(),
+        records_unreadable: landing.lock_unreadable(),
     }
 }
 

--- a/crates/core/src/source/browse.rs
+++ b/crates/core/src/source/browse.rs
@@ -214,10 +214,10 @@ pub fn bundles(env: &Env, catalog: &Catalog) -> Result<Vec<BundleDetail>> {
 }
 
 /// One curated set with per-member installed state. `destination` redirects
-/// the install into a project, exactly as it does for a package's preview:
-/// the members come from the catalog, and every answer about records — each
-/// member's state and the set's own [`BundleDetail::records_unreadable`] —
-/// is about the scope the install would land in.
+/// the install into a project: the members come from the catalog, and every
+/// answer about records — each member's state and the set's own
+/// [`BundleDetail::records_unreadable`] — is about the scope the install
+/// would land in.
 pub fn bundle(
     env: &Env,
     catalog: &Catalog,

--- a/crates/core/src/source/browse.rs
+++ b/crates/core/src/source/browse.rs
@@ -225,17 +225,14 @@ pub fn bundle(
     destination: Option<&crate::model::Scope>,
 ) -> Result<BundleDetail> {
     let browsed = open(env, catalog)?;
-    let redirected = destination
-        .map(|scope| opened::records_of(env, scope))
-        .transpose()?;
+    let landing = opened::landing(env, &browsed, destination)?;
     let Some(found) = super::bundles::find(&browsed.sealed, &browsed.config, bundle_name)? else {
         return Err(CoreError::NoSuchBundle {
             name: bundle_name.to_owned(),
             source_name: catalog.label().to_owned(),
         });
     };
-    let landing = redirected.as_ref().unwrap_or(browsed.records());
-    Ok(detail(&browsed, landing, &found))
+    Ok(detail(&browsed, &landing, &found))
 }
 
 /// A declared set joined against `landing`: every member's state, and the

--- a/crates/core/src/source/browse.rs
+++ b/crates/core/src/source/browse.rs
@@ -174,7 +174,7 @@ pub fn packages(env: &Env, catalog: &Catalog) -> Result<Vec<AvailablePackage>> {
         let bundles: Vec<String> = carried_bundles.iter().map(|b| names::shown(b)).collect();
         out.push(AvailablePackage {
             state: browsed.state(browsed.records(), kind, &name),
-            collision: browsed.collision(kind, &name),
+            collision: browsed.collision(browsed.records(), kind, &name),
             description: header.description.as_deref().map(names::shown),
             summary: header.summary_or_description().map(names::shown),
             tags: header.tags,
@@ -265,7 +265,7 @@ fn detail(
         installed_members: installed.min(u32::MAX as usize) as u32,
         total_members: members.len().min(u32::MAX as usize) as u32,
         members,
-        collision: browsed.bundle_collision(&found.name),
+        collision: browsed.bundle_collision(landing, &found.name),
         records_unreadable: landing.lock_unreadable(),
     }
 }

--- a/crates/core/src/source/browse/deps.rs
+++ b/crates/core/src/source/browse/deps.rs
@@ -15,13 +15,11 @@ use serde::{Deserialize, Serialize};
 use specta::Type;
 
 use crate::engine::deps::OfferedSkills;
-use crate::lock::Lock;
-use crate::manifest::Manifest;
 use crate::model::ItemKind;
 use crate::names;
 
 use super::InstallState;
-use super::opened::Browsed;
+use super::opened::{Browsed, Records};
 
 /// One declared dependency, with where it stands in this scope.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Type)]
@@ -55,47 +53,16 @@ impl PackageDependencies {
     }
 }
 
-/// Which scope's records a dependency's state is read from: what is
-/// already installed there, and what was kept removed. The browsed scope
-/// answers unless the install is being redirected, in which case the
-/// destination does — that is where the install lands, so its removals and
-/// its installations are the ones the row is about.
-pub(super) struct Where<'a> {
-    pub(super) manifest: &'a Manifest,
-    /// `None` where the landing scope's lock could not be read: what is
-    /// installed there is then unknown, and a dependency says so rather
-    /// than claiming it is missing.
-    pub(super) lock: Option<&'a Lock>,
-    /// The subscription the catalog is browsed as. A redirected install
-    /// installs from the same subscription name in the destination.
-    pub(super) subscription: Option<&'a str>,
-}
-
-impl Where<'_> {
-    fn state(&self, kind: ItemKind, name: &str) -> InstallState {
-        let Some(lock) = self.lock else {
-            return InstallState::Unknown;
-        };
-        let locked = lock.entries.values().any(|entry| {
-            entry.kind == kind
-                && entry.name == name
-                && self.subscription == Some(entry.source.as_str())
-        });
-        match locked {
-            true => InstallState::Installed,
-            false => InstallState::Available,
-        }
-    }
-}
-
 /// What this package declares it needs, against this catalog and the scope
-/// the install would land in. `offered` is the catalog's bare-name index,
-/// shared across every package in one read; `text` is the package's own
-/// SKILL.md, already read by the caller that also wants its header.
+/// the install would land in — `landing`, which is the destination where a
+/// page redirects the install and the browsed scope otherwise. `offered` is
+/// the catalog's bare-name index, shared across every package in one read;
+/// `text` is the package's own SKILL.md, already read by the caller that
+/// also wants its header.
 pub(super) fn dependencies(
     browsed: &Browsed,
     offered: &OfferedSkills,
-    landing: &Where<'_>,
+    landing: &Records,
     kind: ItemKind,
     name: &str,
     text: Option<&str>,
@@ -128,7 +95,7 @@ pub(super) fn dependencies(
 fn row(
     browsed: &Browsed,
     offered: &OfferedSkills,
-    landing: &Where<'_>,
+    landing: &Records,
     package: &str,
     declared: &str,
 ) -> Option<PackageDependency> {
@@ -145,7 +112,7 @@ fn row(
             // ladder a bundle member's row climbs, and the same predicate
             // `engine::deps::wanted_by` refuses on.
             Ok(name) if landing.manifest.is_held_back(kind, name) => InstallState::RemovedByYou,
-            Ok(name) => landing.state(kind, name),
+            Ok(name) => browsed.state(landing, kind, name),
             // The two ways a name resolves to nothing are not one state:
             // the catalog carrying it twice under different plugins is
             // what `engine::deps::resolve` warns about by name at install

--- a/crates/core/src/source/browse/opened.rs
+++ b/crates/core/src/source/browse/opened.rs
@@ -15,15 +15,9 @@ use super::super::{ResolvedSource, SourceConfig, find_item, require_ready, sourc
 use super::catalog::browsable;
 use super::{Catalog, InstallState};
 
-/// One catalog opened for reading, with the scope records the
-/// installed-state join needs.
+/// One catalog opened for reading, with the browsed scope's own records.
 pub(crate) struct Browsed {
-    pub(crate) manifest: Manifest,
-    /// `None` where this scope's lock could not be read — a damaged record
-    /// or one an older kendex wrote. What a source offers is a fact about
-    /// the source, so listing goes ahead without it; every answer the lock
-    /// alone can give is [`InstallState::Unknown`] instead of a guess.
-    lock: Option<Lock>,
+    records: Records,
     pub(crate) source: ResolvedSource,
     pub(crate) sealed: SealedSource,
     pub(crate) config: SourceConfig,
@@ -31,11 +25,27 @@ pub(crate) struct Browsed {
     subscription: Option<String>,
 }
 
-/// One scope's records, read for a state join that is not the browsed
-/// scope's: an install redirected into a project lands there, so what is
-/// already installed and what was kept removed are that project's answers.
-/// The lock travels as its absence here for the same reason it does below.
-pub(crate) fn records_of(env: &Env, scope: &Scope) -> Result<(Manifest, Option<Lock>)> {
+/// One scope's records, as every installed-state join reads them: what is
+/// installed there, and what the person kept removed there.
+///
+/// Which scope's is the question this type exists to keep answerable. The
+/// browsed catalog's own scope answers unless a page redirects the install
+/// into a project, and then that project's records do —
+/// [`crate::engine::ops::add_seeded`] mutates the scope it is handed, so a
+/// surface reading anything else offers a button the engine refuses on a
+/// record the reader was never shown.
+pub(crate) struct Records {
+    pub(crate) manifest: Manifest,
+    /// `None` where this scope's lock could not be read — a damaged record
+    /// or one an older kendex wrote. What a source offers is a fact about
+    /// the source, so listing goes ahead without it; every answer the lock
+    /// alone can give is [`InstallState::Unknown`] instead of a guess.
+    lock: Option<Lock>,
+}
+
+/// The records of a scope no catalog was opened for: the destination a
+/// redirected install lands in.
+pub(crate) fn records_of(env: &Env, scope: &Scope) -> Result<Records> {
     records(env, scope)
 }
 
@@ -45,15 +55,34 @@ pub(crate) fn records_of(env: &Env, scope: &Scope) -> Result<(Manifest, Option<L
 /// its absence so one place's broken record never hides what every
 /// subscribed catalog offers. The Problems page is where that record is
 /// explained and fixed.
-fn records(env: &Env, scope: &Scope) -> Result<(Manifest, Option<Lock>)> {
+fn records(env: &Env, scope: &Scope) -> Result<Records> {
     let manifest = crate::manifest::load_current(&crate::manifest::manifest_path(env, scope))?
         .unwrap_or_default();
-    Ok((manifest, lock_of(env, scope)))
+    Ok(Records {
+        manifest,
+        lock: lock_of(env, scope),
+    })
+}
+
+impl Records {
+    /// Whether this scope's lock could NOT be read at all.
+    pub(super) fn lock_unreadable(&self) -> bool {
+        self.lock.is_none()
+    }
+
+    /// An installation of this package recorded here, from `source`.
+    fn locked_from(&self, source: Option<&str>, kind: ItemKind, name: &str) -> bool {
+        self.lock.as_ref().is_some_and(|lock| {
+            lock.entries.values().any(|entry| {
+                entry.kind == kind && entry.name == name && source == Some(entry.source.as_str())
+            })
+        })
+    }
 }
 
 /// This scope's lock, or `None` where it could not be read. The one place
 /// that decides what "unreadable" means, so every carrier of the fact —
-/// [`Browsed::lock_unreadable`] and [`records_unreadable`] — answers alike.
+/// [`Records::lock_unreadable`] and [`records_unreadable`] — answers alike.
 fn lock_of(env: &Env, scope: &Scope) -> Option<Lock> {
     crate::lock::load(&crate::lock::lock_path(env, scope)).ok()
 }
@@ -69,9 +98,9 @@ pub fn records_unreadable(env: &Env, scope: &Scope) -> bool {
 pub(crate) fn open(env: &Env, catalog: &Catalog) -> Result<Browsed> {
     match catalog {
         Catalog::Subscription { scope, source } => {
-            let (manifest, lock) = records(env, scope)?;
-            let resolved = require_ready(env, scope, source, &manifest)?;
-            browsed(manifest, lock, resolved, Some(source.clone()))
+            let records = records(env, scope)?;
+            let resolved = require_ready(env, scope, source, &records.manifest)?;
+            browsed(records, resolved, Some(source.clone()))
         }
         Catalog::Repo { repo } => {
             let key = browsable(repo)?;
@@ -96,27 +125,25 @@ pub(crate) fn open_repo(
     // Collisions are judged against the personal scope: that is where
     // Subscribe lands by default, so the warning shown here is the refusal
     // an install there would meet.
-    let (manifest, lock) = records(env, &Scope::Global)?;
+    let records = records(env, &Scope::Global)?;
     let source = ResolvedSource {
         name: key.clone(),
         root: resolution.root,
         provenance: key,
         commit: Some(resolution.commit),
     };
-    browsed(manifest, lock, source, None)
+    browsed(records, source, None)
 }
 
 fn browsed(
-    manifest: Manifest,
-    lock: Option<Lock>,
+    records: Records,
     source: ResolvedSource,
     subscription: Option<String>,
 ) -> Result<Browsed> {
     let sealed = SealedSource::open(&source.root)?;
     let config = source_config_for(&sealed, &source.provenance)?;
     Ok(Browsed {
-        manifest,
-        lock,
+        records,
         source,
         sealed,
         config,
@@ -139,48 +166,42 @@ impl Browsed {
         self.subscription.as_deref()
     }
 
-    /// This scope's lock, or `None` where it could not be read.
-    pub(super) fn lock(&self) -> Option<&Lock> {
-        self.lock.as_ref()
-    }
-
-    /// Whether this scope's lock could NOT be read at all.
-    pub(super) fn lock_unreadable(&self) -> bool {
-        self.lock.is_none()
-    }
-
-    pub(super) fn locked_here(&self, kind: ItemKind, name: &str) -> bool {
-        self.lock.as_ref().is_some_and(|lock| {
-            lock.entries.values().any(|entry| {
-                entry.kind == kind && entry.name == name && self.owned_here(&entry.source)
-            })
-        })
+    /// The browsed scope's own records — what every read joins against
+    /// unless the caller was handed a destination to redirect into.
+    pub(super) fn records(&self) -> &Records {
+        &self.records
     }
 
     /// The lock+manifest join behind every state column: an installation
     /// recorded from here, or the package on offer.
     ///
+    /// `landing` is the scope the answer is about — [`Browsed::records`]
+    /// for a page that installs where it browses, the destination's
+    /// [`Records`] for one redirecting into a project. Only the records
+    /// move: the subscription an installation must have come from is the
+    /// catalog's, and a redirected install installs from that same name.
+    ///
     /// This and [`Browsed::member_state`] are the only two answers to
-    /// "where does this stand here", and both open with the same refusal:
+    /// "where does this stand there", and both open with the same refusal:
     /// where the lock could not be read, every standing it alone could
     /// have given is [`InstallState::Unknown`]. Every surface offering an
     /// install for ONE package reads that state rather than deciding for
     /// itself, so a new one inherits the rule instead of needing its own
     /// arm. The set page's Install all asks about the set rather than a
     /// package and reads [`super::BundleDetail::records_unreadable`].
-    pub(super) fn state(&self, kind: ItemKind, name: &str) -> InstallState {
-        if self.lock_unreadable() {
+    pub(super) fn state(&self, landing: &Records, kind: ItemKind, name: &str) -> InstallState {
+        if landing.lock_unreadable() {
             return InstallState::Unknown;
         }
-        match self.locked_here(kind, name) {
+        match landing.locked_from(self.subscription(), kind, name) {
             true => InstallState::Installed,
             false => InstallState::Available,
         }
     }
 
-    /// One curated-set member's standing. A member the catalog names but no
-    /// longer carries is a row, not a hard error: one bad entry must not
-    /// sink the whole page.
+    /// One curated-set member's standing in `landing`. A member the catalog
+    /// names but no longer carries is a row, not a hard error: one bad
+    /// entry must not sink the whole page.
     ///
     /// Where the lock could not be read the whole join goes first, ahead of
     /// suppression: "you removed this" is the manifest's word, but the row
@@ -190,20 +211,25 @@ impl Browsed {
     /// way; with a readable lock, suppression still outranks it — that a
     /// removal was the user's own choice is worth saying about a member the
     /// catalog has since dropped.
-    pub(super) fn member_state(&self, kind: ItemKind, name: &str) -> InstallState {
+    pub(super) fn member_state(
+        &self,
+        landing: &Records,
+        kind: ItemKind,
+        name: &str,
+    ) -> InstallState {
         let offered = find_item(&self.sealed, &self.config, kind, name).is_some();
-        if self.lock_unreadable() {
+        if landing.lock_unreadable() {
             return match offered {
                 true => InstallState::Unknown,
                 false => InstallState::NotOffered,
             };
         }
-        if self.locked_here(kind, name) {
+        if landing.locked_from(self.subscription(), kind, name) {
             return InstallState::Installed;
         }
         // Removed by the user, and recorded so the bundle cannot derive it
         // back — their choice, shown as such with a way to reverse it.
-        if self.manifest.is_suppressed(kind, name) {
+        if landing.manifest.is_suppressed(kind, name) {
             return InstallState::RemovedByYou;
         }
         match offered {
@@ -220,13 +246,20 @@ impl Browsed {
     /// offers an install for the engine to refuse — every standing the
     /// lock could have answered is [`InstallState::Unknown`], and the
     /// install surfaces gate on it.
+    ///
+    /// The scope is the BROWSED one, and stays so under a redirect: what
+    /// this reports is the name clash the catalog's own scope holds, while
+    /// invariant 4's refusal is judged where the install lands. Said here
+    /// rather than claimed away — the refusal is the engine's, and this
+    /// only shows what it can see before the click.
     pub(super) fn collision(&self, kind: ItemKind, name: &str) -> Option<String> {
-        if let Some(decl) = self.manifest.declared(kind).get(name)
+        if let Some(decl) = self.records.manifest.declared(kind).get(name)
             && !self.owned_here(&decl.source)
         {
             return Some(decl.source.clone());
         }
-        self.lock
+        self.records
+            .lock
             .iter()
             .flat_map(|lock| lock.entries.values())
             .find(|entry| {
@@ -236,7 +269,8 @@ impl Browsed {
     }
 
     pub(super) fn bundle_collision(&self, name: &str) -> Option<String> {
-        self.manifest
+        self.records
+            .manifest
             .bundles
             .get(name)
             .filter(|decl| !self.owned_here(&decl.source))

--- a/crates/core/src/source/browse/opened.rs
+++ b/crates/core/src/source/browse/opened.rs
@@ -37,8 +37,7 @@ pub(crate) struct Browsed {
 /// surface reading anything else offers a button the engine refuses on a
 /// record the reader was never shown.
 ///
-/// `Clone` is [`Cow`]'s bound in [`landing`] and nothing else: the borrowed
-/// arm is what every unredirected read takes, and nothing calls `to_mut`.
+/// `Clone` is [`Cow`]'s bound in [`landing`].
 #[derive(Clone)]
 pub(crate) struct Records {
     pub(crate) manifest: Manifest,

--- a/crates/core/src/source/browse/opened.rs
+++ b/crates/core/src/source/browse/opened.rs
@@ -252,27 +252,34 @@ impl Browsed {
         }
     }
 
-    /// The source a name is already taken by, when it is not this one. A
-    /// fork counts too — `local` is a source like any other here.
+    /// The source a name is already taken by in `landing`, when it is not
+    /// this one. A fork counts too — `local` is a source like any other
+    /// here.
+    ///
+    /// `landing` is the scope the answer is about, the same parameter
+    /// [`Browsed::state`] takes: the engine judges invariant 4 against the
+    /// scope [`crate::engine::ops::add_seeded`] mutates, so the warning
+    /// shown before the click reads that scope's records. Only the records
+    /// move — whether a name is "ours" is the catalog's subscription name,
+    /// which is [`Browsed::owned_here`].
     ///
     /// A collision only the lock records goes unseen where the lock could
     /// not be read; nothing acts on that, because no row in such a scope
     /// offers an install for the engine to refuse — every standing the
     /// lock could have answered is [`InstallState::Unknown`], and the
     /// install surfaces gate on it.
-    ///
-    /// The scope is the BROWSED one, and stays so under a redirect: what
-    /// this reports is the name clash the catalog's own scope holds, while
-    /// invariant 4's refusal is judged where the install lands. Said here
-    /// rather than claimed away — the refusal is the engine's, and this
-    /// only shows what it can see before the click.
-    pub(super) fn collision(&self, kind: ItemKind, name: &str) -> Option<String> {
-        if let Some(decl) = self.records.manifest.declared(kind).get(name)
+    pub(super) fn collision(
+        &self,
+        landing: &Records,
+        kind: ItemKind,
+        name: &str,
+    ) -> Option<String> {
+        if let Some(decl) = landing.manifest.declared(kind).get(name)
             && !self.owned_here(&decl.source)
         {
             return Some(decl.source.clone());
         }
-        self.records
+        landing
             .lock
             .iter()
             .flat_map(|lock| lock.entries.values())
@@ -282,8 +289,10 @@ impl Browsed {
             .map(|entry| entry.source.clone())
     }
 
-    pub(super) fn bundle_collision(&self, name: &str) -> Option<String> {
-        self.records
+    /// The source a set's name is already taken by in `landing`, read the
+    /// same way and for the same reason as [`Browsed::collision`].
+    pub(super) fn bundle_collision(&self, landing: &Records, name: &str) -> Option<String> {
+        landing
             .manifest
             .bundles
             .get(name)

--- a/crates/core/src/source/browse/opened.rs
+++ b/crates/core/src/source/browse/opened.rs
@@ -4,6 +4,8 @@
 //! bytes, at which revision, joined against whose records — and the pages
 //! above read the answer rather than each assembling it.
 
+use std::borrow::Cow;
+
 use crate::env::Env;
 use crate::error::Result;
 use crate::lock::Lock;
@@ -34,6 +36,10 @@ pub(crate) struct Browsed {
 /// [`crate::engine::ops::add_seeded`] mutates the scope it is handed, so a
 /// surface reading anything else offers a button the engine refuses on a
 /// record the reader was never shown.
+///
+/// `Clone` is [`Cow`]'s bound in [`landing`] and nothing else: the borrowed
+/// arm is what every unredirected read takes, and nothing calls `to_mut`.
+#[derive(Clone)]
 pub(crate) struct Records {
     pub(crate) manifest: Manifest,
     /// `None` where this scope's lock could not be read — a damaged record
@@ -43,10 +49,19 @@ pub(crate) struct Records {
     lock: Option<Lock>,
 }
 
-/// The records of a scope no catalog was opened for: the destination a
-/// redirected install lands in.
-pub(crate) fn records_of(env: &Env, scope: &Scope) -> Result<Records> {
-    records(env, scope)
+/// Which scope's records one read answers for: the destination's where a
+/// page redirects the install into one, the browsed catalog's own where it
+/// does not. Resolved here rather than at each read, so a destination-aware
+/// read added later inherits the rule instead of restating it.
+pub(crate) fn landing<'a>(
+    env: &Env,
+    browsed: &'a Browsed,
+    destination: Option<&Scope>,
+) -> Result<Cow<'a, Records>> {
+    Ok(match destination {
+        Some(scope) => Cow::Owned(records(env, scope)?),
+        None => Cow::Borrowed(browsed.records()),
+    })
 }
 
 /// The scope records the installed-state join reads. The manifest decides

--- a/crates/core/src/source/browse/preview.rs
+++ b/crates/core/src/source/browse/preview.rs
@@ -116,7 +116,7 @@ pub fn package_preview(
             text.as_deref(),
         ),
         state: browsed.state(&landing, kind, name),
-        collision: browsed.collision(kind, name),
+        collision: browsed.collision(&landing, kind, name),
     })
 }
 

--- a/crates/core/src/source/browse/preview.rs
+++ b/crates/core/src/source/browse/preview.rs
@@ -32,9 +32,11 @@ pub struct PackagePreview {
     pub bundles: Vec<String>,
     /// What installing it takes along, and what it offers to take.
     pub dependencies: super::PackageDependencies,
-    /// Where this package stands in the browsed scope, by the same join the
-    /// Packages row shows. The page installs, so it needs the answer the
-    /// row has: [`InstallState::Unknown`] where the scope's lock could not
+    /// Where this package stands in the scope the install would land in —
+    /// the destination when the page redirects into one, the browsed scope
+    /// otherwise — by the same join the Packages row shows. The page
+    /// installs, so it needs the answer for the scope the engine will
+    /// mutate: [`InstallState::Unknown`] where that scope's lock could not
     /// be read, and the page offers the reason rather than a button the
     /// engine would refuse for that same record.
     pub state: InstallState,
@@ -42,9 +44,11 @@ pub struct PackagePreview {
 }
 
 /// `destination` redirects an install into a project. The package's bytes
-/// still come from the subscription; only the dependency state join moves,
-/// because what is already installed and what was kept removed are facts
-/// about the scope the install would land in.
+/// still come from the subscription; every state join moves onto the
+/// destination — its own state and its dependencies' alike — because what
+/// is already installed, what was kept removed, and whether the record can
+/// be read at all are facts about the scope the install would land in, and
+/// that is the scope [`crate::engine::ops::add_seeded`] mutates.
 pub fn package_preview(
     env: &Env,
     catalog: &Catalog,
@@ -91,6 +95,7 @@ pub fn package_preview(
             bundles.push(offered.name);
         }
     }
+    let landing = redirected.as_ref().unwrap_or(browsed.records());
     // The path this function already resolved, rather than a second walk
     // for the same item.
     let text = super::item_text(&browsed, kind, Some(path.as_path()));
@@ -108,16 +113,12 @@ pub fn package_preview(
         dependencies: super::deps::dependencies(
             &browsed,
             &crate::engine::deps::OfferedSkills::default(),
-            &super::deps::Where {
-                manifest: redirected.as_ref().map_or(&browsed.manifest, |r| &r.0),
-                lock: redirected.as_ref().map_or(browsed.lock(), |r| r.1.as_ref()),
-                subscription: browsed.subscription(),
-            },
+            landing,
             kind,
             name,
             text.as_deref(),
         ),
-        state: browsed.state(kind, name),
+        state: browsed.state(landing, kind, name),
         collision: browsed.collision(kind, name),
     })
 }

--- a/crates/core/src/source/browse/preview.rs
+++ b/crates/core/src/source/browse/preview.rs
@@ -57,9 +57,7 @@ pub fn package_preview(
     destination: Option<&crate::model::Scope>,
 ) -> Result<PackagePreview> {
     let browsed = super::open(env, catalog)?;
-    let redirected = destination
-        .map(|scope| super::opened::records_of(env, scope))
-        .transpose()?;
+    let landing = super::opened::landing(env, &browsed, destination)?;
     let Some(path) = crate::source::find_item(&browsed.sealed, &browsed.config, kind, name) else {
         return Err(CoreError::ItemNotInSource {
             name: name.to_owned(),
@@ -95,7 +93,6 @@ pub fn package_preview(
             bundles.push(offered.name);
         }
     }
-    let landing = redirected.as_ref().unwrap_or(browsed.records());
     // The path this function already resolved, rather than a second walk
     // for the same item.
     let text = super::item_text(&browsed, kind, Some(path.as_path()));
@@ -113,12 +110,12 @@ pub fn package_preview(
         dependencies: super::deps::dependencies(
             &browsed,
             &crate::engine::deps::OfferedSkills::default(),
-            landing,
+            &landing,
             kind,
             name,
             text.as_deref(),
         ),
-        state: browsed.state(landing, kind, name),
+        state: browsed.state(&landing, kind, name),
         collision: browsed.collision(kind, name),
     })
 }

--- a/crates/core/src/source/browse/safety.rs
+++ b/crates/core/src/source/browse/safety.rs
@@ -75,7 +75,7 @@ pub fn package_safety(
     // what installs. Nobody has scored that combination yet, so the page
     // says what it did not read.
     let mut notes = Vec::new();
-    if injected_here(&browsed.manifest, kind, name) {
+    if injected_here(&browsed.records().manifest, kind, name) {
         notes.push(format!(
             "this project adds its own instructions to {name}; they are not in this preview and are scored when it installs"
         ));

--- a/crates/core/src/source/browse/safety.rs
+++ b/crates/core/src/source/browse/safety.rs
@@ -62,26 +62,25 @@ pub struct PackageSafety {
     pub from_cache: bool,
 }
 
+/// `destination` redirects the install into a project. The bytes scored are
+/// the catalog's either way; what moves is the note below, because the
+/// instructions a project adds to what installs are that project's.
 pub fn package_safety(
     env: &Env,
     catalog: &Catalog,
     kind: ItemKind,
     name: &str,
+    destination: Option<&crate::model::Scope>,
 ) -> Result<PackageSafety> {
     let browsed = super::open(env, catalog)?;
+    let landing = super::opened::landing(env, &browsed, destination)?;
     let item = item(&browsed, kind, name)?;
     let (score, from_cache) = scored(env, &browsed, kind, name, &item)?;
-    // The preview reads the catalog, and this project adds its own text to
-    // what installs. Nobody has scored that combination yet, so the page
-    // says what it did not read.
-    //
-    // The manifest is the BROWSED scope's, and stays so under a redirect:
-    // this read takes no destination, so an install redirected into a
-    // project that injects its own instructions gets no note about them.
-    // Said here rather than claimed away — the note is advisory, and the
-    // scoring an install runs reads the scope it lands in.
+    // The preview reads the catalog, and the scope the install lands in
+    // adds its own text to what installs there. Nobody has scored that
+    // combination yet, so the page says what it did not read.
     let mut notes = Vec::new();
-    if injected_here(&browsed.records().manifest, kind, name) {
+    if injected_here(&landing.manifest, kind, name) {
         notes.push(format!(
             "this project adds its own instructions to {name}; they are not in this preview and are scored when it installs"
         ));
@@ -96,7 +95,9 @@ pub fn package_safety(
     })
 }
 
-/// Whether this project contributes anything to this item's rendering.
+/// Whether the scope this manifest belongs to contributes anything to this
+/// item's rendering — the scope the install would land in, which is the one
+/// whose instructions the installed item would carry.
 ///
 /// Asked of the same enumeration the rendering subtracts by, never of a
 /// second transcription of it: two lists of one thing is how both ended up

--- a/crates/core/src/source/browse/safety.rs
+++ b/crates/core/src/source/browse/safety.rs
@@ -74,6 +74,12 @@ pub fn package_safety(
     // The preview reads the catalog, and this project adds its own text to
     // what installs. Nobody has scored that combination yet, so the page
     // says what it did not read.
+    //
+    // The manifest is the BROWSED scope's, and stays so under a redirect:
+    // this read takes no destination, so an install redirected into a
+    // project that injects its own instructions gets no note about them.
+    // Said here rather than claimed away — the note is advisory, and the
+    // scoring an install runs reads the scope it lands in.
     let mut notes = Vec::new();
     if injected_here(&browsed.records().manifest, kind, name) {
         notes.push(format!(

--- a/crates/core/src/source/browse/tests.rs
+++ b/crates/core/src/source/browse/tests.rs
@@ -238,7 +238,7 @@ fn bundle_detail_derives_partly_installed_and_full() {
     let (env, scope) = project(tmp.path(), &manifest);
     save_lock(&env, &scope, &SIX[..2]);
 
-    let partly = bundle(&env, &cat(&scope), "starter").unwrap();
+    let partly = bundle(&env, &cat(&scope), "starter", None).unwrap();
     assert_eq!(partly.total_members, 6);
     assert_eq!(partly.installed_members, 2);
     assert_eq!(partly.description.as_deref(), Some("six things"));
@@ -254,7 +254,7 @@ fn bundle_detail_derives_partly_installed_and_full() {
     assert_eq!(state_of(&partly, "guard"), InstallState::Available);
 
     save_lock(&env, &scope, &SIX);
-    let full = bundle(&env, &cat(&scope), "starter").unwrap();
+    let full = bundle(&env, &cat(&scope), "starter", None).unwrap();
     assert_eq!(full.installed_members, 6);
     assert!(
         full.members
@@ -340,7 +340,10 @@ fn listing_sets_agrees_with_opening_one() {
 
     let listed = bundles(&env, &cat(&scope)).unwrap();
     assert_eq!(listed.len(), 1);
-    assert_eq!(listed[0], bundle(&env, &cat(&scope), "starter").unwrap());
+    assert_eq!(
+        listed[0],
+        bundle(&env, &cat(&scope), "starter", None).unwrap()
+    );
 }
 
 /// A bundle member the catalog lists but does not carry — renamed or removed
@@ -363,7 +366,7 @@ fn a_bundle_member_the_catalog_no_longer_carries_is_a_row_not_an_error() {
     );
     let (env, scope) = project(tmp.path(), &manifest);
 
-    let detail = bundle(&env, &cat(&scope), "starter").unwrap();
+    let detail = bundle(&env, &cat(&scope), "starter", None).unwrap();
     assert_eq!(detail.total_members, 2);
     let state_of = |name: &str| {
         detail
@@ -397,7 +400,7 @@ fn a_member_the_user_removed_shows_removed_by_you() {
     );
     let (env, scope) = project(tmp.path(), &manifest);
 
-    let detail = bundle(&env, &cat(&scope), "starter").unwrap();
+    let detail = bundle(&env, &cat(&scope), "starter", None).unwrap();
     let state_of = |name: &str| {
         detail
             .members
@@ -458,7 +461,7 @@ fn a_name_taken_by_another_source_is_shown_before_the_click() {
             .all(|row| row.name == "gh" || row.collision.is_none())
     );
 
-    let detail = bundle(&env, &cat(&scope), "starter").unwrap();
+    let detail = bundle(&env, &cat(&scope), "starter", None).unwrap();
     assert_eq!(detail.collision.as_deref(), Some("two"));
 }
 

--- a/crates/core/src/source/browse/tests/repo.rs
+++ b/crates/core/src/source/browse/tests/repo.rs
@@ -244,7 +244,7 @@ fn preview_and_safety_read_the_repository_and_the_score_is_shared_with_a_later_s
     );
     assert_eq!(preview.files.len(), 2);
 
-    let scored = package_safety(&env, &repo(), ItemKind::Skill, "gh").unwrap();
+    let scored = package_safety(&env, &repo(), ItemKind::Skill, "gh", None).unwrap();
     assert!(!scored.from_cache);
     assert!(scored.advisory.safety.score < 100);
 
@@ -263,6 +263,7 @@ fn preview_and_safety_read_the_repository_and_the_score_is_shared_with_a_later_s
         },
         ItemKind::Skill,
         "gh",
+        None,
     )
     .unwrap();
     assert!(subscribed.from_cache);

--- a/crates/core/src/source/browse/tests/safety_budget.rs
+++ b/crates/core/src/source/browse/tests/safety_budget.rs
@@ -66,6 +66,7 @@ fn a_finding_in_the_tail_reaches_the_preview_and_the_plan() {
         },
         ItemKind::Skill,
         "big",
+        None,
     )
     .unwrap();
     assert!(

--- a/crates/core/src/source/browse/tests/safety_cache.rs
+++ b/crates/core/src/source/browse/tests/safety_cache.rs
@@ -80,6 +80,7 @@ fn score(env: &Env, scope: &Scope) -> PackageSafety {
         },
         ItemKind::Skill,
         "gh",
+        None,
     )
     .unwrap()
 }
@@ -94,6 +95,7 @@ fn agent_safety(env: &Env, scope: &Scope) -> PackageSafety {
         },
         ItemKind::Agent,
         "helper",
+        None,
     )
     .unwrap()
 }

--- a/crates/core/tests/browse_unreadable_lock.rs
+++ b/crates/core/tests/browse_unreadable_lock.rs
@@ -227,6 +227,7 @@ struct Redirect {
     env: Env,
     browsing: Scope,
     destination: Scope,
+    source: std::path::PathBuf,
     browsed_lock: std::path::PathBuf,
     destination_lock: std::path::PathBuf,
 }
@@ -270,6 +271,7 @@ fn redirect() -> Redirect {
         env,
         browsing: Scope::Global,
         destination,
+        source,
         browsed_lock,
         destination_lock,
         _tmp: tmp,
@@ -316,6 +318,34 @@ impl Redirect {
             },
         );
         kendex_core::lock::save(&kendex_core::lock::lock_path(&self.env, scope), &lock).unwrap();
+    }
+
+    /// Declares `gh` and the `starter` set in one place from a source that
+    /// is not the catalog being browsed — the name clash invariant 4
+    /// refuses an install on.
+    #[allow(clippy::unwrap_used)]
+    fn claim_gh_in(&self, scope: &Scope) {
+        let path = self.manifest_path(scope);
+        let manifest = fs::read_to_string(&path).unwrap();
+        put(
+            &path,
+            &format!(
+                "{manifest}\n[sources.other]\npath = \"{}\"\n\n[skills.gh]\nsource = \"other\"\n\n[bundles.starter]\nsource = \"other\"\n",
+                self.source.display()
+            ),
+        );
+    }
+
+    /// Adds this place's own instructions to `gh`, which the catalog's
+    /// bytes do not carry and the preview therefore never scored.
+    #[allow(clippy::unwrap_used)]
+    fn inject_into_gh_in(&self, scope: &Scope) {
+        let path = self.manifest_path(scope);
+        let manifest = fs::read_to_string(&path).unwrap();
+        put(
+            &path,
+            &format!("{manifest}\n[skill-instructions]\ngh = \"house rules\"\n"),
+        );
     }
 
     /// Records that the person removed `gh` on purpose in one place.
@@ -497,5 +527,94 @@ fn a_members_standing_comes_from_the_place_the_install_lands_in() {
         member(&r),
         Some(InstallState::Available),
         "a removal in the scope being browsed says nothing about the project it lands in"
+    );
+}
+
+#[allow(clippy::unwrap_used)]
+fn redirected_preview(r: &Redirect) -> browse::PackagePreview {
+    browse::package_preview(
+        &r.env,
+        &catalog(&r.browsing),
+        ItemKind::Skill,
+        "gh",
+        Some(&r.destination),
+    )
+    .unwrap()
+}
+
+#[allow(clippy::unwrap_used)]
+fn redirected_safety(r: &Redirect) -> browse::PackageSafety {
+    browse::package_safety(
+        &r.env,
+        &catalog(&r.browsing),
+        ItemKind::Skill,
+        "gh",
+        Some(&r.destination),
+    )
+    .unwrap()
+}
+
+/// The name clash a page shows before the click is the one the engine's
+/// invariant 4 would refuse on, and the engine judges that against the
+/// scope it is handed. So the warning reads the destination's records, on
+/// the package page and on the set page alike: a name that place already
+/// holds from another source is warned about, and one only the browsed
+/// scope holds is not, because the install is not going there.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_name_clash_is_read_where_the_install_lands() {
+    let r = redirect();
+    assert_eq!(
+        redirected_preview(&r).collision,
+        None,
+        "the control: nothing claims the name in either place"
+    );
+
+    r.claim_gh_in(&r.destination);
+    assert_eq!(
+        redirected_preview(&r).collision,
+        Some("other".to_owned()),
+        "the install would land on this claim, so the page says so first"
+    );
+    assert_eq!(
+        redirected_detail(&r).collision,
+        Some("other".to_owned()),
+        "the set's own name is claimed there too"
+    );
+
+    // The inverse: claimed only in the scope being browsed, which the
+    // install is not going to.
+    let r = redirect();
+    r.claim_gh_in(&r.browsing);
+    assert_eq!(redirected_preview(&r).collision, None);
+    assert_eq!(redirected_detail(&r).collision, None);
+}
+
+/// The safety note says what the preview did not read: the instructions a
+/// place adds to what installs there. Which place is the one the install
+/// lands in, so a destination that injects gets the note and a browsed
+/// scope that injects does not — the note would otherwise describe text no
+/// installed copy would carry.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn the_safety_note_is_about_the_place_the_install_lands_in() {
+    let r = redirect();
+    assert!(
+        redirected_safety(&r).notes.is_empty(),
+        "the control: neither place adds anything to gh"
+    );
+
+    r.inject_into_gh_in(&r.destination);
+    assert_eq!(
+        redirected_safety(&r).notes.len(),
+        1,
+        "installed there, gh carries that place's instructions, unscored here"
+    );
+
+    let r = redirect();
+    r.inject_into_gh_in(&r.browsing);
+    assert!(
+        redirected_safety(&r).notes.is_empty(),
+        "no installed copy would carry these, so the note would be about nothing"
     );
 }

--- a/crates/core/tests/browse_unreadable_lock.rs
+++ b/crates/core/tests/browse_unreadable_lock.rs
@@ -361,19 +361,6 @@ impl Redirect {
 }
 
 #[allow(clippy::unwrap_used)]
-fn redirected_state(r: &Redirect) -> InstallState {
-    browse::package_preview(
-        &r.env,
-        &catalog(&r.browsing),
-        ItemKind::Skill,
-        "gh",
-        Some(&r.destination),
-    )
-    .unwrap()
-    .state
-}
-
-#[allow(clippy::unwrap_used)]
 fn redirected_detail(r: &Redirect) -> browse::BundleDetail {
     browse::bundle(
         &r.env,
@@ -384,13 +371,15 @@ fn redirected_detail(r: &Redirect) -> browse::BundleDetail {
     .unwrap()
 }
 
-/// The available-package page's Install gates on the state this read
-/// returns, and the install lands in the destination the page picked — so a
-/// damaged record there withholds the button, whatever the scope being
-/// browsed says.
+/// The package page's Install gates on the state this read returns, and the
+/// install lands in the destination the page picked. Both directions: a
+/// damaged record where the install lands withholds the button, and a
+/// damaged one in the scope being browsed does not withhold an install
+/// landing somewhere that reads — the second is the worse of the two, a
+/// valid action denied with no reason to show.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn the_package_page_withholds_its_install_for_an_unreadable_destination() {
+fn the_package_page_is_judged_at_the_destination() {
     let r = redirect();
     assert_eq!(
         redirected_state(&r),
@@ -404,18 +393,9 @@ fn the_package_page_withholds_its_install_for_an_unreadable_destination() {
         InstallState::Unknown,
         "the install lands here, and the engine would refuse on this record"
     );
-}
 
-/// The inverse, and the worse of the two: a scope being browsed whose lock
-/// cannot be read must not withhold an install landing somewhere that reads
-/// perfectly well. Nothing about that record is in the install's way, and
-/// refusing on it is a valid action denied with no reason to show.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn an_unreadable_browsed_scope_does_not_withhold_an_install_landing_elsewhere() {
     let r = redirect();
     fs::write(&r.browsed_lock, "{not json").unwrap();
-
     assert_eq!(redirected_state(&r), InstallState::Available);
     assert_eq!(
         browse::package_preview(&r.env, &catalog(&r.browsing), ItemKind::Skill, "gh", None)
@@ -426,92 +406,59 @@ fn an_unreadable_browsed_scope_does_not_withhold_an_install_landing_elsewhere() 
     );
 }
 
-/// The set page's Install all reads `records_unreadable` and its member
-/// boxes read each member's state; both are about the place the install
-/// lands in, so a damaged record there withholds both.
+/// The set page reaches the same gate through the other engine entry point,
+/// and reads two things there: `records_unreadable`, which Install all
+/// gates on, and each member's standing, which the boxes gate on. Both are
+/// the landing place's, in both directions and past readability — an
+/// installation recorded there is what makes a row say Installed, and a
+/// removal recorded there is what makes it say whose choice it was. Reading
+/// the browsed scope instead puts a wrong count on the page and a box the
+/// reader cannot tick for the place actually missing the member.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn the_set_page_withholds_its_installs_for_an_unreadable_destination() {
+fn the_set_page_is_judged_at_the_destination() {
+    let member = |r: &Redirect| redirected_detail(r).members.first().map(|m| m.state);
+    let count = |r: &Redirect| redirected_detail(r).installed_members;
+
     let r = redirect();
-    let detail = redirected_detail(&r);
     assert!(
-        !detail.records_unreadable,
+        !redirected_detail(&r).records_unreadable,
         "the control: two readable records offer Install all"
     );
-    assert_eq!(
-        detail.members.first().map(|member| member.state),
-        Some(InstallState::Available)
-    );
+    assert_eq!((member(&r), count(&r)), (Some(InstallState::Available), 0));
 
     fs::write(&r.destination_lock, "{not json").unwrap();
     let detail = redirected_detail(&r);
     assert!(detail.records_unreadable);
     assert_eq!(
-        detail.members.first().map(|member| member.state),
+        detail.members.first().map(|m| m.state),
         Some(InstallState::Unknown),
         "no member box may be ticked for a place whose record went unread"
     );
-}
 
-/// The set page's inverse: a damaged record in the scope being browsed
-/// leaves Install all and every member box alone when the install lands in
-/// a project that reads.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn an_unreadable_browsed_scope_leaves_the_sets_installs_alone() {
+    // Damaged in the scope being browsed and nowhere else: the install is
+    // not going there, so nothing about it is in the way.
     let r = redirect();
     fs::write(&r.browsed_lock, "{not json").unwrap();
-
-    let detail = redirected_detail(&r);
-    assert!(!detail.records_unreadable);
-    assert_eq!(
-        detail.members.first().map(|member| member.state),
-        Some(InstallState::Available)
-    );
-
-    let browsed = browse::bundle(&r.env, &catalog(&r.browsing), "starter", None).unwrap();
+    assert!(!redirected_detail(&r).records_unreadable);
+    assert_eq!((member(&r), count(&r)), (Some(InstallState::Available), 0));
     assert!(
-        browsed.records_unreadable,
+        browse::bundle(&r.env, &catalog(&r.browsing), "starter", None)
+            .unwrap()
+            .records_unreadable,
         "the control: with no redirect the same damaged record still answers"
     );
-}
 
-/// The other half of the redirect, and the one an unreadable lock cannot
-/// show: a member's standing is read out of the LANDING place's records,
-/// not just its readability. An installation recorded where the install
-/// lands is what makes the row say Installed, and a removal recorded there
-/// is what makes it say the person's own choice — neither is the browsed
-/// scope's to answer, and reading the wrong one puts a wrong count on the
-/// set page and a box the reader cannot tick for the place that is
-/// actually missing the member.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_members_standing_comes_from_the_place_the_install_lands_in() {
     let r = redirect();
-    let member = |r: &Redirect| redirected_detail(r).members.first().map(|m| m.state);
-    let installed_count = |r: &Redirect| redirected_detail(r).installed_members;
-    assert_eq!(
-        (member(&r), installed_count(&r)),
-        (Some(InstallState::Available), 0),
-        "the control: neither place records anything about gh"
-    );
-
     r.install_gh_in(&r.destination);
     assert_eq!(
-        (member(&r), installed_count(&r)),
+        (member(&r), count(&r)),
         (Some(InstallState::Installed), 1),
         "installed where the install lands, so the row says so"
     );
-
-    // The inverse: recorded in the scope being browsed and nowhere else.
-    // The set is redirected into a project that does not hold it, so the
-    // row must offer it rather than call it installed.
     let r = redirect();
     r.install_gh_in(&r.browsing);
-    assert_eq!(
-        (member(&r), installed_count(&r)),
-        (Some(InstallState::Available), 0)
-    );
+    assert_eq!((member(&r), count(&r)), (Some(InstallState::Available), 0));
 
     let r = redirect();
     r.suppress_gh_in(&r.destination);
@@ -520,7 +467,6 @@ fn a_members_standing_comes_from_the_place_the_install_lands_in() {
         Some(InstallState::RemovedByYou),
         "kept removed where the install lands, so the row says whose choice it was"
     );
-
     let r = redirect();
     r.suppress_gh_in(&r.browsing);
     assert_eq!(
@@ -528,6 +474,10 @@ fn a_members_standing_comes_from_the_place_the_install_lands_in() {
         Some(InstallState::Available),
         "a removal in the scope being browsed says nothing about the project it lands in"
     );
+}
+
+fn redirected_state(r: &Redirect) -> InstallState {
+    redirected_preview(r).state
 }
 
 #[allow(clippy::unwrap_used)]

--- a/crates/core/tests/browse_unreadable_lock.rs
+++ b/crates/core/tests/browse_unreadable_lock.rs
@@ -8,6 +8,13 @@
 //! come through with their installed state answered as unknown — never
 //! guessed as available, which would offer an install the engine refuses
 //! for the same unreadable record.
+//!
+//! Which scope's record is the question the tests at the bottom hold to.
+//! A page browsing a personal subscription can redirect the install into a
+//! project, and the engine mutates the project it is handed — so the state
+//! the page gates on has to be the destination's, in both directions: an
+//! unreadable destination refuses, and an unreadable scope being browsed
+//! does not refuse an install landing somewhere readable.
 #![cfg(unix)]
 
 #[path = "../../test_util.rs"]
@@ -94,7 +101,7 @@ fn offered(f: &Fixture) -> Vec<(String, InstallState)> {
 
 #[allow(clippy::unwrap_used)]
 fn detail(f: &Fixture) -> browse::BundleDetail {
-    browse::bundle(&f.env, &catalog(&f.scope), "starter").unwrap()
+    browse::bundle(&f.env, &catalog(&f.scope), "starter", None).unwrap()
 }
 
 #[allow(clippy::unwrap_used)]
@@ -209,5 +216,173 @@ fn the_set_carries_the_scopes_answer_even_where_no_member_shows_it() {
             .iter()
             .all(|member| member.state == InstallState::NotOffered),
         "no member row carries the fact, which is why the set must"
+    );
+}
+
+/// Browsing one place and installing into another: a personal subscription
+/// to a local catalog, plus a project to redirect the install into. Each
+/// place has its own lock, and either one can be the damaged one.
+struct Redirect {
+    _tmp: tempfile::TempDir,
+    env: Env,
+    browsing: Scope,
+    destination: Scope,
+    browsed_lock: std::path::PathBuf,
+    destination_lock: std::path::PathBuf,
+}
+
+#[allow(clippy::unwrap_used)]
+fn redirect() -> Redirect {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let project = home.join("dev/app");
+    let source = home.join("catalog");
+    put(
+        &source.join("skills/gh/SKILL.md"),
+        "---\nname: gh\ndescription: work a pull request\n---\n\nBody.\n",
+    );
+    put(
+        &source.join("kendex.toml"),
+        "[bundles.starter]\ndescription = \"the starter set\"\nskills = [\"gh\"]\n",
+    );
+    let env = Env::fake(&home, FakeOs::Linux);
+    let declaration = format!(
+        "schema = {}\n\n[sources.cat]\npath = \"{}\"\n\n[install]\nharnesses = [\"claude\"]\nmethod = \"symlink\"\n",
+        kendex_core::manifest::MANIFEST_SCHEMA,
+        source.display()
+    );
+    put(
+        &kendex_core::manifest::manifest_path(&env, &Scope::Global),
+        &declaration,
+    );
+    // The destination declares the same subscription, which is what
+    // installing into a project from a personal one leaves behind.
+    put(&project.join("kendex.toml"), &declaration);
+    let browsed_lock = kendex_core::lock::lock_path(&env, &Scope::Global);
+    Redirect {
+        env,
+        browsing: Scope::Global,
+        destination: Scope::Project {
+            root: project.clone(),
+        },
+        browsed_lock,
+        destination_lock: project.join(".kendex-lock.json"),
+        _tmp: tmp,
+    }
+}
+
+#[allow(clippy::unwrap_used)]
+fn redirected_state(r: &Redirect) -> InstallState {
+    browse::package_preview(
+        &r.env,
+        &catalog(&r.browsing),
+        ItemKind::Skill,
+        "gh",
+        Some(&r.destination),
+    )
+    .unwrap()
+    .state
+}
+
+#[allow(clippy::unwrap_used)]
+fn redirected_detail(r: &Redirect) -> browse::BundleDetail {
+    browse::bundle(
+        &r.env,
+        &catalog(&r.browsing),
+        "starter",
+        Some(&r.destination),
+    )
+    .unwrap()
+}
+
+/// The available-package page's Install gates on the state this read
+/// returns, and the install lands in the destination the page picked — so a
+/// damaged record there withholds the button, whatever the scope being
+/// browsed says.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn the_package_page_withholds_its_install_for_an_unreadable_destination() {
+    let r = redirect();
+    assert_eq!(
+        redirected_state(&r),
+        InstallState::Available,
+        "the control: two readable records offer the install"
+    );
+
+    fs::write(&r.destination_lock, "{not json").unwrap();
+    assert_eq!(
+        redirected_state(&r),
+        InstallState::Unknown,
+        "the install lands here, and the engine would refuse on this record"
+    );
+}
+
+/// The inverse, and the worse of the two: a scope being browsed whose lock
+/// cannot be read must not withhold an install landing somewhere that reads
+/// perfectly well. Nothing about that record is in the install's way, and
+/// refusing on it is a valid action denied with no reason to show.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_unreadable_browsed_scope_does_not_withhold_an_install_landing_elsewhere() {
+    let r = redirect();
+    fs::write(&r.browsed_lock, "{not json").unwrap();
+
+    assert_eq!(redirected_state(&r), InstallState::Available);
+    assert_eq!(
+        browse::package_preview(&r.env, &catalog(&r.browsing), ItemKind::Skill, "gh", None)
+            .unwrap()
+            .state,
+        InstallState::Unknown,
+        "the control: with no redirect the same damaged record still answers"
+    );
+}
+
+/// The set page's Install all reads `records_unreadable` and its member
+/// boxes read each member's state; both are about the place the install
+/// lands in, so a damaged record there withholds both.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn the_set_page_withholds_its_installs_for_an_unreadable_destination() {
+    let r = redirect();
+    let detail = redirected_detail(&r);
+    assert!(
+        !detail.records_unreadable,
+        "the control: two readable records offer Install all"
+    );
+    assert_eq!(
+        detail.members.first().map(|member| member.state),
+        Some(InstallState::Available)
+    );
+
+    fs::write(&r.destination_lock, "{not json").unwrap();
+    let detail = redirected_detail(&r);
+    assert!(detail.records_unreadable);
+    assert_eq!(
+        detail.members.first().map(|member| member.state),
+        Some(InstallState::Unknown),
+        "no member box may be ticked for a place whose record went unread"
+    );
+}
+
+/// The set page's inverse: a damaged record in the scope being browsed
+/// leaves Install all and every member box alone when the install lands in
+/// a project that reads.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_unreadable_browsed_scope_leaves_the_sets_installs_alone() {
+    let r = redirect();
+    fs::write(&r.browsed_lock, "{not json").unwrap();
+
+    let detail = redirected_detail(&r);
+    assert!(!detail.records_unreadable);
+    assert_eq!(
+        detail.members.first().map(|member| member.state),
+        Some(InstallState::Available)
+    );
+
+    let browsed = browse::bundle(&r.env, &catalog(&r.browsing), "starter", None).unwrap();
+    assert!(
+        browsed.records_unreadable,
+        "the control: with no redirect the same damaged record still answers"
     );
 }

--- a/crates/core/tests/browse_unreadable_lock.rs
+++ b/crates/core/tests/browse_unreadable_lock.rs
@@ -25,7 +25,7 @@ use std::fs;
 use std::path::Path;
 
 use kendex_core::env::{Env, FakeOs};
-use kendex_core::model::{ItemKind, Scope};
+use kendex_core::model::{HarnessId, ItemKind, Scope};
 use kendex_core::source::browse::{self, Catalog, InstallState};
 
 struct Fixture {
@@ -258,16 +258,75 @@ fn redirect() -> Redirect {
     // The destination declares the same subscription, which is what
     // installing into a project from a personal one leaves behind.
     put(&project.join("kendex.toml"), &declaration);
+    let destination = Scope::Project {
+        root: project.clone(),
+    };
+    // Both paths come off the engine's own resolver rather than composed
+    // here: a composed one diverges from what a read resolves wherever the
+    // home it is rooted under is a symlink.
     let browsed_lock = kendex_core::lock::lock_path(&env, &Scope::Global);
+    let destination_lock = kendex_core::lock::lock_path(&env, &destination);
     Redirect {
         env,
         browsing: Scope::Global,
-        destination: Scope::Project {
-            root: project.clone(),
-        },
+        destination,
         browsed_lock,
-        destination_lock: project.join(".kendex-lock.json"),
+        destination_lock,
         _tmp: tmp,
+    }
+}
+
+impl Redirect {
+    /// The manifest of one of this fixture's two places, off the engine's
+    /// own resolver rather than composed here.
+    fn manifest_path(&self, scope: &Scope) -> std::path::PathBuf {
+        kendex_core::manifest::manifest_path(&self.env, scope)
+    }
+
+    /// Records `gh` as installed from the `cat` subscription in one place
+    /// and nowhere else.
+    #[allow(clippy::unwrap_used)]
+    fn install_gh_in(&self, scope: &Scope) {
+        let mut lock = kendex_core::lock::Lock {
+            version: kendex_core::lock::LOCK_VERSION,
+            root: match scope {
+                Scope::Project { root } => Some(root.clone()),
+                Scope::Global => None,
+            },
+            ..Default::default()
+        };
+        lock.entries.insert(
+            kendex_core::lock::entry_key(ItemKind::Skill, "gh", HarnessId::Claude),
+            kendex_core::lock::LockEntry {
+                name: "gh".to_owned(),
+                kind: ItemKind::Skill,
+                harness: HarnessId::Claude,
+                source: "cat".to_owned(),
+                source_repo: "cat".to_owned(),
+                method: kendex_core::manifest::Method::Symlink,
+                installed_at: "2026-01-01T00:00:00Z".to_owned(),
+                source_hash: "hash".to_owned(),
+                source_commit: None,
+                rendered_hash: None,
+                enabled: true,
+                upstream_skills: None,
+                emitted: None,
+                registration: None,
+                reasons: std::collections::BTreeSet::from([kendex_core::lock::Reason::Requested]),
+            },
+        );
+        kendex_core::lock::save(&kendex_core::lock::lock_path(&self.env, scope), &lock).unwrap();
+    }
+
+    /// Records that the person removed `gh` on purpose in one place.
+    #[allow(clippy::unwrap_used)]
+    fn suppress_gh_in(&self, scope: &Scope) {
+        let path = self.manifest_path(scope);
+        let manifest = fs::read_to_string(&path).unwrap();
+        put(
+            &path,
+            &format!("{manifest}\n[suppressed]\nskill = [\"gh\"]\n"),
+        );
     }
 }
 
@@ -384,5 +443,59 @@ fn an_unreadable_browsed_scope_leaves_the_sets_installs_alone() {
     assert!(
         browsed.records_unreadable,
         "the control: with no redirect the same damaged record still answers"
+    );
+}
+
+/// The other half of the redirect, and the one an unreadable lock cannot
+/// show: a member's standing is read out of the LANDING place's records,
+/// not just its readability. An installation recorded where the install
+/// lands is what makes the row say Installed, and a removal recorded there
+/// is what makes it say the person's own choice — neither is the browsed
+/// scope's to answer, and reading the wrong one puts a wrong count on the
+/// set page and a box the reader cannot tick for the place that is
+/// actually missing the member.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_members_standing_comes_from_the_place_the_install_lands_in() {
+    let r = redirect();
+    let member = |r: &Redirect| redirected_detail(r).members.first().map(|m| m.state);
+    let installed_count = |r: &Redirect| redirected_detail(r).installed_members;
+    assert_eq!(
+        (member(&r), installed_count(&r)),
+        (Some(InstallState::Available), 0),
+        "the control: neither place records anything about gh"
+    );
+
+    r.install_gh_in(&r.destination);
+    assert_eq!(
+        (member(&r), installed_count(&r)),
+        (Some(InstallState::Installed), 1),
+        "installed where the install lands, so the row says so"
+    );
+
+    // The inverse: recorded in the scope being browsed and nowhere else.
+    // The set is redirected into a project that does not hold it, so the
+    // row must offer it rather than call it installed.
+    let r = redirect();
+    r.install_gh_in(&r.browsing);
+    assert_eq!(
+        (member(&r), installed_count(&r)),
+        (Some(InstallState::Available), 0)
+    );
+
+    let r = redirect();
+    r.suppress_gh_in(&r.destination);
+    assert_eq!(
+        member(&r),
+        Some(InstallState::RemovedByYou),
+        "kept removed where the install lands, so the row says whose choice it was"
+    );
+
+    let r = redirect();
+    r.suppress_gh_in(&r.browsing);
+    assert_eq!(
+        member(&r),
+        Some(InstallState::Available),
+        "a removal in the scope being browsed says nothing about the project it lands in"
     );
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -662,14 +662,13 @@ by core and UI.
   entry from this subscription, "partly installed (2 of 6)" is counted
   from a bundle's members; a lock this build refuses lists the catalog all
   the same, every row it alone would settle Unknown and every install surface gated on it — a set's Install all on the set's own
-  flag, since a dropped member reads NotOffered either way. The installed-state join and that refusal answer for the scope the
-  install would land in: a page redirecting into a project reads that project's records (`browse::opened::Records`, resolved once
-  by `opened::landing`), because `engine::ops::add_seeded` mutates the scope it is handed; Subscribe gates the same way on the
-  place its dialog chose, since subscribing plans against that place's lock. Two advisory reads deliberately stay with the browsed
-  scope and say so where they are: the name clash below, and the pre-install safety note about a project's own injected
-  instructions. With no subscription the join answers Available and judges name clashes against the personal scope. A name another
-  source holds is surfaced on the row (`collision`); the refusal stays in the engine (invariant 4), judged where the install
-  lands. A
+  flag, since a dropped member reads NotOffered either way. Every answer a page draws about records is about the scope the install
+  would land in: the installed-state join, that refusal, the name clash and the pre-install safety note alike. A page redirecting
+  into a project reads that project's records (`browse::opened::Records`, resolved once by `opened::landing` and passed to each of
+  them), because `engine::ops::add_seeded` mutates the scope it is handed; Subscribe gates the same way on the place its dialog
+  chose, since subscribing plans against that place's lock. With no subscription the join answers Available and judges name clashes
+  against the personal scope. A name another source holds is surfaced on the row (`collision`); the refusal stays in the engine
+  (invariant 4). A
   bare repository is fetched by `remote::sync` into the store under the
   canonical `owner/repo` every GitHub spelling folds to — the key Subscribe
   is prefilled with; only GitHub opens blind (`NotBrowsable` otherwise); a

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -661,9 +661,11 @@ by core and UI.
   from the scope's manifest and lock on every call — installed is a lock
   entry from this subscription, "partly installed (2 of 6)" is counted
   from a bundle's members; a lock this build refuses lists the catalog all
-  the same, every row it alone would settle Unknown and every install surface reading that scope's own record gated on it — a set's
-  Install all on the set's own flag, since a dropped member reads NotOffered either way; an install redirected into another scope is
-  not yet gated on the destination's record. With no subscription the join answers Available and judges name clashes against the
+  the same, every row it alone would settle Unknown and every install surface gated on it — a set's Install all on the set's own
+  flag, since a dropped member reads NotOffered either way. The scope answering is the one the install would land in: a page
+  redirecting into a project reads that project's records (`browse::opened::Records`, the one carrier every join takes), because
+  `engine::ops::add_seeded` mutates the scope it is handed; Subscribe gates the same way on the place its dialog chose, since
+  subscribing plans against that place's lock. With no subscription the join answers Available and judges name clashes against the
   personal scope. A name another source holds is surfaced on the row (`collision`); the refusal stays in the engine (invariant 4). A
   bare repository is fetched by `remote::sync` into the store under the
   canonical `owner/repo` every GitHub spelling folds to — the key Subscribe

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -662,11 +662,14 @@ by core and UI.
   entry from this subscription, "partly installed (2 of 6)" is counted
   from a bundle's members; a lock this build refuses lists the catalog all
   the same, every row it alone would settle Unknown and every install surface gated on it — a set's Install all on the set's own
-  flag, since a dropped member reads NotOffered either way. The scope answering is the one the install would land in: a page
-  redirecting into a project reads that project's records (`browse::opened::Records`, the one carrier every join takes), because
-  `engine::ops::add_seeded` mutates the scope it is handed; Subscribe gates the same way on the place its dialog chose, since
-  subscribing plans against that place's lock. With no subscription the join answers Available and judges name clashes against the
-  personal scope. A name another source holds is surfaced on the row (`collision`); the refusal stays in the engine (invariant 4). A
+  flag, since a dropped member reads NotOffered either way. The installed-state join and that refusal answer for the scope the
+  install would land in: a page redirecting into a project reads that project's records (`browse::opened::Records`, resolved once
+  by `opened::landing`), because `engine::ops::add_seeded` mutates the scope it is handed; Subscribe gates the same way on the
+  place its dialog chose, since subscribing plans against that place's lock. Two advisory reads deliberately stay with the browsed
+  scope and say so where they are: the name clash below, and the pre-install safety note about a project's own injected
+  instructions. With no subscription the join answers Available and judges name clashes against the personal scope. A name another
+  source holds is surfaced on the row (`collision`); the refusal stays in the engine (invariant 4), judged where the install
+  lands. A
   bare repository is fetched by `remote::sync` into the store under the
   canonical `owner/repo` every GitHub spelling folds to — the key Subscribe
   is prefilled with; only GitHub opens blind (`NotBrowsable` otherwise); a

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -664,9 +664,9 @@ by core and UI.
   the same, every row it alone would settle Unknown and every install surface gated on it — a set's Install all on the set's own
   flag, since a dropped member reads NotOffered either way. Every answer a page draws about records is about the scope the install
   would land in: the installed-state join, that refusal, the name clash and the pre-install safety note alike. A page redirecting
-  into a project reads that project's records (`browse::opened::Records`, resolved once by `opened::landing` and passed to each of
-  them), because `engine::ops::add_seeded` mutates the scope it is handed; Subscribe gates the same way on the place its dialog
-  chose, since subscribing plans against that place's lock. With no subscription the join answers Available and judges name clashes
+  into a project reads that project's records (`browse::opened::Records`, resolved by `opened::landing` in each read that takes a
+  destination), because `engine::ops::add_seeded` mutates the scope it is handed; Subscribe gates the same way on the place its
+  dialog chose, since subscribing plans against that place's lock. With no subscription the join answers Available and judges name clashes
   against the personal scope. A name another source holds is surfaced on the row (`collision`); the refusal stays in the engine
   (invariant 4). A
   bare repository is fetched by `remote::sync` into the store under the

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -239,14 +239,28 @@ export const commands = {
 	 *  carry on as when this machine already holds one.
 	 */
 	marketplaceSummary: (catalog: Catalog) => typedError<CatalogSummary, string>(__TAURI_INVOKE("marketplace_summary", { catalog })),
-	/**  One curated set with per-member installed state. */
-	marketplaceBundle: (catalog: Catalog, name: string) => typedError<BundleDetail, string>(__TAURI_INVOKE("marketplace_bundle", { catalog, name })),
+	/**
+	 *  One curated set with per-member installed state. `destination`
+	 *  redirects the install into a project, and every answer about records —
+	 *  each member's state and the set's own `records_unreadable` — is then
+	 *  about that project, which is the scope the engine mutates.
+	 */
+	marketplaceBundle: (catalog: Catalog, name: string, destination: { scope: "global" } | { scope: "project"; root: string } | null) => typedError<BundleDetail, string>(__TAURI_INVOKE("marketplace_bundle", { catalog, name, destination })),
 	/**
 	 *  Every curated set a catalog declares, with per-member installed state —
 	 *  what the marketplace page's Bundles tab lists.
 	 */
 	marketplaceBundles: (catalog: Catalog) => typedError<BundleDetail[], string>(__TAURI_INVOKE("marketplace_bundles", { catalog })),
 	marketplacePackagePreview: (catalog: Catalog, kind: ItemKind, name: string, destination: { scope: "global" } | { scope: "project"; root: string } | null) => typedError<PackageView, string>(__TAURI_INVOKE("marketplace_package_preview", { catalog, kind, name, destination })),
+	/**
+	 *  Whether one place's lock is beyond this build, asked for a scope no
+	 *  catalog was opened for. Subscribing plans against the chosen place's
+	 *  lock (`source_ops::persist_and_plan`), so a place whose record cannot
+	 *  be read refuses the write — and the Subscribe dialog says so beside the
+	 *  place it was chosen at rather than letting the engine's raw refusal
+	 *  stand in for the reason.
+	 */
+	scopeRecordsUnreadable: (scope: Scope) => typedError<boolean, string>(__TAURI_INVOKE("scope_records_unreadable", { scope })),
 	/**
 	 *  One offered file's content before install — the same read an installed
 	 *  package's file gets, confined to the package inside the catalog.
@@ -764,13 +778,14 @@ export type BundleDetail = {
 	totalMembers: number,
 	collision: string | null,
 	/**
-	 *  This scope's lock could not be read. The set page's Install all asks
-	 *  about the set rather than about a member, so it needs the scope's own
-	 *  answer: no member row can carry it, because a member the catalog no
-	 *  longer offers reads [`InstallState::NotOffered`] with or without a
-	 *  lock, and a set whose members were all dropped — or one declared with
-	 *  none — would leave the page deriving "readable" from rows that never
-	 *  consulted the record.
+	 *  The lock of the scope this read answers for — the destination where
+	 *  the install is redirected, the browsed scope otherwise — could not be
+	 *  read. The set page's Install all asks about the set rather than about
+	 *  a member, so it needs that scope's own answer: no member row can
+	 *  carry it, because a member the catalog no longer offers reads
+	 *  [`InstallState::NotOffered`] with or without a lock, and a set whose
+	 *  members were all dropped — or one declared with none — would leave the
+	 *  page deriving "readable" from rows that never consulted the record.
 	 */
 	recordsUnreadable: boolean,
 };
@@ -1671,19 +1686,20 @@ export type InstallState =
  */
 "offered-more-than-once" | 
 /**
- *  This scope's lock could not be read, so whether the package is
- *  installed here is unknown. The catalog is still listed — what a
- *  source offers is a fact about the source — but every standing the
- *  lock alone could have given becomes this one, decided in
- *  `Browsed::state` and `Browsed::member_state` and nowhere else. Every
- *  surface offering an install for one package reads the state: the
- *  Packages row, a set's member row, and the available-package page
- *  (through [`PackagePreview::state`]) all say why instead, so none
- *  offers an install the engine would refuse for the same unreadable
- *  record. The state answers for the BROWSED scope: an install a page
- *  redirects into a different scope is not yet judged against that
- *  destination's record. The set page's Install all is about the set,
- *  not a package, and reads [`BundleDetail::records_unreadable`].
+ *  The scope this state answers for has a lock that could not be read,
+ *  so whether the package is installed there is unknown. The catalog is
+ *  still listed — what a source offers is a fact about the source — but
+ *  every standing the lock alone could have given becomes this one,
+ *  decided in `Browsed::state` and `Browsed::member_state` and nowhere
+ *  else. Every surface offering an install for one package reads the
+ *  state: the Packages row, a set's member row, and the
+ *  available-package page (through [`PackagePreview::state`]) all say
+ *  why instead, so none offers an install the engine would refuse for
+ *  the same unreadable record. The scope is the one the install would
+ *  land in — the browsed catalog's own, or the destination a page
+ *  redirects into, which is the scope the engine mutates. The set
+ *  page's Install all is about the set, not a package, and reads
+ *  [`BundleDetail::records_unreadable`].
  */
 "unknown";
 
@@ -2341,9 +2357,11 @@ export type PackagePreview = {
 	/**  What installing it takes along, and what it offers to take. */
 	dependencies: PackageDependencies,
 	/**
-	 *  Where this package stands in the browsed scope, by the same join the
-	 *  Packages row shows. The page installs, so it needs the answer the
-	 *  row has: [`InstallState::Unknown`] where the scope's lock could not
+	 *  Where this package stands in the scope the install would land in —
+	 *  the destination when the page redirects into one, the browsed scope
+	 *  otherwise — by the same join the Packages row shows. The page
+	 *  installs, so it needs the answer for the scope the engine will
+	 *  mutate: [`InstallState::Unknown`] where that scope's lock could not
 	 *  be read, and the page offers the reason rather than a button the
 	 *  engine would refuse for that same record.
 	 */

--- a/ui/src/components/marketplaces/bundle-install-bar.tsx
+++ b/ui/src/components/marketplaces/bundle-install-bar.tsx
@@ -14,8 +14,14 @@ import { Button } from "@/components/ui/button";
  *
  * `choice` is not only this row's: the page's own Install all, in the
  * header, installs the whole set with whatever this picker last answered.
- * So the tool picker at the bottom of the page decides how the button at
- * the top installs, and moving either one has to account for the other. */
+ * So the tool picker here decides how the button at the top installs, and
+ * moving either one has to account for the other.
+ *
+ * The row is drawn above the set's own read and stays on screen while that
+ * read is loading or failed, because the place it picks is what a failed
+ * read is escaped by. Nothing here acts on a set the page does not hold:
+ * `picked` is 0 in every state that reaches one, since choosing a place
+ * clears the ticks and a landed install clears them again. */
 export function BundleInstallBar({
   browsing,
   target,
@@ -40,7 +46,7 @@ export function BundleInstallBar({
   onInstall: () => void;
 }) {
   return (
-    <div className="mt-4 flex items-center justify-end gap-2">
+    <div className="mb-3 flex items-center justify-end gap-2">
       <DestinationSelect
         browsing={browsing}
         value={target}

--- a/ui/src/components/marketplaces/bundle-install-bar.tsx
+++ b/ui/src/components/marketplaces/bundle-install-bar.tsx
@@ -10,7 +10,12 @@ import { Button } from "@/components/ui/button";
 /** Where a set's ticked members install, on what, and the button that
  * installs them. The set page owns every answer here — which place, which
  * tools, which members — and what one answer does to the others; this draws
- * the row. */
+ * the row.
+ *
+ * `choice` is not only this row's: the page's own Install all, in the
+ * header, installs the whole set with whatever this picker last answered.
+ * So the tool picker at the bottom of the page decides how the button at
+ * the top installs, and moving either one has to account for the other. */
 export function BundleInstallBar({
   browsing,
   target,

--- a/ui/src/components/marketplaces/bundle-install-bar.tsx
+++ b/ui/src/components/marketplaces/bundle-install-bar.tsx
@@ -1,0 +1,59 @@
+import type { ItemKind, Scope } from "@/bindings";
+import { DestinationSelect } from "@/components/marketplaces/destination-select";
+import {
+  type Choice,
+  HarnessSelect,
+  isInstallable,
+} from "@/components/marketplaces/harness-select";
+import { Button } from "@/components/ui/button";
+
+/** Where a set's ticked members install, on what, and the button that
+ * installs them. The set page owns every answer here — which place, which
+ * tools, which members — and what one answer does to the others; this draws
+ * the row. */
+export function BundleInstallBar({
+  browsing,
+  target,
+  kinds,
+  choice,
+  picked,
+  busy,
+  onPlace,
+  onChoice,
+  onInstall,
+}: {
+  browsing: Scope;
+  /** Where the install lands: the place picked, or the browsed one. */
+  target: Scope;
+  /** The kinds actually ticked, which is what the tool picker may offer. */
+  kinds: ItemKind[];
+  choice: Choice;
+  picked: number;
+  busy: boolean;
+  onPlace: (scope: Scope) => void;
+  onChoice: (choice: Choice) => void;
+  onInstall: () => void;
+}) {
+  return (
+    <div className="mt-4 flex items-center justify-end gap-2">
+      <DestinationSelect
+        browsing={browsing}
+        value={target}
+        onChange={onPlace}
+      />
+      <HarnessSelect
+        scope={target}
+        kinds={kinds}
+        value={choice}
+        onChange={onChoice}
+      />
+      <Button
+        variant="outline"
+        disabled={busy || picked === 0 || !isInstallable(choice)}
+        onClick={onInstall}
+      >
+        Install {picked} selected
+      </Button>
+    </div>
+  );
+}

--- a/ui/src/components/marketplaces/packages-trouble.tsx
+++ b/ui/src/components/marketplaces/packages-trouble.tsx
@@ -2,6 +2,7 @@ import type { MarketplaceRow, Scope } from "@/bindings";
 import {
   SEE_PROBLEMS_LABEL,
   unreadableRecordsLine,
+  unreadableRecordsWriteLine,
   unreadableSourcesLine,
 } from "@/lib/copy-marketplaces";
 import { scopeLabel } from "@/lib/derive";
@@ -80,6 +81,18 @@ export function RecordsUnreadableNote({ scope }: { scope: Scope }) {
   return (
     <p className="text-xs text-warning">
       {unreadableRecordsLine(scopeName(scope))} <SeeProblemsLink />
+    </p>
+  );
+}
+
+/** What the Subscribe dialog says in place of a button that would write
+ * into a place whose records cannot be read. Drawn beside
+ * [RecordsUnreadableNote] rather than in the dialog, so how an unreadable
+ * record is said stays one shape however many surfaces say it. */
+export function RecordsUnreadableWriteNote({ scope }: { scope: Scope }) {
+  return (
+    <p className="text-xs text-warning">
+      {unreadableRecordsWriteLine(scopeName(scope))} <SeeProblemsLink />
     </p>
   );
 }

--- a/ui/src/components/marketplaces/subscribe-dialog.dom.test.tsx
+++ b/ui/src/components/marketplaces/subscribe-dialog.dom.test.tsx
@@ -101,34 +101,30 @@ describe("the place a subscription is chosen for", () => {
     );
   }
 
-  // The control: a readable record leaves the button live, so the test
-  // below is the record doing the withholding and not the input.
-  it("offers the subscription where its records read", async () => {
-    expect((await filled())?.disabled).toBe(false);
-    expect(document.body.textContent).not.toContain("See Problems");
-  });
-
-  it("takes no subscription and says why where they do not", async () => {
-    records(true);
-
-    expect((await filled())?.disabled).toBe(true);
-    expect(document.body.textContent).toContain(
-      unreadableRecordsWriteLine("Personal"),
+  // Everything the chosen place decides, in one pass. Withheld while its
+  // read is still out and offered once that read says the records are
+  // there; the question follows the picker to the next place, and where
+  // that place cannot answer the button goes and the write line says which
+  // place and why. The control is the first half: a readable record leaves
+  // the button live, so what follows is the record withholding and not the
+  // input.
+  it("offers the subscription only where the chosen place's records read", async () => {
+    let answer: (r: { status: "ok"; data: boolean }) => void = () => {};
+    vi.mocked(commands.scopeRecordsUnreadable).mockReturnValue(
+      new Promise((resolve) => {
+        answer = resolve;
+      }),
     );
-    // Both halves: the line this surface draws, and the one it must not.
-    expect(document.body.textContent).not.toContain(
-      unreadableRecordsLine("Personal"),
-    );
-    expect(document.body.textContent).toContain("See Problems");
-  });
-
-  // The answer belongs to the place, so the question follows the picker.
-  it("asks again for the place the picker moves to", async () => {
     const submit = await filled();
+    expect(submit?.disabled).toBe(true);
+
+    answer({ status: "ok", data: false });
+    await settle();
     expect(commands.scopeRecordsUnreadable).toHaveBeenLastCalledWith({
       scope: "global",
     });
     expect(submit?.disabled).toBe(false);
+    expect(document.body.textContent).not.toContain("See Problems");
 
     records(true);
     const trigger = document.querySelector<HTMLElement>(
@@ -145,28 +141,15 @@ describe("the place a subscription is chosen for", () => {
     await settle();
 
     expect(commands.scopeRecordsUnreadable).toHaveBeenLastCalledWith(ACME);
+    expect(submit?.disabled).toBe(true);
     expect(document.body.textContent).toContain(
       unreadableRecordsWriteLine("acme"),
     );
-  });
-
-  // Withheld while the read is still out: pressing into the gap would be
-  // pressing before the place had answered.
-  it("offers nothing while the read is still out", async () => {
-    vi.mocked(commands.scopeRecordsUnreadable).mockReturnValue(
-      new Promise(() => {}),
+    // Both halves: the line this surface draws, and the one it must not.
+    expect(document.body.textContent).not.toContain(
+      unreadableRecordsLine("acme"),
     );
-    const host = mount(<SubscribeDialog open onOpenChange={() => {}} />);
-    const input = host.ownerDocument.querySelector<HTMLInputElement>(
-      "#subscribe-reference",
-    );
-    if (!input) throw new Error("no reference input rendered");
-    await userEvent.type(input, "Acme/Kit");
-
-    const submit = [...document.querySelectorAll("button")].find(
-      (button) => button.textContent === "Subscribe",
-    );
-    expect(submit?.disabled).toBe(true);
+    expect(document.body.textContent).toContain("See Problems");
   });
 
   // A local read that fails leaves Subscribe live on purpose: the engine

--- a/ui/src/components/marketplaces/subscribe-dialog.dom.test.tsx
+++ b/ui/src/components/marketplaces/subscribe-dialog.dom.test.tsx
@@ -1,7 +1,13 @@
 // @vitest-environment jsdom
 import userEvent from "@testing-library/user-event";
+import { act } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Scope } from "@/bindings";
 import { commands } from "@/bindings";
+import {
+  unreadableRecordsLine,
+  unreadableRecordsWriteLine,
+} from "@/lib/copy-marketplaces";
 import { useMarketplacesStore } from "@/stores/marketplaces";
 import { mount, settle } from "@/test/dom";
 import { SubscribeDialog } from "./subscribe-dialog";
@@ -11,8 +17,13 @@ vi.mock("@/bindings", () => ({
 }));
 vi.mock("@/stores/settings", () => ({
   useSettingsStore: (selector: (state: unknown) => unknown) =>
-    selector({ settings: { projects: [] } }),
+    selector({ settings: { projects: [ACME.root] } }),
 }));
+
+const ACME: Extract<Scope, { scope: "project" }> = {
+  scope: "project",
+  root: "/work/acme",
+};
 
 /** What the chosen place's record read answers. */
 function records(unreadable: boolean) {
@@ -102,8 +113,74 @@ describe("the place a subscription is chosen for", () => {
 
     expect((await filled())?.disabled).toBe(true);
     expect(document.body.textContent).toContain(
-      "can't read Personal's records",
+      unreadableRecordsWriteLine("Personal"),
+    );
+    // The write line, not the read one: the consequence here is that
+    // nothing is written, never that a row is stale.
+    expect(document.body.textContent).not.toContain(
+      unreadableRecordsLine("Personal"),
     );
     expect(document.body.textContent).toContain("See Problems");
+  });
+
+  // The answer belongs to the place, so the question follows the picker.
+  it("asks again for the place the picker moves to", async () => {
+    const submit = await filled();
+    expect(commands.scopeRecordsUnreadable).toHaveBeenLastCalledWith({
+      scope: "global",
+    });
+    expect(submit?.disabled).toBe(false);
+
+    records(true);
+    const trigger = document.querySelector<HTMLElement>(
+      '[data-slot="select-trigger"]',
+    );
+    if (!trigger) throw new Error("no place select rendered");
+    act(() => trigger.focus());
+    await userEvent.keyboard("{Enter}");
+    const option = [...document.querySelectorAll('[role="option"]')].find(
+      (el) => el.textContent === "acme",
+    );
+    if (!(option instanceof HTMLElement)) throw new Error("no acme option");
+    await userEvent.click(option);
+    await settle();
+
+    expect(commands.scopeRecordsUnreadable).toHaveBeenLastCalledWith(ACME);
+    expect(document.body.textContent).toContain(
+      unreadableRecordsWriteLine("acme"),
+    );
+  });
+
+  // Withheld while the read is still out, the way the two install pages
+  // withhold on a payload they have not got yet: pressing into the gap
+  // would be pressing before the place had answered.
+  it("offers nothing while the read is still out", async () => {
+    vi.mocked(commands.scopeRecordsUnreadable).mockReturnValue(
+      new Promise(() => {}),
+    );
+    const host = mount(<SubscribeDialog open onOpenChange={() => {}} />);
+    const input = host.ownerDocument.querySelector<HTMLInputElement>(
+      "#subscribe-reference",
+    );
+    if (!input) throw new Error("no reference input rendered");
+    await userEvent.type(input, "Acme/Kit");
+
+    const submit = [...document.querySelectorAll("button")].find(
+      (button) => button.textContent === "Subscribe",
+    );
+    expect(submit?.disabled).toBe(true);
+  });
+
+  // A local read that fails leaves Subscribe live on purpose: the engine
+  // refuses the write itself with its own words, and failing closed here
+  // would put the button out of reach for good whenever the read errors.
+  it("still offers the subscription when the read itself fails", async () => {
+    vi.mocked(commands.scopeRecordsUnreadable).mockResolvedValue({
+      status: "error",
+      error: "no such place",
+    });
+
+    expect((await filled())?.disabled).toBe(false);
+    expect(document.body.textContent).not.toContain("See Problems");
   });
 });

--- a/ui/src/components/marketplaces/subscribe-dialog.dom.test.tsx
+++ b/ui/src/components/marketplaces/subscribe-dialog.dom.test.tsx
@@ -115,8 +115,7 @@ describe("the place a subscription is chosen for", () => {
     expect(document.body.textContent).toContain(
       unreadableRecordsWriteLine("Personal"),
     );
-    // The write line, not the read one: the consequence here is that
-    // nothing is written, never that a row is stale.
+    // Both halves: the line this surface draws, and the one it must not.
     expect(document.body.textContent).not.toContain(
       unreadableRecordsLine("Personal"),
     );
@@ -151,9 +150,8 @@ describe("the place a subscription is chosen for", () => {
     );
   });
 
-  // Withheld while the read is still out, the way the two install pages
-  // withhold on a payload they have not got yet: pressing into the gap
-  // would be pressing before the place had answered.
+  // Withheld while the read is still out: pressing into the gap would be
+  // pressing before the place had answered.
   it("offers nothing while the read is still out", async () => {
     vi.mocked(commands.scopeRecordsUnreadable).mockReturnValue(
       new Promise(() => {}),

--- a/ui/src/components/marketplaces/subscribe-dialog.dom.test.tsx
+++ b/ui/src/components/marketplaces/subscribe-dialog.dom.test.tsx
@@ -1,18 +1,32 @@
 // @vitest-environment jsdom
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { commands } from "@/bindings";
 import { useMarketplacesStore } from "@/stores/marketplaces";
 import { mount, settle } from "@/test/dom";
 import { SubscribeDialog } from "./subscribe-dialog";
 
+vi.mock("@/bindings", () => ({
+  commands: { scopeRecordsUnreadable: vi.fn() },
+}));
 vi.mock("@/stores/settings", () => ({
   useSettingsStore: (selector: (state: unknown) => unknown) =>
     selector({ settings: { projects: [] } }),
 }));
 
+/** What the chosen place's record read answers. */
+function records(unreadable: boolean) {
+  vi.mocked(commands.scopeRecordsUnreadable).mockResolvedValue({
+    status: "ok",
+    data: unreadable,
+  });
+}
+
 const REFUSAL = "already subscribed as 'kit'";
 
 beforeEach(() => {
+  vi.clearAllMocks();
+  records(false);
   useMarketplacesStore.setState({
     error: null,
     busy: false,
@@ -54,5 +68,42 @@ describe("a refused subscribe", () => {
     await settle();
 
     expect(document.body.textContent).toContain(REFUSAL);
+  });
+});
+
+/** Subscribing plans against the chosen place's lock, so a record this
+ * build can't read refuses the write. The dialog is where the place was
+ * chosen, so it is where the reason belongs — rather than the engine's raw
+ * LockCorrupt arriving after the press. */
+describe("the place a subscription is chosen for", () => {
+  /** The dialog with a reference already typed, ready to submit. */
+  async function filled() {
+    const host = mount(<SubscribeDialog open onOpenChange={() => {}} />);
+    const input = host.ownerDocument.querySelector<HTMLInputElement>(
+      "#subscribe-reference",
+    );
+    if (!input) throw new Error("no reference input rendered");
+    await userEvent.type(input, "Acme/Kit");
+    await settle();
+    return [...document.querySelectorAll("button")].find(
+      (button) => button.textContent === "Subscribe",
+    );
+  }
+
+  // The control: a readable record leaves the button live, so the test
+  // below is the record doing the withholding and not the input.
+  it("offers the subscription where its records read", async () => {
+    expect((await filled())?.disabled).toBe(false);
+    expect(document.body.textContent).not.toContain("See Problems");
+  });
+
+  it("takes no subscription and says why where they do not", async () => {
+    records(true);
+
+    expect((await filled())?.disabled).toBe(true);
+    expect(document.body.textContent).toContain(
+      "can't read Personal's records",
+    );
+    expect(document.body.textContent).toContain("See Problems");
   });
 });

--- a/ui/src/components/marketplaces/subscribe-dialog.tsx
+++ b/ui/src/components/marketplaces/subscribe-dialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import type { Scope } from "@/bindings";
+import { commands, type Scope } from "@/bindings";
+import { SeeProblemsLink } from "@/components/marketplaces/packages-trouble";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -18,10 +19,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { SUBSCRIBE_MEANS } from "@/lib/copy-marketplaces";
+import {
+  SUBSCRIBE_MEANS,
+  unreadableRecordsWriteLine,
+} from "@/lib/copy-marketplaces";
 import { scopeLabel } from "@/lib/derive";
 import { scopeName } from "@/lib/labels";
 import { everyPlace } from "@/lib/scope";
+import { useOrderedRead } from "@/lib/use-ordered-read";
 import { useMarketplacesStore } from "@/stores/marketplaces";
 import { useSettingsStore } from "@/stores/settings";
 import { projectsOf } from "@/stores/settings-projects";
@@ -68,12 +73,24 @@ export function SubscribeDialog({
   }, [open, clearError]);
 
   const scopes = everyPlace(projects);
+  const target: Scope = scopes.find((s) => scopeLabel(s) === where) ?? {
+    scope: "global",
+  };
+
+  // Subscribing plans against the chosen place's lock, so a record this
+  // build can't read refuses the write outright. Asked of the place that
+  // was chosen and re-asked when the choice moves: the answer belongs to
+  // the place, not to this dialog, and the reason has to travel with the
+  // choice that caused it rather than arriving as the engine's raw refusal
+  // after the press.
+  const records = useOrderedRead<boolean>(
+    open ? scopeLabel(target) : null,
+    () => commands.scopeRecordsUnreadable(target),
+  );
+  const recordsUnknown = records.status === "ok" && records.data;
 
   const submit = () => {
-    if (!reference.trim()) return;
-    const target =
-      scopes.find((s) => scopeLabel(s) === where) ??
-      ({ scope: "global" } as Scope);
+    if (!reference.trim() || recordsUnknown) return;
     void subscribe(target, reference.trim(), name.trim() || null).then(
       (outcome) => {
         // A refusal keeps the dialog open with the input intact — the
@@ -157,6 +174,12 @@ export function SubscribeDialog({
               </Select>
             </div>
           </div>
+          {recordsUnknown ? (
+            <p className="text-xs text-warning">
+              {unreadableRecordsWriteLine(scopeName(target))}{" "}
+              <SeeProblemsLink />
+            </p>
+          ) : null}
           {error ? (
             <p className="text-sm text-critical" role="alert">
               {error}
@@ -170,7 +193,10 @@ export function SubscribeDialog({
             >
               Cancel
             </Button>
-            <Button type="submit" disabled={busy || !reference.trim()}>
+            <Button
+              type="submit"
+              disabled={busy || !reference.trim() || recordsUnknown}
+            >
               {busy ? "Subscribing…" : "Subscribe"}
             </Button>
           </DialogFooter>

--- a/ui/src/components/marketplaces/subscribe-dialog.tsx
+++ b/ui/src/components/marketplaces/subscribe-dialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { commands, type Scope } from "@/bindings";
-import { SeeProblemsLink } from "@/components/marketplaces/packages-trouble";
+import { RecordsUnreadableWriteNote } from "@/components/marketplaces/packages-trouble";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -19,10 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  SUBSCRIBE_MEANS,
-  unreadableRecordsWriteLine,
-} from "@/lib/copy-marketplaces";
+import { SUBSCRIBE_MEANS } from "@/lib/copy-marketplaces";
 import { scopeLabel } from "@/lib/derive";
 import { scopeName } from "@/lib/labels";
 import { everyPlace } from "@/lib/scope";
@@ -87,10 +84,17 @@ export function SubscribeDialog({
     open ? scopeLabel(target) : null,
     () => commands.scopeRecordsUnreadable(target),
   );
-  const recordsUnknown = records.status === "ok" && records.data;
+  // The answer, and the button's own question. Subscribe is withheld while
+  // the read is still out too, the way the two install pages withhold on a
+  // payload they do not have yet; only an answered read draws the reason,
+  // since a sub-millisecond wait has nothing to say. A failed read is left
+  // open: the engine refuses the write itself, and failing closed here
+  // would disable Subscribe for good whenever the local read errors.
+  const unreadable = records.status === "ok" && records.data;
+  const withheld = unreadable || records.status === "loading";
 
   const submit = () => {
-    if (!reference.trim() || recordsUnknown) return;
+    if (!reference.trim() || withheld) return;
     void subscribe(target, reference.trim(), name.trim() || null).then(
       (outcome) => {
         // A refusal keeps the dialog open with the input intact — the
@@ -174,12 +178,7 @@ export function SubscribeDialog({
               </Select>
             </div>
           </div>
-          {recordsUnknown ? (
-            <p className="text-xs text-warning">
-              {unreadableRecordsWriteLine(scopeName(target))}{" "}
-              <SeeProblemsLink />
-            </p>
-          ) : null}
+          {unreadable ? <RecordsUnreadableWriteNote scope={target} /> : null}
           {error ? (
             <p className="text-sm text-critical" role="alert">
               {error}
@@ -195,7 +194,7 @@ export function SubscribeDialog({
             </Button>
             <Button
               type="submit"
-              disabled={busy || !reference.trim() || recordsUnknown}
+              disabled={busy || !reference.trim() || withheld}
             >
               {busy ? "Subscribing…" : "Subscribe"}
             </Button>

--- a/ui/src/components/marketplaces/subscribe-dialog.tsx
+++ b/ui/src/components/marketplaces/subscribe-dialog.tsx
@@ -85,11 +85,11 @@ export function SubscribeDialog({
     () => commands.scopeRecordsUnreadable(target),
   );
   // The answer, and the button's own question. Subscribe is withheld while
-  // the read is still out too, the way the two install pages withhold on a
-  // payload they do not have yet; only an answered read draws the reason,
-  // since a sub-millisecond wait has nothing to say. A failed read is left
-  // open: the engine refuses the write itself, and failing closed here
-  // would disable Subscribe for good whenever the local read errors.
+  // the read is still out too, since a press then lands before the place
+  // has answered; only an answered read draws the reason, because a
+  // sub-millisecond wait has nothing to say. A failed read is left open:
+  // the engine refuses the write itself, and failing closed here would
+  // disable Subscribe for good whenever the local read errors.
   const unreadable = records.status === "ok" && records.data;
   const withheld = unreadable || records.status === "loading";
 

--- a/ui/src/lib/copy-marketplaces.ts
+++ b/ui/src/lib/copy-marketplaces.ts
@@ -49,6 +49,13 @@ export const unreadableRecordsLine = (place: string): string =>
 export const unreadableSourcesLine = (place: string): string =>
   `kendex couldn't read some of ${place}'s marketplaces, so their packages aren't listed.`;
 
+/** One place a write cannot land in. Subscribing plans against the chosen
+ * place's lock, so a record this build can't read refuses the subscription
+ * outright — a different consequence from [unreadableRecordsLine]'s rows
+ * that can't say what's installed, and said where the place was chosen. */
+export const unreadableRecordsWriteLine = (place: string): string =>
+  `kendex can't read ${place}'s records, so nothing can be added there yet.`;
+
 export const SEE_PROBLEMS_LABEL = "See Problems";
 
 // What subscribing does, said wherever Subscribe is offered so nobody has

--- a/ui/src/lib/copy-marketplaces.ts
+++ b/ui/src/lib/copy-marketplaces.ts
@@ -49,10 +49,12 @@ export const unreadableRecordsLine = (place: string): string =>
 export const unreadableSourcesLine = (place: string): string =>
   `kendex couldn't read some of ${place}'s marketplaces, so their packages aren't listed.`;
 
-/** One place a write cannot land in. Subscribing plans against the chosen
+/** One place a write cannot land in, said by [RecordsUnreadableWriteNote]
+ * where a subscription's place is being chosen — before any read of that
+ * place exists. [unreadableRecordsLine] is the line for where one already
+ * landed and came back unable to say. Subscribing plans against the chosen
  * place's lock, so a record this build can't read refuses the subscription
- * outright — a different consequence from [unreadableRecordsLine]'s rows
- * that can't say what's installed, and said where the place was chosen. */
+ * outright. */
 export const unreadableRecordsWriteLine = (place: string): string =>
   `kendex can't read ${place}'s records, so nothing can be added there yet.`;
 

--- a/ui/src/lib/copy-marketplaces.ts
+++ b/ui/src/lib/copy-marketplaces.ts
@@ -50,11 +50,9 @@ export const unreadableSourcesLine = (place: string): string =>
   `kendex couldn't read some of ${place}'s marketplaces, so their packages aren't listed.`;
 
 /** One place a write cannot land in, said by [RecordsUnreadableWriteNote]
- * where a subscription's place is being chosen — before any read of that
- * place exists. [unreadableRecordsLine] is the line for where one already
- * landed and came back unable to say. Subscribing plans against the chosen
- * place's lock, so a record this build can't read refuses the subscription
- * outright. */
+ * where a subscription's place is being chosen. Subscribing plans against
+ * the chosen place's lock, so a record this build can't read refuses the
+ * subscription outright. */
 export const unreadableRecordsWriteLine = (place: string): string =>
   `kendex can't read ${place}'s records, so nothing can be added there yet.`;
 

--- a/ui/src/pages/available-package.dom.test.tsx
+++ b/ui/src/pages/available-package.dom.test.tsx
@@ -3,8 +3,12 @@
 // state the app first draws it in. Its tree reads the store through the
 // destination picker, and a store read that answers with a fresh value each
 // time re-renders the tree until React throws.
+import userEvent from "@testing-library/user-event";
+import { act } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppSettings, Scope } from "@/bindings";
 import { commands, type PackageView } from "@/bindings";
+import { unreadableRecordsLine } from "@/lib/copy-marketplaces";
 import { useMarketplacesStore } from "@/stores/marketplaces";
 import { subscription } from "@/stores/marketplaces-shared";
 import { useNavStore } from "@/stores/nav";
@@ -23,6 +27,27 @@ vi.mock("sonner", () => ({
 }));
 
 const catalog = subscription({ scope: "global" }, "kit");
+const ACME: Extract<Scope, { scope: "project" }> = {
+  scope: "project",
+  root: "/work/acme",
+};
+
+/** Pick a place in the destination select. A pointer click does not open a
+ *  base-ui trigger under jsdom, so the keyboard path opens it. */
+async function chooseDestination(host: HTMLElement, label: string) {
+  const trigger = [...host.querySelectorAll("button")].find((button) =>
+    button.textContent?.includes("Install to"),
+  );
+  if (!trigger) throw new Error("no destination select rendered");
+  act(() => trigger.focus());
+  await userEvent.keyboard("{Enter}");
+  const option = [...document.querySelectorAll('[role="option"]')].find(
+    (el) => el.textContent === label,
+  );
+  if (!(option instanceof HTMLElement)) throw new Error(`no ${label} option`);
+  await userEvent.click(option);
+  await settle();
+}
 
 const view: PackageView = {
   preview: {
@@ -51,6 +76,9 @@ const view: PackageView = {
   },
 };
 
+/** The store action the Install button lands on. */
+const installed = vi.fn(async () => true);
+
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(commands.marketplacePackagePreview).mockResolvedValue({
@@ -66,9 +94,12 @@ beforeEach(() => {
     packages: {},
     summaries: {},
     readErrors: {},
+    busy: false,
+    install: installed,
   });
-  // Not yet read — the state the page is first drawn in.
-  useSettingsStore.setState({ settings: null });
+  useSettingsStore.setState({
+    settings: { projects: [ACME.root] } as AppSettings,
+  });
   useNavStore.setState({
     availableRef: { kind: "skill", name: "gh", catalog },
   });
@@ -118,7 +149,49 @@ describe("the available package page", () => {
     await settle();
 
     expect(installButton(host)?.disabled).toBe(true);
-    expect(host.textContent).toContain("can't read Personal's records");
+    expect(host.textContent).toContain(unreadableRecordsLine("Personal"));
     expect(host.textContent).toContain("See Problems");
+  });
+
+  // The read carries the destination, and so does the reason: the record
+  // that could not be read is the chosen project's, so naming the scope
+  // being browsed would send the reader to the wrong place's Problems.
+  it("re-reads for a chosen project and names that place in the reason", async () => {
+    const host = mount(<AvailablePackagePage />);
+    await settle();
+
+    vi.mocked(commands.marketplacePackagePreview).mockResolvedValue({
+      status: "ok",
+      data: { ...view, preview: { ...view.preview, state: "unknown" } },
+    });
+    await chooseDestination(host, "acme");
+
+    expect(commands.marketplacePackagePreview).toHaveBeenLastCalledWith(
+      catalog,
+      "skill",
+      "gh",
+      ACME,
+    );
+    expect(host.textContent).toContain(unreadableRecordsLine("acme"));
+    expect(host.textContent).not.toContain(unreadableRecordsLine("Personal"));
+  });
+
+  // Picking the place already being browsed is not a redirect, and the
+  // picker hands back a freshly built Scope, so identity would call it one
+  // and send the install a destination it does not have.
+  it("sends no destination once the picker comes back to the browsed place", async () => {
+    const host = mount(<AvailablePackagePage />);
+    await settle();
+    await chooseDestination(host, "acme");
+    await chooseDestination(host, "Personal");
+
+    const install = installButton(host);
+    if (!install) throw new Error("no Install button rendered");
+    await userEvent.click(install);
+    await settle();
+
+    expect(installed).toHaveBeenCalledWith(
+      expect.objectContaining({ destination: null }),
+    );
   });
 });

--- a/ui/src/pages/available-package.dom.test.tsx
+++ b/ui/src/pages/available-package.dom.test.tsx
@@ -106,6 +106,14 @@ beforeEach(() => {
   });
 });
 
+/** What the preview read answers with. */
+function answer(preview: PackageView["preview"]) {
+  vi.mocked(commands.marketplacePackagePreview).mockResolvedValue({
+    status: "ok",
+    data: { ...view, preview },
+  });
+}
+
 /** The header's Install, whatever it currently reads. */
 function installButton(host: HTMLElement): HTMLButtonElement | undefined {
   return [...host.querySelectorAll("button")].find(
@@ -134,41 +142,19 @@ describe("the available package page", () => {
     expect(host.textContent).toContain("works a pull request");
   });
 
-  // The engine answers Unknown for the place the install would land in, so
-  // the page has that place's answer and no reason to keep a button the
-  // engine would refuse on the same record.
-  it("withholds Install and says why when the landing place's records went unread", async () => {
+  // Everything the destination decides on this page, in one pass. The read
+  // is asked again for the project; the record standing is that project's,
+  // so Install withholds on it and the reason names it; and coming back to
+  // the place being browsed is not a redirect, so neither the read nor the
+  // install carries one.
+  it("reads, gates and says why for the place the install would land in", async () => {
     const host = mount(<AvailablePackagePage />);
     await settle();
     // The control: a readable record leaves the button alone, so what
     // follows is the state doing the withholding and not the page.
     expect(installButton(host)?.disabled).toBe(false);
 
-    vi.mocked(commands.marketplacePackagePreview).mockResolvedValue({
-      status: "ok",
-      data: { ...view, preview: { ...view.preview, state: "unknown" } },
-    });
-    useNavStore.setState({
-      availableRef: { kind: "skill", name: "gh2", catalog },
-    });
-    await settle();
-
-    expect(installButton(host)?.disabled).toBe(true);
-    expect(host.textContent).toContain(unreadableRecordsLine("Personal"));
-    expect(host.textContent).toContain("See Problems");
-  });
-
-  // The read carries the destination, and so does the reason: the record
-  // that could not be read is the chosen project's, so naming the scope
-  // being browsed would send the reader to the wrong place's Problems.
-  it("re-reads for a chosen project and names that place in the reason", async () => {
-    const host = mount(<AvailablePackagePage />);
-    await settle();
-
-    vi.mocked(commands.marketplacePackagePreview).mockResolvedValue({
-      status: "ok",
-      data: { ...view, preview: { ...view.preview, state: "unknown" } },
-    });
+    answer({ ...view.preview, state: "unknown" });
     await chooseDestination(host, "acme");
 
     expect(commands.marketplacePackagePreview).toHaveBeenLastCalledWith(
@@ -177,20 +163,13 @@ describe("the available package page", () => {
       "gh",
       ACME,
     );
+    expect(installButton(host)?.disabled).toBe(true);
     expect(host.textContent).toContain(unreadableRecordsLine("acme"));
     expect(host.textContent).not.toContain(unreadableRecordsLine("Personal"));
-  });
+    expect(host.textContent).toContain("See Problems");
 
-  // Picking the place already being browsed is not a redirect, and the
-  // picker hands back a freshly built Scope, so identity would call it one:
-  // the read would ask the engine to redirect into the place it is already
-  // browsing, and the install would carry a destination it does not have.
-  it("sends no destination once the picker comes back to the browsed place", async () => {
-    const host = mount(<AvailablePackagePage />);
-    await settle();
-    await chooseDestination(host, "acme");
+    answer(view.preview);
     await chooseDestination(host, "Personal");
-
     expect(commands.marketplacePackagePreview).toHaveBeenLastCalledWith(
       catalog,
       "skill",
@@ -202,7 +181,6 @@ describe("the available package page", () => {
     if (!install) throw new Error("no Install button rendered");
     await userEvent.click(install);
     await settle();
-
     expect(installed).toHaveBeenCalledWith(
       expect.objectContaining({ destination: null }),
     );

--- a/ui/src/pages/available-package.dom.test.tsx
+++ b/ui/src/pages/available-package.dom.test.tsx
@@ -74,6 +74,13 @@ beforeEach(() => {
   });
 });
 
+/** The header's Install, whatever it currently reads. */
+function installButton(host: HTMLElement): HTMLButtonElement | undefined {
+  return [...host.querySelectorAll("button")].find(
+    (button) => button.textContent === "Install",
+  );
+}
+
 describe("the available package page", () => {
   it("settles on mount before the settings read has landed", async () => {
     const host = mount(<AvailablePackagePage />);
@@ -89,5 +96,29 @@ describe("the available package page", () => {
     // this proves was really read.
     expect(host.textContent).toContain("Install to");
     expect(host.textContent).toContain("works a pull request");
+  });
+
+  // The engine answers Unknown for the place the install would land in, so
+  // the page has that place's answer and no reason to keep a button the
+  // engine would refuse on the same record.
+  it("withholds Install and says why when the landing place's records went unread", async () => {
+    const host = mount(<AvailablePackagePage />);
+    await settle();
+    // The control: a readable record leaves the button alone, so what
+    // follows is the state doing the withholding and not the page.
+    expect(installButton(host)?.disabled).toBe(false);
+
+    vi.mocked(commands.marketplacePackagePreview).mockResolvedValue({
+      status: "ok",
+      data: { ...view, preview: { ...view.preview, state: "unknown" } },
+    });
+    useNavStore.setState({
+      availableRef: { kind: "skill", name: "gh2", catalog },
+    });
+    await settle();
+
+    expect(installButton(host)?.disabled).toBe(true);
+    expect(host.textContent).toContain("can't read Personal's records");
+    expect(host.textContent).toContain("See Problems");
   });
 });

--- a/ui/src/pages/available-package.dom.test.tsx
+++ b/ui/src/pages/available-package.dom.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
-// The page mounts and settles with the settings read unlanded, which is the
-// state the app first draws it in. Its tree reads the store through the
+// The page's wiring: which place it reads for, which place its refusal
+// names, and what it sends an install. Its tree reads the store through the
 // destination picker, and a store read that answers with a fresh value each
-// time re-renders the tree until React throws.
+// time re-renders the tree until React throws — so the first case mounts
+// with the settings read unlanded, the state the app first draws it in.
 import userEvent from "@testing-library/user-event";
 import { act } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -114,6 +115,10 @@ function installButton(host: HTMLElement): HTMLButtonElement | undefined {
 
 describe("the available package page", () => {
   it("settles on mount before the settings read has landed", async () => {
+    // The state the app first draws this page in: no place registry yet, so
+    // the picker has only the personal scope to offer. Every other case
+    // here needs a project to pick, which is why the fixture lands one.
+    useSettingsStore.setState({ settings: null });
     const host = mount(<AvailablePackagePage />);
     await settle();
 
@@ -177,13 +182,21 @@ describe("the available package page", () => {
   });
 
   // Picking the place already being browsed is not a redirect, and the
-  // picker hands back a freshly built Scope, so identity would call it one
-  // and send the install a destination it does not have.
+  // picker hands back a freshly built Scope, so identity would call it one:
+  // the read would ask the engine to redirect into the place it is already
+  // browsing, and the install would carry a destination it does not have.
   it("sends no destination once the picker comes back to the browsed place", async () => {
     const host = mount(<AvailablePackagePage />);
     await settle();
     await chooseDestination(host, "acme");
     await chooseDestination(host, "Personal");
+
+    expect(commands.marketplacePackagePreview).toHaveBeenLastCalledWith(
+      catalog,
+      "skill",
+      "gh",
+      null,
+    );
 
     const install = installButton(host);
     if (!install) throw new Error("no Install button rendered");

--- a/ui/src/pages/available-package.tsx
+++ b/ui/src/pages/available-package.tsx
@@ -89,8 +89,7 @@ function AvailablePackage({ availableRef }: { availableRef: AvailableRef }) {
     setChosen(address === null ? null : { at: address, file });
 
   const Icon = kindIcon(kind);
-  // The place named on screen, as against `redirected`, which is whether a
-  // place was chosen at all.
+  // The place named on screen.
   const target = destination ?? scope;
   // Matched by scope and name both — two scopes can subscribe the same
   // alias to different repositories.

--- a/ui/src/pages/available-package.tsx
+++ b/ui/src/pages/available-package.tsx
@@ -99,10 +99,11 @@ function AvailablePackage({ availableRef }: { availableRef: AvailableRef }) {
   const repo = row?.repo ?? row?.path ?? summary?.provenance ?? null;
   const shownError = reachError ?? error;
   // Every Packages row opens this page, "Not known" ones included. The
-  // engine answered unknown because it could not read this scope's lock,
-  // and an install would meet the same record, so the page says why in
-  // place of the button rather than letting a raw engine error stand in
-  // for the reason.
+  // engine answered unknown because it could not read the lock of the place
+  // this install would land in — the destination when one is picked, which
+  // is the scope the engine mutates — and the install would meet that same
+  // record, so the page says why in place of the button rather than letting
+  // a raw engine error stand in for the reason.
   const recordsUnknown = view !== null && recordsUnreadable(view.preview.state);
 
   const doInstall = () => {
@@ -195,8 +196,8 @@ function AvailablePackage({ availableRef }: { availableRef: AvailableRef }) {
                   {shownError}
                 </p>
               ) : null}
-              {recordsUnknown && scope ? (
-                <RecordsUnreadableNote scope={scope} />
+              {recordsUnknown && target ? (
+                <RecordsUnreadableNote scope={target} />
               ) : null}
               {/* The reading comes before the package's own words about
                   itself: the header already says what this is, and this is

--- a/ui/src/pages/available-package.tsx
+++ b/ui/src/pages/available-package.tsx
@@ -21,6 +21,7 @@ import { recordsUnreadable } from "@/lib/install-state";
 import { kindIcon } from "@/lib/kind-icon";
 import { kindLabel, packageDisplayName } from "@/lib/labels";
 import { PAGE_BODY, WIDE_CONTENT_WIDTH } from "@/lib/layout";
+import { sameScope } from "@/lib/scope";
 import { useOrderedRead } from "@/lib/use-ordered-read";
 import { cn } from "@/lib/utils";
 import { catalogKey, useMarketplacesStore } from "@/stores/marketplaces";
@@ -113,7 +114,9 @@ function AvailablePackage({ availableRef }: { availableRef: AvailableRef }) {
       scope,
       source,
       items: [{ kind, name }],
-      destination: target !== scope ? target : null,
+      // Same place, one answer: the picker builds a fresh Scope, so
+      // identity would call the browsed place a redirect.
+      destination: sameScope(target, scope) ? null : target,
       delivery: choice,
     }).then((ok) => {
       // Installed, the same page carries on in its installed mode — the

--- a/ui/src/pages/available-package.tsx
+++ b/ui/src/pages/available-package.tsx
@@ -56,16 +56,24 @@ function AvailablePackage({ availableRef }: { availableRef: AvailableRef }) {
     optional: [],
   });
 
+  const scope = catalog.by === "subscription" ? catalog.scope : null;
+  // One redirect judgment, feeding the address, the read and the install
+  // alike. Not object identity: the picker builds a fresh Scope from
+  // everyPlace, so coming back to the place already being browsed would
+  // read as a redirect into it and re-address the page for nothing.
+  const redirected =
+    destination && scope && !sameScope(destination, scope) ? destination : null;
+
   // Null until the catalog is ready: a repository's first fetch holds the
-  // store's lock, and a read racing it would be refused. The destination is
+  // store's lock, and a read racing it would be refused. The redirect is
   // part of the address: a dependency's state — already installed there,
   // or kept removed there — is a fact about the scope the install lands
   // in, so choosing another place is a different read.
   const address = ready
-    ? `${catalogKey(catalog)}::${kind}::${name}::${destination ? scopeLabel(destination) : ""}`
+    ? `${catalogKey(catalog)}::${kind}::${name}::${redirected ? scopeLabel(redirected) : ""}`
     : null;
   const read = useOrderedRead<PackageView>(address, () =>
-    commands.marketplacePackagePreview(catalog, kind, name, destination),
+    commands.marketplacePackagePreview(catalog, kind, name, redirected),
   );
   const view = read.status === "ok" ? read.data : null;
   const error = read.status === "error" ? read.error : null;
@@ -81,7 +89,8 @@ function AvailablePackage({ availableRef }: { availableRef: AvailableRef }) {
     setChosen(address === null ? null : { at: address, file });
 
   const Icon = kindIcon(kind);
-  const scope = catalog.by === "subscription" ? catalog.scope : null;
+  // The place named on screen, as against `redirected`, which is whether a
+  // place was chosen at all.
   const target = destination ?? scope;
   // Matched by scope and name both — two scopes can subscribe the same
   // alias to different repositories.
@@ -114,9 +123,7 @@ function AvailablePackage({ availableRef }: { availableRef: AvailableRef }) {
       scope,
       source,
       items: [{ kind, name }],
-      // Same place, one answer: the picker builds a fresh Scope, so
-      // identity would call the browsed place a redirect.
-      destination: sameScope(target, scope) ? null : target,
+      destination: redirected,
       delivery: choice,
     }).then((ok) => {
       // Installed, the same page carries on in its installed mode — the

--- a/ui/src/pages/bundle-detail.dom.test.tsx
+++ b/ui/src/pages/bundle-detail.dom.test.tsx
@@ -3,9 +3,12 @@
 // against the place the install would land in, and gate Install all on what
 // that place's record says. A prop-driven test of the member rows cannot
 // see either.
+import userEvent from "@testing-library/user-event";
+import { act } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { BundleDetail } from "@/bindings";
+import type { AppSettings, BundleDetail, Scope } from "@/bindings";
 import { commands } from "@/bindings";
+import { unreadableRecordsLine } from "@/lib/copy-marketplaces";
 import { useMarketplacesStore } from "@/stores/marketplaces";
 import { subscription } from "@/stores/marketplaces-shared";
 import { useNavStore } from "@/stores/nav";
@@ -24,6 +27,27 @@ vi.mock("sonner", () => ({
 }));
 
 const catalog = subscription({ scope: "global" }, "kit");
+const ACME: Extract<Scope, { scope: "project" }> = {
+  scope: "project",
+  root: "/work/acme",
+};
+
+/** Pick a place in the destination select. A pointer click does not open a
+ *  base-ui trigger under jsdom, so the keyboard path opens it. */
+async function chooseDestination(host: HTMLElement, label: string) {
+  const trigger = [...host.querySelectorAll("button")].find((button) =>
+    button.textContent?.includes("Install to"),
+  );
+  if (!trigger) throw new Error("no destination select rendered");
+  act(() => trigger.focus());
+  await userEvent.keyboard("{Enter}");
+  const option = [...document.querySelectorAll('[role="option"]')].find(
+    (el) => el.textContent === label,
+  );
+  if (!(option instanceof HTMLElement)) throw new Error(`no ${label} option`);
+  await userEvent.click(option);
+  await settle();
+}
 
 const starter: BundleDetail = {
   name: "starter",
@@ -59,7 +83,9 @@ beforeEach(() => {
     data: [{ harness: "claude", detected: true, sharesTheUniversalTree: true }],
   });
   useMarketplacesStore.setState({ bundles: {}, readErrors: {}, busy: false });
-  useSettingsStore.setState({ settings: null });
+  useSettingsStore.setState({
+    settings: { projects: [ACME.root] } as AppSettings,
+  });
   useNavStore.setState({ bundleRef: { bundle: "starter", catalog } });
 });
 
@@ -94,7 +120,51 @@ describe("the curated set page", () => {
     await settle();
 
     expect(installAll(host)?.disabled).toBe(true);
-    expect(host.textContent).toContain("can't read Personal's records");
+    expect(host.textContent).toContain(unreadableRecordsLine("Personal"));
     expect(host.textContent).toContain("See Problems");
+  });
+
+  // Everything the destination decides, in one pass: the read is asked
+  // again for the project, a tick made against the place before it is not
+  // carried into the new one, and the reason names the place the install
+  // would land in rather than the one being browsed.
+  it("re-reads for a chosen project, drops the tick, and names that place", async () => {
+    const host = mount(<BundleDetailPage />);
+    await settle();
+    const box = host.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    if (!box) throw new Error("no member checkbox rendered");
+    await userEvent.click(box);
+    await settle();
+    expect(host.textContent).toContain("Install 1 selected");
+
+    answer({ ...starter, recordsUnreadable: true, members: [] });
+    await chooseDestination(host, "acme");
+
+    expect(commands.marketplaceBundle).toHaveBeenLastCalledWith(
+      catalog,
+      "starter",
+      ACME,
+    );
+    expect(host.textContent).toContain("Install 0 selected");
+    expect(host.textContent).toContain(unreadableRecordsLine("acme"));
+    expect(host.textContent).not.toContain(unreadableRecordsLine("Personal"));
+  });
+
+  // Two ways the same read gets asked twice for one answer: the picker
+  // hands back a freshly built Scope, so the place already being browsed
+  // reads as a redirect under object identity; and a place already read
+  // has its answer in a slot of its own. Going out to a project and back
+  // asks the engine once, for the project.
+  it("asks once per place, and not at all for one already read", async () => {
+    const host = mount(<BundleDetailPage />);
+    await settle();
+    expect(commands.marketplaceBundle).toHaveBeenCalledTimes(1);
+
+    await chooseDestination(host, "acme");
+    expect(commands.marketplaceBundle).toHaveBeenCalledTimes(2);
+
+    await chooseDestination(host, "Personal");
+    await chooseDestination(host, "acme");
+    expect(commands.marketplaceBundle).toHaveBeenCalledTimes(2);
   });
 });

--- a/ui/src/pages/bundle-detail.dom.test.tsx
+++ b/ui/src/pages/bundle-detail.dom.test.tsx
@@ -10,7 +10,7 @@ import type { AppSettings, BundleDetail, Scope } from "@/bindings";
 import { commands } from "@/bindings";
 import { unreadableRecordsLine } from "@/lib/copy-marketplaces";
 import { useMarketplacesStore } from "@/stores/marketplaces";
-import { droppedSetCaches, subscription } from "@/stores/marketplaces-shared";
+import { subscription } from "@/stores/marketplaces-shared";
 import { useNavStore } from "@/stores/nav";
 import { useSettingsStore } from "@/stores/settings";
 import { mount, settle } from "@/test/dom";
@@ -82,18 +82,7 @@ beforeEach(() => {
     status: "ok",
     data: [{ harness: "claude", detected: true, sharesTheUniversalTree: true }],
   });
-  useMarketplacesStore.setState({
-    bundles: {},
-    readErrors: {},
-    busy: false,
-    // What the real action does to these caches, which is what asks this
-    // page again. A stub that skipped the drop would leave the count below
-    // passing because nothing re-read at all.
-    install: async () => {
-      useMarketplacesStore.setState(droppedSetCaches());
-      return true;
-    },
-  });
+  useMarketplacesStore.setState({ bundles: {}, readErrors: {}, busy: false });
   useSettingsStore.setState({
     settings: { projects: [ACME.root] } as AppSettings,
   });
@@ -101,52 +90,28 @@ beforeEach(() => {
 });
 
 describe("the curated set page", () => {
-  it("asks for the set against the place the install would land in", async () => {
-    mount(<BundleDetailPage />);
+  // Everything the destination decides on this page, in one pass. The read
+  // is asked again for the project and served from that project's own slot
+  // when it comes back to one already read; a tick made against the place
+  // before it is not carried into the new one; the record standing is that
+  // project's, so Install all withholds on it and the reason names it.
+  it("reads, gates and says why for the place the install would land in", async () => {
+    const host = mount(<BundleDetailPage />);
     await settle();
-
-    // Browsed and installed in the same place, so no redirect — the read
-    // carries the destination all the same, which is the argument a
-    // redirect fills.
     expect(commands.marketplaceBundle).toHaveBeenCalledWith(
       catalog,
       "starter",
       null,
     );
-  });
-
-  // The engine answers for the place the install lands in, so the page has
-  // that place's record standing and no reason to keep a button the engine
-  // would refuse on the same record.
-  it("withholds Install all and says why when that place's records went unread", async () => {
-    const host = mount(<BundleDetailPage />);
-    await settle();
-    // The control: a readable record leaves the button alone, so what
-    // follows is the record doing the withholding and not the page.
-    expect(installAll(host)?.disabled).toBe(false);
-    expect(host.textContent).not.toContain("See Problems");
-
-    answer({ ...starter, recordsUnreadable: true, members: [] });
-    useNavStore.setState({ bundleRef: { bundle: "other", catalog } });
-    await settle();
-
-    expect(installAll(host)?.disabled).toBe(true);
-    expect(host.textContent).toContain(unreadableRecordsLine("Personal"));
-    expect(host.textContent).toContain("See Problems");
-  });
-
-  // Everything the destination decides, in one pass: the read is asked
-  // again for the project, a tick made against the place before it is not
-  // carried into the new one, and the reason names the place the install
-  // would land in rather than the one being browsed.
-  it("re-reads for a chosen project, drops the tick, and names that place", async () => {
-    const host = mount(<BundleDetailPage />);
-    await settle();
     const box = host.querySelector<HTMLInputElement>('input[type="checkbox"]');
     if (!box) throw new Error("no member checkbox rendered");
     await userEvent.click(box);
     await settle();
+    // The control: a readable record leaves the buttons alone, so what
+    // follows is the record doing the withholding and not the page.
     expect(host.textContent).toContain("Install 1 selected");
+    expect(installAll(host)?.disabled).toBe(false);
+    expect(host.textContent).not.toContain("See Problems");
 
     answer({ ...starter, recordsUnreadable: true, members: [] });
     await chooseDestination(host, "acme");
@@ -156,40 +121,14 @@ describe("the curated set page", () => {
       "starter",
       ACME,
     );
+    expect(commands.marketplaceBundle).toHaveBeenCalledTimes(2);
     expect(host.textContent).toContain("Install 0 selected");
+    expect(installAll(host)?.disabled).toBe(true);
     expect(host.textContent).toContain(unreadableRecordsLine("acme"));
     expect(host.textContent).not.toContain(unreadableRecordsLine("Personal"));
-  });
 
-  // The install empties every set cache, and the read watches presence, so
-  // the drop is the whole trigger. A hand-rolled reload beside it asked the
-  // engine the same question twice for one install.
-  it("asks once more after an install, never twice", async () => {
-    const host = mount(<BundleDetailPage />);
-    await settle();
-    expect(commands.marketplaceBundle).toHaveBeenCalledTimes(1);
-
-    const button = installAll(host);
-    if (!button) throw new Error("no Install all rendered");
-    await userEvent.click(button);
-    await settle();
-
-    expect(commands.marketplaceBundle).toHaveBeenCalledTimes(2);
-  });
-
-  // Two ways the same read gets asked twice for one answer: the picker
-  // hands back a freshly built Scope, so the place already being browsed
-  // reads as a redirect under object identity; and a place already read
-  // has its answer in a slot of its own. Going out to a project and back
-  // asks the engine once, for the project.
-  it("asks once per place, and not at all for one already read", async () => {
-    const host = mount(<BundleDetailPage />);
-    await settle();
-    expect(commands.marketplaceBundle).toHaveBeenCalledTimes(1);
-
-    await chooseDestination(host, "acme");
-    expect(commands.marketplaceBundle).toHaveBeenCalledTimes(2);
-
+    // Back to the place being browsed, which is not a redirect, and out to
+    // the project again: both answers are already in slots of their own.
     await chooseDestination(host, "Personal");
     await chooseDestination(host, "acme");
     expect(commands.marketplaceBundle).toHaveBeenCalledTimes(2);

--- a/ui/src/pages/bundle-detail.dom.test.tsx
+++ b/ui/src/pages/bundle-detail.dom.test.tsx
@@ -133,4 +133,24 @@ describe("the curated set page", () => {
     await chooseDestination(host, "acme");
     expect(commands.marketplaceBundle).toHaveBeenCalledTimes(2);
   });
+
+  // A destination whose read fails is the one state the picker has to
+  // outlive: it is the only way to another place, and a page that hid it
+  // would strand the reader on the error with nothing to press.
+  it("can be switched away from a destination whose read failed", async () => {
+    const host = mount(<BundleDetailPage />);
+    await settle();
+
+    vi.mocked(commands.marketplaceBundle).mockResolvedValue({
+      status: "error",
+      error: "no manifest there",
+    });
+    await chooseDestination(host, "acme");
+    expect(host.textContent).toContain("no manifest there");
+    expect(host.textContent).toContain("Install to");
+
+    await chooseDestination(host, "Personal");
+    expect(host.textContent).not.toContain("no manifest there");
+    expect(host.textContent).toContain("the six things to begin with");
+  });
 });

--- a/ui/src/pages/bundle-detail.dom.test.tsx
+++ b/ui/src/pages/bundle-detail.dom.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+// The set page's read is wiring, not a prop: it has to ask for the set
+// against the place the install would land in, and gate Install all on what
+// that place's record says. A prop-driven test of the member rows cannot
+// see either.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BundleDetail } from "@/bindings";
+import { commands } from "@/bindings";
+import { useMarketplacesStore } from "@/stores/marketplaces";
+import { subscription } from "@/stores/marketplaces-shared";
+import { useNavStore } from "@/stores/nav";
+import { useSettingsStore } from "@/stores/settings";
+import { mount, settle } from "@/test/dom";
+import { BundleDetailPage } from "./bundle-detail";
+
+vi.mock("@/bindings", () => ({
+  commands: {
+    marketplaceBundle: vi.fn(),
+    installTargets: vi.fn(),
+  },
+}));
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn(), message: vi.fn() },
+}));
+
+const catalog = subscription({ scope: "global" }, "kit");
+
+const starter: BundleDetail = {
+  name: "starter",
+  description: "the six things to begin with",
+  version: null,
+  category: null,
+  members: [{ kind: "skill", name: "gh", state: "available" }],
+  installedMembers: 0,
+  totalMembers: 1,
+  collision: null,
+  recordsUnreadable: false,
+};
+
+/** Install all, whatever it currently reads. */
+function installAll(host: HTMLElement): HTMLButtonElement | undefined {
+  return [...host.querySelectorAll("button")].find(
+    (button) => button.textContent === "Install all",
+  );
+}
+
+function answer(detail: BundleDetail) {
+  vi.mocked(commands.marketplaceBundle).mockResolvedValue({
+    status: "ok",
+    data: detail,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  answer(starter);
+  vi.mocked(commands.installTargets).mockResolvedValue({
+    status: "ok",
+    data: [{ harness: "claude", detected: true, sharesTheUniversalTree: true }],
+  });
+  useMarketplacesStore.setState({ bundles: {}, readErrors: {}, busy: false });
+  useSettingsStore.setState({ settings: null });
+  useNavStore.setState({ bundleRef: { bundle: "starter", catalog } });
+});
+
+describe("the curated set page", () => {
+  it("asks for the set against the place the install would land in", async () => {
+    mount(<BundleDetailPage />);
+    await settle();
+
+    // Browsed and installed in the same place, so no redirect — the read
+    // carries the destination all the same, which is the argument a
+    // redirect fills.
+    expect(commands.marketplaceBundle).toHaveBeenCalledWith(
+      catalog,
+      "starter",
+      null,
+    );
+  });
+
+  // The engine answers for the place the install lands in, so the page has
+  // that place's record standing and no reason to keep a button the engine
+  // would refuse on the same record.
+  it("withholds Install all and says why when that place's records went unread", async () => {
+    const host = mount(<BundleDetailPage />);
+    await settle();
+    // The control: a readable record leaves the button alone, so what
+    // follows is the record doing the withholding and not the page.
+    expect(installAll(host)?.disabled).toBe(false);
+    expect(host.textContent).not.toContain("See Problems");
+
+    answer({ ...starter, recordsUnreadable: true, members: [] });
+    useNavStore.setState({ bundleRef: { bundle: "other", catalog } });
+    await settle();
+
+    expect(installAll(host)?.disabled).toBe(true);
+    expect(host.textContent).toContain("can't read Personal's records");
+    expect(host.textContent).toContain("See Problems");
+  });
+});

--- a/ui/src/pages/bundle-detail.dom.test.tsx
+++ b/ui/src/pages/bundle-detail.dom.test.tsx
@@ -10,7 +10,7 @@ import type { AppSettings, BundleDetail, Scope } from "@/bindings";
 import { commands } from "@/bindings";
 import { unreadableRecordsLine } from "@/lib/copy-marketplaces";
 import { useMarketplacesStore } from "@/stores/marketplaces";
-import { subscription } from "@/stores/marketplaces-shared";
+import { droppedSetCaches, subscription } from "@/stores/marketplaces-shared";
 import { useNavStore } from "@/stores/nav";
 import { useSettingsStore } from "@/stores/settings";
 import { mount, settle } from "@/test/dom";
@@ -82,7 +82,18 @@ beforeEach(() => {
     status: "ok",
     data: [{ harness: "claude", detected: true, sharesTheUniversalTree: true }],
   });
-  useMarketplacesStore.setState({ bundles: {}, readErrors: {}, busy: false });
+  useMarketplacesStore.setState({
+    bundles: {},
+    readErrors: {},
+    busy: false,
+    // What the real action does to these caches, which is what asks this
+    // page again. A stub that skipped the drop would leave the count below
+    // passing because nothing re-read at all.
+    install: async () => {
+      useMarketplacesStore.setState(droppedSetCaches());
+      return true;
+    },
+  });
   useSettingsStore.setState({
     settings: { projects: [ACME.root] } as AppSettings,
   });
@@ -148,6 +159,22 @@ describe("the curated set page", () => {
     expect(host.textContent).toContain("Install 0 selected");
     expect(host.textContent).toContain(unreadableRecordsLine("acme"));
     expect(host.textContent).not.toContain(unreadableRecordsLine("Personal"));
+  });
+
+  // The install empties every set cache, and the read watches presence, so
+  // the drop is the whole trigger. A hand-rolled reload beside it asked the
+  // engine the same question twice for one install.
+  it("asks once more after an install, never twice", async () => {
+    const host = mount(<BundleDetailPage />);
+    await settle();
+    expect(commands.marketplaceBundle).toHaveBeenCalledTimes(1);
+
+    const button = installAll(host);
+    if (!button) throw new Error("no Install all rendered");
+    await userEvent.click(button);
+    await settle();
+
+    expect(commands.marketplaceBundle).toHaveBeenCalledTimes(2);
   });
 
   // Two ways the same read gets asked twice for one answer: the picker

--- a/ui/src/pages/bundle-detail.tsx
+++ b/ui/src/pages/bundle-detail.tsx
@@ -1,21 +1,21 @@
-import { useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import type { ItemKind, Scope } from "@/bindings";
+import { BundleInstallBar } from "@/components/marketplaces/bundle-install-bar";
 import {
   BundleMemberLine,
   memberKey,
 } from "@/components/marketplaces/bundle-member-row";
-import { DestinationSelect } from "@/components/marketplaces/destination-select";
-import {
-  type Choice,
-  HarnessSelect,
-  isInstallable,
-} from "@/components/marketplaces/harness-select";
+import type { Choice } from "@/components/marketplaces/harness-select";
 import { RecordsUnreadableNote } from "@/components/marketplaces/packages-trouble";
 import { RepoAction } from "@/components/marketplaces/repo-action";
-import { useCatalog } from "@/components/marketplaces/use-catalog";
+import {
+  useCachedRead,
+  useCatalog,
+} from "@/components/marketplaces/use-catalog";
 import { PageHeader } from "@/components/page-header";
 import { Button } from "@/components/ui/button";
 import { CONTENT_WIDTH, PAGE_BODY } from "@/lib/layout";
+import { sameScope } from "@/lib/scope";
 import { cn } from "@/lib/utils";
 import {
   bundleKey,
@@ -59,18 +59,26 @@ function BundleDetail({ bundleRef }: { bundleRef: BundleRef }) {
   const subscribed = catalog.by === "subscription" ? catalog : null;
   const scope = subscribed?.scope ?? null;
   const target = destination ?? scope;
-  const redirected = target && scope && target !== scope ? target : null;
+  // "The same place" has one answer, and it is not object identity: the
+  // picker hands back a freshly built Scope, so picking the place already
+  // being browsed would otherwise read as a redirect and ask again under a
+  // second cache key.
+  const redirected =
+    target && scope && !sameScope(target, scope) ? target : null;
 
   // The destination is part of the read, not a filter over it: every
   // member's state and the set's own record standing are facts about the
-  // scope the install lands in, so choosing another place asks again.
-  useEffect(() => {
-    if (ready) void loadBundle(catalog, bundle, redirected);
-  }, [catalog, ready, bundle, redirected, loadBundle]);
-
+  // scope the install lands in, so each place has a slot of its own and
+  // choosing one already read is served from it, the way every other
+  // catalog read on this page's siblings is.
   const key = bundleKey(catalog, bundle, redirected);
   const detail = bundles[key];
   const readError = reachError ?? readErrors[key];
+  const readBundle = useCallback(
+    () => loadBundle(catalog, bundle, redirected),
+    [loadBundle, catalog, bundle, redirected],
+  );
+  useCachedRead(detail !== undefined, !!readErrors[key], ready, readBundle);
 
   const toggleMember = (kind: string, name: string) => {
     setSelected((prev) => {
@@ -200,38 +208,27 @@ function BundleDetail({ bundleRef }: { bundleRef: BundleRef }) {
                   ))}
                 </div>
                 {subscribed && scope && target ? (
-                  <div className="mt-4 flex items-center justify-end gap-2">
-                    <DestinationSelect
-                      browsing={scope}
-                      value={target}
-                      onChange={(next) => {
-                        // Which tools can take this is a fact about the
-                        // destination, so a choice made against another one
-                        // is not an answer here. Nor is a ticked member:
-                        // the box was ticked against the state the place
-                        // before it answered, and the new place may already
-                        // hold that member or refuse to say.
-                        setChoice(NO_CHOICE);
-                        setSelected(new Set());
-                        setDestination(next);
-                      }}
-                    />
-                    <HarnessSelect
-                      scope={target}
-                      kinds={selectedKinds}
-                      value={choice}
-                      onChange={setChoice}
-                    />
-                    <Button
-                      variant="outline"
-                      disabled={
-                        busy || selected.size === 0 || !isInstallable(choice)
-                      }
-                      onClick={installSelected}
-                    >
-                      Install {selected.size} selected
-                    </Button>
-                  </div>
+                  <BundleInstallBar
+                    browsing={scope}
+                    target={target}
+                    kinds={selectedKinds}
+                    choice={choice}
+                    picked={selected.size}
+                    busy={busy}
+                    onPlace={(next) => {
+                      // Which tools can take this is a fact about the
+                      // destination, so a choice made against another one is
+                      // not an answer here. Nor is a ticked member: the box
+                      // was ticked against the state the place before it
+                      // answered, and the new place may already hold that
+                      // member or refuse to say.
+                      setChoice(NO_CHOICE);
+                      setSelected(new Set());
+                      setDestination(next);
+                    }}
+                    onChoice={setChoice}
+                    onInstall={installSelected}
+                  />
                 ) : null}
               </>
             )}

--- a/ui/src/pages/bundle-detail.tsx
+++ b/ui/src/pages/bundle-detail.tsx
@@ -90,9 +90,9 @@ function BundleDetail({ bundleRef }: { bundleRef: BundleRef }) {
     });
   };
 
-  // The member list re-reads after any install, so a row flips to
-  // Installed the moment it is.
-  const reload = () => loadBundle(catalog, bundle, redirected);
+  // Nothing re-reads the member list by hand: a successful install drops
+  // every set cache, which empties this slot, and the read above watches
+  // presence — so a row flips to Installed the moment it is, asked once.
   const installItems = (items: { kind: ItemKind; name: string }[]) => {
     if (!subscribed) return;
     void install({
@@ -103,10 +103,7 @@ function BundleDetail({ bundleRef }: { bundleRef: BundleRef }) {
       destination: redirected,
       delivery: choice,
     }).then((ok) => {
-      if (ok) {
-        setSelected(new Set());
-        void reload();
-      }
+      if (ok) setSelected(new Set());
     });
   };
   const installSelected = () => {

--- a/ui/src/pages/bundle-detail.tsx
+++ b/ui/src/pages/bundle-detail.tsx
@@ -69,8 +69,7 @@ function BundleDetail({ bundleRef }: { bundleRef: BundleRef }) {
   // The destination is part of the read, not a filter over it: every
   // member's state and the set's own record standing are facts about the
   // scope the install lands in, so each place has a slot of its own and
-  // choosing one already read is served from it, the way every other
-  // catalog read on this page's siblings is.
+  // choosing one already read is served from it.
   const key = bundleKey(catalog, bundle, redirected);
   const detail = bundles[key];
   const readError = reachError ?? readErrors[key];

--- a/ui/src/pages/bundle-detail.tsx
+++ b/ui/src/pages/bundle-detail.tsx
@@ -170,6 +170,29 @@ function BundleDetail({ bundleRef }: { bundleRef: BundleRef }) {
       <div className="min-h-0 flex-1 overflow-y-auto">
         <div className={cn(PAGE_BODY, "pt-0")}>
           <div className={CONTENT_WIDTH}>
+            {subscribed && scope && target ? (
+              <BundleInstallBar
+                browsing={scope}
+                target={target}
+                kinds={selectedKinds}
+                choice={choice}
+                picked={selected.size}
+                busy={busy}
+                onPlace={(next) => {
+                  // Which tools can take this is a fact about the
+                  // destination, so a choice made against another one is not
+                  // an answer here. Nor is a ticked member: the box was
+                  // ticked against the state the place before it answered,
+                  // and the new place may already hold that member or refuse
+                  // to say.
+                  setChoice(NO_CHOICE);
+                  setSelected(new Set());
+                  setDestination(next);
+                }}
+                onChoice={setChoice}
+                onInstall={installSelected}
+              />
+            ) : null}
             {!detail && readError ? (
               <p
                 className="py-16 text-center text-sm text-critical"
@@ -203,29 +226,6 @@ function BundleDetail({ bundleRef }: { bundleRef: BundleRef }) {
                     />
                   ))}
                 </div>
-                {subscribed && scope && target ? (
-                  <BundleInstallBar
-                    browsing={scope}
-                    target={target}
-                    kinds={selectedKinds}
-                    choice={choice}
-                    picked={selected.size}
-                    busy={busy}
-                    onPlace={(next) => {
-                      // Which tools can take this is a fact about the
-                      // destination, so a choice made against another one is
-                      // not an answer here. Nor is a ticked member: the box
-                      // was ticked against the state the place before it
-                      // answered, and the new place may already hold that
-                      // member or refuse to say.
-                      setChoice(NO_CHOICE);
-                      setSelected(new Set());
-                      setDestination(next);
-                    }}
-                    onChoice={setChoice}
-                    onInstall={installSelected}
-                  />
-                ) : null}
               </>
             )}
           </div>

--- a/ui/src/pages/bundle-detail.tsx
+++ b/ui/src/pages/bundle-detail.tsx
@@ -56,17 +56,21 @@ function BundleDetail({ bundleRef }: { bundleRef: BundleRef }) {
   const [destination, setDestination] = useState<Scope | null>(null);
   const [choice, setChoice] = useState<Choice>(NO_CHOICE);
 
-  useEffect(() => {
-    if (ready) void loadBundle(catalog, bundle);
-  }, [catalog, ready, bundle, loadBundle]);
-
-  const key = bundleKey(catalog, bundle);
-  const detail = bundles[key];
-  const readError = reachError ?? readErrors[key];
   const subscribed = catalog.by === "subscription" ? catalog : null;
   const scope = subscribed?.scope ?? null;
   const target = destination ?? scope;
   const redirected = target && scope && target !== scope ? target : null;
+
+  // The destination is part of the read, not a filter over it: every
+  // member's state and the set's own record standing are facts about the
+  // scope the install lands in, so choosing another place asks again.
+  useEffect(() => {
+    if (ready) void loadBundle(catalog, bundle, redirected);
+  }, [catalog, ready, bundle, redirected, loadBundle]);
+
+  const key = bundleKey(catalog, bundle, redirected);
+  const detail = bundles[key];
+  const readError = reachError ?? readErrors[key];
 
   const toggleMember = (kind: string, name: string) => {
     setSelected((prev) => {
@@ -80,7 +84,7 @@ function BundleDetail({ bundleRef }: { bundleRef: BundleRef }) {
 
   // The member list re-reads after any install, so a row flips to
   // Installed the moment it is.
-  const reload = () => loadBundle(catalog, bundle);
+  const reload = () => loadBundle(catalog, bundle, redirected);
   const installItems = (items: { kind: ItemKind; name: string }[]) => {
     if (!subscribed) return;
     void install({
@@ -104,11 +108,13 @@ function BundleDetail({ bundleRef }: { bundleRef: BundleRef }) {
     );
     if (items.length > 0) installItems(items);
   };
-  // This scope's lock could not be read, so no member's standing is known
-  // and every per-member box is already off. "Install all" asks about the
-  // set rather than a member, so it reads the scope's own answer off the
-  // payload: a member the catalog dropped says "no longer offered" with or
-  // without a lock, so no scan of the rows could tell.
+  // The lock of the place this install would land in could not be read, so
+  // no member's standing is known and every per-member box is already off.
+  // "Install all" asks about the set rather than a member, so it reads that
+  // place's own answer off the payload: a member the catalog dropped says
+  // "no longer offered" with or without a lock, so no scan of the rows
+  // could tell. Landing place, not browsed one — the engine mutates where
+  // the install goes.
   const recordsUnknown = detail?.recordsUnreadable ?? false;
   // Which tools the picker may offer follows what is actually ticked; with
   // nothing ticked the set is every kind, which is what the whole bundle
@@ -173,9 +179,9 @@ function BundleDetail({ bundleRef }: { bundleRef: BundleRef }) {
               </p>
             ) : (
               <>
-                {recordsUnknown && scope ? (
+                {recordsUnknown && target ? (
                   <div className="mb-3">
-                    <RecordsUnreadableNote scope={scope} />
+                    <RecordsUnreadableNote scope={target} />
                   </div>
                 ) : null}
                 <div className="divide-y rounded-lg border">
@@ -201,8 +207,12 @@ function BundleDetail({ bundleRef }: { bundleRef: BundleRef }) {
                       onChange={(next) => {
                         // Which tools can take this is a fact about the
                         // destination, so a choice made against another one
-                        // is not an answer here.
+                        // is not an answer here. Nor is a ticked member:
+                        // the box was ticked against the state the place
+                        // before it answered, and the new place may already
+                        // hold that member or refuse to say.
                         setChoice(NO_CHOICE);
+                        setSelected(new Set());
                         setDestination(next);
                       }}
                     />

--- a/ui/src/stores/marketplaces-catalog-reads.ts
+++ b/ui/src/stores/marketplaces-catalog-reads.ts
@@ -1,7 +1,7 @@
 // The marketplaces store's cached reads: each answer lands under its own
 // key, and each failure under its own error key, so a later success
 // elsewhere never erases why a different read produced nothing.
-import { type Catalog, commands } from "@/bindings";
+import { type Catalog, commands, type Scope } from "@/bindings";
 import { settled } from "@/lib/settled";
 import {
   bundleKey,
@@ -44,10 +44,10 @@ export function catalogReads(set: SetReads) {
         () => commands.marketplaceBundles(catalog),
       );
     },
-    loadBundle: (catalog: Catalog, name: string) => {
-      const key = bundleKey(catalog, name);
+    loadBundle: (catalog: Catalog, name: string, destination: Scope | null) => {
+      const key = bundleKey(catalog, name, destination);
       return settle(set, "bundles", key, key, () =>
-        commands.marketplaceBundle(catalog, name),
+        commands.marketplaceBundle(catalog, name, destination),
       );
     },
   };

--- a/ui/src/stores/marketplaces-shared.test.ts
+++ b/ui/src/stores/marketplaces-shared.test.ts
@@ -51,22 +51,4 @@ describe("catalog addressing", () => {
       readErrorKey(catalogKey(catalog), "packages"),
     );
   });
-
-  it("keys one set's read by the place the install would land in", () => {
-    // The same set read for two destinations is two answers — each
-    // member's state and the set's record standing are that place's — so
-    // one must never be served from the other's slot.
-    const catalog = subscription({ scope: "global" }, "kendex");
-    const acme = { scope: "project" as const, root: "/work/acme" };
-    const other = { scope: "project" as const, root: "/work/other" };
-    expect(bundleKey(catalog, "starter", acme)).not.toBe(
-      bundleKey(catalog, "starter", other),
-    );
-    expect(bundleKey(catalog, "starter", acme)).not.toBe(
-      bundleKey(catalog, "starter", null),
-    );
-    expect(bundleKey(catalog, "starter", acme)).toBe(
-      bundleKey(catalog, "starter", { scope: "project", root: "/work/acme" }),
-    );
-  });
 });

--- a/ui/src/stores/marketplaces-shared.test.ts
+++ b/ui/src/stores/marketplaces-shared.test.ts
@@ -47,8 +47,26 @@ describe("catalog addressing", () => {
 
   it("keeps a set named like a read off that read's key", () => {
     const catalog = subscription({ scope: "global" }, "kendex");
-    expect(bundleKey(catalog, "packages")).not.toBe(
+    expect(bundleKey(catalog, "packages", null)).not.toBe(
       readErrorKey(catalogKey(catalog), "packages"),
+    );
+  });
+
+  it("keys one set's read by the place the install would land in", () => {
+    // The same set read for two destinations is two answers — each
+    // member's state and the set's record standing are that place's — so
+    // one must never be served from the other's slot.
+    const catalog = subscription({ scope: "global" }, "kendex");
+    const acme = { scope: "project" as const, root: "/work/acme" };
+    const other = { scope: "project" as const, root: "/work/other" };
+    expect(bundleKey(catalog, "starter", acme)).not.toBe(
+      bundleKey(catalog, "starter", other),
+    );
+    expect(bundleKey(catalog, "starter", acme)).not.toBe(
+      bundleKey(catalog, "starter", null),
+    );
+    expect(bundleKey(catalog, "starter", acme)).toBe(
+      bundleKey(catalog, "starter", { scope: "project", root: "/work/acme" }),
     );
   });
 });

--- a/ui/src/stores/marketplaces-shared.ts
+++ b/ui/src/stores/marketplaces-shared.ts
@@ -11,6 +11,7 @@ import type {
   Scope,
 } from "@/bindings";
 import { invalidations, type ReadState } from "@/lib/read-state";
+import { scopeKey } from "@/lib/scope";
 import { resetPreinstallSafety } from "./preinstall-safety";
 
 /** Every cached catalog read the store holds, declared once here so the
@@ -101,12 +102,7 @@ export const bundleKey = (
 ): string =>
   `${readErrorKey(catalogKey(catalog), "bundle")}::${JSON.stringify([
     name,
-    destination === null
-      ? null
-      : [
-          destination.scope,
-          destination.scope === "global" ? null : destination.root,
-        ],
+    destination === null ? null : scopeKey(destination),
   ])}`;
 
 export const subscription = (scope: Scope, source: string): Catalog => ({

--- a/ui/src/stores/marketplaces-shared.ts
+++ b/ui/src/stores/marketplaces-shared.ts
@@ -88,9 +88,26 @@ export const rowSubscribed = (
   live ? row.repoKey !== null && live.has(row.repoKey) : row.subscribed;
 
 /** One curated set's cache and error key, in its own namespace so a set
- * named like a read ("packages") can never land on that read's key. */
-export const bundleKey = (catalog: Catalog, name: string): string =>
-  `${readErrorKey(catalogKey(catalog), "bundle")}::${name}`;
+ * named like a read ("packages") can never land on that read's key.
+ *
+ * The destination is part of the key because it is part of the answer: a
+ * set read for an install redirected into a project carries that project's
+ * member states and its record standing, so the same set read for another
+ * place is a different read and never the cached one. */
+export const bundleKey = (
+  catalog: Catalog,
+  name: string,
+  destination: Scope | null,
+): string =>
+  `${readErrorKey(catalogKey(catalog), "bundle")}::${JSON.stringify([
+    name,
+    destination === null
+      ? null
+      : [
+          destination.scope,
+          destination.scope === "global" ? null : destination.root,
+        ],
+  ])}`;
 
 export const subscription = (scope: Scope, source: string): Catalog => ({
   by: "subscription",

--- a/ui/src/stores/marketplaces.ts
+++ b/ui/src/stores/marketplaces.ts
@@ -70,7 +70,11 @@ interface MarketplacesState extends InstallActions, CatalogCaches {
   loadPackages: (catalog: Catalog) => Promise<void>;
   loadSummary: (catalog: Catalog) => Promise<void>;
   loadAbout: (catalog: Catalog) => Promise<void>;
-  loadBundle: (catalog: Catalog, name: string) => Promise<void>;
+  loadBundle: (
+    catalog: Catalog,
+    name: string,
+    destination: Scope | null,
+  ) => Promise<void>;
   loadCatalogBundles: (catalog: Catalog) => Promise<void>;
   /** What subscribing answered, handed straight to the caller: the alias
    * the subscription was declared under, or the engine's refusal. The

--- a/ui/src/stores/settings-projects.dom.test.tsx
+++ b/ui/src/stores/settings-projects.dom.test.tsx
@@ -20,6 +20,7 @@ vi.mock("@/bindings", () => ({
     getManifest: vi.fn(),
     getScopeSettings: vi.fn(),
     editorInventory: vi.fn(),
+    scopeRecordsUnreadable: vi.fn(),
   },
 }));
 vi.mock("sonner", () => ({
@@ -41,6 +42,12 @@ beforeEach(() => {
   vi.mocked(commands.editorInventory).mockResolvedValue({
     status: "ok",
     data: { skills: [], hooks: [] },
+  } as never);
+  // The dialog asks whether the chosen place's records can be read before
+  // it offers to write there.
+  vi.mocked(commands.scopeRecordsUnreadable).mockResolvedValue({
+    status: "ok",
+    data: false,
   } as never);
   useSettingsStore.setState({ settings: null });
   useMarketplacesStore.setState({ busy: false, error: null });


### PR DESCRIPTION
## Summary

- Everything an install page says about records now answers for the place the install would land in, not the catalog you happen to be browsing. One resolver, `browse::opened::landing`, and every read that takes a destination goes through it: what is already installed, whether the records can be read, whether the name is taken, and what the destination adds to what installs.
- The package Install, the set's Install all and its member ticks, and the bare-repository Subscribe are all held on the landing place's records, and each says why next to the choice that caused it. The reverse is fixed too. A broken record in the scope you are browsing no longer blocks an install into a project that is perfectly readable.
- The engine did not change. `add_seeded` already refused on the scope it was handed. This is the surface catching up, so the reason arrives before the click instead of as a raw error after it.

## Completed Issues

- Closes KEN-1140 - A redirected install is judged against the browsed scope's record, not the destination's

## Created Issues

- KEN-1197 - Empty kinds reach install_targets as one blank kind - Project: Tech Debt & Bugs
- KEN-1198 - A redirected install silently rebinds a taken project alias - Project: Tech Debt & Bugs

## Test plan

The suites were cut before this PR opened for review. They had grown round over round against the review findings rather than against the Done-when, reaching 895 added test lines and 1.91x the first commit. They now stand at 727 added test lines and 1.68x, measured with `git diff --numstat origin/main...HEAD`.

The rule applied is one control per Done-when surface, each asserting both directions, with the must-fail being the mutation rather than a second test. Core went from 7 tests to 4, the set page from 5 cases to 1, the package page from 3 to 1, the Subscribe dialog from 5 to 2. The package Install and the set's Install all keep one control each because they reach the records gate through different engine entry points and no single test can redden for both. Every surviving control had its must-fail re-run one revert at a time, 13 in all.

One control was dropped with nothing replacing it: the set page's post-install read count, which measured a review fix rather than a Done-when surface. Nothing now catches a hand-rolled reload reappearing beside the cache drop.

| Command | Result |
|---|---|
| `cargo test --workspace` | green |
| `npm run --prefix ui test -- --run` | 1161 passed, 146 files |
| `tools/guard`, `preflight` | clean over 29 changed files |

Nine reviewer domains over five cycles: 21 findings fixed, 0 escalated. Cross-model review was unavailable this session because the codex lane is out of credits, so it is recorded as failed rather than as a pass.

Two things worth knowing before reading the diff:

`ui/src/components/marketplaces/bundle-install-bar.tsx` is a new file only because `ui/src/pages/bundle-detail.tsx` hit the 250-line limit for `ui/*.tsx`. The split was forced, not chosen, and the row that moved out draws the picker and the button without deciding anything. `available-package.tsx` now sits at 249 of 250, so the next change to it needs a split rather than another trim.

`marketplace_package_preview` hands the destination to `package_safety` through one argument no test reaches, because the command resolves its own `Env` and cannot take a fixture. Covering it means pulling a plain function out of the command, which is a refactor rather than a test. Declined here and written down rather than filed.

https://claude.ai/code/session_011i63a2T2mMXY8EpnfQSgh8
