### PR TITLE
fix(KEN-1083): the suites and shipped scripts run on the BSD userland

### DIFF
--- a/.agents/skills/commit-guards/scripts/install-git-hooks
+++ b/.agents/skills/commit-guards/scripts/install-git-hooks
@@ -236,7 +236,10 @@ fi
 # and stays refused, the safe direction.
 helper_is_dangling() { # PATH — 0 when the helper's install directory is gone
   local line="" dir=""
-  line="$(sed -n '3p' -- "$1" 2>/dev/null)" || return 1
+  # The helper comes in on stdin, not as an operand: BSD sed has no `--`
+  # end-of-options, so it would open `--` as a second input and exit 1, and
+  # every helper of ours whose install is gone would read as somebody's file.
+  line="$(sed -n '3p' <"$1" 2>/dev/null)" || return 1
   case "$line" in
     "installed_scripts='"*"'") ;;
     *) return 1 ;;

--- a/.agents/skills/commit-guards/scripts/lib/changelog-grammar.sh
+++ b/.agents/skills/commit-guards/scripts/lib/changelog-grammar.sh
@@ -91,7 +91,13 @@ gg_changelog_blob() { # SHA LABEL — fills $GG_TMP/blob; 1 = not changelog text
   local sha="$1" label="$2" bad
   gg_read_blob "$sha" "$label" changelog
   ! gg_blob_is_binary "$GG_TMP/blob" "$label" || return 1
-  bad="$(LC_ALL=C awk "$GG_UTF8_AWK" <"$GG_TMP/blob")" \
+  # Every NUL becomes \200 before awk reads a byte. An awk that holds a record
+  # as a NUL-terminated C string — the BWK awk macOS ships — otherwise sees a
+  # line that stops at its first NUL, and a blob git calls text for having its
+  # only NUL past the leading sample would be measured as the short prefix
+  # instead of refused. \200 is a stray continuation byte, which the grammar
+  # below already rejects, so the line reports as the invalid UTF-8 it is.
+  bad="$(LC_ALL=C tr '\000' '\200' <"$GG_TMP/blob" | LC_ALL=C awk "$GG_UTF8_AWK")" \
     || gg_collection_error "could not read $(gg_shown "$label") to check its encoding"
   if [ -n "$bad" ]; then
     gg_collection_error "$(gg_shown "$label") line $bad is not valid UTF-8 — text with no character count cannot be measured"

--- a/.agents/skills/commit-guards/scripts/lib/staged-lines.sh
+++ b/.agents/skills/commit-guards/scripts/lib/staged-lines.sh
@@ -32,7 +32,13 @@ gg_staged_added_lines() { # PATH — one "line<TAB>content" record per line this
   # still arrives as hunks, so no path reaches the parser with its content
   # withheld; a genuinely binary blob never reaches the parser at all — the
   # lane's content sniff drops it before this runs.
-  awk '
+  # LC_ALL=C, like the grep every caller runs over this output: BWK awk — the
+  # awk macOS ships — decodes its input as characters under a UTF-8 locale and
+  # aborts with `towc: multibyte conversion failure`, exit 2, on the first byte
+  # sequence that is not valid UTF-8. A tracked text file may hold any byte;
+  # this lane's own content sniff already decided the blob is text, and a
+  # scan that exits 2 is a lane that errors instead of judging.
+  LC_ALL=C awk '
     /^diff --git / { hunk = 0; next }
     /^@@/ {
       h = $3

--- a/.agents/skills/commit-guards/tests/bsd-argv-install.test.sh
+++ b/.agents/skills/commit-guards/tests/bsd-argv-install.test.sh
@@ -135,3 +135,84 @@ if [ -x "$broken/.git/hooks/pre-commit" ] && [ -x "$broken/.git/hooks/commit-msg
 fi
 
 echo "pass: bsd-argv-install"
+
+# --- BSD sed argv, the same way: run it, do not read it -------------------
+#
+# `--` is not an end-of-options marker for BSD sed either. getopt(3) stops at
+# the first non-option argument, which for sed is the script, so a `--` after
+# it is a file operand — a file named `--`, which nobody has. BSD sed reports
+# it and exits 1 while still processing the real file, so a caller reading the
+# exit status sees a failure over content it actually got. install-git-hooks
+# reads line 3 of a candidate helper that way, and preflight reads a runner
+# body that way; the same rule judges both, and this is install-git-hooks.
+REAL_SED="$(command -v sed)"
+cat >"$shim/sed" <<SHIM
+#!/bin/sh
+# Every argument after the script is a file operand; a \`--\` among them is a
+# file nobody has.
+seen_script=0
+for arg in "\$@"; do
+  case "\$seen_script\$arg" in
+    0-*) continue ;;
+  esac
+  if [ "\$seen_script" -eq 1 ] && [ "\$arg" = "--" ]; then
+    echo "sed: --: No such file or directory" >&2
+    exit 1
+  fi
+  seen_script=1
+done
+exec $REAL_SED "\$@"
+SHIM
+chmod 0755 "$shim/sed"
+
+# The shim has teeth, and only on the wrong shape.
+printf 'a\nb\nc\n' >"$TMP/sed-probe"
+if PATH="$shim:$PATH" sed -n '3p' -- "$TMP/sed-probe" >/dev/null 2>&1; then
+  echo "FAIL: the sed shim accepts a -- operand, so it judges nothing" >&2
+  exit 1
+fi
+if [ "$(PATH="$shim:$PATH" sed -n '3p' <"$TMP/sed-probe")" != c ]; then
+  echo "FAIL: the sed shim does not pass a correct call through to the real sed" >&2
+  exit 1
+fi
+
+# A helper an earlier install wrote, whose baked scripts directory is gone.
+# install-git-hooks replaces exactly that file and refuses every other one, so
+# reading its line 3 is the whole decision: a read that fails leaves ours
+# looking like somebody else's file and the install stops.
+dangling_helper() { # REPO — plant a helper of an install that no longer exists
+  printf '#!/bin/sh\n# Scripts directory of the install that wrote this file.\ninstalled_scripts=%s\n# kendex earlier-package git hooks. Managed by an earlier install.\nexit 0\n' \
+    "'$TMP/install-that-moved/scripts'" >"$1/.git/hooks/kendex-guards"
+}
+
+dangling_helper "$repo"
+out=""
+status=0
+out="$(PATH="$shim:$PATH" "$installer" --repo "$repo" 2>&1)" || status=$?
+case "$out" in
+  *"scripts directory is gone; replacing it"*) ;;
+  *)
+    echo "FAIL: under BSD sed argv rules the dangling helper was not recognised (exit $status)" >&2
+    printf '%s\n' "$out" >&2
+    exit 1
+    ;;
+esac
+
+# The control: a copy with the `--` restored must NOT recognise it. Without
+# this the assertion above passes on any installer, including one that never
+# reads line 3.
+perl -pi -e "s/sed -n '3p' <\"\\\$1\"/sed -n '3p' -- \"\\\$1\"/" "$broken_installer"
+grep -q "sed -n '3p' -- " "$broken_installer" || {
+  echo "FAIL: the control could not restore the -- operand; the assertion below proves nothing" >&2
+  exit 1
+}
+dangling_helper "$broken"
+broken_out="$(PATH="$shim:$PATH" "$broken_installer" --repo "$broken" 2>&1)" || true
+case "$broken_out" in
+  *"scripts directory is gone; replacing it"*)
+    echo "FAIL: must-fail control recognised the dangling helper with a -- operand under BSD sed" >&2
+    exit 1
+    ;;
+esac
+
+echo "pass: bsd-argv-sed"

--- a/.agents/skills/commit-guards/tests/bsd-awk-record.test.sh
+++ b/.agents/skills/commit-guards/tests/bsd-awk-record.test.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# The changelog family's encoding check under BWK awk's record rule, as a
+# program rather than a lint.
+#
+# macOS ships BWK awk ("awk version 20200816"), which holds a record as a
+# NUL-terminated C string: a line's content stops at its first NUL. GNU awk
+# carries the whole line, so nothing on a Linux runner can see the
+# difference by reading the source. It is put in a shim on PATH instead and
+# the real check runs under it.
+#
+# What the rule costs: git calls a blob binary only when a NUL falls in its
+# leading sample, so a blob whose only NUL is past that sample is text to
+# git and must be text to this family too. Under BWK's rule the UTF-8 pass
+# never sees that NUL, the blob measures as the short prefix before it, and
+# an unmeasurable file is reported as an over-long entry instead of being
+# refused. scripts/lib/changelog-grammar.sh translates every NUL to \200 — a
+# stray continuation byte its grammar already rejects — before awk reads a
+# byte, which is what this suite pins.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+# shellcheck source=lib/harness.bash
+. "$TEST_DIR/lib/harness.bash"
+
+unset COMMIT_GUARDS_CHANGELOG_CAP COMMIT_GUARDS_CHANGELOG_PATHS \
+  COMMIT_GUARDS_CHANGELOG_RECORD COMMIT_GUARDS_SETTINGS_FILE 2>/dev/null || true
+
+REAL_AWK="$(command -v awk)"
+shim="$TMP/shim"
+mkdir -p "$shim"
+cat >"$shim/awk" <<SHIM
+#!/bin/sh
+# One argument is a program and its input on stdin, which is how the
+# changelog family reads a blob. Every other shape — a file operand, -v, -F —
+# passes straight through, so this shim judges that one read and nothing else.
+if [ "\$#" -eq 1 ]; then
+  perl -pe 's/\\0.*//' | $REAL_AWK "\$1"
+  exit \$?
+fi
+exec $REAL_AWK "\$@"
+SHIM
+chmod 0755 "$shim/awk"
+
+# The shim has teeth, and only on the shape it means to judge.
+truncated="$(printf 'ab\000cd\n' | PATH="$shim:$PATH" awk '{ print length($0) }')"
+[ "$truncated" = 2 ] || {
+  echo "FAIL: the awk shim does not truncate a record at its NUL (length $truncated)" >&2
+  exit 1
+}
+# Compared against the host's own awk, not against a number: BWK awk truncates
+# at a NUL whatever the input is, so on macOS the untouched answer is 2 and on
+# GNU it is 5. What must hold on both is that the shim changed nothing here.
+printf 'ab\000cd\n' >"$TMP/probe"
+whole="$(PATH="$shim:$PATH" awk '{ print length($0) }' "$TMP/probe")"
+native="$("$REAL_AWK" '{ print length($0) }' "$TMP/probe")"
+[ "$whole" = "$native" ] || {
+  echo "FAIL: the awk shim altered a call with a file operand (length $whole, host awk says $native)" >&2
+  exit 1
+}
+
+# A fragment git calls text: 8100 bytes of content, then the file's only NUL.
+plant() { # REPO
+  mkdir -p "$1/changelog.d/added"
+  {
+    printf -- '- '
+    i=0
+    while [ "$i" -lt 8100 ]; do printf x; i=$((i + 1)); done
+    printf '\000tail\n'
+  } >"$1/changelog.d/added/late-nul.md"
+  git -C "$1" add -A
+}
+
+new_repo() { # PATH
+  mkdir -p "$1"
+  git -C "$1" -c init.defaultBranch=main init -q
+  git -C "$1" config user.email t@t
+  git -C "$1" config user.name t
+}
+
+repo="$TMP/nul"
+new_repo "$repo"
+plant "$repo"
+[ -n "$(git -C "$repo" grep --cached -I -l . -- changelog.d/added)" ] || {
+  echo "FAIL: git calls the fixture blob binary, so it is not the case this suite means" >&2
+  exit 1
+}
+
+out=""
+status=0
+out="$(cd "$repo" && PATH="$shim:$PATH" "$SKILL_DIR/scripts/changelog-entries" 2>&1)" || status=$?
+case "$status:$out" in
+  2:*"late-nul.md line 1 is not valid UTF-8"*) ;;
+  *)
+    echo "FAIL: under BWK awk's record rule the NUL past the sample was not refused (exit $status)" >&2
+    printf '%s\n' "$out" >&2
+    exit 1
+    ;;
+esac
+
+# The control: a copy of the package with the translation removed must NOT
+# refuse it. Without this the assertion above passes on any check, including
+# one that never reads the blob's bytes at all.
+broken="$TMP/broken-pkg"
+mkdir -p "$broken"
+cp -R "$SKILL_DIR" "$broken/commit-guards"
+grammar="$broken/commit-guards/scripts/lib/changelog-grammar.sh"
+perl -pi -e "s/LC_ALL=C tr '\\\\000' '\\\\200' <\"\\\$GG_TMP\\/blob\" \\| LC_ALL=C awk/LC_ALL=C awk/" "$grammar"
+grep -q "tr '\\\\000'" "$grammar" && {
+  echo "FAIL: the control could not remove the NUL translation; the assertion below proves nothing" >&2
+  exit 1
+}
+broken_repo="$TMP/broken-repo"
+new_repo "$broken_repo"
+plant "$broken_repo"
+broken_out="$(cd "$broken_repo" && PATH="$shim:$PATH" "$broken/commit-guards/scripts/changelog-entries" 2>&1)" || true
+case "$broken_out" in
+  *"is not valid UTF-8"*)
+    echo "FAIL: must-fail control refused the late NUL with the translation removed" >&2
+    exit 1
+    ;;
+esac
+
+echo "pass: bsd-awk-record"

--- a/.agents/skills/decider/scripts/decisions
+++ b/.agents/skills/decider/scripts/decisions
@@ -250,7 +250,11 @@ body_term_hits() {
     fi
     # -l lists matching files. Unreadable or absent files are not matches, and
     # a term that matches nothing is not an error.
-    matched=$(printf '%s\0' "${paths[@]}" | xargs -0 -r grep -ilE -e "$term" -- 2>/dev/null || true)
+    # No -r: it is a GNU extension, its only job is to skip a run on empty
+    # input, and the array is already proven non-empty above. Dropping it is
+    # what keeps this line off the differences between xargs implementations
+    # rather than resting on any one of them accepting the flag.
+    matched=$(printf '%s\0' "${paths[@]}" | xargs -0 grep -ilE -e "$term" -- 2>/dev/null || true)
     if [[ -n "$matched" ]]; then
       while IFS= read -r path; do
         hits+="$path"$'\t'"$term"$'\n'

--- a/.agents/skills/github/tests/ci-logs-large-log.test.sh
+++ b/.agents/skills/github/tests/ci-logs-large-log.test.sh
@@ -75,9 +75,11 @@ padding="$(printf 'x%.0s' {1..1400})"
     printf '2026-09-02T10:00:00Z  compiling crate %s\n' "$padding"
   done
 } > "$TMP_ROOT/big.log"
-log_bytes=$(wc -c <"$TMP_ROOT/big.log")
+# BSD wc right-aligns its count in a fixed-width field; assert_ge below reads
+# its argument with ^[0-9]+$, which a padded number fails.
+log_bytes=$(wc -c <"$TMP_ROOT/big.log" | tr -d ' ')
 assert_ge "$log_bytes" 131072 "staged log clears the pipe buffer and the single-argument cap"
-assert_eq "$(wc -l <"$TMP_ROOT/big.log")" "100" "staged log fits the default --lines window whole"
+assert_eq "$(wc -l <"$TMP_ROOT/big.log" | tr -d ' ')" "100" "staged log fits the default --lines window whole"
 
 # The job name matches none of the fallback heuristics, so the log is the only
 # thing that can produce a classification other than "unknown".

