### PR TITLE
test(KEN-1241): the md-refs suite as two tables of rows

### DIFF
--- a/.agents/skills/commit-guards/tests/md-refs.test.sh
+++ b/.agents/skills/commit-guards/tests/md-refs.test.sh
@@ -1,426 +1,360 @@
 #!/usr/bin/env bash
-# Pins for scripts/md-refs: a relative link lands on a tracked path and a
-# heading it has; a code-span citation names a tracked file and a heading
-# it has; a decision ID names a tracked decision file, judged only where the
-# decisions directory is tracked, and its heading where the citation names
-# one; the same section citation is judged in a source file's comment text
-# and a TOML file's string literals; fenced code is never read; the scopes and
-# the path list are md-format's. Every green assertion is paired with a
-# control that proves it can fail.
+# Pins for scripts/md-refs, the judge of what a document cites: a relative
+# link lands on a tracked path and a heading it has; a code-span citation
+# names a tracked file and a heading it has; a link followed by § starts with
+# a heading of its target; a decision ID names a tracked decision file, judged
+# only where the decisions directory is tracked; the same section citation is
+# judged in a source file's comment text and a TOML file's string literals;
+# fenced code is never read; the scopes and the path list are md-format's.
+# Two tables: the first holds what one document cites over a seeded world,
+# the second the walk, the scopes and the source carriers. A row runs the
+# judge once and reads back the exit status with every line printed, so the
+# verdict, the file and line it names, the reference it quotes, the count it
+# judged, the remedy and the summary are one pin.
 set -euo pipefail
-
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 MDR="$SKILL_DIR/scripts/md-refs"
+# shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
-
-unset COMMIT_GUARDS_MD_REFS_PATHS COMMIT_GUARDS_MD_REFS_SOURCE_PATHS COMMIT_GUARDS_MD_EXCLUDES COMMIT_GUARDS_MD_SCOPE COMMIT_GUARDS_SETTINGS_FILE \
+# Hermetic: a leaked setting would mask every row below.
+unset COMMIT_GUARDS_MD_REFS_PATHS COMMIT_GUARDS_MD_REFS_SOURCE_PATHS COMMIT_GUARDS_MD_EXCLUDES \
+  COMMIT_GUARDS_MD_SCOPE COMMIT_GUARDS_SETTINGS_FILE \
   DECISIONS_DIR DECISION_ID_PREFIX DECISION_ID_WIDTH 2>/dev/null || true
 
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
 
-new_repo() { # NAME
+# One line for a run in the row's repository: the exit status, then every
+# line printed, in order, joined by ';'. ENVS is a comma-separated list of
+# assignments; ARGS are passed through.
+R=""
+run() { # ENVS ARGS
+  local envs=() rc=0 out=""
+  [ -z "$1" ] || IFS=',' read -ra envs <<<"$1"
+  # shellcheck disable=SC2086
+  out="$(cd "$R" && env ${envs[@]+"${envs[@]}"} "$MDR" $2 2>&1)" || rc=$?
+  printf 'rc=%s%s' "$rc" "${out:+ $(printf '%s\n' "$out" | LC_ALL=C paste -sd ';' -)}"
+}
+
+# Fixture vocabulary. Every fixture builds its own repository and stages
+# what it wrote; a name used twice is refused.
+repo() { # NAME
   R="$TMP/$1"
+  [ ! -e "$R" ] || { echo "harness: fixture $1 already exists" >&2; exit 2; }
   mkdir -p "$R"
   git -C "$R" -c init.defaultBranch=main init -q
   git -C "$R" config user.email test@example.com
   git -C "$R" config user.name test
 }
+put() { mkdir -p "$R/$(dirname "$1")"; printf '%b' "$2" >"$R/$1"; git -C "$R" add -A; } # PATH CONTENT (printf %b), staged
+commit() { git -C "$R" commit -qm "$1"; }
 
-run_refs() { # [args...] — run in $R; sets OUT and RC
-  OUT=""
-  RC=0
-  OUT="$(cd "$R" && "$MDR" "$@" 2>&1)" || RC=$?
+# The seeded worlds a citing document is judged in. Each names what the
+# default path list reads beside AGENTS.md: three tracked markdown files in
+# `refs` (docs/guide.md is outside the list), one in the guide worlds.
+world_refs() {
+  repo "$1"
+  put docs/architecture/overview.md '# Overview\n\n## The one idea\n\n## The one idea\n\n## Fish & Chips (v2) `code`\n\n<a id="explicit"></a>\n\nText.\n'
+  put docs/guide.md '# Guide\n'
+  put skills/x/SKILL.md '# X\n'
+  put pic.png 'not really'
 }
+world_dec() { world_refs "$1"; put docs/decisions/D001-first.md '# D001\n\n## Context\n'; put docs/decisions/INDEX.md '| D001 |\n'; }
+world_adr() { world_dec "$1"; put docs/decisions/ADR-0007-x.md '# ADR-0007\n'; }
+world_install() { repo "$1"; put guide.md '# Guide\n\n## Install\n'; }
+world_numbered() { repo "$1"; put guide.md '# Guide\n\n## 1. Install\n\n### 1.1.1 Choose a path\n'; }
+world_parens() { repo "$1"; put guide.md '# Guide\n\n## 1\n\n## Install\n'; put 'guide(foo).md' '# Guide\n\n## Install\n'; }
+world_text() { repo "$1"; put guide.md '# Guide\n\n## snake_case\n\n## Install\n\n## 2.\n\n## 3)\n\n## 4.1.\n\n## Use *tools*\n'; }
+world_code() { repo "$1"; put guide.md '# Guide\n\n## `snake_case`\n'; }
+# The source-carrier world: two documents to cite into, no source file yet.
+world_src() { repo "$1"; put docs/architecture/plugins.md '# Plugins\n\n## Invariants\n'; put AGENTS.md '# A\n\n## Rules\n'; }
+world_src_dec() { world_src "$1"; put docs/decisions/D008-scope.md '# D008\n\n## Scope\n'; }
 
-put() { # PATH CONTENT — a tracked file, staged
-  mkdir -p "$R/$(dirname "$1")"
-  printf '%s' "$2" >"$R/$1"
-  git -C "$R" add -A
+# The lines the judge prints, as functions of what a row put in.
+REMEDY="  remedies: point the reference at a tracked file, a heading it has, or a recorded decision, or delete it"
+ERR="::error::md-refs: "
+DEC_NO="decision IDs not judged (docs/decisions is not tracked)"
+DEC_YES="decision IDs judged against docs/decisions"
+PATHS_DEFAULT="AGENTS.md */AGENTS.md CLAUDE.md */CLAUDE.md SKILL.md */SKILL.md workflows/*.md */workflows/*.md agents/*.md */agents/*.md docs/architecture/*.md"
+NOTHING_STAGED="md-refs: OK — nothing staged to judge (COMMIT_GUARDS_MD_SCOPE=touched judges the files a commit touches); run with --all, or set COMMIT_GUARDS_MD_SCOPE=all once this repository's markdown is reflowed"
+dead() { printf 'md-refs FAIL dead reference: %s:%s: %s;%s' "$1" "$2" "$3" "$REMEDY"; } # PATH LINE MESSAGE
+skip() { printf 'md-refs: not measured: %s — %s' "$1" "$2"; } # PATH REASON
+unmeasured() { printf '; %s matched path(s) not measured' "$1"; } # N
+clean() { printf 'md-refs: OK — %s reference(s) resolve in %s tracked markdown file(s) and %s source file(s); %s%s' "$1" "$2" "${3:-0}" "${4:-$DEC_NO}" "${5-}"; } # JUDGED MD [SRC] [DEC-NOTE] [UNMEASURED]
+failed() { printf 'md-refs: %s dead reference(s) among %s in %s tracked markdown file(s) and %s source file(s); %s%s' "$1" "$2" "$3" "${4:-0}" "${5:-$DEC_NO}" "${6-}"; } # DEAD JUDGED MD [SRC] [DEC-NOTE] [UNMEASURED]
+# A verdict naming no measurable file echoes both settings' values.
+nomatch() { printf 'md-refs: OK — no tracked markdown file(s) to judge (COMMIT_GUARDS_MD_REFS_PATHS %s; COMMIT_GUARDS_MD_REFS_SOURCE_PATHS %s)' "$1" "$2"; } # MD-GLOBS SRC-GLOBS
+# The messages a reference dies with, each taking the quoted reference.
+untracked() { printf '%s: no tracked file or directory at %s' "$1" "$2"; } # RAW TARGET
+noslug() { printf '%s: %s has no heading or explicit anchor #%s' "$1" "$2" "$3"; } # RAW TARGET ANCHOR
+notext() { printf '`%s`: %s has no heading '"'"'%s'"'" "$1" "$2" "$3"; } # SPAN TARGET HEADING
+nocite() { printf '`%s`: no tracked file at %s beside %s or at the repository root' "$1" "$2" "$3"; } # SPAN PATH SRC
+noprefix() { printf '%s: %s has no heading at the start of '"'"'%s'"'" "$1" "$2" "$3"; } # RAW TARGET VALUE
+climbs() { printf '%s: the link climbs above the repository root' "$1"; } # RAW
+nodecision() { printf '%s: no tracked decision file docs/decisions/%s-*.md' "$1" "$1"; } # ID
+
+# Table one: AGENTS.md holds CONTENT in WORLD, judged with --all under ENVS.
+ROW=0
+cite_rows() { # label | world | envs | content | expect
+  local row label world envs content expect
+  for row in "$@"; do
+    IFS='|' read -r label world envs content expect <<<"$row"
+    ROW=$((ROW + 1))
+    R=""
+    "world_$world" "$world-$ROW"
+    put AGENTS.md "$content"
+    assert_eq "$label" "$expect" "$(run "$envs" --all)"
+  done
 }
-
-# AGENTS.md holds CONTENT; assert the --all verdict, and on a dead reference
-# the line and message fragment named.
-cite() { # LABEL EXPECT-RC CONTENT [LINE MESSAGE-FRAGMENT]
-  local label="$1" want="$2" content="$3" line="${4-}" msg="${5-}"
-  put AGENTS.md "$content"
-  run_refs --all
-  if [ "$RC" -ne "$want" ]; then
-    bad "$label" "rc=$RC want=$want out=$OUT"
-    return
-  fi
-  if [ "$want" -eq 1 ]; then
-    case "$OUT" in
-      *"dead reference: AGENTS.md:$line: "*"$msg"*) ok "$label" ;;
-      *) bad "$label" "expected AGENTS.md:$line: ...$msg in: $OUT" ;;
-    esac
-  else
-    ok "$label"
-  fi
-}
-
-new_repo refs
-put docs/architecture/overview.md $'# Overview\n\n## The one idea\n\n## The one idea\n\n## Fish & Chips (v2) `code`\n\n<a id="explicit"></a>\n\nText.\n'
-put docs/guide.md $'# Guide\n'
-put skills/x/SKILL.md $'# X\n'
-put pic.png 'not really'
 
 echo "=== links: a tracked path, a heading slug, an explicit anchor ==="
-cite "links to a tracked file, a directory and a heading resolve" 0 \
-  $'[a](docs/guide.md) [b](docs/) [c](skills/x/SKILL.md) [d](docs/architecture/overview.md#the-one-idea) [e](pic.png)\n'
-case "$OUT" in *"5 reference(s) resolve in 3 tracked markdown file(s)"*) ok "the verdict counts the references it judged" ;; *) bad "verdict counts references" "$OUT" ;; esac
-cite "a link to an untracked file fails" 1 $'[a](docs/nope.md)\n' 1 "no tracked file or directory at docs/nope.md"
-cite "a link to a heading the target has not got fails" 1 $'[a](docs/guide.md#nothing)\n' 1 "docs/guide.md has no heading or explicit anchor #nothing"
-cite "a duplicate heading takes the -1 suffix" 0 $'[a](docs/architecture/overview.md#the-one-idea-1)\n'
-cite "control: the -2 suffix names no heading" 1 $'[a](docs/architecture/overview.md#the-one-idea-2)\n' 1 "no heading or explicit anchor #the-one-idea-2"
-cite "punctuation is dropped, spaces become hyphens, code text stays" 0 $'[a](docs/architecture/overview.md#fish--chips-v2-code)\n'
-cite "an explicit <a id> is an anchor" 0 $'[a](docs/architecture/overview.md#explicit)\n'
-cite "a non-ASCII letter keeps its case in the slug and in the § comparison" 0 \
-  $'## Über Ünïcode\n\n[v](#Über-Ünïcode) `AGENTS.md § Über Ünïcode`\n'
-cite "control: the lower-cased spelling of that slug is dead" 1 $'## Über Ünïcode\n\n[u](#über-ünïcode)\n' 3 "has no heading or explicit anchor #über-ünïcode"
-cite "control: and so is the lower-cased § citation" 1 $'## Über Ünïcode\n\n`AGENTS.md § über ünïcode`\n' 3 "has no heading 'über ünïcode'"
-cite "a bare #anchor resolves in the citing file" 0 $'# Map\n\n[here](#map)\n'
-cite "control: a bare #anchor with no such heading fails" 1 $'# Map\n\n[gone](#gone)\n' 3 "AGENTS.md has no heading or explicit anchor #gone"
-cite "a link climbing above the root fails" 1 $'[a](../etc/passwd)\n' 1 "climbs above the repository root"
-cite "a bare #anchor after a climbing link is judged on its own" 1 $'# Root\n\n[a](../x.md) [b](#root)\n' 3 "](../x.md): the link climbs above the repository root"
-case "$OUT" in *"](#root)"*) bad "the bare anchor beside the climbing link lands" "$OUT" ;; *"1 dead reference(s)"*) ok "the bare anchor beside the climbing link lands" ;; *) bad "the bare anchor beside the climbing link lands" "$OUT" ;; esac
-cite "control: a dead bare #anchor after a climbing link is named for what it is" 1 $'# Root\n\n[a](../x.md) [b](#gone)\n' 3 "](#gone): AGENTS.md has no heading or explicit anchor #gone"
-cite "an anchor into a file that is not markdown fails" 1 $'[a](pic.png#view)\n' 1 "an anchor into a file that is not markdown"
-cite "a scheme, a mailto and a leading slash are not judged" 0 $'[a](https://x/y.md#z) [b](mailto:x@y.z) [c](/abs/nope.md)\n'
-cite "a reference definition is judged" 1 $'[label]: docs/nope.md\n' 1 "no tracked file or directory at docs/nope.md"
-cite "a link in fenced code is not read" 0 $'```\n[a](docs/nope.md)\n```\n'
-cite "control: the same link outside the fence fails" 1 $'[a](docs/nope.md)\n\n```\n[b](docs/nope.md)\n```\n' 1 "docs/nope.md"
-cite "a link in an indented code block is not read" 0 $'Para\n\n    [a](docs/nope.md)\n'
-
-echo "=== links resolve relative to the citing file ==="
-put docs/architecture/topic.md $'[up](../guide.md) [sib](overview.md#the-one-idea) [down](../../skills/x/SKILL.md)\n'
-cite "a nested file's relative links resolve from its own directory" 0 $'Clean.\n'
-put docs/architecture/topic.md $'[wrong](guide.md)\n'
-run_refs --all
-[ "$RC" -eq 1 ] && case "$OUT" in *"docs/architecture/topic.md:1: "*"no tracked file or directory at docs/architecture/guide.md"*) true ;; *) false ;; esac \
-  && ok "control: a root-relative spelling from a nested file fails, naming where it looked" || bad "control: nested relative link" "rc=$RC out=$OUT"
-git -C "$R" rm -qf docs/architecture/topic.md
+cite_rows \
+  "links to a tracked file, a directory, a heading and a non-markdown file resolve, and the verdict counts them|refs||[a](docs/guide.md) [b](docs/) [c](skills/x/SKILL.md) [d](docs/architecture/overview.md#the-one-idea) [e](pic.png)\n|rc=0 $(clean 5 3)" \
+  "a link to an untracked file fails, quoting the link and naming where it looked|refs||[a](docs/nope.md)\n|rc=1 $(dead AGENTS.md 1 "$(untracked '](docs/nope.md)' docs/nope.md)");$(failed 1 1 3)" \
+  "a link to a heading the target has not got fails|refs||[a](docs/guide.md#nothing)\n|rc=1 $(dead AGENTS.md 1 "$(noslug '](docs/guide.md#nothing)' docs/guide.md nothing)");$(failed 1 1 3)" \
+  "a duplicate heading takes the -1 suffix|refs||[a](docs/architecture/overview.md#the-one-idea-1)\n|rc=0 $(clean 1 3)" \
+  "control: the -2 suffix names no heading|refs||[a](docs/architecture/overview.md#the-one-idea-2)\n|rc=1 $(dead AGENTS.md 1 "$(noslug '](docs/architecture/overview.md#the-one-idea-2)' docs/architecture/overview.md the-one-idea-2)");$(failed 1 1 3)" \
+  "punctuation is dropped, spaces become hyphens, code text stays|refs||[a](docs/architecture/overview.md#fish--chips-v2-code)\n|rc=0 $(clean 1 3)" \
+  "an explicit <a id> is an anchor|refs||[a](docs/architecture/overview.md#explicit)\n|rc=0 $(clean 1 3)" \
+  "a non-ASCII letter keeps its case in the slug and in the § comparison|refs||## Über Ünïcode\n\n[v](#Über-Ünïcode) \`AGENTS.md § Über Ünïcode\`\n|rc=0 $(clean 2 3)" \
+  "control: the lower-cased spelling of that slug is dead|refs||## Über Ünïcode\n\n[u](#über-ünïcode)\n|rc=1 $(dead AGENTS.md 3 "$(noslug '](#über-ünïcode)' AGENTS.md über-ünïcode)");$(failed 1 1 3)" \
+  "control: and so is the lower-cased § citation|refs||## Über Ünïcode\n\n\`AGENTS.md § über ünïcode\`\n|rc=1 $(dead AGENTS.md 3 "$(notext 'AGENTS.md § über ünïcode' AGENTS.md 'über ünïcode')");$(failed 1 1 3)" \
+  "a bare #anchor resolves in the citing file|refs||# Map\n\n[here](#map)\n|rc=0 $(clean 1 3)" \
+  "control: a bare #anchor with no such heading fails|refs||# Map\n\n[gone](#gone)\n|rc=1 $(dead AGENTS.md 3 "$(noslug '](#gone)' AGENTS.md gone)");$(failed 1 1 3)" \
+  "a link climbing above the root fails|refs||[a](../etc/passwd)\n|rc=1 $(dead AGENTS.md 1 "$(climbs '](../etc/passwd)')");$(failed 1 1 3)" \
+  "a bare #anchor after a climbing link is judged on its own and lands|refs||# Root\n\n[a](../x.md) [b](#root)\n|rc=1 $(dead AGENTS.md 3 "$(climbs '](../x.md)')");$(failed 1 2 3)" \
+  "control: a dead bare #anchor after a climbing link is named for what it is|refs||# Root\n\n[a](../x.md) [b](#gone)\n|rc=1 $(dead AGENTS.md 3 "$(climbs '](../x.md)')");$(dead AGENTS.md 3 "$(noslug '](#gone)' AGENTS.md gone)");$(failed 2 2 3)" \
+  "an anchor into a file that is not markdown fails|refs||[a](pic.png#view)\n|rc=1 $(dead AGENTS.md 1 '](pic.png#view): an anchor into a file that is not markdown');$(failed 1 1 3)" \
+  "a scheme, a mailto and a leading slash are not judged|refs||[a](https://x/y.md#z) [b](mailto:x@y.z) [c](/abs/nope.md)\n|rc=0 $(clean 0 3)" \
+  "a reference definition is judged, quoted whole|refs||[label]: docs/nope.md\n|rc=1 $(dead AGENTS.md 1 "$(untracked '[label]: docs/nope.md' docs/nope.md)");$(failed 1 1 3)" \
+  "a link in fenced code is not read|refs||\`\`\`\n[a](docs/nope.md)\n\`\`\`\n|rc=0 $(clean 0 3)" \
+  "control: the same link outside the fence fails, and only it|refs||[a](docs/nope.md)\n\n\`\`\`\n[b](docs/nope.md)\n\`\`\`\n|rc=1 $(dead AGENTS.md 1 "$(untracked '](docs/nope.md)' docs/nope.md)");$(failed 1 1 3)" \
+  "a link in an indented code block is not read|refs||Para\n\n    [a](docs/nope.md)\n|rc=0 $(clean 0 3)"
 
 echo "=== code-span citations: path, § heading, #anchor ==="
