### PR TITLE
fix(KEN-1193): a cwd outside a repository refuses instead of exiting 128

### DIFF
--- a/.agents/skills/linear/scripts/lib/cache.sh
+++ b/.agents/skills/linear/scripts/lib/cache.sh
@@ -42,12 +42,26 @@ linear_cache_project_root() {
         return
     fi
 
-    local root
-    root="$(git rev-parse --show-toplevel 2>/dev/null)"
+    # The assignment sits in the condition on purpose (KEN-1193): `git
+    # rev-parse` exits 128 outside a repository, and under `set -e` a bare
+    # assignment carries that status out of the function before this refusal
+    # can print. Each branch above names its own cause, so this one does too.
+    local root=""
+    if ! root="$(git rev-parse --show-toplevel 2>/dev/null)" || [[ -z "$root" ]]; then
+        jq -cn --arg cwd "$PWD" \
+            '{error: ("Could not resolve a cache root: LINEAR_CACHE_ROOT is unset and there is no git repository at: " + $cwd)}' >&2
+        return 1
+    fi
     linear_cache_canonical_existing_dir "$root"
 }
 
-CACHE_PROJECT_ROOT="$(linear_cache_project_root)"
+# In the condition for the same reason (KEN-1193): a bare assignment carries
+# the function's refusal out here, ending the script at that status with the
+# cause on stderr but no exit of this script's own. Every branch above has
+# already said why, so this one adds nothing.
+if ! CACHE_PROJECT_ROOT="$(linear_cache_project_root)"; then
+    exit 1
+fi
 CACHE_DIR="$CACHE_PROJECT_ROOT/.cache/linear"
 
 # The three single-comment helpers below — cache_append_comment,

--- a/.agents/skills/linear/scripts/lib/common.sh
+++ b/.agents/skills/linear/scripts/lib/common.sh
@@ -26,8 +26,19 @@ linear_canonical_existing_dir() {
 source "$_LIB_DIR/bash-version.sh"
 linear_require_supported_bash || exit $?
 
-PROJECT_ROOT_RAW="$(git rev-parse --show-toplevel 2>/dev/null)"
-PROJECT_ROOT="$(linear_canonical_existing_dir "$PROJECT_ROOT_RAW")"
+# Both assignments sit in the condition on purpose (KEN-1193): `git rev-parse`
+# exits 128 outside a repository and linear_canonical_existing_dir returns 1 on
+# a path that is not a directory, and under `set -e` a bare assignment carries
+# either status out before any guard below can print. Every subcommand died at
+# a bare 128 with nothing on stdout or stderr. Everything past this line — the
+# cache, the attachment store, the project settings and .env.local — is read
+# from the repository, so the resolution refuses rather than degrading.
+if ! PROJECT_ROOT_RAW="$(git rev-parse --show-toplevel 2>/dev/null)" \
+    || ! PROJECT_ROOT="$(linear_canonical_existing_dir "$PROJECT_ROOT_RAW")"; then
+    jq -cn --arg cwd "$PWD" \
+        '{error: ("Could not resolve a git repository from: " + $cwd + ". Run linear.sh from a checkout of the repository whose Linear workspace you mean.")}' >&2
+    exit 1
+fi
 unset PROJECT_ROOT_RAW
 
 # First 12 hex chars of sha256 — enough to tell two keys apart in a diagnostic

--- a/.agents/skills/linear/tests/controls/cache-root-git-worktree.control.sh
+++ b/.agents/skills/linear/tests/controls/cache-root-git-worktree.control.sh
@@ -4,5 +4,5 @@
 # follows the link.
 control_expect "logical installed invocation: the missing-cache diagnostic names the physical cache path"
 control_replace scripts/lib/cache.sh 1 \
-    'CACHE_PROJECT_ROOT="$(linear_cache_project_root)"' \
-    'CACHE_PROJECT_ROOT="$PWD"'
+    'if ! CACHE_PROJECT_ROOT="$(linear_cache_project_root)"; then' \
+    'if ! CACHE_PROJECT_ROOT="$PWD"; then'

--- a/.agents/skills/linear/tests/controls/no-repository-refusal.control.sh
+++ b/.agents/skills/linear/tests/controls/no-repository-refusal.control.sh
@@ -1,0 +1,9 @@
+# Take the repository lookup back out of the condition. Outside a repository
+# `git rev-parse` exits 128, and under `set -e` the bare assignment carries
+# that status out before the refusal below can print: the run dies at 128 with
+# nothing on either stream, which is the defect KEN-1193 fixed. The `if false`
+# keeps the continuation line and the refusal block parsing.
+control_expect "a subcommand run outside a git repository exits 1, not git's bare 128"
+control_replace scripts/lib/common.sh 1 \
+    'if ! PROJECT_ROOT_RAW="$(git rev-parse --show-toplevel 2>/dev/null)" \' \
+    'PROJECT_ROOT_RAW="$(git rev-parse --show-toplevel 2>/dev/null)"; if false \'

--- a/.agents/skills/linear/tests/no-repository-refusal.test.sh
+++ b/.agents/skills/linear/tests/no-repository-refusal.test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# lib/common.sh resolves the project root from the current directory, and
+# every subcommand sources it. Outside a repository `git rev-parse` exits 128,
+# and a bare assignment carried that status out under `set -e` before the
+# guard below it could speak: the run died at 128 with nothing on stdout or
+# stderr (KEN-1193). The refusal now names the directory it could not resolve
+# a repository from. Help is answered before the lib is sourced and is held
+# here from the other side, so the refusal cannot creep in front of it.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/assert.sh
+source "$SCRIPT_DIR/lib/assert.sh"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+LINEAR="$SKILL_DIR/scripts/linear.sh"
+assert_tmpdir TMP_ROOT
+
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below back at the real repository and make the fixture read as one.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
+NOREPO="$TMP_ROOT/norepo"
+mkdir -p "$NOREPO"
+# The scratch root is under TMPDIR, which on a developer box can sit inside a
+# checkout; the ceiling stops rev-parse's upward search at the fixture's own
+# parent so "outside a repository" is what the fixture actually is.
+export GIT_CEILING_DIRECTORIES="$TMP_ROOT"
+
+probe_status=0
+probe=$(LC_ALL=C git -C "$NOREPO" rev-parse --show-toplevel 2>&1) || probe_status=$?
+if [[ "$probe_status" -ne 128 || "$probe" != *"not a git repository"* ]]; then
+	assert_stop "the no-repository fixture is outside a git repository" "$probe"
+fi
+assert_eq "the no-repository fixture is outside a git repository" "$probe_status" 128
+
+status=0
+out=$(cd "$NOREPO" && "$LINEAR" issues list 2>"$TMP_ROOT/norepo.err") || status=$?
+err=$(cat "$TMP_ROOT/norepo.err")
+assert_eq "a subcommand run outside a git repository exits 1, not git's bare 128" "$status" 1
+assert_eq "it prints nothing on stdout" "$out" ""
+assert_contains "the refusal names the directory it could not resolve a repository from" \
+	"$err" "Could not resolve a git repository from: $NOREPO"
+assert_jq "the refusal is the JSON error shape every other linear diagnostic uses" \
+	"$err" '.error | type == "string"'
+
+# Help is answered before lib/common.sh is sourced, so the repository lookup
+# must not reach it.
+status=0
+out=$(cd "$NOREPO" && "$LINEAR" --help) || status=$?
+assert_eq "--help still exits 0 outside a git repository" "$status" 0
+assert_contains "--help still prints its usage there" "$out" "Usage: ./linear.sh"

--- a/.agents/skills/preflight/scripts/preflight
+++ b/.agents/skills/preflight/scripts/preflight
@@ -611,6 +611,29 @@ has_exit_trap() { # FILE
   # end and still exits 1 when nothing matched.
   grep -Ev -- '^[[:space:]]*#' "$1" 2>/dev/null | grep -Ec -- "$TRAP_EXIT_RE" >/dev/null
 }
+# A bare `VAR="$(cmd)"`: the assignment standing alone as the whole command,
+# a `local`-family keyword in front of it changing nothing. Under errexit the
+# substitution's own status escapes from the assignment, so the script dies on
+# that line. `if ! VAR=...` and a same-line `||` put the status somewhere the
+# shell tests, which is the fix rather than the shape.
+# The trailing `[^(]` is what keeps arithmetic expansion out: `$((n + 1))` also
+# opens with `$(`, and it runs no command and carries no status, so a loop
+# counter — the commonest line in this repo's own tooling — is not the shape.
+SUBST_ASSIGN_RE='^[[:space:]]*(local|declare|export|readonly|typeset)?[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=["'\'']?\$\([^(]'
+# The guard the assignment was written to reach: a test naming the assigned
+# variable on one of the lines just below. It is the whole finding — a
+# variable nothing below tests belongs to a command whose failure is MEANT to
+# end the run, and errexit is then doing its job. Four lines because a guard
+# is written directly under the assignment it guards.
+guard_tests_var() { # FILE LINE VAR — 0 when a line just below tests VAR
+  # The window is captured whole rather than piped into the reader: `grep
+  # -q` stops at its first match and closes the pipe, and under pipefail
+  # sed's SIGPIPE makes the pipeline 141 — in this condition position a
+  # match would then read as no match and the finding would be dropped.
+  local window=""
+  window="$(sed -n "$(($2 + 1)),$(($2 + 4))p" -- "$1" 2>/dev/null)" || return 1
+  grep -Eq -- "(\[\[?|test)[[:space:]][^]]*\\\$\{?$3([^A-Za-z0-9_]|\$)" <<<"$window"
+}
 # A directory-CREATING call taking a literal absolute temp path (/tmp,
 # /var/tmp) as (part of) its first argument: mkdtemp/mkdir and their Sync
 # variants (JS/TS), mkdtemp/makedirs/mkdir (Python), create_dir_all (Rust),
@@ -1047,6 +1070,40 @@ while IFS= read -r f; do
 
     if [ "$is_sh" = 1 ] && [ "$vendored_mirror" = 0 ] && [ "$has_ee" = 0 ] && printf '%s' "$content" | grep -Eq -- "$MKTEMP_ASSIGN"; then
       emit "$f" "$n" fail-open "unchecked mktemp in a file without errexit — a failed mktemp leaves the variable empty and the script runs on"
+    fi
+
+    # The mirror shape, in a file that DOES set errexit: a bare assignment
+    # carries the substitution's own status out, so the script dies on the
+    # assignment and the guard written under it never runs. `git rev-parse`
+    # outside a repository is the live one — eight sites each exited at its
+    # bare 128 with nothing on either stream (KEN-1166, KEN-1193).
+    # No comment-line test: the regex anchors the variable name at the start
+    # of the line, so a `#` in front of the shape already fails to match.
+    if [ "$is_sh" = 1 ] && [ "$own_rules" = 0 ] && [ "$vendored_mirror" = 0 ] \
+      && [ "$has_ee" = 1 ]; then
+      case "$content" in
+        *'$('*)
+          # The operator is a status capture only OUTSIDE the substitution, so
+          # the skip reads the tail past the last `)`: `VAR="$(cmd)" || VAR=""`
+          # is the fix shape and stays out, while `VAR="$(cd "$d" && cmd)"` —
+          # whose inner operator captures nothing — is judged like any other.
+          case "${content##*)}" in
+            *'||'* | *'&&'*) ;;
+            *)
+              if grep -Eq -- "$SUBST_ASSIGN_RE" <<<"$content"; then
+                assign_var="${content#"${content%%[![:space:]]*}"}"
+                case "$assign_var" in
+                  local\ * | declare\ * | export\ * | readonly\ * | typeset\ *) assign_var="${assign_var#* }" ;;
+                esac
+                assign_var="${assign_var%%=*}"
+                if guard_tests_var "$cpath" "$n" "$assign_var"; then
+                  emit "$f" "$n" fail-open "bare command-substitution assignment under errexit — its status ends the script here, so the test of \$$assign_var below never runs; move the assignment into the condition"
+                fi
+              fi
+              ;;
+          esac
+          ;;
+      esac
     fi
 
     # The literal prefilters keep the regex passes off the lines that cannot

