### PR TITLE
feat(KEN-1231): a manifest key for CodeRabbit knowledge retention

### DIFF
--- a/.agents/skills/bot-instructions/schemas/renders.md
+++ b/.agents/skills/bot-instructions/schemas/renders.md
@@ -206,7 +206,7 @@ The last two are here for the same reason as the rest. `code_generation` gets no
 
 A final entry with `path: "**"` carries `render-out-of-scope` when the exclusion set is non-empty. The path filters already remove those trees; the instruction is what stops a finding arriving through a file that references them.
 
-**`knowledge_base`.** `opt_out` false, every learning scope local, and `code_guidelines.filePatterns` naming `AGENTS.md`. Pointing CodeRabbit at `AGENTS.md` is the only way it reads that file.
+**`knowledge_base`.** `opt_out` is the inverse of `[bot-instructions.retention] coderabbit`, so `false` by default; every learning scope local; `code_guidelines.filePatterns` naming `AGENTS.md`. Pointing CodeRabbit at `AGENTS.md` is the only way it reads that file. Opting out removes CodeRabbit's stored learnings and its issue and pull request context. Code guidelines and web search are stateless and keep working, so the `AGENTS.md` route survives an opt-out.
 
 **Escaping.** Every string is emitted as a block or folded scalar with explicit indentation, never a quoted one-line scalar. Repo text is passed through with no escaping, which block scalars make safe for everything a YAML scalar can hold. A repo string containing a line that would terminate the block is refused, and so is one carrying a control character, by the same refusal `.pr_agent.toml` relies on: a block scalar cannot carry one either, and one predicate covers both targets because the values reaching them are the same set.
 

