### PR TITLE
test(KEN-1241): the BSD userland suites as tables of rows

### DIFF
--- a/.agents/skills/commit-guards/tests/bsd-argv-install.test.sh
+++ b/.agents/skills/commit-guards/tests/bsd-argv-install.test.sh
@@ -1,52 +1,58 @@
 #!/usr/bin/env bash
-# install-git-hooks under BSD argv rules, as a program rather than a lint.
+# Pins for scripts/install-git-hooks under BSD argv rules, as a program
+# rather than a lint: commit-guards installs on macOS, where chmod and sed
+# are BSD, and getopt(3) there stops at the first non-option argument, so a
+# `--` after chmod's mode or after sed's script is a file operand nobody
+# has. A lint over the shell source has no bottom (the same call can be
+# spelled more ways than a regex enumerates), so the rule is put in two
+# shims on PATH and the real installer runs under them. The merge-group
+# macOS lane stays the platform proof; this is what a Linux run says on its
+# own. Bash 4 syntax in the shipped scripts is `tools/bash32-lint`.
 #
-# commit-guards installs on macOS, where the utilities are BSD, not GNU. That
-# would be a text scan for the shapes a BSD utility rejects, and it was
-# wrong four times running: each spelling missed an argument form the next
-# reviewer found, because a lint over shell source has no bottom — the same
-# command can be written in more ways than a regex can enumerate.
-#
-# So it is not read any more, it is RUN. The BSD rule is put in a shim on
-# PATH and the real installer executes under it, which cannot be evaded by
-# spelling: whatever the scripts call chmod with, the shim judges it the way
-# macOS would. The merge-group macOS lane stays the platform proof; this is
-# what every Linux run can say on its own.
-#
-# Bash 4 syntax in the shipped scripts is `tools/bash32-lint`, run over the
-# roster `tools/bash32-lint --list` prints.
+# One table: PACKAGE is the shipped skill or a copy with one wrong order
+# restored; the installer runs with ARGS in a fresh repository, and the row
+# pins the exit status with every line printed and the mode of each of the
+# three hook files, so the installer's verdict and the bits git will read
+# are one pin. Every row runs under both shims; a package that calls
+# neither utility with a `--` operand never meets them.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SCRIPTS_DIR="$(cd "$TEST_DIR/../scripts" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+# shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
-# The BSD argv rule, as a program the installer actually runs.
-#
-# getopt(3) stops at the first non-option argument. For chmod that argument
-# is the mode, so every token after it is a file operand — and a `--` there
-# is a file named `--`, which does not exist. BSD chmod fails on it. GNU
-# permutes its arguments and accepts the same line, which is why this can
-# only be caught by judging the call rather than by reading the source.
+umask 022
+
+PASS=0
+FAIL=0
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
+
+# The BSD rules, as programs. chmod: options first, exactly as getopt(3)
+# takes them; the first non-option is the mode and everything after it is a
+# file operand, so a `--` there is a file named `--`. GNU permutes its
+# arguments and accepts the same line. sed: the same rule with the script in
+# the mode's place; BSD sed reports the `--` operand and exits 1 while still
+# processing the real file, so a caller reading the exit status sees a
+# failure over content it actually got.
 shim="$TMP/shim"
 mkdir -p "$shim"
 cat >"$shim/chmod" <<'SHIM'
 #!/bin/sh
-# Options first, exactly as getopt(3) takes them.
 while [ $# -gt 0 ]; do
   case "$1" in
-    # `--` here ends option parsing: the mode follows. This is the one
-    # correct shape, and it is passed straight through.
-    --)
-      shift
-      break
-      ;;
+    --) shift; break ;;
     -[RfhvHLP]*) shift ;;
-    # Anything else is the mode, and option parsing is over.
     *) break ;;
   esac
 done
-# From here every argument is a file operand. A `--` among them is a file
-# nobody has.
 mode="${1-}"
 [ $# -gt 0 ] && shift
 for arg in "$@"; do
@@ -57,99 +63,9 @@ for arg in "$@"; do
 done
 exec /bin/chmod "$mode" "$@"
 SHIM
-chmod 0755 "$shim/chmod"
-
-# The shim has teeth, and only on the wrong shape.
-: >"$TMP/probe-file"
-if PATH="$shim:$PATH" chmod +x -- "$TMP/probe-file" 2>/dev/null; then
-  echo "FAIL: the shim accepts a trailing --, so it judges nothing" >&2
-  exit 1
-fi
-if ! PATH="$shim:$PATH" chmod -- +x "$TMP/probe-file" 2>/dev/null; then
-  echo "FAIL: the shim rejects the correct order, so it would fail any installer" >&2
-  exit 1
-fi
-[ -x "$TMP/probe-file" ] || {
-  echo "FAIL: the shim did not exec the real chmod" >&2
-  exit 1
-}
-
-# A repository, and the package installed into it the way a consumer has it.
-repo="$TMP/bsd-repo"
-mkdir -p "$repo/.agents/skills"
-git -C "$repo" init -q
-git -C "$repo" config user.email t@t
-git -C "$repo" config user.name t
-cp -R "$SCRIPTS_DIR/.." "$repo/.agents/skills/commit-guards"
-installer="$repo/.agents/skills/commit-guards/scripts/install-git-hooks"
-
-out=""
-status=0
-out="$(PATH="$shim:$PATH" "$installer" --repo "$repo" 2>&1)" || status=$?
-if [ "$status" -ne 0 ]; then
-  echo "FAIL: the install failed under BSD chmod argv rules (exit $status)" >&2
-  printf '%s\n' "$out" >&2
-  exit 1
-fi
-
-# git ignores a hook without the bit, so this is the assertion that matters:
-# not that the installer said armed, but that the files it wrote can run.
-for lane in pre-commit commit-msg kendex-guards; do
-  [ -x "$repo/.git/hooks/$lane" ] || {
-    echo "FAIL: $lane is not executable after an install under BSD chmod" >&2
-    printf '%s\n' "$out" >&2
-    exit 1
-  }
-done
-
-# And the package's own verdict agrees, which is the pair that came apart on
-# macOS: two hooks reported armed over a repository that gated nothing.
-check=""
-check_status=0
-check="$(PATH="$shim:$PATH" "$installer" --repo "$repo" --check 2>&1)" || check_status=$?
-if [ "$check_status" -ne 0 ]; then
-  echo "FAIL: --check does not read the repository as armed (exit $check_status)" >&2
-  printf '%s\n' "$check" >&2
-  exit 1
-fi
-
-# The control: a copy of the package with the wrong order restored must NOT
-# come out armed. Without this the pin passes on any installer, including one
-# that never calls chmod at all.
-broken="$TMP/broken"
-mkdir -p "$broken/.agents/skills"
-git -C "$broken" init -q
-git -C "$broken" config user.email t@t
-git -C "$broken" config user.name t
-cp -R "$SCRIPTS_DIR/.." "$broken/.agents/skills/commit-guards"
-broken_installer="$broken/.agents/skills/commit-guards/scripts/install-git-hooks"
-perl -pi -e 's/chmod -- \+x/chmod +x --/; s/chmod -- 0755/chmod 0755 --/' "$broken_installer"
-grep -q 'chmod +x --' "$broken_installer" || {
-  echo "FAIL: the control could not restore the wrong order; the assertion below proves nothing" >&2
-  exit 1
-}
-PATH="$shim:$PATH" "$broken_installer" --repo "$broken" >/dev/null 2>&1 || true
-if [ -x "$broken/.git/hooks/pre-commit" ] && [ -x "$broken/.git/hooks/commit-msg" ]; then
-  echo "FAIL: must-fail control armed under BSD chmod with the wrong argv order" >&2
-  exit 1
-fi
-
-echo "pass: bsd-argv-install"
-
-# --- BSD sed argv, the same way: run it, do not read it -------------------
-#
-# `--` is not an end-of-options marker for BSD sed either. getopt(3) stops at
-# the first non-option argument, which for sed is the script, so a `--` after
-# it is a file operand — a file named `--`, which nobody has. BSD sed reports
-# it and exits 1 while still processing the real file, so a caller reading the
-# exit status sees a failure over content it actually got. install-git-hooks
-# reads line 3 of a candidate helper that way, and preflight reads a runner
-# body that way; the same rule judges both, and this is install-git-hooks.
 REAL_SED="$(command -v sed)"
 cat >"$shim/sed" <<SHIM
 #!/bin/sh
-# Every argument after the script is a file operand; a \`--\` among them is a
-# file nobody has.
 seen_script=0
 for arg in "\$@"; do
   case "\$seen_script\$arg" in
@@ -163,56 +79,89 @@ for arg in "\$@"; do
 done
 exec $REAL_SED "\$@"
 SHIM
-chmod 0755 "$shim/sed"
+chmod 0755 "$shim/chmod" "$shim/sed"
+mode() { if [ -e "$1" ]; then ls -ld "$1" | cut -c1-10; else echo absent; fi; } # PATH — the permission string, or absent
+probe() { local rc=0; "$@" >/dev/null 2>&1 || rc=$?; echo "rc=$rc"; } # CMD... — the exit status under the shims
 
-# The shim has teeth, and only on the wrong shape.
+echo "=== premise: each shim refuses only the shape BSD refuses, and hands the rest to the real utility ==="
+: >"$TMP/probe-file"
 printf 'a\nb\nc\n' >"$TMP/sed-probe"
-if PATH="$shim:$PATH" sed -n '3p' -- "$TMP/sed-probe" >/dev/null 2>&1; then
-  echo "FAIL: the sed shim accepts a -- operand, so it judges nothing" >&2
-  exit 1
-fi
-if [ "$(PATH="$shim:$PATH" sed -n '3p' <"$TMP/sed-probe")" != c ]; then
-  echo "FAIL: the sed shim does not pass a correct call through to the real sed" >&2
-  exit 1
-fi
+PATH="$shim:$PATH"
+assert_eq "chmod with -- after the mode is refused" "rc=1" "$(probe chmod +x -- "$TMP/probe-file")"
+assert_eq "control: chmod with -- before the mode runs the real chmod and sets the bit" "rc=0 -rwxr-xr-x" "$(probe chmod -- +x "$TMP/probe-file") $(mode "$TMP/probe-file")"
+assert_eq "sed with a -- operand after the script is refused" "rc=1" "$(probe sed -n '3p' -- "$TMP/sed-probe")"
+assert_eq "control: sed over stdin runs the real sed" "c" "$(sed -n '3p' <"$TMP/sed-probe")"
 
-# A helper an earlier install wrote, whose baked scripts directory is gone.
-# install-git-hooks replaces exactly that file and refuses every other one, so
-# reading its line 3 is the whole decision: a read that fails leaves ours
-# looking like somebody else's file and the install stops.
-dangling_helper() { # REPO — plant a helper of an install that no longer exists
+# One line for a run: the exit status, every line printed with the
+# repository path aliased (the installer prints it resolved, so a symlinked
+# TMPDIR is aliased under both spellings), then the three hook files' modes.
+R=""
+run() { # ARGS...
+  local rc=0 out="" real
+  real="$(cd "$R" && pwd -P)"
+  out="$("$R/.agents/skills/commit-guards/scripts/install-git-hooks" --repo "$R" "$@" 2>&1)" || rc=$?
+  printf 'rc=%s%s modes=%s,%s,%s' "$rc" "${out:+ $(printf '%s\n' "$out" | LC_ALL=C sed "s#$real#<repo>#g; s#$R#<repo>#g" | LC_ALL=C paste -sd ';' -)}" \
+    "$(mode "$R/.git/hooks/pre-commit")" "$(mode "$R/.git/hooks/commit-msg")" "$(mode "$R/.git/hooks/kendex-guards")"
+}
+
+# Fixture vocabulary: a fresh repository with the package copied in as a
+# consumer has it, under one of three packagings.
+repo() { # NAME
+  R="$TMP/$1"
+  [ ! -e "$R" ] || { echo "harness: fixture $1 already exists" >&2; exit 2; }
+  mkdir -p "$R/.agents/skills"
+  git -C "$R" -c init.defaultBranch=main init -q
+  git -C "$R" config user.email t@t
+  git -C "$R" config user.name t
+  cp -R "$SKILL_DIR" "$R/.agents/skills/commit-guards"
+}
+INSTALLER=".agents/skills/commit-guards/scripts/install-git-hooks"
+real() { repo "$1"; } # NAME — the shipped package
+broken_chmod() { # NAME — the package with chmod's wrong order restored
+  repo "$1"
+  perl -pi -e 's/chmod -- \+x/chmod +x --/; s/chmod -- 0755/chmod 0755 --/' "$R/$INSTALLER"
+}
+broken_sed() { # NAME — the package reading a helper's line 3 with a -- operand
+  repo "$1"
+  perl -pi -e "s/sed -n '3p' <\"\\\$1\"/sed -n '3p' -- \"\\\$1\"/" "$R/$INSTALLER"
+}
+installed() { real "$1"; "$R/$INSTALLER" --repo "$R" >/dev/null 2>&1; } # NAME — the shipped package, already armed
+dangling() { # NAME — a helper an install that no longer exists wrote; line 3 names its scripts directory
   printf '#!/bin/sh\n# Scripts directory of the install that wrote this file.\ninstalled_scripts=%s\n# kendex earlier-package git hooks. Managed by an earlier install.\nexit 0\n' \
-    "'$TMP/install-that-moved/scripts'" >"$1/.git/hooks/kendex-guards"
+    "'$TMP/install-that-moved/scripts'" >"$R/.git/hooks/kendex-guards"
+}
+dangling_real() { real "$1"; dangling; }
+dangling_broken_sed() { broken_sed "$1"; dangling; }
+
+echo "=== premise: each broken package holds exactly the shape it restores ==="
+broken_chmod shape-chmod
+assert_eq "the chmod control restores the wrong order at both call sites" "1 1" "$(grep -c 'chmod +x --' "$R/$INSTALLER") $(grep -c 'chmod 0755 --' "$R/$INSTALLER")"
+broken_sed shape-sed
+assert_eq "the sed control restores the -- operand at its one call site" "1" "$(grep -c "sed -n '3p' -- " "$R/$INSTALLER")"
+
+run_rows() { # label | fixture | args | expect
+  local row label fx args expect words
+  for row in "$@"; do
+    IFS='|' read -r label fx args expect <<<"$row"
+    R=""
+    read -ra words <<<"$fx"
+    "${words[@]}"
+    # shellcheck disable=SC2086
+    assert_eq "$label" "$expect" "$(run $args)"
+  done
 }
 
-dangling_helper "$repo"
-out=""
-status=0
-out="$(PATH="$shim:$PATH" "$installer" --repo "$repo" 2>&1)" || status=$?
-case "$out" in
-  *"scripts directory is gone; replacing it"*) ;;
-  *)
-    echo "FAIL: under BSD sed argv rules the dangling helper was not recognised (exit $status)" >&2
-    printf '%s\n' "$out" >&2
-    exit 1
-    ;;
-esac
+echo "=== the installer under BSD chmod and sed: its verdict and the bits git reads are one pin ==="
+X="-rwxr-xr-x"
+ARMED="commit-guards git hooks: pre-commit and commit-msg armed in <repo>/.git/hooks"
+NOT_INSTALLED="commit-guards git hooks: NOT installed — could not write <repo>/.git/hooks/kendex-guards"
+run_rows \
+  "the shipped package arms both hooks and the helper, every file executable|real install||rc=0 $ARMED modes=$X,$X,$X" \
+  "--check reads the same repository as armed|installed check|--check|rc=0 commit-guards git hooks: armed — pre-commit and commit-msg gate commits in <repo>/.git/hooks modes=$X,$X,$X" \
+  "control: chmod's wrong order writes nothing under BSD rules, and the installer says so|broken_chmod broken-install||rc=1 $NOT_INSTALLED modes=absent,absent,absent" \
+  "control: --check over that repository reads it as not armed|broken_chmod broken-check|--check|rc=1 commit-guards git hooks: NOT armed — helper kendex-guards is missing; pre-commit is missing; commit-msg is missing (<repo>/.git/hooks); run 'kendex guard install' (or this installer) to re-arm modes=absent,absent,absent" \
+  "a helper whose scripts directory is gone is recognised from its line 3 and replaced|dangling_real dangling||rc=0 ::warning::install-git-hooks: <repo>/.git/hooks/kendex-guards was written by an install whose scripts directory is gone; replacing it;$ARMED modes=$X,$X,$X" \
+  "control: reading line 3 with a -- operand fails under BSD sed, so the helper reads as somebody else's and the install stops|dangling_broken_sed dangling-broken||rc=1 ::warning::install-git-hooks: <repo>/.git/hooks/kendex-guards exists but was not written by this installer; refusing to overwrite it;$NOT_INSTALLED modes=absent,absent,-rw-r--r--"
 
