### PR TITLE
test(KEN-1241): the tracked-content symlink layout as one table of rows

### DIFF
--- a/.agents/skills/worktree/tests/worktree_symlink_shadows_tracked.sh
+++ b/.agents/skills/worktree/tests/worktree_symlink_shadows_tracked.sh
@@ -250,6 +250,9 @@ err_text() {
 SHADOW_V1='.agents=dir .agents/skills=dir .agents/skills/deep-research=link(<main>/.agents/skills/deep-research) .agents/skills/review-gate=dir .agents/skills/review-gate/engine.md=file:engine v1 .agents/state.json=link(<main>/.agents/state.json) assume=- status=-'
 SHADOW_V2="${SHADOW_V1/engine v1/engine v2}"
 IGNORING='.opencode=dir .opencode/.gitignore=file:bun.lock .opencode/agents=dir .opencode/agents/dev.md=file:agent .opencode/bun.lock=link(<main>/.opencode/bun.lock) assume=- status=-'
+# The copy's first line after main's .gitignore changed; held apart so the
+# expectation carries no escape a shell version could read differently.
+NEXT_IGNORE='file:node_modules/'
 
 # label|fixture|command|rc|out|err|layout
 ROWS="
@@ -265,7 +268,7 @@ an entry tracked only on main so far takes the real-directory shape before the m
 the merge into that shape writes the child beside the links|predated create late repair|@merge|0|-|-|.agents=dir .agents/skills=dir .agents/skills/deep-research=link(<main>/.agents/skills/deep-research) .agents/skills/late.md=file:late .agents/state.json=link(<main>/.agents/state.json) assume=- status=-
 an untracked .gitignore under a tracked-content entry is copied, and the worktree ignores what main ignores|ignoring|create topic|0|wt|-|$IGNORING
 push reads the copy as the expected shape, not a materialized link|ignoring create|push topic --no-rebase -u|0|-|-|$IGNORING
-the copy follows main on the next pass|ignoring create edit-ignore|fix-links @wt|0|restored|-|${IGNORING/file:bun.lock/file:node_modules\/}
+the copy follows main on the next pass|ignoring create edit-ignore|fix-links @wt|0|restored|-|${IGNORING/file:bun.lock/$NEXT_IGNORE}
 a legacy linked .gitignore heals to a copy|ignoring create legacy-ignore-link|fix-links @wt|0|restored|-|$IGNORING
 a worktree edit to the copy is overwritten by main's file|ignoring create edit-copy|fix-links @wt|0|restored|-|$IGNORING
 a locked index during the legacy heal reports failure, not a swallowed success|engine create legacy-link index-lock|repair-links @wt|1|-|index-locked|.agents=dir assume=.agents/engine.md status=-

--- a/.agents/skills/worktree/tests/worktree_symlink_shadows_tracked.sh
+++ b/.agents/skills/worktree/tests/worktree_symlink_shadows_tracked.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# A WORKTREE_SYMLINKS directory entry that contains tracked files must not be
-# linked wholesale: that shadowed the tracked files behind assume-unchanged, so
-# git could not write them (cherry-pick/checkout/merge failed while status
-# looked clean). Setup now ACTS on its detection: the entry stays a
-# real directory, tracked paths stay real files git owns, and only the
-# UNTRACKED children are symlinked — recursing through children that mix
-# tracked and untracked content. A fully untracked entry keeps the plain
-# parent symlink.
+# A WORKTREE_SYMLINKS entry that contains tracked files is not linked
+# wholesale (that shadowed the tracked files behind assume-unchanged, so git
+# could not write them while status looked clean): the entry stays a real
+# directory, tracked paths stay real files git owns, only the untracked
+# children are symlinked, recursing through children that mix the two, an
+# untracked .gitignore is copied (git refuses to read one through a link),
+# and a fully untracked entry keeps the plain parent symlink. One table, a
+# row per scenario.
 set -euo pipefail
 # A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
 # call below at the real repository; -C overrides neither.
@@ -20,44 +20,15 @@ trap 'rm -rf "$TMP_ROOT"' EXIT
 PASS=0
 FAIL=0
 
-assert_ok() {
-  local name="$1"
-  PASS=$((PASS + 1)); printf '  ok    %s\n' "$name"
-}
-
-assert_fail() {
-  local name="$1" detail="${2:-}"
-  FAIL=$((FAIL + 1))
-  printf '  FAIL  %s\n' "$name"
-  [[ -n "$detail" ]] && printf '        %s\n' "$detail"
-}
-
 assert_eq() {
   local got="$1" want="$2" name="$3"
   if [[ "$got" == "$want" ]]; then
-    assert_ok "$name"
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
   else
-    assert_fail "$name" "want: $want | got: $got"
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
   fi
-}
-
-assert_lacks() {
-  local haystack="$1" needle="$2" name="$3"
-  if grep -qF -- "$needle" <<<"$haystack"; then
-    assert_fail "$name" "unexpected substring: $needle"
-  else
-    assert_ok "$name"
-  fi
-}
-
-assert_symlink() {
-  local path="$1" name="$2"
-  if [[ -L "$path" ]]; then assert_ok "$name"; else assert_fail "$name" "not a symlink: $path"; fi
-}
-
-assert_real() {
-  local path="$1" name="$2"
-  if [[ -e "$path" && ! -L "$path" ]]; then assert_ok "$name"; else assert_fail "$name" "not a real path: $path"; fi
 }
 
 # No open PRs in this file; ownership signals are local/remote refs only.
@@ -69,335 +40,260 @@ STUB
 chmod +x "$TMP_ROOT/bin/gh"
 export PATH="$TMP_ROOT/bin:$PATH"
 
+# --- the symlink layout under a tracked-content entry: one table ---------------
+# A row builds its own checkout from a step word list (the first word shapes
+# the entry on main and commits it; the rest drive the worktree), runs one
+# command from the main checkout, and pins the exit status, stdout, stderr
+# whole, and the layout left under the entry in the worktree: every path as a
+# real directory, a real file with its first line, or a link with its target,
+# then the assume-unchanged paths and git's status in the worktree.
+
+ROOT=""
+MAIN=""
+WT=""
+ENTRY=""
+
 make_repo() {
-  local root="$1"
-  mkdir -p "$root/main"
-  git -C "$root/main" init -q -b main
-  git -C "$root/main" config user.email test@example.com
-  git -C "$root/main" config user.name Test
-  git -C "$root/main" config commit.gpgsign false
-  printf 'base\n' >"$root/main/base.txt"
-  git -C "$root/main" add base.txt
-  git -C "$root/main" commit -q -m base
-  git init -q --bare "$root/origin.git"
-  git -C "$root/main" remote add origin "$root/origin.git"
-  git -C "$root/main" push -q -u origin main
+  mkdir -p "$MAIN"
+  git -C "$MAIN" init -q -b main
+  git -C "$MAIN" config user.email test@example.com
+  git -C "$MAIN" config user.name Test
+  git -C "$MAIN" config commit.gpgsign false
+  printf 'base\n' >"$MAIN/base.txt"
+  git -C "$MAIN" add base.txt
+  git -C "$MAIN" commit -q -m base
+  git init -q --bare "$ROOT/origin.git"
+  git -C "$MAIN" remote add origin "$ROOT/origin.git"
+  git -C "$MAIN" push -q -u origin main
 }
 
-push_main() {
-  git -C "$1/main" push -q origin main
+commit_main() {
+  git -C "$MAIN" add -f "$@"
+  git -C "$MAIN" commit -q -m "main: $*"
+  git -C "$MAIN" push -q origin main
 }
 
-echo "=== an entry shadowing a tracked subtree gets per-child links, not assume-unchanged ==="
+# The entry named in WORKTREE_SYMLINKS.
+entry() {
+  ENTRY="$1"
+  printf 'WORKTREE_SYMLINKS="%s"\n' "$1" >>"$MAIN/.env.local"
+}
 
-SHADOW_ROOT="$TMP_ROOT/shadow"
-make_repo "$SHADOW_ROOT"
-# .agents mixes runtime (ignored) content with a tracked subtree — the vendored
-# review-gate shape: `.agents/skills/review-gate` is committed while the other
-# skills and runtime state are kendex-installed.
-mkdir -p "$SHADOW_ROOT/main/.agents/skills/review-gate"
-mkdir -p "$SHADOW_ROOT/main/.agents/skills/deep-research"
-printf '.agents/**\n!.agents/skills/\n!.agents/skills/review-gate/\n!.agents/skills/review-gate/**\n' >"$SHADOW_ROOT/main/.gitignore"
-printf 'runtime\n' >"$SHADOW_ROOT/main/.agents/state.json"
-printf 'engine v1\n' >"$SHADOW_ROOT/main/.agents/skills/review-gate/engine.md"
-printf 'installed skill\n' >"$SHADOW_ROOT/main/.agents/skills/deep-research/SKILL.md"
-printf 'WORKTREE_SYMLINKS=".agents"\n' >"$SHADOW_ROOT/main/.env.local"
-git -C "$SHADOW_ROOT/main" add .gitignore .agents/skills/review-gate/engine.md
-git -C "$SHADOW_ROOT/main" commit -q -m 'vendor review-gate'
-push_main "$SHADOW_ROOT"
+# A tool step of the fixture; a failure is a fixture failure, not a pin.
+tool() {
+  (cd "$MAIN" && "$WORKTREE_SCRIPT" "$@" >/dev/null 2>"$ROOT/fixture.err") && return 0
+  echo "FIXTURE: $* failed: $(cat "$ROOT/fixture.err")" >&2
+  exit 2
+}
 
-set +e
-WT="$( (cd "$SHADOW_ROOT/main" && "$WORKTREE_SCRIPT" create shadow-check) 2>"$SHADOW_ROOT/err" )"
-create_status=$?
-set -e
-shadow_err="$(cat "$SHADOW_ROOT/err")"
+step() {
+  case "$1" in
+    # The vendored review-gate shape: `.agents/skills/review-gate` is tracked,
+    # the other skills and the runtime state are kendex-installed and ignored.
+    shadow)
+      mkdir -p "$MAIN/.agents/skills/review-gate" "$MAIN/.agents/skills/deep-research"
+      printf '.agents/**\n!.agents/skills/\n!.agents/skills/review-gate/\n!.agents/skills/review-gate/**\n' >"$MAIN/.gitignore"
+      printf 'runtime\n' >"$MAIN/.agents/state.json"
+      printf 'engine v1\n' >"$MAIN/.agents/skills/review-gate/engine.md"
+      printf 'installed skill\n' >"$MAIN/.agents/skills/deep-research/SKILL.md"
+      entry .agents
+      commit_main .gitignore .agents/skills/review-gate/engine.md
+      ;;
+    # The same shape with nothing under the entry tracked yet: the worktree
+    # branch predates the commit that starts tracking a child.
+    predated)
+      mkdir -p "$MAIN/.agents/skills/deep-research"
+      printf '.agents/**\n!.agents/skills/\n!.agents/skills/review-gate/\n!.agents/skills/review-gate/**\n' >"$MAIN/.gitignore"
+      printf 'runtime\n' >"$MAIN/.agents/state.json"
+      printf 'installed skill\n' >"$MAIN/.agents/skills/deep-research/SKILL.md"
+      entry .agents
+      commit_main .gitignore
+      ;;
+    # An entry that tracks nothing.
+    untracked)
+      mkdir -p "$MAIN/runtime"
+      printf 'runtime/\n' >"$MAIN/.gitignore"
+      printf 'state\n' >"$MAIN/runtime/state.json"
+      entry runtime
+      commit_main .gitignore
+      ;;
+    # A tracked leaf whose name git's default ls-files output would quote.
+    quoted)
+      mkdir -p "$MAIN/.agents"
+      printf 'a\n' >"$MAIN/.agents/normal.md"
+      printf 'q\n' >"$MAIN/.agents/weird\"quote.md"
+      entry .agents
+      commit_main .agents
+      ;;
+    # One tracked anchor under the entry; a later child arrives on main only.
+    anchored)
+      mkdir -p "$MAIN/.agents/skills"
+      printf 'anchor\n' >"$MAIN/.agents/skills/anchor.md"
+      entry .agents
+      commit_main .agents/skills/anchor.md
+      ;;
+    # drovr's shape: `.opencode/agents` is tracked, `.opencode/.gitignore` is
+    # untracked and ignores bun.lock without ignoring itself.
+    ignoring)
+      mkdir -p "$MAIN/.opencode/agents"
+      printf 'agent\n' >"$MAIN/.opencode/agents/dev.md"
+      printf 'bun.lock\n' >"$MAIN/.opencode/.gitignore"
+      printf 'lock\n' >"$MAIN/.opencode/bun.lock"
+      entry .opencode
+      commit_main .opencode/agents/dev.md
+      ;;
+    # One tracked file under the entry.
+    engine)
+      mkdir -p "$MAIN/.agents"
+      printf 'engine\n' >"$MAIN/.agents/engine.md"
+      entry .agents
+      commit_main .agents/engine.md
+      ;;
+    create) tool create topic ;;
+    repair) tool repair-links "$WT" ;;
+    # The vendored file advances on main.
+    advance) printf 'engine v2\n' >"$MAIN/.agents/skills/review-gate/engine.md"; commit_main .agents/skills/review-gate/engine.md ;;
+    # A child lands under the entry on main only.
+    late) printf 'late\n' >"$MAIN/.agents/skills/late.md"; commit_main .agents/skills/late.md ;;
+    merge)
+      git -C "$WT" fetch -q origin && git -C "$WT" merge -q --no-edit origin/main && return 0
+      echo "FIXTURE: merge failed in $WT" >&2
+      exit 2
+      ;;
+    # A worktree provisioned by the older skill: one parent link over the
+    # entry, the tracked files assume-unchanged and unwritable.
+    legacy-link)
+      rm -rf -- "${WT:?}/$ENTRY"
+      ln -s "$MAIN/$ENTRY" "$WT/$ENTRY"
+      git -C "$WT" update-index --assume-unchanged "$(git -C "$WT" ls-files -- "$ENTRY" | head -n 1)"
+      ;;
+    edit-ignore) printf 'node_modules/\nbun.lock\n' >"$MAIN/.opencode/.gitignore" ;;
+    # The older skill linked the .gitignore too.
+    legacy-ignore-link) rm -f "$WT/.opencode/.gitignore"; ln -s "$MAIN/.opencode/.gitignore" "$WT/.opencode/.gitignore" ;;
+    edit-copy) printf 'edited\n' >"$WT/.opencode/.gitignore" ;;
+    index-lock) : >"$(git -C "$WT" rev-parse --git-path index.lock)" ;;
+    *)
+      echo "UNKNOWN-STEP: $1" >&2
+      exit 2
+      ;;
+  esac
+}
 
