### PR TITLE
docs(hooks): state the refusal rule and apply it to size-ratchet

### DIFF
--- a/.agents/skills/growth-guards/DEVELOPMENT.md
+++ b/.agents/skills/growth-guards/DEVELOPMENT.md
@@ -21,7 +21,7 @@ What a maintainer must not break. What each check fails: [CHECKS.md](CHECKS.md);
 - Content decides what is scannable; an attribute never does. Listings force text (`--text`, no `-I`), diffs pin `--no-ext-diff --no-textconv --no-color --text`, and each named blob is sniffed for a NUL in its first block.
 - `gg_content_carriers` lists the measurable carriers and `gg_grep_lane` details the hits; both force text and move together, since a file the listing names and the detail scan drops is a spurious exit 2.
 - Every skip goes through `gg_note_skip` and is counted in `GG_WALK_SKIPPED` by distinct path; each verdict line carries `N matched path(s) not measured`.
-- Every failure carries its remediation; every exclusion carries its reason; a tighten-only baseline exists only where legacy counts exist.
+- A check that refuses states what it refused, why, and the preferred remedy first, before any exemption path; every exclusion carries its reason; a tighten-only baseline exists only where legacy counts exist.
 - A remedy is data, never a pasteable command line.
 
 ## Git hook install contract

--- a/.agents/skills/growth-guards/scripts/suppression-ban
+++ b/.agents/skills/growth-guards/scripts/suppression-ban
@@ -142,8 +142,8 @@ NL='
 git ls-files -z -- '*.rs' >"$GG_TMP/rs.z" || gg_collection_error "git ls-files failed enumerating *.rs"
 while IFS= read -r -d '' f; do
   case "$f" in
-    *"$NL"*) gg_config_error "tracked path contains a newline, unrepresentable in line-oriented records (exclude it to skip the gate): '$f'" ;;
-    *"$GG_TAB"*) gg_config_error "tracked path contains a tab, unrepresentable in the baseline TSV (exclude it to skip the gate): '$f'" ;;
+    *"$NL"*) gg_config_error "tracked path contains a newline, unrepresentable in line-oriented records; rename the file: '$f'" ;;
+    *"$GG_TAB"*) gg_config_error "tracked path contains a tab, unrepresentable in the baseline TSV; rename the file: '$f'" ;;
   esac
 done <"$GG_TMP/rs.z"
 

--- a/.agents/skills/size-ratchet/SKILL.md
+++ b/.agents/skills/size-ratchet/SKILL.md
@@ -30,4 +30,4 @@ Run the document byte-ceiling check before review and in CI. The growth-guards p
 .agents/skills/size-ratchet/scripts/size-ratchet --staged
 ```
 
-Trim or split an over-limit document. Put an exception in the configured excludes file with a reason. Class selection and the exclusion format are [references/policy.md](references/policy.md). Flags, settings and exit codes are in `size-ratchet --help`.
+Split an over-limit document at a natural seam, move detail to a linked reference, or delete content the code or another document already states. A document that must stay whole gets a row in the configured excludes file with its reason. Class selection and the exclusion format are [references/policy.md](references/policy.md). Flags, settings and exit codes are in `size-ratchet --help`.

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -299,7 +299,7 @@ while IFS="$TAB" read -r oid f limit class; do
   case "$n" in "" | *[!0-9]*) collection_error "invalid byte count for tracked document: $f" ;; esac
   if [ "$n" -gt "$limit" ]; then
     printf 'size-ratchet FAIL: %s: %s bytes > %s bytes (class %s)\n' "$f" "$n" "$limit" "$class"
-    printf '  remedy: trim or split the document; exclusions require a reason in %s\n' "$EXCLUDES_FILE"
+    printf '  remedy: split the document at a natural seam, move detail to a linked reference, or delete content the code or another document already states; a document that must stay whole gets a row in %s with its reason\n' "$EXCLUDES_FILE"
     violations=$((violations + 1))
   fi
   checked=$((checked + 1))

--- a/hooks/AGENTS.md
+++ b/hooks/AGENTS.md
@@ -4,5 +4,6 @@ Catalog hooks, one bash script per hook, each with its suite under `tests/<name>
 
 - A hook opens with a commented frontmatter block between `# ---` lines: `name`, `event` (a name from `crates/core/src/hook.rs::EVENTS`), `matcher`, `description`, `safety`, `timeout` (seconds) and an optional `harnesses: [..]` restricting delivery; `crates/core/src/hook/spec.rs` reads it.
 - Exit 0 allows; exit 2 refuses with the reason on stderr; a payload that cannot be read is a refusal, never a pass.