-# The control: a copy with the `--` restored must NOT recognise it. Without
-# this the assertion above passes on any installer, including one that never
-# reads line 3.
-perl -pi -e "s/sed -n '3p' <\"\\\$1\"/sed -n '3p' -- \"\\\$1\"/" "$broken_installer"
-grep -q "sed -n '3p' -- " "$broken_installer" || {
-  echo "FAIL: the control could not restore the -- operand; the assertion below proves nothing" >&2
-  exit 1
-}
-dangling_helper "$broken"
-broken_out="$(PATH="$shim:$PATH" "$broken_installer" --repo "$broken" 2>&1)" || true
-case "$broken_out" in
-  *"scripts directory is gone; replacing it"*)
-    echo "FAIL: must-fail control recognised the dangling helper with a -- operand under BSD sed" >&2
-    exit 1
-    ;;
-esac
-
-echo "pass: bsd-argv-sed"
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.agents/skills/commit-guards/tests/bsd-argv-install.test.sh
+++ b/.agents/skills/commit-guards/tests/bsd-argv-install.test.sh
@@ -39,57 +39,61 @@ assert_eq() { # LABEL EXPECT ACTUAL
 # takes them; the first non-option is the mode and everything after it is a
 # file operand, so a `--` there is a file named `--`. GNU permutes its
 # arguments and accepts the same line. sed: the same rule with the script in
-# the mode's place; BSD sed reports the `--` operand and exits 1 while still
-# processing the real file, so a caller reading the exit status sees a
-# failure over content it actually got.
+# the mode's place. Both BSD utilities report the `--` operand, still
+# process the real operands, and exit 1, so a caller reading the exit
+# status sees a failure over work it actually got; the shims do the same,
+# which is what makes a read that discards good content on that status
+# visible.
 shim="$TMP/shim"
 mkdir -p "$shim"
 cat >"$shim/chmod" <<'SHIM'
 #!/bin/sh
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --) shift; break ;;
-    -[RfhvHLP]*) shift ;;
-    *) break ;;
+n=$#; i=0; phase=opts; bad=0
+while [ "$i" -lt "$n" ]; do
+  arg=$1; shift; i=$((i + 1))
+  case "$phase" in
+    opts) case "$arg" in
+      --) phase=mode; continue ;;
+      -[RfhvHLP]*) set -- "$@" "$arg"; continue ;;
+      *) phase=files; set -- "$@" "$arg"; continue ;;
+    esac ;;
+    mode) phase=files; set -- "$@" "$arg"; continue ;;
+    files) if [ "$arg" = "--" ]; then bad=1; echo "chmod: --: No such file or directory" >&2; continue; fi; set -- "$@" "$arg" ;;
   esac
 done
-mode="${1-}"
-[ $# -gt 0 ] && shift
-for arg in "$@"; do
-  if [ "$arg" = "--" ]; then
-    echo "chmod: --: No such file or directory" >&2
-    exit 1
-  fi
-done
-exec /bin/chmod "$mode" "$@"
+/bin/chmod "$@"; rc=$?
+[ "$bad" -eq 0 ] || exit 1
+exit "$rc"
 SHIM
 REAL_SED="$(command -v sed)"
 cat >"$shim/sed" <<SHIM
 #!/bin/sh
-seen_script=0
-for arg in "\$@"; do
-  case "\$seen_script\$arg" in
-    0-*) continue ;;
-  esac
-  if [ "\$seen_script" -eq 1 ] && [ "\$arg" = "--" ]; then
-    echo "sed: --: No such file or directory" >&2
-    exit 1
+n=\$#; i=0; seen=0; bad=0
+while [ "\$i" -lt "\$n" ]; do
+  arg=\$1; shift; i=\$((i + 1))
+  if [ "\$seen" -eq 0 ]; then
+    case "\$arg" in -*) ;; *) seen=1 ;; esac
+    set -- "\$@" "\$arg"; continue
   fi
-  seen_script=1
+  if [ "\$arg" = "--" ]; then bad=1; echo "sed: --: No such file or directory" >&2; continue; fi
+  set -- "\$@" "\$arg"
 done
