### PR TITLE
test(KEN-1241): the conflict-markers suite as two tables of rows

### DIFF
--- a/.agents/skills/commit-guards/tests/conflict-markers.test.sh
+++ b/.agents/skills/commit-guards/tests/conflict-markers.test.sh
@@ -1,208 +1,160 @@
 #!/usr/bin/env bash
 # Pins for scripts/conflict-markers: each of the open/base/close trio at
-# column 0 fires, indented/quoted/glued occurrences and the seven-equals
-# separator do not, excludes need reasons, and the check's own source never
-# trips it. Every green assertion is paired with a control that proves it can
-# fail. The index readers this family of checks shares are pinned once, in
-# index-reads.test.sh and lane-readers.test.sh.
+# column 0 fires naming file:line and the remedy, indented, quoted, mid-prose
+# and glued occurrences and the seven-equals separator do not, an excludes
+# row with a reason carves a path out and the list resolves through the
+# setting and the flag, the check's own source never trips it, and a
+# carrier the sniff skips is named and qualifies the verdict. Two tables:
+# one file of CONTENT judged, and the runs over a built repository. A row
+# runs the scan once and pins the exit status with every line printed, so
+# the hit, its line, the remedy, the count, the excludes list named and
+# the unmeasured qualifier are one pin. The index readers this family
+# shares are index-reads.test.sh and lane-readers.test.sh.
 #
-# Marker runs are assembled with printf throughout so this test file never
-# contains a marker shape itself — the kendex repo runs conflict-markers
-# over its own tree, tests included.
+# Marker runs are assembled with printf throughout, so this file never
+# contains a marker shape itself: the kendex repository runs the check over
+# its own tree, tests included. A base marker in a row's content is seven
+# octal pipes, which printf %b renders and the row grammar never sees.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 CM="$SKILL_DIR/scripts/conflict-markers"
+# shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
-
-# Hermetic: a leaked setting would mask every case below.
+# Hermetic: a leaked setting would mask every row below.
 unset COMMIT_GUARDS_CONFLICT_EXCLUDES COMMIT_GUARDS_SETTINGS_FILE 2>/dev/null || true
 
 mk7() { printf '%s%s%s%s%s%s%s' "$1" "$1" "$1" "$1" "$1" "$1" "$1"; }
 OPEN="$(mk7 '<')"
 BASE="$(mk7 '|')"
+BASE_OCT="$(mk7 '\174')" # the base marker as a row writes it
 CLOSE="$(mk7 '>')"
 SEP="$(mk7 '=')"
 
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
 
-new_repo() { # NAME — fresh fixture repo in $R
+# One line for a run in the row's repository: the exit status, then every
+# line printed, in order, joined by ';'. ENVS is a comma-separated list of
+# assignments; ARGS are passed through.
+R=""
+run() { # ENVS ARGS
+  local envs=() rc=0 out=""
+  [ -z "$1" ] || IFS=',' read -ra envs <<<"$1"
+  # shellcheck disable=SC2086
+  out="$(cd "$R" && env ${envs[@]+"${envs[@]}"} "$CM" $2 2>&1)" || rc=$?
+  printf 'rc=%s%s' "$rc" "${out:+ $(printf '%s\n' "$out" | LC_ALL=C paste -sd ';' -)}"
+}
+
+# Fixture vocabulary. Every fixture builds its own repository and stages
+# what it wrote; a name used twice is refused.
+repo() { # NAME
   R="$TMP/$1"
+  [ ! -e "$R" ] || { echo "harness: fixture $1 already exists" >&2; exit 2; }
   mkdir -p "$R"
   git -C "$R" -c init.defaultBranch=main init -q
   git -C "$R" config user.email test@example.com
   git -C "$R" config user.name test
 }
+put() { mkdir -p "$R/$(dirname "$1")"; printf '%b' "$2" >"$R/$1"; git -C "$R" add -A; } # PATH CONTENT (printf %b), staged
 
-run_cm() { # [args...] — run in $R; sets OUT and RC
-  OUT=""
-  RC=0
-  OUT="$(cd "$R" && "$CM" "$@" 2>&1)" || RC=$?
+# The lines the scan prints, as functions of what a row put in.
+EXCL='tools/conflict-markers-excludes'
+ERR="::error::conflict-markers: "
+hit() { printf 'conflict-markers FAIL conflict marker: %s:%s:%s;  remedies: finish the merge and delete the marker lines; a file that legitimately carries the trio at column 0 belongs in %s with a reason' "$1" "$2" "$3" "${4:-$EXCL}"; } # PATH LINE TEXT [EXCLUDES]
+skip() { printf 'conflict-markers: not measured: %s — binary content, not text' "$1"; } # PATH
+unmeasured() { printf '; %s matched path(s) not measured' "$1"; } # N
+clean() { printf 'conflict-markers: OK — no conflict markers in tracked files%s' "${1-}"; } # [UNMEASURED]
+failed() { printf 'conflict-markers: %s conflict marker(s) — excludes %s%s' "$1" "${2:-$EXCL}" "${3-}"; } # N [EXCLUDES] [UNMEASURED]
+
+# Table one: a.rs holds CONTENT in a fresh repository.
+ROW=0
+content_rows() { # label | content | expect
+  local row label content expect
+  for row in "$@"; do
+    IFS='|' read -r label content expect <<<"$row"
+    ROW=$((ROW + 1))
+    R=""
+    repo "content-$ROW"
+    put a.rs "$content"
+    assert_eq "$label" "$expect" "$(run '' '')"
+  done
 }
 
-echo "=== control: a clean repo passes ==="
-new_repo clean
-printf 'fn main() {}\n' >"$R/ok.rs"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 0 ] && case "$OUT" in *"conflict-markers: OK"*) true ;; *) false ;; esac \
-  && ok "clean repo passes" || bad "clean repo passes" "rc=$RC out=$OUT"
+echo "=== each marker of the trio at column 0 fails naming file:line; indented, quoted, glued and the separator do not ==="
+content_rows \
+  "control: a clean file passes|fn main() {}\n|rc=0 $(clean)" \
+  "the open marker with its label fails, naming file:line and carrying the remedy|$OPEN HEAD\n|rc=1 $(hit a.rs 1 "$OPEN HEAD");$(failed 1)" \
+  "the bare base marker at the end of its line fails|$BASE_OCT\n|rc=1 $(hit a.rs 1 "$BASE");$(failed 1)" \
+  "the close marker with its label fails|$CLOSE theirs\n|rc=1 $(hit a.rs 1 "$CLOSE theirs");$(failed 1)" \
+  "a marker on the second line is named by its line|fn main() {}\n$OPEN HEAD\n|rc=1 $(hit a.rs 2 "$OPEN HEAD");$(failed 1)" \
+  "the open and close markers of one conflict are two hits and a count of two|$OPEN HEAD\nours\n$SEP\ntheirs\n$CLOSE other\n|rc=1 $(hit a.rs 1 "$OPEN HEAD");$(hit a.rs 5 "$CLOSE other");$(failed 2)" \
+  "a space-indented open marker does not fire| $OPEN HEAD\n|rc=0 $(clean)" \
+  "a tab-indented close marker does not fire|\t$CLOSE theirs\n|rc=0 $(clean)" \
+  "a base marker mid-prose does not fire|the $BASE_OCT run mid-prose\n|rc=0 $(clean)" \
+  "a quoted open marker does not fire|quoted: \"$OPEN ours\"\n|rc=0 $(clean)" \
+  "an open marker glued to text does not fire|${OPEN}x glued to text\n|rc=0 $(clean)" \
+  "an eight-character run is not the seven-character marker|$OPEN< eight then a space\n|rc=0 $(clean)" \
+  "the seven-equals separator alone never fires: a setext underline is valid markdown|Title\n$SEP\n|rc=0 $(clean)"
 
