### PR TITLE
refactor(growth-guards): share staged text selection

### DIFF
--- a/.agents/skills/growth-guards/scripts/comments
+++ b/.agents/skills/growth-guards/scripts/comments
@@ -256,47 +256,21 @@ index_lane() {
 # text is extracted from the WHOLE staged blob, because a block comment's
 # state comes from lines the commit did not touch, and only hits on the
 # lines the diff adds are reported.
+staged_file() { # PATH BLOBFILE SHA
+  local f="$1" blob="$2" allow rec
+  family_or_skip "$f" "$blob" || return 0
+  # Extract from the whole blob, but report only lines added by the diff.
+  gg_staged_added_lines "$f" >"$GG_TMP/added"
+  allow=$'\n'
+  while IFS= read -r rec; do
+    allow="$allow${rec%%"$GG_TAB"*}"$'\n'
+  done <"$GG_TMP/added"
+  [ "$allow" != $'\n' ] || return 0
+  judge_blob "$FAM" "$f" "$blob" "$allow"
+}
+
 staged_lane() {
-  local meta f dstmode dstsha allow rec
-  gg_require_merged_index
-  git -c diff.renames=true diff --cached --raw --no-abbrev -z --find-renames=100% \
-    --diff-filter=AMT >"$GG_TMP/raw.z" \
-    || gg_collection_error "could not collect the staged changes (git diff --cached --raw failed)"
-  while IFS= read -r -d '' meta && IFS= read -r -d '' f; do
-    # Record shape: ":srcmode dstmode srcsha dstsha status". Only A, M and T
-    # survive the filter, none of which renames a path, so each carries one.
-    set -- $meta
-    dstmode="$2"
-    dstsha="$4"
-    gg_matches_path_glob "$f" || continue
-    gg_is_excluded "$f" && continue
-    case "$dstmode" in
-      120000)
-        gg_note_skip "$f" "tracked as a symlink, not source"
-        continue
-        ;;
-      160000)
-        gg_note_skip "$f" "tracked as a submodule gitlink, not source"
-        continue
-        ;;
-    esac
-    gg_read_blob "$dstsha" "$f" "source file"
-    if gg_blob_is_binary "$GG_TMP/blob" "$f"; then
-      gg_note_skip "$f" "binary content, not source"
-      continue
-    fi
-    family_or_skip "$f" "$GG_TMP/blob" || continue
-    # The admitted set is one newline-delimited string matched by `case`,
-    # the shape todo-ban's carrier set takes: Bash 3.2 has no associative
-    # array. A blob the diff gives no line to has nothing to judge.
-    gg_staged_added_lines "$f" >"$GG_TMP/added"
-    allow=$'\n'
-    while IFS= read -r rec; do
-      allow="$allow${rec%%"$GG_TAB"*}"$'\n'
-    done <"$GG_TMP/added"
-    [ "$allow" != $'\n' ] || continue
-    judge_blob "$FAM" "$f" "$GG_TMP/blob" "$allow"
-  done <"$GG_TMP/raw.z"
+  gg_walk_staged_paths source staged_file
 }
 
 unmeasured() { # the qualifier for this run, empty when everything matched was read
@@ -304,7 +278,6 @@ unmeasured() { # the qualifier for this run, empty when everything matched was r
 }
 
 if [ "$MODE" = "staged" ]; then
-  : >"$GG_TMP/skipped.z"
   staged_lane
   if [ "$GG_COMMENT_EXTRACT_ERRORS" -gt 0 ]; then
     echo "comments: scan incomplete — $GG_COMMENT_EXTRACT_ERRORS file(s) could not be scanned; $GG_VIOLATIONS history reference(s) found in $MATCHED scanned file(s)$(unmeasured)"

--- a/.agents/skills/growth-guards/scripts/lib/configured-paths.sh
+++ b/.agents/skills/growth-guards/scripts/lib/configured-paths.sh
@@ -1,40 +1,9 @@
 # shellcheck shell=bash
-# How a lane scoped by a glob list over repo-relative paths finds its content
-# and decides what it may measure: the glob list, the walk over the index
-# records, and the classification of every shape at a configured path that is
-# not the content the lane reads.
-#
-# TWO glob lists, one matcher. A lane names the paths it is FOR with a
-# configured list, and names the paths it is NOT for with an excludes file
-# read out of the index. Both are shell globs over the full repo-relative
-# path and both go through gg_path_matches, so the two answers cannot come
-# from two spellings; the excludes half sits at the foot of this file.
-#
-# Sourced by lib/common.sh, never executed; the family contract and every
-# helper it leans on (gg_config_error, gg_config_path, gg_require_merged_index,
-# gg_shown) live there.
-#
-# Bash 3.2-safe throughout, like its parent.
+# Shared configured paths, exclusions, policy reads, and text walks.
+# Callers disable pathname expansion with set -f. Patterns match the full
+# repository-relative path; includes and exclusions use gg_path_matches.
+# common.sh loads this file and supplies its diagnostics and path checks.
 
-# --- configured path globs: one setting naming a space-separated list -------
-# The lanes scoped by a PATH LIST rather than by an excludes file share this.
-# Each pattern goes through the family's path discipline — absolute, escaping
-# and '-'-leading values are configuration errors, never a glob that quietly
-# matches nothing — and an empty list is one too: a check that measures
-# nowhere while reporting OK is the silent pass this family refuses, and
-# dropping the check from GROWTH_GUARDS_CHECKS is how it is turned off.
-#
-# The caller runs under `set -f`. The list is word-split, and pathname
-# expansion would resolve each pattern against the WORK TREE — matching
-# whatever happens to be checked out instead of the tracked paths the scan
-# judges, and matching nothing at all in a sparse or bare checkout.
-
-# A setting holding a LIST of path globs, validated the way one path is. The
-# caller word-splits the result, so every check that reads a glob list applies
-# the same path discipline: absolute, escaping and '-'-leading entries are
-# configuration errors rather than globs that quietly match nothing. An empty
-# result means the setting named nothing — the caller decides whether that is
-# a switched-off check or an error.
 gg_config_path_list() { # RAW LABEL — normalized globs, space-separated, on stdout
   local raw="$1" label="$2" entry norm out=""
   # Callers run under `set -f`, so this splits on whitespace without the shell
@@ -269,6 +238,40 @@ gg_walk_configured_paths() { # NOUN UNREAD-NOUN ON_FILE
     fi
     "$on_file" "$f" "$GG_TMP/blob" "$sha"
   done <"$GG_TMP/files.z"
+}
+
+# The staged text walk shares selection and blob classification across lanes.
+# A pure rename adds no content. A rename with changed bytes is an addition.
+gg_walk_staged_paths() { # NOUN ON_FILE — callback receives PATH BLOBFILE SHA
+  local noun="$1" on_file="$2" meta f dstmode dstsha
+  GG_WALK_SKIPPED=0
+  : >"$GG_TMP/skipped.z"
+  gg_require_merged_index
+  git -c diff.renames=true diff --cached --raw --no-abbrev -z --find-renames=100% --diff-filter=AMT >"$GG_TMP/raw.z" \
+    || gg_collection_error "could not collect the staged changes (git diff --cached --raw failed)"
+  while IFS= read -r -d '' meta && IFS= read -r -d '' f; do
+    gg_matches_path_glob "$f" || continue
+    gg_is_excluded "$f" && continue
+    set -- $meta
+    dstmode="$2"
+    dstsha="$4"
+    case "$dstmode" in
+      120000)
+        gg_note_skip "$f" "tracked as a symlink, not $noun"
+        continue
+        ;;
+      160000)
+        gg_note_skip "$f" "tracked as a submodule gitlink, not $noun"
+        continue
+        ;;
+    esac
+    gg_read_blob "$dstsha" "$f" "$noun file"
+    if gg_blob_is_binary "$GG_TMP/blob" "$f"; then
+      gg_note_skip "$f" "binary content, not $noun"
+      continue
+    fi
+    "$on_file" "$f" "$GG_TMP/blob" "$dstsha"
+  done <"$GG_TMP/raw.z"
 }
 
 # --- exclusion list: pattern<TAB>reason, reason mandatory --------------------

