### PR TITLE
fix(KEN-1162): the provenance join keeps one read at a time

### DIFF
--- a/changelog.d/fixed/KEN-1162.md
+++ b/changelog.d/fixed/KEN-1162.md
@@ -1,0 +1,1 @@
+- The Library's From column and a marketplace's Installed in column keep the newest read of where each copy came from, so an older read answering late no longer puts a pre-install answer back.

--- a/ui/src/components/customize/stale-note.dom.test.tsx
+++ b/ui/src/components/customize/stale-note.dom.test.tsx
@@ -11,6 +11,7 @@ import { mount } from "@/test/dom";
 vi.mock("@/bindings", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/bindings")>()),
   commands: {
+    libraryProvenance: vi.fn().mockResolvedValue({ status: "ok", data: [] }),
     getManifest: vi.fn(),
     editorInventory: vi.fn(),
     getScopeSettings: vi.fn(),

--- a/ui/src/components/harnesses/project-list.dom.test.tsx
+++ b/ui/src/components/harnesses/project-list.dom.test.tsx
@@ -15,6 +15,7 @@ import { ProjectList } from "./project-list";
 vi.mock("@/bindings", () => ({
   commands: {
     auditAll: vi.fn(),
+    libraryProvenance: vi.fn().mockResolvedValue({ status: "ok", data: [] }),
     scanMachine: vi.fn(),
     registerProject: vi.fn(),
     unregisterProject: vi.fn(),

--- a/ui/src/components/package/delete-dialog.dom.test.tsx
+++ b/ui/src/components/package/delete-dialog.dom.test.tsx
@@ -8,6 +8,7 @@ import {
   REINSTALL_OWN,
   reinstallFrom,
 } from "@/lib/copy-projects";
+import { READ_PENDING } from "@/lib/read-state";
 import { useAuditStore } from "@/stores/audit";
 import { useProvenanceStore } from "@/stores/provenance";
 import { mount, settle } from "@/test/dom";
@@ -28,7 +29,12 @@ beforeEach(() => {
     error: "not in this test",
   });
   useAuditStore.setState({ busy: false, removeItem: vi.fn() });
-  useProvenanceStore.setState({ rows: [], loaded: true });
+  useProvenanceStore.setState({
+    rows: [],
+    loaded: true,
+    read: READ_PENDING,
+    reading: false,
+  });
 });
 
 /** The dialog's Delete button, read out of the portal. */
@@ -73,6 +79,17 @@ const from = (...origins: [Scope, Origin][]) => {
     data: rows,
   });
 };
+
+/** A join read this test answers by hand, to hold one open. */
+const park = () => {
+  let land: (value: JoinAnswer) => void = () => {};
+  const promise = new Promise<JoinAnswer>((resolve) => {
+    land = resolve;
+  });
+  return { promise, land };
+};
+
+type JoinAnswer = Awaited<ReturnType<typeof commands.libraryProvenance>>;
 
 const MARKET = (source: string): Origin => ({
   origin: "marketplace",
@@ -187,6 +204,34 @@ describe("the read behind the note", () => {
     const said = await openDialog([VG]);
     expect(said).not.toContain(reinstallFrom(["acme"]));
     expect(said).not.toContain(REINSTALL_OWN);
+  });
+
+  // The dialog's own read is routinely overtaken: the sidebar's Scan again
+  // and every write's rescan read the same join, and an open landing under
+  // one gets the newer read's answer. The note has to arrive with that
+  // read — a dialog latching its own call's verdict would go the whole open
+  // with nothing under the confirm step.
+  it("names the marketplace the read that overtook this open's landed", async () => {
+    useProvenanceStore.setState({ rows: rowsFor([[VG, OWN]]), loaded: true });
+    const mine = park();
+    const rescan = park();
+    vi.mocked(commands.libraryProvenance)
+      .mockReturnValueOnce(mine.promise)
+      .mockReturnValueOnce(rescan.promise);
+
+    const said = await openDialog([VG]);
+    expect(said).not.toContain(reinstallFrom(["acme"]));
+
+    // A rescan behind a write begins its own read while this open's is
+    // still out, then this open's answers first and is overtaken.
+    void useProvenanceStore.getState().reload();
+    mine.land({ status: "ok", data: rowsFor([[VG, OWN]]) });
+    await settle();
+    expect(document.body.textContent).not.toContain(REINSTALL_OWN);
+
+    rescan.land({ status: "ok", data: rowsFor([[VG, MARKET("acme")]]) });
+    await settle();
+    expect(document.body.textContent).toContain(reinstallFrom(["acme"]));
   });
 
   it("names nothing off rows a rejected read left standing", async () => {

--- a/ui/src/components/package/delete-dialog.tsx
+++ b/ui/src/components/package/delete-dialog.tsx
@@ -13,22 +13,29 @@ import { scopePath } from "@/lib/labels";
 import { scopeKey } from "@/lib/scope";
 import { placeName } from "@/lib/update-groups";
 import { useAuditStore } from "@/stores/audit";
-import { originsFor, useProvenanceStore } from "@/stores/provenance";
+import {
+  joinCurrent,
+  originsFor,
+  useProvenanceStore,
+} from "@/stores/provenance";
 
 /** Every marketplace a deleted package can be had from again.
  *
  *  The read is taken on every open rather than once. `loaded` says only
  *  that some snapshot landed, never that it covers this installation: a
  *  rescan refreshes the join behind every write, but a refresh that failed
- *  leaves the previous rows standing and says so only in its return, which
- *  nothing on a standing read looks at.
+ *  leaves the previous rows standing.
  *
- *  Until this open's own read lands there is no note. The rows standing
- *  from an earlier one may answer for a different installation, and a
- *  marketplace named wrongly at the confirm step of a deletion is worse
- *  than none. Delete is not held for it either way: the note is where to
- *  get the package again, not what the deletion does, and the engine
- *  answers for the removal. */
+ *  There is no note until this open has asked AND the store says the rows
+ *  are the newest read's answer with nothing newer on its way. So a read
+ *  that failed names nothing, and neither does one still coming — and where
+ *  this open's read was overtaken, the note arrives with the read that
+ *  overtook it, because that second condition is store state rather than
+ *  this call's own answer. The rows standing from an earlier open may
+ *  answer for a different installation, and a marketplace named wrongly at
+ *  the confirm step of a deletion is worse than none. Delete is not held
+ *  for it either way: the note is where to get the package again, not what
+ *  the deletion does, and the engine answers for the removal. */
 function useReinstallNote(
   kind: ItemKind,
   name: string,
@@ -36,23 +43,24 @@ function useReinstallNote(
   open: boolean,
 ): string | null {
   const rows = useProvenanceStore((s) => s.rows);
+  const current = useProvenanceStore(joinCurrent);
   const reload = useProvenanceStore((s) => s.reload);
-  const [landed, setLanded] = useState(false);
+  const [asked, setAsked] = useState(false);
   // Cleared on the way out as well as the way in: the dialog is mounted
   // whether or not it is open, so a flag left standing from the last open
   // is a note built from that open's rows on the next one's first render.
   useEffect(() => {
-    setLanded(false);
+    setAsked(false);
     if (!open) return;
     let cancelled = false;
-    void reload().then((read) => {
-      if (!cancelled) setLanded(read);
+    void reload().then(() => {
+      if (!cancelled) setAsked(true);
     });
     return () => {
       cancelled = true;
     };
   }, [open, reload]);
-  if (!landed) return null;
+  if (!asked || !current) return null;
   const origins = originsFor(rows, kind, name, scopes);
   // Every marketplace among them, sorted so the note reads the same on
   // every open: this deletion reaches each place, and each place records

--- a/ui/src/components/package/delete-dialog.tsx
+++ b/ui/src/components/package/delete-dialog.tsx
@@ -21,21 +21,18 @@ import {
 
 /** Every marketplace a deleted package can be had from again.
  *
- *  The read is taken on every open rather than once. `loaded` says only
- *  that some snapshot landed, never that it covers this installation: a
- *  rescan refreshes the join behind every write, but a refresh that failed
- *  leaves the previous rows standing.
+ *  The read is taken on every open rather than once: `loaded` says a
+ *  snapshot landed, never that it covers this installation, and the rows
+ *  standing from an earlier open may answer for a different one. A
+ *  marketplace named wrongly at the confirm step of a deletion is worse
+ *  than none.
  *
- *  There is no note until this open has asked AND the store says the rows
- *  are the newest read's answer with nothing newer on its way. So a read
- *  that failed names nothing, and neither does one still coming — and where
- *  this open's read was overtaken, the note arrives with the read that
- *  overtook it, because that second condition is store state rather than
- *  this call's own answer. The rows standing from an earlier open may
- *  answer for a different installation, and a marketplace named wrongly at
- *  the confirm step of a deletion is worse than none. Delete is not held
- *  for it either way: the note is where to get the package again, not what
- *  the deletion does, and the engine answers for the removal. */
+ *  So there is no note until this open has asked AND the store says the
+ *  rows are current — a read that failed names nothing, and neither does
+ *  one still coming. That second half is store state, not this call's
+ *  answer, so the note arrives with whichever read lands. Delete is not
+ *  held for it either way: the note is where to get the package again, not
+ *  what the deletion does, and the engine answers for the removal. */
 function useReinstallNote(
   kind: ItemKind,
   name: string,

--- a/ui/src/components/package/package-projects.dom.test.tsx
+++ b/ui/src/components/package/package-projects.dom.test.tsx
@@ -219,6 +219,25 @@ const openTab = async (scopes: Scope[]) => {
 const buttons = (host: HTMLElement) =>
   Array.from(host.querySelectorAll("button"));
 
+/** Every control that removes something: each card's own Remove and the
+ *  header's Remove all, which answer to one judge. */
+const removals = (host: HTMLElement) =>
+  buttons(host).filter(
+    (one) =>
+      one.textContent === REMOVE_LABEL || one.textContent === REMOVE_ALL_LABEL,
+  );
+
+/** A read of the join this test answers by hand, to hold one open. */
+const park = () => {
+  let land: (value: JoinAnswer) => void = () => {};
+  const promise = new Promise<JoinAnswer>((resolve) => {
+    land = resolve;
+  });
+  return { promise, land };
+};
+
+type JoinAnswer = Awaited<ReturnType<typeof commands.libraryProvenance>>;
+
 const click = async (host: HTMLElement, label: string, nth = 0) => {
   const found = buttons(host).filter((one) => one.textContent === label)[nth];
   if (!found) throw new Error(`no "${label}" button at index ${nth}`);
@@ -409,10 +428,10 @@ describe("removing a package from one place", () => {
 
   // The store keeps its older rows when the ownership read fails, and
   // those say nothing about who owns these copies now. Remove is the
-  // destructive control, so one drawn from them is the fail-open case: the
-  // tab holds it closed. A rejection and an error answer are one thing
-  // here — neither joined — so one case covers both.
-  it("offers nothing to remove when the ownership read did not answer", async () => {
+  // destructive control, so one pressed off them is the fail-open case:
+  // the tab holds it shut. A rejection and an error answer are one thing
+  // here — neither read the join — so one case covers both.
+  it("holds every removal shut when the ownership read did not answer", async () => {
     useProvenanceStore.setState({
       rows: ownedBy([VG, OURS], [HYPR, OURS]),
       loaded: true,
@@ -426,10 +445,34 @@ describe("removing a package from one place", () => {
     // The cards still draw: the package is installed there either way.
     expect(host.textContent).toContain("vg");
     expect(host.textContent).toContain("hyprtrade");
-    expect(
-      buttons(host).filter((one) => one.textContent === REMOVE_LABEL),
-    ).toEqual([]);
-    expect(host.textContent).not.toContain(REMOVE_ALL_LABEL);
+    expect(removals(host).length).toBe(3);
+    expect(removals(host).every((one) => one.disabled)).toBe(true);
+  });
+
+  // The join is read behind every write and by the sidebar's Scan again,
+  // both of which reach an open tab. A control that left the row while one
+  // was out would move the buttons under a reader's cursor, and a click
+  // aimed at Remove would land on nothing. So the read decides whether
+  // Remove may be PRESSED, never whether it is there.
+  it("keeps the removal controls in place across a read it did not ask for", async () => {
+    const host = await openTab([VG, HYPR]);
+    expect(removals(host).length).toBe(3);
+    expect(removals(host).some((one) => one.disabled)).toBe(false);
+
+    const parked = park();
+    vi.mocked(commands.libraryProvenance).mockReturnValueOnce(parked.promise);
+    await act(async () => {
+      void useProvenanceStore.getState().reload();
+    });
+
+    expect(removals(host).length).toBe(3);
+    expect(removals(host).every((one) => one.disabled)).toBe(true);
+
+    parked.land({ status: "ok", data: ownedBy([VG, OURS], [HYPR, OURS]) });
+    await settle();
+
+    expect(removals(host).length).toBe(3);
+    expect(removals(host).some((one) => one.disabled)).toBe(false);
   });
 });
 

--- a/ui/src/components/package/package-projects.dom.test.tsx
+++ b/ui/src/components/package/package-projects.dom.test.tsx
@@ -30,7 +30,7 @@ import {
   UPDATE_ALL_LABEL,
   updateInLabel,
 } from "@/lib/copy-projects";
-import { READ_LANDED } from "@/lib/read-state";
+import { READ_LANDED, READ_PENDING } from "@/lib/read-state";
 import { scopeKey } from "@/lib/scope";
 import { useAuditStore } from "@/stores/audit";
 import { useProvenanceStore } from "@/stores/provenance";
@@ -181,7 +181,12 @@ beforeEach(() => {
     updateOne,
     updateRows,
   });
-  useProvenanceStore.setState({ rows: [], loaded: false });
+  useProvenanceStore.setState({
+    rows: [],
+    loaded: false,
+    read: READ_PENDING,
+    reading: false,
+  });
   joinSays(ownedBy([VG, OURS], [HYPR, OURS]));
   scanFound(install(VG), install(HYPR));
   vi.mocked(commands.packageMeta).mockImplementation((scope) =>

--- a/ui/src/components/package/package-projects.tsx
+++ b/ui/src/components/package/package-projects.tsx
@@ -50,7 +50,7 @@ export function PackageProjects({
   busy: boolean;
   onDelete: () => void;
 }) {
-  const { places, loading } = usePackagePlaces(kind, name, scopes);
+  const { places, loading, removalHeld } = usePackagePlaces(kind, name, scopes);
   const updateOne = useUpdatesStore((s) => s.updateOne);
   const updateRows = useUpdatesStore((s) => s.updateRows);
   const removeItem = useAuditStore((s) => s.removeItem);
@@ -82,7 +82,7 @@ export function PackageProjects({
                 variant="link"
                 size="sm"
                 className="px-0"
-                disabled={busy}
+                disabled={busy || removalHeld}
                 onClick={onDelete}
               >
                 {REMOVE_ALL_LABEL}
@@ -103,6 +103,7 @@ export function PackageProjects({
               key={scopeKey(place.scope)}
               place={place}
               busy={busy}
+              removalHeld={removalHeld}
               onUpdate={() => place.row && void updateOne(place.row)}
               onRemove={() => void removeItem(place.scope, kind, name)}
             />

--- a/ui/src/components/package/project-card.test.tsx
+++ b/ui/src/components/package/project-card.test.tsx
@@ -22,6 +22,7 @@ describe("a place whose install date cannot be read", () => {
       <ProjectCard
         place={place}
         busy={false}
+        removalHeld={false}
         onUpdate={() => {}}
         onRemove={() => {}}
       />,

--- a/ui/src/components/package/project-card.tsx
+++ b/ui/src/components/package/project-card.tsx
@@ -19,11 +19,16 @@ import { useNowTick } from "@/lib/use-now-tick";
 export function ProjectCard({
   place,
   busy,
+  removalHeld,
   onUpdate,
   onRemove,
 }: {
   place: PackagePlace;
   busy: boolean;
+  /** The ownership answer under Remove is not current. The button stays
+   *  where it is and goes dead, rather than leaving the row as the read
+   *  behind a write comes and goes under a reader's cursor. */
+  removalHeld: boolean;
   onUpdate: () => void;
   onRemove: () => void;
 }) {
@@ -75,7 +80,7 @@ export function ProjectCard({
           <Button
             size="sm"
             variant="outline"
-            disabled={busy}
+            disabled={busy || removalHeld}
             aria-label={removeFromLabel(place.name)}
             onClick={onRemove}
           >

--- a/ui/src/components/package/use-package-data.test.ts
+++ b/ui/src/components/package/use-package-data.test.ts
@@ -26,6 +26,7 @@ describe("diffHarness", () => {
 
 vi.mock("@/bindings", () => ({
   commands: {
+    libraryProvenance: vi.fn().mockResolvedValue({ status: "ok", data: [] }),
     packageUpdate: vi.fn(),
     packageSetRev: vi.fn(),
   },

--- a/ui/src/components/package/use-package-places.ts
+++ b/ui/src/components/package/use-package-places.ts
@@ -31,7 +31,7 @@ export function usePackagePlaces(
   kind: ItemKind,
   name: string,
   scopes: Scope[],
-): { places: PackagePlace[]; loading: boolean } {
+): { places: PackagePlace[]; loading: boolean; removalHeld: boolean } {
   const rows = useUpdatesStore((s) => s.rows);
   // Read field by field rather than through one selector: `rowUnsettled`
   // takes the state, and a selector returning a fresh object or closure
@@ -45,12 +45,11 @@ export function usePackagePlaces(
   // refresh that failed leaves the previous rows standing, and a stale
   // snapshot would hide Remove on a package that was just installed.
   const provenance = useProvenanceStore((s) => s.rows);
-  // Whether those rows are the newest read's answer, read off the store
-  // rather than from this hook's own read: a read of the join this tab
-  // started can be overtaken by a rescan behind a write, and the answer
-  // then belongs to the read that overtook it. Held as store state, the
-  // cards re-render when it lands; latched from this call's own read, they
-  // would sit with Remove hidden until the package or its copies changed.
+  // Whether those rows are a landed read's answer, read off the store
+  // rather than from this hook's own read: the tab's read joins whatever
+  // rescan is already out, so the answer arrives as store state, and the
+  // cards re-render on it. Latched from this call's own read, they would
+  // hold the first verdict until the package or its copies changed.
   const joined = useProvenanceStore(joinCurrent);
   const reloadProvenance = useProvenanceStore((s) => s.reload);
   // What is actually installed in each place, harness by harness. The join
@@ -108,6 +107,11 @@ export function usePackagePlaces(
   }, [subject, commits, reloadProvenance]);
 
   return {
+    // Held while the ownership answer is being re-read or failed to read:
+    // the rows on hand may predate an install or a take-over, and Remove
+    // is the destructive control. Disabling it says the same thing as
+    // taking it away without moving the buttons under a reader's cursor.
+    removalHeld: !joined,
     places: packagePlaces(
       scopes,
       kind,
@@ -115,12 +119,11 @@ export function usePackagePlaces(
       rows,
       metas ?? {},
       { read: updatesRead, checking, reading, pendingFollows },
-      // A read that failed leaves the store's older rows in place, and a
-      // newer read still coming is about to replace them; neither says who
-      // owns these copies now. Passing none holds the removal controls
-      // closed rather than deriving a destructive button from a snapshot
-      // that may have gone stale.
-      joined ? provenance : [],
+      // The rows as they stand decide which cards carry a Remove at all:
+      // a read merely running does not withhold a control that exists,
+      // which is the rule `lib/updates-read-state.ts` states for its own
+      // surfaces. Whether that control may be PRESSED is `removalHeld`.
+      provenance,
       installed ?? [],
     ),
     loading: metas === null,

--- a/ui/src/components/package/use-package-places.ts
+++ b/ui/src/components/package/use-package-places.ts
@@ -11,21 +11,11 @@ import {
   packagePlaces,
 } from "@/lib/package-places";
 import { scopeKey } from "@/lib/scope";
-import { useProvenanceStore } from "@/stores/provenance";
+import { joinCurrent, useProvenanceStore } from "@/stores/provenance";
 import { useScanStore } from "@/stores/scan";
 import { useUpdatesStore } from "@/stores/updates";
 
 type Metas = Record<string, PackageMeta_Serialize | null>;
-
-/** What one pass over a package's places came back with: each place's own
- *  record, and whether the ownership join landed. Held together so a card
- *  never draws on one without the other. */
-interface Read {
-  metas: Metas;
-  /** The provenance read answered. False keeps every removal closed: the
-   *  rows on hand may predate an install or a take-over. */
-  joined: boolean;
-}
 
 /** Every place this package sits in, with its install date and its update
  *  standing.
@@ -55,12 +45,19 @@ export function usePackagePlaces(
   // refresh that failed leaves the previous rows standing, and a stale
   // snapshot would hide Remove on a package that was just installed.
   const provenance = useProvenanceStore((s) => s.rows);
+  // Whether those rows are the newest read's answer, read off the store
+  // rather than from this hook's own read: a read of the join this tab
+  // started can be overtaken by a rescan behind a write, and the answer
+  // then belongs to the read that overtook it. Held as store state, the
+  // cards re-render when it lands; latched from this call's own read, they
+  // would sit with Remove hidden until the package or its copies changed.
+  const joined = useProvenanceStore(joinCurrent);
   const reloadProvenance = useProvenanceStore((s) => s.reload);
   // What is actually installed in each place, harness by harness. The join
   // answers per harness too, so this is what says whether every one of a
   // place's copies is accounted for.
   const installed = useScanStore((s) => s.result?.items);
-  const [read, setRead] = useState<Read | null>(null);
+  const [metas, setMetas] = useState<Metas | null>(null);
   // The scan rebuilds the group on every read, so what is watched is which
   // places those are, not the array they arrived in.
   const subject = `${kind}|${name}|${scopes.map(scopeKey).join("|")}`;
@@ -77,7 +74,7 @@ export function usePackagePlaces(
     // already on screen rather than flashing the loading state over them.
     if (shown.current !== subject) {
       shown.current = subject;
-      setRead(null);
+      setMetas(null);
     }
     void Promise.all([
       // Both reads settle before any card draws: a card is its date and
@@ -102,8 +99,8 @@ export function usePackagePlaces(
           }
         }),
       ),
-    ]).then(([joined, pairs]) => {
-      if (!cancelled) setRead({ metas: Object.fromEntries(pairs), joined });
+    ]).then(([, pairs]) => {
+      if (!cancelled) setMetas(Object.fromEntries(pairs));
     });
     return () => {
       cancelled = true;
@@ -116,15 +113,16 @@ export function usePackagePlaces(
       kind,
       name,
       rows,
-      read?.metas ?? {},
+      metas ?? {},
       { read: updatesRead, checking, reading, pendingFollows },
-      // A read that failed leaves the store's older rows in place, and
-      // those say nothing about who owns these copies now. Passing none
-      // holds the removal controls closed rather than deriving a
-      // destructive button from a snapshot that may have gone stale.
-      read?.joined ? provenance : [],
+      // A read that failed leaves the store's older rows in place, and a
+      // newer read still coming is about to replace them; neither says who
+      // owns these copies now. Passing none holds the removal controls
+      // closed rather than deriving a destructive button from a snapshot
+      // that may have gone stale.
+      joined ? provenance : [],
       installed ?? [],
     ),
-    loading: read === null,
+    loading: metas === null,
   };
 }

--- a/ui/src/components/update-follow.dom.test.tsx
+++ b/ui/src/components/update-follow.dom.test.tsx
@@ -44,6 +44,7 @@ vi.mock("@/bindings", async (importOriginal) => ({
     applyPlan: vi.fn(),
     scanMachine: vi.fn(),
     auditAll: vi.fn(),
+    libraryProvenance: vi.fn().mockResolvedValue({ status: "ok", data: [] }),
   },
 }));
 

--- a/ui/src/components/updates-table.dom.test.tsx
+++ b/ui/src/components/updates-table.dom.test.tsx
@@ -35,6 +35,7 @@ vi.mock("@/bindings", async (importOriginal) => ({
   // kind list through them, and a copy kept here could go stale unseen.
   ...(await importOriginal<typeof import("@/bindings")>()),
   commands: {
+    libraryProvenance: vi.fn().mockResolvedValue({ status: "ok", data: [] }),
     updatesOverview: vi.fn(),
     packageForkBeside: vi.fn(),
     scanMachine: vi.fn(),

--- a/ui/src/lib/rescan.ts
+++ b/ui/src/lib/rescan.ts
@@ -72,9 +72,10 @@ export async function rescanEverything(opts?: {
     // Forced: a write moved the very bytes a score answers for, and the
     // audit's freshness window would otherwise answer from before it.
     useAuditStore.getState().refresh({ force: true }),
-    // Answers a boolean rather than throwing, and nothing here acts on it:
-    // a join that could not be read is the previous rows staying put, which
-    // is what every reader already handles.
+    // Answers nothing rather than throwing, and there is nothing here to
+    // act on: a join that could not be read is the previous rows staying
+    // put, which its store publishes as its read state for every reader
+    // that gates on the answer.
     useProvenanceStore.getState().reload(),
   ]);
 }
@@ -84,8 +85,10 @@ export async function rescanEverything(opts?: {
 // only once the running one has finished — so every write is answered by a
 // read that began after it, and a page of writes does not pay a whole-machine
 // read each. The scan and audit stores hold a queue of this shape for their
-// own leg, and the provenance join ranks its reads by when they began, so
-// none of the three answers a write with a read that predates it.
+// own leg, and the provenance join ranks its reads by when they began, so a
+// write is never answered by a read that began before it. A read that fails
+// answers for nothing at all: it leaves the rows it had standing, and each
+// store says so in the read state its surfaces gate on.
 let running: Promise<void> | null = null;
 let queued: Promise<void> | null = null;
 

--- a/ui/src/lib/rescan.ts
+++ b/ui/src/lib/rescan.ts
@@ -72,9 +72,9 @@ export async function rescanEverything(opts?: {
     // Forced: a write moved the very bytes a score answers for, and the
     // audit's freshness window would otherwise answer from before it.
     useAuditStore.getState().refresh({ force: true }),
-    // Answers false rather than throwing, and nothing here acts on the
-    // answer: a join that could not be read is the previous rows staying
-    // put, which is what every reader already handles.
+    // Answers a boolean rather than throwing, and nothing here acts on it:
+    // a join that could not be read is the previous rows staying put, which
+    // is what every reader already handles.
     useProvenanceStore.getState().reload(),
   ]);
 }
@@ -84,8 +84,8 @@ export async function rescanEverything(opts?: {
 // only once the running one has finished — so every write is answered by a
 // read that began after it, and a page of writes does not pay a whole-machine
 // read each. The scan and audit stores hold a queue of this shape for their
-// own leg; the provenance join has none, so an older join can still land
-// over a newer one — KEN-1183.
+// own leg, and the provenance join ranks its reads by when they began, so
+// none of the three answers a write with a read that predates it.
 let running: Promise<void> | null = null;
 let queued: Promise<void> | null = null;
 

--- a/ui/src/lib/rescan.ts
+++ b/ui/src/lib/rescan.ts
@@ -72,10 +72,9 @@ export async function rescanEverything(opts?: {
     // Forced: a write moved the very bytes a score answers for, and the
     // audit's freshness window would otherwise answer from before it.
     useAuditStore.getState().refresh({ force: true }),
-    // Answers nothing rather than throwing, and there is nothing here to
-    // act on: a join that could not be read is the previous rows staying
-    // put, which its store publishes as its read state for every reader
-    // that gates on the answer.
+    // Answers nothing to act on: a join that could not be read is the
+    // previous rows staying put, which its store publishes as its read
+    // state for every reader that gates on the answer.
     useProvenanceStore.getState().reload(),
   ]);
 }
@@ -84,11 +83,11 @@ export async function rescanEverything(opts?: {
 // request arriving under a running read joins that follow-up, which starts
 // only once the running one has finished — so every write is answered by a
 // read that began after it, and a page of writes does not pay a whole-machine
-// read each. The scan and audit stores hold a queue of this shape for their
-// own leg, and the provenance join ranks its reads by when they began, so a
-// write is never answered by a read that began before it. A read that fails
-// answers for nothing at all: it leaves the rows it had standing, and each
-// store says so in the read state its surfaces gate on.
+// read each. Each of the three legs keeps a queue of this shape for itself,
+// so a write is never answered by a read that began before it. A read that
+// fails answers for nothing at all: it leaves the rows it had standing, and
+// the join and the audit say so in the read state their surfaces gate on,
+// while the scan says it in a toast and an `error` nothing gates on.
 let running: Promise<void> | null = null;
 let queued: Promise<void> | null = null;
 

--- a/ui/src/lib/rescan.ts
+++ b/ui/src/lib/rescan.ts
@@ -83,11 +83,15 @@ export async function rescanEverything(opts?: {
 // request arriving under a running read joins that follow-up, which starts
 // only once the running one has finished — so every write is answered by a
 // read that began after it, and a page of writes does not pay a whole-machine
-// read each. Each of the three legs keeps a queue of this shape for itself,
-// so a write is never answered by a read that began before it. A read that
-// fails answers for nothing at all: it leaves the rows it had standing, and
-// the join and the audit say so in the read state their surfaces gate on,
-// while the scan says it in a toast and an `error` nothing gates on.
+// read each. Each of the three legs keeps a queue of this shape for itself.
+// The join guards which arrivals may start one, so a write is never answered
+// by a read of the join that began before it; the scan and audit stores hold
+// the pair without that guard, and nothing here establishes the property for
+// them. A read that fails answers for nothing: it leaves the rows it had
+// standing, and the join and the audit say so in the read state their
+// surfaces gate on, while the scan's `error` is drawn rather than gated —
+// the status footer, Problems and Home each render it, and no control is
+// held back on it.
 let running: Promise<void> | null = null;
 let queued: Promise<void> | null = null;
 

--- a/ui/src/pages/problems.dom.test.tsx
+++ b/ui/src/pages/problems.dom.test.tsx
@@ -22,6 +22,7 @@ import { ProblemsPage } from "./problems";
 
 vi.mock("@/bindings", () => ({
   commands: {
+    libraryProvenance: vi.fn().mockResolvedValue({ status: "ok", data: [] }),
     auditAll: vi.fn(),
     scanMachine: vi.fn(),
     adoptItem: vi.fn(),

--- a/ui/src/stores/audit.test.ts
+++ b/ui/src/stores/audit.test.ts
@@ -14,6 +14,7 @@ vi.mock("@/bindings", () => ({
     adoptItem: vi.fn(),
     toggleItem: vi.fn(),
     removeItem: vi.fn(),
+    libraryProvenance: vi.fn().mockResolvedValue({ status: "ok", data: [] }),
   },
 }));
 

--- a/ui/src/stores/editor.test.ts
+++ b/ui/src/stores/editor.test.ts
@@ -21,6 +21,7 @@ import { openInventory, useEditorStore } from "./editor";
 vi.mock("@/bindings", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/bindings")>()),
   commands: {
+    libraryProvenance: vi.fn().mockResolvedValue({ status: "ok", data: [] }),
     getManifest: vi.fn(),
     editorInventory: vi.fn(),
     getScopeSettings: vi.fn(),

--- a/ui/src/stores/marketplaces-install.test.ts
+++ b/ui/src/stores/marketplaces-install.test.ts
@@ -19,6 +19,7 @@ import { useProblemsStore } from "./problems";
 
 vi.mock("@/bindings", () => ({
   commands: {
+    libraryProvenance: vi.fn().mockResolvedValue({ status: "ok", data: [] }),
     marketplaceInstall: vi.fn(),
     marketplaceBundles: vi.fn(),
     repoEffectsApply: vi.fn(),

--- a/ui/src/stores/marketplaces-subscribe-install.test.ts
+++ b/ui/src/stores/marketplaces-subscribe-install.test.ts
@@ -4,6 +4,7 @@ import { useMarketplacesStore } from "./marketplaces";
 
 vi.mock("@/bindings", () => ({
   commands: {
+    libraryProvenance: vi.fn().mockResolvedValue({ status: "ok", data: [] }),
     marketplaceSubscribe: vi.fn(),
     marketplaceInstall: vi.fn(),
     marketplacesOverview: vi.fn(),

--- a/ui/src/stores/marketplaces-subscribed.test.ts
+++ b/ui/src/stores/marketplaces-subscribed.test.ts
@@ -7,6 +7,7 @@ import { rowSubscribed, subscribedKeys } from "./marketplaces-shared";
 
 vi.mock("@/bindings", () => ({
   commands: {
+    libraryProvenance: vi.fn().mockResolvedValue({ status: "ok", data: [] }),
     marketplaceSubscribe: vi.fn(),
     marketplaceUnsubscribe: vi.fn(),
     marketplacesOverview: vi.fn(),

--- a/ui/src/stores/marketplaces-toggle.test.ts
+++ b/ui/src/stores/marketplaces-toggle.test.ts
@@ -9,6 +9,7 @@ import { catalogKey, declaredHolder, repoAction } from "./marketplaces-shared";
 
 vi.mock("@/bindings", () => ({
   commands: {
+    libraryProvenance: vi.fn().mockResolvedValue({ status: "ok", data: [] }),
     marketplaceSubscribe: vi.fn(),
     marketplaceUnsubscribe: vi.fn(),
     marketplacesOverview: vi.fn(),

--- a/ui/src/stores/provenance.test.ts
+++ b/ui/src/stores/provenance.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { commands, type ProvenanceRow } from "@/bindings";
 import { READ_PENDING } from "@/lib/read-state";
+import { NO_REASON_GIVEN } from "@/lib/settled";
 import {
   joinCurrent,
   originFor,
@@ -200,19 +201,36 @@ describe("overlapping reads of the join", () => {
     expect(published.at(-1)).toBe(true);
   });
 
-  // A rejection is the same failed read as a returned refusal, and must
-  // not leave the gate open or the join reading forever.
-  it("lands a rejected call as a failed read", async () => {
-    vi.mocked(commands.libraryProvenance).mockRejectedValueOnce(
-      new Error("the channel is gone"),
-    );
+  // The two failures a shipped path still produces. A refusal after a read
+  // that landed takes the join back off current: the rows it leaves are the
+  // older read's, and the gate closes on `read` alone. A refusal naming no
+  // reason is still a failure with something to say, which is what `settled`
+  // is here for now that the wrapper answers rather than throws.
+  it("lands an engine refusal as a failed read, empty reason and all", async () => {
+    vi.mocked(commands.libraryProvenance)
+      .mockResolvedValueOnce({ status: "ok", data: AFTER })
+      .mockResolvedValueOnce({
+        status: "error",
+        error: "the join did not read",
+      });
 
     await store().reload();
+    await store().reload();
 
+    expect(store().rows).toEqual(AFTER);
     expect(store().read).toEqual({
       status: "failed",
-      error: "the channel is gone",
+      error: "the join did not read",
     });
+    expect(joinCurrent(store())).toBe(false);
     expect(store().reading).toBe(false);
+
+    vi.mocked(commands.libraryProvenance).mockResolvedValueOnce({
+      status: "error",
+      error: "",
+    });
+    await store().reload();
+
+    expect(store().read).toEqual({ status: "failed", error: NO_REASON_GIVEN });
   });
 });

--- a/ui/src/stores/provenance.test.ts
+++ b/ui/src/stores/provenance.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { commands, type ProvenanceRow } from "@/bindings";
+import { READ_PENDING } from "@/lib/read-state";
 import {
+  joinCurrent,
   originFor,
   originLabel,
   originTitle,
@@ -90,9 +92,16 @@ type JoinAnswer = Awaited<ReturnType<typeof commands.libraryProvenance>>;
 const BEFORE: ProvenanceRow[] = [ROWS[0]];
 const AFTER: ProvenanceRow[] = ROWS;
 
+const store = () => useProvenanceStore.getState();
+
 describe("overlapping reads of the join", () => {
   beforeEach(() => {
-    useProvenanceStore.setState({ rows: [], loaded: false });
+    useProvenanceStore.setState({
+      rows: [],
+      loaded: false,
+      read: READ_PENDING,
+      reading: false,
+    });
     vi.clearAllMocks();
   });
 
@@ -106,37 +115,96 @@ describe("overlapping reads of the join", () => {
       .mockReturnValueOnce(slow.promise)
       .mockResolvedValueOnce({ status: "ok", data: AFTER });
 
-    const older = useProvenanceStore.getState().reload();
-    await useProvenanceStore.getState().reload();
-    expect(useProvenanceStore.getState().rows).toEqual(AFTER);
+    const older = store().reload();
+    await store().reload();
+    expect(store().rows).toEqual(AFTER);
 
     slow.land({ status: "ok", data: BEFORE });
+    await older;
 
-    // The overtaken read writes nothing, and says the rows are current
-    // because the read that overtook it has already landed them.
-    expect(await older).toBe(true);
-    expect(useProvenanceStore.getState().rows).toEqual(AFTER);
+    expect(store().rows).toEqual(AFTER);
+    expect(store().read.status).toBe("landed");
   });
 
-  // A caller about to act irreversibly waits on this boolean, so the answer
-  // while a newer read is still coming is the closed one: the rows on screen
-  // are neither this read's answer nor yet the newest.
-  it("tells an overtaken read the rows are not current while a newer one is out", async () => {
+  // The rows are not current while a read that supersedes them is still
+  // coming, and the two gating surfaces read that off the store rather than
+  // off their own call — so the landing that makes them current re-renders
+  // them.
+  it("holds the join uncurrent until the newest read lands", async () => {
     const slow = park();
     const newer = park();
     vi.mocked(commands.libraryProvenance)
       .mockReturnValueOnce(slow.promise)
       .mockReturnValueOnce(newer.promise);
 
-    const older = useProvenanceStore.getState().reload();
-    const outstanding = useProvenanceStore.getState().reload();
-    slow.land({ status: "ok", data: BEFORE });
+    const older = store().reload();
+    const outstanding = store().reload();
 
-    expect(await older).toBe(false);
-    expect(useProvenanceStore.getState().rows).toEqual([]);
+    slow.land({ status: "ok", data: BEFORE });
+    await older;
+    expect(joinCurrent(store())).toBe(false);
+    expect(store().rows).toEqual([]);
 
     newer.land({ status: "ok", data: AFTER });
-    expect(await outstanding).toBe(true);
-    expect(useProvenanceStore.getState().rows).toEqual(AFTER);
+    await outstanding;
+    expect(joinCurrent(store())).toBe(true);
+    expect(store().rows).toEqual(AFTER);
+  });
+
+  // A read that failed keeps the rows it had and says why. It spends its
+  // ticket like any other answer, so nothing is left looking outstanding —
+  // the failure, not a read still on its way, is what holds the gate shut.
+  it("keeps the rows a failed read could not replace, and says why", async () => {
+    vi.mocked(commands.libraryProvenance)
+      .mockResolvedValueOnce({ status: "ok", data: AFTER })
+      .mockResolvedValueOnce({
+        status: "error",
+        error: "the join did not read",
+      });
+
+    await store().reload();
+    await store().reload();
+
+    expect(store().rows).toEqual(AFTER);
+    expect(store().reading).toBe(false);
+    expect(store().read).toEqual({
+      status: "failed",
+      error: "the join did not read",
+    });
+    expect(joinCurrent(store())).toBe(false);
+  });
+
+  // Nothing awaits the read behind a write, so a call that throws where a
+  // promise was expected — a page with no Tauri behind the wrapper — would
+  // be an unhandled rejection at the window rather than a read that failed.
+  it("lands a call that throws outright as a failed read", async () => {
+    vi.mocked(commands.libraryProvenance).mockImplementationOnce(() => {
+      throw new Error("nothing behind the call");
+    });
+
+    await expect(store().reload()).resolves.toBeUndefined();
+
+    expect(store().read).toEqual({
+      status: "failed",
+      error: "nothing behind the call",
+    });
+    expect(store().reading).toBe(false);
+  });
+
+  // A rejection is the same failed read as a returned refusal: the
+  // generated wrapper rethrows a transport failure, and a read that never
+  // answered must not leave the gate open or the join reading forever.
+  it("lands a rejected call as a failed read", async () => {
+    vi.mocked(commands.libraryProvenance).mockRejectedValueOnce(
+      new Error("the channel is gone"),
+    );
+
+    await store().reload();
+
+    expect(store().read).toEqual({
+      status: "failed",
+      error: "the channel is gone",
+    });
+    expect(store().reading).toBe(false);
   });
 });

--- a/ui/src/stores/provenance.test.ts
+++ b/ui/src/stores/provenance.test.ts
@@ -105,55 +105,51 @@ describe("overlapping reads of the join", () => {
     vi.clearAllMocks();
   });
 
-  // The Scan again press and the read behind a write are routinely out at
-  // once, and the press's read began first — so it saw the older machine
-  // however late it answers, and answering late must not put that machine
-  // back on the page.
-  it("keeps the newer answer when the read that began first lands last", async () => {
-    const slow = park();
+  // A read already out saw the machine as it was when it began, which is
+  // not what a write behind it needs read. So a request arriving under one
+  // takes a re-read behind it — however many arrive, one waits.
+  it("takes one re-read behind the read already out, and keeps its answer", async () => {
+    const running = park();
     vi.mocked(commands.libraryProvenance)
-      .mockReturnValueOnce(slow.promise)
-      .mockResolvedValueOnce({ status: "ok", data: AFTER });
+      .mockReturnValueOnce(running.promise)
+      .mockResolvedValue({ status: "ok", data: AFTER });
 
-    const older = store().reload();
-    await store().reload();
+    const out = store().reload();
+    const behind = [store().reload(), store().reload()];
+
+    running.land({ status: "ok", data: BEFORE });
+    await out;
+    await Promise.all(behind);
+
+    expect(commands.libraryProvenance).toHaveBeenCalledTimes(2);
     expect(store().rows).toEqual(AFTER);
-
-    slow.land({ status: "ok", data: BEFORE });
-    await older;
-
-    expect(store().rows).toEqual(AFTER);
-    expect(store().read.status).toBe("landed");
+    expect(joinCurrent(store())).toBe(true);
   });
 
-  // The rows are not current while a read that supersedes them is still
-  // coming, and the two gating surfaces read that off the store rather than
-  // off their own call — so the landing that makes them current re-renders
-  // them.
-  it("holds the join uncurrent until the newest read lands", async () => {
-    const slow = park();
-    const newer = park();
+  // The re-read is about to replace these rows, so the surfaces gating on
+  // the join stay shut across the gap between the two reads.
+  it("holds the join uncurrent while a re-read is still to come", async () => {
+    const running = park();
+    const behind = park();
     vi.mocked(commands.libraryProvenance)
-      .mockReturnValueOnce(slow.promise)
-      .mockReturnValueOnce(newer.promise);
+      .mockReturnValueOnce(running.promise)
+      .mockReturnValueOnce(behind.promise);
 
-    const older = store().reload();
-    const outstanding = store().reload();
+    const out = store().reload();
+    const queued = store().reload();
 
-    slow.land({ status: "ok", data: BEFORE });
-    await older;
+    running.land({ status: "ok", data: BEFORE });
+    await out;
     expect(joinCurrent(store())).toBe(false);
-    expect(store().rows).toEqual([]);
 
-    newer.land({ status: "ok", data: AFTER });
-    await outstanding;
+    behind.land({ status: "ok", data: AFTER });
+    await queued;
     expect(joinCurrent(store())).toBe(true);
     expect(store().rows).toEqual(AFTER);
   });
 
-  // A read that failed keeps the rows it had and says why. It spends its
-  // ticket like any other answer, so nothing is left looking outstanding —
-  // the failure, not a read still on its way, is what holds the gate shut.
+  // A read that failed keeps the rows it had and says why. The failure,
+  // not a read still on its way, is what holds the gate shut.
   it("keeps the rows a failed read could not replace, and says why", async () => {
     vi.mocked(commands.libraryProvenance)
       .mockResolvedValueOnce({ status: "ok", data: AFTER })
@@ -174,26 +170,8 @@ describe("overlapping reads of the join", () => {
     expect(joinCurrent(store())).toBe(false);
   });
 
-  // Nothing awaits the read behind a write, so a call that throws where a
-  // promise was expected — a page with no Tauri behind the wrapper — would
-  // be an unhandled rejection at the window rather than a read that failed.
-  it("lands a call that throws outright as a failed read", async () => {
-    vi.mocked(commands.libraryProvenance).mockImplementationOnce(() => {
-      throw new Error("nothing behind the call");
-    });
-
-    await expect(store().reload()).resolves.toBeUndefined();
-
-    expect(store().read).toEqual({
-      status: "failed",
-      error: "nothing behind the call",
-    });
-    expect(store().reading).toBe(false);
-  });
-
-  // A rejection is the same failed read as a returned refusal: the
-  // generated wrapper rethrows a transport failure, and a read that never
-  // answered must not leave the gate open or the join reading forever.
+  // A rejection is the same failed read as a returned refusal, and must
+  // not leave the gate open or the join reading forever.
   it("lands a rejected call as a failed read", async () => {
     vi.mocked(commands.libraryProvenance).mockRejectedValueOnce(
       new Error("the channel is gone"),

--- a/ui/src/stores/provenance.test.ts
+++ b/ui/src/stores/provenance.test.ts
@@ -148,26 +148,56 @@ describe("overlapping reads of the join", () => {
     expect(store().rows).toEqual(AFTER);
   });
 
-  // A read that failed keeps the rows it had and says why. The failure,
-  // not a read still on its way, is what holds the gate shut.
-  it("keeps the rows a failed read could not replace, and says why", async () => {
+  // A read hands `inFlight` back before the re-read behind it starts, so
+  // there is a moment with nothing running and one still scheduled. A
+  // request arriving there joins what is scheduled: its own read would put
+  // two out at once, and nothing ranks them.
+  it("joins the re-read already scheduled rather than starting a second", async () => {
+    const running = park();
     vi.mocked(commands.libraryProvenance)
-      .mockResolvedValueOnce({ status: "ok", data: AFTER })
-      .mockResolvedValueOnce({
-        status: "error",
-        error: "the join did not read",
-      });
+      .mockReturnValueOnce(running.promise)
+      .mockResolvedValue({ status: "ok", data: AFTER });
 
-    await store().reload();
-    await store().reload();
+    const out = store().reload();
+    // Registered before the request that queues the re-read, so it runs in
+    // the gap rather than behind the re-read's own start.
+    const inTheGap = out.then(() => store().reload());
+    const behind = store().reload();
 
+    running.land({ status: "ok", data: BEFORE });
+    await Promise.all([out, behind, inTheGap]);
+
+    expect(commands.libraryProvenance).toHaveBeenCalledTimes(2);
     expect(store().rows).toEqual(AFTER);
-    expect(store().reading).toBe(false);
-    expect(store().read).toEqual({
-      status: "failed",
-      error: "the join did not read",
-    });
-    expect(joinCurrent(store())).toBe(false);
+  });
+
+  // What a surface reads is what the store PUBLISHES, not what it holds
+  // once everything has settled. Between the running read landing and the
+  // re-read starting, the rows are a landed answer a scheduled read is
+  // about to replace, so `joinCurrent` must not go true there — which only
+  // a subscription across the sequence can see.
+  it("never publishes the join as current before the last read lands", async () => {
+    const running = park();
+    const behind = park();
+    vi.mocked(commands.libraryProvenance)
+      .mockReturnValueOnce(running.promise)
+      .mockReturnValueOnce(behind.promise);
+
+    const published: boolean[] = [];
+    const stop = useProvenanceStore.subscribe((state) =>
+      published.push(joinCurrent(state)),
+    );
+
+    const out = store().reload();
+    const queued = store().reload();
+    running.land({ status: "ok", data: BEFORE });
+    await out;
+    behind.land({ status: "ok", data: AFTER });
+    await queued;
+    stop();
+
+    expect(published.slice(0, -1)).not.toContain(true);
+    expect(published.at(-1)).toBe(true);
   });
 
   // A rejection is the same failed read as a returned refusal, and must

--- a/ui/src/stores/provenance.test.ts
+++ b/ui/src/stores/provenance.test.ts
@@ -1,6 +1,17 @@
-import { describe, expect, it } from "vitest";
-import type { ProvenanceRow } from "@/bindings";
-import { originFor, originLabel, originTitle } from "./provenance";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { commands, type ProvenanceRow } from "@/bindings";
+import {
+  originFor,
+  originLabel,
+  originTitle,
+  useProvenanceStore,
+} from "./provenance";
+
+vi.mock("@/bindings", () => ({
+  commands: {
+    libraryProvenance: vi.fn(),
+  },
+}));
 
 const ROWS: ProvenanceRow[] = [
   {
@@ -61,5 +72,71 @@ describe("the From column's join", () => {
     ).toBeUndefined();
     expect(originLabel({ origin: "unmanaged" })).toBe("Not managed");
     expect(originLabel(null)).toBe("");
+  });
+});
+
+/** A join read this test answers by hand, to hold one open. */
+const park = () => {
+  let land: (value: JoinAnswer) => void = () => {};
+  const promise = new Promise<JoinAnswer>((resolve) => {
+    land = resolve;
+  });
+  return { promise, land };
+};
+
+type JoinAnswer = Awaited<ReturnType<typeof commands.libraryProvenance>>;
+
+/** What the join said before an install landed, and after it. */
+const BEFORE: ProvenanceRow[] = [ROWS[0]];
+const AFTER: ProvenanceRow[] = ROWS;
+
+describe("overlapping reads of the join", () => {
+  beforeEach(() => {
+    useProvenanceStore.setState({ rows: [], loaded: false });
+    vi.clearAllMocks();
+  });
+
+  // The Scan again press and the read behind a write are routinely out at
+  // once, and the press's read began first — so it saw the older machine
+  // however late it answers, and answering late must not put that machine
+  // back on the page.
+  it("keeps the newer answer when the read that began first lands last", async () => {
+    const slow = park();
+    vi.mocked(commands.libraryProvenance)
+      .mockReturnValueOnce(slow.promise)
+      .mockResolvedValueOnce({ status: "ok", data: AFTER });
+
+    const older = useProvenanceStore.getState().reload();
+    await useProvenanceStore.getState().reload();
+    expect(useProvenanceStore.getState().rows).toEqual(AFTER);
+
+    slow.land({ status: "ok", data: BEFORE });
+
+    // The overtaken read writes nothing, and says the rows are current
+    // because the read that overtook it has already landed them.
+    expect(await older).toBe(true);
+    expect(useProvenanceStore.getState().rows).toEqual(AFTER);
+  });
+
+  // A caller about to act irreversibly waits on this boolean, so the answer
+  // while a newer read is still coming is the closed one: the rows on screen
+  // are neither this read's answer nor yet the newest.
+  it("tells an overtaken read the rows are not current while a newer one is out", async () => {
+    const slow = park();
+    const newer = park();
+    vi.mocked(commands.libraryProvenance)
+      .mockReturnValueOnce(slow.promise)
+      .mockReturnValueOnce(newer.promise);
+
+    const older = useProvenanceStore.getState().reload();
+    const outstanding = useProvenanceStore.getState().reload();
+    slow.land({ status: "ok", data: BEFORE });
+
+    expect(await older).toBe(false);
+    expect(useProvenanceStore.getState().rows).toEqual([]);
+
+    newer.land({ status: "ok", data: AFTER });
+    expect(await outstanding).toBe(true);
+    expect(useProvenanceStore.getState().rows).toEqual(AFTER);
   });
 });

--- a/ui/src/stores/provenance.ts
+++ b/ui/src/stores/provenance.ts
@@ -6,6 +6,7 @@ import {
   type ProvenanceRow,
   type Scope,
 } from "@/bindings";
+import { readOrder } from "@/lib/read-state";
 import { scopeKey } from "@/lib/scope";
 
 interface ProvenanceState {
@@ -17,15 +18,26 @@ interface ProvenanceState {
    */
   loaded: boolean;
   load: () => Promise<void>;
-  /** Read the join again and say whether it landed. `rescanEverything` calls
-   * this, which is how a write anywhere reaches every reader of the join
-   * without any of them guessing at when something installed. Anything about
-   * to act irreversibly on the answer — a delete naming the places it will
-   * remove — still asks for its own read and waits on this boolean, because
-   * a refresh that failed is indistinguishable from one that changed
-   * nothing. */
+  /** Read the join again and say whether `rows` is now a landed read's
+   * answer with nothing newer on its way. `rescanEverything` calls this,
+   * which is how a write anywhere reaches every reader of the join without
+   * any of them guessing at when something installed. Anything about to act
+   * irreversibly on the answer — a delete naming the places it will remove —
+   * still asks for its own read and waits on this boolean, because a refresh
+   * that failed is indistinguishable from one that changed nothing.
+   *
+   * The boolean answers for the rows on screen rather than for this call's
+   * own answer: a read a newer one overtook writes nothing, and what its
+   * caller then reads is the newer read's rows, current or still coming. */
   reload: () => Promise<boolean>;
 }
+
+/** The join's reads in the order they were asked for, so the newest answer
+ * is the one on screen. Several are routinely out at once: `rescanEverything`
+ * refreshes the join behind every write while the Scan again buttons, a
+ * delete dialog opening and a marketplace table mounting all ask for their
+ * own, and the slower read is not the truer one. */
+const order = readOrder();
 
 /** Where every installation came from — the Library's From column and a
  * marketplace's Installed in column read this join and match rows into their
@@ -38,18 +50,24 @@ export const useProvenanceStore = create<ProvenanceState>((set, get) => ({
     await get().reload();
   },
   reload: async () => {
+    const ticket = order.begin();
     try {
       const response = await commands.libraryProvenance();
-      if (response.status !== "ok") return false;
-      set({ rows: response.data, loaded: true });
-      return true;
+      // A read that failed takes no landing: leaving the newest ticket
+      // outstanding is what keeps this call, and every read it overtook,
+      // from calling the rows it never replaced current.
+      if (response.status === "ok" && order.lands(ticket))
+        set({ rows: response.data, loaded: true });
     } catch {
       // The wrapper folds a rejected command into an error status, so this
       // is the last guard rather than the first: a read that never answered
       // at all is still a failed read, not a rejection for every caller of
       // this store to catch.
-      return false;
     }
+    // True only where no read is still on its way, which is the same fact
+    // as `rows` holding the newest answer — this call's own, or that of the
+    // newer read which landed while this one was coming.
+    return !order.outstanding();
   },
 }));
 

--- a/ui/src/stores/provenance.ts
+++ b/ui/src/stores/provenance.ts
@@ -6,8 +6,14 @@ import {
   type ProvenanceRow,
   type Scope,
 } from "@/bindings";
-import { readOrder } from "@/lib/read-state";
+import {
+  READ_PENDING,
+  type ReadState,
+  readOf,
+  readOrder,
+} from "@/lib/read-state";
 import { scopeKey } from "@/lib/scope";
+import { settled } from "@/lib/settled";
 
 interface ProvenanceState {
   rows: ProvenanceRow[];
@@ -17,20 +23,37 @@ interface ProvenanceState {
    * which is the right answer for a column and the wrong one for a decision.
    */
   loaded: boolean;
+  /** How the last read of the join went. A failure keeps the rows it had
+   * and says why: a delete dialog naming where to get the package again and
+   * a places tab drawing Remove both gate on this, and acting on rows
+   * nothing confirmed is exactly the fail-open that gate closes. */
+  read: ReadState;
+  /** True while a read of the join is on its way: a mount, a rescan behind
+   * a write and a dialog opening all ask, and the rows under a reader's
+   * buttons are about to be replaced. */
+  reading: boolean;
   load: () => Promise<void>;
-  /** Read the join again and say whether `rows` is now a landed read's
-   * answer with nothing newer on its way. `rescanEverything` calls this,
-   * which is how a write anywhere reaches every reader of the join without
-   * any of them guessing at when something installed. Anything about to act
-   * irreversibly on the answer — a delete naming the places it will remove —
-   * still asks for its own read and waits on this boolean, because a refresh
-   * that failed is indistinguishable from one that changed nothing.
+  /** Read the join again. `rescanEverything` calls this, which is how a
+   * write anywhere reaches every reader of the join without any of them
+   * guessing at when something installed.
    *
-   * The boolean answers for the rows on screen rather than for this call's
-   * own answer: a read a newer one overtook writes nothing, and what its
-   * caller then reads is the newer read's rows, current or still coming. */
-  reload: () => Promise<boolean>;
+   * How the read went is published as [read] and [reading] rather than
+   * returned: the answer belongs to the store and not to the call, so a
+   * caller whose own read was overtaken re-renders when the read that
+   * overtook it lands, instead of holding a boolean that was true for one
+   * instant. [joinCurrent] is that pair read as the one question a caller
+   * gating on the join asks. */
+  reload: () => Promise<void>;
 }
+
+/** Whether `rows` is the newest read's answer with nothing newer on its
+ *  way. False covers both halves: a read that failed, and a read still
+ *  coming that will replace these rows. Anything about to act irreversibly
+ *  on the join — a delete naming the places it will remove — asks this,
+ *  because rows nothing has confirmed are indistinguishable from rows a
+ *  read confirmed. */
+export const joinCurrent = (state: ProvenanceState): boolean =>
+  state.read.status === "landed" && !state.reading;
 
 /** The join's reads in the order they were asked for, so the newest answer
  * is the one on screen. Several are routinely out at once: `rescanEverything`
@@ -46,28 +69,47 @@ const order = readOrder();
 export const useProvenanceStore = create<ProvenanceState>((set, get) => ({
   rows: [],
   loaded: false,
+  read: READ_PENDING,
+  reading: false,
   load: async () => {
     await get().reload();
   },
   reload: async () => {
     const ticket = order.begin();
+    set({ reading: true });
     try {
-      const response = await commands.libraryProvenance();
-      // A read that failed takes no landing: leaving the newest ticket
-      // outstanding is what keeps this call, and every read it overtook,
-      // from calling the rows it never replaced current.
-      if (response.status === "ok" && order.lands(ticket))
-        set({ rows: response.data, loaded: true });
-    } catch {
-      // The wrapper folds a rejected command into an error status, so this
-      // is the last guard rather than the first: a read that never answered
-      // at all is still a failed read, not a rejection for every caller of
-      // this store to catch.
+      // `settled` lands a rejected call as the same failed read as a
+      // returned refusal: the generated wrapper rethrows a transport
+      // failure, and a read that never answered is a failed read, not a
+      // rejection for every caller to catch.
+      //
+      // Called through a `then` because the wrapper reaches Tauri as it is
+      // CALLED, so a page with nothing behind that call throws where a
+      // promise was expected. Nothing awaits this read — `writingRepo`
+      // starts it with `void` — so a throw escaping here is an unhandled
+      // rejection at the window rather than a read that failed.
+      const response = await settled<ProvenanceRow[]>(
+        Promise.resolve().then(() => commands.libraryProvenance()),
+      );
+      // The newest read owns the answer, whatever it says. An older one
+      // landing behind it writes nothing, rows and read state alike; a
+      // failed newest read leaves the rows it had standing and says why
+      // nothing confirmed them, which is [ReadState]'s own contract. So the
+      // rows an overtaken read answered with are dropped even where the
+      // read that overtook it failed: they are older than the state that
+      // failure is about, and preferring them would need a second rank
+      // beside the ticket.
+      if (!order.lands(ticket)) return;
+      set(
+        response.status === "ok"
+          ? { rows: response.data, loaded: true, read: readOf(response) }
+          : { read: readOf(response) },
+      );
+    } finally {
+      // Not simply false: another read begun behind this one is still out,
+      // and the rows are still about to be replaced.
+      set({ reading: order.outstanding() });
     }
-    // True only where no read is still on its way, which is the same fact
-    // as `rows` holding the newest answer — this call's own, or that of the
-    // newer read which landed while this one was coming.
-    return !order.outstanding();
   },
 }));
 

--- a/ui/src/stores/provenance.ts
+++ b/ui/src/stores/provenance.ts
@@ -50,9 +50,10 @@ export const joinCurrent = (state: ProvenanceState): boolean =>
 export const useProvenanceStore = create<ProvenanceState>((set, get) => {
   // The read out and the one re-read waiting behind it — the same pair the
   // scan store keeps, for the same reason. Requests overlap on every
-  // ordinary path, but the reads they ask for do not: one runs and one
-  // waits, so the last to land is always the last to have begun, and there
-  // is no ranking to keep.
+  // ordinary path; the reads they ask for do not, because `reload` starts
+  // one only with both handles clear. That guard is the whole of why the
+  // last read to land is the last to have begun, and so the whole of why
+  // there is no ranking to keep: loosen it and the ordering goes with it.
   let inFlight: Promise<void> | null = null;
   let queued: Promise<void> | null = null;
 
@@ -95,8 +96,15 @@ export const useProvenanceStore = create<ProvenanceState>((set, get) => {
     // one waits, a second arrival joining that one rather than stacking
     // identical whole-machine reads.
     reload: () => {
+      // Both handles, not just the running one. A read hands `inFlight`
+      // back before the re-read behind it starts — the continuation that
+      // starts it is registered on that same promise — so a request
+      // arriving in that gap would see nothing running and start a second
+      // read alongside the one already scheduled. `start` is reachable
+      // only with both clear, which is what makes one-at-a-time true.
+      if (queued) return queued;
       if (!inFlight) return start();
-      queued ??= inFlight.then(() => {
+      queued = inFlight.then(() => {
         queued = null;
         return start();
       });

--- a/ui/src/stores/provenance.ts
+++ b/ui/src/stores/provenance.ts
@@ -58,10 +58,11 @@ export const useProvenanceStore = create<ProvenanceState>((set, get) => {
   let queued: Promise<void> | null = null;
 
   const land = async (): Promise<void> => {
-    // `settled` lands a rejected call as the same failed read as a returned
-    // refusal: the wrapper rethrows a transport failure, and a read that
-    // never answered is a failed read, not a rejection for every caller to
-    // catch. A failure keeps the rows it had, per [ReadState].
+    // The wrapper folds a rejected command into an error status, so
+    // `settled` is the last guard rather than the first: it names a refusal
+    // that carries no reason, and a read that never answered at all is
+    // still a failed read rather than a rejection for every caller of this
+    // store to catch. A failure keeps the rows it had, per [ReadState].
     const response = await settled(commands.libraryProvenance());
     set(
       response.status === "ok"

--- a/ui/src/stores/provenance.ts
+++ b/ui/src/stores/provenance.ts
@@ -6,12 +6,7 @@ import {
   type ProvenanceRow,
   type Scope,
 } from "@/bindings";
-import {
-  READ_PENDING,
-  type ReadState,
-  readOf,
-  readOrder,
-} from "@/lib/read-state";
+import { READ_PENDING, type ReadState, readOf } from "@/lib/read-state";
 import { scopeKey } from "@/lib/scope";
 import { settled } from "@/lib/settled";
 
@@ -23,95 +18,92 @@ interface ProvenanceState {
    * which is the right answer for a column and the wrong one for a decision.
    */
   loaded: boolean;
-  /** How the last read of the join went. A failure keeps the rows it had
-   * and says why: a delete dialog naming where to get the package again and
-   * a places tab drawing Remove both gate on this, and acting on rows
-   * nothing confirmed is exactly the fail-open that gate closes. */
+  /** How the last read went. A failure keeps the rows it had and says why:
+   * the delete dialog's note and the places tab's Remove gate on it, and
+   * acting on rows nothing confirmed is the fail-open they close. */
   read: ReadState;
-  /** True while a read of the join is on its way: a mount, a rescan behind
-   * a write and a dialog opening all ask, and the rows under a reader's
-   * buttons are about to be replaced. */
+  /** True while a read is out, and while a re-read is still to come behind
+   * it: the rows are about to be replaced either way. */
   reading: boolean;
   load: () => Promise<void>;
-  /** Read the join again. `rescanEverything` calls this, which is how a
-   * write anywhere reaches every reader of the join without any of them
-   * guessing at when something installed.
+  /** Read the join again, or join the read already out and take the one
+   * re-read behind it. `rescanEverything` calls this, which is how a write
+   * anywhere reaches every reader of the join.
    *
-   * How the read went is published as [read] and [reading] rather than
-   * returned: the answer belongs to the store and not to the call, so a
-   * caller whose own read was overtaken re-renders when the read that
-   * overtook it lands, instead of holding a boolean that was true for one
-   * instant. [joinCurrent] is that pair read as the one question a caller
-   * gating on the join asks. */
+   * How it went is published as [read] and [reading] rather than returned,
+   * so a caller re-renders when the answer lands instead of holding a
+   * boolean that was true for one instant. [joinCurrent] is the pair read
+   * as the one question a gating caller asks. */
   reload: () => Promise<void>;
 }
 
-/** Whether `rows` is the newest read's answer with nothing newer on its
- *  way. False covers both halves: a read that failed, and a read still
- *  coming that will replace these rows. Anything about to act irreversibly
- *  on the join — a delete naming the places it will remove — asks this,
- *  because rows nothing has confirmed are indistinguishable from rows a
- *  read confirmed. */
+/** Whether the rows are a landed read's answer with none on its way: true
+ *  only there, so never read, failed, and about to be replaced are all
+ *  false. Anything about to act irreversibly on the join asks this. */
 export const joinCurrent = (state: ProvenanceState): boolean =>
   state.read.status === "landed" && !state.reading;
-
-/** The join's reads in the order they were asked for, so the newest answer
- * is the one on screen. Several are routinely out at once: `rescanEverything`
- * refreshes the join behind every write while the Scan again buttons, a
- * delete dialog opening and a marketplace table mounting all ask for their
- * own, and the slower read is not the truer one. */
-const order = readOrder();
 
 /** Where every installation came from — the Library's From column and a
  * marketplace's Installed in column read this join and match rows into their
  * groups. One standing answer, refreshed by `lib/rescan.ts` rather than by
  * each reader deciding for itself when an install might have happened. */
-export const useProvenanceStore = create<ProvenanceState>((set, get) => ({
-  rows: [],
-  loaded: false,
-  read: READ_PENDING,
-  reading: false,
-  load: async () => {
-    await get().reload();
-  },
-  reload: async () => {
-    const ticket = order.begin();
+export const useProvenanceStore = create<ProvenanceState>((set, get) => {
+  // The read out and the one re-read waiting behind it — the same pair the
+  // scan store keeps, for the same reason. Requests overlap on every
+  // ordinary path, but the reads they ask for do not: one runs and one
+  // waits, so the last to land is always the last to have begun, and there
+  // is no ranking to keep.
+  let inFlight: Promise<void> | null = null;
+  let queued: Promise<void> | null = null;
+
+  const land = async (): Promise<void> => {
+    // `settled` lands a rejected call as the same failed read as a returned
+    // refusal: the wrapper rethrows a transport failure, and a read that
+    // never answered is a failed read, not a rejection for every caller to
+    // catch. A failure keeps the rows it had, per [ReadState].
+    const response = await settled(commands.libraryProvenance());
+    set(
+      response.status === "ok"
+        ? { rows: response.data, loaded: true, read: readOf(response) }
+        : { read: readOf(response) },
+    );
+  };
+
+  const start = (): Promise<void> => {
+    const running = land().finally(() => {
+      if (inFlight === running) inFlight = null;
+      // Not simply false: a re-read waiting behind this one is about to
+      // replace these rows, so nothing may call them current yet.
+      set({ reading: queued !== null });
+    });
+    inFlight = running;
     set({ reading: true });
-    try {
-      // `settled` lands a rejected call as the same failed read as a
-      // returned refusal: the generated wrapper rethrows a transport
-      // failure, and a read that never answered is a failed read, not a
-      // rejection for every caller to catch.
-      //
-      // Called through a `then` because the wrapper reaches Tauri as it is
-      // CALLED, so a page with nothing behind that call throws where a
-      // promise was expected. Nothing awaits this read — `writingRepo`
-      // starts it with `void` — so a throw escaping here is an unhandled
-      // rejection at the window rather than a read that failed.
-      const response = await settled<ProvenanceRow[]>(
-        Promise.resolve().then(() => commands.libraryProvenance()),
-      );
-      // The newest read owns the answer, whatever it says. An older one
-      // landing behind it writes nothing, rows and read state alike; a
-      // failed newest read leaves the rows it had standing and says why
-      // nothing confirmed them, which is [ReadState]'s own contract. So the
-      // rows an overtaken read answered with are dropped even where the
-      // read that overtook it failed: they are older than the state that
-      // failure is about, and preferring them would need a second rank
-      // beside the ticket.
-      if (!order.lands(ticket)) return;
-      set(
-        response.status === "ok"
-          ? { rows: response.data, loaded: true, read: readOf(response) }
-          : { read: readOf(response) },
-      );
-    } finally {
-      // Not simply false: another read begun behind this one is still out,
-      // and the rows are still about to be replaced.
-      set({ reading: order.outstanding() });
-    }
-  },
-}));
+    return running;
+  };
+
+  return {
+    rows: [],
+    loaded: false,
+    read: READ_PENDING,
+    reading: false,
+    load: async () => {
+      await get().reload();
+    },
+    // A read already out cannot answer for what has happened since it
+    // began, which is the whole of what a write behind it needs read. So an
+    // overlapping request takes a re-read behind the one running. Exactly
+    // one waits, a second arrival joining that one rather than stacking
+    // identical whole-machine reads.
+    reload: () => {
+      if (!inFlight) return start();
+      queued ??= inFlight.then(() => {
+        queued = null;
+        return start();
+      });
+      return queued;
+    },
+  };
+});
 
 /** Every origin recorded across these scopes, in row order. Each place
  * records its own source, so one package installed in several places can

--- a/ui/src/stores/settings.test.ts
+++ b/ui/src/stores/settings.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/bindings", () => ({
     scanMachine: vi.fn(),
     // Registering or dropping a project re-audits: the scopes changed.
     auditAll: vi.fn(),
+    libraryProvenance: vi.fn().mockResolvedValue({ status: "ok", data: [] }),
     windowSetZoom: vi.fn(),
     windowZoomState: vi.fn(),
     saveZoom: vi.fn(),

--- a/ui/src/stores/updates-apply.test.ts
+++ b/ui/src/stores/updates-apply.test.ts
@@ -23,6 +23,7 @@ vi.mock("@/bindings", async (importOriginal) => ({
     packageUpdateMany: vi.fn(),
     scanMachine: vi.fn(),
     auditAll: vi.fn(),
+    libraryProvenance: vi.fn().mockResolvedValue({ status: "ok", data: [] }),
   },
 }));
 

--- a/ui/src/stores/updates-edits.test.ts
+++ b/ui/src/stores/updates-edits.test.ts
@@ -24,6 +24,7 @@ vi.mock("@/bindings", async (importOriginal) => ({
     packageForkBeside: vi.fn(),
     scanMachine: vi.fn(),
     auditAll: vi.fn(),
+    libraryProvenance: vi.fn().mockResolvedValue({ status: "ok", data: [] }),
   },
 }));
 

--- a/ui/src/stores/updates-exclusion.test.ts
+++ b/ui/src/stores/updates-exclusion.test.ts
@@ -25,6 +25,7 @@ vi.mock("@/bindings", async (importOriginal) => ({
     applyDiscardEdits: vi.fn(),
     scanMachine: vi.fn(),
     auditAll: vi.fn(),
+    libraryProvenance: vi.fn().mockResolvedValue({ status: "ok", data: [] }),
   },
 }));
 

--- a/ui/src/stores/updates.test.ts
+++ b/ui/src/stores/updates.test.ts
@@ -26,6 +26,7 @@ vi.mock("@/bindings", async (importOriginal) => ({
     packageUpdateMany: vi.fn(),
     scanMachine: vi.fn(),
     auditAll: vi.fn(),
+    libraryProvenance: vi.fn().mockResolvedValue({ status: "ok", data: [] }),
   },
 }));
 

--- a/ui/src/stores/write-rescan.test.ts
+++ b/ui/src/stores/write-rescan.test.ts
@@ -136,9 +136,10 @@ beforeEach(() => {
 
 /** What every case below asks: the machine was read again behind a command
  *  that answered with a refusal. Two of the three reads, not all of them —
- *  the provenance join answers false rather than throwing and no store
- *  mocked here would tell a join that ran from one that could not, so it is
- *  asserted through neither. */
+ *  the provenance join's read answers nothing at all, publishing how it
+ *  went as its store's own read state, and no store mocked here would tell
+ *  a join that ran from one that could not, so it is asserted through
+ *  neither. */
 const readAgain = () => {
   expect(commands.scanMachine).toHaveBeenCalled();
   expect(commands.auditAll).toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- `useProvenanceStore.reload` keeps one read of the join at a time — one runs, exactly one waits behind it, and a second arrival joins that one — the shape `ui/src/stores/scan.ts` already uses. A request made after a write is never answered by a read that began before it.
- The store publishes how the read went as `read: ReadState` and `reading`, with `joinCurrent` the one predicate a gating caller asks. A failed read keeps the rows it had and says why, rather than being indistinguishable from a read that changed nothing.
- The Projects tab's removal controls stay in the layout and disable while the join is not current, instead of leaving the DOM. `ui/src/lib/updates-read-state.ts` states the rule they follow: a read merely running does not withhold a row that exists.
- `ui/src/lib/rescan.ts`'s header no longer names the join as the leg with no ordering, and no longer cites the canceled KEN-1183.

## Completed Issues

- Closes KEN-1162 - Scan store drops a rescan requested during an in-flight scan

The scan leg of this issue landed separately in b7b808916 (#2061). This PR is the provenance leg, which was the remainder.

## Test Plan

`tools/guard` green on this base: 145 files, 1164 tests, plus preflight, size-ratchet, and both commit gates.

Six controls, each killing a mutant no other one reaches, verified with `mutation-stability` rather than asserted:

- an overlapping request takes one re-read behind the read already out (`queued ??=` → `=`)
- the join stays uncurrent while a re-read is still to come (`joinCurrent`'s `!reading` half)
- a request arriving in the gap between a read landing and its re-read starting joins rather than forking the queue (the arrival guard)
- the join is never *published* current before the last landing, asserted on the subscription rather than after both reads settle (`reading: queued !== null` → `false`)
- a refusal after a landed read, and a refusal carrying no reason, both land as a failed read (a bare call in place of `settled`; a failed read publishing no read state)
- the places tab and the delete dialog both recover when the read that overtook theirs lands (the per-consumer latch mutants)

## Notes For Review

**Size tripwire.** The branch is 553 diffstat lines against a 268 cap (2 × baseline 134, measured before the review found the regressions below). 157 of those are production. The residual is stated here per the round ruling rather than paid for by deleting a control that kills a mutant.

The cut that was made went at production first, not tests: an earlier shape ordered overlapping reads with a `readOrder` ticket, a landing gate and an `outstanding`-derived flag — three mechanisms ranking reads that overlap. Serializing the reads removed the overlap instead, taking production from 187 lines to 157.

**Two review findings were declined on a disproved premise.** An earlier revision wrapped the binding as `settled(Promise.resolve().then(() => commands.libraryProvenance()))` to guard a synchronous throw. No such throw is reachable: `ui/src/bindings.ts` imports `invoke` from `@tauri-apps/api/core`, which is an `async function`, and `typedError` is `async` too, so a failure is a rejected promise. The wrapper and the test whose premise it was are gone. The 17 one-line `libraryProvenance` mock declarations in this diff are the real producer that the store's old empty `catch` was hiding — fixture files that mock the other two `rescanEverything` legs but never the join's.

**Declined, with reasons.** A rejected `land()` pinning `queued` non-null forever — reaching it needs `zustand`'s `set` itself to throw, an input no shipped producer emits. A disabled Remove control carrying no explanation — a surface no Done-when asks for; `read.error` records the failure for a consumer when one is ordered.

**Observed, not fixed here.** `ui/src/stores/scan.ts`, `ui/src/stores/audit.ts` and `rescan.ts`'s `readBehindWrites` carry the same `inFlight`/`queued` pair without the arrival guard this PR adds to the join, so a request arriving between a read landing and its re-read starting can fork those queues too. Pre-existing and outside this issue; `rescan.ts`'s header now says plainly that the other two legs hold the pair unguarded rather than claiming the ordering for all three.

https://claude.ai/code/session_01Bvnwjr5xQYWwaQTnkyAccL