-assert_eq "$create_status" "0" "create succeeds"
-[[ -n "$WT" && -d "$WT" ]] || { echo "FATAL: worktree not created: $shadow_err"; exit 1; }
+build() {
+  local word
+  ROOT="$TMP_ROOT/$1"
+  shift
+  MAIN="$ROOT/main"
+  WT="$ROOT/trees/topic"
+  ENTRY=""
+  make_repo
+  printf 'WORKTREE_BASE_DIR="../trees"\n' >"$MAIN/.env.local"
+  for word in "$@"; do step "$word"; done
+}
 
-# The entry and the tracked subtree are real directories git can write through;
-# the tracked file is git's own copy, not a link into main.
-assert_real "$WT/.agents" "the entry is a real directory"
-assert_real "$WT/.agents/skills" "the mixed subtree is a real directory"
-assert_real "$WT/.agents/skills/review-gate/engine.md" "the tracked file is a real file"
-assert_eq "$(cat "$WT/.agents/skills/review-gate/engine.md")" "engine v1" "the tracked file has the branch's content"
+# Every path under the entry in the worktree: dir, file:<first line>, or
+# link(<target>); then the assume-unchanged paths and git's status, its own
+# stderr included, so an ignore file git cannot read shows here.
+layout() {
+  local path rel out="" assume status
+  while IFS= read -r path; do
+    rel="${path#"$WT"/}"
+    if [[ -L "$path" ]]; then
+      out="$out $rel=link($(readlink "$path" | sed -e "s|$MAIN|<main>|"))"
+    elif [[ -d "$path" ]]; then
+      out="$out $rel=dir"
+    elif [[ -e "$path" ]]; then
+      out="$out $rel=file:$(head -n 1 "$path")"
+    fi
+  done <<<"$(find "$WT/$ENTRY" -mindepth 0 2>/dev/null | LC_ALL=C sort)"
+  [[ -e "$WT/$ENTRY" || -L "$WT/$ENTRY" ]] || out=" $ENTRY=absent"
+  assume="$(git -C "$WT" ls-files -v 2>/dev/null | grep '^[a-z]' | cut -c3- | paste -s -d ',' - || true)"
+  status="$(git -C "$WT" status --porcelain 2>&1 | paste -s -d ';' -)"
+  printf '%s assume=%s status=%s' "${out# }" "${assume:--}" "${status:--}"
+}
 
-# The untracked children still arrive, as individual links.
-assert_symlink "$WT/.agents/state.json" "an untracked child of the entry is symlinked"
-assert_symlink "$WT/.agents/skills/deep-research" "an untracked child of the mixed subtree is symlinked"
-assert_eq "$(cat "$WT/.agents/skills/deep-research/SKILL.md")" "installed skill" "the linked child resolves to main's content"
+alias_text() {
+  sed -e "s|$WT|<wt>|g" -e "s|$MAIN|<main>|g" -e "s|$ROOT|<root>|g" -e "s|$WORKTREE_SCRIPT|<worktree>|g" \
+    -e '/^To <root>\/origin\.git$/d' -e '/^ [!*+] /d' -e "/^branch '.*' set up to track/d" \
+    -e 's/;/\\;/g' | paste -s -d ';' -
+}
 
-# No assume-unchanged bits: git owns the tracked paths outright.
-assert_lacks "$(git -C "$WT" ls-files -v -- .agents/ | grep '^[a-z]' || true)" "engine.md" \
-  "no tracked file under the entry is assume-unchanged"
-assert_lacks "$shadow_err" "assume-unchanged" "no assume-unchanged advice is printed"
-assert_eq "$(git -C "$WT" status --porcelain)" "" "git status is clean"
+# The command runs from the main checkout; @wt names the worktree's path.
+run() {
+  local -a argv
+  local rc=0 i
+  read -r -a argv <<<"$1"
+  for i in "${!argv[@]}"; do
+    [[ "${argv[i]}" == @wt ]] && argv[i]="$WT"
+  done
+  (cd "$MAIN" && "$WORKTREE_SCRIPT" "${argv[@]}" >"$ROOT/out" 2>"$ROOT/err") || rc=$?
+  printf 'rc=%s out=%s err=%s %s' "$rc" "$(alias_text <"$ROOT/out")" "$(alias_text <"$ROOT/err")" "$(layout)"
+}
 
-# The proof of the fix: git can WRITE the tracked subtree in this worktree.
-# Advance the vendored file on main and merge it into the worktree branch —
-# exactly the flow assume-unchanged would break.
-printf 'engine v2\n' >"$SHADOW_ROOT/main/.agents/skills/review-gate/engine.md"
-git -C "$SHADOW_ROOT/main" add -f .agents/skills/review-gate/engine.md
-git -C "$SHADOW_ROOT/main" commit -q -m 'refresh vendored engine'
-push_main "$SHADOW_ROOT"
+out_text() {
+  case "$1" in
+    -) printf '' ;;
+    wt) printf '<wt>' ;;
+    restored) printf 'Restored symlinks in <wt>' ;;
+    *) printf 'UNKNOWN-OUT-SPEC:%s' "$1" ;;
+  esac
+}
 
-set +e
-git -C "$WT" fetch -q origin
-merge_out="$(git -C "$WT" merge --no-edit origin/main 2>&1)"
-merge_status=$?
-[[ "$merge_status" -eq 0 ]] || printf 'merge output:\n%s\n' "$merge_out" >&2
-set -e
-assert_eq "$merge_status" "0" "a merge updating the tracked subtree succeeds"
-assert_eq "$(cat "$WT/.agents/skills/review-gate/engine.md")" "engine v2" "the merge wrote the tracked file"
-assert_symlink "$WT/.agents/state.json" "the per-child link survives the merge"
+err_text() {
+  case "$1" in
+    -) printf '' ;;
+    index-locked) printf '%s' "Warning: could not clear the assume-unchanged bit on tracked file(s) under '.agents' in <wt>\\; they may still be hidden from git writes.;Warning: could not restore tracked file '.agents/engine.md' under '.agents' in <wt> from the index\\; it may be missing.;Warning: skipping child linking under '.agents' in <wt> until the tracked restore above succeeds\\; re-run repair-links." ;;
+    *) printf 'UNKNOWN-ERR-SPEC:%s' "$1" ;;
+  esac
+}
 
-echo "=== re-running setup on the per-child layout is idempotent ==="
+SHADOW_V1='.agents=dir .agents/skills=dir .agents/skills/deep-research=link(<main>/.agents/skills/deep-research) .agents/skills/review-gate=dir .agents/skills/review-gate/engine.md=file:engine v1 .agents/state.json=link(<main>/.agents/state.json) assume=- status=-'
+SHADOW_V2="${SHADOW_V1/engine v1/engine v2}"
+IGNORING='.opencode=dir .opencode/.gitignore=file:bun.lock .opencode/agents=dir .opencode/agents/dev.md=file:agent .opencode/bun.lock=link(<main>/.opencode/bun.lock) assume=- status=-'
 
