### PR TITLE
test(KEN-1241): usage-limit suite as one screen-by-lane table

### DIFF
--- a/.agents/skills/orch/tests/oversee_watch_usage_limit.sh
+++ b/.agents/skills/orch/tests/oversee_watch_usage_limit.sh
@@ -1,485 +1,262 @@
 #!/usr/bin/env bash
-# Tests for what oversee-watch reads off a spent-account banner:
-# whether a limit banner on a lane's screen is the account speaking now, and
-# what the reset clause on that line resolves to. The rest of the pane side is
+# Tests for what oversee-watch reads off a spent-account banner: whether a
+# limit banner on a lane's screen is the account speaking now, and what the
+# reset clause on that line resolves to. The rest of the pane side is
 # oversee_watch_lanes.sh and the GitHub side oversee_watch.sh; all build their
 # sandbox from lib/oversee-watch-harness.sh.
+#
+# One table. A row names a screen (a byte-exact pane fixture, kept whole in
+# `screen`), the lane it sits in, the clock and zone the pane is read under,
+# and the facts the run must show; `watch` reads exactly those facts, so a row
+# fails on the fact it names. A `cont` row is the next pass of the row above
+# it, with the same state and a fresh capture.
 set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/lib/git-env.sh"
 
 # shellcheck source=lib/oversee-watch-harness.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/oversee-watch-harness.sh"
 
-
 # Every fixture banner below states a clock, and the event carries the UTC
-# instant it resolves to. Cases asserting the whole event line pin both ends of
-# that resolution — RESET_NOW as the moment the pane is read (`now.epoch`, the
-# harness's clock stub) and TZ=UTC as the zone a banner naming none is read in
-# — so they hold on a runner in any zone. Their banner is the measured
+# instant it resolves to. Rows asserting the whole event line pin both ends of
+# that resolution: RESET_NOW as the moment the pane is read (`now.epoch`, the
+# harness's clock stub) and TZ=UTC as the zone a banner naming none is read in,
+# so they hold on a runner in any zone. Their banner is the measured
 # `9:50am (America/Los_Angeles)` shape: no mechanism here rests on the one
 # grammar arm nothing is measured to draw, and `resets 21:00` appears only
 # where that arm is the subject.
 RESET_NOW=1788364800
-RESET_0950=' resets=2026-09-02T16:50:00Z'       # what the banner below resolves to
-pin_now() { printf '%s' "$RESET_NOW" > "$STUB_DIR/now.epoch"; }
+AT_0950='EVENT+usage-limit+gh-2+resets=2026-09-02T16:50:00Z'   # what that banner resolves to
+HEARTBEAT='EVENT+heartbeat+loops=1+interval=0s+since=none'
 
-echo "=== oversee-watch usage limits ==="
+BANNER="You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)"
+CODEX_BANNER='Usage limit reached. Increase your limits to continue.'
+COMPOSER='\xe2\x9d\xaf\xc2\xa0'          # Claude's composer: `❯` + U+00A0
+CODEX_COMPOSER='\xe2\x80\xba Ask Codex to do anything'
+DIALOG='  Select Model and Effort\n\xe2\x80\xba 1. gpt-6-astra (current)  Our most capable model for complex, demanding work.\n  2. gpt-5.6-terra          Balanced agentic coding model for everyday work.'
+QUESTION='Do you want to proceed?\n   ❯ 1. Yes\n     2. No'
 
-# --- 1. usage-limit: the harness is alive, the account is spent -------------
-new_case usage_limit
-pin_now
-{
-  printf '⏺ Working through the queue.\n'
-  printf "You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)\n"
-  printf 'Run /usage-credits to raise it\n'
-  printf '\xe2\x9d\xaf\xc2\xa0\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3f"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "0" "usage-limit exits 0" "$err"
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2$RESET_0950" \
-  "a limit banner under a live harness is the event on ONE pass" "$err"
-assert_contains "$out" "usage limit" "the pane tail follows the usage-limit event" "$err"
-
-# Codex words it its own way; one regex covers both harnesses
-new_case usage_limit_codex
-printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
-printf 'Usage limit reached. Increase your limits to continue.\n' > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3f2"
-out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2" "the codex limit banner fires too" "$err"
-
-# A spent account outranks a prompt left on the same screen
-new_case usage_limit_before_question
-pin_now
-{
-  printf "You've hit your session limit \xc2\xb7 resets 9:50am (America/Los_Angeles)\n"
-  printf 'Do you want to proceed?\n   ❯ 1. Yes\n     2. No\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3g"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2$RESET_0950" \
-  "a limit banner above a stale prompt is usage-limit, not question" "$err"
-assert_not_contains "$out" "EVENT lane-asking" "lane-asking never preempts a spent account" "$err"
-
-# The banner and the prompt are read on the same liveness answer, so a lane
-# wrapped in a shell still gets its banner seen
-new_case usage_limit_wrapped_shell
-printf 'fish\n' > "$STUB_DIR/cmd-gh-2.txt"
-printf '2747883\n' > "$STUB_DIR/kids-9002.txt"
-printf "You've hit your weekly limit \xc2\xb7 resets Sunday\n" > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3f3"
-out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2" \
-  "a wrapped lane's limit banner is still the event" "$err"
-
-# An account that has since reset leaves its old banner on the visible screen.
-# A user turn below it says the harness took another turn, so the banner is
-# scrollback and the lane needs nothing.
-new_case usage_limit_stale_banner
-{
-  printf '⏺ Working through the queue.\n'
-  printf "You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)\n"
-  printf '❯ pick the round back up\n'
-  printf '⏺ Teammate @dev-ken832-r3 finished\n'
-  printf '\xe2\x9d\xaf\xc2\xa0\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3f4"
-out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=1 interval=0s since=none" \
-  "a banner the lane has since worked past is not the event" "$err"
-assert_not_contains "$out" "EVENT usage-limit" \
-  "a stale banner above a later user turn never fires" "$err"
-
-# The composer is the last marker line on the screen, and it is never a turn:
-# if it counted as one the whole pane would be sliced away and usage-limit
-# would go silent for every lane. Claude Code draws it as `❯` + U+00A0, which
-# these fixtures spell in bytes and then verify, so a fixture that degrades
-# into an ASCII space fails here instead of passing quietly.
-new_case usage_limit_above_empty_composer
-pin_now
-{
-  printf '⏺ Working through the queue.\n'
-  printf "You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)\n"
-  printf '\xe2\x9d\xaf\xc2\xa0\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-assert_eq "$(grep -c "$(printf '\xc2\xa0')" "$STUB_DIR/pane-gh-2.txt")" "1" \
-  "the composer fixture carries U+00A0, not an ASCII space"
-err="$TMP_ROOT/e3f6"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2$RESET_0950" \
-  "the empty composer is not a turn, so a banner above it is still reported" "$err"
-
-# ...and neither is a composer holding an unsent draft
-new_case usage_limit_above_composer_draft
-pin_now
-{
-  printf '⏺ Working through the queue.\n'
-  printf "You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)\n"
-  printf '\xe2\x9d\xaf\xc2\xa0take the next round\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-assert_eq "$(grep -c "$(printf '\xc2\xa0')" "$STUB_DIR/pane-gh-2.txt")" "1" \
-  "the draft-composer fixture carries U+00A0, not an ASCII space"
-err="$TMP_ROOT/e3f7"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2$RESET_0950" \
-  "an unsent draft in the composer is not a turn either" "$err"
-
-# Codex draws the composer with the SAME `› ` and text a submitted turn uses,
-# so only its position separates them. Its placeholder must not read as a turn.
-new_case usage_limit_above_codex_composer
-printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
-{
-  printf '\xe2\x80\xba pick the round back up\n'
-  printf '\xe2\x80\xa2 Ran 3 commands\n'
-  printf 'Usage limit reached. Increase your limits to continue.\n'
-  printf '\xe2\x80\xba Ask Codex to do anything\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3f8"
-out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2" \
-  "a codex banner below the last turn is reported, the composer notwithstanding" "$err"
-
-# A Codex dialog screen draws no composer, and Codex does NOT indent the row
-# it has selected: that row keeps the marker at column 0, measured on a live
-# model picker, so the screen still ends in a live-input marker line and the
-# turn above it is the boundary. Only the unselected rows indent.
-new_case usage_limit_codex_dialog_stale_banner
-printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
-{
-  printf 'Usage limit reached. Increase your limits to continue.\n'
-  printf '\xe2\x80\xba pick the round back up\n'
-  printf '\xe2\x80\xa2 Ran 3 commands\n'
-  printf '  Select Model and Effort\n'
-  printf '\xe2\x80\xba 1. gpt-6-astra (current)  Our most capable model for complex, demanding work.\n'
-  printf '  2. gpt-5.6-terra          Balanced agentic coding model for everyday work.\n'
-  printf '  Press enter to confirm or esc to go back\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3fd"
-out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT lane-asking gh-2" \
-  "a codex dialog row is live input, so the banner above the turn stays scrollback" "$err"
-assert_not_contains "$out" "EVENT usage-limit" \
-  "the codex dialog row never resurrects a stale banner" "$err"
-
-# The near-miss control. Every fresh Codex prints a benign reset OFFER, and
-# loosening USAGE_LIMIT_RE toward a bare `usage limit` would turn the startup
-# screen of every Codex lane into a spent-account event.
-new_case usage_limit_codex_reset_offer
-printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
-cat "$CODEX_PANES/codex-composer-idle.txt" > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3fg"
-out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_contains "$(cat "$STUB_DIR/pane-gh-2.txt")" "You have 1 usage limit reset available" \
-  "the fixture really carries the reset offer, so the control is not vacuous" "$err"
-assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=1 interval=0s since=none" \
-  "a codex startup screen is no event at all" "$err"
-assert_not_contains "$out" "EVENT usage-limit" \
-  "an offered reset is credit to spend, never a spent account" "$err"
-
-# ...and its control: the banner below the turn on the same dialog screen
-new_case usage_limit_codex_dialog_live_banner
-printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
-{
-  printf '\xe2\x80\xba pick the round back up\n'
-  printf '\xe2\x80\xa2 Ran 3 commands\n'
-  printf 'Usage limit reached. Increase your limits to continue.\n'
-  printf '  Select Model and Effort\n'
-  printf '\xe2\x80\xba 1. gpt-6-astra (current)  Our most capable model for complex, demanding work.\n'
-  printf '  2. gpt-5.6-terra          Balanced agentic coding model for everyday work.\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3fe"
-out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2" \
-  "a banner below the turn on a codex dialog screen is still the event" "$err"
-
-# ...and the must-fail control: the same codex screen with the banner ABOVE
-# the turn is scrollback, which the composer must not resurrect
-new_case usage_limit_codex_stale_banner
-printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
-{
-  printf 'Usage limit reached. Increase your limits to continue.\n'
-  printf '\xe2\x80\xba pick the round back up\n'
-  printf '\xe2\x80\xa2 Ran 3 commands\n'
-  printf '\xe2\x80\xba Ask Codex to do anything\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3f9"
-out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=1 interval=0s since=none" \
-  "a codex banner the lane has worked past is not the event" "$err"
-assert_not_contains "$out" "EVENT usage-limit" \
-  "the codex composer never resurrects a stale banner" "$err"
-
-# The must-fail control for the case above: the same screen with the banner
-# BELOW the turn — the account is spent right now. It carries the permission
-# line a real screen draws under the composer, so the composer is not the last
-# line of the capture: this is where the Claude signature decides the boundary
-# rather than the last-line fallback, and a signature that stops matching
-# drops the banner out of the slice here.
-new_case usage_limit_after_turn
-pin_now
-{
-  printf '❯ pick the round back up\n'
-  printf '⏺ Working through the queue.\n'
-  printf "You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)\n"
-  printf '\xe2\x9d\xaf\xc2\xa0\n'
-  printf '  bypass permissions on\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3f5"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2$RESET_0950" \
-  "a banner below the last user turn is the event" "$err"
-
-# An input line the composer rule does not recognize must not become the
-# boundary itself: that empties the slice and makes usage-limit a silent
-# no-op. A marker line that is the last line of the capture falls back to the
-# previous marker, so the unrecognized case fails toward a stale banner.
-new_case usage_limit_unrecognized_composer
-pin_now
-{
-  printf '❯ pick the round back up\n'
-  printf '⏺ Working through the queue.\n'
-  printf "You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)\n"
-  printf '❯ \n'
-} > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3f6"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2$RESET_0950" \
-  "an unrecognized last input line never swallows the screen" "$err"
-
-# A realistic transcript, with the E2-lead lines a real screen carries
-# between the banner and the composer. It carries no streaming token counter:
-# the turn that hit the wall is over, and a counter still on screen would mean
-# a turn in flight, which no usage-limit event is emitted under. The marker must be an alternation of
-# literals: as a bracket expression it degrades to a set of BYTES on any awk
-# without multibyte support, every one of these lines then reads as a marker,
-# the boundary lands below the banner and usage-limit goes silent. A short
-# fixture cannot see that; this one can.
-new_case usage_limit_realistic_transcript
-pin_now
-{
-  printf '❯ pick the round back up\n'
-  printf '⏺ Ran 3 shell commands\n'
-  printf "You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)\n"
-  printf '⏺ Teammate @dev-ken832-r3 finished\n'
-  printf '⎿  Wrote 6 lines to tmp/roundD.json\n'
-  printf '─────────────────────────────\n'
-  printf '\xe2\x9d\xaf\xc2\xa0\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-# Run it in BOTH locales. The byte-set degradation only happens on an awk
-# without multibyte support, so under the runner's own UTF-8 locale gawk
-# behaves identically either way and the case cannot fail on the defect it
-# names. Under LC_ALL=C it can, and does. The UTF-8 invocation stays as the
-# control that the case passes for the right reason rather than by locale.
-err="$TMP_ROOT/e3fc"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2$RESET_0950" \
-  "transcript lines between the banner and the composer are not markers" "$err"
-err="$TMP_ROOT/e3fc2"
-out="$(run_watch TZ=UTC LC_ALL=C LANG=C -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2$RESET_0950" \
-  "...and under a byte-oriented locale, where a marker class would degrade" "$err"
-
-# A dialog screen draws no composer at all: Claude replaces it with the
-# selection rows, which it indents, so the last marker line there is the user
-# turn itself. Read as a composer, the boundary would slip back to the turn
-# before it and reopen the window over the very scrollback this slice exists
-# to exclude — a stale banner would mask a live question.
-new_case usage_limit_stale_banner_over_question
-{
-  printf "You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)\n"
-  printf '❯ pick the round back up\n'
-  printf '⏺ Teammate @dev-ken832-r3 finished\n'
-  printf 'Do you want to proceed?\n'
-  printf '   ❯ 1. Yes\n     2. No\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3fa"
-out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT lane-asking gh-2" \
-  "a stale banner never masks the live question on a dialog screen" "$err"
-assert_not_contains "$out" "EVENT usage-limit" \
-  "the banner above the turn stays scrollback when no composer is drawn" "$err"
-
-# ...and its control: on the same dialog screen, a banner BELOW the turn is
-# the account spent right now, and it still outranks the question
-new_case usage_limit_live_banner_over_question
-pin_now
-{
-  printf '❯ pick the round back up\n'
-  printf '⏺ Teammate @dev-ken832-r3 finished\n'
-  printf "You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)\n"
-  printf 'Do you want to proceed?\n'
-  printf '   ❯ 1. Yes\n     2. No\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3fb"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2$RESET_0950" \
-  "a banner below the turn on a dialog screen is still the event" "$err"
-
-# The must-fail control: a lane with no banner at all
-new_case usage_limit_healthy
-printf '⏺ All green, nothing blocking.\n\xe2\x9d\xaf\xc2\xa0\n' > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3h"
-out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=1 interval=0s since=none" \
-  "a lane with no limit banner reaches the heartbeat" "$err"
-assert_not_contains "$out" "EVENT usage-limit" "a healthy lane never fires usage-limit" "$err"
-
-# The account is the actionable part: a live claim maps the window to it
-new_case usage_limit_claim
-printf '900 %%3\n' > "$STUB_DIR/panes.txt"
-printf '900 %%3\n' > "$STUB_DIR/pane-key-gh-2.txt"
-mkdir -p "$STATE_DIR/claims"
-# Read first by glob order, so anything matching on the window NAME alone
-# would answer with one of these instead of the pane actually captured: one
-# claim from another live server, one from THIS server on another pane —
-# window names repeat across sessions as well as across servers.
-printf '%s\t%%3\t/home/me/.otherclaude\tgh-2\t2026-08-16T00:00:00Z\n' "$$" > "$STATE_DIR/claims/a.claim"
-printf '900\t%%9\t/home/me/.thirdclaude\tgh-2\t2026-08-16T00:00:00Z\n' > "$STATE_DIR/claims/b.claim"
-printf '900\t%%3\t/home/me/.eclaude\tgh-2\t2026-08-16T00:00:00Z\n' > "$STATE_DIR/claims/c.claim"
-printf "You've hit your weekly limit\n" > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3i"
-out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2 /home/me/.eclaude" \
-  "the event names the config dir the lane was claimed on" "$err"
-assert_not_contains "$out" "otherclaude" \
-  "a same-named window on another tmux server never answers for this lane" "$err"
-assert_not_contains "$out" "thirdclaude" \
-  "a same-named window on another pane of this server never answers either" "$err"
-
-# ... and a claim whose pane is gone is pruned rather than reported
-new_case usage_limit_claim_stale
-printf '900 %%9\n' > "$STUB_DIR/panes.txt"
-printf '900 %%3\n' > "$STUB_DIR/pane-key-gh-2.txt"
-mkdir -p "$STATE_DIR/claims"
-printf '900\t%%3\t/home/me/.eclaude\tgh-2\t2026-08-16T00:00:00Z\n' > "$STATE_DIR/claims/a.claim"
-printf "You've hit your weekly limit\n" > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3j"
-out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2" \
-  "a claim whose pane is gone names no account" "$err"
-assert_eq "$(ls -1 "$STATE_DIR/claims" | wc -l | tr -d '[:space:]')" "0" \
-  "a dead claim is pruned on read, not left to accumulate" "$err"
-
-# --- 2. the reset the banner states ----------------------------------------
-# Four surfaces, one control and one must-fail each. Every case pins
-# `now.epoch` and the runner's zone per the note beside RESET_NOW above.
-#
-# SURFACE 1, control: the reset parsed out of each banner form the grammar
-# accepts. One pass per form, each a fresh sighting because each names a
-# different wall.
-new_case usage_limit_reset_forms
-printf '%s' "$RESET_NOW" > "$STUB_DIR/now.epoch"
-form() {   # BANNER, EXPECTED-EVENT-LINE, NAME, [RUNNER-TZ]
-  printf '%b\n' "$1" > "$STUB_DIR/pane-gh-2.txt"
-  rm -f "$STUB_DIR/pane-gh-2.calls" "$STUB_DIR/cmd-gh-2.calls"
-  local err="$TMP_ROOT/form-$3"
-  local out; out="$(run_watch "TZ=${4:-UTC}" -- --max-loops 1 gh-1 gh-2 2>"$err")" || true
-  assert_eq "$(head -1 <<<"$out")" "$2" "$3" "$err"
+# screen NAME — writes the pane fixture NAME, whole, as lane gh-2's screen.
+# `banner:TEXT` is a one-line pane holding TEXT (`\x` escapes expanded). The
+# composer is the last marker line on the screen and never a turn: Claude Code
+# draws it as `❯` + U+00A0, spelled in bytes here, and a fixture that degraded
+# into an ASCII space would slice the whole pane away, so `composed` checks
+# the byte is there once before the fixture is used.
+composed() {
+  printf '%b\n' "$@" > "$STUB_DIR/pane-gh-2.txt"
+  [[ "$(grep -c "$(printf '\xc2\xa0')" "$STUB_DIR/pane-gh-2.txt")" == 1 ]] \
+    || { echo "screen: a composer fixture lost its U+00A0" >&2; exit 1; }
 }
-form "You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)" \
-  "EVENT usage-limit gh-2$RESET_0950" "a zone-qualified clock resolves in the zone it names"
-form "You've hit your usage limit \xc2\xb7 resets 9:50pm (UTC)" \
-  "EVENT usage-limit gh-2 resets=2026-09-02T21:50:00Z" \
-  "a one-component zone name is still a zone" America/Los_Angeles
-form "You've hit your session limit \xc2\xb7 resets 21:00" \
-  "EVENT usage-limit gh-2 resets=2026-09-02T21:00:00Z" "a clock with no meridiem is a 24-hour one"
-form "You've hit your usage limit \xc2\xb7 resets 12pm" \
-  "EVENT usage-limit gh-2 resets=2026-09-03T12:00:00Z" "12pm is noon, not midnight and not hour 24"
-form "You've hit your weekly limit \xc2\xb7 resets Sep 6, 4pm" \
-  "EVENT usage-limit gh-2 resets=2026-09-06T16:00:00Z" "a dated banner is read as a date"
-form "You've hit your weekly limit \xc2\xb7 resets Oct 7, 2027, 11:32am" \
-  "EVENT usage-limit gh-2 resets=2027-10-07T11:32:00Z" "the year the dated form carries wins"
-form "You've hit your weekly limit \xc2\xb7 resets Thursday 4am" \
-  "EVENT usage-limit gh-2 resets=2026-09-03T04:00:00Z" "a weekday and a clock name that weekday"
-form "You've hit your usage limit. Try again at Sep 6th, 2026 4:30 PM" \
-  "EVENT usage-limit gh-2 resets=2026-09-06T16:30:00Z" "codex's trigger and ordinal day read the same"
-
-# SURFACE 1, must-fail: a form the grammar deliberately excludes, and a zone
-# the host cannot resolve. Each keeps the plain event with no time on it, and
-# none is ever evidence the wall has lifted.
-new_case usage_limit_reset_unreadable
-printf '%s' "$RESET_NOW" > "$STUB_DIR/now.epoch"
-unreadable() {   # BANNER, NAME
-  printf '%b\n' "$1" > "$STUB_DIR/pane-gh-2.txt"
-  rm -f "$STUB_DIR/pane-gh-2.calls" "$STUB_DIR/cmd-gh-2.calls"
-  local err="$TMP_ROOT/unreadable-$2"
-  local out; out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" || true
-  assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2" "$2" "$err"
-  assert_not_contains "$out" "resets=" "$2, and no time is invented" "$err"
+screen() {
+  case "$1" in
+    banner:*) printf '%b\n' "${1#banner:}" > "$STUB_DIR/pane-gh-2.txt" ;;
+    # the harness alive, the account spent, the realistic idle screen
+    banner_idle) composed '⏺ Working through the queue.' "$BANNER" 'Run /usage-credits to raise it' "$COMPOSER" ;;
+    banner_draft) composed '⏺ Working through the queue.' "$BANNER" "${COMPOSER}take the next round" ;;
+    banner_over_question) printf '%b\n' "You've hit your session limit \xc2\xb7 resets 9:50am (America/Los_Angeles)" "$QUESTION" > "$STUB_DIR/pane-gh-2.txt" ;;
+    # a user turn below the banner: the harness took another turn since
+    stale_banner) composed '⏺ Working through the queue.' "$BANNER" '❯ pick the round back up' '⏺ Teammate @dev-ken832-r3 finished' "$COMPOSER" ;;
+    # the permission line a real screen draws under the composer, so the
+    # composer is not the last line and the Claude signature decides the
+    # boundary rather than the last-line fallback
+    banner_after_turn) composed '❯ pick the round back up' '⏺ Working through the queue.' "$BANNER" "$COMPOSER" '  bypass permissions on' ;;
+    # an input line the composer rule does not recognize
+    unrecognized_composer) printf '%b\n' '❯ pick the round back up' '⏺ Working through the queue.' "$BANNER" '❯ ' > "$STUB_DIR/pane-gh-2.txt" ;;
+    # the E2-lead lines a real screen carries between the banner and the
+    # composer, and no streaming token counter: the turn that hit the wall is
+    # over
+    realistic) composed '❯ pick the round back up' '⏺ Ran 3 shell commands' "$BANNER" '⏺ Teammate @dev-ken832-r3 finished' '⎿  Wrote 6 lines to tmp/roundD.json' '─────────────────────────────' "$COMPOSER" ;;
+    # a dialog screen draws no composer: the selection rows replace it
+    stale_over_question) printf '%b\n' "$BANNER" '❯ pick the round back up' '⏺ Teammate @dev-ken832-r3 finished' "$QUESTION" > "$STUB_DIR/pane-gh-2.txt" ;;
+    live_over_question) printf '%b\n' '❯ pick the round back up' '⏺ Teammate @dev-ken832-r3 finished' "$BANNER" "$QUESTION" > "$STUB_DIR/pane-gh-2.txt" ;;
+    healthy) composed '⏺ All green, nothing blocking.' "$COMPOSER" ;;
+    # this suite's own source among the text a lane prints mid-turn
+    working) printf '%b\n' '⏺ Reading the suite.' "  printf \"You've hit your usage limit \xc2\xb7 resets 17:00\"" 'esc to interrupt' > "$STUB_DIR/pane-gh-2.txt" ;;
+    banner_1700) composed "You've hit your usage limit \xc2\xb7 resets 17:00" "$COMPOSER" ;;
+    # Codex draws the composer with the SAME `› ` and text a submitted turn
+    # uses, so only its position separates them
+    codex_banner) printf '%b\n' "$CODEX_BANNER" > "$STUB_DIR/pane-gh-2.txt" ;;
+    codex_live) printf '%b\n' '\xe2\x80\xba pick the round back up' '\xe2\x80\xa2 Ran 3 commands' "$CODEX_BANNER" "$CODEX_COMPOSER" > "$STUB_DIR/pane-gh-2.txt" ;;
+    codex_stale) printf '%b\n' "$CODEX_BANNER" '\xe2\x80\xba pick the round back up' '\xe2\x80\xa2 Ran 3 commands' "$CODEX_COMPOSER" > "$STUB_DIR/pane-gh-2.txt" ;;
+    # a Codex dialog draws no composer and does NOT indent the selected row:
+    # that row keeps the marker at column 0, measured on a live model picker
+    codex_dialog_stale) printf '%b\n' "$CODEX_BANNER" '\xe2\x80\xba pick the round back up' '\xe2\x80\xa2 Ran 3 commands' "$DIALOG" '  Press enter to confirm or esc to go back' > "$STUB_DIR/pane-gh-2.txt" ;;
+    codex_dialog_live) printf '%b\n' '\xe2\x80\xba pick the round back up' '\xe2\x80\xa2 Ran 3 commands' "$CODEX_BANNER" "$DIALOG" > "$STUB_DIR/pane-gh-2.txt" ;;
+    # the byte-exact startup screen of a fresh Codex, carrying its reset OFFER
+    codex_idle)
+      grep -qF 'You have 1 usage limit reset available' "$CODEX_PANES/codex-composer-idle.txt" \
+        || { echo "screen: the codex idle fixture no longer carries the reset offer, so the near-miss row would pin nothing" >&2; exit 1; }
+      cat "$CODEX_PANES/codex-composer-idle.txt" > "$STUB_DIR/pane-gh-2.txt" ;;
+    *) echo "screen: unknown fixture $1" >&2; exit 1 ;;
+  esac
 }
