### PR TITLE
test(KEN-1241): the pre-commit chain as one table of rows

### DIFF
--- a/.agents/skills/commit-guards/tests/pre-commit-chain.test.sh
+++ b/.agents/skills/commit-guards/tests/pre-commit-chain.test.sh
@@ -62,16 +62,23 @@ stub "$TMP/$FULL" bot-instructions "install bot-instructions ran" 0
 
 # One line for a run in the row's repository from the named install: the
 # exit status, then every line printed, in order, joined by ';', with the
-# row's repository aliased as <repo> and the scratch root as <root>. ENVS
-# is a comma-separated list of assignments; ARGS are passed through. The
-# batch runs one check, so its lines are one shape: its composition is
+# row's repository aliased as <repo> and the scratch root as <root>, each
+# in its physical form first (the chain prints where it resolved to, which
+# under a symlinked temp root such as macOS's /var is not the spelling the
+# fixture was built with) and then its logical one. ENVS is a
+# comma-separated list of assignments; ARGS are passed through. The batch
+# runs one check, so its lines are one shape: its composition is
 # dispatcher's subject.
 R=""
+TMP_P="$(cd "$TMP" && pwd -P)"
 run() { # ENVS INSTALL ARGS
-  local envs=() rc=0 out=""
+  local envs=() rc=0 out="" r_p
   [ -z "$1" ] || IFS=',' read -ra envs <<<"$1"
+  r_p="$(cd "$R" && pwd -P)"
   # shellcheck disable=SC2086
   out="$(cd "$R" && env COMMIT_GUARDS_CHECKS=todo-ban ${envs[@]+"${envs[@]}"} "$TMP/$2/commit-guards/scripts/pre-commit" $3 2>&1)" || rc=$?
+  out="${out//"$r_p"/<repo>}"
+  out="${out//"$TMP_P"/<root>}"
   out="${out//"$R"/<repo>}"
   out="${out//"$TMP"/<root>}"
   printf 'rc=%s%s' "$rc" "${out:+ $(printf '%s\n' "$out" | LC_ALL=C paste -sd ';' -)}"

--- a/.agents/skills/commit-guards/tests/pre-commit-chain.test.sh
+++ b/.agents/skills/commit-guards/tests/pre-commit-chain.test.sh
@@ -36,11 +36,13 @@ assert_eq() { # LABEL EXPECT ACTUAL
   fi
 }
 
-# The two installs, each in another checkout, the tests subtree cut since
-# a consumer install never carries it. The bare one sits under a skill root
+# Three installs, each in another checkout, the tests subtree cut since a
+# consumer install never carries it. The bare one sits under a skill root
 # of its checkout, so the search's project side is that checkout and the
 # skip lines name it; the full one sits outside every skill root, so its
-# three stubs are reached only through the install's own side.
+# three stubs are reached only through the install's own side; the project
+# one sits under a skill root beside a doc-limits stub, reached only
+# through the project side.
 stub() { # ROOT NAME LINE RC — a gate that proves which copy ran, and with what
   mkdir -p "$1/$2/scripts"
   printf '#!/bin/sh\necho "%s $*"\nexit %s\n' "$3" "$4" >"$1/$2/scripts/$2"
@@ -49,8 +51,11 @@ stub() { # ROOT NAME LINE RC — a gate that proves which copy ran, and with wha
 install() { mkdir -p "$1"; cp -R "$SKILL_DIR" "$1/commit-guards"; rm -rf -- "${1:?}/commit-guards/tests"; } # SKILLS-DIR
 BARE=other-checkout/skills
 FULL=other-checkout-full/vendor
+PROJ=other-checkout-project/skills
 install "$TMP/$BARE"
 install "$TMP/$FULL"
+install "$TMP/$PROJ"
+stub "$TMP/$PROJ" doc-limits "project doc-limits ran" 0
 stub "$TMP/$FULL" doc-limits "install doc-limits ran" 0
 stub "$TMP/$FULL" preflight "install preflight ran" 0
 stub "$TMP/$FULL" bot-instructions "install bot-instructions ran" 0
@@ -96,8 +101,8 @@ ROOTS=".agents/skills .claude/skills .cursor/skills .gemini/skills .github/skill
 DL="=== pre-commit: doc-limits (document byte ceilings)"
 PF="=== pre-commit: preflight"
 BOT="=== pre-commit: bot-instructions check --staged"
-# The bare install's skip line: the tree, the install's checkout, the roots, the install's own side.
-skip() { printf '=== pre-commit: %s not installed — skipped (no %s skill under <repo> and <root>/other-checkout (%s), nor at <root>/%s/commit-guards/scripts/../../%s)' "$1" "$1" "$ROOTS" "$BARE" "$1"; } # LANE
+# A skip line: the tree, the install's checkout, the roots, the install's own side.
+skip() { printf '=== pre-commit: %s not installed — skipped (no %s skill under <repo> and <root>/%s (%s), nor at <root>/%s/skills/commit-guards/scripts/../../%s)' "$1" "$1" "${2:-other-checkout}" "$ROOTS" "${2:-other-checkout}" "$1"; } # LANE [CHECKOUT]
 SKIPS="$(skip doc-limits);$(skip preflight);$(skip bot-instructions)"
 BATCH="=== pre-commit: commit-guards all --staged;=== commit-guards: todo-ban --staged"
 BATCH_OK="$BATCH;todo-ban: OK — the staged diff adds no work markers;commit-guards: OK — enabled checks clean (todo-ban)"
@@ -129,16 +134,20 @@ fx_tree_two() { repo tree-two; tree doc-limits "worktree doc-limits ran" 0; ROOT
 fx_tree_fails() { repo tree-fails; tree doc-limits "doc-limits: staged violation" 1; }
 fx_tree_one() { repo tree-one; tree doc-limits "worktree doc-limits ran" 0; }
 fx_tree_none() { repo tree-none; }
+fx_tree_over_project() { repo tree-over-project; tree doc-limits "worktree doc-limits ran" 0; }
+fx_project() { repo project; }
 fx_tree_bot_fails() { repo tree-bot-fails; tree bot-instructions "bot-instructions: AGENTS.md differs from a fresh render" 1; }
-fx_tree_bot_broken() { repo tree-bot-broken; mkdir -p "$R/.agents/skills/bot-instructions/scripts"; }
+fx_tree_bot_broken() { repo tree-bot-broken; tree bot-instructions "never runs" 0; chmod -x "$R/.agents/skills/bot-instructions/scripts/bot-instructions"; }
 fx_absent() { repo absent; }
 run_rows \
   "the tree's doc-limits and preflight run, each under its own root, from an install carrying neither, and the third lane is a stated skip|fx_tree_two||$BARE||rc=0 $DL;worktree doc-limits ran --staged;$PF;worktree preflight ran --staged;$(skip bot-instructions);$BATCH_OK;$LOCAL_NONE;$CHAIN_OK" \
   "a failing tree-carried gate blocks with its own line in front of the committer|fx_tree_fails||$BARE||rc=1 $DL;doc-limits: staged violation --staged;$(skip preflight);$(skip bot-instructions);$BATCH_OK;$LOCAL_NONE;$BLOCKED" \
   "the tree's copy outranks the install's, and the siblings the tree lacks still come from the install|fx_tree_one||$FULL||rc=0 $DL;worktree doc-limits ran --staged;$PF;install preflight ran --staged;$BOT;install bot-instructions ran check --staged;$BATCH_OK;$LOCAL_NONE;$CHAIN_OK" \
   "a tree carrying no sibling gets all three from the install|fx_tree_none||$FULL||rc=0 $DL;install doc-limits ran --staged;$PF;install preflight ran --staged;$BOT;install bot-instructions ran check --staged;$BATCH_OK;$LOCAL_NONE;$CHAIN_OK" \
+  "the tree's copy outranks the one under the install's project root: the re-vendor rule|fx_tree_over_project||$PROJ||rc=0 $DL;worktree doc-limits ran --staged;$(skip preflight other-checkout-project);$(skip bot-instructions other-checkout-project);$BATCH_OK;$LOCAL_NONE;$CHAIN_OK" \
+  "control: a tree carrying none gets the project root's copy|fx_project||$PROJ||rc=0 $DL;project doc-limits ran --staged;$(skip preflight other-checkout-project);$(skip bot-instructions other-checkout-project);$BATCH_OK;$LOCAL_NONE;$CHAIN_OK" \
   "a failing tree-carried bot-instructions check blocks under its own announcement|fx_tree_bot_fails||$BARE||rc=1 $(skip doc-limits);$(skip preflight);$BOT;bot-instructions: AGENTS.md differs from a fresh render check --staged;$BATCH_OK;$LOCAL_NONE;$BLOCKED" \
-  "a tree-carried bot-instructions skill without a runnable script is a broken install, never a skip|fx_tree_bot_broken||$BARE||rc=2 $(skip doc-limits);$(skip preflight);$(broken bot-instructions)" \
+  "a tree-carried bot-instructions skill whose script is not executable is a broken install, never a skip|fx_tree_bot_broken||$BARE||rc=2 $(skip doc-limits);$(skip preflight);$(broken bot-instructions)" \
   "absence on both sides is a stated skip naming both probed sides and every root, and the chain passes|fx_absent||$BARE||rc=0 $SKIPS;$BATCH_OK;$LOCAL_NONE;$CHAIN_OK"
 
 echo "=== every step runs before the verdict, and could-not-complete outranks violations ==="
@@ -153,14 +162,12 @@ fx_local_ran() { repo local-ran; local_entry '#!/bin/sh\necho "repo-local check 
 fx_local_fails() { repo local-fails; local_entry '#!/bin/sh\necho "repo-local: nope"\nexit 1\n'; }
 fx_local_dies() { repo local-dies; local_entry '#!/bin/sh\necho "repo-local check died"\nexit 2\n'; }
 fx_local_unexecutable() { repo local-unexecutable; local_entry '#!/bin/sh\nexit 0\n'; chmod -x "$R/tools/local-check"; }
-fx_local_missing() { repo local-missing; }
 LOCAL_ENV=COMMIT_GUARDS_PRE_COMMIT_LOCAL=tools/local-check
 run_rows \
   "a configured entry announces itself in place of the none line, runs, and passes|fx_local_ran|$LOCAL_ENV|$BARE||rc=0 $SKIPS;$BATCH_OK;$LOCAL;repo-local check ran;$CHAIN_OK" \
   "its violation blocks|fx_local_fails|$LOCAL_ENV|$BARE||rc=1 $SKIPS;$BATCH_OK;$LOCAL;repo-local: nope;$BLOCKED" \
   "its status past 1 is a step that did not complete|fx_local_dies|$LOCAL_ENV|$BARE||rc=2 $SKIPS;$BATCH_OK;$LOCAL;repo-local check died;$(incomplete 'repo-local: tools/local-check' 2);$ERRORS" \
-  "an entry that is not executable is a config error naming it, after the batch ran|fx_local_unexecutable|$LOCAL_ENV|$BARE||rc=2 $SKIPS;$BATCH_OK;${ERR}COMMIT_GUARDS_PRE_COMMIT_LOCAL names 'tools/local-check', which is missing or not executable" \
-  "a missing entry is the same config error|fx_local_missing|$LOCAL_ENV|$BARE||rc=2 $SKIPS;$BATCH_OK;${ERR}COMMIT_GUARDS_PRE_COMMIT_LOCAL names 'tools/local-check', which is missing or not executable"
+  "an entry that is not executable is a config error naming it, after the batch ran|fx_local_unexecutable|$LOCAL_ENV|$BARE||rc=2 $SKIPS;$BATCH_OK;${ERR}COMMIT_GUARDS_PRE_COMMIT_LOCAL names 'tools/local-check', which is missing or not executable"
 
 echo "=== the batch runs at commit scope: a marker the commit does not add belongs to CI ==="
 # The fixture proves its marker landed in HEAD: a row over a repository
@@ -171,6 +178,10 @@ marker_committed() { # NAME
   git -C "$R" add fixture.rs
   git -C "$R" commit -qm 'chore: fixture'
   git -C "$R" grep -q -- "$TD" HEAD -- fixture.rs || { echo "harness: $1: the committed marker is not in HEAD" >&2; exit 2; }
+  # A staged file of its own, so the pass is the chain judging content
+  # rather than an empty diff finding nothing to judge.
+  printf 'fn main() {}\n' >"$R/clean.rs"
+  git -C "$R" add clean.rs
 }
 fx_untouched_marker() { marker_committed untouched-marker; }
 fx_added_marker() { marker_committed added-marker; printf '// %s: added by this commit\n' "$TD" >>"$R/b.txt"; git -C "$R" add b.txt; }

--- a/.agents/skills/commit-guards/tests/pre-commit-chain.test.sh
+++ b/.agents/skills/commit-guards/tests/pre-commit-chain.test.sh
@@ -1,22 +1,24 @@
 #!/usr/bin/env bash
-# Pins for the pre-commit chain's lane resolution and announcements: sibling
-# gates resolve from the COMMITTING work tree before the install the shim
-# execs (linked worktrees share one hooks directory, so that install can live
-# in another checkout whose branch state says nothing about this commit), a
-# genuine double absence is a stated skip naming both probed sides, and the
-# repo-local lane announces itself even when nothing is configured, and the
-# batch runs at commit scope so a marker the commit does not add belongs to
-# CI, not to this commit. Every firing pin is paired with the control that
-# proves the fixture, not the chain, would otherwise pass.
+# Pins for scripts/pre-commit, the chain as the installed shim runs it:
+# which copy of each sibling gate runs (the committing work tree's first,
+# then the install's own, which may sit in another checkout since linked
+# worktrees share one hooks directory), the announcement every lane makes,
+# ran or skipped, run_step's three statuses folded into one verdict that
+# fails closed, the repo-local entry, and the batch at commit scope. One
+# table: a row builds its own repository, runs the chain from one of two
+# shared installs in another checkout — one carrying no sibling, one
+# carrying three stubs that say which copy ran — and reads back the exit
+# status with every line printed. The shim's rediscovery, the project-root
+# and awkward-name searches, the real doc-limits and preflight lanes with
+# their forks and dangling installs, and the first-commit skip are the
+# install-git-hooks suites'; the batch's own lines are dispatcher's.
 set -euo pipefail
-
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+# shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
-
-unset COMMIT_GUARDS_CHECKS COMMIT_GUARDS_PRE_COMMIT_LOCAL \
-  COMMIT_GUARDS_SETTINGS_FILE GG_TMP GG_SETTINGS_INDEX_OWNED \
-  GG_SETTINGS_INDEX_DIR GG_SETTINGS_FROM_INDEX 2>/dev/null || true
+unset COMMIT_GUARDS_CHECKS COMMIT_GUARDS_PRE_COMMIT_LOCAL COMMIT_GUARDS_SETTINGS_FILE \
+  GG_TMP GG_SETTINGS_INDEX_OWNED GG_SETTINGS_INDEX_DIR GG_SETTINGS_FROM_INDEX 2>/dev/null || true
 
 # Assembled from split tokens so this file carries no marker shape of its
 # own: the kendex repo runs todo-ban over its own tree, tests included.
@@ -24,377 +26,167 @@ TD="TO""DO"
 
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
-
-# The chain as a linked worktree runs it: the shim execs a commit-guards
-# install in ANOTHER checkout, so SCRIPT_DIR sits outside the committing work
-# tree and install-relative siblings are that checkout's, not this one's.
-# This install carries NO siblings at all.
-BARE_INSTALL="$TMP/other-checkout/skills"
-mkdir -p "$BARE_INSTALL"
-cp -R "$SKILL_DIR" "$BARE_INSTALL/commit-guards"
-PC="$BARE_INSTALL/commit-guards/scripts/pre-commit"
-
-# A second shared install that DOES carry both siblings, for the fallback and
-# precedence pins.
-FULL_INSTALL="$TMP/other-checkout-full/skills"
-mkdir -p "$FULL_INSTALL"
-cp -R "$SKILL_DIR" "$FULL_INSTALL/commit-guards"
-PC_FULL="$FULL_INSTALL/commit-guards/scripts/pre-commit"
-
-fake_skill() { # ROOT NAME MARKER RC — a gate that proves which copy ran
-  local d="$1/$2"
-  mkdir -p "$d/scripts"
-  printf '#!/bin/sh\necho "%s"\nexit %s\n' "$3" "$4" >"$d/scripts/$2"
-  chmod +x "$d/scripts/$2"
-}
-fake_skill "$FULL_INSTALL" doc-limits "install doc-limits ran" 0
-fake_skill "$FULL_INSTALL" preflight "install preflight ran" 0
-fake_skill "$FULL_INSTALL" bot-instructions "install bot-instructions ran" 0
-
-new_repo() { # NAME -> repo path on stdout; seeded, with one file staged
-  local r="$TMP/$1"
-  mkdir -p "$r"
-  git -C "$r" -c init.defaultBranch=main init -q
-  git -C "$r" config user.email test@example.com
-  git -C "$r" config user.name test
-  printf '[]\n' >"$r/.kendex-generated.json"
-  git -C "$r" add .kendex-generated.json
-  printf 'hello\n' >"$r/a.txt"
-  git -C "$r" add a.txt
-  git -C "$r" commit -qm 'feat: seed'
-  printf 'more\n' >"$r/b.txt"
-  git -C "$r" add b.txt
-  printf '%s' "$r"
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
 }
 
-echo "=== the committing work tree's sibling gates outrank an install that has none ==="
-R1="$(new_repo tree-wins)"
-fake_skill "$R1/.agents/skills" doc-limits "worktree doc-limits ran" 0
-fake_skill "$R1/.agents/skills" preflight "worktree preflight ran" 0
-RC=0
-OUT="$(cd "$R1" && "$PC" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "control: the chain passes on the tree's own gates" \
-  || bad "chain passes on tree-carried gates" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"worktree doc-limits ran"*) ok "the tree's doc-limits is the one that ran" ;;
-  *) bad "tree doc-limits ran" "out=$OUT" ;;
-esac
-case "$OUT" in
-  *"worktree preflight ran"*) ok "the tree's preflight is the one that ran" ;;
-  *) bad "tree preflight ran" "out=$OUT" ;;
-esac
-case "$OUT" in
-  *"doc-limits not installed"* | *"preflight not installed"*)
-    bad "no lane reports the gates as absent" "out=$OUT" ;;
-  *) ok "no lane reports the gates as absent" ;;
-esac
+# The two installs, each in another checkout, the tests subtree cut since
+# a consumer install never carries it. The bare one sits under a skill root
+# of its checkout, so the search's project side is that checkout and the
+# skip lines name it; the full one sits outside every skill root, so its
+# three stubs are reached only through the install's own side.
+stub() { # ROOT NAME LINE RC — a gate that proves which copy ran, and with what
+  mkdir -p "$1/$2/scripts"
+  printf '#!/bin/sh\necho "%s $*"\nexit %s\n' "$3" "$4" >"$1/$2/scripts/$2"
+  chmod +x "$1/$2/scripts/$2"
+}
+install() { mkdir -p "$1"; cp -R "$SKILL_DIR" "$1/commit-guards"; rm -rf -- "${1:?}/commit-guards/tests"; } # SKILLS-DIR
+BARE=other-checkout/skills
+FULL=other-checkout-full/vendor
+install "$TMP/$BARE"
+install "$TMP/$FULL"
+stub "$TMP/$FULL" doc-limits "install doc-limits ran" 0
+stub "$TMP/$FULL" preflight "install preflight ran" 0
+stub "$TMP/$FULL" bot-instructions "install bot-instructions ran" 0
 