--- a/.agents/skills/growth-guards/scripts/lib/md-scope.sh
+++ b/.agents/skills/growth-guards/scripts/lib/md-scope.sh
@@ -66,7 +66,7 @@ gg_md_load_paths() { # LANE KEY DEFAULT
 # $GG_TMP/md-files.z, every one a text blob the lane may read. Sets
 # GG_MD_COUNT; the skips are counted in GG_WALK_SKIPPED.
 gg_md_select() { # NOUN — what the lane calls its content, for the skip lines
-  local noun="$1" meta f dstmode dstsha
+  local noun="$1"
   GG_MD_COUNT=0
   : >"$GG_TMP/md-files.z"
   case "$GG_MD_MODE" in
@@ -74,37 +74,7 @@ gg_md_select() { # NOUN — what the lane calls its content, for the skip lines
       gg_walk_configured_paths "$noun" file gg_md_take
       ;;
     staged)
-      GG_WALK_SKIPPED=0
-      : >"$GG_TMP/skipped.z"
-      gg_require_merged_index
-      # A, M and T, renames at exact content: a pure move carries no new
-      # bytes, a file that moved and changed is read whole at its new path.
-      git -c diff.renames=true diff --cached --raw --no-abbrev -z --find-renames=100% --diff-filter=AMT >"$GG_TMP/raw.z" \
-        || gg_collection_error "could not collect the staged changes (git diff --cached --raw failed)"
-      while IFS= read -r -d '' meta && IFS= read -r -d '' f; do
-        gg_matches_path_glob "$f" || continue
-        gg_is_excluded "$f" && continue
-        # Record shape: ":srcmode dstmode srcsha dstsha status".
-        set -- $meta
-        dstmode="$2"
-        dstsha="$4"
-        case "$dstmode" in
-          120000)
-            gg_note_skip "$f" "tracked as a symlink, not $noun"
-            continue
-            ;;
-          160000)
-            gg_note_skip "$f" "tracked as a submodule gitlink, not $noun"
-            continue
-            ;;
-        esac
-        gg_read_blob "$dstsha" "$f" file
-        if gg_blob_is_binary "$GG_TMP/blob" "$f"; then
-          gg_note_skip "$f" "binary content, not $noun"
-          continue
-        fi
-        gg_md_take "$f" "$GG_TMP/blob" "$dstsha"
-      done <"$GG_TMP/raw.z"
+      gg_walk_staged_paths "$noun" gg_md_take
       ;;
     *) gg_config_error "gg_md_select: no scope resolved (GG_MD_MODE='$GG_MD_MODE')" ;;
   esac