--- a/.agents/skills/github/tests/env-first-auth.sh
+++ b/.agents/skills/github/tests/env-first-auth.sh
@@ -214,15 +214,18 @@ ENVEOF
 rm -f "$TMP_ROOT/op.calls"
 output=$(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" STUB_KEYRING_OK=1 "$REPO_ROOT/skills/github/scripts/github.sh" -C "$TMP_ROOT/repo" pr-view --json number,state)
 assert_eq "$(jq -r .number <<<"$output")" "42" "github.sh router falls back to keyring for unresolved GH_TOKEN"
-assert_eq "$(wc -l <"$TMP_ROOT/op.calls")" "1" "unresolved GH_TOKEN attempts op once before keyring fallback"
+# The blanks come off every count below: BSD wc right-aligns its number in a
+# fixed-width field, so `$(wc -l <f)` reads "       1" on macOS and "1" on
+# GNU, and these are compared as strings.
+assert_eq "$(wc -l <"$TMP_ROOT/op.calls" | tr -d ' ')" "1" "unresolved GH_TOKEN attempts op once before keyring fallback"
 
 rm -f "$TMP_ROOT/op.calls"
 (cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" STUB_KEYRING_OK=1 GH_TOKEN=op://vault/github/user "$REPO_ROOT/skills/github/scripts/commands/label-add.sh" 42 test-label >/dev/null)
-assert_eq "$(wc -l <"$TMP_ROOT/op.calls")" "1" "label-add falls back to keyring for unresolved GH_TOKEN"
+assert_eq "$(wc -l <"$TMP_ROOT/op.calls" | tr -d ' ')" "1" "label-add falls back to keyring for unresolved GH_TOKEN"
 
 rm -f "$TMP_ROOT/op.calls"
 (cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" STUB_KEYRING_OK=1 GITHUB_TOKEN=op://vault/github/user "$REPO_ROOT/skills/github/scripts/commands/label-remove.sh" 42 test-label >/dev/null)
-assert_eq "$(wc -l <"$TMP_ROOT/op.calls")" "1" "label-remove falls back to keyring for unresolved GITHUB_TOKEN"
+assert_eq "$(wc -l <"$TMP_ROOT/op.calls" | tr -d ' ')" "1" "label-remove falls back to keyring for unresolved GITHUB_TOKEN"
 
 cat > "$TMP_ROOT/repo/.env.local" <<'ENVEOF'
 GH_BOT_TOKEN=ghs_ROUTERBOT123
@@ -263,7 +266,7 @@ printf '%s\n' 'body text' >"$TMP_ROOT/pr-body.md"
 rm -f "$TMP_ROOT/op.calls"
 output=$(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" STUB_KEYRING_OK=1 GH_TOKEN=op://vault/github/user "$REPO_ROOT/skills/github/scripts/github.sh" -C "$TMP_ROOT/repo" pr-edit-body 42 --body-file "$TMP_ROOT/pr-body.md")
 assert_eq "$output" "updated" "github.sh pr-edit-body falls back to keyring for unresolved GH_TOKEN"
-assert_eq "$(wc -l <"$TMP_ROOT/op.calls")" "1" "pr-edit-body unresolved GH_TOKEN attempts op once"
+assert_eq "$(wc -l <"$TMP_ROOT/op.calls" | tr -d ' ')" "1" "pr-edit-body unresolved GH_TOKEN attempts op once"
 
 cat > "$TMP_ROOT/repo/.env.local" <<'ENVEOF'
 GH_BOT_TOKEN=op://vault/github/bot
@@ -271,7 +274,7 @@ ENVEOF
 rm -f "$TMP_ROOT/op.calls"
 output=$(load_token)
 assert_eq "$output" "ghs_RESOLVED123" "project op reference resolves when no env token exists"
-assert_eq "$(wc -l <"$TMP_ROOT/op.calls")" "1" "project op reference calls op once"
+assert_eq "$(wc -l <"$TMP_ROOT/op.calls" | tr -d ' ')" "1" "project op reference calls op once"
 
 cat > "$TMP_ROOT/repo/.env.local" <<'ENVEOF'
 GH_BOT_TOKEN=ghs_FILEBOT123

--- a/.agents/skills/github/tests/pr-view.sh
+++ b/.agents/skills/github/tests/pr-view.sh
@@ -315,7 +315,9 @@ for bound in KENDEX_GITHUB_AUTH_TIMEOUT KENDEX_GITHUB_OP_TIMEOUT \
     "the refusal names $bound" "$stderr"
   assert_eq "$(jq -r .detail <<<"$output")" "2.55" \
     "the refusal carries the value it rejected for $bound" "$stderr"
-  assert_eq "$(wc -c <"$calls")" "0" \
+  # BSD wc right-aligns its count in a fixed-width field, so the blanks come
+  # off before the string comparison.
+  assert_eq "$(wc -c <"$calls" | tr -d ' ')" "0" \
     "an unreadable $bound reaches no gh call" "$stderr"
 done
 
@@ -327,7 +329,7 @@ rc=$?
 set -e
 assert_eq "$rc" "0" "inherited op GH_TOKEN falls back to keyring" "$stderr"
 assert_eq "$(jq -r .number <<<"$output")" "42" "inherited op GH_TOKEN preserves gh JSON" "$stderr"
-assert_eq "$(wc -l <"$TMP_ROOT/op.calls")" "1" "inherited op GH_TOKEN attempts op once" "$stderr"
+assert_eq "$(wc -l <"$TMP_ROOT/op.calls" | tr -d ' ')" "1" "inherited op GH_TOKEN attempts op once" "$stderr"
 
 rm -f "$TMP_ROOT/op.calls"
 stderr="$TMP_ROOT/inherited-github-token-op.err"
@@ -337,7 +339,7 @@ rc=$?
 set -e
 assert_eq "$rc" "0" "inherited op GITHUB_TOKEN falls back to keyring" "$stderr"
 assert_eq "$(jq -r .number <<<"$output")" "42" "inherited op GITHUB_TOKEN preserves gh JSON" "$stderr"
-assert_eq "$(wc -l <"$TMP_ROOT/op.calls")" "1" "inherited op GITHUB_TOKEN attempts op once" "$stderr"
+assert_eq "$(wc -l <"$TMP_ROOT/op.calls" | tr -d ' ')" "1" "inherited op GITHUB_TOKEN attempts op once" "$stderr"
 
 cat > "$TMP_ROOT/repo/.env.local" <<'ENVEOF'
 GH_BOT_TOKEN=op://vault/item/field

--- a/.agents/skills/github/tests/verify-lib-error-summary.test.sh
+++ b/.agents/skills/github/tests/verify-lib-error-summary.test.sh
@@ -57,7 +57,9 @@ done
 exit 1
 CMD
 chmod +x "$TMP_ROOT/fail.sh"
-assert_ge "$(bash "$TMP_ROOT/fail.sh" | wc -c || true)" 131072 "failing command's error text clears two pipe buffers"
+# BSD wc right-aligns its count in a fixed-width field; assert_ge reads its
+# argument with ^[0-9]+$, which a padded number fails.
+assert_ge "$(bash "$TMP_ROOT/fail.sh" | wc -c | tr -d ' ' || true)" 131072 "failing command's error text clears two pipe buffers"
 
 # run_stack under live errexit, with RESULTS_JSON recovered from an EXIT trap:
 # an aborted run_stack leaves the entry it never wrote missing rather than

--- a/.agents/skills/github/tests/verify-lib-error-summary.test.sh
+++ b/.agents/skills/github/tests/verify-lib-error-summary.test.sh
@@ -122,7 +122,7 @@ printf 'error[E0001]: %s\n' "$pad"
 exit 1
 CMD
 chmod +x "$TMP_ROOT/fail-long-line.sh"
-assert_ge "$(bash "$TMP_ROOT/fail-long-line.sh" | wc -c || true)" 131072 "the single error line clears MAX_ARG_STRLEN on its own"
+assert_ge "$(bash "$TMP_ROOT/fail-long-line.sh" | wc -c | tr -d ' ' || true)" 131072 "the single error line clears MAX_ARG_STRLEN on its own"
 
 echo "=== one error line past MAX_ARG_STRLEN is still summarized (KEN-1171) ==="
 results="$(drive "rust|bash $TMP_ROOT/fail-long-line.sh||.")"

--- a/.agents/skills/orch/scripts/lanes
+++ b/.agents/skills/orch/scripts/lanes
@@ -70,7 +70,7 @@
 #   the reference case). A lane chooser that silently rotates OAuth tokens
 #   during a fleet launch trades a visible "unknown" for an invisible auth
 #   failure across every session. Reporting the lane as `expired` and letting
-#   the operator decide is the safer default; --refresh takes the same flock the
+#   the operator decide is the safer default; --refresh takes the same lock the
 #   reference implementation uses and re-reads under it.
 #
 # Credentials never reach argv: `ps` and journald can read /proc/<pid>/cmdline,
@@ -353,16 +353,21 @@ measure_lane() {
 	emit_lane "$alias" "$harness" "$dir" "$status" "$detail" "$plan" "$buckets"
 }
 
-# Refresh under an flock on the credentials file, re-reading inside the lock:
+# Refresh under a lock on the credentials file, re-reading inside the lock:
 # a peer tool may have rotated the refresh token between our first read and
 # this attempt, and refreshing with the stale one fails while the credentials
-# are actually fine.
+# are actually fine. lib/file-lock.sh carries the lock on a host with no
+# flock, where the bare `flock -w 30 9` this used to run resolved to nothing
+# and every refresh on that host returned failure instead of a token.
 refresh_claude_token() {
 	local dir="$1" creds="$2" lock="$dir/.lanes-refresh.lock" rt client_id resp new_at
 	client_id="${ORCH_LANES_CLAUDE_CLIENT_ID:-}"
 	[[ -n "$client_id" ]] || return 1
 	exec 9>"$lock" || return 1
-	flock -w 30 9 || return 1
+	# Every caller runs this function in a command substitution, so the whole
+	# body is a subshell and the EXIT trap orch_take_lock arms releases a mkdir
+	# mutex on every path out — including this one.
+	orch_take_lock 9 "$lock" 30 || { exec 9>&-; return 1; }
 	rt=$(jq -r 'try (.claudeAiOauth.refreshToken // empty) catch empty' "$creds")
 	[[ -n "$rt" ]] || { exec 9>&-; return 1; }
 	resp=$(jq -nc --arg ci "$client_id" --arg rt "$rt" \
@@ -560,6 +565,8 @@ need_jq
 
 PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 export PROJECT_ROOT
+# shellcheck source=lib/file-lock.sh
+source "$SCRIPT_DIR/lib/file-lock.sh"
 # shellcheck source=lib/kendex-env.sh
 source "$SCRIPT_DIR/lib/kendex-env.sh"
 # This script runs without errexit, so the loader's refusal must be checked

--- a/.agents/skills/orch/scripts/lib/date-ladder.sh
+++ b/.agents/skills/orch/scripts/lib/date-ladder.sh
@@ -21,8 +21,21 @@ tz_date() {
 # is not shifted by the runner's local zone.
 to_epoch() {
   local stamp="$1" fmt="${2:-%Y-%m-%dT%H:%M:%SZ}" zone="${3-UTC}"
+  local bsd_stamp="$stamp" bsd_fmt="$fmt"
+  # BSD `date -j -f` takes every field its format does not name from the
+  # CURRENT time, so a format without %S resolves to this minute's seconds
+  # instead of to :00 — a clock read seconds late, and a different answer on
+  # every run. GNU `date -d` zeroes them. The seconds are named outright for
+  # the BSD arm rather than left to the clock.
+  case "$bsd_fmt" in
+    *%S*) ;;
+    *)
+      bsd_stamp="$bsd_stamp:00"
+      bsd_fmt="$bsd_fmt:%S"
+      ;;
+  esac
   tz_date "$zone" -d "$stamp" +%s 2>/dev/null \
-    || tz_date "$zone" -j -f "$fmt" "$stamp" +%s 2>/dev/null
+    || tz_date "$zone" -j -f "$bsd_fmt" "$bsd_stamp" +%s 2>/dev/null
 }
 
 # The other direction on the same ladder: GNU spells an epoch input `-d @`,

--- a/.agents/skills/orch/scripts/lib/file-lock.sh
+++ b/.agents/skills/orch/scripts/lib/file-lock.sh
@@ -1,0 +1,51 @@
+# shellcheck shell=bash
+# One exclusive lock for the orch scripts that serialize writers on a file.
+#
+# flock(1) is taken where it exists, because the kernel releases it however
+# the holder dies. Stock macOS ships none — it is util-linux, which macOS is
+# not — and these writers must not run unguarded there: two `workflow-state
+# set` calls racing on one state file both read, both write, and the later
+# write drops the earlier transition. So a mkdir mutex carries the lock where
+# flock is absent; mkdir is atomic on POSIX filesystems, so exactly one
+# contender creates the directory.
+#
+# The two mechanisms do not lock each other out, so this ASSUMES every writer
+# of a given file on a host resolves the same one. That is the assumption
+# skills/worktree/scripts/worktree-session-guard already makes for its own
+# lock, and it holds for the same reason: these files are per-repository and
+# per-host, and a host has one PATH resolution of flock.
+#
+# Sourced, never executed. Bash 3.2-safe, like its callers.
+
+ORCH_LOCK_MUTEX_DIR=""
+
+orch_release_lock() { # release a mutex this shell took; a no-op under flock
+  [ -z "$ORCH_LOCK_MUTEX_DIR" ] || rmdir -- "$ORCH_LOCK_MUTEX_DIR" 2>/dev/null || true
+  ORCH_LOCK_MUTEX_DIR=""
+}
+
+# FD is already open on LOCK_FILE at the caller's redirection, which is what
+# flock locks; the mutex arm ignores it and locks the path. Failure to take
+# the lock is a non-zero return the caller reports — never an unguarded write.
+orch_take_lock() { # FD LOCK_FILE WAIT_SECONDS
+  local fd="$1" lock_file="$2" wait_s="$3" tries=0 limit
+  if command -v flock >/dev/null 2>&1; then
+    flock -w "$wait_s" "$fd"
+    return
+  fi
+  limit=$((wait_s * 10))
+  # Armed before the loop, never after it wins: recording the directory before
+  # mkdir would let a losing contender rmdir the winner's mutex, and arming
+  # after the win leaves a signal in that window holding the lock for good.
+  # orch_release_lock is a no-op while ORCH_LOCK_MUTEX_DIR is empty.
+  trap orch_release_lock EXIT
+  while ! mkdir -- "$lock_file.d" 2>/dev/null; do
+    tries=$((tries + 1))
+    if [ "$tries" -ge "$limit" ]; then
+      echo "Error: could not acquire $lock_file.d after ${wait_s}s. If no orch process is running, remove it: rmdir '$lock_file.d'" >&2
+      return 1
+    fi
+    sleep 0.1
+  done
+  ORCH_LOCK_MUTEX_DIR="$lock_file.d"
+}

--- a/.agents/skills/orch/scripts/lib/review-artifact-gates.sh
+++ b/.agents/skills/orch/scripts/lib/review-artifact-gates.sh
@@ -43,7 +43,21 @@ emit_unavailable() {
 
 # jq's stderr lands here and is read only when the gate's exit status says the
 # gate failed. Never printed as an answer.
-review_artifact_gate_err="$(mktemp 2>/dev/null)" || {
+# The template names $TMPDIR outright. A bare `mktemp` reads it only on GNU;
+# BSD mktemp — the one macOS ships — ignores it and allocates under the OS's
+# own per-user temp directory, so an unusable TMPDIR did not stop the check
+# there and it answered `valid` over a channel the caller never named. The
+# trailing slash comes off because macOS sets TMPDIR with one, and a relative
+# root is prefixed with `./` so a TMPDIR named `-x` cannot reach mktemp, or the
+# rm in the cleanup below, as an option.
+review_artifact_gate_tmp_root="${TMPDIR:-/tmp}"
+review_artifact_gate_tmp_root="${review_artifact_gate_tmp_root%/}"
+case "$review_artifact_gate_tmp_root" in
+  "") review_artifact_gate_tmp_root="/" ;;
+  /*) ;;
+  *) review_artifact_gate_tmp_root="./$review_artifact_gate_tmp_root" ;;
+esac
+review_artifact_gate_err="$(mktemp "$review_artifact_gate_tmp_root/review-artifact-check.XXXXXX" 2>/dev/null)" || {
   emit_unavailable "review-artifact-check could not create its temporary error channel (mktemp failed; check TMPDIR and free space), so no artifact could be validated"
   exit 1
 }

--- a/.agents/skills/orch/scripts/open-terminal
+++ b/.agents/skills/orch/scripts/open-terminal
@@ -652,7 +652,17 @@ open_gui() {
   # carrying arguments — is otherwise substituted in silence.
   [[ -z "${TERMINAL:-}" || "$chosen" == "$TERMINAL" ]] ||
     echo "Warning: \$TERMINAL '$TERMINAL' does not resolve to an executable; launching '$title' with $chosen instead" >&2
-  setsid "${launcher[@]}" </dev/null >/dev/null 2>&1 &
+  # setsid puts the window in its own session so it outlives this script and
+  # its terminal. macOS ships none — it is util-linux — and with stderr
+  # already going to /dev/null the shell's `setsid: command not found` was
+  # swallowed, so the launch never happened and the line below still said it
+  # had. nohup is what every platform has: it detaches the child from the
+  # hangup this script's exit would otherwise deliver.
+  if command -v setsid >/dev/null 2>&1; then
+    setsid "${launcher[@]}" </dev/null >/dev/null 2>&1 &
+  else
+    nohup "${launcher[@]}" </dev/null >/dev/null 2>&1 &
+  fi
   echo "Opened terminal '$title' in $dir"
 }
 

--- a/.agents/skills/orch/scripts/oversee-watch
+++ b/.agents/skills/orch/scripts/oversee-watch
@@ -699,8 +699,12 @@ lane_limit_banner() {
 lane_row_prune() {
   local kind="$1" state="$2"
   shift 2
-  awk -F'\t' -v kind="$kind" -v lanes="$(printf '%s\n' "$@")" '
-    BEGIN { n = split(lanes, a, "\n"); for (i = 1; i <= n; i++) watched[a[i]] = 1 }
+  # The lane list crosses in the environment, never through -v: it holds one
+  # lane per line, and BWK awk — the awk macOS ships — refuses a -v value
+  # carrying a newline outright ("awk: newline in string"), so every prune died
+  # there and no lane event was ever emitted. ENVIRON takes the value whole.
+  ow_lanes="$(printf '%s\n' "$@")" awk -F'\t' -v kind="$kind" '
+    BEGIN { n = split(ENVIRON["ow_lanes"], a, "\n"); for (i = 1; i <= n; i++) watched[a[i]] = 1 }
     NF && !($1 == kind && !($2 in watched))
   ' <<<"$state"
 }

--- a/.agents/skills/orch/scripts/workflow-state
+++ b/.agents/skills/orch/scripts/workflow-state
@@ -26,8 +26,9 @@ ensure_state_exists() {
     fi
 }
 
-# Atomic update: flock + write to temp, validate, move
-# Uses flock to serialize concurrent writes and prevent state corruption.
+# Atomic update: take the lock, write to temp, validate, move.
+# The lock serializes concurrent writes and prevents state corruption;
+# lib/file-lock.sh says which mechanism carries it on which platform.
 # Any remaining arguments are passed to jq ahead of the filter, which is how
 # `update --arg`/`--argjson` hand values in out of band.
 atomic_update() {
@@ -39,7 +40,7 @@ atomic_update() {
     local tmp_file="${state_file}.tmp"
 
     (
-        flock -w 10 200 || { echo "Error: could not acquire lock on $lock_file" >&2; exit 1; }
+        orch_take_lock 200 "$lock_file" 10 || { echo "Error: could not acquire lock on $lock_file" >&2; exit 1; }
 
         if ! jq ${jq_args[@]+"${jq_args[@]}"} "$jq_expr" "$state_file" > "$tmp_file" 2>&1; then
             echo "Error: jq expression failed: $jq_expr" >&2
@@ -210,7 +211,7 @@ cmd_update_report() {
     # file exists to race on, so concurrent calls for the same issue each
     # return exactly their own transition's evidence.
     (
-        flock -w 10 200 || { echo "Error: could not acquire lock on $lock_file" >&2; exit 1; }
+        orch_take_lock 200 "$lock_file" 10 || { echo "Error: could not acquire lock on $lock_file" >&2; exit 1; }
 
         local combined
         if ! combined=$(jq -c ${jq_args[@]+"${jq_args[@]}"} "$jq_expr" "$state_file" 2>&1); then
@@ -309,7 +310,7 @@ cmd_append() {
         local tmp_file="${state_file}.tmp"
         local lock_file="${state_file}.lock"
         (
-            flock -w 10 200 || { echo "Error: could not acquire lock" >&2; exit 1; }
+            orch_take_lock 200 "$lock_file" 10 || { echo "Error: could not acquire lock" >&2; exit 1; }
             jq --arg v "$value" ".${field} += [\$v]" "$state_file" > "$tmp_file" 2>&1 || { rm -f "$tmp_file"; exit 1; }
             jq empty "$tmp_file" 2>/dev/null || { echo "Error: invalid JSON" >&2; rm -f "$tmp_file"; exit 1; }
             mv "$tmp_file" "$state_file"
@@ -458,7 +459,7 @@ cmd_set() {
         local tmp_file="${state_file}.tmp"
         local lock_file="${state_file}.lock"
         (
-            flock -w 10 200 || { echo "Error: could not acquire lock" >&2; exit 1; }
+            orch_take_lock 200 "$lock_file" 10 || { echo "Error: could not acquire lock" >&2; exit 1; }
             jq --arg v "$value" ".${field} = \$v" "$state_file" > "$tmp_file" 2>&1 || { rm -f "$tmp_file"; exit 1; }
             jq empty "$tmp_file" 2>/dev/null || { echo "Error: invalid JSON" >&2; rm -f "$tmp_file"; exit 1; }
             mv "$tmp_file" "$state_file"
@@ -655,7 +656,8 @@ Environment:
 
 Dependencies:
   jq               JSON processing
-  flock             File locking (util-linux)
+  flock             File locking, where it is installed; without it a mkdir
+                    mutex serializes the same writers (stock macOS has no flock)
 EOF
 }
 
@@ -712,6 +714,8 @@ parse_rc=0
 [[ "$parse_rc" -eq 9 ]] || exit "$parse_rc"
 unset parse_rc
 
+# shellcheck source=lib/file-lock.sh
+source "$SCRIPT_DIR/lib/file-lock.sh"
 # shellcheck source=lib/kendex-env.sh
 source "$SCRIPT_DIR/lib/kendex-env.sh"
 kendex_load_project_env "$PROJECT_ROOT"

--- a/.agents/skills/orch/tests/branch_size_check.sh
+++ b/.agents/skills/orch/tests/branch_size_check.sh
@@ -101,12 +101,14 @@ printf 'x\ny\n' > "$WT/src/rewritten.txt"   # 50 deleted, 2 added: bills 2
 commit_files implementation
 
 capture split_json run_check "$CHECK_BIN" --json
-assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$split_json" | paste -sd,)" "16,14" \
+# Every paste below names its input as `-`: GNU paste reads stdin when it is
+# given no file operand, BSD paste prints its usage and exits 2.
+assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$split_json" | paste -sd, -)" "16,14" \
   "each is_test rule classifies alone, a name containing 'test' does not, and a rewrite bills only its additions"
-assert_eq "$(jq -r '.production_allowance, .test_allowance, .verdict' <<<"$split_json" | paste -sd,)" \
+assert_eq "$(jq -r '.production_allowance, .test_allowance, .verdict' <<<"$split_json" | paste -sd, -)" \
   "40,20,pass" "the stated line is the production and test allowance"
-assert_eq "$(jq -r '.base_sha, .head_sha' <<<"$split_json" | paste -sd,)" \
-  "$(git -C "$WT" rev-parse main HEAD | paste -sd,)" \
+assert_eq "$(jq -r '.base_sha, .head_sha' <<<"$split_json" | paste -sd, -)" \
+  "$(git -C "$WT" rev-parse main HEAD | paste -sd, -)" \
   "the record is bound to the base and head it measured"
 assert_eq "$("$STATE" --state-dir "$WT/tmp" get KEN-SIZE '.pr.size_check.verdict')" "pass" \
   "the verdict is recorded beside pr.baseline_lines, in no new state file"
@@ -159,7 +161,7 @@ while IFS='|' read -r line want_fields want_rc; do
   set -e
   assert_eq "$row_rc" "$want_rc" "exit for: $line"
   [[ "$want_rc" != 0 ]] || assert_eq \
-    "$(jq -r '.production_allowance, .test_allowance, .verdict' <<<"$row_json" | paste -sd,)" \
+    "$(jq -r '.production_allowance, .test_allowance, .verdict' <<<"$row_json" | paste -sd, -)" \
     "$want_fields" "record for: $line"
 done <<'ROWS'
 **Expected delta**: 250 lines|250,null,pass|0
@@ -178,7 +180,7 @@ set -e
 assert_eq "$missing_rc" "0" "an issue stating no allowance is reported, not refused and not defaulted"
 assert_eq "$([[ "$missing_error" == *"no allowance to judge by"* && "$missing_error" == *"50 production, 14 test"* ]] && echo yes)" \
   "yes" "the report names the missing line and the counts measured"
-assert_eq "$("$STATE" --state-dir "$WT/tmp" get KEN-SIZE '.pr.size_check.verdict, .pr.size_check.production_allowance' | paste -sd,)" \
+assert_eq "$("$STATE" --state-dir "$WT/tmp" get KEN-SIZE '.pr.size_check.verdict, .pr.size_check.production_allowance' | paste -sd, -)" \
   "allowance_missing,null" "the record says nothing was judged and invents no allowance"
 
 # --- Past the production allowance ------------------------------------------
@@ -243,7 +245,7 @@ chmod +x "$GH_STUB/gh"
 "$STATE" --state-dir "$WT/tmp" init issue-77 --worktree "$WT" --branch size >/dev/null
 capture gh_json env PATH="$GH_STUB:$PATH" ORCH_STATE_DIR="$WT/tmp" \
   "$CHECK_BIN" --worktree "$WT" --issue issue-77 --json
-assert_eq "$(jq -r '.production_allowance, .test_allowance, .verdict' <<<"$gh_json" | paste -sd,)" \
+assert_eq "$(jq -r '.production_allowance, .test_allowance, .verdict' <<<"$gh_json" | paste -sd, -)" \
   "50,60,pass" "a GitHub issue body supplies the same allowance"
 
 # --- An issue the tracker cannot give is an environment failure -------------

--- a/.agents/skills/orch/tests/ci_wait.sh
+++ b/.agents/skills/orch/tests/ci_wait.sh
@@ -411,7 +411,18 @@ table "$JSON" \
 stage ""
 RUN="$TMP_ROOT/runs/$((++RUN_SEQ))"; mkdir -p "$RUN"
 set +e
-OUT=$(timeout 6s bash -c 'cd "$1" && PATH="$2:$PATH" STUB_CLOCK= KENDEX_GITHUB_AUTH_TIMEOUT=1 STUB_GH_AUTH_STATUS_SLEEP=1 .agents/skills/orch/scripts/ci-wait 1 1 30 --json' bash "$TMP_ROOT/repo" "$TMP_ROOT/bin" 2>"$RUN/stderr")
+# The 6s bound is a net under ci-wait's own KENDEX_GITHUB_AUTH_TIMEOUT, which
+# is what the assertion reads. macOS ships no timeout(1) — it is coreutils —
+# so on a host without one the case runs unbounded and a regression that did
+# hang would be caught by the job's timeout-minutes instead of here.
+bounded6() { # CMD... — run CMD under a 6s bound where the host has one
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 6s "$@"
+  else
+    "$@"
+  fi
+}
+OUT=$(bounded6 bash -c 'cd "$1" && PATH="$2:$PATH" STUB_CLOCK= KENDEX_GITHUB_AUTH_TIMEOUT=1 STUB_GH_AUTH_STATUS_SLEEP=1 .agents/skills/orch/scripts/ci-wait 1 1 30 --json' bash "$TMP_ROOT/repo" "$TMP_ROOT/bin" 2>"$RUN/stderr")
 RC=$?
 set -e
 assert_eq "$(observe "rc=3 status=error")" "rc=3 status=error" "a hanging keyring auth is a bounded exit 3, not a hang" "$RUN/stderr"

--- a/.agents/skills/orch/tests/container_close.sh
+++ b/.agents/skills/orch/tests/container_close.sh
@@ -40,7 +40,16 @@ esac
 SH
 chmod +x "$TMP_ROOT/bin/gh"
 
-REAL_FLOCK="$(command -v flock)"
+# container-close refuses to run without flock(1), so this suite cannot
+# execute on a host that has none. It says so and reds: under `set -e` the
+# bare `command -v` below died here with no output at all, which reads from
+# the outside like a suite that ran and printed nothing. macOS ships no
+# flock — it is util-linux — so a stock Mac reds here; the macOS CI leg
+# supplies flock for exactly this reason.
+if ! REAL_FLOCK="$(command -v flock)"; then
+  printf 'FAIL: container-close requires flock(1) and this host has none, so nothing below could run. Install flock (util-linux) and re-run.\n' >&2
+  exit 1
+fi
 cat > "$TMP_ROOT/bin/flock" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail

--- a/.agents/skills/orch/tests/lib/md.sh
+++ b/.agents/skills/orch/tests/lib/md.sh
@@ -287,8 +287,12 @@ _md_body() {
   if [ "$1" = fenced ]; then
     local keep
     keep="$(_md_fenced "$2" | cut -f2)"
-    _md_lines "$2" "$3" | awk -F'\t' -v k="$keep" '
-      BEGIN { n = split(k, a, "\n"); for (i = 1; i <= n; i++) if (a[i] != "") keep[a[i]] = 1 }
+    # The list crosses in the environment, never through -v: it holds one line
+    # number per line, and BWK awk — the awk macOS ships — refuses a -v value
+    # carrying a newline outright ("awk: newline in string"), so every fenced
+    # rule died there. ENVIRON is read at runtime and takes the value whole.
+    _md_lines "$2" "$3" | md_keep="$keep" awk -F'\t' '
+      BEGIN { n = split(ENVIRON["md_keep"], a, "\n"); for (i = 1; i <= n; i++) if (a[i] != "") keep[a[i]] = 1 }
       ($1 in keep) { print }
     '
   else

--- a/.agents/skills/orch/tests/lib/waiter-assertions.sh
+++ b/.agents/skills/orch/tests/lib/waiter-assertions.sh
@@ -72,3 +72,19 @@ assert_not_contains() {
     printf '  ok    %s\n' "$name"
   fi
 }
+
+# touch_epoch EPOCH PATH — set PATH's mtime to EPOCH seconds.
+#
+# `touch -d @EPOCH` is GNU; BSD touch reads -d as an ISO-8601 stamp and
+# refuses the @ form ("out of range or illegal time specification"). Both take
+# a zoned ISO stamp through -d, so the epoch is rendered to one, in UTC, and
+# the trailing Z is what keeps the mtime exact on either — `-t` would be read
+# in the machine's local zone and shift the mtime by its UTC offset. GNU date
+# prints the stamp from `-d @EPOCH`, BSD date from `-r EPOCH`; the same two-arm
+# ladder as scripts/lib/date-ladder.sh, which these suites do not source.
+touch_epoch() {
+  local epoch="$1" path="$2" stamp
+  stamp="$(date -u -d "@$epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -r "$epoch" +%Y-%m-%dT%H:%M:%SZ)" || return 1
+  touch -d "$stamp" "$path"
+}

--- a/.agents/skills/orch/tests/open-terminal-claude-handoff.sh
+++ b/.agents/skills/orch/tests/open-terminal-claude-handoff.sh
@@ -354,7 +354,13 @@ if wait_capture; then
   printf '#!/usr/bin/env bash\nprintf '"'"'%%s\\n'"'"' "$@" > "$OT_ARGV_CAPTURE"\n' > "$BIN/claude"
   chmod +x "$BIN/claude"
   cmd="$(cat "$CAP")"
-  (cd "$globbait" && OT_ARGV_CAPTURE="$TMP_ROOT/argv" PATH="$BIN:$PATH" bash -lc "${cmd##*&& }") >/dev/null 2>&1 || true
+  # PATH is set INSIDE the login shell, not only inherited by it: macOS
+  # /etc/profile runs path_helper, which rebuilds PATH from /etc/paths and
+  # /etc/paths.d and leaves the inherited entries behind them, so an inherited
+  # $BIN prefix does not survive `bash -lc` and a real claude on the host's
+  # login PATH would answer instead of the stub. The launcher still runs the
+  # rendered line through a login shell, which is the shape under test.
+  (cd "$globbait" && OT_ARGV_CAPTURE="$TMP_ROOT/argv" bash -lc "PATH=\"$BIN:\$PATH\"; ${cmd##*&& }") >/dev/null 2>&1 || true
   rm -f "$BIN/claude"
   assert_eq "$(tr '\n' ' ' < "$TMP_ROOT/argv" 2>/dev/null || echo unrun)" "-n CC-737 --model opus[1m] --dangerously-skip-permissions $BRIEF " \
     "the argv claude receives is the flags as given: a same-named file cannot rewrite the model id"

--- a/.agents/skills/orch/tests/open-terminal-mode.sh
+++ b/.agents/skills/orch/tests/open-terminal-mode.sh
@@ -280,6 +280,46 @@ done <<<"$ARM_ROWS"
 RUN_PATH=""
 RUN_TERMINAL="term"
 
+echo "=== the GUI launch happens on a host with no setsid ==="
+
+# open_gui detaches the window so it outlives this script. setsid is util-linux
+# and stock macOS has none, and the launch line sends its own stderr to
+# /dev/null — so a `setsid: command not found` was swallowed there, nothing
+# opened, and open-terminal still printed "Opened terminal". nohup is the arm
+# every platform has. The probe PATH is the real one minus setsid rather than a
+# list of the tools open_gui uses, so it stays true as open_gui changes.
+NO_SETSID_PATH="$TMP_ROOT/path-without-setsid"
+mkdir -p "$NO_SETSID_PATH"
+(
+  IFS=:
+  for d in $PATH; do
+    [[ -d "$d" ]] || continue
+    ln -s "$d"/* "$NO_SETSID_PATH"/ 2>/dev/null || true
+  done
+)
+rm -f -- "$NO_SETSID_PATH/setsid"
+# Without this the case passes vacuously through the setsid branch.
+if PATH="$NO_SETSID_PATH" command -v setsid >/dev/null 2>&1; then
+  bad "the probe PATH resolves no setsid" "setsid is still reachable"
+else
+  ok "the probe PATH resolves no setsid"
+fi
+
+RUN_PATH="$BIN:$NO_SETSID_PATH"
+run "nosetsid" "$REPO/scripts/open-terminal" out CC-1
+assert_eq "$RC" "0" "no setsid: the GUI launch is reported as successful"
+assert_contains "$TERM_LOG_TEXT" "term -e bash -lc" "no setsid: a GUI terminal really opens"
+
+# The control: with the nohup arm deleted the same run opens nothing, so the
+# assertion above is about the arm and not about a launch that would happen
+# either way.
+mutate "nosetsid" 's#^    nohup "${launcher\[@\]}" </dev/null >/dev/null 2>&1 &$#    setsid "${launcher[@]}" </dev/null >/dev/null 2>\&1 \&#'
+RUN_PATH="$BIN:$NO_SETSID_PATH"
+run "mut-nosetsid" "$MUTANT_OT" out CC-1
+assert_eq "$TERM_LOG_TEXT" "" "control: without the nohup arm no GUI terminal opens on a setsid-less host"
+RUN_PATH=""
+RUN_TERMINAL="term"
+
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/.agents/skills/orch/tests/queue_wait.sh
+++ b/.agents/skills/orch/tests/queue_wait.sh
@@ -261,10 +261,22 @@ am_errs_on_200='{"data":{"disablePullRequestAutoMerge":null},"errors":[{"message
 # merge-group head commit, and REST check-runs bodies for that commit.
 q_in_queue_head='{"data":{"repository":{"pullRequest":{"id":"PR_node123","isInMergeQueue":true,"mergeQueueEntry":{"state":"AWAITING_CHECKS","position":1,"headCommit":{"oid":"aaa111"}},"autoMergeRequest":{"enabledAt":"2026-07-24T09:00:00Z"}}}}}'
 # checkruns_body <completed> <in_progress>
+# Counted loops, never `seq 1 "$n"`: BSD seq walks toward its last value, so
+# `seq 1 0` prints `1` and `0` where GNU seq prints nothing. A body asked for
+# zero in-progress runs came back with two of them on macOS, and every case
+# reading a flat, idle queue as stalled read it as still progressing instead.
 checkruns_body() {
   local done="$1" pending="$2" runs="" i
-  for i in $(seq 1 "$done"); do runs+='{"name":"c'"$i"'","status":"completed","conclusion":"success"},'; done
-  for i in $(seq 1 "$pending"); do runs+='{"name":"p'"$i"'","status":"in_progress","conclusion":null},'; done
+  i=0
+  while [ "$i" -lt "$done" ]; do
+    i=$((i + 1))
+    runs+='{"name":"c'"$i"'","status":"completed","conclusion":"success"},'
+  done
+  i=0
+  while [ "$i" -lt "$pending" ]; do
+    i=$((i + 1))
+    runs+='{"name":"p'"$i"'","status":"in_progress","conclusion":null},'
+  done
   printf '{"total_count":%d,"check_runs":[%s]}' "$((done + pending))" "${runs%,}"
 }
 

--- a/.agents/skills/orch/tests/review_artifact_check.sh
+++ b/.agents/skills/orch/tests/review_artifact_check.sh
@@ -96,7 +96,7 @@ stage() {
       none) continue ;;
       *) echo "stage: unknown time $when in $item" >&2; exit 1 ;;
     esac
-    touch -d "@$mtime" "$WT/tmp/$file.json"
+    touch_epoch "$mtime" "$WT/tmp/$file.json"
   done
 }
 

--- a/.agents/skills/orch/tests/review_artifact_check_measurement.sh
+++ b/.agents/skills/orch/tests/review_artifact_check_measurement.sh
@@ -157,7 +157,7 @@ glob_table() {
         before) mtime=$BEFORE ;; after) mtime=$AFTER ;; later) mtime=$LATER ;;
         *) echo "glob_table: unknown time $when in $item" >&2; exit 1 ;;
       esac
-      touch -d "@$mtime" "$WT/tmp/review-r-$file.json"
+      touch_epoch "$mtime" "$WT/tmp/review-r-$file.json"
     done
     case "$which" in
       real) run_check %W r %D ;;

--- a/.agents/skills/orch/tests/workflow-state-flockless.sh
+++ b/.agents/skills/orch/tests/workflow-state-flockless.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# workflow-state's writes on a host with no flock(1).
+#
+# Every mutating subcommand runs its read-decide-write under a lock, because
+# two `set` calls racing on one state file both read, both write, and the
+# later write drops the earlier transition. flock is util-linux and stock
+# macOS ships none, where the bare `flock -w 10 200` this used to run resolved
+# to nothing, the `||` arm fired, and every write refused with "could not
+# acquire lock" — so on that platform workflow-state did not work at all.
+# scripts/lib/file-lock.sh carries the lock with a mkdir mutex there.
+#
+# The probe PATH is the real one minus flock rather than a list of the tools
+# workflow-state uses, so it stays true as the script changes.
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/lib/git-env.sh"
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf -- "${TMP_ROOT:?}"' EXIT
+
+WS="$REPO_ROOT/skills/orch/scripts/workflow-state"
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+
+NOFLOCK="$TMP_ROOT/path-without-flock"
+mkdir -p "$NOFLOCK"
+(
+  IFS=:
+  for d in $PATH; do
+    [[ -d "$d" ]] || continue
+    ln -s "$d"/* "$NOFLOCK"/ 2>/dev/null || true
+  done
+)
+rm -f -- "$NOFLOCK/flock"
+# Without this every case below passes vacuously through the flock branch.
+if PATH="$NOFLOCK" command -v flock >/dev/null 2>&1; then
+  bad "the probe PATH resolves no flock" "flock is still reachable"
+else
+  ok "the probe PATH resolves no flock"
+fi
+
+echo
+echo "--- workflow-state with no flock on PATH ---"
+
+SD="$TMP_ROOT/state"
+PATH="$NOFLOCK" "$WS" --state-dir "$SD" init KEN-LOCK --worktree "$REPO_ROOT" --branch ken-lock >/dev/null
+rc=0
+PATH="$NOFLOCK" "$WS" --state-dir "$SD" set KEN-LOCK phase implementing >/dev/null 2>"$TMP_ROOT/set.err" || rc=$?
+[[ "$rc" -eq 0 ]] && ok "a set lands with no flock on PATH" \
+  || bad "a set lands with no flock on PATH" "rc=$rc $(cat "$TMP_ROOT/set.err")"
+got="$(PATH="$NOFLOCK" "$WS" --state-dir "$SD" get KEN-LOCK .phase)"
+[[ "$got" == "implementing" ]] && ok "and the value it wrote is the one read back" \
+  || bad "and the value it wrote is the one read back" "got=$got"
+
+# The mutex directory is released, not leaked: a second write on the same file
+# would otherwise wait its whole timeout and then refuse.
+rc=0
+PATH="$NOFLOCK" "$WS" --state-dir "$SD" set KEN-LOCK phase reviewing >/dev/null 2>"$TMP_ROOT/set2.err" || rc=$?
+[[ "$rc" -eq 0 ]] && ok "a second write is not blocked by the first one's mutex" \
+  || bad "a second write is not blocked by the first one's mutex" "rc=$rc $(cat "$TMP_ROOT/set2.err")"
+
+# Serialization is the point of the lock, so it is measured: two appends racing
+# on one file must both survive. Without one the loser's element is lost to the
+# winner's read-modify-write.
+RACE_SD="$TMP_ROOT/race"
+PATH="$NOFLOCK" "$WS" --state-dir "$RACE_SD" init KEN-RACE --worktree "$REPO_ROOT" --branch ken-race >/dev/null
+GO="$TMP_ROOT/go"
+for racer in 1 2; do
+  (
+    until [[ -e "$GO" ]]; do :; done
+    PATH="$NOFLOCK" "$WS" --state-dir "$RACE_SD" append KEN-RACE fixed_items "item-$racer" >/dev/null 2>&1
+  ) &
+done
+sleep 0.4
+: >"$GO"
+wait
+count="$(PATH="$NOFLOCK" "$WS" --state-dir "$RACE_SD" get KEN-RACE '.fixed_items | length')"
+[[ "$count" == "2" ]] && ok "two racing appends both survive under the mkdir mutex" \
+  || bad "two racing appends both survive under the mkdir mutex" "count=$count"
+
+# The control: a copy whose lock helper only ever calls flock must refuse every
+# write on this PATH, so the assertions above are about the mutex arm and not
+# about a write that would land unlocked anyway.
+BROKEN="$TMP_ROOT/broken"
+mkdir -p "$BROKEN/scripts/lib"
+cp "$WS" "$BROKEN/scripts/workflow-state"
+cp "$REPO_ROOT"/skills/orch/scripts/lib/*.sh "$BROKEN/scripts/lib/"
+chmod +x "$BROKEN/scripts/workflow-state"
+perl -pi -e 's/^  if command -v flock >\/dev\/null 2>&1; then$/  if true; then/' "$BROKEN/scripts/lib/file-lock.sh"
+if grep -q '^  if true; then$' "$BROKEN/scripts/lib/file-lock.sh"; then
+  ok "control: the mutant really removes the mkdir arm"
+else
+  bad "control: the mutant really removes the mkdir arm" "file-lock.sh unchanged"
+fi
+BSD="$TMP_ROOT/broken-state"
+PATH="$NOFLOCK" "$BROKEN/scripts/workflow-state" --state-dir "$BSD" init KEN-BROKEN --worktree "$REPO_ROOT" --branch ken-broken >/dev/null 2>&1 || true
+rc=0
+PATH="$NOFLOCK" "$BROKEN/scripts/workflow-state" --state-dir "$BSD" set KEN-BROKEN phase implementing >/dev/null 2>&1 || rc=$?
+[[ "$rc" -ne 0 ]] && ok "control: with only the flock arm every write refuses on this PATH" \
+  || bad "control: with only the flock arm every write refuses on this PATH" "rc=$rc"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/.agents/skills/orch/tests/worktree_push.sh
+++ b/.agents/skills/orch/tests/worktree_push.sh
@@ -469,7 +469,10 @@ printf '%s\n' '{"issue_id":"KEN-9","worktree":"","fixed_items":[],"pr_comment_re
 STUB_ARGS_LOG="$mismatch_args_log" STUB_PUSH_STDOUT="→ pushed" run_push "$work" --worktree "$wt" --issue KEN-1
 assert_eq "$RUN_RC" "1" "a state recording another issue id refuses"
 assert_contains "$(cat "$run_err")" "refusing to rewrite another issue" "the issue mismatch is named"
-assert_eq "$(wc -l <"$mismatch_args_log")" "0" "the push never ran against a mismatched issue id"
+# BSD wc right-aligns its count in a fixed-width field, so `$(wc -l <f)` reads
+# "       0" on macOS and "0" on GNU; every count below is compared as a
+# string, so the blanks come off at the measurement.
+assert_eq "$(wc -l <"$mismatch_args_log" | tr -d ' ')" "0" "the push never ran against a mismatched issue id"
 
 other_wt="$TMP_ROOT/other-wt"
 mkdir -p "$other_wt"
@@ -480,7 +483,7 @@ rm -rf "$work" && mkdir -p "$work"
 STUB_ARGS_LOG="$mismatch_args_log" STUB_PUSH_STDOUT="→ pushed" run_push "$work" --worktree "$wt" --issue KEN-1
 assert_eq "$RUN_RC" "1" "a state recording another worktree refuses"
 assert_contains "$(cat "$run_err")" "refusing to rewrite another worktree" "the worktree mismatch is named"
-assert_eq "$(wc -l <"$mismatch_args_log")" "0" "the push never ran against a mismatched worktree"
+assert_eq "$(wc -l <"$mismatch_args_log" | tr -d ' ')" "0" "the push never ran against a mismatched worktree"
 
 echo
 echo "=== a dying stdout cannot lose the map ==="
@@ -563,7 +566,7 @@ numeric_args_log="$TMP_ROOT/numeric-args.log"
 STUB_ARGS_LOG="$numeric_args_log" STUB_PUSH_STDOUT="rebase-map: $numeric_old $numeric_new" \
   run_push "$work" --worktree "$wt" --issue 7
 assert_eq "$RUN_RC" "1" "a bare-numeric issue whose state does not exist fails the landed push"
-assert_eq "$(wc -l <"$numeric_args_log")" "1" \
+assert_eq "$(wc -l <"$numeric_args_log" | tr -d ' ')" "1" \
   "the push itself ran — the failure is reconciliation, not a pre-push refusal"
 assert_contains "$(cat "$run_err")" "State file not found: tmp/workflow-state-7.json" \
   "the failure names the exact key it resolved, not the issue-7 file"

--- a/.agents/skills/review-gate/tests/predicate-re2-engine.test.sh
+++ b/.agents/skills/review-gate/tests/predicate-re2-engine.test.sh
@@ -163,10 +163,12 @@ else
   bad "the shipped program runs under gh's RE2 engine" "exit $re2_rc: $(head -1 "$work/re2.err")"
 fi
 
-if [ "$(wc -l <"$work/re2.out")" = "$replies" ]; then
+# BSD wc right-aligns its count in a fixed-width field, so the blanks come off
+# before this string comparison.
+if [ "$(wc -l <"$work/re2.out" | tr -d ' ')" = "$replies" ]; then
   ok "RE2 answered every one of the $replies fixture replies"
 else
-  bad "RE2 answered every one of the $replies fixture replies" "$(wc -l <"$work/re2.out") verdicts"
+  bad "RE2 answered every one of the $replies fixture replies" "$(wc -l <"$work/re2.out" | tr -d ' ') verdicts"
 fi
 
 # THE assertion, in a function, because control three has to be able to kill

--- a/.agents/skills/second-opinion/scripts/second-opinion
+++ b/.agents/skills/second-opinion/scripts/second-opinion
@@ -289,34 +289,6 @@ if ! $FOREGROUND_CAP_WAS_IN_CALLER_ENV && [[ -n "${SECOND_OPINION_FOREGROUND_CAP
 fi
 source "$SCRIPT_DIR/second-opinion-runtime"
 second_opinion_runtime_setup
-# --- System temp --------------------------------------------------------------
-# Every system-temp allocation goes through these two, with an explicit
-# template rooted at $TMPDIR.
-#
-# A bare `mktemp` reads $TMPDIR only on GNU. BSD mktemp — the one macOS ships —
-# ignores it and allocates under the per-user directory the OS names
-# (_CS_DARWIN_USER_TEMP_DIR), so an operator who set TMPDIR to bound this run's
-# temp files got them somewhere else entirely, and the fallbacks below landed
-# nowhere the caller named. A trailing slash comes off first: macOS sets TMPDIR
-# with one, and `$TMPDIR/x` would carry a `//` into every path this prints.
-# The trailing slash comes off because macOS sets TMPDIR with one, and a
-# relative root is prefixed with `./` so a TMPDIR named `-dashtmp` cannot reach
-# mktemp — or the rm in a cleanup trap — as an option. `--` is not the answer
-# here: mktemp's support for it is not uniform across the BSD/macOS target,
-# which is why artifact_file() below leans on an absolute home instead.
-so_tmp_root() {
-  local root="${TMPDIR:-/tmp}"
-  root="${root%/}"
-  case "$root" in
-    "") root="/" ;;
-    /*) ;;
-    *) root="./$root" ;;
-  esac
-  printf '%s' "$root"
-}
-so_tmpfile() { mktemp "$(so_tmp_root)/second-opinion.XXXXXX"; }
-so_tmpdir() { mktemp -d "$(so_tmp_root)/second-opinion.XXXXXX"; }
-
 # --- Defaults -----------------------------------------------------------------
 MODE=""
 PROMPT_FILE=""

--- a/.agents/skills/second-opinion/scripts/second-opinion
+++ b/.agents/skills/second-opinion/scripts/second-opinion
@@ -289,6 +289,34 @@ if ! $FOREGROUND_CAP_WAS_IN_CALLER_ENV && [[ -n "${SECOND_OPINION_FOREGROUND_CAP
 fi
 source "$SCRIPT_DIR/second-opinion-runtime"
 second_opinion_runtime_setup
+# --- System temp --------------------------------------------------------------
+# Every system-temp allocation goes through these two, with an explicit
+# template rooted at $TMPDIR.
+#
+# A bare `mktemp` reads $TMPDIR only on GNU. BSD mktemp — the one macOS ships —
+# ignores it and allocates under the per-user directory the OS names
+# (_CS_DARWIN_USER_TEMP_DIR), so an operator who set TMPDIR to bound this run's
+# temp files got them somewhere else entirely, and the fallbacks below landed
+# nowhere the caller named. A trailing slash comes off first: macOS sets TMPDIR
+# with one, and `$TMPDIR/x` would carry a `//` into every path this prints.
+# The trailing slash comes off because macOS sets TMPDIR with one, and a
+# relative root is prefixed with `./` so a TMPDIR named `-dashtmp` cannot reach
+# mktemp — or the rm in a cleanup trap — as an option. `--` is not the answer
+# here: mktemp's support for it is not uniform across the BSD/macOS target,
+# which is why artifact_file() below leans on an absolute home instead.
+so_tmp_root() {
+  local root="${TMPDIR:-/tmp}"
+  root="${root%/}"
+  case "$root" in
+    "") root="/" ;;
+    /*) ;;
+    *) root="./$root" ;;
+  esac
+  printf '%s' "$root"
+}
+so_tmpfile() { mktemp "$(so_tmp_root)/second-opinion.XXXXXX"; }
+so_tmpdir() { mktemp -d "$(so_tmp_root)/second-opinion.XXXXXX"; }
+
 # --- Defaults -----------------------------------------------------------------
 MODE=""
 PROMPT_FILE=""
@@ -1392,7 +1420,7 @@ artifact_file() {
     # way to report — losing both the record AND its documented 4/5 exit class.
     # A record is a diagnostic: leaving ARTIFACT_PATH empty lets the caller say
     # so inline and keep the classification.
-    ARTIFACT_PATH=$(mktemp 2>/dev/null) || ARTIFACT_PATH=""
+    ARTIFACT_PATH=$(so_tmpfile 2>/dev/null) || ARTIFACT_PATH=""
     if [[ -n "$ARTIFACT_PATH" ]]; then
       echo "→ record kept in system temp instead: $ARTIFACT_PATH" >&2
     else
@@ -1495,7 +1523,7 @@ derive_review_scope() {
   REVIEW_BRANCH=$(git -C "$cwd" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 
   local git_err diff_files
-  git_err=$(mktemp)
+  git_err=$(so_tmpfile)
   # shellcheck disable=SC2086
   # core.quotePath=false keeps non-ASCII path bytes literal — the default
   # C-quoting ("services/\303\251/…") would break the nested-AGENTS ancestor
@@ -1742,7 +1770,7 @@ if $MULTI_LANE; then
   # this tool owns. And the parent holds each lane's review in memory from the
   # moment that lane is reaped, so nothing it still needs is on disk after the
   # reap either.
-  LANE_TMP_DIR=$(mktemp -d)
+  LANE_TMP_DIR=$(so_tmpdir)
   LANE_TMP_FILES=()
   LANE_PIDS=()
   # On any exit — including INT/TERM — kill still-running lane children before
@@ -1823,7 +1851,7 @@ if $MULTI_LANE; then
       # Placement can never decide whether the review happens, so a lane with no
       # home falls back to a temp file — named on stderr above, so an operator
       # knows that lane traded the home's durability for a temp one.
-      [[ -n "$lane_out" ]] || lane_out=$(mktemp)
+      [[ -n "$lane_out" ]] || lane_out=$(so_tmpfile)
       LANE_TMP_FILES+=("$lane_out")
     fi
     lane_err="$LANE_TMP_DIR/lane-${lane}.stderr"
@@ -2176,14 +2204,14 @@ if [[ -z "$PROMPT" ]]; then
 fi
 
 # Write prompt to temp file — use printf to avoid echo interpreting leading dashes
-PROMPT_TMP=$(mktemp)
+PROMPT_TMP=$(so_tmpfile)
 # Guarded for the same reason as cleanup_lanes: an EXIT trap whose last command
 # fails REPLACES the run's exit status, so a temp directory that turned
 # read-only under the run would rewrite a documented 4/5 into rm's status.
 trap 'rm -f -- "$PROMPT_TMP" || true' EXIT
 printf '%s\n' "$PROMPT" > "$PROMPT_TMP"
 
-STDERR_TMP=$(mktemp)
+STDERR_TMP=$(so_tmpfile)
 # RETRY_PROMPT_TMP is created only when extraction fails and a retry runs; keep
 # it in the cleanup trap. Sidecar files written by preserve_raw_response and
 # preserve_raw_and_fail are deliberately NOT tracked here — they are the durable
@@ -2565,7 +2593,7 @@ if [[ "$MODE" == "review" || "$MODE" == "audit" ]]; then
     # Persist the raw first response now, before the retry outcome is known —
     # a successful reformat must not erase the original.
     preserve_raw_response "$RESULT"
-    RETRY_PROMPT_TMP=$(mktemp)
+    RETRY_PROMPT_TMP=$(so_tmpfile)
     if [[ -n "$RETRY_PROBLEM" ]]; then
       build_retry_prompt "$RESULT" "$RETRY_PROBLEM" > "$RETRY_PROMPT_TMP"
     else

--- a/.agents/skills/second-opinion/scripts/second-opinion-runtime
+++ b/.agents/skills/second-opinion/scripts/second-opinion-runtime
@@ -135,7 +135,13 @@ create_runtime_dir() {
       dir=""
     }
   fi
-  [[ -n "$dir" ]] || dir=$(mktemp -d 2>/dev/null) || die "cannot create runtime directory"
+  # An explicit template rooted at $TMPDIR: a bare `mktemp -d` reads TMPDIR
+  # only on GNU, and BSD mktemp allocates under the OS's per-user temp
+  # directory instead, so this fallback ignored the caller's TMPDIR on macOS.
+  runtime_tmp_root="${TMPDIR:-/tmp}"
+  runtime_tmp_root="${runtime_tmp_root%/}"
+  case "$runtime_tmp_root" in "") runtime_tmp_root="/" ;; /*) ;; *) runtime_tmp_root="./$runtime_tmp_root" ;; esac
+  [[ -n "$dir" ]] || dir=$(mktemp -d "$runtime_tmp_root/second-opinion-runtime.XXXXXX" 2>/dev/null) || die "cannot create runtime directory"
   chmod 700 "$dir" || die "cannot secure runtime directory: $dir"
   printf '%s\n' "$dir"
 }

--- a/.agents/skills/second-opinion/scripts/second-opinion-runtime
+++ b/.agents/skills/second-opinion/scripts/second-opinion-runtime
@@ -10,6 +10,31 @@ LAUNCH_WORKER_PID=""
 LAUNCH_RUNTIME_DIR=""
 RUNTIME_SELF="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)/${BASH_SOURCE[0]##*/}"
 die() { echo "second-opinion-runtime: $1" >&2; exit 1; }
+
+# The system temp directory this run allocates under, as a path mktemp reads
+# as a path. Defined here because this file is SOURCED by second-opinion, so
+# both the detached runtime directory and the command's own temp files come
+# from one rule.
+#
+# A bare `mktemp` reads $TMPDIR only on GNU. BSD mktemp — the one macOS ships —
+# ignores it and allocates under the per-user directory the OS names
+# (_CS_DARWIN_USER_TEMP_DIR), so an operator who set TMPDIR to bound this run
+# got its files somewhere else entirely. The trailing slash comes off because
+# macOS sets TMPDIR with one, and a relative root is prefixed with `./` so a
+# TMPDIR named `-dashtmp` cannot reach mktemp — or the rm in a cleanup trap —
+# as an option.
+so_tmp_root() {
+  local root="${TMPDIR:-/tmp}"
+  root="${root%/}"
+  case "$root" in
+    "") root="/" ;;
+    /*) ;;
+    *) root="./$root" ;;
+  esac
+  printf '%s' "$root"
+}
+so_tmpfile() { mktemp "$(so_tmp_root)/second-opinion.XXXXXX"; }
+so_tmpdir() { mktemp -d "$(so_tmp_root)/second-opinion.XXXXXX"; }
 runtime_dir_valid() { [[ -d "$1" && ! -L "$1" ]]; }
 validate_runtime_dir() {
   runtime_dir_valid "$1" || die "runtime directory is missing, unsafe, or changed: $1"
@@ -138,10 +163,7 @@ create_runtime_dir() {
   # An explicit template rooted at $TMPDIR: a bare `mktemp -d` reads TMPDIR
   # only on GNU, and BSD mktemp allocates under the OS's per-user temp
   # directory instead, so this fallback ignored the caller's TMPDIR on macOS.
-  runtime_tmp_root="${TMPDIR:-/tmp}"
-  runtime_tmp_root="${runtime_tmp_root%/}"
-  case "$runtime_tmp_root" in "") runtime_tmp_root="/" ;; /*) ;; *) runtime_tmp_root="./$runtime_tmp_root" ;; esac
-  [[ -n "$dir" ]] || dir=$(mktemp -d "$runtime_tmp_root/second-opinion-runtime.XXXXXX" 2>/dev/null) || die "cannot create runtime directory"
+  [[ -n "$dir" ]] || dir=$(mktemp -d "$(so_tmp_root)/second-opinion-runtime.XXXXXX" 2>/dev/null) || die "cannot create runtime directory"
   chmod 700 "$dir" || die "cannot secure runtime directory: $dir"
   printf '%s\n' "$dir"
 }

--- a/.agents/skills/second-opinion/tests/lane-scratch-durability.test.sh
+++ b/.agents/skills/second-opinion/tests/lane-scratch-durability.test.sh
@@ -453,7 +453,13 @@ mkdir -p -- "$2/$3.cache"
 printf 'session\n' > "$2/$3.session"
 if [[ $# -ge 4 ]]; then
   printf 'reappeared\n' > "$4"
-  chmod 644 -- "$4"
+  # `--` before the mode, never after it: getopt(3) stops at the first
+  # non-option argument, which for chmod is the mode, so a `--` behind it is a
+  # file operand nobody has. BSD chmod fails on that line, this stub exits
+  # non-zero under set -e, and the lane reads as a failed CLI. The shipped
+  # installer takes the same shape; skills/commit-guards/tests/bsd-argv-install.test.sh
+  # runs the rule as a program.
+  chmod -- 644 "$4"
 fi
 cat "$1"
 SH

--- a/.agents/skills/second-opinion/tests/timestamp-stamp.test.sh
+++ b/.agents/skills/second-opinion/tests/timestamp-stamp.test.sh
@@ -140,7 +140,12 @@ assert_ne "$written_ts" "$BOGUS_TS" "written timestamp is NOT the model-supplied
 
 # The written value must be the wrapper's own wall clock: parse it to epoch and
 # confirm it falls within the [before, after] window of the run.
-written_epoch="$(date -u -d "$written_ts" +%s 2>/dev/null || echo "")"
+# `date -d` is GNU; BSD date parses an explicit format with -j -f, and the -u
+# is load-bearing there because the trailing Z is a LITERAL in the format
+# string — without it BSD date reads the stamp in the machine's local zone and
+# the window check below shifts by the UTC offset.
+written_epoch="$(date -u -d "$written_ts" +%s 2>/dev/null \
+  || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$written_ts" +%s 2>/dev/null || echo "")"
 if [[ -z "$written_epoch" ]]; then
   fail "written timestamp parses as an ISO-8601 UTC time (got '$written_ts')"
 elif (( written_epoch >= before && written_epoch <= after )); then

--- a/.agents/skills/worktree/tests/worktree_session_guard_lifecycle.sh
+++ b/.agents/skills/worktree/tests/worktree_session_guard_lifecycle.sh
@@ -30,9 +30,14 @@ WORKTREE_PACKAGE_DIR="$(cd "$TEST_DIR/.." && pwd)"
 WORKTREE_SCRIPT="$WORKTREE_PACKAGE_DIR/scripts/worktree"
 GUARD_SCRIPT="$WORKTREE_PACKAGE_DIR/scripts/worktree-session-guard"
 
+# A suite that cannot execute on this host reds. Skipping into a green would
+# report that the lifecycle holds on a platform where nothing here ran, which
+# is the one answer a second platform must never give. macOS ships no flock —
+# it is util-linux — so a stock Mac reds here and says what to install; the
+# macOS CI leg supplies flock for exactly this reason.
 if ! command -v flock >/dev/null 2>&1; then
-  printf 'SKIP: worktree lifecycle integration needs flock(1) for the per-issue claim lock, which is not on PATH\n' >&2
-  exit 0
+  printf 'FAIL: worktree lifecycle integration needs flock(1) for the per-issue claim lock, and this host has none. `create` refuses without it, so nothing below could run. Install flock (util-linux) and re-run.\n' >&2
+  exit 1
 fi
 
 TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"

--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -199,7 +199,12 @@ jobs:
           # diffutils)` — and never for the bare word: Apple's grep advertises
           # itself as `grep (BSD grep, GNU compatible)`, so the word alone reds
           # this leg on the very build it exists to run against.
-          for c in sed grep awk find diff ps; do
+          # Every utility whose BSD behaviour a suite or a shipped script now
+          # depends on, not just the five the leg used to install: a coreutils
+          # gnubin arriving on PATH would make wc, paste, touch, date, mktemp
+          # and seq GNU while the rest stayed Apple's, and this assertion would
+          # stay green over a userland the leg no longer measures.
+          for c in sed grep awk find diff ps wc paste touch date mktemp seq; do
             resolved="$(command -v "$c")" || resolved=""
             case "$resolved" in
               /usr/bin/* | /bin/*) ;;

--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -92,14 +92,24 @@ jobs:
   # never tested. The probe step after it is the leg's must-fail control. The
   # node shards are excluded: nothing in them is bash.
   #
-  # The leg swaps the shell and nothing else on purpose: it installs the GNU
-  # userland the suites are written against — coreutils, sed, grep, awk,
-  # find, diff, and util-linux for flock and setsid, which macOS lacks
-  # outright (workflow-state and lanes take flock with no fallback, and
-  # open-terminal detaches with setsid) or ships as BSD — and asserts each
-  # beside the shell, so a red leg is a Bash 3.2 finding and not a utility
-  # difference. What the suites do on the BSD userland is a property of its
-  # own that this leg does not prove.
+  # THE USERLAND the leg runs on is macOS's own: BSD sed, grep, awk, find, diff
+  # and ps, each asserted below beside the shell. A GNU-only construct in a
+  # suite or in a shipped script therefore reds here rather than passing on a
+  # userland no Mac has.
+  #
+  # FOUR UTILITIES ARE SUPPLIED, and they are the whole list: flock and setsid
+  # from util-linux, timeout and sha256sum from coreutils. macOS ships no
+  # flock, setsid or timeout at all, and carries sha256sum only in recent
+  # releases (26 has /sbin/sha256sum; the runner image's own release decides),
+  # so none of the four is a BSD difference to fix at a site — a script that
+  # must run without one carries its own fallback there (open-terminal falls
+  # back to nohup, workflow-state and lanes to a mkdir mutex, ci-wait's suite
+  # to an unbounded run, release-digests' to shasum). Each of the four is
+  # linked in on its own, never through a package's gnubin directory, so
+  # nothing else in coreutils or util-linux shadows a BSD tool. What needs one
+  # of the four and has no fallback — the worktree lifecycle suite,
+  # container-close's suite — reds on a host without it rather than skipping
+  # into a green.
   skill-suites-shard:
     name: Skill suites shard (${{ matrix.shard }}, ${{ matrix.os }})
     if: github.event_name != 'push'
@@ -124,19 +134,25 @@ jobs:
       # ---- macOS leg: Bash 3.2 first on PATH, asserted, and its probe -----
       # gnubin goes on PATH before the shell's directory does, so the
       # directory added last, the shell's, is searched first.
-      - name: the GNU userland the suites are written against
+      - name: the four utilities a stock macOS does not reliably carry
         if: matrix.os == 'macos-latest'
         env:
           HOMEBREW_NO_AUTO_UPDATE: '1'
           HOMEBREW_NO_INSTALL_CLEANUP: '1'
         run: |
           set -u
-          brew install coreutils gnu-sed grep gawk findutils diffutils util-linux
+          brew install coreutils util-linux
           prefix="$(brew --prefix)"
-          for f in coreutils gnu-sed grep gawk findutils; do
-            echo "$prefix/opt/$f/libexec/gnubin" >>"$GITHUB_PATH"
-          done
-          echo "$prefix/opt/util-linux/bin" >>"$GITHUB_PATH"
+          dir="$RUNNER_TEMP/supplied"
+          mkdir "$dir"
+          # One link per supplied utility. A whole gnubin or util-linux bin
+          # directory on PATH would put a GNU cut, sort, head, tr, dirname and
+          # basename in front of the BSD ones this leg exists to run against.
+          ln -s "$prefix/opt/util-linux/bin/flock" "$dir/flock"
+          ln -s "$prefix/opt/util-linux/bin/setsid" "$dir/setsid"
+          ln -s "$prefix/opt/coreutils/libexec/gnubin/timeout" "$dir/timeout"
+          ln -s "$prefix/opt/coreutils/libexec/gnubin/sha256sum" "$dir/sha256sum"
+          echo "$dir" >>"$GITHUB_PATH"
 
       - name: /bin/bash first on PATH
         if: matrix.os == 'macos-latest'
@@ -166,14 +182,34 @@ jobs:
           got "the step shell" "$BASH_VERSION"
           got "bash on PATH, $(command -v bash)" "$(version_of bash)"
           got "/usr/bin/env bash" "$(version_of /usr/bin/env bash)"
-          # The utilities the step above installed, resolved the way a suite
-          # resolves them: present, and the GNU one where macOS ships a BSD one.
+          # The four the step above supplied, resolved the way a suite resolves
+          # them: present, or a suite that calls one fails for the wrong reason.
           for c in flock setsid timeout sha256sum; do
-            command -v "$c" || { echo "$c is not on PATH; the suites that call it would fail for the wrong reason"; fail=1; }
+            command -v "$c" || { echo "$c is not on PATH; this leg promises to supply it"; fail=1; }
           done
-          for c in sed grep awk find diff; do
-            "$c" --version 2>/dev/null | head -n 1 | grep -q GNU ||
-              { echo "$c on PATH is $(command -v "$c"), not the GNU one; a suite red there would be a userland difference"; fail=1; }
+          # Everything else is macOS's own. A GNU build here — a package that
+          # linked its gnubin in, a runner image change — would prove the
+          # suites against a userland no Mac has, which is the property this
+          # leg exists to measure. The path is the assertion: under SIP a GNU
+          # build cannot be what /usr/bin or /bin holds, and a Homebrew one
+          # resolves outside both.
+          #
+          # The banner is read for the VENDOR form GNU prints — `sed (GNU sed)`,
+          # `grep (GNU grep)`, `GNU Awk`, `find (GNU findutils)`, `diff (GNU
+          # diffutils)` — and never for the bare word: Apple's grep advertises
+          # itself as `grep (BSD grep, GNU compatible)`, so the word alone reds
+          # this leg on the very build it exists to run against.
+          for c in sed grep awk find diff ps; do
+            resolved="$(command -v "$c")" || resolved=""
+            case "$resolved" in
+              /usr/bin/* | /bin/*) ;;
+              "") echo "$c is not on PATH at all"; fail=1 ;;
+              *) echo "$c on PATH is $resolved, not the one macOS ships"; fail=1 ;;
+            esac
+            if "$c" --version 2>/dev/null | head -n 1 | grep -Eq '\(GNU |^GNU '; then
+              echo "$c on PATH is a GNU build; this leg runs the BSD userland"
+              fail=1
+            fi
           done
           exit "$fail"
 

--- a/changelog.d/fixed/bsd-userland.md
+++ b/changelog.d/fixed/bsd-userland.md
@@ -1,0 +1,1 @@
+- The shipped scripts and their suites run on the stock macOS userland, where there is no flock, setsid or timeout and sed, awk, wc, paste, touch, date and mktemp are the BSD ones.

--- a/changelog.d/fixed/bsd-userland.md
+++ b/changelog.d/fixed/bsd-userland.md
@@ -1,1 +1,1 @@
-- The shipped scripts and their suites run on the stock macOS userland, where there is no flock, setsid or timeout and sed, awk, wc, paste, touch, date and mktemp are the BSD ones.
+- BSD sed, awk, wc, paste, touch, date, seq and mktemp differences are handled where the shipped scripts and their suites hit them; open-terminal and orch state writers need no setsid or flock.

--- a/skills/commit-guards/scripts/install-git-hooks
+++ b/skills/commit-guards/scripts/install-git-hooks
@@ -236,7 +236,10 @@ fi
 # and stays refused, the safe direction.
 helper_is_dangling() { # PATH — 0 when the helper's install directory is gone
   local line="" dir=""
-  line="$(sed -n '3p' -- "$1" 2>/dev/null)" || return 1
+  # The helper comes in on stdin, not as an operand: BSD sed has no `--`
+  # end-of-options, so it would open `--` as a second input and exit 1, and
+  # every helper of ours whose install is gone would read as somebody's file.
+  line="$(sed -n '3p' <"$1" 2>/dev/null)" || return 1
   case "$line" in
     "installed_scripts='"*"'") ;;
     *) return 1 ;;

--- a/skills/commit-guards/scripts/lib/changelog-grammar.sh
+++ b/skills/commit-guards/scripts/lib/changelog-grammar.sh
@@ -91,7 +91,13 @@ gg_changelog_blob() { # SHA LABEL — fills $GG_TMP/blob; 1 = not changelog text
   local sha="$1" label="$2" bad
   gg_read_blob "$sha" "$label" changelog
   ! gg_blob_is_binary "$GG_TMP/blob" "$label" || return 1
-  bad="$(LC_ALL=C awk "$GG_UTF8_AWK" <"$GG_TMP/blob")" \
+  # Every NUL becomes \200 before awk reads a byte. An awk that holds a record
+  # as a NUL-terminated C string — the BWK awk macOS ships — otherwise sees a
+  # line that stops at its first NUL, and a blob git calls text for having its
+  # only NUL past the leading sample would be measured as the short prefix
+  # instead of refused. \200 is a stray continuation byte, which the grammar
+  # below already rejects, so the line reports as the invalid UTF-8 it is.
+  bad="$(LC_ALL=C tr '\000' '\200' <"$GG_TMP/blob" | LC_ALL=C awk "$GG_UTF8_AWK")" \
     || gg_collection_error "could not read $(gg_shown "$label") to check its encoding"
   if [ -n "$bad" ]; then
     gg_collection_error "$(gg_shown "$label") line $bad is not valid UTF-8 — text with no character count cannot be measured"

--- a/skills/commit-guards/scripts/lib/staged-lines.sh
+++ b/skills/commit-guards/scripts/lib/staged-lines.sh
@@ -32,7 +32,13 @@ gg_staged_added_lines() { # PATH — one "line<TAB>content" record per line this
   # still arrives as hunks, so no path reaches the parser with its content
   # withheld; a genuinely binary blob never reaches the parser at all — the
   # lane's content sniff drops it before this runs.
-  awk '
+  # LC_ALL=C, like the grep every caller runs over this output: BWK awk — the
+  # awk macOS ships — decodes its input as characters under a UTF-8 locale and
+  # aborts with `towc: multibyte conversion failure`, exit 2, on the first byte
+  # sequence that is not valid UTF-8. A tracked text file may hold any byte;
+  # this lane's own content sniff already decided the blob is text, and a
+  # scan that exits 2 is a lane that errors instead of judging.
+  LC_ALL=C awk '
     /^diff --git / { hunk = 0; next }
     /^@@/ {
       h = $3

--- a/skills/commit-guards/tests/bsd-argv-install.test.sh
+++ b/skills/commit-guards/tests/bsd-argv-install.test.sh
@@ -135,3 +135,84 @@ if [ -x "$broken/.git/hooks/pre-commit" ] && [ -x "$broken/.git/hooks/commit-msg
 fi
 
 echo "pass: bsd-argv-install"
+
+# --- BSD sed argv, the same way: run it, do not read it -------------------
+#
+# `--` is not an end-of-options marker for BSD sed either. getopt(3) stops at
+# the first non-option argument, which for sed is the script, so a `--` after
+# it is a file operand — a file named `--`, which nobody has. BSD sed reports
+# it and exits 1 while still processing the real file, so a caller reading the
+# exit status sees a failure over content it actually got. install-git-hooks
+# reads line 3 of a candidate helper that way, and preflight reads a runner
+# body that way; the same rule judges both, and this is install-git-hooks.
+REAL_SED="$(command -v sed)"
+cat >"$shim/sed" <<SHIM
+#!/bin/sh
+# Every argument after the script is a file operand; a \`--\` among them is a
+# file nobody has.
+seen_script=0
+for arg in "\$@"; do
+  case "\$seen_script\$arg" in
+    0-*) continue ;;
+  esac
+  if [ "\$seen_script" -eq 1 ] && [ "\$arg" = "--" ]; then
+    echo "sed: --: No such file or directory" >&2
+    exit 1
+  fi
+  seen_script=1
+done
+exec $REAL_SED "\$@"
+SHIM
+chmod 0755 "$shim/sed"
+
+# The shim has teeth, and only on the wrong shape.
+printf 'a\nb\nc\n' >"$TMP/sed-probe"
+if PATH="$shim:$PATH" sed -n '3p' -- "$TMP/sed-probe" >/dev/null 2>&1; then
+  echo "FAIL: the sed shim accepts a -- operand, so it judges nothing" >&2
+  exit 1
+fi
+if [ "$(PATH="$shim:$PATH" sed -n '3p' <"$TMP/sed-probe")" != c ]; then
+  echo "FAIL: the sed shim does not pass a correct call through to the real sed" >&2
+  exit 1
+fi
+
+# A helper an earlier install wrote, whose baked scripts directory is gone.
+# install-git-hooks replaces exactly that file and refuses every other one, so
+# reading its line 3 is the whole decision: a read that fails leaves ours
+# looking like somebody else's file and the install stops.
+dangling_helper() { # REPO — plant a helper of an install that no longer exists
+  printf '#!/bin/sh\n# Scripts directory of the install that wrote this file.\ninstalled_scripts=%s\n# kendex earlier-package git hooks. Managed by an earlier install.\nexit 0\n' \
+    "'$TMP/install-that-moved/scripts'" >"$1/.git/hooks/kendex-guards"
+}
+
+dangling_helper "$repo"
+out=""
+status=0
+out="$(PATH="$shim:$PATH" "$installer" --repo "$repo" 2>&1)" || status=$?
+case "$out" in
+  *"scripts directory is gone; replacing it"*) ;;
+  *)
+    echo "FAIL: under BSD sed argv rules the dangling helper was not recognised (exit $status)" >&2
+    printf '%s\n' "$out" >&2
+    exit 1
+    ;;
+esac
+
+# The control: a copy with the `--` restored must NOT recognise it. Without
+# this the assertion above passes on any installer, including one that never
+# reads line 3.
+perl -pi -e "s/sed -n '3p' <\"\\\$1\"/sed -n '3p' -- \"\\\$1\"/" "$broken_installer"
+grep -q "sed -n '3p' -- " "$broken_installer" || {
+  echo "FAIL: the control could not restore the -- operand; the assertion below proves nothing" >&2
+  exit 1
+}
+dangling_helper "$broken"
+broken_out="$(PATH="$shim:$PATH" "$broken_installer" --repo "$broken" 2>&1)" || true
+case "$broken_out" in
+  *"scripts directory is gone; replacing it"*)
+    echo "FAIL: must-fail control recognised the dangling helper with a -- operand under BSD sed" >&2
+    exit 1
+    ;;
+esac
+
+echo "pass: bsd-argv-sed"

--- a/skills/commit-guards/tests/bsd-awk-record.test.sh
+++ b/skills/commit-guards/tests/bsd-awk-record.test.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# The changelog family's encoding check under BWK awk's record rule, as a
+# program rather than a lint.
+#
+# macOS ships BWK awk ("awk version 20200816"), which holds a record as a
+# NUL-terminated C string: a line's content stops at its first NUL. GNU awk
+# carries the whole line, so nothing on a Linux runner can see the
+# difference by reading the source. It is put in a shim on PATH instead and
+# the real check runs under it.
+#
+# What the rule costs: git calls a blob binary only when a NUL falls in its
+# leading sample, so a blob whose only NUL is past that sample is text to
+# git and must be text to this family too. Under BWK's rule the UTF-8 pass
+# never sees that NUL, the blob measures as the short prefix before it, and
+# an unmeasurable file is reported as an over-long entry instead of being
+# refused. scripts/lib/changelog-grammar.sh translates every NUL to \200 — a
+# stray continuation byte its grammar already rejects — before awk reads a
+# byte, which is what this suite pins.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+# shellcheck source=lib/harness.bash
+. "$TEST_DIR/lib/harness.bash"
+
+unset COMMIT_GUARDS_CHANGELOG_CAP COMMIT_GUARDS_CHANGELOG_PATHS \
+  COMMIT_GUARDS_CHANGELOG_RECORD COMMIT_GUARDS_SETTINGS_FILE 2>/dev/null || true
+
+REAL_AWK="$(command -v awk)"
+shim="$TMP/shim"
+mkdir -p "$shim"
+cat >"$shim/awk" <<SHIM
+#!/bin/sh
+# One argument is a program and its input on stdin, which is how the
+# changelog family reads a blob. Every other shape — a file operand, -v, -F —
+# passes straight through, so this shim judges that one read and nothing else.
+if [ "\$#" -eq 1 ]; then
+  perl -pe 's/\\0.*//' | $REAL_AWK "\$1"
+  exit \$?
+fi
+exec $REAL_AWK "\$@"
+SHIM
+chmod 0755 "$shim/awk"
+
+# The shim has teeth, and only on the shape it means to judge.
+truncated="$(printf 'ab\000cd\n' | PATH="$shim:$PATH" awk '{ print length($0) }')"
+[ "$truncated" = 2 ] || {
+  echo "FAIL: the awk shim does not truncate a record at its NUL (length $truncated)" >&2
+  exit 1
+}
+# Compared against the host's own awk, not against a number: BWK awk truncates
+# at a NUL whatever the input is, so on macOS the untouched answer is 2 and on
+# GNU it is 5. What must hold on both is that the shim changed nothing here.
+printf 'ab\000cd\n' >"$TMP/probe"
+whole="$(PATH="$shim:$PATH" awk '{ print length($0) }' "$TMP/probe")"
+native="$("$REAL_AWK" '{ print length($0) }' "$TMP/probe")"
+[ "$whole" = "$native" ] || {
+  echo "FAIL: the awk shim altered a call with a file operand (length $whole, host awk says $native)" >&2
+  exit 1
+}
+
+# A fragment git calls text: 8100 bytes of content, then the file's only NUL.
+plant() { # REPO
+  mkdir -p "$1/changelog.d/added"
+  {
+    printf -- '- '
+    i=0
+    while [ "$i" -lt 8100 ]; do printf x; i=$((i + 1)); done
+    printf '\000tail\n'
+  } >"$1/changelog.d/added/late-nul.md"
+  git -C "$1" add -A
+}
+
+new_repo() { # PATH
+  mkdir -p "$1"
+  git -C "$1" -c init.defaultBranch=main init -q
+  git -C "$1" config user.email t@t
+  git -C "$1" config user.name t
+}
+
+repo="$TMP/nul"
+new_repo "$repo"
+plant "$repo"
+[ -n "$(git -C "$repo" grep --cached -I -l . -- changelog.d/added)" ] || {
+  echo "FAIL: git calls the fixture blob binary, so it is not the case this suite means" >&2
+  exit 1
+}
+
+out=""
+status=0
+out="$(cd "$repo" && PATH="$shim:$PATH" "$SKILL_DIR/scripts/changelog-entries" 2>&1)" || status=$?
+case "$status:$out" in
+  2:*"late-nul.md line 1 is not valid UTF-8"*) ;;
+  *)
+    echo "FAIL: under BWK awk's record rule the NUL past the sample was not refused (exit $status)" >&2
+    printf '%s\n' "$out" >&2
+    exit 1
+    ;;
+esac
+
+# The control: a copy of the package with the translation removed must NOT
+# refuse it. Without this the assertion above passes on any check, including
+# one that never reads the blob's bytes at all.
+broken="$TMP/broken-pkg"
+mkdir -p "$broken"
+cp -R "$SKILL_DIR" "$broken/commit-guards"
+grammar="$broken/commit-guards/scripts/lib/changelog-grammar.sh"
+perl -pi -e "s/LC_ALL=C tr '\\\\000' '\\\\200' <\"\\\$GG_TMP\\/blob\" \\| LC_ALL=C awk/LC_ALL=C awk/" "$grammar"
+grep -q "tr '\\\\000'" "$grammar" && {
+  echo "FAIL: the control could not remove the NUL translation; the assertion below proves nothing" >&2
+  exit 1
+}
+broken_repo="$TMP/broken-repo"
+new_repo "$broken_repo"
+plant "$broken_repo"
+broken_out="$(cd "$broken_repo" && PATH="$shim:$PATH" "$broken/commit-guards/scripts/changelog-entries" 2>&1)" || true
+case "$broken_out" in
+  *"is not valid UTF-8"*)
+    echo "FAIL: must-fail control refused the late NUL with the translation removed" >&2
+    exit 1
+    ;;
+esac
+
+echo "pass: bsd-awk-record"

--- a/skills/decider/scripts/decisions
+++ b/skills/decider/scripts/decisions
@@ -250,7 +250,11 @@ body_term_hits() {
     fi
     # -l lists matching files. Unreadable or absent files are not matches, and
     # a term that matches nothing is not an error.
-    matched=$(printf '%s\0' "${paths[@]}" | xargs -0 -r grep -ilE -e "$term" -- 2>/dev/null || true)
+    # No -r: it is a GNU extension, its only job is to skip a run on empty
+    # input, and the array is already proven non-empty above. Dropping it is
+    # what keeps this line off the differences between xargs implementations
+    # rather than resting on any one of them accepting the flag.
+    matched=$(printf '%s\0' "${paths[@]}" | xargs -0 grep -ilE -e "$term" -- 2>/dev/null || true)
     if [[ -n "$matched" ]]; then
       while IFS= read -r path; do
         hits+="$path"$'\t'"$term"$'\n'

--- a/skills/github/tests/ci-logs-large-log.test.sh
+++ b/skills/github/tests/ci-logs-large-log.test.sh
@@ -75,9 +75,11 @@ padding="$(printf 'x%.0s' {1..1400})"
     printf '2026-09-02T10:00:00Z  compiling crate %s\n' "$padding"
   done
 } > "$TMP_ROOT/big.log"
-log_bytes=$(wc -c <"$TMP_ROOT/big.log")
+# BSD wc right-aligns its count in a fixed-width field; assert_ge below reads
+# its argument with ^[0-9]+$, which a padded number fails.
+log_bytes=$(wc -c <"$TMP_ROOT/big.log" | tr -d ' ')
 assert_ge "$log_bytes" 131072 "staged log clears the pipe buffer and the single-argument cap"
-assert_eq "$(wc -l <"$TMP_ROOT/big.log")" "100" "staged log fits the default --lines window whole"
+assert_eq "$(wc -l <"$TMP_ROOT/big.log" | tr -d ' ')" "100" "staged log fits the default --lines window whole"
 
 # The job name matches none of the fallback heuristics, so the log is the only
 # thing that can produce a classification other than "unknown".

--- a/skills/github/tests/env-first-auth.sh
+++ b/skills/github/tests/env-first-auth.sh
@@ -214,15 +214,18 @@ ENVEOF
 rm -f "$TMP_ROOT/op.calls"
 output=$(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" STUB_KEYRING_OK=1 "$REPO_ROOT/skills/github/scripts/github.sh" -C "$TMP_ROOT/repo" pr-view --json number,state)
 assert_eq "$(jq -r .number <<<"$output")" "42" "github.sh router falls back to keyring for unresolved GH_TOKEN"
-assert_eq "$(wc -l <"$TMP_ROOT/op.calls")" "1" "unresolved GH_TOKEN attempts op once before keyring fallback"
+# The blanks come off every count below: BSD wc right-aligns its number in a
+# fixed-width field, so `$(wc -l <f)` reads "       1" on macOS and "1" on
+# GNU, and these are compared as strings.
+assert_eq "$(wc -l <"$TMP_ROOT/op.calls" | tr -d ' ')" "1" "unresolved GH_TOKEN attempts op once before keyring fallback"
 
 rm -f "$TMP_ROOT/op.calls"
 (cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" STUB_KEYRING_OK=1 GH_TOKEN=op://vault/github/user "$REPO_ROOT/skills/github/scripts/commands/label-add.sh" 42 test-label >/dev/null)
-assert_eq "$(wc -l <"$TMP_ROOT/op.calls")" "1" "label-add falls back to keyring for unresolved GH_TOKEN"
+assert_eq "$(wc -l <"$TMP_ROOT/op.calls" | tr -d ' ')" "1" "label-add falls back to keyring for unresolved GH_TOKEN"
 
 rm -f "$TMP_ROOT/op.calls"
 (cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" STUB_KEYRING_OK=1 GITHUB_TOKEN=op://vault/github/user "$REPO_ROOT/skills/github/scripts/commands/label-remove.sh" 42 test-label >/dev/null)
-assert_eq "$(wc -l <"$TMP_ROOT/op.calls")" "1" "label-remove falls back to keyring for unresolved GITHUB_TOKEN"
+assert_eq "$(wc -l <"$TMP_ROOT/op.calls" | tr -d ' ')" "1" "label-remove falls back to keyring for unresolved GITHUB_TOKEN"
 
 cat > "$TMP_ROOT/repo/.env.local" <<'ENVEOF'
 GH_BOT_TOKEN=ghs_ROUTERBOT123
@@ -263,7 +266,7 @@ printf '%s\n' 'body text' >"$TMP_ROOT/pr-body.md"
 rm -f "$TMP_ROOT/op.calls"
 output=$(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" STUB_KEYRING_OK=1 GH_TOKEN=op://vault/github/user "$REPO_ROOT/skills/github/scripts/github.sh" -C "$TMP_ROOT/repo" pr-edit-body 42 --body-file "$TMP_ROOT/pr-body.md")
 assert_eq "$output" "updated" "github.sh pr-edit-body falls back to keyring for unresolved GH_TOKEN"
-assert_eq "$(wc -l <"$TMP_ROOT/op.calls")" "1" "pr-edit-body unresolved GH_TOKEN attempts op once"
+assert_eq "$(wc -l <"$TMP_ROOT/op.calls" | tr -d ' ')" "1" "pr-edit-body unresolved GH_TOKEN attempts op once"
 
 cat > "$TMP_ROOT/repo/.env.local" <<'ENVEOF'
 GH_BOT_TOKEN=op://vault/github/bot
@@ -271,7 +274,7 @@ ENVEOF
 rm -f "$TMP_ROOT/op.calls"
 output=$(load_token)
 assert_eq "$output" "ghs_RESOLVED123" "project op reference resolves when no env token exists"
-assert_eq "$(wc -l <"$TMP_ROOT/op.calls")" "1" "project op reference calls op once"
+assert_eq "$(wc -l <"$TMP_ROOT/op.calls" | tr -d ' ')" "1" "project op reference calls op once"
 
 cat > "$TMP_ROOT/repo/.env.local" <<'ENVEOF'
 GH_BOT_TOKEN=ghs_FILEBOT123

--- a/skills/github/tests/pr-view.sh
+++ b/skills/github/tests/pr-view.sh
@@ -315,7 +315,9 @@ for bound in KENDEX_GITHUB_AUTH_TIMEOUT KENDEX_GITHUB_OP_TIMEOUT \
     "the refusal names $bound" "$stderr"
   assert_eq "$(jq -r .detail <<<"$output")" "2.55" \
     "the refusal carries the value it rejected for $bound" "$stderr"
-  assert_eq "$(wc -c <"$calls")" "0" \
+  # BSD wc right-aligns its count in a fixed-width field, so the blanks come
+  # off before the string comparison.
+  assert_eq "$(wc -c <"$calls" | tr -d ' ')" "0" \
     "an unreadable $bound reaches no gh call" "$stderr"
 done
 
@@ -327,7 +329,7 @@ rc=$?
 set -e
 assert_eq "$rc" "0" "inherited op GH_TOKEN falls back to keyring" "$stderr"
 assert_eq "$(jq -r .number <<<"$output")" "42" "inherited op GH_TOKEN preserves gh JSON" "$stderr"
-assert_eq "$(wc -l <"$TMP_ROOT/op.calls")" "1" "inherited op GH_TOKEN attempts op once" "$stderr"
+assert_eq "$(wc -l <"$TMP_ROOT/op.calls" | tr -d ' ')" "1" "inherited op GH_TOKEN attempts op once" "$stderr"
 
 rm -f "$TMP_ROOT/op.calls"
 stderr="$TMP_ROOT/inherited-github-token-op.err"
@@ -337,7 +339,7 @@ rc=$?
 set -e
 assert_eq "$rc" "0" "inherited op GITHUB_TOKEN falls back to keyring" "$stderr"
 assert_eq "$(jq -r .number <<<"$output")" "42" "inherited op GITHUB_TOKEN preserves gh JSON" "$stderr"
-assert_eq "$(wc -l <"$TMP_ROOT/op.calls")" "1" "inherited op GITHUB_TOKEN attempts op once" "$stderr"
+assert_eq "$(wc -l <"$TMP_ROOT/op.calls" | tr -d ' ')" "1" "inherited op GITHUB_TOKEN attempts op once" "$stderr"
 
 cat > "$TMP_ROOT/repo/.env.local" <<'ENVEOF'
 GH_BOT_TOKEN=op://vault/item/field

--- a/skills/github/tests/verify-lib-error-summary.test.sh
+++ b/skills/github/tests/verify-lib-error-summary.test.sh
@@ -57,7 +57,9 @@ done
 exit 1
 CMD
 chmod +x "$TMP_ROOT/fail.sh"
-assert_ge "$(bash "$TMP_ROOT/fail.sh" | wc -c || true)" 131072 "failing command's error text clears two pipe buffers"
+# BSD wc right-aligns its count in a fixed-width field; assert_ge reads its
+# argument with ^[0-9]+$, which a padded number fails.
+assert_ge "$(bash "$TMP_ROOT/fail.sh" | wc -c | tr -d ' ' || true)" 131072 "failing command's error text clears two pipe buffers"
 
 # run_stack under live errexit, with RESULTS_JSON recovered from an EXIT trap:
 # an aborted run_stack leaves the entry it never wrote missing rather than

--- a/skills/github/tests/verify-lib-error-summary.test.sh
+++ b/skills/github/tests/verify-lib-error-summary.test.sh
@@ -122,7 +122,7 @@ printf 'error[E0001]: %s\n' "$pad"
 exit 1
 CMD
 chmod +x "$TMP_ROOT/fail-long-line.sh"
-assert_ge "$(bash "$TMP_ROOT/fail-long-line.sh" | wc -c || true)" 131072 "the single error line clears MAX_ARG_STRLEN on its own"
+assert_ge "$(bash "$TMP_ROOT/fail-long-line.sh" | wc -c | tr -d ' ' || true)" 131072 "the single error line clears MAX_ARG_STRLEN on its own"
 
 echo "=== one error line past MAX_ARG_STRLEN is still summarized (KEN-1171) ==="
 results="$(drive "rust|bash $TMP_ROOT/fail-long-line.sh||.")"

--- a/skills/orch/scripts/lanes
+++ b/skills/orch/scripts/lanes
@@ -70,7 +70,7 @@
 #   the reference case). A lane chooser that silently rotates OAuth tokens
 #   during a fleet launch trades a visible "unknown" for an invisible auth
 #   failure across every session. Reporting the lane as `expired` and letting
-#   the operator decide is the safer default; --refresh takes the same flock the
+#   the operator decide is the safer default; --refresh takes the same lock the
 #   reference implementation uses and re-reads under it.
 #
 # Credentials never reach argv: `ps` and journald can read /proc/<pid>/cmdline,
@@ -353,16 +353,21 @@ measure_lane() {
 	emit_lane "$alias" "$harness" "$dir" "$status" "$detail" "$plan" "$buckets"
 }
 
-# Refresh under an flock on the credentials file, re-reading inside the lock:
+# Refresh under a lock on the credentials file, re-reading inside the lock:
 # a peer tool may have rotated the refresh token between our first read and
 # this attempt, and refreshing with the stale one fails while the credentials
-# are actually fine.
+# are actually fine. lib/file-lock.sh carries the lock on a host with no
+# flock, where the bare `flock -w 30 9` this used to run resolved to nothing
+# and every refresh on that host returned failure instead of a token.
 refresh_claude_token() {
 	local dir="$1" creds="$2" lock="$dir/.lanes-refresh.lock" rt client_id resp new_at
 	client_id="${ORCH_LANES_CLAUDE_CLIENT_ID:-}"
 	[[ -n "$client_id" ]] || return 1
 	exec 9>"$lock" || return 1
-	flock -w 30 9 || return 1
+	# Every caller runs this function in a command substitution, so the whole
+	# body is a subshell and the EXIT trap orch_take_lock arms releases a mkdir
+	# mutex on every path out — including this one.
+	orch_take_lock 9 "$lock" 30 || { exec 9>&-; return 1; }
 	rt=$(jq -r 'try (.claudeAiOauth.refreshToken // empty) catch empty' "$creds")
 	[[ -n "$rt" ]] || { exec 9>&-; return 1; }
 	resp=$(jq -nc --arg ci "$client_id" --arg rt "$rt" \
@@ -560,6 +565,8 @@ need_jq
 
 PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 export PROJECT_ROOT
+# shellcheck source=lib/file-lock.sh
+source "$SCRIPT_DIR/lib/file-lock.sh"
 # shellcheck source=lib/kendex-env.sh
 source "$SCRIPT_DIR/lib/kendex-env.sh"
 # This script runs without errexit, so the loader's refusal must be checked

--- a/skills/orch/scripts/lib/date-ladder.sh
+++ b/skills/orch/scripts/lib/date-ladder.sh
@@ -21,8 +21,21 @@ tz_date() {
 # is not shifted by the runner's local zone.
 to_epoch() {
   local stamp="$1" fmt="${2:-%Y-%m-%dT%H:%M:%SZ}" zone="${3-UTC}"
+  local bsd_stamp="$stamp" bsd_fmt="$fmt"
+  # BSD `date -j -f` takes every field its format does not name from the
+  # CURRENT time, so a format without %S resolves to this minute's seconds
+  # instead of to :00 — a clock read seconds late, and a different answer on
+  # every run. GNU `date -d` zeroes them. The seconds are named outright for
+  # the BSD arm rather than left to the clock.
+  case "$bsd_fmt" in
+    *%S*) ;;
+    *)
+      bsd_stamp="$bsd_stamp:00"
+      bsd_fmt="$bsd_fmt:%S"
+      ;;
+  esac
   tz_date "$zone" -d "$stamp" +%s 2>/dev/null \
-    || tz_date "$zone" -j -f "$fmt" "$stamp" +%s 2>/dev/null
+    || tz_date "$zone" -j -f "$bsd_fmt" "$bsd_stamp" +%s 2>/dev/null
 }
 
 # The other direction on the same ladder: GNU spells an epoch input `-d @`,

--- a/skills/orch/scripts/lib/file-lock.sh
+++ b/skills/orch/scripts/lib/file-lock.sh
@@ -1,0 +1,51 @@
+# shellcheck shell=bash
+# One exclusive lock for the orch scripts that serialize writers on a file.
+#
+# flock(1) is taken where it exists, because the kernel releases it however
+# the holder dies. Stock macOS ships none — it is util-linux, which macOS is
+# not — and these writers must not run unguarded there: two `workflow-state
+# set` calls racing on one state file both read, both write, and the later
+# write drops the earlier transition. So a mkdir mutex carries the lock where
+# flock is absent; mkdir is atomic on POSIX filesystems, so exactly one
+# contender creates the directory.
+#
+# The two mechanisms do not lock each other out, so this ASSUMES every writer
+# of a given file on a host resolves the same one. That is the assumption
+# skills/worktree/scripts/worktree-session-guard already makes for its own
+# lock, and it holds for the same reason: these files are per-repository and
+# per-host, and a host has one PATH resolution of flock.
+#
+# Sourced, never executed. Bash 3.2-safe, like its callers.
+
+ORCH_LOCK_MUTEX_DIR=""
+
+orch_release_lock() { # release a mutex this shell took; a no-op under flock
+  [ -z "$ORCH_LOCK_MUTEX_DIR" ] || rmdir -- "$ORCH_LOCK_MUTEX_DIR" 2>/dev/null || true
+  ORCH_LOCK_MUTEX_DIR=""
+}
+
+# FD is already open on LOCK_FILE at the caller's redirection, which is what
+# flock locks; the mutex arm ignores it and locks the path. Failure to take
+# the lock is a non-zero return the caller reports — never an unguarded write.
+orch_take_lock() { # FD LOCK_FILE WAIT_SECONDS
+  local fd="$1" lock_file="$2" wait_s="$3" tries=0 limit
+  if command -v flock >/dev/null 2>&1; then
+    flock -w "$wait_s" "$fd"
+    return
+  fi
+  limit=$((wait_s * 10))
+  # Armed before the loop, never after it wins: recording the directory before
+  # mkdir would let a losing contender rmdir the winner's mutex, and arming
+  # after the win leaves a signal in that window holding the lock for good.
+  # orch_release_lock is a no-op while ORCH_LOCK_MUTEX_DIR is empty.
+  trap orch_release_lock EXIT
+  while ! mkdir -- "$lock_file.d" 2>/dev/null; do
+    tries=$((tries + 1))
+    if [ "$tries" -ge "$limit" ]; then
+      echo "Error: could not acquire $lock_file.d after ${wait_s}s. If no orch process is running, remove it: rmdir '$lock_file.d'" >&2
+      return 1
+    fi
+    sleep 0.1
+  done
+  ORCH_LOCK_MUTEX_DIR="$lock_file.d"
+}

--- a/skills/orch/scripts/lib/review-artifact-gates.sh
+++ b/skills/orch/scripts/lib/review-artifact-gates.sh
@@ -43,7 +43,21 @@ emit_unavailable() {
 
 # jq's stderr lands here and is read only when the gate's exit status says the
 # gate failed. Never printed as an answer.
-review_artifact_gate_err="$(mktemp 2>/dev/null)" || {
+# The template names $TMPDIR outright. A bare `mktemp` reads it only on GNU;
+# BSD mktemp — the one macOS ships — ignores it and allocates under the OS's
+# own per-user temp directory, so an unusable TMPDIR did not stop the check
+# there and it answered `valid` over a channel the caller never named. The
+# trailing slash comes off because macOS sets TMPDIR with one, and a relative
+# root is prefixed with `./` so a TMPDIR named `-x` cannot reach mktemp, or the
+# rm in the cleanup below, as an option.
+review_artifact_gate_tmp_root="${TMPDIR:-/tmp}"
+review_artifact_gate_tmp_root="${review_artifact_gate_tmp_root%/}"
+case "$review_artifact_gate_tmp_root" in
+  "") review_artifact_gate_tmp_root="/" ;;
+  /*) ;;
+  *) review_artifact_gate_tmp_root="./$review_artifact_gate_tmp_root" ;;
+esac
+review_artifact_gate_err="$(mktemp "$review_artifact_gate_tmp_root/review-artifact-check.XXXXXX" 2>/dev/null)" || {
   emit_unavailable "review-artifact-check could not create its temporary error channel (mktemp failed; check TMPDIR and free space), so no artifact could be validated"
   exit 1
 }

--- a/skills/orch/scripts/open-terminal
+++ b/skills/orch/scripts/open-terminal
@@ -652,7 +652,17 @@ open_gui() {
   # carrying arguments — is otherwise substituted in silence.
   [[ -z "${TERMINAL:-}" || "$chosen" == "$TERMINAL" ]] ||
     echo "Warning: \$TERMINAL '$TERMINAL' does not resolve to an executable; launching '$title' with $chosen instead" >&2
-  setsid "${launcher[@]}" </dev/null >/dev/null 2>&1 &
+  # setsid puts the window in its own session so it outlives this script and
+  # its terminal. macOS ships none — it is util-linux — and with stderr
+  # already going to /dev/null the shell's `setsid: command not found` was
+  # swallowed, so the launch never happened and the line below still said it
+  # had. nohup is what every platform has: it detaches the child from the
+  # hangup this script's exit would otherwise deliver.
+  if command -v setsid >/dev/null 2>&1; then
+    setsid "${launcher[@]}" </dev/null >/dev/null 2>&1 &
+  else
+    nohup "${launcher[@]}" </dev/null >/dev/null 2>&1 &
+  fi
   echo "Opened terminal '$title' in $dir"
 }
 

--- a/skills/orch/scripts/oversee-watch
+++ b/skills/orch/scripts/oversee-watch
@@ -699,8 +699,12 @@ lane_limit_banner() {
 lane_row_prune() {
   local kind="$1" state="$2"
   shift 2
-  awk -F'\t' -v kind="$kind" -v lanes="$(printf '%s\n' "$@")" '
-    BEGIN { n = split(lanes, a, "\n"); for (i = 1; i <= n; i++) watched[a[i]] = 1 }
+  # The lane list crosses in the environment, never through -v: it holds one
+  # lane per line, and BWK awk — the awk macOS ships — refuses a -v value
+  # carrying a newline outright ("awk: newline in string"), so every prune died
+  # there and no lane event was ever emitted. ENVIRON takes the value whole.
+  ow_lanes="$(printf '%s\n' "$@")" awk -F'\t' -v kind="$kind" '
+    BEGIN { n = split(ENVIRON["ow_lanes"], a, "\n"); for (i = 1; i <= n; i++) watched[a[i]] = 1 }
     NF && !($1 == kind && !($2 in watched))
   ' <<<"$state"
 }

--- a/skills/orch/scripts/workflow-state
+++ b/skills/orch/scripts/workflow-state
@@ -26,8 +26,9 @@ ensure_state_exists() {
     fi
 }
 
-# Atomic update: flock + write to temp, validate, move
-# Uses flock to serialize concurrent writes and prevent state corruption.
+# Atomic update: take the lock, write to temp, validate, move.
+# The lock serializes concurrent writes and prevents state corruption;
+# lib/file-lock.sh says which mechanism carries it on which platform.
 # Any remaining arguments are passed to jq ahead of the filter, which is how
 # `update --arg`/`--argjson` hand values in out of band.
 atomic_update() {
@@ -39,7 +40,7 @@ atomic_update() {
     local tmp_file="${state_file}.tmp"
 
     (
-        flock -w 10 200 || { echo "Error: could not acquire lock on $lock_file" >&2; exit 1; }
+        orch_take_lock 200 "$lock_file" 10 || { echo "Error: could not acquire lock on $lock_file" >&2; exit 1; }
 
         if ! jq ${jq_args[@]+"${jq_args[@]}"} "$jq_expr" "$state_file" > "$tmp_file" 2>&1; then
             echo "Error: jq expression failed: $jq_expr" >&2
@@ -210,7 +211,7 @@ cmd_update_report() {
     # file exists to race on, so concurrent calls for the same issue each
     # return exactly their own transition's evidence.
     (
-        flock -w 10 200 || { echo "Error: could not acquire lock on $lock_file" >&2; exit 1; }
+        orch_take_lock 200 "$lock_file" 10 || { echo "Error: could not acquire lock on $lock_file" >&2; exit 1; }
 
         local combined
         if ! combined=$(jq -c ${jq_args[@]+"${jq_args[@]}"} "$jq_expr" "$state_file" 2>&1); then
@@ -309,7 +310,7 @@ cmd_append() {
         local tmp_file="${state_file}.tmp"
         local lock_file="${state_file}.lock"
         (
-            flock -w 10 200 || { echo "Error: could not acquire lock" >&2; exit 1; }
+            orch_take_lock 200 "$lock_file" 10 || { echo "Error: could not acquire lock" >&2; exit 1; }
             jq --arg v "$value" ".${field} += [\$v]" "$state_file" > "$tmp_file" 2>&1 || { rm -f "$tmp_file"; exit 1; }
             jq empty "$tmp_file" 2>/dev/null || { echo "Error: invalid JSON" >&2; rm -f "$tmp_file"; exit 1; }
             mv "$tmp_file" "$state_file"
@@ -458,7 +459,7 @@ cmd_set() {
         local tmp_file="${state_file}.tmp"
         local lock_file="${state_file}.lock"
         (
-            flock -w 10 200 || { echo "Error: could not acquire lock" >&2; exit 1; }
+            orch_take_lock 200 "$lock_file" 10 || { echo "Error: could not acquire lock" >&2; exit 1; }
             jq --arg v "$value" ".${field} = \$v" "$state_file" > "$tmp_file" 2>&1 || { rm -f "$tmp_file"; exit 1; }
             jq empty "$tmp_file" 2>/dev/null || { echo "Error: invalid JSON" >&2; rm -f "$tmp_file"; exit 1; }
             mv "$tmp_file" "$state_file"
@@ -655,7 +656,8 @@ Environment:
 
 Dependencies:
   jq               JSON processing
-  flock             File locking (util-linux)
+  flock             File locking, where it is installed; without it a mkdir
+                    mutex serializes the same writers (stock macOS has no flock)
 EOF
 }
 
@@ -712,6 +714,8 @@ parse_rc=0
 [[ "$parse_rc" -eq 9 ]] || exit "$parse_rc"
 unset parse_rc
 
+# shellcheck source=lib/file-lock.sh
+source "$SCRIPT_DIR/lib/file-lock.sh"
 # shellcheck source=lib/kendex-env.sh
 source "$SCRIPT_DIR/lib/kendex-env.sh"
 kendex_load_project_env "$PROJECT_ROOT"

--- a/skills/orch/tests/branch_size_check.sh
+++ b/skills/orch/tests/branch_size_check.sh
@@ -101,12 +101,14 @@ printf 'x\ny\n' > "$WT/src/rewritten.txt"   # 50 deleted, 2 added: bills 2
 commit_files implementation
 
 capture split_json run_check "$CHECK_BIN" --json
-assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$split_json" | paste -sd,)" "16,14" \
+# Every paste below names its input as `-`: GNU paste reads stdin when it is
+# given no file operand, BSD paste prints its usage and exits 2.
+assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$split_json" | paste -sd, -)" "16,14" \
   "each is_test rule classifies alone, a name containing 'test' does not, and a rewrite bills only its additions"
-assert_eq "$(jq -r '.production_allowance, .test_allowance, .verdict' <<<"$split_json" | paste -sd,)" \
+assert_eq "$(jq -r '.production_allowance, .test_allowance, .verdict' <<<"$split_json" | paste -sd, -)" \
   "40,20,pass" "the stated line is the production and test allowance"
-assert_eq "$(jq -r '.base_sha, .head_sha' <<<"$split_json" | paste -sd,)" \
-  "$(git -C "$WT" rev-parse main HEAD | paste -sd,)" \
+assert_eq "$(jq -r '.base_sha, .head_sha' <<<"$split_json" | paste -sd, -)" \
+  "$(git -C "$WT" rev-parse main HEAD | paste -sd, -)" \
   "the record is bound to the base and head it measured"
 assert_eq "$("$STATE" --state-dir "$WT/tmp" get KEN-SIZE '.pr.size_check.verdict')" "pass" \
   "the verdict is recorded beside pr.baseline_lines, in no new state file"
@@ -159,7 +161,7 @@ while IFS='|' read -r line want_fields want_rc; do
   set -e
   assert_eq "$row_rc" "$want_rc" "exit for: $line"
   [[ "$want_rc" != 0 ]] || assert_eq \
-    "$(jq -r '.production_allowance, .test_allowance, .verdict' <<<"$row_json" | paste -sd,)" \
+    "$(jq -r '.production_allowance, .test_allowance, .verdict' <<<"$row_json" | paste -sd, -)" \
     "$want_fields" "record for: $line"
 done <<'ROWS'
 **Expected delta**: 250 lines|250,null,pass|0
@@ -178,7 +180,7 @@ set -e
 assert_eq "$missing_rc" "0" "an issue stating no allowance is reported, not refused and not defaulted"
 assert_eq "$([[ "$missing_error" == *"no allowance to judge by"* && "$missing_error" == *"50 production, 14 test"* ]] && echo yes)" \
   "yes" "the report names the missing line and the counts measured"
-assert_eq "$("$STATE" --state-dir "$WT/tmp" get KEN-SIZE '.pr.size_check.verdict, .pr.size_check.production_allowance' | paste -sd,)" \
+assert_eq "$("$STATE" --state-dir "$WT/tmp" get KEN-SIZE '.pr.size_check.verdict, .pr.size_check.production_allowance' | paste -sd, -)" \
   "allowance_missing,null" "the record says nothing was judged and invents no allowance"
 
 # --- Past the production allowance ------------------------------------------
@@ -243,7 +245,7 @@ chmod +x "$GH_STUB/gh"
 "$STATE" --state-dir "$WT/tmp" init issue-77 --worktree "$WT" --branch size >/dev/null
 capture gh_json env PATH="$GH_STUB:$PATH" ORCH_STATE_DIR="$WT/tmp" \
   "$CHECK_BIN" --worktree "$WT" --issue issue-77 --json
-assert_eq "$(jq -r '.production_allowance, .test_allowance, .verdict' <<<"$gh_json" | paste -sd,)" \
+assert_eq "$(jq -r '.production_allowance, .test_allowance, .verdict' <<<"$gh_json" | paste -sd, -)" \
   "50,60,pass" "a GitHub issue body supplies the same allowance"
 
 # --- An issue the tracker cannot give is an environment failure -------------

--- a/skills/orch/tests/ci_wait.sh
+++ b/skills/orch/tests/ci_wait.sh
@@ -411,7 +411,18 @@ table "$JSON" \
 stage ""
 RUN="$TMP_ROOT/runs/$((++RUN_SEQ))"; mkdir -p "$RUN"
 set +e
-OUT=$(timeout 6s bash -c 'cd "$1" && PATH="$2:$PATH" STUB_CLOCK= KENDEX_GITHUB_AUTH_TIMEOUT=1 STUB_GH_AUTH_STATUS_SLEEP=1 .agents/skills/orch/scripts/ci-wait 1 1 30 --json' bash "$TMP_ROOT/repo" "$TMP_ROOT/bin" 2>"$RUN/stderr")
+# The 6s bound is a net under ci-wait's own KENDEX_GITHUB_AUTH_TIMEOUT, which
+# is what the assertion reads. macOS ships no timeout(1) — it is coreutils —
+# so on a host without one the case runs unbounded and a regression that did
+# hang would be caught by the job's timeout-minutes instead of here.
+bounded6() { # CMD... — run CMD under a 6s bound where the host has one
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 6s "$@"
+  else
+    "$@"
+  fi
+}
+OUT=$(bounded6 bash -c 'cd "$1" && PATH="$2:$PATH" STUB_CLOCK= KENDEX_GITHUB_AUTH_TIMEOUT=1 STUB_GH_AUTH_STATUS_SLEEP=1 .agents/skills/orch/scripts/ci-wait 1 1 30 --json' bash "$TMP_ROOT/repo" "$TMP_ROOT/bin" 2>"$RUN/stderr")
 RC=$?
 set -e
 assert_eq "$(observe "rc=3 status=error")" "rc=3 status=error" "a hanging keyring auth is a bounded exit 3, not a hang" "$RUN/stderr"

--- a/skills/orch/tests/container_close.sh
+++ b/skills/orch/tests/container_close.sh
@@ -40,7 +40,16 @@ esac
 SH
 chmod +x "$TMP_ROOT/bin/gh"
 
-REAL_FLOCK="$(command -v flock)"
+# container-close refuses to run without flock(1), so this suite cannot
+# execute on a host that has none. It says so and reds: under `set -e` the
+# bare `command -v` below died here with no output at all, which reads from
+# the outside like a suite that ran and printed nothing. macOS ships no
+# flock — it is util-linux — so a stock Mac reds here; the macOS CI leg
+# supplies flock for exactly this reason.
+if ! REAL_FLOCK="$(command -v flock)"; then
+  printf 'FAIL: container-close requires flock(1) and this host has none, so nothing below could run. Install flock (util-linux) and re-run.\n' >&2
+  exit 1
+fi
 cat > "$TMP_ROOT/bin/flock" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail

--- a/skills/orch/tests/lib/md.sh
+++ b/skills/orch/tests/lib/md.sh
@@ -287,8 +287,12 @@ _md_body() {
   if [ "$1" = fenced ]; then
     local keep
     keep="$(_md_fenced "$2" | cut -f2)"
-    _md_lines "$2" "$3" | awk -F'\t' -v k="$keep" '
-      BEGIN { n = split(k, a, "\n"); for (i = 1; i <= n; i++) if (a[i] != "") keep[a[i]] = 1 }
+    # The list crosses in the environment, never through -v: it holds one line
+    # number per line, and BWK awk — the awk macOS ships — refuses a -v value
+    # carrying a newline outright ("awk: newline in string"), so every fenced
+    # rule died there. ENVIRON is read at runtime and takes the value whole.
+    _md_lines "$2" "$3" | md_keep="$keep" awk -F'\t' '
+      BEGIN { n = split(ENVIRON["md_keep"], a, "\n"); for (i = 1; i <= n; i++) if (a[i] != "") keep[a[i]] = 1 }
       ($1 in keep) { print }
     '
   else

--- a/skills/orch/tests/lib/waiter-assertions.sh
+++ b/skills/orch/tests/lib/waiter-assertions.sh
@@ -72,3 +72,19 @@ assert_not_contains() {
     printf '  ok    %s\n' "$name"
   fi
 }
+
+# touch_epoch EPOCH PATH — set PATH's mtime to EPOCH seconds.
+#
+# `touch -d @EPOCH` is GNU; BSD touch reads -d as an ISO-8601 stamp and
+# refuses the @ form ("out of range or illegal time specification"). Both take
+# a zoned ISO stamp through -d, so the epoch is rendered to one, in UTC, and
+# the trailing Z is what keeps the mtime exact on either — `-t` would be read
+# in the machine's local zone and shift the mtime by its UTC offset. GNU date
+# prints the stamp from `-d @EPOCH`, BSD date from `-r EPOCH`; the same two-arm
+# ladder as scripts/lib/date-ladder.sh, which these suites do not source.
+touch_epoch() {
+  local epoch="$1" path="$2" stamp
+  stamp="$(date -u -d "@$epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -r "$epoch" +%Y-%m-%dT%H:%M:%SZ)" || return 1
+  touch -d "$stamp" "$path"
+}

--- a/skills/orch/tests/open-terminal-claude-handoff.sh
+++ b/skills/orch/tests/open-terminal-claude-handoff.sh
@@ -354,7 +354,13 @@ if wait_capture; then
   printf '#!/usr/bin/env bash\nprintf '"'"'%%s\\n'"'"' "$@" > "$OT_ARGV_CAPTURE"\n' > "$BIN/claude"
   chmod +x "$BIN/claude"
   cmd="$(cat "$CAP")"
-  (cd "$globbait" && OT_ARGV_CAPTURE="$TMP_ROOT/argv" PATH="$BIN:$PATH" bash -lc "${cmd##*&& }") >/dev/null 2>&1 || true
+  # PATH is set INSIDE the login shell, not only inherited by it: macOS
+  # /etc/profile runs path_helper, which rebuilds PATH from /etc/paths and
+  # /etc/paths.d and leaves the inherited entries behind them, so an inherited
+  # $BIN prefix does not survive `bash -lc` and a real claude on the host's
+  # login PATH would answer instead of the stub. The launcher still runs the
+  # rendered line through a login shell, which is the shape under test.
+  (cd "$globbait" && OT_ARGV_CAPTURE="$TMP_ROOT/argv" bash -lc "PATH=\"$BIN:\$PATH\"; ${cmd##*&& }") >/dev/null 2>&1 || true
   rm -f "$BIN/claude"
   assert_eq "$(tr '\n' ' ' < "$TMP_ROOT/argv" 2>/dev/null || echo unrun)" "-n CC-737 --model opus[1m] --dangerously-skip-permissions $BRIEF " \
     "the argv claude receives is the flags as given: a same-named file cannot rewrite the model id"

--- a/skills/orch/tests/open-terminal-mode.sh
+++ b/skills/orch/tests/open-terminal-mode.sh
@@ -280,6 +280,46 @@ done <<<"$ARM_ROWS"
 RUN_PATH=""
 RUN_TERMINAL="term"
 
+echo "=== the GUI launch happens on a host with no setsid ==="
+
+# open_gui detaches the window so it outlives this script. setsid is util-linux
+# and stock macOS has none, and the launch line sends its own stderr to
+# /dev/null — so a `setsid: command not found` was swallowed there, nothing
+# opened, and open-terminal still printed "Opened terminal". nohup is the arm
+# every platform has. The probe PATH is the real one minus setsid rather than a
+# list of the tools open_gui uses, so it stays true as open_gui changes.
+NO_SETSID_PATH="$TMP_ROOT/path-without-setsid"
+mkdir -p "$NO_SETSID_PATH"
+(
+  IFS=:
+  for d in $PATH; do
+    [[ -d "$d" ]] || continue
+    ln -s "$d"/* "$NO_SETSID_PATH"/ 2>/dev/null || true
+  done
+)
+rm -f -- "$NO_SETSID_PATH/setsid"
+# Without this the case passes vacuously through the setsid branch.
+if PATH="$NO_SETSID_PATH" command -v setsid >/dev/null 2>&1; then
+  bad "the probe PATH resolves no setsid" "setsid is still reachable"
+else
+  ok "the probe PATH resolves no setsid"
+fi
+
+RUN_PATH="$BIN:$NO_SETSID_PATH"
+run "nosetsid" "$REPO/scripts/open-terminal" out CC-1
+assert_eq "$RC" "0" "no setsid: the GUI launch is reported as successful"
+assert_contains "$TERM_LOG_TEXT" "term -e bash -lc" "no setsid: a GUI terminal really opens"
+
+# The control: with the nohup arm deleted the same run opens nothing, so the
+# assertion above is about the arm and not about a launch that would happen
+# either way.
+mutate "nosetsid" 's#^    nohup "${launcher\[@\]}" </dev/null >/dev/null 2>&1 &$#    setsid "${launcher[@]}" </dev/null >/dev/null 2>\&1 \&#'
+RUN_PATH="$BIN:$NO_SETSID_PATH"
+run "mut-nosetsid" "$MUTANT_OT" out CC-1
+assert_eq "$TERM_LOG_TEXT" "" "control: without the nohup arm no GUI terminal opens on a setsid-less host"
+RUN_PATH=""
+RUN_TERMINAL="term"
+
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/orch/tests/queue_wait.sh
+++ b/skills/orch/tests/queue_wait.sh
@@ -261,10 +261,22 @@ am_errs_on_200='{"data":{"disablePullRequestAutoMerge":null},"errors":[{"message
 # merge-group head commit, and REST check-runs bodies for that commit.
 q_in_queue_head='{"data":{"repository":{"pullRequest":{"id":"PR_node123","isInMergeQueue":true,"mergeQueueEntry":{"state":"AWAITING_CHECKS","position":1,"headCommit":{"oid":"aaa111"}},"autoMergeRequest":{"enabledAt":"2026-07-24T09:00:00Z"}}}}}'
 # checkruns_body <completed> <in_progress>
+# Counted loops, never `seq 1 "$n"`: BSD seq walks toward its last value, so
+# `seq 1 0` prints `1` and `0` where GNU seq prints nothing. A body asked for
+# zero in-progress runs came back with two of them on macOS, and every case
+# reading a flat, idle queue as stalled read it as still progressing instead.
 checkruns_body() {
   local done="$1" pending="$2" runs="" i
-  for i in $(seq 1 "$done"); do runs+='{"name":"c'"$i"'","status":"completed","conclusion":"success"},'; done
-  for i in $(seq 1 "$pending"); do runs+='{"name":"p'"$i"'","status":"in_progress","conclusion":null},'; done
+  i=0
+  while [ "$i" -lt "$done" ]; do
+    i=$((i + 1))
+    runs+='{"name":"c'"$i"'","status":"completed","conclusion":"success"},'
+  done
+  i=0
+  while [ "$i" -lt "$pending" ]; do
+    i=$((i + 1))
+    runs+='{"name":"p'"$i"'","status":"in_progress","conclusion":null},'
+  done
   printf '{"total_count":%d,"check_runs":[%s]}' "$((done + pending))" "${runs%,}"
 }
 

--- a/skills/orch/tests/review_artifact_check.sh
+++ b/skills/orch/tests/review_artifact_check.sh
@@ -96,7 +96,7 @@ stage() {
       none) continue ;;
       *) echo "stage: unknown time $when in $item" >&2; exit 1 ;;
     esac
-    touch -d "@$mtime" "$WT/tmp/$file.json"
+    touch_epoch "$mtime" "$WT/tmp/$file.json"
   done
 }
 

--- a/skills/orch/tests/review_artifact_check_measurement.sh
+++ b/skills/orch/tests/review_artifact_check_measurement.sh
@@ -157,7 +157,7 @@ glob_table() {
         before) mtime=$BEFORE ;; after) mtime=$AFTER ;; later) mtime=$LATER ;;
         *) echo "glob_table: unknown time $when in $item" >&2; exit 1 ;;
       esac
-      touch -d "@$mtime" "$WT/tmp/review-r-$file.json"
+      touch_epoch "$mtime" "$WT/tmp/review-r-$file.json"
     done
     case "$which" in
       real) run_check %W r %D ;;

--- a/skills/orch/tests/workflow-state-flockless.sh
+++ b/skills/orch/tests/workflow-state-flockless.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# workflow-state's writes on a host with no flock(1).
+#
+# Every mutating subcommand runs its read-decide-write under a lock, because
+# two `set` calls racing on one state file both read, both write, and the
+# later write drops the earlier transition. flock is util-linux and stock
+# macOS ships none, where the bare `flock -w 10 200` this used to run resolved
+# to nothing, the `||` arm fired, and every write refused with "could not
+# acquire lock" — so on that platform workflow-state did not work at all.
+# scripts/lib/file-lock.sh carries the lock with a mkdir mutex there.
+#
+# The probe PATH is the real one minus flock rather than a list of the tools
+# workflow-state uses, so it stays true as the script changes.
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/lib/git-env.sh"
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf -- "${TMP_ROOT:?}"' EXIT
+
+WS="$REPO_ROOT/skills/orch/scripts/workflow-state"
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+
+NOFLOCK="$TMP_ROOT/path-without-flock"
+mkdir -p "$NOFLOCK"
+(
+  IFS=:
+  for d in $PATH; do
+    [[ -d "$d" ]] || continue
+    ln -s "$d"/* "$NOFLOCK"/ 2>/dev/null || true
+  done
+)
+rm -f -- "$NOFLOCK/flock"
+# Without this every case below passes vacuously through the flock branch.
+if PATH="$NOFLOCK" command -v flock >/dev/null 2>&1; then
+  bad "the probe PATH resolves no flock" "flock is still reachable"
+else
+  ok "the probe PATH resolves no flock"
+fi
+
+echo
+echo "--- workflow-state with no flock on PATH ---"
+
+SD="$TMP_ROOT/state"
+PATH="$NOFLOCK" "$WS" --state-dir "$SD" init KEN-LOCK --worktree "$REPO_ROOT" --branch ken-lock >/dev/null
+rc=0
+PATH="$NOFLOCK" "$WS" --state-dir "$SD" set KEN-LOCK phase implementing >/dev/null 2>"$TMP_ROOT/set.err" || rc=$?
+[[ "$rc" -eq 0 ]] && ok "a set lands with no flock on PATH" \
+  || bad "a set lands with no flock on PATH" "rc=$rc $(cat "$TMP_ROOT/set.err")"
+got="$(PATH="$NOFLOCK" "$WS" --state-dir "$SD" get KEN-LOCK .phase)"
+[[ "$got" == "implementing" ]] && ok "and the value it wrote is the one read back" \
+  || bad "and the value it wrote is the one read back" "got=$got"
+
+# The mutex directory is released, not leaked: a second write on the same file
+# would otherwise wait its whole timeout and then refuse.
+rc=0
+PATH="$NOFLOCK" "$WS" --state-dir "$SD" set KEN-LOCK phase reviewing >/dev/null 2>"$TMP_ROOT/set2.err" || rc=$?
+[[ "$rc" -eq 0 ]] && ok "a second write is not blocked by the first one's mutex" \
+  || bad "a second write is not blocked by the first one's mutex" "rc=$rc $(cat "$TMP_ROOT/set2.err")"
+
+# Serialization is the point of the lock, so it is measured: two appends racing
+# on one file must both survive. Without one the loser's element is lost to the
+# winner's read-modify-write.
+RACE_SD="$TMP_ROOT/race"
+PATH="$NOFLOCK" "$WS" --state-dir "$RACE_SD" init KEN-RACE --worktree "$REPO_ROOT" --branch ken-race >/dev/null
+GO="$TMP_ROOT/go"
+for racer in 1 2; do
+  (
+    until [[ -e "$GO" ]]; do :; done
+    PATH="$NOFLOCK" "$WS" --state-dir "$RACE_SD" append KEN-RACE fixed_items "item-$racer" >/dev/null 2>&1
+  ) &
+done
+sleep 0.4
+: >"$GO"
+wait
+count="$(PATH="$NOFLOCK" "$WS" --state-dir "$RACE_SD" get KEN-RACE '.fixed_items | length')"
+[[ "$count" == "2" ]] && ok "two racing appends both survive under the mkdir mutex" \
+  || bad "two racing appends both survive under the mkdir mutex" "count=$count"
+
+# The control: a copy whose lock helper only ever calls flock must refuse every
+# write on this PATH, so the assertions above are about the mutex arm and not
+# about a write that would land unlocked anyway.
+BROKEN="$TMP_ROOT/broken"
+mkdir -p "$BROKEN/scripts/lib"
+cp "$WS" "$BROKEN/scripts/workflow-state"
+cp "$REPO_ROOT"/skills/orch/scripts/lib/*.sh "$BROKEN/scripts/lib/"
+chmod +x "$BROKEN/scripts/workflow-state"
+perl -pi -e 's/^  if command -v flock >\/dev\/null 2>&1; then$/  if true; then/' "$BROKEN/scripts/lib/file-lock.sh"
+if grep -q '^  if true; then$' "$BROKEN/scripts/lib/file-lock.sh"; then
+  ok "control: the mutant really removes the mkdir arm"
+else
+  bad "control: the mutant really removes the mkdir arm" "file-lock.sh unchanged"
+fi
+BSD="$TMP_ROOT/broken-state"
+PATH="$NOFLOCK" "$BROKEN/scripts/workflow-state" --state-dir "$BSD" init KEN-BROKEN --worktree "$REPO_ROOT" --branch ken-broken >/dev/null 2>&1 || true
+rc=0
+PATH="$NOFLOCK" "$BROKEN/scripts/workflow-state" --state-dir "$BSD" set KEN-BROKEN phase implementing >/dev/null 2>&1 || rc=$?
+[[ "$rc" -ne 0 ]] && ok "control: with only the flock arm every write refuses on this PATH" \
+  || bad "control: with only the flock arm every write refuses on this PATH" "rc=$rc"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/orch/tests/worktree_push.sh
+++ b/skills/orch/tests/worktree_push.sh
@@ -469,7 +469,10 @@ printf '%s\n' '{"issue_id":"KEN-9","worktree":"","fixed_items":[],"pr_comment_re
 STUB_ARGS_LOG="$mismatch_args_log" STUB_PUSH_STDOUT="→ pushed" run_push "$work" --worktree "$wt" --issue KEN-1
 assert_eq "$RUN_RC" "1" "a state recording another issue id refuses"
 assert_contains "$(cat "$run_err")" "refusing to rewrite another issue" "the issue mismatch is named"
-assert_eq "$(wc -l <"$mismatch_args_log")" "0" "the push never ran against a mismatched issue id"
+# BSD wc right-aligns its count in a fixed-width field, so `$(wc -l <f)` reads
+# "       0" on macOS and "0" on GNU; every count below is compared as a
+# string, so the blanks come off at the measurement.
+assert_eq "$(wc -l <"$mismatch_args_log" | tr -d ' ')" "0" "the push never ran against a mismatched issue id"
 
 other_wt="$TMP_ROOT/other-wt"
 mkdir -p "$other_wt"
@@ -480,7 +483,7 @@ rm -rf "$work" && mkdir -p "$work"
 STUB_ARGS_LOG="$mismatch_args_log" STUB_PUSH_STDOUT="→ pushed" run_push "$work" --worktree "$wt" --issue KEN-1
 assert_eq "$RUN_RC" "1" "a state recording another worktree refuses"
 assert_contains "$(cat "$run_err")" "refusing to rewrite another worktree" "the worktree mismatch is named"
-assert_eq "$(wc -l <"$mismatch_args_log")" "0" "the push never ran against a mismatched worktree"
+assert_eq "$(wc -l <"$mismatch_args_log" | tr -d ' ')" "0" "the push never ran against a mismatched worktree"
 
 echo
 echo "=== a dying stdout cannot lose the map ==="
@@ -563,7 +566,7 @@ numeric_args_log="$TMP_ROOT/numeric-args.log"
 STUB_ARGS_LOG="$numeric_args_log" STUB_PUSH_STDOUT="rebase-map: $numeric_old $numeric_new" \
   run_push "$work" --worktree "$wt" --issue 7
 assert_eq "$RUN_RC" "1" "a bare-numeric issue whose state does not exist fails the landed push"
-assert_eq "$(wc -l <"$numeric_args_log")" "1" \
+assert_eq "$(wc -l <"$numeric_args_log" | tr -d ' ')" "1" \
   "the push itself ran — the failure is reconciliation, not a pre-push refusal"
 assert_contains "$(cat "$run_err")" "State file not found: tmp/workflow-state-7.json" \
   "the failure names the exact key it resolved, not the issue-7 file"

--- a/skills/review-gate/tests/predicate-re2-engine.test.sh
+++ b/skills/review-gate/tests/predicate-re2-engine.test.sh
@@ -163,10 +163,12 @@ else
   bad "the shipped program runs under gh's RE2 engine" "exit $re2_rc: $(head -1 "$work/re2.err")"
 fi
 
-if [ "$(wc -l <"$work/re2.out")" = "$replies" ]; then
+# BSD wc right-aligns its count in a fixed-width field, so the blanks come off
+# before this string comparison.
+if [ "$(wc -l <"$work/re2.out" | tr -d ' ')" = "$replies" ]; then
   ok "RE2 answered every one of the $replies fixture replies"
 else
-  bad "RE2 answered every one of the $replies fixture replies" "$(wc -l <"$work/re2.out") verdicts"
+  bad "RE2 answered every one of the $replies fixture replies" "$(wc -l <"$work/re2.out" | tr -d ' ') verdicts"
 fi
 
 # THE assertion, in a function, because control three has to be able to kill

--- a/skills/second-opinion/scripts/second-opinion
+++ b/skills/second-opinion/scripts/second-opinion
@@ -289,34 +289,6 @@ if ! $FOREGROUND_CAP_WAS_IN_CALLER_ENV && [[ -n "${SECOND_OPINION_FOREGROUND_CAP
 fi
 source "$SCRIPT_DIR/second-opinion-runtime"
 second_opinion_runtime_setup
-# --- System temp --------------------------------------------------------------
-# Every system-temp allocation goes through these two, with an explicit
-# template rooted at $TMPDIR.
-#
-# A bare `mktemp` reads $TMPDIR only on GNU. BSD mktemp — the one macOS ships —
-# ignores it and allocates under the per-user directory the OS names
-# (_CS_DARWIN_USER_TEMP_DIR), so an operator who set TMPDIR to bound this run's
-# temp files got them somewhere else entirely, and the fallbacks below landed
-# nowhere the caller named. A trailing slash comes off first: macOS sets TMPDIR
-# with one, and `$TMPDIR/x` would carry a `//` into every path this prints.
-# The trailing slash comes off because macOS sets TMPDIR with one, and a
-# relative root is prefixed with `./` so a TMPDIR named `-dashtmp` cannot reach
-# mktemp — or the rm in a cleanup trap — as an option. `--` is not the answer
-# here: mktemp's support for it is not uniform across the BSD/macOS target,
-# which is why artifact_file() below leans on an absolute home instead.
-so_tmp_root() {
-  local root="${TMPDIR:-/tmp}"
-  root="${root%/}"
-  case "$root" in
-    "") root="/" ;;
-    /*) ;;
-    *) root="./$root" ;;
-  esac
-  printf '%s' "$root"
-}
-so_tmpfile() { mktemp "$(so_tmp_root)/second-opinion.XXXXXX"; }
-so_tmpdir() { mktemp -d "$(so_tmp_root)/second-opinion.XXXXXX"; }
-
 # --- Defaults -----------------------------------------------------------------
 MODE=""
 PROMPT_FILE=""

--- a/skills/second-opinion/scripts/second-opinion
+++ b/skills/second-opinion/scripts/second-opinion
@@ -289,6 +289,34 @@ if ! $FOREGROUND_CAP_WAS_IN_CALLER_ENV && [[ -n "${SECOND_OPINION_FOREGROUND_CAP
 fi
 source "$SCRIPT_DIR/second-opinion-runtime"
 second_opinion_runtime_setup
+# --- System temp --------------------------------------------------------------
+# Every system-temp allocation goes through these two, with an explicit
+# template rooted at $TMPDIR.
+#
+# A bare `mktemp` reads $TMPDIR only on GNU. BSD mktemp — the one macOS ships —
+# ignores it and allocates under the per-user directory the OS names
+# (_CS_DARWIN_USER_TEMP_DIR), so an operator who set TMPDIR to bound this run's
+# temp files got them somewhere else entirely, and the fallbacks below landed
+# nowhere the caller named. A trailing slash comes off first: macOS sets TMPDIR
+# with one, and `$TMPDIR/x` would carry a `//` into every path this prints.
+# The trailing slash comes off because macOS sets TMPDIR with one, and a
+# relative root is prefixed with `./` so a TMPDIR named `-dashtmp` cannot reach
+# mktemp — or the rm in a cleanup trap — as an option. `--` is not the answer
+# here: mktemp's support for it is not uniform across the BSD/macOS target,
+# which is why artifact_file() below leans on an absolute home instead.
+so_tmp_root() {
+  local root="${TMPDIR:-/tmp}"
+  root="${root%/}"
+  case "$root" in
+    "") root="/" ;;
+    /*) ;;
+    *) root="./$root" ;;
+  esac
+  printf '%s' "$root"
+}
+so_tmpfile() { mktemp "$(so_tmp_root)/second-opinion.XXXXXX"; }
+so_tmpdir() { mktemp -d "$(so_tmp_root)/second-opinion.XXXXXX"; }
+
 # --- Defaults -----------------------------------------------------------------
 MODE=""
 PROMPT_FILE=""
@@ -1392,7 +1420,7 @@ artifact_file() {
     # way to report — losing both the record AND its documented 4/5 exit class.
     # A record is a diagnostic: leaving ARTIFACT_PATH empty lets the caller say
     # so inline and keep the classification.
-    ARTIFACT_PATH=$(mktemp 2>/dev/null) || ARTIFACT_PATH=""
+    ARTIFACT_PATH=$(so_tmpfile 2>/dev/null) || ARTIFACT_PATH=""
     if [[ -n "$ARTIFACT_PATH" ]]; then
       echo "→ record kept in system temp instead: $ARTIFACT_PATH" >&2
     else
@@ -1495,7 +1523,7 @@ derive_review_scope() {
   REVIEW_BRANCH=$(git -C "$cwd" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 
   local git_err diff_files
-  git_err=$(mktemp)
+  git_err=$(so_tmpfile)
   # shellcheck disable=SC2086
   # core.quotePath=false keeps non-ASCII path bytes literal — the default
   # C-quoting ("services/\303\251/…") would break the nested-AGENTS ancestor
@@ -1742,7 +1770,7 @@ if $MULTI_LANE; then
   # this tool owns. And the parent holds each lane's review in memory from the
   # moment that lane is reaped, so nothing it still needs is on disk after the
   # reap either.
-  LANE_TMP_DIR=$(mktemp -d)
+  LANE_TMP_DIR=$(so_tmpdir)
   LANE_TMP_FILES=()
   LANE_PIDS=()
   # On any exit — including INT/TERM — kill still-running lane children before
@@ -1823,7 +1851,7 @@ if $MULTI_LANE; then
       # Placement can never decide whether the review happens, so a lane with no
       # home falls back to a temp file — named on stderr above, so an operator
       # knows that lane traded the home's durability for a temp one.
-      [[ -n "$lane_out" ]] || lane_out=$(mktemp)
+      [[ -n "$lane_out" ]] || lane_out=$(so_tmpfile)
       LANE_TMP_FILES+=("$lane_out")
     fi
     lane_err="$LANE_TMP_DIR/lane-${lane}.stderr"
@@ -2176,14 +2204,14 @@ if [[ -z "$PROMPT" ]]; then
 fi
 
 # Write prompt to temp file — use printf to avoid echo interpreting leading dashes
-PROMPT_TMP=$(mktemp)
+PROMPT_TMP=$(so_tmpfile)
 # Guarded for the same reason as cleanup_lanes: an EXIT trap whose last command
 # fails REPLACES the run's exit status, so a temp directory that turned
 # read-only under the run would rewrite a documented 4/5 into rm's status.
 trap 'rm -f -- "$PROMPT_TMP" || true' EXIT
 printf '%s\n' "$PROMPT" > "$PROMPT_TMP"
 
-STDERR_TMP=$(mktemp)
+STDERR_TMP=$(so_tmpfile)
 # RETRY_PROMPT_TMP is created only when extraction fails and a retry runs; keep
 # it in the cleanup trap. Sidecar files written by preserve_raw_response and
 # preserve_raw_and_fail are deliberately NOT tracked here — they are the durable
@@ -2565,7 +2593,7 @@ if [[ "$MODE" == "review" || "$MODE" == "audit" ]]; then
     # Persist the raw first response now, before the retry outcome is known —
     # a successful reformat must not erase the original.
     preserve_raw_response "$RESULT"
-    RETRY_PROMPT_TMP=$(mktemp)
+    RETRY_PROMPT_TMP=$(so_tmpfile)
     if [[ -n "$RETRY_PROBLEM" ]]; then
       build_retry_prompt "$RESULT" "$RETRY_PROBLEM" > "$RETRY_PROMPT_TMP"
     else

--- a/skills/second-opinion/scripts/second-opinion-runtime
+++ b/skills/second-opinion/scripts/second-opinion-runtime
@@ -135,7 +135,13 @@ create_runtime_dir() {
       dir=""
     }
   fi
-  [[ -n "$dir" ]] || dir=$(mktemp -d 2>/dev/null) || die "cannot create runtime directory"
+  # An explicit template rooted at $TMPDIR: a bare `mktemp -d` reads TMPDIR
+  # only on GNU, and BSD mktemp allocates under the OS's per-user temp
+  # directory instead, so this fallback ignored the caller's TMPDIR on macOS.
+  runtime_tmp_root="${TMPDIR:-/tmp}"
+  runtime_tmp_root="${runtime_tmp_root%/}"
+  case "$runtime_tmp_root" in "") runtime_tmp_root="/" ;; /*) ;; *) runtime_tmp_root="./$runtime_tmp_root" ;; esac
+  [[ -n "$dir" ]] || dir=$(mktemp -d "$runtime_tmp_root/second-opinion-runtime.XXXXXX" 2>/dev/null) || die "cannot create runtime directory"
   chmod 700 "$dir" || die "cannot secure runtime directory: $dir"
   printf '%s\n' "$dir"
 }

--- a/skills/second-opinion/scripts/second-opinion-runtime
+++ b/skills/second-opinion/scripts/second-opinion-runtime
@@ -10,6 +10,31 @@ LAUNCH_WORKER_PID=""
 LAUNCH_RUNTIME_DIR=""
 RUNTIME_SELF="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)/${BASH_SOURCE[0]##*/}"
 die() { echo "second-opinion-runtime: $1" >&2; exit 1; }
+
+# The system temp directory this run allocates under, as a path mktemp reads
+# as a path. Defined here because this file is SOURCED by second-opinion, so
+# both the detached runtime directory and the command's own temp files come
+# from one rule.
+#
+# A bare `mktemp` reads $TMPDIR only on GNU. BSD mktemp — the one macOS ships —
+# ignores it and allocates under the per-user directory the OS names
+# (_CS_DARWIN_USER_TEMP_DIR), so an operator who set TMPDIR to bound this run
+# got its files somewhere else entirely. The trailing slash comes off because
+# macOS sets TMPDIR with one, and a relative root is prefixed with `./` so a
+# TMPDIR named `-dashtmp` cannot reach mktemp — or the rm in a cleanup trap —
+# as an option.
+so_tmp_root() {
+  local root="${TMPDIR:-/tmp}"
+  root="${root%/}"
+  case "$root" in
+    "") root="/" ;;
+    /*) ;;
+    *) root="./$root" ;;
+  esac
+  printf '%s' "$root"
+}
+so_tmpfile() { mktemp "$(so_tmp_root)/second-opinion.XXXXXX"; }
+so_tmpdir() { mktemp -d "$(so_tmp_root)/second-opinion.XXXXXX"; }
 runtime_dir_valid() { [[ -d "$1" && ! -L "$1" ]]; }
 validate_runtime_dir() {
   runtime_dir_valid "$1" || die "runtime directory is missing, unsafe, or changed: $1"
@@ -138,10 +163,7 @@ create_runtime_dir() {
   # An explicit template rooted at $TMPDIR: a bare `mktemp -d` reads TMPDIR
   # only on GNU, and BSD mktemp allocates under the OS's per-user temp
   # directory instead, so this fallback ignored the caller's TMPDIR on macOS.
-  runtime_tmp_root="${TMPDIR:-/tmp}"
-  runtime_tmp_root="${runtime_tmp_root%/}"
-  case "$runtime_tmp_root" in "") runtime_tmp_root="/" ;; /*) ;; *) runtime_tmp_root="./$runtime_tmp_root" ;; esac
-  [[ -n "$dir" ]] || dir=$(mktemp -d "$runtime_tmp_root/second-opinion-runtime.XXXXXX" 2>/dev/null) || die "cannot create runtime directory"
+  [[ -n "$dir" ]] || dir=$(mktemp -d "$(so_tmp_root)/second-opinion-runtime.XXXXXX" 2>/dev/null) || die "cannot create runtime directory"
   chmod 700 "$dir" || die "cannot secure runtime directory: $dir"
   printf '%s\n' "$dir"
 }

--- a/skills/second-opinion/tests/lane-scratch-durability.test.sh
+++ b/skills/second-opinion/tests/lane-scratch-durability.test.sh
@@ -453,7 +453,13 @@ mkdir -p -- "$2/$3.cache"
 printf 'session\n' > "$2/$3.session"
 if [[ $# -ge 4 ]]; then
   printf 'reappeared\n' > "$4"
-  chmod 644 -- "$4"
+  # `--` before the mode, never after it: getopt(3) stops at the first
+  # non-option argument, which for chmod is the mode, so a `--` behind it is a
+  # file operand nobody has. BSD chmod fails on that line, this stub exits
+  # non-zero under set -e, and the lane reads as a failed CLI. The shipped
+  # installer takes the same shape; skills/commit-guards/tests/bsd-argv-install.test.sh
+  # runs the rule as a program.
+  chmod -- 644 "$4"
 fi
 cat "$1"
 SH

--- a/skills/second-opinion/tests/timestamp-stamp.test.sh
+++ b/skills/second-opinion/tests/timestamp-stamp.test.sh
@@ -140,7 +140,12 @@ assert_ne "$written_ts" "$BOGUS_TS" "written timestamp is NOT the model-supplied
 
 # The written value must be the wrapper's own wall clock: parse it to epoch and
 # confirm it falls within the [before, after] window of the run.
-written_epoch="$(date -u -d "$written_ts" +%s 2>/dev/null || echo "")"
+# `date -d` is GNU; BSD date parses an explicit format with -j -f, and the -u
+# is load-bearing there because the trailing Z is a LITERAL in the format
+# string — without it BSD date reads the stamp in the machine's local zone and
+# the window check below shifts by the UTC offset.
+written_epoch="$(date -u -d "$written_ts" +%s 2>/dev/null \
+  || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$written_ts" +%s 2>/dev/null || echo "")"
 if [[ -z "$written_epoch" ]]; then
   fail "written timestamp parses as an ISO-8601 UTC time (got '$written_ts')"
 elif (( written_epoch >= before && written_epoch <= after )); then

--- a/skills/worktree/tests/worktree_session_guard_lifecycle.sh
+++ b/skills/worktree/tests/worktree_session_guard_lifecycle.sh
@@ -30,9 +30,14 @@ WORKTREE_PACKAGE_DIR="$(cd "$TEST_DIR/.." && pwd)"
 WORKTREE_SCRIPT="$WORKTREE_PACKAGE_DIR/scripts/worktree"
 GUARD_SCRIPT="$WORKTREE_PACKAGE_DIR/scripts/worktree-session-guard"
 
+# A suite that cannot execute on this host reds. Skipping into a green would
+# report that the lifecycle holds on a platform where nothing here ran, which
+# is the one answer a second platform must never give. macOS ships no flock —
+# it is util-linux — so a stock Mac reds here and says what to install; the
+# macOS CI leg supplies flock for exactly this reason.
 if ! command -v flock >/dev/null 2>&1; then
-  printf 'SKIP: worktree lifecycle integration needs flock(1) for the per-issue claim lock, which is not on PATH\n' >&2
-  exit 0
+  printf 'FAIL: worktree lifecycle integration needs flock(1) for the per-issue claim lock, and this host has none. `create` refuses without it, so nothing below could run. Install flock (util-linux) and re-run.\n' >&2
+  exit 1
 fi
 
 TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"

--- a/tools/tests/bash32-lint.test.sh
+++ b/tools/tests/bash32-lint.test.sh
@@ -74,12 +74,14 @@ fi
 # skills/*/scripts and skills/*/tests is scanned or named in one of the
 # lint's exception lists.
 # Read out of the lint rather than restated here — a second copy of the
-# exceptions is the duplication this whole change removes.
+# exceptions is the duplication this whole change removes. -E, because `\|`
+# alternation inside `\(...\)` is a GNU BRE extension: BSD sed reads it as a
+# literal bar, matches nothing, and leaves the roster coverage unproven.
 NL='
 '
 declared=""
 status=0
-declared="$(sed -n 's#^NO_\(SCAN\|SHELL\)="\(.*\)"$#\2#p' "$LINT" | tr ' ' '\n')" || status=$?
+declared="$(sed -nE 's#^NO_(SCAN|SHELL)="(.*)"$#\2#p' "$LINT" | tr ' ' '\n')" || status=$?
 if [ "$status" -ne 0 ] || [ -z "$declared" ]; then
   bad "the lint's exception lists could not be read, so roster coverage is unproven"
 else

--- a/tools/tests/guard.test.sh
+++ b/tools/tests/guard.test.sh
@@ -48,9 +48,12 @@ printf '%s\n' \
 # and its hand-named roster entries against the repository it runs in, so the
 # fixture derives each rather than copying a list that goes stale with it. An
 # exception directory holds no shell file; a roster one dies without one.
+# -E on the exception read, because `\|` alternation inside `\(...\)` is a GNU
+# BRE extension: BSD sed reads it as a literal bar, so the loop below creates
+# no exception directory and every guard pass dies in the bash32-lint lane.
 while IFS= read -r e; do
   mkdir -p "$R/$e" && printf 'not shell\n' >"$R/$e/README.md"
-done < <(sed -n 's#^NO_\(SCAN\|SHELL\)="\(.*\)"$#\2#p' "$REPO/tools/bash32-lint" | tr ' ' '\n' | grep .)
+done < <(sed -nE 's#^NO_(SCAN|SHELL)="(.*)"$#\2#p' "$REPO/tools/bash32-lint" | tr ' ' '\n' | grep .)
 while IFS= read -r e; do
   mkdir -p "$R/$e" && printf '#!/usr/bin/env bash\necho rostered\n' >"$R/$e/rostered.sh"
 done < <(sed -n 's#^  set -- \(.*\)$#\1#p' "$REPO/tools/bash32-lint" | tr ' ' '\n' | grep -v '[*]')

--- a/tools/tests/release-digests.test.sh
+++ b/tools/tests/release-digests.test.sh
@@ -112,8 +112,18 @@ DOC=$(document x86_64-unknown-linux-gnu)
   ok "the document names the release and the target it was written for" ||
   bad "the document names the release and the target it was written for" "$(cat "$DOC")"
 
-expect_command=$(sha256sum "$DIST/kendex-x86_64-unknown-linux-gnu" | cut -d' ' -f1)
-expect_app=$(sha256sum "$DIST/kendex_9.9.9_amd64.AppImage" | cut -d' ' -f1)
+# The same pick tools/release-digests makes, for the same reason: macOS ships
+# shasum and no sha256sum, so the expectation this suite compares against has
+# to come from whichever the host has.
+sha256() { # FILE — the file's SHA-256 in lowercase hex
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1"
+  else
+    shasum -a 256 "$1"
+  fi | cut -d' ' -f1
+}
+expect_command=$(sha256 "$DIST/kendex-x86_64-unknown-linux-gnu")
+expect_app=$(sha256 "$DIST/kendex_9.9.9_amd64.AppImage")
 [ "$(field command "$DOC")" = "$expect_command" ] && [ "$(field app "$DOC")" = "$expect_app" ] &&
   ok "each digest is plain SHA-256 over the download it names" ||
   bad "each digest is plain SHA-256 over the download it names" "$(cat "$DOC")"
@@ -137,8 +147,8 @@ printf 'a signature' >"$DIST/kendex_9.9.9_x64-setup.exe.sig"
 run x86_64-pc-windows-msvc 9.9.9
 DOC=$(document x86_64-pc-windows-msvc)
 [ "$RC" -eq 0 ] &&
-  [ "$(field command "$DOC")" = "$(sha256sum "$DIST/kendex-x86_64-pc-windows-msvc.exe" | cut -d' ' -f1)" ] &&
-  [ "$(field app "$DOC")" = "$(sha256sum "$DIST/kendex_9.9.9_x64-setup.exe" | cut -d' ' -f1)" ] &&
+  [ "$(field command "$DOC")" = "$(sha256 "$DIST/kendex-x86_64-pc-windows-msvc.exe")" ] &&
+  [ "$(field app "$DOC")" = "$(sha256 "$DIST/kendex_9.9.9_x64-setup.exe")" ] &&
   ok "the Windows lane measures the .exe command and the installer" ||
   bad "the Windows lane measures the .exe command and the installer" "rc=$RC out=$OUT"
 
@@ -151,7 +161,7 @@ printf 'a disk image' >"$DIST/kendex_9.9.9_aarch64.dmg"
 run aarch64-apple-darwin 9.9.9
 DOC=$(document aarch64-apple-darwin)
 [ "$RC" -eq 0 ] &&
-  [ "$(field app "$DOC")" = "$(sha256sum "$DIST/kendex-aarch64-apple-darwin.app.tar.gz" | cut -d' ' -f1)" ] &&
+  [ "$(field app "$DOC")" = "$(sha256 "$DIST/kendex-aarch64-apple-darwin.app.tar.gz")" ] &&
   ok "the macOS lane measures the archive its updater installs, not the dmg" ||
   bad "the macOS lane measures the archive its updater installs, not the dmg" "rc=$RC out=$OUT"
 


### PR DESCRIPTION
Closes KEN-1083.

The macOS leg of `skill-tests.yml` installed the GNU userland before running anything, so what the suites and the shipped scripts do on the userland a Mac actually has was never measured. It is measured now.

## The proof run

A Mac (macOS 26.5.2, arm64) over ssh, `/bin/bash` 3.2.57, `PATH` held to `/usr/bin:/bin:/usr/sbin:/sbin` plus only what the GitHub `macos-latest` image itself ships (`jq`, `node`, `npm`, `python3`, `cargo`, `gh`, `perl`), `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` isolated the way a runner's are. No `flock`, no `setsid`, no `timeout`; BSD `sed`, `grep`, `awk`, `ps`, `wc`, `paste`, `touch`, `date`, `mktemp`.

- **Before:** 65 of 220 shell suites red.
- **After (stock userland, no flock/setsid/timeout at all):** 27 red — 15 worktree suites and `container_close.sh` refusing loudly for want of `flock`, which the `worktree` script and `container-close` both declare as a system dependency and the leg supplies; `run-all.sh` as their aggregate; two second-opinion cases wanting `timeout`, whose site already warns and runs unbounded; four suites fixed after that run and re-verified one by one on the same box (`oversee_watch_usage_limit`, `review_artifact_check_channels`, `worktree_push`, `predicate-re2-engine`); and two that are red on that box before and after this change (below).

## The shape

The leg stops installing GNU `sed`, `grep`, `awk`, `find` and `diff` and asserts macOS's own instead, in both directions — a GNU-only construct reds here, and so does a re-introduced GNU userland. It supplies exactly the four utilities macOS ships no version of: `flock` and `setsid` from util-linux, `timeout` and `sha256sum` from coreutils, each symlinked singly so no `gnubin` directory puts a GNU `cut`, `sort`, `head`, `tr`, `dirname` or `basename` in front of a BSD one.

## Each fix, with the behaviour it answers

| BSD behaviour | Where it bit |
|---|---|
| `\|` alternation inside `\(...\)` is a GNU BRE extension | two sed reads of `tools/bash32-lint`'s exception list matched nothing, so every guard pass died in the bash32-lint lane — **36** red assertions in `tools/tests/guard.test.sh` from one construct |
| BSD sed has no `--` end-of-options; it opens `--` as a second input and exits 1 | `install-git-hooks` read every candidate helper that way, so a helper of ours whose install was gone read as somebody else's file; `preflight` read a runner body the same way |
| BWK awk holds a record as a NUL-terminated C string | the changelog UTF-8 pass never saw a blob's late NUL, measured the short prefix, and reported an unmeasurable file as an over-long entry |
| BWK awk refuses a `-v` value carrying a newline | the orch md lints and every `oversee-watch` lane event died on one |
| macOS has no `setsid` | `open-terminal`'s launch line sent its own stderr to `/dev/null`, so the GUI window never opened and the run said it had; `nohup` carries the detach there |
| macOS has no `flock` | `workflow-state` and `lanes` refused every write on it; they take a mkdir mutex now (`skills/orch/scripts/lib/file-lock.sh`, the `worktree-session-guard` precedent) |
| `xargs -r` is a GNU extension | the decider search already proves its path list non-empty, which is all `-r` guarded |
| BSD `wc` right-aligns its count in a fixed-width field | four github suites compared `$(wc -l <f)` as a string |
| BSD `paste` needs its `-` operand | `branch_size_check.sh` printed usage at seven sites |
| BSD `touch` refuses `-d @EPOCH`; `-t` reads a local stamp | the review-artifact staleness fixtures |
| BSD `date` has no `-d` | `timestamp-stamp.test.sh` |
| BSD `mktemp` with no template ignores `$TMPDIR` | second-opinion's fallback records landed somewhere the caller never named |
| macOS `/etc/profile` runs `path_helper`, leaving an inherited PATH behind the system entries | a stub was shadowed through `bash -lc` in `open-terminal-claude-handoff.sh` |

Two suites that cannot execute without `flock` now **red** rather than skipping into a green (`worktree_session_guard_lifecycle.sh`) or dying silently with no output at all (`container_close.sh`). The `ci-wait` and `release-digests` suites carry `timeout` and `sha256sum` fallbacks.

## Controls

Four, each running the real code under a shim or a PATH farm that reproduces the BSD rule, each with a must-fail mutant verified to red when its fix is reverted:

- `skills/commit-guards/tests/bsd-argv-install.test.sh` — a BSD sed shim; the must-fail restores the `--` operand.
- `skills/commit-guards/tests/bsd-awk-record.test.sh` (new) — an awk shim that truncates a record at its first NUL; the must-fail removes the NUL translation.
- `skills/orch/tests/open-terminal-mode.sh` — a PATH farm minus `setsid`; the must-fail deletes the `nohup` arm.
- `skills/orch/tests/workflow-state-flockless.sh` (new) — a PATH farm minus `flock`, including two racing appends; the must-fail forces the flock arm.

## Not touched by this change

`skills/github/tests/bounded-signal.test.sh` is red on the proof host before and after, and `ps -e`/`-A` behave identically there — the macOS CI leg runs that suite today and is green, so it is a property of that box, not of this diff. `skills/orch/tests/queue_wait.sh` has two wall-clock assertions that read as still-progressing under three concurrent suite runs on one machine. `lane-scratch-durability.test.sh` went from six red assertions to three there. The `worktree` script keeps `flock` as the stated system dependency its SKILL.md already declares; the leg supplies it, so its fifteen suites run in CI and red on a stock Mac rather than skipping.

## Review

One local reviewer round. It caught a blocker I had introduced: the new userland assertion matched the bare word `GNU`, which Apple's own grep banner carries (`grep (BSD grep, GNU compatible)`), so the leg would have exited 1 on every macOS shard before running a suite. It reads the vendor form now and was re-measured on both platforms — clean on BSD, red on GNU. It also found four `wc` sites of the fixed class still open, two comments naming a rule the BSD userland does not actually have (one edit reverted as unnecessary, one comment corrected), and two inaccurate claims in the leg's own comment. All applied.

https://claude.ai/code/session_01UhsuWsPWVgqw7WEjKBTH2p
