### PR TITLE
fix(KEN-1198): redirected install refuses a taken project alias

### DIFF
--- a/changelog.d/fixed/KEN-1198.md
+++ b/changelog.d/fixed/KEN-1198.md
@@ -1,0 +1,1 @@
+- Installing into a project from a personal marketplace whose alias the project already uses for a different repository is refused instead of silently rebinding the project's subscription.

--- a/crates/core/src/source_ops/subscribe.rs
+++ b/crates/core/src/source_ops/subscribe.rs
@@ -182,15 +182,14 @@ pub fn install_project_from_personal(
     let project = crate::engine::ops::manifest_for_mutation(env, &scope)?;
     // Redeclaring the same subscription the project already holds is fine; a
     // different repo under a taken alias, or the same repo under another, is
-    // refused before anything is planned.
-    if !project.sources.contains_key(source_name) {
-        let reference = decl
-            .repo
-            .clone()
-            .or_else(|| decl.path.clone())
-            .unwrap_or_default();
-        check_subscription(&project, Some(source_name), &decl, &reference)?;
-    }
+    // refused before anything is planned. Checked whether or not the project
+    // already holds the alias: the taken-alias refusal exists for when it does.
+    let reference = decl
+        .repo
+        .clone()
+        .or_else(|| decl.path.clone())
+        .unwrap_or_default();
+    check_subscription(&project, Some(source_name), &decl, &reference)?;
     // The install reads from this subscription and no other: the context is
     // the subscription itself, so a bare name never wanders to another source.
     let request = crate::engine::ops::AddRequest {

--- a/crates/core/tests/install_into_project.rs
+++ b/crates/core/tests/install_into_project.rs
@@ -107,3 +107,86 @@ fn installing_into_a_project_is_atomic_with_its_subscription() {
     assert!(manifest.contains("[sources.mkt]"), "{manifest}");
     assert!(manifest.contains("[skills.gh]"), "{manifest}");
 }
+
+/// Subscribes both scopes under the alias `kit`: the project to
+/// `project_repo`, the personal scope to `acme/kit`, synced so a package
+/// from it can install.
+#[allow(clippy::unwrap_used)]
+fn both_scopes_hold_kit(env: &Env, project: &Path, project_repo: &str) {
+    upstream(env.home.as_path(), "acme/kit");
+    if project_repo != "acme/kit" {
+        upstream(env.home.as_path(), project_repo);
+    }
+    let scope = Scope::Project {
+        root: project.to_path_buf(),
+    };
+    let report = source_ops::subscribe(env, &scope, project_repo, Some("kit"))
+        .unwrap()
+        .report;
+    apply::execute(env, &report.plan).unwrap();
+    let report = source_ops::subscribe(env, &Scope::Global, "acme/kit", Some("kit"))
+        .unwrap()
+        .report;
+    apply::execute(env, &report.plan).unwrap();
+    remote::sync(env, "acme/kit", None).unwrap();
+}
+
+/// A project already holding the alias for a different repository is refused
+/// rather than rebound: rebinding would move every item it declared from
+/// that alias. Its manifest stays byte-identical.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_taken_alias_for_another_repo_refuses_the_redirected_install() {
+    let (_tmp, env, project) = fixture();
+    both_scopes_hold_kit(&env, &project, "other/kit");
+    let project_path = project.join("kendex.toml");
+    let before = fs::read(&project_path).unwrap();
+
+    let refused = source_ops::install_project_from_personal(
+        &env,
+        &project,
+        "kit",
+        &ops::AddRequest {
+            skills: vec!["gh".into()],
+            ..ops::AddRequest::default()
+        },
+    );
+    assert!(
+        matches!(
+            refused,
+            Err(kendex_core::error::CoreError::SourceRefInvalid { .. })
+        ),
+        "a taken alias must be refused as SourceRefInvalid, got {refused:?}"
+    );
+    assert_eq!(
+        fs::read(&project_path).unwrap(),
+        before,
+        "a refused install must leave the project manifest byte-identical"
+    );
+}
+
+/// The same alias on the same repository in both scopes is a legitimate
+/// redeclare: the install goes through and the subscription is unchanged.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn the_same_repo_under_the_same_alias_still_installs() {
+    let (_tmp, env, project) = fixture();
+    both_scopes_hold_kit(&env, &project, "acme/kit");
+    let project_path = project.join("kendex.toml");
+
+    let report = source_ops::install_project_from_personal(
+        &env,
+        &project,
+        "kit",
+        &ops::AddRequest {
+            skills: vec!["gh".into()],
+            ..ops::AddRequest::default()
+        },
+    )
+    .unwrap();
+    apply::execute(&env, &report.plan).unwrap();
+    let manifest = fs::read_to_string(&project_path).unwrap();
+    assert!(manifest.contains("[sources.kit]"), "{manifest}");
+    assert!(manifest.contains("repo = \"acme/kit\""), "{manifest}");
+    assert!(manifest.contains("[skills.gh]"), "{manifest}");
+}


### PR DESCRIPTION
`install_project_from_personal` called `check_subscription` only when the project did not already hold the alias, which made the taken-alias refusal unreachable on the one path it exists for; `add_seeded` then rebound the project's subscription silently. The check now runs unconditionally, matching `subscribe_project_to`.

Tests in `crates/core/tests/install_into_project.rs`: a project holding the alias for a different repository is refused with `SourceRefInvalid` and its manifest stays byte-identical; the same repository under the same alias still installs. With the wrapper restored the refusal test fails showing `kit` rebound to `acme/kit`.

Closes KEN-1198

https://claude.ai/code/session_01EmoSRaeMZNf692rsqZsJw2
