### PR TITLE
test(KEN-1241): the generated-paths reader as two tables of rows

### DIFF
--- a/.agents/skills/commit-guards/tests/generated-paths.test.sh
+++ b/.agents/skills/commit-guards/tests/generated-paths.test.sh
@@ -55,7 +55,8 @@ load_rows \
   "two arrays are refused: a stream is not one inventory|[] []|rc=2 paths=<> $ONE" \
   "text that is not JSON is refused with jq's parse error ahead of the cause|invalid|rc=2 paths=<> <jq parse error>;$REFUSED" \
   "an object is refused: not an array|{}|rc=2 paths=<> $ARRAY" \
-  "a null entry is refused: not a string|[null]|rc=2 paths=<> $ARRAY" \
+  "a null entry is refused: it has no length|[null]|rc=2 paths=<> $ARRAY" \
+  "a number entry is refused: not a string|[1]|rc=2 paths=<> $ARRAY" \
   "an empty entry is refused|[\"\"]|rc=2 paths=<> $ARRAY" \
   "an entry carrying a newline is refused: the list is newline-delimited|[\"a\\\\nb\"]|rc=2 paths=<> $ARRAY" \
   "an entry carrying a NUL is refused|[\"a\\\\u0000b\"]|rc=2 paths=<> $ARRAY"
@@ -76,6 +77,7 @@ contains_rows \
   "a path the listed glob would match is not in the list|$TWO|.agents/skills/abc/x.md|no" \
   "a glob in the asked path matches nothing: the ask is literal too|$TWO|.agents/*|no" \
   "a suffix of a listed path is not in the list|$TWO|name.md|no" \
+  "a prefix of a listed path is not in the list: a generated file does not exclude the source it is named after|$TWO|.agents|no" \
   "a newline-bearing path is never in the list, even spelling two adjacent entries|$TWO|.agents/skills/a*/x.md\\nspace name.md|no" \
   "the empty path is not in an empty list: the delimiters around nothing are not an entry|[]||no"
 

--- a/.agents/skills/commit-guards/tests/generated-paths.test.sh
+++ b/.agents/skills/commit-guards/tests/generated-paths.test.sh
@@ -1,20 +1,83 @@
 #!/usr/bin/env bash
+# Pins for scripts/lib/generated-paths.sh, the reader of the render writer's
+# inventory: .kendex-generated.json is one JSON array of literal paths, no
+# glob, no stream, no empty, newline-bearing or NUL-bearing entry, and a
+# membership test is literal. Two tables: one inventory loaded, pinned by the
+# exit status, the paths held afterwards and the cause (the loader's own
+# clauses; jq's parse wording is jq's and is reduced to a token), and one
+# path asked of a loaded inventory, pinned by the answer.
 set -euo pipefail
+
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
+# shellcheck source=../scripts/lib/generated-paths.sh
 source "$TEST_DIR/../scripts/lib/generated-paths.sh"
 
