### PR TITLE
docs(KEN-1235): test shape rules and the fix-round rule

### DIFF
--- a/.agents/skills/code-quality/SKILL.md
+++ b/.agents/skills/code-quality/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: code-quality
 description: "Load before writing or modifying code."
-summary: "Code-authoring standards for dev agents: correctness over convenience, no fail-open branches, comment rules, over-engineering limits, prove-your-guards."
+summary: "Code-authoring standards for dev agents: correctness over convenience, no fail-open branches, comment rules, over-engineering limits, prove-your-guards, test shape."
 license: MIT
 user-invocable: true
 dependencies:
@@ -52,6 +52,17 @@ A new or modified check, guard, assertion, or test ships with a must-fail contro
 - **A check narrower than the claim can only confirm it, never establish it.** Match the instrument's reach to the assertion's reach before running it, and prefer one that fails visibly on a planted counterexample. A grep over one directory supports no claim about the tree.
 - **Behaviour measured at an interactive prompt is not what scripts get.** `type <cmd>` names the shadow, which differs per shell. Resolve the command in the script's own shell and PATH, and name the shell and implementation it resolves to.
 - **A guard's failure message is an instrument.** It is what an author acts on. Unescaped backticks inside a double-quoted diagnostic execute their contents, so the intended text is altered or gone while the surrounding command still succeeds.
+
+## Tests
+
+- One control per behaviour surface, a public function, command, rule or contract, plus its inverse: the must-fail control § Prove Your Guards demands.
+- N planted defects means N asserted rows. A fixture that plants several defects under one verdict passes while any one of them is caught, and is never allowed.
+- Shaped input (positions, settings keys, tamper classes) is one table-driven case: one loop, one assertion per row, the row list visible in the file.
+- Assert the code, the enum or the exit status. Pin a human-readable message only inside a contract a consumer parses.
+- No test of the test harness: a pin on a manifest script string or a runner configuration proves nothing about behaviour.
+- A shared fixture is a neutral world (a seeded repository, a fake SDK). A fixture that carries a planted defect is private to its case.
+- One file per surface, beside the code, named for the surface.
+- A file past about 64 KB or about 60 cases holds more than one surface. Split it at a surface seam and move cases whole. The seam is the author's judgement; no check measures it.
 
 ## Language Discipline
 

