### PR TITLE
fix(KEN-1263, KEN-1267): a skill's delivery decides where an agent reads it

### DIFF
--- a/changelog.d/fixed/agent-skill-path-follows-delivery.md
+++ b/changelog.d/fixed/agent-skill-path-follows-delivery.md
@@ -1,0 +1,1 @@
+- An agent requiring a skill installed with `method = "copy"` is told to read it from the directory that copy wrote, not the shared tree a copy never writes.

--- a/changelog.d/fixed/command-cross-read-warning-loadable.md
+++ b/changelog.d/fixed/command-cross-read-warning-loadable.md
@@ -1,0 +1,1 @@
+- A command installed as a skill no longer warns that another tool offers it when that tool's loader would reject the installed name.

--- a/changelog.d/fixed/cross-read-note-loadable.md
+++ b/changelog.d/fixed/cross-read-note-loadable.md
@@ -1,0 +1,1 @@
+- The note saying which other tools already see an installed skill no longer names a tool whose loader would reject the skill's name.

--- a/crates/core/src/engine/desired.rs
+++ b/crates/core/src/engine/desired.rs
@@ -345,6 +345,7 @@ fn compute(
                 config: &config,
                 sealed: &sealed,
                 scope_skills: &scope_skills,
+                expansion: &expansion,
                 name,
                 decl,
                 item_path: &item_path,
@@ -395,6 +396,10 @@ pub(super) struct ItemCtx<'a> {
     /// Skills offered by the current checkout of each source. Item-level
     /// pins do not widen this inventory.
     pub(super) scope_skills: &'a super::ScopeSkills,
+    /// The plan this pass is installing, which holds a declaration for
+    /// every derived item — a set's members included — where the manifest
+    /// holds only what the person wrote.
+    pub(super) expansion: &'a super::expansion::Expansion,
     pub(super) name: &'a str,
     pub(super) decl: &'a ItemDecl,
     pub(super) item_path: &'a std::path::Path,

--- a/crates/core/src/engine/desired_agent.rs
+++ b/crates/core/src/engine/desired_agent.rs
@@ -5,8 +5,8 @@ use crate::manifest::{CustomHook, FrontmatterOverrides, HookAgents, Manifest, Me
 use crate::mapping::EffectiveSkills;
 use crate::model::{HarnessId, ItemKind};
 use crate::render::agent::{
-    EffectiveAgent, RenderedAgent, Selects, SourceAgent, file_name, generate, hooks_for_agent,
-    merge_overrides, merged_instructions, parse_source_agent, selects,
+    EffectiveAgent, RenderedAgent, RequiredSkill, Selects, SourceAgent, file_name, generate,
+    hooks_for_agent, merge_overrides, merged_instructions, parse_source_agent, selects,
 };
 use crate::render::validate::validate_agent;
 
@@ -353,6 +353,24 @@ fn gathered<'a>(
     }
 }
 
+/// Each required skill with the delivery that decides where it was
+/// written: its own declaration's, or the scope's default where it made
+/// none, which is also the answer for a skill this scope never declared.
+pub(crate) fn required_skills(manifest: &Manifest, names: &[String]) -> Vec<RequiredSkill> {
+    names
+        .iter()
+        .map(|name| RequiredSkill {
+            name: name.clone(),
+            method: manifest
+                .skills
+                .get(name)
+                .map_or(manifest.install.method, |decl| {
+                    super::desired::effective_method(decl, manifest)
+                }),
+        })
+        .collect()
+}
+
 /// One agent's effective intent for one harness: what the source asks for,
 /// with whatever this project contributes folded in. Pass
 /// `Project::default()` and what comes out is the publisher's own.
@@ -375,7 +393,10 @@ fn effective_agent<'a>(
         source,
         harness,
         scope: ctx.scope,
-        skills: project.skills.unwrap_or_else(|| upstream_skills.to_vec()),
+        skills: required_skills(
+            ctx.manifest,
+            &project.skills.unwrap_or_else(|| upstream_skills.to_vec()),
+        ),
         overrides,
         permissions,
         launch_instructions: project.launch_instructions,

--- a/crates/core/src/engine/desired_agent.rs
+++ b/crates/core/src/engine/desired_agent.rs
@@ -354,26 +354,34 @@ fn gathered<'a>(
     }
 }
 
