### PR TITLE
test(KEN-1241): the byte-ceiling and settings suites as tables of rows

### DIFF
--- a/.agents/skills/commit-guards/tests/byte-ceiling.test.sh
+++ b/.agents/skills/commit-guards/tests/byte-ceiling.test.sh
@@ -10,7 +10,8 @@
 # a fixture builds the repository, the check runs with ARGS under ENVS, and
 # a row pins the exit status with every line printed, so the hit, the
 # remedy, the counts and the scope named are one pin; the run repeats once
-# in the same repository and a second verdict that differs is shown. The
+# in the same repository and a second verdict that differs is shown (a
+# tripwire: the check writes no state, so no row has a positive case). The
 # settings ladder's own shapes are settings-precedence.test.sh's.
 set -euo pipefail
 
@@ -109,7 +110,8 @@ fx_edit_over() { grown edit-over 1; put seed.bin 5; }
 fx_edit_under() { grown edit-under 1; put seed.bin 1 x; } # the same size with other bytes
 fx_untouched() { grown untouched 5; }
 fx_shrink() { grown shrink 5; put seed.bin 4; }
-fx_grow() { grown grow 5; put seed.bin 5; printf 'x' >>"$R/seed.bin"; git -C "$R" add -A; }
+fx_grow() { grown "${1:-grow}" 5; put seed.bin 5; printf 'x' >>"$R/seed.bin"; git -C "$R" add -A; } # [NAME]
+fx_grow_prior() { fx_grow grow-prior; }
 fx_hold() { grown hold 5; put seed.bin 5 y; }
 fx_rename() { grown "$1" 5; git -C "$R" mv seed.bin moved.bin; } # NAME
 fx_rename_beside() { fx_rename rename-beside; cp "$R/moved.bin" "$R/second-copy.bin"; printf 'x' >>"$R/second-copy.bin"; git -C "$R" add -A; }
@@ -144,8 +146,13 @@ feature() { # NAME ACTION — a feature branch over the legacy file: shrink, gro
   esac
 }
 fx_all_symlink() { repo all-symlink; put old.bin 1; ln -s old.bin "$R/alias"; git -C "$R" add -A; commit; }
-fx_unmerged() { # an add/add conflict: the index carries stages 2 and 3 for one path
-  repo unmerged
+gitlink() { # NAME STAGE — a committed 1 KB file, then a gitlink at mod: staged only, or committed
+  repo "$1"; put ok.bin 1; commit
+  git -C "$R" update-index --add --cacheinfo "160000,$(git -C "$R" rev-parse HEAD),mod"
+  [ "$2" = staged ] || commit gitlink
+}
+fx_unmerged() { # NAME — an add/add conflict: the index carries stages 2 and 3 for one path
+  repo "$1"
   put base.bin 1; commit
   git -C "$R" checkout -qb theirs; put clash.bin 1 a; commit
   git -C "$R" checkout -q main; put clash.bin 1 b; commit
@@ -153,6 +160,7 @@ fx_unmerged() { # an add/add conflict: the index carries stages 2 and 3 for one 
 }
 run_rows \
   "staged mode passes with nothing staged: the legacy file is untouched|legacy legacy-staged|$C=1||rc=0 $(ok 0)" \
+  "--staged spelled out is the same scope, not a sweep|legacy legacy-staged-flag|$C=1|--staged|rc=0 $(ok 0)" \
   "--all fails on the legacy oversized file, naming the sweep|legacy legacy-all|$C=1|--all|rc=1 $(over old.bin 4096 4 1);$(failed 1 1 1 "$SWEEP")" \
   "--base main permits a legacy oversized file to shrink|feature base-shrink shrink|$C=1|--base main|rc=0 $(ok 1 "$(since main)")" \
   "--base main rejects growth from the merge-base size|feature base-grow grow|$C=1|--base main|rc=1 $(grew old.bin 4096 5120 5 1);$(failed 1 1 1 "$(since main)")" \
@@ -160,13 +168,16 @@ run_rows \
   "--base=REF is the same mode|feature base-eq add|$C=1|--base=main|rc=1 $(over feat.bin 2048 2 1);$(failed 1 1 1 "$(since main)")" \
   "--base judges from the merge-base: a legacy file main shrank after the branch point is not the branch's growth|feature base-main-moves main-moves|$C=1|--base main|rc=0 $(ok 1 "$(since main)")" \
   "--all does not size a tracked symlink: one file checked beside it|fx_all_symlink|$C=1|--all|rc=0 $(ok 1 "$SWEEP")" \
+  "--all does not size a committed gitlink either: it carries a commit id, not content|gitlink gitlink-all committed|$C=1|--all|rc=0 $(ok 1 "$SWEEP")" \
+  "a staged gitlink is not sized content|gitlink gitlink-staged staged|$C=1||rc=0 $(ok 0)" \
   "control: --base main on main itself has no additions|legacy base-self|$C=1|--base main|rc=0 $(ok 0 "$(since main)")" \
   "an unknown --base ref is exit 2, naming it|legacy base-unknown|$C=1|--base no-such-ref|rc=2 ${ERR}--base ref 'no-such-ref' does not name a commit" \
   "--base without a ref is exit 2|legacy base-bare|$C=1|--base|rc=2 ${ERR}--base requires a ref" \
-  "an unmerged index is refused rather than measured around: the conflict's addition would vanish from the record set|fx_unmerged|$C=1||rc=2 clash.bin;${ERR}the index carries 1 unmerged path(s) (listed above) and a --cached scan skips them silently — finish or abort the merge, then re-run"
+  "an unmerged index is refused rather than measured around: the conflict's addition would vanish from the record set|fx_unmerged unmerged-staged|$C=1||rc=2 clash.bin;${ERR}the index carries 1 unmerged path(s) (listed above) and a --cached scan skips them silently — finish or abort the merge, then re-run" \
+  "--all refuses it too, where ls-files would size one blob per stage|fx_unmerged unmerged-all|$C=1|--all|rc=2 clash.bin;${ERR}the index carries 1 unmerged path(s) (listed above) and a --cached scan skips them silently — finish or abort the merge, then re-run"
 
 echo "=== lockfiles are exempt by basename; declared asset trees by an excludes row with a reason ==="
-fx_lock() { repo "$1"; put package-lock.json 2; } # NAME
+fx_lock() { repo "$1"; put "${2:-package-lock.json}" 2; } # NAME [PATH]
 fx_lock_twin() { fx_lock lock-twin; cp "$R/package-lock.json" "$R/data.json"; git -C "$R" add -A; }
 fx_lock_suffix() { repo lock-suffix; put not-package-lock.json 2; }
 asset() { repo "$1"; put assets/demo.gif 2; } # NAME
@@ -175,12 +186,14 @@ fx_no_reason() { asset no-reason; excludes 'assets/*\n'; }
 fx_excludes_flag() { asset "$1"; mkdir -p "$R/conf"; printf 'assets/*\tdemo media\n' >"$R/conf/excludes"; git -C "$R" add -A; }
 run_rows \
   "an oversized package-lock.json passes and is not counted: the built-in lockfile exemption|fx_lock lock|$C=1||rc=0 $(ok 0)" \
+  "a nested lockfile is exempt too: the basename is what is judged|fx_lock lock-nested ui/package-lock.json|$C=1||rc=0 $(ok 0)" \
   "control: the same bytes as data.json fail, the exemption is the basename|fx_lock_twin|$C=1||rc=1 $(over data.json 2048 2 1);$(failed 1 1)" \
   "control: a basename that only ends in a lockfile's name is not exempt|fx_lock_suffix|$C=1||rc=1 $(over not-package-lock.json 2048 2 1);$(failed 1 1)" \
   "control: an asset fails without an excludes row|asset asset-bare|$C=1||rc=1 $(over assets/demo.gif 2048 2 1);$(failed 1 1)" \
   "an excludes row exempts the declared tree; the list itself is a staged file and is counted|fx_excluded|$C=1||rc=0 $(ok 1)" \
   "a pattern without a reason is exit 2 naming the line|fx_no_reason|$C=1||rc=2 ${ERR}$EXCL:1: expected 'pattern<TAB>reason' (every exclusion carries its justification)" \
   "--excludes FILE names the list, and the remedy names it too|fx_excludes_flag excludes-flag|$C=1|--excludes conf/excludes|rc=0 $(ok 1)" \
+  "the equals form of --excludes names the same list|fx_excludes_flag excludes-eq|$C=1|--excludes=conf/excludes|rc=0 $(ok 1)" \
   "control: without the flag the same repository fails on the asset, and the remedy names the default list|fx_excludes_flag excludes-default|$C=1||rc=1 $(over assets/demo.gif 2048 2 1);$(failed 1 2)"
 
 echo "=== the ceiling resolves through the settings ladder and is validated ==="
@@ -201,11 +214,19 @@ REAL_GIT="$(command -v git)"
 mkdir -p "$TMP/git-shim"
 printf '#!/usr/bin/env bash\nif [ "${1:-}" = cat-file ] && [ "${2:-}" = -s ]; then echo "fatal: simulated object read failure" >&2; exit 128; fi\nexec %q "$@"\n' "$REAL_GIT" >"$TMP/git-shim/git"
 chmod +x "$TMP/git-shim/git"
-SHA2K="$(head -c 2048 /dev/zero | git hash-object --stdin)"
+# Hashed outside any repository: the fixtures are sha1 by default, and a
+# host checkout under another object format must not answer for them.
+SHA2K="$(cd "$TMP" && head -c 2048 /dev/zero | git hash-object --stdin)"
+SHA5K="$(cd "$TMP" && head -c 5120 /dev/zero | git hash-object --stdin)"
+# A git whose `cat-file -s` fails for the 5 KB blob alone: the prior of a grown file.
+mkdir -p "$TMP/git-shim-prior"
+printf '#!/usr/bin/env bash\nif [ "${1:-}" = cat-file ] && [ "${2:-}" = -s ] && [ "${3:-}" = %s ]; then echo "fatal: simulated object read failure" >&2; exit 128; fi\nexec %q "$@"\n' "$SHA5K" "$REAL_GIT" >"$TMP/git-shim-prior/git"
+chmod +x "$TMP/git-shim-prior/git"
 measure() { repo "$1"; put big.bin 2; } # NAME
 run_rows \
   "control: without the shim the oversized staged file fails|measure measure-real|$C=1||rc=1 $(over big.bin 2048 2 1);$(failed 1 1)" \
-  "an unmeasurable blob is exit 2 naming the blob and the file, with no verdict line, git's own words ahead of it|measure measure-shim|PATH=$TMP/git-shim:$PATH,$C=1||rc=2 fatal: simulated object read failure;${ERR}cannot read blob $SHA2K for 'big.bin' — its size is unmeasurable, refusing to skip it"
+  "an unmeasurable blob is exit 2 naming the blob and the file, with no verdict line, git's own words ahead of it|measure measure-shim|PATH=$TMP/git-shim:$PATH,$C=1||rc=2 fatal: simulated object read failure;${ERR}cannot read blob $SHA2K for 'big.bin' — its size is unmeasurable, refusing to skip it" \
+  "an unmeasurable PRIOR blob is exit 2 too: the tighten-only baseline is not guessed|fx_grow_prior|PATH=$TMP/git-shim-prior:$PATH,$C=1||rc=2 fatal: simulated object read failure;${ERR}cannot read prior blob $SHA5K for 'seed.bin' — its size is unmeasurable, refusing to skip it"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.agents/skills/commit-guards/tests/byte-ceiling.test.sh
+++ b/.agents/skills/commit-guards/tests/byte-ceiling.test.sh
@@ -1,386 +1,211 @@
 #!/usr/bin/env bash
-# Pins for scripts/byte-ceiling: additions and growth over the ceiling fail,
-# an existing oversized file may hold or shrink, renames pass, lockfiles and
-# excluded trees are exempt, configuration resolves, and a broken measurement
-# is a collection error — never a pass.
+# Pins for scripts/byte-ceiling: an addition or a change past the ceiling
+# fails naming the file, its bytes and the ceiling, an existing oversized
+# file may hold or shrink but not grow, a pure rename is no addition while a
+# copy and a moved-and-grown file are, a symlink or gitlink is not sized
+# content, --base judges the branch since its merge-base and --all sweeps
+# every tracked file, lockfiles and declared asset trees are exempt, the
+# ceiling resolves through the settings ladder and is validated, and a
+# measurement that breaks is a collection error, never a pass. One table:
+# a fixture builds the repository, the check runs with ARGS under ENVS, and
+# a row pins the exit status with every line printed, so the hit, the
+# remedy, the counts and the scope named are one pin; the run repeats once
+# in the same repository and a second verdict that differs is shown. The
+# settings ladder's own shapes are settings-precedence.test.sh's.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 BC="$SKILL_DIR/scripts/byte-ceiling"
+# shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
-
+# Hermetic: a leaked setting would move every ceiling below.
 unset COMMIT_GUARDS_BYTE_CEILING_KB COMMIT_GUARDS_BYTE_EXCLUDES COMMIT_GUARDS_SETTINGS_FILE 2>/dev/null || true
 
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
 
-new_repo() { # NAME
+# One line for a run in the row's repository: the exit status, then every
+# line printed, in order, joined by ';'. ENVS is a comma-separated list of
+# assignments; ARGS are passed through. The run repeats once, and a second
+# verdict that differs follows after ' / again: '.
+R=""
+run() { # ENVS ARGS
+  local envs=() rc=0 out="" rc2=0 out2="" line line2
+  [ -z "$1" ] || IFS=',' read -ra envs <<<"$1"
+  # shellcheck disable=SC2086
+  out="$(cd "$R" && env ${envs[@]+"${envs[@]}"} "$BC" $2 2>&1)" || rc=$?
+  # shellcheck disable=SC2086
+  out2="$(cd "$R" && env ${envs[@]+"${envs[@]}"} "$BC" $2 2>&1)" || rc2=$?
+  line="rc=$rc${out:+ $(printf '%s\n' "$out" | LC_ALL=C paste -sd ';' -)}"
+  line2="rc=$rc2${out2:+ $(printf '%s\n' "$out2" | LC_ALL=C paste -sd ';' -)}"
+  printf '%s' "$line"
+  [ "$line" = "$line2" ] || printf ' / again: %s' "$line2"
+}
+
+# Fixture vocabulary. Every fixture builds its own repository; a name used
+# twice is refused. `put` writes KB kibibytes of one byte (NUL unless FILL is
+# given) and stages; `commit` commits what is staged.
+repo() { # NAME
   R="$TMP/$1"
+  [ ! -e "$R" ] || { echo "harness: fixture $1 already exists" >&2; exit 2; }
   mkdir -p "$R"
   git -C "$R" -c init.defaultBranch=main init -q
   git -C "$R" config user.email test@example.com
   git -C "$R" config user.name test
 }
-
-mkbytes() { # PATH KB — file of KB*1024 bytes under $R
+put() { # PATH KB [FILL]
   mkdir -p "$R/$(dirname "$1")"
-  dd if=/dev/zero of="$R/$1" bs=1024 count="$2" 2>/dev/null
+  head -c "$(($2 * 1024))" /dev/zero | tr '\0' "${3:-\0}" >"$R/$1"
+  git -C "$R" add -A
+}
+commit() { git -C "$R" commit -qm "${1:-seed}"; }
+EXCL='tools/byte-ceiling-excludes'
+excludes() { mkdir -p "$R/tools"; printf '%b' "$1" >"$R/$EXCL"; git -C "$R" add -A; } # CONTENT (printf %b)
+
+# The lines the check prints, as functions of what a row put in.
+REMEDY="  remedies: keep big artifacts out of the repo (asset store, Git LFS, build-time generation); a file that genuinely belongs gets a row in $EXCL with its reason"
+ERR="::error::byte-ceiling: "
+over() { printf 'byte-ceiling FAIL oversized file: %s — %s bytes (~%s KB) > ceiling %s KB;%s' "$1" "$2" "$3" "$4" "$REMEDY"; } # PATH BYTES ~KB CEILING
+grew() { printf 'byte-ceiling FAIL oversized file grew: %s — %s -> %s bytes (~%s KB), ceiling %s KB;%s' "$1" "$2" "$3" "$4" "$5" "$REMEDY"; } # PATH PRIOR BYTES ~KB CEILING
+STAGED="staged file(s)"
+SWEEP="tracked file(s) (full sweep)"
+since() { printf 'file(s) added or changed since %s' "$1"; } # REF
+ok() { printf 'byte-ceiling: OK — %s %s checked, ceiling %s KB' "$1" "${2:-$STAGED}" "${3:-1}"; } # CHECKED [SCOPE] [CEILING]
+failed() { printf 'byte-ceiling: %s violation(s) — ceiling %s KB, %s %s checked' "$1" "${3:-1}" "$2" "${4:-$STAGED}"; } # VIOLATIONS CHECKED [CEILING] [SCOPE]
+C=COMMIT_GUARDS_BYTE_CEILING_KB
+
+run_rows() { # label | fixture | envs | args | expect
+  local row label fx envs args expect words
+  for row in "$@"; do
+    IFS='|' read -r label fx envs args expect <<<"$row"
+    R=""
+    read -ra words <<<"$fx"
+    "${words[@]}"
+    assert_eq "$label" "$expect" "$(run "$envs" "$args")"
+  done
 }
 
-run_bc() { # [args...] — run in $R at ceiling 1 KB; sets OUT and RC
-  OUT=""
-  RC=0
-  OUT="$(cd "$R" && COMMIT_GUARDS_BYTE_CEILING_KB=1 "$BC" "$@" 2>&1)" || RC=$?
+echo "=== staged mode: an addition past the ceiling fails; at the ceiling passes ==="
+staged() { repo "$1"; put small.bin 1; [ -z "${2-}" ] || put "$2" "$3"; } # NAME [PATH KB] — a 1 KB file, and one more
+run_rows \
+  "a 1 KB addition at ceiling 1 KB passes: at the ceiling is not over it|staged at-ceiling|$C=1||rc=0 $(ok 1)" \
+  "a 2 KB addition at ceiling 1 KB fails naming file, bytes and ceiling, carrying the remedy and counting both staged files|staged over big.bin 2|$C=1||rc=1 $(over big.bin 2048 2 1);$(failed 1 2)" \
+  "a 205 KB addition fails under the built-in 200 KB|staged default-over big.bin 205|||rc=1 $(over big.bin 209920 205 200);$(failed 1 2 200)" \
+  "control: a 100 KB addition passes under the built-in default|staged default-under ok.bin 100|||rc=0 $(ok 2 "$STAGED" 200)"
+
+echo "=== a change: past the ceiling fails; an oversized file may shrink or hold, not grow; a rename is no addition ==="
+grown() { repo "$1"; put seed.bin "$2"; commit; } # NAME KB — one committed file of KB
+fx_edit_over() { grown edit-over 1; put seed.bin 5; }
+fx_edit_under() { grown edit-under 1; put seed.bin 1 x; } # the same size with other bytes
+fx_untouched() { grown untouched 5; }
+fx_shrink() { grown shrink 5; put seed.bin 4; }
+fx_grow() { grown grow 5; put seed.bin 5; printf 'x' >>"$R/seed.bin"; git -C "$R" add -A; }
+fx_hold() { grown hold 5; put seed.bin 5 y; }
+fx_rename() { grown "$1" 5; git -C "$R" mv seed.bin moved.bin; } # NAME
+fx_rename_beside() { fx_rename rename-beside; cp "$R/moved.bin" "$R/second-copy.bin"; printf 'x' >>"$R/second-copy.bin"; git -C "$R" add -A; }
+fx_move_grow() { grown move-grow 4; git -C "$R" mv seed.bin elsewhere.bin; put elsewhere.bin 5; } # 80% similar: a rename at any lower threshold
+fx_copy() { grown copy 3; cp "$R/seed.bin" "$R/twin.bin"; git -C "$R" add -A; }
+fx_typechange() { repo typechange; put payload.bin 5; ln -s payload.bin "$R/thing"; git -C "$R" add -A; commit; rm "$R/thing"; put thing 5; }
+fx_to_symlink() { grown to-symlink 5; rm "$R/seed.bin"; ln -s payload "$R/seed.bin"; git -C "$R" add -A; }
+run_rows \
+  "editing a tracked file past the ceiling fails: the staged lane reads A and M|fx_edit_over|$C=1||rc=1 $(over seed.bin 5120 5 1);$(failed 1 1)" \
+  "control: the same file edited under the ceiling passes|fx_edit_under|$C=1||rc=0 $(ok 1)" \
+  "a committed oversized file is not re-judged while nothing stages it|fx_untouched|$C=1||rc=0 $(ok 0)" \
+  "a staged oversized file may shrink toward the ceiling, and the verdict is the same on a second run|fx_shrink|$C=1||rc=0 $(ok 1)" \
+  "an existing oversized file may not grow, by one byte|fx_grow|$C=1||rc=1 $(grew seed.bin 5120 5121 6 1);$(failed 1 1)" \
+  "an existing oversized file may change without growing|fx_hold|$C=1||rc=0 $(ok 1)" \
+  "renaming an existing large file is not an addition: rename detection is on, and the rename is not counted|fx_rename rename|$C=1||rc=0 $(ok 0)" \
+  "control: a new large file beside the rename still fails, alone|fx_rename_beside|$C=1||rc=1 $(over second-copy.bin 5121 6 1);$(failed 1 1)" \
+  "a file moved AND grown is an addition at its new path: below exact similarity the growth would ride the rename unjudged|fx_move_grow|$C=1||rc=1 $(over elsewhere.bin 5120 5 1);$(failed 1 1)" \
+  "an exact copy of an oversized tracked file is an addition: it duplicates the bytes, only renames are followed|fx_copy|$C=1||rc=1 $(over twin.bin 3072 3 1);$(failed 1 1)" \
+  "a symlink replaced by an oversized regular file fails as an addition: the link had no prior size|fx_typechange|$C=1||rc=1 $(over thing 5120 5 1);$(failed 1 1)" \
+  "control: a file replaced BY a symlink is not sized content|fx_to_symlink|$C=1||rc=0 $(ok 0)"
+
+echo "=== --all sweeps every tracked file; --base REF judges the branch since the merge-base ==="
+legacy() { repo "$1"; put old.bin 4; commit "legacy oversized file"; } # NAME
+feature() { # NAME ACTION — a feature branch over the legacy file: shrink, grow, add
+  legacy "$1"
+  git -C "$R" checkout -qb feature
+  case "$2" in
+    shrink) put old.bin 3; commit "feature: shrinks the legacy file" ;;
+    grow) put old.bin 5; commit "feature: grows the legacy file" ;;
+    add) put feat.bin 2; commit "feature: adds an oversized file" ;;
+    main-moves) put note.bin 1; commit "feature: a note"; git -C "$R" checkout -q main; put old.bin 3; commit "main shrinks the legacy file"; git -C "$R" checkout -q feature ;;
+  esac
 }
-
-run_bc_default() { # [args...] — run in $R at the built-in default ceiling
-  OUT=""
-  RC=0
-  OUT="$(cd "$R" && "$BC" "$@" 2>&1)" || RC=$?
+fx_all_symlink() { repo all-symlink; put old.bin 1; ln -s old.bin "$R/alias"; git -C "$R" add -A; commit; }
+fx_unmerged() { # an add/add conflict: the index carries stages 2 and 3 for one path
+  repo unmerged
+  put base.bin 1; commit
+  git -C "$R" checkout -qb theirs; put clash.bin 1 a; commit
+  git -C "$R" checkout -q main; put clash.bin 1 b; commit
+  git -C "$R" merge -q theirs >/dev/null 2>&1 || true
 }
+run_rows \
+  "staged mode passes with nothing staged: the legacy file is untouched|legacy legacy-staged|$C=1||rc=0 $(ok 0)" \
+  "--all fails on the legacy oversized file, naming the sweep|legacy legacy-all|$C=1|--all|rc=1 $(over old.bin 4096 4 1);$(failed 1 1 1 "$SWEEP")" \
+  "--base main permits a legacy oversized file to shrink|feature base-shrink shrink|$C=1|--base main|rc=0 $(ok 1 "$(since main)")" \
+  "--base main rejects growth from the merge-base size|feature base-grow grow|$C=1|--base main|rc=1 $(grew old.bin 4096 5120 5 1);$(failed 1 1 1 "$(since main)")" \
+  "--base main fails on the branch's added file|feature base-add add|$C=1|--base main|rc=1 $(over feat.bin 2048 2 1);$(failed 1 1 1 "$(since main)")" \
+  "--base=REF is the same mode|feature base-eq add|$C=1|--base=main|rc=1 $(over feat.bin 2048 2 1);$(failed 1 1 1 "$(since main)")" \
+  "--base judges from the merge-base: a legacy file main shrank after the branch point is not the branch's growth|feature base-main-moves main-moves|$C=1|--base main|rc=0 $(ok 1 "$(since main)")" \
+  "--all does not size a tracked symlink: one file checked beside it|fx_all_symlink|$C=1|--all|rc=0 $(ok 1 "$SWEEP")" \
+  "control: --base main on main itself has no additions|legacy base-self|$C=1|--base main|rc=0 $(ok 0 "$(since main)")" \
+  "an unknown --base ref is exit 2, naming it|legacy base-unknown|$C=1|--base no-such-ref|rc=2 ${ERR}--base ref 'no-such-ref' does not name a commit" \
+  "--base without a ref is exit 2|legacy base-bare|$C=1|--base|rc=2 ${ERR}--base requires a ref" \
+  "an unmerged index is refused rather than measured around: the conflict's addition would vanish from the record set|fx_unmerged|$C=1||rc=2 clash.bin;${ERR}the index carries 1 unmerged path(s) (listed above) and a --cached scan skips them silently — finish or abort the merge, then re-run"
 
-echo "=== staged mode: additions over the ceiling fail; at-ceiling passes ==="
-new_repo staged
-mkbytes small.bin 1
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 0 ] && case "$OUT" in *"1 staged file(s) checked"*) true ;; *) false ;; esac \
-  && ok "a 1 KB addition at ceiling 1 KB passes (at-ceiling is not over)" \
-  || bad "at-ceiling addition passes" "rc=$RC out=$OUT"
+echo "=== lockfiles are exempt by basename; declared asset trees by an excludes row with a reason ==="
+fx_lock() { repo "$1"; put package-lock.json 2; } # NAME
+fx_lock_twin() { fx_lock lock-twin; cp "$R/package-lock.json" "$R/data.json"; git -C "$R" add -A; }
+fx_lock_suffix() { repo lock-suffix; put not-package-lock.json 2; }
+asset() { repo "$1"; put assets/demo.gif 2; } # NAME
+fx_excluded() { asset excluded; excludes 'assets/*\tdemo media\n'; }
+fx_no_reason() { asset no-reason; excludes 'assets/*\n'; }
+fx_excludes_flag() { asset "$1"; mkdir -p "$R/conf"; printf 'assets/*\tdemo media\n' >"$R/conf/excludes"; git -C "$R" add -A; }
+run_rows \
+  "an oversized package-lock.json passes and is not counted: the built-in lockfile exemption|fx_lock lock|$C=1||rc=0 $(ok 0)" \
+  "control: the same bytes as data.json fail, the exemption is the basename|fx_lock_twin|$C=1||rc=1 $(over data.json 2048 2 1);$(failed 1 1)" \
+  "control: a basename that only ends in a lockfile's name is not exempt|fx_lock_suffix|$C=1||rc=1 $(over not-package-lock.json 2048 2 1);$(failed 1 1)" \
+  "control: an asset fails without an excludes row|asset asset-bare|$C=1||rc=1 $(over assets/demo.gif 2048 2 1);$(failed 1 1)" \
+  "an excludes row exempts the declared tree; the list itself is a staged file and is counted|fx_excluded|$C=1||rc=0 $(ok 1)" \
+  "a pattern without a reason is exit 2 naming the line|fx_no_reason|$C=1||rc=2 ${ERR}$EXCL:1: expected 'pattern<TAB>reason' (every exclusion carries its justification)" \
+  "--excludes FILE names the list, and the remedy names it too|fx_excludes_flag excludes-flag|$C=1|--excludes conf/excludes|rc=0 $(ok 1)" \
+  "control: without the flag the same repository fails on the asset, and the remedy names the default list|fx_excludes_flag excludes-default|$C=1||rc=1 $(over assets/demo.gif 2048 2 1);$(failed 1 2)"
 
