### PR TITLE
docs(KEN-564): preflight --help owns each lane's contract

### DIFF
--- a/.agents/skills/preflight/README.md
+++ b/.agents/skills/preflight/README.md
@@ -8,7 +8,7 @@ A checker for changed files in a repository. It detects script errors, broken do
 kendex add vanillagreencom/kendex --skill preflight
 ```
 
-Requires Git, awk and standard POSIX tools. Bash 3.2 is supported. Install shellcheck for its shell checks, jq for JSON checks, and taplo or Python with tomllib for TOML checks. A needed check with a missing tool is named as not run. The final result lists skipped checks without changing the exit status.
+Requires Git, awk and standard POSIX tools. Bash 3.2 is supported. Install shellcheck for its shell checks, jq for JSON checks, and taplo or Python with tomllib for TOML checks. A check whose tool is missing is reported as not run.
 
 ## Features
 
@@ -19,7 +19,7 @@ Requires Git, awk and standard POSIX tools. Bash 3.2 is supported. Install shell
 
 ## How it works
 
-The checker selects changed files from Git. Each check reads the file types it supports and reports only on lines the change added. Findings identify the file, location and check. Your validation command or Git hook uses the exit result to stop on a finding. Run `preflight --help` for each check, its scope and the exit codes.
+The checker selects changed files from Git. Each check reads the file types it supports and judges what the change added. Findings identify the file, location and check. Your validation command or Git hook uses the exit result to stop on a finding. Run `preflight --help` for each check, its scope and the exit codes.
 
 ## Settings
 
@@ -27,7 +27,7 @@ The checker selects changed files from Git. Each check reads the file types it s
 
 `PREFLIGHT_MIGRATION_GLOBS` names migrations whose recorded checksum makes an edit unsafe.
 
-Each setting replaces the shipped set, which [references/lanes.md](references/lanes.md) lists. Set these values in `kendex.settings.toml` under `[env]`, in `.kendex/settings.toml`, in `.env.local`, or in the process environment. Later sources take priority. `--base REF` sets the comparison point. `--repo PATH` runs against another checkout.
+Set either value in `kendex.settings.toml` under `[env]`, in `.kendex/settings.toml`, in `.env.local`, or in the process environment. [references/lanes.md](references/lanes.md) lists the shipped sets.
 
 ## Wiring
 

--- a/.agents/skills/preflight/README.md
+++ b/.agents/skills/preflight/README.md
@@ -8,7 +8,7 @@ A checker for changed files in a repository. It detects script errors, broken do
 kendex add vanillagreencom/kendex --skill preflight
 ```
 
-Requires Git, awk and standard POSIX tools. Bash 3.2 is supported. Install shellcheck for its shell checks, jq for JSON checks, and taplo or Python with tomllib for TOML checks. A check whose tool is missing is reported as not run.
+Requires Git, awk and standard POSIX tools. Bash 3.2 is supported. Install shellcheck for its shell checks, jq for JSON checks, and taplo or Python with tomllib for TOML checks. A check that a change needs, whose tool is missing, is reported as not run.
 
 ## Features
 
@@ -19,7 +19,7 @@ Requires Git, awk and standard POSIX tools. Bash 3.2 is supported. Install shell
 
 ## How it works
 
-The checker selects changed files from Git. Each check reads the file types it supports and judges what the change added. Findings identify the file, location and check. Your validation command or Git hook uses the exit result to stop on a finding. Run `preflight --help` for each check, its scope and the exit codes.
+The checker selects changed files from Git. Each check reads the file types it supports. Findings identify the file, location and check. Your validation command or Git hook uses the exit result to stop on a finding. Run `preflight --help` for each check, its scope and the exit codes.
 
 ## Settings
 

--- a/.agents/skills/preflight/README.md
+++ b/.agents/skills/preflight/README.md
@@ -19,15 +19,15 @@ Requires Git, awk and standard POSIX tools. Bash 3.2 is supported. Install shell
 
 ## How it works
 
-The checker selects changed files from Git. Each check reads the file types it supports. Findings identify the file, location and check. Your validation command or Git hook uses the exit result to stop on a finding.
+The checker selects changed files from Git. Each check reads the file types it supports and reports only on lines the change added. Findings identify the file, location and check. Your validation command or Git hook uses the exit result to stop on a finding. Run `preflight --help` for each check, its scope and the exit codes.
 
 ## Settings
 
-`PREFLIGHT_JSONC_GLOBS` names `.json` files whose producer permits comments. Its default covers tsconfig, jsconfig, `.vscode`, `.devcontainer`, and VS Code `*-color-theme.json` files. The `.jsonc` suffix needs no setting.
+`PREFLIGHT_JSONC_GLOBS` names `.json` files whose producer permits comments. The `.jsonc` suffix needs no setting.
 
-`PREFLIGHT_MIGRATION_GLOBS` names migrations whose recorded checksum makes an edit unsafe. Its default covers the versioned refinery and Flyway paths in [references/lanes.md](references/lanes.md).
+`PREFLIGHT_MIGRATION_GLOBS` names migrations whose recorded checksum makes an edit unsafe.
 
-Set these values in `kendex.settings.toml` under `[env]`, in `.kendex/settings.toml`, in `.env.local`, or in the process environment. Later sources take priority. `--base REF` sets the comparison point. `--repo PATH` runs against another checkout.
+Each setting replaces the shipped set, which [references/lanes.md](references/lanes.md) lists. Set these values in `kendex.settings.toml` under `[env]`, in `.kendex/settings.toml`, in `.env.local`, or in the process environment. Later sources take priority. `--base REF` sets the comparison point. `--repo PATH` runs against another checkout.
 
 ## Wiring
 

--- a/.agents/skills/preflight/SKILL.md
+++ b/.agents/skills/preflight/SKILL.md
@@ -31,6 +31,6 @@ Run preflight in the validate step, before the project's own validation command.
 .agents/skills/preflight/scripts/preflight --all        # every tracked file, every line
 ```
 
-Correct the line a finding names; never widen a lane's exclusions to clear it.
+Fix what a finding reports; never widen a lane's exclusions to clear it.
 
 Lanes, scopes, settings, output and exit codes are in `preflight --help`. Diff construction and the `unwired-suite`, `data-syntax` and `applied-migration-edited` glob grammars are [references/lanes.md](references/lanes.md). Hook and CI wiring is [README.md](README.md) § Wiring.

--- a/.agents/skills/preflight/SKILL.md
+++ b/.agents/skills/preflight/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: preflight
 description: "Load to run, tune, or debug preflight."
-summary: "Diff-scoped deterministic pre-review checks: shell parse and shellcheck errors, fail-open bash, unwired test suites, untrapped scratch dirs, hardcoded temp paths, dead path citations, edited applied migrations, and malformed JSON or TOML."
+summary: "Diff-scoped fail-only checks over one change: shell safety, unwired suites, scratch directories, temp paths, dead path citations, applied migrations and data syntax."
 license: MIT
 user-invocable: true
 metadata:
@@ -23,7 +23,7 @@ Problems with a kendex-owned skill go through `kendex report`; check ownership i
 
 # Preflight
 
-Every lane is diff-scoped and fail-only, with no warnings tier: a finding lands only on a line this change ADDED, and a lane that cannot decide reports no finding. What a lane may read: [references/lanes.md](references/lanes.md).
+Run preflight in the validate step, before the project's own validation command.
 
 ```bash
 .agents/skills/preflight/scripts/preflight              # vs the default branch's merge base
