### PR TITLE
fix(KEN-1196): four plain-value commands join the transport fold

### DIFF
--- a/changelog.d/fixed/1196.md
+++ b/changelog.d/fixed/1196.md
@@ -1,0 +1,1 @@
+- Say why the Settings page, the version it shows, and the marketplace authoring guide could not be read, instead of a blank page or a loading skeleton.

--- a/crates/app/src/commands.rs
+++ b/crates/app/src/commands.rs
@@ -9,10 +9,11 @@ use specta::Type;
 
 use crate::scopes::env;
 
+// A `Result` for the transport fold, not for a refusal: `specta_builder`.
 #[tauri::command]
 #[specta::specta]
-pub fn app_version() -> String {
-    env!("CARGO_PKG_VERSION").to_owned()
+pub fn app_version() -> Result<String, String> {
+    Ok(env!("CARGO_PKG_VERSION").to_owned())
 }
 
 #[tauri::command(async)]
@@ -66,9 +67,10 @@ pub struct CapabilityRow {
 
 /// The full harness × kind capability matrix — the UI gates every action on
 /// this, never on its own assumptions.
+// A `Result` for the transport fold, not for a refusal: `specta_builder`.
 #[tauri::command]
 #[specta::specta]
-pub fn capability_table() -> Vec<CapabilityRow> {
+pub fn capability_table() -> Result<Vec<CapabilityRow>, String> {
     let mut rows = Vec::new();
     for harness in HarnessId::ALL {
         for kind in ItemKind::ALL {
@@ -79,7 +81,7 @@ pub fn capability_table() -> Vec<CapabilityRow> {
             });
         }
     }
-    rows
+    Ok(rows)
 }
 
 #[derive(Serialize, Type)]

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -55,11 +55,15 @@ fn constants(builder: Builder<tauri::Wry>) -> Builder<tauri::Wry> {
 /// refusal in.
 ///
 /// A command returning a plain value gets no wrapper, tauri-specta emitting
-/// one only where there is a refusal type to name: `app_version`,
-/// `capability_table`, `deep_link_take`, `mine_authoring_doc` and
-/// `window_zoom_state` reject to their callers unfolded, so a
-/// fire-and-forget read of one still drops its rejection. Nothing in
-/// `specta_builder` can reach them.
+/// one only where there is a refusal type to name, so its rejection reaches
+/// its caller unfolded and a fire-and-forget read drops it. Returning a
+/// `Result` is what puts a command behind the wrapper, which is the whole
+/// reason `app_version`, `capability_table`, `mine_authoring_doc` and
+/// `window_zoom_state` answer one they never refuse with. `deep_link_take`
+/// is the one command left outside, deliberately: its only caller reads it
+/// through `caught` in `ui/src/lib/deep-link.ts`. That set is pinned by
+/// `crates/app/tests/bindings.rs`, so a fifth is an edit to the list rather
+/// than a command that regenerates clean and reds nothing.
 ///
 /// `E | string` in the signature is what holds a reader honest: the fold
 /// puts a bare message in the `E` slot, and declaring that widening is what

--- a/crates/app/src/mine.rs
+++ b/crates/app/src/mine.rs
@@ -104,8 +104,9 @@ pub fn mine_accept_workflow(path: PathBuf) -> Result<MineRow, String> {
 
 /// The one authoring document, compiled in so the app renders the same
 /// text the repository publishes.
+// A `Result` for the transport fold, not for a refusal: `specta_builder`.
 #[tauri::command(async)]
 #[specta::specta]
-pub fn mine_authoring_doc() -> String {
-    include_str!("../../../docs/authoring/README.md").to_owned()
+pub fn mine_authoring_doc() -> Result<String, String> {
+    Ok(include_str!("../../../docs/authoring/README.md").to_owned())
 }

--- a/crates/app/src/window.rs
+++ b/crates/app/src/window.rs
@@ -68,10 +68,11 @@ pub fn bring_to_front(app: &tauri::AppHandle) {
 }
 
 /// What the webview is showing, for a page with no memory of its own.
+// A `Result` for the transport fold, not for a refusal: `specta_builder`.
 #[tauri::command]
 #[specta::specta]
-pub fn window_zoom_state(zoom: tauri::State<'_, WebviewZoom>) -> ZoomState {
-    zoom.read()
+pub fn window_zoom_state(zoom: tauri::State<'_, WebviewZoom>) -> Result<ZoomState, String> {
+    Ok(zoom.read())
 }
 
 /// Zoom is set on the webview rather than by restyling the page: it holds

--- a/crates/app/tests/bindings.rs
+++ b/crates/app/tests/bindings.rs
@@ -13,20 +13,30 @@ fn committed_path() -> &'static Path {
     ))
 }
 
-/// `cargo test` fails whenever the committed bindings drift from the command
-/// surface. Regenerate with:
-/// `cargo test -p kendex-app -- --ignored regenerate_bindings`
-#[test]
-fn committed_bindings_are_current() {
+/// The bindings `specta_builder` emits right now, written somewhere the test
+/// can read them without touching the committed file.
+#[allow(
+    clippy::expect_used,
+    reason = "an export or a read that fails is the test's own fixture, and the panic names which"
+)]
+fn generated() -> String {
     let tmp = tempfile::tempdir().expect("tempdir");
     let fresh_path = tmp.path().join("bindings.ts");
     kendex_app::specta_builder()
         .export(exporter(), &fresh_path)
         .expect("bindings export");
-    let fresh = std::fs::read_to_string(&fresh_path).expect("fresh bindings readable");
+    std::fs::read_to_string(&fresh_path).expect("fresh bindings readable")
+}
+
+/// `cargo test` fails whenever the committed bindings drift from the command
+/// surface. Regenerate with:
+/// `cargo test -p kendex-app -- --ignored regenerate_bindings`
+#[test]
+fn committed_bindings_are_current() {
     let committed = std::fs::read_to_string(committed_path()).unwrap_or_default();
     assert_eq!(
-        committed, fresh,
+        committed,
+        generated(),
         "ui/src/bindings.ts is stale — run: cargo test -p kendex-app -- --ignored regenerate_bindings"
     );
 }
@@ -36,12 +46,7 @@ fn committed_bindings_are_current() {
 /// missing here.
 #[test]
 fn bindings_export_window_commands() {
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let fresh_path = tmp.path().join("bindings.ts");
-    kendex_app::specta_builder()
-        .export(exporter(), &fresh_path)
-        .expect("bindings export");
-    let fresh = std::fs::read_to_string(&fresh_path).expect("fresh bindings readable");
+    let fresh = generated();
     for command in [
         "window_set_zoom",
         "window_zoom_state",
@@ -61,15 +66,92 @@ fn bindings_export_window_commands() {
 /// constant, so dropping the constant would leave the UI inventing its own.
 #[test]
 fn bindings_export_the_zoom_range() {
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let fresh_path = tmp.path().join("bindings.ts");
-    kendex_app::specta_builder()
-        .export(exporter(), &fresh_path)
-        .expect("bindings export");
-    let fresh = std::fs::read_to_string(&fresh_path).expect("fresh bindings readable");
+    let fresh = generated();
     assert!(
         fresh.contains("export const ZOOM"),
         "expected generated bindings to export the zoom range"
+    );
+}
+
+/// The `commands` object, from its opening line to the line that closes it.
+#[allow(
+    clippy::expect_used,
+    reason = "a generated file without a commands object is a reader that stopped matching it, and the panic says so"
+)]
+fn commands_block(bindings: &str) -> &str {
+    let start = bindings
+        .find("export const commands = {")
+        .expect("generated bindings declare a commands object");
+    let rest = &bindings[start..];
+    let end = rest.find("\n}\n").expect("the commands object closes");
+    &rest[..end]
+}
+
+/// Every command the bindings invoke, paired with whether the `typedError`
+/// fold stands between the bridge and the caller. Read off the generated
+/// file rather than off a list here: an entry reads `=> typedError<…>(
+/// __TAURI_INVOKE…)` where the fold applies and `=> __TAURI_INVOKE…` where it
+/// does not, and the command's own name is the invocation's first argument
+/// either way.
+#[allow(
+    clippy::expect_used,
+    reason = "an invocation that does not match this shape is a reader that stopped matching it, and the panic says so"
+)]
+fn invoked_commands(bindings: &str) -> Vec<(String, bool)> {
+    const INVOKE: &str = "__TAURI_INVOKE";
+    let block = commands_block(bindings);
+    let mut found = Vec::new();
+    let mut at = 0;
+    while let Some(offset) = block[at..].find(INVOKE) {
+        let call = at + offset;
+        let arrow = block[..call]
+            .rfind("=>")
+            .expect("every command entry is an arrow function");
+        let folded = block[arrow..call].contains("typedError");
+        let opened = call
+            + block[call..]
+                .find("(\"")
+                .expect("the invocation names its command")
+            + 2;
+        let closed = opened
+            + block[opened..]
+                .find('"')
+                .expect("the command name is quoted");
+        found.push((block[opened..closed].to_owned(), folded));
+        at = closed;
+    }
+    found
+}
+
+/// The commands whose rejection reaches their caller unfolded. Each one
+/// needs a caller that catches: `deep_link_take` is read through `caught` in
+/// `ui/src/lib/deep-link.ts`.
+const OUTSIDE_THE_FOLD: [&str; 1] = ["deep_link_take"];
+
+/// tauri-specta wraps a command only where its `Result` gives it a refusal
+/// type to name, so a plain-value command added later regenerates clean and
+/// `committed_bindings_are_current` stays green while its rejection escapes
+/// its caller. Joining the fold is a return type; leaving it is an edit here.
+#[test]
+fn only_the_pinned_commands_bypass_the_transport_fold() {
+    let fresh = generated();
+    let invoked = invoked_commands(&fresh);
+    assert!(
+        invoked.len() > 50,
+        "the reader found {} commands in the generated bindings — it is what \
+         broke, not the command surface that thinned",
+        invoked.len()
+    );
+    let outside: Vec<&str> = invoked
+        .iter()
+        .filter(|(_, folded)| !folded)
+        .map(|(name, _)| name.as_str())
+        .collect();
+    assert_eq!(
+        outside, OUTSIDE_THE_FOLD,
+        "a command outside the transport fold rejects to its caller unfolded — \
+         return `Result` from it, or add it to OUTSIDE_THE_FOLD and give it a \
+         caller that catches"
     );
 }
 

--- a/crates/app/tests/bindings.rs
+++ b/crates/app/tests/bindings.rs
@@ -73,7 +73,10 @@ fn bindings_export_the_zoom_range() {
     );
 }
 
-/// The `commands` object, from its opening line to the line that closes it.
+/// The `commands` object, from its opening line to the `};` that closes it.
+/// The generated file carries the events object and every exported type
+/// below that line, so an end matched on a bare closing brace would take
+/// thousands of lines of type declarations into the block with it.
 #[allow(
     clippy::expect_used,
     reason = "a generated file without a commands object is a reader that stopped matching it, and the panic says so"
@@ -83,16 +86,23 @@ fn commands_block(bindings: &str) -> &str {
         .find("export const commands = {")
         .expect("generated bindings declare a commands object");
     let rest = &bindings[start..];
-    let end = rest.find("\n}\n").expect("the commands object closes");
+    let end = rest.find("\n};").expect("the commands object closes");
     &rest[..end]
 }
 
 /// Every command the bindings invoke, paired with whether the `typedError`
 /// fold stands between the bridge and the caller. Read off the generated
-/// file rather than off a list here: an entry reads `=> typedError<…>(
-/// __TAURI_INVOKE…)` where the fold applies and `=> __TAURI_INVOKE…` where it
-/// does not, and the command's own name is the invocation's first argument
-/// either way.
+/// file rather than off a list here, on the two shapes tauri-specta writes:
+/// `typedError<…>(__TAURI_INVOKE…)` for a folded command and
+/// `=> __TAURI_INVOKE…` for one outside the fold. So the character before
+/// the invocation answers it — the wrapper's own open paren, or the space
+/// after the arrow. The command's name is the invocation's first argument,
+/// reached past the generic the call may carry.
+///
+/// Both anchors are one character wide on purpose. tauri-specta writes a
+/// Rust doc comment into the generic itself, `deep_link_take`'s and
+/// `package_meta`'s among them, so a reader that scanned back for the arrow
+/// or forward for the first quoted string would answer off prose.
 #[allow(
     clippy::expect_used,
     reason = "an invocation that does not match this shape is a reader that stopped matching it, and the panic says so"
@@ -104,15 +114,16 @@ fn invoked_commands(bindings: &str) -> Vec<(String, bool)> {
     let mut at = 0;
     while let Some(offset) = block[at..].find(INVOKE) {
         let call = at + offset;
-        let arrow = block[..call]
-            .rfind("=>")
-            .expect("every command entry is an arrow function");
-        let folded = block[arrow..call].contains("typedError");
-        let opened = call
-            + block[call..]
-                .find("(\"")
-                .expect("the invocation names its command")
-            + 2;
+        let folded = block[..call].ends_with('(');
+        let args = call + INVOKE.len();
+        let opened = if block[args..].starts_with('(') {
+            args + 2
+        } else {
+            args + block[args..]
+                .find(">(\"")
+                .expect("an invocation opens on its command name, generic or not")
+                + 3
+        };
         let closed = opened
             + block[opened..]
                 .find('"')
@@ -147,6 +158,16 @@ fn only_the_pinned_commands_bypass_the_transport_fold() {
         .filter(|(_, folded)| !folded)
         .map(|(name, _)| name.as_str())
         .collect();
+    // The block's own count of the wrapper, against the reader's count of
+    // the calls it put behind one. A reader that misread an anchor lands
+    // here rather than in the pin below, where it would read as a command
+    // that changed shape.
+    assert_eq!(
+        invoked.len() - outside.len(),
+        commands_block(&fresh).matches("typedError").count(),
+        "the reader disagrees with the generated file about how many \
+         commands the fold wraps"
+    );
     assert_eq!(
         outside, OUTSIDE_THE_FOLD,
         "a command outside the transport fold rejects to its caller unfolded — \

--- a/ui/src/bindings.test.ts
+++ b/ui/src/bindings.test.ts
@@ -4,8 +4,9 @@ import { commands, type Manifest_Deserialize } from "@/bindings";
 import { NO_REASON_GIVEN } from "@/lib/settled";
 
 // The seam every `Result`-returning command answers through — tauri-specta
-// emits the runtime only where there is a refusal type to name, so the four
-// commands returning a plain value reject to their callers. The transport
+// emits the runtime only where there is a refusal type to name, so
+// `deep_link_take`, the one command still answering a plain value, rejects to
+// its caller and is read through `caught` there. The transport
 // rejects with an `Error` when it fails rather than when the command
 // refuses, and the runtime tauri-specta ships rethrows that — so a write
 // path that fires its command and forgets it would drop the rejection: the

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -6,7 +6,7 @@ import * as __TAURI_EVENT from "@tauri-apps/api/event";
 
 /** Commands */
 export const commands = {
-	appVersion: () => __TAURI_INVOKE<string>("app_version"),
+	appVersion: () => typedError<string, string>(__TAURI_INVOKE("app_version")),
 	/**
 	 *  The page's ask, after its first render: the URL that launched the app,
 	 *  if one did. Asking is also what switches delivery to events, so the
@@ -164,7 +164,7 @@ export const commands = {
 	 *  The full harness × kind capability matrix — the UI gates every action on
 	 *  this, never on its own assumptions.
 	 */
-	capabilityTable: () => __TAURI_INVOKE<CapabilityRow[]>("capability_table"),
+	capabilityTable: () => typedError<CapabilityRow[], string>(__TAURI_INVOKE("capability_table")),
 	/**
 	 *  Where a problem report about this item belongs: the kendex upstream
 	 *  (with a prefilled issue link) or the user's own repo.
@@ -367,7 +367,7 @@ export const commands = {
 	 *  The one authoring document, compiled in so the app renders the same
 	 *  text the repository publishes.
 	 */
-	mineAuthoringDoc: () => __TAURI_INVOKE<string>("mine_authoring_doc"),
+	mineAuthoringDoc: () => typedError<string, string>(__TAURI_INVOKE("mine_authoring_doc")),
 	accountStatus: () => typedError<AccountStatus, AccountReadFailed>(__TAURI_INVOKE("account_status")),
 	accountLoginStart: () => typedError<LoginStart, string>(__TAURI_INVOKE("account_login_start")),
 	/**  One poll; the frontend owns the timer so a closed dialog stops asking. */
@@ -485,7 +485,7 @@ export const commands = {
 	 */
 	windowSetZoom: (percent: number) => typedError<null, string>(__TAURI_INVOKE("window_set_zoom", { percent })),
 	/**  What the webview is showing, for a page with no memory of its own. */
-	windowZoomState: () => __TAURI_INVOKE<ZoomState>("window_zoom_state"),
+	windowZoomState: () => typedError<ZoomState, string>(__TAURI_INVOKE("window_zoom_state")),
 	windowMinimize: () => typedError<null, string>(__TAURI_INVOKE("window_minimize")),
 	windowToggleMaximize: () => typedError<null, string>(__TAURI_INVOKE("window_toggle_maximize")),
 	windowClose: () => typedError<null, string>(__TAURI_INVOKE("window_close")),

--- a/ui/src/components/marketplaces/mine-tab.dom.test.tsx
+++ b/ui/src/components/marketplaces/mine-tab.dom.test.tsx
@@ -174,6 +174,16 @@ describe("the authoring guide", () => {
     await settle();
   };
 
+  /** Close it the way a person does — the dialog's own close control, which
+   *  lives in the portal rather than in the tab's subtree. */
+  const closeGuide = async () => {
+    const close = document.body.querySelector<HTMLElement>(
+      '[role="dialog"] button',
+    );
+    await act(async () => close?.click());
+    await settle();
+  };
+
   it("draws the document the command answered with", async () => {
     vi.mocked(commands.mineSubmissions).mockResolvedValue(answered([]));
     vi.mocked(commands.mineAuthoringDoc).mockResolvedValue(
@@ -185,6 +195,32 @@ describe("the authoring guide", () => {
 
     // The dialog renders in a portal, so its content is on the body rather
     // than in the tab's own subtree.
+    expect(document.body.textContent).toContain("Authoring");
+    expect(document.body.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  // The read is skipped once the document is in hand, so the error has to be
+  // the one answer that does not count as in hand: without that, a person
+  // who hit a failing read once is left with the message for the rest of the
+  // session however many times they reopen the dialog.
+  it("asks again when the dialog is reopened after a read that failed", async () => {
+    vi.mocked(commands.mineSubmissions).mockResolvedValue(answered([]));
+    vi.mocked(commands.mineAuthoringDoc).mockResolvedValue({
+      status: "error",
+      error: "the bridge closed",
+    });
+    const host = mount(<MineTab />);
+    await settle();
+    await openGuide(host);
+    expect(commands.mineAuthoringDoc).toHaveBeenCalledTimes(1);
+
+    await closeGuide();
+    vi.mocked(commands.mineAuthoringDoc).mockResolvedValue(
+      answered("# Authoring"),
+    );
+    await openGuide(host);
+
+    expect(commands.mineAuthoringDoc).toHaveBeenCalledTimes(2);
     expect(document.body.textContent).toContain("Authoring");
     expect(document.body.querySelector('[role="alert"]')).toBeNull();
   });

--- a/ui/src/components/marketplaces/mine-tab.dom.test.tsx
+++ b/ui/src/components/marketplaces/mine-tab.dom.test.tsx
@@ -160,6 +160,51 @@ it("leaves the account alone when a tick fails for any other reason", async () =
   expect(useAccountStore.getState().submissions).toEqual([ROW]);
 });
 
+// The guide is read once, when the dialog first opens. `mine_authoring_doc`
+// cannot refuse — it answers a `Result` so a transport failure folds into
+// the same reply (`specta_builder` in `crates/app/src/lib.rs`), which is the
+// only failure this dialog ever draws. Without it the dialog sits on its
+// loading skeleton for the rest of the session with nothing said.
+describe("the authoring guide", () => {
+  const openGuide = async (host: HTMLElement) => {
+    const button = [...host.querySelectorAll("button")].find((element) =>
+      element.textContent?.includes("How a marketplace repo works"),
+    );
+    await act(async () => button?.click());
+    await settle();
+  };
+
+  it("draws the document the command answered with", async () => {
+    vi.mocked(commands.mineSubmissions).mockResolvedValue(answered([]));
+    vi.mocked(commands.mineAuthoringDoc).mockResolvedValue(
+      answered("# Authoring"),
+    );
+    const host = mount(<MineTab />);
+    await settle();
+    await openGuide(host);
+
+    // The dialog renders in a portal, so its content is on the body rather
+    // than in the tab's own subtree.
+    expect(document.body.textContent).toContain("Authoring");
+    expect(document.body.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it("says why the guide did not arrive when the read answers an error", async () => {
+    vi.mocked(commands.mineSubmissions).mockResolvedValue(answered([]));
+    vi.mocked(commands.mineAuthoringDoc).mockResolvedValue({
+      status: "error",
+      error: "the bridge closed",
+    });
+    const host = mount(<MineTab />);
+    await settle();
+    await openGuide(host);
+
+    const alert = document.body.querySelector('[role="alert"]');
+    expect(alert?.textContent).toContain("Couldn't open the guide");
+    expect(alert?.textContent).toContain("the bridge closed");
+  });
+});
+
 // Which of the three states a marketplace is in, and what each draws as a
 // line and an offer, is `mine-submission.ts`'s ruling and is proven there.
 // What the tab owes is that a row the server named survives a tick that

--- a/ui/src/components/marketplaces/mine-tab.tsx
+++ b/ui/src/components/marketplaces/mine-tab.tsx
@@ -29,7 +29,12 @@ export function MineTab() {
   const actionError = useMineStore((s) => s.actionError);
   const [creating, setCreating] = useState(false);
   const [importTarget, setImportTarget] = useState<string | null>(null);
-  const [doc, setDoc] = useState<string | null>(null);
+  // Null until the read answers; after that the read's own answer, so a
+  // document that never arrived draws the reason and the dialog can be
+  // closed and opened again to ask for it once more.
+  const [doc, setDoc] = useState<Awaited<
+    ReturnType<typeof commands.mineAuthoringDoc>
+  > | null>(null);
   const [docOpen, setDocOpen] = useState(false);
   const [submitTarget, setSubmitTarget] = useState<string | null>(null);
   const loadSubmissions = useAccountStore((s) => s.loadSubmissions);
@@ -64,8 +69,8 @@ export function MineTab() {
 
   const openDoc = () => {
     setDocOpen(true);
-    if (doc === null) {
-      void commands.mineAuthoringDoc().then((text) => setDoc(text));
+    if (doc === null || doc.status === "error") {
+      void commands.mineAuthoringDoc().then(setDoc);
     }
   };
 
@@ -159,8 +164,12 @@ export function MineTab() {
           >
             {doc === null ? (
               <TextBar width="w-64" />
+            ) : doc.status === "ok" ? (
+              <MarkdownView source={doc.data} />
             ) : (
-              <MarkdownView source={doc} />
+              <StatusNote tone="critical" title="Couldn't open the guide">
+                {doc.error}
+              </StatusNote>
             )}
           </section>
           {/* biome-ignore-end lint/a11y/noNoninteractiveTabindex: the rule

--- a/ui/src/components/sidebar-notice.dom.test.tsx
+++ b/ui/src/components/sidebar-notice.dom.test.tsx
@@ -105,7 +105,10 @@ beforeEach(() => {
     error: null,
     note: null,
   });
-  vi.mocked(commands.appVersion).mockResolvedValue(RUNNING);
+  vi.mocked(commands.appVersion).mockResolvedValue({
+    status: "ok",
+    data: RUNNING,
+  });
   vi.mocked(commands.appUpdateCheck).mockResolvedValue(available());
   vi.mocked(commands.getSettings).mockResolvedValue({
     status: "ok",

--- a/ui/src/pages/settings.dom.test.tsx
+++ b/ui/src/pages/settings.dom.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+// The About row reads the running version off a command, and the read is
+// the page's only one. `app_version` cannot refuse — it answers a `Result`
+// so a transport failure folds into the same reply (`specta_builder` in
+// `crates/app/src/lib.rs`), which is the only failure this row ever draws.
+import { beforeEach, expect, it, vi } from "vitest";
+import { commands } from "@/bindings";
+import { mount, settle } from "@/test/dom";
+import { SettingsPage } from "./settings";
+
+vi.mock("@/bindings", () => ({
+  commands: {
+    appVersion: vi.fn(),
+    accountLoginStart: vi.fn(),
+    accountLoginPoll: vi.fn(),
+    accountLogout: vi.fn(),
+    openUrl: vi.fn(),
+  },
+  ZOOM: { min: 50, max: 200, step: 10, default: 100 },
+}));
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+beforeEach(() => vi.clearAllMocks());
+
+it("draws the version the command answered with", async () => {
+  vi.mocked(commands.appVersion).mockResolvedValue({
+    status: "ok",
+    data: "5.0.1",
+  });
+
+  const host = mount(<SettingsPage />);
+  await settle();
+
+  expect(host.textContent).toContain("5.0.1");
+  expect(host.querySelector('[role="alert"]')).toBeNull();
+});
+
+// Without this the row sits on its ellipsis for the rest of the session and
+// the person is told nothing at all about why the version never arrived.
+it("says the version could not be read when the command answers an error", async () => {
+  vi.mocked(commands.appVersion).mockResolvedValue({
+    status: "error",
+    error: "the bridge closed",
+  });
+
+  const host = mount(<SettingsPage />);
+  await settle();
+
+  const alert = host.querySelector('[role="alert"]');
+  expect(alert?.textContent).toContain("the bridge closed");
+  expect(alert?.textContent).toContain("unavailable");
+});

--- a/ui/src/pages/settings.tsx
+++ b/ui/src/pages/settings.tsx
@@ -27,7 +27,12 @@ const THEME_LABELS: Record<Appearance, string> = {
 
 export function SettingsPage() {
   const { settings, onScreen, setAppearance } = useSettingsStore();
-  const [version, setVersion] = useState<string | null>(null);
+  // Null until the read answers; after that the read's own answer, so a
+  // version the app could not ask for says so instead of sitting on the
+  // ellipsis a still-loading read wears.
+  const [version, setVersion] = useState<Awaited<
+    ReturnType<typeof commands.appVersion>
+  > | null>(null);
 
   useEffect(() => {
     void commands.appVersion().then(setVersion);
@@ -101,11 +106,20 @@ export function SettingsPage() {
                 <span className="flex items-baseline gap-2">
                   Version
                   <span className="font-mono text-xs font-normal text-muted-foreground">
-                    {version ?? "…"}
+                    {version === null
+                      ? "…"
+                      : version.status === "ok"
+                        ? version.data
+                        : "unavailable"}
                   </span>
                 </span>
               }
-              description="kendex keeps your AI coding tools in sync."
+              role={version?.status === "error" ? "alert" : undefined}
+              description={
+                version?.status === "error"
+                  ? `kendex couldn't read its own version: ${version.error}`
+                  : "kendex keeps your AI coding tools in sync."
+              }
             />
           </Section>
         </div>

--- a/ui/src/stores/account-startup.dom.test.tsx
+++ b/ui/src/stores/account-startup.dom.test.tsx
@@ -50,12 +50,13 @@ describe("the account read on window focus", () => {
         base: null,
       },
     } as unknown as Awaited<ReturnType<typeof commands.getSettings>>);
-    vi.mocked(commands.capabilityTable).mockResolvedValue(
-      [] as unknown as Awaited<ReturnType<typeof commands.capabilityTable>>,
-    );
+    vi.mocked(commands.capabilityTable).mockResolvedValue({
+      status: "ok",
+      data: [],
+    });
     vi.mocked(commands.windowZoomState).mockResolvedValue({
-      percent: 100,
-      launchRefused: false,
+      status: "ok",
+      data: { percent: 100, launchRefused: false },
     });
     vi.mocked(commands.scanMachine).mockResolvedValue({
       status: "ok",
@@ -78,9 +79,10 @@ describe("the account read on window focus", () => {
       status: "error",
       error: "no command channel in a test",
     } as Awaited<ReturnType<typeof commands.appUpdateCommandChannel>>);
-    vi.mocked(commands.appVersion).mockResolvedValue(
-      "0.0.0-test" as Awaited<ReturnType<typeof commands.appVersion>>,
-    );
+    vi.mocked(commands.appVersion).mockResolvedValue({
+      status: "ok",
+      data: "0.0.0-test",
+    });
   });
 
   // A terminal can sign in or out while the window is away, and a read

--- a/ui/src/stores/notice.ts
+++ b/ui/src/stores/notice.ts
@@ -86,14 +86,14 @@ export const useNoticeStore = create<NoticeState>((set, get) => ({
       settled(commands.appUpdateCommandChannel()),
       // The running version is the half of the sentence the release feed
       // cannot supply; without it there is no notice to write.
-      commands.appVersion().catch(() => null),
+      settled(commands.appVersion()),
     ]);
-    if (view.status === "error" || current === null) return;
+    if (view.status === "error" || current.status === "error") return;
     const status = view.data;
     if (status.kind !== "updateAvailable" || status.muted) return;
     set({
       notice: {
-        current,
+        current: current.data,
         latest: status.version,
         releaseNotesUrl: status.releaseNotesUrl,
       },

--- a/ui/src/stores/settings-zoom.test.ts
+++ b/ui/src/stores/settings-zoom.test.ts
@@ -82,10 +82,9 @@ function freshZoomStore() {
   });
   vi.clearAllMocks();
   windowTakes();
-  vi.mocked(commands.windowZoomState).mockImplementation(async () => ({
-    percent: webviewAt,
-    launchRefused: false,
-  }));
+  vi.mocked(commands.windowZoomState).mockImplementation(async () =>
+    ok({ percent: webviewAt, launchRefused: false }),
+  );
   vi.mocked(commands.updateSettings).mockImplementation(async (next, base) =>
     ok({ settings: next, base }),
   );
@@ -119,11 +118,10 @@ describe("zoom, on screen", () => {
     vi.mocked(commands.getSettings).mockResolvedValue(
       ok({ settings: { ...settings, zoom: 150 }, base: "file" }),
     );
-    vi.mocked(commands.capabilityTable).mockResolvedValue([]);
-    vi.mocked(commands.windowZoomState).mockResolvedValue({
-      percent: 100,
-      launchRefused: true,
-    });
+    vi.mocked(commands.capabilityTable).mockResolvedValue(ok([]));
+    vi.mocked(commands.windowZoomState).mockResolvedValue(
+      ok({ percent: 100, launchRefused: true }),
+    );
 
     await useSettingsStore.getState().load();
 
@@ -160,7 +158,7 @@ describe("zoom, on screen", () => {
     vi.mocked(commands.getSettings).mockResolvedValue(
       ok({ settings: { ...settings, zoom: 150 }, base: "file" }),
     );
-    vi.mocked(commands.capabilityTable).mockResolvedValue([]);
+    vi.mocked(commands.capabilityTable).mockResolvedValue(ok([]));
 
     await useSettingsStore.getState().load();
 
@@ -283,9 +281,7 @@ describe("zoom, on screen", () => {
   /// A run that cannot read the window has nothing to write and says so.
   it("writes nothing when the window cannot say what size it is at", async () => {
     await useSettingsStore.getState().setZoom(150);
-    vi.mocked(commands.windowZoomState).mockRejectedValue(
-      new Error("no bridge"),
-    );
+    vi.mocked(commands.windowZoomState).mockResolvedValue(failed("no bridge"));
 
     await useSettingsStore.getState().saveZoom();
 

--- a/ui/src/stores/settings-zoom.test.ts
+++ b/ui/src/stores/settings-zoom.test.ts
@@ -209,13 +209,13 @@ describe("zoom, on screen", () => {
     expect(dialog().message).toBe("no webview");
   });
 
-  it("puts the size back when the bridge throws, and lets Retry ask again", async () => {
+  it("puts the size back when the window could not be reached, and lets Retry ask again", async () => {
     useSettingsStore.setState({
       settings: { ...settings, zoom: 150 },
       zoom: 150,
     });
     windowAt(150);
-    vi.mocked(commands.windowSetZoom).mockRejectedValue(new Error("no bridge"));
+    vi.mocked(commands.windowSetZoom).mockResolvedValue(failed("no bridge"));
 
     await expect(
       useSettingsStore.getState().setZoom(160),
@@ -225,7 +225,7 @@ describe("zoom, on screen", () => {
     // otherwise write it.
     expect(zoom()).toBe(150);
     expect(dialog().title).toBe("Couldn't change the zoom");
-    expect(dialog().message).toContain("no bridge");
+    expect(dialog().message).toBe("no bridge");
 
     windowTakes();
     dialog().actions[0].onClick();

--- a/ui/src/stores/settings-zoom.ts
+++ b/ui/src/stores/settings-zoom.ts
@@ -69,11 +69,8 @@ export function zoomActions(
   /** What the window is showing, asked of the window. Null when even that
    *  could not be read, which is the one case nothing here can correct. */
   async function showing(): Promise<number | null> {
-    try {
-      return (await commands.windowZoomState()).percent;
-    } catch {
-      return null;
-    }
+    const state = await commands.windowZoomState();
+    return state.status === "ok" ? state.data.percent : null;
   }
 
   /** Why the window did not take the size, or null when it did. A bridge

--- a/ui/src/stores/settings-zoom.ts
+++ b/ui/src/stores/settings-zoom.ts
@@ -36,10 +36,11 @@ export interface ZoomSlice {
  * written once, when the input settles — a save per step rewrites the
  * settings file dozens of times for one gesture.
  *
- * Neither action ever rejects. Both talk to the window over an IPC bridge
- * that throws when the bridge itself fails rather than replying with an
- * error, and every call site here is a fire-and-forget handler where a
- * rejection would reach nobody.
+ * Neither action ever rejects, and neither does a command it calls: every
+ * one of them answers a `Result`, so the generated bindings fold a bridge
+ * that failed into the same `{ status: "error" }` a refusal arrives in
+ * (`specta_builder` in `crates/app/src/lib.rs`). Every call site here is a
+ * fire-and-forget handler, where a rejection would reach nobody.
  */
 export function zoomActions(
   set: (fields: Partial<ZoomFields>) => void,
@@ -74,15 +75,11 @@ export function zoomActions(
   }
 
   /** Why the window did not take the size, or null when it did. A bridge
-   *  that throws and a reply that says no are the same answer here: the
+   *  that failed and a reply that says no arrive as one answer here: the
    *  window is not showing what the display says it is. */
   async function refused(percent: number): Promise<string | null> {
-    try {
-      const shown = await commands.windowSetZoom(percent);
-      return shown.status === "ok" ? null : shown.error;
-    } catch (error: unknown) {
-      return String(error);
-    }
+    const shown = await commands.windowSetZoom(percent);
+    return shown.status === "ok" ? null : shown.error;
   }
 
   function setZoom(percent: number): Promise<void> {

--- a/ui/src/stores/settings.test.ts
+++ b/ui/src/stores/settings.test.ts
@@ -57,8 +57,8 @@ describe("settings store", () => {
       data: { harnesses: [], items: [], missingProjects: [], warnings: [] },
     });
     vi.mocked(commands.windowZoomState).mockResolvedValue({
-      percent: settings.zoom ?? 100,
-      launchRefused: false,
+      status: "ok",
+      data: { percent: settings.zoom ?? 100, launchRefused: false },
     });
   });
 
@@ -333,7 +333,10 @@ describe("settings store", () => {
       status: "error",
       error: "cannot locate the home directory on this system",
     });
-    vi.mocked(commands.capabilityTable).mockResolvedValue([]);
+    vi.mocked(commands.capabilityTable).mockResolvedValue({
+      status: "ok",
+      data: [],
+    });
 
     await useSettingsStore.getState().load();
 
@@ -345,6 +348,53 @@ describe("settings store", () => {
     );
     expect(useSettingsStore.getState().settings).toBeNull();
   });
+
+  // The window and the capability table answer the same page as the settings
+  // file, and each folds a transport failure into a reply of its own rather
+  // than rejecting past the store. A page built from whichever two answered
+  // would offer actions against tools it could not reach, or draw a size the
+  // window is not at, with nothing on screen having said so.
+  it.each([
+    [
+      "the capability table",
+      () =>
+        vi.mocked(commands.capabilityTable).mockResolvedValue({
+          status: "error",
+          error: "the capability table could not be read",
+        }),
+      "the capability table could not be read",
+    ],
+    [
+      "the window's size",
+      () =>
+        vi.mocked(commands.windowZoomState).mockResolvedValue({
+          status: "error",
+          error: "the window could not be asked its size",
+        }),
+      "the window could not be asked its size",
+    ],
+  ])(
+    "shows the error modal when %s could not be read, and holds no settings",
+    async (_what, breakRead, message) => {
+      vi.mocked(commands.getSettings).mockResolvedValue({
+        status: "ok",
+        data: { settings, base: "file" },
+      });
+      vi.mocked(commands.capabilityTable).mockResolvedValue({
+        status: "ok",
+        data: [],
+      });
+      breakRead();
+
+      await useSettingsStore.getState().load();
+
+      const dialog = useProblemsStore.getState().dialog;
+      expect(dialog.open).toBe(true);
+      expect(dialog.title).toBe("Couldn't load your settings");
+      expect(dialog.message).toBe(message);
+      expect(useSettingsStore.getState().settings).toBeNull();
+    },
+  );
 
   it("shows the error modal and returns an empty list when discovering projects fails", async () => {
     vi.mocked(commands.discoverProjects).mockResolvedValue({

--- a/ui/src/stores/settings.ts
+++ b/ui/src/stores/settings.ts
@@ -129,31 +129,40 @@ export const useSettingsStore = create<SettingsState>((set, get) => {
         commands.capabilityTable(),
         commands.windowZoomState(),
       ]);
-      if (settings.status === "ok") {
-        hold(settings.data, at);
-        set({ capabilities, zoom: webview.percent });
-        // The opening had no UI to say this in, so it is said here rather
-        // than leaving the person with an app that quietly ignored their
-        // size. Both halves are needed: the refusal stands for the whole
-        // session, so on its own it would go on complaining after a resize
-        // put the person back where they wanted to be.
-        const asked = settings.data.settings.zoom ?? ZOOM.default;
-        if (webview.launchRefused && webview.percent !== asked) {
-          useProblemsStore.getState().showError({
-            title: "Couldn't open at your saved zoom",
-            message: `kendex is at ${webview.percent}% instead of the ${asked}% you saved. Your saved zoom is unchanged.`,
-            steps: ["Try again", "If it keeps happening, restart kendex"],
-            actions: [
-              { label: "Retry", onClick: () => void get().setZoom(asked) },
-            ],
-          });
-        }
-      } else {
+      // All three or none. The page gates its actions on the capability
+      // table and draws its slider from the window, so one built out of
+      // whichever two answered would be a page quietly claiming it can do
+      // things it cannot. A read that failed is the transport rather than
+      // anything any of the three refuses, and to the person it is the one
+      // page that would not load — so it is said in one set of words.
+      const couldNotLoad = (message: string) =>
         useProblemsStore.getState().showError({
           title: "Couldn't load your settings",
-          message: settings.error,
+          message,
           steps: ["Try again", "If it keeps happening, restart kendex"],
           actions: [{ label: "Retry", onClick: () => void get().load() }],
+        });
+      if (settings.status === "error") return couldNotLoad(settings.error);
+      if (capabilities.status === "error")
+        return couldNotLoad(capabilities.error);
+      if (webview.status === "error") return couldNotLoad(webview.error);
+
+      hold(settings.data, at);
+      set({ capabilities: capabilities.data, zoom: webview.data.percent });
+      // The opening had no UI to say this in, so it is said here rather
+      // than leaving the person with an app that quietly ignored their
+      // size. Both halves are needed: the refusal stands for the whole
+      // session, so on its own it would go on complaining after a resize
+      // put the person back where they wanted to be.
+      const asked = settings.data.settings.zoom ?? ZOOM.default;
+      if (webview.data.launchRefused && webview.data.percent !== asked) {
+        useProblemsStore.getState().showError({
+          title: "Couldn't open at your saved zoom",
+          message: `kendex is at ${webview.data.percent}% instead of the ${asked}% you saved. Your saved zoom is unchanged.`,
+          steps: ["Try again", "If it keeps happening, restart kendex"],
+          actions: [
+            { label: "Retry", onClick: () => void get().setZoom(asked) },
+          ],
         });
       }
     },


### PR DESCRIPTION
`app_version`, `capability_table`, `mine_authoring_doc` and `window_zoom_state` returned a plain value, so tauri-specta emitted no `typedError` wrapper for them and a channel failure rejected past their callers. Three of those callers dropped the rejection: the Settings page never loaded and said nothing, the authoring-doc dialog sat on its loading skeleton with no message and no retry, and the version field went blank.

Each now answers a `Result` it never refuses with, which is what puts a command behind the wrapper — the shape the issue's overseer comment settled on, at the command boundary rather than three per-caller catches. `deep_link_take` stays outside deliberately: its one caller reads it through `caught`.

`crates/app/tests/bindings.rs` reads the unwrapped set off the generated file and pins it, so a fifth plain-value command is an edit to that list rather than one that regenerates clean and reds nothing. `committed_bindings_are_current` asserts only that the committed file equals what `specta_builder` emits, and says nothing about shape.

Callers read the folded shape: the settings store loads all three reads or none and names whichever failed, the version row says the version could not be read, the guide dialog draws the reason and asks again when reopened, and `notice.ts` and `settings-zoom.ts` read the reply. `ui/src/bindings.ts` is regenerated.

**Second commit** is the local review round. The pin's reader ended the commands object on a bare closing brace, which the generated file first carries some three thousand lines lower inside an exported type, and it classified by scanning back to the nearest `=>` and forward to the first quoted string — both of which tauri-specta can put inside a doc comment in a call's generic. Both anchors are one character wide now, and the pin counts the wrapper in the block and holds the reader to that number. `zoomActions`'s header still claimed a bridge that throws; `window_zoom_state` was the last command making that true, so the header and `refused`'s dead catch went with it. `saveZoom`'s outer catch stands — it guards a whole body rather than one command.

**Controls.** One per surface plus its must-fail, each seen red once: the bindings pin (a command reverted to a plain value reports it), the Settings version row, the mine-tab guide dialog, and the settings store's two-row load table.

`tools/guard --full` clean.

https://claude.ai/code/session_01HYdYQNon5R5GF82NvFGAvD