### PR TITLE
fix(KEN-1194): guard names a signal-killed test binary

### DIFF
--- a/tools/guard
+++ b/tools/guard
@@ -435,7 +435,22 @@ if [ "$FULL" -eq 1 ] && [ -f Cargo.toml ]; then
     done
   fi
   cargo doc --no-deps --document-private-items --workspace --quiet || say "cargo doc failed"
-  cargo test --workspace --quiet || say "tests failed"
+  # A test binary that dies by a signal is not a test verdict: the runner
+  # reports the executable's death, and no assertion was reached. A binary
+  # whose code pages come back wrong from disk dies this way; rebuilding
+  # that artifact answers it, re-running the suite does not. Reported apart
+  # from "tests failed" so a red chain names the artifact instead of the
+  # branch.
+  tests_log=$(mktemp)
+  if ! cargo test --workspace --quiet 2>&1 | tee "$tests_log"; then
+    death=$(grep -m1 -o "process didn't exit successfully: .*(signal: [^)]*)" "$tests_log")
+    if [ -n "$death" ]; then
+      say "a test binary died by a signal, which is not a test verdict: ${death#*successfully: }; delete that artifact under target/ and rebuild before reading the suite as red"
+    else
+      say "tests failed"
+    fi
+  fi
+  rm -f "$tests_log"
 fi
 if [ "$ui_changed" -eq 1 ] && [ -f ui/package.json ]; then
   npm run --prefix ui check:types || say "tsc failed"

--- a/tools/guard
+++ b/tools/guard
@@ -435,17 +435,21 @@ if [ "$FULL" -eq 1 ] && [ -f Cargo.toml ]; then
     done
   fi
   cargo doc --no-deps --document-private-items --workspace --quiet || say "cargo doc failed"
-  # A test binary that dies by a signal is not a test verdict: the runner
-  # reports the executable's death, and no assertion was reached. A binary
-  # whose code pages come back wrong from disk dies this way; rebuilding
-  # that artifact answers it, re-running the suite does not. Reported apart
-  # from "tests failed" so a red chain names the artifact instead of the
-  # branch.
+  # A test binary that dies by a signal reached no verdict: the runner
+  # reports the executable's death, not an assertion. A binary whose code
+  # pages come back wrong from disk dies this way, and rebuilding that
+  # artifact rules it out where re-running the suite cannot. Reported apart
+  # from "tests failed" so a red chain names the artifact. Cargo prints the
+  # same death line for a compiler or build script it launched, under
+  # "could not compile" instead of "test failed"; only the runner's is one.
   tests_log=$(mktemp)
   if ! cargo test --workspace --quiet 2>&1 | tee "$tests_log"; then
-    death=$(grep -m1 -o "process didn't exit successfully: .*(signal: [^)]*)" "$tests_log")
+    death=""
+    if grep -q "^error: test failed" "$tests_log"; then
+      death=$(grep -m1 -o "process didn't exit successfully: .*(signal: [^)]*)" "$tests_log")
+    fi
     if [ -n "$death" ]; then
-      say "a test binary died by a signal, which is not a test verdict: ${death#*successfully: }; delete that artifact under target/ and rebuild before reading the suite as red"
+      say "a test binary died by a signal before any verdict: ${death#*successfully: }; rebuild that artifact under target/ to rule out a corrupt binary before reading the suite as red"
     else
       say "tests failed"
     fi

--- a/tools/tests/guard.test.sh
+++ b/tools/tests/guard.test.sh
@@ -783,6 +783,8 @@ run_guard PATH="$R/fake-bin:$PATH" COMPILE_LOG="$COMPILE_LOG"
 
 echo "=== a test binary's death by a signal is named apart from a failing test ==="
 FULL_GUARD=1
+# The compile-scheduling stub above is put back at the end of the block.
+cp "$R/fake-bin/cargo" "$TMP/compile-cargo"
 cat >"$R/fake-bin/cargo" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -800,25 +802,28 @@ DEATH="$(printf '%s\n' \
 ASSERTION="$(printf '%s\n' \
   'test a_case ... FAILED' \
   'error: test failed, to rerun pass `-p kendex-core --test review_fixes`')"
-run_guard PATH="$R/fake-bin:$PATH" RUSTUP_INSTALLED_TARGETS="$BOTH" CARGO_TEST_STDERR="$DEATH"
+run_guard PATH="$R/fake-bin:$PATH" RUSTUP_INSTALLED_TARGETS="$BOTH" COMPILE_LOG="$COMPILE_LOG" CARGO_TEST_STDERR="$DEATH"
 [ "$RC" -eq 1 ] && [[ "$OUT" == *"guard: a test binary died by a signal"*"review_fixes-ff58"*"SIGSEGV"* ]] \
   && [[ "$OUT" != *"guard: tests failed"* ]] \
   && ok "a runner killed by a signal is reported as the artifact's death, not a failing test" \
   || bad "a runner killed by a signal is reported as the artifact's death, not a failing test" "rc=$RC out=$OUT"
