### PR TITLE
test(KEN-1241): the runner's verdicts as one table of rows

### DIFF
--- a/.agents/skills/linear/tests/controls/mutation-isolation.control.sh
+++ b/.agents/skills/linear/tests/controls/mutation-isolation.control.sh
@@ -69,3 +69,30 @@ control_expect "the prefix report names the assertion the mutation did not redde
 control_replace tests/must-fail-controls.sh 1 \
 	'			if ! grep -qxF -- "$want" "$WORK/$stem.fails.$k"; then' \
 	'			if ! grep -qF -- "$want" "$WORK/$stem.fails.$k"; then'
+
+# 11. The check for a control file. Without it the run reaches the control's
+#     source and dies there, a different verdict.
+control_expect "a suite with no control file is reported missing"
+control_replace tests/must-fail-controls.sh 1 \
+	'	if [[ ! -f "$control" ]]; then' \
+	'	if false; then'
+
+# 12. The green check on the unmutated copy. Without it a suite already red
+#     satisfies every mutation that names the assertion it is red on.
+control_expect "a suite failing from its unmutated copy proves nothing under mutation"
+control_replace tests/must-fail-controls.sh 1 \
+	'	if ! timeout "$SUITE_TIMEOUT" bash "$root/tests/$suite" >/dev/null 2>&1; then' \
+	'	if false; then'
+
+# 13. The verdict on a control that counted no mutation.
+control_expect "a control declaring no mutation changed nothing"
+control_replace tests/must-fail-controls.sh 1 \
+	'	if [[ "$mutations" -eq 0 ]]; then' \
+	'	if false; then'
+
+# 14. The verdict on a mutation that did not apply; the copy is then unchanged,
+#     which the NOOP check reports instead.
+control_expect "a mutation whose line the file lacks did not apply"
+control_replace tests/must-fail-controls.sh 1 \
+	'		if ! apply_control "$root" "$k"; then' \
+	'		if ! apply_control "$root" "$k" 2>/dev/null && false; then'

--- a/.agents/skills/linear/tests/controls/mutation-isolation.control.sh
+++ b/.agents/skills/linear/tests/controls/mutation-isolation.control.sh
@@ -42,7 +42,7 @@ control_replace tests/must-fail-controls.sh 1 \
 # 7. The snapshot that guard measures against. Compared with the source
 #    instead, a suite writing inside its own copy is reported as its control
 #    editing outside a mutation.
-control_expect "a suite's residue is not read as the control's edit"
+control_expect "the residue a suite writes in its own copy is not read as the edit of its control"
 control_replace tests/must-fail-controls.sh 1 \
 	'	if ! diff -rq "$snapshot" "$root" >/dev/null 2>&1; then' \
 	'	if ! diff -rq "$SKILL_DIR" "$root" >/dev/null 2>&1; then'

--- a/.agents/skills/linear/tests/mutation-isolation.test.sh
+++ b/.agents/skills/linear/tests/mutation-isolation.test.sh
@@ -22,6 +22,9 @@
 #   - a control that edits its copy outside a numbered mutation is UNGATED:
 #     that edit rides every pass uncounted, and a suite writing a scratch file
 #     inside its own copy is not that
+#   - a suite with no control file is MISSING, one failing from its unmutated
+#     copy is UNSTAGED, a control declaring no mutation is NOOP, and a
+#     mutation whose line the file lacks is BADCTRL
 #
 # One table. A row names the fixture, the control it writes, the cap, and the
 # run's verdict block whole: the exit status, every verdict line the runner
@@ -43,11 +46,15 @@ assert_tmpdir TMP
 # a failed claim the way tests/lib/assert.sh does, since that prefix is what
 # the runner reads a mutation's failures out of.
 # `fixture ROOT residue` makes the suite's own run write a scratch file inside
-# its copy of the skill, the way a cache or lock suite does.
+# its copy of the skill, the way a cache or lock suite does; `fixture ROOT
+# broken` ships a value the suite fails on before any mutation.
 fixture() {
     local root="$1" mode="${2:-}"
     mkdir -p "$root/scripts" "$root/tests/controls"
     printf 'A=1\n' >"$root/scripts/a.sh"
+    if [ "$mode" = broken ]; then
+        printf 'A=2\n' >"$root/scripts/a.sh"
+    fi
     if [ "$mode" = residue ]; then
         # shellcheck disable=SC2016  # the expansion belongs to the written script
         printf 'A=1\n: >"$(dirname "${BASH_SOURCE[0]}")/.alpha-scratch"\n' \
@@ -79,6 +86,7 @@ SUITE
 # every mutation against the file as it ships.
 control() {
     local body
+    # shellcheck disable=SC2016  # the ungated expansion belongs to the written control
     case "$1" in
     # Neither mutation reddens the other's assertion.
     clean) body='control_expect "a is one"
@@ -129,6 +137,25 @@ control_expect "c is one"' ;;
     # and names the shorter: a substring match would read that as proof.
     prefix) body='control_expect "a is one"
 control_replace scripts/e.sh 1 '"'"'E=1'"'"' '"'"'E=2'"'"'' ;;
+    # No control file for alpha; a second suite with its own control keeps
+    # the roster non-empty, which is where a missing control is a verdict
+    # rather than the runner refusing an empty directory.
+    missing)
+        cat >"$2/tests/beta.test.sh" <<'SUITE'
+#!/usr/bin/env bash
+D="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$D/../scripts/b.sh"
+if [ "$B" != 1 ]; then echo "FAIL: b is one" >&2; exit 1; fi
+SUITE
+        printf '%s\n' 'control_expect "b is one"' \
+            "control_replace scripts/b.sh 1 'B=1' 'B=2'" >"$2/tests/controls/beta.control.sh"
+        return 0 ;;
+    # A control that declares no mutation.
+    empty) body='# nothing declared' ;;
+    # A mutation whose line the file does not hold.
+    badctrl) body='control_expect "a is one"
+control_replace scripts/a.sh 1 '"'"'A=7'"'"' '"'"'A=2'"'"'' ;;
     esac
     printf '%s\n' "$body" >"$2/tests/controls/alpha.control.sh"
 }
@@ -146,7 +173,7 @@ run() {
     else
         CONTROL_TIMEOUT="$3" bash "$root/tests/must-fail-controls.sh" >"$root.log" 2>&1 || rc=$?
     fi
-    printf 'rc=%s;%s' "$rc" "$(grep -E '^(ok|WRONG|SHARED|NOEXPECT|GREEN|TIMEOUT|UNGATED|UNSTAGED|ORPHAN) |controls, ' "$root.log" | tr -s ' ' | paste -sd';' -)"
+    printf 'rc=%s;%s' "$rc" "$(grep -E '^(ok|WRONG|SHARED|NOEXPECT|GREEN|TIMEOUT|UNGATED|UNSTAGED|ORPHAN|MISSING|NOOP|BADCTRL) |controls, ' "$root.log" | tr -s ' ' | paste -sd';' -)"
 }
 
 # --- the table -----------------------------------------------------------------
@@ -162,6 +189,10 @@ the ungated report says what it refuses|plain|ungated|-|rc=1;UNGATED alpha.test.
 the residue a suite writes in its own copy is not read as the edit of its control|residue|clean|-|rc=0;ok alpha.test.sh;1 controls, 0 failing, 0 orphaned
 the trailing report names the expectation nothing claims|plain|trailing|-|rc=1;NOEXPECT alpha.test.sh an expectation follows the last mutation and names none: c is one;1 controls, 1 failing, 0 orphaned
 the prefix report names the assertion the mutation did not redden|plain|prefix|-|rc=1;WRONG alpha.test.sh mutation 1 did not redden: a is one;1 controls, 1 failing, 0 orphaned
