### PR TITLE
fix(KEN-1233): Pi carries the agent effort and a model tier is a pin

### DIFF
--- a/.pi/agents/generalist.md
+++ b/.pi/agents/generalist.md
@@ -4,6 +4,7 @@ description: "General-purpose agent for documentation, cleanup, stale references
 tags: docs, refactoring
 deny-tools: subagent, get_subagent_result, steer_subagent, stop_subagent, question
 allowed-subagents: scout
+effort: xhigh
 color: green
 pane: true
 ---

--- a/.pi/agents/iced.md
+++ b/.pi/agents/iced.md
@@ -4,6 +4,7 @@ description: "Iced UI specialist. Use for Iced widgets, Canvas/Shader rendering,
 tags: ui
 deny-tools: subagent, get_subagent_result, steer_subagent, stop_subagent, question
 allowed-subagents: scout
+effort: xhigh
 color: cyan
 pane: true
 ---

--- a/.pi/agents/planner.md
+++ b/.pi/agents/planner.md
@@ -3,6 +3,7 @@ name: planner
 description: "Planning specialist that explores requirements and code context, weighs architecture trade-offs, and produces ordered implementation plans or plan files. May write planning artifacts; does not edit production code."
 tags: planning, research
 deny-tools: subagent, get_subagent_result, steer_subagent, stop_subagent, delegate_subagent
+effort: xhigh
 color: blue
 pane: true
 ---

--- a/.pi/agents/researcher.md
+++ b/.pi/agents/researcher.md
@@ -3,6 +3,7 @@ name: researcher
 description: "Exa-powered research specialist for producing evidence-backed findings reports from project research prompts. Use for research issues, technology investigations, vendor/library comparisons, architectural option analysis, and current-state web research."
 tags: research
 deny-tools: subagent, get_subagent_result, steer_subagent, stop_subagent, delegate_subagent, question
+effort: xhigh
 color: purple
 ---
 

--- a/.pi/agents/reviewer-arch.md
+++ b/.pi/agents/reviewer-arch.md
@@ -3,6 +3,7 @@ name: reviewer-arch
 description: "Architecture reviewer for design reviews, module boundary validation, spec/proposal review, and technical debt assessment."
 tags: review
 deny-tools: subagent, get_subagent_result, steer_subagent, stop_subagent, delegate_subagent, question, tasks_write
+effort: xhigh
 color: yellow
 ---
 

--- a/.pi/agents/reviewer-correctness.md
+++ b/.pi/agents/reviewer-correctness.md
@@ -3,6 +3,7 @@ name: reviewer-correctness
 description: "Broad correctness and regression reviewer for behavior breakage, boundary/edge-case predicates, API/CLI/devex regressions, feature-gate leaks, migrations, state semantics, and cross-module side effects."
 tags: review
 deny-tools: subagent, get_subagent_result, steer_subagent, stop_subagent, delegate_subagent, question, tasks_write
+effort: xhigh
 color: red
 ---
 

--- a/.pi/agents/reviewer-doc.md
+++ b/.pi/agents/reviewer-doc.md
@@ -3,6 +3,7 @@ name: reviewer-doc
 description: "Documentation accuracy reviewer. Verifies changed doc claims against implementation, re-derives transcribed values, checks citations resolve, audits drift."
 tags: review, docs
 deny-tools: subagent, get_subagent_result, steer_subagent, stop_subagent, delegate_subagent, question, tasks_write
+effort: xhigh
 color: yellow
 ---
 

--- a/.pi/agents/reviewer-error.md
+++ b/.pi/agents/reviewer-error.md
@@ -3,6 +3,7 @@ name: reviewer-error
 description: "Silent failure and error handling reviewer. Detects fail-open paths, swallowed errors, wrong-cause diagnostics, and inadequate error propagation."
 tags: review, debugging
 deny-tools: subagent, get_subagent_result, steer_subagent, stop_subagent, delegate_subagent, question, tasks_write
+effort: xhigh
 color: orange
 ---
 

--- a/.pi/agents/reviewer-perf.md
+++ b/.pi/agents/reviewer-perf.md
@@ -3,6 +3,7 @@ name: reviewer-perf
 description: "Performance validation specialist. Latency validation, benchmark execution, percentile analysis, hot-path cost review, regression detection."
 tags: review, performance
 deny-tools: subagent, get_subagent_result, steer_subagent, stop_subagent, delegate_subagent, question, tasks_write
+effort: xhigh
 color: red
 ---
 