-echo "=== each marker of the trio at column 0 fails, naming the file ==="
-new_repo trio
-printf '%s HEAD\n' "$OPEN" >"$R/a.rs"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 1 ] && case "$OUT" in *"conflict marker: a.rs:1:"*) true ;; *) false ;; esac \
-  && ok "the open marker with its label fails, naming file:line" \
-  || bad "open marker fails" "rc=$RC out=$OUT"
-case "$OUT" in *"finish the merge and delete the marker lines"*) ok "diagnostic carries the remediation" ;; *) bad "diagnostic carries the remediation" "$OUT" ;; esac
+# Table two: FIXTURE (a function and its words) builds the repository; the
+# scan runs with ARGS under ENVS.
+run_rows() { # label | fixture | envs | args | expect
+  local row label fx envs args expect words
+  for row in "$@"; do
+    IFS='|' read -r label fx envs args expect <<<"$row"
+    R=""
+    read -ra words <<<"$fx"
+    "${words[@]}"
+    assert_eq "$label" "$expect" "$(run "$envs" "$args")"
+  done
+}
 
-printf '%s\n' "$BASE" >"$R/a.rs"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 1 ] && case "$OUT" in *"conflict marker: a.rs:1:"*) true ;; *) false ;; esac \
-  && ok "the bare base marker (end of line, no label) fails" \
-  || bad "base marker fails" "rc=$RC out=$OUT"
+echo "=== excludes: a declared path is exempt with a reason; the list resolves through the setting and the flag ==="
+MERGE="$OPEN HEAD\nours\n$CLOSE theirs\n"
+fixture() { repo "$1"; put fixtures/merge.txt "$MERGE"; } # NAME — a conflict under fixtures/
+fx_excluded() { fixture excluded; put "$EXCL" 'fixtures/*\tmerge-conflict fixture data\n'; }
+fx_no_reason() { fixture no-reason; put "$EXCL" 'fixtures/*\n'; }
+alt() { fixture "$1"; put alt-excludes 'fixtures/*\tmerge-conflict fixture data\n'; } # NAME — the list at a non-default path
+HITS="$(hit fixtures/merge.txt 1 "$OPEN HEAD");$(hit fixtures/merge.txt 3 "$CLOSE theirs");$(failed 2)"
+run_rows \
+  "control: the fixture conflict fails without an excludes row, naming both markers|fixture bare|||rc=1 $HITS" \
+  "the excludes row silences the declared path|fx_excluded|||rc=0 $(clean)" \
+  "a pattern without a tab-separated reason is exit 2 naming the line|fx_no_reason|||rc=2 ${ERR}$EXCL:1: expected 'pattern<TAB>reason' (every exclusion carries its justification)" \
+  "the excludes path resolves through COMMIT_GUARDS_CONFLICT_EXCLUDES|alt alt-env|COMMIT_GUARDS_CONFLICT_EXCLUDES=alt-excludes||rc=0 $(clean)" \
+  "--excludes FILE points at the same list|alt alt-flag||--excludes alt-excludes|rc=0 $(clean)" \
+  "the equals form of --excludes resolves the same list|alt alt-eq||--excludes=alt-excludes|rc=0 $(clean)" \
+  "control: without either the default path has no list and the conflict fails, the remedy naming the default list|alt alt-none|||rc=1 $HITS" \
+  "--excludes without a path is exit 2|alt alt-bare||--excludes|rc=2 ${ERR}--excludes requires a path" \
+  "an unknown flag is exit 2, quoting it|alt alt-unknown||--no-such-flag|rc=2 ${ERR}unknown argument '--no-such-flag' (see --help)"
+assert_eq "--help prints usage at exit 0" "rc=0 usage: conflict-markers [--excludes FILE]" "$(run '' --help | LC_ALL=C cut -d';' -f1)"
+assert_eq "-h is --help" "$(run '' --help)" "$(run '' -h)"
 