@@ -31,29 +31,6 @@ Every lane is diff-scoped and fail-only, with no warnings tier: a finding lands 
 .agents/skills/preflight/scripts/preflight --all        # every tracked file, every line
 ```
 
-`--base REF` sets the comparison point; `--repo PATH` runs against another checkout. The default base is `origin/HEAD`, then `origin/main`, then `main`; if none resolve, the run fails closed.
+A finding names the line the change added. Correct that line; never widen a lane's exclusions to clear it.
 
-## Lanes
-
-| Lane | Fails on | Tool |
-|---|---|---|
-| `shell-syntax` | A changed shell file bash cannot parse. | `bash -n` |
-| `shellcheck-errors` | Any error-severity finding, anywhere in a changed shell file. | shellcheck |
-| `masked-returns` | SC2155/SC2311 on an added line, a declaration whose exit status hides the command's. | shellcheck |
-| `fail-open` | An `=$(mktemp …)` assignment added to a file without errexit; a new script that never sets `-e`, `-u` and `pipefail`, unless git records it non-executable under a `scripts/lib/` tree, where nothing can run it and the preamble would set the sourcing caller's mode instead; an added `grep`/`find`/`git`/`jq`/`diff`/`cmp`, at a command position, whose status is discarded by `\|\| true` (or `\|\| :`). The same text quoted inside a message is not a finding. | built in |
-| `unwired-suite` | A new suite file that no tracked runner invokes: `tests/*.test.sh`, `tests/test-*.sh`, `*.test.ts`, `*.test.js`, `*.test.mjs`, fixtures excluded. Runner set and wiring grammar: [references/lanes.md](references/lanes.md). | built in |
-| `mktemp-trap` | A new shell file with an added `mktemp` invocation and no `trap … EXIT` anywhere in it. The invocation is the word at a command position, not named in a comment or a string. | built in |
-| `hardcoded-temp-path` | An added directory-creating call taking a literal absolute temp path (`/tmp/…`, `/var/tmp/…`) as (part of) its first argument: `mkdtemp`/`mkdir` and their `Sync` variants (JS/TS), `mkdtemp`/`makedirs`/`mkdir` (Python), `create_dir_all` (Rust), and a shell `mkdir -p` at a command position. Not the shape: the literal as a value (config field, fixture string, path nothing creates), a `$TMPDIR`-derived path, or a commented-out call. | built in |
-| `docs-cited-paths` | An added backticked path in a `.md` file, inside a directory the repo really has and the doc's own subtree, that names nothing tracked or on disk. Also the reverse: an added source line citing a `.md` path that names nothing tracked or on disk. URL spans and double-quoted strings are stripped first; data files (JSON/TOML/YAML/lock), test-named files, and installed-artifact subtrees (`.agents/` and the harness dirs' skills/agents/hooks/rules/instructions/packages/kendex trees) are out of scope; the same directory guards apply. | built in |
-| `applied-migration-edited` | A path the MERGE BASE carries, changed, deleted or renamed, matching a configured migrations glob; the correction is a new migration, never an edit here. `PREFLIGHT_MIGRATION_GLOBS` replaces the default set (refinery and Flyway shapes only). Glob semantics and what is not the shape: [references/lanes.md](references/lanes.md). | built in |
-| `data-syntax` | A changed strict `.json` or `.toml` file no parser accepts. `.jsonc` uses its file kind. `PREFLIGHT_JSONC_GLOBS` names `.json` paths whose producer uses JSON with comments. | jq, taplo or python3 |
-
-Shell files are `*.sh`, `*.bash`, or anything with a `sh`/`bash` shebang. Deleted files, and files under `tests/` or `fixtures/`, are out of scope for the lanes that judge whole files; `unwired-suite` is the exception.
-
-Installed-artifact subtrees (`.agents/` and the harness dirs' skills/agents/hooks/rules/instructions/packages/kendex trees) are out of scope for `masked-returns`, `fail-open`, `unwired-suite`, `mktemp-trap`, `docs-cited-paths`. `shell-syntax`, `shellcheck-errors`, `hardcoded-temp-path`, `applied-migration-edited`, `data-syntax` stay on there. A `prompts/` or `commands/` tree under a harness dir keeps every lane. When a relevant file needs an unavailable tool, the output names the lane as not run and lists it in the final result. Data-syntax details identify JSON or TOML. Other applicable checks still run, and missing optional tools do not change the exit status.
-
-Exit codes: `0` clean, `1` findings, `2` usage/environment error (bad flag, not a git repository, unresolvable base). Findings print as `path:line: [lane] message`, line `0` for a whole-file finding.
-
-## Wiring
-
-Dev agents run `preflight` in the validate step, **before** the project's own validation command. The commit-guards pre-commit chain runs `preflight --staged` itself, and CI runs `preflight --base origin/<default>` on a COMMITTED install. Hook and CI wiring: [README.md](README.md) § Wiring.
+Lanes, scopes, settings, output and exit codes are in `preflight --help`. Diff construction and the `unwired-suite`, `data-syntax` and `applied-migration-edited` glob grammars are [references/lanes.md](references/lanes.md). Hook and CI wiring is [README.md](README.md) § Wiring.

--- a/.agents/skills/preflight/SKILL.md
+++ b/.agents/skills/preflight/SKILL.md
@@ -31,6 +31,6 @@ Run preflight in the validate step, before the project's own validation command.
 .agents/skills/preflight/scripts/preflight --all        # every tracked file, every line
 ```
 
-A finding names the line the change added. Correct that line; never widen a lane's exclusions to clear it.
+Correct the line a finding names; never widen a lane's exclusions to clear it.
 
 Lanes, scopes, settings, output and exit codes are in `preflight --help`. Diff construction and the `unwired-suite`, `data-syntax` and `applied-migration-edited` glob grammars are [references/lanes.md](references/lanes.md). Hook and CI wiring is [README.md](README.md) § Wiring.

--- a/.agents/skills/preflight/references/lanes.md
+++ b/.agents/skills/preflight/references/lanes.md
@@ -1,20 +1,12 @@
 # Lane details
 
-The lane table and the scope rules are [SKILL.md](../SKILL.md) § Lanes. This file holds what does not fit a table cell: how the diff is taken, the `unwired-suite` wiring grammar, and why `applied-migration-edited` ships the default glob set it does.
+What each lane fails on, its exclusions, the settings and the exit codes are in `preflight --help`. This file holds the grammars that do not fit a help entry: how the diff is taken, how `unwired-suite` reads a runner, and which globs `data-syntax` and `applied-migration-edited` ship.
 
-## What a lane may read
+## Diff construction
 
-CONTENT decides which lines a lane may read, never an attribute. The diff is taken with `--text`, so a `.gitattributes` `-diff` or `binary` row cannot withhold the lines a change adds, and a file whose own bytes are binary contributes no lines in any scope.
+Content decides which lines a lane may read, never an attribute. The diff is taken with `--text`, so a `.gitattributes` `-diff` or `binary` row cannot withhold the lines a change adds. A file whose own bytes are binary contributes no lines in any scope.
 
-The default and `--base` scopes include every non-ignored untracked file as a new file; `--staged` sees only the index.
-
-## `data-syntax` JSONC paths
-
-The `.jsonc` suffix declares JSON with comments. Some producers keep `.json` instead. `PREFLIGHT_JSONC_GLOBS` replaces the path set for those files. The default keeps tsconfig, jsconfig, `.vscode`, `.devcontainer`, and VS Code's `*-color-theme.json` convention. A leading `**/` matches at any depth. A `*` does not cross a path component.
-
-The lane has no JSONC parser. It leaves these files to the producer that declares the dialect. Strict `.json` files still pass through `jq`.
-
-During `--staged`, shared settings come from the index. A new untracked shared settings file cannot change the commit verdict. The personal `.env.local` file remains a runtime input.
+The default and `--base` scopes include every non-ignored untracked file as a new file. `--staged` sees only the index, and reads shared settings from the index too, so a new untracked settings file cannot change the commit verdict. The personal `.env.local` file stays a runtime input in every scope.
 
 ## `unwired-suite` wiring grammar
 
@@ -24,14 +16,22 @@ Wiring is the suite named outright, a path-shaped glob its path satisfies, a dir
 
 A command position means directly, chained after `;`/`&`/`|`, behind a directly preceding `npx`/`pnpm`/`yarn`/`exec`/`dlx`, with `NAME=value` assignment words (values plain or quoted) allowed before the runner word.
 
-A comment (full-line or trailing), dependency key, or package path is not an invocation, and neither is a prose mention, except a colon-opened value beginning with the runner word, accepted erring quiet. A path-prefixed binary (`node_modules/.bin/vitest`) is not recognized, and a pinned explicit `include`/`testMatch` is not evaluated. An empty or unreadable runner set leaves the lane quiet.
+A comment (full-line or trailing), dependency key, or package path is not an invocation, and neither is a prose mention, except a colon-opened value beginning with the runner word, accepted erring quiet. A path-prefixed binary (`node_modules/.bin/vitest`) is not recognized, and a pinned explicit `include`/`testMatch` is not evaluated.
+
+## Glob semantics
+
+A leading `**/` matches at any depth and is the only depth crossing, so a `*` never reaches past its own path component. Both glob settings replace their shipped set rather than adding to it, and an empty value leaves the lane quiet.
+
+## `data-syntax` JSONC paths
+
+The `.jsonc` suffix declares JSON with comments. Some producers keep `.json` instead, and `PREFLIGHT_JSONC_GLOBS` names those paths. The shipped set is `**/tsconfig*.json`, `**/jsconfig*.json`, `**/.vscode/*.json`, `**/.devcontainer/*.json` and `**/*-color-theme.json`, which is VS Code's convention plus the two TypeScript manifests.
+
+The lane has no JSONC parser and leaves these files to the producer that declares the dialect.
 
 ## `applied-migration-edited` glob set
 
-refinery and Flyway record a checksum over a versioned migration's name and text and refuse to run against a database whose recorded checksum moved.
+refinery and Flyway record a checksum over a versioned migration's name and text, and refuse to run against a database whose recorded checksum moved.
 
-`PREFLIGHT_MIGRATION_GLOBS` replaces the set, default `**/migrations/V*__*.sql` and `**/db/migration/V*__*.sql`, which is those two runners' filename shape under the two directory names they use, Flyway's own being the singular one, and nothing else: a runner recording an applied version without a checksum (golang-migrate, Goose, Alembic, Django) reopens its database after an edit, so naming its files would hard-fail a legitimate change. Every other layout is opt-in, sqlx and Flyway repeatable migrations (`R__*`) included.
+The shipped set is `**/migrations/V*__*.sql` and `**/db/migration/V*__*.sql`: those two runners' filename shape under the two directory names they use, Flyway's own being the singular one, and nothing else. A runner that records an applied version without a checksum (golang-migrate, Goose, Alembic, Django) reopens its database after an edit, so naming its files would hard-fail a legitimate change. Every other layout is opt-in through `PREFLIGHT_MIGRATION_GLOBS`, sqlx and Flyway repeatable migrations (`R__*`) included.
 
-A leading `**/` matches at any depth and is the only depth crossing, so a `*` never reaches past its own path component.
-
-Not the shape: a migration added at a new version, one this branch added and then corrected (the staged scope diffs against HEAD and is qualified against the base for exactly that), and a mode change, which moves no text. `--all` reads every tracked line as added and a repository with no base to read answers nothing, so both stay quiet, as does an empty value.
+A migration this branch added and then corrected is not the shape: the staged scope diffs against HEAD and qualifies each hit against the base for exactly that.

--- a/.agents/skills/preflight/references/lanes.md
+++ b/.agents/skills/preflight/references/lanes.md
@@ -10,7 +10,7 @@ The default and `--base` scopes include every non-ignored untracked file as a ne
 
 ## `unwired-suite` wiring grammar
 
-Runners are `.github/workflows/*.yml`, `tools/validate*`, `scripts/validate*`, `package.json`, `Makefile`, `justfile`, and any `run-all.sh`.
+Runners are `.github/workflows/*.yml`, `tools/validate*`, `scripts/validate*`, `package.json`, `Makefile`, `justfile`, and any `run-all.sh`. They are collected from tracked and untracked paths alike: an untracked runner is in scope exactly when an untracked suite is, so a workflow added beside its suite wires it before either is committed.
 
 Wiring is the suite named outright, a path-shaped glob its path satisfies, a directory it lives under, a manifest below the repo root whose subtree holds it, a runner beside it globbing its own directory, or a runner invoking bare `vitest`/`jest` at a command position whose default include glob covers the suite (`*.test.ts`/`js`/`mjs`) under the directory the runner runs from.
 
@@ -20,7 +20,7 @@ A comment (full-line or trailing), dependency key, or package path is not an inv
 
 ## Glob semantics
 
-A leading `**/` matches at any depth and is the only depth crossing, so a `*` never reaches past its own path component. Both glob settings replace their shipped set rather than adding to it, and an empty value leaves the lane quiet.
+A leading `**/` matches at any depth and is the only depth crossing, so a `*` never reaches past its own path component. Both glob settings read this grammar.
 
 ## `data-syntax` JSONC paths
 
@@ -32,6 +32,6 @@ The lane has no JSONC parser and leaves these files to the producer that declare
 
 refinery and Flyway record a checksum over a versioned migration's name and text, and refuse to run against a database whose recorded checksum moved.
 
-The shipped set is `**/migrations/V*__*.sql` and `**/db/migration/V*__*.sql`: those two runners' filename shape under the two directory names they use, Flyway's own being the singular one, and nothing else. A runner that records an applied version without a checksum (golang-migrate, Goose, Alembic, Django) reopens its database after an edit, so naming its files would hard-fail a legitimate change. Every other layout is opt-in through `PREFLIGHT_MIGRATION_GLOBS`, sqlx and Flyway repeatable migrations (`R__*`) included.
+The shipped set is `**/migrations/V*__*.sql` and `**/db/migration/V*__*.sql`: those two runners' filename shape under the two directory names they use, Flyway's own being the singular one, and nothing else. A runner that records an applied version without a checksum (golang-migrate, Goose, Alembic, Django) reopens its database after an edit, so naming its files would hard-fail a legitimate change. Every other layout is opt-in, sqlx and Flyway repeatable migrations (`R__*`) included.
 
 A migration this branch added and then corrected is not the shape: the staged scope diffs against HEAD and qualifies each hit against the base for exactly that.

--- a/.agents/skills/preflight/scripts/preflight
+++ b/.agents/skills/preflight/scripts/preflight
@@ -40,7 +40,9 @@ and there is no warnings tier.
 Scopes:
   (default)     the merge base of HEAD and the default branch (origin/HEAD,
                 else origin/main, else main), plus every non-ignored
-                untracked file as a new file with every line added
+                untracked file as a new file with every line added. Where
+                none of the three resolves the run is an environment error,
+                never a clean result
   --staged      the index only (pre-commit scope)
   --base REF    the merge base of HEAD and REF, plus untracked files
   --all         every tracked file, every line treated as added
@@ -54,15 +56,16 @@ Lanes:
                   syntax error has already spoken for it.
   masked-returns  SC2155 or SC2311 on an added line: a declaration whose own
                   exit status hides the command's.
-  fail-open       an =$(mktemp ...) assignment added to a file that never
-                  sets errexit; a new shell file that does not set -e, -u and
-                  pipefail, unless git records it non-executable under a
-                  scripts/lib/ tree, where it is sourced and the preamble
-                  would set the calling shell's mode instead; an added grep,
-                  find, git, jq, diff or cmp at a command position whose
+  fail-open       three shapes. Mktemp assignment: an =$(mktemp ...)
+                  assignment added to a file that never sets errexit. Strict
+                  mode: a new shell file that does not set -e, -u and
+                  pipefail, unless it is non-executable under a scripts/lib/
+                  tree, where it is sourced and the preamble would set the
+                  calling shell's mode instead. Swallowed status: an added
+                  grep, find, git, jq, diff or cmp at a command position whose
                   status a trailing || true (or || :) discards. The same text
                   quoted inside a message is not the shape.
-  unwired-suite   a new suite file no tracked runner invokes. Suites are
+  unwired-suite   a new suite file no runner invokes. Suites are
                   tests/*.test.sh, tests/test-*.sh, *.test.ts, *.test.js and
                   *.test.mjs; a file under a fixtures/ directory is material a
                   suite reads, never a suite. A runner set that is empty or
@@ -72,14 +75,16 @@ Lanes:
                   a command position, not one named in a comment or a string.
                   Reported once per file.
   hardcoded-temp-path
-                  an added directory-creating call taking a literal absolute
-                  temp path as (part of) its first argument: mkdtemp and mkdir
-                  and their Sync variants (JS/TS), mkdtemp, makedirs and mkdir
-                  (Python), create_dir_all (Rust), and a shell mkdir -p at a
-                  command position. The literals are /tmp and /var/tmp. Not
-                  the shape: the literal as a value (a config field, a fixture
-                  string, a path nothing creates), a TMPDIR-derived path, and
-                  a commented-out call.
+                  an added directory-creating call whose first argument opens
+                  a quoted path under the /tmp or /var/tmp root: mkdtemp and
+                  mkdir and their Sync variants (JS/TS), mkdtemp, makedirs and
+                  mkdir (Python), create_dir_all (Rust), and a shell mkdir -p
+                  at a command position. The mkdtemp pair always creates, so a
+                  quoted bare root in any of its arguments is the same shape.
+                  Plain mkdir of the bare root is not, since creating a root
+                  that exists is a no-op. Nor is the literal as a value (a
+                  config field, a fixture string, a path nothing creates), a
+                  TMPDIR-derived path, or a commented-out call.
   docs-cited-paths
                   in a changed .md file, an added backticked path naming
                   nothing tracked or on disk, judged only inside a directory
@@ -106,9 +111,12 @@ Scope rules:
   shebang. A file whose content git reads as binary contributes no lines to
   any lane; the whole-file lanes still see its path. A deleted path leaves the
   change set, and applied-migration-edited reads it from the diff instead.
-  Under a tests/ or fixtures/ tree, and in a test-named source file,
-  fail-open, mktemp-trap and the source-file direction of docs-cited-paths
-  stand down; those trees set their own rules.
+  A tests/ or fixtures/ tree sets its own rules: mktemp-trap, the source-file
+  direction of docs-cited-paths, and the strict-mode and swallowed-status
+  shapes of fail-open stand down there. In a test-named source file (tests.rs,
+  *_test.*, *_tests.*, *.test.*, *.spec.*, test_*) only the swallowed-status
+  shape and that same docs-cited-paths direction stand down. The mktemp
+  assignment shape of fail-open is judged in every tree.
   In an installed-artifact subtree (.agents/ and the harness directories'
   skills, agents, hooks, rules, instructions, packages and kendex trees)
   masked-returns, fail-open, unwired-suite, mktemp-trap and the source-file
@@ -119,9 +127,11 @@ Scope rules:
 Settings (env > .env.local > .kendex/settings.toml > kendex.settings.toml
 [env] > default):
   PREFLIGHT_JSONC_GLOBS      .json paths whose producer writes JSON with
-                             comments; replaces the shipped set
-  PREFLIGHT_MIGRATION_GLOBS  the migrations applied-migration-edited freezes;
-                             replaces the shipped set
+                             comments
+  PREFLIGHT_MIGRATION_GLOBS  the migrations applied-migration-edited freezes
+
+Each replaces its shipped set rather than adding to it, and an empty value
+leaves its lane quiet.
 
 Optional tools: shellcheck for shellcheck-errors and masked-returns, jq for
 JSON, taplo or python3 with tomllib for TOML. A needed lane whose tool is

--- a/.agents/skills/preflight/scripts/preflight
+++ b/.agents/skills/preflight/scripts/preflight
@@ -76,11 +76,12 @@ Lanes:
                   Reported once per file.
   hardcoded-temp-path
                   an added directory-creating call whose first argument opens
-                  a quoted path under the /tmp or /var/tmp root: mkdtemp and
-                  mkdir and their Sync variants (JS/TS), mkdtemp, makedirs and
-                  mkdir (Python), create_dir_all (Rust), and a shell mkdir -p
-                  at a command position. The mkdtemp pair always creates, so a
-                  quoted bare root in any of its arguments is the same shape.
+                  a path under the /tmp or /var/tmp root: mkdtemp and mkdir
+                  and their Sync variants (JS/TS), mkdtemp, makedirs and mkdir
+                  (Python), create_dir_all (Rust), each with the path quoted,
+                  and a shell mkdir -p at a command position, where the quotes
+                  are optional. The mkdtemp pair always creates, so a quoted
+                  bare root in any of its arguments is the same shape.
                   Plain mkdir of the bare root is not, since creating a root
                   that exists is a no-op. Nor is the literal as a value (a
                   config field, a fixture string, a path nothing creates), a

--- a/.agents/skills/preflight/scripts/preflight
+++ b/.agents/skills/preflight/scripts/preflight
@@ -33,22 +33,105 @@ usage() {
   cat <<'EOF'
 usage: preflight [--staged | --base REF | --all] [--repo PATH]
 
-Diff-scoped deterministic checks. Default scope is the merge base of HEAD
-and the default branch (origin/HEAD, else origin/main, else main), plus
-non-ignored untracked files; --staged sees only the index.
+Diff-scoped deterministic checks over one change. A line-scoped lane reports
+only on a line the change added, a lane that cannot decide reports nothing,
+and there is no warnings tier.
 
-  --staged      staged changes only (pre-commit scope)
-  --base REF    changes since the merge base of HEAD and REF, plus every
-                non-ignored untracked file (a new file, every line added)
+Scopes:
+  (default)     the merge base of HEAD and the default branch (origin/HEAD,
+                else origin/main, else main), plus every non-ignored
+                untracked file as a new file with every line added
+  --staged      the index only (pre-commit scope)
+  --base REF    the merge base of HEAD and REF, plus untracked files
   --all         every tracked file, every line treated as added
   --repo PATH   run against the repository containing PATH (default: cwd)
 
-Lanes: shell-syntax, shellcheck-errors, masked-returns, fail-open,
-unwired-suite, mktemp-trap, hardcoded-temp-path, docs-cited-paths,
-applied-migration-edited, data-syntax.
+Lanes:
+  shell-syntax    a changed shell file bash cannot parse.
+  shellcheck-errors
+                  an error-severity shellcheck finding anywhere in a changed
+                  shell file. Runs only where bash parsed the file, since a
+                  syntax error has already spoken for it.
+  masked-returns  SC2155 or SC2311 on an added line: a declaration whose own
+                  exit status hides the command's.
+  fail-open       an =$(mktemp ...) assignment added to a file that never
+                  sets errexit; a new shell file that does not set -e, -u and
+                  pipefail, unless git records it non-executable under a
+                  scripts/lib/ tree, where it is sourced and the preamble
+                  would set the calling shell's mode instead; an added grep,
+                  find, git, jq, diff or cmp at a command position whose
+                  status a trailing || true (or || :) discards. The same text
+                  quoted inside a message is not the shape.
+  unwired-suite   a new suite file no tracked runner invokes. Suites are
+                  tests/*.test.sh, tests/test-*.sh, *.test.ts, *.test.js and
+                  *.test.mjs; a file under a fixtures/ directory is material a
+                  suite reads, never a suite. A runner set that is empty or
+                  that this tool could not read whole leaves the lane quiet.
+  mktemp-trap     a new shell file with an added mktemp invocation and no
+                  trap ... EXIT anywhere in it. The invocation is the word at
+                  a command position, not one named in a comment or a string.
+                  Reported once per file.
+  hardcoded-temp-path
+                  an added directory-creating call taking a literal absolute
+                  temp path as (part of) its first argument: mkdtemp and mkdir
+                  and their Sync variants (JS/TS), mkdtemp, makedirs and mkdir
+                  (Python), create_dir_all (Rust), and a shell mkdir -p at a
+                  command position. The literals are /tmp and /var/tmp. Not
+                  the shape: the literal as a value (a config field, a fixture
+                  string, a path nothing creates), a TMPDIR-derived path, and
+                  a commented-out call.
+  docs-cited-paths
+                  in a changed .md file, an added backticked path naming
+                  nothing tracked or on disk, judged only inside a directory
+                  the repo really has and inside the doc's own top-level
+                  directory (a root-level doc owns the repo). In a changed
+                  source file, an added line citing a .md path that names
+                  nothing tracked or on disk; URL spans and quoted strings are
+                  stripped first. Data files (JSON, TOML, YAML, lock) and
+                  test-named files cite paths as working material and are out
+                  of scope.
+  applied-migration-edited
+                  a path the merge base carries, edited, deleted or renamed,
+                  matching a configured migrations glob. Its recorded checksum
+                  no longer matches, so the correction is a new migration and
+                  never an edit here. A mode change moves no text and is not
+                  the shape. The lane is quiet under --all and where no base
+                  resolves.
+  data-syntax     a changed strict .json or .toml file no parser accepts. The
+                  .jsonc file kind declares JSON with comments and is left to
+                  its producer.
 
-Needed checks with unavailable optional tools are reported by lane name.
-The final result lists those lanes without changing the exit status.
+Scope rules:
+  A shell file is *.sh, *.bash, or a file whose first line is a sh or bash
+  shebang. A file whose content git reads as binary contributes no lines to
+  any lane; the whole-file lanes still see its path. A deleted path leaves the
+  change set, and applied-migration-edited reads it from the diff instead.
+  Under a tests/ or fixtures/ tree, and in a test-named source file,
+  fail-open, mktemp-trap and the source-file direction of docs-cited-paths
+  stand down; those trees set their own rules.
+  In an installed-artifact subtree (.agents/ and the harness directories'
+  skills, agents, hooks, rules, instructions, packages and kendex trees)
+  masked-returns, fail-open, unwired-suite, mktemp-trap and the source-file
+  direction of docs-cited-paths stand down. shell-syntax, shellcheck-errors,
+  hardcoded-temp-path, applied-migration-edited and data-syntax stay on. A
+  prompts/ or commands/ tree under a harness directory keeps every lane.
+
+Settings (env > .env.local > .kendex/settings.toml > kendex.settings.toml
+[env] > default):
+  PREFLIGHT_JSONC_GLOBS      .json paths whose producer writes JSON with
+                             comments; replaces the shipped set
+  PREFLIGHT_MIGRATION_GLOBS  the migrations applied-migration-edited freezes;
+                             replaces the shipped set
+
+Optional tools: shellcheck for shellcheck-errors and masked-returns, jq for
+JSON, taplo or python3 with tomllib for TOML. A needed lane whose tool is
+unavailable prints as not run and is listed in the final result, which does
+not change the exit status.
+
+Output: one finding per line, path:line: [lane] message, line 0 for a
+whole-file finding, then a result line counting findings and changed files.
+
+Diff construction and the glob grammars: references/lanes.md.
 
 Exit codes: 0 clean; 1 findings; 2 usage/environment error.
 EOF

--- a/.agents/skills/preflight/scripts/preflight
+++ b/.agents/skills/preflight/scripts/preflight
@@ -130,8 +130,9 @@ Settings (env > .env.local > .kendex/settings.toml > kendex.settings.toml
                              comments
   PREFLIGHT_MIGRATION_GLOBS  the migrations applied-migration-edited freezes
 
-Each replaces its shipped set rather than adding to it, and an empty value
-leaves its lane quiet.
+Each replaces its shipped set rather than adding to it. Emptied, the JSONC
+set exempts nothing and every .json file is parsed as strict JSON, while an
+empty migration set leaves applied-migration-edited quiet.
 
 Optional tools: shellcheck for shellcheck-errors and masked-returns, jq for
 JSON, taplo or python3 with tomllib for TOML. A needed lane whose tool is

--- a/skills/preflight/README.md
+++ b/skills/preflight/README.md
@@ -8,7 +8,7 @@ A checker for changed files in a repository. It detects script errors, broken do
 kendex add vanillagreencom/kendex --skill preflight
 ```
 
