### PR TITLE
test(KEN-1241): the md-format suite as two tables of rows

### DIFF
--- a/.agents/skills/commit-guards/tests/md-format.test.sh
+++ b/.agents/skills/commit-guards/tests/md-format.test.sh
@@ -1,272 +1,240 @@
 #!/usr/bin/env bash
-# Pins for scripts/md-format: each rule of the format fires on the shape it
-# names and stays quiet on the shapes it skips, the three scopes select the
-# files the docs say, the remedy names md-reflow, and what cannot be judged
-# is named rather than passed. Every green assertion is paired with a
-# control that proves it can fail. The index readers this family shares are
-# pinned once, in index-reads.test.sh and lane-readers.test.sh.
+# Pins for scripts/md-format, the judge of a markdown file's shape: one
+# paragraph per line and one list item per line, blank lines between
+# paragraphs, list blocks, headings and fences, no trailing-double-space
+# break; fenced code, tables, HTML blocks, indented code and front matter
+# left alone; the three scopes select the files the docs say; what cannot be
+# judged is named rather than passed. Two tables: the first holds one shape
+# as doc.md judged with --all, the second the scopes, the path list and the
+# unmeasured paths. A row runs the judge once and pins the exit status with
+# every line printed, so each violation's file, line and rule, the remedy,
+# the count and the scope are one pin. The index readers this family shares
+# are index-reads.test.sh and lane-readers.test.sh.
 set -euo pipefail
-
+# No globbing: a row's ARGS column is word-split into the judge's arguments.
+set -f
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 MDF="$SKILL_DIR/scripts/md-format"
+# shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
-
+# Hermetic: a leaked setting would mask every row below.
 unset COMMIT_GUARDS_MD_PATHS COMMIT_GUARDS_MD_EXCLUDES COMMIT_GUARDS_MD_SCOPE COMMIT_GUARDS_SETTINGS_FILE 2>/dev/null || true
 
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
 
-new_repo() { # NAME — fresh fixture repo in $R
+# One line for a run in the row's repository: the exit status, then every
+# line printed, in order, joined by ';'. ENVS is a comma-separated list of
+# assignments; ARGS are passed through.
+R=""
+run() { # ENVS ARGS
+  local envs=() rc=0 out=""
+  [ -z "$1" ] || IFS=',' read -ra envs <<<"$1"
+  # shellcheck disable=SC2086
+  out="$(cd "$R" && env ${envs[@]+"${envs[@]}"} "$MDF" $2 2>&1)" || rc=$?
+  printf 'rc=%s%s' "$rc" "${out:+ $(printf '%s\n' "$out" | LC_ALL=C paste -sd ';' -)}"
+}
+
+# Fixture vocabulary. Every fixture builds its own repository and stages
+# what it wrote; a name used twice is refused.
+repo() { # NAME
   R="$TMP/$1"
+  [ ! -e "$R" ] || { echo "harness: fixture $1 already exists" >&2; exit 2; }
   mkdir -p "$R"
   git -C "$R" -c init.defaultBranch=main init -q
   git -C "$R" config user.email test@example.com
   git -C "$R" config user.name test
 }
+put() { mkdir -p "$R/$(dirname "$1")"; printf '%b' "$2" >"$R/$1"; git -C "$R" add -A; } # PATH CONTENT (printf %b), staged
+write() { mkdir -p "$R/$(dirname "$1")"; printf '%b' "$2" >"$R/$1"; } # PATH CONTENT — the work tree only
+commit() { git -C "$R" commit -qm "$1"; }
+WRAPPED='Wrapped\ntext.\n'
 
-run_mdf() { # [args...] — run in $R; sets OUT and RC
-  OUT=""
-  RC=0
-  OUT="$(cd "$R" && "$MDF" "$@" 2>&1)" || RC=$?
+# The lines the judge prints, as functions of what a row put in.
+REMEDY="  remedies: reflow the file with md-reflow (scripts/md-reflow PATH), then stage it"
+ERR="::error::md-format: "
+NOTHING_STAGED="md-format: OK — nothing staged to judge (COMMIT_GUARDS_MD_SCOPE=touched judges the files a commit touches); run with --all, or set COMMIT_GUARDS_MD_SCOPE=all once this repository's markdown is reflowed"
+WRAP="a paragraph hard-wrapped over lines; put the whole paragraph on one line"
+ITEM="a list item continued on the next line; put the whole item on one line"
+H_BEFORE="a heading not preceded by a blank line"
+H_AFTER="a heading not followed by a blank line"
+F_AFTER="a fence not followed by a blank line"
+viol() { printf 'md-format FAIL format: %s:%s: %s;%s' "$1" "$2" "$3" "$REMEDY"; } # PATH LINE RULE
+skip() { printf 'md-format: not measured: %s — %s' "$1" "$2"; } # PATH REASON
+unmeasured() { printf '; %s matched path(s) not measured' "$1"; } # N
+clean() { printf 'md-format: OK — %s %s markdown file(s) clean%s' "$1" "${2:-tracked}" "${3-}"; } # N [SCOPE] [UNMEASURED]
+failed() { printf 'md-format: %s format violation(s) in %s %s markdown file(s)%s' "$1" "$2" "${3:-tracked}" "${4-}"; } # VIOLATIONS N [SCOPE] [UNMEASURED]
+nomatch() { printf 'md-format: OK — no %s markdown file(s) to judge (COMMIT_GUARDS_MD_PATHS %s)' "$1" "$2"; } # SCOPE GLOBS
+refused() { printf '%sdoc.md:%s: %s — the file cannot be judged past it; close the construct' "$ERR" "$1" "$2"; } # LINE REASON
+NONE="md-format: OK — nothing measurable to judge"
+
+# Table one: doc.md holds CONTENT in a fresh repository, judged with --all.
+# The columns split on the pipe, so a pipe in the content is written as its
+# octal escape, \174, which printf %b renders.
+ROW=0
+shape_rows() { # label | content | expect
+  local row label content expect
+  for row in "$@"; do
+    IFS='|' read -r label content expect <<<"$row"
+    ROW=$((ROW + 1))
+    R=""
+    repo "shape-$ROW"
+    put doc.md "$content"
+    assert_eq "$label" "$expect" "$(run '' --all)"
+  done
 }
 
-put() { # PATH CONTENT — a tracked file, staged
-  mkdir -p "$R/$(dirname "$1")"
-  printf '%s' "$2" >"$R/$1"
-  git -C "$R" add -A
-}
-
-# The shape under test, staged as doc.md and judged with --all; asserts the
-# verdict and, on a violation, the line and rule named.
-shape() { # LABEL EXPECT-RC CONTENT [LINE RULE-FRAGMENT]
-  local label="$1" want="$2" content="$3" line="${4-}" rule="${5-}"
-  put doc.md "$content"
-  run_mdf --all
-  if [ "$RC" -ne "$want" ]; then
-    bad "$label" "rc=$RC want=$want out=$OUT"
-    return
-  fi
-  if [ "$want" -eq 1 ]; then
-    case "$OUT" in
-      *"format: doc.md:$line: $rule"*) ok "$label" ;;
-      *) bad "$label" "expected doc.md:$line: $rule in: $OUT" ;;
-    esac
-  else
-    ok "$label"
-  fi
-}
-
-new_repo shapes
-
-echo "=== a clean file passes, and the verdict counts it ==="
-shape "one paragraph per line, blank-separated, passes" 0 $'# Title\n\nOne paragraph on one line.\n\n- item one\n- item two\n\nAnother.\n'
-case "$OUT" in *"md-format: OK — 1 tracked markdown file(s) clean"*) ok "the verdict counts the file it read" ;; *) bad "verdict counts files" "$OUT" ;; esac
-
-echo "=== the rules fire on the shapes they name ==="
-shape "a hard-wrapped paragraph fails on the continuation line" 1 $'First line\nsecond line.\n' 2 "a paragraph hard-wrapped over lines"
-shape "a list item continued on the next line fails" 1 $'- item\n  continued\n' 2 "a list item continued on the next line"
-shape "an ordered item continued on the next line fails" 1 $'1. item\n   continued\n' 2 "a list item continued on the next line"
-shape "a heading directly under a paragraph fails" 1 $'Para\n# Heading\n' 2 "a heading not preceded by a blank line"
-shape "a heading not followed by a blank line fails" 1 $'# Heading\nPara\n' 2 "a heading not followed by a blank line"
-shape "a fence directly under a paragraph fails" 1 $'Para\n```\ncode\n```\n' 2 "a fence directly under a paragraph or list line"
-shape "a fence closer not followed by a blank line fails" 1 $'```\ncode\n```\nPara\n' 4 "a fence not followed by a blank line"
-shape "a list directly under a paragraph fails" 1 $'Para\n- item\n' 2 "a list item directly under a paragraph line"
-shape "a table directly under a heading fails" 1 $'# H\n| a |\n|---|\n' 2 "a heading not followed by a blank line"
-shape "a thematic break directly under a heading fails" 1 $'# H\n---\n' 2 "a heading not followed by a blank line"
-shape "an HTML comment directly under a heading fails" 1 $'# H\n<!-- x -->\n' 2 "a heading not followed by a blank line"
-shape "a definition directly under a heading fails" 1 $'# H\n[a]: x\n' 2 "a heading not followed by a blank line"
-shape "a blockquote directly under a heading fails" 1 $'# H\n> q\n' 2 "a heading not followed by a blank line"
-shape "a paragraph leaving the quote a heading sits in fails" 1 $'> # H\nafter\n' 2 "a heading not followed by a blank line"
-shape "a heading directly under a quoted paragraph fails" 1 $'> p\n# H\n' 2 "a heading not preceded by a blank line"
-shape "a table directly under a fence closer fails" 1 $'```\nx\n```\n| a |\n|---|\n' 4 "a fence not followed by a blank line"
-shape "a definition whose destination sits on the next line is a wrap" 1 $'[ref]:\n  http://x\n' 2 "a paragraph hard-wrapped over lines"
-shape "a prompt-section opener sharing its line with prose is a paragraph line" 1 $'<delegation_format> Do it.\nwrapped\n' 2 "a paragraph hard-wrapped over lines"
-shape "control: an HTML element's block still ends at the blank line" 1 $'<details>\nx\n\nwrapped\nlines\n</details>\n' 5 "a paragraph hard-wrapped over lines"
-shape "control: a pipe line over prose is a wrap, not a table" 1 $'a | b\nc | d\n' 2 "a paragraph hard-wrapped over lines"
-shape "control: a delimiter row under a line with no pipe is a wrap" 1 $'a\n--|--\n' 2 "a paragraph hard-wrapped over lines"
-shape "a trailing double space fails" 1 $'Line one  \n\nLine two\n' 1 "a trailing-double-space line break"
-shape "a hard wrap inside a blockquote fails" 1 $'> quoted\n> continued\n' 2 "a paragraph hard-wrapped over lines"
-shape "a lazy continuation of a quoted paragraph fails" 1 $'> quoted\ncontinued\n' 2 "a paragraph hard-wrapped over lines"
-shape "a CRLF line is the file's one violation" 1 $'Line one\r\nLine two\r\n' 1 "a CRLF line ending"
-case "$OUT" in *"doc.md:2:"*) bad "a CRLF file is not judged past its first line" "$OUT" ;; *) ok "a CRLF file is not judged past its first line" ;; esac
-case "$OUT" in *"remedies: reflow the file with md-reflow"*) ok "the remedy names md-reflow" ;; *) bad "remedy names md-reflow" "$OUT" ;; esac
+echo "=== the rules fire on the shapes they name, once per line ==="
+shape_rows \
+  "one paragraph per line, blank-separated, passes, and the verdict counts the file|# Title\n\nOne paragraph on one line.\n\n- item one\n- item two\n\nAnother.\n|rc=0 $(clean 1)" \
+  "a hard-wrapped paragraph fails on the continuation line, with the remedy|First line\nsecond line.\n|rc=1 $(viol doc.md 2 "$WRAP");$(failed 1 1)" \
+  "a list item continued on the next line fails|- item\n  continued\n|rc=1 $(viol doc.md 2 "$ITEM");$(failed 1 1)" \
+  "an ordered item continued on the next line fails|1. item\n   continued\n|rc=1 $(viol doc.md 2 "$ITEM");$(failed 1 1)" \
+  "a heading directly under a paragraph fails|Para\n# Heading\n|rc=1 $(viol doc.md 2 "$H_BEFORE");$(failed 1 1)" \
+  "a heading not followed by a blank line fails|# Heading\nPara\n|rc=1 $(viol doc.md 2 "$H_AFTER");$(failed 1 1)" \
+  "a fence directly under a paragraph fails|Para\n\`\`\`\ncode\n\`\`\`\n|rc=1 $(viol doc.md 2 'a fence directly under a paragraph or list line; put a blank line before it');$(failed 1 1)" \
+  "a fence closer not followed by a blank line fails|\`\`\`\ncode\n\`\`\`\nPara\n|rc=1 $(viol doc.md 4 "$F_AFTER");$(failed 1 1)" \
+  "a list directly under a paragraph fails|Para\n- item\n|rc=1 $(viol doc.md 2 'a list item directly under a paragraph line; put a blank line before the list');$(failed 1 1)" \
+  "a table directly under a heading fails|# H\n\174 a \174\n\174---\174\n|rc=1 $(viol doc.md 2 "$H_AFTER");$(failed 1 1)" \
+  "a thematic break directly under a heading fails|# H\n---\n|rc=1 $(viol doc.md 2 "$H_AFTER");$(failed 1 1)" \
+  "an HTML comment directly under a heading fails|# H\n<!-- x -->\n|rc=1 $(viol doc.md 2 "$H_AFTER");$(failed 1 1)" \
+  "a definition directly under a heading fails|# H\n[a]: x\n|rc=1 $(viol doc.md 2 "$H_AFTER");$(failed 1 1)" \
+  "a blockquote directly under a heading fails|# H\n> q\n|rc=1 $(viol doc.md 2 "$H_AFTER");$(failed 1 1)" \
+  "a paragraph leaving the quote a heading sits in fails|> # H\nafter\n|rc=1 $(viol doc.md 2 "$H_AFTER");$(failed 1 1)" \
+  "a heading directly under a quoted paragraph fails|> p\n# H\n|rc=1 $(viol doc.md 2 "$H_BEFORE");$(failed 1 1)" \
+  "a table directly under a fence closer fails|\`\`\`\nx\n\`\`\`\n\174 a \174\n\174---\174\n|rc=1 $(viol doc.md 4 "$F_AFTER");$(failed 1 1)" \
+  "a definition whose destination sits on the next line is a wrap|[ref]:\n  http://x\n|rc=1 $(viol doc.md 2 "$WRAP");$(failed 1 1)" \
+  "a prompt-section opener sharing its line with prose is a paragraph line|<delegation_format> Do it.\nwrapped\n|rc=1 $(viol doc.md 2 "$WRAP");$(failed 1 1)" \
+  "control: an HTML element's block still ends at the blank line|<details>\nx\n\nwrapped\nlines\n</details>\n|rc=1 $(viol doc.md 5 "$WRAP");$(failed 1 1)" \
+  "control: a pipe line over prose is a wrap, not a table|a \174 b\nc \174 d\n|rc=1 $(viol doc.md 2 "$WRAP");$(failed 1 1)" \
+  "control: a delimiter row under a line with no pipe is a wrap|a\n--\174--\n|rc=1 $(viol doc.md 2 "$WRAP");$(failed 1 1)" \
+  "a trailing double space fails|Line one  \n\nLine two\n|rc=1 $(viol doc.md 1 'a trailing-double-space line break; join the lines instead');$(failed 1 1)" \
+  "a trailing double space on a list item fails|- item  \n- next\n|rc=1 $(viol doc.md 1 'a trailing-double-space line break; join the lines instead');$(failed 1 1)" \
+  "a hard wrap inside a blockquote fails|> quoted\n> continued\n|rc=1 $(viol doc.md 2 "$WRAP");$(failed 1 1)" \
+  "a lazy continuation of a quoted paragraph fails|> quoted\ncontinued\n|rc=1 $(viol doc.md 2 "$WRAP");$(failed 1 1)" \
+  "a CRLF line is the file's one violation: nothing past its first line is judged|Line one\r\nLine two\r\n|rc=1 $(viol doc.md 1 'a CRLF line ending; the format is LF, and the file is not judged past this line');$(failed 1 1)" \
+  "two wraps are two violations, each on its own line|One\ntwo\n\nThree\nfour\n|rc=1 $(viol doc.md 2 "$WRAP");$(viol doc.md 5 "$WRAP");$(failed 2 1)"
 
 echo "=== the shapes the rule skips stay quiet ==="
