### PR TITLE
fix(growth-guards): allow oversized files to shrink

### DIFF
--- a/.agents/skills/growth-guards/CHECKS.md
+++ b/.agents/skills/growth-guards/CHECKS.md
@@ -17,10 +17,10 @@ Comment leaders: `//`, `#`, `;`, `/*`, `<!--`. A marker immediately preceded by 
 
 ## byte-ceiling
 
-A tracked file a change puts over `GROWTH_GUARDS_BYTE_CEILING_KB` (KB = 1024 bytes) fails; size is the blob's object size. Exempt by exact basename: `Cargo.lock`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lock`, `bun.lockb`, `flake.lock`, `poetry.lock`, `uv.lock`, `Pipfile.lock`, `Gemfile.lock`, `composer.lock`, `go.sum`, `gradle.lockfile`, `packages.lock.json`, `Package.resolved`. Asset trees go in `GROWTH_GUARDS_BYTE_EXCLUDES`, overridden by `--excludes FILE`.
+A tracked file a change puts over `GROWTH_GUARDS_BYTE_CEILING_KB` (KB = 1024 bytes) fails; size is the blob's object size. An existing file already over the ceiling may stay the same size or shrink, but may not grow. Exempt by exact basename: `Cargo.lock`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lock`, `bun.lockb`, `flake.lock`, `poetry.lock`, `uv.lock`, `Pipfile.lock`, `Gemfile.lock`, `composer.lock`, `go.sum`, `gradle.lockfile`, `packages.lock.json`, `Package.resolved`. Asset trees go in `GROWTH_GUARDS_BYTE_EXCLUDES`, overridden by `--excludes FILE`.
 
 - `--staged` (default): files added, modified or type-changed in the staged diff, renames held to exact content.
-- `--base REF`: files added since the merge-base with REF.
+- `--base REF`: files added, modified or type-changed since the merge-base with REF.
 - `--all`: every tracked file.
 
 A copy is an addition; symlinks and gitlinks are not sized.

--- a/.agents/skills/growth-guards/DEVELOPMENT.md
+++ b/.agents/skills/growth-guards/DEVELOPMENT.md
@@ -70,7 +70,7 @@ Stated once, in CHECKS.md § todo-ban. At `--staged` the change set is collected
 
 ## byte-ceiling sizing
 
-Sizes are `git cat-file -s` of the recorded blob. Rename detection is pinned on, held to exact content in the staged lane; `--base` reads additions alone.
+Sizes are `git cat-file -s` of the diff's source and destination blobs. The source size is the tighten-only baseline when it already exceeds the ceiling. Rename detection is pinned on and held to exact content in the staged and base lanes.
 
 ## suppression-ban patterns
 

