### PR TITLE
feat(preflight): report checks skipped for unavailable tools

### DIFF
--- a/.agents/skills/preflight/README.md
+++ b/.agents/skills/preflight/README.md
@@ -8,7 +8,7 @@ A checker for changed files in a repository. It detects script errors, broken do
 kendex add vanillagreencom/kendex --skill preflight
 ```
 
-Requires Git, awk and standard POSIX tools. Bash 3.2 is supported. Install shellcheck for its shell checks, jq for JSON checks, and taplo or Python with tomllib for TOML checks. A check with a missing tool is skipped.
+Requires Git, awk and standard POSIX tools. Bash 3.2 is supported. Install shellcheck for its shell checks, jq for JSON checks, and taplo or Python with tomllib for TOML checks. A needed check with a missing tool is named as not run. The final result lists skipped checks without changing the exit status.
 
 ## Features
 

--- a/.agents/skills/preflight/SKILL.md
+++ b/.agents/skills/preflight/SKILL.md
@@ -23,7 +23,7 @@ Problems with a kendex-owned skill go through `kendex report`; check ownership i
 
 # Preflight
 
-Every lane is diff-scoped and fail-only, with no warnings tier: a finding lands only on a line this change ADDED, and a lane that cannot decide reports nothing. What a lane may read: [references/lanes.md](references/lanes.md).
+Every lane is diff-scoped and fail-only, with no warnings tier: a finding lands only on a line this change ADDED, and a lane that cannot decide reports no finding. What a lane may read: [references/lanes.md](references/lanes.md).
 
 ```bash
 .agents/skills/preflight/scripts/preflight              # vs the default branch's merge base
@@ -50,7 +50,7 @@ Every lane is diff-scoped and fail-only, with no warnings tier: a finding lands 
 
 Shell files are `*.sh`, `*.bash`, or anything with a `sh`/`bash` shebang. Deleted files, and files under `tests/` or `fixtures/`, are out of scope for the lanes that judge whole files; `unwired-suite` is the exception.
 
-Installed-artifact subtrees (`.agents/` and the harness dirs' skills/agents/hooks/rules/instructions/packages/kendex trees) are out of scope for `masked-returns`, `fail-open`, `unwired-suite`, `mktemp-trap`, `docs-cited-paths`. `shell-syntax`, `shellcheck-errors`, `hardcoded-temp-path`, `applied-migration-edited`, `data-syntax` stay on there. A `prompts/` or `commands/` tree under a harness dir keeps every lane. A lane whose tool is missing skips silently. It neither fails nor passes the run.
+Installed-artifact subtrees (`.agents/` and the harness dirs' skills/agents/hooks/rules/instructions/packages/kendex trees) are out of scope for `masked-returns`, `fail-open`, `unwired-suite`, `mktemp-trap`, `docs-cited-paths`. `shell-syntax`, `shellcheck-errors`, `hardcoded-temp-path`, `applied-migration-edited`, `data-syntax` stay on there. A `prompts/` or `commands/` tree under a harness dir keeps every lane. When a relevant file needs an unavailable tool, the output names the lane as not run and lists it in the final result. Data-syntax details identify JSON or TOML. Other applicable checks still run, and missing optional tools do not change the exit status.
 
 Exit codes: `0` clean, `1` findings, `2` usage/environment error (bad flag, not a git repository, unresolvable base). Findings print as `path:line: [lane] message`, line `0` for a whole-file finding.
 

--- a/.agents/skills/preflight/scripts/preflight
+++ b/.agents/skills/preflight/scripts/preflight
@@ -5,12 +5,12 @@
 # not exist, source files citing docs that do not exist, edits to a migration
 # a database has already run, malformed JSON/TOML.
 #
-# Precision before coverage: a lane that cannot decide says nothing. The
+# Precision before coverage: a lane that cannot decide reports no finding. The
 # line-scoped lanes report only on lines this diff added, so an existing
 # violation on an untouched line never fails somebody else's change. A
-# missing optional tool (shellcheck, jq, taplo, python3) skips its lane
-# silently — the run never fails because a tool is absent, and a lane never
-# degrades into a warning: it fails or it says nothing.
+# missing optional tool (shellcheck, jq, taplo, python3) is reported when
+# its lane is needed. Missing tools do not change the exit status; the
+# final result lists the lanes that could not run.
 #
 # Exit codes: 0 clean; 1 findings; 2 usage/environment error.
 set -euo pipefail
@@ -46,6 +46,9 @@ non-ignored untracked files; --staged sees only the index.
 Lanes: shell-syntax, shellcheck-errors, masked-returns, fail-open,
 unwired-suite, mktemp-trap, hardcoded-temp-path, docs-cited-paths,
 applied-migration-edited, data-syntax.
+
+Needed checks with unavailable optional tools are reported by lane name.
+The final result lists those lanes without changing the exit status.
 
 Exit codes: 0 clean; 1 findings; 2 usage/environment error.
 EOF
@@ -90,11 +93,13 @@ cleanup() {
 trap cleanup EXIT
 pf_load_project_env "$MODE" "$REPO_ROOT" "$TMP" || env_error "could not load project settings"
 : >"$TMP/findings.tsv"
+: >"$TMP/skipped.tsv"
 : >"$TMP/added.tsv"
 : >"$TMP/newfiles.list"
 
 emit() { printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" >>"$TMP/findings.tsv"; }
 have() { command -v "$1" >/dev/null 2>&1; }
+record_skip() { printf '%s\t%s\n' "$1" "$2" >>"$TMP/skipped.tsv"; }
 
 # --- content, the only judge of what a lane may read -------------------------
 # Two answers no caller may collapse. Nothing to inspect BY DESIGN — a symlink
@@ -461,7 +466,7 @@ check_toml() { # CONTENT-PATH — parser diagnostics on stdout, nonzero when inv
   case "$HAVE_TOML" in
     taplo) taplo check -- "$1" 2>&1 ;;
     python) python3 -c "$TOML_PY" "$1" 2>&1 ;;
-    *) return 0 ;;
+    *) record_skip data-syntax "TOML: taplo or python3 with tomllib is unavailable" ;;
   esac
 }
 