-unreadable "You've hit your fast limit \xc2\xb7 resets in 5m" "a duration names no instant"
-unreadable "You've hit your usage limit \xc2\xb7 resets 2026-09-03" "a bare number is not a clock"
-unreadable "You've hit your weekly limit \xc2\xb7 resets Thursday" "a weekday alone guesses no midnight"
-unreadable "You've hit your usage limit \xc2\xb7 resets 9:50am (Bogus/Zone)" \
-  "a zone the host cannot resolve drops the time"
 
-# SURFACE 2, control: a clause naming no day is usage-limit-passed only once
-# this watch has seen that wall standing. The case the issue was filed on.
-new_case usage_limit_reset_passed
-printf '%s' "$RESET_NOW" > "$STUB_DIR/now.epoch"
-printf "You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)\n" > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3k"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2$RESET_0950" \
-  "the first pass observes the wall and carries the reset it names" "$err"
-printf '1788369300' > "$STUB_DIR/now.epoch"
-rm -f "$STUB_DIR/pane-gh-2.calls" "$STUB_DIR/cmd-gh-2.calls"
-err="$TMP_ROOT/e3l"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit-passed gh-2 resets=2026-09-02T16:50:00Z" \
-  "the reset the first pass observed, now behind us, is its own event" "$err"
+# lane NAME — stages what surrounds the pane: its foreground command, and for
+# the claim lanes the pane identity and the claim files the watch reads.
+lane() {
+  case "$1" in
+    claude) ;;
+    codex) printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt" ;;
+    # the harness under a shell: liveness is answered from the shell's children
+    fish) printf 'fish\n' > "$STUB_DIR/cmd-gh-2.txt"; printf '2747883\n' > "$STUB_DIR/kids-9002.txt" ;;
+    # three claims, read in glob order: one from another live server, one from
+    # THIS server on another pane, and the pane actually captured. Window
+    # names repeat across sessions as well as across servers.
+    claim_live)
+      printf '900 %%3\n' > "$STUB_DIR/panes.txt"
+      printf '900 %%3\n' > "$STUB_DIR/pane-key-gh-2.txt"
+      mkdir -p "$STATE_DIR/claims"
+      printf '%s\t%%3\t/home/me/.otherclaude\tgh-2\t2026-08-16T00:00:00Z\n' "$$" > "$STATE_DIR/claims/a.claim"
+      printf '900\t%%9\t/home/me/.thirdclaude\tgh-2\t2026-08-16T00:00:00Z\n' > "$STATE_DIR/claims/b.claim"
+      printf '900\t%%3\t/home/me/.eclaude\tgh-2\t2026-08-16T00:00:00Z\n' > "$STATE_DIR/claims/c.claim" ;;
+    # one claim whose pane is gone
+    claim_dead)
+      printf '900 %%9\n' > "$STUB_DIR/panes.txt"
+      printf '900 %%3\n' > "$STUB_DIR/pane-key-gh-2.txt"
+      mkdir -p "$STATE_DIR/claims"
+      printf '900\t%%3\t/home/me/.eclaude\tgh-2\t2026-08-16T00:00:00Z\n' > "$STATE_DIR/claims/a.claim" ;;
+    *) echo "lane: unknown lane $1" >&2; exit 1 ;;
+  esac
+}
 
-# SURFACE 2, must-fail: the same screen at the same instant with nothing
-# observed before it cannot know which 9:50am the banner meant, so it parks.
-new_case usage_limit_reset_unobserved
-printf '1788369300' > "$STUB_DIR/now.epoch"
-printf "You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)\n" > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3m"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2 resets=2026-09-03T16:50:00Z" \
-  "a wall this watch never saw standing is parked, not bumped" "$err"
+# run [ENV=VAL ...] — one single-pass watch over gh-1 and gh-2; OUT, RC and
+# ERR (a file) are what `watch` reads.
+RUN_SEQ=0
+run() {
+  ERR="$TMP_ROOT/run-$((++RUN_SEQ)).err"
+  OUT="$(run_watch "$@" -- --max-loops 1 gh-1 gh-2 2>"$ERR")" && RC=0 || RC=$?
+}
 
