### PR TITLE
feat(KEN-1233): Antigravity CLI is a supported harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,15 @@ Installing a package from a git repository needs git 2.41 or newer; kendex refus
 
 ## Supported tools
 
-| | Claude Code | Codex | OpenCode | Cursor | Pi | Gemini CLI | GitHub Copilot |
-|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
-| Agents | ● | ● | ● | ●¹ | ● | ● | ● |
-| Skills | ● | ● | ● | ●¹ | ● | ● | ● |
-| Hooks | ● | ● | ●² | ●¹ ² | ●³ | ● | ● |
-| Commands | ● | ●⁴ | ○ | ○ | ○ | ● | - |
-| MCP servers | ● | ○ | ○ | ○ | - | ●⁵ | ● |
-| Plugins | ◐ | ○ | ○ | ○ | - | ○ | ◐ |
-| Pi extensions | - | - | - | - | ● | - | - |
+| | Claude Code | Codex | OpenCode | Cursor | Pi | Gemini CLI | GitHub Copilot | Antigravity |
+|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
+| Agents | ● | ● | ● | ●¹ | ● | ● | ● | ● |
+| Skills | ● | ● | ● | ●¹ | ● | ● | ● | ● |
+| Hooks | ● | ● | ●² | ●¹ ² | ●³ | ● | ● | - |
+| Commands | ● | ●⁴ | ○ | ○ | ○ | ● | - | - |
+| MCP servers | ● | ○ | ○ | ○ | - | ●⁵ | ● | ○ |
+| Plugins | ◐ | ○ | ○ | ○ | - | ○ | ◐ | ○ |
+| Pi extensions | - | - | - | - | ● | - | - | - |
 
 ● managed · ◐ enable and disable · ○ shown read-only · - not supported.
 

--- a/changelog.d/added/KEN-1233-antigravity.md
+++ b/changelog.d/added/KEN-1233-antigravity.md
@@ -1,0 +1,1 @@
+- Antigravity CLI (`agy`) is a supported harness: agents and skills install at both scopes, MCP servers and plugins are shown read-only, and hooks are not yet supported.

--- a/crates/cli/tests/unmanaged_exits/main.rs
+++ b/crates/cli/tests/unmanaged_exits/main.rs
@@ -317,7 +317,7 @@ fn a_folder_shared_by_hand_is_kept_whichever_method_is_declared() {
     assert_eq!(
         offer(&planned),
         "kendex adopt skill deploy --harness claude --harness codex --harness opencode \
-         --harness cursor --harness pi --harness gemini --harness copilot",
+         --harness cursor --harness pi --harness gemini --harness copilot --harness antigravity",
         "{planned}"
     );
 

--- a/crates/cli/tests/unmanaged_exits/shared.rs
+++ b/crates/cli/tests/unmanaged_exits/shared.rs
@@ -38,7 +38,7 @@ fn a_folder_shared_by_hand_is_kept_by_the_offer_it_prints() {
     assert_eq!(
         offer(&planned),
         "kendex adopt skill deploy --harness claude --harness codex --harness opencode \
-         --harness cursor --harness pi --harness gemini --harness copilot"
+         --harness cursor --harness pi --harness gemini --harness copilot --harness antigravity"
     );
 
     follow(home, &project, &planned);
@@ -76,7 +76,7 @@ fn a_folder_outside_every_tool_is_kept_through_the_tool_that_links_at_it() {
     assert_eq!(
         offer(&planned),
         "kendex adopt skill deploy --harness codex --harness opencode --harness cursor \
-         --harness pi --harness gemini --harness copilot"
+         --harness pi --harness gemini --harness copilot --harness antigravity"
     );
 
     follow(home, &project, &planned);

--- a/crates/core/src/engine/fork/stated.rs
+++ b/crates/core/src/engine/fork/stated.rs
@@ -220,6 +220,7 @@ fn is_rendering(harness: HarnessId, map: &crate::frontmatter::Map) -> bool {
         HarnessId::Claude => &["disallowedTools", "background"],
         HarnessId::Gemini => &["kind"],
         HarnessId::Pi => &["deny-tools"],
+        HarnessId::Antigravity => &["subagent"],
         HarnessId::Codex | HarnessId::Copilot | HarnessId::Cursor | HarnessId::Opencode => &[],
     };
     marks.iter().any(|key| map.get(key).is_some())
@@ -315,7 +316,7 @@ pub(super) fn uncleared(on_disk: &Stated, after: &Stated) -> Vec<&'static str> {
 fn permission_keys(harness: HarnessId) -> (Option<&'static str>, Option<&'static str>) {
     match harness {
         HarnessId::Claude => (Some("tools"), Some("disallowedTools")),
-        HarnessId::Gemini => (Some("tools"), None),
+        HarnessId::Gemini | HarnessId::Antigravity => (Some("tools"), None),
         HarnessId::Pi => (None, Some("deny-tools")),
         HarnessId::Codex | HarnessId::Copilot | HarnessId::Cursor | HarnessId::Opencode => {
             (None, None)

--- a/crates/core/src/engine/fork/stated.rs
+++ b/crates/core/src/engine/fork/stated.rs
@@ -238,7 +238,7 @@ fn carries(harness: HarnessId, key: &str) -> bool {
         (
             HarnessId::Claude,
             "color" | "effort" | "model" | "isolation" | "memory" | "background"
-        ) | (HarnessId::Gemini, "model")
+        ) | (HarnessId::Gemini | HarnessId::Antigravity, "model")
             | (HarnessId::Pi, "color" | "effort")
     )
 }

--- a/crates/core/src/engine/targets.rs
+++ b/crates/core/src/engine/targets.rs
@@ -186,6 +186,8 @@ pub(crate) fn hook_target(
         // own roots (`crate::harness::pi::HOOK_HOME`).
         HarnessId::Pi => Some(pi_hook(env, scope, name)),
         HarnessId::Copilot => Some(copilot_hook(env, scope, name)),
+        // `hooks.json` is a registry kendex does not yet write.
+        HarnessId::Antigravity => None,
     }
 }
 

--- a/crates/core/src/harness/antigravity.rs
+++ b/crates/core/src/harness/antigravity.rs
@@ -7,9 +7,10 @@ use crate::model::{HarnessId, ItemKind};
 /// Antigravity CLI (`agy`). Customizations live under one root per scope,
 /// `~/.gemini/config` and the workspace's `.agents/`, in the same layout:
 /// `agents/<name>.md`, `skills/<name>/SKILL.md`, `rules/*.md`,
-/// `hooks.json`, `mcp_config.json` (the CLI's embedded customization
-/// guide and <https://antigravity.google/docs/cli/subagents/>). Settings
-/// and plugins sit apart under `~/.gemini/antigravity-cli/`.
+/// `hooks.json`, `mcp_config.json`, `plugins/<name>/plugin.json` (the
+/// CLI's embedded customization guide and
+/// <https://antigravity.google/docs/cli/subagents/>). Settings sit apart
+/// under `~/.gemini/antigravity-cli/`.
 pub struct Antigravity;
 
 fn surfaces(kind: ItemKind, root: &Path, shared: Option<&Path>) -> Vec<Surface> {
@@ -23,9 +24,14 @@ fn surfaces(kind: ItemKind, root: &Path, shared: Option<&Path>) -> Vec<Surface> 
             path: root.join("mcp_config.json"),
             reader: Reader::McpServersJson,
         }],
+        // A plugin is a directory carrying its manifest under the root.
+        ItemKind::Plugin => vec![Surface::SubdirPerItem {
+            dir: root.join("plugins"),
+            marker: "plugin.json",
+        }],
         // Skills are the slash commands; hooks run from `hooks.json`, a
         // registry kendex neither reads nor writes yet.
-        ItemKind::Command | ItemKind::Hook | ItemKind::Plugin | ItemKind::PiExtension => vec![],
+        ItemKind::Command | ItemKind::Hook | ItemKind::PiExtension => vec![],
     }
 }
 
@@ -50,20 +56,8 @@ impl HarnessAdapter for Antigravity {
         ]
     }
 