-echo "=== a failing tree-carried gate blocks even when the install has no sibling ==="
-R2="$(new_repo tree-gates)"
-fake_skill "$R2/.agents/skills" doc-limits "doc-limits: staged violation" 1
-RC=0
-OUT="$(cd "$R2" && "$PC" 2>&1)" || RC=$?
-[ "$RC" -eq 1 ] && ok "the tree's doc-limits verdict blocks (exit 1)" \
-  || bad "tree doc-limits verdict blocks" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"doc-limits: staged violation"*) ok "the gate's own output reaches the committer" ;;
-  *) bad "gate output reaches the committer" "out=$OUT" ;;
-esac
+# One line for a run in the row's repository from the named install: the
+# exit status, then every line printed, in order, joined by ';', with the
+# row's repository aliased as <repo> and the scratch root as <root>. ENVS
+# is a comma-separated list of assignments; ARGS are passed through. The
+# batch runs one check, so its lines are one shape: its composition is
+# dispatcher's subject.
+R=""
+run() { # ENVS INSTALL ARGS
+  local envs=() rc=0 out=""
+  [ -z "$1" ] || IFS=',' read -ra envs <<<"$1"
+  # shellcheck disable=SC2086
+  out="$(cd "$R" && env COMMIT_GUARDS_CHECKS=todo-ban ${envs[@]+"${envs[@]}"} "$TMP/$2/commit-guards/scripts/pre-commit" $3 2>&1)" || rc=$?
+  out="${out//"$R"/<repo>}"
+  out="${out//"$TMP"/<root>}"
+  printf 'rc=%s%s' "$rc" "${out:+ $(printf '%s\n' "$out" | LC_ALL=C paste -sd ';' -)}"
+}
 
-echo "=== the tree's copy outranks the install's copy (re-vendor gating) ==="
-R3="$(new_repo tree-over-install)"
-fake_skill "$R3/.agents/skills" doc-limits "worktree doc-limits ran" 0
-RC=0
-OUT="$(cd "$R3" && "$PC_FULL" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "control: the chain passes" || bad "precedence chain passes" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"worktree doc-limits ran"*) ok "the tree's doc-limits wins" ;;
-  *) bad "tree doc-limits wins" "out=$OUT" ;;
-esac
-case "$OUT" in
-  *"install doc-limits ran"*) bad "the install's doc-limits must not also run" "out=$OUT" ;;
-  *) ok "the install's doc-limits did not run" ;;
-esac
-case "$OUT" in
-  *"install preflight ran"*) ok "a sibling the tree lacks still comes from the install" ;;
-  *) bad "install preflight fallback" "out=$OUT" ;;
-esac
+# Fixture vocabulary. Every repository is seeded (preflight --staged has a
+# base) with one clean file staged; a name used twice is refused.
+repo() { # NAME
+  R="$TMP/$1"
+  [ ! -e "$R" ] || { echo "harness: fixture $1 already exists" >&2; exit 2; }
+  mkdir -p "$R"
+  git -C "$R" -c init.defaultBranch=main init -q
+  git -C "$R" config user.email test@example.com
+  git -C "$R" config user.name test
+  printf '[]\n' >"$R/.kendex-generated.json"
+  printf 'hello\n' >"$R/a.txt"
+  git -C "$R" add -A
+  git -C "$R" commit -qm 'feat: seed'
+  printf 'more\n' >"$R/b.txt"
+  git -C "$R" add b.txt
+}
+tree() { stub "$R/${ROOT:-.agents/skills}" "$@"; } # NAME LINE RC — a sibling the committing tree carries, under ROOT
+local_entry() { mkdir -p "$R/tools"; printf '%b' "$1" >"$R/tools/local-check"; chmod +x "$R/tools/local-check"; } # BODY
 
