### PR TITLE
fix(KEN-577): a kind badge counts the rows its click opens

### DIFF
--- a/changelog.d/fixed/577.md
+++ b/changelog.d/fixed/577.md
@@ -1,0 +1,1 @@
+- Count packages, not installations, on the Harnesses and Projects kind badges, so a badge's number is the number of rows in the Library view its click opens.

--- a/ui/src/components/harnesses/harness-list.dom.test.tsx
+++ b/ui/src/components/harnesses/harness-list.dom.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ObservedItem, ScanResult, Scope } from "@/bindings";
+import { InstalledView } from "@/components/library/installed-view";
+import { kindLabel } from "@/lib/labels";
+import { READ_LANDED } from "@/lib/read-state";
+import { useEditorStore } from "@/stores/editor";
+import { useLibraryViewStore } from "@/stores/library-view";
+import { useNavStore } from "@/stores/nav";
+import { useProvenanceStore } from "@/stores/provenance";
+import { useScanStore } from "@/stores/scan";
+import { useSettingsStore } from "@/stores/settings";
+import { useUpdatesStore } from "@/stores/updates";
+import { mount } from "@/test/dom";
+import { HarnessList } from "./harness-list";
+
+const ACME: Scope = { scope: "project", root: "/work/acme" };
+
+const installed = (overrides: Partial<ObservedItem>): ObservedItem => ({
+  kind: "skill",
+  name: "deploy",
+  harness: "claude",
+  scope: { scope: "global" },
+  path: "/h/.claude/skills/deploy",
+  fileState: { state: "dir" },
+  enabled: true,
+  origin: null,
+  description: null,
+  tags: [],
+  modifiedAt: null,
+  vendor: null,
+  ...overrides,
+});
+
+// Claude carries two skills over three installations: one of them lives
+// globally and in a project both. Counting installations puts 3 on the badge
+// over a table of 2 rows, which is what these cases are here to catch.
+const scanned: ScanResult = {
+  harnesses: [
+    { harness: "claude", root: "/h/.claude", version: null },
+    { harness: "codex", root: "/h/.codex", version: null },
+  ],
+  items: [
+    installed({}),
+    installed({ scope: ACME, path: "/work/acme/.claude/skills/deploy" }),
+    installed({ name: "lint", path: "/h/.claude/skills/lint" }),
+    installed({ harness: "codex", path: "/h/.codex/skills/deploy" }),
+  ],
+  missingProjects: [],
+  warnings: [],
+};
+
+// Read off the badge's own wording rather than a second copy of it here, so
+// a relabelled kind fails as a missing badge rather than passing vacuously.
+const SKILL_BADGE = new RegExp(
+  `^(\\d+) (${kindLabel("skill", 1)}|${kindLabel("skill", 2)})$`,
+);
+
+/** The skills badge on the row for one harness. */
+function skillBadge(host: HTMLElement, harness: string): HTMLButtonElement {
+  const row = [...host.querySelectorAll<HTMLElement>("div.group")].find((el) =>
+    el.textContent?.startsWith(harness),
+  );
+  if (!row) throw new Error(`no row for ${harness}`);
+  const badge = [...row.querySelectorAll<HTMLButtonElement>("button")].find(
+    (b) => SKILL_BADGE.test(b.textContent ?? ""),
+  );
+  if (!badge) throw new Error(`no skills badge on the ${harness} row`);
+  return badge;
+}
+
+const badgeCount = (host: HTMLElement, harness: string): number =>
+  Number(SKILL_BADGE.exec(skillBadge(host, harness).textContent ?? "")?.[1]);
+
+/** The rows the Library actually renders for the view the click handed it. */
+const destinationRows = (): number =>
+  mount(<InstalledView />).querySelectorAll("tbody tr").length;
+
+beforeEach(() => {
+  vi.spyOn(useProvenanceStore.getState(), "load").mockResolvedValue();
+  vi.spyOn(useEditorStore.getState(), "loadAll").mockResolvedValue();
+  useUpdatesStore.setState({ rows: [], read: READ_LANDED });
+  useScanStore.setState({ scanning: false, result: scanned, error: null });
+  useSettingsStore.setState({ settings: { projects: [] } as never });
+  useNavStore.setState({
+    page: "harnesses",
+    libraryFilter: null,
+    libraryScope: "all",
+    search: "",
+  });
+  useLibraryViewStore.setState({
+    kind: "any",
+    harness: "any",
+    tag: "any",
+    from: "any",
+  });
+});
+
+// A badge is a promise about the page behind it. The Library shows one row
+// per package however many harnesses or places carry it, so a badge counting
+// installations lands on a table shorter than the number just clicked.
+describe("a harness row's kind badge", () => {
+  it("shows the row count of the view its click opens", () => {
+    const host = mount(<HarnessList />);
+    const badge = badgeCount(host, "Claude Code");
+
+    act(() => skillBadge(host, "Claude Code").click());
+    expect(useNavStore.getState().libraryFilter).toEqual({
+      harness: "claude",
+      kind: "skill",
+    });
+    expect(badge).toBe(destinationRows());
+  });
+
+  // The must-fail control: three installations of two packages sit behind
+  // the Claude row, so 3 is the pre-fix number this case rejects. Without
+  // it the equality above would hold on any pair that moved together.
+  it("counts packages rather than the installations behind them", () => {
+    const host = mount(<HarnessList />);
+    expect(badgeCount(host, "Claude Code")).toBe(2);
+    expect(badgeCount(host, "Codex")).toBe(1);
+  });
+});

