### PR TITLE
fix(KEN-1253): worktree create --pr checks out a fork PR head

### DIFF
--- a/.agents/skills/worktree/scripts/worktree
+++ b/.agents/skills/worktree/scripts/worktree
@@ -178,8 +178,8 @@ Options:
   --pr NUMBER     Look up the branch from a GitHub PR number (implies --base);
                   with --base, the way to inspect existing remote work whose
                   issue worktree is absent. A fork PR checks out origin's
-                  refs/pull/NUMBER/head as a local branch named after the
-                  contributor's branch, with no upstream
+                  refs/pull/NUMBER/head as local branch fork-pr-NUMBER, with
+                  no upstream
   --reuse         Explicitly reuse an existing issue worktree: refuses a
                   foreign session-guard lease by name (exit 75), refreshes its
                   own lease in place, rebases onto origin/<default>, then
@@ -2837,11 +2837,15 @@ merged_pr_for_branch() {
   return 1
 }
 
-# Sets BASE to the PR's head branch name. A fork PR also sets PR_HEAD_OID:
-# its head branch lives in the contributor's repository, so origin carries no
-# such head and the commit is reachable only through origin's
-# refs/pull/<n>/head. A same-repository PR leaves PR_HEAD_OID empty and
-# takes the plain --base path.
+# Sets BASE to the branch the PR checks out as. A same-repository PR leaves
+# PR_HEAD_OID empty, sets BASE to its head branch name and takes the plain
+# --base path. A fork PR sets PR_HEAD_OID and BASE to fork-pr-<n>: its head
+# branch lives in the contributor's repository, so origin carries no such
+# head and the commit is reachable only through origin's refs/pull/<n>/head.
+# The contributor's branch name is not reused locally; it shares a namespace
+# with the user's own branches (a fork PR opened from `main` would name the
+# main checkout's branch) and with origin's heads (a push from the inspection
+# worktree would land on an unrelated origin branch of that name).
 resolve_pr_head() {
   local pr="$1" output="" name="" oid="" cross=""
   if ! command -v gh >/dev/null 2>&1; then
@@ -2860,7 +2864,11 @@ resolve_pr_head() {
     return 1
   fi
   case "$cross" in
-    true) PR_HEAD_OID="$oid" ;;
+    true)
+      PR_HEAD_OID="$oid"
+      BASE="fork-pr-$pr"
+      return 0
+      ;;
     false) PR_HEAD_OID="" ;;
     *)
       echo "Error: gh reported an isCrossRepository value this cannot read for PR #$pr: '$cross'" >&2
@@ -2895,11 +2903,11 @@ ensure_base_start_point() {
   ensure_fork_branch_resettable "$pr" "$base" "$head_oid"
 }
 
-# A fork PR's local branch survives `remove` while the PR is open, so a
-# second inspection finds it. The fork add resets it to the PR head; that is
-# lossless only when every commit on the stale branch is in the PR head. A
-# branch that diverged (local commits, or another contributor's branch of
-# the same name) is refused by name rather than reset.
+# A fork PR's local branch fork-pr-<n> survives `remove` while the PR is
+# open, so a second inspection finds it. The fork add resets it to the PR
+# head; that is lossless only when every commit on the stale branch is in
+# the PR head. A branch that diverged (commits made in the inspection
+# worktree) is refused by name rather than reset.
 ensure_fork_branch_resettable() {
   local pr="$1" base="$2" head_oid="$3"
   git -C "$PROJECT_ROOT" rev-parse --verify --quiet "refs/heads/$base" >/dev/null || return 0
@@ -3930,13 +3938,13 @@ case "${1:-}" in
 
       mkdir -p "$TREES_DIR"
       if [[ -n "$PR_HEAD_OID" ]]; then
-        # A fork head has no origin branch to track; the local branch keeps
-        # the contributor's name and no upstream. -B resets the branch a
-        # previous inspection left behind; ensure_fork_branch_resettable has
-        # already refused a branch that reset would lose commits from.
-        # --no-track skips new tracking config, but -B keeps an upstream a
-        # pre-existing branch carried; drop it so a push cannot reach an
-        # unrelated origin branch of the same name.
+        # A fork head has no origin branch to track; the local branch is
+        # fork-pr-<n> with no upstream. -B resets the branch a previous
+        # inspection left behind; ensure_fork_branch_resettable has already
+        # refused a branch that reset would lose commits from. --no-track
+        # skips new tracking config, but -B keeps an upstream a pre-existing
+        # branch carried; drop it so a push cannot reach an origin branch of
+        # that name.
         git -C "$PROJECT_ROOT" worktree add --no-track -B "$BASE" "$WT_PATH" "$PR_HEAD_OID" >/dev/null 2>&1
         if git -C "$WT_PATH" config --get "branch.$BASE.merge" >/dev/null 2>&1; then
           git -C "$WT_PATH" branch --unset-upstream "$BASE" >/dev/null 2>&1 || {

--- a/.agents/skills/worktree/scripts/worktree
+++ b/.agents/skills/worktree/scripts/worktree
@@ -177,7 +177,9 @@ Options:
                   gate
   --pr NUMBER     Look up the branch from a GitHub PR number (implies --base);
                   with --base, the way to inspect existing remote work whose
-                  issue worktree is absent
+                  issue worktree is absent. A fork PR checks out origin's
+                  refs/pull/NUMBER/head as a local branch named after the
+                  contributor's branch, with no upstream
   --reuse         Explicitly reuse an existing issue worktree: refuses a
                   foreign session-guard lease by name (exit 75), refreshes its
                   own lease in place, rebases onto origin/<default>, then
@@ -2835,22 +2837,61 @@ merged_pr_for_branch() {
   return 1
 }
 
-resolve_pr_branch() {
-  local pr="$1" output=""
+# Sets BASE to the PR's head branch name. A fork PR also sets PR_HEAD_OID:
+# its head branch lives in the contributor's repository, so origin carries no
+# such head and the commit is reachable only through origin's
+# refs/pull/<n>/head. A same-repository PR leaves PR_HEAD_OID empty and
+# takes the plain --base path.
+resolve_pr_head() {
+  local pr="$1" output="" name="" oid="" cross=""
   if ! command -v gh >/dev/null 2>&1; then
     echo "Error: gh is required to resolve PR #$pr" >&2
     return 1
   fi
-  if ! output="$(gh pr view "$pr" --json headRefName -q .headRefName 2>&1)"; then
+  if ! output="$(gh pr view "$pr" --json headRefName,headRefOid,isCrossRepository \
+                  -q '[.headRefName, .headRefOid, (.isCrossRepository | tostring)] | @tsv' 2>&1)"; then
     echo "Error: Could not find branch for PR #$pr" >&2
     [[ -n "$output" ]] && sed 's/^/  /' <<<"$output" >&2
     return 1
   fi
-  if [[ -z "$output" ]]; then
+  IFS=$'\t' read -r name oid cross <<<"$output"
+  if [[ -z "$name" ]] || ! [[ "$oid" =~ ^[0-9a-f]{40,64}$ ]]; then
     echo "Error: Could not find branch for PR #$pr" >&2
     return 1
   fi
-  printf '%s\n' "$output"
+  case "$cross" in
+    true) PR_HEAD_OID="$oid" ;;
+    false) PR_HEAD_OID="" ;;
+    *)
+      echo "Error: gh reported an isCrossRepository value this cannot read for PR #$pr: '$cross'" >&2
+      return 1
+      ;;
+  esac
+  BASE="$name"
+}
+
+# The start point for --base/--pr must exist before any mutation. A fork PR
+# head is fetched from origin's refs/pull/<n>/head, and the fetch counts only
+# if it delivered the commit gh reported as the head. No remote is added for
+# the fork, so nothing here can ever push to it.
+ensure_base_start_point() {
+  local pr="$1" base="$2" head_oid="$3" output=""
+  if [[ -z "$head_oid" ]]; then
+    if ! remote_branch_discovered origin "$base"; then
+      echo "Error: Cannot resolve remote branch 'origin/$base'" >&2
+      return 1
+    fi
+    return 0
+  fi
+  if ! output="$(git_with_github_https_auth -C "$PROJECT_ROOT" fetch origin "refs/pull/$pr/head" 2>&1)"; then
+    echo "Error: Could not fetch refs/pull/$pr/head from origin for fork PR #$pr" >&2
+    [[ -n "$output" ]] && sed 's/^/  /' <<<"$output" >&2
+    return 1
+  fi
+  if ! git -C "$PROJECT_ROOT" rev-parse --verify --quiet "$head_oid^{commit}" >/dev/null; then
+    echo "Error: refs/pull/$pr/head on origin did not deliver commit $head_oid, the head gh reports for PR #$pr" >&2
+    return 1
+  fi
 }
 
 CANDIDATE_BRANCHES=()
@@ -3833,16 +3874,14 @@ case "${1:-}" in
     # 3. Explicit --pr/--base are inspection modes, not claims. Their
     # authoritative branch/ref lookup must succeed before mutation, and the
     # issue lock serializes their final check plus add.
+    PR_HEAD_OID=""
     if [[ -n "$PR" ]]; then
-      BASE="$(resolve_pr_branch "$PR")" || exit 1
+      resolve_pr_head "$PR" || exit 1
     fi
 
     if [[ -n "$BASE" ]]; then
       discover_ownership_remote_heads || exit 1
-      if ! remote_branch_discovered origin "$BASE"; then
-        echo "Error: Cannot resolve remote branch 'origin/$BASE'" >&2
-        exit 1
-      fi
+      ensure_base_start_point "$PR" "$BASE" "$PR_HEAD_OID" || exit 1
       EXISTING_WT="$(worktree_for_branch "$BASE" 2>/dev/null || true)"
       if [[ -n "$EXISTING_WT" ]]; then
         # A base branch checked out in the main checkout is not issue work,
@@ -3858,14 +3897,11 @@ case "${1:-}" in
       acquire_issue_claim_lock "$ISSUE" || exit 1
       guard_new_target_path "$ISSUE" "$WT_PATH" || exit "$ACTIVE_WORK_EXIT"
       if [[ -n "$PR" ]]; then
-        BASE="$(resolve_pr_branch "$PR")" || exit 1
+        resolve_pr_head "$PR" || exit 1
       fi
       fetch_origin || exit 1
       discover_ownership_remote_heads || exit 1
-      if ! remote_branch_discovered origin "$BASE"; then
-        echo "Error: Cannot resolve remote branch 'origin/$BASE'" >&2
-        exit 1
-      fi
+      ensure_base_start_point "$PR" "$BASE" "$PR_HEAD_OID" || exit 1
       EXISTING_WT="$(worktree_for_branch "$BASE" 2>/dev/null || true)"
       if [[ -n "$EXISTING_WT" ]]; then
         # Same main-checkout guard as the pre-lock check above.
@@ -3877,8 +3913,14 @@ case "${1:-}" in
       fi
 
       mkdir -p "$TREES_DIR"
-      git -C "$PROJECT_ROOT" worktree add --track -b "$BASE" "$WT_PATH" "origin/$BASE" >/dev/null 2>&1 || \
-        git -C "$PROJECT_ROOT" worktree add "$WT_PATH" "$BASE" >/dev/null 2>&1
+      if [[ -n "$PR_HEAD_OID" ]]; then
+        # A fork head has no origin branch to track; the local branch keeps
+        # the contributor's name and no upstream.
+        git -C "$PROJECT_ROOT" worktree add --no-track -b "$BASE" "$WT_PATH" "$PR_HEAD_OID" >/dev/null 2>&1
+      else
+        git -C "$PROJECT_ROOT" worktree add --track -b "$BASE" "$WT_PATH" "origin/$BASE" >/dev/null 2>&1 || \
+          git -C "$PROJECT_ROOT" worktree add "$WT_PATH" "$BASE" >/dev/null 2>&1
+      fi
     else
       build_candidate_branches "$ISSUE" "$BRANCH"
       discover_candidate_ownership || exit 1