-mkbytes big.bin 2
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 1 ] && case "$OUT" in *"oversized file: big.bin — 2048 bytes"*"> ceiling 1 KB"*) true ;; *) false ;; esac \
-  && ok "a 2 KB addition at ceiling 1 KB fails, naming file/bytes/ceiling" \
-  || bad "oversized addition fails with bytes and ceiling" "rc=$RC out=$OUT"
-case "$OUT" in *"asset store, Git LFS, build-time generation"*) ok "diagnostic carries the remediation" ;; *) bad "diagnostic carries the remediation" "$OUT" ;; esac
+echo "=== the ceiling resolves through the settings ladder and is validated ==="
+cfg() { repo "$1"; put f.txt 1; } # NAME
+fx_settings() { cfg "$1"; printf '[env]\nCOMMIT_GUARDS_BYTE_CEILING_KB = "3"\n' >"$R/kendex.settings.toml"; put big.bin 4; }
+run_rows \
+  "a non-numeric ceiling is exit 2, quoting it|cfg non-numeric|$C=abc||rc=2 ${ERR}COMMIT_GUARDS_BYTE_CEILING_KB must be a positive integer, got 'abc'" \
+  "a zero ceiling is exit 2|cfg zero|$C=0||rc=2 ${ERR}COMMIT_GUARDS_BYTE_CEILING_KB must be a positive integer, got '0'" \
+  "an unknown flag is exit 2, quoting it|cfg unknown-flag|$C=1|--no-such-flag|rc=2 ${ERR}unknown argument '--no-such-flag' (see --help)" \
+  "kendex.settings.toml supplies the ceiling: 4 KB fails at 3 where the built-in 200 would pass|fx_settings settings-file|||rc=1 $(over big.bin 4096 4 3);$(failed 1 3 3)" \
+  "the environment overrides the settings file: 5 passes where 3 failed|fx_settings settings-env|$C=5||rc=0 $(ok 3 "$STAGED" 5)"
+assert_eq "--help prints usage at exit 0" "rc=0 usage: byte-ceiling [--staged | --base REF | --all] [--excludes FILE]" "$(run '' --help | LC_ALL=C cut -d';' -f1)"
+assert_eq "-h is --help" "$(run '' --help)" "$(run '' -h)"
 
-echo "=== the built-in default 200 KB is real, not vacuous ==="
-new_repo defreal
-mkbytes big.bin 205
-git -C "$R" add -A
-run_bc_default
-[ "$RC" -eq 1 ] && case "$OUT" in *"ceiling 200 KB"*) true ;; *) false ;; esac \
-  && ok "a 205 KB addition fails under the built-in default 200" \
-  || bad "default 200 can fail" "rc=$RC out=$OUT"
-rm "$R/big.bin"
-mkbytes ok.bin 100
-git -C "$R" add -A
-run_bc_default
-[ "$RC" -eq 0 ] && ok "a 100 KB addition passes under the default (control)" \
-  || bad "100 KB passes under the default" "rc=$RC out=$OUT"
-
-echo "=== diff-scoping: a change over the ceiling fails; a rename does not ==="
-new_repo grown
-mkbytes seed.bin 1
-git -C "$R" add -A
-git -C "$R" commit -qm "seed: a file under the ceiling"
-mkbytes seed.bin 5
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 1 ] && case "$OUT" in *"seed.bin"*"5120 bytes"*) true ;; *) false ;; esac \
-  && ok "editing a tracked file past the ceiling fails (the staged lane reads A and M)" \
-  || bad "a change over the ceiling fails" "rc=$RC out=$OUT"
-mkbytes seed.bin 1
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 0 ] && ok "control: the same file edited back under the ceiling passes" \
-  || bad "control: back under the ceiling passes" "rc=$RC out=$OUT"
-mkbytes seed.bin 5
-git -C "$R" add -A
-git -C "$R" commit -qm "grow it past the ceiling"
-run_bc
-[ "$RC" -eq 0 ] && ok "a committed oversized file is not re-judged while nothing stages it" \
-  || bad "a committed oversized file is not re-judged while nothing stages it" "rc=$RC out=$OUT"
-mkbytes seed.bin 4
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 0 ] && ok "a staged oversized file may shrink toward the ceiling" \
-  || bad "a staged oversized file may shrink toward the ceiling" "rc=$RC out=$OUT"
-run_bc
-[ "$RC" -eq 0 ] && ok "the same staged shrink gives a stable clean verdict" \
-  || bad "the same staged shrink gives a stable clean verdict" "rc=$RC out=$OUT"
-mkbytes seed.bin 5
-printf 'x' >>"$R/seed.bin"
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 1 ] && case "$OUT" in *"oversized file grew: seed.bin"*"5120 -> 5121 bytes"*) true ;; *) false ;; esac \
-  && ok "an existing oversized file may not grow" \
-  || bad "an existing oversized file may not grow" "rc=$RC out=$OUT"
-mkbytes seed.bin 5
-printf 'y' | dd of="$R/seed.bin" bs=1 seek=0 conv=notrunc 2>/dev/null
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 0 ] && ok "an existing oversized file may change without increasing its size" \
-  || bad "an existing oversized file may hold its size" "rc=$RC out=$OUT"
-mkbytes seed.bin 5
-git -C "$R" add -A
-git -C "$R" mv seed.bin moved.bin
-run_bc
-[ "$RC" -eq 0 ] && ok "renaming an existing large file is not an addition (rename detection pinned on)" \
-  || bad "rename is not an addition" "rc=$RC out=$OUT"
-# A move that also grows is not a move: below exact similarity it would be one
-# R record the filter drops, and the growth would arrive unjudged.
-new_repo movedgrown
-mkbytes carried.bin 1
-git -C "$R" add -A
-git -C "$R" commit -qm "seed: a file under the ceiling"
-git -C "$R" mv carried.bin elsewhere.bin
-mkbytes elsewhere.bin 5
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 1 ] && case "$OUT" in *"elsewhere.bin"*"5120 bytes"*) true ;; *) false ;; esac \
-  && ok "a file moved AND grown past the ceiling fails at its new path" \
-  || bad "a file moved AND grown past the ceiling fails at its new path" "rc=$RC out=$OUT"
-# A type change carries a new blob too: the symlink's target was a few bytes.
-new_repo typechange
-mkbytes payload.bin 5
-ln -s payload.bin "$R/thing"
-git -C "$R" add -A
-git -C "$R" commit -qm "seed: a symlink beside its target"
-rm "$R/thing"
-mkbytes thing 5
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 1 ] && case "$OUT" in *"thing"*"5120 bytes"*) true ;; *) false ;; esac \
-  && ok "a symlink replaced by an oversized regular file fails (type change)" \
-  || bad "a symlink replaced by an oversized regular file fails (type change)" "rc=$RC out=$OUT"
-new_repo grown2
-mkbytes seed.bin 5
-git -C "$R" add -A
-git -C "$R" commit -qm "seed: an oversized tracked file"
-rm "$R/seed.bin"
-ln -s payload "$R/seed.bin"
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 0 ] && ok "control: a file replaced BY a symlink is not sized content" \
-  || bad "control: a file replaced BY a symlink is not sized content" "rc=$RC out=$OUT"
-R="$TMP/grown" # back to the renamed fixture; the copy case below builds on it
-cp "$R/moved.bin" "$R/second-copy.bin" 2>/dev/null || true
-printf 'x' >>"$R/second-copy.bin"
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 1 ] && case "$OUT" in *"second-copy.bin"*) true ;; *) false ;; esac \
-  && ok "control: a genuinely new large file beside the rename still fails" \
-  || bad "control: new large file fails beside the rename" "rc=$RC out=$OUT"
-new_repo copy
-mkbytes big.bin 3
-git -C "$R" add -A
-git -C "$R" commit -qm "seed: an oversized tracked file"
-cp "$R/big.bin" "$R/twin.bin"
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 1 ] && case "$OUT" in *"twin.bin"*) true ;; *) false ;; esac \
-  && ok "an exact copy of an oversized tracked file IS an addition (it duplicates the bytes; only renames are followed)" \
-  || bad "an exact copy is an addition" "rc=$RC out=$OUT"
-
-echo "=== --all: the full sweep gates legacy files the staged mode skips ==="
-new_repo legacy
-mkbytes old.bin 4
-git -C "$R" add -A
-git -C "$R" commit -qm "seed: legacy oversized file"
-run_bc
-[ "$RC" -eq 0 ] && ok "staged mode passes with nothing staged (legacy untouched)" \
-  || bad "staged mode passes on the legacy repo" "rc=$RC out=$OUT"
-run_bc --all
-[ "$RC" -eq 1 ] && case "$OUT" in *"old.bin"*"full sweep"*) true ;; *) false ;; esac \
-  && ok "--all fails on the legacy oversized file" || bad "--all fails on legacy" "rc=$RC out=$OUT"
-
-echo "=== --base REF: additions and changes since the merge-base ==="
-git -C "$R" checkout -qb feature
-mkbytes old.bin 3
-git -C "$R" add -A
-git -C "$R" commit -qm "feature shrinks the legacy file"
-run_bc --base main
-[ "$RC" -eq 0 ] && case "$OUT" in *"added or changed since main"*) true ;; *) false ;; esac \
-  && ok "--base main permits a legacy oversized file to shrink" \
-  || bad "--base permits a legacy oversized file to shrink" "rc=$RC out=$OUT"
-mkbytes old.bin 5
-git -C "$R" add -A
-git -C "$R" commit -qm "feature grows the legacy file"
-run_bc --base main
-[ "$RC" -eq 1 ] && case "$OUT" in *"oversized file grew: old.bin"*"4096 -> 5120 bytes"*) true ;; *) false ;; esac \
-  && ok "--base main rejects growth from the merge-base size" \
-  || bad "--base rejects growth from the merge-base size" "rc=$RC out=$OUT"
-mkbytes feat.bin 2
-git -C "$R" add -A
-git -C "$R" commit -qm "feature adds an oversized file"
-run_bc --base main
-[ "$RC" -eq 1 ] && case "$OUT" in *"feat.bin"*"added or changed since main"*) true ;; *) false ;; esac \
-  && ok "--base main fails on the branch's added file" || bad "--base fails on the added file" "rc=$RC out=$OUT"
-git -C "$R" checkout -q main
-run_bc --base main
-[ "$RC" -eq 0 ] && ok "control: --base main on main itself has no additions" \
-  || bad "control: --base with no additions passes" "rc=$RC out=$OUT"
-run_bc --base no-such-ref
-[ "$RC" -eq 2 ] && ok "an unknown --base ref is exit 2" || bad "unknown --base ref is exit 2" "rc=$RC out=$OUT"
-
-echo "=== lockfiles are exempt by basename; same bytes elsewhere are not ==="
-new_repo lock
-mkbytes package-lock.json 2
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 0 ] && ok "an oversized package-lock.json passes (built-in lockfile exemption)" \
-  || bad "lockfile exemption" "rc=$RC out=$OUT"
-cp "$R/package-lock.json" "$R/data.json"
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 1 ] && case "$OUT" in *"data.json"*) true ;; *) false ;; esac \
-  && ok "control: the same bytes as data.json fail — the exemption is the basename, not the size" \
-  || bad "control: non-lockfile with same bytes fails" "rc=$RC out=$OUT"
-
-echo "=== excludes: declared asset trees, reason mandatory ==="
-new_repo assets
-mkdir -p "$R/tools"
-mkbytes assets/demo.gif 2
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 1 ] && ok "control: the asset fails without an excludes row" \
-  || bad "control: asset fails without excludes" "rc=$RC out=$OUT"
-printf 'assets/*\tdemo media\n' >"$R/tools/byte-ceiling-excludes"
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 0 ] && ok "the excludes row exempts the declared asset tree" \
-  || bad "excludes row exempts the asset tree" "rc=$RC out=$OUT"
-printf 'assets/*\n' >"$R/tools/byte-ceiling-excludes"
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 2 ] && ok "a pattern without a reason is exit 2" || bad "pattern without a reason is exit 2" "rc=$RC out=$OUT"
-
-echo "=== configuration errors ==="
-new_repo cfg
-printf 'x\n' >"$R/f.txt"
-git -C "$R" add -A
-OUT="$(cd "$R" && COMMIT_GUARDS_BYTE_CEILING_KB=abc "$BC" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && ok "non-numeric ceiling is exit 2" || bad "non-numeric ceiling is exit 2" "rc=$RC out=$OUT"
-OUT="$(cd "$R" && COMMIT_GUARDS_BYTE_CEILING_KB=0 "$BC" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && ok "zero ceiling is exit 2" || bad "zero ceiling is exit 2" "rc=$RC out=$OUT"
-run_bc --no-such-flag
-[ "$RC" -eq 2 ] && ok "unknown flag is exit 2" || bad "unknown flag is exit 2" "rc=$RC out=$OUT"
-
-echo "=== settings file resolution ==="
-printf '[env]\nCOMMIT_GUARDS_BYTE_CEILING_KB = "3"\n' >"$R/kendex.settings.toml"
-mkbytes big.bin 4
-git -C "$R" add -A
-run_bc_default
-[ "$RC" -eq 1 ] && case "$OUT" in *"ceiling 3 KB"*) true ;; *) false ;; esac \
-  && ok "kendex.settings.toml overrides the default (4 KB > 3 fails; 200 would have passed)" \
-  || bad "settings file overrides the default" "rc=$RC out=$OUT"
-OUT="$(cd "$R" && COMMIT_GUARDS_BYTE_CEILING_KB=5 "$BC" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && ok "environment overrides the settings file (5 passes where 3 failed)" \
-  || bad "environment overrides the settings file" "rc=$RC out=$OUT"
-
-echo "=== an EXISTING non-regular settings path never falls back to defaults ==="
-# A directory fails -f exactly like an absent file, so the configured settings
-# would be skipped with nothing said and the built-in 200 KB would decide.
-mkdir -p "$R/nonregular.dir"
-OUT="$(cd "$R" && COMMIT_GUARDS_SETTINGS_FILE=nonregular.dir "$BC" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"not a regular file"*) true ;; *) false ;; esac \
-  && ok "a DIRECTORY settings path is exit 2, not a silent built-in default" \
-  || bad "a DIRECTORY settings path is exit 2" "rc=$RC out=$OUT"
-
-# A symlink that does not resolve fails -e as well as -f, so an existence
-# test alone never sees it — the same silent-defaults trap one shape over.
-ln -s missing.toml "$R/dangling.settings.toml"
-OUT="$(cd "$R" && COMMIT_GUARDS_SETTINGS_FILE=dangling.settings.toml "$BC" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"does not resolve"*) true ;; *) false ;; esac \
-  && ok "a DANGLING symlink settings path is exit 2, not a silent built-in default" \
-  || bad "a DANGLING symlink settings path is exit 2" "rc=$RC out=$OUT"
-
-ln -s cycle-b.settings.toml "$R/cycle-a.settings.toml"
-ln -s cycle-a.settings.toml "$R/cycle-b.settings.toml"
-OUT="$(cd "$R" && COMMIT_GUARDS_SETTINGS_FILE=cycle-a.settings.toml "$BC" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"does not resolve"*) true ;; *) false ;; esac \
-  && ok "a CYCLIC symlink settings path is exit 2, not a silent built-in default" \
-  || bad "a CYCLIC symlink settings path is exit 2" "rc=$RC out=$OUT"
-
-# A RESOLVING symlink is an ordinary install shape and must still read.
-printf '[env]\nCOMMIT_GUARDS_BYTE_CEILING_KB = "3"\n' >"$R/link-target.settings.toml"
-ln -s link-target.settings.toml "$R/link.settings.toml"
-OUT="$(cd "$R" && COMMIT_GUARDS_SETTINGS_FILE=link.settings.toml "$BC" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 1 ] && case "$OUT" in *"ceiling 3 KB"*) true ;; *) false ;; esac \
-  && ok "a RESOLVING symlink reads its target (control: 4 KB > 3 fails; 200 would have passed)" \
-  || bad "a RESOLVING symlink reads its target (control)" "rc=$RC out=$OUT"
-
-# Controls: the two shapes that MUST still resolve to the built-in default
-# (200 KB, under which the 4 KB addition passes).
-OUT="$(cd "$R" && COMMIT_GUARDS_SETTINGS_FILE=/dev/null "$BC" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && ok "/dev/null still forces the built-in default (control)" \
-  || bad "/dev/null still forces the built-in default (control)" "rc=$RC out=$OUT"
-
-OUT="$(cd "$R" && COMMIT_GUARDS_SETTINGS_FILE=absent.settings.toml "$BC" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && ok "an ABSENT plain file still falls back to the built-in default (control)" \
-  || bad "an ABSENT plain file still falls back to the built-in default (control)" "rc=$RC out=$OUT"
-rmdir "$R/nonregular.dir"
-
-echo "=== settings: an unreadable source fails loud, never falls through ==="
-if [ "$(id -u)" -eq 0 ]; then
-  printf '  skip  unreadable-source pins need a non-root reader (chmod 000 cannot deny root)\n'
-else
-  printf 'COMMIT_GUARDS_BYTE_CEILING_KB=5\n' >"$R/.env.local"
-  chmod 000 "$R/.env.local"
-  run_bc_default
-  [ "$RC" -eq 2 ] && case "$OUT" in *"unreadable while resolving a setting"*) true ;; *) false ;; esac \
-    && ok "an unreadable .env.local is exit 2 (falling through would have read 3 from the settings file and exited 1)" \
-    || bad "unreadable .env.local is exit 2" "rc=$RC out=$OUT"
-  chmod 600 "$R/.env.local"
-  run_bc_default
-  [ "$RC" -eq 0 ] && ok "control: the same .env.local, readable, supplies 5 and the 4 KB file passes" \
-    || bad "control: readable .env.local supplies the value" "rc=$RC out=$OUT"
-  rm "$R/.env.local"
-fi
-
-echo "=== an EXISTING non-regular ENV-FILE source never falls through ==="
-# .env.local is probed with -f like the settings file, so a directory or an
-# unresolvable symlink there is skipped exactly like an absent one and a
-# lower-precedence value silently decides.
-mkdir -p "$R/.env.local"
-run_bc_default
-[ "$RC" -eq 2 ] && case "$OUT" in *".env.local: settings source exists but is not a regular file"*) true ;; *) false ;; esac \
-  && ok "a DIRECTORY at .env.local is exit 2 (falling through would have read 3 from the settings file)" \
-  || bad "a DIRECTORY at .env.local is exit 2" "rc=$RC out=$OUT"
-rmdir "$R/.env.local"
-
-ln -s missing.env "$R/.env.local"
-run_bc_default
-[ "$RC" -eq 2 ] && case "$OUT" in *".env.local: settings source is a symlink that does not resolve"*) true ;; *) false ;; esac \
-  && ok "a DANGLING .env.local symlink is exit 2, not a silent skip" \
-  || bad "a DANGLING .env.local symlink is exit 2" "rc=$RC out=$OUT"
-rm -f "$R/.env.local"
-
-run_bc_default
-[ "$RC" -eq 1 ] && case "$OUT" in *"ceiling 3 KB"*) true ;; *) false ;; esac \
-  && ok "control: with .env.local absent the settings file still supplies 3" \
-  || bad "control: an absent env file falls through to the settings file" "rc=$RC out=$OUT"
-
-echo "=== fail-closed: a broken blob measurement terminates, never passes ==="
-new_repo measure
-mkbytes big.bin 2
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 1 ] && ok "shim-free control: the oversized staged file really fails" \
-  || bad "shim-free control fails on the oversized file" "rc=$RC out=$OUT"
+echo "=== fail-closed: a broken blob measurement is a collection error, never a pass ==="
+# A git ahead of PATH whose `cat-file -s` fails as an object read does.
 REAL_GIT="$(command -v git)"