-Requires Git, awk and standard POSIX tools. Bash 3.2 is supported. Install shellcheck for its shell checks, jq for JSON checks, and taplo or Python with tomllib for TOML checks. A needed check with a missing tool is named as not run. The final result lists skipped checks without changing the exit status.
+Requires Git, awk and standard POSIX tools. Bash 3.2 is supported. Install shellcheck for its shell checks, jq for JSON checks, and taplo or Python with tomllib for TOML checks. A check whose tool is missing is reported as not run.
 
 ## Features
 
@@ -19,7 +19,7 @@ Requires Git, awk and standard POSIX tools. Bash 3.2 is supported. Install shell
 
 ## How it works
 
-The checker selects changed files from Git. Each check reads the file types it supports and reports only on lines the change added. Findings identify the file, location and check. Your validation command or Git hook uses the exit result to stop on a finding. Run `preflight --help` for each check, its scope and the exit codes.
+The checker selects changed files from Git. Each check reads the file types it supports and judges what the change added. Findings identify the file, location and check. Your validation command or Git hook uses the exit result to stop on a finding. Run `preflight --help` for each check, its scope and the exit codes.
 
 ## Settings
 
@@ -27,7 +27,7 @@ The checker selects changed files from Git. Each check reads the file types it s
 
 `PREFLIGHT_MIGRATION_GLOBS` names migrations whose recorded checksum makes an edit unsafe.
 
