### PR TITLE
fix(KEN-1230): check exits 2 when it could not complete

### DIFF
--- a/.agents/skills/bot-instructions/SKILL.md
+++ b/.agents/skills/bot-instructions/SKILL.md
@@ -31,6 +31,8 @@ Problems with a kendex-owned skill go through `kendex report`; check ownership i
 
 Flags: `--repo`, `--spec`, `--staged`, `--dry-run`; `bot-instructions --help`. Python 3.11+.
 
+Exit codes: 0 clean, 1 findings, 2 could not complete. A pre-commit lane blocks on both nonzero codes.
+
 ## What reads what
 
 | Bot | Reads | Reads from |

--- a/.agents/skills/bot-instructions/scripts/lib/cli.py
+++ b/.agents/skills/bot-instructions/scripts/lib/cli.py
@@ -3,6 +3,7 @@
 import argparse
 import os
 import sys
+import traceback
 
 from .errors import BotInstructionsError, ValidationFailed
 from . import run, tree, verbs
@@ -97,8 +98,18 @@ def main(argv=None):
         print(f"{len(exc.findings)} finding(s)", file=sys.stderr)
         return 1
     except BotInstructionsError as exc:
+        # Could not complete, which is 2 in the exit convention the
+        # growth-guards pre-commit lane reads: 0 clean, 1 findings, 2 the
+        # check could not answer. Everything a validator can attribute to the
+        # repo's own inputs is already a `ValidationFailed` by the time it
+        # reaches here (`run._as_finding`), so what arrives as a bare error is
+        # a source git could not answer for, an unusable spec copy, or a
+        # write that failed — none of them a violation in the tree.
         print(str(exc), file=sys.stderr)
-        return 1
+        return 2
+    except Exception:  # a crash is not a finding either
+        traceback.print_exc()
+        return 2
     for line in lines:
         print(line)
     return 0

--- a/.agents/skills/bot-instructions/tests/exit-codes.test.sh
+++ b/.agents/skills/bot-instructions/tests/exit-codes.test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# The exit convention the growth-guards pre-commit lane reads: 0 clean, 1
+# findings, 2 could not complete.
+#
+# The silent misreport: a run that could not answer — git would not run, the
+# spec copy is unusable — exiting 1 reads as a violation in the tree, and a
+# lane that sorts its verdicts by code files a tool outage under "fix your
+# repo". The lane blocks either way; what it tells the operator is wrong.
+
+. "$(dirname "$0")/lib/harness.sh"
+
+expect_status() {
+  local want label
+  want="$1"; label="$2"; shift 2
+  bi_run "$@"
+  if [ "$bi_status" -eq "$want" ]; then ok "$label"
+  else bad "$label" "exit $bi_status: $(printf '%s' "$bi_out" | head -2 | tr '\n' ' ')"; fi
+}
+
+repo="$(bi_rendered_repo exit-clean)" || exit 1
+expect_status 0 'a clean repo checks with exit 0' check --repo "$repo"
+
+# A finding is 1: the tree disagrees with a fresh render.
+printf '\nstale\n' >> "$repo/.github/copilot-instructions.md"
+expect_status 1 'a drift finding exits 1' check --repo "$repo"
+git -C "$repo" checkout -- . >/dev/null 2>&1
+
+# A source that cannot answer is 2, not 1: with git gone the run has no
+# tracked-path list to judge anything by, and nothing in the tree is wrong.
+rm -rf -- "${repo:?}/.git"
+expect_status 2 'git unable to answer exits 2' check --repo "$repo"
+if printf '%s\n' "$bi_out" | grep -q 'git ls-files'; then
+  ok 'and the message names the command that could not answer'
+else
+  bad 'and the message names the command that could not answer' "$bi_out"
+fi
+
+# An unusable spec copy is 2 for the same reason: the doctrine the render
+# would be built from is missing, so no verdict about the repo exists.
+repo="$(bi_rendered_repo exit-spec)" || exit 1
+spec="$BI_TMP/exit-spec-copy"
+mkdir -p "$spec/schemas"
+printf -- '---\nmetadata:\n  version: "x"\n---\n\n# no doctrine here\n' > "$spec/SKILL.md"
+cp "$BI_ROOT/skills/bot-instructions/schemas/renders.md" "$spec/schemas/renders.md"
+expect_status 2 'a spec copy with no doctrine source exits 2' check --repo "$repo" --spec "$spec"
+
+# Flag misuse stays 2, as argparse already had it.
+expect_status 2 'flag misuse exits 2' render --staged --repo "$repo"
+
+bi_summary

