### PR TITLE
test(KEN-1241): the cache filter refusals as one table of rows

### DIFF
--- a/.agents/skills/linear/tests/cache-filters-fail-closed.test.sh
+++ b/.agents/skills/linear/tests/cache-filters-fail-closed.test.sh
@@ -22,7 +22,11 @@
 #
 # `issues list --team=X` is NOT asserted here: it already reached the
 # fail-closed arm before this change (the deleted arm named `--team`, not
-# `--team=`), and `cache-issues-no-project.test.sh` § C owns that arm.
+# `--team=`), and `cache-issues-no-project.test.sh` § C owns that arm. Two
+# more surfaces the table leaves out are owned elsewhere: the value the cycles
+# `--team=X` normalisation forwards (cache-cycles-team-filter.test.sh) and the
+# resolved `--cycle` keyword applied as a predicate
+# (cache-date-comparison-utc.test.sh).
 #
 # Fully offline — pure cache read, no curl needed.
 
@@ -157,7 +161,7 @@ H: --team KEN --cycle current resolves KEN cycle, not OTHER|issues|--team KEN --
 '
 
 while IFS='|' read -r label cmd args spec; do
-  [ -n "$label" ] || continue
+  [ -n "$label$cmd$args$spec" ] || continue
   eval "set -- $args"
   # shellcheck disable=SC2086  # the spec's fields are its words
   assert_eq "$label" "$(run "$cmd" "$@")" "$(expected $spec)"

--- a/.agents/skills/linear/tests/cache-filters-fail-closed.test.sh
+++ b/.agents/skills/linear/tests/cache-filters-fail-closed.test.sh
@@ -13,22 +13,12 @@
 # `--assignee` and `--created-since` are real filters on the live issues path,
 # and the cache refuses them because it does not implement them.
 #
-# This locks in:
-#   A. `issues list --team X` returns only that team's issues.
-#   B. `--assignee` and `--created-since` refuse, each naming itself.
-#   C. `labels list --team=X` refuses, the spelling the live twin rejects with
-#      "Unknown option"; the space form still filters.
-#   D. `cycles list` refuses an unknown flag instead of returning every cycle.
-#   E. An unfiltered listing is unaffected by the fail-closed arms.
-#   F. `--team ""` refuses instead of degrading to an unfiltered list.
-#   G. `--team` standing last answers with the file's JSON error shape, not a
-#      bash unbound-variable abort under set -u.
-#   H. `--team X --cycle current` resolves the keyword inside X's cycles, not
-#      against whichever team started a cycle most recently.
-#
-# Every refusal is matched on the whole "Unknown flag for cache <command>: <flag>"
-# prefix, not the shared two words: the three call sites pass their own command
-# name and noun into one helper and can be wrong independently.
+# One table over the three listings. A row names the command, its arguments
+# and what came back, rendered as one line: the exit status, the sorted names
+# or identifiers of a listing that answered, then stderr whole, so a refusal is
+# pinned on its entire line (the three call sites pass their own command name
+# and noun into one helper and can be wrong independently) and a listing on
+# exactly the rows it returned.
 #
 # `issues list --team=X` is NOT asserted here: it already reached the
 # fail-closed arm before this change (the deleted arm named `--team`, not
@@ -108,114 +98,67 @@ cat >"$TMP_ROOT/.cache/linear/cycles.json" <<'JSON'
 ]
 JSON
 
-run_issues() { cd "$TMP_ROOT" && bash "$LINEAR" cache issues list "$@"; }
-run_labels() { cd "$TMP_ROOT" && bash "$LINEAR" cache labels list "$@"; }
-run_cycles() { cd "$TMP_ROOT" && bash "$LINEAR" cache cycles list "$@"; }
+# --- the renderer -------------------------------------------------------------
+# run COMMAND ARGS... — `cache COMMAND list ARGS`, as one line: the status, the
+# listing as its sorted identifiers or names in brackets (a JSON array on
+# stdout; the `ids` format prints one identifier per line), then stderr whole.
+run() {
+  local cmd="$1" rc=0 out err listing
+  shift
+  (cd "$TMP_ROOT" && bash "$LINEAR" cache "$cmd" list "$@" >"$TMP_ROOT/out" 2>"$TMP_ROOT/err") || rc=$?
+  err="$(paste -sd';' "$TMP_ROOT/err")"
+  if listing="$(jq -er 'if type == "array" then [.[] | .identifier // .name] | sort | join(",") else empty end' "$TMP_ROOT/out" 2>/dev/null)"; then
+    out="[$listing]"
+  else
+    out="[$(sort "$TMP_ROOT/out" | paste -sd, -)]"
+  fi
+  printf 'rc=%s %s%s' "$rc" "$out" "${err:+ $err}"
+}
 
-# A refusal is written to stderr, and run_output captures only the subject's
-# stdout — redirecting at the run_output call would merge the harness's stderr,
-# not the subject's. The merge belongs inside the subject.
-msg_issues() { run_issues "$@" 2>&1; }
-msg_labels() { run_labels "$@" 2>&1; }
-msg_cycles() { run_cycles "$@" 2>&1; }
+# --- the expected lines --------------------------------------------------------
+# unknown COMMAND NOUN FLAG   the unknown-flag refusal for that listing
+# empty                        the given-but-empty team refusal
+# novalue                      the missing-value refusal, in the JSON shape
+# list IDS                     a listing that answered with exactly IDS
+expected() {
+  case "$1" in
+  unknown) printf 'rc=1 [] {"error":"Unknown flag for cache %s: %s. A filter the cache cannot honor must fail, not silently return every %s. Run '"'"'cache %s --help'"'"'."}' "$2 list" "$4" "$3" "$2 list" ;;
+  empty) printf 'rc=1 [] {"error": "--team requires a non-empty team name: an empty value would return every team, not the one named"}' ;;
+  novalue) printf 'rc=1 [] {"error":"--team requires a value"}' ;;
+  list) printf 'rc=0 [%s]' "${2:-}" ;;
+  esac
+}
 
