### PR TITLE
test(KEN-1241): the terminal-paths suite as two tables of rows

### DIFF
--- a/.agents/skills/commit-guards/DEVELOPMENT.md
+++ b/.agents/skills/commit-guards/DEVELOPMENT.md
@@ -87,7 +87,7 @@ The row format, the `!` carve and the `\!` escape are stated in `SKILL.md § Con
 
 ## Probing a terminal-only code path
 
-A headless suite cannot reach a branch that exists only at a tty (`mv` prompts before replacing a write-denied destination only there). `gg_pty_run CAP SCRIPT_FILE` in `tests/lib/pty.bash` runs a bash script with fds 0, 1 and 2 on a pseudo-terminal, picking the `script` grammar from `uname`; a host whose `script` answers neither form is a red naming the spawner, not a skip. Its states are enumerated above the function and nowhere else. `tests/terminal-paths.test.sh` is the worked example; its `pty_call` is the wrapper a new case copies.
+A headless suite cannot reach a branch that exists only at a tty (`mv` prompts before replacing a write-denied destination only there). `gg_pty_run CAP SCRIPT_FILE` in `tests/lib/pty.bash` runs a bash script with fds 0, 1 and 2 on a pseudo-terminal, picking the `script` grammar from `uname`; a host whose `script` answers neither form is a red naming the spawner, not a skip. Its states are enumerated above the function and nowhere else. `tests/terminal-paths.test.sh` is the worked example; its `pty_line` runs one session body and `install_line` is the wrapper an install case copies.
 
 - Stdin is `/dev/null`, so a prompt is answered by EOF.
 - A time cap on both sides: after `CAP` seconds the caller kills the session's process group, then the spawner's; the session holds the same deadline over itself a few seconds later.

--- a/.agents/skills/commit-guards/tests/prose.test.sh
+++ b/.agents/skills/commit-guards/tests/prose.test.sh
@@ -103,7 +103,7 @@ line_rows \
   "control: a reference followed by punctuation or a space still fails, one hit per line|Landed in #1204) and #228, per #999.|rc=1 $(hit SKILL.md 1 'Landed in #1204) and #228, per #999.');$(failed 1 1)" \
   "a reference ending its line still fails|Landed in #1204|rc=1 $(hit SKILL.md 1 'Landed in #1204');$(failed 1 1)" \
   "ordinary wording passes: a bare year and a year-month|The 2026 roadmap and the 2026-08 window.|rc=0 $(clean 1)" \
-  "an ATX heading whose text is a number is not an issue reference|#### 1204 items|rc=0 $(clean 1)" \
+  "an ATX heading whose text is a number, to the end of the line, is not an issue reference|#### 1204|rc=0 $(clean 1)" \
   "a decision ID, a code-span D042 § Context and a four-digit ID all pass|Decided in D042; the reason is in \`D042 § Context\`, and D1234 is the same kind.|rc=0 $(clean 1)" \
   "control: the same digits after '#' are still an issue reference|Decided in #042.|rc=1 $(hit SKILL.md 1 'Decided in #042.');$(failed 1 1)" \
   "two hits on two lines are two lines and one count each|First 2026-08-12.\nSecond #228.|rc=1 $(hit SKILL.md 1 'First 2026-08-12.');$(hit SKILL.md 2 'Second #228.');$(failed 2 1)"

--- a/.agents/skills/commit-guards/tests/terminal-paths.test.sh
+++ b/.agents/skills/commit-guards/tests/terminal-paths.test.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 # Pins for the code paths that only exist AT A TERMINAL. The runners invoke
 # every other suite headless, where `mv` never prompts and plain `mv` measures
-# exactly as `mv -f` does — which is how a prompting install shipped green.
-# Each case here runs under a pseudo-terminal. What a call sets is in
-# lib/pty.bash; the rules such a probe follows, and why, are in
-# ../DEVELOPMENT.md § Probing a terminal-only code path.
+# exactly as `mv -f` does, which is how a prompting install shipped green.
+# Every case here runs under a pseudo-terminal through lib/pty.bash; the rules
+# such a probe follows, and why, are in
+# ../DEVELOPMENT.md § Probing a terminal-only code path. Two tables: the
+# probe itself (a session body run at the cap, pinned by its state, status
+# and output), and gg_install_file at a terminal (a lib tree, a source and a
+# read-only destination, pinned by the session's line and what the
+# destination holds after). The abandonment pair beside them needs a runner
+# killed mid-session, so it stays scripted.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -14,224 +19,209 @@ TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$TEST_DIR/lib/pty.bash"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 LIB="$SKILL_DIR/scripts/lib"
-# gg_install_file lives in atomic-install.sh, which needs common.sh sourced
-# first; a session below therefore takes the lib DIRECTORY and sources both.
-INSTALL="$LIB/atomic-install.sh"
 ROOT="$TMP"
 
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
 filemode() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"; }
 
-R="$ROOT/install-file"
-mkdir -p "$R/tools"
+# One line for a session: its state, its own status and every line it
+# printed joined by ';', or `unstarted` with the reason no session ran.
+# ENVS is a comma-separated list of assignments exported for the run only;
+# mktemp's own words are normalised, GNU and BSD phrase them apart. The
+# probe's own stdin holds a line: a spawner that forwarded it instead of
+# reading /dev/null would hand it to the session's prompt.
+pty_line() { # CAP CASE_FILE ENVS
+  local envs=()
+  [ -z "$3" ] || IFS=',' read -ra envs <<<"$3"
+  (
+    [ "${#envs[@]}" -eq 0 ] || export "${envs[@]}"
+    if gg_pty_run "$1" "$2"; then
+      printf 'state=%s rc=%s out=%s' "$GG_PTY_STATE" "$GG_PTY_RC" "$(printf '%s\n' "$GG_PTY_OUT" | LC_ALL=C paste -sd ';' -)"
+    else
+      printf 'unstarted err=%s' "$(printf '%s' "$GG_PTY_ERR" | sed 's/mktemp: .*/mktemp: <its words>/')"
+    fi
+  ) <<<"TYPED AT THE SUITE"
+}
 
-# atomic-install.test.sh's `install_line`, with the session's fds on a pty. LIB is a
-# parameter so a mutant copy of the tree can be run through the same probe.
-#
-# SRC is a parameter for a different reason: every path this helper writes
-# goes through %q, and a caller splicing one into the SNIPPET instead would
-# put it into a shell script body as syntax. $ROOT descends from TMPDIR,
-# which the caller owns, so a directory named with a command substitution
-# ran. No call site interpolates a path into its snippet — it names $SRC and
-# lets this function quote it, so a later case cannot bring the shape back.
-#
-# %q is the right quoting HERE, where pty.bash's spawn string cannot use it:
-# this file is run by `bash`, which is the shell %q quotes for, so the
-# ANSI-C form it emits for a control byte is a form its reader parses.
-#
-# What the session refuses to measure, each with a status of its own, so a
-# case that never reached the code under test cannot satisfy a negative
-# assertion about it:
-#   3  the session's stdin is not a terminal
-#   4  the destination is writable, so `mv` has nothing to prompt about
-#      (which is every run at euid 0, where mode 0444 is not enforced, and
-#      which premise_denies_write also refuses from the suite side before a
-#      session is started at all)
-# The REACHED marker is the separate positive half: it carries no status, and
-# it is the evidence that the call under test was entered.
-pty_call() { # LIB SRC SNIPPET
-  # The case file goes BESIDE the source, not in $ROOT: gg_pty_run writes it
-  # into the session as `bash %q`, so siting it under a hostile SRC is what
-  # drives that line's quoting too. Everything else about it is unchanged —
-  # $ROOT/tty.tsv puts it back where it always was.
-  # Two statements, not one `local`: a builtin's arguments are all expanded
-  # before any of its assignments take effect, so case_file cannot read src
-  # on the same line.
-  local lib="$1" src="$2" snippet="$3" case_file
-  case_file="${src%/*}/pty-case.sh"
+# State functions a row names: their tokens are appended after ' / '.
+child() { # the process the session recorded in GG_T_PIDFILE: gone, alive, or never recorded
+  local pid
+  pid="$(cat "$GG_T_PIDFILE" 2>/dev/null || true)"
+  if [ -z "$pid" ]; then printf 'child=unrecorded'
+  elif kill -0 "$pid" 2>/dev/null; then printf 'child=alive'
+  else printf 'child=gone'
+  fi
+}
+# On a healthy run the caller's cap fires first, so the session's own
+# watchdog leaves no marker beside the body: that absence says which kill it was.
+capped() { child; [ -f "$GG_T_BODY.watchdog" ] && printf ' watchdog=fired' || printf ' watchdog=none'; }
+unpwned() { [ -e "$ROOT/PWNED" ] && printf 'pwned=yes' || printf 'pwned=no'; }
+
+# A `script` that answers neither grammar, first on PATH for one row.
+mkdir -p "$ROOT/noscript"
+printf '#!/bin/sh\necho "script: not this grammar"\nexit 1\n' >"$ROOT/noscript/script"
+chmod +x "$ROOT/noscript/script"
+
+# Table one: BODY is the session, written through printf %b (a pipe is
+# \174); the row's pid file reaches it as GG_T_PIDFILE.
+ROW=0
+pty_rows() { # label | cap | envs | body | state | expect
+  local row label cap envs body state expect actual
+  for row in "$@"; do
+    IFS='|' read -r label cap envs body state expect <<<"$row"
+    ROW=$((ROW + 1))
+    export GG_T_PIDFILE="$ROOT/pty-$ROW.pid"
+    GG_T_BODY="$ROOT/pty-$ROW.sh"
+    printf '%b' "$body" >"$GG_T_BODY"
+    actual="$(pty_line "$cap" "$GG_T_BODY" "$envs")"
+    [ -z "$state" ] || actual="$actual / $($state)"
+    assert_eq "$label" "$expect" "$actual"
+  done
+}
+
+echo "=== gg_pty_run: the probe rules the install cases depend on ==="
+pty_rows \
+  'stdin, stdout and stderr are all on the pty|20||[ -t 0 ] && [ -t 1 ] && [ -t 2 ] && echo ALL-THREE\n||state=ok rc=0 out=ALL-THREE' \
+  'a read from the terminal gets EOF instead of waiting: the spawner reads /dev/null|20||read -r answer </dev/tty && echo "READ $answer" \174\174 echo EOF-AT-THE-PROMPT\n||state=ok rc=0 out=EOF-AT-THE-PROMPT' \
+  'control: a session that never returns is capped by the caller with its output kept, and the child it started is reaped|2||trap "" HUP\necho STARTED\nsleep 300 &\necho "$!" >"$GG_T_PIDFILE"\nwait\n|capped|state=capped rc= out=STARTED / child=gone watchdog=none' \
+  "control: a session's own exit status survives the spawner|20||exit 7\n||state=ok rc=7 out=" \
+  'control: a session that dies before its last line is gone and reports no status|20||echo ABOUT-TO-DIE\nkill -9 "$PPID"\nsleep 5\n||state=gone rc= out=ABOUT-TO-DIE' \
+  "a script answering neither grammar is no session, named with what it said|20|PATH=$ROOT/noscript:$PATH|echo NEVER\n||unstarted err=no working pty spawner: script started no session. It said: script: not this grammar" \
+  "a scratch root that cannot be made is no session, naming TMPDIR|20|TMPDIR=$ROOT/absent|echo NEVER\n||unstarted err=could not create a scratch directory under TMPDIR ($ROOT/absent): mktemp: <its words>"
+
+# Table two: gg_install_file at a terminal. A fixture sets the lib tree the
+# session sources (LIBD), the source (SRC), the read-only destination under
+# R, and the TMPDIR the probe runs under (PTY_TMP). The case file goes BESIDE
+# the source: gg_pty_run runs it as `bash %q`, so a hostile SRC drives that
+# line's quoting too. The session refuses its own premise with a status of
+# its own (3: no terminal; 4: the destination is writable, which is every
+# run at euid 0) and prints REACHED with the source it was handed before
+# the call, so a negative pin cannot be met by a case that never entered the
+# code under test, and the name that reached it is the one the fixture chose.
+install_line() { # LIBD SRC PTY_TMP
+  local case_file="${2%/*}/pty-case.sh" line
   {
     printf 'set -euo pipefail\n'
     printf 'cd %q\n' "$R"
     printf 'GG_CHECK=probe\n'
-    # The session speaks C, because a case below matches mv's own prompt and
-    # coreutils translates it — 46 catalogs on a stock host, fr, de and es
-    # among those carrying `overriding mode`. The environment reaches the
-    # session through `script`, so a contributor whose shell has a localized
-    # message locale would red a healthy tree. common.sh forces LC_ALL=C on
-    # every grep whose match depends on tool wording, for this reason.
+    # C, because a row matches mv's own prompt and coreutils translates it.
     printf 'export LC_ALL=C\n'
     printf '[ -t 0 ] || { echo NOT-A-TERMINAL; exit 3; }\n'
     printf '[ ! -w tools/dest.tsv ] || { echo DESTINATION-IS-WRITABLE; exit 4; }\n'
-    printf 'SRC=%q\n' "$src"
-    printf '. %q\n' "$lib/common.sh"
-    printf '. %q\n' "$lib/atomic-install.sh"
-    printf 'echo REACHED\n'
-    printf '%s\n' "$snippet"
+    printf 'SRC=%q\n' "$2"
+    printf '. %q\n' "$1/common.sh"
+    printf '. %q\n' "$1/atomic-install.sh"
+    printf 'echo "REACHED $SRC"\n'
+    printf 'gg_tmpdir; gg_install_file "$SRC" tools/dest.tsv "the fixture"\n'
   } >"$case_file"
-  OUT=""
-  RC=""
-  STATE=""
-  if ! gg_pty_run 20 "$case_file"; then
-    STATE=unstarted
-    OUT="$GG_PTY_ERR"
-    return 0
-  fi
-  STATE="$GG_PTY_STATE"
-  OUT="$GG_PTY_OUT"
-  RC="$GG_PTY_RC"
+  line="$(pty_line 20 "$case_file" "TMPDIR=$3")"
+  printf '%s / dest=%s mode=%s staged=%s' "$line" "$(cat "$R/tools/dest.tsv")" "$(filemode "$R/tools/dest.tsv")" \
+    "$(find "$R/tools" -name '*gg-install*' | wc -l | tr -d ' ')"
 }
-
-# A case whose premise is a permission denial measures nothing where the
-# denial is not enforced: at euid 0 neither 0444 nor 0500 stops anything. One
-# helper for every such case, so a later one gets the refusal by construction
-# rather than by its author remembering — and so the report names euid 0
-# instead of accusing the code under test of a fault that is not there.
-premise_denies_write() { # PATH CASE_NAME — 0 when the denial really holds here
-  [ ! -w "$1" ] && return 0
-  bad "$2" "premise unmet: $1 is writable to this process (euid $(id -u)), so a permission denial is not enforced and this case cannot measure its branch"
-  return 1
-}
-
-reset_dest() { # CONTENT — a read-only destination carrying CONTENT
-  chmod 644 "$R/tools/dest.tsv" 2>/dev/null || true
-  printf '%s\n' "$1" >"$R/tools/dest.tsv"
+# A read-only destination under R carrying CONTENT. The denial is the premise
+# of every row: where it is not enforced the suite measures nothing, and says
+# so once here rather than accusing the code under test.
+dest() { # NAME CONTENT
+  R="$ROOT/$1"
+  mkdir -p "$R/tools"
+  printf '%s\n' "$2" >"$R/tools/dest.tsv"
   chmod 444 "$R/tools/dest.tsv"
+  [ ! -w "$R/tools/dest.tsv" ] || { echo "harness: $R/tools/dest.tsv is writable to euid $(id -u); a permission denial is not enforced here and the terminal cases cannot measure their branch" >&2; exit 2; }
+}
+fx_real() { dest real ORIGINAL; SRC="$ROOT/real-src.tsv"; printf 'REPLACED AT A TERMINAL\n' >"$SRC"; LIBD="$LIB"; PTY_TMP="$TMPDIR"; }
+# The must-fail control: the same probe against a copy of the helper with the
+# `-f` taken back out. The WHOLE lib tree is copied: common.sh bootstraps its
+# neighbours off its own directory, so a mutant sited elsewhere dies at its
+# first source line, before gg_install_file exists.
+fx_no_f() {
+  dest no-f 'NOT REPLACED'
+  SRC="$ROOT/no-f-src.tsv"
+  printf 'REPLACED AT A TERMINAL\n' >"$SRC"
+  cp -R "$LIB" "$ROOT/lib-no-f"
+  sed 's/mv -f -- /mv -- /' "$LIB/atomic-install.sh" >"$ROOT/lib-no-f/atomic-install.sh"
+  LIBD="$ROOT/lib-no-f"
+  PTY_TMP="$TMPDIR"
+}
+# A scratch root and a source whose NAMES are a space and a command
+# substitution: pty.bash hands the spawner a constant command and passes its
+# paths in the environment, so what this drives is the case body install_line
+# writes, which bash reads. Unquoted there, the substitution runs.
+HOSTILE="$ROOT/a q\$(touch $ROOT/PWNED)x dir"
+fx_hostile() {
+  dest hostile ORIGINAL
+  mkdir -p "$HOSTILE"
+  SRC="$HOSTILE/src.tsv"
+  printf 'FROM A HOSTILE PATH\n' >"$SRC"
+  cp -R "$LIB" "$HOSTILE/lib"
+  rm -f "$ROOT/PWNED"
+  LIBD="$HOSTILE/lib"
+  PTY_TMP="$HOSTILE"
+}
+# Where mv reports the decline, the decline's own words are the evidence:
+# GNU mv prompts, reads EOF, exits 1, and gg_install_why folds the prompt
+# into the refusal. BSD mv answers its prompt's EOF as no and exits 0, so the
+# helper reads a success, leaves the destination alone and its staging file
+# beside it, which is the leak the `-f` closes there. Keyed on uname, the
+# way pty.bash selects its grammar.
+case "$(uname -s)" in
+  Darwin) NO_F="state=ok rc=0 out=REACHED $ROOT/no-f-src.tsv / dest=NOT REPLACED mode=444 staged=1" ;;
+  *) NO_F="state=ok rc=2 out=REACHED $ROOT/no-f-src.tsv;::error::probe: could not replace the fixture at tools/dest.tsv (mv: replace 'tools/dest.tsv', overriding mode 0444 (r--r--r--)? ) — inspect the file before trusting it / dest=NOT REPLACED mode=444 staged=0" ;;
+esac
+install_rows() { # label | fixture | state | expect
+  local row label fx state expect actual
+  for row in "$@"; do
+    IFS='|' read -r label fx state expect <<<"$row"
+    R=""
+    "$fx"
+    actual="$(install_line "$LIBD" "$SRC" "$PTY_TMP")"
+    [ -z "$state" ] || actual="$actual / $($state)"
+    assert_eq "$label" "$expect" "$actual"
+  done
 }
 
 echo "=== gg_install_file: a read-only destination is replaced at a terminal too ==="
+install_rows \
+  "the install lands, and the destination keeps its mode|fx_real||state=ok rc=0 out=REACHED $ROOT/real-src.tsv / dest=REPLACED AT A TERMINAL mode=444 staged=0" \
+  "control: without the -f the same probe leaves the destination unreplaced, the refusal carrying mv's own prompt|fx_no_f||$NO_F" \
+  "control: a path that is a space and a command substitution stays a path, and nothing inside it runs|fx_hostile|unpwned|state=ok rc=0 out=REACHED $ROOT/a q\$(touch $ROOT/PWNED)x dir/src.tsv / dest=FROM A HOSTILE PATH mode=444 staged=0 / pwned=no"
 
-SRC_TTY="$ROOT/tty.tsv"
-printf 'REPLACED AT A TERMINAL\n' >"$SRC_TTY"
-reset_dest ORIGINAL
-if premise_denies_write "$R/tools/dest.tsv" "the install lands, and the destination keeps its mode"; then
-  pty_call "$LIB" "$SRC_TTY" 'gg_tmpdir; gg_install_file "$SRC" tools/dest.tsv "the fixture"'
-  [ "$STATE" = ok ] && [ "$RC" -eq 0 ] && [ "$(cat "$R/tools/dest.tsv")" = "REPLACED AT A TERMINAL" ] \
-    && [ "$(filemode "$R/tools/dest.tsv")" = 444 ] \
-    && ok "the install lands, and the destination keeps its mode" \
-    || bad "the install lands, and the destination keeps its mode" "state=$STATE rc=$RC mode=$(filemode "$R/tools/dest.tsv") out=$OUT"
-fi
-
-# The control that makes the case above a measurement rather than a
-# coincidence: the same probe against a copy of the helper with the `-f` taken
-# back out. Every headless assertion over this helper still passes against it.
-#
-# The WHOLE lib tree is copied, not atomic-install.sh alone: it needs
-# common.sh sourced first, and common.sh bootstraps paths.sh and
-# configured-paths.sh off its own directory, so a mutant sited anywhere else
-# dies at its first source line — before gg_install_file exists, and while
-# still satisfying a control that only asks for an unreplaced destination.
-cp -R "$LIB" "$ROOT/lib-no-f"
-sed 's/mv -f -- /mv -- /' "$INSTALL" >"$ROOT/lib-no-f/atomic-install.sh"
-cmp -s "$INSTALL" "$ROOT/lib-no-f/atomic-install.sh" \
-  && bad "control: the mutant really drops the -f" "the copy is byte-identical to atomic-install.sh" \
-  || ok "control: the mutant really drops the -f"
-
-reset_dest "NOT REPLACED"
-if premise_denies_write "$R/tools/dest.tsv" "control: without the -f the same probe leaves the destination unreplaced"; then
-  pty_call "$ROOT/lib-no-f" "$SRC_TTY" 'gg_tmpdir; gg_install_file "$SRC" tools/dest.tsv "the fixture"'
-  # The session must have REACHED the call and finished on its own, and its
-  # status must be one gg_install_file itself produces: 0, or the 2 of a
-  # collection error. A session that refused its premise (3, 4), was capped,
-  # or died is a probe failure, and an unreplaced destination is what all of
-  # those leave behind too.
-  case "$OUT" in *REACHED*) reached=yes ;; *) reached=no ;; esac
-  [ "$STATE" = ok ] && [ "$reached" = yes ] && { [ "$RC" -eq 0 ] || [ "$RC" -eq 2 ]; } \
-    && [ "$(cat "$R/tools/dest.tsv")" = "NOT REPLACED" ] \
-    && [ "$(filemode "$R/tools/dest.tsv")" = 444 ] \
-    && ok "control: without the -f the same probe leaves the destination unreplaced" \
-    || bad "control: without the -f the same probe leaves the destination unreplaced" "state=$STATE reached=$reached rc=$RC content=$(cat "$R/tools/dest.tsv") out=$OUT"
-
-  # Where mv reports the decline, the decline's own words are the evidence.
-  # `could not replace the fixture` alone is gg_collection_error's frame,
-  # which it prints whether or not gg_install_why relayed anything — so the
-  # match reaches for mv's prompt too, which is the half this case is named
-  # for. GNU mv exits 1 and gg_install_why folds that prompt in; BSD mv
-  # answers no with exit 0 and nothing to relay, so there is no refusal to
-  # read there and this half of the claim is not available. Keyed on uname,
-  # the same way the grammar is chosen.
-  if [ "$(uname -s)" != Darwin ]; then
-    [ "$STATE" = ok ] && [ "$RC" -eq 2 ] && case "$OUT" in
-      *"could not replace the fixture"*"overriding mode"*) true ;;
-      *) false ;;
-    esac \
-      && ok "control: and the refusal carries mv's own prompt as its cause" \
-      || bad "control: and the refusal carries mv's own prompt as its cause" "state=$STATE rc=$RC out=$OUT"
-  fi
-fi
-
-echo "=== gg_pty_run: the probe rules the cases above depend on ==="
-
-# The session's fds really are a terminal — the premise every case here rests
-# on, asserted rather than assumed.
-printf '[ -t 0 ] && [ -t 1 ] && [ -t 2 ] && echo ALL-THREE\n' >"$ROOT/tty-case.sh"
-gg_pty_run 20 "$ROOT/tty-case.sh" && [ "$GG_PTY_STATE" = ok ] && [ "$GG_PTY_RC" -eq 0 ] \
-  && [ "$GG_PTY_OUT" = "ALL-THREE" ] \
-  && ok "stdin, stdout and stderr are all on the pty" \
-  || bad "stdin, stdout and stderr are all on the pty" "state=$GG_PTY_STATE rc=$GG_PTY_RC out=$GG_PTY_OUT err=$GG_PTY_ERR"
-
-# A prompt inside the session is answered by EOF, because the SPAWNER reads
-# /dev/null. Without that redirect this read is the wedge, not a result.
-printf 'read -r answer </dev/tty && echo "READ $answer" || echo EOF-AT-THE-PROMPT\n' >"$ROOT/prompt-case.sh"
-gg_pty_run 20 "$ROOT/prompt-case.sh" && [ "$GG_PTY_OUT" = "EOF-AT-THE-PROMPT" ] \
-  && ok "a read from the terminal gets EOF instead of waiting" \
-  || bad "a read from the terminal gets EOF instead of waiting" "state=$GG_PTY_STATE out=$GG_PTY_OUT err=$GG_PTY_ERR"
-
-# The cap, and what it must leave behind: nothing. The body ignores SIGHUP, so
-# the pty closing behind the killed spawner cannot stand in for the reap, and
-# it records the pid of the process that must be gone. Killing the spawner
-# alone leaves that pid alive while the caller is told the cap worked.
-printf 'trap "" HUP\necho STARTED\nsleep 300 &\necho "$!" >%q\nwait\n' "$ROOT/orphan.pid" >"$ROOT/hang-case.sh"
-rm -f "$ROOT/orphan.pid"
-gg_pty_run 2 "$ROOT/hang-case.sh" && [ "$GG_PTY_STATE" = capped ] && [ -z "$GG_PTY_RC" ] \
-  && [ "$GG_PTY_OUT" = "STARTED" ] \
-  && ok "control: a session that never returns is capped, reported, and its output kept" \
-  || bad "control: a session that never returns is capped, reported, and its output kept" "state=$GG_PTY_STATE rc=$GG_PTY_RC out=$GG_PTY_OUT err=$GG_PTY_ERR"
-orphan="$(cat "$ROOT/orphan.pid" 2>/dev/null || true)"
-[ -n "$orphan" ] \
-  && ok "control: the capped session really did start the child the reap must take" \
-  || bad "control: the capped session really did start the child the reap must take" "no pid recorded; state=$GG_PTY_STATE err=$GG_PTY_ERR out=$GG_PTY_OUT"
-[ -n "$orphan" ] && ! kill -0 "$orphan" 2>/dev/null \
-  && ok "control: and the cap left no process of it behind" \
-  || bad "control: and the cap left no process of it behind" "pid $orphan is still running; state=$GG_PTY_STATE err=$GG_PTY_ERR"
-
-# A suite killed mid-run takes the poll loop above with it, and `script` has
-# already setsid'd the session out of every group that killer could name, so the
-# cap on this side stops existing. What is left is the deadline the session
-# holds over itself. The body traps TERM away, so nothing short of
-# the SIGKILL that deadline sends can end it.
+echo "=== an abandoned session ends itself ==="
+# A suite killed mid-run takes the poll loop with it, and `script` has
+# already setsid'd the session out of every group that killer could name, so
+# the cap on this side stops existing. What is left is the deadline the
+# session holds over itself. The body traps HUP and TERM away, so nothing
+# short of the SIGKILL that deadline sends can end it, and the marker beside
+# the body is written by that watchdog alone: a dead child is also what a
+# collapsing spawner leaves, so the marker is what says WHICH kill fired. The
+# in-session kill runs under /bin/sh, dash on the CI runner, so the marker is
+# the dash measurement too.
 cat >"$ROOT/abandon-runner.sh" <<'RUNNER'
 set -euo pipefail
 . "$1"
 gg_pty_run 2 "$2" || true
 RUNNER
-
-# abandon PTY_LIB CASE_FILE PIDFILE — run a case under PTY_LIB, kill the runner
-# once the session has a child to leave behind, and report what it left:
-# ABANDONED is that child's pid, ABANDONED_GROUP the session's own process
-# group. Cleanup reaps by the GROUP, not the pid: a run that timed out waiting
-# for the pidfile leaves ABANDONED empty, and that is exactly the run with no
-# child handle to reap by. gg_pty_run writes the group into `sid` under its own
-# scratch directory, so the runner gets a TMPDIR this function owns.
-abandon() {
-  local lib="$1" case_file="$2" pidfile="$3" runner i=0 scratch
-  scratch="$(mktemp -d "$ROOT/abandon.XXXXXX")"
-  ABANDONED=""
-  ABANDONED_GROUP=""
-  rm -f "$pidfile"
-  TMPDIR="$scratch" bash "$ROOT/abandon-runner.sh" "$lib" "$case_file" >/dev/null 2>&1 &
+# Run a case under PTY_LIB through a runner, kill the runner once the session
+# has a child to leave behind, wait up to SECONDS for that child to go, and
+# report it with the watchdog marker. The session's group is reaped before
+# the line is returned, by the group the session recorded: a run that timed
+# out waiting for the pid file has no child handle, and that is exactly the
+# run with nothing else to reap by. The cap is 2 and the session's deadline
+# sits five seconds past it; the seconds are slack for a loaded box.
+abandon_line() { # PTY_LIB NAME SECONDS
+  local lib="$1" body="$ROOT/abandon-$2.sh" pidfile="$ROOT/abandon-$2.pid" scratch runner i=0 pid group="" state watchdog
+  printf 'trap "" HUP TERM\necho STARTED\nsleep 300 &\necho "$!" >%q\nwait\n' "$pidfile" >"$body"
+  scratch="$(mktemp -d "$ROOT/abandon-$2.XXXXXX")"
+  TMPDIR="$scratch" bash "$ROOT/abandon-runner.sh" "$lib" "$body" >/dev/null 2>&1 &
   runner=$!
   while [ "$i" -lt 60 ] && [ ! -s "$pidfile" ]; do
     sleep 0.25
@@ -239,106 +229,30 @@ abandon() {
   done
   kill -9 "$runner" 2>/dev/null || true
   wait "$runner" 2>/dev/null || true
-  ABANDONED="$(cat "$pidfile" 2>/dev/null || true)"
-  ABANDONED_GROUP="$(cat "$scratch"/gg-pty.*/sid 2>/dev/null | tr -dc '0-9' || true)"
+  pid="$(cat "$pidfile" 2>/dev/null || true)"
+  group="$(cat "$scratch"/gg-pty.*/sid 2>/dev/null | tr -dc '0-9' || true)"
+  state=child=unrecorded
+  if [ -n "$pid" ]; then
+    state=child=alive
+    i=0
+    while [ "$i" -lt "$3" ]; do
+      if ! kill -0 "$pid" 2>/dev/null; then state=child=gone; break; fi
+      sleep 1
+      i=$((i + 1))
+    done
+  fi
+  [ -f "$body.watchdog" ] && watchdog=fired || watchdog=none
+  # bash, so `--` guards a group id; the session-side kill cannot use it and says why.
+  [ -z "$group" ] || kill -9 -- "-$group" 2>/dev/null || true
+  printf '%s watchdog=%s' "$state" "$watchdog"
 }
-
-# reap_group GROUP — bash, so `--` guards a group id that begins with `-`. The
-# session-side kill in pty.bash cannot use it and says why.
-reap_group() {
-  [ -n "${1:-}" ] || return 0
-  kill -9 -- "-$1" 2>/dev/null || true
-}
-
-# gone_within PID SECONDS
-gone_within() {
-  local i=0
-  while [ "$i" -lt "$2" ]; do
-    kill -0 "$1" 2>/dev/null || return 0
-    sleep 1
-    i=$((i + 1))
-  done
-  return 1
-}
-
-printf 'trap "" HUP TERM\necho STARTED\nsleep 300 &\necho "$!" >%q\nwait\n' \
-  "$ROOT/abandoned.pid" >"$ROOT/abandon-case.sh"
-rm -f "$ROOT/abandon-case.sh.watchdog"
-abandon "$TEST_DIR/lib/pty.bash" "$ROOT/abandon-case.sh" "$ROOT/abandoned.pid"
-real_group="$ABANDONED_GROUP"
-# The cap is 2 and the session's deadline sits five seconds past it; 20 is slack
-# for a loaded box, not a second budget.
-[ -n "$ABANDONED" ] && gone_within "$ABANDONED" 20 \
-  && ok "and the session ends itself once the run that started it is gone" \
-  || bad "and the session ends itself once the run that started it is gone" "pid $ABANDONED is still running"
-# WHICH kill ended it: a dead child is also what a collapsing spawner leaves.
-# The session-side kill runs under /bin/sh — dash on the CI runner, where a
-# mis-parsed argument reaps nothing in silence — and the marker is written by
-# that watchdog alone, so this line is the dash measurement.
-[ -f "$ROOT/abandon-case.sh.watchdog" ] \
-  && ok "and it was the session's own deadline that fired, not something upstream" \
-  || bad "and it was the session's own deadline that fired, not something upstream" "no watchdog marker: the in-session kill did not run (dash argument parsing?)"
-reap_group "$real_group"
-
-# The must-fail control: the same abandonment against a copy whose watchdog
-# never starts. Without it the session outlives the run, which is the leak.
+# The must-fail control: a copy of pty.bash whose watchdog never starts.
+# Without it the session outlives the run, which is the leak; the pinned
+# `alive` after the deadline is reachable only from a copy the edit took.
 NO_DEADLINE="$ROOT/pty-no-deadline.bash"
 sed 's/if \[ -n "$gg_pgid" \]; then/if false; then/' "$TEST_DIR/lib/pty.bash" >"$NO_DEADLINE"
-cmp -s "$TEST_DIR/lib/pty.bash" "$NO_DEADLINE" \
-  && bad "control: the mutant really drops the session's own deadline" "the copy is byte-identical to pty.bash" \
-  || ok "control: the mutant really drops the session's own deadline"
-printf 'trap "" HUP TERM\necho STARTED\nsleep 300 &\necho "$!" >%q\nwait\n' \
-  "$ROOT/abandoned-mutant.pid" >"$ROOT/abandon-mutant-case.sh"
-abandon "$NO_DEADLINE" "$ROOT/abandon-mutant-case.sh" "$ROOT/abandoned-mutant.pid"
-mutant_group="$ABANDONED_GROUP"
-mutant_pid="$ABANDONED"
-# The leak this control creates is reaped BEFORE the assertion, by the group the
-# session recorded: reaping after would be skipped on any path reporting bad and
-# returning early. The pid is read once into a variable of its own, so a later
-# abandon cannot overwrite what is asserted.
-[ -n "$mutant_pid" ] && ! gone_within "$mutant_pid" 12 \
-  && mutant_survived=yes || mutant_survived=no
-reap_group "$mutant_group"
-[ "$mutant_survived" = yes ] \
-  && ok "control: without that deadline the abandoned session is still running" \
-  || bad "control: without that deadline the abandoned session is still running" "pid ${mutant_pid:-none} ended anyway, so the case above proves nothing"
-
-# The status is the SESSION's own, read from the file it wrote rather than
-# from the spawner, which reports on its own account.
-printf 'exit 7\n' >"$ROOT/status-case.sh"
-gg_pty_run 20 "$ROOT/status-case.sh" && [ "$GG_PTY_STATE" = ok ] && [ "$GG_PTY_RC" -eq 7 ] \
-  && ok "control: a session's own exit status survives the spawner" \
-  || bad "control: a session's own exit status survives the spawner" "state=$GG_PTY_STATE rc=$GG_PTY_RC err=$GG_PTY_ERR"
-
-# A session killed before its own last line is `gone`, and carries no status
-# at all: a value invented here would be indistinguishable from one a probe
-# returned, and every status is one a probe may return.
-printf 'echo ABOUT-TO-DIE\nkill -9 "$PPID"\nsleep 5\n' >"$ROOT/die-case.sh"
-gg_pty_run 20 "$ROOT/die-case.sh" && [ "$GG_PTY_STATE" = gone ] && [ -z "$GG_PTY_RC" ] \
-  && ok "control: a session that dies before its last line reports no status" \
-  || bad "control: a session that dies before its last line reports no status" "state=$GG_PTY_STATE rc=$GG_PTY_RC out=$GG_PTY_OUT err=$GG_PTY_ERR"
-
-# A scratch root and a source whose NAMES are a space and a command
-# substitution, run end to end. pty.bash hands the spawner a constant command
-# and passes its paths in the environment, so there is nothing to quote on
-# that side; what this drives is the case body pty_call writes, which bash
-# reads, and the paths gg_pty_run exports reaching the session as values.
-# Unquoted at either, the substitution runs.
-hostile="$ROOT/a q\$(touch $ROOT/PWNED)x dir"
-mkdir -p "$hostile"
-printf 'FROM A HOSTILE PATH\n' >"$hostile/src.tsv"
-rm -f "$ROOT/PWNED"
-if premise_denies_write "$R/tools/dest.tsv" "control: a path that is a space and a command substitution stays a path"; then
-  reset_dest ORIGINAL
-  cp -R "$LIB" "$hostile/lib"
-  TMPDIR="$hostile" pty_call "$hostile/lib" "$hostile/src.tsv" 'gg_tmpdir; gg_install_file "$SRC" tools/dest.tsv "the fixture"'
-  [ "$STATE" = ok ] && [ "$RC" -eq 0 ] && [ "$(cat "$R/tools/dest.tsv")" = "FROM A HOSTILE PATH" ] \
-    && ok "control: a path that is a space and a command substitution stays a path" \
-    || bad "control: a path that is a space and a command substitution stays a path" "state=$STATE rc=$RC out=$OUT content=$(cat "$R/tools/dest.tsv")"
-fi
-[ ! -e "$ROOT/PWNED" ] \
-  && ok "control: and nothing inside that name was executed" \
-  || bad "control: and nothing inside that name was executed" "the substitution ran; $ROOT/PWNED exists"
+assert_eq "the session ends itself once the run that started it is gone, by its own deadline" "child=gone watchdog=fired" "$(abandon_line "$TEST_DIR/lib/pty.bash" real 20)"
+assert_eq "control: without that deadline the abandoned session is still running past it" "child=alive watchdog=none" "$(abandon_line "$NO_DEADLINE" mutant 12)"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/commit-guards/DEVELOPMENT.md
+++ b/skills/commit-guards/DEVELOPMENT.md
@@ -87,7 +87,7 @@ The row format, the `!` carve and the `\!` escape are stated in `SKILL.md § Con
 
 ## Probing a terminal-only code path
 