--- a/.agents/skills/worktree/scripts/worktree
+++ b/.agents/skills/worktree/scripts/worktree
@@ -2787,6 +2787,13 @@ merged_pr_for_branch() {
     printf 'branch has no local tip to compare a merged pull request against\n'
     return 2
   fi
+  # A fork inspection branch is named fork-pr-<n> (see resolve_pr_head), and
+  # GitHub files that PR under the contributor's head name, so a --head query
+  # can never find it. The number in the name is the lookup key instead.
+  if [[ "$branch" =~ ^fork-pr-([0-9]+)$ ]]; then
+    merged_fork_pr_at_tip "${BASH_REMATCH[1]}" "$tip"
+    return $?
+  fi
   if ! err_file="$(mktemp "${TMPDIR:-/tmp}/worktree-merged-pr.XXXXXX")"; then
     printf 'could not create a scratch file for the gh diagnostic\n'
     return 2
@@ -2835,6 +2842,47 @@ merged_pr_for_branch() {
   printf 'carries work past its merged pull request (merged under this name:%s; none has this tip %s as its head)\n' \
     "$seen" "$tip"
   return 1
+}
+
+# The merged proof for a fork-pr-<n> branch: PR <n> is merged into the default
+# branch and the head it merged is this tip. Same exit contract as
+# merged_pr_for_branch; the proof is commit identity, and the PR number in the
+# branch name is only the lookup key.
+merged_fork_pr_at_tip() {
+  local pr="$1" tip="$2" err_file="" row="" detail="" state="" base="" oid="" rc=0
+  if ! err_file="$(mktemp "${TMPDIR:-/tmp}/worktree-merged-pr.XXXXXX")"; then
+    printf 'could not create a scratch file for the gh diagnostic\n'
+    return 2
+  fi
+  row="$( (cd "$PROJECT_ROOT" && env -u GH_REPO -u GITHUB_REPOSITORY \
+             gh pr view "$pr" --json state,baseRefName,headRefOid \
+             --jq '[.state, .baseRefName, .headRefOid] | @tsv') 2>"$err_file" )" || rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    detail="$(tr '\n' ' ' <"$err_file")"
+    rm -f "$err_file"
+    printf '%s\n' "${detail:-gh pr view $pr failed (exit $rc)}"
+    return 2
+  fi
+  rm -f "$err_file"
+  IFS=$'\t' read -r state base oid <<<"$row"
+  if [[ -z "$state" || -z "$base" ]] || ! [[ "$oid" =~ ^[0-9a-f]{7,64}$ ]]; then
+    printf 'gh returned a pull request #%s record this cannot read: %s\n' "$pr" "$row"
+    return 2
+  fi
+  if [[ "$state" != "MERGED" ]]; then
+    printf 'fork pull request #%s is %s, not merged\n' "$pr" "$state"
+    return 1
+  fi
+  if [[ "$base" != "$DEFAULT_BRANCH" ]]; then
+    printf 'fork pull request #%s merged into %s, not %s\n' "$pr" "$base" "$DEFAULT_BRANCH"
+    return 1
+  fi
+  if [[ "$oid" != "$tip" ]]; then
+    printf 'carries work past its merged pull request (#%s merged head %s, not this tip %s)\n' "$pr" "$oid" "$tip"
+    return 1
+  fi
+  printf '%s\n' "$pr"
+  return 0
 }
 
 # Sets BASE to the branch the PR checks out as. A same-repository PR leaves

--- a/.agents/skills/worktree/scripts/worktree
+++ b/.agents/skills/worktree/scripts/worktree
@@ -3934,7 +3934,16 @@ case "${1:-}" in
         # the contributor's name and no upstream. -B resets the branch a
         # previous inspection left behind; ensure_fork_branch_resettable has
         # already refused a branch that reset would lose commits from.
+        # --no-track skips new tracking config, but -B keeps an upstream a
+        # pre-existing branch carried; drop it so a push cannot reach an
+        # unrelated origin branch of the same name.
         git -C "$PROJECT_ROOT" worktree add --no-track -B "$BASE" "$WT_PATH" "$PR_HEAD_OID" >/dev/null 2>&1
+        if git -C "$WT_PATH" config --get "branch.$BASE.merge" >/dev/null 2>&1; then
+          git -C "$WT_PATH" branch --unset-upstream "$BASE" >/dev/null 2>&1 || {
+            echo "Error: could not clear the upstream of branch '$BASE' in $WT_PATH" >&2
+            exit 1
+          }
+        fi
       else
         git -C "$PROJECT_ROOT" worktree add --track -b "$BASE" "$WT_PATH" "origin/$BASE" >/dev/null 2>&1 || \
           git -C "$PROJECT_ROOT" worktree add "$WT_PATH" "$BASE" >/dev/null 2>&1

--- a/.agents/skills/worktree/scripts/worktree
+++ b/.agents/skills/worktree/scripts/worktree
@@ -2892,6 +2892,22 @@ ensure_base_start_point() {
     echo "Error: refs/pull/$pr/head on origin did not deliver commit $head_oid, the head gh reports for PR #$pr" >&2
     return 1
   fi
+  ensure_fork_branch_resettable "$pr" "$base" "$head_oid"
+}
+
+# A fork PR's local branch survives `remove` while the PR is open, so a
+# second inspection finds it. The fork add resets it to the PR head; that is
+# lossless only when every commit on the stale branch is in the PR head. A
+# branch that diverged (local commits, or another contributor's branch of
+# the same name) is refused by name rather than reset.
+ensure_fork_branch_resettable() {
+  local pr="$1" base="$2" head_oid="$3"
+  git -C "$PROJECT_ROOT" rev-parse --verify --quiet "refs/heads/$base" >/dev/null || return 0
+  if git -C "$PROJECT_ROOT" merge-base --is-ancestor "refs/heads/$base" "$head_oid" 2>/dev/null; then
+    return 0
+  fi
+  echo "Error: Local branch '$base' has commits that are not in the head of fork PR #$pr; delete or rename that branch before inspecting the PR again." >&2
+  return 1
 }
 
 CANDIDATE_BRANCHES=()
@@ -3915,8 +3931,10 @@ case "${1:-}" in
       mkdir -p "$TREES_DIR"
       if [[ -n "$PR_HEAD_OID" ]]; then
         # A fork head has no origin branch to track; the local branch keeps
-        # the contributor's name and no upstream.
-        git -C "$PROJECT_ROOT" worktree add --no-track -b "$BASE" "$WT_PATH" "$PR_HEAD_OID" >/dev/null 2>&1
+        # the contributor's name and no upstream. -B resets the branch a
+        # previous inspection left behind; ensure_fork_branch_resettable has
+        # already refused a branch that reset would lose commits from.
+        git -C "$PROJECT_ROOT" worktree add --no-track -B "$BASE" "$WT_PATH" "$PR_HEAD_OID" >/dev/null 2>&1
       else
         git -C "$PROJECT_ROOT" worktree add --track -b "$BASE" "$WT_PATH" "origin/$BASE" >/dev/null 2>&1 || \
           git -C "$PROJECT_ROOT" worktree add "$WT_PATH" "$BASE" >/dev/null 2>&1
@@ -3938,9 +3956,10 @@ case "${1:-}" in
 
     release_issue_claim_lock
 
-    # Set upstream tracking if remote branch exists
+    # Set upstream tracking if remote branch exists. A fork PR branch keeps
+    # no upstream even when origin has an unrelated branch of the same name.
     CREATED_BRANCH=$(git -C "$WT_PATH" branch --show-current 2>/dev/null)
-    if [[ -n "$CREATED_BRANCH" ]]; then
+    if [[ -n "$CREATED_BRANCH" && -z "$PR_HEAD_OID" ]]; then
       _REMOTE="${BOT_REMOTE_NAME:-origin}"
       if git -C "$WT_PATH" rev-parse --verify "$_REMOTE/$CREATED_BRANCH" &>/dev/null; then
         git -C "$WT_PATH" branch --set-upstream-to="$_REMOTE/$CREATED_BRANCH" "$CREATED_BRANCH" >/dev/null 2>&1 || true

--- a/.agents/skills/worktree/tests/worktree_create_active_guard.sh
+++ b/.agents/skills/worktree/tests/worktree_create_active_guard.sh
@@ -121,7 +121,17 @@ case "${1:-}:${2:-}" in
     fi
     ;;
   pr:view)
-    printf 'issue-active\n'
+    # `pr view <n> --json <fields> -q <query>`: the stored document is the
+    # field set gh returns, and the query runs over it.
+    shift 3
+    query=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        -q | --jq) query="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    jq -r "$query" "${GH_STATE:?}/pr-42.json"
     ;;
 esac
 STUB
@@ -194,6 +204,8 @@ assert_eq "$pr_guard_code" "75" "bare create exits 75 for an open PR without a l
 assert_contains "$pr_guard_err" "open pull request (#42)" "branch guard reports the PR ownership signal"
 assert_path_absent "$WT" "open-PR guard creates no duplicate checkout"
 
+printf '{"headRefName":"issue-active","headRefOid":"%s","isCrossRepository":false}\n' \
+  "$(git -C "$ROOT/main" rev-parse origin/issue-active)" >"$GH_STATE/pr-42.json"
 pr_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-active --pr 42)"
 assert_eq "$pr_out" "$WT" "--pr explicitly creates an inspection worktree"
 assert_path_exists "$WT/.git" "explicit PR checkout is a registered worktree"

--- a/.agents/skills/worktree/tests/worktree_create_fork_pr.sh
+++ b/.agents/skills/worktree/tests/worktree_create_fork_pr.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # Tests for `create --pr` against a fork pull request: the head branch lives
 # in the contributor's repository, so origin has no such head and the commit
-# is reachable only through origin's refs/pull/<n>/head. A same-repository PR
-# keeps the tracked origin-branch checkout, and a pull ref that does not
-# deliver the head gh reports refuses before any worktree exists.
+# is reachable only through origin's refs/pull/<n>/head. The worktree branch
+# is fork-pr-<n>, so the contributor's branch name never touches a local or
+# origin branch of the same name. A same-repository PR keeps the tracked
+# origin-branch checkout, and a pull ref that does not deliver the head gh
+# reports refuses before any worktree exists.
 set -euo pipefail
 
 # A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
@@ -93,6 +95,16 @@ git -C "$ROOT/main" branch -q -D feat/same
 git -C "$ROOT/main" push -q origin "main:refs/pull/9/head"
 PHANTOM_OID="$(printf '%040d' 1)"
 
+# A fork PR opened from the fork's own `main`: the head branch name is the
+# main checkout's branch name.
+git -C "$ROOT/fork" checkout -q main
+printf 'fork main fix\n' >"$ROOT/fork/from-main.txt"
+git -C "$ROOT/fork" add from-main.txt
+git -C "$ROOT/fork" commit -q -m 'fork main fix'
+FORK_MAIN_HEAD="$(git -C "$ROOT/fork" rev-parse HEAD)"
+git -C "$ROOT/fork" push -q origin "HEAD:refs/pull/11/head"
+git -C "$ROOT/fork" checkout -q fix/widget-expiry
+
 # gh as it answers `pr view <n> --json <fields> -q <query>`: the stored
 # document is the field set gh returns, and the query runs over it.
 cat >"$ROOT/bin/gh" <<'STUB'
@@ -136,6 +148,7 @@ pr_doc 7 fix/widget-expiry "$FORK_HEAD" true
 pr_doc 8 feat/same "$SAME_HEAD" false
 pr_doc 9 fix/phantom "$PHANTOM_OID" true
 pr_doc 10 fix/no-pull-ref "$FORK_HEAD" true
+pr_doc 11 main "$FORK_MAIN_HEAD" true
 
 echo "=== worktree create --pr on a fork pull request ==="
 
@@ -149,7 +162,8 @@ FORK_WT="$ROOT/trees/issue-fork"
 assert_eq "$fork_code" "0" "fork PR creates a worktree (stderr: $(tr '\n' ' ' <"$ROOT/fork.err"))"
 assert_eq "$fork_out" "$FORK_WT" "fork PR prints the worktree path"
 assert_eq "$(git -C "$FORK_WT" rev-parse HEAD 2>/dev/null || true)" "$FORK_HEAD" "fork worktree HEAD is the PR head commit"
-assert_eq "$(git -C "$FORK_WT" branch --show-current 2>/dev/null || true)" "fix/widget-expiry" "fork worktree branch carries the contributor's branch name"
+assert_eq "$(git -C "$FORK_WT" branch --show-current 2>/dev/null || true)" "fork-pr-7" "fork worktree branch is fork-pr-7, not the contributor's branch name"
+assert_eq "$(git -C "$ROOT/main" rev-parse --verify --quiet refs/heads/fix/widget-expiry || true)" "" "no local branch carries the contributor's branch name"
 set +e
 fork_upstream="$(git -C "$FORK_WT" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null)"
 fork_upstream_code=$?
