### PR TITLE
fix(pi-background-tasks): expire finished task widget

### DIFF
--- a/changelog.d/fixed/2071.md
+++ b/changelog.d/fixed/2071.md
@@ -1,0 +1,1 @@
+- Background task widgets disappear when their last finished task reaches its configured retention limit instead of showing zero tasks. — thanks @lhl

--- a/pi-extensions/pi-background-tasks/extensions/background-tasks.ts
+++ b/pi-extensions/pi-background-tasks/extensions/background-tasks.ts
@@ -79,6 +79,7 @@ import {
 } from "./snapshot.js";
 import { MINI_DASHBOARD_RANK, setMiniDashboardWidget } from "./stacked-widget.js";
 import {
+	createBackgroundWidgetExpiryScheduler,
 	createBackgroundWidgetVisibility,
 	shouldRenderBackgroundWidget,
 	toggleBackgroundWidgetVisibility,
@@ -253,7 +254,9 @@ export default function backgroundTasks(pi: ExtensionAPI): void {
 		task.forceKillTimer = null;
 	};
 
+	const widgetExpiry = createBackgroundWidgetExpiryScheduler(() => activeCtx ? syncWidget(activeCtx) : undefined);
 	const clearWidget = () => {
+		widgetExpiry.clear();
 		if (activeCtx) setMiniDashboardWidget(activeCtx, BG_WIDGET_KEY, MINI_DASHBOARD_RANK.BACKGROUND_TASKS, undefined);
 		requestWidgetRender = null;
 	};
@@ -293,15 +296,17 @@ export default function backgroundTasks(pi: ExtensionAPI): void {
 		return lines;
 	};
 
-	const syncWidget = (ctx: ExtensionContext) => {
+	function syncWidget(ctx: ExtensionContext): void {
 		activeCtx = ctx;
-		const visibleTaskCount = widgetTasks().length;
+		widgetExpiry.clear();
+		const now = Date.now();
+		const visibleTasks = widgetTasks(now);
 		if (!shouldRenderBackgroundWidget({
 			hasUi: ctx.hasUI,
 			mode: widgetVisibility.mode,
 			showWidget: settingBoolean("showWidget", true, ctx.cwd),
 			trackedTaskCount: tasks.size,
-			visibleTaskCount,
+			visibleTaskCount: visibleTasks.length,
 		})) {
 			clearWidget();
 			return;
@@ -313,13 +318,6 @@ export default function backgroundTasks(pi: ExtensionAPI): void {
 			MINI_DASHBOARD_RANK.BACKGROUND_TASKS,
 			(tui, theme) => {
 				requestWidgetRender = () => tui.requestRender();
-				// Previously: setInterval(() => tui.requestRender(), 1_000) to refresh
-				// formatRelativeTime() output. That forced a TUI render every second purely
-				// to advance "5s ago" → "6s ago", which re-diffs the full screen and triggers
-				// pi-tui's above-viewport flicker every time the chat overflows. Relative-time
-				// text is now refreshed only on real task events (start / output / end / mode
-				// toggle / dashboard mutation), accepting a few seconds of staleness between
-				// events as a worthwhile tradeoff against the redraw storm.
 				return {
 					dispose() {
 						if (requestWidgetRender) requestWidgetRender = null;
@@ -332,7 +330,9 @@ export default function backgroundTasks(pi: ExtensionAPI): void {
 			},
 			{ placement: settingString("widgetPlacement", "aboveEditor", ctx.cwd) === "belowEditor" ? "belowEditor" : "aboveEditor" },
 		);
-	};
+
+		widgetExpiry.schedule(visibleTasks, widgetFinishedRetentionMs(ctx.cwd), now);
+	}
 
 	const refreshUi = () => {
 		for (const task of tasks.values()) rememberSnapshot(task);

--- a/pi-extensions/pi-background-tasks/extensions/widget-visibility.ts
+++ b/pi-extensions/pi-background-tasks/extensions/widget-visibility.ts
@@ -26,3 +26,49 @@ export function toggleBackgroundWidgetVisibility(state: BackgroundWidgetVisibili
 export function shouldRenderBackgroundWidget(input: { hasUi: boolean; trackedTaskCount: number; visibleTaskCount: number; showWidget: boolean; mode: BackgroundWidgetMode }): boolean {
 	return input.hasUi && input.trackedTaskCount > 0 && input.visibleTaskCount > 0 && input.showWidget && input.mode !== "hidden";
 }
+
+export function nextBackgroundWidgetExpiryDelay(
+	tasks: Iterable<{ status: string; updatedAt: number }>,
+	retentionMs: number,
+	now: number,
+): number | null {
+	let delay: number | null = null;
+	for (const task of tasks) {
+		if (task.status === "running") continue;
+		const remaining = task.updatedAt + retentionMs - now;
+		if (remaining < 0) continue;
+		const candidate = remaining + 1;
+		delay = delay === null ? candidate : Math.min(delay, candidate);
+	}
+	return delay;
+}
+
+// Expiry uses one-shot timers so relative-time labels do not restore the old
+// per-second full-screen render interval.
+export function createBackgroundWidgetExpiryScheduler(
+	refresh: () => void,
+	scheduleTimer: typeof setTimeout = setTimeout,
+	clearTimer: typeof clearTimeout = clearTimeout,
+): {
+	clear: () => void;
+	schedule: (tasks: Iterable<{ status: string; updatedAt: number }>, retentionMs: number, now: number) => void;
+} {
+	let timer: ReturnType<typeof setTimeout> | null = null;
+	const clear = () => {
+		if (timer) clearTimer(timer);
+		timer = null;
+	};
+	return {
+		clear,
+		schedule(tasks, retentionMs, now) {
+			clear();
+			const delay = nextBackgroundWidgetExpiryDelay(tasks, retentionMs, now);
+			if (delay === null) return;
+			timer = scheduleTimer(() => {
+				timer = null;
+				refresh();
+			}, delay);
+			timer.unref?.();
+		},
+	};
+}

--- a/pi-extensions/pi-background-tasks/tests/widget-visibility.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/widget-visibility.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
+	createBackgroundWidgetExpiryScheduler,
 	createBackgroundWidgetVisibility,
+	nextBackgroundWidgetExpiryDelay,
 	shouldRenderBackgroundWidget,
 	toggleBackgroundWidgetVisibility,
 } from "../extensions/widget-visibility.js";
@@ -28,5 +30,38 @@ describe("background task mini-dashboard visibility", () => {
 		toggleBackgroundWidgetVisibility(visibility);
 		expect(visibility.mode).toBe("expanded");
 		expect(lifecycleRefreshRenders(visibility.mode)).toBe(true);
+	});
+
+	test("refreshes after the earliest finished task expires", () => {
+		const tasks = [
+			{ status: "running", updatedAt: 500 },
+			{ status: "completed", updatedAt: 1_000 },
+			{ status: "failed", updatedAt: 2_000 },
+		];
+		expect(nextBackgroundWidgetExpiryDelay(tasks, 15_000, 10_000)).toBe(6_001);
+		expect(nextBackgroundWidgetExpiryDelay(tasks, 15_000, 16_001)).toBe(1_000);
+		expect(nextBackgroundWidgetExpiryDelay(tasks, 15_000, 17_001)).toBeNull();
+
+		let refreshes = 0;
+		let scheduledDelay = 0;
+		let callback = () => {};
+		let clears = 0;
+		const timer = { unref() {} } as ReturnType<typeof setTimeout>;
+		const expiry = createBackgroundWidgetExpiryScheduler(
+			() => refreshes++,
+			(nextCallback, delay) => {
+				callback = nextCallback;
+				scheduledDelay = delay;
+				return timer;
+			},
+			() => clears++,
+		);
+		expiry.schedule(tasks, 15_000, 10_000);
+		expect(scheduledDelay).toBe(6_001);
+		callback();
+		expect(refreshes).toBe(1);
+		expiry.schedule(tasks, 15_000, 10_000);
+		expiry.clear();
+		expect(clears).toBe(1);
 	});
 });


### PR DESCRIPTION
## Summary

- Schedule a one-shot mini-dashboard refresh for the earliest finished-task retention deadline.
- Clear and reschedule the timer whenever widget state changes, and unregister the widget once no retained task remains.
- Cover deadline selection, refresh delivery, and timer cleanup.

## Reproduction

After a finished task passed `widgetFinishedRetentionSeconds`, an ordinary TUI render recalculated the visible task list as empty and displayed `0 running · 0 finished`. No task event refreshed the widget at the retention boundary, so it remained registered until another lifecycle event.

## Validation

- `bun test ./tests ./extensions/__tests__` — 174 passed
- `changelog-entries` — passed
- `size-ratchet` — passed
- `tools/guard` — native repository tests passed; local cross-target and UI checks could not run because this checkout lacks `rustup` and UI dependencies

Closes #2071.