-cite "a path alone in a code span is a name, not a citation" 0 $'See `docs/nope.md` and `tmp/out.md`.\n'
-cite "control: the same path with a heading is a citation" 1 $'See `docs/nope.md § Top`.\n' 1 "no tracked file at docs/nope.md"
-cite "a bracketed template line holding [X]: [Y] is not a definition" 0 $'   [For each item: "- [ID]: [SUMMARY] and [PATH]"]\n'
-cite "a bare file name in a code span is a name, not a citation" 0 $'The record is `CHANGELOG.md`; see `nope.md`.\n'
-cite "control: the same bare name with a heading is a citation" 1 $'See `nope.md § Top`.\n' 1 "no tracked file at nope.md"
-cite "a § citation matches a heading case-insensitively" 0 $'See `docs/architecture/overview.md § the ONE idea`.\n'
-cite "control: a § citation naming no heading fails" 1 $'See `docs/architecture/overview.md § Nope`.\n' 1 "has no heading 'Nope'"
-cite "a #anchor citation matches a slug" 0 $'See `docs/architecture/overview.md#fish--chips-v2-code`.\n'
-cite "control: a #anchor citation naming no slug fails" 1 $'See `docs/architecture/overview.md#nope`.\n' 1 "no heading or explicit anchor #nope"
-cite "a root-relative citation resolves at the root" 0 $'See `docs/guide.md § Guide`.\n'
-put docs/architecture/topic.md $'See `overview.md § The one idea` and `docs/guide.md`.\n'
-cite "a nested file's citation resolves beside it, and a root path still resolves" 0 $'Clean.\n'
-git -C "$R" rm -qf docs/architecture/topic.md
-cite "a code span that is not a path shape is not a citation" 0 $'Run `md-format --all`, see `*.md`, `changelog.d/<section>/<name>.md`, `foo.md:12`.\n'
-cite "a citation in a fence is not read" 0 $'```\n`docs/nope.md § X`\n```\n'
+cite_rows \
+  "a path alone in a code span is a name, not a citation|refs||See \`docs/nope.md\` and \`tmp/out.md\`.\n|rc=0 $(clean 0 3)" \
+  "control: the same path with a heading is a citation|refs||See \`docs/nope.md § Top\`.\n|rc=1 $(dead AGENTS.md 1 "$(nocite 'docs/nope.md § Top' docs/nope.md AGENTS.md)");$(failed 1 1 3)" \
+  "a bracketed template line holding [X]: [Y] is not a definition|refs||   [For each item: \"- [ID]: [SUMMARY] and [PATH]\"]\n|rc=0 $(clean 0 3)" \
+  "a bare file name in a code span is a name, not a citation|refs||The record is \`CHANGELOG.md\`; see \`nope.md\`.\n|rc=0 $(clean 0 3)" \
+  "control: the same bare name with a heading is a citation|refs||See \`nope.md § Top\`.\n|rc=1 $(dead AGENTS.md 1 "$(nocite 'nope.md § Top' nope.md AGENTS.md)");$(failed 1 1 3)" \
+  "a § citation matches a heading case-insensitively|refs||See \`docs/architecture/overview.md § the ONE idea\`.\n|rc=0 $(clean 1 3)" \
+  "control: a § citation naming no heading fails|refs||See \`docs/architecture/overview.md § Nope\`.\n|rc=1 $(dead AGENTS.md 1 "$(notext 'docs/architecture/overview.md § Nope' docs/architecture/overview.md Nope)");$(failed 1 1 3)" \
+  "a #anchor citation matches a slug|refs||See \`docs/architecture/overview.md#fish--chips-v2-code\`.\n|rc=0 $(clean 1 3)" \
+  "control: a #anchor citation naming no slug fails|refs||See \`docs/architecture/overview.md#nope\`.\n|rc=1 $(dead AGENTS.md 1 "\`docs/architecture/overview.md#nope\`: docs/architecture/overview.md has no heading or explicit anchor #nope");$(failed 1 1 3)" \
+  "a root-relative citation resolves at the root|refs||See \`docs/guide.md § Guide\`.\n|rc=0 $(clean 1 3)" \
+  "a code span that is not a path shape is not a citation|refs||Run \`md-format --all\`, see \`*.md\`, \`changelog.d/<section>/<name>.md\`, \`foo.md:12\`.\n|rc=0 $(clean 0 3)" \
+  "a citation in a fence is not read|refs||\`\`\`\n\`docs/nope.md § X\`\n\`\`\`\n|rc=0 $(clean 0 3)"
 
 echo "=== decision IDs: judged only where the decisions directory is tracked ==="
-cite "with no tracked decisions directory, an ID is not judged and the verdict says so" 0 $'Decided in D042.\n'
-case "$OUT" in *"decision IDs not judged (docs/decisions is not tracked)"*) ok "the verdict names the untracked directory" ;; *) bad "verdict names untracked dir" "$OUT" ;; esac
-put docs/decisions/D001-first.md $'# D001\n\n## Context\n'
-put docs/decisions/INDEX.md $'| D001 |\n'
-cite "a cited ID with a tracked file passes, in prose and in a code span" 0 $'Decided in D001; see `D001 § Context`.\n'
-case "$OUT" in *"decision IDs judged against docs/decisions"*) ok "the verdict names the directory judged against" ;; *) bad "verdict names judged dir" "$OUT" ;; esac
-cite "an ID citing a heading its decision does not have fails" 1 $'See `D001 § Rationale`.\n' 1 "docs/decisions/D001-first.md has no heading at the start of 'Rationale"
-cite "a cited ID with no tracked file fails" 1 $'Decided in D042.\n' 1 "D042: no tracked decision file docs/decisions/D042-*.md"
-cite "a shorter digit run, a glued letter and a colour are not IDs" 0 $'D42, MD001, D001x, #001 and 3D001 are not decisions.\n'
-cite "an ID in fenced code is not read" 0 $'```\nD042\n```\n'
-OUT="$(cd "$R" && DECISION_ID_PREFIX=ADR- DECISION_ID_WIDTH=4 "$MDR" --all 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && ok "under another scheme the D-prefixed text is not an ID" || bad "other scheme ignores D ids" "rc=$RC out=$OUT"
-put AGENTS.md $'Decided in ADR-0007.\n'
-OUT="$(cd "$R" && DECISION_ID_PREFIX=ADR- DECISION_ID_WIDTH=4 "$MDR" --all 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 1 ] && case "$OUT" in *"ADR-0007: no tracked decision file"*) true ;; *) false ;; esac \
-  && ok "DECISION_ID_PREFIX and DECISION_ID_WIDTH select the scheme" || bad "scheme settings" "rc=$RC out=$OUT"
-put docs/decisions/ADR-0007-x.md $'# ADR-0007\n'
-OUT="$(cd "$R" && DECISION_ID_PREFIX=ADR- DECISION_ID_WIDTH=4 "$MDR" --all 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && ok "control: the same ID passes once its file is tracked" || bad "control: ADR file tracked" "rc=$RC out=$OUT"
-put AGENTS.md $'Decided in D001.\n'
-OUT="$(cd "$R" && DECISIONS_DIR=elsewhere "$MDR" --all 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && case "$OUT" in *"not judged (elsewhere is not tracked)"*) true ;; *) false ;; esac \
-  && ok "DECISIONS_DIR moves the directory" || bad "DECISIONS_DIR" "rc=$RC out=$OUT"
-OUT="$(cd "$R" && DECISION_ID_WIDTH=0 "$MDR" --all 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && ok "a zero width is exit 2" || bad "zero width is exit 2" "rc=$RC out=$OUT"
-
-echo "=== the path list: agent-loaded markdown and architecture docs ==="
-new_repo scope
-put ok.md $'# OK\n'
-for f in AGENTS.md CLAUDE.md SKILL.md skills/dev/SKILL.md skills/dev/AGENTS.md workflows/ship.md skills/dev/workflows/ship.md agents/rust.md .claude/agents/rust.md docs/architecture/overview.md; do
-  put "$f" $'[dead](nope.md)\n'
-  run_refs --all
-  [ "$RC" -eq 1 ] && case "$OUT" in *"dead reference: $f:1:"*) true ;; *) false ;; esac \
-    && ok "$f is in the default scope" || bad "$f is in the default scope" "rc=$RC out=$OUT"
-  put "$f" $'# Top\n\n[live](#top)\n'
-done
-for f in README.md docs/design.md skills/dev/references/api.md; do
-  put "$f" $'[dead](nope.md)\n'
-done
-run_refs --all
-[ "$RC" -eq 0 ] && case "$OUT" in *"10 tracked markdown file(s)"*) true ;; *) false ;; esac \
-  && ok "a README, a doc outside docs/architecture and a reference file are not judged, with the ten scoped files still read" \
-  || bad "out-of-scope files not judged" "rc=$RC out=$OUT"
-OUT="$(cd "$R" && COMMIT_GUARDS_MD_REFS_PATHS='docs/*.md' "$MDR" --all 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 1 ] && case "$OUT" in *"AGENTS.md:1:"*) false ;; *"docs/design.md:1:"*) true ;; *) false ;; esac \
-  && ok "COMMIT_GUARDS_MD_REFS_PATHS replaces the list" || bad "path list replaces" "rc=$RC out=$OUT"
+cite_rows \
+  "with no tracked decisions directory, an ID is not judged and the verdict says so|refs||Decided in D042.\n|rc=0 $(clean 0 3)" \
+  "a cited ID with a tracked file passes, in prose and in a code span, and the verdict names the directory|dec||Decided in D001; see \`D001 § Context\`.\n|rc=0 $(clean 2 3 0 "$DEC_YES")" \
+  "an ID citing a heading its decision does not have fails, the heading read to the end of the line|dec||See \`D001 § Rationale\`.\n|rc=1 $(dead AGENTS.md 1 "$(noprefix 'D001 § Rationale`.' docs/decisions/D001-first.md 'Rationale`.')");$(failed 1 1 3 0 "$DEC_YES")" \
+  "a cited ID with no tracked file fails|dec||Decided in D042.\n|rc=1 $(dead AGENTS.md 1 "$(nodecision D042)");$(failed 1 1 3 0 "$DEC_YES")" \
+  "a shorter digit run, a glued letter and a colour are not IDs|dec||D42, MD001, D001x, #001 and 3D001 are not decisions.\n|rc=0 $(clean 0 3 0 "$DEC_YES")" \
+  "an ID in fenced code is not read|dec||\`\`\`\nD042\n\`\`\`\n|rc=0 $(clean 0 3 0 "$DEC_YES")" \
+  "under another scheme the D-prefixed text is not an ID|dec|DECISION_ID_PREFIX=ADR-,DECISION_ID_WIDTH=4|Decided in D042.\n|rc=0 $(clean 0 3 0 "$DEC_YES")" \
+  "DECISION_ID_PREFIX and DECISION_ID_WIDTH select the scheme|dec|DECISION_ID_PREFIX=ADR-,DECISION_ID_WIDTH=4|Decided in ADR-0007.\n|rc=1 $(dead AGENTS.md 1 "$(nodecision ADR-0007)");$(failed 1 1 3 0 "$DEC_YES")" \
+  "control: the same ID passes once its file is tracked|adr|DECISION_ID_PREFIX=ADR-,DECISION_ID_WIDTH=4|Decided in ADR-0007.\n|rc=0 $(clean 1 3 0 "$DEC_YES")" \
+  "DECISIONS_DIR moves the directory, and the verdict names it|dec|DECISIONS_DIR=elsewhere|Decided in D001.\n|rc=0 $(clean 0 3 0 'decision IDs not judged (elsewhere is not tracked)')" \
+  "a zero width is exit 2, quoting the value|dec|DECISION_ID_WIDTH=0|Decided in D001.\n|rc=2 ${ERR}DECISION_ID_WIDTH must be a positive integer, got '0'" \
+  "a prefix outside letters, digits, '_' and '-' is exit 2, quoting the value|dec|DECISION_ID_PREFIX=a.b|Decided in D001.\n|rc=2 ${ERR}DECISION_ID_PREFIX must be letters, digits, '_' or '-', got 'a.b'"
 
 echo "=== a link followed by a section name resolves the heading prefix ==="
-new_repo section-links
-put guide.md $'# Guide\n\n## Install\n'
-cite "a plain section route resolves" 0 $'[guide](guide.md) § Install.\n'
-cite "a formatted section route resolves with following prose" 0 $'[guide](guide.md) § `Install` explains setup.\n'
-cite "a missing section route fails" 1 $'[guide](guide.md) § Missing section.\n' 1 "has no heading at the start"
-cite "a section name needs its boundary" 1 $'[guide](guide.md) § Installer.\n' 1 "has no heading at the start"
-cite "a link inside a code example is not a reference" 0 $'`[guide](guide.md) § Missing section.`\n'
-put guide.md $'# Guide\n\n## 1. Install\n\n### 1.1.1 Choose a path\n'
-cite "a numbered section route resolves" 0 $'[guide](guide.md) § 1 describes setup.\n'
-cite "a nested numbered section route resolves" 0 $'[guide](guide.md) § 1.1.1 describes the path.\n'
-cite "a missing numbered section cannot match its parent" 1 $'[guide](guide.md) § 1.1.2 describes the path.\n' 1 "has no heading at the start"
+cite_rows \
+  "a plain section route resolves, the link and the route each counted|install||[guide](guide.md) § Install.\n|rc=0 $(clean 2 1)" \
+  "a formatted section route resolves with following prose|install||[guide](guide.md) § \`Install\` explains setup.\n|rc=0 $(clean 2 1)" \
+  "a missing section route fails, quoting the route and the text it read|install||[guide](guide.md) § Missing section.\n|rc=1 $(dead AGENTS.md 1 "$(noprefix 'guide.md § Missing section.' guide.md 'Missing section.')");$(failed 1 2 1)" \
+  "a section name needs its boundary|install||[guide](guide.md) § Installer.\n|rc=1 $(dead AGENTS.md 1 "$(noprefix 'guide.md § Installer.' guide.md 'Installer.')");$(failed 1 2 1)" \
+  "a link inside a code example is not a reference|install||\`[guide](guide.md) § Missing section.\`\n|rc=0 $(clean 0 1)" \
+  "a numbered section route resolves|numbered||[guide](guide.md) § 1 describes setup.\n|rc=0 $(clean 2 1)" \
+  "a nested numbered section route resolves|numbered||[guide](guide.md) § 1.1.1 describes the path.\n|rc=0 $(clean 2 1)" \
+  "a missing numbered section cannot match its parent|numbered||[guide](guide.md) § 1.1.2 describes the path.\n|rc=1 $(dead AGENTS.md 1 "$(noprefix 'guide.md § 1.1.2 describes the path.' guide.md '1.1.2 describes the path.')");$(failed 1 2 1)"
 
 echo "=== section-route regression controls ==="
-new_repo section-regressions
-put guide.md $'# Guide\n\n## 1\n\n## Install\n'
-put 'guide(foo).md' $'# Guide\n\n## Install\n'
-cite "numeric routes cannot fall through to a bare parent prefix" 1 $'[guide](guide.md) § 1.1.2 details.\n' 1 "has no heading at the start"
-cite "balanced destination parentheses do not hide a missing section" 1 $'[guide](guide(foo).md) § Missing.\n' 1 "has no heading at the start"
-cite "underscore emphasis resolves like the other emphasis markers" 0 $'[guide](guide.md) § _Install_ explains setup.\n'
-cite "escaped destination parentheses do not hide a missing section" 1 $'[guide](guide\\(foo\\).md) § Missing.\n' 1 "has no heading at the start"
-cite "parentheses in a link title do not hide a missing section" 1 $'[guide](guide(foo).md "A ) title") § Missing.\n' 1 "has no heading at the start"
-cite "an angle destination and title retain a valid section route" 0 $'[guide](<guide(foo).md> "A ) title") § Install.\n'
+cite_rows \
+  "numeric routes cannot fall through to a bare parent prefix|parens||[guide](guide.md) § 1.1.2 details.\n|rc=1 $(dead AGENTS.md 1 "$(noprefix 'guide.md § 1.1.2 details.' guide.md '1.1.2 details.')");$(failed 1 2 1)" \
+  "balanced destination parentheses do not hide a missing section|parens||[guide](guide(foo).md) § Missing.\n|rc=1 $(dead AGENTS.md 1 "$(noprefix 'guide(foo).md § Missing.' 'guide(foo).md' 'Missing.')");$(failed 1 2 1)" \
+  "underscore emphasis resolves like the other emphasis markers|parens||[guide](guide.md) § _Install_ explains setup.\n|rc=0 $(clean 2 1)" \
+  "escaped destination parentheses do not hide a missing section|parens||[guide](guide\\\\(foo\\\\).md) § Missing.\n|rc=1 $(dead AGENTS.md 1 "$(noprefix 'guide(foo).md § Missing.' 'guide(foo).md' 'Missing.')");$(failed 1 2 1)" \
+  "parentheses in a link title do not hide a missing section|parens||[guide](guide(foo).md \"A ) title\") § Missing.\n|rc=1 $(dead AGENTS.md 1 "$(noprefix 'guide(foo).md § Missing.' 'guide(foo).md' 'Missing.')");$(failed 1 2 1)" \
+  "an angle destination and title retain a valid section route|parens||[guide](<guide(foo).md> \"A ) title\") § Install.\n|rc=0 $(clean 2 1)"
 
 echo "=== symmetric normalization, punctuation and anchored section routes ==="
-new_repo section-text
-put guide.md $'# Guide\n\n## snake_case\n\n## Install\n\n## 2.\n\n## 3)\n\n## 4.1.\n\n## Use *tools*\n'
-cite "snake_case resolves with symmetric normalization" 0 $'[guide](guide.md) § snake_case.\n'
-cite "formatted snake_case resolves with symmetric normalization" 0 $'[guide](guide.md) § **snake_case** describes naming.\n'
-cite "emphasis inside a heading resolves" 0 $'[guide](guide.md) § Use tools.\n'
-cite "a question mark ends a section prefix" 0 $'[guide](guide.md) § Install?\n'
-cite "an exclamation mark ends a section prefix" 0 $'[guide](guide.md) § Install!\n'
-cite "punctuation does not accept an incomplete heading" 1 $'[guide](guide.md) § Instal!\n' 1 "has no heading at the start"
-cite "a valid anchor does not hide a missing section" 1 $'[guide](guide.md#install) § Missing.\n' 1 "has no heading at the start"
-cite "an anchored link also accepts a valid section" 0 $'[guide](guide.md#install) § Install.\n'
-cite "a bare anchor does not hide a missing section" 1 $'# Guide\n\n[guide](#guide) § Missing.\n' 3 "has no heading at the start"
-cite "a terminal period in a bare numbered heading resolves" 0 $'[guide](guide.md) § 2 describes setup.\n'
-cite "a terminal parenthesis in a bare numbered heading resolves" 0 $'[guide](guide.md) § 3 describes setup.\n'
-cite "a terminal period in a nested numbered heading resolves" 0 $'[guide](guide.md) § 4.1 describes setup.\n'
-cite "a question mark ends a numbered section prefix" 0 $'[guide](guide.md) § 2?\n'
-cite "an exclamation mark ends a numbered section prefix" 0 $'[guide](guide.md) § 3!\n'
-cite "a missing child cannot resolve to a punctuated number" 1 $'[guide](guide.md) § 4.1.2 describes setup.\n' 1 "has no heading at the start"
-put guide.md $'# Guide\n\n## `snake_case`\n'
-cite "code spans resolve with symmetric normalization" 0 $'[guide](guide.md) § `snake_case`.\n'
+cite_rows \
+  "snake_case resolves with symmetric normalization|text||[guide](guide.md) § snake_case.\n|rc=0 $(clean 2 1)" \
+  "formatted snake_case resolves with symmetric normalization|text||[guide](guide.md) § **snake_case** describes naming.\n|rc=0 $(clean 2 1)" \
+  "emphasis inside a heading resolves|text||[guide](guide.md) § Use tools.\n|rc=0 $(clean 2 1)" \
+  "a question mark ends a section prefix|text||[guide](guide.md) § Install?\n|rc=0 $(clean 2 1)" \
+  "an exclamation mark ends a section prefix|text||[guide](guide.md) § Install!\n|rc=0 $(clean 2 1)" \
+  "punctuation does not accept an incomplete heading|text||[guide](guide.md) § Instal!\n|rc=1 $(dead AGENTS.md 1 "$(noprefix 'guide.md § Instal!' guide.md 'Instal!')");$(failed 1 2 1)" \
+  "a valid anchor does not hide a missing section|text||[guide](guide.md#install) § Missing.\n|rc=1 $(dead AGENTS.md 1 "$(noprefix 'guide.md#install § Missing.' guide.md 'Missing.')");$(failed 1 2 1)" \
+  "an anchored link also accepts a valid section|text||[guide](guide.md#install) § Install.\n|rc=0 $(clean 2 1)" \
+  "a bare anchor does not hide a missing section|text||# Guide\n\n[guide](#guide) § Missing.\n|rc=1 $(dead AGENTS.md 3 "$(noprefix '#guide § Missing.' AGENTS.md 'Missing.')");$(failed 1 2 1)" \
+  "a terminal period in a bare numbered heading resolves|text||[guide](guide.md) § 2 describes setup.\n|rc=0 $(clean 2 1)" \
+  "a terminal parenthesis in a bare numbered heading resolves|text||[guide](guide.md) § 3 describes setup.\n|rc=0 $(clean 2 1)" \
+  "a terminal period in a nested numbered heading resolves|text||[guide](guide.md) § 4.1 describes setup.\n|rc=0 $(clean 2 1)" \
+  "a question mark ends a numbered section prefix|text||[guide](guide.md) § 2?\n|rc=0 $(clean 2 1)" \
+  "an exclamation mark ends a numbered section prefix|text||[guide](guide.md) § 3!\n|rc=0 $(clean 2 1)" \
+  "a missing child cannot resolve to a punctuated number|text||[guide](guide.md) § 4.1.2 describes setup.\n|rc=1 $(dead AGENTS.md 1 "$(noprefix 'guide.md § 4.1.2 describes setup.' guide.md '4.1.2 describes setup.')");$(failed 1 2 1)" \
+  "code spans resolve with symmetric normalization|code||[guide](guide.md) § \`snake_case\`.\n|rc=0 $(clean 2 1)"
 
-echo "=== citations in comment text and in TOML strings ==="
-new_repo source
-put docs/architecture/plugins.md $'# Plugins\n\n## Invariants\n'
-put AGENTS.md $'# A\n\n## Rules\n'
-
-# PATH holds CONTENT for this one case; assert the --all verdict, and on a
-# dead citation the line and message fragment named. The file goes again
-# afterwards, so one case's planted citation cannot decide the next.
-src_cite() { # LABEL EXPECT-RC PATH CONTENT [LINE MESSAGE-FRAGMENT]
-  local label="$1" want="$2" path="$3" content="$4" line="${5-}" msg="${6-}"
-  put "$path" "$content"
-  run_refs --all
-  git -C "$R" rm -q --cached "$path"
-  rm -f "$R/$path"
-  if [ "$RC" -ne "$want" ]; then
-    bad "$label" "rc=$RC want=$want out=$OUT"
-    return
-  fi
-  if [ "$want" -eq 1 ]; then
-    case "$OUT" in
-      *"dead reference: $path:$line: "*"$msg"*) ok "$label" ;;
-      *) bad "$label" "expected $path:$line: ...$msg in: $OUT" ;;
-    esac
-  else
-    ok "$label"
-  fi
+# Table two: FIXTURE (a function and its words) builds the repository; the
+# judge runs with ARGS under ENVS.
+run_rows() { # label | fixture | envs | args | expect
+  local row label fx envs args expect words
+  for row in "$@"; do
+    IFS='|' read -r label fx envs args expect <<<"$row"
+    R=""
+    read -ra words <<<"$fx"
+    "${words[@]}"
+    assert_eq "$label" "$expect" "$(run "$envs" "$args")"
+  done
 }
 
-src_cite "a citation in comment text resolves" 0 bin/helper.sh \
-  $'#!/usr/bin/env bash\n# The rule is docs/architecture/plugins.md § Invariants, not this file.\ntrue\n'
-src_cite "a comment citing a heading the target does not have is dead" 1 bin/helper.sh \
-  $'#!/usr/bin/env bash\n# The rule is docs/architecture/plugins.md § Gone, not this file.\ntrue\n' \
-  2 "docs/architecture/plugins.md has no heading at the start of 'Gone"
-src_cite "a citation in a TOML string resolves" 0 kendex.toml $'note = "AGENTS.md § Rules apply here"\n'
-src_cite "a TOML string citing a heading the target does not have is dead" 1 kendex.toml \
-  $'note = "AGENTS.md § Gone"\n' 1 "AGENTS.md has no heading at the start of 'Gone"
-src_cite "a string literal outside a manifest is not judged" 0 src/lib.rs \
-  $'fn f() -> &\'static str { "AGENTS.md \302\247 Gone" }\n'
-src_cite "control: the same citation in that file's comment is judged" 1 src/lib.rs \
-  $'// AGENTS.md \302\247 Gone\nfn f() {}\n' 1 "AGENTS.md has no heading at the start of 'Gone"
-put docs/decisions/D008-scope.md $'# D008\n\n## Scope\n'
-src_cite "a decision citation in comment text checks the heading" 0 scripts/smoke.sh \
-  $'#!/usr/bin/env bash\n# What this covers is D008 § Scope.\ntrue\n'
-src_cite "a decision citing a heading it does not have is dead" 1 scripts/smoke.sh \
-  $'#!/usr/bin/env bash\n# What this covers is D008 § Reach.\ntrue\n' \
-  2 "docs/decisions/D008-scope.md has no heading at the start of 'Reach"
-src_cite "a bare decision ID in a comment is prose, not a citation" 0 scripts/smoke.sh \
-  $'#!/usr/bin/env bash\n# Superseded by D999, which does not exist.\ntrue\n'
-printf '*.svg %sdiff\n' '-' >"$R/.gitattributes"
-git -C "$R" add .gitattributes
-src_cite "a text file the attributes mark undiffable is still read" 1 icon.svg \
-  $'<!-- AGENTS.md \302\247 Gone -->\n' 1 "AGENTS.md has no heading at the start of 'Gone"
-# A NUL cannot travel through src_cite: bash truncates $'...' at one.
-printf '\001\000\002 AGENTS.md \302\247 Gone\n' >"$R/blob.h"
-git -C "$R" add blob.h
-run_refs --all
-git -C "$R" rm -q --cached blob.h
-rm -f "$R/blob.h"
-[ "$RC" -eq 0 ] && case "$OUT" in *"not measured: blob.h"*"binary content"*) true ;; *) false ;; esac \
-  && ok "a binary blob at a source path is named, never counted clean" \
-  || bad "binary carrier named" "rc=$RC out=$OUT"
+echo "=== links and citations resolve relative to the citing file ==="
+fx_nested_links() { world_refs nested-links; put docs/architecture/topic.md '[up](../guide.md) [sib](overview.md#the-one-idea) [down](../../skills/x/SKILL.md)\n'; put AGENTS.md 'Clean.\n'; }
+fx_nested_wrong() { world_refs nested-wrong; put docs/architecture/topic.md '[wrong](guide.md)\n'; put AGENTS.md 'Clean.\n'; }
+fx_nested_cite() { world_refs nested-cite; put docs/architecture/topic.md 'See `overview.md § The one idea` and `docs/guide.md`.\n'; put AGENTS.md 'Clean.\n'; }
+run_rows \
+  "a nested file's relative links resolve from its own directory|fx_nested_links||--all|rc=0 $(clean 3 4)" \
+  "control: a root-relative spelling from a nested file fails, naming where it looked|fx_nested_wrong||--all|rc=1 $(dead docs/architecture/topic.md 1 "$(untracked '](guide.md)' docs/architecture/guide.md)");$(failed 1 1 4)" \
+  "a nested file's citation resolves beside it, and a bare root path is a name|fx_nested_cite||--all|rc=0 $(clean 1 4)"
 
-src_cite "a URL is prose, not a citation into this repository" 0 scripts/link.sh \
-  $'#!/usr/bin/env bash\n# See https://example.com/guide.md \302\247 Gone for more.\ntrue\n'
-src_cite "a decision ID inside a URL is prose too" 0 scripts/link.sh \
-  $'#!/usr/bin/env bash\n# See https://example.com/D404 \302\247 Scope for more.\ntrue\n'
-src_cite "a path in a URL query is prose wherever it sits in the URL" 0 scripts/link.sh \
-  $'#!/usr/bin/env bash\n# See https://example.com/?doc=AGENTS.md \302\247 Gone here.\ntrue\n'
-src_cite "and so is a decision ID in one" 0 scripts/link.sh \
-  $'#!/usr/bin/env bash\n# See https://example.com/?decision=D404 \302\247 Scope here.\ntrue\n'
-src_cite "control: the same path without the scheme is judged" 1 scripts/link.sh \
-  $'#!/usr/bin/env bash\n# See AGENTS.md \302\247 Gone for more.\ntrue\n' \
-  2 "AGENTS.md has no heading at the start of 'Gone"
-# A carrier the extractor cannot read is an incomplete scan, never a pass:
-# the block comment below never closes, and the file holds a section sign.
-put src/broken.c $'/* AGENTS.md \302\247 Gone\nint main(void) { return 0; }\n'
-run_refs --all
-[ "$RC" -eq 2 ] && case "$OUT" in *"scan incomplete"*"1 carrier(s) could not be read"*) true ;; *) false ;; esac \
-  && ok "a carrier the extractor cannot read is exit 2, never a clean verdict" \
-  || bad "unreadable carrier fails closed" "rc=$RC out=$OUT"
-# The same carrier as the only measurable file: the empty-set answer must not
-# reach the exit 0 ahead of the incomplete scan.
-OUT="$(cd "$R" && COMMIT_GUARDS_MD_REFS_PATHS='no/such/*.md' "$MDR" --all 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"scan incomplete"*) true ;; *) false ;; esac \
-  && ok "an unreadable carrier beats the empty-set fast path" \
-  || bad "empty set hides an unread carrier" "rc=$RC out=$OUT"
-git -C "$R" rm -q --cached src/broken.c
-rm -f "$R/src/broken.c"
+echo "=== the path list: agent-loaded markdown and architecture docs ==="
+SCOPED="AGENTS.md CLAUDE.md SKILL.md skills/dev/SKILL.md skills/dev/AGENTS.md workflows/ship.md skills/dev/workflows/ship.md agents/rust.md .claude/agents/rust.md docs/architecture/overview.md"
+UNSCOPED="README.md docs/design.md skills/dev/references/api.md"
+scoped() { repo "scoped-${1//\//_}"; put "$1" '[dead](nope.md)\n'; } # PATH — the one tracked file, holding a dead link
+fx_unscoped() { # NAME — every scoped path live, every unscoped one dead
+  local f
+  repo "$1"
+  for f in $SCOPED; do put "$f" '# Top\n\n[live](#top)\n'; done
+  for f in $UNSCOPED; do put "$f" '[dead](nope.md)\n'; done
+}
+beside() { case "$1" in */*) printf '%s/%s' "${1%/*}" "$2" ;; *) printf '%s' "$2" ;; esac; } # PATH NAME — where a relative link from PATH lands
+rows=()
+for f in $SCOPED; do
+  rows+=("$f is in the default scope|scoped $f||--all|rc=1 $(dead "$f" 1 "$(untracked '](nope.md)' "$(beside "$f" nope.md)")");$(failed 1 1 1)")
+done
+run_rows "${rows[@]}" \
+  "a README, a doc outside docs/architecture and a reference file are not judged, with the ten scoped files still read|fx_unscoped unscoped||--all|rc=0 $(clean 10 10)" \
+  "COMMIT_GUARDS_MD_REFS_PATHS replaces the list|fx_unscoped replaced|COMMIT_GUARDS_MD_REFS_PATHS=docs/*.md|--all|rc=1 $(dead docs/design.md 1 "$(untracked '](nope.md)' docs/nope.md)");$(failed 1 2 2)"
 
-# The walk's own skip branches, each over a path that carries a live citation
-# so a silent drop would read as a pass.
-put target.sh $'#!/usr/bin/env bash\n# AGENTS.md \302\247 Gone\ntrue\n'
-ln -s target.sh "$R/link.sh"
-git -C "$R" add link.sh
-run_refs --all
-[ "$RC" -eq 1 ] && case "$OUT" in *"not measured: link.sh"*"tracked as a symlink"*) true ;; *) false ;; esac \
-  && ok "a symlink at a source path is named, and its target still judged" \
-  || bad "symlink at a source path" "rc=$RC out=$OUT"
-git -C "$R" rm -q --cached link.sh target.sh
-rm -f "$R/link.sh" "$R/target.sh"
-printf '#!/usr/bin/env bash\n# AGENTS.md \302\247 Gone\ntrue\n' >"$R/one"$'\n'"two.sh"
-git -C "$R" add -A
-run_refs --all
-[ "$RC" -eq 0 ] && case "$OUT" in *"not measured: "*"holds a newline"*) true ;; *) false ;; esac \
-  && ok "a path holding a newline is named, never quietly passed" \
-  || bad "newline path named" "rc=$RC out=$OUT"
-git -C "$R" rm -q --cached -- "one"$'\n'"two.sh"
-rm -f "$R/one"$'\n'"two.sh"
-git -C "$R" rm -q --cached .gitattributes
-rm -f "$R/.gitattributes"
+echo "=== citations in comment text and in TOML strings ==="
+SH='#!/usr/bin/env bash\n'
+fx_comment_ok() { world_src "$1"; put bin/helper.sh "$SH"'# The rule is docs/architecture/plugins.md \302\247 Invariants, not this file.\ntrue\n'; }
+fx_comment_dead() { world_src comment-dead; put bin/helper.sh "$SH"'# The rule is docs/architecture/plugins.md \302\247 Gone, not this file.\ntrue\n'; }
+fx_toml_ok() { world_src toml-ok; put kendex.toml 'note = "AGENTS.md \302\247 Rules apply here"\n'; }
+fx_toml_dead() { world_src toml-dead; put kendex.toml 'note = "AGENTS.md \302\247 Gone"\n'; }
+fx_rs_string() { world_src rs-string; put src/lib.rs 'fn f() -> &'"'"'static str { "AGENTS.md \302\247 Gone" }\n'; }
+fx_rs_comment() { world_src rs-comment; put src/lib.rs '// AGENTS.md \302\247 Gone\nfn f() {}\n'; }
+fx_dec_ok() { world_src_dec dec-ok; put scripts/smoke.sh "$SH"'# What this covers is D008 \302\247 Scope.\ntrue\n'; }
+fx_dec_dead() { world_src_dec dec-dead; put scripts/smoke.sh "$SH"'# What this covers is D008 \302\247 Reach.\ntrue\n'; }
+# The bare ID sits beside a live citation: a file holding no section sign is
+# never opened, so the row would pass on that alone.
+fx_dec_bare() { world_src_dec dec-bare; put scripts/smoke.sh "$SH"'# Superseded by D999, which does not exist; see D008 \302\247 Scope.\ntrue\n'; }
+fx_undiffable() { world_src undiffable; put .gitattributes '*.svg -diff\n'; put icon.svg '<!-- AGENTS.md \302\247 Gone -->\n'; }
+fx_binary() { world_src binary; put blob.h '\001\0000\002 AGENTS.md \302\247 Gone\n'; }
+fx_url() { world_src url; put scripts/link.sh "$SH"'# See https://example.com/guide.md \302\247 Gone for more.\ntrue\n'; }
+fx_url_id() { world_src_dec url-id; put scripts/link.sh "$SH"'# See https://example.com/D404 \302\247 Scope for more.\ntrue\n'; }
+fx_url_query() { world_src url-query; put scripts/link.sh "$SH"'# See https://example.com/?doc=AGENTS.md \302\247 Gone here.\ntrue\n'; }
+fx_url_query_id() { world_src_dec url-query-id; put scripts/link.sh "$SH"'# See https://example.com/?decision=D404 \302\247 Scope here.\ntrue\n'; }
+fx_no_scheme() { world_src no-scheme; put scripts/link.sh "$SH"'# See AGENTS.md \302\247 Gone for more.\ntrue\n'; }
+# A block comment that never closes, in a file holding a section sign.
+fx_unclosed() { world_src "$1"; put src/broken.c '/* AGENTS.md \302\247 Gone\nint main(void) { return 0; }\n'; }
+fx_symlink_src() { world_src symlink-src; put target.sh "$SH"'# AGENTS.md \302\247 Gone\ntrue\n'; ln -s target.sh "$R/link.sh"; git -C "$R" add link.sh; }
+fx_newline_src() { world_src newline-src; put "one"$'\n'"two.sh" "$SH"'# AGENTS.md \302\247 Gone\ntrue\n'; }
+UNCLOSED="$(skip src/broken.c 'comment text could not be extracted: a block comment opened at line 1 is never closed ');md-refs: scan incomplete — 1 carrier(s) could not be read$(unmeasured 1)"
+run_rows \
+  "a citation in comment text resolves|fx_comment_ok comment-ok||--all|rc=0 $(clean 1 2 1)" \
+  "a comment citing a heading the target does not have is dead, the heading read to the end of the line|fx_comment_dead||--all|rc=1 $(dead bin/helper.sh 2 "$(noprefix 'docs/architecture/plugins.md § Gone, not this file.' docs/architecture/plugins.md 'Gone, not this file.')");$(failed 1 1 2 1)" \
+  "a citation in a TOML string resolves|fx_toml_ok||--all|rc=0 $(clean 1 2 1)" \
+  "a TOML string citing a heading the target does not have is dead|fx_toml_dead||--all|rc=1 $(dead kendex.toml 1 "$(noprefix 'AGENTS.md § Gone' AGENTS.md Gone)");$(failed 1 1 2 1)" \
+  "a string literal outside a manifest is not judged|fx_rs_string||--all|rc=0 $(clean 0 2 1)" \
+  "control: the same citation in that file's comment is judged|fx_rs_comment||--all|rc=1 $(dead src/lib.rs 1 "$(noprefix 'AGENTS.md § Gone' AGENTS.md Gone)");$(failed 1 1 2 1)" \
+  "a decision citation in comment text checks the heading|fx_dec_ok||--all|rc=0 $(clean 1 2 1 "$DEC_YES")" \
+  "a decision citing a heading it does not have is dead|fx_dec_dead||--all|rc=1 $(dead scripts/smoke.sh 2 "$(noprefix 'D008 § Reach.' docs/decisions/D008-scope.md 'Reach.')");$(failed 1 1 2 1 "$DEC_YES")" \
+  "a bare decision ID in a comment is prose, not a citation, beside the § one it is|fx_dec_bare||--all|rc=0 $(clean 1 2 1 "$DEC_YES")" \
+  "a text file the attributes mark undiffable is still read|fx_undiffable||--all|rc=1 $(dead icon.svg 1 "$(noprefix 'AGENTS.md § Gone' AGENTS.md Gone)");$(failed 1 1 2 1)" \
+  "a binary blob at a source path is named, never counted clean|fx_binary||--all|rc=0 $(skip blob.h 'binary content, not source');$(clean 0 2 0 "$DEC_NO" "$(unmeasured 1)")" \
+  "a URL is prose, not a citation into this repository|fx_url||--all|rc=0 $(clean 0 2 1)" \
+  "a decision ID inside a URL is prose too, with the directory tracked|fx_url_id||--all|rc=0 $(clean 0 2 1 "$DEC_YES")" \
+  "a path in a URL query is prose wherever it sits in the URL|fx_url_query||--all|rc=0 $(clean 0 2 1)" \
+  "and so is a decision ID in one|fx_url_query_id||--all|rc=0 $(clean 0 2 1 "$DEC_YES")" \
+  "control: the same path without the scheme is judged|fx_no_scheme||--all|rc=1 $(dead scripts/link.sh 2 "$(noprefix 'AGENTS.md § Gone for more.' AGENTS.md 'Gone for more.')");$(failed 1 1 2 1)" \
+  "a carrier the extractor cannot read is exit 2, never a clean verdict|fx_unclosed unclosed||--all|rc=2 $UNCLOSED" \
+  "an unreadable carrier beats the empty-set fast path|fx_unclosed unclosed-empty|COMMIT_GUARDS_MD_REFS_PATHS=no/such/*.md|--all|rc=2 $UNCLOSED" \
+  "a symlink at a source path is named, and its target still judged|fx_symlink_src||--all|rc=1 $(skip link.sh 'tracked as a symlink, not source');$(dead target.sh 2 "$(noprefix 'AGENTS.md § Gone' AGENTS.md Gone)");$(failed 1 1 2 1 "$DEC_NO" "$(unmeasured 1)")" \
+  "a path holding a newline is named, never quietly passed|fx_newline_src||--all|rc=0 $(skip "\$'one\\ntwo.sh'" 'the path holds a newline, which the carrier list cannot separate');$(clean 0 2 0 "$DEC_NO" "$(unmeasured 1)")" \
+  "an empty source path list is refused|fx_comment_ok empty-list|COMMIT_GUARDS_MD_REFS_SOURCE_PATHS=|--all|rc=2 ${ERR}COMMIT_GUARDS_MD_REFS_SOURCE_PATHS names no path — name at least one, or drop this check from COMMIT_GUARDS_CHECKS"
 
 echo "=== scopes: touched, --staged, --all ==="
-new_repo scopes
-put ok.md $'# OK\n'
-put AGENTS.md $'[dead](nope.md)\n'
-git -C "$R" commit -qm seed
-run_refs
-[ "$RC" -eq 0 ] && case "$OUT" in *"nothing staged to judge"*) true ;; *) false ;; esac \
-  && ok "under touched with nothing staged, one line says so" || bad "touched with nothing staged" "rc=$RC out=$OUT"
-run_refs --all
-[ "$RC" -eq 1 ] && case "$OUT" in *"AGENTS.md:1:"*) true ;; *) false ;; esac \
-  && ok "--all reaches the committed dead link" || bad "--all reaches committed" "rc=$RC out=$OUT"
-put docs/architecture/overview.md $'[live](../../ok.md)\n'
-run_refs --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"AGENTS.md:1:"*) true ;; *) false ;; esac \
-  && ok "--staged also checks references from unchanged documents" || bad "incoming references" "rc=$RC out=$OUT"
-put AGENTS.md $'[dead](nope.md) again\n'
-run_refs
-[ "$RC" -eq 1 ] && case "$OUT" in *"AGENTS.md:1:"*) true ;; *) false ;; esac \
-  && ok "control: under touched, the staged AGENTS.md is judged" || bad "control: touched judges staged" "rc=$RC out=$OUT"
-git -C "$R" commit -qm more
-put ok.md $'# Renamed\n'
-git -C "$R" commit -qm rename-heading
-put AGENTS.md $'[a](ok.md#ok)\n'
-run_refs --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"ok.md has no heading or explicit anchor #ok"*) true ;; *) false ;; esac \
-  && ok "a target outside the staged set is still read from the index for its headings" || bad "target read from index" "rc=$RC out=$OUT"
-git -C "$R" rm -q --cached ok.md
-run_refs --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"no tracked file or directory at ok.md"*) true ;; *) false ;; esac \
-  && ok "a link to a file the commit deletes is dead" || bad "deleted target is dead" "rc=$RC out=$OUT"
-
-echo "=== staged references honor exclusions ==="
-new_repo staged-exclusion
-put AGENTS.md $'[dead](missing.md)\n'
-put tools/md-excludes $'AGENTS.md\tvendored instructions\n'
-run_refs --staged
-[ "$RC" -eq 0 ] && case "$OUT" in *"no tracked markdown file(s) to judge"*) true ;; *) false ;; esac \
-  && ok "the staged scan excludes the declared document" || bad "staged exclusion" "rc=$RC out=$OUT"
-git -C "$R" rm -qf tools/md-excludes
-run_refs --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"no tracked file or directory at missing.md"*) true ;; *) false ;; esac \
-  && ok "the same staged reference fails without its exclusion" || bad "staged exclusion control" "rc=$RC out=$OUT"
-
-echo "=== target-only edits recheck incoming references ==="
-new_repo incoming
-put guide.md $'# Guide\n\n## Install\n'
-put AGENTS.md $'[setup](guide.md#install)\n'
-git -C "$R" commit -qm seed
-put guide.md $'# Guide\n\n## Setup\n'
-run_refs
-[ "$RC" -eq 1 ] && case "$OUT" in *"guide.md has no heading or explicit anchor #install"*) true ;; *) false ;; esac \
-  && ok "renaming only the target heading finds an unchanged caller" || bad "target rename" "rc=$RC out=$OUT"
-git -C "$R" rm -qf guide.md
-run_refs
-[ "$RC" -eq 1 ] && case "$OUT" in *"no tracked file or directory at guide.md"*) true ;; *) false ;; esac \
-  && ok "deleting only the target finds an unchanged caller" || bad "target deletion" "rc=$RC out=$OUT"
+seeded() { repo "$1"; put ok.md '# OK\n'; put AGENTS.md '[dead](nope.md)\n'; commit seed; } # NAME — a committed dead link, nothing staged
+fx_staged_live() { seeded staged-live; put docs/architecture/overview.md '[live](../../ok.md)\n'; }
+fx_touched_staged() { seeded touched-staged; put AGENTS.md '[dead](nope.md) again\n'; }
+fx_target_in_index() { repo "$1"; put ok.md '# OK\n'; commit seed; put ok.md '# Renamed\n'; commit rename-heading; put AGENTS.md '[a](ok.md#ok)\n'; }
+fx_target_deleted() { fx_target_in_index target-deleted; git -C "$R" rm -q --cached ok.md; }
+fx_excluded() { repo excluded; put AGENTS.md '[dead](missing.md)\n'; put tools/md-excludes 'AGENTS.md\tvendored instructions\n'; }
+fx_not_excluded() { repo not-excluded; put AGENTS.md '[dead](missing.md)\n'; }
+fx_heading_renamed() { repo "$1"; put guide.md '# Guide\n\n## Install\n'; put AGENTS.md '[setup](guide.md#install)\n'; commit seed; put guide.md '# Guide\n\n## Setup\n'; }
+fx_target_removed() { fx_heading_renamed target-removed; git -C "$R" rm -qf guide.md; }
+run_rows \
+  "under touched with nothing staged, one line says so|seeded touched-nothing|||rc=0 $NOTHING_STAGED" \
+  "--all reaches the committed dead link|seeded all-committed||--all|rc=1 $(dead AGENTS.md 1 "$(untracked '](nope.md)' nope.md)");$(failed 1 1 1)" \
+  "--staged also checks references from unchanged documents|fx_staged_live||--staged|rc=1 $(dead AGENTS.md 1 "$(untracked '](nope.md)' nope.md)");$(failed 1 2 2)" \
+  "control: under touched, the staged AGENTS.md is judged|fx_touched_staged|||rc=1 $(dead AGENTS.md 1 "$(untracked '](nope.md)' nope.md)");$(failed 1 1 1)" \
+  "a target outside the staged set is still read from the index for its headings|fx_target_in_index target-in-index||--staged|rc=1 $(dead AGENTS.md 1 "$(noslug '](ok.md#ok)' ok.md ok)");$(failed 1 1 1)" \
+  "a link to a file the commit deletes is dead|fx_target_deleted||--staged|rc=1 $(dead AGENTS.md 1 "$(untracked '](ok.md#ok)' ok.md)");$(failed 1 1 1)" \
+  "the staged scan excludes the declared document, and the verdict echoes both path settings|fx_excluded|COMMIT_GUARDS_MD_REFS_SOURCE_PATHS=*.sh|--staged|rc=0 $(nomatch "$PATHS_DEFAULT" '*.sh')" \
+  "control: the same staged reference fails without its exclusion|fx_not_excluded||--staged|rc=1 $(dead AGENTS.md 1 "$(untracked '](missing.md)' missing.md)");$(failed 1 1 1)" \
+  "renaming only the target heading finds an unchanged caller|fx_heading_renamed heading-renamed|||rc=1 $(dead AGENTS.md 1 "$(noslug '](guide.md#install)' guide.md install)");$(failed 1 1 1)" \
+  "deleting only the target finds an unchanged caller|fx_target_removed|||rc=1 $(dead AGENTS.md 1 "$(untracked '](guide.md#install)' guide.md)");$(failed 1 1 1)"
 
 echo "=== refusals and unmeasured paths ==="
-new_repo refuse
-put AGENTS.md $'Para\n\n```\nopen\n'
-run_refs --all
-[ "$RC" -eq 2 ] && case "$OUT" in *"AGENTS.md:3: an unterminated fence"*) true ;; *) false ;; esac \
-  && ok "an unterminated fence is exit 2, naming the line" || bad "unterminated fence exit 2" "rc=$RC out=$OUT"
-put AGENTS.md $'clean\n'
-put notes/target.md $'clean\n'
-rm "$R/AGENTS.md"
-ln -s notes/target.md "$R/AGENTS.md"
-git -C "$R" add -A
-run_refs --all
-[ "$RC" -eq 0 ] && case "$OUT" in *"not measured: AGENTS.md"*"tracked as a symlink"*"1 matched path(s) not measured"*) true ;; *) false ;; esac \
-  && ok "a symlink at a scoped path is named as unmeasured" || bad "symlink named" "rc=$RC out=$OUT"
-run_refs --no-such-flag
-[ "$RC" -eq 2 ] && ok "an unknown flag is exit 2" || bad "unknown flag" "rc=$RC out=$OUT"
-run_refs --help
-[ "$RC" -eq 0 ] && case "$OUT" in *"usage: md-refs"*) true ;; *) false ;; esac \
-  && ok "--help prints usage at exit 0" || bad "--help" "rc=$RC out=$OUT"
+fx_open_fence() { repo "$1"; put AGENTS.md 'Para\n\n```\nopen\n'; }
+fx_symlink_doc() { repo symlink-doc; put notes/target.md 'clean\n'; ln -s notes/target.md "$R/AGENTS.md"; git -C "$R" add -A; }
+run_rows \
+  "an unterminated fence is exit 2, naming the line|fx_open_fence open-fence||--all|rc=2 ${ERR}AGENTS.md:3: an unterminated fence — the file cannot be read past it; close the construct" \
+  "a symlink at a scoped path is named as unmeasured|fx_symlink_doc||--all|rc=0 $(skip AGENTS.md 'tracked as a symlink, not markdown');md-refs: OK — nothing measurable to judge$(unmeasured 1)" \
+  "--staged and --all are exclusive|fx_open_fence both-flags||--staged --all|rc=2 ${ERR}--staged and --all are exclusive" \
+  "an unknown flag is exit 2, quoting it|fx_open_fence unknown-flag||--no-such-flag|rc=2 ${ERR}unknown argument '--no-such-flag' (see --help)" \
+  "a scope outside touched and all is exit 2, quoting it|fx_open_fence bad-scope|COMMIT_GUARDS_MD_SCOPE=weird||rc=2 ${ERR}COMMIT_GUARDS_MD_SCOPE must be 'touched' or 'all', got 'weird'"
+# The usage text carries a '|', which a row cannot: its first line and the
+# exit status, beside the table.
+assert_eq "--help prints usage at exit 0" "rc=0 usage: md-refs [--staged | --all]" "$(run '' --help | sed -n 1p | LC_ALL=C cut -d';' -f1)"
 
 echo "=== the skill's own shipped markdown resolves ==="
