### PR TITLE
feat(KEN-1027): the commit, push and pull-request offer after a write

### DIFF
--- a/changelog.d/added/commit-offer.md
+++ b/changelog.d/added/commit-offer.md
@@ -1,0 +1,1 @@
+- After a write into a git project, kendex offers to commit the files it wrote, commit and push, or open a pull request; the CLI also takes `--commit`, `--push`, `--pull-request` and `--leave`.

--- a/crates/app/src/commit_offer.rs
+++ b/crates/app/src/commit_offer.rs
@@ -14,7 +14,7 @@
 
 use std::path::{Path, PathBuf};
 
-use kendex_core::commit_offer::{self, Branch, Committed, Failed, Offer, Step, Unavailable};
+use kendex_core::commit_offer::{self, Branch, Committed, Failed, Offer, Probe, Step, Unavailable};
 use kendex_core::env::Env;
 use kendex_core::model::Scope;
 use serde::Serialize;
@@ -224,7 +224,7 @@ fn read(env: &Env, root: &Path) -> Result<Option<Result<ProjectOffer, ProjectFla
     }
     // The window's write is not a typed command, so the message names the
     // shell the person is in rather than a verb they typed.
-    match commit_offer::offer(scan, COMMAND) {
+    match commit_offer::offer(scan, COMMAND, Probe::Gh) {
         Ok(offer) => Ok(Some(Ok(drawn(root, offer)))),
         Err(failed) => Ok(Some(Err(ProjectFlag {
             root: shown(root),

--- a/crates/app/src/commit_offer.rs
+++ b/crates/app/src/commit_offer.rs
@@ -1,0 +1,442 @@
+//! The desktop's half of the commit, push and pull-request offer: the read
+//! that says what one project has to offer, and one command per step the
+//! window can run.
+//!
+//! A step each rather than a command per route, because the window draws
+//! the step that is running and has its own designed state for each way one
+//! can refuse. Every command here is a thin pass to
+//! [`kendex_core::commit_offer`], which both shells share, so the window
+//! cannot offer something the terminal would refuse.
+//!
+//! Nothing here words anything. A refusal travels as the program's own
+//! lines and the step that produced them, and `ui/src/lib/copy-commit-offer.ts`
+//! is where every sentence the window shows lives.
+
+use std::path::{Path, PathBuf};
+
+use kendex_core::commit_offer::{self, Branch, Committed, Failed, Offer, Step, Unavailable};
+use kendex_core::env::Env;
+use kendex_core::model::Scope;
+use serde::Serialize;
+use specta::Type;
+
+use crate::scopes::env;
+
+/// Why a choice is not on offer, for the labelled row the window draws
+/// under the segments.
+#[derive(Debug, Clone, Serialize, Type)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum Why {
+    NoRemote,
+    RemoteNotDecidable,
+    GhMissing,
+    /// gh's own first line, so a case nobody anticipated still names
+    /// itself rather than reading as one kendex knows.
+    GhSaid {
+        line: String,
+    },
+}
+
+impl From<&Unavailable> for Why {
+    fn from(why: &Unavailable) -> Why {
+        match why {
+            Unavailable::NoRemote => Why::NoRemote,
+            Unavailable::RemoteNotDecidable => Why::RemoteNotDecidable,
+            Unavailable::GhMissing => Why::GhMissing,
+            Unavailable::GhSaid(line) => Why::GhSaid { line: line.clone() },
+        }
+    }
+}
+
+/// One project's offer, everything the dialog draws it from.
+#[derive(Debug, Clone, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectOffer {
+    pub root: String,
+    /// The project's folder name, which the title names.
+    pub name: String,
+    /// The files kendex owns whole that changed, printed whole: an
+    /// abbreviation guesses at a directory and names a different file from
+    /// the one being committed.
+    pub files: Vec<String>,
+    /// The shared configuration files kendex writes one key in.
+    pub shared: Vec<String>,
+    /// How many of the person's own files changed.
+    pub others: u32,
+    pub branch: String,
+    pub remote: Option<String>,
+    /// `null` where the choice stands; the reason otherwise.
+    pub push: Option<Why>,
+    pub pull_request: Option<Why>,
+    /// The pull request already open for this branch.
+    pub open_number: Option<u32>,
+    pub message: String,
+    pub new_branch: String,
+    /// The repository every `gh` call is bound to, from the chosen remote.
+    pub repo: Option<String>,
+    /// The branch already tracks the chosen remote, so a push needs no
+    /// `--set-upstream`.
+    pub tracked: bool,
+}
+
+/// A project where kendex owns changed files and the offer cannot be made.
+/// The window flags it on the project's card rather than opening a dialog
+/// that offers nothing.
+#[derive(Debug, Clone, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectFlag {
+    pub root: String,
+    pub count: u32,
+    pub reason: FlagReason,
+}
+
+#[derive(Debug, Clone, Serialize, Type)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum FlagReason {
+    NoBranch,
+    /// The operation as a line names it: `a rebase`.
+    InProgress {
+        operation: String,
+    },
+    /// A read the offer is built from would not run, so nothing about this
+    /// project can be claimed.
+    Unreadable {
+        said: Vec<String>,
+    },
+}
+
+/// What one read of every project the write could reach found.
+#[derive(Debug, Clone, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitOfferScan {
+    pub offers: Vec<ProjectOffer>,
+    pub flagged: Vec<ProjectFlag>,
+}
+
+/// A step that did not go through.
+#[derive(Debug, Clone, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct Refused {
+    /// The step, as its own line names it.
+    pub step: String,
+    /// The program's own words, whole, in order. Empty where the step ran
+    /// out of time and said nothing.
+    pub said: Vec<String>,
+    pub timed_out: bool,
+    /// The bound in whole seconds, for the line a timeout draws.
+    pub seconds: u32,
+    /// Whether the words are `gh`'s rather than git's.
+    pub gh: bool,
+}
+
+impl From<&Failed> for Refused {
+    fn from(failed: &Failed) -> Refused {
+        Refused {
+            step: failed.step.name().to_owned(),
+            said: failed.said().to_vec(),
+            timed_out: failed.timed_out(),
+            seconds: whole(failed.step.seconds()),
+            gh: matches!(failed.step, Step::Probe | Step::PullRequest),
+        }
+    }
+}
+
+/// What the commit did.
+#[derive(Debug, Clone, Serialize, Type)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum CommitStep {
+    /// The re-read set was empty: the files changed since the offer.
+    Nothing,
+    Made {
+        sha: String,
+        files: u32,
+    },
+    Refused {
+        refused: Refused,
+        /// Paths kendex staged and could not then unstage. They are still
+        /// staged, against the rule that the index ends as it began.
+        #[serde(rename = "stillStaged")]
+        still_staged: Option<u32>,
+    },
+}
+
+/// What one of the other steps did.
+#[derive(Debug, Clone, Serialize, Type)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum StepResult {
+    Done,
+    Refused { refused: Refused },
+}
+
+/// What opening the pull request did.
+#[derive(Debug, Clone, Serialize, Type)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum OpenResult {
+    Opened { url: String },
+    Refused { refused: Refused },
+}
+
+impl From<Result<(), Failed>> for StepResult {
+    fn from(result: Result<(), Failed>) -> StepResult {
+        match result {
+            Ok(()) => StepResult::Done,
+            Err(failed) => StepResult::Refused {
+                refused: Refused::from(&failed),
+            },
+        }
+    }
+}
+
+fn read(env: &Env, root: &Path) -> Result<Option<Result<ProjectOffer, ProjectFlag>>, String> {
+    let scope = Scope::Project {
+        root: root.to_owned(),
+    };
+    // The setting turns off the asking, and the window has no flag that
+    // could answer instead, so nothing is read at all when it is off.
+    if !commit_offer::asking(env) {
+        return Ok(None);
+    }
+    let scan = match commit_offer::scan(&scope, &generated(env, &scope)?) {
+        Ok(None) => return Ok(None),
+        Ok(Some(scan)) => scan,
+        Err(failed) => {
+            return Ok(Some(Err(ProjectFlag {
+                root: shown(root),
+                count: 0,
+                reason: FlagReason::Unreadable {
+                    said: failed.said().to_vec(),
+                },
+            })));
+        }
+    };
+    let flag = |reason: FlagReason| ProjectFlag {
+        root: shown(root),
+        count: counted(scan.count()),
+        reason,
+    };
+    match &scan.branch {
+        Branch::Detached => return Ok(Some(Err(flag(FlagReason::NoBranch)))),
+        Branch::InProgress(operation) => {
+            let operation = operation.article().to_owned();
+            return Ok(Some(Err(flag(FlagReason::InProgress { operation }))));
+        }
+        Branch::On(_) => {}
+    }
+    // The window's write is not a typed command, so the message names the
+    // shell the person is in rather than a verb they typed.
+    match commit_offer::offer(scan, COMMAND) {
+        Ok(offer) => Ok(Some(Ok(drawn(root, offer)))),
+        Err(failed) => Ok(Some(Err(ProjectFlag {
+            root: shown(root),
+            count: 0,
+            reason: FlagReason::Unreadable {
+                said: failed.said().to_vec(),
+            },
+        }))),
+    }
+}
+
+/// What the default message names when the write came from the window.
+/// The rule is the command, and in the app the command is the app.
+const COMMAND: &str = "app";
+
+fn drawn(root: &Path, offer: Offer) -> ProjectOffer {
+    ProjectOffer {
+        root: shown(root),
+        name: root
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| shown(root)),
+        files: offer
+            .scan
+            .owned
+            .iter()
+            .map(|owned| owned.path.clone())
+            .collect(),
+        shared: offer.scan.shared.clone(),
+        others: counted(offer.scan.others),
+        push: offer.push.as_ref().err().map(Why::from),
+        pull_request: offer.pull_request.as_ref().err().map(Why::from),
+        open_number: offer.open.as_ref().map(|open| whole(open.number)),
+        message: offer.message.clone(),
+        new_branch: offer.new_branch.clone(),
+        repo: offer.remote.as_ref().map(|remote| remote.url.clone()),
+        tracked: offer.remote.as_ref().is_some_and(|remote| remote.tracked),
+        remote: offer.remote.as_ref().map(|remote| remote.name.clone()),
+        branch: offer.branch,
+    }
+}
+
+/// The paths kendex renders in a project, which only a plan names.
+fn generated(env: &Env, scope: &Scope) -> Result<kendex_core::engine::GeneratedPaths, String> {
+    kendex_core::engine::plan_apply(env, scope, &kendex_core::engine::PlanOptions::default())
+        .map(|report| report.generated)
+        .map_err(|error| error.to_string())
+}
+
+/// A count on its way to the window. Numbers cross this boundary as
+/// 32-bit: JavaScript loses precision past 2^53, so the binding generator
+/// refuses the wider ones, and a project with more paths than this holds
+/// is not one any of these counts describes.
+fn counted(count: usize) -> u32 {
+    u32::try_from(count).unwrap_or(u32::MAX)
+}
+
+fn whole(count: u64) -> u32 {
+    u32::try_from(count).unwrap_or(u32::MAX)
+}
+
+/// A path as the window shows it: what core settled, character for
+/// character.
+fn shown(path: &Path) -> String {
+    kendex_core::paths::slashed(path)
+}
+
+/// Read every project the write could reach, and say for each one whether
+/// there is an offer to make, a state to flag on its card, or nothing.
+#[tauri::command(async)]
+#[specta::specta]
+pub fn commit_offer_scan(roots: Vec<String>) -> Result<CommitOfferScan, String> {
+    let env = env()?;
+    let mut found = CommitOfferScan {
+        offers: Vec::new(),
+        flagged: Vec::new(),
+    };
+    for root in roots {
+        // A project whose plan will not derive is not one this offer can
+        // claim anything about, and it is not a failure of the write that
+        // reached it either: the read is skipped and nothing is said.
+        match read(&env, &PathBuf::from(root)) {
+            Ok(None) | Err(_) => {}
+            Ok(Some(Ok(offer))) => found.offers.push(offer),
+            Ok(Some(Err(flag))) => found.flagged.push(flag),
+        }
+    }
+    Ok(found)
+}
+
+#[tauri::command(async)]
+#[specta::specta]
+pub fn commit_offer_commit(root: String, message: String) -> Result<CommitStep, String> {
+    let env = env()?;
+    let root = PathBuf::from(root);
+    let scope = Scope::Project { root: root.clone() };
+    let generated = generated(&env, &scope)?;
+    Ok(match commit_offer::commit(&root, &generated, &message) {
+        Ok(Committed::Nothing) => CommitStep::Nothing,
+        Ok(Committed::Made { sha, files }) => CommitStep::Made {
+            sha,
+            files: counted(files),
+        },
+        Err(failure) => CommitStep::Refused {
+            refused: Refused::from(&failure.failed),
+            still_staged: failure.still_staged.map(counted),
+        },
+    })
+}
+
+#[tauri::command(async)]
+#[specta::specta]
+pub fn commit_offer_push(
+    root: String,
+    remote: String,
+    branch: String,
+    tracked: bool,
+) -> Result<StepResult, String> {
+    Ok(
+        commit_offer::push(&PathBuf::from(root), &remote, &branch, tracked)
+            .map(|_| ())
+            .into(),
+    )
+}
+
+/// Push a commit that already exists to a branch of its own, without
+/// moving the branch it is on — the recovery a refused push offers.
+#[tauri::command(async)]
+#[specta::specta]
+pub fn commit_offer_push_head(
+    root: String,
+    remote: String,
+    branch: String,
+) -> Result<StepResult, String> {
+    Ok(
+        commit_offer::push_head(&PathBuf::from(root), &remote, &branch)
+            .map(|_| ())
+            .into(),
+    )
+}
+
+#[tauri::command(async)]
+#[specta::specta]
+pub fn commit_offer_start_branch(root: String, branch: String) -> Result<StepResult, String> {
+    Ok(commit_offer::start_branch(&PathBuf::from(root), &branch).into())
+}
+
+/// Put the checkout back and remove the empty branch kendex made, after a
+/// commit on it refused.
+#[tauri::command(async)]
+#[specta::specta]
+pub fn commit_offer_abandon_branch(root: String, branch: String) -> Result<StepResult, String> {
+    Ok(commit_offer::abandon_branch(&PathBuf::from(root), &branch).into())
+}
+
+/// The commit a recovery would put the branch back to, read before the
+/// commit runs. `null` in a repository with no commit yet.
+#[tauri::command(async)]
+#[specta::specta]
+pub fn commit_offer_previous_head(root: String) -> Result<Option<String>, String> {
+    commit_offer::previous_head(&PathBuf::from(root)).map_err(|failed| failed.said().join("\n"))
+}
+
+#[tauri::command(async)]
+#[specta::specta]
+pub fn commit_offer_open_pull_request(
+    repo: String,
+    head: String,
+    base: String,
+    title: String,
+    files: u32,
+) -> Result<OpenResult, String> {
+    Ok(
+        match commit_offer::open_pull_request(&repo, &head, &base, &title, files as usize) {
+            Ok(opened) => OpenResult::Opened { url: opened.url },
+            Err(failed) => OpenResult::Refused {
+                refused: Refused::from(&failed),
+            },
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kendex_core::commit_offer::Refusal;
+
+    /// Every way a step can fail travels whole: the program's words in
+    /// order, or the bound it ran past with no words at all. Nothing is
+    /// summarised on the way to the window.
+    #[test]
+    fn a_refusal_travels_as_the_step_and_its_own_words() {
+        let refused = Refused::from(&Failed {
+            step: Step::Commit,
+            refusal: Refusal::Said(vec![
+                "commit-msg: no changelog".to_owned(),
+                "  fix".to_owned(),
+            ]),
+        });
+        assert_eq!(refused.step, "the commit");
+        assert_eq!(refused.said, ["commit-msg: no changelog", "  fix"]);
+        assert!(!refused.timed_out);
+        assert!(!refused.gh);
+        assert_eq!(refused.seconds, 300);
+
+        let timed_out = Refused::from(&Failed {
+            step: Step::PullRequest,
+            refusal: Refusal::TimedOut,
+        });
+        assert!(timed_out.timed_out);
+        assert!(timed_out.said.is_empty(), "a timeout carried words");
+        assert!(timed_out.gh, "gh's step read as git's");
+        assert_eq!(timed_out.seconds, 120);
+    }
+}

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -3,6 +3,7 @@ mod app_settings;
 mod app_update;
 pub mod audit;
 mod commands;
+pub mod commit_offer;
 mod community;
 pub mod deep_link;
 mod editor;
@@ -92,6 +93,10 @@ const TYPED_ERROR_IMPL: &str = r#"async function typedError<T, E>(result: Promis
     }
 }"#;
 
+#[allow(
+    clippy::too_many_lines,
+    reason = "the registration list, one line per command the window can call; a split would hide half the surface from the reader who comes here to see it whole"
+)]
 pub fn specta_builder() -> Builder<tauri::Wry> {
     let builder = constants(Builder::<tauri::Wry>::new()).commands(collect_commands![
         commands::app_version,
@@ -141,6 +146,14 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         marketplaces::install::marketplace_install,
         marketplaces::install::install_targets,
         repo_effects::repo_effects_apply,
+        commit_offer::commit_offer_scan,
+        commit_offer::commit_offer_commit,
+        commit_offer::commit_offer_push,
+        commit_offer::commit_offer_push_head,
+        commit_offer::commit_offer_start_branch,
+        commit_offer::commit_offer_abandon_branch,
+        commit_offer::commit_offer_previous_head,
+        commit_offer::commit_offer_open_pull_request,
         marketplaces::marketplace_subscribe,
         unsubscribe::marketplace_unsubscribe_preview,
         unsubscribe::marketplace_unsubscribe,

--- a/crates/cli/src/commands/apply_cmd.rs
+++ b/crates/cli/src/commands/apply_cmd.rs
@@ -43,6 +43,9 @@ pub struct ApplyArgs {
         conflicts_with_all = ["discard_edits", "replace_unmanaged", "allow_repo_effects"]
     )]
     record_existing: bool,
+    /// The commit offer's answer, without asking
+    #[command(flatten)]
+    _commit: crate::commands::commit_offer::CommitFlags,
 }
 
 pub fn run(env: &Env, args: ApplyArgs) -> CliResult {

--- a/crates/cli/src/commands/commit_offer.rs
+++ b/crates/cli/src/commands/commit_offer.rs
@@ -1,0 +1,361 @@
+//! The terminal's half of the commit, push and pull-request offer.
+//!
+//! Where it runs: [`after_writing`] is called from [`super::engine_common::apply_report`],
+//! the one door every verb executes a plan through, and from `update-pi`,
+//! which writes into a project's `.pi` directory without going through it.
+//! A verb cannot be added without the offer, and no verb can offer twice
+//! for one project: the session below records which roots have been asked.
+//!
+//! What it says: every line the offer prints lives in [`block`], the way
+//! the app keeps its own wording in one copy module. The two are reviewed
+//! beside each other, and they say the same things in the same order.
+
+use std::collections::BTreeMap;
+use std::io::IsTerminal;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+use kendex_core::commit_offer::{self, Branch, Offer};
+use kendex_core::engine::GeneratedPaths;
+use kendex_core::env::Env;
+use kendex_core::model::Scope;
+
+use super::CliResult;
+
+mod block;
+mod routes;
+
+#[cfg(test)]
+mod tests;
+
+/// The answer a flag gives without asking, and the message it carries.
+///
+/// One mutually exclusive group: two of them together is refused by clap
+/// before the verb writes anything, naming both. Flattened into every verb
+/// that offers — and only those, so a verb that never writes into a
+/// project does not carry an answer to a question it never asks. The
+/// values are read back off clap's matches by [`CommitFlags::from_matches`]
+/// rather than off each verb's own struct, so no verb is enumerated; that
+/// is why the field carrying this in a verb is never read by name.
+#[derive(clap::Args, Clone, Default, Debug)]
+pub struct CommitFlags {
+    /// Commit the files kendex wrote, without asking
+    #[arg(long, group = "commit-offer")]
+    pub commit: bool,
+    /// Commit them and push, without asking
+    #[arg(long, group = "commit-offer")]
+    pub push: bool,
+    /// Commit them on a new branch and open a pull request, without asking
+    #[arg(long, group = "commit-offer")]
+    pub pull_request: bool,
+    /// Leave them as diffs, without asking
+    #[arg(long, group = "commit-offer")]
+    pub leave: bool,
+    /// The commit message to use instead of the default
+    #[arg(long)]
+    pub message: Option<String>,
+}
+
+impl CommitFlags {
+    /// The flags on the verb the person ran, read off the innermost
+    /// subcommand's matches. A verb that does not carry them answers
+    /// nothing, which is the same as a person who was not asked.
+    pub fn from_matches(matches: &clap::ArgMatches) -> CommitFlags {
+        let mut at = matches;
+        while let Some((_, inner)) = at.subcommand() {
+            at = inner;
+        }
+        let flag = |id: &str| {
+            at.try_get_one::<bool>(id)
+                .ok()
+                .flatten()
+                .copied()
+                .unwrap_or(false)
+        };
+        CommitFlags {
+            commit: flag("commit"),
+            push: flag("push"),
+            pull_request: flag("pull_request"),
+            leave: flag("leave"),
+            message: at.try_get_one::<String>("message").ok().flatten().cloned(),
+        }
+    }
+}
+
+/// One of the four choices.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Choice {
+    Commit,
+    Push,
+    Pr,
+    Leave,
+}
+
+impl CommitFlags {
+    /// The choice a flag named, or `None` where the person is to be asked.
+    fn answered(&self) -> Option<Choice> {
+        match (self.commit, self.push, self.pull_request, self.leave) {
+            (true, _, _, _) => Some(Choice::Commit),
+            (_, true, _, _) => Some(Choice::Push),
+            (_, _, true, _) => Some(Choice::Pr),
+            (_, _, _, true) => Some(Choice::Leave),
+            _ => None,
+        }
+    }
+}
+
+/// What the offer did in one project, for the closing ledger and the exit
+/// code.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum Outcome {
+    /// Left as diffs, or never offered. The ledger says nothing about it.
+    Nothing,
+    Committed(usize),
+    Pushed(usize),
+    PullRequest(usize),
+    /// The commit was refused, or a flag named a choice that was not on
+    /// offer: either way nothing was committed.
+    CommitRefused,
+    PushRefused,
+    PullRequestRefused,
+}
+
+impl Outcome {
+    /// The ledger part this outcome earns, or `None` where it earns none.
+    ///
+    /// No next step is added under any of them: the block above already
+    /// carries the words and the way on, and the ledger's own rule is that
+    /// a part points back at a block the run printed.
+    pub fn part(&self) -> Option<String> {
+        Some(match self {
+            Outcome::Nothing => return None,
+            Outcome::Committed(files) => format!("committed {files} file{}", plural(*files)),
+            Outcome::Pushed(files) => {
+                format!("committed and pushed {files} file{}", plural(*files))
+            }
+            Outcome::PullRequest(files) => format!(
+                "committed {files} file{}, pull request open",
+                plural(*files)
+            ),
+            Outcome::CommitRefused => "not committed".to_owned(),
+            Outcome::PushRefused => "committed, not pushed".to_owned(),
+            Outcome::PullRequestRefused => "committed and pushed, no pull request".to_owned(),
+        })
+    }
+
+    /// A choice the person took that was refused or timed out. The run
+    /// exits 1 for it, and the refusal is its own failure line rather than
+    /// one more item in a verb's failure count.
+    fn refused(&self) -> bool {
+        matches!(
+            self,
+            Outcome::CommitRefused | Outcome::PushRefused | Outcome::PullRequestRefused
+        )
+    }
+}
+
+fn plural(n: usize) -> &'static str {
+    match n {
+        1 => "",
+        _ => "s",
+    }
+}
+
+/// This run: what the person typed, the flag they passed with it, and the
+/// projects the offer has already been made in.
+///
+/// A run rather than a call, because "kendex asks at most once per run per
+/// project" is a property of the run and several verbs execute more than
+/// one plan into one scope. The command is the run's own identity — the
+/// verb the person typed, which is what the default message names — and no
+/// call site can compose a different one.
+struct Session {
+    flags: CommitFlags,
+    command: String,
+}
+
+static SESSION: OnceLock<Session> = OnceLock::new();
+
+/// What every project the offer reached answered, in the order they were
+/// reached. The closing ledger reads its own scope's answer back.
+static ANSWERED: Mutex<BTreeMap<PathBuf, Outcome>> = Mutex::new(BTreeMap::new());
+
+/// Ctrl-C at the offer. Not the cancel a verb's own confirm handles: that
+/// one comes before the write and drops the scope from the reached list
+/// on the ground that it wrote nothing. This one comes after the write,
+/// so the scope keeps its place — its snapshot is still recorded and its
+/// closing ledger line still printed — and only the offer is skipped, in
+/// this project and in every project after it. The run then exits 130.
+static CANCELLED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Whether the person cancelled at the offer, for the exit code.
+pub fn cancelled() -> bool {
+    CANCELLED.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Record the run before any verb dispatches: the command the person
+/// typed, without its flags and arguments, and the flag that answers the
+/// offer.
+pub fn begin(command: &str, flags: CommitFlags) {
+    let _ = SESSION.set(Session {
+        flags,
+        command: command.to_owned(),
+    });
+}
+
+/// The record, whole even after a panic elsewhere poisoned the lock: an
+/// answer already written is still the answer.
+fn record_of() -> std::sync::MutexGuard<'static, BTreeMap<PathBuf, Outcome>> {
+    ANSWERED
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// What one project answered, for its closing ledger line.
+pub fn answered(scope: &Scope) -> Outcome {
+    let Scope::Project { root } = scope else {
+        return Outcome::Nothing;
+    };
+    record_of().get(root).cloned().unwrap_or(Outcome::Nothing)
+}
+
+fn record(root: &Path, outcome: Outcome) {
+    record_of().insert(root.to_owned(), outcome);
+}
+
+/// Whether this project has already been asked in this run.
+fn asked(root: &Path) -> bool {
+    record_of().contains_key(root)
+}
+
+/// The offer, made once for one project scope after a write into it.
+///
+/// A refusal of the choice the person took is recorded and not returned:
+/// the verb goes on to close its scope with the ledger line that names it,
+/// and the run exits 1 at the end through [`refused`], with nothing further
+/// printed. The block above already carries the words and the way on, and
+/// a refusal is its own failure line, never one more item in a verb's
+/// failure count.
+pub fn after_writing(env: &Env, scope: &Scope, generated: &GeneratedPaths) -> CliResult {
+    let Scope::Project { root } = scope else {
+        return Ok(());
+    };
+    if asked(root) || cancelled() {
+        return Ok(());
+    }
+    let outcome = match make(env, scope, root, generated) {
+        Ok(outcome) => outcome,
+        Err(error) if crate::ui::cancelled(error.as_ref()) => {
+            CANCELLED.store(true, std::sync::atomic::Ordering::Relaxed);
+            Outcome::Nothing
+        }
+        Err(error) => return Err(error),
+    };
+    record(root, outcome);
+    Ok(())
+}
+
+/// Whether a choice the person took was refused or timed out in any
+/// project this run reached, for the exit code.
+pub fn refused() -> bool {
+    record_of().values().any(Outcome::refused)
+}
+
+fn make(
+    env: &Env,
+    scope: &Scope,
+    root: &std::path::Path,
+    generated: &GeneratedPaths,
+) -> Result<Outcome, Box<dyn std::error::Error>> {
+    let default = Session {
+        flags: CommitFlags::default(),
+        command: String::new(),
+    };
+    let session = SESSION.get().unwrap_or(&default);
+    let scan = match commit_offer::scan(scope, generated) {
+        Ok(None) => return Ok(Outcome::Nothing),
+        Ok(Some(scan)) => scan,
+        // A read the offer is built from that would not run leaves the
+        // offer unbuildable. The verb's own writes still stand, so this is
+        // one line rather than a failure of the run.
+        Err(failed) => {
+            block::unreadable(root, &failed);
+            return Ok(Outcome::Nothing);
+        }
+    };
+    let answered = session.flags.answered();
+    // Two states where kendex owns changed files and cannot offer at all:
+    // a commit would land somewhere nobody asked for.
+    match &scan.branch {
+        Branch::Detached => {
+            block::no_branch(root, scan.count());
+            return Ok(Outcome::Nothing);
+        }
+        Branch::InProgress(operation) => {
+            block::in_progress(root, scan.count(), *operation);
+            return Ok(Outcome::Nothing);
+        }
+        Branch::On(_) => {}
+    }
+    if answered == Some(Choice::Leave) {
+        return Ok(Outcome::Nothing);
+    }
+    if answered.is_none() {
+        // The setting turns off the asking, not the choices — which is why
+        // it is read here and not before a flag has had its say.
+        if !commit_offer::asking(env) {
+            return Ok(Outcome::Nothing);
+        }
+        if !std::io::stdin().is_terminal() {
+            block::no_terminal(root, scan.count());
+            return Ok(Outcome::Nothing);
+        }
+    }
+    let offer = match commit_offer::offer(scan, &session.command) {
+        Ok(offer) => offer,
+        Err(failed) => {
+            block::unreadable(root, &failed);
+            return Ok(Outcome::Nothing);
+        }
+    };
+    match answered {
+        Some(choice) => {
+            // A precondition that removed the choice a flag names refuses
+            // with that precondition's reason, and the verb's writes still
+            // stand. Nothing was committed, which is what the ledger says.
+            if let Some(reason) = block::not_on_offer(&offer, choice) {
+                block::flag_refused(&offer, &reason);
+                return Ok(Outcome::CommitRefused);
+            }
+            routes::take(
+                &offer,
+                generated,
+                choice,
+                session.flags.message.clone(),
+                Asking::No,
+            )
+        }
+        None => ask(&offer, generated, session.flags.message.clone()),
+    }
+}
+
+/// Whether the person is at the prompt: a flag's answer takes its route
+/// once and reports, where a person is asked again after a refusal the
+/// design offers a way on from.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Asking {
+    Yes,
+    No,
+}
+
+/// Draw the block, take the answer, take the route.
+fn ask(
+    offer: &Offer,
+    generated: &GeneratedPaths,
+    message: Option<String>,
+) -> Result<Outcome, Box<dyn std::error::Error>> {
+    block::offer(offer);
+    let choices = block::choices(offer);
+    let choice = block::pick(&choices)?;
+    routes::take(offer, generated, choice, message, Asking::Yes)
+}

--- a/crates/cli/src/commands/commit_offer.rs
+++ b/crates/cli/src/commands/commit_offer.rs
@@ -15,7 +15,7 @@ use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
-use kendex_core::commit_offer::{self, Branch, Offer};
+use kendex_core::commit_offer::{self, Branch, Offer, Probe};
 use kendex_core::engine::GeneratedPaths;
 use kendex_core::env::Env;
 use kendex_core::model::Scope;
