### PR TITLE
feat(KEN-1242): MCP servers install on Cursor in mcp.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Installing a package from a git repository needs git 2.41 or newer; kendex refus
 | Skills | ● | ● | ● | ●¹ | ● | ● | ● | ● |
 | Hooks | ● | ● | ●² | ●¹ ² | ●³ | ● | ● | ● |
 | Commands | ● | ●⁴ | ● | ○⁵ | ● | ● | -⁶ | - |
-| MCP servers | ● | ○ | ● | ○ | - | ●⁷ | ● | ○ |
+| MCP servers | ● | ○ | ● | ● | - | ●⁷ | ● | ○ |
 | Plugins | ◐ | ○ | ○ | ○ | - | ○ | ◐ | ○ |
 | Pi extensions | - | - | - | - | ● | - | - | - |
 

--- a/changelog.d/added/KEN-1242-cursor-mcp.md
+++ b/changelog.d/added/KEN-1242-cursor-mcp.md
@@ -1,0 +1,1 @@
+- MCP servers install on Cursor in `mcp.json` at both scopes, in the shape Cursor reads, with the remove-and-restore toggle Claude Code's file has.

--- a/crates/cli/tests/install_ux/installing.rs
+++ b/crates/cli/tests/install_ux/installing.rs
@@ -123,17 +123,9 @@ fn an_install_that_would_land_nowhere_is_refused() {
     assert!(!nowhere.status.success(), "{said}");
     assert!(said.contains("nothing would be installed"), "{said}");
 
-    // Cursor takes skills but no MCP servers, so naming it for one is a
+    // Pi takes skills but no MCP servers, so naming it for one is a
     // request that would plan nothing.
-    let wrong = world.try_run(&[
-        "add",
-        "cat",
-        "--mcp-server",
-        "gh",
-        "--harness",
-        "cursor",
-        "-y",
-    ]);
+    let wrong = world.try_run(&["add", "cat", "--mcp-server", "gh", "--harness", "pi", "-y"]);
     let said = crate::said(&wrong);
     assert!(!wrong.status.success(), "{said}");
     assert!(said.contains("nothing would be installed"), "{said}");

--- a/crates/core/src/engine/desired_mcp.rs
+++ b/crates/core/src/engine/desired_mcp.rs
@@ -62,6 +62,7 @@ pub(super) fn desired_mcp(ctx: &ItemCtx, state: &mut DesiredState) -> Result<()>
                 (true, HarnessId::Copilot) => {
                     mcp_upsert(harness, ctx.name, super::copilot::server(&value))
                 }
+                (true, HarnessId::Cursor) => mcp_upsert(harness, ctx.name, cursor_server(&value)),
                 (true, _) => mcp_upsert(harness, ctx.name, value.clone()),
                 (false, _) => mcp_remove(harness, ctx.name),
             };
@@ -107,6 +108,43 @@ fn transport_refusal(harness: HarnessId, value: &Value) -> Option<String> {
         names(&transport),
         harness.display_name(),
     ))
+}
+
+/// The entry as Cursor reads it: transport is inferred from `command` or
+/// `url`, and the `type` key the docs list is never read, while its schema
+/// marks the entry with an unknown key (research on 3.18.9, `KKs`,
+/// `parseMcpServersFromFile`), so the key comes off. An environment value
+/// reaches the process through Cursor's variable resolver, which reads
+/// `${env:NAME}` and nothing else (cursor.com/docs/mcp § interpolation), so
+/// the catalog's `$NAME` and `${NAME}` references are spelled that way; a
+/// value naming a resolver, `${env:…}` or `${workspaceFolder}`, passes
+/// through.
+fn cursor_server(value: &Value) -> Value {
+    let mut entry = value.clone();
+    let Some(object) = entry.as_object_mut() else {
+        return entry;
+    };
+    object.remove("type");
+    if let Some(env) = object.get_mut("env").and_then(Value::as_object_mut) {
+        for reference in env.values_mut() {
+            let name = reference.as_str().and_then(|text| {
+                match text
+                    .strip_prefix("${")
+                    .and_then(|rest| rest.strip_suffix('}'))
+                {
+                    // A colon names one of Cursor's resolvers; a bare name
+                    // inside the braces names nothing it can resolve.
+                    Some(inner) if !inner.contains(':') && !inner.is_empty() => Some(inner),
+                    Some(_) => None,
+                    None => text.strip_prefix('$'),
+                }
+            });
+            if let Some(name) = name {
+                *reference = Value::String(format!("${{env:{name}}}"));
+            }
+        }
+    }
+    entry
 }
 
 /// `mcp/<name>.toml` → the JSON value claude stores under `mcpServers`.