-A headless suite cannot reach a branch that exists only at a tty (`mv` prompts before replacing a write-denied destination only there). `gg_pty_run CAP SCRIPT_FILE` in `tests/lib/pty.bash` runs a bash script with fds 0, 1 and 2 on a pseudo-terminal, picking the `script` grammar from `uname`; a host whose `script` answers neither form is a red naming the spawner, not a skip. Its states are enumerated above the function and nowhere else. `tests/terminal-paths.test.sh` is the worked example; its `pty_call` is the wrapper a new case copies.
+A headless suite cannot reach a branch that exists only at a tty (`mv` prompts before replacing a write-denied destination only there). `gg_pty_run CAP SCRIPT_FILE` in `tests/lib/pty.bash` runs a bash script with fds 0, 1 and 2 on a pseudo-terminal, picking the `script` grammar from `uname`; a host whose `script` answers neither form is a red naming the spawner, not a skip. Its states are enumerated above the function and nowhere else. `tests/terminal-paths.test.sh` is the worked example; its `pty_line` runs one session body and `install_line` is the wrapper an install case copies.
 
 - Stdin is `/dev/null`, so a prompt is answered by EOF.
 - A time cap on both sides: after `CAP` seconds the caller kills the session's process group, then the spawner's; the session holds the same deadline over itself a few seconds later.