-exec $REAL_SED "\$@"
+$REAL_SED "\$@"; rc=\$?
+[ "\$bad" -eq 0 ] || exit 1
+exit "\$rc"
 SHIM
 chmod 0755 "$shim/chmod" "$shim/sed"
 mode() { if [ -e "$1" ]; then ls -ld "$1" | cut -c1-10; else echo absent; fi; } # PATH — the permission string, or absent
 probe() { local rc=0; "$@" >/dev/null 2>&1 || rc=$?; echo "rc=$rc"; } # CMD... — the exit status under the shims
 
-echo "=== premise: each shim refuses only the shape BSD refuses, and hands the rest to the real utility ==="
+echo "=== premise: each shim fails the shape BSD fails after doing the work, and hands the rest to the real utility ==="
 : >"$TMP/probe-file"
+: >"$TMP/probe-file-2"
 printf 'a\nb\nc\n' >"$TMP/sed-probe"
 PATH="$shim:$PATH"
-assert_eq "chmod with -- after the mode is refused" "rc=1" "$(probe chmod +x -- "$TMP/probe-file")"
-assert_eq "control: chmod with -- before the mode runs the real chmod and sets the bit" "rc=0 -rwxr-xr-x" "$(probe chmod -- +x "$TMP/probe-file") $(mode "$TMP/probe-file")"
-assert_eq "sed with a -- operand after the script is refused" "rc=1" "$(probe sed -n '3p' -- "$TMP/sed-probe")"
+assert_eq "chmod with -- after the mode exits 1 with the bit set: BSD does the work, then fails" "rc=1 -rwxr-xr-x" "$(probe chmod +x -- "$TMP/probe-file") $(mode "$TMP/probe-file")"
+assert_eq "control: chmod with -- before the mode runs the real chmod and exits 0" "rc=0 -rwxr-xr-x" "$(probe chmod -- +x "$TMP/probe-file-2") $(mode "$TMP/probe-file-2")"
+assert_eq "sed with a -- operand after the script exits 1 with the line printed" "rc=1 c" "$(probe sed -n '3p' -- "$TMP/sed-probe") $(sed -n '3p' -- "$TMP/sed-probe" 2>/dev/null)"
 assert_eq "control: sed over stdin runs the real sed" "c" "$(sed -n '3p' <"$TMP/sed-probe")"
 
 # One line for a run: the exit status, every line printed with the
@@ -126,12 +130,16 @@ broken_sed() { # NAME — the package reading a helper's line 3 with a -- operan
   perl -pi -e "s/sed -n '3p' <\"\\\$1\"/sed -n '3p' -- \"\\\$1\"/" "$R/$INSTALLER"
 }
 installed() { real "$1"; "$R/$INSTALLER" --repo "$R" >/dev/null 2>&1; } # NAME — the shipped package, already armed
-dangling() { # NAME — a helper an install that no longer exists wrote; line 3 names its scripts directory
+broken_chmod_installed() { broken_chmod "$1"; "$R/$INSTALLER" --repo "$R" >/dev/null 2>&1 || true; } # NAME — after the install the wrong order fails
+helper() { # DIR — a helper another install wrote; line 3 names its scripts directory
   printf '#!/bin/sh\n# Scripts directory of the install that wrote this file.\ninstalled_scripts=%s\n# kendex earlier-package git hooks. Managed by an earlier install.\nexit 0\n' \
-    "'$TMP/install-that-moved/scripts'" >"$R/.git/hooks/kendex-guards"
+    "'$1'" >"$R/.git/hooks/kendex-guards"
 }
+dangling() { helper "$TMP/install-that-moved/scripts"; } # the install that wrote it is gone
+live() { mkdir -p "$TMP/other-install/scripts"; helper "$TMP/other-install/scripts"; } # the install that wrote it still exists
 dangling_real() { real "$1"; dangling; }
 dangling_broken_sed() { broken_sed "$1"; dangling; }
+live_real() { real "$1"; live; }
 
 echo "=== premise: each broken package holds exactly the shape it restores ==="
 broken_chmod shape-chmod
@@ -159,9 +167,10 @@ run_rows \
   "the shipped package arms both hooks and the helper, every file executable|real install||rc=0 $ARMED modes=$X,$X,$X" \
   "--check reads the same repository as armed|installed check|--check|rc=0 commit-guards git hooks: armed — pre-commit and commit-msg gate commits in <repo>/.git/hooks modes=$X,$X,$X" \
   "control: chmod's wrong order writes nothing under BSD rules, and the installer says so|broken_chmod broken-install||rc=1 $NOT_INSTALLED modes=absent,absent,absent" \
-  "control: --check over that repository reads it as not armed|broken_chmod broken-check|--check|rc=1 commit-guards git hooks: NOT armed — helper kendex-guards is missing; pre-commit is missing; commit-msg is missing (<repo>/.git/hooks); run 'kendex guard install' (or this installer) to re-arm modes=absent,absent,absent" \
+  "control: --check over the repository that install left reads it as not armed|broken_chmod_installed broken-check|--check|rc=1 commit-guards git hooks: NOT armed — helper kendex-guards is missing; pre-commit is missing; commit-msg is missing (<repo>/.git/hooks); run 'kendex guard install' (or this installer) to re-arm modes=absent,absent,absent" \
   "a helper whose scripts directory is gone is recognised from its line 3 and replaced|dangling_real dangling||rc=0 ::warning::install-git-hooks: <repo>/.git/hooks/kendex-guards was written by an install whose scripts directory is gone; replacing it;$ARMED modes=$X,$X,$X" \
-  "control: reading line 3 with a -- operand fails under BSD sed, so the helper reads as somebody else's and the install stops|dangling_broken_sed dangling-broken||rc=1 ::warning::install-git-hooks: <repo>/.git/hooks/kendex-guards exists but was not written by this installer; refusing to overwrite it;$NOT_INSTALLED modes=absent,absent,-rw-r--r--"
+  "control: reading line 3 with a -- operand fails under BSD sed, so the helper reads as somebody else's and the install stops|dangling_broken_sed dangling-broken||rc=1 ::warning::install-git-hooks: <repo>/.git/hooks/kendex-guards exists but was not written by this installer; refusing to overwrite it;$NOT_INSTALLED modes=absent,absent,-rw-r--r--" \
+  "control: a helper whose scripts directory still exists is another install's, and is refused|live_real live||rc=1 ::warning::install-git-hooks: <repo>/.git/hooks/kendex-guards exists but was not written by this installer; refusing to overwrite it;$NOT_INSTALLED modes=absent,absent,-rw-r--r--"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.agents/skills/commit-guards/tests/bsd-awk-record.test.sh
+++ b/.agents/skills/commit-guards/tests/bsd-awk-record.test.sh
@@ -1,39 +1,51 @@
 #!/usr/bin/env bash
-# The changelog family's encoding check under BWK awk's record rule, as a
-# program rather than a lint.
+# Pins for the changelog family's encoding check under BWK awk's record
+# rule, as a program rather than a lint. macOS ships BWK awk, which holds a
+# record as a NUL-terminated C string: a line's content stops at its first
+# NUL. GNU awk carries the whole line, so nothing on a Linux runner can see
+# the difference by reading the source; the rule is put in a shim on PATH
+# and the real check runs under it. What the rule costs: git calls a blob
+# binary only when a NUL falls in its leading sample, so a blob whose only
+# NUL is past that sample is text to git and must be text to this family
+# too. Under BWK's rule the UTF-8 pass never sees that NUL, the blob measures
+# as the short prefix before it, and an unmeasurable file is reported as an
+# over-long entry instead of being refused. scripts/lib/changelog-grammar.sh
+# translates every NUL to \200, a stray continuation byte its grammar
+# already rejects, before awk reads a byte; this suite pins that.
 #
-# macOS ships BWK awk ("awk version 20200816"), which holds a record as a
-# NUL-terminated C string: a line's content stops at its first NUL. GNU awk
-# carries the whole line, so nothing on a Linux runner can see the
-# difference by reading the source. It is put in a shim on PATH instead and
-# the real check runs under it.
-#
-# What the rule costs: git calls a blob binary only when a NUL falls in its
-# leading sample, so a blob whose only NUL is past that sample is text to
-# git and must be text to this family too. Under BWK's rule the UTF-8 pass
-# never sees that NUL, the blob measures as the short prefix before it, and
-# an unmeasurable file is reported as an over-long entry instead of being
-# refused. scripts/lib/changelog-grammar.sh translates every NUL to \200 — a
-# stray continuation byte its grammar already rejects — before awk reads a
-# byte, which is what this suite pins.
+# One table: PACKAGE is the shipped skill or a copy with the translation
+# removed; changelog-entries runs under the shim over a fragment git calls
+# text, and the row pins the exit status with every line printed.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 # shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
-
 unset COMMIT_GUARDS_CHANGELOG_CAP COMMIT_GUARDS_CHANGELOG_PATHS \
   COMMIT_GUARDS_CHANGELOG_RECORD COMMIT_GUARDS_SETTINGS_FILE 2>/dev/null || true
 
+PASS=0
+FAIL=0
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
+
+# The BWK rule, as a program: one argument is a program with its input on
+# stdin, which is how the changelog family reads a blob; that read is
+# truncated at each record's first NUL. Every other shape (a file operand,
+# -v, -F) passes straight through, so the shim judges that one read only.
 REAL_AWK="$(command -v awk)"
 shim="$TMP/shim"
 mkdir -p "$shim"
 cat >"$shim/awk" <<SHIM
 #!/bin/sh
-# One argument is a program and its input on stdin, which is how the
-# changelog family reads a blob. Every other shape — a file operand, -v, -F —
-# passes straight through, so this shim judges that one read and nothing else.
 if [ "\$#" -eq 1 ]; then
   perl -pe 's/\\0.*//' | $REAL_AWK "\$1"
   exit \$?
@@ -42,83 +54,63 @@ exec $REAL_AWK "\$@"
 SHIM
 chmod 0755 "$shim/awk"
 
-# The shim has teeth, and only on the shape it means to judge.
-truncated="$(printf 'ab\000cd\n' | PATH="$shim:$PATH" awk '{ print length($0) }')"
-[ "$truncated" = 2 ] || {
-  echo "FAIL: the awk shim does not truncate a record at its NUL (length $truncated)" >&2
-  exit 1
-}
-# Compared against the host's own awk, not against a number: BWK awk truncates
-# at a NUL whatever the input is, so on macOS the untouched answer is 2 and on
-# GNU it is 5. What must hold on both is that the shim changed nothing here.
+echo "=== premise: the shim truncates the one read it means to judge and nothing else ==="
 printf 'ab\000cd\n' >"$TMP/probe"
-whole="$(PATH="$shim:$PATH" awk '{ print length($0) }' "$TMP/probe")"
-native="$("$REAL_AWK" '{ print length($0) }' "$TMP/probe")"
-[ "$whole" = "$native" ] || {
-  echo "FAIL: the awk shim altered a call with a file operand (length $whole, host awk says $native)" >&2
-  exit 1
-}
+PATH="$shim:$PATH"
+assert_eq "a program over stdin sees the record end at its NUL" "2" "$(awk '{ print length($0) }' <"$TMP/probe")"
+# Compared against the host's own awk, not a number: BWK truncates whatever
+# the input, so the untouched answer is 2 on macOS and 5 on GNU.
+assert_eq "control: a file operand reads as the host's awk reads it" "$("$REAL_AWK" '{ print length($0) }' "$TMP/probe")" "$(awk '{ print length($0) }' "$TMP/probe")"
 
-# A fragment git calls text: 8100 bytes of content, then the file's only NUL.
+# The fragment: 8100 bytes of content, then the file's only NUL, past the
+# sample git sniffs; git calls it text, and its measure under BWK's rule is
+# the prefix.
+XS="$(i=0; while [ "$i" -lt 8100 ]; do printf x; i=$((i + 1)); done)"
 plant() { # REPO
   mkdir -p "$1/changelog.d/added"
-  {
-    printf -- '- '
-    i=0
-    while [ "$i" -lt 8100 ]; do printf x; i=$((i + 1)); done
-    printf '\000tail\n'
-  } >"$1/changelog.d/added/late-nul.md"
+  printf -- '- %s\000tail\n' "$XS" >"$1/changelog.d/added/late-nul.md"
   git -C "$1" add -A
 }
+R="$TMP/nul"
+mkdir -p "$R"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email t@t
+git -C "$R" config user.name t
+plant "$R"
+assert_eq "premise: git calls the fragment text" "changelog.d/added/late-nul.md" "$(git -C "$R" grep --cached -I -l . -- changelog.d/added)"
 
-new_repo() { # PATH
-  mkdir -p "$1"
-  git -C "$1" -c init.defaultBranch=main init -q
-  git -C "$1" config user.email t@t
-  git -C "$1" config user.name t
+# Fixture vocabulary: the package a row runs.
+PKG=""
+real() { PKG="$SKILL_DIR"; }
+broken() { # the package with the NUL translation removed
+  PKG="$TMP/broken-pkg/commit-guards"
+  mkdir -p "$TMP/broken-pkg"
+  cp -R "$SKILL_DIR" "$PKG"
+  perl -pi -e "s/LC_ALL=C tr '\\\\000' '\\\\200' <\"\\\$GG_TMP\\/blob\" \\| LC_ALL=C awk/LC_ALL=C awk/" "$PKG/scripts/lib/changelog-grammar.sh"
+}
+run() { # — the exit status and every line printed by PKG's changelog-entries over the fragment
+  local rc=0 out=""
+  out="$(cd "$R" && "$PKG/scripts/changelog-entries" 2>&1)" || rc=$?
+  printf 'rc=%s%s' "$rc" "${out:+ $(printf '%s\n' "$out" | LC_ALL=C paste -sd ';' -)}"
+}
+run_rows() { # label | package | expect
+  local row label pkg expect
+  for row in "$@"; do
+    IFS='|' read -r label pkg expect <<<"$row"
+    PKG=""
+    "$pkg"
+    assert_eq "$label" "$expect" "$(run)"
+  done
 }
 
-repo="$TMP/nul"
-new_repo "$repo"
-plant "$repo"
-[ -n "$(git -C "$repo" grep --cached -I -l . -- changelog.d/added)" ] || {
-  echo "FAIL: git calls the fixture blob binary, so it is not the case this suite means" >&2
-  exit 1
-}
+echo "=== premise: the broken package holds no translation ==="
+broken
+assert_eq "the control removed the NUL translation" "0" "$(grep -c "tr '\\\\000'" "$PKG/scripts/lib/changelog-grammar.sh")"
 
-out=""
-status=0
-out="$(cd "$repo" && PATH="$shim:$PATH" "$SKILL_DIR/scripts/changelog-entries" 2>&1)" || status=$?
-case "$status:$out" in
-  2:*"late-nul.md line 1 is not valid UTF-8"*) ;;
-  *)
-    echo "FAIL: under BWK awk's record rule the NUL past the sample was not refused (exit $status)" >&2
-    printf '%s\n' "$out" >&2
-    exit 1
-    ;;
-esac
+echo "=== a NUL past git's sample is refused as unmeasurable under BWK's record rule, not reported as a long entry ==="
+run_rows \
+  "the shipped package refuses the fragment naming its line|real|rc=2 ::error::changelog-entries: changelog.d/added/late-nul.md line 1 is not valid UTF-8 — text with no character count cannot be measured" \
+  "control: without the translation the record ends at the NUL and the prefix is measured as an over-long entry|broken|rc=1 changelog-entries FAIL long entry: changelog.d/added/late-nul.md — 8102 characters (cap 200);  entry: - $XS;  remedies: state the outcome and stop; a Breaking migration note stays inline, and the reasoning belongs in the commit;changelog-entries: 1 violation(s) — cap 200 characters, 1 fragment(s) measured"
 