@@ -244,7 +244,12 @@ pub fn after_writing(env: &Env, scope: &Scope, generated: &GeneratedPaths) -> Cl
         return Ok(());
     }
     let outcome = match make(env, scope, root, generated) {
-        Ok(outcome) => outcome,
+        // Nothing kendex owns had changed by this write: not an answer,
+        // so a later report the same verb applies into this project can
+        // still offer. `drift-hook` writes an empty report before the one
+        // that renders the hook.
+        Ok(None) => return Ok(()),
+        Ok(Some(outcome)) => outcome,
         Err(error) if crate::ui::cancelled(error.as_ref()) => {
             CANCELLED.store(true, std::sync::atomic::Ordering::Relaxed);
             Outcome::Nothing
@@ -261,26 +266,28 @@ pub fn refused() -> bool {
     record_of().values().any(Outcome::refused)
 }
 
+/// `None` where nothing kendex owns had changed, which records nothing;
+/// every other way out is an outcome the run remembers for this project.
 fn make(
     env: &Env,
     scope: &Scope,
     root: &std::path::Path,
     generated: &GeneratedPaths,
-) -> Result<Outcome, Box<dyn std::error::Error>> {
+) -> Result<Option<Outcome>, Box<dyn std::error::Error>> {
     let default = Session {
         flags: CommitFlags::default(),
         command: String::new(),
     };
     let session = SESSION.get().unwrap_or(&default);
     let scan = match commit_offer::scan(scope, generated) {
-        Ok(None) => return Ok(Outcome::Nothing),
+        Ok(None) => return Ok(None),
         Ok(Some(scan)) => scan,
         // A read the offer is built from that would not run leaves the
         // offer unbuildable. The verb's own writes still stand, so this is
         // one line rather than a failure of the run.
         Err(failed) => {
             block::unreadable(root, &failed);
-            return Ok(Outcome::Nothing);
+            return Ok(Some(Outcome::Nothing));
         }
     };
     let answered = session.flags.answered();
@@ -289,33 +296,39 @@ fn make(
     match &scan.branch {
         Branch::Detached => {
             block::no_branch(root, scan.count());
-            return Ok(Outcome::Nothing);
+            return Ok(Some(Outcome::Nothing));
         }
         Branch::InProgress(operation) => {
             block::in_progress(root, scan.count(), *operation);
-            return Ok(Outcome::Nothing);
+            return Ok(Some(Outcome::Nothing));
         }
         Branch::On(_) => {}
     }
     if answered == Some(Choice::Leave) {
-        return Ok(Outcome::Nothing);
+        return Ok(Some(Outcome::Nothing));
     }
     if answered.is_none() {
         // The setting turns off the asking, not the choices — which is why
         // it is read here and not before a flag has had its say.
         if !commit_offer::asking(env) {
-            return Ok(Outcome::Nothing);
+            return Ok(Some(Outcome::Nothing));
         }
         if !std::io::stdin().is_terminal() {
             block::no_terminal(root, scan.count());
-            return Ok(Outcome::Nothing);
+            return Ok(Some(Outcome::Nothing));
         }
     }
-    let offer = match commit_offer::offer(scan, &session.command) {
+    // A flag that already chose `commit` or `push` never takes the
+    // pull-request choice, so `gh` is not asked about it.
+    let probe = match answered {
+        Some(Choice::Commit) | Some(Choice::Push) => Probe::Skip,
+        Some(Choice::Pr) | Some(Choice::Leave) | None => Probe::Gh,
+    };
+    let offer = match commit_offer::offer(scan, &session.command, probe) {
         Ok(offer) => offer,
         Err(failed) => {
             block::unreadable(root, &failed);
-            return Ok(Outcome::Nothing);
+            return Ok(Some(Outcome::Nothing));
         }
     };
     match answered {
@@ -325,7 +338,7 @@ fn make(
             // stand. Nothing was committed, which is what the ledger says.
             if let Some(reason) = block::not_on_offer(&offer, choice) {
                 block::flag_refused(&offer, &reason);
-                return Ok(Outcome::CommitRefused);
+                return Ok(Some(Outcome::CommitRefused));
             }
             routes::take(
                 &offer,
@@ -334,8 +347,9 @@ fn make(
                 session.flags.message.clone(),
                 Asking::No,
             )
+            .map(Some)
         }
-        None => ask(&offer, generated, session.flags.message.clone()),
+        None => ask(&offer, generated, session.flags.message.clone()).map(Some),
     }
 }
 

--- a/crates/cli/src/commands/commit_offer/block.rs
+++ b/crates/cli/src/commands/commit_offer/block.rs
@@ -1,0 +1,463 @@
+//! Every line the terminal's offer prints, and the two questions it asks.
+//!
+//! One file, so the wording is reviewed in one place beside the app's
+//! `copy-commit-offer.ts`, which says the same things in the same order.
+//!
+//! The grammar is the one every verb already writes in: a line at column 0
+//! opens a block, two spaces make a line detail of it, and four spaces
+//! quote another program's words inside that detail. Every line goes
+//! through `say`, which escapes it: a control character in a hook's output
+//! must not move a cursor or colour a line.
+
+use std::path::Path;
+
+use kendex_core::commit_offer::{Failed, Offer, Operation, Step, Unavailable};
+
+use super::super::say;
+use super::Choice;
+use crate::ui;
+
+/// Enough paths to recognise what is there without burying the choices
+/// under them. The same ten the CLI already shows of a list it cut.
+pub const PATHS_SHOWN: usize = 10;
+
+/// The head line of the block, carrying the scope label the way
+/// `print_set_changes` and the ledger do.
+pub fn head(root: &Path, count: usize) -> String {
+    format!(
+        "{}: {count} file{} kendex wrote {} not committed",
+        kendex_core::paths::slashed(root),
+        plural(count),
+        match count {
+            1 => "is",
+            _ => "are",
+        }
+    )
+}
+
+fn plural(n: usize) -> &'static str {
+    match n {
+        1 => "",
+        _ => "s",
+    }
+}
+
+fn detail(line: &str) {
+    say(&format!("  {line}"));
+}
+
+/// Another program's words, quoted inside the detail they belong to.
+fn quoted(line: &str) {
+    say(&format!("    {line}"));
+}
+
+/// A line and nothing more: kendex owns changed files here and the offer
+/// cannot be made.
+pub fn no_branch(root: &Path, count: usize) {
+    say(&format!(
+        "{}; this checkout is on no branch",
+        head(root, count)
+    ));
+}
+
+pub fn in_progress(root: &Path, count: usize, operation: Operation) {
+    say(&format!(
+        "{}; {} is in progress",
+        head(root, count),
+        operation.article()
+    ));
+}
+
+/// Nobody is at the terminal to answer, so the flags that would have are
+/// named instead.
+pub fn no_terminal(root: &Path, count: usize) {
+    say(&format!(
+        "{}; run again with --commit, --push, --pull-request or --leave",
+        head(root, count)
+    ));
+}
+
+/// A read the offer is built from would not run, so there is no offer to
+/// make. The verb's own writes still stand.
+pub fn unreadable(root: &Path, failed: &Failed) {
+    say(&format!(
+        "{}: the files kendex wrote could not be checked",
+        kendex_core::paths::slashed(root)
+    ));
+    refusal(failed);
+}
+
+/// The offer itself: what changed, what kendex leaves alone, and the
+/// choices.
+pub fn offer(offer: &Offer) {
+    say(&head(&offer.scan.root, offer.scan.count()));
+    for path in offer.scan.owned.iter().take(PATHS_SHOWN) {
+        detail(&path.path);
+    }
+    if offer.scan.owned.len() > PATHS_SHOWN {
+        detail(&format!(
+            "… and {} more",
+            offer.scan.owned.len() - PATHS_SHOWN
+        ));
+    }
+    if !offer.scan.shared.is_empty() {
+        detail(&format!(
+            "kendex also changed {} shared file{}; it writes one key in each, so",
+            offer.scan.shared.len(),
+            plural(offer.scan.shared.len())
+        ));
+        detail("committing them would commit your own changes to them too");
+        for path in &offer.scan.shared {
+            quoted(path);
+        }
+    }
+    if offer.scan.others > 0 {
+        detail(&format!(
+            "{} other file{} in this repository changed; kendex leaves those alone",
+            offer.scan.others,
+            plural(offer.scan.others)
+        ));
+    }
+    for line in reasons(offer) {
+        detail(&line);
+    }
+}
+
+/// A precondition that removed a choice prints its reason as a detail line
+/// under the paths, before the numbered list.
+pub fn reasons(offer: &Offer) -> Vec<String> {
+    let mut lines = Vec::new();
+    if let Err(why) = &offer.push {
+        lines.push(format!("no push: {}", said(why)));
+    }
+    if let Err(why) = &offer.pull_request {
+        lines.push(format!("no pull request: {}", said(why)));
+    }
+    lines
+}
+
+/// Why the choice a flag named is not on offer, as the reason line the
+/// offer would have printed for it, or `None` where the choice stands.
+///
+/// A pull request already open for this branch removes `pr` the way a
+/// precondition does, and a flag naming it gets the same kind of answer.
+pub fn not_on_offer(offer: &Offer, choice: Choice) -> Option<String> {
+    match choice {
+        Choice::Commit | Choice::Leave => None,
+        Choice::Push => offer
+            .push
+            .as_ref()
+            .err()
+            .map(|why| format!("no push: {}", said(why))),
+        Choice::Pr => match (&offer.pull_request, &offer.open) {
+            (Err(why), _) => Some(format!("no pull request: {}", said(why))),
+            (Ok(()), Some(open)) => Some(format!(
+                "no pull request: pull request #{} is already open for this branch",
+                open.number
+            )),
+            (Ok(()), None) => None,
+        },
+    }
+}
+
+/// A flag named a choice that is not on offer: the head line, then the
+/// reason, and nothing is asked.
+pub fn flag_refused(offer: &Offer, reason: &str) {
+    say(&head(&offer.scan.root, offer.scan.count()));
+    detail(reason);
+}
+
+fn said(why: &Unavailable) -> String {
+    match why {
+        Unavailable::NoRemote => "this repository has no remote".to_owned(),
+        Unavailable::RemoteNotDecidable => {
+            "this branch tracks no remote and the repository has more than one".to_owned()
+        }
+        Unavailable::GhMissing => "gh is not installed".to_owned(),
+        Unavailable::GhSaid(line) => format!("gh said: {line}"),
+    }
+}
+
+/// The choices this offer carries, in the order the design fixes, skipping
+/// the ones the preconditions removed. `leave` is always last and is
+/// always the default.
+pub fn choices(offer: &Offer) -> Vec<(Choice, String)> {
+    let mut choices = vec![(Choice::Commit, "commit them".to_owned())];
+    // A push stands only with a remote to push to; the pair is how the
+    // offer was built, and reading both keeps that true here.
+    if let (Ok(()), Some(remote)) = (&offer.push, &offer.remote) {
+        choices.push((
+            Choice::Push,
+            match &offer.open {
+                Some(open) => format!(
+                    "commit them and add a commit to pull request #{}",
+                    open.number
+                ),
+                None => format!("commit them and push to {}/{}", remote.name, offer.branch),
+            },
+        ));
+    }
+    // Where a pull request is already open for this branch, `pr` is not
+    // offered: the branch already has one.
+    if offer.pull_request.is_ok() && offer.open.is_none() {
+        choices.push((
+            Choice::Pr,
+            "commit them on a new branch and open a pull request".to_owned(),
+        ));
+    }
+    choices.push((Choice::Leave, "leave them as diffs".to_owned()));
+    choices
+}
+
+/// Print the numbered list and read the answer.
+///
+/// An answer that is not one of the printed numbers is `leave` — a typo, a
+/// `9`, an `x`, a bare Enter and an end of input alike. That is how the
+/// CLI's confirm already reads its answer, and it puts the safe outcome
+/// behind every wrong key rather than behind a retry loop nobody asked for.
+pub fn pick(choices: &[(Choice, String)]) -> std::io::Result<Choice> {
+    for (nth, (_, label)) in choices.iter().enumerate() {
+        detail(&format!("{}  {label}", nth + 1));
+    }
+    let typed = ui::ask(&format!(
+        "1-{}, or Enter to {}: ",
+        choices.len(),
+        choices
+            .last()
+            .map(|(_, label)| label.as_str())
+            .unwrap_or("leave them as diffs")
+    ))?;
+    Ok(picked(choices, &typed))
+}
+
+pub fn picked(choices: &[(Choice, String)], typed: &str) -> Choice {
+    typed
+        .trim()
+        .parse::<usize>()
+        .ok()
+        .filter(|nth| *nth >= 1 && *nth <= choices.len())
+        .map(|nth| choices[nth - 1].0)
+        .unwrap_or(Choice::Leave)
+}
+
+/// The line the `pr` choice states before it runs: it moves the checkout,
+/// and the person is told so before the message question rather than after
+/// the branch exists.
+pub fn will_move(new_branch: &str, from: &str) {
+    detail(&format!(
+        "this checkout will move to {new_branch}; {from} stays where it is"
+    ));
+}
+
+/// The message question. An empty answer accepts what is offered.
+pub fn message(offered: &str) -> std::io::Result<String> {
+    detail(&format!("message: {offered}"));
+    let typed = ui::ask("press Enter to use this message, or type a different one: ")?;
+    Ok(match typed.trim() {
+        "" => offered.to_owned(),
+        given => given.to_owned(),
+    })
+}
+
+pub fn committed(sha: &str, files: usize, branch: Option<&str>) {
+    detail(&format!(
+        "committed {files} file{} as {sha}{}",
+        plural(files),
+        match branch {
+            Some(branch) => format!(" on {branch}"),
+            None => String::new(),
+        }
+    ));
+}
+
+pub fn pushed(remote: &str, branch: &str) {
+    detail(&format!("pushed to {remote}/{branch}"));
+}
+
+pub fn opened(url: &str) {
+    detail(&format!("opened {url}"));
+}
+
+pub fn now_on(branch: &str) {
+    detail(&format!("this checkout is now on {branch}"));
+}
+
+/// Nothing was left to commit by the time the commit ran.
+pub fn nothing_to_commit() {
+    detail("nothing to commit; the files changed since the offer");
+}
+
+/// What a step said when it refused, or the bound it ran past.
+///
+/// The words are shown whole, one line at a time, in order. Nothing is
+/// summarised, reworded, truncated to a first line, or matched against a
+/// pattern to decide what it means.
+pub fn refusal(failed: &Failed) {
+    if failed.timed_out() {
+        detail(&timed_out(failed.step));
+        return;
+    }
+    detail(program_said(failed.step));
+    for line in failed.said() {
+        quoted(line);
+    }
+}
+
+/// The line a step that ran out of time prints in place of the program's
+/// words: the step's name and its bound.
+pub fn timed_out(step: Step) -> String {
+    format!(
+        "{} did not finish within {} seconds",
+        step.name(),
+        step.seconds()
+    )
+}
+
+/// Whose words follow: gh's for the two steps that run it, git's for the
+/// rest.
+pub fn program_said(step: Step) -> &'static str {
+    match step {
+        Step::Probe | Step::PullRequest => "gh said:",
+        Step::Read
+        | Step::Stage
+        | Step::Commit
+        | Step::Unstage
+        | Step::Branch
+        | Step::SwitchBack
+        | Step::RemoveBranch
+        | Step::Push => "git said:",
+    }
+}
+
+/// The head line of a refusal, before its words.
+pub fn refused(what: &str, failed: &Failed) {
+    // A step that ran out of time reads as that step's refusal with the
+    // bound in place of the program's words, so the head line the refusal
+    // would have carried is the bound line itself.
+    if !failed.timed_out() {
+        detail(what);
+    }
+    refusal(failed);
+}
+
+/// kendex staged paths it could not then unstage, against the rule that
+/// the index ends as it began.
+pub fn still_staged(count: usize) {
+    detail(&format!(
+        "kendex staged {count} file{} it could not unstage; they are still staged",
+        plural(count)
+    ));
+}
+
+pub fn commit_is_on(branch: &str) {
+    detail(&format!(
+        "the commit is on {branch} in this checkout; kendex did not undo it"
+    ));
+}
+
+pub fn branch_is_on(remote: &str, branch: &str) {
+    detail(&format!(
+        "the branch {branch} is on {remote}; open the pull request yourself"
+    ));
+}
+
+/// The head line of a commit that did not happen: the staging is its own
+/// step and its own line, because it runs before any commit and the
+/// commit's line would name something that never ran.
+pub fn commit_refused_head(failed: &Failed) -> &'static str {
+    match failed.step {
+        // The set is re-derived before the commit, and that read can fail
+        // like the one the offer was built from.
+        Step::Read => "the files could not be checked",
+        Step::Stage => "the files could not be staged",
+        _ => "the commit was refused",
+    }
+}
+
+/// The head line of a `git switch -` or `git branch -d` that refused after
+/// a commit on the branch kendex made did not happen. The run stops there.
+pub const NOT_PUT_BACK: &str = "the checkout could not be put back";
+
+pub fn back_on(from: &str, branch: &str) {
+    detail(&format!(
+        "this checkout is back on {from} and {branch} is gone"
+    ));
+}
+
+/// After the recovery push: the local branch still carries the commit, and
+/// the way to put it back is printed rather than run.
+///
+/// `--mixed` and not `--keep`: `--keep` restores the working tree to the
+/// commit it resets to, which would take kendex's files off disk with no
+/// warning, and `--mixed` moves the branch and leaves them where they are,
+/// as the diffs the person started with.
+pub fn how_to_put_back(from: &str, before: &str) {
+    detail(&format!("{from} in this checkout still carries the commit"));
+    detail(&format!(
+        "to put {from} back where it was, leaving the files as diffs again:"
+    ));
+    quoted(&format!("git reset --mixed {before}"));
+}
+
+/// The recovery pushed a first commit, so there is no commit to put the
+/// branch back to and no reset line to print.
+pub fn first_commit_stays(from: &str) {
+    detail(&format!("{from} in this checkout still carries the commit"));
+}
+
+/// The three ways on from a refused commit.
+pub fn after_refusal() -> std::io::Result<Retry> {
+    let labels = [
+        (Retry::Same, "commit again with the same message"),
+        (Retry::Different, "commit again with a different message"),
+        (Retry::Leave, "leave them as diffs"),
+    ];
+    for (nth, (_, label)) in labels.iter().enumerate() {
+        detail(&format!("{}  {label}", nth + 1));
+    }
+    let typed = ui::ask(&format!(
+        "1-{}, or Enter to leave them as diffs: ",
+        labels.len()
+    ))?;
+    Ok(typed
+        .trim()
+        .parse::<usize>()
+        .ok()
+        .filter(|nth| *nth >= 1 && *nth <= labels.len())
+        .map(|nth| labels[nth - 1].0)
+        .unwrap_or(Retry::Leave))
+}
+
+/// What a person picks after a refused commit.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Retry {
+    Same,
+    Different,
+    Leave,
+}
+
+/// The two ways on from a refused push, where a pull request is available.
+pub fn after_push_refusal() -> std::io::Result<Recover> {
+    detail("1  push the commit to a new branch and open a pull request");
+    detail("2  leave it here");
+    let typed = ui::ask("1-2, or Enter to leave it here: ")?;
+    Ok(match typed.trim() {
+        "1" => Recover::PullRequest,
+        _ => Recover::Leave,
+    })
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Recover {
+    PullRequest,
+    Leave,
+}
+
+/// The choices offered again after the `pr` route could not make its
+/// branch: the same list without `pr`.
+pub fn without_pull_request(offer: &Offer) -> Vec<(Choice, String)> {
+    choices(offer)
+        .into_iter()
+        .filter(|(choice, _)| *choice != Choice::Pr)
+        .collect()
+}

--- a/crates/cli/src/commands/commit_offer/routes.rs
+++ b/crates/cli/src/commands/commit_offer/routes.rs
@@ -1,0 +1,312 @@
+//! What each choice runs in the terminal, and what it says when a step of
+//! it refuses.
+//!
+//! Every route ends in an [`Outcome`], which is what the closing ledger
+//! reads back and what decides the exit code. A refusal is never silent
+//! and never summarised: the step's own words are printed, then the way on
+//! that step's state allows.
+
+use kendex_core::commit_offer::{self, Committed, Offer};
+use kendex_core::engine::GeneratedPaths;
+
+use super::block::{self, Recover, Retry};
+use super::{Asking, Choice, Outcome};
+
+type Taken = Result<Outcome, Box<dyn std::error::Error>>;
+
+/// Take one choice. `asking` is whether a person is at the prompt: a flag
+/// answers once and reports, where a person is offered the way on that the
+/// state allows.
+pub fn take(
+    offer: &Offer,
+    generated: &GeneratedPaths,
+    choice: Choice,
+    given: Option<String>,
+    asking: Asking,
+) -> Taken {
+    match choice {
+        Choice::Leave => Ok(Outcome::Nothing),
+        Choice::Commit => straight(offer, generated, given, asking, Push::No),
+        Choice::Push => straight(offer, generated, given, asking, Push::Yes),
+        Choice::Pr => pull_request(offer, generated, given, asking),
+    }
+}
+
+/// Whether the route pushes the commit it makes.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Push {
+    Yes,
+    No,
+}
+
+/// The message this route commits with: the one a flag gave, or the
+/// default with the person's chance to change it.
+fn message(offer: &Offer, given: Option<String>, asking: Asking) -> std::io::Result<String> {
+    match given {
+        Some(message) => Ok(message),
+        None => match asking {
+            Asking::No => Ok(offer.message.clone()),
+            Asking::Yes => block::message(&offer.message),
+        },
+    }
+}
+
+/// `commit`, and `push` — the two routes that commit on the branch the
+/// checkout is already on.
+fn straight(
+    offer: &Offer,
+    generated: &GeneratedPaths,
+    given: Option<String>,
+    asking: Asking,
+    then: Push,
+) -> Taken {
+    let root = &offer.scan.root;
+    // Read before the commit: it is the commit a recovery would put the
+    // branch back to, and after the commit it is no longer what `HEAD`
+    // names.
+    let before = commit_offer::previous_head(root).unwrap_or(None);
+    let mut message = message(offer, given, asking)?;
+    loop {
+        match commit_offer::commit(root, generated, &message) {
+            Ok(Committed::Nothing) => {
+                block::nothing_to_commit();
+                return Ok(Outcome::Nothing);
+            }
+            Ok(Committed::Made { sha, files }) => {
+                block::committed(&sha, files, None);
+                return match then {
+                    Push::No => Ok(Outcome::Committed(files)),
+                    Push::Yes => pushed(offer, files, &message, before.as_deref(), asking),
+                };
+            }
+            Err(refused) => {
+                block::refused(block::commit_refused_head(&refused.failed), &refused.failed);
+                if let Some(count) = refused.still_staged {
+                    block::still_staged(count);
+                }
+                match again(asking)? {
+                    Retry::Leave => return Ok(Outcome::CommitRefused),
+                    Retry::Same => {}
+                    Retry::Different => message = block::message(&message)?,
+                }
+            }
+        }
+    }
+}
+
+/// The ways on from a refused commit, where there is a person to offer
+/// them to.
+fn again(asking: Asking) -> std::io::Result<Retry> {
+    match asking {
+        Asking::No => Ok(Retry::Leave),
+        Asking::Yes => block::after_refusal(),
+    }
+}
+
+/// Push the commit the `push` route just made, on the branch it is on.
+fn pushed(
+    offer: &Offer,
+    files: usize,
+    message: &str,
+    before: Option<&str>,
+    asking: Asking,
+) -> Taken {
+    let Some(remote) = offer.remote.as_ref() else {
+        return Err("the push route ran with no remote".into());
+    };
+    match commit_offer::push(
+        &offer.scan.root,
+        &remote.name,
+        &offer.branch,
+        remote.tracked,
+    ) {
+        Ok(_) => {
+            block::pushed(&remote.name, &offer.branch);
+            Ok(Outcome::Pushed(files))
+        }
+        Err(failed) => {
+            block::refused("the push was refused", &failed);
+            block::commit_is_on(&offer.branch);
+            // The recovery for a refused push is to put the commit on a
+            // branch of its own, so it is offered only where a pull
+            // request can be opened from that branch — and only to a
+            // person, since a flag answered one question and not this one.
+            if offer.pull_request.is_err() || asking == Asking::No {
+                return Ok(Outcome::PushRefused);
+            }
+            match block::after_push_refusal()? {
+                Recover::Leave => Ok(Outcome::PushRefused),
+                Recover::PullRequest => recover(offer, files, message, before),
+            }
+        }
+    }
+}
+
+/// Push the commit that already exists to a branch of its own and open the
+/// pull request, without moving the branch the person is on. The title is
+/// the message the commit was made with, which is the one the person
+/// settled on.
+fn recover(offer: &Offer, files: usize, message: &str, before: Option<&str>) -> Taken {
+    let Some(remote) = offer.remote.as_ref() else {
+        return Err("the recovery ran with no remote".into());
+    };
+    if let Err(failed) = commit_offer::push_head(&offer.scan.root, &remote.name, &offer.new_branch)
+    {
+        block::refused("the push was refused", &failed);
+        return Ok(Outcome::PushRefused);
+    }
+    block::pushed(&remote.name, &offer.new_branch);
+    match commit_offer::open_pull_request(
+        &remote.url,
+        &offer.new_branch,
+        &offer.branch,
+        message,
+        files,
+    ) {
+        Err(failed) => {
+            block::refused("the pull request was refused", &failed);
+            block::branch_is_on(&remote.name, &offer.new_branch);
+            Ok(Outcome::PullRequestRefused)
+        }
+        Ok(opened) => {
+            block::opened(&opened.url);
+            // The local branch is left carrying the commit, and the run
+            // says how to put it back without doing it: kendex never
+            // moves a branch ref backwards.
+            match before {
+                Some(before) => block::how_to_put_back(&offer.branch, before),
+                None => block::first_commit_stays(&offer.branch),
+            }
+            Ok(Outcome::PullRequest(files))
+        }
+    }
+}
+
+/// The `pr` route: switch to a branch of its own, commit there, push it,
+/// and open the pull request.
+///
+/// The switch comes before the commit, so the branch the person was on
+/// gains no commit and needs nothing undone.
+fn pull_request(
+    offer: &Offer,
+    generated: &GeneratedPaths,
+    given: Option<String>,
+    asking: Asking,
+) -> Taken {
+    let root = &offer.scan.root;
+    block::will_move(&offer.new_branch, &offer.branch);
+    let message = message(offer, given, asking)?;
+    if let Err(failed) = commit_offer::start_branch(root, &offer.new_branch) {
+        block::refused("the branch could not be made", &failed);
+        // The checkout has not moved and nothing is staged, so the other
+        // choices still stand — carrying the message already settled on,
+        // so it is not asked for twice.
+        return without_pull_request(offer, generated, Some(message), asking);
+    }
+    let (sha, files) = match commit_offer::commit(root, generated, &message) {
+        Ok(Committed::Nothing) => {
+            // The checkout already moved to a branch that will now carry
+            // no commit, so kendex clears that leftover the way it does
+            // after a refused commit.
+            block::nothing_to_commit();
+            return match commit_offer::abandon_branch(root, &offer.new_branch) {
+                Ok(()) => {
+                    block::back_on(&offer.branch, &offer.new_branch);
+                    Ok(Outcome::Nothing)
+                }
+                Err(failed) => {
+                    block::refused(block::NOT_PUT_BACK, &failed);
+                    Ok(Outcome::CommitRefused)
+                }
+            };
+        }
+        Ok(Committed::Made { sha, files }) => (sha, files),
+        Err(refused) => return abandoned(offer, generated, refused, message, asking),
+    };
+    block::committed(&sha, files, Some(&offer.new_branch));
+    let Some(remote) = offer.remote.as_ref() else {
+        return Err("the pull-request route ran with no remote".into());
+    };
+    if let Err(failed) = commit_offer::push(root, &remote.name, &offer.new_branch, false) {
+        block::refused("the push was refused", &failed);
+        // The commit is already on a branch of its own, which is what the
+        // refused-push recovery would have made, so there is no further
+        // way on to offer.
+        block::commit_is_on(&offer.new_branch);
+        return Ok(Outcome::PushRefused);
+    }
+    block::pushed(&remote.name, &offer.new_branch);
+    match commit_offer::open_pull_request(
+        &remote.url,
+        &offer.new_branch,
+        &offer.branch,
+        &message,
+        files,
+    ) {
+        Err(failed) => {
+            block::refused("the pull request was refused", &failed);
+            block::branch_is_on(&remote.name, &offer.new_branch);
+            Ok(Outcome::PullRequestRefused)
+        }
+        Ok(opened) => {
+            block::opened(&opened.url);
+            block::now_on(&offer.new_branch);
+            Ok(Outcome::PullRequest(files))
+        }
+    }
+}
+
+/// The commit on the new branch refused. The branch carries no commit of
+/// its own, so kendex clears its own leftover — back to where the person
+/// was, and the empty branch removed — and asks again.
+fn abandoned(
+    offer: &Offer,
+    generated: &GeneratedPaths,
+    refused: commit_offer::CommitFailure,
+    message: String,
+    asking: Asking,
+) -> Taken {
+    block::refused(block::commit_refused_head(&refused.failed), &refused.failed);
+    if let Some(count) = refused.still_staged {
+        block::still_staged(count);
+    }
+    if let Err(failed) = commit_offer::abandon_branch(&offer.scan.root, &offer.new_branch) {
+        // Reported, and the run stops here rather than trying anything
+        // else: the checkout is on the branch kendex made.
+        block::refused(block::NOT_PUT_BACK, &failed);
+        return Ok(Outcome::CommitRefused);
+    }
+    block::back_on(&offer.branch, &offer.new_branch);
+    // Committing again is the route the person chose, run again from its
+    // start: the branch is made once more and the commit lands on it. The
+    // message is the one they settled on, not the default.
+    match again(asking)? {
+        Retry::Leave => Ok(Outcome::CommitRefused),
+        Retry::Same => pull_request(offer, generated, Some(message), asking),
+        Retry::Different => {
+            let message = block::message(&message)?;
+            pull_request(offer, generated, Some(message), asking)
+        }
+    }
+}
+
+/// After the branch could not be made: the same choices without `pr`. The
+/// checkout has not moved and nothing is staged.
+fn without_pull_request(
+    offer: &Offer,
+    generated: &GeneratedPaths,
+    given: Option<String>,
+    asking: Asking,
+) -> Taken {
+    if asking == Asking::No {
+        return Ok(Outcome::CommitRefused);
+    }
+    let choices = block::without_pull_request(offer);
+    match block::pick(&choices)? {
+        Choice::Leave => Ok(Outcome::CommitRefused),
+        Choice::Commit => straight(offer, generated, given, asking, Push::No),
+        Choice::Push => straight(offer, generated, given, asking, Push::Yes),
+        // Filtered out of the list this answer came from.
+        Choice::Pr => unreachable!("the pull-request choice was picked from a list without it"),
+    }
+}

--- a/crates/cli/src/commands/commit_offer/tests.rs
+++ b/crates/cli/src/commands/commit_offer/tests.rs
@@ -1,0 +1,339 @@
+//! The terminal's rows, pinned to the design's words. The states are
+//! driven end to end through the binary in `tests/commit_offer_cli.rs`;
+//! what that child cannot reach — the interactive block's lines, its
+//! numbered choices and how an answer is read — is composed here.
+
+use std::path::{Path, PathBuf};
+
+use kendex_core::commit_offer::{
+    Branch, Failed, Offer, OpenPullRequest, Operation, Owned, Refusal, Remote, Scan, Step,
+    Unavailable,
+};
+
+use super::block;
+use super::{Choice, Outcome};
+
+fn scan() -> Scan {
+    Scan {
+        root: PathBuf::from("/home/method/dev/site"),
+        owned: (1..=12)
+            .map(|n| Owned {
+                path: format!(".claude/skills/{n}/SKILL.md"),
+                untracked: false,
+            })
+            .collect(),
+        shared: vec![".claude/settings.json".to_owned()],
+        others: 4,
+        branch: Branch::On("main".to_owned()),
+    }
+}
+
+fn origin() -> Remote {
+    Remote {
+        name: "origin".to_owned(),
+        url: "https://github.com/acme/site.git".to_owned(),
+        tracked: true,
+    }
+}
+
+fn offer() -> Offer {
+    Offer {
+        scan: scan(),
+        branch: "main".to_owned(),
+        remote: Some(origin()),
+        push: Ok(()),
+        pull_request: Ok(()),
+        open: None,
+        message: "chore: kendex refresh".to_owned(),
+        new_branch: "kendex/renders".to_owned(),
+    }
+}
+
+fn labels(choices: &[(Choice, String)]) -> Vec<&str> {
+    choices.iter().map(|(_, label)| label.as_str()).collect()
+}
+
+/// The head line, and the three single lines the preconditions print
+/// with it.
+#[test]
+fn the_head_line_carries_the_scope_and_the_count() {
+    let root = Path::new("/home/method/dev/site");
+    assert_eq!(
+        block::head(root, 12),
+        "/home/method/dev/site: 12 files kendex wrote are not committed"
+    );
+    assert_eq!(
+        block::head(root, 1),
+        "/home/method/dev/site: 1 file kendex wrote is not committed"
+    );
+    assert_eq!(Operation::Rebase.article(), "a rebase");
+}
+
+/// The four choices in the design's order, renumbered as the preconditions
+/// remove them, `leave` always last; an open pull request rewords `push`
+/// and takes `pr` away.
+#[test]
+fn the_choices_are_numbered_in_order_skipping_the_removed_ones() {
+    assert_eq!(
+        labels(&block::choices(&offer())),
+        [
+            "commit them",
+            "commit them and push to origin/main",
+            "commit them on a new branch and open a pull request",
+            "leave them as diffs",
+        ]
+    );
+    let mut no_remote = offer();
+    no_remote.remote = None;
+    no_remote.push = Err(Unavailable::NoRemote);
+    no_remote.pull_request = Err(Unavailable::NoRemote);
+    assert_eq!(
+        labels(&block::choices(&no_remote)),
+        ["commit them", "leave them as diffs"]
+    );
+    let mut no_gh = offer();
+    no_gh.pull_request = Err(Unavailable::GhMissing);
+    assert_eq!(
+        labels(&block::choices(&no_gh)),
+        [
+            "commit them",
+            "commit them and push to origin/main",
+            "leave them as diffs",
+        ]
+    );
+    let mut open = offer();
+    open.open = Some(OpenPullRequest {
+        number: 41,
+        url: "https://github.com/acme/site/pull/41".to_owned(),
+    });
+    assert_eq!(
+        labels(&block::choices(&open)),
+        [
+            "commit them",
+            "commit them and add a commit to pull request #41",
+            "leave them as diffs",
+        ]
+    );
+    assert_eq!(
+        labels(&block::without_pull_request(&offer())),
+        [
+            "commit them",
+            "commit them and push to origin/main",
+            "leave them as diffs",
+        ]
+    );
+}
+
+/// The reason a removed choice prints, one row per precondition, and the
+/// same row a flag naming that choice is refused with.
+#[test]
+fn a_removed_choice_prints_its_reason() {
+    let mut no_remote = offer();
+    no_remote.push = Err(Unavailable::NoRemote);
+    no_remote.pull_request = Err(Unavailable::NoRemote);
+    assert_eq!(
+        block::reasons(&no_remote),
+        [
+            "no push: this repository has no remote",
+            "no pull request: this repository has no remote",
+        ]
+    );
+    let mut several = offer();
+    several.push = Err(Unavailable::RemoteNotDecidable);
+    several.pull_request = Err(Unavailable::RemoteNotDecidable);
+    assert_eq!(
+        block::reasons(&several),
+        [
+            "no push: this branch tracks no remote and the repository has more than one",
+            "no pull request: this branch tracks no remote and the repository has more than one",
+        ]
+    );
+    let mut missing = offer();
+    missing.pull_request = Err(Unavailable::GhMissing);
+    assert_eq!(
+        block::reasons(&missing),
+        ["no pull request: gh is not installed"]
+    );
+    let mut said = offer();
+    said.pull_request = Err(Unavailable::GhSaid(
+        "To get started with GitHub CLI, please run:  gh auth login".to_owned(),
+    ));
+    assert_eq!(
+        block::reasons(&said),
+        ["no pull request: gh said: To get started with GitHub CLI, please run:  gh auth login"]
+    );
+    assert_eq!(block::reasons(&offer()), [] as [&str; 0]);
+
+    assert_eq!(block::not_on_offer(&offer(), Choice::Push), None);
+    assert_eq!(block::not_on_offer(&offer(), Choice::Pr), None);
+    assert_eq!(
+        block::not_on_offer(&missing, Choice::Pr).as_deref(),
+        Some("no pull request: gh is not installed")
+    );
+    assert_eq!(
+        block::not_on_offer(&several, Choice::Push).as_deref(),
+        Some("no push: this branch tracks no remote and the repository has more than one")
+    );
+    let mut open = offer();
+    open.open = Some(OpenPullRequest {
+        number: 41,
+        url: String::new(),
+    });
+    assert_eq!(
+        block::not_on_offer(&open, Choice::Pr).as_deref(),
+        Some("no pull request: pull request #41 is already open for this branch")
+    );
+    assert_eq!(block::not_on_offer(&open, Choice::Push), None);
+}
+
+/// An answer that is not one of the printed numbers is `leave`: a typo, a
+/// `9`, an `x`, a bare Enter and an end of input alike.
+#[test]
+fn an_answer_off_the_list_leaves_the_files_as_diffs() {
+    let choices = block::choices(&offer());
+    assert_eq!(block::picked(&choices, "1"), Choice::Commit);
+    assert_eq!(block::picked(&choices, " 2\n"), Choice::Push);
+    assert_eq!(block::picked(&choices, "3"), Choice::Pr);
+    assert_eq!(block::picked(&choices, "4"), Choice::Leave);
+    for off in ["", "0", "5", "9", "x", "yes"] {
+        assert_eq!(block::picked(&choices, off), Choice::Leave, "{off:?}");
+    }
+    // Renumbered: with `pr` gone, `3` is `leave`.
+    let without = block::without_pull_request(&offer());
+    assert_eq!(block::picked(&without, "3"), Choice::Leave);
+}
+
+/// A timed-out step reads as that step's refusal with the bound in place
+/// of the program's words; the words otherwise follow `git said:` or
+/// `gh said:`.
+#[test]
+fn a_timeout_names_the_step_and_its_bound() {
+    assert_eq!(
+        block::timed_out(Step::Commit),
+        "the commit did not finish within 300 seconds"
+    );
+    assert_eq!(
+        block::timed_out(Step::Push),
+        "the push did not finish within 120 seconds"
+    );
+    assert_eq!(
+        block::timed_out(Step::PullRequest),
+        "the pull request did not finish within 120 seconds"
+    );
+    assert_eq!(
+        block::timed_out(Step::Branch),
+        "the branch did not finish within 30 seconds"
+    );
+    assert_eq!(block::program_said(Step::Commit), "git said:");
+    assert_eq!(block::program_said(Step::Push), "git said:");
+    assert_eq!(block::program_said(Step::Probe), "gh said:");
+    assert_eq!(block::program_said(Step::PullRequest), "gh said:");
+    let staging = Failed {
+        step: Step::Stage,
+        refusal: Refusal::Said(vec!["fatal: index.lock".to_owned()]),
+    };
+    assert_eq!(
+        block::commit_refused_head(&staging),
+        "the files could not be staged"
+    );
+    let unread = Failed {
+        step: Step::Read,
+        refusal: Refusal::Said(vec!["fatal: not a git repository".to_owned()]),
+    };
+    assert_eq!(
+        block::commit_refused_head(&unread),
+        "the files could not be checked"
+    );
+    assert_eq!(
+        block::commit_refused_head(&Failed {
+            step: Step::Commit,
+            refusal: Refusal::TimedOut
+        }),
+        "the commit was refused"
+    );
+    let failed = Failed {
+        step: Step::Commit,
+        refusal: Refusal::TimedOut,
+    };
+    assert!(failed.timed_out());
+}
+
+/// The closing ledger's part for each outcome, and which outcomes exit 1.
+#[test]
+fn the_ledger_part_names_what_the_offer_did() {
+    for (outcome, part) in [
+        (Outcome::Nothing, None),
+        (Outcome::Committed(12), Some("committed 12 files")),
+        (Outcome::Committed(1), Some("committed 1 file")),
+        (Outcome::Pushed(12), Some("committed and pushed 12 files")),
+        (
+            Outcome::PullRequest(12),
+            Some("committed 12 files, pull request open"),
+        ),
+        (Outcome::CommitRefused, Some("not committed")),
+        (Outcome::PushRefused, Some("committed, not pushed")),
+        (
+            Outcome::PullRequestRefused,
+            Some("committed and pushed, no pull request"),
+        ),
+    ] {
+        assert_eq!(outcome.part().as_deref(), part, "{outcome:?}");
+    }
+    for outcome in [
+        Outcome::Nothing,
+        Outcome::Committed(1),
+        Outcome::Pushed(1),
+        Outcome::PullRequest(1),
+    ] {
+        assert!(!outcome.refused(), "{outcome:?}");
+    }
+    for outcome in [
+        Outcome::CommitRefused,
+        Outcome::PushRefused,
+        Outcome::PullRequestRefused,
+    ] {
+        assert!(outcome.refused(), "{outcome:?}");
+    }
+}
+
+/// The flags answer once; two never both stand, and the innermost
+/// subcommand is where they are read from.
+#[test]
+fn the_flags_are_read_off_the_verb_the_person_ran() {
+    use clap::CommandFactory;
+    #[derive(clap::Parser)]
+    struct Fake {
+        #[command(subcommand)]
+        command: Verb,
+    }
+    #[derive(clap::Subcommand)]
+    enum Verb {
+        Refresh {
+            #[command(flatten)]
+            _commit: super::CommitFlags,
+        },
+        List,
+    }
+    let matches =
+        Fake::command().get_matches_from(["kendex", "refresh", "--push", "--message", "m"]);
+    let flags = super::CommitFlags::from_matches(&matches);
+    assert!(flags.push && !flags.commit && !flags.pull_request && !flags.leave);
+    assert_eq!(flags.message.as_deref(), Some("m"));
+    assert_eq!(flags.answered(), Some(Choice::Push));
+
+    let none =
+        super::CommitFlags::from_matches(&Fake::command().get_matches_from(["kendex", "list"]));
+    assert_eq!(none.answered(), None);
+    assert!(
+        Fake::command()
+            .try_get_matches_from(["kendex", "refresh", "--commit", "--leave"])
+            .is_err(),
+        "two answers stood together"
+    );
+    assert!(
+        Fake::command()
+            .try_get_matches_from(["kendex", "list", "--commit"])
+            .is_err(),
+        "a verb that never offers took the flag"
+    );
+}

--- a/crates/cli/src/commands/drift_hook.rs
+++ b/crates/cli/src/commands/drift_hook.rs
@@ -43,6 +43,7 @@ pub fn install(env: &Env, scope: &Scope, yes: bool) -> CliResult {
             safety: Vec::new(),
             instruction_shims: Vec::new(),
             fork_edits: Vec::new(),
+            generated: kendex_core::engine::GeneratedPaths::default(),
         };
         confirm_and_execute(env, &report, yes)?;
     }

--- a/crates/cli/src/commands/engine_common.rs
+++ b/crates/cli/src/commands/engine_common.rs
@@ -130,19 +130,18 @@ pub fn confirm_and_apply(
     report: &EngineReport,
     yes: bool,
 ) -> Result<usize, Box<dyn std::error::Error>> {
-    if report.plan.is_empty() {
-        return Ok(0);
-    }
     // The count is the consequence: an answer given to a bare "apply?" is
-    // an answer to the verb's name rather than to what it writes.
-    let ops = report.plan.ops.len();
-    ask_before_writing(&format!("apply {ops} change{}?", plural(ops)), yes)?;
-    let _writing = ui::spinner("writing");
+    // an answer to the verb's name rather than to what it writes. An empty
+    // plan asks nothing and writes nothing, and still reaches the offer.
+    if !report.plan.is_empty() {
+        let ops = report.plan.ops.len();
+        ask_before_writing(&format!("apply {ops} change{}?", plural(ops)), yes)?;
+    }
     apply_report(env, report)
 }
 
 /// Execute a report's plan — the one way a CLI verb holding an
-/// `EngineReport` writes it.
+/// `EngineReport` writes it, and where the commit offer is made.
 ///
 /// A plan can take a package away whatever the verb — `remove`, a manifest
 /// edited by hand and applied, a sweep, an unsubscribe that drops its
