### PR TITLE
test(KEN-1241): the changelog fold as one table of rows

### DIFF
--- a/.agents/skills/commit-guards/tests/changelog-collate.test.sh
+++ b/.agents/skills/commit-guards/tests/changelog-collate.test.sh
@@ -54,13 +54,20 @@ run() { # ENVS SHIM
   printf 'rc=%s%s' "$rc" "${out:+ $(printf '%s\n' "$out" | LC_ALL=C paste -sd ';' -)}"
 }
 # The record after the run: the name of the text it equals byte for byte
-# (SEED is what the fixture committed), or a diff against the one the row
-# named. cmp, not a substitution: that would drop a trailing blank line.
+# (SEED is the file the fixture committed, kept beside the repository since
+# a shell variable cannot hold every byte a record can), or a diff against
+# the one the row named. cmp, not a substitution: that would drop a trailing
+# blank line.
 record() { # NAME
-  if cmp -s <(printf '%s' "${!1}") "$R/CHANGELOG.md"; then printf '%s' "$1"; else diff <(printf '%s' "${!1}") "$R/CHANGELOG.md" || true; fi
+  local want="$R.seed"
+  [ "$1" = SEED ] || want="$TMP/want-$1"
+  [ "$1" = SEED ] || printf '%s' "${!1}" >"$want"
+  if cmp -s "$want" "$R/CHANGELOG.md"; then printf '%s' "$1"; else diff "$want" "$R/CHANGELOG.md" || true; fi
 }
 # What is left under the fragment tree, sorted and joined by '~', with any
