### PR TITLE
test(KEN-926): the verdict arms are run, not grepped

### DIFF
--- a/.agents/skills/review-gate/tests/pr-watch.test.sh
+++ b/.agents/skills/review-gate/tests/pr-watch.test.sh
@@ -303,6 +303,8 @@ V_THREADS2='verdict=threads-open detail=2 unresolved review threads'
 V_CHANGES='verdict=changes-requested detail=reviewer objects'
 V_AWAITING='verdict=awaiting detail=no evidence'
 V_OFF='verdict=approved detail=review gate disabled by settings (REVIEW_GATE_MODE=off)'
+V_UNTRACKED='verdict=untracked-claim detail=1 tracking claim naming no issue'
+V_UNREASONED='verdict=unreasoned-decline detail=1 decline naming no mechanism'
 V_GARBAGE='garbage output with no verdict'
 # Raw reviewThreads bodies: a cursor that never advances, page one of two
 # (both resolved), page two with one open or one resolved thread, and the
@@ -497,6 +499,30 @@ table "must-fail: without the branch binding another lane's record is reported||
 mutant_watch empty-branch-guard 's#if \[ -n "$branch" \]; then#if true; then#' 'if [ -n "$branch" ]; then'
 table "must-fail: without the empty-branch guard a branchless lane's record is reported||ORCH_STATE_DIR=$SD_NOBRANCH;STUB_OPEN_PRS=$P7UNOREF;STUB_VERDICT_LINE=$V_APPROVED;STUB_GATE_HISTORY=$G_OK|rc=1 kinds=disarmed size=214/250/85%@aaaaaaaa"
 
+WATCH_BIN="$LIVE_WATCH"
+
+echo "=== the predicate's disposition verdicts reach the reducer ==="
+# The two thread-disposition verdicts the predicate can return, driven through
+# the reducer arm that consumes each. unreasoned-decline.test.sh decides both
+# terms and stops at the count; these rows are the other half — the verdict
+# named in the kind column, the attention exit, the stale-green companion a
+# green gate over either verdict earns, and the writer dispatch --heal makes
+# of it. A presence grep on the arm stood in for these rows until the suite
+# they belong beside stopped being size-capped; a grep passes on a branch
+# nothing runs.
+table \
+  "unreasoned-decline is its own kind and its own attention||STUB_OPEN_PRS=$P7;STUB_VERDICT_LINE=$V_UNREASONED;STUB_GATE_HISTORY=$G_PENDING|rc=1 kinds=unreasoned-decline" \
+  "a green gate over it is gate-stale and --heal dispatches the writer at it|--heal|STUB_OPEN_PRS=$P7;STUB_VERDICT_LINE=$V_UNREASONED;STUB_GATE_HISTORY=$G_OK|rc=1 kinds=unreasoned-decline,gate-stale,heal-dispatched dispatches=1" \
+  "untracked-claim is its own kind and its own attention||STUB_OPEN_PRS=$P7;STUB_VERDICT_LINE=$V_UNTRACKED;STUB_GATE_HISTORY=$G_PENDING|rc=1 kinds=untracked-claim" \
+  "a green gate over it is gate-stale and heals the same way|--heal|STUB_OPEN_PRS=$P7;STUB_VERDICT_LINE=$V_UNTRACKED;STUB_GATE_HISTORY=$G_OK|rc=1 kinds=untracked-claim,gate-stale,heal-dispatched dispatches=1"
+
+# The rows above read a kind column, and a column can be right for the wrong
+# reason: the predicate's verdict word is in the stubbed input, so a reducer
+# that echoed its input would satisfy them. With the kind the unreasoned arm
+# emits misspelled, the first row must read the misspelling and nothing else
+# about the run may move.
+mutant_watch emitted-kind 's| unreasoned-decline "$detail$queued"| unreasoned-declined "$detail$queued"|' ' unreasoned-decline "$detail$queued"'
+table "must-fail: with the emitted kind misspelled the row reads the misspelling||STUB_OPEN_PRS=$P7;STUB_VERDICT_LINE=$V_UNREASONED;STUB_GATE_HISTORY=$G_PENDING|rc=1 kinds=unreasoned-declined"
 WATCH_BIN="$LIVE_WATCH"
 
 echo "=== the thread walk is paged, summed and bounded ==="

