### PR TITLE
feat(KEN-1233): Antigravity hooks install into hooks.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Installing a package from a git repository needs git 2.41 or newer; kendex refus
 |---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
 | Agents | ● | ● | ● | ●¹ | ● | ● | ● | ● |
 | Skills | ● | ● | ● | ●¹ | ● | ● | ● | ● |
-| Hooks | ● | ● | ●² | ●¹ ² | ●³ | ● | ● | - |
+| Hooks | ● | ● | ●² | ●¹ ² | ●³ | ● | ● | ● |
 | Commands | ● | ●⁴ | ○ | ○ | ○ | ● | - | - |
 | MCP servers | ● | ○ | ○ | ○ | - | ●⁵ | ● | ○ |
 | Plugins | ◐ | ○ | ○ | ○ | - | ○ | ◐ | ○ |

--- a/changelog.d/added/KEN-1233-antigravity-hooks.md
+++ b/changelog.d/added/KEN-1233-antigravity-hooks.md
@@ -1,0 +1,1 @@
+- Antigravity hooks: a hook installs into `hooks.json` under its own name at either scope, with its matcher in Antigravity's tool names, and the scan reads the registry back.

--- a/crates/core/src/configedit/antigravity.rs
+++ b/crates/core/src/configedit/antigravity.rs
@@ -1,0 +1,190 @@
+//! Antigravity's `hooks.json`: one named hook per top-level key, each an
+//! object holding an optional `enabled` switch and one list per event.
+//! `PreToolUse` and `PostToolUse` nest handlers under a matcher group the
+//! way the shared nested shape does; the other events hold handlers
+//! directly (the CLI's embedded hooks guide, <https://antigravity.google/docs/hooks>).
+//! The name a registration goes under is the hook's own, so the switch
+//! the loader offers switches exactly that hook.
+
+use serde_json::{Map, Value};
+
+use super::nested::{handler, remove_in, upsert_in};
+use super::{ensure_object, names};
+
+/// The events the loader reads as matcher groups; every other event is a
+/// flat list of handlers and a `matcher` there is ignored.
+fn grouped(event: &str) -> bool {
+    matches!(event, "PreToolUse" | "PostToolUse")
+}
+
+/// The switch key, the one key under a name that is not an event.
+const ENABLED: &str = "enabled";
+
+pub(super) fn upsert_antigravity_hook(
+    root: &mut Map<String, Value>,
+    name: &str,
+    event: &str,
+    matcher: Option<&str>,
+    command: &str,
+    timeout: Option<u32>,
+) -> Result<(), String> {
+    let hook = ensure_object(root, name)?;
+    if grouped(event) {
+        return upsert_in(hook, event, matcher, command, timeout);
+    }
+    let handlers = hook
+        .entry(event)
+        .or_insert_with(|| Value::Array(Vec::new()))
+        .as_array_mut()
+        .ok_or("hook event is not an array")?;
+    let ours = |h: &Value| h.get("command").and_then(Value::as_str) == Some(command);
+    // Refreshed where it already stands, and once: a second copy of the
+    // same command under one event would run it twice.
+    let first = handlers.iter().position(ours);
+    let mut kept = false;
+    handlers.retain(|h| !ours(h) || !std::mem::replace(&mut kept, true));
+    match first {
+        Some(index) => handlers[index] = handler(command, timeout),
+        None => handlers.push(handler(command, timeout)),
+    }
+    Ok(())
+}
+
+/// Takes our handler back out from under `name`, or from under every name
+/// when none is given, and from every event when none is named. A name
+/// left holding no event comes out too: an object carrying only a switch
+/// is a hook the person never wrote.
+pub(super) fn remove_antigravity_hook(
+    root: &mut Map<String, Value>,
+    name: Option<&str>,
+    event: Option<&str>,
+    matcher: Option<&str>,
+    command: &str,
+) {
+    let held: Vec<String> = match name {
+        Some(name) => vec![name.to_owned()],
+        None => root.keys().cloned().collect(),
+    };
+    for name in held {
+        let Some(hook) = root.get_mut(&name).and_then(Value::as_object_mut) else {
+            continue;
+        };
+        let events: Vec<String> = match event {
+            Some(event) => vec![event.to_owned()],
+            None => hook.keys().filter(|key| *key != ENABLED).cloned().collect(),
+        };
+        for event in events {
+            if grouped(&event) {
+                remove_in(hook, &event, matcher, command);
+                continue;
+            }
+            if let Some(handlers) = hook.get_mut(&event).and_then(Value::as_array_mut) {
+                handlers.retain(|h| {
+                    !names(h, matcher) || h.get("command").and_then(Value::as_str) != Some(command)
+                });
+                if handlers.is_empty() {
+                    hook.shift_remove(&event);
+                }
+            }
+        }
+        if hook.keys().all(|key| key == ENABLED) {
+            root.shift_remove(&name);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::configedit::ConfigEdit;
+
+    const COMMAND: &str = "bash \"$(git rev-parse --show-toplevel)/.agents/hooks/audit.sh\"";
+
+    fn upsert(event: &str, matcher: Option<&str>) -> ConfigEdit {
+        ConfigEdit::UpsertAntigravityHook {
+            name: "audit".to_owned(),
+            event: event.to_owned(),
+            matcher: matcher.map(str::to_owned),
+            command: COMMAND.to_owned(),
+            timeout: Some(10),
+        }
+    }
+
+    /// Applying twice changes nothing the second time — that equality is how
+    /// the plan tells a registered hook from one still to register.
+    #[test]
+    fn a_tool_event_lands_grouped_under_the_hooks_name_and_re_applying_is_a_no_op() {
+        let once = upsert("PreToolUse", Some("run_command")).apply("").unwrap();
+        let value: serde_json::Value = serde_json::from_str(&once).unwrap();
+        let group = &value["audit"]["PreToolUse"][0];
+        assert_eq!(group["matcher"], "run_command");
+        assert_eq!(group["hooks"][0]["type"], "command");
+        assert_eq!(group["hooks"][0]["command"], COMMAND);
+        assert_eq!(group["hooks"][0]["timeout"], 10);
+        assert_eq!(
+            upsert("PreToolUse", Some("run_command"))
+                .apply(&once)
+                .unwrap(),
+            once
+        );
+    }
+
+    /// The loader reads `Stop` as a list of handlers with no group around
+    /// them; a group there would be a handler with no command.
+    #[test]
+    fn a_stop_event_lands_flat_and_a_second_copy_is_folded_into_one() {
+        let once = upsert("Stop", None).apply("").unwrap();
+        let value: serde_json::Value = serde_json::from_str(&once).unwrap();
+        assert_eq!(value["audit"]["Stop"][0]["command"], COMMAND);
+        assert!(value["audit"]["Stop"][0].get("hooks").is_none());
+        let doubled = format!(
+            r#"{{"audit": {{"Stop": [{{"command": {COMMAND:?}}}, {{"command": {COMMAND:?}}}]}}}}"#
+        );
+        let folded = upsert("Stop", None).apply(&doubled).unwrap();
+        assert_eq!(folded, once);
+    }
+
+    /// Someone else's named hook, and their switch on ours, are not ours to
+    /// touch; the last handler out takes the name with it.
+    #[test]
+    fn removing_ours_leaves_every_other_name_and_prunes_the_empty_one() {
+        let existing = r#"{"lint": {"PostToolUse": [{"matcher": "run_command", "hooks": [{"command": "./lint.sh"}]}]},
+            "audit": {"enabled": false}}"#;
+        let registered = upsert("PreToolUse", Some("run_command"))
+            .apply(existing)
+            .unwrap();
+        let value: serde_json::Value = serde_json::from_str(&registered).unwrap();
+        assert_eq!(value["audit"]["enabled"], false);
+        let removed = ConfigEdit::RemoveAntigravityHook {
+            name: Some("audit".to_owned()),
+            event: None,
+            matcher: None,
+            command: COMMAND.to_owned(),
+        }
+        .apply(&registered)
+        .unwrap();
+        let value: serde_json::Value = serde_json::from_str(&removed).unwrap();
+        assert!(value.get("audit").is_none(), "{removed}");
+        assert_eq!(
+            value["lint"]["PostToolUse"][0]["hooks"][0]["command"],
+            "./lint.sh"
+        );
+    }
+
+    /// Without a name the command comes out from under whichever name
+    /// registered it — what adopting a foreign registration needs.
+    #[test]
+    fn an_unnamed_removal_finds_the_command_under_any_name() {
+        let theirs = format!(
+            r#"{{"theirs": {{"PreToolUse": [{{"matcher": "run_command", "hooks": [{{"command": {COMMAND:?}}}]}}]}}}}"#
+        );
+        let removed = ConfigEdit::RemoveAntigravityHook {
+            name: None,
+            event: Some("PreToolUse".to_owned()),
+            matcher: Some("run_command".to_owned()),
+            command: COMMAND.to_owned(),
+        }
+        .apply(&theirs)
+        .unwrap();
+        assert_eq!(removed.trim(), "{}");
+    }
+}

--- a/crates/core/src/configedit/mod.rs
+++ b/crates/core/src/configedit/mod.rs
@@ -1,10 +1,12 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 
+mod antigravity;
 mod copilot;
 mod nested;
 mod text;
 
+use antigravity::{remove_antigravity_hook, upsert_antigravity_hook};
 use copilot::{remove_copilot_hook, upsert_copilot_hook};
 use nested::{remove_hook, upsert_hook};
 use text::codex_enable_hooks;
@@ -47,6 +49,25 @@ pub enum ConfigEdit {
         timeout: Option<u32>,
     },
     RemoveCopilotHook {
+        event: Option<String>,
+        #[serde(default)]
+        matcher: Option<String>,
+        command: String,
+    },
+    /// antigravity `hooks.json`: upsert our handler under `<name>.<event>`,
+    /// grouped by matcher for the tool events and flat for the rest, the
+    /// way its loader reads them (the CLI's embedded hooks guide).
+    UpsertAntigravityHook {
+        name: String,
+        event: String,
+        matcher: Option<String>,
+        command: String,
+        timeout: Option<u32>,
+    },
+    /// Remove our handler from under `name`, or from under every name when
+    /// none is given; a name left holding no event is pruned with it.
+    RemoveAntigravityHook {
+        name: Option<String>,
         event: Option<String>,
         #[serde(default)]
         matcher: Option<String>,
@@ -136,45 +157,10 @@ impl ConfigEdit {
         let object = root
             .as_object_mut()
             .ok_or("config root is not a JSON object")?;
+        if let Some(applied) = self.apply_hook_edit(object) {
+            return applied;
+        }
         match self {
-            ConfigEdit::UpsertHook {
-                event,
-                matcher,
-                command,
-                timeout,
-            } => upsert_hook(object, event, matcher.as_deref(), command, *timeout),
-            ConfigEdit::RemoveHook {
-                event,
-                matcher,
-                command,
-            } => {
-                let events: Vec<String> = match event {
-                    Some(event) => vec![event.clone()],
-                    None => object
-                        .get("hooks")
-                        .and_then(Value::as_object)
-                        .map(|e| e.keys().cloned().collect())
-                        .unwrap_or_default(),
-                };
-                for event in events {
-                    remove_hook(object, &event, matcher.as_deref(), command);
-                }
-                Ok(())
-            }
-            ConfigEdit::UpsertCopilotHook {
-                event,
-                matcher,
-                command,
-                timeout,
-            } => upsert_copilot_hook(object, event, matcher.as_deref(), command, *timeout),
-            ConfigEdit::RemoveCopilotHook {
-                event,
-                matcher,
-                command,
-            } => {
-                remove_copilot_hook(object, event.as_deref(), matcher.as_deref(), command);
-                Ok(())
-            }
             ConfigEdit::UpsertMcpServer { name, value } => {
                 let servers = ensure_object(object, "mcpServers")?;
                 servers.insert(name.clone(), value.clone());
@@ -226,6 +212,66 @@ impl ConfigEdit {
             }
             _ => Ok(()),
         }
+    }
+
+    /// The hook-registry edits, one shape per registry format, or `None`
+    /// for an edit that touches no hook entry.
+    fn apply_hook_edit(&self, object: &mut Map<String, Value>) -> Option<Result<(), String>> {
+        Some(match self {
+            ConfigEdit::UpsertHook {
+                event,
+                matcher,
+                command,
+                timeout,
+            } => upsert_hook(object, event, matcher.as_deref(), command, *timeout),
+            ConfigEdit::RemoveHook {
+                event,
+                matcher,
+                command,
+            } => {
+                remove_hook(object, event.as_deref(), matcher.as_deref(), command);
+                Ok(())
+            }
+            ConfigEdit::UpsertCopilotHook {
+                event,
+                matcher,
+                command,
+                timeout,
+            } => upsert_copilot_hook(object, event, matcher.as_deref(), command, *timeout),
+            ConfigEdit::RemoveCopilotHook {
+                event,
+                matcher,
+                command,
+            } => {
+                remove_copilot_hook(object, event.as_deref(), matcher.as_deref(), command);
+                Ok(())
+            }
+            ConfigEdit::UpsertAntigravityHook {
+                name,
+                event,
+                matcher,
+                command,
+                timeout,
+            } => {
+                upsert_antigravity_hook(object, name, event, matcher.as_deref(), command, *timeout)
+            }
+            ConfigEdit::RemoveAntigravityHook {
+                name,
+                event,
+                matcher,
+                command,
+            } => {
+                remove_antigravity_hook(
+                    object,
+                    name.as_deref(),
+                    event.as_deref(),
+                    matcher.as_deref(),
+                    command,
+                );
+                Ok(())
+            }
+            _ => return None,
+        })
     }
 }
 

--- a/crates/core/src/configedit/nested.rs
+++ b/crates/core/src/configedit/nested.rs
@@ -16,12 +16,36 @@ pub(super) fn upsert_hook(
     command: &str,
     timeout: Option<u32>,
 ) -> Result<(), String> {
+    upsert_in(
+        ensure_object(root, "hooks")?,
+        event,
+        matcher,
+        command,
+        timeout,
+    )
+}
+
+/// One handler as every nested registry spells it.
+pub(super) fn handler(command: &str, timeout: Option<u32>) -> Value {
     let mut handler = json!({"type": "command", "command": command});
     if let Some(timeout) = timeout {
         handler["timeout"] = json!(timeout);
     }
+    handler
+}
+
+/// The upsert against the map of event name to groups itself, for a
+/// registry that keeps that map somewhere other than under `hooks`.
+pub(super) fn upsert_in(
+    events: &mut Map<String, Value>,
+    event: &str,
+    matcher: Option<&str>,
+    command: &str,
+    timeout: Option<u32>,
+) -> Result<(), String> {
+    let handler = handler(command, timeout);
     let ours = |h: &Value| h.get("command").and_then(Value::as_str) == Some(command);
-    let groups = ensure_object(root, "hooks")?
+    let groups = events
         .entry(event)
         .or_insert_with(|| json!([]))
         .as_array_mut()
@@ -77,15 +101,36 @@ pub(super) fn upsert_hook(
     Ok(())
 }
 
+/// Takes our handler out, from every event when none is named.
 pub(super) fn remove_hook(
     root: &mut Map<String, Value>,
-    event: &str,
+    event: Option<&str>,
     matcher: Option<&str>,
     command: &str,
 ) {
     let Some(events) = root.get_mut("hooks").and_then(Value::as_object_mut) else {
         return;
     };
+    let named: Vec<String> = match event {
+        Some(event) => vec![event.to_owned()],
+        None => events.keys().cloned().collect(),
+    };
+    for event in named {
+        remove_in(events, &event, matcher, command);
+    }
+    if events.is_empty() {
+        root.shift_remove("hooks");
+    }
+}
+
+/// The removal against the map of event name to groups itself; an event
+/// left holding no groups is pruned, the map is the caller's to prune.
+pub(super) fn remove_in(
+    events: &mut Map<String, Value>,
+    event: &str,
+    matcher: Option<&str>,
+    command: &str,
+) {
     if let Some(groups) = events.get_mut(event).and_then(Value::as_array_mut) {
         for group in groups.iter_mut() {
             // A matcher names one group. Without one every group in the
@@ -107,8 +152,5 @@ pub(super) fn remove_hook(
         if groups.is_empty() {
             events.shift_remove(event);
         }
-    }
-    if events.is_empty() {
-        root.shift_remove("hooks");
     }
 }

--- a/crates/core/src/engine/adopt/hooks.rs
+++ b/crates/core/src/engine/adopt/hooks.rs
@@ -132,6 +132,11 @@ fn read(registry: &Path, format: HookFormat) -> Vec<Registration> {
             .and_then(|text| crate::scan::copilot::registrations_text(&text).ok())
             .unwrap_or_default(),
         HookFormat::Nested => crate::scan::hooks::read_registrations(registry).unwrap_or_default(),
+        HookFormat::Antigravity => crate::fs::read_if_exists(registry)
+            .ok()
+            .flatten()
+            .and_then(|text| crate::scan::antigravity::registrations_text(&text).ok())
+            .unwrap_or_default(),
     }
 }
 
@@ -181,6 +186,7 @@ fn format_of(reader: &Reader) -> Option<HookFormat> {
     match reader {
         Reader::HooksObject => Some(HookFormat::Nested),
         Reader::CopilotHooks => Some(HookFormat::Copilot),
+        Reader::AntigravityHooks => Some(HookFormat::Antigravity),
         _ => None,
     }
 }
@@ -322,6 +328,14 @@ fn drop_old_entries(found: &[Found]) -> Result<Vec<PlannedOp>> {
                 command: entry.registration.command.clone(),
             },
             HookFormat::Nested => ConfigEdit::RemoveHook {
+                event: Some(entry.registration.event.clone()),
+                matcher,
+                command: entry.registration.command.clone(),
+            },
+            // The scan names no hook-name key, so the command comes out
+            // from under every name that registered it.
+            HookFormat::Antigravity => ConfigEdit::RemoveAntigravityHook {
+                name: None,
                 event: Some(entry.registration.event.clone()),
                 matcher,
                 command: entry.registration.command.clone(),

--- a/crates/core/src/engine/adopt/hooks/declare.rs
+++ b/crates/core/src/engine/adopt/hooks/declare.rs
@@ -139,7 +139,7 @@ fn timeout_seconds(found: &Found) -> Option<u32> {
         // entry says which unit it is, so it comes from the tool that wrote
         // it — the same table the render used on the way in.
         (HookFormat::Nested, HarnessId::Gemini) => read("timeout").map(|held| held / 1000),
-        (HookFormat::Nested, _) => read("timeout"),
+        (HookFormat::Nested | HookFormat::Antigravity, _) => read("timeout"),
     };
     seconds
         .and_then(|value| u32::try_from(value).ok())
@@ -153,7 +153,7 @@ fn timeout_seconds(found: &Found) -> Option<u32> {
 fn beyond_a_declaration(registration: &Registration, format: HookFormat) -> Option<String> {
     let known: &[&str] = match format {
         HookFormat::Copilot => &["type", "command", "matcher", "timeoutSec"],
-        HookFormat::Nested => &["type", "command", "matcher", "timeout"],
+        HookFormat::Nested | HookFormat::Antigravity => &["type", "command", "matcher", "timeout"],
     };
     let entry = registration.entry.as_object()?;
     if let Some(kind) = entry.get("type").and_then(serde_json::Value::as_str)

--- a/crates/core/src/engine/antigravity.rs
+++ b/crates/core/src/engine/antigravity.rs
@@ -1,0 +1,36 @@
+//! What the shared declaration paths have to ask Antigravity before they
+//! write a hook: whether it fires the event at all, and whether the matcher
+//! can be said in its tool names.
+
+use super::ItemWarning;
+use super::desired::DesiredState;
+use crate::hook::HookSpec;
+use crate::model::{HarnessId, ItemKind};
+
+/// The hook as Antigravity would register it, or `None` with the note
+/// saying why nothing is registered: an event it has no counterpart for.
+pub(super) fn hook(name: &str, hook: &HookSpec, state: &mut DesiredState) -> Option<HookSpec> {
+    let Some(registered) = crate::harness::antigravity::hook_for(hook) else {
+        state.notes.push(format!(
+            "hook {name}: event {} has no Antigravity counterpart, and hanging it on a near-miss would run it at the wrong moment",
+            hook.event
+        ));
+        return None;
+    };
+    if registered.matcher_as_authored {
+        state.warnings.push(ItemWarning {
+            kind: ItemKind::Hook,
+            name: name.to_owned(),
+            harness: Some(HarnessId::Antigravity),
+            message: format!(
+                "Antigravity matches `{}` against its own tool names, and this matcher carries syntax kendex cannot restate in them — it installs as written and may never match",
+                hook.matcher.as_deref().unwrap_or_default()
+            ),
+            remediation: Some(
+                "write the matcher as plain tool names separated by `|`, or check it against Antigravity's names (`run_command`, `view_file`, `write_to_file`)"
+                    .to_owned(),
+            ),
+        });
+    }
+    Some(registered.hook)
+}

--- a/crates/core/src/engine/desired.rs
+++ b/crates/core/src/engine/desired.rs
@@ -97,7 +97,8 @@ impl Artifact {
         };
         edits.iter().find_map(|(_, edit)| match edit {
             crate::configedit::ConfigEdit::UpsertHook { command, .. }
-            | crate::configedit::ConfigEdit::UpsertCopilotHook { command, .. } => {
+            | crate::configedit::ConfigEdit::UpsertCopilotHook { command, .. }
+            | crate::configedit::ConfigEdit::UpsertAntigravityHook { command, .. } => {
                 Some(command.clone())
             }
             _ => None,

--- a/crates/core/src/engine/desired_kinds.rs
+++ b/crates/core/src/engine/desired_kinds.rs
@@ -146,6 +146,7 @@ pub(super) fn restated_hook_artifact(
     let hook = match harness {
         HarnessId::Gemini => super::gemini::hook(env, scope, name, &hook, state)?,
         HarnessId::Copilot => super::copilot::hook(env, scope, name, &hook, state)?,
+        HarnessId::Antigravity => super::antigravity::hook(name, &hook, state)?,
         _ => hook,
     };
     let target = hook_target(env, scope, harness, name)?;
@@ -153,6 +154,57 @@ pub(super) fn restated_hook_artifact(
         .warnings
         .extend(advisory_notice(env, scope, harness, name));
     Some(hook_artifact(&target, &hook, name, enabled))
+}
+
+/// The registry edit one hook's switch state asks for, in the shape its
+/// registry speaks. Switched off, its own entry comes out and nobody
+/// else's: the matcher it would have gone in under is the matcher it is
+/// taken from, spelled the way a registry spells it, since that is what
+/// it will be looked for by.
+fn registration_edit(
+    format: HookFormat,
+    hook: &HookSpec,
+    name: &str,
+    enabled: bool,
+    registered_command: String,
+) -> ConfigEdit {
+    match (enabled, format) {
+        (true, HookFormat::Nested) => ConfigEdit::UpsertHook {
+            event: hook.event.clone(),
+            matcher: hook.matcher.clone(),
+            command: registered_command,
+            timeout: hook.timeout,
+        },
+        (true, HookFormat::Copilot) => ConfigEdit::UpsertCopilotHook {
+            event: hook.event.clone(),
+            matcher: hook.matcher.clone(),
+            command: registered_command,
+            timeout: hook.timeout,
+        },
+        (true, HookFormat::Antigravity) => ConfigEdit::UpsertAntigravityHook {
+            name: name.to_owned(),
+            event: hook.event.clone(),
+            matcher: hook.matcher.clone(),
+            command: registered_command,
+            timeout: hook.timeout,
+        },
+        (false, HookFormat::Nested) => ConfigEdit::RemoveHook {
+            event: Some(hook.event.clone()),
+            matcher: Some(crate::configedit::spelled(hook.matcher.as_deref()).to_owned()),
+            command: registered_command,
+        },
+        (false, HookFormat::Copilot) => ConfigEdit::RemoveCopilotHook {
+            event: Some(hook.event.clone()),
+            matcher: Some(crate::configedit::spelled(hook.matcher.as_deref()).to_owned()),
+            command: registered_command,
+        },
+        (false, HookFormat::Antigravity) => ConfigEdit::RemoveAntigravityHook {
+            name: Some(name.to_owned()),
+            event: Some(hook.event.clone()),
+            matcher: Some(crate::configedit::spelled(hook.matcher.as_deref()).to_owned()),
+            command: registered_command,
+        },
+    }
 }
 
 /// A disabled hook keeps its file under the `.disabled` name and reverses its
@@ -182,34 +234,7 @@ fn hook_artifact(target: &HookTarget, hook: &HookSpec, name: &str, enabled: bool
                 ),
                 HookBody::Command(command) => (command.clone(), None),
             };
-            let registration = match (enabled, format) {
-                (true, HookFormat::Nested) => ConfigEdit::UpsertHook {
-                    event: hook.event.clone(),
-                    matcher: hook.matcher.clone(),
-                    command: registered_command,
-                    timeout: hook.timeout,
-                },
-                (true, HookFormat::Copilot) => ConfigEdit::UpsertCopilotHook {
-                    event: hook.event.clone(),
-                    matcher: hook.matcher.clone(),
-                    command: registered_command,
-                    timeout: hook.timeout,
-                },
-                // Switched off, its own entry comes out and nobody
-                // else's: the matcher it would have gone in under is the
-                // matcher it is taken from, spelled the way a registry
-                // spells it, since that is what it will be looked for by.
-                (false, HookFormat::Nested) => ConfigEdit::RemoveHook {
-                    event: Some(hook.event.clone()),
-                    matcher: Some(crate::configedit::spelled(hook.matcher.as_deref()).to_owned()),
-                    command: registered_command,
-                },
-                (false, HookFormat::Copilot) => ConfigEdit::RemoveCopilotHook {
-                    event: Some(hook.event.clone()),
-                    matcher: Some(crate::configedit::spelled(hook.matcher.as_deref()).to_owned()),
-                    command: registered_command,
-                },
-            };
+            let registration = registration_edit(*format, hook, name, enabled, registered_command);
             let mut edits = registration_edits(registry, registration, enabled);
             if let Some(feature) = feature
                 && enabled

--- a/crates/core/src/engine/item_record.rs
+++ b/crates/core/src/engine/item_record.rs
@@ -10,6 +10,7 @@ use crate::configedit::ConfigEdit;
 use crate::lock::LockEntry;
 
 use super::desired::{Artifact, Desired};
+use super::targets::HookFormat;
 
 /// What the last pass registered, when that is not what this one names —
 /// the removal a change of identity needs before whatever it renders.
@@ -91,13 +92,19 @@ pub(super) fn retire_previous(item: &Desired, existing: Option<&LockEntry>) -> P
     let event = Some(previous.event);
     let matcher = Some(previous.matcher);
     let command = previous.command;
-    let removal = match named.copilot {
-        true => ConfigEdit::RemoveCopilotHook {
+    let removal = match named.format {
+        HookFormat::Copilot => ConfigEdit::RemoveCopilotHook {
             event,
             matcher,
             command,
         },
-        false => ConfigEdit::RemoveHook {
+        HookFormat::Nested => ConfigEdit::RemoveHook {
+            event,
+            matcher,
+            command,
+        },
+        HookFormat::Antigravity => ConfigEdit::RemoveAntigravityHook {
+            name: named.name.map(str::to_owned),
             event,
             matcher,
             command,
@@ -129,9 +136,10 @@ fn found(named: &Named, event: &str, matcher: Option<&str>, command: &str) -> Fo
     let Ok(Some(text)) = crate::fs::read_if_exists(named.path) else {
         return Found::None;
     };
-    let read = match named.copilot {
-        true => crate::scan::copilot::registrations_text(&text),
-        false => crate::scan::hooks::registrations_text(&text),
+    let read = match named.format {
+        HookFormat::Copilot => crate::scan::copilot::registrations_text(&text),
+        HookFormat::Nested => crate::scan::hooks::registrations_text(&text),
+        HookFormat::Antigravity => crate::scan::antigravity::registrations_text(&text),
     };
     let Ok(entries) = read else {
         return Found::None;
@@ -157,7 +165,10 @@ fn found(named: &Named, event: &str, matcher: Option<&str>, command: &str) -> Fo
 /// The identity one edit names, and where it names it.
 struct Named<'a> {
     path: &'a PathBuf,
-    copilot: bool,
+    format: HookFormat,
+    /// The hook-name key an Antigravity entry sits under; the other
+    /// registries key nothing by name.
+    name: Option<&'a str>,
     event: &'a str,
     /// `None` where the edit names no matcher at all — a removal names an
     /// event and a command and no more. Unknown, never "every operation".
@@ -168,8 +179,8 @@ struct Named<'a> {
 /// The identity this pass names for one item's registration, whichever
 /// way round it names it.
 ///
-/// Four edit shapes carry one: an upsert says where the entry is going, a
-/// removal says where it is being taken from, in each of the two registry
+/// Six edit shapes carry one: an upsert says where the entry is going, a
+/// removal says where it is being taken from, in each of the three registry
 /// formats. Everything else a registration artifact carries names no
 /// entry — a codex feature flag, an opencode instruction reference, an
 /// mcp server, a plugin toggle — so there is nothing about them for a
@@ -184,9 +195,15 @@ fn named(item: &Desired) -> Option<Named<'_>> {
             matcher: named,
             command,
             ..
+        }
+        | ConfigEdit::RemoveHook {
+            event: Some(event),
+            matcher: named,
+            command,
         } => Some(Named {
             path,
-            copilot: false,
+            format: HookFormat::Nested,
+            name: None,
             event,
             matcher: Some(crate::configedit::spelled(named.as_deref())),
             command,
@@ -196,31 +213,42 @@ fn named(item: &Desired) -> Option<Named<'_>> {
             matcher: named,
             command,
             ..
-        } => Some(Named {
-            path,
-            copilot: true,
-            event,
-            matcher: Some(crate::configedit::spelled(named.as_deref())),
-            command,
-        }),
-        ConfigEdit::RemoveHook {
+        }
+        | ConfigEdit::RemoveCopilotHook {
             event: Some(event),
             matcher: named,
             command,
         } => Some(Named {
             path,
-            copilot: false,
+            format: HookFormat::Copilot,
+            name: None,
             event,
             matcher: Some(crate::configedit::spelled(named.as_deref())),
             command,
         }),
-        ConfigEdit::RemoveCopilotHook {
+        ConfigEdit::UpsertAntigravityHook {
+            name,
+            event,
+            matcher: named,
+            command,
+            ..
+        } => Some(Named {
+            path,
+            format: HookFormat::Antigravity,
+            name: Some(name),
+            event,
+            matcher: Some(crate::configedit::spelled(named.as_deref())),
+            command,
+        }),
+        ConfigEdit::RemoveAntigravityHook {
+            name,
             event: Some(event),
             matcher: named,
             command,
         } => Some(Named {
             path,
-            copilot: true,
+            format: HookFormat::Antigravity,
+            name: name.as_deref(),
             event,
             matcher: Some(crate::configedit::spelled(named.as_deref())),
             command,
@@ -274,6 +302,12 @@ pub(super) fn registration(item: &Desired) -> Option<crate::lock::HookRegistrati
             matcher,
             command,
             ..
+        }
+        | ConfigEdit::UpsertAntigravityHook {
+            event,
+            matcher,
+            command,
+            ..
         } => record(event, matcher.as_ref(), command),
         // A disabled hook renders the reversed registration, which names
         // the event and matcher its entry was written under.
@@ -286,6 +320,12 @@ pub(super) fn registration(item: &Desired) -> Option<crate::lock::HookRegistrati
             event: Some(event),
             matcher,
             command,
+        }
+        | ConfigEdit::RemoveAntigravityHook {
+            event: Some(event),
+            matcher,
+            command,
+            ..
         } => record(event, matcher.as_ref(), command),
         _ => None,
     })

--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -8,6 +8,7 @@ use crate::model::Scope;
 pub mod adopt;
 mod agent_carry;
 mod agent_skills;
+mod antigravity;
 pub(crate) mod bundles;
 mod catalog;
 mod config_edits;

--- a/crates/core/src/engine/owned.rs
+++ b/crates/core/src/engine/owned.rs
@@ -133,6 +133,12 @@ fn hook_owned(
             matcher,
             command,
         },
+        HookFormat::Antigravity => ConfigEdit::RemoveAntigravityHook {
+            name: Some(entry.name.clone()),
+            event,
+            matcher,
+            command,
+        },
     };
     match hook_target(env, scope, entry.harness, &entry.name) {
         Some(HookTarget::Script {

--- a/crates/core/src/engine/scoring/input.rs
+++ b/crates/core/src/engine/scoring/input.rs
@@ -102,6 +102,12 @@ fn hook_edit(
             matcher,
             command,
             ..
+        }
+        | ConfigEdit::UpsertAntigravityHook {
+            event,
+            matcher,
+            command,
+            ..
         } => Some((event, matcher, command)),
         _ => None,
     })

--- a/crates/core/src/engine/targets.rs
+++ b/crates/core/src/engine/targets.rs
@@ -29,7 +29,7 @@ pub(super) fn advisory_notice(
                 "this protection is advisory on {tool} — it installs as text the model may ignore, not a check the tool runs"
             ),
             format!(
-                "keep it for the tools that run hooks — Claude Code, Codex, Gemini CLI, GitHub Copilot — or accept it as guidance on {tool}"
+                "keep it for the tools that run hooks — Claude Code, Codex, Gemini CLI, GitHub Copilot, Antigravity — or accept it as guidance on {tool}"
             ),
         ),
     };
@@ -44,11 +44,13 @@ pub(super) fn advisory_notice(
 
 /// Which shape a registry file speaks. Claude, codex, cursor and Gemini all
 /// take the same matcher-with-handlers object; Copilot's hook files are a
-/// `{version, hooks}` document whose entries carry the command themselves.
+/// `{version, hooks}` document whose entries carry the command themselves;
+/// Antigravity's `hooks.json` keys that same nested shape by hook name.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum HookFormat {
     Nested,
     Copilot,
+    Antigravity,
 }
 
 /// Where one hook's artifacts live for a harness at a scope. Install and
@@ -186,8 +188,35 @@ pub(crate) fn hook_target(
         // own roots (`crate::harness::pi::HOOK_HOME`).
         HarnessId::Pi => Some(pi_hook(env, scope, name)),
         HarnessId::Copilot => Some(copilot_hook(env, scope, name)),
-        // `hooks.json` is a registry kendex does not yet write.
-        HarnessId::Antigravity => None,
+        // Antigravity runs `hooks.json` from the customization root at
+        // either scope, the entries keyed by hook name. The loader reads
+        // nothing else from a `hooks/` directory beside it, so the script
+        // sits there. Its documented project variable is none, so the
+        // project command resolves through the repo root itself.
+        HarnessId::Antigravity => Some(antigravity_hook(env, scope, name)),
+    }
+}
+
+/// Antigravity's shape: a script under the customization root, registered
+/// in the `hooks.json` beside it under the hook's own name.
+fn antigravity_hook(env: &Env, scope: &Scope, name: &str) -> HookTarget {
+    let root = match scope {
+        Scope::Global => adapter(HarnessId::Antigravity).default_global_root(env),
+        Scope::Project { root } => root.join(".agents"),
+    };
+    let path = root.join("hooks").join(format!("{name}.sh"));
+    let command = match scope {
+        Scope::Global => format!("bash \"{}\"", crate::paths::slashed(&path)),
+        Scope::Project { .. } => {
+            format!("bash \"$(git rev-parse --show-toplevel)/.agents/hooks/{name}.sh\"")
+        }
+    };
+    HookTarget::Script {
+        path,
+        command,
+        registry: root.join("hooks.json"),
+        format: HookFormat::Antigravity,
+        feature: None,
     }
 }
 

--- a/crates/core/src/engine/targets/tests.rs
+++ b/crates/core/src/engine/targets/tests.rs
@@ -142,6 +142,34 @@ fn a_copilot_hook_gets_a_document_of_its_own_beside_its_script() {
     assert_eq!(registry, PathBuf::from("/h/.copilot/hooks/audit.json"));
 }
 
+/// Antigravity keys its one registry by hook name, so the script sits in
+/// a directory its loader never scans and the entry under the name.
+#[test]
+fn an_antigravity_hook_registers_by_name_in_the_roots_hooks_json() {
+    let env = Env::fake("/h", FakeOs::Linux);
+    let scope = Scope::Project {
+        root: PathBuf::from("/p"),
+    };
+    assert_eq!(
+        hook_target(&env, &scope, HarnessId::Antigravity, "audit"),
+        Some(HookTarget::Script {
+            path: PathBuf::from("/p/.agents/hooks/audit.sh"),
+            command: "bash \"$(git rev-parse --show-toplevel)/.agents/hooks/audit.sh\"".into(),
+            registry: PathBuf::from("/p/.agents/hooks.json"),
+            format: HookFormat::Antigravity,
+            feature: None,
+        })
+    );
+    let Some(HookTarget::Script {
+        command, registry, ..
+    }) = hook_target(&env, &Scope::Global, HarnessId::Antigravity, "audit")
+    else {
+        panic!("antigravity hooks are script targets");
+    };
+    assert_eq!(command, "bash \"/h/.gemini/config/hooks/audit.sh\"");
+    assert_eq!(registry, PathBuf::from("/h/.gemini/config/hooks.json"));
+}
+
 /// The reserved name is one kendex never writes at either scope: pi warns
 /// about a `hooks/` beside a root it loads whatever the directory holds.
 #[test]

--- a/crates/core/src/harness/antigravity.rs
+++ b/crates/core/src/harness/antigravity.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 
 use super::{HarnessAdapter, ProjectMarker, Reader, Surface};
 use crate::env::Env;
+use crate::hook::{HookSpec, Registration};
 use crate::model::{HarnessId, ItemKind};
 
 /// Antigravity CLI (`agy`). Customizations live under one root per scope,
@@ -12,6 +13,31 @@ use crate::model::{HarnessId, ItemKind};
 /// <https://antigravity.google/docs/cli/subagents/>). Settings sit apart
 /// under `~/.gemini/antigravity-cli/`.
 pub struct Antigravity;
+
+/// Antigravity's own hook events, and the fleet event each one answers to
+/// (the CLI's embedded hooks guide, <https://antigravity.google/docs/hooks>).
+/// The three it shares with the fleet are spelled the same way;
+/// `PreInvocation` and `PostInvocation` wrap a model call, which no fleet
+/// event means, so they stay unmapped rather than hung on a near-miss.
+pub(crate) fn event(fleet: &str) -> Option<&'static str> {
+    match fleet {
+        "PreToolUse" => Some("PreToolUse"),
+        "PostToolUse" => Some("PostToolUse"),
+        "Stop" => Some("Stop"),
+        _ => None,
+    }
+}
+
+/// The same hook said in Antigravity's words: its own event name and its
+/// matcher in its own tool names. `None` when it has no event that means
+/// what this one means.
+pub fn hook_for(hook: &HookSpec) -> Option<Registration> {
+    Some(Registration::new(
+        hook,
+        HarnessId::Antigravity,
+        event(&hook.event)?,
+    ))
+}
 
 fn surfaces(kind: ItemKind, root: &Path, shared: Option<&Path>) -> Vec<Surface> {
     match kind {
@@ -29,9 +55,14 @@ fn surfaces(kind: ItemKind, root: &Path, shared: Option<&Path>) -> Vec<Surface> 
             dir: root.join("plugins"),
             marker: "plugin.json",
         }],
-        // Skills are the slash commands; hooks run from `hooks.json`, a
-        // registry kendex neither reads nor writes yet.
-        ItemKind::Command | ItemKind::Hook | ItemKind::PiExtension => vec![],
+        // One registry per scope, keyed by hook name; the scripts kendex
+        // writes sit in a `hooks/` beside it that the loader never scans.
+        ItemKind::Hook => vec![Surface::Structured {
+            path: root.join("hooks.json"),
+            reader: Reader::AntigravityHooks,
+        }],
+        // Skills are the slash commands.
+        ItemKind::Command | ItemKind::PiExtension => vec![],
     }
 }
 
@@ -113,7 +144,17 @@ mod tests {
         );
         assert_eq!(
             Antigravity.project_surfaces(ItemKind::Hook, Path::new("/p"), &env),
-            []
+            [Surface::Structured {
+                path: PathBuf::from("/p/.agents/hooks.json"),
+                reader: Reader::AntigravityHooks,
+            }]
         );
+    }
+
+    #[test]
+    fn only_the_events_antigravity_documents_are_registered() {
+        assert_eq!(event("PreToolUse"), Some("PreToolUse"));
+        assert_eq!(event("Stop"), Some("Stop"));
+        assert_eq!(event("SessionStart"), None);
     }
 }

--- a/crates/core/src/harness/caps.rs
+++ b/crates/core/src/harness/caps.rs
@@ -398,11 +398,12 @@ pub fn capabilities(harness: HarnessId, kind: ItemKind) -> KindCaps {
         (Copilot, PiExtension) => unsupported(),
 
         // Agents load from `agents/*.md` and skills from the shared tree at
-        // either scope. Hooks run from `hooks.json`, a registry kendex
-        // neither reads nor writes yet, so the row is honestly unsupported;
-        // MCP servers and plugins are read and never written.
+        // either scope. Hooks run from `hooks.json` at either scope, the
+        // loader honouring the `decision` a command writes; MCP servers and
+        // plugins are read and never written.
         (Antigravity, Agent | Skill) => managed(BOTH),
-        (Antigravity, Command | Hook) => unsupported(),
+        (Antigravity, Hook) => enforced(managed(BOTH)),
+        (Antigravity, Command) => unsupported(),
         (Antigravity, McpServer) => observe_only(BOTH),
         (Antigravity, Plugin) => observe_only(BOTH),
         (Antigravity, PiExtension) => unsupported(),

--- a/crates/core/src/harness/mod.rs
+++ b/crates/core/src/harness/mod.rs
@@ -134,6 +134,12 @@ pub enum Reader {
     /// themselves, so reading them as `HooksObject` would name every one of
     /// them after nothing (matrix §2, §7).
     CopilotHooks,
+    /// `{"<hook-name>": {enabled?, "<Event>": [group | handler]}}` —
+    /// antigravity's `hooks.json`, one named hook per top-level key with
+    /// its own switch, tool events grouped under a matcher and the rest
+    /// flat. Read as `HooksObject` the file would hold no `hooks` key and
+    /// nothing would be found.
+    AntigravityHooks,
     /// copilot settings `enabledPlugins` — `{"<plugin>@<marketplace>": bool}`
     CopilotPlugins,
     /// `~/.claude/plugins/installed_plugins.json` joined with settings

--- a/crates/core/src/hook/delivery.rs
+++ b/crates/core/src/hook/delivery.rs
@@ -56,8 +56,9 @@ fn event_fires(harness: HarnessId, event: &str) -> bool {
         HarnessId::Pi => crate::harness::pi_listener(event).is_some(),
         HarnessId::Gemini => crate::harness::gemini::event(event).is_some(),
         HarnessId::Copilot => crate::harness::copilot::event(event).is_some(),
+        HarnessId::Antigravity => crate::harness::antigravity::event(event).is_some(),
         // Advisory harnesses never fire anything; enforcement answers first.
-        HarnessId::Opencode | HarnessId::Cursor | HarnessId::Antigravity => true,
+        HarnessId::Opencode | HarnessId::Cursor => true,
     }
 }
 
@@ -161,6 +162,12 @@ mod tests {
                 command("PreToolUse", "all"),
                 Registered,
             ),
+            (
+                "antigravity",
+                &project,
+                command("PreToolUse", "all"),
+                Registered,
+            ),
             ("claude", &global, command("PreToolUse", "all"), Registered),
             // Advisory harnesses stay advisory whatever the spec asks.
             ("opencode", &project, command("PreToolUse", "all"), Advisory),
@@ -182,6 +189,12 @@ mod tests {
                 &project,
                 script("SubagentStop"),
                 NotInstallable("Codex never fires SubagentStop".to_owned()),
+            ),
+            (
+                "antigravity",
+                &project,
+                script("SessionStart"),
+                NotInstallable("Antigravity never fires SessionStart".to_owned()),
             ),
             // Scoped agents: enforced in Claude's own agent file, honest
             // prose everywhere nothing identifies the agent at runtime.

--- a/crates/core/src/render/vocab/mod.rs
+++ b/crates/core/src/render/vocab/mod.rs
@@ -91,9 +91,8 @@ pub fn copilot_tool_name(tool: &str) -> String {
         .unwrap_or_else(|| tool.trim().to_owned())
 }
 
-/// Antigravity's own tool names, the step types its loader lowercases
-/// (<https://antigravity.google/docs/subagents>, the CLI's embedded
-/// customization guide). A name of its own passes through unchanged, so an
+/// Antigravity's own tool names, as the CLI's `init` event lists them
+/// (`agy -p --output-format stream-json`; <https://antigravity.google/docs/subagents>). A name of its own passes through unchanged, so an
 /// author may write either vocabulary.
 fn antigravity_tool(tool: &str) -> Option<&'static str> {
     Some(match normalize(tool).as_str() {
@@ -109,8 +108,7 @@ fn antigravity_tool(tool: &str) -> Option<&'static str> {
         "websearch" | "searchweb" => "search_web",
         "task" | "agent" | "subagent" | "spawnagent" | "invokesubagent" => "invoke_subagent",
         "question" | "askuserquestion" | "askquestion" => "ask_question",
-        "notebookread" | "readnotebook" => "read_notebook",
-        "notebookedit" | "editnotebook" => "edit_notebook",
+        "notebookedit" => "notebook_edit",
         _ => return None,
     })
 }

--- a/crates/core/src/render/vocab/mod.rs
+++ b/crates/core/src/render/vocab/mod.rs
@@ -134,6 +134,13 @@ pub fn hook_matcher(matcher: &str, harness: HarnessId) -> (String, bool) {
     let name = match harness {
         HarnessId::Gemini => gemini_tool_name,
         HarnessId::Copilot => copilot_tool_name,
+        // A matcher is a regex, and an alternative it cannot say leaves
+        // the pattern narrower, never wider, so here the name stands.
+        HarnessId::Antigravity => |tool: &str| {
+            antigravity_tool(tool)
+                .map(str::to_owned)
+                .unwrap_or_else(|| tool.trim().to_owned())
+        },
         // Claude's own names are what a matcher is authored in; codex and
         // cursor read the same spelling, and the rest register no matcher.
         _ => return (matcher.to_owned(), true),

--- a/crates/core/src/render/vocab/tests.rs
+++ b/crates/core/src/render/vocab/tests.rs
@@ -363,6 +363,14 @@ fn a_hook_matcher_is_restated_alternative_by_alternative() {
         ("bash".to_owned(), true)
     );
     assert_eq!(
+        hook_matcher("Bash|Write", HarnessId::Antigravity),
+        ("run_command|write_to_file".to_owned(), true)
+    );
+    assert_eq!(
+        hook_matcher("mcp__gh", HarnessId::Antigravity),
+        ("mcp__gh".to_owned(), true)
+    );
+    assert_eq!(
         hook_matcher("Bash|Write", HarnessId::Gemini),
         ("run_shell_command|write_file".to_owned(), true)
     );

--- a/crates/core/src/scan/antigravity.rs
+++ b/crates/core/src/scan/antigravity.rs
@@ -1,0 +1,91 @@
+use std::path::Path;
+
+use serde_json::Value;
+
+use super::RawEntry;
+use super::hooks::{Registration, registrations_in};
+use super::readers::read_json;
+
+/// `{"<hook-name>": {enabled?, "<Event>": [group | handler]}}` — Antigravity's
+/// `hooks.json`, one named hook per top-level key. `PreToolUse` and
+/// `PostToolUse` nest handlers under a matcher group the way claude's
+/// settings do; the other events hold handlers directly (the CLI's embedded
+/// hooks guide, <https://antigravity.google/docs/hooks>). A name switched off
+/// by `enabled: false` is read with every handler off — a hook that will not
+/// run must not read as one that will.
+pub fn read(path: &Path) -> Result<Vec<RawEntry>, String> {
+    let value = read_json(path)?;
+    let Some(named) = value.as_object() else {
+        return Ok(Vec::new());
+    };
+    let mut entries = Vec::new();
+    for (_, hook) in named {
+        let Some(hook) = hook.as_object() else {
+            continue;
+        };
+        let enabled = hook.get("enabled").and_then(Value::as_bool).unwrap_or(true);
+        for registration in registrations_in(hook) {
+            entries.push(RawEntry {
+                name: registration.name(),
+                enabled: Some(enabled),
+                description: Some(registration.command),
+                source_path: None,
+            });
+        }
+    }
+    Ok(entries)
+}
+
+/// Every registration in one document, in its parts — the structured view
+/// of the same reading, for anything asking which entry is which.
+pub(crate) fn registrations_text(text: &str) -> Result<Vec<Registration>, String> {
+    let value: Value =
+        serde_json::from_str(&super::jsonc::to_json(text)).map_err(|e| e.to_string())?;
+    let Some(named) = value.as_object() else {
+        return Ok(Vec::new());
+    };
+    Ok(named
+        .values()
+        .filter_map(Value::as_object)
+        .flat_map(registrations_in)
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grouped_and_flat_events_read_under_their_hook_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("hooks.json");
+        std::fs::write(
+            &path,
+            r#"{
+              "lint": {"PostToolUse": [{"matcher": "run_command", "hooks": [{"type": "command", "command": "./scripts/lint.sh", "timeout": 10}]}]},
+              "gate": {"enabled": false, "PreToolUse": [{"matcher": "run_command", "hooks": [{"command": "./scripts/safety-check.sh"}]}]},
+              "wrap": {"Stop": [{"type": "command", "command": "./scripts/wrap.sh"}]}
+            }"#,
+        )
+        .unwrap();
+        let entries = read(&path).unwrap();
+        let rows: Vec<_> = entries
+            .iter()
+            .map(|e| (e.name.as_str(), e.enabled))
+            .collect();
+        assert_eq!(
+            rows,
+            [
+                ("PostToolUse:run_command:lint", Some(true)),
+                ("PreToolUse:run_command:safety-check", Some(false)),
+                ("Stop:*:wrap", Some(true)),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_document_that_is_not_a_map_of_hooks_holds_none() {
+        assert_eq!(registrations_text("[]").unwrap(), []);
+        assert_eq!(registrations_text(r#"{"lint": 3}"#).unwrap(), []);
+    }
+}

--- a/crates/core/src/scan/hooks.rs
+++ b/crates/core/src/scan/hooks.rs
@@ -95,9 +95,17 @@ fn rows(registrations: Vec<Registration>) -> Vec<RawEntry> {
 }
 
 fn registrations(value: serde_json::Value) -> Vec<Registration> {
-    let Some(events) = value.get("hooks").and_then(|h| h.as_object()) else {
-        return Vec::new();
-    };
+    match value.get("hooks").and_then(|h| h.as_object()) {
+        Some(events) => registrations_in(events),
+        None => Vec::new(),
+    }
+}
+
+/// Every registration under one map of event name to its groups — the part
+/// of the shape that Antigravity's named hooks share with the `hooks` key.
+pub(crate) fn registrations_in(
+    events: &serde_json::Map<String, serde_json::Value>,
+) -> Vec<Registration> {
     let mut found = Vec::new();
     for (event, groups) in events {
         let Some(groups) = groups.as_array() else {

--- a/crates/core/src/scan/mod.rs
+++ b/crates/core/src/scan/mod.rs
@@ -8,6 +8,7 @@ use crate::harness::{HarnessAdapter, Surface, all_adapters};
 use crate::model::{DetectedHarness, FileState, ItemKind, ObservedItem, Scope};
 use crate::settings::AppSettings;
 
+pub(crate) mod antigravity;
 pub(crate) mod copilot;
 mod files;
 pub(crate) mod hooks;

--- a/crates/core/src/scan/readers.rs
+++ b/crates/core/src/scan/readers.rs
@@ -58,7 +58,7 @@ fn mcp_object(servers: Option<&serde_json::Value>) -> Vec<RawEntry> {
 
 /// The command or URL — how a list view tells servers apart.
 fn mcp_summary(entry: &serde_json::Value) -> Option<String> {
-    for key in ["command", "url"] {
+    for key in ["command", "url", "serverUrl"] {
         if let Some(value) = entry.get(key).and_then(|v| v.as_str()) {
             return Some(value.to_owned());
         }

--- a/crates/core/src/scan/readers.rs
+++ b/crates/core/src/scan/readers.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use super::{RawEntry, copilot, hooks, jsonc, plugins};
+use super::{RawEntry, antigravity, copilot, hooks, jsonc, plugins};
 use crate::env::Env;
 use crate::fs::read_if_exists;
 use crate::harness::Reader;
@@ -24,6 +24,7 @@ pub fn read_structured(path: &Path, reader: &Reader, env: &Env) -> Result<Vec<Ra
         Reader::OpencodePluginRefs => opencode_plugin_refs(path),
         Reader::HooksObject => hooks::read(path),
         Reader::CopilotHooks => copilot::read(path),
+        Reader::AntigravityHooks => antigravity::read(path),
         Reader::CopilotPlugins => copilot::plugins(path),
         Reader::ClaudePluginRegistry => plugins::claude_registry(path, env),
         Reader::ClaudeSettingsPlugins => plugins::claude_settings(path),

--- a/crates/core/tests/antigravity.rs
+++ b/crates/core/tests/antigravity.rs
@@ -1,0 +1,265 @@
+//! Antigravity as a managed tool: an agent, a skill and a hook each install
+//! in the shape its loader reads, switch on and off without losing
+//! anything, and come off disk on request — leaving the keys around ours in
+//! its registry untouched.
+#![cfg(unix)]
+
+#[path = "../../test_util.rs"]
+mod test_util;
+use test_util::{rooted, source_path};
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use kendex_core::apply;
+use kendex_core::engine::{EngineReport, audit, ops};
+use kendex_core::env::{Env, FakeOs};
+use kendex_core::model::Scope;
+use serde_json::Value;
+
+const AGENT: &str = "---\nname: rust\ndescription: Rust engineer\nmodel: opus\nrole: engineer\n---\nUse the Grep tool.\n";
+
+const AUDIT_HOOK: &str = "#!/usr/bin/env bash\n# ---\n# name: audit\n# event: PreToolUse\n# matcher: Bash\n# description: log shell commands\n# timeout: 10\n# ---\nexit 0\n";
+
+const COMMAND: &str = "---\ndescription: Ship the branch\n---\n\nRun the checklist.\n";
+
+struct Fixture {
+    _tmp: tempfile::TempDir,
+    env: Env,
+    scope: Scope,
+    project: PathBuf,
+}
+
+/// An antigravity-only project whose catalog carries one of everything;
+/// `declarations` is appended to the manifest verbatim.
+#[allow(clippy::unwrap_used)]
+fn fixture(declarations: &str) -> Fixture {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let env = Env::fake(&home, FakeOs::Linux);
+    let project = home.join("dev/app");
+    fs::create_dir_all(project.join(".agents/agents")).unwrap();
+    fs::create_dir_all(home.join(".gemini/config")).unwrap();
+
+    let source = home.join("catalog");
+    for dir in ["agents", "hooks", "commands", "skills/deploy"] {
+        fs::create_dir_all(source.join(dir)).unwrap();
+    }
+    fs::write(
+        source.join("skills/deploy/SKILL.md"),
+        "---\nname: deploy\ndescription: Ship it\n---\n\nSteps.\n",
+    )
+    .unwrap();
+    fs::write(source.join("agents/rust.md"), AGENT).unwrap();
+    fs::write(source.join("hooks/audit.sh"), AUDIT_HOOK).unwrap();
+    fs::write(source.join("commands/ship.md"), COMMAND).unwrap();
+    fs::write(source.join("kendex.toml"), "is_source_catalog = true\n").unwrap();
+
+    fs::write(
+        project.join("kendex.toml"),
+        format!(
+            "schema = 6\n\n[sources.cat]\n{}\n\n[install]\nharnesses = [\"antigravity\"]\nmethod = \"symlink\"\n\n{declarations}",
+            source_path(&source)
+        ),
+    )
+    .unwrap();
+
+    Fixture {
+        env,
+        scope: Scope::Project {
+            root: project.clone(),
+        },
+        project,
+        _tmp: tmp,
+    }
+}
+
+#[allow(clippy::unwrap_used)]
+fn apply_now(f: &Fixture) -> EngineReport {
+    let report = audit(&f.env, &f.scope).unwrap();
+    apply::execute(&f.env, &report.plan).unwrap();
+    report
+}
+
+#[allow(clippy::unwrap_used)]
+fn toggle(f: &Fixture, name: &str, enabled: bool) {
+    let report = ops::toggle(&f.env, &f.scope, &[name.to_owned()], None, enabled).unwrap();
+    apply::execute(&f.env, &report.plan).unwrap();
+}
+
+#[allow(clippy::unwrap_used)]
+fn remove(f: &Fixture, name: &str) {
+    let report = ops::remove(&f.env, &f.scope, &[name.to_owned()], None, false).unwrap();
+    apply::execute(&f.env, &report.plan).unwrap();
+}
+
+#[allow(clippy::unwrap_used)]
+fn json(path: &Path) -> Value {
+    serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap()
+}
+
+#[allow(clippy::unwrap_used)]
+fn is_clean(f: &Fixture) -> bool {
+    audit(&f.env, &f.scope).unwrap().drift.is_empty()
+}
+
+/// The drift rows by name and state — what a pass over a registry holding
+/// somebody else's entry reports.
+#[allow(clippy::unwrap_used)]
+fn drift(f: &Fixture) -> Vec<(String, kendex_core::engine::DriftState)> {
+    audit(&f.env, &f.scope)
+        .unwrap()
+        .drift
+        .into_iter()
+        .map(|row| (row.name, row.state))
+        .collect()
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_agent_installs_in_the_loaders_tier_and_toggles_by_rename() {
+    let f = fixture("[agents.rust]\nsource = \"cat\"\n");
+    apply_now(&f);
+
+    let file = f.project.join(".agents/agents/rust.md");
+    let text = fs::read_to_string(&file).unwrap();
+    assert!(
+        text.starts_with(
+            "---\nname: rust\ndescription: \"Rust engineer\"\nmodel: pro\nsubagent: true\n---\n"
+        ),
+        "{text}"
+    );
+    assert!(text.contains("Use the grep_search tool."), "{text}");
+    assert!(is_clean(&f));
+
+    toggle(&f, "rust", false);
+    assert!(!file.exists());
+    let parked = f.project.join(".agents/agents/rust.md.disabled");
+    assert_eq!(fs::read_to_string(&parked).unwrap(), text);
+    assert!(is_clean(&f));
+
+    toggle(&f, "rust", true);
+    assert!(file.is_file() && !parked.exists());
+
+    remove(&f, "rust");
+    assert!(!file.exists() && !parked.exists());
+}
+
+/// The project's `.agents/skills` is the one tree Antigravity, Codex and
+/// Pi all read, so a skill goes there and nowhere else.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_skill_installs_into_the_shared_tree() {
+    let f = fixture("[skills.deploy]\nsource = \"cat\"\n");
+    apply_now(&f);
+
+    let marker = f.project.join(".agents/skills/deploy/SKILL.md");
+    assert!(fs::read_to_string(&marker).unwrap().contains("Steps."));
+    assert!(is_clean(&f));
+
+    toggle(&f, "deploy", false);
+    assert!(!marker.exists());
+    assert!(
+        f.project
+            .join(".agents/skills/deploy/SKILL.md.disabled")
+            .exists()
+    );
+    assert!(is_clean(&f));
+
+    remove(&f, "deploy");
+    assert!(!f.project.join(".agents/skills/deploy").exists());
+}
+
+/// The registry is one file keyed by hook name, so the entry goes under
+/// ours, in Antigravity's tool names, and comes out with the name when it
+/// is the last thing under it. Somebody else's name in the same file is
+/// theirs: reported as unmanaged, never touched.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_hook_registers_under_its_name_in_the_roots_hooks_json() {
+    let f = fixture("[hooks.audit]\nsource = \"cat\"\n");
+    let registry = f.project.join(".agents/hooks.json");
+    fs::write(
+        &registry,
+        "{\n  \"lint\": {\"PostToolUse\": [{\"matcher\": \"run_command\", \"hooks\": [{\"command\": \"./lint.sh\"}]}]}\n}\n",
+    )
+    .unwrap();
+    apply_now(&f);
+
+    let script = f.project.join(".agents/hooks/audit.sh");
+    assert!(script.is_file());
+    let registered = json(&registry);
+    let group = &registered["audit"]["PreToolUse"][0];
+    // The same `Bash` the source declares, said in Antigravity's tool
+    // names — a regex of Claude's spelling would match nothing.
+    assert_eq!(group["matcher"], "run_command");
+    let entry = &group["hooks"][0];
+    assert_eq!(entry["type"], "command");
+    assert_eq!(
+        entry["command"],
+        "bash \"$(git rev-parse --show-toplevel)/.agents/hooks/audit.sh\""
+    );
+    assert_eq!(entry["timeout"], 10);
+    assert_eq!(
+        registered["lint"]["PostToolUse"][0]["hooks"][0]["command"],
+        "./lint.sh"
+    );
+    let theirs = vec![(
+        "PostToolUse:run_command:lint".to_owned(),
+        kendex_core::engine::DriftState::Unmanaged,
+    )];
+    assert_eq!(drift(&f), theirs);
+
+    toggle(&f, "audit", false);
+    let off = json(&registry);
+    assert!(off.get("audit").is_none(), "{off}");
+    assert_eq!(off["lint"]["PostToolUse"][0]["matcher"], "run_command");
+    assert!(f.project.join(".agents/hooks/audit.sh.disabled").is_file());
+    assert_eq!(drift(&f), theirs);
+
+    toggle(&f, "audit", true);
+    assert_eq!(json(&registry), registered);
+
+    remove(&f, "audit");
+    assert!(!script.exists());
+    let after = json(&registry);
+    assert!(after.get("audit").is_none(), "{after}");
+    assert_eq!(after["lint"]["PostToolUse"][0]["matcher"], "run_command");
+}
+
+/// What kendex writes is what kendex reads back: the scan finds the entry
+/// under the hook's name in the one registry the loader reads.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_registered_hook_is_read_back_from_the_registry() {
+    let f = fixture("[hooks.audit]\nsource = \"cat\"\n");
+    apply_now(&f);
+
+    let scanned = kendex_core::scan::scan_scopes(
+        &f.env,
+        &std::collections::BTreeMap::new(),
+        std::slice::from_ref(&f.scope),
+    );
+    assert_eq!(scanned.warnings, Vec::<String>::new());
+    let hooks: Vec<_> = scanned
+        .items
+        .iter()
+        .filter(|item| {
+            item.harness == kendex_core::model::HarnessId::Antigravity
+                && item.kind == kendex_core::model::ItemKind::Hook
+        })
+        .map(|item| (item.name.as_str(), item.enabled))
+        .collect();
+    assert_eq!(hooks, [("PreToolUse:run_command:audit", Some(true))]);
+}
+
+/// A skill is Antigravity's slash command, so a command declared for it
+/// produces nothing at all rather than a dead file.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_command_declared_for_antigravity_writes_nothing() {
+    let f = fixture("[commands.ship]\nsource = \"cat\"\n");
+    apply_now(&f);
+    assert!(!f.project.join(".agents/commands").exists());
+    assert!(is_clean(&f));
+}

--- a/crates/core/tests/antigravity.rs
+++ b/crates/core/tests/antigravity.rs
@@ -263,3 +263,34 @@ fn a_command_declared_for_antigravity_writes_nothing() {
     assert!(!f.project.join(".agents/commands").exists());
     assert!(is_clean(&f));
 }
+
+/// A remote server in `mcp_config.json` names its endpoint `serverUrl`, and
+/// the read-only list shows that endpoint rather than a bare name.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_remote_server_is_listed_by_its_endpoint() {
+    let f = fixture("");
+    fs::write(
+        f.project.join(".agents/mcp_config.json"),
+        r#"{"mcpServers": {"docs": {"serverUrl": "https://docs.example/sse"}, "gh": {"command": "gh-mcp"}}}"#,
+    )
+    .unwrap();
+    let scanned = kendex_core::scan::scan_scopes(
+        &f.env,
+        &std::collections::BTreeMap::new(),
+        std::slice::from_ref(&f.scope),
+    );
+    let servers: Vec<_> = scanned
+        .items
+        .iter()
+        .filter(|item| item.kind == kendex_core::model::ItemKind::McpServer)
+        .map(|item| (item.name.as_str(), item.description.as_deref()))
+        .collect();
+    assert_eq!(
+        servers,
+        [
+            ("docs", Some("https://docs.example/sse")),
+            ("gh", Some("gh-mcp")),
+        ]
+    );
+}

--- a/docs/adapters/antigravity.md
+++ b/docs/adapters/antigravity.md
@@ -1,6 +1,6 @@
 # Antigravity
 
-Google's Antigravity CLI (`agy`). One customization layout under a root per scope, an agent file with the loader's own two tiers, and a hook registry kendex does not yet read or write. Owner: `crates/core/src/harness/antigravity.rs`.
+Google's Antigravity CLI (`agy`). One customization layout under a root per scope, an agent file with the loader's own two tiers, and one hook registry per scope keyed by hook name. Owner: `crates/core/src/harness/antigravity.rs`.
 
 ## Roots
 
@@ -20,7 +20,7 @@ Project markers: `.agents/agents/`, `.agents/rules/`, `.agents/hooks.json`, `.ag
 | agent | `~/.gemini/config/agents/*.md` | `.agents/agents/*.md` | managed, both |
 | skill | `~/.gemini/config/skills/<name>/SKILL.md` | `.agents/skills/<name>/SKILL.md`, shared with Codex and Pi | managed, both |
 | command | — | — | unsupported: a skill is the slash command |
-| hook | `~/.gemini/config/hooks.json` | `.agents/hooks.json` | unsupported until kendex reads and writes the registry |
+| hook | `~/.gemini/config/hooks.json`, scripts under `~/.gemini/config/hooks/` | `.agents/hooks.json`, scripts under `.agents/hooks/` | managed, both, enforced |
 | mcp-server | `~/.gemini/config/mcp_config.json` | `.agents/mcp_config.json` | observe only, both |
 | plugin | `~/.gemini/config/plugins/<name>/plugin.json` | `.agents/plugins/<name>/plugin.json` | observe only, both |
 | pi-extension | — | — | unsupported |
@@ -32,12 +32,16 @@ Project markers: `.agents/agents/`, `.agents/rules/`, `.agents/hooks.json`, `.ag
 - Agent file: YAML frontmatter and a markdown body, `<name>.md`. Fields written: `name`, `description`, `model` (only when a tier was asked for), `subagent: true`, `tools` (allowlist) (`crates/core/src/render/agent/antigravity.rs`). Skills travel as prose: the frontmatter's `skills:` list names paths under the customization root, and kendex does not yet write it. An agent may also be a directory, `agents/<name>/agent.md`; kendex writes the file form and reads the directory form as the item `<name>/agent`.
 - Model dialect: `inherit` omits the key; `fable` and `opus` are `pro`, `sonnet` and `haiku` are `flash`; any other value is refused at render, since the loader reads no ids (`crates/core/src/harness/models.rs`, `crates/core/src/render/validate/agent.rs`). The file has no effort key, so an effort setting renders nothing; the session's `--effort` (`low`, `medium`, `high`) and the model's own `-high`/`-medium`/`-low` id suffix decide reasoning.
 - Permissions: an allowlist renders as `tools:` in Antigravity's own names; a name it has no word for is left out with a warning, since its documentation says an unknown name in the list can hang the subagent; a deny list cannot be expressed and warns.
-- Tool vocabulary: Antigravity's own names, the lowercased step types (`view_file`, `grep_search`, `run_command`, `replace_file_content`, `write_to_file`, `find_by_name`, `list_dir`, `read_url_content`, `search_web`, `invoke_subagent`, `ask_question`); prose is restated in them (`crates/core/src/render/vocab/mod.rs`).
+- Tool vocabulary: Antigravity's own names, the lowercased step types (`view_file`, `grep_search`, `run_command`, `replace_file_content`, `write_to_file`, `find_by_name`, `list_dir`, `read_url_content`, `search_web`, `invoke_subagent`, `ask_question`); prose and hook matchers are restated in them (`crates/core/src/render/vocab/mod.rs`).
 
 ## Hooks
 
-Antigravity fires `PreToolUse`, `PostToolUse`, `PreInvocation`, `PostInvocation` and `Stop` from `hooks.json`, a map of hook names to event lists in the matcher-plus-handlers shape, with JSON on stdin and a `decision` on stdout (<https://antigravity.google/docs/hooks>). kendex does not yet read or write that registry, so the capability table says hooks are unsupported here. Reading and writing it natively is the open follow-up; `PreToolUse`, `PostToolUse` and `Stop` map to the fleet events by name.
+Antigravity runs `hooks.json` from the customization root at either scope, one named hook per top-level key: `{"<name>": {"enabled": true, "PreToolUse": [{"matcher": "run_command", "hooks": [{"type": "command", "command": "...", "timeout": 30}]}], "Stop": [{"command": "..."}]}}` (the CLI's embedded hooks guide, <https://antigravity.google/docs/hooks>). `PreToolUse` and `PostToolUse` group handlers under a matcher regex over its tool names; `PreInvocation`, `PostInvocation` and `Stop` hold handlers directly. `timeout` is seconds. A command runs through `sh -c` with the registry's directory as its working directory and JSON on stdin; a `PreToolUse` command answers with `{"decision": "allow" | "deny" | "ask" | "force_ask"}` on stdout, a `Stop` command with `{"decision": "continue"}` to keep the loop running, the rest with `{}`. A hook written for another tool's payload and exit-code contract does not speak this one; a catalog hook names the harnesses whose contract it reads in its `harnesses:` line.
+
+Event map (`crates/core/src/harness/antigravity.rs`): `PreToolUse`, `PostToolUse` and `Stop` by name; `PreInvocation` and `PostInvocation` have no fleet counterpart and stay unmapped, with a note. Each hook registers under its own name, `<name>.<event>`, with the script at `hooks/<name>.sh` beside the registry; at project scope the command resolves through `$(git rev-parse --show-toplevel)`. Disabling renames the script to `.disabled` and takes the entry out; the last entry out takes the name with it (`crates/core/src/configedit/antigravity.rs`). The scan reads a name's `enabled: false` as every handler under it off.
+
+Agent scoping: none; only `agents = "all"` custom hooks are enforced.
 
 ## Not supported
 
-Commands (a skill is the slash command), hooks, Pi extensions, writing MCP servers or plugins, and the `skills:` frontmatter list.
+Commands (a skill is the slash command), Pi extensions, writing MCP servers or plugins, and the `skills:` frontmatter list.


### PR DESCRIPTION
Part 4 of the agent-effort block (KEN-1233), second PR. Held for the overseer; the local reviewer round for the harness ran on #2166, and this PR's editor and reader carry their own unit and integration controls.

What lands:
- `Reader::AntigravityHooks` and `crates/core/src/scan/antigravity.rs`: `hooks.json` reads as one named hook per top-level key, tool events grouped under a matcher and the rest flat, a name's `enabled: false` reading as every handler under it off.
- `HookFormat::Antigravity` with `ConfigEdit::UpsertAntigravityHook` and `RemoveAntigravityHook` (`crates/core/src/configedit/antigravity.rs`): a hook registers under its own name, `<name>.<event>`, and the last handler out takes the name with it; an unnamed removal serves adoption of a foreign entry.
- Hook target: script at `hooks/<name>.sh` under the customization root, registry `hooks.json` beside it, both scopes; caps `enforced(managed(BOTH))`.
- Event map `PreToolUse`, `PostToolUse`, `Stop`; `PreInvocation` and `PostInvocation` stay unmapped with a note. Matchers and prose in Antigravity's tool names (`hook_matcher` arm).
- Every explicit match on the hook edit variants (desired, item_record, scoring, owned, adopt) takes the new ones, so a registered hook reads as kendex's own and is retired on a move.
- `mcp_summary` reads `serverUrl`, so a remote Antigravity server lists by its endpoint (raised by the bots on #2166).
- Tool-name table corrected against the live `init` list of `agy -p --output-format stream-json` (`notebook_edit`; no notebook reader).
- Docs: `docs/adapters/antigravity.md` § Hooks, README hooks row; changelog fragment.
- Tests: `crates/core/tests/antigravity.rs` at the Copilot adapter's level (agent, skill, hook register/toggle/remove with a foreign name left alone, scan read-back, command writes nothing, remote server endpoint).

Pi and `.agents/hooks/`: `docs/architecture/harnesses.md` invariant 6 says Pi reserves `hooks/` beside every root it loads, and Pi reads `<project>/.agents` as a shared root. Checked against Pi 0.85.1 (the mise install): `checkDeprecatedExtensionDirs(baseDir)` is the only `hooks/` check and `migrateExtensionSystem` calls it for exactly two directories, `getAgentDir()` (`~/.pi/agent`) and `join(cwd, CONFIG_DIR_NAME)` with `CONFIG_DIR_NAME` read from `package.json` `piConfig.configDir` = `.pi`. Every other `.agents` read in the binary is `.agents/skills` (skill discovery under home and each ancestor). `crates/core/tests/pi_carrier.rs::nothing_lands_in_the_directory_names_pi_reserved` asserts only `.pi/hooks`. So `.agents/hooks/` is neither scanned nor reserved by Pi, and Antigravity's script directory stays where Antigravity documents it (`<workspace>/.agents/hooks.json` per the CLI changelog, scripts beside it).

Live probe of the hook contract (agy 1.1.27, workspace added with `--add-dir`): a `PreToolUse` command writing `{"decision":"deny"}` blocks `run_command`; a command exiting 2 with stderr text also blocks it. The payload is `toolCall.args.CommandLine`, not `tool_input.command`; the consequence for catalog hooks without a `harnesses:` line goes in the follow-up commit on the next PR (see the Codex thread on `caps.rs`).

Checks: `cargo test -p kendex-core -p kendex-cli -p kendex-app` green on the restacked branch; clippy, fmt, pre-commit chain clean.

Tracking: KEN-1233

https://claude.ai/code/session_011qRAkAD4obmNzrVnokoRZf