-new_repo self
-mkdir -p "$R/skills/commit-guards"
-for doc in SKILL.md README.md CHECKS.md DEVELOPMENT.md; do
-  cp "$SKILL_DIR/$doc" "$R/skills/commit-guards/$doc"
-done
-# The consumer-side files the docs cite by directory path.
-put changelog.d/README.md $'# changelog.d\n'
-put .claude/CLAUDE.md $'@AGENTS.md\n'
-git -C "$R" add -A
-run_refs --all
-[ "$RC" -eq 0 ] && case "$OUT" in *"md-refs: OK — "*"2 tracked markdown file(s)"*) true ;; *) false ;; esac \
-  && ok "the shipped SKILL.md's references resolve (beside the fixture's CLAUDE.md shim)" || bad "shipped SKILL.md resolves" "rc=$RC out=$OUT"
-OUT="$(cd "$R" && COMMIT_GUARDS_MD_REFS_PATHS='*/commit-guards/*.md' "$MDR" --all 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && case "$OUT" in *"4 tracked markdown file(s)"*) true ;; *) false ;; esac \
-  && ok "and so do README.md, CHECKS.md and DEVELOPMENT.md when named" || bad "shipped docs resolve" "rc=$RC out=$OUT"
-put skills/commit-guards/SKILL.md "$(cat "$SKILL_DIR/SKILL.md")"$'\n\nSee [gone](nowhere.md).\n'
-run_refs --all
-[ "$RC" -eq 1 ] && ok "control: a planted dead link in the shipped SKILL.md fails" || bad "control: planted dead link" "rc=$RC out=$OUT"
+fx_shipped() { # the four shipped documents beside the consumer files they cite by directory
+  local doc
+  repo "$1"
+  mkdir -p "$R/skills/commit-guards"
+  for doc in SKILL.md README.md CHECKS.md DEVELOPMENT.md; do
+    cp "$SKILL_DIR/$doc" "$R/skills/commit-guards/$doc"
+  done
+  put changelog.d/README.md '# changelog.d\n'
+  put .claude/CLAUDE.md '@AGENTS.md\n'
+}
+# The shipped documents' own reference count is theirs to change: the pin is
+# the verdict over the two, then the four, files read, with N for that count.
+counted() { LC_ALL=C sed 's/\(OK — \|among \)[0-9][0-9]* /\1N /'; }
+fx_shipped shipped
+assert_eq "the shipped SKILL.md's references resolve (beside the fixture's CLAUDE.md shim)" "rc=0 $(clean N 2)" "$(run '' --all | counted)"
+assert_eq "and so do README.md, CHECKS.md and DEVELOPMENT.md when named" "rc=0 $(clean N 4)" "$(run 'COMMIT_GUARDS_MD_REFS_PATHS=*/commit-guards/*.md' --all | counted)"
+fx_shipped shipped-planted
+put skills/commit-guards/SKILL.md "$(cat "$SKILL_DIR/SKILL.md")"'\n\nSee [gone](nowhere.md).\n'
+assert_eq "control: a planted dead link in the shipped SKILL.md fails, at the line it was planted on" \
+  "rc=1 $(dead skills/commit-guards/SKILL.md "$(($(wc -l <"$SKILL_DIR/SKILL.md") + 2))" "$(untracked '](nowhere.md)' skills/commit-guards/nowhere.md)");$(failed 1 N 2)" "$(run '' --all | counted)"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.agents/skills/commit-guards/tests/md-refs.test.sh
+++ b/.agents/skills/commit-guards/tests/md-refs.test.sh
@@ -12,6 +12,8 @@
 # verdict, the file and line it names, the reference it quotes, the count it
 # judged, the remedy and the summary are one pin.
 set -euo pipefail