-printf '%s theirs\n' "$CLOSE" >"$R/a.rs"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 1 ] && case "$OUT" in *"conflict marker: a.rs:1:"*) true ;; *) false ;; esac \
-  && ok "the close marker with its label fails, naming file:line" \
-  || bad "close marker fails" "rc=$RC out=$OUT"
-
-echo "=== indented, quoted, and glued occurrences never fire ==="
-{
-  printf ' %s HEAD\n' "$OPEN"
-  printf '\t%s theirs\n' "$CLOSE"
-  printf 'the %s run mid-prose\n' "$BASE"
-  printf 'quoted: "%s ours"\n' "$OPEN"
-  printf '%sx glued to text\n' "$OPEN"
-} >"$R/a.rs"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 0 ] && ok "space/tab-indented, quoted, mid-prose and glued runs all pass" \
-  || bad "non-column-0 and glued runs pass" "rc=$RC out=$OUT"
-
-printf '%s%s eight then a space\n' "$OPEN" '<' >"$R/a.rs"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 0 ] && ok "an eight-character run is not the seven-character marker" \
-  || bad "eight-character run passes" "rc=$RC out=$OUT"
-
-echo "=== the seven-equals separator alone never fires ==="
-printf 'Title\n%s\n' "$SEP" >"$R/a.md"
-printf 'fn main() {}\n' >"$R/a.rs"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 0 ] && ok "a setext H2 underline at column 0 passes (separator is deliberately unmatched)" \
-  || bad "seven-equals separator passes" "rc=$RC out=$OUT"
-
-echo "=== excludes: a declared path is exempt WITH a reason ==="
-new_repo exc
-mkdir -p "$R/fixtures" "$R/tools"
-printf '%s HEAD\nours\n%s theirs\n' "$OPEN" "$CLOSE" >"$R/fixtures/merge.txt"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 1 ] && ok "control: the fixture marker fails without an excludes row" \
-  || bad "control: fixture marker fails without excludes" "rc=$RC out=$OUT"
-
-printf 'fixtures/*\tmerge-conflict fixture data\n' >"$R/tools/conflict-markers-excludes"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 0 ] && ok "the excludes row silences exactly the declared path" \
-  || bad "excludes row silences the declared path" "rc=$RC out=$OUT"
-
-printf 'fixtures/*\n' >"$R/tools/conflict-markers-excludes"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 2 ] && case "$OUT" in *"pattern<TAB>reason"*) true ;; *) false ;; esac \
-  && ok "a pattern without a tab-separated reason is exit 2" \
-  || bad "a pattern without a reason is exit 2" "rc=$RC out=$OUT"
-
-echo "=== configuration: COMMIT_GUARDS_CONFLICT_EXCLUDES and --excludes ==="
-printf 'fixtures/*\tmerge-conflict fixture data\n' >"$R/alt-excludes"
-rm "$R/tools/conflict-markers-excludes"
-git -C "$R" add -A
-OUT="$(cd "$R" && COMMIT_GUARDS_CONFLICT_EXCLUDES=alt-excludes "$CM" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && ok "excludes path resolves through the environment key" \
-  || bad "excludes path resolves through the environment key" "rc=$RC out=$OUT"
-run_cm --excludes alt-excludes
-[ "$RC" -eq 0 ] && ok "--excludes flag points at the same list" || bad "--excludes flag" "rc=$RC out=$OUT"
-run_cm --excludes=alt-excludes
-[ "$RC" -eq 0 ] && ok "the equals form of --excludes resolves the same list" || bad "--excludes= equals form" "rc=$RC out=$OUT"
-run_cm
-[ "$RC" -eq 1 ] && ok "control: without either, the fixture marker still fails" \
-  || bad "control: default excludes path has no file, marker fails" "rc=$RC out=$OUT"
-
-run_cm --no-such-flag
-[ "$RC" -eq 2 ] && ok "unknown flag is exit 2" || bad "unknown flag is exit 2" "rc=$RC out=$OUT"
-
-echo "=== the check's own source does not trip it ==="
-new_repo self
-mkdir -p "$R/scripts"
-cp "$CM" "$R/scripts/conflict-markers"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 0 ] && ok "the shipped script, tracked, scans clean (interval-built patterns)" \
-  || bad "the shipped script scans clean" "rc=$RC out=$OUT"
-# Control: the scan still fires in this repo when a real marker appears.
-printf '%s HEAD\n' "$OPEN" >"$R/planted.txt"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 1 ] && case "$OUT" in *"planted.txt:1:"*"scripts/conflict-markers"*) false ;; *"planted.txt:1:"*) true ;; *) false ;; esac \
-  && ok "control: a planted marker fails while the script stays unnamed" \
-  || bad "control: planted marker fails, script unnamed" "rc=$RC out=$OUT"
-
-echo "=== a carrier the sniff skips is named, and qualifies the verdict ==="
-new_repo unmeasured
-printf 'fn main() {}\n' >"$R/ok.rs"
-# An asset whose bytes happen to spell the open marker at column 0. The
-# listing forces text, so this path IS matched and reaches the content
-# sniff; a NUL in git's leading window is what keeps it out of the count.
-# Unread is not clean: the path is named and the verdict carries the count.
-printf '\211PNG\r\n\032\n\000\000\n%s HEAD\n' "$OPEN" >"$R/asset.png"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 0 ] && case "$OUT" in
-  *"not measured: asset.png — binary content, not text"*"conflict-markers: OK"*"1 matched path(s) not measured"*) true ;;
-  *) false ;;
-esac \
-  && ok "a clean verdict names the skipped carrier and says how many went unmeasured" \
-  || bad "clean verdict carries the unmeasured qualifier" "rc=$RC out=$OUT"
-
-# The same qualifier on a FAILING verdict: a real marker elsewhere decides
-# the exit code, and the unread carrier still has to be declared.
-printf '%s theirs\n' "$CLOSE" >"$R/planted.txt"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 1 ] && case "$OUT" in
-  *"not measured: asset.png — binary content, not text"*"conflict-markers: 1 conflict marker(s)"*"1 matched path(s) not measured"*) true ;;
-  *) false ;;
-esac \
-  && ok "a violation verdict carries the same qualifier" \
-  || bad "violation verdict carries the unmeasured qualifier" "rc=$RC out=$OUT"
-
-# The must-fail control: the same bytes with the NULs taken out are text, so
-# the carrier is measured, fires, and nothing is declared unmeasured.
-printf '\211PNG\r\n\032\n\n%s HEAD\n' "$OPEN" >"$R/asset.png"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 1 ] && case "$OUT" in
-  *"conflict marker: asset.png:"*) true ;;
-  *) false ;;
-esac \
-  && ok "control: the same bytes without a NUL are read, and fire" \
-  || bad "control: the NUL-free carrier fires" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"not measured"*) bad "nothing goes unmeasured once the carrier is text" "$OUT" ;;
-  *) ok "and no unmeasured qualifier accompanies a fully read scan" ;;
-esac
+echo "=== the check's own source does not trip it; a carrier the sniff skips is named and qualifies the verdict ==="
+fx_self() { repo "$1"; mkdir -p "$R/scripts"; cp "$CM" "$R/scripts/conflict-markers"; git -C "$R" add -A; } # NAME — the shipped script, tracked
+fx_self_planted() { fx_self self-planted; put planted.txt "$OPEN HEAD\n"; }
+# An asset whose bytes spell the open marker at column 0 behind a NUL in
+# git's leading window: matched by the text-forced listing, refused by the
+# content sniff. The same bytes without the NUL are text, and fire.
+asset() { repo "$1"; put ok.rs 'fn main() {}\n'; put asset.png "\0211PNG\r\n\0032\n\0000\0000\n$OPEN HEAD\n"; } # NAME
+fx_asset_planted() { asset asset-planted; put planted.txt "$CLOSE theirs\n"; }
+fx_asset_text() { repo asset-text; put ok.rs 'fn main() {}\n'; put asset.png "\0211PNG\r\n\0032\n\n$OPEN HEAD\n"; }
+run_rows \
+  "the shipped script, tracked, scans clean: its patterns are interval-built|fx_self self|||rc=0 $(clean)" \
+  "control: a planted marker fails while the script stays unnamed|fx_self_planted|||rc=1 $(hit planted.txt 1 "$OPEN HEAD");$(failed 1)" \
+  "a clean verdict names the skipped carrier and says how many went unmeasured|asset asset|||rc=0 $(skip asset.png);$(clean "$(unmeasured 1)")" \
+  "a violation verdict carries the same qualifier, the marker elsewhere deciding the exit|fx_asset_planted|||rc=1 $(skip asset.png);$(hit planted.txt 1 "$CLOSE theirs");$(failed 1 "$EXCL" "$(unmeasured 1)")" \
+  "control: the same bytes without a NUL are read, fire on their line, and nothing goes unmeasured|fx_asset_text|||rc=1 $(hit asset.png 4 "$OPEN HEAD");$(failed 1)"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.agents/skills/commit-guards/tests/conflict-markers.test.sh
+++ b/.agents/skills/commit-guards/tests/conflict-markers.test.sh
@@ -149,6 +149,10 @@ fx_self_planted() { fx_self self-planted; put planted.txt "$OPEN HEAD\n"; }
 asset() { repo "$1"; put ok.rs 'fn main() {}\n'; put asset.png "\0211PNG\r\n\0032\n\0000\0000\n$OPEN HEAD\n"; } # NAME
 fx_asset_planted() { asset asset-planted; put planted.txt "$CLOSE theirs\n"; }
 fx_asset_text() { repo asset-text; put ok.rs 'fn main() {}\n'; put asset.png "\0211PNG\r\n\0032\n\n$OPEN HEAD\n"; }