+a suite with no control file is reported missing|plain|missing|-|rc=1;MISSING alpha.test.sh no controls/alpha.control.sh;ok beta.test.sh;2 controls, 1 failing, 0 orphaned
+a suite failing from its unmutated copy proves nothing under mutation|broken|clean|-|rc=1;UNSTAGED alpha.test.sh suite fails from an unmutated copy;1 controls, 1 failing, 0 orphaned
+a control declaring no mutation changed nothing|plain|empty|-|rc=1;NOOP alpha.test.sh control changed nothing;1 controls, 1 failing, 0 orphaned
+a mutation whose line the file lacks did not apply|plain|badctrl|-|rc=1;BADCTRL alpha.test.sh mutation 1 did not apply cleanly;1 controls, 1 failing, 0 orphaned
 '
 
 while IFS='|' read -r label fix ctl cap expect; do

--- a/.agents/skills/linear/tests/mutation-isolation.test.sh
+++ b/.agents/skills/linear/tests/mutation-isolation.test.sh
@@ -23,12 +23,12 @@
 #     that edit rides every pass uncounted, and a suite writing a scratch file
 #     inside its own copy is not that
 #
-# Each case asserts what its own verdict says, and only what breaking that
-# verdict's branch can take away: SHARED, GREEN and TIMEOUT all fall through to
-# another verdict when their branch is disabled, so the run still fails and is
-# still counted whatever they do, and asserting either there would assert
-# nothing. tests/roster-orphan.test.sh pins that a failing control fails the
-# run and is counted.
+# One table. A row names the fixture, the control it writes, the cap, and the
+# run's verdict block whole: the exit status, every verdict line the runner
+# printed, and its tally. A verdict whose branch is disabled falls through to
+# another verdict, which is a different line, so every row is reddened by the
+# mutation of its own branch; tests/roster-orphan.test.sh pins that a failing
+# control fails the run and is counted.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -75,226 +75,97 @@ SUITE
     cp "$RUNNER" "$root/tests/must-fail-controls.sh"
 }
 
-# run_roster LOGFILE ROOT — run the fixture's copy of the runner, combined
-# output to LOGFILE. Echoes its status; the caller asserts on that rather than
-# branching, so no assertion runs inside a subshell.
-run_roster() {
-    local log="$1" root="$2"
-    bash "$root/tests/must-fail-controls.sh" >"$log" 2>&1
-    echo "$?"
+# control NAME ROOT — the control each case writes for the fixture's suite,
+# every mutation against the file as it ships.
+control() {
+    local body
+    case "$1" in
+    # Neither mutation reddens the other's assertion.
+    clean) body='control_expect "a is one"
+control_replace scripts/a.sh 1 '"'"'A=1'"'"' '"'"'A=2'"'"'
+control_expect "b is one"
+control_replace scripts/b.sh 1 '"'"'B=1'"'"' '"'"'B=2'"'"'' ;;
+    # The second mutation leaves both values alone and reddens the suite with
+    # one of the verdicts assert.sh prints when it refuses a suite outright:
+    # the same FAIL: prefix an assertion carries, not the assertion it named.
+    misnamed) body='control_expect "a is one"
+control_replace scripts/a.sh 1 '"'"'A=1'"'"' '"'"'A=2'"'"'
+control_expect "b is one"
+control_replace scripts/b.sh 1 '"'"'B=1'"'"' \
+    '"'"'B=1; echo "FAIL: the suite ended with background job(s) still running: 4242" >&2; exit 1'"'"'' ;;
+    # Both reddened something, and the second claims what the first answers
+    # for; asked of the expectations before either runs.
+    shared) body='control_expect "a is one"
+control_replace scripts/a.sh 1 '"'"'A=1'"'"' '"'"'A=2'"'"'
+control_expect "a is one"
+control_replace scripts/b.sh 1 '"'"'B=1'"'"' '"'"'B=2'"'"'' ;;
+    # Declare nothing and there is nothing to check.
+    unnamed) body='control_expect "a is one"
+control_replace scripts/a.sh 1 '"'"'A=1'"'"' '"'"'A=2'"'"'
+control_replace scripts/b.sh 1 '"'"'B=1'"'"' '"'"'B=2'"'"'' ;;
+    # The second mutation lands on a file the suite never reads: the tree
+    # changes, and on its own copy it proves nothing. On one copy with the
+    # first mutation it would ride that one's failures into an ok line.
+    green) body='control_expect "a is one"
+control_replace scripts/a.sh 1 '"'"'A=1'"'"' '"'"'A=2'"'"'
+control_expect "b is one"
+control_replace scripts/inert.sh 1 '"'"'INERT=1'"'"' '"'"'INERT=2'"'"'' ;;
+    # The run reddens on the clock rather than on the mutation.
+    capped) body='control_expect "a is one"
+control_replace scripts/a.sh 1 '"'"'A=1'"'"' '"'"'A=1; sleep 2'"'"'' ;;
+    # A control is arbitrary bash with CONTROL_ROOT set: this one writes under
+    # it directly, so the edit rides the counting pass and every mutation pass.
+    ungated) body='control_expect "a is one"
+printf '"'"'B=9\n'"'"' >"$CONTROL_ROOT/scripts/b.sh"
+control_replace scripts/a.sh 1 '"'"'A=1'"'"' '"'"'A=2'"'"'' ;;
+    # Two mutations naming what their runs redden, then an expectation no
+    # mutation follows: nothing drains it and the next pass truncates it.
+    trailing) body='control_expect "a is one"
+control_replace scripts/a.sh 1 '"'"'A=1'"'"' '"'"'A=2'"'"'
+control_expect "b is one"
+control_replace scripts/b.sh 1 '"'"'B=1'"'"' '"'"'B=2'"'"'
+control_expect "c is one"' ;;
+    # Reddens only the suite's fourth claim, whose text starts with its first,
+    # and names the shorter: a substring match would read that as proof.
+    prefix) body='control_expect "a is one"
+control_replace scripts/e.sh 1 '"'"'E=1'"'"' '"'"'E=2'"'"'' ;;
+    esac
+    printf '%s\n' "$body" >"$2/tests/controls/alpha.control.sh"
 }
 
