### PR TITLE
fix(KEN-1204): hook prose one paragraph per line; prose honours excludes

### DIFF
--- a/.agents/skills/growth-guards/CHECKS.md
+++ b/.agents/skills/growth-guards/CHECKS.md
@@ -82,7 +82,7 @@ Lines joined with CR stripped, whitespace runs collapsed to one space, trimmed, 
 
 A history reference in a scanned markdown file fails: a calendar date (`20YY-MM-DD`), a three- or four-digit issue number after `#`, or one of `previously`, `used to`, `no longer`, `reverted`, `an earlier`, `earlier round`, `incident`, `historically`, `originally`, `at the time`. Matching is case-insensitive and whole-word (`incidental`, `unreverted` do not fire). The issue-number shape takes no leading boundary (`<file>.md#1204` fires), and the character after the digits must be neither a digit nor a hex letter (`#12345`, `#1234ab`, `#0088cc` pass). A decision ID (`D042`) carries no `#` and never fires.
 
-Scope is `GROWTH_GUARDS_PROSE_PATHS`; there is no excludes list. `docs/architecture/*.md` joins the default only under `GROWTH_GUARDS_MD_SCOPE=all`, the switch a repository flips once its markdown is rewritten; an explicit path list is used as given. The default, each name spelled twice because `*` crosses `/` but never stands in for the separator:
+Scope is `GROWTH_GUARDS_PROSE_PATHS` minus `GROWTH_GUARDS_MD_EXCLUDES`, the exclusion list the markdown lanes read, so a vendored skill under a render tree is carved out with a reason rather than by narrowing the scan. `docs/architecture/*.md` joins the default only under `GROWTH_GUARDS_MD_SCOPE=all`, the switch a repository flips once its markdown is rewritten; an explicit path list is used as given. The default, each name spelled twice because `*` crosses `/` but never stands in for the separator:
 
 ```
 SKILL.md */SKILL.md AGENTS.md */AGENTS.md CLAUDE.md */CLAUDE.md workflows/*.md */workflows/*.md agents/*.md */agents/*.md docs/architecture/*.md

--- a/.agents/skills/growth-guards/scripts/prose
+++ b/.agents/skills/growth-guards/scripts/prose
@@ -65,6 +65,9 @@ kendex.settings.toml [env] > default):
                               repo-relative path, '*' crossing '/' as in the
                               excludes lists
                               (default $PATHS_DEFAULT)
+  GROWTH_GUARDS_MD_EXCLUDES   exclusion list, pattern<TAB>reason per line,
+                              shared with md-format and md-refs
+                              (default tools/md-excludes)
 
 Exit codes: 0 clean; 1 violations; 2 usage/config/collection error.
 EOF
@@ -94,6 +97,11 @@ PATHS_RAW="$(gg_setting GROWTH_GUARDS_PROSE_PATHS "$PATHS_DEFAULT")" || exit 2
 # the sibling lane scoped the same way: lib/configured-paths.sh § configured
 # path globs.
 gg_load_path_globs "$PATHS_RAW" prose GROWTH_GUARDS_PROSE_PATHS || exit 2
+# The markdown lanes' exclusion list, honoured here for the same reason: a
+# vendored skill under a render tree matches `*/SKILL.md` and its body is
+# not this repository's to edit.
+EXCLUDES="$(gg_resolve_path "" GROWTH_GUARDS_MD_EXCLUDES tools/md-excludes excludes)" || exit 2
+gg_load_excludes "$EXCLUDES"
 
 # History, and only history. The word list is the drift this catches in
 # practice: a rule that reaches for one of them is narrating a change rather

--- a/.agents/skills/growth-guards/tests/prose.test.sh
+++ b/.agents/skills/growth-guards/tests/prose.test.sh
@@ -146,6 +146,21 @@ run_prose
   && ok "README, CHECKS, docs, CHANGELOG, references and a workflows-named file keep their history, with the ten scoped files still read" \
   || bad "out-of-scope files keep their history" "rc=$RC out=$OUT"
 
+echo "=== the markdown excludes list carves a vendored skill out ==="
+new_repo excluded
+put SKILL.md 'clean'
+put .agents/skills/vendored/SKILL.md 'Seeded 2026-08-12.'
+run_prose
+[ "$RC" -eq 1 ] && case "$OUT" in *"history reference: .agents/skills/vendored/SKILL.md:1:"*) true ;; *) false ;; esac \
+  && ok "control: a vendored skill is scanned before it is excluded" || bad "control: vendored skill scanned" "rc=$RC out=$OUT"
+mkdir -p "$R/tools"
+printf '.agents/skills/vendored/**\tthird-party skill pinned by hash\n' >"$R/tools/md-excludes"
+git -C "$R" add tools/md-excludes
+run_prose
+[ "$RC" -eq 0 ] && ok "an excludes row carves the vendored skill out of the prose scan" \
+  || bad "excludes row honoured" "rc=$RC out=$OUT"
+git -C "$R" rm -qf tools/md-excludes
+
 echo "=== GROWTH_GUARDS_PROSE_PATHS REPLACES the list (and that is provable) ==="
 new_repo override
 put SKILL.md 'Seeded 2026-08-12.'

--- a/changelog.d/fixed/KEN-1204.md
+++ b/changelog.d/fixed/KEN-1204.md
@@ -1,0 +1,1 @@
+- A hook's advisory instruction file (OpenCode, Cursor) renders one paragraph per line with blank lines between, so a fresh install passes the md-format lane.

--- a/changelog.d/fixed/KEN-1205.md
+++ b/changelog.d/fixed/KEN-1205.md
@@ -1,0 +1,1 @@
+- The prose lane honours `GROWTH_GUARDS_MD_EXCLUDES`, so a vendored third-party skill is carved out with a reason instead of by narrowing the scan paths.

--- a/crates/core/src/hook/spec.rs
+++ b/crates/core/src/hook/spec.rs
@@ -84,10 +84,12 @@ impl HookSpec {
     /// Advisory prose for harnesses without native hook support (codex
     /// unmapped events, cursor rules).
     pub fn safety_prose(&self) -> String {
-        let mut prose = format!("**Safety: {}**\n", self.description);
+        // One paragraph per line with a blank line between paragraphs, the
+        // shape the markdown format lane holds every rendered file to.
+        let mut prose = format!("**Safety: {}**\n\n", self.description);
         if let Some(safety) = &self.safety {
             prose.push_str(safety);
-            prose.push('\n');
+            prose.push_str("\n\n");
         }
         let action = match self.event.as_str() {
             "PreToolUse" => "Before executing",

--- a/skills/growth-guards/CHECKS.md
+++ b/skills/growth-guards/CHECKS.md
@@ -82,7 +82,7 @@ Lines joined with CR stripped, whitespace runs collapsed to one space, trimmed, 
 
 A history reference in a scanned markdown file fails: a calendar date (`20YY-MM-DD`), a three- or four-digit issue number after `#`, or one of `previously`, `used to`, `no longer`, `reverted`, `an earlier`, `earlier round`, `incident`, `historically`, `originally`, `at the time`. Matching is case-insensitive and whole-word (`incidental`, `unreverted` do not fire). The issue-number shape takes no leading boundary (`<file>.md#1204` fires), and the character after the digits must be neither a digit nor a hex letter (`#12345`, `#1234ab`, `#0088cc` pass). A decision ID (`D042`) carries no `#` and never fires.
 
