### PR TITLE
test(KEN-1241): fork pull requests as one table of rows

### DIFF
--- a/.agents/skills/worktree/tests/worktree_create_fork_pr.sh
+++ b/.agents/skills/worktree/tests/worktree_create_fork_pr.sh
@@ -144,7 +144,8 @@ step() {
       git -C "$MAIN" add base.txt
       git -C "$MAIN" commit -q -m base
       printf 'WORKTREE_BASE_DIR="../trees"\n' >"$MAIN/.env.local"
-      git init -q --bare "$ROOT/origin.git"
+      # HEAD names main so the clone checks it out whatever the host's default branch is.
+      git init -q --bare -b main "$ROOT/origin.git"
       git -C "$MAIN" remote add origin "$ROOT/origin.git"
       git -C "$MAIN" push -q -u origin main
       OIDS="$OIDS base=$(git -C "$MAIN" rev-parse HEAD)"

--- a/.agents/skills/worktree/tests/worktree_create_fork_pr.sh
+++ b/.agents/skills/worktree/tests/worktree_create_fork_pr.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
-# Tests for `create --pr` against a fork pull request: the head branch lives
-# in the contributor's repository, so origin has no such head and the commit
-# is reachable only through origin's refs/pull/<n>/head. The worktree branch
-# is fork-pr-<n>, so the contributor's branch name never touches a local or
-# origin branch of the same name. A same-repository PR keeps the tracked
-# origin-branch checkout, and a pull ref that does not deliver the head gh
-# reports refuses before any worktree exists.
+# `create --pr` against a fork pull request, and the remove and cleanup of
+# the worktree it leaves: one table, a row per scenario. The head branch of a
+# fork PR lives in the contributor's repository, so origin has no such head
+# and the commit is reachable only through origin's refs/pull/<n>/head; the
+# worktree branch is fork-pr-<n>, so the contributor's branch name never
+# touches a local or origin branch of the same name, and a merged fork PR is
+# proved by its number, never by ancestry or a head query. A row's fixture is
+# a word list of steps that builds the base repository, its origin, the
+# contributor's clone and gh's answers, and drives them to the state under
+# test; the command runs from the main checkout, and the row pins its exit
+# status, its stdout, its stderr, and what is left: every worktree under the
+# trees base with its branch and head, every local branch beside main with
+# its head and upstream, the main checkout's branch and head, origin's branch heads (refs/heads only, not its pull refs)
+# and the remotes the main checkout has.
 set -euo pipefail
 
 # A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
@@ -31,83 +38,10 @@ assert_eq() {
   fi
 }
 
-assert_contains() {
-  local haystack="$1" needle="$2" name="$3"
-  if grep -qF -- "$needle" <<<"$haystack"; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        wanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
-  fi
-}
-
-assert_path_absent() {
-  local path="$1" name="$2"
-  if [[ ! -e "$path" ]]; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        unexpected path: %s\n' "$name" "$path"
-  fi
-}
-
-ROOT="$TMP_ROOT/fork-pr"
-mkdir -p "$ROOT/main" "$ROOT/bin" "$ROOT/gh-state"
-git -C "$ROOT/main" init -q -b main
-git -C "$ROOT/main" config user.email test@example.com
-git -C "$ROOT/main" config user.name Test
-git -C "$ROOT/main" config commit.gpgsign false
-printf 'base\n' >"$ROOT/main/base.txt"
-git -C "$ROOT/main" add base.txt
-git -C "$ROOT/main" commit -q -m base
-printf 'WORKTREE_BASE_DIR="../trees"\n' >"$ROOT/main/.env.local"
-git init -q --bare "$ROOT/origin.git"
-git -C "$ROOT/main" remote add origin "$ROOT/origin.git"
-git -C "$ROOT/main" push -q -u origin main
-
-# The contributor's repository: a clone of origin whose branch never reaches
-# origin as a head. GitHub exposes such a head to the base repository only as
-# refs/pull/<n>/head, which is the one ref the fixture publishes.
-git clone -q "$ROOT/origin.git" "$ROOT/fork"
-git -C "$ROOT/fork" config user.email fork@example.com
-git -C "$ROOT/fork" config user.name Fork
-git -C "$ROOT/fork" config commit.gpgsign false
-git -C "$ROOT/fork" checkout -q -b fix/widget-expiry
-printf 'fork fix\n' >"$ROOT/fork/fix.txt"
-git -C "$ROOT/fork" add fix.txt
-git -C "$ROOT/fork" commit -q -m 'fork fix'
-FORK_HEAD="$(git -C "$ROOT/fork" rev-parse HEAD)"
-git -C "$ROOT/fork" push -q origin "HEAD:refs/pull/7/head"
-
-# A same-repository PR: its head is an ordinary origin branch.
-git -C "$ROOT/main" checkout -q -b feat/same
-printf 'same repo\n' >"$ROOT/main/same.txt"
-git -C "$ROOT/main" add same.txt
-git -C "$ROOT/main" commit -q -m 'same-repo feature'
-SAME_HEAD="$(git -C "$ROOT/main" rev-parse HEAD)"
-git -C "$ROOT/main" push -q origin feat/same "HEAD:refs/pull/8/head"
-git -C "$ROOT/main" checkout -q main
-git -C "$ROOT/main" branch -q -D feat/same
-
-# A pull ref that is not the head gh reports: the base's own tip.
-git -C "$ROOT/main" push -q origin "main:refs/pull/9/head"
-PHANTOM_OID="$(printf '%040d' 1)"
-
-# A fork PR opened from the fork's own `main`: the head branch name is the
-# main checkout's branch name.
-git -C "$ROOT/fork" checkout -q main
-printf 'fork main fix\n' >"$ROOT/fork/from-main.txt"
-git -C "$ROOT/fork" add from-main.txt
-git -C "$ROOT/fork" commit -q -m 'fork main fix'
-FORK_MAIN_HEAD="$(git -C "$ROOT/fork" rev-parse HEAD)"
-git -C "$ROOT/fork" push -q origin "HEAD:refs/pull/11/head"
-git -C "$ROOT/fork" checkout -q fix/widget-expiry
-
 # gh as it answers `pr view <n> --json <fields> -q <query>`: the stored
 # document is the field set gh returns, and the query runs over it.
-cat >"$ROOT/bin/gh" <<'STUB'
+mkdir -p "$TMP_ROOT/bin"
+cat >"$TMP_ROOT/bin/gh" <<'STUB'
 #!/usr/bin/env bash
 set -euo pipefail
 case "${1:-}:${2:-}" in
@@ -135,203 +69,293 @@ case "${1:-}:${2:-}" in
     ;;
 esac
 STUB
-chmod +x "$ROOT/bin/gh"
-export PATH="$ROOT/bin:$PATH"
-export GH_STATE="$ROOT/gh-state"
+chmod +x "$TMP_ROOT/bin/gh"
+export PATH="$TMP_ROOT/bin:$PATH"
+
+# --- fixtures -----------------------------------------------------------------
+# Every row's world lives under its own ROOT: the main checkout at ROOT/main,
+# the bare origin at ROOT/origin.git, the contributor's clone at ROOT/fork,
+# gh's documents at ROOT/gh-state, the worktrees under ROOT/trees.
+
+ROOT=""
+MAIN=""
+FORK=""
+OIDS=""   # "name=commit" words, for the renderer
+PHANTOM="$(printf '%040d' 1)"
 
 pr_doc() {
   local number="$1" name="$2" oid="$3" cross="$4" state="${5:-OPEN}" base="${6:-main}"
   printf '{"headRefName":"%s","headRefOid":"%s","isCrossRepository":%s,"state":"%s","baseRefName":"%s"}\n' \
-    "$name" "$oid" "$cross" "$state" "$base" >"$GH_STATE/pr-$number.json"
+    "$name" "$oid" "$cross" "$state" "$base" >"$ROOT/gh-state/pr-$number.json"
 }
-pr_doc 7 fix/widget-expiry "$FORK_HEAD" true
-pr_doc 8 feat/same "$SAME_HEAD" false
-pr_doc 9 fix/phantom "$PHANTOM_OID" true
-pr_doc 10 fix/no-pull-ref "$FORK_HEAD" true
-pr_doc 11 main "$FORK_MAIN_HEAD" true
 
-echo "=== worktree create --pr on a fork pull request ==="
-
-origin_heads_before="$(git -C "$ROOT/origin.git" for-each-ref --format='%(refname) %(objectname)' | sort)"
-
-set +e
-fork_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-fork --pr 7 2>"$ROOT/fork.err")"
-fork_code=$?
-set -e
-FORK_WT="$ROOT/trees/issue-fork"
-assert_eq "$fork_code" "0" "fork PR creates a worktree (stderr: $(tr '\n' ' ' <"$ROOT/fork.err"))"
-assert_eq "$fork_out" "$FORK_WT" "fork PR prints the worktree path"
-assert_eq "$(git -C "$FORK_WT" rev-parse HEAD 2>/dev/null || true)" "$FORK_HEAD" "fork worktree HEAD is the PR head commit"
-assert_eq "$(git -C "$FORK_WT" branch --show-current 2>/dev/null || true)" "fork-pr-7" "fork worktree branch is fork-pr-7, not the contributor's branch name"
-assert_eq "$(git -C "$ROOT/main" rev-parse --verify --quiet refs/heads/fix/widget-expiry || true)" "" "no local branch carries the contributor's branch name"
-set +e
-fork_upstream="$(git -C "$FORK_WT" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null)"
-fork_upstream_code=$?
-set -e
-assert_eq "$fork_upstream_code:$fork_upstream" "128:" "fork worktree branch has no upstream"
-assert_eq "$(git -C "$ROOT/main" remote | sort | tr '\n' ' ')" "origin " "no remote is added for the fork"
-assert_eq "$(git -C "$ROOT/origin.git" for-each-ref --format='%(refname) %(objectname)' | sort)" "$origin_heads_before" "origin refs are unchanged after the fork checkout"
-
-set +e
-same_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-same --pr 8 2>"$ROOT/same.err")"
-same_code=$?
-set -e
-SAME_WT="$ROOT/trees/issue-same"
-assert_eq "$same_code" "0" "same-repository PR creates a worktree (stderr: $(tr '\n' ' ' <"$ROOT/same.err"))"
-assert_eq "$same_out" "$SAME_WT" "same-repository PR prints the worktree path"
-assert_eq "$(git -C "$SAME_WT" rev-parse HEAD 2>/dev/null || true)" "$SAME_HEAD" "same-repository worktree HEAD is the origin branch tip"
-assert_eq "$(git -C "$SAME_WT" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)" "origin/feat/same" "same-repository branch tracks its origin branch"
-
-# A fork PR whose head branch is named `main` is inspectable: the local
-# branch is fork-pr-11, so the main checkout's `main` is neither in the way
-# nor reset to the contributor's commit.
-LOCAL_MAIN_BEFORE="$(git -C "$ROOT/main" rev-parse refs/heads/main)"
-set +e
-from_main_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-from-main --pr 11 2>"$ROOT/from-main.err")"
-from_main_code=$?
-set -e
-FROM_MAIN_WT="$ROOT/trees/issue-from-main"
-assert_eq "$from_main_code:$from_main_out" "0:$FROM_MAIN_WT" "a fork PR opened from the fork's main creates a worktree (stderr: $(tr '\n' ' ' <"$ROOT/from-main.err"))"
-assert_eq "$(git -C "$FROM_MAIN_WT" rev-parse HEAD 2>/dev/null || true)" "$FORK_MAIN_HEAD" "fork-from-main worktree HEAD is the PR head commit"
-assert_eq "$(git -C "$FROM_MAIN_WT" branch --show-current 2>/dev/null || true)" "fork-pr-11" "fork-from-main worktree branch is fork-pr-11"
-assert_eq "$(git -C "$ROOT/main" rev-parse refs/heads/main)" "$LOCAL_MAIN_BEFORE" "the main checkout's local main is untouched"
-assert_eq "$(git -C "$ROOT/main" branch --show-current)" "main" "the main checkout still has main checked out"
-
-# Inspecting the same fork PR again: `remove` keeps the local fork-pr-7 branch
-# while the PR is open, the contributor has pushed since, and origin has
-# meanwhile grown an unrelated branch under the contributor's branch name.
-# The second create resets the stale branch to the new head and still sets
-# no upstream.
-printf 'fork fix 2\n' >>"$ROOT/fork/fix.txt"
-git -C "$ROOT/fork" commit -q -am 'fork fix 2'
-FORK_HEAD_2="$(git -C "$ROOT/fork" rev-parse HEAD)"
-git -C "$ROOT/fork" push -q -f origin "HEAD:refs/pull/7/head"
-pr_doc 7 fix/widget-expiry "$FORK_HEAD_2" true
-git -C "$ROOT/main" push -q origin "main:refs/heads/fix/widget-expiry"
-(cd "$ROOT/main" && "$WORKTREE_SCRIPT" remove issue-fork >/dev/null 2>&1) || true # exits 1: the open PR's branch stays
-assert_path_absent "$FORK_WT" "remove clears the fork worktree"
-assert_eq "$(git -C "$ROOT/main" rev-parse --verify --quiet refs/heads/fork-pr-7 || true)" "$FORK_HEAD" "remove keeps the open PR's local branch at the first head"
-# The stale branch also carries tracking config pointing at that unrelated
-# origin branch; -B preserves it, so the create must clear it afterwards.
-git -C "$ROOT/main" fetch -q origin
-git -C "$ROOT/main" branch -q --set-upstream-to=origin/fix/widget-expiry fork-pr-7
-set +e
-again_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-fork --pr 7 2>"$ROOT/again.err")"
-again_code=$?
-set -e
-assert_eq "$again_code:$again_out" "0:$FORK_WT" "re-inspecting the fork PR after remove creates the worktree again (stderr: $(tr '\n' ' ' <"$ROOT/again.err"))"
-assert_eq "$(git -C "$FORK_WT" rev-parse HEAD 2>/dev/null || true)" "$FORK_HEAD_2" "re-inspected worktree HEAD is the contributor's new head"
-set +e
-again_upstream="$(git -C "$FORK_WT" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null)"
-again_upstream_code=$?
-set -e
-assert_eq "$again_upstream_code:$again_upstream" "128:" "an unrelated origin branch of the same name does not become the upstream"
-
-# A local branch that diverged from the PR head is refused by name, not reset.
-git -C "$FORK_WT" config user.email test@example.com
-git -C "$FORK_WT" config user.name Test
-git -C "$FORK_WT" config commit.gpgsign false
-printf 'local only\n' >"$FORK_WT/local.txt"
-git -C "$FORK_WT" add local.txt
-git -C "$FORK_WT" commit -q -m 'local only'
-(cd "$ROOT/main" && "$WORKTREE_SCRIPT" remove issue-fork >/dev/null 2>&1) || true # exits 1: the open PR's branch stays
-set +e
-(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-fork --pr 7 >"$ROOT/diverged.out" 2>"$ROOT/diverged.err")
-diverged_code=$?
-set -e
-assert_eq "$diverged_code" "1" "a diverged local branch refuses the fork checkout with exit 1"
-assert_contains "$(cat "$ROOT/diverged.err")" "Local branch 'fork-pr-7' has commits that are not in the head of fork PR #7" "the refusal names the diverged branch"
-assert_path_absent "$FORK_WT" "a diverged local branch creates no worktree"
-
-# A fork head the base cannot deliver refuses before any worktree exists:
-#   number  issue            message fragment
-rows=(
-  "9	issue-phantom	did not deliver commit $PHANTOM_OID"
-  "10	issue-no-ref	Could not fetch refs/pull/10/head from origin"
-)
-for row in "${rows[@]}"; do
-  IFS=$'\t' read -r number issue fragment <<<"$row"
-  set +e
-  (cd "$ROOT/main" && "$WORKTREE_SCRIPT" create "$issue" --pr "$number" >"$ROOT/$issue.out" 2>"$ROOT/$issue.err")
-  code=$?
-  set -e
-  assert_eq "$code" "1" "PR #$number: undeliverable fork head exits 1"
-  assert_contains "$(cat "$ROOT/$issue.err")" "$fragment" "PR #$number: refusal names the cause"
-  assert_path_absent "$ROOT/trees/$issue" "PR #$number: no worktree is created"
-done
-
-echo "=== remove and cleanup prove a merged fork PR by its number ==="
-
-# GitHub files the PR under the contributor's head name, so a --head query
-# for fork-pr-<n> answers nothing; the number in the branch name is the key.
-# A squash lands the content on main as a new commit, so ancestry never
-# proves it either.
-squash_fork_onto_main() {
-  local file="$1" content="$2"
-  printf '%s\n' "$content" >"$ROOT/main/$file"
-  git -C "$ROOT/main" add "$file"
-  git -C "$ROOT/main" commit -q -m "$file (squashed)"
-  git -C "$ROOT/main" push -q origin main
+# A commit on the contributor's clone, on a branch off its main, pushed to
+# origin as the head of a pull request and nothing else.
+fork_pr() {
+  local number="$1" branch="$2" file="$3" content="$4" name="$5"
+  if [[ "$branch" == main ]]; then
+    git -C "$FORK" checkout -q main
+  else
+    git -C "$FORK" checkout -q -b "$branch" main
+  fi
+  printf '%s\n' "$content" >"$FORK/$file"
+  git -C "$FORK" add "$file"
+  git -C "$FORK" commit -q -m "$file"
+  OIDS="$OIDS $name=$(git -C "$FORK" rev-parse HEAD)"
+  must git -C "$FORK" push -q -f origin "HEAD:refs/pull/$number/head"
+  pr_doc "$number" "$branch" "$(oid_of "$name")" true
 }
-squash_fork_onto_main from-main.txt 'fork main fix'
-pr_doc 11 main "$FORK_MAIN_HEAD" true MERGED
-squashed_ancestor=no
-git -C "$ROOT/main" merge-base --is-ancestor fork-pr-11 origin/main && squashed_ancestor=yes
-assert_eq "$squashed_ancestor" "no" "precondition: the squashed fork branch is not an ancestor of origin/main"
-set +e
-merged_rm_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" remove issue-from-main 2>"$ROOT/merged-rm.err")"
-merged_rm_code=$?
-set -e
-assert_eq "$merged_rm_code:$merged_rm_out" "0:Removed: $FROM_MAIN_WT" "remove of a merged fork PR worktree exits 0 (stderr: $(tr '\n' ' ' <"$ROOT/merged-rm.err"))"
-assert_path_absent "$FROM_MAIN_WT" "remove clears the merged fork worktree"
-assert_eq "$(git -C "$ROOT/main" rev-parse --verify --quiet refs/heads/fork-pr-11 || true)" "" "remove deletes the merged fork branch"
-assert_contains "$(cat "$ROOT/merged-rm.err")" "Deleted branch 'fork-pr-11' — squash-merged in pull request #11." "remove names the merged pull request"
 
-# cleanup: one merged fork PR (#12) is collected, an open one (#13) is kept.
-git -C "$ROOT/fork" checkout -q -b fix/cleanup main
-printf 'cleanup fix\n' >"$ROOT/fork/cleanup.txt"
-git -C "$ROOT/fork" add cleanup.txt
-git -C "$ROOT/fork" commit -q -m 'cleanup fix'
-CLEANUP_HEAD="$(git -C "$ROOT/fork" rev-parse HEAD)"
-git -C "$ROOT/fork" push -q origin "HEAD:refs/pull/12/head"
-git -C "$ROOT/fork" checkout -q -b fix/still-open main
-printf 'still open\n' >"$ROOT/fork/open.txt"
-git -C "$ROOT/fork" add open.txt
-git -C "$ROOT/fork" commit -q -m 'still open'
-OPEN_HEAD="$(git -C "$ROOT/fork" rev-parse HEAD)"
-git -C "$ROOT/fork" push -q origin "HEAD:refs/pull/13/head"
-pr_doc 12 fix/cleanup "$CLEANUP_HEAD" true
-pr_doc 13 fix/still-open "$OPEN_HEAD" true
-CLEANUP_WT="$ROOT/trees/issue-cleanup"
-OPEN_WT="$ROOT/trees/issue-open"
-set +e
-cleanup_create_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-cleanup --pr 12 2>"$ROOT/cleanup-create.err" \
-  && "$WORKTREE_SCRIPT" create issue-open --pr 13 2>"$ROOT/open-create.err")"
-cleanup_create_code=$?
-set -e
-assert_eq "$cleanup_create_code" "0" "two fork PR worktrees exist before cleanup (stderr: $(cat "$ROOT/cleanup-create.err" "$ROOT/open-create.err" | tr '\n' ' '))"
-squash_fork_onto_main cleanup.txt 'cleanup fix'
-pr_doc 12 fix/cleanup "$CLEANUP_HEAD" true MERGED
-set +e
-cleanup_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" cleanup 2>"$ROOT/cleanup.err")"
-cleanup_code=$?
-set -e
-assert_eq "$cleanup_code" "0" "cleanup exits 0 (stderr: $(tr '\n' ' ' <"$ROOT/cleanup.err"))"
-assert_contains "$cleanup_out" "Cleaned: $CLEANUP_WT" "cleanup collects the merged fork PR worktree"
-assert_path_absent "$CLEANUP_WT" "the merged fork worktree is gone"
-assert_eq "$(git -C "$ROOT/main" rev-parse --verify --quiet refs/heads/fork-pr-12 || true)" "" "cleanup deletes the merged fork branch"
-assert_eq "$(git -C "$OPEN_WT" rev-parse HEAD 2>/dev/null || true)" "$OPEN_HEAD" "cleanup keeps the open fork PR worktree"
-assert_contains "$(cat "$ROOT/cleanup.err")" "fork pull request #13 is OPEN, not merged" "cleanup names the open fork PR it keeps"
+# The content of a fork PR lands on main as a new commit (a squash), so
+# ancestry never proves the merge.
+squash() {
+  local number="$1" file="$2" content="$3"
+  printf '%s\n' "$content" >"$MAIN/$file"
+  git -C "$MAIN" add "$file"
+  git -C "$MAIN" commit -q -m "$file (squashed)"
+  git -C "$MAIN" push -q origin main
+}
 