-# run_roster_capped SECONDS LOGFILE ROOT — the same, with the runner's suite
-# timeout set, so a case can reach the kill without waiting out the default.
-run_roster_capped() {
-    local cap="$1" log="$2" root="$3"
-    CONTROL_TIMEOUT="$cap" bash "$root/tests/must-fail-controls.sh" >"$log" 2>&1
-    echo "$?"
+# run FIXTURE CONTROL CAP — a fresh fixture (`plain`, or `residue`, whose suite
+# writes a scratch file inside its own copy), the named control, the runner under CAP
+# seconds (`-` for its default), rendered as one line: the status, every
+# verdict line with its spacing collapsed, and the tally.
+run() {
+    local root="$TMP/$2-$1" rc=0
+    fixture "$root" "$1"
+    control "$2" "$root"
+    if [ "$3" = "-" ]; then
+        bash "$root/tests/must-fail-controls.sh" >"$root.log" 2>&1 || rc=$?
+    else
+        CONTROL_TIMEOUT="$3" bash "$root/tests/must-fail-controls.sh" >"$root.log" 2>&1 || rc=$?
+    fi
+    printf 'rc=%s;%s' "$rc" "$(grep -E '^(ok|WRONG|SHARED|NOEXPECT|GREEN|TIMEOUT|UNGATED|UNSTAGED|ORPHAN) |controls, ' "$root.log" | tr -s ' ' | paste -sd';' -)"
 }
 
-# --- each mutation reddening the assertion it named is the baseline --------
-# Neither mutation reddens the other's assertion, so the ok line here says both
-# copies were staged, both suites ran, and no case below can pass by the runner
-# always reporting a finding.
-clean="$TMP/clean"
-fixture "$clean"
-cat >"$clean/tests/controls/alpha.control.sh" <<'CONTROL'
-control_expect "a is one"
-control_replace scripts/a.sh 1 'A=1' 'A=2'
-control_expect "b is one"
-control_replace scripts/b.sh 1 'B=1' 'B=2'
-CONTROL
+# --- the table -----------------------------------------------------------------
+# label|fixture|control|cap|expect
+ROWS='
+a control whose mutations each redden what they named exits 0|plain|clean|-|rc=0;ok alpha.test.sh;1 controls, 0 failing, 0 orphaned
+the misnamed report names the mutation and the assertion|plain|misnamed|-|rc=1;WRONG alpha.test.sh mutation 2 did not redden: b is one;1 controls, 1 failing, 0 orphaned
+the shared report names the assertion|plain|shared|-|rc=1;SHARED alpha.test.sh two mutations name one assertion: a is one;1 controls, 1 failing, 0 orphaned
+the unnamed report names the mutation|plain|unnamed|-|rc=1;NOEXPECT alpha.test.sh mutation 2 names no assertion;1 controls, 1 failing, 0 orphaned
+the green report names its suite|plain|green|-|rc=1;GREEN alpha.test.sh suite passed with mutation 2, its only break;1 controls, 1 failing, 0 orphaned
+the timeout report names the mutation and the cap|plain|capped|1|rc=1;TIMEOUT alpha.test.sh mutation 1 hit the 1s cap having measured nothing;1 controls, 1 failing, 0 orphaned
+the ungated report says what it refuses|plain|ungated|-|rc=1;UNGATED alpha.test.sh control edits its copy outside a numbered mutation;1 controls, 1 failing, 0 orphaned
+the residue a suite writes in its own copy is not read as the edit of its control|residue|clean|-|rc=0;ok alpha.test.sh;1 controls, 0 failing, 0 orphaned
+the trailing report names the expectation nothing claims|plain|trailing|-|rc=1;NOEXPECT alpha.test.sh an expectation follows the last mutation and names none: c is one;1 controls, 1 failing, 0 orphaned
+the prefix report names the assertion the mutation did not redden|plain|prefix|-|rc=1;WRONG alpha.test.sh mutation 1 did not redden: a is one;1 controls, 1 failing, 0 orphaned
+'
 
-rc="$(run_roster "$TMP/clean.log" "$clean")"
-assert_eq "a control whose mutations each redden what they named exits 0" "$rc" 0
-assert_file_contains "the clean control is reported ok" \
-    "$TMP/clean.log" "ok       alpha.test.sh"
-assert_file_contains "the clean run counts no failure" \
-    "$TMP/clean.log" "1 controls, 0 failing, 0 orphaned"
+while IFS='|' read -r label fix ctl cap expect; do
+    [ -n "$label" ] || continue
+    assert_eq "$label" "$(run "$fix" "$ctl" "$cap")" "$expect"
+done <<<"$ROWS"
 
-# --- a mutation whose redness is not the assertion it named ----------------
-# The reproduction the whole rule exists for. The second mutation leaves both
-# values alone and reddens the suite with one of the verdicts assert.sh prints
-# when it refuses a suite outright. That carries the same FAIL: prefix an
-# assertion does, so a non-empty fail set is not proof of anything: it is not
-# the assertion the mutation named.
-misnamed="$TMP/misnamed"
-fixture "$misnamed"
-cat >"$misnamed/tests/controls/alpha.control.sh" <<'CONTROL'
-control_expect "a is one"
-control_replace scripts/a.sh 1 'A=1' 'A=2'
-control_expect "b is one"
-control_replace scripts/b.sh 1 'B=1' \
-    'B=1; echo "FAIL: the suite ended with background job(s) still running: 4242" >&2; exit 1'
-CONTROL
-
-rc="$(run_roster "$TMP/misnamed.log" "$misnamed")"
-assert_ne "a mutation reddening only a harness verdict fails the run" "$rc" 0
-assert_file_contains "the misnamed report names its suite" \
-    "$TMP/misnamed.log" "WRONG    alpha.test.sh"
-assert_file_contains "the misnamed report names the mutation and the assertion" \
-    "$TMP/misnamed.log" "mutation 2 did not redden: b is one"
-assert_file_contains "the misnamed control is counted, not just printed" \
-    "$TMP/misnamed.log" "1 controls, 1 failing, 0 orphaned"
-
-# --- two mutations naming one assertion ------------------------------------
-# Both reddened something, and the second's claim is one the first answers for.
-# Asking each mutation in isolation cannot see that, so it is asked of the
-# expectations before either runs.
-shared="$TMP/shared"
-fixture "$shared"
-cat >"$shared/tests/controls/alpha.control.sh" <<'CONTROL'
-control_expect "a is one"
-control_replace scripts/a.sh 1 'A=1' 'A=2'
-control_expect "a is one"
-control_replace scripts/b.sh 1 'B=1' 'B=2'
-CONTROL
-
-run_roster "$TMP/shared.log" "$shared" >/dev/null
-assert_file_contains "the shared report names its suite" \
-    "$TMP/shared.log" "SHARED   alpha.test.sh"
-assert_file_contains "the shared report names the assertion" \
-    "$TMP/shared.log" "two mutations name one assertion: a is one"
-
-# --- a mutation naming no assertion ----------------------------------------
-# The third way out: declare nothing and there is nothing to check.
-unnamed="$TMP/unnamed"
-fixture "$unnamed"
-cat >"$unnamed/tests/controls/alpha.control.sh" <<'CONTROL'
-control_expect "a is one"
-control_replace scripts/a.sh 1 'A=1' 'A=2'
-control_replace scripts/b.sh 1 'B=1' 'B=2'
-CONTROL
-
-rc="$(run_roster "$TMP/unnamed.log" "$unnamed")"
-assert_ne "a mutation naming no assertion fails the run" "$rc" 0
-assert_file_contains "the unnamed report names its suite" \
-    "$TMP/unnamed.log" "NOEXPECT alpha.test.sh"
-assert_file_contains "the unnamed report names the mutation" \
-    "$TMP/unnamed.log" "mutation 2 names no assertion"
-assert_file_contains "the unnamed control is counted, not just printed" \
-    "$TMP/unnamed.log" "1 controls, 1 failing, 0 orphaned"
-
-# --- a mutation the suite survived -----------------------------------------
-# The second mutation lands on a file the suite never reads, so the tree really
-# changes and this is not the NOOP case. This is where the copies matter: on
-# one copy with the first mutation it rides that one's failures into an ok
-# line, and only run on its own does it report what it proves, which is
-# nothing.
-green="$TMP/green"
-fixture "$green"
-cat >"$green/tests/controls/alpha.control.sh" <<'CONTROL'
-control_expect "a is one"
-control_replace scripts/a.sh 1 'A=1' 'A=2'
-control_expect "b is one"
-control_replace scripts/inert.sh 1 'INERT=1' 'INERT=2'
-CONTROL
-
-run_roster "$TMP/green.log" "$green" >/dev/null
-assert_file_contains "the green report names its suite" \
-    "$TMP/green.log" "GREEN    alpha.test.sh"
-assert_file_contains "the green report names the mutation that proved nothing" \
-    "$TMP/green.log" "mutation 2, its only break"
-
-# --- a run the timeout killed ----------------------------------------------
-# The run reddened on the clock rather than on the mutation, so it names the
-# kill instead of reporting the assertion it could not reach as unreddened.
-capped="$TMP/capped"
-fixture "$capped"
-cat >"$capped/tests/controls/alpha.control.sh" <<'CONTROL'
-control_expect "a is one"
-control_replace scripts/a.sh 1 'A=1' 'A=1; sleep 2'
-CONTROL
-
-run_roster_capped 1 "$TMP/capped.log" "$capped" >/dev/null
-assert_file_contains "the timeout report names its suite" \
-    "$TMP/capped.log" "TIMEOUT  alpha.test.sh"
-assert_file_contains "the timeout report names the mutation and the cap" \
-    "$TMP/capped.log" "mutation 1 hit the 1s cap having measured nothing"
-
-# --- an edit made outside a numbered mutation ------------------------------
-# A control is arbitrary bash with CONTROL_ROOT set. This one writes under it
-# directly, so the edit lands on the counting pass and on every mutation pass,
-# uncounted and never isolated: the way out of the regime, if nothing asks.
-ungated="$TMP/ungated"
-fixture "$ungated"
-cat >"$ungated/tests/controls/alpha.control.sh" <<'CONTROL'
-control_expect "a is one"
-printf 'B=9\n' >"$CONTROL_ROOT/scripts/b.sh"
-control_replace scripts/a.sh 1 'A=1' 'A=2'
-CONTROL
-
-rc="$(run_roster "$TMP/ungated.log" "$ungated")"
-assert_ne "a control that edits its copy unnumbered fails the run" "$rc" 0
-assert_file_contains "the ungated report names its suite" \
-    "$TMP/ungated.log" "UNGATED  alpha.test.sh"
-assert_file_contains "the ungated report says what it refuses" \
-    "$TMP/ungated.log" "edits its copy outside a numbered mutation"
-assert_file_contains "the ungated control is counted, not just printed" \
-    "$TMP/ungated.log" "1 controls, 1 failing, 0 orphaned"
-
-# --- a suite that writes inside its own copy -------------------------------
-# The guard above compares against a snapshot taken after the unmutated suite
-# has run, not against the source, so what it measures is the control's edits
-# and not the suite's own residue. This roster is cache-, lock- and sync-heavy,
-# so a suite writing under its own tree is ordinary and must not be reported as
-# its control editing outside a mutation.
-residue="$TMP/residue"
-fixture "$residue" residue
-cat >"$residue/tests/controls/alpha.control.sh" <<'CONTROL'
-control_expect "a is one"
-control_replace scripts/a.sh 1 'A=1' 'A=2'
-CONTROL
-
-rc="$(run_roster "$TMP/residue.log" "$residue")"
-assert_eq "a suite writing in its own copy leaves its control passing" "$rc" 0
-assert_file_contains "the control of a suite that writes residue is reported ok" \
-    "$TMP/residue.log" "ok       alpha.test.sh"
-assert_file_lacks "a suite's residue is not read as the control's edit" \
-    "$TMP/residue.log" "UNGATED"
-
-# --- an expectation with no mutation after it ------------------------------
-# Both mutations name an assertion their own run reddens, so nothing above
-# catches this control. The third expectation trails: no mutation follows it,
-# so control_mutation_wanted never drains it and the next pass truncates it,
-# and the claim would be dropped in silence. Declaring an expectation after its
-# mutation is the natural reading order, so the mistake is one an author makes.
-trailing="$TMP/trailing"
-fixture "$trailing"
-cat >"$trailing/tests/controls/alpha.control.sh" <<'CONTROL'
-control_expect "a is one"
-control_replace scripts/a.sh 1 'A=1' 'A=2'
-control_expect "b is one"
-control_replace scripts/b.sh 1 'B=1' 'B=2'
-control_expect "c is one"
-CONTROL
-
-rc="$(run_roster "$TMP/trailing.log" "$trailing")"
-assert_ne "an expectation no mutation claims fails the run" "$rc" 0
-assert_file_contains "the trailing report names its suite" \
-    "$TMP/trailing.log" "NOEXPECT alpha.test.sh"
-assert_file_contains "the trailing report names the expectation nothing claims" \
-    "$TMP/trailing.log" "an expectation follows the last mutation and names none: c is one"
-assert_file_contains "the trailing control is counted, not just printed" \
-    "$TMP/trailing.log" "1 controls, 1 failing, 0 orphaned"
-
-# --- a control naming a prefix of an assertion that reddened ---------------
-# The suite's fourth claim starts with the text of its first. This mutation
-# reddens only the longer one, and names the shorter; a substring match would
-# read that as proof, so the match is whole-line. The mutation names an
-# assertion its own run did not redden, which is what WRONG is.
-prefix="$TMP/prefix"
-fixture "$prefix"
-cat >"$prefix/tests/controls/alpha.control.sh" <<'CONTROL'
-control_expect "a is one"
-control_replace scripts/e.sh 1 'E=1' 'E=2'
-CONTROL
-
-rc="$(run_roster "$TMP/prefix.log" "$prefix")"
-assert_ne "a control naming a prefix of what reddened fails the run" "$rc" 0
-assert_file_contains "the prefix report names its suite" \
-    "$TMP/prefix.log" "WRONG    alpha.test.sh"
-assert_file_contains "the prefix report names the assertion the mutation did not redden" \
-    "$TMP/prefix.log" "mutation 1 did not redden: a is one"
-assert_file_contains "the prefix control is counted, not just printed" \
-    "$TMP/prefix.log" "1 controls, 1 failing, 0 orphaned"

--- a/skills/linear/tests/controls/mutation-isolation.control.sh
+++ b/skills/linear/tests/controls/mutation-isolation.control.sh
@@ -69,3 +69,30 @@ control_expect "the prefix report names the assertion the mutation did not redde
 control_replace tests/must-fail-controls.sh 1 \
 	'			if ! grep -qxF -- "$want" "$WORK/$stem.fails.$k"; then' \
 	'			if ! grep -qF -- "$want" "$WORK/$stem.fails.$k"; then'
+
+# 11. The check for a control file. Without it the run reaches the control's
+#     source and dies there, a different verdict.
+control_expect "a suite with no control file is reported missing"
+control_replace tests/must-fail-controls.sh 1 \
+	'	if [[ ! -f "$control" ]]; then' \
+	'	if false; then'
+
+# 12. The green check on the unmutated copy. Without it a suite already red
+#     satisfies every mutation that names the assertion it is red on.
+control_expect "a suite failing from its unmutated copy proves nothing under mutation"
+control_replace tests/must-fail-controls.sh 1 \
+	'	if ! timeout "$SUITE_TIMEOUT" bash "$root/tests/$suite" >/dev/null 2>&1; then' \
+	'	if false; then'
+
+# 13. The verdict on a control that counted no mutation.
+control_expect "a control declaring no mutation changed nothing"
+control_replace tests/must-fail-controls.sh 1 \
+	'	if [[ "$mutations" -eq 0 ]]; then' \
+	'	if false; then'
+
+# 14. The verdict on a mutation that did not apply; the copy is then unchanged,
+#     which the NOOP check reports instead.
+control_expect "a mutation whose line the file lacks did not apply"
+control_replace tests/must-fail-controls.sh 1 \
+	'		if ! apply_control "$root" "$k"; then' \
+	'		if ! apply_control "$root" "$k" 2>/dev/null && false; then'

--- a/skills/linear/tests/controls/mutation-isolation.control.sh
+++ b/skills/linear/tests/controls/mutation-isolation.control.sh
@@ -42,7 +42,7 @@ control_replace tests/must-fail-controls.sh 1 \
 # 7. The snapshot that guard measures against. Compared with the source
 #    instead, a suite writing inside its own copy is reported as its control
 #    editing outside a mutation.
-control_expect "a suite's residue is not read as the control's edit"
+control_expect "the residue a suite writes in its own copy is not read as the edit of its control"
 control_replace tests/must-fail-controls.sh 1 \
 	'	if ! diff -rq "$snapshot" "$root" >/dev/null 2>&1; then' \
 	'	if ! diff -rq "$SKILL_DIR" "$root" >/dev/null 2>&1; then'

--- a/skills/linear/tests/mutation-isolation.test.sh
+++ b/skills/linear/tests/mutation-isolation.test.sh
@@ -22,6 +22,9 @@
 #   - a control that edits its copy outside a numbered mutation is UNGATED:
 #     that edit rides every pass uncounted, and a suite writing a scratch file
 #     inside its own copy is not that
+#   - a suite with no control file is MISSING, one failing from its unmutated
+#     copy is UNSTAGED, a control declaring no mutation is NOOP, and a
+#     mutation whose line the file lacks is BADCTRL
 #
 # One table. A row names the fixture, the control it writes, the cap, and the
 # run's verdict block whole: the exit status, every verdict line the runner
@@ -43,11 +46,15 @@ assert_tmpdir TMP
 # a failed claim the way tests/lib/assert.sh does, since that prefix is what
 # the runner reads a mutation's failures out of.
 # `fixture ROOT residue` makes the suite's own run write a scratch file inside
-# its copy of the skill, the way a cache or lock suite does.
+# its copy of the skill, the way a cache or lock suite does; `fixture ROOT
+# broken` ships a value the suite fails on before any mutation.
 fixture() {
     local root="$1" mode="${2:-}"
     mkdir -p "$root/scripts" "$root/tests/controls"
     printf 'A=1\n' >"$root/scripts/a.sh"
+    if [ "$mode" = broken ]; then
+        printf 'A=2\n' >"$root/scripts/a.sh"
+    fi
     if [ "$mode" = residue ]; then
         # shellcheck disable=SC2016  # the expansion belongs to the written script
         printf 'A=1\n: >"$(dirname "${BASH_SOURCE[0]}")/.alpha-scratch"\n' \
@@ -79,6 +86,7 @@ SUITE
 # every mutation against the file as it ships.
 control() {
     local body
+    # shellcheck disable=SC2016  # the ungated expansion belongs to the written control
     case "$1" in
     # Neither mutation reddens the other's assertion.
     clean) body='control_expect "a is one"
@@ -129,6 +137,25 @@ control_expect "c is one"' ;;
     # and names the shorter: a substring match would read that as proof.
     prefix) body='control_expect "a is one"
 control_replace scripts/e.sh 1 '"'"'E=1'"'"' '"'"'E=2'"'"'' ;;
+    # No control file for alpha; a second suite with its own control keeps
+    # the roster non-empty, which is where a missing control is a verdict
+    # rather than the runner refusing an empty directory.
+    missing)
+        cat >"$2/tests/beta.test.sh" <<'SUITE'
+#!/usr/bin/env bash
+D="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$D/../scripts/b.sh"
+if [ "$B" != 1 ]; then echo "FAIL: b is one" >&2; exit 1; fi
+SUITE
+        printf '%s\n' 'control_expect "b is one"' \
+            "control_replace scripts/b.sh 1 'B=1' 'B=2'" >"$2/tests/controls/beta.control.sh"
+        return 0 ;;
+    # A control that declares no mutation.
+    empty) body='# nothing declared' ;;
+    # A mutation whose line the file does not hold.
+    badctrl) body='control_expect "a is one"
+control_replace scripts/a.sh 1 '"'"'A=7'"'"' '"'"'A=2'"'"'' ;;
     esac
     printf '%s\n' "$body" >"$2/tests/controls/alpha.control.sh"
 }