@@ -168,10 +182,26 @@ assert_eq "$same_out" "$SAME_WT" "same-repository PR prints the worktree path"
 assert_eq "$(git -C "$SAME_WT" rev-parse HEAD 2>/dev/null || true)" "$SAME_HEAD" "same-repository worktree HEAD is the origin branch tip"
 assert_eq "$(git -C "$SAME_WT" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)" "origin/feat/same" "same-repository branch tracks its origin branch"
 
-# Inspecting the same fork PR again: `remove` keeps the local branch while the
-# PR is open, the contributor has pushed since, and origin has meanwhile grown
-# an unrelated branch of the same name. The second create resets the stale
-# branch to the new head and still sets no upstream.
+# A fork PR whose head branch is named `main` is inspectable: the local
+# branch is fork-pr-11, so the main checkout's `main` is neither in the way
+# nor reset to the contributor's commit.
+LOCAL_MAIN_BEFORE="$(git -C "$ROOT/main" rev-parse refs/heads/main)"
+set +e
+from_main_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-from-main --pr 11 2>"$ROOT/from-main.err")"
+from_main_code=$?
+set -e
+FROM_MAIN_WT="$ROOT/trees/issue-from-main"
+assert_eq "$from_main_code:$from_main_out" "0:$FROM_MAIN_WT" "a fork PR opened from the fork's main creates a worktree (stderr: $(tr '\n' ' ' <"$ROOT/from-main.err"))"
+assert_eq "$(git -C "$FROM_MAIN_WT" rev-parse HEAD 2>/dev/null || true)" "$FORK_MAIN_HEAD" "fork-from-main worktree HEAD is the PR head commit"
+assert_eq "$(git -C "$FROM_MAIN_WT" branch --show-current 2>/dev/null || true)" "fork-pr-11" "fork-from-main worktree branch is fork-pr-11"
+assert_eq "$(git -C "$ROOT/main" rev-parse refs/heads/main)" "$LOCAL_MAIN_BEFORE" "the main checkout's local main is untouched"
+assert_eq "$(git -C "$ROOT/main" branch --show-current)" "main" "the main checkout still has main checked out"
+
+# Inspecting the same fork PR again: `remove` keeps the local fork-pr-7 branch
+# while the PR is open, the contributor has pushed since, and origin has
+# meanwhile grown an unrelated branch under the contributor's branch name.
+# The second create resets the stale branch to the new head and still sets
+# no upstream.
 printf 'fork fix 2\n' >>"$ROOT/fork/fix.txt"
 git -C "$ROOT/fork" commit -q -am 'fork fix 2'
 FORK_HEAD_2="$(git -C "$ROOT/fork" rev-parse HEAD)"
@@ -180,11 +210,11 @@ pr_doc 7 fix/widget-expiry "$FORK_HEAD_2" true
 git -C "$ROOT/main" push -q origin "main:refs/heads/fix/widget-expiry"
 (cd "$ROOT/main" && "$WORKTREE_SCRIPT" remove issue-fork >/dev/null 2>&1) || true # exits 1: the open PR's branch stays
 assert_path_absent "$FORK_WT" "remove clears the fork worktree"
-assert_eq "$(git -C "$ROOT/main" rev-parse --verify --quiet refs/heads/fix/widget-expiry || true)" "$FORK_HEAD" "remove keeps the open PR's local branch at the first head"
+assert_eq "$(git -C "$ROOT/main" rev-parse --verify --quiet refs/heads/fork-pr-7 || true)" "$FORK_HEAD" "remove keeps the open PR's local branch at the first head"
 # The stale branch also carries tracking config pointing at that unrelated
 # origin branch; -B preserves it, so the create must clear it afterwards.
 git -C "$ROOT/main" fetch -q origin
-git -C "$ROOT/main" branch -q --set-upstream-to=origin/fix/widget-expiry fix/widget-expiry
+git -C "$ROOT/main" branch -q --set-upstream-to=origin/fix/widget-expiry fork-pr-7
 set +e
 again_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-fork --pr 7 2>"$ROOT/again.err")"
 again_code=$?
@@ -210,7 +240,7 @@ set +e
 diverged_code=$?
 set -e
 assert_eq "$diverged_code" "1" "a diverged local branch refuses the fork checkout with exit 1"
-assert_contains "$(cat "$ROOT/diverged.err")" "Local branch 'fix/widget-expiry' has commits that are not in the head of fork PR #7" "the refusal names the diverged branch"
+assert_contains "$(cat "$ROOT/diverged.err")" "Local branch 'fork-pr-7' has commits that are not in the head of fork PR #7" "the refusal names the diverged branch"
 assert_path_absent "$FORK_WT" "a diverged local branch creates no worktree"
 
 # A fork head the base cannot deliver refuses before any worktree exists:

--- a/.agents/skills/worktree/tests/worktree_create_fork_pr.sh
+++ b/.agents/skills/worktree/tests/worktree_create_fork_pr.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# Tests for `create --pr` against a fork pull request: the head branch lives
+# in the contributor's repository, so origin has no such head and the commit
+# is reachable only through origin's refs/pull/<n>/head. A same-repository PR
+# keeps the tracked origin-branch checkout, and a pull ref that does not
+# deliver the head gh reports refuses before any worktree exists.
+set -euo pipefail
+
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call in this file back at the real repository.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        wanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+  fi
+}
+
+assert_path_absent() {
+  local path="$1" name="$2"
+  if [[ ! -e "$path" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        unexpected path: %s\n' "$name" "$path"
+  fi
+}
+
+ROOT="$TMP_ROOT/fork-pr"
+mkdir -p "$ROOT/main" "$ROOT/bin" "$ROOT/gh-state"
+git -C "$ROOT/main" init -q -b main
+git -C "$ROOT/main" config user.email test@example.com
+git -C "$ROOT/main" config user.name Test
+git -C "$ROOT/main" config commit.gpgsign false
+printf 'base\n' >"$ROOT/main/base.txt"
+git -C "$ROOT/main" add base.txt
+git -C "$ROOT/main" commit -q -m base
+printf 'WORKTREE_BASE_DIR="../trees"\n' >"$ROOT/main/.env.local"
+git init -q --bare "$ROOT/origin.git"
+git -C "$ROOT/main" remote add origin "$ROOT/origin.git"
+git -C "$ROOT/main" push -q -u origin main
+
+# The contributor's repository: a clone of origin whose branch never reaches
+# origin as a head. GitHub exposes such a head to the base repository only as
+# refs/pull/<n>/head, which is the one ref the fixture publishes.
+git clone -q "$ROOT/origin.git" "$ROOT/fork"
+git -C "$ROOT/fork" config user.email fork@example.com
+git -C "$ROOT/fork" config user.name Fork
+git -C "$ROOT/fork" config commit.gpgsign false
+git -C "$ROOT/fork" checkout -q -b fix/widget-expiry
+printf 'fork fix\n' >"$ROOT/fork/fix.txt"
+git -C "$ROOT/fork" add fix.txt
+git -C "$ROOT/fork" commit -q -m 'fork fix'
+FORK_HEAD="$(git -C "$ROOT/fork" rev-parse HEAD)"
+git -C "$ROOT/fork" push -q origin "HEAD:refs/pull/7/head"
+
+# A same-repository PR: its head is an ordinary origin branch.
+git -C "$ROOT/main" checkout -q -b feat/same
+printf 'same repo\n' >"$ROOT/main/same.txt"
+git -C "$ROOT/main" add same.txt
+git -C "$ROOT/main" commit -q -m 'same-repo feature'
+SAME_HEAD="$(git -C "$ROOT/main" rev-parse HEAD)"
+git -C "$ROOT/main" push -q origin feat/same "HEAD:refs/pull/8/head"
+git -C "$ROOT/main" checkout -q main
+git -C "$ROOT/main" branch -q -D feat/same
+
+# A pull ref that is not the head gh reports: the base's own tip.
+git -C "$ROOT/main" push -q origin "main:refs/pull/9/head"
+PHANTOM_OID="$(printf '%040d' 1)"
+
+# gh as it answers `pr view <n> --json <fields> -q <query>`: the stored
+# document is the field set gh returns, and the query runs over it.
+cat >"$ROOT/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}:${2:-}" in
+  pr:list) exit 0 ;;
+  pr:view)
+    pr="$3"
+    shift 3
+    query=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        -q | --jq) query="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    doc="${GH_STATE:?}/pr-$pr.json"
+    if [[ ! -f "$doc" ]]; then
+      printf 'GraphQL: Could not resolve to a PullRequest with the number of %s.\n' "$pr" >&2
+      exit 1
+    fi
+    jq -r "$query" "$doc"
+    ;;
+  *)
+    printf 'gh stub: unexpected call %s\n' "$*" >&2
+    exit 64
+    ;;
+esac
+STUB
+chmod +x "$ROOT/bin/gh"
+export PATH="$ROOT/bin:$PATH"
+export GH_STATE="$ROOT/gh-state"
+
+pr_doc() {
+  local number="$1" name="$2" oid="$3" cross="$4"
+  printf '{"headRefName":"%s","headRefOid":"%s","isCrossRepository":%s}\n' \
+    "$name" "$oid" "$cross" >"$GH_STATE/pr-$number.json"
+}
+pr_doc 7 fix/widget-expiry "$FORK_HEAD" true
+pr_doc 8 feat/same "$SAME_HEAD" false
+pr_doc 9 fix/phantom "$PHANTOM_OID" true
+pr_doc 10 fix/no-pull-ref "$FORK_HEAD" true
+
+echo "=== worktree create --pr on a fork pull request ==="
+
+origin_heads_before="$(git -C "$ROOT/origin.git" for-each-ref --format='%(refname) %(objectname)' | sort)"
+
+set +e
+fork_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-fork --pr 7 2>"$ROOT/fork.err")"
+fork_code=$?
+set -e
+FORK_WT="$ROOT/trees/issue-fork"
+assert_eq "$fork_code" "0" "fork PR creates a worktree (stderr: $(tr '\n' ' ' <"$ROOT/fork.err"))"
+assert_eq "$fork_out" "$FORK_WT" "fork PR prints the worktree path"
+assert_eq "$(git -C "$FORK_WT" rev-parse HEAD 2>/dev/null || true)" "$FORK_HEAD" "fork worktree HEAD is the PR head commit"
+assert_eq "$(git -C "$FORK_WT" branch --show-current 2>/dev/null || true)" "fix/widget-expiry" "fork worktree branch carries the contributor's branch name"
+set +e
+fork_upstream="$(git -C "$FORK_WT" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null)"
+fork_upstream_code=$?
+set -e
+assert_eq "$fork_upstream_code:$fork_upstream" "128:" "fork worktree branch has no upstream"
+assert_eq "$(git -C "$ROOT/main" remote | sort | tr '\n' ' ')" "origin " "no remote is added for the fork"
+assert_eq "$(git -C "$ROOT/origin.git" for-each-ref --format='%(refname) %(objectname)' | sort)" "$origin_heads_before" "origin refs are unchanged after the fork checkout"
+
+set +e
+same_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-same --pr 8 2>"$ROOT/same.err")"
+same_code=$?
+set -e
+SAME_WT="$ROOT/trees/issue-same"
+assert_eq "$same_code" "0" "same-repository PR creates a worktree (stderr: $(tr '\n' ' ' <"$ROOT/same.err"))"
+assert_eq "$same_out" "$SAME_WT" "same-repository PR prints the worktree path"
+assert_eq "$(git -C "$SAME_WT" rev-parse HEAD 2>/dev/null || true)" "$SAME_HEAD" "same-repository worktree HEAD is the origin branch tip"
+assert_eq "$(git -C "$SAME_WT" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)" "origin/feat/same" "same-repository branch tracks its origin branch"
+
+# A fork head the base cannot deliver refuses before any worktree exists:
+#   number  issue            message fragment
+rows=(
+  "9	issue-phantom	did not deliver commit $PHANTOM_OID"
+  "10	issue-no-ref	Could not fetch refs/pull/10/head from origin"
+)
+for row in "${rows[@]}"; do
+  IFS=$'\t' read -r number issue fragment <<<"$row"
+  set +e
+  (cd "$ROOT/main" && "$WORKTREE_SCRIPT" create "$issue" --pr "$number" >"$ROOT/$issue.out" 2>"$ROOT/$issue.err")
+  code=$?
+  set -e
+  assert_eq "$code" "1" "PR #$number: undeliverable fork head exits 1"
+  assert_contains "$(cat "$ROOT/$issue.err")" "$fragment" "PR #$number: refusal names the cause"
+  assert_path_absent "$ROOT/trees/$issue" "PR #$number: no worktree is created"
+done
+
+echo
+echo "Passed: $PASS, Failed: $FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/.agents/skills/worktree/tests/worktree_create_fork_pr.sh
+++ b/.agents/skills/worktree/tests/worktree_create_fork_pr.sh
@@ -168,6 +168,47 @@ assert_eq "$same_out" "$SAME_WT" "same-repository PR prints the worktree path"
 assert_eq "$(git -C "$SAME_WT" rev-parse HEAD 2>/dev/null || true)" "$SAME_HEAD" "same-repository worktree HEAD is the origin branch tip"
 assert_eq "$(git -C "$SAME_WT" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)" "origin/feat/same" "same-repository branch tracks its origin branch"
 