@@ -842,6 +847,11 @@ while IFS= read -r f; do
           fi
         fi
       done <<<"$(run_shellcheck "$cpath")"
+    else
+      record_skip shellcheck-errors "shellcheck is unavailable"
+      if [ "$vendored_mirror" = 0 ]; then
+        record_skip masked-returns "shellcheck is unavailable"
+      fi
     fi
 
     # A new script that never turns on errexit, nounset and pipefail
@@ -861,9 +871,13 @@ while IFS= read -r f; do
   case "$f" in
     *.json | *.jsonc)
       # jq owns strict JSON; suffixes and settings declare the comment dialect.
-      if ! is_jsonc_path "$f" && have jq && ! out="$(jq empty -- "$cpath" 2>&1)"; then
-        msg="$(first_line "$out")"
-        emit "$f" "$(line_hint "$out")" data-syntax "invalid JSON: ${msg#jq: }"
+      if ! is_jsonc_path "$f"; then
+        if ! have jq; then
+          record_skip data-syntax "JSON: jq is unavailable"
+        elif ! out="$(jq empty -- "$cpath" 2>&1)"; then
+          msg="$(first_line "$out")"
+          emit "$f" "$(line_hint "$out")" data-syntax "invalid JSON: ${msg#jq: }"
+        fi
       fi ;;
     *.toml)
       if ! out="$(check_toml "$cpath")"; then
@@ -1032,12 +1046,22 @@ if [ -n "$MIGRATION_BASE" ] && [ -n "$MIGRATION_GLOBS" ]; then
 fi
 
 # --- verdict -----------------------------------------------------------------
+SKIPPED=""
+LC_ALL=C sort -u "$TMP/skipped.tsv" >"$TMP/skipped.unique"
+while IFS="$TAB" read -r lane reason; do
+  printf 'preflight: [%s] not run: %s\n' "$lane" "$reason"
+  case ", $SKIPPED, " in
+    *", $lane, "*) ;;
+    *) SKIPPED="${SKIPPED:+$SKIPPED, }$lane" ;;
+  esac
+done <"$TMP/skipped.unique"
+SKIP_NOTE="${SKIPPED:+; not run: $SKIPPED}"
 COUNT="$(awk 'END { print NR }' "$TMP/findings.tsv")"
 if [ "$COUNT" -gt 0 ]; then
   LC_ALL=C sort -t"$TAB" -k1,1 -k2,2n "$TMP/findings.tsv" | while IFS="$TAB" read -r p n lane msg; do
     printf '%s:%s: [%s] %s\n' "$p" "$n" "$lane" "$msg"
   done
