### PR TITLE
test(KEN-1241): the work-marker ban as one table of rows

### DIFF
--- a/.agents/skills/commit-guards/tests/todo-ban.test.sh
+++ b/.agents/skills/commit-guards/tests/todo-ban.test.sh
@@ -87,6 +87,7 @@ run_rows() { # label | fixture | shim | env | args | expect
   local row label fx shim env args expect
   for row in "$@"; do
     IFS='|' read -r label fx shim env args expect <<<"$row"
+    [ -n "$expect" ] || { echo "harness: row has fewer than six fields: $row" >&2; exit 2; }
     R=""
     "$fx"
     assert_eq "$label" "$expect" "$(run "$shim" "$env" "$args")"
@@ -101,7 +102,10 @@ fx_block() { repo block; put a.rs "code(); /* $HK: inline block */\n"; stage; }
 fx_hash() { repo hash; put a.rs "# $TD implement the frobnicator\n"; stage; }
 fx_glued() { repo glued; put a.rs "//$XX no space before the word\n"; stage; }
 fx_leaders() { repo leaders; put a.rs "; $TD after a semicolon\n<!-- $FX after an HTML leader\n"; stage; }
-fx_four() { repo four; put a.rs "// $TD: one\n// $FX: two\n// $HK: three\n// $XX: four\n"; stage; }
+# Each odd line reaches only the annotated arm (no leader), each even line
+# only the after-a-leader arm (no colon), and line 6 is the one place the
+# block-comment opener is the leader.
+fx_four() { repo four; put a.rs "$TD: one\n//$TD two\n$FX(x): three\n//$FX four\n$HK: five\n/*$HK six\n$XX: seven\n//$XX eight\n"; stage; }
 fx_prose() { repo prose; put a.rs "The $TD marker is banned in this repo.\n"; stage; }
 fx_backticks() { repo backticks; put a.md "the \`$TD:\` shape and \`$FX(\` shape are banned\n"; stage; }
 fx_joined() { repo joined; put a.sh "emit \"$TD:/$FX( marker without an issue reference\"\n"; stage; }
@@ -117,7 +121,7 @@ run_rows \
   "a bare marker after a hash leader fails|fx_hash||||rc=1 $(hit a.rs 1 "# $TD implement the frobnicator");$(idx 1)" \
   "a bare marker glued to a slash leader fails|fx_glued||||rc=1 $(hit a.rs 1 "//$XX no space before the word");$(idx 1)" \
   "a semicolon and an HTML comment are leaders too|fx_leaders||||rc=1 $(hit a.rs 1 "; $TD after a semicolon");$(hit a.rs 2 "<!-- $FX after an HTML leader");$(idx 2)" \
-  "each of the four words is a marker, and every hit is numbered|fx_four||||rc=1 $(hit a.rs 1 "// $TD: one");$(hit a.rs 2 "// $FX: two");$(hit a.rs 3 "// $HK: three");$(hit a.rs 4 "// $XX: four");$(idx 4)" \
+  "each of the four words is a marker in each shape alone, and every hit is numbered|fx_four||||rc=1 $(hit a.rs 1 "$TD: one");$(hit a.rs 2 "//$TD two");$(hit a.rs 3 "$FX(x): three");$(hit a.rs 4 "//$FX four");$(hit a.rs 5 "$HK: five");$(hit a.rs 6 "/*$HK six");$(hit a.rs 7 "$XX: seven");$(hit a.rs 8 "//$XX eight");$(idx 8)" \
   "a bare word mid-prose, with no colon and no adjacent leader, passes|fx_prose||||rc=0 $OK_IDX" \
   "backtick-quoted marker shapes in a document pass|fx_backticks||||rc=0 $OK_IDX" \
   "quote- and slash-joined marker names in a string pass|fx_joined||||rc=0 $OK_IDX" \
@@ -131,6 +135,8 @@ vendored() { repo "$1"; put vendor/lib.rs "// $TD: vendored upstream marker\n"; 
 fx_vendored() { vendored vendored; }
 fx_vendored_row() { vendored vendored-row; excl 'vendor/*\tvendored third-party code\n'; }
 fx_no_reason() { vendored no-reason; excl 'vendor/*\n'; }
+fx_comment_rows() { vendored comment-rows; excl '# a note\n\nvendor/*\tvendored third-party code'; }
+fx_empty_pattern() { vendored empty-pattern; excl '\ta reason with no pattern\n'; }
 fx_alt_env() { vendored alt-env; put alt-excludes 'vendor/*\tvendored third-party code\n'; stage; }
 fx_alt_flag() { vendored alt-flag; put alt-excludes 'vendor/*\tvendored third-party code\n'; stage; }
 fx_alt_eq() { vendored alt-eq; put alt-excludes 'vendor/*\tvendored third-party code\n'; stage; }
@@ -167,6 +173,8 @@ run_rows \
   "control: the vendored marker fails without a row, and the remedy names the default list|fx_vendored||||rc=1 $(hit vendor/lib.rs 1 "// $TD: vendored upstream marker");$(idx 1)" \
   "the row silences exactly the vendored tree|fx_vendored_row||||rc=0 $OK_IDX" \
   "a row without a tab-separated reason is a config error naming the line|fx_no_reason||||rc=2 ${ERR}$EXCL:1: $NO_REASON" \
+  "a comment row and a blank row are skipped, and the last row is read without its newline|fx_comment_rows||||rc=0 $OK_IDX" \
+  "a reason with no pattern before its tab is the same config error|fx_empty_pattern||||rc=2 ${ERR}$EXCL:1: $NO_REASON" \
   "the list path resolves through the environment key, and the verdict names that list|fx_alt_env||$ALT||rc=0 $OK_IDX" \
   "--excludes names the same list|fx_alt_flag|||--excludes alt-excludes|rc=0 $OK_IDX" \
   "--excludes=PATH is the same flag|fx_alt_eq|||--excludes=alt-excludes|rc=0 $OK_IDX" \
@@ -194,6 +202,9 @@ fx_scope_adds() { scoped scope-adds; add ok.rs "// $FX: added by this commit\n";
 # second marker is numbered past the first insertion.
 fx_two_hunks() { repo two-hunks; local i; for i in 1 2 3 4 5 6 7 8 9 10; do add ten.rs "fn f$i() {}\n"; done; stage; commit; put ten.rs "fn f1() {}\nfn f2() {}\n// $TD: after two\nfn f3() {}\nfn f4() {}\nfn f5() {}\nfn f6() {}\nfn f7() {}\nfn f8() {}\n// $HK: after eight\nfn f9() {}\nfn f10() {}\n"; stage; }
 walked() { seeded "$1"; add ok.rs "// $TD: staged\n"; git -C "$R" add ok.rs; put ok.rs 'fn main() {}\n'; } # NAME — the work tree walks it back; the index still carries it
+# The index blob keeps a second marker so the path stays a carrier and the
+# parser really runs over a hunk that only removes.
+fx_removed() { seeded removed; add ok.rs "// $TD: one\n// $TD: two\n"; stage; commit two; put ok.rs "fn main() {}\n// $TD: two\n"; git -C "$R" add ok.rs; }
 fx_walked() { walked walked; }
 fx_walked_staged() { walked walked-staged; git -C "$R" add ok.rs; }
 fx_first() { repo first; put a.rs "// $TD: in the very first commit\n"; stage; }
@@ -205,8 +216,8 @@ staged_vendored() { seeded "$1"; put vendor/lib.rs "// $TD: vendored upstream ma
 fx_staged_vendored() { staged_vendored staged-vendored; }
 fx_staged_vendored_row() { staged_vendored staged-vendored-row; excl 'vendor/*\tvendored third-party code\n'; }
 # A symlink's blob is its target path and a gitlink has no blob here; the
-# pre-filter never lists either (git grep reads no symlink), so neither
-# reaches the per-file read, whatever the target spells.
+# pre-filter never lists either (git grep reads no symlink and no gitlink),
+# so the walk's mode arm is never reached and these pin the verdict alone.
 fx_staged_link() { seeded staged-link; ln -s "$TD: target" "$R/link.rs"; stage; }
 fx_staged_gitlink() { seeded staged-gitlink; git -C "$R" update-index --add --cacheinfo 160000,4b825dc642cb6eb9a060e54bf8d69288fbee4904,sub; }
 # ls-files -s lists an unmerged path once per stage; the lane refuses the
@@ -230,6 +241,7 @@ run_rows \
   "a second hunk is numbered from its own header|fx_two_hunks|||--staged|rc=1 $(hit ten.rs 3 "// $TD: after two");$(hit ten.rs 10 "// $HK: after eight");$(stg 2)" \
   "staged bytes decide, whatever the work tree says now|fx_walked|||--staged|rc=1 $(hit ok.rs 2 "// $TD: staged");$(stg 1)" \
   "control: staging the walked-back file clears it|fx_walked_staged|||--staged|rc=0 $OK_STG" \
+  "a marker the commit removes is not a line it adds|fx_removed|||--staged|rc=0 $OK_STG" \
   "with no HEAD to diff against, the whole staged tree reads as added|fx_first|||--staged|rc=1 $(hit a.rs 1 "// $TD: in the very first commit");$(stg 1)" \
   "control: a clean first commit passes rather than erroring for want of a HEAD|fx_first_clean|||--staged|rc=0 $OK_STG" \
   "a lowercase word the commit adds to a marker-carrying file is prose in this scope too|fx_staged_lower|||--staged|rc=0 $OK_STG" \
@@ -266,6 +278,10 @@ fx_attr_clean() { attributed attr-clean; commit "the marker, now committed"; add
 # NULs are text, and text is read whatever it is called.
 fx_binary() { seeded binary; put asset.png "\\0211PNG\\r\\n\\032\\n\\0000\\0000 $TD: in the pixels\\n"; git -C "$R" add asset.png; }
 fx_binary_control() { seeded binary-control; put asset.png "\\0211PNG\\r\\n\\032\\n $TD: in the pixels\\n"; git -C "$R" add asset.png; }
+# A violation and a skipped carrier in one run: the qualifier rides on the
+# violation summary too, in each lane.
+fx_binary_beside() { seeded binary-beside; put asset.png "\\0211PNG\\r\\n\\032\\n\\0000\\0000 $TD: in the pixels\\n"; add ok.rs "// $TD: beside the asset\\n"; stage; }
+fx_binary_beside_index() { seeded binary-beside-index; put asset.png "\\0211PNG\\r\\n\\032\\n\\0000\\0000 $TD: in the pixels\\n"; add ok.rs "// $TD: beside the asset\\n"; stage; }
 # git's window is 8000 bytes: a NUL past it leaves the blob text for git
 # (`diff --numstat` counts lines rather than printing '-'), so the sniff
 # must read it too, or a marker that fails the index scan passes the commit.
@@ -294,6 +310,8 @@ run_rows \
   "control: a clean addition to a marker-carrying file under the same rule passes, the committed marker out of this commit's verdict|fx_attr_clean|||--staged|rc=0 $OK_STG" \
   "a genuinely binary blob whose bytes spell a marker is named as unmeasured and carried into the verdict|fx_binary|||--staged|rc=0 todo-ban: not measured: asset.png — binary content, not text;$OK_STG; 1 matched path(s) not measured" \
   "control: the same bytes without a NUL are text, and fire|fx_binary_control|||--staged|rc=1 $(hit asset.png 3 " $TD: in the pixels");$(stg 1)" \
+  "a skipped carrier qualifies a violation verdict too|fx_binary_beside|||--staged|rc=1 todo-ban: not measured: asset.png — binary content, not text;$(hit ok.rs 2 "// $TD: beside the asset");$(stg 1); 1 matched path(s) not measured" \
+  "and the index lane's violation verdict the same way|fx_binary_beside_index||||rc=1 todo-ban: not measured: asset.png — binary content, not text;$(hit ok.rs 2 "// $TD: beside the asset");$(idx 1); 1 matched path(s) not measured" \
   "a NUL past git's 8000-byte window leaves the blob text, and it fires|fx_late_nul|||--staged|rc=1 $(hit late-nul.rs 2 "// $TD: past the 8000-byte window");$(stg 1)" \
   "a type change to a clean regular file passes: a marker shape in the path is not content|fx_type_clean|||--staged|rc=0 $OK_STG" \
   "a marker in the new regular file fires at its own line, the section header and the clean line beside it never records|fx_type_marker|||--staged|rc=1 $(hit "a $TD: x.md" 1 "// $FX: added with the regular file");$(stg 1)" \
@@ -342,6 +360,18 @@ done
 exec "$REAL_AWK" "\$@"
 EOF
 chmod +x "$TMP/awk-shim/awk"
+# The per-file grep exits 2 on purpose: 1 is "no marker in this file's
+# additions", so a 2 read as a 1 would skip the file silently.
+REAL_GREP="$(command -v grep)"
+mkdir -p "$TMP/grep-shim"
+cat >"$TMP/grep-shim/grep" <<EOF
+#!/usr/bin/env bash
+for a in "\$@"; do
+  [ "\$a" != "-aE" ] || { echo "grep: simulated scan failure" >&2; exit 2; }
+done
+exec "$REAL_GREP" "\$@"
+EOF
+chmod +x "$TMP/grep-shim/grep"
 fx_shim_clean() { seeded shim-clean; add ok.rs 'fn other() {}\n'; git -C "$R" add ok.rs; }
 fx_shim_raw() { seeded shim-raw; add ok.rs 'fn other() {}\n'; git -C "$R" add ok.rs; }
 # The per-file read and the parser are reached only for a path the
@@ -350,6 +380,7 @@ marked() { seeded "$1"; add ok.rs "// $TD: staged for the per-file read\n"; git 
 fx_shim_control() { marked shim-control; }
 fx_shim_hunk() { marked shim-hunk; }
 fx_shim_awk() { marked shim-awk; }
+fx_shim_grep() { marked shim-grep; }
 # The carriers pre-filter is chunked at 256 paths; a chunk that overwrote
 # its predecessors would drop the carrier named by a prior one and print
 # OK. This repository's render-propagation commits stage several hundred
@@ -361,11 +392,13 @@ run_rows \
   "shim-free control: the staged marker fires with the real tools|fx_shim_control|||--staged|rc=1 $(hit ok.rs 2 "// $TD: staged for the per-file read");$(stg 1)" \
   "a file whose added lines cannot be read is exit 2, naming it|fx_shim_hunk|$TMP/hunk-shim||--staged|rc=2 git diff: simulated execution failure;${ERR}could not read the staged additions in 'ok.rs' (git diff exit 128)" \
   "a hunk parser that fails is exit 2 naming the file, with no violation and no OK|fx_shim_awk|$TMP/awk-shim||--staged|rc=2 awk: simulated hunk-parser failure;${ERR}could not parse the staged additions in 'ok.rs' (awk exit 1)" \
+  "a per-file scan that fails is exit 2 naming the file, never a file skipped|fx_shim_grep|$TMP/grep-shim||--staged|rc=2 grep: simulated scan failure;${ERR}could not scan the staged additions in 'ok.rs' (grep exit 2)" \
   "a marker in the first of 300 staged paths survives every later chunk|fx_chunked|||--staged|rc=1 $(hit a000.rs 1 "// $TD: in the first chunk");$(stg 1)"
 
 echo "=== the usage is answered ==="
 repo help
 assert_eq "--help prints the usage and exits 0" "rc=0 usage: todo-ban [--staged] [--excludes FILE]" "$(run "" "" --help | cut -d';' -f1)"
+assert_eq "-h is the same flag" "$(run "" "" --help)" "$(run "" "" -h)"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.agents/skills/commit-guards/tests/todo-ban.test.sh
+++ b/.agents/skills/commit-guards/tests/todo-ban.test.sh
@@ -1,24 +1,27 @@
 #!/usr/bin/env bash
-# Pins for scripts/todo-ban: both marker shapes fire, prose that quotes or
-# names a marker word does not, excludes need reasons, --staged judges the
-# lines the commit ADDS while the default scope judges the whole index, and
-# the staged lane's change-set collection and hunk parse are collection
-# errors — never a pass. Every green assertion is paired with a control that
-# proves it can fail. The index readers this family of checks shares — the
-# staged lane's carriers pre-filter and content sniff among them — are
-# pinned once, in lane-readers.test.sh, which drives them through this check.
+# Pins for scripts/todo-ban, the flat ban on work markers: both marker
+# shapes fire and prose that quotes or names a marker word does not, an
+# exclusion row needs its reason and a `!` row carves a subtree back in,
+# --staged judges the lines the commit ADDS from the index while the default
+# scope judges the whole index, and a collection step that cannot run is a
+# collection error, never a pass. One table: a row builds its own
+# repository, stages what it means, runs the check once under its settings
+# and reads back the exit status with every line printed, so the verdict,
+# the file and line it names, the quoted line, the remedy and the summary
+# are one pin. The index readers this family shares — the carriers
+# pre-filter, the content sniff, the blob read — are pinned once in
+# lane-readers.test.sh, which drives them through this check.
 #
-# Marker words are assembled from split tokens throughout so this test
-# file never contains a marker shape itself — the kendex repo runs
+# Marker words are assembled from split tokens throughout so this file
+# never contains a marker shape itself — the kendex repository runs
 # todo-ban over its own tree, tests included.
 set -euo pipefail
-
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 TB="$SKILL_DIR/scripts/todo-ban"
+# shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
-
-# Hermetic: a leaked setting would mask every case below.
+# Hermetic: a leaked setting would mask every row below.
 unset COMMIT_GUARDS_TODO_EXCLUDES COMMIT_GUARDS_SETTINGS_FILE 2>/dev/null || true
 
 TD="TO""DO"
@@ -28,524 +31,281 @@ XX="XX""X"
 
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
 
-new_repo() { # NAME — fresh fixture repo in $R
+# One line for a run in the row's repository: the exit status, then every
+# line printed, in order, joined by ';'. SHIM is a directory put ahead of
+# PATH (empty for the real tools); ENVS is a comma-separated list of
+# assignments; ARGS are passed through.
+R=""
+run() { # SHIM ENVS ARGS
+  local envs=() rc=0 out="" path="$PATH"
+  [ -z "$1" ] || path="$1:$PATH"
+  [ -z "$2" ] || IFS=',' read -ra envs <<<"$2"
+  # shellcheck disable=SC2086
+  out="$(cd "$R" && env PATH="$path" ${envs[@]+"${envs[@]}"} "$TB" $3 2>&1)" || rc=$?
+  printf 'rc=%s%s' "$rc" "${out:+ $(printf '%s\n' "$out" | LC_ALL=C paste -sd ';' -)}"
+}
+
+# Fixture vocabulary. Every fixture builds its own repository and stages
+# what it wrote; a name used twice is refused.
+repo() { # NAME
   R="$TMP/$1"
+  [ ! -e "$R" ] || { echo "harness: fixture $1 already exists" >&2; exit 2; }
   mkdir -p "$R"
   git -C "$R" -c init.defaultBranch=main init -q
   git -C "$R" config user.email test@example.com
   git -C "$R" config user.name test
 }
+put() { mkdir -p "$R/$(dirname "$1")"; printf '%b' "$2" >"$R/$1"; } # PATH CONTENT (printf %b)
+add() { mkdir -p "$R/$(dirname "$1")"; printf '%b' "$2" >>"$R/$1"; } # PATH CONTENT, appended
+stage() { git -C "$R" add -A; }
+commit() { git -C "$R" commit -qm "${1:-seed}"; } # [MESSAGE]
+seeded() { repo "$1"; put ok.rs 'fn main() {}\n'; stage; commit; } # NAME — one committed clean file
+excl() { put tools/todo-ban-excludes "$1"; stage; } # ROWS — the exclusion list, staged
 
-run_tb() { # [args...] — run in $R; sets OUT and RC
-  OUT=""
-  RC=0
-  OUT="$(cd "$R" && "$TB" "$@" 2>&1)" || RC=$?
+# The lines the check prints, as functions of what a row put in.
+EXCL=tools/todo-ban-excludes
+remedy() { printf '  remedies: do the work now, or move it to the tracker and delete the marker; vendored/generated trees belong in %s with a reason' "${1:-$EXCL}"; } # [EXCLUDES]
+hit() { printf 'todo-ban FAIL work marker: %s:%s:%s;%s' "$1" "$2" "$3" "$(remedy "${4:-}")"; } # PATH LINE CONTENT [EXCLUDES]
+idx() { printf 'todo-ban: %s work marker(s) — excludes %s' "$1" "${2:-$EXCL}"; } # COUNT [EXCLUDES]
+stg() { printf 'todo-ban: %s work marker(s) added by the staged diff — excludes %s' "$1" "${2:-$EXCL}"; } # COUNT [EXCLUDES]
+OK_IDX="todo-ban: OK — no work markers in tracked files"
+OK_STG="todo-ban: OK — the staged diff adds no work markers"
+ERR="::error::todo-ban: "
+NO_REASON="expected 'pattern<TAB>reason' (every exclusion carries its justification)"
+
+run_rows() { # label | fixture | shim | env | args | expect
+  local row label fx shim env args expect
+  for row in "$@"; do
+    IFS='|' read -r label fx shim env args expect <<<"$row"
+    R=""
+    "$fx"
+    assert_eq "$label" "$expect" "$(run "$shim" "$env" "$args")"
+  done
 }
 
-echo "=== control: a clean repo passes ==="
-new_repo clean
-printf 'fn main() {}\n' >"$R/ok.rs"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 0 ] && case "$OUT" in *"todo-ban: OK"*) true ;; *) false ;; esac \
-  && ok "clean repo passes" || bad "clean repo passes" "rc=$RC out=$OUT"
+echo "=== both marker shapes fire, and prose that quotes or names a marker word does not ==="
+fx_clean() { repo clean; put ok.rs 'fn main() {}\n'; stage; }
+fx_colon() { repo colon; put a.rs "// $TD: wire this up\n"; stage; }
+fx_paren() { repo paren; put a.rs "$FX(alice): assigned marker\n"; stage; }
+fx_block() { repo block; put a.rs "code(); /* $HK: inline block */\n"; stage; }
+fx_hash() { repo hash; put a.rs "# $TD implement the frobnicator\n"; stage; }
+fx_glued() { repo glued; put a.rs "//$XX no space before the word\n"; stage; }
+fx_leaders() { repo leaders; put a.rs "; $TD after a semicolon\n<!-- $FX after an HTML leader\n"; stage; }
+fx_four() { repo four; put a.rs "// $TD: one\n// $FX: two\n// $HK: three\n// $XX: four\n"; stage; }
+fx_prose() { repo prose; put a.rs "The $TD marker is banned in this repo.\n"; stage; }
+fx_backticks() { repo backticks; put a.md "the \`$TD:\` shape and \`$FX(\` shape are banned\n"; stage; }
+fx_joined() { repo joined; put a.sh "emit \"$TD:/$FX( marker without an issue reference\"\n"; stage; }
+fx_escaped() { repo escaped; put a.sh "printf \"then\\\\n$TD: inside a literal\"\n"; stage; }
+fx_lower() { repo lower; put a.rs '// todo: lowercase is prose, not a marker\n'; stage; }
+fx_url() { repo url; put u.md "see http://$TD:8080/path for the mock\n"; stage; }
+fx_url_control() { repo url-control; put u.md "see http://$TD:8080/path for the mock\nleft in: $TD: cleanup\n"; stage; }
+run_rows \
+  "control: a clean repository passes|fx_clean||||rc=0 $OK_IDX" \
+  "a colon-annotated marker in a comment fails, naming file, line and the line itself, with the remedy|fx_colon||||rc=1 $(hit a.rs 1 "// $TD: wire this up");$(idx 1)" \
+  "an attributed marker at line start fails|fx_paren||||rc=1 $(hit a.rs 1 "$FX(alice): assigned marker");$(idx 1)" \
+  "an annotated marker inside a block comment fails|fx_block||||rc=1 $(hit a.rs 1 "code(); /* $HK: inline block */");$(idx 1)" \
+  "a bare marker after a hash leader fails|fx_hash||||rc=1 $(hit a.rs 1 "# $TD implement the frobnicator");$(idx 1)" \
+  "a bare marker glued to a slash leader fails|fx_glued||||rc=1 $(hit a.rs 1 "//$XX no space before the word");$(idx 1)" \
+  "a semicolon and an HTML comment are leaders too|fx_leaders||||rc=1 $(hit a.rs 1 "; $TD after a semicolon");$(hit a.rs 2 "<!-- $FX after an HTML leader");$(idx 2)" \
+  "each of the four words is a marker, and every hit is numbered|fx_four||||rc=1 $(hit a.rs 1 "// $TD: one");$(hit a.rs 2 "// $FX: two");$(hit a.rs 3 "// $HK: three");$(hit a.rs 4 "// $XX: four");$(idx 4)" \
+  "a bare word mid-prose, with no colon and no adjacent leader, passes|fx_prose||||rc=0 $OK_IDX" \
+  "backtick-quoted marker shapes in a document pass|fx_backticks||||rc=0 $OK_IDX" \
+  "quote- and slash-joined marker names in a string pass|fx_joined||||rc=0 $OK_IDX" \
+  "a marker joined to an escape sequence in a literal passes|fx_escaped||||rc=0 $OK_IDX" \
+  "a lowercase word is never a marker|fx_lower||||rc=0 $OK_IDX" \
+  "a marker word inside a URL authority is not after a leader|fx_url||||rc=0 $OK_IDX" \
+  "control: the same word after whitespace fires, at its own line|fx_url_control||||rc=1 $(hit u.md 2 "left in: $TD: cleanup");$(idx 1)"
 
-echo "=== shape (a): annotated markers fire ==="
-new_repo shapes
-printf '// %s: wire this up\n' "$TD" >"$R/a.rs"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: a.rs:1:"*) true ;; *) false ;; esac \
-  && ok "colon-annotated marker in a comment fails, naming file:line" \
-  || bad "colon-annotated marker fails" "rc=$RC out=$OUT"
-case "$OUT" in *"move it to the tracker and delete the marker"*) ok "diagnostic carries the remediation" ;; *) bad "diagnostic carries the remediation" "$OUT" ;; esac
-
-printf '%s(alice): assigned marker\n' "$FX" >"$R/a.rs"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 1 ] && ok "attributed marker at line start fails" || bad "attributed marker at line start fails" "rc=$RC out=$OUT"
-
-printf 'code(); /* %s: inline block */\n' "$HK" >"$R/a.rs"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 1 ] && ok "block-comment annotated marker fails" || bad "block-comment annotated marker fails" "rc=$RC out=$OUT"
-
-echo "=== shape (b): bare marker directly after a comment leader fires ==="
-printf '# %s implement the frobnicator\n' "$TD" >"$R/a.rs"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 1 ] && ok "bare marker after hash leader fails" || bad "bare marker after hash leader fails" "rc=$RC out=$OUT"
-
-printf '//%s no space before the word\n' "$XX" >"$R/a.rs"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 1 ] && ok "bare marker glued to a slash leader fails" || bad "bare marker glued to a slash leader fails" "rc=$RC out=$OUT"
-
-echo "=== prose that names or quotes a marker does not fire ==="
-printf 'The %s marker is banned in this repo.\n' "$TD" >"$R/a.rs"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 0 ] && ok "bare word mid-prose (no colon, no adjacent leader) passes" \
-  || bad "bare word mid-prose passes" "rc=$RC out=$OUT"
-
-printf 'the `%s:` shape and `%s(` shape are banned\n' "$TD" "$FX" >"$R/a.md"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 0 ] && ok "backtick-quoted marker shapes in docs pass" \
-  || bad "backtick-quoted marker shapes pass" "rc=$RC out=$OUT"
-
-printf 'emit "%s:/%s( marker without an issue reference"\n' "$TD" "$FX" >"$R/a.sh"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 0 ] && ok "quote- and slash-joined marker names in a string pass" \
-  || bad "joined marker names in a string pass" "rc=$RC out=$OUT"
-
-printf 'printf "then\\n%s: inside a literal"\n' "$TD" >"$R/a.sh"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 0 ] && ok "marker joined to an escape sequence in a literal passes" \
-  || bad "escape-joined marker passes" "rc=$RC out=$OUT"
-
-printf '// %s: lowercase is prose, not a marker\n' "todo" >"$R/a.rs"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 0 ] && ok "lowercase word is never a marker (case-sensitive match)" \
-  || bad "lowercase word passes" "rc=$RC out=$OUT"
-
-echo "=== excludes: vendored trees are excluded WITH a reason ==="
-new_repo exc
-mkdir -p "$R/vendor" "$R/tools"
-printf '// %s: vendored upstream marker\n' "$TD" >"$R/vendor/lib.rs"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 1 ] && ok "control: the vendored marker fails without an excludes row" \
-  || bad "control: vendored marker fails without excludes" "rc=$RC out=$OUT"
-
-printf 'vendor/*\tvendored third-party code\n' >"$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 0 ] && ok "the excludes row silences exactly the vendored tree" \
-  || bad "excludes row silences the vendored tree" "rc=$RC out=$OUT"
-
-printf 'vendor/*\n' >"$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 2 ] && case "$OUT" in *"pattern<TAB>reason"*) true ;; *) false ;; esac \
-  && ok "a pattern without a tab-separated reason is exit 2" \
-  || bad "a pattern without a reason is exit 2" "rc=$RC out=$OUT"
-
-echo "=== configuration: COMMIT_GUARDS_TODO_EXCLUDES and --excludes ==="
-printf 'vendor/*\tvendored third-party code\n' >"$R/alt-excludes"
-rm "$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-OUT="$(cd "$R" && COMMIT_GUARDS_TODO_EXCLUDES=alt-excludes "$TB" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && ok "excludes path resolves through the environment key" \
-  || bad "excludes path resolves through the environment key" "rc=$RC out=$OUT"
-run_tb --excludes alt-excludes
-[ "$RC" -eq 0 ] && ok "--excludes flag points at the same list" || bad "--excludes flag" "rc=$RC out=$OUT"
-run_tb
-[ "$RC" -eq 1 ] && ok "control: without either, the vendored marker still fails" \
-  || bad "control: default excludes path has no file, marker fails" "rc=$RC out=$OUT"
-
-run_tb --no-such-flag
-[ "$RC" -eq 2 ] && ok "unknown flag is exit 2" || bad "unknown flag is exit 2" "rc=$RC out=$OUT"
-
+echo "=== an exclusion row silences exactly what it names, with a reason; a ! row carves a subtree back in ==="
+vendored() { repo "$1"; put vendor/lib.rs "// $TD: vendored upstream marker\n"; stage; } # NAME
+fx_vendored() { vendored vendored; }
+fx_vendored_row() { vendored vendored-row; excl 'vendor/*\tvendored third-party code\n'; }
+fx_no_reason() { vendored no-reason; excl 'vendor/*\n'; }
+fx_alt_env() { vendored alt-env; put alt-excludes 'vendor/*\tvendored third-party code\n'; stage; }
+fx_alt_flag() { vendored alt-flag; put alt-excludes 'vendor/*\tvendored third-party code\n'; stage; }
+fx_alt_eq() { vendored alt-eq; put alt-excludes 'vendor/*\tvendored third-party code\n'; stage; }
+fx_alt_none() { vendored alt-none; put alt-excludes 'vendor/*\tvendored third-party code\n'; stage; }
+fx_flag_bare() { vendored flag-bare; }
+fx_unknown() { vendored unknown; }
 # A row is a shell glob against the whole path, so every `*` in it crosses
-# `/`. A reader who writes `**/name/**` meaning "that vendored tree wherever
-# it is rendered" gets "any directory called name, at any depth" — and the
-# first-party one goes quiet with it, which is the one thing this file's own
-# header forbids.
-echo "=== excludes: a row anchored at a root does not exempt that name elsewhere ==="
-new_repo cross
-mkdir -p "$R/vendor/thing" "$R/crates/thing/src" "$R/tools"
-printf '// %s: vendored upstream marker\n' "$TD" >"$R/vendor/thing/lib.rs"
-printf '// %s: our own marker\n' "$TD" >"$R/crates/thing/src/lib.rs"
-printf 'vendor/thing/**\tvendored third-party code\n' >"$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 1 ] && case "$OUT" in
-  *"crates/thing/src/lib.rs"*) ok "the first-party tree of the same name still fails" ;;
-  *) bad "the anchored row exempted the wrong tree" "rc=$RC out=$OUT" ;;
-esac || bad "the first-party marker was silenced" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"vendor/thing/lib.rs"*) bad "the anchored row did not silence its own tree" "out=$OUT" ;;
-  *) ok "and the vendored tree it names is silent" ;;
-esac
+# `/`: a row anchored at a root does not exempt that name elsewhere, and the
+# crossing shorthand silences the first-party tree of the same name too.
+crossing() { repo "$1"; put vendor/thing/lib.rs "// $TD: vendored upstream marker\n"; put crates/thing/src/lib.rs "// $TD: our own marker\n"; stage; } # NAME
+fx_anchored() { crossing anchored; excl 'vendor/thing/**\tvendored third-party code\n'; }
+fx_shorthand() { crossing shorthand; excl '**/thing/**\tthe shorthand that crosses\n'; }
+# A rendered install can only be named by a tree wildcard, so hand-written
+# source inside it (a skill declared in-place) is carved back by a ! row,
+# above or below the row it cuts into: a list is a set of rules.
+carved() { repo "$1"; put .agents/skills/rendered/lib.rs "// $TD: a marker in the render\n"; put .agents/skills/in-place/lib.rs "// $TD: a marker in the source of record\n"; stage; } # NAME
+BLANKET='.agents/**\tkendex render, governed at its source\n'
+CARVE='!.agents/skills/in-place/**\tin-place skill: this tree IS the source\n'
+fx_blanket() { carved blanket; excl "$BLANKET"; }
+fx_carve() { carved carve; excl "$BLANKET$CARVE"; }
+fx_carve_above() { carved carve-above; excl "$CARVE$BLANKET"; }
+fx_carve_no_reason() { carved carve-no-reason; excl '.agents/**\tkendex render\n!.agents/skills/in-place/**\n'; }
+fx_carve_bare() { carved carve-bare; excl '.agents/**\tkendex render\n!\ta carve with no pattern\n'; }
+# `\!name` opens with a backslash, so it never reaches the carve arm, and
+# the matcher reads it as the literal path.
+fx_bang() { repo bang; put '!bang.rs' "// $TD: a marker under a bang-leading name\n"; excl '\\!bang.rs\tan escaped literal bang path\n'; }
+# The list is read from the index: a work-tree edit of it governs nothing
+# until staged.
+listed() { repo "$1"; put v.rs "// $TD: vendored\n"; put tools/commit-guards-todo-excludes 'v.rs\tvendored fixture\n'; stage; : >"$R/tools/commit-guards-todo-excludes"; } # NAME
+fx_list_index() { listed list-index; }
+fx_list_staged() { listed list-staged; git -C "$R" add tools/commit-guards-todo-excludes; }
+ALT=COMMIT_GUARDS_TODO_EXCLUDES=alt-excludes
+run_rows \
+  "control: the vendored marker fails without a row, and the remedy names the default list|fx_vendored||||rc=1 $(hit vendor/lib.rs 1 "// $TD: vendored upstream marker");$(idx 1)" \
+  "the row silences exactly the vendored tree|fx_vendored_row||||rc=0 $OK_IDX" \
+  "a row without a tab-separated reason is a config error naming the line|fx_no_reason||||rc=2 ${ERR}$EXCL:1: $NO_REASON" \
+  "the list path resolves through the environment key, and the verdict names that list|fx_alt_env||$ALT||rc=0 $OK_IDX" \
+  "--excludes names the same list|fx_alt_flag|||--excludes alt-excludes|rc=0 $OK_IDX" \
+  "--excludes=PATH is the same flag|fx_alt_eq|||--excludes=alt-excludes|rc=0 $OK_IDX" \
+  "control: without either, the default path has no file and the marker fails|fx_alt_none||||rc=1 $(hit vendor/lib.rs 1 "// $TD: vendored upstream marker");$(idx 1)" \
+  "--excludes with no path is a config error|fx_flag_bare|||--excludes|rc=2 ${ERR}--excludes requires a path" \
+  "an unknown argument is a config error quoting it|fx_unknown|||--no-such-flag|rc=2 ${ERR}unknown argument '--no-such-flag' (see --help)" \
+  "a row anchored at a root silences its own tree and not the first-party tree of the same name|fx_anchored||||rc=1 $(hit crates/thing/src/lib.rs 1 "// $TD: our own marker");$(idx 1)" \
+  "must-fail control: the crossing shorthand silences the first-party tree too|fx_shorthand||||rc=0 $OK_IDX" \
+  "control: the blanket row alone silences both planted markers|fx_blanket||||rc=0 $OK_IDX" \
+  "a ! row carves its subtree back into the scanned set, and the sibling render stays silent|fx_carve||||rc=1 $(hit .agents/skills/in-place/lib.rs 1 "// $TD: a marker in the source of record");$(idx 1)" \
+  "a carve above the row it cuts into carves just the same|fx_carve_above||||rc=1 $(hit .agents/skills/in-place/lib.rs 1 "// $TD: a marker in the source of record");$(idx 1)" \
+  "a carve row without a reason is the same config error as any other|fx_carve_no_reason||||rc=2 ${ERR}$EXCL:2: $NO_REASON" \
+  "a bare ! row is a config error naming its line|fx_carve_bare||||rc=2 ${ERR}$EXCL:2: '!' carves matching paths back into the scanned set and needs a pattern after it" \
+  "an escaped row excludes the literal bang path rather than carving it|fx_bang||||rc=0 $OK_IDX" \
+  "the staged list governs though the work-tree copy dropped the row|fx_list_index||COMMIT_GUARDS_TODO_EXCLUDES=tools/commit-guards-todo-excludes||rc=0 $OK_IDX" \
+  "control: staging the emptied list re-exposes the marker|fx_list_staged||COMMIT_GUARDS_TODO_EXCLUDES=tools/commit-guards-todo-excludes||rc=1 $(hit v.rs 1 "// $TD: vendored" tools/commit-guards-todo-excludes);$(idx 1 tools/commit-guards-todo-excludes)"
 