@@ -151,9 +150,30 @@ pub fn confirm_and_apply(
 /// skips that, so no verb does: every report goes through here, and only a
 /// bare `Plan` with no report behind it, which by construction drops no
 /// package, is executed on its own.
+/// The offer rides here rather than in each verb: a write into a project
+/// checkout is exactly what leaves files git can see, and a verb added
+/// later cannot forget to ask. It is made at most once per project per
+/// run, whichever verb reached it first, and `update-pi` — which writes
+/// into a project's `.pi` directory without a plan — calls it itself.
+///
+/// It runs for every project scope the run reached, an empty plan
+/// included: a scope with nothing left to write can still hold the files
+/// an earlier run left uncommitted, and `run again with --commit` has to
+/// mean something. The empty plan itself writes nothing.
 pub fn apply_report(env: &Env, report: &EngineReport) -> Result<usize, Box<dyn std::error::Error>> {
-    super::repo_effects::undo(&report.plan.scope, report)?;
-    Ok(kendex_core::apply::execute(env, &report.plan)?.applied)
+    let applied = match report.plan.is_empty() {
+        true => 0,
+        false => {
+            super::repo_effects::undo(&report.plan.scope, report)?;
+            // The wait covers the write and nothing after it: the offer
+            // asks a question, and a spinner still ticking under it would
+            // draw over the answer.
+            let _writing = ui::spinner("writing");
+            kendex_core::apply::execute(env, &report.plan)?.applied
+        }
+    };
+    super::commit_offer::after_writing(env, &report.plan.scope, &report.generated)?;
+    Ok(applied)
 }
 
 /// The answer every verb needs before it writes, asked one way. `--yes`

--- a/crates/cli/src/commands/fork_cmd.rs
+++ b/crates/cli/src/commands/fork_cmd.rs
@@ -25,6 +25,9 @@ pub struct ForkArgs {
     /// project | global (default project)
     #[arg(long)]
     scope: Option<String>,
+    /// The commit offer's answer, without asking
+    #[command(flatten)]
+    _commit: crate::commands::commit_offer::CommitFlags,
 }
 
 pub fn run(env: &Env, args: ForkArgs) -> CliResult {

--- a/crates/cli/src/commands/ledger.rs
+++ b/crates/cli/src/commands/ledger.rs
@@ -87,6 +87,10 @@ fn ledger(
     let flagged = flagged(scored);
     let mut parts = vec![wrote(said.verb, said.count, skipped)];
     let mut steps: Vec<String> = Vec::new();
+    // What this run's commit offer did in this project, read back off the
+    // run's own record rather than passed down by each verb: the part has
+    // to name what actually ran, and only the offer knows that.
+    parts.extend(super::commit_offer::answered(scope).part());
     if skipped > 0 {
         parts.push(format!(
             "skipped {skipped} item{} on conflict",

--- a/crates/cli/src/commands/marketplace_cmd.rs
+++ b/crates/cli/src/commands/marketplace_cmd.rs
@@ -31,6 +31,9 @@ pub enum MarketplaceCommand {
         /// project | global (default project)
         #[arg(long)]
         scope: Option<String>,
+        /// The commit offer's answer, without asking
+        #[command(flatten)]
+        _commit: crate::commands::commit_offer::CommitFlags,
     },
     /// Unsubscribe from a marketplace, removing or keeping its packages
     Unsubscribe {
@@ -49,6 +52,9 @@ pub enum MarketplaceCommand {
         /// project | global (default project)
         #[arg(long)]
         scope: Option<String>,
+        /// The commit offer's answer, without asking
+        #[command(flatten)]
+        _commit: crate::commands::commit_offer::CommitFlags,
     },
     /// Packages and curated sets a subscription offers
     Browse {
@@ -293,6 +299,7 @@ pub fn run(env: &Env, command: MarketplaceCommand) -> CliResult {
             name,
             global,
             scope,
+            ..
         } => run_subscribe(env, &reference, name.as_deref(), global, scope)?,
         MarketplaceCommand::Unsubscribe {
             name,
@@ -301,6 +308,7 @@ pub fn run(env: &Env, command: MarketplaceCommand) -> CliResult {
             discard_edits,
             global,
             scope,
+            ..
         } => run_unsubscribe(
             env,
             &name,

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod apply_cmd;
 pub mod blocked;
 pub mod check;
 pub mod check_catalog;
+pub mod commit_offer;
 pub mod diff_cmd;
 pub mod drift_hook;
 pub mod engine_common;

--- a/crates/cli/src/commands/pin.rs
+++ b/crates/cli/src/commands/pin.rs
@@ -25,6 +25,9 @@ pub struct PinArgs {
     /// Skip confirmation prompts
     #[arg(short = 'y', long)]
     yes: bool,
+    /// The commit offer's answer, without asking
+    #[command(flatten)]
+    _commit: crate::commands::commit_offer::CommitFlags,
 }
 
 /// The kinds a user can name on the command line. Plugins declare through

--- a/crates/cli/src/commands/refresh.rs
+++ b/crates/cli/src/commands/refresh.rs
@@ -32,6 +32,9 @@ pub struct RefreshArgs {
     /// Overwrite installations you edited by hand
     #[arg(long)]
     discard_edits: bool,
+    /// The commit offer's answer, without asking
+    #[command(flatten)]
+    _commit: crate::commands::commit_offer::CommitFlags,
 }
 
 /// What this refresh would add to or drop from the installed set — the part
@@ -187,29 +190,23 @@ pub fn run(
             continue;
         }
         refreshed_anything = true;
-        if report.plan.is_empty() {
-            closing.push(Closing {
-                scope: scope.clone(),
-                count: None,
-                blocked,
-                scored: report.safety.clone(),
-            });
-            continue;
-        }
-        // One closing line for both paths: a run that first asked about
+        // One closing line for every path: a run that first asked about
         // what it installs still ends on the same ledger, since the
-        // outcomes it has to report are the same either way.
-        let applied = match report.set_changes.is_empty() {
-            true => apply_report(env, &report),
-            false => {
+        // outcomes it has to report are the same either way. An empty plan
+        // closes on `None` — up to date — and still reaches the commit
+        // offer, on whatever an earlier run left uncommitted.
+        let applied = match (report.plan.is_empty(), report.set_changes.is_empty()) {
+            (true, _) => apply_report(env, &report).map(|_| None),
+            (false, true) => apply_report(env, &report).map(Some),
+            (false, false) => {
                 print_set_changes(&scope, &report);
-                confirm_and_apply(env, &report, yes)
+                confirm_and_apply(env, &report, yes).map(Some)
             }
         };
         match applied {
-            Ok(applied) => closing.push(Closing {
+            Ok(count) => closing.push(Closing {
                 scope: scope.clone(),
-                count: Some(applied),
+                count,
                 blocked,
                 scored: report.safety.clone(),
             }),

--- a/crates/cli/src/commands/source_cmd.rs
+++ b/crates/cli/src/commands/source_cmd.rs
@@ -11,13 +11,34 @@ pub enum SourceCommand {
     /// List declared sources for the scope
     List,
     /// Declare a source: `owner/repo[@rev]`, a git URL, or a local path
-    Add { name: String, reference: String },
+    Add {
+        name: String,
+        reference: String,
+        /// The commit offer's answer, without asking
+        #[command(flatten)]
+        _commit: crate::commands::commit_offer::CommitFlags,
+    },
     /// Remove a source (blocked while items still reference it)
-    Remove { name: String },
+    Remove {
+        name: String,
+        /// The commit offer's answer, without asking
+        #[command(flatten)]
+        _commit: crate::commands::commit_offer::CommitFlags,
+    },
     /// Re-enable a source and restore its installations
-    Enable { name: String },
+    Enable {
+        name: String,
+        /// The commit offer's answer, without asking
+        #[command(flatten)]
+        _commit: crate::commands::commit_offer::CommitFlags,
+    },
     /// Disable a source; its installations deactivate but stay declared
-    Disable { name: String },
+    Disable {
+        name: String,
+        /// The commit offer's answer, without asking
+        #[command(flatten)]
+        _commit: crate::commands::commit_offer::CommitFlags,
+    },
     /// Re-resolve remote source caches
     Refresh {
         /// Only fetch mirrors whose freshness stamp is old, then re-derive
@@ -57,7 +78,9 @@ pub fn run(env: &Env, command: SourceCommand, filter: ScopeFilter) -> CliResult 
                     ));
                 }
             }
-            SourceCommand::Add { name, reference } => {
+            SourceCommand::Add {
+                name, reference, ..
+            } => {
                 let report = source_ops::add_source(env, &scope, name, reference)?;
                 apply_report(env, &report)?;
                 say(&format!(
@@ -65,12 +88,12 @@ pub fn run(env: &Env, command: SourceCommand, filter: ScopeFilter) -> CliResult 
                     scope_label(&scope)
                 ));
             }
-            SourceCommand::Remove { name } => {
+            SourceCommand::Remove { name, .. } => {
                 let report = source_ops::remove_source(env, &scope, name)?;
                 apply_report(env, &report)?;
                 say(&format!("{}: removed source '{name}'", scope_label(&scope)));
             }
-            SourceCommand::Enable { name } | SourceCommand::Disable { name } => {
+            SourceCommand::Enable { name, .. } | SourceCommand::Disable { name, .. } => {
                 let enabled = matches!(command, SourceCommand::Enable { .. });
                 let report = source_ops::toggle_source(env, &scope, name, enabled)?;
                 apply_report(env, &report)?;

--- a/crates/cli/src/commands/update_pi.rs
+++ b/crates/cli/src/commands/update_pi.rs
@@ -359,6 +359,7 @@ fn update(env: &Env, plans: &[ScopePlan]) -> CliResult {
         }
         kendex_core::drift::snapshot::record(env, &plan.scope)?;
     }
+    offer_to_commit(env, plans)?;
     if failures.is_empty() {
         say(&match updated {
             0 => "all pi packages up to date".to_owned(),
@@ -367,6 +368,32 @@ fn update(env: &Env, plans: &[ScopePlan]) -> CliResult {
         return Ok(());
     }
     Err(format!("update failed for: {}", failures.join(", ")).into())
+}
+
+/// The commit offer, made here because this verb writes into a project's
+/// `.pi` directory without going through a plan, and so is not reached by
+/// the seam in `engine_common::apply_report` that every other verb writes
+/// through.
+///
+/// The paths the offer covers are the ones the engine renders in that
+/// project, which only a plan names — so one is derived here for that
+/// alone. A scope whose plan will not derive gets no offer: the writes
+/// above still stand, and nothing about them is claimed.
+fn offer_to_commit(env: &Env, plans: &[ScopePlan]) -> CliResult {
+    for plan in plans {
+        if !matches!(plan.scope, Scope::Project { .. }) {
+            continue;
+        }
+        let Ok(report) = kendex_core::engine::plan_apply(
+            env,
+            &plan.scope,
+            &kendex_core::engine::PlanOptions::default(),
+        ) else {
+            continue;
+        };
+        super::commit_offer::after_writing(env, &plan.scope, &report.generated)?;
+    }
+    Ok(())
 }
 
 fn record_pi_installs(env: &Env, plan: &ScopePlan, completed: Option<&str>) -> CliResult {

--- a/crates/cli/src/commands/updates_cmd.rs
+++ b/crates/cli/src/commands/updates_cmd.rs
@@ -40,6 +40,9 @@ pub struct UpdatesArgs {
     /// Skip confirmation prompts
     #[arg(short = 'y', long, global = true)]
     yes: bool,
+    /// The commit offer's answer, without asking
+    #[command(flatten)]
+    _commit: crate::commands::commit_offer::CommitFlags,
 }
 
 pub fn run(env: &Env, args: UpdatesArgs) -> CliResult {
@@ -50,6 +53,7 @@ pub fn run(env: &Env, args: UpdatesArgs) -> CliResult {
         global,
         scope,
         yes,
+        ..
     } = args;
     let filter = ScopeFilter::resolve(scope.as_deref(), global, ScopeFilter::Project)?;
     let scope = resolve_scopes(env, filter)?.remove(0);

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -13,6 +13,7 @@ use kendex_core::env::Env;
 use kendex_core::install_channel::{Host, HostProbe};
 use kendex_core::legal;
 
+use commands::commit_offer::CommitFlags;
 use commands::project::ProjectCommand;
 use flags::{AddFlags, ReportFlags};
 use scope::ScopeFilter;
@@ -28,6 +29,9 @@ struct Cli {
     source: Option<String>,
     #[command(flatten)]
     add_flags: AddFlags,
+    /// The commit offer's answer for the bare form, which is `add`
+    #[command(flatten)]
+    _commit: CommitFlags,
     #[command(subcommand)]
     command: Option<Command>,
 }
@@ -40,6 +44,9 @@ enum Command {
         source: Option<String>,
         #[command(flatten)]
         flags: AddFlags,
+        /// The commit offer's answer, without asking
+        #[command(flatten)]
+        _commit: crate::commands::commit_offer::CommitFlags,
     },
     /// What changed between two versions of a package
     Diff(commands::diff_cmd::DiffArgs),
@@ -70,6 +77,9 @@ enum Command {
         /// Take the files away and leave kendex.toml untouched; refresh installs what it declares again
         #[arg(long, conflicts_with_all = ["sweep", "no_sweep"])]
         keep_declaration: bool,
+        /// The commit offer's answer, without asking
+        #[command(flatten)]
+        _commit: crate::commands::commit_offer::CommitFlags,
     },
     /// Regenerate every declared installation from its source, and the instruction shims
     Refresh(commands::refresh::RefreshArgs),
@@ -100,6 +110,9 @@ enum Command {
         /// project | global (default project)
         #[arg(long)]
         scope: Option<String>,
+        /// The commit offer's answer, without asking
+        #[command(flatten)]
+        _commit: crate::commands::commit_offer::CommitFlags,
     },
     /// Register, list, and discover kendex-enabled projects
     #[command(subcommand)]
@@ -149,6 +162,9 @@ enum Command {
         /// Skip confirmation prompts
         #[arg(short = 'y', long)]
         yes: bool,
+        /// The commit offer's answer, without asking
+        #[command(flatten)]
+        _commit: crate::commands::commit_offer::CommitFlags,
     },
     /// Commit-time quality guards and the git hooks that run them
     #[command(subcommand)]
@@ -200,6 +216,9 @@ enum Command {
         /// project | global | all (default all)
         #[arg(long)]
         scope: Option<String>,
+        /// The commit offer's answer, without asking
+        #[command(flatten)]
+        _commit: crate::commands::commit_offer::CommitFlags,
     },
 }
 
@@ -216,13 +235,35 @@ pub fn main() -> ExitCode {
         bootstrap_the_command_record(&env);
         announce_the_terms_on_first_run(&env);
     }
-    let cli = Cli::parse();
+    let matches = <Cli as clap::CommandFactory>::command().get_matches();
+    let cli = match <Cli as clap::FromArgMatches>::from_arg_matches(&matches) {
+        Ok(cli) => cli,
+        Err(error) => error.exit(),
+    };
+    // What the person typed, for the commit offer's default message, and
+    // the flag they answered it with. Both read off clap's own resolution
+    // rather than enumerated here, so no list of verbs can fall out of
+    // date as the command surface changes.
+    commands::commit_offer::begin(&typed(&matches), CommitFlags::from_matches(&matches));
     // The machine check's whole contract is its exit code: 1 means "drift,
     // report on stdout". A failure before the check could run — settings
     // unreadable, scope unresolvable — must exit 2 (could not check), or
     // the session hook reads the empty report as a clean machine.
     let machine_check = matches!(&cli.command, Some(Command::Check { catalog: None, .. }));
     match run(cli) {
+        // A Ctrl-C at the commit offer let the verb finish closing its
+        // scopes; the run still ends as a cancel.
+        Ok(_) if commands::commit_offer::cancelled() => {
+            ui::outro_fail("cancelled");
+            ExitCode::from(130)
+        }
+        // A refused commit, push or pull request: the block carried the
+        // program's own words and the way on, and the ledger named it, so
+        // the exit adds nothing.
+        Ok(_) if commands::commit_offer::refused() => {
+            ui::finish();
+            ExitCode::FAILURE
+        }
         Ok(code) => {
             ui::finish();
             code
@@ -339,6 +380,25 @@ fn announce_the_terms_on_first_run(env: &Env) {
     let _ = legal::accept(env);
 }
 
+/// The command the person typed, without its flags and arguments: the
+/// subcommand path clap resolved, joined by spaces, so a group and its
+/// subcommand are named together.
+///
+/// The bare form has no subcommand and maps to `add`, which is the command
+/// it runs and the one a person could type to run it again.
+fn typed(matches: &clap::ArgMatches) -> String {
+    let mut names: Vec<&str> = Vec::new();
+    let mut at = matches;
+    while let Some((name, inner)) = at.subcommand() {
+        names.push(name);
+        at = inner;
+    }
+    match names.is_empty() {
+        true => "add".to_owned(),
+        false => names.join(" "),
+    }
+}
+
 /// The bare form: `kendex <source> [flags]` maps to `add`.
 fn bare_add(
     env: &Env,
@@ -358,7 +418,7 @@ fn run(cli: Cli) -> Result<ExitCode, Box<dyn std::error::Error>> {
         return bare_add(&env, cli.source, cli.add_flags);
     };
     match command {
-        Command::Add { source, flags } => commands::add::run(&env, flags.into_args(source))?,
+        Command::Add { source, flags, .. } => commands::add::run(&env, flags.into_args(source))?,
         Command::Login => commands::login::login()?,
         Command::Logout => commands::login::logout()?,
         Command::Diff(args) => commands::diff_cmd::run(&env, args)?,
@@ -374,6 +434,7 @@ fn run(cli: Cli) -> Result<ExitCode, Box<dyn std::error::Error>> {
             sweep,
             no_sweep,
             keep_declaration,
+            ..
         } => remove(
             &env,
             names,
@@ -399,6 +460,7 @@ fn run(cli: Cli) -> Result<ExitCode, Box<dyn std::error::Error>> {
             harness,
             global,
             scope,
+            ..
         } => {
             let filter = ScopeFilter::resolve(scope.as_deref(), global, ScopeFilter::Project)?;
             commands::adopt::run(&env, kind, name, harness, filter)?;
@@ -420,11 +482,13 @@ fn run(cli: Cli) -> Result<ExitCode, Box<dyn std::error::Error>> {
             catalog,
             strict,
         } => return check(&env, global, scope, json, quiet, catalog, strict),
-        Command::DriftHook { global, scope, yes } => {
+        Command::DriftHook {
+            global, scope, yes, ..
+        } => {
             let filter = ScopeFilter::resolve(scope.as_deref(), global, ScopeFilter::Project)?;
             commands::drift_hook::run(&env, filter, yes)?;
         }
-        Command::UpdatePi { check, scope } => {
+        Command::UpdatePi { check, scope, .. } => {
             let filter = ScopeFilter::resolve(scope.as_deref(), false, ScopeFilter::All)?;
             commands::update_pi::run(&env, filter, check)?;
         }

--- a/crates/cli/tests/commit_offer_cli.rs
+++ b/crates/cli/tests/commit_offer_cli.rs
@@ -1,0 +1,502 @@
+//! The commit offer through the binary: every state the design's table
+//! gives the CLI a detection for, driven by a real repository, a bare
+//! `origin`, the repository's own hooks, and a fake `gh` on the child's
+//! `PATH` whose answer is chosen by the `--repo` value every call is
+//! bound to. The child has no terminal, so the interactive block is not
+//! reachable here; its rows are pinned in `commands/commit_offer/tests.rs`.
+#![cfg(unix)]
+
+#[path = "../../test_util.rs"]
+mod test_util;
+use test_util::rooted;
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use kendex_core::process::Hardened;
+
+#[allow(clippy::expect_used)]
+fn kendex(home: &Path, cwd: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_kendex"))
+        .args(args)
+        .current_dir(cwd)
+        .env_clear()
+        .envs(test_util::fixture_env(home))
+        .env("KENDEX_BACKGROUND_REFRESH", "off")
+        .env("PATH", path_with_fake_gh(home))
+        .output()
+        .expect("kendex binary runs")
+}
+
+fn said(output: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[allow(clippy::unwrap_used)]
+fn git(dir: &Path, args: &[&str]) -> String {
+    let home = dir.to_str().unwrap();
+    let out = Hardened::git(args, Some(dir))
+        .env("HOME", home)
+        .env("KENDEX_REAL_HOME", "1")
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .run()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "git {args:?}: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// A repository declaring the claude harness with its root `AGENTS.md`
+/// committed: `apply --yes` renders the `CLAUDE.md` shim and the
+/// inventory, which is the offer's two-file set.
+#[allow(clippy::unwrap_used)]
+fn project(tmp: &tempfile::TempDir) -> PathBuf {
+    let home = rooted(tmp);
+    let project = home.join("dev/app");
+    fs::create_dir_all(project.join(".claude")).unwrap();
+    fs::write(
+        project.join("kendex.toml"),
+        "schema = 6\n\n[install]\nharnesses = [\"claude\"]\n",
+    )
+    .unwrap();
+    fs::write(project.join("AGENTS.md"), "# app\n").unwrap();
+    fs::write(project.join(".gitignore"), "/.kendex-lock.json\n").unwrap();
+    git(&project, &["init", "-q", "-b", "main"]);
+    git(&project, &["config", "user.email", "t@t"]);
+    git(&project, &["config", "user.name", "t"]);
+    git(&project, &["config", "commit.gpgsign", "false"]);
+    git(&project, &["config", "core.hooksPath", ".git/hooks"]);
+    git(&project, &["add", "-A"]);
+    git(&project, &["commit", "-q", "-m", "files"]);
+    project
+}
+
+/// A bare repository the project calls `origin`, under a name the fake
+/// `gh` reads its answer from.
+#[allow(clippy::unwrap_used)]
+fn origin(project: &Path, name: &str) -> PathBuf {
+    let bare = project.parent().unwrap().join(format!("{name}.git"));
+    git(
+        project,
+        &[
+            "init",
+            "-q",
+            "--bare",
+            "-b",
+            "main",
+            &bare.to_string_lossy(),
+        ],
+    );
+    git(
+        project,
+        &["remote", "add", "origin", &bare.to_string_lossy()],
+    );
+    git(project, &["push", "-q", "-u", "origin", "main"]);
+    bare
+}
+
+#[allow(clippy::unwrap_used)]
+fn executable(path: &Path, body: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, body).unwrap();
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+/// A `gh` whose answers are chosen by the repository it was bound to.
+/// The directory holds nothing but `gh`, so git resolves as before.
+#[allow(clippy::unwrap_used)]
+fn path_with_fake_gh(home: &Path) -> String {
+    let dir = home.join("fake-bin");
+    executable(&dir.join("gh"), FAKE_GH);
+    format!(
+        "{}:{}",
+        dir.display(),
+        std::env::var("PATH").unwrap_or_default()
+    )
+}
+
+const FAKE_GH: &str = r#"#!/bin/sh
+repo=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "--repo" ]; then repo="$a"; fi
+  prev="$a"
+done
+case "$1 $2" in
+"pr list")
+  case "$repo" in
+    *notauth*) echo "To get started with GitHub CLI, please run:  gh auth login" >&2; exit 4;;
+    *open*) echo '[{"number":41,"url":"https://github.com/acme/site/pull/41"}]'; exit 0;;
+    *) echo '[]'; exit 0;;
+  esac;;
+"pr create")
+  case "$repo" in
+    *refuse*) echo "GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)" >&2; exit 1;;
+    *) echo "https://github.com/acme/site/pull/41"; exit 0;;
+  esac;;
+esac
+exit 1
+"#;
+
+fn apply(home: &Path, project: &Path, flags: &[&str]) -> (Output, String) {
+    let mut args = vec!["apply", "--yes"];
+    args.extend_from_slice(flags);
+    let output = kendex(home, project, &args);
+    let text = said(&output);
+    (output, text)
+}
+
+fn head_subject(project: &Path) -> String {
+    git(project, &["log", "-1", "--format=%s"])
+        .trim()
+        .to_owned()
+}
+
+/// No terminal and no flag: one line naming the flags, and the run exits
+/// as the verb would. A flag that leaves is the same success with no line.
+#[test]
+fn without_a_terminal_the_line_names_the_flags_and_leave_says_nothing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let project = project(&tmp);
+    let (output, text) = apply(&home, &project, &[]);
+    assert!(output.status.success(), "{text}");
+    assert!(
+        text.contains(
+            "2 files kendex wrote are not committed; run again with --commit, --push, --pull-request or --leave"
+        ),
+        "{text}"
+    );
+    assert_eq!(head_subject(&project), "files");
+
+    let (output, text) = apply(&home, &project, &["--leave"]);
+    assert!(output.status.success(), "{text}");
+    assert!(!text.contains("not committed"), "{text}");
+    assert!(git(&project, &["status", "--porcelain"]).contains("?? CLAUDE.md"));
+}
+
+/// The commit route: the set is committed with the command's message, or
+/// the one `--message` gives, and the ledger carries the part.
+#[test]
+fn the_commit_flag_commits_the_set_with_the_commands_message() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let project = project(&tmp);
+    let (output, text) = apply(&home, &project, &["--commit"]);
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("committed 2 files as "), "{text}");
+    assert!(
+        text.contains(" · committed 2 files"),
+        "no ledger part: {text}"
+    );
+    assert_eq!(head_subject(&project), "chore: kendex apply");
+    let files = git(&project, &["show", "--name-only", "--format=", "HEAD"]);
+    assert!(
+        files.contains("CLAUDE.md") && files.contains(".kendex-generated.json"),
+        "{files}"
+    );
+    assert!(!files.contains("kendex.toml"), "{files}");
+
+    // A fresh checkout, the person's own edit beside the renders: the
+    // message given is the one used, and the edit is never swept in.
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let project = self::project(&tmp);
+    fs::write(project.join("AGENTS.md"), "# app\n\nmore\n").unwrap();
+    let (output, text) = apply(&home, &project, &["--commit", "--message", "docs: shim"]);
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("committed 2 files as "), "{text}");
+    assert_eq!(head_subject(&project), "docs: shim");
+    assert!(
+        git(&project, &["status", "--porcelain"]).contains(" M AGENTS.md"),
+        "the person's own change was swept into the commit"
+    );
+}
+
+/// A flag naming a choice a precondition removed refuses with that
+/// precondition's reason, commits nothing, and exits 1; the verb's writes
+/// still stand.
+#[test]
+fn a_flag_naming_a_choice_not_on_offer_is_refused_with_the_reason() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let project = project(&tmp);
+    let (output, text) = apply(&home, &project, &["--push"]);
+    assert_eq!(output.status.code(), Some(1), "{text}");
+    assert!(
+        text.contains("no push: this repository has no remote"),
+        "{text}"
+    );
+    assert_eq!(head_subject(&project), "files");
+    assert!(
+        project.join("CLAUDE.md").exists(),
+        "the write did not stand"
+    );
+
+    let (output, text) = apply(&home, &project, &["--pull-request"]);
+    assert_eq!(output.status.code(), Some(1), "{text}");
+    assert!(
+        text.contains("no pull request: this repository has no remote"),
+        "{text}"
+    );
+
+    origin(&project, "open-origin");
+    let (output, text) = apply(&home, &project, &["--pull-request"]);
+    assert_eq!(output.status.code(), Some(1), "{text}");
+    assert!(
+        text.contains("no pull request: pull request #41 is already open for this branch"),
+        "{text}"
+    );
+    assert_eq!(head_subject(&project), "files");
+}
+
+/// The push route lands on the chosen remote, and a remote that refuses
+/// is quoted whole with the commit named and left where it is.
+#[test]
+fn the_push_flag_pushes_or_reports_the_remotes_refusal() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let project = project(&tmp);
+    let bare = origin(&project, "plain-origin");
+    let (output, text) = apply(&home, &project, &["--push"]);
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("committed 2 files as "), "{text}");
+    assert!(text.contains("pushed to origin/main"), "{text}");
+    assert!(
+        text.contains(" · committed and pushed 2 files"),
+        "no ledger part: {text}"
+    );
+    assert_eq!(
+        git(&project, &["rev-parse", "HEAD"]),
+        git(&project, &["rev-parse", "origin/main"])
+    );
+
+    drop(bare);
+    // A fresh checkout whose remote refuses the push: the commit stands
+    // and the remote's words are quoted.
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let project = self::project(&tmp);
+    let bare = origin(&project, "plain-origin");
+    executable(
+        &bare.join("hooks/pre-receive"),
+        "#!/bin/sh\necho 'GH006: Protected branch update failed for refs/heads/main.' >&2\nexit 1\n",
+    );
+    let before = git(&project, &["rev-parse", "HEAD"]);
+    let (output, text) = apply(&home, &project, &["--push"]);
+    assert_eq!(output.status.code(), Some(1), "{text}");
+    assert!(text.contains("committed 2 files as "), "{text}");
+    assert!(text.contains("the push was refused"), "{text}");
+    assert!(text.contains("git said:"), "{text}");
+    assert!(
+        text.contains("GH006: Protected branch update failed"),
+        "{text}"
+    );
+    assert!(
+        text.contains("the commit is on main in this checkout; kendex did not undo it"),
+        "{text}"
+    );
+    assert!(
+        text.contains(" · committed, not pushed"),
+        "no ledger part: {text}"
+    );
+    assert_ne!(
+        git(&project, &["rev-parse", "HEAD"]),
+        before,
+        "the commit was undone"
+    );
+}
+
+/// The pull-request route: a branch of its own, the commit, the push, the
+/// pull request, and the checkout left on the branch; a `gh` that refuses
+/// is quoted and the branch named for the person to open it themselves.
+#[test]
+fn the_pull_request_flag_opens_one_or_names_the_branch_gh_refused() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let project = project(&tmp);
+    origin(&project, "plain-origin");
+    let (output, text) = apply(&home, &project, &["--pull-request"]);
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("committed 2 files as "), "{text}");
+    assert!(text.contains(" on kendex/renders"), "{text}");
+    assert!(text.contains("pushed to origin/kendex/renders"), "{text}");
+    assert!(
+        text.contains("opened https://github.com/acme/site/pull/41"),
+        "{text}"
+    );
+    assert!(
+        text.contains("this checkout is now on kendex/renders"),
+        "{text}"
+    );
+    assert!(
+        text.contains(" · committed 2 files, pull request open"),
+        "no ledger part: {text}"
+    );
+    assert_eq!(
+        git(&project, &["symbolic-ref", "--short", "HEAD"]).trim(),
+        "kendex/renders"
+    );
+    assert_eq!(
+        git(&project, &["rev-parse", "main"]),
+        git(&project, &["rev-parse", "origin/main"]),
+        "main gained the commit"
+    );
+
+    let refusing = tempfile::tempdir().unwrap();
+    let home = rooted(&refusing);
+    let project = self::project(&refusing);
+    origin(&project, "refuse-origin");
+    let (output, text) = apply(&home, &project, &["--pull-request"]);
+    assert_eq!(output.status.code(), Some(1), "{text}");
+    assert!(text.contains("pushed to origin/kendex/renders"), "{text}");
+    assert!(text.contains("the pull request was refused"), "{text}");
+    assert!(text.contains("gh said:"), "{text}");
+    assert!(
+        text.contains("GitHub Actions is not permitted to create or approve pull requests"),
+        "{text}"
+    );
+    assert!(
+        text.contains("the branch kendex/renders is on origin; open the pull request yourself"),
+        "{text}"
+    );
+    assert!(
+        text.contains(" · committed and pushed, no pull request"),
+        "no ledger part: {text}"
+    );
+}
+
+/// A hook's refusal reaches the person whole, nothing is committed, and
+/// the index ends as it began.
+#[test]
+fn a_hooks_refusal_is_quoted_whole_and_nothing_is_committed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let project = project(&tmp);
+    executable(
+        &project.join(".git/hooks/pre-commit"),
+        "#!/bin/sh\necho 'commit-msg: crates/ changed without a changelog entry' >&2\necho '  write one of: changelog.d/*/*.md' >&2\nexit 1\n",
+    );
+    let (output, text) = apply(&home, &project, &["--commit"]);
+    assert_eq!(output.status.code(), Some(1), "{text}");
+    assert!(text.contains("the commit was refused"), "{text}");
+    assert!(text.contains("git said:"), "{text}");
+    assert!(
+        text.contains("commit-msg: crates/ changed without a changelog entry"),
+        "{text}"
+    );
+    assert!(text.contains("write one of: changelog.d/*/*.md"), "{text}");
+    assert_eq!(head_subject(&project), "files");
+    assert!(text.contains(" · not committed"), "no ledger part: {text}");
+    let status = git(&project, &["status", "--porcelain"]);
+    assert!(status.contains("?? CLAUDE.md"), "still staged: {status}");
+
+    // The same refusal through the other verb that closes on a ledger, in
+    // a checkout it still has the shim to write: its own failure line, the
+    // scope's ledger still closed, and never counted as a failure of the
+    // verb.
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let project = self::project(&tmp);
+    executable(
+        &project.join(".git/hooks/pre-commit"),
+        "#!/bin/sh\necho 'commit-msg: no' >&2\nexit 1\n",
+    );
+    let output = kendex(&home, &project, &["refresh", "--yes", "--commit"]);
+    let text = said(&output);
+    assert_eq!(output.status.code(), Some(1), "{text}");
+    assert!(text.contains("the commit was refused"), "{text}");
+    assert!(text.contains(" · not committed"), "no ledger line: {text}");
+    assert!(!text.contains("failed to refresh"), "{text}");
+    assert!(!text.contains("already said"), "{text}");
+}
+
+/// The two states the offer cannot be made in print one line each, and a
+/// flag does not change that.
+#[test]
+fn a_detached_head_or_an_operation_in_progress_prints_one_line() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let project = project(&tmp);
+    fs::write(project.join(".git/MERGE_HEAD"), "").unwrap();
+    let (output, text) = apply(&home, &project, &["--commit"]);
+    assert!(output.status.success(), "{text}");
+    assert!(
+        text.contains("2 files kendex wrote are not committed; a merge is in progress"),
+        "{text}"
+    );
+    fs::remove_file(project.join(".git/MERGE_HEAD")).unwrap();
+
+    let head = git(&project, &["rev-parse", "HEAD"]);
+    git(&project, &["checkout", "-q", "--detach", head.trim()]);
+    let (output, text) = apply(&home, &project, &["--commit"]);
+    assert!(output.status.success(), "{text}");
+    assert!(
+        text.contains("2 files kendex wrote are not committed; this checkout is on no branch"),
+        "{text}"
+    );
+    assert_eq!(head_subject(&project), "files");
+}
+
+/// A read the offer is built from that will not run leaves the offer
+/// unbuildable: one line, git's words, and the verb's own exit.
+#[test]
+fn a_repository_git_cannot_read_says_the_files_could_not_be_checked() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let project = project(&tmp);
+    fs::write(project.join(".git/HEAD"), "not a ref\n").unwrap();
+    let (output, text) = apply(&home, &project, &["--commit"]);
+    assert!(output.status.success(), "{text}");
+    assert!(
+        text.contains("the files kendex wrote could not be checked"),
+        "{text}"
+    );
+    assert!(text.contains("git said:"), "{text}");
+    assert!(text.contains("fatal:"), "{text}");
+}
+
+/// `commit-offer = "off"` turns off the asking, not the choices: no line
+/// without a flag, and a flag still answers.
+#[test]
+fn the_setting_turns_off_the_asking_and_not_the_flags() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let project = project(&tmp);
+    let settings = kendex_core::env::Env::host_rooted(&home).settings_file();
+    fs::create_dir_all(settings.parent().unwrap()).unwrap();
+    fs::write(&settings, "schema = 1\ncommit-offer = \"off\"\n").unwrap();
+    let (output, text) = apply(&home, &project, &[]);
+    assert!(output.status.success(), "{text}");
+    assert!(!text.contains("not committed"), "{text}");
+    let (output, text) = apply(&home, &project, &["--commit"]);
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("committed 2 files as "), "{text}");
+}
+
+/// Two of the group together is refused before the verb writes anything.
+#[test]
+fn two_answers_at_once_are_refused_before_the_write() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let project = project(&tmp);
+    let (output, text) = apply(&home, &project, &["--commit", "--leave"]);
+    assert!(!output.status.success(), "{text}");
+    assert!(text.contains("cannot be used with"), "{text}");
+    assert!(
+        !project.join("CLAUDE.md").exists(),
+        "the verb wrote before refusing"
+    );
+}

--- a/crates/cli/tests/commit_offer_cli.rs
+++ b/crates/cli/tests/commit_offer_cli.rs
@@ -128,6 +128,7 @@ fn path_with_fake_gh(home: &Path) -> String {
 }
 
 const FAKE_GH: &str = r#"#!/bin/sh
+echo "$@" >> "$(dirname "$0")/calls"
 repo=""
 prev=""
 for a in "$@"; do
@@ -200,6 +201,10 @@ fn the_commit_flag_commits_the_set_with_the_commands_message() {
     assert!(
         text.contains(" · committed 2 files"),
         "no ledger part: {text}"
+    );
+    assert!(
+        !home.join("fake-bin/calls").exists(),
+        "a commit that takes no pull request asked gh"
     );
     assert_eq!(head_subject(&project), "chore: kendex apply");
     let files = git(&project, &["show", "--name-only", "--format=", "HEAD"]);
@@ -345,6 +350,7 @@ fn the_pull_request_flag_opens_one_or_names_the_branch_gh_refused() {
         text.contains(" · committed 2 files, pull request open"),
         "no ledger part: {text}"
     );
+    assert!(home.join("fake-bin/calls").exists(), "gh was never asked");
     assert_eq!(
         git(&project, &["symbolic-ref", "--short", "HEAD"]).trim(),
         "kendex/renders"
@@ -498,5 +504,27 @@ fn two_answers_at_once_are_refused_before_the_write() {
     assert!(
         !project.join("CLAUDE.md").exists(),
         "the verb wrote before refusing"
+    );
+}
+
+/// A verb that applies more than one report into the project: the first
+/// report has nothing kendex owns changed and records no answer, so the
+/// report that renders the hook still reaches the offer.
+#[test]
+fn a_verbs_later_report_still_reaches_the_offer() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let project = project(&tmp);
+    let output = kendex(&home, &project, &["drift-hook", "--yes", "--commit"]);
+    let text = said(&output);
+    assert!(output.status.success(), "{text}");
+    assert!(
+        text.contains("committed "),
+        "the hook's render was not offered: {text}"
+    );
+    assert_ne!(
+        head_subject(&project),
+        "files",
+        "nothing was committed: {text}"
     );
 }

--- a/crates/core/src/commit_offer/gh.rs
+++ b/crates/core/src/commit_offer/gh.rs
@@ -1,0 +1,92 @@
+//! The one `gh` question the offer asks before it draws, and the one it
+//! asks after a push.
+
+use crate::process::Hardened;
+
+use super::{Failed, Refusal, Step, Unavailable, git};
+
+/// A pull request already open for a branch.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenPullRequest {
+    pub number: u64,
+    pub url: String,
+}
+
+#[derive(serde::Deserialize)]
+struct Row {
+    number: u64,
+    url: String,
+}
+
+/// Whether the pull-request choice stands, and whether one is already open
+/// for this branch.
+///
+/// One command answers three questions at once — `gh` on the machine, a
+/// credential it will use, and a remote it recognises as a GitHub
+/// repository — and a fourth the offer asks anyway. kendex runs no
+/// separate credential check: `gh auth token` would print the token on a
+/// pipe kendex captures, and a probe that does real work answers the same
+/// question without one.
+///
+/// `--repo` binds it to the remote the offer chose. Without it `gh`
+/// resolves the repository from the remotes itself, so a project whose
+/// `origin` is one host and whose second remote is GitHub would be probed
+/// against a repository the push never reaches.
+pub fn probe(repo: &str, branch: &str) -> Result<Option<OpenPullRequest>, Unavailable> {
+    let output = git::run(
+        Hardened::gh(&[
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--head",
+            branch,
+            "--state",
+            "open",
+            "--json",
+            "number,url",
+        ]),
+        Step::Probe,
+    );
+    let rows = match output {
+        Ok(stdout) => stdout,
+        Err(failed) => return Err(why(&failed)),
+    };
+    // A `gh` that exits zero and answers with something this cannot read is
+    // still a `gh` that works and a repository it recognises, so the choice
+    // stands; what it could not tell us is whether one is already open, and
+    // the create below answers that with its own refusal.
+    Ok(serde_json::from_slice::<Vec<Row>>(&rows)
+        .ok()
+        .and_then(|rows| rows.into_iter().next())
+        .map(|row| OpenPullRequest {
+            number: row.number,
+            url: row.url,
+        }))
+}
+
+/// Why the pull-request choice is not on offer.
+///
+/// A failure to spawn is `gh` not being installed. Everything else is
+/// `gh`'s own first line — not signed in, no remote it recognises as a
+/// GitHub host, or a case nobody anticipated, which still names itself
+/// rather than reading as one of the two above.
+pub(super) fn why(failed: &Failed) -> Unavailable {
+    match &failed.refusal {
+        Refusal::NotStarted(_) => Unavailable::GhMissing,
+        Refusal::TimedOut => Unavailable::GhSaid(format!(
+            "{} did not finish within {} seconds",
+            failed.step.name(),
+            failed.step.seconds()
+        )),
+        // A `gh` that ran and refused always says something; an empty
+        // stderr and stdout from a non-zero exit is a `gh` nobody can act
+        // on, and reading it as "not installed" would be a claim about a
+        // program that is plainly there.
+        Refusal::Said(lines) => Unavailable::GhSaid(match lines.first() {
+            Some(first) => first.clone(),
+            None => "gh exited without saying why".to_owned(),
+        }),
+    }
+}

--- a/crates/core/src/commit_offer/git.rs
+++ b/crates/core/src/commit_offer/git.rs
@@ -1,0 +1,249 @@
+//! Every git call the offer makes, under the bound its step names.
+//!
+//! One runner, because the answer a step gives when it fails is what both
+//! surfaces draw: the program's own words whole, or the bound it ran past.
+//! A per-call-site reading of an exit status would put a different shape
+//! behind each step.
+
+use std::path::Path;
+
+use crate::process::Hardened;
+
+use super::{Failed, Refusal, Remote, Step};
+
+/// Run one git call, bounded by its step, and hand back its output or the
+/// failure both surfaces draw.
+///
+/// A refusal is the program's words, not a verdict about them: nothing is
+/// summarised, truncated to a first line, or matched against a pattern.
+/// A cap is deliberately not set — [`Hardened::max_output`] refuses the
+/// whole call when the cap is passed, and its error carries none of what
+/// the program said, which would lose exactly the words the offer
+/// promises.
+pub fn run(hardened: Hardened, step: Step) -> Result<Vec<u8>, Failed> {
+    let output = match hardened.timeout(step.bound()).run() {
+        Ok(output) => output,
+        Err(error) => {
+            return Err(Failed {
+                step,
+                refusal: refusal(&error),
+            });
+        }
+    };
+    if output.status.success() {
+        return Ok(output.stdout);
+    }
+    Err(Failed {
+        step,
+        refusal: Refusal::Said(said(&output.stderr, &output.stdout)),
+    })
+}
+
+/// git and gh both put a refusal on stderr, and a hook's own output goes
+/// there whole; stdout follows for the programs that also write there.
+/// Shown one line at a time, in order, with nothing dropped.
+pub fn said(stderr: &[u8], stdout: &[u8]) -> Vec<String> {
+    let lines = |bytes: &[u8]| -> Vec<String> {
+        String::from_utf8_lossy(bytes)
+            .lines()
+            .map(str::to_owned)
+            .collect()
+    };
+    let mut all = lines(stderr);
+    all.extend(lines(stdout));
+    all
+}
+
+/// What a call that never produced an exit status says for itself. A
+/// program that is not on the machine, one whose pipes broke, and one that
+/// ran past its bound are three different answers, and the offer draws
+/// each of them differently.
+pub(super) fn refusal(error: &crate::error::CoreError) -> Refusal {
+    match error {
+        crate::error::CoreError::CommandNotStarted { .. } => Refusal::NotStarted(error.to_string()),
+        crate::error::CoreError::Io { source, .. }
+            if source.kind() == std::io::ErrorKind::TimedOut =>
+        {
+            Refusal::TimedOut
+        }
+        other => Refusal::Said(vec![other.to_string()]),
+    }
+}
+
+/// A git read whose non-zero exit is git refusing, not answering — the
+/// status read the whole offer is derived from. Its words reach the person.
+pub fn read_required(root: &Path, args: &[&str]) -> Result<Vec<u8>, Failed> {
+    run(Hardened::git(args, Some(root)), Step::Read)
+}
+
+/// A git read of the checkout, under the read bound. Used where a non-zero
+/// exit is an answer rather than a failure — an unset config key, an
+/// unborn `HEAD` — and the caller says which.
+pub fn read(root: &Path, args: &[&str]) -> Result<Option<Vec<u8>>, Failed> {
+    let hardened = Hardened::git(args, Some(root)).timeout(Step::READ);
+    match hardened.run() {
+        Ok(output) if output.status.success() => Ok(Some(output.stdout)),
+        Ok(_) => Ok(None),
+        Err(error) => Err(Failed {
+            step: Step::Read,
+            refusal: refusal(&error),
+        }),
+    }
+}
+
+/// One line of git's answer, trimmed of the newline git ends it with.
+fn line(bytes: Vec<u8>) -> String {
+    String::from_utf8_lossy(&bytes).trim_end().to_owned()
+}
+
+/// The branch `HEAD` points at, or `None` where the checkout is on no
+/// branch. `git symbolic-ref --quiet HEAD` exits non-zero on a detached
+/// `HEAD`, which is the whole of the detection.
+pub fn head_branch(root: &Path) -> Result<Option<String>, Failed> {
+    let Some(bytes) = read(root, &["symbolic-ref", "--quiet", "--short", "HEAD"])? else {
+        return Ok(None);
+    };
+    let name = line(bytes);
+    Ok(match name.is_empty() {
+        true => None,
+        false => Some(name),
+    })
+}
+
+/// The remotes this repository declares, in git's order.
+pub fn remotes(root: &Path) -> Result<Vec<String>, Failed> {
+    let Some(bytes) = read(root, &["remote"])? else {
+        return Ok(Vec::new());
+    };
+    Ok(String::from_utf8_lossy(&bytes)
+        .lines()
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(str::to_owned)
+        .collect())
+}
+
+/// The remote the offer pushes to: the current branch's upstream remote;
+/// else `origin`; else the only remote when the project has exactly one;
+/// else none, and push and pull request are unavailable.
+///
+/// By rule and never by a prompt: the offer already asks one question, and
+/// a second one about a choice the repository itself answers would be a
+/// question with a right answer.
+pub fn choose_remote(root: &Path, branch: &str) -> Result<Option<Remote>, Failed> {
+    let upstream = read(
+        root,
+        &["config", "--get", &format!("branch.{branch}.remote")],
+    )?
+    .map(line)
+    .filter(|name| !name.is_empty());
+    let declared = remotes(root)?;
+    let name = match upstream.clone() {
+        Some(name) if declared.contains(&name) => Some(name),
+        // A branch configured to push to a remote the repository no longer
+        // declares is not a remote: falling through to the rest of the
+        // rule answers with one that exists, or with none.
+        _ => match declared.iter().any(|known| known == "origin") {
+            true => Some("origin".to_owned()),
+            false => match declared.as_slice() {
+                [only] => Some(only.clone()),
+                _ => None,
+            },
+        },
+    };
+    let Some(name) = name else {
+        return Ok(None);
+    };
+    let Some(url) = read(root, &["remote", "get-url", &name])?.map(line) else {
+        // A declared remote with no URL is not one this offer can push to
+        // or bind `gh` against.
+        return Ok(None);
+    };
+    // Tracked means this branch's own upstream is the remote that was
+    // chosen. A branch with no upstream that fell through to `origin` is
+    // not tracking it, and its first push has to say so.
+    let tracked = upstream.as_deref() == Some(name.as_str())
+        && read(
+            root,
+            &["config", "--get", &format!("branch.{branch}.merge")],
+        )?
+        .map(line)
+        .is_some_and(|value| !value.is_empty());
+    Ok(Some(Remote { name, url, tracked }))
+}
+
+/// The first free `kendex/renders`, `kendex/renders-2`, `kendex/renders-3`
+/// and so on.
+///
+/// Free means no local ref and no remote-tracking ref for the chosen
+/// remote already carries the name, both read from this repository. kendex
+/// runs no `git ls-remote`: it is a network call before a choice has even
+/// been made, and a name only the remote knows about surfaces as a refused
+/// push, which already has its own state.
+pub fn first_free_branch(root: &Path, remote: Option<&Remote>) -> Result<String, Failed> {
+    // `git show-ref` exits 1 with no output in a repository that carries no
+    // refs at all, which is the state a first write into a fresh `git init`
+    // reaches. Every name is free there.
+    let refs = read(root, &["show-ref"])?.unwrap_or_default();
+    let held: Vec<String> = String::from_utf8_lossy(&refs)
+        .lines()
+        .filter_map(|row| row.split_once(' ').map(|(_, name)| name.trim().to_owned()))
+        .collect();
+    let taken = |name: &str| {
+        let local = format!("refs/heads/{name}");
+        let tracking = remote.map(|remote| format!("refs/remotes/{}/{name}", remote.name));
+        held.iter()
+            .any(|got| *got == local || Some(got.as_str()) == tracking.as_deref())
+    };
+    let mut nth = 1u32;
+    loop {
+        let name = match nth {
+            1 => BRANCH.to_owned(),
+            n => format!("{BRANCH}-{n}"),
+        };
+        if !taken(&name) {
+            return Ok(name);
+        }
+        nth += 1;
+    }
+}
+
+/// The branch kendex opens a pull request from.
+pub const BRANCH: &str = "kendex/renders";
+
+/// The short name of the commit `HEAD` points at, or `None` in a
+/// repository with no commit yet — the state a first kendex write in a
+/// fresh `git init` reaches. Read before a commit, it is the commit a
+/// recovery would put the branch back to, and there is nothing to put it
+/// back to when there is none.
+pub fn previous_head(root: &Path) -> Result<Option<String>, Failed> {
+    Ok(read(root, &["rev-parse", "--short", "HEAD"])?
+        .map(line)
+        .filter(|sha| !sha.is_empty()))
+}
+
+/// The short name of the commit that was just made, for the line that
+/// reports it.
+pub fn head_short(root: &Path) -> Result<String, Failed> {
+    let bytes = run(
+        Hardened::git(&["rev-parse", "--short", "HEAD"], Some(root)),
+        Step::Read,
+    )?;
+    Ok(line(bytes))
+}
+
+/// The inventory a commit recorded, as the paths it names relative to the
+/// project root.
+///
+/// Read at `HEAD`, because the offer needs the paths a sweep has just
+/// removed and those are gone from the working tree by then. An unborn
+/// `HEAD`, a project with no inventory committed yet, and an inventory
+/// that will not parse all contribute nothing: none of them is a repository
+/// this offer cannot read, and none names a path to add.
+pub fn committed_inventory(root: &Path) -> Result<std::collections::BTreeSet<String>, Failed> {
+    let spec = format!("HEAD:{}", crate::engine::generated_paths::INVENTORY);
+    let Some(bytes) = read(root, &["show", &spec])? else {
+        return Ok(std::collections::BTreeSet::new());
+    };
+    Ok(serde_json::from_slice(&bytes).unwrap_or_default())
+}

--- a/crates/core/src/commit_offer/message.rs
+++ b/crates/core/src/commit_offer/message.rs
@@ -1,0 +1,18 @@
+//! The commit message kendex offers.
+//!
+//! The rule is the command, not a list, so no enumeration can fall out of
+//! date as the command surface changes.
+
+/// `chore: kendex <command>`, where `<command>` is what the person typed
+/// without its flags and arguments.
+///
+/// A subcommand is named with its group, because the group alone is not a
+/// command anybody can run: `chore: kendex marketplace subscribe`. A verb
+/// that delegates to another names itself, not the one it called —
+/// `kendex updates` runs `refresh`'s plan and its message says `updates`,
+/// because that is what the person ran.
+///
+/// The message has no body.
+pub fn default_message(command: &str) -> String {
+    format!("chore: kendex {}", command.trim())
+}

--- a/crates/core/src/commit_offer/mod.rs
+++ b/crates/core/src/commit_offer/mod.rs
@@ -315,13 +315,25 @@ pub struct Offer {
     pub new_branch: String,
 }
 
-/// Build the whole offer from a scan: choose the remote, probe `gh`, and
-/// pick the branch a pull request would use.
+/// Whether building the offer asks `gh` about the repository.
 ///
-/// Only a surface that is going to ask calls this. It costs one network
-/// call — the `gh` probe — and that probe runs only where a remote was
+/// `Skip` leaves the pull-request choice standing unprobed, and only a
+/// caller that will never take that choice may pass it: a flag that
+/// already answered `commit` or `push` needs the remote and nothing from
+/// `gh`, and should not wait on the network or on a sign-in it does not
+/// use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Probe {
+    Gh,
+    Skip,
+}
+
+/// Build the whole offer from a scan: choose the remote, probe `gh` where
+/// [`Probe::Gh`] asks for it, and pick the branch a pull request would use.
+///
+/// The probe is the one network call, and it runs only where a remote was
 /// chosen, so a project with no remote pays nothing for it.
-pub fn offer(scan: Scan, command: &str) -> std::result::Result<Offer, Failed> {
+pub fn offer(scan: Scan, command: &str, probe: Probe) -> std::result::Result<Offer, Failed> {
     let Some(branch) = scan.on_branch().map(str::to_owned) else {
         // Both callers check the branch state before they reach here: the
         // states it names are flagged, never offered.
@@ -337,6 +349,7 @@ pub fn offer(scan: Scan, command: &str) -> std::result::Result<Offer, Failed> {
             };
             (Err(why.clone()), Err(why), None)
         }
+        Some(_) if probe == Probe::Skip => (Ok(()), Ok(()), None),
         Some(remote) => match gh::probe(&remote.url, &branch) {
             Ok(open) => (Ok(()), Ok(()), open),
             Err(why) => (Ok(()), Err(why), None),

--- a/crates/core/src/commit_offer/mod.rs
+++ b/crates/core/src/commit_offer/mod.rs
@@ -1,0 +1,355 @@
+//! The commit, push and pull-request offer that follows a kendex write in a
+//! git project.
+//!
+//! kendex writes files into a checkout, and a project commits those files
+//! so that a clone works without kendex. This module is what asks what to
+//! do with them, and it is the whole of that answer for both surfaces: the
+//! CLI and the app call the same scan, take the same choices and read the
+//! same failures, so neither can offer something the other would refuse.
+//!
+//! **The offer is explicit.** kendex commits, pushes or opens a pull
+//! request only after a person chose that in this run. There is no setting,
+//! flag or state that makes any of the three happen without a choice, and
+//! leaving the files as diffs is a choice of the same standing as the other
+//! three.
+//!
+//! **kendex stages only the files it owns whole.** A file the person wrote
+//! is never staged and never committed, and a shared configuration file
+//! kendex writes one key in is not a file it owns whole: git has no way to
+//! commit one key, so committing such a path would commit the person's
+//! edits with kendex's. [`crate::engine::GeneratedPaths`] is where that
+//! split is made, once, for the inventory and for this.
+//!
+//! **kendex never undoes.** It does not revert a commit, does not move a
+//! branch ref backwards, does not reset, and does not stash. The two
+//! cleanups here — unstaging what its own `git add` staged, and removing an
+//! empty branch it made a moment earlier — are kendex clearing its own
+//! leftovers: no commit exists to undo, and no branch ref moves backwards.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::env::Env;
+use crate::model::Scope;
+use crate::process::{DEFAULT_TIMEOUT, INTERACTIVE_TIMEOUT};
+
+mod gh;
+mod git;
+mod message;
+mod paths;
+mod pathspec;
+mod run;
+
+pub use gh::{OpenPullRequest, probe};
+pub use git::previous_head;
+pub use message::default_message;
+pub use run::{
+    CommitFailure, Committed, Opened, Pushed, abandon_branch, body, commit, open_pull_request,
+    push, push_head, start_branch,
+};
+
+#[cfg(test)]
+mod tests;
+
+/// One step of the offer: the bound it runs under, and the name a timeout
+/// of it is reported by.
+///
+/// A bound per step rather than one for the module: a repository's own
+/// pre-commit hook can run a test suite, and a bound short enough for a
+/// local read would kill a hook that was working.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Step {
+    /// A git read the offer is built from: status, branch, remote, refs.
+    Read,
+    Stage,
+    Commit,
+    Unstage,
+    Branch,
+    SwitchBack,
+    RemoveBranch,
+    Push,
+    Probe,
+    PullRequest,
+}
+
+impl Step {
+    /// A local read that takes longer than this is a broken checkout.
+    pub const READ: Duration = Duration::from_secs(10);
+    /// A repository's own pre-commit hook can run a test suite.
+    pub const COMMIT: Duration = Duration::from_secs(300);
+    /// The probe runs before the offer is drawn, so a person is waiting on
+    /// it with nothing on screen.
+    pub const PROBE: Duration = Duration::from_secs(15);
+
+    pub fn bound(self) -> Duration {
+        match self {
+            Step::Read => Step::READ,
+            // Local writes over the set, with no hook to wait on.
+            Step::Stage | Step::Unstage | Step::Branch | Step::SwitchBack | Step::RemoveBranch => {
+                INTERACTIVE_TIMEOUT
+            }
+            Step::Commit => Step::COMMIT,
+            Step::Probe => Step::PROBE,
+            Step::Push | Step::PullRequest => DEFAULT_TIMEOUT,
+        }
+    }
+
+    /// How a timeout of this step names it: `<name> did not finish within
+    /// N seconds`.
+    pub fn name(self) -> &'static str {
+        match self {
+            Step::Read => "the check",
+            Step::Stage => "the staging",
+            Step::Commit => "the commit",
+            Step::Unstage => "the unstaging",
+            Step::Branch => "the branch",
+            Step::SwitchBack => "the switch back",
+            Step::RemoveBranch => "removing the branch",
+            Step::Push => "the push",
+            Step::Probe => "the check for an open pull request",
+            Step::PullRequest => "the pull request",
+        }
+    }
+
+    /// The bound in whole seconds, for the line that reports a timeout.
+    pub fn seconds(self) -> u64 {
+        self.bound().as_secs()
+    }
+}
+
+/// What a step said when it refused, or the bound it ran past.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Refusal {
+    /// The program never ran: it is not on this machine, or what it needed
+    /// to run could not be written. Nothing a program that did start can
+    /// fail with belongs here, because the choice this decides — `gh is
+    /// not installed` against `gh said:` — turns on exactly that.
+    NotStarted(String),
+    /// The program's own words, whole, one line at a time, in order:
+    /// stderr first, because git puts a hook's own output there and prints
+    /// nothing on stdout when a hook refuses, then stdout for a program
+    /// that writes diagnostics to it, as `gh` does.
+    ///
+    /// Nothing is summarised, reworded, truncated to a first line, or
+    /// matched against a pattern to decide what it means.
+    Said(Vec<String>),
+    /// The step ran past its bound. Whether it finished is not known here.
+    TimedOut,
+}
+
+/// A step that did not go through, and which step it was.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Failed {
+    pub step: Step,
+    pub refusal: Refusal,
+}
+
+impl Failed {
+    /// The words to show under this failure, empty where the step ran out
+    /// of time and said nothing.
+    pub fn said(&self) -> &[String] {
+        match &self.refusal {
+            Refusal::Said(lines) => lines,
+            Refusal::NotStarted(line) => std::slice::from_ref(line),
+            Refusal::TimedOut => &[],
+        }
+    }
+
+    pub fn timed_out(&self) -> bool {
+        self.refusal == Refusal::TimedOut
+    }
+}
+
+/// One changed path the offer covers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Owned {
+    /// Relative to the project root, with `/` separators — the spelling
+    /// git reports and the spelling both surfaces print.
+    pub path: String,
+    /// git reports this path as untracked, which is exactly a `git status`
+    /// row beginning `??`. `git commit --only` refuses a path git does not
+    /// track, so these are staged first; a path the person already staged
+    /// is not one of them and is neither added nor unstaged.
+    pub untracked: bool,
+}
+
+/// Where the checkout stands. Two of the three are states the offer cannot
+/// be made in: a commit would land somewhere nobody asked for.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Branch {
+    On(String),
+    Detached,
+    InProgress(Operation),
+}
+
+/// A git operation the checkout is in the middle of.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Operation {
+    Merge,
+    Rebase,
+    CherryPick,
+    Bisect,
+}
+
+impl Operation {
+    /// How a line names it: `a rebase is in progress`.
+    pub fn article(self) -> &'static str {
+        match self {
+            Operation::Merge => "a merge",
+            Operation::Rebase => "a rebase",
+            Operation::CherryPick => "a cherry-pick",
+            Operation::Bisect => "a bisect",
+        }
+    }
+}
+
+/// What one read of the project found: the paths the offer covers, and the
+/// state of the checkout it would commit in.
+///
+/// The cheap half of the offer. It runs one `git status` over the whole
+/// checkout and reads the branch, and nothing else — no remote, no network
+/// — so a run that will not ask (a flag already answered, or nobody is
+/// there to ask) pays for none of that.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Scan {
+    pub root: PathBuf,
+    /// The files kendex owns whole that git reports as changed, sorted.
+    pub owned: Vec<Owned>,
+    /// The shared configuration files kendex writes one key in that git
+    /// reports as changed, sorted. Named to the person and left alone.
+    pub shared: Vec<String>,
+    /// How many other paths in this repository changed. The person's own
+    /// changes, which the offer counts and never touches.
+    pub others: usize,
+    pub branch: Branch,
+}
+
+impl Scan {
+    pub fn count(&self) -> usize {
+        self.owned.len()
+    }
+
+    /// The branch a commit would land on, or `None` in a state where the
+    /// offer cannot be made.
+    pub fn on_branch(&self) -> Option<&str> {
+        match &self.branch {
+            Branch::On(name) => Some(name),
+            Branch::Detached | Branch::InProgress(_) => None,
+        }
+    }
+}
+
+/// Read the project. `None` where there is nothing to offer about: the
+/// scope is not a project, the project is not a checkout, or nothing
+/// kendex owns changed.
+///
+/// The offer setting is deliberately not read here. It turns off the
+/// asking, not the choices, so a flag that names a choice still runs one —
+/// [`asking`] is what a surface consults before it asks.
+pub fn scan(
+    scope: &Scope,
+    generated: &crate::engine::GeneratedPaths,
+) -> std::result::Result<Option<Scan>, Failed> {
+    let Scope::Project { root } = scope else {
+        return Ok(None);
+    };
+    if !root.join(".git").exists() {
+        return Ok(None);
+    }
+    paths::scan(root, generated)
+}
+
+/// Whether this machine wants to be asked. Machine-local, like every other
+/// field in the app settings: whether a person is asked is theirs, not
+/// their project's.
+pub fn asking(env: &Env) -> bool {
+    crate::settings::load(env)
+        .map(|settings| settings.commit_offer.asking())
+        .unwrap_or(true)
+}
+
+/// The remote the offer pushes to, chosen by rule rather than by a prompt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Remote {
+    pub name: String,
+    /// The remote's URL. Every `gh` call is bound to it with `--repo`, so
+    /// a project whose `origin` is one host and whose second remote is
+    /// GitHub cannot have `gh` answer about a repository the push would
+    /// never reach.
+    pub url: String,
+    /// The current branch already tracks this remote, so a push needs no
+    /// `--set-upstream`.
+    pub tracked: bool,
+}
+
+/// Why a choice is not on offer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Unavailable {
+    NoRemote,
+    RemoteNotDecidable,
+    GhMissing,
+    /// gh's own first line, so a case nobody anticipated still names
+    /// itself rather than reading as one kendex knows.
+    GhSaid(String),
+}
+
+/// The offer, built and ready to draw: the paths, the choices that stand,
+/// and the reason for each one that does not.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Offer {
+    pub scan: Scan,
+    pub branch: String,
+    pub remote: Option<Remote>,
+    /// `Err` where the choice is not on offer, carrying its reason.
+    pub push: std::result::Result<(), Unavailable>,
+    pub pull_request: std::result::Result<(), Unavailable>,
+    /// A pull request already open for the current branch. Where there is
+    /// one, `push` adds a commit to it and the `pr` choice is not offered.
+    pub open: Option<OpenPullRequest>,
+    /// The default message, editable on both surfaces before the commit
+    /// runs: a repository's commit-msg hook decides what it will accept
+    /// and kendex cannot know that rule.
+    pub message: String,
+    /// The branch the `pr` route would make, and the branch the
+    /// refused-push recovery would push to. Picked by the first-free rule.
+    pub new_branch: String,
+}
+
+/// Build the whole offer from a scan: choose the remote, probe `gh`, and
+/// pick the branch a pull request would use.
+///
+/// Only a surface that is going to ask calls this. It costs one network
+/// call — the `gh` probe — and that probe runs only where a remote was
+/// chosen, so a project with no remote pays nothing for it.
+pub fn offer(scan: Scan, command: &str) -> std::result::Result<Offer, Failed> {
+    let Some(branch) = scan.on_branch().map(str::to_owned) else {
+        // Both callers check the branch state before they reach here: the
+        // states it names are flagged, never offered.
+        unreachable!("an offer was built for a checkout with no branch");
+    };
+    let chosen = git::choose_remote(&scan.root, &branch)?;
+    let new_branch = git::first_free_branch(&scan.root, chosen.as_ref())?;
+    let (push, pull_request, open) = match &chosen {
+        None => {
+            let why = match git::remotes(&scan.root)?.is_empty() {
+                true => Unavailable::NoRemote,
+                false => Unavailable::RemoteNotDecidable,
+            };
+            (Err(why.clone()), Err(why), None)
+        }
+        Some(remote) => match gh::probe(&remote.url, &branch) {
+            Ok(open) => (Ok(()), Ok(()), open),
+            Err(why) => (Ok(()), Err(why), None),
+        },
+    };
+    Ok(Offer {
+        branch,
+        remote: chosen,
+        push,
+        pull_request,
+        open,
+        message: message::default_message(command),
+        new_branch,
+        scan,
+    })
+}