-  printf 'preflight: %s finding(s) across %s changed file(s)\n' "$COUNT" "$FILE_COUNT"
+  printf 'preflight: %s finding(s) across %s changed file(s)%s\n' "$COUNT" "$FILE_COUNT" "$SKIP_NOTE"
   exit 1
 fi
-printf 'preflight: clean (%s changed file(s))\n' "$FILE_COUNT"
+printf 'preflight: clean (%s changed file(s))%s\n' "$FILE_COUNT" "$SKIP_NOTE"

--- a/.agents/skills/preflight/tests/unavailable-tools.test.sh
+++ b/.agents/skills/preflight/tests/unavailable-tools.test.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
+unset PREFLIGHT_JSONC_GLOBS PREFLIGHT_MIGRATION_GLOBS
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PF="${PREFLIGHT_UNDER_TEST:-$TEST_DIR/../scripts/preflight}"
+TMP="$(mktemp -d)"
+trap 'rm -rf -- "${TMP:?}"' EXIT
+R="$TMP/repo"
+BIN="$TMP/bin"
+mkdir -p "$R/scripts" "$R/data" "$BIN"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
+printf '# Fixture\n' >"$R/README.md"
+git -C "$R" add README.md
+git -C "$R" commit -qm fixture
+
+# The restricted PATH has preflight's required tools but no optional parser.
+for tool in bash git awk cat cmp cp cut dirname grep head mkdir mktemp mv readlink rm sed sort tail tr wc; do
+  real="$(command -v "$tool")"
+  ln -s "$real" "$BIN/$tool"
+done
+for name in one two; do
+  printf '#!/usr/bin/env bash\nset -euo pipefail\nprintf "fixture\\n"\n' >"$R/scripts/$name.sh"
+  printf '{"fixture":true}\n' >"$R/data/$name.json"
+done
+printf 'fixture = true\n' >"$R/data/config.toml"
+git -C "$R" add -A
+
+PASS=0 FAIL=0 OUT="" RC=0
+run_pf() {
+  RC=0
+  OUT="$(cd "$R" && PATH="$BIN" "$PF" --staged 2>&1)" || RC=$?
+}
+has() { case "$OUT" in *"$1"*) return 0 ;; esac; return 1; }
+ok() { PASS=$((PASS + 1)); printf '  ok: %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL: %s (exit %s)\n%s\n' "$1" "$RC" "$OUT"; }
+
+run_pf
+[ "$RC" -eq 0 ] && ok 'missing optional tools keep exit 0' || bad 'optional exit status'
+for lane in shellcheck-errors masked-returns data-syntax; do
+  has "[$lane] not run:" && ok "$lane is named" || bad "$lane is named"
+done
+has 'JSON: jq is unavailable' && has 'TOML: taplo or python3 with tomllib is unavailable' \
+  && ok 'data-syntax identifies each unavailable format' || bad 'data format skip details'
+summary="$(printf '%s\n' "$OUT" | tail -n 1)"
+case "$summary" in
+  'preflight: clean ('*'; not run: data-syntax, masked-returns, shellcheck-errors') ok 'clean summary lists the skipped lanes' ;;
+  *) bad 'clean summary lists the skipped lanes' ;;
+esac
+[ "$(printf '%s\n' "$OUT" | grep -cF '[shellcheck-errors] not run:')" -eq 1 ] \
+  && ok 'multiple shell files produce one skip detail' || bad 'skip detail deduplication'
+
+git -C "$R" reset -q HEAD
+printf 'Documentation only.\n' >>"$R/README.md"
+git -C "$R" add README.md
+run_pf
+[ "$RC" -eq 0 ] && ! has 'not run:' \
+  && ok 'unneeded optional tools produce no skip' || bad 'docs-only scope'
+printf '// comment dialect\n{"fixture":true,}\n' >"$R/data/config.jsonc"
+git -C "$R" add data/config.jsonc
+run_pf
+[ "$RC" -eq 0 ] && ! has 'not run:' \
+  && ok 'JSONC remains outside strict JSON parsing' || bad 'JSONC scope'
+
+git -C "$R" add -A
+printf '#!/usr/bin/env bash\necho fixture\n' >"$R/scripts/loose.sh"
+git -C "$R" add scripts/loose.sh
+run_pf
+[ "$RC" -eq 1 ] && has '[fail-open]' && has '[shellcheck-errors] not run:' \
+  && ok 'other findings still fail while optional checks are skipped' || bad 'findings retain exit 1'
+git -C "$R" rm -qf scripts/loose.sh
+
+if real="$(command -v jq)"; then
+  ln -s "$real" "$BIN/jq"
+  printf '{"fixture":\n' >"$R/data/one.json"
+  git -C "$R" add data/one.json
+  run_pf
+  [ "$RC" -eq 1 ] && has 'invalid JSON:' && ! has 'JSON: jq is unavailable' \
+    && has 'TOML: taplo or python3 with tomllib is unavailable' \
+    && ok 'available jq runs while TOML remains skipped' || bad 'JSON partial coverage'
+  printf '{"fixture":true}\n' >"$R/data/one.json"
+  git -C "$R" add data/one.json
+  rm "$BIN/jq"
+else
+  printf '  skip: available-jq control (jq is not installed)\n'
+fi
+
+if real="$(command -v python3)" && "$real" -c 'import tomllib' >/dev/null 2>&1; then
+  ln -s "$real" "$BIN/python3"
+  printf 'fixture = [\n' >"$R/data/config.toml"
+  git -C "$R" add data/config.toml
+  run_pf
+  [ "$RC" -eq 1 ] && has 'invalid TOML:' && ! has 'TOML: taplo or python3 with tomllib is unavailable' \
+    && has 'JSON: jq is unavailable' \
+    && ok 'Python TOML fallback still runs without taplo' || bad 'TOML fallback coverage'
+  rm "$BIN/python3"
+else
+  printf '  skip: Python TOML fallback control (tomllib is not installed)\n'
+fi
+
+# An installed Python without tomllib is also an unavailable TOML parser.
+printf '#!/usr/bin/env bash\nexit 1\n' >"$BIN/python3"
+chmod +x "$BIN/python3"
+run_pf
+[ "$RC" -eq 0 ] && has 'TOML: taplo or python3 with tomllib is unavailable' \
+  && ok 'Python without tomllib preserves the optional-parser status' || bad 'missing tomllib reporting'
+
+printf '%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/changelog.d/changed/ken-1226.md
+++ b/changelog.d/changed/ken-1226.md
@@ -1,0 +1,1 @@
+- Preflight names checks that cannot run because an optional tool is unavailable. Its final result lists skipped lanes while preserving the existing exit status.

