### PR TITLE
test(KEN-1241): the bridge idle probe as one table read back per exec

### DIFF
--- a/pi-extensions/pi-agents-tmux/tests/idle-stall-probe.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/idle-stall-probe.test.ts
@@ -1,217 +1,105 @@
-// The idle-stall watchdog must consult the bridge isIdle signal
-// instead of returning true unconditionally. Default-busy on any
-// failure so the watchdog skips rather than false-fires.
+// The bridge idle probe as one table over the registry entry, the bridge
+// binary and what `pi-bridge state` does: each row reads back as idle or
+// busy with the reason, the exec it made (arguments, cwd, timeout) and the
+// warnings it logged. Anything but a bridge that answers isIdle reads busy,
+// so the watchdog skips rather than fires.
 
 import assert from "node:assert/strict";
 import test from "node:test";
-
-import {
-	probePaneIdle,
-	BRIDGE_IDLE_PROBE_DEFAULT_TIMEOUT_MS,
-	type ProbePaneIdleDeps,
-} from "../extensions/subagent/idle-stall-probe.js";
+import { probePaneIdle, type ProbePaneIdleDeps, type ProbePaneIdleResult } from "../extensions/subagent/idle-stall-probe.js";
 import type { PaneRegistryEntry, PaneTaskRecord } from "../extensions/subagent/types.js";
 