--- a/.agents/skills/review-gate/tests/unreasoned-decline.test.sh
+++ b/.agents/skills/review-gate/tests/unreasoned-decline.test.sh
@@ -16,9 +16,12 @@
 # reply can fall in the seam, which is why `caught_by_either` below reads both
 # counts rather than one.
 #
-# Neither verdict's mapping to a failure status is here: review-writer.test.sh
-# runs both through the writer, w8/w8b for unreasoned-decline and w9/w9b for
-# untracked-claim.
+# Neither verdict's consumers are here, and neither is checked by presence:
+# review-writer.test.sh runs both through the writer, w8/w8b for
+# unreasoned-decline and w9/w9b for untracked-claim, and pr-watch.test.sh
+# runs both through the reducer under `the predicate's disposition verdicts
+# reach the reducer` — the kind column, the attention exit, the stale-green
+# companion and the heal dispatch.
 #
 # The fixtures are tests/corpus/, not literals in here, and adding a label
 # starts there. Each label is paired with the real reason that must
@@ -36,7 +39,6 @@
 # piece and not to the fixture.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WATCH="$SCRIPT_DIR/../scripts/pr-watch.sh"
 PRED="$SCRIPT_DIR/../scripts/review-predicate.sh"
 PASS=0 FAIL=0
 ok()  { PASS=$((PASS+1)); echo "  ok    $1"; }
@@ -256,16 +258,6 @@ case "$out" in "0 0 "*) ok "a Declined: reply with a naked track-word is never a
 
 out=$(page "$(thread true "$(human 'Tracked: KEN-1')" true)")
 case "$out" in malformed) ok "a 50+-comment thread fails closed as malformed";; *) bad "a 50+-comment thread fails closed as malformed" "$out";; esac
-
-echo "=== the verdict reaches its consumers ==="
-# The writer's mapping is RUN, not grepped: review-writer.test.sh w8/w8b
-# drive this verdict through the writer and assert the failure post and the
-# remedy text. A presence grep would pass on a branch nothing executed.
-#
-# pr-watch's mapping is checked by presence here.
-grep -q 'unreasoned-decline)' "$WATCH" \
-  && ok "pr-watch carries the unreasoned-decline arm" \
-  || bad "pr-watch carries the unreasoned-decline arm" "not referenced"
 
 echo
 echo "--- must-fail probe: the term, reverted ---"

--- a/skills/review-gate/tests/pr-watch.test.sh
+++ b/skills/review-gate/tests/pr-watch.test.sh
@@ -303,6 +303,8 @@ V_THREADS2='verdict=threads-open detail=2 unresolved review threads'
 V_CHANGES='verdict=changes-requested detail=reviewer objects'
 V_AWAITING='verdict=awaiting detail=no evidence'
 V_OFF='verdict=approved detail=review gate disabled by settings (REVIEW_GATE_MODE=off)'
+V_UNTRACKED='verdict=untracked-claim detail=1 tracking claim naming no issue'
+V_UNREASONED='verdict=unreasoned-decline detail=1 decline naming no mechanism'
 V_GARBAGE='garbage output with no verdict'
 # Raw reviewThreads bodies: a cursor that never advances, page one of two
 # (both resolved), page two with one open or one resolved thread, and the
@@ -497,6 +499,30 @@ table "must-fail: without the branch binding another lane's record is reported||
 mutant_watch empty-branch-guard 's#if \[ -n "$branch" \]; then#if true; then#' 'if [ -n "$branch" ]; then'
 table "must-fail: without the empty-branch guard a branchless lane's record is reported||ORCH_STATE_DIR=$SD_NOBRANCH;STUB_OPEN_PRS=$P7UNOREF;STUB_VERDICT_LINE=$V_APPROVED;STUB_GATE_HISTORY=$G_OK|rc=1 kinds=disarmed size=214/250/85%@aaaaaaaa"
 