--- a/skills/preflight/README.md
+++ b/skills/preflight/README.md
@@ -8,7 +8,7 @@ A checker for changed files in a repository. It detects script errors, broken do
 kendex add vanillagreencom/kendex --skill preflight
 ```
 
-Requires Git, awk and standard POSIX tools. Bash 3.2 is supported. Install shellcheck for its shell checks, jq for JSON checks, and taplo or Python with tomllib for TOML checks. A check with a missing tool is skipped.
+Requires Git, awk and standard POSIX tools. Bash 3.2 is supported. Install shellcheck for its shell checks, jq for JSON checks, and taplo or Python with tomllib for TOML checks. A needed check with a missing tool is named as not run. The final result lists skipped checks without changing the exit status.
 
 ## Features
 

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -15,7 +15,7 @@ tags: [review, testing]
 
 # Preflight
 
-Every lane is diff-scoped and fail-only, with no warnings tier: a finding lands only on a line this change ADDED, and a lane that cannot decide reports nothing. What a lane may read: [references/lanes.md](references/lanes.md).
+Every lane is diff-scoped and fail-only, with no warnings tier: a finding lands only on a line this change ADDED, and a lane that cannot decide reports no finding. What a lane may read: [references/lanes.md](references/lanes.md).
 
 ```bash
 .agents/skills/preflight/scripts/preflight              # vs the default branch's merge base
@@ -42,7 +42,7 @@ Every lane is diff-scoped and fail-only, with no warnings tier: a finding lands 
 
 Shell files are `*.sh`, `*.bash`, or anything with a `sh`/`bash` shebang. Deleted files, and files under `tests/` or `fixtures/`, are out of scope for the lanes that judge whole files; `unwired-suite` is the exception.
 
