### PR TITLE
fix(KEN-1270): preflight knows a tools/test-<name> suite

### DIFF
--- a/.agents/skills/preflight/scripts/preflight
+++ b/.agents/skills/preflight/scripts/preflight
@@ -86,10 +86,12 @@ Lanes:
                   pipefail preamble of its own is out of scope even where a
                   sourcing caller supplies one.
   unwired-suite   a new suite file no runner invokes. Suites are
-                  tests/*.test.sh, tests/test-*.sh, *.test.ts, *.test.js and
-                  *.test.mjs; a file under a fixtures/ directory is material a
-                  suite reads, never a suite. A runner set that is empty or
-                  that this tool could not read whole leaves the lane quiet.
+                  tests/*.test.sh, tests/test-*.sh, a shell file with a
+                  test-<name> basename and no extension, *.test.ts, *.test.js
+                  and *.test.mjs; a file under a fixtures/ directory is
+                  material a suite reads, never a suite. A runner set that is
+                  empty or that this tool could not read whole leaves the
+                  lane quiet.
   mktemp-trap     a new shell file with an added mktemp invocation and no
                   trap ... EXIT anywhere in it. The invocation is the word at
                   a command position, not one named in a comment or a string.
@@ -132,7 +134,8 @@ Scope rules:
   shebang. A file whose content git reads as binary contributes no lines to
   any lane; the whole-file lanes still see its path. A deleted path leaves the
   change set, and applied-migration-edited reads it from the diff instead.
-  A tests/ or fixtures/ tree sets its own rules: early-close-pipe,
+  The test tree sets its own rules: a tests/ or fixtures/ tree, and a suite
+  as unwired-suite defines one, wherever it lives. early-close-pipe,
   mktemp-trap, the source-file direction of docs-cited-paths, and the
   strict-mode and swallowed-status shapes of fail-open stand down there. In a
   test-named source file (tests.rs, *_test.*, *_tests.*, *.test.*, *.spec.*,
@@ -756,14 +759,28 @@ swallowed_cmd() { # LINE -> command name on stdout
     }'
 }
 
-# A file whose only purpose is to be run by a runner. Fixtures are material
-# a suite reads, never a suite themselves.
-is_suite_path() { # PATH
+# The test tree sets its own rules, and this is its one grammar. A suite is
+# a file whose only purpose is to be run by a runner: tests/*.test.sh,
+# tests/test-*.sh, a shell file with a test-<name> basename and no
+# extension wherever it lives, *.test.ts, *.test.js and *.test.mjs.
+# Material is what a suite reads: anything under a fixtures/ directory, and
+# the rest of a tests/ tree. Returns 1 outside the test tree; otherwise sets
+# TEST_TREE_ROLE to suite or material.
+test_tree_role() { # PATH IS_SHELL(0|1)
+  TEST_TREE_ROLE=""
   case "/$1" in
-    */fixtures/*) return 1 ;;
+    */fixtures/*) TEST_TREE_ROLE=material; return 0 ;;
   esac
   case "/$1" in
-    */tests/*.test.sh | */tests/test-*.sh | *.test.ts | *.test.js | *.test.mjs) return 0 ;;
+    */tests/*.test.sh | */tests/test-*.sh | *.test.ts | *.test.js | *.test.mjs) TEST_TREE_ROLE=suite; return 0 ;;
+  esac
+  if [ "$2" = 1 ]; then
+    case "${1##*/}" in
+      test-*) case "${1##*/}" in *.*) ;; *) TEST_TREE_ROLE=suite; return 0 ;; esac ;;
+    esac
+  fi
+  case "/$1" in
+    */tests/*) TEST_TREE_ROLE=material; return 0 ;;
   esac
   return 1
 }
@@ -866,9 +883,10 @@ suite_is_wired() { # SUITE-PATH
     [ "$r" != "$p" ] || continue
     case "$tok" in
       *"*"*)
-        # Only a glob naming a file shape is wiring. A path filter spelled
-        # `*/*` matches every suite in the repo and invokes none of them.
-        case "${tok##*/}" in *.*) ;; *) continue ;; esac
+        # Only a glob naming a file shape is wiring: an extension, or the
+        # test-<name> prefix of an extensionless suite. A path filter
+        # spelled `*/*` matches every suite in the repo and invokes none.
+        case "${tok##*/}" in *.* | test-*) ;; *) continue ;; esac
         case "$p" in $tok) return 0 ;; esac
         if [ "${r%/*}" = "$dir" ]; then
           case "$base" in ${tok##*/}) return 0 ;; esac
@@ -908,9 +926,7 @@ while IFS= read -r f; do
   mktemp_reported=0
   is_shell_path "$f" "$cpath" && is_sh=1
   own_rules=0
-  case "/$f" in
-    */tests/* | */fixtures/*) own_rules=1 ;;
-  esac
+  test_tree_role "$f" "$is_sh" && own_rules=1
   is_new=0
   if [ "$MODE" = "all" ] || grep -qxF -- "$f" "$TMP/newfiles.list"; then is_new=1; fi
   # A file under a scripts/lib/ tree with no executable bit cannot be run or
@@ -1009,8 +1025,9 @@ while IFS= read -r f; do
     fi
 
     # A new script that never turns on errexit, nounset and pipefail
-    # fails open at its first unchecked command. Test trees and fixtures set
-    # their own rules.
+    # fails open at its first unchecked command. The test tree sets its own
+    # rules (test_tree_role): a suite may observe a status errexit would
+    # abort on.
     if [ "$own_rules" = 0 ] && [ "$vendored_mirror" = 0 ] && [ "$sourced_lib" = 0 ] && [ "$is_new" = 1 ]; then
       if [ "$has_ee" = 0 ] || [ "$has_pf" = 0 ] || ! file_matches "$cpath" "$NOUNSET_RE"; then
         emit "$f" 0 fail-open "new shell file without strict mode (set -euo pipefail)"
@@ -1018,7 +1035,7 @@ while IFS= read -r f; do
     fi
   fi
 
-  if [ "$is_new" = 1 ] && [ "$vendored_mirror" = 0 ] && is_suite_path "$f" && ! suite_is_wired "$f"; then
+  if [ "$is_new" = 1 ] && [ "$vendored_mirror" = 0 ] && [ "$TEST_TREE_ROLE" = suite ] && ! suite_is_wired "$f"; then
     emit "$f" 0 unwired-suite "new suite is not invoked by any runner"
   fi
 

--- a/.agents/skills/preflight/tests/precision.test.sh
+++ b/.agents/skills/preflight/tests/precision.test.sh
@@ -582,6 +582,37 @@ fires "an executable file in a lib tree is a program and still fails" "scripts/l
 fires "a swallowed status inside a sourced lib still fails" "scripts/lib/common.sh:6: [fail-open] grep || true swallows exit 2"
 fires "an unchecked mktemp inside a sourced lib still fails" "scripts/lib/common.sh:7: [fail-open] unchecked mktemp"
 
+echo "=== a test-<name> suite outside a tests/ tree sets its own rules ==="
+seed toolsuite
+mkdir -p "$R/.github/workflows" "$R/tools" "$R/tests/fixtures" "$R/docs"
+printf 'name: ci\non: push\njobs:\n  t:\n    runs-on: ubuntu-latest\n    steps:\n      - run: for t in tools/test-*; do "$t"; done\n' >"$R/.github/workflows/ci.yml"
+cat >"$R/tools/test-lexer" <<'EOF2'
+#!/usr/bin/env bash
+# Observes a guard's exit status; errexit would abort the suite at the first
+# must-fire case.
+set -uo pipefail
+status=0
+"$1" || status=$?
+echo "$status"
+EOF2
+chmod +x "$R/tools/test-lexer"
+# The same bytes as fixture material a suite reads, and a plain-text file
+# whose name alone looks like a suite: neither is one.
+cp "$R/tools/test-lexer" "$R/tests/fixtures/test-input"
+printf 'cases to run by hand\n' >"$R/docs/test-plan"
+git -C "$R" add -A
+run_pf
+clean "a new tools/test-<name> suite without errexit, wired by a tools/test-* glob, is not a finding; a fixture and a text file of that name are not suites"
+
+echo "=== control: the same bytes under a non-suite name, and a suite the glob does not reach, still fail ==="
+cp "$R/tools/test-lexer" "$R/tools/lexer"
+mkdir -p "$R/scripts"
+cp "$R/tools/test-lexer" "$R/scripts/test-orphan"
+git -C "$R" add -A
+run_pf
+fires "a new non-suite script without strict mode still fails" "tools/lexer:0: [fail-open] new shell file without strict mode"
+fires "a test-<name> suite no runner reaches is unwired" "scripts/test-orphan:0: [unwired-suite]"
+
 echo "=== staged scope reads the bit the index carries ==="
 seed stagedlib
 mkdir -p "$R/scripts/lib"

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -86,10 +86,12 @@ Lanes:
                   pipefail preamble of its own is out of scope even where a
                   sourcing caller supplies one.
   unwired-suite   a new suite file no runner invokes. Suites are
-                  tests/*.test.sh, tests/test-*.sh, *.test.ts, *.test.js and
-                  *.test.mjs; a file under a fixtures/ directory is material a
-                  suite reads, never a suite. A runner set that is empty or
-                  that this tool could not read whole leaves the lane quiet.
+                  tests/*.test.sh, tests/test-*.sh, a shell file with a
+                  test-<name> basename and no extension, *.test.ts, *.test.js
+                  and *.test.mjs; a file under a fixtures/ directory is
+                  material a suite reads, never a suite. A runner set that is
+                  empty or that this tool could not read whole leaves the
+                  lane quiet.
   mktemp-trap     a new shell file with an added mktemp invocation and no
                   trap ... EXIT anywhere in it. The invocation is the word at
                   a command position, not one named in a comment or a string.
@@ -132,7 +134,8 @@ Scope rules:
   shebang. A file whose content git reads as binary contributes no lines to
   any lane; the whole-file lanes still see its path. A deleted path leaves the
   change set, and applied-migration-edited reads it from the diff instead.
-  A tests/ or fixtures/ tree sets its own rules: early-close-pipe,
+  The test tree sets its own rules: a tests/ or fixtures/ tree, and a suite
+  as unwired-suite defines one, wherever it lives. early-close-pipe,
   mktemp-trap, the source-file direction of docs-cited-paths, and the
   strict-mode and swallowed-status shapes of fail-open stand down there. In a
   test-named source file (tests.rs, *_test.*, *_tests.*, *.test.*, *.spec.*,
@@ -756,14 +759,28 @@ swallowed_cmd() { # LINE -> command name on stdout
     }'
 }
 
-# A file whose only purpose is to be run by a runner. Fixtures are material
-# a suite reads, never a suite themselves.
-is_suite_path() { # PATH
+# The test tree sets its own rules, and this is its one grammar. A suite is
+# a file whose only purpose is to be run by a runner: tests/*.test.sh,
+# tests/test-*.sh, a shell file with a test-<name> basename and no
+# extension wherever it lives, *.test.ts, *.test.js and *.test.mjs.
+# Material is what a suite reads: anything under a fixtures/ directory, and
+# the rest of a tests/ tree. Returns 1 outside the test tree; otherwise sets
+# TEST_TREE_ROLE to suite or material.
+test_tree_role() { # PATH IS_SHELL(0|1)
+  TEST_TREE_ROLE=""
   case "/$1" in
-    */fixtures/*) return 1 ;;
+    */fixtures/*) TEST_TREE_ROLE=material; return 0 ;;
   esac
   case "/$1" in
-    */tests/*.test.sh | */tests/test-*.sh | *.test.ts | *.test.js | *.test.mjs) return 0 ;;
+    */tests/*.test.sh | */tests/test-*.sh | *.test.ts | *.test.js | *.test.mjs) TEST_TREE_ROLE=suite; return 0 ;;
+  esac
+  if [ "$2" = 1 ]; then
+    case "${1##*/}" in
+      test-*) case "${1##*/}" in *.*) ;; *) TEST_TREE_ROLE=suite; return 0 ;; esac ;;
+    esac
+  fi
+  case "/$1" in
+    */tests/*) TEST_TREE_ROLE=material; return 0 ;;
   esac
   return 1
 }
@@ -866,9 +883,10 @@ suite_is_wired() { # SUITE-PATH
     [ "$r" != "$p" ] || continue
     case "$tok" in
       *"*"*)
-        # Only a glob naming a file shape is wiring. A path filter spelled
-        # `*/*` matches every suite in the repo and invokes none of them.
-        case "${tok##*/}" in *.*) ;; *) continue ;; esac
+        # Only a glob naming a file shape is wiring: an extension, or the
+        # test-<name> prefix of an extensionless suite. A path filter
+        # spelled `*/*` matches every suite in the repo and invokes none.
+        case "${tok##*/}" in *.* | test-*) ;; *) continue ;; esac
         case "$p" in $tok) return 0 ;; esac
         if [ "${r%/*}" = "$dir" ]; then
           case "$base" in ${tok##*/}) return 0 ;; esac
@@ -908,9 +926,7 @@ while IFS= read -r f; do
   mktemp_reported=0
   is_shell_path "$f" "$cpath" && is_sh=1
   own_rules=0
-  case "/$f" in
-    */tests/* | */fixtures/*) own_rules=1 ;;
-  esac
+  test_tree_role "$f" "$is_sh" && own_rules=1
   is_new=0
   if [ "$MODE" = "all" ] || grep -qxF -- "$f" "$TMP/newfiles.list"; then is_new=1; fi
   # A file under a scripts/lib/ tree with no executable bit cannot be run or
@@ -1009,8 +1025,9 @@ while IFS= read -r f; do
     fi
 
     # A new script that never turns on errexit, nounset and pipefail
-    # fails open at its first unchecked command. Test trees and fixtures set
-    # their own rules.
+    # fails open at its first unchecked command. The test tree sets its own
+    # rules (test_tree_role): a suite may observe a status errexit would
+    # abort on.
     if [ "$own_rules" = 0 ] && [ "$vendored_mirror" = 0 ] && [ "$sourced_lib" = 0 ] && [ "$is_new" = 1 ]; then
       if [ "$has_ee" = 0 ] || [ "$has_pf" = 0 ] || ! file_matches "$cpath" "$NOUNSET_RE"; then
         emit "$f" 0 fail-open "new shell file without strict mode (set -euo pipefail)"
@@ -1018,7 +1035,7 @@ while IFS= read -r f; do
     fi
   fi
 
-  if [ "$is_new" = 1 ] && [ "$vendored_mirror" = 0 ] && is_suite_path "$f" && ! suite_is_wired "$f"; then
+  if [ "$is_new" = 1 ] && [ "$vendored_mirror" = 0 ] && [ "$TEST_TREE_ROLE" = suite ] && ! suite_is_wired "$f"; then
     emit "$f" 0 unwired-suite "new suite is not invoked by any runner"
   fi
 

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -582,6 +582,37 @@ fires "an executable file in a lib tree is a program and still fails" "scripts/l
 fires "a swallowed status inside a sourced lib still fails" "scripts/lib/common.sh:6: [fail-open] grep || true swallows exit 2"
 fires "an unchecked mktemp inside a sourced lib still fails" "scripts/lib/common.sh:7: [fail-open] unchecked mktemp"
 
+echo "=== a test-<name> suite outside a tests/ tree sets its own rules ==="
+seed toolsuite
+mkdir -p "$R/.github/workflows" "$R/tools" "$R/tests/fixtures" "$R/docs"
+printf 'name: ci\non: push\njobs:\n  t:\n    runs-on: ubuntu-latest\n    steps:\n      - run: for t in tools/test-*; do "$t"; done\n' >"$R/.github/workflows/ci.yml"
+cat >"$R/tools/test-lexer" <<'EOF2'
+#!/usr/bin/env bash
+# Observes a guard's exit status; errexit would abort the suite at the first
+# must-fire case.
+set -uo pipefail
+status=0
+"$1" || status=$?
+echo "$status"
+EOF2
+chmod +x "$R/tools/test-lexer"
+# The same bytes as fixture material a suite reads, and a plain-text file
+# whose name alone looks like a suite: neither is one.
+cp "$R/tools/test-lexer" "$R/tests/fixtures/test-input"
+printf 'cases to run by hand\n' >"$R/docs/test-plan"
+git -C "$R" add -A
+run_pf
+clean "a new tools/test-<name> suite without errexit, wired by a tools/test-* glob, is not a finding; a fixture and a text file of that name are not suites"
+
+echo "=== control: the same bytes under a non-suite name, and a suite the glob does not reach, still fail ==="
+cp "$R/tools/test-lexer" "$R/tools/lexer"
+mkdir -p "$R/scripts"
+cp "$R/tools/test-lexer" "$R/scripts/test-orphan"
+git -C "$R" add -A
+run_pf
+fires "a new non-suite script without strict mode still fails" "tools/lexer:0: [fail-open] new shell file without strict mode"
+fires "a test-<name> suite no runner reaches is unwired" "scripts/test-orphan:0: [unwired-suite]"
+
 echo "=== staged scope reads the bit the index carries ==="
 seed stagedlib
 mkdir -p "$R/scripts/lib"


### PR DESCRIPTION
Closes KEN-1270.

preflight's strict-mode exemption (`own_rules`) and the `unwired-suite` lane's `is_suite_path` were two grammars for the test tree, and neither knew a suite named `test-<name>` outside a `tests/` directory, which is how hyprtrade lays out every suite (`tools/test-*`). They are now one helper, `test_tree_role`, which classifies a path as `suite` or `material` and covers a shell file with a `test-<name>` basename and no extension wherever it lives (a plain-text file of that name is not a suite). The strict-mode exemption reads that helper, and `unwired-suite` treats such a file as a suite it must find wired. Because that class has no extension, the wiring grammar now accepts a `test-*` glob in a runner (`for t in tools/test-*`) as naming a file shape; the `*/*` path-filter refusal stands.

Result: `preflight --repo <hyprtrade ht-1836 worktree>` goes from seven strict-mode findings (the four the issue names plus three `tools/test-guard-store-pin-*` splits) to clean, with no new `unwired-suite` finding. Precision suite gains one clean case (a new `tools/test-lexer` without errexit, wired by a `tools/test-*` glob, beside a `tests/fixtures/test-input` copy and a `docs/test-plan` text file that are not suites) and two must-fail controls: the same bytes as `tools/lexer` still get the strict-mode finding, and a `scripts/test-orphan` the glob does not reach is unwired. The clean case runs red on the pre-change script, on a mutant with the glob rule reverted (`tools/test-lexer` unwired), and on a mutant without the shell anchor (`docs/test-plan` unwired).

Local reviewer round: no blockers; its three suggestions (anchor the extensionless rule to shell files, let a `test-*` glob wire the class the diff introduces, cover the fixtures precedence) are all applied above.

Out of scope, left as is: the issue's observation 1, that `ERREXIT_RE` is satisfied by a `set -euo pipefail` line inside a fixture heredoc. No new settings key. Tracked renders under `.agents/skills/preflight/` are replayed in the same commit. No changelog fragment: skills/ change.

Validation: all four preflight suites pass; `tools/guard --full` green except one load-induced timing test in `kendex-app` `launch_env` (passes alone, load average 17) and `kendex-cli` `scope_project_outside_a_project_is_an_error`, which fails identically on an untouched main checkout on this machine (its temp home resolves inside a project here); neither touches this diff. CI is the verdict for both.

Program: KEN-1203 (architecture-docs program tracker).

https://claude.ai/code/session_01DryPBfQDkJfrAyE7CLL4ov
