### PR TITLE
chore(pi-extensions): prepare npm consumer wave

### DIFF
--- a/pi-extensions/pi-agents-tmux/CHANGELOG.md
+++ b/pi-extensions/pi-agents-tmux/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Consumer-impacting changes
 
-### Unreleased
+### 3.0.1
 
 - A child, one-shot or pane, runs at the agent's frontmatter `effort` level when its model id carries no `:effort` suffix: the runner and the pane launcher pass it as `--thinking`. Before, an agent that inherited the parent's model ran at Pi's default thinking level whatever its `effort` key said. A live pane picks the level up on its next launch.
 - The extension uses `PI_CODING_AGENT_DIR` only when root-anchored — a drive or UNC share on Windows, a leading `/` on POSIX. Anything else uses `~/.pi/agent`. The install helper is unchanged.

--- a/pi-extensions/pi-agents-tmux/package-lock.json
+++ b/pi-extensions/pi-agents-tmux/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vanillagreen/pi-agents-tmux",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vanillagreen/pi-agents-tmux",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "hasInstallScript": true,
       "license": "MIT",
       "engines": {

--- a/pi-extensions/pi-agents-tmux/package.json
+++ b/pi-extensions/pi-agents-tmux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-agents-tmux",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Pi extension for delegating work to project or user agents, including persistent tmux agent panes.",
   "license": "MIT",
   "keywords": [

--- a/pi-extensions/pi-background-tasks/CHANGELOG.md
+++ b/pi-extensions/pi-background-tasks/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Consumer-impacting changes
 
-### Unreleased
+### 2.0.1
 
+- Finished tasks disappear from the inline widget after `widgetFinishedRetentionSeconds` without waiting for another task event. Long retention periods use bounded timer waits, and hiding the widget or ending the session clears the timer.
 - The extension uses `PI_CODING_AGENT_DIR` only when root-anchored — a drive or UNC share on Windows, a leading `/` on POSIX. Anything else uses `~/.pi/agent`. The install helper is unchanged.
 
 ### 2.0.0

--- a/pi-extensions/pi-background-tasks/package.json
+++ b/pi-extensions/pi-background-tasks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-background-tasks",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Pi extension for explicit non-blocking background shell tasks, log tails, and completion wakeups.",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
## Scope

Prepare npm consumer releases for already-merged fixes: background-task widget expiry (#2160), agent effort propagation (#2157), and hooks setting wording (#2151).

| Package | npm latest checked | Prepared version |
|---|---:|---:|
| @vanillagreen/pi-background-tasks | 2.0.0 | 2.0.1 |
| @vanillagreen/pi-agents-tmux | 3.0.0 | 3.0.1 |
| @vanillagreen/pi-hooks | 0.5.0 | 0.9.0 (unchanged; unpublished) |

This bump PR makes **no runtime changes**. Release notes are a separate commit from package versions and the agents lockfile. Other packages are explicitly deferred.

## Validation

All test HOME, TMPDIR, Pi and XDG writes were physically isolated beneath this worktree's `tmp`; no actual session environment was inherited. Hooks ran in a bubblewrap namespace with the system and original worktree source read-only, and worktree scratch bound as namespace `/tmp`. This gives no-project fixtures a path without repository ancestors; no tests were copied or assertions changed.

- Background tasks: `npm test` — 184 pass, 0 fail.
- Agents/tmux: `npm test` — 387 pass, 0 fail.
- Hooks: `npm test` — **57 pass, 0 fail** in the namespace. The initial direct run had two failures because fixtures discovered the ancestor worktree marker; namespace isolation restored their no-project premise without code changes.
- `node --test pi-extensions/package-policy.test.mjs` — 8 pass after versioning package changelog entries.
- `npm pack --dry-run --ignore-scripts --json` — exit 0 for all three; entrypoints and install helpers present.
- Staged preflight, scoped `tools/guard`, commit hook chains and diff whitespace checks passed.

## Release handoff

Package validation passes; the hooks isolation blocker is resolved. Parent owns push/PR/merge and publication from clean synced main, with fresh registry checks. No publishing, tags, push, refresh/apply or update-pi was performed.

Payload follow-up (existing package policy): all three omit CHANGELOG.md and DEVELOPMENT.md; their READMEs link to DEVELOPMENT.md. Background-tasks and agents-tmux include extension-local test files through their `extensions/` allowlist. Payload policy changes are deferred, not smuggled into the version-only commit.