--- a/.agents/skills/growth-guards/tests/md-reflow.test.sh
+++ b/.agents/skills/growth-guards/tests/md-reflow.test.sh
@@ -226,6 +226,20 @@ run_in "$R" "$MDR" doc.md
 [ "$RC" -eq 0 ] && [ "$(cat "$R/doc.md")" = 'Wrapped text.' ] \
   && ok "the same file reflows when rename succeeds" || bad "successful replacement control" "rc=$RC out=$OUT"
 
+echo "=== staged reflow honors exclusions ==="
+new_repo staged-exclusion
+mkdir -p "$R/tools"
+printf 'Wrapped\ntext.\n' >"$R/doc.md"
+printf 'doc.md\tvendored document\n' >"$R/tools/md-excludes"
+git -C "$R" add -A
+run_in "$R" "$MDR" --staged
+[ "$RC" -eq 0 ] && [ "$(cat "$R/doc.md")" = $'Wrapped\ntext.' ] \
+  && ok "staged reflow leaves the excluded document unchanged" || bad "staged exclusion" "rc=$RC out=$OUT"
+git -C "$R" rm -qf tools/md-excludes
+run_in "$R" "$MDR" --staged
+[ "$RC" -eq 0 ] && [ "$(cat "$R/doc.md")" = 'Wrapped text.' ] \
+  && ok "the same staged document reflows without its exclusion" || bad "staged exclusion control" "rc=$RC out=$OUT"
+
 echo "=== the skill's own shipped markdown is a fixed point ==="
 new_repo self
 mkdir -p "$R/skills/growth-guards"