--- a/crates/core/src/commit_offer/paths.rs
+++ b/crates/core/src/commit_offer/paths.rs
@@ -1,0 +1,202 @@
+//! Which changed paths the offer covers, and which it only counts.
+//!
+//! git decides what changed, in one call over the whole checkout. `git
+//! status` takes no `--pathspec-from-file`, and a pathspec argument per
+//! path would not fit a Windows command line, so the call is unscoped and
+//! the rows are matched against the set here.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use crate::engine::GeneratedPaths;
+
+use super::{Branch, Failed, Operation, Owned, Scan, git};
+
+/// One `git status` row: the two status letters and the path.
+struct Row<'a> {
+    x: u8,
+    y: u8,
+    path: &'a [u8],
+}
+
+impl Row<'_> {
+    fn untracked(&self) -> bool {
+        self.x == b'?' && self.y == b'?'
+    }
+
+    fn deleted(&self) -> bool {
+        self.x == b'D' || self.y == b'D'
+    }
+}
+
+/// Read the project: what changed, and where the checkout stands.
+///
+/// A read the offer is built from that would not run leaves the offer
+/// unbuildable, and its words reach the person as that step's failure, the
+/// way every other step's do.
+pub fn scan(root: &Path, generated: &GeneratedPaths) -> Result<Option<Scan>, Failed> {
+    let whole = generated.owned(root);
+    let owned = relative(root, &whole);
+    let shared = relative(root, &generated.shared);
+    let status = git::read_required(
+        root,
+        &["status", "--porcelain=v1", "-z", "--untracked-files=all"],
+    )?;
+    // Read once and only where it can matter: the rule it feeds adds the
+    // paths a sweep removed, and a sweep's removals are deletions.
+    let mut committed: Option<BTreeSet<String>> = None;
+    let mut ours: Vec<Owned> = Vec::new();
+    let mut theirs: Vec<String> = Vec::new();
+    let mut others = 0usize;
+    for row in rows(&status) {
+        let Some(path) = text(row.path) else {
+            // A path git reports in bytes that are not text is not a path
+            // this offer can pass back to git as a pathspec, and it is not
+            // one kendex wrote: every path kendex renders is text. It is
+            // one of the person's own changed files.
+            others += 1;
+            continue;
+        };
+        if owned.contains(&path) {
+            ours.push(Owned {
+                untracked: row.untracked(),
+                path,
+            });
+            continue;
+        }
+        if shared.contains(&path) {
+            theirs.push(path);
+            continue;
+        }
+        // A path that left the inventory and is gone from the working tree
+        // is a sweep's removal, and the deletion is part of the same
+        // change. Only a deleted one: a path that left the inventory but
+        // still exists left it for another reason, most often a hand edit
+        // putting the item in `Conflict`, and that file is the person's.
+        if row.deleted() {
+            let inventory = match &committed {
+                Some(read) => read,
+                None => committed.insert(git::committed_inventory(root)?),
+            };
+            if inventory.contains(&path) {
+                ours.push(Owned {
+                    untracked: row.untracked(),
+                    path,
+                });
+                continue;
+            }
+        }
+        others += 1;
+    }
+    if ours.is_empty() {
+        return Ok(None);
+    }
+    ours.sort_by(|a, b| a.path.cmp(&b.path));
+    ours.dedup_by(|a, b| a.path == b.path);
+    theirs.sort();
+    theirs.dedup();
+    Ok(Some(Scan {
+        root: root.to_owned(),
+        owned: ours,
+        shared: theirs,
+        others,
+        branch: branch(root)?,
+    }))
+}
+
+/// Where the checkout stands, and whether a commit could land at all.
+fn branch(root: &Path) -> Result<Branch, Failed> {
+    // The operation comes first: a rebase leaves `HEAD` detached, and
+    // saying so instead of naming the rebase would send the person looking
+    // for a branch rather than for the operation they are in the middle of.
+    if let Some(operation) = in_progress(root)? {
+        return Ok(Branch::InProgress(operation));
+    }
+    Ok(match git::head_branch(root)? {
+        Some(name) => Branch::On(name),
+        None => Branch::Detached,
+    })
+}
+
+/// The marker a git operation leaves in the git directory while it runs.
+///
+/// Read from `--git-dir` rather than from `<root>/.git`, which is a file
+/// rather than a directory in a linked work tree.
+fn in_progress(root: &Path) -> Result<Option<Operation>, Failed> {
+    let Some(bytes) = git::read(root, &["rev-parse", "--absolute-git-dir"])? else {
+        return Ok(None);
+    };
+    let Some(dir) = text(String::from_utf8_lossy(&bytes).trim_end().as_bytes()) else {
+        return Ok(None);
+    };
+    let dir = Path::new(&dir);
+    for (marker, operation) in [
+        ("MERGE_HEAD", Operation::Merge),
+        ("REBASE_HEAD", Operation::Rebase),
+        ("rebase-merge", Operation::Rebase),
+        ("rebase-apply", Operation::Rebase),
+        ("CHERRY_PICK_HEAD", Operation::CherryPick),
+        ("BISECT_LOG", Operation::Bisect),
+    ] {
+        if dir.join(marker).exists() {
+            return Ok(Some(operation));
+        }
+    }
+    Ok(None)
+}
+
+/// The rows of one `git status --porcelain=v1 -z` answer.
+///
+/// `-z` because a path may hold any byte but NUL, and because it turns off
+/// the quoting git otherwise applies to an unusual name. A rename or copy
+/// row is followed by a second NUL-terminated field naming where the path
+/// came from; that origin is a change of its own and is classified like
+/// any other row.
+fn rows(status: &[u8]) -> Vec<Row<'_>> {
+    let mut rows = Vec::new();
+    let mut fields = status.split(|byte| *byte == 0).filter(|f| !f.is_empty());
+    while let Some(field) = fields.next() {
+        // `XY ` then the path: three bytes of prefix, and a shorter field
+        // is not a row git wrote.
+        if field.len() < 4 {
+            continue;
+        }
+        let (x, y) = (field[0], field[1]);
+        rows.push(Row {
+            x,
+            y,
+            path: &field[3..],
+        });
+        if x == b'R' || x == b'C' {
+            let Some(origin) = fields.next() else {
+                break;
+            };
+            // Where the path came from: gone from the working tree under
+            // that name, which is what a deletion is.
+            rows.push(Row {
+                x: b'D',
+                y: b' ',
+                path: origin,
+            });
+        }
+    }
+    rows
+}
+
+/// A path git wrote, as text. `None` where the bytes are not text: such a
+/// path is not one kendex rendered, and it cannot travel back to git as a
+/// pathspec through a file this module writes as text.
+fn text(bytes: &[u8]) -> Option<String> {
+    String::from_utf8(bytes.to_vec()).ok()
+}
+
+/// The paths under `root`, spelled the way `git status` spells them.
+fn relative<'a>(
+    root: &Path,
+    paths: impl IntoIterator<Item = &'a std::path::PathBuf>,
+) -> BTreeSet<String> {
+    paths
+        .into_iter()
+        .filter_map(|path| path.strip_prefix(root).ok().map(crate::paths::slashed))
+        .collect()
+}

--- a/crates/core/src/commit_offer/paths.rs
+++ b/crates/core/src/commit_offer/paths.rs
@@ -150,8 +150,9 @@ fn in_progress(root: &Path) -> Result<Option<Operation>, Failed> {
 /// `-z` because a path may hold any byte but NUL, and because it turns off
 /// the quoting git otherwise applies to an unusual name. A rename or copy
 /// row is followed by a second NUL-terminated field naming where the path
-/// came from; that origin is a change of its own and is classified like
-/// any other row.
+/// came from. A rename's origin is gone from the working tree under that
+/// name, which is what a deletion is, and is classified like any other
+/// row; a copy's origin is still there and is no change of its own.
 fn rows(status: &[u8]) -> Vec<Row<'_>> {
     let mut rows = Vec::new();
     let mut fields = status.split(|byte| *byte == 0).filter(|f| !f.is_empty());
@@ -171,13 +172,13 @@ fn rows(status: &[u8]) -> Vec<Row<'_>> {
             let Some(origin) = fields.next() else {
                 break;
             };
-            // Where the path came from: gone from the working tree under
-            // that name, which is what a deletion is.
-            rows.push(Row {
-                x: b'D',
-                y: b' ',
-                path: origin,
-            });
+            if x == b'R' {
+                rows.push(Row {
+                    x: b'D',
+                    y: b' ',
+                    path: origin,
+                });
+            }
         }
     }
     rows
@@ -199,4 +200,32 @@ fn relative<'a>(
         .into_iter()
         .filter_map(|path| path.strip_prefix(root).ok().map(crate::paths::slashed))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rows;
+
+    /// git's `--porcelain=v1 -z` rows as documented: a rename or copy row
+    /// is followed by its origin field. A rename's origin is emitted as a
+    /// deletion; a copy's origin is consumed and is no row of its own.
+    #[test]
+    fn a_renames_origin_is_a_deletion_and_a_copys_is_consumed() {
+        let status = b"R  new.md\0old.md\0C  copy.md\0src.md\0?? loose.md\0";
+        let seen: Vec<(u8, u8, &str)> = rows(status)
+            .iter()
+            .map(|row| (row.x, row.y, std::str::from_utf8(row.path).unwrap()))
+            .collect();
+        assert_eq!(
+            seen,
+            [
+                (b'R', b' ', "new.md"),
+                (b'D', b' ', "old.md"),
+                (b'C', b' ', "copy.md"),
+                (b'?', b'?', "loose.md"),
+            ]
+        );
+        assert!(rows(status)[1].deleted());
+        assert!(rows(status)[3].untracked());
+    }
 }

--- a/crates/core/src/commit_offer/pathspec.rs
+++ b/crates/core/src/commit_offer/pathspec.rs
@@ -1,0 +1,78 @@
+//! How the set reaches git.
+//!
+//! The set runs to a thousand paths in a large project, tens of kilobytes
+//! of path text. Windows caps a command line at 32,767 characters and
+//! kendex supports Windows, so no step passes the set as arguments: it is
+//! written to a file in the system temp directory, NUL-separated, and
+//! passed with `--pathspec-from-file` and `--pathspec-file-nul`. `git add`,
+//! `git commit` and `git reset` all take it.
+//!
+//! The file is outside the checkout, so it is never a path the offer could
+//! then find, and it is removed when the step ends.
+
+use std::io::Write;
+use std::path::PathBuf;
+
+use super::{Failed, Refusal, Step};
+
+/// A NUL-separated pathspec file, removed when it goes out of scope.
+pub struct Spec {
+    path: PathBuf,
+}
+
+impl Spec {
+    /// Write the paths for one step.
+    pub fn write(paths: &[String], step: Step) -> Result<Spec, Failed> {
+        let mut file = tempfile::Builder::new()
+            .prefix("kendex-paths-")
+            .tempfile()
+            .map_err(|error| failure(step, &error))?;
+        for path in paths {
+            file.write_all(path.as_bytes())
+                .and_then(|()| file.write_all(&[0]))
+                .map_err(|error| failure(step, &error))?;
+        }
+        file.flush().map_err(|error| failure(step, &error))?;
+        // Kept by path rather than by handle: git opens the file itself,
+        // and Windows will not open a second handle to a file this process
+        // still holds exclusively.
+        let (_, path) = file.keep().map_err(|error| failure(step, &error.error))?;
+        Ok(Spec { path })
+    }
+
+    /// The two arguments git reads the file through.
+    pub fn args(&self) -> [String; 2] {
+        [
+            format!("--pathspec-from-file={}", self.path.display()),
+            "--pathspec-file-nul".to_owned(),
+        ]
+    }
+
+    /// The git-wide option every step passing this file carries, placed
+    /// before the subcommand, where git reads it.
+    ///
+    /// `--pathspec-file-nul` fixes the separator, not the matching: git
+    /// still reads each entry as a pathspec, so a rendered path holding
+    /// `[`, `*` or `?` would match a different file and put a path in the
+    /// commit that was never in the set. This takes every entry as the
+    /// path it is, including one beginning with the `:` a pathspec magic
+    /// prefix starts with.
+    pub const LITERAL: &'static str = "--literal-pathspecs";
+}
+
+impl Drop for Spec {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// A pathspec file that could not be written is that step failing before
+/// it ran: nothing was staged, nothing was committed.
+fn failure(step: Step, error: &std::io::Error) -> Failed {
+    Failed {
+        step,
+        refusal: Refusal::Said(vec![format!(
+            "the list of paths for this step could not be written: {error}"
+        )]),
+    }
+}

--- a/crates/core/src/commit_offer/run.rs
+++ b/crates/core/src/commit_offer/run.rs
@@ -1,0 +1,275 @@
+//! What each choice runs, and what it leaves behind when a step refuses.
+//!
+//! `git commit --only -- <paths>` is a partial commit, and five of its
+//! behaviours decide the shape here. It refuses a path git does not track,
+//! so the untracked members are staged first. It commits the working
+//! tree's content for the named paths, not the index's, so a person who
+//! staged an older copy of a render gets the copy kendex wrote. It commits
+//! a deletion of a named path that is gone, which is how a sweep's
+//! removals land. It builds a temporary index and exports it to the hooks,
+//! so a hook running `git diff --cached` sees the named paths and nothing
+//! else and a refused commit leaves the person's own staged changes
+//! exactly as they were. And it commits the whole of each file it names,
+//! which is why the shared `edits` targets are out of the set.
+
+use std::path::Path;
+
+use crate::engine::GeneratedPaths;
+use crate::process::Hardened;
+
+use super::pathspec::Spec;
+use super::{Failed, Refusal, Step, git};
+
+/// What the commit did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Committed {
+    /// The re-read set was empty: the files changed since the offer, so
+    /// there was nothing left to commit and no commit was made.
+    Nothing,
+    Made {
+        /// The short name of the commit, for the line that reports it.
+        sha: String,
+        files: usize,
+    },
+}
+
+/// What a push did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Pushed {
+    pub remote: String,
+    pub branch: String,
+}
+
+/// What opening a pull request did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Opened {
+    pub url: String,
+}
+
+/// The commit sequence: stage the set's untracked members, then commit the
+/// whole set.
+///
+/// The set is re-derived immediately before the commit runs. A path that no
+/// longer differs is dropped, and when none is left the run reports that
+/// nothing was committed rather than making an empty one.
+///
+/// The one mark a refusal leaves is the `git add`: a path that was
+/// untracked stays staged. kendex unstages exactly the paths it staged, so
+/// the index ends as it began. It unstages with `git reset`, not `git
+/// restore --staged`, which resolves `HEAD` and exits 128 in a repository
+/// with no commit yet — the state a first kendex write in a fresh `git
+/// init` reaches whenever a hook refuses that first commit.
+pub fn commit(
+    root: &Path,
+    generated: &GeneratedPaths,
+    message: &str,
+) -> Result<Committed, CommitFailure> {
+    let Some(scan) = super::paths::scan(root, generated).map_err(CommitFailure::from)? else {
+        return Ok(Committed::Nothing);
+    };
+    let files = scan.owned.len();
+    let untracked: Vec<String> = scan
+        .owned
+        .iter()
+        .filter(|owned| owned.untracked)
+        .map(|owned| owned.path.clone())
+        .collect();
+    let all: Vec<String> = scan.owned.iter().map(|owned| owned.path.clone()).collect();
+    stage(root, &untracked).map_err(CommitFailure::from)?;
+    match make(root, &all, message) {
+        Ok(()) => Ok(Committed::Made {
+            sha: git::head_short(root).map_err(CommitFailure::from)?,
+            files,
+        }),
+        Err(failed) => Err(CommitFailure {
+            // Both facts reach the person: the refusal that stopped the
+            // commit, and — where the cleanup could not put the index back
+            // — that kendex own paths are still staged.
+            still_staged: unstage(root, &untracked).err().map(|_| untracked.len()),
+            failed,
+        }),
+    }
+}
+
+/// A commit that did not happen, and what it left behind.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommitFailure {
+    pub failed: Failed,
+    /// How many paths kendex staged and could not then unstage. They are
+    /// still staged, against the rule that the index ends as it began.
+    pub still_staged: Option<usize>,
+}
+
+impl From<Failed> for CommitFailure {
+    fn from(failed: Failed) -> CommitFailure {
+        CommitFailure {
+            failed,
+            still_staged: None,
+        }
+    }
+}
+
+fn stage(root: &Path, untracked: &[String]) -> Result<(), Failed> {
+    if untracked.is_empty() {
+        return Ok(());
+    }
+    let spec = Spec::write(untracked, Step::Stage)?;
+    let mut args = vec![Spec::LITERAL.to_owned(), "add".to_owned()];
+    args.extend(spec.args());
+    git::run(Hardened::git(&borrowed(&args), Some(root)), Step::Stage)?;
+    Ok(())
+}
+
+fn make(root: &Path, all: &[String], message: &str) -> Result<(), Failed> {
+    let spec = Spec::write(all, Step::Commit)?;
+    let mut args = vec![
+        Spec::LITERAL.to_owned(),
+        "commit".to_owned(),
+        "--only".to_owned(),
+    ];
+    args.extend(spec.args());
+    args.push("-m".to_owned());
+    args.push(message.to_owned());
+    git::run(Hardened::git(&borrowed(&args), Some(root)), Step::Commit)?;
+    Ok(())
+}
+
+/// Put the index back the way it was. A cleanup that itself refuses leaves
+/// kendex's own paths staged, against the rule that the index ends as it
+/// began, so it is reported rather than swallowed under the refusal that
+/// led to it.
+fn unstage(root: &Path, untracked: &[String]) -> Result<(), Failed> {
+    if untracked.is_empty() {
+        return Ok(());
+    }
+    let spec = Spec::write(untracked, Step::Unstage)?;
+    let mut args = vec![
+        Spec::LITERAL.to_owned(),
+        "reset".to_owned(),
+        "--quiet".to_owned(),
+    ];
+    args.extend(spec.args());
+    git::run(Hardened::git(&borrowed(&args), Some(root)), Step::Unstage)?;
+    Ok(())
+}
+
+/// Push the branch the commit landed on.
+pub fn push(root: &Path, remote: &str, branch: &str, tracked: bool) -> Result<Pushed, Failed> {
+    let mut args = vec!["push"];
+    if !tracked {
+        args.push("--set-upstream");
+    }
+    args.push(remote);
+    args.push(branch);
+    git::run(Hardened::git(&args, Some(root)), Step::Push)?;
+    Ok(Pushed {
+        remote: remote.to_owned(),
+        branch: branch.to_owned(),
+    })
+}
+
+/// Push a commit that already exists to a branch of its own, without
+/// moving the branch it is on.
+///
+/// This is the recovery a refused push offers, and it pushes rather than
+/// making a branch locally so it cannot fast-forward a branch somebody
+/// else named: `<branch>` is picked by the first-free rule, and a name only
+/// the remote knows about surfaces as a second refused push.
+pub fn push_head(root: &Path, remote: &str, branch: &str) -> Result<Pushed, Failed> {
+    git::run(
+        Hardened::git(
+            &["push", remote, &format!("HEAD:refs/heads/{branch}")],
+            Some(root),
+        ),
+        Step::Push,
+    )?;
+    Ok(Pushed {
+        remote: remote.to_owned(),
+        branch: branch.to_owned(),
+    })
+}
+
+/// Move the checkout to the branch a pull request will be opened from,
+/// before anything is committed — so the branch the person was on gains no
+/// commit and needs nothing undone.
+pub fn start_branch(root: &Path, branch: &str) -> Result<(), Failed> {
+    git::run(
+        Hardened::git(&["switch", "-c", branch], Some(root)),
+        Step::Branch,
+    )?;
+    Ok(())
+}
+
+/// Put the checkout back and take away the branch kendex made a moment
+/// earlier, after a commit on it refused.
+///
+/// Not an undo: no commit exists to undo, and no branch ref moves
+/// backwards. It is kendex clearing its own leftover, the same as unstaging
+/// its own `git add`. A step of it that fails is reported and the run stops
+/// there rather than trying anything else.
+pub fn abandon_branch(root: &Path, branch: &str) -> Result<(), Failed> {
+    git::run(
+        Hardened::git(&["switch", "-"], Some(root)),
+        Step::SwitchBack,
+    )?;
+    git::run(
+        Hardened::git(&["branch", "-d", branch], Some(root)),
+        Step::RemoveBranch,
+    )?;
+    Ok(())
+}
+
+/// The pull request's body: two lines, no more.
+pub fn body(files: usize) -> String {
+    format!("kendex wrote these files.\nFiles: {files}")
+}
+
+/// Open the pull request. `--repo` binds it to the remote the offer chose,
+/// so it cannot be opened against a repository the push never reached.
+///
+/// The title and body are passed rather than left out: `gh pr create` with
+/// no terminal to prompt at refuses without them.
+pub fn open_pull_request(
+    repo: &str,
+    head: &str,
+    base: &str,
+    title: &str,
+    files: usize,
+) -> Result<Opened, Failed> {
+    let stdout = git::run(
+        Hardened::gh(&[
+            "pr",
+            "create",
+            "--repo",
+            repo,
+            "--head",
+            head,
+            "--base",
+            base,
+            "--title",
+            title,
+            "--body",
+            &body(files),
+        ]),
+        Step::PullRequest,
+    )?;
+    // `gh` prints the pull request's URL on stdout. A `gh` that exits zero
+    // and prints nothing is a pull request kendex cannot name, which is
+    // that step failing to produce what it was asked for.
+    let url = String::from_utf8_lossy(&stdout)
+        .lines()
+        .map(str::trim)
+        .rfind(|line| !line.is_empty())
+        .map(str::to_owned);
+    match url {
+        Some(url) => Ok(Opened { url }),
+        None => Err(Failed {
+            step: Step::PullRequest,
+            refusal: Refusal::Said(vec!["gh reported no pull request address".to_owned()]),
+        }),
+    }
+}
+
+fn borrowed(args: &[String]) -> Vec<&str> {
+    args.iter().map(String::as_str).collect()
+}