-# The control: the crossing shorthand does silence both, which is why a row
-# is written out per root rather than spelled `**/thing/**`.
-printf '**/thing/**\tthe shorthand that crosses\n' >"$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 0 ] \
-  && ok "must-fail control: the crossing shorthand silences the first-party tree too" \
-  || bad "the crossing shorthand did not cross" "rc=$RC out=$OUT"
-
-# The one exclusion row that ADDS coverage. A rendered install can only be
-# named by a tree wildcard, so a repo keeping hand-written source inside that
-# tree — a skill declared `source = "in-place"` — has no other way to say so,
-# and the coverage goes silently absent: the fail-open direction for a gate.
-echo "=== excludes: a ! row carves a subtree back into the scanned set ==="
-new_repo carve
-mkdir -p "$R/.agents/skills/rendered" "$R/.agents/skills/in-place" "$R/tools"
-printf '// %s: a marker in the render\n' "$TD" >"$R/.agents/skills/rendered/lib.rs"
-printf '// %s: a marker in the source of record\n' "$TD" >"$R/.agents/skills/in-place/lib.rs"
-printf '.agents/**\tkendex render, governed at its source\n' >"$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-
-# Control: the blanket row alone silences BOTH planted markers.
-run_tb
-[ "$RC" -eq 0 ] && ok "control: the blanket .agents/** row silences both planted markers" \
-  || bad "control: the blanket .agents/** row silences both markers" "rc=$RC out=$OUT"
-
-printf '.agents/**\tkendex render, governed at its source\n!.agents/skills/in-place/**\tin-place skill: this tree IS the source\n' >"$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 1 ] && case "$OUT" in *".agents/skills/in-place/lib.rs:1:"*) true ;; *) false ;; esac \
-  && ok "the carved tree is scanned again and its planted marker fires" \
-  || bad "the carved tree is scanned again" "rc=$RC out=$OUT"
-case "$OUT" in
-  *".agents/skills/rendered/lib.rs"*) bad "the carve must not widen past its own pattern" "$OUT" ;;
-  *) ok "the sibling render under the same blanket row stays silent" ;;
-esac
-
-# Order is not policy: the carve wins whether it precedes or follows the row
-# it cuts into, so a list reads as a set of rules rather than as a sequence.
-printf '!.agents/skills/in-place/**\tin-place skill: this tree IS the source\n.agents/**\tkendex render, governed at its source\n' >"$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 1 ] && case "$OUT" in *".agents/skills/in-place/lib.rs:1:"*) true ;; *) false ;; esac \
-  && ok "a carve above the row it cuts into carves just the same" \
-  || bad "a carve above the row it cuts into carves just the same" "rc=$RC out=$OUT"
-
-# A carve still needs its reason, like every other row, and a bare '!' names
-# nothing — keeping it silently would widen the scanned set by a typo.
-printf '.agents/**\tkendex render\n!.agents/skills/in-place/**\n' >"$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 2 ] && case "$OUT" in *":2: expected 'pattern<TAB>reason'"*) true ;; *) false ;; esac \
-  && ok "a carve row without a reason is the same config error as any other" \
-  || bad "a carve row without a reason is a config error" "rc=$RC out=$OUT"
-printf '.agents/**\tkendex render\n!\ta carve with no pattern\n' >"$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 2 ] && case "$OUT" in *":2: '!' carves"*) true ;; *) false ;; esac \
-  && ok "a bare ! row is a config error naming its line" \
-  || bad "a bare ! row is a config error naming its line" "rc=$RC out=$OUT"
-
-# `!` is escapable, which is the only way left to name a path that literally
-# begins with one: `\!name` opens with a backslash, so it never reaches the
-# carve arm, and the case matcher reads it as that literal path.
-new_repo bang
-mkdir -p "$R/tools"
-printf '// %s: a marker under a bang-leading name\n' "$TD" >"$R/!bang.rs"
-printf '\\!bang.rs\tan escaped literal bang path\n' >"$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 0 ] && ok "an escaped row excludes the literal bang path rather than carving it" \
-  || bad "an escaped row excludes the literal bang path" "rc=$RC out=$OUT"
-
-echo "=== a URL is not a comment leader ==="
-new_repo url
-printf 'see http://%s:8080/path for the mock\n' "$TD" >"$R/u.md"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 0 ] && ok "a marker word inside a URL authority does not fire" \
-  || bad "a marker word inside a URL authority does not fire" "rc=$RC out=$OUT"
-# Control: the same word after real whitespace still fires.
-printf 'left in: %s: cleanup\n' "$TD" >>"$R/u.md"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 1 ] && ok "control: the same marker after whitespace fires" \
-  || bad "control: the same marker after whitespace fires" "rc=$RC out=$OUT"
-
-echo "=== the exclusion list is read from the index ==="
-new_repo stagedx
-printf '// %s: vendored\n' "$TD" >"$R/v.rs"
-mkdir -p "$R/tools"
-printf 'v.rs\tvendored fixture\n' >"$R/tools/commit-guards-todo-excludes"
-git -C "$R" add -A
-# Worktree copy now DROPS the exclusion; the staged copy must still govern.
-: >"$R/tools/commit-guards-todo-excludes"
-OUT="$(cd "$R" && COMMIT_GUARDS_TODO_EXCLUDES=tools/commit-guards-todo-excludes "$TB" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && ok "staged exclusion list governs a staged scan" \
-  || bad "staged exclusion list governs a staged scan" "rc=$RC out=$OUT"
-# Control: staging the emptied list re-exposes the marker.
-git -C "$R" add tools/commit-guards-todo-excludes
-OUT="$(cd "$R" && COMMIT_GUARDS_TODO_EXCLUDES=tools/commit-guards-todo-excludes "$TB" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 1 ] && ok "control: staging the emptied list re-exposes the marker" \
-  || bad "control: staging the emptied list re-exposes the marker" "rc=$RC out=$OUT"
-
-echo "=== --staged judges the lines the commit adds, not the whole index ==="
-new_repo stagedscope
-printf 'fn main() {}\n' >"$R/ok.rs"
-git -C "$R" add -A
-git -C "$R" commit -qm seed
+echo "=== --staged judges the lines the commit adds, read from the index, not the whole tree ==="
 # Someone else's marker, committed and untouched by the commit under judgement.