+# Inspecting the same fork PR again: `remove` keeps the local branch while the
+# PR is open, the contributor has pushed since, and origin has meanwhile grown
+# an unrelated branch of the same name. The second create resets the stale
+# branch to the new head and still sets no upstream.
+printf 'fork fix 2\n' >>"$ROOT/fork/fix.txt"
+git -C "$ROOT/fork" commit -q -am 'fork fix 2'
+FORK_HEAD_2="$(git -C "$ROOT/fork" rev-parse HEAD)"
+git -C "$ROOT/fork" push -q -f origin "HEAD:refs/pull/7/head"
+pr_doc 7 fix/widget-expiry "$FORK_HEAD_2" true
+git -C "$ROOT/main" push -q origin "main:refs/heads/fix/widget-expiry"
+(cd "$ROOT/main" && "$WORKTREE_SCRIPT" remove issue-fork >/dev/null 2>&1) || true # exits 1: the open PR's branch stays
+assert_path_absent "$FORK_WT" "remove clears the fork worktree"
+assert_eq "$(git -C "$ROOT/main" rev-parse --verify --quiet refs/heads/fix/widget-expiry || true)" "$FORK_HEAD" "remove keeps the open PR's local branch at the first head"
+set +e
+again_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-fork --pr 7 2>"$ROOT/again.err")"
+again_code=$?
+set -e
+assert_eq "$again_code:$again_out" "0:$FORK_WT" "re-inspecting the fork PR after remove creates the worktree again (stderr: $(tr '\n' ' ' <"$ROOT/again.err"))"
+assert_eq "$(git -C "$FORK_WT" rev-parse HEAD 2>/dev/null || true)" "$FORK_HEAD_2" "re-inspected worktree HEAD is the contributor's new head"
+set +e
+again_upstream="$(git -C "$FORK_WT" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null)"
+again_upstream_code=$?
+set -e
+assert_eq "$again_upstream_code:$again_upstream" "128:" "an unrelated origin branch of the same name does not become the upstream"
+
+# A local branch that diverged from the PR head is refused by name, not reset.
+git -C "$FORK_WT" config user.email test@example.com
+git -C "$FORK_WT" config user.name Test
+git -C "$FORK_WT" config commit.gpgsign false
+printf 'local only\n' >"$FORK_WT/local.txt"
+git -C "$FORK_WT" add local.txt
+git -C "$FORK_WT" commit -q -m 'local only'
+(cd "$ROOT/main" && "$WORKTREE_SCRIPT" remove issue-fork >/dev/null 2>&1) || true # exits 1: the open PR's branch stays
+set +e
+(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-fork --pr 7 >"$ROOT/diverged.out" 2>"$ROOT/diverged.err")
+diverged_code=$?
+set -e
+assert_eq "$diverged_code" "1" "a diverged local branch refuses the fork checkout with exit 1"
+assert_contains "$(cat "$ROOT/diverged.err")" "Local branch 'fix/widget-expiry' has commits that are not in the head of fork PR #7" "the refusal names the diverged branch"
+assert_path_absent "$FORK_WT" "a diverged local branch creates no worktree"
+
 # A fork head the base cannot deliver refuses before any worktree exists:
 #   number  issue            message fragment
 rows=(

--- a/.agents/skills/worktree/tests/worktree_create_fork_pr.sh
+++ b/.agents/skills/worktree/tests/worktree_create_fork_pr.sh
@@ -181,6 +181,10 @@ git -C "$ROOT/main" push -q origin "main:refs/heads/fix/widget-expiry"
 (cd "$ROOT/main" && "$WORKTREE_SCRIPT" remove issue-fork >/dev/null 2>&1) || true # exits 1: the open PR's branch stays
 assert_path_absent "$FORK_WT" "remove clears the fork worktree"
 assert_eq "$(git -C "$ROOT/main" rev-parse --verify --quiet refs/heads/fix/widget-expiry || true)" "$FORK_HEAD" "remove keeps the open PR's local branch at the first head"
+# The stale branch also carries tracking config pointing at that unrelated
+# origin branch; -B preserves it, so the create must clear it afterwards.
+git -C "$ROOT/main" fetch -q origin
+git -C "$ROOT/main" branch -q --set-upstream-to=origin/fix/widget-expiry fix/widget-expiry
 set +e
 again_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-fork --pr 7 2>"$ROOT/again.err")"
 again_code=$?

--- a/.agents/skills/worktree/tests/worktree_create_fork_pr.sh
+++ b/.agents/skills/worktree/tests/worktree_create_fork_pr.sh
@@ -140,9 +140,9 @@ export PATH="$ROOT/bin:$PATH"
 export GH_STATE="$ROOT/gh-state"
 
 pr_doc() {
-  local number="$1" name="$2" oid="$3" cross="$4"
-  printf '{"headRefName":"%s","headRefOid":"%s","isCrossRepository":%s}\n' \
-    "$name" "$oid" "$cross" >"$GH_STATE/pr-$number.json"
+  local number="$1" name="$2" oid="$3" cross="$4" state="${5:-OPEN}" base="${6:-main}"
+  printf '{"headRefName":"%s","headRefOid":"%s","isCrossRepository":%s,"state":"%s","baseRefName":"%s"}\n' \
+    "$name" "$oid" "$cross" "$state" "$base" >"$GH_STATE/pr-$number.json"
 }
 pr_doc 7 fix/widget-expiry "$FORK_HEAD" true
 pr_doc 8 feat/same "$SAME_HEAD" false
@@ -259,6 +259,78 @@ for row in "${rows[@]}"; do
   assert_contains "$(cat "$ROOT/$issue.err")" "$fragment" "PR #$number: refusal names the cause"
   assert_path_absent "$ROOT/trees/$issue" "PR #$number: no worktree is created"
 done
+
+echo "=== remove and cleanup prove a merged fork PR by its number ==="
+
+# GitHub files the PR under the contributor's head name, so a --head query
+# for fork-pr-<n> answers nothing; the number in the branch name is the key.
+# A squash lands the content on main as a new commit, so ancestry never
+# proves it either.
+squash_fork_onto_main() {
+  local file="$1" content="$2"
+  printf '%s\n' "$content" >"$ROOT/main/$file"
+  git -C "$ROOT/main" add "$file"
+  git -C "$ROOT/main" commit -q -m "$file (squashed)"
+  git -C "$ROOT/main" push -q origin main
+}
+squash_fork_onto_main from-main.txt 'fork main fix'
+pr_doc 11 main "$FORK_MAIN_HEAD" true MERGED
+squashed_ancestor=no
+git -C "$ROOT/main" merge-base --is-ancestor fork-pr-11 origin/main && squashed_ancestor=yes
+assert_eq "$squashed_ancestor" "no" "precondition: the squashed fork branch is not an ancestor of origin/main"
+set +e
+merged_rm_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" remove issue-from-main 2>"$ROOT/merged-rm.err")"
+merged_rm_code=$?
+set -e
+assert_eq "$merged_rm_code:$merged_rm_out" "0:Removed: $FROM_MAIN_WT" "remove of a merged fork PR worktree exits 0 (stderr: $(tr '\n' ' ' <"$ROOT/merged-rm.err"))"
+assert_path_absent "$FROM_MAIN_WT" "remove clears the merged fork worktree"
+assert_eq "$(git -C "$ROOT/main" rev-parse --verify --quiet refs/heads/fork-pr-11 || true)" "" "remove deletes the merged fork branch"
+assert_contains "$(cat "$ROOT/merged-rm.err")" "Deleted branch 'fork-pr-11' — squash-merged in pull request #11." "remove names the merged pull request"
+
+# cleanup: one merged fork PR (#12) is collected, an open one (#13) is kept.
+git -C "$ROOT/fork" checkout -q -b fix/cleanup main
+printf 'cleanup fix\n' >"$ROOT/fork/cleanup.txt"
+git -C "$ROOT/fork" add cleanup.txt
+git -C "$ROOT/fork" commit -q -m 'cleanup fix'
+CLEANUP_HEAD="$(git -C "$ROOT/fork" rev-parse HEAD)"
+git -C "$ROOT/fork" push -q origin "HEAD:refs/pull/12/head"
+git -C "$ROOT/fork" checkout -q -b fix/still-open main
+printf 'still open\n' >"$ROOT/fork/open.txt"
+git -C "$ROOT/fork" add open.txt
+git -C "$ROOT/fork" commit -q -m 'still open'
+OPEN_HEAD="$(git -C "$ROOT/fork" rev-parse HEAD)"
+git -C "$ROOT/fork" push -q origin "HEAD:refs/pull/13/head"
+pr_doc 12 fix/cleanup "$CLEANUP_HEAD" true
+pr_doc 13 fix/still-open "$OPEN_HEAD" true
+CLEANUP_WT="$ROOT/trees/issue-cleanup"
+OPEN_WT="$ROOT/trees/issue-open"
+set +e
+cleanup_create_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-cleanup --pr 12 2>"$ROOT/cleanup-create.err" \
+  && "$WORKTREE_SCRIPT" create issue-open --pr 13 2>"$ROOT/open-create.err")"
+cleanup_create_code=$?
+set -e
+assert_eq "$cleanup_create_code" "0" "two fork PR worktrees exist before cleanup (stderr: $(cat "$ROOT/cleanup-create.err" "$ROOT/open-create.err" | tr '\n' ' '))"
+squash_fork_onto_main cleanup.txt 'cleanup fix'
+pr_doc 12 fix/cleanup "$CLEANUP_HEAD" true MERGED
+set +e
+cleanup_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" cleanup 2>"$ROOT/cleanup.err")"
+cleanup_code=$?
+set -e
+assert_eq "$cleanup_code" "0" "cleanup exits 0 (stderr: $(tr '\n' ' ' <"$ROOT/cleanup.err"))"
+assert_contains "$cleanup_out" "Cleaned: $CLEANUP_WT" "cleanup collects the merged fork PR worktree"
+assert_path_absent "$CLEANUP_WT" "the merged fork worktree is gone"
+assert_eq "$(git -C "$ROOT/main" rev-parse --verify --quiet refs/heads/fork-pr-12 || true)" "" "cleanup deletes the merged fork branch"
+assert_eq "$(git -C "$OPEN_WT" rev-parse HEAD 2>/dev/null || true)" "$OPEN_HEAD" "cleanup keeps the open fork PR worktree"
+assert_contains "$(cat "$ROOT/cleanup.err")" "fork pull request #13 is OPEN, not merged" "cleanup names the open fork PR it keeps"
+
+# A merged fork PR whose merged head is not this tip is kept: the branch
+# carries work past the merge.
+pr_doc 13 fix/still-open "$FORK_HEAD" true MERGED
+set +e
+(cd "$ROOT/main" && "$WORKTREE_SCRIPT" cleanup >"$ROOT/moved.out" 2>"$ROOT/moved.err")
+set -e
+assert_eq "$(git -C "$OPEN_WT" rev-parse HEAD 2>/dev/null || true)" "$OPEN_HEAD" "a fork branch past its merged head is kept"
+assert_contains "$(cat "$ROOT/moved.err")" "carries work past its merged pull request (#13 merged head $FORK_HEAD" "cleanup names the head mismatch"
 
 echo
 echo "Passed: $PASS, Failed: $FAIL"

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -178,8 +178,8 @@ Options:
   --pr NUMBER     Look up the branch from a GitHub PR number (implies --base);
                   with --base, the way to inspect existing remote work whose
                   issue worktree is absent. A fork PR checks out origin's