--- a/skills/commit-guards/tests/prose.test.sh
+++ b/skills/commit-guards/tests/prose.test.sh
@@ -103,7 +103,7 @@ line_rows \
   "control: a reference followed by punctuation or a space still fails, one hit per line|Landed in #1204) and #228, per #999.|rc=1 $(hit SKILL.md 1 'Landed in #1204) and #228, per #999.');$(failed 1 1)" \
   "a reference ending its line still fails|Landed in #1204|rc=1 $(hit SKILL.md 1 'Landed in #1204');$(failed 1 1)" \
   "ordinary wording passes: a bare year and a year-month|The 2026 roadmap and the 2026-08 window.|rc=0 $(clean 1)" \
-  "an ATX heading whose text is a number is not an issue reference|#### 1204 items|rc=0 $(clean 1)" \
+  "an ATX heading whose text is a number, to the end of the line, is not an issue reference|#### 1204|rc=0 $(clean 1)" \
   "a decision ID, a code-span D042 § Context and a four-digit ID all pass|Decided in D042; the reason is in \`D042 § Context\`, and D1234 is the same kind.|rc=0 $(clean 1)" \
   "control: the same digits after '#' are still an issue reference|Decided in #042.|rc=1 $(hit SKILL.md 1 'Decided in #042.');$(failed 1 1)" \
   "two hits on two lines are two lines and one count each|First 2026-08-12.\nSecond #228.|rc=1 $(hit SKILL.md 1 'First 2026-08-12.');$(hit SKILL.md 2 'Second #228.');$(failed 2 1)"