+- A refusal states what it refused, why, and the preferred remedy first, before any exemption path.
 - A change to `hooks/<n>` lands the copies under `.claude/hooks`, `.codex/hooks` and `.pi/kendex/hooks` only where those already track the file, judged per file by a `tools/guard` lane; `tests/*` renders nowhere.
 - Shell stays Bash 3.2 compatible; `tools/bash32-lint` runs in the guard.

--- a/skills/growth-guards/DEVELOPMENT.md
+++ b/skills/growth-guards/DEVELOPMENT.md
@@ -21,7 +21,7 @@ What a maintainer must not break. What each check fails: [CHECKS.md](CHECKS.md);
 - Content decides what is scannable; an attribute never does. Listings force text (`--text`, no `-I`), diffs pin `--no-ext-diff --no-textconv --no-color --text`, and each named blob is sniffed for a NUL in its first block.
 - `gg_content_carriers` lists the measurable carriers and `gg_grep_lane` details the hits; both force text and move together, since a file the listing names and the detail scan drops is a spurious exit 2.
 - Every skip goes through `gg_note_skip` and is counted in `GG_WALK_SKIPPED` by distinct path; each verdict line carries `N matched path(s) not measured`.
-- Every failure carries its remediation; every exclusion carries its reason; a tighten-only baseline exists only where legacy counts exist.
+- A check that refuses states what it refused, why, and the preferred remedy first, before any exemption path; every exclusion carries its reason; a tighten-only baseline exists only where legacy counts exist.
 - A remedy is data, never a pasteable command line.
 
 ## Git hook install contract

--- a/skills/growth-guards/scripts/suppression-ban
+++ b/skills/growth-guards/scripts/suppression-ban
@@ -142,8 +142,8 @@ NL='
 git ls-files -z -- '*.rs' >"$GG_TMP/rs.z" || gg_collection_error "git ls-files failed enumerating *.rs"
 while IFS= read -r -d '' f; do
   case "$f" in
-    *"$NL"*) gg_config_error "tracked path contains a newline, unrepresentable in line-oriented records (exclude it to skip the gate): '$f'" ;;
-    *"$GG_TAB"*) gg_config_error "tracked path contains a tab, unrepresentable in the baseline TSV (exclude it to skip the gate): '$f'" ;;
+    *"$NL"*) gg_config_error "tracked path contains a newline, unrepresentable in line-oriented records; rename the file: '$f'" ;;
+    *"$GG_TAB"*) gg_config_error "tracked path contains a tab, unrepresentable in the baseline TSV; rename the file: '$f'" ;;
   esac
 done <"$GG_TMP/rs.z"
 

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -22,4 +22,4 @@ Run the document byte-ceiling check before review and in CI. The growth-guards p
 .agents/skills/size-ratchet/scripts/size-ratchet --staged
 ```
 
-Trim or split an over-limit document. Put an exception in the configured excludes file with a reason. Class selection and the exclusion format are [references/policy.md](references/policy.md). Flags, settings and exit codes are in `size-ratchet --help`.
+Split an over-limit document at a natural seam, move detail to a linked reference, or delete content the code or another document already states. A document that must stay whole gets a row in the configured excludes file with its reason. Class selection and the exclusion format are [references/policy.md](references/policy.md). Flags, settings and exit codes are in `size-ratchet --help`.

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -299,7 +299,7 @@ while IFS="$TAB" read -r oid f limit class; do
   case "$n" in "" | *[!0-9]*) collection_error "invalid byte count for tracked document: $f" ;; esac
   if [ "$n" -gt "$limit" ]; then
     printf 'size-ratchet FAIL: %s: %s bytes > %s bytes (class %s)\n' "$f" "$n" "$limit" "$class"
-    printf '  remedy: trim or split the document; exclusions require a reason in %s\n' "$EXCLUDES_FILE"
+    printf '  remedy: split the document at a natural seam, move detail to a linked reference, or delete content the code or another document already states; a document that must stay whole gets a row in %s with its reason\n' "$EXCLUDES_FILE"
     violations=$((violations + 1))
   fi
   checked=$((checked + 1))


### PR DESCRIPTION
A check that refuses states what it refused, why, and the preferred remedy first, before any exemption path.

- The sentence lands in `hooks/AGENTS.md` and `skills/growth-guards/DEVELOPMENT.md` § Design.
- `size-ratchet`'s remedy line now opens with split at a natural seam, a linked reference, or deleting derivable content, then the reasoned exclusion; `SKILL.md` says the same and `tests/staged-scope.test.sh` pins the text.
- `suppression-ban`'s two unrepresentable-path refusals name the rename before the exclusion.
- Sweep of every printed refusal in growth-guards, size-ratchet and preflight: every other one already leads with the remedy or names no exemption path.
- Renders under `.agents/skills/` carry the same diff.

Program: KEN-1203.

https://claude.ai/code/session_01ULToNSkaZuc12DKQ7MBb35