--- a/.agents/skills/bot-instructions/tests/exit-codes.test.sh
+++ b/.agents/skills/bot-instructions/tests/exit-codes.test.sh
@@ -44,6 +44,27 @@ printf -- '---\nmetadata:\n  version: "x"\n---\n\n# no doctrine here\n' > "$spec
 cp "$BI_ROOT/skills/bot-instructions/schemas/renders.md" "$spec/schemas/renders.md"
 expect_status 2 'a spec copy with no doctrine source exits 2' check --repo "$repo" --spec "$spec"
 
+# A crash is 2 as well: the tool failed, nothing in the tree is wrong, and
+# Python's own exit for an uncaught exception is 1. A dispatched dependency
+# raising something outside the package's error family reaches the last
+# handler, and the traceback still prints.
+crash_out="$(cd "$BI_ROOT/skills/bot-instructions/scripts" && PYTHONDONTWRITEBYTECODE=1 python3 - "$repo" <<'PY' 2>&1
+import sys
+sys.path.insert(0, ".")
+from lib import cli, tree
+def boom(*args, **kwargs):
+    raise RuntimeError("dispatched dependency failed")
+tree.open_tree = boom
+sys.exit(cli.main(["check", "--repo", sys.argv[1]]))
+PY
+)" && crash_status=0 || crash_status=$?
+if [ "$crash_status" -eq 2 ] && printf '%s\n' "$crash_out" | grep -q 'RuntimeError: dispatched dependency failed'; then
+  ok 'a crash outside the package error family exits 2 with its traceback'
+else
+  bad 'a crash outside the package error family exits 2 with its traceback' \
+      "exit $crash_status: $(printf '%s' "$crash_out" | tail -2 | tr '\n' ' ')"
+fi
+
 # Flag misuse stays 2, as argparse already had it.
 expect_status 2 'flag misuse exits 2' render --staged --repo "$repo"
 

--- a/skills/bot-instructions/SKILL.md
+++ b/skills/bot-instructions/SKILL.md
@@ -23,6 +23,8 @@ tags: [review]
 
 Flags: `--repo`, `--spec`, `--staged`, `--dry-run`; `bot-instructions --help`. Python 3.11+.
 
+Exit codes: 0 clean, 1 findings, 2 could not complete. A pre-commit lane blocks on both nonzero codes.
+
 ## What reads what
 
 | Bot | Reads | Reads from |

--- a/skills/bot-instructions/scripts/lib/cli.py
+++ b/skills/bot-instructions/scripts/lib/cli.py
@@ -3,6 +3,7 @@
 import argparse
 import os
 import sys
+import traceback
 
 from .errors import BotInstructionsError, ValidationFailed
 from . import run, tree, verbs
@@ -97,8 +98,18 @@ def main(argv=None):
         print(f"{len(exc.findings)} finding(s)", file=sys.stderr)
         return 1
     except BotInstructionsError as exc:
+        # Could not complete, which is 2 in the exit convention the
+        # growth-guards pre-commit lane reads: 0 clean, 1 findings, 2 the
+        # check could not answer. Everything a validator can attribute to the
+        # repo's own inputs is already a `ValidationFailed` by the time it
+        # reaches here (`run._as_finding`), so what arrives as a bare error is
+        # a source git could not answer for, an unusable spec copy, or a
+        # write that failed — none of them a violation in the tree.
         print(str(exc), file=sys.stderr)
-        return 1
+        return 2
+    except Exception:  # a crash is not a finding either
+        traceback.print_exc()
+        return 2
     for line in lines:
         print(line)
     return 0