-run_guard PATH="$R/fake-bin:$PATH" RUSTUP_INSTALLED_TARGETS="$BOTH" CARGO_TEST_STDERR="$ASSERTION"
+run_guard PATH="$R/fake-bin:$PATH" RUSTUP_INSTALLED_TARGETS="$BOTH" COMPILE_LOG="$COMPILE_LOG" CARGO_TEST_STDERR="$ASSERTION"
 [ "$RC" -eq 1 ] && [[ "$OUT" == *"guard: tests failed"* ]] && [[ "$OUT" != *"died by a signal"* ]] \
   && ok "a failing assertion still reads as tests failed" \
   || bad "a failing assertion still reads as tests failed" "rc=$RC out=$OUT"
 if mutant_guard 's/if \[ -n "\$death" \]; then/if false; then/'; then
   OUT=""
   RC=0
-  OUT="$(cd "$R" && PATH="$R/fake-bin:$PATH" RUSTUP_INSTALLED_TARGETS="$BOTH" CARGO_TEST_STDERR="$DEATH" "$MUTANT_TOOLS/guard" --full 2>&1)" || RC=$?
+  OUT="$(cd "$R" && PATH="$R/fake-bin:$PATH" RUSTUP_INSTALLED_TARGETS="$BOTH" COMPILE_LOG="$COMPILE_LOG" CARGO_TEST_STDERR="$DEATH" "$MUTANT_TOOLS/guard" --full 2>&1)" || RC=$?
   [ "$RC" -eq 1 ] && [[ "$OUT" == *"guard: tests failed"* ]] && [[ "$OUT" != *"died by a signal"* ]] \
     && ok "control: with the death check removed the same death reads as tests failed" \
     || bad "control: with the death check removed the same death reads as tests failed" "rc=$RC out=$OUT"
 else
   bad "control: the death check could not be removed from a guard copy"
 fi
+cp "$TMP/compile-cargo" "$R/fake-bin/cargo"
+git -C "$R" reset -q HEAD -- Cargo.toml
+git -C "$R" checkout -q -- Cargo.toml
 FULL_GUARD=0
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"

--- a/tools/tests/guard.test.sh
+++ b/tools/tests/guard.test.sh
@@ -781,5 +781,45 @@ run_guard PATH="$R/fake-bin:$PATH" COMPILE_LOG="$COMPILE_LOG"
   && ok "shared Rust inputs compile the workspace without running tests" \
   || bad "shared Rust input scheduling" "rc=$RC out=$OUT calls=$(cat "$COMPILE_LOG")"
 
+echo "=== a test binary's death by a signal is named apart from a failing test ==="
+FULL_GUARD=1
+cat >"$R/fake-bin/cargo" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "$*" = "test --workspace --quiet" ] || exit 0
+printf '%s\n' "$CARGO_TEST_STDERR" >&2
+exit 101
+SH
+chmod +x "$R/fake-bin/cargo"
+# cargo's own report of a runner whose executable died, as it prints it.
+DEATH="$(printf '%s\n' \
+  'error: test failed, to rerun pass `-p kendex-core --test review_fixes`' \
+  '' \
+  'Caused by:' \
+  '  process didn'"'"'t exit successfully: `target/debug/deps/review_fixes-ff58 --quiet` (signal: 11, SIGSEGV: invalid memory reference)')"
+ASSERTION="$(printf '%s\n' \
+  'test a_case ... FAILED' \
+  'error: test failed, to rerun pass `-p kendex-core --test review_fixes`')"
+run_guard PATH="$R/fake-bin:$PATH" RUSTUP_INSTALLED_TARGETS="$BOTH" CARGO_TEST_STDERR="$DEATH"
+[ "$RC" -eq 1 ] && [[ "$OUT" == *"guard: a test binary died by a signal"*"review_fixes-ff58"*"SIGSEGV"* ]] \
+  && [[ "$OUT" != *"guard: tests failed"* ]] \
+  && ok "a runner killed by a signal is reported as the artifact's death, not a failing test" \
+  || bad "a runner killed by a signal is reported as the artifact's death, not a failing test" "rc=$RC out=$OUT"
+run_guard PATH="$R/fake-bin:$PATH" RUSTUP_INSTALLED_TARGETS="$BOTH" CARGO_TEST_STDERR="$ASSERTION"
+[ "$RC" -eq 1 ] && [[ "$OUT" == *"guard: tests failed"* ]] && [[ "$OUT" != *"died by a signal"* ]] \
+  && ok "a failing assertion still reads as tests failed" \
+  || bad "a failing assertion still reads as tests failed" "rc=$RC out=$OUT"
+if mutant_guard 's/if \[ -n "\$death" \]; then/if false; then/'; then
+  OUT=""
+  RC=0
+  OUT="$(cd "$R" && PATH="$R/fake-bin:$PATH" RUSTUP_INSTALLED_TARGETS="$BOTH" CARGO_TEST_STDERR="$DEATH" "$MUTANT_TOOLS/guard" --full 2>&1)" || RC=$?
+  [ "$RC" -eq 1 ] && [[ "$OUT" == *"guard: tests failed"* ]] && [[ "$OUT" != *"died by a signal"* ]] \
+    && ok "control: with the death check removed the same death reads as tests failed" \
+    || bad "control: with the death check removed the same death reads as tests failed" "rc=$RC out=$OUT"
+else
+  bad "control: the death check could not be removed from a guard copy"
+fi
+FULL_GUARD=0
+
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/tools/tests/guard.test.sh
+++ b/tools/tests/guard.test.sh
@@ -802,6 +802,13 @@ DEATH="$(printf '%s\n' \
 ASSERTION="$(printf '%s\n' \
   'test a_case ... FAILED' \
   'error: test failed, to rerun pass `-p kendex-core --test review_fixes`')"