--- a/.agents/skills/preflight/scripts/preflight
+++ b/.agents/skills/preflight/scripts/preflight
@@ -630,8 +630,12 @@ guard_tests_var() { # FILE LINE VAR — 0 when a line just below tests VAR
   # -q` stops at its first match and closes the pipe, and under pipefail
   # sed's SIGPIPE makes the pipeline 141 — in this condition position a
   # match would then read as no match and the finding would be dropped.
+  # Read through stdin so the path is never an operand: BSD sed rejects `--`
+  # outright ("illegal option"), and the nonzero status it exits with reached
+  # the `|| return 1` below, so on macOS this answered "no guard" every time
+  # and the lane silently never fired.
   local window=""
-  window="$(sed -n "$(($2 + 1)),$(($2 + 4))p" -- "$1" 2>/dev/null)" || return 1
+  window="$(sed -n "$(($2 + 1)),$(($2 + 4))p" <"$1" 2>/dev/null)" || return 1
   grep -Eq -- "(\[\[?|test)[[:space:]][^]]*\\\$\{?$3([^A-Za-z0-9_]|\$)" <<<"$window"
 }
 # A directory-CREATING call taking a literal absolute temp path (/tmp,

--- a/.agents/skills/preflight/scripts/preflight
+++ b/.agents/skills/preflight/scripts/preflight
@@ -490,6 +490,12 @@ is_shell_path() { # PATH CONTENT-PATH — extension, else a sh/bash shebang
 # as enabled can only cost a finding, while missing one would invent a
 # fail-open report against a script that is in fact strict.
 ERREXIT_RE='^[[:space:]]*set[[:space:]].*(-[a-zA-Z]*e|-o[[:space:]]+errexit)'
+# `set +e` (or `+o errexit`) anywhere in the file: inside such a window a bare
+# assignment does not end the script and the guard below it does run, and this
+# lane reads whole files rather than shell state, so it cannot tell which side
+# of the window a line sits on. Precision before coverage — a file that turns
+# errexit back off is left alone.
+NOERREXIT_RE='^[[:space:]]*set[[:space:]].*(\+[a-zA-Z]*e|\+o[[:space:]]+errexit)'
 NOUNSET_RE='^[[:space:]]*set[[:space:]].*(-[a-zA-Z]*u|-o[[:space:]]+nounset)'
 PIPEFAIL_RE='^[[:space:]]*set[[:space:]].*pipefail'
 file_matches() { grep -Eq -- "$2" "$1" 2>/dev/null; }
@@ -611,15 +617,18 @@ has_exit_trap() { # FILE
   # end and still exits 1 when nothing matched.
   grep -Ev -- '^[[:space:]]*#' "$1" 2>/dev/null | grep -Ec -- "$TRAP_EXIT_RE" >/dev/null
 }
-# A bare `VAR="$(cmd)"`: the assignment standing alone as the whole command,
-# a `local`-family keyword in front of it changing nothing. Under errexit the
-# substitution's own status escapes from the assignment, so the script dies on
-# that line. `if ! VAR=...` and a same-line `||` put the status somewhere the
-# shell tests, which is the fix rather than the shape.
+# A bare `VAR="$(cmd)"`: the assignment standing alone as the whole command.
+# Under errexit the substitution's own status escapes from the assignment, so
+# the script dies on that line. `if ! VAR=...` and a same-line `||` put the
+# status somewhere the shell tests, which is the fix rather than the shape.
+# A `local`/`declare`/`export`/`readonly`/`typeset` in front is NOT the shape:
+# the builtin's own status becomes the command's and masks the substitution's,
+# so the script survives and the guard below does run. SC2155 names that
+# masking, and the masked-returns lane owns it rather than this one.
 # The trailing `[^(]` is what keeps arithmetic expansion out: `$((n + 1))` also
 # opens with `$(`, and it runs no command and carries no status, so a loop
 # counter — the commonest line in this repo's own tooling — is not the shape.
-SUBST_ASSIGN_RE='^[[:space:]]*(local|declare|export|readonly|typeset)?[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=["'\'']?\$\([^(]'
+SUBST_ASSIGN_RE='^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=["'\'']?\$\([^(]'
 # The guard the assignment was written to reach: a test naming the assigned
 # variable on one of the lines just below. It is the whole finding — a
 # variable nothing below tests belongs to a command whose failure is MEANT to
@@ -636,6 +645,10 @@ guard_tests_var() { # FILE LINE VAR — 0 when a line just below tests VAR
   # and the lane silently never fired.
   local window=""
   window="$(sed -n "$(($2 + 1)),$(($2 + 4))p" <"$1" 2>/dev/null)" || return 1
+  # Comment lines go first: a guard written in a comment runs nothing, so a
+  # deliberately fatal assignment with an example guard under it is not the
+  # shape. grep exits 1 on an all-comment window, which is no guard either.
+  window="$(grep -Ev -- '^[[:space:]]*#' <<<"$window")" || return 1
   grep -Eq -- "(\[\[?|test)[[:space:]][^]]*\\\$\{?$3([^A-Za-z0-9_]|\$)" <<<"$window"
 }
 # A directory-CREATING call taking a literal absolute temp path (/tmp,
@@ -930,6 +943,7 @@ while IFS= read -r f; do
 
   is_sh=0
   has_ee=0
+  has_noee=0
   has_pf=0
   has_trap=0
   mktemp_reported=0
@@ -997,6 +1011,7 @@ while IFS= read -r f; do
   fi
   if [ "$is_sh" = 1 ]; then
     file_matches "$cpath" "$ERREXIT_RE" && has_ee=1
+    file_matches "$cpath" "$NOERREXIT_RE" && has_noee=1
     file_matches "$cpath" "$PIPEFAIL_RE" && has_pf=1
     has_exit_trap "$cpath" && has_trap=1
 
@@ -1084,7 +1099,7 @@ while IFS= read -r f; do
     # No comment-line test: the regex anchors the variable name at the start
     # of the line, so a `#` in front of the shape already fails to match.
     if [ "$is_sh" = 1 ] && [ "$own_rules" = 0 ] && [ "$vendored_mirror" = 0 ] \
-      && [ "$has_ee" = 1 ]; then
+      && [ "$has_ee" = 1 ] && [ "$has_noee" = 0 ]; then
       case "$content" in
         *'$('*)
           # The operator is a status capture only OUTSIDE the substitution, so
@@ -1096,9 +1111,6 @@ while IFS= read -r f; do
             *)
               if grep -Eq -- "$SUBST_ASSIGN_RE" <<<"$content"; then
                 assign_var="${content#"${content%%[![:space:]]*}"}"
-                case "$assign_var" in
-                  local\ * | declare\ * | export\ * | readonly\ * | typeset\ *) assign_var="${assign_var#* }" ;;
-                esac
                 assign_var="${assign_var%%=*}"
                 if guard_tests_var "$cpath" "$n" "$assign_var"; then
                   emit "$f" "$n" fail-open "bare command-substitution assignment under errexit — its status ends the script here, so the test of \$$assign_var below never runs; move the assignment into the condition"