--- a/.agents/skills/growth-guards/README.md
+++ b/.agents/skills/growth-guards/README.md
@@ -13,7 +13,7 @@ Needs `git`, `awk` and the usual POSIX userland; Bash 3.2 is enough. `kendex gua
 
 ## What it does
 
-- Refuses work markers, oversized additions, blanket lint suppression and conflict markers.
+- Refuses work markers, new oversized files, growth in existing oversized files, blanket lint suppression and conflict markers.
 - Holds changelog fragments to shape and length, and refuses hand edits to the collated record.
 - Holds the markdown agents load to one paragraph per line, with no dead references and no history prose.
 - Optionally holds source comments to the same no-history rule.
@@ -36,7 +36,7 @@ The `pre-commit` hook judges one commit snapshot and `commit-msg` runs the messa
 
 The markdown lanes start narrow: `md-format` and `md-refs` judge the files a commit touches. Reflow the tree once with `scripts/md-reflow --all`, commit, then set `GROWTH_GUARDS_MD_SCOPE = "all"` so CI judges every tracked markdown file. Vendored or generated markdown goes in `tools/md-excludes` with a reason.
 
-In CI, run the batch without `--staged`: the index-wide `todo-ban` scan is the only lane that sees a marker no commit ever diffed. `byte-ceiling --base origin/main` gates a PR's additions.
+In CI, run the batch without `--staged`: the index-wide `todo-ban` scan is the only lane that sees a marker no commit ever diffed. `byte-ceiling --base origin/main` gates a PR's additions and file-size growth.
 
 ## Who gates a commit
 

--- a/.agents/skills/growth-guards/SKILL.md
+++ b/.agents/skills/growth-guards/SKILL.md
@@ -53,7 +53,7 @@ Problems with a kendex-owned skill go through `kendex report`; check ownership i
 | Check | Verdict |
 |---|---|
 | **todo-ban** | Any work marker (TODO, FIXME, HACK, XXX in comment-marker shapes) in a tracked, non-excluded file fails. No baseline. |
-| **byte-ceiling** | A tracked file over the configured ceiling fails; lockfiles are exempt. |
+| **byte-ceiling** | A new tracked file over the configured ceiling fails; an existing oversized file may hold or shrink but may not grow; lockfiles are exempt. |
 | **suppression-ban** | Blanket lint suppressions fail; reasonless Rust dead or unused allows may only tighten against the baseline. |
 | **conflict-markers** | An unresolved merge-conflict marker in a tracked, non-excluded file fails. |
 | **changelog-entries** | Each `GROWTH_GUARDS_CHANGELOG_PATHS` fragment is one Markdown list item in a Keep a Changelog section and at most `GROWTH_GUARDS_CHANGELOG_CAP` characters. |

--- a/.agents/skills/growth-guards/kendex.settings.toml.example
+++ b/.agents/skills/growth-guards/kendex.settings.toml.example
@@ -12,8 +12,8 @@
 GROWTH_GUARDS_CHECKS = "todo-ban byte-ceiling suppression-ban conflict-markers changelog-entries prose md-format md-refs"
 
 # Kilobytes a single tracked file may reach before byte-ceiling refuses it.
-# Declared asset trees are exempted through GROWTH_GUARDS_BYTE_EXCLUDES
-# rather than by raising this.
+# Existing files already above it may hold or shrink, but may not grow.
+# Declared asset trees are exempted through GROWTH_GUARDS_BYTE_EXCLUDES.
 GROWTH_GUARDS_BYTE_CEILING_KB = "200"
 
 # The changelog-entries fragment tree: a space-separated list of shell globs

--- a/.agents/skills/growth-guards/scripts/byte-ceiling
+++ b/.agents/skills/growth-guards/scripts/byte-ceiling
@@ -1,20 +1,22 @@
 #!/usr/bin/env bash
 # byte-ceiling — tracked files a change puts over the byte ceiling fail
-# (default 200 KB). Growth-oriented like size-ratchet: what a change TOUCHES
-# is gated by the default modes, so adoption needs no cleanup first.
+# (default 200 KB). A touched file already over the ceiling may stay the
+# same size or shrink, so adoption does not freeze the work that reduces it.
 #
 # Modes (mutually exclusive):
 #   --staged (default)  files added, changed, or type-changed in the staged
 #                       diff (the pre-commit shim). A committed file edited
 #                       past the ceiling arrives the same way a new one does,
 #                       so the staged lane judges both.
-#   --base REF          files added since merge-base with REF (CI on a PR)
+#   --base REF          files added, changed, or type-changed since the
+#                       merge-base with REF (CI on a PR)
 #   --all               every tracked file (full sweep)
 #
-# Sizes are OBJECT sizes (`git cat-file -s` of the added blob): the bytes that
-# enter history, filters applied, independent of worktree state. Renames are
-# detected, so moving an existing large file is not an addition; a copy is
-# one. Exit codes: 0 clean; 1 violations; 2 usage/config/collection error.
+# Sizes are OBJECT sizes (`git cat-file -s` of each diff blob): the bytes that
+# enter history, filters applied, independent of worktree state. The source
+# blob is the tighten-only baseline for an existing oversized file. Renames
+# are detected, so moving an existing large file is not an addition; a copy
+# is one. Exit codes: 0 clean; 1 violations; 2 usage/config/collection error.
 set -euo pipefail
 
 GG_BOOT="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd; printf x)"
@@ -31,10 +33,12 @@ usage() {
   cat <<'EOF'
 usage: byte-ceiling [--staged | --base REF | --all] [--excludes FILE]
 
-Tracked files a change puts over the byte ceiling fail. --staged (default)
-checks the staged additions and changes; --base REF checks files added since
-the merge-base with REF; --all sweeps every tracked file. Lockfiles are
-exempt built-in; declared asset trees live in the excludes list.
+Tracked files a change puts over the byte ceiling fail. An existing file
+already over the ceiling may stay the same size or shrink, but may not grow.
+--staged (default) checks the staged additions and changes; --base REF checks
+additions and changes since the merge-base with REF; --all sweeps every
+tracked file. Lockfiles are exempt built-in; declared asset trees live in the
+excludes list.
 
 Configuration (env > .env.local > .kendex/settings.toml >
 kendex.settings.toml [env] > default):
@@ -100,13 +104,13 @@ is_lockfile() { # PATH
 
 gg_tmpdir
 
-# Alternating NUL-terminated fields, sha NUL path NUL: no single-record
-# separator survives arbitrary paths. The SHA is the added blob itself, so
-# measuring needs no path re-quoting.
+# Alternating NUL-terminated fields, destination SHA NUL source SHA NUL source
+# mode NUL path NUL: no single-record separator survives arbitrary paths. The
+# SHAs are the diff blobs themselves, so measuring needs no path re-quoting.
 : >"$GG_TMP/candidates.z"
 
-emit_candidate() { # SHA PATH
-  printf '%s\0%s\0' "$1" "$2" >>"$GG_TMP/candidates.z"
+emit_candidate() { # DEST-SHA SOURCE-SHA SOURCE-MODE PATH
+  printf '%s\0%s\0%s\0%s\0' "$1" "$2" "$3" "$4" >>"$GG_TMP/candidates.z"
 }
 
 case "$MODE" in
@@ -128,7 +132,7 @@ case "$MODE" in
     ;;
   base)
     git rev-parse --verify --quiet "$BASE_REF^{commit}" >/dev/null || gg_config_error "--base ref '$BASE_REF' does not name a commit"
-    git -c diff.renames=true diff --raw --no-abbrev -z --diff-filter=A "$BASE_REF...HEAD" >"$GG_TMP/raw.z" || gg_collection_error "git diff $BASE_REF...HEAD failed collecting added files (no merge base?)"
+    git -c diff.renames=true diff --raw --no-abbrev -z --find-renames=100% --diff-filter=AMT "$BASE_REF...HEAD" >"$GG_TMP/raw.z" || gg_collection_error "git diff $BASE_REF...HEAD failed collecting additions and changes (no merge base?)"
     ;;
   all)
     # ls-files -s emits one record per STAGE for an unmerged path, so the
@@ -144,7 +148,7 @@ case "$MODE" in
       case "$mode" in
         120000 | 160000) continue ;; # symlink / submodule gitlink — not sized content
       esac
-      emit_candidate "$sha" "$f"
+      emit_candidate "$sha" "" "" "$f"
     done <"$GG_TMP/files.z"
     ;;
 esac
@@ -155,7 +159,9 @@ if [ "$MODE" != "all" ]; then
   # diff-filter, none of which renames a path, so each record carries one.
   while IFS= read -r -d '' meta && IFS= read -r -d '' f; do
     set -- $meta
+    srcmode="${1#:}"
     dstmode="$2"
+    srcsha="$3"
     dstsha="$4"
     case "$dstmode" in
       120000 | 160000) continue ;; # symlink / submodule gitlink
@@ -164,20 +170,34 @@ if [ "$MODE" != "all" ]; then
       *[!0]*) ;;
       *) gg_collection_error "'$f' has no destination blob in the diff record — cannot measure it" ;;
     esac
-    emit_candidate "$dstsha" "$f"
+    emit_candidate "$dstsha" "$srcsha" "$srcmode" "$f"
   done <"$GG_TMP/raw.z"
 fi
 
 checked=0
 violations=0
-while IFS= read -r -d '' sha && IFS= read -r -d '' f; do
+while IFS= read -r -d '' sha \
+  && IFS= read -r -d '' srcsha \
+  && IFS= read -r -d '' srcmode \
+  && IFS= read -r -d '' f; do
   is_lockfile "$f" && continue
   gg_is_excluded "$f" && continue
   size="$(git cat-file -s "$sha")" || gg_collection_error "cannot read blob $sha for '$f' — its size is unmeasurable, refusing to skip it"
   checked=$((checked + 1))
   if [ "$size" -gt "$CEILING_BYTES" ]; then
+    prior_size=""
+    if gg_mode_is_regular "$srcmode"; then
+      prior_size="$(git cat-file -s "$srcsha")" || gg_collection_error "cannot read prior blob $srcsha for '$f' — its size is unmeasurable, refusing to skip it"
+    fi
+    if [ -n "$prior_size" ] && [ "$prior_size" -gt "$CEILING_BYTES" ] && [ "$size" -le "$prior_size" ]; then
+      continue
+    fi
     kb=$(((size + 1023) / 1024))
-    echo "byte-ceiling FAIL oversized file: $f — $size bytes (~$kb KB) > ceiling $CEILING_KB KB"
+    if [ -n "$prior_size" ] && [ "$prior_size" -gt "$CEILING_BYTES" ]; then
+      echo "byte-ceiling FAIL oversized file grew: $f — $prior_size -> $size bytes (~$kb KB), ceiling $CEILING_KB KB"
+    else
+      echo "byte-ceiling FAIL oversized file: $f — $size bytes (~$kb KB) > ceiling $CEILING_KB KB"
+    fi
     echo "  remedies: keep big artifacts out of the repo (asset store, Git LFS, build-time generation); a file that genuinely belongs gets a row in $EXCLUDES_FILE with its reason"
     violations=$((violations + 1))
   fi
@@ -185,7 +205,7 @@ done <"$GG_TMP/candidates.z"
 
 case "$MODE" in
   staged) SCOPE_DESC="staged file(s)" ;;
-  base) SCOPE_DESC="file(s) added since $BASE_REF" ;;
+  base) SCOPE_DESC="file(s) added or changed since $BASE_REF" ;;
   all) SCOPE_DESC="tracked file(s) (full sweep)" ;;
 esac
 

--- a/.agents/skills/growth-guards/tests/byte-ceiling.test.sh
+++ b/.agents/skills/growth-guards/tests/byte-ceiling.test.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
-# Pins for scripts/byte-ceiling: additions over the ceiling fail in every
-# mode, diff-scoping really is addition-only (modifications and renames
-# pass), lockfiles and excluded trees are exempt (each with a control
-# proving the exemption is what passed it), configuration resolves, and a
-# broken measurement is a collection error — never a pass.
+# Pins for scripts/byte-ceiling: additions and growth over the ceiling fail,
+# an existing oversized file may hold or shrink, renames pass, lockfiles and
+# excluded trees are exempt, configuration resolves, and a broken measurement
+# is a collection error — never a pass.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -97,6 +96,29 @@ git -C "$R" commit -qm "grow it past the ceiling"
 run_bc
 [ "$RC" -eq 0 ] && ok "a committed oversized file is not re-judged while nothing stages it" \
   || bad "a committed oversized file is not re-judged while nothing stages it" "rc=$RC out=$OUT"
+mkbytes seed.bin 4
+git -C "$R" add -A
+run_bc
+[ "$RC" -eq 0 ] && ok "a staged oversized file may shrink toward the ceiling" \
+  || bad "a staged oversized file may shrink toward the ceiling" "rc=$RC out=$OUT"
+run_bc
+[ "$RC" -eq 0 ] && ok "the same staged shrink gives a stable clean verdict" \
+  || bad "the same staged shrink gives a stable clean verdict" "rc=$RC out=$OUT"
+mkbytes seed.bin 5
+printf 'x' >>"$R/seed.bin"
+git -C "$R" add -A
+run_bc
+[ "$RC" -eq 1 ] && case "$OUT" in *"oversized file grew: seed.bin"*"5120 -> 5121 bytes"*) true ;; *) false ;; esac \
+  && ok "an existing oversized file may not grow" \
+  || bad "an existing oversized file may not grow" "rc=$RC out=$OUT"
+mkbytes seed.bin 5
+printf 'y' | dd of="$R/seed.bin" bs=1 seek=0 conv=notrunc 2>/dev/null
+git -C "$R" add -A
+run_bc
+[ "$RC" -eq 0 ] && ok "an existing oversized file may change without increasing its size" \
+  || bad "an existing oversized file may hold its size" "rc=$RC out=$OUT"
+mkbytes seed.bin 5
+git -C "$R" add -A
 git -C "$R" mv seed.bin moved.bin
 run_bc
 [ "$RC" -eq 0 ] && ok "renaming an existing large file is not an addition (rename detection pinned on)" \
@@ -168,13 +190,27 @@ run_bc --all
 [ "$RC" -eq 1 ] && case "$OUT" in *"old.bin"*"full sweep"*) true ;; *) false ;; esac \
   && ok "--all fails on the legacy oversized file" || bad "--all fails on legacy" "rc=$RC out=$OUT"
 
-echo "=== --base REF: additions since the merge-base ==="
+echo "=== --base REF: additions and changes since the merge-base ==="
 git -C "$R" checkout -qb feature
+mkbytes old.bin 3
+git -C "$R" add -A
+git -C "$R" commit -qm "feature shrinks the legacy file"
+run_bc --base main
+[ "$RC" -eq 0 ] && case "$OUT" in *"added or changed since main"*) true ;; *) false ;; esac \
+  && ok "--base main permits a legacy oversized file to shrink" \
+  || bad "--base permits a legacy oversized file to shrink" "rc=$RC out=$OUT"
+mkbytes old.bin 5
+git -C "$R" add -A
+git -C "$R" commit -qm "feature grows the legacy file"
+run_bc --base main
+[ "$RC" -eq 1 ] && case "$OUT" in *"oversized file grew: old.bin"*"4096 -> 5120 bytes"*) true ;; *) false ;; esac \
+  && ok "--base main rejects growth from the merge-base size" \
+  || bad "--base rejects growth from the merge-base size" "rc=$RC out=$OUT"
 mkbytes feat.bin 2
 git -C "$R" add -A
 git -C "$R" commit -qm "feature adds an oversized file"
 run_bc --base main
-[ "$RC" -eq 1 ] && case "$OUT" in *"feat.bin"*"added since main"*) true ;; *) false ;; esac \
+[ "$RC" -eq 1 ] && case "$OUT" in *"feat.bin"*"added or changed since main"*) true ;; *) false ;; esac \
   && ok "--base main fails on the branch's added file" || bad "--base fails on the added file" "rc=$RC out=$OUT"
 git -C "$R" checkout -q main
 run_bc --base main

--- a/changelog.d/fixed/2090.md
+++ b/changelog.d/fixed/2090.md
@@ -1,0 +1,1 @@
+- Let existing oversized files hold their size or shrink while the byte ceiling still rejects new oversized files and further growth.

--- a/skills/growth-guards/CHECKS.md
+++ b/skills/growth-guards/CHECKS.md
@@ -17,10 +17,10 @@ Comment leaders: `//`, `#`, `;`, `/*`, `<!--`. A marker immediately preceded by 
 
 ## byte-ceiling
 