--- a/skills/bot-instructions/tests/exit-codes.test.sh
+++ b/skills/bot-instructions/tests/exit-codes.test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# The exit convention the growth-guards pre-commit lane reads: 0 clean, 1
+# findings, 2 could not complete.
+#
+# The silent misreport: a run that could not answer — git would not run, the
+# spec copy is unusable — exiting 1 reads as a violation in the tree, and a
+# lane that sorts its verdicts by code files a tool outage under "fix your
+# repo". The lane blocks either way; what it tells the operator is wrong.
+
+. "$(dirname "$0")/lib/harness.sh"
+
+expect_status() {
+  local want label
+  want="$1"; label="$2"; shift 2
+  bi_run "$@"
+  if [ "$bi_status" -eq "$want" ]; then ok "$label"
+  else bad "$label" "exit $bi_status: $(printf '%s' "$bi_out" | head -2 | tr '\n' ' ')"; fi
+}
+
+repo="$(bi_rendered_repo exit-clean)" || exit 1
+expect_status 0 'a clean repo checks with exit 0' check --repo "$repo"
+
+# A finding is 1: the tree disagrees with a fresh render.
+printf '\nstale\n' >> "$repo/.github/copilot-instructions.md"
+expect_status 1 'a drift finding exits 1' check --repo "$repo"
+git -C "$repo" checkout -- . >/dev/null 2>&1
+
+# A source that cannot answer is 2, not 1: with git gone the run has no
+# tracked-path list to judge anything by, and nothing in the tree is wrong.
+rm -rf -- "${repo:?}/.git"
+expect_status 2 'git unable to answer exits 2' check --repo "$repo"
+if printf '%s\n' "$bi_out" | grep -q 'git ls-files'; then
+  ok 'and the message names the command that could not answer'
+else
+  bad 'and the message names the command that could not answer' "$bi_out"
+fi
+
+# An unusable spec copy is 2 for the same reason: the doctrine the render
+# would be built from is missing, so no verdict about the repo exists.
+repo="$(bi_rendered_repo exit-spec)" || exit 1
+spec="$BI_TMP/exit-spec-copy"
+mkdir -p "$spec/schemas"
+printf -- '---\nmetadata:\n  version: "x"\n---\n\n# no doctrine here\n' > "$spec/SKILL.md"
+cp "$BI_ROOT/skills/bot-instructions/schemas/renders.md" "$spec/schemas/renders.md"
+expect_status 2 'a spec copy with no doctrine source exits 2' check --repo "$repo" --spec "$spec"
+
+# Flag misuse stays 2, as argparse already had it.
+expect_status 2 'flag misuse exits 2' render --staged --repo "$repo"
+
+bi_summary

--- a/skills/bot-instructions/tests/exit-codes.test.sh
+++ b/skills/bot-instructions/tests/exit-codes.test.sh
@@ -44,6 +44,27 @@ printf -- '---\nmetadata:\n  version: "x"\n---\n\n# no doctrine here\n' > "$spec
 cp "$BI_ROOT/skills/bot-instructions/schemas/renders.md" "$spec/schemas/renders.md"
 expect_status 2 'a spec copy with no doctrine source exits 2' check --repo "$repo" --spec "$spec"
 
+# A crash is 2 as well: the tool failed, nothing in the tree is wrong, and
+# Python's own exit for an uncaught exception is 1. A dispatched dependency
+# raising something outside the package's error family reaches the last
+# handler, and the traceback still prints.
+crash_out="$(cd "$BI_ROOT/skills/bot-instructions/scripts" && PYTHONDONTWRITEBYTECODE=1 python3 - "$repo" <<'PY' 2>&1
+import sys
+sys.path.insert(0, ".")
+from lib import cli, tree
+def boom(*args, **kwargs):
+    raise RuntimeError("dispatched dependency failed")
+tree.open_tree = boom
+sys.exit(cli.main(["check", "--repo", sys.argv[1]]))
+PY
+)" && crash_status=0 || crash_status=$?
+if [ "$crash_status" -eq 2 ] && printf '%s\n' "$crash_out" | grep -q 'RuntimeError: dispatched dependency failed'; then
+  ok 'a crash outside the package error family exits 2 with its traceback'
+else
+  bad 'a crash outside the package error family exits 2 with its traceback' \
+      "exit $crash_status: $(printf '%s' "$crash_out" | tail -2 | tr '\n' ' ')"
+fi
+
 # Flag misuse stays 2, as argparse already had it.
 expect_status 2 'flag misuse exits 2' render --staged --repo "$repo"
 


### PR DESCRIPTION
Issue: #2143 (KEN-1230).

Class: a could-not-complete failure exiting as a violation. `cli.py` mapped every package error to 1; the growth-guards pre-commit lane contract is 0 clean, 1 findings, 2 could not complete. Now a `ValidationFailed` is 1, every other package error and a crash is 2. Findings on render inputs the repo owns (an absent manifest, a missing vendored schema) stay 1: `run._as_finding` attributes them to a validator by design, and they are the tree's state, not the tool's.

- `skills/bot-instructions/scripts/lib/cli.py`: the exit mapping.
- `skills/bot-instructions/SKILL.md`: the three codes, one line.
- `skills/bot-instructions/tests/exit-codes.test.sh`: 0, 1 and 2 each proven; git unavailable and a doctrine-less spec copy are the must-fail controls (both exit 1 on main).
- `.agents/skills/bot-instructions/**`: the tracked render, same diff.

Checks: all 12 bot-instructions suites pass, `tools/tests/bot-instructions.test.sh` passes, `tools/guard` clean, bash32-lint clean.

Held for the overseer's MERGE.

https://claude.ai/code/session_01P2PmJhqV1CYhWB4yDJdv3q