### PR TITLE
test: check rendered catalog comments and prose

### DIFF
--- a/.agents/skills/iced-rs/tests/mouse-area-no-on-press-maybe.test.sh
+++ b/.agents/skills/iced-rs/tests/mouse-area-no-on-press-maybe.test.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
-# kendex#478: MouseArea (Iced 0.14) has NO `on_press_maybe` method — only `button`
-# does. The skill previously recommended `mouse_area(x).on_press_maybe(...)`, which
-# does not compile. This guard fails if that misuse is ever reintroduced into the
-# guidance sources (SKILL.md + references/), so a future reference refresh cannot
-# silently restore the bug.
+# MouseArea has no `on_press_maybe` method. The guidance must use a
+# conditional `on_press` call and retain the valid Button method.
 #
 # Run: bash skills/iced-rs/tests/mouse-area-no-on-press-maybe.test.sh
 set -euo pipefail

--- a/.agents/skills/linear/tests/cache-safe-format-parent-labels.test.sh
+++ b/.agents/skills/linear/tests/cache-safe-format-parent-labels.test.sh
@@ -1,24 +1,7 @@
 #!/usr/bin/env bash
-# the safe formatter must not silently drop
-# parent_id (and every other field) when a cached issue record's `labels` is
-# null/absent.
-#
-# Root cause: in the safe/compact/table jq programs the `agent`/`platform`
-# fields iterated `.labels.nodes[]` UNGUARDED, while the sibling `labels:` field
-# guarded it with `(.labels.nodes // [])`. A cached record with `labels: null`
-# therefore aborted the ENTIRE safe jq ("Cannot iterate over null"), so
-# `cache issues get <child> --format=safe` produced no usable object — parent_id
-# read back as null/empty even though the record genuinely carried its parent —
-# while `--format=raw` (which just echoes the record) still showed the parent.
-# That is exactly the "safe drops parent_id despite real linkage / raw shows it"
-# symptom class from the report. Guarding the iteration restores the documented
-# null-safe contract.
-#
-# NOTE on the reported CC-803 case specifically: with a WELL-FORMED cached record
-# (labels present, parent present) the safe formatter already resolves parent_id
-# correctly, so the field reported there was most consistent with a stale cache
-# (the record predating the parent assignment). This test locks in the general
-# safe-format robustness that null or absent `labels` does not remove parent_id.
+# The safe formatter must retain parent_id when a cached issue record has
+# null or absent labels. The list and bundle formats must retain the same
+# parent relationship.
 #
 # Fully offline — pure cache read, no curl needed.
 set -euo pipefail