-ids() { jq -r '[.[].id] | sort | join(",")' <<<"$1"; }
-names() { jq -r '[.[].name] | sort | join(",")' <<<"$1"; }
+# --- the table ------------------------------------------------------------------
+# label|command|args|expect
+# `--team X` on issues resolves the keyword `current` inside X's cycles; OTHER's
+# cycle starts later, so a team-blind resolution picks it and answers []. The
+# unfiltered rows are what the fail-closed arms must leave alone. `issues list
+# --team=X` is not here: cache-issues-no-project.test.sh owns that arm.
+ROWS='
+A: --team KEN returns exactly KEN issues|issues|--team KEN --max --format=ids|list KEN-1
+B: --assignee is refused, named as itself on the issues command|issues|--assignee alice --max --format=ids|unknown issues issue --assignee
+B: --created-since is refused, named as itself on the issues command|issues|--created-since 1d --max --format=ids|unknown issues issue --created-since
+C: labels --team=KEN is refused, named as itself on the labels command|labels|--team=KEN|unknown labels label --team=KEN
+C: labels --team KEN, the space form, still filters|labels|--team KEN|list ken-label
+D: cycles --bogus is refused, named as itself on the cycles command|cycles|--bogus x|unknown cycles cycle --bogus
+E: an unfiltered issues list still returns every team|issues|--max --format=ids|list KEN-1,OTH-1
+E: an unfiltered labels list still returns every team|labels||list ken-label,other-label
+E: an unfiltered cycles list still returns every team|cycles||list ken-cycle,other-cycle
+F: --team with an empty value refuses instead of returning every team|issues|--team "" --max --format=ids|empty
+F: labels --team with an empty value refuses too|labels|--team ""|empty
+F: cycles --team with an empty value refuses too|cycles|--team ""|empty
+F: cycles --team= with an empty value refuses too|cycles|--team=|empty
+G: a valueless --team answers with a JSON error, not a bash abort|issues|--max --format=ids --team|novalue
+G: a valueless labels --team answers with a JSON error too|labels|--team|novalue
+G: a valueless cycles --team answers with a JSON error too|cycles|--team|novalue
+G: --team followed by another flag is a missing value, not a team named --max|issues|--team --max --format=ids|novalue
+H: --team KEN --cycle current resolves KEN cycle, not OTHER|issues|--team KEN --cycle current --max --format=ids|list KEN-1
+'
 
-# --- A: issues list --team filters -------------------------------------------
-outA="$(run_issues --team KEN --max --format=compact 2>/dev/null)"
-assert_eq "A: --team KEN returns exactly KEN's issues" \
-  "$(ids "$outA")" "KEN-1"
-
-# --- B: the two filters the cache does not implement refuse -------------------
-run_output assignee_out assignee_rc msg_issues --assignee alice --max --format=ids
-assert_ne "B: --assignee does not exit 0" "$assignee_rc" 0
-assert_contains "B: --assignee is refused, named as itself on the issues command" \
-  "$assignee_out" "Unknown flag for cache issues list: --assignee"
-
-run_output created_out created_rc msg_issues --created-since 1d --max --format=ids
-assert_ne "B: --created-since does not exit 0" "$created_rc" 0
-assert_contains "B: --created-since is refused, named as itself on the issues command" \
-  "$created_out" "Unknown flag for cache issues list: --created-since"
-
-# --- C: labels list refuses the inline spelling, filters on the space form ----
-run_output labels_inline_out labels_inline_rc msg_labels --team=KEN
-assert_ne "C: labels --team=KEN does not exit 0" "$labels_inline_rc" 0
-assert_contains "C: labels --team=KEN is refused, named as itself on the labels command" \
-  "$labels_inline_out" "Unknown flag for cache labels list: --team=KEN"
-assert_eq "C: labels --team KEN, the space form, still filters" \
-  "$(names "$(run_labels --team KEN 2>/dev/null)")" "ken-label"
-
-# --- D: cycles list refuses an unknown flag ----------------------------------
-run_output cycles_out cycles_rc msg_cycles --bogus x
-assert_ne "D: cycles --bogus does not exit 0" "$cycles_rc" 0
-assert_contains "D: cycles --bogus is refused, named as itself on the cycles command" \
-  "$cycles_out" "Unknown flag for cache cycles list: --bogus"
-
-# --- E: unfiltered listings are unaffected -----------------------------------
-assert_eq "E: an unfiltered issues list still returns every team's issues" \
-  "$(printf '%s\n' "$(run_issues --max --format=ids 2>/dev/null)" | sort | tr '\n' ',')" \
-  "KEN-1,OTH-1,"
-assert_eq "E: an unfiltered labels list still returns every team's labels" \
-  "$(names "$(run_labels 2>/dev/null)")" "ken-label,other-label"
-assert_eq "E: an unfiltered cycles list still returns every team's cycles" \
-  "$(names "$(run_cycles 2>/dev/null)")" "ken-cycle,other-cycle"
-
-# --- F: a given-but-empty team refuses, on every command that takes the flag --
-# Reached by a workflow interpolating --team "$LINEAR_TEAM" with nothing in it.
-# All three listings are checked: one command refusing while its siblings return
-# the workspace is the same fail-open shape, one function over.
-run_output empty_out empty_rc msg_issues --team "" --max --format=ids
-assert_ne "F: --team with an empty value does not exit 0" "$empty_rc" 0
-assert_jq "F: --team with an empty value refuses instead of returning every team" \
-  "$empty_out" '.error | test("--team requires a non-empty team name")'
-
-run_output empty_labels_out empty_labels_rc msg_labels --team ""
-assert_ne "F: labels --team with an empty value does not exit 0" "$empty_labels_rc" 0
-assert_jq "F: labels --team with an empty value refuses too" \
-  "$empty_labels_out" '.error | test("--team requires a non-empty team name")'
-
-run_output empty_cycles_out empty_cycles_rc msg_cycles --team ""
-assert_ne "F: cycles --team with an empty value does not exit 0" "$empty_cycles_rc" 0
-assert_jq "F: cycles --team with an empty value refuses too" \
-  "$empty_cycles_out" '.error | test("--team requires a non-empty team name")'
-
-# The inline spelling cycles accepts is normalized onto the space arm, so the
-# same guard reaches it rather than a second binding it could be missing from.
-run_output empty_inline_out empty_inline_rc msg_cycles --team=
-assert_ne "F: cycles --team= with an empty value does not exit 0" "$empty_inline_rc" 0
-assert_jq "F: cycles --team= with an empty value refuses too" \
-  "$empty_inline_out" '.error | test("--team requires a non-empty team name")'
-
-# --- G: --team standing last answers in the file's error shape ----------------
-run_output last_out last_rc msg_issues --max --format=ids --team
-assert_ne "G: a valueless --team does not exit 0" "$last_rc" 0
-assert_jq "G: a valueless --team answers with a JSON error, not a bash abort" \
-  "$last_out" '.error | test("--team requires a value")'
-
-run_output last_labels_out last_labels_rc msg_labels --team
-assert_ne "G: a valueless labels --team does not exit 0" "$last_labels_rc" 0
-assert_jq "G: a valueless labels --team answers with a JSON error too" \
-  "$last_labels_out" '.error | test("--team requires a value")'
-
-run_output last_cycles_out last_cycles_rc msg_cycles --team
-assert_ne "G: a valueless cycles --team does not exit 0" "$last_cycles_rc" 0
-assert_jq "G: a valueless cycles --team answers with a JSON error too" \
-  "$last_cycles_out" '.error | test("--team requires a value")'
-
-# Reached by --team $LINEAR_TEAM --max unquoted with the variable empty: the
-# next flag lands where the value should be. Binding it would swallow the real
-# flag and answer [] at rc 0.
-run_output flagval_out flagval_rc msg_issues --team --max --format=ids
-assert_ne "G: --team followed by another flag does not exit 0" "$flagval_rc" 0
-assert_jq "G: --team followed by another flag is a missing value, not a team named --max" \
-  "$flagval_out" '.error | test("--team requires a value")'
-
-# --- H: the cycle keyword resolves inside the requested team ------------------
-# OTHER's cycle starts later, so a team-blind resolution picks it and this
-# returns nothing at rc 0 — a silently empty answer to a well-formed request,
-# while `cycles list --team KEN --type current` names KEN's cycle off the same
-# file.
-outH="$(run_issues --team KEN --cycle current --max --format=ids 2>/dev/null)"
-assert_eq "H: --team KEN --cycle current resolves KEN's cycle, not OTHER's" \
-  "$(printf '%s\n' "$outH" | sort | tr '\n' ',')" "KEN-1,"
+while IFS='|' read -r label cmd args spec; do
+  [ -n "$label" ] || continue
+  eval "set -- $args"
+  # shellcheck disable=SC2086  # the spec's fields are its words
+  assert_eq "$label" "$(run "$cmd" "$@")" "$(expected $spec)"
+done <<<"$ROWS"