-# The writer emits a JSON array of literal paths, not a glob list or stream.
-for inventory in '[]' '[".agents/skills/a*/x.md","space name.md"]'; do
-  generated_paths_load "$inventory"
-done
-generated_path_contains '.agents/skills/a*/x.md'
-generated_path_contains 'space name.md'
-if generated_path_contains '.agents/skills/abc/x.md'; then exit 1; fi
-if generated_path_contains 'name.md'; then exit 1; fi
-for inventory in '' 'invalid' '{}' '[null]' '[""]' '[] []' '["a\nb"]' '["a\u0000b"]'; do
-  rc=0
-  generated_paths_load "$inventory" >"$TMP/result" 2>&1 || rc=$?
-  [ "$rc" -eq 2 ] || { printf 'invalid inventory accepted: %s\n' "$inventory"; exit 1; }
-done
-echo 'generated inventory reader: passed'
+PASS=0
+FAIL=0
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
+
+# One line for a load: the exit status, the paths held afterwards joined by
+# ';', then every stderr line joined by ';' with jq's framing stripped.
+load() { # INVENTORY
+  local rc=0 err=""
+  GENERATED_PATHS="stale"
+  generated_paths_load "$1" 2>"$TMP/err" || rc=$?
+  err="$(LC_ALL=C sed -e 's/^jq: error (at <stdin>:[0-9]*): //' -e 's/^jq: parse error: .*/<jq parse error>/' "$TMP/err" | LC_ALL=C paste -sd ';' -)"
+  printf 'rc=%s paths=<%s>%s' "$rc" "$(printf '%s' "$GENERATED_PATHS" | LC_ALL=C paste -sd ';' -)" "${err:+ $err}"
+}
+REFUSED='::error::generated paths: cannot read .kendex-generated.json; jq is required; install or refresh kendex at the Git repository root in the main checkout and stage the inventory with the renders'
+ONE="expected one inventory;$REFUSED"
+ARRAY="expected an array of paths without newline or NUL;$REFUSED"
+
+load_rows() { # label | inventory | expect
+  local row label inventory expect
+  for row in "$@"; do
+    IFS='|' read -r label inventory expect <<<"$row"
+    assert_eq "$label" "$expect" "$(load "$(printf '%b' "$inventory")")"
+  done
+}
+
+echo "=== an inventory is one array of literal paths; anything else is refused with its cause and nothing held ==="
+load_rows \
+  "an empty array loads and holds nothing|[]|rc=0 paths=<>" \
+  "literal paths load as written: a glob character and a space are content|[\".agents/skills/a*/x.md\",\"space name.md\"]|rc=0 paths=<.agents/skills/a*/x.md;space name.md>" \
+  "empty input is refused: no inventory is not one inventory||rc=2 paths=<> $ONE" \
+  "two arrays are refused: a stream is not one inventory|[] []|rc=2 paths=<> $ONE" \
+  "text that is not JSON is refused with jq's parse error ahead of the cause|invalid|rc=2 paths=<> <jq parse error>;$REFUSED" \
+  "an object is refused: not an array|{}|rc=2 paths=<> $ARRAY" \
+  "a null entry is refused: not a string|[null]|rc=2 paths=<> $ARRAY" \
+  "an empty entry is refused|[\"\"]|rc=2 paths=<> $ARRAY" \
+  "an entry carrying a newline is refused: the list is newline-delimited|[\"a\\\\nb\"]|rc=2 paths=<> $ARRAY" \
+  "an entry carrying a NUL is refused|[\"a\\\\u0000b\"]|rc=2 paths=<> $ARRAY"
+
+echo "=== membership is literal, both ways ==="
+contains() { generated_paths_load "$1"; if generated_path_contains "$2"; then echo yes; else echo no; fi; } # INVENTORY PATH
+contains_rows() { # label | inventory | path | expect
+  local row label inventory path expect
+  for row in "$@"; do
+    IFS='|' read -r label inventory path expect <<<"$row"
+    assert_eq "$label" "$expect" "$(contains "$inventory" "$(printf '%b' "$path")")"
+  done
+}
+TWO='[".agents/skills/a*/x.md","space name.md"]'
+contains_rows \
+  "the glob-bearing path is found by its literal spelling|$TWO|.agents/skills/a*/x.md|yes" \
+  "the space-bearing path is found whole|$TWO|space name.md|yes" \
+  "a path the listed glob would match is not in the list|$TWO|.agents/skills/abc/x.md|no" \
+  "a glob in the asked path matches nothing: the ask is literal too|$TWO|.agents/*|no" \
+  "a suffix of a listed path is not in the list|$TWO|name.md|no" \
+  "a newline-bearing path is never in the list, even spelling two adjacent entries|$TWO|.agents/skills/a*/x.md\\nspace name.md|no" \
+  "the empty path is not in an empty list: the delimiters around nothing are not an entry|[]||no"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/skills/commit-guards/tests/generated-paths.test.sh
+++ b/skills/commit-guards/tests/generated-paths.test.sh
@@ -55,7 +55,8 @@ load_rows \
   "two arrays are refused: a stream is not one inventory|[] []|rc=2 paths=<> $ONE" \
   "text that is not JSON is refused with jq's parse error ahead of the cause|invalid|rc=2 paths=<> <jq parse error>;$REFUSED" \
   "an object is refused: not an array|{}|rc=2 paths=<> $ARRAY" \
