### PR TITLE
chore(pi-extensions): npm release wave version bumps

### DIFF
--- a/pi-extensions/pi-caveman/CHANGELOG.md
+++ b/pi-extensions/pi-caveman/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Consumer-impacting changes
 
-### Unreleased
+### 2.0.1
 
+- The settings keys `enabled` and `defaultMode` are no longer read. The mode comes from `mode` alone, and a configuration without `mode` is off. `/caveman debug` no longer lists those keys, and no session-start notice names them.
+- A session state entry written before the `override` shape is no longer restored; the session starts from the configured mode.
 - `PI_CODING_AGENT_DIR` is used only when it names a root-anchored path — a drive or UNC share on Windows, a leading `/` on POSIX. Anything else uses `~/.pi/agent`.
 
 ### 2.0.0

--- a/pi-extensions/pi-caveman/CHANGELOG.md
+++ b/pi-extensions/pi-caveman/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 2.0.1
 
-- The settings keys `enabled` and `defaultMode` are no longer read. The mode comes from `mode` alone, and a configuration without `mode` is off. `/caveman debug` no longer lists those keys, and no session-start notice names them.
+- **Breaking**: the settings keys `enabled` and `defaultMode` are no longer read. The mode comes from `mode` alone, and a configuration without `mode` is off. A configuration that relied on `enabled: true` without `mode` had caveman active at 2.0.0 and gets an off session here, with no notice; set `mode` to keep it on. `/caveman debug` no longer lists the removed keys.
 - A session state entry written before the `override` shape is no longer restored; the session starts from the configured mode.
 - `PI_CODING_AGENT_DIR` is used only when it names a root-anchored path — a drive or UNC share on Windows, a leading `/` on POSIX. Anything else uses `~/.pi/agent`.
 

--- a/pi-extensions/pi-caveman/CHANGELOG.md
+++ b/pi-extensions/pi-caveman/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Consumer-impacting changes
 
-### 2.0.1
+### 3.0.0
 
 - **Breaking**: the settings keys `enabled` and `defaultMode` are no longer read. The mode comes from `mode` alone, and a configuration without `mode` is off. A configuration that relied on `enabled: true` without `mode` had caveman active at 2.0.0 and gets an off session here, with no notice; set `mode` to keep it on. `/caveman debug` no longer lists the removed keys.
 - A session state entry written before the `override` shape is no longer restored; the session starts from the configured mode.

--- a/pi-extensions/pi-caveman/package-lock.json
+++ b/pi-extensions/pi-caveman/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vanillagreen/pi-caveman",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vanillagreen/pi-caveman",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.3.0",

--- a/pi-extensions/pi-caveman/package-lock.json
+++ b/pi-extensions/pi-caveman/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vanillagreen/pi-caveman",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vanillagreen/pi-caveman",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.3.0",

