### PR TITLE
feat(KEN-1242): commands install on OpenCode as commands/<name>.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Installing a package from a git repository needs git 2.41 or newer; kendex refus
 | Agents | ● | ● | ● | ●¹ | ● | ● | ● | ● |
 | Skills | ● | ● | ● | ●¹ | ● | ● | ● | ● |
 | Hooks | ● | ● | ●² | ●¹ ² | ●³ | ● | ● | ● |
-| Commands | ● | ●⁴ | ○ | ○ | ● | ● | - | - |
+| Commands | ● | ●⁴ | ● | ○ | ● | ● | - | - |
 | MCP servers | ● | ○ | ○ | ○ | - | ●⁵ | ● | ○ |
 | Plugins | ◐ | ○ | ○ | ○ | - | ○ | ◐ | ○ |
 | Pi extensions | - | - | - | - | ● | - | - | - |

--- a/changelog.d/added/KEN-1242-opencode-commands.md
+++ b/changelog.d/added/KEN-1242-opencode-commands.md
@@ -1,0 +1,1 @@
+- Commands install on OpenCode as `commands/<name>.md` at both scopes, with the rename toggle and removal every managed kind has.

--- a/crates/core/src/harness/caps.rs
+++ b/crates/core/src/harness/caps.rs
@@ -318,7 +318,12 @@ pub fn capabilities(harness: HarnessId, kind: ItemKind) -> KindCaps {
         // artifacts are observable — opencode has no native hook surface, so
         // nothing here runs.
         (Opencode, Hook) => advisory(managed(BOTH)),
-        (Opencode, Command) => observe_only(BOTH),
+        // A command is one `commands/<name>.md` at either scope, read with
+        // the same frontmatter keys and `$ARGUMENTS`, `$1`, !`…` and `@file`
+        // expansions a Claude command carries, unknown keys dropped; only
+        // `.md` loads, so the author's file installs as is and the rename
+        // toggle is safe (opencode.ai/docs/commands, checked on 1.18.29).
+        (Opencode, Command) => managed(BOTH),
         (Opencode, McpServer) => observe_only(BOTH),
         (Opencode, Plugin) => observe_only(BOTH),
         (Opencode, PiExtension) => unsupported(),

--- a/crates/core/tests/commands.rs
+++ b/crates/core/tests/commands.rs
@@ -269,15 +269,12 @@ fn removing_a_command_takes_the_generated_skill_with_it() {
 #[test]
 #[allow(clippy::unwrap_used)]
 fn harnesses_that_only_read_commands_get_nothing_written() {
-    let f = fixture(
-        "\"opencode\", \"cursor\"",
-        "[commands.ship]\nsource = \"cat\"\n",
-    );
+    let f = fixture("\"cursor\"", "[commands.ship]\nsource = \"cat\"\n");
     let report = audit(&f.env, &f.scope).unwrap();
     assert!(report.plan.ops.is_empty(), "{:?}", report.plan.ops);
     apply::execute(&f.env, &report.plan).unwrap();
 
-    for dir in [".opencode", ".cursor", ".agents"] {
+    for dir in [".cursor", ".agents"] {
         assert!(!f.project.join(dir).exists(), "{dir} was written to");
     }
 }

--- a/crates/core/tests/opencode_commands.rs
+++ b/crates/core/tests/opencode_commands.rs
@@ -1,0 +1,177 @@
+//! OpenCode as a managed tool for commands: a declared command installs as
+//! the markdown OpenCode reads, byte for byte, at either scope; switches off
+//! by the rename its `.md`-only glob makes safe; comes off disk on request;
+//! is read back from the same directory; and the name is the filename, with
+//! no rule of the loader's to answer to.
+#![cfg(unix)]
+
+#[path = "../../test_util.rs"]
+mod test_util;
+use test_util::{rooted, source_path};
+
+use std::fs;
+use std::path::PathBuf;
+
+use kendex_core::apply;
+use kendex_core::engine::{EngineReport, audit, ops};
+use kendex_core::env::{Env, FakeOs};
+use kendex_core::model::{HarnessId, ItemKind, Scope};
+
+const SHIP: &str = "---\ndescription: Ship the branch\nagent: build\n---\n\nRelease $1 with $ARGUMENTS.\n\n!`git status --short`\n";
+
+struct Fixture {
+    _tmp: tempfile::TempDir,
+    env: Env,
+    scope: Scope,
+    project: PathBuf,
+    source: PathBuf,
+}
+
+/// An OpenCode-only project whose catalog carries the `ship` command under
+/// two spellings; `declarations` is appended to the manifest verbatim.
+#[allow(clippy::unwrap_used)]
+fn fixture(declarations: &str) -> Fixture {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let env = Env::fake(&home, FakeOs::Linux);
+    let project = home.join("dev/app");
+    fs::create_dir_all(project.join(".opencode")).unwrap();
+    fs::create_dir_all(home.join(".config/opencode")).unwrap();
+
+    let source = home.join("catalog");
+    fs::create_dir_all(source.join("commands")).unwrap();
+    fs::write(source.join("commands/ship.md"), SHIP).unwrap();
+    fs::write(source.join("commands/Ship_It.md"), SHIP).unwrap();
+    fs::write(source.join("kendex.toml"), "is_source_catalog = true\n").unwrap();
+
+    fs::write(
+        project.join("kendex.toml"),
+        format!(
+            "schema = 6\n\n[sources.cat]\n{}\n\n[install]\nharnesses = [\"opencode\"]\nmethod = \"symlink\"\n\n{declarations}",
+            source_path(&source)
+        ),
+    )
+    .unwrap();
+
+    Fixture {
+        env,
+        scope: Scope::Project {
+            root: project.clone(),
+        },
+        project,
+        source,
+        _tmp: tmp,
+    }
+}
+
+#[allow(clippy::unwrap_used)]
+fn apply_now(f: &Fixture) -> EngineReport {
+    let report = audit(&f.env, &f.scope).unwrap();
+    apply::execute(&f.env, &report.plan).unwrap();
+    report
+}
+
+#[allow(clippy::unwrap_used)]
+fn toggle(f: &Fixture, name: &str, enabled: bool) {
+    let report = ops::toggle(&f.env, &f.scope, &[name.to_owned()], None, enabled).unwrap();
+    apply::execute(&f.env, &report.plan).unwrap();
+}
+
+#[allow(clippy::unwrap_used)]
+fn remove(f: &Fixture, name: &str) {
+    let report = ops::remove(&f.env, &f.scope, &[name.to_owned()], None, false).unwrap();
+    apply::execute(&f.env, &report.plan).unwrap();
+}
+
+#[allow(clippy::unwrap_used)]
+fn is_clean(f: &Fixture) -> bool {
+    audit(&f.env, &f.scope).unwrap().drift.is_empty()
+}
+
+/// The command names OpenCode's scan reports for a scope, with their switch.
+fn scanned(f: &Fixture, scope: &Scope) -> Vec<(String, Option<bool>)> {
+    let scanned = kendex_core::scan::scan_scopes(
+        &f.env,
+        &std::collections::BTreeMap::new(),
+        std::slice::from_ref(scope),
+    );
+    scanned
+        .items
+        .iter()
+        .filter(|item| item.harness == HarnessId::Opencode && item.kind == ItemKind::Command)
+        .map(|item| (item.name.clone(), item.enabled))
+        .collect()
+}
+
+/// OpenCode reads the author's frontmatter and expands the same placeholders
+/// Claude does, so the file installs untouched; only `*.md` matches its glob,
+/// so parking it under `.disabled` is the switch.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_command_installs_into_the_projects_commands_dir_and_toggles_by_rename() {
+    let f = fixture("[commands.ship]\nsource = \"cat\"\n");
+    let report = apply_now(&f);
+    assert_eq!(report.warnings, Vec::new(), "nothing to warn about in SHIP");
+
+    let file = f.project.join(".opencode/commands/ship.md");
+    assert_eq!(fs::read_to_string(&file).unwrap(), SHIP);
+    assert!(is_clean(&f));
+    assert_eq!(scanned(&f, &f.scope), [("ship".to_owned(), Some(true))]);
+
+    toggle(&f, "ship", false);
+    assert!(!file.exists());
+    let parked = f.project.join(".opencode/commands/ship.md.disabled");
+    assert_eq!(fs::read_to_string(&parked).unwrap(), SHIP);
+    assert!(is_clean(&f));
+    assert_eq!(scanned(&f, &f.scope), [("ship".to_owned(), Some(false))]);
+
+    toggle(&f, "ship", true);
+    assert!(file.is_file() && !parked.exists());
+
+    remove(&f, "ship");
+    assert!(!file.exists() && !parked.exists());
+    assert!(is_clean(&f));
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_command_installs_under_the_global_root_too() {
+    let f = fixture("");
+    let manifest = f.env.global_manifest_file();
+    fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+    fs::write(
+        &manifest,
+        format!(
+            "schema = 6\n\n[sources.cat]\n{}\n\n[install]\nharnesses = [\"opencode\"]\nmethod = \"symlink\"\n\n[commands.ship]\nsource = \"cat\"\n",
+            source_path(&f.source)
+        ),
+    )
+    .unwrap();
+
+    let report = audit(&f.env, &Scope::Global).unwrap();
+    apply::execute(&f.env, &report.plan).unwrap();
+
+    let file = f.env.home.join(".config/opencode/commands/ship.md");
+    assert_eq!(fs::read_to_string(&file).unwrap(), SHIP);
+    assert!(audit(&f.env, &Scope::Global).unwrap().drift.is_empty());
+    assert_eq!(
+        scanned(&f, &Scope::Global),
+        [("ship".to_owned(), Some(true))]
+    );
+}
+
+/// OpenCode's command loader keys on the filename alone, with no case or
+/// character rule, so a name the skill rule would refuse installs as it is.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_name_outside_the_skill_rule_still_installs_as_the_loader_reads_it() {
+    let f = fixture("[commands.Ship_It]\nsource = \"cat\"\n");
+    let report = apply_now(&f);
+    assert_eq!(report.warnings, Vec::new());
+    assert_eq!(
+        fs::read_to_string(f.project.join(".opencode/commands/Ship_It.md")).unwrap(),
+        SHIP
+    );
+    assert!(is_clean(&f));
+    assert_eq!(scanned(&f, &f.scope), [("Ship_It".to_owned(), Some(true))]);
+}

--- a/docs/adapters/opencode.md
+++ b/docs/adapters/opencode.md
@@ -20,7 +20,7 @@ The config file for a scope is `opencode.jsonc` when it exists, else `opencode.j
 | agent | `<base>/agents/*.md` | managed, both |
 | skill | `.agents/skills/<name>/SKILL.md` in a project; `<base>/skills/<name>/SKILL.md` globally and for a copy delivery | managed, both |
 | hook | `<base>/instructions/kendex-hook-<name>.md` | managed, both, advisory |
-| command | `<base>/commands/*.md` and the legacy singular `<base>/command/*.md` | observe only, both |
+| command | `<base>/commands/*.md`, plus the legacy singular `<base>/command/*.md` for what is already there | managed, both |
 | mcp-server | config `mcp` key, jsonc tolerated, per-entry `enabled` | observe only, both |
 | plugin | `<base>/plugins/*.{js,ts,mjs,cjs}`, plus the config `plugin` array of npm refs | observe only, both |
 | pi-extension | — | unsupported |
@@ -29,8 +29,9 @@ The hook surface reads only files whose name starts `kendex-hook-` (`HOOK_INSTRU
 
 ## Format
 
-- Name rule `LowerKebab`, at most 64 characters; capitals and underscores make an item unloadable. Namespace separator `-`.
+- Name rule `LowerKebab`, at most 64 characters, for agents and skills; capitals and underscores make one unloadable. Namespace separator `-`.
 - MCP transports: stdio and streamable HTTP; servers are `local` (command) or `remote` (url), never SSE.
+- Command file: the author's markdown installed byte for byte as `commands/<name>.md`, the filename being the `/name` typed. OpenCode reads `description`, `agent`, `model`, `variant` and `subtask` from the frontmatter and drops any other key, the body is the template, and `$ARGUMENTS`, `$1`, `!`command`` and `@file` expand as they do on Claude Code. Only `.md` loads, so the `.disabled` rename toggle is safe. The command loader keys on the filename alone with no case or character rule, so the lower-kebab rule above binds agents and skills and not commands. Commands are read once at startup.
 - Agent file: YAML frontmatter and a markdown system prompt. Fields written: `description`, `mode`, `model`, `color` (hex only), `options.reasoningEffort` and its companions, and a `permission:` map of denies (`crates/core/src/render/agent/opencode.rs`). `mode` is `primary`, `subagent` or `all`; kendex writes `subagent` by default and spells a source's `all` as `subagent` too.
 - Model dialect: every tier resolves to `openai/gpt-6-astra`; an explicit id must be `provider/model` and a bare id is refused at render, since kendex names no provider on the author's behalf; an omitted key means inherit (`crates/core/src/harness/models.rs`, `crates/core/src/render/validate/agent.rs`).
 - Permissions: tools are gated by permission key, every entry translated first (`opencode_permission`, `crates/core/src/render/vocab/mod.rs`); the keys the loader knows are `read`, `edit`, `glob`, `grep`, `bash`, `task`, `skill`, `lsp`, `question`, `webfetch`. An allowlist is expressed by denying everything else over exactly that set, `skill` stays allowed, and an entry that maps to no known permission warns. Subagents always deny `task`, and every agent but a `role: planner` denies `question`.


### PR DESCRIPTION
OpenCode reads one `commands/<name>.md` per command at either scope, with the same frontmatter keys and `$ARGUMENTS`, `$1`, `!`…`` and `@file` expansions a Claude command carries, drops unknown frontmatter keys, keys the command on the filename alone, and loads only `.md`. The author's file installs as is and the rename toggle is safe, so the OpenCode × Command cap moves from observe-only to managed.

- `crates/core/src/harness/caps.rs`: `(Opencode, Command) => managed(BOTH)`.
- `crates/core/tests/opencode_commands.rs`: install at both scopes, toggle by rename, remove, scan read-back, a name outside the skill rule installing as the loader reads it. Must-fail control: all fail against the observe-only row.
- `crates/core/tests/commands.rs`: the read-only control narrows to Cursor.
- `docs/adapters/opencode.md`, README cell, changelog fragment.

Live proof on this machine: `kendex apply` on a scratch project wrote `.opencode/commands/kendex-proof.md`; `opencode run --command kendex-proof BANANA` answered `KENDEX-PROOF BANANA`. `opencode debug config` on a probe with `argument-hint` and `allowed-tools` in the frontmatter kept only `description` and `template`. Research: `/var/tmp/arch-rewrite/kendex/commands-mcp/REPORT.md`.

Tracking issue: KEN-1242

https://claude.ai/code/session_01KKVjeGes9mQESaqLzR6TVp