--- a/skills/commit-guards/tests/terminal-paths.test.sh
+++ b/skills/commit-guards/tests/terminal-paths.test.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 # Pins for the code paths that only exist AT A TERMINAL. The runners invoke
 # every other suite headless, where `mv` never prompts and plain `mv` measures
-# exactly as `mv -f` does — which is how a prompting install shipped green.
-# Each case here runs under a pseudo-terminal. What a call sets is in
-# lib/pty.bash; the rules such a probe follows, and why, are in
-# ../DEVELOPMENT.md § Probing a terminal-only code path.
+# exactly as `mv -f` does, which is how a prompting install shipped green.
+# Every case here runs under a pseudo-terminal through lib/pty.bash; the rules
+# such a probe follows, and why, are in
+# ../DEVELOPMENT.md § Probing a terminal-only code path. Two tables: the
+# probe itself (a session body run at the cap, pinned by its state, status
+# and output), and gg_install_file at a terminal (a lib tree, a source and a
+# read-only destination, pinned by the session's line and what the
+# destination holds after). The abandonment pair beside them needs a runner
+# killed mid-session, so it stays scripted.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -14,224 +19,209 @@ TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$TEST_DIR/lib/pty.bash"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 LIB="$SKILL_DIR/scripts/lib"
-# gg_install_file lives in atomic-install.sh, which needs common.sh sourced
-# first; a session below therefore takes the lib DIRECTORY and sources both.
-INSTALL="$LIB/atomic-install.sh"
 ROOT="$TMP"
 
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
 filemode() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"; }
 