-/// Each required skill with the place its own delivery wrote it: its
-/// declaration's method, or the scope's default where it made none, which
-/// is also the answer for a skill this scope never declared. Resolved
-/// here because this is where the `Env` a relocated harness root needs is.
+/// Each required skill with the place its own delivery wrote it.
+///
+/// `delivered` is the caller's authority on how a skill was delivered, and
+/// the manifest is only the fallback: a skill can reach a scope without a
+/// declaration of its own — a set's members carry the set's method
+/// (`bundles::member_decl`) and appear in no `[skills.<name>]` table — so
+/// asking the manifest first would answer with the scope default and send
+/// an agent to a tree the set never wrote. Resolved here because this is
+/// where the `Env` a relocated harness root needs is.
 pub(crate) fn required_skills(
     env: &Env,
     scope: &Scope,
     harness: HarnessId,
     manifest: &Manifest,
+    delivered: impl Fn(&str) -> Option<crate::manifest::Method>,
     names: &[String],
 ) -> Vec<RequiredSkill> {
     names
         .iter()
         .map(|name| {
-            let method = manifest
-                .skills
-                .get(name)
-                .map_or(manifest.install.method, |decl| {
-                    super::desired::effective_method(decl, manifest)
-                });
+            let method = delivered(name).unwrap_or_else(|| {
+                manifest
+                    .skills
+                    .get(name)
+                    .map_or(manifest.install.method, |decl| {
+                        super::desired::effective_method(decl, manifest)
+                    })
+            });
             RequiredSkill {
                 name: name.clone(),
                 root: crate::render::agent::skill_root(env, harness, scope, method),
@@ -409,6 +417,13 @@ fn effective_agent<'a>(
             ctx.scope,
             harness,
             ctx.manifest,
+            // The plan being installed is the authority here: it holds a
+            // set member's declaration, which the manifest does not.
+            |skill| {
+                ctx.expansion
+                    .decl_of(ItemKind::Skill, skill)
+                    .map(|decl| super::desired::effective_method(&decl, ctx.manifest))
+            },
             &project.skills.unwrap_or_else(|| upstream_skills.to_vec()),
         ),
         overrides,

--- a/crates/core/src/engine/desired_agent.rs
+++ b/crates/core/src/engine/desired_agent.rs
@@ -1,9 +1,10 @@
+use crate::env::Env;
 use crate::error::Result;
 use crate::hash::installation_hash;
 use crate::lock::entry_key;
 use crate::manifest::{CustomHook, FrontmatterOverrides, HookAgents, Manifest, Method};
 use crate::mapping::EffectiveSkills;
-use crate::model::{HarnessId, ItemKind};
+use crate::model::{HarnessId, ItemKind, Scope};
 use crate::render::agent::{
     EffectiveAgent, RenderedAgent, RequiredSkill, Selects, SourceAgent, file_name, generate,
     hooks_for_agent, merge_overrides, merged_instructions, parse_source_agent, selects,
@@ -353,20 +354,30 @@ fn gathered<'a>(
     }
 }
 
-/// Each required skill with the delivery that decides where it was
-/// written: its own declaration's, or the scope's default where it made
-/// none, which is also the answer for a skill this scope never declared.
-pub(crate) fn required_skills(manifest: &Manifest, names: &[String]) -> Vec<RequiredSkill> {
+/// Each required skill with the place its own delivery wrote it: its
+/// declaration's method, or the scope's default where it made none, which
+/// is also the answer for a skill this scope never declared. Resolved
+/// here because this is where the `Env` a relocated harness root needs is.
+pub(crate) fn required_skills(
+    env: &Env,
+    scope: &Scope,
+    harness: HarnessId,
+    manifest: &Manifest,
+    names: &[String],
+) -> Vec<RequiredSkill> {
     names
         .iter()
-        .map(|name| RequiredSkill {
-            name: name.clone(),
-            method: manifest
+        .map(|name| {
+            let method = manifest
                 .skills
                 .get(name)
                 .map_or(manifest.install.method, |decl| {
                     super::desired::effective_method(decl, manifest)
-                }),
+                });
+            RequiredSkill {
+                name: name.clone(),
+                root: crate::render::agent::skill_root(env, harness, scope, method),
+            }
         })
         .collect()
 }
@@ -394,6 +405,9 @@ fn effective_agent<'a>(
         harness,
         scope: ctx.scope,
         skills: required_skills(
+            ctx.env,
+            ctx.scope,
+            harness,
             ctx.manifest,
             &project.skills.unwrap_or_else(|| upstream_skills.to_vec()),
         ),

--- a/crates/core/src/engine/desired_command.rs
+++ b/crates/core/src/engine/desired_command.rs
@@ -158,11 +158,22 @@ fn as_skill(
     // surface declarations the write used, never a list spelled here:
     // saying "Pi" while three more tools also read it is the surprise this
     // warning exists to prevent.
+    //
+    // Reading the directory is not enough to be offered what is in it. A
+    // loader that rejects this tree — an emitted name carrying `__` is
+    // unloadable wherever names must be lower-kebab — offers nothing, and
+    // naming that tool here would warn about a command nobody can reach.
     let also: Vec<&str> = HarnessId::ALL
         .into_iter()
         .filter(|other| *other != harness)
         .filter(|other| {
             native_dir(ctx.env, ctx.scope, *other, ItemKind::Skill).as_ref() == Some(&dir)
+        })
+        .filter(|other| {
+            refusal_reason(&crate::render::validate::validate_skill_tree(
+                *other, ctx.name, &name, &files,
+            ))
+            .is_none()
         })
         .map(HarnessId::display_name)
         .collect();

--- a/crates/core/src/engine/desired_skill.rs
+++ b/crates/core/src/engine/desired_skill.rs
@@ -48,6 +48,9 @@ fn cross_read_note(ctx: &ItemCtx, method: Method, state: &mut DesiredState) {
         return;
     }
     let shared = skill_canonical(ctx.env, ctx.scope, ctx.name);
+    // The name the shared tree lists it under, which is what each reader's
+    // loader is held to.
+    let installed = crate::harness::canonical_name(ctx.name);
     let readers: Vec<String> = HarnessId::ALL
         .into_iter()
         .filter(|harness| !ctx.harnesses.contains(harness))
@@ -60,6 +63,16 @@ fn cross_read_note(ctx: &ItemCtx, method: Method, state: &mut DesiredState) {
             adapter
                 .detect(ctx.env, &adapter.default_global_root(ctx.env))
                 .is_some()
+        })
+        // Reading the directory is not enough to be shown what is in it.
+        // A name this loader will not take — capitals or an underscore
+        // where names must be lower-kebab — makes the tree invisible
+        // there, and counting that tool as already having the skill would
+        // be counting a definition it cannot load.
+        .filter(|harness| {
+            crate::render::validate::validate_name(*harness, &installed)
+                .iter()
+                .all(|finding| !finding.is_breakage())
         })
         .map(|harness| harness.display_name().to_owned())
         .collect();

--- a/crates/core/src/engine/fork/agent.rs
+++ b/crates/core/src/engine/fork/agent.rs
@@ -48,7 +48,10 @@ pub(super) fn capture_agent(of: &ForkOf, edited: &Path) -> Result<CapturedAgent>
         read_at,
     } = published(of)?;
     let around = Around {
-        skills: carry.as_ref().map(AgentCarry::skills).unwrap_or_default(),
+        skills: crate::engine::desired_agent::required_skills(
+            manifest,
+            &carry.as_ref().map(AgentCarry::skills).unwrap_or_default(),
+        ),
         overrides,
         launch: merged_instructions(&manifest.agent_launch_instructions, name),
         additional: merged_instructions(&manifest.agent_additional_instructions, name),
@@ -225,7 +228,7 @@ fn crlf(body: &str) -> bool {
 }
 
 struct Around<'a> {
-    skills: Vec<String>,
+    skills: Vec<crate::render::agent::RequiredSkill>,
     overrides: FrontmatterOverrides,
     launch: Option<String>,
     additional: Option<String>,

--- a/crates/core/src/engine/fork/agent.rs
+++ b/crates/core/src/engine/fork/agent.rs
@@ -49,6 +49,9 @@ pub(super) fn capture_agent(of: &ForkOf, edited: &Path) -> Result<CapturedAgent>
     } = published(of)?;
     let around = Around {
         skills: crate::engine::desired_agent::required_skills(
+            env,
+            scope,
+            harness,
             manifest,
             &carry.as_ref().map(AgentCarry::skills).unwrap_or_default(),
         ),

--- a/crates/core/src/engine/fork/agent.rs
+++ b/crates/core/src/engine/fork/agent.rs
@@ -47,10 +47,12 @@ pub(super) fn capture_agent(of: &ForkOf, edited: &Path) -> Result<CapturedAgent>
         overrides,
         read_at,
     } = published(of)?;
-    // What this scope's last install recorded. A missing or unreadable
-    // record leaves every skill to the manifest fallback, which is the
-    // answer for a scope that has installed nothing yet.
-    let installed = crate::lock::load(&crate::lock::lock_path(env, scope)).unwrap_or_default();
+    // What this scope's last install recorded. An absent record already
+    // loads as an empty current one, which is the answer for a scope that
+    // has installed nothing yet; a corrupt or too-new one is an error and
+    // is raised, because reconstructing an agent from the manifest default
+    // would rewrite its skill paths on a guess.
+    let installed = crate::lock::load(&crate::lock::lock_path(env, scope))?;
     let around = Around {
         skills: crate::engine::desired_agent::required_skills(
             env,

--- a/crates/core/src/engine/fork/agent.rs
+++ b/crates/core/src/engine/fork/agent.rs
@@ -47,12 +47,25 @@ pub(super) fn capture_agent(of: &ForkOf, edited: &Path) -> Result<CapturedAgent>
         overrides,
         read_at,
     } = published(of)?;
+    // What this scope's last install recorded. A missing or unreadable
+    // record leaves every skill to the manifest fallback, which is the
+    // answer for a scope that has installed nothing yet.
+    let installed = crate::lock::load(&crate::lock::lock_path(env, scope)).unwrap_or_default();
     let around = Around {
         skills: crate::engine::desired_agent::required_skills(
             env,
             scope,
             harness,
             manifest,
+            // A fork reads back an installation, so the record of what was
+            // written is the authority: a set's members are in the lock
+            // under their own delivery and in no `[skills.<name>]` table.
+            |skill| {
+                installed
+                    .entries
+                    .get(&crate::lock::entry_key(ItemKind::Skill, skill, harness))
+                    .map(|entry| entry.method)
+            },
             &carry.as_ref().map(AgentCarry::skills).unwrap_or_default(),
         ),
         overrides,

--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -15,7 +15,7 @@ mod config_edits;
 mod copilot;
 pub mod deps;
 pub mod desired;
-mod desired_agent;
+pub(crate) mod desired_agent;
 mod desired_command;
 mod desired_custom_hooks;
 mod desired_item;

--- a/crates/core/src/harness/codex.rs
+++ b/crates/core/src/harness/codex.rs
@@ -25,13 +25,15 @@ impl HarnessAdapter for Codex {
     fn global_surfaces(&self, kind: ItemKind, root: &Path, env: &Env) -> Vec<Surface> {
         match kind {
             ItemKind::Agent => vec![Surface::files(root.join("agents"), &["toml"])],
-            // `$HOME/.agents/skills` is the only user-level skills location
-            // Codex documents, so it leads here as it does in a project.
-            // `~/.codex/skills` stays on the list to read back what an
-            // older install left there. It is also where a copy delivery
-            // writes, being the only directory of Codex's own — and Codex
-            // does not read it, so a global copy is reported installed and
-            // is loaded by nothing.
+            // Codex reads three skill roots at user level: the shared
+            // `$HOME/.agents/skills`, `<root>/skills`, and
+            // `<root>/skills/.system`, where it stages the skills it ships.
+            // The shared tree leads, as it does in a project, because one
+            // definition there is seen by every tool that reads it.
+            // `<root>/skills` stays on the list because Codex reads it too:
+            // it holds what an older install left, and it is the only one
+            // of the three that is Codex's alone, so it is where a copy
+            // delivery writes.
             ItemKind::Skill => {
                 super::shared_first(Some(&env.global_skills_dir()), root.join("skills"))
             }

--- a/crates/core/src/render/agent/antigravity.rs
+++ b/crates/core/src/render/agent/antigravity.rs
@@ -118,7 +118,11 @@ mod tests {
             source,
             harness: HarnessId::Antigravity,
             scope,
-            skills: vec!["dev".into()],
+            skills: vec![crate::render::agent::linked_skill(
+                "dev",
+                HarnessId::Antigravity,
+                scope,
+            )],
             overrides: FrontmatterOverrides::default(),
             permissions: PermissionIntent::Unspecified,
             launch_instructions: None,

--- a/crates/core/src/render/agent/antigravity.rs
+++ b/crates/core/src/render/agent/antigravity.rs
@@ -1,6 +1,6 @@
 use super::{EffectiveAgent, GENERATED_BANNER, RenderedAgent, hooks_prose, skills_prose};
 use crate::harness::models::resolve_model;
-use crate::model::{HarnessId, Scope};
+use crate::model::HarnessId;
 use crate::render::permission::PermissionIntent;
 use crate::render::vocab::{antigravity_tool_name, rewrite_prose};
 use crate::render::{RenderWarning, yaml_quoted, yaml_scalar};
@@ -84,11 +84,7 @@ pub fn generate(agent: &EffectiveAgent) -> RenderedAgent {
     // The frontmatter's `skills:` list names paths under the customization
     // root; kendex does not yet write it, so skills and hooks travel as
     // prose the agent's own instructions carry.
-    let skill_root = match agent.scope {
-        Scope::Global => "~/.gemini/config/skills",
-        Scope::Project { .. } => ".agents/skills",
-    };
-    if let Some(skills) = skills_prose(agent, skill_root) {
+    if let Some(skills) = skills_prose(agent) {
         body.push_str(&format!("\n{skills}"));
     }
     if let Some(hooks) = hooks_prose(agent) {
@@ -108,6 +104,7 @@ mod tests {
     use super::super::{SourceAgent, parse_source_agent};
     use super::*;
     use crate::manifest::FrontmatterOverrides;
+    use crate::model::Scope;
 
     fn source(model: &str) -> SourceAgent {
         parse_source_agent(&format!(

--- a/crates/core/src/render/agent/claude.rs
+++ b/crates/core/src/render/agent/claude.rs
@@ -64,7 +64,10 @@ pub fn generate(agent: &EffectiveAgent) -> RenderedAgent {
         push(format!("color: {}", yaml_scalar(color)));
     }
     if !agent.skills.is_empty() {
-        push(format!("skills: {}", yaml_scalar(&agent.skills.join(", "))));
+        push(format!(
+            "skills: {}",
+            yaml_scalar(&super::RequiredSkill::names(&agent.skills).join(", "))
+        ));
     }
     if !agent.custom_hooks.is_empty() {
         push("hooks:".to_owned());

--- a/crates/core/src/render/agent/claude.rs
+++ b/crates/core/src/render/agent/claude.rs
@@ -178,7 +178,10 @@ mod tests {
             source,
             harness: HarnessId::Claude,
             scope,
-            skills: vec!["dev".into(), "rust-perf".into()],
+            skills: vec![
+                crate::render::agent::linked_skill("dev", HarnessId::Claude, scope),
+                crate::render::agent::linked_skill("rust-perf", HarnessId::Claude, scope),
+            ],
             overrides: FrontmatterOverrides::default(),
             permissions: PermissionIntent::Unspecified,
             launch_instructions: Some("start here".into()),

--- a/crates/core/src/render/agent/codex.rs
+++ b/crates/core/src/render/agent/codex.rs
@@ -227,7 +227,11 @@ mod tests {
             source,
             harness: HarnessId::Codex,
             scope,
-            skills: vec!["dev".into()],
+            skills: vec![crate::render::agent::linked_skill(
+                "dev",
+                HarnessId::Codex,
+                scope,
+            )],
             overrides: FrontmatterOverrides::default(),
             permissions: PermissionIntent::Unspecified,
             launch_instructions: None,

--- a/crates/core/src/render/agent/codex.rs
+++ b/crates/core/src/render/agent/codex.rs
@@ -161,8 +161,7 @@ fn instructions(
     warnings.extend(reworded);
     out.push_str(&prose);
     out.push('\n');
-    let skill_root = super::skill_root(HarnessId::Codex, agent.scope);
-    if let Some(skills) = skills_prose(agent, skill_root) {
+    if let Some(skills) = skills_prose(agent) {
         out.push_str(&format!("\n{skills}"));
     }
     if let Some(hooks) = hooks_prose(agent) {

--- a/crates/core/src/render/agent/copilot.rs
+++ b/crates/core/src/render/agent/copilot.rs
@@ -113,7 +113,11 @@ mod tests {
             source,
             harness: HarnessId::Copilot,
             scope,
-            skills: vec!["dev".into()],
+            skills: vec![crate::render::agent::linked_skill(
+                "dev",
+                HarnessId::Copilot,
+                scope,
+            )],
             overrides: FrontmatterOverrides::default(),
             permissions: PermissionIntent::Unspecified,
             launch_instructions: None,

--- a/crates/core/src/render/agent/copilot.rs
+++ b/crates/core/src/render/agent/copilot.rs
@@ -62,8 +62,7 @@ pub fn generate(agent: &EffectiveAgent) -> RenderedAgent {
     body.push('\n');
     // Neither skills nor hooks are agent frontmatter fields, so both travel
     // as prose the agent's own instructions carry (matrix §2).
-    let skill_root = super::skill_root(HarnessId::Copilot, agent.scope);
-    if let Some(skills) = skills_prose(agent, skill_root) {
+    if let Some(skills) = skills_prose(agent) {
         body.push_str(&format!("\n{skills}"));
     }
     if let Some(hooks) = hooks_prose(agent) {

--- a/crates/core/src/render/agent/cursor.rs
+++ b/crates/core/src/render/agent/cursor.rs
@@ -72,7 +72,11 @@ mod tests {
             source,
             harness: HarnessId::Cursor,
             scope,
-            skills: vec!["dev".into()],
+            skills: vec![crate::render::agent::linked_skill(
+                "dev",
+                HarnessId::Cursor,
+                scope,
+            )],
             overrides: FrontmatterOverrides {
                 model: Some("sonnet".into()),
                 color: Some("blue".into()),

--- a/crates/core/src/render/agent/gemini.rs
+++ b/crates/core/src/render/agent/gemini.rs
@@ -119,7 +119,11 @@ mod tests {
             source,
             harness: HarnessId::Gemini,
             scope,
-            skills: vec!["dev".into()],
+            skills: vec![crate::render::agent::linked_skill(
+                "dev",
+                HarnessId::Gemini,
+                scope,
+            )],
             overrides: FrontmatterOverrides::default(),
             permissions: PermissionIntent::Unspecified,
             launch_instructions: None,

--- a/crates/core/src/render/agent/gemini.rs
+++ b/crates/core/src/render/agent/gemini.rs
@@ -68,8 +68,7 @@ pub fn generate(agent: &EffectiveAgent) -> RenderedAgent {
     body.push('\n');
     // Neither skills nor per-agent hooks are subagent frontmatter fields, so
     // both travel as prose the system prompt carries (matrix §1).
-    let skill_root = super::skill_root(HarnessId::Gemini, agent.scope);
-    if let Some(skills) = skills_prose(agent, skill_root) {
+    if let Some(skills) = skills_prose(agent) {
         body.push_str(&format!("\n{skills}"));
     }
     if let Some(hooks) = hooks_prose(agent) {

--- a/crates/core/src/render/agent/mod.rs
+++ b/crates/core/src/render/agent/mod.rs
@@ -1,3 +1,6 @@
+use std::path::Path;
+
+use crate::env::Env;
 use crate::manifest::{CustomHook, FrontmatterOverrides, HookAgents, Manifest, Method};
 use crate::model::{HarnessId, ItemKind, Scope};
 
@@ -15,14 +18,17 @@ mod source;
 
 pub use source::{Role, SourceAgent, default_pane, parse_source_agent};
 
-/// One skill an agent requires, with the delivery that decides where it
-/// was written. The method rides with the name because a scope's default
-/// is not the answer: a declaration sets its own, and an agent naming two
-/// skills delivered two ways reads them from two directories.
+/// One skill an agent requires, with the directory the agent is told to
+/// read it from. The place rides with the name because it is not derivable
+/// from the harness and scope alone: a declaration sets its own delivery,
+/// an agent naming two skills delivered two ways reads them from two
+/// directories, and a relocation variable can move either of them.
+/// Resolved once by `desired_agent::required_skills`, which is where the
+/// `Env` that answers all three lives.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RequiredSkill {
     pub name: String,
-    pub method: Method,
+    pub root: String,
 }
 
 impl RequiredSkill {
@@ -33,15 +39,20 @@ impl RequiredSkill {
     }
 }
 
-/// A name delivered the scope's own default way. Every installation
-/// resolves the real method through `desired_agent::required_skills`; this
-/// is for naming a skill where the delivery is not what is under test.
-impl From<&str> for RequiredSkill {
-    fn from(name: &str) -> Self {
-        Self {
-            name: name.to_owned(),
-            method: Method::default(),
-        }
+/// A required skill placed the way the default delivery places it, for a
+/// fixture whose subject is not the place. It asks `skill_root` rather
+/// than spelling a directory, so a fixture cannot assert against a rule
+/// the renderers no longer follow.
+#[cfg(test)]
+pub(crate) fn linked_skill(name: &str, harness: HarnessId, scope: &Scope) -> RequiredSkill {
+    RequiredSkill {
+        name: name.to_owned(),
+        root: skill_root(
+            &Env::fake("/h", crate::env::FakeOs::Linux),
+            harness,
+            scope,
+            Method::Symlink,
+        ),
     }
 }
 
@@ -275,48 +286,56 @@ pub fn file_name(harness: HarnessId, agent_name: &str) -> String {
     }
 }
 
-/// Skills prose section for harnesses without a native skills field.
-/// Where an agent is told to read its required skills: the directory this
-/// skill's own delivery wrote, for this harness at this scope.
+/// The shared tree a project's default delivery writes, which every tool
+/// but Claude Code and Antigravity reads directly and those two are linked
+/// into. No relocation variable moves it.
+pub const PROJECT_SHARED_SKILLS: &str = ".agents/skills";
+
+/// Where an agent is told to read a required skill: the directory this
+/// skill's own delivery wrote, in the short spelling an agent reads.
 ///
 /// One owner, because five renderers each spelling it is five chances to
 /// name a place the install stopped writing. A symlink delivery writes the
 /// shared tree, which every tool but Claude Code and Antigravity reads;
-/// those two read only their own directory and are linked into it. A copy
-/// is a tree only one tool reads, so it is written in that tool's own
-/// directory and nowhere else — a different answer at both scopes, and the
-/// one an agent must be given or it is sent to a path nothing wrote.
-///
-/// The copy answers are the adapters' own `own_dir`, held to it by
-/// `the_copy_roots_are_the_places_a_copy_delivery_writes`.
-pub fn skill_root(harness: HarnessId, scope: &Scope, method: Method) -> &'static str {
-    match (method, scope) {
-        (Method::Copy, Scope::Project { .. }) => match harness {
-            HarnessId::Claude => ".claude/skills",
-            HarnessId::Cursor => ".cursor/skills",
-            HarnessId::Gemini => ".gemini/skills",
-            HarnessId::Copilot => ".github/skills",
-            HarnessId::Opencode => ".opencode/skills",
-            HarnessId::Codex | HarnessId::Pi | HarnessId::Antigravity => ".agents/skills",
+/// those two read only their own directory and are linked into it, and no
+/// relocation variable moves any of the three. A copy is a tree only one
+/// tool reads, written in that tool's own directory — which four adapters
+/// let a variable relocate (`Env::HARNESS_VARS`), so it is asked of
+/// `own_dir` rather than spelled here. Naming a literal would send an
+/// agent to the unrelocated path on any machine that sets one.
+pub fn skill_root(env: &Env, harness: HarnessId, scope: &Scope, method: Method) -> String {
+    match method {
+        Method::Copy => match crate::engine::desired::own_dir(env, scope, harness, ItemKind::Skill)
+        {
+            Some(dir) => shown(&dir, env, scope),
+            // Cursor holds no global skills, so a copy writes nothing and
+            // the shared tree is the only honest thing to name.
+            None => format!("~/{}", PROJECT_SHARED_SKILLS),
         },
-        (Method::Copy, Scope::Global) => match harness {
-            HarnessId::Claude => "~/.claude/skills",
-            HarnessId::Codex => "~/.codex/skills",
-            HarnessId::Pi => "~/.pi/agent/skills",
-            HarnessId::Gemini => "~/.gemini/skills",
-            HarnessId::Copilot => "~/.copilot/skills",
-            HarnessId::Antigravity => "~/.gemini/config/skills",
-            HarnessId::Opencode => "~/.config/opencode/skills",
-            // Cursor holds no global skills at all, so nothing is written
-            // and the shared tree is the only honest thing to name.
-            HarnessId::Cursor => "~/.agents/skills",
+        Method::Symlink => match scope {
+            Scope::Project { .. } => PROJECT_SHARED_SKILLS.to_owned(),
+            Scope::Global => match harness {
+                HarnessId::Claude => "~/.claude/skills".to_owned(),
+                HarnessId::Antigravity => "~/.gemini/config/skills".to_owned(),
+                _ => format!("~/{}", PROJECT_SHARED_SKILLS),
+            },
         },
-        (Method::Symlink, Scope::Project { .. }) => ".agents/skills",
-        (Method::Symlink, Scope::Global) => match harness {
-            HarnessId::Claude => "~/.claude/skills",
-            HarnessId::Antigravity => "~/.gemini/config/skills",
-            _ => "~/.agents/skills",
-        },
+    }
+}
+
+/// An absolute install path as an agent reads it: relative to the project
+/// it is in, or under `~` for anything below the home directory. A path
+/// under neither is left absolute, which is what a relocation variable
+/// pointing outside both produces.
+fn shown(path: &Path, env: &Env, scope: &Scope) -> String {
+    if let Scope::Project { root } = scope
+        && let Ok(rest) = path.strip_prefix(root)
+    {
+        return rest.display().to_string();
+    }
+    match path.strip_prefix(&env.home) {
+        Ok(rest) => format!("~/{}", rest.display()),
+        Err(_) => path.display().to_string(),
     }
 }
 
@@ -326,8 +345,7 @@ pub fn skills_prose(agent: &EffectiveAgent) -> Option<String> {
     }
     let mut out = String::from("## Required Skills\n\nRead each before acting:\n\n");
     for skill in &agent.skills {
-        let root = skill_root(agent.harness, agent.scope, skill.method);
-        let name = &skill.name;
+        let RequiredSkill { name, root } = skill;
         out.push_str(&format!("- {name}: {root}/{name}/SKILL.md\n"));
     }
     Some(out)
@@ -522,20 +540,20 @@ mod tests {
         );
     }
 
-    /// The path an agent is told to read a skill from is the one the
-    /// install writes. Under the default symlink delivery that is the
-    /// shared tree for every tool that reads it, and its own directory for
-    /// the two that do not; a project's is the shared tree for all of
-    /// them. A renderer naming a tool's own global directory would send
-    /// the agent to a path this delivery no longer creates.
+    /// The linked delivery's places, which no relocation variable moves:
+    /// the shared tree for every tool that reads it, and its own directory
+    /// for the two that do not. The copy delivery is `own_dir`'s answer,
+    /// proved end to end against what an install actually wrote in
+    /// `tests/agent_skill_roots.rs`.
     #[test]
     fn an_agent_reads_a_linked_skill_from_the_shared_tree() {
+        let env = crate::env::Env::fake("/h", crate::env::FakeOs::Linux);
         let project = Scope::Project {
             root: std::path::PathBuf::from("/p"),
         };
         for harness in HarnessId::ALL {
             assert_eq!(
-                skill_root(harness, &project, Method::Symlink),
+                skill_root(&env, harness, &project, Method::Symlink),
                 ".agents/skills",
                 "{harness:?} in a project"
             );
@@ -548,53 +566,23 @@ mod tests {
             HarnessId::Copilot,
         ] {
             assert_eq!(
-                skill_root(harness, &Scope::Global, Method::Symlink),
+                skill_root(&env, harness, &Scope::Global, Method::Symlink),
                 "~/.agents/skills",
                 "{harness:?} reads the shared global tree"
             );
         }
         assert_eq!(
-            skill_root(HarnessId::Claude, &Scope::Global, Method::Symlink),
+            skill_root(&env, HarnessId::Claude, &Scope::Global, Method::Symlink),
             "~/.claude/skills"
         );
         assert_eq!(
-            skill_root(HarnessId::Antigravity, &Scope::Global, Method::Symlink),
+            skill_root(
+                &env,
+                HarnessId::Antigravity,
+                &Scope::Global,
+                Method::Symlink
+            ),
             "~/.gemini/config/skills"
-        );
-    }
-
-    /// The other delivery, which the shared tree is the wrong answer for.
-    /// A copy is a tree only one tool reads, written in that tool's own
-    /// directory, so an agent is sent there instead — at both scopes. The
-    /// must-fail half is the pair: wherever a copy writes somewhere other
-    /// than the linked delivery, naming the linked place would be naming a
-    /// path this install never wrote.
-    #[test]
-    fn an_agent_reads_a_copied_skill_from_the_directory_only_that_tool_reads() {
-        let project = Scope::Project {
-            root: std::path::PathBuf::from("/p"),
-        };
-        assert_eq!(
-            skill_root(HarnessId::Claude, &project, Method::Copy),
-            ".claude/skills"
-        );
-        assert_eq!(
-            skill_root(HarnessId::Codex, &Scope::Global, Method::Copy),
-            "~/.codex/skills"
-        );
-        // Both differ from what the linked delivery answers, which is the
-        // must-fail half: a `skill_root` that ignored the method would
-        // return the shared tree here and send the agent to a path a copy
-        // never wrote. The whole matrix is held to the adapters' own
-        // `own_dir` by `the_copy_roots_are_the_places_a_copy_delivery_writes`
-        // in `tests/agent_skill_roots.rs`.
-        assert_ne!(
-            skill_root(HarnessId::Claude, &project, Method::Copy),
-            skill_root(HarnessId::Claude, &project, Method::Symlink)
-        );
-        assert_ne!(
-            skill_root(HarnessId::Codex, &Scope::Global, Method::Copy),
-            skill_root(HarnessId::Codex, &Scope::Global, Method::Symlink)
         );
     }
 }

--- a/crates/core/src/render/agent/mod.rs
+++ b/crates/core/src/render/agent/mod.rs
@@ -1,4 +1,4 @@
-use crate::manifest::{CustomHook, FrontmatterOverrides, HookAgents, Manifest};
+use crate::manifest::{CustomHook, FrontmatterOverrides, HookAgents, Manifest, Method};
 use crate::model::{HarnessId, ItemKind, Scope};
 
 use super::permission::PermissionIntent;
@@ -15,6 +15,36 @@ mod source;
 
 pub use source::{Role, SourceAgent, default_pane, parse_source_agent};
 
+/// One skill an agent requires, with the delivery that decides where it
+/// was written. The method rides with the name because a scope's default
+/// is not the answer: a declaration sets its own, and an agent naming two
+/// skills delivered two ways reads them from two directories.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RequiredSkill {
+    pub name: String,
+    pub method: Method,
+}
+
+impl RequiredSkill {
+    /// The names alone, for a harness whose own frontmatter field takes a
+    /// list of them and resolves the place itself.
+    pub fn names(skills: &[Self]) -> Vec<&str> {
+        skills.iter().map(|skill| skill.name.as_str()).collect()
+    }
+}
+
+/// A name delivered the scope's own default way. Every installation
+/// resolves the real method through `desired_agent::required_skills`; this
+/// is for naming a skill where the delivery is not what is under test.
+impl From<&str> for RequiredSkill {
+    fn from(name: &str) -> Self {
+        Self {
+            name: name.to_owned(),
+            method: Method::default(),
+        }
+    }
+}
+
 /// Everything a per-harness generator needs, already merged. `permissions`
 /// is the effective intent — source `tools:` narrowed by manifest overrides;
 /// renderers read it, never `overrides.deny_tools` directly.
@@ -23,7 +53,7 @@ pub struct EffectiveAgent<'a> {
     pub source: &'a SourceAgent,
     pub harness: HarnessId,
     pub scope: &'a Scope,
-    pub skills: Vec<String>,
+    pub skills: Vec<RequiredSkill>,
     pub overrides: FrontmatterOverrides,
     pub permissions: PermissionIntent,
     pub launch_instructions: Option<String>,
@@ -246,20 +276,43 @@ pub fn file_name(harness: HarnessId, agent_name: &str) -> String {
 }
 
 /// Skills prose section for harnesses without a native skills field.
-/// Where an agent is told to read its required skills: the directory the
-/// install writes for this harness at this scope.
+/// Where an agent is told to read its required skills: the directory this
+/// skill's own delivery wrote, for this harness at this scope.
 ///
 /// One owner, because five renderers each spelling it is five chances to
-/// name a place the install stopped writing. Every tool but Claude Code
-/// and Antigravity reads the shared tree, so that is where their skills
-/// are; those two read only their own directory and are linked into it.
-/// A `method = "copy"` delivery writes each tool's own directory instead,
-/// which this does not distinguish — the prose has never said so, at
-/// either scope.
-pub fn skill_root(harness: HarnessId, scope: &Scope) -> &'static str {
-    match scope {
-        Scope::Project { .. } => ".agents/skills",
-        Scope::Global => match harness {
+/// name a place the install stopped writing. A symlink delivery writes the
+/// shared tree, which every tool but Claude Code and Antigravity reads;
+/// those two read only their own directory and are linked into it. A copy
+/// is a tree only one tool reads, so it is written in that tool's own
+/// directory and nowhere else — a different answer at both scopes, and the
+/// one an agent must be given or it is sent to a path nothing wrote.
+///
+/// The copy answers are the adapters' own `own_dir`, held to it by
+/// `the_copy_roots_are_the_places_a_copy_delivery_writes`.
+pub fn skill_root(harness: HarnessId, scope: &Scope, method: Method) -> &'static str {
+    match (method, scope) {
+        (Method::Copy, Scope::Project { .. }) => match harness {
+            HarnessId::Claude => ".claude/skills",
+            HarnessId::Cursor => ".cursor/skills",
+            HarnessId::Gemini => ".gemini/skills",
+            HarnessId::Copilot => ".github/skills",
+            HarnessId::Opencode => ".opencode/skills",
+            HarnessId::Codex | HarnessId::Pi | HarnessId::Antigravity => ".agents/skills",
+        },
+        (Method::Copy, Scope::Global) => match harness {
+            HarnessId::Claude => "~/.claude/skills",
+            HarnessId::Codex => "~/.codex/skills",
+            HarnessId::Pi => "~/.pi/agent/skills",
+            HarnessId::Gemini => "~/.gemini/skills",
+            HarnessId::Copilot => "~/.copilot/skills",
+            HarnessId::Antigravity => "~/.gemini/config/skills",
+            HarnessId::Opencode => "~/.config/opencode/skills",
+            // Cursor holds no global skills at all, so nothing is written
+            // and the shared tree is the only honest thing to name.
+            HarnessId::Cursor => "~/.agents/skills",
+        },
+        (Method::Symlink, Scope::Project { .. }) => ".agents/skills",
+        (Method::Symlink, Scope::Global) => match harness {
             HarnessId::Claude => "~/.claude/skills",
             HarnessId::Antigravity => "~/.gemini/config/skills",
             _ => "~/.agents/skills",
@@ -267,13 +320,15 @@ pub fn skill_root(harness: HarnessId, scope: &Scope) -> &'static str {
     }
 }
 
-pub fn skills_prose(agent: &EffectiveAgent, skill_root_hint: &str) -> Option<String> {
+pub fn skills_prose(agent: &EffectiveAgent) -> Option<String> {
     if agent.skills.is_empty() {
         return None;
     }
     let mut out = String::from("## Required Skills\n\nRead each before acting:\n\n");
     for skill in &agent.skills {
-        out.push_str(&format!("- {skill}: {skill_root_hint}/{skill}/SKILL.md\n"));
+        let root = skill_root(agent.harness, agent.scope, skill.method);
+        let name = &skill.name;
+        out.push_str(&format!("- {name}: {root}/{name}/SKILL.md\n"));
     }
     Some(out)
 }
@@ -468,19 +523,19 @@ mod tests {
     }
 
     /// The path an agent is told to read a skill from is the one the
-    /// install writes. Globally that is the shared tree for every tool
-    /// that reads it, and its own directory for the two that do not; a
-    /// project's is the shared tree for all of them. A renderer naming a
-    /// tool's own global directory would send the agent to a path the
-    /// default delivery no longer creates.
+    /// install writes. Under the default symlink delivery that is the
+    /// shared tree for every tool that reads it, and its own directory for
+    /// the two that do not; a project's is the shared tree for all of
+    /// them. A renderer naming a tool's own global directory would send
+    /// the agent to a path this delivery no longer creates.
     #[test]
-    fn an_agent_reads_its_skills_from_the_place_the_install_writes() {
+    fn an_agent_reads_a_linked_skill_from_the_shared_tree() {
         let project = Scope::Project {
             root: std::path::PathBuf::from("/p"),
         };
         for harness in HarnessId::ALL {
             assert_eq!(
-                skill_root(harness, &project),
+                skill_root(harness, &project, Method::Symlink),
                 ".agents/skills",
                 "{harness:?} in a project"
             );
@@ -493,18 +548,53 @@ mod tests {
             HarnessId::Copilot,
         ] {
             assert_eq!(
-                skill_root(harness, &Scope::Global),
+                skill_root(harness, &Scope::Global, Method::Symlink),
                 "~/.agents/skills",
                 "{harness:?} reads the shared global tree"
             );
         }
         assert_eq!(
-            skill_root(HarnessId::Claude, &Scope::Global),
+            skill_root(HarnessId::Claude, &Scope::Global, Method::Symlink),
             "~/.claude/skills"
         );
         assert_eq!(
-            skill_root(HarnessId::Antigravity, &Scope::Global),
+            skill_root(HarnessId::Antigravity, &Scope::Global, Method::Symlink),
             "~/.gemini/config/skills"
+        );
+    }
+
+    /// The other delivery, which the shared tree is the wrong answer for.
+    /// A copy is a tree only one tool reads, written in that tool's own
+    /// directory, so an agent is sent there instead — at both scopes. The
+    /// must-fail half is the pair: wherever a copy writes somewhere other
+    /// than the linked delivery, naming the linked place would be naming a
+    /// path this install never wrote.
+    #[test]
+    fn an_agent_reads_a_copied_skill_from_the_directory_only_that_tool_reads() {
+        let project = Scope::Project {
+            root: std::path::PathBuf::from("/p"),
+        };
+        assert_eq!(
+            skill_root(HarnessId::Claude, &project, Method::Copy),
+            ".claude/skills"
+        );
+        assert_eq!(
+            skill_root(HarnessId::Codex, &Scope::Global, Method::Copy),
+            "~/.codex/skills"
+        );
+        // Both differ from what the linked delivery answers, which is the
+        // must-fail half: a `skill_root` that ignored the method would
+        // return the shared tree here and send the agent to a path a copy
+        // never wrote. The whole matrix is held to the adapters' own
+        // `own_dir` by `the_copy_roots_are_the_places_a_copy_delivery_writes`
+        // in `tests/agent_skill_roots.rs`.
+        assert_ne!(
+            skill_root(HarnessId::Claude, &project, Method::Copy),
+            skill_root(HarnessId::Claude, &project, Method::Symlink)
+        );
+        assert_ne!(
+            skill_root(HarnessId::Codex, &Scope::Global, Method::Copy),
+            skill_root(HarnessId::Codex, &Scope::Global, Method::Symlink)
         );
     }
 }

--- a/crates/core/src/render/agent/opencode.rs
+++ b/crates/core/src/render/agent/opencode.rs
@@ -377,7 +377,11 @@ mod tests {
             root: "/tmp/proj".into(),
         };
         let mut agent = effective(&source, &scope);
-        agent.skills = vec!["dev".into()];
+        agent.skills = vec![crate::render::agent::linked_skill(
+            "dev",
+            HarnessId::Opencode,
+            &scope,
+        )];
         agent.additional_instructions = Some("end here".into());
         let text = generate(&agent).text;
         assert!(text.contains("- dev: .agents/skills/dev/SKILL.md"));

--- a/crates/core/src/render/agent/opencode.rs
+++ b/crates/core/src/render/agent/opencode.rs
@@ -162,8 +162,7 @@ fn body(agent: &EffectiveAgent, warnings: &mut Vec<crate::render::RenderWarning>
     warnings.extend(reworded);
     out.push_str(&prose);
     out.push('\n');
-    let skill_root = super::skill_root(HarnessId::Opencode, agent.scope);
-    if let Some(skills) = skills_prose(agent, skill_root) {
+    if let Some(skills) = skills_prose(agent) {
         out.push_str(&format!("\n{skills}"));
     }
     if let Some(hooks) = hooks_prose(agent) {

--- a/crates/core/src/render/agent/pi.rs
+++ b/crates/core/src/render/agent/pi.rs
@@ -177,8 +177,7 @@ fn body(agent: &EffectiveAgent, warnings: &mut Vec<crate::render::RenderWarning>
     warnings.extend(reworded);
     out.push_str(&prose);
     out.push('\n');
-    let skill_root = super::skill_root(HarnessId::Pi, agent.scope);
-    if let Some(skills) = skills_prose(agent, skill_root) {
+    if let Some(skills) = skills_prose(agent) {
         out.push_str(&format!("\n{skills}"));
     }
     if let Some(hooks) = hooks_prose(agent) {

--- a/crates/core/src/render/agent/pi.rs
+++ b/crates/core/src/render/agent/pi.rs
@@ -327,7 +327,11 @@ mod tests {
             root: "/tmp/proj".into(),
         };
         let mut agent = effective(&source, &scope);
-        agent.skills = vec!["dev".into()];
+        agent.skills = vec![crate::render::agent::linked_skill(
+            "dev",
+            HarnessId::Pi,
+            &scope,
+        )];
         agent.overrides = FrontmatterOverrides {
             model: Some("inherit".into()),
             allowed_subagents: Some(vec!["scout".into(), " Scout ".into(), "researcher".into()]),

--- a/crates/core/tests/agent_skill_roots.rs
+++ b/crates/core/tests/agent_skill_roots.rs
@@ -1,57 +1,106 @@
 //! The path an agent is told to read a required skill from is the place
-//! that skill's own delivery wrote.
+//! that skill's own delivery wrote — proved against what the install put
+//! on disk, not against a second derivation of the same rule.
 //!
-//! `render::agent::skill_root` answers in the short spelling an agent
-//! reads — `~/.codex/skills`, not an absolute fixture path — so it cannot
-//! call the adapter surfaces directly. This holds the copy half of its
-//! table to `own_dir`, which is where a copy delivery actually writes: the
-//! two are one answer or the prose sends an agent to a path nothing wrote.
+//! A copy is written in the tool's own directory, which four adapters let
+//! a variable relocate, so the relocated case is the one under test: it is
+//! the only one where naming a literal and asking the surfaces give
+//! different answers.
 #![cfg(unix)]
 
-use std::path::{Path, PathBuf};
+#[path = "../../test_util.rs"]
+mod test_util;
+use test_util::{rooted, source_path};
 
-use kendex_core::engine::desired::own_dir;
+use std::fs;
+use std::path::Path;
+
+use kendex_core::apply;
+use kendex_core::engine::audit;
 use kendex_core::env::{Env, FakeOs};
-use kendex_core::manifest::Method;
-use kendex_core::model::{HarnessId, ItemKind, Scope};
-use kendex_core::render::agent::skill_root;
+use kendex_core::model::Scope;
 
-/// The prose spelling of a path under the fixture's home or project root.
-fn shown(path: &Path, home: &Path, project: &Path) -> String {
-    match path.strip_prefix(project) {
-        Ok(rest) => rest.display().to_string(),
-        Err(_) => match path.strip_prefix(home) {
-            Ok(rest) => format!("~/{}", rest.display()),
-            Err(_) => path.display().to_string(),
-        },
+const AGENT: &str = "---\nname: rust\ndescription: Rust engineer\nrole: engineer\n---\nBody.\n";
+const SKILL: &str = "---\nname: gh\ndescription: github\n---\nBody.\n";
+
+/// A catalog carrying one agent that requires one skill, installed for
+/// Codex at `scope` under `method`, with `vars` applied to the fixture env.
+#[allow(clippy::unwrap_used)]
+fn installed(home: &Path, method: &str, vars: &[(&str, String)]) -> (Env, String) {
+    let mut env = Env::fake(home, FakeOs::Linux);
+    for (key, value) in vars {
+        env = env.with_var(key, value);
     }
+    let source = home.join("catalog");
+    fs::create_dir_all(source.join("skills/gh")).unwrap();
+    fs::write(source.join("skills/gh/SKILL.md"), SKILL).unwrap();
+    fs::create_dir_all(source.join("agents")).unwrap();
+    fs::write(source.join("agents/rust.md"), AGENT).unwrap();
+    let manifest = env.global_manifest_file();
+    fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+    fs::write(
+        &manifest,
+        format!(
+            "schema = 6\n\n[sources.cat]\n{}\n\n[install]\nharnesses = [\"codex\"]\nmethod = \"{method}\"\n\n[skills.gh]\nsource = \"cat\"\n\n[agents.rust]\nsource = \"cat\"\n\n[agent-skills]\nrust = [\"gh\"]\n",
+            source_path(&source)
+        ),
+    )
+    .unwrap();
+
+    let report = audit(&env, &Scope::Global).unwrap();
+    apply::execute(&env, &report.plan).unwrap();
+    let root = kendex_core::harness::adapter(kendex_core::model::HarnessId::Codex)
+        .default_global_root(&env);
+    (
+        env,
+        fs::read_to_string(root.join("agents/rust.toml")).unwrap(),
+    )
 }
 
+/// A copy for a harness whose root a variable moved: the tree lands under
+/// the relocated root, and the agent is told to read it there. Naming the
+/// unrelocated literal is the failure this pins.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn the_copy_roots_are_the_places_a_copy_delivery_writes() {
-    let home = PathBuf::from("/h");
-    let project = PathBuf::from("/p");
-    let env = Env::fake(&home, FakeOs::Linux);
-    let scopes = [
-        Scope::Project {
-            root: project.clone(),
-        },
-        Scope::Global,
-    ];
+fn a_copied_skill_is_read_from_the_relocated_root_the_copy_wrote() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let elsewhere = home.join("alt/codex");
+    let (_env, agent) = installed(
+        &home,
+        "copy",
+        &[("CODEX_HOME", elsewhere.display().to_string())],
+    );
 
-    for scope in &scopes {
-        for harness in HarnessId::ALL {
-            // Cursor holds no global skills, so a copy writes nothing and
-            // there is no directory for the prose to name.
-            let Some(dir) = own_dir(&env, scope, harness, ItemKind::Skill) else {
-                continue;
-            };
-            assert_eq!(
-                skill_root(harness, scope, Method::Copy),
-                shown(&dir, &home, &project),
-                "{harness:?} at {scope:?}"
-            );
-        }
-    }
+    assert!(elsewhere.join("skills/gh/SKILL.md").is_file());
+    assert!(!home.join(".codex/skills/gh").exists());
+    assert!(!home.join(".agents/skills/gh").exists());
+    assert!(
+        agent.contains("- gh: ~/alt/codex/skills/gh/SKILL.md"),
+        "the agent reads the copy where it landed: {agent}"
+    );
+}
+
+/// The must-fail pair. The same declaration delivered the other way writes
+/// the shared tree instead, and the agent is told that place — so the
+/// assertion above holds because the delivery and the root were read, not
+/// because every install names one directory.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_linked_skill_is_read_from_the_shared_tree_the_link_wrote() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let elsewhere = home.join("alt/codex");
+    let (_env, agent) = installed(
+        &home,
+        "symlink",
+        &[("CODEX_HOME", elsewhere.display().to_string())],
+    );
+
+    assert!(home.join(".agents/skills/gh/SKILL.md").is_file());
+    assert!(!elsewhere.join("skills/gh").exists());
+    assert!(
+        agent.contains("- gh: ~/.agents/skills/gh/SKILL.md"),
+        "the agent reads the shared tree: {agent}"
+    );
 }

--- a/crates/core/tests/agent_skill_roots.rs
+++ b/crates/core/tests/agent_skill_roots.rs
@@ -1,0 +1,57 @@
+//! The path an agent is told to read a required skill from is the place
+//! that skill's own delivery wrote.
+//!
+//! `render::agent::skill_root` answers in the short spelling an agent
+//! reads — `~/.codex/skills`, not an absolute fixture path — so it cannot
+//! call the adapter surfaces directly. This holds the copy half of its
+//! table to `own_dir`, which is where a copy delivery actually writes: the
+//! two are one answer or the prose sends an agent to a path nothing wrote.
+#![cfg(unix)]
+
+use std::path::{Path, PathBuf};
+
+use kendex_core::engine::desired::own_dir;
+use kendex_core::env::{Env, FakeOs};
+use kendex_core::manifest::Method;
+use kendex_core::model::{HarnessId, ItemKind, Scope};
+use kendex_core::render::agent::skill_root;
+
+/// The prose spelling of a path under the fixture's home or project root.
+fn shown(path: &Path, home: &Path, project: &Path) -> String {
+    match path.strip_prefix(project) {
+        Ok(rest) => rest.display().to_string(),
+        Err(_) => match path.strip_prefix(home) {
+            Ok(rest) => format!("~/{}", rest.display()),
+            Err(_) => path.display().to_string(),
+        },
+    }
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn the_copy_roots_are_the_places_a_copy_delivery_writes() {
+    let home = PathBuf::from("/h");
+    let project = PathBuf::from("/p");
+    let env = Env::fake(&home, FakeOs::Linux);
+    let scopes = [
+        Scope::Project {
+            root: project.clone(),
+        },
+        Scope::Global,
+    ];
+
+    for scope in &scopes {
+        for harness in HarnessId::ALL {
+            // Cursor holds no global skills, so a copy writes nothing and
+            // there is no directory for the prose to name.
+            let Some(dir) = own_dir(&env, scope, harness, ItemKind::Skill) else {
+                continue;
+            };
+            assert_eq!(
+                skill_root(harness, scope, Method::Copy),
+                shown(&dir, &home, &project),
+                "{harness:?} at {scope:?}"
+            );
+        }
+    }
+}

--- a/crates/core/tests/bundles/more.rs
+++ b/crates/core/tests/bundles/more.rs
@@ -323,3 +323,46 @@ fn members_that_fold_onto_one_file_install_neither() {
     assert!(!installed(&f, ItemKind::Skill, "deploy"));
     assert!(!installed(&f, ItemKind::Skill, "Deploy"));
 }
+
+/// A set's method reaches its members, and its members are in no
+/// `[skills.<name>]` table — so an agent requiring one is told where the
+/// set's delivery wrote it, not where the scope's default would have.
+/// Asking the manifest first answers `symlink` here and names a tree the
+/// copy never wrote. Gemini because its own project directory is not the
+/// shared tree, so the two deliveries have different answers to give.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_agent_reads_a_set_member_from_the_place_the_sets_method_wrote() {
+    let f = fixture(
+        "[bundles.starter]\nsource = \"cat\"\nmethod = \"copy\"\nharnesses = [\"gemini\"]\n\n[agent-skills]\nwriter = [\"dev\"]\n",
+    );
+    apply_now(&f);
+
+    // The copy is a tree only Gemini reads, in its own directory.
+    assert!(f.project.join(".gemini/skills/dev/SKILL.md").is_file());
+    assert!(!f.project.join(".agents/skills/dev").exists());
+    let agent = fs::read_to_string(f.project.join(".gemini/agents/writer.md")).unwrap();
+    assert!(
+        agent.contains("- dev: .gemini/skills/dev/SKILL.md"),
+        "the agent reads the member where the set's copy landed: {agent}"
+    );
+}
+
+/// The pair: the same set delivered the default way writes the shared tree
+/// and the agent is told that, so the assertion above holds because the
+/// set's own method was read and not because one directory is always named.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_agent_reads_a_linked_set_member_from_the_shared_tree() {
+    let f = fixture(
+        "[bundles.starter]\nsource = \"cat\"\nharnesses = [\"gemini\"]\n\n[agent-skills]\nwriter = [\"dev\"]\n",
+    );
+    apply_now(&f);
+
+    assert!(f.project.join(".agents/skills/dev/SKILL.md").is_file());
+    let agent = fs::read_to_string(f.project.join(".gemini/agents/writer.md")).unwrap();
+    assert!(
+        agent.contains("- dev: .agents/skills/dev/SKILL.md"),
+        "the agent reads the shared tree: {agent}"
+    );
+}

--- a/crates/core/tests/commands.rs
+++ b/crates/core/tests/commands.rs
@@ -280,3 +280,59 @@ fn harnesses_that_only_read_commands_get_nothing_written() {
         assert!(!f.project.join(dir).exists(), "{dir} was written to");
     }
 }
+
+/// The cross-read warning names a tool only when that tool's loader would
+/// take the tree. Reading the directory is not enough: a name carrying
+/// `__` is unloadable where names must be lower-kebab, so OpenCode and
+/// Copilot are offered nothing and naming them would warn about a command
+/// nobody can reach. Pi takes any name, so it is named.
+///
+/// The pair is the same warning over a plain name, which those loaders do
+/// take — without it the assertion would pass on a warning that had simply
+/// stopped naming anyone.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn the_cross_read_warning_skips_a_loader_that_would_reject_the_name() {
+    let rejecting = ["OpenCode", "GitHub Copilot"];
+
+    let f = fixture(
+        "\"codex\"",
+        "[skills.ship]\nsource = \"cat\"\n\n[commands.ship]\nsource = \"cat\"\n",
+    );
+    add_skill(&f, "ship", "The real skill.");
+    let reach = cross_read_warning(&f);
+    assert!(
+        reach.contains("ship__command"),
+        "the collision fallback is what is installed: {reach}"
+    );
+    assert!(reach.contains("Pi"), "Pi takes any name: {reach}");
+    for tool in rejecting {
+        assert!(
+            !reach.contains(tool),
+            "{tool} rejects a `__` name and cannot offer it: {reach}"
+        );
+    }
+
+    let plain = fixture("\"codex\"", "[commands.ship]\nsource = \"cat\"\n");
+    let reach = cross_read_warning(&plain);
+    for tool in rejecting {
+        assert!(
+            reach.contains(tool),
+            "{tool} reads the tree and takes a plain name: {reach}"
+        );
+    }
+}
+
+/// The one warning that says which other tools are offered the command.
+#[allow(clippy::unwrap_used)]
+fn cross_read_warning(f: &Fixture) -> String {
+    let report = audit(&f.env, &f.scope).unwrap();
+    let found: Vec<String> = report
+        .warnings
+        .iter()
+        .filter(|w| w.message.contains("also read"))
+        .map(|w| w.message.clone())
+        .collect();
+    assert_eq!(found.len(), 1, "{:?}", report.warnings);
+    found.into_iter().next().unwrap()
+}

--- a/crates/core/tests/copilot_reports.rs
+++ b/crates/core/tests/copilot_reports.rs
@@ -195,6 +195,36 @@ fn a_skill_installed_for_another_tool_is_noted_as_visible_to_copilot() {
     );
 }
 
+/// The same note, over a name that reader's loader will not take. Copilot
+/// keys a skill on a lowercase-hyphen slug, so `Deploy` is unloadable
+/// there rather than renamed — counting Copilot as already having the
+/// definition would be counting one it cannot read. The test above is the
+/// pair: the same install under a plain name does name Copilot, so this
+/// cannot pass by the note having gone silent.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn the_cross_read_note_skips_a_loader_that_would_reject_the_name() {
+    let f = fixture("\"claude\"", "[skills.Deploy]\nsource = \"cat\"\n");
+    let source = f.env.home.join("catalog/skills/Deploy");
+    fs::create_dir_all(&source).unwrap();
+    fs::write(
+        source.join("SKILL.md"),
+        "---\nname: Deploy\ndescription: Ship it\n---\n\nSteps.\n",
+    )
+    .unwrap();
+
+    let report = apply_now(&f);
+    assert!(f.project.join(".agents/skills/Deploy/SKILL.md").is_file());
+    assert!(
+        !report
+            .notes
+            .iter()
+            .any(|note| note.contains("GitHub Copilot")),
+        "Copilot cannot load `Deploy`: {:?}",
+        report.notes
+    );
+}
+
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_model_the_repository_will_not_run_is_named() {

--- a/crates/core/tests/edits_and_forks/agent_capture.rs
+++ b/crates/core/tests/edits_and_forks/agent_capture.rs
@@ -217,3 +217,50 @@ fn a_crlf_rendering_forks_with_its_wrapper_off_and_its_endings_kept() {
         assert_eq!(times(&after, section), 1, "{section}: {after}");
     }
 }
+
+/// A fork reads the record of the install to place an agent's required
+/// skills, so a record it cannot read is raised rather than treated as an
+/// empty one. Falling back would rewrite every skill path in the captured
+/// agent from the scope default — a guess, written over the person's file.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_fork_refuses_a_lock_it_cannot_read_rather_than_guessing_the_paths() {
+    let w = world();
+    write_skill(&w.upstream, "recon", "Recon.");
+    write_agent(&w.upstream, "rev", "Upstream body.");
+    fs::write(
+        w.upstream.join("kendex.toml"),
+        "[agent-skills]\nrev = [\"recon\"]\n",
+    )
+    .unwrap();
+    commit(&w.upstream, "one");
+
+    let path = manifest::manifest_path(&w.env, &w.scope);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(
+        &path,
+        format!(
+            "schema = 6\n\n[sources.cat]\nrepo = \"{REPO}\"\n\n[install]\nharnesses = [\"gemini\"]\nmethod = \"symlink\"\n\n[agents.rev]\nsource = \"cat\"\n\n[skills.recon]\nsource = \"cat\"\n"
+        ),
+    )
+    .unwrap();
+    sync_and_apply(&w);
+    edit_body(&rendered(&w, HarnessId::Gemini, "rev"));
+
+    // The same fork settles while the record is readable, so what the
+    // corrupt one below changes is the record and nothing else.
+    let lock = lock_path(&w.env, &w.scope);
+    let good = fs::read_to_string(&lock).unwrap();
+    fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Gemini).unwrap();
+
+    fs::write(&lock, "{ not json").unwrap();
+    let error = fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Gemini)
+        .expect_err("a record this build cannot read is raised");
+    assert!(
+        matches!(error, kendex_core::error::CoreError::LockCorrupt { .. }),
+        "{error}"
+    );
+
+    fs::write(&lock, good).unwrap();
+    fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Gemini).unwrap();
+}

--- a/crates/core/tests/surfaces.rs
+++ b/crates/core/tests/surfaces.rs
@@ -225,3 +225,52 @@ fn verify_reads_a_global_skill_from_the_shared_tree() {
     let drift = audit(&env, &Scope::Global).unwrap().drift;
     assert!(drift.iter().any(|row| row.name == "gh"), "{drift:?}");
 }
+
+/// A global copy for Codex writes the one root that is Codex's alone.
+/// Codex reads three skill roots at user level: the shared
+/// `~/.agents/skills`, `~/.codex/skills`, and `~/.codex/skills/.system`,
+/// where it stages the skills it ships. A copy is a tree only one tool
+/// reads, so it goes to the second of those — read by Codex, and by
+/// nothing else. Leaving the shared tree untouched is what separates a
+/// copy from the install above, which writes that tree and nothing else.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_global_copy_for_codex_writes_the_directory_only_codex_reads() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let env = Env::fake(&home, FakeOs::Linux);
+
+    let source = home.join("catalog");
+    fs::create_dir_all(source.join("skills/gh")).unwrap();
+    let body = "---\nname: gh\ndescription: github\n---\nBody.\n";
+    fs::write(source.join("skills/gh/SKILL.md"), body).unwrap();
+    let manifest = env.global_manifest_file();
+    fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+    fs::write(
+        &manifest,
+        format!(
+            "schema = 6\n\n[sources.cat]\n{}\n\n[install]\nharnesses = [\"codex\"]\nmethod = \"copy\"\n\n[skills.gh]\nsource = \"cat\"\n",
+            source_path(&source)
+        ),
+    )
+    .unwrap();
+
+    let report = audit(&env, &Scope::Global).unwrap();
+    apply::execute(&env, &report.plan).unwrap();
+
+    let own = home.join(".codex/skills/gh");
+    assert!(
+        own.join("SKILL.md").is_file(),
+        "the copy lands in the root only Codex reads"
+    );
+    assert!(!own.is_symlink(), "a copy is a tree, not a link");
+    assert_eq!(fs::read_to_string(own.join("SKILL.md")).unwrap(), body);
+    // The half that must fail if the delivery stopped being per-tool: the
+    // shared tree every one of these tools reads is left alone, so this is
+    // a copy and not the shared install under another name.
+    assert!(
+        !home.join(".agents/skills/gh").exists(),
+        "a copy writes no shared tree"
+    );
+    assert!(audit(&env, &Scope::Global).unwrap().drift.is_empty());
+}

--- a/docs/adapters/codex.md
+++ b/docs/adapters/codex.md
@@ -16,7 +16,7 @@ Project markers: a `.codex/` or `.agents/` directory.
 | Kind | Global | Project | Caps |
 |---|---|---|---|
 | agent | `~/.codex/agents/*.toml` | `.codex/agents/*.toml` | managed, both |
-| skill | `~/.agents/skills/<name>/SKILL.md`, shared with Pi, OpenCode, Gemini and Copilot; `~/.codex/skills/<name>/SKILL.md` read back only | `.agents/skills/<name>/SKILL.md`, shared with Pi and Antigravity | managed, both |
+| skill | `~/.agents/skills/<name>/SKILL.md`, shared with Pi, OpenCode, Gemini and Copilot; `~/.codex/skills/<name>/SKILL.md` for a copy delivery | `.agents/skills/<name>/SKILL.md`, shared with Pi and Antigravity | managed, both |
 | command | — | — | install, toggle, remove, refresh both; `installs_as: skill` |
 | hook | `~/.codex/hooks.json` | `.codex/hooks.json` | managed, both, enforced |
 | mcp-server | `~/.codex/config.toml` `[mcp_servers.<name>]` | `.codex/config.toml` | managed, both |
@@ -25,7 +25,7 @@ Project markers: a `.codex/` or `.agents/` directory.
 
 Codex removed custom prompts in 0.118 (2026-03), so `~/.codex/prompts` is read by nothing and kendex neither scans nor writes it; a command is a skill there, invoked as `$name` or through `/skills`.
 
-`$HOME/.agents/skills` is the only user-level skills location Codex documents, so a global install lands there and `~/.codex/skills` is read back only. A global copy delivery still writes `~/.codex/skills`, which Codex does not read: it is the only directory of Codex's own, and what a copy should do instead is open.
+Codex reads three skill roots at user level: the shared `~/.agents/skills`, `~/.codex/skills`, and `~/.codex/skills/.system`, where it stages the skills it ships. A global install lands in the shared tree, one definition every tool reading it sees. `~/.codex/skills` is read as well, and is the only one of the three that is Codex's alone, so it is where a global copy delivery writes its tree and where a skill an older install left is read back (`a_global_copy_for_codex_writes_the_directory_only_codex_reads`, `crates/core/tests/surfaces.rs`).
 
 ## Format
 


### PR DESCRIPTION
Two issues of one class: a place or a claim derived without the per-skill delivery method.

## KEN-1263 — the premise is false, so the copy target stays

The issue said a global per-tool copy for Codex lands in `~/.codex/skills`, "which Codex does not read", and asked either to move the copy or refuse the method. Verified against the shipped Codex binary, 0.153.4: under a faked `HOME` with `CODEX_HOME` unset, `codex debug prompt-input` renders the model-visible skill roots as

```
<project>/.codex/skills
~/.codex/skills
~/.agents/skills
~/.codex/skills/.system
<project>/.agents/skills
```

A probe skill planted in `~/.codex/skills` is listed to the model from that root. Codex's own bundled `skill-installer` skill installs into `$CODEX_HOME/skills`, and Codex stages the skills it ships under `~/.codex/skills/.system`.

So `~/.codex/skills` is read, and is the only one of the three that is Codex's alone — which is what a per-tool copy needs. The capability table states `managed(BOTH)` honestly as it stands: no refusal, no new surface, no behaviour change. What changes is the comment and the adapter doc paragraph that said otherwise, both landed by #2282, plus a control and its paired negative.

## KEN-1267 — the delivery decides the path and the warning

`render::agent::skill_root` answered from harness and scope alone, so an agent requiring a skill installed with `method = "copy"` was told to read the shared tree, which a copy never writes. `EffectiveAgent` now carries each required skill with the place its own delivery wrote, resolved in `desired_agent::required_skills`.

`desired_command::as_skill` derived the "these tools also read this directory" warning from directory equality alone, so it could name OpenCode or Copilot for a tree whose `__` name their lower-kebab loaders reject. The tree must now validate for a tool before that tool is named.

## What the review round changed

The first attempt at `skill_root` kept a literal table of copy roots. That was wrong: `own_dir` resolves through `default_global_root`, and four adapters read a relocation variable there (`CODEX_HOME`, `COPILOT_HOME`, `OPENCODE_CONFIG_DIR`, `PI_CODING_AGENT_DIR`). With one set, the copy lands under the relocated root while the agent was told the unrelocated literal — the exact failure this PR claims to remove. The table is gone rather than corrected; the place is asked of `own_dir`.

The controls did not reach that far either. Mutating `required_skills` to the pre-fix behaviour left the whole suite green, because both tests called `skill_root` directly rather than through a rendering. They now install under a relocated `CODEX_HOME` and read the generated agent file, one control per delivery; the mutation fails them.

`cross_read_note` in `desired_skill.rs` carried the same defect as the command half — a skill named `Deploy` was reported already visible to Copilot, which cannot load that name. Same root cause, folded in here rather than tracked.

## Checks

`tools/guard --full` clean on the final tree: exit 0, zero `guard:` lines, full Rust workspace, 152 UI files and 1225 UI tests. One local reviewer round, its three findings all fixed.

Closes KEN-1263. Closes KEN-1267.