-Each setting replaces the shipped set, which [references/lanes.md](references/lanes.md) lists. Set these values in `kendex.settings.toml` under `[env]`, in `.kendex/settings.toml`, in `.env.local`, or in the process environment. Later sources take priority. `--base REF` sets the comparison point. `--repo PATH` runs against another checkout.
+Set either value in `kendex.settings.toml` under `[env]`, in `.kendex/settings.toml`, in `.env.local`, or in the process environment. [references/lanes.md](references/lanes.md) lists the shipped sets.
 
 ## Wiring
 

--- a/skills/preflight/README.md
+++ b/skills/preflight/README.md
@@ -8,7 +8,7 @@ A checker for changed files in a repository. It detects script errors, broken do
 kendex add vanillagreencom/kendex --skill preflight
 ```
 
-Requires Git, awk and standard POSIX tools. Bash 3.2 is supported. Install shellcheck for its shell checks, jq for JSON checks, and taplo or Python with tomllib for TOML checks. A check whose tool is missing is reported as not run.
+Requires Git, awk and standard POSIX tools. Bash 3.2 is supported. Install shellcheck for its shell checks, jq for JSON checks, and taplo or Python with tomllib for TOML checks. A check that a change needs, whose tool is missing, is reported as not run.
 
 ## Features
 
@@ -19,7 +19,7 @@ Requires Git, awk and standard POSIX tools. Bash 3.2 is supported. Install shell
 
 ## How it works
 
-The checker selects changed files from Git. Each check reads the file types it supports and judges what the change added. Findings identify the file, location and check. Your validation command or Git hook uses the exit result to stop on a finding. Run `preflight --help` for each check, its scope and the exit codes.
+The checker selects changed files from Git. Each check reads the file types it supports. Findings identify the file, location and check. Your validation command or Git hook uses the exit result to stop on a finding. Run `preflight --help` for each check, its scope and the exit codes.
 
 ## Settings
 

--- a/skills/preflight/README.md
+++ b/skills/preflight/README.md
@@ -19,15 +19,15 @@ Requires Git, awk and standard POSIX tools. Bash 3.2 is supported. Install shell
 
 ## How it works
 
-The checker selects changed files from Git. Each check reads the file types it supports. Findings identify the file, location and check. Your validation command or Git hook uses the exit result to stop on a finding.
+The checker selects changed files from Git. Each check reads the file types it supports and reports only on lines the change added. Findings identify the file, location and check. Your validation command or Git hook uses the exit result to stop on a finding. Run `preflight --help` for each check, its scope and the exit codes.
 
 ## Settings
 
-`PREFLIGHT_JSONC_GLOBS` names `.json` files whose producer permits comments. Its default covers tsconfig, jsconfig, `.vscode`, `.devcontainer`, and VS Code `*-color-theme.json` files. The `.jsonc` suffix needs no setting.
+`PREFLIGHT_JSONC_GLOBS` names `.json` files whose producer permits comments. The `.jsonc` suffix needs no setting.
 
-`PREFLIGHT_MIGRATION_GLOBS` names migrations whose recorded checksum makes an edit unsafe. Its default covers the versioned refinery and Flyway paths in [references/lanes.md](references/lanes.md).
+`PREFLIGHT_MIGRATION_GLOBS` names migrations whose recorded checksum makes an edit unsafe.
 
-Set these values in `kendex.settings.toml` under `[env]`, in `.kendex/settings.toml`, in `.env.local`, or in the process environment. Later sources take priority. `--base REF` sets the comparison point. `--repo PATH` runs against another checkout.
+Each setting replaces the shipped set, which [references/lanes.md](references/lanes.md) lists. Set these values in `kendex.settings.toml` under `[env]`, in `.kendex/settings.toml`, in `.env.local`, or in the process environment. Later sources take priority. `--base REF` sets the comparison point. `--repo PATH` runs against another checkout.
 
 ## Wiring
 

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -23,6 +23,6 @@ Run preflight in the validate step, before the project's own validation command.
 .agents/skills/preflight/scripts/preflight --all        # every tracked file, every line
 ```
 