-A tracked file a change puts over `GROWTH_GUARDS_BYTE_CEILING_KB` (KB = 1024 bytes) fails; size is the blob's object size. Exempt by exact basename: `Cargo.lock`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lock`, `bun.lockb`, `flake.lock`, `poetry.lock`, `uv.lock`, `Pipfile.lock`, `Gemfile.lock`, `composer.lock`, `go.sum`, `gradle.lockfile`, `packages.lock.json`, `Package.resolved`. Asset trees go in `GROWTH_GUARDS_BYTE_EXCLUDES`, overridden by `--excludes FILE`.
+A tracked file a change puts over `GROWTH_GUARDS_BYTE_CEILING_KB` (KB = 1024 bytes) fails; size is the blob's object size. An existing file already over the ceiling may stay the same size or shrink, but may not grow. Exempt by exact basename: `Cargo.lock`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lock`, `bun.lockb`, `flake.lock`, `poetry.lock`, `uv.lock`, `Pipfile.lock`, `Gemfile.lock`, `composer.lock`, `go.sum`, `gradle.lockfile`, `packages.lock.json`, `Package.resolved`. Asset trees go in `GROWTH_GUARDS_BYTE_EXCLUDES`, overridden by `--excludes FILE`.
 
 - `--staged` (default): files added, modified or type-changed in the staged diff, renames held to exact content.