--- a/.agents/skills/preflight/scripts/preflight
+++ b/.agents/skills/preflight/scripts/preflight
@@ -625,10 +625,12 @@ has_exit_trap() { # FILE
 # the builtin's own status becomes the command's and masks the substitution's,
 # so the script survives and the guard below does run. SC2155 names that
 # masking, and the masked-returns lane owns it rather than this one.
+# Only a double quote, or none: inside single quotes `$(cmd)` is literal text,
+# no command runs and no status can end anything.
 # The trailing `[^(]` is what keeps arithmetic expansion out: `$((n + 1))` also
 # opens with `$(`, and it runs no command and carries no status, so a loop
 # counter — the commonest line in this repo's own tooling — is not the shape.
-SUBST_ASSIGN_RE='^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=["'\'']?\$\([^(]'
+SUBST_ASSIGN_RE='^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*="?\$\([^(]'
 # The guard the assignment was written to reach: a test naming the assigned
 # variable on one of the lines just below. It is the whole finding — a
 # variable nothing below tests belongs to a command whose failure is MEANT to

--- a/.agents/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/.agents/skills/preflight/tests/lanes-must-fail.test.sh
@@ -127,14 +127,15 @@ fires "a condition piping echo into grep -q fails as early-close-pipe" "scripts/
 
 echo "=== lane fail-open: a bare command-substitution assignment under errexit ==="
 seed bareassign
-# The keyword spelling, and the guard at the far edge of the look-ahead
-# window: the assignment is on line 3 and the test of $ROOT on line 7, four
-# lines below it. A narrower window, or a keyword strip that leaves the
-# variable named `readonly ROOT`, stops finding this.
+# The guard sits at the far edge of the look-ahead window: the assignment is
+# on line 3 and the test of $ROOT on line 7, four lines below it. A narrower
+# window stops finding this. The assignment is bare on purpose — a `readonly`
+# or `local` in front would mask the substitution's status and the script
+# would survive, which is the masked-returns lane's shape, not this one's.
 {
   printf '#!/usr/bin/env bash\n'
   printf 'set -euo pipefail\n'
-  printf 'readonly ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"\n'
+  printf 'ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"\n'
   printf 'log() {\n'
   printf '  printf "%%s\\n" "$1" >&2\n'
   printf '}\n'

--- a/.agents/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/.agents/skills/preflight/tests/lanes-must-fail.test.sh
@@ -125,6 +125,38 @@ git -C "$R" add -A
 run_pf
 fires "a condition piping echo into grep -q fails as early-close-pipe" "scripts/existing.sh:3: [early-close-pipe] a shell writer piped into a reader that stops before EOF"
 
+echo "=== lane fail-open: a bare command-substitution assignment under errexit ==="
+seed bareassign
+# The keyword spelling, and the guard at the far edge of the look-ahead
+# window: the assignment is on line 3 and the test of $ROOT on line 7, four
+# lines below it. A narrower window, or a keyword strip that leaves the
+# variable named `readonly ROOT`, stops finding this.
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'set -euo pipefail\n'
+  printf 'readonly ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"\n'
+  printf 'log() {\n'
+  printf '  printf "%%s\\n" "$1" >&2\n'
+  printf '}\n'
+  printf 'if [ -z "$ROOT" ]; then\n'
+  printf '  log "not inside a repository"\n'
+  printf '  exit 1\n'
+  printf 'fi\n'
+  printf 'INNER="$(cd "$ROOT" && git rev-parse HEAD 2>/dev/null)"\n'
+  printf 'if [ -z "$INNER" ]; then\n'
+  printf '  exit 1\n'
+  printf 'fi\n'
+  printf 'echo "$ROOT $INNER"\n'
+} >"$R/scripts/bare.sh"
+git -C "$R" add -A
+run_pf
+fires "an assignment whose guard errexit kills first fails as fail-open" \
+  "scripts/bare.sh:3: [fail-open] bare command-substitution assignment under errexit"
+# An operator INSIDE the substitution captures nothing, so it must not read as
+# the same-line status capture that makes the fix shape exempt.
+fires "an operator inside the substitution does not exempt the assignment" \
+  "scripts/bare.sh:11: [fail-open] bare command-substitution assignment under errexit"
+
 echo "=== lane mktemp-trap: a new script whose scratch nothing removes ==="
 seed scratch
 printf '#!/usr/bin/env bash\nset -euo pipefail\nD="$(mktemp -d)"\necho "$D"\n' >"$R/scripts/scratch.sh"

--- a/.agents/skills/preflight/tests/precision.test.sh
+++ b/.agents/skills/preflight/tests/precision.test.sh
@@ -211,9 +211,43 @@ echo "$v" | jq -e . >/dev/null 2>&1 || grep -q x <<<"$v"
 echo "$MSG"
 EOF
 printf '{\n  // a comment: this dialect is real and jq is right to reject it\n  "strict": true\n}\n' >"$R/tsconfig.json"
+# Every benign spelling of a command substitution assigned under errexit. The
+# shape is a defect only when a guard below the assignment can never run, so a
+# substitution whose failure is MEANT to end the script, one already sitting in
+# a condition, and one whose status the same line captures are all correct code.
+cat >"$R/scripts/assign.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+# Nothing below tests it: errexit ending the run here is the intended fatal.
+# The test of $STAMP far below is out of the look-ahead window and must stay
+# out — a guard that distant belongs to no assignment, so a wider window turns
+# every deliberate fatal into a finding.
+STAMP="$(date +%s)"
+echo "$STAMP"
+# The fix shape: the status is in a position the shell tests.
+if ! ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || [ -z "$ROOT" ]; then
+  echo "no repository" >&2
+  exit 1
+fi
+# Captured on the same line, so the test below is reachable.
+BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null)" || BRANCH=""
+[ -z "$BRANCH" ] || echo "$BRANCH"
+# Arithmetic expansion opens with the same two characters and runs no command,
+# so a loop counter under its own bound test is not the shape.
+tries=0
+while [ "$tries" -lt 3 ]; do
+  tries=$((tries + 1))
+  if [ "$tries" -gt 2 ]; then
+    break
+  fi
+done
+# Naming the shape is not writing it: HERE="$(cmd)" with [ -z "$HERE" ] under it.
+echo "$ROOT"
+[ -z "$STAMP" ] || echo "still set"
+EOF
 git -C "$R" add -A
 run_pf
-clean "no lane fires on placeholders, URLs, quoted or data-file or test-file doc cites, foreign subtrees, referenced TODOs, strict scripts, wired suites, trapped scratch dirs, captured statuses, here-string, read-to-EOF and OR-list pipeline shapes, the same shapes named in a comment or a string, or JSON-with-comments"
+clean "no lane fires on placeholders, URLs, quoted or data-file or test-file doc cites, foreign subtrees, referenced TODOs, strict scripts, wired suites, trapped scratch dirs, captured statuses, here-string, read-to-EOF and OR-list pipeline shapes, guarded or deliberately fatal command-substitution assignments, the same shapes named in a comment or a string, or JSON-with-comments"
 
 echo "=== control: the same fixture still fails on a real defect ==="
 printf 'And a citation that is dead: `docs/gone.md`.\n' >>"$R/README.md"

--- a/.agents/skills/preflight/tests/precision.test.sh
+++ b/.agents/skills/preflight/tests/precision.test.sh
@@ -114,6 +114,19 @@ echo "=== benign patterns across every lane stay clean ==="
 seed benign
 # mktemp is fine under errexit; a new script that declares strict mode is fine.
 printf '#!/usr/bin/env bash\nset -euo pipefail\nTMP="$(mktemp -d)"\ntrap %s EXIT\necho "$TMP"\n' "'rm -rf \"\$TMP\"'" >"$R/scripts/strict.sh"
+# Inside a `set +e` window a bare assignment ends nothing and the guard below
+# it does run, so a file that turns errexit back off is not judged at all.
+cat >"$R/scripts/window.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+set +e
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+set -e
+if [ -z "$ROOT" ]; then
+  exit 1
+fi
+echo "$ROOT"
+EOF
 # A test-tree script sets its own rules — including the fixture path it cites.
 printf '#!/usr/bin/env bash\n# fixture: docs/gone.md\necho helper\n' >"$R/tests/helper.sh"
 # Every benign doc-citation shape a source file can carry.
@@ -243,6 +256,11 @@ while [ "$tries" -lt 3 ]; do
 done
 # Naming the shape is not writing it: HERE="$(cmd)" with [ -z "$HERE" ] under it.
 echo "$ROOT"
+# A guard written in a comment runs nothing, so the deliberate fatal above it
+# stands and is not this lane's shape.
+FATAL="$(date +%s)"
+# if [ -z "$FATAL" ]; then exit 1; fi
+echo "$FATAL"
 [ -z "$STAMP" ] || echo "still set"
 EOF
 git -C "$R" add -A

--- a/.agents/skills/preflight/tests/precision.test.sh
+++ b/.agents/skills/preflight/tests/precision.test.sh
@@ -260,7 +260,12 @@ echo "$ROOT"
 # stands and is not this lane's shape.
 FATAL="$(date +%s)"
 # if [ -z "$FATAL" ]; then exit 1; fi
-echo "$FATAL"
+# Single quotes make it literal text: no command runs, so nothing can end here.
+LITERAL='$(date +%s)'
+if [ -z "$LITERAL" ]; then
+  exit 1
+fi
+echo "$FATAL $LITERAL"
 [ -z "$STAMP" ] || echo "still set"
 EOF
 git -C "$R" add -A

--- a/.agents/skills/second-opinion/scripts/second-opinion
+++ b/.agents/skills/second-opinion/scripts/second-opinion
@@ -285,8 +285,13 @@ readonly -a ORIGINAL_ARGS
 # because the message being read is translated.
 if ! PROJECT_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)"; then
   _git_diag="$(LC_ALL=C git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>&1 >/dev/null)" || :
+  # The parenthetical is what separates "there is no repository above me" from
+  # "there is one and it is broken": a linked worktree whose marker points at a
+  # gone or unreadable target answers `not a git repository: (null)`, and that
+  # checkout DOES carry settings, so it must refuse rather than degrade. Any
+  # message this does not recognise refuses too.
   case "$_git_diag" in
-    *"not a git repository"*) PROJECT_ROOT="" ;;
+    *"not a git repository (or any of the parent directories)"*) PROJECT_ROOT="" ;;
     *)
       echo "second-opinion: could not resolve a repository at $SCRIPT_DIR" >&2
       echo "  git said: ${_git_diag#fatal: }" >&2

--- a/.agents/skills/second-opinion/scripts/second-opinion
+++ b/.agents/skills/second-opinion/scripts/second-opinion
@@ -268,8 +268,33 @@ readonly SCRIPT_DIR FOREGROUND_CAP_IN_CALLER_ENV FOREGROUND_CAP_WAS_IN_CALLER_EN
   CURRENT_MODEL_IS_SESSION_SCOPED CURRENT_MODEL_IN_CALLER_ENV
 readonly -a ORIGINAL_ARGS
 # Resolved only after help is answered: help must not require a git
-# checkout around the installed script.
-PROJECT_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)"
+# checkout around the installed script. The assignment sits in the condition
+# (KEN-1193): outside a repository `git rev-parse` exits 128 and under `set -e`
+# a bare assignment carries that status out, ending the run before anything
+# below it.
+#
+# Only ONE failure means there is nothing to load. An install outside a
+# repository has no project configuration, and kendex_load_project_env already
+# treats an empty root as exactly that. Every other nonzero status — git's
+# dubious-ownership refusal on a checkout owned by another uid, which is the
+# normal shape of a mounted workspace, or no git on PATH — comes from a
+# checkout that DOES carry kendex.settings.toml and .env.local. Degrading
+# there would run the review on built-in defaults with the project's own
+# model and command settings silently ignored, so it refuses instead and
+# quotes git's own account rather than guessing at the cause. LC_ALL=C
+# because the message being read is translated.
+if ! PROJECT_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)"; then
+  _git_diag="$(LC_ALL=C git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>&1 >/dev/null)" || :
+  case "$_git_diag" in
+    *"not a git repository"*) PROJECT_ROOT="" ;;
+    *)
+      echo "second-opinion: could not resolve a repository at $SCRIPT_DIR" >&2
+      echo "  git said: ${_git_diag#fatal: }" >&2
+      exit 1
+      ;;
+  esac
+  unset _git_diag
+fi
 # Source project config/secrets. .env.local overrides public settings; the
 # caller's own environment (set or set-but-empty) outranks every project file —
 # kendex_load_project_env snapshots and re-asserts it.

--- a/.agents/skills/second-opinion/scripts/second-opinion
+++ b/.agents/skills/second-opinion/scripts/second-opinion
@@ -286,12 +286,16 @@ readonly -a ORIGINAL_ARGS
 if ! PROJECT_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)"; then
   _git_diag="$(LC_ALL=C git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>&1 >/dev/null)" || :
   # The parenthetical is what separates "there is no repository above me" from
-  # "there is one and it is broken": a linked worktree whose marker points at a
-  # gone or unreadable target answers `not a git repository: (null)`, and that
-  # checkout DOES carry settings, so it must refuse rather than degrade. Any
-  # message this does not recognise refuses too.
+  # "there is one and it is broken". Git names the parents it searched two ways
+  # — the parent directories, or the parents up to a mount point when discovery
+  # stops at a filesystem boundary — and both are the absence. A `.git` that
+  # points nowhere gets the same three words WITHOUT a parenthetical
+  # (`not a git repository: (null)`), and that is a repository git could not
+  # read, from a checkout that does carry settings, so it refuses. Any message
+  # this does not recognise refuses too. hooks/block-worktree-refresh.sh splits
+  # the same diagnostic the same way.
   case "$_git_diag" in
-    *"not a git repository (or any of the parent directories)"*) PROJECT_ROOT="" ;;
+    *"not a git repository (or any"*) PROJECT_ROOT="" ;;
     *)
       echo "second-opinion: could not resolve a repository at $SCRIPT_DIR" >&2
       echo "  git said: ${_git_diag#fatal: }" >&2

--- a/.agents/skills/second-opinion/scripts/second-opinion
+++ b/.agents/skills/second-opinion/scripts/second-opinion
@@ -294,6 +294,12 @@ if ! PROJECT_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)
   # read, from a checkout that does carry settings, so it refuses. Any message
   # this does not recognise refuses too. hooks/block-worktree-refresh.sh splits
   # the same diagnostic the same way.
+  #
+  # The limit of reading the message: an EMPTY or malformed `.git` DIRECTORY
+  # draws the parenthetical too, so it lands here as an absence. Separating
+  # that from a true absence takes an ancestor walk for a `.git` entry, which
+  # the hook above owns; this does not carry a second copy of it. Git itself
+  # reports no repository in that state, so no root could be resolved anyway.
   case "$_git_diag" in
     *"not a git repository (or any"*) PROJECT_ROOT="" ;;
     *)