-R="$ROOT/install-file"
-mkdir -p "$R/tools"
+# One line for a session: its state, its own status and every line it
+# printed joined by ';', or `unstarted` with the reason no session ran.
+# ENVS is a comma-separated list of assignments exported for the run only;
+# mktemp's own words are normalised, GNU and BSD phrase them apart. The
+# probe's own stdin holds a line: a spawner that forwarded it instead of
+# reading /dev/null would hand it to the session's prompt.
+pty_line() { # CAP CASE_FILE ENVS
+  local envs=()
+  [ -z "$3" ] || IFS=',' read -ra envs <<<"$3"
+  (
+    [ "${#envs[@]}" -eq 0 ] || export "${envs[@]}"
+    if gg_pty_run "$1" "$2"; then
+      printf 'state=%s rc=%s out=%s' "$GG_PTY_STATE" "$GG_PTY_RC" "$(printf '%s\n' "$GG_PTY_OUT" | LC_ALL=C paste -sd ';' -)"
+    else
+      printf 'unstarted err=%s' "$(printf '%s' "$GG_PTY_ERR" | sed 's/mktemp: .*/mktemp: <its words>/')"
+    fi
+  ) <<<"TYPED AT THE SUITE"
+}
 
-# atomic-install.test.sh's `install_line`, with the session's fds on a pty. LIB is a
-# parameter so a mutant copy of the tree can be run through the same probe.
-#
-# SRC is a parameter for a different reason: every path this helper writes
-# goes through %q, and a caller splicing one into the SNIPPET instead would
-# put it into a shell script body as syntax. $ROOT descends from TMPDIR,
-# which the caller owns, so a directory named with a command substitution
-# ran. No call site interpolates a path into its snippet — it names $SRC and
-# lets this function quote it, so a later case cannot bring the shape back.
-#
-# %q is the right quoting HERE, where pty.bash's spawn string cannot use it:
-# this file is run by `bash`, which is the shell %q quotes for, so the
-# ANSI-C form it emits for a control byte is a form its reader parses.
-#
-# What the session refuses to measure, each with a status of its own, so a
-# case that never reached the code under test cannot satisfy a negative
-# assertion about it:
-#   3  the session's stdin is not a terminal
-#   4  the destination is writable, so `mv` has nothing to prompt about
-#      (which is every run at euid 0, where mode 0444 is not enforced, and
-#      which premise_denies_write also refuses from the suite side before a
-#      session is started at all)
-# The REACHED marker is the separate positive half: it carries no status, and
-# it is the evidence that the call under test was entered.
-pty_call() { # LIB SRC SNIPPET
-  # The case file goes BESIDE the source, not in $ROOT: gg_pty_run writes it
-  # into the session as `bash %q`, so siting it under a hostile SRC is what
-  # drives that line's quoting too. Everything else about it is unchanged —
-  # $ROOT/tty.tsv puts it back where it always was.
-  # Two statements, not one `local`: a builtin's arguments are all expanded
-  # before any of its assignments take effect, so case_file cannot read src
-  # on the same line.
-  local lib="$1" src="$2" snippet="$3" case_file
-  case_file="${src%/*}/pty-case.sh"
+# State functions a row names: their tokens are appended after ' / '.
+child() { # the process the session recorded in GG_T_PIDFILE: gone, alive, or never recorded
+  local pid
+  pid="$(cat "$GG_T_PIDFILE" 2>/dev/null || true)"
+  if [ -z "$pid" ]; then printf 'child=unrecorded'
+  elif kill -0 "$pid" 2>/dev/null; then printf 'child=alive'
+  else printf 'child=gone'
+  fi
+}
+# On a healthy run the caller's cap fires first, so the session's own
+# watchdog leaves no marker beside the body: that absence says which kill it was.
+capped() { child; [ -f "$GG_T_BODY.watchdog" ] && printf ' watchdog=fired' || printf ' watchdog=none'; }
+unpwned() { [ -e "$ROOT/PWNED" ] && printf 'pwned=yes' || printf 'pwned=no'; }
+
+# A `script` that answers neither grammar, first on PATH for one row.
+mkdir -p "$ROOT/noscript"
+printf '#!/bin/sh\necho "script: not this grammar"\nexit 1\n' >"$ROOT/noscript/script"
+chmod +x "$ROOT/noscript/script"
+
+# Table one: BODY is the session, written through printf %b (a pipe is
+# \174); the row's pid file reaches it as GG_T_PIDFILE.
+ROW=0
+pty_rows() { # label | cap | envs | body | state | expect
+  local row label cap envs body state expect actual
+  for row in "$@"; do
+    IFS='|' read -r label cap envs body state expect <<<"$row"
+    ROW=$((ROW + 1))
+    export GG_T_PIDFILE="$ROOT/pty-$ROW.pid"
+    GG_T_BODY="$ROOT/pty-$ROW.sh"
+    printf '%b' "$body" >"$GG_T_BODY"
+    actual="$(pty_line "$cap" "$GG_T_BODY" "$envs")"
+    [ -z "$state" ] || actual="$actual / $($state)"
+    assert_eq "$label" "$expect" "$actual"
+  done
+}
+
+echo "=== gg_pty_run: the probe rules the install cases depend on ==="
+pty_rows \
+  'stdin, stdout and stderr are all on the pty|20||[ -t 0 ] && [ -t 1 ] && [ -t 2 ] && echo ALL-THREE\n||state=ok rc=0 out=ALL-THREE' \
+  'a read from the terminal gets EOF instead of waiting: the spawner reads /dev/null|20||read -r answer </dev/tty && echo "READ $answer" \174\174 echo EOF-AT-THE-PROMPT\n||state=ok rc=0 out=EOF-AT-THE-PROMPT' \
+  'control: a session that never returns is capped by the caller with its output kept, and the child it started is reaped|2||trap "" HUP\necho STARTED\nsleep 300 &\necho "$!" >"$GG_T_PIDFILE"\nwait\n|capped|state=capped rc= out=STARTED / child=gone watchdog=none' \
+  "control: a session's own exit status survives the spawner|20||exit 7\n||state=ok rc=7 out=" \
+  'control: a session that dies before its last line is gone and reports no status|20||echo ABOUT-TO-DIE\nkill -9 "$PPID"\nsleep 5\n||state=gone rc= out=ABOUT-TO-DIE' \
+  "a script answering neither grammar is no session, named with what it said|20|PATH=$ROOT/noscript:$PATH|echo NEVER\n||unstarted err=no working pty spawner: script started no session. It said: script: not this grammar" \
+  "a scratch root that cannot be made is no session, naming TMPDIR|20|TMPDIR=$ROOT/absent|echo NEVER\n||unstarted err=could not create a scratch directory under TMPDIR ($ROOT/absent): mktemp: <its words>"
+
+# Table two: gg_install_file at a terminal. A fixture sets the lib tree the
+# session sources (LIBD), the source (SRC), the read-only destination under
+# R, and the TMPDIR the probe runs under (PTY_TMP). The case file goes BESIDE
+# the source: gg_pty_run runs it as `bash %q`, so a hostile SRC drives that
+# line's quoting too. The session refuses its own premise with a status of
+# its own (3: no terminal; 4: the destination is writable, which is every
+# run at euid 0) and prints REACHED with the source it was handed before
+# the call, so a negative pin cannot be met by a case that never entered the
+# code under test, and the name that reached it is the one the fixture chose.
+install_line() { # LIBD SRC PTY_TMP
+  local case_file="${2%/*}/pty-case.sh" line
   {
     printf 'set -euo pipefail\n'
     printf 'cd %q\n' "$R"
     printf 'GG_CHECK=probe\n'
-    # The session speaks C, because a case below matches mv's own prompt and
-    # coreutils translates it — 46 catalogs on a stock host, fr, de and es
-    # among those carrying `overriding mode`. The environment reaches the
-    # session through `script`, so a contributor whose shell has a localized
-    # message locale would red a healthy tree. common.sh forces LC_ALL=C on
-    # every grep whose match depends on tool wording, for this reason.
+    # C, because a row matches mv's own prompt and coreutils translates it.
     printf 'export LC_ALL=C\n'
     printf '[ -t 0 ] || { echo NOT-A-TERMINAL; exit 3; }\n'
     printf '[ ! -w tools/dest.tsv ] || { echo DESTINATION-IS-WRITABLE; exit 4; }\n'
-    printf 'SRC=%q\n' "$src"
-    printf '. %q\n' "$lib/common.sh"
-    printf '. %q\n' "$lib/atomic-install.sh"
-    printf 'echo REACHED\n'
-    printf '%s\n' "$snippet"
+    printf 'SRC=%q\n' "$2"
+    printf '. %q\n' "$1/common.sh"
+    printf '. %q\n' "$1/atomic-install.sh"
+    printf 'echo "REACHED $SRC"\n'
+    printf 'gg_tmpdir; gg_install_file "$SRC" tools/dest.tsv "the fixture"\n'
   } >"$case_file"
-  OUT=""
-  RC=""
-  STATE=""
-  if ! gg_pty_run 20 "$case_file"; then
-    STATE=unstarted
-    OUT="$GG_PTY_ERR"
-    return 0
-  fi
-  STATE="$GG_PTY_STATE"
-  OUT="$GG_PTY_OUT"
-  RC="$GG_PTY_RC"
+  line="$(pty_line 20 "$case_file" "TMPDIR=$3")"
+  printf '%s / dest=%s mode=%s staged=%s' "$line" "$(cat "$R/tools/dest.tsv")" "$(filemode "$R/tools/dest.tsv")" \
+    "$(find "$R/tools" -name '*gg-install*' | wc -l | tr -d ' ')"
 }
-
-# A case whose premise is a permission denial measures nothing where the
-# denial is not enforced: at euid 0 neither 0444 nor 0500 stops anything. One
-# helper for every such case, so a later one gets the refusal by construction
-# rather than by its author remembering — and so the report names euid 0
-# instead of accusing the code under test of a fault that is not there.
-premise_denies_write() { # PATH CASE_NAME — 0 when the denial really holds here
-  [ ! -w "$1" ] && return 0
-  bad "$2" "premise unmet: $1 is writable to this process (euid $(id -u)), so a permission denial is not enforced and this case cannot measure its branch"
-  return 1
-}
-
-reset_dest() { # CONTENT — a read-only destination carrying CONTENT
-  chmod 644 "$R/tools/dest.tsv" 2>/dev/null || true
-  printf '%s\n' "$1" >"$R/tools/dest.tsv"
+# A read-only destination under R carrying CONTENT. The denial is the premise
+# of every row: where it is not enforced the suite measures nothing, and says
+# so once here rather than accusing the code under test.
+dest() { # NAME CONTENT
+  R="$ROOT/$1"
+  mkdir -p "$R/tools"
+  printf '%s\n' "$2" >"$R/tools/dest.tsv"
   chmod 444 "$R/tools/dest.tsv"
+  [ ! -w "$R/tools/dest.tsv" ] || { echo "harness: $R/tools/dest.tsv is writable to euid $(id -u); a permission denial is not enforced here and the terminal cases cannot measure their branch" >&2; exit 2; }
+}
+fx_real() { dest real ORIGINAL; SRC="$ROOT/real-src.tsv"; printf 'REPLACED AT A TERMINAL\n' >"$SRC"; LIBD="$LIB"; PTY_TMP="$TMPDIR"; }
+# The must-fail control: the same probe against a copy of the helper with the
+# `-f` taken back out. The WHOLE lib tree is copied: common.sh bootstraps its
+# neighbours off its own directory, so a mutant sited elsewhere dies at its
+# first source line, before gg_install_file exists.
+fx_no_f() {
+  dest no-f 'NOT REPLACED'
+  SRC="$ROOT/no-f-src.tsv"
+  printf 'REPLACED AT A TERMINAL\n' >"$SRC"
+  cp -R "$LIB" "$ROOT/lib-no-f"
+  sed 's/mv -f -- /mv -- /' "$LIB/atomic-install.sh" >"$ROOT/lib-no-f/atomic-install.sh"
+  LIBD="$ROOT/lib-no-f"
+  PTY_TMP="$TMPDIR"
+}
+# A scratch root and a source whose NAMES are a space and a command
+# substitution: pty.bash hands the spawner a constant command and passes its
+# paths in the environment, so what this drives is the case body install_line
+# writes, which bash reads. Unquoted there, the substitution runs.
+HOSTILE="$ROOT/a q\$(touch $ROOT/PWNED)x dir"
+fx_hostile() {
+  dest hostile ORIGINAL
+  mkdir -p "$HOSTILE"
+  SRC="$HOSTILE/src.tsv"
+  printf 'FROM A HOSTILE PATH\n' >"$SRC"
+  cp -R "$LIB" "$HOSTILE/lib"
+  rm -f "$ROOT/PWNED"
+  LIBD="$HOSTILE/lib"
+  PTY_TMP="$HOSTILE"
+}
+# Where mv reports the decline, the decline's own words are the evidence:
+# GNU mv prompts, reads EOF, exits 1, and gg_install_why folds the prompt
+# into the refusal. BSD mv answers its prompt's EOF as no and exits 0, so the
+# helper reads a success, leaves the destination alone and its staging file
+# beside it, which is the leak the `-f` closes there. Keyed on uname, the
+# way pty.bash selects its grammar.
+case "$(uname -s)" in
+  Darwin) NO_F="state=ok rc=0 out=REACHED $ROOT/no-f-src.tsv / dest=NOT REPLACED mode=444 staged=1" ;;
+  *) NO_F="state=ok rc=2 out=REACHED $ROOT/no-f-src.tsv;::error::probe: could not replace the fixture at tools/dest.tsv (mv: replace 'tools/dest.tsv', overriding mode 0444 (r--r--r--)? ) — inspect the file before trusting it / dest=NOT REPLACED mode=444 staged=0" ;;
+esac
+install_rows() { # label | fixture | state | expect
+  local row label fx state expect actual
+  for row in "$@"; do
+    IFS='|' read -r label fx state expect <<<"$row"
+    R=""
+    "$fx"
+    actual="$(install_line "$LIBD" "$SRC" "$PTY_TMP")"
+    [ -z "$state" ] || actual="$actual / $($state)"
+    assert_eq "$label" "$expect" "$actual"
+  done
 }
 
 echo "=== gg_install_file: a read-only destination is replaced at a terminal too ==="