-printf '// %s: left in a fixture\n' "$TD" >"$R/fixture.rs"
-git -C "$R" add -A
-git -C "$R" commit -qm fixture
-printf 'fn other() {}\n' >>"$R/ok.rs"
-git -C "$R" add ok.rs
-run_tb --staged
-[ "$RC" -eq 0 ] && case "$OUT" in *"the staged diff adds no work markers"*) true ;; *) false ;; esac \
-  && ok "a commit that adds no marker passes on a repo whose index holds one" \
-  || bad "a commit adding no marker passes" "rc=$RC out=$OUT"
-run_tb
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: fixture.rs:1:"*) true ;; *) false ;; esac \
-  && ok "control: the index scan (CI) still refuses that same marker" \
-  || bad "control: the index scan refuses the marker" "rc=$RC out=$OUT"
+scoped() { seeded "$1"; put fixture.rs "// $TD: left in a fixture\n"; stage; commit fixture; add ok.rs 'fn other() {}\n'; git -C "$R" add ok.rs; } # NAME
+fx_scope() { scoped scope; }
+fx_scope_index() { scoped scope-index; }
+fx_scope_adds() { scoped scope-adds; add ok.rs "// $FX: added by this commit\n"; git -C "$R" add ok.rs; }
+# Two hunks in one file: the line numbers come from each hunk header, so the
+# second marker is numbered past the first insertion.
+fx_two_hunks() { repo two-hunks; local i; for i in 1 2 3 4 5 6 7 8 9 10; do add ten.rs "fn f$i() {}\n"; done; stage; commit; put ten.rs "fn f1() {}\nfn f2() {}\n// $TD: after two\nfn f3() {}\nfn f4() {}\nfn f5() {}\nfn f6() {}\nfn f7() {}\nfn f8() {}\n// $HK: after eight\nfn f9() {}\nfn f10() {}\n"; stage; }
+walked() { seeded "$1"; add ok.rs "// $TD: staged\n"; git -C "$R" add ok.rs; put ok.rs 'fn main() {}\n'; } # NAME — the work tree walks it back; the index still carries it
+fx_walked() { walked walked; }
+fx_walked_staged() { walked walked-staged; git -C "$R" add ok.rs; }
+fx_first() { repo first; put a.rs "// $TD: in the very first commit\n"; stage; }
+# The blob carries a committed marker, so the pre-filter lists the path and
+# the per-file scan really runs over the one lowercase line this commit adds.
+fx_staged_lower() { seeded staged-lower; add ok.rs "// $TD: committed\n"; stage; commit marker; add ok.rs '// todo: lowercase is prose here too\n'; git -C "$R" add ok.rs; }
+fx_first_clean() { repo first-clean; put a.rs 'fn main() {}\n'; stage; }
+staged_vendored() { seeded "$1"; put vendor/lib.rs "// $TD: vendored upstream marker\n"; stage; } # NAME
+fx_staged_vendored() { staged_vendored staged-vendored; }
+fx_staged_vendored_row() { staged_vendored staged-vendored-row; excl 'vendor/*\tvendored third-party code\n'; }
+# A symlink's blob is its target path and a gitlink has no blob here; the
+# pre-filter never lists either (git grep reads no symlink), so neither
+# reaches the per-file read, whatever the target spells.
+fx_staged_link() { seeded staged-link; ln -s "$TD: target" "$R/link.rs"; stage; }
+fx_staged_gitlink() { seeded staged-gitlink; git -C "$R" update-index --add --cacheinfo 160000,4b825dc642cb6eb9a060e54bf8d69288fbee4904,sub; }
+# ls-files -s lists an unmerged path once per stage; the lane refuses the
+# index before reading anything.
+fx_unmerged() {
+  seeded unmerged
+  git -C "$R" checkout -qb other
+  put ok.rs 'fn theirs() {}\n'
+  stage
+  commit theirs
+  git -C "$R" checkout -q main
+  put ok.rs 'fn ours() {}\n'
+  stage
+  commit ours
+  git -C "$R" merge -q other >/dev/null 2>&1 || true
+}
+run_rows \
+  "a commit adding no marker passes on a repository whose index holds one|fx_scope|||--staged|rc=0 $OK_STG" \
+  "control: the index scan still refuses that same marker|fx_scope_index||||rc=1 $(hit fixture.rs 1 "// $TD: left in a fixture");$(idx 1)" \
+  "a marker the staged diff adds is refused at the line it lands on, and the untouched fixture stays out of the verdict|fx_scope_adds|||--staged|rc=1 $(hit ok.rs 3 "// $FX: added by this commit");$(stg 1)" \
+  "a second hunk is numbered from its own header|fx_two_hunks|||--staged|rc=1 $(hit ten.rs 3 "// $TD: after two");$(hit ten.rs 10 "// $HK: after eight");$(stg 2)" \
+  "staged bytes decide, whatever the work tree says now|fx_walked|||--staged|rc=1 $(hit ok.rs 2 "// $TD: staged");$(stg 1)" \
+  "control: staging the walked-back file clears it|fx_walked_staged|||--staged|rc=0 $OK_STG" \
+  "with no HEAD to diff against, the whole staged tree reads as added|fx_first|||--staged|rc=1 $(hit a.rs 1 "// $TD: in the very first commit");$(stg 1)" \
+  "control: a clean first commit passes rather than erroring for want of a HEAD|fx_first_clean|||--staged|rc=0 $OK_STG" \
+  "a lowercase word the commit adds to a marker-carrying file is prose in this scope too|fx_staged_lower|||--staged|rc=0 $OK_STG" \
+  "control: a staged vendored marker fails without a row|fx_staged_vendored|||--staged|rc=1 $(hit vendor/lib.rs 1 "// $TD: vendored upstream marker");$(stg 1)" \
+  "the row silences the staged vendored tree too|fx_staged_vendored_row|||--staged|rc=0 $OK_STG" \
+  "a staged symlink whose target spells a marker has no lines to read|fx_staged_link|||--staged|rc=0 $OK_STG" \
+  "a staged gitlink has no lines to read|fx_staged_gitlink|||--staged|rc=0 $OK_STG" \
+  "an unmerged index is refused before the walk|fx_unmerged|||--staged|rc=2 ok.rs;${ERR}the index carries 1 unmerged path(s) (listed above) and a --cached scan skips them silently — finish or abort the merge, then re-run"
 
-# The same commit, now adding a marker of its own.
-printf '// %s: added by this commit\n' "$FX" >>"$R/ok.rs"
-git -C "$R" add ok.rs
-run_tb --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: ok.rs:3:"*) true ;; *) false ;; esac \
-  && ok "a marker the staged diff adds is refused, at the line it lands on" \
-  || bad "a staged marker is refused" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"fixture.rs"*) bad "the untouched fixture must stay out of the commit-scope verdict" "$OUT" ;;
-  *) ok "and the untouched fixture is not in that verdict" ;;
-esac
+echo "=== content decides what --staged reads: never an attribute, never a name ==="
+# A committed '-diff' rule makes git call every .rs file binary, so the
+# unforced staged diff carries no hunks; the fixture proves the rule took.
+attributed() { # NAME
+  seeded "$1"
+  put .gitattributes '*.rs -diff\n'
+  stage
+  commit attrs
+  add ok.rs "// $TD: behind an attributes rule\n"
+  git -C "$R" add ok.rs
+  case "$(git -C "$R" diff --cached -- ok.rs)" in
+    *"Binary files"*) ;;
+    *) echo "harness: fixture $1: the attributes rule did not suppress the staged diff" >&2; exit 2 ;;
+  esac
+}
+fx_attr() { attributed attr; }
+# The marker committed, then a clean addition under the same rule: the
+# index blob still carries a marker, so the pre-filter lists the path and
+# the forced diff really runs, and the verdict is the one line this commit
+# adds.
+fx_attr_clean() { attributed attr-clean; commit "the marker, now committed"; add ok.rs 'fn clean() {}\n'; git -C "$R" add ok.rs; }
+# A real asset whose bytes spell a marker: the pre-filter lists it (no -I),
+# and the content sniff — a NUL in the leading bytes, git's own test — keeps
+# it out of the verdict, named as unmeasured. The same bytes without the
+# NULs are text, and text is read whatever it is called.
+fx_binary() { seeded binary; put asset.png "\\0211PNG\\r\\n\\032\\n\\0000\\0000 $TD: in the pixels\\n"; git -C "$R" add asset.png; }
+fx_binary_control() { seeded binary-control; put asset.png "\\0211PNG\\r\\n\\032\\n $TD: in the pixels\\n"; git -C "$R" add asset.png; }
+# git's window is 8000 bytes: a NUL past it leaves the blob text for git
+# (`diff --numstat` counts lines rather than printing '-'), so the sniff
+# must read it too, or a marker that fails the index scan passes the commit.
+fx_late_nul() {
+  seeded late-nul
+  { head -c 8050 /dev/zero | LC_ALL=C tr '\000' 'x'; printf '\000\n// %s: past the 8000-byte window\n' "$TD"; } >"$R/late-nul.rs"
+  git -C "$R" add late-nul.rs
+  [ "$(git -C "$R" diff --cached --numstat -- late-nul.rs | cut -f1)" = 2 ] \
+    || { echo "harness: fixture late-nul: git does not call the late-NUL blob text" >&2; exit 2; }
+}
+# A symlink-to-file change emits a deletion section and a creation section
+# for the one path, the creation header between them at the deletion
+# hunk's numbering; the path itself spells a marker shape, so a header read
+# as content fires.
+typechanged() { seeded "$1"; ln -s ok.rs "$R/a $TD: x.md"; stage; commit; rm -- "$R/a $TD: x.md"; put "a $TD: x.md" "$2"; stage; } # NAME CONTENT
+fx_type_clean() { typechanged type-clean 'fn clean() {}\n'; }
+fx_type_marker() { typechanged type-marker "// $FX: added with the regular file\nfn clean() {}\n"; }
+# Rename detection held to EXACT content: a file that moved AND changed
+# arrives as an addition and is read whole; a pure move adds no line.
+fx_moved() { repo moved; local i=1; while [ "$i" -le 40 ]; do add old.rs "fn f$i() {}\n"; i=$((i + 1)); done; stage; commit; git -C "$R" mv old.rs new.rs; add new.rs "// $TD: added in the move\n"; git -C "$R" add new.rs; }
+pure_move() { repo "$1"; put legacy.rs "// $TD: committed long ago\n"; stage; commit; git -C "$R" mv legacy.rs moved.rs; } # NAME
+fx_pure_move() { pure_move pure-move; }
+fx_pure_move_index() { pure_move pure-move-index; }
+run_rows \
+  "a marker added under a non-diffable path is refused, at its own line|fx_attr|||--staged|rc=1 $(hit ok.rs 2 "// $TD: behind an attributes rule");$(stg 1)" \
+  "control: a clean addition to a marker-carrying file under the same rule passes, the committed marker out of this commit's verdict|fx_attr_clean|||--staged|rc=0 $OK_STG" \
+  "a genuinely binary blob whose bytes spell a marker is named as unmeasured and carried into the verdict|fx_binary|||--staged|rc=0 todo-ban: not measured: asset.png — binary content, not text;$OK_STG; 1 matched path(s) not measured" \
+  "control: the same bytes without a NUL are text, and fire|fx_binary_control|||--staged|rc=1 $(hit asset.png 3 " $TD: in the pixels");$(stg 1)" \
+  "a NUL past git's 8000-byte window leaves the blob text, and it fires|fx_late_nul|||--staged|rc=1 $(hit late-nul.rs 2 "// $TD: past the 8000-byte window");$(stg 1)" \
+  "a type change to a clean regular file passes: a marker shape in the path is not content|fx_type_clean|||--staged|rc=0 $OK_STG" \
+  "a marker in the new regular file fires at its own line, the section header and the clean line beside it never records|fx_type_marker|||--staged|rc=1 $(hit "a $TD: x.md" 1 "// $FX: added with the regular file");$(stg 1)" \
+  "a file that moved and gained a marker is read whole, at its new path|fx_moved|||--staged|rc=1 $(hit new.rs 41 "// $TD: added in the move");$(stg 1)" \
+  "a pure move of a committed marker adds no line, so it passes|fx_pure_move|||--staged|rc=0 $OK_STG" \
+  "control: the index scan still refuses that marker at its new path|fx_pure_move_index||||rc=1 $(hit moved.rs 1 "// $TD: committed long ago");$(idx 1)"
 
