### PR TITLE
docs(hooks): block-bare-cd names the case it guards; drop a dead class

### DIFF
--- a/.claude/hooks/block-bare-cd.sh
+++ b/.claude/hooks/block-bare-cd.sh
@@ -43,7 +43,7 @@ fi
 STRIPPED=$(echo "$COMMAND" | sed 's/^[[:space:]]*//')
 if echo "$STRIPPED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
   echo "block-bare-cd: refusing a bare 'cd'. Where the shell persists across tool calls it re-roots every later command and every hook judging the working directory, while instruction files and hook paths stay with the launch directory." >&2
-  echo "  Scope the move instead: (cd /path && command). To work in a worktree, enter it with the harness's worktree tool where it has one (Claude Code's EnterWorktree) rather than cd." >&2
+  echo "  Use a subshell instead: (cd /path && command). To work in a worktree, enter it with the harness's worktree tool where it has one (Claude Code's EnterWorktree) rather than cd." >&2
   exit 2
 fi
 

--- a/.claude/hooks/block-bare-cd.sh
+++ b/.claude/hooks/block-bare-cd.sh
@@ -3,8 +3,8 @@
 # name: block-bare-cd
 # event: PreToolUse
 # matcher: Bash
-# description: Block bare cd commands that permanently change the working directory. Suggests using subshells instead.
-# safety: Prevents accidental working directory pollution across tool calls.
+# description: Refuse a command with a line that is only a `cd`. Where the shell persists across tool calls (Claude Code) a bare cd re-roots every later command and every hook that judges the working directory, while instruction files and hook paths stay with the launch directory; a cd into a worktree inside the repository, Claude Code's default `.claude/worktrees/<name>/`, also loads that tree's instruction files a second time as files there are read. Names the scoped form, `(cd /path && command)`, and, where the harness has one (Claude Code's EnterWorktree), its worktree tool for a move.
+# safety: Reads the command text only. On a harness that runs each command in a fresh shell (Codex, the Pi carrier) a bare cd changes nothing and the refusal costs one rewrite; the scoped form is right on every harness.
 # ---
 
 set -euo pipefail
@@ -42,8 +42,8 @@ fi
 # Simple heuristic: if the command is just "cd /path" with nothing else meaningful
 STRIPPED=$(echo "$COMMAND" | sed 's/^[[:space:]]*//')
 if echo "$STRIPPED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
-  echo "Bare 'cd' changes working directory permanently across tool calls." >&2
-  echo "Use a subshell instead: (cd /path && command)" >&2
+  echo "block-bare-cd: refusing a bare 'cd'. Where the shell persists across tool calls it re-roots every later command and every hook judging the working directory, while instruction files and hook paths stay with the launch directory." >&2
+  echo "  Scope the move instead: (cd /path && command). To work in a worktree, enter it with the harness's worktree tool where it has one (Claude Code's EnterWorktree) rather than cd." >&2
   exit 2
 fi
 

--- a/.claude/hooks/block-repo-copy.sh
+++ b/.claude/hooks/block-repo-copy.sh
@@ -91,11 +91,9 @@ fi
 # expression carries no order, so the set below is the set named above.
 ENDERS='&;'$'\n'
 CROSSABLE="[^${ENDERS}]"
-# BLANK and SPACE_ANY are the class names as they are spelled INSIDE a bracket
-# expression, so the same two definitions serve a class of their own and a
-# member of a larger one.
+# BLANK is the class name as it is spelled INSIDE a bracket expression, so the
+# one definition serves a class of its own and a member of a larger one.
 BLANK='[:blank:]'
-SPACE_ANY='[:space:]'
 GAP="[${BLANK}]"
 # The backslash is doubled twice over: once for the double quotes, once for the
 # regex, so this alternative is a literal backslash or a literal pipe followed

--- a/.codex/hooks/block-bare-cd.sh
+++ b/.codex/hooks/block-bare-cd.sh
@@ -43,7 +43,7 @@ fi
 STRIPPED=$(echo "$COMMAND" | sed 's/^[[:space:]]*//')
 if echo "$STRIPPED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
   echo "block-bare-cd: refusing a bare 'cd'. Where the shell persists across tool calls it re-roots every later command and every hook judging the working directory, while instruction files and hook paths stay with the launch directory." >&2