--- a/.agents/skills/growth-guards/tests/md-refs.test.sh
+++ b/.agents/skills/growth-guards/tests/md-refs.test.sh
@@ -197,6 +197,18 @@ run_refs --staged
 [ "$RC" -eq 1 ] && case "$OUT" in *"no tracked file or directory at ok.md"*) true ;; *) false ;; esac \
   && ok "a link to a file the commit deletes is dead" || bad "deleted target is dead" "rc=$RC out=$OUT"
 
+echo "=== staged references honor exclusions ==="
+new_repo staged-exclusion
+put AGENTS.md $'[dead](missing.md)\n'
+put tools/md-excludes $'AGENTS.md\tvendored instructions\n'
+run_refs --staged
+[ "$RC" -eq 0 ] && case "$OUT" in *"no staged markdown file(s) to judge"*) true ;; *) false ;; esac \
+  && ok "the staged scan excludes the declared document" || bad "staged exclusion" "rc=$RC out=$OUT"
+git -C "$R" rm -qf tools/md-excludes
+run_refs --staged
+[ "$RC" -eq 1 ] && case "$OUT" in *"no tracked file or directory at missing.md"*) true ;; *) false ;; esac \
+  && ok "the same staged reference fails without its exclusion" || bad "staged exclusion control" "rc=$RC out=$OUT"
+
 echo "=== refusals and unmeasured paths ==="
 new_repo refuse
 put AGENTS.md $'Para\n\n```\nopen\n'