-echo "=== a tree carrying no siblings still gets the install's gates ==="
-R4="$(new_repo install-fallback)"
-RC=0
-OUT="$(cd "$R4" && "$PC_FULL" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "control: the chain passes on the install's gates" \
-  || bad "chain passes on install gates" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"install doc-limits ran"*) ok "the install's doc-limits ran" ;;
-  *) bad "install doc-limits ran" "out=$OUT" ;;
-esac
-case "$OUT" in
-  *"install preflight ran"*) ok "the install's preflight ran" ;;
-  *) bad "install preflight ran" "out=$OUT" ;;
-esac
-case "$OUT" in
-  *"install bot-instructions ran"*) ok "the install's bot-instructions check ran" ;;
-  *) bad "install bot-instructions ran" "out=$OUT" ;;
-esac
+# The lines the chain prints, as functions of what a row put in.
+ROOTS=".agents/skills .claude/skills .cursor/skills .gemini/skills .github/skills .opencode/skills skills"
+DL="=== pre-commit: doc-limits (document byte ceilings)"
+PF="=== pre-commit: preflight"
+BOT="=== pre-commit: bot-instructions check --staged"
+# The bare install's skip line: the tree, the install's checkout, the roots, the install's own side.
+skip() { printf '=== pre-commit: %s not installed — skipped (no %s skill under <repo> and <root>/other-checkout (%s), nor at <root>/%s/commit-guards/scripts/../../%s)' "$1" "$1" "$ROOTS" "$BARE" "$1"; } # LANE
+SKIPS="$(skip doc-limits);$(skip preflight);$(skip bot-instructions)"
+BATCH="=== pre-commit: commit-guards all --staged;=== commit-guards: todo-ban --staged"
+BATCH_OK="$BATCH;todo-ban: OK — the staged diff adds no work markers;commit-guards: OK — enabled checks clean (todo-ban)"
+LOCAL_NONE="=== pre-commit: repo-local entry: none configured"
+LOCAL="=== pre-commit: repo-local: tools/local-check"
+CHAIN_OK="pre-commit: OK — staged guard chain clean"
+BLOCKED="pre-commit: violations — commit blocked; see the failures above"
+# The verdict names git's bypass flag; assembled from split tokens so this
+# file never carries the flag itself.
+ERRORS="pre-commit: a guard could not complete — commit blocked; fix the errors above (bypass only with git commit --no-""verify)"
+incomplete() { printf "pre-commit: step '%s' did not complete (exit %s)" "$1" "$2"; } # LABEL STATUS
+ERR="::error::pre-commit: "
+broken() { printf '%sthe %s skill is installed at <repo>/.agents/skills/%s but <repo>/.agents/skills/%s/scripts/%s is missing or not executable — reinstall it' "$ERR" "$1" "$1" "$1" "$1"; } # SKILL
 
-echo "=== a failing tree-carried bot-instructions check blocks ==="
-RBOT="$(new_repo tree-bot-check)"
-fake_skill "$RBOT/.agents/skills" bot-instructions "bot-instructions: AGENTS.md differs from a fresh render" 1
-RC=0
-OUT="$(cd "$RBOT" && "$PC" 2>&1)" || RC=$?
-[ "$RC" -eq 1 ] && ok "the tree's bot-instructions verdict blocks (exit 1)" \
-  || bad "tree bot-instructions verdict blocks" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"=== pre-commit: bot-instructions check --staged"*) ok "the lane announces itself" ;;
-  *) bad "bot-instructions lane announces itself" "out=$OUT" ;;
-esac
+# The table: label | fixture | env | install | args | expect.
+run_rows() {
+  local row label fx env inst args expect
+  for row in "$@"; do
+    IFS='|' read -r label fx env inst args expect <<<"$row"
+    [ -n "$expect" ] || { echo "harness: row has fewer than six fields: $row" >&2; exit 2; }
+    R=""
+    "$fx"
+    assert_eq "$label" "$expect" "$(run "$env" "$inst" "$args")"
+  done
+}
 
-echo "=== genuine absence on both sides is a stated skip naming both probes ==="
-R5="$(new_repo double-absence)"
-RC=0
-OUT="$(cd "$R5" && "$PC" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "an absent gate skill stays a pass (exit 0)" \
-  || bad "absent gates stay exit 0" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"doc-limits not installed — skipped (no doc-limits skill under "*)
-    ok "the doc-limits skip names the work-tree probe" ;;
-  *) bad "doc-limits skip names the tree probe" "out=$OUT" ;;
-esac
-# Derived, not restated: this would carry its own copy of the list and so
-# pinned the shape of a message rather than the roots actually probed —
-# which is how it went on passing while the list it named was stale.
-# shellcheck source=../scripts/lib/skill-roots.sh
-. "$SKILL_DIR/scripts/lib/skill-roots.sh"
-case "$OUT" in
-  *"($GG_SKILL_ROOTS)"*)
-    ok "the skip names every probed skills root" ;;
-  *) bad "skip names the probed roots" "out=$OUT" ;;
-esac
-case "$OUT" in
-  *"nor at $BARE_INSTALL/commit-guards/scripts/../../doc-limits)"*)
-    ok "the doc-limits skip names the install probe" ;;
-  *) bad "doc-limits skip names the install probe" "out=$OUT" ;;
-esac
-case "$OUT" in
-  *"preflight not installed — skipped (no preflight skill under "*)
-    ok "the preflight skip names the work-tree probe" ;;
-  *) bad "preflight skip names the tree probe" "out=$OUT" ;;
-esac
-case "$OUT" in
-  *"nor at $BARE_INSTALL/commit-guards/scripts/../../preflight)"*)
-    ok "the preflight skip names the install probe" ;;
-  *) bad "preflight skip names the install probe" "out=$OUT" ;;
-esac
-case "$OUT" in
-  *"bot-instructions not installed — skipped (no bot-instructions skill under "*)
-    ok "the bot-instructions skip names the work-tree probe" ;;
-  *) bad "bot-instructions skip names the tree probe" "out=$OUT" ;;
-esac
+echo "=== the committing tree's copy of a sibling gate runs; the install's serves only a tree without one ==="
+fx_tree_two() { repo tree-two; tree doc-limits "worktree doc-limits ran" 0; ROOT=.github/skills tree preflight "worktree preflight ran" 0; }
+fx_tree_fails() { repo tree-fails; tree doc-limits "doc-limits: staged violation" 1; }
+fx_tree_one() { repo tree-one; tree doc-limits "worktree doc-limits ran" 0; }
+fx_tree_none() { repo tree-none; }
+fx_tree_bot_fails() { repo tree-bot-fails; tree bot-instructions "bot-instructions: AGENTS.md differs from a fresh render" 1; }
+fx_tree_bot_broken() { repo tree-bot-broken; mkdir -p "$R/.agents/skills/bot-instructions/scripts"; }
+fx_absent() { repo absent; }
+run_rows \
+  "the tree's doc-limits and preflight run, each under its own root, from an install carrying neither, and the third lane is a stated skip|fx_tree_two||$BARE||rc=0 $DL;worktree doc-limits ran --staged;$PF;worktree preflight ran --staged;$(skip bot-instructions);$BATCH_OK;$LOCAL_NONE;$CHAIN_OK" \
+  "a failing tree-carried gate blocks with its own line in front of the committer|fx_tree_fails||$BARE||rc=1 $DL;doc-limits: staged violation --staged;$(skip preflight);$(skip bot-instructions);$BATCH_OK;$LOCAL_NONE;$BLOCKED" \
+  "the tree's copy outranks the install's, and the siblings the tree lacks still come from the install|fx_tree_one||$FULL||rc=0 $DL;worktree doc-limits ran --staged;$PF;install preflight ran --staged;$BOT;install bot-instructions ran check --staged;$BATCH_OK;$LOCAL_NONE;$CHAIN_OK" \
+  "a tree carrying no sibling gets all three from the install|fx_tree_none||$FULL||rc=0 $DL;install doc-limits ran --staged;$PF;install preflight ran --staged;$BOT;install bot-instructions ran check --staged;$BATCH_OK;$LOCAL_NONE;$CHAIN_OK" \
+  "a failing tree-carried bot-instructions check blocks under its own announcement|fx_tree_bot_fails||$BARE||rc=1 $(skip doc-limits);$(skip preflight);$BOT;bot-instructions: AGENTS.md differs from a fresh render check --staged;$BATCH_OK;$LOCAL_NONE;$BLOCKED" \
+  "a tree-carried bot-instructions skill without a runnable script is a broken install, never a skip|fx_tree_bot_broken||$BARE||rc=2 $(skip doc-limits);$(skip preflight);$(broken bot-instructions)" \
+  "absence on both sides is a stated skip naming both probed sides and every root, and the chain passes|fx_absent||$BARE||rc=0 $SKIPS;$BATCH_OK;$LOCAL_NONE;$CHAIN_OK"
 
-echo "=== a tree-carried skill without a runnable script blocks, never skips ==="
-R6="$(new_repo broken-tree-sibling)"
-mkdir -p "$R6/.agents/skills/doc-limits/scripts"
-RC=0
-OUT="$(cd "$R6" && "$PC" 2>&1)" || RC=$?
-[ "$RC" -eq 2 ] && ok "a present-but-broken tree sibling exits 2 (could not complete)" \
-  || bad "broken tree sibling exits 2" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"doc-limits skill is installed at"*) ok "the broken install is named" ;;
-  *) bad "broken install is named" "out=$OUT" ;;
-esac
+echo "=== every step runs before the verdict, and could-not-complete outranks violations ==="
+fx_both() { repo both; tree doc-limits "doc-limits: staged violation" 1; tree preflight "preflight died" 2; }
+fx_bot_dies() { repo bot-dies; tree bot-instructions "bot died" 3; }
+run_rows \
+  "a violation and a step that did not complete both print, every later lane still runs, and the verdict is the error's|fx_both||$BARE||rc=2 $DL;doc-limits: staged violation --staged;$PF;preflight died --staged;$(incomplete preflight 2);$(skip bot-instructions);$BATCH_OK;$LOCAL_NONE;$ERRORS" \
+  "a status past 1 is a step that did not complete, with its status|fx_bot_dies||$BARE||rc=2 $(skip doc-limits);$(skip preflight);$BOT;bot died check --staged;$(incomplete 'bot-instructions check --staged' 3);$BATCH_OK;$LOCAL_NONE;$ERRORS"
 
-echo "=== the repo-local lane announces itself even with nothing configured ==="
-R7="$(new_repo local-unconfigured)"
-RC=0
-OUT="$(cd "$R7" && "$PC" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "an unconfigured repo-local lane stays a pass (exit 0)" \
-  || bad "unconfigured local lane exits 0" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"=== pre-commit: repo-local entry: none configured"*)
-    ok "the lane states that none is configured" ;;
-  *) bad "none-configured line printed" "out=$OUT" ;;
-esac
+echo "=== the repo-local entry: announced, run last, and its status folded like every lane's ==="
+fx_local_ran() { repo local-ran; local_entry '#!/bin/sh\necho "repo-local check ran"\nexit 0\n'; }
+fx_local_fails() { repo local-fails; local_entry '#!/bin/sh\necho "repo-local: nope"\nexit 1\n'; }
+fx_local_dies() { repo local-dies; local_entry '#!/bin/sh\necho "repo-local check died"\nexit 2\n'; }
+fx_local_unexecutable() { repo local-unexecutable; local_entry '#!/bin/sh\nexit 0\n'; chmod -x "$R/tools/local-check"; }
+fx_local_missing() { repo local-missing; }
+LOCAL_ENV=COMMIT_GUARDS_PRE_COMMIT_LOCAL=tools/local-check
+run_rows \
+  "a configured entry announces itself in place of the none line, runs, and passes|fx_local_ran|$LOCAL_ENV|$BARE||rc=0 $SKIPS;$BATCH_OK;$LOCAL;repo-local check ran;$CHAIN_OK" \
+  "its violation blocks|fx_local_fails|$LOCAL_ENV|$BARE||rc=1 $SKIPS;$BATCH_OK;$LOCAL;repo-local: nope;$BLOCKED" \
+  "its status past 1 is a step that did not complete|fx_local_dies|$LOCAL_ENV|$BARE||rc=2 $SKIPS;$BATCH_OK;$LOCAL;repo-local check died;$(incomplete 'repo-local: tools/local-check' 2);$ERRORS" \
+  "an entry that is not executable is a config error naming it, after the batch ran|fx_local_unexecutable|$LOCAL_ENV|$BARE||rc=2 $SKIPS;$BATCH_OK;${ERR}COMMIT_GUARDS_PRE_COMMIT_LOCAL names 'tools/local-check', which is missing or not executable" \
+  "a missing entry is the same config error|fx_local_missing|$LOCAL_ENV|$BARE||rc=2 $SKIPS;$BATCH_OK;${ERR}COMMIT_GUARDS_PRE_COMMIT_LOCAL names 'tools/local-check', which is missing or not executable"
 