-                  refs/pull/NUMBER/head as a local branch named after the
-                  contributor's branch, with no upstream
+                  refs/pull/NUMBER/head as local branch fork-pr-NUMBER, with
+                  no upstream
   --reuse         Explicitly reuse an existing issue worktree: refuses a
                   foreign session-guard lease by name (exit 75), refreshes its
                   own lease in place, rebases onto origin/<default>, then
@@ -2837,11 +2837,15 @@ merged_pr_for_branch() {
   return 1
 }
 
-# Sets BASE to the PR's head branch name. A fork PR also sets PR_HEAD_OID:
-# its head branch lives in the contributor's repository, so origin carries no
-# such head and the commit is reachable only through origin's
-# refs/pull/<n>/head. A same-repository PR leaves PR_HEAD_OID empty and
-# takes the plain --base path.
+# Sets BASE to the branch the PR checks out as. A same-repository PR leaves
+# PR_HEAD_OID empty, sets BASE to its head branch name and takes the plain
+# --base path. A fork PR sets PR_HEAD_OID and BASE to fork-pr-<n>: its head
+# branch lives in the contributor's repository, so origin carries no such
+# head and the commit is reachable only through origin's refs/pull/<n>/head.
+# The contributor's branch name is not reused locally; it shares a namespace
+# with the user's own branches (a fork PR opened from `main` would name the
+# main checkout's branch) and with origin's heads (a push from the inspection
+# worktree would land on an unrelated origin branch of that name).
 resolve_pr_head() {
   local pr="$1" output="" name="" oid="" cross=""
   if ! command -v gh >/dev/null 2>&1; then
@@ -2860,7 +2864,11 @@ resolve_pr_head() {
     return 1
   fi
   case "$cross" in
-    true) PR_HEAD_OID="$oid" ;;
+    true)
+      PR_HEAD_OID="$oid"
+      BASE="fork-pr-$pr"
+      return 0
+      ;;
     false) PR_HEAD_OID="" ;;
     *)
       echo "Error: gh reported an isCrossRepository value this cannot read for PR #$pr: '$cross'" >&2
@@ -2895,11 +2903,11 @@ ensure_base_start_point() {
   ensure_fork_branch_resettable "$pr" "$base" "$head_oid"
 }
 
-# A fork PR's local branch survives `remove` while the PR is open, so a
-# second inspection finds it. The fork add resets it to the PR head; that is
-# lossless only when every commit on the stale branch is in the PR head. A
-# branch that diverged (local commits, or another contributor's branch of
-# the same name) is refused by name rather than reset.
+# A fork PR's local branch fork-pr-<n> survives `remove` while the PR is
+# open, so a second inspection finds it. The fork add resets it to the PR
+# head; that is lossless only when every commit on the stale branch is in
+# the PR head. A branch that diverged (commits made in the inspection
+# worktree) is refused by name rather than reset.
 ensure_fork_branch_resettable() {
   local pr="$1" base="$2" head_oid="$3"
   git -C "$PROJECT_ROOT" rev-parse --verify --quiet "refs/heads/$base" >/dev/null || return 0
@@ -3930,13 +3938,13 @@ case "${1:-}" in
 
       mkdir -p "$TREES_DIR"
       if [[ -n "$PR_HEAD_OID" ]]; then
-        # A fork head has no origin branch to track; the local branch keeps
-        # the contributor's name and no upstream. -B resets the branch a
-        # previous inspection left behind; ensure_fork_branch_resettable has
-        # already refused a branch that reset would lose commits from.
-        # --no-track skips new tracking config, but -B keeps an upstream a
-        # pre-existing branch carried; drop it so a push cannot reach an
-        # unrelated origin branch of the same name.
+        # A fork head has no origin branch to track; the local branch is
+        # fork-pr-<n> with no upstream. -B resets the branch a previous
+        # inspection left behind; ensure_fork_branch_resettable has already
+        # refused a branch that reset would lose commits from. --no-track
+        # skips new tracking config, but -B keeps an upstream a pre-existing
+        # branch carried; drop it so a push cannot reach an origin branch of
+        # that name.
         git -C "$PROJECT_ROOT" worktree add --no-track -B "$BASE" "$WT_PATH" "$PR_HEAD_OID" >/dev/null 2>&1
         if git -C "$WT_PATH" config --get "branch.$BASE.merge" >/dev/null 2>&1; then
           git -C "$WT_PATH" branch --unset-upstream "$BASE" >/dev/null 2>&1 || {

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -177,7 +177,9 @@ Options:
                   gate
   --pr NUMBER     Look up the branch from a GitHub PR number (implies --base);
                   with --base, the way to inspect existing remote work whose
-                  issue worktree is absent
+                  issue worktree is absent. A fork PR checks out origin's
+                  refs/pull/NUMBER/head as a local branch named after the
+                  contributor's branch, with no upstream
   --reuse         Explicitly reuse an existing issue worktree: refuses a
                   foreign session-guard lease by name (exit 75), refreshes its
                   own lease in place, rebases onto origin/<default>, then
@@ -2835,22 +2837,61 @@ merged_pr_for_branch() {
   return 1
 }
 
-resolve_pr_branch() {
-  local pr="$1" output=""
+# Sets BASE to the PR's head branch name. A fork PR also sets PR_HEAD_OID:
+# its head branch lives in the contributor's repository, so origin carries no
+# such head and the commit is reachable only through origin's
+# refs/pull/<n>/head. A same-repository PR leaves PR_HEAD_OID empty and
+# takes the plain --base path.
+resolve_pr_head() {
+  local pr="$1" output="" name="" oid="" cross=""
   if ! command -v gh >/dev/null 2>&1; then
     echo "Error: gh is required to resolve PR #$pr" >&2
     return 1
   fi
-  if ! output="$(gh pr view "$pr" --json headRefName -q .headRefName 2>&1)"; then
+  if ! output="$(gh pr view "$pr" --json headRefName,headRefOid,isCrossRepository \
+                  -q '[.headRefName, .headRefOid, (.isCrossRepository | tostring)] | @tsv' 2>&1)"; then
     echo "Error: Could not find branch for PR #$pr" >&2
     [[ -n "$output" ]] && sed 's/^/  /' <<<"$output" >&2
     return 1
   fi
-  if [[ -z "$output" ]]; then
+  IFS=$'\t' read -r name oid cross <<<"$output"
+  if [[ -z "$name" ]] || ! [[ "$oid" =~ ^[0-9a-f]{40,64}$ ]]; then
     echo "Error: Could not find branch for PR #$pr" >&2
     return 1
   fi
-  printf '%s\n' "$output"
+  case "$cross" in
+    true) PR_HEAD_OID="$oid" ;;
+    false) PR_HEAD_OID="" ;;
+    *)
+      echo "Error: gh reported an isCrossRepository value this cannot read for PR #$pr: '$cross'" >&2
+      return 1
+      ;;
+  esac
+  BASE="$name"
+}
+
+# The start point for --base/--pr must exist before any mutation. A fork PR
+# head is fetched from origin's refs/pull/<n>/head, and the fetch counts only
+# if it delivered the commit gh reported as the head. No remote is added for
+# the fork, so nothing here can ever push to it.
+ensure_base_start_point() {
+  local pr="$1" base="$2" head_oid="$3" output=""
+  if [[ -z "$head_oid" ]]; then
+    if ! remote_branch_discovered origin "$base"; then
+      echo "Error: Cannot resolve remote branch 'origin/$base'" >&2
+      return 1
+    fi
+    return 0
+  fi
+  if ! output="$(git_with_github_https_auth -C "$PROJECT_ROOT" fetch origin "refs/pull/$pr/head" 2>&1)"; then
+    echo "Error: Could not fetch refs/pull/$pr/head from origin for fork PR #$pr" >&2
+    [[ -n "$output" ]] && sed 's/^/  /' <<<"$output" >&2
+    return 1
+  fi
+  if ! git -C "$PROJECT_ROOT" rev-parse --verify --quiet "$head_oid^{commit}" >/dev/null; then
+    echo "Error: refs/pull/$pr/head on origin did not deliver commit $head_oid, the head gh reports for PR #$pr" >&2
+    return 1
+  fi
 }
 
 CANDIDATE_BRANCHES=()
@@ -3833,16 +3874,14 @@ case "${1:-}" in
     # 3. Explicit --pr/--base are inspection modes, not claims. Their
     # authoritative branch/ref lookup must succeed before mutation, and the
     # issue lock serializes their final check plus add.
+    PR_HEAD_OID=""
     if [[ -n "$PR" ]]; then
-      BASE="$(resolve_pr_branch "$PR")" || exit 1
+      resolve_pr_head "$PR" || exit 1
     fi
 
     if [[ -n "$BASE" ]]; then
       discover_ownership_remote_heads || exit 1
-      if ! remote_branch_discovered origin "$BASE"; then
-        echo "Error: Cannot resolve remote branch 'origin/$BASE'" >&2
-        exit 1
-      fi
+      ensure_base_start_point "$PR" "$BASE" "$PR_HEAD_OID" || exit 1
       EXISTING_WT="$(worktree_for_branch "$BASE" 2>/dev/null || true)"
       if [[ -n "$EXISTING_WT" ]]; then
         # A base branch checked out in the main checkout is not issue work,
@@ -3858,14 +3897,11 @@ case "${1:-}" in
       acquire_issue_claim_lock "$ISSUE" || exit 1
       guard_new_target_path "$ISSUE" "$WT_PATH" || exit "$ACTIVE_WORK_EXIT"
       if [[ -n "$PR" ]]; then
-        BASE="$(resolve_pr_branch "$PR")" || exit 1
+        resolve_pr_head "$PR" || exit 1
       fi
       fetch_origin || exit 1
       discover_ownership_remote_heads || exit 1
-      if ! remote_branch_discovered origin "$BASE"; then
-        echo "Error: Cannot resolve remote branch 'origin/$BASE'" >&2
-        exit 1
-      fi
+      ensure_base_start_point "$PR" "$BASE" "$PR_HEAD_OID" || exit 1
       EXISTING_WT="$(worktree_for_branch "$BASE" 2>/dev/null || true)"
       if [[ -n "$EXISTING_WT" ]]; then
         # Same main-checkout guard as the pre-lock check above.
@@ -3877,8 +3913,14 @@ case "${1:-}" in
       fi
 
       mkdir -p "$TREES_DIR"