-GIT_SHIM="$TMP/git-shim"
-mkdir -p "$GIT_SHIM"
-cat >"$GIT_SHIM/git" <<EOF
-#!/usr/bin/env bash
-if [ "\${1:-}" = "cat-file" ] && [ "\${2:-}" = "-s" ]; then
-  echo "fatal: simulated object read failure" >&2
-  exit 128
-fi
-exec "$REAL_GIT" "\$@"
-EOF
-chmod +x "$GIT_SHIM/git"
-OUT="$(cd "$R" && PATH="$GIT_SHIM:$PATH" COMMIT_GUARDS_BYTE_CEILING_KB=1 "$BC" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"cannot read blob"*"big.bin"*) true ;; *) false ;; esac \
-  && ok "an unmeasurable blob is a collection error: exit 2, diagnostic names the file" \
-  || bad "an unmeasurable blob is a collection error naming the file" "rc=$RC out=$OUT"
-case "$OUT" in *"byte-ceiling: OK"*) bad "no OK verdict may accompany a broken measurement" "$OUT" ;; *) ok "no OK verdict accompanies the broken measurement" ;; esac
+mkdir -p "$TMP/git-shim"
+printf '#!/usr/bin/env bash\nif [ "${1:-}" = cat-file ] && [ "${2:-}" = -s ]; then echo "fatal: simulated object read failure" >&2; exit 128; fi\nexec %q "$@"\n' "$REAL_GIT" >"$TMP/git-shim/git"
+chmod +x "$TMP/git-shim/git"
+SHA2K="$(head -c 2048 /dev/zero | git hash-object --stdin)"
+measure() { repo "$1"; put big.bin 2; } # NAME
+run_rows \
+  "control: without the shim the oversized staged file fails|measure measure-real|$C=1||rc=1 $(over big.bin 2048 2 1);$(failed 1 1)" \
+  "an unmeasurable blob is exit 2 naming the blob and the file, with no verdict line, git's own words ahead of it|measure measure-shim|PATH=$TMP/git-shim:$PATH,$C=1||rc=2 fatal: simulated object read failure;${ERR}cannot read blob $SHA2K for 'big.bin' — its size is unmeasurable, refusing to skip it"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.agents/skills/commit-guards/tests/settings-precedence.test.sh
+++ b/.agents/skills/commit-guards/tests/settings-precedence.test.sh
@@ -1,137 +1,151 @@
 #!/usr/bin/env bash
-# Precedence pins for lib/settings.sh's gg_setting contract: explicit env >
-# .env.local > .kendex/settings.toml > kendex.settings.toml > built-in
-# default, with `.env` read by nothing, only the [env] table consulted, and
-# the contract value grammar (single-line double-quoted, no `"`, no `\`)
-# enforced loudly.
+# Pins for lib/settings.sh's gg_setting contract: explicit env > .env.local
+# > .kendex/settings.toml > kendex.settings.toml > built-in default, with
+# `.env` read by nothing, only the [env] table consulted, the contract value
+# grammar (single-line double-quoted, no `"`, no `\`) enforced loudly over
+# the whole table, a malformed lower source failing under a higher override,
+# and a source skipped only when it is ABSENT: a directory, a dangling or
+# cyclic symlink, or an unreadable file at a source path is a loud refusal,
+# never a silent fall-through to the next layer. One table: a world builds
+# the directory, the key resolves under ENVS, and a row pins the exit
+# status with the value printed and every error line. The staged-index
+# resolution of a tracked source is index-reads.test.sh's and
+# commit-msg-settings.test.sh's.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+SETTINGS="$SKILL_DIR/scripts/lib/settings.sh"
 # shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
 
-# shellcheck source=../scripts/lib/settings.sh
-source "$SKILL_DIR/scripts/lib/settings.sh"
-
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
-
-R="$TMP/repo"
-mkdir -p "$R/.kendex"
-
-resolve() { # NAME DEFAULT [ENV_ASSIGN] — sets OUT and RC from inside the repo
-  OUT=""; RC=0
-  OUT="$(cd "$R" && { unset "$1" COMMIT_GUARDS_SETTINGS_FILE 2>/dev/null; env ${3:+"$3"} bash -c '
-    set -euo pipefail
-    source "$0"
-    gg_setting "$1" "$2"
-  ' "$SKILL_DIR/scripts/lib/settings.sh" "$1" "$2" 2>"$TMP/err"; })" || RC=$?
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
 }
 
-echo "=== the resolution ladder, one layer at a time ==="
-resolve COMMIT_GUARDS_TP "dflt"
-[ "$RC" -eq 0 ] && [ "$OUT" = "dflt" ] && ok "no source configured: the built-in default answers" || bad "built-in default answers" "rc=$RC out=$OUT"
-
-printf '[env]\nCOMMIT_GUARDS_TP = "root"\n' >"$R/kendex.settings.toml"
-resolve COMMIT_GUARDS_TP "dflt"
-[ "$RC" -eq 0 ] && [ "$OUT" = "root" ] && ok "kendex.settings.toml supplies the value" || bad "kendex.settings.toml supplies the value" "rc=$RC out=$OUT"
-
-printf '[env]\nCOMMIT_GUARDS_TP = "nested"\n' >"$R/.kendex/settings.toml"
-resolve COMMIT_GUARDS_TP "dflt"
-[ "$RC" -eq 0 ] && [ "$OUT" = "nested" ] && ok ".kendex/settings.toml beats kendex.settings.toml" || bad ".kendex/settings.toml beats kendex.settings.toml" "rc=$RC out=$OUT"
-
-printf 'COMMIT_GUARDS_TP=dotenv\n' >"$R/.env.local"
-resolve COMMIT_GUARDS_TP "dflt"
-[ "$RC" -eq 0 ] && [ "$OUT" = "dotenv" ] && ok ".env.local beats both settings files" || bad ".env.local beats both settings files" "rc=$RC out=$OUT"
-
-resolve COMMIT_GUARDS_TP "dflt" "COMMIT_GUARDS_TP=explicit"
-[ "$RC" -eq 0 ] && [ "$OUT" = "explicit" ] && ok "explicit environment beats every project file" || bad "explicit environment beats every project file" "rc=$RC out=$OUT"
-
-resolve COMMIT_GUARDS_TP "dflt" "COMMIT_GUARDS_TP="
-[ "$RC" -eq 0 ] && [ "$OUT" = "" ] && ok "a SET-but-empty environment value still wins (explicitly empty)" || bad "set-but-empty environment wins" "rc=$RC out=$OUT"
-rm -f "$R/.env.local" "$R/.kendex/settings.toml" "$R/kendex.settings.toml"
-
-echo "=== a .env value is read by nothing ==="
-# Fails against a resolver that still reads the dropped layer: the value
-# would resolve instead of the default.
-printf 'COMMIT_GUARDS_TP=from-dotenv\n' >"$R/.env"
-resolve COMMIT_GUARDS_TP "dflt"
-[ "$RC" -eq 0 ] && [ "$OUT" = "dflt" ] && ok "a .env assignment is ignored and the default answers" || bad "a .env assignment is ignored" "rc=$RC out=$OUT"
-rm -f "$R/.env"
-
-echo "=== only the [env] table is read ==="
-printf 'COMMIT_GUARDS_TT = "top"\n[env]\nCOMMIT_GUARDS_OTHER = "x"\n' >"$R/kendex.settings.toml"
-resolve COMMIT_GUARDS_TT "dflt"
-[ "$RC" -eq 0 ] && [ "$OUT" = "dflt" ] && ok "an assignment ABOVE the [env] header is ignored" || bad "assignment above [env] ignored" "rc=$RC out=$OUT"
-
-printf '[notes]\nCOMMIT_GUARDS_TT = "elsewhere"\n' >"$R/kendex.settings.toml"
-resolve COMMIT_GUARDS_TT "dflt"
-[ "$RC" -eq 0 ] && [ "$OUT" = "dflt" ] && ok "an assignment under an UNRELATED table is ignored" || bad "assignment under another table ignored" "rc=$RC out=$OUT"
-
-printf '[env]\nCOMMIT_GUARDS_TT = "in-env"\n' >"$R/kendex.settings.toml"
-resolve COMMIT_GUARDS_TT "dflt"
-[ "$RC" -eq 0 ] && [ "$OUT" = "in-env" ] && ok "control: the same assignment inside [env] resolves" || bad "control: [env] assignment resolves" "rc=$RC out=$OUT"
-
-echo "=== ambiguity and the contract grammar fail loud ==="
-printf '[env]\nCOMMIT_GUARDS_TT = "a"\nCOMMIT_GUARDS_TT = "b"\n' >"$R/kendex.settings.toml"
-resolve COMMIT_GUARDS_TT "dflt"
-[ "$RC" -ne 0 ] && grep -q "assigned more than once in \[env\]" "$TMP/err" && ok "a duplicate inside [env] is a config error" || bad "duplicate inside [env] errors" "rc=$RC out=$OUT"
-
-printf '[env]\nCOMMIT_GUARDS_TT = "a\\b"\n' >"$R/kendex.settings.toml"
-resolve COMMIT_GUARDS_TT "dflt"
-[ "$RC" -ne 0 ] && grep -q "unsupported syntax" "$TMP/err" && ok "a backslash in the value is a config error, never decoded" || bad "backslash value errors" "rc=$RC out=$OUT"
-
-printf '[env]\nCOMMIT_GUARDS_TT = "kept" # comment\n' >"$R/kendex.settings.toml"
-resolve COMMIT_GUARDS_TT "dflt"
-[ "$RC" -eq 0 ] && [ "$OUT" = "kept" ] && ok "a trailing comment is dropped from the decoded value" || bad "trailing comment decode" "rc=$RC out=$OUT"
-
-echo "=== a header the parser cannot read fails loud ==="
-# Headers decide which assignments load: `[env] # comment` passing as
-# content hides the whole table behind silent defaults.
-printf '[env] # comment\nCOMMIT_GUARDS_TT = "hidden"\n' >"$R/kendex.settings.toml"
-resolve COMMIT_GUARDS_TT "dflt"
-[ "$RC" -ne 0 ] && grep -q "unsupported table header shape" "$TMP/err" && ok "a commented [env] header is a config error, not an invisible table" || bad "commented [env] header errors" "rc=$RC out=$OUT"
-
-echo "=== a SET-but-EMPTY settings-file override is unset, not a source ==="
-# "" names no file: consulting only it resolved every key to its built-in
-# default with nothing said. /dev/null stays the one force-defaults handle.
-printf '[env]\nCOMMIT_GUARDS_TT = "fromrepo"\n' >"$R/kendex.settings.toml"
-OUT=""; RC=0
-OUT="$(cd "$R" && { unset COMMIT_GUARDS_TT 2>/dev/null; env COMMIT_GUARDS_SETTINGS_FILE= bash -c '
+# One line for a resolution in the row's world: the exit status, the value
+# printed, and every error line joined by ';'. The key and the settings-file
+# override are unset first, so only ENVS (comma-separated assignments)
+# reach the resolver.
+K=COMMIT_GUARDS_TP
+R=""
+resolve() { # ENVS [KEY]
+  local envs=() rc=0 out="" err=""
+  [ -z "$1" ] || IFS=',' read -ra envs <<<"$1"
+  out="$(cd "$R" && { unset "$K" COMMIT_GUARDS_SETTINGS_FILE 2>/dev/null; env ${envs[@]+"${envs[@]}"} bash -c '
     set -euo pipefail
     source "$0"
-    gg_setting "$1" "$2"
-  ' "$SKILL_DIR/scripts/lib/settings.sh" COMMIT_GUARDS_TT "dflt" 2>"$TMP/err"; })" || RC=$?
-[ "$RC" -eq 0 ] && [ "$OUT" = "fromrepo" ] && ok "a SET-but-EMPTY COMMIT_GUARDS_SETTINGS_FILE reads the default sources" || bad "set-but-empty override reads default sources" "rc=$RC out=$OUT"
+    gg_setting "$1" dflt
+  ' "$SETTINGS" "${2:-$K}" 2>"$TMP/err"; })" || rc=$?
+  # bash names the resolver's own path and line when a redirect inside it is
+  # refused; the path and the line number are not the row's to pin.
+  err="$(LC_ALL=C sed -e "s#$SETTINGS#<settings.sh>#" -e 's/line [0-9]*:/line N:/' "$TMP/err" | LC_ALL=C paste -sd ';' -)"
+  printf 'rc=%s value=%s%s' "$rc" "$out" "${err:+ err=$err}"
+}
 
-echo "=== the WHOLE [env] table is validated, not only the requested key ==="
-# kendex-env.sh refuses these same files, so a per-key-only extractor would
-# split the family contract.
-printf '[env]\nUNRELATED = bare\nCOMMIT_GUARDS_TT = "v"\n' >"$R/kendex.settings.toml"
-resolve COMMIT_GUARDS_TT "dflt"
-[ "$RC" -ne 0 ] && grep -q "unsupported syntax for UNRELATED" "$TMP/err" && ok "an unrelated non-contract assignment fails the read" || bad "unrelated malformed assignment" "rc=$RC out=$OUT"
+# World vocabulary: a fresh directory per row, a name used twice refused.
+world() { # NAME
+  R="$TMP/$1"
+  [ ! -e "$R" ] || { echo "harness: world $1 already exists" >&2; exit 2; }
+  mkdir -p "$R/.kendex"
+}
+put() { printf '%b' "$2" >"$R/$1"; } # PATH CONTENT (printf %b)
+root() { world "$1"; put kendex.settings.toml '[env]\nCOMMIT_GUARDS_TP = "root"\n'; } # NAME — the root file says root
+fx_nested() { root "$1"; put .kendex/settings.toml '[env]\nCOMMIT_GUARDS_TP = "nested"\n'; } # NAME
+fx_dotenv() { fx_nested "$1"; put .env.local 'COMMIT_GUARDS_TP=dotenv\n'; } # NAME
+fx_dotenv_only() { world dotenv-only; put .env 'COMMIT_GUARDS_TP=from-dotenv\n'; }
+toml() { world "$1"; shift; put kendex.settings.toml "$*"; } # NAME CONTENT... — the root file holds CONTENT, the fixture column's words rejoined
+fx_backslash() { world backslash; printf '[env]\nCOMMIT_GUARDS_TP = "a\\b"\n' >"$R/kendex.settings.toml"; }
+fx_bom() { world bom; printf '\357\273\277[env]\nCOMMIT_GUARDS_TP = "hidden"\n' >"$R/kendex.settings.toml"; }
+fx_dir_settings() { root dir-settings; mkdir -p "$R/nonregular.dir"; }
+fx_dangling() { root dangling; ln -s missing.toml "$R/dangling.settings.toml"; }
+fx_cyclic() { root cyclic; ln -s cycle-b.settings.toml "$R/cycle-a.settings.toml"; ln -s cycle-a.settings.toml "$R/cycle-b.settings.toml"; }
+fx_resolving() { root resolving; put link-target.settings.toml '[env]\nCOMMIT_GUARDS_TP = "linked"\n'; ln -s link-target.settings.toml "$R/link.settings.toml"; }
+fx_env_dir() { root "$1"; mkdir -p "$R/.env.local"; } # NAME
+fx_env_dangling() { root env-dangling; ln -s missing.env "$R/.env.local"; }
+dotenv() { root "$1"; shift; put .env.local "$*\n"; } # NAME LINE... — .env.local holds the rejoined words
+ERR_DUP='::error::kendex.settings.toml: COMMIT_GUARDS_TP is assigned more than once in [env] (each key must be unique in the table)'
+NOT_REGULAR='settings source exists but is not a regular file (directory, FIFO, socket or device); a source is skipped only when it is absent'
+NOT_RESOLVING='settings source is a symlink that does not resolve (dangling target, cycle, or over-long chain); a source is skipped only when it is absent'
 