-  echo "  Scope the move instead: (cd /path && command). To work in a worktree, enter it with the harness's worktree tool where it has one (Claude Code's EnterWorktree) rather than cd." >&2
+  echo "  Use a subshell instead: (cd /path && command). To work in a worktree, enter it with the harness's worktree tool where it has one (Claude Code's EnterWorktree) rather than cd." >&2
   exit 2
 fi
 

--- a/.codex/hooks/block-bare-cd.sh
+++ b/.codex/hooks/block-bare-cd.sh
@@ -3,8 +3,8 @@
 # name: block-bare-cd
 # event: PreToolUse
 # matcher: Bash
-# description: Block bare cd commands that permanently change the working directory. Suggests using subshells instead.
-# safety: Prevents accidental working directory pollution across tool calls.
+# description: Refuse a command with a line that is only a `cd`. Where the shell persists across tool calls (Claude Code) a bare cd re-roots every later command and every hook that judges the working directory, while instruction files and hook paths stay with the launch directory; a cd into a worktree inside the repository, Claude Code's default `.claude/worktrees/<name>/`, also loads that tree's instruction files a second time as files there are read. Names the scoped form, `(cd /path && command)`, and, where the harness has one (Claude Code's EnterWorktree), its worktree tool for a move.
+# safety: Reads the command text only. On a harness that runs each command in a fresh shell (Codex, the Pi carrier) a bare cd changes nothing and the refusal costs one rewrite; the scoped form is right on every harness.
 # ---
 
 set -euo pipefail
@@ -42,8 +42,8 @@ fi
 # Simple heuristic: if the command is just "cd /path" with nothing else meaningful
 STRIPPED=$(echo "$COMMAND" | sed 's/^[[:space:]]*//')
 if echo "$STRIPPED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
-  echo "Bare 'cd' changes working directory permanently across tool calls." >&2
-  echo "Use a subshell instead: (cd /path && command)" >&2
+  echo "block-bare-cd: refusing a bare 'cd'. Where the shell persists across tool calls it re-roots every later command and every hook judging the working directory, while instruction files and hook paths stay with the launch directory." >&2
+  echo "  Scope the move instead: (cd /path && command). To work in a worktree, enter it with the harness's worktree tool where it has one (Claude Code's EnterWorktree) rather than cd." >&2
   exit 2
 fi
 

--- a/.codex/hooks/block-repo-copy.sh
+++ b/.codex/hooks/block-repo-copy.sh
@@ -91,11 +91,9 @@ fi
 # expression carries no order, so the set below is the set named above.
 ENDERS='&;'$'\n'
 CROSSABLE="[^${ENDERS}]"
-# BLANK and SPACE_ANY are the class names as they are spelled INSIDE a bracket
-# expression, so the same two definitions serve a class of their own and a
-# member of a larger one.
+# BLANK is the class name as it is spelled INSIDE a bracket expression, so the
+# one definition serves a class of its own and a member of a larger one.
 BLANK='[:blank:]'
-SPACE_ANY='[:space:]'
 GAP="[${BLANK}]"
 # The backslash is doubled twice over: once for the double quotes, once for the
 # regex, so this alternative is a literal backslash or a literal pipe followed

--- a/.pi/kendex/hooks/block-bare-cd.sh
+++ b/.pi/kendex/hooks/block-bare-cd.sh
@@ -43,7 +43,7 @@ fi
 STRIPPED=$(echo "$COMMAND" | sed 's/^[[:space:]]*//')
 if echo "$STRIPPED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
   echo "block-bare-cd: refusing a bare 'cd'. Where the shell persists across tool calls it re-roots every later command and every hook judging the working directory, while instruction files and hook paths stay with the launch directory." >&2
-  echo "  Scope the move instead: (cd /path && command). To work in a worktree, enter it with the harness's worktree tool where it has one (Claude Code's EnterWorktree) rather than cd." >&2
+  echo "  Use a subshell instead: (cd /path && command). To work in a worktree, enter it with the harness's worktree tool where it has one (Claude Code's EnterWorktree) rather than cd." >&2
   exit 2
 fi
 

--- a/.pi/kendex/hooks/block-bare-cd.sh
+++ b/.pi/kendex/hooks/block-bare-cd.sh
@@ -3,8 +3,8 @@
 # name: block-bare-cd
 # event: PreToolUse
 # matcher: Bash