--- a/.agents/skills/second-opinion/tests/no-repository-classification.test.sh
+++ b/.agents/skills/second-opinion/tests/no-repository-classification.test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# The script resolves PROJECT_ROOT from its own location before loading project
+# settings. Outside a repository `git rev-parse` exits 128, and a bare
+# assignment carried that status out under `set -e`, ending the run at 128 with
+# nothing on either stream (KEN-1193).
+#
+# Only ONE failure means there is nothing to load. An install outside a
+# repository has no project configuration, and that degrades to the caller's
+# environment. Every other nonzero status comes from a checkout that DOES carry
+# settings — git's dubious-ownership refusal, or no git at all — so those refuse
+# rather than silently running on built-in defaults. This suite pins the split.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf -- "${TMP_ROOT:?}"' EXIT
+
+PASS=0
+FAIL=0
+ok() {
+  PASS=$((PASS + 1))
+  printf '  ok    %s\n' "$1"
+}
+bad() {
+  FAIL=$((FAIL + 1))
+  printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"
+}
+
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below back at the real repository and make the copy read as a checkout.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
+# TMPDIR can itself sit inside a checkout on a developer box; the ceiling stops
+# rev-parse's upward search so "outside a repository" is what this actually is.
+export GIT_CEILING_DIRECTORIES="$TMP_ROOT"
+
+# No `git init` anywhere above it: this is the installed-outside-a-repository
+# case the degrade branch exists for.
+mkdir -p "$TMP_ROOT/install"
+cp -R "$REPO_ROOT/skills/second-opinion" "$TMP_ROOT/install/second-opinion"
+SECOND_OPINION="$TMP_ROOT/install/second-opinion/scripts/second-opinion"
+
+probe_status=0
+probe=$(LC_ALL=C git -C "$TMP_ROOT/install" rev-parse --show-toplevel 2>&1) || probe_status=$?
+probe_is_norepo=1
+case "$probe" in *"not a git repository"*) ;; *) probe_is_norepo=0 ;; esac
+if [ "$probe_status" -ne 128 ] || [ "$probe_is_norepo" -eq 0 ]; then
+  bad "the install fixture is outside a git repository" "status=$probe_status out=$probe"
+  printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+  exit 1
+fi
+ok "the install fixture is outside a git repository"
+
+# An unparseable argument is answered by the option parser, which sits below the
+# repository lookup: reaching it at all proves the lookup did not end the run.
+status=0
+out=$("$SECOND_OPINION" --mode no-such-mode 2>"$TMP_ROOT/degrade.err") || status=$?
+err=$(cat "$TMP_ROOT/degrade.err")
+if [ "$status" -eq 128 ]; then
+  bad "an install outside a repository runs on rather than exiting at git's 128" "err=$err"
+else
+  ok "an install outside a repository runs on rather than exiting at git's 128"
+fi
+case "$err" in
+  *"unknown argument"*) ok "it reaches the option parser below the lookup" ;;
+  *) bad "it reaches the option parser below the lookup" "err=$err" ;;
+esac
+case "$err" in
+  *"could not resolve a repository"*) bad "having nothing to load is not a refusal" "err=$err" ;;
+  *) ok "having nothing to load is not a refusal" ;;
+esac
+
+# Any OTHER nonzero status is a checkout whose settings would be skipped in
+# silence, so it refuses and quotes git rather than guessing at the cause. A
+# PATH with no git on it is that case, and the one this box can produce.
+mkdir -p "$TMP_ROOT/emptybin"
+for tool in bash env sed grep dirname cat mktemp; do
+  resolved="$(command -v "$tool" 2>/dev/null)" || continue
+  ln -sf "$resolved" "$TMP_ROOT/emptybin/$tool"
+done
+status=0
+out=$(PATH="$TMP_ROOT/emptybin" LC_ALL=C "$SECOND_OPINION" --mode no-such-mode 2>"$TMP_ROOT/nogit.err") || status=$?
+err=$(cat "$TMP_ROOT/nogit.err")
+if [ "$status" -eq 1 ]; then
+  ok "a lookup failure that is not an absent repository refuses with status 1"
+else
+  bad "a lookup failure that is not an absent repository refuses with status 1" "status=$status err=$err"
+fi
+case "$err" in
+  *"could not resolve a repository at"*) ok "the refusal names the directory it looked in" ;;
+  *) bad "the refusal names the directory it looked in" "err=$err" ;;
+esac
+# Read the quoted line alone: without the anchor the needle also matches the
+# shell's own unredirected "command not found", which is what stderr carries
+# when the refusal quotes nothing at all.
+said=""
+if ! said=$(grep -F '  git said: ' "$TMP_ROOT/nogit.err"); then said=""; fi
+case "$said" in
+  *"git: command not found"*) ok "the refusal quotes git's own account rather than asserting a cause" ;;
+  *) bad "the refusal quotes git's own account rather than asserting a cause" "said=$said" ;;
+esac
+if [ -z "$out" ]; then
+  ok "the refusal prints nothing on stdout"
+else
+  bad "the refusal prints nothing on stdout" "out=$out"
+fi
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.agents/skills/second-opinion/tests/no-repository-classification.test.sh
+++ b/.agents/skills/second-opinion/tests/no-repository-classification.test.sh
@@ -154,5 +154,36 @@ case "$err" in
   *) bad "that refusal names the directory too" "err=$err" ;;
 esac
 
+# Git names the parents it searched a second way when discovery stops at a
+# filesystem boundary: `not a git repository (or any parent up to mount point
+# ...)`. That is still the absence of a repository, so it must degrade. A real
+# second mount is not portable across the platforms this suite runs on, so the
+# diagnostic is delivered by a git that answers with it — the tool the script
+# calls, not the branch under test.
+mkdir -p "$TMP_ROOT/mountbin"
+for tool in bash env sed grep dirname cat mktemp; do
+  resolved="$(command -v "$tool" 2>/dev/null)" || continue
+  ln -sf "$resolved" "$TMP_ROOT/mountbin/$tool"
+done
+cat >"$TMP_ROOT/mountbin/git" <<'GITSH'
+#!/usr/bin/env bash
+printf 'fatal: not a git repository (or any parent up to mount point /mnt)\n' >&2
+printf 'Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).\n' >&2
+exit 128
+GITSH
+chmod +x "$TMP_ROOT/mountbin/git"
+
+status=0
+out=$(PATH="$TMP_ROOT/mountbin" LC_ALL=C "$SECOND_OPINION" --mode no-such-mode 2>"$TMP_ROOT/mount.err") || status=$?
+err=$(cat "$TMP_ROOT/mount.err")
+case "$err" in
+  *"could not resolve a repository"*) bad "a mount-point boundary is the absence of a repository, not a refusal" "err=$err" ;;
+  *) ok "a mount-point boundary is the absence of a repository, not a refusal" ;;
+esac
+case "$err" in
+  *"unknown argument"*) ok "it degrades past the lookup into option parsing" ;;
+  *) bad "it degrades past the lookup into option parsing" "status=$status err=$err" ;;
+esac
+
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.agents/skills/second-opinion/tests/no-repository-classification.test.sh
+++ b/.agents/skills/second-opinion/tests/no-repository-classification.test.sh
@@ -91,6 +91,10 @@ case "$err" in
   *"could not resolve a repository at"*) ok "the refusal names the directory it looked in" ;;
   *) bad "the refusal names the directory it looked in" "err=$err" ;;
 esac
+case "$err" in
+  *"unknown argument"*) bad "it refuses above option parsing rather than degrading into it" "err=$err" ;;
+  *) ok "it refuses above option parsing rather than degrading into it" ;;
+esac
 # Read the quoted line alone: without the anchor the needle also matches the
 # shell's own unredirected "command not found", which is what stderr carries
 # when the refusal quotes nothing at all.
@@ -105,6 +109,50 @@ if [ -z "$out" ]; then
 else
   bad "the refusal prints nothing on stdout" "out=$out"
 fi
+
+# A linked worktree whose marker points at a gone target answers
+# `not a git repository: (null)` — the same three words as the absent-repository
+# case, from a checkout that DOES carry settings. Lanes here run out of linked
+# worktrees, so a pruned or moved main checkout produces exactly this.
+mkdir -p "$TMP_ROOT/wtmain"
+git init -q "$TMP_ROOT/wtmain"
+git -C "$TMP_ROOT/wtmain" config user.email test@example.com
+git -C "$TMP_ROOT/wtmain" config user.name test
+printf 'x\n' >"$TMP_ROOT/wtmain/f"
+git -C "$TMP_ROOT/wtmain" add f
+git -C "$TMP_ROOT/wtmain" -c commit.gpgsign=false commit -qm init
+git -C "$TMP_ROOT/wtmain" worktree add -q -b wt "$TMP_ROOT/wtlinked"
+mkdir -p "$TMP_ROOT/wtlinked/skills"
+cp -R "$REPO_ROOT/skills/second-opinion" "$TMP_ROOT/wtlinked/skills/second-opinion"
+# Break the marker the way a pruned or relocated main checkout does.
+rm -rf -- "${TMP_ROOT:?}/wtmain/.git/worktrees"
+
+marker_diag=$(LC_ALL=C git -C "$TMP_ROOT/wtlinked" rev-parse --show-toplevel 2>&1) || true
+case "$marker_diag" in
+  *"not a git repository"*) ok "a broken worktree marker still says 'not a git repository'" ;;
+  *) bad "a broken worktree marker still says 'not a git repository'" "diag=$marker_diag" ;;
+esac
+
+status=0
+out=$(LC_ALL=C "$TMP_ROOT/wtlinked/skills/second-opinion/scripts/second-opinion" \
+  --mode no-such-mode 2>"$TMP_ROOT/marker.err") || status=$?
+err=$(cat "$TMP_ROOT/marker.err")
+# Status alone proves nothing here: the unparseable argument would exit 1 too.
+# The refusal happens at the lookup, ABOVE option parsing, so never reaching
+# the parser is what separates refusing from degrading.
+if [ "$status" -eq 1 ]; then
+  ok "a broken worktree marker exits 1"
+else
+  bad "a broken worktree marker exits 1" "status=$status err=$err"
+fi
+case "$err" in
+  *"unknown argument"*) bad "it refuses above option parsing rather than degrading into it" "err=$err" ;;
+  *) ok "it refuses above option parsing rather than degrading into it" ;;
+esac
+case "$err" in
+  *"could not resolve a repository at"*) ok "that refusal names the directory too" ;;
+  *) bad "that refusal names the directory too" "err=$err" ;;
+esac
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/changelog.d/fixed/1193.md
+++ b/changelog.d/fixed/1193.md
@@ -1,1 +1,1 @@
-- Name the directory a linear or second-opinion command could not resolve a git repository from, rather than exiting at git's bare 128 with nothing on either stream.
+- Name the directory a linear command could not resolve a repository from, and let second-opinion run on when its install sits outside one, instead of exiting at git's bare 128 in silence.

--- a/changelog.d/fixed/1193.md
+++ b/changelog.d/fixed/1193.md
@@ -1,0 +1,1 @@
+- Name the directory a linear or second-opinion command could not resolve a git repository from, rather than exiting at git's bare 128 with nothing on either stream.

--- a/skills/linear/scripts/lib/cache.sh
+++ b/skills/linear/scripts/lib/cache.sh
@@ -42,12 +42,26 @@ linear_cache_project_root() {
         return
     fi
 
-    local root
-    root="$(git rev-parse --show-toplevel 2>/dev/null)"
+    # The assignment sits in the condition on purpose (KEN-1193): `git
+    # rev-parse` exits 128 outside a repository, and under `set -e` a bare
+    # assignment carries that status out of the function before this refusal
+    # can print. Each branch above names its own cause, so this one does too.
+    local root=""
+    if ! root="$(git rev-parse --show-toplevel 2>/dev/null)" || [[ -z "$root" ]]; then
+        jq -cn --arg cwd "$PWD" \
+            '{error: ("Could not resolve a cache root: LINEAR_CACHE_ROOT is unset and there is no git repository at: " + $cwd)}' >&2
+        return 1
+    fi
     linear_cache_canonical_existing_dir "$root"
 }
 