+# No globbing: a row's ARGS column is word-split into the judge's arguments.
+set -f
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 MDR="$SKILL_DIR/scripts/md-refs"
@@ -69,7 +71,7 @@ world_refs() {
   put skills/x/SKILL.md '# X\n'
   put pic.png 'not really'
 }
-world_dec() { world_refs "$1"; put docs/decisions/D001-first.md '# D001\n\n## Context\n'; put docs/decisions/INDEX.md '| D001 |\n'; }
+world_dec() { world_refs "$1"; put docs/decisions/D001-first.md '# D001\n\n## Context\n'; }
 world_adr() { world_dec "$1"; put docs/decisions/ADR-0007-x.md '# ADR-0007\n'; }
 world_install() { repo "$1"; put guide.md '# Guide\n\n## Install\n'; }
 world_numbered() { repo "$1"; put guide.md '# Guide\n\n## 1. Install\n\n### 1.1.1 Choose a path\n'; }
@@ -347,7 +349,7 @@ fx_shipped() { # the four shipped documents beside the consumer files they cite 
 }
 # The shipped documents' own reference count is theirs to change: the pin is
 # the verdict over the two, then the four, files read, with N for that count.
-counted() { LC_ALL=C sed 's/\(OK — \|among \)[0-9][0-9]* /\1N /'; }
+counted() { LC_ALL=C sed -e 's/OK — [0-9][0-9]* /OK — N /' -e 's/among [0-9][0-9]* /among N /'; }
 fx_shipped shipped
 assert_eq "the shipped SKILL.md's references resolve (beside the fixture's CLAUDE.md shim)" "rc=0 $(clean N 2)" "$(run '' --all | counted)"
 assert_eq "and so do README.md, CHECKS.md and DEVELOPMENT.md when named" "rc=0 $(clean N 4)" "$(run 'COMMIT_GUARDS_MD_REFS_PATHS=*/commit-guards/*.md' --all | counted)"

--- a/skills/commit-guards/tests/md-refs.test.sh
+++ b/skills/commit-guards/tests/md-refs.test.sh
@@ -1,426 +1,360 @@
 #!/usr/bin/env bash
-# Pins for scripts/md-refs: a relative link lands on a tracked path and a
-# heading it has; a code-span citation names a tracked file and a heading
-# it has; a decision ID names a tracked decision file, judged only where the
-# decisions directory is tracked, and its heading where the citation names
-# one; the same section citation is judged in a source file's comment text
-# and a TOML file's string literals; fenced code is never read; the scopes and
-# the path list are md-format's. Every green assertion is paired with a
-# control that proves it can fail.
+# Pins for scripts/md-refs, the judge of what a document cites: a relative
+# link lands on a tracked path and a heading it has; a code-span citation
+# names a tracked file and a heading it has; a link followed by § starts with
+# a heading of its target; a decision ID names a tracked decision file, judged
+# only where the decisions directory is tracked; the same section citation is
+# judged in a source file's comment text and a TOML file's string literals;
+# fenced code is never read; the scopes and the path list are md-format's.
+# Two tables: the first holds what one document cites over a seeded world,
+# the second the walk, the scopes and the source carriers. A row runs the
+# judge once and reads back the exit status with every line printed, so the
+# verdict, the file and line it names, the reference it quotes, the count it
+# judged, the remedy and the summary are one pin.
 set -euo pipefail
-
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 MDR="$SKILL_DIR/scripts/md-refs"
+# shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
-
-unset COMMIT_GUARDS_MD_REFS_PATHS COMMIT_GUARDS_MD_REFS_SOURCE_PATHS COMMIT_GUARDS_MD_EXCLUDES COMMIT_GUARDS_MD_SCOPE COMMIT_GUARDS_SETTINGS_FILE \
+# Hermetic: a leaked setting would mask every row below.
+unset COMMIT_GUARDS_MD_REFS_PATHS COMMIT_GUARDS_MD_REFS_SOURCE_PATHS COMMIT_GUARDS_MD_EXCLUDES \
+  COMMIT_GUARDS_MD_SCOPE COMMIT_GUARDS_SETTINGS_FILE \
   DECISIONS_DIR DECISION_ID_PREFIX DECISION_ID_WIDTH 2>/dev/null || true
 
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
 