--- a/.agents/skills/linear/tests/controls/cache-filters-fail-closed.control.sh
+++ b/.agents/skills/linear/tests/controls/cache-filters-fail-closed.control.sh
@@ -8,7 +8,7 @@
 # 1. Neutralize the team stage `cache issues list --team` composes into its
 #    filter. The flag is still bound and still exits 0, so every team's issues
 #    come back — the symptom the deleted consume-and-ignore arm produced.
-control_expect "A: --team KEN returns exactly KEN's issues"
+control_expect "A: --team KEN returns exactly KEN issues"
 control_replace scripts/commands/cache-query.sh 1 \
     '    jq_filter="$jq_filter$(cache_team_stage "$team")"' \
     '    : # control: the flag is bound and the cache goes through unfiltered'
@@ -16,9 +16,7 @@ control_replace scripts/commands/cache-query.sh 1 \
 # 2. Restore consume-and-ignore on the issues arm, the shape the deleted
 #    `--team | --assignee | --created-since) shift 2` arm had: a filter the
 #    cache does not implement is swallowed and the full listing comes back.
-control_expect "B: --assignee does not exit 0"
 control_expect "B: --assignee is refused, named as itself on the issues command"
-control_expect "B: --created-since does not exit 0"
 control_expect "B: --created-since is refused, named as itself on the issues command"
 control_replace scripts/commands/cache-query.sh 1 \
     '        -*) cache_unknown_flag "issues list" "issue" "$1"; return 1 ;;' \
@@ -26,7 +24,6 @@ control_replace scripts/commands/cache-query.sh 1 \
 
 # 3. Restore `*) shift ;;` on the labels arm, so the inline `--team=X` spelling
 #    is swallowed and every team's labels come back at rc 0.
-control_expect "C: labels --team=KEN does not exit 0"
 control_expect "C: labels --team=KEN is refused, named as itself on the labels command"
 control_replace scripts/commands/cache-query.sh 1 \
     '        -*) cache_unknown_flag "labels list" "label" "$1"; return 1 ;;' \
@@ -34,7 +31,6 @@ control_replace scripts/commands/cache-query.sh 1 \
 
 # 4. Restore `*) shift ;;` on the cycles arm, so an unknown flag is swallowed
 #    and every cycle comes back at rc 0.
-control_expect "D: cycles --bogus does not exit 0"
 control_expect "D: cycles --bogus is refused, named as itself on the cycles command"
 control_replace scripts/commands/cache-query.sh 1 \
     '        -*) cache_unknown_flag "cycles list" "cycle" "$1"; return 1 ;;' \
@@ -44,13 +40,9 @@ control_replace scripts/commands/cache-query.sh 1 \
 #    workspace at rc 0 on all three listings. The guard above it survives, so
 #    the G assertions still answer in the JSON shape and this claims none of
 #    them.
-control_expect "F: --team with an empty value does not exit 0"
 control_expect "F: --team with an empty value refuses instead of returning every team"
-control_expect "F: labels --team with an empty value does not exit 0"
 control_expect "F: labels --team with an empty value refuses too"