-shape "a nested list item is an item, not a continuation" 0 $'- parent\n  - child\n    - grandchild\n- sibling\n'
-shape "a multi-paragraph item after a blank line is a paragraph" 0 $'- item\n\n  second paragraph of the item\n'
-shape "fenced code keeps its lines, tilde and backtick alike" 0 $'```\nwrapped\ntext\n# not a heading\n```\n\n~~~\nmore\nlines\n~~~\n'
-shape "a longer fence closes only on a run at least as long" 0 $'````\n```\ninner\n```\n````\n'
-shape "a table is not judged" 0 $'| a | b |\n|---|---|\n| c | d |\n'
-shape "a table directly under a paragraph is a boundary, not a wrap" 0 $'Para\n| a | b |\n|---|---|\n'
-shape "a table without outer pipes is a table" 0 $'a | b\n:--|--:\n1 | 2\n'
-shape "a table runs to the next blank line, so a row without a pipe is a row" 0 $'| a |\n|---|\nrow\n\nPara\n'
-shape "a prompt-section block is not judged, blank lines included, to its closing tag" 0 $'<output_format>\nwrapped\nlines\n\nSource: [S]\nIssue: [I]\n</output_format>\n'
-shape "a prompt-section block indented under a list item is not judged" 0 $'1. step\n\n   <delegation_format>\n   Follow: x\n\n   Source: [S]\n   Issue: [I]\n   </delegation_format>\n'
-shape "a quote directly under a paragraph is a boundary" 0 $'Para\n> q\n'
-shape "an HTML block is not judged" 0 $'<details>\n<summary>x</summary>\nwrapped\nlines\n</details>\n'
-shape "an HTML comment block is not judged" 0 $'<!--\nwrapped\nlines\n-->\n'
-shape "a heading directly under a one-line HTML comment passes (the render marker shape)" 0 $'<!-- kendex:project-instructions:start -->\n## Project Instructions\n\n<!-- kendex:shared-instructions:start -->\nOne line.\n<!-- kendex:shared-instructions:end -->\n<!-- kendex:project-instructions:end -->\n'
-shape "indented code after a blank line is not judged" 0 $'Para\n\n    code\n    more code\n'
-shape "front matter is skipped" 0 $'---\ntitle: x\nwrapped: y\n---\n\nPara\n'
-shape "a setext heading is a heading, not a wrap" 0 $'Heading\n=======\n\nPara\n\nSecond\n-------\n'
-shape "reference definitions stack without blank lines" 0 $'Para\n\n[a]: https://x\n[b]: https://y\n'
-shape "a thematic break is a boundary" 0 $'Para\n\n---\n\nPara\n'
-shape "a blockquote paragraph on one line passes" 0 $'> one line\n\n> another\n'
-shape "a `#hashtag` line is a paragraph, not a heading" 0 $'#tag one\n'
-shape "a file without a trailing newline passes" 0 $'Para'
+shape_rows \
+  "a nested list item is an item, not a continuation|- parent\n  - child\n    - grandchild\n- sibling\n|rc=0 $(clean 1)" \
+  "a multi-paragraph item after a blank line is a paragraph|- item\n\n  second paragraph of the item\n|rc=0 $(clean 1)" \
+  "fenced code keeps its lines, tilde and backtick alike|\`\`\`\nwrapped\ntext\n# not a heading\n\`\`\`\n\n~~~\nmore\nlines\n~~~\n|rc=0 $(clean 1)" \
+  "a longer fence closes only on a run at least as long|\`\`\`\`\n\`\`\`\ninner\n\`\`\`\n\`\`\`\`\n|rc=0 $(clean 1)" \
+  "a table is not judged|\174 a \174 b \174\n\174---\174---\174\n\174 c \174 d \174\n|rc=0 $(clean 1)" \
+  "a table directly under a paragraph is a boundary, not a wrap|Para\n\174 a \174 b \174\n\174---\174---\174\n|rc=0 $(clean 1)" \
+  "a table without outer pipes is a table|a \174 b\n:--\174--:\n1 \174 2\n|rc=0 $(clean 1)" \
+  "a table runs to the next blank line, so a row without a pipe is a row|\174 a \174\n\174---\174\nrow\n\nPara\n|rc=0 $(clean 1)" \
+  "a prompt-section block is not judged, blank lines included, to its closing tag|<output_format>\nwrapped\nlines\n\nSource: [S]\nIssue: [I]\n</output_format>\n|rc=0 $(clean 1)" \
+  "a prompt-section block indented under a list item is not judged|1. step\n\n   <delegation_format>\n   Follow: x\n\n   Source: [S]\n   Issue: [I]\n   </delegation_format>\n|rc=0 $(clean 1)" \
+  "a quote directly under a paragraph is a boundary|Para\n> q\n|rc=0 $(clean 1)" \
+  "an HTML block is not judged|<details>\n<summary>x</summary>\nwrapped\nlines\n</details>\n|rc=0 $(clean 1)" \
+  "an HTML comment block is not judged|<!--\nwrapped\nlines\n-->\n|rc=0 $(clean 1)" \
+  "a heading directly under a one-line HTML comment passes (the render marker shape)|<!-- kendex:project-instructions:start -->\n## Project Instructions\n\n<!-- kendex:shared-instructions:start -->\nOne line.\n<!-- kendex:shared-instructions:end -->\n<!-- kendex:project-instructions:end -->\n|rc=0 $(clean 1)" \
+  "indented code after a blank line is not judged|Para\n\n    code\n    more code\n|rc=0 $(clean 1)" \
+  "front matter is skipped|---\ntitle: x\nwrapped: y\n---\n\nPara\n|rc=0 $(clean 1)" \
+  "a setext heading is a heading, not a wrap|Heading\n=======\n\nPara\n\nSecond\n-------\n|rc=0 $(clean 1)" \
+  "reference definitions stack without blank lines|Para\n\n[a]: https://x\n[b]: https://y\n|rc=0 $(clean 1)" \
+  "a thematic break is a boundary|Para\n\n---\n\nPara\n|rc=0 $(clean 1)" \
+  "a blockquote paragraph on one line passes|> one line\n\n> another\n|rc=0 $(clean 1)" \
+  "a #hashtag line is a paragraph, not a heading|#tag one\n|rc=0 $(clean 1)" \
+  "a file without a trailing newline passes|Para|rc=0 $(clean 1)"
 
-echo "=== a construct with no end is a collection error, not a pass ==="
-shape "an unterminated fence is exit 2" 2 $'Para\n\n```\nnever closed\n'
-case "$OUT" in *"doc.md:3: an unterminated fence"*) ok "the refusal names the file and line" ;; *) bad "refusal names file and line" "$OUT" ;; esac
-shape "unterminated front matter is exit 2" 2 $'---\ntitle: x\n'
-shape "a prompt-section block with no closing tag is exit 2" 2 $'Para\n\n<output_format>\nprose\n\nmore\n'
-case "$OUT" in *"doc.md:3: a block with no closing </output_format>"*) ok "the refusal names the opener's line and tag" ;; *) bad "refusal names the opener" "$OUT" ;; esac
+echo "=== a construct with no end is a collection error naming the opener, not a pass ==="
+shape_rows \
+  "an unterminated fence is exit 2, naming the file and line|Para\n\n\`\`\`\nnever closed\n|rc=2 $(refused 3 'an unterminated fence')" \
+  "unterminated front matter is exit 2|---\ntitle: x\n|rc=2 $(refused 1 'unterminated front matter')" \
+  "a prompt-section block with no closing tag is exit 2, naming the opener's line and tag|Para\n\n<output_format>\nprose\n\nmore\n|rc=2 $(refused 3 'a block with no closing </output_format>')"
+
+# Table two: FIXTURE (a function and its words) builds the repository; the
+# judge runs with ARGS under ENVS.
+run_rows() { # label | fixture | envs | args | expect
+  local row label fx envs args expect words
+  for row in "$@"; do
+    IFS='|' read -r label fx envs args expect <<<"$row"
+    R=""
+    read -ra words <<<"$fx"
+    "${words[@]}"
+    assert_eq "$label" "$expect" "$(run "$envs" "$args")"
+  done
+}
 
 echo "=== scopes: --staged judges the files a commit touches, in full ==="