-# staging file beside the record; '-' when nothing.
+# staging file beside the record; '-' when nothing. Line-oriented, so a path
+# carrying a newline is shown as two: the one row with such a path leaves
+# nothing behind.
 left() {
   local out
   out="$(cd "$R" && { find changelog.d -mindepth 1 2>/dev/null; ls -d CHANGELOG.md.* 2>/dev/null; } | LC_ALL=C sort | LC_ALL=C paste -sd '~' -)"
@@ -83,7 +90,6 @@ RECORD='# Changelog
 
 - A released entry.
 '
-SEED=""
 repo() { # NAME [RECORD]
   R="$TMP/$1"
   [ ! -e "$R" ] || { echo "harness: fixture $1 already exists" >&2; exit 2; }
@@ -91,12 +97,13 @@ repo() { # NAME [RECORD]
   git -C "$R" -c init.defaultBranch=main init -q
   git -C "$R" config user.email test@example.com
   git -C "$R" config user.name test
-  SEED="${2:-$RECORD}"
-  printf '%s' "$SEED" >"$R/CHANGELOG.md"
+  printf '%s' "${2:-$RECORD}" >"$R/CHANGELOG.md"
   printf 'Release input.\n' >"$R/release-input.txt"
+  reseed
   git -C "$R" add -A
   git -C "$R" commit -qm 'chore: seed'
 }
+reseed() { cp -- "$R/CHANGELOG.md" "$R.seed"; } # the record as it stands is the row's SEED
 frag() { mkdir -p "$R/changelog.d/$1"; printf '%b' "$3" >"$R/changelog.d/$1/$2"; git -C "$R" add -A -- changelog.d; git -C "$R" commit -qm 'chore: prepare release input'; } # SECTION NAME CONTENT (printf %b)
 pending() { repo "$1"; frag fixed pending.md '- Folded in.\n'; } # NAME — one fragment, ready to fold
 shim() { mkdir -p "$TMP/shim-$1"; printf '%b' "$2" >"$TMP/shim-$1/$1"; chmod +x "$TMP/shim-$1/$1"; } # NAME BODY
@@ -178,6 +185,10 @@ fx_two_headings() { repo two-headings "$(printf '%s\n## [Unreleased]\n' "$RECORD
 fx_open_fence() { repo open-fence "$(printf '%s\n```\nopen\n' "$RECORD")"; frag fixed pending.md '- Folded in.\n'; }
 fx_untracked_record() { repo untracked-record; git -C "$R" rm -q --cached CHANGELOG.md; printf '/CHANGELOG.md\n' >"$R/.gitignore"; git -C "$R" add .gitignore; git -C "$R" commit -qm 'chore: untrack'; frag fixed pending.md '- Folded in.\n'; }
 fx_scope_off() { pending scope-off; }
+fx_symlink_record() { pending symlink-record; mv "$R/CHANGELOG.md" "$R/real.md"; ln -s real.md "$R/CHANGELOG.md"; git -C "$R" add -A; git -C "$R" commit -qm 'chore: link'; }
+# A NUL in the record: written with printf's own escape, since no shell
+# variable carries the byte.
+fx_nul_record() { pending nul-record; printf '%s\0' "$RECORD" >"$R/CHANGELOG.md"; reseed; git -C "$R" add -A; git -C "$R" commit -qm 'chore: nul'; }
 fx_bad_beside() { pending bad-beside; frag fixed bad.md 'Prose, not a list item.\n'; }
 run_rows \
   "a heading that is not a section refuses, naming it and the sections|fx_misspelled|||rc=1 $(refused "names 'Add' under [Unreleased], which is not a Keep a Changelog section" "section one of: $SECTIONS")|SEED|$ONE" \
@@ -186,6 +197,8 @@ run_rows \
   "an unclosed fence is the same class|fx_open_fence|||rc=2 ${ERR}CHANGELOG.md leaves a code fence unclosed — the [Unreleased] section cannot be located|SEED|$ONE" \
   "a record git does not track is refused: nothing measured it|fx_untracked_record|||rc=2 ${ERR}CHANGELOG.md is not tracked; commit the collation destination first|SEED|$ONE" \
   "the record scope off leaves the fold nowhere to write|fx_scope_off|COMMIT_GUARDS_CHANGELOG_RECORD=||rc=2 ${ERR}no collation destination: COMMIT_GUARDS_CHANGELOG_RECORD is empty|SEED|$ONE" \
+  "a record tracked as a symlink is not a destination|fx_symlink_record|||rc=2 ${ERR}CHANGELOG.md is not a regular collation destination|SEED|$ONE" \
+  "a record carrying a NUL is binary, not a destination|fx_nul_record|||rc=2 ${ERR}CHANGELOG.md holds binary content; collation needs text|SEED|$ONE" \
   "a fragment the judge refuses stops the run as its own refusal, and the acceptable one beside it is neither folded nor deleted|fx_bad_beside|||rc=1 changelog-entries FAIL changelog.d/fixed/bad.md does not open with a list marker — a fragment is the Markdown list item it becomes, opening with a hyphen and a space;changelog-entries: 1 violation(s) — cap 200 characters, 1 fragment(s) measured|SEED|changelog.d/fixed~changelog.d/fixed/bad.md~changelog.d/fixed/pending.md"
 
 echo "=== every guarantee of the fold, on one record and one exact expected output ==="
@@ -342,18 +355,20 @@ TAIL_OUT='# Changelog
 fx_tail() { repo tail "$TAIL_IN"; frag added ken-1.md '- Folded in at the end of the file.\n'; }
 fx_newline_name() { repo newline-name; frag fixed $'a\nb.md' '- Folded in.\n'; }
 fx_readme() { repo readme; mkdir -p "$R/changelog.d"; printf 'The format.\n' >"$R/changelog.d/README.md"; git -C "$R" add -A; git -C "$R" commit -qm 'chore: readme'; frag fixed pending.md '- Folded in.\n'; }
-fx_nothing() { repo nothing; }
+fx_nothing() { repo nothing "$(printf '%s' "$RECORD" | sed 's/^## \[Unreleased\]$/## Unreleased/')"; }
 fx_mv_fails() { pending mv-fails; }
-fx_rm_fails() { pending rm-fails; }
+fx_rm_fails() { pending rm-fails; frag fixed 'a b.md' '- Folded in, first by filename.\n'; }
+FOLDED2="${FOLDED/- Folded in./- Folded in, first by filename.
+- Folded in.}"
 run_rows \
   "every section in Keep a Changelog order, filename order within one, two headings collapsed, the lead trimmed, a newline-less fragment normalized|fx_all|||rc=0 $(folded 7 entries)|ALL_OUT|-" \
   "a heading further down is split at its own line numbers, losing no preamble|fx_moved|||rc=0 $(folded 1 entry)|MOVED_OUT|-" \
   "a section that ends with the file is folded into with no separator after it|fx_tail|||rc=0 $(folded 1 entry)|TAIL_OUT|-" \
   "a fragment whose name carries a newline is folded in and removed like any other|fx_newline_name|||rc=0 $(folded 1 entry)|FOLDED|-" \
   "the format's README is neither folded nor swept, and its directory stays|fx_readme|||rc=0 $(folded 1 entry)|FOLDED|changelog.d/README.md" \
-  "nothing to fold is a stated no-op|fx_nothing|||rc=0 changelog-entries: no fragments — nothing to collate|SEED|-" \
+  "nothing to fold is a stated no-op that reads no destination: a record with no heading passes|fx_nothing|||rc=0 changelog-entries: no fragments — nothing to collate|SEED|-" \
   "a rename that fails is a loud refusal carrying what mv said, the record byte-identical, no staging file, the fragment kept|fx_mv_fails||mv|rc=2 ${ERR}could not replace the collated changelog at CHANGELOG.md (mv: refused by the test stub) — inspect the file before trusting it|SEED|$ONE" \
-  "a fragment that survives its delete is named, after the record was replaced|fx_rm_fails||rm|rc=2 rm: refused by the test stub;${ERR}CHANGELOG.md is collated, but these fragments survived and would fold in a second time — delete them by hand:;  changelog.d/fixed/pending.md|FOLDED|$ONE"
+  "every fragment that survives its delete is named, escaped, after the record was replaced|fx_rm_fails||rm|rc=2 rm: refused by the test stub;rm: refused by the test stub;${ERR}CHANGELOG.md is collated, but these fragments survived and would fold in a second time — delete them by hand:;  changelog.d/fixed/a\\ b.md;  changelog.d/fixed/pending.md|FOLDED2|changelog.d/fixed~changelog.d/fixed/a b.md~changelog.d/fixed/pending.md"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.agents/skills/commit-guards/tests/changelog-collate.test.sh
+++ b/.agents/skills/commit-guards/tests/changelog-collate.test.sh
@@ -1,72 +1,74 @@
 #!/usr/bin/env bash
-# Pins the WRITE path of scripts/changelog-entries --collate: it folds the
-# fragments this run accepted into the record's [Unreleased] section, under
-# the heading each fragment's own section names, in Keep a Changelog order and
-# filename order within a section; it splits the record at the line numbers
-# the committed copy was accepted with, collapses two headings for one section
-# into one, deletes the fragments and the section directory each leaves empty,
-# and refuses without writing when the judgement refuses, the index or working
-# tree has pending changes, or the release flag is absent. The refusing
-# direction runs first in every pair, and each refusal is checked to have left
-# the record and the fragments as they were — a fold that half-writes or
-# half-deletes is the failure this guards.
+# Pins for the WRITE path of scripts/changelog-entries --collate
+# (lib/changelog-collate.sh over lib/changelog-record-scope.sh and
+# lib/atomic-install.sh): it folds the fragments this run accepted into the
+# record's [Unreleased] section under the heading each fragment's section
+# names, in Keep a Changelog order and filename order within a section,
+# splits the record at the line numbers the committed copy was accepted
+# with, collapses two headings for one section into one, deletes the
+# fragments and the section directory each leaves empty, and refuses
+# without writing when the judgement refuses, the record's shape cannot be
+# folded into, the index or working tree has pending changes, or the
+# release flag is absent. One table: a row builds its own repository, runs
+# the fold and reads back the exit status with every line printed, then
+# the record (the seed it was, or the exact folded text) and what is left
+# under the fragment tree beside any staging file. The judgement's own
+# lines are changelog-entries.test.sh's; here they ride along where the
+# fold carries them as its own refusal.
 set -euo pipefail
-
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CE="$(cd "$TEST_DIR/.." && pwd)/scripts/changelog-entries"
 # shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
-
-unset COMMIT_GUARDS_CHANGELOG_CAP COMMIT_GUARDS_CHANGELOG_PATHS \
-  COMMIT_GUARDS_CHANGELOG_RECORD COMMIT_GUARDS_CHANGELOG_COLLATE \
-  COMMIT_GUARDS_SETTINGS_FILE 2>/dev/null || true
-
-export COMMIT_GUARDS_CHANGELOG_COLLATE=1
+unset COMMIT_GUARDS_CHANGELOG_CAP COMMIT_GUARDS_CHANGELOG_PATHS COMMIT_GUARDS_CHANGELOG_RECORD \
+  COMMIT_GUARDS_CHANGELOG_COLLATE COMMIT_GUARDS_SETTINGS_FILE 2>/dev/null || true
 
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
-
-R="$TMP/repo"
-mkdir -p "$R"
-git -C "$R" -c init.defaultBranch=main init -q
-git -C "$R" config user.email test@example.com
-git -C "$R" config user.name test
-
-reset() { # RECORD on stdin — the fixture record and an empty tree, committed
-  rm -rf -- "${R:?}/changelog.d"
-  cat >"$R/CHANGELOG.md"
-  printf 'Release input.\n' >"$R/release-input.txt"
-  git -C "$R" add -A
-  # Each case starts from a committed fixture with a clean index.
-  git -C "$R" commit -q --allow-empty -m "chore: reset the fixture"
-  cp "$R/CHANGELOG.md" "$TMP/before"
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
 }
 
-stage_record() { # RECORD on stdin — staged over the committed one, not committed
-  cat >"$R/CHANGELOG.md"
-  git -C "$R" add -A -- CHANGELOG.md
-  cp "$R/CHANGELOG.md" "$TMP/before"
+# One line for a fold in the row's repository: the exit status, then every
+# line printed, in order, joined by ';'. The release flag is set unless the
+# row's ENVS (a comma-separated list of assignments; -u,NAME unsets, and
+# comes first) names it; SHIM names a directory of stand-in tools put ahead
+# of PATH.
+R=""
+run() { # ENVS SHIM
+  local envs=() rc=0 out="" path="$PATH"
+  [ -z "$1" ] || IFS=',' read -ra envs <<<"$1"
+  case ",$1," in
+    *,COMMIT_GUARDS_CHANGELOG_COLLATE,* | *,COMMIT_GUARDS_CHANGELOG_COLLATE=*) ;;
+    *) envs+=(COMMIT_GUARDS_CHANGELOG_COLLATE=1) ;;
+  esac
+  [ -z "$2" ] || path="$TMP/shim-$2:$PATH"
+  # shellcheck disable=SC2086
+  out="$(cd "$R" && env ${envs[@]+"${envs[@]}"} PATH="$path" "$CE" --collate 2>&1)" || rc=$?
+  printf 'rc=%s%s' "$rc" "${out:+ $(printf '%s\n' "$out" | LC_ALL=C paste -sd ';' -)}"
+}
+# The record after the run: the name of the text it equals byte for byte
+# (SEED is what the fixture committed), or a diff against the one the row
+# named. cmp, not a substitution: that would drop a trailing blank line.
+record() { # NAME
+  if cmp -s <(printf '%s' "${!1}") "$R/CHANGELOG.md"; then printf '%s' "$1"; else diff <(printf '%s' "${!1}") "$R/CHANGELOG.md" || true; fi
+}
+# What is left under the fragment tree, sorted and joined by '~', with any
+# staging file beside the record; '-' when nothing.
+left() {
+  local out
+  out="$(cd "$R" && { find changelog.d -mindepth 1 2>/dev/null; ls -d CHANGELOG.md.* 2>/dev/null; } | LC_ALL=C sort | LC_ALL=C paste -sd '~' -)"
+  printf '%s' "${out:--}"
 }
 
-frag() { # SECTION NAME: content on stdin, written and committed
-  mkdir -p "$R/changelog.d/$1"
-  cat >"$R/changelog.d/$1/$2"
-  git -C "$R" add -A -- changelog.d
-  git -C "$R" commit -qm "chore: prepare release input"
-}
-
-run_collate() { OUT=""; RC=0; OUT="$(cd "$R" && "$CE" --collate 2>&1)" || RC=$?; }
-untouched() { cmp -s "$R/CHANGELOG.md" "$TMP/before"; }
-no_staging() { # no residue beside the record, whatever mktemp named it
-  STAGING=""
-  for f in "$R"/CHANGELOG.md.*; do
-    [ ! -e "$f" ] || STAGING="$STAGING $f"
-  done
-  [ -z "$STAGING" ]
-}
-
+# Fixture vocabulary. Every fixture builds its own repository, the record
+# and one release input committed; a name used twice is refused.
 RECORD='# Changelog
 
 ## [Unreleased]
@@ -81,101 +83,118 @@ RECORD='# Changelog
 
 - A released entry.
 '
+SEED=""
+repo() { # NAME [RECORD]
+  R="$TMP/$1"
+  [ ! -e "$R" ] || { echo "harness: fixture $1 already exists" >&2; exit 2; }
+  mkdir -p "$R"
+  git -C "$R" -c init.defaultBranch=main init -q
+  git -C "$R" config user.email test@example.com
+  git -C "$R" config user.name test
+  SEED="${2:-$RECORD}"
+  printf '%s' "$SEED" >"$R/CHANGELOG.md"
+  printf 'Release input.\n' >"$R/release-input.txt"
+  git -C "$R" add -A
+  git -C "$R" commit -qm 'chore: seed'
+}
+frag() { mkdir -p "$R/changelog.d/$1"; printf '%b' "$3" >"$R/changelog.d/$1/$2"; git -C "$R" add -A -- changelog.d; git -C "$R" commit -qm 'chore: prepare release input'; } # SECTION NAME CONTENT (printf %b)
+pending() { repo "$1"; frag fixed pending.md '- Folded in.\n'; } # NAME — one fragment, ready to fold
+shim() { mkdir -p "$TMP/shim-$1"; printf '%b' "$2" >"$TMP/shim-$1/$1"; chmod +x "$TMP/shim-$1/$1"; } # NAME BODY
+shim mv '#!/bin/sh\necho "mv: refused by the test stub" >&2\nexit 1\n'
+# Refuses the fragment only: the run's own scratch is removed with rm too.
+shim rm "#!/bin/sh\\ncase \"\$*\" in *changelog.d/*) echo \"rm: refused by the test stub\" >&2; exit 1 ;; esac\\nexec $(command -v rm) \"\$@\"\\n"
+shim git "#!/usr/bin/env bash\\nif [ \"\$1\" = status ]; then exit 1; fi\\nexec $(printf '%q' "$(command -v git)") \"\$@\"\\n"
 
-echo "=== the release write requires authorization and committed inputs ==="
-for refusal in missing-flag disabled-flag staged unstaged untracked; do
-  printf '%s' "$RECORD" | reset
-  printf -- '- Folded in.\n' | frag fixed pending.md
-  cp "$R/changelog.d/fixed/pending.md" "$TMP/fragment-before"
-  case "$refusal" in
-    missing-flag) unset COMMIT_GUARDS_CHANGELOG_COLLATE ;;
-    disabled-flag) export COMMIT_GUARDS_CHANGELOG_COLLATE=0 ;;
-    untracked) printf 'Pending release file.\n' >"$R/pending-release.txt" ;;
-    staged|unstaged)
-      printf 'Pending version edit.\n' >"$R/release-input.txt"
-      if [ "$refusal" = staged ]; then
-        git -C "$R" add -- release-input.txt
-      fi
-      ;;
-  esac
-  index_before="$(git -C "$R" ls-files -s)"
-  run_collate
-  case "$refusal" in
-    missing-flag|disabled-flag) expected='requires COMMIT_GUARDS_CHANGELOG_COLLATE=1' ;;
-    staged|unstaged|untracked) expected='requires a clean index and working tree' ;;
-  esac
-  [ "$RC" -eq 2 ] && case "$OUT" in *"$expected"*) true ;; *) false ;; esac \
-    && ok "$refusal refuses with its cause" || bad "$refusal refusal" "rc=$RC out=$OUT"
-  untouched && cmp -s "$R/changelog.d/fixed/pending.md" "$TMP/fragment-before" \
-    && [ "$(git -C "$R" ls-files -s)" = "$index_before" ] \
-    && ok "$refusal preserves exact record, fragment and index" || bad "$refusal preservation" "$OUT"
-  export COMMIT_GUARDS_CHANGELOG_COLLATE=1
-  git -C "$R" reset --hard -q HEAD
-  rm -f -- "$R/pending-release.txt"
-  run_collate
-  [ "$RC" -eq 0 ] && [ ! -e "$R/changelog.d/fixed/pending.md" ] \
-    && grep -Fxq -- '- Folded in.' "$R/CHANGELOG.md" \
-    && ok "$refusal passes after its cause is removed" || bad "$refusal repair" "rc=$RC out=$OUT"
-done
+# The lines the fold prints, as functions of what a row put in.
+ERR="::error::changelog-entries: "
+DIRTY="${ERR}--collate requires a clean index and working tree; commit, restore or remove these first:"
+FLAG="${ERR}--collate requires COMMIT_GUARDS_CHANGELOG_COLLATE=1 for the release write"
+folded() { printf "changelog-entries: folded %s %s into CHANGELOG.md's [Unreleased] section" "$1" "$2"; } # COUNT NOUN
+refused() { printf 'changelog-entries FAIL CHANGELOG.md %s;  %s;changelog-entries: 1 violation(s) — cap 200 characters, 1 fragment(s) measured' "$1" "$2"; } # COMPLAINT REMEDY
+SECTIONS="added changed deprecated removed fixed security"
+FOLDED='# Changelog
 
-echo "=== ignored scratch does not block a release ==="
-printf '%s' "$RECORD" | reset
-printf -- '- Folded in.\n' | frag fixed pending.md
-printf 'scratch/\n' >"$R/.git/info/exclude"
-mkdir -p "$R/scratch"
-printf 'Release scratch.\n' >"$R/scratch/note"
-run_collate
-[ "$RC" -eq 0 ] && [ ! -e "$R/changelog.d/fixed/pending.md" ] \
-  && grep -Fxq -- '- Folded in.' "$R/CHANGELOG.md" \
-  && ok "ignored scratch permits collation" || bad "ignored scratch" "rc=$RC out=$OUT"
+## [Unreleased]
 