-Installed-artifact subtrees (`.agents/` and the harness dirs' skills/agents/hooks/rules/instructions/packages/kendex trees) are out of scope for `masked-returns`, `fail-open`, `unwired-suite`, `mktemp-trap`, `docs-cited-paths`. `shell-syntax`, `shellcheck-errors`, `hardcoded-temp-path`, `applied-migration-edited`, `data-syntax` stay on there. A `prompts/` or `commands/` tree under a harness dir keeps every lane. A lane whose tool is missing skips silently. It neither fails nor passes the run.
+Installed-artifact subtrees (`.agents/` and the harness dirs' skills/agents/hooks/rules/instructions/packages/kendex trees) are out of scope for `masked-returns`, `fail-open`, `unwired-suite`, `mktemp-trap`, `docs-cited-paths`. `shell-syntax`, `shellcheck-errors`, `hardcoded-temp-path`, `applied-migration-edited`, `data-syntax` stay on there. A `prompts/` or `commands/` tree under a harness dir keeps every lane. When a relevant file needs an unavailable tool, the output names the lane as not run and lists it in the final result. Data-syntax details identify JSON or TOML. Other applicable checks still run, and missing optional tools do not change the exit status.
 
 Exit codes: `0` clean, `1` findings, `2` usage/environment error (bad flag, not a git repository, unresolvable base). Findings print as `path:line: [lane] message`, line `0` for a whole-file finding.
 

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -5,12 +5,12 @@
 # not exist, source files citing docs that do not exist, edits to a migration
 # a database has already run, malformed JSON/TOML.
 #
-# Precision before coverage: a lane that cannot decide says nothing. The
+# Precision before coverage: a lane that cannot decide reports no finding. The
 # line-scoped lanes report only on lines this diff added, so an existing
 # violation on an untouched line never fails somebody else's change. A
-# missing optional tool (shellcheck, jq, taplo, python3) skips its lane
-# silently — the run never fails because a tool is absent, and a lane never
-# degrades into a warning: it fails or it says nothing.
+# missing optional tool (shellcheck, jq, taplo, python3) is reported when
+# its lane is needed. Missing tools do not change the exit status; the
+# final result lists the lanes that could not run.
 #
 # Exit codes: 0 clean; 1 findings; 2 usage/environment error.
 set -euo pipefail
@@ -46,6 +46,9 @@ non-ignored untracked files; --staged sees only the index.
 Lanes: shell-syntax, shellcheck-errors, masked-returns, fail-open,
 unwired-suite, mktemp-trap, hardcoded-temp-path, docs-cited-paths,
 applied-migration-edited, data-syntax.
+
+Needed checks with unavailable optional tools are reported by lane name.
+The final result lists those lanes without changing the exit status.
 
 Exit codes: 0 clean; 1 findings; 2 usage/environment error.
 EOF
@@ -90,11 +93,13 @@ cleanup() {
 trap cleanup EXIT
 pf_load_project_env "$MODE" "$REPO_ROOT" "$TMP" || env_error "could not load project settings"
 : >"$TMP/findings.tsv"
+: >"$TMP/skipped.tsv"
 : >"$TMP/added.tsv"
 : >"$TMP/newfiles.list"
 
 emit() { printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" >>"$TMP/findings.tsv"; }
 have() { command -v "$1" >/dev/null 2>&1; }
+record_skip() { printf '%s\t%s\n' "$1" "$2" >>"$TMP/skipped.tsv"; }
 
 # --- content, the only judge of what a lane may read -------------------------
 # Two answers no caller may collapse. Nothing to inspect BY DESIGN — a symlink
@@ -461,7 +466,7 @@ check_toml() { # CONTENT-PATH — parser diagnostics on stdout, nonzero when inv
   case "$HAVE_TOML" in
     taplo) taplo check -- "$1" 2>&1 ;;
     python) python3 -c "$TOML_PY" "$1" 2>&1 ;;
-    *) return 0 ;;
+    *) record_skip data-syntax "TOML: taplo or python3 with tomllib is unavailable" ;;
   esac
 }
 
@@ -842,6 +847,11 @@ while IFS= read -r f; do
           fi
         fi
       done <<<"$(run_shellcheck "$cpath")"
+    else
+      record_skip shellcheck-errors "shellcheck is unavailable"
+      if [ "$vendored_mirror" = 0 ]; then
+        record_skip masked-returns "shellcheck is unavailable"
+      fi
     fi
 
     # A new script that never turns on errexit, nounset and pipefail
@@ -861,9 +871,13 @@ while IFS= read -r f; do
   case "$f" in
     *.json | *.jsonc)
       # jq owns strict JSON; suffixes and settings declare the comment dialect.