-      git -C "$PROJECT_ROOT" worktree add --track -b "$BASE" "$WT_PATH" "origin/$BASE" >/dev/null 2>&1 || \
-        git -C "$PROJECT_ROOT" worktree add "$WT_PATH" "$BASE" >/dev/null 2>&1
+      if [[ -n "$PR_HEAD_OID" ]]; then
+        # A fork head has no origin branch to track; the local branch keeps
+        # the contributor's name and no upstream.
+        git -C "$PROJECT_ROOT" worktree add --no-track -b "$BASE" "$WT_PATH" "$PR_HEAD_OID" >/dev/null 2>&1
+      else
+        git -C "$PROJECT_ROOT" worktree add --track -b "$BASE" "$WT_PATH" "origin/$BASE" >/dev/null 2>&1 || \
+          git -C "$PROJECT_ROOT" worktree add "$WT_PATH" "$BASE" >/dev/null 2>&1
+      fi
     else
       build_candidate_branches "$ISSUE" "$BRANCH"
       discover_candidate_ownership || exit 1

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -2787,6 +2787,13 @@ merged_pr_for_branch() {
     printf 'branch has no local tip to compare a merged pull request against\n'
     return 2
   fi
+  # A fork inspection branch is named fork-pr-<n> (see resolve_pr_head), and
+  # GitHub files that PR under the contributor's head name, so a --head query
+  # can never find it. The number in the name is the lookup key instead.
+  if [[ "$branch" =~ ^fork-pr-([0-9]+)$ ]]; then
+    merged_fork_pr_at_tip "${BASH_REMATCH[1]}" "$tip"
+    return $?
+  fi
   if ! err_file="$(mktemp "${TMPDIR:-/tmp}/worktree-merged-pr.XXXXXX")"; then
     printf 'could not create a scratch file for the gh diagnostic\n'
     return 2
@@ -2835,6 +2842,47 @@ merged_pr_for_branch() {
   printf 'carries work past its merged pull request (merged under this name:%s; none has this tip %s as its head)\n' \
     "$seen" "$tip"
   return 1
+}
+
+# The merged proof for a fork-pr-<n> branch: PR <n> is merged into the default
+# branch and the head it merged is this tip. Same exit contract as
+# merged_pr_for_branch; the proof is commit identity, and the PR number in the
+# branch name is only the lookup key.
+merged_fork_pr_at_tip() {
+  local pr="$1" tip="$2" err_file="" row="" detail="" state="" base="" oid="" rc=0
+  if ! err_file="$(mktemp "${TMPDIR:-/tmp}/worktree-merged-pr.XXXXXX")"; then
+    printf 'could not create a scratch file for the gh diagnostic\n'
+    return 2
+  fi
+  row="$( (cd "$PROJECT_ROOT" && env -u GH_REPO -u GITHUB_REPOSITORY \
+             gh pr view "$pr" --json state,baseRefName,headRefOid \
+             --jq '[.state, .baseRefName, .headRefOid] | @tsv') 2>"$err_file" )" || rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    detail="$(tr '\n' ' ' <"$err_file")"
+    rm -f "$err_file"
+    printf '%s\n' "${detail:-gh pr view $pr failed (exit $rc)}"
+    return 2
+  fi
+  rm -f "$err_file"
+  IFS=$'\t' read -r state base oid <<<"$row"
+  if [[ -z "$state" || -z "$base" ]] || ! [[ "$oid" =~ ^[0-9a-f]{7,64}$ ]]; then
+    printf 'gh returned a pull request #%s record this cannot read: %s\n' "$pr" "$row"
+    return 2
+  fi
+  if [[ "$state" != "MERGED" ]]; then
+    printf 'fork pull request #%s is %s, not merged\n' "$pr" "$state"
+    return 1
+  fi
+  if [[ "$base" != "$DEFAULT_BRANCH" ]]; then
+    printf 'fork pull request #%s merged into %s, not %s\n' "$pr" "$base" "$DEFAULT_BRANCH"
+    return 1
+  fi
+  if [[ "$oid" != "$tip" ]]; then
+    printf 'carries work past its merged pull request (#%s merged head %s, not this tip %s)\n' "$pr" "$oid" "$tip"
+    return 1
+  fi
+  printf '%s\n' "$pr"
+  return 0
 }
 
 # Sets BASE to the branch the PR checks out as. A same-repository PR leaves

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -3934,7 +3934,16 @@ case "${1:-}" in
         # the contributor's name and no upstream. -B resets the branch a
         # previous inspection left behind; ensure_fork_branch_resettable has
         # already refused a branch that reset would lose commits from.
+        # --no-track skips new tracking config, but -B keeps an upstream a
+        # pre-existing branch carried; drop it so a push cannot reach an
+        # unrelated origin branch of the same name.
         git -C "$PROJECT_ROOT" worktree add --no-track -B "$BASE" "$WT_PATH" "$PR_HEAD_OID" >/dev/null 2>&1
+        if git -C "$WT_PATH" config --get "branch.$BASE.merge" >/dev/null 2>&1; then
+          git -C "$WT_PATH" branch --unset-upstream "$BASE" >/dev/null 2>&1 || {
+            echo "Error: could not clear the upstream of branch '$BASE' in $WT_PATH" >&2
+            exit 1
+          }
+        fi
       else
         git -C "$PROJECT_ROOT" worktree add --track -b "$BASE" "$WT_PATH" "origin/$BASE" >/dev/null 2>&1 || \
           git -C "$PROJECT_ROOT" worktree add "$WT_PATH" "$BASE" >/dev/null 2>&1

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -2892,6 +2892,22 @@ ensure_base_start_point() {
     echo "Error: refs/pull/$pr/head on origin did not deliver commit $head_oid, the head gh reports for PR #$pr" >&2
     return 1
   fi
+  ensure_fork_branch_resettable "$pr" "$base" "$head_oid"
+}
+
+# A fork PR's local branch survives `remove` while the PR is open, so a
+# second inspection finds it. The fork add resets it to the PR head; that is
+# lossless only when every commit on the stale branch is in the PR head. A
+# branch that diverged (local commits, or another contributor's branch of
+# the same name) is refused by name rather than reset.
+ensure_fork_branch_resettable() {
+  local pr="$1" base="$2" head_oid="$3"
+  git -C "$PROJECT_ROOT" rev-parse --verify --quiet "refs/heads/$base" >/dev/null || return 0
+  if git -C "$PROJECT_ROOT" merge-base --is-ancestor "refs/heads/$base" "$head_oid" 2>/dev/null; then
+    return 0
+  fi
+  echo "Error: Local branch '$base' has commits that are not in the head of fork PR #$pr; delete or rename that branch before inspecting the PR again." >&2
+  return 1
 }
 
 CANDIDATE_BRANCHES=()
@@ -3915,8 +3931,10 @@ case "${1:-}" in
       mkdir -p "$TREES_DIR"
       if [[ -n "$PR_HEAD_OID" ]]; then
         # A fork head has no origin branch to track; the local branch keeps
-        # the contributor's name and no upstream.
-        git -C "$PROJECT_ROOT" worktree add --no-track -b "$BASE" "$WT_PATH" "$PR_HEAD_OID" >/dev/null 2>&1
+        # the contributor's name and no upstream. -B resets the branch a
+        # previous inspection left behind; ensure_fork_branch_resettable has
+        # already refused a branch that reset would lose commits from.
+        git -C "$PROJECT_ROOT" worktree add --no-track -B "$BASE" "$WT_PATH" "$PR_HEAD_OID" >/dev/null 2>&1
       else
         git -C "$PROJECT_ROOT" worktree add --track -b "$BASE" "$WT_PATH" "origin/$BASE" >/dev/null 2>&1 || \
           git -C "$PROJECT_ROOT" worktree add "$WT_PATH" "$BASE" >/dev/null 2>&1
@@ -3938,9 +3956,10 @@ case "${1:-}" in
 
     release_issue_claim_lock
 
-    # Set upstream tracking if remote branch exists
+    # Set upstream tracking if remote branch exists. A fork PR branch keeps
+    # no upstream even when origin has an unrelated branch of the same name.
     CREATED_BRANCH=$(git -C "$WT_PATH" branch --show-current 2>/dev/null)
-    if [[ -n "$CREATED_BRANCH" ]]; then
+    if [[ -n "$CREATED_BRANCH" && -z "$PR_HEAD_OID" ]]; then
       _REMOTE="${BOT_REMOTE_NAME:-origin}"
       if git -C "$WT_PATH" rev-parse --verify "$_REMOTE/$CREATED_BRANCH" &>/dev/null; then
         git -C "$WT_PATH" branch --set-upstream-to="$_REMOTE/$CREATED_BRANCH" "$CREATED_BRANCH" >/dev/null 2>&1 || true

--- a/skills/worktree/tests/worktree_create_active_guard.sh
+++ b/skills/worktree/tests/worktree_create_active_guard.sh
@@ -121,7 +121,17 @@ case "${1:-}:${2:-}" in
     fi
     ;;
   pr:view)
-    printf 'issue-active\n'
+    # `pr view <n> --json <fields> -q <query>`: the stored document is the
+    # field set gh returns, and the query runs over it.
+    shift 3
+    query=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        -q | --jq) query="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    jq -r "$query" "${GH_STATE:?}/pr-42.json"
     ;;
 esac
 STUB
@@ -194,6 +204,8 @@ assert_eq "$pr_guard_code" "75" "bare create exits 75 for an open PR without a l
 assert_contains "$pr_guard_err" "open pull request (#42)" "branch guard reports the PR ownership signal"
 assert_path_absent "$WT" "open-PR guard creates no duplicate checkout"
 
+printf '{"headRefName":"issue-active","headRefOid":"%s","isCrossRepository":false}\n' \
+  "$(git -C "$ROOT/main" rev-parse origin/issue-active)" >"$GH_STATE/pr-42.json"
 pr_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-active --pr 42)"
 assert_eq "$pr_out" "$WT" "--pr explicitly creates an inspection worktree"
 assert_path_exists "$WT/.git" "explicit PR checkout is a registered worktree"

--- a/skills/worktree/tests/worktree_create_fork_pr.sh
+++ b/skills/worktree/tests/worktree_create_fork_pr.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # Tests for `create --pr` against a fork pull request: the head branch lives
 # in the contributor's repository, so origin has no such head and the commit
-# is reachable only through origin's refs/pull/<n>/head. A same-repository PR
-# keeps the tracked origin-branch checkout, and a pull ref that does not
-# deliver the head gh reports refuses before any worktree exists.
+# is reachable only through origin's refs/pull/<n>/head. The worktree branch
+# is fork-pr-<n>, so the contributor's branch name never touches a local or
+# origin branch of the same name. A same-repository PR keeps the tracked
+# origin-branch checkout, and a pull ref that does not deliver the head gh
+# reports refuses before any worktree exists.
 set -euo pipefail
 
 # A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
@@ -93,6 +95,16 @@ git -C "$ROOT/main" branch -q -D feat/same
 git -C "$ROOT/main" push -q origin "main:refs/pull/9/head"
 PHANTOM_OID="$(printf '%040d' 1)"
 
+# A fork PR opened from the fork's own `main`: the head branch name is the
+# main checkout's branch name.
+git -C "$ROOT/fork" checkout -q main
+printf 'fork main fix\n' >"$ROOT/fork/from-main.txt"
+git -C "$ROOT/fork" add from-main.txt
+git -C "$ROOT/fork" commit -q -m 'fork main fix'
+FORK_MAIN_HEAD="$(git -C "$ROOT/fork" rev-parse HEAD)"
+git -C "$ROOT/fork" push -q origin "HEAD:refs/pull/11/head"
+git -C "$ROOT/fork" checkout -q fix/widget-expiry
+
 # gh as it answers `pr view <n> --json <fields> -q <query>`: the stored
 # document is the field set gh returns, and the query runs over it.
 cat >"$ROOT/bin/gh" <<'STUB'
@@ -136,6 +148,7 @@ pr_doc 7 fix/widget-expiry "$FORK_HEAD" true
 pr_doc 8 feat/same "$SAME_HEAD" false
 pr_doc 9 fix/phantom "$PHANTOM_OID" true
 pr_doc 10 fix/no-pull-ref "$FORK_HEAD" true
+pr_doc 11 main "$FORK_MAIN_HEAD" true
 
 echo "=== worktree create --pr on a fork pull request ==="
 
@@ -149,7 +162,8 @@ FORK_WT="$ROOT/trees/issue-fork"
 assert_eq "$fork_code" "0" "fork PR creates a worktree (stderr: $(tr '\n' ' ' <"$ROOT/fork.err"))"
 assert_eq "$fork_out" "$FORK_WT" "fork PR prints the worktree path"
 assert_eq "$(git -C "$FORK_WT" rev-parse HEAD 2>/dev/null || true)" "$FORK_HEAD" "fork worktree HEAD is the PR head commit"
-assert_eq "$(git -C "$FORK_WT" branch --show-current 2>/dev/null || true)" "fix/widget-expiry" "fork worktree branch carries the contributor's branch name"
+assert_eq "$(git -C "$FORK_WT" branch --show-current 2>/dev/null || true)" "fork-pr-7" "fork worktree branch is fork-pr-7, not the contributor's branch name"
+assert_eq "$(git -C "$ROOT/main" rev-parse --verify --quiet refs/heads/fix/widget-expiry || true)" "" "no local branch carries the contributor's branch name"
 set +e
 fork_upstream="$(git -C "$FORK_WT" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null)"
 fork_upstream_code=$?
@@ -168,10 +182,26 @@ assert_eq "$same_out" "$SAME_WT" "same-repository PR prints the worktree path"
 assert_eq "$(git -C "$SAME_WT" rev-parse HEAD 2>/dev/null || true)" "$SAME_HEAD" "same-repository worktree HEAD is the origin branch tip"
 assert_eq "$(git -C "$SAME_WT" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)" "origin/feat/same" "same-repository branch tracks its origin branch"
 