-echo "=== --staged reads the index, not the work tree ==="
-new_repo stagedbytes
-printf 'fn main() {}\n' >"$R/ok.rs"
-git -C "$R" add -A
-git -C "$R" commit -qm seed
-printf '// %s: staged\n' "$TD" >>"$R/ok.rs"
-git -C "$R" add ok.rs
-printf 'fn main() {}\n' >"$R/ok.rs" # the work tree walks it back; the index still carries it
-run_tb --staged
-[ "$RC" -eq 1 ] && ok "staged bytes decide, whatever the work tree says now" \
-  || bad "staged bytes decide" "rc=$RC out=$OUT"
-# Control: staging the walked-back file clears the verdict.
-git -C "$R" add ok.rs
-run_tb --staged
-[ "$RC" -eq 0 ] && ok "control: staging the walked-back file clears it" \
-  || bad "control: staging the walked-back file clears it" "rc=$RC out=$OUT"
-
-echo "=== --staged on a repository's first commit diffs against the empty tree ==="
-new_repo firstcommit
-printf '// %s: in the very first commit\n' "$TD" >"$R/a.rs"
-git -C "$R" add -A
-run_tb --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: a.rs:1:"*) true ;; *) false ;; esac \
-  && ok "with no HEAD to diff against, the whole staged tree reads as added" \
-  || bad "the first commit is judged" "rc=$RC out=$OUT"
-# Control: the same repository with no marker staged passes rather than
-# erroring on the missing HEAD.
-printf 'fn main() {}\n' >"$R/a.rs"
-git -C "$R" add -A
-run_tb --staged
-[ "$RC" -eq 0 ] && case "$OUT" in *"the staged diff adds no work markers"*) true ;; *) false ;; esac \
-  && ok "control: a clean first commit passes, not exit 2 for want of a HEAD" \
-  || bad "control: a clean first commit passes" "rc=$RC out=$OUT"
-
-echo "=== --staged honours the exclusion list ==="
-new_repo stagedexc
-printf 'fn main() {}\n' >"$R/ok.rs"
-mkdir -p "$R/vendor" "$R/tools"
-git -C "$R" add -A
-git -C "$R" commit -qm seed
-printf '// %s: vendored upstream marker\n' "$TD" >"$R/vendor/lib.rs"
-git -C "$R" add -A
-run_tb --staged
-[ "$RC" -eq 1 ] && ok "control: the staged vendored marker fails without an excludes row" \
-  || bad "control: staged vendored marker fails" "rc=$RC out=$OUT"
-printf 'vendor/*\tvendored third-party code\n' >"$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-run_tb --staged
-[ "$RC" -eq 0 ] && ok "the excludes row silences the staged vendored tree too" \
-  || bad "excludes row silences the staged tree" "rc=$RC out=$OUT"
-
-echo "=== a .gitattributes rule cannot hide staged content from the lane ==="
-new_repo stagedattr
-printf 'fn main() {}\n' >"$R/ok.rs"
-git -C "$R" add -A
-git -C "$R" commit -qm seed
-# A committed '-diff' rule makes git call every .rs file binary: the plain
-# staged diff then carries no hunks at all, and the index scan skips the blob
-# unless both are forced to text. That is the shape a whole extension could
-# be hidden behind by committing one attributes line.
-printf '*.rs -diff\n' >"$R/.gitattributes"
-git -C "$R" add -A
-git -C "$R" commit -qm attrs
-printf '// %s: behind an attributes rule\n' "$TD" >>"$R/ok.rs"
-git -C "$R" add ok.rs
-case "$(git -C "$R" diff --cached -- ok.rs)" in
-  *"Binary files"*) ok "fixture: the rule does suppress the unforced staged diff" ;;
-  *) bad "fixture: the rule suppresses the unforced staged diff" "the attributes rule did not take" ;;
-esac
-run_tb --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: ok.rs:2:"*) true ;; *) false ;; esac \
-  && ok "a marker added under a non-diffable path is refused, at its own line" \
-  || bad "a marker under a non-diffable path is refused" "rc=$RC out=$OUT"
-
-# Control: the same rule still in force, over an addition that carries no
-# marker — forcing text reads real content, it does not fail everything it
-# forces through. Committing the marker first is what makes this arm reach
-# that read: the index blob goes on carrying a marker, so the pre-filter
-# lists the path and the --text diff really runs over it, and the verdict
-# is decided by the one line THIS commit adds.
-git -C "$R" commit -qm "the marker, now committed"
-printf 'fn clean() {}\n' >>"$R/ok.rs"
-git -C "$R" add ok.rs
-case "$(git -C "$R" diff --cached -- ok.rs)" in
-  *"Binary files"*) ok "fixture: the rule still suppresses the unforced staged diff" ;;
-  *) bad "fixture: the rule still suppresses the unforced staged diff" "the attributes rule lapsed" ;;
-esac
-run_tb --staged
-[ "$RC" -eq 0 ] && case "$OUT" in *"the staged diff adds no work markers"*) true ;; *) false ;; esac \
-  && ok "a clean addition to a marker-carrying file under the same rule passes" \
-  || bad "a clean addition under the rule passes" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"ok.rs"*) bad "the committed marker was attributed to the commit that only added a clean line" "$OUT" ;;
-  *) ok "and the marker it already carried stays out of this commit's verdict" ;;
-esac
-
-echo "=== content decides what is scanned, never an attribute ==="
-new_repo binaryblob
-printf 'fn main() {}\n' >"$R/ok.rs"
-git -C "$R" add -A
-git -C "$R" commit -qm seed
-# A real asset whose bytes happen to spell a marker. The pre-filter forces
-# every blob to text, so this path IS listed; what keeps it out of the
-# verdict is the content sniff — a NUL in the first block, git's own test —
-# and nothing about how the path is named or attributed. Without the sniff
-# the raw bytes reach awk and the commit is blocked by a garbled record.
-printf '\211PNG\r\n\032\n\000\000 %s: in the pixels\n' "$TD" >"$R/asset.png"
-git -C "$R" add asset.png
-run_tb --staged
-[ "$RC" -eq 0 ] && case "$OUT" in *"the staged diff adds no work markers"*) true ;; *) false ;; esac \
-  && ok "a genuinely binary blob whose bytes spell a marker does not fire" \
-  || bad "a binary blob does not fire" "rc=$RC out=$OUT"
-# An unread match leaves a trace and qualifies the verdict, rather than
-# riding inside a plain OK over content the lane deliberately did not read.
-case "$OUT" in
-  *"not measured: asset.png — binary content"*"1 matched path(s) not measured"*)
-    ok "the skipped carrier is named and carried into the verdict"
-    ;;
-  *) bad "the skipped carrier is named and carried into the verdict" "out=$OUT" ;;
-esac
-
-# The must-fail control: the same bytes with the NULs taken out are a text
-# file, and a text file is read whatever it is called.
-printf '\211PNG\r\n\032\n %s: in the pixels\n' "$TD" >"$R/asset.png"
-git -C "$R" add asset.png
-run_tb --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: asset.png:"*) true ;; *) false ;; esac \
-  && ok "control: the same bytes without a NUL are text, and fire" \
-  || bad "control: the NUL-free bytes fire" "rc=$RC out=$OUT"
-
-# The window is git's, 8000 bytes, and the arms above only pin it from
-# below. A NUL past 8000 leaves git calling the blob text — `git diff
-# --numstat` counts its lines rather than printing '-' — so the sniff must
-# read it too. A wider read here answers "binary", the file is skipped, and
-# a marker that fails the index scan passes the commit.
-{
-  head -c 8050 /dev/zero | LC_ALL=C tr '\000' 'x'
-  printf '\000\n// %s: past the 8000-byte window\n' "$TD"
-} >"$R/late-nul.rs"
-git -C "$R" reset -q -- asset.png
-git -C "$R" add late-nul.rs
-[ "$(git -C "$R" diff --cached --numstat -- late-nul.rs | cut -f1)" = 2 ] \
-  || bad "fixture: git does not call the late-NUL blob text" "$(git -C "$R" diff --cached --numstat -- late-nul.rs)"
-run_tb --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: late-nul.rs:2:"*) true ;; *) false ;; esac \
-  && ok "a NUL past git's 8000-byte window leaves the blob text, and it fires" \
-  || bad "a late NUL leaves the blob text" "rc=$RC out=$OUT"
-
-echo "=== a type change emits two diff sections, neither header an added line ==="
-new_repo typechange
-printf 'fn main() {}\n' >"$R/ok.rs"
-# The path itself carries a marker shape, so a '+++ b/<path>' header read as
-# content fires. A symlink-to-file change emits a deletion section and a
-# creation section for the one path, and the creation section's header sits
-# between them at the deletion hunk's numbering.
-ln -s ok.rs "$R/a $TD: x.md"
-git -C "$R" add -A
-git -C "$R" commit -qm seed
-rm -- "$R/a $TD: x.md"
-printf 'fn clean() {}\n' >"$R/a $TD: x.md"
-git -C "$R" add -A
-run_tb --staged
-# The pre-filter matches CONTENT, never path names, so a clean file at a
-# path shaped like a marker is never listed and the run ends before the
-# parser. That is the whole of what this arm pins; the parser is the pair
-# below.
-[ "$RC" -eq 0 ] \
-  && ok "a type change to a clean regular file passes: a marker shape in the PATH is not content" \
-  || bad "a clean type change passes" "rc=$RC out=$OUT"
-
-# The same type change, its new regular file carrying a marker on one line
-# and clean content on the next. This is the arm that reaches the parser:
-# the path is listed, both diff sections are read, and only the line the
-# file actually carries may be named — not the creation section's header,
-# and not the clean line beside it.
-printf '// %s: added with the regular file\nfn clean() {}\n' "$FX" >"$R/a $TD: x.md"
-git -C "$R" add -A
-run_tb --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"x.md:1:"*) true ;; *) false ;; esac \
-  && ok "a marker in the new regular file fires at its own line" \
-  || bad "the marker in the new regular file fires" "rc=$RC out=$OUT"
-case "$OUT" in *":0:"*) bad "the creation section's header rode along as line 0" "$OUT" ;; *) ok "and the section header is not a record" ;; esac
-case "$OUT" in *"x.md:2:"*) bad "the clean line beside the marker was judged a marker" "$OUT" ;; *) ok "and the clean line beside it is judged on its own" ;; esac
-
-echo "=== rename detection is held to EXACT content ==="
-new_repo renamed
-i=1
-: >"$R/old.rs"
-while [ "$i" -le 40 ]; do
-  printf 'fn f%s() {}\n' "$i" >>"$R/old.rs"
-  i=$((i + 1))
-done
-git -C "$R" add -A
-git -C "$R" commit -qm seed
-# Moved AND edited: at 100% it does not pair, so it arrives as an addition
-# and is read whole. At any lower threshold it pairs as R, is dropped by
-# --diff-filter=AMT, and the marker below is never judged.
-git -C "$R" mv old.rs new.rs
-printf '// %s: added in the move\n' "$TD" >>"$R/new.rs"
-git -C "$R" add new.rs
-run_tb --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: new.rs:41:"*) true ;; *) false ;; esac \
-  && ok "a file that moved and gained a marker is read whole, at its new path" \
-  || bad "a moved-and-edited file is read whole" "rc=$RC out=$OUT"
-
-# The counterpart the same threshold buys: a pure move adds no line, so a
-# marker someone else committed does not become this commit's.
-new_repo renamepure
-printf '// %s: committed long ago\n' "$TD" >"$R/legacy.rs"
-git -C "$R" add -A
-git -C "$R" commit -qm seed
-git -C "$R" mv legacy.rs moved.rs
-run_tb --staged
-[ "$RC" -eq 0 ] && ok "a pure move of a committed marker adds no line, so it passes" \
-  || bad "a pure move passes" "rc=$RC out=$OUT"
-run_tb
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: moved.rs:1:"*) true ;; *) false ;; esac \
-  && ok "control: the index scan still refuses that marker at its new path" \
-  || bad "control: the index scan refuses the moved marker" "rc=$RC out=$OUT"
-
-echo "=== fail-closed: a broken staged scan terminates, never passes ==="
-new_repo stagedfail
-printf 'fn main() {}\n' >"$R/ok.rs"
-git -C "$R" add -A
-git -C "$R" commit -qm seed
-printf 'fn other() {}\n' >>"$R/ok.rs"
-git -C "$R" add ok.rs
-run_tb --staged
-[ "$RC" -eq 0 ] && ok "shim-free control: the fixture passes with the real git" \
-  || bad "shim-free control passes" "rc=$RC out=$OUT"
-
-# One shim per collection step, so each error path is proven on its own: the
-# change-set collection, then the per-file read of the added lines.
+echo "=== fail-closed: a collection step that cannot run is exit 2, never a pass and never a violation ==="
+# One shim per collection step, so each error path is proven on its own.
 REAL_GIT="$(command -v git)"
-make_diff_shim() { # DIR MATCH — a git whose `diff` fails when MATCH is in argv
+REAL_AWK="$(command -v awk)"
+diff_shim() { # DIR MATCH — a git whose `diff` fails when MATCH is in argv
   mkdir -p "$1"
   cat >"$1/git" <<EOF
 #!/usr/bin/env bash
@@ -563,43 +323,13 @@ exec "$REAL_GIT" "\$@"
 EOF
   chmod +x "$1/git"
 }
-
-make_diff_shim "$TMP/raw-shim" --raw
-OUT="$(cd "$R" && PATH="$TMP/raw-shim:$PATH" "$TB" --staged 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"could not collect the staged changes"*) true ;; *) false ;; esac \
-  && ok "a failed change-set collection is exit 2, never OK" \
-  || bad "failed change-set collection is exit 2" "rc=$RC out=$OUT"
-case "$OUT" in *"todo-ban: OK"*) bad "no OK verdict may accompany a broken collection" "$OUT" ;; *) ok "no OK verdict accompanies the broken collection" ;; esac
-
-# The per-file read is reached only for a path the index scan named, so this
-# case stages a marker to give the shim a file to fail on.
-printf '// %s: staged for the per-file read\n' "$TD" >>"$R/ok.rs"
-git -C "$R" add ok.rs
-make_diff_shim "$TMP/hunk-shim" -U0
-OUT="$(cd "$R" && PATH="$TMP/hunk-shim:$PATH" "$TB" --staged 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"could not read the staged additions in 'ok.rs'"*) true ;; *) false ;; esac \
-  && ok "a file whose added lines cannot be read is exit 2, naming it" \
-  || bad "unreadable added lines are exit 2" "rc=$RC out=$OUT"
-case "$OUT" in *"todo-ban: OK"*) bad "no OK verdict may accompany an unread file" "$OUT" ;; *) ok "no OK verdict accompanies the unread file" ;; esac
-
-echo "=== fail-closed: a hunk parser that cannot run is a collection error ==="
-new_repo hunkparse
-printf 'fn main() {}\n' >"$R/ok.rs"
-git -C "$R" add -A
-git -C "$R" commit -qm seed
-printf '// %s: staged for the parser to read\n' "$TD" >>"$R/ok.rs"
-git -C "$R" add ok.rs
-run_tb --staged
-[ "$RC" -eq 1 ] && ok "shim-free control: the staged marker fires with the real awk" \
-  || bad "shim-free control fires" "rc=$RC out=$OUT"
-
-# The shim exits 1 on purpose: 1 is this family's "violations", so a parser
-# status read as the lane's own would fold a measurement that never ran into
-# a violation verdict, with no line saying so.
-REAL_AWK="$(command -v awk)"
-AWK_SHIM="$TMP/awk-shim"
-mkdir -p "$AWK_SHIM"
-cat >"$AWK_SHIM/awk" <<EOF
+diff_shim "$TMP/raw-shim" --raw
+diff_shim "$TMP/hunk-shim" -U0
+# The awk shim exits 1 on purpose: 1 is this family's "violations", so a
+# parser status read as the lane's own would fold a measurement that never
+# ran into a violation verdict.
+mkdir -p "$TMP/awk-shim"
+cat >"$TMP/awk-shim/awk" <<EOF
 #!/usr/bin/env bash
 for a in "\$@"; do
   case "\$a" in
@@ -611,36 +341,31 @@ for a in "\$@"; do
 done
 exec "$REAL_AWK" "\$@"
 EOF
-chmod +x "$AWK_SHIM/awk"
-OUT="$(cd "$R" && PATH="$AWK_SHIM:$PATH" "$TB" --staged 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"could not parse the staged additions in 'ok.rs'"*) true ;; *) false ;; esac \
-  && ok "a hunk parser that fails is exit 2, naming the file" \
-  || bad "a failed hunk parser is exit 2" "rc=$RC out=$OUT"
-case "$OUT" in *"work marker:"*) bad "a scan that never ran may not produce a violation" "$OUT" ;; *) ok "and no violation verdict comes with it" ;; esac
-case "$OUT" in *"todo-ban: OK"*) bad "no OK verdict may accompany a broken parse" "$OUT" ;; *) ok "no OK verdict accompanies the broken parse" ;; esac
+chmod +x "$TMP/awk-shim/awk"
+fx_shim_clean() { seeded shim-clean; add ok.rs 'fn other() {}\n'; git -C "$R" add ok.rs; }
+fx_shim_raw() { seeded shim-raw; add ok.rs 'fn other() {}\n'; git -C "$R" add ok.rs; }
+# The per-file read and the parser are reached only for a path the
+# pre-filter named, so these stage a marker to give the shim a file to fail on.
+marked() { seeded "$1"; add ok.rs "// $TD: staged for the per-file read\n"; git -C "$R" add ok.rs; } # NAME
+fx_shim_control() { marked shim-control; }
+fx_shim_hunk() { marked shim-hunk; }
+fx_shim_awk() { marked shim-awk; }
+# The carriers pre-filter is chunked at 256 paths; a chunk that overwrote
+# its predecessors would drop the carrier named by a prior one and print
+# OK. This repository's render-propagation commits stage several hundred
+# files at a time.
+fx_chunked() { seeded chunked; put a000.rs "// $TD: in the first chunk\n"; local i=1; while [ "$i" -lt 300 ]; do put "$(printf 'a%03d' "$i").rs" "fn f$i() {}\n"; i=$((i + 1)); done; stage; }
+run_rows \
+  "shim-free control: the clean fixture passes with the real git|fx_shim_clean|||--staged|rc=0 $OK_STG" \
+  "a failed change-set collection is exit 2 carrying git's own line|fx_shim_raw|$TMP/raw-shim||--staged|rc=2 git diff: simulated execution failure;${ERR}could not collect the staged changes (git diff --cached --raw failed)" \
+  "shim-free control: the staged marker fires with the real tools|fx_shim_control|||--staged|rc=1 $(hit ok.rs 2 "// $TD: staged for the per-file read");$(stg 1)" \
+  "a file whose added lines cannot be read is exit 2, naming it|fx_shim_hunk|$TMP/hunk-shim||--staged|rc=2 git diff: simulated execution failure;${ERR}could not read the staged additions in 'ok.rs' (git diff exit 128)" \
+  "a hunk parser that fails is exit 2 naming the file, with no violation and no OK|fx_shim_awk|$TMP/awk-shim||--staged|rc=2 awk: simulated hunk-parser failure;${ERR}could not parse the staged additions in 'ok.rs' (awk exit 1)" \
+  "a marker in the first of 300 staged paths survives every later chunk|fx_chunked|||--staged|rc=1 $(hit a000.rs 1 "// $TD: in the first chunk");$(stg 1)"
 