-echo "=== a configured repo-local entry still runs, announces, and suppresses the none line ==="
-R8="$(new_repo local-configured)"
-mkdir -p "$R8/tools"
-printf '#!/bin/sh\necho "repo-local check ran"\nexit 0\n' >"$R8/tools/local-check"
-chmod +x "$R8/tools/local-check"
-RC=0
-OUT="$(cd "$R8" && COMMIT_GUARDS_PRE_COMMIT_LOCAL=tools/local-check "$PC" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "control: a passing entry keeps the chain green" \
-  || bad "configured local entry passes" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"=== pre-commit: repo-local: tools/local-check"*) ok "the configured lane announces its entry" ;;
-  *) bad "configured lane announces" "out=$OUT" ;;
-esac
-case "$OUT" in
-  *"repo-local check ran"*) ok "the entry actually ran" ;;
-  *) bad "configured entry ran" "out=$OUT" ;;
-esac
-case "$OUT" in
-  *"repo-local entry: none configured"*)
-    bad "the none-configured line must not appear beside a configured entry" "out=$OUT" ;;
-  *) ok "the none-configured line stays out of the configured lane" ;;
-esac
+echo "=== the batch runs at commit scope: a marker the commit does not add belongs to CI ==="
+# The fixture proves its marker landed in HEAD: a row over a repository
+# without one passes for the wrong reason.
+marker_committed() { # NAME
+  repo "$1"
+  printf '// %s: left in a fixture\n' "$TD" >"$R/fixture.rs"
+  git -C "$R" add fixture.rs
+  git -C "$R" commit -qm 'chore: fixture'
+  git -C "$R" grep -q -- "$TD" HEAD -- fixture.rs || { echo "harness: $1: the committed marker is not in HEAD" >&2; exit 2; }
+}
+fx_untouched_marker() { marker_committed untouched-marker; }
+fx_added_marker() { marker_committed added-marker; printf '// %s: added by this commit\n' "$TD" >>"$R/b.txt"; git -C "$R" add b.txt; }
+HIT="todo-ban FAIL work marker: b.txt:2:// $TD: added by this commit;  remedies: do the work now, or move it to the tracker and delete the marker; vendored/generated trees belong in tools/todo-ban-excludes with a reason;todo-ban: 1 work marker(s) added by the staged diff — excludes tools/todo-ban-excludes;commit-guards: violations — see the failures above"
+run_rows \
+  "a marker committed earlier and untouched is not this commit's: the staged file is clean and the chain passes|fx_untouched_marker||$BARE||rc=0 $SKIPS;$BATCH_OK;$LOCAL_NONE;$CHAIN_OK" \
+  "control: a marker this commit adds blocks it at its line|fx_added_marker||$BARE||rc=1 $SKIPS;$BATCH;$HIT;$LOCAL_NONE;$BLOCKED"
 
-echo "=== a project below the git top level finds its own siblings ==="
-# kendex renders into the PROJECT's root, and a repository can hold several.
-# git runs a hook from the WORK TREE root, so every search anchored there
-# looked past a nested project entirely: the sibling gates were beside the
-# installed copy and nowhere near $PWD. A gate that is not found is a gate
-# that reports nothing, and the chain exited 0 while preflight failed.
-R80="$TMP/nested"
-mkdir -p "$R80/apps/web/.agents/skills" "$R80/apps/web/.github/skills"
-git -C "$R80" init -q
-git -C "$R80" config user.email t@t
-git -C "$R80" config user.name t
-cp -R "$SKILL_DIR" "$R80/apps/web/.agents/skills/commit-guards"
-
-# Under a DIFFERENT root of the same project, so the pin needs the project
-# anchor and the full root list at once.
-mkdir -p "$R80/apps/web/.github/skills/preflight/scripts"
-cat >"$R80/apps/web/.github/skills/preflight/scripts/preflight" <<'PREFLIGHT'
-#!/bin/sh
-echo "preflight: refusing this commit"
-exit 1
-PREFLIGHT
-chmod +x "$R80/apps/web/.github/skills/preflight/scripts/preflight"
-
-# A base commit before arming: preflight compares against one and announces
-# a skip without it, which would pass this pin for the wrong reason.
-printf 'hello\n' >"$R80/a.txt"
-git -C "$R80" add -A
-git -C "$R80" commit -q -m "feat: base"
-"$R80/apps/web/.agents/skills/commit-guards/scripts/install-git-hooks" \
-  --repo "$R80" >/dev/null 2>&1
-
-printf 'more\n' >"$R80/b.txt"
-git -C "$R80" add -A
-OUT=""; RC=0
-OUT="$(cd "$R80" && git commit -m "feat: nested" 2>&1)" || RC=$?
-case "$OUT" in
-  *"preflight: refusing this commit"*)
-    ok "the chain ran the nested project's preflight" ;;
-  *"preflight not installed"*)
-    bad "the nested preflight was never found" "$OUT" ;;
-  *) bad "preflight neither ran nor announced a skip" "$OUT" ;;
-esac
-[ "$RC" -ne 0 ] && ok "and its failure fails the commit" \
-  || bad "nested sibling failed and the commit passed" "rc=$RC out=$OUT"
-
-echo "=== a project directory whose name ends in a newline ==="
-# `$(...)` strips trailing newlines, and a directory name may end in one. The
-# PROJECT root is the path that matters: it is derived from where this script
-# lives, handed back to a caller, made relative, baked into the helper and
-# read again by the chain. Every one of those was a capture, and a capture
-# lost the last byte — so the sibling search looked under a directory that is
-# not there, announced the gate as not installed, and the commit passed while
-# the gate would have failed it.
-NL="$TMP/nlrepo"
-mkdir -p "$NL"
-git -C "$NL" init -q
-git -C "$NL" config user.email t@t
-git -C "$NL" config user.name t
-# The project directory itself ends in a newline.
-PROJ="$NL/web
-"
-mkdir -p "$PROJ/.agents/skills" "$PROJ/.github/skills"
-cp -R "$SKILL_DIR" "$PROJ/.agents/skills/commit-guards"
-mkdir -p "$PROJ/.github/skills/preflight/scripts"
-cat >"$PROJ/.github/skills/preflight/scripts/preflight" <<'PREFLIGHT'
-#!/bin/sh
-echo "preflight: refusing this commit"
-exit 1
-PREFLIGHT
-chmod +x "$PROJ/.github/skills/preflight/scripts/preflight"
-
-printf 'hello\n' >"$NL/a.txt"
-git -C "$NL" add -A
-git -C "$NL" commit -q -m "feat: base"
-OUT=""; RC=0
-OUT="$("$PROJ/.agents/skills/commit-guards/scripts/install-git-hooks" --repo "$NL" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "the install resolves a newline-terminated project" \
-  || bad "install under a newline-named project" "rc=$RC out=$OUT"
-
-printf 'more\n' >"$NL/b.txt"
-git -C "$NL" add -A
-OUT=""; RC=0
-OUT="$(cd "$NL" && git commit -m "feat: nl" 2>&1)" || RC=$?
-case "$OUT" in
-  *"preflight: refusing this commit"*) ok "and the chain still finds the project's siblings" ;;
-  *"preflight not installed"*) bad "the sibling was lost with the newline" "$OUT" ;;
-  *) bad "preflight neither ran nor announced a skip" "$OUT" ;;
-esac
-[ "$RC" -ne 0 ] && ok "so the failing gate still fails the commit" \
-  || bad "commit passed with a failing sibling" "rc=$RC out=$OUT"
-
-echo "=== a project name carrying a quote does not become helper script ==="
-# Everything baked into the helper is a shell assignment inside single
-# quotes, and a value carrying a quote of its own ENDS that quote — the rest
-# of the directory name is then script, in a file git executes before every
-# commit. A name like `kid'; exit 0; #` baked a helper that exited 0 before
-# running anything, so both hooks passed everything: this package writing
-# the exact fail-open it exists to refuse.
-Q="'"
-NASTY="kid${Q}; exit 0; #"
-QR="$TMP/quoted"
-mkdir -p "$QR"
-git -C "$QR" init -q
-git -C "$QR" config user.email t@t
-git -C "$QR" config user.name t
-QP="$QR/$NASTY"
-mkdir -p "$QP/.agents/skills"
-cp -R "$SKILL_DIR" "$QP/.agents/skills/commit-guards"
-
-printf 'hello\n' >"$QR/a.txt"
-git -C "$QR" add -A
-git -C "$QR" commit -q -m "feat: base"
-OUT=""; RC=0
-OUT="$("$QP/.agents/skills/commit-guards/scripts/install-git-hooks" --repo "$QR" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "the install survives a quote in the project name" \
-  || bad "install under a quoted project name" "rc=$RC out=$OUT"
-
-# The helper still parses, and still runs the gate: a banned marker blocks.
-# Split so this file carries no marker of its own — the repo runs todo-ban
-# over its own tree.
-MARK="TO""DO"
-printf '# %s: nope\n' "$MARK" >"$QR/b.py"
-git -C "$QR" add -A
-OUT=""; RC=0
-OUT="$(cd "$QR" && git commit -m "feat: quoted" 2>&1)" || RC=$?
-[ "$RC" -ne 0 ] && ok "and the baked helper still gates the commit" \
-  || bad "the quoted name disarmed the helper" "rc=$RC out=$OUT"
-case "$OUT" in
-  *todo-ban*) ok "with the package's own verdict, not an early exit" ;;
-  *) bad "the chain did not reach todo-ban" "$OUT" ;;
-esac
-
-echo "=== the batch runs at commit scope: an untouched marker is CI's, not this commit's ==="
-RMARK="$(new_repo marker-scope)"
-printf '// %s: left in a fixture\n' "$TD" >"$RMARK/fixture.rs"
-git -C "$RMARK" add fixture.rs
-git -C "$RMARK" commit -qm 'chore: fixture'
-# A staged file of its own, so the pass is the chain judging content rather
-# than an empty diff finding nothing to judge.
-printf 'fn main() {}\n' >"$RMARK/clean.rs"
-git -C "$RMARK" add clean.rs
-RC=0
-OUT="$(cd "$RMARK" && "$PC" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "the staged file carries no marker, so the chain passes" \
-  || bad "chain passes over an untouched marker" "rc=$RC out=$OUT"
-# Control: the same repository, with the commit itself adding one.
-printf '// %s: added by this commit\n' "$TD" >>"$RMARK/b.txt"
-git -C "$RMARK" add b.txt
-RC=0
-OUT="$(cd "$RMARK" && "$PC" 2>&1)" || RC=$?
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: b.txt"*) true ;; *) false ;; esac \
-  && ok "control: a marker this commit adds blocks it" \
-  || bad "control: a staged marker blocks the commit" "rc=$RC out=$OUT"
+echo "=== the usage is answered, and an argument is refused ==="
+fx_usage() { repo usage; }
+fx_arg() { repo arg; }
+run_rows \
+  "an argument is a config error: git passes none|fx_arg||$BARE|--staged|rc=2 ${ERR}takes no arguments (see --help)"
+fx_usage
+assert_eq "--help prints the usage and exits 0" "rc=0 usage: pre-commit" "$(run "" "$BARE" --help | cut -d';' -f1)"
+assert_eq "-h is the same flag" "$(run "" "$BARE" --help)" "$(run "" "$BARE" -h)"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/commit-guards/tests/pre-commit-chain.test.sh
+++ b/skills/commit-guards/tests/pre-commit-chain.test.sh
@@ -62,16 +62,23 @@ stub "$TMP/$FULL" bot-instructions "install bot-instructions ran" 0
 
 # One line for a run in the row's repository from the named install: the
 # exit status, then every line printed, in order, joined by ';', with the
-# row's repository aliased as <repo> and the scratch root as <root>. ENVS
-# is a comma-separated list of assignments; ARGS are passed through. The
-# batch runs one check, so its lines are one shape: its composition is
+# row's repository aliased as <repo> and the scratch root as <root>, each
+# in its physical form first (the chain prints where it resolved to, which
+# under a symlinked temp root such as macOS's /var is not the spelling the
+# fixture was built with) and then its logical one. ENVS is a
+# comma-separated list of assignments; ARGS are passed through. The batch
+# runs one check, so its lines are one shape: its composition is
 # dispatcher's subject.
 R=""
