### PR TITLE
test(KEN-1241): the milestone scope as one table of rows

### DIFF
--- a/.agents/skills/linear/tests/controls/milestone-project-scope.control.sh
+++ b/.agents/skills/linear/tests/controls/milestone-project-scope.control.sh
@@ -44,12 +44,14 @@ control_replace scripts/commands/issues.sh 1 \
 
 # Leave the create's milestone unresolved where it is hoisted, so the refusal
 # falls back to whatever runs after the upload.
+control_expect "a project-less name refuses the create before its upload"
 control_expect "an ambiguous name refuses the create before its upload"
 control_replace scripts/commands/issues.sh 1 \
     '        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")' \
     '        milestone_id=deferred-uuid'
 
 # Same for the update's.
+control_expect "a name refuses the update of an issue in no project before its upload"
 control_expect "an ambiguous name refuses the update before its upload"
 control_replace scripts/commands/issues.sh 1 \
     '        milestone_id=$(resolve_milestone_id "$milestone" "${project_id:-$issue_project_id}")' \
@@ -77,3 +79,10 @@ control_expect "an unreadable --attach path refuses before any lookup"
 control_replace scripts/commands/issues.sh 2 \
     '        attach_preflight_files "${attach_paths[@]}" || return 1' \
     '        true'
+
+# Read the UUID grammar as lowercase only, so an uppercase UUID is looked up
+# as a name.
+control_expect "an uppercase UUID is a UUID too"
+control_replace scripts/lib/common.sh 1 \
+    '    [[ "$1" =~ $LINEAR_UUID_PATTERN ]]' \
+    '    [[ "$1" =~ ^[0-9a-f-]+$ ]]'

--- a/.agents/skills/linear/tests/controls/milestone-project-scope.control.sh
+++ b/.agents/skills/linear/tests/controls/milestone-project-scope.control.sh
@@ -1,21 +1,22 @@
 # Drop the scope at the create call site, so the resolver is asked for a
 # milestone name with no project to resolve it in — which is what both call
 # sites did before, having resolved the project id and then not passed it.
-control_expect "issues create files the issue under the project's own milestone"
+control_expect "issues create files the issue under the project own milestone"
 control_replace scripts/commands/issues.sh 1 \
     '        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")' \
     '        milestone_id=$(resolve_milestone_id "$milestone")'
 
 # Ask the name query without the project filter, as it shipped. The fixture then
-# answers from every project, foreign milestone first.
-control_expect "issues update succeeds without --project on an issue that has one"
+# answers from every project, foreign milestone first, so a name the project
+# does not hold is matched anyway.
+control_expect "an unmatched name reports a miss, not an API failure"
 control_replace scripts/lib/common.sh 1 \
     "    local query='query GetMilestone(\$name: String!, \$projectId: ID!) { projectMilestones(filter: {name: {eq: \$name}, project: {id: {eq: \$projectId}}}) { nodes { id } } }'" \
     "    local query='query GetMilestone(\$name: String!) { projectMilestones(filter: {name: {eq: \$name}}) { nodes { id } } }'"
 
 # Take the first match instead of the whole set, so a second milestone of that
 # name is picked from rather than refused.
-control_expect "the ambiguity refusal names the second candidate UUID"
+control_expect "two milestones of that name in the project is a refusal, not a pick"
 control_replace scripts/lib/common.sh 1 \
     "    milestone_ids=\$(echo \"\$result\" | jq -r '[(.projectMilestones.nodes // [])[].id] | join(\", \")')" \
     "    milestone_ids=\$(echo \"\$result\" | jq -r '.projectMilestones.nodes[0].id // empty')"
@@ -23,33 +24,33 @@ control_replace scripts/lib/common.sh 1 \
 # Let every name resolver take a failed lookup for an empty one. Only the
 # milestone lookup fails in this suite, so this is the unchecked exit status
 # resolve_milestone_id shipped with: an outage reported as a missing milestone.
-control_expect "a failed lookup reports the API failure"
+control_expect "a failed lookup reports the API failure, not a miss"
 control_replace scripts/lib/common.sh 3 \
     '    if ! result=$(graphql_query "$query" "$vars"); then' \
     '    if ! result=$(graphql_query "$query" "$vars" || true); then'
 
 # Resolve a name with no project rather than refusing it.
-control_expect "the refusal names the missing project"
+control_expect "a milestone name with no project to scope it is refused before any lookup"
 control_replace scripts/lib/common.sh 1 \
     '    if [ -z "$milestone_ref" ] || [ -n "$project_scope" ]; then' \
     '    if true; then'
 
 # Scope the update's name to --project alone, so an issue already in a project
 # is refused unless the caller re-sends the project it is in.
-control_expect "issues update scopes the name to the issue's own project"
+control_expect "issues update scopes the name to the issue own project"
 control_replace scripts/commands/issues.sh 1 \
     '        milestone_id=$(resolve_milestone_id "$milestone" "${project_id:-$issue_project_id}")' \
     '        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")'
 
 # Leave the create's milestone unresolved where it is hoisted, so the refusal
 # falls back to whatever runs after the upload.
-control_expect "no upload is sent before the create ambiguity refusal"
+control_expect "an ambiguous name refuses the create before its upload"
 control_replace scripts/commands/issues.sh 1 \
     '        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")' \
     '        milestone_id=deferred-uuid'
 
 # Same for the update's.
-control_expect "no upload is sent before the update ambiguity refusal"
+control_expect "an ambiguous name refuses the update before its upload"
 control_replace scripts/commands/issues.sh 1 \
     '        milestone_id=$(resolve_milestone_id "$milestone" "${project_id:-$issue_project_id}")' \
     '        milestone_id=deferred-uuid'
@@ -65,14 +66,14 @@ control_replace scripts/commands/issues.sh 1 \
 
 # Stop treating a UUID as already resolved, so the project requirement reaches
 # a reference that names one milestone on its own.
-control_expect "a milestone UUID needs no project"
+control_expect "a milestone UUID needs no project and no lookup"
 control_replace scripts/lib/common.sh 2 \
     '    if milestone_ref_is_uuid "$milestone_ref"; then' \
     '    if false; then'
 
 # Skip the --attach preflight, so an unreadable path reaches the resolvers this
 # change hoisted and costs API calls before the refusal --help promises.
-control_expect "no project lookup precedes the missing-path refusal"
+control_expect "an unreadable --attach path refuses before any lookup"
 control_replace scripts/commands/issues.sh 2 \
     '        attach_preflight_files "${attach_paths[@]}" || return 1' \
     '        true'