-control_expect "F: cycles --team with an empty value does not exit 0"
 control_expect "F: cycles --team with an empty value refuses too"
-control_expect "F: cycles --team= with an empty value does not exit 0"
 control_expect "F: cycles --team= with an empty value refuses too"
 control_replace scripts/commands/cache-query.sh 1 \
     '    [[ -n "$2" ]] && return 0' \
@@ -69,7 +61,7 @@ control_replace scripts/commands/cache-query.sh 1 \
 
 # 7. Resolve the cycle keyword against every team's cycles again, so
 #    `--team KEN --cycle current` picks OTHER's cycle and prints nothing.
-control_expect "H: --team KEN --cycle current resolves KEN's cycle, not OTHER's"
+control_expect "H: --team KEN --cycle current resolves KEN cycle, not OTHER"
 control_replace scripts/commands/cache-query.sh 1 \
     '                all_cycles=$(cache_jq_file "$cycles_file" "[]" ".$(cache_team_stage "$team")") || return 1' \
     '                all_cycles=$(cache_jq_file "$cycles_file" "[]" '"'"'.'"'"') || return 1 # control: team-blind'
@@ -85,14 +77,13 @@ control_replace scripts/commands/cache-query.sh 1 \
 #    composes `select(.team.name == "")` and matches nothing. Arms 1 and 8 have
 #    already removed the issues and labels stages, so the cycles read is where
 #    this still shows.
-control_expect "E: an unfiltered cycles list still returns every team's cycles"
+control_expect "E: an unfiltered cycles list still returns every team"
 control_replace scripts/commands/cache-query.sh 1 \
     '    [[ -n "$1" ]] || return 0' \
     '    : # control: an empty team still emits a stage'
 
 # 10. Bind a flag standing where the value should be, so `--team --max` takes
 #     --max as the team name, swallows the real flag, and answers [] at rc 0.
-control_expect "G: --team followed by another flag does not exit 0"
 control_expect "G: --team followed by another flag is a missing value, not a team named --max"
 control_replace scripts/commands/cache-query.sh 1 \
     '    -*)' \

--- a/.agents/skills/linear/tests/controls/cache-filters-fail-closed.control.sh
+++ b/.agents/skills/linear/tests/controls/cache-filters-fail-closed.control.sh
@@ -1,9 +1,8 @@
-# One mutation per behaviour the suite claims, and every expectation below is
-# what that arm reddens with ALL of them applied — the harness applies the
-# roster at once (KEN-1177). Arms 1 and 8 remove the issues and labels team
-# stages outright, so arm 9 is the only one the E assertions for those two can
-# still reach; its expectation names the cycles one, the read no other arm
-# touches.
+# One mutation per behaviour the suite claims, each on its own copy. Arms 1
+# and 8 remove the issues and labels team stages outright, so arm 9 names the
+# cycles read for the unfiltered listing; arms 11 and 12 narrow the issues and
+# labels reads when no team is asked for, which is what their unfiltered rows
+# refuse.
 
 # 1. Neutralize the team stage `cache issues list --team` composes into its
 #    filter. The flag is still bound and still exits 0, so every team's issues
@@ -88,3 +87,16 @@ control_expect "G: --team followed by another flag is a missing value, not a tea
 control_replace scripts/commands/cache-query.sh 1 \
     '    -*)' \
     '    --this-value-never-arrives)'
+
+# 11. Narrow the issues read to KEN when no team is asked for, so the unfiltered
+#     listing loses OTHER's issue while every filtered row still answers.
+control_expect "E: an unfiltered issues list still returns every team"
+control_replace scripts/commands/cache-query.sh 1 \
+    '    jq_filter="$jq_filter$(cache_team_stage "$team")"' \
+    '    jq_filter="$jq_filter$(cache_team_stage "${team:-KEN}")" # control: narrowed unasked'
+
+# 12. The same for the labels read.
+control_expect "E: an unfiltered labels list still returns every team"
+control_replace scripts/commands/cache-query.sh 1 \
+    '    labels=$(cache_jq_file "$CACHE_DIR/labels.json" "[]" ".$(cache_team_stage "$team")") || return 1' \
+    '    labels=$(cache_jq_file "$CACHE_DIR/labels.json" "[]" ".$(cache_team_stage "${team:-KEN}")") || return 1 # control: narrowed unasked'

--- a/skills/linear/tests/cache-filters-fail-closed.test.sh
+++ b/skills/linear/tests/cache-filters-fail-closed.test.sh
@@ -22,7 +22,11 @@
 #
 # `issues list --team=X` is NOT asserted here: it already reached the
 # fail-closed arm before this change (the deleted arm named `--team`, not
-# `--team=`), and `cache-issues-no-project.test.sh` § C owns that arm.
+# `--team=`), and `cache-issues-no-project.test.sh` § C owns that arm. Two
+# more surfaces the table leaves out are owned elsewhere: the value the cycles
+# `--team=X` normalisation forwards (cache-cycles-team-filter.test.sh) and the
+# resolved `--cycle` keyword applied as a predicate
+# (cache-date-comparison-utc.test.sh).
 #
 # Fully offline — pure cache read, no curl needed.
 
@@ -157,7 +161,7 @@ H: --team KEN --cycle current resolves KEN cycle, not OTHER|issues|--team KEN --
 '
 
 while IFS='|' read -r label cmd args spec; do
-  [ -n "$label" ] || continue
+  [ -n "$label$cmd$args$spec" ] || continue
   eval "set -- $args"
   # shellcheck disable=SC2086  # the spec's fields are its words
   assert_eq "$label" "$(run "$cmd" "$@")" "$(expected $spec)"

--- a/skills/linear/tests/cache-filters-fail-closed.test.sh
+++ b/skills/linear/tests/cache-filters-fail-closed.test.sh
@@ -13,22 +13,12 @@
 # `--assignee` and `--created-since` are real filters on the live issues path,
 # and the cache refuses them because it does not implement them.
 #