-echo "=== a failed Git status cannot authorize a release write ==="
-printf '%s' "$RECORD" | reset
-printf -- '- Folded in.\n' | frag fixed pending.md
-cp "$R/changelog.d/fixed/pending.md" "$TMP/fragment-before"
-index_before="$(git -C "$R" ls-files -s)"
-STATUS_STUB="$TMP/status-stub"
-mkdir -p "$STATUS_STUB"
-REAL_GIT="$(command -v git)"
-printf '#!/usr/bin/env bash\nif [ "$1" = status ]; then exit 1; fi\nexec %q "$@"\n' "$REAL_GIT" >"$STATUS_STUB/git"
-chmod +x "$STATUS_STUB/git"
-RC=0
-OUT="$(cd "$R" && PATH="$STATUS_STUB:$PATH" "$CE" --collate 2>&1)" || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"could not read repository status"*) true ;; *) false ;; esac \
-  && ok "Git status failure refuses with its cause" || bad "Git status failure" "rc=$RC out=$OUT"
-untouched && cmp -s "$R/changelog.d/fixed/pending.md" "$TMP/fragment-before" \
-  && [ "$(git -C "$R" ls-files -s)" = "$index_before" ] \
-  && ok "Git status failure preserves exact record, fragment and index" || bad "Git status preservation" "$OUT"
+### Added
 
-echo "=== a record naming a section this family cannot write is refused, and nothing is written ==="
-printf '%s' "$RECORD" | sed 's/^### Added$/### Add/' | reset
-printf -- '- Folded in.\n' | frag fixed ken-1.md
-run_collate
-[ "$RC" -eq 1 ] && case "$OUT" in *"names 'Add' under [Unreleased], which is not a Keep a Changelog section"*) true ;; *) false ;; esac \
-  && ok "a misspelled section heading refuses the fold" || bad "a misspelled section heading refuses the fold" "rc=$RC out=$OUT"
-untouched && ok "the record is untouched by that refusal" || bad "the record is untouched by that refusal" "$(cat "$R/CHANGELOG.md")"
-[ -f "$R/changelog.d/fixed/ken-1.md" ] && ok "and the fragment survives it" || bad "and the fragment survives it" "deleted"
+- An entry the record already carries.
 
-echo "=== a fragment the judge refuses stops the run before any write ==="
-printf '%s' "$RECORD" | reset
-printf -- '- Folded in.\n' | frag fixed ken-1.md
-printf 'Prose, not a list item.\n' | frag fixed bad.md
-run_collate
-[ "$RC" -eq 1 ] && case "$OUT" in *"changelog.d/fixed/bad.md does not open with a list marker"*) true ;; *) false ;; esac \
-  && ok "the fold carries the judgement's refusal as its own" \
-  || bad "the fold carries the judgement's refusal as its own" "rc=$RC out=$OUT"
-untouched && ok "the record is untouched while one fragment is refused" \
-  || bad "the record is untouched while one fragment is refused" "$(cat "$R/CHANGELOG.md")"
-[ -f "$R/changelog.d/fixed/ken-1.md" ] && ok "and the acceptable fragment beside it is not folded in and deleted" \
-  || bad "and the acceptable fragment beside it is not folded in and deleted" "deleted"
+### Fixed
+
+- Folded in.
+
+## [1.0.0] - 2026-01-01
+
+### Added
+
+- A released entry.
+'
+ONE="changelog.d/fixed~changelog.d/fixed/pending.md"
+
+# The table: label | fixture | env | shim | expect | record | left.
+run_rows() {
+  local row label fx env sh expect rec want_left
+  for row in "$@"; do
+    IFS='|' read -r label fx env sh expect rec want_left <<<"$row"
+    [ -n "$want_left" ] || { echo "harness: row has fewer than seven fields: $row" >&2; exit 2; }
+    R=""
+    "$fx"
+    assert_eq "$label" "$expect" "$(run "$env" "$sh")"
+    assert_eq "$label — the record" "$rec" "$(record "$rec")"
+    assert_eq "$label — left behind" "$want_left" "$(left)"
+  done
+}
+
+echo "=== the release write needs its flag and committed inputs, and a refusal writes nothing ==="
+fx_no_flag() { pending no-flag; }
+fx_flag_off() { pending flag-off; }
+edited() { pending "$1"; printf 'Pending version edit.\n' >"$R/release-input.txt"; } # NAME
+fx_unstaged() { edited unstaged; }
+fx_staged() { edited staged; git -C "$R" add release-input.txt; }
+fx_untracked() { pending untracked; printf 'Pending release file.\n' >"$R/pending-release.txt"; }
+fx_frag_edited() { pending frag-edited; printf -- '- Edited only on disk.\n' >"$R/changelog.d/fixed/pending.md"; }
+fx_record_edited() { pending record-edited; printf -- '\n- An entry only the disk carries.\n' >>"$R/CHANGELOG.md"; }
+DISK="$RECORD
+- An entry only the disk carries.
+"
+fx_ignored() { pending ignored; printf 'scratch/\n.keep\n' >"$R/.git/info/exclude"; mkdir -p "$R/scratch"; printf 'Release scratch.\n' >"$R/scratch/note"; : >"$R/changelog.d/fixed/.keep"; }
+fx_status_fails() { pending status-fails; }
+run_rows \
+  "the flag absent refuses, naming it|fx_no_flag|-u,COMMIT_GUARDS_CHANGELOG_COLLATE||rc=2 $FLAG|SEED|$ONE" \
+  "the flag set to 0 is the same refusal|fx_flag_off|COMMIT_GUARDS_CHANGELOG_COLLATE=0||rc=2 $FLAG|SEED|$ONE" \
+  "an unstaged edit refuses, listing the path as git shows it|fx_unstaged|||rc=2 $DIRTY;  \\ M\\ release-input.txt|SEED|$ONE" \
+  "a staged edit refuses|fx_staged|||rc=2 $DIRTY;  M\\ \\ release-input.txt|SEED|$ONE" \
+  "an untracked file refuses|fx_untracked|||rc=2 $DIRTY;  \\?\\?\\ pending-release.txt|SEED|$ONE" \
+  "a fragment git and the disk disagree about refuses, and the disk copy survives|fx_frag_edited|||rc=2 $DIRTY;  \\ M\\ changelog.d/fixed/pending.md|SEED|$ONE" \
+  "a record git and the disk disagree about refuses: the disk edit is neither published nor overwritten|fx_record_edited|||rc=2 $DIRTY;  \\ M\\ CHANGELOG.md|DISK|$ONE" \
+  "ignored scratch, inside the fragment tree too, does not block; the section directory it keeps non-empty stays|fx_ignored|||rc=0 $(folded 1 entry)|FOLDED|changelog.d/fixed~changelog.d/fixed/.keep" \
+  "a git status that fails cannot authorize the write|fx_status_fails||git|rc=2 ${ERR}could not read repository status; nothing was written|SEED|$ONE"
+
+echo "=== the record's shape is judged before the fold, and a shape the fold cannot use is refused ==="
+fx_misspelled() { repo misspelled "$(printf '%s' "$RECORD" | sed 's/^### Added$/### Add/')"; frag fixed pending.md '- Folded in.\n'; }
+fx_no_heading() { repo no-heading "$(printf '%s' "$RECORD" | sed 's/^## \[Unreleased\]$/## Unreleased/')"; frag fixed pending.md '- Folded in.\n'; }
+fx_two_headings() { repo two-headings "$(printf '%s\n## [Unreleased]\n' "$RECORD")"; frag fixed pending.md '- Folded in.\n'; }
+fx_open_fence() { repo open-fence "$(printf '%s\n```\nopen\n' "$RECORD")"; frag fixed pending.md '- Folded in.\n'; }
+fx_untracked_record() { repo untracked-record; git -C "$R" rm -q --cached CHANGELOG.md; printf '/CHANGELOG.md\n' >"$R/.gitignore"; git -C "$R" add .gitignore; git -C "$R" commit -qm 'chore: untrack'; frag fixed pending.md '- Folded in.\n'; }
+fx_scope_off() { pending scope-off; }
+fx_bad_beside() { pending bad-beside; frag fixed bad.md 'Prose, not a list item.\n'; }
+run_rows \
+  "a heading that is not a section refuses, naming it and the sections|fx_misspelled|||rc=1 $(refused "names 'Add' under [Unreleased], which is not a Keep a Changelog section" "section one of: $SECTIONS")|SEED|$ONE" \
+  "a record with no [Unreleased] heading refuses with the remedy|fx_no_heading|||rc=1 $(refused "carries no '## [Unreleased]' heading" "open one — a release folds the fragments into it and has nowhere to put them otherwise")|SEED|$ONE" \
+  "two [Unreleased] headings are a shape nothing can decide: a collection error|fx_two_headings|||rc=2 ${ERR}CHANGELOG.md carries more than one '## [Unreleased]' heading — which one is the section cannot be decided|SEED|$ONE" \
+  "an unclosed fence is the same class|fx_open_fence|||rc=2 ${ERR}CHANGELOG.md leaves a code fence unclosed — the [Unreleased] section cannot be located|SEED|$ONE" \
+  "a record git does not track is refused: nothing measured it|fx_untracked_record|||rc=2 ${ERR}CHANGELOG.md is not tracked; commit the collation destination first|SEED|$ONE" \
+  "the record scope off leaves the fold nowhere to write|fx_scope_off|COMMIT_GUARDS_CHANGELOG_RECORD=||rc=2 ${ERR}no collation destination: COMMIT_GUARDS_CHANGELOG_RECORD is empty|SEED|$ONE" \
+  "a fragment the judge refuses stops the run as its own refusal, and the acceptable one beside it is neither folded nor deleted|fx_bad_beside|||rc=1 changelog-entries FAIL changelog.d/fixed/bad.md does not open with a list marker — a fragment is the Markdown list item it becomes, opening with a hyphen and a space;changelog-entries: 1 violation(s) — cap 200 characters, 1 fragment(s) measured|SEED|changelog.d/fixed~changelog.d/fixed/bad.md~changelog.d/fixed/pending.md"
 
 echo "=== every guarantee of the fold, on one record and one exact expected output ==="
 # One fixture, because these rules only meet in a file: all six section
-# headings spelled from the section names alone, two fragments in one section
-# to make within-section filename order observable, a lead carrying a blank
-# RUN so the collapse to one blank is visible, and a second section heading
-# further down so the collapse of two headings into one is too.
-printf '%s' '# Changelog
+# headings spelled from the section names alone, two fragments in one
+# section to make within-section filename order observable, a lead carrying
+# a blank RUN so the collapse to one blank is visible, and a second section
+# heading further down so the collapse of two headings into one is too.
+ALL_IN='# Changelog
 
 Preamble.
 
@@ -203,20 +222,8 @@ A second lead paragraph, after the blank run above.
 ### Added
 
 - A released entry.
-' | reset
-printf -- '- Added, first by filename.\n' | frag added ken-1.md
-printf -- '- Added, second by filename.\n' | frag added ken-2.md
-printf -- '- Changed something.\n' | frag changed ken-3.md
-printf -- '- Deprecated something.\n' | frag deprecated ken-4.md
-printf -- '- Removed something.\n' | frag removed ken-5.md
-printf -- '- Fixed something.\n' | frag fixed ken-6.md
-# No trailing newline: two entries glued into one line is what normalizing it
-# prevents, and only a fixture written this way can catch that.
-printf -- '- Tightened something.' | frag security ken-7.md
-run_collate
-[ "$RC" -eq 0 ] && case "$OUT" in *"folded 7 entries into CHANGELOG.md's [Unreleased] section"*) true ;; *) false ;; esac \
-  && ok "the fold reports what it folded" || bad "the fold reports what it folded" "rc=$RC out=$OUT"
-EXPECTED='# Changelog
+'
+ALL_OUT='# Changelog
 
 Preamble.
 
@@ -259,20 +266,23 @@ A second lead paragraph, after the blank run above.
 
 - A released entry.
 '