-  "a null entry is refused: not a string|[null]|rc=2 paths=<> $ARRAY" \
+  "a null entry is refused: it has no length|[null]|rc=2 paths=<> $ARRAY" \
+  "a number entry is refused: not a string|[1]|rc=2 paths=<> $ARRAY" \
   "an empty entry is refused|[\"\"]|rc=2 paths=<> $ARRAY" \
   "an entry carrying a newline is refused: the list is newline-delimited|[\"a\\\\nb\"]|rc=2 paths=<> $ARRAY" \
   "an entry carrying a NUL is refused|[\"a\\\\u0000b\"]|rc=2 paths=<> $ARRAY"
@@ -76,6 +77,7 @@ contains_rows \
   "a path the listed glob would match is not in the list|$TWO|.agents/skills/abc/x.md|no" \
   "a glob in the asked path matches nothing: the ask is literal too|$TWO|.agents/*|no" \
   "a suffix of a listed path is not in the list|$TWO|name.md|no" \
+  "a prefix of a listed path is not in the list: a generated file does not exclude the source it is named after|$TWO|.agents|no" \
   "a newline-bearing path is never in the list, even spelling two adjacent entries|$TWO|.agents/skills/a*/x.md\\nspace name.md|no" \
   "the empty path is not in an empty list: the delimiters around nothing are not an entry|[]||no"
 

--- a/skills/commit-guards/tests/generated-paths.test.sh
+++ b/skills/commit-guards/tests/generated-paths.test.sh
@@ -1,20 +1,83 @@
 #!/usr/bin/env bash
+# Pins for scripts/lib/generated-paths.sh, the reader of the render writer's
+# inventory: .kendex-generated.json is one JSON array of literal paths, no
+# glob, no stream, no empty, newline-bearing or NUL-bearing entry, and a
+# membership test is literal. Two tables: one inventory loaded, pinned by the
+# exit status, the paths held afterwards and the cause (the loader's own
+# clauses; jq's parse wording is jq's and is reduced to a token), and one
+# path asked of a loaded inventory, pinned by the answer.
 set -euo pipefail
+
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
+# shellcheck source=../scripts/lib/generated-paths.sh
 source "$TEST_DIR/../scripts/lib/generated-paths.sh"
 