-# This locks in:
-#   A. `issues list --team X` returns only that team's issues.
-#   B. `--assignee` and `--created-since` refuse, each naming itself.
-#   C. `labels list --team=X` refuses, the spelling the live twin rejects with
-#      "Unknown option"; the space form still filters.
-#   D. `cycles list` refuses an unknown flag instead of returning every cycle.
-#   E. An unfiltered listing is unaffected by the fail-closed arms.
-#   F. `--team ""` refuses instead of degrading to an unfiltered list.
-#   G. `--team` standing last answers with the file's JSON error shape, not a
-#      bash unbound-variable abort under set -u.
-#   H. `--team X --cycle current` resolves the keyword inside X's cycles, not
-#      against whichever team started a cycle most recently.
-#
-# Every refusal is matched on the whole "Unknown flag for cache <command>: <flag>"
-# prefix, not the shared two words: the three call sites pass their own command
-# name and noun into one helper and can be wrong independently.
+# One table over the three listings. A row names the command, its arguments
+# and what came back, rendered as one line: the exit status, the sorted names
+# or identifiers of a listing that answered, then stderr whole, so a refusal is
+# pinned on its entire line (the three call sites pass their own command name
+# and noun into one helper and can be wrong independently) and a listing on
+# exactly the rows it returned.
 #
 # `issues list --team=X` is NOT asserted here: it already reached the
 # fail-closed arm before this change (the deleted arm named `--team`, not
@@ -108,114 +98,67 @@ cat >"$TMP_ROOT/.cache/linear/cycles.json" <<'JSON'
 ]
 JSON
 
-run_issues() { cd "$TMP_ROOT" && bash "$LINEAR" cache issues list "$@"; }
-run_labels() { cd "$TMP_ROOT" && bash "$LINEAR" cache labels list "$@"; }
-run_cycles() { cd "$TMP_ROOT" && bash "$LINEAR" cache cycles list "$@"; }
+# --- the renderer -------------------------------------------------------------
+# run COMMAND ARGS... — `cache COMMAND list ARGS`, as one line: the status, the
+# listing as its sorted identifiers or names in brackets (a JSON array on
+# stdout; the `ids` format prints one identifier per line), then stderr whole.
+run() {
+  local cmd="$1" rc=0 out err listing
+  shift
+  (cd "$TMP_ROOT" && bash "$LINEAR" cache "$cmd" list "$@" >"$TMP_ROOT/out" 2>"$TMP_ROOT/err") || rc=$?
+  err="$(paste -sd';' "$TMP_ROOT/err")"
+  if listing="$(jq -er 'if type == "array" then [.[] | .identifier // .name] | sort | join(",") else empty end' "$TMP_ROOT/out" 2>/dev/null)"; then
+    out="[$listing]"
+  else
+    out="[$(sort "$TMP_ROOT/out" | paste -sd, -)]"
+  fi
+  printf 'rc=%s %s%s' "$rc" "$out" "${err:+ $err}"
+}
 
-# A refusal is written to stderr, and run_output captures only the subject's
-# stdout — redirecting at the run_output call would merge the harness's stderr,
-# not the subject's. The merge belongs inside the subject.
-msg_issues() { run_issues "$@" 2>&1; }
-msg_labels() { run_labels "$@" 2>&1; }
-msg_cycles() { run_cycles "$@" 2>&1; }
+# --- the expected lines --------------------------------------------------------
+# unknown COMMAND NOUN FLAG   the unknown-flag refusal for that listing
+# empty                        the given-but-empty team refusal
+# novalue                      the missing-value refusal, in the JSON shape
+# list IDS                     a listing that answered with exactly IDS
+expected() {
+  case "$1" in
+  unknown) printf 'rc=1 [] {"error":"Unknown flag for cache %s: %s. A filter the cache cannot honor must fail, not silently return every %s. Run '"'"'cache %s --help'"'"'."}' "$2 list" "$4" "$3" "$2 list" ;;
+  empty) printf 'rc=1 [] {"error": "--team requires a non-empty team name: an empty value would return every team, not the one named"}' ;;
+  novalue) printf 'rc=1 [] {"error":"--team requires a value"}' ;;
+  list) printf 'rc=0 [%s]' "${2:-}" ;;
+  esac
+}
 
-ids() { jq -r '[.[].id] | sort | join(",")' <<<"$1"; }
-names() { jq -r '[.[].name] | sort | join(",")' <<<"$1"; }
+# --- the table ------------------------------------------------------------------
+# label|command|args|expect
+# `--team X` on issues resolves the keyword `current` inside X's cycles; OTHER's
+# cycle starts later, so a team-blind resolution picks it and answers []. The
+# unfiltered rows are what the fail-closed arms must leave alone. `issues list
+# --team=X` is not here: cache-issues-no-project.test.sh owns that arm.
+ROWS='
+A: --team KEN returns exactly KEN issues|issues|--team KEN --max --format=ids|list KEN-1
+B: --assignee is refused, named as itself on the issues command|issues|--assignee alice --max --format=ids|unknown issues issue --assignee
+B: --created-since is refused, named as itself on the issues command|issues|--created-since 1d --max --format=ids|unknown issues issue --created-since
+C: labels --team=KEN is refused, named as itself on the labels command|labels|--team=KEN|unknown labels label --team=KEN
+C: labels --team KEN, the space form, still filters|labels|--team KEN|list ken-label
+D: cycles --bogus is refused, named as itself on the cycles command|cycles|--bogus x|unknown cycles cycle --bogus
+E: an unfiltered issues list still returns every team|issues|--max --format=ids|list KEN-1,OTH-1
+E: an unfiltered labels list still returns every team|labels||list ken-label,other-label
+E: an unfiltered cycles list still returns every team|cycles||list ken-cycle,other-cycle
+F: --team with an empty value refuses instead of returning every team|issues|--team "" --max --format=ids|empty
+F: labels --team with an empty value refuses too|labels|--team ""|empty
+F: cycles --team with an empty value refuses too|cycles|--team ""|empty
+F: cycles --team= with an empty value refuses too|cycles|--team=|empty
+G: a valueless --team answers with a JSON error, not a bash abort|issues|--max --format=ids --team|novalue
+G: a valueless labels --team answers with a JSON error too|labels|--team|novalue
+G: a valueless cycles --team answers with a JSON error too|cycles|--team|novalue
+G: --team followed by another flag is a missing value, not a team named --max|issues|--team --max --format=ids|novalue
+H: --team KEN --cycle current resolves KEN cycle, not OTHER|issues|--team KEN --cycle current --max --format=ids|list KEN-1
+'
 