-# description: Block bare cd commands that permanently change the working directory. Suggests using subshells instead.
-# safety: Prevents accidental working directory pollution across tool calls.
+# description: Refuse a command with a line that is only a `cd`. Where the shell persists across tool calls (Claude Code) a bare cd re-roots every later command and every hook that judges the working directory, while instruction files and hook paths stay with the launch directory; a cd into a worktree inside the repository, Claude Code's default `.claude/worktrees/<name>/`, also loads that tree's instruction files a second time as files there are read. Names the scoped form, `(cd /path && command)`, and, where the harness has one (Claude Code's EnterWorktree), its worktree tool for a move.
+# safety: Reads the command text only. On a harness that runs each command in a fresh shell (Codex, the Pi carrier) a bare cd changes nothing and the refusal costs one rewrite; the scoped form is right on every harness.
 # ---
 
 set -euo pipefail
@@ -42,8 +42,8 @@ fi
 # Simple heuristic: if the command is just "cd /path" with nothing else meaningful
 STRIPPED=$(echo "$COMMAND" | sed 's/^[[:space:]]*//')
 if echo "$STRIPPED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
-  echo "Bare 'cd' changes working directory permanently across tool calls." >&2
-  echo "Use a subshell instead: (cd /path && command)" >&2
+  echo "block-bare-cd: refusing a bare 'cd'. Where the shell persists across tool calls it re-roots every later command and every hook judging the working directory, while instruction files and hook paths stay with the launch directory." >&2
+  echo "  Scope the move instead: (cd /path && command). To work in a worktree, enter it with the harness's worktree tool where it has one (Claude Code's EnterWorktree) rather than cd." >&2
   exit 2
 fi
 

--- a/.pi/kendex/hooks/block-repo-copy.sh
+++ b/.pi/kendex/hooks/block-repo-copy.sh
@@ -91,11 +91,9 @@ fi
 # expression carries no order, so the set below is the set named above.
 ENDERS='&;'$'\n'
 CROSSABLE="[^${ENDERS}]"
-# BLANK and SPACE_ANY are the class names as they are spelled INSIDE a bracket
-# expression, so the same two definitions serve a class of their own and a
-# member of a larger one.
+# BLANK is the class name as it is spelled INSIDE a bracket expression, so the
+# one definition serves a class of its own and a member of a larger one.
 BLANK='[:blank:]'
-SPACE_ANY='[:space:]'
 GAP="[${BLANK}]"
 # The backslash is doubled twice over: once for the double quotes, once for the
 # regex, so this alternative is a literal backslash or a literal pipe followed

--- a/hooks/block-bare-cd.sh
+++ b/hooks/block-bare-cd.sh
@@ -43,7 +43,7 @@ fi
 STRIPPED=$(echo "$COMMAND" | sed 's/^[[:space:]]*//')
 if echo "$STRIPPED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
   echo "block-bare-cd: refusing a bare 'cd'. Where the shell persists across tool calls it re-roots every later command and every hook judging the working directory, while instruction files and hook paths stay with the launch directory." >&2
-  echo "  Scope the move instead: (cd /path && command). To work in a worktree, enter it with the harness's worktree tool where it has one (Claude Code's EnterWorktree) rather than cd." >&2
+  echo "  Use a subshell instead: (cd /path && command). To work in a worktree, enter it with the harness's worktree tool where it has one (Claude Code's EnterWorktree) rather than cd." >&2
   exit 2
 fi
 

--- a/hooks/block-bare-cd.sh
+++ b/hooks/block-bare-cd.sh
@@ -3,8 +3,8 @@
 # name: block-bare-cd
 # event: PreToolUse
 # matcher: Bash
-# description: Block bare cd commands that permanently change the working directory. Suggests using subshells instead.
-# safety: Prevents accidental working directory pollution across tool calls.
+# description: Refuse a command with a line that is only a `cd`. Where the shell persists across tool calls (Claude Code) a bare cd re-roots every later command and every hook that judges the working directory, while instruction files and hook paths stay with the launch directory; a cd into a worktree inside the repository, Claude Code's default `.claude/worktrees/<name>/`, also loads that tree's instruction files a second time as files there are read. Names the scoped form, `(cd /path && command)`, and, where the harness has one (Claude Code's EnterWorktree), its worktree tool for a move.
+# safety: Reads the command text only. On a harness that runs each command in a fresh shell (Codex, the Pi carrier) a bare cd changes nothing and the refusal costs one rewrite; the scoped form is right on every harness.
 # ---
 
 set -euo pipefail
@@ -42,8 +42,8 @@ fi
 # Simple heuristic: if the command is just "cd /path" with nothing else meaningful
 STRIPPED=$(echo "$COMMAND" | sed 's/^[[:space:]]*//')
 if echo "$STRIPPED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