-echo "=== the carriers pre-filter is chunked, and every chunk survives ==="
-# The chunk size is 256, so a change set larger than that is the only shape
-# that runs the loop more than once. A chunk that overwrites its
-# predecessors instead of appending drops the carrier named by a prior
-# one, and the lane prints OK: this repository's own render-propagation
-# commits stage several hundred files at a time, so the shape is routine.
-new_repo chunking
-printf 'fn main() {}\n' >"$R/seed.rs"
-git -C "$R" add -A
-git -C "$R" commit -qm seed
-printf '// %s: in the first chunk\n' "$TD" >"$R/a000.rs"
-i=1
-while [ "$i" -lt 300 ]; do
-  printf 'fn f%s() {}\n' "$i" >"$R/$(printf 'a%03d' "$i").rs"
-  i=$((i + 1))
-done
-git -C "$R" add -A
-run_tb --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: a000.rs:1:"*) true ;; *) false ;; esac \
-  && ok "a marker in the first of 300 staged paths survives every later chunk" \
-  || bad "the first chunk's carrier survives" "rc=$RC out=$OUT"
-case "$OUT" in *"todo-ban: OK"*) bad "no OK verdict may accompany a chunked carrier" "$OUT" ;; *) ok "no OK verdict accompanies the chunked scan" ;; esac
+echo "=== the usage is answered ==="
+repo help
+assert_eq "--help prints the usage and exits 0" "rc=0 usage: todo-ban [--staged] [--excludes FILE]" "$(run "" "" --help | cut -d';' -f1)"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/commit-guards/tests/todo-ban.test.sh
+++ b/skills/commit-guards/tests/todo-ban.test.sh
@@ -87,6 +87,7 @@ run_rows() { # label | fixture | shim | env | args | expect
   local row label fx shim env args expect
   for row in "$@"; do
     IFS='|' read -r label fx shim env args expect <<<"$row"
+    [ -n "$expect" ] || { echo "harness: row has fewer than six fields: $row" >&2; exit 2; }
     R=""
     "$fx"
     assert_eq "$label" "$expect" "$(run "$shim" "$env" "$args")"
@@ -101,7 +102,10 @@ fx_block() { repo block; put a.rs "code(); /* $HK: inline block */\n"; stage; }
 fx_hash() { repo hash; put a.rs "# $TD implement the frobnicator\n"; stage; }
 fx_glued() { repo glued; put a.rs "//$XX no space before the word\n"; stage; }
 fx_leaders() { repo leaders; put a.rs "; $TD after a semicolon\n<!-- $FX after an HTML leader\n"; stage; }
-fx_four() { repo four; put a.rs "// $TD: one\n// $FX: two\n// $HK: three\n// $XX: four\n"; stage; }
+# Each odd line reaches only the annotated arm (no leader), each even line
+# only the after-a-leader arm (no colon), and line 6 is the one place the
+# block-comment opener is the leader.
+fx_four() { repo four; put a.rs "$TD: one\n//$TD two\n$FX(x): three\n//$FX four\n$HK: five\n/*$HK six\n$XX: seven\n//$XX eight\n"; stage; }
 fx_prose() { repo prose; put a.rs "The $TD marker is banned in this repo.\n"; stage; }
 fx_backticks() { repo backticks; put a.md "the \`$TD:\` shape and \`$FX(\` shape are banned\n"; stage; }
 fx_joined() { repo joined; put a.sh "emit \"$TD:/$FX( marker without an issue reference\"\n"; stage; }
@@ -117,7 +121,7 @@ run_rows \
   "a bare marker after a hash leader fails|fx_hash||||rc=1 $(hit a.rs 1 "# $TD implement the frobnicator");$(idx 1)" \
   "a bare marker glued to a slash leader fails|fx_glued||||rc=1 $(hit a.rs 1 "//$XX no space before the word");$(idx 1)" \
   "a semicolon and an HTML comment are leaders too|fx_leaders||||rc=1 $(hit a.rs 1 "; $TD after a semicolon");$(hit a.rs 2 "<!-- $FX after an HTML leader");$(idx 2)" \
-  "each of the four words is a marker, and every hit is numbered|fx_four||||rc=1 $(hit a.rs 1 "// $TD: one");$(hit a.rs 2 "// $FX: two");$(hit a.rs 3 "// $HK: three");$(hit a.rs 4 "// $XX: four");$(idx 4)" \
+  "each of the four words is a marker in each shape alone, and every hit is numbered|fx_four||||rc=1 $(hit a.rs 1 "$TD: one");$(hit a.rs 2 "//$TD two");$(hit a.rs 3 "$FX(x): three");$(hit a.rs 4 "//$FX four");$(hit a.rs 5 "$HK: five");$(hit a.rs 6 "/*$HK six");$(hit a.rs 7 "$XX: seven");$(hit a.rs 8 "//$XX eight");$(idx 8)" \
   "a bare word mid-prose, with no colon and no adjacent leader, passes|fx_prose||||rc=0 $OK_IDX" \
   "backtick-quoted marker shapes in a document pass|fx_backticks||||rc=0 $OK_IDX" \
   "quote- and slash-joined marker names in a string pass|fx_joined||||rc=0 $OK_IDX" \
@@ -131,6 +135,8 @@ vendored() { repo "$1"; put vendor/lib.rs "// $TD: vendored upstream marker\n"; 
 fx_vendored() { vendored vendored; }
 fx_vendored_row() { vendored vendored-row; excl 'vendor/*\tvendored third-party code\n'; }
 fx_no_reason() { vendored no-reason; excl 'vendor/*\n'; }
+fx_comment_rows() { vendored comment-rows; excl '# a note\n\nvendor/*\tvendored third-party code'; }
+fx_empty_pattern() { vendored empty-pattern; excl '\ta reason with no pattern\n'; }
 fx_alt_env() { vendored alt-env; put alt-excludes 'vendor/*\tvendored third-party code\n'; stage; }
 fx_alt_flag() { vendored alt-flag; put alt-excludes 'vendor/*\tvendored third-party code\n'; stage; }
 fx_alt_eq() { vendored alt-eq; put alt-excludes 'vendor/*\tvendored third-party code\n'; stage; }
@@ -167,6 +173,8 @@ run_rows \
   "control: the vendored marker fails without a row, and the remedy names the default list|fx_vendored||||rc=1 $(hit vendor/lib.rs 1 "// $TD: vendored upstream marker");$(idx 1)" \
   "the row silences exactly the vendored tree|fx_vendored_row||||rc=0 $OK_IDX" \
   "a row without a tab-separated reason is a config error naming the line|fx_no_reason||||rc=2 ${ERR}$EXCL:1: $NO_REASON" \
+  "a comment row and a blank row are skipped, and the last row is read without its newline|fx_comment_rows||||rc=0 $OK_IDX" \
+  "a reason with no pattern before its tab is the same config error|fx_empty_pattern||||rc=2 ${ERR}$EXCL:1: $NO_REASON" \
   "the list path resolves through the environment key, and the verdict names that list|fx_alt_env||$ALT||rc=0 $OK_IDX" \
   "--excludes names the same list|fx_alt_flag|||--excludes alt-excludes|rc=0 $OK_IDX" \
   "--excludes=PATH is the same flag|fx_alt_eq|||--excludes=alt-excludes|rc=0 $OK_IDX" \
@@ -194,6 +202,9 @@ fx_scope_adds() { scoped scope-adds; add ok.rs "// $FX: added by this commit\n";
 # second marker is numbered past the first insertion.
 fx_two_hunks() { repo two-hunks; local i; for i in 1 2 3 4 5 6 7 8 9 10; do add ten.rs "fn f$i() {}\n"; done; stage; commit; put ten.rs "fn f1() {}\nfn f2() {}\n// $TD: after two\nfn f3() {}\nfn f4() {}\nfn f5() {}\nfn f6() {}\nfn f7() {}\nfn f8() {}\n// $HK: after eight\nfn f9() {}\nfn f10() {}\n"; stage; }
 walked() { seeded "$1"; add ok.rs "// $TD: staged\n"; git -C "$R" add ok.rs; put ok.rs 'fn main() {}\n'; } # NAME — the work tree walks it back; the index still carries it
+# The index blob keeps a second marker so the path stays a carrier and the
+# parser really runs over a hunk that only removes.
+fx_removed() { seeded removed; add ok.rs "// $TD: one\n// $TD: two\n"; stage; commit two; put ok.rs "fn main() {}\n// $TD: two\n"; git -C "$R" add ok.rs; }
 fx_walked() { walked walked; }
 fx_walked_staged() { walked walked-staged; git -C "$R" add ok.rs; }
 fx_first() { repo first; put a.rs "// $TD: in the very first commit\n"; stage; }
@@ -205,8 +216,8 @@ staged_vendored() { seeded "$1"; put vendor/lib.rs "// $TD: vendored upstream ma
 fx_staged_vendored() { staged_vendored staged-vendored; }
 fx_staged_vendored_row() { staged_vendored staged-vendored-row; excl 'vendor/*\tvendored third-party code\n'; }
 # A symlink's blob is its target path and a gitlink has no blob here; the
-# pre-filter never lists either (git grep reads no symlink), so neither
-# reaches the per-file read, whatever the target spells.
+# pre-filter never lists either (git grep reads no symlink and no gitlink),
+# so the walk's mode arm is never reached and these pin the verdict alone.
 fx_staged_link() { seeded staged-link; ln -s "$TD: target" "$R/link.rs"; stage; }
 fx_staged_gitlink() { seeded staged-gitlink; git -C "$R" update-index --add --cacheinfo 160000,4b825dc642cb6eb9a060e54bf8d69288fbee4904,sub; }
 # ls-files -s lists an unmerged path once per stage; the lane refuses the
@@ -230,6 +241,7 @@ run_rows \
   "a second hunk is numbered from its own header|fx_two_hunks|||--staged|rc=1 $(hit ten.rs 3 "// $TD: after two");$(hit ten.rs 10 "// $HK: after eight");$(stg 2)" \
   "staged bytes decide, whatever the work tree says now|fx_walked|||--staged|rc=1 $(hit ok.rs 2 "// $TD: staged");$(stg 1)" \
   "control: staging the walked-back file clears it|fx_walked_staged|||--staged|rc=0 $OK_STG" \
+  "a marker the commit removes is not a line it adds|fx_removed|||--staged|rc=0 $OK_STG" \
   "with no HEAD to diff against, the whole staged tree reads as added|fx_first|||--staged|rc=1 $(hit a.rs 1 "// $TD: in the very first commit");$(stg 1)" \
   "control: a clean first commit passes rather than erroring for want of a HEAD|fx_first_clean|||--staged|rc=0 $OK_STG" \
   "a lowercase word the commit adds to a marker-carrying file is prose in this scope too|fx_staged_lower|||--staged|rc=0 $OK_STG" \
@@ -266,6 +278,10 @@ fx_attr_clean() { attributed attr-clean; commit "the marker, now committed"; add
 # NULs are text, and text is read whatever it is called.
 fx_binary() { seeded binary; put asset.png "\\0211PNG\\r\\n\\032\\n\\0000\\0000 $TD: in the pixels\\n"; git -C "$R" add asset.png; }
 fx_binary_control() { seeded binary-control; put asset.png "\\0211PNG\\r\\n\\032\\n $TD: in the pixels\\n"; git -C "$R" add asset.png; }
+# A violation and a skipped carrier in one run: the qualifier rides on the
+# violation summary too, in each lane.
+fx_binary_beside() { seeded binary-beside; put asset.png "\\0211PNG\\r\\n\\032\\n\\0000\\0000 $TD: in the pixels\\n"; add ok.rs "// $TD: beside the asset\\n"; stage; }
+fx_binary_beside_index() { seeded binary-beside-index; put asset.png "\\0211PNG\\r\\n\\032\\n\\0000\\0000 $TD: in the pixels\\n"; add ok.rs "// $TD: beside the asset\\n"; stage; }
 # git's window is 8000 bytes: a NUL past it leaves the blob text for git
 # (`diff --numstat` counts lines rather than printing '-'), so the sniff
 # must read it too, or a marker that fails the index scan passes the commit.
@@ -294,6 +310,8 @@ run_rows \
   "control: a clean addition to a marker-carrying file under the same rule passes, the committed marker out of this commit's verdict|fx_attr_clean|||--staged|rc=0 $OK_STG" \
   "a genuinely binary blob whose bytes spell a marker is named as unmeasured and carried into the verdict|fx_binary|||--staged|rc=0 todo-ban: not measured: asset.png — binary content, not text;$OK_STG; 1 matched path(s) not measured" \
   "control: the same bytes without a NUL are text, and fire|fx_binary_control|||--staged|rc=1 $(hit asset.png 3 " $TD: in the pixels");$(stg 1)" \
+  "a skipped carrier qualifies a violation verdict too|fx_binary_beside|||--staged|rc=1 todo-ban: not measured: asset.png — binary content, not text;$(hit ok.rs 2 "// $TD: beside the asset");$(stg 1); 1 matched path(s) not measured" \
+  "and the index lane's violation verdict the same way|fx_binary_beside_index||||rc=1 todo-ban: not measured: asset.png — binary content, not text;$(hit ok.rs 2 "// $TD: beside the asset");$(idx 1); 1 matched path(s) not measured" \
   "a NUL past git's 8000-byte window leaves the blob text, and it fires|fx_late_nul|||--staged|rc=1 $(hit late-nul.rs 2 "// $TD: past the 8000-byte window");$(stg 1)" \
   "a type change to a clean regular file passes: a marker shape in the path is not content|fx_type_clean|||--staged|rc=0 $OK_STG" \
   "a marker in the new regular file fires at its own line, the section header and the clean line beside it never records|fx_type_marker|||--staged|rc=1 $(hit "a $TD: x.md" 1 "// $FX: added with the regular file");$(stg 1)" \
@@ -342,6 +360,18 @@ done
 exec "$REAL_AWK" "\$@"
 EOF
 chmod +x "$TMP/awk-shim/awk"
+# The per-file grep exits 2 on purpose: 1 is "no marker in this file's
+# additions", so a 2 read as a 1 would skip the file silently.
+REAL_GREP="$(command -v grep)"
+mkdir -p "$TMP/grep-shim"
+cat >"$TMP/grep-shim/grep" <<EOF
+#!/usr/bin/env bash
+for a in "\$@"; do
+  [ "\$a" != "-aE" ] || { echo "grep: simulated scan failure" >&2; exit 2; }
+done
+exec "$REAL_GREP" "\$@"
+EOF
+chmod +x "$TMP/grep-shim/grep"
 fx_shim_clean() { seeded shim-clean; add ok.rs 'fn other() {}\n'; git -C "$R" add ok.rs; }
 fx_shim_raw() { seeded shim-raw; add ok.rs 'fn other() {}\n'; git -C "$R" add ok.rs; }
 # The per-file read and the parser are reached only for a path the
@@ -350,6 +380,7 @@ marked() { seeded "$1"; add ok.rs "// $TD: staged for the per-file read\n"; git 
 fx_shim_control() { marked shim-control; }
 fx_shim_hunk() { marked shim-hunk; }
 fx_shim_awk() { marked shim-awk; }
+fx_shim_grep() { marked shim-grep; }
 # The carriers pre-filter is chunked at 256 paths; a chunk that overwrote
 # its predecessors would drop the carrier named by a prior one and print
 # OK. This repository's render-propagation commits stage several hundred
@@ -361,11 +392,13 @@ run_rows \
   "shim-free control: the staged marker fires with the real tools|fx_shim_control|||--staged|rc=1 $(hit ok.rs 2 "// $TD: staged for the per-file read");$(stg 1)" \
   "a file whose added lines cannot be read is exit 2, naming it|fx_shim_hunk|$TMP/hunk-shim||--staged|rc=2 git diff: simulated execution failure;${ERR}could not read the staged additions in 'ok.rs' (git diff exit 128)" \
   "a hunk parser that fails is exit 2 naming the file, with no violation and no OK|fx_shim_awk|$TMP/awk-shim||--staged|rc=2 awk: simulated hunk-parser failure;${ERR}could not parse the staged additions in 'ok.rs' (awk exit 1)" \
+  "a per-file scan that fails is exit 2 naming the file, never a file skipped|fx_shim_grep|$TMP/grep-shim||--staged|rc=2 grep: simulated scan failure;${ERR}could not scan the staged additions in 'ok.rs' (grep exit 2)" \
   "a marker in the first of 300 staged paths survives every later chunk|fx_chunked|||--staged|rc=1 $(hit a000.rs 1 "// $TD: in the first chunk");$(stg 1)"
 
 echo "=== the usage is answered ==="
 repo help
 assert_eq "--help prints the usage and exits 0" "rc=0 usage: todo-ban [--staged] [--excludes FILE]" "$(run "" "" --help | cut -d';' -f1)"
+assert_eq "-h is the same flag" "$(run "" "" --help)" "$(run "" "" -h)"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/commit-guards/tests/todo-ban.test.sh
+++ b/skills/commit-guards/tests/todo-ban.test.sh
@@ -1,24 +1,27 @@
 #!/usr/bin/env bash
-# Pins for scripts/todo-ban: both marker shapes fire, prose that quotes or
-# names a marker word does not, excludes need reasons, --staged judges the
-# lines the commit ADDS while the default scope judges the whole index, and
-# the staged lane's change-set collection and hunk parse are collection
-# errors — never a pass. Every green assertion is paired with a control that
-# proves it can fail. The index readers this family of checks shares — the
-# staged lane's carriers pre-filter and content sniff among them — are
-# pinned once, in lane-readers.test.sh, which drives them through this check.
+# Pins for scripts/todo-ban, the flat ban on work markers: both marker
+# shapes fire and prose that quotes or names a marker word does not, an
+# exclusion row needs its reason and a `!` row carves a subtree back in,
+# --staged judges the lines the commit ADDS from the index while the default
+# scope judges the whole index, and a collection step that cannot run is a
+# collection error, never a pass. One table: a row builds its own
+# repository, stages what it means, runs the check once under its settings
+# and reads back the exit status with every line printed, so the verdict,
+# the file and line it names, the quoted line, the remedy and the summary
+# are one pin. The index readers this family shares — the carriers
+# pre-filter, the content sniff, the blob read — are pinned once in
+# lane-readers.test.sh, which drives them through this check.
 #
-# Marker words are assembled from split tokens throughout so this test
-# file never contains a marker shape itself — the kendex repo runs
+# Marker words are assembled from split tokens throughout so this file
+# never contains a marker shape itself — the kendex repository runs
 # todo-ban over its own tree, tests included.
 set -euo pipefail
-
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 TB="$SKILL_DIR/scripts/todo-ban"
+# shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
-
-# Hermetic: a leaked setting would mask every case below.
+# Hermetic: a leaked setting would mask every row below.
 unset COMMIT_GUARDS_TODO_EXCLUDES COMMIT_GUARDS_SETTINGS_FILE 2>/dev/null || true
 
 TD="TO""DO"
@@ -28,524 +31,281 @@ XX="XX""X"
 
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
 
-new_repo() { # NAME — fresh fixture repo in $R
+# One line for a run in the row's repository: the exit status, then every
+# line printed, in order, joined by ';'. SHIM is a directory put ahead of
+# PATH (empty for the real tools); ENVS is a comma-separated list of
+# assignments; ARGS are passed through.
+R=""
+run() { # SHIM ENVS ARGS
+  local envs=() rc=0 out="" path="$PATH"
+  [ -z "$1" ] || path="$1:$PATH"
+  [ -z "$2" ] || IFS=',' read -ra envs <<<"$2"
+  # shellcheck disable=SC2086
+  out="$(cd "$R" && env PATH="$path" ${envs[@]+"${envs[@]}"} "$TB" $3 2>&1)" || rc=$?
+  printf 'rc=%s%s' "$rc" "${out:+ $(printf '%s\n' "$out" | LC_ALL=C paste -sd ';' -)}"
+}
+
+# Fixture vocabulary. Every fixture builds its own repository and stages
+# what it wrote; a name used twice is refused.
+repo() { # NAME
   R="$TMP/$1"
+  [ ! -e "$R" ] || { echo "harness: fixture $1 already exists" >&2; exit 2; }
   mkdir -p "$R"
   git -C "$R" -c init.defaultBranch=main init -q
   git -C "$R" config user.email test@example.com
   git -C "$R" config user.name test
 }
+put() { mkdir -p "$R/$(dirname "$1")"; printf '%b' "$2" >"$R/$1"; } # PATH CONTENT (printf %b)
+add() { mkdir -p "$R/$(dirname "$1")"; printf '%b' "$2" >>"$R/$1"; } # PATH CONTENT, appended
+stage() { git -C "$R" add -A; }
+commit() { git -C "$R" commit -qm "${1:-seed}"; } # [MESSAGE]
+seeded() { repo "$1"; put ok.rs 'fn main() {}\n'; stage; commit; } # NAME — one committed clean file
+excl() { put tools/todo-ban-excludes "$1"; stage; } # ROWS — the exclusion list, staged
 
-run_tb() { # [args...] — run in $R; sets OUT and RC
-  OUT=""
-  RC=0
-  OUT="$(cd "$R" && "$TB" "$@" 2>&1)" || RC=$?
+# The lines the check prints, as functions of what a row put in.
+EXCL=tools/todo-ban-excludes
+remedy() { printf '  remedies: do the work now, or move it to the tracker and delete the marker; vendored/generated trees belong in %s with a reason' "${1:-$EXCL}"; } # [EXCLUDES]
+hit() { printf 'todo-ban FAIL work marker: %s:%s:%s;%s' "$1" "$2" "$3" "$(remedy "${4:-}")"; } # PATH LINE CONTENT [EXCLUDES]
+idx() { printf 'todo-ban: %s work marker(s) — excludes %s' "$1" "${2:-$EXCL}"; } # COUNT [EXCLUDES]
+stg() { printf 'todo-ban: %s work marker(s) added by the staged diff — excludes %s' "$1" "${2:-$EXCL}"; } # COUNT [EXCLUDES]
+OK_IDX="todo-ban: OK — no work markers in tracked files"
+OK_STG="todo-ban: OK — the staged diff adds no work markers"
+ERR="::error::todo-ban: "
+NO_REASON="expected 'pattern<TAB>reason' (every exclusion carries its justification)"
+
+run_rows() { # label | fixture | shim | env | args | expect
+  local row label fx shim env args expect
+  for row in "$@"; do
+    IFS='|' read -r label fx shim env args expect <<<"$row"
+    R=""
+    "$fx"
+    assert_eq "$label" "$expect" "$(run "$shim" "$env" "$args")"
+  done
 }
 
-echo "=== control: a clean repo passes ==="
-new_repo clean
-printf 'fn main() {}\n' >"$R/ok.rs"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 0 ] && case "$OUT" in *"todo-ban: OK"*) true ;; *) false ;; esac \
-  && ok "clean repo passes" || bad "clean repo passes" "rc=$RC out=$OUT"
+echo "=== both marker shapes fire, and prose that quotes or names a marker word does not ==="
+fx_clean() { repo clean; put ok.rs 'fn main() {}\n'; stage; }
+fx_colon() { repo colon; put a.rs "// $TD: wire this up\n"; stage; }
+fx_paren() { repo paren; put a.rs "$FX(alice): assigned marker\n"; stage; }
+fx_block() { repo block; put a.rs "code(); /* $HK: inline block */\n"; stage; }
+fx_hash() { repo hash; put a.rs "# $TD implement the frobnicator\n"; stage; }
+fx_glued() { repo glued; put a.rs "//$XX no space before the word\n"; stage; }
+fx_leaders() { repo leaders; put a.rs "; $TD after a semicolon\n<!-- $FX after an HTML leader\n"; stage; }
+fx_four() { repo four; put a.rs "// $TD: one\n// $FX: two\n// $HK: three\n// $XX: four\n"; stage; }
+fx_prose() { repo prose; put a.rs "The $TD marker is banned in this repo.\n"; stage; }
+fx_backticks() { repo backticks; put a.md "the \`$TD:\` shape and \`$FX(\` shape are banned\n"; stage; }
+fx_joined() { repo joined; put a.sh "emit \"$TD:/$FX( marker without an issue reference\"\n"; stage; }
+fx_escaped() { repo escaped; put a.sh "printf \"then\\\\n$TD: inside a literal\"\n"; stage; }
+fx_lower() { repo lower; put a.rs '// todo: lowercase is prose, not a marker\n'; stage; }
+fx_url() { repo url; put u.md "see http://$TD:8080/path for the mock\n"; stage; }
+fx_url_control() { repo url-control; put u.md "see http://$TD:8080/path for the mock\nleft in: $TD: cleanup\n"; stage; }
+run_rows \
+  "control: a clean repository passes|fx_clean||||rc=0 $OK_IDX" \
+  "a colon-annotated marker in a comment fails, naming file, line and the line itself, with the remedy|fx_colon||||rc=1 $(hit a.rs 1 "// $TD: wire this up");$(idx 1)" \
+  "an attributed marker at line start fails|fx_paren||||rc=1 $(hit a.rs 1 "$FX(alice): assigned marker");$(idx 1)" \
+  "an annotated marker inside a block comment fails|fx_block||||rc=1 $(hit a.rs 1 "code(); /* $HK: inline block */");$(idx 1)" \
+  "a bare marker after a hash leader fails|fx_hash||||rc=1 $(hit a.rs 1 "# $TD implement the frobnicator");$(idx 1)" \
+  "a bare marker glued to a slash leader fails|fx_glued||||rc=1 $(hit a.rs 1 "//$XX no space before the word");$(idx 1)" \
+  "a semicolon and an HTML comment are leaders too|fx_leaders||||rc=1 $(hit a.rs 1 "; $TD after a semicolon");$(hit a.rs 2 "<!-- $FX after an HTML leader");$(idx 2)" \
+  "each of the four words is a marker, and every hit is numbered|fx_four||||rc=1 $(hit a.rs 1 "// $TD: one");$(hit a.rs 2 "// $FX: two");$(hit a.rs 3 "// $HK: three");$(hit a.rs 4 "// $XX: four");$(idx 4)" \
+  "a bare word mid-prose, with no colon and no adjacent leader, passes|fx_prose||||rc=0 $OK_IDX" \
+  "backtick-quoted marker shapes in a document pass|fx_backticks||||rc=0 $OK_IDX" \
+  "quote- and slash-joined marker names in a string pass|fx_joined||||rc=0 $OK_IDX" \
+  "a marker joined to an escape sequence in a literal passes|fx_escaped||||rc=0 $OK_IDX" \
+  "a lowercase word is never a marker|fx_lower||||rc=0 $OK_IDX" \
+  "a marker word inside a URL authority is not after a leader|fx_url||||rc=0 $OK_IDX" \
+  "control: the same word after whitespace fires, at its own line|fx_url_control||||rc=1 $(hit u.md 2 "left in: $TD: cleanup");$(idx 1)"
 
-echo "=== shape (a): annotated markers fire ==="
-new_repo shapes
-printf '// %s: wire this up\n' "$TD" >"$R/a.rs"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: a.rs:1:"*) true ;; *) false ;; esac \
-  && ok "colon-annotated marker in a comment fails, naming file:line" \
-  || bad "colon-annotated marker fails" "rc=$RC out=$OUT"
-case "$OUT" in *"move it to the tracker and delete the marker"*) ok "diagnostic carries the remediation" ;; *) bad "diagnostic carries the remediation" "$OUT" ;; esac
-
-printf '%s(alice): assigned marker\n' "$FX" >"$R/a.rs"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 1 ] && ok "attributed marker at line start fails" || bad "attributed marker at line start fails" "rc=$RC out=$OUT"
-
-printf 'code(); /* %s: inline block */\n' "$HK" >"$R/a.rs"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 1 ] && ok "block-comment annotated marker fails" || bad "block-comment annotated marker fails" "rc=$RC out=$OUT"
-
-echo "=== shape (b): bare marker directly after a comment leader fires ==="
-printf '# %s implement the frobnicator\n' "$TD" >"$R/a.rs"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 1 ] && ok "bare marker after hash leader fails" || bad "bare marker after hash leader fails" "rc=$RC out=$OUT"
-
-printf '//%s no space before the word\n' "$XX" >"$R/a.rs"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 1 ] && ok "bare marker glued to a slash leader fails" || bad "bare marker glued to a slash leader fails" "rc=$RC out=$OUT"
-
-echo "=== prose that names or quotes a marker does not fire ==="
-printf 'The %s marker is banned in this repo.\n' "$TD" >"$R/a.rs"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 0 ] && ok "bare word mid-prose (no colon, no adjacent leader) passes" \
-  || bad "bare word mid-prose passes" "rc=$RC out=$OUT"
-
-printf 'the `%s:` shape and `%s(` shape are banned\n' "$TD" "$FX" >"$R/a.md"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 0 ] && ok "backtick-quoted marker shapes in docs pass" \
-  || bad "backtick-quoted marker shapes pass" "rc=$RC out=$OUT"
-
-printf 'emit "%s:/%s( marker without an issue reference"\n' "$TD" "$FX" >"$R/a.sh"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 0 ] && ok "quote- and slash-joined marker names in a string pass" \
-  || bad "joined marker names in a string pass" "rc=$RC out=$OUT"
-
-printf 'printf "then\\n%s: inside a literal"\n' "$TD" >"$R/a.sh"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 0 ] && ok "marker joined to an escape sequence in a literal passes" \
-  || bad "escape-joined marker passes" "rc=$RC out=$OUT"
-
-printf '// %s: lowercase is prose, not a marker\n' "todo" >"$R/a.rs"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 0 ] && ok "lowercase word is never a marker (case-sensitive match)" \
-  || bad "lowercase word passes" "rc=$RC out=$OUT"
-
-echo "=== excludes: vendored trees are excluded WITH a reason ==="
-new_repo exc
-mkdir -p "$R/vendor" "$R/tools"
-printf '// %s: vendored upstream marker\n' "$TD" >"$R/vendor/lib.rs"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 1 ] && ok "control: the vendored marker fails without an excludes row" \
-  || bad "control: vendored marker fails without excludes" "rc=$RC out=$OUT"
-
-printf 'vendor/*\tvendored third-party code\n' >"$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 0 ] && ok "the excludes row silences exactly the vendored tree" \
-  || bad "excludes row silences the vendored tree" "rc=$RC out=$OUT"
-
-printf 'vendor/*\n' >"$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 2 ] && case "$OUT" in *"pattern<TAB>reason"*) true ;; *) false ;; esac \
-  && ok "a pattern without a tab-separated reason is exit 2" \
-  || bad "a pattern without a reason is exit 2" "rc=$RC out=$OUT"
-
-echo "=== configuration: COMMIT_GUARDS_TODO_EXCLUDES and --excludes ==="
-printf 'vendor/*\tvendored third-party code\n' >"$R/alt-excludes"
-rm "$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-OUT="$(cd "$R" && COMMIT_GUARDS_TODO_EXCLUDES=alt-excludes "$TB" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && ok "excludes path resolves through the environment key" \
-  || bad "excludes path resolves through the environment key" "rc=$RC out=$OUT"
-run_tb --excludes alt-excludes
-[ "$RC" -eq 0 ] && ok "--excludes flag points at the same list" || bad "--excludes flag" "rc=$RC out=$OUT"
-run_tb
-[ "$RC" -eq 1 ] && ok "control: without either, the vendored marker still fails" \
-  || bad "control: default excludes path has no file, marker fails" "rc=$RC out=$OUT"
-
-run_tb --no-such-flag
-[ "$RC" -eq 2 ] && ok "unknown flag is exit 2" || bad "unknown flag is exit 2" "rc=$RC out=$OUT"
-
+echo "=== an exclusion row silences exactly what it names, with a reason; a ! row carves a subtree back in ==="
+vendored() { repo "$1"; put vendor/lib.rs "// $TD: vendored upstream marker\n"; stage; } # NAME
+fx_vendored() { vendored vendored; }
+fx_vendored_row() { vendored vendored-row; excl 'vendor/*\tvendored third-party code\n'; }
+fx_no_reason() { vendored no-reason; excl 'vendor/*\n'; }
+fx_alt_env() { vendored alt-env; put alt-excludes 'vendor/*\tvendored third-party code\n'; stage; }
+fx_alt_flag() { vendored alt-flag; put alt-excludes 'vendor/*\tvendored third-party code\n'; stage; }
+fx_alt_eq() { vendored alt-eq; put alt-excludes 'vendor/*\tvendored third-party code\n'; stage; }
+fx_alt_none() { vendored alt-none; put alt-excludes 'vendor/*\tvendored third-party code\n'; stage; }
+fx_flag_bare() { vendored flag-bare; }
+fx_unknown() { vendored unknown; }
 # A row is a shell glob against the whole path, so every `*` in it crosses
-# `/`. A reader who writes `**/name/**` meaning "that vendored tree wherever
-# it is rendered" gets "any directory called name, at any depth" — and the
-# first-party one goes quiet with it, which is the one thing this file's own
-# header forbids.
-echo "=== excludes: a row anchored at a root does not exempt that name elsewhere ==="
-new_repo cross
-mkdir -p "$R/vendor/thing" "$R/crates/thing/src" "$R/tools"
-printf '// %s: vendored upstream marker\n' "$TD" >"$R/vendor/thing/lib.rs"
-printf '// %s: our own marker\n' "$TD" >"$R/crates/thing/src/lib.rs"
-printf 'vendor/thing/**\tvendored third-party code\n' >"$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 1 ] && case "$OUT" in
-  *"crates/thing/src/lib.rs"*) ok "the first-party tree of the same name still fails" ;;
-  *) bad "the anchored row exempted the wrong tree" "rc=$RC out=$OUT" ;;
-esac || bad "the first-party marker was silenced" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"vendor/thing/lib.rs"*) bad "the anchored row did not silence its own tree" "out=$OUT" ;;
-  *) ok "and the vendored tree it names is silent" ;;
-esac
+# `/`: a row anchored at a root does not exempt that name elsewhere, and the
+# crossing shorthand silences the first-party tree of the same name too.
+crossing() { repo "$1"; put vendor/thing/lib.rs "// $TD: vendored upstream marker\n"; put crates/thing/src/lib.rs "// $TD: our own marker\n"; stage; } # NAME
+fx_anchored() { crossing anchored; excl 'vendor/thing/**\tvendored third-party code\n'; }
+fx_shorthand() { crossing shorthand; excl '**/thing/**\tthe shorthand that crosses\n'; }
+# A rendered install can only be named by a tree wildcard, so hand-written
+# source inside it (a skill declared in-place) is carved back by a ! row,
+# above or below the row it cuts into: a list is a set of rules.
+carved() { repo "$1"; put .agents/skills/rendered/lib.rs "// $TD: a marker in the render\n"; put .agents/skills/in-place/lib.rs "// $TD: a marker in the source of record\n"; stage; } # NAME
+BLANKET='.agents/**\tkendex render, governed at its source\n'
+CARVE='!.agents/skills/in-place/**\tin-place skill: this tree IS the source\n'
+fx_blanket() { carved blanket; excl "$BLANKET"; }
+fx_carve() { carved carve; excl "$BLANKET$CARVE"; }
+fx_carve_above() { carved carve-above; excl "$CARVE$BLANKET"; }
+fx_carve_no_reason() { carved carve-no-reason; excl '.agents/**\tkendex render\n!.agents/skills/in-place/**\n'; }
+fx_carve_bare() { carved carve-bare; excl '.agents/**\tkendex render\n!\ta carve with no pattern\n'; }
+# `\!name` opens with a backslash, so it never reaches the carve arm, and
+# the matcher reads it as the literal path.
+fx_bang() { repo bang; put '!bang.rs' "// $TD: a marker under a bang-leading name\n"; excl '\\!bang.rs\tan escaped literal bang path\n'; }
+# The list is read from the index: a work-tree edit of it governs nothing
+# until staged.
+listed() { repo "$1"; put v.rs "// $TD: vendored\n"; put tools/commit-guards-todo-excludes 'v.rs\tvendored fixture\n'; stage; : >"$R/tools/commit-guards-todo-excludes"; } # NAME
+fx_list_index() { listed list-index; }
+fx_list_staged() { listed list-staged; git -C "$R" add tools/commit-guards-todo-excludes; }
+ALT=COMMIT_GUARDS_TODO_EXCLUDES=alt-excludes
+run_rows \
+  "control: the vendored marker fails without a row, and the remedy names the default list|fx_vendored||||rc=1 $(hit vendor/lib.rs 1 "// $TD: vendored upstream marker");$(idx 1)" \
+  "the row silences exactly the vendored tree|fx_vendored_row||||rc=0 $OK_IDX" \
+  "a row without a tab-separated reason is a config error naming the line|fx_no_reason||||rc=2 ${ERR}$EXCL:1: $NO_REASON" \
+  "the list path resolves through the environment key, and the verdict names that list|fx_alt_env||$ALT||rc=0 $OK_IDX" \
+  "--excludes names the same list|fx_alt_flag|||--excludes alt-excludes|rc=0 $OK_IDX" \
+  "--excludes=PATH is the same flag|fx_alt_eq|||--excludes=alt-excludes|rc=0 $OK_IDX" \
+  "control: without either, the default path has no file and the marker fails|fx_alt_none||||rc=1 $(hit vendor/lib.rs 1 "// $TD: vendored upstream marker");$(idx 1)" \
+  "--excludes with no path is a config error|fx_flag_bare|||--excludes|rc=2 ${ERR}--excludes requires a path" \
+  "an unknown argument is a config error quoting it|fx_unknown|||--no-such-flag|rc=2 ${ERR}unknown argument '--no-such-flag' (see --help)" \
+  "a row anchored at a root silences its own tree and not the first-party tree of the same name|fx_anchored||||rc=1 $(hit crates/thing/src/lib.rs 1 "// $TD: our own marker");$(idx 1)" \
+  "must-fail control: the crossing shorthand silences the first-party tree too|fx_shorthand||||rc=0 $OK_IDX" \
+  "control: the blanket row alone silences both planted markers|fx_blanket||||rc=0 $OK_IDX" \
+  "a ! row carves its subtree back into the scanned set, and the sibling render stays silent|fx_carve||||rc=1 $(hit .agents/skills/in-place/lib.rs 1 "// $TD: a marker in the source of record");$(idx 1)" \
+  "a carve above the row it cuts into carves just the same|fx_carve_above||||rc=1 $(hit .agents/skills/in-place/lib.rs 1 "// $TD: a marker in the source of record");$(idx 1)" \
+  "a carve row without a reason is the same config error as any other|fx_carve_no_reason||||rc=2 ${ERR}$EXCL:2: $NO_REASON" \
+  "a bare ! row is a config error naming its line|fx_carve_bare||||rc=2 ${ERR}$EXCL:2: '!' carves matching paths back into the scanned set and needs a pattern after it" \
+  "an escaped row excludes the literal bang path rather than carving it|fx_bang||||rc=0 $OK_IDX" \
+  "the staged list governs though the work-tree copy dropped the row|fx_list_index||COMMIT_GUARDS_TODO_EXCLUDES=tools/commit-guards-todo-excludes||rc=0 $OK_IDX" \
+  "control: staging the emptied list re-exposes the marker|fx_list_staged||COMMIT_GUARDS_TODO_EXCLUDES=tools/commit-guards-todo-excludes||rc=1 $(hit v.rs 1 "// $TD: vendored" tools/commit-guards-todo-excludes);$(idx 1 tools/commit-guards-todo-excludes)"
 
