### PR TITLE
fix(growth-guards): check incoming markdown references

### DIFF
--- a/.agents/skills/growth-guards/CHECKS.md
+++ b/.agents/skills/growth-guards/CHECKS.md
@@ -124,15 +124,16 @@ An unterminated fence, front matter, HTML comment or prompt-section block is exi
 
 ## md-refs
 
-A dead reference in a scanned markdown file fails. Fenced code, indented code and front matter are never read. Three forms:
+A dead reference in a scanned markdown file fails. Fenced code, indented code and front matter are never read. Forms:
 
 - A link or reference definition whose destination is relative (no scheme, no leading `/`, not `mailto:`) must name a tracked file or directory, resolved against the citing file's directory; `..` above the repository root is dead. With `#anchor`, the target must be markdown and the anchor one of its heading slugs or an explicit `<a id="...">` or `<a name="...">`; a bare `#anchor` resolves in the citing file. A definition is read only where the line begins with its `[label]:`.
 - A code span holding `<path>.md § Heading` must name a tracked file with a heading equal to `Heading` case-insensitively after trimming; one holding `<path>.md#anchor` a tracked file with that slug or explicit anchor. The path resolves against the citing file's directory, then the repository root. A path alone in a code span is not judged.
+- A relative markdown link followed by `§` must start with an existing heading name from that target. Matching ignores case, backticks, and emphasis markers. The heading name ends at a word boundary; prose can follow it. A section number also resolves to a heading with that number. Text routes check a heading prefix. Use an anchor link or an exact code-span citation where heading names share a prefix.
 - A decision ID, `DECISION_ID_PREFIX` plus at least `DECISION_ID_WIDTH` digits bounded by non-alphanumerics, must have a tracked file `DECISIONS_DIR/<ID>-*.md`; where that directory is not tracked, IDs are not judged and the verdict says so.
 
 The slug is GitHub's: link syntax, code-span backticks and HTML tags reduce to their text; ASCII letters lower-case (a non-ASCII letter keeps its case); every character not a letter, digit, space, `-` or `_` is dropped; each space becomes a hyphen; a repeat takes the first free `-1`, `-2` suffix.
 
-Scopes are md-format's over `GROWTH_GUARDS_MD_REFS_PATHS` minus `GROWTH_GUARDS_MD_EXCLUDES`, with the same `GROWTH_GUARDS_MD_SCOPE`. Targets resolve against the index whatever the scope, so a link into a file the commit deletes is dead; a tracked path holding a newline is no link target.
+`--staged` and `--all` check every tracked file named by `GROWTH_GUARDS_MD_REFS_PATHS` minus `GROWTH_GUARDS_MD_EXCLUDES`. With neither flag, `GROWTH_GUARDS_MD_SCOPE=touched` checks that set when any change is staged, including deletions; `all` checks it unconditionally. This includes references in unchanged documents. Callers and targets resolve against the index; a tracked path holding a newline is no link target.
 
 ## comments
 

--- a/.agents/skills/growth-guards/DEVELOPMENT.md
+++ b/.agents/skills/growth-guards/DEVELOPMENT.md
@@ -62,7 +62,7 @@ Every step runs before the verdict; any other companion failure blocks. The shim
 - md-refs runs the `lines` stream through `md-refs.awk`, then resolves in three passes: every selected file's references, the headings of every cited file read from the index whether or not in scope, then the verdict.
 - Both programs are POSIX awk (no interval expressions, no gawk builtins) under `LC_ALL=C`; `mawk` and `gawk --posix` give the same records over the suites' fixtures.
 - The reflow is the check's state machine printing instead of complaining, so a reflowed file passes md-format by construction; `tests/md-reflow.test.sh` proves it over the corpus and proves each rewrite is a fixed point.
-- md-format and md-refs are in `STAGED_SCOPED_CHECKS`; a repository widens them with `GROWTH_GUARDS_MD_SCOPE=all` after reflowing its tree.
+- The batch passes `--staged` to both markdown checks. md-format selects changed documents; md-refs checks all configured documents against the index. `GROWTH_GUARDS_MD_SCOPE=all` makes unflagged checks unconditional.
 
 ## todo-ban marker shapes
 

--- a/.agents/skills/growth-guards/README.md
+++ b/.agents/skills/growth-guards/README.md
@@ -34,7 +34,7 @@ Every check is a standalone executable with one exit contract: `0` clean, `1` vi
 
 The `pre-commit` hook judges one commit snapshot and `commit-msg` runs the message gate; the chain and its order are [DEVELOPMENT.md](DEVELOPMENT.md) § The pre-commit chain. Both block on any failure; `git commit --no-verify` is the only bypass.
 
-The markdown lanes start narrow: `md-format` and `md-refs` judge the files a commit touches. Reflow the tree once with `scripts/md-reflow --all`, commit, then set `GROWTH_GUARDS_MD_SCOPE = "all"` so CI judges every tracked markdown file. Vendored or generated markdown goes in `tools/md-excludes` with a reason.
+`md-format` starts with changed documents. `md-refs` checks all configured documents when any change is staged, so it also finds broken references from unchanged callers. Reflow the tree with `scripts/md-reflow --all`, then set `GROWTH_GUARDS_MD_SCOPE = "all"` for unconditional checks. Put vendored or generated markdown in `tools/md-excludes` with a reason.
 
 In CI, run the batch without `--staged`: the index-wide `todo-ban` scan is the only lane that sees a marker no commit ever diffed. `byte-ceiling --base origin/main` gates a PR's additions and file-size growth.
 

--- a/.agents/skills/growth-guards/SKILL.md
+++ b/.agents/skills/growth-guards/SKILL.md
@@ -59,7 +59,7 @@ Problems with a kendex-owned skill go through `kendex report`; check ownership i
 | **changelog-entries** | Each `GROWTH_GUARDS_CHANGELOG_PATHS` fragment is one Markdown list item in a Keep a Changelog section and at most `GROWTH_GUARDS_CHANGELOG_CAP` characters. |
 | **prose** | A history reference in Markdown named by `GROWTH_GUARDS_PROSE_PATHS` fails; `GROWTH_GUARDS_CHECKS` controls whether the lane runs. |
 | **md-format** | A hard-wrapped paragraph or list item, a missing blank line around a heading, fence or list, or a trailing-double-space break in Markdown named by `GROWTH_GUARDS_MD_PATHS` fails; `md-reflow` is the remedy. |
-| **md-refs** | A relative link, a `<path>.md § Heading` or `<path>.md#anchor` code-span citation, or a decision ID in Markdown named by `GROWTH_GUARDS_MD_REFS_PATHS` that lands on no tracked file, heading or decision fails. |
+| **md-refs** | A relative link, a link followed by `§` and a heading prefix, a `<path>.md § Heading` or `<path>.md#anchor` code-span citation, or a decision ID in Markdown named by `GROWTH_GUARDS_MD_REFS_PATHS` that lands on no tracked file, heading or decision fails. |
 | **comments** | A history reference in the comment text of a source file named by `GROWTH_GUARDS_COMMENT_PATHS` fails: an issue id (`GH_ISSUE_PATTERN`), `#NNN`, or a date. Opt-in: name it in `GROWTH_GUARDS_CHECKS`. |
 | **commit-msg** | The header must be `type(scope)!: subject` within `GROWTH_GUARDS_SUBJECT_MAX`; a commit touching `GROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS` also owes a changelog entry or `[no-changelog]`. |
 
@@ -96,7 +96,7 @@ Exclude immutable first-party sources, including applied SQL migrations, from th
 | `GROWTH_GUARDS_MD_PATHS` | `*.md` | Globs naming the markdown md-format and md-reflow take under `--all`. |
 | `GROWTH_GUARDS_MD_REFS_PATHS` | the `GROWTH_GUARDS_PROSE_PATHS` default | Globs naming the markdown md-refs judges under `--all`. |
 | `GROWTH_GUARDS_MD_EXCLUDES` | `tools/md-excludes` | Exclusion list both markdown lanes honour in every scope, and md-reflow under `--staged` and `--all`. |
