### PR TITLE
test(KEN-1271): the pi-agents-tmux suite runs on its own tmux server

### DIFF
--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -477,15 +477,15 @@ jobs:
       # Pi 0.84.x is the release the extensions are audited against, so the
       # suites that assert 0.84 wire-format parity install that line rather
       # than the 0.80.5 floor above.
-      # The two pane-preflight cases in pane-cwd-stale.test.ts call
-      # ensureTmux(), which throws when $TMUX is unset; they skip themselves
-      # on a bare runner the same way they already skip off Linux. The whole
-      # directory is globbed, so all test files run here without
-      # editing this step.
+      # The suite's preload starts a tmux server of its own and fails the
+      # run when it cannot, so the runner needs the tmux binary; the
+      # GitHub image does not carry it. The whole directory is globbed, so
+      # all test files run here without editing this step.
       - name: pi-agents-tmux suite
         if: matrix.shard == 'node'
         working-directory: pi-extensions/pi-agents-tmux
         run: |
+          command -v tmux >/dev/null || { sudo apt-get update && sudo apt-get install -y tmux; }
           npm install --no-save --no-package-lock --ignore-scripts --no-audit --no-fund @earendil-works/pi-agent-core@0.84.1 @earendil-works/pi-ai@0.84.1 @earendil-works/pi-coding-agent@0.84.1 @earendil-works/pi-tui@0.84.1 typebox
           npm test
 