-# SURFACE 3: a dated clause names its own day, so it needs no sighting — spent
-# on sight when the date is behind us, standing when it is ahead.
-new_case usage_limit_reset_dated
-printf '%s' "$RESET_NOW" > "$STUB_DIR/now.epoch"
-printf "You've hit your weekly limit \xc2\xb7 resets Aug 30, 4pm\n" > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3ad"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit-passed gh-2 resets=2026-08-30T16:00:00Z" \
-  "a dated reset already behind us is passed without an observation" "$err"
-printf "You've hit your weekly limit \xc2\xb7 resets Sep 6, 4pm\n" > "$STUB_DIR/pane-gh-2.txt"
-rm -f "$STUB_DIR/pane-gh-2.calls" "$STUB_DIR/cmd-gh-2.calls"
-err="$TMP_ROOT/e3o"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2 resets=2026-09-06T16:00:00Z" \
-  "and a dated reset still ahead is a wall standing" "$err"
+# watch EXPECT — prints the run's value of every `name=` field EXPECT names,
+# in EXPECT's order (in a needle `+` reads as a space and %e as `=`):
+#   rc            exit status
+#   first         the first stdout line, or `none`
+#   out~<text>    whether stdout carries <text>
+#   claims        how many claim files the state directory holds
+watch() {
+  local got="" token name value needle
+  set -f
+  for token in $1; do
+    name="${token%%=*}"
+    needle="${name#*~}"; needle="${needle//+/ }"; needle="${needle//%e/=}"
+    case "$name" in
+      rc) value="$RC" ;;
+      first) value="$(head -n 1 <<<"$OUT")"; value="${value:-none}"; value="${value// /+}" ;;
+      out~*) value="$(grep -qF -- "$needle" <<<"$OUT" && echo true || echo false)" ;;
+      claims) value="$(find "$STATE_DIR/claims" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d '[:space:]')" ;;
+      *) echo "watch: unknown field $name" >&2; exit 1 ;;
+    esac
+    got="$got $name=$value"
+  done
+  set +f
+  printf '%s' "${got# }"
+}
 