-# --- A: issues list --team filters -------------------------------------------
-outA="$(run_issues --team KEN --max --format=compact 2>/dev/null)"
-assert_eq "A: --team KEN returns exactly KEN's issues" \
-  "$(ids "$outA")" "KEN-1"
-
-# --- B: the two filters the cache does not implement refuse -------------------
-run_output assignee_out assignee_rc msg_issues --assignee alice --max --format=ids
-assert_ne "B: --assignee does not exit 0" "$assignee_rc" 0
-assert_contains "B: --assignee is refused, named as itself on the issues command" \
-  "$assignee_out" "Unknown flag for cache issues list: --assignee"
-
-run_output created_out created_rc msg_issues --created-since 1d --max --format=ids
-assert_ne "B: --created-since does not exit 0" "$created_rc" 0
-assert_contains "B: --created-since is refused, named as itself on the issues command" \
-  "$created_out" "Unknown flag for cache issues list: --created-since"
-
-# --- C: labels list refuses the inline spelling, filters on the space form ----
-run_output labels_inline_out labels_inline_rc msg_labels --team=KEN
-assert_ne "C: labels --team=KEN does not exit 0" "$labels_inline_rc" 0
-assert_contains "C: labels --team=KEN is refused, named as itself on the labels command" \
-  "$labels_inline_out" "Unknown flag for cache labels list: --team=KEN"
-assert_eq "C: labels --team KEN, the space form, still filters" \
-  "$(names "$(run_labels --team KEN 2>/dev/null)")" "ken-label"
-
-# --- D: cycles list refuses an unknown flag ----------------------------------
-run_output cycles_out cycles_rc msg_cycles --bogus x
-assert_ne "D: cycles --bogus does not exit 0" "$cycles_rc" 0
-assert_contains "D: cycles --bogus is refused, named as itself on the cycles command" \
-  "$cycles_out" "Unknown flag for cache cycles list: --bogus"
-
-# --- E: unfiltered listings are unaffected -----------------------------------
-assert_eq "E: an unfiltered issues list still returns every team's issues" \
-  "$(printf '%s\n' "$(run_issues --max --format=ids 2>/dev/null)" | sort | tr '\n' ',')" \
-  "KEN-1,OTH-1,"
-assert_eq "E: an unfiltered labels list still returns every team's labels" \
-  "$(names "$(run_labels 2>/dev/null)")" "ken-label,other-label"
-assert_eq "E: an unfiltered cycles list still returns every team's cycles" \
-  "$(names "$(run_cycles 2>/dev/null)")" "ken-cycle,other-cycle"
-
-# --- F: a given-but-empty team refuses, on every command that takes the flag --
-# Reached by a workflow interpolating --team "$LINEAR_TEAM" with nothing in it.
-# All three listings are checked: one command refusing while its siblings return
-# the workspace is the same fail-open shape, one function over.
-run_output empty_out empty_rc msg_issues --team "" --max --format=ids
-assert_ne "F: --team with an empty value does not exit 0" "$empty_rc" 0
-assert_jq "F: --team with an empty value refuses instead of returning every team" \
-  "$empty_out" '.error | test("--team requires a non-empty team name")'
-
-run_output empty_labels_out empty_labels_rc msg_labels --team ""
-assert_ne "F: labels --team with an empty value does not exit 0" "$empty_labels_rc" 0
-assert_jq "F: labels --team with an empty value refuses too" \
-  "$empty_labels_out" '.error | test("--team requires a non-empty team name")'
-
-run_output empty_cycles_out empty_cycles_rc msg_cycles --team ""
-assert_ne "F: cycles --team with an empty value does not exit 0" "$empty_cycles_rc" 0
-assert_jq "F: cycles --team with an empty value refuses too" \
-  "$empty_cycles_out" '.error | test("--team requires a non-empty team name")'
-
-# The inline spelling cycles accepts is normalized onto the space arm, so the
-# same guard reaches it rather than a second binding it could be missing from.
-run_output empty_inline_out empty_inline_rc msg_cycles --team=
-assert_ne "F: cycles --team= with an empty value does not exit 0" "$empty_inline_rc" 0
-assert_jq "F: cycles --team= with an empty value refuses too" \
-  "$empty_inline_out" '.error | test("--team requires a non-empty team name")'
-
-# --- G: --team standing last answers in the file's error shape ----------------
-run_output last_out last_rc msg_issues --max --format=ids --team
-assert_ne "G: a valueless --team does not exit 0" "$last_rc" 0
-assert_jq "G: a valueless --team answers with a JSON error, not a bash abort" \
-  "$last_out" '.error | test("--team requires a value")'
-
-run_output last_labels_out last_labels_rc msg_labels --team
-assert_ne "G: a valueless labels --team does not exit 0" "$last_labels_rc" 0
-assert_jq "G: a valueless labels --team answers with a JSON error too" \
-  "$last_labels_out" '.error | test("--team requires a value")'
-
-run_output last_cycles_out last_cycles_rc msg_cycles --team
-assert_ne "G: a valueless cycles --team does not exit 0" "$last_cycles_rc" 0
-assert_jq "G: a valueless cycles --team answers with a JSON error too" \
-  "$last_cycles_out" '.error | test("--team requires a value")'
-
-# Reached by --team $LINEAR_TEAM --max unquoted with the variable empty: the
-# next flag lands where the value should be. Binding it would swallow the real
-# flag and answer [] at rc 0.
-run_output flagval_out flagval_rc msg_issues --team --max --format=ids
-assert_ne "G: --team followed by another flag does not exit 0" "$flagval_rc" 0
-assert_jq "G: --team followed by another flag is a missing value, not a team named --max" \
-  "$flagval_out" '.error | test("--team requires a value")'
-
-# --- H: the cycle keyword resolves inside the requested team ------------------
-# OTHER's cycle starts later, so a team-blind resolution picks it and this
-# returns nothing at rc 0 — a silently empty answer to a well-formed request,
-# while `cycles list --team KEN --type current` names KEN's cycle off the same
-# file.
-outH="$(run_issues --team KEN --cycle current --max --format=ids 2>/dev/null)"
-assert_eq "H: --team KEN --cycle current resolves KEN's cycle, not OTHER's" \
-  "$(printf '%s\n' "$outH" | sort | tr '\n' ',')" "KEN-1,"
+while IFS='|' read -r label cmd args spec; do
+  [ -n "$label" ] || continue
+  eval "set -- $args"
+  # shellcheck disable=SC2086  # the spec's fields are its words
+  assert_eq "$label" "$(run "$cmd" "$@")" "$(expected $spec)"
+done <<<"$ROWS"