-# Inspecting the same fork PR again: `remove` keeps the local branch while the
-# PR is open, the contributor has pushed since, and origin has meanwhile grown
-# an unrelated branch of the same name. The second create resets the stale
-# branch to the new head and still sets no upstream.
+# A fork PR whose head branch is named `main` is inspectable: the local
+# branch is fork-pr-11, so the main checkout's `main` is neither in the way
+# nor reset to the contributor's commit.
+LOCAL_MAIN_BEFORE="$(git -C "$ROOT/main" rev-parse refs/heads/main)"
+set +e
+from_main_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-from-main --pr 11 2>"$ROOT/from-main.err")"
+from_main_code=$?
+set -e
+FROM_MAIN_WT="$ROOT/trees/issue-from-main"
+assert_eq "$from_main_code:$from_main_out" "0:$FROM_MAIN_WT" "a fork PR opened from the fork's main creates a worktree (stderr: $(tr '\n' ' ' <"$ROOT/from-main.err"))"
+assert_eq "$(git -C "$FROM_MAIN_WT" rev-parse HEAD 2>/dev/null || true)" "$FORK_MAIN_HEAD" "fork-from-main worktree HEAD is the PR head commit"
+assert_eq "$(git -C "$FROM_MAIN_WT" branch --show-current 2>/dev/null || true)" "fork-pr-11" "fork-from-main worktree branch is fork-pr-11"
+assert_eq "$(git -C "$ROOT/main" rev-parse refs/heads/main)" "$LOCAL_MAIN_BEFORE" "the main checkout's local main is untouched"
+assert_eq "$(git -C "$ROOT/main" branch --show-current)" "main" "the main checkout still has main checked out"
+
+# Inspecting the same fork PR again: `remove` keeps the local fork-pr-7 branch
+# while the PR is open, the contributor has pushed since, and origin has
+# meanwhile grown an unrelated branch under the contributor's branch name.
+# The second create resets the stale branch to the new head and still sets
+# no upstream.
 printf 'fork fix 2\n' >>"$ROOT/fork/fix.txt"
 git -C "$ROOT/fork" commit -q -am 'fork fix 2'
 FORK_HEAD_2="$(git -C "$ROOT/fork" rev-parse HEAD)"
@@ -180,11 +210,11 @@ pr_doc 7 fix/widget-expiry "$FORK_HEAD_2" true
 git -C "$ROOT/main" push -q origin "main:refs/heads/fix/widget-expiry"
 (cd "$ROOT/main" && "$WORKTREE_SCRIPT" remove issue-fork >/dev/null 2>&1) || true # exits 1: the open PR's branch stays
 assert_path_absent "$FORK_WT" "remove clears the fork worktree"
-assert_eq "$(git -C "$ROOT/main" rev-parse --verify --quiet refs/heads/fix/widget-expiry || true)" "$FORK_HEAD" "remove keeps the open PR's local branch at the first head"
+assert_eq "$(git -C "$ROOT/main" rev-parse --verify --quiet refs/heads/fork-pr-7 || true)" "$FORK_HEAD" "remove keeps the open PR's local branch at the first head"
 # The stale branch also carries tracking config pointing at that unrelated
 # origin branch; -B preserves it, so the create must clear it afterwards.
 git -C "$ROOT/main" fetch -q origin
-git -C "$ROOT/main" branch -q --set-upstream-to=origin/fix/widget-expiry fix/widget-expiry
+git -C "$ROOT/main" branch -q --set-upstream-to=origin/fix/widget-expiry fork-pr-7
 set +e
 again_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-fork --pr 7 2>"$ROOT/again.err")"
 again_code=$?
@@ -210,7 +240,7 @@ set +e
 diverged_code=$?
 set -e
 assert_eq "$diverged_code" "1" "a diverged local branch refuses the fork checkout with exit 1"
-assert_contains "$(cat "$ROOT/diverged.err")" "Local branch 'fix/widget-expiry' has commits that are not in the head of fork PR #7" "the refusal names the diverged branch"
+assert_contains "$(cat "$ROOT/diverged.err")" "Local branch 'fork-pr-7' has commits that are not in the head of fork PR #7" "the refusal names the diverged branch"
 assert_path_absent "$FORK_WT" "a diverged local branch creates no worktree"
 
 # A fork head the base cannot deliver refuses before any worktree exists:

--- a/skills/worktree/tests/worktree_create_fork_pr.sh
+++ b/skills/worktree/tests/worktree_create_fork_pr.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# Tests for `create --pr` against a fork pull request: the head branch lives
+# in the contributor's repository, so origin has no such head and the commit
+# is reachable only through origin's refs/pull/<n>/head. A same-repository PR
+# keeps the tracked origin-branch checkout, and a pull ref that does not
+# deliver the head gh reports refuses before any worktree exists.
+set -euo pipefail
+
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call in this file back at the real repository.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        wanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
+  fi
+}
+
+assert_path_absent() {
+  local path="$1" name="$2"
+  if [[ ! -e "$path" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        unexpected path: %s\n' "$name" "$path"
+  fi
+}
+
+ROOT="$TMP_ROOT/fork-pr"
+mkdir -p "$ROOT/main" "$ROOT/bin" "$ROOT/gh-state"
+git -C "$ROOT/main" init -q -b main
+git -C "$ROOT/main" config user.email test@example.com
+git -C "$ROOT/main" config user.name Test
+git -C "$ROOT/main" config commit.gpgsign false
+printf 'base\n' >"$ROOT/main/base.txt"
+git -C "$ROOT/main" add base.txt
+git -C "$ROOT/main" commit -q -m base
+printf 'WORKTREE_BASE_DIR="../trees"\n' >"$ROOT/main/.env.local"
+git init -q --bare "$ROOT/origin.git"
+git -C "$ROOT/main" remote add origin "$ROOT/origin.git"
+git -C "$ROOT/main" push -q -u origin main
+
+# The contributor's repository: a clone of origin whose branch never reaches
+# origin as a head. GitHub exposes such a head to the base repository only as
+# refs/pull/<n>/head, which is the one ref the fixture publishes.
+git clone -q "$ROOT/origin.git" "$ROOT/fork"
+git -C "$ROOT/fork" config user.email fork@example.com
+git -C "$ROOT/fork" config user.name Fork
+git -C "$ROOT/fork" config commit.gpgsign false
+git -C "$ROOT/fork" checkout -q -b fix/widget-expiry
+printf 'fork fix\n' >"$ROOT/fork/fix.txt"
+git -C "$ROOT/fork" add fix.txt
+git -C "$ROOT/fork" commit -q -m 'fork fix'
+FORK_HEAD="$(git -C "$ROOT/fork" rev-parse HEAD)"
+git -C "$ROOT/fork" push -q origin "HEAD:refs/pull/7/head"
+
+# A same-repository PR: its head is an ordinary origin branch.
+git -C "$ROOT/main" checkout -q -b feat/same
+printf 'same repo\n' >"$ROOT/main/same.txt"
+git -C "$ROOT/main" add same.txt
+git -C "$ROOT/main" commit -q -m 'same-repo feature'
+SAME_HEAD="$(git -C "$ROOT/main" rev-parse HEAD)"
+git -C "$ROOT/main" push -q origin feat/same "HEAD:refs/pull/8/head"
+git -C "$ROOT/main" checkout -q main
+git -C "$ROOT/main" branch -q -D feat/same
+
+# A pull ref that is not the head gh reports: the base's own tip.
+git -C "$ROOT/main" push -q origin "main:refs/pull/9/head"
+PHANTOM_OID="$(printf '%040d' 1)"
+
+# gh as it answers `pr view <n> --json <fields> -q <query>`: the stored
+# document is the field set gh returns, and the query runs over it.
+cat >"$ROOT/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}:${2:-}" in
+  pr:list) exit 0 ;;
+  pr:view)
+    pr="$3"
+    shift 3
+    query=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        -q | --jq) query="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    doc="${GH_STATE:?}/pr-$pr.json"
+    if [[ ! -f "$doc" ]]; then
+      printf 'GraphQL: Could not resolve to a PullRequest with the number of %s.\n' "$pr" >&2
+      exit 1
+    fi
+    jq -r "$query" "$doc"
+    ;;
+  *)
+    printf 'gh stub: unexpected call %s\n' "$*" >&2
+    exit 64
+    ;;
+esac
+STUB
+chmod +x "$ROOT/bin/gh"
+export PATH="$ROOT/bin:$PATH"
+export GH_STATE="$ROOT/gh-state"
+
+pr_doc() {
+  local number="$1" name="$2" oid="$3" cross="$4"
+  printf '{"headRefName":"%s","headRefOid":"%s","isCrossRepository":%s}\n' \
+    "$name" "$oid" "$cross" >"$GH_STATE/pr-$number.json"
+}
+pr_doc 7 fix/widget-expiry "$FORK_HEAD" true
+pr_doc 8 feat/same "$SAME_HEAD" false
+pr_doc 9 fix/phantom "$PHANTOM_OID" true
+pr_doc 10 fix/no-pull-ref "$FORK_HEAD" true
+
+echo "=== worktree create --pr on a fork pull request ==="
+
+origin_heads_before="$(git -C "$ROOT/origin.git" for-each-ref --format='%(refname) %(objectname)' | sort)"
+
+set +e
+fork_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-fork --pr 7 2>"$ROOT/fork.err")"
+fork_code=$?
+set -e
+FORK_WT="$ROOT/trees/issue-fork"
+assert_eq "$fork_code" "0" "fork PR creates a worktree (stderr: $(tr '\n' ' ' <"$ROOT/fork.err"))"
+assert_eq "$fork_out" "$FORK_WT" "fork PR prints the worktree path"
+assert_eq "$(git -C "$FORK_WT" rev-parse HEAD 2>/dev/null || true)" "$FORK_HEAD" "fork worktree HEAD is the PR head commit"
+assert_eq "$(git -C "$FORK_WT" branch --show-current 2>/dev/null || true)" "fix/widget-expiry" "fork worktree branch carries the contributor's branch name"
+set +e
+fork_upstream="$(git -C "$FORK_WT" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null)"
+fork_upstream_code=$?
+set -e
+assert_eq "$fork_upstream_code:$fork_upstream" "128:" "fork worktree branch has no upstream"
+assert_eq "$(git -C "$ROOT/main" remote | sort | tr '\n' ' ')" "origin " "no remote is added for the fork"
+assert_eq "$(git -C "$ROOT/origin.git" for-each-ref --format='%(refname) %(objectname)' | sort)" "$origin_heads_before" "origin refs are unchanged after the fork checkout"
+
+set +e
+same_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-same --pr 8 2>"$ROOT/same.err")"
+same_code=$?
+set -e
+SAME_WT="$ROOT/trees/issue-same"
+assert_eq "$same_code" "0" "same-repository PR creates a worktree (stderr: $(tr '\n' ' ' <"$ROOT/same.err"))"
+assert_eq "$same_out" "$SAME_WT" "same-repository PR prints the worktree path"
+assert_eq "$(git -C "$SAME_WT" rev-parse HEAD 2>/dev/null || true)" "$SAME_HEAD" "same-repository worktree HEAD is the origin branch tip"
+assert_eq "$(git -C "$SAME_WT" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)" "origin/feat/same" "same-repository branch tracks its origin branch"
+
+# A fork head the base cannot deliver refuses before any worktree exists:
+#   number  issue            message fragment
+rows=(
+  "9	issue-phantom	did not deliver commit $PHANTOM_OID"
+  "10	issue-no-ref	Could not fetch refs/pull/10/head from origin"
+)
+for row in "${rows[@]}"; do
+  IFS=$'\t' read -r number issue fragment <<<"$row"
+  set +e
+  (cd "$ROOT/main" && "$WORKTREE_SCRIPT" create "$issue" --pr "$number" >"$ROOT/$issue.out" 2>"$ROOT/$issue.err")
+  code=$?
+  set -e
+  assert_eq "$code" "1" "PR #$number: undeliverable fork head exits 1"
+  assert_contains "$(cat "$ROOT/$issue.err")" "$fragment" "PR #$number: refusal names the cause"
+  assert_path_absent "$ROOT/trees/$issue" "PR #$number: no worktree is created"
+done
+
+echo
+echo "Passed: $PASS, Failed: $FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/worktree/tests/worktree_create_fork_pr.sh
+++ b/skills/worktree/tests/worktree_create_fork_pr.sh
@@ -168,6 +168,47 @@ assert_eq "$same_out" "$SAME_WT" "same-repository PR prints the worktree path"
 assert_eq "$(git -C "$SAME_WT" rev-parse HEAD 2>/dev/null || true)" "$SAME_HEAD" "same-repository worktree HEAD is the origin branch tip"
 assert_eq "$(git -C "$SAME_WT" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)" "origin/feat/same" "same-repository branch tracks its origin branch"
 