--- a/ui/src/components/harnesses/harness-list.tsx
+++ b/ui/src/components/harnesses/harness-list.tsx
@@ -1,7 +1,7 @@
 import type { HarnessId } from "@/bindings";
 import { HarnessRow } from "@/components/harnesses/harness-row";
 import { Button } from "@/components/ui/button";
-import { countByKind } from "@/lib/derive";
+import { installedCountByKind } from "@/lib/derive";
 import { CONTENT_WIDTH, PAGE_BODY } from "@/lib/layout";
 import { useScanStore } from "@/stores/scan";
 import { useSettingsStore } from "@/stores/settings";
@@ -59,12 +59,15 @@ export function HarnessList() {
         <div className="flex flex-col">
           {rows.map((id) => {
             const info = result?.harnesses.find((h) => h.harness === id);
-            const items = result?.items.filter((i) => i.harness === id) ?? [];
-            const counts = countByKind(items);
+            // The row's badges count what this harness holds, and its links
+            // ask the Library for the same place — one object, so neither
+            // can be narrowed without the other.
+            const place = { harness: id };
+            const counts = installedCountByKind(result?.items ?? [], place);
             return (
               <HarnessRow
                 key={id}
-                id={id}
+                place={place}
                 detectedRoot={info?.root ?? null}
                 version={info?.version ?? null}
                 counts={[...counts.entries()]}

--- a/ui/src/components/harnesses/harness-row.test.tsx
+++ b/ui/src/components/harnesses/harness-row.test.tsx
@@ -20,7 +20,7 @@ const mount = (detectedRoot: string | null) => {
   useNavStore.setState(navHome);
   return mountTree(
     <HarnessRow
-      id="claude"
+      place={{ harness: "claude" }}
       detectedRoot={detectedRoot}
       version={null}
       counts={[["skill", 3]]}

--- a/ui/src/components/harnesses/harness-row.tsx
+++ b/ui/src/components/harnesses/harness-row.tsx
@@ -7,6 +7,7 @@ import { ShowEverythingButton } from "@/components/harnesses/show-everything-but
 import { KindCountBadges } from "@/components/kind-count-badges";
 import { Button } from "@/components/ui/button";
 import { HARNESS_FOLDER_HELP, NOT_INSTALLED_LABEL } from "@/lib/copy";
+import type { ItemPlace } from "@/lib/derive";
 import { harnessName } from "@/lib/labels";
 import { cn } from "@/lib/utils";
 import { useNavStore } from "@/stores/nav";
@@ -18,14 +19,17 @@ import { useNavStore } from "@/stores/nav";
  * harnesses, one "Set folder" button each, would say the same thing twice and
  * bury the fact that almost nobody needs it. */
 export function HarnessRow({
-  id,
+  place,
   detectedRoot,
   version,
   counts,
   folder,
   onFolderChange,
 }: {
-  id: HarnessId;
+  /** What this row is a row of, in the form the Library takes: the same
+   * object the counts were taken over, so every link below asks for the
+   * set that was counted rather than a second description of it. */
+  place: ItemPlace & { harness: HarnessId };
   detectedRoot: string | null;
   version: string | null;
   counts: [ItemKind, number][];
@@ -35,6 +39,7 @@ export function HarnessRow({
 }) {
   const goToLibrary = useNavStore((s) => s.goToLibrary);
   const [editing, setEditing] = useState(false);
+  const id = place.harness;
   const name = harnessName(id);
 
   return (
@@ -47,7 +52,7 @@ export function HarnessRow({
           {detectedRoot ? (
             <ShowEverythingButton
               name={name}
-              onOpen={() => goToLibrary({ harness: id })}
+              onOpen={() => goToLibrary(place)}
             />
           ) : (
             <span className="text-sm font-medium text-muted-foreground">
@@ -96,7 +101,7 @@ export function HarnessRow({
         <div className="flex shrink-0 flex-wrap justify-end gap-1.5 pt-0.5">
           <KindCountBadges
             counts={counts}
-            onKindClick={(kind) => goToLibrary({ harness: id, kind })}
+            onKindClick={(kind) => goToLibrary({ ...place, kind })}
           />
         </div>
       ) : null}

--- a/ui/src/components/harnesses/project-list.dom.test.tsx
+++ b/ui/src/components/harnesses/project-list.dom.test.tsx
@@ -1,14 +1,27 @@
 // @vitest-environment jsdom
 import { act } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { AuditView, DriftRow, ScanResult, Scope } from "@/bindings";
+import type {
+  AuditView,
+  DriftRow,
+  ObservedItem,
+  ScanResult,
+  Scope,
+} from "@/bindings";
 import { commands } from "@/bindings";
+import { InstalledView } from "@/components/library/installed-view";
 import { ADOPTABLE } from "@/lib/adoptable";
 import { unmanagedHereLabel } from "@/lib/copy";
+import { kindLabel } from "@/lib/labels";
 import { READ_LANDED } from "@/lib/read-state";
 import { useAuditStore } from "@/stores/audit";
+import { useEditorStore } from "@/stores/editor";
+import { useLibraryViewStore } from "@/stores/library-view";
+import { useNavStore } from "@/stores/nav";
+import { useProvenanceStore } from "@/stores/provenance";
 import { useScanStore } from "@/stores/scan";
 import { useSettingsStore } from "@/stores/settings";
+import { useUpdatesStore } from "@/stores/updates";
 import { mount, settle } from "@/test/dom";
 import { ProjectList } from "./project-list";
 
@@ -132,5 +145,114 @@ describe("a project added while the list is on screen", () => {
     expect(vi.mocked(commands.auditAll).mock.calls.length).toBeGreaterThan(
       beforeRegistering,
     );
+  });
+});
+
+const installed = (overrides: Partial<ObservedItem>): ObservedItem => ({
+  kind: "skill",
+  name: "deploy",
+  harness: "claude",
+  scope: { scope: "global" },
+  path: "/h/.claude/skills/deploy",
+  fileState: { state: "dir" },
+  enabled: true,
+  origin: null,
+  description: null,
+  tags: [],
+  modifiedAt: null,
+  vendor: null,
+  ...overrides,
+});
+
+// Personal holds two skills over three installations: one of them is applied
+// to two harnesses. Counting installations puts 3 on the card's badge over a
+// table of 2 rows, which is what these cases are here to catch. The project's
+// own skill is at another place and belongs to neither number.
+const machine: ScanResult = {
+  ...emptyScan,
+  items: [
+    installed({}),
+    installed({ harness: "codex", path: "/h/.codex/skills/deploy" }),
+    installed({ name: "lint", path: "/h/.claude/skills/lint" }),
+    installed({
+      name: "release",
+      scope: ACME,
+      path: "/work/acme/.claude/skills/release",
+    }),
+  ],
+};
+
+// Read off the badge's own wording rather than a second copy of it here, so
+// a relabelled kind fails as a missing badge rather than passing vacuously.
+const SKILL_BADGE = new RegExp(
+  `^(\\d+) (${kindLabel("skill", 1)}|${kindLabel("skill", 2)})$`,
+);
+
+/** The skills badge on the card whose name button reads `name`. */
+function skillBadge(host: HTMLElement, name: string): HTMLButtonElement {
+  const card = [...host.querySelectorAll<HTMLElement>('[data-slot="card"]')]
+    .filter((el) => el.textContent?.startsWith(name))
+    .at(0);
+  if (!card) throw new Error(`no card for ${name}`);
+  const badge = [...card.querySelectorAll<HTMLButtonElement>("button")].find(
+    (b) => SKILL_BADGE.test(b.textContent ?? ""),
+  );
+  if (!badge) throw new Error(`no skills badge on the ${name} card`);
+  return badge;
+}
+
+const badgeCount = (host: HTMLElement, name: string): number =>
+  Number(SKILL_BADGE.exec(skillBadge(host, name).textContent ?? "")?.[1]);
+
+/** The rows the Library actually renders for the view the click handed it. */
+const destinationRows = (): number =>
+  mount(<InstalledView />).querySelectorAll("tbody tr").length;
+
+// A badge is a promise about the page behind it. The Library shows one row
+// per package however many harnesses or places carry it, so a badge counting
+// installations lands on a table shorter than the number just clicked.
+describe("a place card's kind badge", () => {
+  beforeEach(() => {
+    vi.spyOn(useProvenanceStore.getState(), "load").mockResolvedValue();
+    vi.spyOn(useEditorStore.getState(), "loadAll").mockResolvedValue();
+    useUpdatesStore.setState({ rows: [], read: READ_LANDED });
+    useScanStore.setState({ scanning: false, result: machine, error: null });
+    useSettingsStore.setState({
+      settings: { projects: ["/work/acme"] } as never,
+    });
+    useNavStore.setState({
+      page: "projects",
+      libraryFilter: null,
+      libraryScope: "all",
+      search: "",
+    });
+    useLibraryViewStore.setState({
+      kind: "any",
+      harness: "any",
+      tag: "any",
+      from: "any",
+    });
+  });
+
+  it("shows the row count of the view its click opens", () => {
+    const host = mount(<ProjectList />);
+    const badge = badgeCount(host, "Personal");
+
+    act(() => skillBadge(host, "Personal").click());
+    expect(useNavStore.getState().libraryFilter).toEqual({
+      scope: "global",
+      kind: "skill",
+    });
+    expect(badge).toBe(destinationRows());
+  });
+
+  // The must-fail control: three installations of two packages sit behind
+  // Personal, so 3 is the pre-fix number this case rejects. Without it the
+  // equality above would hold on any pair that moved together. The project
+  // card pins that a place counts only what is at it.
+  it("counts packages rather than the installations behind them", () => {
+    const host = mount(<ProjectList />);
+    expect(badgeCount(host, "Personal")).toBe(2);
+    expect(badgeCount(host, "acme")).toBe(1);
   });
 });

--- a/ui/src/components/harnesses/project-list.tsx
+++ b/ui/src/components/harnesses/project-list.tsx
@@ -7,7 +7,7 @@ import { ProjectCard } from "@/components/harnesses/project-card";
 import { ScanFolderDialog } from "@/components/harnesses/scan-folder-dialog";
 import { Button } from "@/components/ui/button";
 import { unmanagedCount } from "@/lib/audit-counts";
-import { countByKind } from "@/lib/derive";
+import { type ItemPlace, installedCountByKind } from "@/lib/derive";
 import { CONTENT_WIDTH, PAGE_BODY } from "@/lib/layout";
 import { sameScope } from "@/lib/scope";
 import { cn } from "@/lib/utils";
@@ -44,9 +44,11 @@ export function ProjectList() {
   const [adding, setAdding] = useState(false);
   const [scanning, setScanning] = useState(false);
 
-  const globalItems =
-    result?.items.filter((i) => i.scope.scope === "global") ?? [];
+  const items = result?.items ?? [];
   const projects = settings?.projects ?? [];
+  // A card counts one place and links to that place. Both read the same
+  // object, so the badge cannot name a narrowing its click does not make.
+  const personal: ItemPlace = { scope: "global" };
 
   return (
     <div className={PAGE_BODY}>
@@ -64,10 +66,10 @@ export function ProjectList() {
         <ProjectCard
           name="Personal"
           subtitle="Works in every project on this computer"
-          counts={[...countByKind(globalItems).entries()]}
+          counts={[...installedCountByKind(items, personal).entries()]}
           emptyLabel="Nothing from kendex yet."
-          onOpen={() => goToLibrary({ scope: "global" })}
-          onKindClick={(kind) => goToLibrary({ kind, scope: "global" })}
+          onOpen={() => goToLibrary(personal)}
+          onKindClick={(kind) => goToLibrary({ ...personal, kind })}
           unmanaged={notManaged(GLOBAL)}
           onUnmanaged={() => goToUnmanaged(GLOBAL)}
         />
@@ -78,29 +80,24 @@ export function ProjectList() {
           </p>
         ) : (
           projects.map((root) => {
-            const items =
-              result?.items.filter(
-                (i) => i.scope.scope === "project" && i.scope.root === root,
-              ) ?? [];
             const name = root.split("/").pop() ?? root;
             const scope: Scope = { scope: "project", root };
+            const place: ItemPlace = { scope: { project: root } };
             return (
               <ProjectCard
                 key={root}
                 name={name}
                 subtitle={root}
                 path={root}
-                counts={[...countByKind(items).entries()]}
+                counts={[...installedCountByKind(items, place).entries()]}
                 emptyLabel="Nothing from kendex yet."
                 badge={
                   result?.missingProjects.includes(root)
                     ? "Folder not found"
                     : undefined
                 }
-                onOpen={() => goToLibrary({ scope: { project: root } })}
-                onKindClick={(kind) =>
-                  goToLibrary({ kind, scope: { project: root } })
-                }
+                onOpen={() => goToLibrary(place)}
+                onKindClick={(kind) => goToLibrary({ ...place, kind })}
                 unmanaged={notManaged(scope)}
                 onUnmanaged={() => goToUnmanaged(scope)}
                 action={

--- a/ui/src/lib/derive.test.ts
+++ b/ui/src/lib/derive.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it } from "vitest";
 import type { ObservedItem } from "@/bindings";
+import { KINDS } from "@/lib/labels";
 import {
-  countByKind,
   filterItems,
   groupItems,
   groupScopes,
   groupVendor,
   installationAt,
   installedCount,
+  installedCountByKind,
   recentItems,
   scopeMatches,
 } from "./derive";
@@ -166,15 +167,56 @@ describe("groupScopes", () => {
   });
 });
 
-describe("countByKind", () => {
+describe("installedCountByKind", () => {
   it("tallies per kind", () => {
-    const counts = countByKind([
-      item({}),
-      item({ name: "x" }),
-      item({ kind: "agent" }),
-    ]);
+    const counts = installedCountByKind(
+      [item({}), item({ name: "x" }), item({ kind: "agent" })],
+      {},
+    );
     expect(counts.get("skill")).toBe(2);
     expect(counts.get("agent")).toBe(1);
+  });
+
+  it("counts packages, not installations", () => {
+    const counts = installedCountByKind(
+      [
+        item({ harness: "claude" }),
+        item({ harness: "codex" }),
+        item({ scope: { scope: "project", root: "/p" } }),
+      ],
+      {},
+    );
+    expect(counts.get("skill")).toBe(1);
+  });
+
+  it("counts only what the place holds", () => {
+    const items = [
+      item({}),
+      item({ name: "elsewhere", harness: "codex" }),
+      item({ name: "over-there", scope: { scope: "project", root: "/p" } }),
+    ];
+    expect(
+      installedCountByKind(items, { harness: "claude" }).get("skill"),
+    ).toBe(2);
+    expect(installedCountByKind(items, { scope: "global" }).get("skill")).toBe(
+      2,
+    );
+    expect(
+      installedCountByKind(items, { scope: { project: "/p" } }).get("skill"),
+    ).toBe(1);
+  });
+
+  // The badges sit beside the Library's kind filter, which lists kinds in
+  // KINDS order. Grouping sorts on `kind:name`, so tallying straight off the
+  // groups hands back the wire order instead.
+  it("hands the kinds back in the order the app shows them in", () => {
+    const items = KINDS.map((kind) => item({ kind, name: `one-${kind}` }));
+    expect([...installedCountByKind(items, {}).keys()]).toEqual(KINDS);
+  });
+
+  it("leaves out a kind the place holds nothing of", () => {
+    const counts = installedCountByKind([item({ kind: "agent" })], {});
+    expect(counts.has("skill")).toBe(false);
   });
 });
 

--- a/ui/src/lib/derive.ts
+++ b/ui/src/lib/derive.ts
@@ -1,10 +1,12 @@
 import type {
+  HarnessId,
   ItemKind,
   ObservedItem,
   ScanResult,
   Scope,
   Tag,
 } from "@/bindings";
+import { KINDS } from "@/lib/labels";
 import { sameScope } from "@/lib/scope";
 
 export type ScopeSelection = "all" | "global" | { project: string };
@@ -127,6 +129,47 @@ export function installedCount(groups: ItemGroup[]): number {
   return groups.length;
 }
 
+/** Where a count is being taken: everything the Library narrows by when a
+ *  kind badge there is clicked, less the kind the badge itself names. A
+ *  surface hands one of these to {@link installedCountByKind} and the same
+ *  one to the link it draws, so the number and the page it opens cannot
+ *  describe different views. */
+export interface ItemPlace {
+  scope?: ScopeSelection;
+  harness?: HarnessId;
+}
+
+/** How many packages a place holds of each kind — one per kind+name group,
+ *  the unit the Library shows a row per, counted over the place's own
+ *  narrowing so a badge's number is the row count on the page its click
+ *  opens. A package installed on two harnesses, or in two locations, is one
+ *  package here as it is there. A kind the place holds nothing of is absent
+ *  rather than zero: the badges are what a place has, not a checklist of
+ *  what it hasn't. */
+export function installedCountByKind(
+  items: ObservedItem[],
+  place: ItemPlace,
+): Map<ItemKind, number> {
+  const tally = new Map<ItemKind, number>();
+  const here = filterItems(items, {
+    scope: place.scope ?? "all",
+    harness: place.harness,
+  });
+  for (const group of groupItems(here)) {
+    tally.set(group.kind, (tally.get(group.kind) ?? 0) + 1);
+  }
+  // Handed back in the app's kind order, not the grouping's: the badges sit
+  // beside the Library's own kind filter, and a reader must meet one order.
+  // `groupItems` sorts on the group key, which puts kinds in the wire order
+  // {@link KINDS} exists to keep off screen.
+  const counts = new Map<ItemKind, number>();
+  for (const kind of KINDS) {
+    const count = tally.get(kind);
+    if (count) counts.set(kind, count);
+  }
+  return counts;
+}
+
 /** The installation belonging to one place, where the group has one.
  *
  *  A package can be installed in several places and a page names one of
@@ -159,14 +202,6 @@ export function groupScopes(group: ItemGroup): Scope[] {
     if (!seen.has(key)) seen.set(key, install.scope);
   }
   return [...seen.values()];
-}
-
-export function countByKind(items: ObservedItem[]): Map<ItemKind, number> {
-  const counts = new Map<ItemKind, number>();
-  for (const item of items) {
-    counts.set(item.kind, (counts.get(item.kind) ?? 0) + 1);
-  }
-  return counts;
 }
 
 function projectScopes(result: ScanResult): string[] {

--- a/ui/src/stores/nav-types.ts
+++ b/ui/src/stores/nav-types.ts
@@ -1,7 +1,7 @@
 // The vocabulary of places: every page id, the refs that address what a
 // nested page is showing, and the snapshot the back stack keeps.
-import type { Catalog, HarnessId, ItemKind, Scope } from "@/bindings";
-import type { ScopeSelection } from "@/lib/derive";
+import type { Catalog, ItemKind, Scope } from "@/bindings";
+import type { ItemPlace } from "@/lib/derive";
 
 export type Page =
   | "home"
@@ -34,11 +34,10 @@ export type MarketplacesTab = "subscribed" | "packages" | "community" | "mine";
 /** What a link into the Library is asking to see — every narrowing it wants,
  * where to look included. A link states the whole thing, so a field it leaves
  * out is a narrowing it does not want, and an all-empty filter asks for
- * everything. */
-export interface LibraryFilter {
-  harness?: HarnessId;
+ * everything. It is a place plus a kind, which is what lets a kind badge
+ * count exactly the rows its own link lands on. */
+export interface LibraryFilter extends ItemPlace {
   kind?: ItemKind;
-  scope?: ScopeSelection;
 }
 
 /** The package a package page is showing — everything a backend query

--- a/ui/src/stores/nav.ts
+++ b/ui/src/stores/nav.ts
@@ -135,10 +135,13 @@ export const useNavStore = create<NavState>((set) => ({
   // Always a handoff, even an empty one: a link that names no filter is
   // asking for everything, and the Library has to be able to tell that
   // apart from arriving with no link at all, where the stored view stands.
-  goToLibrary: ({ harness, kind, scope } = {}) =>
+  // Carried whole rather than field by field: a narrowing the filter gains
+  // is one a badge already counts by, and a link that dropped it would open
+  // a wider page than the number that was clicked.
+  goToLibrary: (filter = {}) =>
     set((state) => ({
       page: "library",
-      libraryFilter: { harness, kind, scope },
+      libraryFilter: { ...filter },
       history: pushHistory(state, "library"),
       future: [],
     })),


### PR DESCRIPTION
The kind badges on a harness row and on a place card counted one per installation, while the Library table each badge opens shows one row per kind+name package. A package on two harnesses, or in the global scope and a project both, put a number on the badge that the page under it could not account for.

They now count the way the destination does: `installedCountByKind` runs the Library's own `filterItems` and `groupItems` over the place the badge belongs to, and tallies the groups. A place is an `ItemPlace`, which `LibraryFilter` extends, so a surface hands the same object to the count and to the link and neither can narrow without the other; `goToLibrary` carries that filter whole rather than re-listing its fields, which is what makes the type relation load-bearing.

The tally comes back in `KINDS` order. Grouping sorts on the `kind:name` group key, which is the wire order `labels.ts` exists to keep off screen.

Each badge surface has a dom control that clicks the badge, renders `InstalledView` on the view the click handed it, and pins the badge number against the rows it draws, plus a must-fail sibling. All of them go red on a planted installation tally, and the ordering case goes red on a tally handed straight back.

The staged pre-commit chain (doc-limits, preflight, bot-instructions, commit-guards, `tools/guard`) is clean. `tools/guard --full` could not be got to a verdict on this machine: its vitest lane failed 13 and then 9 different cases, every one a five-second timeout and eight of the nine files untouched here, and the next run was killed by the memory reaper. The box is at load ~160-180 on 32 cores from about twenty sibling worktrees. The changed files' own suites pass three runs in a row.

Architecture-docs program: this PR holds for the overseer's MERGE.

https://claude.ai/code/session_01HSdgok3XHZTVYd7Smu65Hu