-# The control: a copy of the package with the translation removed must NOT
-# refuse it. Without this the assertion above passes on any check, including
-# one that never reads the blob's bytes at all.
-broken="$TMP/broken-pkg"
-mkdir -p "$broken"
-cp -R "$SKILL_DIR" "$broken/commit-guards"
-grammar="$broken/commit-guards/scripts/lib/changelog-grammar.sh"
-perl -pi -e "s/LC_ALL=C tr '\\\\000' '\\\\200' <\"\\\$GG_TMP\\/blob\" \\| LC_ALL=C awk/LC_ALL=C awk/" "$grammar"
-grep -q "tr '\\\\000'" "$grammar" && {
-  echo "FAIL: the control could not remove the NUL translation; the assertion below proves nothing" >&2
-  exit 1
-}
-broken_repo="$TMP/broken-repo"
-new_repo "$broken_repo"
-plant "$broken_repo"
-broken_out="$(cd "$broken_repo" && PATH="$shim:$PATH" "$broken/commit-guards/scripts/changelog-entries" 2>&1)" || true
-case "$broken_out" in
-  *"is not valid UTF-8"*)
-    echo "FAIL: must-fail control refused the late NUL with the translation removed" >&2
-    exit 1
-    ;;
-esac
-
-echo "pass: bsd-awk-record"
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/skills/commit-guards/tests/bsd-argv-install.test.sh
+++ b/skills/commit-guards/tests/bsd-argv-install.test.sh
@@ -1,52 +1,58 @@
 #!/usr/bin/env bash
-# install-git-hooks under BSD argv rules, as a program rather than a lint.
+# Pins for scripts/install-git-hooks under BSD argv rules, as a program
+# rather than a lint: commit-guards installs on macOS, where chmod and sed
+# are BSD, and getopt(3) there stops at the first non-option argument, so a
+# `--` after chmod's mode or after sed's script is a file operand nobody
+# has. A lint over the shell source has no bottom (the same call can be
+# spelled more ways than a regex enumerates), so the rule is put in two
+# shims on PATH and the real installer runs under them. The merge-group
+# macOS lane stays the platform proof; this is what a Linux run says on its
+# own. Bash 4 syntax in the shipped scripts is `tools/bash32-lint`.
 #
-# commit-guards installs on macOS, where the utilities are BSD, not GNU. That
-# would be a text scan for the shapes a BSD utility rejects, and it was
-# wrong four times running: each spelling missed an argument form the next
-# reviewer found, because a lint over shell source has no bottom — the same
-# command can be written in more ways than a regex can enumerate.
-#
-# So it is not read any more, it is RUN. The BSD rule is put in a shim on
-# PATH and the real installer executes under it, which cannot be evaded by
-# spelling: whatever the scripts call chmod with, the shim judges it the way
-# macOS would. The merge-group macOS lane stays the platform proof; this is
-# what every Linux run can say on its own.
-#
-# Bash 4 syntax in the shipped scripts is `tools/bash32-lint`, run over the
-# roster `tools/bash32-lint --list` prints.
+# One table: PACKAGE is the shipped skill or a copy with one wrong order
+# restored; the installer runs with ARGS in a fresh repository, and the row
+# pins the exit status with every line printed and the mode of each of the
+# three hook files, so the installer's verdict and the bits git will read
+# are one pin. Every row runs under both shims; a package that calls
+# neither utility with a `--` operand never meets them.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SCRIPTS_DIR="$(cd "$TEST_DIR/../scripts" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+# shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
-# The BSD argv rule, as a program the installer actually runs.
-#
-# getopt(3) stops at the first non-option argument. For chmod that argument
-# is the mode, so every token after it is a file operand — and a `--` there
-# is a file named `--`, which does not exist. BSD chmod fails on it. GNU
-# permutes its arguments and accepts the same line, which is why this can
-# only be caught by judging the call rather than by reading the source.
+umask 022
+
+PASS=0
+FAIL=0
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
+
+# The BSD rules, as programs. chmod: options first, exactly as getopt(3)
+# takes them; the first non-option is the mode and everything after it is a
+# file operand, so a `--` there is a file named `--`. GNU permutes its
+# arguments and accepts the same line. sed: the same rule with the script in
+# the mode's place; BSD sed reports the `--` operand and exits 1 while still
+# processing the real file, so a caller reading the exit status sees a
+# failure over content it actually got.
 shim="$TMP/shim"
 mkdir -p "$shim"
 cat >"$shim/chmod" <<'SHIM'
 #!/bin/sh
-# Options first, exactly as getopt(3) takes them.
 while [ $# -gt 0 ]; do
   case "$1" in
-    # `--` here ends option parsing: the mode follows. This is the one
-    # correct shape, and it is passed straight through.
-    --)
-      shift
-      break
-      ;;
+    --) shift; break ;;
     -[RfhvHLP]*) shift ;;
-    # Anything else is the mode, and option parsing is over.
     *) break ;;
   esac
 done