+# Premise: the self rows read a clean verdict, which an empty repository
+# also gives, so the fixture must be shown to track the script.
+fx_self self-premise
+assert_eq "premise: the self fixture tracks the shipped script" "scripts/conflict-markers" "$(git -C "$R" ls-files scripts)"
 run_rows \
   "the shipped script, tracked, scans clean: its patterns are interval-built|fx_self self|||rc=0 $(clean)" \
   "control: a planted marker fails while the script stays unnamed|fx_self_planted|||rc=1 $(hit planted.txt 1 "$OPEN HEAD");$(failed 1)" \

--- a/skills/commit-guards/tests/conflict-markers.test.sh
+++ b/skills/commit-guards/tests/conflict-markers.test.sh
@@ -1,208 +1,160 @@
 #!/usr/bin/env bash
 # Pins for scripts/conflict-markers: each of the open/base/close trio at
-# column 0 fires, indented/quoted/glued occurrences and the seven-equals
-# separator do not, excludes need reasons, and the check's own source never
-# trips it. Every green assertion is paired with a control that proves it can
-# fail. The index readers this family of checks shares are pinned once, in
-# index-reads.test.sh and lane-readers.test.sh.
+# column 0 fires naming file:line and the remedy, indented, quoted, mid-prose
+# and glued occurrences and the seven-equals separator do not, an excludes
+# row with a reason carves a path out and the list resolves through the
+# setting and the flag, the check's own source never trips it, and a
+# carrier the sniff skips is named and qualifies the verdict. Two tables:
+# one file of CONTENT judged, and the runs over a built repository. A row
+# runs the scan once and pins the exit status with every line printed, so
+# the hit, its line, the remedy, the count, the excludes list named and
+# the unmeasured qualifier are one pin. The index readers this family
+# shares are index-reads.test.sh and lane-readers.test.sh.
 #
-# Marker runs are assembled with printf throughout so this test file never
-# contains a marker shape itself — the kendex repo runs conflict-markers
-# over its own tree, tests included.
+# Marker runs are assembled with printf throughout, so this file never
+# contains a marker shape itself: the kendex repository runs the check over
+# its own tree, tests included. A base marker in a row's content is seven
+# octal pipes, which printf %b renders and the row grammar never sees.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 CM="$SKILL_DIR/scripts/conflict-markers"
+# shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
-
-# Hermetic: a leaked setting would mask every case below.
+# Hermetic: a leaked setting would mask every row below.
 unset COMMIT_GUARDS_CONFLICT_EXCLUDES COMMIT_GUARDS_SETTINGS_FILE 2>/dev/null || true
 
 mk7() { printf '%s%s%s%s%s%s%s' "$1" "$1" "$1" "$1" "$1" "$1" "$1"; }
 OPEN="$(mk7 '<')"
 BASE="$(mk7 '|')"
+BASE_OCT="$(mk7 '\174')" # the base marker as a row writes it
 CLOSE="$(mk7 '>')"
 SEP="$(mk7 '=')"
 
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
 