-CACHE_PROJECT_ROOT="$(linear_cache_project_root)"
+# In the condition for the same reason (KEN-1193): a bare assignment carries
+# the function's refusal out here, ending the script at that status with the
+# cause on stderr but no exit of this script's own. Every branch above has
+# already said why, so this one adds nothing.
+if ! CACHE_PROJECT_ROOT="$(linear_cache_project_root)"; then
+    exit 1
+fi
 CACHE_DIR="$CACHE_PROJECT_ROOT/.cache/linear"
 
 # The three single-comment helpers below — cache_append_comment,

--- a/skills/linear/scripts/lib/common.sh
+++ b/skills/linear/scripts/lib/common.sh
@@ -26,8 +26,19 @@ linear_canonical_existing_dir() {
 source "$_LIB_DIR/bash-version.sh"
 linear_require_supported_bash || exit $?
 
-PROJECT_ROOT_RAW="$(git rev-parse --show-toplevel 2>/dev/null)"
-PROJECT_ROOT="$(linear_canonical_existing_dir "$PROJECT_ROOT_RAW")"
+# Both assignments sit in the condition on purpose (KEN-1193): `git rev-parse`
+# exits 128 outside a repository and linear_canonical_existing_dir returns 1 on
+# a path that is not a directory, and under `set -e` a bare assignment carries
+# either status out before any guard below can print. Every subcommand died at
+# a bare 128 with nothing on stdout or stderr. Everything past this line — the
+# cache, the attachment store, the project settings and .env.local — is read
+# from the repository, so the resolution refuses rather than degrading.
+if ! PROJECT_ROOT_RAW="$(git rev-parse --show-toplevel 2>/dev/null)" \
+    || ! PROJECT_ROOT="$(linear_canonical_existing_dir "$PROJECT_ROOT_RAW")"; then
+    jq -cn --arg cwd "$PWD" \
+        '{error: ("Could not resolve a git repository from: " + $cwd + ". Run linear.sh from a checkout of the repository whose Linear workspace you mean.")}' >&2
+    exit 1
+fi
 unset PROJECT_ROOT_RAW
 
 # First 12 hex chars of sha256 — enough to tell two keys apart in a diagnostic

--- a/skills/linear/tests/controls/cache-root-git-worktree.control.sh
+++ b/skills/linear/tests/controls/cache-root-git-worktree.control.sh
@@ -4,5 +4,5 @@
 # follows the link.
 control_expect "logical installed invocation: the missing-cache diagnostic names the physical cache path"
 control_replace scripts/lib/cache.sh 1 \
-    'CACHE_PROJECT_ROOT="$(linear_cache_project_root)"' \
-    'CACHE_PROJECT_ROOT="$PWD"'
+    'if ! CACHE_PROJECT_ROOT="$(linear_cache_project_root)"; then' \
+    'if ! CACHE_PROJECT_ROOT="$PWD"; then'

--- a/skills/linear/tests/controls/no-repository-refusal.control.sh
+++ b/skills/linear/tests/controls/no-repository-refusal.control.sh
@@ -1,0 +1,9 @@
+# Take the repository lookup back out of the condition. Outside a repository
+# `git rev-parse` exits 128, and under `set -e` the bare assignment carries
+# that status out before the refusal below can print: the run dies at 128 with
+# nothing on either stream, which is the defect KEN-1193 fixed. The `if false`
+# keeps the continuation line and the refusal block parsing.
+control_expect "a subcommand run outside a git repository exits 1, not git's bare 128"
+control_replace scripts/lib/common.sh 1 \
+    'if ! PROJECT_ROOT_RAW="$(git rev-parse --show-toplevel 2>/dev/null)" \' \
+    'PROJECT_ROOT_RAW="$(git rev-parse --show-toplevel 2>/dev/null)"; if false \'

--- a/skills/linear/tests/no-repository-refusal.test.sh
+++ b/skills/linear/tests/no-repository-refusal.test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# lib/common.sh resolves the project root from the current directory, and
+# every subcommand sources it. Outside a repository `git rev-parse` exits 128,
+# and a bare assignment carried that status out under `set -e` before the
+# guard below it could speak: the run died at 128 with nothing on stdout or
+# stderr (KEN-1193). The refusal now names the directory it could not resolve
+# a repository from. Help is answered before the lib is sourced and is held
+# here from the other side, so the refusal cannot creep in front of it.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/assert.sh
+source "$SCRIPT_DIR/lib/assert.sh"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+LINEAR="$SKILL_DIR/scripts/linear.sh"
+assert_tmpdir TMP_ROOT
+
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below back at the real repository and make the fixture read as one.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
+NOREPO="$TMP_ROOT/norepo"
+mkdir -p "$NOREPO"
+# The scratch root is under TMPDIR, which on a developer box can sit inside a
+# checkout; the ceiling stops rev-parse's upward search at the fixture's own
+# parent so "outside a repository" is what the fixture actually is.
+export GIT_CEILING_DIRECTORIES="$TMP_ROOT"
+
+probe_status=0
+probe=$(LC_ALL=C git -C "$NOREPO" rev-parse --show-toplevel 2>&1) || probe_status=$?
+if [[ "$probe_status" -ne 128 || "$probe" != *"not a git repository"* ]]; then
+	assert_stop "the no-repository fixture is outside a git repository" "$probe"
+fi
+assert_eq "the no-repository fixture is outside a git repository" "$probe_status" 128
+
+status=0
+out=$(cd "$NOREPO" && "$LINEAR" issues list 2>"$TMP_ROOT/norepo.err") || status=$?
+err=$(cat "$TMP_ROOT/norepo.err")
+assert_eq "a subcommand run outside a git repository exits 1, not git's bare 128" "$status" 1
+assert_eq "it prints nothing on stdout" "$out" ""
+assert_contains "the refusal names the directory it could not resolve a repository from" \
+	"$err" "Could not resolve a git repository from: $NOREPO"
+assert_jq "the refusal is the JSON error shape every other linear diagnostic uses" \
+	"$err" '.error | type == "string"'
+
+# Help is answered before lib/common.sh is sourced, so the repository lookup
+# must not reach it.
+status=0
+out=$(cd "$NOREPO" && "$LINEAR" --help) || status=$?
+assert_eq "--help still exits 0 outside a git repository" "$status" 0
+assert_contains "--help still prints its usage there" "$out" "Usage: ./linear.sh"

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -611,6 +611,29 @@ has_exit_trap() { # FILE
   # end and still exits 1 when nothing matched.
   grep -Ev -- '^[[:space:]]*#' "$1" 2>/dev/null | grep -Ec -- "$TRAP_EXIT_RE" >/dev/null
 }
+# A bare `VAR="$(cmd)"`: the assignment standing alone as the whole command,
+# a `local`-family keyword in front of it changing nothing. Under errexit the
+# substitution's own status escapes from the assignment, so the script dies on
+# that line. `if ! VAR=...` and a same-line `||` put the status somewhere the
+# shell tests, which is the fix rather than the shape.
+# The trailing `[^(]` is what keeps arithmetic expansion out: `$((n + 1))` also
+# opens with `$(`, and it runs no command and carries no status, so a loop
+# counter — the commonest line in this repo's own tooling — is not the shape.
+SUBST_ASSIGN_RE='^[[:space:]]*(local|declare|export|readonly|typeset)?[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=["'\'']?\$\([^(]'
+# The guard the assignment was written to reach: a test naming the assigned
+# variable on one of the lines just below. It is the whole finding — a
+# variable nothing below tests belongs to a command whose failure is MEANT to
+# end the run, and errexit is then doing its job. Four lines because a guard
+# is written directly under the assignment it guards.
+guard_tests_var() { # FILE LINE VAR — 0 when a line just below tests VAR
+  # The window is captured whole rather than piped into the reader: `grep
+  # -q` stops at its first match and closes the pipe, and under pipefail
+  # sed's SIGPIPE makes the pipeline 141 — in this condition position a
+  # match would then read as no match and the finding would be dropped.
+  local window=""
+  window="$(sed -n "$(($2 + 1)),$(($2 + 4))p" -- "$1" 2>/dev/null)" || return 1
+  grep -Eq -- "(\[\[?|test)[[:space:]][^]]*\\\$\{?$3([^A-Za-z0-9_]|\$)" <<<"$window"
+}
 # A directory-CREATING call taking a literal absolute temp path (/tmp,
 # /var/tmp) as (part of) its first argument: mkdtemp/mkdir and their Sync
 # variants (JS/TS), mkdtemp/makedirs/mkdir (Python), create_dir_all (Rust),
@@ -1047,6 +1070,40 @@ while IFS= read -r f; do
 
     if [ "$is_sh" = 1 ] && [ "$vendored_mirror" = 0 ] && [ "$has_ee" = 0 ] && printf '%s' "$content" | grep -Eq -- "$MKTEMP_ASSIGN"; then
       emit "$f" "$n" fail-open "unchecked mktemp in a file without errexit — a failed mktemp leaves the variable empty and the script runs on"
+    fi
+
+    # The mirror shape, in a file that DOES set errexit: a bare assignment
+    # carries the substitution's own status out, so the script dies on the
+    # assignment and the guard written under it never runs. `git rev-parse`
+    # outside a repository is the live one — eight sites each exited at its
+    # bare 128 with nothing on either stream (KEN-1166, KEN-1193).
+    # No comment-line test: the regex anchors the variable name at the start
+    # of the line, so a `#` in front of the shape already fails to match.
+    if [ "$is_sh" = 1 ] && [ "$own_rules" = 0 ] && [ "$vendored_mirror" = 0 ] \
+      && [ "$has_ee" = 1 ]; then
+      case "$content" in
+        *'$('*)
+          # The operator is a status capture only OUTSIDE the substitution, so
+          # the skip reads the tail past the last `)`: `VAR="$(cmd)" || VAR=""`
+          # is the fix shape and stays out, while `VAR="$(cd "$d" && cmd)"` —
+          # whose inner operator captures nothing — is judged like any other.
+          case "${content##*)}" in
+            *'||'* | *'&&'*) ;;
+            *)
+              if grep -Eq -- "$SUBST_ASSIGN_RE" <<<"$content"; then
+                assign_var="${content#"${content%%[![:space:]]*}"}"
+                case "$assign_var" in
+                  local\ * | declare\ * | export\ * | readonly\ * | typeset\ *) assign_var="${assign_var#* }" ;;
+                esac
+                assign_var="${assign_var%%=*}"
+                if guard_tests_var "$cpath" "$n" "$assign_var"; then
+                  emit "$f" "$n" fail-open "bare command-substitution assignment under errexit — its status ends the script here, so the test of \$$assign_var below never runs; move the assignment into the condition"
+                fi
+              fi
+              ;;
+          esac
+          ;;
+      esac
     fi
 
     # The literal prefilters keep the regex passes off the lines that cannot

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -630,8 +630,12 @@ guard_tests_var() { # FILE LINE VAR — 0 when a line just below tests VAR
   # -q` stops at its first match and closes the pipe, and under pipefail
   # sed's SIGPIPE makes the pipeline 141 — in this condition position a
   # match would then read as no match and the finding would be dropped.
+  # Read through stdin so the path is never an operand: BSD sed rejects `--`
+  # outright ("illegal option"), and the nonzero status it exits with reached
+  # the `|| return 1` below, so on macOS this answered "no guard" every time
+  # and the lane silently never fired.
   local window=""
-  window="$(sed -n "$(($2 + 1)),$(($2 + 4))p" -- "$1" 2>/dev/null)" || return 1
+  window="$(sed -n "$(($2 + 1)),$(($2 + 4))p" <"$1" 2>/dev/null)" || return 1
   grep -Eq -- "(\[\[?|test)[[:space:]][^]]*\\\$\{?$3([^A-Za-z0-9_]|\$)" <<<"$window"
 }
 # A directory-CREATING call taking a literal absolute temp path (/tmp,

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -490,6 +490,12 @@ is_shell_path() { # PATH CONTENT-PATH — extension, else a sh/bash shebang
 # as enabled can only cost a finding, while missing one would invent a
 # fail-open report against a script that is in fact strict.
 ERREXIT_RE='^[[:space:]]*set[[:space:]].*(-[a-zA-Z]*e|-o[[:space:]]+errexit)'
+# `set +e` (or `+o errexit`) anywhere in the file: inside such a window a bare
+# assignment does not end the script and the guard below it does run, and this
+# lane reads whole files rather than shell state, so it cannot tell which side
+# of the window a line sits on. Precision before coverage — a file that turns
+# errexit back off is left alone.
+NOERREXIT_RE='^[[:space:]]*set[[:space:]].*(\+[a-zA-Z]*e|\+o[[:space:]]+errexit)'
 NOUNSET_RE='^[[:space:]]*set[[:space:]].*(-[a-zA-Z]*u|-o[[:space:]]+nounset)'
 PIPEFAIL_RE='^[[:space:]]*set[[:space:]].*pipefail'
 file_matches() { grep -Eq -- "$2" "$1" 2>/dev/null; }
@@ -611,15 +617,18 @@ has_exit_trap() { # FILE
   # end and still exits 1 when nothing matched.
   grep -Ev -- '^[[:space:]]*#' "$1" 2>/dev/null | grep -Ec -- "$TRAP_EXIT_RE" >/dev/null
 }
-# A bare `VAR="$(cmd)"`: the assignment standing alone as the whole command,
-# a `local`-family keyword in front of it changing nothing. Under errexit the
-# substitution's own status escapes from the assignment, so the script dies on
-# that line. `if ! VAR=...` and a same-line `||` put the status somewhere the
-# shell tests, which is the fix rather than the shape.
+# A bare `VAR="$(cmd)"`: the assignment standing alone as the whole command.
+# Under errexit the substitution's own status escapes from the assignment, so
+# the script dies on that line. `if ! VAR=...` and a same-line `||` put the
+# status somewhere the shell tests, which is the fix rather than the shape.
+# A `local`/`declare`/`export`/`readonly`/`typeset` in front is NOT the shape:
+# the builtin's own status becomes the command's and masks the substitution's,
+# so the script survives and the guard below does run. SC2155 names that
+# masking, and the masked-returns lane owns it rather than this one.
 # The trailing `[^(]` is what keeps arithmetic expansion out: `$((n + 1))` also
 # opens with `$(`, and it runs no command and carries no status, so a loop
 # counter — the commonest line in this repo's own tooling — is not the shape.
-SUBST_ASSIGN_RE='^[[:space:]]*(local|declare|export|readonly|typeset)?[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=["'\'']?\$\([^(]'
+SUBST_ASSIGN_RE='^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=["'\'']?\$\([^(]'
 # The guard the assignment was written to reach: a test naming the assigned
 # variable on one of the lines just below. It is the whole finding — a
 # variable nothing below tests belongs to a command whose failure is MEANT to
@@ -636,6 +645,10 @@ guard_tests_var() { # FILE LINE VAR — 0 when a line just below tests VAR
   # and the lane silently never fired.
   local window=""
   window="$(sed -n "$(($2 + 1)),$(($2 + 4))p" <"$1" 2>/dev/null)" || return 1
+  # Comment lines go first: a guard written in a comment runs nothing, so a
+  # deliberately fatal assignment with an example guard under it is not the
+  # shape. grep exits 1 on an all-comment window, which is no guard either.
+  window="$(grep -Ev -- '^[[:space:]]*#' <<<"$window")" || return 1
   grep -Eq -- "(\[\[?|test)[[:space:]][^]]*\\\$\{?$3([^A-Za-z0-9_]|\$)" <<<"$window"
 }
 # A directory-CREATING call taking a literal absolute temp path (/tmp,
@@ -930,6 +943,7 @@ while IFS= read -r f; do
 
   is_sh=0
   has_ee=0
+  has_noee=0
   has_pf=0
   has_trap=0
   mktemp_reported=0
@@ -997,6 +1011,7 @@ while IFS= read -r f; do
   fi
   if [ "$is_sh" = 1 ]; then
     file_matches "$cpath" "$ERREXIT_RE" && has_ee=1
+    file_matches "$cpath" "$NOERREXIT_RE" && has_noee=1
     file_matches "$cpath" "$PIPEFAIL_RE" && has_pf=1
     has_exit_trap "$cpath" && has_trap=1
 
@@ -1084,7 +1099,7 @@ while IFS= read -r f; do
     # No comment-line test: the regex anchors the variable name at the start
     # of the line, so a `#` in front of the shape already fails to match.
     if [ "$is_sh" = 1 ] && [ "$own_rules" = 0 ] && [ "$vendored_mirror" = 0 ] \
-      && [ "$has_ee" = 1 ]; then
+      && [ "$has_ee" = 1 ] && [ "$has_noee" = 0 ]; then
       case "$content" in
         *'$('*)
           # The operator is a status capture only OUTSIDE the substitution, so
@@ -1096,9 +1111,6 @@ while IFS= read -r f; do
             *)
               if grep -Eq -- "$SUBST_ASSIGN_RE" <<<"$content"; then
                 assign_var="${content#"${content%%[![:space:]]*}"}"
-                case "$assign_var" in
-                  local\ * | declare\ * | export\ * | readonly\ * | typeset\ *) assign_var="${assign_var#* }" ;;
-                esac
                 assign_var="${assign_var%%=*}"
                 if guard_tests_var "$cpath" "$n" "$assign_var"; then
                   emit "$f" "$n" fail-open "bare command-substitution assignment under errexit — its status ends the script here, so the test of \$$assign_var below never runs; move the assignment into the condition"

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -625,10 +625,12 @@ has_exit_trap() { # FILE
 # the builtin's own status becomes the command's and masks the substitution's,
 # so the script survives and the guard below does run. SC2155 names that
 # masking, and the masked-returns lane owns it rather than this one.
+# Only a double quote, or none: inside single quotes `$(cmd)` is literal text,
+# no command runs and no status can end anything.
 # The trailing `[^(]` is what keeps arithmetic expansion out: `$((n + 1))` also
 # opens with `$(`, and it runs no command and carries no status, so a loop
 # counter — the commonest line in this repo's own tooling — is not the shape.
-SUBST_ASSIGN_RE='^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=["'\'']?\$\([^(]'
+SUBST_ASSIGN_RE='^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*="?\$\([^(]'
 # The guard the assignment was written to reach: a test naming the assigned
 # variable on one of the lines just below. It is the whole finding — a
 # variable nothing below tests belongs to a command whose failure is MEANT to

--- a/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/skills/preflight/tests/lanes-must-fail.test.sh
@@ -127,14 +127,15 @@ fires "a condition piping echo into grep -q fails as early-close-pipe" "scripts/
 
 echo "=== lane fail-open: a bare command-substitution assignment under errexit ==="
 seed bareassign
-# The keyword spelling, and the guard at the far edge of the look-ahead
-# window: the assignment is on line 3 and the test of $ROOT on line 7, four
-# lines below it. A narrower window, or a keyword strip that leaves the
-# variable named `readonly ROOT`, stops finding this.
+# The guard sits at the far edge of the look-ahead window: the assignment is
+# on line 3 and the test of $ROOT on line 7, four lines below it. A narrower
+# window stops finding this. The assignment is bare on purpose — a `readonly`
+# or `local` in front would mask the substitution's status and the script
+# would survive, which is the masked-returns lane's shape, not this one's.
 {
   printf '#!/usr/bin/env bash\n'
   printf 'set -euo pipefail\n'
-  printf 'readonly ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"\n'
+  printf 'ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"\n'
   printf 'log() {\n'
   printf '  printf "%%s\\n" "$1" >&2\n'
   printf '}\n'

--- a/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/skills/preflight/tests/lanes-must-fail.test.sh
@@ -125,6 +125,38 @@ git -C "$R" add -A
 run_pf
 fires "a condition piping echo into grep -q fails as early-close-pipe" "scripts/existing.sh:3: [early-close-pipe] a shell writer piped into a reader that stops before EOF"
 
+echo "=== lane fail-open: a bare command-substitution assignment under errexit ==="
+seed bareassign
+# The keyword spelling, and the guard at the far edge of the look-ahead
+# window: the assignment is on line 3 and the test of $ROOT on line 7, four
+# lines below it. A narrower window, or a keyword strip that leaves the
+# variable named `readonly ROOT`, stops finding this.
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'set -euo pipefail\n'
+  printf 'readonly ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"\n'
+  printf 'log() {\n'
+  printf '  printf "%%s\\n" "$1" >&2\n'
+  printf '}\n'
+  printf 'if [ -z "$ROOT" ]; then\n'
+  printf '  log "not inside a repository"\n'
+  printf '  exit 1\n'
+  printf 'fi\n'
+  printf 'INNER="$(cd "$ROOT" && git rev-parse HEAD 2>/dev/null)"\n'
+  printf 'if [ -z "$INNER" ]; then\n'
+  printf '  exit 1\n'
+  printf 'fi\n'
+  printf 'echo "$ROOT $INNER"\n'
+} >"$R/scripts/bare.sh"
+git -C "$R" add -A
+run_pf
+fires "an assignment whose guard errexit kills first fails as fail-open" \
+  "scripts/bare.sh:3: [fail-open] bare command-substitution assignment under errexit"
+# An operator INSIDE the substitution captures nothing, so it must not read as
+# the same-line status capture that makes the fix shape exempt.
+fires "an operator inside the substitution does not exempt the assignment" \
+  "scripts/bare.sh:11: [fail-open] bare command-substitution assignment under errexit"
+
 echo "=== lane mktemp-trap: a new script whose scratch nothing removes ==="
 seed scratch
 printf '#!/usr/bin/env bash\nset -euo pipefail\nD="$(mktemp -d)"\necho "$D"\n' >"$R/scripts/scratch.sh"

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -211,9 +211,43 @@ echo "$v" | jq -e . >/dev/null 2>&1 || grep -q x <<<"$v"
 echo "$MSG"
 EOF
 printf '{\n  // a comment: this dialect is real and jq is right to reject it\n  "strict": true\n}\n' >"$R/tsconfig.json"
+# Every benign spelling of a command substitution assigned under errexit. The
+# shape is a defect only when a guard below the assignment can never run, so a
+# substitution whose failure is MEANT to end the script, one already sitting in
+# a condition, and one whose status the same line captures are all correct code.
+cat >"$R/scripts/assign.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+# Nothing below tests it: errexit ending the run here is the intended fatal.
+# The test of $STAMP far below is out of the look-ahead window and must stay
+# out — a guard that distant belongs to no assignment, so a wider window turns
+# every deliberate fatal into a finding.
+STAMP="$(date +%s)"
+echo "$STAMP"
+# The fix shape: the status is in a position the shell tests.
+if ! ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || [ -z "$ROOT" ]; then
+  echo "no repository" >&2
+  exit 1
+fi
+# Captured on the same line, so the test below is reachable.
+BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null)" || BRANCH=""
+[ -z "$BRANCH" ] || echo "$BRANCH"
+# Arithmetic expansion opens with the same two characters and runs no command,
+# so a loop counter under its own bound test is not the shape.
+tries=0
+while [ "$tries" -lt 3 ]; do
+  tries=$((tries + 1))
+  if [ "$tries" -gt 2 ]; then
+    break
+  fi
+done
+# Naming the shape is not writing it: HERE="$(cmd)" with [ -z "$HERE" ] under it.
+echo "$ROOT"
+[ -z "$STAMP" ] || echo "still set"
+EOF
 git -C "$R" add -A
 run_pf
-clean "no lane fires on placeholders, URLs, quoted or data-file or test-file doc cites, foreign subtrees, referenced TODOs, strict scripts, wired suites, trapped scratch dirs, captured statuses, here-string, read-to-EOF and OR-list pipeline shapes, the same shapes named in a comment or a string, or JSON-with-comments"
+clean "no lane fires on placeholders, URLs, quoted or data-file or test-file doc cites, foreign subtrees, referenced TODOs, strict scripts, wired suites, trapped scratch dirs, captured statuses, here-string, read-to-EOF and OR-list pipeline shapes, guarded or deliberately fatal command-substitution assignments, the same shapes named in a comment or a string, or JSON-with-comments"
 
 echo "=== control: the same fixture still fails on a real defect ==="
 printf 'And a citation that is dead: `docs/gone.md`.\n' >>"$R/README.md"

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -114,6 +114,19 @@ echo "=== benign patterns across every lane stay clean ==="
 seed benign
 # mktemp is fine under errexit; a new script that declares strict mode is fine.
 printf '#!/usr/bin/env bash\nset -euo pipefail\nTMP="$(mktemp -d)"\ntrap %s EXIT\necho "$TMP"\n' "'rm -rf \"\$TMP\"'" >"$R/scripts/strict.sh"
+# Inside a `set +e` window a bare assignment ends nothing and the guard below
+# it does run, so a file that turns errexit back off is not judged at all.
+cat >"$R/scripts/window.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+set +e
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+set -e
+if [ -z "$ROOT" ]; then
+  exit 1
+fi
+echo "$ROOT"
+EOF
 # A test-tree script sets its own rules — including the fixture path it cites.
 printf '#!/usr/bin/env bash\n# fixture: docs/gone.md\necho helper\n' >"$R/tests/helper.sh"
 # Every benign doc-citation shape a source file can carry.
@@ -243,6 +256,11 @@ while [ "$tries" -lt 3 ]; do
 done
 # Naming the shape is not writing it: HERE="$(cmd)" with [ -z "$HERE" ] under it.
 echo "$ROOT"
+# A guard written in a comment runs nothing, so the deliberate fatal above it
+# stands and is not this lane's shape.
+FATAL="$(date +%s)"
+# if [ -z "$FATAL" ]; then exit 1; fi
+echo "$FATAL"
 [ -z "$STAMP" ] || echo "still set"
 EOF
 git -C "$R" add -A

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -260,7 +260,12 @@ echo "$ROOT"
 # stands and is not this lane's shape.
 FATAL="$(date +%s)"
 # if [ -z "$FATAL" ]; then exit 1; fi
-echo "$FATAL"
+# Single quotes make it literal text: no command runs, so nothing can end here.
+LITERAL='$(date +%s)'
+if [ -z "$LITERAL" ]; then
+  exit 1
+fi
+echo "$FATAL $LITERAL"
 [ -z "$STAMP" ] || echo "still set"
 EOF
 git -C "$R" add -A

--- a/skills/second-opinion/scripts/second-opinion
+++ b/skills/second-opinion/scripts/second-opinion
@@ -285,8 +285,13 @@ readonly -a ORIGINAL_ARGS
 # because the message being read is translated.
 if ! PROJECT_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)"; then
   _git_diag="$(LC_ALL=C git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>&1 >/dev/null)" || :