-      if ! is_jsonc_path "$f" && have jq && ! out="$(jq empty -- "$cpath" 2>&1)"; then
-        msg="$(first_line "$out")"
-        emit "$f" "$(line_hint "$out")" data-syntax "invalid JSON: ${msg#jq: }"
+      if ! is_jsonc_path "$f"; then
+        if ! have jq; then
+          record_skip data-syntax "JSON: jq is unavailable"
+        elif ! out="$(jq empty -- "$cpath" 2>&1)"; then
+          msg="$(first_line "$out")"
+          emit "$f" "$(line_hint "$out")" data-syntax "invalid JSON: ${msg#jq: }"
+        fi
       fi ;;
     *.toml)
       if ! out="$(check_toml "$cpath")"; then
@@ -1032,12 +1046,22 @@ if [ -n "$MIGRATION_BASE" ] && [ -n "$MIGRATION_GLOBS" ]; then
 fi
 
 # --- verdict -----------------------------------------------------------------
+SKIPPED=""
+LC_ALL=C sort -u "$TMP/skipped.tsv" >"$TMP/skipped.unique"
+while IFS="$TAB" read -r lane reason; do
+  printf 'preflight: [%s] not run: %s\n' "$lane" "$reason"
+  case ", $SKIPPED, " in
+    *", $lane, "*) ;;
+    *) SKIPPED="${SKIPPED:+$SKIPPED, }$lane" ;;
+  esac
+done <"$TMP/skipped.unique"
+SKIP_NOTE="${SKIPPED:+; not run: $SKIPPED}"
 COUNT="$(awk 'END { print NR }' "$TMP/findings.tsv")"
 if [ "$COUNT" -gt 0 ]; then
   LC_ALL=C sort -t"$TAB" -k1,1 -k2,2n "$TMP/findings.tsv" | while IFS="$TAB" read -r p n lane msg; do
     printf '%s:%s: [%s] %s\n' "$p" "$n" "$lane" "$msg"
   done
-  printf 'preflight: %s finding(s) across %s changed file(s)\n' "$COUNT" "$FILE_COUNT"
+  printf 'preflight: %s finding(s) across %s changed file(s)%s\n' "$COUNT" "$FILE_COUNT" "$SKIP_NOTE"
   exit 1
 fi
-printf 'preflight: clean (%s changed file(s))\n' "$FILE_COUNT"
+printf 'preflight: clean (%s changed file(s))%s\n' "$FILE_COUNT" "$SKIP_NOTE"