-    fn global_surfaces(&self, kind: ItemKind, root: &Path, env: &Env) -> Vec<Surface> {
-        match kind {
-            // An installed plugin is a directory carrying its manifest,
-            // beside the settings rather than under the customization root.
-            ItemKind::Plugin => vec![Surface::SubdirPerItem {
-                dir: env
-                    .home
-                    .join(".gemini")
-                    .join("antigravity-cli")
-                    .join("plugins"),
-                marker: "plugin.json",
-            }],
-            other => surfaces(other, root, None),
-        }
+    fn global_surfaces(&self, kind: ItemKind, root: &Path, _env: &Env) -> Vec<Surface> {
+        surfaces(kind, root, None)
     }
 
     fn project_surfaces(&self, kind: ItemKind, project: &Path, _env: &Env) -> Vec<Surface> {
@@ -106,7 +100,14 @@ mod tests {
         assert_eq!(
             Antigravity.global_surfaces(ItemKind::Plugin, &root, &env),
             [Surface::SubdirPerItem {
-                dir: PathBuf::from("/h/.gemini/antigravity-cli/plugins"),
+                dir: PathBuf::from("/h/.gemini/config/plugins"),
+                marker: "plugin.json",
+            }]
+        );
+        assert_eq!(
+            Antigravity.project_surfaces(ItemKind::Plugin, Path::new("/p"), &env),
+            [Surface::SubdirPerItem {
+                dir: PathBuf::from("/p/.agents/plugins"),
                 marker: "plugin.json",
             }]
         );

--- a/crates/core/src/harness/antigravity.rs
+++ b/crates/core/src/harness/antigravity.rs
@@ -1,0 +1,118 @@
+use std::path::{Path, PathBuf};
+
+use super::{HarnessAdapter, ProjectMarker, Reader, Surface};
+use crate::env::Env;
+use crate::model::{HarnessId, ItemKind};
+
+/// Antigravity CLI (`agy`). Customizations live under one root per scope,
+/// `~/.gemini/config` and the workspace's `.agents/`, in the same layout:
+/// `agents/<name>.md`, `skills/<name>/SKILL.md`, `rules/*.md`,
+/// `hooks.json`, `mcp_config.json` (the CLI's embedded customization
+/// guide and <https://antigravity.google/docs/cli/subagents/>). Settings
+/// and plugins sit apart under `~/.gemini/antigravity-cli/`.
+pub struct Antigravity;
+
+fn surfaces(kind: ItemKind, root: &Path, shared: Option<&Path>) -> Vec<Surface> {
+    match kind {
+        ItemKind::Agent => vec![Surface::files(root.join("agents"), &["md"])],
+        ItemKind::Skill => super::shared_first(shared, root.join("skills")),
+        // `mcp_config.json` carries the `mcpServers` map every other tool
+        // reads; a remote server is keyed `serverUrl`, so it is read here
+        // and never written.
+        ItemKind::McpServer => vec![Surface::Structured {
+            path: root.join("mcp_config.json"),
+            reader: Reader::McpServersJson,
+        }],
+        // Skills are the slash commands; hooks run from `hooks.json`, a
+        // registry kendex neither reads nor writes yet.
+        ItemKind::Command | ItemKind::Hook | ItemKind::Plugin | ItemKind::PiExtension => vec![],
+    }
+}
+
+impl HarnessAdapter for Antigravity {
+    fn id(&self) -> HarnessId {
+        HarnessId::Antigravity
+    }
+
+    /// No documented variable relocates the customization root.
+    fn default_global_root(&self, env: &Env) -> PathBuf {
+        env.home.join(".gemini").join("config")
+    }
+
+    /// `.agents/` alone is Codex's and Pi's too; only the entries the
+    /// Antigravity loader is the sole reader of mark a workspace.
+    fn project_markers(&self) -> &'static [ProjectMarker] {
+        &[
+            ProjectMarker::Dir(".agents/agents"),
+            ProjectMarker::Dir(".agents/rules"),
+            ProjectMarker::File(".agents/hooks.json"),
+            ProjectMarker::File(".agents/mcp_config.json"),
+        ]
+    }
+
+    fn global_surfaces(&self, kind: ItemKind, root: &Path, env: &Env) -> Vec<Surface> {
+        match kind {
+            // An installed plugin is a directory carrying its manifest,
+            // beside the settings rather than under the customization root.
+            ItemKind::Plugin => vec![Surface::SubdirPerItem {
+                dir: env
+                    .home
+                    .join(".gemini")
+                    .join("antigravity-cli")
+                    .join("plugins"),
+                marker: "plugin.json",
+            }],
+            other => surfaces(other, root, None),
+        }
+    }
+
+    fn project_surfaces(&self, kind: ItemKind, project: &Path, _env: &Env) -> Vec<Surface> {
+        let root = project.join(".agents");
+        // The workspace root is the shared tree: one `.agents/skills` serves
+        // Codex, Pi and Antigravity, so there is no second directory to
+        // list.
+        match kind {
+            ItemKind::Skill => vec![Surface::skills(root.join("skills"))],
+            other => surfaces(other, &root, None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::env::FakeOs;
+
+    #[test]
+    fn both_scopes_share_one_layout_and_the_project_skills_are_the_shared_tree() {
+        let env = Env::fake("/h", FakeOs::Linux);
+        let root = Antigravity.default_global_root(&env);
+        assert_eq!(root, PathBuf::from("/h/.gemini/config"));
+        assert_eq!(
+            Antigravity.global_surfaces(ItemKind::Agent, &root, &env),
+            [Surface::files(
+                PathBuf::from("/h/.gemini/config/agents"),
+                &["md"]
+            )]
+        );
+        assert_eq!(
+            Antigravity.project_surfaces(ItemKind::Agent, Path::new("/p"), &env),
+            [Surface::files(PathBuf::from("/p/.agents/agents"), &["md"])]
+        );
+        assert_eq!(
+            Antigravity.project_surfaces(ItemKind::Skill, Path::new("/p"), &env),
+            [Surface::skills(PathBuf::from("/p/.agents/skills"))]
+        );
+        assert_eq!(
+            Antigravity.global_surfaces(ItemKind::Plugin, &root, &env),
+            [Surface::SubdirPerItem {
+                dir: PathBuf::from("/h/.gemini/antigravity-cli/plugins"),
+                marker: "plugin.json",
+            }]
+        );
+        assert_eq!(
+            Antigravity.project_surfaces(ItemKind::Hook, Path::new("/p"), &env),
+            []
+        );
+    }
+}

--- a/crates/core/src/harness/caps.rs
+++ b/crates/core/src/harness/caps.rs
@@ -194,6 +194,9 @@ pub const fn format_caps(harness: HarnessId) -> FormatCaps {
             name_rule: NameRule::LowerKebab { max_len: None },
             ..format_defaults()
         },
+        // Antigravity's `mcp_config.json` keys a remote server `serverUrl`
+        // and is read, never written; its names are unconstrained.
+        HarnessId::Antigravity => format_defaults(),
     }
 }
 
@@ -389,5 +392,15 @@ pub fn capabilities(harness: HarnessId, kind: ItemKind) -> KindCaps {
             ..observe_only(BOTH)
         },
         (Copilot, PiExtension) => unsupported(),
+
+        // Agents load from `agents/*.md` and skills from the shared tree at
+        // either scope. Hooks run from `hooks.json`, a registry kendex
+        // neither reads nor writes yet, so the row is honestly unsupported;
+        // MCP servers and plugins are read and never written.
+        (Antigravity, Agent | Skill) => managed(BOTH),
+        (Antigravity, Command | Hook) => unsupported(),
+        (Antigravity, McpServer) => observe_only(BOTH),
+        (Antigravity, Plugin) => observe_only(GLOBAL),
+        (Antigravity, PiExtension) => unsupported(),
     }
 }

--- a/crates/core/src/harness/caps.rs
+++ b/crates/core/src/harness/caps.rs
@@ -194,9 +194,13 @@ pub const fn format_caps(harness: HarnessId) -> FormatCaps {
             name_rule: NameRule::LowerKebab { max_len: None },
             ..format_defaults()
         },
-        // Antigravity's `mcp_config.json` keys a remote server `serverUrl`
-        // and is read, never written; its names are unconstrained.
-        HarnessId::Antigravity => format_defaults(),
+        // Antigravity's `mcp_config.json` carries `command` or a
+        // `serverUrl` it reads over SSE, and is read, never written; its
+        // names are unconstrained.
+        HarnessId::Antigravity => FormatCaps {
+            mcp_transports: &[Stdio, Sse],
+            ..format_defaults()
+        },
     }
 }
 