+install_rows \
+  "the install lands, and the destination keeps its mode|fx_real||state=ok rc=0 out=REACHED $ROOT/real-src.tsv / dest=REPLACED AT A TERMINAL mode=444 staged=0" \
+  "control: without the -f the same probe leaves the destination unreplaced, the refusal carrying mv's own prompt|fx_no_f||$NO_F" \
+  "control: a path that is a space and a command substitution stays a path, and nothing inside it runs|fx_hostile|unpwned|state=ok rc=0 out=REACHED $ROOT/a q\$(touch $ROOT/PWNED)x dir/src.tsv / dest=FROM A HOSTILE PATH mode=444 staged=0 / pwned=no"
 
-SRC_TTY="$ROOT/tty.tsv"
-printf 'REPLACED AT A TERMINAL\n' >"$SRC_TTY"
-reset_dest ORIGINAL
-if premise_denies_write "$R/tools/dest.tsv" "the install lands, and the destination keeps its mode"; then
-  pty_call "$LIB" "$SRC_TTY" 'gg_tmpdir; gg_install_file "$SRC" tools/dest.tsv "the fixture"'
-  [ "$STATE" = ok ] && [ "$RC" -eq 0 ] && [ "$(cat "$R/tools/dest.tsv")" = "REPLACED AT A TERMINAL" ] \
-    && [ "$(filemode "$R/tools/dest.tsv")" = 444 ] \
-    && ok "the install lands, and the destination keeps its mode" \
-    || bad "the install lands, and the destination keeps its mode" "state=$STATE rc=$RC mode=$(filemode "$R/tools/dest.tsv") out=$OUT"
-fi
-
-# The control that makes the case above a measurement rather than a
-# coincidence: the same probe against a copy of the helper with the `-f` taken
-# back out. Every headless assertion over this helper still passes against it.
-#
-# The WHOLE lib tree is copied, not atomic-install.sh alone: it needs
-# common.sh sourced first, and common.sh bootstraps paths.sh and
-# configured-paths.sh off its own directory, so a mutant sited anywhere else
-# dies at its first source line — before gg_install_file exists, and while
-# still satisfying a control that only asks for an unreplaced destination.
-cp -R "$LIB" "$ROOT/lib-no-f"
-sed 's/mv -f -- /mv -- /' "$INSTALL" >"$ROOT/lib-no-f/atomic-install.sh"
-cmp -s "$INSTALL" "$ROOT/lib-no-f/atomic-install.sh" \
-  && bad "control: the mutant really drops the -f" "the copy is byte-identical to atomic-install.sh" \
-  || ok "control: the mutant really drops the -f"
-
-reset_dest "NOT REPLACED"
-if premise_denies_write "$R/tools/dest.tsv" "control: without the -f the same probe leaves the destination unreplaced"; then
-  pty_call "$ROOT/lib-no-f" "$SRC_TTY" 'gg_tmpdir; gg_install_file "$SRC" tools/dest.tsv "the fixture"'
-  # The session must have REACHED the call and finished on its own, and its
-  # status must be one gg_install_file itself produces: 0, or the 2 of a
-  # collection error. A session that refused its premise (3, 4), was capped,
-  # or died is a probe failure, and an unreplaced destination is what all of
-  # those leave behind too.
-  case "$OUT" in *REACHED*) reached=yes ;; *) reached=no ;; esac
-  [ "$STATE" = ok ] && [ "$reached" = yes ] && { [ "$RC" -eq 0 ] || [ "$RC" -eq 2 ]; } \
-    && [ "$(cat "$R/tools/dest.tsv")" = "NOT REPLACED" ] \
-    && [ "$(filemode "$R/tools/dest.tsv")" = 444 ] \
-    && ok "control: without the -f the same probe leaves the destination unreplaced" \
-    || bad "control: without the -f the same probe leaves the destination unreplaced" "state=$STATE reached=$reached rc=$RC content=$(cat "$R/tools/dest.tsv") out=$OUT"
-
-  # Where mv reports the decline, the decline's own words are the evidence.
-  # `could not replace the fixture` alone is gg_collection_error's frame,
-  # which it prints whether or not gg_install_why relayed anything — so the
-  # match reaches for mv's prompt too, which is the half this case is named
-  # for. GNU mv exits 1 and gg_install_why folds that prompt in; BSD mv
-  # answers no with exit 0 and nothing to relay, so there is no refusal to
-  # read there and this half of the claim is not available. Keyed on uname,
-  # the same way the grammar is chosen.
-  if [ "$(uname -s)" != Darwin ]; then
-    [ "$STATE" = ok ] && [ "$RC" -eq 2 ] && case "$OUT" in
-      *"could not replace the fixture"*"overriding mode"*) true ;;
-      *) false ;;
-    esac \
-      && ok "control: and the refusal carries mv's own prompt as its cause" \
-      || bad "control: and the refusal carries mv's own prompt as its cause" "state=$STATE rc=$RC out=$OUT"
-  fi
-fi
-
-echo "=== gg_pty_run: the probe rules the cases above depend on ==="
-
-# The session's fds really are a terminal — the premise every case here rests
-# on, asserted rather than assumed.
-printf '[ -t 0 ] && [ -t 1 ] && [ -t 2 ] && echo ALL-THREE\n' >"$ROOT/tty-case.sh"
-gg_pty_run 20 "$ROOT/tty-case.sh" && [ "$GG_PTY_STATE" = ok ] && [ "$GG_PTY_RC" -eq 0 ] \
-  && [ "$GG_PTY_OUT" = "ALL-THREE" ] \
-  && ok "stdin, stdout and stderr are all on the pty" \
-  || bad "stdin, stdout and stderr are all on the pty" "state=$GG_PTY_STATE rc=$GG_PTY_RC out=$GG_PTY_OUT err=$GG_PTY_ERR"
-
-# A prompt inside the session is answered by EOF, because the SPAWNER reads
-# /dev/null. Without that redirect this read is the wedge, not a result.
-printf 'read -r answer </dev/tty && echo "READ $answer" || echo EOF-AT-THE-PROMPT\n' >"$ROOT/prompt-case.sh"
-gg_pty_run 20 "$ROOT/prompt-case.sh" && [ "$GG_PTY_OUT" = "EOF-AT-THE-PROMPT" ] \
-  && ok "a read from the terminal gets EOF instead of waiting" \
-  || bad "a read from the terminal gets EOF instead of waiting" "state=$GG_PTY_STATE out=$GG_PTY_OUT err=$GG_PTY_ERR"
-
-# The cap, and what it must leave behind: nothing. The body ignores SIGHUP, so
-# the pty closing behind the killed spawner cannot stand in for the reap, and
-# it records the pid of the process that must be gone. Killing the spawner
-# alone leaves that pid alive while the caller is told the cap worked.
-printf 'trap "" HUP\necho STARTED\nsleep 300 &\necho "$!" >%q\nwait\n' "$ROOT/orphan.pid" >"$ROOT/hang-case.sh"
-rm -f "$ROOT/orphan.pid"
-gg_pty_run 2 "$ROOT/hang-case.sh" && [ "$GG_PTY_STATE" = capped ] && [ -z "$GG_PTY_RC" ] \
-  && [ "$GG_PTY_OUT" = "STARTED" ] \
-  && ok "control: a session that never returns is capped, reported, and its output kept" \
-  || bad "control: a session that never returns is capped, reported, and its output kept" "state=$GG_PTY_STATE rc=$GG_PTY_RC out=$GG_PTY_OUT err=$GG_PTY_ERR"
-orphan="$(cat "$ROOT/orphan.pid" 2>/dev/null || true)"
-[ -n "$orphan" ] \
-  && ok "control: the capped session really did start the child the reap must take" \
-  || bad "control: the capped session really did start the child the reap must take" "no pid recorded; state=$GG_PTY_STATE err=$GG_PTY_ERR out=$GG_PTY_OUT"
-[ -n "$orphan" ] && ! kill -0 "$orphan" 2>/dev/null \
-  && ok "control: and the cap left no process of it behind" \
-  || bad "control: and the cap left no process of it behind" "pid $orphan is still running; state=$GG_PTY_STATE err=$GG_PTY_ERR"
-
-# A suite killed mid-run takes the poll loop above with it, and `script` has
-# already setsid'd the session out of every group that killer could name, so the
-# cap on this side stops existing. What is left is the deadline the session
-# holds over itself. The body traps TERM away, so nothing short of
-# the SIGKILL that deadline sends can end it.
+echo "=== an abandoned session ends itself ==="
+# A suite killed mid-run takes the poll loop with it, and `script` has
+# already setsid'd the session out of every group that killer could name, so
+# the cap on this side stops existing. What is left is the deadline the
+# session holds over itself. The body traps HUP and TERM away, so nothing
+# short of the SIGKILL that deadline sends can end it, and the marker beside
+# the body is written by that watchdog alone: a dead child is also what a
+# collapsing spawner leaves, so the marker is what says WHICH kill fired. The
+# in-session kill runs under /bin/sh, dash on the CI runner, so the marker is
+# the dash measurement too.
 cat >"$ROOT/abandon-runner.sh" <<'RUNNER'
 set -euo pipefail
 . "$1"
 gg_pty_run 2 "$2" || true
 RUNNER