-printf '[env]\nUNRELATED = "a"\nUNRELATED = "b"\nCOMMIT_GUARDS_TT = "v"\n' >"$R/kendex.settings.toml"
-resolve COMMIT_GUARDS_TT "dflt"
-[ "$RC" -ne 0 ] && grep -q "UNRELATED is assigned more than once" "$TMP/err" && ok "an unrelated duplicated key fails the read" || bad "unrelated duplicated key" "rc=$RC out=$OUT"
+run_rows() { # label | world | envs | expect
+  local row label fx envs expect words
+  for row in "$@"; do
+    IFS='|' read -r label fx envs expect <<<"$row"
+    R=""
+    read -ra words <<<"$fx"
+    "${words[@]}"
+    assert_eq "$label" "$expect" "$(resolve "$envs")"
+  done
+}
 
-echo "=== a malformed lower file fails even under a higher-precedence override ==="
-# kendex-env validates before its parent-env skip; an exported value must
-# never let a broken committed file pass silently.
-printf '[env]\nDUP = "a"\nDUP = "b"\n' >"$R/kendex.settings.toml"
-resolve COMMIT_GUARDS_TT "dflt" "COMMIT_GUARDS_TT=explicit"
-[ "$RC" -ne 0 ] && grep -q "assigned more than once" "$TMP/err" && ok "an exported value does not mask a malformed settings file" || bad "env override over malformed file" "rc=$RC out=$OUT"
+echo "=== the resolution ladder, one layer at a time; .env is read by nothing ==="
+run_rows \
+  "no source configured: the built-in default answers|world bare||rc=0 value=dflt" \
+  "kendex.settings.toml supplies the value|root root||rc=0 value=root" \
+  ".kendex/settings.toml beats kendex.settings.toml|fx_nested nested||rc=0 value=nested" \
+  ".env.local beats both settings files|fx_dotenv dotenv||rc=0 value=dotenv" \
+  "the explicit environment beats every project file|fx_dotenv explicit|COMMIT_GUARDS_TP=explicit|rc=0 value=explicit" \
+  "a SET-but-empty environment value still wins: explicitly empty|fx_dotenv explicit-empty|COMMIT_GUARDS_TP=|rc=0 value=" \
+  "a .env assignment is read by nothing and the default answers|fx_dotenv_only||rc=0 value=dflt"
 