--- a/skills/growth-guards/scripts/comments
+++ b/skills/growth-guards/scripts/comments
@@ -256,47 +256,21 @@ index_lane() {
 # text is extracted from the WHOLE staged blob, because a block comment's
 # state comes from lines the commit did not touch, and only hits on the
 # lines the diff adds are reported.
+staged_file() { # PATH BLOBFILE SHA
+  local f="$1" blob="$2" allow rec
+  family_or_skip "$f" "$blob" || return 0
+  # Extract from the whole blob, but report only lines added by the diff.
+  gg_staged_added_lines "$f" >"$GG_TMP/added"
+  allow=$'\n'
+  while IFS= read -r rec; do
+    allow="$allow${rec%%"$GG_TAB"*}"$'\n'
+  done <"$GG_TMP/added"
+  [ "$allow" != $'\n' ] || return 0
+  judge_blob "$FAM" "$f" "$blob" "$allow"
+}
+
 staged_lane() {
-  local meta f dstmode dstsha allow rec
-  gg_require_merged_index
-  git -c diff.renames=true diff --cached --raw --no-abbrev -z --find-renames=100% \
-    --diff-filter=AMT >"$GG_TMP/raw.z" \
-    || gg_collection_error "could not collect the staged changes (git diff --cached --raw failed)"
-  while IFS= read -r -d '' meta && IFS= read -r -d '' f; do
-    # Record shape: ":srcmode dstmode srcsha dstsha status". Only A, M and T
-    # survive the filter, none of which renames a path, so each carries one.
-    set -- $meta
-    dstmode="$2"
-    dstsha="$4"
-    gg_matches_path_glob "$f" || continue
-    gg_is_excluded "$f" && continue
-    case "$dstmode" in
-      120000)
-        gg_note_skip "$f" "tracked as a symlink, not source"
-        continue
-        ;;
-      160000)
-        gg_note_skip "$f" "tracked as a submodule gitlink, not source"
-        continue
-        ;;
-    esac
-    gg_read_blob "$dstsha" "$f" "source file"
-    if gg_blob_is_binary "$GG_TMP/blob" "$f"; then
-      gg_note_skip "$f" "binary content, not source"
-      continue
-    fi
-    family_or_skip "$f" "$GG_TMP/blob" || continue
-    # The admitted set is one newline-delimited string matched by `case`,
-    # the shape todo-ban's carrier set takes: Bash 3.2 has no associative
-    # array. A blob the diff gives no line to has nothing to judge.
-    gg_staged_added_lines "$f" >"$GG_TMP/added"
-    allow=$'\n'
-    while IFS= read -r rec; do
-      allow="$allow${rec%%"$GG_TAB"*}"$'\n'
-    done <"$GG_TMP/added"
-    [ "$allow" != $'\n' ] || continue
-    judge_blob "$FAM" "$f" "$GG_TMP/blob" "$allow"
-  done <"$GG_TMP/raw.z"
+  gg_walk_staged_paths source staged_file
 }
 
 unmeasured() { # the qualifier for this run, empty when everything matched was read
@@ -304,7 +278,6 @@ unmeasured() { # the qualifier for this run, empty when everything matched was r
 }
 
 if [ "$MODE" = "staged" ]; then
-  : >"$GG_TMP/skipped.z"
   staged_lane
   if [ "$GG_COMMENT_EXTRACT_ERRORS" -gt 0 ]; then
     echo "comments: scan incomplete — $GG_COMMENT_EXTRACT_ERRORS file(s) could not be scanned; $GG_VIOLATIONS history reference(s) found in $MATCHED scanned file(s)$(unmeasured)"

--- a/skills/growth-guards/scripts/lib/configured-paths.sh
+++ b/skills/growth-guards/scripts/lib/configured-paths.sh
@@ -1,40 +1,9 @@
 # shellcheck shell=bash
-# How a lane scoped by a glob list over repo-relative paths finds its content
-# and decides what it may measure: the glob list, the walk over the index
-# records, and the classification of every shape at a configured path that is
-# not the content the lane reads.
-#
-# TWO glob lists, one matcher. A lane names the paths it is FOR with a
-# configured list, and names the paths it is NOT for with an excludes file
-# read out of the index. Both are shell globs over the full repo-relative
-# path and both go through gg_path_matches, so the two answers cannot come
-# from two spellings; the excludes half sits at the foot of this file.
-#
-# Sourced by lib/common.sh, never executed; the family contract and every
-# helper it leans on (gg_config_error, gg_config_path, gg_require_merged_index,
-# gg_shown) live there.
-#
-# Bash 3.2-safe throughout, like its parent.
+# Shared configured paths, exclusions, policy reads, and text walks.
+# Callers disable pathname expansion with set -f. Patterns match the full
+# repository-relative path; includes and exclusions use gg_path_matches.
+# common.sh loads this file and supplies its diagnostics and path checks.
 
-# --- configured path globs: one setting naming a space-separated list -------
-# The lanes scoped by a PATH LIST rather than by an excludes file share this.
-# Each pattern goes through the family's path discipline — absolute, escaping
-# and '-'-leading values are configuration errors, never a glob that quietly
-# matches nothing — and an empty list is one too: a check that measures
-# nowhere while reporting OK is the silent pass this family refuses, and
-# dropping the check from GROWTH_GUARDS_CHECKS is how it is turned off.
-#
-# The caller runs under `set -f`. The list is word-split, and pathname
-# expansion would resolve each pattern against the WORK TREE — matching
-# whatever happens to be checked out instead of the tracked paths the scan
-# judges, and matching nothing at all in a sparse or bare checkout.
-
-# A setting holding a LIST of path globs, validated the way one path is. The
-# caller word-splits the result, so every check that reads a glob list applies
-# the same path discipline: absolute, escaping and '-'-leading entries are
-# configuration errors rather than globs that quietly match nothing. An empty
-# result means the setting named nothing — the caller decides whether that is
-# a switched-off check or an error.
 gg_config_path_list() { # RAW LABEL — normalized globs, space-separated, on stdout
   local raw="$1" label="$2" entry norm out=""
   # Callers run under `set -f`, so this splits on whitespace without the shell
@@ -269,6 +238,40 @@ gg_walk_configured_paths() { # NOUN UNREAD-NOUN ON_FILE
     fi
     "$on_file" "$f" "$GG_TMP/blob" "$sha"
   done <"$GG_TMP/files.z"
+}
+
+# The staged text walk shares selection and blob classification across lanes.
+# A pure rename adds no content. A rename with changed bytes is an addition.
+gg_walk_staged_paths() { # NOUN ON_FILE — callback receives PATH BLOBFILE SHA
+  local noun="$1" on_file="$2" meta f dstmode dstsha
+  GG_WALK_SKIPPED=0
+  : >"$GG_TMP/skipped.z"
+  gg_require_merged_index
+  git -c diff.renames=true diff --cached --raw --no-abbrev -z --find-renames=100% --diff-filter=AMT >"$GG_TMP/raw.z" \
+    || gg_collection_error "could not collect the staged changes (git diff --cached --raw failed)"
+  while IFS= read -r -d '' meta && IFS= read -r -d '' f; do
+    gg_matches_path_glob "$f" || continue
+    gg_is_excluded "$f" && continue
+    set -- $meta
+    dstmode="$2"
+    dstsha="$4"
+    case "$dstmode" in
+      120000)
+        gg_note_skip "$f" "tracked as a symlink, not $noun"
+        continue
+        ;;
+      160000)
+        gg_note_skip "$f" "tracked as a submodule gitlink, not $noun"
+        continue
+        ;;
+    esac
+    gg_read_blob "$dstsha" "$f" "$noun file"
+    if gg_blob_is_binary "$GG_TMP/blob" "$f"; then
+      gg_note_skip "$f" "binary content, not $noun"
+      continue
+    fi
+    "$on_file" "$f" "$GG_TMP/blob" "$dstsha"
+  done <"$GG_TMP/raw.z"
 }
 
 # --- exclusion list: pattern<TAB>reason, reason mandatory --------------------