@@ -146,7 +173,7 @@ run() {
     else
         CONTROL_TIMEOUT="$3" bash "$root/tests/must-fail-controls.sh" >"$root.log" 2>&1 || rc=$?
     fi
-    printf 'rc=%s;%s' "$rc" "$(grep -E '^(ok|WRONG|SHARED|NOEXPECT|GREEN|TIMEOUT|UNGATED|UNSTAGED|ORPHAN) |controls, ' "$root.log" | tr -s ' ' | paste -sd';' -)"
+    printf 'rc=%s;%s' "$rc" "$(grep -E '^(ok|WRONG|SHARED|NOEXPECT|GREEN|TIMEOUT|UNGATED|UNSTAGED|ORPHAN|MISSING|NOOP|BADCTRL) |controls, ' "$root.log" | tr -s ' ' | paste -sd';' -)"
 }
 
 # --- the table -----------------------------------------------------------------
@@ -162,6 +189,10 @@ the ungated report says what it refuses|plain|ungated|-|rc=1;UNGATED alpha.test.
 the residue a suite writes in its own copy is not read as the edit of its control|residue|clean|-|rc=0;ok alpha.test.sh;1 controls, 0 failing, 0 orphaned
 the trailing report names the expectation nothing claims|plain|trailing|-|rc=1;NOEXPECT alpha.test.sh an expectation follows the last mutation and names none: c is one;1 controls, 1 failing, 0 orphaned
 the prefix report names the assertion the mutation did not redden|plain|prefix|-|rc=1;WRONG alpha.test.sh mutation 1 did not redden: a is one;1 controls, 1 failing, 0 orphaned
