### PR TITLE
fix(dev): load code-quality before editing

### DIFF
--- a/.agents/skills/dev/workflows/dev-fix.md
+++ b/.agents/skills/dev/workflows/dev-fix.md
@@ -1,5 +1,7 @@
 # Fix Lifecycle
 
+Read [code-quality](../../code-quality/SKILL.md) before writing or modifying code, including for ad-hoc requests.
+
 The workflow for a dev agent receiving a review-fix delegation. Every path is worktree-scoped.
 
 ---

--- a/.agents/skills/dev/workflows/dev-implement.md
+++ b/.agents/skills/dev/workflows/dev-implement.md
@@ -1,5 +1,7 @@
 # Issue Lifecycle
 
+Read [code-quality](../../code-quality/SKILL.md) before writing or modifying code, including for ad-hoc requests.
+
 The workflow for a dev or QA agent receiving a work-item delegation. Skip every tracker update for ad-hoc requests (no issue reference).
 
 Run `pwd -P` before the first repo-relative command; it must print the delegation's `Worktree:` path. On any other path, stop and report where the shell started.

--- a/skills/dev/workflows/dev-fix.md
+++ b/skills/dev/workflows/dev-fix.md
@@ -1,5 +1,7 @@
 # Fix Lifecycle
 
+Read [code-quality](../../code-quality/SKILL.md) before writing or modifying code, including for ad-hoc requests.
+
 The workflow for a dev agent receiving a review-fix delegation. Every path is worktree-scoped.
 
 ---

--- a/skills/dev/workflows/dev-implement.md
+++ b/skills/dev/workflows/dev-implement.md
@@ -1,5 +1,7 @@
 # Issue Lifecycle
 
+Read [code-quality](../../code-quality/SKILL.md) before writing or modifying code, including for ad-hoc requests.
+
 The workflow for a dev or QA agent receiving a work-item delegation. Skip every tracker update for ad-hoc requests (no issue reference).
 
 Run `pwd -P` before the first repo-relative command; it must print the delegation's `Worktree:` path. On any other path, stop and report where the shell started.


### PR DESCRIPTION
Both development workflows now load code-quality before edits, including ad-hoc requests. The source and tracked render instructions match.

Validation: link targets and diff checks passed. The full commit hook chain passed. The single local review found no blockers.

phase: hold-for-overseer

KEN-563. Program: KEN-1203.