-[ "$(cat "$R/CHANGELOG.md")" = "$(printf '%s' "$EXPECTED")" ] \
-  && ok "the collated block is exactly the expected one" \
-  || bad "the collated block is exactly the expected one" "$(diff <(printf '%s' "$EXPECTED") "$R/CHANGELOG.md" || true)"
-LEFT="$(find "$R/changelog.d" -mindepth 1 | sort | tr '\n' ' ')"
-[ -z "$LEFT" ] && ok "every fragment and the section directory each leaves empty are gone" \
-  || bad "every fragment and the section directory each leaves empty are gone" "$LEFT"
-no_staging && ok "the install leaves no staging file beside the record" \
-  || bad "the install leaves no staging file beside the record" "$STAGING"
+fx_all() {
+  repo all "$ALL_IN"
+  frag added ken-1.md '- Added, first by filename.\n'
+  frag added ken-2.md '- Added, second by filename.\n'
+  frag changed ken-3.md '- Changed something.\n'
+  frag deprecated ken-4.md '- Deprecated something.\n'
+  frag removed ken-5.md '- Removed something.\n'
+  frag fixed ken-6.md '- Fixed something.\n'
+  # No trailing newline: two entries glued into one line is what normalizing
+  # it prevents, and only a fixture written this way can catch that.
+  frag security ken-7.md '- Tightened something.'
+}
+# The heading further down than the seed's: the split runs at the line
+# numbers this record was accepted with, and no preamble is lost.
+MOVED_IN='# Changelog
 
-echo "=== moving the heading moves the split point ==="
-printf '%s' "$RECORD" | reset
-printf '%s' '# Changelog
-
-Preamble the staged copy adds.
+Preamble the record adds.
 
 More preamble.
 
@@ -287,13 +297,10 @@ More preamble.
 ### Added
 
 - A released entry.
-' | stage_record
-printf -- '- Folded in below the moved heading.\n' | frag fixed ken-1.md
-run_collate
-[ "$RC" -eq 0 ] && ok "a record whose section moved still folds" || bad "a record whose section moved still folds" "rc=$RC out=$OUT"
-MOVED='# Changelog
+'
+MOVED_OUT='# Changelog
 
-Preamble the staged copy adds.
+Preamble the record adds.
 
 More preamble.
 
@@ -313,74 +320,40 @@ More preamble.
 
 - A released entry.
 '
-[ "$(cat "$R/CHANGELOG.md")" = "$(printf '%s' "$MOVED")" ] \
-  && ok "and it is split at the moved section, losing no preamble" \
-  || bad "and it is split at the moved section, losing no preamble" "$(diff <(printf '%s' "$MOVED") "$R/CHANGELOG.md" || true)"
+fx_moved() { repo moved "$MOVED_IN"; frag fixed ken-1.md '- Folded in below the moved heading.\n'; }
+# The section ends with the file: nothing follows it, and no separator is written.
+TAIL_IN='# Changelog
 
-echo "=== an unstaged edit stops the write, on either side of the fold ==="
-printf '%s' "$RECORD" | reset
-printf -- '- Folded in.\n' | frag fixed ken-1.md
-printf -- '- Edited only on disk.\n' >"$R/changelog.d/fixed/ken-1.md"
-run_collate
-[ "$RC" -eq 2 ] && case "$OUT" in *"requires a clean index and working tree"*"changelog.d/fixed/ken-1.md"*) true ;; *) false ;; esac \
-  && ok "a fragment git and the disk disagree about refuses the fold" \
-  || bad "a fragment git and the disk disagree about refuses the fold" "rc=$RC out=$OUT"
-untouched && ok "the record is untouched by that refusal too" || bad "the record is untouched by that refusal too" "$(cat "$R/CHANGELOG.md")"
-[ -f "$R/changelog.d/fixed/ken-1.md" ] && ok "and the fragment survives it too" || bad "and the fragment survives it too" "deleted"
+## [Unreleased]
 
-# The RECORD half of that same guard. Without it the fold publishes a record
-# nothing measured and then deletes the fragments that went into it, so the
-# unstaged edit ships with no copy left to recover the entries from.
-printf '%s' "$RECORD" | reset
-printf -- '- Folded in.\n' | frag fixed ken-1.md
-printf -- '\n- An entry only the disk carries.\n' >>"$R/CHANGELOG.md"
-run_collate
-[ "$RC" -eq 2 ] && case "$OUT" in *"requires a clean index and working tree"*"CHANGELOG.md"*) true ;; *) false ;; esac \
-  && ok "a record git and the disk disagree about refuses the fold" \
-  || bad "a record git and the disk disagree about refuses the fold" "rc=$RC out=$OUT"
-[ -f "$R/changelog.d/fixed/ken-1.md" ] && ok "and the fragment survives that refusal" \
-  || bad "and the fragment survives that refusal" "deleted"
-case "$(cat "$R/CHANGELOG.md")" in
-  *"An entry only the disk carries"*) ok "the unstaged record edit is neither published nor overwritten" ;;
-  *) bad "the unstaged record edit is neither published nor overwritten" "$(cat "$R/CHANGELOG.md")" ;;
-esac
+### Added
 
-echo "=== a failure at the rename leaves nothing half-written ==="
-# A stub ahead of PATH is how a failure is reached in the window where the
-# staging file already exists: nothing else in the fold runs mv.
-STUB="$TMP/stub"
-mkdir -p "$STUB"
-printf '#!/bin/sh\necho "mv: refused by the test stub" >&2\nexit 1\n' >"$STUB/mv"
-chmod +x "$STUB/mv"
-printf '%s' "$RECORD" | reset
-printf -- '- Folded in.\n' | frag fixed ken-1.md
-OUT=""
-RC=0
-OUT="$(cd "$R" && PATH="$STUB:$PATH" "$CE" --collate 2>&1)" || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"could not replace the collated changelog"*) true ;; *) false ;; esac \
-  && ok "a failed rename is a loud refusal" || bad "a failed rename is a loud refusal" "rc=$RC out=$OUT"
-# What the tool said arrives INSIDE the guard's line, not on a bare line ahead
-# of it: a reader takes the first line they see as the cause, and `mv: ...`
-# alone names the symptom without saying what was being done.
-case "$OUT" in
-  *"could not replace the collated changelog"*"refused by the test stub"*)
-    ok "and it carries what mv said inside its own line" ;;
-  *) bad "and it carries what mv said inside its own line" "$OUT" ;;
-esac
-untouched && ok "the record is byte-identical after the failed rename" \
-  || bad "the record is byte-identical after the failed rename" "$(cat "$R/CHANGELOG.md")"
-no_staging && ok "and no staging file survives beside it" || bad "and no staging file survives beside it" "$STAGING"
-[ -f "$R/changelog.d/fixed/ken-1.md" ] \
-  && ok "the fragment is not deleted for a record that was never replaced" \
-  || bad "the fragment is not deleted for a record that was never replaced" "deleted"
+- An entry the record already carries.
+'
+TAIL_OUT='# Changelog
 
-echo "=== nothing to fold is a no-op ==="
-printf '%s' "$RECORD" | reset
-run_collate
-[ "$RC" -eq 0 ] && case "$OUT" in *"no fragments — nothing to collate"*) true ;; *) false ;; esac \
-  && ok "an empty tree folds nothing and says so" || bad "an empty tree folds nothing and says so" "rc=$RC out=$OUT"
+## [Unreleased]
 
-untouched && ok "the record is untouched with nothing to fold" || bad "the record is untouched with nothing to fold" "$(cat "$R/CHANGELOG.md")"
+### Added
+
+- An entry the record already carries.
+- Folded in at the end of the file.
+'
+fx_tail() { repo tail "$TAIL_IN"; frag added ken-1.md '- Folded in at the end of the file.\n'; }
+fx_newline_name() { repo newline-name; frag fixed $'a\nb.md' '- Folded in.\n'; }
+fx_readme() { repo readme; mkdir -p "$R/changelog.d"; printf 'The format.\n' >"$R/changelog.d/README.md"; git -C "$R" add -A; git -C "$R" commit -qm 'chore: readme'; frag fixed pending.md '- Folded in.\n'; }
+fx_nothing() { repo nothing; }
+fx_mv_fails() { pending mv-fails; }
+fx_rm_fails() { pending rm-fails; }
+run_rows \
+  "every section in Keep a Changelog order, filename order within one, two headings collapsed, the lead trimmed, a newline-less fragment normalized|fx_all|||rc=0 $(folded 7 entries)|ALL_OUT|-" \
+  "a heading further down is split at its own line numbers, losing no preamble|fx_moved|||rc=0 $(folded 1 entry)|MOVED_OUT|-" \
+  "a section that ends with the file is folded into with no separator after it|fx_tail|||rc=0 $(folded 1 entry)|TAIL_OUT|-" \
+  "a fragment whose name carries a newline is folded in and removed like any other|fx_newline_name|||rc=0 $(folded 1 entry)|FOLDED|-" \
+  "the format's README is neither folded nor swept, and its directory stays|fx_readme|||rc=0 $(folded 1 entry)|FOLDED|changelog.d/README.md" \
+  "nothing to fold is a stated no-op|fx_nothing|||rc=0 changelog-entries: no fragments — nothing to collate|SEED|-" \
+  "a rename that fails is a loud refusal carrying what mv said, the record byte-identical, no staging file, the fragment kept|fx_mv_fails||mv|rc=2 ${ERR}could not replace the collated changelog at CHANGELOG.md (mv: refused by the test stub) — inspect the file before trusting it|SEED|$ONE" \
+  "a fragment that survives its delete is named, after the record was replaced|fx_rm_fails||rm|rc=2 rm: refused by the test stub;${ERR}CHANGELOG.md is collated, but these fragments survived and would fold in a second time — delete them by hand:;  changelog.d/fixed/pending.md|FOLDED|$ONE"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/commit-guards/tests/changelog-collate.test.sh
+++ b/skills/commit-guards/tests/changelog-collate.test.sh
@@ -54,13 +54,20 @@ run() { # ENVS SHIM
   printf 'rc=%s%s' "$rc" "${out:+ $(printf '%s\n' "$out" | LC_ALL=C paste -sd ';' -)}"
 }
 # The record after the run: the name of the text it equals byte for byte
-# (SEED is what the fixture committed), or a diff against the one the row
-# named. cmp, not a substitution: that would drop a trailing blank line.
+# (SEED is the file the fixture committed, kept beside the repository since
+# a shell variable cannot hold every byte a record can), or a diff against
+# the one the row named. cmp, not a substitution: that would drop a trailing
+# blank line.
 record() { # NAME
-  if cmp -s <(printf '%s' "${!1}") "$R/CHANGELOG.md"; then printf '%s' "$1"; else diff <(printf '%s' "${!1}") "$R/CHANGELOG.md" || true; fi
+  local want="$R.seed"
+  [ "$1" = SEED ] || want="$TMP/want-$1"
+  [ "$1" = SEED ] || printf '%s' "${!1}" >"$want"
+  if cmp -s "$want" "$R/CHANGELOG.md"; then printf '%s' "$1"; else diff "$want" "$R/CHANGELOG.md" || true; fi
 }
 # What is left under the fragment tree, sorted and joined by '~', with any