--- a/skills/linear/tests/controls/cache-filters-fail-closed.control.sh
+++ b/skills/linear/tests/controls/cache-filters-fail-closed.control.sh
@@ -8,7 +8,7 @@
 # 1. Neutralize the team stage `cache issues list --team` composes into its
 #    filter. The flag is still bound and still exits 0, so every team's issues
 #    come back — the symptom the deleted consume-and-ignore arm produced.
-control_expect "A: --team KEN returns exactly KEN's issues"
+control_expect "A: --team KEN returns exactly KEN issues"
 control_replace scripts/commands/cache-query.sh 1 \
     '    jq_filter="$jq_filter$(cache_team_stage "$team")"' \
     '    : # control: the flag is bound and the cache goes through unfiltered'
@@ -16,9 +16,7 @@ control_replace scripts/commands/cache-query.sh 1 \
 # 2. Restore consume-and-ignore on the issues arm, the shape the deleted
 #    `--team | --assignee | --created-since) shift 2` arm had: a filter the
 #    cache does not implement is swallowed and the full listing comes back.
-control_expect "B: --assignee does not exit 0"
 control_expect "B: --assignee is refused, named as itself on the issues command"
-control_expect "B: --created-since does not exit 0"
 control_expect "B: --created-since is refused, named as itself on the issues command"
 control_replace scripts/commands/cache-query.sh 1 \
     '        -*) cache_unknown_flag "issues list" "issue" "$1"; return 1 ;;' \
@@ -26,7 +24,6 @@ control_replace scripts/commands/cache-query.sh 1 \
 
 # 3. Restore `*) shift ;;` on the labels arm, so the inline `--team=X` spelling
 #    is swallowed and every team's labels come back at rc 0.
-control_expect "C: labels --team=KEN does not exit 0"
 control_expect "C: labels --team=KEN is refused, named as itself on the labels command"
 control_replace scripts/commands/cache-query.sh 1 \
     '        -*) cache_unknown_flag "labels list" "label" "$1"; return 1 ;;' \
@@ -34,7 +31,6 @@ control_replace scripts/commands/cache-query.sh 1 \
 
 # 4. Restore `*) shift ;;` on the cycles arm, so an unknown flag is swallowed
 #    and every cycle comes back at rc 0.
-control_expect "D: cycles --bogus does not exit 0"
 control_expect "D: cycles --bogus is refused, named as itself on the cycles command"
 control_replace scripts/commands/cache-query.sh 1 \
     '        -*) cache_unknown_flag "cycles list" "cycle" "$1"; return 1 ;;' \
@@ -44,13 +40,9 @@ control_replace scripts/commands/cache-query.sh 1 \
 #    workspace at rc 0 on all three listings. The guard above it survives, so
 #    the G assertions still answer in the JSON shape and this claims none of
 #    them.
-control_expect "F: --team with an empty value does not exit 0"
 control_expect "F: --team with an empty value refuses instead of returning every team"
-control_expect "F: labels --team with an empty value does not exit 0"
 control_expect "F: labels --team with an empty value refuses too"
-control_expect "F: cycles --team with an empty value does not exit 0"
 control_expect "F: cycles --team with an empty value refuses too"
-control_expect "F: cycles --team= with an empty value does not exit 0"
 control_expect "F: cycles --team= with an empty value refuses too"
 control_replace scripts/commands/cache-query.sh 1 \
     '    [[ -n "$2" ]] && return 0' \
@@ -69,7 +61,7 @@ control_replace scripts/commands/cache-query.sh 1 \
 
 # 7. Resolve the cycle keyword against every team's cycles again, so
 #    `--team KEN --cycle current` picks OTHER's cycle and prints nothing.
-control_expect "H: --team KEN --cycle current resolves KEN's cycle, not OTHER's"
+control_expect "H: --team KEN --cycle current resolves KEN cycle, not OTHER"
 control_replace scripts/commands/cache-query.sh 1 \
     '                all_cycles=$(cache_jq_file "$cycles_file" "[]" ".$(cache_team_stage "$team")") || return 1' \
     '                all_cycles=$(cache_jq_file "$cycles_file" "[]" '"'"'.'"'"') || return 1 # control: team-blind'
@@ -85,14 +77,13 @@ control_replace scripts/commands/cache-query.sh 1 \
 #    composes `select(.team.name == "")` and matches nothing. Arms 1 and 8 have
 #    already removed the issues and labels stages, so the cycles read is where
 #    this still shows.
-control_expect "E: an unfiltered cycles list still returns every team's cycles"
+control_expect "E: an unfiltered cycles list still returns every team"
 control_replace scripts/commands/cache-query.sh 1 \
     '    [[ -n "$1" ]] || return 0' \
     '    : # control: an empty team still emits a stage'
 
 # 10. Bind a flag standing where the value should be, so `--team --max` takes
 #     --max as the team name, swallows the real flag, and answers [] at rc 0.