-# ...and it must not mask a BROKEN .env.local either: the layer's
-# usability is part of every resolution, same as the generic loader.
-printf '[env]\nCOMMIT_GUARDS_TT = "fromrepo"\n' >"$R/kendex.settings.toml"
-mkdir -p "$R/.env.local"
-resolve COMMIT_GUARDS_TT "dflt" "COMMIT_GUARDS_TT=explicit"
-[ "$RC" -ne 0 ] && grep -q "not a regular file" "$TMP/err" && ok "an exported value does not mask a DIRECTORY at .env.local" || bad "env override over broken .env.local" "rc=$RC out=$OUT"
-rmdir "$R/.env.local"
+echo "=== only the [env] table is read, and it is validated whole ==="
+run_rows \
+  "an assignment ABOVE the [env] header is ignored|toml above COMMIT_GUARDS_TP = \"top\"\n[env]\nCOMMIT_GUARDS_OTHER = \"x\"\n||rc=0 value=dflt" \
+  "an assignment under an UNRELATED table is ignored|toml unrelated-table [notes]\nCOMMIT_GUARDS_TP = \"elsewhere\"\n||rc=0 value=dflt" \
+  "control: the same assignment inside [env] resolves|toml in-env [env]\nCOMMIT_GUARDS_TP = \"in-env\"\n||rc=0 value=in-env" \
+  "a trailing comment is dropped from the decoded value, a quote inside it included|toml comment [env]\nCOMMIT_GUARDS_TP = \"kept\" # a \"quoted\" comment\n||rc=0 value=kept" \
+  "a key assigned twice inside [env] is a config error, naming the key|toml dup [env]\nCOMMIT_GUARDS_TP = \"a\"\nCOMMIT_GUARDS_TP = \"b\"\n||rc=1 value= err=$ERR_DUP" \
+  "a backslash in the value is a config error, never decoded|fx_backslash||rc=1 value= err=::error::kendex.settings.toml: unsupported syntax for COMMIT_GUARDS_TP (expected a single-line basic string, no double quote and no backslash: COMMIT_GUARDS_TP = \"value\")" \
+  "a commented [env] header is a config error naming its line, not an invisible table|toml header [env] # comment\nCOMMIT_GUARDS_TP = \"hidden\"\n||rc=1 value= err=::error::kendex.settings.toml:1: unsupported table header shape (a header is a lone [name] on its own line, with no comment and no second bracket)" \
+  "a leading byte-order mark is a config error, not a misread first line|fx_bom||rc=1 value= err=::error::kendex.settings.toml: file starts with a UTF-8 byte-order mark; remove it (the first header or assignment would otherwise be misread)" \
+  "an unrelated non-contract assignment fails the read|toml unrelated-bare [env]\nUNRELATED = bare\nCOMMIT_GUARDS_TP = \"v\"\n||rc=1 value= err=::error::kendex.settings.toml: unsupported syntax for UNRELATED (expected a single-line basic string, no double quote and no backslash: UNRELATED = \"value\")" \
+  "an unrelated duplicated key fails the read|toml unrelated-dup [env]\nUNRELATED = \"a\"\nUNRELATED = \"b\"\nCOMMIT_GUARDS_TP = \"v\"\n||rc=1 value= err=::error::kendex.settings.toml: UNRELATED is assigned more than once in [env] (each key must be unique in the table)" \
+  "an exported value does not mask a malformed settings file|toml masked-dup [env]\nDUP = \"a\"\nDUP = \"b\"\n|COMMIT_GUARDS_TP=explicit|rc=1 value= err=::error::kendex.settings.toml: DUP is assigned more than once in [env] (each key must be unique in the table)" \
+  "an exported value does not mask a DIRECTORY at .env.local|fx_env_dir env-dir-masked|COMMIT_GUARDS_TP=explicit|rc=1 value= err=::error::.env.local: $NOT_REGULAR"
+
+echo "=== a source is skipped only when it is ABSENT; the overrides that force defaults ==="
+run_rows \
+  "a SET-but-EMPTY COMMIT_GUARDS_SETTINGS_FILE is unset and reads the default sources|root empty-override|COMMIT_GUARDS_SETTINGS_FILE=|rc=0 value=root" \
+  "COMMIT_GUARDS_SETTINGS_FILE=/dev/null forces the built-in default past every source|fx_dotenv devnull|COMMIT_GUARDS_SETTINGS_FILE=/dev/null|rc=0 value=dflt" \
+  "an ABSENT explicit settings file falls back to the built-in default|root absent-explicit|COMMIT_GUARDS_SETTINGS_FILE=absent.settings.toml|rc=0 value=dflt" \
+  "a DIRECTORY at the settings path is a config error, not a silent default|fx_dir_settings|COMMIT_GUARDS_SETTINGS_FILE=nonregular.dir|rc=1 value= err=::error::nonregular.dir: $NOT_REGULAR" \
+  "a DANGLING symlink at the settings path is a config error|fx_dangling|COMMIT_GUARDS_SETTINGS_FILE=dangling.settings.toml|rc=1 value= err=::error::dangling.settings.toml: $NOT_RESOLVING" \
+  "a CYCLIC symlink at the settings path is a config error|fx_cyclic|COMMIT_GUARDS_SETTINGS_FILE=cycle-a.settings.toml|rc=1 value= err=::error::cycle-a.settings.toml: $NOT_RESOLVING" \
+  "control: a RESOLVING symlink reads its target|fx_resolving|COMMIT_GUARDS_SETTINGS_FILE=link.settings.toml|rc=0 value=linked" \
+  "a DIRECTORY at .env.local is a config error where the settings file would have answered|fx_env_dir env-dir||rc=1 value= err=::error::.env.local: $NOT_REGULAR" \
+  "a DANGLING .env.local symlink is a config error, not a silent skip|fx_env_dangling||rc=1 value= err=::error::.env.local: $NOT_RESOLVING" \
+  "control: with .env.local absent the settings file answers|root env-absent||rc=0 value=root"
+
+echo "=== the .env.local grammar: last assignment wins, quotes stripped, a comment after the closing quote dropped ==="
+run_rows \
+  "an export prefix is accepted|dotenv env-export export COMMIT_GUARDS_TP=exported||rc=0 value=exported" \
+  "the LAST matching assignment wins|dotenv env-last COMMIT_GUARDS_TP=first\nCOMMIT_GUARDS_TP=last||rc=0 value=last" \
+  "double quotes are stripped and a comment after the closing quote dropped|dotenv env-dq COMMIT_GUARDS_TP=\"quoted value\" # comment||rc=0 value=quoted value" \
+  "single quotes are stripped|dotenv env-sq COMMIT_GUARDS_TP='single'||rc=0 value=single" \
+  "an unquoted value ends at the first whitespace|dotenv env-bare COMMIT_GUARDS_TP=abc def||rc=0 value=abc" \
+  "a segment adjacent to the closing quote is a config error naming the key, not a truncated value|dotenv env-adjacent COMMIT_GUARDS_TP=\"abc\"#def||rc=1 value= err=::error::.env.local: unsupported syntax for COMMIT_GUARDS_TP (a quoted value must end at its closing quote, optionally followed by a comment)"
+assert_eq "a key that is not a shell identifier is refused before any source is read" "rc=1 value= err=::error::gg_setting: invalid key name 'bad-key' (shell identifier shape required: [A-Za-z_][A-Za-z0-9_]*)" "$(root bad-key; resolve '' bad-key)"
+
+echo "=== an unreadable .env.local fails loud, never falls through ==="
+if [ "$(id -u)" -eq 0 ]; then
+  printf '  skip  the unreadable-source pins need a non-root reader (chmod 000 cannot deny root)\n'
+else
+  root unreadable
+  put .env.local 'COMMIT_GUARDS_TP=dotenv\n'
+  chmod 000 "$R/.env.local"
+  assert_eq "an unreadable .env.local is a config error: falling through would have read root" "rc=1 value= err=<settings.sh>: line N: .env.local: Permission denied;::error::.env.local: unreadable while resolving a setting (permission denied)" "$(resolve '')"
+  chmod 600 "$R/.env.local"
+  assert_eq "control: the same file, readable, supplies its value" "rc=0 value=dotenv" "$(resolve '')"
+fi
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.agents/skills/commit-guards/tests/settings-precedence.test.sh
+++ b/.agents/skills/commit-guards/tests/settings-precedence.test.sh
@@ -72,7 +72,8 @@ fx_resolving() { root resolving; put link-target.settings.toml '[env]\nCOMMIT_GU
 fx_env_dir() { root "$1"; mkdir -p "$R/.env.local"; } # NAME
 fx_env_dangling() { root env-dangling; ln -s missing.env "$R/.env.local"; }
 dotenv() { root "$1"; shift; put .env.local "$*\n"; } # NAME LINE... — .env.local holds the rejoined words
-ERR_DUP='::error::kendex.settings.toml: COMMIT_GUARDS_TP is assigned more than once in [env] (each key must be unique in the table)'
+fx_nested_dup() { root nested-dup; put .kendex/settings.toml '[env]\nCOMMIT_GUARDS_TP = "a"\nCOMMIT_GUARDS_TP = "b"\n'; }
+ERR_DUP='::error::.kendex/settings.toml: COMMIT_GUARDS_TP is assigned more than once in [env] (each key must be unique in the table)'
 NOT_REGULAR='settings source exists but is not a regular file (directory, FIFO, socket or device); a source is skipped only when it is absent'
 NOT_RESOLVING='settings source is a symlink that does not resolve (dangling target, cycle, or over-long chain); a source is skipped only when it is absent'
 
@@ -103,7 +104,7 @@ run_rows \
   "an assignment under an UNRELATED table is ignored|toml unrelated-table [notes]\nCOMMIT_GUARDS_TP = \"elsewhere\"\n||rc=0 value=dflt" \
   "control: the same assignment inside [env] resolves|toml in-env [env]\nCOMMIT_GUARDS_TP = \"in-env\"\n||rc=0 value=in-env" \
   "a trailing comment is dropped from the decoded value, a quote inside it included|toml comment [env]\nCOMMIT_GUARDS_TP = \"kept\" # a \"quoted\" comment\n||rc=0 value=kept" \
-  "a key assigned twice inside [env] is a config error, naming the key|toml dup [env]\nCOMMIT_GUARDS_TP = \"a\"\nCOMMIT_GUARDS_TP = \"b\"\n||rc=1 value= err=$ERR_DUP" \
+  "a key assigned twice inside [env] is a config error naming the key, in the nested file under a good root file|fx_nested_dup||rc=1 value= err=$ERR_DUP" \
   "a backslash in the value is a config error, never decoded|fx_backslash||rc=1 value= err=::error::kendex.settings.toml: unsupported syntax for COMMIT_GUARDS_TP (expected a single-line basic string, no double quote and no backslash: COMMIT_GUARDS_TP = \"value\")" \
   "a commented [env] header is a config error naming its line, not an invisible table|toml header [env] # comment\nCOMMIT_GUARDS_TP = \"hidden\"\n||rc=1 value= err=::error::kendex.settings.toml:1: unsupported table header shape (a header is a lone [name] on its own line, with no comment and no second bracket)" \
   "a leading byte-order mark is a config error, not a misread first line|fx_bom||rc=1 value= err=::error::kendex.settings.toml: file starts with a UTF-8 byte-order mark; remove it (the first header or assignment would otherwise be misread)" \

--- a/skills/commit-guards/tests/byte-ceiling.test.sh
+++ b/skills/commit-guards/tests/byte-ceiling.test.sh
@@ -10,7 +10,8 @@
 # a fixture builds the repository, the check runs with ARGS under ENVS, and
 # a row pins the exit status with every line printed, so the hit, the
 # remedy, the counts and the scope named are one pin; the run repeats once
-# in the same repository and a second verdict that differs is shown. The
+# in the same repository and a second verdict that differs is shown (a
+# tripwire: the check writes no state, so no row has a positive case). The
 # settings ladder's own shapes are settings-precedence.test.sh's.
 set -euo pipefail
 
@@ -109,7 +110,8 @@ fx_edit_over() { grown edit-over 1; put seed.bin 5; }
 fx_edit_under() { grown edit-under 1; put seed.bin 1 x; } # the same size with other bytes
 fx_untouched() { grown untouched 5; }
 fx_shrink() { grown shrink 5; put seed.bin 4; }
-fx_grow() { grown grow 5; put seed.bin 5; printf 'x' >>"$R/seed.bin"; git -C "$R" add -A; }
+fx_grow() { grown "${1:-grow}" 5; put seed.bin 5; printf 'x' >>"$R/seed.bin"; git -C "$R" add -A; } # [NAME]
+fx_grow_prior() { fx_grow grow-prior; }
 fx_hold() { grown hold 5; put seed.bin 5 y; }
 fx_rename() { grown "$1" 5; git -C "$R" mv seed.bin moved.bin; } # NAME
 fx_rename_beside() { fx_rename rename-beside; cp "$R/moved.bin" "$R/second-copy.bin"; printf 'x' >>"$R/second-copy.bin"; git -C "$R" add -A; }
@@ -144,8 +146,13 @@ feature() { # NAME ACTION — a feature branch over the legacy file: shrink, gro
   esac
 }
 fx_all_symlink() { repo all-symlink; put old.bin 1; ln -s old.bin "$R/alias"; git -C "$R" add -A; commit; }
-fx_unmerged() { # an add/add conflict: the index carries stages 2 and 3 for one path
-  repo unmerged
+gitlink() { # NAME STAGE — a committed 1 KB file, then a gitlink at mod: staged only, or committed
+  repo "$1"; put ok.bin 1; commit
+  git -C "$R" update-index --add --cacheinfo "160000,$(git -C "$R" rev-parse HEAD),mod"
+  [ "$2" = staged ] || commit gitlink
+}
+fx_unmerged() { # NAME — an add/add conflict: the index carries stages 2 and 3 for one path
+  repo "$1"
   put base.bin 1; commit
   git -C "$R" checkout -qb theirs; put clash.bin 1 a; commit
   git -C "$R" checkout -q main; put clash.bin 1 b; commit
@@ -153,6 +160,7 @@ fx_unmerged() { # an add/add conflict: the index carries stages 2 and 3 for one 
 }
 run_rows \
   "staged mode passes with nothing staged: the legacy file is untouched|legacy legacy-staged|$C=1||rc=0 $(ok 0)" \
+  "--staged spelled out is the same scope, not a sweep|legacy legacy-staged-flag|$C=1|--staged|rc=0 $(ok 0)" \
   "--all fails on the legacy oversized file, naming the sweep|legacy legacy-all|$C=1|--all|rc=1 $(over old.bin 4096 4 1);$(failed 1 1 1 "$SWEEP")" \
   "--base main permits a legacy oversized file to shrink|feature base-shrink shrink|$C=1|--base main|rc=0 $(ok 1 "$(since main)")" \
   "--base main rejects growth from the merge-base size|feature base-grow grow|$C=1|--base main|rc=1 $(grew old.bin 4096 5120 5 1);$(failed 1 1 1 "$(since main)")" \
@@ -160,13 +168,16 @@ run_rows \
   "--base=REF is the same mode|feature base-eq add|$C=1|--base=main|rc=1 $(over feat.bin 2048 2 1);$(failed 1 1 1 "$(since main)")" \
   "--base judges from the merge-base: a legacy file main shrank after the branch point is not the branch's growth|feature base-main-moves main-moves|$C=1|--base main|rc=0 $(ok 1 "$(since main)")" \
   "--all does not size a tracked symlink: one file checked beside it|fx_all_symlink|$C=1|--all|rc=0 $(ok 1 "$SWEEP")" \
+  "--all does not size a committed gitlink either: it carries a commit id, not content|gitlink gitlink-all committed|$C=1|--all|rc=0 $(ok 1 "$SWEEP")" \
+  "a staged gitlink is not sized content|gitlink gitlink-staged staged|$C=1||rc=0 $(ok 0)" \
   "control: --base main on main itself has no additions|legacy base-self|$C=1|--base main|rc=0 $(ok 0 "$(since main)")" \
   "an unknown --base ref is exit 2, naming it|legacy base-unknown|$C=1|--base no-such-ref|rc=2 ${ERR}--base ref 'no-such-ref' does not name a commit" \
   "--base without a ref is exit 2|legacy base-bare|$C=1|--base|rc=2 ${ERR}--base requires a ref" \
-  "an unmerged index is refused rather than measured around: the conflict's addition would vanish from the record set|fx_unmerged|$C=1||rc=2 clash.bin;${ERR}the index carries 1 unmerged path(s) (listed above) and a --cached scan skips them silently — finish or abort the merge, then re-run"
+  "an unmerged index is refused rather than measured around: the conflict's addition would vanish from the record set|fx_unmerged unmerged-staged|$C=1||rc=2 clash.bin;${ERR}the index carries 1 unmerged path(s) (listed above) and a --cached scan skips them silently — finish or abort the merge, then re-run" \
+  "--all refuses it too, where ls-files would size one blob per stage|fx_unmerged unmerged-all|$C=1|--all|rc=2 clash.bin;${ERR}the index carries 1 unmerged path(s) (listed above) and a --cached scan skips them silently — finish or abort the merge, then re-run"
 
 echo "=== lockfiles are exempt by basename; declared asset trees by an excludes row with a reason ==="
-fx_lock() { repo "$1"; put package-lock.json 2; } # NAME
+fx_lock() { repo "$1"; put "${2:-package-lock.json}" 2; } # NAME [PATH]
 fx_lock_twin() { fx_lock lock-twin; cp "$R/package-lock.json" "$R/data.json"; git -C "$R" add -A; }
 fx_lock_suffix() { repo lock-suffix; put not-package-lock.json 2; }
 asset() { repo "$1"; put assets/demo.gif 2; } # NAME
@@ -175,12 +186,14 @@ fx_no_reason() { asset no-reason; excludes 'assets/*\n'; }
 fx_excludes_flag() { asset "$1"; mkdir -p "$R/conf"; printf 'assets/*\tdemo media\n' >"$R/conf/excludes"; git -C "$R" add -A; }
 run_rows \
   "an oversized package-lock.json passes and is not counted: the built-in lockfile exemption|fx_lock lock|$C=1||rc=0 $(ok 0)" \
+  "a nested lockfile is exempt too: the basename is what is judged|fx_lock lock-nested ui/package-lock.json|$C=1||rc=0 $(ok 0)" \
   "control: the same bytes as data.json fail, the exemption is the basename|fx_lock_twin|$C=1||rc=1 $(over data.json 2048 2 1);$(failed 1 1)" \
   "control: a basename that only ends in a lockfile's name is not exempt|fx_lock_suffix|$C=1||rc=1 $(over not-package-lock.json 2048 2 1);$(failed 1 1)" \
   "control: an asset fails without an excludes row|asset asset-bare|$C=1||rc=1 $(over assets/demo.gif 2048 2 1);$(failed 1 1)" \
   "an excludes row exempts the declared tree; the list itself is a staged file and is counted|fx_excluded|$C=1||rc=0 $(ok 1)" \
   "a pattern without a reason is exit 2 naming the line|fx_no_reason|$C=1||rc=2 ${ERR}$EXCL:1: expected 'pattern<TAB>reason' (every exclusion carries its justification)" \
   "--excludes FILE names the list, and the remedy names it too|fx_excludes_flag excludes-flag|$C=1|--excludes conf/excludes|rc=0 $(ok 1)" \
+  "the equals form of --excludes names the same list|fx_excludes_flag excludes-eq|$C=1|--excludes=conf/excludes|rc=0 $(ok 1)" \
   "control: without the flag the same repository fails on the asset, and the remedy names the default list|fx_excludes_flag excludes-default|$C=1||rc=1 $(over assets/demo.gif 2048 2 1);$(failed 1 2)"
 
 echo "=== the ceiling resolves through the settings ladder and is validated ==="
@@ -201,11 +214,19 @@ REAL_GIT="$(command -v git)"
 mkdir -p "$TMP/git-shim"
 printf '#!/usr/bin/env bash\nif [ "${1:-}" = cat-file ] && [ "${2:-}" = -s ]; then echo "fatal: simulated object read failure" >&2; exit 128; fi\nexec %q "$@"\n' "$REAL_GIT" >"$TMP/git-shim/git"
 chmod +x "$TMP/git-shim/git"
-SHA2K="$(head -c 2048 /dev/zero | git hash-object --stdin)"
+# Hashed outside any repository: the fixtures are sha1 by default, and a
+# host checkout under another object format must not answer for them.
+SHA2K="$(cd "$TMP" && head -c 2048 /dev/zero | git hash-object --stdin)"
+SHA5K="$(cd "$TMP" && head -c 5120 /dev/zero | git hash-object --stdin)"
+# A git whose `cat-file -s` fails for the 5 KB blob alone: the prior of a grown file.
+mkdir -p "$TMP/git-shim-prior"
+printf '#!/usr/bin/env bash\nif [ "${1:-}" = cat-file ] && [ "${2:-}" = -s ] && [ "${3:-}" = %s ]; then echo "fatal: simulated object read failure" >&2; exit 128; fi\nexec %q "$@"\n' "$SHA5K" "$REAL_GIT" >"$TMP/git-shim-prior/git"
+chmod +x "$TMP/git-shim-prior/git"
 measure() { repo "$1"; put big.bin 2; } # NAME
 run_rows \
   "control: without the shim the oversized staged file fails|measure measure-real|$C=1||rc=1 $(over big.bin 2048 2 1);$(failed 1 1)" \
-  "an unmeasurable blob is exit 2 naming the blob and the file, with no verdict line, git's own words ahead of it|measure measure-shim|PATH=$TMP/git-shim:$PATH,$C=1||rc=2 fatal: simulated object read failure;${ERR}cannot read blob $SHA2K for 'big.bin' — its size is unmeasurable, refusing to skip it"
+  "an unmeasurable blob is exit 2 naming the blob and the file, with no verdict line, git's own words ahead of it|measure measure-shim|PATH=$TMP/git-shim:$PATH,$C=1||rc=2 fatal: simulated object read failure;${ERR}cannot read blob $SHA2K for 'big.bin' — its size is unmeasurable, refusing to skip it" \
+  "an unmeasurable PRIOR blob is exit 2 too: the tighten-only baseline is not guessed|fx_grow_prior|PATH=$TMP/git-shim-prior:$PATH,$C=1||rc=2 fatal: simulated object read failure;${ERR}cannot read prior blob $SHA5K for 'seed.bin' — its size is unmeasurable, refusing to skip it"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/commit-guards/tests/byte-ceiling.test.sh
+++ b/skills/commit-guards/tests/byte-ceiling.test.sh
@@ -1,386 +1,211 @@
 #!/usr/bin/env bash
-# Pins for scripts/byte-ceiling: additions and growth over the ceiling fail,
-# an existing oversized file may hold or shrink, renames pass, lockfiles and
-# excluded trees are exempt, configuration resolves, and a broken measurement
-# is a collection error — never a pass.
+# Pins for scripts/byte-ceiling: an addition or a change past the ceiling
+# fails naming the file, its bytes and the ceiling, an existing oversized
+# file may hold or shrink but not grow, a pure rename is no addition while a
+# copy and a moved-and-grown file are, a symlink or gitlink is not sized
+# content, --base judges the branch since its merge-base and --all sweeps
+# every tracked file, lockfiles and declared asset trees are exempt, the
+# ceiling resolves through the settings ladder and is validated, and a
+# measurement that breaks is a collection error, never a pass. One table:
+# a fixture builds the repository, the check runs with ARGS under ENVS, and
+# a row pins the exit status with every line printed, so the hit, the
+# remedy, the counts and the scope named are one pin; the run repeats once
+# in the same repository and a second verdict that differs is shown. The
+# settings ladder's own shapes are settings-precedence.test.sh's.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 BC="$SKILL_DIR/scripts/byte-ceiling"
+# shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
-
+# Hermetic: a leaked setting would move every ceiling below.
 unset COMMIT_GUARDS_BYTE_CEILING_KB COMMIT_GUARDS_BYTE_EXCLUDES COMMIT_GUARDS_SETTINGS_FILE 2>/dev/null || true
 
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
 
-new_repo() { # NAME
+# One line for a run in the row's repository: the exit status, then every
+# line printed, in order, joined by ';'. ENVS is a comma-separated list of
+# assignments; ARGS are passed through. The run repeats once, and a second
+# verdict that differs follows after ' / again: '.
+R=""
+run() { # ENVS ARGS
+  local envs=() rc=0 out="" rc2=0 out2="" line line2
+  [ -z "$1" ] || IFS=',' read -ra envs <<<"$1"
+  # shellcheck disable=SC2086
+  out="$(cd "$R" && env ${envs[@]+"${envs[@]}"} "$BC" $2 2>&1)" || rc=$?
+  # shellcheck disable=SC2086
+  out2="$(cd "$R" && env ${envs[@]+"${envs[@]}"} "$BC" $2 2>&1)" || rc2=$?
+  line="rc=$rc${out:+ $(printf '%s\n' "$out" | LC_ALL=C paste -sd ';' -)}"
+  line2="rc=$rc2${out2:+ $(printf '%s\n' "$out2" | LC_ALL=C paste -sd ';' -)}"
+  printf '%s' "$line"
+  [ "$line" = "$line2" ] || printf ' / again: %s' "$line2"
+}
+
+# Fixture vocabulary. Every fixture builds its own repository; a name used
+# twice is refused. `put` writes KB kibibytes of one byte (NUL unless FILL is
+# given) and stages; `commit` commits what is staged.
+repo() { # NAME
   R="$TMP/$1"
+  [ ! -e "$R" ] || { echo "harness: fixture $1 already exists" >&2; exit 2; }
   mkdir -p "$R"
   git -C "$R" -c init.defaultBranch=main init -q
   git -C "$R" config user.email test@example.com
   git -C "$R" config user.name test
 }
-
-mkbytes() { # PATH KB — file of KB*1024 bytes under $R
+put() { # PATH KB [FILL]
   mkdir -p "$R/$(dirname "$1")"
-  dd if=/dev/zero of="$R/$1" bs=1024 count="$2" 2>/dev/null
+  head -c "$(($2 * 1024))" /dev/zero | tr '\0' "${3:-\0}" >"$R/$1"
+  git -C "$R" add -A
+}
+commit() { git -C "$R" commit -qm "${1:-seed}"; }
+EXCL='tools/byte-ceiling-excludes'
+excludes() { mkdir -p "$R/tools"; printf '%b' "$1" >"$R/$EXCL"; git -C "$R" add -A; } # CONTENT (printf %b)
+
+# The lines the check prints, as functions of what a row put in.
+REMEDY="  remedies: keep big artifacts out of the repo (asset store, Git LFS, build-time generation); a file that genuinely belongs gets a row in $EXCL with its reason"
+ERR="::error::byte-ceiling: "
+over() { printf 'byte-ceiling FAIL oversized file: %s — %s bytes (~%s KB) > ceiling %s KB;%s' "$1" "$2" "$3" "$4" "$REMEDY"; } # PATH BYTES ~KB CEILING
+grew() { printf 'byte-ceiling FAIL oversized file grew: %s — %s -> %s bytes (~%s KB), ceiling %s KB;%s' "$1" "$2" "$3" "$4" "$5" "$REMEDY"; } # PATH PRIOR BYTES ~KB CEILING
+STAGED="staged file(s)"
+SWEEP="tracked file(s) (full sweep)"
+since() { printf 'file(s) added or changed since %s' "$1"; } # REF
+ok() { printf 'byte-ceiling: OK — %s %s checked, ceiling %s KB' "$1" "${2:-$STAGED}" "${3:-1}"; } # CHECKED [SCOPE] [CEILING]
+failed() { printf 'byte-ceiling: %s violation(s) — ceiling %s KB, %s %s checked' "$1" "${3:-1}" "$2" "${4:-$STAGED}"; } # VIOLATIONS CHECKED [CEILING] [SCOPE]
+C=COMMIT_GUARDS_BYTE_CEILING_KB
+
+run_rows() { # label | fixture | envs | args | expect
+  local row label fx envs args expect words
+  for row in "$@"; do
+    IFS='|' read -r label fx envs args expect <<<"$row"
+    R=""
+    read -ra words <<<"$fx"
+    "${words[@]}"
+    assert_eq "$label" "$expect" "$(run "$envs" "$args")"
+  done
 }
 
-run_bc() { # [args...] — run in $R at ceiling 1 KB; sets OUT and RC
-  OUT=""
-  RC=0
-  OUT="$(cd "$R" && COMMIT_GUARDS_BYTE_CEILING_KB=1 "$BC" "$@" 2>&1)" || RC=$?
+echo "=== staged mode: an addition past the ceiling fails; at the ceiling passes ==="
+staged() { repo "$1"; put small.bin 1; [ -z "${2-}" ] || put "$2" "$3"; } # NAME [PATH KB] — a 1 KB file, and one more
+run_rows \
+  "a 1 KB addition at ceiling 1 KB passes: at the ceiling is not over it|staged at-ceiling|$C=1||rc=0 $(ok 1)" \
+  "a 2 KB addition at ceiling 1 KB fails naming file, bytes and ceiling, carrying the remedy and counting both staged files|staged over big.bin 2|$C=1||rc=1 $(over big.bin 2048 2 1);$(failed 1 2)" \
+  "a 205 KB addition fails under the built-in 200 KB|staged default-over big.bin 205|||rc=1 $(over big.bin 209920 205 200);$(failed 1 2 200)" \
+  "control: a 100 KB addition passes under the built-in default|staged default-under ok.bin 100|||rc=0 $(ok 2 "$STAGED" 200)"
+
+echo "=== a change: past the ceiling fails; an oversized file may shrink or hold, not grow; a rename is no addition ==="
+grown() { repo "$1"; put seed.bin "$2"; commit; } # NAME KB — one committed file of KB
+fx_edit_over() { grown edit-over 1; put seed.bin 5; }
+fx_edit_under() { grown edit-under 1; put seed.bin 1 x; } # the same size with other bytes
+fx_untouched() { grown untouched 5; }
+fx_shrink() { grown shrink 5; put seed.bin 4; }
+fx_grow() { grown grow 5; put seed.bin 5; printf 'x' >>"$R/seed.bin"; git -C "$R" add -A; }
+fx_hold() { grown hold 5; put seed.bin 5 y; }
+fx_rename() { grown "$1" 5; git -C "$R" mv seed.bin moved.bin; } # NAME
+fx_rename_beside() { fx_rename rename-beside; cp "$R/moved.bin" "$R/second-copy.bin"; printf 'x' >>"$R/second-copy.bin"; git -C "$R" add -A; }
+fx_move_grow() { grown move-grow 4; git -C "$R" mv seed.bin elsewhere.bin; put elsewhere.bin 5; } # 80% similar: a rename at any lower threshold
+fx_copy() { grown copy 3; cp "$R/seed.bin" "$R/twin.bin"; git -C "$R" add -A; }
+fx_typechange() { repo typechange; put payload.bin 5; ln -s payload.bin "$R/thing"; git -C "$R" add -A; commit; rm "$R/thing"; put thing 5; }
+fx_to_symlink() { grown to-symlink 5; rm "$R/seed.bin"; ln -s payload "$R/seed.bin"; git -C "$R" add -A; }
+run_rows \
+  "editing a tracked file past the ceiling fails: the staged lane reads A and M|fx_edit_over|$C=1||rc=1 $(over seed.bin 5120 5 1);$(failed 1 1)" \
+  "control: the same file edited under the ceiling passes|fx_edit_under|$C=1||rc=0 $(ok 1)" \
+  "a committed oversized file is not re-judged while nothing stages it|fx_untouched|$C=1||rc=0 $(ok 0)" \
+  "a staged oversized file may shrink toward the ceiling, and the verdict is the same on a second run|fx_shrink|$C=1||rc=0 $(ok 1)" \
+  "an existing oversized file may not grow, by one byte|fx_grow|$C=1||rc=1 $(grew seed.bin 5120 5121 6 1);$(failed 1 1)" \
+  "an existing oversized file may change without growing|fx_hold|$C=1||rc=0 $(ok 1)" \
+  "renaming an existing large file is not an addition: rename detection is on, and the rename is not counted|fx_rename rename|$C=1||rc=0 $(ok 0)" \
+  "control: a new large file beside the rename still fails, alone|fx_rename_beside|$C=1||rc=1 $(over second-copy.bin 5121 6 1);$(failed 1 1)" \
+  "a file moved AND grown is an addition at its new path: below exact similarity the growth would ride the rename unjudged|fx_move_grow|$C=1||rc=1 $(over elsewhere.bin 5120 5 1);$(failed 1 1)" \
+  "an exact copy of an oversized tracked file is an addition: it duplicates the bytes, only renames are followed|fx_copy|$C=1||rc=1 $(over twin.bin 3072 3 1);$(failed 1 1)" \
+  "a symlink replaced by an oversized regular file fails as an addition: the link had no prior size|fx_typechange|$C=1||rc=1 $(over thing 5120 5 1);$(failed 1 1)" \
+  "control: a file replaced BY a symlink is not sized content|fx_to_symlink|$C=1||rc=0 $(ok 0)"
+
+echo "=== --all sweeps every tracked file; --base REF judges the branch since the merge-base ==="
+legacy() { repo "$1"; put old.bin 4; commit "legacy oversized file"; } # NAME
+feature() { # NAME ACTION — a feature branch over the legacy file: shrink, grow, add
+  legacy "$1"
+  git -C "$R" checkout -qb feature
+  case "$2" in
+    shrink) put old.bin 3; commit "feature: shrinks the legacy file" ;;
+    grow) put old.bin 5; commit "feature: grows the legacy file" ;;
+    add) put feat.bin 2; commit "feature: adds an oversized file" ;;
+    main-moves) put note.bin 1; commit "feature: a note"; git -C "$R" checkout -q main; put old.bin 3; commit "main shrinks the legacy file"; git -C "$R" checkout -q feature ;;
+  esac
 }
-
-run_bc_default() { # [args...] — run in $R at the built-in default ceiling
-  OUT=""
-  RC=0
-  OUT="$(cd "$R" && "$BC" "$@" 2>&1)" || RC=$?
+fx_all_symlink() { repo all-symlink; put old.bin 1; ln -s old.bin "$R/alias"; git -C "$R" add -A; commit; }
+fx_unmerged() { # an add/add conflict: the index carries stages 2 and 3 for one path
+  repo unmerged
+  put base.bin 1; commit
+  git -C "$R" checkout -qb theirs; put clash.bin 1 a; commit
+  git -C "$R" checkout -q main; put clash.bin 1 b; commit
+  git -C "$R" merge -q theirs >/dev/null 2>&1 || true
 }
+run_rows \
+  "staged mode passes with nothing staged: the legacy file is untouched|legacy legacy-staged|$C=1||rc=0 $(ok 0)" \
+  "--all fails on the legacy oversized file, naming the sweep|legacy legacy-all|$C=1|--all|rc=1 $(over old.bin 4096 4 1);$(failed 1 1 1 "$SWEEP")" \
+  "--base main permits a legacy oversized file to shrink|feature base-shrink shrink|$C=1|--base main|rc=0 $(ok 1 "$(since main)")" \
+  "--base main rejects growth from the merge-base size|feature base-grow grow|$C=1|--base main|rc=1 $(grew old.bin 4096 5120 5 1);$(failed 1 1 1 "$(since main)")" \
+  "--base main fails on the branch's added file|feature base-add add|$C=1|--base main|rc=1 $(over feat.bin 2048 2 1);$(failed 1 1 1 "$(since main)")" \
+  "--base=REF is the same mode|feature base-eq add|$C=1|--base=main|rc=1 $(over feat.bin 2048 2 1);$(failed 1 1 1 "$(since main)")" \
+  "--base judges from the merge-base: a legacy file main shrank after the branch point is not the branch's growth|feature base-main-moves main-moves|$C=1|--base main|rc=0 $(ok 1 "$(since main)")" \
+  "--all does not size a tracked symlink: one file checked beside it|fx_all_symlink|$C=1|--all|rc=0 $(ok 1 "$SWEEP")" \
+  "control: --base main on main itself has no additions|legacy base-self|$C=1|--base main|rc=0 $(ok 0 "$(since main)")" \
+  "an unknown --base ref is exit 2, naming it|legacy base-unknown|$C=1|--base no-such-ref|rc=2 ${ERR}--base ref 'no-such-ref' does not name a commit" \
+  "--base without a ref is exit 2|legacy base-bare|$C=1|--base|rc=2 ${ERR}--base requires a ref" \
+  "an unmerged index is refused rather than measured around: the conflict's addition would vanish from the record set|fx_unmerged|$C=1||rc=2 clash.bin;${ERR}the index carries 1 unmerged path(s) (listed above) and a --cached scan skips them silently — finish or abort the merge, then re-run"
 
-echo "=== staged mode: additions over the ceiling fail; at-ceiling passes ==="
-new_repo staged
-mkbytes small.bin 1
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 0 ] && case "$OUT" in *"1 staged file(s) checked"*) true ;; *) false ;; esac \
-  && ok "a 1 KB addition at ceiling 1 KB passes (at-ceiling is not over)" \
-  || bad "at-ceiling addition passes" "rc=$RC out=$OUT"
+echo "=== lockfiles are exempt by basename; declared asset trees by an excludes row with a reason ==="
+fx_lock() { repo "$1"; put package-lock.json 2; } # NAME
+fx_lock_twin() { fx_lock lock-twin; cp "$R/package-lock.json" "$R/data.json"; git -C "$R" add -A; }
+fx_lock_suffix() { repo lock-suffix; put not-package-lock.json 2; }
+asset() { repo "$1"; put assets/demo.gif 2; } # NAME
+fx_excluded() { asset excluded; excludes 'assets/*\tdemo media\n'; }
+fx_no_reason() { asset no-reason; excludes 'assets/*\n'; }
+fx_excludes_flag() { asset "$1"; mkdir -p "$R/conf"; printf 'assets/*\tdemo media\n' >"$R/conf/excludes"; git -C "$R" add -A; }
+run_rows \
+  "an oversized package-lock.json passes and is not counted: the built-in lockfile exemption|fx_lock lock|$C=1||rc=0 $(ok 0)" \
+  "control: the same bytes as data.json fail, the exemption is the basename|fx_lock_twin|$C=1||rc=1 $(over data.json 2048 2 1);$(failed 1 1)" \
+  "control: a basename that only ends in a lockfile's name is not exempt|fx_lock_suffix|$C=1||rc=1 $(over not-package-lock.json 2048 2 1);$(failed 1 1)" \
+  "control: an asset fails without an excludes row|asset asset-bare|$C=1||rc=1 $(over assets/demo.gif 2048 2 1);$(failed 1 1)" \
+  "an excludes row exempts the declared tree; the list itself is a staged file and is counted|fx_excluded|$C=1||rc=0 $(ok 1)" \
+  "a pattern without a reason is exit 2 naming the line|fx_no_reason|$C=1||rc=2 ${ERR}$EXCL:1: expected 'pattern<TAB>reason' (every exclusion carries its justification)" \
+  "--excludes FILE names the list, and the remedy names it too|fx_excludes_flag excludes-flag|$C=1|--excludes conf/excludes|rc=0 $(ok 1)" \
+  "control: without the flag the same repository fails on the asset, and the remedy names the default list|fx_excludes_flag excludes-default|$C=1||rc=1 $(over assets/demo.gif 2048 2 1);$(failed 1 2)"
 