--- a/.pi/agents/reviewer-quality.md
+++ b/.pi/agents/reviewer-quality.md
@@ -3,6 +3,7 @@ name: reviewer-quality
 description: "Code quality reviewer for maintainability, simplification, abstraction value, type boundaries, helper reuse, decomposition, and god objects."
 tags: review
 deny-tools: subagent, get_subagent_result, steer_subagent, stop_subagent, delegate_subagent, question, tasks_write
+effort: xhigh
 color: purple
 ---
 

--- a/.pi/agents/reviewer-safety.md
+++ b/.pi/agents/reviewer-safety.md
@@ -3,6 +3,7 @@ name: reviewer-safety
 description: "Memory, thread, and process safety auditor. Unsafe code, data races, lock-free correctness, and file/process races (TOCTOU, PID reuse, shared mutable state)."
 tags: review, security
 deny-tools: subagent, get_subagent_result, steer_subagent, stop_subagent, delegate_subagent, question, tasks_write
+effort: xhigh
 color: red
 ---
 

--- a/.pi/agents/reviewer-security.md
+++ b/.pi/agents/reviewer-security.md
@@ -3,6 +3,7 @@ name: reviewer-security
 description: "Application security reviewer. Auth logic, input handling, trust/ownership gating, path containment, and secret exposure."
 tags: review, security
 deny-tools: subagent, get_subagent_result, steer_subagent, stop_subagent, delegate_subagent, question, tasks_write
+effort: xhigh
 color: red
 ---
 

--- a/.pi/agents/reviewer-test.md
+++ b/.pi/agents/reviewer-test.md
@@ -3,6 +3,7 @@ name: reviewer-test
 description: "Test coverage and quality reviewer. Verifies coverage, detects vacuous tests and missing must-fail controls, audits assertion tightness and test wiring."
 tags: review, testing
 deny-tools: subagent, get_subagent_result, steer_subagent, stop_subagent, delegate_subagent, question, tasks_write
+effort: xhigh
 color: blue
 ---
 

--- a/.pi/agents/rust.md
+++ b/.pi/agents/rust.md
@@ -4,6 +4,7 @@ description: "Rust engineer for performance-critical systems. Use for zero-alloc
 tags: performance
 deny-tools: subagent, get_subagent_result, steer_subagent, stop_subagent, question
 allowed-subagents: scout
+effort: xhigh
 color: orange
 pane: true
 ---

--- a/.pi/agents/scout.md
+++ b/.pi/agents/scout.md
@@ -4,6 +4,7 @@ description: "Fast reconnaissance agent for exploring codebases, finding files b
 tags: research
 deny-tools: subagent, get_subagent_result, steer_subagent, stop_subagent, delegate_subagent, question
 model: openai-codex/gpt-5.5:medium
+effort: medium
 color: cyan
 ---
 

--- a/.pi/agents/tpm.md
+++ b/.pi/agents/tpm.md
@@ -3,6 +3,7 @@ name: tpm
 description: "Technical Program Manager for analyzing roadmaps, project lifecycle, and progress. Returns recommendations only. Does not modify project management tools."
 tags: planning
 deny-tools: subagent, get_subagent_result, steer_subagent, stop_subagent, delegate_subagent, question
+effort: high
 color: blue
 ---
 

--- a/changelog.d/changed/KEN-1233-model-tiers.md
+++ b/changelog.d/changed/KEN-1233-model-tiers.md
@@ -1,0 +1,1 @@
+- On Claude Code a model tier is a pin: `opus` renders as `opus`, not `inherit`. Say `inherit` to follow the session model.

--- a/changelog.d/fixed/KEN-1233-pi-effort.md
+++ b/changelog.d/fixed/KEN-1233-pi-effort.md
@@ -1,0 +1,1 @@
+- A Pi agent whose model inherits the session now renders its effort as an `effort` key, which `pi-agents-tmux` passes to the child as `--thinking`; before, the effort was dropped with the model id.

--- a/crates/core/src/harness/models.rs
+++ b/crates/core/src/harness/models.rs
@@ -3,6 +3,11 @@
 //! vendor ids pass through untouched. Renderers own how "inherit" is
 //! spelled on their surface (a literal, or omitting the field) — this table
 //! only decides *what* the alias means there.
+//!
+//! A tier is a pin, never a synonym for inherit: an agent that wants the
+//! session's model says `inherit`. Only Pi reads the heavy tiers as
+//! inherit, because Pi has no alias for a Claude tier and a pinned id
+//! there would name one provider's model for every session.
 
 use crate::model::HarnessId;
 
