### PR TITLE
fix(KEN-1203): agent renders pass the format lane; nested shims committed

### DIFF
--- a/.codex/agents/generalist.toml
+++ b/.codex/agents/generalist.toml
@@ -27,6 +27,7 @@ What changed, what you verified it against, and anything you deliberately left f
 ## Required Skills
 
 Read each before acting:
+
 - code-quality: .agents/skills/code-quality/SKILL.md
 - decider: .agents/skills/decider/SKILL.md
 - dep-radar: .agents/skills/dep-radar/SKILL.md

--- a/.codex/agents/iced.toml
+++ b/.codex/agents/iced.toml
@@ -27,6 +27,7 @@ What changed, what you saw or asserted to verify it, and any framework invariant
 ## Required Skills
 
 Read each before acting:
+
 - code-quality: .agents/skills/code-quality/SKILL.md
 - decider: .agents/skills/decider/SKILL.md
 - dev: .agents/skills/dev/SKILL.md

--- a/.codex/agents/planner.toml
+++ b/.codex/agents/planner.toml
@@ -40,6 +40,7 @@ Write a file only when asked. Given no path, a technical plan goes to `docs/plan
 ## Required Skills
 
 Read each before acting:
+
 - github: .agents/skills/github/SKILL.md
 - linear: .agents/skills/linear/SKILL.md
 

--- a/.codex/agents/researcher.toml
+++ b/.codex/agents/researcher.toml
@@ -29,6 +29,7 @@ Provider-backed research and the report it produces. Not production code, not ar
 ## Required Skills
 
 Read each before acting:
+
 - decider: .agents/skills/decider/SKILL.md
 - deep-research: .agents/skills/deep-research/SKILL.md
 - github: .agents/skills/github/SKILL.md

--- a/.codex/agents/reviewer-arch.toml
+++ b/.codex/agents/reviewer-arch.toml
@@ -27,6 +27,7 @@ Architecture violations, boundary breaches, spec holes → `blockers[]`. Tech de
 ## Required Skills
 
 Read each before acting:
+
 - reviewer: .agents/skills/reviewer/SKILL.md
 
 ## Additional Instructions

--- a/.codex/agents/reviewer-correctness.toml
+++ b/.codex/agents/reviewer-correctness.toml
@@ -55,6 +55,7 @@ Regressions, boundary defects, compatibility/contract breaks, feature leaks, sta
 ## Required Skills
 
 Read each before acting:
+
 - reviewer: .agents/skills/reviewer/SKILL.md
 
 ## Additional Instructions

--- a/.codex/agents/reviewer-doc.toml
+++ b/.codex/agents/reviewer-doc.toml
@@ -30,6 +30,7 @@ Wrong claims, wrong values, dead citations, contradicted invariants → `blocker
 ## Required Skills
 
 Read each before acting:
+
 - reviewer: .agents/skills/reviewer/SKILL.md
 
 ## Additional Instructions

--- a/.codex/agents/reviewer-error.toml
+++ b/.codex/agents/reviewer-error.toml
@@ -38,6 +38,7 @@ Fail-open paths, silent failures, swallowed errors, wrong-cause diagnostics → 
 ## Required Skills
 
 Read each before acting:
+
 - reviewer: .agents/skills/reviewer/SKILL.md
 
 ## Additional Instructions

--- a/.codex/agents/reviewer-perf.toml
+++ b/.codex/agents/reviewer-perf.toml
@@ -26,6 +26,7 @@ Budget exceedances, classified regressions, hot-path cost introductions → `blo
 ## Required Skills
 
 Read each before acting:
+
 - reviewer: .agents/skills/reviewer/SKILL.md
 
 ## Additional Instructions

--- a/.codex/agents/reviewer-quality.toml
+++ b/.codex/agents/reviewer-quality.toml
@@ -33,6 +33,7 @@ Maintainability regressions, avoidable complexity, mechanism-level misses, god o
 ## Required Skills
 
 Read each before acting:
+
 - reviewer: .agents/skills/reviewer/SKILL.md
 
 ## Additional Instructions

--- a/.codex/agents/reviewer-safety.toml
+++ b/.codex/agents/reviewer-safety.toml
@@ -33,6 +33,7 @@ Safety violations, races, UB → `blockers[]`. Missing safety annotations, minor
 ## Required Skills
 
 Read each before acting:
+
 - reviewer: .agents/skills/reviewer/SKILL.md
 
 ## Additional Instructions

--- a/.codex/agents/reviewer-security.toml
+++ b/.codex/agents/reviewer-security.toml
@@ -29,6 +29,7 @@ Vulnerabilities, gating gaps, containment escapes, secret exposure → `blockers
 ## Required Skills
 
 Read each before acting:
+
 - reviewer: .agents/skills/reviewer/SKILL.md
 
 ## Additional Instructions

--- a/.codex/agents/reviewer-test.toml
+++ b/.codex/agents/reviewer-test.toml
@@ -34,6 +34,7 @@ Coverage gaps, vacuous tests, missing must-fail controls, unwired suites → `bl
 ## Required Skills
 
 Read each before acting:
+
 - reviewer: .agents/skills/reviewer/SKILL.md
 
 ## Additional Instructions

--- a/.codex/agents/rust.toml
+++ b/.codex/agents/rust.toml
@@ -30,6 +30,7 @@ The change, the measurement behind any performance claim, and every `unsafe` or 
 ## Required Skills
 
 Read each before acting:
+
 - code-quality: .agents/skills/code-quality/SKILL.md
 - decider: .agents/skills/decider/SKILL.md
 - dev: .agents/skills/dev/SKILL.md

--- a/.codex/agents/scout.toml
+++ b/.codex/agents/scout.toml
@@ -37,6 +37,7 @@ Answer four things: where the relevant code lives, how the key types and functio
 ## Required Skills
 
 Read each before acting:
+
 - github: .agents/skills/github/SKILL.md
 - linear: .agents/skills/linear/SKILL.md
 

--- a/.codex/agents/tpm.toml
+++ b/.codex/agents/tpm.toml
@@ -28,6 +28,7 @@ Findings the caller can act on without re-deriving them, structured as JSON when
 ## Required Skills
 
 Read each before acting:
+
 - decider: .agents/skills/decider/SKILL.md
 - dev: .agents/skills/dev/SKILL.md
 - github: .agents/skills/github/SKILL.md

--- a/changelog.d/fixed/KEN-1203-agent-render-list.md
+++ b/changelog.d/fixed/KEN-1203-agent-render-list.md
@@ -1,0 +1,1 @@
+- An agent's rendered Required Skills list is preceded by a blank line, so the render passes the markdown format lane every harness reads it under.

--- a/crates/app/CLAUDE.md
+++ b/crates/app/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/crates/cli/CLAUDE.md
+++ b/crates/cli/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/crates/core/CLAUDE.md
+++ b/crates/core/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -339,7 +339,7 @@ pub enum CoreError {
     /// Pi extensions are carrier-only: `add` never installs one. A scope
     /// declares the package in its manifest and `kendex update-pi` installs it.
     #[error(
-        "pi extension '{name}' is not installable on its own: declare it under [pi-extensions] in the scope's kendex.toml and run kendex update-pi"
+        "pi extension '{name}' is not installable on its own: declare it under [pi-extensions] in the scope's kendex.toml, then the update-pi verb installs it"
     )]
     PiExtensionDirect { name: String },
 

--- a/crates/core/src/render/agent/mod.rs
+++ b/crates/core/src/render/agent/mod.rs
@@ -248,7 +248,7 @@ pub fn skills_prose(agent: &EffectiveAgent, skill_root_hint: &str) -> Option<Str
     if agent.skills.is_empty() {
         return None;
     }
-    let mut out = String::from("## Required Skills\n\nRead each before acting:\n");
+    let mut out = String::from("## Required Skills\n\nRead each before acting:\n\n");
     for skill in &agent.skills {
         out.push_str(&format!("- {skill}: {skill_root_hint}/{skill}/SKILL.md\n"));
     }

--- a/hooks/CLAUDE.md
+++ b/hooks/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/pi-extensions/CLAUDE.md
+++ b/pi-extensions/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/skills/CLAUDE.md
+++ b/skills/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/ui/CLAUDE.md
+++ b/ui/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
The rendered Required Skills list gets its blank line so every harness's agent render passes md-format (the Pi renders were the only ones the reflow could not settle); the Pi extension refusal presents the update-pi verb as data (the one bot comment on #2076 that bites); the CLAUDE.md shims kendex writes beside each nested AGENTS.md are committed. Tracking: KEN-1203.

https://claude.ai/code/session_01LbVeBZNo3nBLtjiNcRG2JA