+  # The parenthetical is what separates "there is no repository above me" from
+  # "there is one and it is broken": a linked worktree whose marker points at a
+  # gone or unreadable target answers `not a git repository: (null)`, and that
+  # checkout DOES carry settings, so it must refuse rather than degrade. Any
+  # message this does not recognise refuses too.
   case "$_git_diag" in
-    *"not a git repository"*) PROJECT_ROOT="" ;;
+    *"not a git repository (or any of the parent directories)"*) PROJECT_ROOT="" ;;
     *)
       echo "second-opinion: could not resolve a repository at $SCRIPT_DIR" >&2
       echo "  git said: ${_git_diag#fatal: }" >&2

--- a/skills/second-opinion/scripts/second-opinion
+++ b/skills/second-opinion/scripts/second-opinion
@@ -268,8 +268,33 @@ readonly SCRIPT_DIR FOREGROUND_CAP_IN_CALLER_ENV FOREGROUND_CAP_WAS_IN_CALLER_EN
   CURRENT_MODEL_IS_SESSION_SCOPED CURRENT_MODEL_IN_CALLER_ENV
 readonly -a ORIGINAL_ARGS
 # Resolved only after help is answered: help must not require a git
-# checkout around the installed script.
-PROJECT_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)"
+# checkout around the installed script. The assignment sits in the condition
+# (KEN-1193): outside a repository `git rev-parse` exits 128 and under `set -e`
+# a bare assignment carries that status out, ending the run before anything
+# below it.
+#
+# Only ONE failure means there is nothing to load. An install outside a
+# repository has no project configuration, and kendex_load_project_env already
+# treats an empty root as exactly that. Every other nonzero status — git's
+# dubious-ownership refusal on a checkout owned by another uid, which is the
+# normal shape of a mounted workspace, or no git on PATH — comes from a
+# checkout that DOES carry kendex.settings.toml and .env.local. Degrading
+# there would run the review on built-in defaults with the project's own
+# model and command settings silently ignored, so it refuses instead and
+# quotes git's own account rather than guessing at the cause. LC_ALL=C
+# because the message being read is translated.
+if ! PROJECT_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)"; then
+  _git_diag="$(LC_ALL=C git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>&1 >/dev/null)" || :
+  case "$_git_diag" in
+    *"not a git repository"*) PROJECT_ROOT="" ;;
+    *)
+      echo "second-opinion: could not resolve a repository at $SCRIPT_DIR" >&2
+      echo "  git said: ${_git_diag#fatal: }" >&2
+      exit 1
+      ;;
+  esac
+  unset _git_diag
+fi
 # Source project config/secrets. .env.local overrides public settings; the
 # caller's own environment (set or set-but-empty) outranks every project file —
 # kendex_load_project_env snapshots and re-asserts it.

