### PR TITLE
test(KEN-1241): oneshot-completion as three tables and the abort case

### DIFF
--- a/pi-extensions/pi-agents-tmux/tests/needs-completion-snapshot.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/needs-completion-snapshot.test.ts
@@ -70,8 +70,8 @@ const rows: Array<[string, Entry, string, string]> = [
 		utimesSync(outboxFile, ahead, ahead);
 		const count = await pollPaneCompletions(root, fakePi(emitted));
 		const persisted = (await readTaskRegistry(root))["task-poll-fresh"];
-		return { own: `count=${count} status=${persisted?.status} events=${eventNames(emitted)}`, persisted };
-	}, "count=0 status=running events=none", ABSENT],
+		return { own: `count=${count} status=${persisted?.status} outbox=${existsSync(outboxFile) ? "present" : "gone"} events=${eventNames(emitted)}`, persisted };
+	}, "count=0 status=running outbox=present events=none", ABSENT],
 	["a dispatch failure whose requeue restore fails", async (root, repo) => {
 		const processing = join(root, "processing", "rust", "task-dispatch.md");
 		const source = join(root, "missing-inbox-parent", "rust", "task-dispatch.md");

--- a/pi-extensions/pi-agents-tmux/tests/oneshot-completion.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/oneshot-completion.test.ts
@@ -1,616 +1,230 @@
-// How a one-shot run classifies its end: the context-length retry,
-// compact-then-empty, needs_completion delivery and the reused-session budget.
+// How a one-shot run classifies its end from the bridge stream (compact-then-
+// empty, the context-overflow retry, abort), the overflow detector's grammar,
+// and the reused-session budget guard that runs before the spawn.
 
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { DEFAULT_MODEL_CONTEXT_LIMIT_TOKENS, isContextLengthExceededEnvelope, isContextLengthExceededText, resolveBgSession, setSessionCompactorForTests } from "../extensions/subagent/sessions.js";
-import { runSingleAgent, setGitExecFileForTests, setSingleAgentSpawnForTests } from "../extensions/subagent/runner.js";
-import type { SubagentDetails } from "../extensions/subagent/types.js";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 import test, { after } from "node:test";
-import { cleanupTempRuntimes, tempRuntime, tempGitRepo, writeSettings, testAgent, installMockSpawn, bridgeStdout, bridgeEvent, shapedStreamEvent, transcriptEventName, mockPiEvents, makeDetails } from "./single-agent-fixture.js";
+import { runSingleAgent, setGitExecFileForTests, setSingleAgentSpawnForTests } from "../extensions/subagent/runner.js";
+import { isContextLengthExceededEnvelope, isContextLengthExceededText, resolveBgSession, setSessionCompactorForTests } from "../extensions/subagent/sessions.js";
+import type { SingleResult } from "../extensions/subagent/types.js";
+import { bridgeEvent, bridgeStdout, cleanupTempRuntimes, installMockSpawn, makeDetails, mockPiEvents, shapedStreamEvent, tempGitRepo, tempRuntime, testAgent, transcriptEventName, writeSettings } from "./single-agent-fixture.js";
 
 after(cleanupTempRuntimes);
 
-test("context_length_exceeded detection triggers one retry with fresh session", async () => {
-	assert.equal(isContextLengthExceededText('Codex error: {"type":"error","error":{"type":"invalid_request_error","code":"context_length_exceeded"}}'), true);
-	assert.equal(isContextLengthExceededText("Input length (265330) exceeds model's maximum context length (262144)."), true);
-	assert.equal(isContextLengthExceededText("Your input exceeds the context window of this model"), true);
-	assert.equal(isContextLengthExceededEnvelope({ type: "turn_end", message: { errorMessage: "context_length_exceeded" } }), true);
-	const calls = installMockSpawn([
-		{ code: 1, stdout: `${JSON.stringify({ error: { type: "invalid_request_error", code: "context_length_exceeded" } })}\n` },
-		{ code: 0, stdout: `${JSON.stringify({ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "ok after retry" }], usage: { input: 1, output: 1, totalTokens: 2 } } })}\n` },
-	]);
-	try {
-		const agent = testAgent();
-		const result = await runSingleAgent(
-			process.cwd(),
-			tempRuntime(),
-			[agent],
-			"reviewer-test",
-			"review code",
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			{ getActiveTools: () => [], events: { emit: () => undefined } } as any,
-			undefined,
-			undefined,
-			(results): SubagentDetails => ({ mode: "single", agentScope: "project", projectAgentsDir: null, results }),
-		);
-		assert.equal(calls.length, 2);
-		assert.equal(result.exitCode, 0);
-		assert.equal(result.attempt, 2);
-		assert.equal(result.attempts?.length, 2);
-		assert.notEqual(result.attempts?.[0]?.sessionKey, result.attempts?.[1]?.sessionKey);
-		assert.match(result.attempts?.[0]?.errorEnvelope ?? "", /context_length_exceeded/);
-		assert.match(result.stderr, /retrying once with fresh session/);
-	} finally {
-		setSingleAgentSpawnForTests();
+type Emitted = Array<{ name: string; payload: any }>;
+
+function runOneShot(options: { cwd: string; pi: any; runtimeRoot?: string; sessionKey?: string; signal?: AbortSignal }): Promise<SingleResult> {
+	return runSingleAgent(options.cwd, options.runtimeRoot ?? tempRuntime(), [testAgent()], "reviewer-test", "review code", undefined, undefined, undefined, undefined, options.pi, options.signal, undefined, makeDetails, options.sessionKey);
+}
+
+// The pi bus as one line, in emit order: `needs_completion` carries its reason
+// and whether the payload's snapshot names the run's cwd; `retrying` its reason;
+// `started` is the spawn announcement and is read as the spawn count instead.
+function busLine(emitted: Emitted, cwd: string): string {
+	const names = emitted.filter((event) => event.name !== "subagents:started").map((event) => {
+		const name = event.name.replace(/^subagents:/, "");
+		if (name === "needs_completion") return `needs_completion(${event.payload.reason},${event.payload.cwdSnapshot ? (event.payload.cwdSnapshot.cwd === cwd ? "snapshot" : "wrong-snapshot") : "-"})`;
+		if (name === "retrying") return `retrying(${event.payload.reason})`;
+		return name;
+	});
+	return names.length ? names.join(",") : "none";
+}
+
+// Each diagnostic by the detector that wrote it; an unknown one prints whole.
+function diagTags(result: SingleResult): string {
+	const tags = (result.diagnostics ?? []).map((d) => {
+		if (d.startsWith("compact-then-empty detector skipped malformed agent_end content")) return "malformed-agent-end";
+		if (d.startsWith("cwdSnapshot git failed")) return "git-failed";
+		if (d.startsWith("Failed to emit subagents:needs_completion")) return "emit-failed";
+		return JSON.stringify(d);
+	});
+	return tags.length ? tags.join(",") : "-";
+}
+
+// The classification as one line: spawns and the returned attempt, whether a
+// retry ran on a fresh session, the first attempt's stop reason when there were
+// two, the status and reason, the snapshot, the diagnostics and the bus.
+function classification(result: SingleResult, emitted: Emitted, spawns: number, cwd: string): string {
+	const attempts = result.attempts;
+	const retry = attempts ? (attempts[0]?.sessionKey !== attempts[1]?.sessionKey ? "fresh-session" : "same-session") : "-";
+	const firstStop = attempts ? `${attempts[0]?.stopReason ?? "-"}` : "-";
+	const snapshot = result.cwdSnapshot ? (result.cwdSnapshot.cwd === cwd ? "cwd" : "other") : "-";
+	return `spawns=${spawns} exit=${result.exitCode} attempt=${result.attempt ?? "-"} retry=${retry} first-stop=${firstStop} status=${result.status ?? "-"} reason=${result.needsCompletionReason ?? "-"} stop=${result.stopReason ?? "-"} snapshot=${snapshot} diags=${diagTags(result)} bus=${busLine(emitted, cwd)}`;
+}
+
+const OVERFLOW_ENVELOPE = `${JSON.stringify({ error: { type: "invalid_request_error", code: "context_length_exceeded" } })}\n`;
+const textEnd = (text: string) => bridgeEvent("agent_end", { content: [{ type: "text", text }] });
+const assistantText = (text: string) => bridgeEvent("message_end", { message: { role: "assistant", content: [{ type: "text", text }] } });
+const EMPTY_END = bridgeEvent("agent_end", { content: [] });
+const COMPACT = bridgeEvent("session_compact");
+
+type World = { git?: "missing"; pi?: (emitted: Emitted) => any; stream: Array<{ code?: number; stdout?: string }> };
+
+const COMPLETED = "spawns=1 exit=0 attempt=1 retry=- first-stop=- status=- reason=- stop=- snapshot=- diags=- bus=completed";
+const NEEDS_COMPLETION = "spawns=1 exit=0 attempt=1 retry=- first-stop=- status=needs_completion reason=compact-then-empty stop=needs_completion snapshot=cwd diags=- bus=needs_completion(compact-then-empty,snapshot)";
+
+// label | the spawn's stdout per attempt (and the world around it) | expect the classification line
+// Every row runs in a fresh git repo, so a needs_completion row's snapshot is the cwd's.
+const endRows: Array<[string, World, string]> = [
+	["a compact then an empty agent_end is needs_completion with the cwd's snapshot", { stream: [{ stdout: bridgeStdout([COMPACT, EMPTY_END]) }] }, NEEDS_COMPLETION],
+	["assistant text before the compact does not mask it", { stream: [{ stdout: bridgeStdout([assistantText("pre-compact progress"), COMPACT, EMPTY_END]) }] }, NEEDS_COMPLETION],
+	["a null agent_end content is empty", { stream: [{ stdout: bridgeStdout([COMPACT, bridgeEvent("agent_end", { content: null })]) }] }, NEEDS_COMPLETION],
+	["an omitted agent_end content is empty", { stream: [{ stdout: bridgeStdout([COMPACT, bridgeEvent("agent_end")]) }] }, NEEDS_COMPLETION],
+	["assistant text after the compact completes", { stream: [{ stdout: bridgeStdout([COMPACT, assistantText("post-compact answer"), EMPTY_END]) }] }, COMPLETED],
+	["a compact then a text agent_end completes", { stream: [{ stdout: bridgeStdout([COMPACT, textEnd("ok")]) }] }, COMPLETED],
+	["an empty agent_end without a compact completes", { stream: [{ stdout: bridgeStdout([EMPTY_END]) }] }, COMPLETED],
+	["a compact with no agent_end (bridge gone) completes", { stream: [{ stdout: bridgeStdout([COMPACT]) }] }, COMPLETED],
+	["a malformed agent_end content is logged and completes", { stream: [{ stdout: bridgeStdout([COMPACT, bridgeEvent("agent_end", { content: "bad-shape" })]) }] },
+		"spawns=1 exit=0 attempt=1 retry=- first-stop=- status=- reason=- stop=- snapshot=- diags=malformed-agent-end bus=completed"],
+	["a missing git keeps needs_completion without the snapshot", { git: "missing", stream: [{ stdout: bridgeStdout([COMPACT, EMPTY_END]) }] },
+		"spawns=1 exit=0 attempt=1 retry=- first-stop=- status=needs_completion reason=compact-then-empty stop=needs_completion snapshot=- diags=git-failed bus=needs_completion(compact-then-empty,-)"],
+	["a needs_completion emit that throws is a diagnostic on the result", {
+		pi: (emitted) => ({ getActiveTools: () => [], events: { emit: (name: string, payload: unknown) => {
+			if (name === "subagents:needs_completion") throw new Error("bus disposed");
+			emitted.push({ name, payload });
+		} } }),
+		stream: [{ stdout: bridgeStdout([COMPACT, EMPTY_END]) }],
+	}, "spawns=1 exit=0 attempt=1 retry=- first-stop=- status=needs_completion reason=compact-then-empty stop=needs_completion snapshot=cwd diags=emit-failed bus=none"],
+	["a context overflow envelope retries once on a fresh session", { stream: [{ code: 1, stdout: OVERFLOW_ENVELOPE }, { stdout: bridgeStdout([textEnd("ok after retry")]) }] },
+		"spawns=2 exit=0 attempt=2 retry=fresh-session first-stop=- status=- reason=- stop=- snapshot=- diags=- bus=failed,retrying(context_length_exceeded),completed"],
+	["a compact-then-empty on the retry is needs_completion", { stream: [{ code: 1, stdout: OVERFLOW_ENVELOPE }, { stdout: bridgeStdout([COMPACT, EMPTY_END]) }] },
+		"spawns=2 exit=0 attempt=2 retry=fresh-session first-stop=- status=needs_completion reason=compact-then-empty stop=needs_completion snapshot=cwd diags=- bus=failed,retrying(context_length_exceeded),needs_completion(compact-then-empty,snapshot)"],
+	["a compact-then-empty beside an overflow in the same attempt is the retry's, not needs_completion", { stream: [{ code: 1, stdout: bridgeStdout([COMPACT, EMPTY_END, JSON.parse(OVERFLOW_ENVELOPE)]) }, { stdout: bridgeStdout([textEnd("ok after retry")]) }] },
+		"spawns=2 exit=0 attempt=2 retry=fresh-session first-stop=- status=- reason=- stop=- snapshot=- diags=- bus=failed,retrying(context_length_exceeded),completed"],
+	["overflow wording inside a tool result is not an overflow", { stream: [{ stdout: bridgeStdout([
+		{ type: "tool_execution_end", toolCallId: "call-grep", toolName: "grep", result: { content: [{ type: "text", text: "tests/session-lanes.test.ts: context_length_exceeded detection triggers one retry" }] } },
+		assistantText("Reviewed context_length_exceeded docs/tests; no runtime overflow."),
+		textEnd("done"),
+	]) }] }, COMPLETED],
+];
+
+test("the end of a one-shot run", async () => {
+	for (const [label, world, expect] of endRows) {
+		const cwd = tempGitRepo();
+		const emitted: Emitted = [];
+		const calls = installMockSpawn(world.stream.map((attempt) => ({ code: attempt.code ?? 0, stdout: attempt.stdout })));
+		if (world.git === "missing") {
+			setGitExecFileForTests(((command: string, args: string[], options: any, callback: any) => {
+				void command;
+				void args;
+				const cb = typeof options === "function" ? options : callback;
+				queueMicrotask(() => cb(Object.assign(new Error("spawn git ENOENT"), { code: "ENOENT" }), "", "spawn git ENOENT"));
+				return new EventEmitter() as any;
+			}) as any);
+		}
+		try {
+			const result = await runOneShot({ cwd, pi: world.pi ? world.pi(emitted) : mockPiEvents(emitted) });
+			assert.equal(classification(result, emitted, calls.length, cwd), expect, label);
+		} finally {
+			setGitExecFileForTests();
+			setSingleAgentSpawnForTests();
+		}
 	}
 });
 
-test("default reused-session context limit tracks current Codex backend cap", () => {
-	assert.equal(DEFAULT_MODEL_CONTEXT_LIMIT_TOKENS, 272_000);
-});
-
-test("context_length_exceeded text in normal tool output does not trigger retry", async () => {
-	const stdout = bridgeStdout([
-		{
-			type: "tool_execution_end",
-			toolCallId: "call-grep",
-			toolName: "grep",
-			result: {
-				content: [
-					{ type: "text", text: "tests/session-lanes.test.ts: context_length_exceeded detection triggers one retry" },
-				],
-			},
-		},
-		{
-			type: "message_end",
-			message: {
-				role: "assistant",
-				content: [{ type: "text", text: "Reviewed context_length_exceeded docs/tests; no runtime overflow." }],
-				usage: { input: 1, output: 1, totalTokens: 2 },
-			},
-		},
-	]);
-	const calls = installMockSpawn([{ code: 0, stdout }]);
-	try {
-		const result = await runSingleAgent(
-			process.cwd(),
-			tempRuntime(),
-			[testAgent()],
-			"reviewer-test",
-			"review code",
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			{ getActiveTools: () => [], events: { emit: () => undefined } } as any,
-			undefined,
-			undefined,
-			makeDetails,
-		);
-		assert.equal(calls.length, 1);
-		assert.equal(result.exitCode, 0);
-		assert.equal(result.attempt, 1);
-		assert.equal(result.attempts, undefined);
-		assert.equal(result.errorEnvelope, undefined);
-		assert.equal(result.errorMessage, undefined);
-		assert.equal(result.stderr, "");
-	} finally {
-		setSingleAgentSpawnForTests();
-	}
-});
-
-test("aborted oneshot emits failed event with summary", async () => {
-	const emitted: Array<{ name: string; payload: any }> = [];
+test("an aborted run fails with the partial answer flushed to its transcript", async () => {
+	const emitted: Emitted = [];
+	const cwd = tempRuntime();
 	const calls = installMockSpawn([{ code: 0, stdout: bridgeStdout([
 		shapedStreamEvent("top-level", "message_update", { message: { role: "assistant", content: [{ type: "text", text: "aborted partial" }] } }),
 	]) }]);
 	const controller = new AbortController();
 	controller.abort();
 	try {
-		await assert.rejects(
-			runSingleAgent(
-				process.cwd(),
-				tempRuntime(),
-				[testAgent()],
-				"reviewer-test",
-				"review code",
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				mockPiEvents(emitted),
-				controller.signal,
-				undefined,
-				makeDetails,
-			),
-			/Agent was aborted/,
-		);
-		assert.equal(calls.length, 1);
+		await assert.rejects(runOneShot({ cwd, pi: mockPiEvents(emitted), signal: controller.signal }), /Agent was aborted/);
 		const failed = emitted.find((event) => event.name === "subagents:failed");
-		assert.ok(failed);
-		assert.equal(failed.payload.summary, "Agent was aborted before completion.");
-		assert.equal(failed.payload.error, "Agent was aborted");
-		const content = readFileSync(failed.payload.transcriptPath, "utf8");
-		assert.match(content, /message_update/);
-		assert.match(content, /aborted partial/);
-		assert.match(content, /"buffered":true/);
-		const updateRecords = content.trim().split(/\r?\n/).map((line) => JSON.parse(line)).filter((record) => record.event && transcriptEventName(record.event) === "message_update");
-		assert.equal(updateRecords.length, 1);
-	} finally {
-		setSingleAgentSpawnForTests();
-	}
-});
-
-test("session_compact followed by empty agent_end emits synthetic needs_completion", async () => {
-	const cwd = tempGitRepo();
-	const emitted: Array<{ name: string; payload: any }> = [];
-	const calls = installMockSpawn([
-		{ code: 0, stdout: bridgeStdout([bridgeEvent("session_compact"), bridgeEvent("agent_end", { content: [] })]) },
-	]);
-	try {
-		const result = await runSingleAgent(
-			cwd,
-			tempRuntime(),
-			[testAgent()],
-			"reviewer-test",
-			"review code",
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			mockPiEvents(emitted),
-			undefined,
-			undefined,
-			makeDetails,
+		const records = readFileSync(failed?.payload.transcriptPath, "utf8").trim().split(/\r?\n/).map((line) => JSON.parse(line));
+		const updates = records.filter((record) => record.event && transcriptEventName(record.event) === "message_update");
+		assert.equal(
+			`spawns=${calls.length} bus=${busLine(emitted, cwd)} status=${failed?.payload.status} updates=${updates.length} buffered=${updates.every((record) => record.buffered === true)} partial=${updates.some((record) => JSON.stringify(record.event).includes("aborted partial"))}`,
+			"spawns=1 bus=failed status=aborted updates=1 buffered=true partial=true",
 		);
-		assert.equal(calls.length, 1);
-		assert.equal(result.exitCode, 0);
-		assert.equal(result.status, "needs_completion");
-		assert.equal(result.needsCompletionReason, "compact-then-empty");
-		assert.equal(result.cwdSnapshot?.cwd, cwd);
-		assert.match(result.cwdSnapshot?.head ?? "", /^[0-9a-f]{40}$/);
-		assert.equal(result.cwdSnapshot?.dirty, true);
-		assert.match(result.cwdSnapshot?.status ?? "", /\?\? dirty\.txt/);
-		assert.equal(result.cwdSnapshot?.lastCommit.subject, "initial commit");
-		assert.equal(existsSync(join(cwd, ".git", "index.lock")), false);
-
-		const needsCompletion = emitted.find((event) => event.name === "subagents:needs_completion");
-		assert.ok(needsCompletion);
-		assert.equal(needsCompletion.payload.reason, "compact-then-empty");
-		assert.equal(needsCompletion.payload.status, "needs_completion");
-		assert.equal(needsCompletion.payload.cwdSnapshot?.cwd, cwd);
-		assert.equal(emitted.some((event) => event.name === "subagents:completed" || event.name === "subagents:failed"), false);
 	} finally {
 		setSingleAgentSpawnForTests();
 	}
 });
 
-test("pre-compact assistant text does not mask compact-then-empty", async () => {
-	const emitted: Array<{ name: string; payload: any }> = [];
-	const calls = installMockSpawn([
-		{
-			code: 0,
-			stdout: bridgeStdout([
-				bridgeEvent("message_end", { message: { role: "assistant", content: [{ type: "text", text: "pre-compact progress" }] } }),
-				bridgeEvent("session_compact"),
-				bridgeEvent("agent_end", { content: [] }),
-			]),
-		},
-	]);
-	try {
-		const result = await runSingleAgent(
-			tempRuntime(),
-			tempRuntime(),
-			[testAgent()],
-			"reviewer-test",
-			"review code",
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			mockPiEvents(emitted),
-			undefined,
-			undefined,
-			makeDetails,
-		);
-		assert.equal(calls.length, 1);
-		assert.equal(result.status, "needs_completion");
-		assert.equal(result.needsCompletionReason, "compact-then-empty");
-		assert.equal(emitted.some((event) => event.name === "subagents:needs_completion"), true);
-	} finally {
-		setSingleAgentSpawnForTests();
+// label | the text or envelope under test | expect
+const overflowRows: Array<[string, unknown, boolean]> = [
+	["text: the error code as a word", 'Codex error: {"type":"error","error":{"type":"invalid_request_error","code":"context_length_exceeded"}}', true],
+	["text: hyphenated code", "context-length-exceeded", true],
+	["text: exceeds the model's maximum context length with a parenthesised size", "Input length (265330) exceeds model's maximum context length (262144).", true],
+	["text: exceeds maximum context length of N tokens", "Prompt exceeds maximum context length of 200,000 tokens", true],
+	["text: exceeds the context window", "Your input exceeds the context window of this model", true],
+	["text: maximum context length without a size is not an overflow", "This model's maximum context length is large.", false],
+	["text: an ordinary completion", "Reviewed the diff; no findings.", false],
+	["envelope: error.code", { error: { code: "context_length_exceeded" } }, true],
+	["envelope: error.type", { error: { type: "context_length_exceeded" } }, true],
+	["envelope: top-level code", { code: "context_length_exceeded" }, true],
+	["envelope: top-level type", { type: "context_length_exceeded" }, true],
+	["envelope: error as a string", { error: "request failed: context_length_exceeded" }, true],
+	["envelope: errorMessage", { errorMessage: "context_length_exceeded" }, true],
+	["envelope: stopReason", { stopReason: "context_length_exceeded" }, true],
+	["envelope: message.errorMessage", { type: "turn_end", message: { errorMessage: "context_length_exceeded" } }, true],
+	["envelope: message.stopReason", { type: "turn_end", message: { stopReason: "context_length_exceeded" } }, true],
+	["envelope: an ordinary message_end", { type: "message_end", message: { role: "assistant", stopReason: "stop", content: [{ type: "text", text: "ok" }] } }, false],
+	["envelope: the code in a tool result is not read", { type: "tool_execution_end", result: { content: [{ type: "text", text: "context_length_exceeded" }] } }, false],
+];
+
+test("the context-overflow detector", () => {
+	for (const [label, input, expect] of overflowRows) {
+		const actual = typeof input === "string" ? isContextLengthExceededText(input) : isContextLengthExceededEnvelope(input);
+		assert.equal(actual, expect, label);
 	}
 });
 
-test("compact-then-empty detection applies after context retry", async () => {
-	const emitted: Array<{ name: string; payload: any }> = [];
-	const calls = installMockSpawn([
-		{ code: 1, stdout: `${JSON.stringify({ error: { type: "invalid_request_error", code: "context_length_exceeded" } })}\n` },
-		{ code: 0, stdout: bridgeStdout([bridgeEvent("session_compact"), bridgeEvent("agent_end", { content: [] })]) },
-	]);
-	try {
-		const result = await runSingleAgent(
-			tempRuntime(),
-			tempRuntime(),
-			[testAgent()],
-			"reviewer-test",
-			"review code",
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			mockPiEvents(emitted),
-			undefined,
-			undefined,
-			makeDetails,
-		);
-		assert.equal(calls.length, 2);
-		assert.equal(result.attempt, 2);
-		assert.equal(result.attempts?.length, 2);
-		assert.equal(result.status, "needs_completion");
-		assert.equal(result.needsCompletionReason, "compact-then-empty");
-		assert.equal(emitted.some((event) => event.name === "subagents:needs_completion"), true);
-		assert.equal(emitted.some((event) => event.name === "subagents:completed"), false);
-	} finally {
-		setSingleAgentSpawnForTests();
-	}
-});
+const OK_STDOUT = bridgeStdout([textEnd("ok")]);
 
-test("compact-then-empty treats null and omitted agent_end content as empty", async () => {
-	for (const data of [{ content: null }, {}]) {
-		const emitted: Array<{ name: string; payload: any }> = [];
-		const calls = installMockSpawn([
-			{ code: 0, stdout: bridgeStdout([bridgeEvent("session_compact"), bridgeEvent("agent_end", data)]) },
-		]);
+type BudgetWorld = { compactor?: "fails" | "truncates"; session?: "absent" | number; settings?: Record<string, unknown> };
+
+// The guard's outcome as one line: spawns, compactor calls, the exit and stop
+// reason, the session mode and whether stderr carries the guard's line.
+function budgetLine(result: SingleResult, spawns: number, compactions: number): string {
+	return `spawns=${spawns} compactions=${compactions} exit=${result.exitCode} refused=${result.refused ?? false} stop=${result.stopReason ?? "-"} mode=${result.sessionMode ?? "-"} stderr=${result.stderr ? "guard-line" : "-"}`;
+}
+
+const TIGHT = { reusedSessionBudgetThreshold: 0.5, reusedSessionContextLimitTokens: 100 };
+
+// label | the reused session's size in bytes and the project's budget settings | expect the guard's line
+const budgetRows: Array<[string, BudgetWorld, string]> = [
+	["over the default 80% of the default 272k-token limit is refused before the spawn", { session: 900_000 }, "spawns=0 compactions=0 exit=1 refused=true stop=session_budget_exceeded mode=resumed stderr=guard-line"],
+	["under the default threshold spawns", { session: 800_000 }, "spawns=1 compactions=0 exit=0 refused=false stop=- mode=resumed stderr=-"],
+	["a configured limit decides under the default threshold", { session: 1_000, settings: { reusedSessionContextLimitTokens: 100 } }, "spawns=0 compactions=0 exit=1 refused=true stop=session_budget_exceeded mode=resumed stderr=guard-line"],
+	["a configured threshold decides under a configured limit", { session: 100, settings: { ...TIGHT, reusedSessionBudgetThreshold: 0.2 } }, "spawns=0 compactions=0 exit=1 refused=true stop=session_budget_exceeded mode=resumed stderr=guard-line"],
+	["under a configured threshold spawns", { session: 100, settings: TIGHT }, "spawns=1 compactions=0 exit=0 refused=false stop=- mode=resumed stderr=-"],
+	["an explicit key with no session file yet spawns", { session: "absent", settings: TIGHT }, "spawns=1 compactions=0 exit=0 refused=false stop=- mode=resumed stderr=-"],
+	["the warn policy spawns with the guard's line on stderr", { session: 1_000, settings: { ...TIGHT, reusedSessionBudgetPolicy: "warn" } }, "spawns=1 compactions=0 exit=0 refused=false stop=- mode=resumed stderr=guard-line"],
+	["compact-then-resume compacts once, then spawns", { compactor: "truncates", session: 1_000, settings: { ...TIGHT, reusedSessionBudgetPolicy: "compact-then-resume" } }, "spawns=1 compactions=1 exit=0 refused=false stop=- mode=resumed stderr=guard-line"],
+	["a failed compaction refuses", { compactor: "fails", session: 1_000, settings: { ...TIGHT, reusedSessionBudgetPolicy: "compact-then-resume" } }, "spawns=0 compactions=1 exit=1 refused=true stop=session_budget_exceeded mode=resumed stderr=guard-line"],
+];
+
+test("the reused-session budget guard", async () => {
+	for (const [label, world, expect] of budgetRows) {
+		const runtimeRoot = tempRuntime();
+		const cwd = tempRuntime();
+		if (world.settings) writeSettings(cwd, world.settings);
+		const session = resolveBgSession(runtimeRoot, "reviewer-test", "reuse");
+		if (world.session !== "absent") {
+			mkdirSync(dirname(session.path), { recursive: true });
+			writeFileSync(session.path, "x".repeat(world.session ?? 0), "utf8");
+		}
+		let compactions = 0;
+		setSessionCompactorForTests(async (request) => {
+			compactions += 1;
+			if (world.compactor === "fails") throw new Error("archive disk full");
+			writeFileSync(request.sessionPath, "", "utf8");
+			return { archivePath: `${request.sessionPath}.archive` };
+		});
+		const calls = installMockSpawn([{ code: 0, stdout: OK_STDOUT }]);
 		try {
-			const result = await runSingleAgent(
-				tempRuntime(),
-				tempRuntime(),
-				[testAgent()],
-				"reviewer-test",
-				"review code",
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				mockPiEvents(emitted),
-				undefined,
-				undefined,
-				makeDetails,
-			);
-			assert.equal(calls.length, 1);
-			assert.equal(result.status, "needs_completion");
-			assert.equal(result.needsCompletionReason, "compact-then-empty");
-			assert.equal(emitted.some((event) => event.name === "subagents:needs_completion"), true);
+			const result = await runOneShot({ cwd, pi: mockPiEvents([]), runtimeRoot, sessionKey: "reuse" });
+			assert.equal(budgetLine(result, calls.length, compactions), expect, label);
 		} finally {
+			setSessionCompactorForTests();
 			setSingleAgentSpawnForTests();
 		}
-	}
-});
-
-test("session_compact followed by text agent_end completes normally", async () => {
-	const emitted: Array<{ name: string; payload: any }> = [];
-	const calls = installMockSpawn([
-		{ code: 0, stdout: bridgeStdout([bridgeEvent("session_compact"), bridgeEvent("agent_end", { content: [{ type: "text", text: "ok" }] })]) },
-	]);
-	try {
-		const result = await runSingleAgent(
-			tempRuntime(),
-			tempRuntime(),
-			[testAgent()],
-			"reviewer-test",
-			"review code",
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			mockPiEvents(emitted),
-			undefined,
-			undefined,
-			makeDetails,
-		);
-		assert.equal(calls.length, 1);
-		assert.equal(result.exitCode, 0);
-		assert.notEqual(result.status, "needs_completion");
-		assert.equal(emitted.some((event) => event.name === "subagents:needs_completion"), false);
-		assert.equal(emitted.some((event) => event.name === "subagents:completed"), true);
-	} finally {
-		setSingleAgentSpawnForTests();
-	}
-});
-
-test("empty agent_end without session_compact preserves existing completion behavior", async () => {
-	const emitted: Array<{ name: string; payload: any }> = [];
-	const calls = installMockSpawn([
-		{ code: 0, stdout: bridgeStdout([bridgeEvent("agent_end", { content: [] })]) },
-	]);
-	try {
-		const result = await runSingleAgent(
-			tempRuntime(),
-			tempRuntime(),
-			[testAgent()],
-			"reviewer-test",
-			"review code",
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			mockPiEvents(emitted),
-			undefined,
-			undefined,
-			makeDetails,
-		);
-		assert.equal(calls.length, 1);
-		assert.equal(result.exitCode, 0);
-		assert.notEqual(result.status, "needs_completion");
-		assert.equal(emitted.some((event) => event.name === "subagents:needs_completion"), false);
-		assert.equal(emitted.some((event) => event.name === "subagents:completed"), true);
-	} finally {
-		setSingleAgentSpawnForTests();
-	}
-});
-
-test("bridge disconnect after session_compact does not classify compact-then-empty", async () => {
-	const emitted: Array<{ name: string; payload: any }> = [];
-	const calls = installMockSpawn([
-		{ code: 0, stdout: bridgeStdout([bridgeEvent("session_compact")]) },
-	]);
-	try {
-		const result = await runSingleAgent(
-			tempRuntime(),
-			tempRuntime(),
-			[testAgent()],
-			"reviewer-test",
-			"review code",
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			mockPiEvents(emitted),
-			undefined,
-			undefined,
-			makeDetails,
-		);
-		assert.equal(calls.length, 1);
-		assert.notEqual(result.status, "needs_completion");
-		assert.equal(emitted.some((event) => event.name === "subagents:needs_completion"), false);
-		assert.equal(emitted.some((event) => event.name === "subagents:completed"), true);
-	} finally {
-		setSingleAgentSpawnForTests();
-	}
-});
-
-test("malformed agent_end content is logged and skipped", async () => {
-	const emitted: Array<{ name: string; payload: any }> = [];
-	const calls = installMockSpawn([
-		{ code: 0, stdout: bridgeStdout([bridgeEvent("session_compact"), bridgeEvent("agent_end", { content: "bad-shape" })]) },
-	]);
-	try {
-		const result = await runSingleAgent(
-			tempRuntime(),
-			tempRuntime(),
-			[testAgent()],
-			"reviewer-test",
-			"review code",
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			mockPiEvents(emitted),
-			undefined,
-			undefined,
-			makeDetails,
-		);
-		assert.equal(calls.length, 1);
-		assert.notEqual(result.status, "needs_completion");
-		assert.match(result.diagnostics?.join("\n") ?? "", /malformed agent_end content/);
-		assert.equal(emitted.some((event) => event.name === "subagents:needs_completion"), false);
-		assert.equal(emitted.some((event) => event.name === "subagents:completed"), true);
-	} finally {
-		setSingleAgentSpawnForTests();
-	}
-});
-
-test("missing git binary omits cwdSnapshot but still emits compact-then-empty", async () => {
-	const emitted: Array<{ name: string; payload: any }> = [];
-	const calls = installMockSpawn([
-		{ code: 0, stdout: bridgeStdout([bridgeEvent("session_compact"), bridgeEvent("agent_end", { content: [] })]) },
-	]);
-	setGitExecFileForTests(((command: string, args: string[], options: any, callback: any) => {
-		void command;
-		void args;
-		const cb = typeof options === "function" ? options : callback;
-		queueMicrotask(() => cb(Object.assign(new Error("spawn git ENOENT"), { code: "ENOENT" }), "", "spawn git ENOENT"));
-		return new EventEmitter() as any;
-	}) as any);
-	try {
-		const result = await runSingleAgent(
-			tempRuntime(),
-			tempRuntime(),
-			[testAgent()],
-			"reviewer-test",
-			"review code",
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			mockPiEvents(emitted),
-			undefined,
-			undefined,
-			makeDetails,
-		);
-		assert.equal(calls.length, 1);
-		assert.equal(result.status, "needs_completion");
-		assert.equal(result.needsCompletionReason, "compact-then-empty");
-		assert.equal(result.cwdSnapshot, undefined);
-		assert.match(result.diagnostics?.join("\n") ?? "", /cwdSnapshot git failed/);
-		const needsCompletion = emitted.find((event) => event.name === "subagents:needs_completion");
-		assert.ok(needsCompletion);
-		assert.equal(needsCompletion.payload.reason, "compact-then-empty");
-		assert.equal(needsCompletion.payload.cwdSnapshot, undefined);
-		assert.match(needsCompletion.payload.diagnostics?.join("\n") ?? "", /cwdSnapshot git failed/);
-	} finally {
-		setGitExecFileForTests();
-		setSingleAgentSpawnForTests();
-	}
-});
-
-test("needs_completion emit failure is attached to result diagnostics", async () => {
-	const emitted: Array<{ name: string; payload: any }> = [];
-	const calls = installMockSpawn([
-		{ code: 0, stdout: bridgeStdout([bridgeEvent("session_compact"), bridgeEvent("agent_end", { content: [] })]) },
-	]);
-	try {
-		const result = await runSingleAgent(
-			tempGitRepo(),
-			tempRuntime(),
-			[testAgent()],
-			"reviewer-test",
-			"review code",
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			{
-				getActiveTools: () => [],
-				events: {
-					emit: (name: string, payload: unknown) => {
-						if (name === "subagents:needs_completion") throw new Error("bus disposed");
-						emitted.push({ name, payload });
-					},
-				},
-			} as any,
-			undefined,
-			undefined,
-			makeDetails,
-		);
-		assert.equal(calls.length, 1);
-		assert.equal(result.status, "needs_completion");
-		assert.match(result.diagnostics?.join("\n") ?? "", /Failed to emit subagents:needs_completion/);
-		assert.equal(emitted.some((event) => event.name === "subagents:needs_completion"), false);
-	} finally {
-		setSingleAgentSpawnForTests();
-	}
-});
-
-test("reused session budget guard refuses over-threshold explicit session by default without spawning", async () => {
-	const runtimeRoot = tempRuntime();
-	const cwd = tempRuntime();
-	const session = resolveBgSession(runtimeRoot, "reviewer-test", "reuse");
-	mkdirSync(dirname(session.path), { recursive: true });
-	writeFileSync(session.path, "x".repeat(900_000), "utf8");
-	const calls = installMockSpawn([{ code: 0 }]);
-	try {
-		const result = await runSingleAgent(
-			cwd,
-			runtimeRoot,
-			[testAgent()],
-			"reviewer-test",
-			"reuse old context",
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			{ getActiveTools: () => [], events: { emit: () => undefined } } as any,
-			undefined,
-			undefined,
-			makeDetails,
-			"reuse",
-		);
-		assert.equal(calls.length, 0);
-		assert.equal(result.exitCode, 1);
-		assert.equal(result.stopReason, "session_budget_exceeded");
-		assert.equal(result.sessionMode, "resumed");
-		assert.equal(result.sessionKey, "reuse");
-		assert.match(result.errorMessage ?? "", /Refusing reused session/);
-		assert.match(result.errorMessage ?? "", /exceeds 80% guard threshold/);
-	} finally {
-		setSingleAgentSpawnForTests();
-	}
-});
-
-test("reused session budget guard allows below-threshold explicit session", async () => {
-	const runtimeRoot = tempRuntime();
-	const cwd = tempRuntime();
-	const session = resolveBgSession(runtimeRoot, "reviewer-test", "reuse-small");
-	mkdirSync(dirname(session.path), { recursive: true });
-	writeFileSync(session.path, "small", "utf8");
-	const calls = installMockSpawn([
-		{ code: 0, stdout: `${JSON.stringify({ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "ok" }], usage: { input: 1, output: 1, totalTokens: 2 } } })}\n` },
-	]);
-	try {
-		const result = await runSingleAgent(
-			cwd,
-			runtimeRoot,
-			[testAgent()],
-			"reviewer-test",
-			"reuse small context",
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			{ getActiveTools: () => [], events: { emit: () => undefined } } as any,
-			undefined,
-			undefined,
-			makeDetails,
-			"reuse-small",
-		);
-		assert.equal(calls.length, 1);
-		assert.equal(result.exitCode, 0);
-	} finally {
-		setSingleAgentSpawnForTests();
-	}
-});
-
-test("reused session compact-then-resume policy compacts then launches", async () => {
-	const runtimeRoot = tempRuntime();
-	const cwd = tempRuntime();
-	writeSettings(cwd, {
-		reusedSessionBudgetPolicy: "compact-then-resume",
-		reusedSessionBudgetThreshold: 0.5,
-		reusedSessionContextLimitTokens: 100,
-	});
-	const session = resolveBgSession(runtimeRoot, "reviewer-test", "reuse-compact");
-	mkdirSync(dirname(session.path), { recursive: true });
-	writeFileSync(session.path, "x".repeat(1_000), "utf8");
-	let compactCalls = 0;
-	setSessionCompactorForTests(async (request) => {
-		compactCalls += 1;
-		writeFileSync(request.sessionPath, "", "utf8");
-		return { archivePath: `${request.sessionPath}.archive` };
-	});
-	const calls = installMockSpawn([
-		{ code: 0, stdout: `${JSON.stringify({ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "ok" }], usage: { input: 1, output: 1, totalTokens: 2 } } })}\n` },
-	]);
-	try {
-		const result = await runSingleAgent(
-			cwd,
-			runtimeRoot,
-			[testAgent()],
-			"reviewer-test",
-			"compact old context",
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			{ getActiveTools: () => [], events: { emit: () => undefined } } as any,
-			undefined,
-			undefined,
-			makeDetails,
-			"reuse-compact",
-		);
-		assert.equal(compactCalls, 1);
-		assert.equal(calls.length, 1);
-		assert.equal(result.exitCode, 0);
-		assert.match(result.stderr, /Compacted reused session/);
-	} finally {
-		setSessionCompactorForTests();
-		setSingleAgentSpawnForTests();
 	}
 });

--- a/pi-extensions/pi-agents-tmux/tests/oneshot-completion.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/oneshot-completion.test.ts
@@ -20,13 +20,22 @@ function runOneShot(options: { cwd: string; pi: any; runtimeRoot?: string; sessi
 	return runSingleAgent(options.cwd, options.runtimeRoot ?? tempRuntime(), [testAgent()], "reviewer-test", "review code", undefined, undefined, undefined, undefined, options.pi, options.signal, undefined, makeDetails, options.sessionKey);
 }
 
-// The pi bus as one line, in emit order: `needs_completion` carries its reason
-// and whether the payload's snapshot names the run's cwd; `retrying` its reason;
-// `started` is the spawn announcement and is read as the spawn count instead.
-function busLine(emitted: Emitted, cwd: string): string {
-	const names = emitted.filter((event) => event.name !== "subagents:started").map((event) => {
+// The pi bus as one line, in emit order. A `needs_completion` event must carry
+// what the result carries (status, reason, diagnostics, the snapshot's cwd);
+// it prints the fields that differ, or `mirrors-result`. `retrying` prints its reason.
+function busLine(emitted: Emitted, result: SingleResult): string {
+	const names = emitted.map((event) => {
 		const name = event.name.replace(/^subagents:/, "");
-		if (name === "needs_completion") return `needs_completion(${event.payload.reason},${event.payload.cwdSnapshot ? (event.payload.cwdSnapshot.cwd === cwd ? "snapshot" : "wrong-snapshot") : "-"})`;
+		if (name === "needs_completion") {
+			const p = event.payload;
+			const differs = [
+				p.status !== result.status ? "status" : "",
+				p.reason !== result.needsCompletionReason ? "reason" : "",
+				JSON.stringify(p.diagnostics ?? null) !== JSON.stringify(result.diagnostics ?? null) ? "diagnostics" : "",
+				(p.cwdSnapshot?.cwd ?? "-") !== (result.cwdSnapshot?.cwd ?? "-") ? "snapshot" : "",
+			].filter(Boolean);
+			return `needs_completion(${differs.length ? differs.join("+") : "mirrors-result"})`;
+		}
 		if (name === "retrying") return `retrying(${event.payload.reason})`;
 		return name;
 	});
@@ -44,27 +53,32 @@ function diagTags(result: SingleResult): string {
 	return tags.length ? tags.join(",") : "-";
 }
 
-// The classification as one line: spawns and the returned attempt, whether a
-// retry ran on a fresh session, the first attempt's stop reason when there were
-// two, the status and reason, the snapshot, the diagnostics and the bus.
+// The classification as one line: spawns and the returned attempt; when there
+// were two attempts, whether the retry ran on a fresh session and the first
+// attempt's summary as `stop/envelope`; then the status, reason and stop of the
+// returned result, its snapshot, its diagnostics, whether stderr carries text,
+// and the bus.
 function classification(result: SingleResult, emitted: Emitted, spawns: number, cwd: string): string {
 	const attempts = result.attempts;
 	const retry = attempts ? (attempts[0]?.sessionKey !== attempts[1]?.sessionKey ? "fresh-session" : "same-session") : "-";
-	const firstStop = attempts ? `${attempts[0]?.stopReason ?? "-"}` : "-";
+	const first = attempts ? `${attempts[0]?.stopReason ?? "-"}/${attempts[0]?.errorEnvelope ? "envelope" : "-"}` : "-";
 	const snapshot = result.cwdSnapshot ? (result.cwdSnapshot.cwd === cwd ? "cwd" : "other") : "-";
-	return `spawns=${spawns} exit=${result.exitCode} attempt=${result.attempt ?? "-"} retry=${retry} first-stop=${firstStop} status=${result.status ?? "-"} reason=${result.needsCompletionReason ?? "-"} stop=${result.stopReason ?? "-"} snapshot=${snapshot} diags=${diagTags(result)} bus=${busLine(emitted, cwd)}`;
+	return `spawns=${spawns} exit=${result.exitCode} attempt=${result.attempt ?? "-"} retry=${retry} first=${first} status=${result.status ?? "-"} reason=${result.needsCompletionReason ?? "-"} stop=${result.stopReason ?? "-"} snapshot=${snapshot} diags=${diagTags(result)} stderr=${result.stderr ? "text" : "-"} bus=${busLine(emitted, result)}`;
 }
 
 const OVERFLOW_ENVELOPE = `${JSON.stringify({ error: { type: "invalid_request_error", code: "context_length_exceeded" } })}\n`;
 const textEnd = (text: string) => bridgeEvent("agent_end", { content: [{ type: "text", text }] });
 const assistantText = (text: string) => bridgeEvent("message_end", { message: { role: "assistant", content: [{ type: "text", text }] } });
 const EMPTY_END = bridgeEvent("agent_end", { content: [] });
+// An assistant turn that pi ends with an error instead of an error envelope.
+const OVERFLOW_TURN = bridgeEvent("message_end", { message: { role: "assistant", content: [], stopReason: "error", errorMessage: "context_length_exceeded" } });
 const COMPACT = bridgeEvent("session_compact");
 
 type World = { git?: "missing"; pi?: (emitted: Emitted) => any; stream: Array<{ code?: number; stdout?: string }> };
 
-const COMPLETED = "spawns=1 exit=0 attempt=1 retry=- first-stop=- status=- reason=- stop=- snapshot=- diags=- bus=completed";
-const NEEDS_COMPLETION = "spawns=1 exit=0 attempt=1 retry=- first-stop=- status=needs_completion reason=compact-then-empty stop=needs_completion snapshot=cwd diags=- bus=needs_completion(compact-then-empty,snapshot)";
+const COMPLETED = "spawns=1 exit=0 attempt=1 retry=- first=- status=- reason=- stop=- snapshot=- diags=- stderr=- bus=started,completed";
+const NEEDS_COMPLETION = "spawns=1 exit=0 attempt=1 retry=- first=- status=needs_completion reason=compact-then-empty stop=needs_completion snapshot=cwd diags=- stderr=- bus=started,needs_completion(mirrors-result)";
+const RETRIED_OK = "spawns=2 exit=0 attempt=2 retry=fresh-session first=-/envelope status=- reason=- stop=- snapshot=- diags=- stderr=text bus=started,failed,retrying(context_length_exceeded),started,completed";
 
 // label | the spawn's stdout per attempt (and the world around it) | expect the classification line
 // Every row runs in a fresh git repo, so a needs_completion row's snapshot is the cwd's.
@@ -78,22 +92,24 @@ const endRows: Array<[string, World, string]> = [
 	["an empty agent_end without a compact completes", { stream: [{ stdout: bridgeStdout([EMPTY_END]) }] }, COMPLETED],
 	["a compact with no agent_end (bridge gone) completes", { stream: [{ stdout: bridgeStdout([COMPACT]) }] }, COMPLETED],
 	["a malformed agent_end content is logged and completes", { stream: [{ stdout: bridgeStdout([COMPACT, bridgeEvent("agent_end", { content: "bad-shape" })]) }] },
-		"spawns=1 exit=0 attempt=1 retry=- first-stop=- status=- reason=- stop=- snapshot=- diags=malformed-agent-end bus=completed"],
+		"spawns=1 exit=0 attempt=1 retry=- first=- status=- reason=- stop=- snapshot=- diags=malformed-agent-end stderr=- bus=started,completed"],
 	["a missing git keeps needs_completion without the snapshot", { git: "missing", stream: [{ stdout: bridgeStdout([COMPACT, EMPTY_END]) }] },
-		"spawns=1 exit=0 attempt=1 retry=- first-stop=- status=needs_completion reason=compact-then-empty stop=needs_completion snapshot=- diags=git-failed bus=needs_completion(compact-then-empty,-)"],
+		"spawns=1 exit=0 attempt=1 retry=- first=- status=needs_completion reason=compact-then-empty stop=needs_completion snapshot=- diags=git-failed stderr=- bus=started,needs_completion(mirrors-result)"],
 	["a needs_completion emit that throws is a diagnostic on the result", {
 		pi: (emitted) => ({ getActiveTools: () => [], events: { emit: (name: string, payload: unknown) => {
 			if (name === "subagents:needs_completion") throw new Error("bus disposed");
 			emitted.push({ name, payload });
 		} } }),
 		stream: [{ stdout: bridgeStdout([COMPACT, EMPTY_END]) }],
-	}, "spawns=1 exit=0 attempt=1 retry=- first-stop=- status=needs_completion reason=compact-then-empty stop=needs_completion snapshot=cwd diags=emit-failed bus=none"],
-	["a context overflow envelope retries once on a fresh session", { stream: [{ code: 1, stdout: OVERFLOW_ENVELOPE }, { stdout: bridgeStdout([textEnd("ok after retry")]) }] },
-		"spawns=2 exit=0 attempt=2 retry=fresh-session first-stop=- status=- reason=- stop=- snapshot=- diags=- bus=failed,retrying(context_length_exceeded),completed"],
+	}, "spawns=1 exit=0 attempt=1 retry=- first=- status=needs_completion reason=compact-then-empty stop=needs_completion snapshot=cwd diags=emit-failed stderr=- bus=started"],
+	["a context overflow envelope retries once on a fresh session", { stream: [{ code: 1, stdout: OVERFLOW_ENVELOPE }, { stdout: bridgeStdout([textEnd("ok after retry")]) }] }, RETRIED_OK],
+	["an assistant turn ending in a context-length error retries", { stream: [{ stdout: bridgeStdout([OVERFLOW_TURN]) }, { stdout: bridgeStdout([textEnd("ok after retry")]) }] },
+		"spawns=2 exit=0 attempt=2 retry=fresh-session first=error/envelope status=- reason=- stop=- snapshot=- diags=- stderr=text bus=started,failed,retrying(context_length_exceeded),started,completed"],
+	["an overflow on the retry too fails, whatever the retry's exit code", { stream: [{ code: 1, stdout: OVERFLOW_ENVELOPE }, { code: 0, stdout: bridgeStdout([OVERFLOW_TURN]) }] },
+		"spawns=2 exit=1 attempt=2 retry=fresh-session first=-/envelope status=- reason=- stop=error snapshot=- diags=- stderr=text bus=started,failed,retrying(context_length_exceeded),started,failed"],
 	["a compact-then-empty on the retry is needs_completion", { stream: [{ code: 1, stdout: OVERFLOW_ENVELOPE }, { stdout: bridgeStdout([COMPACT, EMPTY_END]) }] },
-		"spawns=2 exit=0 attempt=2 retry=fresh-session first-stop=- status=needs_completion reason=compact-then-empty stop=needs_completion snapshot=cwd diags=- bus=failed,retrying(context_length_exceeded),needs_completion(compact-then-empty,snapshot)"],
-	["a compact-then-empty beside an overflow in the same attempt is the retry's, not needs_completion", { stream: [{ code: 1, stdout: bridgeStdout([COMPACT, EMPTY_END, JSON.parse(OVERFLOW_ENVELOPE)]) }, { stdout: bridgeStdout([textEnd("ok after retry")]) }] },
-		"spawns=2 exit=0 attempt=2 retry=fresh-session first-stop=- status=- reason=- stop=- snapshot=- diags=- bus=failed,retrying(context_length_exceeded),completed"],
+		"spawns=2 exit=0 attempt=2 retry=fresh-session first=-/envelope status=needs_completion reason=compact-then-empty stop=needs_completion snapshot=cwd diags=- stderr=text bus=started,failed,retrying(context_length_exceeded),started,needs_completion(mirrors-result)"],
+	["a compact-then-empty beside an overflow in the same attempt is the retry's, not needs_completion", { stream: [{ code: 1, stdout: bridgeStdout([COMPACT, EMPTY_END, JSON.parse(OVERFLOW_ENVELOPE)]) }, { stdout: bridgeStdout([textEnd("ok after retry")]) }] }, RETRIED_OK],
 	["overflow wording inside a tool result is not an overflow", { stream: [{ stdout: bridgeStdout([
 		{ type: "tool_execution_end", toolCallId: "call-grep", toolName: "grep", result: { content: [{ type: "text", text: "tests/session-lanes.test.ts: context_length_exceeded detection triggers one retry" }] } },
 		assistantText("Reviewed context_length_exceeded docs/tests; no runtime overflow."),
@@ -139,8 +155,8 @@ test("an aborted run fails with the partial answer flushed to its transcript", a
 		const records = readFileSync(failed?.payload.transcriptPath, "utf8").trim().split(/\r?\n/).map((line) => JSON.parse(line));
 		const updates = records.filter((record) => record.event && transcriptEventName(record.event) === "message_update");
 		assert.equal(
-			`spawns=${calls.length} bus=${busLine(emitted, cwd)} status=${failed?.payload.status} updates=${updates.length} buffered=${updates.every((record) => record.buffered === true)} partial=${updates.some((record) => JSON.stringify(record.event).includes("aborted partial"))}`,
-			"spawns=1 bus=failed status=aborted updates=1 buffered=true partial=true",
+			`spawns=${calls.length} bus=${emitted.map((event) => event.name.replace(/^subagents:/, "")).join(",")} status=${failed?.payload.status} updates=${updates.length} buffered=${updates.every((record) => record.buffered === true)} partial=${updates.some((record) => JSON.stringify(record.event).includes("aborted partial"))}`,
+			"spawns=1 bus=started,failed status=aborted updates=1 buffered=true partial=true",
 		);
 	} finally {
 		setSingleAgentSpawnForTests();
@@ -178,7 +194,7 @@ test("the context-overflow detector", () => {
 
 const OK_STDOUT = bridgeStdout([textEnd("ok")]);
 
-type BudgetWorld = { compactor?: "fails" | "truncates"; session?: "absent" | number; settings?: Record<string, unknown> };
+type BudgetWorld = { compactor?: "fails" | "truncates"; key?: string; session?: "absent" | number; settings?: Record<string, unknown> };
 
 // The guard's outcome as one line: spawns, compactor calls, the exit and stop
 // reason, the session mode and whether stderr carries the guard's line.
@@ -187,15 +203,24 @@ function budgetLine(result: SingleResult, spawns: number, compactions: number): 
 }
 
 const TIGHT = { reusedSessionBudgetThreshold: 0.5, reusedSessionContextLimitTokens: 100 };
+const REFUSED = "spawns=0 compactions=0 exit=1 refused=true stop=session_budget_exceeded mode=resumed stderr=guard-line";
+const SPAWNED = "spawns=1 compactions=0 exit=0 refused=false stop=- mode=resumed stderr=-";
 
+// A session estimates at one token per four bytes against the limit; the
+// default limit is 272k tokens and the default threshold 80%, so 870,400 bytes
+// sit exactly on the default line.
 // label | the reused session's size in bytes and the project's budget settings | expect the guard's line
 const budgetRows: Array<[string, BudgetWorld, string]> = [
-	["over the default 80% of the default 272k-token limit is refused before the spawn", { session: 900_000 }, "spawns=0 compactions=0 exit=1 refused=true stop=session_budget_exceeded mode=resumed stderr=guard-line"],
-	["under the default threshold spawns", { session: 800_000 }, "spawns=1 compactions=0 exit=0 refused=false stop=- mode=resumed stderr=-"],
-	["a configured limit decides under the default threshold", { session: 1_000, settings: { reusedSessionContextLimitTokens: 100 } }, "spawns=0 compactions=0 exit=1 refused=true stop=session_budget_exceeded mode=resumed stderr=guard-line"],
-	["a configured threshold decides under a configured limit", { session: 100, settings: { ...TIGHT, reusedSessionBudgetThreshold: 0.2 } }, "spawns=0 compactions=0 exit=1 refused=true stop=session_budget_exceeded mode=resumed stderr=guard-line"],
-	["under a configured threshold spawns", { session: 100, settings: TIGHT }, "spawns=1 compactions=0 exit=0 refused=false stop=- mode=resumed stderr=-"],
-	["an explicit key with no session file yet spawns", { session: "absent", settings: TIGHT }, "spawns=1 compactions=0 exit=0 refused=false stop=- mode=resumed stderr=-"],
+	["one token over the default line is refused before the spawn", { session: 870_404 }, REFUSED],
+	["exactly on the default line spawns", { session: 870_400 }, SPAWNED],
+	["a configured limit decides under the default threshold", { session: 1_000, settings: { reusedSessionContextLimitTokens: 100 } }, REFUSED],
+	["a configured threshold decides under a configured limit", { session: 100, settings: { ...TIGHT, reusedSessionBudgetThreshold: 0.2 } }, REFUSED],
+	["a threshold above 1 is a percentage", { session: 100, settings: { ...TIGHT, reusedSessionBudgetThreshold: 20 } }, REFUSED],
+	["a percentage above 100 clamps to the whole limit", { session: 600, settings: { ...TIGHT, reusedSessionBudgetThreshold: 150 } }, REFUSED],
+	["a zero threshold falls back to the default", { session: 100, settings: { ...TIGHT, reusedSessionBudgetThreshold: 0 } }, SPAWNED],
+	["under a configured threshold spawns", { session: 100, settings: TIGHT }, SPAWNED],
+	["an explicit key with no session file yet spawns", { session: "absent", settings: TIGHT }, SPAWNED],
+	["a one-shot session key is never guarded", { key: "oneshot-fixed", session: 1_000, settings: TIGHT }, "spawns=1 compactions=0 exit=0 refused=false stop=- mode=fresh stderr=-"],
 	["the warn policy spawns with the guard's line on stderr", { session: 1_000, settings: { ...TIGHT, reusedSessionBudgetPolicy: "warn" } }, "spawns=1 compactions=0 exit=0 refused=false stop=- mode=resumed stderr=guard-line"],
 	["compact-then-resume compacts once, then spawns", { compactor: "truncates", session: 1_000, settings: { ...TIGHT, reusedSessionBudgetPolicy: "compact-then-resume" } }, "spawns=1 compactions=1 exit=0 refused=false stop=- mode=resumed stderr=guard-line"],
 	["a failed compaction refuses", { compactor: "fails", session: 1_000, settings: { ...TIGHT, reusedSessionBudgetPolicy: "compact-then-resume" } }, "spawns=0 compactions=1 exit=1 refused=true stop=session_budget_exceeded mode=resumed stderr=guard-line"],
@@ -206,7 +231,8 @@ test("the reused-session budget guard", async () => {
 		const runtimeRoot = tempRuntime();
 		const cwd = tempRuntime();
 		if (world.settings) writeSettings(cwd, world.settings);
-		const session = resolveBgSession(runtimeRoot, "reviewer-test", "reuse");
+		const key = world.key ?? "reuse";
+		const session = resolveBgSession(runtimeRoot, "reviewer-test", key);
 		if (world.session !== "absent") {
 			mkdirSync(dirname(session.path), { recursive: true });
 			writeFileSync(session.path, "x".repeat(world.session ?? 0), "utf8");
@@ -220,7 +246,7 @@ test("the reused-session budget guard", async () => {
 		});
 		const calls = installMockSpawn([{ code: 0, stdout: OK_STDOUT }]);
 		try {
-			const result = await runOneShot({ cwd, pi: mockPiEvents([]), runtimeRoot, sessionKey: "reuse" });
+			const result = await runOneShot({ cwd, pi: mockPiEvents([]), runtimeRoot, sessionKey: key });
 			assert.equal(budgetLine(result, calls.length, compactions), expect, label);
 		} finally {
 			setSessionCompactorForTests();

--- a/pi-extensions/pi-agents-tmux/tests/oneshot-completion.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/oneshot-completion.test.ts
@@ -53,15 +53,32 @@ function diagTags(result: SingleResult): string {
 	return tags.length ? tags.join(",") : "-";
 }
 
+// The envelope an attempt recorded (the raw stream line), read back as the
+// overflow it carried: the error code, or the assistant message's error text
+// (top-level or under a bridge event's `data`); anything else prints whole.
+function envelopeTag(raw: string | undefined): string {
+	if (raw === undefined) return "-";
+	try {
+		const parsed = JSON.parse(raw);
+		if (typeof parsed?.error?.code === "string") return `code:${parsed.error.code}`;
+		const message = parsed?.message ?? parsed?.data?.message;
+		if (typeof message?.errorMessage === "string") return `message:${message.errorMessage}`;
+	} catch {
+		/* not JSON: printed whole below */
+	}
+	return JSON.stringify(raw);
+}
+
 // The classification as one line: spawns and the returned attempt; when there
 // were two attempts, their count and whether the retry ran on a fresh session,
-// and the first attempt's summary as `stop/envelope`; then the status, reason and stop of the
+// and the first attempt's summary as `stop/envelope` with the envelope read
+// back by `envelopeTag`; then the status, reason and stop of the
 // returned result, its snapshot, its diagnostics, whether stderr carries text,
 // and the bus.
 function classification(result: SingleResult, emitted: Emitted, spawns: number, cwd: string): string {
 	const attempts = result.attempts;
 	const retry = attempts ? `${attempts.length}/${attempts[0]?.sessionKey !== attempts[1]?.sessionKey ? "fresh-session" : "same-session"}` : "-";
-	const first = attempts ? `${attempts[0]?.stopReason ?? "-"}/${attempts[0]?.errorEnvelope ? "envelope" : "-"}` : "-";
+	const first = attempts ? `${attempts[0]?.stopReason ?? "-"}/${envelopeTag(attempts[0]?.errorEnvelope)}` : "-";
 	const snapshot = result.cwdSnapshot ? (result.cwdSnapshot.cwd === cwd ? "cwd" : "other") : "-";
 	return `spawns=${spawns} exit=${result.exitCode} attempt=${result.attempt ?? "-"} retry=${retry} first=${first} status=${result.status ?? "-"} reason=${result.needsCompletionReason ?? "-"} stop=${result.stopReason ?? "-"} snapshot=${snapshot} diags=${diagTags(result)} stderr=${result.stderr ? "text" : "-"} bus=${busLine(emitted, result)}`;
 }
@@ -78,7 +95,7 @@ type World = { git?: "missing"; pi?: (emitted: Emitted) => any; stream: Array<{ 
 
 const COMPLETED = "spawns=1 exit=0 attempt=1 retry=- first=- status=- reason=- stop=- snapshot=- diags=- stderr=- bus=started,completed";
 const NEEDS_COMPLETION = "spawns=1 exit=0 attempt=1 retry=- first=- status=needs_completion reason=compact-then-empty stop=needs_completion snapshot=cwd diags=- stderr=- bus=started,needs_completion(mirrors-result)";
-const RETRIED_OK = "spawns=2 exit=0 attempt=2 retry=2/fresh-session first=-/envelope status=- reason=- stop=- snapshot=- diags=- stderr=text bus=started,failed,retrying(context_length_exceeded),started,completed";
+const RETRIED_OK = "spawns=2 exit=0 attempt=2 retry=2/fresh-session first=-/code:context_length_exceeded status=- reason=- stop=- snapshot=- diags=- stderr=text bus=started,failed,retrying(context_length_exceeded),started,completed";
 
 // label | the spawn's stdout per attempt (and the world around it) | expect the classification line
 // Every row runs in a fresh git repo, so a needs_completion row's snapshot is the cwd's.
@@ -106,11 +123,11 @@ const endRows: Array<[string, World, string]> = [
 	}, "spawns=1 exit=0 attempt=1 retry=- first=- status=needs_completion reason=compact-then-empty stop=needs_completion snapshot=cwd diags=emit-failed stderr=- bus=started"],
 	["a context overflow envelope retries once on a fresh session", { stream: [{ code: 1, stdout: OVERFLOW_ENVELOPE }, { stdout: bridgeStdout([textEnd("ok after retry")]) }] }, RETRIED_OK],
 	["an assistant turn ending in a context-length error retries", { stream: [{ stdout: bridgeStdout([OVERFLOW_TURN]) }, { stdout: bridgeStdout([textEnd("ok after retry")]) }] },
-		"spawns=2 exit=0 attempt=2 retry=2/fresh-session first=error/envelope status=- reason=- stop=- snapshot=- diags=- stderr=text bus=started,failed,retrying(context_length_exceeded),started,completed"],
+		"spawns=2 exit=0 attempt=2 retry=2/fresh-session first=error/message:context_length_exceeded status=- reason=- stop=- snapshot=- diags=- stderr=text bus=started,failed,retrying(context_length_exceeded),started,completed"],
 	["an overflow on the retry too fails, whatever the retry's exit code", { stream: [{ code: 1, stdout: OVERFLOW_ENVELOPE }, { code: 0, stdout: bridgeStdout([OVERFLOW_TURN]) }] },
-		"spawns=2 exit=1 attempt=2 retry=2/fresh-session first=-/envelope status=- reason=- stop=error snapshot=- diags=- stderr=text bus=started,failed,retrying(context_length_exceeded),started,failed"],
+		"spawns=2 exit=1 attempt=2 retry=2/fresh-session first=-/code:context_length_exceeded status=- reason=- stop=error snapshot=- diags=- stderr=text bus=started,failed,retrying(context_length_exceeded),started,failed"],
 	["a compact-then-empty on the retry is needs_completion", { stream: [{ code: 1, stdout: OVERFLOW_ENVELOPE }, { stdout: bridgeStdout([COMPACT, EMPTY_END]) }] },
-		"spawns=2 exit=0 attempt=2 retry=2/fresh-session first=-/envelope status=needs_completion reason=compact-then-empty stop=needs_completion snapshot=cwd diags=- stderr=text bus=started,failed,retrying(context_length_exceeded),started,needs_completion(mirrors-result)"],
+		"spawns=2 exit=0 attempt=2 retry=2/fresh-session first=-/code:context_length_exceeded status=needs_completion reason=compact-then-empty stop=needs_completion snapshot=cwd diags=- stderr=text bus=started,failed,retrying(context_length_exceeded),started,needs_completion(mirrors-result)"],
 	["a compact-then-empty beside an overflow in the same attempt is the retry's, not needs_completion", { stream: [{ code: 1, stdout: bridgeStdout([COMPACT, EMPTY_END, JSON.parse(OVERFLOW_ENVELOPE)]) }, { stdout: bridgeStdout([textEnd("ok after retry")]) }] }, RETRIED_OK],
 	["overflow wording inside a tool result is not an overflow", { stream: [{ stdout: bridgeStdout([
 		{ type: "tool_execution_end", toolCallId: "call-grep", toolName: "grep", result: { content: [{ type: "text", text: "tests/session-lanes.test.ts: context_length_exceeded detection triggers one retry" }] } },

--- a/pi-extensions/pi-agents-tmux/tests/oneshot-completion.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/oneshot-completion.test.ts
@@ -54,13 +54,13 @@ function diagTags(result: SingleResult): string {
 }
 
 // The classification as one line: spawns and the returned attempt; when there
-// were two attempts, whether the retry ran on a fresh session and the first
-// attempt's summary as `stop/envelope`; then the status, reason and stop of the
+// were two attempts, their count and whether the retry ran on a fresh session,
+// and the first attempt's summary as `stop/envelope`; then the status, reason and stop of the
 // returned result, its snapshot, its diagnostics, whether stderr carries text,
 // and the bus.
 function classification(result: SingleResult, emitted: Emitted, spawns: number, cwd: string): string {
 	const attempts = result.attempts;
-	const retry = attempts ? (attempts[0]?.sessionKey !== attempts[1]?.sessionKey ? "fresh-session" : "same-session") : "-";
+	const retry = attempts ? `${attempts.length}/${attempts[0]?.sessionKey !== attempts[1]?.sessionKey ? "fresh-session" : "same-session"}` : "-";
 	const first = attempts ? `${attempts[0]?.stopReason ?? "-"}/${attempts[0]?.errorEnvelope ? "envelope" : "-"}` : "-";
 	const snapshot = result.cwdSnapshot ? (result.cwdSnapshot.cwd === cwd ? "cwd" : "other") : "-";
 	return `spawns=${spawns} exit=${result.exitCode} attempt=${result.attempt ?? "-"} retry=${retry} first=${first} status=${result.status ?? "-"} reason=${result.needsCompletionReason ?? "-"} stop=${result.stopReason ?? "-"} snapshot=${snapshot} diags=${diagTags(result)} stderr=${result.stderr ? "text" : "-"} bus=${busLine(emitted, result)}`;
@@ -78,7 +78,7 @@ type World = { git?: "missing"; pi?: (emitted: Emitted) => any; stream: Array<{ 
 
 const COMPLETED = "spawns=1 exit=0 attempt=1 retry=- first=- status=- reason=- stop=- snapshot=- diags=- stderr=- bus=started,completed";
 const NEEDS_COMPLETION = "spawns=1 exit=0 attempt=1 retry=- first=- status=needs_completion reason=compact-then-empty stop=needs_completion snapshot=cwd diags=- stderr=- bus=started,needs_completion(mirrors-result)";
-const RETRIED_OK = "spawns=2 exit=0 attempt=2 retry=fresh-session first=-/envelope status=- reason=- stop=- snapshot=- diags=- stderr=text bus=started,failed,retrying(context_length_exceeded),started,completed";
+const RETRIED_OK = "spawns=2 exit=0 attempt=2 retry=2/fresh-session first=-/envelope status=- reason=- stop=- snapshot=- diags=- stderr=text bus=started,failed,retrying(context_length_exceeded),started,completed";
 
 // label | the spawn's stdout per attempt (and the world around it) | expect the classification line
 // Every row runs in a fresh git repo, so a needs_completion row's snapshot is the cwd's.
@@ -91,6 +91,8 @@ const endRows: Array<[string, World, string]> = [
 	["a compact then a text agent_end completes", { stream: [{ stdout: bridgeStdout([COMPACT, textEnd("ok")]) }] }, COMPLETED],
 	["an empty agent_end without a compact completes", { stream: [{ stdout: bridgeStdout([EMPTY_END]) }] }, COMPLETED],
 	["a compact with no agent_end (bridge gone) completes", { stream: [{ stdout: bridgeStdout([COMPACT]) }] }, COMPLETED],
+	["a compact after an empty agent_end, with no further end, completes", { stream: [{ stdout: bridgeStdout([COMPACT, EMPTY_END, COMPACT]) }] }, COMPLETED],
+	["a second compact re-arms the empty-end rule", { stream: [{ stdout: bridgeStdout([COMPACT, assistantText("first answer"), EMPTY_END, COMPACT, EMPTY_END]) }] }, NEEDS_COMPLETION],
 	["a malformed agent_end content is logged and completes", { stream: [{ stdout: bridgeStdout([COMPACT, bridgeEvent("agent_end", { content: "bad-shape" })]) }] },
 		"spawns=1 exit=0 attempt=1 retry=- first=- status=- reason=- stop=- snapshot=- diags=malformed-agent-end stderr=- bus=started,completed"],
 	["a missing git keeps needs_completion without the snapshot", { git: "missing", stream: [{ stdout: bridgeStdout([COMPACT, EMPTY_END]) }] },
@@ -104,11 +106,11 @@ const endRows: Array<[string, World, string]> = [
 	}, "spawns=1 exit=0 attempt=1 retry=- first=- status=needs_completion reason=compact-then-empty stop=needs_completion snapshot=cwd diags=emit-failed stderr=- bus=started"],
 	["a context overflow envelope retries once on a fresh session", { stream: [{ code: 1, stdout: OVERFLOW_ENVELOPE }, { stdout: bridgeStdout([textEnd("ok after retry")]) }] }, RETRIED_OK],
 	["an assistant turn ending in a context-length error retries", { stream: [{ stdout: bridgeStdout([OVERFLOW_TURN]) }, { stdout: bridgeStdout([textEnd("ok after retry")]) }] },
-		"spawns=2 exit=0 attempt=2 retry=fresh-session first=error/envelope status=- reason=- stop=- snapshot=- diags=- stderr=text bus=started,failed,retrying(context_length_exceeded),started,completed"],
+		"spawns=2 exit=0 attempt=2 retry=2/fresh-session first=error/envelope status=- reason=- stop=- snapshot=- diags=- stderr=text bus=started,failed,retrying(context_length_exceeded),started,completed"],
 	["an overflow on the retry too fails, whatever the retry's exit code", { stream: [{ code: 1, stdout: OVERFLOW_ENVELOPE }, { code: 0, stdout: bridgeStdout([OVERFLOW_TURN]) }] },
-		"spawns=2 exit=1 attempt=2 retry=fresh-session first=-/envelope status=- reason=- stop=error snapshot=- diags=- stderr=text bus=started,failed,retrying(context_length_exceeded),started,failed"],
+		"spawns=2 exit=1 attempt=2 retry=2/fresh-session first=-/envelope status=- reason=- stop=error snapshot=- diags=- stderr=text bus=started,failed,retrying(context_length_exceeded),started,failed"],
 	["a compact-then-empty on the retry is needs_completion", { stream: [{ code: 1, stdout: OVERFLOW_ENVELOPE }, { stdout: bridgeStdout([COMPACT, EMPTY_END]) }] },
-		"spawns=2 exit=0 attempt=2 retry=fresh-session first=-/envelope status=needs_completion reason=compact-then-empty stop=needs_completion snapshot=cwd diags=- stderr=text bus=started,failed,retrying(context_length_exceeded),started,needs_completion(mirrors-result)"],
+		"spawns=2 exit=0 attempt=2 retry=2/fresh-session first=-/envelope status=needs_completion reason=compact-then-empty stop=needs_completion snapshot=cwd diags=- stderr=text bus=started,failed,retrying(context_length_exceeded),started,needs_completion(mirrors-result)"],
 	["a compact-then-empty beside an overflow in the same attempt is the retry's, not needs_completion", { stream: [{ code: 1, stdout: bridgeStdout([COMPACT, EMPTY_END, JSON.parse(OVERFLOW_ENVELOPE)]) }, { stdout: bridgeStdout([textEnd("ok after retry")]) }] }, RETRIED_OK],
 	["overflow wording inside a tool result is not an overflow", { stream: [{ stdout: bridgeStdout([
 		{ type: "tool_execution_end", toolCallId: "call-grep", toolName: "grep", result: { content: [{ type: "text", text: "tests/session-lanes.test.ts: context_length_exceeded detection triggers one retry" }] } },
@@ -197,36 +199,51 @@ const OK_STDOUT = bridgeStdout([textEnd("ok")]);
 type BudgetWorld = { compactor?: "fails" | "truncates"; key?: string; session?: "absent" | number; settings?: Record<string, unknown> };
 
 // The guard's outcome as one line: spawns, compactor calls, the exit and stop
-// reason, the session mode and whether stderr carries the guard's line.
-function budgetLine(result: SingleResult, spawns: number, compactions: number): string {
-	return `spawns=${spawns} compactions=${compactions} exit=${result.exitCode} refused=${result.refused ?? false} stop=${result.stopReason ?? "-"} mode=${result.sessionMode ?? "-"} stderr=${result.stderr ? "guard-line" : "-"}`;
+// reason, the session mode, whether the result names the requested key, and
+// whether stderr carries the guard's line.
+function budgetLine(result: SingleResult, spawns: number, compactions: number, key: string): string {
+	return `spawns=${spawns} compactions=${compactions} exit=${result.exitCode} refused=${result.refused ?? false} stop=${result.stopReason ?? "-"} mode=${result.sessionMode ?? "-"} key=${result.sessionKey === key ? "key" : result.sessionKey ?? "-"} stderr=${result.stderr ? "guard-line" : "-"}`;
 }
 
 const TIGHT = { reusedSessionBudgetThreshold: 0.5, reusedSessionContextLimitTokens: 100 };
-const REFUSED = "spawns=0 compactions=0 exit=1 refused=true stop=session_budget_exceeded mode=resumed stderr=guard-line";
-const SPAWNED = "spawns=1 compactions=0 exit=0 refused=false stop=- mode=resumed stderr=-";
+const REFUSED = "spawns=0 compactions=0 exit=1 refused=true stop=session_budget_exceeded mode=resumed key=key stderr=guard-line";
+const SPAWNED = "spawns=1 compactions=0 exit=0 refused=false stop=- mode=resumed key=key stderr=-";
 
-// A session estimates at one token per four bytes against the limit; the
-// default limit is 272k tokens and the default threshold 80%, so 870,400 bytes
-// sit exactly on the default line.
+// A session estimates at one token per four bytes, rounded up, against the
+// limit; the default limit is 272k tokens and the default threshold 80%, so
+// 870,400 bytes sit exactly on the default line and one more byte is over it.
 // label | the reused session's size in bytes and the project's budget settings | expect the guard's line
 const budgetRows: Array<[string, BudgetWorld, string]> = [
-	["one token over the default line is refused before the spawn", { session: 870_404 }, REFUSED],
+	["one byte over the default line is refused before the spawn", { session: 870_401 }, REFUSED],
 	["exactly on the default line spawns", { session: 870_400 }, SPAWNED],
 	["a configured limit decides under the default threshold", { session: 1_000, settings: { reusedSessionContextLimitTokens: 100 } }, REFUSED],
 	["a configured threshold decides under a configured limit", { session: 100, settings: { ...TIGHT, reusedSessionBudgetThreshold: 0.2 } }, REFUSED],
 	["a threshold above 1 is a percentage", { session: 100, settings: { ...TIGHT, reusedSessionBudgetThreshold: 20 } }, REFUSED],
 	["a percentage above 100 clamps to the whole limit", { session: 600, settings: { ...TIGHT, reusedSessionBudgetThreshold: 150 } }, REFUSED],
-	["a zero threshold falls back to the default", { session: 100, settings: { ...TIGHT, reusedSessionBudgetThreshold: 0 } }, SPAWNED],
+	["a zero threshold falls back to the default: on the 80% line spawns", { session: 320, settings: { reusedSessionContextLimitTokens: 100, reusedSessionBudgetThreshold: 0 } }, SPAWNED],
+	["a zero threshold falls back to the default: over the 80% line is refused", { session: 324, settings: { reusedSessionContextLimitTokens: 100, reusedSessionBudgetThreshold: 0 } }, REFUSED],
 	["under a configured threshold spawns", { session: 100, settings: TIGHT }, SPAWNED],
 	["an explicit key with no session file yet spawns", { session: "absent", settings: TIGHT }, SPAWNED],
-	["a one-shot session key is never guarded", { key: "oneshot-fixed", session: 1_000, settings: TIGHT }, "spawns=1 compactions=0 exit=0 refused=false stop=- mode=fresh stderr=-"],
-	["the warn policy spawns with the guard's line on stderr", { session: 1_000, settings: { ...TIGHT, reusedSessionBudgetPolicy: "warn" } }, "spawns=1 compactions=0 exit=0 refused=false stop=- mode=resumed stderr=guard-line"],
-	["compact-then-resume compacts once, then spawns", { compactor: "truncates", session: 1_000, settings: { ...TIGHT, reusedSessionBudgetPolicy: "compact-then-resume" } }, "spawns=1 compactions=1 exit=0 refused=false stop=- mode=resumed stderr=guard-line"],
-	["a failed compaction refuses", { compactor: "fails", session: 1_000, settings: { ...TIGHT, reusedSessionBudgetPolicy: "compact-then-resume" } }, "spawns=0 compactions=1 exit=1 refused=true stop=session_budget_exceeded mode=resumed stderr=guard-line"],
+	["a one-shot session key is never guarded", { key: "oneshot-fixed", session: 1_000, settings: TIGHT }, "spawns=1 compactions=0 exit=0 refused=false stop=- mode=fresh key=key stderr=-"],
+	["the warn policy spawns with the guard's line on stderr", { session: 1_000, settings: { ...TIGHT, reusedSessionBudgetPolicy: "warn" } }, "spawns=1 compactions=0 exit=0 refused=false stop=- mode=resumed key=key stderr=guard-line"],
+	["compact-then-resume compacts once, then spawns", { compactor: "truncates", session: 1_000, settings: { ...TIGHT, reusedSessionBudgetPolicy: "compact-then-resume" } }, "spawns=1 compactions=1 exit=0 refused=false stop=- mode=resumed key=key stderr=guard-line"],
+	["a failed compaction refuses", { compactor: "fails", session: 1_000, settings: { ...TIGHT, reusedSessionBudgetPolicy: "compact-then-resume" } }, "spawns=0 compactions=1 exit=1 refused=true stop=session_budget_exceeded mode=resumed key=key stderr=guard-line"],
 ];
 
 test("the reused-session budget guard", async () => {
+	// The user-scope settings layer is read from PI_CODING_AGENT_DIR; a temp dir
+	// keeps the developer's own settings out of the rows.
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = tempRuntime();
+	try {
+		await runBudgetRows();
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+	}
+});
+
+async function runBudgetRows(): Promise<void> {
 	for (const [label, world, expect] of budgetRows) {
 		const runtimeRoot = tempRuntime();
 		const cwd = tempRuntime();
@@ -247,10 +264,10 @@ test("the reused-session budget guard", async () => {
 		const calls = installMockSpawn([{ code: 0, stdout: OK_STDOUT }]);
 		try {
 			const result = await runOneShot({ cwd, pi: mockPiEvents([]), runtimeRoot, sessionKey: key });
-			assert.equal(budgetLine(result, calls.length, compactions), expect, label);
+			assert.equal(budgetLine(result, calls.length, compactions, key), expect, label);
 		} finally {
 			setSessionCompactorForTests();
 			setSingleAgentSpawnForTests();
 		}
 	}
-});
+}


### PR DESCRIPTION
Reshapes `pi-extensions/pi-agents-tmux/tests/oneshot-completion.test.ts` to code-quality § Tests: seventeen cases with a dozen expects each on one spawn become three tables (the end of a one-shot run, the context-overflow detector, the reused-session budget guard) with one classification line per row, plus the abort path as its own case. Also lands the row tracked off #2231 in `needs-completion-snapshot.test.ts`.

## Folded and deleted cases, with the surviving row

| Former case | Surviving row |
|---|---|
| context_length_exceeded detection triggers one retry with fresh session | end table `a context overflow envelope retries once on a fresh session` (two spawns, fresh session, the first attempt's envelope in its summary, the retry warning on stderr); its four inline detector asserts are detector rows `text: the error code as a word`, `text: exceeds the model's maximum context length…`, `text: exceeds the context window`, `envelope: message.errorMessage` |
| default reused-session context limit tracks current Codex backend cap | deleted: it pinned `DEFAULT_MODEL_CONTEXT_LIMIT_TOKENS` against its own literal. Budget rows `one byte over the default line is refused before the spawn` (870,401 bytes) and `exactly on the default line spawns` (870,400 bytes) fail when either default moves in either direction (mutants at 262,144, 280,000 and 300,000 tokens and at a 90% threshold) |
| context_length_exceeded text in normal tool output does not trigger retry | end row `overflow wording inside a tool result is not an overflow`; detector row `envelope: the code in a tool result is not read` |
| aborted oneshot emits failed event with summary | `an aborted run fails with the partial answer flushed to its transcript` (status `aborted`, one buffered `message_update` record carrying the partial); the summary and error prose pins are dropped, the enum stays |
| session_compact followed by empty agent_end emits synthetic needs_completion | end row `a compact then an empty agent_end is needs_completion with the cwd's snapshot` (the event's status, reason, diagnostics and snapshot cwd must mirror the result's, rendered `mirrors-result`). The snapshot's contents (HEAD, dirty, subject) are the snapshot helper's and are pinned in `needs-completion-snapshot.test.ts`; the `index.lock` absence check is deleted, the lock is gone once git exits whether or not it was taken |
| pre-compact assistant text does not mask compact-then-empty | `assistant text before the compact does not mask it`; new inverse `assistant text after the compact completes` (the `postCompactAssistantHasText` guard had no control) |
| compact-then-empty detection applies after context retry | `a compact-then-empty on the retry is needs_completion` |
| compact-then-empty treats null and omitted agent_end content as empty | `a null agent_end content is empty`, `an omitted agent_end content is empty` |
| session_compact followed by text agent_end completes normally | `a compact then a text agent_end completes` |
| empty agent_end without session_compact preserves existing completion behavior | `an empty agent_end without a compact completes` |
| bridge disconnect after session_compact does not classify compact-then-empty | `a compact with no agent_end (bridge gone) completes` |
| malformed agent_end content is logged and skipped | `a malformed agent_end content is logged and completes` (diagnostic read as its detector tag) |
| missing git binary omits cwdSnapshot but still emits compact-then-empty | `a missing git keeps needs_completion without the snapshot` |
| needs_completion emit failure is attached to result diagnostics | `a needs_completion emit that throws is a diagnostic on the result` |
| reused session budget guard refuses over-threshold explicit session by default | budget row `one byte over the default line is refused before the spawn` |
| reused session budget guard allows below-threshold explicit session | `exactly on the default line spawns` |
| reused session compact-then-resume policy compacts then launches | `compact-then-resume compacts once, then spawns` |

New rows with no former case, each the must-fail control of a guard that had none: `a compact-then-empty beside an overflow in the same attempt is the retry's, not needs_completion`, `an assistant turn ending in a context-length error retries`, `an overflow on the retry too fails, whatever the retry's exit code`, `a compact after an empty agent_end, with no further end, completes`, `a second compact re-arms the empty-end rule`; in the budget table the warn policy, a failed compaction, a configured limit, a configured threshold, the threshold normaliser's percent, clamp and zero arms, an absent session file and the one-shot key the guard skips; the remaining envelope arms and text patterns, with three negatives, in the detector table.

## Mutation

54 mutants over `runner.ts` and `sessions.ts`, 54 killed, each by the row named for it. The first reviewer round's own probe (24 extra mutants) left fifteen survivors; the second commit answers thirteen with rows or observer fields, and two are equivalent mutants (the two JSON-shaped overflow patterns are subsumed by the first pattern; the missing-session short circuit cannot fire when the file is absent). Warning and summary prose mutants are declined under the message-pin rule.

## Checks

- `bun test ./tests/oneshot-completion.test.ts`: 4 pass. Package: 340 pass across 52 files.
- `tools/guard --full`: exit 0.
- Two reviewer-test rounds (the first died with its session before reporting; its mutation probe was recovered from disk and answered in the second commit). The second round's four findings (the compact resets, the byte-to-token ceiling, the zero-threshold fallback from both sides, the refusal's session key and the attempt count) are the fourth commit; its five dispositions of equivalent and prose-only mutants were confirmed.

KEN-1241

https://claude.ai/code/session_01TKCoMRNssSfe4qr3ik9VDa