-# A merged fork PR whose merged head is not this tip is kept: the branch
-# carries work past the merge.
-pr_doc 13 fix/still-open "$FORK_HEAD" true MERGED
-set +e
-(cd "$ROOT/main" && "$WORKTREE_SCRIPT" cleanup >"$ROOT/moved.out" 2>"$ROOT/moved.err")
-set -e
-assert_eq "$(git -C "$OPEN_WT" rev-parse HEAD 2>/dev/null || true)" "$OPEN_HEAD" "a fork branch past its merged head is kept"
-assert_contains "$(cat "$ROOT/moved.err")" "carries work past its merged pull request (#13 merged head $FORK_HEAD" "cleanup names the head mismatch"
+tool() {
+  (cd "$MAIN" && "$WORKTREE_SCRIPT" "$@" >/dev/null 2>&1) || true
+}
+
+# A fixture command that must succeed; its failure is the fixture's, not a
+# row's, and stops the suite with a FIXTURE: line.
+must() {
+  "$@" || { echo "FIXTURE: '$*' failed in $ROOT" >&2; exit 2; }
+}
+
+# The step vocabulary. `world` builds the base repository, its origin, the
+# contributor's clone and the pull requests every row can name: #7 a fork PR
+# on the contributor's branch, #8 a same-repository PR whose head is an
+# origin branch, #9 a fork PR whose pull ref delivers the base's tip rather
+# than the head gh reports, #10 a fork PR with no pull ref, #11 a fork PR
+# opened from the contributor's own main.
+step() {
+  case "$1" in
+    world)
+      mkdir -p "$MAIN" "$ROOT/gh-state"
+      git -C "$MAIN" init -q -b main
+      git -C "$MAIN" config user.email test@example.com
+      git -C "$MAIN" config user.name Test
+      git -C "$MAIN" config commit.gpgsign false
+      printf 'base\n' >"$MAIN/base.txt"
+      git -C "$MAIN" add base.txt
+      git -C "$MAIN" commit -q -m base
+      printf 'WORKTREE_BASE_DIR="../trees"\n' >"$MAIN/.env.local"
+      git init -q --bare "$ROOT/origin.git"
+      git -C "$MAIN" remote add origin "$ROOT/origin.git"
+      git -C "$MAIN" push -q -u origin main
+      OIDS="$OIDS base=$(git -C "$MAIN" rev-parse HEAD)"
+      git clone -q "$ROOT/origin.git" "$FORK"
+      git -C "$FORK" config user.email fork@example.com
+      git -C "$FORK" config user.name Fork
+      git -C "$FORK" config commit.gpgsign false
+      fork_pr 7 fix/widget-expiry fix.txt 'fork fix' fork
+      git -C "$MAIN" checkout -q -b feat/same
+      printf 'same repo\n' >"$MAIN/same.txt"
+      git -C "$MAIN" add same.txt
+      git -C "$MAIN" commit -q -m 'same-repo feature'
+      OIDS="$OIDS same=$(git -C "$MAIN" rev-parse HEAD)"
+      git -C "$MAIN" push -q origin feat/same "HEAD:refs/pull/8/head"
+      git -C "$MAIN" checkout -q main
+      git -C "$MAIN" branch -q -D feat/same
+      pr_doc 8 feat/same "$(oid_of same)" false
+      git -C "$MAIN" push -q origin "main:refs/pull/9/head"
+      pr_doc 9 fix/phantom "$PHANTOM" true
+      pr_doc 10 fix/no-pull-ref "$(oid_of fork)" true
+      fork_pr 11 main from-main.txt 'fork main fix' fork-main
+      ;;
+    inspect:*)
+      tool create "issue-${1#inspect:}" --pr "${1#inspect:}"
+      [[ -d "$ROOT/trees/issue-${1#inspect:}" ]] || { echo "FIXTURE: create --pr ${1#inspect:} left no worktree in $ROOT" >&2; exit 2; }
+      ;;
+    remove:*) tool remove "issue-${1#remove:}" ;;
+    # The contributor pushed again since the worktree was made.
+    advance-fork)
+      git -C "$FORK" checkout -q fix/widget-expiry
+      printf 'fork fix 2\n' >>"$FORK/fix.txt"
+      git -C "$FORK" commit -q -am 'fork fix 2'
+      OIDS="$OIDS fork2=$(git -C "$FORK" rev-parse HEAD)"
+      git -C "$FORK" push -q -f origin "HEAD:refs/pull/7/head"
+      pr_doc 7 fix/widget-expiry "$(oid_of fork2)" true
+      ;;
+    # Origin grew an unrelated branch under the contributor's branch name,
+    # and the stale local branch tracks it.
+    unrelated-branch)
+      must git -C "$MAIN" push -q origin "main:refs/heads/fix/widget-expiry"
+      must git -C "$MAIN" fetch -q origin
+      must git -C "$MAIN" branch -q --set-upstream-to=origin/fix/widget-expiry fork-pr-7
+      ;;
+    # A commit of this checkout's own on the fork PR's branch.
+    local-commit)
+      git -C "$ROOT/trees/issue-7" config user.email test@example.com
+      git -C "$ROOT/trees/issue-7" config user.name Test
+      git -C "$ROOT/trees/issue-7" config commit.gpgsign false
+      printf 'local only\n' >"$ROOT/trees/issue-7/local.txt"
+      git -C "$ROOT/trees/issue-7" add local.txt
+      git -C "$ROOT/trees/issue-7" commit -q -m 'local only'
+      OIDS="$OIDS local=$(git -C "$ROOT/trees/issue-7" rev-parse HEAD)"
+      ;;
+    squash:11) squash 11 from-main.txt 'fork main fix' ;;
+    squash:12) squash 12 cleanup.txt 'cleanup fix' ;;
+    merged:11) pr_doc 11 main "$(oid_of fork-main)" true MERGED ;;
+    merged:12) pr_doc 12 fix/cleanup "$(oid_of cleanup)" true MERGED ;;
+    # #13's merged head is not this checkout's tip.
+    merged:13-elsewhere) pr_doc 13 fix/still-open "$(oid_of fork)" true MERGED ;;
+    # Two more fork PRs, #12 and #13, each checked out.
+    two-more)
+      fork_pr 12 fix/cleanup cleanup.txt 'cleanup fix' cleanup
+      fork_pr 13 fix/still-open open.txt 'still open' open
+      step inspect:12
+      step inspect:13
+      ;;
+    *)
+      echo "UNKNOWN-STEP: $1" >&2
+      exit 2
+      ;;
+  esac
+}
+
+build() {
+  local word
+  ROOT="$TMP_ROOT/$1"
+  shift
+  MAIN="$ROOT/main"
+  FORK="$ROOT/fork"
+  OIDS=""
+  export GH_STATE="$ROOT/gh-state"
+  for word in "$@"; do
+    step "$word"
+  done
+}
+
+# --- rendering ------------------------------------------------------------------
+
+oid_of() {
+  local word
+  for word in $OIDS; do
+    [[ "${word%%=*}" == "$1" ]] && { printf '%s' "${word#*=}"; return; }
+  done
+}
+
+oid_name() {
+  local oid="$1" word
+  [[ -n "$oid" ]] || { printf -- '-'; return; }
+  for word in $OIDS; do
+    if [[ "${word#*=}" == "$oid" ]]; then
+      printf '%s' "${word%%=*}"
+      return
+    fi
+  done
+  if [[ "$oid" == "$(git -C "$MAIN" rev-parse origin/main)" ]]; then printf 'squashed'
+  else printf '%s' "$oid"
+  fi
+}
+
+alias_text() {
+  local sed_args=() word
+  for word in $OIDS; do
+    sed_args+=(-e "s|${word#*=}|<${word%%=*}>|g")
+  done
+  sed -e "s|$ROOT|<root>|g" -e "s|$PHANTOM|<phantom>|g" ${sed_args[@]+"${sed_args[@]}"} -e 's/;/\\;/g' |
+    paste -s -d ';' -
+}
+
+upstream_of() {
+  git -C "$MAIN" rev-parse --abbrev-ref --symbolic-full-name "$1@{upstream}" 2>/dev/null || printf -- '-'
+}
+
+state() {
+  local trees="" branches="" origin="" dir branch line
+  for dir in "$ROOT"/trees/*; do
+    [[ -e "$dir" ]] || continue
+    if git -C "$MAIN" worktree list --porcelain | grep -qx "worktree $dir"; then
+      branch="$(git -C "$dir" branch --show-current 2>/dev/null)"
+      trees="$trees,${dir#"$ROOT"/trees/}=${branch:-detached}@$(oid_name "$(git -C "$dir" rev-parse HEAD 2>/dev/null)")"
+    else
+      trees="$trees,${dir#"$ROOT"/trees/}=unregistered"
+    fi
+  done
+  while IFS=' ' read -r branch line; do
+    [[ -n "$branch" && "$branch" != main ]] || continue
+    branches="$branches,$branch@$(oid_name "$line")/$(upstream_of "$branch")"
+  done <<<"$(git -C "$MAIN" for-each-ref --format='%(refname:short) %(objectname)' refs/heads)"
+  while IFS=' ' read -r branch line; do
+    [[ -n "$branch" ]] || continue
+    origin="$origin,${branch#refs/heads/}@$(oid_name "$line")"
+  done <<<"$(git --git-dir="$ROOT/origin.git" for-each-ref --format='%(refname) %(objectname)' refs/heads)"
+  printf 'trees=%s branches=%s main=%s@%s origin=%s remotes=%s' \
+    "${trees:-,-}" "${branches:-,-}" "$(git -C "$MAIN" branch --show-current)" \
+    "$(oid_name "$(git -C "$MAIN" rev-parse HEAD)")" "${origin:-,-}" \
+    "$(git -C "$MAIN" remote | paste -s -d ',' -)" | sed 's/=,/=/g'
+}
+
+run() {
+  local -a argv
+  local rc=0
+  read -r -a argv <<<"$1"
+  (cd "$MAIN" && "$WORKTREE_SCRIPT" "${argv[@]}" >"$ROOT/out" 2>"$ROOT/err") || rc=$?
+  printf 'rc=%s out=%s err=%s %s' "$rc" \
+    "$(alias_text <"$ROOT/out")" "$(alias_text <"$ROOT/err")" "$(state)"
+}
+
+# --- the expected text ----------------------------------------------------------
+
+err_text() {
+  case "$1" in
+    -) printf '' ;;
+    diverged) printf '%s' "Error: Local branch 'fork-pr-7' has commits that are not in the head of fork PR #7\; delete or rename that branch before inspecting the PR again." ;;
+    phantom) printf '%s' "Error: refs/pull/9/head on origin did not deliver commit <phantom>, the head gh reports for PR #9" ;;
+    no-ref) printf '%s' "Error: Could not fetch refs/pull/10/head from origin for fork PR #10;  fatal: couldn't find remote ref refs/pull/10/head" ;;
+    deleted:*) printf '%s' "Deleted branch 'fork-pr-${1#deleted:}' — squash-merged in pull request #${1#deleted:}." ;;
+    remove-open) printf '%s' "Error: Removed worktree but could not delete local branch 'fork-pr-7'.;  Remaining branch: fork-pr-7;  Worktree path removed/pruned: <root>/trees/issue-7;  Not merged into origin/main, and fork pull request #7 is OPEN, not merged;  After verifying it is safe, delete manually with: git -C \"<root>/main\" branch -D \"fork-pr-7\"" ;;
+    open-kept) printf '%s' "Skipped (branch 'fork-pr-13' is not merged — not an ancestor of origin/main, and fork pull request #13 is OPEN, not merged): <root>/trees/issue-13" ;;
+    moved-kept) printf '%s' "Skipped (branch 'fork-pr-13' is not merged — not an ancestor of origin/main, and carries work past its merged pull request (#13 merged head <fork>, not this tip <open>)): <root>/trees/issue-13" ;;
+    *) printf 'UNKNOWN-ERR-SPEC:%s' "$1" ;;
+  esac
+}
+
+out_text() {
+  case "$1" in
+    -) printf '' ;;
+    wt:*) printf '<root>/trees/issue-%s' "${1#wt:}" ;;
+    removed:*) printf 'Removed: <root>/trees/issue-%s' "${1#removed:}" ;;
+    cleaned:*) printf 'Cleaned: <root>/trees/issue-%s' "${1#cleaned:}" ;;
+    *) printf 'UNKNOWN-OUT-SPEC:%s' "$1" ;;
+  esac
+}
+
+# --- the rows ---------------------------------------------------------------------
+# label|fixture|command|rc|out|err|state
+ROWS='a fork PR is checked out on fork-pr-<n> at the head gh reports, with no upstream, no fork remote and no contributor-named branch|world|create issue-7 --pr 7|0|wt:7|-|trees=issue-7=fork-pr-7@fork branches=fork-pr-7@fork/- main=main@base origin=feat/same@same,main@base remotes=origin
+a same-repository PR keeps the tracked origin-branch checkout|world|create issue-8 --pr 8|0|wt:8|-|trees=issue-8=feat/same@same branches=feat/same@same/origin/feat/same main=main@base origin=feat/same@same,main@base remotes=origin
+a fork PR opened from the contributor'"'"'s main leaves this checkout'"'"'s main untouched|world|create issue-11 --pr 11|0|wt:11|-|trees=issue-11=fork-pr-11@fork-main branches=fork-pr-11@fork-main/- main=main@base origin=feat/same@same,main@base remotes=origin
+remove keeps the open fork PR'"'"'s local branch|world inspect:7|remove issue-7|1|removed:7|remove-open|trees=- branches=fork-pr-7@fork/- main=main@base origin=feat/same@same,main@base remotes=origin
+re-inspecting after the contributor pushed resets the stale branch to the new head and clears the tracking an unrelated origin branch left|world inspect:7 advance-fork remove:7 unrelated-branch|create issue-7 --pr 7|0|wt:7|-|trees=issue-7=fork-pr-7@fork2 branches=fork-pr-7@fork2/- main=main@base origin=feat/same@same,fix/widget-expiry@base,main@base remotes=origin
+a local branch that diverged from the PR head is refused by name, not reset|world inspect:7 local-commit remove:7|create issue-7 --pr 7|1|-|diverged|trees=- branches=fork-pr-7@local/- main=main@base origin=feat/same@same,main@base remotes=origin
+a pull ref that delivers a commit other than the head gh reports is refused before any worktree exists|world|create issue-9 --pr 9|1|-|phantom|trees=- branches=- main=main@base origin=feat/same@same,main@base remotes=origin
+a fork PR with no pull ref on origin is refused before any worktree exists|world|create issue-10 --pr 10|1|-|no-ref|trees=- branches=- main=main@base origin=feat/same@same,main@base remotes=origin
+remove proves a squash-merged fork PR by its number and deletes the branch|world inspect:11 squash:11 merged:11|remove issue-11|0|removed:11|deleted:11|trees=- branches=- main=main@squashed origin=feat/same@same,main@squashed remotes=origin
+cleanup collects the merged fork PR and keeps the open one, naming it|world two-more squash:12 merged:12|cleanup|0|cleaned:12|open-kept|trees=issue-13=fork-pr-13@open branches=fork-pr-13@open/- main=main@squashed origin=feat/same@same,main@squashed remotes=origin
+cleanup keeps a fork branch whose tip is past its merged head, naming the mismatch|world two-more squash:12 merged:12 merged:13-elsewhere|cleanup|0|cleaned:12|moved-kept|trees=issue-13=fork-pr-13@open branches=fork-pr-13@open/- main=main@squashed origin=feat/same@same,main@squashed remotes=origin
+'
+
+echo "=== worktree create --pr, remove and cleanup on fork pull requests ==="
+n=0
+while IFS='|' read -r label fixture command rc out err want_state; do
+  [[ -n "$label$fixture$command$rc$out$err$want_state" ]] || continue
+  n=$((n + 1))
+  # shellcheck disable=SC2086
+  build "row-$n" $fixture
+  if [[ "${PROBE:-}" == 1 ]]; then
+    printf '%s => %s\n' "$label" "$(run "$command")"
+    continue
+  fi
+  assert_eq "$(run "$command")" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want_state" "$label"
+done <<<"$ROWS"
 
 echo
-echo "Passed: $PASS, Failed: $FAIL"
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/worktree/tests/worktree_create_fork_pr.sh
+++ b/skills/worktree/tests/worktree_create_fork_pr.sh
@@ -144,7 +144,8 @@ step() {
       git -C "$MAIN" add base.txt
       git -C "$MAIN" commit -q -m base
       printf 'WORKTREE_BASE_DIR="../trees"\n' >"$MAIN/.env.local"
-      git init -q --bare "$ROOT/origin.git"
+      # HEAD names main so the clone checks it out whatever the host's default branch is.
+      git init -q --bare -b main "$ROOT/origin.git"
       git -C "$MAIN" remote add origin "$ROOT/origin.git"
       git -C "$MAIN" push -q -u origin main
       OIDS="$OIDS base=$(git -C "$MAIN" rev-parse HEAD)"

--- a/skills/worktree/tests/worktree_create_fork_pr.sh
+++ b/skills/worktree/tests/worktree_create_fork_pr.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
-# Tests for `create --pr` against a fork pull request: the head branch lives
-# in the contributor's repository, so origin has no such head and the commit
-# is reachable only through origin's refs/pull/<n>/head. The worktree branch
-# is fork-pr-<n>, so the contributor's branch name never touches a local or
-# origin branch of the same name. A same-repository PR keeps the tracked
-# origin-branch checkout, and a pull ref that does not deliver the head gh
-# reports refuses before any worktree exists.
+# `create --pr` against a fork pull request, and the remove and cleanup of
+# the worktree it leaves: one table, a row per scenario. The head branch of a
+# fork PR lives in the contributor's repository, so origin has no such head
+# and the commit is reachable only through origin's refs/pull/<n>/head; the
+# worktree branch is fork-pr-<n>, so the contributor's branch name never
+# touches a local or origin branch of the same name, and a merged fork PR is
+# proved by its number, never by ancestry or a head query. A row's fixture is
+# a word list of steps that builds the base repository, its origin, the
+# contributor's clone and gh's answers, and drives them to the state under
+# test; the command runs from the main checkout, and the row pins its exit
+# status, its stdout, its stderr, and what is left: every worktree under the
+# trees base with its branch and head, every local branch beside main with
+# its head and upstream, the main checkout's branch and head, origin's branch heads (refs/heads only, not its pull refs)
+# and the remotes the main checkout has.
 set -euo pipefail
 
 # A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
@@ -31,83 +38,10 @@ assert_eq() {
   fi
 }
 
-assert_contains() {
-  local haystack="$1" needle="$2" name="$3"
-  if grep -qF -- "$needle" <<<"$haystack"; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        wanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
-  fi
-}
-
-assert_path_absent() {
-  local path="$1" name="$2"
-  if [[ ! -e "$path" ]]; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        unexpected path: %s\n' "$name" "$path"
-  fi
-}
-
-ROOT="$TMP_ROOT/fork-pr"
-mkdir -p "$ROOT/main" "$ROOT/bin" "$ROOT/gh-state"
-git -C "$ROOT/main" init -q -b main
-git -C "$ROOT/main" config user.email test@example.com
-git -C "$ROOT/main" config user.name Test
-git -C "$ROOT/main" config commit.gpgsign false
-printf 'base\n' >"$ROOT/main/base.txt"
-git -C "$ROOT/main" add base.txt
-git -C "$ROOT/main" commit -q -m base
-printf 'WORKTREE_BASE_DIR="../trees"\n' >"$ROOT/main/.env.local"
-git init -q --bare "$ROOT/origin.git"
-git -C "$ROOT/main" remote add origin "$ROOT/origin.git"
-git -C "$ROOT/main" push -q -u origin main
-
-# The contributor's repository: a clone of origin whose branch never reaches
-# origin as a head. GitHub exposes such a head to the base repository only as
-# refs/pull/<n>/head, which is the one ref the fixture publishes.
-git clone -q "$ROOT/origin.git" "$ROOT/fork"
-git -C "$ROOT/fork" config user.email fork@example.com
-git -C "$ROOT/fork" config user.name Fork
-git -C "$ROOT/fork" config commit.gpgsign false
-git -C "$ROOT/fork" checkout -q -b fix/widget-expiry
-printf 'fork fix\n' >"$ROOT/fork/fix.txt"
-git -C "$ROOT/fork" add fix.txt
-git -C "$ROOT/fork" commit -q -m 'fork fix'
-FORK_HEAD="$(git -C "$ROOT/fork" rev-parse HEAD)"
-git -C "$ROOT/fork" push -q origin "HEAD:refs/pull/7/head"
-
-# A same-repository PR: its head is an ordinary origin branch.
-git -C "$ROOT/main" checkout -q -b feat/same
-printf 'same repo\n' >"$ROOT/main/same.txt"
-git -C "$ROOT/main" add same.txt
-git -C "$ROOT/main" commit -q -m 'same-repo feature'
-SAME_HEAD="$(git -C "$ROOT/main" rev-parse HEAD)"
-git -C "$ROOT/main" push -q origin feat/same "HEAD:refs/pull/8/head"
-git -C "$ROOT/main" checkout -q main
-git -C "$ROOT/main" branch -q -D feat/same
-
-# A pull ref that is not the head gh reports: the base's own tip.
-git -C "$ROOT/main" push -q origin "main:refs/pull/9/head"
-PHANTOM_OID="$(printf '%040d' 1)"
-
-# A fork PR opened from the fork's own `main`: the head branch name is the
-# main checkout's branch name.
-git -C "$ROOT/fork" checkout -q main
-printf 'fork main fix\n' >"$ROOT/fork/from-main.txt"
-git -C "$ROOT/fork" add from-main.txt
-git -C "$ROOT/fork" commit -q -m 'fork main fix'
-FORK_MAIN_HEAD="$(git -C "$ROOT/fork" rev-parse HEAD)"
-git -C "$ROOT/fork" push -q origin "HEAD:refs/pull/11/head"
-git -C "$ROOT/fork" checkout -q fix/widget-expiry
-
 # gh as it answers `pr view <n> --json <fields> -q <query>`: the stored
 # document is the field set gh returns, and the query runs over it.
-cat >"$ROOT/bin/gh" <<'STUB'
+mkdir -p "$TMP_ROOT/bin"
+cat >"$TMP_ROOT/bin/gh" <<'STUB'
 #!/usr/bin/env bash
 set -euo pipefail
 case "${1:-}:${2:-}" in
@@ -135,203 +69,293 @@ case "${1:-}:${2:-}" in
     ;;
 esac
 STUB
-chmod +x "$ROOT/bin/gh"
-export PATH="$ROOT/bin:$PATH"
-export GH_STATE="$ROOT/gh-state"
+chmod +x "$TMP_ROOT/bin/gh"
+export PATH="$TMP_ROOT/bin:$PATH"
+
+# --- fixtures -----------------------------------------------------------------
+# Every row's world lives under its own ROOT: the main checkout at ROOT/main,
+# the bare origin at ROOT/origin.git, the contributor's clone at ROOT/fork,
+# gh's documents at ROOT/gh-state, the worktrees under ROOT/trees.
+
+ROOT=""
+MAIN=""
+FORK=""
+OIDS=""   # "name=commit" words, for the renderer
+PHANTOM="$(printf '%040d' 1)"
 
 pr_doc() {
   local number="$1" name="$2" oid="$3" cross="$4" state="${5:-OPEN}" base="${6:-main}"
   printf '{"headRefName":"%s","headRefOid":"%s","isCrossRepository":%s,"state":"%s","baseRefName":"%s"}\n' \
-    "$name" "$oid" "$cross" "$state" "$base" >"$GH_STATE/pr-$number.json"
+    "$name" "$oid" "$cross" "$state" "$base" >"$ROOT/gh-state/pr-$number.json"
 }
-pr_doc 7 fix/widget-expiry "$FORK_HEAD" true
-pr_doc 8 feat/same "$SAME_HEAD" false
-pr_doc 9 fix/phantom "$PHANTOM_OID" true
-pr_doc 10 fix/no-pull-ref "$FORK_HEAD" true
-pr_doc 11 main "$FORK_MAIN_HEAD" true
 
-echo "=== worktree create --pr on a fork pull request ==="
-
-origin_heads_before="$(git -C "$ROOT/origin.git" for-each-ref --format='%(refname) %(objectname)' | sort)"
-
-set +e
-fork_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-fork --pr 7 2>"$ROOT/fork.err")"
-fork_code=$?
-set -e
-FORK_WT="$ROOT/trees/issue-fork"
-assert_eq "$fork_code" "0" "fork PR creates a worktree (stderr: $(tr '\n' ' ' <"$ROOT/fork.err"))"
-assert_eq "$fork_out" "$FORK_WT" "fork PR prints the worktree path"
-assert_eq "$(git -C "$FORK_WT" rev-parse HEAD 2>/dev/null || true)" "$FORK_HEAD" "fork worktree HEAD is the PR head commit"
-assert_eq "$(git -C "$FORK_WT" branch --show-current 2>/dev/null || true)" "fork-pr-7" "fork worktree branch is fork-pr-7, not the contributor's branch name"
-assert_eq "$(git -C "$ROOT/main" rev-parse --verify --quiet refs/heads/fix/widget-expiry || true)" "" "no local branch carries the contributor's branch name"
-set +e
-fork_upstream="$(git -C "$FORK_WT" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null)"
-fork_upstream_code=$?
-set -e
-assert_eq "$fork_upstream_code:$fork_upstream" "128:" "fork worktree branch has no upstream"
-assert_eq "$(git -C "$ROOT/main" remote | sort | tr '\n' ' ')" "origin " "no remote is added for the fork"
-assert_eq "$(git -C "$ROOT/origin.git" for-each-ref --format='%(refname) %(objectname)' | sort)" "$origin_heads_before" "origin refs are unchanged after the fork checkout"
-
-set +e
-same_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-same --pr 8 2>"$ROOT/same.err")"
-same_code=$?
-set -e
-SAME_WT="$ROOT/trees/issue-same"
-assert_eq "$same_code" "0" "same-repository PR creates a worktree (stderr: $(tr '\n' ' ' <"$ROOT/same.err"))"
-assert_eq "$same_out" "$SAME_WT" "same-repository PR prints the worktree path"
-assert_eq "$(git -C "$SAME_WT" rev-parse HEAD 2>/dev/null || true)" "$SAME_HEAD" "same-repository worktree HEAD is the origin branch tip"
-assert_eq "$(git -C "$SAME_WT" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)" "origin/feat/same" "same-repository branch tracks its origin branch"
-
-# A fork PR whose head branch is named `main` is inspectable: the local
-# branch is fork-pr-11, so the main checkout's `main` is neither in the way
-# nor reset to the contributor's commit.
-LOCAL_MAIN_BEFORE="$(git -C "$ROOT/main" rev-parse refs/heads/main)"
-set +e
-from_main_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-from-main --pr 11 2>"$ROOT/from-main.err")"
-from_main_code=$?
-set -e
-FROM_MAIN_WT="$ROOT/trees/issue-from-main"
-assert_eq "$from_main_code:$from_main_out" "0:$FROM_MAIN_WT" "a fork PR opened from the fork's main creates a worktree (stderr: $(tr '\n' ' ' <"$ROOT/from-main.err"))"
-assert_eq "$(git -C "$FROM_MAIN_WT" rev-parse HEAD 2>/dev/null || true)" "$FORK_MAIN_HEAD" "fork-from-main worktree HEAD is the PR head commit"
-assert_eq "$(git -C "$FROM_MAIN_WT" branch --show-current 2>/dev/null || true)" "fork-pr-11" "fork-from-main worktree branch is fork-pr-11"
-assert_eq "$(git -C "$ROOT/main" rev-parse refs/heads/main)" "$LOCAL_MAIN_BEFORE" "the main checkout's local main is untouched"
-assert_eq "$(git -C "$ROOT/main" branch --show-current)" "main" "the main checkout still has main checked out"
-
-# Inspecting the same fork PR again: `remove` keeps the local fork-pr-7 branch
-# while the PR is open, the contributor has pushed since, and origin has
-# meanwhile grown an unrelated branch under the contributor's branch name.
-# The second create resets the stale branch to the new head and still sets
-# no upstream.
-printf 'fork fix 2\n' >>"$ROOT/fork/fix.txt"
-git -C "$ROOT/fork" commit -q -am 'fork fix 2'
-FORK_HEAD_2="$(git -C "$ROOT/fork" rev-parse HEAD)"
-git -C "$ROOT/fork" push -q -f origin "HEAD:refs/pull/7/head"
-pr_doc 7 fix/widget-expiry "$FORK_HEAD_2" true
-git -C "$ROOT/main" push -q origin "main:refs/heads/fix/widget-expiry"
-(cd "$ROOT/main" && "$WORKTREE_SCRIPT" remove issue-fork >/dev/null 2>&1) || true # exits 1: the open PR's branch stays
-assert_path_absent "$FORK_WT" "remove clears the fork worktree"
-assert_eq "$(git -C "$ROOT/main" rev-parse --verify --quiet refs/heads/fork-pr-7 || true)" "$FORK_HEAD" "remove keeps the open PR's local branch at the first head"
-# The stale branch also carries tracking config pointing at that unrelated
-# origin branch; -B preserves it, so the create must clear it afterwards.
-git -C "$ROOT/main" fetch -q origin
-git -C "$ROOT/main" branch -q --set-upstream-to=origin/fix/widget-expiry fork-pr-7
-set +e
-again_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-fork --pr 7 2>"$ROOT/again.err")"
-again_code=$?
-set -e
-assert_eq "$again_code:$again_out" "0:$FORK_WT" "re-inspecting the fork PR after remove creates the worktree again (stderr: $(tr '\n' ' ' <"$ROOT/again.err"))"
-assert_eq "$(git -C "$FORK_WT" rev-parse HEAD 2>/dev/null || true)" "$FORK_HEAD_2" "re-inspected worktree HEAD is the contributor's new head"
-set +e
-again_upstream="$(git -C "$FORK_WT" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null)"
-again_upstream_code=$?
-set -e
-assert_eq "$again_upstream_code:$again_upstream" "128:" "an unrelated origin branch of the same name does not become the upstream"
-
-# A local branch that diverged from the PR head is refused by name, not reset.
-git -C "$FORK_WT" config user.email test@example.com
-git -C "$FORK_WT" config user.name Test
-git -C "$FORK_WT" config commit.gpgsign false
-printf 'local only\n' >"$FORK_WT/local.txt"
-git -C "$FORK_WT" add local.txt
-git -C "$FORK_WT" commit -q -m 'local only'
-(cd "$ROOT/main" && "$WORKTREE_SCRIPT" remove issue-fork >/dev/null 2>&1) || true # exits 1: the open PR's branch stays
-set +e
-(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-fork --pr 7 >"$ROOT/diverged.out" 2>"$ROOT/diverged.err")
-diverged_code=$?
-set -e
-assert_eq "$diverged_code" "1" "a diverged local branch refuses the fork checkout with exit 1"
-assert_contains "$(cat "$ROOT/diverged.err")" "Local branch 'fork-pr-7' has commits that are not in the head of fork PR #7" "the refusal names the diverged branch"
-assert_path_absent "$FORK_WT" "a diverged local branch creates no worktree"
-
-# A fork head the base cannot deliver refuses before any worktree exists:
-#   number  issue            message fragment
-rows=(
-  "9	issue-phantom	did not deliver commit $PHANTOM_OID"
-  "10	issue-no-ref	Could not fetch refs/pull/10/head from origin"
-)
-for row in "${rows[@]}"; do
-  IFS=$'\t' read -r number issue fragment <<<"$row"
-  set +e
-  (cd "$ROOT/main" && "$WORKTREE_SCRIPT" create "$issue" --pr "$number" >"$ROOT/$issue.out" 2>"$ROOT/$issue.err")
-  code=$?
-  set -e
-  assert_eq "$code" "1" "PR #$number: undeliverable fork head exits 1"
-  assert_contains "$(cat "$ROOT/$issue.err")" "$fragment" "PR #$number: refusal names the cause"
-  assert_path_absent "$ROOT/trees/$issue" "PR #$number: no worktree is created"
-done
-
-echo "=== remove and cleanup prove a merged fork PR by its number ==="
-
-# GitHub files the PR under the contributor's head name, so a --head query
-# for fork-pr-<n> answers nothing; the number in the branch name is the key.
-# A squash lands the content on main as a new commit, so ancestry never
-# proves it either.
-squash_fork_onto_main() {
-  local file="$1" content="$2"
-  printf '%s\n' "$content" >"$ROOT/main/$file"
-  git -C "$ROOT/main" add "$file"
-  git -C "$ROOT/main" commit -q -m "$file (squashed)"
-  git -C "$ROOT/main" push -q origin main
+# A commit on the contributor's clone, on a branch off its main, pushed to
+# origin as the head of a pull request and nothing else.
+fork_pr() {
+  local number="$1" branch="$2" file="$3" content="$4" name="$5"
+  if [[ "$branch" == main ]]; then
+    git -C "$FORK" checkout -q main
+  else
+    git -C "$FORK" checkout -q -b "$branch" main
+  fi
+  printf '%s\n' "$content" >"$FORK/$file"
+  git -C "$FORK" add "$file"
+  git -C "$FORK" commit -q -m "$file"
+  OIDS="$OIDS $name=$(git -C "$FORK" rev-parse HEAD)"
+  must git -C "$FORK" push -q -f origin "HEAD:refs/pull/$number/head"
+  pr_doc "$number" "$branch" "$(oid_of "$name")" true
 }
-squash_fork_onto_main from-main.txt 'fork main fix'
-pr_doc 11 main "$FORK_MAIN_HEAD" true MERGED
-squashed_ancestor=no
-git -C "$ROOT/main" merge-base --is-ancestor fork-pr-11 origin/main && squashed_ancestor=yes
-assert_eq "$squashed_ancestor" "no" "precondition: the squashed fork branch is not an ancestor of origin/main"
-set +e
-merged_rm_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" remove issue-from-main 2>"$ROOT/merged-rm.err")"
-merged_rm_code=$?
-set -e
-assert_eq "$merged_rm_code:$merged_rm_out" "0:Removed: $FROM_MAIN_WT" "remove of a merged fork PR worktree exits 0 (stderr: $(tr '\n' ' ' <"$ROOT/merged-rm.err"))"
-assert_path_absent "$FROM_MAIN_WT" "remove clears the merged fork worktree"
-assert_eq "$(git -C "$ROOT/main" rev-parse --verify --quiet refs/heads/fork-pr-11 || true)" "" "remove deletes the merged fork branch"
-assert_contains "$(cat "$ROOT/merged-rm.err")" "Deleted branch 'fork-pr-11' — squash-merged in pull request #11." "remove names the merged pull request"
 
-# cleanup: one merged fork PR (#12) is collected, an open one (#13) is kept.
-git -C "$ROOT/fork" checkout -q -b fix/cleanup main
-printf 'cleanup fix\n' >"$ROOT/fork/cleanup.txt"
-git -C "$ROOT/fork" add cleanup.txt
-git -C "$ROOT/fork" commit -q -m 'cleanup fix'
-CLEANUP_HEAD="$(git -C "$ROOT/fork" rev-parse HEAD)"
-git -C "$ROOT/fork" push -q origin "HEAD:refs/pull/12/head"
-git -C "$ROOT/fork" checkout -q -b fix/still-open main
-printf 'still open\n' >"$ROOT/fork/open.txt"
-git -C "$ROOT/fork" add open.txt
-git -C "$ROOT/fork" commit -q -m 'still open'
-OPEN_HEAD="$(git -C "$ROOT/fork" rev-parse HEAD)"
-git -C "$ROOT/fork" push -q origin "HEAD:refs/pull/13/head"
-pr_doc 12 fix/cleanup "$CLEANUP_HEAD" true
-pr_doc 13 fix/still-open "$OPEN_HEAD" true
-CLEANUP_WT="$ROOT/trees/issue-cleanup"
-OPEN_WT="$ROOT/trees/issue-open"
-set +e
-cleanup_create_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" create issue-cleanup --pr 12 2>"$ROOT/cleanup-create.err" \
-  && "$WORKTREE_SCRIPT" create issue-open --pr 13 2>"$ROOT/open-create.err")"
-cleanup_create_code=$?
-set -e
-assert_eq "$cleanup_create_code" "0" "two fork PR worktrees exist before cleanup (stderr: $(cat "$ROOT/cleanup-create.err" "$ROOT/open-create.err" | tr '\n' ' '))"
-squash_fork_onto_main cleanup.txt 'cleanup fix'
-pr_doc 12 fix/cleanup "$CLEANUP_HEAD" true MERGED
-set +e
-cleanup_out="$(cd "$ROOT/main" && "$WORKTREE_SCRIPT" cleanup 2>"$ROOT/cleanup.err")"
-cleanup_code=$?
-set -e
-assert_eq "$cleanup_code" "0" "cleanup exits 0 (stderr: $(tr '\n' ' ' <"$ROOT/cleanup.err"))"
-assert_contains "$cleanup_out" "Cleaned: $CLEANUP_WT" "cleanup collects the merged fork PR worktree"
-assert_path_absent "$CLEANUP_WT" "the merged fork worktree is gone"
-assert_eq "$(git -C "$ROOT/main" rev-parse --verify --quiet refs/heads/fork-pr-12 || true)" "" "cleanup deletes the merged fork branch"
-assert_eq "$(git -C "$OPEN_WT" rev-parse HEAD 2>/dev/null || true)" "$OPEN_HEAD" "cleanup keeps the open fork PR worktree"
-assert_contains "$(cat "$ROOT/cleanup.err")" "fork pull request #13 is OPEN, not merged" "cleanup names the open fork PR it keeps"
+# The content of a fork PR lands on main as a new commit (a squash), so
+# ancestry never proves the merge.
+squash() {
+  local number="$1" file="$2" content="$3"
+  printf '%s\n' "$content" >"$MAIN/$file"
+  git -C "$MAIN" add "$file"
+  git -C "$MAIN" commit -q -m "$file (squashed)"
+  git -C "$MAIN" push -q origin main
+}
 
-# A merged fork PR whose merged head is not this tip is kept: the branch
-# carries work past the merge.
-pr_doc 13 fix/still-open "$FORK_HEAD" true MERGED
-set +e
-(cd "$ROOT/main" && "$WORKTREE_SCRIPT" cleanup >"$ROOT/moved.out" 2>"$ROOT/moved.err")
-set -e
-assert_eq "$(git -C "$OPEN_WT" rev-parse HEAD 2>/dev/null || true)" "$OPEN_HEAD" "a fork branch past its merged head is kept"
-assert_contains "$(cat "$ROOT/moved.err")" "carries work past its merged pull request (#13 merged head $FORK_HEAD" "cleanup names the head mismatch"
+tool() {
+  (cd "$MAIN" && "$WORKTREE_SCRIPT" "$@" >/dev/null 2>&1) || true
+}
+
+# A fixture command that must succeed; its failure is the fixture's, not a
+# row's, and stops the suite with a FIXTURE: line.
+must() {
+  "$@" || { echo "FIXTURE: '$*' failed in $ROOT" >&2; exit 2; }
+}
+
+# The step vocabulary. `world` builds the base repository, its origin, the
+# contributor's clone and the pull requests every row can name: #7 a fork PR
+# on the contributor's branch, #8 a same-repository PR whose head is an
+# origin branch, #9 a fork PR whose pull ref delivers the base's tip rather
+# than the head gh reports, #10 a fork PR with no pull ref, #11 a fork PR
+# opened from the contributor's own main.
+step() {
+  case "$1" in
+    world)
+      mkdir -p "$MAIN" "$ROOT/gh-state"
+      git -C "$MAIN" init -q -b main
+      git -C "$MAIN" config user.email test@example.com
+      git -C "$MAIN" config user.name Test
+      git -C "$MAIN" config commit.gpgsign false
+      printf 'base\n' >"$MAIN/base.txt"
+      git -C "$MAIN" add base.txt
+      git -C "$MAIN" commit -q -m base
+      printf 'WORKTREE_BASE_DIR="../trees"\n' >"$MAIN/.env.local"
+      git init -q --bare "$ROOT/origin.git"
+      git -C "$MAIN" remote add origin "$ROOT/origin.git"
+      git -C "$MAIN" push -q -u origin main
+      OIDS="$OIDS base=$(git -C "$MAIN" rev-parse HEAD)"
+      git clone -q "$ROOT/origin.git" "$FORK"
+      git -C "$FORK" config user.email fork@example.com
+      git -C "$FORK" config user.name Fork
+      git -C "$FORK" config commit.gpgsign false
+      fork_pr 7 fix/widget-expiry fix.txt 'fork fix' fork
+      git -C "$MAIN" checkout -q -b feat/same
+      printf 'same repo\n' >"$MAIN/same.txt"
+      git -C "$MAIN" add same.txt
+      git -C "$MAIN" commit -q -m 'same-repo feature'
+      OIDS="$OIDS same=$(git -C "$MAIN" rev-parse HEAD)"
+      git -C "$MAIN" push -q origin feat/same "HEAD:refs/pull/8/head"
+      git -C "$MAIN" checkout -q main
+      git -C "$MAIN" branch -q -D feat/same
+      pr_doc 8 feat/same "$(oid_of same)" false
+      git -C "$MAIN" push -q origin "main:refs/pull/9/head"
+      pr_doc 9 fix/phantom "$PHANTOM" true
+      pr_doc 10 fix/no-pull-ref "$(oid_of fork)" true
+      fork_pr 11 main from-main.txt 'fork main fix' fork-main
+      ;;
+    inspect:*)
+      tool create "issue-${1#inspect:}" --pr "${1#inspect:}"
+      [[ -d "$ROOT/trees/issue-${1#inspect:}" ]] || { echo "FIXTURE: create --pr ${1#inspect:} left no worktree in $ROOT" >&2; exit 2; }
+      ;;
+    remove:*) tool remove "issue-${1#remove:}" ;;
+    # The contributor pushed again since the worktree was made.
+    advance-fork)
+      git -C "$FORK" checkout -q fix/widget-expiry
+      printf 'fork fix 2\n' >>"$FORK/fix.txt"
+      git -C "$FORK" commit -q -am 'fork fix 2'
+      OIDS="$OIDS fork2=$(git -C "$FORK" rev-parse HEAD)"
+      git -C "$FORK" push -q -f origin "HEAD:refs/pull/7/head"
+      pr_doc 7 fix/widget-expiry "$(oid_of fork2)" true
+      ;;
+    # Origin grew an unrelated branch under the contributor's branch name,
+    # and the stale local branch tracks it.
+    unrelated-branch)
+      must git -C "$MAIN" push -q origin "main:refs/heads/fix/widget-expiry"
+      must git -C "$MAIN" fetch -q origin
+      must git -C "$MAIN" branch -q --set-upstream-to=origin/fix/widget-expiry fork-pr-7
+      ;;
+    # A commit of this checkout's own on the fork PR's branch.
+    local-commit)
+      git -C "$ROOT/trees/issue-7" config user.email test@example.com
+      git -C "$ROOT/trees/issue-7" config user.name Test
+      git -C "$ROOT/trees/issue-7" config commit.gpgsign false
+      printf 'local only\n' >"$ROOT/trees/issue-7/local.txt"
+      git -C "$ROOT/trees/issue-7" add local.txt
+      git -C "$ROOT/trees/issue-7" commit -q -m 'local only'
+      OIDS="$OIDS local=$(git -C "$ROOT/trees/issue-7" rev-parse HEAD)"
+      ;;
+    squash:11) squash 11 from-main.txt 'fork main fix' ;;
+    squash:12) squash 12 cleanup.txt 'cleanup fix' ;;
+    merged:11) pr_doc 11 main "$(oid_of fork-main)" true MERGED ;;
+    merged:12) pr_doc 12 fix/cleanup "$(oid_of cleanup)" true MERGED ;;
+    # #13's merged head is not this checkout's tip.
+    merged:13-elsewhere) pr_doc 13 fix/still-open "$(oid_of fork)" true MERGED ;;
+    # Two more fork PRs, #12 and #13, each checked out.
+    two-more)
+      fork_pr 12 fix/cleanup cleanup.txt 'cleanup fix' cleanup
+      fork_pr 13 fix/still-open open.txt 'still open' open
+      step inspect:12
+      step inspect:13
+      ;;
+    *)
+      echo "UNKNOWN-STEP: $1" >&2
+      exit 2
+      ;;
+  esac
+}
+
+build() {
+  local word
+  ROOT="$TMP_ROOT/$1"
+  shift
+  MAIN="$ROOT/main"
+  FORK="$ROOT/fork"
+  OIDS=""
+  export GH_STATE="$ROOT/gh-state"
+  for word in "$@"; do
+    step "$word"
+  done
+}
+
+# --- rendering ------------------------------------------------------------------
+
+oid_of() {
+  local word
+  for word in $OIDS; do
+    [[ "${word%%=*}" == "$1" ]] && { printf '%s' "${word#*=}"; return; }
+  done
+}
+
+oid_name() {
+  local oid="$1" word
+  [[ -n "$oid" ]] || { printf -- '-'; return; }
+  for word in $OIDS; do
+    if [[ "${word#*=}" == "$oid" ]]; then
+      printf '%s' "${word%%=*}"
+      return
+    fi
+  done
+  if [[ "$oid" == "$(git -C "$MAIN" rev-parse origin/main)" ]]; then printf 'squashed'
+  else printf '%s' "$oid"
+  fi
+}
+
+alias_text() {
+  local sed_args=() word
+  for word in $OIDS; do
+    sed_args+=(-e "s|${word#*=}|<${word%%=*}>|g")
+  done
+  sed -e "s|$ROOT|<root>|g" -e "s|$PHANTOM|<phantom>|g" ${sed_args[@]+"${sed_args[@]}"} -e 's/;/\\;/g' |
+    paste -s -d ';' -
+}
+
+upstream_of() {
+  git -C "$MAIN" rev-parse --abbrev-ref --symbolic-full-name "$1@{upstream}" 2>/dev/null || printf -- '-'
+}
+
+state() {
+  local trees="" branches="" origin="" dir branch line
+  for dir in "$ROOT"/trees/*; do
+    [[ -e "$dir" ]] || continue
+    if git -C "$MAIN" worktree list --porcelain | grep -qx "worktree $dir"; then
+      branch="$(git -C "$dir" branch --show-current 2>/dev/null)"
+      trees="$trees,${dir#"$ROOT"/trees/}=${branch:-detached}@$(oid_name "$(git -C "$dir" rev-parse HEAD 2>/dev/null)")"
+    else
+      trees="$trees,${dir#"$ROOT"/trees/}=unregistered"
+    fi
+  done
+  while IFS=' ' read -r branch line; do
+    [[ -n "$branch" && "$branch" != main ]] || continue
+    branches="$branches,$branch@$(oid_name "$line")/$(upstream_of "$branch")"
+  done <<<"$(git -C "$MAIN" for-each-ref --format='%(refname:short) %(objectname)' refs/heads)"
+  while IFS=' ' read -r branch line; do
+    [[ -n "$branch" ]] || continue
+    origin="$origin,${branch#refs/heads/}@$(oid_name "$line")"
+  done <<<"$(git --git-dir="$ROOT/origin.git" for-each-ref --format='%(refname) %(objectname)' refs/heads)"
+  printf 'trees=%s branches=%s main=%s@%s origin=%s remotes=%s' \
+    "${trees:-,-}" "${branches:-,-}" "$(git -C "$MAIN" branch --show-current)" \
+    "$(oid_name "$(git -C "$MAIN" rev-parse HEAD)")" "${origin:-,-}" \
+    "$(git -C "$MAIN" remote | paste -s -d ',' -)" | sed 's/=,/=/g'
+}
+
+run() {
+  local -a argv
+  local rc=0
+  read -r -a argv <<<"$1"
+  (cd "$MAIN" && "$WORKTREE_SCRIPT" "${argv[@]}" >"$ROOT/out" 2>"$ROOT/err") || rc=$?
+  printf 'rc=%s out=%s err=%s %s' "$rc" \
+    "$(alias_text <"$ROOT/out")" "$(alias_text <"$ROOT/err")" "$(state)"
+}
+
+# --- the expected text ----------------------------------------------------------
+
+err_text() {
+  case "$1" in
+    -) printf '' ;;
+    diverged) printf '%s' "Error: Local branch 'fork-pr-7' has commits that are not in the head of fork PR #7\; delete or rename that branch before inspecting the PR again." ;;
+    phantom) printf '%s' "Error: refs/pull/9/head on origin did not deliver commit <phantom>, the head gh reports for PR #9" ;;
+    no-ref) printf '%s' "Error: Could not fetch refs/pull/10/head from origin for fork PR #10;  fatal: couldn't find remote ref refs/pull/10/head" ;;
+    deleted:*) printf '%s' "Deleted branch 'fork-pr-${1#deleted:}' — squash-merged in pull request #${1#deleted:}." ;;
+    remove-open) printf '%s' "Error: Removed worktree but could not delete local branch 'fork-pr-7'.;  Remaining branch: fork-pr-7;  Worktree path removed/pruned: <root>/trees/issue-7;  Not merged into origin/main, and fork pull request #7 is OPEN, not merged;  After verifying it is safe, delete manually with: git -C \"<root>/main\" branch -D \"fork-pr-7\"" ;;
+    open-kept) printf '%s' "Skipped (branch 'fork-pr-13' is not merged — not an ancestor of origin/main, and fork pull request #13 is OPEN, not merged): <root>/trees/issue-13" ;;
+    moved-kept) printf '%s' "Skipped (branch 'fork-pr-13' is not merged — not an ancestor of origin/main, and carries work past its merged pull request (#13 merged head <fork>, not this tip <open>)): <root>/trees/issue-13" ;;
+    *) printf 'UNKNOWN-ERR-SPEC:%s' "$1" ;;
+  esac
+}
+
+out_text() {
+  case "$1" in
+    -) printf '' ;;
+    wt:*) printf '<root>/trees/issue-%s' "${1#wt:}" ;;
+    removed:*) printf 'Removed: <root>/trees/issue-%s' "${1#removed:}" ;;
+    cleaned:*) printf 'Cleaned: <root>/trees/issue-%s' "${1#cleaned:}" ;;
+    *) printf 'UNKNOWN-OUT-SPEC:%s' "$1" ;;
+  esac
+}
+
+# --- the rows ---------------------------------------------------------------------
+# label|fixture|command|rc|out|err|state
+ROWS='a fork PR is checked out on fork-pr-<n> at the head gh reports, with no upstream, no fork remote and no contributor-named branch|world|create issue-7 --pr 7|0|wt:7|-|trees=issue-7=fork-pr-7@fork branches=fork-pr-7@fork/- main=main@base origin=feat/same@same,main@base remotes=origin
+a same-repository PR keeps the tracked origin-branch checkout|world|create issue-8 --pr 8|0|wt:8|-|trees=issue-8=feat/same@same branches=feat/same@same/origin/feat/same main=main@base origin=feat/same@same,main@base remotes=origin
+a fork PR opened from the contributor'"'"'s main leaves this checkout'"'"'s main untouched|world|create issue-11 --pr 11|0|wt:11|-|trees=issue-11=fork-pr-11@fork-main branches=fork-pr-11@fork-main/- main=main@base origin=feat/same@same,main@base remotes=origin
+remove keeps the open fork PR'"'"'s local branch|world inspect:7|remove issue-7|1|removed:7|remove-open|trees=- branches=fork-pr-7@fork/- main=main@base origin=feat/same@same,main@base remotes=origin
+re-inspecting after the contributor pushed resets the stale branch to the new head and clears the tracking an unrelated origin branch left|world inspect:7 advance-fork remove:7 unrelated-branch|create issue-7 --pr 7|0|wt:7|-|trees=issue-7=fork-pr-7@fork2 branches=fork-pr-7@fork2/- main=main@base origin=feat/same@same,fix/widget-expiry@base,main@base remotes=origin
+a local branch that diverged from the PR head is refused by name, not reset|world inspect:7 local-commit remove:7|create issue-7 --pr 7|1|-|diverged|trees=- branches=fork-pr-7@local/- main=main@base origin=feat/same@same,main@base remotes=origin
+a pull ref that delivers a commit other than the head gh reports is refused before any worktree exists|world|create issue-9 --pr 9|1|-|phantom|trees=- branches=- main=main@base origin=feat/same@same,main@base remotes=origin
+a fork PR with no pull ref on origin is refused before any worktree exists|world|create issue-10 --pr 10|1|-|no-ref|trees=- branches=- main=main@base origin=feat/same@same,main@base remotes=origin
+remove proves a squash-merged fork PR by its number and deletes the branch|world inspect:11 squash:11 merged:11|remove issue-11|0|removed:11|deleted:11|trees=- branches=- main=main@squashed origin=feat/same@same,main@squashed remotes=origin
+cleanup collects the merged fork PR and keeps the open one, naming it|world two-more squash:12 merged:12|cleanup|0|cleaned:12|open-kept|trees=issue-13=fork-pr-13@open branches=fork-pr-13@open/- main=main@squashed origin=feat/same@same,main@squashed remotes=origin
+cleanup keeps a fork branch whose tip is past its merged head, naming the mismatch|world two-more squash:12 merged:12 merged:13-elsewhere|cleanup|0|cleaned:12|moved-kept|trees=issue-13=fork-pr-13@open branches=fork-pr-13@open/- main=main@squashed origin=feat/same@same,main@squashed remotes=origin
+'
+
+echo "=== worktree create --pr, remove and cleanup on fork pull requests ==="
+n=0
+while IFS='|' read -r label fixture command rc out err want_state; do
+  [[ -n "$label$fixture$command$rc$out$err$want_state" ]] || continue
+  n=$((n + 1))
+  # shellcheck disable=SC2086
+  build "row-$n" $fixture
+  if [[ "${PROBE:-}" == 1 ]]; then
+    printf '%s => %s\n' "$label" "$(run "$command")"
+    continue
+  fi
+  assert_eq "$(run "$command")" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want_state" "$label"
+done <<<"$ROWS"
 
 echo
-echo "Passed: $PASS, Failed: $FAIL"
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Reshapes `skills/worktree/tests/worktree_create_fork_pr.sh` to code-quality § Tests. The suite pinned `create --pr` on a fork pull request, and the remove and cleanup of the worktree it leaves, in eleven long-lived scenarios over one shared world of substring, ref and path checks. Those are now one table of 11 rows: a row builds its own base repository, its origin, the contributor's clone and gh's stored answers from a step word list (`world`, then `inspect:<n> advance-fork remove:<n> unrelated-branch local-commit two-more squash:<n> merged:<n> merged:<n>-elsewhere`), runs one command from the main checkout, and pins the exit status, stdout, stderr whole and what is left: every worktree under the trees base with its branch and head, every local branch beside main with its head and upstream, the main checkout's branch and head, origin's branch heads and the remotes the main checkout has. Commits are named (`base`, `fork`, `fork2`, `fork-main`, `same`, `local`, `open`, `squashed` for a commit that is none of the named ones). A fixture that fails to reach its state exits 2 with a `FIXTURE:` line (`must`, the checked `inspect:` step), so a mutant that breaks a fixture reports as an abort, never as a silent pass.

The tracked render under `.agents` is replayed with `patch`.

## Folded or deleted cases, with the surviving row

| Former assertions | Surviving row |
|---|---|
| fork PR creates a worktree; prints its path; HEAD is the PR head; the branch is fork-pr-7, not the contributor's; no local branch carries the contributor's name; no upstream; no remote added for the fork; origin refs unchanged | `a fork PR is checked out on fork-pr-<n> at the head gh reports, with no upstream, no fork remote and no contributor-named branch` (`trees=issue-7=fork-pr-7@fork branches=fork-pr-7@fork/- origin=feat/same@same,main@base remotes=origin`) |
| same-repository PR creates a worktree; prints its path; HEAD is the origin branch tip; the upstream is origin/feat/same | `a same-repository PR keeps the tracked origin-branch checkout` (`branches=feat/same@same/origin/feat/same`) |
| a fork PR opened from the fork's main creates a worktree; HEAD is the PR head; the branch is fork-pr-11; the main checkout's local main untouched; main still checked out | `a fork PR opened from the contributor's main leaves this checkout's main untouched` (`main=main@base`) |
| remove clears the fork worktree; keeps the open PR's local branch at the head | `remove keeps the open fork PR's local branch` (`trees=- branches=fork-pr-7@fork/-`, `err=remove-open` whole) |
| re-inspecting after remove creates the worktree again; HEAD is the contributor's new head; an unrelated origin branch of the same name does not become the upstream | `re-inspecting after the contributor pushed resets the stale branch to the new head and clears the tracking an unrelated origin branch left` (`branches=fork-pr-7@fork2/-`, `origin=...,fix/widget-expiry@base,...`) |
| a diverged local branch exits 1; the refusal names the branch; no worktree | `a local branch that diverged from the PR head is refused by name, not reset` (`branches=fork-pr-7@local/-`) |
| PR #9 (the pull ref delivers the base's own tip): exit 1, the cause named, no worktree | `a pull ref that delivers a commit other than the head gh reports is refused before any worktree exists` |
| PR #10 (no pull ref): exit 1, the cause named, no worktree | `a fork PR with no pull ref on origin is refused before any worktree exists` |
| precondition: the squashed fork branch is not an ancestor of origin/main | deleted: a fixture premise; the fixture mutant `f-squash-is-merge` (the squash made a real merge) reddens the three merged rows because the renderer names commits before it falls back to `squashed` |
| remove of a merged fork PR exits 0 with `Removed:`; the worktree gone; the branch deleted; stderr names the pull request | `remove proves a squash-merged fork PR by its number and deletes the branch` (`out=removed:11 err=deleted:11 trees=- branches=-`) |
| two fork PR worktrees exist before cleanup | deleted: a fixture premise, now the `inspect:` step's `FIXTURE:` check |
| cleanup exits 0; `Cleaned:` names the merged worktree; it is gone; its branch deleted; the open worktree kept at its head; stderr names the open PR | `cleanup collects the merged fork PR and keeps the open one, naming it` |
| a fork branch past its merged head is kept; stderr names the head mismatch | `cleanup keeps a fork branch whose tip is past its merged head, naming the mismatch` (`err=moved-kept` whole, with both commits named) |

## Mutation

Twenty-three must-fail mutants over a scratch copy of `skills/worktree` (`mutants-fp-3.txt` in the lane scratchpad; `mutate-fp.py` makes them, each run in its own process group under a bound), all killed: the fork branch named by the contributor, a same-repository PR treated as a fork, the stale upstream kept, a diverged branch reset, the phantom commit accepted, a fetch failure swallowed, the merged proof looked up by head name, an open PR counting as merged, a moved tip counting as merged, remove's deletion and refusal silent, cleanup's skip silent, a fork PR from the contributor's main taking the default-branch name (the reviewer's mutant, folded in as `m13`; it reddens the fork-from-main row alone before aborting at a later fixture); and ten fixture mutants (the fork pushing its branch as an origin head too, the advance, the unrelated branch, the local commit, the squash made a merge, the merged document and the two merged PRs each made a no-op or at-tip, the phantom made the real head, the missing ref present).

## Reviewer round

One reviewer-test round, ACCEPT with five suggestions. Applied: the reviewer's isolating mutant for the fork-from-main row (above) and the header's wording (origin's branch heads, refs/heads only; the pull refs are outside the pin). Declined: rows for three arms of the merged-fork proof no suite pins (the refusal of a non-default base, the unreadable record, a failed `gh pr view` read as unmerged) because the old suite pinned none of them and this commit changes no behaviour; the two renderer arms no row reaches and the `squashed` name carrying little are recorded as they stand.

## Checks

- `worktree_create_fork_pr.sh`: 11 assertions, TMPDIR=/var/tmp/ken-c; `shellcheck` clean; `tools/bash32-lint skills/worktree` clean; source and render byte-identical.
- `tools/guard --full`: exit 0 on 570a0a291, the same tree before the restack (TMPDIR=/var/tmp/ken-c).

KEN-1241

https://claude.ai/code/session_011qxNLABFza7z5QjT3aHFU3