-new_repo() { # NAME
+# One line for a run in the row's repository: the exit status, then every
+# line printed, in order, joined by ';'. ENVS is a comma-separated list of
+# assignments; ARGS are passed through.
+R=""
+run() { # ENVS ARGS
+  local envs=() rc=0 out=""
+  [ -z "$1" ] || IFS=',' read -ra envs <<<"$1"
+  # shellcheck disable=SC2086
+  out="$(cd "$R" && env ${envs[@]+"${envs[@]}"} "$MDR" $2 2>&1)" || rc=$?
+  printf 'rc=%s%s' "$rc" "${out:+ $(printf '%s\n' "$out" | LC_ALL=C paste -sd ';' -)}"
+}
+
+# Fixture vocabulary. Every fixture builds its own repository and stages
+# what it wrote; a name used twice is refused.
+repo() { # NAME
   R="$TMP/$1"
+  [ ! -e "$R" ] || { echo "harness: fixture $1 already exists" >&2; exit 2; }
   mkdir -p "$R"
   git -C "$R" -c init.defaultBranch=main init -q
   git -C "$R" config user.email test@example.com
   git -C "$R" config user.name test
 }
+put() { mkdir -p "$R/$(dirname "$1")"; printf '%b' "$2" >"$R/$1"; git -C "$R" add -A; } # PATH CONTENT (printf %b), staged
+commit() { git -C "$R" commit -qm "$1"; }
 
-run_refs() { # [args...] — run in $R; sets OUT and RC
-  OUT=""
-  RC=0
-  OUT="$(cd "$R" && "$MDR" "$@" 2>&1)" || RC=$?
+# The seeded worlds a citing document is judged in. Each names what the
+# default path list reads beside AGENTS.md: three tracked markdown files in
+# `refs` (docs/guide.md is outside the list), one in the guide worlds.
+world_refs() {
+  repo "$1"
+  put docs/architecture/overview.md '# Overview\n\n## The one idea\n\n## The one idea\n\n## Fish & Chips (v2) `code`\n\n<a id="explicit"></a>\n\nText.\n'
+  put docs/guide.md '# Guide\n'
+  put skills/x/SKILL.md '# X\n'
+  put pic.png 'not really'
 }
+world_dec() { world_refs "$1"; put docs/decisions/D001-first.md '# D001\n\n## Context\n'; put docs/decisions/INDEX.md '| D001 |\n'; }
+world_adr() { world_dec "$1"; put docs/decisions/ADR-0007-x.md '# ADR-0007\n'; }
+world_install() { repo "$1"; put guide.md '# Guide\n\n## Install\n'; }
+world_numbered() { repo "$1"; put guide.md '# Guide\n\n## 1. Install\n\n### 1.1.1 Choose a path\n'; }
+world_parens() { repo "$1"; put guide.md '# Guide\n\n## 1\n\n## Install\n'; put 'guide(foo).md' '# Guide\n\n## Install\n'; }
+world_text() { repo "$1"; put guide.md '# Guide\n\n## snake_case\n\n## Install\n\n## 2.\n\n## 3)\n\n## 4.1.\n\n## Use *tools*\n'; }
+world_code() { repo "$1"; put guide.md '# Guide\n\n## `snake_case`\n'; }
+# The source-carrier world: two documents to cite into, no source file yet.
+world_src() { repo "$1"; put docs/architecture/plugins.md '# Plugins\n\n## Invariants\n'; put AGENTS.md '# A\n\n## Rules\n'; }
+world_src_dec() { world_src "$1"; put docs/decisions/D008-scope.md '# D008\n\n## Scope\n'; }
 
-put() { # PATH CONTENT — a tracked file, staged
-  mkdir -p "$R/$(dirname "$1")"
-  printf '%s' "$2" >"$R/$1"
-  git -C "$R" add -A
+# The lines the judge prints, as functions of what a row put in.
+REMEDY="  remedies: point the reference at a tracked file, a heading it has, or a recorded decision, or delete it"
+ERR="::error::md-refs: "
+DEC_NO="decision IDs not judged (docs/decisions is not tracked)"
+DEC_YES="decision IDs judged against docs/decisions"
+PATHS_DEFAULT="AGENTS.md */AGENTS.md CLAUDE.md */CLAUDE.md SKILL.md */SKILL.md workflows/*.md */workflows/*.md agents/*.md */agents/*.md docs/architecture/*.md"
+NOTHING_STAGED="md-refs: OK — nothing staged to judge (COMMIT_GUARDS_MD_SCOPE=touched judges the files a commit touches); run with --all, or set COMMIT_GUARDS_MD_SCOPE=all once this repository's markdown is reflowed"
+dead() { printf 'md-refs FAIL dead reference: %s:%s: %s;%s' "$1" "$2" "$3" "$REMEDY"; } # PATH LINE MESSAGE
+skip() { printf 'md-refs: not measured: %s — %s' "$1" "$2"; } # PATH REASON
+unmeasured() { printf '; %s matched path(s) not measured' "$1"; } # N
+clean() { printf 'md-refs: OK — %s reference(s) resolve in %s tracked markdown file(s) and %s source file(s); %s%s' "$1" "$2" "${3:-0}" "${4:-$DEC_NO}" "${5-}"; } # JUDGED MD [SRC] [DEC-NOTE] [UNMEASURED]
+failed() { printf 'md-refs: %s dead reference(s) among %s in %s tracked markdown file(s) and %s source file(s); %s%s' "$1" "$2" "$3" "${4:-0}" "${5:-$DEC_NO}" "${6-}"; } # DEAD JUDGED MD [SRC] [DEC-NOTE] [UNMEASURED]
+# A verdict naming no measurable file echoes both settings' values.
+nomatch() { printf 'md-refs: OK — no tracked markdown file(s) to judge (COMMIT_GUARDS_MD_REFS_PATHS %s; COMMIT_GUARDS_MD_REFS_SOURCE_PATHS %s)' "$1" "$2"; } # MD-GLOBS SRC-GLOBS
+# The messages a reference dies with, each taking the quoted reference.
+untracked() { printf '%s: no tracked file or directory at %s' "$1" "$2"; } # RAW TARGET
+noslug() { printf '%s: %s has no heading or explicit anchor #%s' "$1" "$2" "$3"; } # RAW TARGET ANCHOR
+notext() { printf '`%s`: %s has no heading '"'"'%s'"'" "$1" "$2" "$3"; } # SPAN TARGET HEADING
+nocite() { printf '`%s`: no tracked file at %s beside %s or at the repository root' "$1" "$2" "$3"; } # SPAN PATH SRC
+noprefix() { printf '%s: %s has no heading at the start of '"'"'%s'"'" "$1" "$2" "$3"; } # RAW TARGET VALUE
+climbs() { printf '%s: the link climbs above the repository root' "$1"; } # RAW
+nodecision() { printf '%s: no tracked decision file docs/decisions/%s-*.md' "$1" "$1"; } # ID
+
+# Table one: AGENTS.md holds CONTENT in WORLD, judged with --all under ENVS.
+ROW=0
+cite_rows() { # label | world | envs | content | expect
+  local row label world envs content expect
+  for row in "$@"; do
+    IFS='|' read -r label world envs content expect <<<"$row"
+    ROW=$((ROW + 1))
+    R=""
+    "world_$world" "$world-$ROW"
+    put AGENTS.md "$content"
+    assert_eq "$label" "$expect" "$(run "$envs" --all)"
+  done
 }
-
-# AGENTS.md holds CONTENT; assert the --all verdict, and on a dead reference
-# the line and message fragment named.
-cite() { # LABEL EXPECT-RC CONTENT [LINE MESSAGE-FRAGMENT]
-  local label="$1" want="$2" content="$3" line="${4-}" msg="${5-}"
-  put AGENTS.md "$content"
-  run_refs --all
-  if [ "$RC" -ne "$want" ]; then
-    bad "$label" "rc=$RC want=$want out=$OUT"
-    return
-  fi
-  if [ "$want" -eq 1 ]; then
-    case "$OUT" in
-      *"dead reference: AGENTS.md:$line: "*"$msg"*) ok "$label" ;;
-      *) bad "$label" "expected AGENTS.md:$line: ...$msg in: $OUT" ;;
-    esac
-  else
-    ok "$label"
-  fi
-}
-
-new_repo refs
-put docs/architecture/overview.md $'# Overview\n\n## The one idea\n\n## The one idea\n\n## Fish & Chips (v2) `code`\n\n<a id="explicit"></a>\n\nText.\n'
-put docs/guide.md $'# Guide\n'
-put skills/x/SKILL.md $'# X\n'
-put pic.png 'not really'
 
 echo "=== links: a tracked path, a heading slug, an explicit anchor ==="
-cite "links to a tracked file, a directory and a heading resolve" 0 \
-  $'[a](docs/guide.md) [b](docs/) [c](skills/x/SKILL.md) [d](docs/architecture/overview.md#the-one-idea) [e](pic.png)\n'
-case "$OUT" in *"5 reference(s) resolve in 3 tracked markdown file(s)"*) ok "the verdict counts the references it judged" ;; *) bad "verdict counts references" "$OUT" ;; esac
-cite "a link to an untracked file fails" 1 $'[a](docs/nope.md)\n' 1 "no tracked file or directory at docs/nope.md"
-cite "a link to a heading the target has not got fails" 1 $'[a](docs/guide.md#nothing)\n' 1 "docs/guide.md has no heading or explicit anchor #nothing"
-cite "a duplicate heading takes the -1 suffix" 0 $'[a](docs/architecture/overview.md#the-one-idea-1)\n'
-cite "control: the -2 suffix names no heading" 1 $'[a](docs/architecture/overview.md#the-one-idea-2)\n' 1 "no heading or explicit anchor #the-one-idea-2"
-cite "punctuation is dropped, spaces become hyphens, code text stays" 0 $'[a](docs/architecture/overview.md#fish--chips-v2-code)\n'
-cite "an explicit <a id> is an anchor" 0 $'[a](docs/architecture/overview.md#explicit)\n'
-cite "a non-ASCII letter keeps its case in the slug and in the § comparison" 0 \
-  $'## Über Ünïcode\n\n[v](#Über-Ünïcode) `AGENTS.md § Über Ünïcode`\n'
-cite "control: the lower-cased spelling of that slug is dead" 1 $'## Über Ünïcode\n\n[u](#über-ünïcode)\n' 3 "has no heading or explicit anchor #über-ünïcode"
-cite "control: and so is the lower-cased § citation" 1 $'## Über Ünïcode\n\n`AGENTS.md § über ünïcode`\n' 3 "has no heading 'über ünïcode'"
-cite "a bare #anchor resolves in the citing file" 0 $'# Map\n\n[here](#map)\n'
-cite "control: a bare #anchor with no such heading fails" 1 $'# Map\n\n[gone](#gone)\n' 3 "AGENTS.md has no heading or explicit anchor #gone"
-cite "a link climbing above the root fails" 1 $'[a](../etc/passwd)\n' 1 "climbs above the repository root"
-cite "a bare #anchor after a climbing link is judged on its own" 1 $'# Root\n\n[a](../x.md) [b](#root)\n' 3 "](../x.md): the link climbs above the repository root"
-case "$OUT" in *"](#root)"*) bad "the bare anchor beside the climbing link lands" "$OUT" ;; *"1 dead reference(s)"*) ok "the bare anchor beside the climbing link lands" ;; *) bad "the bare anchor beside the climbing link lands" "$OUT" ;; esac
-cite "control: a dead bare #anchor after a climbing link is named for what it is" 1 $'# Root\n\n[a](../x.md) [b](#gone)\n' 3 "](#gone): AGENTS.md has no heading or explicit anchor #gone"
-cite "an anchor into a file that is not markdown fails" 1 $'[a](pic.png#view)\n' 1 "an anchor into a file that is not markdown"
-cite "a scheme, a mailto and a leading slash are not judged" 0 $'[a](https://x/y.md#z) [b](mailto:x@y.z) [c](/abs/nope.md)\n'
-cite "a reference definition is judged" 1 $'[label]: docs/nope.md\n' 1 "no tracked file or directory at docs/nope.md"
-cite "a link in fenced code is not read" 0 $'```\n[a](docs/nope.md)\n```\n'
-cite "control: the same link outside the fence fails" 1 $'[a](docs/nope.md)\n\n```\n[b](docs/nope.md)\n```\n' 1 "docs/nope.md"
-cite "a link in an indented code block is not read" 0 $'Para\n\n    [a](docs/nope.md)\n'
-
-echo "=== links resolve relative to the citing file ==="
-put docs/architecture/topic.md $'[up](../guide.md) [sib](overview.md#the-one-idea) [down](../../skills/x/SKILL.md)\n'
-cite "a nested file's relative links resolve from its own directory" 0 $'Clean.\n'
-put docs/architecture/topic.md $'[wrong](guide.md)\n'
-run_refs --all
-[ "$RC" -eq 1 ] && case "$OUT" in *"docs/architecture/topic.md:1: "*"no tracked file or directory at docs/architecture/guide.md"*) true ;; *) false ;; esac \
-  && ok "control: a root-relative spelling from a nested file fails, naming where it looked" || bad "control: nested relative link" "rc=$RC out=$OUT"
-git -C "$R" rm -qf docs/architecture/topic.md
+cite_rows \
+  "links to a tracked file, a directory, a heading and a non-markdown file resolve, and the verdict counts them|refs||[a](docs/guide.md) [b](docs/) [c](skills/x/SKILL.md) [d](docs/architecture/overview.md#the-one-idea) [e](pic.png)\n|rc=0 $(clean 5 3)" \
+  "a link to an untracked file fails, quoting the link and naming where it looked|refs||[a](docs/nope.md)\n|rc=1 $(dead AGENTS.md 1 "$(untracked '](docs/nope.md)' docs/nope.md)");$(failed 1 1 3)" \
+  "a link to a heading the target has not got fails|refs||[a](docs/guide.md#nothing)\n|rc=1 $(dead AGENTS.md 1 "$(noslug '](docs/guide.md#nothing)' docs/guide.md nothing)");$(failed 1 1 3)" \
+  "a duplicate heading takes the -1 suffix|refs||[a](docs/architecture/overview.md#the-one-idea-1)\n|rc=0 $(clean 1 3)" \
+  "control: the -2 suffix names no heading|refs||[a](docs/architecture/overview.md#the-one-idea-2)\n|rc=1 $(dead AGENTS.md 1 "$(noslug '](docs/architecture/overview.md#the-one-idea-2)' docs/architecture/overview.md the-one-idea-2)");$(failed 1 1 3)" \
+  "punctuation is dropped, spaces become hyphens, code text stays|refs||[a](docs/architecture/overview.md#fish--chips-v2-code)\n|rc=0 $(clean 1 3)" \
+  "an explicit <a id> is an anchor|refs||[a](docs/architecture/overview.md#explicit)\n|rc=0 $(clean 1 3)" \
+  "a non-ASCII letter keeps its case in the slug and in the § comparison|refs||## Über Ünïcode\n\n[v](#Über-Ünïcode) \`AGENTS.md § Über Ünïcode\`\n|rc=0 $(clean 2 3)" \
+  "control: the lower-cased spelling of that slug is dead|refs||## Über Ünïcode\n\n[u](#über-ünïcode)\n|rc=1 $(dead AGENTS.md 3 "$(noslug '](#über-ünïcode)' AGENTS.md über-ünïcode)");$(failed 1 1 3)" \
+  "control: and so is the lower-cased § citation|refs||## Über Ünïcode\n\n\`AGENTS.md § über ünïcode\`\n|rc=1 $(dead AGENTS.md 3 "$(notext 'AGENTS.md § über ünïcode' AGENTS.md 'über ünïcode')");$(failed 1 1 3)" \
+  "a bare #anchor resolves in the citing file|refs||# Map\n\n[here](#map)\n|rc=0 $(clean 1 3)" \
+  "control: a bare #anchor with no such heading fails|refs||# Map\n\n[gone](#gone)\n|rc=1 $(dead AGENTS.md 3 "$(noslug '](#gone)' AGENTS.md gone)");$(failed 1 1 3)" \
+  "a link climbing above the root fails|refs||[a](../etc/passwd)\n|rc=1 $(dead AGENTS.md 1 "$(climbs '](../etc/passwd)')");$(failed 1 1 3)" \
+  "a bare #anchor after a climbing link is judged on its own and lands|refs||# Root\n\n[a](../x.md) [b](#root)\n|rc=1 $(dead AGENTS.md 3 "$(climbs '](../x.md)')");$(failed 1 2 3)" \
+  "control: a dead bare #anchor after a climbing link is named for what it is|refs||# Root\n\n[a](../x.md) [b](#gone)\n|rc=1 $(dead AGENTS.md 3 "$(climbs '](../x.md)')");$(dead AGENTS.md 3 "$(noslug '](#gone)' AGENTS.md gone)");$(failed 2 2 3)" \
+  "an anchor into a file that is not markdown fails|refs||[a](pic.png#view)\n|rc=1 $(dead AGENTS.md 1 '](pic.png#view): an anchor into a file that is not markdown');$(failed 1 1 3)" \
+  "a scheme, a mailto and a leading slash are not judged|refs||[a](https://x/y.md#z) [b](mailto:x@y.z) [c](/abs/nope.md)\n|rc=0 $(clean 0 3)" \
+  "a reference definition is judged, quoted whole|refs||[label]: docs/nope.md\n|rc=1 $(dead AGENTS.md 1 "$(untracked '[label]: docs/nope.md' docs/nope.md)");$(failed 1 1 3)" \
+  "a link in fenced code is not read|refs||\`\`\`\n[a](docs/nope.md)\n\`\`\`\n|rc=0 $(clean 0 3)" \
+  "control: the same link outside the fence fails, and only it|refs||[a](docs/nope.md)\n\n\`\`\`\n[b](docs/nope.md)\n\`\`\`\n|rc=1 $(dead AGENTS.md 1 "$(untracked '](docs/nope.md)' docs/nope.md)");$(failed 1 1 3)" \
+  "a link in an indented code block is not read|refs||Para\n\n    [a](docs/nope.md)\n|rc=0 $(clean 0 3)"
 
 echo "=== code-span citations: path, § heading, #anchor ==="