-new_repo scopes
-put clean.md $'Clean.\n'
-put wrapped.md $'Wrapped\ntext.\n'
-git -C "$R" commit -qm seed
-run_mdf --staged
-[ "$RC" -eq 0 ] && case "$OUT" in *"no staged markdown file(s) to judge"*) true ;; *) false ;; esac \
-  && ok "with nothing staged, --staged judges nothing and says so" || bad "--staged with nothing staged" "rc=$RC out=$OUT"
-printf 'Wrapped\ntext.\nMore.\n' >"$R/wrapped.md"
-git -C "$R" add wrapped.md
-run_mdf --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"wrapped.md:2:"*"wrapped.md:3:"*) true ;; *) false ;; esac \
-  && ok "a touched file is judged in full: the committed wrap on line 2 fails beside the new line 3" \
-  || bad "touched file judged in full" "rc=$RC out=$OUT"
-printf 'Wrapped text. More.\n' >"$R/wrapped.md"
-printf 'Wrapped\ntext.\n' >"$R/clean.md"
-git -C "$R" add wrapped.md
-run_mdf --staged
-[ "$RC" -eq 0 ] && case "$OUT" in *"1 staged markdown file(s) clean"*) true ;; *) false ;; esac \
-  && ok "control: the unstaged edit to clean.md is not judged, and the staged fix passes" \
-  || bad "control: unstaged edit not judged" "rc=$RC out=$OUT"
-git -C "$R" add clean.md
-run_mdf --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"clean.md:2:"*) true ;; *) false ;; esac \
-  && ok "once staged, the same edit fails" || bad "staged edit fails" "rc=$RC out=$OUT"
-git -C "$R" commit -qm fix
-
-echo "=== scopes: --all judges every tracked matching file ==="
-run_mdf --all
-[ "$RC" -eq 1 ] && case "$OUT" in *"clean.md:2:"*) true ;; *) false ;; esac \
-  && ok "--all reaches the committed file no commit is touching" || bad "--all reaches committed files" "rc=$RC out=$OUT"
-printf 'Clean.\n' >"$R/clean.md"
-git -C "$R" add clean.md && git -C "$R" commit -qm clean
-run_mdf --all
-[ "$RC" -eq 0 ] && case "$OUT" in *"2 tracked markdown file(s) clean"*) true ;; *) false ;; esac \
-  && ok "control: --all passes once every tracked file is clean, counting both" || bad "control: --all clean" "rc=$RC out=$OUT"
-
-echo "=== scopes: with neither flag, COMMIT_GUARDS_MD_SCOPE decides ==="
-run_mdf
-[ "$RC" -eq 0 ] && case "$OUT" in *"nothing staged to judge"*"COMMIT_GUARDS_MD_SCOPE=all"*) true ;; *) false ;; esac \
-  && ok "under the default touched scope with nothing staged, one line says so and how to widen" \
-  || bad "touched scope with nothing staged" "rc=$RC out=$OUT"
-printf 'Wrapped\nagain.\n' >"$R/clean.md"
-git -C "$R" add clean.md
-run_mdf
-[ "$RC" -eq 1 ] && case "$OUT" in *"1 staged markdown file(s)"*) true ;; *) false ;; esac \
-  && ok "under touched, a staged file is judged" || bad "touched judges the staged file" "rc=$RC out=$OUT"
-git -C "$R" checkout -q -- clean.md 2>/dev/null || true
-git -C "$R" reset -q --hard
-printf 'Wrapped\ntext.\n' >"$R/committed.md"
-git -C "$R" add committed.md && git -C "$R" commit -qm wrapped
-run_mdf
-[ "$RC" -eq 0 ] && ok "control: under touched, the committed wrap is out of scope" || bad "control: touched ignores committed files" "rc=$RC out=$OUT"
-OUT="$(cd "$R" && COMMIT_GUARDS_MD_SCOPE=all "$MDF" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 1 ] && case "$OUT" in *"committed.md:2:"*) true ;; *) false ;; esac \
-  && ok "COMMIT_GUARDS_MD_SCOPE=all is --all" || bad "scope=all is --all" "rc=$RC out=$OUT"
-printf '[env]\nCOMMIT_GUARDS_MD_SCOPE = "all"\n' >"$R/kendex.settings.toml"
-git -C "$R" add -A
-run_mdf
-[ "$RC" -eq 1 ] && case "$OUT" in *"committed.md:2:"*) true ;; *) false ;; esac \
-  && ok "the scope resolves from kendex.settings.toml [env]" || bad "scope from settings" "rc=$RC out=$OUT"
-rm "$R/kendex.settings.toml"
-git -C "$R" add -A
-OUT="$(cd "$R" && COMMIT_GUARDS_MD_SCOPE=sometimes "$MDF" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"must be 'touched' or 'all'"*) true ;; *) false ;; esac \
-  && ok "an unknown scope is exit 2" || bad "unknown scope is exit 2" "rc=$RC out=$OUT"
-run_mdf --staged --all
-[ "$RC" -eq 2 ] && ok "--staged with --all is exit 2" || bad "--staged with --all is exit 2" "rc=$RC out=$OUT"
+seeded() { repo "$1"; put clean.md 'Clean.\n'; put wrapped.md "$WRAPPED"; commit seed; } # NAME — a committed wrap, nothing staged
+fx_touched_full() { seeded touched-full; put wrapped.md 'Wrapped\ntext.\nMore.\n'; }
+fx_unstaged_edit() { seeded unstaged-edit; put wrapped.md 'Wrapped text. More.\n'; write clean.md "$WRAPPED"; }
+fx_staged_edit() { seeded staged-edit; put wrapped.md 'Wrapped text. More.\n'; put clean.md "$WRAPPED"; }
+fx_committed_wrap() { seeded committed-wrap; put wrapped.md 'Wrapped text. More.\n'; put clean.md "$WRAPPED"; commit fix; } # both committed, clean.md wrapped
+fx_all_clean() { seeded all-clean; put wrapped.md 'Wrapped text. More.\n'; commit fix; }
+fx_touched_staged() { seeded touched-staged; put clean.md 'Wrapped\nagain.\n'; }
+fx_deletion() { seeded deletion; git -C "$R" rm -q clean.md; }
+fx_settings_all() { seeded settings-all; put kendex.settings.toml '[env]\nCOMMIT_GUARDS_MD_SCOPE = "all"\n'; }
+run_rows \
+  "with nothing staged, --staged judges nothing and says so, naming the path list|seeded staged-nothing||--staged|rc=0 $(nomatch staged '*.md')" \
+  "a touched file is judged in full: the committed wrap on line 2 fails beside the new line 3|fx_touched_full||--staged|rc=1 $(viol wrapped.md 2 "$WRAP");$(viol wrapped.md 3 "$WRAP");$(failed 2 1 staged)" \
+  "control: the unstaged edit to clean.md is not judged, and the staged fix passes|fx_unstaged_edit||--staged|rc=0 $(clean 1 staged)" \
+  "once staged, the same edit fails, with both staged files counted|fx_staged_edit||--staged|rc=1 $(viol clean.md 2 "$WRAP");$(failed 1 2 staged)" \
+  "a staged deletion is no file to judge|fx_deletion||--staged|rc=0 $(nomatch staged '*.md')" \
+  "--all reaches the committed file no commit is touching|fx_committed_wrap||--all|rc=1 $(viol clean.md 2 "$WRAP");$(failed 1 2)" \
+  "control: --all passes once every tracked file is clean, counting both|fx_all_clean||--all|rc=0 $(clean 2)" \
+  "under the default touched scope with nothing staged, one line says so and how to widen|seeded touched-nothing|||rc=0 $NOTHING_STAGED" \
+  "under touched, a staged file is judged|fx_touched_staged|||rc=1 $(viol clean.md 2 "$WRAP");$(failed 1 1 staged)" \
+  "control: under touched, the committed wrap is out of scope|seeded touched-committed|||rc=0 $NOTHING_STAGED" \
+  "COMMIT_GUARDS_MD_SCOPE=all is --all|seeded env-all|COMMIT_GUARDS_MD_SCOPE=all||rc=1 $(viol wrapped.md 2 "$WRAP");$(failed 1 2)" \
+  "the scope resolves from kendex.settings.toml [env]|fx_settings_all|||rc=1 $(viol wrapped.md 2 "$WRAP");$(failed 1 2)" \
+  "an unknown scope is exit 2, quoting it|seeded scope-unknown|COMMIT_GUARDS_MD_SCOPE=sometimes||rc=2 ${ERR}COMMIT_GUARDS_MD_SCOPE must be 'touched' or 'all', got 'sometimes'" \
+  "--staged with --all is exit 2|seeded both-flags||--staged --all|rc=2 ${ERR}--staged and --all are exclusive"
 
 echo "=== the path list and the excludes list bound both scopes ==="
-new_repo paths
-put docs/wrapped.md $'Wrapped\ntext.\n'
-put vendor/wrapped.md $'Wrapped\ntext.\n'
-put notes.txt $'Wrapped\ntext.\n'
-run_mdf --all
-[ "$RC" -eq 1 ] && case "$OUT" in *"docs/wrapped.md:2:"*"vendor/wrapped.md:2:"*) true ;; *) false ;; esac \
-  && ok "control: the default *.md reaches both markdown files and not the .txt" || bad "control: default path list" "rc=$RC out=$OUT"
-case "$OUT" in *"notes.txt"*) bad "a non-markdown path is never judged" "$OUT" ;; *) ok "a non-markdown path is never judged" ;; esac
-OUT="$(cd "$R" && COMMIT_GUARDS_MD_PATHS='docs/*.md' "$MDF" --all 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 1 ] && case "$OUT" in *"vendor/wrapped.md"*) false ;; *"docs/wrapped.md:2:"*) true ;; *) false ;; esac \
-  && ok "COMMIT_GUARDS_MD_PATHS replaces the list" || bad "path list replaces" "rc=$RC out=$OUT"
-mkdir -p "$R/tools"
-printf 'vendor/*\tupstream docs, not ours\n' >"$R/tools/md-excludes"
-git -C "$R" add -A
-run_mdf --all
-[ "$RC" -eq 1 ] && case "$OUT" in *"vendor/wrapped.md"*) false ;; *"docs/wrapped.md:2:"*) true ;; *) false ;; esac \
-  && ok "tools/md-excludes drops the vendored tree from --all" || bad "excludes drop vendored tree" "rc=$RC out=$OUT"
-run_mdf --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"vendor/wrapped.md"*) false ;; *"docs/wrapped.md:2:"*) true ;; *) false ;; esac \
-  && ok "and from --staged" || bad "excludes drop vendored tree at commit" "rc=$RC out=$OUT"
-printf 'vendor/*\tupstream docs, not ours\n!vendor/wrapped.md\tours after all\n' >"$R/tools/md-excludes"
-git -C "$R" add -A
-run_mdf --all
-[ "$RC" -eq 1 ] && case "$OUT" in *"vendor/wrapped.md:2:"*) true ;; *) false ;; esac \
-  && ok "a ! row carves a path back in" || bad "carve-in" "rc=$RC out=$OUT"
-printf 'vendor/*\n' >"$R/tools/md-excludes"
-git -C "$R" add -A
-run_mdf --all
-[ "$RC" -eq 2 ] && case "$OUT" in *"pattern<TAB>reason"*) true ;; *) false ;; esac \
-  && ok "an exclusion without a reason is exit 2" || bad "reasonless exclusion is exit 2" "rc=$RC out=$OUT"
-OUT="$(cd "$R" && COMMIT_GUARDS_MD_PATHS=' ' "$MDF" --all 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"names no path"*) true ;; *) false ;; esac \
-  && ok "an empty path list is exit 2" || bad "empty path list is exit 2" "rc=$RC out=$OUT"
-run_mdf --no-such-flag
-[ "$RC" -eq 2 ] && ok "an unknown flag is exit 2" || bad "unknown flag is exit 2" "rc=$RC out=$OUT"
-run_mdf --help
-[ "$RC" -eq 0 ] && case "$OUT" in *"usage: md-format"*) true ;; *) false ;; esac \
-  && ok "--help prints usage at exit 0" || bad "--help prints usage" "rc=$RC out=$OUT"
+paths() { repo "$1"; put docs/wrapped.md "$WRAPPED"; put vendor/wrapped.md "$WRAPPED"; put notes.txt "$WRAPPED"; } # NAME — two wrapped markdown files and a .txt
+fx_excluded() { paths "$1"; put tools/md-excludes 'vendor/*\tupstream docs, not ours\n'; }
+fx_carved() { paths carved; put tools/md-excludes 'vendor/*\tupstream docs, not ours\n!vendor/wrapped.md\tours after all\n'; }
+fx_reasonless() { paths reasonless; put tools/md-excludes 'vendor/*\n'; }
+run_rows \
+  "control: the default *.md reaches both markdown files and never the .txt|paths default||--all|rc=1 $(viol docs/wrapped.md 2 "$WRAP");$(viol vendor/wrapped.md 2 "$WRAP");$(failed 2 2)" \
+  "COMMIT_GUARDS_MD_PATHS replaces the list|paths replaced|COMMIT_GUARDS_MD_PATHS=docs/*.md|--all|rc=1 $(viol docs/wrapped.md 2 "$WRAP");$(failed 1 1)" \
+  "tools/md-excludes drops the vendored tree from --all|fx_excluded excluded-all||--all|rc=1 $(viol docs/wrapped.md 2 "$WRAP");$(failed 1 1)" \
+  "and from --staged|fx_excluded excluded-staged||--staged|rc=1 $(viol docs/wrapped.md 2 "$WRAP");$(failed 1 1 staged)" \
+  "a ! row carves a path back in|fx_carved||--all|rc=1 $(viol docs/wrapped.md 2 "$WRAP");$(viol vendor/wrapped.md 2 "$WRAP");$(failed 2 2)" \
+  "an exclusion without a reason is exit 2, naming the row|fx_reasonless||--all|rc=2 ${ERR}tools/md-excludes:1: expected 'pattern<TAB>reason' (every exclusion carries its justification)" \
+  "an empty path list is exit 2|paths empty-list|COMMIT_GUARDS_MD_PATHS= |--all|rc=2 ${ERR}COMMIT_GUARDS_MD_PATHS names no path — name at least one, or drop this check from COMMIT_GUARDS_CHECKS" \
+  "an unknown flag is exit 2, quoting it|paths unknown-flag||--no-such-flag|rc=2 ${ERR}unknown argument '--no-such-flag' (see --help)"
+# The usage text carries a '|', which a row cannot: its first line and the
+# exit status, beside the table.
+assert_eq "--help prints usage at exit 0" "rc=0 usage: md-format [--staged | --all]" "$(run '' --help | sed -n 1p | LC_ALL=C cut -d';' -f1)"
 
 echo "=== a selected path that is not markdown is named, never counted clean ==="