-new_repo() { # NAME — fresh fixture repo in $R
+# One line for a run in the row's repository: the exit status, then every
+# line printed, in order, joined by ';'. ENVS is a comma-separated list of
+# assignments; ARGS are passed through.
+R=""
+run() { # ENVS ARGS
+  local envs=() rc=0 out=""
+  [ -z "$1" ] || IFS=',' read -ra envs <<<"$1"
+  # shellcheck disable=SC2086
+  out="$(cd "$R" && env ${envs[@]+"${envs[@]}"} "$CM" $2 2>&1)" || rc=$?
+  printf 'rc=%s%s' "$rc" "${out:+ $(printf '%s\n' "$out" | LC_ALL=C paste -sd ';' -)}"
+}
+
+# Fixture vocabulary. Every fixture builds its own repository and stages
+# what it wrote; a name used twice is refused.
+repo() { # NAME
   R="$TMP/$1"
+  [ ! -e "$R" ] || { echo "harness: fixture $1 already exists" >&2; exit 2; }
   mkdir -p "$R"
   git -C "$R" -c init.defaultBranch=main init -q
   git -C "$R" config user.email test@example.com
   git -C "$R" config user.name test
 }
+put() { mkdir -p "$R/$(dirname "$1")"; printf '%b' "$2" >"$R/$1"; git -C "$R" add -A; } # PATH CONTENT (printf %b), staged
 
-run_cm() { # [args...] — run in $R; sets OUT and RC
-  OUT=""
-  RC=0
-  OUT="$(cd "$R" && "$CM" "$@" 2>&1)" || RC=$?
+# The lines the scan prints, as functions of what a row put in.
+EXCL='tools/conflict-markers-excludes'
+ERR="::error::conflict-markers: "
+hit() { printf 'conflict-markers FAIL conflict marker: %s:%s:%s;  remedies: finish the merge and delete the marker lines; a file that legitimately carries the trio at column 0 belongs in %s with a reason' "$1" "$2" "$3" "${4:-$EXCL}"; } # PATH LINE TEXT [EXCLUDES]
+skip() { printf 'conflict-markers: not measured: %s — binary content, not text' "$1"; } # PATH
+unmeasured() { printf '; %s matched path(s) not measured' "$1"; } # N
+clean() { printf 'conflict-markers: OK — no conflict markers in tracked files%s' "${1-}"; } # [UNMEASURED]
+failed() { printf 'conflict-markers: %s conflict marker(s) — excludes %s%s' "$1" "${2:-$EXCL}" "${3-}"; } # N [EXCLUDES] [UNMEASURED]
+
+# Table one: a.rs holds CONTENT in a fresh repository.
+ROW=0
+content_rows() { # label | content | expect
+  local row label content expect
+  for row in "$@"; do
+    IFS='|' read -r label content expect <<<"$row"
+    ROW=$((ROW + 1))
+    R=""
+    repo "content-$ROW"
+    put a.rs "$content"
+    assert_eq "$label" "$expect" "$(run '' '')"
+  done
 }
 
-echo "=== control: a clean repo passes ==="
-new_repo clean
-printf 'fn main() {}\n' >"$R/ok.rs"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 0 ] && case "$OUT" in *"conflict-markers: OK"*) true ;; *) false ;; esac \
-  && ok "clean repo passes" || bad "clean repo passes" "rc=$RC out=$OUT"
+echo "=== each marker of the trio at column 0 fails naming file:line; indented, quoted, glued and the separator do not ==="
+content_rows \
+  "control: a clean file passes|fn main() {}\n|rc=0 $(clean)" \
+  "the open marker with its label fails, naming file:line and carrying the remedy|$OPEN HEAD\n|rc=1 $(hit a.rs 1 "$OPEN HEAD");$(failed 1)" \
+  "the bare base marker at the end of its line fails|$BASE_OCT\n|rc=1 $(hit a.rs 1 "$BASE");$(failed 1)" \
+  "the close marker with its label fails|$CLOSE theirs\n|rc=1 $(hit a.rs 1 "$CLOSE theirs");$(failed 1)" \
+  "a marker on the second line is named by its line|fn main() {}\n$OPEN HEAD\n|rc=1 $(hit a.rs 2 "$OPEN HEAD");$(failed 1)" \
+  "the open and close markers of one conflict are two hits and a count of two|$OPEN HEAD\nours\n$SEP\ntheirs\n$CLOSE other\n|rc=1 $(hit a.rs 1 "$OPEN HEAD");$(hit a.rs 5 "$CLOSE other");$(failed 2)" \
+  "a space-indented open marker does not fire| $OPEN HEAD\n|rc=0 $(clean)" \
+  "a tab-indented close marker does not fire|\t$CLOSE theirs\n|rc=0 $(clean)" \
+  "a base marker mid-prose does not fire|the $BASE_OCT run mid-prose\n|rc=0 $(clean)" \
+  "a quoted open marker does not fire|quoted: \"$OPEN ours\"\n|rc=0 $(clean)" \
+  "an open marker glued to text does not fire|${OPEN}x glued to text\n|rc=0 $(clean)" \
+  "an eight-character run is not the seven-character marker|$OPEN< eight then a space\n|rc=0 $(clean)" \
+  "the seven-equals separator alone never fires: a setext underline is valid markdown|Title\n$SEP\n|rc=0 $(clean)"
 
-echo "=== each marker of the trio at column 0 fails, naming the file ==="
-new_repo trio
-printf '%s HEAD\n' "$OPEN" >"$R/a.rs"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 1 ] && case "$OUT" in *"conflict marker: a.rs:1:"*) true ;; *) false ;; esac \
-  && ok "the open marker with its label fails, naming file:line" \
-  || bad "open marker fails" "rc=$RC out=$OUT"
-case "$OUT" in *"finish the merge and delete the marker lines"*) ok "diagnostic carries the remediation" ;; *) bad "diagnostic carries the remediation" "$OUT" ;; esac
+# Table two: FIXTURE (a function and its words) builds the repository; the
+# scan runs with ARGS under ENVS.
+run_rows() { # label | fixture | envs | args | expect
+  local row label fx envs args expect words
+  for row in "$@"; do
+    IFS='|' read -r label fx envs args expect <<<"$row"
+    R=""
+    read -ra words <<<"$fx"
+    "${words[@]}"
+    assert_eq "$label" "$expect" "$(run "$envs" "$args")"
+  done
+}
 