-cite "a path alone in a code span is a name, not a citation" 0 $'See `docs/nope.md` and `tmp/out.md`.\n'
-cite "control: the same path with a heading is a citation" 1 $'See `docs/nope.md § Top`.\n' 1 "no tracked file at docs/nope.md"
-cite "a bracketed template line holding [X]: [Y] is not a definition" 0 $'   [For each item: "- [ID]: [SUMMARY] and [PATH]"]\n'
-cite "a bare file name in a code span is a name, not a citation" 0 $'The record is `CHANGELOG.md`; see `nope.md`.\n'
-cite "control: the same bare name with a heading is a citation" 1 $'See `nope.md § Top`.\n' 1 "no tracked file at nope.md"
-cite "a § citation matches a heading case-insensitively" 0 $'See `docs/architecture/overview.md § the ONE idea`.\n'
-cite "control: a § citation naming no heading fails" 1 $'See `docs/architecture/overview.md § Nope`.\n' 1 "has no heading 'Nope'"
-cite "a #anchor citation matches a slug" 0 $'See `docs/architecture/overview.md#fish--chips-v2-code`.\n'
-cite "control: a #anchor citation naming no slug fails" 1 $'See `docs/architecture/overview.md#nope`.\n' 1 "no heading or explicit anchor #nope"
-cite "a root-relative citation resolves at the root" 0 $'See `docs/guide.md § Guide`.\n'
-put docs/architecture/topic.md $'See `overview.md § The one idea` and `docs/guide.md`.\n'
-cite "a nested file's citation resolves beside it, and a root path still resolves" 0 $'Clean.\n'
-git -C "$R" rm -qf docs/architecture/topic.md
-cite "a code span that is not a path shape is not a citation" 0 $'Run `md-format --all`, see `*.md`, `changelog.d/<section>/<name>.md`, `foo.md:12`.\n'
-cite "a citation in a fence is not read" 0 $'```\n`docs/nope.md § X`\n```\n'
+cite_rows \
+  "a path alone in a code span is a name, not a citation|refs||See \`docs/nope.md\` and \`tmp/out.md\`.\n|rc=0 $(clean 0 3)" \
+  "control: the same path with a heading is a citation|refs||See \`docs/nope.md § Top\`.\n|rc=1 $(dead AGENTS.md 1 "$(nocite 'docs/nope.md § Top' docs/nope.md AGENTS.md)");$(failed 1 1 3)" \
+  "a bracketed template line holding [X]: [Y] is not a definition|refs||   [For each item: \"- [ID]: [SUMMARY] and [PATH]\"]\n|rc=0 $(clean 0 3)" \
+  "a bare file name in a code span is a name, not a citation|refs||The record is \`CHANGELOG.md\`; see \`nope.md\`.\n|rc=0 $(clean 0 3)" \
+  "control: the same bare name with a heading is a citation|refs||See \`nope.md § Top\`.\n|rc=1 $(dead AGENTS.md 1 "$(nocite 'nope.md § Top' nope.md AGENTS.md)");$(failed 1 1 3)" \
+  "a § citation matches a heading case-insensitively|refs||See \`docs/architecture/overview.md § the ONE idea\`.\n|rc=0 $(clean 1 3)" \
+  "control: a § citation naming no heading fails|refs||See \`docs/architecture/overview.md § Nope\`.\n|rc=1 $(dead AGENTS.md 1 "$(notext 'docs/architecture/overview.md § Nope' docs/architecture/overview.md Nope)");$(failed 1 1 3)" \
+  "a #anchor citation matches a slug|refs||See \`docs/architecture/overview.md#fish--chips-v2-code\`.\n|rc=0 $(clean 1 3)" \
+  "control: a #anchor citation naming no slug fails|refs||See \`docs/architecture/overview.md#nope\`.\n|rc=1 $(dead AGENTS.md 1 "\`docs/architecture/overview.md#nope\`: docs/architecture/overview.md has no heading or explicit anchor #nope");$(failed 1 1 3)" \
+  "a root-relative citation resolves at the root|refs||See \`docs/guide.md § Guide\`.\n|rc=0 $(clean 1 3)" \
+  "a code span that is not a path shape is not a citation|refs||Run \`md-format --all\`, see \`*.md\`, \`changelog.d/<section>/<name>.md\`, \`foo.md:12\`.\n|rc=0 $(clean 0 3)" \
+  "a citation in a fence is not read|refs||\`\`\`\n\`docs/nope.md § X\`\n\`\`\`\n|rc=0 $(clean 0 3)"
 
 echo "=== decision IDs: judged only where the decisions directory is tracked ==="
-cite "with no tracked decisions directory, an ID is not judged and the verdict says so" 0 $'Decided in D042.\n'
-case "$OUT" in *"decision IDs not judged (docs/decisions is not tracked)"*) ok "the verdict names the untracked directory" ;; *) bad "verdict names untracked dir" "$OUT" ;; esac
-put docs/decisions/D001-first.md $'# D001\n\n## Context\n'
-put docs/decisions/INDEX.md $'| D001 |\n'
-cite "a cited ID with a tracked file passes, in prose and in a code span" 0 $'Decided in D001; see `D001 § Context`.\n'
-case "$OUT" in *"decision IDs judged against docs/decisions"*) ok "the verdict names the directory judged against" ;; *) bad "verdict names judged dir" "$OUT" ;; esac
-cite "an ID citing a heading its decision does not have fails" 1 $'See `D001 § Rationale`.\n' 1 "docs/decisions/D001-first.md has no heading at the start of 'Rationale"
-cite "a cited ID with no tracked file fails" 1 $'Decided in D042.\n' 1 "D042: no tracked decision file docs/decisions/D042-*.md"
-cite "a shorter digit run, a glued letter and a colour are not IDs" 0 $'D42, MD001, D001x, #001 and 3D001 are not decisions.\n'
-cite "an ID in fenced code is not read" 0 $'```\nD042\n```\n'
-OUT="$(cd "$R" && DECISION_ID_PREFIX=ADR- DECISION_ID_WIDTH=4 "$MDR" --all 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && ok "under another scheme the D-prefixed text is not an ID" || bad "other scheme ignores D ids" "rc=$RC out=$OUT"
-put AGENTS.md $'Decided in ADR-0007.\n'
-OUT="$(cd "$R" && DECISION_ID_PREFIX=ADR- DECISION_ID_WIDTH=4 "$MDR" --all 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 1 ] && case "$OUT" in *"ADR-0007: no tracked decision file"*) true ;; *) false ;; esac \
-  && ok "DECISION_ID_PREFIX and DECISION_ID_WIDTH select the scheme" || bad "scheme settings" "rc=$RC out=$OUT"
-put docs/decisions/ADR-0007-x.md $'# ADR-0007\n'
-OUT="$(cd "$R" && DECISION_ID_PREFIX=ADR- DECISION_ID_WIDTH=4 "$MDR" --all 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && ok "control: the same ID passes once its file is tracked" || bad "control: ADR file tracked" "rc=$RC out=$OUT"
-put AGENTS.md $'Decided in D001.\n'
-OUT="$(cd "$R" && DECISIONS_DIR=elsewhere "$MDR" --all 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && case "$OUT" in *"not judged (elsewhere is not tracked)"*) true ;; *) false ;; esac \
-  && ok "DECISIONS_DIR moves the directory" || bad "DECISIONS_DIR" "rc=$RC out=$OUT"
-OUT="$(cd "$R" && DECISION_ID_WIDTH=0 "$MDR" --all 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && ok "a zero width is exit 2" || bad "zero width is exit 2" "rc=$RC out=$OUT"
-
-echo "=== the path list: agent-loaded markdown and architecture docs ==="
-new_repo scope
-put ok.md $'# OK\n'
-for f in AGENTS.md CLAUDE.md SKILL.md skills/dev/SKILL.md skills/dev/AGENTS.md workflows/ship.md skills/dev/workflows/ship.md agents/rust.md .claude/agents/rust.md docs/architecture/overview.md; do
-  put "$f" $'[dead](nope.md)\n'
-  run_refs --all
-  [ "$RC" -eq 1 ] && case "$OUT" in *"dead reference: $f:1:"*) true ;; *) false ;; esac \
-    && ok "$f is in the default scope" || bad "$f is in the default scope" "rc=$RC out=$OUT"
-  put "$f" $'# Top\n\n[live](#top)\n'
-done
-for f in README.md docs/design.md skills/dev/references/api.md; do
-  put "$f" $'[dead](nope.md)\n'
-done
-run_refs --all
-[ "$RC" -eq 0 ] && case "$OUT" in *"10 tracked markdown file(s)"*) true ;; *) false ;; esac \
-  && ok "a README, a doc outside docs/architecture and a reference file are not judged, with the ten scoped files still read" \
-  || bad "out-of-scope files not judged" "rc=$RC out=$OUT"
-OUT="$(cd "$R" && COMMIT_GUARDS_MD_REFS_PATHS='docs/*.md' "$MDR" --all 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 1 ] && case "$OUT" in *"AGENTS.md:1:"*) false ;; *"docs/design.md:1:"*) true ;; *) false ;; esac \
-  && ok "COMMIT_GUARDS_MD_REFS_PATHS replaces the list" || bad "path list replaces" "rc=$RC out=$OUT"
+cite_rows \
+  "with no tracked decisions directory, an ID is not judged and the verdict says so|refs||Decided in D042.\n|rc=0 $(clean 0 3)" \
+  "a cited ID with a tracked file passes, in prose and in a code span, and the verdict names the directory|dec||Decided in D001; see \`D001 § Context\`.\n|rc=0 $(clean 2 3 0 "$DEC_YES")" \
+  "an ID citing a heading its decision does not have fails, the heading read to the end of the line|dec||See \`D001 § Rationale\`.\n|rc=1 $(dead AGENTS.md 1 "$(noprefix 'D001 § Rationale`.' docs/decisions/D001-first.md 'Rationale`.')");$(failed 1 1 3 0 "$DEC_YES")" \
+  "a cited ID with no tracked file fails|dec||Decided in D042.\n|rc=1 $(dead AGENTS.md 1 "$(nodecision D042)");$(failed 1 1 3 0 "$DEC_YES")" \
+  "a shorter digit run, a glued letter and a colour are not IDs|dec||D42, MD001, D001x, #001 and 3D001 are not decisions.\n|rc=0 $(clean 0 3 0 "$DEC_YES")" \
+  "an ID in fenced code is not read|dec||\`\`\`\nD042\n\`\`\`\n|rc=0 $(clean 0 3 0 "$DEC_YES")" \
+  "under another scheme the D-prefixed text is not an ID|dec|DECISION_ID_PREFIX=ADR-,DECISION_ID_WIDTH=4|Decided in D042.\n|rc=0 $(clean 0 3 0 "$DEC_YES")" \
+  "DECISION_ID_PREFIX and DECISION_ID_WIDTH select the scheme|dec|DECISION_ID_PREFIX=ADR-,DECISION_ID_WIDTH=4|Decided in ADR-0007.\n|rc=1 $(dead AGENTS.md 1 "$(nodecision ADR-0007)");$(failed 1 1 3 0 "$DEC_YES")" \
+  "control: the same ID passes once its file is tracked|adr|DECISION_ID_PREFIX=ADR-,DECISION_ID_WIDTH=4|Decided in ADR-0007.\n|rc=0 $(clean 1 3 0 "$DEC_YES")" \
+  "DECISIONS_DIR moves the directory, and the verdict names it|dec|DECISIONS_DIR=elsewhere|Decided in D001.\n|rc=0 $(clean 0 3 0 'decision IDs not judged (elsewhere is not tracked)')" \
+  "a zero width is exit 2, quoting the value|dec|DECISION_ID_WIDTH=0|Decided in D001.\n|rc=2 ${ERR}DECISION_ID_WIDTH must be a positive integer, got '0'" \
+  "a prefix outside letters, digits, '_' and '-' is exit 2, quoting the value|dec|DECISION_ID_PREFIX=a.b|Decided in D001.\n|rc=2 ${ERR}DECISION_ID_PREFIX must be letters, digits, '_' or '-', got 'a.b'"
 
 echo "=== a link followed by a section name resolves the heading prefix ==="
-new_repo section-links
-put guide.md $'# Guide\n\n## Install\n'
-cite "a plain section route resolves" 0 $'[guide](guide.md) § Install.\n'
-cite "a formatted section route resolves with following prose" 0 $'[guide](guide.md) § `Install` explains setup.\n'
-cite "a missing section route fails" 1 $'[guide](guide.md) § Missing section.\n' 1 "has no heading at the start"
-cite "a section name needs its boundary" 1 $'[guide](guide.md) § Installer.\n' 1 "has no heading at the start"
-cite "a link inside a code example is not a reference" 0 $'`[guide](guide.md) § Missing section.`\n'
-put guide.md $'# Guide\n\n## 1. Install\n\n### 1.1.1 Choose a path\n'
-cite "a numbered section route resolves" 0 $'[guide](guide.md) § 1 describes setup.\n'
-cite "a nested numbered section route resolves" 0 $'[guide](guide.md) § 1.1.1 describes the path.\n'
-cite "a missing numbered section cannot match its parent" 1 $'[guide](guide.md) § 1.1.2 describes the path.\n' 1 "has no heading at the start"
+cite_rows \
+  "a plain section route resolves, the link and the route each counted|install||[guide](guide.md) § Install.\n|rc=0 $(clean 2 1)" \
+  "a formatted section route resolves with following prose|install||[guide](guide.md) § \`Install\` explains setup.\n|rc=0 $(clean 2 1)" \
+  "a missing section route fails, quoting the route and the text it read|install||[guide](guide.md) § Missing section.\n|rc=1 $(dead AGENTS.md 1 "$(noprefix 'guide.md § Missing section.' guide.md 'Missing section.')");$(failed 1 2 1)" \
+  "a section name needs its boundary|install||[guide](guide.md) § Installer.\n|rc=1 $(dead AGENTS.md 1 "$(noprefix 'guide.md § Installer.' guide.md 'Installer.')");$(failed 1 2 1)" \
+  "a link inside a code example is not a reference|install||\`[guide](guide.md) § Missing section.\`\n|rc=0 $(clean 0 1)" \
+  "a numbered section route resolves|numbered||[guide](guide.md) § 1 describes setup.\n|rc=0 $(clean 2 1)" \
+  "a nested numbered section route resolves|numbered||[guide](guide.md) § 1.1.1 describes the path.\n|rc=0 $(clean 2 1)" \
+  "a missing numbered section cannot match its parent|numbered||[guide](guide.md) § 1.1.2 describes the path.\n|rc=1 $(dead AGENTS.md 1 "$(noprefix 'guide.md § 1.1.2 describes the path.' guide.md '1.1.2 describes the path.')");$(failed 1 2 1)"
 
 echo "=== section-route regression controls ==="
-new_repo section-regressions
-put guide.md $'# Guide\n\n## 1\n\n## Install\n'
-put 'guide(foo).md' $'# Guide\n\n## Install\n'
-cite "numeric routes cannot fall through to a bare parent prefix" 1 $'[guide](guide.md) § 1.1.2 details.\n' 1 "has no heading at the start"
-cite "balanced destination parentheses do not hide a missing section" 1 $'[guide](guide(foo).md) § Missing.\n' 1 "has no heading at the start"
-cite "underscore emphasis resolves like the other emphasis markers" 0 $'[guide](guide.md) § _Install_ explains setup.\n'
-cite "escaped destination parentheses do not hide a missing section" 1 $'[guide](guide\\(foo\\).md) § Missing.\n' 1 "has no heading at the start"
-cite "parentheses in a link title do not hide a missing section" 1 $'[guide](guide(foo).md "A ) title") § Missing.\n' 1 "has no heading at the start"
-cite "an angle destination and title retain a valid section route" 0 $'[guide](<guide(foo).md> "A ) title") § Install.\n'
+cite_rows \
+  "numeric routes cannot fall through to a bare parent prefix|parens||[guide](guide.md) § 1.1.2 details.\n|rc=1 $(dead AGENTS.md 1 "$(noprefix 'guide.md § 1.1.2 details.' guide.md '1.1.2 details.')");$(failed 1 2 1)" \
+  "balanced destination parentheses do not hide a missing section|parens||[guide](guide(foo).md) § Missing.\n|rc=1 $(dead AGENTS.md 1 "$(noprefix 'guide(foo).md § Missing.' 'guide(foo).md' 'Missing.')");$(failed 1 2 1)" \
+  "underscore emphasis resolves like the other emphasis markers|parens||[guide](guide.md) § _Install_ explains setup.\n|rc=0 $(clean 2 1)" \
+  "escaped destination parentheses do not hide a missing section|parens||[guide](guide\\\\(foo\\\\).md) § Missing.\n|rc=1 $(dead AGENTS.md 1 "$(noprefix 'guide(foo).md § Missing.' 'guide(foo).md' 'Missing.')");$(failed 1 2 1)" \
+  "parentheses in a link title do not hide a missing section|parens||[guide](guide(foo).md \"A ) title\") § Missing.\n|rc=1 $(dead AGENTS.md 1 "$(noprefix 'guide(foo).md § Missing.' 'guide(foo).md' 'Missing.')");$(failed 1 2 1)" \
+  "an angle destination and title retain a valid section route|parens||[guide](<guide(foo).md> \"A ) title\") § Install.\n|rc=0 $(clean 2 1)"
 
 echo "=== symmetric normalization, punctuation and anchored section routes ==="
-new_repo section-text
-put guide.md $'# Guide\n\n## snake_case\n\n## Install\n\n## 2.\n\n## 3)\n\n## 4.1.\n\n## Use *tools*\n'
-cite "snake_case resolves with symmetric normalization" 0 $'[guide](guide.md) § snake_case.\n'
-cite "formatted snake_case resolves with symmetric normalization" 0 $'[guide](guide.md) § **snake_case** describes naming.\n'
-cite "emphasis inside a heading resolves" 0 $'[guide](guide.md) § Use tools.\n'
-cite "a question mark ends a section prefix" 0 $'[guide](guide.md) § Install?\n'
-cite "an exclamation mark ends a section prefix" 0 $'[guide](guide.md) § Install!\n'
-cite "punctuation does not accept an incomplete heading" 1 $'[guide](guide.md) § Instal!\n' 1 "has no heading at the start"
-cite "a valid anchor does not hide a missing section" 1 $'[guide](guide.md#install) § Missing.\n' 1 "has no heading at the start"
-cite "an anchored link also accepts a valid section" 0 $'[guide](guide.md#install) § Install.\n'
-cite "a bare anchor does not hide a missing section" 1 $'# Guide\n\n[guide](#guide) § Missing.\n' 3 "has no heading at the start"
-cite "a terminal period in a bare numbered heading resolves" 0 $'[guide](guide.md) § 2 describes setup.\n'
-cite "a terminal parenthesis in a bare numbered heading resolves" 0 $'[guide](guide.md) § 3 describes setup.\n'
-cite "a terminal period in a nested numbered heading resolves" 0 $'[guide](guide.md) § 4.1 describes setup.\n'
-cite "a question mark ends a numbered section prefix" 0 $'[guide](guide.md) § 2?\n'
-cite "an exclamation mark ends a numbered section prefix" 0 $'[guide](guide.md) § 3!\n'
-cite "a missing child cannot resolve to a punctuated number" 1 $'[guide](guide.md) § 4.1.2 describes setup.\n' 1 "has no heading at the start"
-put guide.md $'# Guide\n\n## `snake_case`\n'
-cite "code spans resolve with symmetric normalization" 0 $'[guide](guide.md) § `snake_case`.\n'
+cite_rows \
+  "snake_case resolves with symmetric normalization|text||[guide](guide.md) § snake_case.\n|rc=0 $(clean 2 1)" \
+  "formatted snake_case resolves with symmetric normalization|text||[guide](guide.md) § **snake_case** describes naming.\n|rc=0 $(clean 2 1)" \
+  "emphasis inside a heading resolves|text||[guide](guide.md) § Use tools.\n|rc=0 $(clean 2 1)" \
+  "a question mark ends a section prefix|text||[guide](guide.md) § Install?\n|rc=0 $(clean 2 1)" \
+  "an exclamation mark ends a section prefix|text||[guide](guide.md) § Install!\n|rc=0 $(clean 2 1)" \
+  "punctuation does not accept an incomplete heading|text||[guide](guide.md) § Instal!\n|rc=1 $(dead AGENTS.md 1 "$(noprefix 'guide.md § Instal!' guide.md 'Instal!')");$(failed 1 2 1)" \
+  "a valid anchor does not hide a missing section|text||[guide](guide.md#install) § Missing.\n|rc=1 $(dead AGENTS.md 1 "$(noprefix 'guide.md#install § Missing.' guide.md 'Missing.')");$(failed 1 2 1)" \
+  "an anchored link also accepts a valid section|text||[guide](guide.md#install) § Install.\n|rc=0 $(clean 2 1)" \
+  "a bare anchor does not hide a missing section|text||# Guide\n\n[guide](#guide) § Missing.\n|rc=1 $(dead AGENTS.md 3 "$(noprefix '#guide § Missing.' AGENTS.md 'Missing.')");$(failed 1 2 1)" \
+  "a terminal period in a bare numbered heading resolves|text||[guide](guide.md) § 2 describes setup.\n|rc=0 $(clean 2 1)" \
+  "a terminal parenthesis in a bare numbered heading resolves|text||[guide](guide.md) § 3 describes setup.\n|rc=0 $(clean 2 1)" \
+  "a terminal period in a nested numbered heading resolves|text||[guide](guide.md) § 4.1 describes setup.\n|rc=0 $(clean 2 1)" \
+  "a question mark ends a numbered section prefix|text||[guide](guide.md) § 2?\n|rc=0 $(clean 2 1)" \
+  "an exclamation mark ends a numbered section prefix|text||[guide](guide.md) § 3!\n|rc=0 $(clean 2 1)" \
+  "a missing child cannot resolve to a punctuated number|text||[guide](guide.md) § 4.1.2 describes setup.\n|rc=1 $(dead AGENTS.md 1 "$(noprefix 'guide.md § 4.1.2 describes setup.' guide.md '4.1.2 describes setup.')");$(failed 1 2 1)" \
+  "code spans resolve with symmetric normalization|code||[guide](guide.md) § \`snake_case\`.\n|rc=0 $(clean 2 1)"
 
-echo "=== citations in comment text and in TOML strings ==="
-new_repo source
-put docs/architecture/plugins.md $'# Plugins\n\n## Invariants\n'
-put AGENTS.md $'# A\n\n## Rules\n'
-
-# PATH holds CONTENT for this one case; assert the --all verdict, and on a
-# dead citation the line and message fragment named. The file goes again
-# afterwards, so one case's planted citation cannot decide the next.
-src_cite() { # LABEL EXPECT-RC PATH CONTENT [LINE MESSAGE-FRAGMENT]
-  local label="$1" want="$2" path="$3" content="$4" line="${5-}" msg="${6-}"
-  put "$path" "$content"
-  run_refs --all
-  git -C "$R" rm -q --cached "$path"
-  rm -f "$R/$path"
-  if [ "$RC" -ne "$want" ]; then
-    bad "$label" "rc=$RC want=$want out=$OUT"
-    return
-  fi
-  if [ "$want" -eq 1 ]; then
-    case "$OUT" in
-      *"dead reference: $path:$line: "*"$msg"*) ok "$label" ;;
-      *) bad "$label" "expected $path:$line: ...$msg in: $OUT" ;;
-    esac
-  else
-    ok "$label"
-  fi
+# Table two: FIXTURE (a function and its words) builds the repository; the
+# judge runs with ARGS under ENVS.
+run_rows() { # label | fixture | envs | args | expect
+  local row label fx envs args expect words
+  for row in "$@"; do
+    IFS='|' read -r label fx envs args expect <<<"$row"
+    R=""
+    read -ra words <<<"$fx"
+    "${words[@]}"
+    assert_eq "$label" "$expect" "$(run "$envs" "$args")"
+  done
 }
 
-src_cite "a citation in comment text resolves" 0 bin/helper.sh \
-  $'#!/usr/bin/env bash\n# The rule is docs/architecture/plugins.md § Invariants, not this file.\ntrue\n'
-src_cite "a comment citing a heading the target does not have is dead" 1 bin/helper.sh \
-  $'#!/usr/bin/env bash\n# The rule is docs/architecture/plugins.md § Gone, not this file.\ntrue\n' \
-  2 "docs/architecture/plugins.md has no heading at the start of 'Gone"
-src_cite "a citation in a TOML string resolves" 0 kendex.toml $'note = "AGENTS.md § Rules apply here"\n'
-src_cite "a TOML string citing a heading the target does not have is dead" 1 kendex.toml \
-  $'note = "AGENTS.md § Gone"\n' 1 "AGENTS.md has no heading at the start of 'Gone"
-src_cite "a string literal outside a manifest is not judged" 0 src/lib.rs \
-  $'fn f() -> &\'static str { "AGENTS.md \302\247 Gone" }\n'
-src_cite "control: the same citation in that file's comment is judged" 1 src/lib.rs \
-  $'// AGENTS.md \302\247 Gone\nfn f() {}\n' 1 "AGENTS.md has no heading at the start of 'Gone"
-put docs/decisions/D008-scope.md $'# D008\n\n## Scope\n'
-src_cite "a decision citation in comment text checks the heading" 0 scripts/smoke.sh \
-  $'#!/usr/bin/env bash\n# What this covers is D008 § Scope.\ntrue\n'
-src_cite "a decision citing a heading it does not have is dead" 1 scripts/smoke.sh \
-  $'#!/usr/bin/env bash\n# What this covers is D008 § Reach.\ntrue\n' \
-  2 "docs/decisions/D008-scope.md has no heading at the start of 'Reach"
-src_cite "a bare decision ID in a comment is prose, not a citation" 0 scripts/smoke.sh \
-  $'#!/usr/bin/env bash\n# Superseded by D999, which does not exist.\ntrue\n'
-printf '*.svg %sdiff\n' '-' >"$R/.gitattributes"
-git -C "$R" add .gitattributes
-src_cite "a text file the attributes mark undiffable is still read" 1 icon.svg \
-  $'<!-- AGENTS.md \302\247 Gone -->\n' 1 "AGENTS.md has no heading at the start of 'Gone"
-# A NUL cannot travel through src_cite: bash truncates $'...' at one.
-printf '\001\000\002 AGENTS.md \302\247 Gone\n' >"$R/blob.h"
-git -C "$R" add blob.h
-run_refs --all
-git -C "$R" rm -q --cached blob.h
-rm -f "$R/blob.h"
-[ "$RC" -eq 0 ] && case "$OUT" in *"not measured: blob.h"*"binary content"*) true ;; *) false ;; esac \
-  && ok "a binary blob at a source path is named, never counted clean" \
-  || bad "binary carrier named" "rc=$RC out=$OUT"
+echo "=== links and citations resolve relative to the citing file ==="
+fx_nested_links() { world_refs nested-links; put docs/architecture/topic.md '[up](../guide.md) [sib](overview.md#the-one-idea) [down](../../skills/x/SKILL.md)\n'; put AGENTS.md 'Clean.\n'; }
+fx_nested_wrong() { world_refs nested-wrong; put docs/architecture/topic.md '[wrong](guide.md)\n'; put AGENTS.md 'Clean.\n'; }
+fx_nested_cite() { world_refs nested-cite; put docs/architecture/topic.md 'See `overview.md § The one idea` and `docs/guide.md`.\n'; put AGENTS.md 'Clean.\n'; }
+run_rows \
+  "a nested file's relative links resolve from its own directory|fx_nested_links||--all|rc=0 $(clean 3 4)" \
+  "control: a root-relative spelling from a nested file fails, naming where it looked|fx_nested_wrong||--all|rc=1 $(dead docs/architecture/topic.md 1 "$(untracked '](guide.md)' docs/architecture/guide.md)");$(failed 1 1 4)" \
+  "a nested file's citation resolves beside it, and a bare root path is a name|fx_nested_cite||--all|rc=0 $(clean 1 4)"
 
-src_cite "a URL is prose, not a citation into this repository" 0 scripts/link.sh \
-  $'#!/usr/bin/env bash\n# See https://example.com/guide.md \302\247 Gone for more.\ntrue\n'
-src_cite "a decision ID inside a URL is prose too" 0 scripts/link.sh \
-  $'#!/usr/bin/env bash\n# See https://example.com/D404 \302\247 Scope for more.\ntrue\n'
-src_cite "a path in a URL query is prose wherever it sits in the URL" 0 scripts/link.sh \
-  $'#!/usr/bin/env bash\n# See https://example.com/?doc=AGENTS.md \302\247 Gone here.\ntrue\n'
-src_cite "and so is a decision ID in one" 0 scripts/link.sh \
-  $'#!/usr/bin/env bash\n# See https://example.com/?decision=D404 \302\247 Scope here.\ntrue\n'
-src_cite "control: the same path without the scheme is judged" 1 scripts/link.sh \
-  $'#!/usr/bin/env bash\n# See AGENTS.md \302\247 Gone for more.\ntrue\n' \
-  2 "AGENTS.md has no heading at the start of 'Gone"
-# A carrier the extractor cannot read is an incomplete scan, never a pass:
-# the block comment below never closes, and the file holds a section sign.
-put src/broken.c $'/* AGENTS.md \302\247 Gone\nint main(void) { return 0; }\n'
-run_refs --all
-[ "$RC" -eq 2 ] && case "$OUT" in *"scan incomplete"*"1 carrier(s) could not be read"*) true ;; *) false ;; esac \
-  && ok "a carrier the extractor cannot read is exit 2, never a clean verdict" \
-  || bad "unreadable carrier fails closed" "rc=$RC out=$OUT"
-# The same carrier as the only measurable file: the empty-set answer must not
-# reach the exit 0 ahead of the incomplete scan.
-OUT="$(cd "$R" && COMMIT_GUARDS_MD_REFS_PATHS='no/such/*.md' "$MDR" --all 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"scan incomplete"*) true ;; *) false ;; esac \
-  && ok "an unreadable carrier beats the empty-set fast path" \
-  || bad "empty set hides an unread carrier" "rc=$RC out=$OUT"
-git -C "$R" rm -q --cached src/broken.c
-rm -f "$R/src/broken.c"
+echo "=== the path list: agent-loaded markdown and architecture docs ==="
+SCOPED="AGENTS.md CLAUDE.md SKILL.md skills/dev/SKILL.md skills/dev/AGENTS.md workflows/ship.md skills/dev/workflows/ship.md agents/rust.md .claude/agents/rust.md docs/architecture/overview.md"
+UNSCOPED="README.md docs/design.md skills/dev/references/api.md"
+scoped() { repo "scoped-${1//\//_}"; put "$1" '[dead](nope.md)\n'; } # PATH — the one tracked file, holding a dead link
+fx_unscoped() { # NAME — every scoped path live, every unscoped one dead
+  local f
+  repo "$1"
+  for f in $SCOPED; do put "$f" '# Top\n\n[live](#top)\n'; done
+  for f in $UNSCOPED; do put "$f" '[dead](nope.md)\n'; done
+}
+beside() { case "$1" in */*) printf '%s/%s' "${1%/*}" "$2" ;; *) printf '%s' "$2" ;; esac; } # PATH NAME — where a relative link from PATH lands
+rows=()
+for f in $SCOPED; do
+  rows+=("$f is in the default scope|scoped $f||--all|rc=1 $(dead "$f" 1 "$(untracked '](nope.md)' "$(beside "$f" nope.md)")");$(failed 1 1 1)")
+done
+run_rows "${rows[@]}" \
+  "a README, a doc outside docs/architecture and a reference file are not judged, with the ten scoped files still read|fx_unscoped unscoped||--all|rc=0 $(clean 10 10)" \
+  "COMMIT_GUARDS_MD_REFS_PATHS replaces the list|fx_unscoped replaced|COMMIT_GUARDS_MD_REFS_PATHS=docs/*.md|--all|rc=1 $(dead docs/design.md 1 "$(untracked '](nope.md)' docs/nope.md)");$(failed 1 2 2)"
 
-# The walk's own skip branches, each over a path that carries a live citation
-# so a silent drop would read as a pass.
-put target.sh $'#!/usr/bin/env bash\n# AGENTS.md \302\247 Gone\ntrue\n'
-ln -s target.sh "$R/link.sh"
-git -C "$R" add link.sh
-run_refs --all
-[ "$RC" -eq 1 ] && case "$OUT" in *"not measured: link.sh"*"tracked as a symlink"*) true ;; *) false ;; esac \
-  && ok "a symlink at a source path is named, and its target still judged" \
-  || bad "symlink at a source path" "rc=$RC out=$OUT"
-git -C "$R" rm -q --cached link.sh target.sh
-rm -f "$R/link.sh" "$R/target.sh"
-printf '#!/usr/bin/env bash\n# AGENTS.md \302\247 Gone\ntrue\n' >"$R/one"$'\n'"two.sh"
-git -C "$R" add -A
-run_refs --all
-[ "$RC" -eq 0 ] && case "$OUT" in *"not measured: "*"holds a newline"*) true ;; *) false ;; esac \
-  && ok "a path holding a newline is named, never quietly passed" \
-  || bad "newline path named" "rc=$RC out=$OUT"
-git -C "$R" rm -q --cached -- "one"$'\n'"two.sh"
-rm -f "$R/one"$'\n'"two.sh"
-git -C "$R" rm -q --cached .gitattributes
-rm -f "$R/.gitattributes"
+echo "=== citations in comment text and in TOML strings ==="
+SH='#!/usr/bin/env bash\n'
+fx_comment_ok() { world_src "$1"; put bin/helper.sh "$SH"'# The rule is docs/architecture/plugins.md \302\247 Invariants, not this file.\ntrue\n'; }
+fx_comment_dead() { world_src comment-dead; put bin/helper.sh "$SH"'# The rule is docs/architecture/plugins.md \302\247 Gone, not this file.\ntrue\n'; }
+fx_toml_ok() { world_src toml-ok; put kendex.toml 'note = "AGENTS.md \302\247 Rules apply here"\n'; }
+fx_toml_dead() { world_src toml-dead; put kendex.toml 'note = "AGENTS.md \302\247 Gone"\n'; }
+fx_rs_string() { world_src rs-string; put src/lib.rs 'fn f() -> &'"'"'static str { "AGENTS.md \302\247 Gone" }\n'; }
+fx_rs_comment() { world_src rs-comment; put src/lib.rs '// AGENTS.md \302\247 Gone\nfn f() {}\n'; }
+fx_dec_ok() { world_src_dec dec-ok; put scripts/smoke.sh "$SH"'# What this covers is D008 \302\247 Scope.\ntrue\n'; }
+fx_dec_dead() { world_src_dec dec-dead; put scripts/smoke.sh "$SH"'# What this covers is D008 \302\247 Reach.\ntrue\n'; }
+# The bare ID sits beside a live citation: a file holding no section sign is
+# never opened, so the row would pass on that alone.
+fx_dec_bare() { world_src_dec dec-bare; put scripts/smoke.sh "$SH"'# Superseded by D999, which does not exist; see D008 \302\247 Scope.\ntrue\n'; }
+fx_undiffable() { world_src undiffable; put .gitattributes '*.svg -diff\n'; put icon.svg '<!-- AGENTS.md \302\247 Gone -->\n'; }
+fx_binary() { world_src binary; put blob.h '\001\0000\002 AGENTS.md \302\247 Gone\n'; }
+fx_url() { world_src url; put scripts/link.sh "$SH"'# See https://example.com/guide.md \302\247 Gone for more.\ntrue\n'; }
+fx_url_id() { world_src_dec url-id; put scripts/link.sh "$SH"'# See https://example.com/D404 \302\247 Scope for more.\ntrue\n'; }
+fx_url_query() { world_src url-query; put scripts/link.sh "$SH"'# See https://example.com/?doc=AGENTS.md \302\247 Gone here.\ntrue\n'; }
+fx_url_query_id() { world_src_dec url-query-id; put scripts/link.sh "$SH"'# See https://example.com/?decision=D404 \302\247 Scope here.\ntrue\n'; }
+fx_no_scheme() { world_src no-scheme; put scripts/link.sh "$SH"'# See AGENTS.md \302\247 Gone for more.\ntrue\n'; }
+# A block comment that never closes, in a file holding a section sign.
+fx_unclosed() { world_src "$1"; put src/broken.c '/* AGENTS.md \302\247 Gone\nint main(void) { return 0; }\n'; }
+fx_symlink_src() { world_src symlink-src; put target.sh "$SH"'# AGENTS.md \302\247 Gone\ntrue\n'; ln -s target.sh "$R/link.sh"; git -C "$R" add link.sh; }
+fx_newline_src() { world_src newline-src; put "one"$'\n'"two.sh" "$SH"'# AGENTS.md \302\247 Gone\ntrue\n'; }
+UNCLOSED="$(skip src/broken.c 'comment text could not be extracted: a block comment opened at line 1 is never closed ');md-refs: scan incomplete — 1 carrier(s) could not be read$(unmeasured 1)"
+run_rows \
+  "a citation in comment text resolves|fx_comment_ok comment-ok||--all|rc=0 $(clean 1 2 1)" \
+  "a comment citing a heading the target does not have is dead, the heading read to the end of the line|fx_comment_dead||--all|rc=1 $(dead bin/helper.sh 2 "$(noprefix 'docs/architecture/plugins.md § Gone, not this file.' docs/architecture/plugins.md 'Gone, not this file.')");$(failed 1 1 2 1)" \
+  "a citation in a TOML string resolves|fx_toml_ok||--all|rc=0 $(clean 1 2 1)" \
+  "a TOML string citing a heading the target does not have is dead|fx_toml_dead||--all|rc=1 $(dead kendex.toml 1 "$(noprefix 'AGENTS.md § Gone' AGENTS.md Gone)");$(failed 1 1 2 1)" \
+  "a string literal outside a manifest is not judged|fx_rs_string||--all|rc=0 $(clean 0 2 1)" \
+  "control: the same citation in that file's comment is judged|fx_rs_comment||--all|rc=1 $(dead src/lib.rs 1 "$(noprefix 'AGENTS.md § Gone' AGENTS.md Gone)");$(failed 1 1 2 1)" \
+  "a decision citation in comment text checks the heading|fx_dec_ok||--all|rc=0 $(clean 1 2 1 "$DEC_YES")" \
+  "a decision citing a heading it does not have is dead|fx_dec_dead||--all|rc=1 $(dead scripts/smoke.sh 2 "$(noprefix 'D008 § Reach.' docs/decisions/D008-scope.md 'Reach.')");$(failed 1 1 2 1 "$DEC_YES")" \
+  "a bare decision ID in a comment is prose, not a citation, beside the § one it is|fx_dec_bare||--all|rc=0 $(clean 1 2 1 "$DEC_YES")" \
+  "a text file the attributes mark undiffable is still read|fx_undiffable||--all|rc=1 $(dead icon.svg 1 "$(noprefix 'AGENTS.md § Gone' AGENTS.md Gone)");$(failed 1 1 2 1)" \
+  "a binary blob at a source path is named, never counted clean|fx_binary||--all|rc=0 $(skip blob.h 'binary content, not source');$(clean 0 2 0 "$DEC_NO" "$(unmeasured 1)")" \
+  "a URL is prose, not a citation into this repository|fx_url||--all|rc=0 $(clean 0 2 1)" \
+  "a decision ID inside a URL is prose too, with the directory tracked|fx_url_id||--all|rc=0 $(clean 0 2 1 "$DEC_YES")" \
+  "a path in a URL query is prose wherever it sits in the URL|fx_url_query||--all|rc=0 $(clean 0 2 1)" \
+  "and so is a decision ID in one|fx_url_query_id||--all|rc=0 $(clean 0 2 1 "$DEC_YES")" \
+  "control: the same path without the scheme is judged|fx_no_scheme||--all|rc=1 $(dead scripts/link.sh 2 "$(noprefix 'AGENTS.md § Gone for more.' AGENTS.md 'Gone for more.')");$(failed 1 1 2 1)" \
+  "a carrier the extractor cannot read is exit 2, never a clean verdict|fx_unclosed unclosed||--all|rc=2 $UNCLOSED" \
+  "an unreadable carrier beats the empty-set fast path|fx_unclosed unclosed-empty|COMMIT_GUARDS_MD_REFS_PATHS=no/such/*.md|--all|rc=2 $UNCLOSED" \
+  "a symlink at a source path is named, and its target still judged|fx_symlink_src||--all|rc=1 $(skip link.sh 'tracked as a symlink, not source');$(dead target.sh 2 "$(noprefix 'AGENTS.md § Gone' AGENTS.md Gone)");$(failed 1 1 2 1 "$DEC_NO" "$(unmeasured 1)")" \
+  "a path holding a newline is named, never quietly passed|fx_newline_src||--all|rc=0 $(skip "\$'one\\ntwo.sh'" 'the path holds a newline, which the carrier list cannot separate');$(clean 0 2 0 "$DEC_NO" "$(unmeasured 1)")" \
+  "an empty source path list is refused|fx_comment_ok empty-list|COMMIT_GUARDS_MD_REFS_SOURCE_PATHS=|--all|rc=2 ${ERR}COMMIT_GUARDS_MD_REFS_SOURCE_PATHS names no path — name at least one, or drop this check from COMMIT_GUARDS_CHECKS"
 
 echo "=== scopes: touched, --staged, --all ==="
-new_repo scopes
-put ok.md $'# OK\n'
-put AGENTS.md $'[dead](nope.md)\n'
-git -C "$R" commit -qm seed
-run_refs
-[ "$RC" -eq 0 ] && case "$OUT" in *"nothing staged to judge"*) true ;; *) false ;; esac \
-  && ok "under touched with nothing staged, one line says so" || bad "touched with nothing staged" "rc=$RC out=$OUT"
-run_refs --all
-[ "$RC" -eq 1 ] && case "$OUT" in *"AGENTS.md:1:"*) true ;; *) false ;; esac \
-  && ok "--all reaches the committed dead link" || bad "--all reaches committed" "rc=$RC out=$OUT"
-put docs/architecture/overview.md $'[live](../../ok.md)\n'
-run_refs --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"AGENTS.md:1:"*) true ;; *) false ;; esac \
-  && ok "--staged also checks references from unchanged documents" || bad "incoming references" "rc=$RC out=$OUT"
-put AGENTS.md $'[dead](nope.md) again\n'
-run_refs
-[ "$RC" -eq 1 ] && case "$OUT" in *"AGENTS.md:1:"*) true ;; *) false ;; esac \
-  && ok "control: under touched, the staged AGENTS.md is judged" || bad "control: touched judges staged" "rc=$RC out=$OUT"
-git -C "$R" commit -qm more
-put ok.md $'# Renamed\n'
-git -C "$R" commit -qm rename-heading
-put AGENTS.md $'[a](ok.md#ok)\n'
-run_refs --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"ok.md has no heading or explicit anchor #ok"*) true ;; *) false ;; esac \
-  && ok "a target outside the staged set is still read from the index for its headings" || bad "target read from index" "rc=$RC out=$OUT"
-git -C "$R" rm -q --cached ok.md
-run_refs --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"no tracked file or directory at ok.md"*) true ;; *) false ;; esac \
-  && ok "a link to a file the commit deletes is dead" || bad "deleted target is dead" "rc=$RC out=$OUT"
-
-echo "=== staged references honor exclusions ==="
-new_repo staged-exclusion
-put AGENTS.md $'[dead](missing.md)\n'
-put tools/md-excludes $'AGENTS.md\tvendored instructions\n'
-run_refs --staged
-[ "$RC" -eq 0 ] && case "$OUT" in *"no tracked markdown file(s) to judge"*) true ;; *) false ;; esac \
-  && ok "the staged scan excludes the declared document" || bad "staged exclusion" "rc=$RC out=$OUT"
-git -C "$R" rm -qf tools/md-excludes
-run_refs --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"no tracked file or directory at missing.md"*) true ;; *) false ;; esac \
-  && ok "the same staged reference fails without its exclusion" || bad "staged exclusion control" "rc=$RC out=$OUT"
-
-echo "=== target-only edits recheck incoming references ==="
-new_repo incoming
-put guide.md $'# Guide\n\n## Install\n'
-put AGENTS.md $'[setup](guide.md#install)\n'
-git -C "$R" commit -qm seed
-put guide.md $'# Guide\n\n## Setup\n'
-run_refs
-[ "$RC" -eq 1 ] && case "$OUT" in *"guide.md has no heading or explicit anchor #install"*) true ;; *) false ;; esac \
-  && ok "renaming only the target heading finds an unchanged caller" || bad "target rename" "rc=$RC out=$OUT"
-git -C "$R" rm -qf guide.md
-run_refs
-[ "$RC" -eq 1 ] && case "$OUT" in *"no tracked file or directory at guide.md"*) true ;; *) false ;; esac \
-  && ok "deleting only the target finds an unchanged caller" || bad "target deletion" "rc=$RC out=$OUT"
+seeded() { repo "$1"; put ok.md '# OK\n'; put AGENTS.md '[dead](nope.md)\n'; commit seed; } # NAME — a committed dead link, nothing staged
+fx_staged_live() { seeded staged-live; put docs/architecture/overview.md '[live](../../ok.md)\n'; }
+fx_touched_staged() { seeded touched-staged; put AGENTS.md '[dead](nope.md) again\n'; }
+fx_target_in_index() { repo "$1"; put ok.md '# OK\n'; commit seed; put ok.md '# Renamed\n'; commit rename-heading; put AGENTS.md '[a](ok.md#ok)\n'; }
+fx_target_deleted() { fx_target_in_index target-deleted; git -C "$R" rm -q --cached ok.md; }
+fx_excluded() { repo excluded; put AGENTS.md '[dead](missing.md)\n'; put tools/md-excludes 'AGENTS.md\tvendored instructions\n'; }
+fx_not_excluded() { repo not-excluded; put AGENTS.md '[dead](missing.md)\n'; }
+fx_heading_renamed() { repo "$1"; put guide.md '# Guide\n\n## Install\n'; put AGENTS.md '[setup](guide.md#install)\n'; commit seed; put guide.md '# Guide\n\n## Setup\n'; }
+fx_target_removed() { fx_heading_renamed target-removed; git -C "$R" rm -qf guide.md; }
+run_rows \
+  "under touched with nothing staged, one line says so|seeded touched-nothing|||rc=0 $NOTHING_STAGED" \
+  "--all reaches the committed dead link|seeded all-committed||--all|rc=1 $(dead AGENTS.md 1 "$(untracked '](nope.md)' nope.md)");$(failed 1 1 1)" \
+  "--staged also checks references from unchanged documents|fx_staged_live||--staged|rc=1 $(dead AGENTS.md 1 "$(untracked '](nope.md)' nope.md)");$(failed 1 2 2)" \
+  "control: under touched, the staged AGENTS.md is judged|fx_touched_staged|||rc=1 $(dead AGENTS.md 1 "$(untracked '](nope.md)' nope.md)");$(failed 1 1 1)" \
+  "a target outside the staged set is still read from the index for its headings|fx_target_in_index target-in-index||--staged|rc=1 $(dead AGENTS.md 1 "$(noslug '](ok.md#ok)' ok.md ok)");$(failed 1 1 1)" \
+  "a link to a file the commit deletes is dead|fx_target_deleted||--staged|rc=1 $(dead AGENTS.md 1 "$(untracked '](ok.md#ok)' ok.md)");$(failed 1 1 1)" \
+  "the staged scan excludes the declared document, and the verdict echoes both path settings|fx_excluded|COMMIT_GUARDS_MD_REFS_SOURCE_PATHS=*.sh|--staged|rc=0 $(nomatch "$PATHS_DEFAULT" '*.sh')" \
+  "control: the same staged reference fails without its exclusion|fx_not_excluded||--staged|rc=1 $(dead AGENTS.md 1 "$(untracked '](missing.md)' missing.md)");$(failed 1 1 1)" \
+  "renaming only the target heading finds an unchanged caller|fx_heading_renamed heading-renamed|||rc=1 $(dead AGENTS.md 1 "$(noslug '](guide.md#install)' guide.md install)");$(failed 1 1 1)" \
+  "deleting only the target finds an unchanged caller|fx_target_removed|||rc=1 $(dead AGENTS.md 1 "$(untracked '](guide.md#install)' guide.md)");$(failed 1 1 1)"
 
 echo "=== refusals and unmeasured paths ==="
-new_repo refuse
-put AGENTS.md $'Para\n\n```\nopen\n'
-run_refs --all
-[ "$RC" -eq 2 ] && case "$OUT" in *"AGENTS.md:3: an unterminated fence"*) true ;; *) false ;; esac \
-  && ok "an unterminated fence is exit 2, naming the line" || bad "unterminated fence exit 2" "rc=$RC out=$OUT"
-put AGENTS.md $'clean\n'
-put notes/target.md $'clean\n'
-rm "$R/AGENTS.md"
-ln -s notes/target.md "$R/AGENTS.md"
-git -C "$R" add -A
-run_refs --all
-[ "$RC" -eq 0 ] && case "$OUT" in *"not measured: AGENTS.md"*"tracked as a symlink"*"1 matched path(s) not measured"*) true ;; *) false ;; esac \
-  && ok "a symlink at a scoped path is named as unmeasured" || bad "symlink named" "rc=$RC out=$OUT"
-run_refs --no-such-flag
-[ "$RC" -eq 2 ] && ok "an unknown flag is exit 2" || bad "unknown flag" "rc=$RC out=$OUT"
-run_refs --help
-[ "$RC" -eq 0 ] && case "$OUT" in *"usage: md-refs"*) true ;; *) false ;; esac \
-  && ok "--help prints usage at exit 0" || bad "--help" "rc=$RC out=$OUT"
+fx_open_fence() { repo "$1"; put AGENTS.md 'Para\n\n```\nopen\n'; }
+fx_symlink_doc() { repo symlink-doc; put notes/target.md 'clean\n'; ln -s notes/target.md "$R/AGENTS.md"; git -C "$R" add -A; }
+run_rows \
+  "an unterminated fence is exit 2, naming the line|fx_open_fence open-fence||--all|rc=2 ${ERR}AGENTS.md:3: an unterminated fence — the file cannot be read past it; close the construct" \
+  "a symlink at a scoped path is named as unmeasured|fx_symlink_doc||--all|rc=0 $(skip AGENTS.md 'tracked as a symlink, not markdown');md-refs: OK — nothing measurable to judge$(unmeasured 1)" \
+  "--staged and --all are exclusive|fx_open_fence both-flags||--staged --all|rc=2 ${ERR}--staged and --all are exclusive" \
+  "an unknown flag is exit 2, quoting it|fx_open_fence unknown-flag||--no-such-flag|rc=2 ${ERR}unknown argument '--no-such-flag' (see --help)" \
+  "a scope outside touched and all is exit 2, quoting it|fx_open_fence bad-scope|COMMIT_GUARDS_MD_SCOPE=weird||rc=2 ${ERR}COMMIT_GUARDS_MD_SCOPE must be 'touched' or 'all', got 'weird'"
+# The usage text carries a '|', which a row cannot: its first line and the
+# exit status, beside the table.
+assert_eq "--help prints usage at exit 0" "rc=0 usage: md-refs [--staged | --all]" "$(run '' --help | sed -n 1p | LC_ALL=C cut -d';' -f1)"
 
 echo "=== the skill's own shipped markdown resolves ==="
