### PR TITLE
feat(bot-instructions): include shared doctrine in workflow

### DIFF
--- a/changelog.d/added/KEN-1007-delivery.md
+++ b/changelog.d/added/KEN-1007-delivery.md
@@ -1,0 +1,1 @@
+- The workflow bundle includes bot-instructions for generating GitHub review-bot files from shared rules and repository settings.

--- a/crates/core/src/source/bundles/own_catalog.rs
+++ b/crates/core/src/source/bundles/own_catalog.rs
@@ -21,7 +21,7 @@ use crate::source::{SourceConfig, find_item, list_items, source_config};
 use crate::source_read::SealedSource;
 
 /// The set that is orchestration, code-review and commit-guards plus
-/// deep-research in one install. A partial set leans on dependency
+/// deep-research and bot-instructions in one install. A partial set leans on dependency
 /// expansion to complete itself; this one promises to carry what it
 /// needs.
 const WHOLE: &str = "workflow";
@@ -34,7 +34,10 @@ const DRAWN_FROM: [&str; 3] = ["orchestration", "code-review", "commit-guards"];
 /// containment check runs both ways: a member of `workflow` and of
 /// nothing else has to be a deliberate entry here rather than a quiet
 /// one, or it goes undescribed.
-const BEYOND: [(ItemKind, &str); 1] = [(ItemKind::Skill, "deep-research")];
+const BEYOND: [(ItemKind, &str); 2] = [
+    (ItemKind::Skill, "deep-research"),
+    (ItemKind::Skill, "bot-instructions"),
+];
 
 /// One member per kind these sets carry, each of which has to read back.
 /// [`super::declared`] refuses a body key it does not know, so a `hooks`
@@ -43,7 +46,7 @@ const BEYOND: [(ItemKind, &str); 1] = [(ItemKind::Skill, "deep-research")];
 /// kinds and nothing said. That is what naming one member per kind buys.
 const A_MEMBER: [(&str, ItemKind, &str); 3] = [
     ("workflow", ItemKind::Agent, "reviewer-arch"),
-    ("workflow", ItemKind::Skill, "orch"),
+    ("workflow", ItemKind::Skill, "bot-instructions"),
     ("commit-guards", ItemKind::Hook, "block-bare-cd"),
 ];
 

--- a/kendex.toml
+++ b/kendex.toml
@@ -19,10 +19,10 @@ tags = ["agents", "skills", "hooks", "official"]
 # Curated sets, drawn from how these packages depend on one another. Install
 # a whole set with one preview, or pick from it. Members are bare names in
 # one list per kind, the shape `[bundles]` is read in. `workflow` is
-# orchestration, code-review and commit-guards plus deep-research, in one
-# install; those three stay for partial installs, and research sits beside it.
+# orchestration, code-review and commit-guards plus deep-research and
+# bot-instructions in one install; the partial bundles remain available.
 [bundles.workflow]