-printf '%s\n' "$BASE" >"$R/a.rs"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 1 ] && case "$OUT" in *"conflict marker: a.rs:1:"*) true ;; *) false ;; esac \
-  && ok "the bare base marker (end of line, no label) fails" \
-  || bad "base marker fails" "rc=$RC out=$OUT"
+echo "=== excludes: a declared path is exempt with a reason; the list resolves through the setting and the flag ==="
+MERGE="$OPEN HEAD\nours\n$CLOSE theirs\n"
+fixture() { repo "$1"; put fixtures/merge.txt "$MERGE"; } # NAME — a conflict under fixtures/
+fx_excluded() { fixture excluded; put "$EXCL" 'fixtures/*\tmerge-conflict fixture data\n'; }
+fx_no_reason() { fixture no-reason; put "$EXCL" 'fixtures/*\n'; }
+alt() { fixture "$1"; put alt-excludes 'fixtures/*\tmerge-conflict fixture data\n'; } # NAME — the list at a non-default path
+HITS="$(hit fixtures/merge.txt 1 "$OPEN HEAD");$(hit fixtures/merge.txt 3 "$CLOSE theirs");$(failed 2)"
+run_rows \
+  "control: the fixture conflict fails without an excludes row, naming both markers|fixture bare|||rc=1 $HITS" \
+  "the excludes row silences the declared path|fx_excluded|||rc=0 $(clean)" \
+  "a pattern without a tab-separated reason is exit 2 naming the line|fx_no_reason|||rc=2 ${ERR}$EXCL:1: expected 'pattern<TAB>reason' (every exclusion carries its justification)" \
+  "the excludes path resolves through COMMIT_GUARDS_CONFLICT_EXCLUDES|alt alt-env|COMMIT_GUARDS_CONFLICT_EXCLUDES=alt-excludes||rc=0 $(clean)" \
+  "--excludes FILE points at the same list|alt alt-flag||--excludes alt-excludes|rc=0 $(clean)" \
+  "the equals form of --excludes resolves the same list|alt alt-eq||--excludes=alt-excludes|rc=0 $(clean)" \
+  "control: without either the default path has no list and the conflict fails, the remedy naming the default list|alt alt-none|||rc=1 $HITS" \
+  "--excludes without a path is exit 2|alt alt-bare||--excludes|rc=2 ${ERR}--excludes requires a path" \
+  "an unknown flag is exit 2, quoting it|alt alt-unknown||--no-such-flag|rc=2 ${ERR}unknown argument '--no-such-flag' (see --help)"
+assert_eq "--help prints usage at exit 0" "rc=0 usage: conflict-markers [--excludes FILE]" "$(run '' --help | LC_ALL=C cut -d';' -f1)"
+assert_eq "-h is --help" "$(run '' --help)" "$(run '' -h)"
 