-new_repo unmeasurable
-put notes/target.md $'Wrapped\ntext.\n'
-put docs/link.md $'Clean.\n'
-rm "$R/docs/link.md"
-ln -s ../notes/target.md "$R/docs/link.md"
-git -C "$R" add -A
-OUT="$(cd "$R" && COMMIT_GUARDS_MD_PATHS='docs/*.md' "$MDF" --all 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && case "$OUT" in *"not measured: docs/link.md"*"tracked as a symlink"*"1 matched path(s) not measured"*) true ;; *) false ;; esac \
-  && ok "a symlink at a selected path is named as unmeasured and counted apart" || bad "symlink named as unmeasured" "rc=$RC out=$OUT"
-case "$OUT" in *"markdown file(s) clean"*) bad "no clean count covers the unread link" "$OUT" ;; *) ok "no clean count covers the unread link" ;; esac
-OUT="$(cd "$R" && COMMIT_GUARDS_MD_PATHS='docs/*.md' "$MDF" --staged 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && case "$OUT" in *"not measured: docs/link.md"*) true ;; *) false ;; esac \
-  && ok "the staged scope names the same link" || bad "staged scope names the link" "rc=$RC out=$OUT"
-printf 'lead\000Wrapped\ntext.\n' >"$R/docs/bin.md"
-git -C "$R" add -A
-OUT="$(cd "$R" && COMMIT_GUARDS_MD_PATHS='docs/*.md' "$MDF" --all 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && case "$OUT" in *"not measured: docs/bin.md"*"binary content"*) true ;; *) false ;; esac \
-  && ok "a binary blob at a selected path is named as unmeasured" || bad "binary blob named" "rc=$RC out=$OUT"
+fx_symlink() { repo "$1"; put notes/target.md "$WRAPPED"; mkdir -p "$R/docs"; ln -s ../notes/target.md "$R/docs/link.md"; git -C "$R" add -A; }
+fx_symlink_and_binary() { fx_symlink symlink-binary; put docs/bin.md 'lead\0000Wrapped\ntext.\n'; }
+run_rows \
+  "a symlink at a selected path is named as unmeasured and counted apart, with no clean count|fx_symlink symlink-all|COMMIT_GUARDS_MD_PATHS=docs/*.md|--all|rc=0 $(skip docs/link.md 'tracked as a symlink, not markdown');$NONE$(unmeasured 1)" \
+  "the staged scope names the same link|fx_symlink symlink-staged|COMMIT_GUARDS_MD_PATHS=docs/*.md|--staged|rc=0 $(skip docs/link.md 'tracked as a symlink, not markdown');$NONE$(unmeasured 1)" \
+  "a binary blob at a selected path is named as unmeasured, in index order beside the link|fx_symlink_and_binary|COMMIT_GUARDS_MD_PATHS=docs/*.md|--all|rc=0 $(skip docs/bin.md 'binary content, not markdown');$(skip docs/link.md 'tracked as a symlink, not markdown');$NONE$(unmeasured 2)"
 
 echo "=== the skill's own shipped markdown is in the format ==="
-new_repo self
-mkdir -p "$R/skills/commit-guards"
-for doc in SKILL.md README.md CHECKS.md DEVELOPMENT.md; do
-  cp "$SKILL_DIR/$doc" "$R/skills/commit-guards/$doc"
-done
-git -C "$R" add -A
-run_mdf --all
-[ "$RC" -eq 0 ] && case "$OUT" in *"4 tracked markdown file(s) clean"*) true ;; *) false ;; esac \
-  && ok "SKILL.md, README.md, CHECKS.md and DEVELOPMENT.md pass" || bad "shipped docs pass" "rc=$RC out=$OUT"
-put skills/commit-guards/wrapped.md $'Wrapped\ntext.\n'
-run_mdf --all
-[ "$RC" -eq 1 ] && ok "control: a planted wrap beside them fails" || bad "control: planted wrap fails" "rc=$RC out=$OUT"
+fx_shipped() { # NAME — the four shipped documents
+  local doc
+  repo "$1"
+  mkdir -p "$R/skills/commit-guards"
+  for doc in SKILL.md README.md CHECKS.md DEVELOPMENT.md; do
+    cp "$SKILL_DIR/$doc" "$R/skills/commit-guards/$doc"
+  done
+  git -C "$R" add -A
+}
+fx_shipped_planted() { fx_shipped shipped-planted; put skills/commit-guards/wrapped.md "$WRAPPED"; }
+run_rows \
+  "SKILL.md, README.md, CHECKS.md and DEVELOPMENT.md pass|fx_shipped shipped||--all|rc=0 $(clean 4)" \
+  "control: a planted wrap beside them fails, counted with them|fx_shipped_planted||--all|rc=1 $(viol skills/commit-guards/wrapped.md 2 "$WRAP");$(failed 1 5)"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.agents/skills/commit-guards/tests/md-format.test.sh
+++ b/.agents/skills/commit-guards/tests/md-format.test.sh
@@ -121,6 +121,7 @@ shape_rows \
   "a trailing double space fails|Line one  \n\nLine two\n|rc=1 $(viol doc.md 1 'a trailing-double-space line break; join the lines instead');$(failed 1 1)" \
   "a trailing double space on a list item fails|- item  \n- next\n|rc=1 $(viol doc.md 1 'a trailing-double-space line break; join the lines instead');$(failed 1 1)" \
   "a hard wrap inside a blockquote fails|> quoted\n> continued\n|rc=1 $(viol doc.md 2 "$WRAP");$(failed 1 1)" \
+  "a #hashtag line is a paragraph, not a heading: the line under it is its wrap|#tag one\nwrapped\n|rc=1 $(viol doc.md 2 "$WRAP");$(failed 1 1)" \
   "a lazy continuation of a quoted paragraph fails|> quoted\ncontinued\n|rc=1 $(viol doc.md 2 "$WRAP");$(failed 1 1)" \
   "a CRLF line is the file's one violation: nothing past its first line is judged|Line one\r\nLine two\r\n|rc=1 $(viol doc.md 1 'a CRLF line ending; the format is LF, and the file is not judged past this line');$(failed 1 1)" \
   "two wraps are two violations, each on its own line|One\ntwo\n\nThree\nfour\n|rc=1 $(viol doc.md 2 "$WRAP");$(viol doc.md 5 "$WRAP");$(failed 2 1)"
@@ -147,7 +148,6 @@ shape_rows \
   "reference definitions stack without blank lines|Para\n\n[a]: https://x\n[b]: https://y\n|rc=0 $(clean 1)" \
   "a thematic break is a boundary|Para\n\n---\n\nPara\n|rc=0 $(clean 1)" \
   "a blockquote paragraph on one line passes|> one line\n\n> another\n|rc=0 $(clean 1)" \
-  "a #hashtag line is a paragraph, not a heading|#tag one\n|rc=0 $(clean 1)" \
   "a file without a trailing newline passes|Para|rc=0 $(clean 1)"
 
 echo "=== a construct with no end is a collection error naming the opener, not a pass ==="