--- a/skills/growth-guards/scripts/lib/md-scope.sh
+++ b/skills/growth-guards/scripts/lib/md-scope.sh
@@ -66,7 +66,7 @@ gg_md_load_paths() { # LANE KEY DEFAULT
 # $GG_TMP/md-files.z, every one a text blob the lane may read. Sets
 # GG_MD_COUNT; the skips are counted in GG_WALK_SKIPPED.
 gg_md_select() { # NOUN — what the lane calls its content, for the skip lines
-  local noun="$1" meta f dstmode dstsha
+  local noun="$1"
   GG_MD_COUNT=0
   : >"$GG_TMP/md-files.z"
   case "$GG_MD_MODE" in
@@ -74,37 +74,7 @@ gg_md_select() { # NOUN — what the lane calls its content, for the skip lines
       gg_walk_configured_paths "$noun" file gg_md_take
       ;;
     staged)
-      GG_WALK_SKIPPED=0
-      : >"$GG_TMP/skipped.z"
-      gg_require_merged_index
-      # A, M and T, renames at exact content: a pure move carries no new
-      # bytes, a file that moved and changed is read whole at its new path.
-      git -c diff.renames=true diff --cached --raw --no-abbrev -z --find-renames=100% --diff-filter=AMT >"$GG_TMP/raw.z" \
-        || gg_collection_error "could not collect the staged changes (git diff --cached --raw failed)"
-      while IFS= read -r -d '' meta && IFS= read -r -d '' f; do
-        gg_matches_path_glob "$f" || continue
-        gg_is_excluded "$f" && continue
-        # Record shape: ":srcmode dstmode srcsha dstsha status".
-        set -- $meta
-        dstmode="$2"
-        dstsha="$4"
-        case "$dstmode" in
-          120000)
-            gg_note_skip "$f" "tracked as a symlink, not $noun"
-            continue
-            ;;
-          160000)
-            gg_note_skip "$f" "tracked as a submodule gitlink, not $noun"
-            continue
-            ;;
-        esac
-        gg_read_blob "$dstsha" "$f" file
-        if gg_blob_is_binary "$GG_TMP/blob" "$f"; then
-          gg_note_skip "$f" "binary content, not $noun"
-          continue
-        fi
-        gg_md_take "$f" "$GG_TMP/blob" "$dstsha"
-      done <"$GG_TMP/raw.z"
+      gg_walk_staged_paths "$noun" gg_md_take
       ;;
     *) gg_config_error "gg_md_select: no scope resolved (GG_MD_MODE='$GG_MD_MODE')" ;;
   esac