+a suite with no control file is reported missing|plain|missing|-|rc=1;MISSING alpha.test.sh no controls/alpha.control.sh;ok beta.test.sh;2 controls, 1 failing, 0 orphaned
+a suite failing from its unmutated copy proves nothing under mutation|broken|clean|-|rc=1;UNSTAGED alpha.test.sh suite fails from an unmutated copy;1 controls, 1 failing, 0 orphaned
+a control declaring no mutation changed nothing|plain|empty|-|rc=1;NOOP alpha.test.sh control changed nothing;1 controls, 1 failing, 0 orphaned
+a mutation whose line the file lacks did not apply|plain|badctrl|-|rc=1;BADCTRL alpha.test.sh mutation 1 did not apply cleanly;1 controls, 1 failing, 0 orphaned
 '
 
 while IFS='|' read -r label fix ctl cap expect; do

--- a/skills/linear/tests/mutation-isolation.test.sh
+++ b/skills/linear/tests/mutation-isolation.test.sh
@@ -23,12 +23,12 @@
 #     that edit rides every pass uncounted, and a suite writing a scratch file
 #     inside its own copy is not that
 #
-# Each case asserts what its own verdict says, and only what breaking that
-# verdict's branch can take away: SHARED, GREEN and TIMEOUT all fall through to
-# another verdict when their branch is disabled, so the run still fails and is
-# still counted whatever they do, and asserting either there would assert
-# nothing. tests/roster-orphan.test.sh pins that a failing control fails the
-# run and is counted.
+# One table. A row names the fixture, the control it writes, the cap, and the
+# run's verdict block whole: the exit status, every verdict line the runner
+# printed, and its tally. A verdict whose branch is disabled falls through to
+# another verdict, which is a different line, so every row is reddened by the
+# mutation of its own branch; tests/roster-orphan.test.sh pins that a failing
+# control fails the run and is counted.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -75,226 +75,97 @@ SUITE
     cp "$RUNNER" "$root/tests/must-fail-controls.sh"
 }
 