+# Inspecting the same fork PR again: `remove` keeps the local branch while the
+# PR is open, the contributor has pushed since, and origin has meanwhile grown
+# an unrelated branch of the same name. The second create resets the stale
+# branch to the new head and still sets no upstream.
+printf 'fork fix 2\n' >>"$ROOT/fork/fix.txt"
+git -C "$ROOT/fork" commit -q -am 'fork fix 2'
+FORK_HEAD_2="$(git -C "$ROOT/fork" rev-parse HEAD)"
+git -C "$ROOT/fork" push -q -f origin "HEAD:refs/pull/7/head"
+pr_doc 7 fix/widget-expiry "$FORK_HEAD_2" true
+git -C "$ROOT/main" push -q origin "main:refs/heads/fix/widget-expiry"
+(cd "$ROOT/main" && "$WORKTREE_SCRIPT" remove issue-fork >/dev/null 2>&1) || true # exits 1: the open PR's branch stays
+assert_path_absent "$FORK_WT" "remove clears the fork worktree"
+assert_eq "$(git -C "$ROOT/main" rev-parse --verify --quiet refs/heads/fix/widget-expiry || true)" "$FORK_HEAD" "remove keeps the open PR's local branch at the first head"
+set +e
+again_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-fork --pr 7 2>"$ROOT/again.err")"
+again_code=$?
+set -e
+assert_eq "$again_code:$again_out" "0:$FORK_WT" "re-inspecting the fork PR after remove creates the worktree again (stderr: $(tr '\n' ' ' <"$ROOT/again.err"))"
+assert_eq "$(git -C "$FORK_WT" rev-parse HEAD 2>/dev/null || true)" "$FORK_HEAD_2" "re-inspected worktree HEAD is the contributor's new head"
+set +e
+again_upstream="$(git -C "$FORK_WT" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null)"
+again_upstream_code=$?
+set -e
+assert_eq "$again_upstream_code:$again_upstream" "128:" "an unrelated origin branch of the same name does not become the upstream"
+
+# A local branch that diverged from the PR head is refused by name, not reset.
+git -C "$FORK_WT" config user.email test@example.com
+git -C "$FORK_WT" config user.name Test
+git -C "$FORK_WT" config commit.gpgsign false
+printf 'local only\n' >"$FORK_WT/local.txt"
+git -C "$FORK_WT" add local.txt
+git -C "$FORK_WT" commit -q -m 'local only'
+(cd "$ROOT/main" && "$WORKTREE_SCRIPT" remove issue-fork >/dev/null 2>&1) || true # exits 1: the open PR's branch stays
+set +e
+(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-fork --pr 7 >"$ROOT/diverged.out" 2>"$ROOT/diverged.err")
+diverged_code=$?
+set -e
+assert_eq "$diverged_code" "1" "a diverged local branch refuses the fork checkout with exit 1"
+assert_contains "$(cat "$ROOT/diverged.err")" "Local branch 'fix/widget-expiry' has commits that are not in the head of fork PR #7" "the refusal names the diverged branch"
+assert_path_absent "$FORK_WT" "a diverged local branch creates no worktree"
+
 # A fork head the base cannot deliver refuses before any worktree exists:
 #   number  issue            message fragment
 rows=(

--- a/skills/worktree/tests/worktree_create_fork_pr.sh
+++ b/skills/worktree/tests/worktree_create_fork_pr.sh
@@ -181,6 +181,10 @@ git -C "$ROOT/main" push -q origin "main:refs/heads/fix/widget-expiry"
 (cd "$ROOT/main" && "$WORKTREE_SCRIPT" remove issue-fork >/dev/null 2>&1) || true # exits 1: the open PR's branch stays
 assert_path_absent "$FORK_WT" "remove clears the fork worktree"
 assert_eq "$(git -C "$ROOT/main" rev-parse --verify --quiet refs/heads/fix/widget-expiry || true)" "$FORK_HEAD" "remove keeps the open PR's local branch at the first head"
+# The stale branch also carries tracking config pointing at that unrelated
+# origin branch; -B preserves it, so the create must clear it afterwards.
+git -C "$ROOT/main" fetch -q origin
+git -C "$ROOT/main" branch -q --set-upstream-to=origin/fix/widget-expiry fix/widget-expiry
 set +e
 again_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-fork --pr 7 2>"$ROOT/again.err")"
 again_code=$?

--- a/skills/worktree/tests/worktree_create_fork_pr.sh
+++ b/skills/worktree/tests/worktree_create_fork_pr.sh
@@ -140,9 +140,9 @@ export PATH="$ROOT/bin:$PATH"
 export GH_STATE="$ROOT/gh-state"
 
 pr_doc() {
-  local number="$1" name="$2" oid="$3" cross="$4"
-  printf '{"headRefName":"%s","headRefOid":"%s","isCrossRepository":%s}\n' \
-    "$name" "$oid" "$cross" >"$GH_STATE/pr-$number.json"
+  local number="$1" name="$2" oid="$3" cross="$4" state="${5:-OPEN}" base="${6:-main}"
+  printf '{"headRefName":"%s","headRefOid":"%s","isCrossRepository":%s,"state":"%s","baseRefName":"%s"}\n' \
+    "$name" "$oid" "$cross" "$state" "$base" >"$GH_STATE/pr-$number.json"
 }
 pr_doc 7 fix/widget-expiry "$FORK_HEAD" true
 pr_doc 8 feat/same "$SAME_HEAD" false
@@ -259,6 +259,78 @@ for row in "${rows[@]}"; do
   assert_contains "$(cat "$ROOT/$issue.err")" "$fragment" "PR #$number: refusal names the cause"
   assert_path_absent "$ROOT/trees/$issue" "PR #$number: no worktree is created"
 done
+
+echo "=== remove and cleanup prove a merged fork PR by its number ==="
+
+# GitHub files the PR under the contributor's head name, so a --head query
+# for fork-pr-<n> answers nothing; the number in the branch name is the key.
+# A squash lands the content on main as a new commit, so ancestry never
+# proves it either.
+squash_fork_onto_main() {
+  local file="$1" content="$2"
+  printf '%s\n' "$content" >"$ROOT/main/$file"
+  git -C "$ROOT/main" add "$file"
+  git -C "$ROOT/main" commit -q -m "$file (squashed)"
+  git -C "$ROOT/main" push -q origin main
+}
+squash_fork_onto_main from-main.txt 'fork main fix'
+pr_doc 11 main "$FORK_MAIN_HEAD" true MERGED
+squashed_ancestor=no
+git -C "$ROOT/main" merge-base --is-ancestor fork-pr-11 origin/main && squashed_ancestor=yes
+assert_eq "$squashed_ancestor" "no" "precondition: the squashed fork branch is not an ancestor of origin/main"
+set +e
+merged_rm_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" remove issue-from-main 2>"$ROOT/merged-rm.err")"
+merged_rm_code=$?
+set -e
+assert_eq "$merged_rm_code:$merged_rm_out" "0:Removed: $FROM_MAIN_WT" "remove of a merged fork PR worktree exits 0 (stderr: $(tr '\n' ' ' <"$ROOT/merged-rm.err"))"
+assert_path_absent "$FROM_MAIN_WT" "remove clears the merged fork worktree"
+assert_eq "$(git -C "$ROOT/main" rev-parse --verify --quiet refs/heads/fork-pr-11 || true)" "" "remove deletes the merged fork branch"
+assert_contains "$(cat "$ROOT/merged-rm.err")" "Deleted branch 'fork-pr-11' — squash-merged in pull request #11." "remove names the merged pull request"
+
+# cleanup: one merged fork PR (#12) is collected, an open one (#13) is kept.
+git -C "$ROOT/fork" checkout -q -b fix/cleanup main
+printf 'cleanup fix\n' >"$ROOT/fork/cleanup.txt"
+git -C "$ROOT/fork" add cleanup.txt
+git -C "$ROOT/fork" commit -q -m 'cleanup fix'
+CLEANUP_HEAD="$(git -C "$ROOT/fork" rev-parse HEAD)"
+git -C "$ROOT/fork" push -q origin "HEAD:refs/pull/12/head"
+git -C "$ROOT/fork" checkout -q -b fix/still-open main
+printf 'still open\n' >"$ROOT/fork/open.txt"
+git -C "$ROOT/fork" add open.txt
+git -C "$ROOT/fork" commit -q -m 'still open'
+OPEN_HEAD="$(git -C "$ROOT/fork" rev-parse HEAD)"
+git -C "$ROOT/fork" push -q origin "HEAD:refs/pull/13/head"
+pr_doc 12 fix/cleanup "$CLEANUP_HEAD" true
+pr_doc 13 fix/still-open "$OPEN_HEAD" true
+CLEANUP_WT="$ROOT/trees/issue-cleanup"
+OPEN_WT="$ROOT/trees/issue-open"
+set +e
+cleanup_create_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-cleanup --pr 12 2>"$ROOT/cleanup-create.err" \
+  && "$WORKTREE_SCRIPT" create issue-open --pr 13 2>"$ROOT/open-create.err")"
+cleanup_create_code=$?
+set -e
+assert_eq "$cleanup_create_code" "0" "two fork PR worktrees exist before cleanup (stderr: $(cat "$ROOT/cleanup-create.err" "$ROOT/open-create.err" | tr '\n' ' '))"
+squash_fork_onto_main cleanup.txt 'cleanup fix'
+pr_doc 12 fix/cleanup "$CLEANUP_HEAD" true MERGED
+set +e
+cleanup_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" cleanup 2>"$ROOT/cleanup.err")"
+cleanup_code=$?
+set -e
+assert_eq "$cleanup_code" "0" "cleanup exits 0 (stderr: $(tr '\n' ' ' <"$ROOT/cleanup.err"))"
+assert_contains "$cleanup_out" "Cleaned: $CLEANUP_WT" "cleanup collects the merged fork PR worktree"
+assert_path_absent "$CLEANUP_WT" "the merged fork worktree is gone"
+assert_eq "$(git -C "$ROOT/main" rev-parse --verify --quiet refs/heads/fork-pr-12 || true)" "" "cleanup deletes the merged fork branch"
+assert_eq "$(git -C "$OPEN_WT" rev-parse HEAD 2>/dev/null || true)" "$OPEN_HEAD" "cleanup keeps the open fork PR worktree"
+assert_contains "$(cat "$ROOT/cleanup.err")" "fork pull request #13 is OPEN, not merged" "cleanup names the open fork PR it keeps"
+
+# A merged fork PR whose merged head is not this tip is kept: the branch
+# carries work past the merge.
+pr_doc 13 fix/still-open "$FORK_HEAD" true MERGED
+set +e
+(cd "$ROOT/main" && "$WORKTREE_SCRIPT" cleanup >"$ROOT/moved.out" 2>"$ROOT/moved.err")
+set -e
+assert_eq "$(git -C "$OPEN_WT" rev-parse HEAD 2>/dev/null || true)" "$OPEN_HEAD" "a fork branch past its merged head is kept"
+assert_contains "$(cat "$ROOT/moved.err")" "carries work past its merged pull request (#13 merged head $FORK_HEAD" "cleanup names the head mismatch"
 
 echo
 echo "Passed: $PASS, Failed: $FAIL"


### PR DESCRIPTION
Closes KEN-1253.

`worktree create --pr N` failed for a fork pull request with
`Cannot resolve remote branch 'origin/<head>'`: the head branch lives in the
contributor's repository and origin has no head by that name.

- `resolve_pr_head` reads headRefName, headRefOid and isCrossRepository from gh.
- A fork PR fetches origin's `refs/pull/N/head` and refuses unless the fetch
  delivered the head gh reported. The worktree branch keeps the contributor's
  branch name with no upstream, also when origin has an unrelated branch of
  that name. No remote is added, so nothing can push to the fork.
- Inspecting the same fork PR again after `remove` (which keeps the open PR's
  local branch) resets that branch to the current PR head. A local branch with
  commits that are not in the PR head is refused by name, not reset.
- A same-repository PR keeps the tracked origin-branch checkout; the --base
  ownership and main-checkout guards are unchanged.
- New suite `skills/worktree/tests/worktree_create_fork_pr.sh`: fork checkout at
  the PR head commit, same-repository regression, create/remove/create-again
  landing at the contributor's new head with no upstream, a diverged local
  branch refused by name, and two undeliverable-head refusals (stale pull ref,
  missing pull ref). The active-guard stub now answers
  `pr view` with the real three-field document.

Must-fail control: the new suite against origin/main's script fails the fork
rows with the production error and keeps the same-repository rows green.

Source and render ship together. No changelog fragment: skills are outside the
required consumer paths.