-Scope is `GROWTH_GUARDS_PROSE_PATHS`; there is no excludes list. `docs/architecture/*.md` joins the default only under `GROWTH_GUARDS_MD_SCOPE=all`, the switch a repository flips once its markdown is rewritten; an explicit path list is used as given. The default, each name spelled twice because `*` crosses `/` but never stands in for the separator:
+Scope is `GROWTH_GUARDS_PROSE_PATHS` minus `GROWTH_GUARDS_MD_EXCLUDES`, the exclusion list the markdown lanes read, so a vendored skill under a render tree is carved out with a reason rather than by narrowing the scan. `docs/architecture/*.md` joins the default only under `GROWTH_GUARDS_MD_SCOPE=all`, the switch a repository flips once its markdown is rewritten; an explicit path list is used as given. The default, each name spelled twice because `*` crosses `/` but never stands in for the separator:
 
 ```
 SKILL.md */SKILL.md AGENTS.md */AGENTS.md CLAUDE.md */CLAUDE.md workflows/*.md */workflows/*.md agents/*.md */agents/*.md docs/architecture/*.md

--- a/skills/growth-guards/scripts/prose
+++ b/skills/growth-guards/scripts/prose
@@ -65,6 +65,9 @@ kendex.settings.toml [env] > default):
                               repo-relative path, '*' crossing '/' as in the
                               excludes lists
                               (default $PATHS_DEFAULT)
+  GROWTH_GUARDS_MD_EXCLUDES   exclusion list, pattern<TAB>reason per line,
+                              shared with md-format and md-refs
+                              (default tools/md-excludes)
 
 Exit codes: 0 clean; 1 violations; 2 usage/config/collection error.
 EOF
@@ -94,6 +97,11 @@ PATHS_RAW="$(gg_setting GROWTH_GUARDS_PROSE_PATHS "$PATHS_DEFAULT")" || exit 2
 # the sibling lane scoped the same way: lib/configured-paths.sh § configured
 # path globs.
 gg_load_path_globs "$PATHS_RAW" prose GROWTH_GUARDS_PROSE_PATHS || exit 2
+# The markdown lanes' exclusion list, honoured here for the same reason: a
+# vendored skill under a render tree matches `*/SKILL.md` and its body is
+# not this repository's to edit.
+EXCLUDES="$(gg_resolve_path "" GROWTH_GUARDS_MD_EXCLUDES tools/md-excludes excludes)" || exit 2
+gg_load_excludes "$EXCLUDES"
 
 # History, and only history. The word list is the drift this catches in
 # practice: a rule that reaches for one of them is narrating a change rather

--- a/skills/growth-guards/tests/prose.test.sh
+++ b/skills/growth-guards/tests/prose.test.sh
@@ -146,6 +146,21 @@ run_prose
   && ok "README, CHECKS, docs, CHANGELOG, references and a workflows-named file keep their history, with the ten scoped files still read" \
   || bad "out-of-scope files keep their history" "rc=$RC out=$OUT"
 
+echo "=== the markdown excludes list carves a vendored skill out ==="
+new_repo excluded
+put SKILL.md 'clean'
+put .agents/skills/vendored/SKILL.md 'Seeded 2026-08-12.'
+run_prose
+[ "$RC" -eq 1 ] && case "$OUT" in *"history reference: .agents/skills/vendored/SKILL.md:1:"*) true ;; *) false ;; esac \
+  && ok "control: a vendored skill is scanned before it is excluded" || bad "control: vendored skill scanned" "rc=$RC out=$OUT"
+mkdir -p "$R/tools"
+printf '.agents/skills/vendored/**\tthird-party skill pinned by hash\n' >"$R/tools/md-excludes"
+git -C "$R" add tools/md-excludes
+run_prose
+[ "$RC" -eq 0 ] && ok "an excludes row carves the vendored skill out of the prose scan" \
+  || bad "excludes row honoured" "rc=$RC out=$OUT"
+git -C "$R" rm -qf tools/md-excludes
+
 echo "=== GROWTH_GUARDS_PROSE_PATHS REPLACES the list (and that is provable) ==="
 new_repo override
 put SKILL.md 'Seeded 2026-08-12.'


### PR DESCRIPTION
KEN-1204: a hook's advisory instruction file (OpenCode, Cursor) renders with a blank line between its paragraphs, so a fresh install passes the md-format lane. KEN-1205: the prose lane reads GROWTH_GUARDS_MD_EXCLUDES like the markdown lanes, so a vendored third-party skill is carved out with a reason instead of by narrowing the scan. Both found by kendex-web's onboarding under KEN-1203.

https://claude.ai/code/session_01LbVeBZNo3nBLtjiNcRG2JA