-mkbytes big.bin 2
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 1 ] && case "$OUT" in *"oversized file: big.bin — 2048 bytes"*"> ceiling 1 KB"*) true ;; *) false ;; esac \
-  && ok "a 2 KB addition at ceiling 1 KB fails, naming file/bytes/ceiling" \
-  || bad "oversized addition fails with bytes and ceiling" "rc=$RC out=$OUT"
-case "$OUT" in *"asset store, Git LFS, build-time generation"*) ok "diagnostic carries the remediation" ;; *) bad "diagnostic carries the remediation" "$OUT" ;; esac
+echo "=== the ceiling resolves through the settings ladder and is validated ==="
+cfg() { repo "$1"; put f.txt 1; } # NAME
+fx_settings() { cfg "$1"; printf '[env]\nCOMMIT_GUARDS_BYTE_CEILING_KB = "3"\n' >"$R/kendex.settings.toml"; put big.bin 4; }
+run_rows \
+  "a non-numeric ceiling is exit 2, quoting it|cfg non-numeric|$C=abc||rc=2 ${ERR}COMMIT_GUARDS_BYTE_CEILING_KB must be a positive integer, got 'abc'" \
+  "a zero ceiling is exit 2|cfg zero|$C=0||rc=2 ${ERR}COMMIT_GUARDS_BYTE_CEILING_KB must be a positive integer, got '0'" \
+  "an unknown flag is exit 2, quoting it|cfg unknown-flag|$C=1|--no-such-flag|rc=2 ${ERR}unknown argument '--no-such-flag' (see --help)" \
+  "kendex.settings.toml supplies the ceiling: 4 KB fails at 3 where the built-in 200 would pass|fx_settings settings-file|||rc=1 $(over big.bin 4096 4 3);$(failed 1 3 3)" \
+  "the environment overrides the settings file: 5 passes where 3 failed|fx_settings settings-env|$C=5||rc=0 $(ok 3 "$STAGED" 5)"
+assert_eq "--help prints usage at exit 0" "rc=0 usage: byte-ceiling [--staged | --base REF | --all] [--excludes FILE]" "$(run '' --help | LC_ALL=C cut -d';' -f1)"
+assert_eq "-h is --help" "$(run '' --help)" "$(run '' -h)"
 
-echo "=== the built-in default 200 KB is real, not vacuous ==="
-new_repo defreal
-mkbytes big.bin 205
-git -C "$R" add -A
-run_bc_default
-[ "$RC" -eq 1 ] && case "$OUT" in *"ceiling 200 KB"*) true ;; *) false ;; esac \
-  && ok "a 205 KB addition fails under the built-in default 200" \
-  || bad "default 200 can fail" "rc=$RC out=$OUT"
-rm "$R/big.bin"
-mkbytes ok.bin 100
-git -C "$R" add -A
-run_bc_default
-[ "$RC" -eq 0 ] && ok "a 100 KB addition passes under the default (control)" \
-  || bad "100 KB passes under the default" "rc=$RC out=$OUT"
-
-echo "=== diff-scoping: a change over the ceiling fails; a rename does not ==="
-new_repo grown
-mkbytes seed.bin 1
-git -C "$R" add -A
-git -C "$R" commit -qm "seed: a file under the ceiling"
-mkbytes seed.bin 5
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 1 ] && case "$OUT" in *"seed.bin"*"5120 bytes"*) true ;; *) false ;; esac \
-  && ok "editing a tracked file past the ceiling fails (the staged lane reads A and M)" \
-  || bad "a change over the ceiling fails" "rc=$RC out=$OUT"
-mkbytes seed.bin 1
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 0 ] && ok "control: the same file edited back under the ceiling passes" \
-  || bad "control: back under the ceiling passes" "rc=$RC out=$OUT"
-mkbytes seed.bin 5
-git -C "$R" add -A
-git -C "$R" commit -qm "grow it past the ceiling"
-run_bc
-[ "$RC" -eq 0 ] && ok "a committed oversized file is not re-judged while nothing stages it" \
-  || bad "a committed oversized file is not re-judged while nothing stages it" "rc=$RC out=$OUT"
-mkbytes seed.bin 4
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 0 ] && ok "a staged oversized file may shrink toward the ceiling" \
-  || bad "a staged oversized file may shrink toward the ceiling" "rc=$RC out=$OUT"
-run_bc
-[ "$RC" -eq 0 ] && ok "the same staged shrink gives a stable clean verdict" \
-  || bad "the same staged shrink gives a stable clean verdict" "rc=$RC out=$OUT"
-mkbytes seed.bin 5
-printf 'x' >>"$R/seed.bin"
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 1 ] && case "$OUT" in *"oversized file grew: seed.bin"*"5120 -> 5121 bytes"*) true ;; *) false ;; esac \
-  && ok "an existing oversized file may not grow" \
-  || bad "an existing oversized file may not grow" "rc=$RC out=$OUT"
-mkbytes seed.bin 5
-printf 'y' | dd of="$R/seed.bin" bs=1 seek=0 conv=notrunc 2>/dev/null
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 0 ] && ok "an existing oversized file may change without increasing its size" \
-  || bad "an existing oversized file may hold its size" "rc=$RC out=$OUT"
-mkbytes seed.bin 5
-git -C "$R" add -A
-git -C "$R" mv seed.bin moved.bin
-run_bc
-[ "$RC" -eq 0 ] && ok "renaming an existing large file is not an addition (rename detection pinned on)" \
-  || bad "rename is not an addition" "rc=$RC out=$OUT"
-# A move that also grows is not a move: below exact similarity it would be one
-# R record the filter drops, and the growth would arrive unjudged.
-new_repo movedgrown
-mkbytes carried.bin 1
-git -C "$R" add -A
-git -C "$R" commit -qm "seed: a file under the ceiling"
-git -C "$R" mv carried.bin elsewhere.bin
-mkbytes elsewhere.bin 5
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 1 ] && case "$OUT" in *"elsewhere.bin"*"5120 bytes"*) true ;; *) false ;; esac \
-  && ok "a file moved AND grown past the ceiling fails at its new path" \
-  || bad "a file moved AND grown past the ceiling fails at its new path" "rc=$RC out=$OUT"
-# A type change carries a new blob too: the symlink's target was a few bytes.
-new_repo typechange
-mkbytes payload.bin 5
-ln -s payload.bin "$R/thing"
-git -C "$R" add -A
-git -C "$R" commit -qm "seed: a symlink beside its target"
-rm "$R/thing"
-mkbytes thing 5
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 1 ] && case "$OUT" in *"thing"*"5120 bytes"*) true ;; *) false ;; esac \
-  && ok "a symlink replaced by an oversized regular file fails (type change)" \
-  || bad "a symlink replaced by an oversized regular file fails (type change)" "rc=$RC out=$OUT"
-new_repo grown2
-mkbytes seed.bin 5
-git -C "$R" add -A
-git -C "$R" commit -qm "seed: an oversized tracked file"
-rm "$R/seed.bin"
-ln -s payload "$R/seed.bin"
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 0 ] && ok "control: a file replaced BY a symlink is not sized content" \
-  || bad "control: a file replaced BY a symlink is not sized content" "rc=$RC out=$OUT"
-R="$TMP/grown" # back to the renamed fixture; the copy case below builds on it
-cp "$R/moved.bin" "$R/second-copy.bin" 2>/dev/null || true
-printf 'x' >>"$R/second-copy.bin"
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 1 ] && case "$OUT" in *"second-copy.bin"*) true ;; *) false ;; esac \
-  && ok "control: a genuinely new large file beside the rename still fails" \
-  || bad "control: new large file fails beside the rename" "rc=$RC out=$OUT"
-new_repo copy
-mkbytes big.bin 3
-git -C "$R" add -A
-git -C "$R" commit -qm "seed: an oversized tracked file"
-cp "$R/big.bin" "$R/twin.bin"
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 1 ] && case "$OUT" in *"twin.bin"*) true ;; *) false ;; esac \
-  && ok "an exact copy of an oversized tracked file IS an addition (it duplicates the bytes; only renames are followed)" \
-  || bad "an exact copy is an addition" "rc=$RC out=$OUT"
-
-echo "=== --all: the full sweep gates legacy files the staged mode skips ==="
-new_repo legacy
-mkbytes old.bin 4
-git -C "$R" add -A
-git -C "$R" commit -qm "seed: legacy oversized file"
-run_bc
-[ "$RC" -eq 0 ] && ok "staged mode passes with nothing staged (legacy untouched)" \
-  || bad "staged mode passes on the legacy repo" "rc=$RC out=$OUT"
-run_bc --all
-[ "$RC" -eq 1 ] && case "$OUT" in *"old.bin"*"full sweep"*) true ;; *) false ;; esac \
-  && ok "--all fails on the legacy oversized file" || bad "--all fails on legacy" "rc=$RC out=$OUT"
-
-echo "=== --base REF: additions and changes since the merge-base ==="
-git -C "$R" checkout -qb feature
-mkbytes old.bin 3
-git -C "$R" add -A
-git -C "$R" commit -qm "feature shrinks the legacy file"
-run_bc --base main
-[ "$RC" -eq 0 ] && case "$OUT" in *"added or changed since main"*) true ;; *) false ;; esac \
-  && ok "--base main permits a legacy oversized file to shrink" \
-  || bad "--base permits a legacy oversized file to shrink" "rc=$RC out=$OUT"
-mkbytes old.bin 5
-git -C "$R" add -A
-git -C "$R" commit -qm "feature grows the legacy file"
-run_bc --base main
-[ "$RC" -eq 1 ] && case "$OUT" in *"oversized file grew: old.bin"*"4096 -> 5120 bytes"*) true ;; *) false ;; esac \
-  && ok "--base main rejects growth from the merge-base size" \
-  || bad "--base rejects growth from the merge-base size" "rc=$RC out=$OUT"
-mkbytes feat.bin 2
-git -C "$R" add -A
-git -C "$R" commit -qm "feature adds an oversized file"
-run_bc --base main
-[ "$RC" -eq 1 ] && case "$OUT" in *"feat.bin"*"added or changed since main"*) true ;; *) false ;; esac \
-  && ok "--base main fails on the branch's added file" || bad "--base fails on the added file" "rc=$RC out=$OUT"
-git -C "$R" checkout -q main
-run_bc --base main
-[ "$RC" -eq 0 ] && ok "control: --base main on main itself has no additions" \
-  || bad "control: --base with no additions passes" "rc=$RC out=$OUT"
-run_bc --base no-such-ref
-[ "$RC" -eq 2 ] && ok "an unknown --base ref is exit 2" || bad "unknown --base ref is exit 2" "rc=$RC out=$OUT"
-
-echo "=== lockfiles are exempt by basename; same bytes elsewhere are not ==="
-new_repo lock
-mkbytes package-lock.json 2
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 0 ] && ok "an oversized package-lock.json passes (built-in lockfile exemption)" \
-  || bad "lockfile exemption" "rc=$RC out=$OUT"
-cp "$R/package-lock.json" "$R/data.json"
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 1 ] && case "$OUT" in *"data.json"*) true ;; *) false ;; esac \
-  && ok "control: the same bytes as data.json fail — the exemption is the basename, not the size" \
-  || bad "control: non-lockfile with same bytes fails" "rc=$RC out=$OUT"
-
-echo "=== excludes: declared asset trees, reason mandatory ==="
-new_repo assets
-mkdir -p "$R/tools"
-mkbytes assets/demo.gif 2
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 1 ] && ok "control: the asset fails without an excludes row" \
-  || bad "control: asset fails without excludes" "rc=$RC out=$OUT"
-printf 'assets/*\tdemo media\n' >"$R/tools/byte-ceiling-excludes"
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 0 ] && ok "the excludes row exempts the declared asset tree" \
-  || bad "excludes row exempts the asset tree" "rc=$RC out=$OUT"
-printf 'assets/*\n' >"$R/tools/byte-ceiling-excludes"
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 2 ] && ok "a pattern without a reason is exit 2" || bad "pattern without a reason is exit 2" "rc=$RC out=$OUT"
-
-echo "=== configuration errors ==="
-new_repo cfg
-printf 'x\n' >"$R/f.txt"
-git -C "$R" add -A
-OUT="$(cd "$R" && COMMIT_GUARDS_BYTE_CEILING_KB=abc "$BC" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && ok "non-numeric ceiling is exit 2" || bad "non-numeric ceiling is exit 2" "rc=$RC out=$OUT"
-OUT="$(cd "$R" && COMMIT_GUARDS_BYTE_CEILING_KB=0 "$BC" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && ok "zero ceiling is exit 2" || bad "zero ceiling is exit 2" "rc=$RC out=$OUT"
-run_bc --no-such-flag
-[ "$RC" -eq 2 ] && ok "unknown flag is exit 2" || bad "unknown flag is exit 2" "rc=$RC out=$OUT"
-
-echo "=== settings file resolution ==="
-printf '[env]\nCOMMIT_GUARDS_BYTE_CEILING_KB = "3"\n' >"$R/kendex.settings.toml"
-mkbytes big.bin 4
-git -C "$R" add -A
-run_bc_default
-[ "$RC" -eq 1 ] && case "$OUT" in *"ceiling 3 KB"*) true ;; *) false ;; esac \
-  && ok "kendex.settings.toml overrides the default (4 KB > 3 fails; 200 would have passed)" \
-  || bad "settings file overrides the default" "rc=$RC out=$OUT"
-OUT="$(cd "$R" && COMMIT_GUARDS_BYTE_CEILING_KB=5 "$BC" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && ok "environment overrides the settings file (5 passes where 3 failed)" \
-  || bad "environment overrides the settings file" "rc=$RC out=$OUT"
-
-echo "=== an EXISTING non-regular settings path never falls back to defaults ==="
-# A directory fails -f exactly like an absent file, so the configured settings
-# would be skipped with nothing said and the built-in 200 KB would decide.
-mkdir -p "$R/nonregular.dir"
-OUT="$(cd "$R" && COMMIT_GUARDS_SETTINGS_FILE=nonregular.dir "$BC" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"not a regular file"*) true ;; *) false ;; esac \
-  && ok "a DIRECTORY settings path is exit 2, not a silent built-in default" \
-  || bad "a DIRECTORY settings path is exit 2" "rc=$RC out=$OUT"
-
-# A symlink that does not resolve fails -e as well as -f, so an existence
-# test alone never sees it — the same silent-defaults trap one shape over.
-ln -s missing.toml "$R/dangling.settings.toml"
-OUT="$(cd "$R" && COMMIT_GUARDS_SETTINGS_FILE=dangling.settings.toml "$BC" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"does not resolve"*) true ;; *) false ;; esac \
-  && ok "a DANGLING symlink settings path is exit 2, not a silent built-in default" \
-  || bad "a DANGLING symlink settings path is exit 2" "rc=$RC out=$OUT"
-
-ln -s cycle-b.settings.toml "$R/cycle-a.settings.toml"
-ln -s cycle-a.settings.toml "$R/cycle-b.settings.toml"
-OUT="$(cd "$R" && COMMIT_GUARDS_SETTINGS_FILE=cycle-a.settings.toml "$BC" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"does not resolve"*) true ;; *) false ;; esac \
-  && ok "a CYCLIC symlink settings path is exit 2, not a silent built-in default" \
-  || bad "a CYCLIC symlink settings path is exit 2" "rc=$RC out=$OUT"
-
-# A RESOLVING symlink is an ordinary install shape and must still read.
-printf '[env]\nCOMMIT_GUARDS_BYTE_CEILING_KB = "3"\n' >"$R/link-target.settings.toml"
-ln -s link-target.settings.toml "$R/link.settings.toml"
-OUT="$(cd "$R" && COMMIT_GUARDS_SETTINGS_FILE=link.settings.toml "$BC" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 1 ] && case "$OUT" in *"ceiling 3 KB"*) true ;; *) false ;; esac \
-  && ok "a RESOLVING symlink reads its target (control: 4 KB > 3 fails; 200 would have passed)" \
-  || bad "a RESOLVING symlink reads its target (control)" "rc=$RC out=$OUT"
-
-# Controls: the two shapes that MUST still resolve to the built-in default
-# (200 KB, under which the 4 KB addition passes).
-OUT="$(cd "$R" && COMMIT_GUARDS_SETTINGS_FILE=/dev/null "$BC" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && ok "/dev/null still forces the built-in default (control)" \
-  || bad "/dev/null still forces the built-in default (control)" "rc=$RC out=$OUT"
-
-OUT="$(cd "$R" && COMMIT_GUARDS_SETTINGS_FILE=absent.settings.toml "$BC" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && ok "an ABSENT plain file still falls back to the built-in default (control)" \
-  || bad "an ABSENT plain file still falls back to the built-in default (control)" "rc=$RC out=$OUT"
-rmdir "$R/nonregular.dir"
-
-echo "=== settings: an unreadable source fails loud, never falls through ==="
-if [ "$(id -u)" -eq 0 ]; then
-  printf '  skip  unreadable-source pins need a non-root reader (chmod 000 cannot deny root)\n'
-else
-  printf 'COMMIT_GUARDS_BYTE_CEILING_KB=5\n' >"$R/.env.local"
-  chmod 000 "$R/.env.local"
-  run_bc_default
-  [ "$RC" -eq 2 ] && case "$OUT" in *"unreadable while resolving a setting"*) true ;; *) false ;; esac \
-    && ok "an unreadable .env.local is exit 2 (falling through would have read 3 from the settings file and exited 1)" \
-    || bad "unreadable .env.local is exit 2" "rc=$RC out=$OUT"
-  chmod 600 "$R/.env.local"
-  run_bc_default
-  [ "$RC" -eq 0 ] && ok "control: the same .env.local, readable, supplies 5 and the 4 KB file passes" \
-    || bad "control: readable .env.local supplies the value" "rc=$RC out=$OUT"
-  rm "$R/.env.local"
-fi
-
-echo "=== an EXISTING non-regular ENV-FILE source never falls through ==="
-# .env.local is probed with -f like the settings file, so a directory or an
-# unresolvable symlink there is skipped exactly like an absent one and a
-# lower-precedence value silently decides.
-mkdir -p "$R/.env.local"
-run_bc_default
-[ "$RC" -eq 2 ] && case "$OUT" in *".env.local: settings source exists but is not a regular file"*) true ;; *) false ;; esac \
-  && ok "a DIRECTORY at .env.local is exit 2 (falling through would have read 3 from the settings file)" \
-  || bad "a DIRECTORY at .env.local is exit 2" "rc=$RC out=$OUT"
-rmdir "$R/.env.local"
-
-ln -s missing.env "$R/.env.local"
-run_bc_default
-[ "$RC" -eq 2 ] && case "$OUT" in *".env.local: settings source is a symlink that does not resolve"*) true ;; *) false ;; esac \
-  && ok "a DANGLING .env.local symlink is exit 2, not a silent skip" \
-  || bad "a DANGLING .env.local symlink is exit 2" "rc=$RC out=$OUT"
-rm -f "$R/.env.local"
-
-run_bc_default
-[ "$RC" -eq 1 ] && case "$OUT" in *"ceiling 3 KB"*) true ;; *) false ;; esac \
-  && ok "control: with .env.local absent the settings file still supplies 3" \
-  || bad "control: an absent env file falls through to the settings file" "rc=$RC out=$OUT"
-
-echo "=== fail-closed: a broken blob measurement terminates, never passes ==="
-new_repo measure
-mkbytes big.bin 2
-git -C "$R" add -A
-run_bc
-[ "$RC" -eq 1 ] && ok "shim-free control: the oversized staged file really fails" \
-  || bad "shim-free control fails on the oversized file" "rc=$RC out=$OUT"
+echo "=== fail-closed: a broken blob measurement is a collection error, never a pass ==="
+# A git ahead of PATH whose `cat-file -s` fails as an object read does.
 REAL_GIT="$(command -v git)"