--- a/.agents/skills/linear/tests/milestone-project-scope.test.sh
+++ b/.agents/skills/linear/tests/milestone-project-scope.test.sh
@@ -110,9 +110,9 @@ chmod +x "$PROJECT/bin/curl"
 
 # --- the renderer -------------------------------------------------------------
 # Every payload the fake curl logged, as `Operation(key=value,...)`: the named
-# operation, with the lookup's name and projectId, the mutation's
-# projectMilestoneId, and `upload` for a file upload, so the order of a
-# refusal against an upload is on the line.
+# operation, with the lookup's name and projectId and the mutation's
+# projectMilestoneId; a file upload is its bare `FileUpload()`, so the order
+# of a refusal against an upload is on the line.
 wire() {
   jq -r '
     def op: (.query | capture("^[[:space:]]*(query|mutation)[[:space:]]+(?<n>[A-Za-z_]+)").n)
@@ -169,6 +169,7 @@ an unmatched name reports a miss, not an API failure|$CREATE --project Dup --mil
 a milestone name with no project to scope it is refused before any lookup|$CREATE --milestone Alpha|1||unscoped:Alpha
 issues update scopes the name to the issue own project|issues update ISS-1 --milestone Alpha|0|GetIssue(),GetMilestone(name=Alpha,projectId=old-uuid),UpdateIssue(input.projectMilestoneId=alpha-old)|-
 a milestone UUID needs no project and no lookup|issues update ISS-2 --milestone 11111111-2222-3333-4444-555555555555|0|GetIssue(),UpdateIssue(input.projectMilestoneId=11111111-2222-3333-4444-555555555555)|-
+an uppercase UUID is a UUID too|issues update ISS-2 --milestone 11111111-2222-3333-4444-5555555555AA|0|GetIssue(),UpdateIssue(input.projectMilestoneId=11111111-2222-3333-4444-5555555555AA)|-
 a project-less name refuses the create before its upload|$CREATE --milestone Alpha --attach $TMP_ROOT/asset.bin|1||unscoped:Alpha
 a name refuses the update of an issue in no project before its upload|issues update ISS-2 --milestone Alpha --attach $TMP_ROOT/asset.bin|1|GetIssue()|unscoped:Alpha
 an unreadable --attach path refuses before any lookup|$CREATE --project Dup --milestone Alpha --attach $TMP_ROOT/nope.bin|1||unreadable:nope.bin

--- a/.agents/skills/linear/tests/milestone-project-scope.test.sh
+++ b/.agents/skills/linear/tests/milestone-project-scope.test.sh
@@ -9,6 +9,12 @@
 # reported "Milestone not found" — the wrong cause. The fixture returns the
 # foreign milestone first whenever the query arrives unscoped, which is the
 # order the old code got wrong.
+#
+# One table. A row is one command line and what it left behind, rendered as
+# one line: the exit status, every logged operation with the milestone
+# reference it carried (a lookup's name and project scope, a mutation's
+# projectMilestoneId), then stderr whole, so a refusal is pinned on its entire
+# line and a proceed on the milestone it filed under and the lookups it made.
 
 set -euo pipefail
 
@@ -102,136 +108,76 @@ esac
 SH
 chmod +x "$PROJECT/bin/curl"
 
-run_linear() {
-  ( cd "$PROJECT" \
-    && CURL_LOG="$CURL_LOG" PATH="$PROJECT/bin:$PATH" \
-       LINEAR_API_KEY_OVERRIDE=test-token LINEAR_TEAM=TestTeam \
-       "$LINEAR" "$@" ) >"$TMP_ROOT/out.txt" 2>"$ERR_FILE"
+# --- the renderer -------------------------------------------------------------
+# Every payload the fake curl logged, as `Operation(key=value,...)`: the named
+# operation, with the lookup's name and projectId, the mutation's
+# projectMilestoneId, and `upload` for a file upload, so the order of a
+# refusal against an upload is on the line.
+wire() {
+  jq -r '
+    def op: (.query | capture("^[[:space:]]*(query|mutation)[[:space:]]+(?<n>[A-Za-z_]+)").n)
+      // (.query | capture("\\{[[:space:]]*(?<n>[A-Za-z_]+)").n);
+    def shown: [(.variables // {}) as $v | $v | paths(scalars) as $p
+      | select($p == ["name"] or $p == ["projectId"] or $p == ["input", "projectMilestoneId"])
+      | "\($p | join("."))=\($v | getpath($p))"];
+    "\(op)(\(shown | join(",")))"' "$CURL_LOG" | paste -sd, -
 }
 
-create_with_milestone() {
-  run_linear issues create --title t --team TestTeam --project Dup \
-    --labels agent:rust --priority 3 --description d --milestone "$1"
+# run ARGS... — one command in the project, rendered.
+run() {
+  local rc=0 err
+  : >"$CURL_LOG"
+  (cd "$PROJECT" && CURL_LOG="$CURL_LOG" PATH="$PROJECT/bin:$PATH" \
+    LINEAR_API_KEY_OVERRIDE=test-token LINEAR_TEAM=TestTeam "$LINEAR" "$@") >"$TMP_ROOT/out.txt" 2>"$TMP_ROOT/err" || rc=$?
+  err="$(sed "s#$TMP_ROOT#<root>#g" "$TMP_ROOT/err" | paste -sd';' -)"
+  printf 'rc=%s wire=%s%s' "$rc" "$(wire)" "${err:+ $err}"
 }
 
-update_with_milestone() {
-  run_linear issues update ISS-1 --project Dup --milestone "$1"
+# --- the expected lines --------------------------------------------------------
+# expected RC WIRE MESSAGE — the line a row expects. MESSAGE is `-` (nothing
+# on stderr), or one of ambiguous:NAME, unscoped:NAME, failed:NAME,
+# notfound:NAME, unreadable:FILE, each the resolver's or the preflight's line.
+expected() {
+  local msg
+  case "$3" in
+  -) msg="" ;;
+  ambiguous:*) msg="$(printf ' {"error":"Milestone name is ambiguous within the project: \\"%s\\" matches twin-one, twin-two; pass a milestone UUID to target one)"}' "${3#*:}")" ;;
+  unscoped:*) msg="$(printf ' {"error":"Cannot resolve milestone \\"%s\\" without a project: the same milestone name exists in other projects. Pass --project, or pass the milestone UUID."}' "${3#*:}")" ;;
+  failed:*) msg="$(printf ' {"error":"Rate limited"};{"error":"Could not resolve milestone \\"%s\\": Linear API request failed (see previous error)"}' "${3#*:}")" ;;
+  notfound:*) msg="$(printf ' {"error":"Milestone not found: %s"}' "${3#*:}")" ;;
+  unreadable:*) msg="$(printf ' {"error":"--attach path not readable: <root>/%s"}' "${3#*:}")" ;;
+  esac
+  printf 'rc=%s wire=%s%s' "$1" "$2" "$msg"
 }
 
-# Surface: create resolves the milestone inside the project it just resolved.
-: >"$CURL_LOG"
-run_status create_rc create_with_milestone Alpha
-assert_eq "issues create succeeds with a project-scoped milestone name" "$create_rc" 0
-assert "issues create files the issue under the project's own milestone" \
-  jq -s -e 'any(.[]; (.query | contains("issueCreate")) and .variables.input.projectMilestoneId == "alpha-here")' \
-  "$CURL_LOG" >/dev/null
-
-# Surface: update resolves the milestone inside the project it just resolved.
-: >"$CURL_LOG"
-run_status update_rc update_with_milestone Alpha
-assert_eq "issues update succeeds with a project-scoped milestone name" "$update_rc" 0
-assert "--project wins over the project the issue is already in" \
-  jq -s -e 'any(.[]; (.query | contains("issueUpdate")) and .variables.input.projectMilestoneId == "alpha-here")' \
-  "$CURL_LOG" >/dev/null
-
-# Surface: two milestones of that name in the project is a refusal, not a pick.
-: >"$CURL_LOG"
-run_status twin_rc create_with_milestone Twin
-assert_ne "an ambiguous milestone name refuses the create" "$twin_rc" 0
-assert_file_contains "the ambiguity refusal names the first candidate UUID" "$ERR_FILE" "twin-one"
-assert_file_contains "the ambiguity refusal names the second candidate UUID" "$ERR_FILE" "twin-two"
-assert_file_lacks "no issue is created for an ambiguous milestone" "$CURL_LOG" "issueCreate"
-
-# Surface: a failed lookup is an API failure, a successful empty one is a miss.
-: >"$CURL_LOG"
-run_status boom_rc create_with_milestone Boom
-assert_ne "a failed milestone lookup refuses the create" "$boom_rc" 0
-assert_file_contains "a failed lookup reports the API failure" "$ERR_FILE" "Could not resolve milestone"
-
-: >"$CURL_LOG"
-run_status ghost_rc create_with_milestone Ghost
-assert_ne "an unmatched milestone name refuses the create" "$ghost_rc" 0
-assert_file_contains "an unmatched name reports a miss, not an API failure" "$ERR_FILE" "Milestone not found"
-
-# Surface: a milestone name with no project to scope it is refused.
-: >"$CURL_LOG"
-run_status unscoped_rc run_linear issues create --title t --team TestTeam \
-  --labels agent:rust --priority 3 --description d --milestone Alpha
-assert_ne "a milestone name without a project refuses the create" "$unscoped_rc" 0
-assert_file_contains "the refusal names the missing project" "$ERR_FILE" "without a project"
-assert_file_lacks "no milestone lookup is sent without a project to scope it" \
-  "$CURL_LOG" "projectMilestones"
-
-# Surface: on update, the issue's own project scopes the name. Asking for
-# --project to name the project the issue is already in would move it to
-# satisfy a lookup.
-: >"$CURL_LOG"
-run_status own_project_rc run_linear issues update ISS-1 --milestone Alpha
-assert_eq "issues update succeeds without --project on an issue that has one" "$own_project_rc" 0
-assert "issues update scopes the name to the issue's own project" \
-  jq -s -e 'any(.[]; (.query | contains("issueUpdate")) and .variables.input.projectMilestoneId == "alpha-old")' \
-  "$CURL_LOG" >/dev/null
-
-# Surface: a milestone UUID resolves with no project at all. It names one
-# milestone already, and refusing it would take `--milestone <uuid>` with it.
-: >"$CURL_LOG"
-run_status uuid_rc run_linear issues update ISS-2 \
-  --milestone 11111111-2222-3333-4444-555555555555
-assert_eq "a milestone UUID needs no project" "$uuid_rc" 0
-assert "the UUID reaches the mutation as given" \
-  jq -s -e 'any(.[]; (.query | contains("issueUpdate")) and .variables.input.projectMilestoneId == "11111111-2222-3333-4444-555555555555")' \
-  "$CURL_LOG" >/dev/null
-assert_file_lacks "a milestone UUID is not looked up by name" "$CURL_LOG" "projectMilestones"
-
-# Surface: the refusal is decided from the arguments, so it lands before
-# --attach uploads. A refusal after an upload strands the asset in Linear
-# storage with no issue referencing it.
+# --- the table ------------------------------------------------------------------
+# label|args|rc|wire|message
+# CREATE is the create up to its milestone; the fixture answers the project
+# lookup first because the resolvers are hoisted ahead of the team and label
+# ones. --attach rows put an asset behind the resolution: a refusal that lands
+# after the upload strands the asset in Linear storage with no issue
+# referencing it. The ambiguity rows need the lookup, not just the arguments,
+# so they are the ones proving the whole resolution runs ahead of the upload.
+CREATE='issues create --title t --team TestTeam --labels agent:rust --priority 3 --description d'
 printf 'x' >"$TMP_ROOT/asset.bin"
+ROWS='
+issues create files the issue under the project own milestone|$CREATE --project Dup --milestone Alpha|0|GetProject(name=Dup),GetMilestone(name=Alpha,projectId=live-uuid),GetTeam(name=TestTeam),GetLabel(name=agent:rust),CreateIssue(input.projectMilestoneId=alpha-here)|-
+--project wins over the project the issue is already in|issues update ISS-1 --project Dup --milestone Alpha|0|GetIssue(),GetProject(name=Dup),GetMilestone(name=Alpha,projectId=live-uuid),UpdateIssue(input.projectMilestoneId=alpha-here)|-
+two milestones of that name in the project is a refusal, not a pick|$CREATE --project Dup --milestone Twin|1|GetProject(name=Dup),GetMilestone(name=Twin,projectId=live-uuid)|ambiguous:Twin
+a failed lookup reports the API failure, not a miss|$CREATE --project Dup --milestone Boom|1|GetProject(name=Dup),GetMilestone(name=Boom,projectId=live-uuid)|failed:Boom
+an unmatched name reports a miss, not an API failure|$CREATE --project Dup --milestone Ghost|1|GetProject(name=Dup),GetMilestone(name=Ghost,projectId=live-uuid)|notfound:Ghost
+a milestone name with no project to scope it is refused before any lookup|$CREATE --milestone Alpha|1||unscoped:Alpha
+issues update scopes the name to the issue own project|issues update ISS-1 --milestone Alpha|0|GetIssue(),GetMilestone(name=Alpha,projectId=old-uuid),UpdateIssue(input.projectMilestoneId=alpha-old)|-
+a milestone UUID needs no project and no lookup|issues update ISS-2 --milestone 11111111-2222-3333-4444-555555555555|0|GetIssue(),UpdateIssue(input.projectMilestoneId=11111111-2222-3333-4444-555555555555)|-
+a project-less name refuses the create before its upload|$CREATE --milestone Alpha --attach $TMP_ROOT/asset.bin|1||unscoped:Alpha
+a name refuses the update of an issue in no project before its upload|issues update ISS-2 --milestone Alpha --attach $TMP_ROOT/asset.bin|1|GetIssue()|unscoped:Alpha
+an unreadable --attach path refuses before any lookup|$CREATE --project Dup --milestone Alpha --attach $TMP_ROOT/nope.bin|1||unreadable:nope.bin
+an ambiguous name refuses the create before its upload|$CREATE --project Dup --milestone Twin --attach $TMP_ROOT/asset.bin|1|GetProject(name=Dup),GetMilestone(name=Twin,projectId=live-uuid)|ambiguous:Twin
+an ambiguous name refuses the update before its upload|issues update ISS-1 --project Dup --milestone Twin --attach $TMP_ROOT/asset.bin|1|GetIssue(),GetProject(name=Dup),GetMilestone(name=Twin,projectId=live-uuid)|ambiguous:Twin
+'
 
-: >"$CURL_LOG"
-run_status create_attach_rc run_linear issues create --title t --team TestTeam \
-  --labels agent:rust --priority 3 --description d --milestone Alpha \
-  --attach "$TMP_ROOT/asset.bin"
-assert_ne "a project-less milestone name refuses the create that carries --attach" \
-  "$create_attach_rc" 0
-assert_file_lacks "no upload is sent before the create refusal" "$CURL_LOG" "fileUpload"
-
-: >"$CURL_LOG"
-run_status update_attach_rc run_linear issues update ISS-2 --milestone Alpha \
-  --attach "$TMP_ROOT/asset.bin"
-assert_ne "a milestone name refuses the update of an issue in no project" \
-  "$update_attach_rc" 0
-assert_file_lacks "no upload is sent before the update refusal" "$CURL_LOG" "fileUpload"
-
-# Hoisting the resolvers above the upload must not hoist them above the
-# --attach preflight: `--help` promises an unreadable path refuses before any
-# API call, and the existing preflight case passes no --project, so nothing
-# else reaches this ordering.
-: >"$CURL_LOG"
-run_status missing_attach_rc run_linear issues create --title t --team TestTeam \
-  --labels agent:rust --priority 3 --description d --project Dup --milestone Alpha \
-  --attach "$TMP_ROOT/nope.bin"
-assert_ne "a missing --attach path refuses the create" "$missing_attach_rc" 0
-assert_file_lacks "no project lookup precedes the missing-path refusal" \
-  "$CURL_LOG" "projects(filter:"
-assert_file_lacks "no milestone lookup precedes the missing-path refusal" \
-  "$CURL_LOG" "projectMilestones"
-
-# The ambiguity refusal needs the lookup, not just the arguments, so it is the
-# one that proves the whole resolution runs ahead of the upload.
-: >"$CURL_LOG"
-run_status create_twin_attach_rc run_linear issues create --title t --team TestTeam \
-  --labels agent:rust --priority 3 --description d --project Dup --milestone Twin \
-  --attach "$TMP_ROOT/asset.bin"
-assert_ne "an ambiguous milestone name refuses the create that carries --attach" \
-  "$create_twin_attach_rc" 0
-assert_file_lacks "no upload is sent before the create ambiguity refusal" \
-  "$CURL_LOG" "fileUpload"
-
-: >"$CURL_LOG"
-run_status update_twin_attach_rc run_linear issues update ISS-1 --project Dup \
-  --milestone Twin --attach "$TMP_ROOT/asset.bin"
-assert_ne "an ambiguous milestone name refuses the update that carries --attach" \
-  "$update_twin_attach_rc" 0
-assert_file_lacks "no upload is sent before the update ambiguity refusal" \
-  "$CURL_LOG" "fileUpload"
+while IFS='|' read -r label args rc wire msg; do
+  [ -n "$label" ] || continue
+  eval "set -- $args"
+  assert_eq "$label" "$(run "$@")" "$(expected "$rc" "$wire" "$msg")"
+done <<<"$ROWS"

--- a/skills/linear/tests/controls/milestone-project-scope.control.sh
+++ b/skills/linear/tests/controls/milestone-project-scope.control.sh
@@ -44,12 +44,14 @@ control_replace scripts/commands/issues.sh 1 \
 
 # Leave the create's milestone unresolved where it is hoisted, so the refusal
 # falls back to whatever runs after the upload.
+control_expect "a project-less name refuses the create before its upload"
 control_expect "an ambiguous name refuses the create before its upload"
 control_replace scripts/commands/issues.sh 1 \
     '        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")' \
     '        milestone_id=deferred-uuid'
 
 # Same for the update's.
+control_expect "a name refuses the update of an issue in no project before its upload"
 control_expect "an ambiguous name refuses the update before its upload"
 control_replace scripts/commands/issues.sh 1 \
     '        milestone_id=$(resolve_milestone_id "$milestone" "${project_id:-$issue_project_id}")' \
@@ -77,3 +79,10 @@ control_expect "an unreadable --attach path refuses before any lookup"
 control_replace scripts/commands/issues.sh 2 \
     '        attach_preflight_files "${attach_paths[@]}" || return 1' \
     '        true'
+
+# Read the UUID grammar as lowercase only, so an uppercase UUID is looked up
+# as a name.
+control_expect "an uppercase UUID is a UUID too"
+control_replace scripts/lib/common.sh 1 \
+    '    [[ "$1" =~ $LINEAR_UUID_PATTERN ]]' \
+    '    [[ "$1" =~ ^[0-9a-f-]+$ ]]'

--- a/skills/linear/tests/controls/milestone-project-scope.control.sh
+++ b/skills/linear/tests/controls/milestone-project-scope.control.sh
@@ -1,21 +1,22 @@
 # Drop the scope at the create call site, so the resolver is asked for a
 # milestone name with no project to resolve it in — which is what both call
 # sites did before, having resolved the project id and then not passed it.
-control_expect "issues create files the issue under the project's own milestone"
+control_expect "issues create files the issue under the project own milestone"
 control_replace scripts/commands/issues.sh 1 \
     '        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")' \
     '        milestone_id=$(resolve_milestone_id "$milestone")'
 
 # Ask the name query without the project filter, as it shipped. The fixture then
-# answers from every project, foreign milestone first.
-control_expect "issues update succeeds without --project on an issue that has one"
+# answers from every project, foreign milestone first, so a name the project
+# does not hold is matched anyway.
+control_expect "an unmatched name reports a miss, not an API failure"
 control_replace scripts/lib/common.sh 1 \
     "    local query='query GetMilestone(\$name: String!, \$projectId: ID!) { projectMilestones(filter: {name: {eq: \$name}, project: {id: {eq: \$projectId}}}) { nodes { id } } }'" \
     "    local query='query GetMilestone(\$name: String!) { projectMilestones(filter: {name: {eq: \$name}}) { nodes { id } } }'"
 
 # Take the first match instead of the whole set, so a second milestone of that
 # name is picked from rather than refused.
-control_expect "the ambiguity refusal names the second candidate UUID"
+control_expect "two milestones of that name in the project is a refusal, not a pick"
 control_replace scripts/lib/common.sh 1 \
     "    milestone_ids=\$(echo \"\$result\" | jq -r '[(.projectMilestones.nodes // [])[].id] | join(\", \")')" \
     "    milestone_ids=\$(echo \"\$result\" | jq -r '.projectMilestones.nodes[0].id // empty')"
@@ -23,33 +24,33 @@ control_replace scripts/lib/common.sh 1 \
 # Let every name resolver take a failed lookup for an empty one. Only the
 # milestone lookup fails in this suite, so this is the unchecked exit status
 # resolve_milestone_id shipped with: an outage reported as a missing milestone.
-control_expect "a failed lookup reports the API failure"
+control_expect "a failed lookup reports the API failure, not a miss"
 control_replace scripts/lib/common.sh 3 \
     '    if ! result=$(graphql_query "$query" "$vars"); then' \
     '    if ! result=$(graphql_query "$query" "$vars" || true); then'
 
 # Resolve a name with no project rather than refusing it.
-control_expect "the refusal names the missing project"
+control_expect "a milestone name with no project to scope it is refused before any lookup"
 control_replace scripts/lib/common.sh 1 \
     '    if [ -z "$milestone_ref" ] || [ -n "$project_scope" ]; then' \
     '    if true; then'
 
 # Scope the update's name to --project alone, so an issue already in a project
 # is refused unless the caller re-sends the project it is in.
-control_expect "issues update scopes the name to the issue's own project"
+control_expect "issues update scopes the name to the issue own project"
 control_replace scripts/commands/issues.sh 1 \
     '        milestone_id=$(resolve_milestone_id "$milestone" "${project_id:-$issue_project_id}")' \
     '        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")'
 
 # Leave the create's milestone unresolved where it is hoisted, so the refusal
 # falls back to whatever runs after the upload.
-control_expect "no upload is sent before the create ambiguity refusal"
+control_expect "an ambiguous name refuses the create before its upload"
 control_replace scripts/commands/issues.sh 1 \
     '        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")' \
     '        milestone_id=deferred-uuid'
 
 # Same for the update's.
-control_expect "no upload is sent before the update ambiguity refusal"
+control_expect "an ambiguous name refuses the update before its upload"
 control_replace scripts/commands/issues.sh 1 \
     '        milestone_id=$(resolve_milestone_id "$milestone" "${project_id:-$issue_project_id}")' \
     '        milestone_id=deferred-uuid'
@@ -65,14 +66,14 @@ control_replace scripts/commands/issues.sh 1 \
 
 # Stop treating a UUID as already resolved, so the project requirement reaches
 # a reference that names one milestone on its own.
-control_expect "a milestone UUID needs no project"
+control_expect "a milestone UUID needs no project and no lookup"
 control_replace scripts/lib/common.sh 2 \
     '    if milestone_ref_is_uuid "$milestone_ref"; then' \
     '    if false; then'
 
 # Skip the --attach preflight, so an unreadable path reaches the resolvers this
 # change hoisted and costs API calls before the refusal --help promises.
-control_expect "no project lookup precedes the missing-path refusal"
+control_expect "an unreadable --attach path refuses before any lookup"
 control_replace scripts/commands/issues.sh 2 \
     '        attach_preflight_files "${attach_paths[@]}" || return 1' \
     '        true'

--- a/skills/linear/tests/milestone-project-scope.test.sh
+++ b/skills/linear/tests/milestone-project-scope.test.sh
@@ -110,9 +110,9 @@ chmod +x "$PROJECT/bin/curl"
 
 # --- the renderer -------------------------------------------------------------
 # Every payload the fake curl logged, as `Operation(key=value,...)`: the named
-# operation, with the lookup's name and projectId, the mutation's
-# projectMilestoneId, and `upload` for a file upload, so the order of a
-# refusal against an upload is on the line.
+# operation, with the lookup's name and projectId and the mutation's
+# projectMilestoneId; a file upload is its bare `FileUpload()`, so the order
+# of a refusal against an upload is on the line.
 wire() {
   jq -r '
     def op: (.query | capture("^[[:space:]]*(query|mutation)[[:space:]]+(?<n>[A-Za-z_]+)").n)
@@ -169,6 +169,7 @@ an unmatched name reports a miss, not an API failure|$CREATE --project Dup --mil
 a milestone name with no project to scope it is refused before any lookup|$CREATE --milestone Alpha|1||unscoped:Alpha
 issues update scopes the name to the issue own project|issues update ISS-1 --milestone Alpha|0|GetIssue(),GetMilestone(name=Alpha,projectId=old-uuid),UpdateIssue(input.projectMilestoneId=alpha-old)|-
 a milestone UUID needs no project and no lookup|issues update ISS-2 --milestone 11111111-2222-3333-4444-555555555555|0|GetIssue(),UpdateIssue(input.projectMilestoneId=11111111-2222-3333-4444-555555555555)|-
+an uppercase UUID is a UUID too|issues update ISS-2 --milestone 11111111-2222-3333-4444-5555555555AA|0|GetIssue(),UpdateIssue(input.projectMilestoneId=11111111-2222-3333-4444-5555555555AA)|-
 a project-less name refuses the create before its upload|$CREATE --milestone Alpha --attach $TMP_ROOT/asset.bin|1||unscoped:Alpha
 a name refuses the update of an issue in no project before its upload|issues update ISS-2 --milestone Alpha --attach $TMP_ROOT/asset.bin|1|GetIssue()|unscoped:Alpha
 an unreadable --attach path refuses before any lookup|$CREATE --project Dup --milestone Alpha --attach $TMP_ROOT/nope.bin|1||unreadable:nope.bin

--- a/skills/linear/tests/milestone-project-scope.test.sh
+++ b/skills/linear/tests/milestone-project-scope.test.sh
@@ -9,6 +9,12 @@
 # reported "Milestone not found" — the wrong cause. The fixture returns the
 # foreign milestone first whenever the query arrives unscoped, which is the
 # order the old code got wrong.
+#
+# One table. A row is one command line and what it left behind, rendered as
+# one line: the exit status, every logged operation with the milestone
+# reference it carried (a lookup's name and project scope, a mutation's
+# projectMilestoneId), then stderr whole, so a refusal is pinned on its entire
+# line and a proceed on the milestone it filed under and the lookups it made.
 
 set -euo pipefail
 
@@ -102,136 +108,76 @@ esac
 SH
 chmod +x "$PROJECT/bin/curl"
 
-run_linear() {
-  ( cd "$PROJECT" \
-    && CURL_LOG="$CURL_LOG" PATH="$PROJECT/bin:$PATH" \
-       LINEAR_API_KEY_OVERRIDE=test-token LINEAR_TEAM=TestTeam \
-       "$LINEAR" "$@" ) >"$TMP_ROOT/out.txt" 2>"$ERR_FILE"
+# --- the renderer -------------------------------------------------------------
+# Every payload the fake curl logged, as `Operation(key=value,...)`: the named
+# operation, with the lookup's name and projectId, the mutation's
+# projectMilestoneId, and `upload` for a file upload, so the order of a
+# refusal against an upload is on the line.
+wire() {
+  jq -r '
+    def op: (.query | capture("^[[:space:]]*(query|mutation)[[:space:]]+(?<n>[A-Za-z_]+)").n)
+      // (.query | capture("\\{[[:space:]]*(?<n>[A-Za-z_]+)").n);
+    def shown: [(.variables // {}) as $v | $v | paths(scalars) as $p
+      | select($p == ["name"] or $p == ["projectId"] or $p == ["input", "projectMilestoneId"])
+      | "\($p | join("."))=\($v | getpath($p))"];
+    "\(op)(\(shown | join(",")))"' "$CURL_LOG" | paste -sd, -
 }
 
-create_with_milestone() {
-  run_linear issues create --title t --team TestTeam --project Dup \
-    --labels agent:rust --priority 3 --description d --milestone "$1"
+# run ARGS... — one command in the project, rendered.
+run() {
+  local rc=0 err
+  : >"$CURL_LOG"
+  (cd "$PROJECT" && CURL_LOG="$CURL_LOG" PATH="$PROJECT/bin:$PATH" \
+    LINEAR_API_KEY_OVERRIDE=test-token LINEAR_TEAM=TestTeam "$LINEAR" "$@") >"$TMP_ROOT/out.txt" 2>"$TMP_ROOT/err" || rc=$?
+  err="$(sed "s#$TMP_ROOT#<root>#g" "$TMP_ROOT/err" | paste -sd';' -)"
+  printf 'rc=%s wire=%s%s' "$rc" "$(wire)" "${err:+ $err}"
 }
 
-update_with_milestone() {
-  run_linear issues update ISS-1 --project Dup --milestone "$1"
+# --- the expected lines --------------------------------------------------------
+# expected RC WIRE MESSAGE — the line a row expects. MESSAGE is `-` (nothing
+# on stderr), or one of ambiguous:NAME, unscoped:NAME, failed:NAME,
+# notfound:NAME, unreadable:FILE, each the resolver's or the preflight's line.
+expected() {
+  local msg
+  case "$3" in
+  -) msg="" ;;
+  ambiguous:*) msg="$(printf ' {"error":"Milestone name is ambiguous within the project: \\"%s\\" matches twin-one, twin-two; pass a milestone UUID to target one)"}' "${3#*:}")" ;;
+  unscoped:*) msg="$(printf ' {"error":"Cannot resolve milestone \\"%s\\" without a project: the same milestone name exists in other projects. Pass --project, or pass the milestone UUID."}' "${3#*:}")" ;;
+  failed:*) msg="$(printf ' {"error":"Rate limited"};{"error":"Could not resolve milestone \\"%s\\": Linear API request failed (see previous error)"}' "${3#*:}")" ;;
+  notfound:*) msg="$(printf ' {"error":"Milestone not found: %s"}' "${3#*:}")" ;;
+  unreadable:*) msg="$(printf ' {"error":"--attach path not readable: <root>/%s"}' "${3#*:}")" ;;
+  esac
+  printf 'rc=%s wire=%s%s' "$1" "$2" "$msg"
 }
 
-# Surface: create resolves the milestone inside the project it just resolved.
-: >"$CURL_LOG"
-run_status create_rc create_with_milestone Alpha
-assert_eq "issues create succeeds with a project-scoped milestone name" "$create_rc" 0
-assert "issues create files the issue under the project's own milestone" \
-  jq -s -e 'any(.[]; (.query | contains("issueCreate")) and .variables.input.projectMilestoneId == "alpha-here")' \
-  "$CURL_LOG" >/dev/null
-
-# Surface: update resolves the milestone inside the project it just resolved.
-: >"$CURL_LOG"
-run_status update_rc update_with_milestone Alpha
-assert_eq "issues update succeeds with a project-scoped milestone name" "$update_rc" 0
-assert "--project wins over the project the issue is already in" \
-  jq -s -e 'any(.[]; (.query | contains("issueUpdate")) and .variables.input.projectMilestoneId == "alpha-here")' \
-  "$CURL_LOG" >/dev/null
-
-# Surface: two milestones of that name in the project is a refusal, not a pick.
-: >"$CURL_LOG"
-run_status twin_rc create_with_milestone Twin
-assert_ne "an ambiguous milestone name refuses the create" "$twin_rc" 0
-assert_file_contains "the ambiguity refusal names the first candidate UUID" "$ERR_FILE" "twin-one"
-assert_file_contains "the ambiguity refusal names the second candidate UUID" "$ERR_FILE" "twin-two"
-assert_file_lacks "no issue is created for an ambiguous milestone" "$CURL_LOG" "issueCreate"
-
-# Surface: a failed lookup is an API failure, a successful empty one is a miss.
-: >"$CURL_LOG"
-run_status boom_rc create_with_milestone Boom
-assert_ne "a failed milestone lookup refuses the create" "$boom_rc" 0
-assert_file_contains "a failed lookup reports the API failure" "$ERR_FILE" "Could not resolve milestone"
-
-: >"$CURL_LOG"
-run_status ghost_rc create_with_milestone Ghost
-assert_ne "an unmatched milestone name refuses the create" "$ghost_rc" 0
-assert_file_contains "an unmatched name reports a miss, not an API failure" "$ERR_FILE" "Milestone not found"
-
-# Surface: a milestone name with no project to scope it is refused.
-: >"$CURL_LOG"
-run_status unscoped_rc run_linear issues create --title t --team TestTeam \
-  --labels agent:rust --priority 3 --description d --milestone Alpha
-assert_ne "a milestone name without a project refuses the create" "$unscoped_rc" 0
-assert_file_contains "the refusal names the missing project" "$ERR_FILE" "without a project"
-assert_file_lacks "no milestone lookup is sent without a project to scope it" \
-  "$CURL_LOG" "projectMilestones"
-
-# Surface: on update, the issue's own project scopes the name. Asking for
-# --project to name the project the issue is already in would move it to
-# satisfy a lookup.
-: >"$CURL_LOG"
-run_status own_project_rc run_linear issues update ISS-1 --milestone Alpha
-assert_eq "issues update succeeds without --project on an issue that has one" "$own_project_rc" 0
-assert "issues update scopes the name to the issue's own project" \
-  jq -s -e 'any(.[]; (.query | contains("issueUpdate")) and .variables.input.projectMilestoneId == "alpha-old")' \
-  "$CURL_LOG" >/dev/null
-
-# Surface: a milestone UUID resolves with no project at all. It names one
-# milestone already, and refusing it would take `--milestone <uuid>` with it.
-: >"$CURL_LOG"
-run_status uuid_rc run_linear issues update ISS-2 \
-  --milestone 11111111-2222-3333-4444-555555555555
-assert_eq "a milestone UUID needs no project" "$uuid_rc" 0
-assert "the UUID reaches the mutation as given" \
-  jq -s -e 'any(.[]; (.query | contains("issueUpdate")) and .variables.input.projectMilestoneId == "11111111-2222-3333-4444-555555555555")' \
-  "$CURL_LOG" >/dev/null
-assert_file_lacks "a milestone UUID is not looked up by name" "$CURL_LOG" "projectMilestones"
-
-# Surface: the refusal is decided from the arguments, so it lands before
-# --attach uploads. A refusal after an upload strands the asset in Linear
-# storage with no issue referencing it.
+# --- the table ------------------------------------------------------------------
+# label|args|rc|wire|message
+# CREATE is the create up to its milestone; the fixture answers the project
+# lookup first because the resolvers are hoisted ahead of the team and label
+# ones. --attach rows put an asset behind the resolution: a refusal that lands
+# after the upload strands the asset in Linear storage with no issue
+# referencing it. The ambiguity rows need the lookup, not just the arguments,
+# so they are the ones proving the whole resolution runs ahead of the upload.
+CREATE='issues create --title t --team TestTeam --labels agent:rust --priority 3 --description d'
 printf 'x' >"$TMP_ROOT/asset.bin"
+ROWS='
+issues create files the issue under the project own milestone|$CREATE --project Dup --milestone Alpha|0|GetProject(name=Dup),GetMilestone(name=Alpha,projectId=live-uuid),GetTeam(name=TestTeam),GetLabel(name=agent:rust),CreateIssue(input.projectMilestoneId=alpha-here)|-
+--project wins over the project the issue is already in|issues update ISS-1 --project Dup --milestone Alpha|0|GetIssue(),GetProject(name=Dup),GetMilestone(name=Alpha,projectId=live-uuid),UpdateIssue(input.projectMilestoneId=alpha-here)|-
+two milestones of that name in the project is a refusal, not a pick|$CREATE --project Dup --milestone Twin|1|GetProject(name=Dup),GetMilestone(name=Twin,projectId=live-uuid)|ambiguous:Twin
+a failed lookup reports the API failure, not a miss|$CREATE --project Dup --milestone Boom|1|GetProject(name=Dup),GetMilestone(name=Boom,projectId=live-uuid)|failed:Boom
+an unmatched name reports a miss, not an API failure|$CREATE --project Dup --milestone Ghost|1|GetProject(name=Dup),GetMilestone(name=Ghost,projectId=live-uuid)|notfound:Ghost
+a milestone name with no project to scope it is refused before any lookup|$CREATE --milestone Alpha|1||unscoped:Alpha
+issues update scopes the name to the issue own project|issues update ISS-1 --milestone Alpha|0|GetIssue(),GetMilestone(name=Alpha,projectId=old-uuid),UpdateIssue(input.projectMilestoneId=alpha-old)|-
+a milestone UUID needs no project and no lookup|issues update ISS-2 --milestone 11111111-2222-3333-4444-555555555555|0|GetIssue(),UpdateIssue(input.projectMilestoneId=11111111-2222-3333-4444-555555555555)|-
+a project-less name refuses the create before its upload|$CREATE --milestone Alpha --attach $TMP_ROOT/asset.bin|1||unscoped:Alpha
+a name refuses the update of an issue in no project before its upload|issues update ISS-2 --milestone Alpha --attach $TMP_ROOT/asset.bin|1|GetIssue()|unscoped:Alpha
+an unreadable --attach path refuses before any lookup|$CREATE --project Dup --milestone Alpha --attach $TMP_ROOT/nope.bin|1||unreadable:nope.bin
+an ambiguous name refuses the create before its upload|$CREATE --project Dup --milestone Twin --attach $TMP_ROOT/asset.bin|1|GetProject(name=Dup),GetMilestone(name=Twin,projectId=live-uuid)|ambiguous:Twin
+an ambiguous name refuses the update before its upload|issues update ISS-1 --project Dup --milestone Twin --attach $TMP_ROOT/asset.bin|1|GetIssue(),GetProject(name=Dup),GetMilestone(name=Twin,projectId=live-uuid)|ambiguous:Twin
+'
 
-: >"$CURL_LOG"
-run_status create_attach_rc run_linear issues create --title t --team TestTeam \
-  --labels agent:rust --priority 3 --description d --milestone Alpha \
-  --attach "$TMP_ROOT/asset.bin"
-assert_ne "a project-less milestone name refuses the create that carries --attach" \
-  "$create_attach_rc" 0
-assert_file_lacks "no upload is sent before the create refusal" "$CURL_LOG" "fileUpload"
-
-: >"$CURL_LOG"
-run_status update_attach_rc run_linear issues update ISS-2 --milestone Alpha \
-  --attach "$TMP_ROOT/asset.bin"
-assert_ne "a milestone name refuses the update of an issue in no project" \
-  "$update_attach_rc" 0
-assert_file_lacks "no upload is sent before the update refusal" "$CURL_LOG" "fileUpload"
-
-# Hoisting the resolvers above the upload must not hoist them above the
-# --attach preflight: `--help` promises an unreadable path refuses before any
-# API call, and the existing preflight case passes no --project, so nothing
-# else reaches this ordering.
-: >"$CURL_LOG"
-run_status missing_attach_rc run_linear issues create --title t --team TestTeam \
-  --labels agent:rust --priority 3 --description d --project Dup --milestone Alpha \
-  --attach "$TMP_ROOT/nope.bin"
-assert_ne "a missing --attach path refuses the create" "$missing_attach_rc" 0
-assert_file_lacks "no project lookup precedes the missing-path refusal" \
-  "$CURL_LOG" "projects(filter:"
-assert_file_lacks "no milestone lookup precedes the missing-path refusal" \
-  "$CURL_LOG" "projectMilestones"
-
-# The ambiguity refusal needs the lookup, not just the arguments, so it is the
-# one that proves the whole resolution runs ahead of the upload.
-: >"$CURL_LOG"
-run_status create_twin_attach_rc run_linear issues create --title t --team TestTeam \
-  --labels agent:rust --priority 3 --description d --project Dup --milestone Twin \
-  --attach "$TMP_ROOT/asset.bin"
-assert_ne "an ambiguous milestone name refuses the create that carries --attach" \
-  "$create_twin_attach_rc" 0
-assert_file_lacks "no upload is sent before the create ambiguity refusal" \
-  "$CURL_LOG" "fileUpload"
-
-: >"$CURL_LOG"
-run_status update_twin_attach_rc run_linear issues update ISS-1 --project Dup \
-  --milestone Twin --attach "$TMP_ROOT/asset.bin"
-assert_ne "an ambiguous milestone name refuses the update that carries --attach" \
-  "$update_twin_attach_rc" 0
-assert_file_lacks "no upload is sent before the update ambiguity refusal" \
-  "$CURL_LOG" "fileUpload"
+while IFS='|' read -r label args rc wire msg; do
+  [ -n "$label" ] || continue
+  eval "set -- $args"
+  assert_eq "$label" "$(run "$@")" "$(expected "$rc" "$wire" "$msg")"
+done <<<"$ROWS"


### PR DESCRIPTION
Reshapes `skills/linear/tests/milestone-project-scope.test.sh` to code-quality § Tests. It pinned the project-scoped milestone resolution (`resolve_milestone_id`, `require_milestone_project`, their hoisted call sites in `issues create` and `issues update`) in a 237-line linear script of 13 cases and 31 assertions: an rc check beside a jq selection over the logged payloads or a substring of the refusal. It is now one table of 14 rows: a row is one command line and pins the exit status, every logged operation with the milestone reference it carried (a lookup's name and project scope, a mutation's projectMilestoneId), and stderr whole, in order, so a refusal is pinned on its entire line and a proceed on the milestone it filed under and the lookups it made ahead of any upload. The assertions go through the package's counting library; the control's eleven mutations are unchanged and name the surviving rows.

The tracked render under `.agents` is replayed with `patch`.

## Folded or deleted cases, with the surviving row

| Former assertion | Surviving row |
|---|---|
| create succeeds with a project-scoped name; files under the project's own milestone | `issues create files the issue under the project own milestone` (`GetMilestone(name=Alpha,projectId=live-uuid)` then `CreateIssue(input.projectMilestoneId=alpha-here)`) |
| update succeeds with --project; --project wins over the issue's project | `--project wins over the project the issue is already in` |
| an ambiguous name refuses; names both candidates; no issueCreate | `two milestones of that name in the project is a refusal, not a pick` (the refusal line whole, `twin-one, twin-two`; no CreateIssue on the wire) |
| a failed lookup refuses; reports the API failure | `a failed lookup reports the API failure, not a miss` (both stderr lines) |
| an unmatched name refuses; reports a miss | `an unmatched name reports a miss, not an API failure` |
| a name with no project refuses; names the missing project; no milestone lookup | `a milestone name with no project to scope it is refused before any lookup` (an empty wire: no lookup at all, the team one included) |
| update without --project succeeds; scopes to the issue's own project | `issues update scopes the name to the issue own project` |
| a UUID needs no project; reaches the mutation as given; no name lookup | `a milestone UUID needs no project and no lookup` |
| a project-less name refuses the create with --attach; no upload | `a project-less name refuses the create before its upload` |
| a name refuses the update of an issue in no project with --attach; no upload | `a name refuses the update of an issue in no project before its upload` |
| a missing --attach path refuses; no project lookup; no milestone lookup | `an unreadable --attach path refuses before any lookup` |
| an ambiguous name refuses the create with --attach; no upload | `an ambiguous name refuses the create before its upload` |
| an ambiguous name refuses the update with --attach; no upload | `an ambiguous name refuses the update before its upload` |

The control's mutation 2 (the unscoped name query) now names the Ghost row: the old case it named merged with mutation 6's into one row, and under an unscoped query the fixture answers two foreign Alphas for any name, so Ghost reads as ambiguous.

## Mutation

The control's eleven mutations, each on its own copy, each reddening the row it names (`must-fail-controls.sh milestone-project-scope`: 1 controls, 0 failing). Seven author mutants over the lookup's variables, the ambiguity refusal (candidates dropped; the first candidate taken), the not-found wording, the unscoped remedy, the UUID short-circuit and the preflight's path: all killed. The reviewer's 16: 13 killed; P1 (a lowercase-only UUID grammar) closed by the second commit's uppercase row and control arm; P12b (a second milestone reference under an unselected key) has no shipped producer; F5 (the fixture's unscoped answer reduced to one node) shows the unscoped branch unreachable in a correct build.

## Checks

- `milestone-project-scope.test.sh`: 14 assertions; its control 1/1 (12 arms, the two --attach refusal rows the old arms reddened but never named now named); `tools/guard --full`: exit 0 on the second commit's tree (TMPDIR=/var/tmp/ken-c).
- `tools/bash32-lint skills/linear/tests`: clean.
- One reviewer-test round: verdict accept, no blockers; four judgements confirmed (the ordered wire catches the hoisting and the upload order the old file could only see the absence of); its suggestions 1, 2 and 4 are the second commit; suggestion 3 (a second milestone key under a fourth path) has no producer; suggestion 5 (`eval` glob-expands the args column) is a constraint on future rows.

KEN-1241

https://claude.ai/code/session_01JuvYHZWvL6GLtcLMwjj834