-# staging file beside the record; '-' when nothing.
+# staging file beside the record; '-' when nothing. Line-oriented, so a path
+# carrying a newline is shown as two: the one row with such a path leaves
+# nothing behind.
 left() {
   local out
   out="$(cd "$R" && { find changelog.d -mindepth 1 2>/dev/null; ls -d CHANGELOG.md.* 2>/dev/null; } | LC_ALL=C sort | LC_ALL=C paste -sd '~' -)"
@@ -83,7 +90,6 @@ RECORD='# Changelog
 
 - A released entry.
 '
-SEED=""
 repo() { # NAME [RECORD]
   R="$TMP/$1"
   [ ! -e "$R" ] || { echo "harness: fixture $1 already exists" >&2; exit 2; }
@@ -91,12 +97,13 @@ repo() { # NAME [RECORD]
   git -C "$R" -c init.defaultBranch=main init -q
   git -C "$R" config user.email test@example.com
   git -C "$R" config user.name test
-  SEED="${2:-$RECORD}"
-  printf '%s' "$SEED" >"$R/CHANGELOG.md"
+  printf '%s' "${2:-$RECORD}" >"$R/CHANGELOG.md"
   printf 'Release input.\n' >"$R/release-input.txt"
+  reseed
   git -C "$R" add -A
   git -C "$R" commit -qm 'chore: seed'
 }
+reseed() { cp -- "$R/CHANGELOG.md" "$R.seed"; } # the record as it stands is the row's SEED
 frag() { mkdir -p "$R/changelog.d/$1"; printf '%b' "$3" >"$R/changelog.d/$1/$2"; git -C "$R" add -A -- changelog.d; git -C "$R" commit -qm 'chore: prepare release input'; } # SECTION NAME CONTENT (printf %b)
 pending() { repo "$1"; frag fixed pending.md '- Folded in.\n'; } # NAME — one fragment, ready to fold
 shim() { mkdir -p "$TMP/shim-$1"; printf '%b' "$2" >"$TMP/shim-$1/$1"; chmod +x "$TMP/shim-$1/$1"; } # NAME BODY
@@ -178,6 +185,10 @@ fx_two_headings() { repo two-headings "$(printf '%s\n## [Unreleased]\n' "$RECORD
 fx_open_fence() { repo open-fence "$(printf '%s\n```\nopen\n' "$RECORD")"; frag fixed pending.md '- Folded in.\n'; }
 fx_untracked_record() { repo untracked-record; git -C "$R" rm -q --cached CHANGELOG.md; printf '/CHANGELOG.md\n' >"$R/.gitignore"; git -C "$R" add .gitignore; git -C "$R" commit -qm 'chore: untrack'; frag fixed pending.md '- Folded in.\n'; }
 fx_scope_off() { pending scope-off; }
+fx_symlink_record() { pending symlink-record; mv "$R/CHANGELOG.md" "$R/real.md"; ln -s real.md "$R/CHANGELOG.md"; git -C "$R" add -A; git -C "$R" commit -qm 'chore: link'; }
+# A NUL in the record: written with printf's own escape, since no shell
+# variable carries the byte.
+fx_nul_record() { pending nul-record; printf '%s\0' "$RECORD" >"$R/CHANGELOG.md"; reseed; git -C "$R" add -A; git -C "$R" commit -qm 'chore: nul'; }
 fx_bad_beside() { pending bad-beside; frag fixed bad.md 'Prose, not a list item.\n'; }
 run_rows \
   "a heading that is not a section refuses, naming it and the sections|fx_misspelled|||rc=1 $(refused "names 'Add' under [Unreleased], which is not a Keep a Changelog section" "section one of: $SECTIONS")|SEED|$ONE" \
@@ -186,6 +197,8 @@ run_rows \
   "an unclosed fence is the same class|fx_open_fence|||rc=2 ${ERR}CHANGELOG.md leaves a code fence unclosed — the [Unreleased] section cannot be located|SEED|$ONE" \
   "a record git does not track is refused: nothing measured it|fx_untracked_record|||rc=2 ${ERR}CHANGELOG.md is not tracked; commit the collation destination first|SEED|$ONE" \
   "the record scope off leaves the fold nowhere to write|fx_scope_off|COMMIT_GUARDS_CHANGELOG_RECORD=||rc=2 ${ERR}no collation destination: COMMIT_GUARDS_CHANGELOG_RECORD is empty|SEED|$ONE" \
+  "a record tracked as a symlink is not a destination|fx_symlink_record|||rc=2 ${ERR}CHANGELOG.md is not a regular collation destination|SEED|$ONE" \
+  "a record carrying a NUL is binary, not a destination|fx_nul_record|||rc=2 ${ERR}CHANGELOG.md holds binary content; collation needs text|SEED|$ONE" \
   "a fragment the judge refuses stops the run as its own refusal, and the acceptable one beside it is neither folded nor deleted|fx_bad_beside|||rc=1 changelog-entries FAIL changelog.d/fixed/bad.md does not open with a list marker — a fragment is the Markdown list item it becomes, opening with a hyphen and a space;changelog-entries: 1 violation(s) — cap 200 characters, 1 fragment(s) measured|SEED|changelog.d/fixed~changelog.d/fixed/bad.md~changelog.d/fixed/pending.md"
 
 echo "=== every guarantee of the fold, on one record and one exact expected output ==="
@@ -342,18 +355,20 @@ TAIL_OUT='# Changelog
 fx_tail() { repo tail "$TAIL_IN"; frag added ken-1.md '- Folded in at the end of the file.\n'; }
 fx_newline_name() { repo newline-name; frag fixed $'a\nb.md' '- Folded in.\n'; }
 fx_readme() { repo readme; mkdir -p "$R/changelog.d"; printf 'The format.\n' >"$R/changelog.d/README.md"; git -C "$R" add -A; git -C "$R" commit -qm 'chore: readme'; frag fixed pending.md '- Folded in.\n'; }
-fx_nothing() { repo nothing; }
+fx_nothing() { repo nothing "$(printf '%s' "$RECORD" | sed 's/^## \[Unreleased\]$/## Unreleased/')"; }
 fx_mv_fails() { pending mv-fails; }
-fx_rm_fails() { pending rm-fails; }
+fx_rm_fails() { pending rm-fails; frag fixed 'a b.md' '- Folded in, first by filename.\n'; }
+FOLDED2="${FOLDED/- Folded in./- Folded in, first by filename.
+- Folded in.}"
 run_rows \
   "every section in Keep a Changelog order, filename order within one, two headings collapsed, the lead trimmed, a newline-less fragment normalized|fx_all|||rc=0 $(folded 7 entries)|ALL_OUT|-" \
   "a heading further down is split at its own line numbers, losing no preamble|fx_moved|||rc=0 $(folded 1 entry)|MOVED_OUT|-" \
   "a section that ends with the file is folded into with no separator after it|fx_tail|||rc=0 $(folded 1 entry)|TAIL_OUT|-" \
   "a fragment whose name carries a newline is folded in and removed like any other|fx_newline_name|||rc=0 $(folded 1 entry)|FOLDED|-" \
   "the format's README is neither folded nor swept, and its directory stays|fx_readme|||rc=0 $(folded 1 entry)|FOLDED|changelog.d/README.md" \
-  "nothing to fold is a stated no-op|fx_nothing|||rc=0 changelog-entries: no fragments — nothing to collate|SEED|-" \
+  "nothing to fold is a stated no-op that reads no destination: a record with no heading passes|fx_nothing|||rc=0 changelog-entries: no fragments — nothing to collate|SEED|-" \
   "a rename that fails is a loud refusal carrying what mv said, the record byte-identical, no staging file, the fragment kept|fx_mv_fails||mv|rc=2 ${ERR}could not replace the collated changelog at CHANGELOG.md (mv: refused by the test stub) — inspect the file before trusting it|SEED|$ONE" \
-  "a fragment that survives its delete is named, after the record was replaced|fx_rm_fails||rm|rc=2 rm: refused by the test stub;${ERR}CHANGELOG.md is collated, but these fragments survived and would fold in a second time — delete them by hand:;  changelog.d/fixed/pending.md|FOLDED|$ONE"
+  "every fragment that survives its delete is named, escaped, after the record was replaced|fx_rm_fails||rm|rc=2 rm: refused by the test stub;rm: refused by the test stub;${ERR}CHANGELOG.md is collated, but these fragments survived and would fold in a second time — delete them by hand:;  changelog.d/fixed/a\\ b.md;  changelog.d/fixed/pending.md|FOLDED2|changelog.d/fixed~changelog.d/fixed/a b.md~changelog.d/fixed/pending.md"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/commit-guards/tests/changelog-collate.test.sh
+++ b/skills/commit-guards/tests/changelog-collate.test.sh
@@ -1,72 +1,74 @@
 #!/usr/bin/env bash
-# Pins the WRITE path of scripts/changelog-entries --collate: it folds the
-# fragments this run accepted into the record's [Unreleased] section, under
-# the heading each fragment's own section names, in Keep a Changelog order and
-# filename order within a section; it splits the record at the line numbers
-# the committed copy was accepted with, collapses two headings for one section
-# into one, deletes the fragments and the section directory each leaves empty,
-# and refuses without writing when the judgement refuses, the index or working
-# tree has pending changes, or the release flag is absent. The refusing
-# direction runs first in every pair, and each refusal is checked to have left
-# the record and the fragments as they were — a fold that half-writes or
-# half-deletes is the failure this guards.
+# Pins for the WRITE path of scripts/changelog-entries --collate
+# (lib/changelog-collate.sh over lib/changelog-record-scope.sh and
+# lib/atomic-install.sh): it folds the fragments this run accepted into the
+# record's [Unreleased] section under the heading each fragment's section
+# names, in Keep a Changelog order and filename order within a section,
+# splits the record at the line numbers the committed copy was accepted
+# with, collapses two headings for one section into one, deletes the
+# fragments and the section directory each leaves empty, and refuses
+# without writing when the judgement refuses, the record's shape cannot be
+# folded into, the index or working tree has pending changes, or the
+# release flag is absent. One table: a row builds its own repository, runs
+# the fold and reads back the exit status with every line printed, then
+# the record (the seed it was, or the exact folded text) and what is left
+# under the fragment tree beside any staging file. The judgement's own
+# lines are changelog-entries.test.sh's; here they ride along where the
+# fold carries them as its own refusal.
 set -euo pipefail
-
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CE="$(cd "$TEST_DIR/.." && pwd)/scripts/changelog-entries"
 # shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
-
-unset COMMIT_GUARDS_CHANGELOG_CAP COMMIT_GUARDS_CHANGELOG_PATHS \
-  COMMIT_GUARDS_CHANGELOG_RECORD COMMIT_GUARDS_CHANGELOG_COLLATE \
-  COMMIT_GUARDS_SETTINGS_FILE 2>/dev/null || true
-
-export COMMIT_GUARDS_CHANGELOG_COLLATE=1
+unset COMMIT_GUARDS_CHANGELOG_CAP COMMIT_GUARDS_CHANGELOG_PATHS COMMIT_GUARDS_CHANGELOG_RECORD \
+  COMMIT_GUARDS_CHANGELOG_COLLATE COMMIT_GUARDS_SETTINGS_FILE 2>/dev/null || true
 
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
-
-R="$TMP/repo"
-mkdir -p "$R"
-git -C "$R" -c init.defaultBranch=main init -q
-git -C "$R" config user.email test@example.com
-git -C "$R" config user.name test
-
-reset() { # RECORD on stdin — the fixture record and an empty tree, committed
-  rm -rf -- "${R:?}/changelog.d"
-  cat >"$R/CHANGELOG.md"
-  printf 'Release input.\n' >"$R/release-input.txt"
-  git -C "$R" add -A
-  # Each case starts from a committed fixture with a clean index.
-  git -C "$R" commit -q --allow-empty -m "chore: reset the fixture"
-  cp "$R/CHANGELOG.md" "$TMP/before"
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
 }
 
-stage_record() { # RECORD on stdin — staged over the committed one, not committed
-  cat >"$R/CHANGELOG.md"
-  git -C "$R" add -A -- CHANGELOG.md
-  cp "$R/CHANGELOG.md" "$TMP/before"
+# One line for a fold in the row's repository: the exit status, then every
+# line printed, in order, joined by ';'. The release flag is set unless the
+# row's ENVS (a comma-separated list of assignments; -u,NAME unsets, and
+# comes first) names it; SHIM names a directory of stand-in tools put ahead
+# of PATH.
+R=""
+run() { # ENVS SHIM
+  local envs=() rc=0 out="" path="$PATH"
+  [ -z "$1" ] || IFS=',' read -ra envs <<<"$1"
+  case ",$1," in
+    *,COMMIT_GUARDS_CHANGELOG_COLLATE,* | *,COMMIT_GUARDS_CHANGELOG_COLLATE=*) ;;
+    *) envs+=(COMMIT_GUARDS_CHANGELOG_COLLATE=1) ;;
+  esac
+  [ -z "$2" ] || path="$TMP/shim-$2:$PATH"
+  # shellcheck disable=SC2086
+  out="$(cd "$R" && env ${envs[@]+"${envs[@]}"} PATH="$path" "$CE" --collate 2>&1)" || rc=$?
+  printf 'rc=%s%s' "$rc" "${out:+ $(printf '%s\n' "$out" | LC_ALL=C paste -sd ';' -)}"
+}
+# The record after the run: the name of the text it equals byte for byte
+# (SEED is what the fixture committed), or a diff against the one the row
+# named. cmp, not a substitution: that would drop a trailing blank line.
+record() { # NAME
+  if cmp -s <(printf '%s' "${!1}") "$R/CHANGELOG.md"; then printf '%s' "$1"; else diff <(printf '%s' "${!1}") "$R/CHANGELOG.md" || true; fi
+}
+# What is left under the fragment tree, sorted and joined by '~', with any
+# staging file beside the record; '-' when nothing.
+left() {
+  local out
+  out="$(cd "$R" && { find changelog.d -mindepth 1 2>/dev/null; ls -d CHANGELOG.md.* 2>/dev/null; } | LC_ALL=C sort | LC_ALL=C paste -sd '~' -)"
+  printf '%s' "${out:--}"
 }
 
-frag() { # SECTION NAME: content on stdin, written and committed
-  mkdir -p "$R/changelog.d/$1"
-  cat >"$R/changelog.d/$1/$2"
-  git -C "$R" add -A -- changelog.d
-  git -C "$R" commit -qm "chore: prepare release input"
-}
-
-run_collate() { OUT=""; RC=0; OUT="$(cd "$R" && "$CE" --collate 2>&1)" || RC=$?; }
-untouched() { cmp -s "$R/CHANGELOG.md" "$TMP/before"; }
-no_staging() { # no residue beside the record, whatever mktemp named it
-  STAGING=""
-  for f in "$R"/CHANGELOG.md.*; do
-    [ ! -e "$f" ] || STAGING="$STAGING $f"
-  done
-  [ -z "$STAGING" ]
-}
-
+# Fixture vocabulary. Every fixture builds its own repository, the record
+# and one release input committed; a name used twice is refused.
 RECORD='# Changelog
 
 ## [Unreleased]
@@ -81,101 +83,118 @@ RECORD='# Changelog
 
 - A released entry.
 '
+SEED=""
+repo() { # NAME [RECORD]
+  R="$TMP/$1"
+  [ ! -e "$R" ] || { echo "harness: fixture $1 already exists" >&2; exit 2; }
+  mkdir -p "$R"
+  git -C "$R" -c init.defaultBranch=main init -q
+  git -C "$R" config user.email test@example.com
+  git -C "$R" config user.name test
+  SEED="${2:-$RECORD}"
+  printf '%s' "$SEED" >"$R/CHANGELOG.md"
+  printf 'Release input.\n' >"$R/release-input.txt"
+  git -C "$R" add -A
+  git -C "$R" commit -qm 'chore: seed'
+}
+frag() { mkdir -p "$R/changelog.d/$1"; printf '%b' "$3" >"$R/changelog.d/$1/$2"; git -C "$R" add -A -- changelog.d; git -C "$R" commit -qm 'chore: prepare release input'; } # SECTION NAME CONTENT (printf %b)
+pending() { repo "$1"; frag fixed pending.md '- Folded in.\n'; } # NAME — one fragment, ready to fold
+shim() { mkdir -p "$TMP/shim-$1"; printf '%b' "$2" >"$TMP/shim-$1/$1"; chmod +x "$TMP/shim-$1/$1"; } # NAME BODY
+shim mv '#!/bin/sh\necho "mv: refused by the test stub" >&2\nexit 1\n'
+# Refuses the fragment only: the run's own scratch is removed with rm too.
+shim rm "#!/bin/sh\\ncase \"\$*\" in *changelog.d/*) echo \"rm: refused by the test stub\" >&2; exit 1 ;; esac\\nexec $(command -v rm) \"\$@\"\\n"
+shim git "#!/usr/bin/env bash\\nif [ \"\$1\" = status ]; then exit 1; fi\\nexec $(printf '%q' "$(command -v git)") \"\$@\"\\n"
 
-echo "=== the release write requires authorization and committed inputs ==="
-for refusal in missing-flag disabled-flag staged unstaged untracked; do
-  printf '%s' "$RECORD" | reset
-  printf -- '- Folded in.\n' | frag fixed pending.md
-  cp "$R/changelog.d/fixed/pending.md" "$TMP/fragment-before"
-  case "$refusal" in
-    missing-flag) unset COMMIT_GUARDS_CHANGELOG_COLLATE ;;
-    disabled-flag) export COMMIT_GUARDS_CHANGELOG_COLLATE=0 ;;
-    untracked) printf 'Pending release file.\n' >"$R/pending-release.txt" ;;
-    staged|unstaged)
-      printf 'Pending version edit.\n' >"$R/release-input.txt"
-      if [ "$refusal" = staged ]; then
-        git -C "$R" add -- release-input.txt
-      fi
-      ;;
-  esac
-  index_before="$(git -C "$R" ls-files -s)"
-  run_collate
-  case "$refusal" in
-    missing-flag|disabled-flag) expected='requires COMMIT_GUARDS_CHANGELOG_COLLATE=1' ;;
-    staged|unstaged|untracked) expected='requires a clean index and working tree' ;;
-  esac
-  [ "$RC" -eq 2 ] && case "$OUT" in *"$expected"*) true ;; *) false ;; esac \
-    && ok "$refusal refuses with its cause" || bad "$refusal refusal" "rc=$RC out=$OUT"
-  untouched && cmp -s "$R/changelog.d/fixed/pending.md" "$TMP/fragment-before" \
-    && [ "$(git -C "$R" ls-files -s)" = "$index_before" ] \
-    && ok "$refusal preserves exact record, fragment and index" || bad "$refusal preservation" "$OUT"
-  export COMMIT_GUARDS_CHANGELOG_COLLATE=1
-  git -C "$R" reset --hard -q HEAD
-  rm -f -- "$R/pending-release.txt"
-  run_collate
-  [ "$RC" -eq 0 ] && [ ! -e "$R/changelog.d/fixed/pending.md" ] \
-    && grep -Fxq -- '- Folded in.' "$R/CHANGELOG.md" \
-    && ok "$refusal passes after its cause is removed" || bad "$refusal repair" "rc=$RC out=$OUT"
-done
+# The lines the fold prints, as functions of what a row put in.
+ERR="::error::changelog-entries: "
+DIRTY="${ERR}--collate requires a clean index and working tree; commit, restore or remove these first:"
+FLAG="${ERR}--collate requires COMMIT_GUARDS_CHANGELOG_COLLATE=1 for the release write"
+folded() { printf "changelog-entries: folded %s %s into CHANGELOG.md's [Unreleased] section" "$1" "$2"; } # COUNT NOUN
+refused() { printf 'changelog-entries FAIL CHANGELOG.md %s;  %s;changelog-entries: 1 violation(s) — cap 200 characters, 1 fragment(s) measured' "$1" "$2"; } # COMPLAINT REMEDY
+SECTIONS="added changed deprecated removed fixed security"
+FOLDED='# Changelog
 