-| `GROWTH_GUARDS_MD_SCOPE` | `touched` | What the markdown lanes judge with neither `--staged` nor `--all`: `touched` is the staged files, and nothing when nothing is staged; `all` is every tracked matching file. |
+| `GROWTH_GUARDS_MD_SCOPE` | `touched` | With neither flag, `touched` runs md-format on staged files and md-refs on all configured documents when anything is staged; `all` checks every matching file. |
 | `DECISIONS_DIR`, `DECISION_ID_PREFIX`, `DECISION_ID_WIDTH` | `docs/decisions`, `D`, `3` | The decider skill's scheme, read by md-refs to judge decision IDs; IDs are not judged where the directory is not tracked. |
 | `GROWTH_GUARDS_COMMENT_PATHS` | the extensions in [CHECKS.md § comments](CHECKS.md#comments) | Space-separated globs naming the source files the comments lane scans, matched against the full repo-relative path (`*` crosses `/`); replaces the default. |
 | `GROWTH_GUARDS_COMMENT_EXCLUDES` | `tools/comments-excludes` | comments exclusion list (generated, vendored, and immutable first-party files). `GH_ISSUE_PATTERN` (the github skill's key) is the issue-id shape; empty keeps `[A-Z]+-[0-9]+`. |

--- a/.agents/skills/growth-guards/kendex.settings.toml.example
+++ b/.agents/skills/growth-guards/kendex.settings.toml.example
@@ -34,11 +34,9 @@ GROWTH_GUARDS_CHANGELOG_RECORD = "CHANGELOG.md"
 # Empty = rule off.
 GROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS = ""
 
-# What md-format and md-refs judge with neither --staged nor --all: "touched"
-# is the markdown files a commit touches, and nothing when nothing is staged;
-# "all" is every tracked file the path globs name. Set "all" once the
-# repository's markdown is reflowed (scripts/md-reflow --all), so CI judges
-# the whole tree.
+# Without flags, touched runs md-format on changed documents. It runs md-refs
+# on all configured documents when any change is staged. All runs both checks
+# unconditionally. Explicit --staged retains each lane's own scope.
 GROWTH_GUARDS_MD_SCOPE = "touched"
 
 # The markdown md-format and md-reflow take under --all, and the markdown

--- a/.agents/skills/growth-guards/scripts/growth-guards
+++ b/.agents/skills/growth-guards/scripts/growth-guards
@@ -24,9 +24,9 @@ KNOWN_CHECKS="todo-ban byte-ceiling suppression-ban conflict-markers changelog-e
 BATCH_DEFAULT="todo-ban byte-ceiling suppression-ban conflict-markers changelog-entries prose md-format md-refs"
 # The checks the batch hands --staged when it is asked for commit scope.
 # todo-ban and comments default to the whole index, which is a CI subject:
-# at commit each judges what the commit adds. md-format and md-refs judge
-# the markdown files a commit touches, in full, until GROWTH_GUARDS_MD_SCOPE
-# widens them. byte-ceiling is already staged by default, and the rest read
+# at commit each judges what the commit adds. md-format judges touched
+# documents; md-refs checks every configured document for broken incoming
+# references. byte-ceiling is already staged by default, and the rest read
 # the index by design.
 STAGED_SCOPED_CHECKS="todo-ban md-format md-refs comments"
 
@@ -38,8 +38,9 @@ Checks: $KNOWN_CHECKS
 
 With no argument (or 'all'), runs every check named by
 GROWTH_GUARDS_CHECKS (default: $BATCH_DEFAULT).
---staged puts the batch at commit scope: the checks that take it
-($STAGED_SCOPED_CHECKS) judge the staged diff instead of the whole index.
+--staged is passed to: $STAGED_SCOPED_CHECKS.
+Those checks apply their own commit scope. md-refs checks all configured
+documents for broken references, including unchanged callers.
 commit-msg reads a message file/stdin and only runs by name.
 
 Exit codes: 0 clean; 1 violations; 2 usage/config/collection error, or

--- a/.agents/skills/growth-guards/scripts/lib/md-refs.awk
+++ b/.agents/skills/growth-guards/scripts/lib/md-refs.awk
@@ -52,32 +52,49 @@ function emit_explicit(content,   s, id) {
   }
 }
 
-# A destination beginning at P in S: the `<...>` form, or up to whitespace or
-# an unbalanced `)`, backslash escapes before ASCII punctuation resolved.
-function parse_dest(s, p,   c, out, depth) {
+# Parse the destination and retain its enclosing link's closing position.
+# Angle destinations, escaped punctuation, and optional titles share this read.
+function parse_dest(s, p,   c, out, depth, title) {
+  LINK_CLOSE = 0
   while (p <= length(s) && substr(s, p, 1) ~ /[ \t]/) p++
   out = ""
   if (substr(s, p, 1) == "<") {
     p++
     while (p <= length(s)) {
       c = substr(s, p, 1)
-      if (c == ">") return out
+      if (c == ">") { p++; break }
       if (c == "\\" && index(ESCAPABLE, substr(s, p + 1, 1)) > 0) { out = out substr(s, p + 1, 1); p += 2; continue }
       out = out c
       p++
     }
-    return out
+  } else {
+    depth = 0
+    while (p <= length(s)) {
+      c = substr(s, p, 1)
+      if (c == "\\" && index(ESCAPABLE, substr(s, p + 1, 1)) > 0) { out = out substr(s, p + 1, 1); p += 2; continue }
+      if (c ~ /[ \t]/) break
+      if (c == "(") depth++
+      else if (c == ")") { if (depth == 0) break; depth-- }
+      out = out c
+      p++
+    }
   }
-  depth = 0
-  while (p <= length(s)) {
-    c = substr(s, p, 1)
-    if (c == "\\" && index(ESCAPABLE, substr(s, p + 1, 1)) > 0) { out = out substr(s, p + 1, 1); p += 2; continue }
-    if (c ~ /[ \t]/) break
-    if (c == "(") depth++
-    else if (c == ")") { if (depth == 0) break; depth-- }
-    out = out c
+  while (p <= length(s) && substr(s, p, 1) ~ /[ \t]/) p++
+  title = substr(s, p, 1)
+  if (title == "\"" || title == "\047" || title == "(") {
     p++
+    depth = 1
+    while (p <= length(s) && depth > 0) {
+      c = substr(s, p, 1)
+      if (c == "\\" && index(ESCAPABLE, substr(s, p + 1, 1)) > 0) { p += 2; continue }
+      if (title == "(" && c == "(") depth++
+      else if (c == (title == "(" ? ")" : title)) depth--
+      p++
+    }
+    if (depth > 0) return out
+    while (p <= length(s) && substr(s, p, 1) ~ /[ \t]/) p++
   }
+  if (substr(s, p, 1) == ")") LINK_CLOSE = p
   return out
 }
 
@@ -96,17 +113,17 @@ function emit_links(s, original,   i, j, k, dest, raw, tail) {
     if (j == 0) break
     j = i + j - 1
     dest = parse_dest(s, j + 2)
-    k = index(substr(s, j), ")")
-    raw = (k > 0) ? substr(s, j, k) : substr(s, j)
+    k = LINK_CLOSE
+    raw = (k > 0) ? substr(s, j, k - j + 1) : substr(s, j)
     if (is_local(dest)) {
       printf "L\t%s\t%d\t%s\t%s\n", src, line_no, dest, raw
-      tail = (k > 0) ? substr(original, j + k) : ""
+      tail = (k > 0) ? substr(original, k + 1) : ""
       if (dest ~ /\.md$/ && tail ~ /^[ \t]+§[ \t]+/) {
         sub(/^[ \t]+§[ \t]+/, "", tail)
         printf "C\t%s\t%d\t%s\tprefix-section\t%s\t%s\n", src, line_no, dest, tail, dest " § " tail
       }
     }
-    i = j + 2
+    i = (k > 0) ? k + 1 : j + 2
   }
   if (s ~ /^[ \t]*\[[^][]+\]:[ \t]*[^ \t]/) {
     j = index(s, "]:")
@@ -214,14 +231,17 @@ function load_headings(   line, f) {
 function has_section_prefix(target, value,   key, prefix, name, tail, number) {
   prefix = target "#"
   value = tolower(value)
-  gsub(/[`*]/, "", value)
+  gsub(/[`*_]/, "", value)
   number = ""
   if (match(value, /^[0-9]+(\.[0-9]+)*/) && substr(value, RLENGTH + 1) ~ /^([ \t.,;:)]|$)/) number = substr(value, 1, RLENGTH)
   for (key in texts) {
     if (index(key, prefix) != 1) continue
     name = substr(key, length(prefix) + 1)
-    gsub(/[`*]/, "", name)
-    if (number != "" && match(name, /^[0-9]+(\.[0-9]+)*/) && substr(name, 1, RLENGTH) == number && substr(name, RLENGTH + 1) ~ /^([.)]?[ \t]|$)/) return 1
+    gsub(/[`*_]/, "", name)
+    if (number != "") {
+      if (match(name, /^[0-9]+(\.[0-9]+)*/) && substr(name, 1, RLENGTH) == number && substr(name, RLENGTH + 1) ~ /^([.)]?[ \t]|$)/) return 1
+      continue
+    }
     if (name == "" || substr(value, 1, length(name)) != name) continue
     tail = substr(value, length(name) + 1)
     if (tail == "" || tail ~ /^[ \t.,;:)]/) return 1

--- a/.agents/skills/growth-guards/scripts/lib/md-refs.awk
+++ b/.agents/skills/growth-guards/scripts/lib/md-refs.awk
@@ -89,7 +89,7 @@ function is_local(dest) {
   return 1
 }
 
-function emit_links(s,   i, j, k, dest, raw) {
+function emit_links(s, original,   i, j, k, dest, raw, tail) {
   i = 1
   while (1) {
     j = index(substr(s, i), "](")
@@ -98,7 +98,14 @@ function emit_links(s,   i, j, k, dest, raw) {
     dest = parse_dest(s, j + 2)
     k = index(substr(s, j), ")")
     raw = (k > 0) ? substr(s, j, k) : substr(s, j)
-    if (is_local(dest)) printf "L\t%s\t%d\t%s\t%s\n", src, line_no, dest, raw
+    if (is_local(dest)) {
+      printf "L\t%s\t%d\t%s\t%s\n", src, line_no, dest, raw
+      tail = (k > 0) ? substr(original, j + k) : ""
+      if (dest ~ /\.md$/ && tail ~ /^[ \t]+§[ \t]+/) {
+        sub(/^[ \t]+§[ \t]+/, "", tail)
+        printf "C\t%s\t%d\t%s\tprefix-section\t%s\t%s\n", src, line_no, dest, tail, dest " § " tail
+      }
+    }
     i = j + 2
   }
   if (s ~ /^[ \t]*\[[^][]+\]:[ \t]*[^ \t]/) {
@@ -202,6 +209,26 @@ function load_headings(   line, f) {
   close(headings)
 }
 
+# A bare section route starts with an existing heading; prose may follow it.
+# Exact code-span citations and anchor links keep their exact-match rules.
+function has_section_prefix(target, value,   key, prefix, name, tail, number) {
+  prefix = target "#"
+  value = tolower(value)
+  gsub(/[`*]/, "", value)
+  number = ""
+  if (match(value, /^[0-9]+(\.[0-9]+)*/) && substr(value, RLENGTH + 1) ~ /^([ \t.,;:)]|$)/) number = substr(value, 1, RLENGTH)
+  for (key in texts) {
+    if (index(key, prefix) != 1) continue
+    name = substr(key, length(prefix) + 1)
+    gsub(/[`*]/, "", name)
+    if (number != "" && match(name, /^[0-9]+(\.[0-9]+)*/) && substr(name, 1, RLENGTH) == number && substr(name, RLENGTH + 1) ~ /^([.)]?[ \t]|$)/) return 1
+    if (name == "" || substr(value, 1, length(name)) != name) continue
+    tail = substr(value, length(name) + 1)
+    if (tail == "" || tail ~ /^[ \t.,;:)]/) return 1
+  }
+  return 0
+}
+
 function fail(msg) { if (phase == "verdict") printf "V\t%s\t%d\t%s\n", src_path, line_no, msg }
 
 function want_target(t) { if (phase == "targets" && !(t in wanted)) { wanted[t] = 1; print t } }
@@ -249,7 +276,7 @@ mode == "refs" {
   }
   split_spans(f[3])
   for (i = 1; i <= nspans; i++) emit_citation(spans[i])
-  emit_links(outside)
+  emit_links(outside, f[3])
   emit_ids(f[3])
   next
 }
@@ -298,6 +325,8 @@ mode == "resolve" {
     want_target(target)
     if (ckind == "section") {
       if (!((target "#" tolower(value)) in texts)) fail("`" raw "`: " target " has no heading '" value "'")
+    } else if (ckind == "prefix-section") {
+      if (!has_section_prefix(target, value)) fail(raw ": " target " has no heading at the start of '" value "'")
     } else if (!((target "#" value) in slugs)) fail("`" raw "`: " target " has no heading or explicit anchor #" value)
     next
   }

--- a/.agents/skills/growth-guards/scripts/lib/md-scope.sh
+++ b/.agents/skills/growth-guards/scripts/lib/md-scope.sh
@@ -13,6 +13,9 @@
 #              --staged, and with nothing staged the lane judges nothing
 #              and says so; `all` is --all
 #
+# md-refs widens a triggered check to all configured documents so target edits
+# recheck unchanged callers.
+#
 # Both scopes take the lane's path globs and GROWTH_GUARDS_MD_EXCLUDES, the
 # family's `pattern<TAB>reason` list with `!` carve-ins. A symlink, a gitlink
 # and a binary blob at a selected path are named as unmeasured, never folded

--- a/.agents/skills/growth-guards/scripts/lib/md-slug.awk
+++ b/.agents/skills/growth-guards/scripts/lib/md-slug.awk
@@ -12,7 +12,7 @@
 # drop_punct, and any other multibyte character is kept as a letter.
 
 # The text of every code span in S into spans[1..nspans], and the text
-# between them into `outside`, each span replaced by one space. Runs of
+# between them into `outside`, each span replaced by spaces of equal length. Runs of
 # backticks pair by length; an unmatched run is literal text.
 function split_spans(s,   i, n, rest, p, j, k, m, found) {
   nspans = 0
@@ -42,7 +42,7 @@ function split_spans(s,   i, n, rest, p, j, k, m, found) {
     if (found > 0) {
       nspans++
       spans[nspans] = substr(rest, 1, found - 1)
-      outside = outside " "
+      outside = outside sprintf("%*s", found + 2 * n - 1, "")
       s = substr(rest, found + n)
     } else {
       outside = outside substr(s, 1, n)

--- a/.agents/skills/growth-guards/scripts/md-refs
+++ b/.agents/skills/growth-guards/scripts/md-refs
@@ -1,17 +1,8 @@
 #!/usr/bin/env bash
-# md-refs — every reference in agent-loaded markdown and architecture docs
-# lands: a relative link's path is a tracked file or directory and its
-# anchor a heading slug or explicit anchor in that file; a code-span citation
-# (`path.md`, `path.md § Heading`, `path.md#anchor`) names a tracked file and
-# a heading it has; a decision ID names a tracked decision file. Fenced code
-# is never read. The grammar is lib/md-refs.awk's (with lib/md-slug.awk's
-# reductions) over lib/md-blocks.awk's line stream, stated in CHECKS.md §
-# md-refs.
-#
-# Scopes: --staged judges every matching markdown file the staged diff adds
-# or changes; --all judges every tracked matching file; with neither,
-# GROWTH_GUARDS_MD_SCOPE decides (lib/md-scope.sh). Targets resolve against
-# the index, so a link to a file this commit deletes is dead.
+# md-refs checks links, section routes, and decision references in markdown.
+# Both callers and targets come from the index. A staged change rechecks all
+# configured documents so target edits cannot leave unchanged callers broken.
+# Fenced code is not read. The grammar is in lib/md-refs.awk.
 #
 # Exit codes: 0 clean; 1 dead references; 2 usage/config/collection error.
 set -euo pipefail
@@ -47,17 +38,16 @@ usage() {
   cat <<EOF
 usage: md-refs [--staged | --all]
 
-A dead reference in agent-loaded markdown fails: a relative link whose path
-is not a tracked file or directory or whose #anchor is no heading of the
-target; a code-span citation (\`path.md\`, \`path.md § Heading\`,
-\`path.md#anchor\`) naming no tracked file or no heading it has; a decision
-ID with no tracked file under DECISIONS_DIR. Fenced code is never read.
-Decision IDs are judged only where DECISIONS_DIR is tracked.
+A dead relative link, code-span section or anchor citation, or decision
+reference fails. A link followed by § must start with a heading from its
+target; prose may follow that heading. Fenced code is not read. A path alone
+in a code span is not a citation. Decision IDs are judged only where
+DECISIONS_DIR is tracked.
 
---staged judges every matching markdown file the staged diff adds or
-changes; --all judges every tracked matching file. With neither,
-GROWTH_GUARDS_MD_SCOPE decides: 'touched' (the default) is --staged and
-judges nothing when nothing is staged; 'all' is --all.
+--staged and --all check every tracked matching document. With neither,
+GROWTH_GUARDS_MD_SCOPE=touched checks that set when any change is staged,
+including a deletion; all checks it unconditionally. Callers and targets
+both resolve against the index. Exclusions apply to the document set.
 
 Configuration (env > .env.local > .kendex/settings.toml >
 kendex.settings.toml [env] > default):
@@ -107,8 +97,25 @@ esac
 ID_WIDTH="$(gg_setting DECISION_ID_WIDTH "$DECISION_ID_WIDTH_DEFAULT")" || exit 2
 gg_positive_int "$ID_WIDTH" DECISION_ID_WIDTH
 
+# A removed target also invalidates references in unchanged documents.
+if [ "$STAGED" -eq 0 ] && [ "$ALL" -eq 0 ]; then
+  scope="$(gg_setting GROWTH_GUARDS_MD_SCOPE "$GG_MD_SCOPE_DEFAULT")" || exit 2
+  if [ "$scope" = touched ]; then
+    gg_require_merged_index
+    diff_status=0
+    git diff --cached --quiet || diff_status=$?
+    case "$diff_status" in
+      0) ;;
+      1) STAGED=1 ;;
+      *) gg_collection_error "could not read staged changes (git diff exit $diff_status)" ;;
+    esac
+  fi
+fi
 gg_md_scope md-refs "$STAGED" "$ALL"
 [ "$GG_MD_MODE" != none ] || exit 0
+# References are checked across the configured document set, including callers
+# the commit does not edit. Targets and callers both come from the index.
+GG_MD_MODE=all
 
 gg_tmpdir
 gg_md_select markdown

--- a/.agents/skills/growth-guards/tests/md-refs.test.sh
+++ b/.agents/skills/growth-guards/tests/md-refs.test.sh
@@ -179,6 +179,17 @@ cite "a numbered section route resolves" 0 $'[guide](guide.md) § 1 describes se
 cite "a nested numbered section route resolves" 0 $'[guide](guide.md) § 1.1.1 describes the path.\n'
 cite "a missing numbered section cannot match its parent" 1 $'[guide](guide.md) § 1.1.2 describes the path.\n' 1 "has no heading at the start"
 
+echo "=== section-route regression controls ==="
+new_repo section-regressions
+put guide.md $'# Guide\n\n## 1\n\n## Install\n'
+put 'guide(foo).md' $'# Guide\n\n## Install\n'
+cite "numeric routes cannot fall through to a bare parent prefix" 1 $'[guide](guide.md) § 1.1.2 details.\n' 1 "has no heading at the start"
+cite "balanced destination parentheses do not hide a missing section" 1 $'[guide](guide(foo).md) § Missing.\n' 1 "has no heading at the start"
+cite "underscore emphasis resolves like the other emphasis markers" 0 $'[guide](guide.md) § _Install_ explains setup.\n'
+cite "escaped destination parentheses do not hide a missing section" 1 $'[guide](guide\\(foo\\).md) § Missing.\n' 1 "has no heading at the start"
+cite "parentheses in a link title do not hide a missing section" 1 $'[guide](guide(foo).md "A ) title") § Missing.\n' 1 "has no heading at the start"
+cite "an angle destination and title retain a valid section route" 0 $'[guide](<guide(foo).md> "A ) title") § Install.\n'
+
 echo "=== scopes: touched, --staged, --all ==="
 new_repo scopes
 put ok.md $'# OK\n'

--- a/.agents/skills/growth-guards/tests/md-refs.test.sh
+++ b/.agents/skills/growth-guards/tests/md-refs.test.sh
@@ -166,6 +166,19 @@ OUT="$(cd "$R" && GROWTH_GUARDS_MD_REFS_PATHS='docs/*.md' "$MDR" --all 2>&1)" &&
 [ "$RC" -eq 1 ] && case "$OUT" in *"AGENTS.md:1:"*) false ;; *"docs/design.md:1:"*) true ;; *) false ;; esac \
   && ok "GROWTH_GUARDS_MD_REFS_PATHS replaces the list" || bad "path list replaces" "rc=$RC out=$OUT"
 
+echo "=== a link followed by a section name resolves the heading prefix ==="
+new_repo section-links
+put guide.md $'# Guide\n\n## Install\n'
+cite "a plain section route resolves" 0 $'[guide](guide.md) § Install.\n'
+cite "a formatted section route resolves with following prose" 0 $'[guide](guide.md) § `Install` explains setup.\n'
+cite "a missing section route fails" 1 $'[guide](guide.md) § Missing section.\n' 1 "has no heading at the start"
+cite "a section name needs its boundary" 1 $'[guide](guide.md) § Installer.\n' 1 "has no heading at the start"
+cite "a link inside a code example is not a reference" 0 $'`[guide](guide.md) § Missing section.`\n'
+put guide.md $'# Guide\n\n## 1. Install\n\n### 1.1.1 Choose a path\n'
+cite "a numbered section route resolves" 0 $'[guide](guide.md) § 1 describes setup.\n'
+cite "a nested numbered section route resolves" 0 $'[guide](guide.md) § 1.1.1 describes the path.\n'
+cite "a missing numbered section cannot match its parent" 1 $'[guide](guide.md) § 1.1.2 describes the path.\n' 1 "has no heading at the start"
+
 echo "=== scopes: touched, --staged, --all ==="
 new_repo scopes
 put ok.md $'# OK\n'
@@ -179,8 +192,8 @@ run_refs --all
   && ok "--all reaches the committed dead link" || bad "--all reaches committed" "rc=$RC out=$OUT"
 put docs/architecture/overview.md $'[live](../../ok.md)\n'
 run_refs --staged
-[ "$RC" -eq 0 ] && case "$OUT" in *"1 staged markdown file(s)"*) true ;; *) false ;; esac \
-  && ok "--staged judges the staged file alone, so the committed dead link is out of scope" || bad "--staged judges staged only" "rc=$RC out=$OUT"
+[ "$RC" -eq 1 ] && case "$OUT" in *"AGENTS.md:1:"*) true ;; *) false ;; esac \
+  && ok "--staged also checks references from unchanged documents" || bad "incoming references" "rc=$RC out=$OUT"
 put AGENTS.md $'[dead](nope.md) again\n'
 run_refs
 [ "$RC" -eq 1 ] && case "$OUT" in *"AGENTS.md:1:"*) true ;; *) false ;; esac \
@@ -202,12 +215,26 @@ new_repo staged-exclusion
 put AGENTS.md $'[dead](missing.md)\n'
 put tools/md-excludes $'AGENTS.md\tvendored instructions\n'
 run_refs --staged
-[ "$RC" -eq 0 ] && case "$OUT" in *"no staged markdown file(s) to judge"*) true ;; *) false ;; esac \
+[ "$RC" -eq 0 ] && case "$OUT" in *"no tracked markdown file(s) to judge"*) true ;; *) false ;; esac \
   && ok "the staged scan excludes the declared document" || bad "staged exclusion" "rc=$RC out=$OUT"
 git -C "$R" rm -qf tools/md-excludes
 run_refs --staged
 [ "$RC" -eq 1 ] && case "$OUT" in *"no tracked file or directory at missing.md"*) true ;; *) false ;; esac \
   && ok "the same staged reference fails without its exclusion" || bad "staged exclusion control" "rc=$RC out=$OUT"
+
+echo "=== target-only edits recheck incoming references ==="
+new_repo incoming
+put guide.md $'# Guide\n\n## Install\n'
+put AGENTS.md $'[setup](guide.md#install)\n'
+git -C "$R" commit -qm seed
+put guide.md $'# Guide\n\n## Setup\n'
+run_refs
+[ "$RC" -eq 1 ] && case "$OUT" in *"guide.md has no heading or explicit anchor #install"*) true ;; *) false ;; esac \
+  && ok "renaming only the target heading finds an unchanged caller" || bad "target rename" "rc=$RC out=$OUT"
+git -C "$R" rm -qf guide.md
+run_refs
+[ "$RC" -eq 1 ] && case "$OUT" in *"no tracked file or directory at guide.md"*) true ;; *) false ;; esac \
+  && ok "deleting only the target finds an unchanged caller" || bad "target deletion" "rc=$RC out=$OUT"
 
 echo "=== refusals and unmeasured paths ==="
 new_repo refuse

--- a/.agents/skills/review-gate/SKILL.md
+++ b/.agents/skills/review-gate/SKILL.md
@@ -25,7 +25,7 @@ Problems with a kendex-owned skill go through `kendex report`; check ownership i
 
 The gate answers ONE question: **has this exact PR head been reviewed?** It posts that answer as a commit status the repo's branch rules require. It does not check CI, re-run anything, or reason about jobs.
 
-Two greens do NOT mean a review happened. Under `REVIEW_GATE_MODE = "off"` the predicate evaluates no evidence and attests only that the repo disabled the gate; and merge-group statuses never read the mode, posting green as "merge-queue entry: post-approval by construction". Both: [references/settings.md](references/settings.md) § `REVIEW_GATE_MODE`.
+Two greens do NOT mean a review happened. Under `REVIEW_GATE_MODE = "off"` the predicate evaluates no evidence and attests only that the repo disabled the gate; and merge-group statuses never read the mode, posting green as "merge-queue entry: post-approval by construction". Both: [`REVIEW_GATE_MODE` in the settings table](references/settings.md).
 
 ## Decision table
 
@@ -102,7 +102,7 @@ Keys a repo decides: [references/adoption.md](references/adoption.md) § Keys a 
 
 ## 4. Operations
 
-**Watching one or many PRs without stalling.** Never key a hand-rolled monitor on gate-state transitions. Run `.agents/skills/review-gate/scripts/pr-watch.sh` (optionally `--heal`) on the harness's wake-up mechanism: silence + exit 0 means nothing needs you; attention lines name exactly what does. See [references/adoption.md](references/adoption.md) § Watching PRs as an agent.
+**Watching one or many PRs without stalling.** Never key a hand-rolled monitor on gate-state transitions. Run `.agents/skills/review-gate/scripts/pr-watch.sh` (optionally `--heal`) on the harness's wake-up mechanism: silence + exit 0 means nothing needs you; attention lines name exactly what does. See [Watching PRs as an agent](references/adoption.md#watching-prs-as-an-agent-pr-watch).
 
 **Reviewers are down / nothing is reviewing.** Run the internal review loop: fix findings, resolve every thread, then post the override status with a real reason. It cannot bypass an objection or an open thread.
 

--- a/changelog.d/fixed/markdown-incoming-references.md
+++ b/changelog.d/fixed/markdown-incoming-references.md
@@ -1,0 +1,1 @@
+- Markdown checks catch broken incoming references after target edits and check links followed by a section heading prefix.

--- a/skills/growth-guards/CHECKS.md
+++ b/skills/growth-guards/CHECKS.md
@@ -124,15 +124,16 @@ An unterminated fence, front matter, HTML comment or prompt-section block is exi
 
 ## md-refs
 
-A dead reference in a scanned markdown file fails. Fenced code, indented code and front matter are never read. Three forms:
+A dead reference in a scanned markdown file fails. Fenced code, indented code and front matter are never read. Forms:
 
 - A link or reference definition whose destination is relative (no scheme, no leading `/`, not `mailto:`) must name a tracked file or directory, resolved against the citing file's directory; `..` above the repository root is dead. With `#anchor`, the target must be markdown and the anchor one of its heading slugs or an explicit `<a id="...">` or `<a name="...">`; a bare `#anchor` resolves in the citing file. A definition is read only where the line begins with its `[label]:`.
 - A code span holding `<path>.md § Heading` must name a tracked file with a heading equal to `Heading` case-insensitively after trimming; one holding `<path>.md#anchor` a tracked file with that slug or explicit anchor. The path resolves against the citing file's directory, then the repository root. A path alone in a code span is not judged.
+- A relative markdown link followed by `§` must start with an existing heading name from that target. Matching ignores case, backticks, and emphasis markers. The heading name ends at a word boundary; prose can follow it. A section number also resolves to a heading with that number. Text routes check a heading prefix. Use an anchor link or an exact code-span citation where heading names share a prefix.
 - A decision ID, `DECISION_ID_PREFIX` plus at least `DECISION_ID_WIDTH` digits bounded by non-alphanumerics, must have a tracked file `DECISIONS_DIR/<ID>-*.md`; where that directory is not tracked, IDs are not judged and the verdict says so.
 
 The slug is GitHub's: link syntax, code-span backticks and HTML tags reduce to their text; ASCII letters lower-case (a non-ASCII letter keeps its case); every character not a letter, digit, space, `-` or `_` is dropped; each space becomes a hyphen; a repeat takes the first free `-1`, `-2` suffix.
 
-Scopes are md-format's over `GROWTH_GUARDS_MD_REFS_PATHS` minus `GROWTH_GUARDS_MD_EXCLUDES`, with the same `GROWTH_GUARDS_MD_SCOPE`. Targets resolve against the index whatever the scope, so a link into a file the commit deletes is dead; a tracked path holding a newline is no link target.
+`--staged` and `--all` check every tracked file named by `GROWTH_GUARDS_MD_REFS_PATHS` minus `GROWTH_GUARDS_MD_EXCLUDES`. With neither flag, `GROWTH_GUARDS_MD_SCOPE=touched` checks that set when any change is staged, including deletions; `all` checks it unconditionally. This includes references in unchanged documents. Callers and targets resolve against the index; a tracked path holding a newline is no link target.
 
 ## comments
 

--- a/skills/growth-guards/DEVELOPMENT.md
+++ b/skills/growth-guards/DEVELOPMENT.md
@@ -62,7 +62,7 @@ Every step runs before the verdict; any other companion failure blocks. The shim
 - md-refs runs the `lines` stream through `md-refs.awk`, then resolves in three passes: every selected file's references, the headings of every cited file read from the index whether or not in scope, then the verdict.
 - Both programs are POSIX awk (no interval expressions, no gawk builtins) under `LC_ALL=C`; `mawk` and `gawk --posix` give the same records over the suites' fixtures.
 - The reflow is the check's state machine printing instead of complaining, so a reflowed file passes md-format by construction; `tests/md-reflow.test.sh` proves it over the corpus and proves each rewrite is a fixed point.
-- md-format and md-refs are in `STAGED_SCOPED_CHECKS`; a repository widens them with `GROWTH_GUARDS_MD_SCOPE=all` after reflowing its tree.
+- The batch passes `--staged` to both markdown checks. md-format selects changed documents; md-refs checks all configured documents against the index. `GROWTH_GUARDS_MD_SCOPE=all` makes unflagged checks unconditional.
 
 ## todo-ban marker shapes
 

--- a/skills/growth-guards/README.md
+++ b/skills/growth-guards/README.md
@@ -34,7 +34,7 @@ Every check is a standalone executable with one exit contract: `0` clean, `1` vi
 
 The `pre-commit` hook judges one commit snapshot and `commit-msg` runs the message gate; the chain and its order are [DEVELOPMENT.md](DEVELOPMENT.md) § The pre-commit chain. Both block on any failure; `git commit --no-verify` is the only bypass.
 
-The markdown lanes start narrow: `md-format` and `md-refs` judge the files a commit touches. Reflow the tree once with `scripts/md-reflow --all`, commit, then set `GROWTH_GUARDS_MD_SCOPE = "all"` so CI judges every tracked markdown file. Vendored or generated markdown goes in `tools/md-excludes` with a reason.
+`md-format` starts with changed documents. `md-refs` checks all configured documents when any change is staged, so it also finds broken references from unchanged callers. Reflow the tree with `scripts/md-reflow --all`, then set `GROWTH_GUARDS_MD_SCOPE = "all"` for unconditional checks. Put vendored or generated markdown in `tools/md-excludes` with a reason.
 
 In CI, run the batch without `--staged`: the index-wide `todo-ban` scan is the only lane that sees a marker no commit ever diffed. `byte-ceiling --base origin/main` gates a PR's additions and file-size growth.
 

--- a/skills/growth-guards/SKILL.md
+++ b/skills/growth-guards/SKILL.md
@@ -51,7 +51,7 @@ repo-effects:
 | **changelog-entries** | Each `GROWTH_GUARDS_CHANGELOG_PATHS` fragment is one Markdown list item in a Keep a Changelog section and at most `GROWTH_GUARDS_CHANGELOG_CAP` characters. |
 | **prose** | A history reference in Markdown named by `GROWTH_GUARDS_PROSE_PATHS` fails; `GROWTH_GUARDS_CHECKS` controls whether the lane runs. |
 | **md-format** | A hard-wrapped paragraph or list item, a missing blank line around a heading, fence or list, or a trailing-double-space break in Markdown named by `GROWTH_GUARDS_MD_PATHS` fails; `md-reflow` is the remedy. |
-| **md-refs** | A relative link, a `<path>.md § Heading` or `<path>.md#anchor` code-span citation, or a decision ID in Markdown named by `GROWTH_GUARDS_MD_REFS_PATHS` that lands on no tracked file, heading or decision fails. |
+| **md-refs** | A relative link, a link followed by `§` and a heading prefix, a `<path>.md § Heading` or `<path>.md#anchor` code-span citation, or a decision ID in Markdown named by `GROWTH_GUARDS_MD_REFS_PATHS` that lands on no tracked file, heading or decision fails. |
 | **comments** | A history reference in the comment text of a source file named by `GROWTH_GUARDS_COMMENT_PATHS` fails: an issue id (`GH_ISSUE_PATTERN`), `#NNN`, or a date. Opt-in: name it in `GROWTH_GUARDS_CHECKS`. |
 | **commit-msg** | The header must be `type(scope)!: subject` within `GROWTH_GUARDS_SUBJECT_MAX`; a commit touching `GROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS` also owes a changelog entry or `[no-changelog]`. |
 
@@ -88,7 +88,7 @@ Exclude immutable first-party sources, including applied SQL migrations, from th
 | `GROWTH_GUARDS_MD_PATHS` | `*.md` | Globs naming the markdown md-format and md-reflow take under `--all`. |
 | `GROWTH_GUARDS_MD_REFS_PATHS` | the `GROWTH_GUARDS_PROSE_PATHS` default | Globs naming the markdown md-refs judges under `--all`. |
 | `GROWTH_GUARDS_MD_EXCLUDES` | `tools/md-excludes` | Exclusion list both markdown lanes honour in every scope, and md-reflow under `--staged` and `--all`. |
-| `GROWTH_GUARDS_MD_SCOPE` | `touched` | What the markdown lanes judge with neither `--staged` nor `--all`: `touched` is the staged files, and nothing when nothing is staged; `all` is every tracked matching file. |
+| `GROWTH_GUARDS_MD_SCOPE` | `touched` | With neither flag, `touched` runs md-format on staged files and md-refs on all configured documents when anything is staged; `all` checks every matching file. |
 | `DECISIONS_DIR`, `DECISION_ID_PREFIX`, `DECISION_ID_WIDTH` | `docs/decisions`, `D`, `3` | The decider skill's scheme, read by md-refs to judge decision IDs; IDs are not judged where the directory is not tracked. |
 | `GROWTH_GUARDS_COMMENT_PATHS` | the extensions in [CHECKS.md § comments](CHECKS.md#comments) | Space-separated globs naming the source files the comments lane scans, matched against the full repo-relative path (`*` crosses `/`); replaces the default. |
 | `GROWTH_GUARDS_COMMENT_EXCLUDES` | `tools/comments-excludes` | comments exclusion list (generated, vendored, and immutable first-party files). `GH_ISSUE_PATTERN` (the github skill's key) is the issue-id shape; empty keeps `[A-Z]+-[0-9]+`. |

--- a/skills/growth-guards/kendex.settings.toml.example
+++ b/skills/growth-guards/kendex.settings.toml.example
@@ -34,11 +34,9 @@ GROWTH_GUARDS_CHANGELOG_RECORD = "CHANGELOG.md"
 # Empty = rule off.
 GROWTH_GUARDS_CHANGELOG_REQUIRED_PATHS = ""
 
-# What md-format and md-refs judge with neither --staged nor --all: "touched"
-# is the markdown files a commit touches, and nothing when nothing is staged;
-# "all" is every tracked file the path globs name. Set "all" once the
-# repository's markdown is reflowed (scripts/md-reflow --all), so CI judges
-# the whole tree.
+# Without flags, touched runs md-format on changed documents. It runs md-refs
+# on all configured documents when any change is staged. All runs both checks
+# unconditionally. Explicit --staged retains each lane's own scope.
 GROWTH_GUARDS_MD_SCOPE = "touched"
 
 # The markdown md-format and md-reflow take under --all, and the markdown

--- a/skills/growth-guards/scripts/growth-guards
+++ b/skills/growth-guards/scripts/growth-guards
@@ -24,9 +24,9 @@ KNOWN_CHECKS="todo-ban byte-ceiling suppression-ban conflict-markers changelog-e
 BATCH_DEFAULT="todo-ban byte-ceiling suppression-ban conflict-markers changelog-entries prose md-format md-refs"
 # The checks the batch hands --staged when it is asked for commit scope.
 # todo-ban and comments default to the whole index, which is a CI subject:
-# at commit each judges what the commit adds. md-format and md-refs judge
-# the markdown files a commit touches, in full, until GROWTH_GUARDS_MD_SCOPE
-# widens them. byte-ceiling is already staged by default, and the rest read
+# at commit each judges what the commit adds. md-format judges touched
+# documents; md-refs checks every configured document for broken incoming
+# references. byte-ceiling is already staged by default, and the rest read
 # the index by design.
 STAGED_SCOPED_CHECKS="todo-ban md-format md-refs comments"
 
@@ -38,8 +38,9 @@ Checks: $KNOWN_CHECKS
 
 With no argument (or 'all'), runs every check named by
 GROWTH_GUARDS_CHECKS (default: $BATCH_DEFAULT).
---staged puts the batch at commit scope: the checks that take it
-($STAGED_SCOPED_CHECKS) judge the staged diff instead of the whole index.
+--staged is passed to: $STAGED_SCOPED_CHECKS.
+Those checks apply their own commit scope. md-refs checks all configured
+documents for broken references, including unchanged callers.
 commit-msg reads a message file/stdin and only runs by name.
 
 Exit codes: 0 clean; 1 violations; 2 usage/config/collection error, or

--- a/skills/growth-guards/scripts/lib/md-refs.awk
+++ b/skills/growth-guards/scripts/lib/md-refs.awk
@@ -52,32 +52,49 @@ function emit_explicit(content,   s, id) {
   }
 }
 
-# A destination beginning at P in S: the `<...>` form, or up to whitespace or
-# an unbalanced `)`, backslash escapes before ASCII punctuation resolved.
-function parse_dest(s, p,   c, out, depth) {
+# Parse the destination and retain its enclosing link's closing position.
+# Angle destinations, escaped punctuation, and optional titles share this read.
+function parse_dest(s, p,   c, out, depth, title) {
+  LINK_CLOSE = 0
   while (p <= length(s) && substr(s, p, 1) ~ /[ \t]/) p++
   out = ""
   if (substr(s, p, 1) == "<") {
     p++
     while (p <= length(s)) {
       c = substr(s, p, 1)
-      if (c == ">") return out
+      if (c == ">") { p++; break }
       if (c == "\\" && index(ESCAPABLE, substr(s, p + 1, 1)) > 0) { out = out substr(s, p + 1, 1); p += 2; continue }
       out = out c
       p++
     }
-    return out
+  } else {
+    depth = 0
+    while (p <= length(s)) {
+      c = substr(s, p, 1)
+      if (c == "\\" && index(ESCAPABLE, substr(s, p + 1, 1)) > 0) { out = out substr(s, p + 1, 1); p += 2; continue }
+      if (c ~ /[ \t]/) break
+      if (c == "(") depth++
+      else if (c == ")") { if (depth == 0) break; depth-- }
+      out = out c
+      p++
+    }
   }
-  depth = 0
-  while (p <= length(s)) {
-    c = substr(s, p, 1)
-    if (c == "\\" && index(ESCAPABLE, substr(s, p + 1, 1)) > 0) { out = out substr(s, p + 1, 1); p += 2; continue }
-    if (c ~ /[ \t]/) break
-    if (c == "(") depth++
-    else if (c == ")") { if (depth == 0) break; depth-- }
-    out = out c
+  while (p <= length(s) && substr(s, p, 1) ~ /[ \t]/) p++
+  title = substr(s, p, 1)
+  if (title == "\"" || title == "\047" || title == "(") {
     p++
+    depth = 1
+    while (p <= length(s) && depth > 0) {
+      c = substr(s, p, 1)
+      if (c == "\\" && index(ESCAPABLE, substr(s, p + 1, 1)) > 0) { p += 2; continue }
+      if (title == "(" && c == "(") depth++
+      else if (c == (title == "(" ? ")" : title)) depth--
+      p++
+    }
+    if (depth > 0) return out
+    while (p <= length(s) && substr(s, p, 1) ~ /[ \t]/) p++
   }
+  if (substr(s, p, 1) == ")") LINK_CLOSE = p
   return out
 }
 
@@ -96,17 +113,17 @@ function emit_links(s, original,   i, j, k, dest, raw, tail) {
     if (j == 0) break
     j = i + j - 1
     dest = parse_dest(s, j + 2)
-    k = index(substr(s, j), ")")
-    raw = (k > 0) ? substr(s, j, k) : substr(s, j)
+    k = LINK_CLOSE
+    raw = (k > 0) ? substr(s, j, k - j + 1) : substr(s, j)
     if (is_local(dest)) {
       printf "L\t%s\t%d\t%s\t%s\n", src, line_no, dest, raw
-      tail = (k > 0) ? substr(original, j + k) : ""
+      tail = (k > 0) ? substr(original, k + 1) : ""
       if (dest ~ /\.md$/ && tail ~ /^[ \t]+§[ \t]+/) {
         sub(/^[ \t]+§[ \t]+/, "", tail)
         printf "C\t%s\t%d\t%s\tprefix-section\t%s\t%s\n", src, line_no, dest, tail, dest " § " tail
       }
     }
-    i = j + 2
+    i = (k > 0) ? k + 1 : j + 2
   }
   if (s ~ /^[ \t]*\[[^][]+\]:[ \t]*[^ \t]/) {
     j = index(s, "]:")
@@ -214,14 +231,17 @@ function load_headings(   line, f) {
 function has_section_prefix(target, value,   key, prefix, name, tail, number) {
   prefix = target "#"
   value = tolower(value)
-  gsub(/[`*]/, "", value)
+  gsub(/[`*_]/, "", value)
   number = ""
   if (match(value, /^[0-9]+(\.[0-9]+)*/) && substr(value, RLENGTH + 1) ~ /^([ \t.,;:)]|$)/) number = substr(value, 1, RLENGTH)
   for (key in texts) {
     if (index(key, prefix) != 1) continue
     name = substr(key, length(prefix) + 1)
-    gsub(/[`*]/, "", name)
-    if (number != "" && match(name, /^[0-9]+(\.[0-9]+)*/) && substr(name, 1, RLENGTH) == number && substr(name, RLENGTH + 1) ~ /^([.)]?[ \t]|$)/) return 1
+    gsub(/[`*_]/, "", name)
+    if (number != "") {
+      if (match(name, /^[0-9]+(\.[0-9]+)*/) && substr(name, 1, RLENGTH) == number && substr(name, RLENGTH + 1) ~ /^([.)]?[ \t]|$)/) return 1
+      continue
+    }
     if (name == "" || substr(value, 1, length(name)) != name) continue
     tail = substr(value, length(name) + 1)
     if (tail == "" || tail ~ /^[ \t.,;:)]/) return 1

--- a/skills/growth-guards/scripts/lib/md-refs.awk
+++ b/skills/growth-guards/scripts/lib/md-refs.awk
@@ -89,7 +89,7 @@ function is_local(dest) {
   return 1
 }
 
-function emit_links(s,   i, j, k, dest, raw) {
+function emit_links(s, original,   i, j, k, dest, raw, tail) {
   i = 1
   while (1) {
     j = index(substr(s, i), "](")
@@ -98,7 +98,14 @@ function emit_links(s,   i, j, k, dest, raw) {
     dest = parse_dest(s, j + 2)
     k = index(substr(s, j), ")")
     raw = (k > 0) ? substr(s, j, k) : substr(s, j)
-    if (is_local(dest)) printf "L\t%s\t%d\t%s\t%s\n", src, line_no, dest, raw
+    if (is_local(dest)) {
+      printf "L\t%s\t%d\t%s\t%s\n", src, line_no, dest, raw
+      tail = (k > 0) ? substr(original, j + k) : ""
+      if (dest ~ /\.md$/ && tail ~ /^[ \t]+§[ \t]+/) {
+        sub(/^[ \t]+§[ \t]+/, "", tail)
+        printf "C\t%s\t%d\t%s\tprefix-section\t%s\t%s\n", src, line_no, dest, tail, dest " § " tail
+      }
+    }
     i = j + 2
   }
   if (s ~ /^[ \t]*\[[^][]+\]:[ \t]*[^ \t]/) {
@@ -202,6 +209,26 @@ function load_headings(   line, f) {
   close(headings)
 }
 
+# A bare section route starts with an existing heading; prose may follow it.
+# Exact code-span citations and anchor links keep their exact-match rules.
+function has_section_prefix(target, value,   key, prefix, name, tail, number) {
+  prefix = target "#"
+  value = tolower(value)
+  gsub(/[`*]/, "", value)
+  number = ""
+  if (match(value, /^[0-9]+(\.[0-9]+)*/) && substr(value, RLENGTH + 1) ~ /^([ \t.,;:)]|$)/) number = substr(value, 1, RLENGTH)
+  for (key in texts) {
+    if (index(key, prefix) != 1) continue
+    name = substr(key, length(prefix) + 1)
+    gsub(/[`*]/, "", name)
+    if (number != "" && match(name, /^[0-9]+(\.[0-9]+)*/) && substr(name, 1, RLENGTH) == number && substr(name, RLENGTH + 1) ~ /^([.)]?[ \t]|$)/) return 1
+    if (name == "" || substr(value, 1, length(name)) != name) continue
+    tail = substr(value, length(name) + 1)
+    if (tail == "" || tail ~ /^[ \t.,;:)]/) return 1
+  }
+  return 0
+}
+
 function fail(msg) { if (phase == "verdict") printf "V\t%s\t%d\t%s\n", src_path, line_no, msg }
 
 function want_target(t) { if (phase == "targets" && !(t in wanted)) { wanted[t] = 1; print t } }
@@ -249,7 +276,7 @@ mode == "refs" {
   }
   split_spans(f[3])
   for (i = 1; i <= nspans; i++) emit_citation(spans[i])
-  emit_links(outside)
+  emit_links(outside, f[3])
   emit_ids(f[3])
   next
 }
@@ -298,6 +325,8 @@ mode == "resolve" {
     want_target(target)
     if (ckind == "section") {
       if (!((target "#" tolower(value)) in texts)) fail("`" raw "`: " target " has no heading '" value "'")
+    } else if (ckind == "prefix-section") {
+      if (!has_section_prefix(target, value)) fail(raw ": " target " has no heading at the start of '" value "'")
     } else if (!((target "#" value) in slugs)) fail("`" raw "`: " target " has no heading or explicit anchor #" value)
     next
   }

--- a/skills/growth-guards/scripts/lib/md-scope.sh
+++ b/skills/growth-guards/scripts/lib/md-scope.sh
@@ -13,6 +13,9 @@
 #              --staged, and with nothing staged the lane judges nothing
 #              and says so; `all` is --all
 #
+# md-refs widens a triggered check to all configured documents so target edits
+# recheck unchanged callers.
+#
 # Both scopes take the lane's path globs and GROWTH_GUARDS_MD_EXCLUDES, the
 # family's `pattern<TAB>reason` list with `!` carve-ins. A symlink, a gitlink
 # and a binary blob at a selected path are named as unmeasured, never folded

--- a/skills/growth-guards/scripts/lib/md-slug.awk
+++ b/skills/growth-guards/scripts/lib/md-slug.awk
@@ -12,7 +12,7 @@
 # drop_punct, and any other multibyte character is kept as a letter.
 
 # The text of every code span in S into spans[1..nspans], and the text
-# between them into `outside`, each span replaced by one space. Runs of
+# between them into `outside`, each span replaced by spaces of equal length. Runs of
 # backticks pair by length; an unmatched run is literal text.
 function split_spans(s,   i, n, rest, p, j, k, m, found) {
   nspans = 0
@@ -42,7 +42,7 @@ function split_spans(s,   i, n, rest, p, j, k, m, found) {
     if (found > 0) {
       nspans++
       spans[nspans] = substr(rest, 1, found - 1)
-      outside = outside " "
+      outside = outside sprintf("%*s", found + 2 * n - 1, "")
       s = substr(rest, found + n)
     } else {
       outside = outside substr(s, 1, n)

--- a/skills/growth-guards/scripts/md-refs
+++ b/skills/growth-guards/scripts/md-refs
@@ -1,17 +1,8 @@
 #!/usr/bin/env bash
-# md-refs — every reference in agent-loaded markdown and architecture docs
-# lands: a relative link's path is a tracked file or directory and its
-# anchor a heading slug or explicit anchor in that file; a code-span citation
-# (`path.md`, `path.md § Heading`, `path.md#anchor`) names a tracked file and
-# a heading it has; a decision ID names a tracked decision file. Fenced code
-# is never read. The grammar is lib/md-refs.awk's (with lib/md-slug.awk's
-# reductions) over lib/md-blocks.awk's line stream, stated in CHECKS.md §
-# md-refs.
-#
-# Scopes: --staged judges every matching markdown file the staged diff adds
-# or changes; --all judges every tracked matching file; with neither,
-# GROWTH_GUARDS_MD_SCOPE decides (lib/md-scope.sh). Targets resolve against
-# the index, so a link to a file this commit deletes is dead.
+# md-refs checks links, section routes, and decision references in markdown.
+# Both callers and targets come from the index. A staged change rechecks all
+# configured documents so target edits cannot leave unchanged callers broken.
+# Fenced code is not read. The grammar is in lib/md-refs.awk.
 #
 # Exit codes: 0 clean; 1 dead references; 2 usage/config/collection error.
 set -euo pipefail
@@ -47,17 +38,16 @@ usage() {
   cat <<EOF
 usage: md-refs [--staged | --all]
 
-A dead reference in agent-loaded markdown fails: a relative link whose path
-is not a tracked file or directory or whose #anchor is no heading of the
-target; a code-span citation (\`path.md\`, \`path.md § Heading\`,
-\`path.md#anchor\`) naming no tracked file or no heading it has; a decision
-ID with no tracked file under DECISIONS_DIR. Fenced code is never read.
-Decision IDs are judged only where DECISIONS_DIR is tracked.
+A dead relative link, code-span section or anchor citation, or decision
+reference fails. A link followed by § must start with a heading from its
+target; prose may follow that heading. Fenced code is not read. A path alone
+in a code span is not a citation. Decision IDs are judged only where
+DECISIONS_DIR is tracked.
 
---staged judges every matching markdown file the staged diff adds or
-changes; --all judges every tracked matching file. With neither,
-GROWTH_GUARDS_MD_SCOPE decides: 'touched' (the default) is --staged and
-judges nothing when nothing is staged; 'all' is --all.
+--staged and --all check every tracked matching document. With neither,
+GROWTH_GUARDS_MD_SCOPE=touched checks that set when any change is staged,
+including a deletion; all checks it unconditionally. Callers and targets
+both resolve against the index. Exclusions apply to the document set.
 
 Configuration (env > .env.local > .kendex/settings.toml >
 kendex.settings.toml [env] > default):
@@ -107,8 +97,25 @@ esac
 ID_WIDTH="$(gg_setting DECISION_ID_WIDTH "$DECISION_ID_WIDTH_DEFAULT")" || exit 2
 gg_positive_int "$ID_WIDTH" DECISION_ID_WIDTH
 
+# A removed target also invalidates references in unchanged documents.
+if [ "$STAGED" -eq 0 ] && [ "$ALL" -eq 0 ]; then
+  scope="$(gg_setting GROWTH_GUARDS_MD_SCOPE "$GG_MD_SCOPE_DEFAULT")" || exit 2
+  if [ "$scope" = touched ]; then
+    gg_require_merged_index
+    diff_status=0
+    git diff --cached --quiet || diff_status=$?
+    case "$diff_status" in
+      0) ;;
+      1) STAGED=1 ;;
+      *) gg_collection_error "could not read staged changes (git diff exit $diff_status)" ;;
+    esac
+  fi
+fi
 gg_md_scope md-refs "$STAGED" "$ALL"
 [ "$GG_MD_MODE" != none ] || exit 0
+# References are checked across the configured document set, including callers
+# the commit does not edit. Targets and callers both come from the index.
+GG_MD_MODE=all
 
 gg_tmpdir
 gg_md_select markdown

--- a/skills/growth-guards/tests/md-refs.test.sh
+++ b/skills/growth-guards/tests/md-refs.test.sh
@@ -179,6 +179,17 @@ cite "a numbered section route resolves" 0 $'[guide](guide.md) § 1 describes se
 cite "a nested numbered section route resolves" 0 $'[guide](guide.md) § 1.1.1 describes the path.\n'
 cite "a missing numbered section cannot match its parent" 1 $'[guide](guide.md) § 1.1.2 describes the path.\n' 1 "has no heading at the start"
 
+echo "=== section-route regression controls ==="
+new_repo section-regressions
+put guide.md $'# Guide\n\n## 1\n\n## Install\n'
+put 'guide(foo).md' $'# Guide\n\n## Install\n'
+cite "numeric routes cannot fall through to a bare parent prefix" 1 $'[guide](guide.md) § 1.1.2 details.\n' 1 "has no heading at the start"
+cite "balanced destination parentheses do not hide a missing section" 1 $'[guide](guide(foo).md) § Missing.\n' 1 "has no heading at the start"
+cite "underscore emphasis resolves like the other emphasis markers" 0 $'[guide](guide.md) § _Install_ explains setup.\n'
+cite "escaped destination parentheses do not hide a missing section" 1 $'[guide](guide\\(foo\\).md) § Missing.\n' 1 "has no heading at the start"
+cite "parentheses in a link title do not hide a missing section" 1 $'[guide](guide(foo).md "A ) title") § Missing.\n' 1 "has no heading at the start"
+cite "an angle destination and title retain a valid section route" 0 $'[guide](<guide(foo).md> "A ) title") § Install.\n'
+
 echo "=== scopes: touched, --staged, --all ==="
 new_repo scopes
 put ok.md $'# OK\n'

--- a/skills/growth-guards/tests/md-refs.test.sh
+++ b/skills/growth-guards/tests/md-refs.test.sh
@@ -166,6 +166,19 @@ OUT="$(cd "$R" && GROWTH_GUARDS_MD_REFS_PATHS='docs/*.md' "$MDR" --all 2>&1)" &&
 [ "$RC" -eq 1 ] && case "$OUT" in *"AGENTS.md:1:"*) false ;; *"docs/design.md:1:"*) true ;; *) false ;; esac \
   && ok "GROWTH_GUARDS_MD_REFS_PATHS replaces the list" || bad "path list replaces" "rc=$RC out=$OUT"
 
+echo "=== a link followed by a section name resolves the heading prefix ==="
+new_repo section-links
+put guide.md $'# Guide\n\n## Install\n'
+cite "a plain section route resolves" 0 $'[guide](guide.md) § Install.\n'
+cite "a formatted section route resolves with following prose" 0 $'[guide](guide.md) § `Install` explains setup.\n'
+cite "a missing section route fails" 1 $'[guide](guide.md) § Missing section.\n' 1 "has no heading at the start"
+cite "a section name needs its boundary" 1 $'[guide](guide.md) § Installer.\n' 1 "has no heading at the start"
+cite "a link inside a code example is not a reference" 0 $'`[guide](guide.md) § Missing section.`\n'
+put guide.md $'# Guide\n\n## 1. Install\n\n### 1.1.1 Choose a path\n'
+cite "a numbered section route resolves" 0 $'[guide](guide.md) § 1 describes setup.\n'
+cite "a nested numbered section route resolves" 0 $'[guide](guide.md) § 1.1.1 describes the path.\n'
+cite "a missing numbered section cannot match its parent" 1 $'[guide](guide.md) § 1.1.2 describes the path.\n' 1 "has no heading at the start"
+
 echo "=== scopes: touched, --staged, --all ==="
 new_repo scopes
 put ok.md $'# OK\n'
@@ -179,8 +192,8 @@ run_refs --all
   && ok "--all reaches the committed dead link" || bad "--all reaches committed" "rc=$RC out=$OUT"
 put docs/architecture/overview.md $'[live](../../ok.md)\n'
 run_refs --staged
-[ "$RC" -eq 0 ] && case "$OUT" in *"1 staged markdown file(s)"*) true ;; *) false ;; esac \
-  && ok "--staged judges the staged file alone, so the committed dead link is out of scope" || bad "--staged judges staged only" "rc=$RC out=$OUT"
+[ "$RC" -eq 1 ] && case "$OUT" in *"AGENTS.md:1:"*) true ;; *) false ;; esac \
+  && ok "--staged also checks references from unchanged documents" || bad "incoming references" "rc=$RC out=$OUT"
 put AGENTS.md $'[dead](nope.md) again\n'
 run_refs
 [ "$RC" -eq 1 ] && case "$OUT" in *"AGENTS.md:1:"*) true ;; *) false ;; esac \
@@ -202,12 +215,26 @@ new_repo staged-exclusion
 put AGENTS.md $'[dead](missing.md)\n'
 put tools/md-excludes $'AGENTS.md\tvendored instructions\n'
 run_refs --staged
-[ "$RC" -eq 0 ] && case "$OUT" in *"no staged markdown file(s) to judge"*) true ;; *) false ;; esac \
+[ "$RC" -eq 0 ] && case "$OUT" in *"no tracked markdown file(s) to judge"*) true ;; *) false ;; esac \
   && ok "the staged scan excludes the declared document" || bad "staged exclusion" "rc=$RC out=$OUT"
 git -C "$R" rm -qf tools/md-excludes
 run_refs --staged
 [ "$RC" -eq 1 ] && case "$OUT" in *"no tracked file or directory at missing.md"*) true ;; *) false ;; esac \
   && ok "the same staged reference fails without its exclusion" || bad "staged exclusion control" "rc=$RC out=$OUT"
+
+echo "=== target-only edits recheck incoming references ==="
+new_repo incoming
+put guide.md $'# Guide\n\n## Install\n'
+put AGENTS.md $'[setup](guide.md#install)\n'
+git -C "$R" commit -qm seed
+put guide.md $'# Guide\n\n## Setup\n'
+run_refs
+[ "$RC" -eq 1 ] && case "$OUT" in *"guide.md has no heading or explicit anchor #install"*) true ;; *) false ;; esac \
+  && ok "renaming only the target heading finds an unchanged caller" || bad "target rename" "rc=$RC out=$OUT"
+git -C "$R" rm -qf guide.md
+run_refs
+[ "$RC" -eq 1 ] && case "$OUT" in *"no tracked file or directory at guide.md"*) true ;; *) false ;; esac \
+  && ok "deleting only the target finds an unchanged caller" || bad "target deletion" "rc=$RC out=$OUT"
 
 echo "=== refusals and unmeasured paths ==="
 new_repo refuse

--- a/skills/review-gate/SKILL.md
+++ b/skills/review-gate/SKILL.md
@@ -17,7 +17,7 @@ tags: [review]
 
 The gate answers ONE question: **has this exact PR head been reviewed?** It posts that answer as a commit status the repo's branch rules require. It does not check CI, re-run anything, or reason about jobs.
 
-Two greens do NOT mean a review happened. Under `REVIEW_GATE_MODE = "off"` the predicate evaluates no evidence and attests only that the repo disabled the gate; and merge-group statuses never read the mode, posting green as "merge-queue entry: post-approval by construction". Both: [references/settings.md](references/settings.md) § `REVIEW_GATE_MODE`.
+Two greens do NOT mean a review happened. Under `REVIEW_GATE_MODE = "off"` the predicate evaluates no evidence and attests only that the repo disabled the gate; and merge-group statuses never read the mode, posting green as "merge-queue entry: post-approval by construction". Both: [`REVIEW_GATE_MODE` in the settings table](references/settings.md).
 
 ## Decision table
 
@@ -94,7 +94,7 @@ Keys a repo decides: [references/adoption.md](references/adoption.md) § Keys a 
 
 ## 4. Operations
 
-**Watching one or many PRs without stalling.** Never key a hand-rolled monitor on gate-state transitions. Run `.agents/skills/review-gate/scripts/pr-watch.sh` (optionally `--heal`) on the harness's wake-up mechanism: silence + exit 0 means nothing needs you; attention lines name exactly what does. See [references/adoption.md](references/adoption.md) § Watching PRs as an agent.
+**Watching one or many PRs without stalling.** Never key a hand-rolled monitor on gate-state transitions. Run `.agents/skills/review-gate/scripts/pr-watch.sh` (optionally `--heal`) on the harness's wake-up mechanism: silence + exit 0 means nothing needs you; attention lines name exactly what does. See [Watching PRs as an agent](references/adoption.md#watching-prs-as-an-agent-pr-watch).
 
 **Reviewers are down / nothing is reviewing.** Run the internal review loop: fix findings, resolve every thread, then post the override status with a real reason. It cannot bypass an objection or an open thread.
 


### PR DESCRIPTION
Changing or deleting a reference target can leave unchanged callers broken. md-refs now checks all configured documents after a staged change. It also checks markdown links followed by a section heading prefix or section number. Exact anchor and code-span references keep their existing rules.

Validation: red-first controls failed on the old scanner. Focused tests and the repository reference scan pass. The full package suite and commit chain passed. The review found stale scope guidance; that guidance was corrected.

Hold for overseer review. Merge only after a new MERGE directive.

Part of KEN-1203.