-Correct the line a finding names; never widen a lane's exclusions to clear it.
+Fix what a finding reports; never widen a lane's exclusions to clear it.
 
 Lanes, scopes, settings, output and exit codes are in `preflight --help`. Diff construction and the `unwired-suite`, `data-syntax` and `applied-migration-edited` glob grammars are [references/lanes.md](references/lanes.md). Hook and CI wiring is [README.md](README.md) § Wiring.

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: preflight
 description: "Load to run, tune, or debug preflight."
-summary: "Diff-scoped deterministic pre-review checks: shell parse and shellcheck errors, fail-open bash, unwired test suites, untrapped scratch dirs, hardcoded temp paths, dead path citations, edited applied migrations, and malformed JSON or TOML."
+summary: "Diff-scoped fail-only checks over one change: shell safety, unwired suites, scratch directories, temp paths, dead path citations, applied migrations and data syntax."
 license: MIT
 user-invocable: true
 metadata:
@@ -15,7 +15,7 @@ tags: [review, testing]
 
 # Preflight
 
-Every lane is diff-scoped and fail-only, with no warnings tier: a finding lands only on a line this change ADDED, and a lane that cannot decide reports no finding. What a lane may read: [references/lanes.md](references/lanes.md).
+Run preflight in the validate step, before the project's own validation command.
 
 ```bash
 .agents/skills/preflight/scripts/preflight              # vs the default branch's merge base
@@ -23,29 +23,6 @@ Every lane is diff-scoped and fail-only, with no warnings tier: a finding lands 
 .agents/skills/preflight/scripts/preflight --all        # every tracked file, every line
 ```
 
-`--base REF` sets the comparison point; `--repo PATH` runs against another checkout. The default base is `origin/HEAD`, then `origin/main`, then `main`; if none resolve, the run fails closed.
+A finding names the line the change added. Correct that line; never widen a lane's exclusions to clear it.
 