@@ -177,6 +177,9 @@ fx_staged_edit() { seeded staged-edit; put wrapped.md 'Wrapped text. More.\n'; p
 fx_committed_wrap() { seeded committed-wrap; put wrapped.md 'Wrapped text. More.\n'; put clean.md "$WRAPPED"; commit fix; } # both committed, clean.md wrapped
 fx_all_clean() { seeded all-clean; put wrapped.md 'Wrapped text. More.\n'; commit fix; }
 fx_touched_staged() { seeded touched-staged; put clean.md 'Wrapped\nagain.\n'; }
+# The deletion row's verdict is the no-match line: a deletion that never
+# happened reads the same. What the row guards is the staged walk's
+# --diff-filter=AMT, which a D would turn into a read of a null sha.
 fx_deletion() { seeded deletion; git -C "$R" rm -q clean.md; }
 fx_settings_all() { seeded settings-all; put kendex.settings.toml '[env]\nCOMMIT_GUARDS_MD_SCOPE = "all"\n'; }
 run_rows \

--- a/skills/commit-guards/tests/md-format.test.sh
+++ b/skills/commit-guards/tests/md-format.test.sh
@@ -1,272 +1,240 @@
 #!/usr/bin/env bash
-# Pins for scripts/md-format: each rule of the format fires on the shape it
-# names and stays quiet on the shapes it skips, the three scopes select the
-# files the docs say, the remedy names md-reflow, and what cannot be judged
-# is named rather than passed. Every green assertion is paired with a
-# control that proves it can fail. The index readers this family shares are
-# pinned once, in index-reads.test.sh and lane-readers.test.sh.
+# Pins for scripts/md-format, the judge of a markdown file's shape: one
+# paragraph per line and one list item per line, blank lines between
+# paragraphs, list blocks, headings and fences, no trailing-double-space
+# break; fenced code, tables, HTML blocks, indented code and front matter
+# left alone; the three scopes select the files the docs say; what cannot be
+# judged is named rather than passed. Two tables: the first holds one shape
+# as doc.md judged with --all, the second the scopes, the path list and the
+# unmeasured paths. A row runs the judge once and pins the exit status with
+# every line printed, so each violation's file, line and rule, the remedy,
+# the count and the scope are one pin. The index readers this family shares
+# are index-reads.test.sh and lane-readers.test.sh.
 set -euo pipefail
-
+# No globbing: a row's ARGS column is word-split into the judge's arguments.
+set -f
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 MDF="$SKILL_DIR/scripts/md-format"
+# shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
-
+# Hermetic: a leaked setting would mask every row below.
 unset COMMIT_GUARDS_MD_PATHS COMMIT_GUARDS_MD_EXCLUDES COMMIT_GUARDS_MD_SCOPE COMMIT_GUARDS_SETTINGS_FILE 2>/dev/null || true
 
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
 
-new_repo() { # NAME — fresh fixture repo in $R
+# One line for a run in the row's repository: the exit status, then every
+# line printed, in order, joined by ';'. ENVS is a comma-separated list of
+# assignments; ARGS are passed through.
+R=""
+run() { # ENVS ARGS
+  local envs=() rc=0 out=""
+  [ -z "$1" ] || IFS=',' read -ra envs <<<"$1"
+  # shellcheck disable=SC2086
+  out="$(cd "$R" && env ${envs[@]+"${envs[@]}"} "$MDF" $2 2>&1)" || rc=$?
+  printf 'rc=%s%s' "$rc" "${out:+ $(printf '%s\n' "$out" | LC_ALL=C paste -sd ';' -)}"
+}
+
+# Fixture vocabulary. Every fixture builds its own repository and stages
+# what it wrote; a name used twice is refused.
+repo() { # NAME
   R="$TMP/$1"
+  [ ! -e "$R" ] || { echo "harness: fixture $1 already exists" >&2; exit 2; }
   mkdir -p "$R"
   git -C "$R" -c init.defaultBranch=main init -q
   git -C "$R" config user.email test@example.com
   git -C "$R" config user.name test
 }
+put() { mkdir -p "$R/$(dirname "$1")"; printf '%b' "$2" >"$R/$1"; git -C "$R" add -A; } # PATH CONTENT (printf %b), staged
+write() { mkdir -p "$R/$(dirname "$1")"; printf '%b' "$2" >"$R/$1"; } # PATH CONTENT — the work tree only
+commit() { git -C "$R" commit -qm "$1"; }
+WRAPPED='Wrapped\ntext.\n'
 
-run_mdf() { # [args...] — run in $R; sets OUT and RC
-  OUT=""
-  RC=0
-  OUT="$(cd "$R" && "$MDF" "$@" 2>&1)" || RC=$?
+# The lines the judge prints, as functions of what a row put in.
+REMEDY="  remedies: reflow the file with md-reflow (scripts/md-reflow PATH), then stage it"
+ERR="::error::md-format: "
+NOTHING_STAGED="md-format: OK — nothing staged to judge (COMMIT_GUARDS_MD_SCOPE=touched judges the files a commit touches); run with --all, or set COMMIT_GUARDS_MD_SCOPE=all once this repository's markdown is reflowed"
+WRAP="a paragraph hard-wrapped over lines; put the whole paragraph on one line"
+ITEM="a list item continued on the next line; put the whole item on one line"
+H_BEFORE="a heading not preceded by a blank line"
+H_AFTER="a heading not followed by a blank line"
+F_AFTER="a fence not followed by a blank line"
+viol() { printf 'md-format FAIL format: %s:%s: %s;%s' "$1" "$2" "$3" "$REMEDY"; } # PATH LINE RULE
+skip() { printf 'md-format: not measured: %s — %s' "$1" "$2"; } # PATH REASON
+unmeasured() { printf '; %s matched path(s) not measured' "$1"; } # N
+clean() { printf 'md-format: OK — %s %s markdown file(s) clean%s' "$1" "${2:-tracked}" "${3-}"; } # N [SCOPE] [UNMEASURED]
+failed() { printf 'md-format: %s format violation(s) in %s %s markdown file(s)%s' "$1" "$2" "${3:-tracked}" "${4-}"; } # VIOLATIONS N [SCOPE] [UNMEASURED]
+nomatch() { printf 'md-format: OK — no %s markdown file(s) to judge (COMMIT_GUARDS_MD_PATHS %s)' "$1" "$2"; } # SCOPE GLOBS
+refused() { printf '%sdoc.md:%s: %s — the file cannot be judged past it; close the construct' "$ERR" "$1" "$2"; } # LINE REASON
+NONE="md-format: OK — nothing measurable to judge"
+
+# Table one: doc.md holds CONTENT in a fresh repository, judged with --all.
+# The columns split on the pipe, so a pipe in the content is written as its
+# octal escape, \174, which printf %b renders.
+ROW=0
+shape_rows() { # label | content | expect
+  local row label content expect
+  for row in "$@"; do
+    IFS='|' read -r label content expect <<<"$row"
+    ROW=$((ROW + 1))
+    R=""
+    repo "shape-$ROW"
+    put doc.md "$content"
+    assert_eq "$label" "$expect" "$(run '' --all)"
+  done
 }
 
-put() { # PATH CONTENT — a tracked file, staged
-  mkdir -p "$R/$(dirname "$1")"
-  printf '%s' "$2" >"$R/$1"
-  git -C "$R" add -A
-}
-
-# The shape under test, staged as doc.md and judged with --all; asserts the
-# verdict and, on a violation, the line and rule named.
-shape() { # LABEL EXPECT-RC CONTENT [LINE RULE-FRAGMENT]
-  local label="$1" want="$2" content="$3" line="${4-}" rule="${5-}"
-  put doc.md "$content"
-  run_mdf --all
-  if [ "$RC" -ne "$want" ]; then
-    bad "$label" "rc=$RC want=$want out=$OUT"
-    return
-  fi
-  if [ "$want" -eq 1 ]; then
-    case "$OUT" in
-      *"format: doc.md:$line: $rule"*) ok "$label" ;;
-      *) bad "$label" "expected doc.md:$line: $rule in: $OUT" ;;
-    esac
-  else
-    ok "$label"
-  fi
-}
-
-new_repo shapes
-
-echo "=== a clean file passes, and the verdict counts it ==="
-shape "one paragraph per line, blank-separated, passes" 0 $'# Title\n\nOne paragraph on one line.\n\n- item one\n- item two\n\nAnother.\n'
-case "$OUT" in *"md-format: OK — 1 tracked markdown file(s) clean"*) ok "the verdict counts the file it read" ;; *) bad "verdict counts files" "$OUT" ;; esac
-
-echo "=== the rules fire on the shapes they name ==="
-shape "a hard-wrapped paragraph fails on the continuation line" 1 $'First line\nsecond line.\n' 2 "a paragraph hard-wrapped over lines"
-shape "a list item continued on the next line fails" 1 $'- item\n  continued\n' 2 "a list item continued on the next line"
-shape "an ordered item continued on the next line fails" 1 $'1. item\n   continued\n' 2 "a list item continued on the next line"
-shape "a heading directly under a paragraph fails" 1 $'Para\n# Heading\n' 2 "a heading not preceded by a blank line"
-shape "a heading not followed by a blank line fails" 1 $'# Heading\nPara\n' 2 "a heading not followed by a blank line"
-shape "a fence directly under a paragraph fails" 1 $'Para\n```\ncode\n```\n' 2 "a fence directly under a paragraph or list line"
-shape "a fence closer not followed by a blank line fails" 1 $'```\ncode\n```\nPara\n' 4 "a fence not followed by a blank line"
-shape "a list directly under a paragraph fails" 1 $'Para\n- item\n' 2 "a list item directly under a paragraph line"
-shape "a table directly under a heading fails" 1 $'# H\n| a |\n|---|\n' 2 "a heading not followed by a blank line"
-shape "a thematic break directly under a heading fails" 1 $'# H\n---\n' 2 "a heading not followed by a blank line"
-shape "an HTML comment directly under a heading fails" 1 $'# H\n<!-- x -->\n' 2 "a heading not followed by a blank line"
-shape "a definition directly under a heading fails" 1 $'# H\n[a]: x\n' 2 "a heading not followed by a blank line"
-shape "a blockquote directly under a heading fails" 1 $'# H\n> q\n' 2 "a heading not followed by a blank line"
-shape "a paragraph leaving the quote a heading sits in fails" 1 $'> # H\nafter\n' 2 "a heading not followed by a blank line"
-shape "a heading directly under a quoted paragraph fails" 1 $'> p\n# H\n' 2 "a heading not preceded by a blank line"
-shape "a table directly under a fence closer fails" 1 $'```\nx\n```\n| a |\n|---|\n' 4 "a fence not followed by a blank line"
-shape "a definition whose destination sits on the next line is a wrap" 1 $'[ref]:\n  http://x\n' 2 "a paragraph hard-wrapped over lines"
-shape "a prompt-section opener sharing its line with prose is a paragraph line" 1 $'<delegation_format> Do it.\nwrapped\n' 2 "a paragraph hard-wrapped over lines"
-shape "control: an HTML element's block still ends at the blank line" 1 $'<details>\nx\n\nwrapped\nlines\n</details>\n' 5 "a paragraph hard-wrapped over lines"
-shape "control: a pipe line over prose is a wrap, not a table" 1 $'a | b\nc | d\n' 2 "a paragraph hard-wrapped over lines"
-shape "control: a delimiter row under a line with no pipe is a wrap" 1 $'a\n--|--\n' 2 "a paragraph hard-wrapped over lines"
-shape "a trailing double space fails" 1 $'Line one  \n\nLine two\n' 1 "a trailing-double-space line break"
-shape "a hard wrap inside a blockquote fails" 1 $'> quoted\n> continued\n' 2 "a paragraph hard-wrapped over lines"
-shape "a lazy continuation of a quoted paragraph fails" 1 $'> quoted\ncontinued\n' 2 "a paragraph hard-wrapped over lines"
-shape "a CRLF line is the file's one violation" 1 $'Line one\r\nLine two\r\n' 1 "a CRLF line ending"
-case "$OUT" in *"doc.md:2:"*) bad "a CRLF file is not judged past its first line" "$OUT" ;; *) ok "a CRLF file is not judged past its first line" ;; esac
-case "$OUT" in *"remedies: reflow the file with md-reflow"*) ok "the remedy names md-reflow" ;; *) bad "remedy names md-reflow" "$OUT" ;; esac
+echo "=== the rules fire on the shapes they name, once per line ==="
+shape_rows \
+  "one paragraph per line, blank-separated, passes, and the verdict counts the file|# Title\n\nOne paragraph on one line.\n\n- item one\n- item two\n\nAnother.\n|rc=0 $(clean 1)" \
+  "a hard-wrapped paragraph fails on the continuation line, with the remedy|First line\nsecond line.\n|rc=1 $(viol doc.md 2 "$WRAP");$(failed 1 1)" \
+  "a list item continued on the next line fails|- item\n  continued\n|rc=1 $(viol doc.md 2 "$ITEM");$(failed 1 1)" \
+  "an ordered item continued on the next line fails|1. item\n   continued\n|rc=1 $(viol doc.md 2 "$ITEM");$(failed 1 1)" \
+  "a heading directly under a paragraph fails|Para\n# Heading\n|rc=1 $(viol doc.md 2 "$H_BEFORE");$(failed 1 1)" \
+  "a heading not followed by a blank line fails|# Heading\nPara\n|rc=1 $(viol doc.md 2 "$H_AFTER");$(failed 1 1)" \
+  "a fence directly under a paragraph fails|Para\n\`\`\`\ncode\n\`\`\`\n|rc=1 $(viol doc.md 2 'a fence directly under a paragraph or list line; put a blank line before it');$(failed 1 1)" \
+  "a fence closer not followed by a blank line fails|\`\`\`\ncode\n\`\`\`\nPara\n|rc=1 $(viol doc.md 4 "$F_AFTER");$(failed 1 1)" \
+  "a list directly under a paragraph fails|Para\n- item\n|rc=1 $(viol doc.md 2 'a list item directly under a paragraph line; put a blank line before the list');$(failed 1 1)" \
+  "a table directly under a heading fails|# H\n\174 a \174\n\174---\174\n|rc=1 $(viol doc.md 2 "$H_AFTER");$(failed 1 1)" \
+  "a thematic break directly under a heading fails|# H\n---\n|rc=1 $(viol doc.md 2 "$H_AFTER");$(failed 1 1)" \
+  "an HTML comment directly under a heading fails|# H\n<!-- x -->\n|rc=1 $(viol doc.md 2 "$H_AFTER");$(failed 1 1)" \
+  "a definition directly under a heading fails|# H\n[a]: x\n|rc=1 $(viol doc.md 2 "$H_AFTER");$(failed 1 1)" \
+  "a blockquote directly under a heading fails|# H\n> q\n|rc=1 $(viol doc.md 2 "$H_AFTER");$(failed 1 1)" \
+  "a paragraph leaving the quote a heading sits in fails|> # H\nafter\n|rc=1 $(viol doc.md 2 "$H_AFTER");$(failed 1 1)" \
+  "a heading directly under a quoted paragraph fails|> p\n# H\n|rc=1 $(viol doc.md 2 "$H_BEFORE");$(failed 1 1)" \
+  "a table directly under a fence closer fails|\`\`\`\nx\n\`\`\`\n\174 a \174\n\174---\174\n|rc=1 $(viol doc.md 4 "$F_AFTER");$(failed 1 1)" \
+  "a definition whose destination sits on the next line is a wrap|[ref]:\n  http://x\n|rc=1 $(viol doc.md 2 "$WRAP");$(failed 1 1)" \
+  "a prompt-section opener sharing its line with prose is a paragraph line|<delegation_format> Do it.\nwrapped\n|rc=1 $(viol doc.md 2 "$WRAP");$(failed 1 1)" \
+  "control: an HTML element's block still ends at the blank line|<details>\nx\n\nwrapped\nlines\n</details>\n|rc=1 $(viol doc.md 5 "$WRAP");$(failed 1 1)" \
+  "control: a pipe line over prose is a wrap, not a table|a \174 b\nc \174 d\n|rc=1 $(viol doc.md 2 "$WRAP");$(failed 1 1)" \
+  "control: a delimiter row under a line with no pipe is a wrap|a\n--\174--\n|rc=1 $(viol doc.md 2 "$WRAP");$(failed 1 1)" \
+  "a trailing double space fails|Line one  \n\nLine two\n|rc=1 $(viol doc.md 1 'a trailing-double-space line break; join the lines instead');$(failed 1 1)" \
+  "a trailing double space on a list item fails|- item  \n- next\n|rc=1 $(viol doc.md 1 'a trailing-double-space line break; join the lines instead');$(failed 1 1)" \
+  "a hard wrap inside a blockquote fails|> quoted\n> continued\n|rc=1 $(viol doc.md 2 "$WRAP");$(failed 1 1)" \
+  "a lazy continuation of a quoted paragraph fails|> quoted\ncontinued\n|rc=1 $(viol doc.md 2 "$WRAP");$(failed 1 1)" \
+  "a CRLF line is the file's one violation: nothing past its first line is judged|Line one\r\nLine two\r\n|rc=1 $(viol doc.md 1 'a CRLF line ending; the format is LF, and the file is not judged past this line');$(failed 1 1)" \
+  "two wraps are two violations, each on its own line|One\ntwo\n\nThree\nfour\n|rc=1 $(viol doc.md 2 "$WRAP");$(viol doc.md 5 "$WRAP");$(failed 2 1)"
 
 echo "=== the shapes the rule skips stay quiet ==="