--- a/pi-extensions/pi-agents-tmux/DEVELOPMENT.md
+++ b/pi-extensions/pi-agents-tmux/DEVELOPMENT.md
@@ -40,4 +40,6 @@ For maintainers. What the package does for a consumer is [README.md](README.md);
 bun test ./tests ./extensions/subagent/__tests__
 ```
 
+The suite needs the `tmux` binary: `tests/preload.ts` drops the launching shell's `TMUX` and `TMUX_PANE`, starts a tmux server of its own for the run and points both variables at it, so no case and no spawned child reaches the server the suite was launched from; `tests/own-tmux-server.test.ts` holds it.
+
 `tests/settings-manifest.test.ts` holds the settings defaults in `package.json` to the runtime defaults the code applies. A behaviour that depends on process orderings (timeouts, settled shutdown, lock contention) gets a test that drives the orderings explicitly rather than a sleep.

--- a/pi-extensions/pi-agents-tmux/tests/own-tmux-server.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/own-tmux-server.test.ts
@@ -1,0 +1,93 @@
+// The suite's tmux world, set up in tests/preload.ts: a pane title set
+// through the real code path lands on the server this run started, never on
+// the one that launched the suite, and a child spawned with the default
+// environment carries the same values this process holds. A scratch server
+// plays the launching shell's server so both rows run on a bare runner; when
+// the suite really was launched inside tmux, the launching pane is read back
+// too and must not have moved.
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { rmSync } from "node:fs";
+import { setCurrentTmuxPaneTitle } from "../extensions/subagent/pane.js";
+
+const INHERITED_TMUX_SYMBOL = Symbol.for("pi-agents-tmux.tests.inherited-tmux");
+const inherited = (globalThis as Record<PropertyKey, unknown>)[INHERITED_TMUX_SYMBOL] as { TMUX?: string; TMUX_PANE?: string };
+
+interface TmuxWorld {
+	socket: string;
+	TMUX: string;
+	TMUX_PANE: string;
+}
+
+function tmuxAt(socket: string, args: string[]): string {
+	const result = spawnSync("tmux", ["-S", socket, ...args], { encoding: "utf8" });
+	assert.equal(result.status, 0, `tmux -S ${socket} ${args.join(" ")}: ${result.stderr}`);
+	return result.stdout.trim();
+}
+
+function worldFromEnv(TMUX: string, TMUX_PANE: string): TmuxWorld {
+	return { socket: TMUX.split(",")[0]!, TMUX, TMUX_PANE };
+}
+
+// `#{window_name}` and `#{pane_title}` of the pane the world's TMUX_PANE names.
+function paneLabel(world: TmuxWorld): string {
+	return tmuxAt(world.socket, ["display-message", "-p", "-t", world.TMUX_PANE, "#{window_name}\t#{pane_title}"]);
+}
+
+function startScratchServer(): TmuxWorld {
+	const name = `pi-agents-tmux-control-${process.pid}`;
+	const started = spawnSync("tmux", ["-L", name, "-f", "/dev/null", "new-session", "-d", "-s", "launching", "sh", "-c", `while kill -0 ${process.pid} 2>/dev/null; do sleep 5; done`], { encoding: "utf8" });
+	assert.equal(started.status, 0, `scratch tmux server: ${started.stderr}`);
+	const [TMUX, TMUX_PANE] = spawnSync("tmux", ["-L", name, "display-message", "-p", "#{socket_path},#{pid},#{session_id}\t#{pane_id}"], { encoding: "utf8" }).stdout.trim().split("\t");
+	return worldFromEnv(TMUX!.replace(",$", ","), TMUX_PANE!);
+}
+
+function childSees(): string {
+	return spawnSync("sh", ["-c", 'printf "%s|%s" "$TMUX" "$TMUX_PANE"'], { encoding: "utf8" }).stdout;
+}
+
+async function titleLanded(worlds: TmuxWorld[], title: string): Promise<void> {
+	for (let i = 0; i < 60; i += 1) {
+		if (worlds.some((world) => paneLabel(world).endsWith(`\t${title}`))) return;
+		await new Promise((resolve) => setTimeout(resolve, 50));
+	}
+}
+
+// label | the environment the title is set under | expect: where the title and the child's values landed
+const rows: Array<[string, "suite" | "launching", string]> = [
+	["the suite's environment: the title lands on the suite's own server", "suite", "suite=agent:control-suite launching=unchanged child=suite"],
+	["the launching shell's environment restored: the title lands on the launching server", "launching", "suite=unchanged launching=agent:control-launching child=launching"],
+];
+
+test("a pane title set by the suite lands on its own tmux server", async () => {
+	const suite = worldFromEnv(process.env.TMUX ?? "", process.env.TMUX_PANE ?? "");
+	assert.ok(suite.TMUX && suite.TMUX_PANE, "the preload left no suite tmux server in the environment");
+	const realLaunching = inherited.TMUX && inherited.TMUX_PANE ? worldFromEnv(inherited.TMUX, inherited.TMUX_PANE) : undefined;
+	assert.notEqual(realLaunching?.socket, suite.socket, "the suite runs on the server that launched it");
+	const realLaunchingBefore = realLaunching ? paneLabel(realLaunching) : undefined;
+	const launching = startScratchServer();
+	try {
+		for (const [label, env, expect] of rows) {
+			const world = env === "suite" ? suite : launching;
+			process.env.TMUX = world.TMUX;
+			process.env.TMUX_PANE = world.TMUX_PANE;
+			const before = { suite: paneLabel(suite), launching: paneLabel(launching) };
+			const title = `agent:control-${env}`;
+			setCurrentTmuxPaneTitle(title);
+			await titleLanded([suite, launching], title);
+			const after = { suite: paneLabel(suite), launching: paneLabel(launching) };
+			const landed = (key: "suite" | "launching") => (after[key] === before[key] ? "unchanged" : after[key].split("\t")[1]);
+			const seen = childSees().split("|")[0]?.split(",")[0];
+			const child = seen === suite.socket ? "suite" : seen === launching.socket ? "launching" : `other(${seen})`;
+			assert.equal(`suite=${landed("suite")} launching=${landed("launching")} child=${child}`, expect, label);
+		}
+	} finally {
+		process.env.TMUX = suite.TMUX;
+		process.env.TMUX_PANE = suite.TMUX_PANE;
+		// No assertion here: a teardown failure must not replace a row's.
+		spawnSync("tmux", ["-S", launching.socket, "kill-server"], { stdio: "ignore" });
+		rmSync(launching.socket, { force: true });
+	}
+	if (realLaunching) assert.equal(paneLabel(realLaunching), realLaunchingBefore, "the launching pane moved");
+});

--- a/pi-extensions/pi-agents-tmux/tests/preload.ts
+++ b/pi-extensions/pi-agents-tmux/tests/preload.ts
@@ -1,4 +1,5 @@
 import { afterAll, mock } from "bun:test";
+import * as childProcess from "node:child_process";
 import { mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -39,6 +40,59 @@ afterAll(async () => {
 		rmSync(RUN_TMP_ROOT, { force: true, recursive: true });
 	}
 });