-- `--base REF`: files added since the merge-base with REF.
+- `--base REF`: files added, modified or type-changed since the merge-base with REF.
 - `--all`: every tracked file.
 
 A copy is an addition; symlinks and gitlinks are not sized.

--- a/skills/growth-guards/DEVELOPMENT.md
+++ b/skills/growth-guards/DEVELOPMENT.md
@@ -70,7 +70,7 @@ Stated once, in CHECKS.md § todo-ban. At `--staged` the change set is collected
 
 ## byte-ceiling sizing
 
-Sizes are `git cat-file -s` of the recorded blob. Rename detection is pinned on, held to exact content in the staged lane; `--base` reads additions alone.
+Sizes are `git cat-file -s` of the diff's source and destination blobs. The source size is the tighten-only baseline when it already exceeds the ceiling. Rename detection is pinned on and held to exact content in the staged and base lanes.
 
 ## suppression-ban patterns
 

--- a/skills/growth-guards/README.md
+++ b/skills/growth-guards/README.md
@@ -13,7 +13,7 @@ Needs `git`, `awk` and the usual POSIX userland; Bash 3.2 is enough. `kendex gua
 
 ## What it does
 
-- Refuses work markers, oversized additions, blanket lint suppression and conflict markers.
+- Refuses work markers, new oversized files, growth in existing oversized files, blanket lint suppression and conflict markers.
 - Holds changelog fragments to shape and length, and refuses hand edits to the collated record.
 - Holds the markdown agents load to one paragraph per line, with no dead references and no history prose.
 - Optionally holds source comments to the same no-history rule.
@@ -36,7 +36,7 @@ The `pre-commit` hook judges one commit snapshot and `commit-msg` runs the messa
 
 The markdown lanes start narrow: `md-format` and `md-refs` judge the files a commit touches. Reflow the tree once with `scripts/md-reflow --all`, commit, then set `GROWTH_GUARDS_MD_SCOPE = "all"` so CI judges every tracked markdown file. Vendored or generated markdown goes in `tools/md-excludes` with a reason.
 
-In CI, run the batch without `--staged`: the index-wide `todo-ban` scan is the only lane that sees a marker no commit ever diffed. `byte-ceiling --base origin/main` gates a PR's additions.
+In CI, run the batch without `--staged`: the index-wide `todo-ban` scan is the only lane that sees a marker no commit ever diffed. `byte-ceiling --base origin/main` gates a PR's additions and file-size growth.
 
 ## Who gates a commit
 

--- a/skills/growth-guards/SKILL.md
+++ b/skills/growth-guards/SKILL.md
@@ -45,7 +45,7 @@ repo-effects:
 | Check | Verdict |
 |---|---|
 | **todo-ban** | Any work marker (TODO, FIXME, HACK, XXX in comment-marker shapes) in a tracked, non-excluded file fails. No baseline. |
-| **byte-ceiling** | A tracked file over the configured ceiling fails; lockfiles are exempt. |
+| **byte-ceiling** | A new tracked file over the configured ceiling fails; an existing oversized file may hold or shrink but may not grow; lockfiles are exempt. |
 | **suppression-ban** | Blanket lint suppressions fail; reasonless Rust dead or unused allows may only tighten against the baseline. |
 | **conflict-markers** | An unresolved merge-conflict marker in a tracked, non-excluded file fails. |
 | **changelog-entries** | Each `GROWTH_GUARDS_CHANGELOG_PATHS` fragment is one Markdown list item in a Keep a Changelog section and at most `GROWTH_GUARDS_CHANGELOG_CAP` characters. |

--- a/skills/growth-guards/kendex.settings.toml.example
+++ b/skills/growth-guards/kendex.settings.toml.example
@@ -12,8 +12,8 @@
 GROWTH_GUARDS_CHECKS = "todo-ban byte-ceiling suppression-ban conflict-markers changelog-entries prose md-format md-refs"
 
 # Kilobytes a single tracked file may reach before byte-ceiling refuses it.
-# Declared asset trees are exempted through GROWTH_GUARDS_BYTE_EXCLUDES
-# rather than by raising this.
+# Existing files already above it may hold or shrink, but may not grow.
+# Declared asset trees are exempted through GROWTH_GUARDS_BYTE_EXCLUDES.
 GROWTH_GUARDS_BYTE_CEILING_KB = "200"
 
 # The changelog-entries fragment tree: a space-separated list of shell globs

--- a/skills/growth-guards/scripts/byte-ceiling
+++ b/skills/growth-guards/scripts/byte-ceiling
@@ -1,20 +1,22 @@
 #!/usr/bin/env bash
 # byte-ceiling — tracked files a change puts over the byte ceiling fail
-# (default 200 KB). Growth-oriented like size-ratchet: what a change TOUCHES
-# is gated by the default modes, so adoption needs no cleanup first.
+# (default 200 KB). A touched file already over the ceiling may stay the
+# same size or shrink, so adoption does not freeze the work that reduces it.
 #
 # Modes (mutually exclusive):
 #   --staged (default)  files added, changed, or type-changed in the staged
 #                       diff (the pre-commit shim). A committed file edited
 #                       past the ceiling arrives the same way a new one does,
 #                       so the staged lane judges both.
-#   --base REF          files added since merge-base with REF (CI on a PR)
+#   --base REF          files added, changed, or type-changed since the
+#                       merge-base with REF (CI on a PR)
 #   --all               every tracked file (full sweep)
 #
-# Sizes are OBJECT sizes (`git cat-file -s` of the added blob): the bytes that
-# enter history, filters applied, independent of worktree state. Renames are
-# detected, so moving an existing large file is not an addition; a copy is
-# one. Exit codes: 0 clean; 1 violations; 2 usage/config/collection error.
+# Sizes are OBJECT sizes (`git cat-file -s` of each diff blob): the bytes that
+# enter history, filters applied, independent of worktree state. The source
+# blob is the tighten-only baseline for an existing oversized file. Renames
+# are detected, so moving an existing large file is not an addition; a copy
+# is one. Exit codes: 0 clean; 1 violations; 2 usage/config/collection error.
 set -euo pipefail
 
 GG_BOOT="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd; printf x)"
@@ -31,10 +33,12 @@ usage() {
   cat <<'EOF'
 usage: byte-ceiling [--staged | --base REF | --all] [--excludes FILE]
 
-Tracked files a change puts over the byte ceiling fail. --staged (default)
-checks the staged additions and changes; --base REF checks files added since
-the merge-base with REF; --all sweeps every tracked file. Lockfiles are
-exempt built-in; declared asset trees live in the excludes list.
+Tracked files a change puts over the byte ceiling fail. An existing file
+already over the ceiling may stay the same size or shrink, but may not grow.
+--staged (default) checks the staged additions and changes; --base REF checks
+additions and changes since the merge-base with REF; --all sweeps every
+tracked file. Lockfiles are exempt built-in; declared asset trees live in the
+excludes list.
 
 Configuration (env > .env.local > .kendex/settings.toml >
 kendex.settings.toml [env] > default):
@@ -100,13 +104,13 @@ is_lockfile() { # PATH
 
 gg_tmpdir
 
-# Alternating NUL-terminated fields, sha NUL path NUL: no single-record
-# separator survives arbitrary paths. The SHA is the added blob itself, so
-# measuring needs no path re-quoting.
+# Alternating NUL-terminated fields, destination SHA NUL source SHA NUL source
+# mode NUL path NUL: no single-record separator survives arbitrary paths. The
+# SHAs are the diff blobs themselves, so measuring needs no path re-quoting.
 : >"$GG_TMP/candidates.z"
 
-emit_candidate() { # SHA PATH
-  printf '%s\0%s\0' "$1" "$2" >>"$GG_TMP/candidates.z"
+emit_candidate() { # DEST-SHA SOURCE-SHA SOURCE-MODE PATH
+  printf '%s\0%s\0%s\0%s\0' "$1" "$2" "$3" "$4" >>"$GG_TMP/candidates.z"
 }
 
 case "$MODE" in
@@ -128,7 +132,7 @@ case "$MODE" in
     ;;
   base)
     git rev-parse --verify --quiet "$BASE_REF^{commit}" >/dev/null || gg_config_error "--base ref '$BASE_REF' does not name a commit"
-    git -c diff.renames=true diff --raw --no-abbrev -z --diff-filter=A "$BASE_REF...HEAD" >"$GG_TMP/raw.z" || gg_collection_error "git diff $BASE_REF...HEAD failed collecting added files (no merge base?)"
+    git -c diff.renames=true diff --raw --no-abbrev -z --find-renames=100% --diff-filter=AMT "$BASE_REF...HEAD" >"$GG_TMP/raw.z" || gg_collection_error "git diff $BASE_REF...HEAD failed collecting additions and changes (no merge base?)"
     ;;
   all)
     # ls-files -s emits one record per STAGE for an unmerged path, so the
@@ -144,7 +148,7 @@ case "$MODE" in
       case "$mode" in
         120000 | 160000) continue ;; # symlink / submodule gitlink — not sized content
       esac
-      emit_candidate "$sha" "$f"
+      emit_candidate "$sha" "" "" "$f"
     done <"$GG_TMP/files.z"
     ;;
 esac
@@ -155,7 +159,9 @@ if [ "$MODE" != "all" ]; then
   # diff-filter, none of which renames a path, so each record carries one.
   while IFS= read -r -d '' meta && IFS= read -r -d '' f; do
     set -- $meta
+    srcmode="${1#:}"
     dstmode="$2"
+    srcsha="$3"
     dstsha="$4"
     case "$dstmode" in
       120000 | 160000) continue ;; # symlink / submodule gitlink
@@ -164,20 +170,34 @@ if [ "$MODE" != "all" ]; then
       *[!0]*) ;;
       *) gg_collection_error "'$f' has no destination blob in the diff record — cannot measure it" ;;
     esac
-    emit_candidate "$dstsha" "$f"
+    emit_candidate "$dstsha" "$srcsha" "$srcmode" "$f"
   done <"$GG_TMP/raw.z"
 fi
 
 checked=0
 violations=0
-while IFS= read -r -d '' sha && IFS= read -r -d '' f; do
+while IFS= read -r -d '' sha \
+  && IFS= read -r -d '' srcsha \
+  && IFS= read -r -d '' srcmode \
+  && IFS= read -r -d '' f; do
   is_lockfile "$f" && continue
   gg_is_excluded "$f" && continue
   size="$(git cat-file -s "$sha")" || gg_collection_error "cannot read blob $sha for '$f' — its size is unmeasurable, refusing to skip it"
   checked=$((checked + 1))
   if [ "$size" -gt "$CEILING_BYTES" ]; then
+    prior_size=""
+    if gg_mode_is_regular "$srcmode"; then
+      prior_size="$(git cat-file -s "$srcsha")" || gg_collection_error "cannot read prior blob $srcsha for '$f' — its size is unmeasurable, refusing to skip it"
+    fi
+    if [ -n "$prior_size" ] && [ "$prior_size" -gt "$CEILING_BYTES" ] && [ "$size" -le "$prior_size" ]; then
+      continue
+    fi
     kb=$(((size + 1023) / 1024))
-    echo "byte-ceiling FAIL oversized file: $f — $size bytes (~$kb KB) > ceiling $CEILING_KB KB"
+    if [ -n "$prior_size" ] && [ "$prior_size" -gt "$CEILING_BYTES" ]; then
+      echo "byte-ceiling FAIL oversized file grew: $f — $prior_size -> $size bytes (~$kb KB), ceiling $CEILING_KB KB"
+    else
+      echo "byte-ceiling FAIL oversized file: $f — $size bytes (~$kb KB) > ceiling $CEILING_KB KB"
+    fi
     echo "  remedies: keep big artifacts out of the repo (asset store, Git LFS, build-time generation); a file that genuinely belongs gets a row in $EXCLUDES_FILE with its reason"
     violations=$((violations + 1))
   fi
@@ -185,7 +205,7 @@ done <"$GG_TMP/candidates.z"
 
 case "$MODE" in
   staged) SCOPE_DESC="staged file(s)" ;;
-  base) SCOPE_DESC="file(s) added since $BASE_REF" ;;
+  base) SCOPE_DESC="file(s) added or changed since $BASE_REF" ;;
   all) SCOPE_DESC="tracked file(s) (full sweep)" ;;
 esac
 

--- a/skills/growth-guards/tests/byte-ceiling.test.sh
+++ b/skills/growth-guards/tests/byte-ceiling.test.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
-# Pins for scripts/byte-ceiling: additions over the ceiling fail in every
-# mode, diff-scoping really is addition-only (modifications and renames
-# pass), lockfiles and excluded trees are exempt (each with a control
-# proving the exemption is what passed it), configuration resolves, and a
-# broken measurement is a collection error — never a pass.
+# Pins for scripts/byte-ceiling: additions and growth over the ceiling fail,
+# an existing oversized file may hold or shrink, renames pass, lockfiles and
+# excluded trees are exempt, configuration resolves, and a broken measurement
+# is a collection error — never a pass.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -97,6 +96,29 @@ git -C "$R" commit -qm "grow it past the ceiling"
 run_bc
 [ "$RC" -eq 0 ] && ok "a committed oversized file is not re-judged while nothing stages it" \
   || bad "a committed oversized file is not re-judged while nothing stages it" "rc=$RC out=$OUT"
+mkbytes seed.bin 4
+git -C "$R" add -A
+run_bc
+[ "$RC" -eq 0 ] && ok "a staged oversized file may shrink toward the ceiling" \
+  || bad "a staged oversized file may shrink toward the ceiling" "rc=$RC out=$OUT"
+run_bc
+[ "$RC" -eq 0 ] && ok "the same staged shrink gives a stable clean verdict" \
+  || bad "the same staged shrink gives a stable clean verdict" "rc=$RC out=$OUT"
+mkbytes seed.bin 5
+printf 'x' >>"$R/seed.bin"
+git -C "$R" add -A
+run_bc
+[ "$RC" -eq 1 ] && case "$OUT" in *"oversized file grew: seed.bin"*"5120 -> 5121 bytes"*) true ;; *) false ;; esac \
+  && ok "an existing oversized file may not grow" \
+  || bad "an existing oversized file may not grow" "rc=$RC out=$OUT"
+mkbytes seed.bin 5
+printf 'y' | dd of="$R/seed.bin" bs=1 seek=0 conv=notrunc 2>/dev/null
+git -C "$R" add -A
+run_bc
+[ "$RC" -eq 0 ] && ok "an existing oversized file may change without increasing its size" \
+  || bad "an existing oversized file may hold its size" "rc=$RC out=$OUT"
+mkbytes seed.bin 5
+git -C "$R" add -A
 git -C "$R" mv seed.bin moved.bin
 run_bc
 [ "$RC" -eq 0 ] && ok "renaming an existing large file is not an addition (rename detection pinned on)" \
@@ -168,13 +190,27 @@ run_bc --all
 [ "$RC" -eq 1 ] && case "$OUT" in *"old.bin"*"full sweep"*) true ;; *) false ;; esac \
   && ok "--all fails on the legacy oversized file" || bad "--all fails on legacy" "rc=$RC out=$OUT"
 
-echo "=== --base REF: additions since the merge-base ==="
+echo "=== --base REF: additions and changes since the merge-base ==="
 git -C "$R" checkout -qb feature
+mkbytes old.bin 3
+git -C "$R" add -A
+git -C "$R" commit -qm "feature shrinks the legacy file"
+run_bc --base main
+[ "$RC" -eq 0 ] && case "$OUT" in *"added or changed since main"*) true ;; *) false ;; esac \
+  && ok "--base main permits a legacy oversized file to shrink" \
+  || bad "--base permits a legacy oversized file to shrink" "rc=$RC out=$OUT"
+mkbytes old.bin 5
+git -C "$R" add -A
+git -C "$R" commit -qm "feature grows the legacy file"
+run_bc --base main
+[ "$RC" -eq 1 ] && case "$OUT" in *"oversized file grew: old.bin"*"4096 -> 5120 bytes"*) true ;; *) false ;; esac \
+  && ok "--base main rejects growth from the merge-base size" \
+  || bad "--base rejects growth from the merge-base size" "rc=$RC out=$OUT"
 mkbytes feat.bin 2
 git -C "$R" add -A
 git -C "$R" commit -qm "feature adds an oversized file"
 run_bc --base main
-[ "$RC" -eq 1 ] && case "$OUT" in *"feat.bin"*"added since main"*) true ;; *) false ;; esac \
+[ "$RC" -eq 1 ] && case "$OUT" in *"feat.bin"*"added or changed since main"*) true ;; *) false ;; esac \
   && ok "--base main fails on the branch's added file" || bad "--base fails on the added file" "rc=$RC out=$OUT"
 git -C "$R" checkout -q main
 run_bc --base main


### PR DESCRIPTION
The byte-ceiling check now lets an existing oversized file keep its size or shrink. Growth and new oversized files still fail. This allows comment cleanup to reduce large files without removing the size limit.

The check uses the previous Git blob in staged and base comparisons. It needs no separate baseline file.

Validation: source and rendered suites, full growth-guards suite, preflight, size ratchet, Bash portability lint, repository guard, and commit checks passed. The old implementation failed the shrink controls; clean stability passed.

Closes #2090. Linear mirror: KEN-1214.

Held for overseer review. Merge requires a new MERGE instruction.

Program: KEN-1203.