-function record(): PaneTaskRecord {
-	return {
-		taskId: "task-stall-1",
-		agent: "planner",
-		task: "Plan.",
-		status: "running",
-		createdAt: "2026-05-15T12:00:00.000Z",
-		updatedAt: "2026-05-15T12:00:00.000Z",
-	};
+const RECORD: PaneTaskRecord = { agent: "planner", createdAt: "2026-05-15T12:00:00.000Z", status: "running", task: "Plan.", taskId: "task-stall-1", updatedAt: "2026-05-15T12:00:00.000Z" };
+const ENTRY: PaneRegistryEntry = { agent: "planner", bridgePid: "12345", bridgeSocket: "/tmp/pi-bridge.sock", cwd: "/tmp/cwd", launcherFile: "/tmp/launcher.sh", paneId: "%7", promptFile: "/tmp/prompt.md", sessionFile: "/tmp/session.jsonl", startedAt: "2026-05-15T12:00:00.000Z", windowName: "agent-planner" };
+const BIN = "/usr/bin/pi-bridge";
+
+type Exec = { code: number; stdout: string; stderr: string; error?: unknown };
+interface Opts {
+	record?: PaneTaskRecord;
+	entry?: Partial<PaneRegistryEntry> | null;
+	bin?: string | null;
+	exec?: Exec;
+	throws?: unknown;
+	timeoutMs?: number;
 }
 
-function entry(overrides: Partial<PaneRegistryEntry> = {}): PaneRegistryEntry {
-	return {
-		agent: "planner",
-		paneId: "%7",
-		windowName: "agent-planner",
-		cwd: "/tmp/cwd",
-		sessionFile: "/tmp/session.jsonl",
-		promptFile: "/tmp/prompt.md",
-		launcherFile: "/tmp/launcher.sh",
-		startedAt: "2026-05-15T12:00:00.000Z",
-		bridgePid: "12345",
-		bridgeSocket: "/tmp/pi-bridge.sock",
-		...overrides,
-	};
+// A spawn ENOENT as node raises it: the code, the syscall and the path.
+function spawnEnoent(path = BIN): Error {
+	return Object.assign(new Error(`spawn ${path} ENOENT`), { code: "ENOENT", path, syscall: "spawn" });
+}
+function state(body: unknown): Exec {
+	return { code: 0, stderr: "", stdout: JSON.stringify(body) };
 }
 
-function spawnEnoent(path = "/usr/bin/pi-bridge", overrides: Record<string, unknown> = {}): Error {
-	return Object.assign(new Error(`spawn ${path} ENOENT`), {
-		code: "ENOENT",
-		syscall: "spawn",
-		path,
-		...overrides,
-	});
+// A warning by the failure it names, with what it carried; any other line
+// printed whole.
+function warnTag(line: string): string {
+	const threw = /exec threw: (.*)$/.exec(line);
+	if (threw) return `threw(${JSON.stringify(threw[1])})`;
+	const exit = /pi-bridge state exit (\d+): (.*)$/.exec(line);
+	if (exit) return `exit${exit[1]}(${JSON.stringify(exit[2])})`;
+	return JSON.stringify(line);
 }
 
-function deps(opts: {
-	bridgeBin?: string | null;
-	registry?: Partial<PaneRegistryEntry> | null;
-	execResult?: { code: number; stdout: string; stderr: string; error?: unknown };
-	execError?: unknown;
-}): { d: ProbePaneIdleDeps; calls: { args: string[]; cwd?: string }[]; warnings: string[] } {
-	const calls: { args: string[]; cwd?: string }[] = [];
+async function probeLine(opts: Opts): Promise<string> {
+	const execs: string[] = [];
 	const warnings: string[] = [];
-	const d: ProbePaneIdleDeps = {
-		resolveBridgeBin: async () => {
-			if (opts.bridgeBin === null) return undefined;
-			return opts.bridgeBin ?? "/usr/bin/pi-bridge";
+	const deps: ProbePaneIdleDeps = {
+		resolveBridgeBin: async () => (opts.bin === null ? undefined : (opts.bin ?? BIN)),
+		execCapture: async (command, args, options) => {
+			execs.push(`${command === BIN ? "bin" : JSON.stringify(command)} ${args.join(" ")} cwd=${options?.cwd} timeout=${options?.timeoutMs}`);
+			if (opts.throws !== undefined) throw opts.throws;
+			return opts.exec ?? { code: 0, stderr: "", stdout: "" };
 		},
-		execCapture: async (_command, args, options) => {
-			calls.push({ args, cwd: options?.cwd });
-			if (opts.execError) throw opts.execError;
-			return opts.execResult ?? { code: 0, stdout: "", stderr: "" };
-		},
-		readPaneRegistryEntry: async () => {
-			if (opts.registry === null) return undefined;
-			return entry(opts.registry);
-		},
-		logWarn: (msg) => warnings.push(msg),
+		readPaneRegistryEntry: async () => (opts.entry === null ? undefined : { ...ENTRY, ...opts.entry }),
+		logWarn: (msg) => void warnings.push(msg),
+		...(opts.timeoutMs === undefined ? {} : { timeoutMs: opts.timeoutMs }),
 	};
-	return { d, calls, warnings };
+	let result: ProbePaneIdleResult;
+	try {
+		result = await probePaneIdle(opts.record ?? RECORD, deps);
+	} catch (err) {
+		return `threw(${JSON.stringify((err as Error).message)})`;
+	}
+	return `${result.idle ? "idle" : "busy"}:${result.reason} exec=[${execs.join(";")}]${warnings.length ? ` warn=[${warnings.map(warnTag).join(",")}]` : ""}`;
 }
 
-test("bridge reports isIdle:true -> idle (can fire)", async () => {
-	const { d, calls } = deps({
-		execResult: { code: 0, stdout: JSON.stringify({ data: { isIdle: true } }), stderr: "" },
-	});
-	const result = await probePaneIdle(record(), d);
-	assert.equal(result.idle, true);
-	assert.equal(result.reason, "bridge-idle");
-	assert.equal(calls.length, 1);
-	assert.deepEqual(calls[0]!.args, ["state", "--socket", "/tmp/pi-bridge.sock"]);
-});
+const SOCKET_EXEC = "exec=[bin state --socket /tmp/pi-bridge.sock cwd=/tmp/cwd timeout=2000]";
 
-test("bridge reports isIdle:false -> busy (skip fire)", async () => {
-	const { d } = deps({
-		execResult: { code: 0, stdout: JSON.stringify({ data: { isIdle: false } }), stderr: "" },
-	});
-	const result = await probePaneIdle(record(), d);
-	assert.equal(result.idle, false);
-	assert.equal(result.reason, "bridge-busy");
-});
+// label | deps | expect
+const rows: Array<[string, Opts, string]> = [
+	["the bridge answers idle under its data wrapper", { exec: state({ data: { isIdle: true } }) }, `idle:bridge-idle ${SOCKET_EXEC}`],
+	["the bridge answers busy under its data wrapper", { exec: state({ data: { isIdle: false } }) }, `busy:bridge-busy ${SOCKET_EXEC}`],
+	["a flat state answers idle", { exec: state({ isIdle: true }) }, `idle:bridge-idle ${SOCKET_EXEC}`],
+	["a flat state answers busy", { exec: state({ isIdle: false }) }, `busy:bridge-busy ${SOCKET_EXEC}`],
+	["a data field that is not an object falls back to the flat shape", { exec: state({ data: "v2", isIdle: true }) }, `idle:bridge-idle ${SOCKET_EXEC}`],
+	["an isIdle that is not a boolean is malformed", { exec: state({ data: { isIdle: "true" } }) }, `busy:bridge-malformed-json ${SOCKET_EXEC}`],
+	["a state without isIdle is malformed", { exec: state({ data: {} }) }, `busy:bridge-malformed-json ${SOCKET_EXEC}`],
+	["a JSON null is malformed", { exec: state(null) }, `busy:bridge-malformed-json ${SOCKET_EXEC}`],
+	["output that is not JSON is malformed", { exec: { code: 0, stderr: "", stdout: "not json" } }, `busy:bridge-malformed-json ${SOCKET_EXEC}`],
+	["a spawn ENOENT on the bridge binary is the binary missing, unwarned", { throws: spawnEnoent() }, `busy:bridge-bin-not-found ${SOCKET_EXEC}`],
+	["a non-zero result carrying that ENOENT is the same, unwarned", { exec: { code: 1, error: spawnEnoent(), stderr: "Error: spawn /usr/bin/pi-bridge ENOENT", stdout: "" } }, `busy:bridge-bin-not-found ${SOCKET_EXEC}`],
+	["an ENOENT in prose only is a bridge error and warned", { throws: new Error("spawn /usr/bin/pi-bridge ENOENT") }, `busy:bridge-error ${SOCKET_EXEC} warn=[threw("spawn /usr/bin/pi-bridge ENOENT")]`],
+	["a spawn ENOENT on another path is a bridge error and warned", { throws: spawnEnoent("/tmp/not-pi-bridge") }, `busy:bridge-error ${SOCKET_EXEC} warn=[threw("spawn /tmp/not-pi-bridge ENOENT")]`],
+	["an ENOENT on the binary path from another syscall is a bridge error and warned", { throws: Object.assign(new Error("open /usr/bin/pi-bridge ENOENT"), { code: "ENOENT", path: BIN, syscall: "open" }) }, `busy:bridge-error ${SOCKET_EXEC} warn=[threw("open /usr/bin/pi-bridge ENOENT")]`],
+	["an ENOENT thrown as bare text is a bridge error and warned", { throws: "spawn /usr/bin/pi-bridge ENOENT" }, `busy:bridge-error ${SOCKET_EXEC} warn=[threw("spawn /usr/bin/pi-bridge ENOENT")]`],
+	["any other throw is a bridge error and warned", { throws: new Error("ECONNRESET") }, `busy:bridge-error ${SOCKET_EXEC} warn=[threw("ECONNRESET")]`],
+	["a throw naming a timeout is a bridge timeout and warned", { throws: new Error("pi-bridge state timed out after 2000ms") }, `busy:bridge-timeout ${SOCKET_EXEC} warn=[threw("pi-bridge state timed out after 2000ms")]`],
+	["a throw that is not an Error is printed as text", { throws: "socket closed" }, `busy:bridge-error ${SOCKET_EXEC} warn=[threw("socket closed")]`],
+	["a non-zero exit is a bridge error warned with its stderr", { exec: { code: 1, stderr: "no such session\n", stdout: "" } }, `busy:bridge-error ${SOCKET_EXEC} warn=[exit1("no such session")]`],
+	["a non-zero exit without stderr is warned with its error", { exec: { code: 2, error: new Error("killed by signal"), stderr: "", stdout: "" } }, `busy:bridge-error ${SOCKET_EXEC} warn=[exit2("killed by signal")]`],
+	["a non-zero exit with neither is warned as such", { exec: { code: 3, stderr: "", stdout: "" } }, `busy:bridge-error ${SOCKET_EXEC} warn=[exit3("non-zero exit")]`],
+	["a long stderr is cut at two hundred characters", { exec: { code: 1, stderr: "x".repeat(250), stdout: "" } }, `busy:bridge-error ${SOCKET_EXEC} warn=[exit1(${JSON.stringify("x".repeat(200))})]`],
+	["no registry entry for the agent", { entry: null }, "busy:registry-miss exec=[]"],
+	["a record without an agent", { record: { ...RECORD, agent: "" } }, "busy:registry-miss exec=[]"],
+	["an entry without bridge metadata", { entry: { bridgePid: undefined, bridgeSocket: undefined } }, "busy:bridge-missing-metadata exec=[]"],
+	["no bridge binary", { bin: null }, "busy:bridge-bin-not-found exec=[]"],
+	["a pid alone is probed by pid", { entry: { bridgePid: "9999", bridgeSocket: undefined }, exec: state({ data: { isIdle: true } }) }, "idle:bridge-idle exec=[bin state --pid 9999 cwd=/tmp/cwd timeout=2000]"],
+	["a socket beside a pid wins", { entry: { bridgePid: "9999", bridgeSocket: "/run/b.sock" }, exec: state({ data: { isIdle: true } }) }, "idle:bridge-idle exec=[bin state --socket /run/b.sock cwd=/tmp/cwd timeout=2000]"],
+	["an injected timeout is handed to the exec", { exec: state({ data: { isIdle: true } }), timeoutMs: 500 }, "idle:bridge-idle exec=[bin state --socket /tmp/pi-bridge.sock cwd=/tmp/cwd timeout=500]"],
+	["the resolved binary is the command", { bin: "/opt/pi-bridge", exec: state({ data: { isIdle: true } }) }, 'idle:bridge-idle exec=["/opt/pi-bridge" state --socket /tmp/pi-bridge.sock cwd=/tmp/cwd timeout=2000]'],
+];
 
-test("flat state shape (no .data wrapper) is also accepted", async () => {
-	const { d } = deps({
-		execResult: { code: 0, stdout: JSON.stringify({ isIdle: true }), stderr: "" },
-	});
-	const result = await probePaneIdle(record(), d);
-	assert.equal(result.idle, true);
-});
-
-test("bridge spawn ENOENT (exec throws) -> default-busy without warning toast", async () => {
-	const { d, warnings } = deps({
-		execError: spawnEnoent(),
-	});
-	const result = await probePaneIdle(record(), d);
-	assert.equal(result.idle, false);
-	assert.equal(result.reason, "bridge-bin-not-found");
-	assert.equal(warnings.length, 0);
-});
-
-test("bridge spawn ENOENT (non-zero result) -> default-busy without warning toast", async () => {
-	const { d, warnings } = deps({
-		execResult: { code: 1, stdout: "", stderr: "Error: spawn /usr/bin/pi-bridge ENOENT", error: spawnEnoent() },
-	});
-	const result = await probePaneIdle(record(), d);
-	assert.equal(result.idle, false);
-	assert.equal(result.reason, "bridge-bin-not-found");
-	assert.equal(warnings.length, 0);
-});
-
-test("text-only spawn ENOENT is not treated as expected bridge-bin missing", async () => {
-	const { d, warnings } = deps({
-		execError: new Error("spawn /usr/bin/pi-bridge ENOENT"),
-	});
-	const result = await probePaneIdle(record(), d);
-	assert.equal(result.idle, false);
-	assert.equal(result.reason, "bridge-error");
-	assert.ok(warnings.some((w) => w.includes("exec threw")));
-});
-
-test("structured ENOENT for a different path is logged as a real failure", async () => {
-	const { d, warnings } = deps({
-		execError: spawnEnoent("/tmp/not-pi-bridge"),
-	});
-	const result = await probePaneIdle(record(), d);
-	assert.equal(result.idle, false);
-	assert.equal(result.reason, "bridge-error");
-	assert.ok(warnings.some((w) => w.includes("exec threw")));
-});
-
-test("bridge unreachable (non-ENOENT exec throws) -> default-busy with bridge-error", async () => {
-	const { d, warnings } = deps({
-		execError: new Error("ECONNRESET"),
-	});
-	const result = await probePaneIdle(record(), d);
-	assert.equal(result.idle, false);
-	assert.equal(result.reason, "bridge-error");
-	assert.ok(warnings.some((w) => w.includes("exec threw")));
-});
-
-test("bridge times out -> default-busy with bridge-timeout", async () => {
-	const { d } = deps({ execError: new Error("pi-bridge state timed out after 2000ms") });
-	const result = await probePaneIdle(record(), d);
-	assert.equal(result.idle, false);
-	assert.equal(result.reason, "bridge-timeout");
-});
-
-test("non-zero exit code -> default-busy with bridge-error", async () => {
-	const { d, warnings } = deps({
-		execResult: { code: 1, stdout: "", stderr: "no such session" },
-	});
-	const result = await probePaneIdle(record(), d);
-	assert.equal(result.idle, false);
-	assert.equal(result.reason, "bridge-error");
-	assert.ok(warnings.some((w) => w.includes("exit 1")));
-});
-
-test("malformed JSON output -> default-busy with bridge-malformed-json", async () => {
-	const { d } = deps({
-		execResult: { code: 0, stdout: "not json", stderr: "" },
-	});
-	const result = await probePaneIdle(record(), d);
-	assert.equal(result.idle, false);
-	assert.equal(result.reason, "bridge-malformed-json");
-});
-
-test("registry miss (no entry for agent) -> default-busy with registry-miss", async () => {
-	const { d } = deps({ registry: null });
-	const result = await probePaneIdle(record(), d);
-	assert.equal(result.idle, false);
-	assert.equal(result.reason, "registry-miss");
-});
-
-test("entry missing bridge metadata -> default-busy with bridge-missing-metadata", async () => {
-	const { d } = deps({
-		registry: { bridgePid: undefined, bridgeSocket: undefined },
-	});
-	const result = await probePaneIdle(record(), d);
-	assert.equal(result.idle, false);
-	assert.equal(result.reason, "bridge-missing-metadata");
-});
-
-test("pi-bridge binary not found -> default-busy with bridge-bin-not-found", async () => {
-	const { d } = deps({ bridgeBin: null });
-	const result = await probePaneIdle(record(), d);
-	assert.equal(result.idle, false);
-	assert.equal(result.reason, "bridge-bin-not-found");
-});
-
-test("falls back to --pid when only bridgePid is present", async () => {
-	const { d, calls } = deps({
-		registry: { bridgeSocket: undefined, bridgePid: "9999" },
-		execResult: { code: 0, stdout: JSON.stringify({ data: { isIdle: true } }), stderr: "" },
-	});
-	const result = await probePaneIdle(record(), d);
-	assert.equal(result.idle, true);
-	assert.deepEqual(calls[0]!.args, ["state", "--pid", "9999"]);
-});
-
-test("default timeout constant is 2000ms", () => {
-	assert.equal(BRIDGE_IDLE_PROBE_DEFAULT_TIMEOUT_MS, 2000);
+test("probePaneIdle", async () => {
+	for (const [label, opts, expect] of rows) assert.equal(await probeLine(opts), expect, label);
 });

--- a/pi-extensions/pi-agents-tmux/tests/idle-stall-probe.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/idle-stall-probe.test.ts
@@ -31,13 +31,13 @@ function state(body: unknown): Exec {
 	return { code: 0, stderr: "", stdout: JSON.stringify(body) };
 }
 
-// A warning by the failure it names, with what it carried; any other line
-// printed whole.
+// A warning by the pane it names, the failure and what it carried; any
+// other line printed whole.
 function warnTag(line: string): string {
-	const threw = /exec threw: (.*)$/.exec(line);
-	if (threw) return `threw(${JSON.stringify(threw[1])})`;
-	const exit = /pi-bridge state exit (\d+): (.*)$/.exec(line);
-	if (exit) return `exit${exit[1]}(${JSON.stringify(exit[2])})`;
+	const threw = /^probePaneIdle: (\S+) exec threw: (.*)$/.exec(line);
+	if (threw) return `${threw[1]} threw(${JSON.stringify(threw[2])})`;
+	const exit = /^probePaneIdle: (\S+) pi-bridge state exit (\d+): (.*)$/.exec(line);
+	if (exit) return `${exit[1]} exit${exit[2]}(${JSON.stringify(exit[3])})`;
 	return JSON.stringify(line);
 }
 
@@ -47,7 +47,7 @@ async function probeLine(opts: Opts): Promise<string> {
 	const deps: ProbePaneIdleDeps = {
 		resolveBridgeBin: async () => (opts.bin === null ? undefined : (opts.bin ?? BIN)),
 		execCapture: async (command, args, options) => {
-			execs.push(`${command === BIN ? "bin" : JSON.stringify(command)} ${args.join(" ")} cwd=${options?.cwd} timeout=${options?.timeoutMs}`);
+			execs.push(`${command === BIN ? "bin" : JSON.stringify(command)} ${args.join(",")} cwd=${options?.cwd} timeout=${options?.timeoutMs}`);
 			if (opts.throws !== undefined) throw opts.throws;
 			return opts.exec ?? { code: 0, stderr: "", stdout: "" };
 		},
@@ -64,7 +64,7 @@ async function probeLine(opts: Opts): Promise<string> {
 	return `${result.idle ? "idle" : "busy"}:${result.reason} exec=[${execs.join(";")}]${warnings.length ? ` warn=[${warnings.map(warnTag).join(",")}]` : ""}`;
 }
 
-const SOCKET_EXEC = "exec=[bin state --socket /tmp/pi-bridge.sock cwd=/tmp/cwd timeout=2000]";
+const SOCKET_EXEC = "exec=[bin state,--socket,/tmp/pi-bridge.sock cwd=/tmp/cwd timeout=2000]";
 
 // label | deps | expect
 const rows: Array<[string, Opts, string]> = [
@@ -79,25 +79,24 @@ const rows: Array<[string, Opts, string]> = [
 	["output that is not JSON is malformed", { exec: { code: 0, stderr: "", stdout: "not json" } }, `busy:bridge-malformed-json ${SOCKET_EXEC}`],
 	["a spawn ENOENT on the bridge binary is the binary missing, unwarned", { throws: spawnEnoent() }, `busy:bridge-bin-not-found ${SOCKET_EXEC}`],
 	["a non-zero result carrying that ENOENT is the same, unwarned", { exec: { code: 1, error: spawnEnoent(), stderr: "Error: spawn /usr/bin/pi-bridge ENOENT", stdout: "" } }, `busy:bridge-bin-not-found ${SOCKET_EXEC}`],
-	["an ENOENT in prose only is a bridge error and warned", { throws: new Error("spawn /usr/bin/pi-bridge ENOENT") }, `busy:bridge-error ${SOCKET_EXEC} warn=[threw("spawn /usr/bin/pi-bridge ENOENT")]`],
-	["a spawn ENOENT on another path is a bridge error and warned", { throws: spawnEnoent("/tmp/not-pi-bridge") }, `busy:bridge-error ${SOCKET_EXEC} warn=[threw("spawn /tmp/not-pi-bridge ENOENT")]`],
-	["an ENOENT on the binary path from another syscall is a bridge error and warned", { throws: Object.assign(new Error("open /usr/bin/pi-bridge ENOENT"), { code: "ENOENT", path: BIN, syscall: "open" }) }, `busy:bridge-error ${SOCKET_EXEC} warn=[threw("open /usr/bin/pi-bridge ENOENT")]`],
-	["an ENOENT thrown as bare text is a bridge error and warned", { throws: "spawn /usr/bin/pi-bridge ENOENT" }, `busy:bridge-error ${SOCKET_EXEC} warn=[threw("spawn /usr/bin/pi-bridge ENOENT")]`],
-	["any other throw is a bridge error and warned", { throws: new Error("ECONNRESET") }, `busy:bridge-error ${SOCKET_EXEC} warn=[threw("ECONNRESET")]`],
-	["a throw naming a timeout is a bridge timeout and warned", { throws: new Error("pi-bridge state timed out after 2000ms") }, `busy:bridge-timeout ${SOCKET_EXEC} warn=[threw("pi-bridge state timed out after 2000ms")]`],
-	["a throw that is not an Error is printed as text", { throws: "socket closed" }, `busy:bridge-error ${SOCKET_EXEC} warn=[threw("socket closed")]`],
-	["a non-zero exit is a bridge error warned with its stderr", { exec: { code: 1, stderr: "no such session\n", stdout: "" } }, `busy:bridge-error ${SOCKET_EXEC} warn=[exit1("no such session")]`],
-	["a non-zero exit without stderr is warned with its error", { exec: { code: 2, error: new Error("killed by signal"), stderr: "", stdout: "" } }, `busy:bridge-error ${SOCKET_EXEC} warn=[exit2("killed by signal")]`],
-	["a non-zero exit with neither is warned as such", { exec: { code: 3, stderr: "", stdout: "" } }, `busy:bridge-error ${SOCKET_EXEC} warn=[exit3("non-zero exit")]`],
-	["a long stderr is cut at two hundred characters", { exec: { code: 1, stderr: "x".repeat(250), stdout: "" } }, `busy:bridge-error ${SOCKET_EXEC} warn=[exit1(${JSON.stringify("x".repeat(200))})]`],
+	["an ENOENT in prose only is a bridge error and warned", { throws: new Error("spawn /usr/bin/pi-bridge ENOENT") }, `busy:bridge-error ${SOCKET_EXEC} warn=[planner threw("spawn /usr/bin/pi-bridge ENOENT")]`],
+	["a spawn ENOENT on another path is a bridge error and warned", { throws: spawnEnoent("/tmp/not-pi-bridge") }, `busy:bridge-error ${SOCKET_EXEC} warn=[planner threw("spawn /tmp/not-pi-bridge ENOENT")]`],
+	["an ENOENT on the binary path from another syscall is a bridge error and warned", { throws: Object.assign(new Error("open /usr/bin/pi-bridge ENOENT"), { code: "ENOENT", path: BIN, syscall: "open" }) }, `busy:bridge-error ${SOCKET_EXEC} warn=[planner threw("open /usr/bin/pi-bridge ENOENT")]`],
+	["an ENOENT thrown as bare text is a bridge error and warned", { throws: "spawn /usr/bin/pi-bridge ENOENT" }, `busy:bridge-error ${SOCKET_EXEC} warn=[planner threw("spawn /usr/bin/pi-bridge ENOENT")]`],
+	["any other throw is a bridge error and warned", { throws: new Error("ECONNRESET") }, `busy:bridge-error ${SOCKET_EXEC} warn=[planner threw("ECONNRESET")]`],
+	["a throw naming a timeout is a bridge timeout and warned", { throws: new Error("pi-bridge state timed out after 2000ms") }, `busy:bridge-timeout ${SOCKET_EXEC} warn=[planner threw("pi-bridge state timed out after 2000ms")]`],
+	["a non-zero exit is a bridge error warned with its stderr", { exec: { code: 1, stderr: "no such session\n", stdout: "" } }, `busy:bridge-error ${SOCKET_EXEC} warn=[planner exit1("no such session")]`],
+	["a non-zero exit without stderr is warned with its error", { exec: { code: 2, error: new Error("killed by signal"), stderr: "", stdout: "" } }, `busy:bridge-error ${SOCKET_EXEC} warn=[planner exit2("killed by signal")]`],
+	["a non-zero exit with neither is warned as such", { exec: { code: 3, stderr: "", stdout: "" } }, `busy:bridge-error ${SOCKET_EXEC} warn=[planner exit3("non-zero exit")]`],
+	["a long stderr is cut at two hundred characters", { exec: { code: 1, stderr: "x".repeat(250), stdout: "" } }, `busy:bridge-error ${SOCKET_EXEC} warn=[planner exit1(${JSON.stringify("x".repeat(200))})]`],
 	["no registry entry for the agent", { entry: null }, "busy:registry-miss exec=[]"],
 	["a record without an agent", { record: { ...RECORD, agent: "" } }, "busy:registry-miss exec=[]"],
 	["an entry without bridge metadata", { entry: { bridgePid: undefined, bridgeSocket: undefined } }, "busy:bridge-missing-metadata exec=[]"],
 	["no bridge binary", { bin: null }, "busy:bridge-bin-not-found exec=[]"],
-	["a pid alone is probed by pid", { entry: { bridgePid: "9999", bridgeSocket: undefined }, exec: state({ data: { isIdle: true } }) }, "idle:bridge-idle exec=[bin state --pid 9999 cwd=/tmp/cwd timeout=2000]"],
-	["a socket beside a pid wins", { entry: { bridgePid: "9999", bridgeSocket: "/run/b.sock" }, exec: state({ data: { isIdle: true } }) }, "idle:bridge-idle exec=[bin state --socket /run/b.sock cwd=/tmp/cwd timeout=2000]"],
-	["an injected timeout is handed to the exec", { exec: state({ data: { isIdle: true } }), timeoutMs: 500 }, "idle:bridge-idle exec=[bin state --socket /tmp/pi-bridge.sock cwd=/tmp/cwd timeout=500]"],
-	["the resolved binary is the command", { bin: "/opt/pi-bridge", exec: state({ data: { isIdle: true } }) }, 'idle:bridge-idle exec=["/opt/pi-bridge" state --socket /tmp/pi-bridge.sock cwd=/tmp/cwd timeout=2000]'],
+	["a pid alone is probed by pid", { entry: { bridgePid: "9999", bridgeSocket: undefined }, exec: state({ data: { isIdle: true } }) }, "idle:bridge-idle exec=[bin state,--pid,9999 cwd=/tmp/cwd timeout=2000]"],
+	["a socket beside a pid wins", { entry: { bridgePid: "9999", bridgeSocket: "/run/b.sock" }, exec: state({ data: { isIdle: true } }) }, "idle:bridge-idle exec=[bin state,--socket,/run/b.sock cwd=/tmp/cwd timeout=2000]"],
+	["an injected timeout is handed to the exec", { exec: state({ data: { isIdle: true } }), timeoutMs: 500 }, "idle:bridge-idle exec=[bin state,--socket,/tmp/pi-bridge.sock cwd=/tmp/cwd timeout=500]"],
+	["the resolved binary is the command", { bin: "/opt/pi-bridge", exec: state({ data: { isIdle: true } }) }, 'idle:bridge-idle exec=["/opt/pi-bridge" state,--socket,/tmp/pi-bridge.sock cwd=/tmp/cwd timeout=2000]'],
 ];
 
 test("probePaneIdle", async () => {


### PR DESCRIPTION
Reshapes `pi-extensions/pi-agents-tmux/tests/idle-stall-probe.test.ts` to code-quality § Tests: sixteen cases, each two or three asserts on the result bit and reason with the exec arguments read on one of them, become one table of twenty-nine rows. Each row reads back idle or busy with the reason, the exec it made (the resolved binary, the arguments, the pane's cwd, the timeout handed down) and the warnings by the pane they name, the failure and what it carried.

## Folded and deleted cases, with the surviving row

| Former case | Surviving row |
|---|---|
| bridge reports isIdle:true / isIdle:false | `the bridge answers idle under its data wrapper`, `the bridge answers busy under its data wrapper` (the exec line on every row, not one) |
| flat state shape is also accepted | `a flat state answers idle`; new `a flat state answers busy`, `a data field that is not an object falls back to the flat shape`, `an isIdle that is not a boolean is malformed`, `a state without isIdle is malformed`, `a JSON null is malformed` |
| bridge spawn ENOENT (exec throws / non-zero result) | `a spawn ENOENT on the bridge binary is the binary missing, unwarned`, `a non-zero result carrying that ENOENT is the same, unwarned` |
| text-only spawn ENOENT; structured ENOENT for a different path | `an ENOENT in prose only is a bridge error and warned`, `a spawn ENOENT on another path is a bridge error and warned`; new `an ENOENT on the binary path from another syscall is a bridge error and warned`, `an ENOENT thrown as bare text is a bridge error and warned` (two survivors of the first batch) |
| bridge unreachable (non-ENOENT exec throws) | `any other throw is a bridge error and warned` |
| bridge times out | `a throw naming a timeout is a bridge timeout and warned` |
| non-zero exit code | `a non-zero exit is a bridge error warned with its stderr`; new `a non-zero exit without stderr is warned with its error`, `a non-zero exit with neither is warned as such`, `a long stderr is cut at two hundred characters` |
| malformed JSON output | `output that is not JSON is malformed` |
| registry miss | `no registry entry for the agent`; new `a record without an agent` |
| entry missing bridge metadata | `an entry without bridge metadata` |
| pi-bridge binary not found | `no bridge binary` |
| falls back to --pid when only bridgePid is present | `a pid alone is probed by pid`; new `a socket beside a pid wins` |
| default timeout constant is 2000ms | deleted: it pinned the constant against its own literal. Every exec line reads `timeout=2000`, and `an injected timeout is handed to the exec` reads `timeout=500`; a mutant moving the constant reddens the first row |

New with no former case: `the resolved binary is the command`.

## Recorded, not fixed

- The `/timeout|timed out/i` classifier's one-word arm and case-insensitivity match nothing a shipped producer emits (index.ts emits exactly `pi-bridge state timed out after Nms`); the reviewer round suggests narrowing the regex rather than a row.
- `logWarn` is optional on the deps but the only production caller always supplies it.
- The `!parsed ||` clause in parseIsIdle is an equivalent mutant: a null state throws inside the same try and the catch returns undefined.

## Mutation

35 mutants over `idle-stall-probe.ts`, 34 killed, each by the row named for it; the survivor is the equivalent mutant above. The first batch left two more (the spawn syscall unchecked, ENOENT prose in a non-object throw); two rows answer them. The reviewer round's probe found two more (the arguments as one packed string, the warnings naming the task); the second commit answers both.

## Checks

- `bun test ./tests/idle-stall-probe.test.ts`: 1 pass (29 rows). Package: 282 pass.
- `tools/guard --full`: exit 0.
- One reviewer-test round: accepted with two blockers and three suggestions; the blockers and the deletion applied, the two production suggestions recorded above.

KEN-1241

https://claude.ai/code/session_01D6wb5KLMMnPv7njYdSSTzL
