### PR TITLE
fix(KEN-1197): the tool picker answers before a member is ticked

### DIFF
--- a/changelog.d/fixed/KEN-1197.md
+++ b/changelog.d/fixed/KEN-1197.md
@@ -1,0 +1,1 @@
+- A curated set's tool picker opens before any member is ticked, offering every tool the set could install to, and Install all is held back when that picker is emptied by hand.

--- a/ui/src/components/marketplaces/harness-select.tsx
+++ b/ui/src/components/marketplaces/harness-select.tsx
@@ -64,15 +64,20 @@ export function HarnessSelect({
   onChange: (choice: Choice) => void;
 }) {
   const [targets, setTargets] = useState<InstallTarget[]>([]);
+  // The read's dependency is the kinds as one value, because the array
+  // itself is fresh on every render. Splitting that key back is where the
+  // emptiness has to survive: `"".split(",")` is one blank kind, which
+  // `ItemKind` has no variant for, so the command refuses the whole call
+  // and the picker is left with no row to tick. Naming no kind is what an
+  // empty key means, and the command reads that as every kind.
   const wanted = kinds.join(",");
 
   useEffect(() => {
     let live = true;
-    void commands
-      .installTargets(scope, wanted.split(",") as ItemKind[])
-      .then((r) => {
-        if (live && r.status === "ok") setTargets(r.data);
-      });
+    const asked = wanted === "" ? [] : (wanted.split(",") as ItemKind[]);
+    void commands.installTargets(scope, asked).then((r) => {
+      if (live && r.status === "ok") setTargets(r.data);
+    });
     return () => {
       live = false;
     };

--- a/ui/src/pages/bundle-detail.dom.test.tsx
+++ b/ui/src/pages/bundle-detail.dom.test.tsx
@@ -9,6 +9,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppSettings, BundleDetail, Scope } from "@/bindings";
 import { commands } from "@/bindings";
 import { unreadableRecordsLine } from "@/lib/copy-marketplaces";
+import { harnessName } from "@/lib/labels";
 import { useMarketplacesStore } from "@/stores/marketplaces";
 import { subscription } from "@/stores/marketplaces-shared";
 import { useNavStore } from "@/stores/nav";
@@ -26,7 +27,8 @@ vi.mock("sonner", () => ({
   toast: { error: vi.fn(), success: vi.fn(), message: vi.fn() },
 }));
 
-const catalog = subscription({ scope: "global" }, "kit");
+const HOME: Scope = { scope: "global" };
+const catalog = subscription(HOME, "kit");
 const ACME: Extract<Scope, { scope: "project" }> = {
   scope: "project",
   root: "/work/acme",
@@ -47,6 +49,23 @@ async function chooseDestination(host: HTMLElement, label: string) {
   if (!(option instanceof HTMLElement)) throw new Error(`no ${label} option`);
   await userEvent.click(option);
   await settle();
+}
+
+/** The tool picker's row for one tool, opened. Same keyboard path as the
+ *  destination select: a pointer click does not open a base-ui trigger
+ *  under jsdom. The popup is portalled, so it is read off the document. */
+async function toolBox(host: HTMLElement, tool: string) {
+  const trigger = [...host.querySelectorAll("button")].find((button) =>
+    button.textContent?.includes("Install for"),
+  );
+  if (!trigger) throw new Error("no tool picker rendered");
+  act(() => trigger.focus());
+  await userEvent.keyboard("{Enter}");
+  await settle();
+  const row = [
+    ...document.querySelectorAll('[data-slot="dropdown-menu-content"] label'),
+  ].find((label) => label.textContent?.includes(tool));
+  return row?.querySelector<HTMLInputElement>('input[type="checkbox"]');
 }
 
 const starter: BundleDetail = {
@@ -78,10 +97,25 @@ function answer(detail: BundleDetail) {
 beforeEach(() => {
   vi.clearAllMocks();
   answer(starter);
-  vi.mocked(commands.installTargets).mockResolvedValue({
-    status: "ok",
-    data: [{ harness: "claude", detected: true, sharesTheUniversalTree: true }],
-  });
+  // The real command deserializes its payload into `ItemKind`, which has no
+  // variant for a blank string, so a call carrying one is refused whole and
+  // the picker gets no rows. The mock refuses the same payload, or the
+  // picker would draw its rows off an answer the app never gets.
+  vi.mocked(commands.installTargets).mockImplementation(
+    async (_scope, kinds) =>
+      kinds.some((kind) => (kind as string) === "")
+        ? { status: "error", error: "unknown variant ``" }
+        : {
+            status: "ok",
+            data: [
+              {
+                harness: "claude",
+                detected: true,
+                sharesTheUniversalTree: true,
+              },
+            ],
+          },
+  );
   useMarketplacesStore.setState({ bundles: {}, readErrors: {}, busy: false });
   useSettingsStore.setState({
     settings: { projects: [ACME.root] } as AppSettings,
@@ -133,6 +167,48 @@ describe("the curated set page", () => {
     await chooseDestination(host, "Personal");
     await chooseDestination(host, "acme");
     expect(commands.marketplaceBundle).toHaveBeenCalledTimes(2);
+  });
+
+  // The tool picker is the one control that decides how Install all lands,
+  // and this page opens it before any member is ticked. Nothing ticked
+  // names no kind, and no kind has to reach the command as no kinds: joined
+  // and split back naively it arrives as one blank kind, which `ItemKind`
+  // has no variant for, so the command refuses the call, no row is drawn,
+  // and the control is dead until a member is ticked.
+  it("asks about every kind while nothing is ticked, and draws the tools", async () => {
+    const host = mount(<BundleDetailPage />);
+    await settle();
+
+    expect(commands.installTargets).toHaveBeenCalledWith(HOME, []);
+    expect(host.textContent).not.toContain("No tools — pick at least one");
+    expect(await toolBox(host, harnessName("claude"))).toBeTruthy();
+
+    // The other half of the same answer: ticking narrows the picker to the
+    // kinds actually ticked, which is the filter the install of those
+    // members is refused by. No kinds means every kind; it does not mean
+    // the picker stops asking about the ticked ones.
+    const box = host.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    if (!box) throw new Error("no member checkbox rendered");
+    await userEvent.click(box);
+    await settle();
+
+    expect(commands.installTargets).toHaveBeenLastCalledWith(HOME, ["skill"]);
+  });
+
+  // Install all installs with whatever this picker last answered, so a
+  // picker emptied by hand is a choice to install nowhere for it too: a
+  // plan that writes nothing and reports success.
+  it("holds Install all back on a picker emptied by hand", async () => {
+    const host = mount(<BundleDetailPage />);
+    await settle();
+    expect(installAll(host)?.disabled).toBe(false);
+
+    const claude = await toolBox(host, harnessName("claude"));
+    if (!claude) throw new Error("no tool row rendered");
+    await userEvent.click(claude);
+    await settle();
+
+    expect(installAll(host)?.disabled).toBe(true);
   });
 
   // A destination whose read fails is the one state the picker has to

--- a/ui/src/pages/bundle-detail.tsx
+++ b/ui/src/pages/bundle-detail.tsx
@@ -5,7 +5,10 @@ import {
   BundleMemberLine,
   memberKey,
 } from "@/components/marketplaces/bundle-member-row";
-import type { Choice } from "@/components/marketplaces/harness-select";
+import {
+  type Choice,
+  isInstallable,
+} from "@/components/marketplaces/harness-select";
 import { RecordsUnreadableNote } from "@/components/marketplaces/packages-trouble";
 import { RepoAction } from "@/components/marketplaces/repo-action";
 import {
@@ -120,9 +123,10 @@ function BundleDetail({ bundleRef }: { bundleRef: BundleRef }) {
   // could tell. Landing place, not browsed one — the engine mutates where
   // the install goes.
   const recordsUnknown = detail?.recordsUnreadable ?? false;
-  // Which tools the picker may offer follows what is actually ticked; with
-  // nothing ticked the set is every kind, which is what the whole bundle
-  // would carry.
+  // Which tools the picker may offer follows what is actually ticked. With
+  // nothing ticked it names no kind, and no kind is read as every kind —
+  // the same answer Install all is refused by, since a bundle install
+  // declares every kind whatever the set happens to hold.
   const selectedKinds = [
     ...new Set(
       (detail?.members ?? [])
@@ -152,8 +156,14 @@ function BundleDetail({ bundleRef }: { bundleRef: BundleRef }) {
         }
         action={
           subscribed ? (
+            // This installs with whatever the bar's tool picker last
+            // answered, so a picker emptied by hand holds it back the same
+            // way it holds back the bar's own button: an install to no tool
+            // reports success over a plan that wrote nothing.
             <Button
-              disabled={busy || !detail || recordsUnknown}
+              disabled={
+                busy || !detail || recordsUnknown || !isInstallable(choice)
+              }
               onClick={() => installItems([])}
             >
               Install all


### PR DESCRIPTION
`HarnessSelect` joined its kinds into one value to give the read a stable dependency, and split that value back for the call. An empty join split back to one blank kind, which `ItemKind` has no variant for, so `install_targets` refused the whole call: no rows, and a trigger reading "No tools — pick at least one" over an empty dropdown. On a curated-set page nothing is ticked until someone ticks it, so the one control that decides how Install all lands could not be opened before it.

The empty key now splits back to no kinds, which `install_targets` already reads as every kind. That is the same answer a bundle install is refused by — `requested_kinds` declares `ItemKind::ALL` for one whatever the set holds — so the picker's rows and `lands_nowhere`'s filter read the identical kind set. The set page's comment states that holding.

Install all also now consults `isInstallable(choice)`, as the bar's own button does: it installs with whatever that picker last answered, so a picker emptied by hand would have had it report success over a plan that wrote nothing.

## Tests

Two cases in `ui/src/pages/bundle-detail.dom.test.tsx`, which already mounts the page and mocks the command: the untouched-picker round trip (with the ticked-member narrowing folded in as the other half of the same answer), and Install all held back on a picker emptied by hand. That file's `installTargets` mock now refuses a blank-kind payload the way serde does, or the symptom assertions would have passed against an answer the app never gets.

Three must-fail controls each ran red once: the naive split restored, the split over-corrected to always-empty, and the Install all gate reverted.

## Review

One local round, reviewer-correctness: pass, no blockers, mutation 3/3 killed and stability 10/10 against those same three mutants. Two non-blocking suggestions, both pre-existing rather than introduced here.

Tracked: KEN-1258 — `isInstallable` reads `choice.harnesses` raw while the trigger's label reads it reconciled against the tools currently offered, so a choice the picker no longer offers leaves Install all pressable over a set install that writes nothing. Reachable through `bundle-install-bar.tsx` before this change; out of KEN-1197's Requirements, which scoped only the header-gate asymmetry.

Closes KEN-1197.

https://claude.ai/code/session_01J8UwcAsZA4Zn8HP7qMBbW9