-GIT_SHIM="$TMP/git-shim"
-mkdir -p "$GIT_SHIM"
-cat >"$GIT_SHIM/git" <<EOF
-#!/usr/bin/env bash
-if [ "\${1:-}" = "cat-file" ] && [ "\${2:-}" = "-s" ]; then
-  echo "fatal: simulated object read failure" >&2
-  exit 128
-fi
-exec "$REAL_GIT" "\$@"
-EOF
-chmod +x "$GIT_SHIM/git"
-OUT="$(cd "$R" && PATH="$GIT_SHIM:$PATH" COMMIT_GUARDS_BYTE_CEILING_KB=1 "$BC" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"cannot read blob"*"big.bin"*) true ;; *) false ;; esac \
-  && ok "an unmeasurable blob is a collection error: exit 2, diagnostic names the file" \
-  || bad "an unmeasurable blob is a collection error naming the file" "rc=$RC out=$OUT"
-case "$OUT" in *"byte-ceiling: OK"*) bad "no OK verdict may accompany a broken measurement" "$OUT" ;; *) ok "no OK verdict accompanies the broken measurement" ;; esac
+mkdir -p "$TMP/git-shim"
+printf '#!/usr/bin/env bash\nif [ "${1:-}" = cat-file ] && [ "${2:-}" = -s ]; then echo "fatal: simulated object read failure" >&2; exit 128; fi\nexec %q "$@"\n' "$REAL_GIT" >"$TMP/git-shim/git"
+chmod +x "$TMP/git-shim/git"
+SHA2K="$(head -c 2048 /dev/zero | git hash-object --stdin)"
+measure() { repo "$1"; put big.bin 2; } # NAME
+run_rows \
+  "control: without the shim the oversized staged file fails|measure measure-real|$C=1||rc=1 $(over big.bin 2048 2 1);$(failed 1 1)" \
+  "an unmeasurable blob is exit 2 naming the blob and the file, with no verdict line, git's own words ahead of it|measure measure-shim|PATH=$TMP/git-shim:$PATH,$C=1||rc=2 fatal: simulated object read failure;${ERR}cannot read blob $SHA2K for 'big.bin' — its size is unmeasurable, refusing to skip it"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/commit-guards/tests/settings-precedence.test.sh
+++ b/skills/commit-guards/tests/settings-precedence.test.sh
@@ -1,137 +1,151 @@
 #!/usr/bin/env bash
-# Precedence pins for lib/settings.sh's gg_setting contract: explicit env >
-# .env.local > .kendex/settings.toml > kendex.settings.toml > built-in
-# default, with `.env` read by nothing, only the [env] table consulted, and
-# the contract value grammar (single-line double-quoted, no `"`, no `\`)
-# enforced loudly.
+# Pins for lib/settings.sh's gg_setting contract: explicit env > .env.local
+# > .kendex/settings.toml > kendex.settings.toml > built-in default, with
+# `.env` read by nothing, only the [env] table consulted, the contract value
+# grammar (single-line double-quoted, no `"`, no `\`) enforced loudly over
+# the whole table, a malformed lower source failing under a higher override,
+# and a source skipped only when it is ABSENT: a directory, a dangling or
+# cyclic symlink, or an unreadable file at a source path is a loud refusal,
+# never a silent fall-through to the next layer. One table: a world builds
+# the directory, the key resolves under ENVS, and a row pins the exit
+# status with the value printed and every error line. The staged-index
+# resolution of a tracked source is index-reads.test.sh's and
+# commit-msg-settings.test.sh's.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+SETTINGS="$SKILL_DIR/scripts/lib/settings.sh"
 # shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
 
-# shellcheck source=../scripts/lib/settings.sh
-source "$SKILL_DIR/scripts/lib/settings.sh"
-
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
-
-R="$TMP/repo"
-mkdir -p "$R/.kendex"
-
-resolve() { # NAME DEFAULT [ENV_ASSIGN] — sets OUT and RC from inside the repo
-  OUT=""; RC=0
-  OUT="$(cd "$R" && { unset "$1" COMMIT_GUARDS_SETTINGS_FILE 2>/dev/null; env ${3:+"$3"} bash -c '
-    set -euo pipefail
-    source "$0"
-    gg_setting "$1" "$2"
-  ' "$SKILL_DIR/scripts/lib/settings.sh" "$1" "$2" 2>"$TMP/err"; })" || RC=$?
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
 }
 
-echo "=== the resolution ladder, one layer at a time ==="
-resolve COMMIT_GUARDS_TP "dflt"
-[ "$RC" -eq 0 ] && [ "$OUT" = "dflt" ] && ok "no source configured: the built-in default answers" || bad "built-in default answers" "rc=$RC out=$OUT"
-
-printf '[env]\nCOMMIT_GUARDS_TP = "root"\n' >"$R/kendex.settings.toml"
-resolve COMMIT_GUARDS_TP "dflt"
-[ "$RC" -eq 0 ] && [ "$OUT" = "root" ] && ok "kendex.settings.toml supplies the value" || bad "kendex.settings.toml supplies the value" "rc=$RC out=$OUT"
-
-printf '[env]\nCOMMIT_GUARDS_TP = "nested"\n' >"$R/.kendex/settings.toml"
-resolve COMMIT_GUARDS_TP "dflt"
-[ "$RC" -eq 0 ] && [ "$OUT" = "nested" ] && ok ".kendex/settings.toml beats kendex.settings.toml" || bad ".kendex/settings.toml beats kendex.settings.toml" "rc=$RC out=$OUT"
-
-printf 'COMMIT_GUARDS_TP=dotenv\n' >"$R/.env.local"
-resolve COMMIT_GUARDS_TP "dflt"
-[ "$RC" -eq 0 ] && [ "$OUT" = "dotenv" ] && ok ".env.local beats both settings files" || bad ".env.local beats both settings files" "rc=$RC out=$OUT"
-
-resolve COMMIT_GUARDS_TP "dflt" "COMMIT_GUARDS_TP=explicit"
-[ "$RC" -eq 0 ] && [ "$OUT" = "explicit" ] && ok "explicit environment beats every project file" || bad "explicit environment beats every project file" "rc=$RC out=$OUT"
-
-resolve COMMIT_GUARDS_TP "dflt" "COMMIT_GUARDS_TP="
-[ "$RC" -eq 0 ] && [ "$OUT" = "" ] && ok "a SET-but-empty environment value still wins (explicitly empty)" || bad "set-but-empty environment wins" "rc=$RC out=$OUT"
-rm -f "$R/.env.local" "$R/.kendex/settings.toml" "$R/kendex.settings.toml"
-
-echo "=== a .env value is read by nothing ==="
-# Fails against a resolver that still reads the dropped layer: the value
-# would resolve instead of the default.
-printf 'COMMIT_GUARDS_TP=from-dotenv\n' >"$R/.env"
-resolve COMMIT_GUARDS_TP "dflt"
-[ "$RC" -eq 0 ] && [ "$OUT" = "dflt" ] && ok "a .env assignment is ignored and the default answers" || bad "a .env assignment is ignored" "rc=$RC out=$OUT"
-rm -f "$R/.env"
-
-echo "=== only the [env] table is read ==="
-printf 'COMMIT_GUARDS_TT = "top"\n[env]\nCOMMIT_GUARDS_OTHER = "x"\n' >"$R/kendex.settings.toml"
-resolve COMMIT_GUARDS_TT "dflt"
-[ "$RC" -eq 0 ] && [ "$OUT" = "dflt" ] && ok "an assignment ABOVE the [env] header is ignored" || bad "assignment above [env] ignored" "rc=$RC out=$OUT"
-
-printf '[notes]\nCOMMIT_GUARDS_TT = "elsewhere"\n' >"$R/kendex.settings.toml"
-resolve COMMIT_GUARDS_TT "dflt"
-[ "$RC" -eq 0 ] && [ "$OUT" = "dflt" ] && ok "an assignment under an UNRELATED table is ignored" || bad "assignment under another table ignored" "rc=$RC out=$OUT"
-
-printf '[env]\nCOMMIT_GUARDS_TT = "in-env"\n' >"$R/kendex.settings.toml"
-resolve COMMIT_GUARDS_TT "dflt"
-[ "$RC" -eq 0 ] && [ "$OUT" = "in-env" ] && ok "control: the same assignment inside [env] resolves" || bad "control: [env] assignment resolves" "rc=$RC out=$OUT"
-
-echo "=== ambiguity and the contract grammar fail loud ==="
-printf '[env]\nCOMMIT_GUARDS_TT = "a"\nCOMMIT_GUARDS_TT = "b"\n' >"$R/kendex.settings.toml"
-resolve COMMIT_GUARDS_TT "dflt"
-[ "$RC" -ne 0 ] && grep -q "assigned more than once in \[env\]" "$TMP/err" && ok "a duplicate inside [env] is a config error" || bad "duplicate inside [env] errors" "rc=$RC out=$OUT"
-
-printf '[env]\nCOMMIT_GUARDS_TT = "a\\b"\n' >"$R/kendex.settings.toml"
-resolve COMMIT_GUARDS_TT "dflt"
-[ "$RC" -ne 0 ] && grep -q "unsupported syntax" "$TMP/err" && ok "a backslash in the value is a config error, never decoded" || bad "backslash value errors" "rc=$RC out=$OUT"
-
-printf '[env]\nCOMMIT_GUARDS_TT = "kept" # comment\n' >"$R/kendex.settings.toml"
-resolve COMMIT_GUARDS_TT "dflt"
-[ "$RC" -eq 0 ] && [ "$OUT" = "kept" ] && ok "a trailing comment is dropped from the decoded value" || bad "trailing comment decode" "rc=$RC out=$OUT"
-
-echo "=== a header the parser cannot read fails loud ==="
-# Headers decide which assignments load: `[env] # comment` passing as
-# content hides the whole table behind silent defaults.
-printf '[env] # comment\nCOMMIT_GUARDS_TT = "hidden"\n' >"$R/kendex.settings.toml"
-resolve COMMIT_GUARDS_TT "dflt"
-[ "$RC" -ne 0 ] && grep -q "unsupported table header shape" "$TMP/err" && ok "a commented [env] header is a config error, not an invisible table" || bad "commented [env] header errors" "rc=$RC out=$OUT"
-
-echo "=== a SET-but-EMPTY settings-file override is unset, not a source ==="
-# "" names no file: consulting only it resolved every key to its built-in
-# default with nothing said. /dev/null stays the one force-defaults handle.
-printf '[env]\nCOMMIT_GUARDS_TT = "fromrepo"\n' >"$R/kendex.settings.toml"
-OUT=""; RC=0
-OUT="$(cd "$R" && { unset COMMIT_GUARDS_TT 2>/dev/null; env COMMIT_GUARDS_SETTINGS_FILE= bash -c '
+# One line for a resolution in the row's world: the exit status, the value
+# printed, and every error line joined by ';'. The key and the settings-file
+# override are unset first, so only ENVS (comma-separated assignments)
+# reach the resolver.
+K=COMMIT_GUARDS_TP
+R=""
+resolve() { # ENVS [KEY]
+  local envs=() rc=0 out="" err=""
+  [ -z "$1" ] || IFS=',' read -ra envs <<<"$1"
+  out="$(cd "$R" && { unset "$K" COMMIT_GUARDS_SETTINGS_FILE 2>/dev/null; env ${envs[@]+"${envs[@]}"} bash -c '
     set -euo pipefail
     source "$0"
-    gg_setting "$1" "$2"
-  ' "$SKILL_DIR/scripts/lib/settings.sh" COMMIT_GUARDS_TT "dflt" 2>"$TMP/err"; })" || RC=$?
-[ "$RC" -eq 0 ] && [ "$OUT" = "fromrepo" ] && ok "a SET-but-EMPTY COMMIT_GUARDS_SETTINGS_FILE reads the default sources" || bad "set-but-empty override reads default sources" "rc=$RC out=$OUT"
+    gg_setting "$1" dflt
+  ' "$SETTINGS" "${2:-$K}" 2>"$TMP/err"; })" || rc=$?
+  # bash names the resolver's own path and line when a redirect inside it is
+  # refused; the path and the line number are not the row's to pin.
+  err="$(LC_ALL=C sed -e "s#$SETTINGS#<settings.sh>#" -e 's/line [0-9]*:/line N:/' "$TMP/err" | LC_ALL=C paste -sd ';' -)"
+  printf 'rc=%s value=%s%s' "$rc" "$out" "${err:+ err=$err}"
+}
 
-echo "=== the WHOLE [env] table is validated, not only the requested key ==="
-# kendex-env.sh refuses these same files, so a per-key-only extractor would
-# split the family contract.
-printf '[env]\nUNRELATED = bare\nCOMMIT_GUARDS_TT = "v"\n' >"$R/kendex.settings.toml"
-resolve COMMIT_GUARDS_TT "dflt"
-[ "$RC" -ne 0 ] && grep -q "unsupported syntax for UNRELATED" "$TMP/err" && ok "an unrelated non-contract assignment fails the read" || bad "unrelated malformed assignment" "rc=$RC out=$OUT"
+# World vocabulary: a fresh directory per row, a name used twice refused.
+world() { # NAME
+  R="$TMP/$1"
+  [ ! -e "$R" ] || { echo "harness: world $1 already exists" >&2; exit 2; }
+  mkdir -p "$R/.kendex"
+}
+put() { printf '%b' "$2" >"$R/$1"; } # PATH CONTENT (printf %b)
+root() { world "$1"; put kendex.settings.toml '[env]\nCOMMIT_GUARDS_TP = "root"\n'; } # NAME — the root file says root
+fx_nested() { root "$1"; put .kendex/settings.toml '[env]\nCOMMIT_GUARDS_TP = "nested"\n'; } # NAME
+fx_dotenv() { fx_nested "$1"; put .env.local 'COMMIT_GUARDS_TP=dotenv\n'; } # NAME
+fx_dotenv_only() { world dotenv-only; put .env 'COMMIT_GUARDS_TP=from-dotenv\n'; }
+toml() { world "$1"; shift; put kendex.settings.toml "$*"; } # NAME CONTENT... — the root file holds CONTENT, the fixture column's words rejoined
+fx_backslash() { world backslash; printf '[env]\nCOMMIT_GUARDS_TP = "a\\b"\n' >"$R/kendex.settings.toml"; }
+fx_bom() { world bom; printf '\357\273\277[env]\nCOMMIT_GUARDS_TP = "hidden"\n' >"$R/kendex.settings.toml"; }
+fx_dir_settings() { root dir-settings; mkdir -p "$R/nonregular.dir"; }
+fx_dangling() { root dangling; ln -s missing.toml "$R/dangling.settings.toml"; }
+fx_cyclic() { root cyclic; ln -s cycle-b.settings.toml "$R/cycle-a.settings.toml"; ln -s cycle-a.settings.toml "$R/cycle-b.settings.toml"; }
+fx_resolving() { root resolving; put link-target.settings.toml '[env]\nCOMMIT_GUARDS_TP = "linked"\n'; ln -s link-target.settings.toml "$R/link.settings.toml"; }
+fx_env_dir() { root "$1"; mkdir -p "$R/.env.local"; } # NAME
+fx_env_dangling() { root env-dangling; ln -s missing.env "$R/.env.local"; }
+dotenv() { root "$1"; shift; put .env.local "$*\n"; } # NAME LINE... — .env.local holds the rejoined words
+ERR_DUP='::error::kendex.settings.toml: COMMIT_GUARDS_TP is assigned more than once in [env] (each key must be unique in the table)'
+NOT_REGULAR='settings source exists but is not a regular file (directory, FIFO, socket or device); a source is skipped only when it is absent'
+NOT_RESOLVING='settings source is a symlink that does not resolve (dangling target, cycle, or over-long chain); a source is skipped only when it is absent'
 
-printf '[env]\nUNRELATED = "a"\nUNRELATED = "b"\nCOMMIT_GUARDS_TT = "v"\n' >"$R/kendex.settings.toml"
-resolve COMMIT_GUARDS_TT "dflt"
-[ "$RC" -ne 0 ] && grep -q "UNRELATED is assigned more than once" "$TMP/err" && ok "an unrelated duplicated key fails the read" || bad "unrelated duplicated key" "rc=$RC out=$OUT"
+run_rows() { # label | world | envs | expect
+  local row label fx envs expect words
+  for row in "$@"; do
+    IFS='|' read -r label fx envs expect <<<"$row"
+    R=""
+    read -ra words <<<"$fx"
+    "${words[@]}"
+    assert_eq "$label" "$expect" "$(resolve "$envs")"
+  done
+}
 
-echo "=== a malformed lower file fails even under a higher-precedence override ==="
-# kendex-env validates before its parent-env skip; an exported value must
-# never let a broken committed file pass silently.
-printf '[env]\nDUP = "a"\nDUP = "b"\n' >"$R/kendex.settings.toml"
-resolve COMMIT_GUARDS_TT "dflt" "COMMIT_GUARDS_TT=explicit"
-[ "$RC" -ne 0 ] && grep -q "assigned more than once" "$TMP/err" && ok "an exported value does not mask a malformed settings file" || bad "env override over malformed file" "rc=$RC out=$OUT"
+echo "=== the resolution ladder, one layer at a time; .env is read by nothing ==="
+run_rows \
+  "no source configured: the built-in default answers|world bare||rc=0 value=dflt" \
+  "kendex.settings.toml supplies the value|root root||rc=0 value=root" \
+  ".kendex/settings.toml beats kendex.settings.toml|fx_nested nested||rc=0 value=nested" \
+  ".env.local beats both settings files|fx_dotenv dotenv||rc=0 value=dotenv" \
+  "the explicit environment beats every project file|fx_dotenv explicit|COMMIT_GUARDS_TP=explicit|rc=0 value=explicit" \
+  "a SET-but-empty environment value still wins: explicitly empty|fx_dotenv explicit-empty|COMMIT_GUARDS_TP=|rc=0 value=" \
+  "a .env assignment is read by nothing and the default answers|fx_dotenv_only||rc=0 value=dflt"
 
