### PR TITLE
fix(hooks): task-completed-check budget covers a cold clippy build

### DIFF
--- a/.claude/hooks/task-completed-check.sh
+++ b/.claude/hooks/task-completed-check.sh
@@ -3,9 +3,9 @@
 # name: task-completed-check
 # event: TaskCompleted
 # matcher:
-# description: Run workspace lint checks before marking a task complete. Currently supports Rust (cargo clippy).
-# safety: Prevents marking tasks done when source files have lint violations.
-# timeout: 120
+# description: Before a task is marked complete, runs `cargo clippy --workspace --all-targets -- -D warnings` when a Rust file changed in the working tree, the index or as an untracked file, and refuses the completion naming the first diagnostics. Rust only.
+# safety: Refuses on any clippy failure and on a git that cannot list the changed set. Claude Code does not block on a hook that outruns its budget, so the budget is that harness's own default for a command hook; a cold build of a large workspace that outruns it completes the task unchecked, and a warm target directory is what keeps this gate closed.
+# timeout: 600
 # harnesses: [claude-code]
 # ---
 

--- a/.claude/hooks/task-completed-check.sh
+++ b/.claude/hooks/task-completed-check.sh
@@ -3,7 +3,7 @@
 # name: task-completed-check
 # event: TaskCompleted
 # matcher:
-# description: Before a task is marked complete, runs `cargo clippy --workspace --all-targets -- -D warnings` when a Rust file changed in the working tree, the index or as an untracked file, and refuses the completion naming the first diagnostics. Rust only.
+# description: Before a task is marked complete, runs `cargo clippy --workspace --all-targets -- -D warnings` against the repository's Cargo.toml, or the nearest one above a changed file when the root has none, whenever a Rust file changed in the working tree, the index or as an untracked file, and refuses the completion naming the first error lines, or the output tail when there are none. Rust only.
 # safety: Refuses on any clippy failure and on a git that cannot list the changed set. Claude Code does not block on a hook that outruns its budget, so the budget is that harness's own default for a command hook; a cold build of a large workspace that outruns it completes the task unchecked, and a warm target directory is what keeps this gate closed.
 # timeout: 600
 # harnesses: [claude-code]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -66,7 +66,7 @@
           {
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/task-completed-check.sh\"",
-            "timeout": 120
+            "timeout": 600
           }
         ]
       }

--- a/hooks/task-completed-check.sh
+++ b/hooks/task-completed-check.sh
@@ -3,9 +3,9 @@
 # name: task-completed-check
 # event: TaskCompleted
 # matcher:
-# description: Run workspace lint checks before marking a task complete. Currently supports Rust (cargo clippy).
-# safety: Prevents marking tasks done when source files have lint violations.
-# timeout: 120
+# description: Before a task is marked complete, runs `cargo clippy --workspace --all-targets -- -D warnings` when a Rust file changed in the working tree, the index or as an untracked file, and refuses the completion naming the first diagnostics. Rust only.
+# safety: Refuses on any clippy failure and on a git that cannot list the changed set. Claude Code does not block on a hook that outruns its budget, so the budget is that harness's own default for a command hook; a cold build of a large workspace that outruns it completes the task unchecked, and a warm target directory is what keeps this gate closed.
+# timeout: 600
 # harnesses: [claude-code]
 # ---
 

--- a/hooks/task-completed-check.sh
+++ b/hooks/task-completed-check.sh
@@ -3,7 +3,7 @@
 # name: task-completed-check
 # event: TaskCompleted
 # matcher:
-# description: Before a task is marked complete, runs `cargo clippy --workspace --all-targets -- -D warnings` when a Rust file changed in the working tree, the index or as an untracked file, and refuses the completion naming the first diagnostics. Rust only.
+# description: Before a task is marked complete, runs `cargo clippy --workspace --all-targets -- -D warnings` against the repository's Cargo.toml, or the nearest one above a changed file when the root has none, whenever a Rust file changed in the working tree, the index or as an untracked file, and refuses the completion naming the first error lines, or the output tail when there are none. Rust only.
 # safety: Refuses on any clippy failure and on a git that cannot list the changed set. Claude Code does not block on a hook that outruns its budget, so the budget is that harness's own default for a command hook; a cold build of a large workspace that outruns it completes the task unchecked, and a warm target directory is what keeps this gate closed.
 # timeout: 600
 # harnesses: [claude-code]


### PR DESCRIPTION
Claude Code's hooks reference states that a timed-out command hook does not block: the call continues through the normal flow. task-completed-check declared a 120 second budget around `cargo clippy --workspace --all-targets`, so on a cold target directory the run outran the budget and the task completed unchecked.

The budget is now 600 seconds, Claude Code's own default for a command hook, and the frontmatter states what the hook runs, when, and the residue: a cold build of a large workspace that still outruns it is not gated, and a warm target directory is what keeps the gate closed. No logic changed; the suite passes; the tracked render under `.claude/hooks` carries the same bytes.

Found by the hooks audit, KEN-1232.

https://claude.ai/code/session_01G8mGZKa8sxjow9QaQuMAWp