@@ -400,7 +404,7 @@ pub fn capabilities(harness: HarnessId, kind: ItemKind) -> KindCaps {
         (Antigravity, Agent | Skill) => managed(BOTH),
         (Antigravity, Command | Hook) => unsupported(),
         (Antigravity, McpServer) => observe_only(BOTH),
-        (Antigravity, Plugin) => observe_only(GLOBAL),
+        (Antigravity, Plugin) => observe_only(BOTH),
         (Antigravity, PiExtension) => unsupported(),
     }
 }

--- a/crates/core/src/harness/mod.rs
+++ b/crates/core/src/harness/mod.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use crate::env::Env;
 use crate::model::{DetectedHarness, HarnessId, ItemKind};
 
+pub mod antigravity;
 pub mod claude;
 pub mod codex;
 pub mod copilot;
@@ -174,7 +175,7 @@ pub trait HarnessAdapter: Send + Sync {
     fn project_surfaces(&self, kind: ItemKind, project: &Path, env: &Env) -> Vec<Surface>;
 }
 
-pub fn all_adapters() -> [&'static dyn HarnessAdapter; 7] {
+pub fn all_adapters() -> [&'static dyn HarnessAdapter; 8] {
     [
         &claude::Claude,
         &codex::Codex,
@@ -183,6 +184,7 @@ pub fn all_adapters() -> [&'static dyn HarnessAdapter; 7] {
         &pi::Pi,
         &gemini::Gemini,
         &copilot::Copilot,
+        &antigravity::Antigravity,
     ]
 }
 
@@ -195,6 +197,7 @@ pub fn adapter(id: HarnessId) -> &'static dyn HarnessAdapter {
         HarnessId::Pi => &pi::Pi,
         HarnessId::Gemini => &gemini::Gemini,
         HarnessId::Copilot => &copilot::Copilot,
+        HarnessId::Antigravity => &antigravity::Antigravity,
     }
 }
 

--- a/crates/core/src/harness/models.rs
+++ b/crates/core/src/harness/models.rs
@@ -53,9 +53,11 @@ pub enum ModelShape {
 
 pub fn model_shape(harness: HarnessId) -> ModelShape {
     match harness {
-        HarnessId::Claude | HarnessId::Codex | HarnessId::Gemini | HarnessId::Copilot => {
-            ModelShape::Bare
-        }
+        HarnessId::Claude
+        | HarnessId::Codex
+        | HarnessId::Gemini
+        | HarnessId::Copilot
+        | HarnessId::Antigravity => ModelShape::Bare,
         HarnessId::Opencode | HarnessId::Pi => ModelShape::ProviderQualified,
         HarnessId::Cursor => ModelShape::Absent,
     }
@@ -73,7 +75,7 @@ pub fn effort_levels(harness: HarnessId) -> Option<&'static [&'static str]> {
             Some(&["minimal", "low", "medium", "high", "xhigh"])
         }
         HarnessId::Pi => Some(&["minimal", "low", "medium", "high", "xhigh", "max"]),
-        HarnessId::Cursor | HarnessId::Gemini | HarnessId::Copilot => None,
+        HarnessId::Cursor | HarnessId::Gemini | HarnessId::Copilot | HarnessId::Antigravity => None,
     }
 }
 
@@ -101,6 +103,9 @@ pub fn resolve_model(harness: HarnessId, model: &str) -> ResolvedModel {
             // policy, and a per-repo allowlist, so kendex pins nothing and
             // lets Copilot choose (matrix §4, §D12).
             (HarnessId::Copilot, _) => resolved(Some("auto")),
+            // Antigravity's frontmatter takes its own two tiers and inherit.
+            (HarnessId::Antigravity, "fable" | "opus") => resolved(Some("pro")),
+            (HarnessId::Antigravity, _) => resolved(Some("flash")),
         };
     }
     // Explicit ids pass through as written. OpenCode and Pi load a model

--- a/crates/core/src/hook/delivery.rs
+++ b/crates/core/src/hook/delivery.rs
@@ -57,7 +57,7 @@ fn event_fires(harness: HarnessId, event: &str) -> bool {
         HarnessId::Gemini => crate::harness::gemini::event(event).is_some(),
         HarnessId::Copilot => crate::harness::copilot::event(event).is_some(),
         // Advisory harnesses never fire anything; enforcement answers first.
-        HarnessId::Opencode | HarnessId::Cursor => true,
+        HarnessId::Opencode | HarnessId::Cursor | HarnessId::Antigravity => true,
     }
 }
 

--- a/crates/core/src/manifest/validate.rs
+++ b/crates/core/src/manifest/validate.rs
@@ -148,7 +148,7 @@ fn frontmatter_keys_for(harness: &str) -> &'static [&'static str] {
             "effort",
             "model-reasoning-effort",
         ],
-        "gemini" | "copilot" => &["model", "deny-tools", "allow-tools"],
+        "gemini" | "copilot" | "antigravity" => &["model", "deny-tools", "allow-tools"],
         _ => &[],
     }
 }

--- a/crates/core/src/manifest/validate/tests.rs
+++ b/crates/core/src/manifest/validate/tests.rs
@@ -91,6 +91,9 @@ model = "inherit"
 effort = "high"
 [agent-frontmatter.cursor.rust]
 color = "red"
+[agent-frontmatter.antigravity.rust]
+effort = "high"
+model = "opus"
 "#,
     );
     let findings = validate(&table);
@@ -109,6 +112,14 @@ color = "red"
     );
     assert!(
         !locations.contains(&"agent-frontmatter.claude.rust.effort"),
+        "{locations:?}"
+    );
+    assert!(
+        locations.contains(&"agent-frontmatter.antigravity.rust.effort"),
+        "{locations:?}"
+    );
+    assert!(
+        !locations.contains(&"agent-frontmatter.antigravity.rust.model"),
         "{locations:?}"
     );
 }

--- a/crates/core/src/model.rs
+++ b/crates/core/src/model.rs
@@ -15,10 +15,11 @@ pub enum HarnessId {
     Pi,
     Gemini,
     Copilot,
+    Antigravity,
 }
 
 impl HarnessId {
-    pub const ALL: [HarnessId; 7] = [
+    pub const ALL: [HarnessId; 8] = [
         HarnessId::Claude,
         HarnessId::Codex,
         HarnessId::Opencode,
@@ -26,6 +27,7 @@ impl HarnessId {
         HarnessId::Pi,
         HarnessId::Gemini,
         HarnessId::Copilot,
+        HarnessId::Antigravity,
     ];
 
     pub fn name(self) -> &'static str {
@@ -37,6 +39,7 @@ impl HarnessId {
             HarnessId::Pi => "pi",
             HarnessId::Gemini => "gemini",
             HarnessId::Copilot => "copilot",
+            HarnessId::Antigravity => "antigravity",
         }
     }
 
@@ -51,6 +54,7 @@ impl HarnessId {
             HarnessId::Pi => "Pi",
             HarnessId::Gemini => "Gemini CLI",
             HarnessId::Copilot => "GitHub Copilot",
+            HarnessId::Antigravity => "Antigravity",
         }
     }
 
@@ -64,6 +68,7 @@ impl HarnessId {
             "pi" => Some(HarnessId::Pi),
             "gemini" | "gemini-cli" => Some(HarnessId::Gemini),
             "copilot" | "github-copilot" => Some(HarnessId::Copilot),
+            "antigravity" | "agy" => Some(HarnessId::Antigravity),
             _ => None,
         }
     }