+TMP_P="$(cd "$TMP" && pwd -P)"
 run() { # ENVS INSTALL ARGS
-  local envs=() rc=0 out=""
+  local envs=() rc=0 out="" r_p
   [ -z "$1" ] || IFS=',' read -ra envs <<<"$1"
+  r_p="$(cd "$R" && pwd -P)"
   # shellcheck disable=SC2086
   out="$(cd "$R" && env COMMIT_GUARDS_CHECKS=todo-ban ${envs[@]+"${envs[@]}"} "$TMP/$2/commit-guards/scripts/pre-commit" $3 2>&1)" || rc=$?
+  out="${out//"$r_p"/<repo>}"
+  out="${out//"$TMP_P"/<root>}"
   out="${out//"$R"/<repo>}"
   out="${out//"$TMP"/<root>}"
   printf 'rc=%s%s' "$rc" "${out:+ $(printf '%s\n' "$out" | LC_ALL=C paste -sd ';' -)}"

--- a/skills/commit-guards/tests/pre-commit-chain.test.sh
+++ b/skills/commit-guards/tests/pre-commit-chain.test.sh
@@ -36,11 +36,13 @@ assert_eq() { # LABEL EXPECT ACTUAL
   fi
 }
 
-# The two installs, each in another checkout, the tests subtree cut since
-# a consumer install never carries it. The bare one sits under a skill root
+# Three installs, each in another checkout, the tests subtree cut since a
+# consumer install never carries it. The bare one sits under a skill root
 # of its checkout, so the search's project side is that checkout and the
 # skip lines name it; the full one sits outside every skill root, so its
-# three stubs are reached only through the install's own side.
+# three stubs are reached only through the install's own side; the project
+# one sits under a skill root beside a doc-limits stub, reached only
+# through the project side.
 stub() { # ROOT NAME LINE RC — a gate that proves which copy ran, and with what
   mkdir -p "$1/$2/scripts"
   printf '#!/bin/sh\necho "%s $*"\nexit %s\n' "$3" "$4" >"$1/$2/scripts/$2"
@@ -49,8 +51,11 @@ stub() { # ROOT NAME LINE RC — a gate that proves which copy ran, and with wha
 install() { mkdir -p "$1"; cp -R "$SKILL_DIR" "$1/commit-guards"; rm -rf -- "${1:?}/commit-guards/tests"; } # SKILLS-DIR
 BARE=other-checkout/skills
 FULL=other-checkout-full/vendor
+PROJ=other-checkout-project/skills
 install "$TMP/$BARE"
 install "$TMP/$FULL"
+install "$TMP/$PROJ"
+stub "$TMP/$PROJ" doc-limits "project doc-limits ran" 0
 stub "$TMP/$FULL" doc-limits "install doc-limits ran" 0
 stub "$TMP/$FULL" preflight "install preflight ran" 0
 stub "$TMP/$FULL" bot-instructions "install bot-instructions ran" 0
@@ -96,8 +101,8 @@ ROOTS=".agents/skills .claude/skills .cursor/skills .gemini/skills .github/skill
 DL="=== pre-commit: doc-limits (document byte ceilings)"
 PF="=== pre-commit: preflight"
 BOT="=== pre-commit: bot-instructions check --staged"
-# The bare install's skip line: the tree, the install's checkout, the roots, the install's own side.
-skip() { printf '=== pre-commit: %s not installed — skipped (no %s skill under <repo> and <root>/other-checkout (%s), nor at <root>/%s/commit-guards/scripts/../../%s)' "$1" "$1" "$ROOTS" "$BARE" "$1"; } # LANE
+# A skip line: the tree, the install's checkout, the roots, the install's own side.
+skip() { printf '=== pre-commit: %s not installed — skipped (no %s skill under <repo> and <root>/%s (%s), nor at <root>/%s/skills/commit-guards/scripts/../../%s)' "$1" "$1" "${2:-other-checkout}" "$ROOTS" "${2:-other-checkout}" "$1"; } # LANE [CHECKOUT]
 SKIPS="$(skip doc-limits);$(skip preflight);$(skip bot-instructions)"
 BATCH="=== pre-commit: commit-guards all --staged;=== commit-guards: todo-ban --staged"
 BATCH_OK="$BATCH;todo-ban: OK — the staged diff adds no work markers;commit-guards: OK — enabled checks clean (todo-ban)"
@@ -129,16 +134,20 @@ fx_tree_two() { repo tree-two; tree doc-limits "worktree doc-limits ran" 0; ROOT
 fx_tree_fails() { repo tree-fails; tree doc-limits "doc-limits: staged violation" 1; }
 fx_tree_one() { repo tree-one; tree doc-limits "worktree doc-limits ran" 0; }
 fx_tree_none() { repo tree-none; }
+fx_tree_over_project() { repo tree-over-project; tree doc-limits "worktree doc-limits ran" 0; }
+fx_project() { repo project; }
 fx_tree_bot_fails() { repo tree-bot-fails; tree bot-instructions "bot-instructions: AGENTS.md differs from a fresh render" 1; }
-fx_tree_bot_broken() { repo tree-bot-broken; mkdir -p "$R/.agents/skills/bot-instructions/scripts"; }
+fx_tree_bot_broken() { repo tree-bot-broken; tree bot-instructions "never runs" 0; chmod -x "$R/.agents/skills/bot-instructions/scripts/bot-instructions"; }
 fx_absent() { repo absent; }
 run_rows \
   "the tree's doc-limits and preflight run, each under its own root, from an install carrying neither, and the third lane is a stated skip|fx_tree_two||$BARE||rc=0 $DL;worktree doc-limits ran --staged;$PF;worktree preflight ran --staged;$(skip bot-instructions);$BATCH_OK;$LOCAL_NONE;$CHAIN_OK" \
   "a failing tree-carried gate blocks with its own line in front of the committer|fx_tree_fails||$BARE||rc=1 $DL;doc-limits: staged violation --staged;$(skip preflight);$(skip bot-instructions);$BATCH_OK;$LOCAL_NONE;$BLOCKED" \
   "the tree's copy outranks the install's, and the siblings the tree lacks still come from the install|fx_tree_one||$FULL||rc=0 $DL;worktree doc-limits ran --staged;$PF;install preflight ran --staged;$BOT;install bot-instructions ran check --staged;$BATCH_OK;$LOCAL_NONE;$CHAIN_OK" \
   "a tree carrying no sibling gets all three from the install|fx_tree_none||$FULL||rc=0 $DL;install doc-limits ran --staged;$PF;install preflight ran --staged;$BOT;install bot-instructions ran check --staged;$BATCH_OK;$LOCAL_NONE;$CHAIN_OK" \
+  "the tree's copy outranks the one under the install's project root: the re-vendor rule|fx_tree_over_project||$PROJ||rc=0 $DL;worktree doc-limits ran --staged;$(skip preflight other-checkout-project);$(skip bot-instructions other-checkout-project);$BATCH_OK;$LOCAL_NONE;$CHAIN_OK" \
+  "control: a tree carrying none gets the project root's copy|fx_project||$PROJ||rc=0 $DL;project doc-limits ran --staged;$(skip preflight other-checkout-project);$(skip bot-instructions other-checkout-project);$BATCH_OK;$LOCAL_NONE;$CHAIN_OK" \
   "a failing tree-carried bot-instructions check blocks under its own announcement|fx_tree_bot_fails||$BARE||rc=1 $(skip doc-limits);$(skip preflight);$BOT;bot-instructions: AGENTS.md differs from a fresh render check --staged;$BATCH_OK;$LOCAL_NONE;$BLOCKED" \
-  "a tree-carried bot-instructions skill without a runnable script is a broken install, never a skip|fx_tree_bot_broken||$BARE||rc=2 $(skip doc-limits);$(skip preflight);$(broken bot-instructions)" \
+  "a tree-carried bot-instructions skill whose script is not executable is a broken install, never a skip|fx_tree_bot_broken||$BARE||rc=2 $(skip doc-limits);$(skip preflight);$(broken bot-instructions)" \
   "absence on both sides is a stated skip naming both probed sides and every root, and the chain passes|fx_absent||$BARE||rc=0 $SKIPS;$BATCH_OK;$LOCAL_NONE;$CHAIN_OK"
 
 echo "=== every step runs before the verdict, and could-not-complete outranks violations ==="
@@ -153,14 +162,12 @@ fx_local_ran() { repo local-ran; local_entry '#!/bin/sh\necho "repo-local check 
 fx_local_fails() { repo local-fails; local_entry '#!/bin/sh\necho "repo-local: nope"\nexit 1\n'; }
 fx_local_dies() { repo local-dies; local_entry '#!/bin/sh\necho "repo-local check died"\nexit 2\n'; }
 fx_local_unexecutable() { repo local-unexecutable; local_entry '#!/bin/sh\nexit 0\n'; chmod -x "$R/tools/local-check"; }
-fx_local_missing() { repo local-missing; }
 LOCAL_ENV=COMMIT_GUARDS_PRE_COMMIT_LOCAL=tools/local-check
 run_rows \
   "a configured entry announces itself in place of the none line, runs, and passes|fx_local_ran|$LOCAL_ENV|$BARE||rc=0 $SKIPS;$BATCH_OK;$LOCAL;repo-local check ran;$CHAIN_OK" \
   "its violation blocks|fx_local_fails|$LOCAL_ENV|$BARE||rc=1 $SKIPS;$BATCH_OK;$LOCAL;repo-local: nope;$BLOCKED" \
   "its status past 1 is a step that did not complete|fx_local_dies|$LOCAL_ENV|$BARE||rc=2 $SKIPS;$BATCH_OK;$LOCAL;repo-local check died;$(incomplete 'repo-local: tools/local-check' 2);$ERRORS" \
-  "an entry that is not executable is a config error naming it, after the batch ran|fx_local_unexecutable|$LOCAL_ENV|$BARE||rc=2 $SKIPS;$BATCH_OK;${ERR}COMMIT_GUARDS_PRE_COMMIT_LOCAL names 'tools/local-check', which is missing or not executable" \
-  "a missing entry is the same config error|fx_local_missing|$LOCAL_ENV|$BARE||rc=2 $SKIPS;$BATCH_OK;${ERR}COMMIT_GUARDS_PRE_COMMIT_LOCAL names 'tools/local-check', which is missing or not executable"
+  "an entry that is not executable is a config error naming it, after the batch ran|fx_local_unexecutable|$LOCAL_ENV|$BARE||rc=2 $SKIPS;$BATCH_OK;${ERR}COMMIT_GUARDS_PRE_COMMIT_LOCAL names 'tools/local-check', which is missing or not executable"
 
 echo "=== the batch runs at commit scope: a marker the commit does not add belongs to CI ==="
 # The fixture proves its marker landed in HEAD: a row over a repository
@@ -171,6 +178,10 @@ marker_committed() { # NAME
   git -C "$R" add fixture.rs
   git -C "$R" commit -qm 'chore: fixture'
   git -C "$R" grep -q -- "$TD" HEAD -- fixture.rs || { echo "harness: $1: the committed marker is not in HEAD" >&2; exit 2; }
+  # A staged file of its own, so the pass is the chain judging content
+  # rather than an empty diff finding nothing to judge.
+  printf 'fn main() {}\n' >"$R/clean.rs"
+  git -C "$R" add clean.rs
 }
 fx_untouched_marker() { marker_committed untouched-marker; }
 fx_added_marker() { marker_committed added-marker; printf '// %s: added by this commit\n' "$TD" >>"$R/b.txt"; git -C "$R" add b.txt; }

--- a/skills/commit-guards/tests/pre-commit-chain.test.sh
+++ b/skills/commit-guards/tests/pre-commit-chain.test.sh
@@ -1,22 +1,24 @@
 #!/usr/bin/env bash
-# Pins for the pre-commit chain's lane resolution and announcements: sibling
-# gates resolve from the COMMITTING work tree before the install the shim
-# execs (linked worktrees share one hooks directory, so that install can live
-# in another checkout whose branch state says nothing about this commit), a
-# genuine double absence is a stated skip naming both probed sides, and the
-# repo-local lane announces itself even when nothing is configured, and the
-# batch runs at commit scope so a marker the commit does not add belongs to
-# CI, not to this commit. Every firing pin is paired with the control that
-# proves the fixture, not the chain, would otherwise pass.
+# Pins for scripts/pre-commit, the chain as the installed shim runs it:
+# which copy of each sibling gate runs (the committing work tree's first,
+# then the install's own, which may sit in another checkout since linked
+# worktrees share one hooks directory), the announcement every lane makes,
+# ran or skipped, run_step's three statuses folded into one verdict that
+# fails closed, the repo-local entry, and the batch at commit scope. One
+# table: a row builds its own repository, runs the chain from one of two
+# shared installs in another checkout — one carrying no sibling, one
+# carrying three stubs that say which copy ran — and reads back the exit
+# status with every line printed. The shim's rediscovery, the project-root
+# and awkward-name searches, the real doc-limits and preflight lanes with
+# their forks and dangling installs, and the first-commit skip are the
+# install-git-hooks suites'; the batch's own lines are dispatcher's.
 set -euo pipefail
-
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+# shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
-
-unset COMMIT_GUARDS_CHECKS COMMIT_GUARDS_PRE_COMMIT_LOCAL \
-  COMMIT_GUARDS_SETTINGS_FILE GG_TMP GG_SETTINGS_INDEX_OWNED \
-  GG_SETTINGS_INDEX_DIR GG_SETTINGS_FROM_INDEX 2>/dev/null || true
+unset COMMIT_GUARDS_CHECKS COMMIT_GUARDS_PRE_COMMIT_LOCAL COMMIT_GUARDS_SETTINGS_FILE \
+  GG_TMP GG_SETTINGS_INDEX_OWNED GG_SETTINGS_INDEX_DIR GG_SETTINGS_FROM_INDEX 2>/dev/null || true
 
 # Assembled from split tokens so this file carries no marker shape of its
 # own: the kendex repo runs todo-ban over its own tree, tests included.
@@ -24,377 +26,167 @@ TD="TO""DO"
 
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
-
-# The chain as a linked worktree runs it: the shim execs a commit-guards
-# install in ANOTHER checkout, so SCRIPT_DIR sits outside the committing work
-# tree and install-relative siblings are that checkout's, not this one's.
-# This install carries NO siblings at all.
-BARE_INSTALL="$TMP/other-checkout/skills"
-mkdir -p "$BARE_INSTALL"
-cp -R "$SKILL_DIR" "$BARE_INSTALL/commit-guards"
-PC="$BARE_INSTALL/commit-guards/scripts/pre-commit"
-
-# A second shared install that DOES carry both siblings, for the fallback and
-# precedence pins.
-FULL_INSTALL="$TMP/other-checkout-full/skills"
-mkdir -p "$FULL_INSTALL"
-cp -R "$SKILL_DIR" "$FULL_INSTALL/commit-guards"
-PC_FULL="$FULL_INSTALL/commit-guards/scripts/pre-commit"
-
-fake_skill() { # ROOT NAME MARKER RC — a gate that proves which copy ran
-  local d="$1/$2"
-  mkdir -p "$d/scripts"
-  printf '#!/bin/sh\necho "%s"\nexit %s\n' "$3" "$4" >"$d/scripts/$2"
-  chmod +x "$d/scripts/$2"
-}
-fake_skill "$FULL_INSTALL" doc-limits "install doc-limits ran" 0
-fake_skill "$FULL_INSTALL" preflight "install preflight ran" 0
-fake_skill "$FULL_INSTALL" bot-instructions "install bot-instructions ran" 0
-
-new_repo() { # NAME -> repo path on stdout; seeded, with one file staged
-  local r="$TMP/$1"
-  mkdir -p "$r"
-  git -C "$r" -c init.defaultBranch=main init -q
-  git -C "$r" config user.email test@example.com
-  git -C "$r" config user.name test
-  printf '[]\n' >"$r/.kendex-generated.json"
-  git -C "$r" add .kendex-generated.json
-  printf 'hello\n' >"$r/a.txt"
-  git -C "$r" add a.txt
-  git -C "$r" commit -qm 'feat: seed'
-  printf 'more\n' >"$r/b.txt"
-  git -C "$r" add b.txt
-  printf '%s' "$r"
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
 }
 
-echo "=== the committing work tree's sibling gates outrank an install that has none ==="
-R1="$(new_repo tree-wins)"
-fake_skill "$R1/.agents/skills" doc-limits "worktree doc-limits ran" 0
-fake_skill "$R1/.agents/skills" preflight "worktree preflight ran" 0
-RC=0
-OUT="$(cd "$R1" && "$PC" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "control: the chain passes on the tree's own gates" \
-  || bad "chain passes on tree-carried gates" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"worktree doc-limits ran"*) ok "the tree's doc-limits is the one that ran" ;;
-  *) bad "tree doc-limits ran" "out=$OUT" ;;
-esac
-case "$OUT" in
-  *"worktree preflight ran"*) ok "the tree's preflight is the one that ran" ;;
-  *) bad "tree preflight ran" "out=$OUT" ;;
-esac
-case "$OUT" in
-  *"doc-limits not installed"* | *"preflight not installed"*)
-    bad "no lane reports the gates as absent" "out=$OUT" ;;
-  *) ok "no lane reports the gates as absent" ;;
-esac
+# The two installs, each in another checkout, the tests subtree cut since
+# a consumer install never carries it. The bare one sits under a skill root
+# of its checkout, so the search's project side is that checkout and the
+# skip lines name it; the full one sits outside every skill root, so its
+# three stubs are reached only through the install's own side.
+stub() { # ROOT NAME LINE RC — a gate that proves which copy ran, and with what
+  mkdir -p "$1/$2/scripts"
+  printf '#!/bin/sh\necho "%s $*"\nexit %s\n' "$3" "$4" >"$1/$2/scripts/$2"
+  chmod +x "$1/$2/scripts/$2"
+}
+install() { mkdir -p "$1"; cp -R "$SKILL_DIR" "$1/commit-guards"; rm -rf -- "${1:?}/commit-guards/tests"; } # SKILLS-DIR
+BARE=other-checkout/skills
+FULL=other-checkout-full/vendor
+install "$TMP/$BARE"
+install "$TMP/$FULL"
+stub "$TMP/$FULL" doc-limits "install doc-limits ran" 0
+stub "$TMP/$FULL" preflight "install preflight ran" 0
+stub "$TMP/$FULL" bot-instructions "install bot-instructions ran" 0
 