-echo "=== ignored scratch does not block a release ==="
-printf '%s' "$RECORD" | reset
-printf -- '- Folded in.\n' | frag fixed pending.md
-printf 'scratch/\n' >"$R/.git/info/exclude"
-mkdir -p "$R/scratch"
-printf 'Release scratch.\n' >"$R/scratch/note"
-run_collate
-[ "$RC" -eq 0 ] && [ ! -e "$R/changelog.d/fixed/pending.md" ] \
-  && grep -Fxq -- '- Folded in.' "$R/CHANGELOG.md" \
-  && ok "ignored scratch permits collation" || bad "ignored scratch" "rc=$RC out=$OUT"
+## [Unreleased]
 
-echo "=== a failed Git status cannot authorize a release write ==="
-printf '%s' "$RECORD" | reset
-printf -- '- Folded in.\n' | frag fixed pending.md
-cp "$R/changelog.d/fixed/pending.md" "$TMP/fragment-before"
-index_before="$(git -C "$R" ls-files -s)"
-STATUS_STUB="$TMP/status-stub"
-mkdir -p "$STATUS_STUB"
-REAL_GIT="$(command -v git)"
-printf '#!/usr/bin/env bash\nif [ "$1" = status ]; then exit 1; fi\nexec %q "$@"\n' "$REAL_GIT" >"$STATUS_STUB/git"
-chmod +x "$STATUS_STUB/git"
-RC=0
-OUT="$(cd "$R" && PATH="$STATUS_STUB:$PATH" "$CE" --collate 2>&1)" || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"could not read repository status"*) true ;; *) false ;; esac \
-  && ok "Git status failure refuses with its cause" || bad "Git status failure" "rc=$RC out=$OUT"
-untouched && cmp -s "$R/changelog.d/fixed/pending.md" "$TMP/fragment-before" \
-  && [ "$(git -C "$R" ls-files -s)" = "$index_before" ] \
-  && ok "Git status failure preserves exact record, fragment and index" || bad "Git status preservation" "$OUT"
+### Added
 
-echo "=== a record naming a section this family cannot write is refused, and nothing is written ==="
-printf '%s' "$RECORD" | sed 's/^### Added$/### Add/' | reset
-printf -- '- Folded in.\n' | frag fixed ken-1.md
-run_collate
-[ "$RC" -eq 1 ] && case "$OUT" in *"names 'Add' under [Unreleased], which is not a Keep a Changelog section"*) true ;; *) false ;; esac \
-  && ok "a misspelled section heading refuses the fold" || bad "a misspelled section heading refuses the fold" "rc=$RC out=$OUT"
-untouched && ok "the record is untouched by that refusal" || bad "the record is untouched by that refusal" "$(cat "$R/CHANGELOG.md")"
-[ -f "$R/changelog.d/fixed/ken-1.md" ] && ok "and the fragment survives it" || bad "and the fragment survives it" "deleted"
+- An entry the record already carries.
 