--- a/.agents/skills/bot-instructions/schemas/repo-toml.md
+++ b/.agents/skills/bot-instructions/schemas/repo-toml.md
@@ -156,6 +156,10 @@ First-push-only cadence is `coderabbit_incremental = false` with `qodo_push_trig
 
 `coderabbit`, string, optional. Renders to `tone_instructions`, whose hard cap is 250 characters after the generator strips the newlines a TOML multi-line string introduces. Over the cap, CodeRabbit rejects the entire file. The cap counts Unicode code points, which is what the vendored schema's `maxLength` counts. Absent, the shipped default is used; see `renders.md` for its text.
 
+### `[bot-instructions.retention]`
+
+`coderabbit`, bool, default `true`. What CodeRabbit keeps between pull requests. `false` renders `knowledge_base.opt_out = true`, which removes its stored learnings and its issue and pull request context; code guidelines and web search are stateless and stay on. A repo whose checked-in policy is complete sets it `false` so no learning accumulated in chat shadows the policy.
+
 ### `[bot-instructions.budgets]`
 
 | Key | Type | Default | Bounds |

--- a/.agents/skills/bot-instructions/scripts/lib/config.py
+++ b/.agents/skills/bot-instructions/scripts/lib/config.py
@@ -40,6 +40,11 @@ KEYS = {
         "qodo_push_trigger": (bool, False, False, None),
     },
     "tone": {"coderabbit": (str, False, None, "[bot-instructions.tone] coderabbit")},
+    # What a bot keeps between pull requests. `false` renders CodeRabbit's
+    # `knowledge_base.opt_out = true`: no stored learnings, issue or pull
+    # request context. Code guidelines and web search are stateless and stay
+    # on, so the `AGENTS.md` route survives an opt-out.
+    "retention": {"coderabbit": (bool, False, True, None)},
     "budgets": {
         "copilot_chars": (int, False, DEFAULT_COPILOT_CHARS, None),
         "qodo_best_practices_lines": (int, False, DEFAULT_QODO_LINES, None),
@@ -71,6 +76,7 @@ class Config:
         self.bots = data["bots"]
         self.cadence = data["cadence"]
         self.tone = data["tone"]
+        self.retention = data["retention"]
         self.budgets = data["budgets"]
         self.exclusions = data["exclusions"]
         self.surfaces = data["surface"]

--- a/.agents/skills/bot-instructions/scripts/lib/render_coderabbit.py
+++ b/.agents/skills/bot-instructions/scripts/lib/render_coderabbit.py
@@ -91,7 +91,7 @@ def overrides(model):
         # has been observed to skip pull requests targeting it, and the
         # wildcard also covers stacked pull requests.
         "reviews.auto_review.base_branches": [".*"],
-        "knowledge_base.opt_out": False,
+        "knowledge_base.opt_out": not model.config.retention["coderabbit"],
         "knowledge_base.code_guidelines.filePatterns": ["AGENTS.md"],
         "knowledge_base.learnings.scope": "local",
         "knowledge_base.issues.scope": "local",

--- a/.agents/skills/bot-instructions/tests/coderabbit.test.sh
+++ b/.agents/skills/bot-instructions/tests/coderabbit.test.sh
@@ -242,4 +242,25 @@ expect_red drift \
   'a line separator in the rendered .coderabbit.yaml' check --repo "$repo"
 git -C "$repo" checkout -- .coderabbit.yaml
 
+# --- `[bot-instructions.retention] coderabbit` -------------------------------
+# The render is full state, so a hand-kept `opt_out: true` has nowhere to go
+# on adoption unless the manifest can say it. Default true renders `false`;
+# false renders `true` and leaves the rest of the block alone.
+repo="$(bi_rendered_repo coderabbit-retention)" || exit 1
+if grep -q '^  opt_out: false$' "$repo/.coderabbit.yaml"; then
+  ok 'retention defaults to true, rendered as opt_out false'
+else
+  bad 'retention defaults to true, rendered as opt_out false' \
+      "$(grep -n opt_out "$repo/.coderabbit.yaml")"
+fi
+printf '\n[bot-instructions.retention]\ncoderabbit = false\n' >> "$repo/kendex.toml"
+if bi_must render --repo "$repo" \
+   && grep -q '^  opt_out: true$' "$repo/.coderabbit.yaml" \
+   && grep -q 'filePatterns' "$repo/.coderabbit.yaml"; then
+  ok 'retention false renders opt_out true and keeps code_guidelines'
+else
+  bad 'retention false renders opt_out true and keeps code_guidelines' \
+      "$(grep -n 'opt_out\|filePatterns' "$repo/.coderabbit.yaml")"
+fi
+
 bi_summary

--- a/.agents/skills/bot-instructions/tests/toml-schema.test.sh
+++ b/.agents/skills/bot-instructions/tests/toml-schema.test.sh
@@ -271,6 +271,15 @@ glob = "a/**"
 reason = "two, and the second reason is the one a reader believes"
 EOF
 
+c 'an unknown retention key' <<'EOF'
+[bot-instructions.retention]
+learnings = false
+EOF
+c 'a retention flag that is not a boolean' <<'EOF'
+[bot-instructions.retention]
+coderabbit = "no"
+EOF
+
 # --- the cross-flag set -----------------------------------------------------
 c 'qodo_best_practices true with qodo false' <<'EOF'
 [bot-instructions.bots]

--- a/skills/bot-instructions/schemas/renders.md
+++ b/skills/bot-instructions/schemas/renders.md
@@ -206,7 +206,7 @@ The last two are here for the same reason as the rest. `code_generation` gets no
 
 A final entry with `path: "**"` carries `render-out-of-scope` when the exclusion set is non-empty. The path filters already remove those trees; the instruction is what stops a finding arriving through a file that references them.
 
-**`knowledge_base`.** `opt_out` false, every learning scope local, and `code_guidelines.filePatterns` naming `AGENTS.md`. Pointing CodeRabbit at `AGENTS.md` is the only way it reads that file.
+**`knowledge_base`.** `opt_out` is the inverse of `[bot-instructions.retention] coderabbit`, so `false` by default; every learning scope local; `code_guidelines.filePatterns` naming `AGENTS.md`. Pointing CodeRabbit at `AGENTS.md` is the only way it reads that file. Opting out removes CodeRabbit's stored learnings and its issue and pull request context. Code guidelines and web search are stateless and keep working, so the `AGENTS.md` route survives an opt-out.
 
 **Escaping.** Every string is emitted as a block or folded scalar with explicit indentation, never a quoted one-line scalar. Repo text is passed through with no escaping, which block scalars make safe for everything a YAML scalar can hold. A repo string containing a line that would terminate the block is refused, and so is one carrying a control character, by the same refusal `.pr_agent.toml` relies on: a block scalar cannot carry one either, and one predicate covers both targets because the values reaching them are the same set.
 

--- a/skills/bot-instructions/schemas/repo-toml.md
+++ b/skills/bot-instructions/schemas/repo-toml.md
@@ -156,6 +156,10 @@ First-push-only cadence is `coderabbit_incremental = false` with `qodo_push_trig
 
 `coderabbit`, string, optional. Renders to `tone_instructions`, whose hard cap is 250 characters after the generator strips the newlines a TOML multi-line string introduces. Over the cap, CodeRabbit rejects the entire file. The cap counts Unicode code points, which is what the vendored schema's `maxLength` counts. Absent, the shipped default is used; see `renders.md` for its text.
 