-printf '%s theirs\n' "$CLOSE" >"$R/a.rs"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 1 ] && case "$OUT" in *"conflict marker: a.rs:1:"*) true ;; *) false ;; esac \
-  && ok "the close marker with its label fails, naming file:line" \
-  || bad "close marker fails" "rc=$RC out=$OUT"
-
-echo "=== indented, quoted, and glued occurrences never fire ==="
-{
-  printf ' %s HEAD\n' "$OPEN"
-  printf '\t%s theirs\n' "$CLOSE"
-  printf 'the %s run mid-prose\n' "$BASE"
-  printf 'quoted: "%s ours"\n' "$OPEN"
-  printf '%sx glued to text\n' "$OPEN"
-} >"$R/a.rs"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 0 ] && ok "space/tab-indented, quoted, mid-prose and glued runs all pass" \
-  || bad "non-column-0 and glued runs pass" "rc=$RC out=$OUT"
-
-printf '%s%s eight then a space\n' "$OPEN" '<' >"$R/a.rs"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 0 ] && ok "an eight-character run is not the seven-character marker" \
-  || bad "eight-character run passes" "rc=$RC out=$OUT"
-
-echo "=== the seven-equals separator alone never fires ==="
-printf 'Title\n%s\n' "$SEP" >"$R/a.md"
-printf 'fn main() {}\n' >"$R/a.rs"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 0 ] && ok "a setext H2 underline at column 0 passes (separator is deliberately unmatched)" \
-  || bad "seven-equals separator passes" "rc=$RC out=$OUT"
-
-echo "=== excludes: a declared path is exempt WITH a reason ==="
-new_repo exc
-mkdir -p "$R/fixtures" "$R/tools"
-printf '%s HEAD\nours\n%s theirs\n' "$OPEN" "$CLOSE" >"$R/fixtures/merge.txt"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 1 ] && ok "control: the fixture marker fails without an excludes row" \
-  || bad "control: fixture marker fails without excludes" "rc=$RC out=$OUT"
-
-printf 'fixtures/*\tmerge-conflict fixture data\n' >"$R/tools/conflict-markers-excludes"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 0 ] && ok "the excludes row silences exactly the declared path" \
-  || bad "excludes row silences the declared path" "rc=$RC out=$OUT"
-
-printf 'fixtures/*\n' >"$R/tools/conflict-markers-excludes"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 2 ] && case "$OUT" in *"pattern<TAB>reason"*) true ;; *) false ;; esac \
-  && ok "a pattern without a tab-separated reason is exit 2" \
-  || bad "a pattern without a reason is exit 2" "rc=$RC out=$OUT"
-
-echo "=== configuration: COMMIT_GUARDS_CONFLICT_EXCLUDES and --excludes ==="
-printf 'fixtures/*\tmerge-conflict fixture data\n' >"$R/alt-excludes"
-rm "$R/tools/conflict-markers-excludes"
-git -C "$R" add -A
-OUT="$(cd "$R" && COMMIT_GUARDS_CONFLICT_EXCLUDES=alt-excludes "$CM" 2>&1)" && RC=0 || RC=$?
-[ "$RC" -eq 0 ] && ok "excludes path resolves through the environment key" \
-  || bad "excludes path resolves through the environment key" "rc=$RC out=$OUT"
-run_cm --excludes alt-excludes
-[ "$RC" -eq 0 ] && ok "--excludes flag points at the same list" || bad "--excludes flag" "rc=$RC out=$OUT"
-run_cm --excludes=alt-excludes
-[ "$RC" -eq 0 ] && ok "the equals form of --excludes resolves the same list" || bad "--excludes= equals form" "rc=$RC out=$OUT"
-run_cm
-[ "$RC" -eq 1 ] && ok "control: without either, the fixture marker still fails" \
-  || bad "control: default excludes path has no file, marker fails" "rc=$RC out=$OUT"
-
-run_cm --no-such-flag
-[ "$RC" -eq 2 ] && ok "unknown flag is exit 2" || bad "unknown flag is exit 2" "rc=$RC out=$OUT"
-
-echo "=== the check's own source does not trip it ==="
-new_repo self
-mkdir -p "$R/scripts"
-cp "$CM" "$R/scripts/conflict-markers"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 0 ] && ok "the shipped script, tracked, scans clean (interval-built patterns)" \
-  || bad "the shipped script scans clean" "rc=$RC out=$OUT"
-# Control: the scan still fires in this repo when a real marker appears.
-printf '%s HEAD\n' "$OPEN" >"$R/planted.txt"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 1 ] && case "$OUT" in *"planted.txt:1:"*"scripts/conflict-markers"*) false ;; *"planted.txt:1:"*) true ;; *) false ;; esac \
-  && ok "control: a planted marker fails while the script stays unnamed" \
-  || bad "control: planted marker fails, script unnamed" "rc=$RC out=$OUT"
-
-echo "=== a carrier the sniff skips is named, and qualifies the verdict ==="
-new_repo unmeasured
-printf 'fn main() {}\n' >"$R/ok.rs"
-# An asset whose bytes happen to spell the open marker at column 0. The
-# listing forces text, so this path IS matched and reaches the content
-# sniff; a NUL in git's leading window is what keeps it out of the count.
-# Unread is not clean: the path is named and the verdict carries the count.
-printf '\211PNG\r\n\032\n\000\000\n%s HEAD\n' "$OPEN" >"$R/asset.png"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 0 ] && case "$OUT" in
-  *"not measured: asset.png — binary content, not text"*"conflict-markers: OK"*"1 matched path(s) not measured"*) true ;;
-  *) false ;;
-esac \
-  && ok "a clean verdict names the skipped carrier and says how many went unmeasured" \
-  || bad "clean verdict carries the unmeasured qualifier" "rc=$RC out=$OUT"
-
-# The same qualifier on a FAILING verdict: a real marker elsewhere decides
-# the exit code, and the unread carrier still has to be declared.
-printf '%s theirs\n' "$CLOSE" >"$R/planted.txt"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 1 ] && case "$OUT" in
-  *"not measured: asset.png — binary content, not text"*"conflict-markers: 1 conflict marker(s)"*"1 matched path(s) not measured"*) true ;;
-  *) false ;;
-esac \
-  && ok "a violation verdict carries the same qualifier" \
-  || bad "violation verdict carries the unmeasured qualifier" "rc=$RC out=$OUT"
-
-# The must-fail control: the same bytes with the NULs taken out are text, so
-# the carrier is measured, fires, and nothing is declared unmeasured.
-printf '\211PNG\r\n\032\n\n%s HEAD\n' "$OPEN" >"$R/asset.png"
-git -C "$R" add -A
-run_cm
-[ "$RC" -eq 1 ] && case "$OUT" in
-  *"conflict marker: asset.png:"*) true ;;
-  *) false ;;
-esac \
-  && ok "control: the same bytes without a NUL are read, and fire" \
-  || bad "control: the NUL-free carrier fires" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"not measured"*) bad "nothing goes unmeasured once the carrier is text" "$OUT" ;;
-  *) ok "and no unmeasured qualifier accompanies a fully read scan" ;;
-esac
+echo "=== the check's own source does not trip it; a carrier the sniff skips is named and qualifies the verdict ==="
+fx_self() { repo "$1"; mkdir -p "$R/scripts"; cp "$CM" "$R/scripts/conflict-markers"; git -C "$R" add -A; } # NAME — the shipped script, tracked
+fx_self_planted() { fx_self self-planted; put planted.txt "$OPEN HEAD\n"; }
+# An asset whose bytes spell the open marker at column 0 behind a NUL in
+# git's leading window: matched by the text-forced listing, refused by the
+# content sniff. The same bytes without the NUL are text, and fire.
+asset() { repo "$1"; put ok.rs 'fn main() {}\n'; put asset.png "\0211PNG\r\n\0032\n\0000\0000\n$OPEN HEAD\n"; } # NAME
+fx_asset_planted() { asset asset-planted; put planted.txt "$CLOSE theirs\n"; }
+fx_asset_text() { repo asset-text; put ok.rs 'fn main() {}\n'; put asset.png "\0211PNG\r\n\0032\n\n$OPEN HEAD\n"; }
+run_rows \
+  "the shipped script, tracked, scans clean: its patterns are interval-built|fx_self self|||rc=0 $(clean)" \
+  "control: a planted marker fails while the script stays unnamed|fx_self_planted|||rc=1 $(hit planted.txt 1 "$OPEN HEAD");$(failed 1)" \
+  "a clean verdict names the skipped carrier and says how many went unmeasured|asset asset|||rc=0 $(skip asset.png);$(clean "$(unmeasured 1)")" \
+  "a violation verdict carries the same qualifier, the marker elsewhere deciding the exit|fx_asset_planted|||rc=1 $(skip asset.png);$(hit planted.txt 1 "$CLOSE theirs");$(failed 1 "$EXCL" "$(unmeasured 1)")" \
+  "control: the same bytes without a NUL are read, fire on their line, and nothing goes unmeasured|fx_asset_text|||rc=1 $(hit asset.png 4 "$OPEN HEAD");$(failed 1)"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/commit-guards/tests/conflict-markers.test.sh
+++ b/skills/commit-guards/tests/conflict-markers.test.sh
@@ -149,6 +149,10 @@ fx_self_planted() { fx_self self-planted; put planted.txt "$OPEN HEAD\n"; }
 asset() { repo "$1"; put ok.rs 'fn main() {}\n'; put asset.png "\0211PNG\r\n\0032\n\0000\0000\n$OPEN HEAD\n"; } # NAME
 fx_asset_planted() { asset asset-planted; put planted.txt "$CLOSE theirs\n"; }
 fx_asset_text() { repo asset-text; put ok.rs 'fn main() {}\n'; put asset.png "\0211PNG\r\n\0032\n\n$OPEN HEAD\n"; }
+# Premise: the self rows read a clean verdict, which an empty repository
+# also gives, so the fixture must be shown to track the script.
+fx_self self-premise
+assert_eq "premise: the self fixture tracks the shipped script" "scripts/conflict-markers" "$(git -C "$R" ls-files scripts)"
 run_rows \
   "the shipped script, tracked, scans clean: its patterns are interval-built|fx_self self|||rc=0 $(clean)" \
   "control: a planted marker fails while the script stays unnamed|fx_self_planted|||rc=1 $(hit planted.txt 1 "$OPEN HEAD");$(failed 1)" \


### PR DESCRIPTION
Reshapes `skills/commit-guards/tests/conflict-markers.test.sh` to code-quality § Tests.