-shape "a nested list item is an item, not a continuation" 0 $'- parent\n  - child\n    - grandchild\n- sibling\n'
-shape "a multi-paragraph item after a blank line is a paragraph" 0 $'- item\n\n  second paragraph of the item\n'
-shape "fenced code keeps its lines, tilde and backtick alike" 0 $'```\nwrapped\ntext\n# not a heading\n```\n\n~~~\nmore\nlines\n~~~\n'
-shape "a longer fence closes only on a run at least as long" 0 $'````\n```\ninner\n```\n````\n'
-shape "a table is not judged" 0 $'| a | b |\n|---|---|\n| c | d |\n'
-shape "a table directly under a paragraph is a boundary, not a wrap" 0 $'Para\n| a | b |\n|---|---|\n'
-shape "a table without outer pipes is a table" 0 $'a | b\n:--|--:\n1 | 2\n'
-shape "a table runs to the next blank line, so a row without a pipe is a row" 0 $'| a |\n|---|\nrow\n\nPara\n'
-shape "a prompt-section block is not judged, blank lines included, to its closing tag" 0 $'<output_format>\nwrapped\nlines\n\nSource: [S]\nIssue: [I]\n</output_format>\n'
-shape "a prompt-section block indented under a list item is not judged" 0 $'1. step\n\n   <delegation_format>\n   Follow: x\n\n   Source: [S]\n   Issue: [I]\n   </delegation_format>\n'
-shape "a quote directly under a paragraph is a boundary" 0 $'Para\n> q\n'
-shape "an HTML block is not judged" 0 $'<details>\n<summary>x</summary>\nwrapped\nlines\n</details>\n'
-shape "an HTML comment block is not judged" 0 $'<!--\nwrapped\nlines\n-->\n'
-shape "a heading directly under a one-line HTML comment passes (the render marker shape)" 0 $'<!-- kendex:project-instructions:start -->\n## Project Instructions\n\n<!-- kendex:shared-instructions:start -->\nOne line.\n<!-- kendex:shared-instructions:end -->\n<!-- kendex:project-instructions:end -->\n'
-shape "indented code after a blank line is not judged" 0 $'Para\n\n    code\n    more code\n'
-shape "front matter is skipped" 0 $'---\ntitle: x\nwrapped: y\n---\n\nPara\n'
-shape "a setext heading is a heading, not a wrap" 0 $'Heading\n=======\n\nPara\n\nSecond\n-------\n'
-shape "reference definitions stack without blank lines" 0 $'Para\n\n[a]: https://x\n[b]: https://y\n'
-shape "a thematic break is a boundary" 0 $'Para\n\n---\n\nPara\n'
-shape "a blockquote paragraph on one line passes" 0 $'> one line\n\n> another\n'
-shape "a `#hashtag` line is a paragraph, not a heading" 0 $'#tag one\n'
-shape "a file without a trailing newline passes" 0 $'Para'
+shape_rows \
+  "a nested list item is an item, not a continuation|- parent\n  - child\n    - grandchild\n- sibling\n|rc=0 $(clean 1)" \
+  "a multi-paragraph item after a blank line is a paragraph|- item\n\n  second paragraph of the item\n|rc=0 $(clean 1)" \
+  "fenced code keeps its lines, tilde and backtick alike|\`\`\`\nwrapped\ntext\n# not a heading\n\`\`\`\n\n~~~\nmore\nlines\n~~~\n|rc=0 $(clean 1)" \
+  "a longer fence closes only on a run at least as long|\`\`\`\`\n\`\`\`\ninner\n\`\`\`\n\`\`\`\`\n|rc=0 $(clean 1)" \
+  "a table is not judged|\174 a \174 b \174\n\174---\174---\174\n\174 c \174 d \174\n|rc=0 $(clean 1)" \
+  "a table directly under a paragraph is a boundary, not a wrap|Para\n\174 a \174 b \174\n\174---\174---\174\n|rc=0 $(clean 1)" \
+  "a table without outer pipes is a table|a \174 b\n:--\174--:\n1 \174 2\n|rc=0 $(clean 1)" \
+  "a table runs to the next blank line, so a row without a pipe is a row|\174 a \174\n\174---\174\nrow\n\nPara\n|rc=0 $(clean 1)" \
+  "a prompt-section block is not judged, blank lines included, to its closing tag|<output_format>\nwrapped\nlines\n\nSource: [S]\nIssue: [I]\n</output_format>\n|rc=0 $(clean 1)" \
+  "a prompt-section block indented under a list item is not judged|1. step\n\n   <delegation_format>\n   Follow: x\n\n   Source: [S]\n   Issue: [I]\n   </delegation_format>\n|rc=0 $(clean 1)" \
+  "a quote directly under a paragraph is a boundary|Para\n> q\n|rc=0 $(clean 1)" \
+  "an HTML block is not judged|<details>\n<summary>x</summary>\nwrapped\nlines\n</details>\n|rc=0 $(clean 1)" \
+  "an HTML comment block is not judged|<!--\nwrapped\nlines\n-->\n|rc=0 $(clean 1)" \
+  "a heading directly under a one-line HTML comment passes (the render marker shape)|<!-- kendex:project-instructions:start -->\n## Project Instructions\n\n<!-- kendex:shared-instructions:start -->\nOne line.\n<!-- kendex:shared-instructions:end -->\n<!-- kendex:project-instructions:end -->\n|rc=0 $(clean 1)" \
+  "indented code after a blank line is not judged|Para\n\n    code\n    more code\n|rc=0 $(clean 1)" \
+  "front matter is skipped|---\ntitle: x\nwrapped: y\n---\n\nPara\n|rc=0 $(clean 1)" \
+  "a setext heading is a heading, not a wrap|Heading\n=======\n\nPara\n\nSecond\n-------\n|rc=0 $(clean 1)" \
+  "reference definitions stack without blank lines|Para\n\n[a]: https://x\n[b]: https://y\n|rc=0 $(clean 1)" \
+  "a thematic break is a boundary|Para\n\n---\n\nPara\n|rc=0 $(clean 1)" \
+  "a blockquote paragraph on one line passes|> one line\n\n> another\n|rc=0 $(clean 1)" \
+  "a #hashtag line is a paragraph, not a heading|#tag one\n|rc=0 $(clean 1)" \
+  "a file without a trailing newline passes|Para|rc=0 $(clean 1)"
 
-echo "=== a construct with no end is a collection error, not a pass ==="
-shape "an unterminated fence is exit 2" 2 $'Para\n\n```\nnever closed\n'
-case "$OUT" in *"doc.md:3: an unterminated fence"*) ok "the refusal names the file and line" ;; *) bad "refusal names file and line" "$OUT" ;; esac
-shape "unterminated front matter is exit 2" 2 $'---\ntitle: x\n'
-shape "a prompt-section block with no closing tag is exit 2" 2 $'Para\n\n<output_format>\nprose\n\nmore\n'
-case "$OUT" in *"doc.md:3: a block with no closing </output_format>"*) ok "the refusal names the opener's line and tag" ;; *) bad "refusal names the opener" "$OUT" ;; esac
+echo "=== a construct with no end is a collection error naming the opener, not a pass ==="
+shape_rows \
+  "an unterminated fence is exit 2, naming the file and line|Para\n\n\`\`\`\nnever closed\n|rc=2 $(refused 3 'an unterminated fence')" \
+  "unterminated front matter is exit 2|---\ntitle: x\n|rc=2 $(refused 1 'unterminated front matter')" \
+  "a prompt-section block with no closing tag is exit 2, naming the opener's line and tag|Para\n\n<output_format>\nprose\n\nmore\n|rc=2 $(refused 3 'a block with no closing </output_format>')"
+
+# Table two: FIXTURE (a function and its words) builds the repository; the
+# judge runs with ARGS under ENVS.
+run_rows() { # label | fixture | envs | args | expect
+  local row label fx envs args expect words
+  for row in "$@"; do
+    IFS='|' read -r label fx envs args expect <<<"$row"
+    R=""
+    read -ra words <<<"$fx"
+    "${words[@]}"
+    assert_eq "$label" "$expect" "$(run "$envs" "$args")"
+  done
+}
 
 echo "=== scopes: --staged judges the files a commit touches, in full ==="
-new_repo scopes
-put clean.md $'Clean.\n'
-put wrapped.md $'Wrapped\ntext.\n'
-git -C "$R" commit -qm seed
-run_mdf --staged
-[ "$RC" -eq 0 ] && case "$OUT" in *"no staged markdown file(s) to judge"*) true ;; *) false ;; esac \
-  && ok "with nothing staged, --staged judges nothing and says so" || bad "--staged with nothing staged" "rc=$RC out=$OUT"
-printf 'Wrapped\ntext.\nMore.\n' >"$R/wrapped.md"
-git -C "$R" add wrapped.md
-run_mdf --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"wrapped.md:2:"*"wrapped.md:3:"*) true ;; *) false ;; esac \
-  && ok "a touched file is judged in full: the committed wrap on line 2 fails beside the new line 3" \
-  || bad "touched file judged in full" "rc=$RC out=$OUT"
-printf 'Wrapped text. More.\n' >"$R/wrapped.md"
-printf 'Wrapped\ntext.\n' >"$R/clean.md"
-git -C "$R" add wrapped.md
-run_mdf --staged
-[ "$RC" -eq 0 ] && case "$OUT" in *"1 staged markdown file(s) clean"*) true ;; *) false ;; esac \
-  && ok "control: the unstaged edit to clean.md is not judged, and the staged fix passes" \
-  || bad "control: unstaged edit not judged" "rc=$RC out=$OUT"
-git -C "$R" add clean.md
-run_mdf --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"clean.md:2:"*) true ;; *) false ;; esac \
-  && ok "once staged, the same edit fails" || bad "staged edit fails" "rc=$RC out=$OUT"
-git -C "$R" commit -qm fix
-
-echo "=== scopes: --all judges every tracked matching file ==="
-run_mdf --all
-[ "$RC" -eq 1 ] && case "$OUT" in *"clean.md:2:"*) true ;; *) false ;; esac \
-  && ok "--all reaches the committed file no commit is touching" || bad "--all reaches committed files" "rc=$RC out=$OUT"
-printf 'Clean.\n' >"$R/clean.md"
-git -C "$R" add clean.md && git -C "$R" commit -qm clean
-run_mdf --all
-[ "$RC" -eq 0 ] && case "$OUT" in *"2 tracked markdown file(s) clean"*) true ;; *) false ;; esac \
-  && ok "control: --all passes once every tracked file is clean, counting both" || bad "control: --all clean" "rc=$RC out=$OUT"
-
-echo "=== scopes: with neither flag, COMMIT_GUARDS_MD_SCOPE decides ==="
-run_mdf
-[ "$RC" -eq 0 ] && case "$OUT" in *"nothing staged to judge"*"COMMIT_GUARDS_MD_SCOPE=all"*) true ;; *) false ;; esac \
-  && ok "under the default touched scope with nothing staged, one line says so and how to widen" \
-  || bad "touched scope with nothing staged" "rc=$RC out=$OUT"
-printf 'Wrapped\nagain.\n' >"$R/clean.md"
-git -C "$R" add clean.md
-run_mdf
-[ "$RC" -eq 1 ] && case "$OUT" in *"1 staged markdown file(s)"*) true ;; *) false ;; esac \
-  && ok "under touched, a staged file is judged" || bad "touched judges the staged file" "rc=$RC out=$OUT"
-git -C "$R" checkout -q -- clean.md 2>/dev/null || true
-git -C "$R" reset -q --hard
-printf 'Wrapped\ntext.\n' >"$R/committed.md"
-git -C "$R" add committed.md && git -C "$R" commit -qm wrapped
-run_mdf
-[ "$RC" -eq 0 ] && ok "control: under touched, the committed wrap is out of scope" || bad "control: touched ignores committed files" "rc=$RC out=$OUT"
-OUT="$(cd "$R" && COMMIT_GUARDS_MD_SCOPE=all "$MDF" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 1 ] && case "$OUT" in *"committed.md:2:"*) true ;; *) false ;; esac \
-  && ok "COMMIT_GUARDS_MD_SCOPE=all is --all" || bad "scope=all is --all" "rc=$RC out=$OUT"
-printf '[env]\nCOMMIT_GUARDS_MD_SCOPE = "all"\n' >"$R/kendex.settings.toml"
-git -C "$R" add -A
-run_mdf
-[ "$RC" -eq 1 ] && case "$OUT" in *"committed.md:2:"*) true ;; *) false ;; esac \
-  && ok "the scope resolves from kendex.settings.toml [env]" || bad "scope from settings" "rc=$RC out=$OUT"
-rm "$R/kendex.settings.toml"
-git -C "$R" add -A
-OUT="$(cd "$R" && COMMIT_GUARDS_MD_SCOPE=sometimes "$MDF" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"must be 'touched' or 'all'"*) true ;; *) false ;; esac \
-  && ok "an unknown scope is exit 2" || bad "unknown scope is exit 2" "rc=$RC out=$OUT"
-run_mdf --staged --all
-[ "$RC" -eq 2 ] && ok "--staged with --all is exit 2" || bad "--staged with --all is exit 2" "rc=$RC out=$OUT"
+seeded() { repo "$1"; put clean.md 'Clean.\n'; put wrapped.md "$WRAPPED"; commit seed; } # NAME — a committed wrap, nothing staged
+fx_touched_full() { seeded touched-full; put wrapped.md 'Wrapped\ntext.\nMore.\n'; }
+fx_unstaged_edit() { seeded unstaged-edit; put wrapped.md 'Wrapped text. More.\n'; write clean.md "$WRAPPED"; }
+fx_staged_edit() { seeded staged-edit; put wrapped.md 'Wrapped text. More.\n'; put clean.md "$WRAPPED"; }
+fx_committed_wrap() { seeded committed-wrap; put wrapped.md 'Wrapped text. More.\n'; put clean.md "$WRAPPED"; commit fix; } # both committed, clean.md wrapped
+fx_all_clean() { seeded all-clean; put wrapped.md 'Wrapped text. More.\n'; commit fix; }
+fx_touched_staged() { seeded touched-staged; put clean.md 'Wrapped\nagain.\n'; }
+fx_deletion() { seeded deletion; git -C "$R" rm -q clean.md; }
+fx_settings_all() { seeded settings-all; put kendex.settings.toml '[env]\nCOMMIT_GUARDS_MD_SCOPE = "all"\n'; }
+run_rows \
+  "with nothing staged, --staged judges nothing and says so, naming the path list|seeded staged-nothing||--staged|rc=0 $(nomatch staged '*.md')" \
+  "a touched file is judged in full: the committed wrap on line 2 fails beside the new line 3|fx_touched_full||--staged|rc=1 $(viol wrapped.md 2 "$WRAP");$(viol wrapped.md 3 "$WRAP");$(failed 2 1 staged)" \
+  "control: the unstaged edit to clean.md is not judged, and the staged fix passes|fx_unstaged_edit||--staged|rc=0 $(clean 1 staged)" \
+  "once staged, the same edit fails, with both staged files counted|fx_staged_edit||--staged|rc=1 $(viol clean.md 2 "$WRAP");$(failed 1 2 staged)" \
+  "a staged deletion is no file to judge|fx_deletion||--staged|rc=0 $(nomatch staged '*.md')" \
+  "--all reaches the committed file no commit is touching|fx_committed_wrap||--all|rc=1 $(viol clean.md 2 "$WRAP");$(failed 1 2)" \
+  "control: --all passes once every tracked file is clean, counting both|fx_all_clean||--all|rc=0 $(clean 2)" \
+  "under the default touched scope with nothing staged, one line says so and how to widen|seeded touched-nothing|||rc=0 $NOTHING_STAGED" \
+  "under touched, a staged file is judged|fx_touched_staged|||rc=1 $(viol clean.md 2 "$WRAP");$(failed 1 1 staged)" \
+  "control: under touched, the committed wrap is out of scope|seeded touched-committed|||rc=0 $NOTHING_STAGED" \
+  "COMMIT_GUARDS_MD_SCOPE=all is --all|seeded env-all|COMMIT_GUARDS_MD_SCOPE=all||rc=1 $(viol wrapped.md 2 "$WRAP");$(failed 1 2)" \
+  "the scope resolves from kendex.settings.toml [env]|fx_settings_all|||rc=1 $(viol wrapped.md 2 "$WRAP");$(failed 1 2)" \
+  "an unknown scope is exit 2, quoting it|seeded scope-unknown|COMMIT_GUARDS_MD_SCOPE=sometimes||rc=2 ${ERR}COMMIT_GUARDS_MD_SCOPE must be 'touched' or 'all', got 'sometimes'" \
+  "--staged with --all is exit 2|seeded both-flags||--staged --all|rc=2 ${ERR}--staged and --all are exclusive"
 
 echo "=== the path list and the excludes list bound both scopes ==="
