### PR TITLE
fix(catalog): drop the retired gpt-5.6-sol pin on the Codex tpm agent

### DIFF
--- a/.codex/agents/tpm.toml
+++ b/.codex/agents/tpm.toml
@@ -1,7 +1,7 @@
 name = "tpm"
 nickname_candidates = ["TPM-Atlas", "TPM-Delta", "TPM-Echo", "TPM-Nova", "TPM-Orion", "TPM-Vector"]
 description = "Technical Program Manager for analyzing roadmaps, project lifecycle, and progress. Returns recommendations only. Does not modify project management tools."
-model = "gpt-5.6-sol"
+model = "gpt-6-astra"
 model_reasoning_effort = "medium"
 sandbox_mode = "workspace-write"
 developer_instructions = '''

--- a/changelog.d/fixed/2182-tpm-codex-model.md
+++ b/changelog.d/fixed/2182-tpm-codex-model.md
@@ -1,0 +1,1 @@
+- The catalog no longer pins the Codex `tpm` agent to the retired `gpt-5.6-sol`; it renders `gpt-6-astra` like every other Codex agent.

--- a/kendex.toml
+++ b/kendex.toml
@@ -168,8 +168,3 @@ analyst = ["linear", "github"]
 engineer = ["dev", "github", "decider", "linear", "preflight", "code-quality"]
 manager = ["dev", "github", "project-management", "linear", "decider"]
 reviewer = ["reviewer"]
-
-# Per-harness frontmatter defaults beneath any project-level overrides.
-# tpm plans rather than builds, so on Codex it runs on the lighter model.
-[agent-frontmatter.codex]
-tpm = { model = "gpt-5.6-sol" }


### PR DESCRIPTION
The catalog pinned the Codex `tpm` agent to the retired `gpt-5.6-sol` in `kendex.toml` `[agent-frontmatter.codex]` after the model sweep replaced it everywhere else, so a consumer with no override rendered a retired id. The pin and its table go; `tpm` (`model: opus`) resolves to `gpt-6-astra` on Codex like every other agent, and `.codex/agents/tpm.toml` is re-rendered in the same commit. Changelog fragment under fixed/.

Fixes #2182

https://claude.ai/code/session_01KKVjeGes9mQESaqLzR6TVp