-# SURFACE 4: one predicate answers is-the-account-speaking for both consumers,
-# so a turn in flight neither emits nor stamps — this suite's own source among
-# the text a lane prints mid-turn.
-new_case usage_limit_working_lane
-printf '%s' "$RESET_NOW" > "$STUB_DIR/now.epoch"
-{
-  printf '⏺ Reading the suite.\n'
-  printf "  printf \"You've hit your usage limit \xc2\xb7 resets 17:00\"\n"
-  printf 'esc to interrupt\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3n"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=1 interval=0s since=none" \
-  "a lane with a turn in flight is left alone" "$err"
-printf '1788372000' > "$STUB_DIR/now.epoch"
-{
-  printf "You've hit your usage limit \xc2\xb7 resets 17:00\n"
-  printf '\xe2\x9d\xaf\xc2\xa0\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-rm -f "$STUB_DIR/pane-gh-2.calls" "$STUB_DIR/cmd-gh-2.calls"
-err="$TMP_ROOT/e3am"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2 resets=2026-09-03T17:00:00Z" \
-  "the working pass left no sighting, so this one is the first" "$err"
+# usage_table ROW... — `label|pass|screen|lane|now|zone|expect`. `pass` is
+# `new` (a fresh sandbox) or `cont` (the next pass over the row above: same
+# state, fresh capture); `now` the epoch the pane is read at or `-` for the
+# host clock; `zone` the runner's zone, UTC, LA (America/Los_Angeles), C (UTC
+# under a byte-oriented locale) or `-` for the host's.
+CASE_SEQ=0
+usage_table() {
+  local row label pass name which now zone expect env
+  for row in "$@"; do
+    IFS='|' read -r label pass name which now zone expect <<<"$row"
+    [[ -n "$expect" ]] || { printf 'usage_table: a row with no expect asserts nothing: %s\n' "$row" >&2; exit 1; }
+    case "$pass" in
+      new) new_case "usage_$((++CASE_SEQ))" ;;
+      cont) rm -f "$STUB_DIR/pane-gh-2.calls" "$STUB_DIR/cmd-gh-2.calls" ;;
+      *) echo "usage_table: unknown pass $pass in $row" >&2; exit 1 ;;
+    esac
+    lane "$which"
+    screen "$name"
+    [[ "$now" == - ]] || printf '%s' "$now" > "$STUB_DIR/now.epoch"
+    env=()
+    case "$zone" in
+      UTC) env=(TZ=UTC) ;;
+      LA) env=(TZ=America/Los_Angeles) ;;
+      C) env=(TZ=UTC LC_ALL=C LANG=C) ;;
+      -) ;;
+      *) echo "usage_table: unknown zone $zone in $row" >&2; exit 1 ;;
+    esac
+    run ${env[@]+"${env[@]}"}
+    assert_eq "$(watch "$expect")" "$expect" "$label" "$ERR"
+  done
+}
+
+echo "=== oversee-watch usage limits: is the account speaking now ==="
+# A banner is the event only when nothing below it says the harness took
+# another turn: the last user-turn marker is the boundary, the composer is
+# never a turn, and a dialog screen draws no composer at all, so its last
+# marker line is the user turn itself. The realistic transcript runs under
+# both locales: the marker must be an alternation of literals, since as a
+# bracket expression it degrades to a set of BYTES on an awk without multibyte
+# support and every transcript line reads as a marker; gawk under the runner's
+# UTF-8 locale cannot see that, LC_ALL=C can. A spent account outranks a
+# prompt on the same screen, and the near-miss is every fresh Codex's benign
+# reset OFFER, which a looser USAGE_LIMIT_RE would turn into an event.
+usage_table \
+  "a limit banner under a live harness is the event on ONE pass, the pane tail following|new|banner_idle|claude|$RESET_NOW|UTC|rc=0 first=$AT_0950 out~usage+limit=true" \
+  "the codex banner fires too: one regex covers both harnesses|new|codex_banner|codex|-|-|first=EVENT+usage-limit+gh-2" \
+  "a limit banner above a stale prompt is usage-limit, never lane-asking|new|banner_over_question|claude|$RESET_NOW|UTC|first=$AT_0950 out~EVENT+lane-asking=false" \
+  "a lane wrapped in a shell still gets its banner seen|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Sunday|fish|-|-|first=EVENT+usage-limit+gh-2" \
+  "a banner the lane has since worked past is scrollback|new|stale_banner|claude|-|-|first=$HEARTBEAT out~EVENT+usage-limit=false" \
+  "an unsent draft in the composer is not a turn either|new|banner_draft|claude|$RESET_NOW|UTC|first=$AT_0950" \
+  "a banner below the last user turn is the event, the Claude signature deciding the boundary|new|banner_after_turn|claude|$RESET_NOW|UTC|first=$AT_0950" \
+  "an unrecognized last input line never swallows the screen|new|unrecognized_composer|claude|$RESET_NOW|UTC|first=$AT_0950" \
+  "transcript lines between the banner and the composer are not markers|new|realistic|claude|$RESET_NOW|UTC|first=$AT_0950" \
+  "...and under a byte-oriented locale, where a marker class would degrade|cont|realistic|claude|-|C|first=$AT_0950" \
+  "a stale banner never masks the live question on a dialog screen|new|stale_over_question|claude|-|-|first=EVENT+lane-asking+gh-2 out~EVENT+usage-limit=false" \
+  "a banner below the turn on a dialog screen is still the event, and outranks the question|new|live_over_question|claude|$RESET_NOW|UTC|first=$AT_0950" \
+  "a codex banner below the last turn is reported, the composer notwithstanding|new|codex_live|codex|-|-|first=EVENT+usage-limit+gh-2" \
+  "a codex banner the lane has worked past is not the event: the composer never resurrects it|new|codex_stale|codex|-|-|first=$HEARTBEAT out~EVENT+usage-limit=false" \
+  "a codex dialog row is live input, so the banner above the turn stays scrollback|new|codex_dialog_stale|codex|-|-|first=EVENT+lane-asking+gh-2 out~EVENT+usage-limit=false" \
+  "a banner below the turn on a codex dialog screen is still the event|new|codex_dialog_live|codex|-|-|first=EVENT+usage-limit+gh-2" \
+  "a codex startup screen is no event: an offered reset is credit to spend|new|codex_idle|codex|-|-|first=$HEARTBEAT out~EVENT+usage-limit=false" \
+  "control: a lane with no banner reaches the heartbeat|new|healthy|claude|-|-|first=$HEARTBEAT out~EVENT+usage-limit=false"
+
+echo "=== the account is the actionable part ==="
+# A live claim maps the window to its config dir; anything matching on the
+# window NAME alone would answer with another server's or another pane's
+# claim. A claim whose pane is gone is pruned on read, not reported.
+usage_table \
+  "the event names the config dir the lane was claimed on, never a same-named window elsewhere|new|banner:You've hit your weekly limit|claim_live|-|-|first=EVENT+usage-limit+gh-2+/home/me/.eclaude out~otherclaude=false out~thirdclaude=false" \
+  "a claim whose pane is gone names no account and is pruned|new|banner:You've hit your weekly limit|claim_dead|-|-|first=EVENT+usage-limit+gh-2 claims=0"
+
+echo "=== the reset the banner states ==="
+# SURFACE 1: the reset parsed out of each banner form the grammar accepts,
+# each a fresh sighting because each names a different wall; then the forms
+# the grammar deliberately excludes and a zone the host cannot resolve, which
+# keep the plain event with no time on it and are never evidence the wall
+# has lifted.
+usage_table \
+  "a zone-qualified clock resolves in the zone it names|new|banner:$BANNER|claude|$RESET_NOW|UTC|first=$AT_0950" \
+  "a one-component zone name is still a zone|new|banner:You've hit your usage limit \\xc2\\xb7 resets 9:50pm (UTC)|claude|$RESET_NOW|LA|first=EVENT+usage-limit+gh-2+resets=2026-09-02T21:50:00Z" \
+  "a clock with no meridiem is a 24-hour one|new|banner:You've hit your session limit \\xc2\\xb7 resets 21:00|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-02T21:00:00Z" \
+  "12pm is noon, not midnight and not hour 24|new|banner:You've hit your usage limit \\xc2\\xb7 resets 12pm|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-03T12:00:00Z" \
+  "a dated banner is read as a date|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Sep 6, 4pm|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-06T16:00:00Z" \
+  "the year the dated form carries wins|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Oct 7, 2027, 11:32am|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2+resets=2027-10-07T11:32:00Z" \
+  "a weekday and a clock name that weekday|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Thursday 4am|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-03T04:00:00Z" \
+  "codex's trigger and ordinal day read the same|new|banner:You've hit your usage limit. Try again at Sep 6th, 2026 4:30 PM|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-06T16:30:00Z" \
+  "a duration names no instant, and no time is invented|new|banner:You've hit your fast limit \\xc2\\xb7 resets in 5m|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2 out~resets%e=false" \
+  "a bare number is not a clock|new|banner:You've hit your usage limit \\xc2\\xb7 resets 2026-09-03|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2 out~resets%e=false" \
+  "a weekday alone guesses no midnight|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Thursday|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2 out~resets%e=false" \
+  "a zone the host cannot resolve drops the time|new|banner:You've hit your usage limit \\xc2\\xb7 resets 9:50am (Bogus/Zone)|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2 out~resets%e=false"
+
+# SURFACE 2: a clause naming no day is usage-limit-passed only once this watch
+# has seen that wall standing (the case the issue was filed on); the same
+# screen at the same instant with nothing observed before it cannot know which
+# 9:50am the banner meant, so it parks. SURFACE 3: a dated clause names its
+# own day and needs no sighting. SURFACE 4: one predicate answers
+# is-the-account-speaking for both consumers, so a turn in flight neither
+# emits nor stamps.
+usage_table \
+  "the first pass observes the wall and carries the reset it names|new|banner:$BANNER|claude|$RESET_NOW|UTC|first=$AT_0950" \
+  "the reset the first pass observed, now behind us, is its own event|cont|banner:$BANNER|claude|1788369300|UTC|first=EVENT+usage-limit-passed+gh-2+resets=2026-09-02T16:50:00Z" \
+  "a wall this watch never saw standing is parked, not bumped|new|banner:$BANNER|claude|1788369300|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-03T16:50:00Z" \
+  "a dated reset already behind us is passed without an observation|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Aug 30, 4pm|claude|$RESET_NOW|UTC|first=EVENT+usage-limit-passed+gh-2+resets=2026-08-30T16:00:00Z" \
+  "and a dated reset still ahead is a wall standing|cont|banner:You've hit your weekly limit \\xc2\\xb7 resets Sep 6, 4pm|claude|-|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-06T16:00:00Z" \
+  "a lane with a turn in flight is left alone|new|working|claude|$RESET_NOW|UTC|first=$HEARTBEAT" \
+  "the working pass left no sighting, so this one is the first|cont|banner_1700|claude|1788372000|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-03T17:00:00Z"
 
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/.agents/skills/orch/tests/oversee_watch_usage_limit.sh
+++ b/.agents/skills/orch/tests/oversee_watch_usage_limit.sh
@@ -153,8 +153,9 @@ watch() {
 
 # usage_table ROW... — `label|pass|screen|lane|now|zone|expect`. `pass` is
 # `new` (a fresh sandbox) or `cont` (the next pass over the row above: same
-# state, fresh capture); `now` the epoch the pane is read at or `-` for the
-# host clock; `zone` the runner's zone, UTC, LA (America/Los_Angeles), C (UTC
+# state, fresh capture); `now` the epoch the pane is read at, or `-` for the
+# host clock on a new row and the row above's clock on a cont row; `zone`
+# the runner's zone, UTC, LA (America/Los_Angeles), C (UTC
 # under a byte-oriented locale) or `-` for the host's.
 CASE_SEQ=0
 usage_table() {
@@ -196,51 +197,52 @@ echo "=== oversee-watch usage limits: is the account speaking now ==="
 # reset OFFER, which a looser USAGE_LIMIT_RE would turn into an event.
 usage_table \
   "a limit banner under a live harness is the event on ONE pass, the pane tail following|new|banner_idle|claude|$RESET_NOW|UTC|rc=0 first=$AT_0950 out~usage+limit=true" \
-  "the codex banner fires too: one regex covers both harnesses|new|codex_banner|codex|-|-|first=EVENT+usage-limit+gh-2" \
-  "a limit banner above a stale prompt is usage-limit, never lane-asking|new|banner_over_question|claude|$RESET_NOW|UTC|first=$AT_0950 out~EVENT+lane-asking=false" \
-  "a lane wrapped in a shell still gets its banner seen|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Sunday|fish|-|-|first=EVENT+usage-limit+gh-2" \
-  "a banner the lane has since worked past is scrollback|new|stale_banner|claude|-|-|first=$HEARTBEAT out~EVENT+usage-limit=false" \
-  "an unsent draft in the composer is not a turn either|new|banner_draft|claude|$RESET_NOW|UTC|first=$AT_0950" \
-  "a banner below the last user turn is the event, the Claude signature deciding the boundary|new|banner_after_turn|claude|$RESET_NOW|UTC|first=$AT_0950" \
-  "an unrecognized last input line never swallows the screen|new|unrecognized_composer|claude|$RESET_NOW|UTC|first=$AT_0950" \
-  "transcript lines between the banner and the composer are not markers|new|realistic|claude|$RESET_NOW|UTC|first=$AT_0950" \
-  "...and under a byte-oriented locale, where a marker class would degrade|cont|realistic|claude|-|C|first=$AT_0950" \
-  "a stale banner never masks the live question on a dialog screen|new|stale_over_question|claude|-|-|first=EVENT+lane-asking+gh-2 out~EVENT+usage-limit=false" \
-  "a banner below the turn on a dialog screen is still the event, and outranks the question|new|live_over_question|claude|$RESET_NOW|UTC|first=$AT_0950" \
-  "a codex banner below the last turn is reported, the composer notwithstanding|new|codex_live|codex|-|-|first=EVENT+usage-limit+gh-2" \
-  "a codex banner the lane has worked past is not the event: the composer never resurrects it|new|codex_stale|codex|-|-|first=$HEARTBEAT out~EVENT+usage-limit=false" \
-  "a codex dialog row is live input, so the banner above the turn stays scrollback|new|codex_dialog_stale|codex|-|-|first=EVENT+lane-asking+gh-2 out~EVENT+usage-limit=false" \
-  "a banner below the turn on a codex dialog screen is still the event|new|codex_dialog_live|codex|-|-|first=EVENT+usage-limit+gh-2" \
-  "a codex startup screen is no event: an offered reset is credit to spend|new|codex_idle|codex|-|-|first=$HEARTBEAT out~EVENT+usage-limit=false" \
-  "control: a lane with no banner reaches the heartbeat|new|healthy|claude|-|-|first=$HEARTBEAT out~EVENT+usage-limit=false"
+  "the codex banner fires too: one regex covers both harnesses|new|codex_banner|codex|-|-|rc=0 first=EVENT+usage-limit+gh-2" \
+  "a limit banner above a stale prompt is usage-limit, never lane-asking|new|banner_over_question|claude|$RESET_NOW|UTC|rc=0 first=$AT_0950 out~EVENT+lane-asking=false" \
+  "a lane wrapped in a shell still gets its banner seen|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Sunday|fish|-|-|rc=0 first=EVENT+usage-limit+gh-2" \
+  "a banner the lane has since worked past is scrollback|new|stale_banner|claude|-|-|rc=0 first=$HEARTBEAT out~EVENT+usage-limit=false" \
+  "an unsent draft in the composer is not a turn either|new|banner_draft|claude|$RESET_NOW|UTC|rc=0 first=$AT_0950" \
+  "a banner below the last user turn is the event, the Claude signature deciding the boundary|new|banner_after_turn|claude|$RESET_NOW|UTC|rc=0 first=$AT_0950" \
+  "an unrecognized last input line never swallows the screen|new|unrecognized_composer|claude|$RESET_NOW|UTC|rc=0 first=$AT_0950" \
+  "transcript lines between the banner and the composer are not markers|new|realistic|claude|$RESET_NOW|UTC|rc=0 first=$AT_0950" \
+  "...and under a byte-oriented locale, where a marker class would degrade|cont|realistic|claude|-|C|rc=0 first=$AT_0950" \
+  "a stale banner never masks the live question on a dialog screen|new|stale_over_question|claude|-|-|rc=0 first=EVENT+lane-asking+gh-2 out~EVENT+usage-limit=false" \
+  "a banner below the turn on a dialog screen is still the event, and outranks the question|new|live_over_question|claude|$RESET_NOW|UTC|rc=0 first=$AT_0950" \
+  "a codex banner below the last turn is reported, the composer notwithstanding|new|codex_live|codex|-|-|rc=0 first=EVENT+usage-limit+gh-2" \
+  "a codex banner the lane has worked past is not the event: the composer never resurrects it|new|codex_stale|codex|-|-|rc=0 first=$HEARTBEAT out~EVENT+usage-limit=false" \
+  "a codex dialog row is live input, so the banner above the turn stays scrollback|new|codex_dialog_stale|codex|-|-|rc=0 first=EVENT+lane-asking+gh-2 out~EVENT+usage-limit=false" \
+  "a banner below the turn on a codex dialog screen is still the event|new|codex_dialog_live|codex|-|-|rc=0 first=EVENT+usage-limit+gh-2" \
+  "a codex startup screen is no event: an offered reset is credit to spend|new|codex_idle|codex|-|-|rc=0 first=$HEARTBEAT out~EVENT+usage-limit=false" \
+  "control: a lane with no banner reaches the heartbeat|new|healthy|claude|-|-|rc=0 first=$HEARTBEAT out~EVENT+usage-limit=false"
 
 echo "=== the account is the actionable part ==="
 # A live claim maps the window to its config dir; anything matching on the
 # window NAME alone would answer with another server's or another pane's
 # claim. A claim whose pane is gone is pruned on read, not reported.
 usage_table \
-  "the event names the config dir the lane was claimed on, never a same-named window elsewhere|new|banner:You've hit your weekly limit|claim_live|-|-|first=EVENT+usage-limit+gh-2+/home/me/.eclaude out~otherclaude=false out~thirdclaude=false" \
-  "a claim whose pane is gone names no account and is pruned|new|banner:You've hit your weekly limit|claim_dead|-|-|first=EVENT+usage-limit+gh-2 claims=0"
+  "the event names the config dir the lane was claimed on, never a same-named window elsewhere|new|banner:You've hit your weekly limit|claim_live|-|-|rc=0 first=EVENT+usage-limit+gh-2+/home/me/.eclaude out~otherclaude=false out~thirdclaude=false" \
+  "a claim whose pane is gone names no account and is pruned|new|banner:You've hit your weekly limit|claim_dead|-|-|rc=0 first=EVENT+usage-limit+gh-2 claims=0"
 
 echo "=== the reset the banner states ==="
 # SURFACE 1: the reset parsed out of each banner form the grammar accepts,
-# each a fresh sighting because each names a different wall; then the forms
+# each a fresh sighting because each names a different wall (the
+# zone-qualified form is the row that opens the observed-reset sequence
+# below); then the forms
 # the grammar deliberately excludes and a zone the host cannot resolve, which
 # keep the plain event with no time on it and are never evidence the wall
 # has lifted.
 usage_table \
-  "a zone-qualified clock resolves in the zone it names|new|banner:$BANNER|claude|$RESET_NOW|UTC|first=$AT_0950" \
-  "a one-component zone name is still a zone|new|banner:You've hit your usage limit \\xc2\\xb7 resets 9:50pm (UTC)|claude|$RESET_NOW|LA|first=EVENT+usage-limit+gh-2+resets=2026-09-02T21:50:00Z" \
-  "a clock with no meridiem is a 24-hour one|new|banner:You've hit your session limit \\xc2\\xb7 resets 21:00|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-02T21:00:00Z" \
-  "12pm is noon, not midnight and not hour 24|new|banner:You've hit your usage limit \\xc2\\xb7 resets 12pm|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-03T12:00:00Z" \
-  "a dated banner is read as a date|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Sep 6, 4pm|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-06T16:00:00Z" \
-  "the year the dated form carries wins|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Oct 7, 2027, 11:32am|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2+resets=2027-10-07T11:32:00Z" \
-  "a weekday and a clock name that weekday|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Thursday 4am|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-03T04:00:00Z" \
-  "codex's trigger and ordinal day read the same|new|banner:You've hit your usage limit. Try again at Sep 6th, 2026 4:30 PM|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-06T16:30:00Z" \
-  "a duration names no instant, and no time is invented|new|banner:You've hit your fast limit \\xc2\\xb7 resets in 5m|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2 out~resets%e=false" \
-  "a bare number is not a clock|new|banner:You've hit your usage limit \\xc2\\xb7 resets 2026-09-03|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2 out~resets%e=false" \
-  "a weekday alone guesses no midnight|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Thursday|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2 out~resets%e=false" \
-  "a zone the host cannot resolve drops the time|new|banner:You've hit your usage limit \\xc2\\xb7 resets 9:50am (Bogus/Zone)|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2 out~resets%e=false"
+  "a one-component zone name is still a zone|new|banner:You've hit your usage limit \\xc2\\xb7 resets 9:50pm (UTC)|claude|$RESET_NOW|LA|rc=0 first=EVENT+usage-limit+gh-2+resets=2026-09-02T21:50:00Z" \
+  "a clock with no meridiem is a 24-hour one|new|banner:You've hit your session limit \\xc2\\xb7 resets 21:00|claude|$RESET_NOW|UTC|rc=0 first=EVENT+usage-limit+gh-2+resets=2026-09-02T21:00:00Z" \
+  "12pm is noon, not midnight and not hour 24|new|banner:You've hit your usage limit \\xc2\\xb7 resets 12pm|claude|$RESET_NOW|UTC|rc=0 first=EVENT+usage-limit+gh-2+resets=2026-09-03T12:00:00Z" \
+  "a dated banner is read as a date|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Sep 6, 4pm|claude|$RESET_NOW|UTC|rc=0 first=EVENT+usage-limit+gh-2+resets=2026-09-06T16:00:00Z" \
+  "the year the dated form carries wins|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Oct 7, 2027, 11:32am|claude|$RESET_NOW|UTC|rc=0 first=EVENT+usage-limit+gh-2+resets=2027-10-07T11:32:00Z" \
+  "a weekday and a clock name that weekday|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Thursday 4am|claude|$RESET_NOW|UTC|rc=0 first=EVENT+usage-limit+gh-2+resets=2026-09-03T04:00:00Z" \
+  "codex's trigger and ordinal day read the same|new|banner:You've hit your usage limit. Try again at Sep 6th, 2026 4:30 PM|claude|$RESET_NOW|UTC|rc=0 first=EVENT+usage-limit+gh-2+resets=2026-09-06T16:30:00Z" \
+  "a duration names no instant, and no time is invented|new|banner:You've hit your fast limit \\xc2\\xb7 resets in 5m|claude|$RESET_NOW|UTC|rc=0 first=EVENT+usage-limit+gh-2 out~resets%e=false" \
+  "a bare number is not a clock|new|banner:You've hit your usage limit \\xc2\\xb7 resets 2026-09-03|claude|$RESET_NOW|UTC|rc=0 first=EVENT+usage-limit+gh-2 out~resets%e=false" \
+  "a weekday alone guesses no midnight|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Thursday|claude|$RESET_NOW|UTC|rc=0 first=EVENT+usage-limit+gh-2 out~resets%e=false" \
+  "a zone the host cannot resolve drops the time|new|banner:You've hit your usage limit \\xc2\\xb7 resets 9:50am (Bogus/Zone)|claude|$RESET_NOW|UTC|rc=0 first=EVENT+usage-limit+gh-2 out~resets%e=false"
 
 # SURFACE 2: a clause naming no day is usage-limit-passed only once this watch
 # has seen that wall standing (the case the issue was filed on); the same
@@ -250,13 +252,13 @@ usage_table \
 # is-the-account-speaking for both consumers, so a turn in flight neither
 # emits nor stamps.
 usage_table \
-  "the first pass observes the wall and carries the reset it names|new|banner:$BANNER|claude|$RESET_NOW|UTC|first=$AT_0950" \
-  "the reset the first pass observed, now behind us, is its own event|cont|banner:$BANNER|claude|1788369300|UTC|first=EVENT+usage-limit-passed+gh-2+resets=2026-09-02T16:50:00Z" \
-  "a wall this watch never saw standing is parked, not bumped|new|banner:$BANNER|claude|1788369300|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-03T16:50:00Z" \
-  "a dated reset already behind us is passed without an observation|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Aug 30, 4pm|claude|$RESET_NOW|UTC|first=EVENT+usage-limit-passed+gh-2+resets=2026-08-30T16:00:00Z" \
-  "and a dated reset still ahead is a wall standing|cont|banner:You've hit your weekly limit \\xc2\\xb7 resets Sep 6, 4pm|claude|-|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-06T16:00:00Z" \
-  "a lane with a turn in flight is left alone|new|working|claude|$RESET_NOW|UTC|first=$HEARTBEAT" \
-  "the working pass left no sighting, so this one is the first|cont|banner_1700|claude|1788372000|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-03T17:00:00Z"
+  "the first pass observes the wall and carries the reset it names|new|banner:$BANNER|claude|$RESET_NOW|UTC|rc=0 first=$AT_0950" \
+  "the reset the first pass observed, now behind us, is its own event|cont|banner:$BANNER|claude|1788369300|UTC|rc=0 first=EVENT+usage-limit-passed+gh-2+resets=2026-09-02T16:50:00Z" \
+  "a wall this watch never saw standing is parked, not bumped|new|banner:$BANNER|claude|1788369300|UTC|rc=0 first=EVENT+usage-limit+gh-2+resets=2026-09-03T16:50:00Z" \
+  "a dated reset already behind us is passed without an observation|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Aug 30, 4pm|claude|$RESET_NOW|UTC|rc=0 first=EVENT+usage-limit-passed+gh-2+resets=2026-08-30T16:00:00Z" \
+  "and a dated reset still ahead is a wall standing|cont|banner:You've hit your weekly limit \\xc2\\xb7 resets Sep 6, 4pm|claude|-|UTC|rc=0 first=EVENT+usage-limit+gh-2+resets=2026-09-06T16:00:00Z" \
+  "a lane with a turn in flight is left alone|new|working|claude|$RESET_NOW|UTC|rc=0 first=$HEARTBEAT" \
+  "the working pass left no sighting, so this one is the first|cont|banner_1700|claude|1788372000|UTC|rc=0 first=EVENT+usage-limit+gh-2+resets=2026-09-03T17:00:00Z"
 
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/orch/tests/oversee_watch_usage_limit.sh
+++ b/skills/orch/tests/oversee_watch_usage_limit.sh
@@ -1,485 +1,262 @@
 #!/usr/bin/env bash
-# Tests for what oversee-watch reads off a spent-account banner:
-# whether a limit banner on a lane's screen is the account speaking now, and
-# what the reset clause on that line resolves to. The rest of the pane side is
+# Tests for what oversee-watch reads off a spent-account banner: whether a
+# limit banner on a lane's screen is the account speaking now, and what the
+# reset clause on that line resolves to. The rest of the pane side is
 # oversee_watch_lanes.sh and the GitHub side oversee_watch.sh; all build their
 # sandbox from lib/oversee-watch-harness.sh.
+#
+# One table. A row names a screen (a byte-exact pane fixture, kept whole in
+# `screen`), the lane it sits in, the clock and zone the pane is read under,
+# and the facts the run must show; `watch` reads exactly those facts, so a row
+# fails on the fact it names. A `cont` row is the next pass of the row above
+# it, with the same state and a fresh capture.
 set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/lib/git-env.sh"
 
 # shellcheck source=lib/oversee-watch-harness.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/oversee-watch-harness.sh"
 
-
 # Every fixture banner below states a clock, and the event carries the UTC
-# instant it resolves to. Cases asserting the whole event line pin both ends of
-# that resolution — RESET_NOW as the moment the pane is read (`now.epoch`, the
-# harness's clock stub) and TZ=UTC as the zone a banner naming none is read in
-# — so they hold on a runner in any zone. Their banner is the measured
+# instant it resolves to. Rows asserting the whole event line pin both ends of
+# that resolution: RESET_NOW as the moment the pane is read (`now.epoch`, the
+# harness's clock stub) and TZ=UTC as the zone a banner naming none is read in,
+# so they hold on a runner in any zone. Their banner is the measured
 # `9:50am (America/Los_Angeles)` shape: no mechanism here rests on the one
 # grammar arm nothing is measured to draw, and `resets 21:00` appears only
 # where that arm is the subject.
 RESET_NOW=1788364800
-RESET_0950=' resets=2026-09-02T16:50:00Z'       # what the banner below resolves to
-pin_now() { printf '%s' "$RESET_NOW" > "$STUB_DIR/now.epoch"; }
+AT_0950='EVENT+usage-limit+gh-2+resets=2026-09-02T16:50:00Z'   # what that banner resolves to
+HEARTBEAT='EVENT+heartbeat+loops=1+interval=0s+since=none'
 
-echo "=== oversee-watch usage limits ==="
+BANNER="You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)"
+CODEX_BANNER='Usage limit reached. Increase your limits to continue.'
+COMPOSER='\xe2\x9d\xaf\xc2\xa0'          # Claude's composer: `❯` + U+00A0
+CODEX_COMPOSER='\xe2\x80\xba Ask Codex to do anything'
+DIALOG='  Select Model and Effort\n\xe2\x80\xba 1. gpt-6-astra (current)  Our most capable model for complex, demanding work.\n  2. gpt-5.6-terra          Balanced agentic coding model for everyday work.'
+QUESTION='Do you want to proceed?\n   ❯ 1. Yes\n     2. No'
 
-# --- 1. usage-limit: the harness is alive, the account is spent -------------
-new_case usage_limit
-pin_now
-{
-  printf '⏺ Working through the queue.\n'
-  printf "You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)\n"
-  printf 'Run /usage-credits to raise it\n'
-  printf '\xe2\x9d\xaf\xc2\xa0\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3f"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "0" "usage-limit exits 0" "$err"
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2$RESET_0950" \
-  "a limit banner under a live harness is the event on ONE pass" "$err"
-assert_contains "$out" "usage limit" "the pane tail follows the usage-limit event" "$err"
-
-# Codex words it its own way; one regex covers both harnesses
-new_case usage_limit_codex
-printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
-printf 'Usage limit reached. Increase your limits to continue.\n' > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3f2"
-out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2" "the codex limit banner fires too" "$err"
-
-# A spent account outranks a prompt left on the same screen
-new_case usage_limit_before_question
-pin_now
-{
-  printf "You've hit your session limit \xc2\xb7 resets 9:50am (America/Los_Angeles)\n"
-  printf 'Do you want to proceed?\n   ❯ 1. Yes\n     2. No\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3g"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2$RESET_0950" \
-  "a limit banner above a stale prompt is usage-limit, not question" "$err"
-assert_not_contains "$out" "EVENT lane-asking" "lane-asking never preempts a spent account" "$err"
-
-# The banner and the prompt are read on the same liveness answer, so a lane
-# wrapped in a shell still gets its banner seen
-new_case usage_limit_wrapped_shell
-printf 'fish\n' > "$STUB_DIR/cmd-gh-2.txt"
-printf '2747883\n' > "$STUB_DIR/kids-9002.txt"
-printf "You've hit your weekly limit \xc2\xb7 resets Sunday\n" > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3f3"
-out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2" \
-  "a wrapped lane's limit banner is still the event" "$err"
-
-# An account that has since reset leaves its old banner on the visible screen.
-# A user turn below it says the harness took another turn, so the banner is
-# scrollback and the lane needs nothing.
-new_case usage_limit_stale_banner
-{
-  printf '⏺ Working through the queue.\n'
-  printf "You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)\n"
-  printf '❯ pick the round back up\n'
-  printf '⏺ Teammate @dev-ken832-r3 finished\n'
-  printf '\xe2\x9d\xaf\xc2\xa0\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3f4"
-out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=1 interval=0s since=none" \
-  "a banner the lane has since worked past is not the event" "$err"
-assert_not_contains "$out" "EVENT usage-limit" \
-  "a stale banner above a later user turn never fires" "$err"
-
-# The composer is the last marker line on the screen, and it is never a turn:
-# if it counted as one the whole pane would be sliced away and usage-limit
-# would go silent for every lane. Claude Code draws it as `❯` + U+00A0, which
-# these fixtures spell in bytes and then verify, so a fixture that degrades
-# into an ASCII space fails here instead of passing quietly.
-new_case usage_limit_above_empty_composer
-pin_now
-{
-  printf '⏺ Working through the queue.\n'
-  printf "You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)\n"
-  printf '\xe2\x9d\xaf\xc2\xa0\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-assert_eq "$(grep -c "$(printf '\xc2\xa0')" "$STUB_DIR/pane-gh-2.txt")" "1" \
-  "the composer fixture carries U+00A0, not an ASCII space"
-err="$TMP_ROOT/e3f6"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2$RESET_0950" \
-  "the empty composer is not a turn, so a banner above it is still reported" "$err"
-
-# ...and neither is a composer holding an unsent draft
-new_case usage_limit_above_composer_draft
-pin_now
-{
-  printf '⏺ Working through the queue.\n'
-  printf "You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)\n"
-  printf '\xe2\x9d\xaf\xc2\xa0take the next round\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-assert_eq "$(grep -c "$(printf '\xc2\xa0')" "$STUB_DIR/pane-gh-2.txt")" "1" \
-  "the draft-composer fixture carries U+00A0, not an ASCII space"
-err="$TMP_ROOT/e3f7"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2$RESET_0950" \
-  "an unsent draft in the composer is not a turn either" "$err"
-
-# Codex draws the composer with the SAME `› ` and text a submitted turn uses,
-# so only its position separates them. Its placeholder must not read as a turn.
-new_case usage_limit_above_codex_composer
-printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
-{
-  printf '\xe2\x80\xba pick the round back up\n'
-  printf '\xe2\x80\xa2 Ran 3 commands\n'
-  printf 'Usage limit reached. Increase your limits to continue.\n'
-  printf '\xe2\x80\xba Ask Codex to do anything\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3f8"
-out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2" \
-  "a codex banner below the last turn is reported, the composer notwithstanding" "$err"
-
-# A Codex dialog screen draws no composer, and Codex does NOT indent the row
-# it has selected: that row keeps the marker at column 0, measured on a live
-# model picker, so the screen still ends in a live-input marker line and the
-# turn above it is the boundary. Only the unselected rows indent.
-new_case usage_limit_codex_dialog_stale_banner
-printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
-{
-  printf 'Usage limit reached. Increase your limits to continue.\n'
-  printf '\xe2\x80\xba pick the round back up\n'
-  printf '\xe2\x80\xa2 Ran 3 commands\n'
-  printf '  Select Model and Effort\n'
-  printf '\xe2\x80\xba 1. gpt-6-astra (current)  Our most capable model for complex, demanding work.\n'
-  printf '  2. gpt-5.6-terra          Balanced agentic coding model for everyday work.\n'
-  printf '  Press enter to confirm or esc to go back\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3fd"
-out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT lane-asking gh-2" \
-  "a codex dialog row is live input, so the banner above the turn stays scrollback" "$err"
-assert_not_contains "$out" "EVENT usage-limit" \
-  "the codex dialog row never resurrects a stale banner" "$err"
-
-# The near-miss control. Every fresh Codex prints a benign reset OFFER, and
-# loosening USAGE_LIMIT_RE toward a bare `usage limit` would turn the startup
-# screen of every Codex lane into a spent-account event.
-new_case usage_limit_codex_reset_offer
-printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
-cat "$CODEX_PANES/codex-composer-idle.txt" > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3fg"
-out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_contains "$(cat "$STUB_DIR/pane-gh-2.txt")" "You have 1 usage limit reset available" \
-  "the fixture really carries the reset offer, so the control is not vacuous" "$err"
-assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=1 interval=0s since=none" \
-  "a codex startup screen is no event at all" "$err"
-assert_not_contains "$out" "EVENT usage-limit" \
-  "an offered reset is credit to spend, never a spent account" "$err"
-
-# ...and its control: the banner below the turn on the same dialog screen
-new_case usage_limit_codex_dialog_live_banner
-printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
-{
-  printf '\xe2\x80\xba pick the round back up\n'
-  printf '\xe2\x80\xa2 Ran 3 commands\n'
-  printf 'Usage limit reached. Increase your limits to continue.\n'
-  printf '  Select Model and Effort\n'
-  printf '\xe2\x80\xba 1. gpt-6-astra (current)  Our most capable model for complex, demanding work.\n'
-  printf '  2. gpt-5.6-terra          Balanced agentic coding model for everyday work.\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3fe"
-out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2" \
-  "a banner below the turn on a codex dialog screen is still the event" "$err"
-
-# ...and the must-fail control: the same codex screen with the banner ABOVE
-# the turn is scrollback, which the composer must not resurrect
-new_case usage_limit_codex_stale_banner
-printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt"
-{
-  printf 'Usage limit reached. Increase your limits to continue.\n'
-  printf '\xe2\x80\xba pick the round back up\n'
-  printf '\xe2\x80\xa2 Ran 3 commands\n'
-  printf '\xe2\x80\xba Ask Codex to do anything\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3f9"
-out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=1 interval=0s since=none" \
-  "a codex banner the lane has worked past is not the event" "$err"
-assert_not_contains "$out" "EVENT usage-limit" \
-  "the codex composer never resurrects a stale banner" "$err"
-
-# The must-fail control for the case above: the same screen with the banner
-# BELOW the turn — the account is spent right now. It carries the permission
-# line a real screen draws under the composer, so the composer is not the last
-# line of the capture: this is where the Claude signature decides the boundary
-# rather than the last-line fallback, and a signature that stops matching
-# drops the banner out of the slice here.
-new_case usage_limit_after_turn
-pin_now
-{
-  printf '❯ pick the round back up\n'
-  printf '⏺ Working through the queue.\n'
-  printf "You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)\n"
-  printf '\xe2\x9d\xaf\xc2\xa0\n'
-  printf '  bypass permissions on\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3f5"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2$RESET_0950" \
-  "a banner below the last user turn is the event" "$err"
-
-# An input line the composer rule does not recognize must not become the
-# boundary itself: that empties the slice and makes usage-limit a silent
-# no-op. A marker line that is the last line of the capture falls back to the
-# previous marker, so the unrecognized case fails toward a stale banner.
-new_case usage_limit_unrecognized_composer
-pin_now
-{
-  printf '❯ pick the round back up\n'
-  printf '⏺ Working through the queue.\n'
-  printf "You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)\n"
-  printf '❯ \n'
-} > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3f6"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2$RESET_0950" \
-  "an unrecognized last input line never swallows the screen" "$err"
-
-# A realistic transcript, with the E2-lead lines a real screen carries
-# between the banner and the composer. It carries no streaming token counter:
-# the turn that hit the wall is over, and a counter still on screen would mean
-# a turn in flight, which no usage-limit event is emitted under. The marker must be an alternation of
-# literals: as a bracket expression it degrades to a set of BYTES on any awk
-# without multibyte support, every one of these lines then reads as a marker,
-# the boundary lands below the banner and usage-limit goes silent. A short
-# fixture cannot see that; this one can.
-new_case usage_limit_realistic_transcript
-pin_now
-{
-  printf '❯ pick the round back up\n'
-  printf '⏺ Ran 3 shell commands\n'
-  printf "You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)\n"
-  printf '⏺ Teammate @dev-ken832-r3 finished\n'
-  printf '⎿  Wrote 6 lines to tmp/roundD.json\n'
-  printf '─────────────────────────────\n'
-  printf '\xe2\x9d\xaf\xc2\xa0\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-# Run it in BOTH locales. The byte-set degradation only happens on an awk
-# without multibyte support, so under the runner's own UTF-8 locale gawk
-# behaves identically either way and the case cannot fail on the defect it
-# names. Under LC_ALL=C it can, and does. The UTF-8 invocation stays as the
-# control that the case passes for the right reason rather than by locale.
-err="$TMP_ROOT/e3fc"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2$RESET_0950" \
-  "transcript lines between the banner and the composer are not markers" "$err"
-err="$TMP_ROOT/e3fc2"
-out="$(run_watch TZ=UTC LC_ALL=C LANG=C -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2$RESET_0950" \
-  "...and under a byte-oriented locale, where a marker class would degrade" "$err"
-
-# A dialog screen draws no composer at all: Claude replaces it with the
-# selection rows, which it indents, so the last marker line there is the user
-# turn itself. Read as a composer, the boundary would slip back to the turn
-# before it and reopen the window over the very scrollback this slice exists
-# to exclude — a stale banner would mask a live question.
-new_case usage_limit_stale_banner_over_question
-{
-  printf "You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)\n"
-  printf '❯ pick the round back up\n'
-  printf '⏺ Teammate @dev-ken832-r3 finished\n'
-  printf 'Do you want to proceed?\n'
-  printf '   ❯ 1. Yes\n     2. No\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3fa"
-out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT lane-asking gh-2" \
-  "a stale banner never masks the live question on a dialog screen" "$err"
-assert_not_contains "$out" "EVENT usage-limit" \
-  "the banner above the turn stays scrollback when no composer is drawn" "$err"
-
-# ...and its control: on the same dialog screen, a banner BELOW the turn is
-# the account spent right now, and it still outranks the question
-new_case usage_limit_live_banner_over_question
-pin_now
-{
-  printf '❯ pick the round back up\n'
-  printf '⏺ Teammate @dev-ken832-r3 finished\n'
-  printf "You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)\n"
-  printf 'Do you want to proceed?\n'
-  printf '   ❯ 1. Yes\n     2. No\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3fb"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2$RESET_0950" \
-  "a banner below the turn on a dialog screen is still the event" "$err"
-
-# The must-fail control: a lane with no banner at all
-new_case usage_limit_healthy
-printf '⏺ All green, nothing blocking.\n\xe2\x9d\xaf\xc2\xa0\n' > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3h"
-out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=1 interval=0s since=none" \
-  "a lane with no limit banner reaches the heartbeat" "$err"
-assert_not_contains "$out" "EVENT usage-limit" "a healthy lane never fires usage-limit" "$err"
-
-# The account is the actionable part: a live claim maps the window to it
-new_case usage_limit_claim
-printf '900 %%3\n' > "$STUB_DIR/panes.txt"
-printf '900 %%3\n' > "$STUB_DIR/pane-key-gh-2.txt"
-mkdir -p "$STATE_DIR/claims"
-# Read first by glob order, so anything matching on the window NAME alone
-# would answer with one of these instead of the pane actually captured: one
-# claim from another live server, one from THIS server on another pane —
-# window names repeat across sessions as well as across servers.
-printf '%s\t%%3\t/home/me/.otherclaude\tgh-2\t2026-08-16T00:00:00Z\n' "$$" > "$STATE_DIR/claims/a.claim"
-printf '900\t%%9\t/home/me/.thirdclaude\tgh-2\t2026-08-16T00:00:00Z\n' > "$STATE_DIR/claims/b.claim"
-printf '900\t%%3\t/home/me/.eclaude\tgh-2\t2026-08-16T00:00:00Z\n' > "$STATE_DIR/claims/c.claim"
-printf "You've hit your weekly limit\n" > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3i"
-out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2 /home/me/.eclaude" \
-  "the event names the config dir the lane was claimed on" "$err"
-assert_not_contains "$out" "otherclaude" \
-  "a same-named window on another tmux server never answers for this lane" "$err"
-assert_not_contains "$out" "thirdclaude" \
-  "a same-named window on another pane of this server never answers either" "$err"
-
-# ... and a claim whose pane is gone is pruned rather than reported
-new_case usage_limit_claim_stale
-printf '900 %%9\n' > "$STUB_DIR/panes.txt"
-printf '900 %%3\n' > "$STUB_DIR/pane-key-gh-2.txt"
-mkdir -p "$STATE_DIR/claims"
-printf '900\t%%3\t/home/me/.eclaude\tgh-2\t2026-08-16T00:00:00Z\n' > "$STATE_DIR/claims/a.claim"
-printf "You've hit your weekly limit\n" > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3j"
-out="$(run_watch -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2" \
-  "a claim whose pane is gone names no account" "$err"
-assert_eq "$(ls -1 "$STATE_DIR/claims" | wc -l | tr -d '[:space:]')" "0" \
-  "a dead claim is pruned on read, not left to accumulate" "$err"
-
-# --- 2. the reset the banner states ----------------------------------------
-# Four surfaces, one control and one must-fail each. Every case pins
-# `now.epoch` and the runner's zone per the note beside RESET_NOW above.
-#
-# SURFACE 1, control: the reset parsed out of each banner form the grammar
-# accepts. One pass per form, each a fresh sighting because each names a
-# different wall.
-new_case usage_limit_reset_forms
-printf '%s' "$RESET_NOW" > "$STUB_DIR/now.epoch"
-form() {   # BANNER, EXPECTED-EVENT-LINE, NAME, [RUNNER-TZ]
-  printf '%b\n' "$1" > "$STUB_DIR/pane-gh-2.txt"
-  rm -f "$STUB_DIR/pane-gh-2.calls" "$STUB_DIR/cmd-gh-2.calls"
-  local err="$TMP_ROOT/form-$3"
-  local out; out="$(run_watch "TZ=${4:-UTC}" -- --max-loops 1 gh-1 gh-2 2>"$err")" || true
-  assert_eq "$(head -1 <<<"$out")" "$2" "$3" "$err"
+# screen NAME — writes the pane fixture NAME, whole, as lane gh-2's screen.
+# `banner:TEXT` is a one-line pane holding TEXT (`\x` escapes expanded). The
+# composer is the last marker line on the screen and never a turn: Claude Code
+# draws it as `❯` + U+00A0, spelled in bytes here, and a fixture that degraded
+# into an ASCII space would slice the whole pane away, so `composed` checks
+# the byte is there once before the fixture is used.
+composed() {
+  printf '%b\n' "$@" > "$STUB_DIR/pane-gh-2.txt"
+  [[ "$(grep -c "$(printf '\xc2\xa0')" "$STUB_DIR/pane-gh-2.txt")" == 1 ]] \
+    || { echo "screen: a composer fixture lost its U+00A0" >&2; exit 1; }
 }
-form "You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)" \
-  "EVENT usage-limit gh-2$RESET_0950" "a zone-qualified clock resolves in the zone it names"
-form "You've hit your usage limit \xc2\xb7 resets 9:50pm (UTC)" \
-  "EVENT usage-limit gh-2 resets=2026-09-02T21:50:00Z" \
-  "a one-component zone name is still a zone" America/Los_Angeles
-form "You've hit your session limit \xc2\xb7 resets 21:00" \
-  "EVENT usage-limit gh-2 resets=2026-09-02T21:00:00Z" "a clock with no meridiem is a 24-hour one"
-form "You've hit your usage limit \xc2\xb7 resets 12pm" \
-  "EVENT usage-limit gh-2 resets=2026-09-03T12:00:00Z" "12pm is noon, not midnight and not hour 24"
-form "You've hit your weekly limit \xc2\xb7 resets Sep 6, 4pm" \
-  "EVENT usage-limit gh-2 resets=2026-09-06T16:00:00Z" "a dated banner is read as a date"
-form "You've hit your weekly limit \xc2\xb7 resets Oct 7, 2027, 11:32am" \
-  "EVENT usage-limit gh-2 resets=2027-10-07T11:32:00Z" "the year the dated form carries wins"
-form "You've hit your weekly limit \xc2\xb7 resets Thursday 4am" \
-  "EVENT usage-limit gh-2 resets=2026-09-03T04:00:00Z" "a weekday and a clock name that weekday"
-form "You've hit your usage limit. Try again at Sep 6th, 2026 4:30 PM" \
-  "EVENT usage-limit gh-2 resets=2026-09-06T16:30:00Z" "codex's trigger and ordinal day read the same"
-
-# SURFACE 1, must-fail: a form the grammar deliberately excludes, and a zone
-# the host cannot resolve. Each keeps the plain event with no time on it, and
-# none is ever evidence the wall has lifted.
-new_case usage_limit_reset_unreadable
-printf '%s' "$RESET_NOW" > "$STUB_DIR/now.epoch"
-unreadable() {   # BANNER, NAME
-  printf '%b\n' "$1" > "$STUB_DIR/pane-gh-2.txt"
-  rm -f "$STUB_DIR/pane-gh-2.calls" "$STUB_DIR/cmd-gh-2.calls"
-  local err="$TMP_ROOT/unreadable-$2"
-  local out; out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" || true
-  assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2" "$2" "$err"
-  assert_not_contains "$out" "resets=" "$2, and no time is invented" "$err"
+screen() {
+  case "$1" in
+    banner:*) printf '%b\n' "${1#banner:}" > "$STUB_DIR/pane-gh-2.txt" ;;
+    # the harness alive, the account spent, the realistic idle screen
+    banner_idle) composed '⏺ Working through the queue.' "$BANNER" 'Run /usage-credits to raise it' "$COMPOSER" ;;
+    banner_draft) composed '⏺ Working through the queue.' "$BANNER" "${COMPOSER}take the next round" ;;
+    banner_over_question) printf '%b\n' "You've hit your session limit \xc2\xb7 resets 9:50am (America/Los_Angeles)" "$QUESTION" > "$STUB_DIR/pane-gh-2.txt" ;;
+    # a user turn below the banner: the harness took another turn since
+    stale_banner) composed '⏺ Working through the queue.' "$BANNER" '❯ pick the round back up' '⏺ Teammate @dev-ken832-r3 finished' "$COMPOSER" ;;
+    # the permission line a real screen draws under the composer, so the
+    # composer is not the last line and the Claude signature decides the
+    # boundary rather than the last-line fallback
+    banner_after_turn) composed '❯ pick the round back up' '⏺ Working through the queue.' "$BANNER" "$COMPOSER" '  bypass permissions on' ;;
+    # an input line the composer rule does not recognize
+    unrecognized_composer) printf '%b\n' '❯ pick the round back up' '⏺ Working through the queue.' "$BANNER" '❯ ' > "$STUB_DIR/pane-gh-2.txt" ;;
+    # the E2-lead lines a real screen carries between the banner and the
+    # composer, and no streaming token counter: the turn that hit the wall is
+    # over
+    realistic) composed '❯ pick the round back up' '⏺ Ran 3 shell commands' "$BANNER" '⏺ Teammate @dev-ken832-r3 finished' '⎿  Wrote 6 lines to tmp/roundD.json' '─────────────────────────────' "$COMPOSER" ;;
+    # a dialog screen draws no composer: the selection rows replace it
+    stale_over_question) printf '%b\n' "$BANNER" '❯ pick the round back up' '⏺ Teammate @dev-ken832-r3 finished' "$QUESTION" > "$STUB_DIR/pane-gh-2.txt" ;;
+    live_over_question) printf '%b\n' '❯ pick the round back up' '⏺ Teammate @dev-ken832-r3 finished' "$BANNER" "$QUESTION" > "$STUB_DIR/pane-gh-2.txt" ;;
+    healthy) composed '⏺ All green, nothing blocking.' "$COMPOSER" ;;
+    # this suite's own source among the text a lane prints mid-turn
+    working) printf '%b\n' '⏺ Reading the suite.' "  printf \"You've hit your usage limit \xc2\xb7 resets 17:00\"" 'esc to interrupt' > "$STUB_DIR/pane-gh-2.txt" ;;
+    banner_1700) composed "You've hit your usage limit \xc2\xb7 resets 17:00" "$COMPOSER" ;;
+    # Codex draws the composer with the SAME `› ` and text a submitted turn
+    # uses, so only its position separates them
+    codex_banner) printf '%b\n' "$CODEX_BANNER" > "$STUB_DIR/pane-gh-2.txt" ;;
+    codex_live) printf '%b\n' '\xe2\x80\xba pick the round back up' '\xe2\x80\xa2 Ran 3 commands' "$CODEX_BANNER" "$CODEX_COMPOSER" > "$STUB_DIR/pane-gh-2.txt" ;;
+    codex_stale) printf '%b\n' "$CODEX_BANNER" '\xe2\x80\xba pick the round back up' '\xe2\x80\xa2 Ran 3 commands' "$CODEX_COMPOSER" > "$STUB_DIR/pane-gh-2.txt" ;;
+    # a Codex dialog draws no composer and does NOT indent the selected row:
+    # that row keeps the marker at column 0, measured on a live model picker
+    codex_dialog_stale) printf '%b\n' "$CODEX_BANNER" '\xe2\x80\xba pick the round back up' '\xe2\x80\xa2 Ran 3 commands' "$DIALOG" '  Press enter to confirm or esc to go back' > "$STUB_DIR/pane-gh-2.txt" ;;
+    codex_dialog_live) printf '%b\n' '\xe2\x80\xba pick the round back up' '\xe2\x80\xa2 Ran 3 commands' "$CODEX_BANNER" "$DIALOG" > "$STUB_DIR/pane-gh-2.txt" ;;
+    # the byte-exact startup screen of a fresh Codex, carrying its reset OFFER
+    codex_idle)
+      grep -qF 'You have 1 usage limit reset available' "$CODEX_PANES/codex-composer-idle.txt" \
+        || { echo "screen: the codex idle fixture no longer carries the reset offer, so the near-miss row would pin nothing" >&2; exit 1; }
+      cat "$CODEX_PANES/codex-composer-idle.txt" > "$STUB_DIR/pane-gh-2.txt" ;;
+    *) echo "screen: unknown fixture $1" >&2; exit 1 ;;
+  esac
 }
