### PR TITLE
docs: README features and how it works in plain sentences [no-changelog]

### DIFF
--- a/.agents/skills/bot-instructions/README.md
+++ b/.agents/skills/bot-instructions/README.md
@@ -19,7 +19,10 @@ Requires Python 3.11 or newer. Follow [references/checklist.md](references/check
 
 ## How it works
 
-You enable the review bots in the manifest's `[bot-instructions]` table. The renderer reads that table and the shared review rules. It prepares and validates each bot's instruction file before writing it. The check command compares those files with the configured output.
+- You list the review bots you use in the `[bot-instructions]` table of the project's `kendex.toml`.
+- The skill reads that table together with the review rules every bot shares.
+- It checks each bot's instruction file is valid, then writes it where that bot looks for it.
+- The check command compares the files on disk with what the table says they should hold.
 
 ## Settings
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ A package on a local path needs no git. On Windows, `kendex guard` runs the comm
 - Convert agent and skill files into the formats each tool reads.
 - Preview package changes before applying them.
 - Keep personal settings and a separate setup for each project.
-- Manage customizations you already have.
-- Browse the [community marketplace](https://kendex.ai) and subscribe to package repositories.
-- Open a marketplace or package in the app from a `kendex://` link, the scheme the app registers for kendex.ai pages.
+- Adopt customizations you already set up yourself: kendex keeps your files and starts managing them.
+- Browse the [community marketplace](https://kendex.ai) for packages to install.
+- Subscribe to a package repository so you can install from it too.
+- Open a marketplace or a package in the app by clicking a `kendex://` link on a kendex.ai page.
 - Find outdated packages and update them.
-- Add your own instructions to agents and skills, and per-tool settings to agents.
+- Add your own instructions to an agent or a skill.
+- Give one agent different settings in each tool.
 - Enable, disable or remove installed customizations.
 - See where an installed package came from.
 
@@ -61,7 +63,13 @@ The full per-tool facts are in [docs/adapters](docs/adapters/README.md).
 
 ## How it works
 
-The desktop app and CLI share the core code that manages your setup. kendex reads the customizations in each coding tool's folders. A global `kendex.toml` declares your personal setup, and each project can have its own `kendex.toml`. kendex compares that file with the installed setup and shows a preview. After you apply the changes, a lock file records what kendex installed. To undo an installation, remove the package.
+- The desktop app and the CLI read and write the same setup, so a change made in one shows up in the other.
+- You list what you want in a `kendex.toml` file: one for your personal setup, and one inside any project that needs its own.
+- kendex reads the customizations already sitting in each coding tool's folders.
+- It compares your list with what it found, and shows you the difference before it changes anything.
+- You apply the change, and kendex writes the files each tool reads.
+- kendex records what it installed, and where each package came from, in a lock file, so it can update it or take it away later.
+- Delete a package from your list and the next apply deletes its files.
 
 ## Settings
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The full per-tool facts are in [docs/adapters](docs/adapters/README.md).
 - It compares your list with what it found, and shows you the difference before it changes anything.
 - You apply the change, and kendex writes the files each tool reads.
 - kendex records what it installed, and where each package came from, in a lock file, so it can update it or take it away later.
-- Delete a package from your list and the next apply deletes its files.
+- Delete a package from your list and the next apply removes its files, except ones you edited by hand and Pi extensions, which kendex keeps and reports.
 
 ## Settings
 

--- a/pi-extensions/pi-claude-bridge/README.md
+++ b/pi-extensions/pi-claude-bridge/README.md
@@ -28,7 +28,11 @@ Fable 5.1 requires [Claude Code 2.1.255 or later](https://code.claude.com/docs/e
 
 ## How it works
 
-You select a pi-claude model in Pi. Select **Claude Fable 5.1** (`pi-claude/claude-fable-5-1`) for Fable. The bridge starts or resumes Claude Code through the Agent SDK. It sends the prompt and makes Pi's tools available to Claude Code. Tool calls return to Pi for execution, then their results return to Claude Code. Pi displays the response and saves the Claude session identifier.
+- You pick one of the `pi-claude` models in Pi's model menu; **Claude Fable 5.1** is `pi-claude/claude-fable-5-1`.
+- The bridge starts Claude Code, or resumes it, through the Claude Agent SDK, Anthropic's library for driving Claude Code from another program.
+- It sends your prompt to Claude Code and offers it Pi's tools.
+- When Claude Code calls a tool, Pi runs the tool and sends the result back to Claude Code.
+- Pi shows the reply and remembers which Claude Code conversation it belongs to, so your next message continues it.
 
 ## Settings
 

--- a/pi-extensions/pi-extension-manager/README.md
+++ b/pi-extensions/pi-extension-manager/README.md
@@ -26,9 +26,13 @@ Restart the host after installation.
 
 ## How it works
 
-Open `/extensions` on Pi or `/kendex:extensions` on OMP. OMP keeps its built-in `/extensions` command. The manager reads Pi's package settings or OMP's installed plugin records, then displays each package's declared extension entrypoints. OMP keeps user and project entrypoints separate and offers manager settings only for its active installation. Restart the host after toggling a package.
+- Open `/extensions` on Pi, or `/kendex:extensions` on OMP, which keeps its own built-in `/extensions` command.
+- The manager reads Pi's package settings, or OMP's record of the plugins it has installed.
+- It lists each package together with the extension files that package declares.
+- On OMP it keeps packages installed for your user apart from packages installed for the project, and offers its own settings only for the copy that is running.
+- Restart Pi or OMP after you turn a package on or off.
 
-OMP module toggles, updates, uninstall, and other extensions' settings are unavailable in this manager. Use OMP's native controls for those actions, optional plugin features, or project plugin overrides that block enabling a plugin. The manager does not run Pi package commands or Pi append-system scripts on OMP.
+On OMP the manager cannot toggle a plugin's modules, update or uninstall a plugin, or edit another extension's settings. Use OMP's own controls for those actions, for a plugin's optional features, and for a project override that stops a plugin being enabled. The manager also does not run a Pi package's commands or its append-system scripts on OMP.
 
 ## Settings
 

--- a/pi-extensions/pi-hooks/README.md
+++ b/pi-extensions/pi-hooks/README.md
@@ -26,7 +26,7 @@ Restart Pi after installation. Use `kendex update-pi --check` to preview the ins
 ## How it works
 
 - kendex installs the hook scripts, and a registry: the list of which hook runs on which event.
-- Before Pi runs a tool, this extension reads the registry for the project and the one for your user account.
+- Before Pi runs a tool, this extension reads the registry for your user account, and the project's own registry once Pi has marked the workspace trusted.
 - Every hook whose matcher fits is given the tool's name and the arguments it was called with.
 - Pi runs the tool only once every one of those hooks has allowed the call.
 

--- a/pi-extensions/pi-hooks/README.md
+++ b/pi-extensions/pi-hooks/README.md
@@ -25,7 +25,10 @@ Restart Pi after installation. Use `kendex update-pi --check` to preview the ins
 
 ## How it works
 
-kendex installs hook scripts and a hook registry for Pi. Before a tool call, this extension reads the applicable project and user registries. It gives each matching hook the tool name and arguments. Pi runs the tool only after the hooks allow the call.
+- kendex installs the hook scripts, and a registry: the list of which hook runs on which event.
+- Before Pi runs a tool, this extension reads the registry for the project and the one for your user account.
+- Every hook whose matcher fits is given the tool's name and the arguments it was called with.
+- Pi runs the tool only once every one of those hooks has allowed the call.
 
 The other hook events cannot stop anything in Pi, so the extension delivers what a hook says instead:
 
@@ -35,7 +38,11 @@ The other hook events cannot stop anything in Pi, so the extension delivers what
 | `Stop`, `TaskCompleted` | `turn_end`, read once per response on `agent_settled` | Sent to the agent once as a message that starts the next turn. A hook's answer to that message runs the hooks again with `stop_hook_active: true` and is not sent back, so a response runs them at most twice. |
 | `SessionStart` | `session_start` | Added to the session's opening context. |
 
-On those three events every matching hook runs. Exit `2` delivers the hook's stderr, exit `0` delivers its stdout, and any other exit status, a timeout or a missing script is reported to the agent as a hook that did not run. A `PostToolUse` matcher is read against the tool name and a `SessionStart` matcher against the source (`startup`, `resume` or `clear`); `Stop` and `TaskCompleted` hooks take no matcher.
+- Every hook whose matcher fits runs on those three events.
+- A hook that exits `2` hands the agent what it wrote to its error output, and one that exits `0` hands over what it wrote to its normal output.
+- Any other exit status, a hook that runs out of time, and a script that is missing are each reported to the agent as a hook that did not run.
+- A `PostToolUse` matcher is matched against the tool's name, and a `SessionStart` matcher against why the session started: `startup`, `resume` or `clear`.
+- `Stop` and `TaskCompleted` hooks take no matcher, so both always run.
 
 ## Settings
 

--- a/pi-extensions/pi-hooks/README.md
+++ b/pi-extensions/pi-hooks/README.md
@@ -40,7 +40,7 @@ The other hook events cannot stop anything in Pi, so the extension delivers what
 
 - Every hook whose matcher fits runs on those three events.
 - A hook that exits `2` hands the agent what it wrote to its error output, and one that exits `0` hands over what it wrote to its normal output.
-- Any other exit status, a hook that runs out of time, and a script that is missing are each reported to the agent as a hook that did not run.
+- Any other exit status is reported to the agent as a hook that reached no verdict; a hook that ran out of time, or whose script is missing, is reported as one that did not run.
 - A `PostToolUse` matcher is matched against the tool's name, and a `SessionStart` matcher against why the session started: `startup`, `resume` or `clear`.
 - `Stop` and `TaskCompleted` hooks take no matcher, so both always run.
 

--- a/pi-extensions/pi-hooks/README.md
+++ b/pi-extensions/pi-hooks/README.md
@@ -27,7 +27,7 @@ Restart Pi after installation. Use `kendex update-pi --check` to preview the ins
 
 - kendex installs the hook scripts, and a registry: the list of which hook runs on which event.
 - Before Pi runs a tool, this extension reads the registry for your user account, and the project's own registry once Pi has marked the workspace trusted.
-- Every hook whose matcher fits is given the tool's name and the arguments it was called with.
+- It gives each hook whose matcher fits the tool's name and the arguments it was called with, and stops at the first refusal.
 - Pi runs the tool only once every one of those hooks has allowed the call.
 
 The other hook events cannot stop anything in Pi, so the extension delivers what a hook says instead:

--- a/pi-extensions/pi-session-bridge/README.md
+++ b/pi-extensions/pi-session-bridge/README.md
@@ -25,7 +25,11 @@ Restart Pi after installation. Use `kendex update-pi --check` to preview the ins
 
 ## How it works
 
-Each Pi session opens a local socket and writes a discovery record. The CLI uses those records to select the requested session. It sends a request through the socket. The session returns the result and sends subscribed activity updates. Large saved events can be read in full through the history command.
+- Each Pi session opens a connection on your own machine and writes a small file saying where that connection is.
+- The CLI reads those files to find the session you asked for.
+- It sends your request down that channel, and the session sends the result back.
+- A session you subscribed to keeps sending you what it does next.
+- The history command reads a saved event in full when it was too large to return inline.
 
 ## Settings
 

--- a/pi-extensions/pi-session-bridge/README.md
+++ b/pi-extensions/pi-session-bridge/README.md
@@ -29,7 +29,7 @@ Restart Pi after installation. Use `kendex update-pi --check` to preview the ins
 - The CLI reads those files to find the session you asked for.
 - It sends your request down that channel, and the session sends the result back.
 - A session you subscribed to keeps sending you what it does next.
-- The history command reads a saved event in full when it was too large to return inline.
+- `pi-bridge history --raw` reads a saved event in full when it was too large to return inline.
 
 ## Settings
 

--- a/skills/bot-instructions/README.md
+++ b/skills/bot-instructions/README.md
@@ -19,7 +19,10 @@ Requires Python 3.11 or newer. Follow [references/checklist.md](references/check
 
 ## How it works
 
-You enable the review bots in the manifest's `[bot-instructions]` table. The renderer reads that table and the shared review rules. It prepares and validates each bot's instruction file before writing it. The check command compares those files with the configured output.
+- You list the review bots you use in the `[bot-instructions]` table of the project's `kendex.toml`.
+- The skill reads that table together with the review rules every bot shares.
+- It checks each bot's instruction file is valid, then writes it where that bot looks for it.
+- The check command compares the files on disk with what the table says they should hold.
 
 ## Settings
 

--- a/skills/harness-ci/README.md
+++ b/skills/harness-ci/README.md
@@ -21,7 +21,7 @@ Commit the installed skill and generated-file inventory. The CI runner needs `jq
 - kendex writes a list of every file it generated, called the inventory, beside the files it installed.
 - Your CI step tells the checker which GitHub event it is handling and which two commits to compare.
 - The checker works out the range that event needs, then reads the inventory as it stood at each end of that range.
-- It answers `true` only when every file the change touched appears in one of those two inventories.
+- It answers `true` only when every file the change touched is on the inventory at each end where that file exists.
 - Anything it cannot prove answers `false`, and your workflow uses that answer to run or skip the product checks.
 
 ## Settings

--- a/skills/harness-ci/README.md
+++ b/skills/harness-ci/README.md
@@ -12,13 +12,17 @@ Commit the installed skill and generated-file inventory. The CI runner needs `jq
 
 ## Features
 
-- Compare changed files with kendex's generated-file inventory.
+- Compare the files a change touched with the list of files kendex generated.
 - Run product checks for unrecorded files and uncertain results.
 - Support pull requests, pushes and merge-queue events.
 
 ## How it works
 
-kendex writes a generated-file inventory beside the installed files. Your CI step gives the checker the event and the base and head commits. The checker reads both inventories and compares them with the changed files. It returns a value your workflow uses to run or skip product checks.
+- kendex writes a list of every file it generated, called the inventory, beside the files it installed.
+- Your CI step tells the checker which GitHub event it is handling and which two commits to compare.
+- The checker works out the range that event needs, then reads the inventory as it stood at each end of that range.
+- It answers `true` only when every file the change touched appears in one of those two inventories.
+- Anything it cannot prove answers `false`, and your workflow uses that answer to run or skip the product checks.
 
 ## Settings
 


### PR DESCRIPTION
A plain-language pass over the human-facing READMEs, scoped to feature lists and how-it-works sections. SKILL.md, AGENTS.md and reference files are untouched; they are agent instruction and terse by rule.

All 40 READMEs were audited. Most already read as short plain sentences, so this touches the seven where a section used a term it never defined, packed several ideas into one sentence, or stated mechanics inline.

| File | What was wrong |
| --- | --- |
| `README.md` | four feature bullets vague or doubled up; how it works was a six-sentence paragraph naming an undefined lock file |
| `skills/bot-instructions/README.md` | "the manifest" and "the renderer", neither named |
| `skills/harness-ci/README.md` | "generated-file inventory" used twice and never defined; "both inventories" ambiguous |
| `pi-extensions/pi-claude-bridge/README.md` | "Agent SDK" and "session identifier" unglossed |
| `pi-extensions/pi-extension-manager/README.md` | "extension entrypoints" unglossed; a run-on limits paragraph |
| `pi-extensions/pi-hooks/README.md` | "registry" unglossed; the exit-code and matcher rules as one 34-word sentence |
| `pi-extensions/pi-session-bridge/README.md` | "local socket" and "discovery record" unglossed |

Every fact was kept and nothing moved out of a README. `.agents/skills/bot-instructions/README.md` is the one tracked render affected, replayed with `git apply` and byte-identical to its source.

## Review

One local reviewer-doc round returned seven findings, all applied. Two were blocking:

- `README.md` said "take over customizations you already set up yourself". *Take-over* is kendex's own word for the exit that keeps the declaration and trashes your files (`docs/architecture/overview.md` § Vocabulary); the feature meant is adopt. A reader following that bullet into the app would have picked the destructive option.
- `README.md` claimed the app and the CLI "both give the same result". `fork_beside` and `package::update_one` are app-only, so the pass had introduced a false parity claim.

The rest restored the `kendex://` scheme name and the lock file to the root README, corrected `harness-ci` to say the inventory is read at each end of the range the event needs (for a pull request that is the merge base and the head, not the two commits CI passed), corrected `pi-extension-manager` to say the manager lists the extension files a package declares, and dropped "private" from `pi-session-bridge`, since keeping the socket private is something the operator arranges.

## Validation

`doc-limits` 713 documents, `md-format`, `md-refs` 623 references, `prose`, `preflight`, `bot-instructions check --staged` and the full staged pre-commit chain are clean.

`tools/guard --full` is otherwise clean with three unresolved lanes, none reachable from a markdown-only diff:

- the `ui` vitest lane fails two tests in `ui/src/pages/package.test.tsx`, both `Test timed out in 5000ms`;
- the `pi-extension-manager` lane fails the same way;
- the same suite fails on a clean `main` checkout under the same conditions, on its own wall-clock assertion.

These ran under a load average of 175 on 32 cores from seven concurrent sibling guard runs. `pi-claude-bridge` passes 543/543 in this worktree, and `pi-extension-manager` passed 50/50 on `main` before the load rose.

Program tracker: KEN-1203.

https://claude.ai/code/session_01W8E1dH7G5BikPYnTsPWw9L