-echo "=== a fragment the judge refuses stops the run before any write ==="
-printf '%s' "$RECORD" | reset
-printf -- '- Folded in.\n' | frag fixed ken-1.md
-printf 'Prose, not a list item.\n' | frag fixed bad.md
-run_collate
-[ "$RC" -eq 1 ] && case "$OUT" in *"changelog.d/fixed/bad.md does not open with a list marker"*) true ;; *) false ;; esac \
-  && ok "the fold carries the judgement's refusal as its own" \
-  || bad "the fold carries the judgement's refusal as its own" "rc=$RC out=$OUT"
-untouched && ok "the record is untouched while one fragment is refused" \
-  || bad "the record is untouched while one fragment is refused" "$(cat "$R/CHANGELOG.md")"
-[ -f "$R/changelog.d/fixed/ken-1.md" ] && ok "and the acceptable fragment beside it is not folded in and deleted" \
-  || bad "and the acceptable fragment beside it is not folded in and deleted" "deleted"
+### Fixed
+
+- Folded in.
+
+## [1.0.0] - 2026-01-01
+
+### Added
+
+- A released entry.
+'
+ONE="changelog.d/fixed~changelog.d/fixed/pending.md"
+
+# The table: label | fixture | env | shim | expect | record | left.
+run_rows() {
+  local row label fx env sh expect rec want_left
+  for row in "$@"; do
+    IFS='|' read -r label fx env sh expect rec want_left <<<"$row"
+    [ -n "$want_left" ] || { echo "harness: row has fewer than seven fields: $row" >&2; exit 2; }
+    R=""
+    "$fx"
+    assert_eq "$label" "$expect" "$(run "$env" "$sh")"
+    assert_eq "$label — the record" "$rec" "$(record "$rec")"
+    assert_eq "$label — left behind" "$want_left" "$(left)"
+  done
+}
+
+echo "=== the release write needs its flag and committed inputs, and a refusal writes nothing ==="
+fx_no_flag() { pending no-flag; }
+fx_flag_off() { pending flag-off; }
+edited() { pending "$1"; printf 'Pending version edit.\n' >"$R/release-input.txt"; } # NAME
+fx_unstaged() { edited unstaged; }
+fx_staged() { edited staged; git -C "$R" add release-input.txt; }
+fx_untracked() { pending untracked; printf 'Pending release file.\n' >"$R/pending-release.txt"; }
+fx_frag_edited() { pending frag-edited; printf -- '- Edited only on disk.\n' >"$R/changelog.d/fixed/pending.md"; }
+fx_record_edited() { pending record-edited; printf -- '\n- An entry only the disk carries.\n' >>"$R/CHANGELOG.md"; }
+DISK="$RECORD
+- An entry only the disk carries.
+"
+fx_ignored() { pending ignored; printf 'scratch/\n.keep\n' >"$R/.git/info/exclude"; mkdir -p "$R/scratch"; printf 'Release scratch.\n' >"$R/scratch/note"; : >"$R/changelog.d/fixed/.keep"; }
+fx_status_fails() { pending status-fails; }
+run_rows \
+  "the flag absent refuses, naming it|fx_no_flag|-u,COMMIT_GUARDS_CHANGELOG_COLLATE||rc=2 $FLAG|SEED|$ONE" \
+  "the flag set to 0 is the same refusal|fx_flag_off|COMMIT_GUARDS_CHANGELOG_COLLATE=0||rc=2 $FLAG|SEED|$ONE" \
+  "an unstaged edit refuses, listing the path as git shows it|fx_unstaged|||rc=2 $DIRTY;  \\ M\\ release-input.txt|SEED|$ONE" \
+  "a staged edit refuses|fx_staged|||rc=2 $DIRTY;  M\\ \\ release-input.txt|SEED|$ONE" \
+  "an untracked file refuses|fx_untracked|||rc=2 $DIRTY;  \\?\\?\\ pending-release.txt|SEED|$ONE" \
+  "a fragment git and the disk disagree about refuses, and the disk copy survives|fx_frag_edited|||rc=2 $DIRTY;  \\ M\\ changelog.d/fixed/pending.md|SEED|$ONE" \
+  "a record git and the disk disagree about refuses: the disk edit is neither published nor overwritten|fx_record_edited|||rc=2 $DIRTY;  \\ M\\ CHANGELOG.md|DISK|$ONE" \
+  "ignored scratch, inside the fragment tree too, does not block; the section directory it keeps non-empty stays|fx_ignored|||rc=0 $(folded 1 entry)|FOLDED|changelog.d/fixed~changelog.d/fixed/.keep" \
+  "a git status that fails cannot authorize the write|fx_status_fails||git|rc=2 ${ERR}could not read repository status; nothing was written|SEED|$ONE"
+
+echo "=== the record's shape is judged before the fold, and a shape the fold cannot use is refused ==="
+fx_misspelled() { repo misspelled "$(printf '%s' "$RECORD" | sed 's/^### Added$/### Add/')"; frag fixed pending.md '- Folded in.\n'; }
+fx_no_heading() { repo no-heading "$(printf '%s' "$RECORD" | sed 's/^## \[Unreleased\]$/## Unreleased/')"; frag fixed pending.md '- Folded in.\n'; }
+fx_two_headings() { repo two-headings "$(printf '%s\n## [Unreleased]\n' "$RECORD")"; frag fixed pending.md '- Folded in.\n'; }
+fx_open_fence() { repo open-fence "$(printf '%s\n```\nopen\n' "$RECORD")"; frag fixed pending.md '- Folded in.\n'; }
+fx_untracked_record() { repo untracked-record; git -C "$R" rm -q --cached CHANGELOG.md; printf '/CHANGELOG.md\n' >"$R/.gitignore"; git -C "$R" add .gitignore; git -C "$R" commit -qm 'chore: untrack'; frag fixed pending.md '- Folded in.\n'; }
+fx_scope_off() { pending scope-off; }
+fx_bad_beside() { pending bad-beside; frag fixed bad.md 'Prose, not a list item.\n'; }
+run_rows \
+  "a heading that is not a section refuses, naming it and the sections|fx_misspelled|||rc=1 $(refused "names 'Add' under [Unreleased], which is not a Keep a Changelog section" "section one of: $SECTIONS")|SEED|$ONE" \
+  "a record with no [Unreleased] heading refuses with the remedy|fx_no_heading|||rc=1 $(refused "carries no '## [Unreleased]' heading" "open one — a release folds the fragments into it and has nowhere to put them otherwise")|SEED|$ONE" \
+  "two [Unreleased] headings are a shape nothing can decide: a collection error|fx_two_headings|||rc=2 ${ERR}CHANGELOG.md carries more than one '## [Unreleased]' heading — which one is the section cannot be decided|SEED|$ONE" \
+  "an unclosed fence is the same class|fx_open_fence|||rc=2 ${ERR}CHANGELOG.md leaves a code fence unclosed — the [Unreleased] section cannot be located|SEED|$ONE" \
+  "a record git does not track is refused: nothing measured it|fx_untracked_record|||rc=2 ${ERR}CHANGELOG.md is not tracked; commit the collation destination first|SEED|$ONE" \
+  "the record scope off leaves the fold nowhere to write|fx_scope_off|COMMIT_GUARDS_CHANGELOG_RECORD=||rc=2 ${ERR}no collation destination: COMMIT_GUARDS_CHANGELOG_RECORD is empty|SEED|$ONE" \
+  "a fragment the judge refuses stops the run as its own refusal, and the acceptable one beside it is neither folded nor deleted|fx_bad_beside|||rc=1 changelog-entries FAIL changelog.d/fixed/bad.md does not open with a list marker — a fragment is the Markdown list item it becomes, opening with a hyphen and a space;changelog-entries: 1 violation(s) — cap 200 characters, 1 fragment(s) measured|SEED|changelog.d/fixed~changelog.d/fixed/bad.md~changelog.d/fixed/pending.md"
 
 echo "=== every guarantee of the fold, on one record and one exact expected output ==="
 # One fixture, because these rules only meet in a file: all six section
-# headings spelled from the section names alone, two fragments in one section
-# to make within-section filename order observable, a lead carrying a blank
-# RUN so the collapse to one blank is visible, and a second section heading
-# further down so the collapse of two headings into one is too.
-printf '%s' '# Changelog
+# headings spelled from the section names alone, two fragments in one
+# section to make within-section filename order observable, a lead carrying
+# a blank RUN so the collapse to one blank is visible, and a second section
+# heading further down so the collapse of two headings into one is too.
+ALL_IN='# Changelog
 
 Preamble.
 
@@ -203,20 +222,8 @@ A second lead paragraph, after the blank run above.
 ### Added
 
 - A released entry.
-' | reset
-printf -- '- Added, first by filename.\n' | frag added ken-1.md
-printf -- '- Added, second by filename.\n' | frag added ken-2.md
-printf -- '- Changed something.\n' | frag changed ken-3.md
-printf -- '- Deprecated something.\n' | frag deprecated ken-4.md
-printf -- '- Removed something.\n' | frag removed ken-5.md
-printf -- '- Fixed something.\n' | frag fixed ken-6.md
-# No trailing newline: two entries glued into one line is what normalizing it
-# prevents, and only a fixture written this way can catch that.
-printf -- '- Tightened something.' | frag security ken-7.md
-run_collate
-[ "$RC" -eq 0 ] && case "$OUT" in *"folded 7 entries into CHANGELOG.md's [Unreleased] section"*) true ;; *) false ;; esac \
-  && ok "the fold reports what it folded" || bad "the fold reports what it folded" "rc=$RC out=$OUT"
-EXPECTED='# Changelog
+'
+ALL_OUT='# Changelog
 
 Preamble.
 
@@ -259,20 +266,23 @@ A second lead paragraph, after the blank run above.
 
 - A released entry.
 '
-[ "$(cat "$R/CHANGELOG.md")" = "$(printf '%s' "$EXPECTED")" ] \
-  && ok "the collated block is exactly the expected one" \
-  || bad "the collated block is exactly the expected one" "$(diff <(printf '%s' "$EXPECTED") "$R/CHANGELOG.md" || true)"
-LEFT="$(find "$R/changelog.d" -mindepth 1 | sort | tr '\n' ' ')"
-[ -z "$LEFT" ] && ok "every fragment and the section directory each leaves empty are gone" \
-  || bad "every fragment and the section directory each leaves empty are gone" "$LEFT"
-no_staging && ok "the install leaves no staging file beside the record" \
-  || bad "the install leaves no staging file beside the record" "$STAGING"
+fx_all() {
+  repo all "$ALL_IN"
+  frag added ken-1.md '- Added, first by filename.\n'
+  frag added ken-2.md '- Added, second by filename.\n'
+  frag changed ken-3.md '- Changed something.\n'
+  frag deprecated ken-4.md '- Deprecated something.\n'
+  frag removed ken-5.md '- Removed something.\n'
+  frag fixed ken-6.md '- Fixed something.\n'
+  # No trailing newline: two entries glued into one line is what normalizing
+  # it prevents, and only a fixture written this way can catch that.
+  frag security ken-7.md '- Tightened something.'
+}
+# The heading further down than the seed's: the split runs at the line
+# numbers this record was accepted with, and no preamble is lost.
+MOVED_IN='# Changelog
 
-echo "=== moving the heading moves the split point ==="
-printf '%s' "$RECORD" | reset
-printf '%s' '# Changelog
-
-Preamble the staged copy adds.
+Preamble the record adds.
 
 More preamble.
 
@@ -287,13 +297,10 @@ More preamble.
 ### Added
 
 - A released entry.
-' | stage_record
-printf -- '- Folded in below the moved heading.\n' | frag fixed ken-1.md
-run_collate
-[ "$RC" -eq 0 ] && ok "a record whose section moved still folds" || bad "a record whose section moved still folds" "rc=$RC out=$OUT"
-MOVED='# Changelog
+'
+MOVED_OUT='# Changelog
 