-unreadable "You've hit your fast limit \xc2\xb7 resets in 5m" "a duration names no instant"
-unreadable "You've hit your usage limit \xc2\xb7 resets 2026-09-03" "a bare number is not a clock"
-unreadable "You've hit your weekly limit \xc2\xb7 resets Thursday" "a weekday alone guesses no midnight"
-unreadable "You've hit your usage limit \xc2\xb7 resets 9:50am (Bogus/Zone)" \
-  "a zone the host cannot resolve drops the time"
 
-# SURFACE 2, control: a clause naming no day is usage-limit-passed only once
-# this watch has seen that wall standing. The case the issue was filed on.
-new_case usage_limit_reset_passed
-printf '%s' "$RESET_NOW" > "$STUB_DIR/now.epoch"
-printf "You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)\n" > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3k"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2$RESET_0950" \
-  "the first pass observes the wall and carries the reset it names" "$err"
-printf '1788369300' > "$STUB_DIR/now.epoch"
-rm -f "$STUB_DIR/pane-gh-2.calls" "$STUB_DIR/cmd-gh-2.calls"
-err="$TMP_ROOT/e3l"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit-passed gh-2 resets=2026-09-02T16:50:00Z" \
-  "the reset the first pass observed, now behind us, is its own event" "$err"
+# lane NAME — stages what surrounds the pane: its foreground command, and for
+# the claim lanes the pane identity and the claim files the watch reads.
+lane() {
+  case "$1" in
+    claude) ;;
+    codex) printf 'codex\n' > "$STUB_DIR/cmd-gh-2.txt" ;;
+    # the harness under a shell: liveness is answered from the shell's children
+    fish) printf 'fish\n' > "$STUB_DIR/cmd-gh-2.txt"; printf '2747883\n' > "$STUB_DIR/kids-9002.txt" ;;
+    # three claims, read in glob order: one from another live server, one from
+    # THIS server on another pane, and the pane actually captured. Window
+    # names repeat across sessions as well as across servers.
+    claim_live)
+      printf '900 %%3\n' > "$STUB_DIR/panes.txt"
+      printf '900 %%3\n' > "$STUB_DIR/pane-key-gh-2.txt"
+      mkdir -p "$STATE_DIR/claims"
+      printf '%s\t%%3\t/home/me/.otherclaude\tgh-2\t2026-08-16T00:00:00Z\n' "$$" > "$STATE_DIR/claims/a.claim"
+      printf '900\t%%9\t/home/me/.thirdclaude\tgh-2\t2026-08-16T00:00:00Z\n' > "$STATE_DIR/claims/b.claim"
+      printf '900\t%%3\t/home/me/.eclaude\tgh-2\t2026-08-16T00:00:00Z\n' > "$STATE_DIR/claims/c.claim" ;;
+    # one claim whose pane is gone
+    claim_dead)
+      printf '900 %%9\n' > "$STUB_DIR/panes.txt"
+      printf '900 %%3\n' > "$STUB_DIR/pane-key-gh-2.txt"
+      mkdir -p "$STATE_DIR/claims"
+      printf '900\t%%3\t/home/me/.eclaude\tgh-2\t2026-08-16T00:00:00Z\n' > "$STATE_DIR/claims/a.claim" ;;
+    *) echo "lane: unknown lane $1" >&2; exit 1 ;;
+  esac
+}
 