-new_repo self
-mkdir -p "$R/skills/commit-guards"
-for doc in SKILL.md README.md CHECKS.md DEVELOPMENT.md; do
-  cp "$SKILL_DIR/$doc" "$R/skills/commit-guards/$doc"
-done
-# The consumer-side files the docs cite by directory path.
-put changelog.d/README.md $'# changelog.d\n'
-put .claude/CLAUDE.md $'@AGENTS.md\n'
-git -C "$R" add -A
-run_refs --all
-[ "$RC" -eq 0 ] && case "$OUT" in *"md-refs: OK — "*"2 tracked markdown file(s)"*) true ;; *) false ;; esac \
-  && ok "the shipped SKILL.md's references resolve (beside the fixture's CLAUDE.md shim)" || bad "shipped SKILL.md resolves" "rc=$RC out=$OUT"
-OUT="$(cd "$R" && COMMIT_GUARDS_MD_REFS_PATHS='*/commit-guards/*.md' "$MDR" --all 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && case "$OUT" in *"4 tracked markdown file(s)"*) true ;; *) false ;; esac \
-  && ok "and so do README.md, CHECKS.md and DEVELOPMENT.md when named" || bad "shipped docs resolve" "rc=$RC out=$OUT"
-put skills/commit-guards/SKILL.md "$(cat "$SKILL_DIR/SKILL.md")"$'\n\nSee [gone](nowhere.md).\n'
-run_refs --all
-[ "$RC" -eq 1 ] && ok "control: a planted dead link in the shipped SKILL.md fails" || bad "control: planted dead link" "rc=$RC out=$OUT"
+fx_shipped() { # the four shipped documents beside the consumer files they cite by directory
+  local doc
+  repo "$1"
+  mkdir -p "$R/skills/commit-guards"
+  for doc in SKILL.md README.md CHECKS.md DEVELOPMENT.md; do
+    cp "$SKILL_DIR/$doc" "$R/skills/commit-guards/$doc"
+  done
+  put changelog.d/README.md '# changelog.d\n'
+  put .claude/CLAUDE.md '@AGENTS.md\n'
+}
+# The shipped documents' own reference count is theirs to change: the pin is
+# the verdict over the two, then the four, files read, with N for that count.
+counted() { LC_ALL=C sed 's/\(OK — \|among \)[0-9][0-9]* /\1N /'; }
+fx_shipped shipped
+assert_eq "the shipped SKILL.md's references resolve (beside the fixture's CLAUDE.md shim)" "rc=0 $(clean N 2)" "$(run '' --all | counted)"
+assert_eq "and so do README.md, CHECKS.md and DEVELOPMENT.md when named" "rc=0 $(clean N 4)" "$(run 'COMMIT_GUARDS_MD_REFS_PATHS=*/commit-guards/*.md' --all | counted)"
+fx_shipped shipped-planted
+put skills/commit-guards/SKILL.md "$(cat "$SKILL_DIR/SKILL.md")"'\n\nSee [gone](nowhere.md).\n'
+assert_eq "control: a planted dead link in the shipped SKILL.md fails, at the line it was planted on" \
+  "rc=1 $(dead skills/commit-guards/SKILL.md "$(($(wc -l <"$SKILL_DIR/SKILL.md") + 2))" "$(untracked '](nowhere.md)' skills/commit-guards/nowhere.md)");$(failed 1 N 2)" "$(run '' --all | counted)"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/commit-guards/tests/md-refs.test.sh
+++ b/skills/commit-guards/tests/md-refs.test.sh
@@ -12,6 +12,8 @@
 # verdict, the file and line it names, the reference it quotes, the count it
 # judged, the remedy and the summary are one pin.
 set -euo pipefail