@@ -184,6 +222,17 @@ mod tests {
             "env value for TOKEN must be a $REFERENCE, never a secret"
         );
         assert!(mcp_value("transport = \"stdio\"\n").is_err());
+        assert!(mcp_value("transport = \"carrier-pigeon\"\n").is_err());
+
+        let cursor = cursor_server(&json!({"type": "sse", "url": "https://mcp.example"}));
+        assert_eq!(cursor, json!({"url": "https://mcp.example"}));
+        let cursor = cursor_server(
+            &json!({"command": "gh", "env": {"A": "$A_TOKEN", "B": "${B_TOKEN}", "C": "${env:C_TOKEN}"}}),
+        );
+        assert_eq!(
+            cursor,
+            json!({"command": "gh", "env": {"A": "${env:A_TOKEN}", "B": "${env:B_TOKEN}", "C": "${env:C_TOKEN}"}})
+        );
         assert!(mcp_value("transport = \"carrier-pigeon\"\n").is_err());
     }
 }

--- a/crates/core/src/engine/targets.rs
+++ b/crates/core/src/engine/targets.rs
@@ -325,6 +325,13 @@ pub(super) fn mcp_registry(env: &Env, scope: &Scope, harness: HarnessId) -> Opti
         // OpenCode keeps its servers in the scope's one config file, under
         // `mcp` (opencode.ai/docs/mcp-servers).
         HarnessId::Opencode => Some(crate::harness::opencode::config_file(env, scope)),
+        // Cursor merges `~/.cursor/mcp.json` with the workspace's
+        // `.cursor/mcp.json`, the project entry winning a name clash
+        // (cursor.com/docs/mcp).
+        HarnessId::Cursor => Some(match scope {
+            Scope::Global => adapter(harness).default_global_root(env).join("mcp.json"),
+            Scope::Project { root } => root.join(".cursor/mcp.json"),
+        }),
         // Copilot reads a repository's servers from `.github/mcp.json` and a
         // machine's from its own config root (matrix §2). A `.mcp.json` at
         // the repo root is Claude Code's file, which Copilot also reads —

--- a/crates/core/src/harness/caps.rs
+++ b/crates/core/src/harness/caps.rs
@@ -331,8 +331,8 @@ pub fn capabilities(harness: HarnessId, kind: ItemKind) -> KindCaps {
         (Opencode, Plugin) => observe_only(BOTH),
         (Opencode, PiExtension) => unsupported(),
 
-        // Cursor is managed project-only (no global agent scope in v1), but
-        // its global command/MCP surfaces exist and are observed.
+        // Cursor's agents and skills are managed project-only (no global
+        // rules or skills directory); its global command surface is observed.
         (Cursor, Agent) => managed(PROJECT),
         // Cursor reads the shared `.agents/skills` tree, which is where a
         // project skill goes; `.cursor/skills` is the directory only Cursor
@@ -345,7 +345,10 @@ pub fn capabilities(harness: HarnessId, kind: ItemKind) -> KindCaps {
             ..managed(PROJECT)
         }),
         (Cursor, Command) => observe_only(BOTH),
-        (Cursor, McpServer) => observe_only(BOTH),
+        // `mcp.json` under either root, `mcpServers.<name>` in Claude's
+        // shape less the `type` key Cursor never reads; the file holds no
+        // switch of its own, so off is out (cursor.com/docs/mcp).
+        (Cursor, McpServer) => managed(BOTH),
         (Cursor, Plugin) => observe_only(GLOBAL),
         (Cursor, PiExtension) => unsupported(),
 