-set +e
-(cd "$SHADOW_ROOT/main" && "$WORKTREE_SCRIPT" fix-links "$WT") >/dev/null 2>"$SHADOW_ROOT/err2"
-fixlinks_status=$?
-set -e
-assert_eq "$fixlinks_status" "0" "fix-links succeeds on the per-child layout"
-assert_lacks "$(cat "$SHADOW_ROOT/err2")" "Warning" "fix-links stays quiet on the healthy per-child layout"
-assert_real "$WT/.agents/skills/review-gate/engine.md" "the tracked file is still a real file"
-assert_eq "$(cat "$WT/.agents/skills/review-gate/engine.md")" "engine v2" "the tracked content survives fix-links"
-assert_symlink "$WT/.agents/state.json" "the per-child link survives fix-links"
-assert_eq "$(git -C "$WT" status --porcelain)" "" "git status is clean after fix-links"
+# label|fixture|command|rc|out|err|layout
+ROWS="
+an entry shadowing a tracked subtree gets per-child links, not a parent link over assume-unchanged files|shadow|create topic|0|wt|-|$SHADOW_V1
+git can write the tracked subtree: a merge advancing the vendored file lands beside the links|shadow create advance|@merge|0|-|-|$SHADOW_V2
+fix-links on the per-child layout is idempotent and quiet|shadow create advance merge|fix-links @wt|0|restored|-|$SHADOW_V2
+a legacy parent link over tracked files heals to the per-child layout and clears the stale bit|shadow create advance merge legacy-link|fix-links @wt|0|restored|-|$SHADOW_V2
+a fully untracked entry keeps the plain parent symlink|untracked|create topic|0|wt|-|runtime=link(<main>/runtime) assume=- status=-
+a tracked leaf whose name git would quote stays a real file|quoted|create topic|0|wt|-|.agents=dir .agents/normal.md=file:a .agents/weird\"quote.md=file:q assume=- status=-
+a child tracked only on main is left absent, not linked over|anchored create late|repair-links @wt|0|-|-|.agents=dir .agents/skills=dir .agents/skills/anchor.md=file:anchor assume=- status=-
+the merge that introduces that child writes it as a real file|anchored create late|@merge|0|-|-|.agents=dir .agents/skills=dir .agents/skills/anchor.md=file:anchor .agents/skills/late.md=file:late assume=- status=-
+an entry tracked only on main so far takes the real-directory shape before the merge|predated create late|repair-links @wt|0|-|-|.agents=dir .agents/skills=dir .agents/skills/deep-research=link(<main>/.agents/skills/deep-research) .agents/state.json=link(<main>/.agents/state.json) assume=- status=-
+the merge into that shape writes the child beside the links|predated create late repair|@merge|0|-|-|.agents=dir .agents/skills=dir .agents/skills/deep-research=link(<main>/.agents/skills/deep-research) .agents/skills/late.md=file:late .agents/state.json=link(<main>/.agents/state.json) assume=- status=-
+an untracked .gitignore under a tracked-content entry is copied, and the worktree ignores what main ignores|ignoring|create topic|0|wt|-|$IGNORING
+push reads the copy as the expected shape, not a materialized link|ignoring create|push topic --no-rebase -u|0|-|-|$IGNORING
+the copy follows main on the next pass|ignoring create edit-ignore|fix-links @wt|0|restored|-|${IGNORING/file:bun.lock/file:node_modules\/}
+a legacy linked .gitignore heals to a copy|ignoring create legacy-ignore-link|fix-links @wt|0|restored|-|$IGNORING
+a worktree edit to the copy is overwritten by main's file|ignoring create edit-copy|fix-links @wt|0|restored|-|$IGNORING
+a locked index during the legacy heal reports failure, not a swallowed success|engine create legacy-link index-lock|repair-links @wt|1|-|index-locked|.agents=dir assume=.agents/engine.md status=-
+"
 
-echo "=== a legacy parent link over tracked files heals to the per-child layout ==="
+echo "=== the symlink layout under a tracked-content entry ==="
+n=0
+while IFS='|' read -r label fixture command rc out err want; do
+  [[ -n "$label$fixture$command$rc$out$err$want" ]] || continue
+  n=$((n + 1))
+  # shellcheck disable=SC2086
+  build "row-$n" $fixture
+  if [[ "$command" == @merge ]]; then
+    # git's own merge, run in the worktree; its report is git's, so the row
+    # pins its status and what it wrote.
+    merge_rc=0
+    (git -C "$WT" fetch -q origin && git -C "$WT" merge -q --no-edit origin/main >/dev/null 2>&1) || merge_rc=$?
+    got="rc=$merge_rc out= err= $(layout)"
+  else
+    got="$(run "$command")"
+  fi
+  if [[ "${PROBE:-}" == 1 ]]; then
+    printf '%s => %s\n' "$label" "$got"
+    continue
+  fi
+  assert_eq "$got" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want" "$label"
+done <<<"$ROWS"
 