--- a/crates/core/src/render/agent/antigravity.rs
+++ b/crates/core/src/render/agent/antigravity.rs
@@ -1,0 +1,151 @@
+use super::{EffectiveAgent, GENERATED_BANNER, RenderedAgent, hooks_prose, skills_prose};
+use crate::harness::models::resolve_model;
+use crate::model::{HarnessId, Scope};
+use crate::render::permission::PermissionIntent;
+use crate::render::vocab::rewrite_prose;
+use crate::render::{RenderWarning, yaml_quoted, yaml_scalar};
+
+/// Antigravity custom agent: YAML frontmatter + markdown body, saved as
+/// `<name>.md`. `name` and `description` are required; `model` is a tier
+/// of the loader's own (`inherit`, `flash`, `pro`) and is written only
+/// when a tier was asked for; `subagent: true` lets the primary agent
+/// delegate to it; `tools` is an allowlist of Antigravity's tool names
+/// (<https://antigravity.google/docs/subagents>). The file carries no
+/// effort key, so an effort setting renders nothing here.
+pub fn generate(agent: &EffectiveAgent) -> RenderedAgent {
+    let source = agent.source;
+    let mut warnings = Vec::new();
+    let mut fm = String::new();
+    let mut push = |line: String| {
+        fm.push_str(&line);
+        fm.push('\n');
+    };
+
+    push(format!("name: {}", yaml_scalar(&source.name)));
+    push(format!("description: {}", yaml_quoted(&source.description)));
+    let model = agent.overrides.model.as_deref().unwrap_or(&source.model);
+    let resolved = resolve_model(HarnessId::Antigravity, model);
+    warnings.extend(resolved.warning.map(RenderWarning::new));
+    if let Some(id) = &resolved.id {
+        push(format!("model: {}", yaml_scalar(id)));
+    }
+    push("subagent: true".to_owned());
+    if let PermissionIntent::AllowOnly { allow, .. } = &agent.permissions {
+        match allow.is_empty() {
+            true => push("tools: []".to_owned()),
+            false => {
+                push("tools:".to_owned());
+                for tool in allow {
+                    push(format!("  - {}", yaml_scalar(tool)));
+                }
+            }
+        }
+    }
+    // The frontmatter carries an allowlist and no deny list, and completing
+    // one from a deny list would take the agent's own tools away the moment
+    // the loader grows a built-in it never named.
+    if let PermissionIntent::DenyExtra(deny) = &agent.permissions {
+        warnings.push(RenderWarning::with_fix(
+            format!(
+                "Antigravity agents take a tool allowlist and no deny list, so this agent keeps access to {}",
+                deny.join(", ")
+            ),
+            "declare the agent's tools as an allowlist, or drop Antigravity from its harnesses",
+        ));
+    }
+
+    let mut body = format!("---\n{fm}---\n\n{GENERATED_BANNER}\n\n");
+    if let Some(launch) = &agent.launch_instructions {
+        body.push_str(&format!("## Launch Instructions\n\n{launch}\n\n"));
+    }
+    let (prose, reworded) = rewrite_prose(source.body.trim_end(), HarnessId::Antigravity);
+    warnings.extend(reworded);
+    body.push_str(&prose);
+    body.push('\n');
+    // A skill is named in the frontmatter by a path relative to the agent
+    // file, whose rules kendex does not yet follow, so skills and hooks
+    // travel as prose the agent's own instructions carry.
+    let skill_root = match agent.scope {
+        Scope::Global => "~/.gemini/config/skills",
+        Scope::Project { .. } => ".agents/skills",
+    };
+    if let Some(skills) = skills_prose(agent, skill_root) {
+        body.push_str(&format!("\n{skills}"));
+    }
+    if let Some(hooks) = hooks_prose(agent) {
+        body.push_str(&format!("\n{hooks}\n"));
+    }
+    if let Some(additional) = &agent.additional_instructions {
+        body.push_str(&format!("\n## Additional Instructions\n\n{additional}\n"));
+    }
+    RenderedAgent {
+        text: body,
+        warnings,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{SourceAgent, parse_source_agent};
+    use super::*;
+    use crate::manifest::FrontmatterOverrides;
+
+    fn source(model: &str) -> SourceAgent {
+        parse_source_agent(&format!(
+            "---\nname: rust\ndescription: Rust \"systems\" engineer\nmodel: {model}\nrole: engineer\neffort: high\n---\nUse the Bash tool.\n"
+        ))
+        .unwrap()
+    }
+
+    fn effective<'a>(source: &'a SourceAgent, scope: &'a Scope) -> EffectiveAgent<'a> {
+        EffectiveAgent {
+            source,
+            harness: HarnessId::Antigravity,
+            scope,
+            skills: vec!["dev".into()],
+            overrides: FrontmatterOverrides::default(),
+            permissions: PermissionIntent::Unspecified,
+            launch_instructions: None,
+            additional_instructions: None,
+            custom_hooks: vec![],
+        }
+    }
+
+    #[test]
+    fn a_tier_is_the_loaders_own_and_inherit_leaves_the_key_out() {
+        let scope = Scope::Project {
+            root: "/tmp/proj".into(),
+        };
+        let pro = generate(&effective(&source("opus"), &scope)).text;
+        assert!(pro.starts_with("---\nname: rust\ndescription: \"Rust \\\"systems\\\" engineer\"\nmodel: pro\nsubagent: true\n---\n"), "{pro}");
+        assert!(!pro.contains("effort"), "{pro}");
+        assert!(pro.contains("- dev: .agents/skills/dev/SKILL.md"));
+        let inherited = generate(&effective(&source("inherit"), &scope)).text;
+        assert!(!inherited.contains("model:"), "{inherited}");
+        let flash = generate(&effective(&source("haiku"), &scope)).text;
+        assert!(flash.contains("model: flash\n"), "{flash}");
+    }
+
+    #[test]
+    fn an_allowlist_renders_native_and_a_deny_list_warns() {
+        let scope = Scope::Global;
+        let source = source("inherit");
+        let mut agent = effective(&source, &scope);
+        agent.permissions = PermissionIntent::allow_only(vec!["view_file".into()]);
+        let rendered = generate(&agent);
+        assert!(
+            rendered.text.contains("tools:\n  - view_file\n"),
+            "{}",
+            rendered.text
+        );
+        agent.permissions = PermissionIntent::DenyExtra(vec!["run_command".into()]);
+        let rendered = generate(&agent);
+        assert!(!rendered.text.contains("tools:"));
+        assert!(
+            rendered
+                .warnings
+                .iter()
+                .any(|w| w.message.contains("no deny list"))
+        );
+    }
+}

--- a/crates/core/src/render/agent/antigravity.rs
+++ b/crates/core/src/render/agent/antigravity.rs
@@ -2,14 +2,16 @@ use super::{EffectiveAgent, GENERATED_BANNER, RenderedAgent, hooks_prose, skills
 use crate::harness::models::resolve_model;
 use crate::model::{HarnessId, Scope};
 use crate::render::permission::PermissionIntent;
-use crate::render::vocab::rewrite_prose;
+use crate::render::vocab::{antigravity_tool_name, rewrite_prose};
 use crate::render::{RenderWarning, yaml_quoted, yaml_scalar};
 
 /// Antigravity custom agent: YAML frontmatter + markdown body, saved as
 /// `<name>.md`. `name` and `description` are required; `model` is a tier
 /// of the loader's own (`inherit`, `flash`, `pro`) and is written only
 /// when a tier was asked for; `subagent: true` lets the primary agent
-/// delegate to it; `tools` is an allowlist of Antigravity's tool names
+/// delegate to it; `tools` is an allowlist of Antigravity's own tool names,
+/// and a name it has no word for is left out rather than written, since
+/// the loader documents that an unknown name there can hang the subagent
 /// (<https://antigravity.google/docs/subagents>). The file carries no
 /// effort key, so an effort setting renders nothing here.
 pub fn generate(agent: &EffectiveAgent) -> RenderedAgent {
@@ -31,12 +33,29 @@ pub fn generate(agent: &EffectiveAgent) -> RenderedAgent {
     }
     push("subagent: true".to_owned());
     if let PermissionIntent::AllowOnly { allow, .. } = &agent.permissions {
-        match allow.is_empty() {
+        let (named, unknown): (Vec<&String>, Vec<&String>) = allow
+            .iter()
+            .partition(|tool| antigravity_tool_name(tool).is_some());
+        if !unknown.is_empty() {
+            warnings.push(RenderWarning::with_fix(
+                format!(
+                    "Antigravity has no tool named {}, and an unknown name in its allowlist can hang the subagent, so the agent installs without it",
+                    unknown
+                        .iter()
+                        .map(|tool| format!("`{tool}`"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+                "name the tool as Antigravity does (`view_file`, `run_command`, `grep_search`), or drop it from the allowlist",
+            ));
+        }
+        match named.is_empty() {
             true => push("tools: []".to_owned()),
             false => {
                 push("tools:".to_owned());
-                for tool in allow {
-                    push(format!("  - {}", yaml_scalar(tool)));
+                for tool in named {
+                    let own = antigravity_tool_name(tool).unwrap_or_default();
+                    push(format!("  - {}", yaml_scalar(own)));
                 }
             }
         }
@@ -62,9 +81,9 @@ pub fn generate(agent: &EffectiveAgent) -> RenderedAgent {
     warnings.extend(reworded);
     body.push_str(&prose);
     body.push('\n');
-    // A skill is named in the frontmatter by a path relative to the agent
-    // file, whose rules kendex does not yet follow, so skills and hooks
-    // travel as prose the agent's own instructions carry.
+    // The frontmatter's `skills:` list names paths under the customization
+    // root; kendex does not yet write it, so skills and hooks travel as
+    // prose the agent's own instructions carry.
     let skill_root = match agent.scope {
         Scope::Global => "~/.gemini/config/skills",
         Scope::Project { .. } => ".agents/skills",
@@ -126,17 +145,31 @@ mod tests {
         assert!(flash.contains("model: flash\n"), "{flash}");
     }
 
+    /// The allowlist arrives in Claude's names and leaves in Antigravity's;
+    /// a name Antigravity lacks is left out and said, never written.
     #[test]
-    fn an_allowlist_renders_native_and_a_deny_list_warns() {
+    fn an_allowlist_renders_in_antigravitys_names_and_a_deny_list_warns() {
         let scope = Scope::Global;
         let source = source("inherit");
         let mut agent = effective(&source, &scope);
-        agent.permissions = PermissionIntent::allow_only(vec!["view_file".into()]);
+        agent.permissions =
+            PermissionIntent::allow_only(vec!["Read".into(), "Bash".into(), "mcp__gh".into()]);
         let rendered = generate(&agent);
         assert!(
-            rendered.text.contains("tools:\n  - view_file\n"),
+            rendered
+                .text
+                .contains("tools:\n  - view_file\n  - run_command\n---"),
             "{}",
             rendered.text
+        );
+        assert!(!rendered.text.contains("mcp__gh"), "{}", rendered.text);
+        assert!(
+            rendered
+                .warnings
+                .iter()
+                .any(|w| w.message.contains("`mcp__gh`")),
+            "{:?}",
+            rendered.warnings
         );
         agent.permissions = PermissionIntent::DenyExtra(vec!["run_command".into()]);
         let rendered = generate(&agent);

--- a/crates/core/src/render/agent/mod.rs
+++ b/crates/core/src/render/agent/mod.rs
@@ -3,6 +3,7 @@ use crate::model::{HarnessId, ItemKind, Scope};
 
 use super::permission::PermissionIntent;
 
+pub mod antigravity;
 pub mod claude;
 pub mod codex;
 pub mod copilot;
@@ -225,6 +226,7 @@ pub fn generate(agent: &EffectiveAgent) -> Result<RenderedAgent, String> {
         HarnessId::Pi => pi::generate(agent),
         HarnessId::Gemini => Ok(gemini::generate(agent)),
         HarnessId::Copilot => Ok(copilot::generate(agent)),
+        HarnessId::Antigravity => Ok(antigravity::generate(agent)),
     }
 }
 

--- a/crates/core/src/render/validate/agent.rs
+++ b/crates/core/src/render/validate/agent.rs
@@ -275,6 +275,56 @@ pub(super) fn gemini(name: &str, text: &str) -> Vec<Finding> {
     findings
 }
 
+/// Antigravity requires `name` and `description`, registers the agent under
+/// the name its frontmatter gives, and reads `model` as one of its own
+/// tiers (<https://antigravity.google/docs/subagents>).
+pub(super) fn antigravity(name: &str, text: &str) -> Vec<Finding> {
+    const TIERS: [&str; 3] = ["inherit", "flash", "pro"];
+    let map = match frontmatter_map(text, "Antigravity") {
+        Ok(map) => map,
+        Err(finding) => return vec![finding],
+    };
+    let text_at = |key: &str| {
+        map.get(key)
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .trim()
+    };
+    let mut findings = Vec::new();
+    match text_at("name") {
+        "" => findings.push(Finding::breakage(
+            format!("the Antigravity agent for `{name}` has no name, so nothing can call it"),
+            format!("add `name: {name}` to the agent's frontmatter in the catalog"),
+        )),
+        declared if declared != name => findings.push(Finding::breakage(
+            format!(
+                "the agent installs as `{name}` but calls itself `{declared}`, so Antigravity answers to the wrong one"
+            ),
+            format!("rename it to `{name}` in the catalog, or declare the agent as `{declared}`"),
+        )),
+        _ => {}
+    }
+    if text_at("description").is_empty() {
+        findings.push(Finding::breakage(
+            format!(
+                "the Antigravity agent for `{name}` has no description, so it is never delegated to"
+            ),
+            "add `description:` to the agent's frontmatter in the catalog",
+        ));
+    }
+    let model = text_at("model");
+    if !model.is_empty() && !TIERS.contains(&model) {
+        findings.push(Finding::breakage(
+            format!("`model: {model}` is not a tier Antigravity reads"),
+            format!(
+                "use one of {}, or a tier alias so kendex picks one",
+                TIERS.join(", ")
+            ),
+        ));
+    }
+    findings
+}
+
 /// Copilot requires a description and nothing else — but an agent that
 /// calls itself something other than the file it lives in is offered under a
 /// name nobody declared, and its model is free text a repository allowlist

--- a/crates/core/src/render/validate/mod.rs
+++ b/crates/core/src/render/validate/mod.rs
@@ -21,6 +21,7 @@
 //! | Gemini agent carries a description | breakage |
 //! | Copilot agent carries a description | breakage |
 //! | Copilot agent names the installed agent | breakage |
+//! | Antigravity agent carries name and description, and `model` is inherit, flash or pro | breakage |
 //! | Gemini agent `model` is a Gemini id or `inherit` | advisory |
 //! | Gemini command parses as TOML | breakage |
 //! | Gemini command carries a prompt | breakage |
@@ -90,6 +91,7 @@ pub fn validate_agent(harness: HarnessId, name: &str, text: &str) -> Vec<Finding
         HarnessId::Pi => agent::pi(text),
         HarnessId::Gemini => agent::gemini(name, text),
         HarnessId::Copilot => agent::copilot(name, text),
+        HarnessId::Antigravity => agent::antigravity(name, text),
     });
     findings
 }

--- a/crates/core/src/render/vocab/mod.rs
+++ b/crates/core/src/render/vocab/mod.rs
@@ -193,7 +193,7 @@ fn word(tool: &str, harness: HarnessId) -> Option<Word> {
         // Both name a tool the same way in prose as in an allowlist.
         HarnessId::Copilot => Some(Word::Name(copilot_tool(&tool)?)),
         HarnessId::Gemini => Some(Word::Name(gemini_tool(&tool)?)),
-        HarnessId::Codex => Some(Word::Phrase(match tool.as_str() {
+        HarnessId::Codex | HarnessId::Antigravity => Some(Word::Phrase(match tool.as_str() {
             "read" => "open the file",
             "grep" => "search",
             "glob" | "ls" => "list files",

--- a/crates/core/src/render/vocab/mod.rs
+++ b/crates/core/src/render/vocab/mod.rs
@@ -91,6 +91,38 @@ pub fn copilot_tool_name(tool: &str) -> String {
         .unwrap_or_else(|| tool.trim().to_owned())
 }
 
+/// Antigravity's own tool names, the step types its loader lowercases
+/// (<https://antigravity.google/docs/subagents>, the CLI's embedded
+/// customization guide). A name of its own passes through unchanged, so an
+/// author may write either vocabulary.
+fn antigravity_tool(tool: &str) -> Option<&'static str> {
+    Some(match normalize(tool).as_str() {
+        "read" | "viewfile" => "view_file",
+        "grep" | "grepsearch" => "grep_search",
+        "glob" | "find" | "findbyname" => "find_by_name",
+        "ls" | "list" | "listdir" => "list_dir",
+        "bash" | "shell" | "runcommand" => "run_command",
+        "edit" | "replacefilecontent" => "replace_file_content",
+        "multiedit" | "multireplacefilecontent" => "multi_replace_file_content",
+        "write" | "writetofile" => "write_to_file",
+        "webfetch" | "readurlcontent" => "read_url_content",
+        "websearch" | "searchweb" => "search_web",
+        "task" | "agent" | "subagent" | "spawnagent" | "invokesubagent" => "invoke_subagent",
+        "question" | "askuserquestion" | "askquestion" => "ask_question",
+        "notebookread" | "readnotebook" => "read_notebook",
+        "notebookedit" | "editnotebook" => "edit_notebook",
+        _ => return None,
+    })
+}
+
+/// What an agent's `tools:` allowlist may name on Antigravity, or `None`
+/// for a name it has no word for. An unmapped name is not passed through:
+/// the loader documents that an unknown name in the list can hang the
+/// subagent, so the caller drops it and says so.
+pub fn antigravity_tool_name(tool: &str) -> Option<&'static str> {
+    antigravity_tool(tool)
+}
+
 /// A hook matcher said in `harness`'s own tool names, and whether all of it
 /// could be. Matchers are regexes over tool names authored in Claude's
 /// vocabulary, so `Bash` left as written matches nothing on a tool whose
@@ -193,7 +225,8 @@ fn word(tool: &str, harness: HarnessId) -> Option<Word> {
         // Both name a tool the same way in prose as in an allowlist.
         HarnessId::Copilot => Some(Word::Name(copilot_tool(&tool)?)),
         HarnessId::Gemini => Some(Word::Name(gemini_tool(&tool)?)),
-        HarnessId::Codex | HarnessId::Antigravity => Some(Word::Phrase(match tool.as_str() {
+        HarnessId::Antigravity => Some(Word::Name(antigravity_tool(&tool)?)),
+        HarnessId::Codex => Some(Word::Phrase(match tool.as_str() {
             "read" => "open the file",
             "grep" => "search",
             "glob" | "ls" => "list files",

--- a/crates/core/src/scan/tests.rs
+++ b/crates/core/src/scan/tests.rs
@@ -112,7 +112,7 @@ fn scans_a_realistic_machine() {
     // The shared .agents/skills tree surfaces once per harness that reads
     // it — every one but Claude Code — always at the same path.
     let deploy = find(ItemKind::Skill, "deploy");
-    assert_eq!(deploy.len(), 6);
+    assert_eq!(deploy.len(), 7);
     assert!(deploy.iter().all(|item| item.path == deploy[0].path));
     let harnesses: Vec<_> = deploy.iter().map(|i| i.harness).collect();
     assert!(harnesses.contains(&HarnessId::Codex) && harnesses.contains(&HarnessId::Pi));

--- a/docs/adapters/README.md
+++ b/docs/adapters/README.md
@@ -11,6 +11,7 @@ One page per harness, holding the on-disk facts an adapter maintainer needs: roo
 | Pi | [pi.md](pi.md) | `crates/core/src/harness/pi.rs` | `~/.pi/agent` (`PI_CODING_AGENT_DIR`) | `.pi/`, `.agents/` |
 | Gemini CLI | [gemini.md](gemini.md) | `crates/core/src/harness/gemini/mod.rs` | `~/.gemini` | `.gemini/` |
 | GitHub Copilot | [copilot.md](copilot.md) | `crates/core/src/harness/copilot/mod.rs` | `~/.copilot` (`COPILOT_HOME`) | `.github/` |
+| Antigravity | [antigravity.md](antigravity.md) | `crates/core/src/harness/antigravity.rs` | `~/.gemini/config` | `.agents/` |
 
 The Gemini and Copilot pages rest on [gemini-copilot-matrix.md](gemini-copilot-matrix.md), the observation record the code cites as `matrix §N`; it is kept as written.
 
@@ -36,6 +37,7 @@ An agent's `model` and `effort` reach each harness under that harness's own key 
 | Gemini CLI | bare `gemini-*` id or `inherit`; tiers map to the 3.x previews | none | — | — |
 | GitHub Copilot | bare id from Copilot's own list; every tier is `auto`; an omitted key inherits | none | — | — |
 | Cursor | none | none | — | — |
+| Antigravity | its own tiers: `inherit`, `flash`, `pro`; opus and fable are `pro`, sonnet and haiku `flash` | none | — | — |
 
 A tier alias is a pin, never a synonym for `inherit`; `inherit` is the default that follows the session on every harness. A `provider/model` id is refused on a harness bound to one vendor, and a bare id is refused where the loader needs the provider named (both halves non-empty, and on Pi an optional `:level` from Pi's own set); kendex names no fallback provider because a subagent cannot run on a provider the session is not signed in to.
 

--- a/docs/adapters/antigravity.md
+++ b/docs/adapters/antigravity.md
@@ -1,0 +1,43 @@
+# Antigravity
+
+Google's Antigravity CLI (`agy`). One customization layout under a root per scope, an agent file with the loader's own two tiers, and a hook registry kendex does not yet read or write. Owner: `crates/core/src/harness/antigravity.rs`.
+
+## Roots
+
+| Scope | Path | Relocated by |
+|---|---|---|
+| Global | `~/.gemini/config` | nothing |
+| Project | `<project>/.agents` (the loader also accepts `.agent/`, `_agents/`, `_agent/`; kendex writes `.agents/`) | nothing |
+
+Settings (`settings.json`, `keybindings.json`) and installed plugins sit apart under `~/.gemini/antigravity-cli/`.
+
+Project markers: `.agents/agents/`, `.agents/rules/`, `.agents/hooks.json`, `.agents/mcp_config.json`. A bare `.agents/skills` is the shared tree Codex and Pi read too, so it marks nothing on its own.
+
+## Surfaces
+
+| Kind | Global | Project | Caps |
+|---|---|---|---|
+| agent | `~/.gemini/config/agents/*.md` | `.agents/agents/*.md` | managed, both |
+| skill | `~/.gemini/config/skills/<name>/SKILL.md` | `.agents/skills/<name>/SKILL.md`, shared with Codex and Pi | managed, both |
+| command | — | — | unsupported: a skill is the slash command |
+| hook | `~/.gemini/config/hooks.json` | `.agents/hooks.json` | unsupported until kendex reads and writes the registry |
+| mcp-server | `~/.gemini/config/mcp_config.json` | `.agents/mcp_config.json` | observe only, both |
+| plugin | `~/.gemini/antigravity-cli/plugins/<name>/plugin.json` | — | observe only, global |
+| pi-extension | — | — | unsupported |
+
+## Format
+
+- Name rule `Any`; namespace separator `__`.
+- MCP transports: stdio (`command`) and remote (`serverUrl`); the file is read, never written.
+- Agent file: YAML frontmatter and a markdown body, `<name>.md`. Fields written: `name`, `description`, `model` (only when a tier was asked for), `subagent: true`, `tools` (allowlist) (`crates/core/src/render/agent/antigravity.rs`). Skills travel as prose: the loader names a skill by a path relative to the agent file, a rule kendex does not yet follow.
+- Model dialect: `inherit` omits the key; `fable` and `opus` are `pro`, `sonnet` and `haiku` are `flash`; any other value is refused at render, since the loader reads no ids (`crates/core/src/harness/models.rs`, `crates/core/src/render/validate/agent.rs`). The file has no effort key, so an effort setting renders nothing; the session's `--effort` (`low`, `medium`, `high`) and the model's own `-high`/`-medium`/`-low` id suffix decide reasoning.
+- Permissions: an allowlist renders as `tools:`; a deny list cannot be expressed and warns.
+- Tool vocabulary: prose is rewritten to phrases, as for Codex (`crates/core/src/render/vocab/mod.rs`).
+
+## Hooks
+
+Antigravity fires `PreToolUse`, `PostToolUse`, `PreInvocation`, `PostInvocation` and `Stop` from `hooks.json`, a map of hook names to event lists in the matcher-plus-handlers shape, with JSON on stdin and a `decision` on stdout (<https://antigravity.google/docs/hooks>). kendex does not yet read or write that registry, so the capability table says hooks are unsupported here. Reading and writing it natively is the open follow-up; `PreToolUse`, `PostToolUse` and `Stop` map to the fleet events by name.
+
+## Not supported
+
+Commands (a skill is the slash command), hooks, Pi extensions, writing MCP servers or plugins, and the `skills:` and `agents:` frontmatter lists.

--- a/docs/adapters/antigravity.md
+++ b/docs/adapters/antigravity.md
@@ -9,7 +9,7 @@ Google's Antigravity CLI (`agy`). One customization layout under a root per scop
 | Global | `~/.gemini/config` | nothing |
 | Project | `<project>/.agents` (the loader also accepts `.agent/`, `_agents/`, `_agent/`; kendex writes `.agents/`) | nothing |
 
-Settings (`settings.json`, `keybindings.json`) and installed plugins sit apart under `~/.gemini/antigravity-cli/`.
+Settings (`settings.json`, `keybindings.json`) sit apart under `~/.gemini/antigravity-cli/`.
 
 Project markers: `.agents/agents/`, `.agents/rules/`, `.agents/hooks.json`, `.agents/mcp_config.json`. A bare `.agents/skills` is the shared tree Codex and Pi read too, so it marks nothing on its own.
 
@@ -22,17 +22,17 @@ Project markers: `.agents/agents/`, `.agents/rules/`, `.agents/hooks.json`, `.ag
 | command | — | — | unsupported: a skill is the slash command |
 | hook | `~/.gemini/config/hooks.json` | `.agents/hooks.json` | unsupported until kendex reads and writes the registry |
 | mcp-server | `~/.gemini/config/mcp_config.json` | `.agents/mcp_config.json` | observe only, both |
-| plugin | `~/.gemini/antigravity-cli/plugins/<name>/plugin.json` | — | observe only, global |
+| plugin | `~/.gemini/config/plugins/<name>/plugin.json` | `.agents/plugins/<name>/plugin.json` | observe only, both |
 | pi-extension | — | — | unsupported |
 
 ## Format
 
 - Name rule `Any`; namespace separator `__`.
-- MCP transports: stdio (`command`) and remote (`serverUrl`); the file is read, never written.
-- Agent file: YAML frontmatter and a markdown body, `<name>.md`. Fields written: `name`, `description`, `model` (only when a tier was asked for), `subagent: true`, `tools` (allowlist) (`crates/core/src/render/agent/antigravity.rs`). Skills travel as prose: the loader names a skill by a path relative to the agent file, a rule kendex does not yet follow.
+- MCP transports: stdio (`command`) and SSE (`serverUrl`); the file is read, never written.
+- Agent file: YAML frontmatter and a markdown body, `<name>.md`. Fields written: `name`, `description`, `model` (only when a tier was asked for), `subagent: true`, `tools` (allowlist) (`crates/core/src/render/agent/antigravity.rs`). Skills travel as prose: the frontmatter's `skills:` list names paths under the customization root, and kendex does not yet write it. An agent may also be a directory, `agents/<name>/agent.md`; kendex writes the file form and reads the directory form as the item `<name>/agent`.
 - Model dialect: `inherit` omits the key; `fable` and `opus` are `pro`, `sonnet` and `haiku` are `flash`; any other value is refused at render, since the loader reads no ids (`crates/core/src/harness/models.rs`, `crates/core/src/render/validate/agent.rs`). The file has no effort key, so an effort setting renders nothing; the session's `--effort` (`low`, `medium`, `high`) and the model's own `-high`/`-medium`/`-low` id suffix decide reasoning.
-- Permissions: an allowlist renders as `tools:`; a deny list cannot be expressed and warns.
-- Tool vocabulary: prose is rewritten to phrases, as for Codex (`crates/core/src/render/vocab/mod.rs`).
+- Permissions: an allowlist renders as `tools:` in Antigravity's own names; a name it has no word for is left out with a warning, since its documentation says an unknown name in the list can hang the subagent; a deny list cannot be expressed and warns.
+- Tool vocabulary: Antigravity's own names, the lowercased step types (`view_file`, `grep_search`, `run_command`, `replace_file_content`, `write_to_file`, `find_by_name`, `list_dir`, `read_url_content`, `search_web`, `invoke_subagent`, `ask_question`); prose is restated in them (`crates/core/src/render/vocab/mod.rs`).
 
 ## Hooks
 
@@ -40,4 +40,4 @@ Antigravity fires `PreToolUse`, `PostToolUse`, `PreInvocation`, `PostInvocation`
 
 ## Not supported
 
-Commands (a skill is the slash command), hooks, Pi extensions, writing MCP servers or plugins, and the `skills:` and `agents:` frontmatter lists.
+Commands (a skill is the slash command), hooks, Pi extensions, writing MCP servers or plugins, and the `skills:` frontmatter list.

--- a/ui/src/assets/tools/SOURCES.md
+++ b/ui/src/assets/tools/SOURCES.md
@@ -13,3 +13,4 @@ Each mark was taken from the vendor's own site or brand kit on 2026-08-16, for n
 | copilot.svg | github.com/primer/octicons — icons/copilot-24.svg (GitHub's own icon set) |
 
 Brand-terms notes seen at fetch time: GitHub's octicons licence carves the GitHub logos out of MIT and points at brand.github.com (integration use in secondary placement is permitted); Anthropic and OpenAI publish no fetchable terms page; Cursor's brand page only prescribes the name "Cursor"; OpenCode is MIT; Google's mark is governed by the Google Brand Resource Center.
+| antigravity.svg | placeholder drawn for kendex (a letter A); replace with Google's Antigravity mark once its brand kit publishes one |

--- a/ui/src/assets/tools/SOURCES.md
+++ b/ui/src/assets/tools/SOURCES.md
@@ -11,6 +11,6 @@ Each mark was taken from the vendor's own site or brand kit on 2026-08-16, for n
 | pi.svg | https://pi.dev/favicon.svg (Earendil Works; plate removed) |
 | gemini.svg | https://www.gstatic.com/lamda/images/gemini_sparkle_v002_d4735304ff6292a690345.svg (Google) |
 | copilot.svg | github.com/primer/octicons — icons/copilot-24.svg (GitHub's own icon set) |
+| antigravity.svg | placeholder drawn for kendex (a letter A); replace with Google's Antigravity mark once its brand kit publishes one |
 
 Brand-terms notes seen at fetch time: GitHub's octicons licence carves the GitHub logos out of MIT and points at brand.github.com (integration use in secondary placement is permitted); Anthropic and OpenAI publish no fetchable terms page; Cursor's brand page only prescribes the name "Cursor"; OpenCode is MIT; Google's mark is governed by the Google Brand Resource Center.
-| antigravity.svg | placeholder drawn for kendex (a letter A); replace with Google's Antigravity mark once its brand kit publishes one |

--- a/ui/src/assets/tools/antigravity.svg
+++ b/ui/src/assets/tools/antigravity.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><title>Antigravity</title><path d="M12 2.5 3 20.5h3.1l1.9-4h8l1.9 4H21L12 2.5Zm-2.7 11 2.7-5.8 2.7 5.8H9.3Z"/></svg>

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -391,7 +391,7 @@ export const commands = {
 	 *  the view alone would report a switch that never reached the files.
 	 */
 	packageSetRev: (scope: Scope, kind: ItemKind, name: string, rev: string | null) => typedError<PackageUpdate_Serialize, string>(__TAURI_INVOKE("package_set_rev", { scope, kind, name, rev })),
-	packageDiff: (scope: Scope, kind: ItemKind, name: string, from: VersionSel, to: VersionSel, harness: "claude" | "codex" | "opencode" | "cursor" | "pi" | "gemini" | "copilot" | null) => typedError<PackageDiff, string>(__TAURI_INVOKE("package_diff", { scope, kind, name, from, to, harness })),
+	packageDiff: (scope: Scope, kind: ItemKind, name: string, from: VersionSel, to: VersionSel, harness: "claude" | "codex" | "opencode" | "cursor" | "pi" | "gemini" | "copilot" | "antigravity" | null) => typedError<PackageDiff, string>(__TAURI_INVOKE("package_diff", { scope, kind, name, from, to, harness })),
 	/**  Keep an edited install as a local fork, then render it in place. */
 	packageFork: (scope: Scope, kind: ItemKind, name: string, harness: HarnessId) => typedError<AuditView_Serialize, string>(__TAURI_INVOKE("package_fork", { scope, kind, name, harness })),
 	/**
@@ -1495,7 +1495,7 @@ export type GitReadiness = {
 	ahead: number | null,
 };
 
-export type HarnessId = "claude" | "codex" | "opencode" | "cursor" | "pi" | "gemini" | "copilot";
+export type HarnessId = "claude" | "codex" | "opencode" | "cursor" | "pi" | "gemini" | "copilot" | "antigravity";
 
 /**
  *  Whose hold keeps a place at its revision — what the Follow source

--- a/ui/src/components/harness-badge.tsx
+++ b/ui/src/components/harness-badge.tsx
@@ -21,6 +21,7 @@ const HARNESS_CHIP: Record<HarnessId, string> = {
   pi: "bg-harness-pi/12 text-harness-pi",
   gemini: "bg-harness-gemini/12 text-harness-gemini",
   copilot: "bg-harness-copilot/12 text-harness-copilot",
+  antigravity: "bg-harness-antigravity/12 text-harness-antigravity",
 };
 
 /**

--- a/ui/src/components/harness-icon.tsx
+++ b/ui/src/components/harness-icon.tsx
@@ -1,3 +1,4 @@
+import AntigravityMark from "@/assets/tools/antigravity.svg?react";
 import ClaudeMark from "@/assets/tools/claude.svg?react";
 import CodexMark from "@/assets/tools/codex.svg?react";
 import CopilotMark from "@/assets/tools/copilot.svg?react";
@@ -22,6 +23,7 @@ const MARKS: Record<HarnessId, React.FC<React.SVGProps<SVGSVGElement>>> = {
   pi: PiMark,
   gemini: GeminiMark,
   copilot: CopilotMark,
+  antigravity: AntigravityMark,
 };
 
 const TINT: Record<HarnessId, string> = {
@@ -32,6 +34,7 @@ const TINT: Record<HarnessId, string> = {
   pi: "text-harness-pi",
   gemini: "text-harness-gemini",
   copilot: "text-harness-copilot",
+  antigravity: "text-harness-antigravity",
 };
 
 // Each vendor draws its mark with its own padding and its own weight, so
@@ -46,6 +49,7 @@ const OPTICAL: Record<HarnessId, string> = {
   pi: "scale-[0.66]",
   gemini: "scale-[1.15]",
   copilot: "scale-[0.88]",
+  antigravity: "scale-[0.9]",
 };
 
 /** A tool's mark, in the tool's own colour. Decorative — every place this

--- a/ui/src/components/harnesses/harness-list.tsx
+++ b/ui/src/components/harnesses/harness-list.tsx
@@ -14,6 +14,7 @@ const ALL_HARNESSES: HarnessId[] = [
   "pi",
   "gemini",
   "copilot",
+  "antigravity",
 ];
 
 /** "Harnesses": the AI coding tools this machine has, one row each. */
@@ -32,8 +33,8 @@ export function HarnessList() {
       <div className="flex flex-col items-center gap-2 py-16 text-center">
         <p className="font-medium">No AI coding tools found.</p>
         <p className="text-sm text-muted-foreground">
-          Install Claude Code, Codex, OpenCode, Cursor, Pi, Gemini CLI, or
-          GitHub Copilot and scan again.
+          Install Claude Code, Codex, OpenCode, Cursor, Pi, Gemini CLI, GitHub
+          Copilot, or Antigravity and scan again.
         </p>
         <Button
           variant="outline"

--- a/ui/src/components/library/library-filters.tsx
+++ b/ui/src/components/library/library-filters.tsx
@@ -29,6 +29,7 @@ const HARNESSES: HarnessId[] = [
   "pi",
   "gemini",
   "copilot",
+  "antigravity",
 ];
 
 export function LibraryFilters({

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -62,6 +62,7 @@
      asks you to decode two colour languages at once. */
   --harness-claude: oklch(0.55 0.16 45);
   --harness-copilot: oklch(0.52 0.14 96);
+  --harness-antigravity: oklch(0.55 0.16 280);
   --harness-codex: oklch(0.52 0.13 147);
   --harness-cursor: oklch(0.52 0.13 198);
   --harness-gemini: oklch(0.53 0.16 249);
@@ -112,6 +113,7 @@
   --code-comment: oklch(0.6 0.02 260);
   --harness-claude: oklch(0.76 0.13 45);
   --harness-copilot: oklch(0.76 0.12 96);
+  --harness-antigravity: oklch(0.78 0.12 280);
   --harness-codex: oklch(0.76 0.11 147);
   --harness-cursor: oklch(0.76 0.11 198);
   --harness-gemini: oklch(0.74 0.13 249);
@@ -166,6 +168,7 @@
   --color-harness-pi: var(--harness-pi);
   --color-harness-gemini: var(--harness-gemini);
   --color-harness-copilot: var(--harness-copilot);
+  --color-harness-antigravity: var(--harness-antigravity);
 }
 
 @layer base {

--- a/ui/src/lib/labels.ts
+++ b/ui/src/lib/labels.ts
@@ -11,6 +11,7 @@ export const HARNESS_NAMES: Record<HarnessId, string> = {
   pi: "Pi",
   gemini: "Gemini CLI",
   copilot: "GitHub Copilot",
+  antigravity: "Antigravity",
 };
 
 export const harnessName = (id: HarnessId): string => HARNESS_NAMES[id];


### PR DESCRIPTION
Part 4 of the agent-effort block (KEN-1233), first PR. Held for the overseer; the local reviewer round has run (second commit).

What lands:
- `HarnessId::Antigravity` with every match site filled; adapter `crates/core/src/harness/antigravity.rs` (global root `~/.gemini/config`, workspace `.agents/`, markers `.agents/agents`, `.agents/rules`, `.agents/hooks.json`, `.agents/mcp_config.json`).
- Agent renderer `crates/core/src/render/agent/antigravity.rs`: `name`, `description`, `model` as the loader's own tiers (`inherit` omits the key; opus and fable are `pro`, sonnet and haiku `flash`), `subagent: true`, `tools` allowlist in Antigravity's own names (a name it lacks is left out with a warning, since its docs say an unknown name can hang the subagent); prose restated in the same names; skills as prose; no effort key (the file has none).
- Render validation: name, description, and `model` in `inherit|flash|pro`. Manifest validation accepts `model`, `allow-tools`, `deny-tools` under `[agent-frontmatter.antigravity.*]`.
- Capabilities: agents and skills managed at both scopes; MCP servers (stdio, SSE) and plugins observe-only at both scopes; hooks and commands unsupported (`hooks.json` is the next PR).
- Docs: `docs/adapters/antigravity.md`, adapter README rows, the README supported-tools column; app harness list, Library filter, label, badge, placeholder mark (SOURCES.md says so), regenerated bindings.

Reviewer round (reviewer-correctness, one round): fixed the four blocking findings (tools allowlist in Claude's names, manifest refusing the overrides the renderer reads, plugin surface under the CLI state dir, Library filter missing the harness) and the suggestions (skills-as-prose reason, fork `model` carry, SOURCES.md row, MCP transports); the directory-form agent note went to the adapter doc.

Not in this PR: a `hooks.json` reader and writer (next PR, stacked), the `skills:` frontmatter list, the live proof on this machine (Part 2), and a real vendor mark.

Checks: `cargo test -p kendex-core -p kendex-cli -p kendex-app` green; UI typecheck and biome clean; pre-commit chain clean.

Tracking: KEN-1233

https://claude.ai/code/session_011qRAkAD4obmNzrVnokoRZf