-control_expect "G: --team followed by another flag does not exit 0"
 control_expect "G: --team followed by another flag is a missing value, not a team named --max"
 control_replace scripts/commands/cache-query.sh 1 \
     '    -*)' \

--- a/skills/linear/tests/controls/cache-filters-fail-closed.control.sh
+++ b/skills/linear/tests/controls/cache-filters-fail-closed.control.sh
@@ -1,9 +1,8 @@
-# One mutation per behaviour the suite claims, and every expectation below is
-# what that arm reddens with ALL of them applied — the harness applies the
-# roster at once (KEN-1177). Arms 1 and 8 remove the issues and labels team
-# stages outright, so arm 9 is the only one the E assertions for those two can
-# still reach; its expectation names the cycles one, the read no other arm
-# touches.
+# One mutation per behaviour the suite claims, each on its own copy. Arms 1
+# and 8 remove the issues and labels team stages outright, so arm 9 names the
+# cycles read for the unfiltered listing; arms 11 and 12 narrow the issues and
+# labels reads when no team is asked for, which is what their unfiltered rows
+# refuse.
 
 # 1. Neutralize the team stage `cache issues list --team` composes into its
 #    filter. The flag is still bound and still exits 0, so every team's issues
@@ -88,3 +87,16 @@ control_expect "G: --team followed by another flag is a missing value, not a tea
 control_replace scripts/commands/cache-query.sh 1 \
     '    -*)' \
     '    --this-value-never-arrives)'
+
+# 11. Narrow the issues read to KEN when no team is asked for, so the unfiltered
+#     listing loses OTHER's issue while every filtered row still answers.
+control_expect "E: an unfiltered issues list still returns every team"
+control_replace scripts/commands/cache-query.sh 1 \
+    '    jq_filter="$jq_filter$(cache_team_stage "$team")"' \
+    '    jq_filter="$jq_filter$(cache_team_stage "${team:-KEN}")" # control: narrowed unasked'
+
+# 12. The same for the labels read.
+control_expect "E: an unfiltered labels list still returns every team"
+control_replace scripts/commands/cache-query.sh 1 \
+    '    labels=$(cache_jq_file "$CACHE_DIR/labels.json" "[]" ".$(cache_team_stage "$team")") || return 1' \
+    '    labels=$(cache_jq_file "$CACHE_DIR/labels.json" "[]" ".$(cache_team_stage "${team:-KEN}")") || return 1 # control: narrowed unasked'


### PR DESCRIPTION
Reshapes `skills/linear/tests/cache-filters-fail-closed.test.sh` to code-quality § Tests. It pinned the honored-or-refused cache filters (`cache issues|labels|cycles list`) in one 221-line linear script of 30 assertions: an rc check beside a substring or jq test of each refusal. It is now one table of 18 rows over the three listings: a row names the command and its arguments and pins the exit status, the sorted identifiers or names a listing answered with, and stderr whole, so each refusal is pinned on its entire line (the three call sites pass their own command name and noun into one helper and can be wrong independently) and a listing on exactly the rows it returned. The assertions go through the package's counting library; the control's ten mutations are unchanged and name the surviving rows, and the reviewer's round added two arms for the unfiltered issues and labels rows that no arm named.

The tracked render under `.agents` is replayed with `patch`.

## Folded or deleted cases, with the surviving row

| Former assertion | Surviving row |
|---|---|
| A: `--team KEN` returns exactly KEN's issues | `A: --team KEN returns exactly KEN issues` |
| B: `--assignee` / `--created-since` do not exit 0; refused, named as itself on the issues command (4) | the two `B:` rows, the refusal line whole |
| C: `labels --team=KEN` does not exit 0; refused; the space form still filters (3) | the two `C:` rows |
| D: `cycles --bogus` does not exit 0; refused (2) | `D: cycles --bogus is refused, named as itself on the cycles command` |
| E: unfiltered issues, labels, cycles return every team (3) | the three `E:` rows (sorted identifiers or names) |
| F: `--team ""` on issues, labels, cycles and `--team=` on cycles do not exit 0; refuse (8) | the four `F:` rows |
| G: a valueless `--team` on the three listings, and `--team --max`, do not exit 0; answer in the JSON shape (8) | the four `G:` rows |
| H: `--team KEN --cycle current` resolves KEN's cycle | `H: --team KEN --cycle current resolves KEN cycle, not OTHER` |

Twelve `does not exit 0` assertions are the `rc=1` prefix of their refusal row. `issues list --team=X` stays out (cache-issues-no-project.test.sh owns that arm); the header now names the two other sibling owners the table leaves out.

## Mutation

The control's ten mutations, each on its own copy, each reddening the row it names (`must-fail-controls.sh cache-filters-fail-closed`: 1 controls, 0 failing); plus the two new arms narrowing the issues and labels reads to KEN unasked, killed by the unfiltered rows. Seven author mutants over the refusal helper (the noun dropped, the labels site naming the issues command, the cycles site naming the wrong noun, the refusal on stdout), the empty-team message, the flag-as-value branch and cycles' `--team=` normalisation: all killed. The reviewer's 19: 16 killed; M7 (cycles `--team=` value dropped) and M9 (the resolved `--cycle` predicate never composed) owned by cache-cycles-team-filter.test.sh and cache-date-comparison-utc.test.sh (verified red there); M10 the fixture ordering proving itself load-bearing for row H; M13 (a row with a blank label skipped) closed by the second commit.

## Checks

- `cache-filters-fail-closed.test.sh`: 18 assertions; its control 1/1; all 61 `skills/linear/tests` suites and 62 controls pass under `tools/guard --full` (exit 0 on the second commit's tree).
- `tools/bash32-lint skills/linear/tests`: clean.
- One reviewer-test round: verdict accept, no blockers; four judgements confirmed; its three suggestions are the second commit.

KEN-1241

https://claude.ai/code/session_01JuvYHZWvL6GLtcLMwjj834