--- a/skills/second-opinion/scripts/second-opinion
+++ b/skills/second-opinion/scripts/second-opinion
@@ -286,12 +286,16 @@ readonly -a ORIGINAL_ARGS
 if ! PROJECT_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)"; then
   _git_diag="$(LC_ALL=C git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>&1 >/dev/null)" || :
   # The parenthetical is what separates "there is no repository above me" from
-  # "there is one and it is broken": a linked worktree whose marker points at a
-  # gone or unreadable target answers `not a git repository: (null)`, and that
-  # checkout DOES carry settings, so it must refuse rather than degrade. Any
-  # message this does not recognise refuses too.
+  # "there is one and it is broken". Git names the parents it searched two ways
+  # — the parent directories, or the parents up to a mount point when discovery
+  # stops at a filesystem boundary — and both are the absence. A `.git` that
+  # points nowhere gets the same three words WITHOUT a parenthetical
+  # (`not a git repository: (null)`), and that is a repository git could not
+  # read, from a checkout that does carry settings, so it refuses. Any message
+  # this does not recognise refuses too. hooks/block-worktree-refresh.sh splits
+  # the same diagnostic the same way.
   case "$_git_diag" in
-    *"not a git repository (or any of the parent directories)"*) PROJECT_ROOT="" ;;
+    *"not a git repository (or any"*) PROJECT_ROOT="" ;;
     *)
       echo "second-opinion: could not resolve a repository at $SCRIPT_DIR" >&2
       echo "  git said: ${_git_diag#fatal: }" >&2

--- a/skills/second-opinion/scripts/second-opinion
+++ b/skills/second-opinion/scripts/second-opinion
@@ -294,6 +294,12 @@ if ! PROJECT_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)
   # read, from a checkout that does carry settings, so it refuses. Any message
   # this does not recognise refuses too. hooks/block-worktree-refresh.sh splits
   # the same diagnostic the same way.
+  #
+  # The limit of reading the message: an EMPTY or malformed `.git` DIRECTORY
+  # draws the parenthetical too, so it lands here as an absence. Separating
+  # that from a true absence takes an ancestor walk for a `.git` entry, which
+  # the hook above owns; this does not carry a second copy of it. Git itself
+  # reports no repository in that state, so no root could be resolved anyway.
   case "$_git_diag" in
     *"not a git repository (or any"*) PROJECT_ROOT="" ;;
     *)

