### PR TITLE
feat(KEN-492): terms of service, privacy policy, and the accept step

### DIFF
--- a/changelog.d/added/KEN-492.md
+++ b/changelog.d/added/KEN-492.md
@@ -1,1 +1,1 @@
-- kendex asks you to accept its Terms of Service and Privacy Policy on first run, in the app and on the command line. The version and date are recorded on this computer; Settings → About shows them.
+- The app asks you to accept its Terms of Service and Privacy Policy when it first opens; the command line says so on its first run. The version and date are recorded on this computer.

--- a/changelog.d/added/KEN-492.md
+++ b/changelog.d/added/KEN-492.md
@@ -1,0 +1,1 @@
+- kendex asks you to accept its Terms of Service and Privacy Policy on first run, in the app and on the command line. The version and date are recorded on this computer; Settings → About shows them.

--- a/crates/app/src/legal.rs
+++ b/crates/app/src/legal.rs
@@ -1,0 +1,57 @@
+//! The terms step: what the first-run screen asks, and the record it
+//! leaves behind.
+//!
+//! The rule lives in `kendex_core::legal`, which the command line obeys
+//! from its own first run against the same settings file. Nothing is
+//! decided here, and nothing is decided in the UI either: a screen that
+//! worked out for itself whether to ask would be a second copy of that
+//! rule, and the two would disagree the first time a version moved.
+
+use kendex_core::legal::TermsAcceptance;
+use kendex_core::settings::AppSettings;
+use serde::Serialize;
+use specta::Type;
+
+use crate::scopes::env;
+
+/// Whether to ask, and what is on record — from one read, because the
+/// first-run screen and the About row would otherwise hold two answers
+/// taken at different moments, and only one of them would be right after
+/// an accept.
+#[derive(Debug, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct TermsState {
+    pub ask: bool,
+    pub accepted: Option<TermsAcceptance>,
+}
+
+impl From<AppSettings> for TermsState {
+    fn from(settings: AppSettings) -> TermsState {
+        TermsState {
+            ask: kendex_core::legal::asks_again(settings.terms.as_ref()),
+            accepted: settings.terms,
+        }
+    }
+}
+
+#[tauri::command(async)]
+#[specta::specta]
+pub fn terms_state() -> Result<TermsState, String> {
+    kendex_core::settings::load(&env()?)
+        .map(TermsState::from)
+        .map_err(|error| error.to_string())
+}
+
+/// Record that the person accepted the documents this build asks about.
+///
+/// Its own targeted write rather than the whole-file settings path:
+/// acceptance is one field settled by one click, and sending the whole
+/// object back would let a copy read before the screen opened put an older
+/// file over whatever else has been saved since.
+#[tauri::command(async)]
+#[specta::specta]
+pub fn accept_terms() -> Result<TermsState, String> {
+    kendex_core::legal::accept(&env()?)
+        .map(|(settings, _)| TermsState::from(settings))
+        .map_err(|error| error.to_string())
+}

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -10,6 +10,7 @@ mod editor;
 // and for how the Linux app is packaged.
 #[cfg(target_os = "linux")]
 mod launch_env;
+mod legal;
 pub mod marketplaces;
 mod mine;
 mod native;
@@ -42,7 +43,12 @@ fn constants(builder: Builder<tauri::Wry>) -> Builder<tauri::Wry> {
     // manifest yet. `save::check` validates that draft before the plan's
     // `manifest::save` would stamp anything, so a second copy of this
     // number in the UI is a first save refused by its own validator.
-    builder.constant("MANIFEST_SCHEMA", kendex_core::manifest::MANIFEST_SCHEMA)
+    let builder = builder.constant("MANIFEST_SCHEMA", kendex_core::manifest::MANIFEST_SCHEMA);
+    // The version of the terms this build asks about, and where the two
+    // documents are published. The first-run screen decides from the same
+    // number the record stores and the command line prints, so the three
+    // cannot disagree about which documents someone accepted.
+    builder.constant("LEGAL", kendex_core::legal::LEGAL)
 }
 
 /// The runtime the generated bindings call every `Result`-returning command
@@ -98,6 +104,8 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         app_settings::get_settings,
         app_settings::update_settings,
         app_settings::save_zoom,