+
+// The suite's own tmux server. The launching shell's TMUX and TMUX_PANE
+// name the developer's live server and pane, and the extension reaches
+// tmux through them: `tmux` resolves its server from TMUX, and
+// pane.ts::setCurrentTmuxPaneTitle retitles TMUX_PANE. Both are stashed for
+// tests/own-tmux-server.test.ts and dropped before any test module loads,
+// then pointed at a server this run starts and kills, so every real tmux
+// call from this process or a child lands there. The session's command
+// exits once this process is gone, which closes the server after a crash
+// too. A tmux that cannot start is a failed run, never a silent fallback
+// to the launching server.
+const INHERITED_TMUX_SYMBOL = Symbol.for("pi-agents-tmux.tests.inherited-tmux");
+(globalThis as Record<PropertyKey, unknown>)[INHERITED_TMUX_SYMBOL] = { TMUX: process.env.TMUX, TMUX_PANE: process.env.TMUX_PANE };
+delete process.env.TMUX;
+delete process.env.TMUX_PANE;
+const TMUX_SERVER_NAME = `pi-agents-tmux-tests-${process.pid}`;
+const tmuxServer = (args: string[]) => childProcess.spawnSync("tmux", ["-L", TMUX_SERVER_NAME, ...args], { encoding: "utf8", env: process.env });
+const started = tmuxServer(["-f", "/dev/null", "new-session", "-d", "-s", "tests", "sh", "-c", `while kill -0 ${process.pid} 2>/dev/null; do sleep 5; done`]);
+if (started.error || started.status !== 0) {
+	throw new Error(`pi-agents-tmux tests need a tmux server of their own and could not start one: ${started.error ?? started.stderr.trim()}`);
+}
+const world = tmuxServer(["display-message", "-p", "#{socket_path},#{pid},#{session_id}\t#{pane_id}"]).stdout.trim();
+const [tmuxEnv, tmuxPane] = world.split("\t");
+if (!tmuxEnv || !tmuxPane) throw new Error(`pi-agents-tmux tests could not read their tmux server back: ${JSON.stringify(world)}`);
+process.env.TMUX = tmuxEnv.replace(",$", ",");
+process.env.TMUX_PANE = tmuxPane;
+
+afterAll(() => {
+	// tmux leaves the socket file behind when the server exits.
+	tmuxServer(["kill-server"]);
+	rmSync(tmuxEnv.split(",")[0]!, { force: true });
+});
+
+// Bun's spawnSync and execFileSync hand a child the environment this
+// process STARTED with unless `env` is given, so the deletion above would
+// not reach them; spawn reads the live process.env. The fixture git calls
+// (single-agent-fixture.ts, needs-completion-fixture.ts,
+// cwd-snapshot-dirty-status.test.ts) and the launcher runs in
+// pi-invocation.test.ts are the sync producers. A caller's own env wins.
+const realChildProcess = { ...childProcess };
+type SyncOptions = Record<string, unknown> | undefined;
+const withLiveEnv = (options: SyncOptions) => ({ env: process.env, ...(options ?? {}) });
+mock.module("node:child_process", () => ({
+	...realChildProcess,
+	execFileSync: (command: string, args?: string[] | SyncOptions, options?: SyncOptions) =>
+		Array.isArray(args)
+			? realChildProcess.execFileSync(command, args, withLiveEnv(options))
+			: realChildProcess.execFileSync(command, withLiveEnv(args)),
+	spawnSync: (command: string, args?: string[] | SyncOptions, options?: SyncOptions) =>
+		Array.isArray(args)
+			? realChildProcess.spawnSync(command, args, withLiveEnv(options))
+			: realChildProcess.spawnSync(command, withLiveEnv(args)),
+}));
 
 // Minimal typebox surface used by extensions/subagent/tools.ts; typebox is an
 // uninstalled peer dependency in this checkout, mocked like the pi peers below.


### PR DESCRIPTION
Closes KEN-1271.

The pi-agents-tmux suite inherited the launching shell's `TMUX` and `TMUX_PANE`, so a real `tmux` call from a case or a spawned child reached the developer's live server. `tests/preload.ts` now stashes and drops both before any test module loads, starts a tmux server for the run (`-L pi-agents-tmux-tests-<pid>`, `-f /dev/null`) and points both variables at it; `afterAll` kills it and removes the socket, and the session's own command exits once the suite process is gone, so a crash leaves no server behind. Bun's `spawnSync` and `execFileSync` hand children the start environment, so the preload wraps them with the live one; `spawn` already reads it.

`tests/own-tmux-server.test.ts` holds it: a pane title set through the real `setCurrentTmuxPaneTitle` lands on the suite's server and a spawned child carries the suite's values; the inverse row restores a scratch launching server's values and the title lands there; run inside tmux, the real launching pane's window name and title are read back and must be unchanged.

Proof on a scratch tmux server of my own: 245 pass with the launching window and pane unchanged and no socket left; 245 pass outside tmux. Must-fail: the inherited environment restored in the preload goes red before any retitle; the sync-spawn wrapper removed goes red with `child=other(<launching socket>)`.

The CI step installs tmux, which the GitHub image lacks. No `crates/` or `ui/` change, no changelog fragment. `tools/guard --full` is clean except `kendex-cli cli::scope_project_outside_a_project_is_an_error`, which fails on every branch on the lane machine (`/home/method/.agents` and `.copilot` make any temp dir read as inside a project); CI is the verdict for it.

Program tracking issue: KEN-1203.

https://claude.ai/code/session_01Uic79Lvmg3rq3zDxLgZM5m