-# Model a worktree provisioned with a parent symlink over the
-# entry, tracked files assume-unchanged and unwritable.
-rm -rf "$WT/.agents"
-ln -s "$SHADOW_ROOT/main/.agents" "$WT/.agents"
-git -C "$WT" update-index --assume-unchanged .agents/skills/review-gate/engine.md
-
-set +e
-(cd "$SHADOW_ROOT/main" && "$WORKTREE_SCRIPT" fix-links "$WT") >/dev/null 2>&1
-legacy_status=$?
-set -e
-assert_eq "$legacy_status" "0" "fix-links succeeds on the legacy parent-link layout"
-assert_real "$WT/.agents" "the legacy parent link became a real directory"
-assert_real "$WT/.agents/skills/review-gate/engine.md" "the shadowed tracked file was restored as a real file"
-assert_lacks "$(git -C "$WT" ls-files -v -- .agents/ | grep '^[a-z]' || true)" "engine.md" \
-  "the stale assume-unchanged bit was cleared"
-assert_symlink "$WT/.agents/state.json" "untracked children are linked after the heal"
-
-echo "=== a fully untracked entry keeps the plain parent symlink ==="
-
-CLEAN_ROOT="$TMP_ROOT/clean"
-make_repo "$CLEAN_ROOT"
-mkdir -p "$CLEAN_ROOT/main/runtime"
-printf 'runtime/\n' >"$CLEAN_ROOT/main/.gitignore"
-printf 'state\n' >"$CLEAN_ROOT/main/runtime/state.json"
-printf 'WORKTREE_SYMLINKS="runtime"\n' >"$CLEAN_ROOT/main/.env.local"
-git -C "$CLEAN_ROOT/main" add .gitignore
-git -C "$CLEAN_ROOT/main" commit -q -m runtime
-push_main "$CLEAN_ROOT"
-
-set +e
-CLEAN_WT="$( (cd "$CLEAN_ROOT/main" && "$WORKTREE_SCRIPT" create clean-check) 2>"$CLEAN_ROOT/err" )"
-clean_status=$?
-set -e
-
-assert_eq "$clean_status" "0" "create succeeds for the untracked entry"
-assert_symlink "$CLEAN_WT/runtime" "an entry with no tracked files is still one parent symlink"
-assert_lacks "$(cat "$CLEAN_ROOT/err")" "shadows" "no warning when the entry tracks nothing"
-
-echo "=== a tracked leaf name containing a quote is not turned into a link (#875) ==="
-
-# git's default (non -z) ls-files output quotes names with special bytes, so
-# comparing that display form against the raw filesystem name misclassifies
-# a tracked leaf as untracked and replaces it with a symlink.
-QUOTE_ROOT="$TMP_ROOT/quote"
-make_repo "$QUOTE_ROOT"
-mkdir -p "$QUOTE_ROOT/main/.agents"
-printf 'a\n' >"$QUOTE_ROOT/main/.agents/normal.md"
-printf 'q\n' >"$QUOTE_ROOT/main/.agents/weird\"quote.md"
-printf 'WORKTREE_SYMLINKS=".agents"\n' >"$QUOTE_ROOT/main/.env.local"
-git -C "$QUOTE_ROOT/main" add .agents
-git -C "$QUOTE_ROOT/main" commit -q -m quoted
-push_main "$QUOTE_ROOT"
-
-set +e
-QUOTE_WT="$( (cd "$QUOTE_ROOT/main" && "$WORKTREE_SCRIPT" create quote-check) 2>"$QUOTE_ROOT/err" )"
-quote_status=$?
-set -e
-
-assert_eq "$quote_status" "0" "create succeeds for the quoted-name entry"
-assert_real "$QUOTE_WT/.agents/weird\"quote.md" "the quoted tracked leaf stays a real file, not a link"
-assert_eq "$(cat "$QUOTE_WT/.agents/weird\"quote.md")" "q" "the quoted tracked leaf has the branch's content"
-
-echo "=== a child tracked only on main (branch predates it) is not linked over (#964) ==="
-
-# Top-level provisioning already checks both indexes for the parent's shape;
-# this proves the per-child walk inside a shadowed entry does the same, so a
-# path that only main tracks so far is left to the eventual merge instead of
-# being symlinked out from under it.
-PREDATE_ROOT="$TMP_ROOT/predate"
-make_repo "$PREDATE_ROOT"
-mkdir -p "$PREDATE_ROOT/main/.agents/skills"
-printf 'anchor\n' >"$PREDATE_ROOT/main/.agents/skills/anchor.md"
-printf 'WORKTREE_SYMLINKS=".agents"\n' >"$PREDATE_ROOT/main/.env.local"
-git -C "$PREDATE_ROOT/main" add .agents/skills/anchor.md
-git -C "$PREDATE_ROOT/main" commit -q -m anchor
-push_main "$PREDATE_ROOT"
-
-set +e
-PREDATE_WT="$( (cd "$PREDATE_ROOT/main" && "$WORKTREE_SCRIPT" create predate-check) 2>"$PREDATE_ROOT/err" )"
-predate_status=$?
-set -e
-assert_eq "$predate_status" "0" "create succeeds before the new child is tracked"
-
-# Advance MAIN only: a file lands under the shadowed entry and becomes
-# tracked there, but the worktree branch does not have it yet.
-printf 'late\n' >"$PREDATE_ROOT/main/.agents/skills/late.md"
-git -C "$PREDATE_ROOT/main" add .agents/skills/late.md
-git -C "$PREDATE_ROOT/main" commit -q -m late
-push_main "$PREDATE_ROOT"
-
-set +e
-(cd "$PREDATE_ROOT/main" && "$WORKTREE_SCRIPT" repair-links "$PREDATE_WT") >/dev/null 2>"$PREDATE_ROOT/err2"
-predate_repair_status=$?
-set -e
-assert_eq "$predate_repair_status" "0" "repair-links succeeds while the child is main-only"
-
-if [[ ! -e "$PREDATE_WT/.agents/skills/late.md" && ! -L "$PREDATE_WT/.agents/skills/late.md" ]]; then
-  assert_ok "a child tracked only on main is left absent, not symlinked"
-else
-  assert_fail "a child tracked only on main is left absent, not symlinked" \
-    "found: $(ls -la "$PREDATE_WT/.agents/skills/late.md" 2>&1)"
-fi
-
-set +e
-git -C "$PREDATE_WT" fetch -q origin
-merge_out2="$(git -C "$PREDATE_WT" merge --no-edit origin/main 2>&1)"
-merge_status2=$?
-[[ "$merge_status2" -eq 0 ]] || printf 'merge output:\n%s\n' "$merge_out2" >&2
-set -e
-assert_eq "$merge_status2" "0" "the merge that introduces the tracked child succeeds"
-assert_real "$PREDATE_WT/.agents/skills/late.md" "the merge wrote the newly-tracked child as a real file"
-
-echo "=== an untracked .gitignore under a tracked-content entry is copied, not linked (KEN-685) ==="
-
-# Git refuses to read .gitignore through a symlink, so a linked one applies
-# none of its rules in the worktree and prints "unable to access" on every
-# command. drovr's shape: `.opencode/agents` is tracked, `.opencode/.gitignore`
-# is untracked and ignores bun.lock. It does NOT ignore itself: the copy in the
-# worktree is kept out of `git status` only by the info/exclude entry setup
-# writes for it, so the status assertions below prove that entry too.
-IGN_ROOT="$TMP_ROOT/ignore"
-make_repo "$IGN_ROOT"
-mkdir -p "$IGN_ROOT/main/.opencode/agents"
-printf 'agent\n' >"$IGN_ROOT/main/.opencode/agents/dev.md"
-printf 'bun.lock\n' >"$IGN_ROOT/main/.opencode/.gitignore"
-printf 'lock\n' >"$IGN_ROOT/main/.opencode/bun.lock"
-printf 'WORKTREE_SYMLINKS=".opencode"\n' >"$IGN_ROOT/main/.env.local"
-git -C "$IGN_ROOT/main" add .opencode/agents/dev.md
-git -C "$IGN_ROOT/main" commit -q -m 'track opencode agents'
-push_main "$IGN_ROOT"
-assert_eq "$(git -C "$IGN_ROOT/main" status --porcelain -- .opencode/bun.lock)" "" "main ignores bun.lock through the untracked .gitignore"
-assert_eq "$(git -C "$IGN_ROOT/main" status --porcelain -- .opencode)" "?? .opencode/.gitignore" "main's .gitignore is untracked and does not hide itself"
-
-set +e
-IGN_WT="$( (cd "$IGN_ROOT/main" && "$WORKTREE_SCRIPT" create ignore-check) 2>"$IGN_ROOT/err" )"
-ign_status=$?
-set -e
-assert_eq "$ign_status" "0" "create succeeds for the entry holding an untracked .gitignore"
-[[ -n "$IGN_WT" && -d "$IGN_WT" ]] || { echo "FATAL: worktree not created: $(cat "$IGN_ROOT/err")"; exit 1; }
-
-assert_real "$IGN_WT/.opencode/.gitignore" "the .gitignore is a real file in the worktree, not a link"
-assert_eq "$(cat "$IGN_WT/.opencode/.gitignore")" "$(cat "$IGN_ROOT/main/.opencode/.gitignore")" "the copy has main's content"
-assert_real "$IGN_WT/.opencode/agents/dev.md" "the tracked file beside it stays a real file"
-
-# The proof: the worktree ignores what main ignores, and git stops complaining.
-printf 'lock\n' >"$IGN_WT/.opencode/bun.lock"
-assert_eq "$(git -C "$IGN_WT" status --porcelain 2>&1)" "" "bun.lock is ignored in the worktree"
-assert_lacks "$(git -C "$IGN_WT" status 2>&1)" "unable to access" "git prints no ignore-file access warning"
-
-# push is the one command that runs the materialization detector; the copy
-# must read as the expected shape there, not as a real path where a link belongs.
-set +e
-(cd "$IGN_ROOT/main" && "$WORKTREE_SCRIPT" push ignore-check --no-rebase -u) >/dev/null 2>"$IGN_ROOT/perr"
-ign_push_status=$?
-set -e
-assert_eq "$ign_push_status" "0" "push succeeds from the worktree holding the copy"
-assert_lacks "$(cat "$IGN_ROOT/perr")" "harness paths in this worktree" "push does not report the copy as a materialized link"
-
-echo "=== the .gitignore copy follows main on the next pass, and a legacy link heals to a copy ==="
-
-printf 'bun.lock\nnode_modules/\n' >"$IGN_ROOT/main/.opencode/.gitignore"
-set +e
-(cd "$IGN_ROOT/main" && "$WORKTREE_SCRIPT" fix-links "$IGN_WT") >/dev/null 2>"$IGN_ROOT/err2"
-ign_fix_status=$?
-set -e
-assert_eq "$ign_fix_status" "0" "fix-links succeeds after main's .gitignore changed"
-assert_lacks "$(cat "$IGN_ROOT/err2")" "Warning" "fix-links stays quiet while re-copying"
-assert_eq "$(cat "$IGN_WT/.opencode/.gitignore")" "$(cat "$IGN_ROOT/main/.opencode/.gitignore")" "the copy picked up main's change"
-
-# A worktree provisioned by the older skill holds a link where the copy belongs.
-rm -f "$IGN_WT/.opencode/.gitignore"
-ln -s "$IGN_ROOT/main/.opencode/.gitignore" "$IGN_WT/.opencode/.gitignore"
-set +e
-(cd "$IGN_ROOT/main" && "$WORKTREE_SCRIPT" fix-links "$IGN_WT") >/dev/null 2>"$IGN_ROOT/err3"
-ign_legacy_status=$?
-set -e
-assert_eq "$ign_legacy_status" "0" "fix-links succeeds on a legacy linked .gitignore"
-assert_real "$IGN_WT/.opencode/.gitignore" "the legacy link became a copy"
-assert_eq "$(git -C "$IGN_WT" status --porcelain 2>&1)" "" "the healed worktree ignores bun.lock again"
-
-# fix-links judges the copy's content: a worktree edit is drift it closes.
-printf 'edited\n' >"$IGN_WT/.opencode/.gitignore"
-set +e
-(cd "$IGN_ROOT/main" && "$WORKTREE_SCRIPT" fix-links "$IGN_WT") >/dev/null 2>&1
-set -e
-assert_eq "$(cat "$IGN_WT/.opencode/.gitignore")" "$(cat "$IGN_ROOT/main/.opencode/.gitignore")" "a worktree edit to the copy is overwritten by main's file"
-
-echo "=== a locked index during legacy heal reports failure, not a swallowed success (#850) ==="
-
-# The old code discarded failures from --no-assume-unchanged and the missing-
-# file checkout with `|| true`, so a locked index or unwritable destination
-# left tracked paths missing/unwritable while the heal still reported success.
-LOCK_ROOT="$TMP_ROOT/lock"
-make_repo "$LOCK_ROOT"
-mkdir -p "$LOCK_ROOT/main/.agents"
-printf 'engine\n' >"$LOCK_ROOT/main/.agents/engine.md"
-printf 'WORKTREE_SYMLINKS=".agents"\n' >"$LOCK_ROOT/main/.env.local"
-git -C "$LOCK_ROOT/main" add .agents/engine.md
-git -C "$LOCK_ROOT/main" commit -q -m engine
-push_main "$LOCK_ROOT"
-
-set +e
-LOCK_WT="$( (cd "$LOCK_ROOT/main" && "$WORKTREE_SCRIPT" create lock-check) 2>"$LOCK_ROOT/err" )"
-lock_status=$?
-set -e
-assert_eq "$lock_status" "0" "create succeeds for the lock scenario"
-
-# Model the legacy parent-link state once more so the shadowed-restore path
-# (clear assume-unchanged, checkout missing tracked files) actually runs.
-rm -rf "$LOCK_WT/.agents"
-ln -s "$LOCK_ROOT/main/.agents" "$LOCK_WT/.agents"
-git -C "$LOCK_WT" update-index --assume-unchanged .agents/engine.md
-
-LOCKFILE="$(git -C "$LOCK_WT" rev-parse --git-path index.lock)"
-: >"$LOCKFILE"
-
-set +e
-lock_out="$(cd "$LOCK_ROOT/main" && "$WORKTREE_SCRIPT" repair-links "$LOCK_WT" 2>&1)"
-lock_repair_status=$?
-set -e
-rm -f "$LOCKFILE"
-
-if [[ "$lock_repair_status" -ne 0 ]]; then
-  assert_ok "a locked index makes the heal report failure instead of success"
-else
-  assert_fail "a locked index makes the heal report failure instead of success" "exit status was 0: $lock_out"
-fi
-if grep -qF -- "could not" <<<"$lock_out"; then
-  assert_ok "the failure names what could not be healed"
-else
-  assert_fail "the failure names what could not be healed" "output: $lock_out"
-fi
-
-printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/worktree/tests/worktree_symlink_shadows_tracked.sh
+++ b/skills/worktree/tests/worktree_symlink_shadows_tracked.sh
@@ -250,6 +250,9 @@ err_text() {
 SHADOW_V1='.agents=dir .agents/skills=dir .agents/skills/deep-research=link(<main>/.agents/skills/deep-research) .agents/skills/review-gate=dir .agents/skills/review-gate/engine.md=file:engine v1 .agents/state.json=link(<main>/.agents/state.json) assume=- status=-'
 SHADOW_V2="${SHADOW_V1/engine v1/engine v2}"
 IGNORING='.opencode=dir .opencode/.gitignore=file:bun.lock .opencode/agents=dir .opencode/agents/dev.md=file:agent .opencode/bun.lock=link(<main>/.opencode/bun.lock) assume=- status=-'
+# The copy's first line after main's .gitignore changed; held apart so the
+# expectation carries no escape a shell version could read differently.
+NEXT_IGNORE='file:node_modules/'
 
 # label|fixture|command|rc|out|err|layout
 ROWS="
@@ -265,7 +268,7 @@ an entry tracked only on main so far takes the real-directory shape before the m
 the merge into that shape writes the child beside the links|predated create late repair|@merge|0|-|-|.agents=dir .agents/skills=dir .agents/skills/deep-research=link(<main>/.agents/skills/deep-research) .agents/skills/late.md=file:late .agents/state.json=link(<main>/.agents/state.json) assume=- status=-
 an untracked .gitignore under a tracked-content entry is copied, and the worktree ignores what main ignores|ignoring|create topic|0|wt|-|$IGNORING
 push reads the copy as the expected shape, not a materialized link|ignoring create|push topic --no-rebase -u|0|-|-|$IGNORING
-the copy follows main on the next pass|ignoring create edit-ignore|fix-links @wt|0|restored|-|${IGNORING/file:bun.lock/file:node_modules\/}
+the copy follows main on the next pass|ignoring create edit-ignore|fix-links @wt|0|restored|-|${IGNORING/file:bun.lock/$NEXT_IGNORE}
 a legacy linked .gitignore heals to a copy|ignoring create legacy-ignore-link|fix-links @wt|0|restored|-|$IGNORING
 a worktree edit to the copy is overwritten by main's file|ignoring create edit-copy|fix-links @wt|0|restored|-|$IGNORING
 a locked index during the legacy heal reports failure, not a swallowed success|engine create legacy-link index-lock|repair-links @wt|1|-|index-locked|.agents=dir assume=.agents/engine.md status=-

--- a/skills/worktree/tests/worktree_symlink_shadows_tracked.sh
+++ b/skills/worktree/tests/worktree_symlink_shadows_tracked.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# A WORKTREE_SYMLINKS directory entry that contains tracked files must not be
-# linked wholesale: that shadowed the tracked files behind assume-unchanged, so
-# git could not write them (cherry-pick/checkout/merge failed while status
-# looked clean). Setup now ACTS on its detection: the entry stays a
-# real directory, tracked paths stay real files git owns, and only the
-# UNTRACKED children are symlinked — recursing through children that mix
-# tracked and untracked content. A fully untracked entry keeps the plain
-# parent symlink.
+# A WORKTREE_SYMLINKS entry that contains tracked files is not linked
+# wholesale (that shadowed the tracked files behind assume-unchanged, so git
+# could not write them while status looked clean): the entry stays a real
+# directory, tracked paths stay real files git owns, only the untracked
+# children are symlinked, recursing through children that mix the two, an
+# untracked .gitignore is copied (git refuses to read one through a link),
+# and a fully untracked entry keeps the plain parent symlink. One table, a
+# row per scenario.
 set -euo pipefail
 # A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
 # call below at the real repository; -C overrides neither.
@@ -20,44 +20,15 @@ trap 'rm -rf "$TMP_ROOT"' EXIT
 PASS=0
 FAIL=0
 
-assert_ok() {
-  local name="$1"
-  PASS=$((PASS + 1)); printf '  ok    %s\n' "$name"
-}
-
-assert_fail() {
-  local name="$1" detail="${2:-}"
-  FAIL=$((FAIL + 1))
-  printf '  FAIL  %s\n' "$name"
-  [[ -n "$detail" ]] && printf '        %s\n' "$detail"
-}
-
 assert_eq() {
   local got="$1" want="$2" name="$3"
   if [[ "$got" == "$want" ]]; then
-    assert_ok "$name"
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
   else
-    assert_fail "$name" "want: $want | got: $got"
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
   fi
-}
-
-assert_lacks() {
-  local haystack="$1" needle="$2" name="$3"
-  if grep -qF -- "$needle" <<<"$haystack"; then
-    assert_fail "$name" "unexpected substring: $needle"
-  else
-    assert_ok "$name"
-  fi
-}
-
-assert_symlink() {
-  local path="$1" name="$2"
-  if [[ -L "$path" ]]; then assert_ok "$name"; else assert_fail "$name" "not a symlink: $path"; fi
-}
-
-assert_real() {
-  local path="$1" name="$2"
-  if [[ -e "$path" && ! -L "$path" ]]; then assert_ok "$name"; else assert_fail "$name" "not a real path: $path"; fi
 }
 
 # No open PRs in this file; ownership signals are local/remote refs only.
@@ -69,335 +40,260 @@ STUB
 chmod +x "$TMP_ROOT/bin/gh"
 export PATH="$TMP_ROOT/bin:$PATH"
 
+# --- the symlink layout under a tracked-content entry: one table ---------------
+# A row builds its own checkout from a step word list (the first word shapes
+# the entry on main and commits it; the rest drive the worktree), runs one
+# command from the main checkout, and pins the exit status, stdout, stderr
+# whole, and the layout left under the entry in the worktree: every path as a
+# real directory, a real file with its first line, or a link with its target,
+# then the assume-unchanged paths and git's status in the worktree.
+
+ROOT=""
+MAIN=""
+WT=""
+ENTRY=""
+
 make_repo() {
-  local root="$1"
-  mkdir -p "$root/main"
-  git -C "$root/main" init -q -b main
-  git -C "$root/main" config user.email test@example.com
-  git -C "$root/main" config user.name Test
-  git -C "$root/main" config commit.gpgsign false
-  printf 'base\n' >"$root/main/base.txt"
-  git -C "$root/main" add base.txt
-  git -C "$root/main" commit -q -m base
-  git init -q --bare "$root/origin.git"
-  git -C "$root/main" remote add origin "$root/origin.git"
-  git -C "$root/main" push -q -u origin main
+  mkdir -p "$MAIN"
+  git -C "$MAIN" init -q -b main
+  git -C "$MAIN" config user.email test@example.com
+  git -C "$MAIN" config user.name Test
+  git -C "$MAIN" config commit.gpgsign false
+  printf 'base\n' >"$MAIN/base.txt"
+  git -C "$MAIN" add base.txt
+  git -C "$MAIN" commit -q -m base
+  git init -q --bare "$ROOT/origin.git"
+  git -C "$MAIN" remote add origin "$ROOT/origin.git"
+  git -C "$MAIN" push -q -u origin main
 }
 
-push_main() {
-  git -C "$1/main" push -q origin main
+commit_main() {
+  git -C "$MAIN" add -f "$@"
+  git -C "$MAIN" commit -q -m "main: $*"
+  git -C "$MAIN" push -q origin main
 }
 
-echo "=== an entry shadowing a tracked subtree gets per-child links, not assume-unchanged ==="
+# The entry named in WORKTREE_SYMLINKS.
+entry() {
+  ENTRY="$1"
+  printf 'WORKTREE_SYMLINKS="%s"\n' "$1" >>"$MAIN/.env.local"
+}
 
-SHADOW_ROOT="$TMP_ROOT/shadow"
-make_repo "$SHADOW_ROOT"
-# .agents mixes runtime (ignored) content with a tracked subtree — the vendored
-# review-gate shape: `.agents/skills/review-gate` is committed while the other
-# skills and runtime state are kendex-installed.
-mkdir -p "$SHADOW_ROOT/main/.agents/skills/review-gate"
-mkdir -p "$SHADOW_ROOT/main/.agents/skills/deep-research"
-printf '.agents/**\n!.agents/skills/\n!.agents/skills/review-gate/\n!.agents/skills/review-gate/**\n' >"$SHADOW_ROOT/main/.gitignore"
-printf 'runtime\n' >"$SHADOW_ROOT/main/.agents/state.json"
-printf 'engine v1\n' >"$SHADOW_ROOT/main/.agents/skills/review-gate/engine.md"
-printf 'installed skill\n' >"$SHADOW_ROOT/main/.agents/skills/deep-research/SKILL.md"
-printf 'WORKTREE_SYMLINKS=".agents"\n' >"$SHADOW_ROOT/main/.env.local"
-git -C "$SHADOW_ROOT/main" add .gitignore .agents/skills/review-gate/engine.md
-git -C "$SHADOW_ROOT/main" commit -q -m 'vendor review-gate'
-push_main "$SHADOW_ROOT"
+# A tool step of the fixture; a failure is a fixture failure, not a pin.
+tool() {
+  (cd "$MAIN" && "$WORKTREE_SCRIPT" "$@" >/dev/null 2>"$ROOT/fixture.err") && return 0
+  echo "FIXTURE: $* failed: $(cat "$ROOT/fixture.err")" >&2
+  exit 2
+}
 
-set +e
-WT="$( (cd "$SHADOW_ROOT/main" && "$WORKTREE_SCRIPT" create shadow-check) 2>"$SHADOW_ROOT/err" )"
-create_status=$?
-set -e
-shadow_err="$(cat "$SHADOW_ROOT/err")"
+step() {
+  case "$1" in
+    # The vendored review-gate shape: `.agents/skills/review-gate` is tracked,
+    # the other skills and the runtime state are kendex-installed and ignored.
+    shadow)
+      mkdir -p "$MAIN/.agents/skills/review-gate" "$MAIN/.agents/skills/deep-research"
+      printf '.agents/**\n!.agents/skills/\n!.agents/skills/review-gate/\n!.agents/skills/review-gate/**\n' >"$MAIN/.gitignore"
+      printf 'runtime\n' >"$MAIN/.agents/state.json"
+      printf 'engine v1\n' >"$MAIN/.agents/skills/review-gate/engine.md"
+      printf 'installed skill\n' >"$MAIN/.agents/skills/deep-research/SKILL.md"
+      entry .agents
+      commit_main .gitignore .agents/skills/review-gate/engine.md
+      ;;
+    # The same shape with nothing under the entry tracked yet: the worktree
+    # branch predates the commit that starts tracking a child.
+    predated)
+      mkdir -p "$MAIN/.agents/skills/deep-research"
+      printf '.agents/**\n!.agents/skills/\n!.agents/skills/review-gate/\n!.agents/skills/review-gate/**\n' >"$MAIN/.gitignore"
+      printf 'runtime\n' >"$MAIN/.agents/state.json"
+      printf 'installed skill\n' >"$MAIN/.agents/skills/deep-research/SKILL.md"
+      entry .agents
+      commit_main .gitignore
+      ;;
+    # An entry that tracks nothing.
+    untracked)
+      mkdir -p "$MAIN/runtime"
+      printf 'runtime/\n' >"$MAIN/.gitignore"
+      printf 'state\n' >"$MAIN/runtime/state.json"
+      entry runtime
+      commit_main .gitignore
+      ;;
+    # A tracked leaf whose name git's default ls-files output would quote.
+    quoted)
+      mkdir -p "$MAIN/.agents"
+      printf 'a\n' >"$MAIN/.agents/normal.md"
+      printf 'q\n' >"$MAIN/.agents/weird\"quote.md"
+      entry .agents
+      commit_main .agents
+      ;;
+    # One tracked anchor under the entry; a later child arrives on main only.
+    anchored)
+      mkdir -p "$MAIN/.agents/skills"
+      printf 'anchor\n' >"$MAIN/.agents/skills/anchor.md"
+      entry .agents
+      commit_main .agents/skills/anchor.md
+      ;;
+    # drovr's shape: `.opencode/agents` is tracked, `.opencode/.gitignore` is
+    # untracked and ignores bun.lock without ignoring itself.
+    ignoring)
+      mkdir -p "$MAIN/.opencode/agents"
+      printf 'agent\n' >"$MAIN/.opencode/agents/dev.md"
+      printf 'bun.lock\n' >"$MAIN/.opencode/.gitignore"
+      printf 'lock\n' >"$MAIN/.opencode/bun.lock"
+      entry .opencode
+      commit_main .opencode/agents/dev.md
+      ;;
+    # One tracked file under the entry.
+    engine)
+      mkdir -p "$MAIN/.agents"
+      printf 'engine\n' >"$MAIN/.agents/engine.md"
+      entry .agents
+      commit_main .agents/engine.md
+      ;;
+    create) tool create topic ;;
+    repair) tool repair-links "$WT" ;;
+    # The vendored file advances on main.
+    advance) printf 'engine v2\n' >"$MAIN/.agents/skills/review-gate/engine.md"; commit_main .agents/skills/review-gate/engine.md ;;
+    # A child lands under the entry on main only.
+    late) printf 'late\n' >"$MAIN/.agents/skills/late.md"; commit_main .agents/skills/late.md ;;
+    merge)
+      git -C "$WT" fetch -q origin && git -C "$WT" merge -q --no-edit origin/main && return 0
+      echo "FIXTURE: merge failed in $WT" >&2
+      exit 2
+      ;;
+    # A worktree provisioned by the older skill: one parent link over the
+    # entry, the tracked files assume-unchanged and unwritable.
+    legacy-link)
+      rm -rf -- "${WT:?}/$ENTRY"
+      ln -s "$MAIN/$ENTRY" "$WT/$ENTRY"
+      git -C "$WT" update-index --assume-unchanged "$(git -C "$WT" ls-files -- "$ENTRY" | head -n 1)"
+      ;;
+    edit-ignore) printf 'node_modules/\nbun.lock\n' >"$MAIN/.opencode/.gitignore" ;;
+    # The older skill linked the .gitignore too.
+    legacy-ignore-link) rm -f "$WT/.opencode/.gitignore"; ln -s "$MAIN/.opencode/.gitignore" "$WT/.opencode/.gitignore" ;;
+    edit-copy) printf 'edited\n' >"$WT/.opencode/.gitignore" ;;
+    index-lock) : >"$(git -C "$WT" rev-parse --git-path index.lock)" ;;
+    *)
+      echo "UNKNOWN-STEP: $1" >&2
+      exit 2
+      ;;
+  esac
+}
 