--- a/.agents/skills/orch/scripts/lib/usage-reset.sh
+++ b/.agents/skills/orch/scripts/lib/usage-reset.sh
@@ -100,10 +100,8 @@ usage_reset_key() {
   else
     return 0
   fi
-  # A run of digits carrying neither minutes nor a meridiem is a number that
-  # follows the word, not a clock: `resets 2026-09-03` would otherwise put the
-  # `20` of the year on the event as an hour. Every shape above carries one or
-  # the other, so nothing attested is lost.
+  # Minutes or a meridiem distinguish a clock from the start of a calendar
+  # year. Every supported clock shape carries one or the other.
   [[ -n "$min" || -n "$meridiem" ]] || return 0
   # 12-hour to 24-hour; a clock with no meridiem is already a 24-hour one, as
   # it is for the sibling parser. Nothing range-checks the result: every clock

--- a/.agents/skills/review-gate/templates/review-gate-writer.yml
+++ b/.agents/skills/review-gate/templates/review-gate-writer.yml
@@ -1,7 +1,7 @@
 # SCAFFOLD from the kendex review-gate skill (templates/review-gate-writer.yml).
-# Copy it once into `.github/workflows/` during adoption. The copy is repo-owned
-# because `kendex refresh` does not sync workflow YAML. Copy it verbatim because
-# it carries no per-repo values. This workflow is the only writer and
+# Copy verbatim into `.github/workflows/`; `kendex refresh` does not sync it.
+# `validate-workflow.sh` allows YAML comment edits outside block scalars only.
+# Comments inside `run: |` remain executable input. This is the only writer and
 # posts the gate commit status on every leg that reaches it
 # (workflow_dispatch, schedule, merge_group), evaluating
 # review-predicate.sh on the two converge legs — the merge_group leg posts
@@ -44,7 +44,7 @@
 # minutes (a 60s-bounded attempt, a wait capped at 120s plus up to 14s of
 # jitter, a second 60s-bounded attempt), inside the 5-minute job budget.
 # Event-fast latency grows by a whole run lifecycle (the relay's own queue
-# and runner allocation, then the converge run's, which now starts only
+# and runner allocation, then the converge run's, which starts only
 # after the relay finishes) — dominated by runner allocation, which GitHub
 # does not bound. Typically that is seconds, well inside the cron floor's
 # period; when allocation exceeds the period, the scheduled pass converges
@@ -71,8 +71,7 @@
 # SECURITY (the pull_request_target posture): a write-capable token is only
 # safe while the job NEVER executes PR-controlled code. Every checkout below
 # pins the DEFAULT branch with credentials dropped, and PR data is read only
-# through the API — stricter than the old TRUST_PR_WORKFLOWS="true" posture,
-# in which PR-editable workflow definitions held the pen.
+# through the API.
 #
 # Anti-loop: the writer's own status posts are GITHUB_TOKEN-authored, and
 # GitHub suppresses workflow runs for token-authored events, so the status

--- a/.agents/skills/review-gate/tests/unreasoned-decline.test.sh
+++ b/.agents/skills/review-gate/tests/unreasoned-decline.test.sh
@@ -393,7 +393,7 @@ fi
 
 echo
 echo "--- must-fail probe: each name strip alone ---"
-# The two strips divide the #1851 replies between them, so each is proven on
+# The two strips divide the fixture replies between them, so each is proven on
 # the reply only it reaches. "pr-merge 103/103" needs the count strip: nothing
 # else takes a name the vocabulary has never heard of. "workflow 16/16" does
 # not — the word list already carries `workflows?` — so that one is the path

--- a/changelog.d/fixed/catalog-render-lint.md
+++ b/changelog.d/fixed/catalog-render-lint.md
@@ -1,0 +1,1 @@
+- Shipped workflow templates and scripts pass the comment checks that consumers install.

--- a/crates/cli/tests/catalog_check.rs
+++ b/crates/cli/tests/catalog_check.rs
@@ -10,6 +10,9 @@ use test_util::rooted;
 use std::path::Path;
 use std::process::{Command, Output};
 
+#[path = "catalog_check/render_lint.rs"]
+mod render_lint;
+
 #[allow(clippy::expect_used)]
 fn kendex(home: &Path, cwd: &Path, args: &[&str]) -> Output {
     Command::new(env!("CARGO_BIN_EXE_kendex"))

--- a/crates/cli/tests/catalog_check/render_lint.rs
+++ b/crates/cli/tests/catalog_check/render_lint.rs
@@ -1,0 +1,118 @@
+//! The trusted repository catalog must install files its shipped lanes accept.
+
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use super::{kendex, rooted};
+
+#[allow(clippy::unwrap_used)]
+fn command(home: &Path, project: &Path, program: &Path, args: &[&str]) -> Output {
+    Command::new(program)
+        .args(args)
+        .current_dir(project)
+        .env_clear()
+        .env("HOME", home)
+        .env("KENDEX_REAL_HOME", "1")
+        .env("PATH", std::env::var("PATH").unwrap())
+        // Include extensionless scripts and hooks. The shipped extractor
+        // decides which installed files have a comment grammar.
+        .env("GROWTH_GUARDS_COMMENT_PATHS", "*")
+        .output()
+        .unwrap()
+}
+
+fn success(output: Output) {
+    assert!(
+        output.status.success(),
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn installed_catalog_passes_comment_and_prose_lanes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let project = home.join("consumer");
+    let catalog = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .unwrap();
+    // Project discovery uses a harness marker. The manifest alone does not
+    // stop its ancestor walk at this fixture.
+    fs::create_dir_all(project.join(".agents")).unwrap();
+    success(command(&home, &project, Path::new("git"), &["init", "-q"]));
+    fs::write(
+        project.join("kendex.toml"),
+        format!(
+            "schema = 6\n[sources.catalog]\n{}\n",
+            crate::test_util::source_path(&catalog)
+        ),
+    )
+    .unwrap();
+    // The CLI's catalog discovery selects every package. Copy delivery makes
+    // every harness output available to the index-based scanners.
+    success(kendex(
+        &home,
+        &project,
+        &["add", "catalog", "--all", "--all-harnesses", "--copy", "-y"],
+    ));
+    let scripts = project.join(".claude/skills/growth-guards/scripts");
+    let controls = [
+        (
+            "comments",
+            ".claude/skills/review-gate/templates/review-gate-writer.yml",
+            "# Regression history: #2107\n",
+        ),
+        (
+            "comments",
+            ".claude/hooks/command-safety.sh",
+            "# Regression history: #2107\n",
+        ),
+        (
+            "comments",
+            ".claude/skills/growth-guards/scripts/install-git-hooks",
+            "# Regression history: #2107\n",
+        ),
+        (
+            "prose",
+            ".claude/skills/review-gate/SKILL.md",
+            "Regression history: #2107\n",
+        ),
+    ];
+    // Stage only each planted output for its control. A failure must name
+    // that output, so an unrelated catalog finding cannot pass the control.
+    for (lane, relative, defect) in controls {
+        let path = project.join(relative);
+        let original = fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("installed control {relative}: {error}"));
+        fs::write(&path, format!("{original}\n{defect}")).unwrap();
+        success(command(
+            &home,
+            &project,
+            Path::new("git"),
+            &["add", "--", relative],
+        ));
+        let output = command(&home, &project, &scripts.join(lane), &[]);
+        assert_eq!(output.status.code(), Some(1), "{output:?}");
+        let said = String::from_utf8_lossy(&output.stdout);
+        assert!(said.contains(relative), "{said}");
+        assert!(said.contains("history reference"), "{said}");
+        fs::write(path, original).unwrap();
+        success(command(
+            &home,
+            &project,
+            Path::new("git"),
+            &["rm", "--cached", "-f", "--", relative],
+        ));
+    }
+    // Git discovers the complete installed tree. No catalog or harness path
+    // allowlist can hide a newly shipped file from an applicable lane.
+    success(command(&home, &project, Path::new("git"), &["add", "-A"]));
+    for lane in ["prose", "comments"] {
+        success(command(&home, &project, &scripts.join(lane), &[]));
+    }
+}

--- a/skills/iced-rs/tests/mouse-area-no-on-press-maybe.test.sh
+++ b/skills/iced-rs/tests/mouse-area-no-on-press-maybe.test.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
-# kendex#478: MouseArea (Iced 0.14) has NO `on_press_maybe` method — only `button`
-# does. The skill previously recommended `mouse_area(x).on_press_maybe(...)`, which
-# does not compile. This guard fails if that misuse is ever reintroduced into the
-# guidance sources (SKILL.md + references/), so a future reference refresh cannot
-# silently restore the bug.
+# MouseArea has no `on_press_maybe` method. The guidance must use a
+# conditional `on_press` call and retain the valid Button method.
 #
 # Run: bash skills/iced-rs/tests/mouse-area-no-on-press-maybe.test.sh
 set -euo pipefail

--- a/skills/linear/tests/cache-safe-format-parent-labels.test.sh
+++ b/skills/linear/tests/cache-safe-format-parent-labels.test.sh
@@ -1,24 +1,7 @@
 #!/usr/bin/env bash
-# the safe formatter must not silently drop
-# parent_id (and every other field) when a cached issue record's `labels` is
-# null/absent.
-#
-# Root cause: in the safe/compact/table jq programs the `agent`/`platform`
-# fields iterated `.labels.nodes[]` UNGUARDED, while the sibling `labels:` field
-# guarded it with `(.labels.nodes // [])`. A cached record with `labels: null`
-# therefore aborted the ENTIRE safe jq ("Cannot iterate over null"), so
-# `cache issues get <child> --format=safe` produced no usable object — parent_id
-# read back as null/empty even though the record genuinely carried its parent —
-# while `--format=raw` (which just echoes the record) still showed the parent.
-# That is exactly the "safe drops parent_id despite real linkage / raw shows it"
-# symptom class from the report. Guarding the iteration restores the documented
-# null-safe contract.
-#
-# NOTE on the reported CC-803 case specifically: with a WELL-FORMED cached record
-# (labels present, parent present) the safe formatter already resolves parent_id
-# correctly, so the field reported there was most consistent with a stale cache
-# (the record predating the parent assignment). This test locks in the general
-# safe-format robustness that null or absent `labels` does not remove parent_id.
+# The safe formatter must retain parent_id when a cached issue record has
+# null or absent labels. The list and bundle formats must retain the same
+# parent relationship.
 #
 # Fully offline — pure cache read, no curl needed.
 set -euo pipefail

--- a/skills/orch/scripts/lib/usage-reset.sh
+++ b/skills/orch/scripts/lib/usage-reset.sh
@@ -100,10 +100,8 @@ usage_reset_key() {
   else
     return 0
   fi
-  # A run of digits carrying neither minutes nor a meridiem is a number that
-  # follows the word, not a clock: `resets 2026-09-03` would otherwise put the
-  # `20` of the year on the event as an hour. Every shape above carries one or
-  # the other, so nothing attested is lost.
+  # Minutes or a meridiem distinguish a clock from the start of a calendar
+  # year. Every supported clock shape carries one or the other.
   [[ -n "$min" || -n "$meridiem" ]] || return 0
   # 12-hour to 24-hour; a clock with no meridiem is already a 24-hour one, as
   # it is for the sibling parser. Nothing range-checks the result: every clock

--- a/skills/review-gate/templates/review-gate-writer.yml
+++ b/skills/review-gate/templates/review-gate-writer.yml
@@ -1,7 +1,7 @@
 # SCAFFOLD from the kendex review-gate skill (templates/review-gate-writer.yml).
-# Copy it once into `.github/workflows/` during adoption. The copy is repo-owned
-# because `kendex refresh` does not sync workflow YAML. Copy it verbatim because
-# it carries no per-repo values. This workflow is the only writer and
+# Copy verbatim into `.github/workflows/`; `kendex refresh` does not sync it.
+# `validate-workflow.sh` allows YAML comment edits outside block scalars only.
+# Comments inside `run: |` remain executable input. This is the only writer and
 # posts the gate commit status on every leg that reaches it
 # (workflow_dispatch, schedule, merge_group), evaluating
 # review-predicate.sh on the two converge legs — the merge_group leg posts
@@ -44,7 +44,7 @@
 # minutes (a 60s-bounded attempt, a wait capped at 120s plus up to 14s of
 # jitter, a second 60s-bounded attempt), inside the 5-minute job budget.
 # Event-fast latency grows by a whole run lifecycle (the relay's own queue
-# and runner allocation, then the converge run's, which now starts only
+# and runner allocation, then the converge run's, which starts only
 # after the relay finishes) — dominated by runner allocation, which GitHub
 # does not bound. Typically that is seconds, well inside the cron floor's
 # period; when allocation exceeds the period, the scheduled pass converges
@@ -71,8 +71,7 @@
 # SECURITY (the pull_request_target posture): a write-capable token is only
 # safe while the job NEVER executes PR-controlled code. Every checkout below
 # pins the DEFAULT branch with credentials dropped, and PR data is read only
-# through the API — stricter than the old TRUST_PR_WORKFLOWS="true" posture,
-# in which PR-editable workflow definitions held the pen.
+# through the API.
 #
 # Anti-loop: the writer's own status posts are GITHUB_TOKEN-authored, and
 # GitHub suppresses workflow runs for token-authored events, so the status

--- a/skills/review-gate/tests/unreasoned-decline.test.sh
+++ b/skills/review-gate/tests/unreasoned-decline.test.sh
@@ -393,7 +393,7 @@ fi
 
 echo
 echo "--- must-fail probe: each name strip alone ---"
-# The two strips divide the #1851 replies between them, so each is proven on
+# The two strips divide the fixture replies between them, so each is proven on
 # the reply only it reaches. "pr-merge 103/103" needs the count strip: nothing
 # else takes a name the vocabulary has never heard of. "workflow 16/16" does
 # not — the word list already carries `workflows?` — so that one is the path

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -113,7 +113,7 @@ skills/review-gate/scripts/pr-watch.sh	871
 skills/review-gate/scripts/review-predicate-selftest.sh	2474
 skills/review-gate/scripts/review-predicate.sh	1567
 skills/review-gate/scripts/validate.sh	581
-skills/review-gate/templates/review-gate-writer.yml	652
+skills/review-gate/templates/review-gate-writer.yml	651
 skills/review-gate/tests/pr-watch.test.sh	1158
 skills/second-opinion/scripts/second-opinion	2679
 skills/second-opinion/tests/cli-failure-gate.test.sh	1204


### PR DESCRIPTION
The catalog test installs the shipped packages and runs their comment and prose checks over the installed files. It covers workflow templates, scripts, hooks, and instruction files. Shipped comments that failed those checks are corrected in source and tracked renders.

The catalog suite passed 10 tests. Planted violations in a workflow template, shell hook, extensionless script, and skill file failed as required. Full repository checks, the commit chain, and one local review passed.

This PR builds on #2121. Merge #2121 first, then retarget this PR to main.

Closes #2107

phase: hold-for-overseer

Program: KEN-1203