-new_repo paths
-put docs/wrapped.md $'Wrapped\ntext.\n'
-put vendor/wrapped.md $'Wrapped\ntext.\n'
-put notes.txt $'Wrapped\ntext.\n'
-run_mdf --all
-[ "$RC" -eq 1 ] && case "$OUT" in *"docs/wrapped.md:2:"*"vendor/wrapped.md:2:"*) true ;; *) false ;; esac \
-  && ok "control: the default *.md reaches both markdown files and not the .txt" || bad "control: default path list" "rc=$RC out=$OUT"
-case "$OUT" in *"notes.txt"*) bad "a non-markdown path is never judged" "$OUT" ;; *) ok "a non-markdown path is never judged" ;; esac
-OUT="$(cd "$R" && COMMIT_GUARDS_MD_PATHS='docs/*.md' "$MDF" --all 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 1 ] && case "$OUT" in *"vendor/wrapped.md"*) false ;; *"docs/wrapped.md:2:"*) true ;; *) false ;; esac \
-  && ok "COMMIT_GUARDS_MD_PATHS replaces the list" || bad "path list replaces" "rc=$RC out=$OUT"
-mkdir -p "$R/tools"
-printf 'vendor/*\tupstream docs, not ours\n' >"$R/tools/md-excludes"
-git -C "$R" add -A
-run_mdf --all
-[ "$RC" -eq 1 ] && case "$OUT" in *"vendor/wrapped.md"*) false ;; *"docs/wrapped.md:2:"*) true ;; *) false ;; esac \
-  && ok "tools/md-excludes drops the vendored tree from --all" || bad "excludes drop vendored tree" "rc=$RC out=$OUT"
-run_mdf --staged
-[ "$RC" -eq 1 ] && case "$OUT" in *"vendor/wrapped.md"*) false ;; *"docs/wrapped.md:2:"*) true ;; *) false ;; esac \
-  && ok "and from --staged" || bad "excludes drop vendored tree at commit" "rc=$RC out=$OUT"
-printf 'vendor/*\tupstream docs, not ours\n!vendor/wrapped.md\tours after all\n' >"$R/tools/md-excludes"
-git -C "$R" add -A
-run_mdf --all
-[ "$RC" -eq 1 ] && case "$OUT" in *"vendor/wrapped.md:2:"*) true ;; *) false ;; esac \
-  && ok "a ! row carves a path back in" || bad "carve-in" "rc=$RC out=$OUT"
-printf 'vendor/*\n' >"$R/tools/md-excludes"
-git -C "$R" add -A
-run_mdf --all
-[ "$RC" -eq 2 ] && case "$OUT" in *"pattern<TAB>reason"*) true ;; *) false ;; esac \
-  && ok "an exclusion without a reason is exit 2" || bad "reasonless exclusion is exit 2" "rc=$RC out=$OUT"
-OUT="$(cd "$R" && COMMIT_GUARDS_MD_PATHS=' ' "$MDF" --all 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"names no path"*) true ;; *) false ;; esac \
-  && ok "an empty path list is exit 2" || bad "empty path list is exit 2" "rc=$RC out=$OUT"
-run_mdf --no-such-flag
-[ "$RC" -eq 2 ] && ok "an unknown flag is exit 2" || bad "unknown flag is exit 2" "rc=$RC out=$OUT"
-run_mdf --help
-[ "$RC" -eq 0 ] && case "$OUT" in *"usage: md-format"*) true ;; *) false ;; esac \
-  && ok "--help prints usage at exit 0" || bad "--help prints usage" "rc=$RC out=$OUT"
+paths() { repo "$1"; put docs/wrapped.md "$WRAPPED"; put vendor/wrapped.md "$WRAPPED"; put notes.txt "$WRAPPED"; } # NAME — two wrapped markdown files and a .txt
+fx_excluded() { paths "$1"; put tools/md-excludes 'vendor/*\tupstream docs, not ours\n'; }
+fx_carved() { paths carved; put tools/md-excludes 'vendor/*\tupstream docs, not ours\n!vendor/wrapped.md\tours after all\n'; }
+fx_reasonless() { paths reasonless; put tools/md-excludes 'vendor/*\n'; }
+run_rows \
+  "control: the default *.md reaches both markdown files and never the .txt|paths default||--all|rc=1 $(viol docs/wrapped.md 2 "$WRAP");$(viol vendor/wrapped.md 2 "$WRAP");$(failed 2 2)" \
+  "COMMIT_GUARDS_MD_PATHS replaces the list|paths replaced|COMMIT_GUARDS_MD_PATHS=docs/*.md|--all|rc=1 $(viol docs/wrapped.md 2 "$WRAP");$(failed 1 1)" \
+  "tools/md-excludes drops the vendored tree from --all|fx_excluded excluded-all||--all|rc=1 $(viol docs/wrapped.md 2 "$WRAP");$(failed 1 1)" \
+  "and from --staged|fx_excluded excluded-staged||--staged|rc=1 $(viol docs/wrapped.md 2 "$WRAP");$(failed 1 1 staged)" \
+  "a ! row carves a path back in|fx_carved||--all|rc=1 $(viol docs/wrapped.md 2 "$WRAP");$(viol vendor/wrapped.md 2 "$WRAP");$(failed 2 2)" \
+  "an exclusion without a reason is exit 2, naming the row|fx_reasonless||--all|rc=2 ${ERR}tools/md-excludes:1: expected 'pattern<TAB>reason' (every exclusion carries its justification)" \
+  "an empty path list is exit 2|paths empty-list|COMMIT_GUARDS_MD_PATHS= |--all|rc=2 ${ERR}COMMIT_GUARDS_MD_PATHS names no path — name at least one, or drop this check from COMMIT_GUARDS_CHECKS" \
+  "an unknown flag is exit 2, quoting it|paths unknown-flag||--no-such-flag|rc=2 ${ERR}unknown argument '--no-such-flag' (see --help)"
+# The usage text carries a '|', which a row cannot: its first line and the
+# exit status, beside the table.
+assert_eq "--help prints usage at exit 0" "rc=0 usage: md-format [--staged | --all]" "$(run '' --help | sed -n 1p | LC_ALL=C cut -d';' -f1)"
 
 echo "=== a selected path that is not markdown is named, never counted clean ==="
-new_repo unmeasurable
-put notes/target.md $'Wrapped\ntext.\n'
-put docs/link.md $'Clean.\n'
-rm "$R/docs/link.md"
-ln -s ../notes/target.md "$R/docs/link.md"
-git -C "$R" add -A
-OUT="$(cd "$R" && COMMIT_GUARDS_MD_PATHS='docs/*.md' "$MDF" --all 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && case "$OUT" in *"not measured: docs/link.md"*"tracked as a symlink"*"1 matched path(s) not measured"*) true ;; *) false ;; esac \
-  && ok "a symlink at a selected path is named as unmeasured and counted apart" || bad "symlink named as unmeasured" "rc=$RC out=$OUT"
-case "$OUT" in *"markdown file(s) clean"*) bad "no clean count covers the unread link" "$OUT" ;; *) ok "no clean count covers the unread link" ;; esac
-OUT="$(cd "$R" && COMMIT_GUARDS_MD_PATHS='docs/*.md' "$MDF" --staged 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && case "$OUT" in *"not measured: docs/link.md"*) true ;; *) false ;; esac \
-  && ok "the staged scope names the same link" || bad "staged scope names the link" "rc=$RC out=$OUT"
-printf 'lead\000Wrapped\ntext.\n' >"$R/docs/bin.md"
-git -C "$R" add -A
-OUT="$(cd "$R" && COMMIT_GUARDS_MD_PATHS='docs/*.md' "$MDF" --all 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && case "$OUT" in *"not measured: docs/bin.md"*"binary content"*) true ;; *) false ;; esac \
-  && ok "a binary blob at a selected path is named as unmeasured" || bad "binary blob named" "rc=$RC out=$OUT"
+fx_symlink() { repo "$1"; put notes/target.md "$WRAPPED"; mkdir -p "$R/docs"; ln -s ../notes/target.md "$R/docs/link.md"; git -C "$R" add -A; }
+fx_symlink_and_binary() { fx_symlink symlink-binary; put docs/bin.md 'lead\0000Wrapped\ntext.\n'; }
+run_rows \
+  "a symlink at a selected path is named as unmeasured and counted apart, with no clean count|fx_symlink symlink-all|COMMIT_GUARDS_MD_PATHS=docs/*.md|--all|rc=0 $(skip docs/link.md 'tracked as a symlink, not markdown');$NONE$(unmeasured 1)" \
+  "the staged scope names the same link|fx_symlink symlink-staged|COMMIT_GUARDS_MD_PATHS=docs/*.md|--staged|rc=0 $(skip docs/link.md 'tracked as a symlink, not markdown');$NONE$(unmeasured 1)" \
+  "a binary blob at a selected path is named as unmeasured, in index order beside the link|fx_symlink_and_binary|COMMIT_GUARDS_MD_PATHS=docs/*.md|--all|rc=0 $(skip docs/bin.md 'binary content, not markdown');$(skip docs/link.md 'tracked as a symlink, not markdown');$NONE$(unmeasured 2)"
 
 echo "=== the skill's own shipped markdown is in the format ==="