--- a/skills/preflight/tests/unavailable-tools.test.sh
+++ b/skills/preflight/tests/unavailable-tools.test.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
+unset PREFLIGHT_JSONC_GLOBS PREFLIGHT_MIGRATION_GLOBS
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PF="${PREFLIGHT_UNDER_TEST:-$TEST_DIR/../scripts/preflight}"
+TMP="$(mktemp -d)"
+trap 'rm -rf -- "${TMP:?}"' EXIT
+R="$TMP/repo"
+BIN="$TMP/bin"
+mkdir -p "$R/scripts" "$R/data" "$BIN"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
+printf '# Fixture\n' >"$R/README.md"
+git -C "$R" add README.md
+git -C "$R" commit -qm fixture
+
+# The restricted PATH has preflight's required tools but no optional parser.
+for tool in bash git awk cat cmp cp cut dirname grep head mkdir mktemp mv readlink rm sed sort tail tr wc; do
+  real="$(command -v "$tool")"
+  ln -s "$real" "$BIN/$tool"
+done
+for name in one two; do
+  printf '#!/usr/bin/env bash\nset -euo pipefail\nprintf "fixture\\n"\n' >"$R/scripts/$name.sh"
+  printf '{"fixture":true}\n' >"$R/data/$name.json"
+done
+printf 'fixture = true\n' >"$R/data/config.toml"
+git -C "$R" add -A
+
+PASS=0 FAIL=0 OUT="" RC=0
+run_pf() {
+  RC=0
+  OUT="$(cd "$R" && PATH="$BIN" "$PF" --staged 2>&1)" || RC=$?
+}
+has() { case "$OUT" in *"$1"*) return 0 ;; esac; return 1; }
+ok() { PASS=$((PASS + 1)); printf '  ok: %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL: %s (exit %s)\n%s\n' "$1" "$RC" "$OUT"; }
+
+run_pf
+[ "$RC" -eq 0 ] && ok 'missing optional tools keep exit 0' || bad 'optional exit status'
+for lane in shellcheck-errors masked-returns data-syntax; do
+  has "[$lane] not run:" && ok "$lane is named" || bad "$lane is named"
+done
+has 'JSON: jq is unavailable' && has 'TOML: taplo or python3 with tomllib is unavailable' \
+  && ok 'data-syntax identifies each unavailable format' || bad 'data format skip details'
+summary="$(printf '%s\n' "$OUT" | tail -n 1)"
+case "$summary" in
+  'preflight: clean ('*'; not run: data-syntax, masked-returns, shellcheck-errors') ok 'clean summary lists the skipped lanes' ;;
+  *) bad 'clean summary lists the skipped lanes' ;;
+esac
+[ "$(printf '%s\n' "$OUT" | grep -cF '[shellcheck-errors] not run:')" -eq 1 ] \
+  && ok 'multiple shell files produce one skip detail' || bad 'skip detail deduplication'
+
+git -C "$R" reset -q HEAD
+printf 'Documentation only.\n' >>"$R/README.md"
+git -C "$R" add README.md
+run_pf
+[ "$RC" -eq 0 ] && ! has 'not run:' \
+  && ok 'unneeded optional tools produce no skip' || bad 'docs-only scope'
+printf '// comment dialect\n{"fixture":true,}\n' >"$R/data/config.jsonc"
+git -C "$R" add data/config.jsonc
+run_pf
+[ "$RC" -eq 0 ] && ! has 'not run:' \
+  && ok 'JSONC remains outside strict JSON parsing' || bad 'JSONC scope'
+
+git -C "$R" add -A
+printf '#!/usr/bin/env bash\necho fixture\n' >"$R/scripts/loose.sh"
+git -C "$R" add scripts/loose.sh
+run_pf
+[ "$RC" -eq 1 ] && has '[fail-open]' && has '[shellcheck-errors] not run:' \
+  && ok 'other findings still fail while optional checks are skipped' || bad 'findings retain exit 1'
+git -C "$R" rm -qf scripts/loose.sh
+
+if real="$(command -v jq)"; then
+  ln -s "$real" "$BIN/jq"
+  printf '{"fixture":\n' >"$R/data/one.json"
+  git -C "$R" add data/one.json
+  run_pf
+  [ "$RC" -eq 1 ] && has 'invalid JSON:' && ! has 'JSON: jq is unavailable' \
+    && has 'TOML: taplo or python3 with tomllib is unavailable' \
+    && ok 'available jq runs while TOML remains skipped' || bad 'JSON partial coverage'
+  printf '{"fixture":true}\n' >"$R/data/one.json"
+  git -C "$R" add data/one.json
+  rm "$BIN/jq"
+else
+  printf '  skip: available-jq control (jq is not installed)\n'
+fi
+
+if real="$(command -v python3)" && "$real" -c 'import tomllib' >/dev/null 2>&1; then
+  ln -s "$real" "$BIN/python3"
+  printf 'fixture = [\n' >"$R/data/config.toml"
+  git -C "$R" add data/config.toml
+  run_pf
+  [ "$RC" -eq 1 ] && has 'invalid TOML:' && ! has 'TOML: taplo or python3 with tomllib is unavailable' \
+    && has 'JSON: jq is unavailable' \
+    && ok 'Python TOML fallback still runs without taplo' || bad 'TOML fallback coverage'
+  rm "$BIN/python3"
+else
+  printf '  skip: Python TOML fallback control (tomllib is not installed)\n'
+fi
+
+# An installed Python without tomllib is also an unavailable TOML parser.
+printf '#!/usr/bin/env bash\nexit 1\n' >"$BIN/python3"
+chmod +x "$BIN/python3"
+run_pf
+[ "$RC" -eq 0 ] && has 'TOML: taplo or python3 with tomllib is unavailable' \
+  && ok 'Python without tomllib preserves the optional-parser status' || bad 'missing tomllib reporting'
+
+printf '%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Reports preflight lanes that could not run because an optional tool is unavailable. The final result names skipped checks. Reporting applies when a relevant file reaches the check; existing parser fallbacks and exit codes remain.

Updates the package documentation and tracked renders. No required-lane setting is added.

Validation: hidden-tool suite passes 13 controls. Restoring silent omission fails lane-name and summary assertions. Existing mode, precision and lane-control suites pass. Full Rust/UI validation and normal commit hooks pass.

Held for overseer MERGE.

Closes KEN-1226

Architecture-docs program: KEN-1203
