### PR TITLE
fix(growth-guards): share markdown replacement cleanup

### DIFF
--- a/.agents/skills/growth-guards/DEVELOPMENT.md
+++ b/.agents/skills/growth-guards/DEVELOPMENT.md
@@ -42,7 +42,7 @@ The installer writes into `.git/hooks`, never `core.hooksPath`:
 - `--uninstall` drops the helper and the marked line, deletes a hook file this installer created outright, leaves every other line, and runs under `core.hooksPath` too. A line it may not edit keeps the helper and fails the removal.
 - `--check` writes nothing, not even the hooks directory. `0`: helper and both hooks pass the install predicate. `1`: a shim drifted or absent, or `core.hooksPath` set and empty. `2`: unmeasurable, or `core.hooksPath` naming a directory; the verifier reads `.git/hooks` only. Definitive drift outranks an unmeasured component. One stdout line carries every finding.
 - The helper is compared byte for byte against `helper_body`, its head against `helper_head_shape` with the per-checkout value blanked. Only `SCRIPT_DIR` may differ, and only when it round-trips through `gg_shell_quote` and names this project's scripts directory in another checkout of this repository; `project_rel` and `skill_roots` compare exactly.
-- `gg_install_file` in `scripts/lib/atomic-install.sh` is a rename inside the destination's directory; its staging file is declared and removed in `common.sh`.
+- `gg_install_file` in `scripts/lib/atomic-install.sh` replaces baselines, collated changelogs, and reflowed markdown by a rename inside the destination's directory. `common.sh` removes its staging file on exit.
 - kendex runs the installer through the `repo-effects` declaration in `SKILL.md`; every verb that drops the package runs `--uninstall` while the scripts are still on disk; `kendex guard install`, `guard uninstall` and `guard check` call it directly; `kendex check` relays `--check` only where `.git/hooks/kendex-guards` exists.
 
 ## The pre-commit chain

--- a/.agents/skills/growth-guards/scripts/lib/atomic-install.sh
+++ b/.agents/skills/growth-guards/scripts/lib/atomic-install.sh
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 # atomic-install.sh — how this family REPLACES a file it owns: a policy
-# baseline, a collated changelog record. One helper does the write, and the
+# baseline, a collated changelog record, or reflowed markdown. One helper does the write, and the
 # two it leans on are what it needs to do that safely — the destination's
 # mode, and what a failing step said.
 #

--- a/.agents/skills/growth-guards/scripts/lib/common.sh
+++ b/.agents/skills/growth-guards/scripts/lib/common.sh
@@ -38,7 +38,7 @@ GG_TMP=""
 GG_SETTINGS_INDEX_OWNED=0
 # In-flight staging file for gg_install_file, so an interrupt between its
 # creation and its rename leaves nothing beside the destination. The helper
-# that sets it lives in lib/atomic-install.sh, which only the two writing
+# that sets it lives in lib/atomic-install.sh, which the writing
 # lanes source; the declaration and the removal below stay here on purpose,
 # because the reset has to reach every guard and one process arms one trap.
 GG_INSTALL_TMP=""

--- a/.agents/skills/growth-guards/scripts/md-reflow
+++ b/.agents/skills/growth-guards/scripts/md-reflow
@@ -30,6 +30,8 @@ source "$SCRIPT_DIR/lib/common.sh"
 source "$SCRIPT_DIR/lib/settings.sh"
 # shellcheck source=lib/md-scope.sh
 source "$SCRIPT_DIR/lib/md-scope.sh"
+# shellcheck source=lib/atomic-install.sh
+source "$SCRIPT_DIR/lib/atomic-install.sh"
 
 PATHS_DEFAULT="*.md"
 BLOCKS_AWK="$SCRIPT_DIR/lib/md-blocks.awk"
@@ -152,18 +154,7 @@ while IFS= read -r -d '' f; do
     would=$((would + 1))
     continue
   fi