--- a/pi-extensions/pi-caveman/package.json
+++ b/pi-extensions/pi-caveman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-caveman",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Native Pi caveman communication mode with session persistence, slash command control, status badge, and settings-manager integration.",
   "license": "MIT",
   "keywords": [

--- a/pi-extensions/pi-caveman/package.json
+++ b/pi-extensions/pi-caveman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-caveman",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "Native Pi caveman communication mode with session persistence, slash command control, status badge, and settings-manager integration.",
   "license": "MIT",
   "keywords": [

--- a/pi-extensions/pi-codex-minimal-tools/CHANGELOG.md
+++ b/pi-extensions/pi-codex-minimal-tools/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Consumer-impacting changes
 
-### Unreleased
+### 2.0.1
 
+- Pi 0.85.1 parity: the SSE transport no longer fails with "Stream closed before response.completed" when the backend closes the stream right after the terminal event without a trailing blank line. The last frame is parsed at end of stream.
+- `gpt-6-astra` replaces `gpt-5.6-sol` in the OpenAI model probe lists and as the model with the 2.5x `priority` service-tier cost multiplier.
 - `PI_CODING_AGENT_DIR` is used only when it names a root-anchored path — a drive or UNC share on Windows, a leading `/` on POSIX. Anything else uses `~/.pi/agent`.
 
 ### 2.0.0

--- a/pi-extensions/pi-codex-minimal-tools/package.json
+++ b/pi-extensions/pi-codex-minimal-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-codex-minimal-tools",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Minimal Codex/OpenAI native tools for Pi: Codex image_generation, view_image, apply_patch",
   "type": "module",
   "keywords": [

--- a/pi-extensions/pi-extension-manager/CHANGELOG.md
+++ b/pi-extensions/pi-extension-manager/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Keep native user/project entrypoints separate in search, filters and inspectors, and show settings only for the active manager installation. Trusted OMP project edits can create project settings without changing global values.
 - Manager enable display, edits, resets and recovery use the global setting even for a project-installed manager. Project enable flags are ignored; other manager settings retain project layering.
 - `PI_CODING_AGENT_DIR` is used only when it names a root-anchored path — a drive or UNC share on Windows, a leading `/` on POSIX. Anything else uses `~/.pi/agent`.
-- An `APPEND_SYSTEM.md` write that the vendored `scripts/append-system.mjs` reports on stderr is a failure: the toggle notice and the uninstall message say the block was not written instead of reporting success. A package that declares `pi.appendSystem` but ships no script warns too. On npm uninstall the block is stripped before npm removes the package tree, and a failed uninstall rewrites it.
+- `APPEND_SYSTEM.md` blocks are written by each package's own vendored `scripts/append-system.mjs`, run by the manager under a 10-second bound, instead of by manager code. A package that declares `pi.appendSystem` but ships no script gets no block on enable. On npm uninstall the block is stripped before npm removes the package tree; the former global-directory cleanup backstop after uninstall is gone.
 - `@oh-my-pi/pi-coding-agent` and `@oh-my-pi/pi-utils` (`>=18.1.11`) are optional peer dependencies.
 
 ### 2.0.0

--- a/pi-extensions/pi-extension-manager/CHANGELOG.md
+++ b/pi-extensions/pi-extension-manager/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 ## Consumer-impacting changes
 
-### Unreleased
+### 2.1.0
 
 - Detect native oh-my-pi npm/link plugins, including disabled installations, through host-resolved configuration and plugin roots. Open `/kendex:extensions` or `/kendex:extensions:settings` on OMP 18.1.11 or later; Pi keeps `/extensions`. Native package toggles update plugin lock records. OMP updates, uninstall, individual module toggles, project suppression edits and other extensions' settings remain unsupported. Manager settings preserve existing YAML filenames and unknown fields, and malformed settings refuse writes.
 - Keep native user/project entrypoints separate in search, filters and inspectors, and show settings only for the active manager installation. Trusted OMP project edits can create project settings without changing global values.
 - Manager enable display, edits, resets and recovery use the global setting even for a project-installed manager. Project enable flags are ignored; other manager settings retain project layering.
 - `PI_CODING_AGENT_DIR` is used only when it names a root-anchored path — a drive or UNC share on Windows, a leading `/` on POSIX. Anything else uses `~/.pi/agent`.
+- An `APPEND_SYSTEM.md` write that the vendored `scripts/append-system.mjs` reports on stderr is a failure: the toggle notice and the uninstall message say the block was not written instead of reporting success. A package that declares `pi.appendSystem` but ships no script warns too. On npm uninstall the block is stripped before npm removes the package tree, and a failed uninstall rewrites it.
+- `@oh-my-pi/pi-coding-agent` and `@oh-my-pi/pi-utils` (`>=18.1.11`) are optional peer dependencies.
 
 ### 2.0.0
 

--- a/pi-extensions/pi-extension-manager/CHANGELOG.md
+++ b/pi-extensions/pi-extension-manager/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## Consumer-impacting changes
 
-### 2.1.0
+### 3.0.0
 
 - Detect native oh-my-pi npm/link plugins, including disabled installations, through host-resolved configuration and plugin roots. Open `/kendex:extensions` or `/kendex:extensions:settings` on OMP 18.1.11 or later; Pi keeps `/extensions`. Native package toggles update plugin lock records. OMP updates, uninstall, individual module toggles, project suppression edits and other extensions' settings remain unsupported. Manager settings preserve existing YAML filenames and unknown fields, and malformed settings refuse writes.
 - Keep native user/project entrypoints separate in search, filters and inspectors, and show settings only for the active manager installation. Trusted OMP project edits can create project settings without changing global values.
-- Manager enable display, edits, resets and recovery use the global setting even for a project-installed manager. Project enable flags are ignored; other manager settings retain project layering.
+- **Breaking**: manager enable display, edits, resets and recovery use the global setting even for a project-installed manager. Project enable flags are ignored, so a project that disabled the manager through a project-scoped `enabled` has it follow the global value after this update; other manager settings retain project layering.
 - `PI_CODING_AGENT_DIR` is used only when it names a root-anchored path — a drive or UNC share on Windows, a leading `/` on POSIX. Anything else uses `~/.pi/agent`.
 - `APPEND_SYSTEM.md` blocks are written by each package's own vendored `scripts/append-system.mjs`, run by the manager under a 10-second bound, instead of by manager code. A package that declares `pi.appendSystem` but ships no script gets no block on enable. On npm uninstall the block is stripped before npm removes the package tree; the former global-directory cleanup backstop after uninstall is gone.
 - `@oh-my-pi/pi-coding-agent` and `@oh-my-pi/pi-utils` (`>=18.1.11`) are optional peer dependencies.

--- a/pi-extensions/pi-extension-manager/package.json
+++ b/pi-extensions/pi-extension-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-extension-manager",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Pi package manager and settings editor with native oh-my-pi plugin inventory and enable controls.",
   "license": "MIT",
   "keywords": [

--- a/pi-extensions/pi-extension-manager/package.json
+++ b/pi-extensions/pi-extension-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-extension-manager",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Pi package manager and settings editor with native oh-my-pi plugin inventory and enable controls.",
   "license": "MIT",
   "keywords": [

--- a/pi-extensions/pi-output-policy/CHANGELOG.md
+++ b/pi-extensions/pi-output-policy/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Consumer-impacting changes
 
-### Unreleased
+### 2.0.1
 
+- Artifacts are no longer moved from the older locations `~/.pi/agent/kendex/pi-output-policy/sessions/<id>/artifacts` and `<project>/.pi/artifacts/output-policy` at session start or on the first write. Artifacts left there stay there; new artifacts land in the per-session directory only.
 - `PI_CODING_AGENT_DIR` is used only when it names a root-anchored path — a drive or UNC share on Windows, a leading `/` on POSIX. Anything else uses `~/.pi/agent`.
 
 ### 2.0.0

--- a/pi-extensions/pi-output-policy/package.json
+++ b/pi-extensions/pi-output-policy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-output-policy",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Large-output policy for Pi: runaway model-output guards plus tool-result minimization, truncation, and spill preservation.",
   "license": "MIT",
   "keywords": [

--- a/pi-extensions/pi-prompt-stash/CHANGELOG.md
+++ b/pi-extensions/pi-prompt-stash/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Consumer-impacting changes
 
-### Unreleased
+### 2.0.1
 
+- Stash stores are no longer moved from the older locations `~/.pi/agent/kendex/prompt-stash/sessions/<id>/` and `<project>/.pi/<store file>` at session start or when the popup opens. Items left there stay there; the store is read from the per-session directory only.
 - `PI_CODING_AGENT_DIR` is used only when it names a root-anchored path — a drive or UNC share on Windows, a leading `/` on POSIX. Anything else uses `~/.pi/agent`.
 
 ### 2.0.0

--- a/pi-extensions/pi-prompt-stash/CHANGELOG.md
+++ b/pi-extensions/pi-prompt-stash/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Consumer-impacting changes
 
-### 2.0.1
+### 3.0.0
 
-- Stash stores are no longer moved from the older locations `~/.pi/agent/kendex/prompt-stash/sessions/<id>/` and `<project>/.pi/<store file>` at session start or when the popup opens. Items left there stay there; the store is read from the per-session directory only.
+- **Breaking**: stash stores are no longer moved from the older locations `~/.pi/agent/kendex/prompt-stash/sessions/<id>/` and `<project>/.pi/<store file>` at session start or when the popup opens. Drafts still sitting in those locations stay there and `/prompt-stash` no longer shows them; move them into the per-session directory by hand to keep them.
 - `PI_CODING_AGENT_DIR` is used only when it names a root-anchored path — a drive or UNC share on Windows, a leading `/` on POSIX. Anything else uses `~/.pi/agent`.
 
 ### 2.0.0

--- a/pi-extensions/pi-prompt-stash/package.json
+++ b/pi-extensions/pi-prompt-stash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-prompt-stash",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Pi package for per-session prompt stash history with alt+s stash/restore workflow.",
   "license": "MIT",
   "keywords": [

--- a/pi-extensions/pi-prompt-stash/package.json
+++ b/pi-extensions/pi-prompt-stash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-prompt-stash",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "Pi package for per-session prompt stash history with alt+s stash/restore workflow.",
   "license": "MIT",
   "keywords": [

--- a/pi-extensions/pi-qol/CHANGELOG.md
+++ b/pi-extensions/pi-qol/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Consumer-impacting changes
 
-### Unreleased
+### 2.0.1
 
+- Pi 0.85.1 parity: the shared summarizer rejects a summary whose generation stopped at the token cap, with the error "Summary generation hit the token cap and the summary is incomplete", as Pi's own compaction and branch-summary generators do. An incomplete summary no longer becomes the continuation checkpoint.
 - `PI_CODING_AGENT_DIR` is used only when it names a root-anchored path — a drive or UNC share on Windows, a leading `/` on POSIX. Anything else uses `~/.pi/agent`.
 
 ### 2.0.0

--- a/pi-extensions/pi-qol/package.json
+++ b/pi-extensions/pi-qol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-qol",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Pi quality-of-life extension: compact statusline/π prompt, reliable multiline input, styled pasted-image chips, session naming/search/context import, scheduled prompts, handoff, permission prompts, notifications, custom compaction, and a collapsed-thinking timer.",
   "license": "MIT",
   "keywords": [

--- a/pi-extensions/pi-questions/CHANGELOG.md
+++ b/pi-extensions/pi-questions/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Consumer-impacting changes
 
-### Unreleased
+### 2.0.1
 
 - The extension uses `PI_CODING_AGENT_DIR` only when root-anchored — a drive or UNC share on Windows, a leading `/` on POSIX. Anything else uses `~/.pi/agent`. The install helper is unchanged.
 

--- a/pi-extensions/pi-questions/package.json
+++ b/pi-extensions/pi-questions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-questions",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Pi extension for structured multi-tab inline questions and bridge-driven replies.",
   "license": "MIT",
   "keywords": [

--- a/pi-extensions/pi-session-bridge/CHANGELOG.md
+++ b/pi-extensions/pi-session-bridge/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Consumer-impacting changes
 
-### Unreleased
+### 2.0.1
 
 - The extension uses `PI_CODING_AGENT_DIR` only when root-anchored — a drive or UNC share on Windows, a leading `/` on POSIX. Anything else uses `~/.pi/agent`. The install helper is unchanged.
 

--- a/pi-extensions/pi-session-bridge/package.json
+++ b/pi-extensions/pi-session-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-session-bridge",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Pi extension and CLI for controlling visible interactive Pi sessions over a structured Unix-socket side channel.",
   "license": "MIT",
   "keywords": [

--- a/pi-extensions/pi-session-manager/CHANGELOG.md
+++ b/pi-extensions/pi-session-manager/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Consumer-impacting changes
 
-### Unreleased
+### 2.0.1
 
+- Deleting a session removes `~/.pi/agent/kendex/sessions/<id>/` only. The older per-package directories `~/.pi/agent/kendex/{pi-agents-tmux,prompt-stash,pi-output-policy}/sessions/<id>/` are no longer removed with it, and the older `session-manager` status entry is no longer cleared at session start, on resume or on rename.
 - `PI_CODING_AGENT_DIR` is used only when it names a root-anchored path — a drive or UNC share on Windows, a leading `/` on POSIX. Anything else uses `~/.pi/agent`.
 
 ### 2.0.0

--- a/pi-extensions/pi-session-manager/package.json
+++ b/pi-extensions/pi-session-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-session-manager",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Polished Pi session manager overlay for browsing, searching, resuming, renaming, and safely deleting sessions.",
   "license": "MIT",
   "keywords": [

--- a/pi-extensions/pi-skills-manager/CHANGELOG.md
+++ b/pi-extensions/pi-skills-manager/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Consumer-impacting changes
 
-### Unreleased
+### 2.0.1
 
 - `PI_CODING_AGENT_DIR` is used only when it names a root-anchored path — a drive or UNC share on Windows, a leading `/` on POSIX. Anything else uses `~/.pi/agent`.
 

--- a/pi-extensions/pi-skills-manager/package.json
+++ b/pi-extensions/pi-skills-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-skills-manager",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Polished Pi skills manager with a dedicated /skill menu for browsing, previewing, inserting, creating, editing, renaming, deleting, and toggling skills while preserving native /skill:name invocation.",
   "license": "MIT",
   "keywords": [

--- a/pi-extensions/pi-task-panel/CHANGELOG.md
+++ b/pi-extensions/pi-task-panel/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Consumer-impacting changes
 
-### Unreleased
+### 3.0.1
 
 - The extension uses `PI_CODING_AGENT_DIR` only when root-anchored — a drive or UNC share on Windows, a leading `/` on POSIX. Anything else uses `~/.pi/agent`. The install helper is unchanged.
 

--- a/pi-extensions/pi-task-panel/package.json
+++ b/pi-extensions/pi-task-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-task-panel",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Persistent Claude-style tasks panel for Pi with slash commands and a structured tasks_write tool.",
   "license": "MIT",
   "keywords": [

--- a/pi-extensions/pi-tool-renderer/CHANGELOG.md
+++ b/pi-extensions/pi-tool-renderer/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Consumer-impacting changes
 
-### Unreleased
+### 2.0.1
 
+- Pi 0.85.1 parity: the re-registered `edit` tool forwards Pi's `prepareArguments` hook from the wrapped definition. Argument shapes Pi's own tool normalizes before validation are accepted with the renderer active instead of failing validation.
 - `PI_CODING_AGENT_DIR` is used only when it names a root-anchored path — a drive or UNC share on Windows, a leading `/` on POSIX. Anything else uses `~/.pi/agent`.
 
 ### 2.0.0

--- a/pi-extensions/pi-tool-renderer/package.json
+++ b/pi-extensions/pi-tool-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-tool-renderer",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Compact Claude/opencode-style renderers for Pi tools with rich diffs, apply_patch, generic/MCP rendering, and optional global chrome.",
   "license": "MIT",
   "keywords": [

--- a/pi-extensions/pi-web-tools/CHANGELOG.md
+++ b/pi-extensions/pi-web-tools/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## Consumer-impacting changes
 
-### 2.0.1
+### 3.0.0
 
 - `web_fetch` stays in the active tool set without an Exa API key. Its direct HTTP, GitHub clone, PDF and YouTube transcript paths need no key, and the Exa `/contents` fallback is skipped when the key is unset. The Exa-only tools (`web_research`, `web_answer`, `web_find_similar`, `code_search` and their `_exa` aliases) remain gated on the key.
-- `buildWebFetchToolResult` takes an options object only; the numeric `maxCharacters` positional form and the trailing page-images argument are removed.
+- **Breaking**: `buildWebFetchToolResult` takes an options object only; the numeric `maxCharacters` positional form and the trailing page-images argument are removed. Callers pass `{ maxCharacters, pageImages }` instead.
 - The extension uses `PI_CODING_AGENT_DIR` only when root-anchored — a drive or UNC share on Windows, a leading `/` on POSIX. Anything else uses `~/.pi/agent`. The install helper is unchanged.
 
 ### 2.0.0

--- a/pi-extensions/pi-web-tools/CHANGELOG.md
+++ b/pi-extensions/pi-web-tools/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Consumer-impacting changes
 
-### Unreleased
+### 2.0.1
 
+- `web_fetch` stays in the active tool set without an Exa API key. Its direct HTTP, GitHub clone, PDF and YouTube transcript paths need no key, and the Exa `/contents` fallback is skipped when the key is unset. The Exa-only tools (`web_research`, `web_answer`, `web_find_similar`, `code_search` and their `_exa` aliases) remain gated on the key.
+- `buildWebFetchToolResult` takes an options object only; the numeric `maxCharacters` positional form and the trailing page-images argument are removed.
 - The extension uses `PI_CODING_AGENT_DIR` only when root-anchored — a drive or UNC share on Windows, a leading `/` on POSIX. Anything else uses `~/.pi/agent`. The install helper is unchanged.
 
 ### 2.0.0

--- a/pi-extensions/pi-web-tools/package.json
+++ b/pi-extensions/pi-web-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-web-tools",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "First-party Pi web tools: provider-toggled web search, Exa deep research, content retrieval, and OpenAI native web_search integration.",
   "type": "module",
   "keywords": [

--- a/pi-extensions/pi-web-tools/package.json
+++ b/pi-extensions/pi-web-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-web-tools",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "First-party Pi web tools: provider-toggled web search, Exa deep research, content retrieval, and OpenAI native web_search integration.",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary

Version bumps and changelog entries for the pi-extensions npm release wave. Every package under `pi-extensions/` was diffed against its last release tag; the thirteen with consumer-facing changes are bumped, four with repo-only or no changes are left alone, and pi-nested-agents-md is included at 0.1.0 for its first publish. Publishing happens after merge, not in this PR.

## Bumps

| Package | Version |
|---|---|
| pi-codex-minimal-tools, pi-output-policy, pi-qol, pi-questions, pi-session-bridge, pi-session-manager, pi-skills-manager, pi-tool-renderer | 2.0.0 → 2.0.1 |
| pi-caveman, pi-prompt-stash, pi-web-tools | 2.0.0 → 3.0.0 (Breaking: caveman drops the enabled/defaultMode fallback; web-tools removes buildWebFetchToolResult positional call forms; prompt-stash drops the legacy-store migration) |
| pi-task-panel | 3.0.0 → 3.0.1 |
| pi-extension-manager | 2.0.0 → 3.0.0 (Breaking: project enable flags ignored) |
| pi-nested-agents-md | 0.1.0, first publish |

No bump: pi-agents-tmux (tests only), pi-background-tasks (no diff), pi-claude-bridge (no diff, bundle unchanged), pi-hooks (one test line).

## Changelog content

Each package's `### Unreleased` section becomes the released version. The root-anchored `PI_CODING_AGENT_DIR` line (KEN-1037) was already there. Lines added from the diffs:

- pi-caveman: **Breaking** — `enabled`/`defaultMode` settings keys and the old session-state shape are no longer read; a config relying on `enabled: true` without `mode` goes off silently, remedy is setting `mode` (KEN-1107).
- pi-codex-minimal-tools: Pi 0.85.1 SSE end-of-stream frame (#2216); `gpt-6-astra` replaces `gpt-5.6-sol` in probes and the priority-tier multiplier (#2108).
- pi-extension-manager: APPEND_SYSTEM.md blocks are written by each package's vendored script under a 10-second bound; uninstall strips the block before npm runs and the former global-directory cleanup backstop is gone (KEN-1107); optional `@oh-my-pi/*` peers. The native oh-my-pi lines from #2170 were already present.
- pi-output-policy, pi-session-manager: legacy layout migrations and cleanups removed (KEN-1107).
- pi-qol: length-stop summaries are rejected (#2216).
- pi-tool-renderer: `edit` forwards `prepareArguments` (#2216).
- pi-web-tools: `web_fetch` stays active without an Exa key (#1808); **Breaking** — `buildWebFetchToolResult` takes an options object only, positional forms removed (KEN-1107).

Headings stay `### <version>` with no date because `package-policy.test.mjs` requires that exact line.

## Validation

- `node --test pi-extensions/package-policy.test.mjs`: 8 pass.
- Every bumped package's `npm test` after the CI install lines from `skill-tests.yml`: all green. pi-prompt-stash has no test script. pi-session-bridge passes 68/68 in a clean env; two cases read `PI_BRIDGE_*` from `process.env` and fail only inside a Pi subagent pane that sets them.
- Installed pre-commit chain and commit-msg gate: OK.

No bundle rebuild was needed: pi-claude-bridge is the only package with a `prepack` script and has no diff since its tag.

[no-changelog]: `pi-extensions/` is outside `crates/` and `ui/`.