-# ...and it must not mask a BROKEN .env.local either: the layer's
-# usability is part of every resolution, same as the generic loader.
-printf '[env]\nCOMMIT_GUARDS_TT = "fromrepo"\n' >"$R/kendex.settings.toml"
-mkdir -p "$R/.env.local"
-resolve COMMIT_GUARDS_TT "dflt" "COMMIT_GUARDS_TT=explicit"
-[ "$RC" -ne 0 ] && grep -q "not a regular file" "$TMP/err" && ok "an exported value does not mask a DIRECTORY at .env.local" || bad "env override over broken .env.local" "rc=$RC out=$OUT"
-rmdir "$R/.env.local"
+echo "=== only the [env] table is read, and it is validated whole ==="
+run_rows \
+  "an assignment ABOVE the [env] header is ignored|toml above COMMIT_GUARDS_TP = \"top\"\n[env]\nCOMMIT_GUARDS_OTHER = \"x\"\n||rc=0 value=dflt" \
+  "an assignment under an UNRELATED table is ignored|toml unrelated-table [notes]\nCOMMIT_GUARDS_TP = \"elsewhere\"\n||rc=0 value=dflt" \
+  "control: the same assignment inside [env] resolves|toml in-env [env]\nCOMMIT_GUARDS_TP = \"in-env\"\n||rc=0 value=in-env" \
+  "a trailing comment is dropped from the decoded value, a quote inside it included|toml comment [env]\nCOMMIT_GUARDS_TP = \"kept\" # a \"quoted\" comment\n||rc=0 value=kept" \
+  "a key assigned twice inside [env] is a config error, naming the key|toml dup [env]\nCOMMIT_GUARDS_TP = \"a\"\nCOMMIT_GUARDS_TP = \"b\"\n||rc=1 value= err=$ERR_DUP" \
+  "a backslash in the value is a config error, never decoded|fx_backslash||rc=1 value= err=::error::kendex.settings.toml: unsupported syntax for COMMIT_GUARDS_TP (expected a single-line basic string, no double quote and no backslash: COMMIT_GUARDS_TP = \"value\")" \
+  "a commented [env] header is a config error naming its line, not an invisible table|toml header [env] # comment\nCOMMIT_GUARDS_TP = \"hidden\"\n||rc=1 value= err=::error::kendex.settings.toml:1: unsupported table header shape (a header is a lone [name] on its own line, with no comment and no second bracket)" \
+  "a leading byte-order mark is a config error, not a misread first line|fx_bom||rc=1 value= err=::error::kendex.settings.toml: file starts with a UTF-8 byte-order mark; remove it (the first header or assignment would otherwise be misread)" \
+  "an unrelated non-contract assignment fails the read|toml unrelated-bare [env]\nUNRELATED = bare\nCOMMIT_GUARDS_TP = \"v\"\n||rc=1 value= err=::error::kendex.settings.toml: unsupported syntax for UNRELATED (expected a single-line basic string, no double quote and no backslash: UNRELATED = \"value\")" \
+  "an unrelated duplicated key fails the read|toml unrelated-dup [env]\nUNRELATED = \"a\"\nUNRELATED = \"b\"\nCOMMIT_GUARDS_TP = \"v\"\n||rc=1 value= err=::error::kendex.settings.toml: UNRELATED is assigned more than once in [env] (each key must be unique in the table)" \
+  "an exported value does not mask a malformed settings file|toml masked-dup [env]\nDUP = \"a\"\nDUP = \"b\"\n|COMMIT_GUARDS_TP=explicit|rc=1 value= err=::error::kendex.settings.toml: DUP is assigned more than once in [env] (each key must be unique in the table)" \
+  "an exported value does not mask a DIRECTORY at .env.local|fx_env_dir env-dir-masked|COMMIT_GUARDS_TP=explicit|rc=1 value= err=::error::.env.local: $NOT_REGULAR"
+
+echo "=== a source is skipped only when it is ABSENT; the overrides that force defaults ==="
+run_rows \
+  "a SET-but-EMPTY COMMIT_GUARDS_SETTINGS_FILE is unset and reads the default sources|root empty-override|COMMIT_GUARDS_SETTINGS_FILE=|rc=0 value=root" \
+  "COMMIT_GUARDS_SETTINGS_FILE=/dev/null forces the built-in default past every source|fx_dotenv devnull|COMMIT_GUARDS_SETTINGS_FILE=/dev/null|rc=0 value=dflt" \
+  "an ABSENT explicit settings file falls back to the built-in default|root absent-explicit|COMMIT_GUARDS_SETTINGS_FILE=absent.settings.toml|rc=0 value=dflt" \
+  "a DIRECTORY at the settings path is a config error, not a silent default|fx_dir_settings|COMMIT_GUARDS_SETTINGS_FILE=nonregular.dir|rc=1 value= err=::error::nonregular.dir: $NOT_REGULAR" \
+  "a DANGLING symlink at the settings path is a config error|fx_dangling|COMMIT_GUARDS_SETTINGS_FILE=dangling.settings.toml|rc=1 value= err=::error::dangling.settings.toml: $NOT_RESOLVING" \
+  "a CYCLIC symlink at the settings path is a config error|fx_cyclic|COMMIT_GUARDS_SETTINGS_FILE=cycle-a.settings.toml|rc=1 value= err=::error::cycle-a.settings.toml: $NOT_RESOLVING" \
+  "control: a RESOLVING symlink reads its target|fx_resolving|COMMIT_GUARDS_SETTINGS_FILE=link.settings.toml|rc=0 value=linked" \
+  "a DIRECTORY at .env.local is a config error where the settings file would have answered|fx_env_dir env-dir||rc=1 value= err=::error::.env.local: $NOT_REGULAR" \
+  "a DANGLING .env.local symlink is a config error, not a silent skip|fx_env_dangling||rc=1 value= err=::error::.env.local: $NOT_RESOLVING" \
+  "control: with .env.local absent the settings file answers|root env-absent||rc=0 value=root"
+
+echo "=== the .env.local grammar: last assignment wins, quotes stripped, a comment after the closing quote dropped ==="
+run_rows \
+  "an export prefix is accepted|dotenv env-export export COMMIT_GUARDS_TP=exported||rc=0 value=exported" \
+  "the LAST matching assignment wins|dotenv env-last COMMIT_GUARDS_TP=first\nCOMMIT_GUARDS_TP=last||rc=0 value=last" \
+  "double quotes are stripped and a comment after the closing quote dropped|dotenv env-dq COMMIT_GUARDS_TP=\"quoted value\" # comment||rc=0 value=quoted value" \
+  "single quotes are stripped|dotenv env-sq COMMIT_GUARDS_TP='single'||rc=0 value=single" \
+  "an unquoted value ends at the first whitespace|dotenv env-bare COMMIT_GUARDS_TP=abc def||rc=0 value=abc" \
+  "a segment adjacent to the closing quote is a config error naming the key, not a truncated value|dotenv env-adjacent COMMIT_GUARDS_TP=\"abc\"#def||rc=1 value= err=::error::.env.local: unsupported syntax for COMMIT_GUARDS_TP (a quoted value must end at its closing quote, optionally followed by a comment)"
+assert_eq "a key that is not a shell identifier is refused before any source is read" "rc=1 value= err=::error::gg_setting: invalid key name 'bad-key' (shell identifier shape required: [A-Za-z_][A-Za-z0-9_]*)" "$(root bad-key; resolve '' bad-key)"
+
+echo "=== an unreadable .env.local fails loud, never falls through ==="
+if [ "$(id -u)" -eq 0 ]; then
+  printf '  skip  the unreadable-source pins need a non-root reader (chmod 000 cannot deny root)\n'
+else
+  root unreadable
+  put .env.local 'COMMIT_GUARDS_TP=dotenv\n'
+  chmod 000 "$R/.env.local"
+  assert_eq "an unreadable .env.local is a config error: falling through would have read root" "rc=1 value= err=<settings.sh>: line N: .env.local: Permission denied;::error::.env.local: unreadable while resolving a setting (permission denied)" "$(resolve '')"
+  chmod 600 "$R/.env.local"
+  assert_eq "control: the same file, readable, supplies its value" "rc=0 value=dotenv" "$(resolve '')"
+fi
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/commit-guards/tests/settings-precedence.test.sh
+++ b/skills/commit-guards/tests/settings-precedence.test.sh
@@ -72,7 +72,8 @@ fx_resolving() { root resolving; put link-target.settings.toml '[env]\nCOMMIT_GU
 fx_env_dir() { root "$1"; mkdir -p "$R/.env.local"; } # NAME
 fx_env_dangling() { root env-dangling; ln -s missing.env "$R/.env.local"; }
 dotenv() { root "$1"; shift; put .env.local "$*\n"; } # NAME LINE... — .env.local holds the rejoined words
-ERR_DUP='::error::kendex.settings.toml: COMMIT_GUARDS_TP is assigned more than once in [env] (each key must be unique in the table)'
+fx_nested_dup() { root nested-dup; put .kendex/settings.toml '[env]\nCOMMIT_GUARDS_TP = "a"\nCOMMIT_GUARDS_TP = "b"\n'; }
+ERR_DUP='::error::.kendex/settings.toml: COMMIT_GUARDS_TP is assigned more than once in [env] (each key must be unique in the table)'
 NOT_REGULAR='settings source exists but is not a regular file (directory, FIFO, socket or device); a source is skipped only when it is absent'
 NOT_RESOLVING='settings source is a symlink that does not resolve (dangling target, cycle, or over-long chain); a source is skipped only when it is absent'
 
@@ -103,7 +104,7 @@ run_rows \
   "an assignment under an UNRELATED table is ignored|toml unrelated-table [notes]\nCOMMIT_GUARDS_TP = \"elsewhere\"\n||rc=0 value=dflt" \
   "control: the same assignment inside [env] resolves|toml in-env [env]\nCOMMIT_GUARDS_TP = \"in-env\"\n||rc=0 value=in-env" \
   "a trailing comment is dropped from the decoded value, a quote inside it included|toml comment [env]\nCOMMIT_GUARDS_TP = \"kept\" # a \"quoted\" comment\n||rc=0 value=kept" \
-  "a key assigned twice inside [env] is a config error, naming the key|toml dup [env]\nCOMMIT_GUARDS_TP = \"a\"\nCOMMIT_GUARDS_TP = \"b\"\n||rc=1 value= err=$ERR_DUP" \
+  "a key assigned twice inside [env] is a config error naming the key, in the nested file under a good root file|fx_nested_dup||rc=1 value= err=$ERR_DUP" \
   "a backslash in the value is a config error, never decoded|fx_backslash||rc=1 value= err=::error::kendex.settings.toml: unsupported syntax for COMMIT_GUARDS_TP (expected a single-line basic string, no double quote and no backslash: COMMIT_GUARDS_TP = \"value\")" \
   "a commented [env] header is a config error naming its line, not an invisible table|toml header [env] # comment\nCOMMIT_GUARDS_TP = \"hidden\"\n||rc=1 value= err=::error::kendex.settings.toml:1: unsupported table header shape (a header is a lone [name] on its own line, with no comment and no second bracket)" \
   "a leading byte-order mark is a config error, not a misread first line|fx_bom||rc=1 value= err=::error::kendex.settings.toml: file starts with a UTF-8 byte-order mark; remove it (the first header or assignment would otherwise be misread)" \


### PR DESCRIPTION
Reshapes `skills/commit-guards/tests/byte-ceiling.test.sh` and `skills/commit-guards/tests/settings-precedence.test.sh` to code-quality § Tests, one PR because eleven cases move between them.

byte-ceiling pinned `scripts/byte-ceiling` in a 386-line script of 49 assertions, each an exit status read as a bit beside a substring, over long-lived repositories each case rewrote. It is one table now (`run_rows`, `label|fixture|envs|args|expect`): a fixture function with its words builds a fresh repository (`repo`, `put PATH KB [FILL]` writes KB kibibytes of one byte and stages, `commit`, `excludes`), the check runs with ARGS under ENVS, and a row pins the exit status with every line printed, so the hit, the remedy, the counts and the scope named are one pin; the run repeats once in the same repository and a differing second verdict is shown after ` / again: ` (the old "stable clean verdict" case, now every row). Expected lines are built by `over`, `grew`, `ok`, `failed`, `since` from what the row put in. Rows added: `--base=REF`, `--base` without a ref, an unmerged add/add conflict refused rather than measured around, `--excludes FILE` with its control (the remedy naming each list), `--help` and `-h`, a merge-base row where main shrank the legacy file after the branch point (a two-dot diff would charge the branch with growth), `--all` not counting a tracked symlink, a lockfile suffix that is not the basename, a moved-and-grown file at 80% similarity (a rename at any threshold below exact). One old arm has no row: the `'$f' has no destination blob` refusal, which no shipped producer reaches (`git add -N` entries do not appear in `diff --cached`); recorded, not pinned. The old settings-source shape cases (a directory, dangling or cyclic symlink at the settings path, a resolving symlink, /dev/null, an absent file, an unreadable, directory or dangling `.env.local`, the absent-env control) are the settings loader's clauses and moved to its suite; byte-ceiling keeps two ladder rows as consumer proof (the settings file supplies 3, the environment supplies 5 over it). The old suite ran 49 assertions (the reviewer recounted it): 35 kept, 11 moved, 3 folded (the remedy line, the stable second verdict, the no-OK-line negative); 35 + 10 added = 45, then the reviewer round's seven rows = 52.

settings-precedence pinned `scripts/lib/settings.sh`'s `gg_setting` in 19 assertions reading a stderr file with `grep -q`. It is one table now (`run_rows`, `label|world|envs|expect`): a world function builds a fresh directory (`world`, `root`, `fx_nested`, `fx_dotenv`, `toml NAME CONTENT...` and `dotenv NAME LINE...` rejoining the fixture column's words), `resolve` unsets the key and the settings-file override, runs `gg_setting` under ENVS and pins `rc=N value=<stdout>` plus ` err=<every stderr line>`. The eleven moved rows are its third section. Rows added: the dotenv grammar (an export prefix, the last assignment wins, double and single quotes stripped, an unquoted value ending at whitespace, a segment adjacent to the closing quote refused naming the key), a leading byte-order mark on the settings file, a key that is not a shell identifier, and the trailing-comment row now carries a quote inside the comment. The old suite ran 19 assertions (recounted): 19 + 11 moved + 6 grammar + a BOM + a key name = 38, the two unreadable pins staying outside the table under the euid-0 skip. One finding for the loader, not fixed here: bash names the resolver's own path and line when the BOM guard's redirect (`head -c 3 < "$1"`) is refused on an unreadable `.env.local`, ahead of the loader's permission-denied error; the row normalises that line to `<settings.sh>: line N:`.

The tracked render is replayed with `patch`. A `kendex refresh` in the main checkout is currently refused (it wants to remove another lane's pending command-safety hook records), so nothing about `.kendex-generated.json` changed here.

## Mutation

47 exact-substring mutants over `scripts/byte-ceiling`, `scripts/lib/settings.sh` and `gg_positive_int`, each run against the final suites in a scratch copy; 46 killed, 1 equivalent.

| mutant | result |
|---|---|
| ceiling: at the ceiling is over | killed by "a 1 KB addition at ceiling 1 KB passes: at the ceiling is not over it" |
| ceiling: the default is 2000 | killed by "a 205 KB addition fails under the built-in 200 KB" |
| ceiling: KB read as bytes | killed by "a 1 KB addition at ceiling 1 KB passes: at the ceiling is not over it" |
| ceiling: the value is not validated | killed by "a non-numeric ceiling is exit 2, quoting it" |
| staged: only additions are read | killed by "editing a tracked file past the ceiling fails: the staged lane reads A and M" |
| staged: renames followed at 50% | killed by "a file moved AND grown is an addition at its new path: below exact similarity the growth would ride the rename unjudged" |
| staged: renames not followed | killed by "renaming an existing large file is not an addition: rename detection is on, and the rename is not counted" |
| staged: the unmerged index is measured around | killed by "an unmerged index is refused rather than measured around: the conflict's addition would vanish from the record set" |
| base: an unknown ref is not refused | killed by "an unknown --base ref is exit 2, naming it" |
| base: two-dot diff instead of merge-base | killed by "--base judges from the merge-base: a legacy file main shrank after the branch point is not the branch's growth" |
| all: symlinks and gitlinks are sized | killed by "--all does not size a tracked symlink: one file checked beside it" |
| diff: a symlink destination is sized | killed by "control: a file replaced BY a symlink is not sized content" |
| lockfile: package-lock.json is not exempt | killed by "an oversized package-lock.json passes and is not counted: the built-in lockfile exemption" |
| lockfile: matched by suffix, not basename | killed by "control: a basename that only ends in a lockfile's name is not exempt" |
| excludes: not consulted | killed by "an excludes row exempts the declared tree; the list itself is a staged file and is counted" |
| excludes: the flag is ignored | killed by "--excludes FILE names the list, and the remedy names it too" |
| measure: an unreadable blob is skipped | killed by "an unmeasurable blob is exit 2 naming the blob and the file, with no verdict line, git's own words ahead of it" |
| tighten: a prior oversized file may grow | killed by "an existing oversized file may not grow, by one byte" |
| tighten: a prior under-ceiling file is a baseline too | SURVIVED: equivalent. The dropped conjunct `prior > ceiling` is implied by the branch's own guard (`size > ceiling`) and `size <= prior` |
| tighten: a symlink source is a prior size | killed by "a 2 KB addition at ceiling 1 KB fails naming file, bytes and ceiling, carrying the remedy and counting both staged files" |
| verdict: violations exit 0 | killed by "a 2 KB addition at ceiling 1 KB fails naming file, bytes and ceiling, carrying the remedy and counting both staged files" |
| verdict: the checked count skips the first | killed by "a 1 KB addition at ceiling 1 KB passes: at the ceiling is not over it" |
| verdict: the KB rounding floors | killed by "an existing oversized file may not grow, by one byte" |
| verdict: the remedy is dropped | killed by "a 2 KB addition at ceiling 1 KB fails naming file, bytes and ceiling, carrying the remedy and counting both staged files" |
| verdict: the grew line is the over line | killed by "an existing oversized file may not grow, by one byte" |
| verdict: the scope names staged for --base | killed by "--base main permits a legacy oversized file to shrink" |
| usage: an unknown flag is ignored | killed by "an unknown flag is exit 2, quoting it" |
| usage: --base without a ref is --staged | killed by "--base without a ref is exit 2" |
| int: zero is positive | killed by "a zero ceiling is exit 2" |
| ladder: .env.local loses to the settings files | killed by ".env.local beats both settings files" |
| ladder: the root file beats the nested file | killed by ".kendex/settings.toml beats kendex.settings.toml" |
| ladder: .env is a layer | killed by "a .env assignment is read by nothing and the default answers" |
| ladder: a set-but-empty env var is unset | killed by "a SET-but-empty environment value still wins: explicitly empty" |
| ladder: an empty settings-file override consults nothing | killed by "a SET-but-EMPTY COMMIT_GUARDS_SETTINGS_FILE is unset and reads the default sources" |
| ladder: /dev/null skips only the TOML layer | killed by "COMMIT_GUARDS_SETTINGS_FILE=/dev/null forces the built-in default past every source" |
| usable: a directory source is skipped | killed by "a DANGLING symlink at the settings path is a config error" |
| usable: a dangling symlink is skipped | killed by "a DANGLING symlink at the settings path is a config error" |
| usable: the two shapes swap their words | killed by "an exported value does not mask a DIRECTORY at .env.local" |
| table: a header with a comment is a header | killed by "a commented [env] header is a config error naming its line, not an invisible table" |
| table: the whole-table validation is skipped | killed by "an exported value does not mask a malformed settings file" |
| table: an override skips the .env.local usability probe | killed by "an exported value does not mask a DIRECTORY at .env.local" |
| bom: the guard passes a BOM | killed by "a leading byte-order mark is a config error, not a misread first line" |
| dotenv: the first assignment wins | killed by "the LAST matching assignment wins" |
| dotenv: an adjacent segment is a comment | killed by "a segment adjacent to the closing quote is a config error naming the key, not a truncated value" |
| dotenv: an export prefix is not recognised | killed by "an export prefix is accepted" |
| key: any name is accepted | killed by "a key that is not a shell identifier is refused before any source is read" |
| value: a trailing comment is kept | killed by "a trailing comment is dropped from the decoded value, a quote inside it included" |

20 fixture mutants (one fixture's planted element removed, the named row must fail): 14 killed, 6 by design.

| fixture mutant | result |
|---|---|
| F1 grow: the extra byte not appended | killed by "an existing oversized file may not grow, by one byte" |
| F2 hold: the bytes unchanged | killed by "an existing oversized file may change without growing" |
| F3 rename: no rename, the file stays | no kill by design: a fixture that does not rename reads the same `OK 0` as the untouched row; the rename-detection code mutants are its kills |
| F4 move-grow: moved without growing | killed by "a file moved AND grown is an addition at its new path: below exact similarity the growth would ride the rename unjudged" |
| F13 main-moves: main does not move | no kill by design: the branch's diff since the merge-base is the same either way; the two-dot code mutant is its kill |
| F14 all-symlink: no symlink | no kill by design: an uncounted symlink and no symlink both read one file checked; the --all mode-skip code mutant is its kill |
| F5 typechange: the symlink never committed | no kill by design: without the committed symlink the file is a plain addition with the same line; the symlink-source code mutant is its kill |
| F6 unmerged: the merge resolved | killed by "an unmerged index is refused rather than measured around: the conflict's addition would vanish from the record set" |
| F7 excluded: the reason row not written | killed by "an excludes row exempts the declared tree; the list itself is a staged file and is counted" |
| F8 lock-twin: the twin not written | killed by "control: the same bytes as data.json fail, the exemption is the basename" |
| F9 settings: the settings file not written | killed by "kendex.settings.toml supplies the ceiling: 4 KB fails at 3 where the built-in 200 would pass" |
| F10 shim: the shim passes cat-file through | killed by "an unmeasurable blob is exit 2 naming the blob and the file, with no verdict line, git's own words ahead of it" |
| F11 legacy: the legacy file under the ceiling | killed by "--all fails on the legacy oversized file, naming the sweep" |
| F12 run: the second run not compared | no kill by design: every verdict here is stable, so the fold has nothing to show |
| S1 nested: the nested file not written | killed by ".kendex/settings.toml beats kendex.settings.toml" |
| S2 dotenv: .env.local not written | killed by ".env.local beats both settings files" |
| S3 dotenv-only: .env.local instead of .env | killed by "a .env assignment is read by nothing and the default answers" |
| S4 bom: no BOM | killed by "a leading byte-order mark is a config error, not a misread first line" |
| S5 cyclic: the cycle broken | killed by "a CYCLIC symlink at the settings path is a config error" |
| S6 resolving: the link target not written | killed by "control: a RESOLVING symlink reads its target" |
| S7 resolve: the key not unset first | no kill by design: the key is never in the suite's environment |
| S8 unreadable: the file readable | killed by "an unreadable .env.local is a config error: falling through would have read root" |

## Checks

- `byte-ceiling.test.sh`: 52 assertions; `settings-precedence.test.sh`: 38 assertions; both pass on this host, under a symlinked TMPDIR, and on a macOS box (bash 3.2.57, BSD userland). Every commit-guards suite passes on the worktree. `tools/bash32-lint` clean.
- `tools/guard --full`: exit 0 on the first commit under TMPDIR=/tmp; the rerun on the second commit was launched at PR time (the box was under another lane's fork storm), CI is the verdict.
- One reviewer-test round: fix-first, five blockers (the pinned sha hashed in the host repository; no row for a nested lockfile's basename, a gitlink in either mode, `--staged` spelled out, or the unmerged-index refusal under `--all`), every one applied in the second commit together with its suggestions (`--excludes=`, an unmeasurable prior blob, the duplicate-key row moved to the nested settings file under a good root, the double-run fold named a tripwire in the header). Its 100 mutants (75 killed) are in `review-bc/REPORT-final.md` of the session scratchpad; the survivors it named are the rows of the second commit.

KEN-1241

https://claude.ai/code/session_01Kt4SUzEL9gcpU7Pdvyhips