-# The control: the crossing shorthand does silence both, which is why a row
-# is written out per root rather than spelled `**/thing/**`.
-printf '**/thing/**\tthe shorthand that crosses\n' >"$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 0 ] \
-  && ok "must-fail control: the crossing shorthand silences the first-party tree too" \
-  || bad "the crossing shorthand did not cross" "rc=$RC out=$OUT"
-
-# The one exclusion row that ADDS coverage. A rendered install can only be
-# named by a tree wildcard, so a repo keeping hand-written source inside that
-# tree — a skill declared `source = "in-place"` — has no other way to say so,
-# and the coverage goes silently absent: the fail-open direction for a gate.
-echo "=== excludes: a ! row carves a subtree back into the scanned set ==="
-new_repo carve
-mkdir -p "$R/.agents/skills/rendered" "$R/.agents/skills/in-place" "$R/tools"
-printf '// %s: a marker in the render\n' "$TD" >"$R/.agents/skills/rendered/lib.rs"
-printf '// %s: a marker in the source of record\n' "$TD" >"$R/.agents/skills/in-place/lib.rs"
-printf '.agents/**\tkendex render, governed at its source\n' >"$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-
-# Control: the blanket row alone silences BOTH planted markers.
-run_tb
-[ "$RC" -eq 0 ] && ok "control: the blanket .agents/** row silences both planted markers" \
-  || bad "control: the blanket .agents/** row silences both markers" "rc=$RC out=$OUT"
-
-printf '.agents/**\tkendex render, governed at its source\n!.agents/skills/in-place/**\tin-place skill: this tree IS the source\n' >"$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 1 ] && case "$OUT" in *".agents/skills/in-place/lib.rs:1:"*) true ;; *) false ;; esac \
-  && ok "the carved tree is scanned again and its planted marker fires" \
-  || bad "the carved tree is scanned again" "rc=$RC out=$OUT"
-case "$OUT" in
-  *".agents/skills/rendered/lib.rs"*) bad "the carve must not widen past its own pattern" "$OUT" ;;
-  *) ok "the sibling render under the same blanket row stays silent" ;;
-esac
-
-# Order is not policy: the carve wins whether it precedes or follows the row
-# it cuts into, so a list reads as a set of rules rather than as a sequence.
-printf '!.agents/skills/in-place/**\tin-place skill: this tree IS the source\n.agents/**\tkendex render, governed at its source\n' >"$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 1 ] && case "$OUT" in *".agents/skills/in-place/lib.rs:1:"*) true ;; *) false ;; esac \
-  && ok "a carve above the row it cuts into carves just the same" \
-  || bad "a carve above the row it cuts into carves just the same" "rc=$RC out=$OUT"
-
-# A carve still needs its reason, like every other row, and a bare '!' names
-# nothing — keeping it silently would widen the scanned set by a typo.
-printf '.agents/**\tkendex render\n!.agents/skills/in-place/**\n' >"$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 2 ] && case "$OUT" in *":2: expected 'pattern<TAB>reason'"*) true ;; *) false ;; esac \
-  && ok "a carve row without a reason is the same config error as any other" \
-  || bad "a carve row without a reason is a config error" "rc=$RC out=$OUT"
-printf '.agents/**\tkendex render\n!\ta carve with no pattern\n' >"$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 2 ] && case "$OUT" in *":2: '!' carves"*) true ;; *) false ;; esac \
-  && ok "a bare ! row is a config error naming its line" \
-  || bad "a bare ! row is a config error naming its line" "rc=$RC out=$OUT"
-
-# `!` is escapable, which is the only way left to name a path that literally
-# begins with one: `\!name` opens with a backslash, so it never reaches the
-# carve arm, and the case matcher reads it as that literal path.
-new_repo bang
-mkdir -p "$R/tools"
-printf '// %s: a marker under a bang-leading name\n' "$TD" >"$R/!bang.rs"
-printf '\\!bang.rs\tan escaped literal bang path\n' >"$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 0 ] && ok "an escaped row excludes the literal bang path rather than carving it" \
-  || bad "an escaped row excludes the literal bang path" "rc=$RC out=$OUT"
-
-echo "=== a URL is not a comment leader ==="
-new_repo url
-printf 'see http://%s:8080/path for the mock\n' "$TD" >"$R/u.md"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 0 ] && ok "a marker word inside a URL authority does not fire" \
-  || bad "a marker word inside a URL authority does not fire" "rc=$RC out=$OUT"
-# Control: the same word after real whitespace still fires.
-printf 'left in: %s: cleanup\n' "$TD" >>"$R/u.md"
-git -C "$R" add -A
-run_tb
-[ "$RC" -eq 1 ] && ok "control: the same marker after whitespace fires" \
-  || bad "control: the same marker after whitespace fires" "rc=$RC out=$OUT"
-
-echo "=== the exclusion list is read from the index ==="
-new_repo stagedx
-printf '// %s: vendored\n' "$TD" >"$R/v.rs"
-mkdir -p "$R/tools"
-printf 'v.rs\tvendored fixture\n' >"$R/tools/commit-guards-todo-excludes"
-git -C "$R" add -A
-# Worktree copy now DROPS the exclusion; the staged copy must still govern.
-: >"$R/tools/commit-guards-todo-excludes"
-OUT="$(cd "$R" && COMMIT_GUARDS_TODO_EXCLUDES=tools/commit-guards-todo-excludes "$TB" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && ok "staged exclusion list governs a staged scan" \
-  || bad "staged exclusion list governs a staged scan" "rc=$RC out=$OUT"
-# Control: staging the emptied list re-exposes the marker.
-git -C "$R" add tools/commit-guards-todo-excludes
-OUT="$(cd "$R" && COMMIT_GUARDS_TODO_EXCLUDES=tools/commit-guards-todo-excludes "$TB" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 1 ] && ok "control: staging the emptied list re-exposes the marker" \
-  || bad "control: staging the emptied list re-exposes the marker" "rc=$RC out=$OUT"
-
-echo "=== --staged judges the lines the commit adds, not the whole index ==="
-new_repo stagedscope
-printf 'fn main() {}\n' >"$R/ok.rs"
-git -C "$R" add -A
-git -C "$R" commit -qm seed
+echo "=== --staged judges the lines the commit adds, read from the index, not the whole tree ==="
 # Someone else's marker, committed and untouched by the commit under judgement.