-
-# abandon PTY_LIB CASE_FILE PIDFILE — run a case under PTY_LIB, kill the runner
-# once the session has a child to leave behind, and report what it left:
-# ABANDONED is that child's pid, ABANDONED_GROUP the session's own process
-# group. Cleanup reaps by the GROUP, not the pid: a run that timed out waiting
-# for the pidfile leaves ABANDONED empty, and that is exactly the run with no
-# child handle to reap by. gg_pty_run writes the group into `sid` under its own
-# scratch directory, so the runner gets a TMPDIR this function owns.
-abandon() {
-  local lib="$1" case_file="$2" pidfile="$3" runner i=0 scratch
-  scratch="$(mktemp -d "$ROOT/abandon.XXXXXX")"
-  ABANDONED=""
-  ABANDONED_GROUP=""
-  rm -f "$pidfile"
-  TMPDIR="$scratch" bash "$ROOT/abandon-runner.sh" "$lib" "$case_file" >/dev/null 2>&1 &
+# Run a case under PTY_LIB through a runner, kill the runner once the session
+# has a child to leave behind, wait up to SECONDS for that child to go, and
+# report it with the watchdog marker. The session's group is reaped before
+# the line is returned, by the group the session recorded: a run that timed
+# out waiting for the pid file has no child handle, and that is exactly the
+# run with nothing else to reap by. The cap is 2 and the session's deadline
+# sits five seconds past it; the seconds are slack for a loaded box.
+abandon_line() { # PTY_LIB NAME SECONDS
+  local lib="$1" body="$ROOT/abandon-$2.sh" pidfile="$ROOT/abandon-$2.pid" scratch runner i=0 pid group="" state watchdog
+  printf 'trap "" HUP TERM\necho STARTED\nsleep 300 &\necho "$!" >%q\nwait\n' "$pidfile" >"$body"
+  scratch="$(mktemp -d "$ROOT/abandon-$2.XXXXXX")"
+  TMPDIR="$scratch" bash "$ROOT/abandon-runner.sh" "$lib" "$body" >/dev/null 2>&1 &
   runner=$!
   while [ "$i" -lt 60 ] && [ ! -s "$pidfile" ]; do
     sleep 0.25
@@ -239,106 +229,30 @@ abandon() {
   done
   kill -9 "$runner" 2>/dev/null || true
   wait "$runner" 2>/dev/null || true
-  ABANDONED="$(cat "$pidfile" 2>/dev/null || true)"
-  ABANDONED_GROUP="$(cat "$scratch"/gg-pty.*/sid 2>/dev/null | tr -dc '0-9' || true)"
+  pid="$(cat "$pidfile" 2>/dev/null || true)"
+  group="$(cat "$scratch"/gg-pty.*/sid 2>/dev/null | tr -dc '0-9' || true)"
+  state=child=unrecorded
+  if [ -n "$pid" ]; then
+    state=child=alive
+    i=0
+    while [ "$i" -lt "$3" ]; do
+      if ! kill -0 "$pid" 2>/dev/null; then state=child=gone; break; fi
+      sleep 1
+      i=$((i + 1))
+    done
+  fi
+  [ -f "$body.watchdog" ] && watchdog=fired || watchdog=none
+  # bash, so `--` guards a group id; the session-side kill cannot use it and says why.
+  [ -z "$group" ] || kill -9 -- "-$group" 2>/dev/null || true
+  printf '%s watchdog=%s' "$state" "$watchdog"
 }
-
-# reap_group GROUP — bash, so `--` guards a group id that begins with `-`. The
-# session-side kill in pty.bash cannot use it and says why.
-reap_group() {
-  [ -n "${1:-}" ] || return 0
-  kill -9 -- "-$1" 2>/dev/null || true
-}
-
-# gone_within PID SECONDS
-gone_within() {
-  local i=0
-  while [ "$i" -lt "$2" ]; do
-    kill -0 "$1" 2>/dev/null || return 0
-    sleep 1
-    i=$((i + 1))
-  done
-  return 1
-}
-
-printf 'trap "" HUP TERM\necho STARTED\nsleep 300 &\necho "$!" >%q\nwait\n' \
-  "$ROOT/abandoned.pid" >"$ROOT/abandon-case.sh"
-rm -f "$ROOT/abandon-case.sh.watchdog"
-abandon "$TEST_DIR/lib/pty.bash" "$ROOT/abandon-case.sh" "$ROOT/abandoned.pid"
-real_group="$ABANDONED_GROUP"
-# The cap is 2 and the session's deadline sits five seconds past it; 20 is slack
-# for a loaded box, not a second budget.
-[ -n "$ABANDONED" ] && gone_within "$ABANDONED" 20 \
-  && ok "and the session ends itself once the run that started it is gone" \
-  || bad "and the session ends itself once the run that started it is gone" "pid $ABANDONED is still running"
-# WHICH kill ended it: a dead child is also what a collapsing spawner leaves.
-# The session-side kill runs under /bin/sh — dash on the CI runner, where a
-# mis-parsed argument reaps nothing in silence — and the marker is written by
-# that watchdog alone, so this line is the dash measurement.
-[ -f "$ROOT/abandon-case.sh.watchdog" ] \
-  && ok "and it was the session's own deadline that fired, not something upstream" \
-  || bad "and it was the session's own deadline that fired, not something upstream" "no watchdog marker: the in-session kill did not run (dash argument parsing?)"
-reap_group "$real_group"
-
-# The must-fail control: the same abandonment against a copy whose watchdog
-# never starts. Without it the session outlives the run, which is the leak.
+# The must-fail control: a copy of pty.bash whose watchdog never starts.
+# Without it the session outlives the run, which is the leak; the pinned
+# `alive` after the deadline is reachable only from a copy the edit took.
 NO_DEADLINE="$ROOT/pty-no-deadline.bash"
 sed 's/if \[ -n "$gg_pgid" \]; then/if false; then/' "$TEST_DIR/lib/pty.bash" >"$NO_DEADLINE"
-cmp -s "$TEST_DIR/lib/pty.bash" "$NO_DEADLINE" \
-  && bad "control: the mutant really drops the session's own deadline" "the copy is byte-identical to pty.bash" \
-  || ok "control: the mutant really drops the session's own deadline"
-printf 'trap "" HUP TERM\necho STARTED\nsleep 300 &\necho "$!" >%q\nwait\n' \
-  "$ROOT/abandoned-mutant.pid" >"$ROOT/abandon-mutant-case.sh"
-abandon "$NO_DEADLINE" "$ROOT/abandon-mutant-case.sh" "$ROOT/abandoned-mutant.pid"
-mutant_group="$ABANDONED_GROUP"
-mutant_pid="$ABANDONED"
-# The leak this control creates is reaped BEFORE the assertion, by the group the
-# session recorded: reaping after would be skipped on any path reporting bad and
-# returning early. The pid is read once into a variable of its own, so a later
-# abandon cannot overwrite what is asserted.
-[ -n "$mutant_pid" ] && ! gone_within "$mutant_pid" 12 \
-  && mutant_survived=yes || mutant_survived=no
-reap_group "$mutant_group"
-[ "$mutant_survived" = yes ] \
-  && ok "control: without that deadline the abandoned session is still running" \
-  || bad "control: without that deadline the abandoned session is still running" "pid ${mutant_pid:-none} ended anyway, so the case above proves nothing"
-
-# The status is the SESSION's own, read from the file it wrote rather than
-# from the spawner, which reports on its own account.
-printf 'exit 7\n' >"$ROOT/status-case.sh"
-gg_pty_run 20 "$ROOT/status-case.sh" && [ "$GG_PTY_STATE" = ok ] && [ "$GG_PTY_RC" -eq 7 ] \
-  && ok "control: a session's own exit status survives the spawner" \
-  || bad "control: a session's own exit status survives the spawner" "state=$GG_PTY_STATE rc=$GG_PTY_RC err=$GG_PTY_ERR"
-
-# A session killed before its own last line is `gone`, and carries no status
-# at all: a value invented here would be indistinguishable from one a probe
-# returned, and every status is one a probe may return.
-printf 'echo ABOUT-TO-DIE\nkill -9 "$PPID"\nsleep 5\n' >"$ROOT/die-case.sh"
-gg_pty_run 20 "$ROOT/die-case.sh" && [ "$GG_PTY_STATE" = gone ] && [ -z "$GG_PTY_RC" ] \
-  && ok "control: a session that dies before its last line reports no status" \
-  || bad "control: a session that dies before its last line reports no status" "state=$GG_PTY_STATE rc=$GG_PTY_RC out=$GG_PTY_OUT err=$GG_PTY_ERR"
-
-# A scratch root and a source whose NAMES are a space and a command
-# substitution, run end to end. pty.bash hands the spawner a constant command
-# and passes its paths in the environment, so there is nothing to quote on
-# that side; what this drives is the case body pty_call writes, which bash
-# reads, and the paths gg_pty_run exports reaching the session as values.
-# Unquoted at either, the substitution runs.
-hostile="$ROOT/a q\$(touch $ROOT/PWNED)x dir"
-mkdir -p "$hostile"
-printf 'FROM A HOSTILE PATH\n' >"$hostile/src.tsv"
-rm -f "$ROOT/PWNED"
-if premise_denies_write "$R/tools/dest.tsv" "control: a path that is a space and a command substitution stays a path"; then
-  reset_dest ORIGINAL
-  cp -R "$LIB" "$hostile/lib"
-  TMPDIR="$hostile" pty_call "$hostile/lib" "$hostile/src.tsv" 'gg_tmpdir; gg_install_file "$SRC" tools/dest.tsv "the fixture"'
-  [ "$STATE" = ok ] && [ "$RC" -eq 0 ] && [ "$(cat "$R/tools/dest.tsv")" = "FROM A HOSTILE PATH" ] \
-    && ok "control: a path that is a space and a command substitution stays a path" \
-    || bad "control: a path that is a space and a command substitution stays a path" "state=$STATE rc=$RC out=$OUT content=$(cat "$R/tools/dest.tsv")"
-fi
-[ ! -e "$ROOT/PWNED" ] \
-  && ok "control: and nothing inside that name was executed" \
-  || bad "control: and nothing inside that name was executed" "the substitution ran; $ROOT/PWNED exists"
+assert_eq "the session ends itself once the run that started it is gone, by its own deadline" "child=gone watchdog=fired" "$(abandon_line "$TEST_DIR/lib/pty.bash" real 20)"
+assert_eq "control: without that deadline the abandoned session is still running past it" "child=alive watchdog=none" "$(abandon_line "$NO_DEADLINE" mutant 12)"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Reshapes `skills/commit-guards/tests/terminal-paths.test.sh` to code-quality § Tests. It pinned the code paths that only exist at a terminal (`tests/lib/pty.bash`'s `gg_pty_run`, and `gg_install_file`'s `mv -f` against a read-only destination) in a 344-line script of 17 assertions, each an exit status read as a bit beside substrings, over shared fixtures each case reset. It is now two tables plus one scripted pair. Table one (`pty_rows`, `label|cap|envs|body|state|expect`): the session body is written through `printf %b`, run in a subshell exporting ENVS with the probe's own stdin holding a line, and pinned by `state=… rc=… out=…` or `unstarted err=…`; a STATE function appends tokens after ` / ` (`capped`: the recorded child's liveness and the watchdog marker). Table two (`install_rows`, `label|fixture|state|expect`): a fixture sets the lib tree, the source, a read-only `tools/dest.tsv` and the TMPDIR the probe runs under; the case file is written beside the source with the premise checks inside the session (exit 3 no terminal, exit 4 destination writable) and `REACHED $SRC` before the call, and the line ends with the destination's content, mode and staging-file count. The abandonment pair stays scripted (`abandon_line`: a runner killed mid-session, the child's liveness within a budget, the watchdog marker, the group reaped before the line returns).