-# From here every argument is a file operand. A `--` among them is a file
-# nobody has.
 mode="${1-}"
 [ $# -gt 0 ] && shift
 for arg in "$@"; do
@@ -57,99 +63,9 @@ for arg in "$@"; do
 done
 exec /bin/chmod "$mode" "$@"
 SHIM
-chmod 0755 "$shim/chmod"
-
-# The shim has teeth, and only on the wrong shape.
-: >"$TMP/probe-file"
-if PATH="$shim:$PATH" chmod +x -- "$TMP/probe-file" 2>/dev/null; then
-  echo "FAIL: the shim accepts a trailing --, so it judges nothing" >&2
-  exit 1
-fi
-if ! PATH="$shim:$PATH" chmod -- +x "$TMP/probe-file" 2>/dev/null; then
-  echo "FAIL: the shim rejects the correct order, so it would fail any installer" >&2
-  exit 1
-fi
-[ -x "$TMP/probe-file" ] || {
-  echo "FAIL: the shim did not exec the real chmod" >&2
-  exit 1
-}
-
-# A repository, and the package installed into it the way a consumer has it.
-repo="$TMP/bsd-repo"
-mkdir -p "$repo/.agents/skills"
-git -C "$repo" init -q
-git -C "$repo" config user.email t@t
-git -C "$repo" config user.name t
-cp -R "$SCRIPTS_DIR/.." "$repo/.agents/skills/commit-guards"
-installer="$repo/.agents/skills/commit-guards/scripts/install-git-hooks"
-
-out=""
-status=0
-out="$(PATH="$shim:$PATH" "$installer" --repo "$repo" 2>&1)" || status=$?
-if [ "$status" -ne 0 ]; then
-  echo "FAIL: the install failed under BSD chmod argv rules (exit $status)" >&2
-  printf '%s\n' "$out" >&2
-  exit 1
-fi
-
-# git ignores a hook without the bit, so this is the assertion that matters:
-# not that the installer said armed, but that the files it wrote can run.
-for lane in pre-commit commit-msg kendex-guards; do
-  [ -x "$repo/.git/hooks/$lane" ] || {
-    echo "FAIL: $lane is not executable after an install under BSD chmod" >&2
-    printf '%s\n' "$out" >&2
-    exit 1
-  }
-done
-
-# And the package's own verdict agrees, which is the pair that came apart on
-# macOS: two hooks reported armed over a repository that gated nothing.
-check=""
-check_status=0
-check="$(PATH="$shim:$PATH" "$installer" --repo "$repo" --check 2>&1)" || check_status=$?
-if [ "$check_status" -ne 0 ]; then
-  echo "FAIL: --check does not read the repository as armed (exit $check_status)" >&2
-  printf '%s\n' "$check" >&2
-  exit 1
-fi
-
-# The control: a copy of the package with the wrong order restored must NOT
-# come out armed. Without this the pin passes on any installer, including one
-# that never calls chmod at all.
-broken="$TMP/broken"
-mkdir -p "$broken/.agents/skills"
-git -C "$broken" init -q
-git -C "$broken" config user.email t@t
-git -C "$broken" config user.name t
-cp -R "$SCRIPTS_DIR/.." "$broken/.agents/skills/commit-guards"
-broken_installer="$broken/.agents/skills/commit-guards/scripts/install-git-hooks"
-perl -pi -e 's/chmod -- \+x/chmod +x --/; s/chmod -- 0755/chmod 0755 --/' "$broken_installer"
-grep -q 'chmod +x --' "$broken_installer" || {
-  echo "FAIL: the control could not restore the wrong order; the assertion below proves nothing" >&2
-  exit 1
-}
-PATH="$shim:$PATH" "$broken_installer" --repo "$broken" >/dev/null 2>&1 || true
-if [ -x "$broken/.git/hooks/pre-commit" ] && [ -x "$broken/.git/hooks/commit-msg" ]; then
-  echo "FAIL: must-fail control armed under BSD chmod with the wrong argv order" >&2
-  exit 1
-fi
-
-echo "pass: bsd-argv-install"
-
-# --- BSD sed argv, the same way: run it, do not read it -------------------
-#
-# `--` is not an end-of-options marker for BSD sed either. getopt(3) stops at
-# the first non-option argument, which for sed is the script, so a `--` after
-# it is a file operand — a file named `--`, which nobody has. BSD sed reports
-# it and exits 1 while still processing the real file, so a caller reading the
-# exit status sees a failure over content it actually got. install-git-hooks
-# reads line 3 of a candidate helper that way, and preflight reads a runner
-# body that way; the same rule judges both, and this is install-git-hooks.
 REAL_SED="$(command -v sed)"
 cat >"$shim/sed" <<SHIM
 #!/bin/sh
-# Every argument after the script is a file operand; a \`--\` among them is a
-# file nobody has.
 seen_script=0
 for arg in "\$@"; do
   case "\$seen_script\$arg" in
@@ -163,56 +79,89 @@ for arg in "\$@"; do
 done
 exec $REAL_SED "\$@"
 SHIM
-chmod 0755 "$shim/sed"
+chmod 0755 "$shim/chmod" "$shim/sed"
+mode() { if [ -e "$1" ]; then ls -ld "$1" | cut -c1-10; else echo absent; fi; } # PATH — the permission string, or absent
+probe() { local rc=0; "$@" >/dev/null 2>&1 || rc=$?; echo "rc=$rc"; } # CMD... — the exit status under the shims
 
-# The shim has teeth, and only on the wrong shape.
+echo "=== premise: each shim refuses only the shape BSD refuses, and hands the rest to the real utility ==="
+: >"$TMP/probe-file"
 printf 'a\nb\nc\n' >"$TMP/sed-probe"
-if PATH="$shim:$PATH" sed -n '3p' -- "$TMP/sed-probe" >/dev/null 2>&1; then
-  echo "FAIL: the sed shim accepts a -- operand, so it judges nothing" >&2
-  exit 1
-fi
-if [ "$(PATH="$shim:$PATH" sed -n '3p' <"$TMP/sed-probe")" != c ]; then
-  echo "FAIL: the sed shim does not pass a correct call through to the real sed" >&2
-  exit 1
-fi
+PATH="$shim:$PATH"
+assert_eq "chmod with -- after the mode is refused" "rc=1" "$(probe chmod +x -- "$TMP/probe-file")"
+assert_eq "control: chmod with -- before the mode runs the real chmod and sets the bit" "rc=0 -rwxr-xr-x" "$(probe chmod -- +x "$TMP/probe-file") $(mode "$TMP/probe-file")"
+assert_eq "sed with a -- operand after the script is refused" "rc=1" "$(probe sed -n '3p' -- "$TMP/sed-probe")"
+assert_eq "control: sed over stdin runs the real sed" "c" "$(sed -n '3p' <"$TMP/sed-probe")"
 
-# A helper an earlier install wrote, whose baked scripts directory is gone.
-# install-git-hooks replaces exactly that file and refuses every other one, so
-# reading its line 3 is the whole decision: a read that fails leaves ours
-# looking like somebody else's file and the install stops.
-dangling_helper() { # REPO — plant a helper of an install that no longer exists
+# One line for a run: the exit status, every line printed with the
+# repository path aliased (the installer prints it resolved, so a symlinked
+# TMPDIR is aliased under both spellings), then the three hook files' modes.
+R=""
+run() { # ARGS...
+  local rc=0 out="" real
+  real="$(cd "$R" && pwd -P)"
+  out="$("$R/.agents/skills/commit-guards/scripts/install-git-hooks" --repo "$R" "$@" 2>&1)" || rc=$?
+  printf 'rc=%s%s modes=%s,%s,%s' "$rc" "${out:+ $(printf '%s\n' "$out" | LC_ALL=C sed "s#$real#<repo>#g; s#$R#<repo>#g" | LC_ALL=C paste -sd ';' -)}" \
+    "$(mode "$R/.git/hooks/pre-commit")" "$(mode "$R/.git/hooks/commit-msg")" "$(mode "$R/.git/hooks/kendex-guards")"
+}
+
+# Fixture vocabulary: a fresh repository with the package copied in as a
+# consumer has it, under one of three packagings.
+repo() { # NAME
+  R="$TMP/$1"
+  [ ! -e "$R" ] || { echo "harness: fixture $1 already exists" >&2; exit 2; }
+  mkdir -p "$R/.agents/skills"
+  git -C "$R" -c init.defaultBranch=main init -q
+  git -C "$R" config user.email t@t
+  git -C "$R" config user.name t
+  cp -R "$SKILL_DIR" "$R/.agents/skills/commit-guards"
+}
+INSTALLER=".agents/skills/commit-guards/scripts/install-git-hooks"
+real() { repo "$1"; } # NAME — the shipped package
+broken_chmod() { # NAME — the package with chmod's wrong order restored
+  repo "$1"
+  perl -pi -e 's/chmod -- \+x/chmod +x --/; s/chmod -- 0755/chmod 0755 --/' "$R/$INSTALLER"
+}
+broken_sed() { # NAME — the package reading a helper's line 3 with a -- operand
+  repo "$1"
+  perl -pi -e "s/sed -n '3p' <\"\\\$1\"/sed -n '3p' -- \"\\\$1\"/" "$R/$INSTALLER"
+}
+installed() { real "$1"; "$R/$INSTALLER" --repo "$R" >/dev/null 2>&1; } # NAME — the shipped package, already armed
+dangling() { # NAME — a helper an install that no longer exists wrote; line 3 names its scripts directory
   printf '#!/bin/sh\n# Scripts directory of the install that wrote this file.\ninstalled_scripts=%s\n# kendex earlier-package git hooks. Managed by an earlier install.\nexit 0\n' \
-    "'$TMP/install-that-moved/scripts'" >"$1/.git/hooks/kendex-guards"
+    "'$TMP/install-that-moved/scripts'" >"$R/.git/hooks/kendex-guards"
+}
+dangling_real() { real "$1"; dangling; }
+dangling_broken_sed() { broken_sed "$1"; dangling; }
+
+echo "=== premise: each broken package holds exactly the shape it restores ==="
+broken_chmod shape-chmod
+assert_eq "the chmod control restores the wrong order at both call sites" "1 1" "$(grep -c 'chmod +x --' "$R/$INSTALLER") $(grep -c 'chmod 0755 --' "$R/$INSTALLER")"
+broken_sed shape-sed
+assert_eq "the sed control restores the -- operand at its one call site" "1" "$(grep -c "sed -n '3p' -- " "$R/$INSTALLER")"
+
+run_rows() { # label | fixture | args | expect
+  local row label fx args expect words
+  for row in "$@"; do
+    IFS='|' read -r label fx args expect <<<"$row"
+    R=""
+    read -ra words <<<"$fx"
+    "${words[@]}"
+    # shellcheck disable=SC2086
+    assert_eq "$label" "$expect" "$(run $args)"
+  done
 }
 
-dangling_helper "$repo"
-out=""
-status=0
-out="$(PATH="$shim:$PATH" "$installer" --repo "$repo" 2>&1)" || status=$?
-case "$out" in
-  *"scripts directory is gone; replacing it"*) ;;
-  *)
-    echo "FAIL: under BSD sed argv rules the dangling helper was not recognised (exit $status)" >&2
-    printf '%s\n' "$out" >&2
-    exit 1
-    ;;
-esac
+echo "=== the installer under BSD chmod and sed: its verdict and the bits git reads are one pin ==="
+X="-rwxr-xr-x"
+ARMED="commit-guards git hooks: pre-commit and commit-msg armed in <repo>/.git/hooks"
+NOT_INSTALLED="commit-guards git hooks: NOT installed — could not write <repo>/.git/hooks/kendex-guards"
+run_rows \
+  "the shipped package arms both hooks and the helper, every file executable|real install||rc=0 $ARMED modes=$X,$X,$X" \
+  "--check reads the same repository as armed|installed check|--check|rc=0 commit-guards git hooks: armed — pre-commit and commit-msg gate commits in <repo>/.git/hooks modes=$X,$X,$X" \
+  "control: chmod's wrong order writes nothing under BSD rules, and the installer says so|broken_chmod broken-install||rc=1 $NOT_INSTALLED modes=absent,absent,absent" \
+  "control: --check over that repository reads it as not armed|broken_chmod broken-check|--check|rc=1 commit-guards git hooks: NOT armed — helper kendex-guards is missing; pre-commit is missing; commit-msg is missing (<repo>/.git/hooks); run 'kendex guard install' (or this installer) to re-arm modes=absent,absent,absent" \
+  "a helper whose scripts directory is gone is recognised from its line 3 and replaced|dangling_real dangling||rc=0 ::warning::install-git-hooks: <repo>/.git/hooks/kendex-guards was written by an install whose scripts directory is gone; replacing it;$ARMED modes=$X,$X,$X" \
+  "control: reading line 3 with a -- operand fails under BSD sed, so the helper reads as somebody else's and the install stops|dangling_broken_sed dangling-broken||rc=1 ::warning::install-git-hooks: <repo>/.git/hooks/kendex-guards exists but was not written by this installer; refusing to overwrite it;$NOT_INSTALLED modes=absent,absent,-rw-r--r--"
 