-  # A rename inside the file's own directory, so an interrupt leaves the
-  # original whole; the mode is carried over, since cp -p keeps it.
-  case "$f" in
-    */*) staging="${f%/*}/.md-reflow.$$.tmp" ;;
-    *) staging=".md-reflow.$$.tmp" ;;
-  esac
-  cp -p -- "$f" "$staging" || gg_collection_error "could not stage a rewrite of $(gg_shown "$f")"
-  if ! cat -- "$GG_TMP/reflowed" >"$staging"; then
-    rm -f -- "$staging"
-    gg_collection_error "could not write the rewrite of $(gg_shown "$f")"
-  fi
-  mv -f -- "$staging" "$f" || gg_collection_error "could not replace $(gg_shown "$f")"
+  gg_install_file "$GG_TMP/reflowed" "$f" "the reflowed markdown"
   echo "md-reflow: reflowed $(gg_shown "$f")"
   reflowed=$((reflowed + 1))
 done <"$GG_TMP/targets.z"

--- a/.agents/skills/growth-guards/tests/md-reflow.test.sh
+++ b/.agents/skills/growth-guards/tests/md-reflow.test.sh
@@ -205,6 +205,27 @@ git -C "$R" add -A
 run_in "$R" "$MDF" --all
 [ "$RC" -eq 0 ] && ok "control: md-format --all passes on what --all reflowed" || bad "control: md-format after --all" "rc=$RC out=$OUT"
 
+echo "=== a failed replacement preserves the file and removes its staging file ==="
+new_repo replacement
+printf 'Wrapped\ntext.\n' >"$R/doc.md"
+cp "$R/doc.md" "$TMP/original.md"
+mkdir -p "$TMP/fail-bin"
+cat >"$TMP/fail-bin/mv" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'injected rename failure\n' >&2
+exit 1
+STUB
+chmod +x "$TMP/fail-bin/mv"
+run_in "$R" env PATH="$TMP/fail-bin:$PATH" "$MDR" doc.md
+[ "$RC" -eq 2 ] && cmp -s "$R/doc.md" "$TMP/original.md" \
+  && ok "rename failure is an error and preserves the original bytes" || bad "failed replacement" "rc=$RC out=$OUT"
+leftovers="$(find "$R" -maxdepth 1 -type f ! -name doc.md -print)"
+[ -z "$leftovers" ] && ok "failed replacement removes the staging file" || bad "staging file cleanup" "$leftovers"
+run_in "$R" "$MDR" doc.md
+[ "$RC" -eq 0 ] && [ "$(cat "$R/doc.md")" = 'Wrapped text.' ] \
+  && ok "the same file reflows when rename succeeds" || bad "successful replacement control" "rc=$RC out=$OUT"
+
 echo "=== the skill's own shipped markdown is a fixed point ==="
 new_repo self
 mkdir -p "$R/skills/growth-guards"

--- a/changelog.d/fixed/reflow-staging-cleanup.md
+++ b/changelog.d/fixed/reflow-staging-cleanup.md
@@ -1,0 +1,1 @@
+- Markdown reflow removes its temporary file when replacement fails and preserves the original document.

--- a/skills/growth-guards/DEVELOPMENT.md
+++ b/skills/growth-guards/DEVELOPMENT.md
@@ -42,7 +42,7 @@ The installer writes into `.git/hooks`, never `core.hooksPath`:
 - `--uninstall` drops the helper and the marked line, deletes a hook file this installer created outright, leaves every other line, and runs under `core.hooksPath` too. A line it may not edit keeps the helper and fails the removal.
 - `--check` writes nothing, not even the hooks directory. `0`: helper and both hooks pass the install predicate. `1`: a shim drifted or absent, or `core.hooksPath` set and empty. `2`: unmeasurable, or `core.hooksPath` naming a directory; the verifier reads `.git/hooks` only. Definitive drift outranks an unmeasured component. One stdout line carries every finding.
 - The helper is compared byte for byte against `helper_body`, its head against `helper_head_shape` with the per-checkout value blanked. Only `SCRIPT_DIR` may differ, and only when it round-trips through `gg_shell_quote` and names this project's scripts directory in another checkout of this repository; `project_rel` and `skill_roots` compare exactly.
-- `gg_install_file` in `scripts/lib/atomic-install.sh` is a rename inside the destination's directory; its staging file is declared and removed in `common.sh`.
+- `gg_install_file` in `scripts/lib/atomic-install.sh` replaces baselines, collated changelogs, and reflowed markdown by a rename inside the destination's directory. `common.sh` removes its staging file on exit.
 - kendex runs the installer through the `repo-effects` declaration in `SKILL.md`; every verb that drops the package runs `--uninstall` while the scripts are still on disk; `kendex guard install`, `guard uninstall` and `guard check` call it directly; `kendex check` relays `--check` only where `.git/hooks/kendex-guards` exists.
 
 ## The pre-commit chain

--- a/skills/growth-guards/scripts/lib/atomic-install.sh
+++ b/skills/growth-guards/scripts/lib/atomic-install.sh
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 # atomic-install.sh — how this family REPLACES a file it owns: a policy
-# baseline, a collated changelog record. One helper does the write, and the
+# baseline, a collated changelog record, or reflowed markdown. One helper does the write, and the
 # two it leans on are what it needs to do that safely — the destination's
 # mode, and what a failing step said.
 #

--- a/skills/growth-guards/scripts/lib/common.sh
+++ b/skills/growth-guards/scripts/lib/common.sh
@@ -38,7 +38,7 @@ GG_TMP=""
 GG_SETTINGS_INDEX_OWNED=0
 # In-flight staging file for gg_install_file, so an interrupt between its
 # creation and its rename leaves nothing beside the destination. The helper
-# that sets it lives in lib/atomic-install.sh, which only the two writing
+# that sets it lives in lib/atomic-install.sh, which the writing
 # lanes source; the declaration and the removal below stay here on purpose,
 # because the reset has to reach every guard and one process arms one trap.
 GG_INSTALL_TMP=""

--- a/skills/growth-guards/scripts/md-reflow
+++ b/skills/growth-guards/scripts/md-reflow
@@ -30,6 +30,8 @@ source "$SCRIPT_DIR/lib/common.sh"
 source "$SCRIPT_DIR/lib/settings.sh"
 # shellcheck source=lib/md-scope.sh
 source "$SCRIPT_DIR/lib/md-scope.sh"
+# shellcheck source=lib/atomic-install.sh
+source "$SCRIPT_DIR/lib/atomic-install.sh"
 
 PATHS_DEFAULT="*.md"
 BLOCKS_AWK="$SCRIPT_DIR/lib/md-blocks.awk"
@@ -152,18 +154,7 @@ while IFS= read -r -d '' f; do
     would=$((would + 1))
     continue
   fi
-  # A rename inside the file's own directory, so an interrupt leaves the
-  # original whole; the mode is carried over, since cp -p keeps it.
-  case "$f" in
-    */*) staging="${f%/*}/.md-reflow.$$.tmp" ;;
-    *) staging=".md-reflow.$$.tmp" ;;
-  esac
-  cp -p -- "$f" "$staging" || gg_collection_error "could not stage a rewrite of $(gg_shown "$f")"
-  if ! cat -- "$GG_TMP/reflowed" >"$staging"; then
-    rm -f -- "$staging"
-    gg_collection_error "could not write the rewrite of $(gg_shown "$f")"
-  fi
-  mv -f -- "$staging" "$f" || gg_collection_error "could not replace $(gg_shown "$f")"
+  gg_install_file "$GG_TMP/reflowed" "$f" "the reflowed markdown"
   echo "md-reflow: reflowed $(gg_shown "$f")"
   reflowed=$((reflowed + 1))
 done <"$GG_TMP/targets.z"