+WATCH_BIN="$LIVE_WATCH"
+
+echo "=== the predicate's disposition verdicts reach the reducer ==="
+# The two thread-disposition verdicts the predicate can return, driven through
+# the reducer arm that consumes each. unreasoned-decline.test.sh decides both
+# terms and stops at the count; these rows are the other half — the verdict
+# named in the kind column, the attention exit, the stale-green companion a
+# green gate over either verdict earns, and the writer dispatch --heal makes
+# of it. A presence grep on the arm stood in for these rows until the suite
+# they belong beside stopped being size-capped; a grep passes on a branch
+# nothing runs.
+table \
+  "unreasoned-decline is its own kind and its own attention||STUB_OPEN_PRS=$P7;STUB_VERDICT_LINE=$V_UNREASONED;STUB_GATE_HISTORY=$G_PENDING|rc=1 kinds=unreasoned-decline" \
+  "a green gate over it is gate-stale and --heal dispatches the writer at it|--heal|STUB_OPEN_PRS=$P7;STUB_VERDICT_LINE=$V_UNREASONED;STUB_GATE_HISTORY=$G_OK|rc=1 kinds=unreasoned-decline,gate-stale,heal-dispatched dispatches=1" \
+  "untracked-claim is its own kind and its own attention||STUB_OPEN_PRS=$P7;STUB_VERDICT_LINE=$V_UNTRACKED;STUB_GATE_HISTORY=$G_PENDING|rc=1 kinds=untracked-claim" \
+  "a green gate over it is gate-stale and heals the same way|--heal|STUB_OPEN_PRS=$P7;STUB_VERDICT_LINE=$V_UNTRACKED;STUB_GATE_HISTORY=$G_OK|rc=1 kinds=untracked-claim,gate-stale,heal-dispatched dispatches=1"
+
+# The rows above read a kind column, and a column can be right for the wrong
+# reason: the predicate's verdict word is in the stubbed input, so a reducer
+# that echoed its input would satisfy them. With the kind the unreasoned arm
+# emits misspelled, the first row must read the misspelling and nothing else
+# about the run may move.
+mutant_watch emitted-kind 's| unreasoned-decline "$detail$queued"| unreasoned-declined "$detail$queued"|' ' unreasoned-decline "$detail$queued"'
+table "must-fail: with the emitted kind misspelled the row reads the misspelling||STUB_OPEN_PRS=$P7;STUB_VERDICT_LINE=$V_UNREASONED;STUB_GATE_HISTORY=$G_PENDING|rc=1 kinds=unreasoned-declined"
 WATCH_BIN="$LIVE_WATCH"
 
 echo "=== the thread walk is paged, summed and bounded ==="

--- a/skills/review-gate/tests/unreasoned-decline.test.sh
+++ b/skills/review-gate/tests/unreasoned-decline.test.sh
@@ -16,9 +16,12 @@
 # reply can fall in the seam, which is why `caught_by_either` below reads both
 # counts rather than one.
 #
-# Neither verdict's mapping to a failure status is here: review-writer.test.sh
-# runs both through the writer, w8/w8b for unreasoned-decline and w9/w9b for
-# untracked-claim.
+# Neither verdict's consumers are here, and neither is checked by presence:
+# review-writer.test.sh runs both through the writer, w8/w8b for
+# unreasoned-decline and w9/w9b for untracked-claim, and pr-watch.test.sh
+# runs both through the reducer under `the predicate's disposition verdicts
+# reach the reducer` — the kind column, the attention exit, the stale-green
+# companion and the heal dispatch.
 #
 # The fixtures are tests/corpus/, not literals in here, and adding a label
 # starts there. Each label is paired with the real reason that must
@@ -36,7 +39,6 @@
 # piece and not to the fixture.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WATCH="$SCRIPT_DIR/../scripts/pr-watch.sh"
 PRED="$SCRIPT_DIR/../scripts/review-predicate.sh"
 PASS=0 FAIL=0
 ok()  { PASS=$((PASS+1)); echo "  ok    $1"; }