-# The control: a copy with the `--` restored must NOT recognise it. Without
-# this the assertion above passes on any installer, including one that never
-# reads line 3.
-perl -pi -e "s/sed -n '3p' <\"\\\$1\"/sed -n '3p' -- \"\\\$1\"/" "$broken_installer"
-grep -q "sed -n '3p' -- " "$broken_installer" || {
-  echo "FAIL: the control could not restore the -- operand; the assertion below proves nothing" >&2
-  exit 1
-}
-dangling_helper "$broken"
-broken_out="$(PATH="$shim:$PATH" "$broken_installer" --repo "$broken" 2>&1)" || true
-case "$broken_out" in
-  *"scripts directory is gone; replacing it"*)
-    echo "FAIL: must-fail control recognised the dangling helper with a -- operand under BSD sed" >&2
-    exit 1
-    ;;
-esac
-
-echo "pass: bsd-argv-sed"
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/skills/commit-guards/tests/bsd-argv-install.test.sh
+++ b/skills/commit-guards/tests/bsd-argv-install.test.sh
@@ -39,57 +39,61 @@ assert_eq() { # LABEL EXPECT ACTUAL
 # takes them; the first non-option is the mode and everything after it is a
 # file operand, so a `--` there is a file named `--`. GNU permutes its
 # arguments and accepts the same line. sed: the same rule with the script in
-# the mode's place; BSD sed reports the `--` operand and exits 1 while still
-# processing the real file, so a caller reading the exit status sees a
-# failure over content it actually got.
+# the mode's place. Both BSD utilities report the `--` operand, still
+# process the real operands, and exit 1, so a caller reading the exit
+# status sees a failure over work it actually got; the shims do the same,
+# which is what makes a read that discards good content on that status
+# visible.
 shim="$TMP/shim"
 mkdir -p "$shim"
 cat >"$shim/chmod" <<'SHIM'
 #!/bin/sh
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --) shift; break ;;
-    -[RfhvHLP]*) shift ;;
-    *) break ;;
+n=$#; i=0; phase=opts; bad=0
+while [ "$i" -lt "$n" ]; do
+  arg=$1; shift; i=$((i + 1))
+  case "$phase" in
+    opts) case "$arg" in
+      --) phase=mode; continue ;;
+      -[RfhvHLP]*) set -- "$@" "$arg"; continue ;;
+      *) phase=files; set -- "$@" "$arg"; continue ;;
+    esac ;;
+    mode) phase=files; set -- "$@" "$arg"; continue ;;
+    files) if [ "$arg" = "--" ]; then bad=1; echo "chmod: --: No such file or directory" >&2; continue; fi; set -- "$@" "$arg" ;;
   esac
 done
-mode="${1-}"
-[ $# -gt 0 ] && shift
-for arg in "$@"; do
-  if [ "$arg" = "--" ]; then
-    echo "chmod: --: No such file or directory" >&2
-    exit 1
-  fi
-done
-exec /bin/chmod "$mode" "$@"
+/bin/chmod "$@"; rc=$?
+[ "$bad" -eq 0 ] || exit 1
+exit "$rc"
 SHIM
 REAL_SED="$(command -v sed)"
 cat >"$shim/sed" <<SHIM
 #!/bin/sh
-seen_script=0
-for arg in "\$@"; do
-  case "\$seen_script\$arg" in
-    0-*) continue ;;
-  esac
-  if [ "\$seen_script" -eq 1 ] && [ "\$arg" = "--" ]; then
-    echo "sed: --: No such file or directory" >&2
-    exit 1
+n=\$#; i=0; seen=0; bad=0
+while [ "\$i" -lt "\$n" ]; do
+  arg=\$1; shift; i=\$((i + 1))
+  if [ "\$seen" -eq 0 ]; then
+    case "\$arg" in -*) ;; *) seen=1 ;; esac
+    set -- "\$@" "\$arg"; continue
   fi
-  seen_script=1
+  if [ "\$arg" = "--" ]; then bad=1; echo "sed: --: No such file or directory" >&2; continue; fi
+  set -- "\$@" "\$arg"
 done
-exec $REAL_SED "\$@"
+$REAL_SED "\$@"; rc=\$?
+[ "\$bad" -eq 0 ] || exit 1
+exit "\$rc"
 SHIM
 chmod 0755 "$shim/chmod" "$shim/sed"
 mode() { if [ -e "$1" ]; then ls -ld "$1" | cut -c1-10; else echo absent; fi; } # PATH — the permission string, or absent
 probe() { local rc=0; "$@" >/dev/null 2>&1 || rc=$?; echo "rc=$rc"; } # CMD... — the exit status under the shims
 
-echo "=== premise: each shim refuses only the shape BSD refuses, and hands the rest to the real utility ==="
+echo "=== premise: each shim fails the shape BSD fails after doing the work, and hands the rest to the real utility ==="
 : >"$TMP/probe-file"
+: >"$TMP/probe-file-2"
 printf 'a\nb\nc\n' >"$TMP/sed-probe"
 PATH="$shim:$PATH"
-assert_eq "chmod with -- after the mode is refused" "rc=1" "$(probe chmod +x -- "$TMP/probe-file")"
-assert_eq "control: chmod with -- before the mode runs the real chmod and sets the bit" "rc=0 -rwxr-xr-x" "$(probe chmod -- +x "$TMP/probe-file") $(mode "$TMP/probe-file")"
-assert_eq "sed with a -- operand after the script is refused" "rc=1" "$(probe sed -n '3p' -- "$TMP/sed-probe")"
+assert_eq "chmod with -- after the mode exits 1 with the bit set: BSD does the work, then fails" "rc=1 -rwxr-xr-x" "$(probe chmod +x -- "$TMP/probe-file") $(mode "$TMP/probe-file")"
+assert_eq "control: chmod with -- before the mode runs the real chmod and exits 0" "rc=0 -rwxr-xr-x" "$(probe chmod -- +x "$TMP/probe-file-2") $(mode "$TMP/probe-file-2")"
+assert_eq "sed with a -- operand after the script exits 1 with the line printed" "rc=1 c" "$(probe sed -n '3p' -- "$TMP/sed-probe") $(sed -n '3p' -- "$TMP/sed-probe" 2>/dev/null)"
 assert_eq "control: sed over stdin runs the real sed" "c" "$(sed -n '3p' <"$TMP/sed-probe")"
 
 # One line for a run: the exit status, every line printed with the
@@ -126,12 +130,16 @@ broken_sed() { # NAME — the package reading a helper's line 3 with a -- operan
   perl -pi -e "s/sed -n '3p' <\"\\\$1\"/sed -n '3p' -- \"\\\$1\"/" "$R/$INSTALLER"
 }
 installed() { real "$1"; "$R/$INSTALLER" --repo "$R" >/dev/null 2>&1; } # NAME — the shipped package, already armed