--- a/crates/core/src/harness/cursor.rs
+++ b/crates/core/src/harness/cursor.rs
@@ -21,7 +21,7 @@ impl HarnessAdapter for Cursor {
 
     fn global_surfaces(&self, kind: ItemKind, root: &Path, _env: &Env) -> Vec<Surface> {
         match kind {
-            // v1 manages cursor project-only; there is no global rules dir.
+            // agents and skills are project-only; there is no global rules dir.
             ItemKind::Agent | ItemKind::Skill | ItemKind::PiExtension => vec![],
             ItemKind::Hook => vec![Surface::Structured {
                 path: root.join("hooks.json"),

--- a/crates/core/tests/cursor_mcp.rs
+++ b/crates/core/tests/cursor_mcp.rs
@@ -1,0 +1,190 @@
+//! Cursor as a managed tool for MCP servers: a declared server lands under
+//! `mcpServers.<name>` in the scope's `mcp.json` in the shape Cursor reads,
+//! comes out when switched off and goes back when switched on, comes out on
+//! request, and leaves every other entry in the file as it found it.
+#![cfg(unix)]
+
+#[path = "../../test_util.rs"]
+mod test_util;
+use test_util::{rooted, source_path};
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use kendex_core::apply;
+use kendex_core::engine::{EngineReport, audit, ops};
+use kendex_core::env::{Env, FakeOs};
+use kendex_core::model::{HarnessId, ItemKind, Scope};
+use serde_json::{Value, json};
+
+const GH_MCP: &str =
+    "command = \"gh-mcp\"\nargs = [\"--stdio\"]\n[env]\nGITHUB_TOKEN = \"$GH_TOKEN\"\n";
+const DOCS_MCP: &str = "transport = \"sse\"\nurl = \"https://mcp.example/sse\"\n";
+
+/// What somebody else already keeps in the project's file.
+const THEIRS: &str =
+    "{\n  \"mcpServers\": {\n    \"other\": {\"command\": \"x\", \"envFile\": \".env\"}\n  }\n}\n";
+
+struct Fixture {
+    _tmp: tempfile::TempDir,
+    env: Env,
+    scope: Scope,
+    project: PathBuf,
+    source: PathBuf,
+}
+
+/// A Cursor-only project whose catalog carries a command server and an SSE
+/// server; `declarations` is appended to the manifest verbatim.
+#[allow(clippy::unwrap_used)]
+fn fixture(declarations: &str) -> Fixture {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let env = Env::fake(&home, FakeOs::Linux);
+    let project = home.join("dev/app");
+    fs::create_dir_all(project.join(".cursor")).unwrap();
+    fs::create_dir_all(home.join(".cursor")).unwrap();
+
+    let source = home.join("catalog");
+    fs::create_dir_all(source.join("mcp")).unwrap();
+    fs::write(source.join("mcp/gh.toml"), GH_MCP).unwrap();
+    fs::write(source.join("mcp/docs.toml"), DOCS_MCP).unwrap();
+    fs::write(source.join("kendex.toml"), "is_source_catalog = true\n").unwrap();
+
+    fs::write(
+        project.join("kendex.toml"),
+        format!(
+            "schema = 6\n\n[sources.cat]\n{}\n\n[install]\nharnesses = [\"cursor\"]\nmethod = \"symlink\"\n\n{declarations}",
+            source_path(&source)
+        ),
+    )
+    .unwrap();
+
+    Fixture {
+        env,
+        scope: Scope::Project {
+            root: project.clone(),
+        },
+        project,
+        source,
+        _tmp: tmp,
+    }
+}
+
+#[allow(clippy::unwrap_used)]
+fn apply_now(f: &Fixture) -> EngineReport {
+    let report = audit(&f.env, &f.scope).unwrap();
+    apply::execute(&f.env, &report.plan).unwrap();
+    report
+}
+
+#[allow(clippy::unwrap_used)]
+fn toggle(f: &Fixture, name: &str, enabled: bool) {
+    let report = ops::toggle(&f.env, &f.scope, &[name.to_owned()], None, enabled).unwrap();
+    apply::execute(&f.env, &report.plan).unwrap();
+}
+
+#[allow(clippy::unwrap_used)]
+fn remove(f: &Fixture, name: &str) {
+    let report = ops::remove(&f.env, &f.scope, &[name.to_owned()], None, false).unwrap();
+    apply::execute(&f.env, &report.plan).unwrap();
+}
+
+#[allow(clippy::unwrap_used)]
+fn json(path: &Path) -> Value {
+    serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap()
+}
+
+#[allow(clippy::unwrap_used)]
+fn is_clean(f: &Fixture) -> bool {
+    audit(&f.env, &f.scope).unwrap().drift.is_empty()
+}
+
+/// The server names Cursor's scan reports for a scope.
+fn scanned(f: &Fixture, scope: &Scope) -> Vec<String> {
+    let scanned = kendex_core::scan::scan_scopes(
+        &f.env,
+        &std::collections::BTreeMap::new(),
+        std::slice::from_ref(scope),
+    );
+    let mut rows: Vec<_> = scanned
+        .items
+        .iter()
+        .filter(|item| item.harness == HarnessId::Cursor && item.kind == ItemKind::McpServer)
+        .map(|item| item.name.clone())
+        .collect();
+    rows.sort();
+    rows
+}
+
+/// A command server keeps `command` and `args` and spells its `env`
+/// references the way Cursor's resolver reads them; a url server keeps
+/// `url` and loses the `type` Cursor never reads. Off takes the entry out
+/// and on puts it back, because the file has no switch of its own.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_server_is_declared_in_the_projects_mcp_json_and_toggles_by_presence() {
+    let f = fixture("[mcp-servers.gh]\nsource = \"cat\"\n\n[mcp-servers.docs]\nsource = \"cat\"\n");
+    let config = f.project.join(".cursor/mcp.json");
+    fs::write(&config, THEIRS).unwrap();
+    let report = apply_now(&f);
+    assert_eq!(report.warnings, Vec::new());
+
+    let installed = json(&config);
+    assert_eq!(installed["mcpServers"]["other"]["envFile"], ".env");
+    assert_eq!(
+        installed["mcpServers"]["gh"],
+        json!({"command": "gh-mcp", "args": ["--stdio"], "env": {"GITHUB_TOKEN": "${env:GH_TOKEN}"}})
+    );
+    assert_eq!(
+        installed["mcpServers"]["docs"],
+        json!({"url": "https://mcp.example/sse"})
+    );
+    assert!(is_clean(&f));
+    assert_eq!(scanned(&f, &f.scope), ["docs", "gh", "other"]);
+
+    toggle(&f, "gh", false);
+    let off = json(&config);
+    assert!(off["mcpServers"].get("gh").is_none(), "{off}");
+    assert_eq!(off["mcpServers"]["other"]["command"], "x");
+    assert!(is_clean(&f));
+    assert_eq!(scanned(&f, &f.scope), ["docs", "other"]);
+
+    toggle(&f, "gh", true);
+    assert_eq!(json(&config), installed);
+
+    remove(&f, "gh");
+    let after = json(&config);
+    assert!(after["mcpServers"].get("gh").is_none(), "{after}");
+    assert_eq!(
+        after["mcpServers"]["docs"]["url"],
+        "https://mcp.example/sse"
+    );
+    assert_eq!(after["mcpServers"]["other"]["command"], "x");
+    assert!(is_clean(&f));
+}
+
+/// The global scope writes `~/.cursor/mcp.json`, the file Cursor merges
+/// under every workspace.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_global_server_lands_in_the_users_mcp_json() {
+    let f = fixture("");
+    let manifest = f.env.global_manifest_file();
+    fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+    fs::write(
+        &manifest,
+        format!(
+            "schema = 6\n\n[sources.cat]\n{}\n\n[install]\nharnesses = [\"cursor\"]\nmethod = \"symlink\"\n\n[mcp-servers.gh]\nsource = \"cat\"\n",
+            source_path(&f.source)
+        ),
+    )
+    .unwrap();
+
+    let report = audit(&f.env, &Scope::Global).unwrap();
+    apply::execute(&f.env, &report.plan).unwrap();
+
+    let config = f.env.home.join(".cursor/mcp.json");
+    assert_eq!(json(&config)["mcpServers"]["gh"]["command"], "gh-mcp");
+    assert!(audit(&f.env, &Scope::Global).unwrap().drift.is_empty());
+    assert_eq!(scanned(&f, &Scope::Global), ["gh"]);
+}

--- a/docs/adapters/cursor.md
+++ b/docs/adapters/cursor.md
@@ -1,6 +1,6 @@
 # Cursor
 
-A narrow adapter, managed in projects only: an agent installs as a rule file, a project skill goes to the shared `.agents/skills` tree, and nothing about a rule is enforced. Owner: `crates/core/src/harness/cursor.rs`.
+A narrow adapter: an agent installs as a rule file in projects only, a project skill goes to the shared `.agents/skills` tree, an MCP server is written at either scope, and nothing about a rule is enforced. Owner: `crates/core/src/harness/cursor.rs`.
 
 ## Roots
 
@@ -19,16 +19,16 @@ Project marker: a `.cursor/` directory.
 | skill | — | `.agents/skills/<name>/SKILL.md`, with `.cursor/skills/<name>/SKILL.md` for a copy delivery | managed, project only |
 | hook | `~/.cursor/hooks.json` | `.cursor/hooks.json` | observe both; install, toggle, remove, refresh project only; advisory |
 | command | `~/.cursor/commands/*.md` | `.cursor/commands/*.md` | observe only, both |
-| mcp-server | `~/.cursor/mcp.json` | `.cursor/mcp.json` | observe only, both |
+| mcp-server | `~/.cursor/mcp.json` | `.cursor/mcp.json` | managed, both |
 | plugin | `~/.cursor/plugins/{local,cache}` with `.cursor-plugin/plugin.json` | — | observe only, global |
 | pi-extension | — | — | unsupported |
 
-Cursor has no global rules directory and no documented global skills path, so both stay unsupported at global scope while the global command, MCP and plugin surfaces are scanned. `hooks.json` is observed at both scopes and never written.
+Cursor has no global rules directory and no documented global skills path, so both stay unsupported at global scope while the global command and plugin surfaces are scanned. `hooks.json` is observed at both scopes and never written.
 
 ## Format
 
 - Name rule `Any`; namespace separator `__`.
-- MCP transports: stdio, streamable HTTP, SSE.
+- MCP transports: stdio, streamable HTTP, SSE. A server is written under `mcpServers.<name>` in the scope's `mcp.json` as `command`, `args` and `env`, or `url`; Cursor infers the transport from which of those is present and never reads a `type` key, so none is written, and an `env` value's `$NAME` or `${NAME}` reference is spelled `${env:NAME}`, the one form Cursor's variable resolver reads (`cursor_server`, `crates/core/src/engine/desired_mcp.rs`). The file carries no per-entry switch, Cursor keeps that state in its own storage, so switching a server off takes the entry out and on puts it back; other entries stay, and a remote server switched off loses the OAuth state Cursor held for it. Cursor watches both files, and asks once before it runs a project server that is new or changed. A server Cursor's own switch holds off is not read by kendex and stays reported as installed.
 - Rule file: `<name>.mdc`, YAML frontmatter and markdown. Fields written: `description` (the agent's name and description joined) and `alwaysApply: false`; a rule carries no model, tool, skill or hook field, so only the prompt survives (`crates/core/src/render/agent/cursor.rs`).
 - Model dialect: every tier resolves to nothing and the field is dropped (`crates/core/src/harness/models.rs`).
 - Frontmatter keys Cursor honours: `description`, `globs`, `alwaysApply`; anything else is an advisory finding (`CURSOR_KEYS`, `crates/core/src/render/validate/agent.rs`).


### PR DESCRIPTION
Cursor merges `~/.cursor/mcp.json` with the workspace's `.cursor/mcp.json` under `mcpServers.<name>`, infers the transport from `command` or `url`, never reads the `type` key its docs list, and resolves an `env` value only as `${env:NAME}`. A declared server is written there in that shape, `type` off and env references respelled; the file has no switch of its own, so switching off takes the entry out and on puts it back, and other entries stay. The cap moves from observe-only to managed at both scopes.

- `crates/core/src/harness/caps.rs`: `(Cursor, McpServer) => managed(BOTH)`.
- `crates/core/src/engine/targets.rs`: the two registry paths. `crates/core/src/engine/desired_mcp.rs`: `cursor_server`.
- `crates/core/tests/cursor_mcp.rs`: install at both scopes beside the user's entry, toggle by presence, remove, scan read-back. Must-fail control: both fail against the observe-only row.
- `docs/adapters/cursor.md`, README cell, changelog fragment.

Reviewer round: one blocking finding fixed (`$NAME` becomes `${env:NAME}`), three doc claims of project-only management corrected. Live proof: `kendex apply` wrote `mcpServers.kendex-proof-mcp` into a scratch project's `.cursor/mcp.json`; `cursor-agent mcp list` showed `not loaded (needs approval)`, Cursor's own gate for a new project server, and `ready` after `cursor-agent mcp enable`. Research: `/var/tmp/arch-rewrite/kendex/commands-mcp/REPORT.md`.

Tracking issue: KEN-1242

https://claude.ai/code/session_01KKVjeGes9mQESaqLzR6TVp