-# run_roster LOGFILE ROOT — run the fixture's copy of the runner, combined
-# output to LOGFILE. Echoes its status; the caller asserts on that rather than
-# branching, so no assertion runs inside a subshell.
-run_roster() {
-    local log="$1" root="$2"
-    bash "$root/tests/must-fail-controls.sh" >"$log" 2>&1
-    echo "$?"
+# control NAME ROOT — the control each case writes for the fixture's suite,
+# every mutation against the file as it ships.
+control() {
+    local body
+    case "$1" in
+    # Neither mutation reddens the other's assertion.
+    clean) body='control_expect "a is one"
+control_replace scripts/a.sh 1 '"'"'A=1'"'"' '"'"'A=2'"'"'
+control_expect "b is one"
+control_replace scripts/b.sh 1 '"'"'B=1'"'"' '"'"'B=2'"'"'' ;;
+    # The second mutation leaves both values alone and reddens the suite with
+    # one of the verdicts assert.sh prints when it refuses a suite outright:
+    # the same FAIL: prefix an assertion carries, not the assertion it named.
+    misnamed) body='control_expect "a is one"
+control_replace scripts/a.sh 1 '"'"'A=1'"'"' '"'"'A=2'"'"'
+control_expect "b is one"
+control_replace scripts/b.sh 1 '"'"'B=1'"'"' \
+    '"'"'B=1; echo "FAIL: the suite ended with background job(s) still running: 4242" >&2; exit 1'"'"'' ;;
+    # Both reddened something, and the second claims what the first answers
+    # for; asked of the expectations before either runs.
+    shared) body='control_expect "a is one"
+control_replace scripts/a.sh 1 '"'"'A=1'"'"' '"'"'A=2'"'"'
+control_expect "a is one"
+control_replace scripts/b.sh 1 '"'"'B=1'"'"' '"'"'B=2'"'"'' ;;
+    # Declare nothing and there is nothing to check.
+    unnamed) body='control_expect "a is one"
+control_replace scripts/a.sh 1 '"'"'A=1'"'"' '"'"'A=2'"'"'
+control_replace scripts/b.sh 1 '"'"'B=1'"'"' '"'"'B=2'"'"'' ;;
+    # The second mutation lands on a file the suite never reads: the tree
+    # changes, and on its own copy it proves nothing. On one copy with the
+    # first mutation it would ride that one's failures into an ok line.
+    green) body='control_expect "a is one"
+control_replace scripts/a.sh 1 '"'"'A=1'"'"' '"'"'A=2'"'"'
+control_expect "b is one"
+control_replace scripts/inert.sh 1 '"'"'INERT=1'"'"' '"'"'INERT=2'"'"'' ;;
+    # The run reddens on the clock rather than on the mutation.
+    capped) body='control_expect "a is one"
+control_replace scripts/a.sh 1 '"'"'A=1'"'"' '"'"'A=1; sleep 2'"'"'' ;;
+    # A control is arbitrary bash with CONTROL_ROOT set: this one writes under
+    # it directly, so the edit rides the counting pass and every mutation pass.
+    ungated) body='control_expect "a is one"
+printf '"'"'B=9\n'"'"' >"$CONTROL_ROOT/scripts/b.sh"
+control_replace scripts/a.sh 1 '"'"'A=1'"'"' '"'"'A=2'"'"'' ;;
+    # Two mutations naming what their runs redden, then an expectation no
+    # mutation follows: nothing drains it and the next pass truncates it.
+    trailing) body='control_expect "a is one"
+control_replace scripts/a.sh 1 '"'"'A=1'"'"' '"'"'A=2'"'"'
+control_expect "b is one"
+control_replace scripts/b.sh 1 '"'"'B=1'"'"' '"'"'B=2'"'"'
+control_expect "c is one"' ;;
+    # Reddens only the suite's fourth claim, whose text starts with its first,
+    # and names the shorter: a substring match would read that as proof.
+    prefix) body='control_expect "a is one"
+control_replace scripts/e.sh 1 '"'"'E=1'"'"' '"'"'E=2'"'"'' ;;
+    esac
+    printf '%s\n' "$body" >"$2/tests/controls/alpha.control.sh"
 }
 