-assert_eq "$create_status" "0" "create succeeds"
-[[ -n "$WT" && -d "$WT" ]] || { echo "FATAL: worktree not created: $shadow_err"; exit 1; }
+build() {
+  local word
+  ROOT="$TMP_ROOT/$1"
+  shift
+  MAIN="$ROOT/main"
+  WT="$ROOT/trees/topic"
+  ENTRY=""
+  make_repo
+  printf 'WORKTREE_BASE_DIR="../trees"\n' >"$MAIN/.env.local"
+  for word in "$@"; do step "$word"; done
+}
 
-# The entry and the tracked subtree are real directories git can write through;
-# the tracked file is git's own copy, not a link into main.
-assert_real "$WT/.agents" "the entry is a real directory"
-assert_real "$WT/.agents/skills" "the mixed subtree is a real directory"
-assert_real "$WT/.agents/skills/review-gate/engine.md" "the tracked file is a real file"
-assert_eq "$(cat "$WT/.agents/skills/review-gate/engine.md")" "engine v1" "the tracked file has the branch's content"
+# Every path under the entry in the worktree: dir, file:<first line>, or
+# link(<target>); then the assume-unchanged paths and git's status, its own
+# stderr included, so an ignore file git cannot read shows here.
+layout() {
+  local path rel out="" assume status
+  while IFS= read -r path; do
+    rel="${path#"$WT"/}"
+    if [[ -L "$path" ]]; then
+      out="$out $rel=link($(readlink "$path" | sed -e "s|$MAIN|<main>|"))"
+    elif [[ -d "$path" ]]; then
+      out="$out $rel=dir"
+    elif [[ -e "$path" ]]; then
+      out="$out $rel=file:$(head -n 1 "$path")"
+    fi
+  done <<<"$(find "$WT/$ENTRY" -mindepth 0 2>/dev/null | LC_ALL=C sort)"
+  [[ -e "$WT/$ENTRY" || -L "$WT/$ENTRY" ]] || out=" $ENTRY=absent"
+  assume="$(git -C "$WT" ls-files -v 2>/dev/null | grep '^[a-z]' | cut -c3- | paste -s -d ',' - || true)"
+  status="$(git -C "$WT" status --porcelain 2>&1 | paste -s -d ';' -)"
+  printf '%s assume=%s status=%s' "${out# }" "${assume:--}" "${status:--}"
+}
 