-echo "=== a failing tree-carried gate blocks even when the install has no sibling ==="
-R2="$(new_repo tree-gates)"
-fake_skill "$R2/.agents/skills" doc-limits "doc-limits: staged violation" 1
-RC=0
-OUT="$(cd "$R2" && "$PC" 2>&1)" || RC=$?
-[ "$RC" -eq 1 ] && ok "the tree's doc-limits verdict blocks (exit 1)" \
-  || bad "tree doc-limits verdict blocks" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"doc-limits: staged violation"*) ok "the gate's own output reaches the committer" ;;
-  *) bad "gate output reaches the committer" "out=$OUT" ;;
-esac
+# One line for a run in the row's repository from the named install: the
+# exit status, then every line printed, in order, joined by ';', with the
+# row's repository aliased as <repo> and the scratch root as <root>. ENVS
+# is a comma-separated list of assignments; ARGS are passed through. The
+# batch runs one check, so its lines are one shape: its composition is
+# dispatcher's subject.
+R=""
+run() { # ENVS INSTALL ARGS
+  local envs=() rc=0 out=""
+  [ -z "$1" ] || IFS=',' read -ra envs <<<"$1"
+  # shellcheck disable=SC2086
+  out="$(cd "$R" && env COMMIT_GUARDS_CHECKS=todo-ban ${envs[@]+"${envs[@]}"} "$TMP/$2/commit-guards/scripts/pre-commit" $3 2>&1)" || rc=$?
+  out="${out//"$R"/<repo>}"
+  out="${out//"$TMP"/<root>}"
+  printf 'rc=%s%s' "$rc" "${out:+ $(printf '%s\n' "$out" | LC_ALL=C paste -sd ';' -)}"
+}
 
-echo "=== the tree's copy outranks the install's copy (re-vendor gating) ==="
-R3="$(new_repo tree-over-install)"
-fake_skill "$R3/.agents/skills" doc-limits "worktree doc-limits ran" 0
-RC=0
-OUT="$(cd "$R3" && "$PC_FULL" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "control: the chain passes" || bad "precedence chain passes" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"worktree doc-limits ran"*) ok "the tree's doc-limits wins" ;;
-  *) bad "tree doc-limits wins" "out=$OUT" ;;
-esac
-case "$OUT" in
-  *"install doc-limits ran"*) bad "the install's doc-limits must not also run" "out=$OUT" ;;
-  *) ok "the install's doc-limits did not run" ;;
-esac
-case "$OUT" in
-  *"install preflight ran"*) ok "a sibling the tree lacks still comes from the install" ;;
-  *) bad "install preflight fallback" "out=$OUT" ;;
-esac
+# Fixture vocabulary. Every repository is seeded (preflight --staged has a
+# base) with one clean file staged; a name used twice is refused.
+repo() { # NAME
+  R="$TMP/$1"
+  [ ! -e "$R" ] || { echo "harness: fixture $1 already exists" >&2; exit 2; }
+  mkdir -p "$R"
+  git -C "$R" -c init.defaultBranch=main init -q
+  git -C "$R" config user.email test@example.com
+  git -C "$R" config user.name test
+  printf '[]\n' >"$R/.kendex-generated.json"
+  printf 'hello\n' >"$R/a.txt"
+  git -C "$R" add -A
+  git -C "$R" commit -qm 'feat: seed'
+  printf 'more\n' >"$R/b.txt"
+  git -C "$R" add b.txt
+}
+tree() { stub "$R/${ROOT:-.agents/skills}" "$@"; } # NAME LINE RC — a sibling the committing tree carries, under ROOT
+local_entry() { mkdir -p "$R/tools"; printf '%b' "$1" >"$R/tools/local-check"; chmod +x "$R/tools/local-check"; } # BODY
 
-echo "=== a tree carrying no siblings still gets the install's gates ==="
-R4="$(new_repo install-fallback)"
-RC=0
-OUT="$(cd "$R4" && "$PC_FULL" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "control: the chain passes on the install's gates" \
-  || bad "chain passes on install gates" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"install doc-limits ran"*) ok "the install's doc-limits ran" ;;
-  *) bad "install doc-limits ran" "out=$OUT" ;;
-esac
-case "$OUT" in
-  *"install preflight ran"*) ok "the install's preflight ran" ;;
-  *) bad "install preflight ran" "out=$OUT" ;;
-esac
-case "$OUT" in
-  *"install bot-instructions ran"*) ok "the install's bot-instructions check ran" ;;
-  *) bad "install bot-instructions ran" "out=$OUT" ;;
-esac
+# The lines the chain prints, as functions of what a row put in.
+ROOTS=".agents/skills .claude/skills .cursor/skills .gemini/skills .github/skills .opencode/skills skills"
+DL="=== pre-commit: doc-limits (document byte ceilings)"
+PF="=== pre-commit: preflight"
+BOT="=== pre-commit: bot-instructions check --staged"
+# The bare install's skip line: the tree, the install's checkout, the roots, the install's own side.
+skip() { printf '=== pre-commit: %s not installed — skipped (no %s skill under <repo> and <root>/other-checkout (%s), nor at <root>/%s/commit-guards/scripts/../../%s)' "$1" "$1" "$ROOTS" "$BARE" "$1"; } # LANE
+SKIPS="$(skip doc-limits);$(skip preflight);$(skip bot-instructions)"
+BATCH="=== pre-commit: commit-guards all --staged;=== commit-guards: todo-ban --staged"
+BATCH_OK="$BATCH;todo-ban: OK — the staged diff adds no work markers;commit-guards: OK — enabled checks clean (todo-ban)"
+LOCAL_NONE="=== pre-commit: repo-local entry: none configured"
+LOCAL="=== pre-commit: repo-local: tools/local-check"
+CHAIN_OK="pre-commit: OK — staged guard chain clean"
+BLOCKED="pre-commit: violations — commit blocked; see the failures above"
+# The verdict names git's bypass flag; assembled from split tokens so this
+# file never carries the flag itself.
+ERRORS="pre-commit: a guard could not complete — commit blocked; fix the errors above (bypass only with git commit --no-""verify)"
+incomplete() { printf "pre-commit: step '%s' did not complete (exit %s)" "$1" "$2"; } # LABEL STATUS
+ERR="::error::pre-commit: "
+broken() { printf '%sthe %s skill is installed at <repo>/.agents/skills/%s but <repo>/.agents/skills/%s/scripts/%s is missing or not executable — reinstall it' "$ERR" "$1" "$1" "$1" "$1"; } # SKILL
 