-printf '// %s: left in a fixture\n' "$TD" >"$R/fixture.rs"
-git -C "$R" add -A
-git -C "$R" commit -qm fixture
-printf 'fn other() {}\n' >>"$R/ok.rs"
-git -C "$R" add ok.rs
-run_tb --staged
-[ "$RC" -eq 0 ] && case "$OUT" in *"the staged diff adds no work markers"*) true ;; *) false ;; esac \
-  && ok "a commit that adds no marker passes on a repo whose index holds one" \
-  || bad "a commit adding no marker passes" "rc=$RC out=$OUT"
-run_tb
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: fixture.rs:1:"*) true ;; *) false ;; esac \
-  && ok "control: the index scan (CI) still refuses that same marker" \
-  || bad "control: the index scan refuses the marker" "rc=$RC out=$OUT"
+scoped() { seeded "$1"; put fixture.rs "// $TD: left in a fixture\n"; stage; commit fixture; add ok.rs 'fn other() {}\n'; git -C "$R" add ok.rs; } # NAME
+fx_scope() { scoped scope; }
+fx_scope_index() { scoped scope-index; }
+fx_scope_adds() { scoped scope-adds; add ok.rs "// $FX: added by this commit\n"; git -C "$R" add ok.rs; }
+# Two hunks in one file: the line numbers come from each hunk header, so the
+# second marker is numbered past the first insertion.
+fx_two_hunks() { repo two-hunks; local i; for i in 1 2 3 4 5 6 7 8 9 10; do add ten.rs "fn f$i() {}\n"; done; stage; commit; put ten.rs "fn f1() {}\nfn f2() {}\n// $TD: after two\nfn f3() {}\nfn f4() {}\nfn f5() {}\nfn f6() {}\nfn f7() {}\nfn f8() {}\n// $HK: after eight\nfn f9() {}\nfn f10() {}\n"; stage; }
+walked() { seeded "$1"; add ok.rs "// $TD: staged\n"; git -C "$R" add ok.rs; put ok.rs 'fn main() {}\n'; } # NAME — the work tree walks it back; the index still carries it
+fx_walked() { walked walked; }
+fx_walked_staged() { walked walked-staged; git -C "$R" add ok.rs; }
+fx_first() { repo first; put a.rs "// $TD: in the very first commit\n"; stage; }
+# The blob carries a committed marker, so the pre-filter lists the path and
+# the per-file scan really runs over the one lowercase line this commit adds.
+fx_staged_lower() { seeded staged-lower; add ok.rs "// $TD: committed\n"; stage; commit marker; add ok.rs '// todo: lowercase is prose here too\n'; git -C "$R" add ok.rs; }
+fx_first_clean() { repo first-clean; put a.rs 'fn main() {}\n'; stage; }
+staged_vendored() { seeded "$1"; put vendor/lib.rs "// $TD: vendored upstream marker\n"; stage; } # NAME
+fx_staged_vendored() { staged_vendored staged-vendored; }
+fx_staged_vendored_row() { staged_vendored staged-vendored-row; excl 'vendor/*\tvendored third-party code\n'; }
+# A symlink's blob is its target path and a gitlink has no blob here; the
+# pre-filter never lists either (git grep reads no symlink), so neither
+# reaches the per-file read, whatever the target spells.
+fx_staged_link() { seeded staged-link; ln -s "$TD: target" "$R/link.rs"; stage; }
+fx_staged_gitlink() { seeded staged-gitlink; git -C "$R" update-index --add --cacheinfo 160000,4b825dc642cb6eb9a060e54bf8d69288fbee4904,sub; }
+# ls-files -s lists an unmerged path once per stage; the lane refuses the
+# index before reading anything.
+fx_unmerged() {
+  seeded unmerged
+  git -C "$R" checkout -qb other
+  put ok.rs 'fn theirs() {}\n'
+  stage
+  commit theirs
+  git -C "$R" checkout -q main
+  put ok.rs 'fn ours() {}\n'
+  stage
+  commit ours
+  git -C "$R" merge -q other >/dev/null 2>&1 || true
+}
+run_rows \
+  "a commit adding no marker passes on a repository whose index holds one|fx_scope|||--staged|rc=0 $OK_STG" \
+  "control: the index scan still refuses that same marker|fx_scope_index||||rc=1 $(hit fixture.rs 1 "// $TD: left in a fixture");$(idx 1)" \
+  "a marker the staged diff adds is refused at the line it lands on, and the untouched fixture stays out of the verdict|fx_scope_adds|||--staged|rc=1 $(hit ok.rs 3 "// $FX: added by this commit");$(stg 1)" \
+  "a second hunk is numbered from its own header|fx_two_hunks|||--staged|rc=1 $(hit ten.rs 3 "// $TD: after two");$(hit ten.rs 10 "// $HK: after eight");$(stg 2)" \
+  "staged bytes decide, whatever the work tree says now|fx_walked|||--staged|rc=1 $(hit ok.rs 2 "// $TD: staged");$(stg 1)" \
+  "control: staging the walked-back file clears it|fx_walked_staged|||--staged|rc=0 $OK_STG" \
+  "with no HEAD to diff against, the whole staged tree reads as added|fx_first|||--staged|rc=1 $(hit a.rs 1 "// $TD: in the very first commit");$(stg 1)" \
+  "control: a clean first commit passes rather than erroring for want of a HEAD|fx_first_clean|||--staged|rc=0 $OK_STG" \
+  "a lowercase word the commit adds to a marker-carrying file is prose in this scope too|fx_staged_lower|||--staged|rc=0 $OK_STG" \
+  "control: a staged vendored marker fails without a row|fx_staged_vendored|||--staged|rc=1 $(hit vendor/lib.rs 1 "// $TD: vendored upstream marker");$(stg 1)" \
+  "the row silences the staged vendored tree too|fx_staged_vendored_row|||--staged|rc=0 $OK_STG" \
+  "a staged symlink whose target spells a marker has no lines to read|fx_staged_link|||--staged|rc=0 $OK_STG" \
+  "a staged gitlink has no lines to read|fx_staged_gitlink|||--staged|rc=0 $OK_STG" \
+  "an unmerged index is refused before the walk|fx_unmerged|||--staged|rc=2 ok.rs;${ERR}the index carries 1 unmerged path(s) (listed above) and a --cached scan skips them silently — finish or abort the merge, then re-run"
 
-# The same commit, now adding a marker of its own.
-printf '// %s: added by this commit\n' "$FX" >>"$R/ok.rs"
-git -C "$R" add ok.rs
-run_tb --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: ok.rs:3:"*) true ;; *) false ;; esac \
-  && ok "a marker the staged diff adds is refused, at the line it lands on" \
-  || bad "a staged marker is refused" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"fixture.rs"*) bad "the untouched fixture must stay out of the commit-scope verdict" "$OUT" ;;
-  *) ok "and the untouched fixture is not in that verdict" ;;
-esac
+echo "=== content decides what --staged reads: never an attribute, never a name ==="
+# A committed '-diff' rule makes git call every .rs file binary, so the
+# unforced staged diff carries no hunks; the fixture proves the rule took.
+attributed() { # NAME
+  seeded "$1"
+  put .gitattributes '*.rs -diff\n'
+  stage
+  commit attrs
+  add ok.rs "// $TD: behind an attributes rule\n"
+  git -C "$R" add ok.rs
+  case "$(git -C "$R" diff --cached -- ok.rs)" in
+    *"Binary files"*) ;;
+    *) echo "harness: fixture $1: the attributes rule did not suppress the staged diff" >&2; exit 2 ;;
+  esac
+}
+fx_attr() { attributed attr; }
+# The marker committed, then a clean addition under the same rule: the
+# index blob still carries a marker, so the pre-filter lists the path and
+# the forced diff really runs, and the verdict is the one line this commit
+# adds.
+fx_attr_clean() { attributed attr-clean; commit "the marker, now committed"; add ok.rs 'fn clean() {}\n'; git -C "$R" add ok.rs; }
+# A real asset whose bytes spell a marker: the pre-filter lists it (no -I),
+# and the content sniff — a NUL in the leading bytes, git's own test — keeps
+# it out of the verdict, named as unmeasured. The same bytes without the
+# NULs are text, and text is read whatever it is called.
+fx_binary() { seeded binary; put asset.png "\\0211PNG\\r\\n\\032\\n\\0000\\0000 $TD: in the pixels\\n"; git -C "$R" add asset.png; }
+fx_binary_control() { seeded binary-control; put asset.png "\\0211PNG\\r\\n\\032\\n $TD: in the pixels\\n"; git -C "$R" add asset.png; }
+# git's window is 8000 bytes: a NUL past it leaves the blob text for git
+# (`diff --numstat` counts lines rather than printing '-'), so the sniff
+# must read it too, or a marker that fails the index scan passes the commit.
+fx_late_nul() {
+  seeded late-nul
+  { head -c 8050 /dev/zero | LC_ALL=C tr '\000' 'x'; printf '\000\n// %s: past the 8000-byte window\n' "$TD"; } >"$R/late-nul.rs"
+  git -C "$R" add late-nul.rs
+  [ "$(git -C "$R" diff --cached --numstat -- late-nul.rs | cut -f1)" = 2 ] \
+    || { echo "harness: fixture late-nul: git does not call the late-NUL blob text" >&2; exit 2; }
+}
+# A symlink-to-file change emits a deletion section and a creation section
+# for the one path, the creation header between them at the deletion
+# hunk's numbering; the path itself spells a marker shape, so a header read
+# as content fires.
+typechanged() { seeded "$1"; ln -s ok.rs "$R/a $TD: x.md"; stage; commit; rm -- "$R/a $TD: x.md"; put "a $TD: x.md" "$2"; stage; } # NAME CONTENT
+fx_type_clean() { typechanged type-clean 'fn clean() {}\n'; }
+fx_type_marker() { typechanged type-marker "// $FX: added with the regular file\nfn clean() {}\n"; }
+# Rename detection held to EXACT content: a file that moved AND changed
+# arrives as an addition and is read whole; a pure move adds no line.
+fx_moved() { repo moved; local i=1; while [ "$i" -le 40 ]; do add old.rs "fn f$i() {}\n"; i=$((i + 1)); done; stage; commit; git -C "$R" mv old.rs new.rs; add new.rs "// $TD: added in the move\n"; git -C "$R" add new.rs; }
+pure_move() { repo "$1"; put legacy.rs "// $TD: committed long ago\n"; stage; commit; git -C "$R" mv legacy.rs moved.rs; } # NAME
+fx_pure_move() { pure_move pure-move; }
+fx_pure_move_index() { pure_move pure-move-index; }
+run_rows \
+  "a marker added under a non-diffable path is refused, at its own line|fx_attr|||--staged|rc=1 $(hit ok.rs 2 "// $TD: behind an attributes rule");$(stg 1)" \
+  "control: a clean addition to a marker-carrying file under the same rule passes, the committed marker out of this commit's verdict|fx_attr_clean|||--staged|rc=0 $OK_STG" \
+  "a genuinely binary blob whose bytes spell a marker is named as unmeasured and carried into the verdict|fx_binary|||--staged|rc=0 todo-ban: not measured: asset.png — binary content, not text;$OK_STG; 1 matched path(s) not measured" \
+  "control: the same bytes without a NUL are text, and fire|fx_binary_control|||--staged|rc=1 $(hit asset.png 3 " $TD: in the pixels");$(stg 1)" \
+  "a NUL past git's 8000-byte window leaves the blob text, and it fires|fx_late_nul|||--staged|rc=1 $(hit late-nul.rs 2 "// $TD: past the 8000-byte window");$(stg 1)" \
+  "a type change to a clean regular file passes: a marker shape in the path is not content|fx_type_clean|||--staged|rc=0 $OK_STG" \
+  "a marker in the new regular file fires at its own line, the section header and the clean line beside it never records|fx_type_marker|||--staged|rc=1 $(hit "a $TD: x.md" 1 "// $FX: added with the regular file");$(stg 1)" \
+  "a file that moved and gained a marker is read whole, at its new path|fx_moved|||--staged|rc=1 $(hit new.rs 41 "// $TD: added in the move");$(stg 1)" \
+  "a pure move of a committed marker adds no line, so it passes|fx_pure_move|||--staged|rc=0 $OK_STG" \
+  "control: the index scan still refuses that marker at its new path|fx_pure_move_index||||rc=1 $(hit moved.rs 1 "// $TD: committed long ago");$(idx 1)"
 