-# The writer emits a JSON array of literal paths, not a glob list or stream.
-for inventory in '[]' '[".agents/skills/a*/x.md","space name.md"]'; do
-  generated_paths_load "$inventory"
-done
-generated_path_contains '.agents/skills/a*/x.md'
-generated_path_contains 'space name.md'
-if generated_path_contains '.agents/skills/abc/x.md'; then exit 1; fi
-if generated_path_contains 'name.md'; then exit 1; fi
-for inventory in '' 'invalid' '{}' '[null]' '[""]' '[] []' '["a\nb"]' '["a\u0000b"]'; do
-  rc=0
-  generated_paths_load "$inventory" >"$TMP/result" 2>&1 || rc=$?
-  [ "$rc" -eq 2 ] || { printf 'invalid inventory accepted: %s\n' "$inventory"; exit 1; }
-done
-echo 'generated inventory reader: passed'
+PASS=0
+FAIL=0
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
+
+# One line for a load: the exit status, the paths held afterwards joined by
+# ';', then every stderr line joined by ';' with jq's framing stripped.
+load() { # INVENTORY
+  local rc=0 err=""
+  GENERATED_PATHS="stale"
+  generated_paths_load "$1" 2>"$TMP/err" || rc=$?
+  err="$(LC_ALL=C sed -e 's/^jq: error (at <stdin>:[0-9]*): //' -e 's/^jq: parse error: .*/<jq parse error>/' "$TMP/err" | LC_ALL=C paste -sd ';' -)"
+  printf 'rc=%s paths=<%s>%s' "$rc" "$(printf '%s' "$GENERATED_PATHS" | LC_ALL=C paste -sd ';' -)" "${err:+ $err}"
+}
+REFUSED='::error::generated paths: cannot read .kendex-generated.json; jq is required; install or refresh kendex at the Git repository root in the main checkout and stage the inventory with the renders'
+ONE="expected one inventory;$REFUSED"
+ARRAY="expected an array of paths without newline or NUL;$REFUSED"
+
+load_rows() { # label | inventory | expect
+  local row label inventory expect
+  for row in "$@"; do
+    IFS='|' read -r label inventory expect <<<"$row"
+    assert_eq "$label" "$expect" "$(load "$(printf '%b' "$inventory")")"
+  done
+}
+
+echo "=== an inventory is one array of literal paths; anything else is refused with its cause and nothing held ==="
+load_rows \
+  "an empty array loads and holds nothing|[]|rc=0 paths=<>" \
+  "literal paths load as written: a glob character and a space are content|[\".agents/skills/a*/x.md\",\"space name.md\"]|rc=0 paths=<.agents/skills/a*/x.md;space name.md>" \
+  "empty input is refused: no inventory is not one inventory||rc=2 paths=<> $ONE" \
+  "two arrays are refused: a stream is not one inventory|[] []|rc=2 paths=<> $ONE" \
+  "text that is not JSON is refused with jq's parse error ahead of the cause|invalid|rc=2 paths=<> <jq parse error>;$REFUSED" \
+  "an object is refused: not an array|{}|rc=2 paths=<> $ARRAY" \
+  "a null entry is refused: not a string|[null]|rc=2 paths=<> $ARRAY" \
+  "an empty entry is refused|[\"\"]|rc=2 paths=<> $ARRAY" \
+  "an entry carrying a newline is refused: the list is newline-delimited|[\"a\\\\nb\"]|rc=2 paths=<> $ARRAY" \
+  "an entry carrying a NUL is refused|[\"a\\\\u0000b\"]|rc=2 paths=<> $ARRAY"
+
+echo "=== membership is literal, both ways ==="
+contains() { generated_paths_load "$1"; if generated_path_contains "$2"; then echo yes; else echo no; fi; } # INVENTORY PATH
+contains_rows() { # label | inventory | path | expect
+  local row label inventory path expect
+  for row in "$@"; do
+    IFS='|' read -r label inventory path expect <<<"$row"
+    assert_eq "$label" "$expect" "$(contains "$inventory" "$(printf '%b' "$path")")"
+  done
+}
+TWO='[".agents/skills/a*/x.md","space name.md"]'
+contains_rows \
+  "the glob-bearing path is found by its literal spelling|$TWO|.agents/skills/a*/x.md|yes" \
+  "the space-bearing path is found whole|$TWO|space name.md|yes" \
+  "a path the listed glob would match is not in the list|$TWO|.agents/skills/abc/x.md|no" \
+  "a glob in the asked path matches nothing: the ask is literal too|$TWO|.agents/*|no" \
+  "a suffix of a listed path is not in the list|$TWO|name.md|no" \
+  "a newline-bearing path is never in the list, even spelling two adjacent entries|$TWO|.agents/skills/a*/x.md\\nspace name.md|no" \
+  "the empty path is not in an empty list: the delimiters around nothing are not an entry|[]||no"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Reshapes `skills/commit-guards/tests/generated-paths.test.sh` to code-quality § Tests.

The suite for `scripts/lib/generated-paths.sh` (the reader of the render writer's inventory: `generated_paths_load JSON` takes one array of non-empty strings without newline or NUL through `jq -ers`, joined by newline, else a `::error::generated paths: cannot read…` line and return 2; `generated_path_contains PATH` is literal whole-line membership, refusing the empty path and any newline-bearing path first) was a 20-line exit-1 script of 13 assertions with no tally, reading each refusal as an exit status alone. It is two tables now. `load_rows` (`label|inventory|expect`): the inventory goes through `printf %b`, GENERATED_PATHS is set to `stale` first, and the row pins `rc=N paths=<the paths held afterwards> <every stderr line>` with jq's framing stripped (`jq: error (at <stdin>:N): ` removed so the loader's own `error()` clauses stand; a `jq: parse error: …` line reduced to `<jq parse error>`, that wording being jq's, not this guard's). `contains_rows` (`label|inventory|path|expect`): loads the inventory, asks the path, pinned `yes` or `no`.

Every old assertion has a row: the good load of two inventories is two rows showing the paths held; the eight refused inventories (empty, a stream, non-JSON, an object, a null entry, an empty entry, a newline entry, a NUL entry) each a row with its cause and nothing held; the four membership checks four rows. Rows added: a glob in the asked path matches nothing, a newline-bearing ask spelling two adjacent entries in list order, the empty path against an empty list, and the reviewer round's two: a prefix of a listed path is not in the list (the trailing delimiter of the whole-line match had no row; without it a generated `hooks/foo.sh` would exclude a changed source `hooks/foo` from the suppression-ban scan through `gg_is_excluded`), and a number entry is refused (the null-entry row was refused by the length clause, never the type clause, so a dropped type check answered with jq's own wording). 13 + 3 + 2 + 1 (the second good load) = 19.

Recorded, not pinned: jq's `-e` (no accepted inventory yields a null or false result, the accepted branch always joins to a string); the `GENERATED_PATHS=""` initialiser (unreachable from a caller under `set -u`); the `%b` conversion in the contains table (load-bearing for the newline row's kill, its own removal reads the same on the shipped reader).