-## Lanes
-
-| Lane | Fails on | Tool |
-|---|---|---|
-| `shell-syntax` | A changed shell file bash cannot parse. | `bash -n` |
-| `shellcheck-errors` | Any error-severity finding, anywhere in a changed shell file. | shellcheck |
-| `masked-returns` | SC2155/SC2311 on an added line, a declaration whose exit status hides the command's. | shellcheck |
-| `fail-open` | An `=$(mktemp …)` assignment added to a file without errexit; a new script that never sets `-e`, `-u` and `pipefail`, unless git records it non-executable under a `scripts/lib/` tree, where nothing can run it and the preamble would set the sourcing caller's mode instead; an added `grep`/`find`/`git`/`jq`/`diff`/`cmp`, at a command position, whose status is discarded by `\|\| true` (or `\|\| :`). The same text quoted inside a message is not a finding. | built in |
-| `unwired-suite` | A new suite file that no tracked runner invokes: `tests/*.test.sh`, `tests/test-*.sh`, `*.test.ts`, `*.test.js`, `*.test.mjs`, fixtures excluded. Runner set and wiring grammar: [references/lanes.md](references/lanes.md). | built in |
-| `mktemp-trap` | A new shell file with an added `mktemp` invocation and no `trap … EXIT` anywhere in it. The invocation is the word at a command position, not named in a comment or a string. | built in |
-| `hardcoded-temp-path` | An added directory-creating call taking a literal absolute temp path (`/tmp/…`, `/var/tmp/…`) as (part of) its first argument: `mkdtemp`/`mkdir` and their `Sync` variants (JS/TS), `mkdtemp`/`makedirs`/`mkdir` (Python), `create_dir_all` (Rust), and a shell `mkdir -p` at a command position. Not the shape: the literal as a value (config field, fixture string, path nothing creates), a `$TMPDIR`-derived path, or a commented-out call. | built in |
-| `docs-cited-paths` | An added backticked path in a `.md` file, inside a directory the repo really has and the doc's own subtree, that names nothing tracked or on disk. Also the reverse: an added source line citing a `.md` path that names nothing tracked or on disk. URL spans and double-quoted strings are stripped first; data files (JSON/TOML/YAML/lock), test-named files, and installed-artifact subtrees (`.agents/` and the harness dirs' skills/agents/hooks/rules/instructions/packages/kendex trees) are out of scope; the same directory guards apply. | built in |
-| `applied-migration-edited` | A path the MERGE BASE carries, changed, deleted or renamed, matching a configured migrations glob; the correction is a new migration, never an edit here. `PREFLIGHT_MIGRATION_GLOBS` replaces the default set (refinery and Flyway shapes only). Glob semantics and what is not the shape: [references/lanes.md](references/lanes.md). | built in |
-| `data-syntax` | A changed strict `.json` or `.toml` file no parser accepts. `.jsonc` uses its file kind. `PREFLIGHT_JSONC_GLOBS` names `.json` paths whose producer uses JSON with comments. | jq, taplo or python3 |
-
-Shell files are `*.sh`, `*.bash`, or anything with a `sh`/`bash` shebang. Deleted files, and files under `tests/` or `fixtures/`, are out of scope for the lanes that judge whole files; `unwired-suite` is the exception.
-
-Installed-artifact subtrees (`.agents/` and the harness dirs' skills/agents/hooks/rules/instructions/packages/kendex trees) are out of scope for `masked-returns`, `fail-open`, `unwired-suite`, `mktemp-trap`, `docs-cited-paths`. `shell-syntax`, `shellcheck-errors`, `hardcoded-temp-path`, `applied-migration-edited`, `data-syntax` stay on there. A `prompts/` or `commands/` tree under a harness dir keeps every lane. When a relevant file needs an unavailable tool, the output names the lane as not run and lists it in the final result. Data-syntax details identify JSON or TOML. Other applicable checks still run, and missing optional tools do not change the exit status.
-
-Exit codes: `0` clean, `1` findings, `2` usage/environment error (bad flag, not a git repository, unresolvable base). Findings print as `path:line: [lane] message`, line `0` for a whole-file finding.
-
-## Wiring
-
-Dev agents run `preflight` in the validate step, **before** the project's own validation command. The commit-guards pre-commit chain runs `preflight --staged` itself, and CI runs `preflight --base origin/<default>` on a COMMITTED install. Hook and CI wiring: [README.md](README.md) § Wiring.
+Lanes, scopes, settings, output and exit codes are in `preflight --help`. Diff construction and the `unwired-suite`, `data-syntax` and `applied-migration-edited` glob grammars are [references/lanes.md](references/lanes.md). Hook and CI wiring is [README.md](README.md) § Wiring.

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -23,6 +23,6 @@ Run preflight in the validate step, before the project's own validation command.
 .agents/skills/preflight/scripts/preflight --all        # every tracked file, every line
 ```
 
-A finding names the line the change added. Correct that line; never widen a lane's exclusions to clear it.
+Correct the line a finding names; never widen a lane's exclusions to clear it.
 
 Lanes, scopes, settings, output and exit codes are in `preflight --help`. Diff construction and the `unwired-suite`, `data-syntax` and `applied-migration-edited` glob grammars are [references/lanes.md](references/lanes.md). Hook and CI wiring is [README.md](README.md) § Wiring.

--- a/skills/preflight/references/lanes.md
+++ b/skills/preflight/references/lanes.md
@@ -1,20 +1,12 @@
 # Lane details
 
-The lane table and the scope rules are [SKILL.md](../SKILL.md) § Lanes. This file holds what does not fit a table cell: how the diff is taken, the `unwired-suite` wiring grammar, and why `applied-migration-edited` ships the default glob set it does.
+What each lane fails on, its exclusions, the settings and the exit codes are in `preflight --help`. This file holds the grammars that do not fit a help entry: how the diff is taken, how `unwired-suite` reads a runner, and which globs `data-syntax` and `applied-migration-edited` ship.
 
-## What a lane may read
+## Diff construction
 
-CONTENT decides which lines a lane may read, never an attribute. The diff is taken with `--text`, so a `.gitattributes` `-diff` or `binary` row cannot withhold the lines a change adds, and a file whose own bytes are binary contributes no lines in any scope.
+Content decides which lines a lane may read, never an attribute. The diff is taken with `--text`, so a `.gitattributes` `-diff` or `binary` row cannot withhold the lines a change adds. A file whose own bytes are binary contributes no lines in any scope.
 
-The default and `--base` scopes include every non-ignored untracked file as a new file; `--staged` sees only the index.
-
-## `data-syntax` JSONC paths
-
-The `.jsonc` suffix declares JSON with comments. Some producers keep `.json` instead. `PREFLIGHT_JSONC_GLOBS` replaces the path set for those files. The default keeps tsconfig, jsconfig, `.vscode`, `.devcontainer`, and VS Code's `*-color-theme.json` convention. A leading `**/` matches at any depth. A `*` does not cross a path component.
-
-The lane has no JSONC parser. It leaves these files to the producer that declares the dialect. Strict `.json` files still pass through `jq`.
-
-During `--staged`, shared settings come from the index. A new untracked shared settings file cannot change the commit verdict. The personal `.env.local` file remains a runtime input.
+The default and `--base` scopes include every non-ignored untracked file as a new file. `--staged` sees only the index, and reads shared settings from the index too, so a new untracked settings file cannot change the commit verdict. The personal `.env.local` file stays a runtime input in every scope.
 
 ## `unwired-suite` wiring grammar
 
@@ -24,14 +16,22 @@ Wiring is the suite named outright, a path-shaped glob its path satisfies, a dir
 
 A command position means directly, chained after `;`/`&`/`|`, behind a directly preceding `npx`/`pnpm`/`yarn`/`exec`/`dlx`, with `NAME=value` assignment words (values plain or quoted) allowed before the runner word.
 
-A comment (full-line or trailing), dependency key, or package path is not an invocation, and neither is a prose mention, except a colon-opened value beginning with the runner word, accepted erring quiet. A path-prefixed binary (`node_modules/.bin/vitest`) is not recognized, and a pinned explicit `include`/`testMatch` is not evaluated. An empty or unreadable runner set leaves the lane quiet.
+A comment (full-line or trailing), dependency key, or package path is not an invocation, and neither is a prose mention, except a colon-opened value beginning with the runner word, accepted erring quiet. A path-prefixed binary (`node_modules/.bin/vitest`) is not recognized, and a pinned explicit `include`/`testMatch` is not evaluated.
+
+## Glob semantics
+
+A leading `**/` matches at any depth and is the only depth crossing, so a `*` never reaches past its own path component. Both glob settings replace their shipped set rather than adding to it, and an empty value leaves the lane quiet.
+
+## `data-syntax` JSONC paths
+
+The `.jsonc` suffix declares JSON with comments. Some producers keep `.json` instead, and `PREFLIGHT_JSONC_GLOBS` names those paths. The shipped set is `**/tsconfig*.json`, `**/jsconfig*.json`, `**/.vscode/*.json`, `**/.devcontainer/*.json` and `**/*-color-theme.json`, which is VS Code's convention plus the two TypeScript manifests.
+
+The lane has no JSONC parser and leaves these files to the producer that declares the dialect.
 
 ## `applied-migration-edited` glob set
 
-refinery and Flyway record a checksum over a versioned migration's name and text and refuse to run against a database whose recorded checksum moved.
+refinery and Flyway record a checksum over a versioned migration's name and text, and refuse to run against a database whose recorded checksum moved.
 
-`PREFLIGHT_MIGRATION_GLOBS` replaces the set, default `**/migrations/V*__*.sql` and `**/db/migration/V*__*.sql`, which is those two runners' filename shape under the two directory names they use, Flyway's own being the singular one, and nothing else: a runner recording an applied version without a checksum (golang-migrate, Goose, Alembic, Django) reopens its database after an edit, so naming its files would hard-fail a legitimate change. Every other layout is opt-in, sqlx and Flyway repeatable migrations (`R__*`) included.
+The shipped set is `**/migrations/V*__*.sql` and `**/db/migration/V*__*.sql`: those two runners' filename shape under the two directory names they use, Flyway's own being the singular one, and nothing else. A runner that records an applied version without a checksum (golang-migrate, Goose, Alembic, Django) reopens its database after an edit, so naming its files would hard-fail a legitimate change. Every other layout is opt-in through `PREFLIGHT_MIGRATION_GLOBS`, sqlx and Flyway repeatable migrations (`R__*`) included.
 
-A leading `**/` matches at any depth and is the only depth crossing, so a `*` never reaches past its own path component.
-
-Not the shape: a migration added at a new version, one this branch added and then corrected (the staged scope diffs against HEAD and is qualified against the base for exactly that), and a mode change, which moves no text. `--all` reads every tracked line as added and a repository with no base to read answers nothing, so both stay quiet, as does an empty value.
+A migration this branch added and then corrected is not the shape: the staged scope diffs against HEAD and qualifies each hit against the base for exactly that.

--- a/skills/preflight/references/lanes.md
+++ b/skills/preflight/references/lanes.md
@@ -10,7 +10,7 @@ The default and `--base` scopes include every non-ignored untracked file as a ne
 
 ## `unwired-suite` wiring grammar
 
-Runners are `.github/workflows/*.yml`, `tools/validate*`, `scripts/validate*`, `package.json`, `Makefile`, `justfile`, and any `run-all.sh`.
+Runners are `.github/workflows/*.yml`, `tools/validate*`, `scripts/validate*`, `package.json`, `Makefile`, `justfile`, and any `run-all.sh`. They are collected from tracked and untracked paths alike: an untracked runner is in scope exactly when an untracked suite is, so a workflow added beside its suite wires it before either is committed.
 
 Wiring is the suite named outright, a path-shaped glob its path satisfies, a directory it lives under, a manifest below the repo root whose subtree holds it, a runner beside it globbing its own directory, or a runner invoking bare `vitest`/`jest` at a command position whose default include glob covers the suite (`*.test.ts`/`js`/`mjs`) under the directory the runner runs from.
 
@@ -20,7 +20,7 @@ A comment (full-line or trailing), dependency key, or package path is not an inv
 
 ## Glob semantics
 
-A leading `**/` matches at any depth and is the only depth crossing, so a `*` never reaches past its own path component. Both glob settings replace their shipped set rather than adding to it, and an empty value leaves the lane quiet.
+A leading `**/` matches at any depth and is the only depth crossing, so a `*` never reaches past its own path component. Both glob settings read this grammar.
 
 ## `data-syntax` JSONC paths
 
@@ -32,6 +32,6 @@ The lane has no JSONC parser and leaves these files to the producer that declare
 
 refinery and Flyway record a checksum over a versioned migration's name and text, and refuse to run against a database whose recorded checksum moved.
 
-The shipped set is `**/migrations/V*__*.sql` and `**/db/migration/V*__*.sql`: those two runners' filename shape under the two directory names they use, Flyway's own being the singular one, and nothing else. A runner that records an applied version without a checksum (golang-migrate, Goose, Alembic, Django) reopens its database after an edit, so naming its files would hard-fail a legitimate change. Every other layout is opt-in through `PREFLIGHT_MIGRATION_GLOBS`, sqlx and Flyway repeatable migrations (`R__*`) included.
+The shipped set is `**/migrations/V*__*.sql` and `**/db/migration/V*__*.sql`: those two runners' filename shape under the two directory names they use, Flyway's own being the singular one, and nothing else. A runner that records an applied version without a checksum (golang-migrate, Goose, Alembic, Django) reopens its database after an edit, so naming its files would hard-fail a legitimate change. Every other layout is opt-in, sqlx and Flyway repeatable migrations (`R__*`) included.
 
 A migration this branch added and then corrected is not the shape: the staged scope diffs against HEAD and qualifies each hit against the base for exactly that.

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -40,7 +40,9 @@ and there is no warnings tier.
 Scopes:
   (default)     the merge base of HEAD and the default branch (origin/HEAD,
                 else origin/main, else main), plus every non-ignored
-                untracked file as a new file with every line added
+                untracked file as a new file with every line added. Where
+                none of the three resolves the run is an environment error,
+                never a clean result
   --staged      the index only (pre-commit scope)
   --base REF    the merge base of HEAD and REF, plus untracked files
   --all         every tracked file, every line treated as added
@@ -54,15 +56,16 @@ Lanes:
                   syntax error has already spoken for it.
   masked-returns  SC2155 or SC2311 on an added line: a declaration whose own
                   exit status hides the command's.
-  fail-open       an =$(mktemp ...) assignment added to a file that never
-                  sets errexit; a new shell file that does not set -e, -u and
-                  pipefail, unless git records it non-executable under a
-                  scripts/lib/ tree, where it is sourced and the preamble
-                  would set the calling shell's mode instead; an added grep,
-                  find, git, jq, diff or cmp at a command position whose
+  fail-open       three shapes. Mktemp assignment: an =$(mktemp ...)
+                  assignment added to a file that never sets errexit. Strict
+                  mode: a new shell file that does not set -e, -u and
+                  pipefail, unless it is non-executable under a scripts/lib/
+                  tree, where it is sourced and the preamble would set the
+                  calling shell's mode instead. Swallowed status: an added
+                  grep, find, git, jq, diff or cmp at a command position whose
                   status a trailing || true (or || :) discards. The same text
                   quoted inside a message is not the shape.
-  unwired-suite   a new suite file no tracked runner invokes. Suites are
+  unwired-suite   a new suite file no runner invokes. Suites are
                   tests/*.test.sh, tests/test-*.sh, *.test.ts, *.test.js and
                   *.test.mjs; a file under a fixtures/ directory is material a
                   suite reads, never a suite. A runner set that is empty or
@@ -72,14 +75,16 @@ Lanes:
                   a command position, not one named in a comment or a string.
                   Reported once per file.
   hardcoded-temp-path
-                  an added directory-creating call taking a literal absolute
-                  temp path as (part of) its first argument: mkdtemp and mkdir
-                  and their Sync variants (JS/TS), mkdtemp, makedirs and mkdir
-                  (Python), create_dir_all (Rust), and a shell mkdir -p at a
-                  command position. The literals are /tmp and /var/tmp. Not
-                  the shape: the literal as a value (a config field, a fixture
-                  string, a path nothing creates), a TMPDIR-derived path, and
-                  a commented-out call.
+                  an added directory-creating call whose first argument opens
+                  a quoted path under the /tmp or /var/tmp root: mkdtemp and
+                  mkdir and their Sync variants (JS/TS), mkdtemp, makedirs and
+                  mkdir (Python), create_dir_all (Rust), and a shell mkdir -p
+                  at a command position. The mkdtemp pair always creates, so a
+                  quoted bare root in any of its arguments is the same shape.
+                  Plain mkdir of the bare root is not, since creating a root
+                  that exists is a no-op. Nor is the literal as a value (a
+                  config field, a fixture string, a path nothing creates), a
+                  TMPDIR-derived path, or a commented-out call.
   docs-cited-paths
                   in a changed .md file, an added backticked path naming
                   nothing tracked or on disk, judged only inside a directory
@@ -106,9 +111,12 @@ Scope rules:
   shebang. A file whose content git reads as binary contributes no lines to
   any lane; the whole-file lanes still see its path. A deleted path leaves the
   change set, and applied-migration-edited reads it from the diff instead.
-  Under a tests/ or fixtures/ tree, and in a test-named source file,
-  fail-open, mktemp-trap and the source-file direction of docs-cited-paths
-  stand down; those trees set their own rules.
+  A tests/ or fixtures/ tree sets its own rules: mktemp-trap, the source-file
+  direction of docs-cited-paths, and the strict-mode and swallowed-status
+  shapes of fail-open stand down there. In a test-named source file (tests.rs,
+  *_test.*, *_tests.*, *.test.*, *.spec.*, test_*) only the swallowed-status
+  shape and that same docs-cited-paths direction stand down. The mktemp
+  assignment shape of fail-open is judged in every tree.
   In an installed-artifact subtree (.agents/ and the harness directories'
   skills, agents, hooks, rules, instructions, packages and kendex trees)
   masked-returns, fail-open, unwired-suite, mktemp-trap and the source-file
@@ -119,9 +127,11 @@ Scope rules:
 Settings (env > .env.local > .kendex/settings.toml > kendex.settings.toml
 [env] > default):
   PREFLIGHT_JSONC_GLOBS      .json paths whose producer writes JSON with
-                             comments; replaces the shipped set
-  PREFLIGHT_MIGRATION_GLOBS  the migrations applied-migration-edited freezes;
-                             replaces the shipped set
+                             comments
+  PREFLIGHT_MIGRATION_GLOBS  the migrations applied-migration-edited freezes
+
+Each replaces its shipped set rather than adding to it, and an empty value
+leaves its lane quiet.
 
 Optional tools: shellcheck for shellcheck-errors and masked-returns, jq for
 JSON, taplo or python3 with tomllib for TOML. A needed lane whose tool is

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -76,11 +76,12 @@ Lanes:
                   Reported once per file.
   hardcoded-temp-path
                   an added directory-creating call whose first argument opens
-                  a quoted path under the /tmp or /var/tmp root: mkdtemp and
-                  mkdir and their Sync variants (JS/TS), mkdtemp, makedirs and
-                  mkdir (Python), create_dir_all (Rust), and a shell mkdir -p
-                  at a command position. The mkdtemp pair always creates, so a
-                  quoted bare root in any of its arguments is the same shape.
+                  a path under the /tmp or /var/tmp root: mkdtemp and mkdir
+                  and their Sync variants (JS/TS), mkdtemp, makedirs and mkdir
+                  (Python), create_dir_all (Rust), each with the path quoted,
+                  and a shell mkdir -p at a command position, where the quotes
+                  are optional. The mkdtemp pair always creates, so a quoted
+                  bare root in any of its arguments is the same shape.
                   Plain mkdir of the bare root is not, since creating a root
                   that exists is a no-op. Nor is the literal as a value (a
                   config field, a fixture string, a path nothing creates), a

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -33,22 +33,105 @@ usage() {
   cat <<'EOF'
 usage: preflight [--staged | --base REF | --all] [--repo PATH]
 
-Diff-scoped deterministic checks. Default scope is the merge base of HEAD
-and the default branch (origin/HEAD, else origin/main, else main), plus
-non-ignored untracked files; --staged sees only the index.
+Diff-scoped deterministic checks over one change. A line-scoped lane reports
+only on a line the change added, a lane that cannot decide reports nothing,
+and there is no warnings tier.
 
-  --staged      staged changes only (pre-commit scope)
-  --base REF    changes since the merge base of HEAD and REF, plus every
-                non-ignored untracked file (a new file, every line added)
+Scopes:
+  (default)     the merge base of HEAD and the default branch (origin/HEAD,
+                else origin/main, else main), plus every non-ignored
+                untracked file as a new file with every line added
+  --staged      the index only (pre-commit scope)
+  --base REF    the merge base of HEAD and REF, plus untracked files
   --all         every tracked file, every line treated as added
   --repo PATH   run against the repository containing PATH (default: cwd)
 
-Lanes: shell-syntax, shellcheck-errors, masked-returns, fail-open,
-unwired-suite, mktemp-trap, hardcoded-temp-path, docs-cited-paths,
-applied-migration-edited, data-syntax.
+Lanes:
+  shell-syntax    a changed shell file bash cannot parse.
+  shellcheck-errors
+                  an error-severity shellcheck finding anywhere in a changed
+                  shell file. Runs only where bash parsed the file, since a
+                  syntax error has already spoken for it.
+  masked-returns  SC2155 or SC2311 on an added line: a declaration whose own
+                  exit status hides the command's.
+  fail-open       an =$(mktemp ...) assignment added to a file that never
+                  sets errexit; a new shell file that does not set -e, -u and
+                  pipefail, unless git records it non-executable under a
+                  scripts/lib/ tree, where it is sourced and the preamble
+                  would set the calling shell's mode instead; an added grep,
+                  find, git, jq, diff or cmp at a command position whose
+                  status a trailing || true (or || :) discards. The same text
+                  quoted inside a message is not the shape.
+  unwired-suite   a new suite file no tracked runner invokes. Suites are
+                  tests/*.test.sh, tests/test-*.sh, *.test.ts, *.test.js and
+                  *.test.mjs; a file under a fixtures/ directory is material a
+                  suite reads, never a suite. A runner set that is empty or
+                  that this tool could not read whole leaves the lane quiet.
+  mktemp-trap     a new shell file with an added mktemp invocation and no
+                  trap ... EXIT anywhere in it. The invocation is the word at
+                  a command position, not one named in a comment or a string.
+                  Reported once per file.
+  hardcoded-temp-path
+                  an added directory-creating call taking a literal absolute
+                  temp path as (part of) its first argument: mkdtemp and mkdir
+                  and their Sync variants (JS/TS), mkdtemp, makedirs and mkdir
+                  (Python), create_dir_all (Rust), and a shell mkdir -p at a
+                  command position. The literals are /tmp and /var/tmp. Not
+                  the shape: the literal as a value (a config field, a fixture
+                  string, a path nothing creates), a TMPDIR-derived path, and
+                  a commented-out call.
+  docs-cited-paths
+                  in a changed .md file, an added backticked path naming
+                  nothing tracked or on disk, judged only inside a directory
+                  the repo really has and inside the doc's own top-level
+                  directory (a root-level doc owns the repo). In a changed
+                  source file, an added line citing a .md path that names
+                  nothing tracked or on disk; URL spans and quoted strings are
+                  stripped first. Data files (JSON, TOML, YAML, lock) and
+                  test-named files cite paths as working material and are out
+                  of scope.
+  applied-migration-edited
+                  a path the merge base carries, edited, deleted or renamed,
+                  matching a configured migrations glob. Its recorded checksum
+                  no longer matches, so the correction is a new migration and
+                  never an edit here. A mode change moves no text and is not
+                  the shape. The lane is quiet under --all and where no base
+                  resolves.
+  data-syntax     a changed strict .json or .toml file no parser accepts. The
+                  .jsonc file kind declares JSON with comments and is left to
+                  its producer.
 
-Needed checks with unavailable optional tools are reported by lane name.
-The final result lists those lanes without changing the exit status.
+Scope rules:
+  A shell file is *.sh, *.bash, or a file whose first line is a sh or bash
+  shebang. A file whose content git reads as binary contributes no lines to
+  any lane; the whole-file lanes still see its path. A deleted path leaves the
+  change set, and applied-migration-edited reads it from the diff instead.
+  Under a tests/ or fixtures/ tree, and in a test-named source file,
+  fail-open, mktemp-trap and the source-file direction of docs-cited-paths
+  stand down; those trees set their own rules.
+  In an installed-artifact subtree (.agents/ and the harness directories'
+  skills, agents, hooks, rules, instructions, packages and kendex trees)
+  masked-returns, fail-open, unwired-suite, mktemp-trap and the source-file
+  direction of docs-cited-paths stand down. shell-syntax, shellcheck-errors,
+  hardcoded-temp-path, applied-migration-edited and data-syntax stay on. A
+  prompts/ or commands/ tree under a harness directory keeps every lane.
+
+Settings (env > .env.local > .kendex/settings.toml > kendex.settings.toml
+[env] > default):
+  PREFLIGHT_JSONC_GLOBS      .json paths whose producer writes JSON with
+                             comments; replaces the shipped set
+  PREFLIGHT_MIGRATION_GLOBS  the migrations applied-migration-edited freezes;
+                             replaces the shipped set
+
+Optional tools: shellcheck for shellcheck-errors and masked-returns, jq for
+JSON, taplo or python3 with tomllib for TOML. A needed lane whose tool is
+unavailable prints as not run and is listed in the final result, which does
+not change the exit status.
+
+Output: one finding per line, path:line: [lane] message, line 0 for a
+whole-file finding, then a result line counting findings and changed files.
+
+Diff construction and the glob grammars: references/lanes.md.
 
 Exit codes: 0 clean; 1 findings; 2 usage/environment error.
 EOF

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -130,8 +130,9 @@ Settings (env > .env.local > .kendex/settings.toml > kendex.settings.toml
                              comments
   PREFLIGHT_MIGRATION_GLOBS  the migrations applied-migration-edited freezes
 
-Each replaces its shipped set rather than adding to it, and an empty value
-leaves its lane quiet.
+Each replaces its shipped set rather than adding to it. Emptied, the JSONC
+set exempts nothing and every .json file is parsed as strict JSON, while an
+empty migration set leaves applied-migration-edited quiet.
 
 Optional tools: shellcheck for shellcheck-errors and masked-returns, jq for
 JSON, taplo or python3 with tomllib for TOML. A needed lane whose tool is


### PR DESCRIPTION
KEN-564. An agent reading a preflight finding looked in SKILL.md, which every agent also pays for on every load. The retained lane semantics move to `preflight --help`, where that reader already is.

`preflight --help` now owns each lane's failure condition and exclusions, the scope rules, the two settings, the output shape and the exit codes. `references/lanes.md` keeps only what a help entry cannot carry: diff construction, the `unwired-suite` wiring grammar, the glob grammar, and the two shipped glob sets with the reason the migration set is narrow. README points at `preflight --help` and stops restating those sets and the flags. SKILL.md drops from 5614 to 1236 bytes: when to run preflight, the three commands, one rule, three pointers.

Wording was re-derived from the script rather than carried over, and the reviewer round then re-derived it again. Six claims inherited or introduced were wrong and are fixed in the second commit, each against a probe run on the shipped lane:

- `fail-open`'s three shapes do not share a guard. The mktemp assignment shape is judged under `tests/` and `fixtures/`; `mktemp-trap` and both other `fail-open` shapes fire in a test-named file. The old "out of scope for the lanes that judge whole files" blurred this; the stand-down lists now name shapes.
- `hardcoded-temp-path` needs a path *under* the root, so plain `mkdir` of a bare `/tmp` is not the shape, and the `mkdtemp` pair scans every argument rather than the first.
- `fail-open`'s `scripts/lib/` exemption reads git's mode only under `--staged`, the work tree otherwise.
- `unwired-suite` collects runners from untracked paths too, so "tracked runner" is dropped.
- An unresolvable default base is an environment error, not a clean run. That fact was lost in the move and is back.
- The replace-versus-add rule had three owners; it stays in `--help` alone. README and SKILL.md stop claiming every finding sits on an added line, which is false for the whole-file lanes and for `shellcheck-errors`.

No new flag, no new document, no test pinning prose, per the issue. Tracked renders under `.agents` land in the same commits.

Checks: `tools/guard --full` clean, preflight clean, doc-limits 710 documents, md-format 917 files, md-refs 617 references, prose clean, preflight suites 33/58/76/13 passed with 0 failed.

Architecture-docs program: KEN-1203.

https://claude.ai/code/session_01Bk6n4QyFNuzrXA1VbBVPiK