@@ -256,16 +258,6 @@ case "$out" in "0 0 "*) ok "a Declined: reply with a naked track-word is never a
 
 out=$(page "$(thread true "$(human 'Tracked: KEN-1')" true)")
 case "$out" in malformed) ok "a 50+-comment thread fails closed as malformed";; *) bad "a 50+-comment thread fails closed as malformed" "$out";; esac
-
-echo "=== the verdict reaches its consumers ==="
-# The writer's mapping is RUN, not grepped: review-writer.test.sh w8/w8b
-# drive this verdict through the writer and assert the failure post and the
-# remedy text. A presence grep would pass on a branch nothing executed.
-#
-# pr-watch's mapping is checked by presence here.
-grep -q 'unreasoned-decline)' "$WATCH" \
-  && ok "pr-watch carries the unreasoned-decline arm" \
-  || bad "pr-watch carries the unreasoned-decline arm" "not referenced"
 
 echo
 echo "--- must-fail probe: the term, reverted ---"


### PR DESCRIPTION
Closes KEN-926.

The last STOPGAP presence check in `skills/review-gate/tests/unreasoned-decline.test.sh` was `grep -q 'unreasoned-decline)' "$WATCH"` — it asserted only that a literal appears in `pr-watch.sh`, passed on a branch nothing executes, and said nothing at all about `untracked-claim`. It is gone, along with the section that held it and the now-unused `WATCH` variable; that file's header note now delegates both consumers, the way it already delegated the writer to `review-writer.test.sh`.

### Where the rows landed, and why

In `skills/review-gate/tests/pr-watch.test.sh`, not inside `unreasoned-decline.test.sh`. That suite already owns the sandbox — the real `pr-watch.sh` over a stubbed `gh` and a stubbed predicate — and the `table`/`observe` harness. `d5c958928` (KEN-1013) wrote that these rows "belong in pr-watch.test.sh beside every other verdict" and named that file's frozen size-ratchet row as the only thing stopping them; KEN-1222 removed source-line ratchets in #2131. Restating the 150-line `gh` stub inside `unreasoned-decline.test.sh` would have broken that file's own rule that a fixture written twice is a fixture that drifts in one place.

### What runs

Four rows under `=== the predicate's disposition verdicts reach the reducer ===`, one assertion each, over both disposition verdicts: the kind column, the attention exit, the stale-green companion a green gate over either verdict earns, and the writer dispatch `--heal` makes of it.

One must-fail control follows, through the `mutant_watch` helper KEN-1186 (#2260) put in this file rather than a second copy of that verb: it misspells the kind the unreasoned arm emits and pins the first row to the misspelling, with the anchor asserted present once before the mutation and gone after.

### Planted-defect proofs

Each defect the issue names was run against the table on a copy of `pr-watch.sh` outside the worktree, after the restack onto current main. Rows numbered in table order.

| planted defect | rows red |
|---|---|
| misspelled emitted kind (unreasoned arm) | 1, 2 |
| dropped `attention=1` (unreasoned arm) | 1, 2 |
| stale-green branch unable to fire (that arm's `= "success"`) | 2 |
| removed `heal` dispatch from `stale_gate()` | 2, 4 |
| verdict dropped from the accept-list `case` | 1, 2 |

No mutant reddened a row it should not. The `mutant_watch` anchor guard also proved itself: under the misspelling planted at source it reported `mutant emitted-kind: its anchor stands once in the live script` as a failure rather than asserting against an unplanted mutant.

### Checks

- `skills/review-gate/tests/pr-watch.test.sh` — 114/114
- `skills/review-gate/tests/unreasoned-decline.test.sh` — 309/309
- Tracked renders under `.agents/` byte-identical to source
- `tools/guard --full` — the staged chain, `bash32-lint`, all Rust and skill suites clean. The `ui` vitest leg timed out on three DOM tests; the machine was at load average 113-175 with sixteen concurrent lanes, a different set of files timed out on each run, and all of them pass in isolation. This change touches no TypeScript.

One local reviewer round (reviewer-test): pass, no blockers. Its one suggestion — drop a row that killed nothing another row did not — was taken before the commit.

https://claude.ai/code/session_01Aqk6E758HMF11E5JybreXA