-echo "=== --staged reads the index, not the work tree ==="
-new_repo stagedbytes
-printf 'fn main() {}\n' >"$R/ok.rs"
-git -C "$R" add -A
-git -C "$R" commit -qm seed
-printf '// %s: staged\n' "$TD" >>"$R/ok.rs"
-git -C "$R" add ok.rs
-printf 'fn main() {}\n' >"$R/ok.rs" # the work tree walks it back; the index still carries it
-run_tb --staged
-[ "$RC" -eq 1 ] && ok "staged bytes decide, whatever the work tree says now" \
-  || bad "staged bytes decide" "rc=$RC out=$OUT"
-# Control: staging the walked-back file clears the verdict.
-git -C "$R" add ok.rs
-run_tb --staged
-[ "$RC" -eq 0 ] && ok "control: staging the walked-back file clears it" \
-  || bad "control: staging the walked-back file clears it" "rc=$RC out=$OUT"
-
-echo "=== --staged on a repository's first commit diffs against the empty tree ==="
-new_repo firstcommit
-printf '// %s: in the very first commit\n' "$TD" >"$R/a.rs"
-git -C "$R" add -A
-run_tb --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: a.rs:1:"*) true ;; *) false ;; esac \
-  && ok "with no HEAD to diff against, the whole staged tree reads as added" \
-  || bad "the first commit is judged" "rc=$RC out=$OUT"
-# Control: the same repository with no marker staged passes rather than
-# erroring on the missing HEAD.
-printf 'fn main() {}\n' >"$R/a.rs"
-git -C "$R" add -A
-run_tb --staged
-[ "$RC" -eq 0 ] && case "$OUT" in *"the staged diff adds no work markers"*) true ;; *) false ;; esac \
-  && ok "control: a clean first commit passes, not exit 2 for want of a HEAD" \
-  || bad "control: a clean first commit passes" "rc=$RC out=$OUT"
-
-echo "=== --staged honours the exclusion list ==="
-new_repo stagedexc
-printf 'fn main() {}\n' >"$R/ok.rs"
-mkdir -p "$R/vendor" "$R/tools"
-git -C "$R" add -A
-git -C "$R" commit -qm seed
-printf '// %s: vendored upstream marker\n' "$TD" >"$R/vendor/lib.rs"
-git -C "$R" add -A
-run_tb --staged
-[ "$RC" -eq 1 ] && ok "control: the staged vendored marker fails without an excludes row" \
-  || bad "control: staged vendored marker fails" "rc=$RC out=$OUT"
-printf 'vendor/*\tvendored third-party code\n' >"$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-run_tb --staged
-[ "$RC" -eq 0 ] && ok "the excludes row silences the staged vendored tree too" \
-  || bad "excludes row silences the staged tree" "rc=$RC out=$OUT"
-
-echo "=== a .gitattributes rule cannot hide staged content from the lane ==="
-new_repo stagedattr
-printf 'fn main() {}\n' >"$R/ok.rs"
-git -C "$R" add -A
-git -C "$R" commit -qm seed
-# A committed '-diff' rule makes git call every .rs file binary: the plain
-# staged diff then carries no hunks at all, and the index scan skips the blob
-# unless both are forced to text. That is the shape a whole extension could
-# be hidden behind by committing one attributes line.
-printf '*.rs -diff\n' >"$R/.gitattributes"
-git -C "$R" add -A
-git -C "$R" commit -qm attrs
-printf '// %s: behind an attributes rule\n' "$TD" >>"$R/ok.rs"
-git -C "$R" add ok.rs
-case "$(git -C "$R" diff --cached -- ok.rs)" in
-  *"Binary files"*) ok "fixture: the rule does suppress the unforced staged diff" ;;
-  *) bad "fixture: the rule suppresses the unforced staged diff" "the attributes rule did not take" ;;
-esac
-run_tb --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: ok.rs:2:"*) true ;; *) false ;; esac \
-  && ok "a marker added under a non-diffable path is refused, at its own line" \
-  || bad "a marker under a non-diffable path is refused" "rc=$RC out=$OUT"
-
-# Control: the same rule still in force, over an addition that carries no
-# marker — forcing text reads real content, it does not fail everything it
-# forces through. Committing the marker first is what makes this arm reach
-# that read: the index blob goes on carrying a marker, so the pre-filter
-# lists the path and the --text diff really runs over it, and the verdict
-# is decided by the one line THIS commit adds.
-git -C "$R" commit -qm "the marker, now committed"
-printf 'fn clean() {}\n' >>"$R/ok.rs"
-git -C "$R" add ok.rs
-case "$(git -C "$R" diff --cached -- ok.rs)" in
-  *"Binary files"*) ok "fixture: the rule still suppresses the unforced staged diff" ;;
-  *) bad "fixture: the rule still suppresses the unforced staged diff" "the attributes rule lapsed" ;;
-esac
-run_tb --staged
-[ "$RC" -eq 0 ] && case "$OUT" in *"the staged diff adds no work markers"*) true ;; *) false ;; esac \
-  && ok "a clean addition to a marker-carrying file under the same rule passes" \
-  || bad "a clean addition under the rule passes" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"ok.rs"*) bad "the committed marker was attributed to the commit that only added a clean line" "$OUT" ;;
-  *) ok "and the marker it already carried stays out of this commit's verdict" ;;
-esac
-
-echo "=== content decides what is scanned, never an attribute ==="
-new_repo binaryblob
-printf 'fn main() {}\n' >"$R/ok.rs"
-git -C "$R" add -A
-git -C "$R" commit -qm seed
-# A real asset whose bytes happen to spell a marker. The pre-filter forces
-# every blob to text, so this path IS listed; what keeps it out of the
-# verdict is the content sniff — a NUL in the first block, git's own test —
-# and nothing about how the path is named or attributed. Without the sniff
-# the raw bytes reach awk and the commit is blocked by a garbled record.
-printf '\211PNG\r\n\032\n\000\000 %s: in the pixels\n' "$TD" >"$R/asset.png"
-git -C "$R" add asset.png
-run_tb --staged
-[ "$RC" -eq 0 ] && case "$OUT" in *"the staged diff adds no work markers"*) true ;; *) false ;; esac \
-  && ok "a genuinely binary blob whose bytes spell a marker does not fire" \
-  || bad "a binary blob does not fire" "rc=$RC out=$OUT"
-# An unread match leaves a trace and qualifies the verdict, rather than
-# riding inside a plain OK over content the lane deliberately did not read.
-case "$OUT" in
-  *"not measured: asset.png — binary content"*"1 matched path(s) not measured"*)
-    ok "the skipped carrier is named and carried into the verdict"
-    ;;
-  *) bad "the skipped carrier is named and carried into the verdict" "out=$OUT" ;;
-esac
-
-# The must-fail control: the same bytes with the NULs taken out are a text
-# file, and a text file is read whatever it is called.
-printf '\211PNG\r\n\032\n %s: in the pixels\n' "$TD" >"$R/asset.png"
-git -C "$R" add asset.png
-run_tb --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: asset.png:"*) true ;; *) false ;; esac \
-  && ok "control: the same bytes without a NUL are text, and fire" \
-  || bad "control: the NUL-free bytes fire" "rc=$RC out=$OUT"
-
-# The window is git's, 8000 bytes, and the arms above only pin it from
-# below. A NUL past 8000 leaves git calling the blob text — `git diff
-# --numstat` counts its lines rather than printing '-' — so the sniff must
-# read it too. A wider read here answers "binary", the file is skipped, and
-# a marker that fails the index scan passes the commit.
-{
-  head -c 8050 /dev/zero | LC_ALL=C tr '\000' 'x'
-  printf '\000\n// %s: past the 8000-byte window\n' "$TD"
-} >"$R/late-nul.rs"
-git -C "$R" reset -q -- asset.png
-git -C "$R" add late-nul.rs
-[ "$(git -C "$R" diff --cached --numstat -- late-nul.rs | cut -f1)" = 2 ] \
-  || bad "fixture: git does not call the late-NUL blob text" "$(git -C "$R" diff --cached --numstat -- late-nul.rs)"
-run_tb --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: late-nul.rs:2:"*) true ;; *) false ;; esac \
-  && ok "a NUL past git's 8000-byte window leaves the blob text, and it fires" \
-  || bad "a late NUL leaves the blob text" "rc=$RC out=$OUT"
-
-echo "=== a type change emits two diff sections, neither header an added line ==="
-new_repo typechange
-printf 'fn main() {}\n' >"$R/ok.rs"
-# The path itself carries a marker shape, so a '+++ b/<path>' header read as
-# content fires. A symlink-to-file change emits a deletion section and a
-# creation section for the one path, and the creation section's header sits
-# between them at the deletion hunk's numbering.
-ln -s ok.rs "$R/a $TD: x.md"
-git -C "$R" add -A
-git -C "$R" commit -qm seed
-rm -- "$R/a $TD: x.md"
-printf 'fn clean() {}\n' >"$R/a $TD: x.md"
-git -C "$R" add -A
-run_tb --staged
-# The pre-filter matches CONTENT, never path names, so a clean file at a
-# path shaped like a marker is never listed and the run ends before the
-# parser. That is the whole of what this arm pins; the parser is the pair
-# below.
-[ "$RC" -eq 0 ] \
-  && ok "a type change to a clean regular file passes: a marker shape in the PATH is not content" \
-  || bad "a clean type change passes" "rc=$RC out=$OUT"
-
-# The same type change, its new regular file carrying a marker on one line
-# and clean content on the next. This is the arm that reaches the parser:
-# the path is listed, both diff sections are read, and only the line the
-# file actually carries may be named — not the creation section's header,
-# and not the clean line beside it.
-printf '// %s: added with the regular file\nfn clean() {}\n' "$FX" >"$R/a $TD: x.md"
-git -C "$R" add -A
-run_tb --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"x.md:1:"*) true ;; *) false ;; esac \
-  && ok "a marker in the new regular file fires at its own line" \
-  || bad "the marker in the new regular file fires" "rc=$RC out=$OUT"
-case "$OUT" in *":0:"*) bad "the creation section's header rode along as line 0" "$OUT" ;; *) ok "and the section header is not a record" ;; esac
-case "$OUT" in *"x.md:2:"*) bad "the clean line beside the marker was judged a marker" "$OUT" ;; *) ok "and the clean line beside it is judged on its own" ;; esac
-
-echo "=== rename detection is held to EXACT content ==="
-new_repo renamed
-i=1
-: >"$R/old.rs"
-while [ "$i" -le 40 ]; do
-  printf 'fn f%s() {}\n' "$i" >>"$R/old.rs"
-  i=$((i + 1))
-done
-git -C "$R" add -A
-git -C "$R" commit -qm seed
-# Moved AND edited: at 100% it does not pair, so it arrives as an addition
-# and is read whole. At any lower threshold it pairs as R, is dropped by
-# --diff-filter=AMT, and the marker below is never judged.
-git -C "$R" mv old.rs new.rs
-printf '// %s: added in the move\n' "$TD" >>"$R/new.rs"
-git -C "$R" add new.rs
-run_tb --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: new.rs:41:"*) true ;; *) false ;; esac \
-  && ok "a file that moved and gained a marker is read whole, at its new path" \
-  || bad "a moved-and-edited file is read whole" "rc=$RC out=$OUT"
-
-# The counterpart the same threshold buys: a pure move adds no line, so a
-# marker someone else committed does not become this commit's.
-new_repo renamepure
-printf '// %s: committed long ago\n' "$TD" >"$R/legacy.rs"
-git -C "$R" add -A
-git -C "$R" commit -qm seed
-git -C "$R" mv legacy.rs moved.rs
-run_tb --staged
-[ "$RC" -eq 0 ] && ok "a pure move of a committed marker adds no line, so it passes" \
-  || bad "a pure move passes" "rc=$RC out=$OUT"
-run_tb
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: moved.rs:1:"*) true ;; *) false ;; esac \
-  && ok "control: the index scan still refuses that marker at its new path" \
-  || bad "control: the index scan refuses the moved marker" "rc=$RC out=$OUT"
-
-echo "=== fail-closed: a broken staged scan terminates, never passes ==="
-new_repo stagedfail
-printf 'fn main() {}\n' >"$R/ok.rs"
-git -C "$R" add -A
-git -C "$R" commit -qm seed
-printf 'fn other() {}\n' >>"$R/ok.rs"
-git -C "$R" add ok.rs
-run_tb --staged
-[ "$RC" -eq 0 ] && ok "shim-free control: the fixture passes with the real git" \
-  || bad "shim-free control passes" "rc=$RC out=$OUT"
-
-# One shim per collection step, so each error path is proven on its own: the
-# change-set collection, then the per-file read of the added lines.
+echo "=== fail-closed: a collection step that cannot run is exit 2, never a pass and never a violation ==="
+# One shim per collection step, so each error path is proven on its own.
 REAL_GIT="$(command -v git)"
-make_diff_shim() { # DIR MATCH — a git whose `diff` fails when MATCH is in argv
+REAL_AWK="$(command -v awk)"
+diff_shim() { # DIR MATCH — a git whose `diff` fails when MATCH is in argv
   mkdir -p "$1"
   cat >"$1/git" <<EOF
 #!/usr/bin/env bash
@@ -563,43 +323,13 @@ exec "$REAL_GIT" "\$@"
 EOF
   chmod +x "$1/git"
 }
-
-make_diff_shim "$TMP/raw-shim" --raw
-OUT="$(cd "$R" && PATH="$TMP/raw-shim:$PATH" "$TB" --staged 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"could not collect the staged changes"*) true ;; *) false ;; esac \
-  && ok "a failed change-set collection is exit 2, never OK" \
-  || bad "failed change-set collection is exit 2" "rc=$RC out=$OUT"
-case "$OUT" in *"todo-ban: OK"*) bad "no OK verdict may accompany a broken collection" "$OUT" ;; *) ok "no OK verdict accompanies the broken collection" ;; esac
-
-# The per-file read is reached only for a path the index scan named, so this
-# case stages a marker to give the shim a file to fail on.
-printf '// %s: staged for the per-file read\n' "$TD" >>"$R/ok.rs"
-git -C "$R" add ok.rs
-make_diff_shim "$TMP/hunk-shim" -U0
-OUT="$(cd "$R" && PATH="$TMP/hunk-shim:$PATH" "$TB" --staged 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"could not read the staged additions in 'ok.rs'"*) true ;; *) false ;; esac \
-  && ok "a file whose added lines cannot be read is exit 2, naming it" \
-  || bad "unreadable added lines are exit 2" "rc=$RC out=$OUT"
-case "$OUT" in *"todo-ban: OK"*) bad "no OK verdict may accompany an unread file" "$OUT" ;; *) ok "no OK verdict accompanies the unread file" ;; esac
-
-echo "=== fail-closed: a hunk parser that cannot run is a collection error ==="
-new_repo hunkparse
-printf 'fn main() {}\n' >"$R/ok.rs"
-git -C "$R" add -A
-git -C "$R" commit -qm seed
-printf '// %s: staged for the parser to read\n' "$TD" >>"$R/ok.rs"
-git -C "$R" add ok.rs
-run_tb --staged
-[ "$RC" -eq 1 ] && ok "shim-free control: the staged marker fires with the real awk" \
-  || bad "shim-free control fires" "rc=$RC out=$OUT"
-
-# The shim exits 1 on purpose: 1 is this family's "violations", so a parser
-# status read as the lane's own would fold a measurement that never ran into
-# a violation verdict, with no line saying so.
-REAL_AWK="$(command -v awk)"
-AWK_SHIM="$TMP/awk-shim"
-mkdir -p "$AWK_SHIM"
-cat >"$AWK_SHIM/awk" <<EOF
+diff_shim "$TMP/raw-shim" --raw
+diff_shim "$TMP/hunk-shim" -U0
+# The awk shim exits 1 on purpose: 1 is this family's "violations", so a
+# parser status read as the lane's own would fold a measurement that never
+# ran into a violation verdict.
+mkdir -p "$TMP/awk-shim"
+cat >"$TMP/awk-shim/awk" <<EOF
 #!/usr/bin/env bash
 for a in "\$@"; do
   case "\$a" in
@@ -611,36 +341,31 @@ for a in "\$@"; do
 done
 exec "$REAL_AWK" "\$@"
 EOF
-chmod +x "$AWK_SHIM/awk"
-OUT="$(cd "$R" && PATH="$AWK_SHIM:$PATH" "$TB" --staged 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"could not parse the staged additions in 'ok.rs'"*) true ;; *) false ;; esac \
-  && ok "a hunk parser that fails is exit 2, naming the file" \
-  || bad "a failed hunk parser is exit 2" "rc=$RC out=$OUT"
-case "$OUT" in *"work marker:"*) bad "a scan that never ran may not produce a violation" "$OUT" ;; *) ok "and no violation verdict comes with it" ;; esac
-case "$OUT" in *"todo-ban: OK"*) bad "no OK verdict may accompany a broken parse" "$OUT" ;; *) ok "no OK verdict accompanies the broken parse" ;; esac
+chmod +x "$TMP/awk-shim/awk"
+fx_shim_clean() { seeded shim-clean; add ok.rs 'fn other() {}\n'; git -C "$R" add ok.rs; }
+fx_shim_raw() { seeded shim-raw; add ok.rs 'fn other() {}\n'; git -C "$R" add ok.rs; }
+# The per-file read and the parser are reached only for a path the
+# pre-filter named, so these stage a marker to give the shim a file to fail on.
+marked() { seeded "$1"; add ok.rs "// $TD: staged for the per-file read\n"; git -C "$R" add ok.rs; } # NAME
+fx_shim_control() { marked shim-control; }
+fx_shim_hunk() { marked shim-hunk; }
+fx_shim_awk() { marked shim-awk; }
+# The carriers pre-filter is chunked at 256 paths; a chunk that overwrote
+# its predecessors would drop the carrier named by a prior one and print
+# OK. This repository's render-propagation commits stage several hundred
+# files at a time.
+fx_chunked() { seeded chunked; put a000.rs "// $TD: in the first chunk\n"; local i=1; while [ "$i" -lt 300 ]; do put "$(printf 'a%03d' "$i").rs" "fn f$i() {}\n"; i=$((i + 1)); done; stage; }
+run_rows \
+  "shim-free control: the clean fixture passes with the real git|fx_shim_clean|||--staged|rc=0 $OK_STG" \
+  "a failed change-set collection is exit 2 carrying git's own line|fx_shim_raw|$TMP/raw-shim||--staged|rc=2 git diff: simulated execution failure;${ERR}could not collect the staged changes (git diff --cached --raw failed)" \
+  "shim-free control: the staged marker fires with the real tools|fx_shim_control|||--staged|rc=1 $(hit ok.rs 2 "// $TD: staged for the per-file read");$(stg 1)" \
+  "a file whose added lines cannot be read is exit 2, naming it|fx_shim_hunk|$TMP/hunk-shim||--staged|rc=2 git diff: simulated execution failure;${ERR}could not read the staged additions in 'ok.rs' (git diff exit 128)" \
+  "a hunk parser that fails is exit 2 naming the file, with no violation and no OK|fx_shim_awk|$TMP/awk-shim||--staged|rc=2 awk: simulated hunk-parser failure;${ERR}could not parse the staged additions in 'ok.rs' (awk exit 1)" \
+  "a marker in the first of 300 staged paths survives every later chunk|fx_chunked|||--staged|rc=1 $(hit a000.rs 1 "// $TD: in the first chunk");$(stg 1)"
 
-echo "=== the carriers pre-filter is chunked, and every chunk survives ==="
-# The chunk size is 256, so a change set larger than that is the only shape
-# that runs the loop more than once. A chunk that overwrites its
-# predecessors instead of appending drops the carrier named by a prior
-# one, and the lane prints OK: this repository's own render-propagation
-# commits stage several hundred files at a time, so the shape is routine.
-new_repo chunking
-printf 'fn main() {}\n' >"$R/seed.rs"
-git -C "$R" add -A
-git -C "$R" commit -qm seed
-printf '// %s: in the first chunk\n' "$TD" >"$R/a000.rs"
-i=1
-while [ "$i" -lt 300 ]; do
-  printf 'fn f%s() {}\n' "$i" >"$R/$(printf 'a%03d' "$i").rs"
-  i=$((i + 1))
-done
-git -C "$R" add -A
-run_tb --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: a000.rs:1:"*) true ;; *) false ;; esac \
-  && ok "a marker in the first of 300 staged paths survives every later chunk" \
-  || bad "the first chunk's carrier survives" "rc=$RC out=$OUT"
-case "$OUT" in *"todo-ban: OK"*) bad "no OK verdict may accompany a chunked carrier" "$OUT" ;; *) ok "no OK verdict accompanies the chunked scan" ;; esac
+echo "=== the usage is answered ==="
+repo help
+assert_eq "--help prints the usage and exits 0" "rc=0 usage: todo-ban [--staged] [--excludes FILE]" "$(run "" "" --help | cut -d';' -f1)"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Reshapes `skills/commit-guards/tests/todo-ban.test.sh` to code-quality § Tests. It pinned the work-marker ban in one 646-line linear script: 70 assertions over about 20 long-lived fixtures, most an exit status read as a bit beside a substring of one line (`*"work marker: ok.rs:3:"*`, `*"todo-ban: OK"*`), with the negative pins (the untouched fixture absent from the staged verdict, no OK beside a broken collection or parse, no violation from a parser that never ran, no `:0:` header record, the clean line beside a marker not judged, the sibling render silent under a carve) folded into their neighbours. It is now one table of 70 rows plus the `--help` and `-h` controls: a row builds its own repository, stages what it means, runs the check once under its settings and reads back the exit status with every line printed, so the verdict, the file and line it names, the quoted line, the remedy and the summary are one pin, and every old negative pin is a property of the exact line. The expected lines are built by small functions from what the row put in (`hit PATH LINE CONTENT [EXCLUDES]`, `idx`, `stg`, `remedy`). Marker words stay assembled from split tokens, since the repository runs todo-ban over its own tree.

Every former assertion has a row; none were deleted. Reshaped: the two fixture checks (the attributes rule suppresses the unforced diff; git calls the late-NUL blob text) are guards inside the fixture functions that abort the suite with a harness line, since they prove the fixture and not the check; the index readers this family shares (the carriers pre-filter, the content sniff, the blob read, the index lane's `-diff` and unmeasured-carrier rows) stay pinned in lane-readers.test.sh and index-reads.test.sh, which drive them through this check, and this suite keeps the staged-lane versions only. New rows for surfaces the old suite never reached: the four marker words in one file with every hit numbered, the semicolon and HTML-comment leaders, a second hunk numbered from its own header, `--excludes=PATH` and the bare `--excludes`, a staged symlink and gitlink, an unmerged index under `--staged`, a lowercase addition to a marker-carrying file (the seed is what makes the per-file grep run at all), and `--help`.

The second commit is the reviewer's round: a commit that only removes a marker (no control; a parser reading every hunk line as an addition shipped green and refused exactly the commit the remedy asks for), the four-words row reshaped so each line reaches one arm of the marker expression alone (a word dropped from either arm survived), and a shim for the per-file scan's status guard, the fourth collection step. Beside them: the unmeasured qualifier on a violation verdict in each lane, the loader's comment and blank rows and its empty-pattern refusal, the `-h` alias, and the harness refusing a row short of six fields.

The tracked render is replayed with `patch`. A `kendex refresh` in the main checkout at fe4a0bb82 left `.kendex-generated.json` unchanged, so nothing is owed.

## Mutation

42 exact-substring mutants over the check, the staged-lines parser and the exclusion loader (the marker set, the leaders, the whitespace boundary before a leader and before the annotated word, case-insensitive scans on both lanes, rename detection at 50%, the exclusion skip, the sniff, the hit's line number, the count, the exit status, the unmeasured qualifier, chunk overwrite, the unmerged-index refusal, the source sha read for the destination, both `--excludes` arms, the remedy naming the default list, the file header not closing a hunk, numbering from the old side, `--text` dropped, a failed diff or parser read as no additions, the no-tab row, the bare `!` row, a carve that never carves, the `!` arm as a literal, and after the review: a word dropped from each arm, the block-comment opener as a leader, the grep guard removed and widened, both qualifiers dropped, `-h`, every hunk line as an addition, the loader's comment arm, an empty pattern, the last row's newline): 40 killed by a named row. The two alive: the `120000 | 160000` arm of the staged walk is unreachable in both halves (git grep never lists a symlink or a gitlink, so the pre-filter drops them before the arm; the two rows stay as the verdicts), and the loader's read of a last row without a newline is behind a here-string that supplies one. Ten fixture mutants: nine fail their row; the type-change fixture without its symlink step passes the same, as its drift is load-bearing against the header production mutant (killed), not against the row's value. The reviewer's 64 production and 13 fixture mutants: 47 killed before the second commit, the 17 alive each a blocker above, a suggestion taken, an equivalent (`:(literal)` pathspecs, `--no-abbrev`, the chunk size, the context rule under `-U0`, the header `+` strip, `--no-textconv`), a shared reader pinned by lane-readers or index-reads, or a tab-in-path split no fixture here carries.

## Checks

- `todo-ban.test.sh`: 72 assertions pass on this host and under a symlinked TMPDIR. `lane-readers.test.sh` 35/35, `index-reads.test.sh` 17/17, `pre-commit-chain.test.sh` 41/41; all 35 commit-guards suites green inside the guard run. `tools/bash32-lint` clean over 38 files. The check itself passes over the worktree with the suite staged.
- `tools/guard --full`: exit 0 on both commits (`TMPDIR=/tmp`).
- One reviewer-test round: fix-first with three blockers and the suggestions above, all applied in the second commit; judgements 1 to 6 confirmed, judgement 4 widened to both halves of the mode arm as the reviewer showed.

KEN-1241

https://claude.ai/code/session_01EXcTQUz7oysbpcbTPuu5R4