-# SURFACE 2, must-fail: the same screen at the same instant with nothing
-# observed before it cannot know which 9:50am the banner meant, so it parks.
-new_case usage_limit_reset_unobserved
-printf '1788369300' > "$STUB_DIR/now.epoch"
-printf "You've hit your usage limit \xc2\xb7 resets 9:50am (America/Los_Angeles)\n" > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3m"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2 resets=2026-09-03T16:50:00Z" \
-  "a wall this watch never saw standing is parked, not bumped" "$err"
+# run [ENV=VAL ...] — one single-pass watch over gh-1 and gh-2; OUT, RC and
+# ERR (a file) are what `watch` reads.
+RUN_SEQ=0
+run() {
+  ERR="$TMP_ROOT/run-$((++RUN_SEQ)).err"
+  OUT="$(run_watch "$@" -- --max-loops 1 gh-1 gh-2 2>"$ERR")" && RC=0 || RC=$?
+}
 
-# SURFACE 3: a dated clause names its own day, so it needs no sighting — spent
-# on sight when the date is behind us, standing when it is ahead.
-new_case usage_limit_reset_dated
-printf '%s' "$RESET_NOW" > "$STUB_DIR/now.epoch"
-printf "You've hit your weekly limit \xc2\xb7 resets Aug 30, 4pm\n" > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3ad"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit-passed gh-2 resets=2026-08-30T16:00:00Z" \
-  "a dated reset already behind us is passed without an observation" "$err"
-printf "You've hit your weekly limit \xc2\xb7 resets Sep 6, 4pm\n" > "$STUB_DIR/pane-gh-2.txt"
-rm -f "$STUB_DIR/pane-gh-2.calls" "$STUB_DIR/cmd-gh-2.calls"
-err="$TMP_ROOT/e3o"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2 resets=2026-09-06T16:00:00Z" \
-  "and a dated reset still ahead is a wall standing" "$err"
+# watch EXPECT — prints the run's value of every `name=` field EXPECT names,
+# in EXPECT's order (in a needle `+` reads as a space and %e as `=`):
+#   rc            exit status
+#   first         the first stdout line, or `none`
+#   out~<text>    whether stdout carries <text>
+#   claims        how many claim files the state directory holds
+watch() {
+  local got="" token name value needle
+  set -f
+  for token in $1; do
+    name="${token%%=*}"
+    needle="${name#*~}"; needle="${needle//+/ }"; needle="${needle//%e/=}"
+    case "$name" in
+      rc) value="$RC" ;;
+      first) value="$(head -n 1 <<<"$OUT")"; value="${value:-none}"; value="${value// /+}" ;;
+      out~*) value="$(grep -qF -- "$needle" <<<"$OUT" && echo true || echo false)" ;;
+      claims) value="$(find "$STATE_DIR/claims" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d '[:space:]')" ;;
+      *) echo "watch: unknown field $name" >&2; exit 1 ;;
+    esac
+    got="$got $name=$value"
+  done
+  set +f
+  printf '%s' "${got# }"
+}
 