The tracked render is replayed with `patch`. Nothing about `.kendex-generated.json` changed.

## Mutation

17 exact-substring production mutants over `scripts/lib/generated-paths.sh` (`mutate-gp.py`, results `mutants-gp-2.txt` in the session scratchpad), run against the final suite in a scratch copy: 16 killed, 1 equivalent.

| mutant | result |
|---|---|
| load: a stream of inventories accepted | killed by "two arrays are refused: a stream is not one inventory" |
| load: an empty entry accepted | killed by "an empty entry is refused" |
| load: a newline entry accepted | killed by "an entry carrying a newline is refused: the list is newline-delimited" |
| load: a NUL entry accepted | killed by "an entry carrying a NUL is refused" |
| load: an object accepted | killed by "an object is refused: not an array" |
| load: a null entry accepted | killed by "a null entry is refused: it has no length" |
| load: the paths joined by a space | killed by "literal paths load as written: a glob character and a space are content" |
| load: a refusal keeps the previous paths | killed by "empty input is refused: no inventory is not one inventory" |
| load: a refusal exits 1 | killed by the same row |
| load: the refusal line dropped | killed by the same row |
| load: jq's -e dropped | SURVIVED: equivalent, no accepted inventory yields null or false |
| load: the string type clause dropped | killed by "a number entry is refused: not a string" |
| contains: a glob match | killed by "a glob in the asked path matches nothing: the ask is literal too" |
| contains: a prefix match (the trailing delimiter dropped) | killed by "a prefix of a listed path is not in the list: a generated file does not exclude the source it is named after" |
| contains: a suffix match | killed by "a suffix of a listed path is not in the list" |
| contains: the empty and newline guard dropped | killed by "a newline-bearing path is never in the list, even spelling two adjacent entries" |
| contains: the empty guard dropped | killed by "the empty path is not in an empty list: the delimiters around nothing are not an entry" |

6 fixture mutants: 3 killed, 1 killed by rows other than the one the runner named, 2 by design.

| fixture mutant | result |
|---|---|
| F1 load: the stale marker not planted | no kill by design: an empty previous state reads the same; the marker is what "a refusal keeps the previous paths" needs |
| F2 load: stderr not read | killed by "empty input is refused: no inventory is not one inventory" |
| F3 rows: %b becomes %s | killed by "an entry carrying a newline is refused: the list is newline-delimited" |
| F6 contains: %b becomes %s | no kill by design: a literal backslash-n path is absent either way; the conversion is what the newline-guard mutant's kill needs |
| F4 contains: the inventory not loaded per row | killed by "the glob-bearing path is found by its literal spelling" and "the space-bearing path is found whole" |
| F5 contains: the newline row without its newline | killed by "a newline-bearing path is never in the list, even spelling two adjacent entries" |

The reviewer's 44 mutants: 34 killed on the first commit; its two blocker survivors are the second commit's rows; the rest are the equivalents above and assertion-disabling pairs. Its report is `review-gp/REPORT-final.md` of the session scratchpad.

## Checks

- `generated-paths.test.sh`: 19 assertions; passes on this host under TMPDIR=/tmp and a symlinked TMPDIR, and on a macOS box (bash 3.2.57); jq 1.8.2 on both, the parse-wording token covering jq 1.7 by construction. `tools/bash32-lint` clean over the tests directory.
- `tools/guard --full`: exit 0 on the first commit under TMPDIR=/tmp; the run on the rebased second commit was launched at PR time, CI is the verdict.
- One reviewer-test round: fix-first, its two rows in the second commit.

KEN-1241

https://claude.ai/code/session_01ESWfqKsTYCo5LjWxeBmaKi