-new_repo self
-mkdir -p "$R/skills/commit-guards"
-for doc in SKILL.md README.md CHECKS.md DEVELOPMENT.md; do
-  cp "$SKILL_DIR/$doc" "$R/skills/commit-guards/$doc"
-done
-git -C "$R" add -A
-run_mdf --all
-[ "$RC" -eq 0 ] && case "$OUT" in *"4 tracked markdown file(s) clean"*) true ;; *) false ;; esac \
-  && ok "SKILL.md, README.md, CHECKS.md and DEVELOPMENT.md pass" || bad "shipped docs pass" "rc=$RC out=$OUT"
-put skills/commit-guards/wrapped.md $'Wrapped\ntext.\n'
-run_mdf --all
-[ "$RC" -eq 1 ] && ok "control: a planted wrap beside them fails" || bad "control: planted wrap fails" "rc=$RC out=$OUT"
+fx_shipped() { # NAME — the four shipped documents
+  local doc
+  repo "$1"
+  mkdir -p "$R/skills/commit-guards"
+  for doc in SKILL.md README.md CHECKS.md DEVELOPMENT.md; do
+    cp "$SKILL_DIR/$doc" "$R/skills/commit-guards/$doc"
+  done
+  git -C "$R" add -A
+}
+fx_shipped_planted() { fx_shipped shipped-planted; put skills/commit-guards/wrapped.md "$WRAPPED"; }
+run_rows \
+  "SKILL.md, README.md, CHECKS.md and DEVELOPMENT.md pass|fx_shipped shipped||--all|rc=0 $(clean 4)" \
+  "control: a planted wrap beside them fails, counted with them|fx_shipped_planted||--all|rc=1 $(viol skills/commit-guards/wrapped.md 2 "$WRAP");$(failed 1 5)"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/commit-guards/tests/md-format.test.sh
+++ b/skills/commit-guards/tests/md-format.test.sh
@@ -121,6 +121,7 @@ shape_rows \
   "a trailing double space fails|Line one  \n\nLine two\n|rc=1 $(viol doc.md 1 'a trailing-double-space line break; join the lines instead');$(failed 1 1)" \
   "a trailing double space on a list item fails|- item  \n- next\n|rc=1 $(viol doc.md 1 'a trailing-double-space line break; join the lines instead');$(failed 1 1)" \
   "a hard wrap inside a blockquote fails|> quoted\n> continued\n|rc=1 $(viol doc.md 2 "$WRAP");$(failed 1 1)" \
+  "a #hashtag line is a paragraph, not a heading: the line under it is its wrap|#tag one\nwrapped\n|rc=1 $(viol doc.md 2 "$WRAP");$(failed 1 1)" \
   "a lazy continuation of a quoted paragraph fails|> quoted\ncontinued\n|rc=1 $(viol doc.md 2 "$WRAP");$(failed 1 1)" \
   "a CRLF line is the file's one violation: nothing past its first line is judged|Line one\r\nLine two\r\n|rc=1 $(viol doc.md 1 'a CRLF line ending; the format is LF, and the file is not judged past this line');$(failed 1 1)" \
   "two wraps are two violations, each on its own line|One\ntwo\n\nThree\nfour\n|rc=1 $(viol doc.md 2 "$WRAP");$(viol doc.md 5 "$WRAP");$(failed 2 1)"
@@ -147,7 +148,6 @@ shape_rows \
   "reference definitions stack without blank lines|Para\n\n[a]: https://x\n[b]: https://y\n|rc=0 $(clean 1)" \
   "a thematic break is a boundary|Para\n\n---\n\nPara\n|rc=0 $(clean 1)" \
   "a blockquote paragraph on one line passes|> one line\n\n> another\n|rc=0 $(clean 1)" \
-  "a #hashtag line is a paragraph, not a heading|#tag one\n|rc=0 $(clean 1)" \
   "a file without a trailing newline passes|Para|rc=0 $(clean 1)"
 
 echo "=== a construct with no end is a collection error naming the opener, not a pass ==="
@@ -177,6 +177,9 @@ fx_staged_edit() { seeded staged-edit; put wrapped.md 'Wrapped text. More.\n'; p
 fx_committed_wrap() { seeded committed-wrap; put wrapped.md 'Wrapped text. More.\n'; put clean.md "$WRAPPED"; commit fix; } # both committed, clean.md wrapped
 fx_all_clean() { seeded all-clean; put wrapped.md 'Wrapped text. More.\n'; commit fix; }
 fx_touched_staged() { seeded touched-staged; put clean.md 'Wrapped\nagain.\n'; }
+# The deletion row's verdict is the no-match line: a deletion that never
+# happened reads the same. What the row guards is the staged walk's
+# --diff-filter=AMT, which a D would turn into a read of a null sha.
 fx_deletion() { seeded deletion; git -C "$R" rm -q clean.md; }
 fx_settings_all() { seeded settings-all; put kendex.settings.toml '[env]\nCOMMIT_GUARDS_MD_SCOPE = "all"\n'; }
 run_rows \


### PR DESCRIPTION
Reshapes `skills/commit-guards/tests/md-format.test.sh` to code-quality § Tests. It pinned the format judge in a 272-line linear script of 85 assertions, each an exit status read as a bit beside the rule's opening words (`*"format: doc.md:2: a paragraph hard-wrapped over lines"*`), over two long-lived fixtures. It is now two tables. Table one (`shape_rows`): one shape as doc.md in a fresh repository, judged with `--all`; a pipe in the content is written as its octal escape `\174`, since the columns split on the pipe. Table two (`run_rows`): a fixture function builds the repository for the scopes, the path list, the excludes list and the unmeasured paths. A row runs the judge once and pins the exit status with every line printed, so each violation's file, line and whole rule text (the inline remedy clause included, which the old suite never read), the remedy line, the count and the scope are one pin. The expected lines are built by small functions from what the row put in (`viol PATH LINE RULE`, `clean N [SCOPE] [UNMEASURED]`, `failed`, `skip`, `nomatch`, `refused`).

Every former assertion has a row; none were deleted. Folded into the whole-output pin: "the verdict counts the file it read", "a CRLF file is not judged past its first line", "the remedy names md-reflow", the two refusal-names-the-line assertions, "a non-markdown path is never judged" and "no clean count covers the unread link". Added: a two-violation row (each wrap on its own line, counted), a trailing double space on a list-item line (the item branch's own check, which the old suite never reached), and a staged deletion (no file to judge); the last two were found by author mutants surviving the old cases. Beside the table: `--help` (its usage line carries a `|`). The scopes' "nothing staged" line, the no-match verdict naming the path list, the unknown-scope and reasonless-exclusion errors quoting their input, and the nothing-measurable verdict with its unmeasured count are pinned whole.

The tracked render is replayed with `patch`. A `kendex refresh` in the main checkout left `.kendex-generated.json` unchanged, so nothing is owed.

## Mutation

34 exact-substring mutants over `scripts/md-format`, `scripts/lib/md-blocks.awk`, `scripts/lib/md-scope.sh` and `scripts/lib/configured-paths.sh`, each run against the final suite in a scratch copy; 34 killed. Two of them (the item-line trailing-space check removed; a staged deletion walked) survived the old cases and drove the two added rows.

| mutant | result |
|---|---|
| wrap: a continuation line is not a violation | killed by "a hard-wrapped paragraph fails on the continuation line, with the remedy" |
| wrap: an item continuation is named as a paragraph wrap | killed by "a list item continued on the next line fails" |
| heading: no blank line needed after a heading | killed by "a heading not followed by a blank line fails" |
| fence: no blank line needed after a fence closer | killed by "a fence closer not followed by a blank line fails" |
| fence: a fence may sit directly under a paragraph | killed by "a fence directly under a paragraph fails" |
| heading: a heading may sit directly under a paragraph | killed by "one paragraph per line, blank-separated, passes, and the verdict counts the file" |
| list: a list may sit directly under a paragraph | killed by "a list directly under a paragraph fails" |
| trailing: a double space on an item line is not a break | killed by "a trailing double space on a list item fails" |
| trailing: a double space on a paragraph line is not a break | killed by "a trailing double space fails" |
| crlf: a CRLF line is not a violation in check mode | killed by "a CRLF line is the file's one violation: nothing past its first line is judged" |
| front: front matter is judged as prose | killed by "front matter is skipped" |
| code: indented code after a blank line is judged | killed by "indented code after a blank line is not judged" |
| table: a pipe paragraph over a delimiter row is not a table | killed by "a table without outer pipes is a table" |
| table: a delimiter row under any one-line paragraph is a table | killed by "control: a delimiter row under a line with no pipe is a wrap" |
| setext: an underline is a wrap | killed by "a setext heading is a heading, not a wrap" |
| html: a line opening with < is prose | killed by "control: an HTML element's block still ends at the blank line" |
| def: a reference definition is a paragraph line | killed by "reference definitions stack without blank lines" |
| end: an unterminated fence is a pass | killed by "an unterminated fence is exit 2, naming the file and line" |
| end: unterminated front matter is a pass | killed by "unterminated front matter is exit 2" |
| end: an unclosed prompt-section block is a pass | killed by "a prompt-section block with no closing tag is exit 2, naming the opener's line and tag" |
| verdict: violations exit 0 | killed by "a hard-wrapped paragraph fails on the continuation line, with the remedy" |
| verdict: the unmeasured count is dropped | killed by "a symlink at a selected path is named as unmeasured and counted apart, with no clean count" |
| verdict: a refusal record is read as a pass | killed by "an unterminated fence is exit 2, naming the file and line" |
| paths: every tracked file is markdown | killed by "with nothing staged, --staged judges nothing and says so, naming the path list" |
| usage: an unknown argument is ignored | killed by "an unknown flag is exit 2, quoting it" |
| scope: --staged and --all are not exclusive | killed by "--staged with --all is exit 2" |
| scope: an unknown COMMIT_GUARDS_MD_SCOPE is touched | killed by "an unknown scope is exit 2, quoting it" |
| scope: the setting all is touched | killed by "COMMIT_GUARDS_MD_SCOPE=all is --all" |
| excludes: a reasonless row is accepted | killed by "an exclusion without a reason is exit 2, naming the row" |
| excludes: a ! row excludes instead of carving | killed by "a ! row carves a path back in" |
| excludes: exclusions are ignored | killed by "tools/md-excludes drops the vendored tree from --all" |
| walk: a symlink is read as markdown | killed by "a symlink at a selected path is named as unmeasured and counted apart, with no clean count" |
| walk: a binary blob is judged | killed by "a binary blob at a selected path is named as unmeasured, in index order beside the link" |
| staged: a deleted path is judged too | killed by "a staged deletion is no file to judge" |

14 fixture mutants (one fixture's planted drift removed, the named row must fail): 14 killed.

| fixture mutant | result |
|---|---|
| F1 touched-full: the third line not added | killed by "a touched file is judged in full: the committed wrap on line 2 fails beside the new line 3" |
| F2 unstaged-edit: clean.md edit staged after all | killed by "control: the unstaged edit to clean.md is not judged, and the staged fix passes" |
| F3 staged-edit: clean.md left clean | killed by "once staged, the same edit fails, with both staged files counted" |
| F4 committed-wrap: the wrap not committed | killed by "--all reaches the committed file no commit is touching" |
| F5 all-clean: wrapped.md left wrapped | killed by "control: --all passes once every tracked file is clean, counting both" |
| F6 touched-staged: nothing staged | killed by "under touched, a staged file is judged" |
| F7 settings-all: the settings file not written | killed by "the scope resolves from kendex.settings.toml [env]" |
| F8 excluded: no exclusion written | killed by "tools/md-excludes drops the vendored tree from --all" |
| F9 carved: no carve-in row | killed by "a ! row carves a path back in" |
| F10 reasonless: a reason given | killed by "an exclusion without a reason is exit 2, naming the row" |
| F11 symlink: a real file instead | killed by "a symlink at a selected path is named as unmeasured and counted apart, with no clean count" |
| F12 symlink-binary: no NUL planted | killed by "a binary blob at a selected path is named as unmeasured, in index order beside the link" |
| F13 shipped-planted: nothing planted | killed by "control: a planted wrap beside them fails, counted with them" |
| F14 paths: the .txt made markdown | killed by "control: the default *.md reaches both markdown files and never the .txt" |

## Checks

- `md-format.test.sh`: 81 assertions pass on this host and under a symlinked TMPDIR. All 38 commit-guards suites pass in the worktree (`suites failing: 0`). `tools/bash32-lint` clean.
- `tools/guard --full`: exit 0 with `TMPDIR=/tmp` on both commits (under the agent scratch `TMPDIR` one pre-existing Rust CLI test fails on main too; recorded in KEN-1241, not this PR's).
- One reviewer-test round: accept, no blockers; every one of the reviewer's 12 surviving production mutants also survives the old suite, so no coverage was lost. Two suggestions taken in the second commit: the hashtag row now has a line under it so it pins `is_atx` (a lone end-of-file paragraph emitted nothing under either reading), and the staged-deletion row carries a comment naming the `--diff-filter=AMT` clause it guards, since its verdict reads the same without the deletion. Recorded, not chased: eight pre-existing grammar surfaces no markdown suite reaches (`is_thematic` as a boundary and its underscore arm, `is_delim_row` without a pipe, seven-hash `is_atx`, the closing-tag arm of `is_lone_tag`, `lead_cols` tab stops, the list-indent stack never popping, `list_push` storing the wrong indent, the lone-tag branch's paragraph guard). A note for CI images: the whole-output pin folds stderr in, so a missing locale fails every row on bash's warning rather than one.

KEN-1241

https://claude.ai/code/session_0178hScanMtjD7MsEhUGNayE