-# run_roster_capped SECONDS LOGFILE ROOT — the same, with the runner's suite
-# timeout set, so a case can reach the kill without waiting out the default.
-run_roster_capped() {
-    local cap="$1" log="$2" root="$3"
-    CONTROL_TIMEOUT="$cap" bash "$root/tests/must-fail-controls.sh" >"$log" 2>&1
-    echo "$?"
+# run FIXTURE CONTROL CAP — a fresh fixture (`plain`, or `residue`, whose suite
+# writes a scratch file inside its own copy), the named control, the runner under CAP
+# seconds (`-` for its default), rendered as one line: the status, every
+# verdict line with its spacing collapsed, and the tally.
+run() {
+    local root="$TMP/$2-$1" rc=0
+    fixture "$root" "$1"
+    control "$2" "$root"
+    if [ "$3" = "-" ]; then
+        bash "$root/tests/must-fail-controls.sh" >"$root.log" 2>&1 || rc=$?
+    else
+        CONTROL_TIMEOUT="$3" bash "$root/tests/must-fail-controls.sh" >"$root.log" 2>&1 || rc=$?
+    fi
+    printf 'rc=%s;%s' "$rc" "$(grep -E '^(ok|WRONG|SHARED|NOEXPECT|GREEN|TIMEOUT|UNGATED|UNSTAGED|ORPHAN) |controls, ' "$root.log" | tr -s ' ' | paste -sd';' -)"
 }
 
-# --- each mutation reddening the assertion it named is the baseline --------
-# Neither mutation reddens the other's assertion, so the ok line here says both
-# copies were staged, both suites ran, and no case below can pass by the runner
-# always reporting a finding.
-clean="$TMP/clean"
-fixture "$clean"
-cat >"$clean/tests/controls/alpha.control.sh" <<'CONTROL'
-control_expect "a is one"
-control_replace scripts/a.sh 1 'A=1' 'A=2'
-control_expect "b is one"
-control_replace scripts/b.sh 1 'B=1' 'B=2'
-CONTROL
+# --- the table -----------------------------------------------------------------
+# label|fixture|control|cap|expect
+ROWS='
+a control whose mutations each redden what they named exits 0|plain|clean|-|rc=0;ok alpha.test.sh;1 controls, 0 failing, 0 orphaned
+the misnamed report names the mutation and the assertion|plain|misnamed|-|rc=1;WRONG alpha.test.sh mutation 2 did not redden: b is one;1 controls, 1 failing, 0 orphaned
+the shared report names the assertion|plain|shared|-|rc=1;SHARED alpha.test.sh two mutations name one assertion: a is one;1 controls, 1 failing, 0 orphaned
+the unnamed report names the mutation|plain|unnamed|-|rc=1;NOEXPECT alpha.test.sh mutation 2 names no assertion;1 controls, 1 failing, 0 orphaned
+the green report names its suite|plain|green|-|rc=1;GREEN alpha.test.sh suite passed with mutation 2, its only break;1 controls, 1 failing, 0 orphaned
+the timeout report names the mutation and the cap|plain|capped|1|rc=1;TIMEOUT alpha.test.sh mutation 1 hit the 1s cap having measured nothing;1 controls, 1 failing, 0 orphaned
+the ungated report says what it refuses|plain|ungated|-|rc=1;UNGATED alpha.test.sh control edits its copy outside a numbered mutation;1 controls, 1 failing, 0 orphaned
+the residue a suite writes in its own copy is not read as the edit of its control|residue|clean|-|rc=0;ok alpha.test.sh;1 controls, 0 failing, 0 orphaned
+the trailing report names the expectation nothing claims|plain|trailing|-|rc=1;NOEXPECT alpha.test.sh an expectation follows the last mutation and names none: c is one;1 controls, 1 failing, 0 orphaned
+the prefix report names the assertion the mutation did not redden|plain|prefix|-|rc=1;WRONG alpha.test.sh mutation 1 did not redden: a is one;1 controls, 1 failing, 0 orphaned
+'
 
-rc="$(run_roster "$TMP/clean.log" "$clean")"
-assert_eq "a control whose mutations each redden what they named exits 0" "$rc" 0
-assert_file_contains "the clean control is reported ok" \
-    "$TMP/clean.log" "ok       alpha.test.sh"
-assert_file_contains "the clean run counts no failure" \
-    "$TMP/clean.log" "1 controls, 0 failing, 0 orphaned"
+while IFS='|' read -r label fix ctl cap expect; do
+    [ -n "$label" ] || continue
+    assert_eq "$label" "$(run "$fix" "$ctl" "$cap")" "$expect"
+done <<<"$ROWS"
 
-# --- a mutation whose redness is not the assertion it named ----------------
-# The reproduction the whole rule exists for. The second mutation leaves both
-# values alone and reddens the suite with one of the verdicts assert.sh prints
-# when it refuses a suite outright. That carries the same FAIL: prefix an
-# assertion does, so a non-empty fail set is not proof of anything: it is not
-# the assertion the mutation named.
-misnamed="$TMP/misnamed"
-fixture "$misnamed"
-cat >"$misnamed/tests/controls/alpha.control.sh" <<'CONTROL'
-control_expect "a is one"
-control_replace scripts/a.sh 1 'A=1' 'A=2'
-control_expect "b is one"
-control_replace scripts/b.sh 1 'B=1' \
-    'B=1; echo "FAIL: the suite ended with background job(s) still running: 4242" >&2; exit 1'
-CONTROL
-
-rc="$(run_roster "$TMP/misnamed.log" "$misnamed")"
-assert_ne "a mutation reddening only a harness verdict fails the run" "$rc" 0
-assert_file_contains "the misnamed report names its suite" \
-    "$TMP/misnamed.log" "WRONG    alpha.test.sh"
-assert_file_contains "the misnamed report names the mutation and the assertion" \
-    "$TMP/misnamed.log" "mutation 2 did not redden: b is one"
-assert_file_contains "the misnamed control is counted, not just printed" \
-    "$TMP/misnamed.log" "1 controls, 1 failing, 0 orphaned"
-
-# --- two mutations naming one assertion ------------------------------------
-# Both reddened something, and the second's claim is one the first answers for.
-# Asking each mutation in isolation cannot see that, so it is asked of the
-# expectations before either runs.
-shared="$TMP/shared"
-fixture "$shared"
-cat >"$shared/tests/controls/alpha.control.sh" <<'CONTROL'
-control_expect "a is one"
-control_replace scripts/a.sh 1 'A=1' 'A=2'
-control_expect "a is one"
-control_replace scripts/b.sh 1 'B=1' 'B=2'
-CONTROL
-
-run_roster "$TMP/shared.log" "$shared" >/dev/null
-assert_file_contains "the shared report names its suite" \
-    "$TMP/shared.log" "SHARED   alpha.test.sh"
-assert_file_contains "the shared report names the assertion" \
-    "$TMP/shared.log" "two mutations name one assertion: a is one"
-
-# --- a mutation naming no assertion ----------------------------------------
-# The third way out: declare nothing and there is nothing to check.
-unnamed="$TMP/unnamed"
-fixture "$unnamed"
-cat >"$unnamed/tests/controls/alpha.control.sh" <<'CONTROL'
-control_expect "a is one"
-control_replace scripts/a.sh 1 'A=1' 'A=2'
-control_replace scripts/b.sh 1 'B=1' 'B=2'
-CONTROL
-
-rc="$(run_roster "$TMP/unnamed.log" "$unnamed")"
-assert_ne "a mutation naming no assertion fails the run" "$rc" 0
-assert_file_contains "the unnamed report names its suite" \
-    "$TMP/unnamed.log" "NOEXPECT alpha.test.sh"
-assert_file_contains "the unnamed report names the mutation" \
-    "$TMP/unnamed.log" "mutation 2 names no assertion"
-assert_file_contains "the unnamed control is counted, not just printed" \
-    "$TMP/unnamed.log" "1 controls, 1 failing, 0 orphaned"
-
-# --- a mutation the suite survived -----------------------------------------
-# The second mutation lands on a file the suite never reads, so the tree really
-# changes and this is not the NOOP case. This is where the copies matter: on
-# one copy with the first mutation it rides that one's failures into an ok
-# line, and only run on its own does it report what it proves, which is
-# nothing.
-green="$TMP/green"
-fixture "$green"
-cat >"$green/tests/controls/alpha.control.sh" <<'CONTROL'
-control_expect "a is one"
-control_replace scripts/a.sh 1 'A=1' 'A=2'
-control_expect "b is one"
-control_replace scripts/inert.sh 1 'INERT=1' 'INERT=2'
-CONTROL
-
-run_roster "$TMP/green.log" "$green" >/dev/null
-assert_file_contains "the green report names its suite" \
-    "$TMP/green.log" "GREEN    alpha.test.sh"
-assert_file_contains "the green report names the mutation that proved nothing" \
-    "$TMP/green.log" "mutation 2, its only break"
-
-# --- a run the timeout killed ----------------------------------------------
-# The run reddened on the clock rather than on the mutation, so it names the
-# kill instead of reporting the assertion it could not reach as unreddened.
-capped="$TMP/capped"
-fixture "$capped"
-cat >"$capped/tests/controls/alpha.control.sh" <<'CONTROL'
-control_expect "a is one"
-control_replace scripts/a.sh 1 'A=1' 'A=1; sleep 2'
-CONTROL
-
-run_roster_capped 1 "$TMP/capped.log" "$capped" >/dev/null
-assert_file_contains "the timeout report names its suite" \
-    "$TMP/capped.log" "TIMEOUT  alpha.test.sh"
-assert_file_contains "the timeout report names the mutation and the cap" \
-    "$TMP/capped.log" "mutation 1 hit the 1s cap having measured nothing"
-
-# --- an edit made outside a numbered mutation ------------------------------
-# A control is arbitrary bash with CONTROL_ROOT set. This one writes under it
-# directly, so the edit lands on the counting pass and on every mutation pass,
-# uncounted and never isolated: the way out of the regime, if nothing asks.
-ungated="$TMP/ungated"
-fixture "$ungated"
-cat >"$ungated/tests/controls/alpha.control.sh" <<'CONTROL'
-control_expect "a is one"
-printf 'B=9\n' >"$CONTROL_ROOT/scripts/b.sh"
-control_replace scripts/a.sh 1 'A=1' 'A=2'
-CONTROL
-
-rc="$(run_roster "$TMP/ungated.log" "$ungated")"
-assert_ne "a control that edits its copy unnumbered fails the run" "$rc" 0
-assert_file_contains "the ungated report names its suite" \
-    "$TMP/ungated.log" "UNGATED  alpha.test.sh"
-assert_file_contains "the ungated report says what it refuses" \
-    "$TMP/ungated.log" "edits its copy outside a numbered mutation"
-assert_file_contains "the ungated control is counted, not just printed" \
-    "$TMP/ungated.log" "1 controls, 1 failing, 0 orphaned"
-
-# --- a suite that writes inside its own copy -------------------------------
-# The guard above compares against a snapshot taken after the unmutated suite
-# has run, not against the source, so what it measures is the control's edits
-# and not the suite's own residue. This roster is cache-, lock- and sync-heavy,
-# so a suite writing under its own tree is ordinary and must not be reported as
-# its control editing outside a mutation.
-residue="$TMP/residue"
-fixture "$residue" residue
-cat >"$residue/tests/controls/alpha.control.sh" <<'CONTROL'
-control_expect "a is one"
-control_replace scripts/a.sh 1 'A=1' 'A=2'
-CONTROL
-
-rc="$(run_roster "$TMP/residue.log" "$residue")"
-assert_eq "a suite writing in its own copy leaves its control passing" "$rc" 0
-assert_file_contains "the control of a suite that writes residue is reported ok" \
-    "$TMP/residue.log" "ok       alpha.test.sh"
-assert_file_lacks "a suite's residue is not read as the control's edit" \
-    "$TMP/residue.log" "UNGATED"
-
-# --- an expectation with no mutation after it ------------------------------
-# Both mutations name an assertion their own run reddens, so nothing above
-# catches this control. The third expectation trails: no mutation follows it,
-# so control_mutation_wanted never drains it and the next pass truncates it,
-# and the claim would be dropped in silence. Declaring an expectation after its
-# mutation is the natural reading order, so the mistake is one an author makes.
-trailing="$TMP/trailing"
-fixture "$trailing"
-cat >"$trailing/tests/controls/alpha.control.sh" <<'CONTROL'
-control_expect "a is one"
-control_replace scripts/a.sh 1 'A=1' 'A=2'
-control_expect "b is one"
-control_replace scripts/b.sh 1 'B=1' 'B=2'
-control_expect "c is one"
-CONTROL
-
-rc="$(run_roster "$TMP/trailing.log" "$trailing")"
-assert_ne "an expectation no mutation claims fails the run" "$rc" 0
-assert_file_contains "the trailing report names its suite" \
-    "$TMP/trailing.log" "NOEXPECT alpha.test.sh"
-assert_file_contains "the trailing report names the expectation nothing claims" \
-    "$TMP/trailing.log" "an expectation follows the last mutation and names none: c is one"
-assert_file_contains "the trailing control is counted, not just printed" \
-    "$TMP/trailing.log" "1 controls, 1 failing, 0 orphaned"
-
-# --- a control naming a prefix of an assertion that reddened ---------------
-# The suite's fourth claim starts with the text of its first. This mutation
-# reddens only the longer one, and names the shorter; a substring match would
-# read that as proof, so the match is whole-line. The mutation names an
-# assertion its own run did not redden, which is what WRONG is.
-prefix="$TMP/prefix"
-fixture "$prefix"
-cat >"$prefix/tests/controls/alpha.control.sh" <<'CONTROL'
-control_expect "a is one"
-control_replace scripts/e.sh 1 'E=1' 'E=2'
-CONTROL
-
-rc="$(run_roster "$TMP/prefix.log" "$prefix")"
-assert_ne "a control naming a prefix of what reddened fails the run" "$rc" 0
-assert_file_contains "the prefix report names its suite" \
-    "$TMP/prefix.log" "WRONG    alpha.test.sh"
-assert_file_contains "the prefix report names the assertion the mutation did not redden" \
-    "$TMP/prefix.log" "mutation 1 did not redden: a is one"
-assert_file_contains "the prefix control is counted, not just printed" \
-    "$TMP/prefix.log" "1 controls, 1 failing, 0 orphaned"


### PR DESCRIPTION
Reshapes `skills/linear/tests/mutation-isolation.test.sh` to code-quality § Tests. It pinned `must-fail-controls.sh`'s per-mutation verdicts, driven against a synthetic one-suite skill, in ten hand-built cases of 32 substring assertions over the runner's log. It is now one table of 14 rows: a row names the fixture (`plain`, `residue`, or `broken`), the control it writes (the old cases' heredocs, verbatim, plus three new ones), the cap, and pins the exit status, every verdict line the runner printed and its tally as one line. The reviewer's round found four verdicts (MISSING, UNSTAGED, NOOP, BADCTRL) owned by no row anywhere in the roster (disabling each left every suite green); each has a row and a control arm now. The assertions go through the package's counting library; the control's ten mutations are unchanged and four arms are added.

The tracked render under `.agents` is replayed with `patch`.

## Folded or deleted cases, with the surviving row

| Former case (its assertions) | Surviving row |
|---|---|
| clean: exits 0; `ok alpha.test.sh`; counts no failure | `a control whose mutations each redden what they named exits 0` |
| misnamed: fails; `WRONG alpha.test.sh`; `mutation 2 did not redden: b is one`; counted | `the misnamed report names the mutation and the assertion` |
| shared: `SHARED`; the assertion named | `the shared report names the assertion` (rc and tally now pinned too) |
| unnamed: fails; `NOEXPECT`; `mutation 2 names no assertion`; counted | `the unnamed report names the mutation` |
| green: `GREEN`; `mutation 2, its only break` | `the green report names its suite` |
| capped: `TIMEOUT`; `mutation 1 hit the 1s cap having measured nothing` | `the timeout report names the mutation and the cap` |
| ungated: fails; `UNGATED`; `edits its copy outside a numbered mutation`; counted | `the ungated report says what it refuses` |
| residue: exits 0; `ok`; no `UNGATED` | `the residue a suite writes in its own copy is not read as the edit of its control` (the block holds only `ok` and the tally) |
| trailing: fails; `NOEXPECT`; the expectation named; counted | `the trailing report names the expectation nothing claims` |
| prefix: fails; `WRONG`; `mutation 1 did not redden: a is one`; counted | `the prefix report names the assertion the mutation did not redden` |
| (new) no control file, beside a suite that has one | `a suite with no control file is reported missing` |
| (new) a suite failing from its unmutated copy | `a suite failing from its unmutated copy proves nothing under mutation` |
| (new) a control declaring no mutation | `a control declaring no mutation changed nothing` |
| (new) a mutation whose line the file lacks | `a mutation whose line the file lacks did not apply` |

The render collapses column padding, so the `ok` line's padding and the verdict columns' `%-52s` are not pinned (presentation; the old file pinned the former by accident of its literal).

## Mutation

The control's fourteen arms, each on its own copy, each reddening the row it names (`must-fail-controls.sh mutation-isolation`: 1 controls, 0 failing). Five author mutants over the runner (the tally not counting a failure; the run exiting 0 with a failing control; WRONG naming the wrong mutation number; a killed run reading as GREEN; the trailing NOEXPECT line reworded): all killed. The reviewer's 19: 14 killed; 6 (the TIMEOUT mutation number, with one mutation in that control) and 15 (fail_set deduplication) equivalent under these fixtures; 12 and 13 the padding above; 14 (the expectation index match losing its `^` anchor) needs a control with ten or more mutations, pre-existing and not pinned here.

## Checks

- `mutation-isolation.test.sh`: 14 assertions, three runs identical; its control 1/1 (14 arms); `tools/guard --full`: exit 0 on the second commit's tree (TMPDIR=/var/tmp/ken-c; under this box's agents TMPDIR the crates/cli test `scope_project_outside_a_project_is_an_error` fails because /home/method/.claude is an ancestor of the fixture, recorded in the status file).
- `tools/bash32-lint skills/linear/tests`: clean.
- One reviewer-test round: verdict accept, no blockers; four judgements confirmed; its suggestions 1 and 3 are the second commit, suggestion 2 (the padding) recorded above as the render's deliberate cost.

KEN-1241

https://claude.ai/code/session_01JuvYHZWvL6GLtcLMwjj834