Every former assertion has a row; none were deleted. Seven folded: the two `cmp` checks that a sed took (the `-f` drop and the watchdog drop: each pinned outcome is reachable only from a copy the edit took, and the reviewer's F1 and F2 prove it), the orphan pid recorded and reaped (the `child=` token has three values: unrecorded, alive, gone), mv's prompt as the cause (the no-f row's whole output), the watchdog marker (the abandonment line's `watchdog=` token), and the PWNED negative (`pwned=no`). Two rows added: a `script` shim answering neither grammar (the `unstarted` arm with what it said), and a scratch root that cannot be made (mktemp's words normalised, GNU and BSD phrase them apart). 17 - 7 + 2 = 12. The cap row also pins `watchdog=none`: on a healthy run the caller's cap fires first. The BSD half of the no-f control is pinned as what the helper does under BSD mv (it answers its prompt's EOF as no and exits 0, so the helper reads a success and leaves the staging file beside the untouched destination: `rc=0 … staged=1`), verified on a macOS box under bash 3.2.57 (12/12); the old suite skipped that half. A euid-0 run aborts once with a `harness:` line instead of failing each row.

The second and third commits: `DEVELOPMENT.md` § Probing a terminal-only code path named the deleted `pty_call`; it names `pty_line` and `install_line` now. And the prose heading row's input becomes `#### 1204` (a numeric-only heading to the end of its line), the boundary a Copilot thread on #2319 asked for, replied Tracked there.

The tracked render is replayed with `patch`. A `kendex refresh` in the main checkout after #2319 left `.kendex-generated.json` unchanged, so nothing is owed.

## Mutation

23 exact-substring mutants over `tests/lib/pty.bash` and `scripts/lib/atomic-install.sh`, each run against the final suite in a scratch copy; 18 killed, 5 recorded. The reviewer's own 35 (24 killed) are in its report; it disputed one recorded equivalence, corrected below.

| mutant | result |
|---|---|
| spawner: stdin is not /dev/null | killed by "a read from the terminal gets EOF instead of waiting" (rerun after the probe's stdin gained its here-string; the first run survived because the runner's own stdin was already /dev/null) |
| state: a capped session keeps a status | SURVIVED: no deterministic construction. The rc file is written the instant the body returns, so only a body ending within the poll's 100 ms of the cap reaches `capped` with a status; the reviewer measured 20 of 40 trials at a 2-second cap with bodies sleeping 1.995 to 2.015 s. The clause is load-bearing (the helper's header says GG_PTY_RC is empty when capped) and a row would have to win that race |
| state: a dead session is ok | killed by "control: a session that dies before its last line is gone and reports no status" |
| cap: the session's own group is not killed | killed by "control: a session that never returns is capped by the caller with its output kept, and the child it started is reaped" |
| cap: the spawner is not killed | SURVIVED: equivalent for any started session. The group kill ends the session and `script` exits on its own; the spawner kill is the fallback for a session that never recorded its group, a state no started session leaves |
| cap: the sid file is not read | killed by "control: a session that never returns is capped by the caller with its output kept, and the child it started is reaped" |
| output: the marker line is kept | killed by "stdin, stdout and stderr are all on the pty" |
| output: carriage returns are kept | killed by "stdin, stdout and stderr are all on the pty" |
| spawner: a missing marker is a session | killed by "a script answering neither grammar is no session, named with what it said" |
| spawner: the scratch failure is silent | killed by "a scratch root that cannot be made is no session, naming TMPDIR" |
| session: the status file holds 0 | killed by "control: a session's own exit status survives the spawner" |
| session: the rc file is not read | killed by "stdin, stdout and stderr are all on the pty" |
| watchdog: the deadline sits far past the cap | killed by "the session ends itself once the run that started it is gone, by its own deadline" |
| watchdog: the deadline sits before the cap | killed by "control: a session that never returns is capped by the caller with its output kept, and the child it started is reaped" |
| watchdog: no marker is written | killed by "the session ends itself once the run that started it is gone, by its own deadline" |
| watchdog: the kill takes -- (dash reads it as a pid) | SURVIVED on this host: /bin/sh is bash here; on the CI runner it is dash, where `--` is read as a pid and the abandonment row's `watchdog=fired` with `child=gone` is the kill |
| watchdog: the kill names the session pid, not its group | killed by "the session ends itself once the run that started it is gone, by its own deadline" |
| session: the group is not recorded | killed by "control: a session that never returns is capped by the caller with its output kept, and the child it started is reaped" |
| spawner: no job control for the spawner | SURVIVED: equivalent. The bare-pid fallback after the group kill ends the spawner |
| install: the rename prompts (no -f) | killed by "the install lands, and the destination keeps its mode" |
| install: the refusal drops what mv said | killed by "control: without the -f the same probe leaves the destination unreplaced, the refusal carrying mv's own prompt" |
| install: the destination's mode is not restored | killed by "the install lands, and the destination keeps its mode" |
| install: the staging file is kept after the rename | SURVIVED: equivalent here. After a successful rename the staging file no longer exists, so gg_cleanup's rm is a no-op; no terminal case can observe the clear |

8 fixture mutants (one fixture's planted element removed, the named row must fail): 7 killed, 1 a harness abort.

| fixture mutant | result |
|---|---|
| F1 no-f: the -f left in the copy | killed by "control: without the -f the same probe leaves the destination unreplaced, the refusal carrying mv's own prompt" |
| F2 hostile: a plain name instead | killed by "control: a path that is a space and a command substitution stays a path, and nothing inside it runs" (rerun after the row took the hostile name literally) |
| F3 no-deadline: the watchdog left in the copy | killed by "control: without that deadline the abandoned session is still running past it" |
| F4 dest: the destination left writable | the suite aborts with the `harness:` line naming the euid before any row is judged |
| F5 noscript: a script shim that exits 0 saying nothing | killed by "a script answering neither grammar is no session, named with what it said" |
| F6 cap: the body returns instead of hanging | killed by "control: a session that never returns is capped by the caller with its output kept, and the child it started is reaped" |
| F7 dies: the body does not kill its session | killed by "control: a session that dies before its last line is gone and reports no status" |
| F8 abandon: the runner is not killed | killed by "control: without that deadline the abandoned session is still running past it" |

## Checks

- `terminal-paths.test.sh`: 12 assertions pass on this host, under a symlinked TMPDIR, and on a macOS box (bash 3.2.57, BSD mv and script). `prose.test.sh` 63/63 after the heading row change. `tools/bash32-lint` clean.
- `tools/guard --full`: exit 0 on 7b2912f51 under TMPDIR=/tmp.
- One reviewer-test round: accept; its one suggestion (the DEVELOPMENT.md drift) is the second commit, its dispute of equivalence (a) is the corrected record above. Noted and left: the ENVS column splits on `,`, so a PATH holding a comma would misread the shim row (no shipped producer emits one); `cd %q` in the case body has no hostile-`R` fixture (the two `%q` sites a fixture drives are pinned).

KEN-1241

https://claude.ai/code/session_01Kt4SUzEL9gcpU7Pdvyhips