+### `[bot-instructions.retention]`
+
+`coderabbit`, bool, default `true`. What CodeRabbit keeps between pull requests. `false` renders `knowledge_base.opt_out = true`, which removes its stored learnings and its issue and pull request context; code guidelines and web search are stateless and stay on. A repo whose checked-in policy is complete sets it `false` so no learning accumulated in chat shadows the policy.
+
 ### `[bot-instructions.budgets]`
 
 | Key | Type | Default | Bounds |

--- a/skills/bot-instructions/scripts/lib/config.py
+++ b/skills/bot-instructions/scripts/lib/config.py
@@ -40,6 +40,11 @@ KEYS = {
         "qodo_push_trigger": (bool, False, False, None),
     },
     "tone": {"coderabbit": (str, False, None, "[bot-instructions.tone] coderabbit")},
+    # What a bot keeps between pull requests. `false` renders CodeRabbit's
+    # `knowledge_base.opt_out = true`: no stored learnings, issue or pull
+    # request context. Code guidelines and web search are stateless and stay
+    # on, so the `AGENTS.md` route survives an opt-out.
+    "retention": {"coderabbit": (bool, False, True, None)},
     "budgets": {
         "copilot_chars": (int, False, DEFAULT_COPILOT_CHARS, None),
         "qodo_best_practices_lines": (int, False, DEFAULT_QODO_LINES, None),
@@ -71,6 +76,7 @@ class Config:
         self.bots = data["bots"]
         self.cadence = data["cadence"]
         self.tone = data["tone"]
+        self.retention = data["retention"]
         self.budgets = data["budgets"]
         self.exclusions = data["exclusions"]
         self.surfaces = data["surface"]

--- a/skills/bot-instructions/scripts/lib/render_coderabbit.py
+++ b/skills/bot-instructions/scripts/lib/render_coderabbit.py
@@ -91,7 +91,7 @@ def overrides(model):
         # has been observed to skip pull requests targeting it, and the
         # wildcard also covers stacked pull requests.
         "reviews.auto_review.base_branches": [".*"],
-        "knowledge_base.opt_out": False,
+        "knowledge_base.opt_out": not model.config.retention["coderabbit"],
         "knowledge_base.code_guidelines.filePatterns": ["AGENTS.md"],
         "knowledge_base.learnings.scope": "local",
         "knowledge_base.issues.scope": "local",

--- a/skills/bot-instructions/tests/coderabbit.test.sh
+++ b/skills/bot-instructions/tests/coderabbit.test.sh
@@ -242,4 +242,25 @@ expect_red drift \
   'a line separator in the rendered .coderabbit.yaml' check --repo "$repo"
 git -C "$repo" checkout -- .coderabbit.yaml
 
+# --- `[bot-instructions.retention] coderabbit` -------------------------------
+# The render is full state, so a hand-kept `opt_out: true` has nowhere to go
+# on adoption unless the manifest can say it. Default true renders `false`;
+# false renders `true` and leaves the rest of the block alone.
+repo="$(bi_rendered_repo coderabbit-retention)" || exit 1
+if grep -q '^  opt_out: false$' "$repo/.coderabbit.yaml"; then
+  ok 'retention defaults to true, rendered as opt_out false'
+else
+  bad 'retention defaults to true, rendered as opt_out false' \
+      "$(grep -n opt_out "$repo/.coderabbit.yaml")"
+fi
+printf '\n[bot-instructions.retention]\ncoderabbit = false\n' >> "$repo/kendex.toml"
+if bi_must render --repo "$repo" \
+   && grep -q '^  opt_out: true$' "$repo/.coderabbit.yaml" \
+   && grep -q 'filePatterns' "$repo/.coderabbit.yaml"; then
+  ok 'retention false renders opt_out true and keeps code_guidelines'
+else
+  bad 'retention false renders opt_out true and keeps code_guidelines' \
+      "$(grep -n 'opt_out\|filePatterns' "$repo/.coderabbit.yaml")"
+fi
+
 bi_summary

--- a/skills/bot-instructions/tests/toml-schema.test.sh
+++ b/skills/bot-instructions/tests/toml-schema.test.sh
@@ -271,6 +271,15 @@ glob = "a/**"
 reason = "two, and the second reason is the one a reader believes"
 EOF
 
+c 'an unknown retention key' <<'EOF'
+[bot-instructions.retention]
+learnings = false
+EOF
+c 'a retention flag that is not a boolean' <<'EOF'
+[bot-instructions.retention]
+coderabbit = "no"
+EOF
+
 # --- the cross-flag set -----------------------------------------------------
 c 'qodo_best_practices true with qodo false' <<'EOF'
 [bot-instructions.bots]


### PR DESCRIPTION
Issue: #2144 (KEN-1231).

Class: a full-state render fixing a posture the manifest cannot express, so adoption silently inverts a repo's hand-kept setting. hyprtrade's file (HT-1704) carried `knowledge_base.opt_out: true`; the package rendered `false` with no key to say otherwise. CodeRabbit's knowledge-base documentation states that opting out removes stored learnings and issue and pull request context while code guidelines and web search, being stateless, keep working, so an opt-out does not break the route through which CodeRabbit reads `AGENTS.md`. That makes the setting a repo choice, not a package invariant, and a key is the fix.

- `scripts/lib/config.py`: `[bot-instructions.retention] coderabbit`, bool, default `true`, in the closed schema.
- `scripts/lib/render_coderabbit.py`: `knowledge_base.opt_out` is its inverse.
- `schemas/repo-toml.md`, `schemas/renders.md`: the key and the posture it maps to.
- `tests/coderabbit.test.sh`: default renders `opt_out: false`; `false` renders `opt_out: true` and keeps `code_guidelines`. Both fail on main (unknown table). `tests/toml-schema.test.sh`: unknown key and wrong type in the new table.
- `.agents/skills/bot-instructions/**`: the tracked render, same diff.

Kendex's own renders are unchanged: this repo has CodeRabbit off. hyprtrade sets the key `false` in its re-render.

Checks: all 11 bot-instructions suites pass, `tools/tests/bot-instructions.test.sh` passes, `tools/guard` clean.

Held for the overseer's MERGE.

https://claude.ai/code/session_01P2PmJhqV1CYhWB4yDJdv3q