-Preamble the staged copy adds.
+Preamble the record adds.
 
 More preamble.
 
@@ -313,74 +320,40 @@ More preamble.
 
 - A released entry.
 '
-[ "$(cat "$R/CHANGELOG.md")" = "$(printf '%s' "$MOVED")" ] \
-  && ok "and it is split at the moved section, losing no preamble" \
-  || bad "and it is split at the moved section, losing no preamble" "$(diff <(printf '%s' "$MOVED") "$R/CHANGELOG.md" || true)"
+fx_moved() { repo moved "$MOVED_IN"; frag fixed ken-1.md '- Folded in below the moved heading.\n'; }
+# The section ends with the file: nothing follows it, and no separator is written.
+TAIL_IN='# Changelog
 
-echo "=== an unstaged edit stops the write, on either side of the fold ==="
-printf '%s' "$RECORD" | reset
-printf -- '- Folded in.\n' | frag fixed ken-1.md
-printf -- '- Edited only on disk.\n' >"$R/changelog.d/fixed/ken-1.md"
-run_collate
-[ "$RC" -eq 2 ] && case "$OUT" in *"requires a clean index and working tree"*"changelog.d/fixed/ken-1.md"*) true ;; *) false ;; esac \
-  && ok "a fragment git and the disk disagree about refuses the fold" \
-  || bad "a fragment git and the disk disagree about refuses the fold" "rc=$RC out=$OUT"
-untouched && ok "the record is untouched by that refusal too" || bad "the record is untouched by that refusal too" "$(cat "$R/CHANGELOG.md")"
-[ -f "$R/changelog.d/fixed/ken-1.md" ] && ok "and the fragment survives it too" || bad "and the fragment survives it too" "deleted"
+## [Unreleased]
 
-# The RECORD half of that same guard. Without it the fold publishes a record
-# nothing measured and then deletes the fragments that went into it, so the
-# unstaged edit ships with no copy left to recover the entries from.
-printf '%s' "$RECORD" | reset
-printf -- '- Folded in.\n' | frag fixed ken-1.md
-printf -- '\n- An entry only the disk carries.\n' >>"$R/CHANGELOG.md"
-run_collate
-[ "$RC" -eq 2 ] && case "$OUT" in *"requires a clean index and working tree"*"CHANGELOG.md"*) true ;; *) false ;; esac \
-  && ok "a record git and the disk disagree about refuses the fold" \
-  || bad "a record git and the disk disagree about refuses the fold" "rc=$RC out=$OUT"
-[ -f "$R/changelog.d/fixed/ken-1.md" ] && ok "and the fragment survives that refusal" \
-  || bad "and the fragment survives that refusal" "deleted"
-case "$(cat "$R/CHANGELOG.md")" in
-  *"An entry only the disk carries"*) ok "the unstaged record edit is neither published nor overwritten" ;;
-  *) bad "the unstaged record edit is neither published nor overwritten" "$(cat "$R/CHANGELOG.md")" ;;
-esac
+### Added
 
-echo "=== a failure at the rename leaves nothing half-written ==="
-# A stub ahead of PATH is how a failure is reached in the window where the
-# staging file already exists: nothing else in the fold runs mv.
-STUB="$TMP/stub"
-mkdir -p "$STUB"
-printf '#!/bin/sh\necho "mv: refused by the test stub" >&2\nexit 1\n' >"$STUB/mv"
-chmod +x "$STUB/mv"
-printf '%s' "$RECORD" | reset
-printf -- '- Folded in.\n' | frag fixed ken-1.md
-OUT=""
-RC=0
-OUT="$(cd "$R" && PATH="$STUB:$PATH" "$CE" --collate 2>&1)" || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"could not replace the collated changelog"*) true ;; *) false ;; esac \
-  && ok "a failed rename is a loud refusal" || bad "a failed rename is a loud refusal" "rc=$RC out=$OUT"
-# What the tool said arrives INSIDE the guard's line, not on a bare line ahead
-# of it: a reader takes the first line they see as the cause, and `mv: ...`
-# alone names the symptom without saying what was being done.
-case "$OUT" in
-  *"could not replace the collated changelog"*"refused by the test stub"*)
-    ok "and it carries what mv said inside its own line" ;;
-  *) bad "and it carries what mv said inside its own line" "$OUT" ;;
-esac
-untouched && ok "the record is byte-identical after the failed rename" \
-  || bad "the record is byte-identical after the failed rename" "$(cat "$R/CHANGELOG.md")"
-no_staging && ok "and no staging file survives beside it" || bad "and no staging file survives beside it" "$STAGING"
-[ -f "$R/changelog.d/fixed/ken-1.md" ] \
-  && ok "the fragment is not deleted for a record that was never replaced" \
-  || bad "the fragment is not deleted for a record that was never replaced" "deleted"
+- An entry the record already carries.
+'
+TAIL_OUT='# Changelog
 
-echo "=== nothing to fold is a no-op ==="
-printf '%s' "$RECORD" | reset
-run_collate
-[ "$RC" -eq 0 ] && case "$OUT" in *"no fragments — nothing to collate"*) true ;; *) false ;; esac \
-  && ok "an empty tree folds nothing and says so" || bad "an empty tree folds nothing and says so" "rc=$RC out=$OUT"
+## [Unreleased]
 
-untouched && ok "the record is untouched with nothing to fold" || bad "the record is untouched with nothing to fold" "$(cat "$R/CHANGELOG.md")"
+### Added
+
+- An entry the record already carries.
+- Folded in at the end of the file.
+'
+fx_tail() { repo tail "$TAIL_IN"; frag added ken-1.md '- Folded in at the end of the file.\n'; }
+fx_newline_name() { repo newline-name; frag fixed $'a\nb.md' '- Folded in.\n'; }
+fx_readme() { repo readme; mkdir -p "$R/changelog.d"; printf 'The format.\n' >"$R/changelog.d/README.md"; git -C "$R" add -A; git -C "$R" commit -qm 'chore: readme'; frag fixed pending.md '- Folded in.\n'; }
+fx_nothing() { repo nothing; }
+fx_mv_fails() { pending mv-fails; }
+fx_rm_fails() { pending rm-fails; }
+run_rows \
+  "every section in Keep a Changelog order, filename order within one, two headings collapsed, the lead trimmed, a newline-less fragment normalized|fx_all|||rc=0 $(folded 7 entries)|ALL_OUT|-" \
+  "a heading further down is split at its own line numbers, losing no preamble|fx_moved|||rc=0 $(folded 1 entry)|MOVED_OUT|-" \
+  "a section that ends with the file is folded into with no separator after it|fx_tail|||rc=0 $(folded 1 entry)|TAIL_OUT|-" \
+  "a fragment whose name carries a newline is folded in and removed like any other|fx_newline_name|||rc=0 $(folded 1 entry)|FOLDED|-" \
+  "the format's README is neither folded nor swept, and its directory stays|fx_readme|||rc=0 $(folded 1 entry)|FOLDED|changelog.d/README.md" \
+  "nothing to fold is a stated no-op|fx_nothing|||rc=0 changelog-entries: no fragments — nothing to collate|SEED|-" \
+  "a rename that fails is a loud refusal carrying what mv said, the record byte-identical, no staging file, the fragment kept|fx_mv_fails||mv|rc=2 ${ERR}could not replace the collated changelog at CHANGELOG.md (mv: refused by the test stub) — inspect the file before trusting it|SEED|$ONE" \
+  "a fragment that survives its delete is named, after the record was replaced|fx_rm_fails||rm|rc=2 rm: refused by the test stub;${ERR}CHANGELOG.md is collated, but these fragments survived and would fold in a second time — delete them by hand:;  changelog.d/fixed/pending.md|FOLDED|$ONE"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Reshapes `skills/commit-guards/tests/changelog-collate.test.sh` to code-quality § Tests. The old suite pinned the release fold in one 386-line linear script of about forty substring assertions, so the exit status was read as a bit, the record was searched for phrases rather than compared, and what the fold left under the fragment tree was never pinned. It is now one table of 26 rows, 78 assertions (`label|fixture|env|shim|expect|record|left`): a row builds its own repository with the record and one release input committed, runs `changelog-entries --collate` and reads back the exit status with every line printed, joined by `;`; then the record, compared with `cmp` against the seed the fixture committed or the exact folded text the row names; then what is left under `changelog.d` beside any staging file. Three sections: the release write's flag and clean-tree gate (every refusal writes nothing, the disk edit neither published nor overwritten, ignored scratch inside the tree not blocking, a failing `git status` unable to authorize the write); the record's shape judged before the fold (a misspelled section, no heading, two headings, an open fence, an untracked record, the scope off, a fragment the judge refuses stopping the run with its acceptable neighbour neither folded nor deleted); and every guarantee of the fold on one record with one exact expected output (all six sections in Keep a Changelog order, filename order within one, two headings collapsed, the lead trimmed, a newline-less fragment normalized, a heading further down split at its own line numbers, a section ending with the file, a newline-named fragment, the README kept, the no-op, a failed rename, a failed delete).

Every former assertion has a row; none were deleted. The second commit is the reviewer's round: every survivor of a failed delete named through the path escaper (a second fragment `a b.md` beside the first, both listed, the record carrying both), the record scope's two shape refusals the fold carries as its own (a record tracked as a symlink, a record carrying a NUL), and the no-fragments no-op run against a record with no `[Unreleased]` heading, which passes because nothing reads the destination. The seed is kept as a file beside each repository so a record holding a NUL still compares byte for byte.

The tracked render under `.agents/` is replayed with `patch`.

## Mutation

39 exact-substring mutants over `lib/changelog-collate.sh`, `lib/changelog-record-scope.sh` and the script's collate branch (the flag gate, the dirty gate and its listing, the no-op, the section headings and their order, within-section order, the two-heading collapse, the lead trim, the newline normalization, the split bounds, the separator before the released versions, the assemble and install path, the survivor listing, the directory sweep, the count noun): all 39 killed by a named row (`mutants-cc.txt`, `mutants-cc-2.txt`). Nine fixture mutants, each fixture's planted drift removed: eight fail their row, one equivalent (`fixture-mutants-cc.txt`). The reviewer's three blockers are the second commit's rows; five mutants over them (the escaper bypassed, only the first survivor named, a symlink record accepted, a binary record accepted, the destination read with nothing to fold) all killed (`mutants-cc-3.txt`).

Recorded, not fixed: the collate library's own RECORD and RECORD_SHA refusals and three more arms (`lib/changelog-collate.sh` lines 94 to 98, 118, 137, 143) are shadowed by the record scope and the dirty gate; dead code, a separate disposition.

## Checks

- `changelog-collate.test.sh`: 78 assertions pass on this host and under a symlinked TMPDIR. `tools/bash32-lint` clean over 38 files.
- `tools/guard --full` (`TMPDIR=/tmp`): exit 0 on the first commit; on the second every lane passed except `install-git-hooks.test.sh`, whose nine failures all carried `failed to create thread: Resource temporarily unavailable` from `git grep` under box load, and the suite re-run alone passes 111/111.
- One reviewer-test round: fix-first with three blockers and two suggestions, the blockers applied as the second commit, one suggestion a comment, one recorded above (the harness refused the subagent's report write; the verdict was read from its transcript).

KEN-1241

https://claude.ai/code/session_01BfzLjeGYNT3DMhBJhg24md