-echo "=== a failing tree-carried bot-instructions check blocks ==="
-RBOT="$(new_repo tree-bot-check)"
-fake_skill "$RBOT/.agents/skills" bot-instructions "bot-instructions: AGENTS.md differs from a fresh render" 1
-RC=0
-OUT="$(cd "$RBOT" && "$PC" 2>&1)" || RC=$?
-[ "$RC" -eq 1 ] && ok "the tree's bot-instructions verdict blocks (exit 1)" \
-  || bad "tree bot-instructions verdict blocks" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"=== pre-commit: bot-instructions check --staged"*) ok "the lane announces itself" ;;
-  *) bad "bot-instructions lane announces itself" "out=$OUT" ;;
-esac
+# The table: label | fixture | env | install | args | expect.
+run_rows() {
+  local row label fx env inst args expect
+  for row in "$@"; do
+    IFS='|' read -r label fx env inst args expect <<<"$row"
+    [ -n "$expect" ] || { echo "harness: row has fewer than six fields: $row" >&2; exit 2; }
+    R=""
+    "$fx"
+    assert_eq "$label" "$expect" "$(run "$env" "$inst" "$args")"
+  done
+}
 
-echo "=== genuine absence on both sides is a stated skip naming both probes ==="
-R5="$(new_repo double-absence)"
-RC=0
-OUT="$(cd "$R5" && "$PC" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "an absent gate skill stays a pass (exit 0)" \
-  || bad "absent gates stay exit 0" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"doc-limits not installed — skipped (no doc-limits skill under "*)
-    ok "the doc-limits skip names the work-tree probe" ;;
-  *) bad "doc-limits skip names the tree probe" "out=$OUT" ;;
-esac
-# Derived, not restated: this would carry its own copy of the list and so
-# pinned the shape of a message rather than the roots actually probed —
-# which is how it went on passing while the list it named was stale.
-# shellcheck source=../scripts/lib/skill-roots.sh
-. "$SKILL_DIR/scripts/lib/skill-roots.sh"
-case "$OUT" in
-  *"($GG_SKILL_ROOTS)"*)
-    ok "the skip names every probed skills root" ;;
-  *) bad "skip names the probed roots" "out=$OUT" ;;
-esac
-case "$OUT" in
-  *"nor at $BARE_INSTALL/commit-guards/scripts/../../doc-limits)"*)
-    ok "the doc-limits skip names the install probe" ;;
-  *) bad "doc-limits skip names the install probe" "out=$OUT" ;;
-esac
-case "$OUT" in
-  *"preflight not installed — skipped (no preflight skill under "*)
-    ok "the preflight skip names the work-tree probe" ;;
-  *) bad "preflight skip names the tree probe" "out=$OUT" ;;
-esac
-case "$OUT" in
-  *"nor at $BARE_INSTALL/commit-guards/scripts/../../preflight)"*)
-    ok "the preflight skip names the install probe" ;;
-  *) bad "preflight skip names the install probe" "out=$OUT" ;;
-esac
-case "$OUT" in
-  *"bot-instructions not installed — skipped (no bot-instructions skill under "*)
-    ok "the bot-instructions skip names the work-tree probe" ;;
-  *) bad "bot-instructions skip names the tree probe" "out=$OUT" ;;
-esac
+echo "=== the committing tree's copy of a sibling gate runs; the install's serves only a tree without one ==="
+fx_tree_two() { repo tree-two; tree doc-limits "worktree doc-limits ran" 0; ROOT=.github/skills tree preflight "worktree preflight ran" 0; }
+fx_tree_fails() { repo tree-fails; tree doc-limits "doc-limits: staged violation" 1; }
+fx_tree_one() { repo tree-one; tree doc-limits "worktree doc-limits ran" 0; }
+fx_tree_none() { repo tree-none; }
+fx_tree_bot_fails() { repo tree-bot-fails; tree bot-instructions "bot-instructions: AGENTS.md differs from a fresh render" 1; }
+fx_tree_bot_broken() { repo tree-bot-broken; mkdir -p "$R/.agents/skills/bot-instructions/scripts"; }
+fx_absent() { repo absent; }
+run_rows \
+  "the tree's doc-limits and preflight run, each under its own root, from an install carrying neither, and the third lane is a stated skip|fx_tree_two||$BARE||rc=0 $DL;worktree doc-limits ran --staged;$PF;worktree preflight ran --staged;$(skip bot-instructions);$BATCH_OK;$LOCAL_NONE;$CHAIN_OK" \
+  "a failing tree-carried gate blocks with its own line in front of the committer|fx_tree_fails||$BARE||rc=1 $DL;doc-limits: staged violation --staged;$(skip preflight);$(skip bot-instructions);$BATCH_OK;$LOCAL_NONE;$BLOCKED" \
+  "the tree's copy outranks the install's, and the siblings the tree lacks still come from the install|fx_tree_one||$FULL||rc=0 $DL;worktree doc-limits ran --staged;$PF;install preflight ran --staged;$BOT;install bot-instructions ran check --staged;$BATCH_OK;$LOCAL_NONE;$CHAIN_OK" \
+  "a tree carrying no sibling gets all three from the install|fx_tree_none||$FULL||rc=0 $DL;install doc-limits ran --staged;$PF;install preflight ran --staged;$BOT;install bot-instructions ran check --staged;$BATCH_OK;$LOCAL_NONE;$CHAIN_OK" \
+  "a failing tree-carried bot-instructions check blocks under its own announcement|fx_tree_bot_fails||$BARE||rc=1 $(skip doc-limits);$(skip preflight);$BOT;bot-instructions: AGENTS.md differs from a fresh render check --staged;$BATCH_OK;$LOCAL_NONE;$BLOCKED" \
+  "a tree-carried bot-instructions skill without a runnable script is a broken install, never a skip|fx_tree_bot_broken||$BARE||rc=2 $(skip doc-limits);$(skip preflight);$(broken bot-instructions)" \
+  "absence on both sides is a stated skip naming both probed sides and every root, and the chain passes|fx_absent||$BARE||rc=0 $SKIPS;$BATCH_OK;$LOCAL_NONE;$CHAIN_OK"
 
-echo "=== a tree-carried skill without a runnable script blocks, never skips ==="
-R6="$(new_repo broken-tree-sibling)"
-mkdir -p "$R6/.agents/skills/doc-limits/scripts"
-RC=0
-OUT="$(cd "$R6" && "$PC" 2>&1)" || RC=$?
-[ "$RC" -eq 2 ] && ok "a present-but-broken tree sibling exits 2 (could not complete)" \
-  || bad "broken tree sibling exits 2" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"doc-limits skill is installed at"*) ok "the broken install is named" ;;
-  *) bad "broken install is named" "out=$OUT" ;;
-esac
+echo "=== every step runs before the verdict, and could-not-complete outranks violations ==="
+fx_both() { repo both; tree doc-limits "doc-limits: staged violation" 1; tree preflight "preflight died" 2; }
+fx_bot_dies() { repo bot-dies; tree bot-instructions "bot died" 3; }
+run_rows \
+  "a violation and a step that did not complete both print, every later lane still runs, and the verdict is the error's|fx_both||$BARE||rc=2 $DL;doc-limits: staged violation --staged;$PF;preflight died --staged;$(incomplete preflight 2);$(skip bot-instructions);$BATCH_OK;$LOCAL_NONE;$ERRORS" \
+  "a status past 1 is a step that did not complete, with its status|fx_bot_dies||$BARE||rc=2 $(skip doc-limits);$(skip preflight);$BOT;bot died check --staged;$(incomplete 'bot-instructions check --staged' 3);$BATCH_OK;$LOCAL_NONE;$ERRORS"
 
-echo "=== the repo-local lane announces itself even with nothing configured ==="
-R7="$(new_repo local-unconfigured)"
-RC=0
-OUT="$(cd "$R7" && "$PC" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "an unconfigured repo-local lane stays a pass (exit 0)" \
-  || bad "unconfigured local lane exits 0" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"=== pre-commit: repo-local entry: none configured"*)
-    ok "the lane states that none is configured" ;;
-  *) bad "none-configured line printed" "out=$OUT" ;;
-esac
+echo "=== the repo-local entry: announced, run last, and its status folded like every lane's ==="
+fx_local_ran() { repo local-ran; local_entry '#!/bin/sh\necho "repo-local check ran"\nexit 0\n'; }
+fx_local_fails() { repo local-fails; local_entry '#!/bin/sh\necho "repo-local: nope"\nexit 1\n'; }
+fx_local_dies() { repo local-dies; local_entry '#!/bin/sh\necho "repo-local check died"\nexit 2\n'; }
+fx_local_unexecutable() { repo local-unexecutable; local_entry '#!/bin/sh\nexit 0\n'; chmod -x "$R/tools/local-check"; }
+fx_local_missing() { repo local-missing; }
+LOCAL_ENV=COMMIT_GUARDS_PRE_COMMIT_LOCAL=tools/local-check
+run_rows \
+  "a configured entry announces itself in place of the none line, runs, and passes|fx_local_ran|$LOCAL_ENV|$BARE||rc=0 $SKIPS;$BATCH_OK;$LOCAL;repo-local check ran;$CHAIN_OK" \
+  "its violation blocks|fx_local_fails|$LOCAL_ENV|$BARE||rc=1 $SKIPS;$BATCH_OK;$LOCAL;repo-local: nope;$BLOCKED" \
+  "its status past 1 is a step that did not complete|fx_local_dies|$LOCAL_ENV|$BARE||rc=2 $SKIPS;$BATCH_OK;$LOCAL;repo-local check died;$(incomplete 'repo-local: tools/local-check' 2);$ERRORS" \
+  "an entry that is not executable is a config error naming it, after the batch ran|fx_local_unexecutable|$LOCAL_ENV|$BARE||rc=2 $SKIPS;$BATCH_OK;${ERR}COMMIT_GUARDS_PRE_COMMIT_LOCAL names 'tools/local-check', which is missing or not executable" \
+  "a missing entry is the same config error|fx_local_missing|$LOCAL_ENV|$BARE||rc=2 $SKIPS;$BATCH_OK;${ERR}COMMIT_GUARDS_PRE_COMMIT_LOCAL names 'tools/local-check', which is missing or not executable"
 
-echo "=== a configured repo-local entry still runs, announces, and suppresses the none line ==="
-R8="$(new_repo local-configured)"
-mkdir -p "$R8/tools"
-printf '#!/bin/sh\necho "repo-local check ran"\nexit 0\n' >"$R8/tools/local-check"
-chmod +x "$R8/tools/local-check"
-RC=0
-OUT="$(cd "$R8" && COMMIT_GUARDS_PRE_COMMIT_LOCAL=tools/local-check "$PC" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "control: a passing entry keeps the chain green" \
-  || bad "configured local entry passes" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"=== pre-commit: repo-local: tools/local-check"*) ok "the configured lane announces its entry" ;;
-  *) bad "configured lane announces" "out=$OUT" ;;
-esac
-case "$OUT" in
-  *"repo-local check ran"*) ok "the entry actually ran" ;;
-  *) bad "configured entry ran" "out=$OUT" ;;
-esac
-case "$OUT" in
-  *"repo-local entry: none configured"*)
-    bad "the none-configured line must not appear beside a configured entry" "out=$OUT" ;;
-  *) ok "the none-configured line stays out of the configured lane" ;;
-esac
+echo "=== the batch runs at commit scope: a marker the commit does not add belongs to CI ==="
+# The fixture proves its marker landed in HEAD: a row over a repository
+# without one passes for the wrong reason.
+marker_committed() { # NAME
+  repo "$1"
+  printf '// %s: left in a fixture\n' "$TD" >"$R/fixture.rs"
+  git -C "$R" add fixture.rs
+  git -C "$R" commit -qm 'chore: fixture'
+  git -C "$R" grep -q -- "$TD" HEAD -- fixture.rs || { echo "harness: $1: the committed marker is not in HEAD" >&2; exit 2; }
+}
+fx_untouched_marker() { marker_committed untouched-marker; }
+fx_added_marker() { marker_committed added-marker; printf '// %s: added by this commit\n' "$TD" >>"$R/b.txt"; git -C "$R" add b.txt; }
+HIT="todo-ban FAIL work marker: b.txt:2:// $TD: added by this commit;  remedies: do the work now, or move it to the tracker and delete the marker; vendored/generated trees belong in tools/todo-ban-excludes with a reason;todo-ban: 1 work marker(s) added by the staged diff — excludes tools/todo-ban-excludes;commit-guards: violations — see the failures above"
+run_rows \
+  "a marker committed earlier and untouched is not this commit's: the staged file is clean and the chain passes|fx_untouched_marker||$BARE||rc=0 $SKIPS;$BATCH_OK;$LOCAL_NONE;$CHAIN_OK" \
+  "control: a marker this commit adds blocks it at its line|fx_added_marker||$BARE||rc=1 $SKIPS;$BATCH;$HIT;$LOCAL_NONE;$BLOCKED"
 