The suite pinned `scripts/conflict-markers` in a 208-line script of 22 assertions (the commit message says 27; the old suite prints 22 when run), each an exit status read as a bit beside a substring, over long-lived fixtures each case rewrote. It is two tables now. Table one (`content_rows`, `label|content|expect`): a.rs holds CONTENT through `printf %b` in a fresh repository; a base marker in content is seven octal `\174`, since a literal pipe would split the row. Table two (`run_rows`, `label|fixture|envs|args|expect`): a fixture function with its words builds the repository, the scan runs with ARGS under ENVS. A row runs the scan once and pins the exit status with every line printed, so the hit, its line, the remedy, the count, the excludes list named and the unmeasured qualifier are one pin. Expected lines are built by `hit`, `skip`, `unmeasured`, `clean`, `failed` from what the row put in. Marker runs come from `mk7`; the file spells no marker shape (the repository scans its own tests).

Every old assertion has a row: the clean control, the open, base and close markers, the eight-character run, the separator, the excludes control and the silencing row, the reasonless row, the setting, `--excludes FILE`, `--excludes=FILE`, the no-list control, the unknown flag, the shipped script clean and its planted control, the skipped carrier on a clean and on a violation verdict, the NUL-free control. Folded into whole-output pins: "diagnostic carries the remediation" (every hit row pins the remedy line) and "no unmeasured qualifier accompanies a fully read scan" (the NUL-free control pins its whole output). The old five-in-one negative ("space/tab-indented, quoted, mid-prose and glued runs all pass") is five rows. Rows added: a marker on the second line named by its line, a conflict's two markers counted as two, `--excludes` without a path, `--help` first line, `-h` equal to `--help`. The reviewer round added a premise assertion beside the self rows: the fixture's index holds `scripts/conflict-markers`, since an empty repository also reads clean. 22 - 2 folded + 4 (the five-in-one) + 5 added + 1 premise = 30.

The index readers this family shares (the unmerged index, attributes, the sniff's mechanics, reader failures) are `index-reads.test.sh`'s and `lane-readers.test.sh`'s; this suite pins only that conflict-markers names the skipped carrier and qualifies both verdicts. Two mutants dropping `-a` from the carrier listing and the detail scan survive this suite and are killed by lane-readers (the reviewer measured it).

The tracked render is replayed with `patch`. Nothing about `.kendex-generated.json` changed.

## Mutation

24 exact-substring mutants over `scripts/conflict-markers`, the lane in `scripts/lib/common.sh` and the excludes loader in `scripts/lib/configured-paths.sh`, each run against the final suite in a scratch copy: 24 killed.

| mutant | result |
|---|---|
| pattern: the open marker is six or more | killed by "an eight-character run is not the seven-character marker" |
| pattern: the open marker is not matched | killed by "the open marker with its label fails, naming file:line and carrying the remedy" |
| pattern: the base marker is not matched | killed by "the bare base marker at the end of its line fails" |
| pattern: the close marker is not matched | killed by "the close marker with its label fails" |
| pattern: the separator is matched too | killed by "the open and close markers of one conflict are two hits and a count of two" |
| pattern: not anchored at column 0 | killed by "a space-indented open marker does not fire" |
| pattern: leading whitespace allowed | killed by "a space-indented open marker does not fire" |
| pattern: a glued run fires | killed by "an open marker glued to text does not fire" |
| pattern: only a space may follow | killed by "the bare base marker at the end of its line fails" |
| remedy: the excludes list not named | killed by "the open marker with its label fails, naming file:line and carrying the remedy" |
| verdict: the unmeasured qualifier dropped | killed by "a clean verdict names the skipped carrier and says how many went unmeasured" |
| verdict: violations exit 0 | killed by "the open marker with its label fails, naming file:line and carrying the remedy" |
| verdict: the failing line names no excludes list | killed by "the open marker with its label fails, naming file:line and carrying the remedy" |
| excludes: the flag is ignored | killed by "--excludes FILE points at the same list" |
| excludes: the setting is ignored | killed by "the excludes path resolves through COMMIT_GUARDS_CONFLICT_EXCLUDES" |
| excludes: the list is not loaded | killed by "the excludes row silences the declared path" |
| usage: an unknown argument is ignored | killed by "an unknown flag is exit 2, quoting it" |
| usage: --excludes without a path is accepted | killed by "--excludes without a path is exit 2" |
| lane: the remedy line is dropped | killed by "the open marker with its label fails, naming file:line and carrying the remedy" |
| lane: violations are not counted | killed by "the open marker with its label fails, naming file:line and carrying the remedy" |
| lane: the line number is dropped | killed by "the open marker with its label fails, naming file:line and carrying the remedy" |
| lane: a binary carrier is scanned as text | killed by "a clean verdict names the skipped carrier and says how many went unmeasured" |
| excludes: a reasonless row is accepted | killed by "a pattern without a tab-separated reason is exit 2 naming the line" |
| excludes: a matching path is still scanned | killed by "the excludes row silences the declared path" |

7 fixture mutants (one fixture's planted element removed, the named row must fail): 7 killed.

| fixture mutant | result |
|---|---|
| F1 excluded: the row not written | killed by "the excludes row silences the declared path" |
| F2 alt: the alternate list not written | killed by "the excludes path resolves through COMMIT_GUARDS_CONFLICT_EXCLUDES" |
| F3 self: the script not copied in | survived the first commit by design (an empty repository reads the same clean verdict); killed by "premise: the self fixture tracks the shipped script" after the reviewer round |
| F4 asset: no NUL in the leading window | killed by "a clean verdict names the skipped carrier and says how many went unmeasured" |
| F5 asset-text: the NUL kept | killed by "control: the same bytes without a NUL are read, fire on their line, and nothing goes unmeasured" |
| F6 put: %b becomes %s | killed by "the bare base marker at the end of its line fails" |
| F7 self-planted: nothing planted | killed by "control: a planted marker fails while the script stays unnamed" |

## Checks

- `conflict-markers.test.sh`: 30 assertions; passes on this host under TMPDIR=/tmp, under a symlinked TMPDIR, and (the 29-row first commit) on a macOS box (bash 3.2.57, BSD userland). `lane-readers.test.sh` 35/35 beside it. The repository's own conflict-markers scan over the file is clean. `tools/bash32-lint` clean.
- `tools/guard --full`: exit 0 on the first commit under TMPDIR=/tmp; the run on the rebased second commit was launched at PR time, CI is the verdict.
- One reviewer-test round: accept; its one suggestion (the premise assertion) is the second commit; its `--excludes=` empty-value row was declined as coverage past the old suite's surface (the behaviour is fail-closed and unchanged). Its report is `review-cm/REPORT.md` of the session scratchpad.

KEN-1241

https://claude.ai/code/session_01ESWfqKsTYCo5LjWxeBmaKi