-  echo "Bare 'cd' changes working directory permanently across tool calls." >&2
-  echo "Use a subshell instead: (cd /path && command)" >&2
+  echo "block-bare-cd: refusing a bare 'cd'. Where the shell persists across tool calls it re-roots every later command and every hook judging the working directory, while instruction files and hook paths stay with the launch directory." >&2
+  echo "  Scope the move instead: (cd /path && command). To work in a worktree, enter it with the harness's worktree tool where it has one (Claude Code's EnterWorktree) rather than cd." >&2
   exit 2
 fi
 

--- a/hooks/block-repo-copy.sh
+++ b/hooks/block-repo-copy.sh
@@ -91,11 +91,9 @@ fi
 # expression carries no order, so the set below is the set named above.
 ENDERS='&;'$'\n'
 CROSSABLE="[^${ENDERS}]"
-# BLANK and SPACE_ANY are the class names as they are spelled INSIDE a bracket
-# expression, so the same two definitions serve a class of their own and a
-# member of a larger one.
+# BLANK is the class name as it is spelled INSIDE a bracket expression, so the
+# one definition serves a class of its own and a member of a larger one.
 BLANK='[:blank:]'
-SPACE_ANY='[:space:]'
 GAP="[${BLANK}]"
 # The backslash is doubled twice over: once for the double quotes, once for the
 # regex, so this alternative is a literal backslash or a literal pipe followed

--- a/hooks/tests/block-bare-cd.test.sh
+++ b/hooks/tests/block-bare-cd.test.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 # Tests for the block-bare-cd hook.
 #
-# The hook refuses a top-level `cd` that would move the working directory for
-# every later tool call, and passes anything that scopes the move — a
-# subshell, an &&-chain doing the real work — or that only mentions cd. The
-# argument is optional on both sides of the check: a bare `cd` goes to $HOME,
-# which is the same permanent move as `cd /tmp`.
+# The hook refuses a line that is only a `cd`, the move that re-roots every
+# later tool call where the shell persists (Claude Code) and changes nothing
+# where each command runs fresh (Codex, the Pi carrier), and passes anything
+# that scopes the move — a subshell, an &&-chain doing the real work — or that
+# only mentions cd. The argument is optional on both sides of the check: a
+# bare `cd` goes to $HOME, which is the same move as `cd /tmp`.
 #
 # The command reaches the hook JSON-encoded, and jq is the only thing that
 # reads it: a quoted operand carries \" escapes, and the parser this replaced

--- a/pi-extensions/pi-hooks/package.json
+++ b/pi-extensions/pi-hooks/package.json
@@ -35,7 +35,7 @@
         {
           "key": "blockBareCd",
           "label": "Block bare cd",
-          "description": "Run the rendered hooks/block-bare-cd.sh on every bash tool call. It blocks a command consisting of a bare `cd /path` or a bare `cd` (no subshell, no `&&` chain), which permanently changes the agent's working directory across tool calls and leaks state between unrelated tools. Use `(cd /path && command)` instead.",
+          "description": "Run the rendered hooks/block-bare-cd.sh on every bash tool call. It refuses a command with a line that is only a bare `cd /path` or `cd` (no subshell, no `&&` chain). Pi runs each command in a fresh shell, so the cd changes nothing here; the refusal keeps the one form that is right on every harness, `(cd /path && command)`.",
           "type": "boolean",
           "default": true,
           "category": "Bash",


### PR DESCRIPTION
block-bare-cd's description said a bare `cd` changes the working directory permanently on every harness. The audit's evidence: on Claude Code the Bash tool's shell persists, so a bare cd re-roots every later command and every hook that judges the working directory while `CLAUDE_PROJECT_DIR`, hook paths and instruction files stay with the launch directory, and a cd into a worktree inside the repository (Claude Code's default `.claude/worktrees/<name>/`) also loads that tree's instruction files a second time as files there are read; on Codex and the Pi carrier each command runs in a fresh shell and a bare cd changes nothing. The description, safety line and refusal now state that case and name the harness's worktree tool for a move. The suite's assertions on the refusal text still hold.

block-repo-copy defined `SPACE_ANY` and read it nowhere; it is gone with the comment that named it.

Tracked renders under `.claude/hooks`, `.codex/hooks` and `.pi/kendex/hooks` carry the same bytes. Both suites pass.

Found by the hooks audit, KEN-1232.

https://claude.ai/code/session_01G8mGZKa8sxjow9QaQuMAWp