-dangling() { # NAME — a helper an install that no longer exists wrote; line 3 names its scripts directory
+broken_chmod_installed() { broken_chmod "$1"; "$R/$INSTALLER" --repo "$R" >/dev/null 2>&1 || true; } # NAME — after the install the wrong order fails
+helper() { # DIR — a helper another install wrote; line 3 names its scripts directory
   printf '#!/bin/sh\n# Scripts directory of the install that wrote this file.\ninstalled_scripts=%s\n# kendex earlier-package git hooks. Managed by an earlier install.\nexit 0\n' \
-    "'$TMP/install-that-moved/scripts'" >"$R/.git/hooks/kendex-guards"
+    "'$1'" >"$R/.git/hooks/kendex-guards"
 }
+dangling() { helper "$TMP/install-that-moved/scripts"; } # the install that wrote it is gone
+live() { mkdir -p "$TMP/other-install/scripts"; helper "$TMP/other-install/scripts"; } # the install that wrote it still exists
 dangling_real() { real "$1"; dangling; }
 dangling_broken_sed() { broken_sed "$1"; dangling; }
+live_real() { real "$1"; live; }
 
 echo "=== premise: each broken package holds exactly the shape it restores ==="
 broken_chmod shape-chmod
@@ -159,9 +167,10 @@ run_rows \
   "the shipped package arms both hooks and the helper, every file executable|real install||rc=0 $ARMED modes=$X,$X,$X" \
   "--check reads the same repository as armed|installed check|--check|rc=0 commit-guards git hooks: armed — pre-commit and commit-msg gate commits in <repo>/.git/hooks modes=$X,$X,$X" \
   "control: chmod's wrong order writes nothing under BSD rules, and the installer says so|broken_chmod broken-install||rc=1 $NOT_INSTALLED modes=absent,absent,absent" \
-  "control: --check over that repository reads it as not armed|broken_chmod broken-check|--check|rc=1 commit-guards git hooks: NOT armed — helper kendex-guards is missing; pre-commit is missing; commit-msg is missing (<repo>/.git/hooks); run 'kendex guard install' (or this installer) to re-arm modes=absent,absent,absent" \
+  "control: --check over the repository that install left reads it as not armed|broken_chmod_installed broken-check|--check|rc=1 commit-guards git hooks: NOT armed — helper kendex-guards is missing; pre-commit is missing; commit-msg is missing (<repo>/.git/hooks); run 'kendex guard install' (or this installer) to re-arm modes=absent,absent,absent" \
   "a helper whose scripts directory is gone is recognised from its line 3 and replaced|dangling_real dangling||rc=0 ::warning::install-git-hooks: <repo>/.git/hooks/kendex-guards was written by an install whose scripts directory is gone; replacing it;$ARMED modes=$X,$X,$X" \
-  "control: reading line 3 with a -- operand fails under BSD sed, so the helper reads as somebody else's and the install stops|dangling_broken_sed dangling-broken||rc=1 ::warning::install-git-hooks: <repo>/.git/hooks/kendex-guards exists but was not written by this installer; refusing to overwrite it;$NOT_INSTALLED modes=absent,absent,-rw-r--r--"
+  "control: reading line 3 with a -- operand fails under BSD sed, so the helper reads as somebody else's and the install stops|dangling_broken_sed dangling-broken||rc=1 ::warning::install-git-hooks: <repo>/.git/hooks/kendex-guards exists but was not written by this installer; refusing to overwrite it;$NOT_INSTALLED modes=absent,absent,-rw-r--r--" \
+  "control: a helper whose scripts directory still exists is another install's, and is refused|live_real live||rc=1 ::warning::install-git-hooks: <repo>/.git/hooks/kendex-guards exists but was not written by this installer; refusing to overwrite it;$NOT_INSTALLED modes=absent,absent,-rw-r--r--"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/commit-guards/tests/bsd-awk-record.test.sh
+++ b/skills/commit-guards/tests/bsd-awk-record.test.sh
@@ -1,39 +1,51 @@
 #!/usr/bin/env bash
-# The changelog family's encoding check under BWK awk's record rule, as a
-# program rather than a lint.
+# Pins for the changelog family's encoding check under BWK awk's record
+# rule, as a program rather than a lint. macOS ships BWK awk, which holds a
+# record as a NUL-terminated C string: a line's content stops at its first
+# NUL. GNU awk carries the whole line, so nothing on a Linux runner can see
+# the difference by reading the source; the rule is put in a shim on PATH
+# and the real check runs under it. What the rule costs: git calls a blob
+# binary only when a NUL falls in its leading sample, so a blob whose only
+# NUL is past that sample is text to git and must be text to this family
+# too. Under BWK's rule the UTF-8 pass never sees that NUL, the blob measures
+# as the short prefix before it, and an unmeasurable file is reported as an
+# over-long entry instead of being refused. scripts/lib/changelog-grammar.sh
+# translates every NUL to \200, a stray continuation byte its grammar
+# already rejects, before awk reads a byte; this suite pins that.
 #
-# macOS ships BWK awk ("awk version 20200816"), which holds a record as a
-# NUL-terminated C string: a line's content stops at its first NUL. GNU awk
-# carries the whole line, so nothing on a Linux runner can see the
-# difference by reading the source. It is put in a shim on PATH instead and
-# the real check runs under it.
-#
-# What the rule costs: git calls a blob binary only when a NUL falls in its
-# leading sample, so a blob whose only NUL is past that sample is text to
-# git and must be text to this family too. Under BWK's rule the UTF-8 pass
-# never sees that NUL, the blob measures as the short prefix before it, and
-# an unmeasurable file is reported as an over-long entry instead of being
-# refused. scripts/lib/changelog-grammar.sh translates every NUL to \200 — a
-# stray continuation byte its grammar already rejects — before awk reads a
-# byte, which is what this suite pins.
+# One table: PACKAGE is the shipped skill or a copy with the translation
+# removed; changelog-entries runs under the shim over a fragment git calls
+# text, and the row pins the exit status with every line printed.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 # shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
-
 unset COMMIT_GUARDS_CHANGELOG_CAP COMMIT_GUARDS_CHANGELOG_PATHS \
   COMMIT_GUARDS_CHANGELOG_RECORD COMMIT_GUARDS_SETTINGS_FILE 2>/dev/null || true
 
+PASS=0
+FAIL=0
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
+
+# The BWK rule, as a program: one argument is a program with its input on
+# stdin, which is how the changelog family reads a blob; that read is
+# truncated at each record's first NUL. Every other shape (a file operand,
+# -v, -F) passes straight through, so the shim judges that one read only.
 REAL_AWK="$(command -v awk)"
 shim="$TMP/shim"
 mkdir -p "$shim"
 cat >"$shim/awk" <<SHIM
 #!/bin/sh
-# One argument is a program and its input on stdin, which is how the
-# changelog family reads a blob. Every other shape — a file operand, -v, -F —
-# passes straight through, so this shim judges that one read and nothing else.
 if [ "\$#" -eq 1 ]; then
   perl -pe 's/\\0.*//' | $REAL_AWK "\$1"
   exit \$?
@@ -42,83 +54,63 @@ exec $REAL_AWK "\$@"
 SHIM
 chmod 0755 "$shim/awk"
 
-# The shim has teeth, and only on the shape it means to judge.
-truncated="$(printf 'ab\000cd\n' | PATH="$shim:$PATH" awk '{ print length($0) }')"
-[ "$truncated" = 2 ] || {
-  echo "FAIL: the awk shim does not truncate a record at its NUL (length $truncated)" >&2
-  exit 1
-}
-# Compared against the host's own awk, not against a number: BWK awk truncates
-# at a NUL whatever the input is, so on macOS the untouched answer is 2 and on
-# GNU it is 5. What must hold on both is that the shim changed nothing here.
+echo "=== premise: the shim truncates the one read it means to judge and nothing else ==="
 printf 'ab\000cd\n' >"$TMP/probe"
-whole="$(PATH="$shim:$PATH" awk '{ print length($0) }' "$TMP/probe")"
-native="$("$REAL_AWK" '{ print length($0) }' "$TMP/probe")"
-[ "$whole" = "$native" ] || {
-  echo "FAIL: the awk shim altered a call with a file operand (length $whole, host awk says $native)" >&2
-  exit 1
-}
+PATH="$shim:$PATH"
+assert_eq "a program over stdin sees the record end at its NUL" "2" "$(awk '{ print length($0) }' <"$TMP/probe")"
+# Compared against the host's own awk, not a number: BWK truncates whatever
+# the input, so the untouched answer is 2 on macOS and 5 on GNU.
+assert_eq "control: a file operand reads as the host's awk reads it" "$("$REAL_AWK" '{ print length($0) }' "$TMP/probe")" "$(awk '{ print length($0) }' "$TMP/probe")"
 
-# A fragment git calls text: 8100 bytes of content, then the file's only NUL.
+# The fragment: 8100 bytes of content, then the file's only NUL, past the
+# sample git sniffs; git calls it text, and its measure under BWK's rule is
+# the prefix.
+XS="$(i=0; while [ "$i" -lt 8100 ]; do printf x; i=$((i + 1)); done)"
 plant() { # REPO
   mkdir -p "$1/changelog.d/added"
-  {
-    printf -- '- '
-    i=0
-    while [ "$i" -lt 8100 ]; do printf x; i=$((i + 1)); done
-    printf '\000tail\n'
-  } >"$1/changelog.d/added/late-nul.md"
+  printf -- '- %s\000tail\n' "$XS" >"$1/changelog.d/added/late-nul.md"
   git -C "$1" add -A
 }
+R="$TMP/nul"
+mkdir -p "$R"
+git -C "$R" -c init.defaultBranch=main init -q
+git -C "$R" config user.email t@t
+git -C "$R" config user.name t
+plant "$R"
+assert_eq "premise: git calls the fragment text" "changelog.d/added/late-nul.md" "$(git -C "$R" grep --cached -I -l . -- changelog.d/added)"
 
-new_repo() { # PATH
-  mkdir -p "$1"
-  git -C "$1" -c init.defaultBranch=main init -q
-  git -C "$1" config user.email t@t
-  git -C "$1" config user.name t
+# Fixture vocabulary: the package a row runs.
+PKG=""
+real() { PKG="$SKILL_DIR"; }
+broken() { # the package with the NUL translation removed
+  PKG="$TMP/broken-pkg/commit-guards"
+  mkdir -p "$TMP/broken-pkg"
+  cp -R "$SKILL_DIR" "$PKG"
+  perl -pi -e "s/LC_ALL=C tr '\\\\000' '\\\\200' <\"\\\$GG_TMP\\/blob\" \\| LC_ALL=C awk/LC_ALL=C awk/" "$PKG/scripts/lib/changelog-grammar.sh"
+}
+run() { # — the exit status and every line printed by PKG's changelog-entries over the fragment
+  local rc=0 out=""
+  out="$(cd "$R" && "$PKG/scripts/changelog-entries" 2>&1)" || rc=$?
+  printf 'rc=%s%s' "$rc" "${out:+ $(printf '%s\n' "$out" | LC_ALL=C paste -sd ';' -)}"
+}
+run_rows() { # label | package | expect
+  local row label pkg expect
+  for row in "$@"; do
+    IFS='|' read -r label pkg expect <<<"$row"
+    PKG=""
+    "$pkg"
+    assert_eq "$label" "$expect" "$(run)"
+  done
 }
 
-repo="$TMP/nul"
-new_repo "$repo"
-plant "$repo"
-[ -n "$(git -C "$repo" grep --cached -I -l . -- changelog.d/added)" ] || {
-  echo "FAIL: git calls the fixture blob binary, so it is not the case this suite means" >&2
-  exit 1
-}
+echo "=== premise: the broken package holds no translation ==="
+broken
+assert_eq "the control removed the NUL translation" "0" "$(grep -c "tr '\\\\000'" "$PKG/scripts/lib/changelog-grammar.sh")"
 
-out=""
-status=0
-out="$(cd "$repo" && PATH="$shim:$PATH" "$SKILL_DIR/scripts/changelog-entries" 2>&1)" || status=$?
-case "$status:$out" in
-  2:*"late-nul.md line 1 is not valid UTF-8"*) ;;
-  *)
-    echo "FAIL: under BWK awk's record rule the NUL past the sample was not refused (exit $status)" >&2
-    printf '%s\n' "$out" >&2
-    exit 1
-    ;;
-esac
+echo "=== a NUL past git's sample is refused as unmeasurable under BWK's record rule, not reported as a long entry ==="
+run_rows \
+  "the shipped package refuses the fragment naming its line|real|rc=2 ::error::changelog-entries: changelog.d/added/late-nul.md line 1 is not valid UTF-8 — text with no character count cannot be measured" \
+  "control: without the translation the record ends at the NUL and the prefix is measured as an over-long entry|broken|rc=1 changelog-entries FAIL long entry: changelog.d/added/late-nul.md — 8102 characters (cap 200);  entry: - $XS;  remedies: state the outcome and stop; a Breaking migration note stays inline, and the reasoning belongs in the commit;changelog-entries: 1 violation(s) — cap 200 characters, 1 fragment(s) measured"
 