--- a/skills/second-opinion/tests/no-repository-classification.test.sh
+++ b/skills/second-opinion/tests/no-repository-classification.test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# The script resolves PROJECT_ROOT from its own location before loading project
+# settings. Outside a repository `git rev-parse` exits 128, and a bare
+# assignment carried that status out under `set -e`, ending the run at 128 with
+# nothing on either stream (KEN-1193).
+#
+# Only ONE failure means there is nothing to load. An install outside a
+# repository has no project configuration, and that degrades to the caller's
+# environment. Every other nonzero status comes from a checkout that DOES carry
+# settings — git's dubious-ownership refusal, or no git at all — so those refuse
+# rather than silently running on built-in defaults. This suite pins the split.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf -- "${TMP_ROOT:?}"' EXIT
+
+PASS=0
+FAIL=0
+ok() {
+  PASS=$((PASS + 1))
+  printf '  ok    %s\n' "$1"
+}
+bad() {
+  FAIL=$((FAIL + 1))
+  printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"
+}
+
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below back at the real repository and make the copy read as a checkout.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
+# TMPDIR can itself sit inside a checkout on a developer box; the ceiling stops
+# rev-parse's upward search so "outside a repository" is what this actually is.
+export GIT_CEILING_DIRECTORIES="$TMP_ROOT"
+
+# No `git init` anywhere above it: this is the installed-outside-a-repository
+# case the degrade branch exists for.
+mkdir -p "$TMP_ROOT/install"
+cp -R "$REPO_ROOT/skills/second-opinion" "$TMP_ROOT/install/second-opinion"
+SECOND_OPINION="$TMP_ROOT/install/second-opinion/scripts/second-opinion"
+
+probe_status=0
+probe=$(LC_ALL=C git -C "$TMP_ROOT/install" rev-parse --show-toplevel 2>&1) || probe_status=$?
+probe_is_norepo=1
+case "$probe" in *"not a git repository"*) ;; *) probe_is_norepo=0 ;; esac
+if [ "$probe_status" -ne 128 ] || [ "$probe_is_norepo" -eq 0 ]; then
+  bad "the install fixture is outside a git repository" "status=$probe_status out=$probe"
+  printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+  exit 1
+fi
+ok "the install fixture is outside a git repository"
+
+# An unparseable argument is answered by the option parser, which sits below the
+# repository lookup: reaching it at all proves the lookup did not end the run.
+status=0
+out=$("$SECOND_OPINION" --mode no-such-mode 2>"$TMP_ROOT/degrade.err") || status=$?
+err=$(cat "$TMP_ROOT/degrade.err")
+if [ "$status" -eq 128 ]; then
+  bad "an install outside a repository runs on rather than exiting at git's 128" "err=$err"
+else
+  ok "an install outside a repository runs on rather than exiting at git's 128"
+fi
+case "$err" in
+  *"unknown argument"*) ok "it reaches the option parser below the lookup" ;;
+  *) bad "it reaches the option parser below the lookup" "err=$err" ;;
+esac
+case "$err" in
+  *"could not resolve a repository"*) bad "having nothing to load is not a refusal" "err=$err" ;;
+  *) ok "having nothing to load is not a refusal" ;;
+esac
+
+# Any OTHER nonzero status is a checkout whose settings would be skipped in
+# silence, so it refuses and quotes git rather than guessing at the cause. A
+# PATH with no git on it is that case, and the one this box can produce.
+mkdir -p "$TMP_ROOT/emptybin"
+for tool in bash env sed grep dirname cat mktemp; do
+  resolved="$(command -v "$tool" 2>/dev/null)" || continue
+  ln -sf "$resolved" "$TMP_ROOT/emptybin/$tool"
+done
+status=0
+out=$(PATH="$TMP_ROOT/emptybin" LC_ALL=C "$SECOND_OPINION" --mode no-such-mode 2>"$TMP_ROOT/nogit.err") || status=$?
+err=$(cat "$TMP_ROOT/nogit.err")
+if [ "$status" -eq 1 ]; then
+  ok "a lookup failure that is not an absent repository refuses with status 1"
+else
+  bad "a lookup failure that is not an absent repository refuses with status 1" "status=$status err=$err"
+fi
+case "$err" in
+  *"could not resolve a repository at"*) ok "the refusal names the directory it looked in" ;;
+  *) bad "the refusal names the directory it looked in" "err=$err" ;;
+esac
+# Read the quoted line alone: without the anchor the needle also matches the
+# shell's own unredirected "command not found", which is what stderr carries
+# when the refusal quotes nothing at all.
+said=""
+if ! said=$(grep -F '  git said: ' "$TMP_ROOT/nogit.err"); then said=""; fi
+case "$said" in
+  *"git: command not found"*) ok "the refusal quotes git's own account rather than asserting a cause" ;;
+  *) bad "the refusal quotes git's own account rather than asserting a cause" "said=$said" ;;
+esac
+if [ -z "$out" ]; then
+  ok "the refusal prints nothing on stdout"
+else
+  bad "the refusal prints nothing on stdout" "out=$out"
+fi
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/skills/second-opinion/tests/no-repository-classification.test.sh
+++ b/skills/second-opinion/tests/no-repository-classification.test.sh
@@ -154,5 +154,36 @@ case "$err" in
   *) bad "that refusal names the directory too" "err=$err" ;;
 esac
 
+# Git names the parents it searched a second way when discovery stops at a
+# filesystem boundary: `not a git repository (or any parent up to mount point
+# ...)`. That is still the absence of a repository, so it must degrade. A real
+# second mount is not portable across the platforms this suite runs on, so the
+# diagnostic is delivered by a git that answers with it — the tool the script
+# calls, not the branch under test.
+mkdir -p "$TMP_ROOT/mountbin"
+for tool in bash env sed grep dirname cat mktemp; do
+  resolved="$(command -v "$tool" 2>/dev/null)" || continue
+  ln -sf "$resolved" "$TMP_ROOT/mountbin/$tool"
+done
+cat >"$TMP_ROOT/mountbin/git" <<'GITSH'
+#!/usr/bin/env bash
+printf 'fatal: not a git repository (or any parent up to mount point /mnt)\n' >&2
+printf 'Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).\n' >&2
+exit 128
+GITSH
+chmod +x "$TMP_ROOT/mountbin/git"
+
+status=0
+out=$(PATH="$TMP_ROOT/mountbin" LC_ALL=C "$SECOND_OPINION" --mode no-such-mode 2>"$TMP_ROOT/mount.err") || status=$?
+err=$(cat "$TMP_ROOT/mount.err")
+case "$err" in
+  *"could not resolve a repository"*) bad "a mount-point boundary is the absence of a repository, not a refusal" "err=$err" ;;
+  *) ok "a mount-point boundary is the absence of a repository, not a refusal" ;;
+esac
+case "$err" in
+  *"unknown argument"*) ok "it degrades past the lookup into option parsing" ;;
+  *) bad "it degrades past the lookup into option parsing" "status=$status err=$err" ;;
+esac
+
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/second-opinion/tests/no-repository-classification.test.sh
+++ b/skills/second-opinion/tests/no-repository-classification.test.sh
@@ -91,6 +91,10 @@ case "$err" in
   *"could not resolve a repository at"*) ok "the refusal names the directory it looked in" ;;
   *) bad "the refusal names the directory it looked in" "err=$err" ;;
 esac
+case "$err" in
+  *"unknown argument"*) bad "it refuses above option parsing rather than degrading into it" "err=$err" ;;
+  *) ok "it refuses above option parsing rather than degrading into it" ;;
+esac
 # Read the quoted line alone: without the anchor the needle also matches the
 # shell's own unredirected "command not found", which is what stderr carries
 # when the refusal quotes nothing at all.
@@ -105,6 +109,50 @@ if [ -z "$out" ]; then
 else
   bad "the refusal prints nothing on stdout" "out=$out"
 fi
+
+# A linked worktree whose marker points at a gone target answers
+# `not a git repository: (null)` — the same three words as the absent-repository
+# case, from a checkout that DOES carry settings. Lanes here run out of linked
+# worktrees, so a pruned or moved main checkout produces exactly this.
+mkdir -p "$TMP_ROOT/wtmain"
+git init -q "$TMP_ROOT/wtmain"
+git -C "$TMP_ROOT/wtmain" config user.email test@example.com
+git -C "$TMP_ROOT/wtmain" config user.name test
+printf 'x\n' >"$TMP_ROOT/wtmain/f"
+git -C "$TMP_ROOT/wtmain" add f
+git -C "$TMP_ROOT/wtmain" -c commit.gpgsign=false commit -qm init
+git -C "$TMP_ROOT/wtmain" worktree add -q -b wt "$TMP_ROOT/wtlinked"
+mkdir -p "$TMP_ROOT/wtlinked/skills"
+cp -R "$REPO_ROOT/skills/second-opinion" "$TMP_ROOT/wtlinked/skills/second-opinion"
+# Break the marker the way a pruned or relocated main checkout does.
+rm -rf -- "${TMP_ROOT:?}/wtmain/.git/worktrees"
+
+marker_diag=$(LC_ALL=C git -C "$TMP_ROOT/wtlinked" rev-parse --show-toplevel 2>&1) || true
+case "$marker_diag" in
+  *"not a git repository"*) ok "a broken worktree marker still says 'not a git repository'" ;;
+  *) bad "a broken worktree marker still says 'not a git repository'" "diag=$marker_diag" ;;
+esac
+
+status=0
+out=$(LC_ALL=C "$TMP_ROOT/wtlinked/skills/second-opinion/scripts/second-opinion" \
+  --mode no-such-mode 2>"$TMP_ROOT/marker.err") || status=$?
+err=$(cat "$TMP_ROOT/marker.err")
+# Status alone proves nothing here: the unparseable argument would exit 1 too.
+# The refusal happens at the lookup, ABOVE option parsing, so never reaching
+# the parser is what separates refusing from degrading.
+if [ "$status" -eq 1 ]; then
+  ok "a broken worktree marker exits 1"
+else
+  bad "a broken worktree marker exits 1" "status=$status err=$err"
+fi
+case "$err" in
+  *"unknown argument"*) bad "it refuses above option parsing rather than degrading into it" "err=$err" ;;
+  *) ok "it refuses above option parsing rather than degrading into it" ;;
+esac
+case "$err" in
+  *"could not resolve a repository at"*) ok "that refusal names the directory too" ;;
+  *) bad "that refusal names the directory too" "err=$err" ;;
+esac
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
`git rev-parse --show-toplevel` exits 128 outside a repository. Assigned with a bare `VAR="$(...)"` the status escapes from the assignment itself under `set -e`, so the guard written on the next lines never runs. Every linear subcommand run from outside a checkout died at a bare 128 with zero bytes on stdout and stderr; second-opinion did the same for an install outside one.

## The five sites

`lib/common.sh` puts both the rev-parse and the `linear_canonical_existing_dir` call in one condition and refuses with the JSON error shape the rest of the CLI uses, naming the directory it could not resolve a repository from. `lib/cache.sh` does the same in `linear_cache_project_root` and at the `CACHE_PROJECT_ROOT` assignment that carries the function's status out.

`second-opinion` degrades instead, but only for the one failure that means there is nothing to load. An install outside a repository has no project configuration, and `kendex_load_project_env` already treats an empty root as exactly that. Every other nonzero status comes from a checkout that does carry `kendex.settings.toml` and `.env.local` — git's dubious-ownership refusal on a checkout owned by another uid, or no git on PATH — so degrading there would run the review on built-in defaults with the project's own model and command settings silently ignored. Those refuse, quoting git's own account.

## The lane

One grep in the existing added-lines lane loop: an added line assigning a bare command substitution in a file that sets errexit, whose next four lines test the assigned variable. It reuses the added-lines record and the `is_sh` / `own_rules` / `vendored_mirror` classification, and reports under the existing `fail-open` lane, so the lane list and `--help` are unchanged.

Two things the regex must not do. Arithmetic expansion opens with the same two characters and runs no command, so the substitution is anchored `\$\([^(]` — a loop counter under its own bound test is the commonest line in this repo's tooling and is not the shape. And the same-line `||` that makes the fix shape exempt is a status capture only outside the substitution, so that test reads the tail past the last `)`: `VAR="$(cd "$d" && cmd)"` is judged like any other bare assignment while `VAR="$(cmd)" || VAR=""` stays out.

## Tests

One must-fail control for the grep, one precision control, and `skills/linear/tests/no-repository-refusal.test.sh` with its `controls/` entry, fenced with `GIT_CEILING_DIRECTORIES` as `worktree_help_dispatch.sh` is. The two preflight fixtures are spelled to pin what they cover, and five mutants of the lane are killed by them: the keyword strip, the look-ahead window in each direction, the arithmetic anchor and the operator tail.

`cache.sh` and `second-opinion` get no test of their own, deliberately: after `common.sh` refuses, `cache.sh`'s git branch is unreachable from a linear command, and `second-opinion`'s site needs an install outside a repository, which this box cannot produce.

`controls/cache-root-git-worktree.control.sh` declared its mutation on the exact `CACHE_PROJECT_ROOT` line this reshapes and matched nothing; it is retargeted at the new line with the same mutation.

## Notes

KEN-1171 landed mid-review and its `early-close-pipe` lane caught a real defect in this diff: the look-ahead window was piped into `grep -q`, which stops at its first match and closes the pipe, so under pipefail the writer's SIGPIPE made the pipeline 141 — in condition position that reads as no match and drops the finding. The window is now captured whole and read with a here-string. Its grep and this one sit in the same loop without overlapping; the merged must-fail suite runs 36 assertions.

`tools/guard --full` is clean apart from `guard: vitest failed` — seven UI DOM tests timing out at 5000 ms under load 150 on a shared box. This diff touches no `ui/` or `crates/` file and vitest alone re-runs 1193/1193. Tracked as KEN-1266.

Closes KEN-1193.

https://claude.ai/code/session_01Te7naCEyQmnnRnuad6Qn3F