--- a/crates/core/src/commit_offer/tests.rs
+++ b/crates/core/src/commit_offer/tests.rs
@@ -1,0 +1,718 @@
+//! One control per state of the offer that this module detects, driven by
+//! a real repository. The two `gh` steps are driven through the CLI in
+//! `crates/cli/tests/commit_offer_cli.rs`, where a fake `gh` can be put on
+//! the child's `PATH`; here their failure mapping is what is proved.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::*;
+use crate::engine::GeneratedPaths;
+use crate::engine::generated_paths::INVENTORY;
+use crate::error::CoreError;
+use crate::process::Hardened;
+
+/// The message is the command the person typed, with nothing enumerated:
+/// a group and its subcommand together, because the group alone is not a
+/// command anybody can run.
+#[test]
+fn the_message_is_the_command_and_nothing_else() {
+    for (typed, expected) in [
+        ("refresh", "chore: kendex refresh"),
+        (
+            "marketplace subscribe",
+            "chore: kendex marketplace subscribe",
+        ),
+        ("source add", "chore: kendex source add"),
+        ("updates", "chore: kendex updates"),
+        (" apply ", "chore: kendex apply"),
+    ] {
+        assert_eq!(default_message(typed), expected, "{typed:?}");
+    }
+    assert_eq!(body(12), "kendex wrote these files.\nFiles: 12");
+}
+
+/// The timeouts table: each step's bound and the name its timeout line
+/// carries.
+#[test]
+fn every_step_has_the_bound_the_design_gives_it() {
+    for (step, seconds, name) in [
+        (Step::Read, 10, "the check"),
+        (Step::Stage, 30, "the staging"),
+        (Step::Unstage, 30, "the unstaging"),
+        (Step::Branch, 30, "the branch"),
+        (Step::SwitchBack, 30, "the switch back"),
+        (Step::RemoveBranch, 30, "removing the branch"),
+        (Step::Commit, 300, "the commit"),
+        (Step::Push, 120, "the push"),
+        (Step::Probe, 15, "the check for an open pull request"),
+        (Step::PullRequest, 120, "the pull request"),
+    ] {
+        assert_eq!(step.seconds(), seconds, "{step:?}");
+        assert_eq!(step.name(), name, "{step:?}");
+    }
+}
+
+/// A call that produced no exit status is one of three answers, and each
+/// is drawn differently: a program that is not there, one that ran past
+/// its bound, and one whose pipes broke.
+#[test]
+fn a_call_with_no_exit_status_is_told_apart_by_what_stopped_it() {
+    let missing = CoreError::not_started("gh pr list", "No such file or directory");
+    assert!(matches!(git::refusal(&missing), Refusal::NotStarted(_)));
+    let late = CoreError::io(
+        "git commit",
+        std::io::Error::new(std::io::ErrorKind::TimedOut, "no result after 300s"),
+    );
+    assert_eq!(git::refusal(&late), Refusal::TimedOut);
+    let broken = CoreError::io("git commit", std::io::Error::other("pipe closed"));
+    assert!(matches!(git::refusal(&broken), Refusal::Said(lines) if lines.len() == 1));
+    // The words a failure carries: none for a timeout, the reason for a
+    // program that never started.
+    let timed_out = Failed {
+        step: Step::Commit,
+        refusal: Refusal::TimedOut,
+    };
+    assert!(timed_out.timed_out());
+    assert!(timed_out.said().is_empty());
+    let not_started = Failed {
+        step: Step::Probe,
+        refusal: Refusal::NotStarted("gh: not found".to_owned()),
+    };
+    assert_eq!(not_started.said(), ["gh: not found"]);
+}
+
+/// Why the pull-request choice is off: a `gh` that never started is not
+/// installed, and everything else is `gh`'s own first line — a case nobody
+/// anticipated names itself rather than reading as one kendex knows.
+#[test]
+fn the_probe_maps_its_failure_structurally() {
+    let missing = Failed {
+        step: Step::Probe,
+        refusal: Refusal::NotStarted("gh: No such file or directory".to_owned()),
+    };
+    assert_eq!(gh::why(&missing), Unavailable::GhMissing);
+    let said = Failed {
+        step: Step::Probe,
+        refusal: Refusal::Said(vec!["first".to_owned(), "second".to_owned()]),
+    };
+    assert_eq!(gh::why(&said), Unavailable::GhSaid("first".to_owned()));
+    let silent = Failed {
+        step: Step::Probe,
+        refusal: Refusal::Said(Vec::new()),
+    };
+    assert!(
+        matches!(gh::why(&silent), Unavailable::GhSaid(line) if !line.is_empty()),
+        "a silent non-zero exit read as gh missing"
+    );
+    let late = Failed {
+        step: Step::Probe,
+        refusal: Refusal::TimedOut,
+    };
+    assert_eq!(
+        gh::why(&late),
+        Unavailable::GhSaid(
+            "the check for an open pull request did not finish within 15 seconds".to_owned()
+        )
+    );
+}
+
+// ---------------------------------------------------------------------
+// A repository to offer in.
+
+struct Repo {
+    _tmp: tempfile::TempDir,
+    root: PathBuf,
+}
+
+impl Repo {
+    /// `git init` on `main`, with an identity, hooks pinned to the
+    /// repository's own directory, and one commit carrying the inventory
+    /// and every file `committed` names.
+    fn new(committed: &[(&str, &str)]) -> Repo {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("site");
+        fs::create_dir_all(&root).unwrap();
+        let repo = Repo { _tmp: tmp, root };
+        repo.git(&["init", "--quiet", "-b", "main"]);
+        repo.git(&["config", "user.email", "t@t"]);
+        repo.git(&["config", "user.name", "t"]);
+        repo.git(&["config", "commit.gpgsign", "false"]);
+        repo.git(&["config", "core.hooksPath", ".git/hooks"]);
+        let inventory: Vec<&str> = committed
+            .iter()
+            .map(|(path, _)| *path)
+            .chain(std::iter::once(INVENTORY))
+            .collect();
+        repo.write(INVENTORY, &serde_json::to_string(&inventory).unwrap());
+        for (path, content) in committed {
+            repo.write(path, content);
+        }
+        repo.git(&["add", "-A"]);
+        repo.git(&["commit", "--quiet", "-m", "one"]);
+        repo
+    }
+
+    fn git(&self, args: &[&str]) -> String {
+        let output = Hardened::git(args, Some(&self.root)).run().unwrap();
+        assert!(
+            output.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).into_owned()
+    }
+
+    fn write(&self, path: &str, content: &str) {
+        let full = self.root.join(path);
+        fs::create_dir_all(full.parent().unwrap()).unwrap();
+        fs::write(full, content).unwrap();
+    }
+
+    fn scope(&self) -> Scope {
+        Scope::Project {
+            root: self.root.clone(),
+        }
+    }
+
+    /// What kendex renders here: `whole` owned end to end, `shared` the
+    /// edit targets.
+    fn generated(&self, whole: &[&str], shared: &[&str]) -> GeneratedPaths {
+        GeneratedPaths {
+            whole: whole.iter().map(|p| self.root.join(p)).collect(),
+            shared: shared.iter().map(|p| self.root.join(p)).collect(),
+        }
+    }
+
+    fn status(&self) -> String {
+        self.git(&["status", "--porcelain=v1"])
+    }
+
+    /// The paths the commit at `HEAD` touched.
+    fn head_files(&self) -> BTreeSet<String> {
+        self.git(&["show", "--name-only", "--format=", "HEAD"])
+            .lines()
+            .map(str::to_owned)
+            .collect()
+    }
+
+    fn scan(&self, generated: &GeneratedPaths) -> Option<Scan> {
+        scan(&self.scope(), generated).unwrap()
+    }
+
+    /// A hook in this repository that prints `lines` on stderr and exits 1.
+    #[cfg(unix)]
+    fn refusing_hook(&self, name: &str, lines: &[&str], then: &str) {
+        use std::os::unix::fs::PermissionsExt;
+        let body = lines
+            .iter()
+            .map(|line| format!("echo '{line}' >&2"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let hooks = self.root.join(".git/hooks");
+        fs::create_dir_all(&hooks).unwrap();
+        let path = hooks.join(name);
+        fs::write(&path, format!("#!/bin/sh\n{body}\n{then}\nexit 1\n")).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    /// A bare repository this one calls `origin`, so a push has somewhere
+    /// to land.
+    fn with_origin(&self) -> PathBuf {
+        let bare = self.root.parent().unwrap().join("origin.git");
+        let output = Hardened::git(
+            &[
+                "init",
+                "--quiet",
+                "--bare",
+                "-b",
+                "main",
+                &bare.to_string_lossy(),
+            ],
+            None,
+        )
+        .run()
+        .unwrap();
+        assert!(output.status.success());
+        self.git(&["remote", "add", "origin", &bare.to_string_lossy()]);
+        bare
+    }
+}
+
+const OWNED: &[&str] = &[".claude/skills/dev/SKILL.md", ".claude/CLAUDE.md"];
+
+// ---------------------------------------------------------------------
+// The preconditions and the path set.
+
+#[test]
+fn the_global_scope_and_a_folder_without_git_are_never_offered() {
+    let generated = GeneratedPaths::default();
+    assert_eq!(scan(&Scope::Global, &generated).unwrap(), None);
+    let tmp = tempfile::tempdir().unwrap();
+    let plain = Scope::Project {
+        root: tmp.path().to_owned(),
+    };
+    assert_eq!(scan(&plain, &generated).unwrap(), None);
+}
+
+#[test]
+fn a_clean_checkout_and_an_ignored_render_are_nothing_to_offer() {
+    let repo = Repo::new(&[(OWNED[0], "one\n"), (".gitignore", ".codex/\n")]);
+    let generated = repo.generated(&[OWNED[0], ".codex/CLAUDE.md"], &[]);
+    assert_eq!(repo.scan(&generated), None);
+    // Ignored paths never reach `git status` output, so a render that
+    // lands under one is not a change the offer can see.
+    repo.write(".codex/CLAUDE.md", "@AGENTS.md\n");
+    assert_eq!(repo.scan(&generated), None);
+}
+
+/// Render-only dirty, mixed dirty, and a changed shared file: the three
+/// blocks of the offer come off the one status read.
+#[test]
+fn the_set_is_the_changed_owned_paths_and_the_rest_is_counted_or_named() {
+    let repo = Repo::new(&[
+        (OWNED[0], "one\n"),
+        (".claude/settings.json", "{}\n"),
+        ("mine.md", "mine\n"),
+    ]);
+    let generated = repo.generated(OWNED, &[".claude/settings.json"]);
+    repo.write(OWNED[0], "two\n");
+    repo.write(OWNED[1], "@AGENTS.md\n");
+    let only = repo.scan(&generated).unwrap();
+    assert_eq!(
+        only.owned,
+        [
+            Owned {
+                path: OWNED[1].to_owned(),
+                untracked: true
+            },
+            Owned {
+                path: OWNED[0].to_owned(),
+                untracked: false
+            },
+        ]
+    );
+    assert!(only.shared.is_empty());
+    assert_eq!(only.others, 0, "render-only dirty counted other files");
+    assert_eq!(only.branch, Branch::On("main".to_owned()));
+    assert_eq!(only.count(), 2);
+
+    repo.write("mine.md", "changed\n");
+    repo.write(".claude/settings.json", "{\"permissions\":{}}\n");
+    let mixed = repo.scan(&generated).unwrap();
+    assert_eq!(mixed.owned.len(), 2, "the person's file joined the set");
+    assert_eq!(mixed.shared, [".claude/settings.json"]);
+    assert_eq!(
+        mixed.others, 1,
+        "the shared file or the render counted as other"
+    );
+}
+
+/// A sweep's removal is a deletion of a path the committed inventory names
+/// and the collection no longer gathers; a path that merely left the
+/// inventory but still exists is the person's.
+#[test]
+fn a_sweeps_removal_joins_the_set_and_a_surviving_path_does_not() {
+    let repo = Repo::new(&[
+        (OWNED[0], "one\n"),
+        (".claude/skills/old/SKILL.md", "old\n"),
+        (".claude/skills/kept/SKILL.md", "kept\n"),
+    ]);
+    let generated = repo.generated(&[OWNED[0]], &[]);
+    fs::remove_file(repo.root.join(".claude/skills/old/SKILL.md")).unwrap();
+    repo.write(".claude/skills/kept/SKILL.md", "hand edited\n");
+    let found = repo.scan(&generated).unwrap();
+    assert_eq!(
+        found.owned,
+        [Owned {
+            path: ".claude/skills/old/SKILL.md".to_owned(),
+            untracked: false
+        }]
+    );
+    assert_eq!(found.others, 1, "the surviving path was not the person's");
+}
+
+/// The two states the offer cannot be made in, each read where git keeps
+/// it. The operation outranks the detached `HEAD` it leaves behind.
+#[test]
+fn a_detached_head_and_an_operation_in_progress_are_read_off_the_git_directory() {
+    let repo = Repo::new(&[(OWNED[0], "one\n")]);
+    let generated = repo.generated(&[OWNED[0]], &[]);
+    repo.write(OWNED[0], "two\n");
+    for (marker, operation) in [
+        ("MERGE_HEAD", Operation::Merge),
+        ("REBASE_HEAD", Operation::Rebase),
+        ("rebase-merge/", Operation::Rebase),
+        ("rebase-apply/", Operation::Rebase),
+        ("CHERRY_PICK_HEAD", Operation::CherryPick),
+        ("BISECT_LOG", Operation::Bisect),
+    ] {
+        let path = repo.root.join(".git").join(marker);
+        match marker.ends_with('/') {
+            true => fs::create_dir_all(&path).unwrap(),
+            false => fs::write(&path, "").unwrap(),
+        }
+        assert_eq!(
+            repo.scan(&generated).unwrap().branch,
+            Branch::InProgress(operation),
+            "{marker}"
+        );
+        match marker.ends_with('/') {
+            true => fs::remove_dir_all(&path).unwrap(),
+            false => fs::remove_file(&path).unwrap(),
+        }
+    }
+    let head = repo.git(&["rev-parse", "HEAD"]);
+    repo.git(&["checkout", "--quiet", "--detach", head.trim()]);
+    let detached = repo.scan(&generated).unwrap();
+    assert_eq!(detached.branch, Branch::Detached);
+    assert_eq!(detached.on_branch(), None);
+    assert_eq!(Operation::CherryPick.article(), "a cherry-pick");
+}
+
+/// The remote rule: the branch's upstream, else `origin`, else the only
+/// one, else none. `tracked` only where the branch's own upstream is the
+/// remote that was chosen.
+#[test]
+fn the_remote_is_chosen_by_rule_and_never_by_a_prompt() {
+    let repo = Repo::new(&[(OWNED[0], "one\n")]);
+    assert_eq!(git::choose_remote(&repo.root, "main").unwrap(), None);
+    assert!(git::remotes(&repo.root).unwrap().is_empty());
+
+    repo.git(&["remote", "add", "alpha", "https://example.com/a.git"]);
+    let only = git::choose_remote(&repo.root, "main").unwrap().unwrap();
+    assert_eq!((only.name.as_str(), only.tracked), ("alpha", false));
+
+    repo.git(&["remote", "add", "beta", "https://example.com/b.git"]);
+    assert_eq!(
+        git::choose_remote(&repo.root, "main").unwrap(),
+        None,
+        "two remotes with no origin and no upstream were decided"
+    );
+
+    repo.git(&["remote", "add", "origin", "https://example.com/o.git"]);
+    let origin = git::choose_remote(&repo.root, "main").unwrap().unwrap();
+    assert_eq!(origin.name, "origin");
+    assert_eq!(origin.url, "https://example.com/o.git");
+    assert!(
+        !origin.tracked,
+        "a branch with no upstream read as tracking origin"
+    );
+
+    repo.git(&["config", "branch.main.remote", "beta"]);
+    repo.git(&["config", "branch.main.merge", "refs/heads/main"]);
+    let upstream = git::choose_remote(&repo.root, "main").unwrap().unwrap();
+    assert_eq!((upstream.name.as_str(), upstream.tracked), ("beta", true));
+}
+
+/// Without a remote the offer stands with push and pull request off, and
+/// says which of the two rules failed.
+#[test]
+fn without_a_remote_the_offer_names_why_push_and_pull_request_are_off() {
+    let repo = Repo::new(&[(OWNED[0], "one\n")]);
+    let generated = repo.generated(&[OWNED[0]], &[]);
+    repo.write(OWNED[0], "two\n");
+    let none = offer(repo.scan(&generated).unwrap(), "refresh").unwrap();
+    assert_eq!(none.push, Err(Unavailable::NoRemote));
+    assert_eq!(none.pull_request, Err(Unavailable::NoRemote));
+    assert_eq!(none.message, "chore: kendex refresh");
+    assert_eq!(none.new_branch, "kendex/renders");
+    assert_eq!(none.branch, "main");
+
+    repo.git(&["remote", "add", "alpha", "https://example.com/a.git"]);
+    repo.git(&["remote", "add", "beta", "https://example.com/b.git"]);
+    let several = offer(repo.scan(&generated).unwrap(), "refresh").unwrap();
+    assert_eq!(several.push, Err(Unavailable::RemoteNotDecidable));
+    assert_eq!(several.pull_request, Err(Unavailable::RemoteNotDecidable));
+}
+
+/// Free means no local ref and no remote-tracking ref for the chosen
+/// remote carries the name; another remote's ref does not count.
+#[test]
+fn the_new_branch_is_the_first_free_name() {
+    let repo = Repo::new(&[(OWNED[0], "one\n")]);
+    assert_eq!(
+        git::first_free_branch(&repo.root, None).unwrap(),
+        "kendex/renders"
+    );
+    repo.git(&["branch", "kendex/renders"]);
+    let head = repo.git(&["rev-parse", "HEAD"]);
+    repo.git(&[
+        "update-ref",
+        "refs/remotes/origin/kendex/renders-2",
+        head.trim(),
+    ]);
+    repo.git(&[
+        "update-ref",
+        "refs/remotes/other/kendex/renders-3",
+        head.trim(),
+    ]);
+    let origin = Remote {
+        name: "origin".to_owned(),
+        url: String::new(),
+        tracked: false,
+    };
+    assert_eq!(
+        git::first_free_branch(&repo.root, Some(&origin)).unwrap(),
+        "kendex/renders-3"
+    );
+    assert_eq!(
+        git::first_free_branch(&repo.root, None).unwrap(),
+        "kendex/renders-2"
+    );
+}
+
+// ---------------------------------------------------------------------
+// The commit.
+
+/// The set's untracked members are staged, the whole set is committed and
+/// nothing else is: the person's modified file and their own staged change
+/// are exactly where they were.
+#[test]
+fn the_commit_takes_the_set_and_leaves_the_persons_changes_alone() {
+    let repo = Repo::new(&[
+        (OWNED[0], "one\n"),
+        ("mine.md", "mine\n"),
+        ("staged.md", "s\n"),
+    ]);
+    let generated = repo.generated(OWNED, &[]);
+    repo.write(OWNED[0], "two\n");
+    repo.write(OWNED[1], "@AGENTS.md\n");
+    repo.write("mine.md", "changed\n");
+    repo.write("staged.md", "staged\n");
+    repo.git(&["add", "staged.md"]);
+    let before = git::previous_head(&repo.root).unwrap().unwrap();
+
+    let made = commit(&repo.root, &generated, "chore: kendex refresh").unwrap();
+    let Committed::Made { sha, files } = made else {
+        panic!("nothing was committed");
+    };
+    assert_eq!(files, 2);
+    assert_ne!(sha, before);
+    assert_eq!(git::head_short(&repo.root).unwrap(), sha);
+    assert_eq!(
+        repo.head_files(),
+        OWNED
+            .iter()
+            .map(|p| (*p).to_owned())
+            .collect::<BTreeSet<_>>()
+    );
+    assert_eq!(
+        repo.git(&["log", "-1", "--format=%s"]).trim(),
+        "chore: kendex refresh"
+    );
+    let status = repo.status();
+    assert!(status.contains(" M mine.md"), "{status}");
+    assert!(status.contains("M  staged.md"), "{status}");
+    assert!(!status.contains(".claude/"), "{status}");
+
+    // Re-derived immediately before the commit runs: nothing left means
+    // no commit, not an empty one.
+    assert_eq!(
+        commit(&repo.root, &generated, "again").unwrap(),
+        Committed::Nothing
+    );
+    assert_eq!(git::head_short(&repo.root).unwrap(), sha);
+}
+
+/// A rendered path holding pathspec metacharacters names itself and no
+/// other file. The must-fail control is the literal option: without it
+/// `a[b].md` is a glob that matches `ab.md`, the person's file.
+#[test]
+fn a_path_with_metacharacters_commits_itself_and_nothing_it_would_match() {
+    let repo = Repo::new(&[(OWNED[0], "one\n")]);
+    let generated = repo.generated(&["docs/a[b].md"], &[]);
+    repo.write("docs/a[b].md", "ours\n");
+    repo.write("docs/ab.md", "theirs\n");
+    let Committed::Made { files, .. } = commit(&repo.root, &generated, "m").unwrap() else {
+        panic!("nothing was committed");
+    };
+    assert_eq!(files, 1);
+    assert_eq!(
+        repo.head_files(),
+        BTreeSet::from(["docs/a[b].md".to_owned()])
+    );
+    assert!(repo.status().contains("?? docs/ab.md"), "{}", repo.status());
+    assert_eq!(pathspec::Spec::LITERAL, "--literal-pathspecs");
+}
+
+/// A hook's refusal reaches the person whole and in order, and the index
+/// ends as it began: the untracked member kendex staged is unstaged.
+#[cfg(unix)]
+#[test]
+fn a_refused_commit_carries_the_hooks_words_and_puts_the_index_back() {
+    let repo = Repo::new(&[(OWNED[0], "one\n")]);
+    let generated = repo.generated(OWNED, &[]);
+    repo.write(OWNED[0], "two\n");
+    repo.write(OWNED[1], "@AGENTS.md\n");
+    repo.refusing_hook(
+        "pre-commit",
+        &[
+            "commit-msg: crates/ changed without a changelog entry",
+            "  write one of: changelog.d/*/*.md",
+        ],
+        "",
+    );
+    let before = git::head_short(&repo.root).unwrap();
+    let refused = commit(&repo.root, &generated, "m").unwrap_err();
+    assert_eq!(refused.failed.step, Step::Commit);
+    assert_eq!(
+        refused.failed.said(),
+        [
+            "commit-msg: crates/ changed without a changelog entry",
+            "  write one of: changelog.d/*/*.md",
+        ]
+    );
+    assert_eq!(refused.still_staged, None);
+    assert_eq!(git::head_short(&repo.root).unwrap(), before);
+    let status = repo.status();
+    assert!(
+        status.contains("?? .claude/CLAUDE.md"),
+        "still staged: {status}"
+    );
+    assert!(
+        status.contains(" M .claude/skills/dev/SKILL.md"),
+        "{status}"
+    );
+}
+
+/// The cleanup itself refusing is reported rather than swallowed: the
+/// hook takes the write bit off the git directory, so the reset that
+/// would unstage cannot take the index lock and kendex's own paths are
+/// still staged.
+#[cfg(unix)]
+#[test]
+fn a_cleanup_that_cannot_unstage_says_how_many_paths_are_still_staged() {
+    use std::os::unix::fs::PermissionsExt;
+    let repo = Repo::new(&[(OWNED[0], "one\n")]);
+    let generated = repo.generated(OWNED, &[]);
+    repo.write(OWNED[1], "@AGENTS.md\n");
+    repo.refusing_hook("pre-commit", &["no"], "chmod 555 .git");
+    let refused = commit(&repo.root, &generated, "m").unwrap_err();
+    fs::set_permissions(repo.root.join(".git"), fs::Permissions::from_mode(0o755)).unwrap();
+    let _ = fs::remove_file(repo.root.join(".git/index.lock"));
+    assert_eq!(
+        refused.failed.said()[0],
+        "no",
+        "{:?}",
+        refused.failed.said()
+    );
+    assert_eq!(refused.still_staged, Some(1));
+    assert!(
+        repo.status().contains("A  .claude/CLAUDE.md"),
+        "{}",
+        repo.status()
+    );
+}
+
+// ---------------------------------------------------------------------
+// The branch, the push, and gh.
+
+/// The `pr` route's branch: made and switched to before anything is
+/// committed, and taken away again, checkout restored, when the commit on
+/// it did not happen.
+#[test]
+fn the_branch_is_made_before_the_commit_and_abandoned_after_a_refusal() {
+    let repo = Repo::new(&[(OWNED[0], "one\n")]);
+    start_branch(&repo.root, "kendex/renders").unwrap();
+    assert_eq!(
+        git::head_branch(&repo.root).unwrap().as_deref(),
+        Some("kendex/renders")
+    );
+    let again = start_branch(&repo.root, "kendex/renders").unwrap_err();
+    assert_eq!(again.step, Step::Branch);
+    assert!(
+        again
+            .said()
+            .iter()
+            .any(|line| line.contains("already exists")),
+        "{:?}",
+        again.said()
+    );
+    abandon_branch(&repo.root, "kendex/renders").unwrap();
+    assert_eq!(
+        git::head_branch(&repo.root).unwrap().as_deref(),
+        Some("main")
+    );
+    assert!(
+        !repo
+            .git(&["branch", "--list", "kendex/renders"])
+            .contains("renders")
+    );
+}
+
+/// A push lands on the remote, sets the upstream where the branch had
+/// none, and a refused push carries the remote's words. The recovery push
+/// puts an existing commit on a branch of its own without moving the
+/// local branch.
+#[cfg(unix)]
+#[test]
+fn a_push_lands_or_is_refused_in_the_remotes_words() {
+    let repo = Repo::new(&[(OWNED[0], "one\n")]);
+    let bare = repo.with_origin();
+    let pushed = push(&repo.root, "origin", "main", false).unwrap();
+    assert_eq!(
+        (pushed.remote.as_str(), pushed.branch.as_str()),
+        ("origin", "main")
+    );
+    assert_eq!(
+        repo.git(&["config", "branch.main.remote"]).trim(),
+        "origin",
+        "the first push set no upstream"
+    );
+
+    let head_pushed = push_head(&repo.root, "origin", "kendex/renders").unwrap();
+    assert_eq!(head_pushed.branch, "kendex/renders");
+    assert_eq!(
+        git::head_branch(&repo.root).unwrap().as_deref(),
+        Some("main")
+    );
+    assert!(
+        !repo
+            .git(&["branch", "--list", "kendex/renders"])
+            .contains("renders"),
+        "the recovery made a local branch"
+    );
+
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let hook = bare.join("hooks/pre-receive");
+        fs::write(
+            &hook,
+            "#!/bin/sh\necho 'GH006: Protected branch update failed for refs/heads/main.' >&2\nexit 1\n",
+        )
+        .unwrap();
+        fs::set_permissions(&hook, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    repo.write(OWNED[0], "two\n");
+    repo.git(&["commit", "--quiet", "-am", "two"]);
+    let refused = push(&repo.root, "origin", "main", true).unwrap_err();
+    assert_eq!(refused.step, Step::Push);
+    assert!(
+        refused
+            .said()
+            .iter()
+            .any(|line| line.contains("GH006: Protected branch update failed")),
+        "{:?}",
+        refused.said()
+    );
+}
+
+/// `previous_head` is what a recovery would put the branch back to, and
+/// there is nothing to put it back to in a repository with no commit.
+#[test]
+fn the_previous_head_is_none_before_the_first_commit() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root: &Path = tmp.path();
+    let init = Hardened::git(&["init", "--quiet", "-b", "main"], Some(root))
+        .run()
+        .unwrap();
+    assert!(init.status.success());
+    assert_eq!(previous_head(root).unwrap(), None);
+    assert_eq!(
+        git::first_free_branch(root, None).unwrap(),
+        "kendex/renders"
+    );
+    assert!(git::committed_inventory(root).unwrap().is_empty());
+}

--- a/crates/core/src/commit_offer/tests.rs
+++ b/crates/core/src/commit_offer/tests.rs
@@ -333,6 +333,33 @@ fn a_sweeps_removal_joins_the_set_and_a_surviving_path_does_not() {
     assert_eq!(found.others, 1, "the surviving path was not the person's");
 }
 
+/// A rename's origin is a deletion, so a renamed-away inventory path joins
+/// the set as a sweep's removal. The copy row, which git emits only under
+/// `status.renames=copies`, is proved against its documented bytes in
+/// `paths.rs`.
+#[test]
+fn a_renames_origin_is_a_removal() {
+    let repo = Repo::new(&[(".claude/skills/old/SKILL.md", "old content here\n")]);
+    let generated = repo.generated(&[], &[]);
+    repo.git(&["config", "status.renames", "copies"]);
+    fs::create_dir_all(repo.root.join(".claude/skills/moved")).unwrap();
+    repo.git(&[
+        "mv",
+        ".claude/skills/old/SKILL.md",
+        ".claude/skills/moved/SKILL.md",
+    ]);
+    assert!(repo.status().starts_with("R  "), "{}", repo.status());
+    let renamed = repo.scan(&generated).unwrap();
+    assert_eq!(
+        renamed.owned,
+        [Owned {
+            path: ".claude/skills/old/SKILL.md".to_owned(),
+            untracked: false
+        }]
+    );
+    assert_eq!(renamed.others, 1, "the moved-to path was not the person's");
+}
+
 /// The two states the offer cannot be made in, each read where git keeps
 /// it. The operation outranks the detached `HEAD` it leaves behind.
 #[test]
@@ -413,7 +440,7 @@ fn without_a_remote_the_offer_names_why_push_and_pull_request_are_off() {
     let repo = Repo::new(&[(OWNED[0], "one\n")]);
     let generated = repo.generated(&[OWNED[0]], &[]);
     repo.write(OWNED[0], "two\n");
-    let none = offer(repo.scan(&generated).unwrap(), "refresh").unwrap();
+    let none = offer(repo.scan(&generated).unwrap(), "refresh", Probe::Gh).unwrap();
     assert_eq!(none.push, Err(Unavailable::NoRemote));
     assert_eq!(none.pull_request, Err(Unavailable::NoRemote));
     assert_eq!(none.message, "chore: kendex refresh");
@@ -422,7 +449,7 @@ fn without_a_remote_the_offer_names_why_push_and_pull_request_are_off() {
 
     repo.git(&["remote", "add", "alpha", "https://example.com/a.git"]);
     repo.git(&["remote", "add", "beta", "https://example.com/b.git"]);
-    let several = offer(repo.scan(&generated).unwrap(), "refresh").unwrap();
+    let several = offer(repo.scan(&generated).unwrap(), "refresh", Probe::Gh).unwrap();
     assert_eq!(several.push, Err(Unavailable::RemoteNotDecidable));
     assert_eq!(several.pull_request, Err(Unavailable::RemoteNotDecidable));
 }

--- a/crates/core/src/engine/generated_paths.rs
+++ b/crates/core/src/engine/generated_paths.rs
@@ -1,7 +1,13 @@
 //! Committed CI inventory derived from the artifacts the engine renders.
 //! Carrier packages and in-place sources are executable source, not renders.
+//!
+//! The collection is a value rather than a step inside the write, because
+//! two readers need it: the inventory this file writes, and the commit
+//! offer, which covers only the files kendex owns whole. One collection,
+//! so the two cannot disagree about what kendex wrote.
 
 use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
 
 use crate::apply::{Op, PlannedOp, Pre};
 use crate::error::Result;
@@ -10,20 +16,67 @@ use crate::model::Scope;
 use super::desired::{Artifact, DesiredState};
 use super::instruction_shims::{ShimStanding, ShimState};
 
-pub(super) fn plan(
-    scope: &Scope,
+/// The name of the inventory CI reads, at a project root.
+pub const INVENTORY: &str = ".kendex-generated.json";
+
+/// What kendex renders in one project, split by whether it owns the whole
+/// file.
+///
+/// The split is what the commit offer needs and the inventory does not: a
+/// shared configuration file kendex writes one key in cannot be committed
+/// on its own, because git commits whole files and the person's own keys
+/// live in the same one.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GeneratedPaths {
+    /// Files kendex writes end to end: rendered agents, skill trees and
+    /// their links, registration scripts, instruction shims.
+    pub whole: BTreeSet<PathBuf>,
+    /// Shared configuration files kendex writes one key in — the
+    /// `Registration` edit targets. `desired.rs` states why kendex edits
+    /// rather than renders them: every unrelated key in them stays intact.
+    pub shared: BTreeSet<PathBuf>,
+}
+
+impl GeneratedPaths {
+    /// Nothing rendered at all, in either group.
+    pub fn is_empty(&self) -> bool {
+        self.whole.is_empty() && self.shared.is_empty()
+    }
+
+    /// Every path the inventory records: both groups, plus the inventory
+    /// file itself. CI reads this to know every path kendex touches.
+    pub fn inventory(&self, root: &Path) -> BTreeSet<PathBuf> {
+        self.whole
+            .iter()
+            .chain(&self.shared)
+            .cloned()
+            .chain(std::iter::once(root.join(INVENTORY)))
+            .collect()
+    }
+
+    /// The files kendex owns whole, the inventory file among them — what
+    /// the commit offer covers. The inventory is kendex's own file end to
+    /// end, so it is committed with the renders it records.
+    pub fn owned(&self, root: &Path) -> BTreeSet<PathBuf> {
+        self.whole
+            .iter()
+            .cloned()
+            .chain(std::iter::once(root.join(INVENTORY)))
+            .collect()
+    }
+}
+
+/// The paths this pass renders, by group.
+///
+/// In-place sources and items whose drift row is `Conflict` or `Unmanaged`
+/// are out: kendex writes nothing for them, so neither the inventory nor
+/// the offer may claim them.
+fn collect(
     state: &DesiredState,
     shims: &[ShimStanding],
     drift: &[super::DriftRow],
-    ops: &mut Vec<PlannedOp>,
-) -> Result<()> {
-    let Scope::Project { root } = scope else {
-        return Ok(());
-    };
-    if !root.join(".git").exists() {
-        return Ok(());
-    }
-    let mut paths = BTreeSet::new();
+) -> GeneratedPaths {
+    let mut generated = GeneratedPaths::default();
     for item in &state.items {
         if item.source_name == crate::manifest::INPLACE_SOURCE_NAME
             || drift.iter().any(|row| {
@@ -40,23 +93,29 @@ pub(super) fn plan(
         }
         match &item.artifact {
             Artifact::File { path, .. } => {
-                paths.insert(path.clone());
+                generated.whole.insert(path.clone());
             }
             Artifact::Tree {
                 canonical,
                 files,
                 link,
             } => {
-                paths.extend(files.iter().map(|(path, _)| canonical.join(path)));
-                paths.extend(link.iter().cloned());
+                generated
+                    .whole
+                    .extend(files.iter().map(|(path, _)| canonical.join(path)));
+                generated.whole.extend(link.iter().cloned());
             }
             Artifact::Registration { script, edits } => {
-                paths.extend(script.iter().map(|(path, _)| path.clone()));
-                paths.extend(edits.iter().map(|(path, _)| path.clone()));
+                generated
+                    .whole
+                    .extend(script.iter().map(|(path, _)| path.clone()));
+                generated
+                    .shared
+                    .extend(edits.iter().map(|(path, _)| path.clone()));
             }
         }
     }
-    paths.extend(
+    generated.whole.extend(
         shims
             .iter()
             .filter(|shim| {
@@ -67,12 +126,34 @@ pub(super) fn plan(
             })
             .map(|shim| shim.path.clone()),
     );
-    let path = root.join(".kendex-generated.json");
-    if paths.is_empty() && !path.exists() {
-        return Ok(());
+    generated
+}
+
+/// Collect what this pass renders and plan the inventory write for it.
+/// The collection is handed back so the report can carry it to the commit
+/// offer: one collection, so the inventory and the offer cannot disagree.
+pub(super) fn plan(
+    scope: &Scope,
+    state: &DesiredState,
+    shims: &[ShimStanding],
+    drift: &[super::DriftRow],
+    ops: &mut Vec<PlannedOp>,
+) -> Result<GeneratedPaths> {
+    let generated = collect(state, shims, drift);
+    let Scope::Project { root } = scope else {
+        return Ok(generated);
+    };
+    if !root.join(".git").exists() {
+        return Ok(generated);
     }
-    paths.insert(path.clone());
-    let relative: BTreeSet<String> = paths
+    let path = root.join(INVENTORY);
+    // A project that renders nothing gets no inventory, and one that
+    // already has one keeps it current even when it empties out.
+    if generated.is_empty() && !path.exists() {
+        return Ok(generated);
+    }
+    let relative: BTreeSet<String> = generated
+        .inventory(root)
         .iter()
         .filter_map(|path| path.strip_prefix(root).ok().map(crate::paths::slashed))
         .collect();
@@ -83,7 +164,7 @@ pub(super) fn plan(
         })?;
     text.push('\n');
     if crate::fs::read_if_exists(&path)?.as_deref() == Some(&text) {
-        return Ok(());
+        return Ok(generated);
     }
     ops.push(PlannedOp {
         description: "Record generated paths for CI".to_owned().into(),
@@ -93,5 +174,5 @@ pub(super) fn plan(
             bytes: text.into_bytes(),
         },
     });
-    Ok(())
+    Ok(generated)
 }

--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -29,7 +29,8 @@ mod expansion;
 mod file_plan;
 pub mod fork;
 mod gemini;
-mod generated_paths;
+pub mod generated_paths;
+pub use generated_paths::GeneratedPaths;
 mod holds;
 mod installed;
 mod recovery;
@@ -221,11 +222,10 @@ pub fn plan_scope(
     let repo_effects_leaving = repo_effects::leaving(env, scope, lock, &new_lock)?;
     plan_lock_write(env, scope, declared, disk_lock, new_lock, &mut ops)?;
     scope_notes.extend(scope_wide(scope, &mut ops)?);
-    generated_paths::plan(scope, &state, &instruction_shims, &drift, &mut ops)?;
+    let generated = generated_paths::plan(scope, &state, &instruction_shims, &drift, &mut ops)?;
 
-    let declaration_status = DeclarationStatus::of(&state);
     let mut report = EngineReport {
-        declaration_status,
+        declaration_status: DeclarationStatus::of(&state),
         // Ahead of the moves out of `state` below, and read before `drift`
         // moves in: an effect belongs to a package this pass adds to what
         // the scope carries, and to no other.
@@ -241,6 +241,7 @@ pub fn plan_scope(
         safety,
         instruction_shims,
         fork_edits,
+        generated,
     };
     report.notes.extend(scope_notes);
     unmanaged_rows(env, scope, &manifest, lock, &state.items, &mut report.drift)?;
@@ -355,6 +356,7 @@ pub fn plan_apply(env: &Env, scope: &Scope, options: &PlanOptions) -> Result<Eng
         repo_effects_leaving: Vec::new(),
         instruction_shims: Vec::new(),
         fork_edits: Vec::new(),
+        generated: GeneratedPaths::default(),
     };
     let empty = Manifest::default();
     unmanaged_rows(env, scope, &empty, &lock, &[], &mut report.drift)?;

--- a/crates/core/src/engine/report_types.rs
+++ b/crates/core/src/engine/report_types.rs
@@ -225,6 +225,12 @@ pub struct EngineReport {
     /// The forks this pass found edited on disk. They are not in `drift`:
     /// there is nothing to fix and nothing to decide.
     pub fork_edits: Vec<ForkEdit>,
+    /// The paths this pass renders into the scope, split into the files
+    /// kendex owns whole and the shared configuration files it writes one
+    /// key in. The inventory is written from it, and the commit offer
+    /// covers the whole-file group — one collection, so the two cannot
+    /// name different files.
+    pub generated: super::GeneratedPaths,
 }
 
 /// One name a removal was asked for, with the kind it must be when the

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -21,6 +21,7 @@ pub(crate) mod capture;
 pub mod check_catalog;
 pub mod clock;
 pub mod command_update;
+pub mod commit_offer;
 pub mod configedit;
 pub mod discover;
 pub mod drift;

--- a/crates/core/src/settings/mod.rs
+++ b/crates/core/src/settings/mod.rs
@@ -47,6 +47,31 @@ pub struct AppSettings {
     /// here. [`crate::legal`] owns the rule.
     #[serde(default)]
     pub terms: Option<crate::legal::TermsAcceptance>,
+    /// Whether kendex asks what to do with the files it wrote in a git
+    /// project. Machine-local like the rest of this file: whether a person
+    /// is asked is theirs, not their project's, and both shells read it.
+    #[serde(default, rename = "commit-offer")]
+    pub commit_offer: CommitOffer,
+}
+
+/// What a kendex write in a git project does about the files it left
+/// behind.
+///
+/// There is no value that commits without asking, because the offer's
+/// contract has none: kendex commits, pushes or opens a pull request only
+/// after a person chose that in this run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, Type)]
+#[serde(rename_all = "kebab-case")]
+pub enum CommitOffer {
+    #[default]
+    Ask,
+    Off,
+}
+
+impl CommitOffer {
+    pub fn asking(self) -> bool {
+        self == CommitOffer::Ask
+    }
 }
 
 fn default_zoom() -> u16 {
@@ -80,6 +105,7 @@ impl Default for AppSettings {
             muted_app_notice: None,
             zoom: ZOOM.default,
             terms: None,
+            commit_offer: CommitOffer::Ask,
         }
     }
 }

--- a/docs/design/post-refresh-commit-flow.md
+++ b/docs/design/post-refresh-commit-flow.md
@@ -42,7 +42,7 @@ That one call answers three questions at once.
 | An excluded `edits` target | The **Shared files** block |
 | Everything else | The person's own changes, which the offer counts and never touches |
 
-The set is re-derived immediately before the commit runs. A path that no longer differs is dropped. When none is left, the action reports that nothing was committed and the run ends without a commit.
+The set is re-derived immediately before the commit runs. A path that no longer differs is dropped. When none is left, the action reports that nothing was committed and the run ends without a commit. On the `pr` route the checkout has already moved to the new branch by then, so kendex clears that leftover the way it does after a refused commit there: `git switch -` back and `git branch -d <branch>`, and both surfaces say so with the line the refused commit uses.
 
 `kendex.toml` is the person's file and `.kendex-lock.json` is this machine's install ledger. Neither is in the collection, so neither is ever in the set.
 
@@ -50,7 +50,7 @@ The set is re-derived immediately before the commit runs. A path that no longer 
 
 The offer belongs to a project scope. The global scope is not a checkout and is never offered.
 
-On the CLI it is one call in each verb that applies a plan into a project scope, made once for that scope, after the verb's blocks and before that scope's closing ledger line. It runs for every project scope the run reached, whether the run is about to succeed or about to report failures: a verb that wrote and then failed left the same diffs behind as one that wrote and succeeded. A cancel is the exception and skips it, because a cancelled scope wrote nothing.
+On the CLI it is one call at the seam every verb writes a plan through, `engine_common::apply_report`, made once for each project scope the run reached, after the verb's blocks and before that scope's closing ledger line. One door rather than a call in each verb, so a verb added later cannot forget to ask; once per run per project is kept by the run's own record of which projects answered, not by call-site discipline. It runs for every project scope the run reached, whether the run is about to succeed or about to report failures, and whether or not the plan had anything to write: a verb that wrote and then failed left the same diffs behind as one that wrote and succeeded, and a scope with an empty plan can still hold the files an earlier run left uncommitted, which is what `run again with --commit` relies on. A cancel at the verb's own confirm is the exception and skips it, because a cancelled scope wrote nothing.
 
 Two verbs need naming because they sit at the edges of that rule.
 
@@ -93,12 +93,14 @@ The remote is chosen by rule, never by a prompt: the current branch's upstream r
 The pull-request choice needs three things at once: `gh` on the machine, a credential it will use, and a remote it recognises as a GitHub repository. One command answers all three, and answers a fourth question the offer asks anyway:
 
 ```
-gh pr list --head <branch> --state open --json number,url
+gh pr list --repo <url> --head <branch> --state open --json number,url
 ```
+
+`<url>` is the chosen remote's URL from `git remote get-url`, and every `gh` call carries it as `--repo`: the probe, the open-pull-request lookup and the create. Without it `gh` resolves the repository from the remotes itself, so a project whose `origin` is GitLab and whose second remote is GitHub would be probed against a repository the push never reaches.
 
 - It fails to spawn: `gh` is not installed.
 - It exits non-zero saying it is not authenticated: `gh` is not signed in.
-- It exits non-zero saying no remote points at a known GitHub host: this project is not on GitHub, which is the answer for a GitLab, a Gitea or a local-path remote.
+- It exits non-zero for a `--repo` that is not a GitHub repository it can reach: this project is not on GitHub, which is the answer for a GitLab, a Gitea or a local-path remote. What `gh` says there depends on the URL — a host it cannot query answers with that host's own error, a local path with `expected the "[HOST/]OWNER/REPO" format` — and kendex repeats its first line rather than naming the case itself.
 - It exits zero: the pull-request choice stands, and the rows it returned say whether one is already open for this branch.
 
 The reason a surface prints is `gh`'s own first line, so a case nobody anticipated still names itself rather than reading as one of the three above. The probe runs only where a remote was chosen, so a project with no remote pays no network call for it. It is bounded at 15 s, in the timeouts table.
@@ -113,7 +115,7 @@ kendex does not ask GitHub whether a branch is protected. That answer needs a pe
 | --- | --- | --- | --- | --- |
 | `commit` | `commit them` | `Commit` | `Commit` | the commit sequence below |
 | `push` | `commit them and push to <remote>/<branch>` | `Commit and push` | `Commit and push` | the commit, then `git push <remote> <branch>`, with `--set-upstream` where the branch has none |
-| `pr` | `commit them on a new branch and open a pull request` | `Pull request` | `Open pull request` | `git switch -c <branch>`, the commit, `git push --set-upstream <remote> <branch>`, `gh pr create --head <branch> --base <base> --title <message> --body <body>` |
+| `pr` | `commit them on a new branch and open a pull request` | `Pull request` | `Open pull request` | `git switch -c <branch>`, the commit, `git push --set-upstream <remote> <branch>`, `gh pr create --repo <url> --head <branch> --base <base> --title <message> --body <body>` |
 | `leave` | `leave them as diffs` | not a segment | `Leave as diffs` | nothing |
 
 The commit sequence is `git add` over the set's untracked members, then `git commit --only` over the whole set. Its behaviour is in **How the commit is made** below.
@@ -124,7 +126,7 @@ The new branch is `kendex/renders`, or the first free `kendex/renders-2`, `kende
 
 The base of the pull request is the branch the checkout was on when the offer was made.
 
-Where an open pull request already exists for the current branch, `push` reads `adds a commit to pull request #<n>` in place of `push to <remote>/<branch>`, and `pr` is not offered: the branch already has one. kendex reads this with `gh pr list --head <branch> --state open --json number,url`.
+Where an open pull request already exists for the current branch, `push` reads `commit them and add a commit to pull request #<n>`, and `pr` is not offered: the branch already has one. kendex reads this with the probe above. A `--pull-request` flag there is refused with `no pull request: pull request #<n> is already open for this branch`, the way a flag naming any removed choice is.
 
 ### When a step of the `pr` route fails
 
@@ -155,6 +157,8 @@ The set runs to a thousand paths in a large project, about 58 KB of path text in
 
 kendex writes the set to a file in the system temp directory, NUL-separated, and passes `--pathspec-from-file=<file> --pathspec-file-nul` to `git add`, `git commit` and `git reset`. All three take it. The file is removed when the step ends. It is outside the checkout, so it is never a path the offer could then find.
 
+`--pathspec-file-nul` fixes the separator, not the matching: git still reads each entry as a pathspec, so a rendered path holding `[`, `*` or `?` would match a different file and put a path in the commit that was never in the set. Every one of those three calls therefore runs as `git --literal-pathspecs <subcommand> …`, the git-wide option placed before the subcommand, which takes every entry as the path it is. One option rather than a `:(literal)` prefix per entry, because a path that itself begins with `:` cannot defeat it.
+
 `git status` takes no such option, which is why the status call is unscoped and filtered in kendex instead.
 
 ### What a refusal leaves behind
@@ -167,7 +171,7 @@ It unstages with `git reset -- <paths>`, not `git restore --staged`. `git restor
 
 The default message is `chore: kendex <command>`, where `<command>` is what the person typed, without its flags and arguments: `chore: kendex refresh`, `chore: kendex marketplace subscribe`, `chore: kendex source add`. A subcommand is named with its group, because the group alone is not a command anybody can run. A verb that delegates to another names itself, not the one it called: `kendex updates` runs `refresh`'s plan and its message says `updates`, because that is what the person ran. The message has no body.
 
-The rule is the command, not a list, so no enumeration can fall out of date as the command surface changes.
+The rule is the command, not a list, so no enumeration can fall out of date as the command surface changes. In the app nobody typed a command, so the message names the app: `chore: kendex app`.
 
 
 The message is editable on both surfaces before the commit runs, because a repository's commit-msg hook decides what it will accept and kendex cannot know that rule.
@@ -237,8 +241,10 @@ A precondition that removed a choice prints its reason as a detail line under th
   no pull request: this branch tracks no remote and the repository has more than one
   no pull request: gh is not installed
   no pull request: gh said: To get started with GitHub CLI, please run:  gh auth login
-  no pull request: gh said: none of the git remotes configured for this repository point to a known GitHub host
+  no pull request: gh said: expected the "[HOST/]OWNER/REPO" format, got "/srv/git/site.git"
 ```
+
+The last two are `gh`'s own first line for the repository it was bound to, whatever it turns out to be; the lines above show the shape, not a fixed list.
 
 The reader is asked for the message next, through `ui::ask`, where an empty answer accepts what is offered:
 
@@ -303,7 +309,7 @@ A refused push names what landed and what did not, and offers the way on:
 
 That block is the `commit` and `push` routes. On the `pr` route the commit is already on the branch kendex made, so a refused push there offers only `leave it here`: the recovery below is to put the commit on a branch, and it is there.
 
-Choice 1 pushes the commit that already exists rather than making a branch locally: `git push <remote> HEAD:refs/heads/<branch>`, then `gh pr create --head <branch> --base <current branch> --title <message> --body <body>`. `<branch>` is picked by the first-free rule above, so the push cannot fast-forward a branch somebody else named. The title and body are the ones the `pr` route uses: `gh pr create` with no terminal to prompt at refuses without them. The local branch is left carrying the commit, and the run says how to put it back without doing it:
+Choice 1 pushes the commit that already exists rather than making a branch locally: `git push <remote> HEAD:refs/heads/<branch>`, then `gh pr create --repo <url> --head <branch> --base <current branch> --title <message> --body <body>`. `<branch>` is picked by the first-free rule above, so the push cannot fast-forward a branch somebody else named. The title and body are the ones the `pr` route uses: `gh pr create` with no terminal to prompt at refuses without them. The local branch is left carrying the commit, and the run says how to put it back without doing it:
 
 ```
   pushed to origin/kendex/renders
@@ -358,6 +364,46 @@ The `pr` route's own failures, each ending the block:
   the commit is on kendex/renders in this checkout; kendex did not undo it
 ```
 
+The steps around the commit, each ending the block. A status, branch or remote read that fails leaves the offer unbuildable, and the verb's writes still stand:
+
+```
+/home/method/dev/site: the files kendex wrote could not be checked
+  git said:
+    fatal: not a git repository (or any of the parent directories): .git
+```
+
+A `git add` that fails happens before any commit:
+
+```
+  the files could not be staged
+  git said:
+    fatal: Unable to create '/home/method/dev/site/.git/index.lock': File exists.
+  1  commit again with the same message
+  2  commit again with a different message
+  3  leave them as diffs
+1-3, or Enter to leave them as diffs:
+```
+
+A cleanup `git reset` that fails after a refused commit leaves kendex's own paths staged, against the rule that the index ends as it began, and says so under the refusal it followed:
+
+```
+  the commit was refused
+  git said:
+    commit-msg: crates/ changed without a changelog entry
+  kendex staged 3 files it could not unstage; they are still staged
+```
+
+A `git switch -` or `git branch -d` that fails after a refused commit on the `pr` route is reported the same way, under that refusal, and the run stops there: the checkout is on the branch kendex made.
+
+```
+  the commit was refused
+  git said:
+    commit-msg: crates/ changed without a changelog entry
+  the checkout could not be put back
+  git said:
+    error: cannot switch branch while merging
+```
+
 ### Timed out
 
 A step that ran out of time reads as that step's refusal, with the bound in place of the program's words, and offers whatever that step's refusal offers:
@@ -409,11 +455,14 @@ A flag answers the offer without asking. A precondition that removed the choice 
 | `leave`, or no offer | the verb's own code |
 | Commit, push or pull request went through | the verb's own code |
 | A choice the person took was refused or timed out | 1 |
-| Ctrl-C at the offer | 130, through `ui::cancelled` |
+| A flag named a choice the remote or `gh` preconditions removed | 1 |
+| The files could not be staged, or the checkout could not be put back | 1 |
+| No offer at all — a detached `HEAD`, an operation in progress, a read that failed — whatever flag was passed | the verb's own code |
+| Ctrl-C at the offer | 130 |
 
-A cancel at the offer is not the cancel `refresh.rs` already handles. That one is a cancel at the write confirm, and it drops the scope from the reached list on the ground that the scope wrote nothing. A cancel at the offer comes after the write: the scope keeps its place on that list, so its snapshot is still recorded and its closing ledger line is still printed. Only the offer is skipped.
+A cancel at the offer is not the cancel `refresh.rs` already handles. That one is a cancel at the write confirm, and it drops the scope from the reached list on the ground that the scope wrote nothing. A cancel at the offer comes after the write: the scope keeps its place on that list, so its snapshot is still recorded and its closing ledger line is still printed. Only the offer is skipped, in that project and in every project the run reaches after it, and the run exits 130 once the verb has closed its scopes.
 
-A refused commit, push or pull request is its own failure line and is not counted into `failed to refresh <n> item/source(s)`.
+A refused commit, push or pull request is its own failure line and is not counted into `failed to refresh <n> item/source(s)`. The verb closes its scope as it would have — the snapshot recorded, the ledger line printed with its refusal part — and the run exits 1 once the verb has finished, printing nothing further: the block already carried the words and the way on.
 
 ## App
 
@@ -457,7 +506,7 @@ A segment a precondition removed is not rendered. Its reason is a labelled row u
 | `Pull request` | `This repository has no remote.` |
 | `Pull request` | `This branch tracks no remote and the repository has more than one.` |
 | `Pull request` | `gh is not installed.` |
-| `Pull request` | `gh is not signed in. Run gh auth login.` |
+| `Pull request` | gh's own first line, as **The `gh` probe** fixes it: `To get started with GitHub CLI, please run:  gh auth login`, or whatever `gh` says of a `--repo` that is not a GitHub repository it can reach |
 
 Where every segment but `Commit` is gone, the segmented control is not drawn and the primary button reads `Commit`.
 
@@ -500,6 +549,12 @@ Commit refused:
 
 The `Files` and `Other changes` sections stay as they were, so the person can still see what the commit covers.
 
+A `git add` that failed takes this state with the title `The files could not be staged`: it happens before any commit, so the commit's title would name something that never ran. A cleanup `git reset` that failed adds the line `kendex staged 3 files it could not unstage. They are still staged.` under the section.
+
+Commit refused on the `pr` route where the switch back or the branch removal then failed: this state, with the line `The checkout could not be put back.` after the section and a second `What git said` section under it carrying that step's words, and only the outline `Leave as diffs` in the footer, because the checkout is on the branch kendex made and kendex stops there.
+
+Nothing left to commit on the `pr` route where the switch back then failed: no commit was refused, so the state is titled `The checkout could not be put back`, with the line `Nothing to commit` under the title, the `What git said` section for that step, and only `Leave as diffs` in the footer.
+
 Branch not made, on the `pr` route:
 
 | Element | Copy |
@@ -513,7 +568,7 @@ Branch not made, on the `pr` route:
 
 The `Pull request` segment is gone from that state, so the segmented control offers `Commit` and `Commit and push` only.
 
-Commit refused on the `pr` route: the commit-refused state above, with one line added under its title, `This checkout is back on main and kendex/renders is gone.`
+Commit refused on the `pr` route: the commit-refused state above, with one line added under its title, `This checkout is back on main and kendex/renders is gone.` `Commit again` there runs the `pr` route again from its start, on both surfaces: the branch is made once more and the commit lands on it, because that is the choice the person made and a refused hook does not change it.
 
 Push refused:
 
@@ -529,7 +584,7 @@ Push refused:
 
 The branch in that state's rows is the branch the commit landed on. On the `pr` route that is `kendex/renders`, and `Open a pull request` is not offered there: the commit is already on a branch of its own, which is what the recovery would have made.
 
-`Open a pull request` there runs the same recovery the CLI runs: it pushes the commit that exists to a new branch and opens the pull request, without moving the local branch. Its result state adds two rows to the pull-request result above:
+`Open a pull request` there runs the same recovery the CLI runs: it pushes the commit that exists to a new branch and opens the pull request, without moving the local branch. Its result state is the pull-request result above with two rows in place of the `This checkout is now on` line, which would not be true:
 
 | Element | Copy |
 | --- | --- |
@@ -569,6 +624,7 @@ A dialog that offers nothing is a modal a person has to dismiss for no reason, s
 | --- | --- | --- |
 | Detached HEAD | `12 uncommitted` | `12 files kendex wrote are not committed. This checkout is on no branch.` |
 | Merge, rebase, cherry-pick or bisect in progress | `12 uncommitted` | `12 files kendex wrote are not committed. A rebase is in progress.` |
+| A status, branch or remote read failed | `Not checked` | `kendex could not check the files it wrote here. git said: <git's first line>` |
 
 `ProjectCard` renders its badge as `variant="destructive"`, which is right for its one caller today, `Folder not found`. Uncommitted files are not a fault, so the prop becomes a pair, the text and the variant, and this one passes `info`. `ProjectCard` also gains a `title` for the reason. The badge itself is short because the card's other badges are, and the reason is on hover, the way the app already hides a status word behind one.
 
@@ -603,17 +659,23 @@ Every state, its detection, and where its words are.
 | Remote not decidable | Several remotes, no upstream, no `origin` | Offer, `no push` and `no pull request` reasons | Offer, `Push` and `Pull request` rows |
 | `gh` missing | The probe fails to spawn | Offer, `no pull request: gh is not installed` | Offer, `Pull request` row |
 | `gh` not signed in | The probe exits non-zero | Offer, `no pull request` with gh's first line | Offer, `Pull request` row with gh's first line |
-| The remote is not on GitHub | The probe exits non-zero | Offer, `no pull request` with gh's first line | Offer, `Pull request` row with gh's first line |
+| The remote is not on GitHub | The probe exits non-zero for the `--repo` it was bound to | Offer, `no pull request` with gh's first line | Offer, `Pull request` row with gh's first line |
 | Pull request already open | The probe returns a row | `push` reworded, `pr` not offered | `Commit and push` reworded, `Pull request` segment absent |
 | Detached HEAD | `git symbolic-ref --quiet HEAD` non-zero | One line | Project card badge |
 | Merge, rebase, cherry-pick, bisect | The marker files in the git directory | One line | Project card badge |
 | No terminal | `stdin().is_terminal()` false | One line naming the flags | not reachable |
+| A read failed | `git status`, `symbolic-ref`, `remote` or `show-ref` exits non-zero or does not run | `the files kendex wrote could not be checked`, git's words, no offer | Project card badge `Not checked` |
+| The re-read at commit time failed | `git status` exits non-zero or does not run when the set is re-derived | `the files could not be checked`, git's words, then the commit's three choices | `The files could not be checked`, the commit-refused state |
+| The files could not be staged | `git add` exits non-zero | `the files could not be staged`, git's words, then three choices | `The files could not be staged` |
+| The cleanup could not unstage | `git reset` exits non-zero after a refused commit | The refusal, then `kendex staged N files it could not unstage; they are still staged` | The refusal, then that line |
 | Commit refused | `git commit` exits non-zero | git's words, then three choices | `The commit was refused` |
 | Branch not made, `pr` route | `git switch -c` exits non-zero | git's words, then the choices without `pr` | `The branch could not be made` |
 | Commit refused, `pr` route | `git commit` exits non-zero after the switch | The same, plus the line naming the switch back and the removed branch | The same, plus that line |
+| The checkout could not be put back | `git switch -` or `git branch -d` exits non-zero after that | The refusal, then `the checkout could not be put back` and git's words, no further choice | The refusal, then that line and git's words, `Leave as diffs` only |
 | Push refused, `pr` route | `git push` exits non-zero after the switch | git's words, the commit named on the new branch, no further choice | `Committed, not pushed`, no `Open a pull request` |
 | Push refused, protection or otherwise | `git push` exits non-zero on the `commit` or `push` route | git's words, the commit named, then two choices | `Committed, not pushed` |
 | Pull request refused | `gh pr create` exits non-zero | gh's words, the commit and branch named | `Committed and pushed, no pull request` |
 | A step timed out | The bound in the timeouts table | The CLI's **Timed out** block | The app's **Timed out** state |
-| Nothing left to commit at commit time | The re-read path set is empty | `nothing to commit; the files changed since the offer` | Toast `Nothing to commit`, dialog closes |
+| Nothing left to commit at commit time | The re-read path set is empty | `nothing to commit; the files changed since the offer`, and on the `pr` route the branch is abandoned and `this checkout is back on main and kendex/renders is gone` follows | Toast `Nothing to commit`, dialog closes, the branch abandoned on the `pr` route |
+| A flag named a removed choice | The flag's choice is not on offer | The head line, then that choice's reason, nothing committed | not reachable |
 | Cancelled | Ctrl-C, or the dialog dismissed | exit 130 | The dialog closes, nothing runs |

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { Toaster } from "sonner";
 import { commands } from "@/bindings";
+import { CommitOfferDialog } from "@/components/commit-offer-dialog";
 import { ErrorDialog } from "@/components/error-dialog";
 import { RepoEffectsDialog } from "@/components/marketplaces/repo-effects-dialog";
 import { NavBar } from "@/components/nav-bar";
@@ -201,6 +202,9 @@ export default function App() {
         />
         <ErrorDialog />
         <RepoEffectsDialog />
+        {/* The question a write leaves behind: what to do with the files
+            kendex wrote in a git project. */}
+        <CommitOfferDialog />
         <div className="flex flex-1 overflow-hidden">
           <Sidebar />
           <main className="relative flex flex-1 flex-col overflow-hidden">

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -324,6 +324,30 @@ export const commands = {
 	installTargets: (scope: Scope, kinds: ItemKind[]) => typedError<InstallTarget[], string>(__TAURI_INVOKE("install_targets", { scope, kinds })),
 	repoEffectsApply: (scope: Scope, declared: DeclaredEffects) => typedError<Said, string>(__TAURI_INVOKE("repo_effects_apply", { scope, declared })),
 	/**
+	 *  Read every project the write could reach, and say for each one whether
+	 *  there is an offer to make, a state to flag on its card, or nothing.
+	 */
+	commitOfferScan: (roots: string[]) => typedError<CommitOfferScan, string>(__TAURI_INVOKE("commit_offer_scan", { roots })),
+	commitOfferCommit: (root: string, message: string) => typedError<CommitStep, string>(__TAURI_INVOKE("commit_offer_commit", { root, message })),
+	commitOfferPush: (root: string, remote: string, branch: string, tracked: boolean) => typedError<StepResult, string>(__TAURI_INVOKE("commit_offer_push", { root, remote, branch, tracked })),
+	/**
+	 *  Push a commit that already exists to a branch of its own, without
+	 *  moving the branch it is on — the recovery a refused push offers.
+	 */
+	commitOfferPushHead: (root: string, remote: string, branch: string) => typedError<StepResult, string>(__TAURI_INVOKE("commit_offer_push_head", { root, remote, branch })),
+	commitOfferStartBranch: (root: string, branch: string) => typedError<StepResult, string>(__TAURI_INVOKE("commit_offer_start_branch", { root, branch })),
+	/**
+	 *  Put the checkout back and remove the empty branch kendex made, after a
+	 *  commit on it refused.
+	 */
+	commitOfferAbandonBranch: (root: string, branch: string) => typedError<StepResult, string>(__TAURI_INVOKE("commit_offer_abandon_branch", { root, branch })),
+	/**
+	 *  The commit a recovery would put the branch back to, read before the
+	 *  commit runs. `null` in a repository with no commit yet.
+	 */
+	commitOfferPreviousHead: (root: string) => typedError<string | null, string>(__TAURI_INVOKE("commit_offer_previous_head", { root })),
+	commitOfferOpenPullRequest: (repo: string, head: string, base: string, title: string, files: number) => typedError<OpenResult, string>(__TAURI_INVOKE("commit_offer_open_pull_request", { repo, head, base, title, files })),
+	/**
 	 *  Subscribe a scope to a marketplace: `owner/repo[@rev]`, a git URL, a
 	 *  GitHub tree URL, a skills.sh package URL, or a local folder.
 	 */
@@ -627,6 +651,12 @@ export type AppSettings = {
 	 *  here. [`crate::legal`] owns the rule.
 	 */
 	terms?: TermsAcceptance | null,
+	/**
+	 *  Whether kendex asks what to do with the files it wrote in a git
+	 *  project. Machine-local like the rest of this file: whether a person
+	 *  is asked is theirs, not their project's, and both shells read it.
+	 */
+	"commit-offer"?: CommitOffer,
 };
 
 export type AppUpdateStatus = { kind: "neverChecked" } | { kind: "upToDate"; version: string } | { kind: "updateAvailable"; version: string; releaseNotesUrl: string; cliAssetAvailable: boolean; muted: boolean } | { kind: "feedOlder"; version: string };
@@ -1046,6 +1076,32 @@ export type CommandNotice =
  *  nothing here to hand a person to run.
  */
 { kind: "needsDownload"; path: string; page: string };
+
+/**
+ *  What a kendex write in a git project does about the files it left
+ *  behind.
+ * 
+ *  There is no value that commits without asking, because the offer's
+ *  contract has none: kendex commits, pushes or opens a pull request only
+ *  after a person chose that in this run.
+ */
+export type CommitOffer = "ask" | "off";
+
+/**  What one read of every project the write could reach found. */
+export type CommitOfferScan = {
+	offers: ProjectOffer[],
+	flagged: ProjectFlag[],
+};
+
+/**  What the commit did. */
+export type CommitStep = 
+/**  The re-read set was empty: the files changed since the offer. */
+{ kind: "nothing" } | { kind: "made"; sha: string; files: number } | { kind: "refused"; refused: Refused; 
+/**
+ *  Paths kendex staged and could not then unstage. They are still
+ *  staged, against the rule that the index ends as it began.
+ */
+stillStaged: number | null };
 
 /**
  *  A package whose presence changes what this one does, and whether it is
@@ -1492,6 +1548,15 @@ export type Finding = {
 	message: string,
 	remediation: string,
 };
+
+export type FlagReason = { kind: "noBranch" } | 
+/**  The operation as a line names it: `a rebase`. */
+{ kind: "inProgress"; operation: string } | 
+/**
+ *  A read the offer is built from would not run, so nothing about this
+ *  project can be claimed.
+ */
+{ kind: "unreadable"; said: string[] };
 
 /**
  *  Why installing beside did not finish, by phase: a refusal wrote
@@ -2356,6 +2421,9 @@ export type OpSupport = {
 	global: boolean,
 };
 
+/**  What opening the pull request did. */
+export type OpenResult = { kind: "opened"; url: string } | { kind: "refused"; refused: Refused };
+
 /**  Where one installation came from. */
 export type Origin = 
 /**
@@ -2717,6 +2785,50 @@ export type PreflightCheck = {
 	fix: string | null,
 };
 
+/**
+ *  A project where kendex owns changed files and the offer cannot be made.
+ *  The window flags it on the project's card rather than opening a dialog
+ *  that offers nothing.
+ */
+export type ProjectFlag = {
+	root: string,
+	count: number,
+	reason: FlagReason,
+};
+
+/**  One project's offer, everything the dialog draws it from. */
+export type ProjectOffer = {
+	root: string,
+	/**  The project's folder name, which the title names. */
+	name: string,
+	/**
+	 *  The files kendex owns whole that changed, printed whole: an
+	 *  abbreviation guesses at a directory and names a different file from
+	 *  the one being committed.
+	 */
+	files: string[],
+	/**  The shared configuration files kendex writes one key in. */
+	shared: string[],
+	/**  How many of the person's own files changed. */
+	others: number,
+	branch: string,
+	remote: string | null,
+	/**  `null` where the choice stands; the reason otherwise. */
+	push: Why | null,
+	pullRequest: Why | null,
+	/**  The pull request already open for this branch. */
+	openNumber: number | null,
+	message: string,
+	newBranch: string,
+	/**  The repository every `gh` call is bound to, from the chosen remote. */
+	repo: string | null,
+	/**
+	 *  The branch already tracks the chosen remote, so a push needs no
+	 *  `--set-upstream`.
+	 */
+	tracked: boolean,
+};
+
 /**  One installation's origin, keyed the way the Library table joins it. */
 export type ProvenanceRow = {
 	scope: Scope,
@@ -2736,6 +2848,22 @@ export type QualityScore = {
 	 *  replace it.
 	 */
 	penaltyPercent: number,
+};
+
+/**  A step that did not go through. */
+export type Refused = {
+	/**  The step, as its own line names it. */
+	step: string,
+	/**
+	 *  The program's own words, whole, in order. Empty where the step ran
+	 *  out of time and said nothing.
+	 */
+	said: string[],
+	timedOut: boolean,
+	/**  The bound in whole seconds, for the line a timeout draws. */
+	seconds: number,
+	/**  Whether the words are `gh`'s rather than git's. */
+	gh: boolean,
 };
 
 /**  A package's declared effects on the repository it installs into. */
@@ -3092,6 +3220,9 @@ export type StatusFinding = {
 	message: string,
 	fix: string,
 };
+
+/**  What one of the other steps did. */
+export type StepResult = { kind: "done" } | { kind: "refused"; refused: Refused };
 
 /**  One row of GET /api/v1/submissions — what a Mine row polls. */
 export type SubmissionRow = {
@@ -3515,6 +3646,17 @@ export type VersionSel =
 { at: "commit"; commit: string } | 
 /**  What is installed on disk right now. */
 { at: "installed" };
+
+/**
+ *  Why a choice is not on offer, for the labelled row the window draws
+ *  under the segments.
+ */
+export type Why = { kind: "noRemote" } | { kind: "remoteNotDecidable" } | { kind: "ghMissing" } | 
+/**
+ *  gh's own first line, so a case nobody anticipated still names
+ *  itself rather than reading as one kendex knows.
+ */
+{ kind: "ghSaid"; line: string };
 
 /**  An effect that was neither shown nor offered, and why. */
 export type Withheld = {

--- a/ui/src/components/commit-offer-dialog.dom.test.tsx
+++ b/ui/src/components/commit-offer-dialog.dom.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProjectOffer, Refused } from "@/bindings";
+import { useCommitOfferStore } from "@/stores/commit-offer";
+import { mount, settle } from "@/test/dom";
+import { CommitOfferDialog } from "./commit-offer-dialog";
+
+vi.mock("@/bindings", () => ({ commands: {} }));
+vi.mock("sonner", () => ({ toast: { info: vi.fn(), success: vi.fn() } }));
+
+const offer: ProjectOffer = {
+  root: "/home/method/dev/site",
+  name: "site",
+  files: [".claude/CLAUDE.md"],
+  shared: [],
+  others: 0,
+  branch: "main",
+  remote: "origin",
+  push: null,
+  pullRequest: null,
+  openNumber: null,
+  message: "chore: kendex refresh",
+  newBranch: "kendex/renders",
+  repo: "acme/site",
+  tracked: true,
+};
+
+const refused = (step: string, said: string): Refused => ({
+  step,
+  said: [said],
+  timedOut: false,
+  seconds: 30,
+  gh: false,
+});
+
+const buttons = () =>
+  [...document.body.querySelectorAll("button")].map((one) => one.textContent);
+
+beforeEach(() => {
+  useCommitOfferStore.setState({
+    queue: [offer],
+    flagged: [],
+    stage: { at: "offer" },
+    route: "commit",
+    message: offer.message,
+  });
+});
+
+describe("the branch-not-made state", () => {
+  it("offers the segments again without the pull request", async () => {
+    useCommitOfferStore.setState({
+      stage: {
+        at: "branchRefused",
+        refused: refused(
+          "the branch",
+          "fatal: a branch named 'kendex/renders' already exists",
+        ),
+      },
+      route: "commit",
+    });
+    mount(<CommitOfferDialog />);
+    await settle();
+
+    const text = document.body.textContent ?? "";
+    expect(text).toContain("The branch could not be made");
+    expect(text).toContain(
+      "fatal: a branch named 'kendex/renders' already exists",
+    );
+    expect(text).toContain(
+      "Nothing was committed and this checkout has not moved.",
+    );
+    const labels = buttons();
+    expect(labels).toContain("Commit and push");
+    expect(labels).not.toContain("Pull request");
+    expect(labels).toContain("Leave as diffs");
+    expect(labels.filter((one) => one === "Commit")).toHaveLength(2);
+  });
+
+  it("follows the picked segment on its primary button", async () => {
+    useCommitOfferStore.setState({
+      stage: { at: "branchRefused", refused: refused("the branch", "no") },
+      route: "push",
+    });
+    mount(<CommitOfferDialog />);
+    await settle();
+
+    expect(document.body.textContent).toContain("Pushes to origin/main.");
+    expect(buttons().filter((one) => one === "Commit and push")).toHaveLength(
+      2,
+    );
+  });
+});
+
+describe("the commit refused where the checkout could not be put back", () => {
+  it("shows both refusals and offers only to leave", async () => {
+    useCommitOfferStore.setState({
+      stage: {
+        at: "commitRefused",
+        refused: refused(
+          "the commit",
+          "commit-msg: crates/ changed without a changelog entry",
+        ),
+        stillStaged: null,
+        abandoned: false,
+        notPutBack: refused(
+          "the switch back",
+          "error: Your local changes would be overwritten by checkout",
+        ),
+      },
+    });
+    mount(<CommitOfferDialog />);
+    await settle();
+
+    const text = document.body.textContent ?? "";
+    expect(text).toContain("The commit was refused");
+    expect(text).toContain(
+      "commit-msg: crates/ changed without a changelog entry",
+    );
+    expect(text).toContain("The checkout could not be put back.");
+    expect(text).toContain(
+      "error: Your local changes would be overwritten by checkout",
+    );
+    expect(text).not.toContain("is gone.");
+    const labels = buttons();
+    expect(labels).toContain("Leave as diffs");
+    expect(labels).not.toContain("Commit again");
+  });
+
+  it("names only the switch back where nothing was left to commit", async () => {
+    useCommitOfferStore.setState({
+      stage: {
+        at: "notPutBack",
+        refused: refused("the switch back", "error: cannot switch branch"),
+      },
+    });
+    mount(<CommitOfferDialog />);
+    await settle();
+
+    const text = document.body.textContent ?? "";
+    expect(text).toContain("The checkout could not be put back");
+    expect(text).toContain("Nothing to commit");
+    expect(text).toContain("error: cannot switch branch");
+    expect(text).not.toContain("The commit was refused");
+    const labels = buttons();
+    expect(labels).toContain("Leave as diffs");
+    expect(labels).not.toContain("Commit again");
+  });
+
+  it("offers to commit again where the checkout is back", async () => {
+    useCommitOfferStore.setState({
+      stage: {
+        at: "commitRefused",
+        refused: refused("the commit", "commit-msg: no"),
+        stillStaged: null,
+        abandoned: true,
+        notPutBack: null,
+      },
+    });
+    mount(<CommitOfferDialog />);
+    await settle();
+
+    expect(document.body.textContent).toContain(
+      "This checkout is back on main and kendex/renders is gone.",
+    );
+    expect(buttons()).toContain("Commit again");
+  });
+});

--- a/ui/src/components/commit-offer-dialog.tsx
+++ b/ui/src/components/commit-offer-dialog.tsx
@@ -1,0 +1,646 @@
+import { CheckIcon, CopyIcon } from "lucide-react";
+import { useState } from "react";
+import type { ProjectOffer, Refused } from "@/bindings";
+import { ExternalLink } from "@/components/external-link";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  addsToPullRequest,
+  BRANCH_REFUSED_LINE,
+  BRANCH_REFUSED_TITLE,
+  BRANCH_ROW_LABEL,
+  backOn,
+  branchIsOn,
+  COMMIT_AGAIN_LABEL,
+  COMMIT_LABEL,
+  COMMIT_OFFER_STANDING,
+  COMMIT_ROW_LABEL,
+  COMMIT_SEGMENT,
+  COMMIT_STAYS,
+  COMMITTING_LABEL,
+  commitIsOn,
+  commitOfferTitle,
+  commitOn,
+  commitRefusedTitle,
+  DONE_LABEL,
+  didNotFinish,
+  FILES_LABEL,
+  LEAVE_IT_HERE_LABEL,
+  LEAVE_LABEL,
+  MESSAGE_LABEL,
+  NOT_PUT_BACK_LINE,
+  NOT_PUT_BACK_TITLE,
+  NOTHING_TO_COMMIT_TOAST,
+  nowOn,
+  OPEN_PR_LABEL,
+  OPENING_LABEL,
+  OTHER_LABEL,
+  otherNote,
+  PR_LABEL,
+  PR_OPEN_TITLE,
+  PR_ROW_LABEL,
+  PR_SEGMENT,
+  PUSH_LABEL,
+  PUSH_ROW_LABEL,
+  PUSH_SEGMENT,
+  PUSHING_LABEL,
+  prMoves,
+  pullRequestRefusedTitle,
+  pushesTo,
+  pushRefusedTitle,
+  putBackRowLabel,
+  remoteBranch,
+  resetCommand,
+  SHARED_LABEL,
+  SHARED_NOTE,
+  saidLabel,
+  stillCarries,
+  stillStaged,
+  unavailableReason,
+  WHAT_TO_DO_LABEL,
+} from "@/lib/copy-commit-offer";
+import { cn } from "@/lib/utils";
+import {
+  type Route,
+  routesFor,
+  type Stage,
+  useCommitOfferStore,
+} from "@/stores/commit-offer";
+
+/** The question a kendex write leaves behind, rendered once in App.tsx:
+ *  what to do with the files kendex wrote in this repository. One project
+ *  at a time, each with its own answer, in the order the write reached
+ *  them. Dismissing it is leaving the files as diffs — a choice of the
+ *  same standing as the other three, and a success rather than a refusal. */
+export function CommitOfferDialog() {
+  const offer = useCommitOfferStore((s) => s.queue[0]);
+  const stage = useCommitOfferStore((s) => s.stage);
+  const leave = useCommitOfferStore((s) => s.leave);
+  if (!offer) return null;
+  const busy = stage.at === "busy";
+  return (
+    <Dialog
+      open
+      onOpenChange={(next) => {
+        // A step is running the repository's own hooks, and closing the
+        // window would not stop them.
+        if (!next && !busy) leave();
+      }}
+    >
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-xl">
+        <Body offer={offer} stage={stage} />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Body({ offer, stage }: { offer: ProjectOffer; stage: Stage }) {
+  switch (stage.at) {
+    case "offer":
+    case "busy":
+      return <OfferState offer={offer} stage={stage} />;
+    case "commitRefused":
+      return (
+        <CommitRefusedState
+          offer={offer}
+          refused={stage.refused}
+          held={stage.stillStaged}
+          abandoned={stage.abandoned}
+          notPutBack={stage.notPutBack}
+        />
+      );
+    case "branchRefused":
+      return <BranchRefusedState offer={offer} refused={stage.refused} />;
+    case "notPutBack":
+      return <NotPutBackState refused={stage.refused} />;
+    case "pushRefused":
+      return (
+        <PushRefusedState
+          refused={stage.refused}
+          sha={stage.sha}
+          branch={stage.branch}
+          canOpen={stage.canOpen}
+        />
+      );
+    case "pullRequestRefused":
+      return (
+        <PullRequestRefusedState
+          offer={offer}
+          refused={stage.refused}
+          sha={stage.sha}
+          branch={stage.branch}
+        />
+      );
+    case "opened":
+      return (
+        <OpenedState
+          url={stage.url}
+          sha={stage.sha}
+          branch={stage.branch}
+          moved={stage.moved}
+          before={stage.before}
+          from={stage.from}
+        />
+      );
+  }
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-1.5">
+      <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+/** Paths are printed whole: an abbreviation guesses at a directory and
+ *  names a different file from the one being committed. */
+function Paths({ paths, muted }: { paths: string[]; muted?: boolean }) {
+  return (
+    <ul
+      className={cn(
+        "max-h-40 overflow-y-auto font-mono text-xs",
+        muted && "text-muted-foreground",
+      )}
+    >
+      {paths.map((path) => (
+        <li key={path} className="break-all">
+          {path}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/** A program's own words, whole, one line at a time, in order. Nothing is
+ *  summarised, reworded or truncated. A step that ran out of time has no
+ *  words to show, so it says what it stopped waiting for instead. */
+function Said({ refused }: { refused: Refused }) {
+  if (refused.timedOut) {
+    return <p className="text-sm">{didNotFinish(refused.seconds)}</p>;
+  }
+  return (
+    <Section title={saidLabel(refused)}>
+      <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-2 font-mono text-xs">
+        {refused.said.join("\n")}
+      </pre>
+    </Section>
+  );
+}
+
+function Row({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-3 text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="min-w-0 break-all text-right">{children}</span>
+    </div>
+  );
+}
+
+function OfferState({
+  offer,
+  stage,
+}: {
+  offer: ProjectOffer;
+  stage: Stage & { at: "offer" | "busy" };
+}) {
+  const route = useCommitOfferStore((s) => s.route);
+  const message = useCommitOfferStore((s) => s.message);
+  const pick = useCommitOfferStore((s) => s.pick);
+  const setMessage = useCommitOfferStore((s) => s.setMessage);
+  const run = useCommitOfferStore((s) => s.run);
+  const leave = useCommitOfferStore((s) => s.leave);
+  const routes = routesFor(offer);
+  const busy = stage.at === "busy";
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>
+          {commitOfferTitle(offer.files.length, offer.name)}
+        </DialogTitle>
+        <DialogDescription>{COMMIT_OFFER_STANDING}</DialogDescription>
+      </DialogHeader>
+      <div className="space-y-4 text-sm">
+        <Section title={FILES_LABEL}>
+          <Paths paths={offer.files} />
+        </Section>
+        {offer.shared.length > 0 ? (
+          <Section title={SHARED_LABEL}>
+            <Paths paths={offer.shared} muted />
+            <p className="text-muted-foreground">{SHARED_NOTE}</p>
+          </Section>
+        ) : null}
+        {offer.others > 0 ? (
+          <Section title={OTHER_LABEL}>
+            <p className="text-muted-foreground">{otherNote(offer.others)}</p>
+          </Section>
+        ) : null}
+        <Section title={WHAT_TO_DO_LABEL}>
+          <Segments routes={routes} route={route} busy={busy} pick={pick} />
+          <p className="text-muted-foreground">{under(offer, route)}</p>
+          {offer.push !== null ? (
+            <Row label={PUSH_ROW_LABEL}>{unavailableReason(offer.push)}</Row>
+          ) : null}
+          {offer.pullRequest !== null ? (
+            <Row label={PR_ROW_LABEL}>
+              {unavailableReason(offer.pullRequest)}
+            </Row>
+          ) : null}
+        </Section>
+        <Section title={MESSAGE_LABEL}>
+          <Input
+            value={message}
+            disabled={busy}
+            onChange={(event) => setMessage(event.target.value)}
+          />
+        </Section>
+      </div>
+      <DialogFooter>
+        <Button variant="outline" disabled={busy} onClick={leave}>
+          {LEAVE_LABEL}
+        </Button>
+        <Button disabled={busy} onClick={() => void run()}>
+          {busy ? busyLabel(stage.step) : primaryLabel(route)}
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+/** The segmented control. Where every segment but `Commit` is gone it is
+ *  not drawn: one segment is not a choice. */
+function Segments({
+  routes,
+  route,
+  busy,
+  pick,
+}: {
+  routes: Route[];
+  route: Route;
+  busy: boolean;
+  pick: (route: Route) => void;
+}) {
+  if (routes.length < 2) return null;
+  return (
+    <div className="flex w-fit rounded-md border border-border p-0.5">
+      {routes.map((each) => (
+        <button
+          key={each}
+          type="button"
+          disabled={busy}
+          onClick={() => pick(each)}
+          className={cn(
+            "rounded px-3 py-1 text-sm",
+            each === route
+              ? "bg-accent text-accent-foreground"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          {segmentLabel(each)}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function segmentLabel(route: Route): string {
+  switch (route) {
+    case "commit":
+      return COMMIT_SEGMENT;
+    case "push":
+      return PUSH_SEGMENT;
+    case "pr":
+      return PR_SEGMENT;
+  }
+}
+
+function primaryLabel(route: Route): string {
+  switch (route) {
+    case "commit":
+      return COMMIT_LABEL;
+    case "push":
+      return PUSH_LABEL;
+    case "pr":
+      return PR_LABEL;
+  }
+}
+
+function busyLabel(route: Route): string {
+  switch (route) {
+    case "commit":
+      return COMMITTING_LABEL;
+    case "push":
+      return PUSHING_LABEL;
+    case "pr":
+      return OPENING_LABEL;
+  }
+}
+
+/** What the picked segment does, said under the segments. */
+function under(offer: ProjectOffer, route: Route): string {
+  switch (route) {
+    case "commit":
+      return COMMIT_STAYS;
+    case "push":
+      return offer.openNumber !== null
+        ? addsToPullRequest(offer.openNumber)
+        : pushesTo(offer.remote ?? "", offer.branch);
+    case "pr":
+      return prMoves(offer.newBranch, offer.branch);
+  }
+}
+
+function CommitRefusedState({
+  offer,
+  refused,
+  held,
+  abandoned,
+  notPutBack,
+}: {
+  offer: ProjectOffer;
+  refused: Refused;
+  held: number | null;
+  abandoned: boolean;
+  notPutBack: Refused | null;
+}) {
+  const message = useCommitOfferStore((s) => s.message);
+  const setMessage = useCommitOfferStore((s) => s.setMessage);
+  const run = useCommitOfferStore((s) => s.run);
+  const leave = useCommitOfferStore((s) => s.leave);
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>{commitRefusedTitle(refused)}</DialogTitle>
+        {abandoned ? (
+          <DialogDescription>
+            {backOn(offer.branch, offer.newBranch)}
+          </DialogDescription>
+        ) : null}
+      </DialogHeader>
+      <div className="space-y-4 text-sm">
+        <Said refused={refused} />
+        {held !== null ? <p>{stillStaged(held)}</p> : null}
+        {notPutBack !== null ? (
+          <>
+            <p>{NOT_PUT_BACK_LINE}</p>
+            <Said refused={notPutBack} />
+          </>
+        ) : null}
+        {/* The files the commit covers stay on screen, so the person can
+            still see what they are answering about. */}
+        <Section title={FILES_LABEL}>
+          <Paths paths={offer.files} />
+        </Section>
+        {offer.others > 0 ? (
+          <Section title={OTHER_LABEL}>
+            <p className="text-muted-foreground">{otherNote(offer.others)}</p>
+          </Section>
+        ) : null}
+        <Section title={MESSAGE_LABEL}>
+          {/* Never emptied by a refusal: the message the person settled on
+              is the one they are deciding whether to change. */}
+          <Input
+            value={message}
+            onChange={(event) => setMessage(event.target.value)}
+          />
+        </Section>
+      </div>
+      <DialogFooter>
+        <Button variant="outline" onClick={leave}>
+          {LEAVE_LABEL}
+        </Button>
+        {/* With the checkout still on the new branch, kendex stops there:
+            another commit would land on the branch it could not leave. */}
+        {notPutBack === null ? (
+          <Button onClick={() => void run()}>{COMMIT_AGAIN_LABEL}</Button>
+        ) : null}
+      </DialogFooter>
+    </>
+  );
+}
+
+/** Nothing was left to commit on the `pr` route and the switch back then
+ *  refused: no commit to report, the checkout still on the branch kendex
+ *  made, and kendex stops there. */
+function NotPutBackState({ refused }: { refused: Refused }) {
+  const leave = useCommitOfferStore((s) => s.leave);
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>{NOT_PUT_BACK_TITLE}</DialogTitle>
+        <DialogDescription>{NOTHING_TO_COMMIT_TOAST}</DialogDescription>
+      </DialogHeader>
+      <div className="space-y-4 text-sm">
+        <Said refused={refused} />
+      </div>
+      <DialogFooter>
+        <Button variant="outline" onClick={leave}>
+          {LEAVE_LABEL}
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+/** The `pr` route's first step refused: nothing has moved, and the same
+ *  offer stands without the segment that failed. */
+function BranchRefusedState({
+  offer,
+  refused,
+}: {
+  offer: ProjectOffer;
+  refused: Refused;
+}) {
+  const route = useCommitOfferStore((s) => s.route);
+  const pick = useCommitOfferStore((s) => s.pick);
+  const run = useCommitOfferStore((s) => s.run);
+  const leave = useCommitOfferStore((s) => s.leave);
+  // The store moved the picked route off `pr` when it entered this state.
+  const routes = routesFor(offer).filter((each) => each !== "pr");
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>
+          {refused.timedOut
+            ? commitRefusedTitle(refused)
+            : BRANCH_REFUSED_TITLE}
+        </DialogTitle>
+      </DialogHeader>
+      <div className="space-y-4 text-sm">
+        <Said refused={refused} />
+        <p>{BRANCH_REFUSED_LINE}</p>
+        <Section title={WHAT_TO_DO_LABEL}>
+          <Segments routes={routes} route={route} busy={false} pick={pick} />
+          <p className="text-muted-foreground">{under(offer, route)}</p>
+        </Section>
+      </div>
+      <DialogFooter>
+        <Button variant="outline" onClick={leave}>
+          {LEAVE_LABEL}
+        </Button>
+        <Button onClick={() => void run()}>{primaryLabel(route)}</Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+function PushRefusedState({
+  refused,
+  sha,
+  branch,
+  canOpen,
+}: {
+  refused: Refused;
+  sha: string;
+  branch: string;
+  canOpen: boolean;
+}) {
+  const leave = useCommitOfferStore((s) => s.leave);
+  const openPullRequest = useCommitOfferStore((s) => s.openPullRequest);
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>{pushRefusedTitle(refused)}</DialogTitle>
+      </DialogHeader>
+      <div className="space-y-4 text-sm">
+        <Row label={COMMIT_ROW_LABEL}>{commitOn(sha, branch)}</Row>
+        <Said refused={refused} />
+        <p>{commitIsOn(branch)}</p>
+      </div>
+      <DialogFooter>
+        <Button variant="outline" onClick={leave}>
+          {LEAVE_IT_HERE_LABEL}
+        </Button>
+        {canOpen ? (
+          <Button onClick={() => void openPullRequest()}>
+            {OPEN_PR_LABEL}
+          </Button>
+        ) : null}
+      </DialogFooter>
+    </>
+  );
+}
+
+function PullRequestRefusedState({
+  offer,
+  refused,
+  sha,
+  branch,
+}: {
+  offer: ProjectOffer;
+  refused: Refused;
+  sha: string;
+  branch: string;
+}) {
+  const leave = useCommitOfferStore((s) => s.leave);
+  const remote = offer.remote ?? "";
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>{pullRequestRefusedTitle(refused)}</DialogTitle>
+      </DialogHeader>
+      <div className="space-y-4 text-sm">
+        <Row label={COMMIT_ROW_LABEL}>{commitOn(sha, branch)}</Row>
+        <Row label={BRANCH_ROW_LABEL}>{remoteBranch(remote, branch)}</Row>
+        <Said refused={refused} />
+        <p>{branchIsOn(remote)}</p>
+      </div>
+      <DialogFooter>
+        <Button onClick={leave}>{DONE_LABEL}</Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+function OpenedState({
+  url,
+  sha,
+  branch,
+  moved,
+  before,
+  from,
+}: {
+  url: string;
+  sha: string;
+  branch: string;
+  moved: boolean;
+  before: string | null;
+  from: string;
+}) {
+  const leave = useCommitOfferStore((s) => s.leave);
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>{PR_OPEN_TITLE}</DialogTitle>
+      </DialogHeader>
+      <div className="space-y-4 text-sm">
+        <Row label={COMMIT_ROW_LABEL}>{commitOn(sha, branch)}</Row>
+        <Row label={PR_ROW_LABEL}>
+          <ExternalLink url={url}>{url}</ExternalLink>
+        </Row>
+        {moved ? <p>{nowOn(branch)}</p> : <p>{stillCarries(from)}</p>}
+        {/* kendex never moves a branch ref backwards, so the way to put it
+            back is printed rather than run. */}
+        {!moved && before !== null ? (
+          <Row label={putBackRowLabel(from)}>
+            <Copyable text={resetCommand(before)} />
+          </Row>
+        ) : null}
+      </div>
+      <DialogFooter>
+        <Button onClick={leave}>{DONE_LABEL}</Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+/** A command the person runs themselves, beside a button that copies it.
+ *  Nothing here runs it. */
+function Copyable({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <span className="inline-flex items-center gap-2">
+      <code className="font-mono text-xs">{text}</code>
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        aria-label={`Copy ${text}`}
+        onClick={() => {
+          void navigator.clipboard.writeText(text).then(() => {
+            setCopied(true);
+            window.setTimeout(() => setCopied(false), 1500);
+          });
+        }}
+      >
+        {copied ? (
+          <CheckIcon className="size-3.5" />
+        ) : (
+          <CopyIcon className="size-3.5" />
+        )}
+      </Button>
+    </span>
+  );
+}

--- a/ui/src/components/harnesses/project-card.test.tsx
+++ b/ui/src/components/harnesses/project-card.test.tsx
@@ -7,7 +7,12 @@ import { ProjectCard } from "./project-card";
 // same way before it is looked for.
 const esc = (copy: string) => copy.replace(/'/g, "&#x27;");
 
-const render = (over: { unmanaged?: number | null } = {}) =>
+const render = (
+  over: {
+    unmanaged?: number | null;
+    badge?: { text: string; variant: "destructive" | "info"; title?: string };
+  } = {},
+) =>
   renderToStaticMarkup(
     <ProjectCard
       name="acme"
@@ -57,5 +62,31 @@ describe("a place's card", () => {
     expect(before.lastIndexOf("<span")).toBeGreaterThan(
       before.lastIndexOf("<button"),
     );
+  });
+
+  // Files kendex wrote and could not offer to commit are not a fault, so
+  // the badge carries its own variant, and the reason rides on hover.
+  it("flags uncommitted files quietly, with the reason on hover", () => {
+    const html = render({
+      badge: {
+        text: "12 uncommitted",
+        variant: "info",
+        title:
+          "12 files kendex wrote are not committed. This checkout is on no branch.",
+      },
+    });
+    expect(html).toContain("12 uncommitted");
+    expect(html).toContain(
+      'title="12 files kendex wrote are not committed. This checkout is on no branch."',
+    );
+    expect(html).not.toContain("bg-destructive");
+  });
+
+  it("still flags a missing folder as a fault", () => {
+    const html = render({
+      badge: { text: "Folder not found", variant: "destructive" },
+    });
+    expect(html).toContain("Folder not found");
+    expect(html).toContain("bg-destructive");
   });
 });

--- a/ui/src/components/harnesses/project-card.tsx
+++ b/ui/src/components/harnesses/project-card.tsx
@@ -40,8 +40,11 @@ export function ProjectCard({
   onOpen: () => void;
   onKindClick: (kind: ItemKind) => void;
   emptyLabel: string;
-  /** A state worth flagging beside the name, e.g. a missing folder. */
-  badge?: string;
+  /** A state worth flagging beside the name, with the reason behind it on
+   *  hover. A missing folder is a fault and draws as one; files kendex
+   *  wrote and could not offer to commit are not, so the variant travels
+   *  with the text rather than being fixed here. */
+  badge?: { text: string; variant: "destructive" | "info"; title?: string };
   action?: ReactNode;
   /** How many items here kendex was never asked to look after. Zero says
    *  nothing: this is the one place the app mentions them, and a card
@@ -65,7 +68,11 @@ export function ProjectCard({
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
             <ShowEverythingButton name={name} path={path} onOpen={onOpen} />
-            {badge ? <Badge variant="destructive">{badge}</Badge> : null}
+            {badge ? (
+              <Badge variant={badge.variant} title={badge.title}>
+                {badge.text}
+              </Badge>
+            ) : null}
           </div>
           <p className="truncate text-[13px] text-muted-foreground">
             {subtitle}

--- a/ui/src/components/harnesses/project-list.tsx
+++ b/ui/src/components/harnesses/project-list.tsx
@@ -1,22 +1,67 @@
 import { Trash2 } from "lucide-react";
 import { useState } from "react";
-import type { Scope } from "@/bindings";
+import type { ProjectFlag, Scope } from "@/bindings";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { AddProjectDialog } from "@/components/harnesses/add-project-dialog";
 import { ProjectCard } from "@/components/harnesses/project-card";
 import { ScanFolderDialog } from "@/components/harnesses/scan-folder-dialog";
 import { Button } from "@/components/ui/button";
 import { unmanagedCount } from "@/lib/audit-counts";
+import {
+  NOT_CHECKED_BADGE,
+  notChecked,
+  uncommittedBadge,
+  uncommittedInProgress,
+  uncommittedNoBranch,
+} from "@/lib/copy-commit-offer";
 import { type ItemPlace, installedCountByKind } from "@/lib/derive";
 import { CONTENT_WIDTH, PAGE_BODY } from "@/lib/layout";
 import { sameScope } from "@/lib/scope";
 import { cn } from "@/lib/utils";
 import { useAuditOnMount, useAuditStore } from "@/stores/audit";
+import { useCommitOfferStore } from "@/stores/commit-offer";
 import { useNavStore } from "@/stores/nav";
 import { useScanStore } from "@/stores/scan";
 import { useSettingsStore } from "@/stores/settings";
 
 const GLOBAL: Scope = { scope: "global" };
+
+/** What the card flags beside the project's name. A missing folder is a
+ *  fault and outranks everything; uncommitted files kendex wrote are not a
+ *  fault, and their reason is on hover the way the card already hides a
+ *  status word behind one. */
+function badgeFor(
+  root: string,
+  missing: string[],
+  flagged: ProjectFlag[],
+):
+  | { text: string; variant: "destructive" | "info"; title?: string }
+  | undefined {
+  if (missing.includes(root))
+    return { text: "Folder not found", variant: "destructive" };
+  const flag = flagged.find((each) => each.root === root);
+  if (!flag) return undefined;
+  switch (flag.reason.kind) {
+    case "noBranch":
+      return {
+        text: uncommittedBadge(flag.count),
+        variant: "info",
+        title: uncommittedNoBranch(flag.count),
+      };
+    case "inProgress":
+      return {
+        text: uncommittedBadge(flag.count),
+        variant: "info",
+        title: uncommittedInProgress(flag.count, flag.reason.operation),
+      };
+    case "unreadable":
+      return {
+        text: NOT_CHECKED_BADGE,
+        variant: "info",
+        title: notChecked(flag.reason.said),
+      };
+  }
+}
 
 /** "Projects": personal plus every registered project, one card each. */
 export function ProjectList() {
@@ -44,6 +89,10 @@ export function ProjectList() {
   const [adding, setAdding] = useState(false);
   const [scanning, setScanning] = useState(false);
 
+  // Projects where kendex owns changed files and no offer can be made: a
+  // dialog that offers nothing is a modal a person has to dismiss for no
+  // reason, so the state is flagged on the card instead.
+  const flagged = useCommitOfferStore((s) => s.flagged);
   const items = result?.items ?? [];
   const projects = settings?.projects ?? [];
   // A card counts one place and links to that place. Both read the same
@@ -91,11 +140,7 @@ export function ProjectList() {
                 path={root}
                 counts={[...installedCountByKind(items, place).entries()]}
                 emptyLabel="Nothing from kendex yet."
-                badge={
-                  result?.missingProjects.includes(root)
-                    ? "Folder not found"
-                    : undefined
-                }
+                badge={badgeFor(root, result?.missingProjects ?? [], flagged)}
                 onOpen={() => goToLibrary(place)}
                 onKindClick={(kind) => goToLibrary({ ...place, kind })}
                 unmanaged={notManaged(scope)}

--- a/ui/src/components/package/package-version-actions.ts
+++ b/ui/src/components/package/package-version-actions.ts
@@ -13,7 +13,7 @@ import {
   VERSION_ERROR_TITLE,
 } from "@/lib/copy";
 import { UPDATES_ONE_AT_A_TIME_NOTE } from "@/lib/copy-updates";
-import { rescanEverything } from "@/lib/rescan";
+import { offerToCommit, rescanEverything, trackedProjects } from "@/lib/rescan";
 import { settled } from "@/lib/settled";
 import { saying } from "@/lib/undone";
 import { workOut } from "@/lib/updates-read-state";
@@ -43,6 +43,7 @@ export function packageVersionActions(
     // the same call the updates store's own apply makes, on the rule
     // `rescan.ts`'s header states.
     void rescanEverything();
+    void offerToCommit(trackedProjects());
   };
   // Every one of these applies a plan that can refuse a rendering, so
   // none of them toasts off the click: the command's own report says what

--- a/ui/src/lib/copy-commit-offer.test.ts
+++ b/ui/src/lib/copy-commit-offer.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it } from "vitest";
+import type { Refused } from "@/bindings";
+import {
+  addsToPullRequest,
+  BRANCH_REFUSED_LINE,
+  BRANCH_REFUSED_TITLE,
+  BRANCH_ROW_LABEL,
+  backOn,
+  branchIsOn,
+  COMMIT_AGAIN_LABEL,
+  COMMIT_LABEL,
+  COMMIT_OFFER_SETTING_DESCRIPTION,
+  COMMIT_OFFER_SETTING_LABEL,
+  COMMIT_OFFER_STANDING,
+  COMMIT_ROW_LABEL,
+  COMMIT_SEGMENT,
+  COMMIT_STAYS,
+  COMMITTING_LABEL,
+  commitIsOn,
+  commitOfferTitle,
+  commitOn,
+  commitRefusedTitle,
+  committedToast,
+  DONE_LABEL,
+  didNotFinish,
+  FILES_LABEL,
+  GH_SAID_LABEL,
+  GIT_PROJECTS_SECTION,
+  GIT_SAID_LABEL,
+  LEAVE_IT_HERE_LABEL,
+  LEAVE_LABEL,
+  MESSAGE_LABEL,
+  NOT_CHECKED_BADGE,
+  NOT_PUT_BACK_LINE,
+  NOT_PUT_BACK_TITLE,
+  NOTHING_TO_COMMIT_TOAST,
+  notChecked,
+  nowOn,
+  OPEN_PR_LABEL,
+  OPENING_LABEL,
+  OTHER_LABEL,
+  otherNote,
+  PR_LABEL,
+  PR_OPEN_TITLE,
+  PR_ROW_LABEL,
+  PR_SEGMENT,
+  PUSH_LABEL,
+  PUSH_ROW_LABEL,
+  PUSH_SEGMENT,
+  PUSHING_LABEL,
+  prMoves,
+  pullRequestRefusedTitle,
+  pushedToast,
+  pushesTo,
+  pushRefusedTitle,
+  putBackRowLabel,
+  remoteBranch,
+  resetCommand,
+  SHARED_LABEL,
+  SHARED_NOTE,
+  saidLabel,
+  stillCarries,
+  stillStaged,
+  unavailableReason,
+  uncommittedBadge,
+  uncommittedInProgress,
+  uncommittedNoBranch,
+  WHAT_TO_DO_LABEL,
+} from "./copy-commit-offer";
+
+// The design's example values, `docs/design/post-refresh-commit-flow.md`
+// § App: every string below is the one its table prints for them.
+const FILES = 12;
+const OTHERS = 4;
+const PROJECT = "site";
+const REMOTE = "origin";
+const BRANCH = "main";
+const NEW_BRANCH = "kendex/renders";
+const SHA = "9fbb1a2";
+const NUMBER = 41;
+const BEFORE = "4c1d90e";
+const SECONDS = 300;
+
+const refused = (over: Partial<Refused> = {}): Refused => ({
+  step: "the commit",
+  said: ["commit-msg: crates/ changed without a changelog entry"],
+  timedOut: false,
+  seconds: SECONDS,
+  gh: false,
+  ...over,
+});
+
+describe("the offer state", () => {
+  it("prints the design's words for its example values", () => {
+    expect(commitOfferTitle(FILES, PROJECT)).toBe(
+      "kendex changed 12 files in site",
+    );
+    expect(commitOfferTitle(1, PROJECT)).toBe("kendex changed 1 file in site");
+    expect(COMMIT_OFFER_STANDING).toBe(
+      "These are the files kendex writes in this repository. Nothing is committed yet.",
+    );
+    expect(FILES_LABEL).toBe("Files");
+    expect(SHARED_LABEL).toBe("Shared files");
+    expect(SHARED_NOTE).toBe(
+      "kendex writes one key in each of these. Committing them would commit your own changes to them too, so kendex leaves them to you.",
+    );
+    expect(OTHER_LABEL).toBe("Other changes");
+    expect(otherNote(OTHERS)).toBe(
+      "4 other files in this repository changed. kendex does not commit these.",
+    );
+    expect(otherNote(1)).toBe(
+      "1 other file in this repository changed. kendex does not commit these.",
+    );
+    expect(WHAT_TO_DO_LABEL).toBe("What to do");
+    expect(COMMIT_SEGMENT).toBe("Commit");
+    expect(PUSH_SEGMENT).toBe("Commit and push");
+    expect(PR_SEGMENT).toBe("Pull request");
+    expect(COMMIT_STAYS).toBe("The commit stays in this checkout.");
+    expect(pushesTo(REMOTE, BRANCH)).toBe("Pushes to origin/main.");
+    expect(addsToPullRequest(NUMBER)).toBe(
+      "Adds a commit to pull request #41.",
+    );
+    expect(prMoves(NEW_BRANCH, BRANCH)).toBe(
+      "Commits on kendex/renders and opens a pull request. This checkout moves to that branch. main stays where it is.",
+    );
+    expect(MESSAGE_LABEL).toBe("Message");
+    expect(LEAVE_LABEL).toBe("Leave as diffs");
+    expect(COMMIT_LABEL).toBe("Commit");
+    expect(PUSH_LABEL).toBe("Commit and push");
+    expect(PR_LABEL).toBe("Open pull request");
+  });
+});
+
+describe("the rows for a segment a precondition removed", () => {
+  // The `ghSaid` row is gh's own first line, not the design's fixed
+  // `gh is not signed in. Run gh auth login.`: kendex does not decide what
+  // gh meant.
+  it("labels the row and names the reason", () => {
+    expect(PUSH_ROW_LABEL).toBe("Push");
+    expect(PR_ROW_LABEL).toBe("Pull request");
+    expect(unavailableReason({ kind: "noRemote" })).toBe(
+      "This repository has no remote.",
+    );
+    expect(unavailableReason({ kind: "remoteNotDecidable" })).toBe(
+      "This branch tracks no remote and the repository has more than one.",
+    );
+    expect(unavailableReason({ kind: "ghMissing" })).toBe(
+      "gh is not installed.",
+    );
+    expect(
+      unavailableReason({
+        kind: "ghSaid",
+        line: "To get started with GitHub CLI, please run:  gh auth login",
+      }),
+    ).toBe("To get started with GitHub CLI, please run:  gh auth login");
+  });
+});
+
+describe("the busy state", () => {
+  it("names the step running, with an ellipsis", () => {
+    expect(COMMITTING_LABEL).toBe("Committing…");
+    expect(PUSHING_LABEL).toBe("Pushing…");
+    expect(OPENING_LABEL).toBe("Opening the pull request…");
+  });
+});
+
+describe("the result states", () => {
+  it("toasts the two that close and draws the pull request", () => {
+    expect(committedToast(FILES)).toBe("Committed 12 files");
+    expect(committedToast(1)).toBe("Committed 1 file");
+    expect(pushedToast(FILES)).toBe("Committed and pushed 12 files");
+    expect(NOTHING_TO_COMMIT_TOAST).toBe("Nothing to commit");
+    expect(PR_OPEN_TITLE).toBe("Pull request open");
+    expect(COMMIT_ROW_LABEL).toBe("Commit");
+    expect(commitOn(SHA, NEW_BRANCH)).toBe("9fbb1a2 on kendex/renders");
+    expect(nowOn(NEW_BRANCH)).toBe("This checkout is now on kendex/renders.");
+    expect(DONE_LABEL).toBe("Done");
+    // The refused-push recovery's two added rows.
+    expect(stillCarries(BRANCH)).toBe(
+      "main in this checkout still carries the commit.",
+    );
+    expect(putBackRowLabel(BRANCH)).toBe("To put main back");
+    expect(resetCommand(BEFORE)).toBe("git reset --mixed 4c1d90e");
+  });
+});
+
+describe("the refusal states", () => {
+  it("prints each title, section heading, line and footer", () => {
+    expect(commitRefusedTitle(refused())).toBe("The commit was refused");
+    expect(commitRefusedTitle(refused({ step: "the check" }))).toBe(
+      "The files could not be checked",
+    );
+    expect(NOT_PUT_BACK_TITLE).toBe("The checkout could not be put back");
+    expect(commitRefusedTitle(refused({ step: "the staging" }))).toBe(
+      "The files could not be staged",
+    );
+    expect(GIT_SAID_LABEL).toBe("What git said");
+    expect(GH_SAID_LABEL).toBe("What gh said");
+    expect(saidLabel(refused())).toBe("What git said");
+    expect(saidLabel(refused({ gh: true }))).toBe("What gh said");
+    expect(COMMIT_AGAIN_LABEL).toBe("Commit again");
+    expect(stillStaged(OTHERS)).toBe(
+      "kendex staged 4 files it could not unstage. They are still staged.",
+    );
+    expect(BRANCH_REFUSED_TITLE).toBe("The branch could not be made");
+    expect(BRANCH_REFUSED_LINE).toBe(
+      "Nothing was committed and this checkout has not moved.",
+    );
+    expect(backOn(BRANCH, NEW_BRANCH)).toBe(
+      "This checkout is back on main and kendex/renders is gone.",
+    );
+    expect(NOT_PUT_BACK_LINE).toBe("The checkout could not be put back.");
+    expect(pushRefusedTitle(refused({ step: "the push" }))).toBe(
+      "Committed, not pushed",
+    );
+    expect(commitOn(SHA, BRANCH)).toBe("9fbb1a2 on main");
+    expect(commitIsOn(BRANCH)).toBe(
+      "The commit is on main in this checkout. kendex did not undo it.",
+    );
+    expect(LEAVE_IT_HERE_LABEL).toBe("Leave it here");
+    expect(OPEN_PR_LABEL).toBe("Open a pull request");
+    expect(pullRequestRefusedTitle(refused({ step: "the pull request" }))).toBe(
+      "Committed and pushed, no pull request",
+    );
+    expect(BRANCH_ROW_LABEL).toBe("Branch");
+    expect(remoteBranch(REMOTE, NEW_BRANCH)).toBe("origin/kendex/renders");
+    expect(branchIsOn(REMOTE)).toBe(
+      "The branch is on origin. Open the pull request yourself.",
+    );
+  });
+});
+
+describe("a step that timed out", () => {
+  it("turns the title's verb and replaces the section with one line", () => {
+    const out = { timedOut: true, said: [] };
+    expect(commitRefusedTitle(refused({ ...out, step: "the commit" }))).toBe(
+      "The commit did not finish",
+    );
+    expect(pushRefusedTitle(refused({ ...out, step: "the push" }))).toBe(
+      "The push did not finish",
+    );
+    expect(
+      pullRequestRefusedTitle(refused({ ...out, step: "the pull request" })),
+    ).toBe("The pull request did not finish");
+    expect(didNotFinish(SECONDS)).toBe(
+      "kendex stopped waiting after 300 seconds. Whether it finished is not known here.",
+    );
+    expect(didNotFinish(1)).toBe(
+      "kendex stopped waiting after 1 second. Whether it finished is not known here.",
+    );
+  });
+});
+
+describe("the project card where no offer can be made", () => {
+  it("draws the badge and puts the reason on hover", () => {
+    expect(uncommittedBadge(FILES)).toBe("12 uncommitted");
+    expect(uncommittedNoBranch(FILES)).toBe(
+      "12 files kendex wrote are not committed. This checkout is on no branch.",
+    );
+    expect(uncommittedNoBranch(1)).toBe(
+      "1 file kendex wrote is not committed. This checkout is on no branch.",
+    );
+    expect(uncommittedInProgress(FILES, "a rebase")).toBe(
+      "12 files kendex wrote are not committed. A rebase is in progress.",
+    );
+    expect(NOT_CHECKED_BADGE).toBe("Not checked");
+    expect(notChecked(["fatal: not a git repository"])).toBe(
+      "kendex could not check the files it wrote here. git said: fatal: not a git repository",
+    );
+    expect(notChecked([])).toBe(
+      "kendex could not check the files it wrote here.",
+    );
+  });
+});
+
+describe("the setting", () => {
+  it("names the section, the row and what the switch does", () => {
+    expect(GIT_PROJECTS_SECTION).toBe("Git projects");
+    expect(COMMIT_OFFER_SETTING_LABEL).toBe("Offer to commit kendex's changes");
+    expect(COMMIT_OFFER_SETTING_DESCRIPTION).toBe(
+      "In a git project, ask what to do with the files kendex wrote.",
+    );
+  });
+});

--- a/ui/src/lib/copy-commit-offer.ts
+++ b/ui/src/lib/copy-commit-offer.ts
@@ -1,0 +1,170 @@
+// Commit-offer copy: what the window asks after kendex writes into a git
+// project, and every word of every state it can reach. Kept in one place so
+// the wording is reviewed beside the terminal's `commit_offer/block.rs`,
+// which says the same things in the same order.
+//
+// Every value in here is of the moment. The counts, the project's folder
+// name, the remote, the branches, the commit and the pull request number
+// are arguments, the way `repoEffectsTitle` takes a package name.
+
+import type { Refused, Why } from "@/bindings";
+
+const plural = (n: number) => (n === 1 ? "" : "s");
+
+export const commitOfferTitle = (files: number, project: string) =>
+  `kendex changed ${files} file${plural(files)} in ${project}`;
+
+export const COMMIT_OFFER_STANDING =
+  "These are the files kendex writes in this repository. Nothing is committed yet.";
+
+export const FILES_LABEL = "Files";
+export const SHARED_LABEL = "Shared files";
+export const SHARED_NOTE =
+  "kendex writes one key in each of these. Committing them would commit your own changes to them too, so kendex leaves them to you.";
+export const OTHER_LABEL = "Other changes";
+export const otherNote = (others: number) =>
+  `${others} other file${plural(others)} in this repository changed. kendex does not commit these.`;
+
+export const WHAT_TO_DO_LABEL = "What to do";
+export const MESSAGE_LABEL = "Message";
+
+export const COMMIT_SEGMENT = "Commit";
+export const PUSH_SEGMENT = "Commit and push";
+export const PR_SEGMENT = "Pull request";
+
+export const COMMIT_STAYS = "The commit stays in this checkout.";
+export const pushesTo = (remote: string, branch: string) =>
+  `Pushes to ${remote}/${branch}.`;
+export const addsToPullRequest = (number: number) =>
+  `Adds a commit to pull request #${number}.`;
+export const prMoves = (newBranch: string, from: string) =>
+  `Commits on ${newBranch} and opens a pull request. This checkout moves to that branch. ${from} stays where it is.`;
+
+export const LEAVE_LABEL = "Leave as diffs";
+export const LEAVE_IT_HERE_LABEL = "Leave it here";
+export const COMMIT_LABEL = "Commit";
+export const PUSH_LABEL = "Commit and push";
+export const PR_LABEL = "Open pull request";
+export const COMMIT_AGAIN_LABEL = "Commit again";
+export const OPEN_PR_LABEL = "Open a pull request";
+export const DONE_LABEL = "Done";
+
+export const COMMITTING_LABEL = "Committing…";
+export const PUSHING_LABEL = "Pushing…";
+export const OPENING_LABEL = "Opening the pull request…";
+
+export const PUSH_ROW_LABEL = "Push";
+export const PR_ROW_LABEL = "Pull request";
+export const COMMIT_ROW_LABEL = "Commit";
+export const BRANCH_ROW_LABEL = "Branch";
+export const putBackRowLabel = (from: string) => `To put ${from} back`;
+
+/** Why a choice is not on offer. A refusal `gh` itself worded travels as
+ *  gh's own first line: kendex does not decide what it means. */
+export function unavailableReason(why: Why): string {
+  switch (why.kind) {
+    case "noRemote":
+      return "This repository has no remote.";
+    case "remoteNotDecidable":
+      return "This branch tracks no remote and the repository has more than one.";
+    case "ghMissing":
+      return "gh is not installed.";
+    case "ghSaid":
+      return why.line;
+  }
+}
+
+export const GIT_SAID_LABEL = "What git said";
+export const GH_SAID_LABEL = "What gh said";
+
+export const saidLabel = (refused: Refused) =>
+  refused.gh ? GH_SAID_LABEL : GIT_SAID_LABEL;
+
+/** A step that ran out of time. Its outcome is not known here, so it is
+ *  never reported as done. */
+export const didNotFinish = (seconds: number) =>
+  `kendex stopped waiting after ${seconds} second${plural(seconds)}. Whether it finished is not known here.`;
+
+const capitalised = (step: string) =>
+  step.charAt(0).toUpperCase() + step.slice(1);
+
+/** The title of the state a refused commit reaches. The staging is its own
+ *  step and its own title: it happens before any commit, so the words the
+ *  commit's title carries would name something that never ran. */
+export function commitRefusedTitle(refused: Refused): string {
+  if (refused.timedOut) return `${capitalised(refused.step)} did not finish`;
+  switch (refused.step) {
+    case "the staging":
+      return "The files could not be staged";
+    // The set is re-derived before the commit, and that read can fail
+    // like the one the offer was built from.
+    case "the check":
+      return "The files could not be checked";
+    default:
+      return "The commit was refused";
+  }
+}
+
+export const BRANCH_REFUSED_TITLE = "The branch could not be made";
+export const BRANCH_REFUSED_LINE =
+  "Nothing was committed and this checkout has not moved.";
+export const backOn = (from: string, branch: string) =>
+  `This checkout is back on ${from} and ${branch} is gone.`;
+
+/** The commit refused on the `pr` route and the switch back, or the
+ *  removal of the empty branch, refused too: the checkout is still on the
+ *  new branch, and kendex stops there. Both programs' words are shown,
+ *  this line between them. */
+export const NOT_PUT_BACK_LINE = "The checkout could not be put back.";
+/** The same state where no commit was refused first: the set emptied on
+ *  the `pr` route and the switch back refused. */
+export const NOT_PUT_BACK_TITLE = "The checkout could not be put back";
+
+/** kendex staged paths it could not then unstage, against the rule that
+ *  the index ends as it began. */
+export const stillStaged = (count: number) =>
+  `kendex staged ${count} file${plural(count)} it could not unstage. They are still staged.`;
+
+export const PUSH_REFUSED_TITLE = "Committed, not pushed";
+export const pushRefusedTitle = (refused: Refused) =>
+  refused.timedOut ? "The push did not finish" : PUSH_REFUSED_TITLE;
+export const commitIsOn = (branch: string) =>
+  `The commit is on ${branch} in this checkout. kendex did not undo it.`;
+export const stillCarries = (from: string) =>
+  `${from} in this checkout still carries the commit.`;
+export const resetCommand = (before: string) => `git reset --mixed ${before}`;
+
+export const PR_REFUSED_TITLE = "Committed and pushed, no pull request";
+export const pullRequestRefusedTitle = (refused: Refused) =>
+  refused.timedOut ? "The pull request did not finish" : PR_REFUSED_TITLE;
+export const branchIsOn = (remote: string) =>
+  `The branch is on ${remote}. Open the pull request yourself.`;
+
+export const PR_OPEN_TITLE = "Pull request open";
+export const commitOn = (sha: string, branch: string) => `${sha} on ${branch}`;
+export const remoteBranch = (remote: string, branch: string) =>
+  `${remote}/${branch}`;
+export const nowOn = (branch: string) => `This checkout is now on ${branch}.`;
+
+export const committedToast = (files: number) =>
+  `Committed ${files} file${plural(files)}`;
+export const pushedToast = (files: number) =>
+  `Committed and pushed ${files} file${plural(files)}`;
+export const NOTHING_TO_COMMIT_TOAST = "Nothing to commit";
+
+/** The project card's badge, for the two states where kendex owns changed
+ *  files and cannot offer, and for a repository it could not read. */
+export const uncommittedBadge = (count: number) => `${count} uncommitted`;
+export const NOT_CHECKED_BADGE = "Not checked";
+
+export const uncommittedNoBranch = (count: number) =>
+  `${count} file${plural(count)} kendex wrote ${count === 1 ? "is" : "are"} not committed. This checkout is on no branch.`;
+export const uncommittedInProgress = (count: number, operation: string) =>
+  `${count} file${plural(count)} kendex wrote ${count === 1 ? "is" : "are"} not committed. ${capitalised(operation)} is in progress.`;
+export const notChecked = (said: string[]) =>
+  `kendex could not check the files it wrote here.${said.length > 0 ? ` git said: ${said[0]}` : ""}`;
+
+export const GIT_PROJECTS_SECTION = "Git projects";
+export const COMMIT_OFFER_SETTING_LABEL = "Offer to commit kendex's changes";
+export const COMMIT_OFFER_SETTING_DESCRIPTION =
+  "In a git project, ask what to do with the files kendex wrote.";

--- a/ui/src/lib/rescan.ts
+++ b/ui/src/lib/rescan.ts
@@ -56,8 +56,10 @@
 // a project card ends up hiding the only way to the ones it holds — the
 // reason the registry writes above rescan at all.
 import { useAuditStore } from "@/stores/audit";
+import { useCommitOfferStore } from "@/stores/commit-offer";
 import { useProvenanceStore } from "@/stores/provenance";
 import { useScanStore } from "@/stores/scan";
+import { useSettingsStore } from "@/stores/settings";
 
 export async function rescanEverything(opts?: {
   /** Say so when the scan fails, however many times running. Somebody who
@@ -111,6 +113,31 @@ const readBehindWrites = (): Promise<void> => {
   return queued;
 };
 
+/** Ask what to do with the files a write left in a git project.
+ *
+ *  Every write that renders into a project checkout comes through here:
+ *  [`writingRepo`] calls it, and so does every write that spells
+ *  `rescanEverything` out for itself — this file's header names those, and
+ *  each is a project-scope apply. The offer runs after the write, never
+ *  before it and never as part of it, and the backend answers with nothing
+ *  for a project where there is nothing to ask about.
+ *
+ *  Not awaited by its callers, for the reason the read behind a write is
+ *  not: the caller's own busy window and refusal belong to the write, and
+ *  holding either behind a git read of every project would leave a
+ *  destructive button live with nothing under it. */
+export async function offerToCommit(roots: string[]): Promise<void> {
+  await useCommitOfferStore.getState().enqueue(roots);
+}
+
+/** The project roots a write could have reached: every project this
+ *  machine tracks. A write redirected into another project writes under
+ *  the destination's root, so a caller naming only its own scope would
+ *  miss it. */
+export function trackedProjects(): string[] {
+  return useSettingsStore.getState().settings?.projects ?? [];
+}
+
 /** Run a write that reaches `repo_effects` and read the machine again
  *  behind it.
  *
@@ -131,6 +158,7 @@ export async function writingRepo<R>(body: () => Promise<R>): Promise<R> {
     return await body();
   } finally {
     void readBehindWrites();
+    void offerToCommit(trackedProjects());
   }
 }
 

--- a/ui/src/pages/settings.tsx
+++ b/ui/src/pages/settings.tsx
@@ -14,6 +14,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import {
+  COMMIT_OFFER_SETTING_DESCRIPTION,
+  COMMIT_OFFER_SETTING_LABEL,
+  GIT_PROJECTS_SECTION,
+} from "@/lib/copy-commit-offer";
 import { SETTINGS_SUBTITLE } from "@/lib/labels";
 import { CONTENT_WIDTH, PAGE_BODY } from "@/lib/layout";
 import { cn } from "@/lib/utils";
@@ -28,7 +34,8 @@ const THEME_LABELS: Record<Appearance, string> = {
 };
 
 export function SettingsPage() {
-  const { settings, onScreen, setAppearance } = useSettingsStore();
+  const { settings, onScreen, setAppearance, setCommitOffer } =
+    useSettingsStore();
   // Null until the read answers; after that the read's own answer, so a
   // version the app could not ask for says so instead of sitting on the
   // ellipsis a still-loading read wears.
@@ -103,6 +110,20 @@ export function SettingsPage() {
                   <PlusIcon />
                 </Button>
               </div>
+            </SettingRow>
+          </Section>
+
+          <Section title={GIT_PROJECTS_SECTION}>
+            <SettingRow
+              label={COMMIT_OFFER_SETTING_LABEL}
+              description={COMMIT_OFFER_SETTING_DESCRIPTION}
+            >
+              <Switch
+                checked={(settings?.["commit-offer"] ?? "ask") === "ask"}
+                onCheckedChange={(on) =>
+                  void setCommitOffer(on ? "ask" : "off")
+                }
+              />
             </SettingRow>
           </Section>
 

--- a/ui/src/pages/settings.tsx
+++ b/ui/src/pages/settings.tsx
@@ -117,8 +117,10 @@ export function SettingsPage() {
             <SettingRow
               label={COMMIT_OFFER_SETTING_LABEL}
               description={COMMIT_OFFER_SETTING_DESCRIPTION}
+              htmlFor="commit-offer"
             >
               <Switch
+                id="commit-offer"
                 checked={(settings?.["commit-offer"] ?? "ask") === "ask"}
                 onCheckedChange={(on) =>
                   void setCommitOffer(on ? "ask" : "off")

--- a/ui/src/stores/commit-offer.test.ts
+++ b/ui/src/stores/commit-offer.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { commands, type ProjectOffer } from "@/bindings";
+import { routesFor, useCommitOfferStore } from "./commit-offer";
+
+vi.mock("@/bindings", () => ({ commands: { commitOfferScan: vi.fn() } }));
+vi.mock("sonner", () => ({ toast: { info: vi.fn(), success: vi.fn() } }));
+
+/** A project with every choice standing: a remote chosen, `gh` answering,
+ *  and no pull request open for the branch. */
+const offer = (over: Partial<ProjectOffer> = {}): ProjectOffer => ({
+  root: "/home/method/dev/site",
+  name: "site",
+  files: [".claude/CLAUDE.md", ".kendex-generated.json"],
+  shared: [],
+  others: 0,
+  branch: "main",
+  remote: "origin",
+  push: null,
+  pullRequest: null,
+  openNumber: null,
+  message: "chore: kendex refresh",
+  newBranch: "kendex/renders",
+  repo: "acme/site",
+  tracked: true,
+  ...over,
+});
+
+// The rows of the design's state table that decide which segments the
+// offer draws, `docs/design/post-refresh-commit-flow.md` § State table.
+describe("the choices an offer carries", () => {
+  it("offers all three where nothing removed one", () => {
+    expect(routesFor(offer())).toEqual(["commit", "push", "pr"]);
+  });
+
+  it("offers commit only with no remote", () => {
+    expect(
+      routesFor(
+        offer({
+          remote: null,
+          repo: null,
+          push: { kind: "noRemote" },
+          pullRequest: { kind: "noRemote" },
+        }),
+      ),
+    ).toEqual(["commit"]);
+  });
+
+  it("keeps the push where only gh is missing", () => {
+    expect(
+      routesFor(offer({ repo: null, pullRequest: { kind: "ghMissing" } })),
+    ).toEqual(["commit", "push"]);
+  });
+
+  it("drops the pull request where one is already open", () => {
+    expect(routesFor(offer({ openNumber: 41 }))).toEqual(["commit", "push"]);
+  });
+});
+
+// kendex asks at most once per run per project: a project already in the
+// line keeps its place, and leaving takes it off the line.
+describe("the line of projects to ask", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCommitOfferStore.setState({
+      queue: [],
+      flagged: [],
+      stage: { at: "offer" },
+      route: "commit",
+      message: "",
+    });
+  });
+
+  it("asks each project once, whatever the write reached it twice", async () => {
+    vi.mocked(commands.commitOfferScan).mockResolvedValue({
+      status: "ok",
+      data: { offers: [offer()], flagged: [] },
+    });
+    const { enqueue } = useCommitOfferStore.getState();
+    await enqueue(["/home/method/dev/site"]);
+    await enqueue(["/home/method/dev/site"]);
+    const state = useCommitOfferStore.getState();
+    expect(state.queue.map((each) => each.root)).toEqual([
+      "/home/method/dev/site",
+    ]);
+    expect(state.message).toBe("chore: kendex refresh");
+    expect(commands.commitOfferScan).toHaveBeenCalledTimes(2);
+  });
+
+  it("asks nothing when the write could reach no project", async () => {
+    await useCommitOfferStore.getState().enqueue([]);
+    expect(commands.commitOfferScan).not.toHaveBeenCalled();
+  });
+
+  it("leaves the files as diffs and moves to the next project", async () => {
+    const second = offer({ root: "/home/method/dev/other", name: "other" });
+    vi.mocked(commands.commitOfferScan).mockResolvedValue({
+      status: "ok",
+      data: { offers: [offer(), second], flagged: [] },
+    });
+    await useCommitOfferStore.getState().enqueue(["/a", "/b"]);
+    useCommitOfferStore.getState().pick("pr");
+    useCommitOfferStore.getState().leave();
+    const state = useCommitOfferStore.getState();
+    expect(state.queue.map((each) => each.root)).toEqual([
+      "/home/method/dev/other",
+    ]);
+    expect(state.stage).toEqual({ at: "offer" });
+    expect(state.route).toBe("commit");
+    useCommitOfferStore.getState().leave();
+    expect(useCommitOfferStore.getState().queue).toEqual([]);
+  });
+});

--- a/ui/src/stores/commit-offer.ts
+++ b/ui/src/stores/commit-offer.ts
@@ -1,0 +1,369 @@
+import { toast } from "sonner";
+import { create } from "zustand";
+import {
+  type CommitOfferScan,
+  commands,
+  type ProjectFlag,
+  type ProjectOffer,
+  type Refused,
+} from "@/bindings";
+import {
+  committedToast,
+  NOTHING_TO_COMMIT_TOAST,
+  pushedToast,
+} from "@/lib/copy-commit-offer";
+import { useProblemsStore } from "./problems";
+
+/** Which of the three the person picked. `leave` is not one: leaving is
+ *  dismissing, and nothing runs for it. */
+export type Route = "commit" | "push" | "pr";
+
+/** Where the dialog is. Each state carries exactly what its own copy
+ *  draws, so no view has to guess which fields apply to it. */
+export type Stage =
+  | { at: "offer" }
+  | { at: "busy"; step: Route }
+  | {
+      at: "commitRefused";
+      refused: Refused;
+      stillStaged: number | null;
+      /** The commit refused on the `pr` route and the branch kendex made
+       *  is gone again, which the state says in one added line. */
+      abandoned: boolean;
+      /** The commit refused on the `pr` route and the way back refused
+       *  too: the checkout is still on the new branch, and this carries
+       *  the words of the step that would have put it back. Null on every
+       *  other path. */
+      notPutBack: Refused | null;
+    }
+  | { at: "branchRefused"; refused: Refused }
+  /** Nothing was left to commit on the `pr` route and the switch back
+   *  then refused: no commit to report, and the checkout is still on the
+   *  branch kendex made, so kendex stops there. */
+  | { at: "notPutBack"; refused: Refused }
+  | {
+      at: "pushRefused";
+      refused: Refused;
+      sha: string;
+      branch: string;
+      files: number;
+      /** The recovery is to put the commit on a branch of its own, so it
+       *  is offered only where a pull request can be opened and only where
+       *  the commit is not already on such a branch. */
+      canOpen: boolean;
+      before: string | null;
+    }
+  | { at: "pullRequestRefused"; refused: Refused; sha: string; branch: string }
+  | {
+      at: "opened";
+      sha: string;
+      branch: string;
+      url: string;
+      /** The checkout moved to the branch, which the `pr` route does and
+       *  the refused-push recovery does not. */
+      moved: boolean;
+      /** Where the checkout did not move, the commit the person can put
+       *  their branch back to. */
+      before: string | null;
+      from: string;
+    };
+
+interface CommitOfferState {
+  /** One entry per project the last write reached, first in line first.
+   *  Each is asked on its own and answered on its own. */
+  queue: ProjectOffer[];
+  /** Projects where kendex owns changed files and no offer can be made.
+   *  The Projects page draws these on the cards. */
+  flagged: ProjectFlag[];
+  stage: Stage;
+  route: Route;
+  message: string;
+  enqueue: (roots: string[]) => Promise<void>;
+  pick: (route: Route) => void;
+  setMessage: (message: string) => void;
+  run: () => Promise<void>;
+  openPullRequest: () => Promise<void>;
+  /** Leaving the files as diffs, which dismissing the dialog also is. */
+  leave: () => void;
+}
+
+/** The choices this offer carries, in the order the design fixes. */
+export function routesFor(offer: ProjectOffer): Route[] {
+  const routes: Route[] = ["commit"];
+  if (offer.push === null) routes.push("push");
+  // Where a pull request is already open for this branch, `pr` is not
+  // offered: the branch already has one.
+  if (offer.pullRequest === null && offer.openNumber === null)
+    routes.push("pr");
+  return routes;
+}
+
+export const useCommitOfferStore = create<CommitOfferState>((set, get) => {
+  /** Take the project at the head of the line off it, closing the dialog
+   *  when nobody is left. */
+  const advance = () => {
+    const queue = get().queue.slice(1);
+    set({
+      queue,
+      stage: { at: "offer" },
+      route: "commit",
+      message: queue[0]?.message ?? "",
+    });
+  };
+
+  /** A transport failure is not an answer about the repository: it says
+   *  nothing about what was committed, so it opens the problems dialog
+   *  rather than closing over the project in silence. */
+  const transport = (message: string) => {
+    useProblemsStore.getState().showError({
+      title: "Couldn't reach kendex",
+      message,
+      steps: ["Try again", "If it keeps happening, restart kendex"],
+    });
+    set({ stage: { at: "offer" } });
+  };
+
+  const head = () => get().queue[0];
+
+  /** The last step of both pull-request routes. `moved` says whether the
+   *  checkout is now on the branch, which the `pr` route does and the
+   *  refused-push recovery deliberately does not. */
+  const open = async (
+    offer: ProjectOffer,
+    sha: string,
+    branch: string,
+    files: number,
+    moved: boolean,
+    before: string | null,
+    from: string,
+  ) => {
+    const repo = offer.repo;
+    if (repo === null) return;
+    set({ stage: { at: "busy", step: "pr" } });
+    const opened = await commands.commitOfferOpenPullRequest(
+      repo,
+      branch,
+      from,
+      get().message,
+      files,
+    );
+    if (opened.status === "error") return transport(opened.error);
+    if (opened.data.kind === "refused") {
+      set({
+        stage: {
+          at: "pullRequestRefused",
+          refused: opened.data.refused,
+          sha,
+          branch,
+        },
+      });
+      return;
+    }
+    set({
+      stage: {
+        at: "opened",
+        sha,
+        branch,
+        url: opened.data.url,
+        moved,
+        before,
+        from,
+      },
+    });
+  };
+
+  return {
+    queue: [],
+    flagged: [],
+    stage: { at: "offer" },
+    route: "commit",
+    message: "",
+
+    enqueue: async (roots) => {
+      if (roots.length === 0) return;
+      const response = await commands.commitOfferScan(roots);
+      if (response.status === "error") {
+        // The write itself landed and was reported by its own caller; a
+        // read behind it that failed is said here and nowhere else.
+        transport(response.error);
+        return;
+      }
+      const found: CommitOfferScan = response.data;
+      const { queue } = get();
+      // A project already in the line keeps its place and its answer in
+      // progress: kendex asks at most once per project.
+      const waiting = new Set(queue.map((offer) => offer.root));
+      const added = found.offers.filter((offer) => !waiting.has(offer.root));
+      const next = [...queue, ...added];
+      set({
+        queue: next,
+        flagged: found.flagged,
+        message: queue.length > 0 ? get().message : (next[0]?.message ?? ""),
+      });
+    },
+
+    pick: (route) => set({ route }),
+    setMessage: (message) => set({ message }),
+
+    leave: () => advance(),
+
+    run: async () => {
+      const offer = head();
+      if (!offer) return;
+      const { route, message } = get();
+      set({ stage: { at: "busy", step: route } });
+      // Read before the commit: it is the commit a recovery would put the
+      // branch back to, and after the commit it is no longer HEAD.
+      const previous = await commands.commitOfferPreviousHead(offer.root);
+      const before = previous.status === "ok" ? previous.data : null;
+      if (route === "pr") {
+        const started = await commands.commitOfferStartBranch(
+          offer.root,
+          offer.newBranch,
+        );
+        if (started.status === "error") return transport(started.error);
+        if (started.data.kind === "refused") {
+          // The pull-request segment is gone from that state, so the
+          // picked one moves to a route it still offers.
+          set({
+            stage: { at: "branchRefused", refused: started.data.refused },
+            route: "commit",
+          });
+          return;
+        }
+      }
+      const committed = await commands.commitOfferCommit(offer.root, message);
+      if (committed.status === "error") return transport(committed.error);
+      if (committed.data.kind === "nothing") {
+        if (route === "pr") {
+          // The checkout was switched to the new branch before the commit
+          // and no commit landed on it, so without this the branch would
+          // be left empty with the checkout on it.
+          const back = await commands.commitOfferAbandonBranch(
+            offer.root,
+            offer.newBranch,
+          );
+          if (back.status === "error") return transport(back.error);
+          if (back.data.kind === "refused") {
+            set({ stage: { at: "notPutBack", refused: back.data.refused } });
+            return;
+          }
+        }
+        toast.info(NOTHING_TO_COMMIT_TOAST);
+        advance();
+        return;
+      }
+      if (committed.data.kind === "refused") {
+        const { refused, stillStaged } = committed.data;
+        let abandoned = false;
+        if (route === "pr") {
+          // The branch carries no commit of its own, so kendex clears its
+          // own leftover: back to where the person was, and the empty
+          // branch removed.
+          const back = await commands.commitOfferAbandonBranch(
+            offer.root,
+            offer.newBranch,
+          );
+          if (back.status === "error") return transport(back.error);
+          if (back.data.kind === "refused") {
+            // Both refusals are shown: the commit's own, and the one that
+            // left the checkout on the new branch.
+            set({
+              stage: {
+                at: "commitRefused",
+                refused,
+                stillStaged,
+                abandoned: false,
+                notPutBack: back.data.refused,
+              },
+            });
+            return;
+          }
+          abandoned = true;
+        }
+        set({
+          stage: {
+            at: "commitRefused",
+            refused,
+            stillStaged,
+            abandoned,
+            notPutBack: null,
+          },
+        });
+        return;
+      }
+      const { sha, files } = committed.data;
+      if (route === "commit") {
+        toast.success(committedToast(files));
+        advance();
+        return;
+      }
+      const remote = offer.remote;
+      if (remote === null) {
+        // Neither push route is offered without a remote, so reaching
+        // here would be the dialog offering what the scan refused.
+        transport("kendex has no remote to push to in this project.");
+        return;
+      }
+      const branch = route === "pr" ? offer.newBranch : offer.branch;
+      set({ stage: { at: "busy", step: "push" } });
+      const pushed = await commands.commitOfferPush(
+        offer.root,
+        remote,
+        branch,
+        route === "pr" ? false : offer.tracked,
+      );
+      if (pushed.status === "error") return transport(pushed.error);
+      if (pushed.data.kind === "refused") {
+        set({
+          stage: {
+            at: "pushRefused",
+            refused: pushed.data.refused,
+            sha,
+            branch,
+            files,
+            // On the `pr` route the commit is already on a branch of its
+            // own, which is what the recovery would have made.
+            canOpen: route !== "pr" && offer.pullRequest === null,
+            before,
+          },
+        });
+        return;
+      }
+      if (route === "push") {
+        toast.success(pushedToast(files));
+        advance();
+        return;
+      }
+      await open(offer, sha, branch, files, true, null, offer.branch);
+    },
+
+    openPullRequest: async () => {
+      const offer = head();
+      const stage = get().stage;
+      if (!offer || stage.at !== "pushRefused") return;
+      const remote = offer.remote;
+      if (remote === null) return;
+      set({ stage: { at: "busy", step: "pr" } });
+      const pushed = await commands.commitOfferPushHead(
+        offer.root,
+        remote,
+        offer.newBranch,
+      );
+      if (pushed.status === "error") return transport(pushed.error);
+      if (pushed.data.kind === "refused") {
+        set({ stage: { ...stage, refused: pushed.data.refused } });
+        return;
+      }
+      await open(
+        offer,
+        stage.sha,
+        offer.newBranch,
+        stage.files,
+        false,
+        stage.before,
+        stage.branch,
+      );
+    },
+  };
+});

--- a/ui/src/stores/settings.ts
+++ b/ui/src/stores/settings.ts
@@ -3,6 +3,7 @@ import {
   type Appearance,
   type AppSettings,
   type CapabilityRow,
+  type CommitOffer,
   commands,
   type SettingsRead,
   ZOOM,
@@ -23,6 +24,7 @@ interface SettingsState extends ZoomSlice, ProjectsSlice {
   capabilities: CapabilityRow[];
   load: () => Promise<void>;
   setAppearance: (appearance: Appearance) => Promise<void>;
+  setCommitOffer: (commitOffer: CommitOffer) => Promise<void>;
   setHarnessRoot: (harness: string, root: string) => Promise<void>;
 }
 
@@ -181,6 +183,27 @@ export const useSettingsStore = create<SettingsState>((set, get) => {
             {
               label: "Retry",
               onClick: () => void get().setAppearance(appearance),
+            },
+          ],
+        });
+    },
+
+    // Whether kendex asks is machine-local and takes effect on the next
+    // write; nothing on screen changes with it, so only a failure speaks.
+    setCommitOffer: async (commitOffer) => {
+      const result = await write((current) => ({
+        ...current,
+        "commit-offer": commitOffer,
+      }));
+      if (!result.ok)
+        useProblemsStore.getState().showError({
+          title: "Couldn't change the commit offer",
+          message: result.message,
+          steps: ["Try again"],
+          actions: [
+            {
+              label: "Retry",
+              onClick: () => void get().setCommitOffer(commitOffer),
             },
           ],
         });

--- a/ui/src/stores/updates-edits.ts
+++ b/ui/src/stores/updates-edits.ts
@@ -8,7 +8,7 @@ import {
   UPDATES_ONE_AT_A_TIME_NOTE,
 } from "@/lib/copy-updates";
 import { packageDisplayName } from "@/lib/labels";
-import { rescanEverything } from "@/lib/rescan";
+import { offerToCommit, rescanEverything, trackedProjects } from "@/lib/rescan";
 import { caught } from "@/lib/settled";
 import { saying } from "@/lib/undone";
 import { rowUnsettled, workOut } from "@/lib/updates-read-state";
@@ -45,6 +45,7 @@ const run = <T>(
     // Then the machine, on `rescan.ts`'s rule: asked whatever the work
     // answered, and inside the busy this wrapper holds.
     await rescanEverything();
+    void offerToCommit(trackedProjects());
   });
 
 const report = (outcome: Outcome<unknown>) => {

--- a/ui/src/stores/updates-follow.ts
+++ b/ui/src/stores/updates-follow.ts
@@ -24,7 +24,7 @@ import {
   UPDATES_ONE_AT_A_TIME_NOTE,
 } from "@/lib/copy-updates";
 import type { ReadState } from "@/lib/read-state";
-import { rescanEverything } from "@/lib/rescan";
+import { offerToCommit, rescanEverything, trackedProjects } from "@/lib/rescan";
 import { sameScope } from "@/lib/scope";
 import { settled } from "@/lib/settled";
 import { saying } from "@/lib/undone";
@@ -174,6 +174,7 @@ export function followSwitch({
         // the scan lists and the audit scores. Asked whatever the write
         // answered and whichever way the switch went, on that same rule.
         await rescanEverything();
+        void offerToCommit(trackedProjects());
       }
     });
   };

--- a/ui/src/stores/updates.ts
+++ b/ui/src/stores/updates.ts
@@ -9,7 +9,7 @@ import {
 } from "@/lib/copy-updates";
 import { countingWrites } from "@/lib/package-places";
 import { READ_PENDING } from "@/lib/read-state";
-import { rescanEverything } from "@/lib/rescan";
+import { offerToCommit, rescanEverything, trackedProjects } from "@/lib/rescan";
 import { caught, settled } from "@/lib/settled";
 import { saying } from "@/lib/undone";
 import {
@@ -160,6 +160,7 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
         // Then the machine, on `rescan.ts`'s rule: asked whatever the apply
         // answered, and inside the busy the write holds.
         await rescanEverything();
+        void offerToCommit(trackedProjects());
       });
     },
 
@@ -212,6 +213,7 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
         // plan moved, which is the wrong question for a refresh.
         wrote(rows);
         await rescanEverything();
+        void offerToCommit(trackedProjects());
       });
     },
 

--- a/ui/src/stores/write-rescan.test.ts
+++ b/ui/src/stores/write-rescan.test.ts
@@ -43,6 +43,7 @@ vi.mock("@/bindings", async (importOriginal) => ({
     scanMachine: vi.fn(),
     auditAll: vi.fn(),
     libraryProvenance: vi.fn(),
+    commitOfferScan: vi.fn(),
   },
 }));
 
@@ -113,6 +114,15 @@ beforeEach(() => {
     status: "ok",
     data: [],
   });
+  // The commit offer rides behind every write here, over the projects
+  // this machine tracks, and answers with nothing to offer.
+  vi.mocked(commands.commitOfferScan).mockResolvedValue({
+    status: "ok",
+    data: { offers: [], flagged: [] },
+  });
+  useSettingsStore.setState({
+    settings: { projects: ["/home/me/tracked"] } as never,
+  });
   useScanStore.setState({
     scanning: false,
     result: null,
@@ -140,6 +150,12 @@ beforeEach(() => {
 const readAgain = () => {
   expect(commands.scanMachine).toHaveBeenCalled();
   expect(commands.auditAll).toHaveBeenCalled();
+  // And the offer was made behind the same write, over the tracked
+  // projects: a write redirected into another project writes under that
+  // project's root, so the scope alone would miss it.
+  expect(commands.commitOfferScan).toHaveBeenCalledWith(
+    useSettingsStore.getState().settings?.projects,
+  );
 };
 
 describe("a write that reaches repo_effects and is refused", () => {


### PR DESCRIPTION
Implements the post-refresh commit, push and pull-request offer from `docs/design/post-refresh-commit-flow.md` (KEN-1026) on both surfaces: the CLI block with its numbered choices, flags and exit codes, and the app dialog with every designed state, the project-card badges and the `Git projects` setting.

The shared half lives in `crates/core/src/commit_offer/`: the path set off `GeneratedPaths` (lifted out of `generated_paths::plan`, the inventory unchanged), the one `git status` read, the branch and remote rules, the `gh` probe, and the commit, push, branch and pull-request steps with their bounds.

## Design corrections in this PR

Each changes the design document in the same commit, with the reason.

- **`--repo <url>` on every `gh` call** (gap 1 of the issue's comment). Without it `gh` resolves the repository from the remotes itself, so a project whose `origin` is GitLab and whose second remote is GitHub would be probed against a repository the push never reaches.
- **`--literal-pathspecs` before `add`, `commit` and `reset`** (gap 2). `--pathspec-file-nul` fixes the separator, not the matching; a rendered path holding `[`, `*` or `?` would otherwise match a different file. One git-wide option rather than a `:(literal)` prefix per entry, which a path beginning with `:` could defeat. The metacharacter control in `crates/core/src/commit_offer/tests.rs` fails without it.
- **Failure states for the reads, `git add`, the cleanup `git reset` and the `pr` route's switch back** (gap 3). The design bounded these steps and worded no state for them. Now: `the files kendex wrote could not be checked` (no offer, the verb's own exit), `the files could not be staged` (the commit's choices, exit 1), `kendex staged N files it could not unstage; they are still staged` (under the refusal), and `the checkout could not be put back` (the run stops, exit 1); the app has the matching title, lines and the `Not checked` badge.
- **The offer rides on `engine_common::apply_report`, not on a call in each verb.** It is the one door every verb writes a plan through, so a verb added later cannot forget to ask; once per run per project is kept by the run's own record. `update-pi` calls it itself, as designed. It also runs for a reached scope whose plan was empty: a scope with nothing left to write can still hold the files an earlier run left uncommitted, which is what `run again with --commit` relies on.
- **The flags are flattened into every verb that offers**, as the design says, and read off clap's innermost matches, so no verb list lives in `lib.rs`; `kendex list --commit` is refused.
- **The `push` label with an open pull request reads `commit them and add a commit to pull request #41`.** The design's substitution produced a non-sentence.
- **`--pull-request` with a pull request already open is refused with `no pull request: pull request #41 is already open for this branch`.** The design removed the choice and gave the flag no words.
- **The app's `Pull request` reason row carries gh's own first line**, not a fixed `gh is not signed in. Run gh auth login.`; the design's state table and § Surfacing a refusal already said gh's own words, and kendex does not decide what a refusal means.
- **The app's default message is `chore: kendex app`.** The rule is the command the person typed, and in the window there is none.
- **Nothing left to commit on the `pr` route abandons the branch** and says `this checkout is back on main and kendex/renders is gone`; the design ended the run with the checkout on an empty branch.
- **The refused-push recovery's result replaces `This checkout is now on …`** with the two put-back rows rather than adding to it, because the checkout did not move.
- **A Ctrl-C at the offer** keeps the scope, closes its ledger, skips the offer in every later project, and exits 130 once the verb has closed.
- **A refused choice does not abort the verb.** The scope still closes on its ledger line with the refusal part, nothing is counted into `failed to refresh`, and the run exits 1 once the verb has finished with nothing further printed.
- **`Commit again` after a refused commit on the `pr` route runs the `pr` route again**, on both surfaces: the branch is made once more and the commit lands on it, because that is the choice the person made.
- **The design's fixed "none of the git remotes… point to a known GitHub host" line is gone.** With `--repo` bound, `gh` never resolves remotes and never says it; the design now says gh's own first line for the repository it was bound to, whatever that is.
- **A re-read that fails at commit time** is titled `the files could not be checked` / `The files could not be checked`, not as a refused commit.
- **Nothing left to commit on the `pr` route where the switch back then fails** has its own app state: `The checkout could not be put back`, `Nothing to commit`, git's words, `Leave as diffs` only.

## Tests

- `crates/core/src/commit_offer/tests.rs`: one control per state this module detects, over a real repository with hooks, a bare `origin` and the marker files; the metacharacter must-fail; the failure-mapping tables.
- `crates/cli/src/commands/commit_offer/tests.rs`: the block's rows, the numbered choices and their renumbering, how an answer is read, the ledger parts, the flag group.
- `crates/cli/tests/commit_offer_cli.rs`: ten states end to end through the binary with a fake `gh` on the child's `PATH`, each asserting the ledger part, plus the refusal through `refresh`.
- `ui/src/lib/copy-commit-offer.test.ts`, `ui/src/stores/commit-offer.test.ts`, `ui/src/components/commit-offer-dialog.dom.test.tsx`, `project-card.test.tsx`: every app string pinned through the copy module, the routes per state, the dialog states, the badge pair.

Tracking issue: KEN-1025.


https://claude.ai/code/session_01NjtDjuibnhMPdeJx2N6Gzu