--- a/.agents/skills/dev/SKILL.md
+++ b/.agents/skills/dev/SKILL.md
@@ -41,6 +41,10 @@ Review and QA-review belong to the reviewer skill: [`../reviewer/workflows/revie
   - the mechanical enablers of landing it ride without tracing to it: locks, changelog, baselines, dismissal renewals, that list and nothing else, never code that runs at runtime;
   - a defect the change introduces or arms is in scope by definition, unless Step 0 of [`../orch/references/finding-disposition.md`](../orch/references/finding-disposition.md) excludes it.
 - Every behavior change ships with a test that runs against the script or program enforcing it, at the smallest surface that fails. A workflow sentence ships no test. A test that pins prose, drives a second implementation, or stubs the function under test does not count as a test.
+- A review finding adds a case only when it names a behaviour no existing case reaches. Otherwise it tightens the existing case's assertion, and the item reasoning names that case.
+- A second fix round on the same function's guard is recurrence: redesign the rule under test so the class is unrepresentable, and fold the family of cases into one table.
+- A test whose premise died is deleted whole in the commit that kills the premise, and the PR body names the deletion.
+- Test shape (one control per surface, tables for shaped input, one file per surface) is [code-quality § Tests](../code-quality/SKILL.md#tests).
 - A refusal, a validator, a lock, a retry, or a test exists only for an input a real producer emits, this project's code or anything it calls or serves; name that producer beside it, or do not write it.
 - When a change deletes a call, apply [code-quality § Cleanup](../code-quality/SKILL.md#cleanup) to its callee. Its deletion maps to the call removal's Done-when item; no internal caller is not proof that a supported external API is unused.
 - A field, setting, or view member added by the change has a real producer and consumer. A named and documented external producer or consumer is valid when the change adds its in-repository counterpart; otherwise, add both sides in the change.

--- a/.agents/skills/dev/workflows/dev-fix.md
+++ b/.agents/skills/dev/workflows/dev-fix.md
@@ -34,6 +34,8 @@ An optional `Adds:` line is the complete blank-separated list of protected addit
 
 Before writing a refusal, a validator, a lock, a retry, or a test, read [dev SKILL.md § Engineering Rules](../SKILL.md#engineering-rules).
 
+An item asking for a test takes the fix-round rule there.
+
 Update the architecture docs when a fix changes an invariant, boundary or decision they state; the `docs-writing` skill says what belongs there. For **UI lifecycle or cache fixes** — cached or mirrored UI state, changed window or event handling — trace every invalidation and event-entry path before returning, prefer extending an existing listener over a parallel subscription for the same event family, and add regression coverage for the non-obvious paths you touched.
 
 Before a fix returns, grep for every other reader of the field, caller of the helper, or surface stating the rule the fix changed, and fix each one; name the sweep in the item reasoning. A fix at one site with its sibling untouched comes back as the next round.

--- a/skills/code-quality/SKILL.md
+++ b/skills/code-quality/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: code-quality
 description: "Load before writing or modifying code."
-summary: "Code-authoring standards for dev agents: correctness over convenience, no fail-open branches, comment rules, over-engineering limits, prove-your-guards."
+summary: "Code-authoring standards for dev agents: correctness over convenience, no fail-open branches, comment rules, over-engineering limits, prove-your-guards, test shape."
 license: MIT
 user-invocable: true
 dependencies:
@@ -44,6 +44,17 @@ A new or modified check, guard, assertion, or test ships with a must-fail contro
 - **A check narrower than the claim can only confirm it, never establish it.** Match the instrument's reach to the assertion's reach before running it, and prefer one that fails visibly on a planted counterexample. A grep over one directory supports no claim about the tree.
 - **Behaviour measured at an interactive prompt is not what scripts get.** `type <cmd>` names the shadow, which differs per shell. Resolve the command in the script's own shell and PATH, and name the shell and implementation it resolves to.
 - **A guard's failure message is an instrument.** It is what an author acts on. Unescaped backticks inside a double-quoted diagnostic execute their contents, so the intended text is altered or gone while the surrounding command still succeeds.
+
+## Tests
+
+- One control per behaviour surface, a public function, command, rule or contract, plus its inverse: the must-fail control § Prove Your Guards demands.
+- N planted defects means N asserted rows. A fixture that plants several defects under one verdict passes while any one of them is caught, and is never allowed.
+- Shaped input (positions, settings keys, tamper classes) is one table-driven case: one loop, one assertion per row, the row list visible in the file.
+- Assert the code, the enum or the exit status. Pin a human-readable message only inside a contract a consumer parses.
+- No test of the test harness: a pin on a manifest script string or a runner configuration proves nothing about behaviour.
+- A shared fixture is a neutral world (a seeded repository, a fake SDK). A fixture that carries a planted defect is private to its case.
+- One file per surface, beside the code, named for the surface.
+- A file past about 64 KB or about 60 cases holds more than one surface. Split it at a surface seam and move cases whole. The seam is the author's judgement; no check measures it.
 
 ## Language Discipline
 

--- a/skills/dev/SKILL.md
+++ b/skills/dev/SKILL.md
@@ -33,6 +33,10 @@ Review and QA-review belong to the reviewer skill: [`../reviewer/workflows/revie
   - the mechanical enablers of landing it ride without tracing to it: locks, changelog, baselines, dismissal renewals, that list and nothing else, never code that runs at runtime;
   - a defect the change introduces or arms is in scope by definition, unless Step 0 of [`../orch/references/finding-disposition.md`](../orch/references/finding-disposition.md) excludes it.
 - Every behavior change ships with a test that runs against the script or program enforcing it, at the smallest surface that fails. A workflow sentence ships no test. A test that pins prose, drives a second implementation, or stubs the function under test does not count as a test.
+- A review finding adds a case only when it names a behaviour no existing case reaches. Otherwise it tightens the existing case's assertion, and the item reasoning names that case.
+- A second fix round on the same function's guard is recurrence: redesign the rule under test so the class is unrepresentable, and fold the family of cases into one table.
+- A test whose premise died is deleted whole in the commit that kills the premise, and the PR body names the deletion.
+- Test shape (one control per surface, tables for shaped input, one file per surface) is [code-quality § Tests](../code-quality/SKILL.md#tests).
 - A refusal, a validator, a lock, a retry, or a test exists only for an input a real producer emits, this project's code or anything it calls or serves; name that producer beside it, or do not write it.
 - When a change deletes a call, apply [code-quality § Cleanup](../code-quality/SKILL.md#cleanup) to its callee. Its deletion maps to the call removal's Done-when item; no internal caller is not proof that a supported external API is unused.
 - A field, setting, or view member added by the change has a real producer and consumer. A named and documented external producer or consumer is valid when the change adds its in-repository counterpart; otherwise, add both sides in the change.

--- a/skills/dev/workflows/dev-fix.md
+++ b/skills/dev/workflows/dev-fix.md
@@ -34,6 +34,8 @@ An optional `Adds:` line is the complete blank-separated list of protected addit
 
 Before writing a refusal, a validator, a lock, a retry, or a test, read [dev SKILL.md § Engineering Rules](../SKILL.md#engineering-rules).
 
+An item asking for a test takes the fix-round rule there.
+
 Update the architecture docs when a fix changes an invariant, boundary or decision they state; the `docs-writing` skill says what belongs there. For **UI lifecycle or cache fixes** — cached or mirrored UI state, changed window or event handling — trace every invalidation and event-entry path before returning, prefer extending an existing listener over a parallel subscription for the same event family, and add regression coverage for the non-obvious paths you touched.
 
 Before a fix returns, grep for every other reader of the field, caller of the helper, or surface stating the rule the fix changed, and fix each one; name the sweep in the item reasoning. A fix at one site with its sibling untouched comes back as the next round.


### PR DESCRIPTION
code-quality gains § Tests: one control per behaviour surface plus its inverse; N planted defects means N asserted rows; table-driven cases for shaped input; no message pin outside a parsed contract; no test of the harness; one file per surface, split at a surface seam past about 64 KB or 60 cases (a judgement, no check).

dev § Engineering Rules gains the fix-round rule: a finding adds a case only for a behaviour no case reaches, otherwise tightens and names the case; a second round on one function's guard redesigns the rule and folds the family into one table; a dead-premise test is deleted whole and named in the PR body. dev-fix cites it.

Renders under `.agents/` replay the source diffs. Prose only; no crates/ or ui/ change.

Program: architecture-docs, tests-impl block. Tracking issue: KEN-1235.

https://claude.ai/code/session_01M823vM6cTiR4RGpDpriL8B