+        legal::terms_state,
+        legal::accept_terms,
         app_settings::register_project,
         app_settings::unregister_project,
         app_settings::project_offers,

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -313,8 +313,16 @@ fn bootstrap_the_command_record(env: &Env) {
 /// that would be read as the check having something to say. `KENDEX_UI`
 /// is deliberately not consulted: it picks a rendering, and being sent to
 /// a person is a different question from how it is drawn for them.
+///
+/// Nor under `sudo`. `legal::accept` refuses a root write outright, so a
+/// line printed here would be one that could never be answered — and the
+/// person's own next unprivileged run says it and records it. The refusal
+/// and its reasoning are `kendex_core::privilege`'s, beside the command
+/// record above, which stops for the same reason.
 fn announce_the_terms_on_first_run(env: &Env) {
-    if !std::io::IsTerminal::is_terminal(&std::io::stderr()) {
+    if !std::io::IsTerminal::is_terminal(&std::io::stderr())
+        || kendex_core::privilege::acting_as_root()
+    {
         return;
     }
     let Ok(settings) = kendex_core::settings::load(env) else {

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -11,6 +11,7 @@ use clap::{Parser, Subcommand};
 use kendex_core::command_update::record_first_run;
 use kendex_core::env::Env;
 use kendex_core::install_channel::{Host, HostProbe};
+use kendex_core::legal;
 
 use commands::project::ProjectCommand;
 use flags::{AddFlags, ReportFlags};
@@ -213,6 +214,7 @@ pub fn main() -> ExitCode {
     // the install this record is missing from.
     if let Ok(env) = Env::detect() {
         bootstrap_the_command_record(&env);
+        announce_the_terms_on_first_run(&env);
     }
     let cli = Cli::parse();
     // The machine check's whole contract is its exit code: 1 means "drift,
@@ -279,6 +281,54 @@ fn bootstrap_the_command_record(env: &Env) {
         return;
     };
     let _ = record_first_run(env, &Host.resolve(&running));
+}
+
+/// The one line a first run says about the terms, and the record it leaves.
+///
+/// Said once and then not again, because it writes the same field the
+/// app's first-run screen writes: accepting in either shell answers for
+/// both, and a version the person has already agreed to is not put in
+/// front of them a second time. A later version of the documents asks
+/// again, which is the whole reason the record carries a number.
+///
+/// Nothing here refuses. The verb the person ran still runs, whether or
+/// not they have seen the line: the acceptance is a step, not a gate on
+/// the work.
+///
+/// Beside the command record and for its reason — `--version` and `--help`
+/// are answered by clap without reaching dispatch, and either is as likely
+/// to be someone's first run as any verb.
+///
+/// The line goes out before the record is written, so a write that fails
+/// leaves the line to print again next run. That is the direction worth
+/// failing in: a record with nobody told proves nothing. A settings file
+/// that cannot be read says nothing at all — there is nowhere to record an
+/// answer, and a verb the person ran is not held up over it.
+///
+/// Only where stderr is a terminal, and the record follows the line rather
+/// than the run: a pipe has no reader, and the person whose first runs all
+/// went through one is still asked the first time they are at a terminal.
+/// Not a preference — `kendex check`'s whole contract with the session
+/// hooks is an exit code over a quiet stderr, and a notice written into
+/// that would be read as the check having something to say. `KENDEX_UI`
+/// is deliberately not consulted: it picks a rendering, and being sent to
+/// a person is a different question from how it is drawn for them.
+fn announce_the_terms_on_first_run(env: &Env) {
+    if !std::io::IsTerminal::is_terminal(&std::io::stderr()) {
+        return;
+    }
+    let Ok(settings) = kendex_core::settings::load(env) else {
+        return;
+    };
+    if !legal::asks_again(settings.terms.as_ref()) {
+        return;
+    }
+    ui::note(&format!(
+        "using kendex accepts its terms and privacy policy — {} and {}",
+        legal::LEGAL.terms_url,
+        legal::LEGAL.privacy_url
+    ));
+    let _ = legal::accept(env);
 }
 
 /// The bare form: `kendex <source> [flags]` maps to `add`.

--- a/crates/cli/tests/presentation/main.rs
+++ b/crates/cli/tests/presentation/main.rs
@@ -9,6 +9,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
 use kendex_core::env::Env;
+#[path = "../pty.rs"]
+mod pty;
 #[path = "../../../test_util.rs"]
 mod test_util;
 pub use test_util::{rooted, source_path};
@@ -56,38 +58,16 @@ fn kendex(home: &Path, cwd: &Path, ui: &str, args: &[&str]) -> Output {
 
 /// The same run, with a terminal on stderr instead of a pipe.
 ///
-/// One thing needs it. The framed rendering's spinner draws through
+/// One thing here needs it. The framed rendering's spinner draws through
 /// `indicatif`, which writes nothing whatever when stderr is not a
 /// terminal, so the line it puts on the screen is invisible to every other
 /// test in this file. `TERM` has to be set for the same reason: without it
 /// `console` reports a terminal it cannot draw on, and the spinner stays
 /// silent on the pty too.
-///
-/// Returns everything the terminal was sent, colour codes and redraws
-/// included. Reading runs until the last writer closes, which on Linux
-/// arrives as `EIO` rather than end of file. Stdout goes nowhere: only
-/// the terminal is under test, and a pipe nobody drains deadlocks the
-/// pair once a chattier verb fills its buffer.
 #[allow(clippy::expect_used)]
 fn kendex_on_a_terminal(home: &Path, cwd: &Path, args: &[&str]) -> String {
-    use std::io::Read;
-    use std::os::fd::OwnedFd;
-
-    let controller =
-        rustix::pty::openpt(rustix::pty::OpenptFlags::RDWR | rustix::pty::OpenptFlags::NOCTTY)
-            .expect("a pseudoterminal");
-    rustix::pty::grantpt(&controller).expect("granted");
-    rustix::pty::unlockpt(&controller).expect("unlocked");
-    let name = rustix::pty::ptsname(&controller, Vec::new()).expect("its name");
-    let terminal: OwnedFd = fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .open(name.to_str().expect("a utf-8 device name"))
-        .expect("the terminal side opens")
-        .into();
-
-    let mut child = Command::new(env!("CARGO_BIN_EXE_kendex"))
-        .args(args)
+    let mut run = Command::new(env!("CARGO_BIN_EXE_kendex"));
+    run.args(args)
         .current_dir(cwd)
         .env_clear()
         .envs(test_util::fixture_env(home))
@@ -95,35 +75,8 @@ fn kendex_on_a_terminal(home: &Path, cwd: &Path, args: &[&str]) -> String {
         .env("KENDEX_UI", "pretty")
         .env("LANG", "C.UTF-8")
         .env("TERM", "xterm-256color")
-        .env("PATH", std::env::var("PATH").unwrap_or_default())
-        .stdin(std::process::Stdio::from(
-            terminal.try_clone().expect("a second handle"),
-        ))
-        .stderr(std::process::Stdio::from(
-            terminal.try_clone().expect("a third handle"),
-        ))
-        .stdout(std::process::Stdio::null())
-        .spawn()
-        .expect("kendex binary runs");
-    // The parent's own handle goes now, or the read below never ends: the
-    // terminal stays open as long as any writer holds it.
-    drop(terminal);
-
-    let mut sent = Vec::new();
-    let mut buffer = [0u8; 4096];
-    let mut reader = std::fs::File::from(controller);
-    loop {
-        match Read::read(&mut reader, &mut buffer) {
-            Ok(0) => break,
-            Ok(read) => sent.extend_from_slice(&buffer[..read]),
-            // A signal arriving mid-read is not the end of the stream.
-            // Taking it for one cuts the capture short without saying so.
-            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
-            Err(_) => break,
-        }
-    }
-    let _ = child.wait();
-    String::from_utf8_lossy(&sent).into_owned()
+        .env("PATH", std::env::var("PATH").unwrap_or_default());
+    pty::sent_to_a_terminal(run)
 }
 
 fn said(output: &Output) -> String {

--- a/crates/cli/tests/presentation/main.rs
+++ b/crates/cli/tests/presentation/main.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
 use kendex_core::env::Env;
-#[path = "../pty.rs"]
+#[path = "../support/pty.rs"]
 mod pty;
 #[path = "../../../test_util.rs"]
 mod test_util;

--- a/crates/cli/tests/pty.rs
+++ b/crates/cli/tests/pty.rs
@@ -1,0 +1,80 @@
+//! Running the binary with a terminal on stderr instead of a pipe.
+//!
+//! Two suites need it, for the two things a pipe cannot show: what the
+//! framed rendering draws through `indicatif`, which writes nothing at all
+//! unless stderr is a terminal, and the first-run terms line, which is
+//! addressed to a person and says nothing where there is none.
+//!
+//! The caller builds the command — its home, its arguments, its
+//! environment — and this wires the terminal into it, so neither suite
+//! inherits the other's rendering variables.
+#![cfg(unix)]
+
+use std::process::Command;
+
+/// Everything the terminal was sent, colour codes and redraws included.
+///
+/// Reading runs until the last writer closes, which on Linux arrives as
+/// `EIO` rather than end of file. Stdout goes nowhere: only the terminal is
+/// under test, and a pipe nobody drains deadlocks the pair once a chattier
+/// verb fills its buffer.
+///
+/// The command is taken by value and dropped before the read, because a
+/// `Command` holds the handles it was given until it is: left alive, it is
+/// a writer on the terminal that never closes, and the read below runs
+/// until the suite is killed.
+#[allow(
+    dead_code,
+    clippy::expect_used,
+    reason = "both including suites use it; the expects are fixture preconditions"
+)]
+pub fn sent_to_a_terminal(mut command: Command) -> String {
+    use std::fs;
+    use std::io::Read;
+    use std::os::fd::OwnedFd;
+
+    let controller =
+        rustix::pty::openpt(rustix::pty::OpenptFlags::RDWR | rustix::pty::OpenptFlags::NOCTTY)
+            .expect("a pseudoterminal");
+    rustix::pty::grantpt(&controller).expect("granted");
+    rustix::pty::unlockpt(&controller).expect("unlocked");
+    let name = rustix::pty::ptsname(&controller, Vec::new()).expect("its name");
+    let terminal: OwnedFd = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(name.to_str().expect("a utf-8 device name"))
+        .expect("the terminal side opens")
+        .into();
+
+    let mut child = command
+        .stdin(std::process::Stdio::from(
+            terminal.try_clone().expect("a second handle"),
+        ))
+        .stderr(std::process::Stdio::from(
+            terminal.try_clone().expect("a third handle"),
+        ))
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .expect("kendex binary runs");
+    // Every handle the parent still holds goes now, or the read below never
+    // ends: the terminal stays open as long as any writer holds it, and the
+    // command holds the three it was handed.
+    drop(terminal);
+    drop(command);
+
+    let mut sent = Vec::new();
+    let mut buffer = [0u8; 4096];
+    let mut reader = fs::File::from(controller);
+    loop {
+        match Read::read(&mut reader, &mut buffer) {
+            Ok(0) => break,
+            Ok(read) => sent.extend_from_slice(&buffer[..read]),
+            // A signal arriving mid-read is not the end of the stream.
+            // Taking it for one cuts the capture short without saying so.
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(_) => break,
+        }
+    }
+    let _ = child.wait();
+    String::from_utf8_lossy(&sent).into_owned()
+}

--- a/crates/cli/tests/support/pty.rs
+++ b/crates/cli/tests/support/pty.rs
@@ -8,6 +8,9 @@
 //! The caller builds the command — its home, its arguments, its
 //! environment — and this wires the terminal into it, so neither suite
 //! inherits the other's rendering variables.
+//!
+//! Under `tests/support/` rather than `tests/`, where cargo's autodiscovery
+//! would compile a file holding no `#[test]` as a test binary of its own.
 #![cfg(unix)]
 
 use std::process::Command;

--- a/crates/cli/tests/terms_first_run.rs
+++ b/crates/cli/tests/terms_first_run.rs
@@ -1,0 +1,143 @@
+//! The one line a first run says about the terms, and the record that
+//! stops it saying it again.
+//!
+//! Asserted against the built binary rather than the function behind it:
+//! the line has to reach a person running a verb, and a test that called
+//! the seam would pass while the wiring in `main` said nothing.
+//!
+//! `list` is the verb throughout because it has nothing to do with the
+//! terms — a line printed there is a line printed by any run.
+#![cfg(unix)]
+
+#[path = "pty.rs"]
+mod pty;
+#[path = "../../test_util.rs"]
+mod test_util;
+
+use std::path::Path;
+use std::process::Command;
+
+use kendex_core::env::Env;
+use kendex_core::legal::LEGAL;
+use test_util::rooted;
+
+fn command(home: &Path) -> Command {
+    let mut run = Command::new(env!("CARGO_BIN_EXE_kendex"));
+    run.current_dir(home)
+        .env_clear()
+        .envs(test_util::fixture_env(home))
+        .env("KENDEX_BACKGROUND_REFRESH", "off")
+        .env("KENDEX_UI", "plain")
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .arg("list");
+    run
+}
+
+/// What a person at a terminal is sent.
+fn on_a_terminal(home: &Path) -> String {
+    pty::sent_to_a_terminal(command(home))
+}
+
+/// What a pipe is sent — a script, a session hook, another program.
+#[allow(clippy::expect_used)]
+fn through_a_pipe(home: &Path) -> String {
+    let run = command(home).output().expect("kendex binary runs");
+    String::from_utf8_lossy(&run.stderr).into_owned()
+}
+
+#[allow(clippy::expect_used)]
+fn recorded(home: &Path) -> Option<kendex_core::legal::TermsAcceptance> {
+    kendex_core::settings::load(&Env::host_rooted(home))
+        .expect("settings read")
+        .terms
+}
+
+#[allow(clippy::expect_used)]
+fn write_settings(home: &Path, version: u32, accepted_at: &str) {
+    let path = Env::host_rooted(home).settings_file();
+    std::fs::create_dir_all(path.parent().expect("settings file has a parent"))
+        .expect("settings directory");
+    std::fs::write(
+        path,
+        format!("schema = 1\n\n[terms]\nversion = {version}\naccepted-at = \"{accepted_at}\"\n"),
+    )
+    .expect("settings written");
+}
+
+/// The first run says it and records the version; the second says nothing
+/// and leaves the record where it is.
+#[test]
+fn the_first_run_says_it_once_and_records_the_version() {
+    let tmp = tempfile::tempdir().expect("a home to run in");
+    // The canonical root, and the same spelling handed to the run: a
+    // settings path read back under another spelling reads an empty file.
+    let home = rooted(&tmp);
+
+    let first = on_a_terminal(&home);
+    assert!(first.contains(LEGAL.terms_url), "first run: {first:?}");
+    assert!(first.contains(LEGAL.privacy_url), "first run: {first:?}");
+    let record = recorded(&home).expect("the first run records");
+    assert_eq!(record.version, LEGAL.version);
+
+    let second = on_a_terminal(&home);
+    assert!(!second.contains(LEGAL.terms_url), "second run: {second:?}");
+    assert_eq!(recorded(&home), Some(record));
+}
+
+/// The record carries a version so a later one can ask again. A machine
+/// holding an older acceptance is told, and its record moves up.
+#[test]
+fn a_record_from_an_older_version_is_asked_again() {
+    let tmp = tempfile::tempdir().expect("a home to run in");
+    // The canonical root, and the same spelling handed to the run: a
+    // settings path read back under another spelling reads an empty file.
+    let home = rooted(&tmp);
+    write_settings(&home, LEGAL.version - 1, "2020-01-01T00:00:00Z");
+
+    let sent = on_a_terminal(&home);
+    assert!(sent.contains(LEGAL.terms_url), "{sent:?}");
+    assert_eq!(
+        recorded(&home).map(|record| record.version),
+        Some(LEGAL.version)
+    );
+}
+
+/// Saying nothing is the acceptance working, not the line being broken:
+/// with the current version on record the run is silent, and the date
+/// already there is not moved by it.
+#[test]
+fn a_current_record_is_not_asked_again() {
+    let tmp = tempfile::tempdir().expect("a home to run in");
+    // The canonical root, and the same spelling handed to the run: a
+    // settings path read back under another spelling reads an empty file.
+    let home = rooted(&tmp);
+    write_settings(&home, LEGAL.version, "2026-09-06T00:00:00Z");
+
+    let sent = on_a_terminal(&home);
+    assert!(!sent.contains(LEGAL.terms_url), "{sent:?}");
+    assert_eq!(
+        recorded(&home).map(|record| record.accepted_at),
+        Some("2026-09-06T00:00:00Z".to_owned())
+    );
+}
+
+/// A pipe has no reader. `kendex check`'s whole contract with the session
+/// hooks is an exit code over a quiet stderr, so a notice written there
+/// would be read as the check having something to say — and the person
+/// whose first runs all went through a script is still asked the first
+/// time they are at a terminal, which is why nothing is recorded either.
+#[test]
+fn a_run_nobody_is_watching_says_nothing_and_records_nothing() {
+    let tmp = tempfile::tempdir().expect("a home to run in");
+    // The canonical root, and the same spelling handed to the run: a
+    // settings path read back under another spelling reads an empty file.
+    let home = rooted(&tmp);
+
+    let piped = through_a_pipe(&home);
+    assert!(!piped.contains(LEGAL.terms_url), "{piped:?}");
+    assert_eq!(recorded(&home), None);
+
+    let sent = on_a_terminal(&home);
+    assert!(sent.contains(LEGAL.terms_url), "{sent:?}");
+    assert!(recorded(&home).is_some());
+}

--- a/crates/cli/tests/terms_first_run.rs
+++ b/crates/cli/tests/terms_first_run.rs
@@ -9,7 +9,7 @@
 //! terms — a line printed there is a line printed by any run.
 #![cfg(unix)]
 
-#[path = "pty.rs"]
+#[path = "support/pty.rs"]
 mod pty;
 #[path = "../../test_util.rs"]
 mod test_util;
@@ -21,7 +21,7 @@ use kendex_core::env::Env;
 use kendex_core::legal::LEGAL;
 use test_util::rooted;
 
-fn command(home: &Path) -> Command {
+fn command_with(home: &Path, arg: &str) -> Command {
     let mut run = Command::new(env!("CARGO_BIN_EXE_kendex"));
     run.current_dir(home)
         .env_clear()
@@ -29,8 +29,14 @@ fn command(home: &Path) -> Command {
         .env("KENDEX_BACKGROUND_REFRESH", "off")
         .env("KENDEX_UI", "plain")
         .env("PATH", std::env::var("PATH").unwrap_or_default())
-        .arg("list");
+        .arg(arg);
     run
+}
+
+/// `list` is the ordinary verb the cases below run: it has nothing to do
+/// with the terms, so a line printed there is a line printed by any run.
+fn command(home: &Path) -> Command {
+    command_with(home, "list")
 }
 
 /// What a person at a terminal is sent.
@@ -82,6 +88,24 @@ fn the_first_run_says_it_once_and_records_the_version() {
     let second = on_a_terminal(&home);
     assert!(!second.contains(LEGAL.terms_url), "second run: {second:?}");
     assert_eq!(recorded(&home), Some(record));
+}
+
+/// The forms clap answers itself, which is why this runs before the parse:
+/// `--version` and `--help` never reach dispatch, and either is as likely
+/// to be someone's first run as any verb.
+#[test]
+fn the_forms_clap_answers_itself_say_it_too() {
+    for form in ["--version", "--help"] {
+        let tmp = tempfile::tempdir().expect("a home to run in");
+        let home = rooted(&tmp);
+        let sent = pty::sent_to_a_terminal(command_with(&home, form));
+        assert!(sent.contains(LEGAL.terms_url), "{form}: {sent:?}");
+        assert_eq!(
+            recorded(&home).map(|record| record.version),
+            Some(LEGAL.version),
+            "{form}"
+        );
+    }
 }
 
 /// The record carries a version so a later one can ask again. A machine

--- a/crates/core/src/command_update/record.rs
+++ b/crates/core/src/command_update/record.rs
@@ -20,36 +20,9 @@ pub struct InstalledCommand {
     pub path: PathBuf,
 }
 
-/// Whether this process is acting as root.
-///
-/// Every path written below is resolved from the environment this process
-/// was handed — `HOME` and `XDG_DATA_HOME` decide where [`Env`] puts the
-/// record — and a privileged run was handed that environment by whoever
-/// invoked it. `sudo` resets it on most machines, but a `sudoers` carrying
-/// `env_keep HOME` does not, and then a root process opens a file every
-/// component of whose name belongs to the invoking account: a link there
-/// is followed, and root writes wherever it points.
-///
-/// So a run acting as root writes no record. The person's own next
-/// unprivileged run — any verb, `--version` included — writes one into the
-/// file their own account owns.
-///
-/// The effective uid and nothing else. `sudo`, `su`, `doas` and a root
-/// login are one case here and none of them is distinguishable by a
-/// variable: `SUDO_USER` and its neighbours are set by whoever invoked the
-/// command, so a check reading one would be a check the invoker decides.
-#[cfg(unix)]
-fn acting_as_root() -> bool {
-    rustix::process::geteuid().is_root()
-}
-
-/// Windows has no uid to answer with, and none of the elevation this
-/// guards for — a command re-run under another account against the first
-/// account's environment — is reachable there.
-#[cfg(not(unix))]
-fn acting_as_root() -> bool {
-    false
-}
+/// Whether this process is acting as root, and so writes no record: the
+/// reasoning, which the settings file shares, is [`crate::privilege`]'s.
+use crate::privilege::acting_as_root;
 
 /// What a run is asking to record. The two entries below differ only in
 /// this value, so [`acting_as_root`] is read in one place: a wrapper that

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -159,6 +159,12 @@ pub enum CoreError {
     #[error("settings are busy: another kendex process holds {lock}")]
     SettingsBusy { lock: PathBuf },
 
+    /// A write refused because the run is acting as root. Writing would
+    /// leave a file the invoking account can never write again, so the
+    /// refusal is the whole point: `crate::privilege` holds the reasoning.
+    #[error("kendex is running as root; do this from your own account")]
+    WouldWriteAsRoot,
+
     /// A settings edit that did not go in; the shapes are the module's.
     #[error(transparent)]
     SettingsRefused(#[from] crate::settings_file::SettingsRefusal),

--- a/crates/core/src/legal.rs
+++ b/crates/core/src/legal.rs
@@ -67,7 +67,27 @@ pub fn asks_again(accepted: Option<&TermsAcceptance>) -> bool {
 /// wrote. Under the settings write lock like every other targeted change,
 /// so the app accepting and a `kendex` command running in a terminal at
 /// the same moment cannot lose each other's file.
+///
+/// A run acting as root records nothing and says so. The settings file and
+/// its lock are resolved from the environment the run was handed, so a
+/// privileged write leaves them owned by root in a directory the person's
+/// own account named — and every unprivileged settings write after it
+/// fails, for good, naming nothing. [`crate::privilege`] holds the whole
+/// reasoning, and the command record refuses on it too.
 pub fn accept(env: &Env) -> Result<(AppSettings, crate::base::Base)> {
+    accept_as(env, crate::privilege::acting_as_root())
+}
+
+/// The same, told who is making it, so a suite drives either arm whatever
+/// uid it is running under. Every caller outside a test comes through
+/// [`accept`], which asks the process.
+///
+/// Guarded here and nowhere below, ahead of the write lock: a root run
+/// creates neither the lock file nor the directory holding it.
+fn accept_as(env: &Env, root: bool) -> Result<(AppSettings, crate::base::Base)> {
+    if root {
+        return Err(crate::error::CoreError::WouldWriteAsRoot);
+    }
     settings::mutate(env, |settings| {
         if asks_again(settings.terms.as_ref()) {
             settings.terms = Some(TermsAcceptance {
@@ -132,9 +152,13 @@ mod tests {
         }
     }
 
-    /// Accepting writes the version this build asks about, once. The second
-    /// accept is the must-fail half: a record that moved would mean the
-    /// date no longer says when the person agreed.
+    /// Accepting writes the version this build asks about, once.
+    ///
+    /// The second half is the must-fail one, and the seeded date is what
+    /// makes it bite: `timestamp` has second resolution, so two accepts a
+    /// few microseconds apart produce the same string and would agree
+    /// whether or not the guard is there. A date from years ago cannot.
+    /// The date is when the person agreed, and no later run moves it.
     #[test]
     fn acceptance_is_recorded_once_with_its_version() {
         let tmp = tempfile::tempdir().unwrap();
@@ -146,8 +170,24 @@ mod tests {
         assert_eq!(first.version, LEGAL.version);
         assert!(!asks_again(Some(&first)));
 
+        let agreed = "2020-01-01T00:00:00Z";
+        settings::mutate(&env, |settings| {
+            settings.terms = Some(TermsAcceptance {
+                version: LEGAL.version,
+                accepted_at: agreed.to_owned(),
+            });
+            Ok(())
+        })
+        .unwrap();
+
         accept(&env).unwrap();
-        assert_eq!(recorded(&env), Some(first));
+        assert_eq!(
+            recorded(&env),
+            Some(TermsAcceptance {
+                version: LEGAL.version,
+                accepted_at: agreed.to_owned(),
+            })
+        );
     }
 
     /// A record left by an older version is replaced by this one, rather
@@ -169,6 +209,47 @@ mod tests {
         let record = recorded(&env).expect("accept records");
         assert_eq!(record.version, LEGAL.version);
         assert_ne!(record.accepted_at, "2020-01-01T00:00:00Z");
+    }
+
+    /// A root run records nothing and creates nothing — not the settings
+    /// file, not its lock, not the directory holding them. Writing would
+    /// leave those owned by root under a path the invoking account named,
+    /// and every unprivileged settings write after it would fail for good
+    /// with nothing on screen naming the cause. The command record refuses
+    /// on the same reasoning; `crate::privilege` holds it.
+    #[test]
+    fn a_run_acting_as_root_records_nothing_and_says_so() {
+        let dir = tempfile::tempdir().unwrap();
+        // The home an elevated run would be pointed at: this account's,
+        // kept across the privilege change by the sudoers policy.
+        let theirs = dir.path().join("home");
+        let env = env_in(&theirs);
+        let settings_file = env.settings_file();
+
+        assert!(matches!(
+            accept_as(&env, true),
+            Err(crate::error::CoreError::WouldWriteAsRoot)
+        ));
+        assert!(
+            !settings_file.exists(),
+            "{} was written by a root run",
+            settings_file.display()
+        );
+        let holding = settings_file.parent().unwrap();
+        assert!(
+            !holding.exists(),
+            "{} was created by a root run",
+            holding.display()
+        );
+
+        // The same call from the person's own account does the work, so
+        // the refusal above is the uid and not a fixture that could never
+        // have written anywhere.
+        accept_as(&env, false).unwrap();
+        assert_eq!(
+            recorded(&env).map(|record| record.version),
+            Some(LEGAL.version)
+        );
     }
 
     /// The published documents name the version the record stores. Without

--- a/crates/core/src/legal.rs
+++ b/crates/core/src/legal.rs
@@ -1,0 +1,202 @@
+//! The terms record: which version of the published Terms of Service and
+//! Privacy Policy this machine accepted, and when.
+//!
+//! One record for both shells. The app's first-run screen and the CLI's
+//! first-run line write the same field in the same settings file, so a
+//! person who accepted in one is not asked again by the other. Nothing
+//! else in kendex reads it: no command, page or install refuses because
+//! the record is absent — the acceptance is the step, not a gate on the
+//! work.
+//!
+//! The version is what makes the record evidentiary. It names the exact
+//! documents accepted, which is why `docs/legal/terms.md` and
+//! `docs/legal/privacy.md` state it in their own bytes and
+//! `documents_state_the_version_this_build_asks_about` holds the three to
+//! one number.
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+use crate::clock::timestamp;
+use crate::env::Env;
+use crate::error::Result;
+use crate::settings::{self, AppSettings};
+
+/// Where the documents are published. The app links them beside its accept
+/// button and the CLI prints them; both read here, because a second
+/// spelling of a URL is a link that rots on its own.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct Legal {
+    /// The version of the two documents this build asks about. Bumped only
+    /// when what a person agreed to changes: a re-prompt for a correction
+    /// nobody needs to read is how people learn to click past the one that
+    /// matters.
+    pub version: u32,
+    pub terms_url: &'static str,
+    pub privacy_url: &'static str,
+}
+
+pub const LEGAL: Legal = Legal {
+    version: 1,
+    terms_url: "https://kendex.ai/legal/terms",
+    privacy_url: "https://kendex.ai/legal/privacy",
+};
+
+/// What this machine accepted. Written once per version — a second accept
+/// of a version already recorded leaves the first date standing, because
+/// the date is when the person agreed and no later run changes that.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "kebab-case")]
+pub struct TermsAcceptance {
+    pub version: u32,
+    /// ISO-8601 UTC, from [`crate::clock::timestamp`].
+    pub accepted_at: String,
+}
+
+/// Whether the person still has to be asked.
+///
+/// A record from a later version than this build asks about is left alone:
+/// an older kendex run beside a newer one has nothing to add, and asking
+/// again would overwrite the newer record with an older number.
+pub fn asks_again(accepted: Option<&TermsAcceptance>) -> bool {
+    accepted.is_none_or(|record| record.version < LEGAL.version)
+}
+
+/// Record acceptance of the current version, and hand back the settings it
+/// wrote. Under the settings write lock like every other targeted change,
+/// so the app accepting and a `kendex` command running in a terminal at
+/// the same moment cannot lose each other's file.
+pub fn accept(env: &Env) -> Result<(AppSettings, crate::base::Base)> {
+    settings::mutate(env, |settings| {
+        if asks_again(settings.terms.as_ref()) {
+            settings.terms = Some(TermsAcceptance {
+                version: LEGAL.version,
+                accepted_at: timestamp(),
+            });
+        }
+        Ok(())
+    })
+}
+
+/// The version a published document declares, from its `Version N.` line.
+///
+/// Read rather than assumed: the number in the record is only worth
+/// something if it names bytes someone can go and read.
+pub fn stated_version(document: &str) -> Option<u32> {
+    document
+        .lines()
+        .find_map(|line| line.strip_prefix("Version "))
+        .and_then(|rest| rest.split('.').next())
+        .and_then(|digits| digits.parse().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::env::FakeOs;
+    use std::path::{Path, PathBuf};
+
+    fn env_in(dir: &Path) -> Env {
+        Env::fake(dir, FakeOs::Linux)
+    }
+
+    fn recorded(env: &Env) -> Option<TermsAcceptance> {
+        settings::load(env).unwrap().terms
+    }
+
+    fn document(name: &str) -> String {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../docs/legal")
+            .join(name);
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("{}: {e}", path.display()))
+    }
+
+    /// The whole rule the two first-run surfaces share, over every shape a
+    /// settings file can hold: nothing recorded and a record left by an
+    /// older version ask; the current version and a newer one do not.
+    #[test]
+    fn a_record_older_than_this_build_asks_again_and_a_current_one_does_not() {
+        let rows: [(Option<u32>, bool); 4] = [
+            (None, true),
+            (Some(LEGAL.version - 1), true),
+            (Some(LEGAL.version), false),
+            (Some(LEGAL.version + 1), false),
+        ];
+        for (version, asks) in rows {
+            let record = version.map(|version| TermsAcceptance {
+                version,
+                accepted_at: "2026-09-06T00:00:00Z".to_owned(),
+            });
+            assert_eq!(asks_again(record.as_ref()), asks, "recorded {version:?}");
+        }
+    }
+
+    /// Accepting writes the version this build asks about, once. The second
+    /// accept is the must-fail half: a record that moved would mean the
+    /// date no longer says when the person agreed.
+    #[test]
+    fn acceptance_is_recorded_once_with_its_version() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = env_in(tmp.path());
+        assert!(asks_again(recorded(&env).as_ref()));
+
+        accept(&env).unwrap();
+        let first = recorded(&env).expect("accept records");
+        assert_eq!(first.version, LEGAL.version);
+        assert!(!asks_again(Some(&first)));
+
+        accept(&env).unwrap();
+        assert_eq!(recorded(&env), Some(first));
+    }
+
+    /// A record left by an older version is replaced by this one, rather
+    /// than kept beside it: one record, naming the documents in force.
+    #[test]
+    fn accepting_a_later_version_replaces_the_older_record() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = env_in(tmp.path());
+        settings::mutate(&env, |settings| {
+            settings.terms = Some(TermsAcceptance {
+                version: LEGAL.version - 1,
+                accepted_at: "2020-01-01T00:00:00Z".to_owned(),
+            });
+            Ok(())
+        })
+        .unwrap();
+
+        accept(&env).unwrap();
+        let record = recorded(&env).expect("accept records");
+        assert_eq!(record.version, LEGAL.version);
+        assert_ne!(record.accepted_at, "2020-01-01T00:00:00Z");
+    }
+
+    /// The published documents name the version the record stores. Without
+    /// this the number is a number: the bytes it points at could say
+    /// anything.
+    #[test]
+    fn documents_state_the_version_this_build_asks_about() {
+        for name in ["terms.md", "privacy.md"] {
+            assert_eq!(
+                stated_version(&document(name)),
+                Some(LEGAL.version),
+                "{name}"
+            );
+        }
+    }
+
+    /// The reader that claim rests on, over the shapes it must tell apart —
+    /// a document declaring another version must not read as this one.
+    #[test]
+    fn the_version_line_is_read_and_not_assumed() {
+        let rows: [(&str, Option<u32>); 4] = [
+            ("# Terms\n\nVersion 1. Effective today.\n", Some(1)),
+            ("# Terms\n\nVersion 2. Effective today.\n", Some(2)),
+            ("# Terms\n\nEffective today.\n", None),
+            ("# Terms\n\nVersion one. Effective today.\n", None),
+        ];
+        for (document, version) in rows {
+            assert_eq!(stated_version(document), version, "{document:?}");
+        }
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -46,6 +46,7 @@ pub mod package;
 pub mod parallel;
 pub mod paths;
 pub mod pi_ext;
+pub mod privilege;
 pub mod process;
 pub mod quality;
 pub mod registry;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -34,6 +34,7 @@ pub mod harness;
 pub mod hash;
 pub mod hook;
 pub mod install_channel;
+pub mod legal;
 pub mod library;
 pub mod lock;
 pub mod manifest;

--- a/crates/core/src/privilege.rs
+++ b/crates/core/src/privilege.rs
@@ -1,0 +1,35 @@
+//! Whether this process is acting as root.
+//!
+//! Every path kendex writes on a person's own machine is resolved from the
+//! environment this process was handed — `HOME`, `XDG_CONFIG_HOME` and
+//! `XDG_DATA_HOME` decide where [`crate::env::Env`] puts the settings file,
+//! the command record and the global scope — and a privileged run was
+//! handed that environment by whoever invoked it. `sudo` resets it on most
+//! machines, but a `sudoers` carrying `env_keep HOME` does not, and then a
+//! root process opens a file every component of whose name belongs to the
+//! invoking account: a link there is followed, and root writes wherever it
+//! points. Worse where it succeeds than where it fails — a lock file or a
+//! config directory left owned by root refuses every unprivileged write
+//! after it, for good, with nothing on screen naming the cause.
+//!
+//! So a run acting as root writes none of that. The person's own next
+//! unprivileged run does it instead.
+//!
+//! The effective uid and nothing else. `sudo`, `su`, `doas` and a root
+//! login are one case here and none of them is distinguishable by a
+//! variable: `SUDO_USER` and its neighbours are set by whoever invoked the
+//! command, so a check reading one would be a check the invoker decides.
+
+/// Whether this process is acting as root.
+#[cfg(unix)]
+pub fn acting_as_root() -> bool {
+    rustix::process::geteuid().is_root()
+}
+
+/// Windows has no uid to answer with, and none of the elevation this
+/// guards for — a command re-run under another account against the first
+/// account's environment — is reachable there.
+#[cfg(not(unix))]
+pub fn acting_as_root() -> bool {
+    false
+}

--- a/crates/core/src/settings/mod.rs
+++ b/crates/core/src/settings/mod.rs
@@ -40,6 +40,13 @@ pub struct AppSettings {
     /// the person and the display in front of them, not to a project.
     #[serde(default = "default_zoom")]
     pub zoom: u16,
+    /// Which version of the Terms of Service and Privacy Policy this
+    /// machine accepted, and when. Machine-local like the rest of this
+    /// file, and shared by both shells: the app's first-run screen and the
+    /// CLI's first-run line write it, and neither asks again once it is
+    /// here. [`crate::legal`] owns the rule.
+    #[serde(default)]
+    pub terms: Option<crate::legal::TermsAcceptance>,
 }
 
 fn default_zoom() -> u16 {
@@ -72,6 +79,7 @@ impl Default for AppSettings {
             ignored_updates: Vec::new(),
             muted_app_notice: None,
             zoom: ZOOM.default,
+            terms: None,
         }
     }
 }

--- a/docs/legal/privacy.md
+++ b/docs/legal/privacy.md
@@ -1,0 +1,64 @@
+# Privacy Policy
+
+Version 1. Effective 6 September 2026.
+
+This policy covers the kendex desktop app, the kendex command-line tool, and kendex.ai. The controller is Vanillagreen LLC of Bellevue, Washington, USA.
+
+## The app and the CLI collect nothing
+
+There is no telemetry, no analytics, no crash reporting and no install identifier in the desktop app or the command-line tool. We do not know who has kendex installed or what they installed with it.
+
+Your projects, packages, settings, lock files and scan results are files on your own computer. kendex reads and writes them there and uploads none of them.
+
+Your acceptance of these documents is recorded in kendex's settings file on your own computer, as the version accepted and the date. It goes nowhere else.
+
+The app and the CLI do make network requests: to kendex.ai for the community directory, to skills.sh for its listings, to GitHub for kendex's own releases, and to whichever host a package's source repository lives on. None of them carries anything about you or your code beyond what any HTTP request carries. A package is fetched from its author's own repository, so that host sees the request and we do not.
+
+## kendex.ai, signed out
+
+You can browse the site and read the directory without an account.
+
+We run no analytics on it: no Google Analytics, no Vercel Analytics, no session recording, no advertising pixel, no third-party tracker, and no analytics or advertising cookies.
+
+## When you sign in
+
+Signing in is optional. It is needed only to submit a marketplace, manage one you own, or create a collection. Sign-in is through GitHub. We ask GitHub for `read:user` and `user:email` and nothing more, so we cannot read your private code.
+
+We store:
+
+- your account, which is the name, email address and avatar image URL GitHub gives us;
+- your GitHub link, which is your GitHub account identifier, the scopes you granted, and the OAuth tokens GitHub issued, encrypted at rest;
+- your session, which is a session token and when it expires;
+- your machine tokens: `kendex login` stores a hash of each token, never the token itself, with what it may do and when it expires, and the same for the short-lived sign-in codes;
+- what you submitted, which is the repository, that you are the submitter, and the result of each index run;
+- your collections, which are a name, a description and their members.
+
+## Rate limits and server logs
+
+We count requests to stop abuse. A counter holds one key, which is an IP address as our host reports it, an account, or a sign-in code, along with the time its window opened and how many attempts it has seen.
+
+Every request to kendex.ai reaches Vercel, our host, which logs what any web server logs: the IP address, the URL, the time, the response status and the user-agent. How long Vercel keeps those logs is their setting rather than ours.
+
+## Who else sees it
+
+We do not sell your data, share it for advertising, or use it to train any model.
+
+Vercel hosts the site and Neon holds the database; both process data on our behalf. GitHub and skills.sh are separate controllers under their own policies: GitHub when you sign in, when kendex fetches a release or a package hosted there, and when you file an issue through `kendex report`; skills.sh when kendex searches it. A package hosted anywhere else reaches you from that host under its own policy.
+
+We may disclose data where the law requires it.
+
+## How long we keep it
+
+Sessions, machine tokens and sign-in codes expire on their own, and a revoked token is refused from the next request onward. Rate-limit counters hold one window and are overwritten. Your account, your collections and what you submitted stay until you ask us to delete them. Server logs are kept for whatever period Vercel sets.
+
+## Your rights
+
+You can ask for a copy of your data, ask us to correct or delete it, or object to what we do with it. Email us, and we will check who you are first, normally by asking you to reply from the address on the account.
+
+## Changes to this policy
+
+If we change this policy, we change the version and the date at the top and publish the new text.
+
+## Contact
+
+brad@vanillagreen.com

--- a/docs/legal/privacy.md
+++ b/docs/legal/privacy.md
@@ -6,13 +6,13 @@ This policy covers the kendex desktop app, the kendex command-line tool, and ken
 
 ## The app and the CLI collect nothing
 
-There is no telemetry, no analytics, no crash reporting and no install identifier in the desktop app or the command-line tool. We do not know who has kendex installed or what they installed with it.
+There is no telemetry, no analytics, no crash reporting and no install identifier in the desktop app or the command-line tool. We do not know who has kendex installed or what they installed with it. Signing in is the one thing that changes what leaves your machine, and **When you sign in** below says what.
 
 Your projects, packages, settings, lock files and scan results are files on your own computer. kendex reads and writes them there and uploads none of them.
 
 Your acceptance of these documents is recorded in kendex's settings file on your own computer, as the version accepted and the date. It goes nowhere else.
 
-The app and the CLI do make network requests: to kendex.ai for the community directory, to skills.sh for its listings, to GitHub for kendex's own releases, and to whichever host a package's source repository lives on. None of them carries anything about you or your code beyond what any HTTP request carries. A package is fetched from its author's own repository, so that host sees the request and we do not.
+The app and the CLI do make network requests. Signed out, they go to kendex.ai for the community directory and for the skills.sh listings it proxies, to skills.sh for a search you type, to GitHub for kendex's own releases, and to whichever host a package's source repository lives on. None of them carries an account, a credential or an identifier, and none carries your code. What a search sends is the words you typed. A package is fetched from its author's own repository, so that host sees the request and we do not.
 
 ## kendex.ai, signed out
 
@@ -24,6 +24,8 @@ We run no analytics on it: no Google Analytics, no Vercel Analytics, no session 
 
 Signing in is optional. It is needed only to submit a marketplace, manage one you own, or create a collection. Sign-in is through GitHub. We ask GitHub for `read:user` and `user:email` and nothing more, so we cannot read your private code.
 
+Once you are signed in, the app and the CLI do send a credential that names your account: signing in and out, reading who you are, submitting a repository and reading your submissions, and opening a collection link. `kendex login` is what starts that; before it there is nothing to send. A submission also asks GitHub about the repository you named.
+
 We store:
 
 - your account, which is the name, email address and avatar image URL GitHub gives us;
@@ -31,7 +33,7 @@ We store:
 - your session, which is a session token and when it expires;
 - your machine tokens: `kendex login` stores a hash of each token, never the token itself, with what it may do and when it expires, and the same for the short-lived sign-in codes;
 - what you submitted, which is the repository, that you are the submitter, and the result of each index run;
-- your collections, which are a name, a description and their members.
+- your collections, which are a name, a description and their members. Deleting a collection stops its link working and keeps the row.
 
 ## Rate limits and server logs
 

--- a/docs/legal/terms.md
+++ b/docs/legal/terms.md
@@ -42,7 +42,7 @@ Do not use kendex to publish or install malware, credential stealers, or anythin
 
 ## Changes to these terms
 
-We may change these terms. When we do, we change the version and the date at the top and publish the new text. A change to what you agreed to asks you again in the app and on the command line; a correction that changes nothing you agreed to does not. Continuing to use kendex after a change accepts it.
+We may change these terms. When we do, we change the version and the date at the top and publish the new text. A change to what you agreed to is put in front of you once more — the app asks again, and the command line says so again the next time you run it at a terminal. A correction that changes nothing you agreed to does neither. Continuing to use kendex after a change accepts it.
 
 ## Governing law
 

--- a/docs/legal/terms.md
+++ b/docs/legal/terms.md
@@ -1,0 +1,53 @@
+# Terms of Service
+
+Version 1. Effective 6 September 2026.
+
+These terms cover the kendex desktop app, the kendex command-line tool, the kendex.ai website, and the community directory they read. They are an agreement between you and Vanillagreen LLC of Bellevue, Washington, USA ("kendex", "we", "us"). Using kendex accepts them. If you do not accept them, do not use kendex.
+
+kendex's own source code is published under the MIT Licence, which governs your rights in that code. kendex is free to use.
+
+## Third-party packages
+
+kendex finds and installs other people's work: agents, skills, hooks, commands, MCP servers, plugins and extensions written by people who are not us.
+
+A package belongs to its author and is distributed under the licence in its source repository. That licence is between you and the author. We did not write it, commission it, or review it. Listing a package is not endorsement, and neither is a search result, a ranking, or a score.
+
+A package is not passive text. Once installed, your AI coding tools load and run it with whatever access those tools have: your files, your commands, your network, your credentials. Vetting a package is yours to do. Read the source, check who published it, try it somewhere that does not matter, and keep your own backups. You install and run third-party packages entirely at your own risk.
+
+We may delist or remove anything at any time, and we have no duty to monitor what authors publish.
+
+## Scanning is a heuristic, not an approval
+
+kendex scans packages for patterns that are often risky and shows you what it found. The scan is an automated heuristic. It is not a review, an audit, a certification, or an approval.
+
+A clean scan is not a statement by us that a package is safe, correct, lawful, or free of malicious code. It means only that our rules, as they stood when the scan ran, did not match. Rules miss things and misjudge things, and code that passes today can be changed by its author tomorrow. A scan result is not a substitute for reading a package yourself.
+
+## No warranty
+
+THE APP, THE CLI, THE SITE, THE API, AND EVERY PACKAGE, LISTING, SCORE AND SCAN RESULT MADE AVAILABLE THROUGH THEM ARE PROVIDED "AS IS" AND "AS AVAILABLE", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT. WE DO NOT WARRANT THAT KENDEX WILL BE UNINTERRUPTED OR ERROR-FREE, THAT ANY SCAN WILL DETECT ANY PARTICULAR RISK, OR THAT ANY PACKAGE IS SAFE OR FIT FOR ANY PURPOSE.
+
+## Liability
+
+To the fullest extent the law allows, we are not liable for loss of data: any loss, corruption, unauthorised alteration, deletion or disclosure of data, source code, repositories, configuration, credentials or files, including anything a package reads, writes, changes, deletes or sends. Loss of data stands on its own here. It does not depend on also being indirect, incidental or consequential.
+
+Nor are we liable for damage to your device or to other software, for lost profits or business, or for any indirect, incidental, special or consequential loss, however caused.
+
+kendex writes into the directories your coding tools own, and it moves and deletes files it manages there. Removals go to a trash directory and an interrupted change is rolled back, but neither is a backup and neither is promised to work. Keep your own backups.
+
+Nothing here excludes liability that the law does not allow us to exclude, and your statutory rights as a consumer stand whatever this document says. Some of these limits may not apply to you where your state, province or country does not allow them.
+
+## Acceptable use
+
+Do not use kendex to publish or install malware, credential stealers, or anything built to damage a system or take data out of one. Do not publish content you have no right to distribute, impersonate another project or person, misrepresent what a package does, or interfere with the service by probing it, scraping past what the API allows, or evading a removal. We may suspend or remove any package, marketplace or account that breaks these rules.
+
+## Changes to these terms
+
+We may change these terms. When we do, we change the version and the date at the top and publish the new text. A change to what you agreed to asks you again in the app and on the command line; a correction that changes nothing you agreed to does not. Continuing to use kendex after a change accepts it.
+
+## Governing law
+
+These terms are governed by the laws of the State of Washington, USA.
+
+## Contact
+
+brad@vanillagreen.com

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -6,6 +6,7 @@ import { RepoEffectsDialog } from "@/components/marketplaces/repo-effects-dialog
 import { NavBar } from "@/components/nav-bar";
 import { Sidebar } from "@/components/sidebar";
 import { StatusFooter } from "@/components/status-footer";
+import { TermsGate } from "@/components/terms-gate";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { WindowControls } from "@/components/window-controls";
 import { receiveDeepLinks } from "@/lib/deep-link";
@@ -234,6 +235,10 @@ export default function App() {
           </main>
         </div>
         <StatusFooter />
+        {/* Last, and over everything: the first thing a new install shows.
+            It records an answer and gets out of the way — nothing else in
+            the app waits on it. */}
+        <TermsGate />
       </div>
     </TooltipProvider>
   );

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -139,6 +139,16 @@ export const commands = {
 	 *  survives whatever else is being saved at the same moment.
 	 */
 	saveZoom: (percent: number) => typedError<number, string>(__TAURI_INVOKE("save_zoom", { percent })),
+	termsState: () => typedError<TermsState, string>(__TAURI_INVOKE("terms_state")),
+	/**
+	 *  Record that the person accepted the documents this build asks about.
+	 * 
+	 *  Its own targeted write rather than the whole-file settings path:
+	 *  acceptance is one field settled by one click, and sending the whole
+	 *  object back would let a copy read before the screen opened put an older
+	 *  file over whatever else has been saved since.
+	 */
+	acceptTerms: () => typedError<TermsState, string>(__TAURI_INVOKE("accept_terms")),
 	registerProject: (path: string) => typedError<SettingsRead, string>(__TAURI_INVOKE("register_project", { path })),
 	unregisterProject: (path: string) => typedError<SettingsRead, string>(__TAURI_INVOKE("unregister_project", { path })),
 	/**
@@ -497,6 +507,8 @@ export const events = {
 };
 
 /* Constants */
+export const LEGAL = {"version":1,"termsUrl":"https://kendex.ai/legal/terms","privacyUrl":"https://kendex.ai/legal/privacy"} as const;
+
 export const MANIFEST_SCHEMA = 6 as const;
 
 export const ZOOM = {"min":50,"max":200,"step":10,"default":100} as const;
@@ -607,6 +619,14 @@ export type AppSettings = {
 	 *  the person and the display in front of them, not to a project.
 	 */
 	zoom?: number,
+	/**
+	 *  Which version of the Terms of Service and Privacy Policy this
+	 *  machine accepted, and when. Machine-local like the rest of this
+	 *  file, and shared by both shells: the app's first-run screen and the
+	 *  CLI's first-run line write it, and neither asks again once it is
+	 *  here. [`crate::legal`] owns the rule.
+	 */
+	terms?: TermsAcceptance | null,
 };
 
 export type AppUpdateStatus = { kind: "neverChecked" } | { kind: "upToDate"; version: string } | { kind: "updateAvailable"; version: string; releaseNotesUrl: string; cliAssetAvailable: boolean; muted: boolean } | { kind: "feedOlder"; version: string };
@@ -3150,6 +3170,28 @@ export type TemplateFinding = {
 	line: number,
 	problem: string,
 	fix: string,
+};
+
+/**
+ *  What this machine accepted. Written once per version — a second accept
+ *  of a version already recorded leaves the first date standing, because
+ *  the date is when the person agreed and no later run changes that.
+ */
+export type TermsAcceptance = {
+	version: number,
+	/**  ISO-8601 UTC, from [`crate::clock::timestamp`]. */
+	"accepted-at": string,
+};
+
+/**
+ *  Whether to ask, and what is on record — from one read, because the
+ *  first-run screen and the About row would otherwise hold two answers
+ *  taken at different moments, and only one of them would be right after
+ *  an accept.
+ */
+export type TermsState = {
+	ask: boolean,
+	accepted: TermsAcceptance | null,
 };
 
 /**

--- a/ui/src/components/terms-gate.dom.test.tsx
+++ b/ui/src/components/terms-gate.dom.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import userEvent from "@testing-library/user-event";
+import { act } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { commands } from "@/bindings";
+import { useTermsStore } from "@/stores/terms";
+import { mount, settle } from "@/test/dom";
+import { TermsGate } from "./terms-gate";
+
+vi.mock("@/bindings", () => ({
+  LEGAL: {
+    version: 1,
+    termsUrl: "https://kendex.ai/legal/terms",
+    privacyUrl: "https://kendex.ai/legal/privacy",
+  },
+  commands: {
+    termsState: vi.fn(),
+    acceptTerms: vi.fn(),
+    openUrl: vi.fn(),
+    windowMinimize: vi.fn(),
+    windowToggleMaximize: vi.fn(),
+    windowClose: vi.fn(),
+  },
+}));
+
+const agree = (host: HTMLElement): HTMLButtonElement | null =>
+  [...host.querySelectorAll("button")].find((button) =>
+    (button.textContent ?? "").startsWith("I agree"),
+  ) ?? null;
+
+beforeEach(() => {
+  vi.mocked(commands.termsState).mockReset();
+  vi.mocked(commands.acceptTerms).mockReset();
+  useTermsStore.setState({ state: null, error: null });
+});
+
+describe("the first-run terms screen", () => {
+  it("asks when nothing is on record, and records the version on the one button", async () => {
+    vi.mocked(commands.termsState).mockResolvedValue({
+      status: "ok",
+      data: { ask: true, accepted: null },
+    });
+    vi.mocked(commands.acceptTerms).mockResolvedValue({
+      status: "ok",
+      data: {
+        ask: false,
+        accepted: { version: 1, "accepted-at": "2026-09-06T10:00:00Z" },
+      },
+    });
+
+    const host = mount(<TermsGate />);
+    await settle();
+    const button = agree(host);
+    expect(button).not.toBeNull();
+
+    await act(async () => {
+      await userEvent.click(button as HTMLButtonElement);
+    });
+    expect(commands.acceptTerms).toHaveBeenCalledTimes(1);
+    expect(agree(host)).toBeNull();
+  });
+
+  // The must-fail half: a screen that drew itself whatever the record said
+  // would pass the case above and ask everyone, every launch.
+  it("asks nothing once the current version is on record", async () => {
+    vi.mocked(commands.termsState).mockResolvedValue({
+      status: "ok",
+      data: {
+        ask: false,
+        accepted: { version: 1, "accepted-at": "2026-09-06T10:00:00Z" },
+      },
+    });
+
+    const host = mount(<TermsGate />);
+    await settle();
+    expect(agree(host)).toBeNull();
+    expect(commands.acceptTerms).not.toHaveBeenCalled();
+  });
+
+  // Whether to ask is the backend's answer, not a version comparison made
+  // here: an older record reaches this component as the same `ask`.
+  it("asks again when the backend says the record is behind", async () => {
+    vi.mocked(commands.termsState).mockResolvedValue({
+      status: "ok",
+      data: {
+        ask: true,
+        accepted: { version: 1, "accepted-at": "2020-01-01T00:00:00Z" },
+      },
+    });
+
+    const host = mount(<TermsGate />);
+    await settle();
+    expect(agree(host)).not.toBeNull();
+  });
+
+  it("keeps the screen up and says why when the record could not be written", async () => {
+    vi.mocked(commands.termsState).mockResolvedValue({
+      status: "ok",
+      data: { ask: true, accepted: null },
+    });
+    vi.mocked(commands.acceptTerms).mockResolvedValue({
+      status: "error",
+      error: "settings.toml is not writable",
+    });
+
+    const host = mount(<TermsGate />);
+    await settle();
+    await act(async () => {
+      await userEvent.click(agree(host) as HTMLButtonElement);
+    });
+    expect(host.textContent).toContain("settings.toml is not writable");
+    expect(agree(host)).not.toBeNull();
+  });
+
+  // A read that failed is not evidence that nobody accepted. Asking on it
+  // would put the screen in front of a person who answered months ago.
+  it("asks nothing when the record could not be read", async () => {
+    vi.mocked(commands.termsState).mockResolvedValue({
+      status: "error",
+      error: "settings.toml is not readable",
+    });
+
+    const host = mount(<TermsGate />);
+    await settle();
+    expect(agree(host)).toBeNull();
+  });
+});

--- a/ui/src/components/terms-gate.tsx
+++ b/ui/src/components/terms-gate.tsx
@@ -1,0 +1,76 @@
+import { useEffect } from "react";
+import { LEGAL } from "@/bindings";
+import { ExternalLink } from "@/components/external-link";
+import { Button } from "@/components/ui/button";
+import { WindowControls } from "@/components/window-controls";
+import { useTermsStore } from "@/stores/terms";
+
+/**
+ * The first-run screen: what kendex asks a person to accept before it puts
+ * anything on screen, and the one control that records the answer.
+ *
+ * It is the whole of the accept step. Nothing else in the app waits on the
+ * record — no page, install or apply refuses because it is missing — so
+ * this screen is the only place the question is ever in the way.
+ *
+ * One button, saying what it does. A "Continue" that quietly counted as
+ * agreement, or a box already ticked, would be a person carried past a
+ * document they never chose to accept.
+ */
+export function TermsGate() {
+  const state = useTermsStore((s) => s.state);
+  const error = useTermsStore((s) => s.error);
+  const accept = useTermsStore((s) => s.accept);
+  const load = useTermsStore((s) => s.load);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (state?.ask !== true) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Terms of Service and Privacy Policy"
+      className="fixed inset-0 z-40 flex items-center justify-center bg-background"
+    >
+      {/* The window still minimizes, resizes and closes while this is up:
+          a screen that asks a question must not also be the one thing
+          standing between a person and closing the app. */}
+      <div data-tauri-drag-region className="absolute inset-x-0 top-0 h-8" />
+      <WindowControls className="absolute top-0 right-0 z-50" />
+      <div className="mx-auto flex w-full max-w-lg flex-col gap-5 px-8">
+        <h1 className="text-lg font-medium">Before you start</h1>
+        <div className="flex flex-col gap-3 text-sm text-muted-foreground">
+          <p>
+            kendex installs agents, skills, hooks and other packages written by
+            other people. Your AI coding tools load and run them with the access
+            those tools have. Checking a package before you install it is yours
+            to do, and kendex is not liable for data a package loses, corrupts
+            or changes.
+          </p>
+          <p>
+            The app and the command line collect nothing about you or your code.
+            What kendex.ai stores is in the privacy policy.
+          </p>
+          <p className="flex gap-4">
+            <ExternalLink url={LEGAL.termsUrl}>Terms of Service</ExternalLink>
+            <ExternalLink url={LEGAL.privacyUrl}>Privacy Policy</ExternalLink>
+          </p>
+        </div>
+        <div className="flex flex-col gap-2">
+          <Button className="self-start" onClick={() => void accept()}>
+            I agree to the Terms and Privacy Policy
+          </Button>
+          {error === null ? null : (
+            <span className="text-critical text-sm" role="alert">
+              {error}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/settings.dom.test.tsx
+++ b/ui/src/pages/settings.dom.test.tsx
@@ -15,8 +15,17 @@ vi.mock("@/bindings", () => ({
     accountLoginPoll: vi.fn(),
     accountLogout: vi.fn(),
     openUrl: vi.fn(),
+    termsState: vi.fn().mockResolvedValue({
+      status: "ok",
+      data: { ask: false, accepted: null },
+    }),
   },
   ZOOM: { min: 50, max: 200, step: 10, default: 100 },
+  LEGAL: {
+    version: 1,
+    termsUrl: "https://kendex.ai/legal/terms",
+    privacyUrl: "https://kendex.ai/legal/privacy",
+  },
 }));
 vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
 

--- a/ui/src/pages/settings.tsx
+++ b/ui/src/pages/settings.tsx
@@ -18,7 +18,7 @@ import { SETTINGS_SUBTITLE } from "@/lib/labels";
 import { CONTENT_WIDTH, PAGE_BODY } from "@/lib/layout";
 import { cn } from "@/lib/utils";
 import { useSettingsStore } from "@/stores/settings";
-import { useTermsStore } from "@/stores/terms";
+import { acceptedSummary, useTermsStore } from "@/stores/terms";
 import { zoom } from "@/stores/zoom";
 
 const THEME_LABELS: Record<Appearance, string> = {
@@ -35,7 +35,7 @@ export function SettingsPage() {
   const [version, setVersion] = useState<Awaited<
     ReturnType<typeof commands.appVersion>
   > | null>(null);
-  const accepted = useTermsStore((s) => s.state?.accepted ?? null);
+  const terms = useTermsStore((s) => s.state);
   const loadTerms = useTermsStore((s) => s.load);
 
   useEffect(() => {
@@ -134,9 +134,7 @@ export function SettingsPage() {
                 <span className="flex items-baseline gap-2">
                   Terms
                   <span className="font-mono text-xs font-normal text-muted-foreground">
-                    {accepted
-                      ? `version ${accepted.version}, accepted ${accepted["accepted-at"].slice(0, 10)}`
-                      : "not accepted"}
+                    {acceptedSummary(terms)}
                   </span>
                 </span>
               }

--- a/ui/src/pages/settings.tsx
+++ b/ui/src/pages/settings.tsx
@@ -1,8 +1,9 @@
 import { MinusIcon, PlusIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { Appearance } from "@/bindings";
-import { commands, ZOOM } from "@/bindings";
+import { commands, LEGAL, ZOOM } from "@/bindings";
 import { AccountSection } from "@/components/account-section";
+import { ExternalLink } from "@/components/external-link";
 import { PageHeader } from "@/components/page-header";
 import { Section, SettingRow } from "@/components/section";
 import { Button } from "@/components/ui/button";
@@ -17,6 +18,7 @@ import { SETTINGS_SUBTITLE } from "@/lib/labels";
 import { CONTENT_WIDTH, PAGE_BODY } from "@/lib/layout";
 import { cn } from "@/lib/utils";
 import { useSettingsStore } from "@/stores/settings";
+import { useTermsStore } from "@/stores/terms";
 import { zoom } from "@/stores/zoom";
 
 const THEME_LABELS: Record<Appearance, string> = {
@@ -33,10 +35,16 @@ export function SettingsPage() {
   const [version, setVersion] = useState<Awaited<
     ReturnType<typeof commands.appVersion>
   > | null>(null);
+  const accepted = useTermsStore((s) => s.state?.accepted ?? null);
+  const loadTerms = useTermsStore((s) => s.load);
 
   useEffect(() => {
     void commands.appVersion().then(setVersion);
-  }, []);
+    // The record is written on first run and on an accept, both of which
+    // can have happened since this page last read it — in this window or
+    // in a terminal.
+    void loadTerms();
+  }, [loadTerms]);
 
   const percent = onScreen();
 
@@ -121,6 +129,24 @@ export function SettingsPage() {
                   : "kendex keeps your AI coding tools in sync."
               }
             />
+            <SettingRow
+              label={
+                <span className="flex items-baseline gap-2">
+                  Terms
+                  <span className="font-mono text-xs font-normal text-muted-foreground">
+                    {accepted
+                      ? `version ${accepted.version}, accepted ${accepted["accepted-at"].slice(0, 10)}`
+                      : "not accepted"}
+                  </span>
+                </span>
+              }
+              description="What you accepted, and when. The record is on this computer only."
+            >
+              <div className="flex gap-4 text-sm">
+                <ExternalLink url={LEGAL.termsUrl}>Terms</ExternalLink>
+                <ExternalLink url={LEGAL.privacyUrl}>Privacy</ExternalLink>
+              </div>
+            </SettingRow>
           </Section>
         </div>
       </div>

--- a/ui/src/stores/terms.test.ts
+++ b/ui/src/stores/terms.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { acceptedSummary } from "./terms";
+
+describe("what the About row says the terms record holds", () => {
+  it("names the version and the date it was accepted on", () => {
+    expect(
+      acceptedSummary({
+        ask: false,
+        accepted: { version: 1, "accepted-at": "2026-09-06T10:11:12Z" },
+      }),
+    ).toBe("version 1, accepted 2026-09-06");
+  });
+
+  it("says nothing is accepted only when the record is read and empty", () => {
+    expect(acceptedSummary({ ask: true, accepted: null })).toBe("not accepted");
+  });
+
+  // The must-fail half. Nothing read is not the same as nothing accepted,
+  // and telling a person who accepted months ago that they did not is the
+  // one thing this row must never do.
+  it("claims nothing while the record is unread", () => {
+    expect(acceptedSummary(null)).toBe("…");
+  });
+});

--- a/ui/src/stores/terms.ts
+++ b/ui/src/stores/terms.ts
@@ -1,0 +1,45 @@
+import { create } from "zustand";
+import { commands, type TermsState } from "@/bindings";
+import { settled } from "@/lib/settled";
+
+interface TermsStoreState {
+  /** Null until the first read lands. Nothing is asked on a null: a read
+   *  that has not happened is no evidence that the person has not already
+   *  accepted, and putting the screen up on it would ask someone who
+   *  answered months ago. */
+  state: TermsState | null;
+  /** Why the accept did not go through, shown beside the button. */
+  error: string | null;
+  load: () => Promise<void>;
+  accept: () => Promise<void>;
+}
+
+/**
+ * Whether to ask about the terms, and what is on record.
+ *
+ * Both answers come from the backend, which reads them off the same
+ * settings file the command line writes on its own first run. Nothing
+ * here compares versions: the rule for when a later version asks again is
+ * `kendex_core::legal`'s, and a copy of it in the UI would be a second
+ * rule to keep in step.
+ *
+ * A read that failed asks nothing. The screen exists to record an answer,
+ * and an app that cannot read its settings cannot write one either — so it
+ * would be a wall with nothing behind it.
+ */
+export const useTermsStore = create<TermsStoreState>((set, get) => ({
+  state: null,
+  error: null,
+
+  load: async () => {
+    const read = await settled(commands.termsState());
+    if (read.status === "ok") set({ state: read.data, error: null });
+  },
+
+  accept: async () => {
+    if (get().state?.ask !== true) return;
+    const written = await settled(commands.acceptTerms());
+    if (written.status === "ok") set({ state: written.data, error: null });
+    else set({ error: written.error });
+  },
+}));

--- a/ui/src/stores/terms.ts
+++ b/ui/src/stores/terms.ts
@@ -15,6 +15,21 @@ interface TermsStoreState {
 }
 
 /**
+ * What the About row says the record holds.
+ *
+ * Three answers, not two. A read that has not landed or that failed leaves
+ * nothing known, and saying "not accepted" there would tell a person who
+ * accepted months ago that they did not — about the one row on the page
+ * whose whole job is to be evidence.
+ */
+export function acceptedSummary(state: TermsState | null): string {
+  if (state === null) return "…";
+  const record = state.accepted;
+  if (record === null) return "not accepted";
+  return `version ${record.version}, accepted ${record["accepted-at"].slice(0, 10)}`;
+}
+
+/**
  * Whether to ask about the terms, and what is on record.
  *
  * Both answers come from the backend, which reads them off the same


### PR DESCRIPTION
Drafts the Terms of Service and the Privacy Policy, and the step that accepts them. **The wording is for the owner to read before this merges.**

## The documents

`docs/legal/terms.md` and `docs/legal/privacy.md`, plain markdown, canonical here. Both carry `Version 1.` in their own bytes, which is the number the acceptance record stores.

The Terms say the two things KEN-492 asked for: third-party packages are the user's to vet, and we are not liable for lost, corrupted or altered data — loss of data enumerated on its own rather than left inside "consequential". The scanning section says a clean scan is not an approval. The Privacy Policy says what the app and the CLI collect (nothing) and what kendex.ai stores.

## The accept step

One record in the app's machine-local `settings.toml`, written by both shells, holding the version and the date. `kendex_core::legal` owns the rule: recorded once per version, a later version asks again, a correction does not.

- **App** — a first-run screen with one button that says what it does. Window controls stay reachable while it is up.
- **CLI** — one line on a first run, where stderr is a terminal. A run through a pipe says nothing and records nothing: `kendex check`'s whole contract with the session hooks is an exit code over a quiet stderr, and the person whose first runs all went through a script is still asked the first time they are at a terminal.
- **Settings → About** — the version accepted and the date, which is what the recorded date is for.

Nothing refuses on the record. No page, verb, install or apply waits for it.

## Controls

One per surface, each run red once against a planted defect before its green counted:

| Surface | Control | Planted defect it caught |
| -- | -- | -- |
| `legal::asks_again` | table over no record / older / current / newer | `asks_again` pinned true, then pinned false |
| `legal::accept` | records once with its version; a later version replaces the older record | both of the above |
| the documents | both state the version this build asks about | version bumped without touching the documents |
| `legal::stated_version` | reads the line rather than assuming it | reader pinned to `LEGAL.version` |
| CLI first run | says it once at a terminal, records it, then silent; older record asked again; a pipe says and records nothing | gate removed, announce pinned on, announce pinned off |
| the app screen | shown on ask, gone on accept, error kept on screen, silent on a failed read | screen drawn regardless, screen never drawn |
| the root guard | a root run records nothing and creates neither the settings file nor its lock | guard removed — plus a real `unshare -Ur` run of the binary, which leaves no config directory |
| the About row | three answers, and an unread record is not "not accepted" | unread folded back into "not accepted" |

`crates/cli/tests/pty.rs` is the terminal harness lifted out of `crates/cli/tests/presentation/main.rs` rather than written a second time; it takes the `Command` by value now, because a live `Command` holds the terminal fds open and the read never ends.

## From the review round

Two local reviewers, one round. What they caught, all fixed on the branch:

- **The privacy policy understated what leaves the machine.** The network list omitted every signed-in kendex.ai call — `kendex login`, `/api/v1/me`, submissions and collection links all send a bearer credential naming the account, and a submission also asks GitHub about the named repository. Signed-out and signed-in traffic are now separated and the "collect nothing" heading points forward. The skills.sh leaderboard comes through a kendex.ai proxy; only a typed search reaches skills.sh directly.
- **Collections are soft-deleted** and the live site says so; the draft had dropped it.
- **The Terms said the command line "asks you again".** It does not — it says one line and records. Reworded, changelog with it.
- **`legal::accept` wrote into the config directory with no root guard**, one line below `bootstrap_the_command_record`, which refuses for exactly this reason. Under `sudo -E` it would leave `settings.toml.lock` and possibly `~/.config/kendex/` owned by root, after which every unprivileged settings write — zoom, project registration, the accept itself — fails for good, naming nothing. The reasoning moved to `kendex_core::privilege`, cited by both writers; `accept` now refuses with `WouldWriteAsRoot`, and the CLI says nothing under sudo so the line is never one that could not be answered.
- **The once-per-version control was vacuous.** `timestamp()` has second resolution, so two accepts in the same second agreed whether or not the guard was there; the reviewer's planted mutant survived. The control now seeds a date from 2020 and the mutant dies.
- **`--help` and `--version`** — the placement claim now has the row its sibling in `command_record.rs` already had.
- **`tests/pty.rs` became a cargo test target of its own** (no `#[test]` in it); moved under `tests/support/`.

## Not in this change

kendex.ai's copies of the two pages. The site already publishes `/legal/terms` and `/legal/privacy` from `src/content/legal/` on kendex-web main; bringing them into line with the text merged here is a follow-up in the **kendex-web** repo, and KEN-492 stays open for it.

**That follow-up is a release dependency, not just a nicety.** The record stores `version 1`, and the app and the CLI link to those two URLs — which today serve different text carrying no version line at all. Until kendex-web publishes the text merged here as Version 1, an acceptance record points at bytes that do not match it. Nothing in this repo can close that gap, and no test here can see across the two repos: `documents_state_the_version_this_build_asks_about` binds the number to the local copies only. **The site should publish before any app release carrying the accept step reaches people.**

KEN-492