-# SURFACE 4: one predicate answers is-the-account-speaking for both consumers,
-# so a turn in flight neither emits nor stamps — this suite's own source among
-# the text a lane prints mid-turn.
-new_case usage_limit_working_lane
-printf '%s' "$RESET_NOW" > "$STUB_DIR/now.epoch"
-{
-  printf '⏺ Reading the suite.\n'
-  printf "  printf \"You've hit your usage limit \xc2\xb7 resets 17:00\"\n"
-  printf 'esc to interrupt\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-err="$TMP_ROOT/e3n"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=1 interval=0s since=none" \
-  "a lane with a turn in flight is left alone" "$err"
-printf '1788372000' > "$STUB_DIR/now.epoch"
-{
-  printf "You've hit your usage limit \xc2\xb7 resets 17:00\n"
-  printf '\xe2\x9d\xaf\xc2\xa0\n'
-} > "$STUB_DIR/pane-gh-2.txt"
-rm -f "$STUB_DIR/pane-gh-2.calls" "$STUB_DIR/cmd-gh-2.calls"
-err="$TMP_ROOT/e3am"
-out="$(run_watch TZ=UTC -- --max-loops 1 gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT usage-limit gh-2 resets=2026-09-03T17:00:00Z" \
-  "the working pass left no sighting, so this one is the first" "$err"
+# usage_table ROW... — `label|pass|screen|lane|now|zone|expect`. `pass` is
+# `new` (a fresh sandbox) or `cont` (the next pass over the row above: same
+# state, fresh capture); `now` the epoch the pane is read at or `-` for the
+# host clock; `zone` the runner's zone, UTC, LA (America/Los_Angeles), C (UTC
+# under a byte-oriented locale) or `-` for the host's.
+CASE_SEQ=0
+usage_table() {
+  local row label pass name which now zone expect env
+  for row in "$@"; do
+    IFS='|' read -r label pass name which now zone expect <<<"$row"
+    [[ -n "$expect" ]] || { printf 'usage_table: a row with no expect asserts nothing: %s\n' "$row" >&2; exit 1; }
+    case "$pass" in
+      new) new_case "usage_$((++CASE_SEQ))" ;;
+      cont) rm -f "$STUB_DIR/pane-gh-2.calls" "$STUB_DIR/cmd-gh-2.calls" ;;
+      *) echo "usage_table: unknown pass $pass in $row" >&2; exit 1 ;;
+    esac
+    lane "$which"
+    screen "$name"
+    [[ "$now" == - ]] || printf '%s' "$now" > "$STUB_DIR/now.epoch"
+    env=()
+    case "$zone" in
+      UTC) env=(TZ=UTC) ;;
+      LA) env=(TZ=America/Los_Angeles) ;;
+      C) env=(TZ=UTC LC_ALL=C LANG=C) ;;
+      -) ;;
+      *) echo "usage_table: unknown zone $zone in $row" >&2; exit 1 ;;
+    esac
+    run ${env[@]+"${env[@]}"}
+    assert_eq "$(watch "$expect")" "$expect" "$label" "$ERR"
+  done
+}
+
+echo "=== oversee-watch usage limits: is the account speaking now ==="
+# A banner is the event only when nothing below it says the harness took
+# another turn: the last user-turn marker is the boundary, the composer is
+# never a turn, and a dialog screen draws no composer at all, so its last
+# marker line is the user turn itself. The realistic transcript runs under
+# both locales: the marker must be an alternation of literals, since as a
+# bracket expression it degrades to a set of BYTES on an awk without multibyte
+# support and every transcript line reads as a marker; gawk under the runner's
+# UTF-8 locale cannot see that, LC_ALL=C can. A spent account outranks a
+# prompt on the same screen, and the near-miss is every fresh Codex's benign
+# reset OFFER, which a looser USAGE_LIMIT_RE would turn into an event.
+usage_table \
+  "a limit banner under a live harness is the event on ONE pass, the pane tail following|new|banner_idle|claude|$RESET_NOW|UTC|rc=0 first=$AT_0950 out~usage+limit=true" \
+  "the codex banner fires too: one regex covers both harnesses|new|codex_banner|codex|-|-|first=EVENT+usage-limit+gh-2" \
+  "a limit banner above a stale prompt is usage-limit, never lane-asking|new|banner_over_question|claude|$RESET_NOW|UTC|first=$AT_0950 out~EVENT+lane-asking=false" \
+  "a lane wrapped in a shell still gets its banner seen|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Sunday|fish|-|-|first=EVENT+usage-limit+gh-2" \
+  "a banner the lane has since worked past is scrollback|new|stale_banner|claude|-|-|first=$HEARTBEAT out~EVENT+usage-limit=false" \
+  "an unsent draft in the composer is not a turn either|new|banner_draft|claude|$RESET_NOW|UTC|first=$AT_0950" \
+  "a banner below the last user turn is the event, the Claude signature deciding the boundary|new|banner_after_turn|claude|$RESET_NOW|UTC|first=$AT_0950" \
+  "an unrecognized last input line never swallows the screen|new|unrecognized_composer|claude|$RESET_NOW|UTC|first=$AT_0950" \
+  "transcript lines between the banner and the composer are not markers|new|realistic|claude|$RESET_NOW|UTC|first=$AT_0950" \
+  "...and under a byte-oriented locale, where a marker class would degrade|cont|realistic|claude|-|C|first=$AT_0950" \
+  "a stale banner never masks the live question on a dialog screen|new|stale_over_question|claude|-|-|first=EVENT+lane-asking+gh-2 out~EVENT+usage-limit=false" \
+  "a banner below the turn on a dialog screen is still the event, and outranks the question|new|live_over_question|claude|$RESET_NOW|UTC|first=$AT_0950" \
+  "a codex banner below the last turn is reported, the composer notwithstanding|new|codex_live|codex|-|-|first=EVENT+usage-limit+gh-2" \
+  "a codex banner the lane has worked past is not the event: the composer never resurrects it|new|codex_stale|codex|-|-|first=$HEARTBEAT out~EVENT+usage-limit=false" \
+  "a codex dialog row is live input, so the banner above the turn stays scrollback|new|codex_dialog_stale|codex|-|-|first=EVENT+lane-asking+gh-2 out~EVENT+usage-limit=false" \
+  "a banner below the turn on a codex dialog screen is still the event|new|codex_dialog_live|codex|-|-|first=EVENT+usage-limit+gh-2" \
+  "a codex startup screen is no event: an offered reset is credit to spend|new|codex_idle|codex|-|-|first=$HEARTBEAT out~EVENT+usage-limit=false" \
+  "control: a lane with no banner reaches the heartbeat|new|healthy|claude|-|-|first=$HEARTBEAT out~EVENT+usage-limit=false"
+
+echo "=== the account is the actionable part ==="
+# A live claim maps the window to its config dir; anything matching on the
+# window NAME alone would answer with another server's or another pane's
+# claim. A claim whose pane is gone is pruned on read, not reported.
+usage_table \
+  "the event names the config dir the lane was claimed on, never a same-named window elsewhere|new|banner:You've hit your weekly limit|claim_live|-|-|first=EVENT+usage-limit+gh-2+/home/me/.eclaude out~otherclaude=false out~thirdclaude=false" \
+  "a claim whose pane is gone names no account and is pruned|new|banner:You've hit your weekly limit|claim_dead|-|-|first=EVENT+usage-limit+gh-2 claims=0"
+
+echo "=== the reset the banner states ==="
+# SURFACE 1: the reset parsed out of each banner form the grammar accepts,
+# each a fresh sighting because each names a different wall; then the forms
+# the grammar deliberately excludes and a zone the host cannot resolve, which
+# keep the plain event with no time on it and are never evidence the wall
+# has lifted.
+usage_table \
+  "a zone-qualified clock resolves in the zone it names|new|banner:$BANNER|claude|$RESET_NOW|UTC|first=$AT_0950" \
+  "a one-component zone name is still a zone|new|banner:You've hit your usage limit \\xc2\\xb7 resets 9:50pm (UTC)|claude|$RESET_NOW|LA|first=EVENT+usage-limit+gh-2+resets=2026-09-02T21:50:00Z" \
+  "a clock with no meridiem is a 24-hour one|new|banner:You've hit your session limit \\xc2\\xb7 resets 21:00|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-02T21:00:00Z" \
+  "12pm is noon, not midnight and not hour 24|new|banner:You've hit your usage limit \\xc2\\xb7 resets 12pm|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-03T12:00:00Z" \
+  "a dated banner is read as a date|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Sep 6, 4pm|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-06T16:00:00Z" \
+  "the year the dated form carries wins|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Oct 7, 2027, 11:32am|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2+resets=2027-10-07T11:32:00Z" \
+  "a weekday and a clock name that weekday|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Thursday 4am|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-03T04:00:00Z" \
+  "codex's trigger and ordinal day read the same|new|banner:You've hit your usage limit. Try again at Sep 6th, 2026 4:30 PM|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-06T16:30:00Z" \
+  "a duration names no instant, and no time is invented|new|banner:You've hit your fast limit \\xc2\\xb7 resets in 5m|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2 out~resets%e=false" \
+  "a bare number is not a clock|new|banner:You've hit your usage limit \\xc2\\xb7 resets 2026-09-03|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2 out~resets%e=false" \
+  "a weekday alone guesses no midnight|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Thursday|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2 out~resets%e=false" \
+  "a zone the host cannot resolve drops the time|new|banner:You've hit your usage limit \\xc2\\xb7 resets 9:50am (Bogus/Zone)|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2 out~resets%e=false"
+
+# SURFACE 2: a clause naming no day is usage-limit-passed only once this watch
+# has seen that wall standing (the case the issue was filed on); the same
+# screen at the same instant with nothing observed before it cannot know which
+# 9:50am the banner meant, so it parks. SURFACE 3: a dated clause names its
+# own day and needs no sighting. SURFACE 4: one predicate answers
+# is-the-account-speaking for both consumers, so a turn in flight neither
+# emits nor stamps.
+usage_table \
+  "the first pass observes the wall and carries the reset it names|new|banner:$BANNER|claude|$RESET_NOW|UTC|first=$AT_0950" \
+  "the reset the first pass observed, now behind us, is its own event|cont|banner:$BANNER|claude|1788369300|UTC|first=EVENT+usage-limit-passed+gh-2+resets=2026-09-02T16:50:00Z" \
+  "a wall this watch never saw standing is parked, not bumped|new|banner:$BANNER|claude|1788369300|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-03T16:50:00Z" \
+  "a dated reset already behind us is passed without an observation|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Aug 30, 4pm|claude|$RESET_NOW|UTC|first=EVENT+usage-limit-passed+gh-2+resets=2026-08-30T16:00:00Z" \
+  "and a dated reset still ahead is a wall standing|cont|banner:You've hit your weekly limit \\xc2\\xb7 resets Sep 6, 4pm|claude|-|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-06T16:00:00Z" \
+  "a lane with a turn in flight is left alone|new|working|claude|$RESET_NOW|UTC|first=$HEARTBEAT" \
+  "the working pass left no sighting, so this one is the first|cont|banner_1700|claude|1788372000|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-03T17:00:00Z"
 
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/orch/tests/oversee_watch_usage_limit.sh
+++ b/skills/orch/tests/oversee_watch_usage_limit.sh
@@ -153,8 +153,9 @@ watch() {
 
 # usage_table ROW... — `label|pass|screen|lane|now|zone|expect`. `pass` is
 # `new` (a fresh sandbox) or `cont` (the next pass over the row above: same
-# state, fresh capture); `now` the epoch the pane is read at or `-` for the
-# host clock; `zone` the runner's zone, UTC, LA (America/Los_Angeles), C (UTC
+# state, fresh capture); `now` the epoch the pane is read at, or `-` for the
+# host clock on a new row and the row above's clock on a cont row; `zone`
+# the runner's zone, UTC, LA (America/Los_Angeles), C (UTC
 # under a byte-oriented locale) or `-` for the host's.
 CASE_SEQ=0
 usage_table() {
@@ -196,51 +197,52 @@ echo "=== oversee-watch usage limits: is the account speaking now ==="
 # reset OFFER, which a looser USAGE_LIMIT_RE would turn into an event.
 usage_table \
   "a limit banner under a live harness is the event on ONE pass, the pane tail following|new|banner_idle|claude|$RESET_NOW|UTC|rc=0 first=$AT_0950 out~usage+limit=true" \
-  "the codex banner fires too: one regex covers both harnesses|new|codex_banner|codex|-|-|first=EVENT+usage-limit+gh-2" \
-  "a limit banner above a stale prompt is usage-limit, never lane-asking|new|banner_over_question|claude|$RESET_NOW|UTC|first=$AT_0950 out~EVENT+lane-asking=false" \
-  "a lane wrapped in a shell still gets its banner seen|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Sunday|fish|-|-|first=EVENT+usage-limit+gh-2" \
-  "a banner the lane has since worked past is scrollback|new|stale_banner|claude|-|-|first=$HEARTBEAT out~EVENT+usage-limit=false" \
-  "an unsent draft in the composer is not a turn either|new|banner_draft|claude|$RESET_NOW|UTC|first=$AT_0950" \
-  "a banner below the last user turn is the event, the Claude signature deciding the boundary|new|banner_after_turn|claude|$RESET_NOW|UTC|first=$AT_0950" \
-  "an unrecognized last input line never swallows the screen|new|unrecognized_composer|claude|$RESET_NOW|UTC|first=$AT_0950" \
-  "transcript lines between the banner and the composer are not markers|new|realistic|claude|$RESET_NOW|UTC|first=$AT_0950" \
-  "...and under a byte-oriented locale, where a marker class would degrade|cont|realistic|claude|-|C|first=$AT_0950" \
-  "a stale banner never masks the live question on a dialog screen|new|stale_over_question|claude|-|-|first=EVENT+lane-asking+gh-2 out~EVENT+usage-limit=false" \
-  "a banner below the turn on a dialog screen is still the event, and outranks the question|new|live_over_question|claude|$RESET_NOW|UTC|first=$AT_0950" \
-  "a codex banner below the last turn is reported, the composer notwithstanding|new|codex_live|codex|-|-|first=EVENT+usage-limit+gh-2" \
-  "a codex banner the lane has worked past is not the event: the composer never resurrects it|new|codex_stale|codex|-|-|first=$HEARTBEAT out~EVENT+usage-limit=false" \
-  "a codex dialog row is live input, so the banner above the turn stays scrollback|new|codex_dialog_stale|codex|-|-|first=EVENT+lane-asking+gh-2 out~EVENT+usage-limit=false" \
-  "a banner below the turn on a codex dialog screen is still the event|new|codex_dialog_live|codex|-|-|first=EVENT+usage-limit+gh-2" \
-  "a codex startup screen is no event: an offered reset is credit to spend|new|codex_idle|codex|-|-|first=$HEARTBEAT out~EVENT+usage-limit=false" \
-  "control: a lane with no banner reaches the heartbeat|new|healthy|claude|-|-|first=$HEARTBEAT out~EVENT+usage-limit=false"
+  "the codex banner fires too: one regex covers both harnesses|new|codex_banner|codex|-|-|rc=0 first=EVENT+usage-limit+gh-2" \
+  "a limit banner above a stale prompt is usage-limit, never lane-asking|new|banner_over_question|claude|$RESET_NOW|UTC|rc=0 first=$AT_0950 out~EVENT+lane-asking=false" \
+  "a lane wrapped in a shell still gets its banner seen|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Sunday|fish|-|-|rc=0 first=EVENT+usage-limit+gh-2" \
+  "a banner the lane has since worked past is scrollback|new|stale_banner|claude|-|-|rc=0 first=$HEARTBEAT out~EVENT+usage-limit=false" \
+  "an unsent draft in the composer is not a turn either|new|banner_draft|claude|$RESET_NOW|UTC|rc=0 first=$AT_0950" \
+  "a banner below the last user turn is the event, the Claude signature deciding the boundary|new|banner_after_turn|claude|$RESET_NOW|UTC|rc=0 first=$AT_0950" \
+  "an unrecognized last input line never swallows the screen|new|unrecognized_composer|claude|$RESET_NOW|UTC|rc=0 first=$AT_0950" \
+  "transcript lines between the banner and the composer are not markers|new|realistic|claude|$RESET_NOW|UTC|rc=0 first=$AT_0950" \
+  "...and under a byte-oriented locale, where a marker class would degrade|cont|realistic|claude|-|C|rc=0 first=$AT_0950" \
+  "a stale banner never masks the live question on a dialog screen|new|stale_over_question|claude|-|-|rc=0 first=EVENT+lane-asking+gh-2 out~EVENT+usage-limit=false" \
+  "a banner below the turn on a dialog screen is still the event, and outranks the question|new|live_over_question|claude|$RESET_NOW|UTC|rc=0 first=$AT_0950" \
+  "a codex banner below the last turn is reported, the composer notwithstanding|new|codex_live|codex|-|-|rc=0 first=EVENT+usage-limit+gh-2" \
+  "a codex banner the lane has worked past is not the event: the composer never resurrects it|new|codex_stale|codex|-|-|rc=0 first=$HEARTBEAT out~EVENT+usage-limit=false" \
+  "a codex dialog row is live input, so the banner above the turn stays scrollback|new|codex_dialog_stale|codex|-|-|rc=0 first=EVENT+lane-asking+gh-2 out~EVENT+usage-limit=false" \
+  "a banner below the turn on a codex dialog screen is still the event|new|codex_dialog_live|codex|-|-|rc=0 first=EVENT+usage-limit+gh-2" \
+  "a codex startup screen is no event: an offered reset is credit to spend|new|codex_idle|codex|-|-|rc=0 first=$HEARTBEAT out~EVENT+usage-limit=false" \
+  "control: a lane with no banner reaches the heartbeat|new|healthy|claude|-|-|rc=0 first=$HEARTBEAT out~EVENT+usage-limit=false"
 
 echo "=== the account is the actionable part ==="
 # A live claim maps the window to its config dir; anything matching on the
 # window NAME alone would answer with another server's or another pane's
 # claim. A claim whose pane is gone is pruned on read, not reported.
 usage_table \
-  "the event names the config dir the lane was claimed on, never a same-named window elsewhere|new|banner:You've hit your weekly limit|claim_live|-|-|first=EVENT+usage-limit+gh-2+/home/me/.eclaude out~otherclaude=false out~thirdclaude=false" \
-  "a claim whose pane is gone names no account and is pruned|new|banner:You've hit your weekly limit|claim_dead|-|-|first=EVENT+usage-limit+gh-2 claims=0"
+  "the event names the config dir the lane was claimed on, never a same-named window elsewhere|new|banner:You've hit your weekly limit|claim_live|-|-|rc=0 first=EVENT+usage-limit+gh-2+/home/me/.eclaude out~otherclaude=false out~thirdclaude=false" \
+  "a claim whose pane is gone names no account and is pruned|new|banner:You've hit your weekly limit|claim_dead|-|-|rc=0 first=EVENT+usage-limit+gh-2 claims=0"
 
 echo "=== the reset the banner states ==="
 # SURFACE 1: the reset parsed out of each banner form the grammar accepts,
-# each a fresh sighting because each names a different wall; then the forms
+# each a fresh sighting because each names a different wall (the
+# zone-qualified form is the row that opens the observed-reset sequence
+# below); then the forms
 # the grammar deliberately excludes and a zone the host cannot resolve, which
 # keep the plain event with no time on it and are never evidence the wall
 # has lifted.
 usage_table \
-  "a zone-qualified clock resolves in the zone it names|new|banner:$BANNER|claude|$RESET_NOW|UTC|first=$AT_0950" \
-  "a one-component zone name is still a zone|new|banner:You've hit your usage limit \\xc2\\xb7 resets 9:50pm (UTC)|claude|$RESET_NOW|LA|first=EVENT+usage-limit+gh-2+resets=2026-09-02T21:50:00Z" \
-  "a clock with no meridiem is a 24-hour one|new|banner:You've hit your session limit \\xc2\\xb7 resets 21:00|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-02T21:00:00Z" \
-  "12pm is noon, not midnight and not hour 24|new|banner:You've hit your usage limit \\xc2\\xb7 resets 12pm|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-03T12:00:00Z" \
-  "a dated banner is read as a date|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Sep 6, 4pm|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-06T16:00:00Z" \
-  "the year the dated form carries wins|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Oct 7, 2027, 11:32am|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2+resets=2027-10-07T11:32:00Z" \
-  "a weekday and a clock name that weekday|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Thursday 4am|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-03T04:00:00Z" \
-  "codex's trigger and ordinal day read the same|new|banner:You've hit your usage limit. Try again at Sep 6th, 2026 4:30 PM|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-06T16:30:00Z" \
-  "a duration names no instant, and no time is invented|new|banner:You've hit your fast limit \\xc2\\xb7 resets in 5m|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2 out~resets%e=false" \
-  "a bare number is not a clock|new|banner:You've hit your usage limit \\xc2\\xb7 resets 2026-09-03|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2 out~resets%e=false" \
-  "a weekday alone guesses no midnight|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Thursday|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2 out~resets%e=false" \
-  "a zone the host cannot resolve drops the time|new|banner:You've hit your usage limit \\xc2\\xb7 resets 9:50am (Bogus/Zone)|claude|$RESET_NOW|UTC|first=EVENT+usage-limit+gh-2 out~resets%e=false"
+  "a one-component zone name is still a zone|new|banner:You've hit your usage limit \\xc2\\xb7 resets 9:50pm (UTC)|claude|$RESET_NOW|LA|rc=0 first=EVENT+usage-limit+gh-2+resets=2026-09-02T21:50:00Z" \
+  "a clock with no meridiem is a 24-hour one|new|banner:You've hit your session limit \\xc2\\xb7 resets 21:00|claude|$RESET_NOW|UTC|rc=0 first=EVENT+usage-limit+gh-2+resets=2026-09-02T21:00:00Z" \
+  "12pm is noon, not midnight and not hour 24|new|banner:You've hit your usage limit \\xc2\\xb7 resets 12pm|claude|$RESET_NOW|UTC|rc=0 first=EVENT+usage-limit+gh-2+resets=2026-09-03T12:00:00Z" \
+  "a dated banner is read as a date|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Sep 6, 4pm|claude|$RESET_NOW|UTC|rc=0 first=EVENT+usage-limit+gh-2+resets=2026-09-06T16:00:00Z" \
+  "the year the dated form carries wins|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Oct 7, 2027, 11:32am|claude|$RESET_NOW|UTC|rc=0 first=EVENT+usage-limit+gh-2+resets=2027-10-07T11:32:00Z" \
+  "a weekday and a clock name that weekday|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Thursday 4am|claude|$RESET_NOW|UTC|rc=0 first=EVENT+usage-limit+gh-2+resets=2026-09-03T04:00:00Z" \
+  "codex's trigger and ordinal day read the same|new|banner:You've hit your usage limit. Try again at Sep 6th, 2026 4:30 PM|claude|$RESET_NOW|UTC|rc=0 first=EVENT+usage-limit+gh-2+resets=2026-09-06T16:30:00Z" \
+  "a duration names no instant, and no time is invented|new|banner:You've hit your fast limit \\xc2\\xb7 resets in 5m|claude|$RESET_NOW|UTC|rc=0 first=EVENT+usage-limit+gh-2 out~resets%e=false" \
+  "a bare number is not a clock|new|banner:You've hit your usage limit \\xc2\\xb7 resets 2026-09-03|claude|$RESET_NOW|UTC|rc=0 first=EVENT+usage-limit+gh-2 out~resets%e=false" \
+  "a weekday alone guesses no midnight|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Thursday|claude|$RESET_NOW|UTC|rc=0 first=EVENT+usage-limit+gh-2 out~resets%e=false" \
+  "a zone the host cannot resolve drops the time|new|banner:You've hit your usage limit \\xc2\\xb7 resets 9:50am (Bogus/Zone)|claude|$RESET_NOW|UTC|rc=0 first=EVENT+usage-limit+gh-2 out~resets%e=false"
 
 # SURFACE 2: a clause naming no day is usage-limit-passed only once this watch
 # has seen that wall standing (the case the issue was filed on); the same
@@ -250,13 +252,13 @@ usage_table \
 # is-the-account-speaking for both consumers, so a turn in flight neither
 # emits nor stamps.
 usage_table \
-  "the first pass observes the wall and carries the reset it names|new|banner:$BANNER|claude|$RESET_NOW|UTC|first=$AT_0950" \
-  "the reset the first pass observed, now behind us, is its own event|cont|banner:$BANNER|claude|1788369300|UTC|first=EVENT+usage-limit-passed+gh-2+resets=2026-09-02T16:50:00Z" \
-  "a wall this watch never saw standing is parked, not bumped|new|banner:$BANNER|claude|1788369300|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-03T16:50:00Z" \
-  "a dated reset already behind us is passed without an observation|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Aug 30, 4pm|claude|$RESET_NOW|UTC|first=EVENT+usage-limit-passed+gh-2+resets=2026-08-30T16:00:00Z" \
-  "and a dated reset still ahead is a wall standing|cont|banner:You've hit your weekly limit \\xc2\\xb7 resets Sep 6, 4pm|claude|-|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-06T16:00:00Z" \
-  "a lane with a turn in flight is left alone|new|working|claude|$RESET_NOW|UTC|first=$HEARTBEAT" \
-  "the working pass left no sighting, so this one is the first|cont|banner_1700|claude|1788372000|UTC|first=EVENT+usage-limit+gh-2+resets=2026-09-03T17:00:00Z"
+  "the first pass observes the wall and carries the reset it names|new|banner:$BANNER|claude|$RESET_NOW|UTC|rc=0 first=$AT_0950" \
+  "the reset the first pass observed, now behind us, is its own event|cont|banner:$BANNER|claude|1788369300|UTC|rc=0 first=EVENT+usage-limit-passed+gh-2+resets=2026-09-02T16:50:00Z" \
+  "a wall this watch never saw standing is parked, not bumped|new|banner:$BANNER|claude|1788369300|UTC|rc=0 first=EVENT+usage-limit+gh-2+resets=2026-09-03T16:50:00Z" \
+  "a dated reset already behind us is passed without an observation|new|banner:You've hit your weekly limit \\xc2\\xb7 resets Aug 30, 4pm|claude|$RESET_NOW|UTC|rc=0 first=EVENT+usage-limit-passed+gh-2+resets=2026-08-30T16:00:00Z" \
+  "and a dated reset still ahead is a wall standing|cont|banner:You've hit your weekly limit \\xc2\\xb7 resets Sep 6, 4pm|claude|-|UTC|rc=0 first=EVENT+usage-limit+gh-2+resets=2026-09-06T16:00:00Z" \
+  "a lane with a turn in flight is left alone|new|working|claude|$RESET_NOW|UTC|rc=0 first=$HEARTBEAT" \
+  "the working pass left no sighting, so this one is the first|cont|banner_1700|claude|1788372000|UTC|rc=0 first=EVENT+usage-limit+gh-2+resets=2026-09-03T17:00:00Z"
 
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Part of the KEN-1241 tests audit (arch-docs program, tests-audit lane). Reshapes `skills/orch/tests/oversee_watch_usage_limit.sh` to code-quality § Tests: one table, one run and one assertion per row, must-fail controls beside their rows, fixtures kept whole, no test of the harness.

## What changed

- 59 assertions over 25 hand-drawn cases became 38 rows of one table, `label|pass|screen|lane|now|zone|expect`: a screen (a byte-exact pane fixture under a name in `screen`), the lane it sits in (`lane`: foreground command, children, claims), the clock and zone the pane is read under, and one comparison over the fields the row names (`rc`, `first`, `out~`, `claims`). A `cont` row is the next pass over the row above with the same state and a fresh capture, so the observed-reset, dated-reset, working-lane and byte-locale sequences read as rows rather than hand-driven reruns.
- The U+00A0 composer checks and the Codex reset-offer check are fixture guards in `composed` and `screen` now, aborting the suite rather than counting as assertions.
- `usage_limit_above_empty_composer` (banner over an empty composer, the realistic idle screen minus its `/usage-credits` line) is folded into `banner_idle`; the adjacency it covered is also in the `banner_1700` and `healthy` fixtures.
- Review round: every row pins `rc=0` (only the first did, so an emission path exiting nonzero died on one row); the zone-qualified reset-form row was field-identical to the row seeding the observed-reset sequence and is that row now; the `now` column's comment says what `-` means on a `cont` row.

## Folded or deleted cases, with the surviving row

| old case | surviving row |
|---|---|
| `usage_limit` (3) | `a limit banner under a live harness is the event on ONE pass, the pane tail following` |
| `usage_limit_codex` | `the codex banner fires too` |
| `usage_limit_before_question` (2) | `a limit banner above a stale prompt is usage-limit, never lane-asking` |
| `usage_limit_wrapped_shell` | `a lane wrapped in a shell still gets its banner seen` |
| `usage_limit_stale_banner` (2) | `a banner the lane has since worked past is scrollback` |
| `usage_limit_above_empty_composer` (2) | folded into `banner_idle`; the NBSP check is the `composed` guard |
| `usage_limit_above_composer_draft` (2) | `an unsent draft in the composer is not a turn either` |
| `usage_limit_above_codex_composer` | `a codex banner below the last turn is reported, the composer notwithstanding` |
| `usage_limit_codex_dialog_stale_banner` (2) | `a codex dialog row is live input...` |
| `usage_limit_codex_reset_offer` (3) | `a codex startup screen is no event`; the offer check is the `codex_idle` guard |
| `usage_limit_codex_dialog_live_banner` | `a banner below the turn on a codex dialog screen is still the event` |
| `usage_limit_codex_stale_banner` (2) | `a codex banner the lane has worked past is not the event` |
| `usage_limit_after_turn` | `a banner below the last user turn is the event...` |
| `usage_limit_unrecognized_composer` | `an unrecognized last input line never swallows the screen` |
| `usage_limit_realistic_transcript` (2) | `transcript lines between the banner and the composer are not markers` + its `C` zone `cont` row |
| `usage_limit_stale_banner_over_question` (2), `..._live_banner_over_question` | the two dialog-screen rows |
| `usage_limit_healthy` (2) | `control: a lane with no banner reaches the heartbeat` |
| `usage_limit_claim` (3), `usage_limit_claim_stale` (2) | the two `the account is the actionable part` rows |
| `usage_limit_reset_forms` (8) | seven reset-form rows plus the observed-reset seed row |
| `usage_limit_reset_unreadable` (8) | four rows with `out~resets%e=false` |
| `usage_limit_reset_passed` (2), `_unobserved`, `_dated` (2), `_working_lane` (2) | the seven surface 2 to 4 rows |

## Mutation evidence

Each mutant applied with `sed -i` on `oversee-watch`, `cmp` against the original, run, restored.

| mutant | killed by |
|---|---|
| `USAGE_LIMIT_RE` loosened to bare `limit` | `a codex startup screen is no event` |
| the composer counts as a turn (`live = 0`) | ten rows |
| `PANE_MARKER_RE` as a bracket expression | the byte-locale `cont` row |
| every timed reset reads as passed | twenty rows |

Tracking: KEN-1241.

https://claude.ai/code/session_01XbeNsGuRXj4v5QvPABATx9