--- a/skills/growth-guards/tests/md-reflow.test.sh
+++ b/skills/growth-guards/tests/md-reflow.test.sh
@@ -205,6 +205,27 @@ git -C "$R" add -A
 run_in "$R" "$MDF" --all
 [ "$RC" -eq 0 ] && ok "control: md-format --all passes on what --all reflowed" || bad "control: md-format after --all" "rc=$RC out=$OUT"
 
+echo "=== a failed replacement preserves the file and removes its staging file ==="
+new_repo replacement
+printf 'Wrapped\ntext.\n' >"$R/doc.md"
+cp "$R/doc.md" "$TMP/original.md"
+mkdir -p "$TMP/fail-bin"
+cat >"$TMP/fail-bin/mv" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'injected rename failure\n' >&2
+exit 1
+STUB
+chmod +x "$TMP/fail-bin/mv"
+run_in "$R" env PATH="$TMP/fail-bin:$PATH" "$MDR" doc.md
+[ "$RC" -eq 2 ] && cmp -s "$R/doc.md" "$TMP/original.md" \
+  && ok "rename failure is an error and preserves the original bytes" || bad "failed replacement" "rc=$RC out=$OUT"
+leftovers="$(find "$R" -maxdepth 1 -type f ! -name doc.md -print)"
+[ -z "$leftovers" ] && ok "failed replacement removes the staging file" || bad "staging file cleanup" "$leftovers"
+run_in "$R" "$MDR" doc.md
+[ "$RC" -eq 0 ] && [ "$(cat "$R/doc.md")" = 'Wrapped text.' ] \
+  && ok "the same file reflows when rename succeeds" || bad "successful replacement control" "rc=$RC out=$OUT"
+
 echo "=== the skill's own shipped markdown is a fixed point ==="
 new_repo self
 mkdir -p "$R/skills/growth-guards"


### PR DESCRIPTION
A failed markdown replacement leaves a temporary file beside the document. md-reflow now uses the shared replacement helper, which preserves the original bytes and removes its staging file on failure.

Validation: the cleanup control fails against the original writer. The reflow suite passes all 50 checks. One local review and the full repository commit chain pass.

Hold for overseer review. Merge only after a new MERGE directive.

Part of KEN-1203.