-# The untracked children still arrive, as individual links.
-assert_symlink "$WT/.agents/state.json" "an untracked child of the entry is symlinked"
-assert_symlink "$WT/.agents/skills/deep-research" "an untracked child of the mixed subtree is symlinked"
-assert_eq "$(cat "$WT/.agents/skills/deep-research/SKILL.md")" "installed skill" "the linked child resolves to main's content"
+alias_text() {
+  sed -e "s|$WT|<wt>|g" -e "s|$MAIN|<main>|g" -e "s|$ROOT|<root>|g" -e "s|$WORKTREE_SCRIPT|<worktree>|g" \
+    -e '/^To <root>\/origin\.git$/d' -e '/^ [!*+] /d' -e "/^branch '.*' set up to track/d" \
+    -e 's/;/\\;/g' | paste -s -d ';' -
+}
 
-# No assume-unchanged bits: git owns the tracked paths outright.
-assert_lacks "$(git -C "$WT" ls-files -v -- .agents/ | grep '^[a-z]' || true)" "engine.md" \
-  "no tracked file under the entry is assume-unchanged"
-assert_lacks "$shadow_err" "assume-unchanged" "no assume-unchanged advice is printed"
-assert_eq "$(git -C "$WT" status --porcelain)" "" "git status is clean"
+# The command runs from the main checkout; @wt names the worktree's path.
+run() {
+  local -a argv
+  local rc=0 i
+  read -r -a argv <<<"$1"
+  for i in "${!argv[@]}"; do
+    [[ "${argv[i]}" == @wt ]] && argv[i]="$WT"
+  done
+  (cd "$MAIN" && "$WORKTREE_SCRIPT" "${argv[@]}" >"$ROOT/out" 2>"$ROOT/err") || rc=$?
+  printf 'rc=%s out=%s err=%s %s' "$rc" "$(alias_text <"$ROOT/out")" "$(alias_text <"$ROOT/err")" "$(layout)"
+}
 
-# The proof of the fix: git can WRITE the tracked subtree in this worktree.
-# Advance the vendored file on main and merge it into the worktree branch —
-# exactly the flow assume-unchanged would break.
-printf 'engine v2\n' >"$SHADOW_ROOT/main/.agents/skills/review-gate/engine.md"
-git -C "$SHADOW_ROOT/main" add -f .agents/skills/review-gate/engine.md
-git -C "$SHADOW_ROOT/main" commit -q -m 'refresh vendored engine'
-push_main "$SHADOW_ROOT"
+out_text() {
+  case "$1" in
+    -) printf '' ;;
+    wt) printf '<wt>' ;;
+    restored) printf 'Restored symlinks in <wt>' ;;
+    *) printf 'UNKNOWN-OUT-SPEC:%s' "$1" ;;
+  esac
+}
 
-set +e
-git -C "$WT" fetch -q origin
-merge_out="$(git -C "$WT" merge --no-edit origin/main 2>&1)"
-merge_status=$?
-[[ "$merge_status" -eq 0 ]] || printf 'merge output:\n%s\n' "$merge_out" >&2
-set -e
-assert_eq "$merge_status" "0" "a merge updating the tracked subtree succeeds"
-assert_eq "$(cat "$WT/.agents/skills/review-gate/engine.md")" "engine v2" "the merge wrote the tracked file"
-assert_symlink "$WT/.agents/state.json" "the per-child link survives the merge"
+err_text() {
+  case "$1" in
+    -) printf '' ;;
+    index-locked) printf '%s' "Warning: could not clear the assume-unchanged bit on tracked file(s) under '.agents' in <wt>\\; they may still be hidden from git writes.;Warning: could not restore tracked file '.agents/engine.md' under '.agents' in <wt> from the index\\; it may be missing.;Warning: skipping child linking under '.agents' in <wt> until the tracked restore above succeeds\\; re-run repair-links." ;;
+    *) printf 'UNKNOWN-ERR-SPEC:%s' "$1" ;;
+  esac
+}
 
-echo "=== re-running setup on the per-child layout is idempotent ==="
+SHADOW_V1='.agents=dir .agents/skills=dir .agents/skills/deep-research=link(<main>/.agents/skills/deep-research) .agents/skills/review-gate=dir .agents/skills/review-gate/engine.md=file:engine v1 .agents/state.json=link(<main>/.agents/state.json) assume=- status=-'
+SHADOW_V2="${SHADOW_V1/engine v1/engine v2}"
+IGNORING='.opencode=dir .opencode/.gitignore=file:bun.lock .opencode/agents=dir .opencode/agents/dev.md=file:agent .opencode/bun.lock=link(<main>/.opencode/bun.lock) assume=- status=-'
 
-set +e
-(cd "$SHADOW_ROOT/main" && "$WORKTREE_SCRIPT" fix-links "$WT") >/dev/null 2>"$SHADOW_ROOT/err2"
-fixlinks_status=$?
-set -e
-assert_eq "$fixlinks_status" "0" "fix-links succeeds on the per-child layout"
-assert_lacks "$(cat "$SHADOW_ROOT/err2")" "Warning" "fix-links stays quiet on the healthy per-child layout"
-assert_real "$WT/.agents/skills/review-gate/engine.md" "the tracked file is still a real file"
-assert_eq "$(cat "$WT/.agents/skills/review-gate/engine.md")" "engine v2" "the tracked content survives fix-links"
-assert_symlink "$WT/.agents/state.json" "the per-child link survives fix-links"
-assert_eq "$(git -C "$WT" status --porcelain)" "" "git status is clean after fix-links"
+# label|fixture|command|rc|out|err|layout
+ROWS="
+an entry shadowing a tracked subtree gets per-child links, not a parent link over assume-unchanged files|shadow|create topic|0|wt|-|$SHADOW_V1
+git can write the tracked subtree: a merge advancing the vendored file lands beside the links|shadow create advance|@merge|0|-|-|$SHADOW_V2
+fix-links on the per-child layout is idempotent and quiet|shadow create advance merge|fix-links @wt|0|restored|-|$SHADOW_V2
+a legacy parent link over tracked files heals to the per-child layout and clears the stale bit|shadow create advance merge legacy-link|fix-links @wt|0|restored|-|$SHADOW_V2
+a fully untracked entry keeps the plain parent symlink|untracked|create topic|0|wt|-|runtime=link(<main>/runtime) assume=- status=-
+a tracked leaf whose name git would quote stays a real file|quoted|create topic|0|wt|-|.agents=dir .agents/normal.md=file:a .agents/weird\"quote.md=file:q assume=- status=-
+a child tracked only on main is left absent, not linked over|anchored create late|repair-links @wt|0|-|-|.agents=dir .agents/skills=dir .agents/skills/anchor.md=file:anchor assume=- status=-
+the merge that introduces that child writes it as a real file|anchored create late|@merge|0|-|-|.agents=dir .agents/skills=dir .agents/skills/anchor.md=file:anchor .agents/skills/late.md=file:late assume=- status=-
+an entry tracked only on main so far takes the real-directory shape before the merge|predated create late|repair-links @wt|0|-|-|.agents=dir .agents/skills=dir .agents/skills/deep-research=link(<main>/.agents/skills/deep-research) .agents/state.json=link(<main>/.agents/state.json) assume=- status=-
+the merge into that shape writes the child beside the links|predated create late repair|@merge|0|-|-|.agents=dir .agents/skills=dir .agents/skills/deep-research=link(<main>/.agents/skills/deep-research) .agents/skills/late.md=file:late .agents/state.json=link(<main>/.agents/state.json) assume=- status=-
+an untracked .gitignore under a tracked-content entry is copied, and the worktree ignores what main ignores|ignoring|create topic|0|wt|-|$IGNORING
+push reads the copy as the expected shape, not a materialized link|ignoring create|push topic --no-rebase -u|0|-|-|$IGNORING
+the copy follows main on the next pass|ignoring create edit-ignore|fix-links @wt|0|restored|-|${IGNORING/file:bun.lock/file:node_modules\/}
+a legacy linked .gitignore heals to a copy|ignoring create legacy-ignore-link|fix-links @wt|0|restored|-|$IGNORING
+a worktree edit to the copy is overwritten by main's file|ignoring create edit-copy|fix-links @wt|0|restored|-|$IGNORING
+a locked index during the legacy heal reports failure, not a swallowed success|engine create legacy-link index-lock|repair-links @wt|1|-|index-locked|.agents=dir assume=.agents/engine.md status=-
+"
 
