### PR TITLE
fix(core): complete ownership records and report recovery

### DIFF
--- a/changelog.d/fixed/1203.md
+++ b/changelog.d/fixed/1203.md
@@ -1,0 +1,1 @@
+- Keep Pi extension records after partial updates, honor pinned revisions, and route app reports when an install record is unreadable.

--- a/crates/app/src/commands.rs
+++ b/crates/app/src/commands.rs
@@ -90,6 +90,8 @@ pub struct ReportRouteView {
     pub label: Option<String>,
     /// Prefilled issue page — only when the report belongs upstream.
     pub issue_url: Option<String>,
+    /// Install-record and scan failures kept beside fallback routing.
+    pub warnings: Vec<String>,
 }
 
 /// Where a problem report about this item belongs: the kendex upstream
@@ -110,10 +112,14 @@ fn route_for(
     name: &str,
     kind: Option<ItemKind>,
 ) -> Result<ReportRouteView, String> {
-    let lock = kendex_core::lock::load(&kendex_core::lock::lock_path(env, scope))
-        .map_err(|e| e.to_string())?;
-    let route =
-        kendex_core::report::route(&lock, name, kind, kendex_core::report::DEFAULT_UPSTREAM);
+    let resolved = kendex_core::report::resolve(
+        env,
+        scope,
+        name,
+        kind,
+        kendex_core::report::DEFAULT_UPSTREAM,
+    );
+    let route = resolved.route;
     let issue_url = route.repo.as_ref().map(|repo| {
         let mut url = format!(
             "https://github.com/{repo}/issues/new?title={}",
@@ -129,6 +135,7 @@ fn route_for(
         repo: route.repo,
         label: route.label,
         issue_url,
+        warnings: resolved.warnings,
     })
 }
 
@@ -139,21 +146,30 @@ mod tests {
     use kendex_core::model::Scope;
 
     #[test]
-    fn a_malformed_lock_fails_the_report_route() {
+    fn old_and_malformed_locks_keep_the_warning_beside_fallback_routing() {
         let tmp = tempfile::tempdir().unwrap();
         let env = Env::fake(tmp.path(), FakeOs::Linux);
         let project = tmp.path().join("dev/app");
         std::fs::create_dir_all(&project).unwrap();
         std::fs::write(
-            project.join(".kendex-lock.json"),
-            format!(r#"{{"version":{}"#, kendex_core::lock::LOCK_VERSION),
+            project.join("kendex.toml"),
+            "schema = 6\n[sources.kendex]\nrepo = \"vanillagreencom/kendex\"\n[skills.gh]\nsource = \"kendex\"\n",
         )
         .unwrap();
-        let scope = Scope::Project { root: project };
-
-        let Err(error) = route_for(&env, &scope, "gh", None) else {
-            panic!("a malformed lock must fail the route");
+        let scope = Scope::Project {
+            root: project.clone(),
         };
-        assert!(error.contains("could not be read"), "{error}");
+
+        for record in [
+            "{\"version\":5}\n".to_owned(),
+            format!(r#"{{"version":{}"#, kendex_core::lock::LOCK_VERSION),
+        ] {
+            std::fs::write(project.join(".kendex-lock.json"), record).unwrap();
+            let route = route_for(&env, &scope, "gh", None).unwrap();
+            assert!(route.kendex_owned);
+            assert_eq!(route.repo.as_deref(), Some("vanillagreencom/kendex"));
+            assert_eq!(route.warnings.len(), 1);
+            assert!(route.warnings[0].contains("install record unreadable"));
+        }
     }
 }

--- a/crates/cli/src/commands/update_pi.rs
+++ b/crates/cli/src/commands/update_pi.rs
@@ -366,8 +366,8 @@ fn update(env: &Env, plans: &[ScopePlan]) -> CliResult {
             }
         }
     }
+    record_pi_installs(env, plans)?;
     if failures.is_empty() {
-        record_pi_installs(env, plans)?;
         say(&match updated {
             0 => "all pi packages up to date".to_owned(),
             count => format!("updated {count} package(s)"),

--- a/crates/cli/src/commands/update_pi.rs
+++ b/crates/cli/src/commands/update_pi.rs
@@ -219,9 +219,8 @@ fn plan_scope(
     })
 }
 
-/// Where each declared pi-extension's bytes live right now. A source that
-/// cannot be read is a note, not a failure — the rest of the scope still
-/// updates.
+/// Resolve each declared Pi extension. An unreadable source becomes a note
+/// so the rest of the scope still updates.
 fn declared_sources(
     env: &Env,
     scope: &Scope,
@@ -346,6 +345,7 @@ fn update(env: &Env, plans: &[ScopePlan]) -> CliResult {
             };
             match pi_ext::install(env, &plan.root, source_dir) {
                 Ok(outcome) => {
+                    record_pi_installs(env, plan, Some(&row.name))?;
                     updated += 1;
                     out(&format!(
                         "  {verb} {} -> {}",
@@ -366,8 +366,10 @@ fn update(env: &Env, plans: &[ScopePlan]) -> CliResult {
             }
         }
     }
-    record_pi_installs(env, plans)?;
     if failures.is_empty() {
+        plans
+            .iter()
+            .try_for_each(|plan| record_pi_installs(env, plan, None))?;
         say(&match updated {
             0 => "all pi packages up to date".to_owned(),
             count => format!("updated {count} package(s)"),
@@ -377,22 +379,22 @@ fn update(env: &Env, plans: &[ScopePlan]) -> CliResult {
     Err(format!("update failed for: {}", failures.join(", ")).into())
 }
 
-fn record_pi_installs(env: &Env, plans: &[ScopePlan]) -> CliResult {
-    for plan in plans {
-        let Some(manifest) = manifest::load_current(&manifest::manifest_path(env, &plan.scope))?
-        else {
-            continue;
-        };
-        let path = kendex_core::lock::lock_path(env, &plan.scope);
-        let mut lock = kendex_core::lock::load(&path)?;
-        let before = lock.clone();
-        let drift = pi_ext::record_matching_manifest(env, &plan.scope, &manifest, &mut lock)?;
-        if lock != before {
-            kendex_core::lock::save(&path, &lock)?;
-        }
-        for row in drift {
-            say(&format!("  ! {}: {}", row.name, row.detail));
-        }
+fn record_pi_installs(env: &Env, plan: &ScopePlan, completed: Option<&str>) -> CliResult {
+    let Some(manifest) = manifest::load_current(&manifest::manifest_path(env, &plan.scope))? else {
+        return Ok(());
+    };
+    let path = kendex_core::lock::lock_path(env, &plan.scope);
+    let mut lock = kendex_core::lock::load(&path)?;
+    let before = lock.clone();
+    let drift = match completed {
+        Some(name) => pi_ext::record_matching_name(env, &plan.scope, &manifest, &mut lock, name)?,
+        None => pi_ext::record_matching_manifest(env, &plan.scope, &manifest, &mut lock)?,
+    };
+    if lock != before {
+        kendex_core::lock::save(&path, &lock)?;
+    }
+    for row in drift {
+        say(&format!("  ! {}: {}", row.name, row.detail));
     }
     Ok(())
 }

--- a/crates/cli/tests/update_pi.rs
+++ b/crates/cli/tests/update_pi.rs
@@ -1,8 +1,14 @@
 #![cfg(unix)]
 
+#[path = "../../test_util.rs"]
+mod test_util;
+use test_util::rooted;
+
 use std::fs;
 use std::path::Path;
 use std::process::{Command, Output};
+
+use kendex_core::process::Hardened;
 
 // Integration-test helpers sit outside #[test] fns, so clippy's
 // allow-unwrap-in-tests does not reach them.
@@ -14,6 +20,10 @@ fn kendex(home: &Path, cwd: &Path, args: &[&str]) -> Output {
         .env_clear()
         .env("HOME", home)
         .env("KENDEX_REAL_HOME", "1")
+        .env(
+            "KENDEX_GIT_BASE",
+            format!("file://{}", home.join("git").display()),
+        )
         .env("PATH", std::env::var("PATH").unwrap_or_default())
         .output()
         .expect("kendex binary runs")
@@ -23,6 +33,34 @@ fn kendex(home: &Path, cwd: &Path, args: &[&str]) -> Output {
 fn write(path: &Path, text: &str) {
     fs::create_dir_all(path.parent().unwrap()).unwrap();
     fs::write(path, text).unwrap();
+}
+
+#[allow(clippy::unwrap_used)]
+fn git(dir: &Path, args: &[&str]) {
+    let output = Hardened::git(args, Some(dir)).run().unwrap();
+    assert!(output.status.success(), "git {args:?}");
+}
+
+#[allow(clippy::unwrap_used)]
+fn commit(dir: &Path, message: &str) -> String {
+    git(dir, &["add", "-A"]);
+    git(
+        dir,
+        &[
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "--quiet",
+            "-m",
+            message,
+        ],
+    );
+    let output = Hardened::git(&["rev-parse", "HEAD"], Some(dir))
+        .run()
+        .unwrap();
+    String::from_utf8_lossy(&output.stdout).trim().to_owned()
 }
 
 /// A project that declares one pi extension from a local catalog and already
@@ -104,6 +142,104 @@ fn update_reinstalls_from_the_declared_source() {
     assert!(output.status.success());
     let summary = String::from_utf8_lossy(&output.stderr);
     assert!(summary.contains("all pi packages up to date"), "{summary}");
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_successful_package_is_recorded_when_another_update_fails() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = rooted(&tmp);
+    let project = root.join("dev/app");
+    write(
+        &project.join("kendex.toml"),
+        "schema = 6\n\n[sources.cat]\npath = \"catalog\"\n\n[pi-extensions.bad]\nsource = \"cat\"\n\n[pi-extensions.good]\nsource = \"cat\"\n",
+    );
+    write(
+        &project.join("catalog/pi-extensions/good/package.json"),
+        "{\"name\":\"good\",\"version\":\"1.0.0\"}\n",
+    );
+    write(
+        &project.join("catalog/pi-extensions/good/index.js"),
+        "export const good = true;\n",
+    );
+    write(
+        &project.join("catalog/pi-extensions/bad/package.json"),
+        "{\"name\":\"../bad\",\"version\":\"1.0.0\"}\n",
+    );
+    fs::create_dir_all(project.join(".pi")).unwrap();
+
+    let output = kendex(&root, &project, &["update-pi"]);
+
+    assert!(!output.status.success(), "{output:?}");
+    assert!(project.join(".pi/packages/good/index.js").is_file());
+    let lock = kendex_core::lock::load(&project.join(".kendex-lock.json")).unwrap();
+    assert!(lock.entries.values().any(|entry| entry.name == "good"));
+    assert!(!lock.entries.values().any(|entry| entry.name == "bad"));
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_pinned_pi_extension_installs_and_verifies_against_its_revision() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = rooted(&tmp);
+    let project = root.join("dev/app");
+    let upstream = root.join("git/owner/catalog");
+    write(
+        &upstream.join("pi-extensions/pi-widgets/package.json"),
+        "{\"name\":\"pi-widgets\",\"version\":\"1.0.0\"}\n",
+    );
+    write(
+        &upstream.join("pi-extensions/pi-widgets/index.js"),
+        "export const version = 1;\n",
+    );
+    git(&upstream, &["init", "--quiet", "-b", "main"]);
+    let pinned = commit(&upstream, "one");
+    write(
+        &upstream.join("pi-extensions/pi-widgets/package.json"),
+        "{\"name\":\"pi-widgets\",\"version\":\"2.0.0\"}\n",
+    );
+    write(
+        &upstream.join("pi-extensions/pi-widgets/index.js"),
+        "export const version = 2;\n",
+    );
+    commit(&upstream, "two");
+    write(
+        &project.join("kendex.toml"),
+        &format!(
+            "schema = 6\n\n[sources.cat]\nrepo = \"owner/catalog\"\n\n[pi-extensions.pi-widgets]\nsource = \"cat\"\nrev = \"{pinned}\"\n"
+        ),
+    );
+    fs::create_dir_all(project.join(".pi")).unwrap();
+    let refresh = kendex(&root, &project, &["refresh", "--scope", "project", "--yes"]);
+    assert!(
+        refresh.status.success(),
+        "{}",
+        String::from_utf8_lossy(&refresh.stderr)
+    );
+
+    let update = kendex(&root, &project, &["update-pi"]);
+    assert!(
+        update.status.success(),
+        "{}",
+        String::from_utf8_lossy(&update.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(project.join(".pi/packages/pi-widgets/index.js")).unwrap(),
+        "export const version = 1;\n"
+    );
+    let lock = kendex_core::lock::load(&project.join(".kendex-lock.json")).unwrap();
+    let recorded = lock
+        .entries
+        .values()
+        .find(|entry| entry.name == "pi-widgets")
+        .unwrap();
+    assert_eq!(recorded.source_commit.as_deref(), Some(pinned.as_str()));
+    let verify = kendex(&root, &project, &["verify", "--scope", "project"]);
+    assert!(
+        verify.status.success(),
+        "{}",
+        String::from_utf8_lossy(&verify.stderr)
+    );
 }
 
 #[test]

--- a/crates/cli/tests/update_pi.rs
+++ b/crates/cli/tests/update_pi.rs
@@ -5,6 +5,7 @@ mod test_util;
 use test_util::rooted;
 
 use std::fs;
+use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::process::{Command, Output};
 
@@ -14,6 +15,11 @@ use kendex_core::process::Hardened;
 // allow-unwrap-in-tests does not reach them.
 #[allow(clippy::expect_used)]
 fn kendex(home: &Path, cwd: &Path, args: &[&str]) -> Output {
+    let mut paths = vec![home.join("bin")];
+    paths.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
+    let path = std::env::join_paths(paths).expect("fixture PATH joins");
     Command::new(env!("CARGO_BIN_EXE_kendex"))
         .args(args)
         .current_dir(cwd)
@@ -24,7 +30,7 @@ fn kendex(home: &Path, cwd: &Path, args: &[&str]) -> Output {
             "KENDEX_GIT_BASE",
             format!("file://{}", home.join("git").display()),
         )
-        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("PATH", path)
         .output()
         .expect("kendex binary runs")
 }
@@ -146,7 +152,7 @@ fn update_reinstalls_from_the_declared_source() {
 
 #[test]
 #[allow(clippy::unwrap_used)]
-fn a_successful_package_is_recorded_when_another_update_fails() {
+fn an_npm_failure_records_only_the_sibling_whose_install_completed() {
     let tmp = tempfile::tempdir().unwrap();
     let root = rooted(&tmp);
     let project = root.join("dev/app");
@@ -164,15 +170,34 @@ fn a_successful_package_is_recorded_when_another_update_fails() {
     );
     write(
         &project.join("catalog/pi-extensions/bad/package.json"),
-        "{\"name\":\"../bad\",\"version\":\"1.0.0\"}\n",
+        "{\"name\":\"bad\",\"version\":\"1.0.0\",\"dependencies\":{\"dep\":\"1.0.0\"}}\n",
     );
+    write(
+        &project.join("catalog/pi-extensions/bad/index.js"),
+        "export const copiedBeforeNpm = true;\n",
+    );
+    let npm = root.join("bin/npm");
+    write(&npm, "#!/bin/sh\nexit 1\n");
+    fs::set_permissions(&npm, fs::Permissions::from_mode(0o755)).unwrap();
     fs::create_dir_all(project.join(".pi")).unwrap();
 
     let output = kendex(&root, &project, &["update-pi"]);
 
     assert!(!output.status.success(), "{output:?}");
     assert!(project.join(".pi/packages/good/index.js").is_file());
+    assert!(
+        project.join(".pi/packages/bad/index.js").is_file(),
+        "npm fails after the source package is copied"
+    );
+    let settings = fs::read_to_string(project.join(".pi/settings.json")).unwrap();
+    assert!(settings.contains("./packages/good"), "{settings}");
+    assert!(!settings.contains("./packages/bad"), "{settings}");
     let lock = kendex_core::lock::load(&project.join(".kendex-lock.json")).unwrap();
+    let verify = kendex(&root, &project, &["verify", "--scope", "project"]);
+    assert!(
+        !verify.status.success(),
+        "an unregistered failed package must not verify as installed"
+    );
     assert!(lock.entries.values().any(|entry| entry.name == "good"));
     assert!(!lock.entries.values().any(|entry| entry.name == "bad"));
 }

--- a/crates/core/src/pi_ext/mod.rs
+++ b/crates/core/src/pi_ext/mod.rs
@@ -17,8 +17,8 @@ use crate::process::Hardened;
 pub mod carrier;
 mod record;
 pub use record::{
-    DeclaredPackage, check_origin, matching_lock_entry, record_matching_manifest, resolve_declared,
-    scope_root,
+    DeclaredPackage, check_origin, matching_lock_entry, record_matching_manifest,
+    record_matching_name, resolve_declared, scope_root,
 };
 mod files;
 mod renames;

--- a/crates/core/src/pi_ext/record.rs
+++ b/crates/core/src/pi_ext/record.rs
@@ -25,7 +25,8 @@ pub fn resolve_declared(
     name: &str,
     decl: &crate::manifest::ItemDecl,
 ) -> Result<DeclaredPackage> {
-    let ready = crate::source::require_ready(env, scope, &decl.source, manifest)?;
+    let ready =
+        crate::source::require_ready_at(env, scope, &decl.source, manifest, decl.rev.as_deref())?;
     let sealed = crate::source_read::SealedSource::open(&ready.root)?;
     let direct = sealed.root().join("pi-extensions").join(name);
     let source_dir = if sealed.is_file(&direct.join("package.json")) {

--- a/crates/core/src/pi_ext/record.rs
+++ b/crates/core/src/pi_ext/record.rs
@@ -107,11 +107,38 @@ pub fn record_matching_manifest(
     manifest: &crate::manifest::Manifest,
     lock: &mut crate::lock::Lock,
 ) -> Result<Vec<crate::engine::DriftRow>> {
+    record_matching(env, scope, manifest, lock, manifest.pi_extensions.iter())
+}
+
+/// Compare one declaration after its carrier install completed.
+pub fn record_matching_name(
+    env: &Env,
+    scope: &crate::model::Scope,
+    manifest: &crate::manifest::Manifest,
+    lock: &mut crate::lock::Lock,
+    name: &str,
+) -> Result<Vec<crate::engine::DriftRow>> {
+    record_matching(
+        env,
+        scope,
+        manifest,
+        lock,
+        manifest.pi_extensions.get_key_value(name).into_iter(),
+    )
+}
+
+fn record_matching<'a>(
+    env: &Env,
+    scope: &crate::model::Scope,
+    manifest: &crate::manifest::Manifest,
+    lock: &mut crate::lock::Lock,
+    declarations: impl Iterator<Item = (&'a String, &'a crate::manifest::ItemDecl)>,
+) -> Result<Vec<crate::engine::DriftRow>> {
     use crate::engine::{DriftRow, DriftState};
     use crate::model::{HarnessId, ItemKind};
     let root = scope_root(env, scope)?;
     let mut drift = Vec::new();
-    for (name, decl) in &manifest.pi_extensions {
+    for (name, decl) in declarations {
         let key = crate::lock::entry_key(ItemKind::PiExtension, name, HarnessId::Pi);
         let result = resolve_declared(env, scope, manifest, name, decl)
             .and_then(|package| matching_lock_entry(&root, name, &package, lock.entries.get(&key)));

--- a/crates/core/src/source.rs
+++ b/crates/core/src/source.rs
@@ -284,7 +284,23 @@ pub fn require_ready(
     name: &str,
     manifest: &Manifest,
 ) -> Result<ResolvedSource> {
-    match resolve(env, scope, name, manifest)? {
+    require_resolved(resolve(env, scope, name, manifest)?)
+}
+
+/// A source's ready root at an item-level revision, or the error that
+/// explains why those bytes are unreachable.
+pub fn require_ready_at(
+    env: &Env,
+    scope: &Scope,
+    name: &str,
+    manifest: &Manifest,
+    rev: Option<&str>,
+) -> Result<ResolvedSource> {
+    require_resolved(resolve_at(env, scope, name, manifest, rev)?)
+}
+
+fn require_resolved(state: SourceState) -> Result<ResolvedSource> {
+    match state {
         SourceState::Ready(source) => Ok(source),
         SourceState::Pending { name, .. } => Err(CoreError::SourcePending { name }),
         SourceState::Disabled { name } => Err(CoreError::SourceDisabled { name }),

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -2626,6 +2626,8 @@ export type ReportRouteView = {
 	label: string | null,
 	/**  Prefilled issue page — only when the report belongs upstream. */
 	issueUrl: string | null,
+	/**  Install-record and scan failures kept beside fallback routing. */
+	warnings: string[],
 };
 
 /**

--- a/ui/src/components/report-dialog.dom.test.tsx
+++ b/ui/src/components/report-dialog.dom.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { commands, type Scope } from "@/bindings";
+import { mount, settle } from "@/test/dom";
+import { ReportDialog } from "./report-dialog";
+
+vi.mock("@/bindings", () => ({
+  commands: { reportRoute: vi.fn() },
+}));
+
+const PROJECT: Scope = { scope: "project", root: "/work/acme" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("report routing with an unreadable install record", () => {
+  it("shows the warning kept by fallback routing", async () => {
+    vi.mocked(commands.reportRoute).mockResolvedValue({
+      status: "ok",
+      data: {
+        kendexOwned: true,
+        repo: "vanillagreencom/kendex",
+        label: "skills",
+        issueUrl: "https://github.com/vanillagreencom/kendex/issues/new",
+        warnings: ["install record unreadable: old record"],
+      },
+    });
+    const host = mount(<ReportDialog scope={PROJECT} name="gh" kind="skill" />);
+
+    await userEvent.click(host.querySelector("button") as HTMLButtonElement);
+    await settle();
+
+    expect(document.body.textContent).toContain(
+      "Routing used fallback evidence",
+    );
+    expect(document.body.textContent).toContain(
+      "install record unreadable: old record",
+    );
+  });
+
+  it("shows no fallback warning for a clean route", async () => {
+    vi.mocked(commands.reportRoute).mockResolvedValue({
+      status: "ok",
+      data: {
+        kendexOwned: true,
+        repo: "vanillagreencom/kendex",
+        label: "skills",
+        issueUrl: "https://github.com/vanillagreencom/kendex/issues/new",
+        warnings: [],
+      },
+    });
+    const host = mount(<ReportDialog scope={PROJECT} name="gh" kind="skill" />);
+
+    await userEvent.click(host.querySelector("button") as HTMLButtonElement);
+    await settle();
+
+    expect(document.body.textContent).not.toContain(
+      "Routing used fallback evidence",
+    );
+  });
+});

--- a/ui/src/components/report-dialog.tsx
+++ b/ui/src/components/report-dialog.tsx
@@ -5,6 +5,7 @@ import {
   type ReportRouteView,
   type Scope,
 } from "@/bindings";
+import { StatusNote } from "@/components/status-note";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -62,6 +63,15 @@ export function ReportDialog({
               {route.issueUrl}
             </p>
           ) : null}
+          {route?.warnings.map((warning) => (
+            <StatusNote
+              key={warning}
+              tone="warning"
+              title="Routing used fallback evidence"
+            >
+              {warning}
+            </StatusNote>
+          ))}
           <DialogFooter>
             <Button variant="outline" onClick={() => setOpen(false)}>
               Close


### PR DESCRIPTION
Successful Pi updates now retain matching records when another update fails. Pi installs, verification, and recording also honor each item's declared revision. This prevents current bytes and recorded ownership from disagreeing in those flows.

Desktop reports use the shared ownership resolver when a lock cannot be read. The app displays the resolver warnings instead of losing the report path.

Validation: focused core, CLI, app, and UI tests passed. Removing each fix made its control fail. Preflight, size ratchet, repository checks, commit checks, and kendex verification passed.

This completes the confirmed Class A follow-ups from PR #2098. The program tracker remains open for its later queued blocks.

Held for overseer review. Merge requires a new MERGE instruction.

Program: KEN-1203.