@@ -38,10 +43,8 @@ pub fn resolve_model(harness: HarnessId, model: &str) -> ResolvedModel {
     let tier = matches!(bare.as_str(), "fable" | "opus" | "sonnet" | "haiku");
     if tier {
         return match (harness, bare.as_str()) {
-            // Heavy tiers inherit the session model rather than pinning a
-            // possibly-smaller default; light tiers pin their alias.
-            (HarnessId::Claude, "fable" | "opus") => resolved(None),
-            (HarnessId::Claude, other) => resolved(Some(other)),
+            // Claude Code takes every tier alias as written.
+            (HarnessId::Claude, tier) => resolved(Some(tier)),
             (HarnessId::Codex, _) => resolved(Some("gpt-6-astra")),
             (HarnessId::Opencode, _) => resolved(Some("openai/gpt-6-astra")),
             (HarnessId::Pi, "fable" | "opus") => resolved(None),
@@ -95,12 +98,12 @@ mod tests {
 
     #[test]
     fn tiers_stay_tiers_and_explicit_ids_pass_through() {
-        assert_eq!(resolve_model(HarnessId::Claude, "opus").id, None);
-        assert_eq!(resolve_model(HarnessId::Claude, "fable").id, None);
-        assert_eq!(
-            resolve_model(HarnessId::Claude, "sonnet").id.as_deref(),
-            Some("sonnet")
-        );
+        for tier in ["fable", "opus", "sonnet", "haiku"] {
+            assert_eq!(
+                resolve_model(HarnessId::Claude, tier).id.as_deref(),
+                Some(tier)
+            );
+        }
         assert_eq!(
             resolve_model(HarnessId::Codex, "haiku").id.as_deref(),
             Some("gpt-6-astra")

--- a/crates/core/src/render/agent/claude.rs
+++ b/crates/core/src/render/agent/claude.rs
@@ -182,11 +182,15 @@ mod tests {
     }
 
     #[test]
-    fn engineer_defaults_pane_true_background_false_and_opus_inherits() {
+    fn engineer_defaults_pane_true_background_false_and_opus_pins() {
         let source = engineer();
         let scope = Scope::Global;
         let text = generate(&effective(&source, &scope, vec![])).text;
-        assert!(text.contains("model: inherit"));
+        assert!(text.contains("model: opus"));
+        let mut inheriting = engineer();
+        inheriting.model = "inherit".into();
+        let text_inheriting = generate(&effective(&inheriting, &scope, vec![])).text;
+        assert!(text_inheriting.contains("model: inherit"));
         assert!(text.contains("background: false"));
         assert!(text.contains("disallowedTools: Agent, AskUserQuestion"));
         assert!(text.contains("skills: dev, rust-perf"));

--- a/crates/core/src/render/agent/mod.rs
+++ b/crates/core/src/render/agent/mod.rs
@@ -308,6 +308,57 @@ mod tests {
         assert!(solo.contains(SHARED_START) && !solo.contains("rust rule"));
     }
 
+    /// One control per harness: a custom effort reaches the rendered file
+    /// under that harness's own key, and a harness with no per-agent effort
+    /// carries nothing rather than a key its loader will not read.
+    #[test]
+    fn a_custom_effort_round_trips_under_each_harness_key() {
+        use crate::model::{HarnessId, Scope};
+        let source = parse_source_agent(
+            "---\nname: rust\ndescription: Rust engineer\nmodel: inherit\nrole: engineer\neffort: high\n---\nBody.\n",
+        )
+        .unwrap();
+        let scope = Scope::Global;
+        let overrides = FrontmatterOverrides {
+            effort: Some("low".into()),
+            ..FrontmatterOverrides::default()
+        };
+        let spelled = |harness: HarnessId| -> String {
+            let agent = EffectiveAgent {
+                source: &source,
+                harness,
+                scope: &scope,
+                skills: vec![],
+                permissions: EffectiveAgent::intent(&source, &overrides),
+                overrides: overrides.clone(),
+                launch_instructions: None,
+                additional_instructions: None,
+                custom_hooks: vec![],
+            };
+            generate(&agent).unwrap().text
+        };
+        let keyed = [
+            (HarnessId::Claude, "effort: low\n"),
+            (HarnessId::Codex, "model_reasoning_effort = \"low\"\n"),
+            (HarnessId::Opencode, "reasoningEffort: low\n"),
+            (HarnessId::Pi, "effort: low\n"),
+        ];
+        for (harness, line) in keyed {
+            let text = spelled(harness);
+            assert!(text.contains(line), "{}: {text}", harness.name());
+            let source_line = line.replace("low", "high");
+            assert!(!text.contains(&source_line), "{}: {text}", harness.name());
+        }
+        for harness in [HarnessId::Cursor, HarnessId::Gemini, HarnessId::Copilot] {
+            let text = spelled(harness);
+            assert!(
+                !text.to_lowercase().contains("effort"),
+                "{}: {text}",
+                harness.name()
+            );
+        }
+    }
+
     #[test]
     fn deny_tools_merge_while_other_fields_prefer_project() {
         let source = FrontmatterOverrides {

--- a/crates/core/src/render/agent/pi.rs
+++ b/crates/core/src/render/agent/pi.rs
@@ -35,12 +35,16 @@ pub fn generate(agent: &EffectiveAgent) -> Result<RenderedAgent, String> {
         ));
     }
     let mut warnings = Vec::new();
-    let (model, model_warning) = model(agent);
+    let effort = effort(agent);
+    let (model, model_warning) = model(agent, effort);
     warnings.extend(model_warning.map(|w| {
         crate::render::RenderWarning::with_fix(w, "use a provider/model id or a tier alias")
     }));
     if let Some(model) = model {
         out.push_str(&format!("model: {}\n", yaml_scalar(&model)));
+    }
+    if let Some(effort) = effort {
+        out.push_str(&format!("effort: {}\n", yaml_scalar(effort)));
     }
     if let Some(color) = o.color.as_deref().or(source.color.as_deref()) {
         out.push_str(&format!("color: {}\n", yaml_scalar(color)));
@@ -56,17 +60,24 @@ pub fn generate(agent: &EffectiveAgent) -> Result<RenderedAgent, String> {
     })
 }
 
-/// Heavy tiers omit `model` so the child inherits the parent session;
-/// everything else resolves through the shared alias table and carries the
-/// `:effort` suffix.
-fn model(agent: &EffectiveAgent) -> (Option<String>, Option<String>) {
-    let effort = agent
+/// The effort the child runs at, under either spelling of the override.
+/// It is written as its own `effort:` key — the key the subagent extension
+/// reads and turns into `--thinking` — because a suffix on the model id
+/// has nowhere to sit when the model inherits.
+fn effort<'b>(agent: &'b EffectiveAgent<'_>) -> Option<&'b str> {
+    agent
         .overrides
         .model_reasoning_effort
         .as_deref()
         .or(agent.overrides.effort.as_deref())
         .or(agent.source.effort.as_deref())
-        .filter(|effort| !is_none_value(effort));
+        .filter(|effort| !is_none_value(effort))
+}
+
+/// Heavy tiers omit `model` so the child inherits the parent session;
+/// everything else resolves through the shared alias table and also
+/// carries the `:effort` suffix Pi reads on a model id.
+fn model(agent: &EffectiveAgent, effort: Option<&str>) -> (Option<String>, Option<String>) {
     let model = agent
         .overrides
         .model
@@ -226,13 +237,17 @@ mod tests {
 
     #[test]
     fn engineer_keeps_scout_delegation_and_inherits_the_opus_model() {
-        let source = source("rust", "engineer", "opus");
+        let mut source = source("rust", "engineer", "opus");
+        source.effort = Some("high".into());
         let scope = Scope::Global;
         let text = generate(&effective(&source, &scope)).unwrap().text;
         assert!(text.contains("allowed-subagents: scout\n"));
         assert!(text.contains("pane: true\n"));
         assert!(text.contains("color: green\n"));
         assert!(!text.lines().any(|line| line.starts_with("model:")));
+        // An inherited model has no id to carry a suffix, so the effort
+        // stands on its own key or it reaches nothing.
+        assert!(text.contains("effort: high\n"));
         assert_eq!(
             deny_line(&text),
             "deny-tools: subagent, get_subagent_result, steer_subagent, stop_subagent, question"
@@ -246,6 +261,7 @@ mod tests {
         let scope = Scope::Global;
         let text = generate(&effective(&source, &scope)).unwrap().text;
         assert!(text.contains("model: openai-codex/gpt-6-astra:high\n"));
+        assert!(text.contains("effort: high\n"));
         assert!(!text.contains("allowed-subagents:"));
         assert!(!text.contains("pane: true"));
         assert_eq!(

--- a/docs/adapters/claude.md
+++ b/docs/adapters/claude.md
@@ -32,7 +32,7 @@ A project skill lives in the shared `.agents/skills/<name>` tree, and `.claude/s
 - Name rule `Any`; namespace separator `__`.
 - MCP transports: stdio, streamable HTTP, SSE.
 - Agent file: YAML frontmatter and a markdown body, `<name>.md`. Fields written: `name`, `description`, `model`, `effort`, `background`, `isolation`, `memory`, `tools` (allowlist, comma-joined), `disallowedTools` always, `color`, `skills`, and a nested `hooks:` block for per-agent custom hooks (`crates/core/src/render/agent/claude.rs`).
-- Model dialect: `fable` and `opus` resolve to the literal `inherit`; `sonnet` and `haiku` pin their own alias; explicit vendor ids pass through (`crates/core/src/harness/models.rs`).
+- Model dialect: every tier pins its own alias (`fable`, `opus`, `sonnet`, `haiku`); `inherit` is the literal `inherit`; explicit vendor ids pass through (`crates/core/src/harness/models.rs`). `effort` is written as given: `low`, `medium`, `high`, `xhigh` or `max`, and an absent key inherits the session's level.
 - Tool vocabulary: Claude's PascalCase names are the fleet's authoring vocabulary; bodies pass through unrewritten, and manifest tool names are case-normalized by `claude_tool_name` (`crates/core/src/render/vocab/mod.rs`).
 - Rendered agents are refused before the plan is shown when the frontmatter is missing or names another agent (`crates/core/src/render/validate/agent.rs`).
 

--- a/docs/adapters/codex.md
+++ b/docs/adapters/codex.md
@@ -31,7 +31,7 @@ The prompts directory is scanned because Codex still loads it, and never written
 - Name rule `Any`; namespace separator `__`.
 - MCP transports: stdio and streamable HTTP, never SSE.
 - Agent file: TOML, `<name>.toml`. Fields written: `name`, `nickname_candidates`, `description`, `model`, `model_reasoning_effort`, `sandbox_mode`, and `developer_instructions` as a triple-quoted string carrying the whole prompt (`crates/core/src/render/agent/codex.rs`).
-- Model dialect: every tier resolves to `gpt-6-astra`; an omitted key is Codex's spelling of inherit (`crates/core/src/harness/models.rs`).
+- Model dialect: every tier resolves to `gpt-6-astra`; an omitted key is Codex's spelling of inherit (`crates/core/src/harness/models.rs`). `model_reasoning_effort` is written as given (`minimal`, `low`, `medium`, `high`, `xhigh`); an absent key takes the model's own default.
 - Permissions: Codex has no tool allowlist. A read-only allowlist caps `sandbox_mode` at `read-only`, any other allowlist at `workspace-write`, and only an explicit Engineer role with no allowlist earns `danger-full-access`; an allowlist always warns that the list itself is not enforced.
 - Tool vocabulary: prose is rewritten to phrases, `Read` to "open the file", `Bash` to "run a shell command" (`crates/core/src/render/vocab/mod.rs`).
 

--- a/docs/adapters/pi.md
+++ b/docs/adapters/pi.md
@@ -29,8 +29,8 @@ Project markers: a `.pi/` or `.agents/` directory.
 
 - Name rule `Any`; namespace separator `__`.
 - MCP transports: none; Pi reads no MCP servers.
-- Agent file: YAML frontmatter and a markdown body, `<name>.md`. Fields written: `name`, `description`, `deny-tools`, `allowed-subagents`, `model`, `color`, `pane` (`crates/core/src/render/agent/pi.rs`). No frontmatter schema is enforced beyond the name rule.
-- Model dialect: `fable` and `opus` omit the key (inherit); other tiers resolve to `openai-codex/gpt-6-astra`; a bare id with no `/` passes through with a warning; an effort setting rides as a `:<effort>` suffix on the model id (`crates/core/src/harness/models.rs`).
+- Agent file: YAML frontmatter and a markdown body, `<name>.md`. Fields written: `name`, `description`, `deny-tools`, `allowed-subagents`, `model`, `effort`, `color`, `pane` (`crates/core/src/render/agent/pi.rs`). No frontmatter schema is enforced beyond the name rule.
+- Model dialect: `fable` and `opus` omit the key (inherit); other tiers resolve to `openai-codex/gpt-6-astra`; a bare id with no `/` passes through with a warning (`crates/core/src/harness/models.rs`). An effort setting is written as its own `effort` key (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`), which the `pi-agents-tmux` extension passes to the child as `--thinking`; a pinned model id also carries it as a `:<effort>` suffix. An absent key runs the child at Pi's `defaultThinkingLevel`.
 - Permissions: deny-only. `allowed-subagents` and `deny-tools` are resolved together: engineers delegate to `scout` by default and every other role is a leaf; `subagent`, `get_subagent_result`, `steer_subagent` and `stop_subagent` are always denied; `delegate_subagent` is denied unless delegation was declared; every agent but a `role: planner` denies `question`, and a `role: reviewer` agent also denies `tasks_write`. An `AllowOnly` intent is a hard refusal naming both fixes: an explicit `deny-tools` override for Pi, or dropping Pi from the agent's harnesses.
 
 ## Hooks

--- a/pi-extensions/pi-agents-tmux/CHANGELOG.md
+++ b/pi-extensions/pi-agents-tmux/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+- A child, one-shot or pane, runs at the agent's frontmatter `effort` level when its model id carries no `:effort` suffix: the runner and the pane launcher pass it as `--thinking`. Before, an agent that inherited the parent's model ran at Pi's default thinking level whatever its `effort` key said. A live pane picks the level up on its next launch.
 - The extension uses `PI_CODING_AGENT_DIR` only when root-anchored — a drive or UNC share on Windows, a leading `/` on POSIX. Anything else uses `~/.pi/agent`. The install helper is unchanged.
 
 ### 3.0.0

--- a/pi-extensions/pi-agents-tmux/README.md
+++ b/pi-extensions/pi-agents-tmux/README.md
@@ -43,6 +43,6 @@ Maintainer notes are in [DEVELOPMENT.md](DEVELOPMENT.md).
 
 ## Agent files
 
-An agent is a markdown file whose YAML frontmatter holds `name` and `description`, and optionally `model` (a Pi model id, with `:effort` suffix), `deny-tools`, `pane`, `color` and `allowed-subagents`. Everything after the frontmatter is the agent's system prompt. When the same name exists in several sources, project Pi wins over project Claude over user Pi over user Claude.
+An agent is a markdown file whose YAML frontmatter holds `name` and `description`, and optionally `model` (a Pi model id, with `:effort` suffix), `effort` (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`; passed to the child as `--thinking` when the model carries no suffix), `deny-tools`, `pane`, `color` and `allowed-subagents`. Everything after the frontmatter is the agent's system prompt. When the same name exists in several sources, project Pi wins over project Claude over user Pi over user Claude.
 
 kendex generates `allowed-subagents: scout` for engineer-role agents and denies `delegate_subagent` for every other role; override per agent under `[agent-frontmatter.pi]` in `kendex.toml`, where an explicit empty list turns delegation off.

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/agents.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/agents.ts
@@ -150,7 +150,8 @@ function loadAgentsFromDir(dir: string, source: "user" | "project", blockedSourc
 		}
 
 		const model = normalizeModel(frontmatter.model);
-		const effort = normalizeReasoningEffort(frontmatter["model-reasoning-effort"] ?? frontmatter.modelReasoningEffort ?? frontmatter.effort) ?? effortFromModelId(model);
+		// Suffix first, the order the launchers spawn with (`selectedEffortForAgent`).
+		const effort = effortFromModelId(model) ?? normalizeReasoningEffort(frontmatter["model-reasoning-effort"] ?? frontmatter.modelReasoningEffort ?? frontmatter.effort);
 
 		agents.push({
 			name,

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/pane.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/pane.ts
@@ -727,7 +727,10 @@ export async function writeLauncher(
 	const bridgeExtension = settingBoolean("forceSessionBridgeForPanes", true, cwd) ? resolveSessionBridgeExtension(cwd) : undefined;
 	if (bridgeExtension) args.push("-e", bridgeExtension);
 	if (model) args.push("--model", model);
-	if (thinkingLevel && thinkingLevel !== "off") args.push("--thinking", thinkingLevel);
+	// The same choice the one-shot runner makes: the parent's level, the model
+	// id's `:level` suffix, or the agent's own `effort` key, in that order.
+	const effort = selectedEffortForAgent(agent, model, thinkingLevel);
+	if (effort && effort !== "off") args.push("--thinking", effort);
 	const selectedTools = selectedToolsForAgent(agent, cwd, ["complete_subagent"], activeTools);
 	if (selectedTools && selectedTools.length > 0) args.push("--tools", selectedTools.join(","));
 

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/runner.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/runner.ts
@@ -599,7 +599,10 @@ async function runSingleAgentAttempt(
 ): Promise<SingleResult> {
 	const args: string[] = ["--mode", "json", "-p", "--name", agent.name, "--session", session.path];
 	if (selectedModel) args.push("--model", selectedModel);
-	if (selectedThinking && selectedThinking !== "off") args.push("--thinking", selectedThinking);
+	// The effort is the parent's level, the model id's `:level` suffix, or the
+	// agent's own `effort` key, in that order; an inherited model has no suffix
+	// to carry the key, so it reaches the child as `--thinking` or not at all.
+	if (selectedEffort && selectedEffort !== "off") args.push("--thinking", selectedEffort);
 	args.push("--exclude-tools", BG_EXCLUDED_TOOLS.join(","));
 	const inheritedActiveTools = pi.getActiveTools?.() ?? [];
 	const selectedTools = selectedToolsForAgent(agent, defaultCwd, [], activeToolsForBgAgent(inheritedActiveTools));

--- a/pi-extensions/pi-agents-tmux/extensions/subagent/settings.ts
+++ b/pi-extensions/pi-agents-tmux/extensions/subagent/settings.ts
@@ -188,9 +188,9 @@ export function subagentThinkingSource(cwd?: string): "frontmatter" | "parent" {
 	return settingString("subagentThinkingSource", "frontmatter", cwd) === "parent" ? "parent" : "frontmatter";
 }
 
-// When source is "frontmatter" the agent's model `:effort` suffix governs the
-// child's thinking level, so we omit `--thinking` and let pi-core read the
-// suffix. Passing `--thinking` would override the suffix unconditionally.
+// When source is "frontmatter" the parent's level is not consulted: the
+// agent's model `:effort` suffix or its `effort` key governs the child's
+// thinking level (`selectedEffortForAgent`).
 export function selectedThinkingLevelForAgent(parentThinkingLevel: string | undefined, cwd?: string): string | undefined {
 	return subagentThinkingSource(cwd) === "parent" ? parentThinkingLevel : undefined;
 }

--- a/pi-extensions/pi-agents-tmux/tests/pi-invocation.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/pi-invocation.test.ts
@@ -337,6 +337,63 @@ function promptTempDirs(): string[] {
 	return readdirSync(tmpdir()).filter((name) => name.startsWith("pi-subagent-"));
 }
 
+function captureSpawnedArgs(): string[][] {
+	const calls: string[][] = [];
+	setSingleAgentSpawnForTests(((command: string, args: string[]) => {
+		void command;
+		calls.push(args);
+		const proc = new EventEmitter() as any;
+		proc.stdout = new EventEmitter();
+		proc.stderr = new EventEmitter();
+		proc.killed = false;
+		proc.kill = () => { proc.killed = true; return true; };
+		queueMicrotask(() => proc.emit("close", 0, null));
+		return proc;
+	}) as any);
+	return calls;
+}
+
+function thinkingFlag(args: string[]): string | undefined {
+	const at = args.indexOf("--thinking");
+	return at < 0 ? undefined : args[at + 1];
+}
+
+describe("bg one-shot runner effort wiring (KEN-1233)", () => {
+	const noPi = { getActiveTools: () => [], events: { emit: () => undefined } } as any;
+	const previousDepth = process.env[PI_SUBAGENT_DEPTH_ENV];
+
+	async function spawnedArgs(config: AgentConfig, parentModel: string | undefined): Promise<string[]> {
+		const calls = captureSpawnedArgs();
+		try {
+			delete process.env[PI_SUBAGENT_DEPTH_ENV];
+			const root = tempDir("pi-agents-effort-");
+			await runSingleAgent(root, root, [config], config.name, "recon", undefined, parentModel, undefined, undefined, noPi, undefined, undefined, makeDetails);
+			expect(calls).toHaveLength(1);
+			return calls[0]!;
+		} finally {
+			setSingleAgentSpawnForTests();
+			if (previousDepth === undefined) delete process.env[PI_SUBAGENT_DEPTH_ENV];
+			else process.env[PI_SUBAGENT_DEPTH_ENV] = previousDepth;
+		}
+	}
+
+	test("an inherited model runs at the frontmatter effort", async () => {
+		const args = await spawnedArgs({ ...agent("scout"), effort: "high" }, "anthropic/claude-opus-5");
+		expect(args).toContain("anthropic/claude-opus-5");
+		expect(thinkingFlag(args)).toBe("high");
+	});
+
+	test("a model suffix wins over the effort key", async () => {
+		const args = await spawnedArgs({ ...agent("scout"), model: "openai-codex/gpt-6-astra:low", effort: "high" }, undefined);
+		expect(thinkingFlag(args)).toBe("low");
+	});
+
+	test("no effort anywhere passes no --thinking", async () => {
+		const args = await spawnedArgs(agent("scout"), "anthropic/claude-opus-5");
+		expect(thinkingFlag(args)).toBeUndefined();
+	});
+});
+
 describe("bg one-shot runner depth guard wiring (kendex#192)", () => {
 	test("spawned child env carries the incremented PI_SUBAGENT_DEPTH", async () => {
 		const envs = captureSpawnedEnv();
@@ -402,6 +459,26 @@ describe("bg one-shot runner depth guard wiring (kendex#192)", () => {
 			if (previous === undefined) delete process.env[PI_SUBAGENT_DEPTH_ENV];
 			else process.env[PI_SUBAGENT_DEPTH_ENV] = previous;
 		}
+	});
+});
+
+describe("persistent pane launcher effort wiring (KEN-1233)", () => {
+	test("an inherited model runs at the frontmatter effort", async () => {
+		const root = tempDir("pi-agents-launcher-effort-");
+		const cwd = tempDir("pi-agents-launcher-effort-cwd-");
+		const paths = await writeLauncher(root, "parent-session-id", cwd, { ...agent("iced", "You are iced.", true), effort: "high" }, "anthropic/claude-opus-5", undefined);
+		const script = readFileSync(paths.launcherFile, "utf-8");
+		expect(script).toContain("'--thinking' 'high'");
+		expect(script).toContain("anthropic/claude-opus-5");
+	});
+
+	test("a model suffix wins over the effort key, and no effort passes no flag", async () => {
+		const root = tempDir("pi-agents-launcher-effort-");
+		const cwd = tempDir("pi-agents-launcher-effort-cwd-");
+		const suffixed = await writeLauncher(root, "parent-session-id", cwd, { ...agent("iced", "You are iced.", true), effort: "high" }, "openai-codex/gpt-6-astra:low", undefined);
+		expect(readFileSync(suffixed.launcherFile, "utf-8")).toContain("'--thinking' 'low'");
+		const bare = await writeLauncher(root, "parent-session-id", cwd, agent("iced", "You are iced.", true), "anthropic/claude-opus-5", undefined);
+		expect(readFileSync(bare.launcherFile, "utf-8")).not.toContain("'--thinking'");
 	});
 });
 


### PR DESCRIPTION
Part of the agent-effort block of the architecture-docs program (KEN-1233). Held for the overseer; admin-merged on MERGE.

## What changes

- A Pi agent's effort is written as its own `effort:` frontmatter key. Before, it rode only as a `:level` suffix on a pinned model id, so every agent that inherits its model (all catalog agents) lost it and the child ran at Pi's `defaultThinkingLevel`.
- `pi-agents-tmux` passes that key to the one-shot child as `--thinking` when the model id carries no suffix. Before, the runner read the key for display only.
- The model tier table stops reading `opus` and `fable` as `inherit` on Claude Code: a tier is a pin, and an agent that wants the session model says `inherit`.
- One control per harness proves a custom `effort` reaches the rendered file under that harness's own key, and that Cursor, Gemini and Copilot carry none.
- Adapter docs for Claude Code, Codex and Pi state each effort key's name, accepted values and absent-key behaviour.
- The `.pi/agents` renders in this repository are regenerated from the same tree with the debug CLI; the Claude and Codex renders do not change because `kendex-local.toml` pins their model and effort.

## Follow-up in this block

The catalog defaults, the published `kendex.toml` defaults and this repository's `kendex-local.toml` overrides change in the next PR, which also carries every render; the Pi extension needs an npm publish before consumers' children run at the rendered effort.

## Checks

- `cargo test -p kendex-core`: 1761 passed.
- `bun test` in `pi-extensions/pi-agents-tmux`: 387 passed; the new runner tests fail against the old runner line, and the pane launcher has the same control.
- Pre-commit chain clean (size-ratchet, preflight, growth-guards, tools/guard).

Tracking: KEN-1233

https://claude.ai/code/session_015fMFPgKCbddFEZ14yWEsw4