+# The same death line for a compiler cargo launched, under cargo's compile
+# failure rather than its test failure.
+COMPILER_DEATH="$(printf '%s\n' \
+  'error: could not compile `kendex-core` (lib test)' \
+  '' \
+  'Caused by:' \
+  '  process didn'"'"'t exit successfully: `rustc --crate-name kendex_core ...` (signal: 9, SIGKILL: kill)')"
 run_guard PATH="$R/fake-bin:$PATH" RUSTUP_INSTALLED_TARGETS="$BOTH" COMPILE_LOG="$COMPILE_LOG" CARGO_TEST_STDERR="$DEATH"
 [ "$RC" -eq 1 ] && [[ "$OUT" == *"guard: a test binary died by a signal"*"review_fixes-ff58"*"SIGSEGV"* ]] \
   && [[ "$OUT" != *"guard: tests failed"* ]] \
@@ -811,6 +818,10 @@ run_guard PATH="$R/fake-bin:$PATH" RUSTUP_INSTALLED_TARGETS="$BOTH" COMPILE_LOG=
 [ "$RC" -eq 1 ] && [[ "$OUT" == *"guard: tests failed"* ]] && [[ "$OUT" != *"died by a signal"* ]] \
   && ok "a failing assertion still reads as tests failed" \
   || bad "a failing assertion still reads as tests failed" "rc=$RC out=$OUT"
+run_guard PATH="$R/fake-bin:$PATH" RUSTUP_INSTALLED_TARGETS="$BOTH" COMPILE_LOG="$COMPILE_LOG" CARGO_TEST_STDERR="$COMPILER_DEATH"
+[ "$RC" -eq 1 ] && [[ "$OUT" == *"guard: tests failed"* ]] && [[ "$OUT" != *"died by a signal"* ]] \
+  && ok "a compiler killed by a signal is not named as a test binary's death" \
+  || bad "a compiler killed by a signal is not named as a test binary's death" "rc=$RC out=$OUT"
 if mutant_guard 's/if \[ -n "\$death" \]; then/if false; then/'; then
   OUT=""
   RC=0


### PR DESCRIPTION
Closes KEN-1194.

**Cause.** The `review_fixes` SIGSEGV under `cargo test --workspace` is not a test-order or shared-fixture interaction. Both cores recorded on the box fault with the instruction pointer inside the binary's own text at a function entry (kernel `error 7`, three threads at one address at once): the code pages faulted in were not the binary's code. The worktrees volume (`/home/method/dev`, btrfs on nvme2n1p1) is corrupting data it writes: 367 corruption errors in `btrfs device stats`, 214 uncorrectable csum errors in the post-reboot scrub, and the flagged extents that still resolve are cargo artifacts in kendex worktrees, one a kendex-core test binary. The NVMe reports zero media errors and the root volume failed the same night, so the fault sits above the drive. A long workspace run under heavy swap re-reads cold code pages from disk; a short single-target run executes pages still hot from the link, which is why the target passes alone and on CI.

**Runs.** Two clean full `cargo test --workspace` runs in a fresh worktree off main. 40 loop runs of the built `review_fixes` binary while a git-archive copy sharing `CARGO_TARGET_DIR` relinked the same file, all green: cargo and rust-lld replace the output by unlink, temp file, rename (strace-verified), so a concurrent relink never touches a running binary. A page-cache-versus-disk sweep of 301 test binaries: no mismatch.

**Change.** `tools/guard`'s workspace test lane reports a test binary that died by a signal apart from `tests failed`, naming the executable, the signal and the rebuild remedy, so a red chain is read as an artifact to rebuild and not as the branch. `tools/tests/guard.test.sh`: one control, the else arm, one must-fail mutant. No `--test-threads=1`, no retry, no automatic artifact deletion: the suite is correct and a machinery answer to bad hardware fails open. No `crates/` change, so `[no-changelog]`.

**Review round.** One local round, verdict pass. Applied: the block's rc assertions now measure only this lane, and the block restores its fixture. Declined: widening the diagnosis to rustc or build-script deaths in the check, clippy, doc and cross-target lanes. Those are a different producer with a different failure line and none was observed; the issue's producer is the test runner.

**Outside this repository.** The machine needs a memory test.

Program tracking issue: KEN-1203

https://claude.ai/code/session_01KGx3k6zt6TWTGcfvGX2te4