-echo "=== a project below the git top level finds its own siblings ==="
-# kendex renders into the PROJECT's root, and a repository can hold several.
-# git runs a hook from the WORK TREE root, so every search anchored there
-# looked past a nested project entirely: the sibling gates were beside the
-# installed copy and nowhere near $PWD. A gate that is not found is a gate
-# that reports nothing, and the chain exited 0 while preflight failed.
-R80="$TMP/nested"
-mkdir -p "$R80/apps/web/.agents/skills" "$R80/apps/web/.github/skills"
-git -C "$R80" init -q
-git -C "$R80" config user.email t@t
-git -C "$R80" config user.name t
-cp -R "$SKILL_DIR" "$R80/apps/web/.agents/skills/commit-guards"
-
-# Under a DIFFERENT root of the same project, so the pin needs the project
-# anchor and the full root list at once.
-mkdir -p "$R80/apps/web/.github/skills/preflight/scripts"
-cat >"$R80/apps/web/.github/skills/preflight/scripts/preflight" <<'PREFLIGHT'
-#!/bin/sh
-echo "preflight: refusing this commit"
-exit 1
-PREFLIGHT
-chmod +x "$R80/apps/web/.github/skills/preflight/scripts/preflight"
-
-# A base commit before arming: preflight compares against one and announces
-# a skip without it, which would pass this pin for the wrong reason.
-printf 'hello\n' >"$R80/a.txt"
-git -C "$R80" add -A
-git -C "$R80" commit -q -m "feat: base"
-"$R80/apps/web/.agents/skills/commit-guards/scripts/install-git-hooks" \
-  --repo "$R80" >/dev/null 2>&1
-
-printf 'more\n' >"$R80/b.txt"
-git -C "$R80" add -A
-OUT=""; RC=0
-OUT="$(cd "$R80" && git commit -m "feat: nested" 2>&1)" || RC=$?
-case "$OUT" in
-  *"preflight: refusing this commit"*)
-    ok "the chain ran the nested project's preflight" ;;
-  *"preflight not installed"*)
-    bad "the nested preflight was never found" "$OUT" ;;
-  *) bad "preflight neither ran nor announced a skip" "$OUT" ;;
-esac
-[ "$RC" -ne 0 ] && ok "and its failure fails the commit" \
-  || bad "nested sibling failed and the commit passed" "rc=$RC out=$OUT"
-
-echo "=== a project directory whose name ends in a newline ==="
-# `$(...)` strips trailing newlines, and a directory name may end in one. The
-# PROJECT root is the path that matters: it is derived from where this script
-# lives, handed back to a caller, made relative, baked into the helper and
-# read again by the chain. Every one of those was a capture, and a capture
-# lost the last byte — so the sibling search looked under a directory that is
-# not there, announced the gate as not installed, and the commit passed while
-# the gate would have failed it.
-NL="$TMP/nlrepo"
-mkdir -p "$NL"
-git -C "$NL" init -q
-git -C "$NL" config user.email t@t
-git -C "$NL" config user.name t
-# The project directory itself ends in a newline.
-PROJ="$NL/web
-"
-mkdir -p "$PROJ/.agents/skills" "$PROJ/.github/skills"
-cp -R "$SKILL_DIR" "$PROJ/.agents/skills/commit-guards"
-mkdir -p "$PROJ/.github/skills/preflight/scripts"
-cat >"$PROJ/.github/skills/preflight/scripts/preflight" <<'PREFLIGHT'
-#!/bin/sh
-echo "preflight: refusing this commit"
-exit 1
-PREFLIGHT
-chmod +x "$PROJ/.github/skills/preflight/scripts/preflight"
-
-printf 'hello\n' >"$NL/a.txt"
-git -C "$NL" add -A
-git -C "$NL" commit -q -m "feat: base"
-OUT=""; RC=0
-OUT="$("$PROJ/.agents/skills/commit-guards/scripts/install-git-hooks" --repo "$NL" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "the install resolves a newline-terminated project" \
-  || bad "install under a newline-named project" "rc=$RC out=$OUT"
-
-printf 'more\n' >"$NL/b.txt"
-git -C "$NL" add -A
-OUT=""; RC=0
-OUT="$(cd "$NL" && git commit -m "feat: nl" 2>&1)" || RC=$?
-case "$OUT" in
-  *"preflight: refusing this commit"*) ok "and the chain still finds the project's siblings" ;;
-  *"preflight not installed"*) bad "the sibling was lost with the newline" "$OUT" ;;
-  *) bad "preflight neither ran nor announced a skip" "$OUT" ;;
-esac
-[ "$RC" -ne 0 ] && ok "so the failing gate still fails the commit" \
-  || bad "commit passed with a failing sibling" "rc=$RC out=$OUT"
-
-echo "=== a project name carrying a quote does not become helper script ==="
-# Everything baked into the helper is a shell assignment inside single
-# quotes, and a value carrying a quote of its own ENDS that quote — the rest
-# of the directory name is then script, in a file git executes before every
-# commit. A name like `kid'; exit 0; #` baked a helper that exited 0 before
-# running anything, so both hooks passed everything: this package writing
-# the exact fail-open it exists to refuse.
-Q="'"
-NASTY="kid${Q}; exit 0; #"
-QR="$TMP/quoted"
-mkdir -p "$QR"
-git -C "$QR" init -q
-git -C "$QR" config user.email t@t
-git -C "$QR" config user.name t
-QP="$QR/$NASTY"
-mkdir -p "$QP/.agents/skills"
-cp -R "$SKILL_DIR" "$QP/.agents/skills/commit-guards"
-
-printf 'hello\n' >"$QR/a.txt"
-git -C "$QR" add -A
-git -C "$QR" commit -q -m "feat: base"
-OUT=""; RC=0
-OUT="$("$QP/.agents/skills/commit-guards/scripts/install-git-hooks" --repo "$QR" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "the install survives a quote in the project name" \
-  || bad "install under a quoted project name" "rc=$RC out=$OUT"
-
-# The helper still parses, and still runs the gate: a banned marker blocks.
-# Split so this file carries no marker of its own — the repo runs todo-ban
-# over its own tree.
-MARK="TO""DO"
-printf '# %s: nope\n' "$MARK" >"$QR/b.py"
-git -C "$QR" add -A
-OUT=""; RC=0
-OUT="$(cd "$QR" && git commit -m "feat: quoted" 2>&1)" || RC=$?
-[ "$RC" -ne 0 ] && ok "and the baked helper still gates the commit" \
-  || bad "the quoted name disarmed the helper" "rc=$RC out=$OUT"
-case "$OUT" in
-  *todo-ban*) ok "with the package's own verdict, not an early exit" ;;
-  *) bad "the chain did not reach todo-ban" "$OUT" ;;
-esac
-
-echo "=== the batch runs at commit scope: an untouched marker is CI's, not this commit's ==="
-RMARK="$(new_repo marker-scope)"
-printf '// %s: left in a fixture\n' "$TD" >"$RMARK/fixture.rs"
-git -C "$RMARK" add fixture.rs
-git -C "$RMARK" commit -qm 'chore: fixture'
-# A staged file of its own, so the pass is the chain judging content rather
-# than an empty diff finding nothing to judge.
-printf 'fn main() {}\n' >"$RMARK/clean.rs"
-git -C "$RMARK" add clean.rs
-RC=0
-OUT="$(cd "$RMARK" && "$PC" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "the staged file carries no marker, so the chain passes" \
-  || bad "chain passes over an untouched marker" "rc=$RC out=$OUT"
-# Control: the same repository, with the commit itself adding one.
-printf '// %s: added by this commit\n' "$TD" >>"$RMARK/b.txt"
-git -C "$RMARK" add b.txt
-RC=0
-OUT="$(cd "$RMARK" && "$PC" 2>&1)" || RC=$?
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: b.txt"*) true ;; *) false ;; esac \
-  && ok "control: a marker this commit adds blocks it" \
-  || bad "control: a staged marker blocks the commit" "rc=$RC out=$OUT"
+echo "=== the usage is answered, and an argument is refused ==="
+fx_usage() { repo usage; }
+fx_arg() { repo arg; }
+run_rows \
+  "an argument is a config error: git passes none|fx_arg||$BARE|--staged|rc=2 ${ERR}takes no arguments (see --help)"
+fx_usage
+assert_eq "--help prints the usage and exits 0" "rc=0 usage: pre-commit" "$(run "" "$BARE" --help | cut -d';' -f1)"
+assert_eq "-h is the same flag" "$(run "" "$BARE" --help)" "$(run "" "$BARE" -h)"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Reshapes `skills/commit-guards/tests/pre-commit-chain.test.sh` to code-quality § Tests. The old suite pinned the chain in one 563-line linear script of about fifty substring assertions, each an exit status read as a bit beside a phrase, so which lanes ran, in what order, with what arguments, and what the verdict line said were never pinned. It is now one table of 20 rows (`label|fixture|env|install|args|expect`): a row builds its own repository, runs the chain from one of three installs in another checkout (bare under a skill root; full outside every skill root with three stubs that print which copy ran and with what arguments; project under a skill root beside a doc-limits stub) and reads back the exit status with every line printed, joined by `;`, the fixture's repository and the install root aliased as `<repo>` and `<root>`.

Every former assertion has a row here or in the install family. Dropped as pinned by `install-git-hooks` suites, each claim verified by the reviewer: the nested project, the newline- and quote-named project, the double absence naming every root, the broken doc-limits install; the repo-local `none` line rides in every row here anyway. The batch-scope pair and the tree-over-install precedence stay. New rows for surfaces the old suite never reached: a tree sibling under a later skill root, a broken tree-carried bot-instructions install (never a skip), a violation beside a step that did not complete (the error's verdict, every later lane still run), a status past 1 with its number, the repo-local entry failing, dying, missing and unexecutable, an argument refused, and the `-h` and `--help` controls.

The second commit is the reviewer's round: the re-vendor rule (the tree's copy over one under the install's project root, with its control), the `-x` half of the broken-install guard (a present script that is not executable), and the marker rows running over an empty index (a clean file staged after the fixture commit). The duplicate missing-entry row, byte-identical to the unexecutable one, goes.

The third commit is the macOS shard's finding: the chain prints where it resolved to, which under a symlinked temp root (`/var` to `/private/var`) is not the spelling the fixture was built with, so five skip lines read `/private<repo>`. The renderer now substitutes the physical form (`pwd -P`) of the fixture repository and of the scratch root before their logical forms; reproduced and proven here under a symlinked TMPDIR (15 rows failing before, 20 passing after).

The tracked render under `.agents/` is replayed with `patch`.

## Mutation

30 exact-substring mutants over `scripts/pre-commit` and its lib (the sibling lookup order and each root, the tree-over-install precedence, the `-x` and `-f` halves of the broken-install guard, the skip line and its roots, the could-not-complete arm and its status, the batch scope, the repo-local entry's announcement, status folding, missing and unexecutable arms, the argument refusal, the usage): all 30 killed by a named row (`mutants-pc-4.txt`). Seven fixture mutants, each new fixture's planted drift removed: all fail their row (`fixture-mutants-pc-2.txt`). The reviewer's three survivors are the second commit's rows, all killed (`mutants-pc-3.txt`).

## Checks

- `pre-commit-chain.test.sh`: 20 rows pass on this host, under `TMPDIR=/tmp` and under a symlinked TMPDIR. `tools/bash32-lint` clean over the tests directory.
- `tools/guard --full` (`TMPDIR=/tmp`): exit 0 on the first commit; on the second every lane passed except `guard_hooks`, whose 36 failures were all `failed to spawn thread: Resource temporarily unavailable` under box load, and `cargo test -p kendex-cli --test guard_hooks` re-run alone passes 42/42.
- One reviewer-test round: fix-first with three blockers, all applied as the second commit (the harness refused the subagent's report write; the verdict was read from its transcript).

KEN-1241

https://claude.ai/code/session_01BfzLjeGYNT3DMhBJhg24md