-description = "Orchestration, code review and commit guards in one install, with deep-research"
+description = "Orchestration, code review and commit guards in one install, with deep-research and bot-instructions"
 agents = [
   "reviewer-arch",
   "reviewer-correctness",
@@ -44,6 +44,7 @@ skills = [
   "reviewer",
   "linear",
   "review-gate",
+  "bot-instructions",
   "second-opinion",
   "code-quality",
   "docs-writing",

--- a/skills/bot-instructions/SKILL.md
+++ b/skills/bot-instructions/SKILL.md
@@ -9,7 +9,7 @@ metadata:
   source: kendex
   repository: "https://github.com/vanillagreencom/kendex"
   bugs: "https://github.com/vanillagreencom/kendex/issues"
-  version: "1.0.0"
+  version: "1.0.1"
 tags: [review]
 ---
 
@@ -92,39 +92,39 @@ Version and marker semantics: [schemas/renders.md](schemas/renders.md) § Common
 
 ## Doctrine
 
-The generator reads exactly one `## Doctrine` section from the spec copy named by `--spec`, or the running copy by default, ending at the next level-one or level-two heading. Each `###` heading inside it is a frozen block id; a repeated id is an error. A section with no blocks or a block with no text is an error. A block holds no repo, path, issue, or markdown that a YAML or TOML scalar cannot carry verbatim; repo text goes in `bot-instructions.toml`.
+Keep one `## Doctrine` section in the spec copy. `--spec` selects that copy; the default is the running package. End the section at the next level-one or level-two heading. Keep each `###` block ID unchanged and unique. Keep every block non-empty. Write text that YAML and TOML scalars can carry verbatim. Put repo names, paths, issues, and repo-specific rules in `bot-instructions.toml`.
 
 ### scope
 
-Raise a defect in the lines this pull request changed, or one those lines directly break. Correctness, security, data loss, and a fail-open path in gate, guard, or CI code are the classes that matter. Anything outside the diff and its direct blast radius is out of scope, including a scope observation about a file the pull request body already names as deliberate.
+Raise a defect only in changed lines or code those lines directly break. Report correctness defects, security defects, data loss, and fail-open paths in gates, guards, or CI. Do not report unrelated defects. Do not question the inclusion of a file that the PR body explicitly includes in its scope.
 
 ### rounds
 
-Surface everything you have about the current diff in one round. A finding held back for the next round costs a full re-review cycle, and these pull requests are pushed at agent speed. One comment per root cause, naming every affected site in that comment, rather than one comment per site.
+Report all findings about the current diff in one round. Write one comment per root cause. Name every affected site in that comment.
 
 ### severity
 
-Mark a finding blocking only if you would stop a colleague's merge for it. Everything else is a suggestion. Batch suggestions, and omit them on a re-review round whose diff is a one-line fix. Naming a finding's severity honestly is worth more than raising it: a confident wrong finding costs more than a hedged one.
+Mark a finding as blocking only if it must stop the merge. Mark other findings as suggestions. Group suggestions together. Omit suggestions when a repeat review covers a one-line fix. Match severity and confidence to the evidence.
 
 ### no-preferences
 
-Style, wording, naming, and comment phrasing are not findings here. Neither is speculative hardening on a path that already fails closed. Formatting and lint belong to CI. Ask for test coverage only where the diff changes behavior no test exercises, and then say which behavior, in one comment.
+Do not report style, wording, naming, or comment preferences. Do not request speculative changes to a path that already fails closed. Leave formatting and lint to CI. Request a test only when the diff changes behavior that no test exercises. Name that behavior in one comment.
 
 ### declined
 
-A finding class answered on this pull request with a stated decline is settled. Do not raise it again on a later round unless the relevant code changed since. The same holds for a class the repo has recorded as an accepted trade-off in its own instruction files: read those before asserting a rule.
+Read the PR's decline replies and the repo's instruction files before reporting a finding. Do not repeat a finding class that a stated decline or a documented accepted trade-off already answers. Reopen it only when the relevant code has changed.
 
 ### reply-contract
 
-Author replies are `Fixed in <sha>`, `Declined: <reason>`, or `Tracked: <issue>`. A decline names the passing state or the false premise it disproves, and a label alone is not a reason. A merge gate reading these replies rejects a tracking claim naming no issue, and a decline whose reason is nothing but a label it knows.
+Author replies are `Fixed in <sha>`, `Declined: <reason>`, or `Tracked: <issue>`. A decline names the passing state or the false premise it disproves. A label alone is not a reason. A merge gate that reads these replies rejects a tracking claim without an issue. It rejects a decline whose reason contains only a label it knows.
 
 ### render-out-of-scope
 
-A tracked tree this repo renders from an upstream package is not this repo's code. A review comment on it cannot be acted on here: the fix lands upstream and arrives by re-render, and an in-repo edit is erased. Report nothing on those paths, on any surface, in any round. The paths themselves follow this block wherever a surface has no other way to receive them.
+Do not report findings on tracked files that the repo renders from an upstream package. Apply this exclusion to every bot and every review round. Fix the upstream package and render it again; a local edit is overwritten. Include the excluded paths with this block wherever the bot has no other way to receive them.
 
 ### trust-model
 
-Review evidence is a formal review object from a trusted login, or another evidence form the repo's gate configuration names. Comment text, emoji reactions, and approvals spelled in prose are never approval, by design. Do not recommend parsing them.
+Accept review evidence only from a formal review object by a trusted login or an evidence form the repo's gate configuration names. Never treat comment text, emoji reactions, or prose approvals as approval. Do not recommend parsing them for approval.
 
 ## Adding a repo
 

--- a/skills/bot-instructions/tests/doctrine-routing.test.sh
+++ b/skills/bot-instructions/tests/doctrine-routing.test.sh
@@ -288,13 +288,18 @@ wrapped_spec="$BI_TMP/wrapped-spec"
 mkdir -p "$wrapped_spec" || exit 1
 cp -R "$PKG/SKILL.md" "$PKG/schemas" "$wrapped_spec/"
 python3 - "$wrapped_spec/SKILL.md" <<'PLANT' || exit 1
-import sys
+import re, sys
 p = sys.argv[1]
 s = open(p).read()
-needle = "in one round. A finding"
-if s.count(needle) != 1:
-    sys.exit(f"the rounds block no longer holds {needle!r}; plant the wrap elsewhere")
-open(p, "w").write(s.replace(needle, "in one round.\nA finding"))
+pattern = r"(?m)(^### rounds\n\n)([^\n]+)"
+matches = list(re.finditer(pattern, s))
+assert len(matches) == 1, "fixture needs one rounds block"
+body = matches[0].group(2)
+assert " " in body, "fixture needs a rounds paragraph to wrap"
+wrapped = body.replace(" ", "\n", 1)
+changed = s[:matches[0].start(2)] + wrapped + s[matches[0].end(2):]
+assert changed != s, "fixture did not plant a wrap"
+open(p, "w").write(changed)
 PLANT
 bi_must adopt --repo "$fenced" --spec "$wrapped_spec" || exit 1
 bi_must render --repo "$fenced" --spec "$wrapped_spec" || exit 1


### PR DESCRIPTION
The workflow bundle now includes bot-instructions. Its shared review doctrine uses the docs-writing standard while preserving the existing block IDs and routing.

Validation: bot-instructions suites, full repository validation, and normal commit hooks pass. Controls fail when bundle delivery is removed or wrapped doctrine paragraphs are not joined. The routing test selects its block by ID instead of matching an English sentence.

This PR covers package delivery. Manifest configuration and kendex adoption follow in separate PRs. Hold for overseer MERGE.

Related: KEN-1007.

Program: KEN-1203.