--- a/skills/growth-guards/tests/md-reflow.test.sh
+++ b/skills/growth-guards/tests/md-reflow.test.sh
@@ -226,6 +226,20 @@ run_in "$R" "$MDR" doc.md
 [ "$RC" -eq 0 ] && [ "$(cat "$R/doc.md")" = 'Wrapped text.' ] \
   && ok "the same file reflows when rename succeeds" || bad "successful replacement control" "rc=$RC out=$OUT"
 
+echo "=== staged reflow honors exclusions ==="
+new_repo staged-exclusion
+mkdir -p "$R/tools"
+printf 'Wrapped\ntext.\n' >"$R/doc.md"
+printf 'doc.md\tvendored document\n' >"$R/tools/md-excludes"
+git -C "$R" add -A
+run_in "$R" "$MDR" --staged
+[ "$RC" -eq 0 ] && [ "$(cat "$R/doc.md")" = $'Wrapped\ntext.' ] \
+  && ok "staged reflow leaves the excluded document unchanged" || bad "staged exclusion" "rc=$RC out=$OUT"
+git -C "$R" rm -qf tools/md-excludes
+run_in "$R" "$MDR" --staged
+[ "$RC" -eq 0 ] && [ "$(cat "$R/doc.md")" = 'Wrapped text.' ] \
+  && ok "the same staged document reflows without its exclusion" || bad "staged exclusion control" "rc=$RC out=$OUT"
+
 echo "=== the skill's own shipped markdown is a fixed point ==="
 new_repo self
 mkdir -p "$R/skills/growth-guards"

--- a/skills/growth-guards/tests/md-refs.test.sh
+++ b/skills/growth-guards/tests/md-refs.test.sh
@@ -197,6 +197,18 @@ run_refs --staged
 [ "$RC" -eq 1 ] && case "$OUT" in *"no tracked file or directory at ok.md"*) true ;; *) false ;; esac \
   && ok "a link to a file the commit deletes is dead" || bad "deleted target is dead" "rc=$RC out=$OUT"
 
+echo "=== staged references honor exclusions ==="
+new_repo staged-exclusion
+put AGENTS.md $'[dead](missing.md)\n'
+put tools/md-excludes $'AGENTS.md\tvendored instructions\n'
+run_refs --staged
+[ "$RC" -eq 0 ] && case "$OUT" in *"no staged markdown file(s) to judge"*) true ;; *) false ;; esac \
+  && ok "the staged scan excludes the declared document" || bad "staged exclusion" "rc=$RC out=$OUT"
+git -C "$R" rm -qf tools/md-excludes
+run_refs --staged
+[ "$RC" -eq 1 ] && case "$OUT" in *"no tracked file or directory at missing.md"*) true ;; *) false ;; esac \
+  && ok "the same staged reference fails without its exclusion" || bad "staged exclusion control" "rc=$RC out=$OUT"
+
 echo "=== refusals and unmeasured paths ==="
 new_repo refuse
 put AGENTS.md $'Para\n\n```\nopen\n'


### PR DESCRIPTION
Comments and markdown checks duplicate staged-file selection and blob classification. They now use one shared text scanner. Comment checks retain their added-line filter; markdown checks retain their selected-file scope.

Validation: focused caller and shared-index suites pass. Disabling staged exclusions fails a control in every caller suite. One local review passes. The full commit chain passes after repeated library comments were removed to meet the size cap.

Hold for overseer review. Merge only after a new MERGE directive.

Part of KEN-1203.
