### PR TITLE
fix(KEN-1203): no shim inside a harness render tree

### DIFF
--- a/changelog.d/fixed/KEN-1203-shim-render-trees.md
+++ b/changelog.d/fixed/KEN-1203-shim-render-trees.md
@@ -1,0 +1,1 @@
+- The CLAUDE.md shim is written beside a project's own AGENTS.md files only; an AGENTS.md inside a harness render tree such as a rendered skill gets none.

--- a/crates/core/src/engine/instruction_shims/observe.rs
+++ b/crates/core/src/engine/instruction_shims/observe.rs
@@ -19,6 +19,22 @@ use crate::model::{HarnessId, Scope};
 /// git's refusal to answer is read for the one reason this pass expects —
 /// no repository here — and every other failure is the pass's own error:
 /// a repository git will not read is not a project with one file in it.
+/// Whether any directory on the relative path is a dot directory, the
+/// shape every harness keeps its render tree under.
+fn under_dot_directory(relative: &Path) -> bool {
+    relative
+        .parent()
+        .map(|dir| {
+            dir.components().any(|component| {
+                component
+                    .as_os_str()
+                    .to_str()
+                    .is_some_and(|name| name.starts_with('.'))
+            })
+        })
+        .unwrap_or(false)
+}
+
 pub(super) fn agents_files(root: &Path) -> Result<Vec<PathBuf>> {
     let nested = format!("*/{AGENTS_FILE}");
     let output = crate::guard::english(crate::process::Hardened::git(
@@ -50,6 +66,13 @@ pub(super) fn agents_files(root: &Path) -> Result<Vec<PathBuf>> {
         // so what counts as an instruction file is decided by this pass
         // and not by git's glob rules.
         if relative.file_name() != Some(OsStr::new(AGENTS_FILE)) {
+            continue;
+        }
+        // A harness render tree (`.agents`, `.claude`, `.codex`, `.pi`, and
+        // the rest) holds package payloads, and an `AGENTS.md` inside a
+        // rendered skill is that skill's content, not this project's
+        // instructions: no shim is owed there.
+        if under_dot_directory(&relative) {
             continue;
         }
         let path = root.join(relative);

--- a/crates/core/tests/instruction_shims.rs
+++ b/crates/core/tests/instruction_shims.rs
@@ -187,6 +187,22 @@ fn a_nested_tracked_agents_file_gets_its_own_shim() {
     assert!(plan(&f).plan.is_empty());
 }
 
+/// A render tree is a harness's, and an `AGENTS.md` inside a rendered
+/// skill is that skill's content: tracked or not, it gets no shim.
+#[test]
+fn an_agents_file_inside_a_render_tree_gets_no_shim() {
+    let f = fixture("\"claude\"", true);
+    let rendered = f.project.join(".agents/skills/vendored");
+    fs::create_dir_all(&rendered).unwrap();
+    fs::write(rendered.join("AGENTS.md"), "# a skill's own file\n").unwrap();
+    commit(&f.project);
+
+    let report = apply_now(&f);
+    assert_eq!(touched(&f, &report), ["CLAUDE.md"]);
+    assert!(!rendered.join("CLAUDE.md").exists());
+    assert!(plan(&f).plan.is_empty());
+}
+
 /// A directory git does not track is never walked: the nested file is
 /// ignored, and only the root one is served.
 #[test]


### PR DESCRIPTION
hyprtrade-io's propagation showed CLAUDE.md shims written beside AGENTS.md files inside vendored skill payloads under .agents/skills. An AGENTS.md under a dot directory is a package's content, not the project's instructions, so no shim is owed there. Tracking: KEN-1203.

https://claude.ai/code/session_01LbVeBZNo3nBLtjiNcRG2JA