+# No globbing: a row's ARGS column is word-split into the judge's arguments.
+set -f
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 MDR="$SKILL_DIR/scripts/md-refs"
@@ -69,7 +71,7 @@ world_refs() {
   put skills/x/SKILL.md '# X\n'
   put pic.png 'not really'
 }
-world_dec() { world_refs "$1"; put docs/decisions/D001-first.md '# D001\n\n## Context\n'; put docs/decisions/INDEX.md '| D001 |\n'; }
+world_dec() { world_refs "$1"; put docs/decisions/D001-first.md '# D001\n\n## Context\n'; }
 world_adr() { world_dec "$1"; put docs/decisions/ADR-0007-x.md '# ADR-0007\n'; }
 world_install() { repo "$1"; put guide.md '# Guide\n\n## Install\n'; }
 world_numbered() { repo "$1"; put guide.md '# Guide\n\n## 1. Install\n\n### 1.1.1 Choose a path\n'; }
@@ -347,7 +349,7 @@ fx_shipped() { # the four shipped documents beside the consumer files they cite 
 }
 # The shipped documents' own reference count is theirs to change: the pin is
 # the verdict over the two, then the four, files read, with N for that count.
-counted() { LC_ALL=C sed 's/\(OK — \|among \)[0-9][0-9]* /\1N /'; }
+counted() { LC_ALL=C sed -e 's/OK — [0-9][0-9]* /OK — N /' -e 's/among [0-9][0-9]* /among N /'; }
 fx_shipped shipped
 assert_eq "the shipped SKILL.md's references resolve (beside the fixture's CLAUDE.md shim)" "rc=0 $(clean N 2)" "$(run '' --all | counted)"
 assert_eq "and so do README.md, CHECKS.md and DEVELOPMENT.md when named" "rc=0 $(clean N 4)" "$(run 'COMMIT_GUARDS_MD_REFS_PATHS=*/commit-guards/*.md' --all | counted)"


### PR DESCRIPTION
Reshapes `skills/commit-guards/tests/md-refs.test.sh` to code-quality § Tests. It pinned the reference judge in a 426-line linear script of 130 assertions, each an exit status read as a bit beside a substring of one line (`*"has no heading at the start"*`, `*"AGENTS.md:1:"*`), over long-lived fixtures every case rewrote. It is now two tables. Table one (`cite_rows`): AGENTS.md holds the row's content in a seeded world (the reference world of three scoped documents, the decisions worlds, the five guide worlds for section routes), judged with `--all`. Table two (`run_rows`): a fixture function builds the repository for the walk, the path list, the source carriers, the scopes and the refusals. A row runs the judge once and pins the exit status with every line printed, so the verdict, the file and line it names, the reference it quotes, the count it judged, the remedy and the summary are one pin. The expected lines are built by small functions from what the row put in (`dead PATH LINE MESSAGE`, `clean JUDGED MD [SRC] [DEC-NOTE] [UNMEASURED]`, `failed`, `skip`, `nomatch`, and one message function per way a reference dies).

Every former assertion has a row; none were deleted. Folded: "the verdict counts the references it judged" and "the bare anchor beside the climbing link lands" are the judged count every row now pins (`5 reference(s)`, `1 dead reference(s) among 2`); "the verdict names the untracked directory" and "names the directory judged against" are the `decision IDs ...` clause of every summary; the two-step nested-link case is the row "control: a root-relative spelling from a nested file fails". One old row could not fail and now reaches its predicate, found by an author mutant surviving the old fixture: the bare decision ID in a comment sits beside a live `D008 § Scope` so the carrier pre-filter opens the file at all (`fx_dec_bare`). The decision-IDs-inside-URLs rows live in `world_src_dec`: the old long-lived fixture had a decision file staged by an earlier case, and a per-row world has to stage one itself or the rows go vacuous (`fx_url_id`, `fx_url_query_id`). Added controls: `--staged --all` exclusive, the prefix outside its character class, the unknown `COMMIT_GUARDS_MD_SCOPE`, the empty source path list, each pinning the quoted value. The exclusion rows set `COMMIT_GUARDS_MD_REFS_SOURCE_PATHS=*.sh` so the no-match verdict echoes a value the row put in rather than the extractor's forty-extension default. Beside the tables: `--help` (its usage line carries a `|`) and the three shipped-document assertions, their reference count normalised to N since SKILL.md's own count is not this suite's to pin.

Pinned as emitted: the decision code-span heading runs to the end of the line, so `` `D001 § Rationale`. `` is reported as `has no heading at the start of 'Rationale`.'`; the unclosed-block-comment skip line carries the extractor's trailing space.

The tracked render is replayed with `patch`. A `kendex refresh` in the main checkout at 87a1e0036 left `.kendex-generated.json` unchanged, so nothing is owed.

## Mutation

37 exact-substring mutants over `scripts/md-refs`, `scripts/lib/md-refs.awk` and `scripts/lib/md-scope.sh`, each run against the final suite in a scratch copy; 36 killed, 1 equivalent. Two of them (the bare ID in comment text judged; the ID inside a URL judged) survived the first per-row fixtures and drove the fixture repairs above.

| mutant | result |
|---|---|
| slug: a duplicate heading keeps the base slug | killed by "a duplicate heading takes the -1 suffix" |
| slug: heading text keeps its case for the § comparison | killed by "a § citation matches a heading case-insensitively" |
| anchor: an explicit <a id> is not an anchor | killed by "an explicit <a id> is an anchor" |
| link: a scheme is judged as a local path | killed by "a scheme, a mailto and a leading slash are not judged" |
| link: a directory link keeps its slash | SURVIVED, equivalent: `normalize` drops the empty segment a trailing slash leaves |
| link: a climbing link is resolved as if rooted | killed by "a link climbing above the root fails" |
| link: an anchor into a non-markdown file is accepted | killed by "an anchor into a file that is not markdown fails" |
| link: a link is not counted as judged | killed by "links to a tracked file, a directory, a heading and a non-markdown file resolve, and the verdict counts them" |
| link: a reference definition is not read | killed by "a reference definition is judged, quoted whole" |
| citation: a § heading is matched case-sensitively | killed by "a § citation matches a heading case-insensitively" |
| citation: a code span holding a path alone is a citation | killed by "a path alone in a code span is a name, not a citation" |
| route: a section prefix needs no boundary | killed by "a section name needs its boundary" |
| route: a numbered route falls through to the text prefix | killed by "numeric routes cannot fall through to a bare parent prefix" |
| route: emphasis markers stay in the cited text | killed by "a cited ID with a tracked file passes, in prose and in a code span, and the verdict names the directory" |
| route: an anchored link carries no section route | killed by "a valid anchor does not hide a missing section" |
| id: one digit is enough | killed by "a shorter digit run, a glued letter and a colour are not IDs" |
| id: a glued letter before the prefix does not stop an ID | killed by "a shorter digit run, a glued letter and a colour are not IDs" |
| id: a bare ID in comment text is judged | killed by "a bare decision ID in a comment is prose, not a citation, beside the § one it is" |
| id: an ID inside a URL is judged | killed by "a decision ID inside a URL is prose too, with the directory tracked" |
| text: a path inside a URL is judged | killed by "a URL is prose, not a citation into this repository" |
| decision: IDs are judged without a tracked directory | killed by "with no tracked decisions directory, an ID is not judged and the verdict says so" |
| decision: a § heading on a decision is not checked | killed by "an ID citing a heading its decision does not have fails, the heading read to the end of the line" |
| verdict: dead references exit 0 | killed by "a link to an untracked file fails, quoting the link and naming where it looked" |
| verdict: the unmeasured count is not reported | killed by "a binary blob at a source path is named, never counted clean" |
| verdict: an unreadable carrier is a clean scan | killed by "a carrier the extractor cannot read is exit 2, never a clean verdict" |
| scope: a staged run reads only the staged documents | killed by "--staged also checks references from unchanged documents" |
| source: a TOML file is read for its comments only | killed by "a citation in a TOML string resolves" |
| source: an undiffable carrier is dropped from the search | killed by "a text file the attributes mark undiffable is still read" |
| source: a symlink is read as source | killed by "a symlink at a source path is named, and its target still judged" |
| source: a binary carrier is extracted | killed by "a binary blob at a source path is named, never counted clean" |
| source: a newline path is looked up anyway | killed by "a path holding a newline is named, never quietly passed" |
| config: the decisions directory is always judged | killed by "links to a tracked file, a directory, a heading and a non-markdown file resolve, and the verdict counts them" |
| config: any prefix is accepted | killed by "a prefix outside letters, digits, '_' and '-' is exit 2, quoting the value" |
| config: the width is not validated | killed by "a zero width is exit 2, quoting the value" |
| usage: an unknown argument is ignored | killed by "an unknown flag is exit 2, quoting it" |
| scope: --staged and --all are not exclusive | killed by "--staged and --all are exclusive" |
| scope: an unknown COMMIT_GUARDS_MD_SCOPE is touched | killed by "a scope outside touched and all is exit 2, quoting it" |

17 fixture mutants (one fixture's planted drift removed, the named row must fail): 16 killed, 1 by design.

| fixture mutant | result |
|---|---|
| F1 adr: the ADR file not tracked | killed by "control: the same ID passes once its file is tracked" |
| F2 dec: the decision file not tracked, the directory still is | killed by "a cited ID with a tracked file passes, in prose and in a code span, and the verdict names the directory" |
| F3 nested-wrong: the nested file holds the right spelling | killed by "control: a root-relative spelling from a nested file fails, naming where it looked" |
| F4 unscoped: the unscoped files not written | killed by "COMMIT_GUARDS_MD_REFS_PATHS replaces the list" |
| F5 undiffable: the attribute not written | no kill by design: the attribute changes no verdict; the `-I` code mutant above is its kill |
| F6 binary: the NUL not planted | killed by "a binary blob at a source path is named, never counted clean" |
| F7 unclosed: the block comment closed | killed by "a carrier the extractor cannot read is exit 2, never a clean verdict" |
| F8 symlink-src: the symlink not made | killed by "a symlink at a source path is named, and its target still judged" |
| F9 staged-live: the unchanged document not restaged | killed by "--staged also checks references from unchanged documents" |
| F10 target-in-index: the heading not renamed | killed by "a target outside the staged set is still read from the index for its headings" |
| F11 target-deleted: the target kept | killed by "a link to a file the commit deletes is dead" |
| F12 excluded: the exclusion not written | killed by "the staged scan excludes the declared document, and the verdict echoes both path settings" |
| F13 heading-renamed: the heading kept | killed by "renaming only the target heading finds an unchanged caller" |
| F14 target-removed: the target kept | killed by "deleting only the target finds an unchanged caller" |
| F15 symlink-doc: a real file instead | killed by "a symlink at a scoped path is named as unmeasured" |
| F16 open-fence: the fence closed | killed by "an unterminated fence is exit 2, naming the line" |
| F17 shipped-planted: nothing planted | killed by "control: a planted dead link in the shipped SKILL.md fails, at the line it was planted on" |

## Checks

- `md-refs.test.sh`: 130 assertions pass on this host and under a symlinked TMPDIR. All 38 commit-guards suites pass in the worktree (`suites failing: 0`). `tools/bash32-lint` clean.
- `tools/guard --full`: exit 0 with `TMPDIR=/tmp`. Under the agent scratch `TMPDIR` (`~/dev/.scratch/agents`) one pre-existing Rust test fails on main too, `scope_project_outside_a_project_is_an_error` in `crates/cli/tests/cli.rs`: the walk-up from a temp dir under the real home crosses harness markers there and resolves a project; recorded for the crates round, not touched here.
- One reviewer-test round: fix-first on one blocker, the GNU-only sed alternation in the count filter that BSD sed reads as a literal pipe (three assertions would fail on the macOS shard); fixed in the second commit with two POSIX substitutions. Two suggestions taken: `set -f` for the suite, and the decisions world drops an INDEX.md no row could read. The reviewer's own 37 production mutants: 20 killed, 2 equivalent, 15 surviving both the old and the new suite (coverage gaps of the judge, listed below, not this round's); 19 fixture mutants, 15 killed. Its dispute of one stated reason (the URL rows) is folded into the paragraph above.

Coverage gaps the reviewer listed, unchanged by this PR and recorded for a later round: `<a name=` as an explicit anchor; the protocol-relative `//host` arm of `in_url`; the `<path>.md` placeholder guards; single-quoted, parenthesised and unterminated link titles; the "no tracked markdown file ... to read a heading from" decision arm; a gitlink at a source path; the "no comment grammar" skip; a binary file cited by heading; exclusions on the source set; the merged-index check on the source walk; `§` without surrounding space; an empty `§` heading.

KEN-1241

https://claude.ai/code/session_0178hScanMtjD7MsEhUGNayE