-# The control: a copy of the package with the translation removed must NOT
-# refuse it. Without this the assertion above passes on any check, including
-# one that never reads the blob's bytes at all.
-broken="$TMP/broken-pkg"
-mkdir -p "$broken"
-cp -R "$SKILL_DIR" "$broken/commit-guards"
-grammar="$broken/commit-guards/scripts/lib/changelog-grammar.sh"
-perl -pi -e "s/LC_ALL=C tr '\\\\000' '\\\\200' <\"\\\$GG_TMP\\/blob\" \\| LC_ALL=C awk/LC_ALL=C awk/" "$grammar"
-grep -q "tr '\\\\000'" "$grammar" && {
-  echo "FAIL: the control could not remove the NUL translation; the assertion below proves nothing" >&2
-  exit 1
-}
-broken_repo="$TMP/broken-repo"
-new_repo "$broken_repo"
-plant "$broken_repo"
-broken_out="$(cd "$broken_repo" && PATH="$shim:$PATH" "$broken/commit-guards/scripts/changelog-entries" 2>&1)" || true
-case "$broken_out" in
-  *"is not valid UTF-8"*)
-    echo "FAIL: must-fail control refused the late NUL with the translation removed" >&2
-    exit 1
-    ;;
-esac
-
-echo "pass: bsd-awk-record"
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Reshapes `skills/commit-guards/tests/bsd-argv-install.test.sh` and `skills/commit-guards/tests/bsd-awk-record.test.sh` to code-quality § Tests, one PR because both are the BSD-userland-as-a-program idea: a BSD rule put in a shim on PATH and the real script run under it, which a lint over the shell source cannot do.

bsd-argv-install pinned `scripts/install-git-hooks` under BSD chmod and sed argv rules (getopt(3) stops at the first non-option, so a `--` after chmod's mode or after sed's script is a file operand nobody has; GNU permutes and accepts the same line) as a 218-line program of 15 assertions (13 failure sites, one a loop over three hook files) that exited at the first failure and printed `pass:` lines. It is premise assertions and one table now. The shim premises: chmod with `--` after the mode exits 1 with the bit set (BSD does the work, then fails), `--` before the mode runs the real chmod and exits 0, sed with a `--` operand exits 1 with the line printed, sed over stdin passes through; the package-shape premises count the wrong order each broken copy restores. The table (`run_rows`, `label|fixture|args|expect`): a fixture builds a fresh repository with the package copied in as a consumer has it (`real`, `broken_chmod`, `broken_sed`, `installed`, `broken_chmod_installed`, `dangling_real`, `dangling_broken_sed`, `live_real`), the installer runs with ARGS under both shims, and the row pins `rc=N` with every line printed (the repository path aliased under both its spellings) and the mode string of each of the three hook files under `umask 022`, so the installer's verdict and the bits git reads are one pin. Rows: the shipped package arms all three executable; `--check` reads it armed; the broken-chmod package writes nothing and says NOT installed; `--check` over the repository that install left reads NOT armed (new); a dangling helper (line 3 names a scripts directory that is gone) is recognised and replaced; the broken-sed package fails the line-3 read so the helper reads as somebody else's and the install stops; a helper whose scripts directory still exists is another install's and is refused (new, the reviewer's). Folds: the three-lane executable loop, the install's exit status and the armed line into the first row; `--check` into the second; "not both executable" into the broken-install row's `absent,absent,absent`; the "exec'd the real chmod" self-test into the accepted-order premise's mode read. 15 - 3 - 1 + 2 = 13.

bsd-awk-record pinned `scripts/lib/changelog-grammar.sh`'s NUL-to-`\200` translation under BWK awk's record rule (a record is a C string, a line stops at its first NUL; the shim truncates the one-argument program-over-stdin shape only) in 6 assertions of the same style. It is 6 rows: two shim premises (stdin read truncates to 2; a file operand reads as the host awk reads it), the git-calls-it-text premise on the 8100-byte fragment with a late NUL, the broken-package shape premise, and a two-row table (`label|package|expect`): the shipped package refuses the fragment as not valid UTF-8 (rc=2, the whole error line); the package with the translation removed reads the prefix and reports an over-long entry of 8102 characters (rc=1, all four lines, the entry line built from the same 8100 x's; the whole line would be 8107, so the count pins that the shim's rule reached the blob read).

The reviewer round: its blocker (the `--check` control ran over a repository nobody had installed into; the fixture now attempts the broken install first, and with the shims switched off that row fails with the other three) and its suggestions (both shims did nothing before exiting 1, against the rule the file's own comment states; they now report the operand, process the real operands and exit 1 as BSD does, which turns the author's one "equivalent" mutant, the line-3 read's `|| return 1`, into a kill; the sed premise reads the line printed beside the status; the live-helper row). Recorded, not pinned: the warn arm of `ensure_hook_executable` (a chmod that fails for a hook but not for the helper has no fixture); `--check` over the dangling-helper repository.

The tracked render is replayed with `patch`. Nothing about `.kendex-generated.json` changed.

## Mutation

8 exact-substring production mutants over `scripts/install-git-hooks` and `scripts/lib/changelog-grammar.sh` (`mutate-bsd.py`, results `mutants-bsd-2.txt` in the session scratchpad), run against the final suites in a scratch copy: 8 killed.

| mutant | result |
|---|---|
| chmod: the helper's mode with -- after it | killed by "the shipped package arms both hooks and the helper, every file executable" |
| chmod: the hook's +x with -- after it | killed by the same row |
| chmod: the hook's bit not set at all | killed by "the chmod control restores the wrong order at both call sites" |
| sed: line 3 read with a -- operand | killed by "a helper whose scripts directory is gone is recognised from its line 3 and replaced" |
| sed: line 3 read failure ignored | killed by "control: reading line 3 with a -- operand fails under BSD sed, so the helper reads as somebody else's and the install stops" (survived the first commit's shims, which failed before doing the work) |
| dangling: a helper whose directory still exists is dangling too | killed by "control: a helper whose scripts directory still exists is another install's, and is refused" |
| grammar: the NUL translation removed | killed by "the shipped package refuses the fragment naming its line" |
| grammar: the NUL translated to a valid byte | killed by "the control removed the NUL translation" |

16 fixture mutants: 15 killed, 1 by design.

| fixture mutant | result |
|---|---|
| F1 chmod shim: a -- operand accepted | killed by "chmod with -- after the mode exits 1 with the bit set" |
| F2 chmod shim: the real chmod not run | killed by "control: chmod with -- before the mode runs the real chmod and exits 0" |
| F3 sed shim: a -- operand accepted | killed by "sed with a -- operand after the script exits 1 with the line printed" |
| F13 chmod shim: fails before doing the work | killed by "chmod with -- after the mode exits 1 with the bit set" |
| F14 sed shim: fails before doing the work | killed by "sed with a -- operand after the script exits 1 with the line printed" |
| F15 broken_chmod_installed: never installs | no kill by design: a failed install writes nothing, so the row reads the same; the reviewer's shims-off run is its kill (the row fails there only with the install attempted) |
| F16 live: the directory does not exist | killed by "control: a helper whose scripts directory still exists is another install's, and is refused" |
| F4 broken_chmod: the order not restored | killed by "the chmod control restores the wrong order at both call sites" |
| F5 broken_sed: the operand not restored | killed by "the sed control restores the -- operand at its one call site" |
| F6 dangling: line 3 names no scripts directory | killed by "a helper whose scripts directory is gone is recognised from its line 3 and replaced" |
| F7 umask not set | killed by "chmod with -- after the mode exits 1 with the bit set" |
| F8 run: the modes not read | killed by "control: chmod's wrong order writes nothing under BSD rules, and the installer says so" |
| F9 awk shim: no truncation | killed by "a program over stdin sees the record end at its NUL" |
| F10 fragment: no NUL | killed by "the shipped package refuses the fragment naming its line" |
| F11 fragment: the NUL inside git's sample | killed by "premise: git calls the fragment text" |
| F12 broken: the translation kept | killed by "the control removed the NUL translation" |

The reviewer's 26 mutants (13 production, 13 fixture and harness): 23 killed on the first commit, its three survivors the read-failure mutant above (killed by the faithful shims), the `[ ! -d "$dir" ]` tautology (killed by the live-helper row) and the warn arm (recorded). Its report is `review-bsd/REPORT-final.md` of the session scratchpad.

## Checks

- `bsd-argv-install.test.sh`: 13 assertions; `bsd-awk-record.test.sh`: 6; both pass on this host under TMPDIR=/tmp and a symlinked TMPDIR, and on a macOS box (bash 3.2.57, the real BSD userland beside the shims). `tools/bash32-lint` clean over the tests directory.
- `tools/guard --full`: exit 0 on the first commit under TMPDIR=/tmp; the run on the rebased second commit was launched at PR time, CI is the verdict.
- One reviewer-test round: fix-first, applied in the second commit as above.

KEN-1241

https://claude.ai/code/session_01ESWfqKsTYCo5LjWxeBmaKi