-echo "=== a legacy parent link over tracked files heals to the per-child layout ==="
+echo "=== the symlink layout under a tracked-content entry ==="
+n=0
+while IFS='|' read -r label fixture command rc out err want; do
+  [[ -n "$label$fixture$command$rc$out$err$want" ]] || continue
+  n=$((n + 1))
+  # shellcheck disable=SC2086
+  build "row-$n" $fixture
+  if [[ "$command" == @merge ]]; then
+    # git's own merge, run in the worktree; its report is git's, so the row
+    # pins its status and what it wrote.
+    merge_rc=0
+    (git -C "$WT" fetch -q origin && git -C "$WT" merge -q --no-edit origin/main >/dev/null 2>&1) || merge_rc=$?
+    got="rc=$merge_rc out= err= $(layout)"
+  else
+    got="$(run "$command")"
+  fi
+  if [[ "${PROBE:-}" == 1 ]]; then
+    printf '%s => %s\n' "$label" "$got"
+    continue
+  fi
+  assert_eq "$got" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want" "$label"
+done <<<"$ROWS"
 
-# Model a worktree provisioned with a parent symlink over the
-# entry, tracked files assume-unchanged and unwritable.
-rm -rf "$WT/.agents"
-ln -s "$SHADOW_ROOT/main/.agents" "$WT/.agents"
-git -C "$WT" update-index --assume-unchanged .agents/skills/review-gate/engine.md
-
-set +e
-(cd "$SHADOW_ROOT/main" && "$WORKTREE_SCRIPT" fix-links "$WT") >/dev/null 2>&1
-legacy_status=$?
-set -e
-assert_eq "$legacy_status" "0" "fix-links succeeds on the legacy parent-link layout"
-assert_real "$WT/.agents" "the legacy parent link became a real directory"
-assert_real "$WT/.agents/skills/review-gate/engine.md" "the shadowed tracked file was restored as a real file"
-assert_lacks "$(git -C "$WT" ls-files -v -- .agents/ | grep '^[a-z]' || true)" "engine.md" \
-  "the stale assume-unchanged bit was cleared"
-assert_symlink "$WT/.agents/state.json" "untracked children are linked after the heal"
-
-echo "=== a fully untracked entry keeps the plain parent symlink ==="
-
-CLEAN_ROOT="$TMP_ROOT/clean"
-make_repo "$CLEAN_ROOT"
-mkdir -p "$CLEAN_ROOT/main/runtime"
-printf 'runtime/\n' >"$CLEAN_ROOT/main/.gitignore"
-printf 'state\n' >"$CLEAN_ROOT/main/runtime/state.json"
-printf 'WORKTREE_SYMLINKS="runtime"\n' >"$CLEAN_ROOT/main/.env.local"
-git -C "$CLEAN_ROOT/main" add .gitignore
-git -C "$CLEAN_ROOT/main" commit -q -m runtime
-push_main "$CLEAN_ROOT"
-
-set +e
-CLEAN_WT="$( (cd "$CLEAN_ROOT/main" && "$WORKTREE_SCRIPT" create clean-check) 2>"$CLEAN_ROOT/err" )"
-clean_status=$?
-set -e
-
-assert_eq "$clean_status" "0" "create succeeds for the untracked entry"
-assert_symlink "$CLEAN_WT/runtime" "an entry with no tracked files is still one parent symlink"
-assert_lacks "$(cat "$CLEAN_ROOT/err")" "shadows" "no warning when the entry tracks nothing"
-
-echo "=== a tracked leaf name containing a quote is not turned into a link (#875) ==="
-
-# git's default (non -z) ls-files output quotes names with special bytes, so
-# comparing that display form against the raw filesystem name misclassifies
-# a tracked leaf as untracked and replaces it with a symlink.
-QUOTE_ROOT="$TMP_ROOT/quote"
-make_repo "$QUOTE_ROOT"
-mkdir -p "$QUOTE_ROOT/main/.agents"
-printf 'a\n' >"$QUOTE_ROOT/main/.agents/normal.md"
-printf 'q\n' >"$QUOTE_ROOT/main/.agents/weird\"quote.md"
-printf 'WORKTREE_SYMLINKS=".agents"\n' >"$QUOTE_ROOT/main/.env.local"
-git -C "$QUOTE_ROOT/main" add .agents
-git -C "$QUOTE_ROOT/main" commit -q -m quoted
-push_main "$QUOTE_ROOT"
-
-set +e
-QUOTE_WT="$( (cd "$QUOTE_ROOT/main" && "$WORKTREE_SCRIPT" create quote-check) 2>"$QUOTE_ROOT/err" )"
-quote_status=$?
-set -e
-
-assert_eq "$quote_status" "0" "create succeeds for the quoted-name entry"
-assert_real "$QUOTE_WT/.agents/weird\"quote.md" "the quoted tracked leaf stays a real file, not a link"
-assert_eq "$(cat "$QUOTE_WT/.agents/weird\"quote.md")" "q" "the quoted tracked leaf has the branch's content"
-
-echo "=== a child tracked only on main (branch predates it) is not linked over (#964) ==="
-
-# Top-level provisioning already checks both indexes for the parent's shape;
-# this proves the per-child walk inside a shadowed entry does the same, so a
-# path that only main tracks so far is left to the eventual merge instead of
-# being symlinked out from under it.
-PREDATE_ROOT="$TMP_ROOT/predate"
-make_repo "$PREDATE_ROOT"
-mkdir -p "$PREDATE_ROOT/main/.agents/skills"
-printf 'anchor\n' >"$PREDATE_ROOT/main/.agents/skills/anchor.md"
-printf 'WORKTREE_SYMLINKS=".agents"\n' >"$PREDATE_ROOT/main/.env.local"
-git -C "$PREDATE_ROOT/main" add .agents/skills/anchor.md
-git -C "$PREDATE_ROOT/main" commit -q -m anchor
-push_main "$PREDATE_ROOT"
-
-set +e
-PREDATE_WT="$( (cd "$PREDATE_ROOT/main" && "$WORKTREE_SCRIPT" create predate-check) 2>"$PREDATE_ROOT/err" )"
-predate_status=$?
-set -e
-assert_eq "$predate_status" "0" "create succeeds before the new child is tracked"
-
-# Advance MAIN only: a file lands under the shadowed entry and becomes
-# tracked there, but the worktree branch does not have it yet.
-printf 'late\n' >"$PREDATE_ROOT/main/.agents/skills/late.md"
-git -C "$PREDATE_ROOT/main" add .agents/skills/late.md
-git -C "$PREDATE_ROOT/main" commit -q -m late
-push_main "$PREDATE_ROOT"
-
-set +e
-(cd "$PREDATE_ROOT/main" && "$WORKTREE_SCRIPT" repair-links "$PREDATE_WT") >/dev/null 2>"$PREDATE_ROOT/err2"
-predate_repair_status=$?
-set -e
-assert_eq "$predate_repair_status" "0" "repair-links succeeds while the child is main-only"
-
-if [[ ! -e "$PREDATE_WT/.agents/skills/late.md" && ! -L "$PREDATE_WT/.agents/skills/late.md" ]]; then
-  assert_ok "a child tracked only on main is left absent, not symlinked"
-else
-  assert_fail "a child tracked only on main is left absent, not symlinked" \
-    "found: $(ls -la "$PREDATE_WT/.agents/skills/late.md" 2>&1)"
-fi
-
-set +e
-git -C "$PREDATE_WT" fetch -q origin
-merge_out2="$(git -C "$PREDATE_WT" merge --no-edit origin/main 2>&1)"
-merge_status2=$?
-[[ "$merge_status2" -eq 0 ]] || printf 'merge output:\n%s\n' "$merge_out2" >&2
-set -e
-assert_eq "$merge_status2" "0" "the merge that introduces the tracked child succeeds"
-assert_real "$PREDATE_WT/.agents/skills/late.md" "the merge wrote the newly-tracked child as a real file"
-
-echo "=== an untracked .gitignore under a tracked-content entry is copied, not linked (KEN-685) ==="
-
-# Git refuses to read .gitignore through a symlink, so a linked one applies
-# none of its rules in the worktree and prints "unable to access" on every
-# command. drovr's shape: `.opencode/agents` is tracked, `.opencode/.gitignore`
-# is untracked and ignores bun.lock. It does NOT ignore itself: the copy in the
-# worktree is kept out of `git status` only by the info/exclude entry setup
-# writes for it, so the status assertions below prove that entry too.
-IGN_ROOT="$TMP_ROOT/ignore"
-make_repo "$IGN_ROOT"
-mkdir -p "$IGN_ROOT/main/.opencode/agents"
-printf 'agent\n' >"$IGN_ROOT/main/.opencode/agents/dev.md"
-printf 'bun.lock\n' >"$IGN_ROOT/main/.opencode/.gitignore"
-printf 'lock\n' >"$IGN_ROOT/main/.opencode/bun.lock"
-printf 'WORKTREE_SYMLINKS=".opencode"\n' >"$IGN_ROOT/main/.env.local"
-git -C "$IGN_ROOT/main" add .opencode/agents/dev.md
-git -C "$IGN_ROOT/main" commit -q -m 'track opencode agents'
-push_main "$IGN_ROOT"
-assert_eq "$(git -C "$IGN_ROOT/main" status --porcelain -- .opencode/bun.lock)" "" "main ignores bun.lock through the untracked .gitignore"
-assert_eq "$(git -C "$IGN_ROOT/main" status --porcelain -- .opencode)" "?? .opencode/.gitignore" "main's .gitignore is untracked and does not hide itself"
-
-set +e
-IGN_WT="$( (cd "$IGN_ROOT/main" && "$WORKTREE_SCRIPT" create ignore-check) 2>"$IGN_ROOT/err" )"
-ign_status=$?
-set -e
-assert_eq "$ign_status" "0" "create succeeds for the entry holding an untracked .gitignore"
-[[ -n "$IGN_WT" && -d "$IGN_WT" ]] || { echo "FATAL: worktree not created: $(cat "$IGN_ROOT/err")"; exit 1; }
-
-assert_real "$IGN_WT/.opencode/.gitignore" "the .gitignore is a real file in the worktree, not a link"
-assert_eq "$(cat "$IGN_WT/.opencode/.gitignore")" "$(cat "$IGN_ROOT/main/.opencode/.gitignore")" "the copy has main's content"
-assert_real "$IGN_WT/.opencode/agents/dev.md" "the tracked file beside it stays a real file"
-
-# The proof: the worktree ignores what main ignores, and git stops complaining.
-printf 'lock\n' >"$IGN_WT/.opencode/bun.lock"
-assert_eq "$(git -C "$IGN_WT" status --porcelain 2>&1)" "" "bun.lock is ignored in the worktree"
-assert_lacks "$(git -C "$IGN_WT" status 2>&1)" "unable to access" "git prints no ignore-file access warning"
-
-# push is the one command that runs the materialization detector; the copy
-# must read as the expected shape there, not as a real path where a link belongs.
-set +e
-(cd "$IGN_ROOT/main" && "$WORKTREE_SCRIPT" push ignore-check --no-rebase -u) >/dev/null 2>"$IGN_ROOT/perr"
-ign_push_status=$?
-set -e
-assert_eq "$ign_push_status" "0" "push succeeds from the worktree holding the copy"
-assert_lacks "$(cat "$IGN_ROOT/perr")" "harness paths in this worktree" "push does not report the copy as a materialized link"
-
-echo "=== the .gitignore copy follows main on the next pass, and a legacy link heals to a copy ==="
-
-printf 'bun.lock\nnode_modules/\n' >"$IGN_ROOT/main/.opencode/.gitignore"
-set +e
-(cd "$IGN_ROOT/main" && "$WORKTREE_SCRIPT" fix-links "$IGN_WT") >/dev/null 2>"$IGN_ROOT/err2"
-ign_fix_status=$?
-set -e
-assert_eq "$ign_fix_status" "0" "fix-links succeeds after main's .gitignore changed"
-assert_lacks "$(cat "$IGN_ROOT/err2")" "Warning" "fix-links stays quiet while re-copying"
-assert_eq "$(cat "$IGN_WT/.opencode/.gitignore")" "$(cat "$IGN_ROOT/main/.opencode/.gitignore")" "the copy picked up main's change"
-
-# A worktree provisioned by the older skill holds a link where the copy belongs.
-rm -f "$IGN_WT/.opencode/.gitignore"
-ln -s "$IGN_ROOT/main/.opencode/.gitignore" "$IGN_WT/.opencode/.gitignore"
-set +e
-(cd "$IGN_ROOT/main" && "$WORKTREE_SCRIPT" fix-links "$IGN_WT") >/dev/null 2>"$IGN_ROOT/err3"
-ign_legacy_status=$?
-set -e
-assert_eq "$ign_legacy_status" "0" "fix-links succeeds on a legacy linked .gitignore"
-assert_real "$IGN_WT/.opencode/.gitignore" "the legacy link became a copy"
-assert_eq "$(git -C "$IGN_WT" status --porcelain 2>&1)" "" "the healed worktree ignores bun.lock again"
-
-# fix-links judges the copy's content: a worktree edit is drift it closes.
-printf 'edited\n' >"$IGN_WT/.opencode/.gitignore"
-set +e
-(cd "$IGN_ROOT/main" && "$WORKTREE_SCRIPT" fix-links "$IGN_WT") >/dev/null 2>&1
-set -e
-assert_eq "$(cat "$IGN_WT/.opencode/.gitignore")" "$(cat "$IGN_ROOT/main/.opencode/.gitignore")" "a worktree edit to the copy is overwritten by main's file"
-
-echo "=== a locked index during legacy heal reports failure, not a swallowed success (#850) ==="
-
-# The old code discarded failures from --no-assume-unchanged and the missing-
-# file checkout with `|| true`, so a locked index or unwritable destination
-# left tracked paths missing/unwritable while the heal still reported success.
-LOCK_ROOT="$TMP_ROOT/lock"
-make_repo "$LOCK_ROOT"
-mkdir -p "$LOCK_ROOT/main/.agents"
-printf 'engine\n' >"$LOCK_ROOT/main/.agents/engine.md"
-printf 'WORKTREE_SYMLINKS=".agents"\n' >"$LOCK_ROOT/main/.env.local"
-git -C "$LOCK_ROOT/main" add .agents/engine.md
-git -C "$LOCK_ROOT/main" commit -q -m engine
-push_main "$LOCK_ROOT"
-
-set +e
-LOCK_WT="$( (cd "$LOCK_ROOT/main" && "$WORKTREE_SCRIPT" create lock-check) 2>"$LOCK_ROOT/err" )"
-lock_status=$?
-set -e
-assert_eq "$lock_status" "0" "create succeeds for the lock scenario"
-
-# Model the legacy parent-link state once more so the shadowed-restore path
-# (clear assume-unchanged, checkout missing tracked files) actually runs.
-rm -rf "$LOCK_WT/.agents"
-ln -s "$LOCK_ROOT/main/.agents" "$LOCK_WT/.agents"
-git -C "$LOCK_WT" update-index --assume-unchanged .agents/engine.md
-
-LOCKFILE="$(git -C "$LOCK_WT" rev-parse --git-path index.lock)"
-: >"$LOCKFILE"
-
-set +e
-lock_out="$(cd "$LOCK_ROOT/main" && "$WORKTREE_SCRIPT" repair-links "$LOCK_WT" 2>&1)"
-lock_repair_status=$?
-set -e
-rm -f "$LOCKFILE"
-
-if [[ "$lock_repair_status" -ne 0 ]]; then
-  assert_ok "a locked index makes the heal report failure instead of success"
-else
-  assert_fail "a locked index makes the heal report failure instead of success" "exit status was 0: $lock_out"
-fi
-if grep -qF -- "could not" <<<"$lock_out"; then
-  assert_ok "the failure names what could not be healed"
-else
-  assert_fail "the failure names what could not be healed" "output: $lock_out"
-fi
-
-printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Reshapes `skills/worktree/tests/worktree_symlink_shadows_tracked.sh` to code-quality § Tests. The file pinned the per-child symlink layout under a `WORKTREE_SYMLINKS` entry with tracked content (the shadowing fix, the legacy heal, the `.gitignore` copy, the main-only child) in nine long-lived scenarios of path-kind, substring and status checks. Those are now one table of 16 rows: a row shapes the entry on main from a word list of steps (`shadow untracked quoted anchored predated ignoring engine`, then `create advance merge legacy-link late repair edit-ignore legacy-ignore-link edit-copy index-lock`), runs one command from the main checkout (or git's own merge in the worktree, `@merge`), and pins the exit status, stdout, stderr whole and the layout under the entry: every path found under it as `dir`, `file:<first line>` or `link(<target>)`, then the assume-unchanged paths of the whole worktree and git's porcelain status with its stderr. The layout is compared as one string, so an extra, missing or reshaped path reddens the row; absence is pinned, not left unasserted.

Two rows are new, pinning the promise at `link_tracked_content`'s directory branch (ask both indexes; a branch that predates the commit tracking the path reserves the real-directory shape before the merge lands): an entry tracked only on main so far takes the real-directory shape before the merge, and that merge writes the child beside the links.

The `merge` fixture step fails as a fixture (`FIXTURE:` line, exit 2) rather than dying under `set -e` with git's raw error, so a mutant that breaks the shadowing fix reports the rows it reddened before the fixture stops the run.

The tracked render under `.agents` is replayed with `patch`.

## Folded or deleted cases, with the surviving row

| Former assertions | Surviving row |
|---|---|
| create succeeds; the entry and the mixed subtree are real directories; the tracked file is real with the branch's content; the untracked children are links resolving to main; no assume-unchanged bit; no assume-unchanged advice; status clean | `an entry shadowing a tracked subtree gets per-child links, not a parent link over assume-unchanged files` (the whole layout, `assume=- status=-`, `err=-`) |
| a merge updating the tracked subtree succeeds; wrote the tracked file; the per-child link survives | `git can write the tracked subtree: a merge advancing the vendored file lands beside the links` (`engine v2` in the layout) |
| fix-links succeeds on the per-child layout; stays quiet; the tracked file still real with its content; the link survives; status clean | `fix-links on the per-child layout is idempotent and quiet` (`out=restored err=-`) |
| fix-links succeeds on the legacy parent link; the link became a real directory; the shadowed file restored; no assume-unchanged bit; the untracked children linked | `a legacy parent link over tracked files heals to the per-child layout and clears the stale bit` |
| create succeeds for the untracked entry; one parent symlink; no shadowing warning | `a fully untracked entry keeps the plain parent symlink` |
| create succeeds for the quoted name; the quoted leaf is a real file with the branch's content (#875) | `a tracked leaf whose name git would quote stays a real file` |
| create succeeds before the child is tracked; repair-links succeeds while the child is main-only; the child neither exists nor is a link (#964) | `a child tracked only on main is left absent, not linked over` (the create is a fixture step; the layout lists every path, so a linked child reddens it) |
| the merge introducing the child succeeds; wrote it as a real file | `the merge that introduces that child writes it as a real file` |
| (new) | `an entry tracked only on main so far takes the real-directory shape before the merge` and `the merge into that shape writes the child beside the links` |
| main ignores bun.lock through the untracked .gitignore; main's .gitignore is untracked | deleted: fixture premises about main, not the worktree; the fixture mutant `f-ignoring-tracks-gitignore` (the .gitignore committed) reddens three rows |
| create succeeds for the entry holding an untracked .gitignore; the copy is a real file with main's content; the tracked file beside it real; bun.lock ignored in the worktree; no ignore-file access warning (KEN-685) | `an untracked .gitignore under a tracked-content entry is copied, and the worktree ignores what main ignores` (`status=` carries git's stderr too) |
| push succeeds from the worktree holding the copy; does not report the copy as a materialized link | `push reads the copy as the expected shape, not a materialized link` (`err=-`) |
| fix-links succeeds after main's .gitignore changed; stays quiet; the copy picked up the change | `the copy follows main on the next pass` (`file:node_modules/`, and `status=-` only if the new pattern is honoured) |
| fix-links succeeds on a legacy linked .gitignore; the link became a copy; the healed worktree ignores bun.lock | `a legacy linked .gitignore heals to a copy` |
| a worktree edit to the copy is overwritten by main's file | `a worktree edit to the copy is overwritten by main's file` |
| create succeeds for the lock scenario; a locked index makes the heal report failure; the failure names what could not be healed | `a locked index during the legacy heal reports failure, not a swallowed success` (`rc=1`, the three diagnostic sentences whole, `assume=.agents/engine.md` left standing) |

The copy's whole-content comparison narrowed to the first line; the reviewer mutated the copy two ways (truncated to one line, reversed) and the `copy follows main` row reddens on both, through `status=` and `file:`.

## Mutation

Thirty-one must-fail mutants over a scratch copy of `skills/worktree` (`mutants-ss-3.txt` in the lane scratchpad; `mutate-ss.py` makes them), twenty-nine killed: a parent link laid over the tracked subtree, the parent's and the children's both-index test reduced to one index, a tracked leaf linked, a mixed child linked, classification by git's display form, the heal keeping the assume bit or skipping the restore, a failed restore swallowed, the .gitignore linked, the copy never refreshed, the legacy .gitignore link kept, an untracked entry materialized, fix-links silent, create silent (the reviewer's; the `out=` column), push's materialization detector blind to the copy (isolates the push row), the drift policy inverted (isolates the worktree-edit row), the copy left out of the worktree's exclude file (the `status=` column); and thirteen fixture mutants (each damage step made a no-op, the shadow entry tracking nothing, the merge made linear, the quoted name made plain, the late child tracked early). Two survive by design and are recorded as such: the legacy-ignore-link and edit-copy fixture no-ops leave the healthy layout, which equals the healed one, and each of those rows has a script mutant that isolates it. Two runs abort at the shadow rows' merge fixture (the mutants that break the shadowing fix); the reviewer re-ran one of them with the shadow rows trimmed and found it reddens four more rows than its recorded list.

## Checks

- `worktree_symlink_shadows_tracked.sh`: 16 assertions, TMPDIR=/var/tmp/ken-c; `shellcheck` clean; `tools/bash32-lint skills/worktree` clean.
- `tools/guard --full`: exit 0 (TMPDIR=/var/tmp/ken-c).
- One reviewer-test round: accept with fixes, both applied (the merge step as a fixture failure; the assume-unchanged grep guarded under pipefail as the old file had it); its four isolating mutants folded into the battery.

KEN-1241

https://claude.ai/code/session_01T2QoxigYxjmFEdbSaQXtmR
