### PR TITLE
fix(hooks): command-safety completes on Bash 3.2

### DIFF
--- a/hooks/command-safety.sh
+++ b/hooks/command-safety.sh
@@ -16,7 +16,7 @@ refuse() { printf 'command-safety: %s\n' "$1" >&2; exit 2; }
 # such exit on Bash 3.2 too: an ERR trap inherited through `set -E` fires there
 # inside a command substitution even when the substitution stands on the left
 # of `||`, which reads the settings loader's guarded probes as failures.
-trap 'rc=$?; case $rc in 0 | 2) ;; *) printf "command-safety: the command safety check could not complete (exit %s)\n" "$rc" >&2; exit 2 ;; esac' EXIT
+trap 'rc=$?; case $rc in 0 | 2) ;; *) printf "command-safety: the command safety check could not complete (exit %s)\n" "$rc" >&2 || :; exit 2 ;; esac' EXIT
 for dependency in jq git grep cat; do
   command -v "$dependency" >/dev/null 2>&1 || refuse "$dependency is required"
 done

--- a/hooks/command-safety.sh
+++ b/hooks/command-safety.sh
@@ -8,10 +8,15 @@
 # timeout: 10
 # ---
 
-set -Eeuo pipefail
+set -euo pipefail
 
 refuse() { printf 'command-safety: %s\n' "$1" >&2; exit 2; }
-trap 'refuse "the command safety check could not complete"' ERR
+# An exit that is neither a verdict (0) nor a refusal (2) is a check that did
+# not complete, and it leaves as a refusal. The EXIT trap is what reaches every
+# such exit on Bash 3.2 too: an ERR trap inherited through `set -E` fires there
+# inside a command substitution even when the substitution stands on the left
+# of `||`, which reads the settings loader's guarded probes as failures.
+trap 'rc=$?; case $rc in 0 | 2) ;; *) printf "command-safety: the command safety check could not complete (exit %s)\n" "$rc" >&2; exit 2 ;; esac' EXIT
 for dependency in jq git grep cat; do
   command -v "$dependency" >/dev/null 2>&1 || refuse "$dependency is required"
 done


### PR DESCRIPTION
On macOS system bash (3.2.57) the command-safety hook refused every shell command in a project with a configured policy: its ERR trap, inherited through `set -E`, fired inside the growth-guards settings loader's command substitutions even where the substitution stood on the left of `||`, so the guarded probe for an absent `.env.local` read as a failed check.

The hook now converts any exit other than a verdict (0) or a refusal (2) into a refusal through an EXIT trap, which does not inherit into the loader and keeps every unexpected failure closed on both shells.

Proof: `hooks/tests/command-safety.test.sh` passes under bash 5.3 and under bash 3.2.57 with busybox tools (16 passed, 9 failed before the change on 3.2). A planted unguarded failure still leaves as exit 2 on both shells. The hook has no tracked render in this repository.

Found by the hooks audit, KEN-1232.

https://claude.ai/code/session_01G8mGZKa8sxjow9QaQuMAWp
