### PR TITLE
test(KEN-1241): the amend widening as two tables of rows

### DIFF
--- a/.agents/skills/commit-guards/tests/commit-msg-amend.test.sh
+++ b/.agents/skills/commit-guards/tests/commit-msg-amend.test.sh
@@ -1,14 +1,21 @@
 #!/usr/bin/env bash
 # Pins for the one commit-msg rule that cannot be judged from an index alone:
-# the changelog a commit owes is read against the parent the commit will HAVE,
-# so an amend is judged against HEAD's parent, not the HEAD it replaces. Four
-# pins, each firing one against its control: a real `git commit` for the rule
-# end to end, and an argv FILE for which argv IS an amend.
+# the changelog a commit owes is read against the parent the commit will
+# HAVE, so an amend is judged against HEAD's parent, not the HEAD it
+# replaces. The widening is read off /proc/<pid>/cmdline of the committing
+# git and nowhere else, so a host without procfs (macOS, which this family
+# supports) answers "not an amend" and the rows asserting the widening are
+# SKIPPED there rather than reporting a portability fact as a defect. Two
+# tables: a real `git commit` in a repository whose HEAD carries a crate
+# change with its fragment and more crate code staged on top, pinned by
+# git's exit status with every line the hook printed; and an argv as the
+# kernel would hold it, pinned by whether it IS an amend.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 CM="$SKILL_DIR/scripts/commit-msg"
+# shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
 # shellcheck source=../scripts/lib/commit-parent.sh
 source "$SKILL_DIR/scripts/lib/commit-parent.sh"
@@ -18,92 +25,115 @@ unset COMMIT_GUARDS_COMMIT_TYPES COMMIT_GUARDS_SUBJECT_MAX \
 
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
 skip() { printf '  skip  %s\n' "$1"; }
 
-# The widening is read off /proc/<pid>/cmdline and nowhere else, so a host
-# without procfs — macOS, which this family supports — answers "not an amend",
-# and the pair of pins asserting the widening is SKIPPED there rather than
-# reporting a portability fact as a defect.
 HAVE_PROC=0
 if [ -r "/proc/$$/cmdline" ]; then HAVE_PROC=1; fi
 
-mk_repo() { # DIR — a repo with the commit-msg hook installed and the rule armed
-  mkdir -p "$1/crates/core" "$1/changelog.d/fixed"
-  git -C "$1" -c init.defaultBranch=main init -q
-  git -C "$1" config user.email test@example.com
-  git -C "$1" config user.name test
-  printf '#!/bin/sh\nexec %s "$1"\n' "$CM" >"$1/.git/hooks/commit-msg"
-  chmod +x "$1/.git/hooks/commit-msg"
-  printf '[env]\nCOMMIT_GUARDS_CHANGELOG_REQUIRED_PATHS = "crates/* ui/*"\n' >"$1/kendex.settings.toml"
-}
-commit_in() { # DIR ARG... — a real commit; sets OUT and RC
-  OUT=""; RC=0
-  OUT="$(git -C "$1" commit "${@:2}" 2>&1)" || RC=$?
-}
-staged_on_fragment() { # NAME — HEAD carries a crate change and its fragment,
-  R="$TMP/$1"          # more crate code is staged on top, and nothing else is.
-  mk_repo "$R"         # One fixture per pin, named by R, so a pin skipped for
-  printf 'seed\n' >"$R/README.md"   # want of /proc leaves nothing behind.
+# The fixture: the commit-msg hook installed with its output captured, the
+# rule armed for crates/* and ui/*, HEAD carrying a crate change and its
+# fragment, more crate code staged on top and nothing else. One repository
+# per row, so a row skipped for want of /proc leaves nothing behind.
+R=""
+staged_on_fragment() { # NAME
+  R="$TMP/$1"
+  [ ! -e "$R" ] || { echo "harness: fixture $1 already exists" >&2; exit 2; }
+  mkdir -p "$R/crates/core" "$R/changelog.d/fixed"
+  git -C "$R" -c init.defaultBranch=main init -q
+  git -C "$R" config user.email test@example.com
+  git -C "$R" config user.name test
+  printf '#!/bin/sh\nexec %s "$1" >"%s/hook.out" 2>&1\n' "$CM" "$R" >"$R/.git/hooks/commit-msg"
+  chmod +x "$R/.git/hooks/commit-msg"
+  printf '[env]\nCOMMIT_GUARDS_CHANGELOG_REQUIRED_PATHS = "crates/* ui/*"\n' >"$R/kendex.settings.toml"
+  printf 'seed\n' >"$R/README.md"
   git -C "$R" add -A
   git -C "$R" commit -qm "chore: base [no-changelog]" >/dev/null 2>&1
   printf 'fn one() {}\n' >"$R/crates/core/lib.rs"
   printf -- '- A fix consumers see.\n' >"$R/changelog.d/fixed/ken-1.md"
   git -C "$R" add -A
-  commit_in "$R" -m 'fix(KEN-1): change a crate'
+  git -C "$R" commit -qm 'fix(KEN-1): change a crate' >/dev/null 2>&1
+  # The hook judged that commit too: a fixture whose seed was refused would
+  # amend the base commit, whose header waives the entry.
+  [ "$(git -C "$R" log -1 --format=%s)" = 'fix(KEN-1): change a crate' ] \
+    || { echo "harness: fixture $1's seed commit was refused" >&2; exit 2; }
   printf 'fn two() {}\n' >>"$R/crates/core/lib.rs"
   git -C "$R" add -A
 }
-refused_naming_lib() { # 0 when RC/OUT are the refusal that names the crate path
-  [ "$RC" -eq 1 ] || return 1
-  case "$OUT" in *"crates/core/lib.rs changed without a changelog entry"*) return 0 ;; esac
-  return 1
+# One line for a commit: git's exit status, then every line the hook wrote.
+commit() { # ARGS...
+  local rc=0
+  : >"$R/hook.out"
+  git -C "$R" commit "$@" >/dev/null 2>&1 || rc=$?
+  printf 'rc=%s %s' "$rc" "$(LC_ALL=C paste -sd ';' - <"$R/hook.out")"
 }
+OWED="commit-msg FAIL crates/core/lib.rs changed without a changelog entry;  write one of: changelog.d/*/*.md;  or put [no-changelog] in the header when the commit changes nothing a consumer sees;  CHANGELOG.md counts only under COMMIT_GUARDS_CHANGELOG_COLLATE=1, which is the release commit collating the fragments"
+header() { printf 'commit-msg: OK — conventional header: %s' "$1"; } # HEADER
 
 echo "=== an amend is judged against the parent it will HAVE, not the HEAD it replaces ==="
 # `git diff --cached` on an amend shows only what was staged ON TOP of the
 # commit being replaced, so a fragment already inside that commit read as no
 # fragment at all and a commit satisfying the rule was refused, the obvious
-# escape being the flag that skips the whole hook chain. The control that reds
-# when the widening goes too far, and the one pin here needing no /proc: the
-# NEXT commit, whose parent really is that HEAD, is not excused by the fragment
-# in the one before.
-staged_on_fragment repo-next
-commit_in "$R" -m 'fix(KEN-2): change a crate again'
-refused_naming_lib \
-  && ok "control: the commit AFTER a fragment commit still owes its own entry" \
-  || bad "control: the commit after a fragment commit still owes its own entry" "rc=$RC out=$OUT"
-
+# escape being the flag that skips the whole hook chain. The control that
+# reds when the widening goes too far needs no /proc: the NEXT commit,
+# whose parent really is that HEAD, is not excused by the fragment in the
+# one before.
+staged_on_fragment next
+assert_eq "control: the commit AFTER a fragment commit still owes its own entry" \
+  "rc=1 $(header 'fix(KEN-2): change a crate again');$OWED" "$(commit -m 'fix(KEN-2): change a crate again')"
 if [ "$HAVE_PROC" -eq 0 ]; then
-  skip "the widening pins need /proc/<pid>/cmdline, where the committing argv is read"
+  skip "the widening rows need /proc/<pid>/cmdline, where the committing argv is read"
 else
-  staged_on_fragment repo-amend
-  commit_in "$R" --amend --no-edit
-  [ "$RC" -eq 0 ] && ok "an amend adding more code passes on the fragment the commit already carries" \
-    || bad "an amend passes on the fragment the commit already carries" "rc=$RC out=$OUT"
-
+  staged_on_fragment amend
+  assert_eq "an amend adding more code passes on the fragment the commit already carries" \
+    "rc=0 $(header 'fix(KEN-1): change a crate')" "$(commit --amend --no-edit)"
   # MUST-FAIL: `--mess` is git's abbreviation of `--message`, so the `--amend`
-  # behind it is the committer's message TEXT, not the flag. A scan reading the
-  # flag out of a value fails open, excusing this commit with the fragment the
-  # previous one carries; the widening is what that class attacks, and every
-  # fail-open this lane had came from it.
-  staged_on_fragment repo-value
-  commit_in "$R" --mess '--amend'
-  refused_naming_lib \
-    && ok "must-fail: a message VALUE spelling the flag does not widen the base" \
-    || bad "a message value spelling the flag must not widen the base" "rc=$RC out=$OUT"
+  # behind it is the committer's message TEXT, not the flag. A scan reading
+  # the flag out of a value fails open, excusing this commit with the
+  # fragment the previous one carries; every fail-open this lane had came
+  # from that class. The header refusal is the message's own; the owed entry
+  # is the pin.
+  staged_on_fragment value
+  assert_eq "must-fail: a message VALUE spelling the flag does not widen the base" \
+    "rc=1 commit-msg FAIL non-conventional header: --amend;  expected: type(scope)!: subject — scope and '!' optional; types: build chore ci docs feat fix perf refactor revert style test;  scope accepts uppercase issue keys and issue numbers, e.g. fix(ABC-123): tighten the gate / fix(#123): case-fold IDs;  git-generated headers (Merge/Revert/Reapply, fixup!/squash!/amend!) pass unchanged;$OWED" \
+    "$(commit --mess '--amend')"
 fi
 
-echo '=== which argv is an amend ==='
-# The NUL-delimited bytes the kernel would hold. A message is an argument like
-# any other, so the flag BEHIND one is still the flag: nothing dash-prefixed
-# stands before it to have swallowed it.
-ARGV="$TMP/argv"
-printf '%s\0' git commit -m 'fix(KEN-1): change a crate' --amend >"$ARGV"
-gg_argv_is_amend "$ARGV" \
-  && ok "the flag behind a message is the flag" \
-  || bad "the flag behind a message is the flag" "read as plain, wanted amend"
+echo "=== which argv is an amend: the NUL-delimited bytes the kernel would hold ==="
+# The scan reads the token immediately before each `--amend`: a value-taking
+# option consumes the next argument and nothing further, so it is the only
+# token that can swallow it; `--no-amend` stands outside that guard; a bare
+# `--` stops the scan; the wrapper's arguments ahead of `commit` are skipped.
+is_amend() { # WORDS... — yes or no
+  printf '%s\0' "$@" >"$TMP/argv"
+  if gg_argv_is_amend "$TMP/argv"; then echo yes; else echo no; fi
+}
+argv_rows() { # label | argv words | expect
+  local row label argv expect words
+  for row in "$@"; do
+    IFS='|' read -r label argv expect <<<"$row"
+    read -ra words <<<"$argv"
+    assert_eq "$label" "$expect" "$(is_amend "${words[@]}")"
+  done
+}
+argv_rows \
+  "the flag behind a message is the flag: a message is an argument like any other|git commit -m fix(KEN-1):_change --amend|yes" \
+  "the flag behind a value-taking option is that option's value|git commit --mess --amend|no" \
+  "the flag behind a clustered short option ending in -m is its value|git commit -am --amend|no" \
+  "a flag behind a no-value option is the flag|git commit --no-edit --amend|yes" \
+  "--no-amend after the flag withdraws it|git commit --amend --no-amend|no" \
+  "git's abbreviation of the flag is the flag|git commit --ame|yes" \
+  "a bare -- stops the scan: the flag behind it is a path|git commit -- lib.rs --amend|no" \
+  "the wrapper's arguments ahead of commit are skipped: -c never reads as swallowing|git -c core.editor=true commit --amend|yes" \
+  "a git that is not committing is not an amend|git rebase --amend|no"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.agents/skills/commit-guards/tests/commit-msg-amend.test.sh
+++ b/.agents/skills/commit-guards/tests/commit-msg-amend.test.sh
@@ -60,7 +60,7 @@ staged_on_fragment() { # NAME
   printf 'fn one() {}\n' >"$R/crates/core/lib.rs"
   printf -- '- A fix consumers see.\n' >"$R/changelog.d/fixed/ken-1.md"
   git -C "$R" add -A
-  git -C "$R" commit -qm 'fix(KEN-1): change a crate' >/dev/null 2>&1
+  git -C "$R" commit -qm 'fix(KEN-1): change a crate' >/dev/null 2>&1 || true
   # The hook judged that commit too: a fixture whose seed was refused would
   # amend the base commit, whose header waives the entry.
   [ "$(git -C "$R" log -1 --format=%s)" = 'fix(KEN-1): change a crate' ] \
@@ -105,6 +105,14 @@ else
   assert_eq "must-fail: a message VALUE spelling the flag does not widen the base" \
     "rc=1 commit-msg FAIL non-conventional header: --amend;  expected: type(scope)!: subject — scope and '!' optional; types: build chore ci docs feat fix perf refactor revert style test;  scope accepts uppercase issue keys and issue numbers, e.g. fix(ABC-123): tighten the gate / fix(#123): case-fold IDs;  git-generated headers (Merge/Revert/Reapply, fixup!/squash!/amend!) pass unchanged;$OWED" \
     "$(commit --mess '--amend')"
+  # MUST-FAIL: a message merely CONTAINING the flag. The argv is read
+  # NUL-delimited so this stays one argument; a scan joining argv with spaces
+  # (what `ps` would give) would read the flag out of it and excuse the
+  # commit with the fragment the previous one carries.
+  staged_on_fragment mention
+  assert_eq "must-fail: a message CONTAINING the flag is not the flag" \
+    "rc=1 $(header 'fix(KEN-2): wire the --amend path');$OWED" \
+    "$(commit -m 'fix(KEN-2): wire the --amend path')"
 fi
 
 echo "=== which argv is an amend: the NUL-delimited bytes the kernel would hold ==="
@@ -129,7 +137,10 @@ argv_rows \
   "the flag behind a value-taking option is that option's value|git commit --mess --amend|no" \
   "the flag behind a clustered short option ending in -m is its value|git commit -am --amend|no" \
   "a flag behind a no-value option is the flag|git commit --no-edit --amend|yes" \
+  "a flag behind a short valueless option is the flag|git commit -a --amend|yes" \
+  "an option carrying its own value is read as swallowing: the conservative miss the scan accepts|git commit --message=x --amend|no" \
   "--no-amend after the flag withdraws it|git commit --amend --no-amend|no" \
+  "--no-amend before the flag does not withdraw it: the last word wins|git commit --no-amend --amend|yes" \
   "git's abbreviation of the flag is the flag|git commit --ame|yes" \
   "a bare -- stops the scan: the flag behind it is a path|git commit -- lib.rs --amend|no" \
   "the wrapper's arguments ahead of commit are skipped: -c never reads as swallowing|git -c core.editor=true commit --amend|yes" \

--- a/skills/commit-guards/tests/commit-msg-amend.test.sh
+++ b/skills/commit-guards/tests/commit-msg-amend.test.sh
@@ -1,14 +1,21 @@
 #!/usr/bin/env bash
 # Pins for the one commit-msg rule that cannot be judged from an index alone:
-# the changelog a commit owes is read against the parent the commit will HAVE,
-# so an amend is judged against HEAD's parent, not the HEAD it replaces. Four
-# pins, each firing one against its control: a real `git commit` for the rule
-# end to end, and an argv FILE for which argv IS an amend.
+# the changelog a commit owes is read against the parent the commit will
+# HAVE, so an amend is judged against HEAD's parent, not the HEAD it
+# replaces. The widening is read off /proc/<pid>/cmdline of the committing
+# git and nowhere else, so a host without procfs (macOS, which this family
+# supports) answers "not an amend" and the rows asserting the widening are
+# SKIPPED there rather than reporting a portability fact as a defect. Two
+# tables: a real `git commit` in a repository whose HEAD carries a crate
+# change with its fragment and more crate code staged on top, pinned by
+# git's exit status with every line the hook printed; and an argv as the
+# kernel would hold it, pinned by whether it IS an amend.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 CM="$SKILL_DIR/scripts/commit-msg"
+# shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
 # shellcheck source=../scripts/lib/commit-parent.sh
 source "$SKILL_DIR/scripts/lib/commit-parent.sh"
@@ -18,92 +25,115 @@ unset COMMIT_GUARDS_COMMIT_TYPES COMMIT_GUARDS_SUBJECT_MAX \
 
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
 skip() { printf '  skip  %s\n' "$1"; }
 
-# The widening is read off /proc/<pid>/cmdline and nowhere else, so a host
-# without procfs — macOS, which this family supports — answers "not an amend",
-# and the pair of pins asserting the widening is SKIPPED there rather than
-# reporting a portability fact as a defect.
 HAVE_PROC=0
 if [ -r "/proc/$$/cmdline" ]; then HAVE_PROC=1; fi
 
-mk_repo() { # DIR — a repo with the commit-msg hook installed and the rule armed
-  mkdir -p "$1/crates/core" "$1/changelog.d/fixed"
-  git -C "$1" -c init.defaultBranch=main init -q
-  git -C "$1" config user.email test@example.com
-  git -C "$1" config user.name test
-  printf '#!/bin/sh\nexec %s "$1"\n' "$CM" >"$1/.git/hooks/commit-msg"
-  chmod +x "$1/.git/hooks/commit-msg"
-  printf '[env]\nCOMMIT_GUARDS_CHANGELOG_REQUIRED_PATHS = "crates/* ui/*"\n' >"$1/kendex.settings.toml"
-}
-commit_in() { # DIR ARG... — a real commit; sets OUT and RC
-  OUT=""; RC=0
-  OUT="$(git -C "$1" commit "${@:2}" 2>&1)" || RC=$?
-}
-staged_on_fragment() { # NAME — HEAD carries a crate change and its fragment,
-  R="$TMP/$1"          # more crate code is staged on top, and nothing else is.
-  mk_repo "$R"         # One fixture per pin, named by R, so a pin skipped for
-  printf 'seed\n' >"$R/README.md"   # want of /proc leaves nothing behind.
+# The fixture: the commit-msg hook installed with its output captured, the
+# rule armed for crates/* and ui/*, HEAD carrying a crate change and its
+# fragment, more crate code staged on top and nothing else. One repository
+# per row, so a row skipped for want of /proc leaves nothing behind.
+R=""
+staged_on_fragment() { # NAME
+  R="$TMP/$1"
+  [ ! -e "$R" ] || { echo "harness: fixture $1 already exists" >&2; exit 2; }
+  mkdir -p "$R/crates/core" "$R/changelog.d/fixed"
+  git -C "$R" -c init.defaultBranch=main init -q
+  git -C "$R" config user.email test@example.com
+  git -C "$R" config user.name test
+  printf '#!/bin/sh\nexec %s "$1" >"%s/hook.out" 2>&1\n' "$CM" "$R" >"$R/.git/hooks/commit-msg"
+  chmod +x "$R/.git/hooks/commit-msg"
+  printf '[env]\nCOMMIT_GUARDS_CHANGELOG_REQUIRED_PATHS = "crates/* ui/*"\n' >"$R/kendex.settings.toml"
+  printf 'seed\n' >"$R/README.md"
   git -C "$R" add -A
   git -C "$R" commit -qm "chore: base [no-changelog]" >/dev/null 2>&1
   printf 'fn one() {}\n' >"$R/crates/core/lib.rs"
   printf -- '- A fix consumers see.\n' >"$R/changelog.d/fixed/ken-1.md"
   git -C "$R" add -A
-  commit_in "$R" -m 'fix(KEN-1): change a crate'
+  git -C "$R" commit -qm 'fix(KEN-1): change a crate' >/dev/null 2>&1
+  # The hook judged that commit too: a fixture whose seed was refused would
+  # amend the base commit, whose header waives the entry.
+  [ "$(git -C "$R" log -1 --format=%s)" = 'fix(KEN-1): change a crate' ] \
+    || { echo "harness: fixture $1's seed commit was refused" >&2; exit 2; }
   printf 'fn two() {}\n' >>"$R/crates/core/lib.rs"
   git -C "$R" add -A
 }
-refused_naming_lib() { # 0 when RC/OUT are the refusal that names the crate path
-  [ "$RC" -eq 1 ] || return 1
-  case "$OUT" in *"crates/core/lib.rs changed without a changelog entry"*) return 0 ;; esac
-  return 1
+# One line for a commit: git's exit status, then every line the hook wrote.
+commit() { # ARGS...
+  local rc=0
+  : >"$R/hook.out"
+  git -C "$R" commit "$@" >/dev/null 2>&1 || rc=$?
+  printf 'rc=%s %s' "$rc" "$(LC_ALL=C paste -sd ';' - <"$R/hook.out")"
 }
+OWED="commit-msg FAIL crates/core/lib.rs changed without a changelog entry;  write one of: changelog.d/*/*.md;  or put [no-changelog] in the header when the commit changes nothing a consumer sees;  CHANGELOG.md counts only under COMMIT_GUARDS_CHANGELOG_COLLATE=1, which is the release commit collating the fragments"
+header() { printf 'commit-msg: OK — conventional header: %s' "$1"; } # HEADER
 
 echo "=== an amend is judged against the parent it will HAVE, not the HEAD it replaces ==="
 # `git diff --cached` on an amend shows only what was staged ON TOP of the
 # commit being replaced, so a fragment already inside that commit read as no
 # fragment at all and a commit satisfying the rule was refused, the obvious
-# escape being the flag that skips the whole hook chain. The control that reds
-# when the widening goes too far, and the one pin here needing no /proc: the
-# NEXT commit, whose parent really is that HEAD, is not excused by the fragment
-# in the one before.
-staged_on_fragment repo-next
-commit_in "$R" -m 'fix(KEN-2): change a crate again'
-refused_naming_lib \
-  && ok "control: the commit AFTER a fragment commit still owes its own entry" \
-  || bad "control: the commit after a fragment commit still owes its own entry" "rc=$RC out=$OUT"
-
+# escape being the flag that skips the whole hook chain. The control that
+# reds when the widening goes too far needs no /proc: the NEXT commit,
+# whose parent really is that HEAD, is not excused by the fragment in the
+# one before.
+staged_on_fragment next
+assert_eq "control: the commit AFTER a fragment commit still owes its own entry" \
+  "rc=1 $(header 'fix(KEN-2): change a crate again');$OWED" "$(commit -m 'fix(KEN-2): change a crate again')"
 if [ "$HAVE_PROC" -eq 0 ]; then
-  skip "the widening pins need /proc/<pid>/cmdline, where the committing argv is read"
+  skip "the widening rows need /proc/<pid>/cmdline, where the committing argv is read"
 else
-  staged_on_fragment repo-amend
-  commit_in "$R" --amend --no-edit
-  [ "$RC" -eq 0 ] && ok "an amend adding more code passes on the fragment the commit already carries" \
-    || bad "an amend passes on the fragment the commit already carries" "rc=$RC out=$OUT"
-
+  staged_on_fragment amend
+  assert_eq "an amend adding more code passes on the fragment the commit already carries" \
+    "rc=0 $(header 'fix(KEN-1): change a crate')" "$(commit --amend --no-edit)"
   # MUST-FAIL: `--mess` is git's abbreviation of `--message`, so the `--amend`
-  # behind it is the committer's message TEXT, not the flag. A scan reading the
-  # flag out of a value fails open, excusing this commit with the fragment the
-  # previous one carries; the widening is what that class attacks, and every
-  # fail-open this lane had came from it.
-  staged_on_fragment repo-value
-  commit_in "$R" --mess '--amend'
-  refused_naming_lib \
-    && ok "must-fail: a message VALUE spelling the flag does not widen the base" \
-    || bad "a message value spelling the flag must not widen the base" "rc=$RC out=$OUT"
+  # behind it is the committer's message TEXT, not the flag. A scan reading
+  # the flag out of a value fails open, excusing this commit with the
+  # fragment the previous one carries; every fail-open this lane had came
+  # from that class. The header refusal is the message's own; the owed entry
+  # is the pin.
+  staged_on_fragment value
+  assert_eq "must-fail: a message VALUE spelling the flag does not widen the base" \
+    "rc=1 commit-msg FAIL non-conventional header: --amend;  expected: type(scope)!: subject — scope and '!' optional; types: build chore ci docs feat fix perf refactor revert style test;  scope accepts uppercase issue keys and issue numbers, e.g. fix(ABC-123): tighten the gate / fix(#123): case-fold IDs;  git-generated headers (Merge/Revert/Reapply, fixup!/squash!/amend!) pass unchanged;$OWED" \
+    "$(commit --mess '--amend')"
 fi
 
-echo '=== which argv is an amend ==='
-# The NUL-delimited bytes the kernel would hold. A message is an argument like
-# any other, so the flag BEHIND one is still the flag: nothing dash-prefixed
-# stands before it to have swallowed it.
-ARGV="$TMP/argv"
-printf '%s\0' git commit -m 'fix(KEN-1): change a crate' --amend >"$ARGV"
-gg_argv_is_amend "$ARGV" \
-  && ok "the flag behind a message is the flag" \
-  || bad "the flag behind a message is the flag" "read as plain, wanted amend"
+echo "=== which argv is an amend: the NUL-delimited bytes the kernel would hold ==="
+# The scan reads the token immediately before each `--amend`: a value-taking
+# option consumes the next argument and nothing further, so it is the only
+# token that can swallow it; `--no-amend` stands outside that guard; a bare
+# `--` stops the scan; the wrapper's arguments ahead of `commit` are skipped.
+is_amend() { # WORDS... — yes or no
+  printf '%s\0' "$@" >"$TMP/argv"
+  if gg_argv_is_amend "$TMP/argv"; then echo yes; else echo no; fi
+}
+argv_rows() { # label | argv words | expect
+  local row label argv expect words
+  for row in "$@"; do
+    IFS='|' read -r label argv expect <<<"$row"
+    read -ra words <<<"$argv"
+    assert_eq "$label" "$expect" "$(is_amend "${words[@]}")"
+  done
+}
+argv_rows \
+  "the flag behind a message is the flag: a message is an argument like any other|git commit -m fix(KEN-1):_change --amend|yes" \
+  "the flag behind a value-taking option is that option's value|git commit --mess --amend|no" \
+  "the flag behind a clustered short option ending in -m is its value|git commit -am --amend|no" \
+  "a flag behind a no-value option is the flag|git commit --no-edit --amend|yes" \
+  "--no-amend after the flag withdraws it|git commit --amend --no-amend|no" \
+  "git's abbreviation of the flag is the flag|git commit --ame|yes" \
+  "a bare -- stops the scan: the flag behind it is a path|git commit -- lib.rs --amend|no" \
+  "the wrapper's arguments ahead of commit are skipped: -c never reads as swallowing|git -c core.editor=true commit --amend|yes" \
+  "a git that is not committing is not an amend|git rebase --amend|no"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/commit-guards/tests/commit-msg-amend.test.sh
+++ b/skills/commit-guards/tests/commit-msg-amend.test.sh
@@ -60,7 +60,7 @@ staged_on_fragment() { # NAME
   printf 'fn one() {}\n' >"$R/crates/core/lib.rs"
   printf -- '- A fix consumers see.\n' >"$R/changelog.d/fixed/ken-1.md"
   git -C "$R" add -A
-  git -C "$R" commit -qm 'fix(KEN-1): change a crate' >/dev/null 2>&1
+  git -C "$R" commit -qm 'fix(KEN-1): change a crate' >/dev/null 2>&1 || true
   # The hook judged that commit too: a fixture whose seed was refused would
   # amend the base commit, whose header waives the entry.
   [ "$(git -C "$R" log -1 --format=%s)" = 'fix(KEN-1): change a crate' ] \
@@ -105,6 +105,14 @@ else
   assert_eq "must-fail: a message VALUE spelling the flag does not widen the base" \
     "rc=1 commit-msg FAIL non-conventional header: --amend;  expected: type(scope)!: subject — scope and '!' optional; types: build chore ci docs feat fix perf refactor revert style test;  scope accepts uppercase issue keys and issue numbers, e.g. fix(ABC-123): tighten the gate / fix(#123): case-fold IDs;  git-generated headers (Merge/Revert/Reapply, fixup!/squash!/amend!) pass unchanged;$OWED" \
     "$(commit --mess '--amend')"
+  # MUST-FAIL: a message merely CONTAINING the flag. The argv is read
+  # NUL-delimited so this stays one argument; a scan joining argv with spaces
+  # (what `ps` would give) would read the flag out of it and excuse the
+  # commit with the fragment the previous one carries.
+  staged_on_fragment mention
+  assert_eq "must-fail: a message CONTAINING the flag is not the flag" \
+    "rc=1 $(header 'fix(KEN-2): wire the --amend path');$OWED" \
+    "$(commit -m 'fix(KEN-2): wire the --amend path')"
 fi
 
 echo "=== which argv is an amend: the NUL-delimited bytes the kernel would hold ==="
@@ -129,7 +137,10 @@ argv_rows \
   "the flag behind a value-taking option is that option's value|git commit --mess --amend|no" \
   "the flag behind a clustered short option ending in -m is its value|git commit -am --amend|no" \
   "a flag behind a no-value option is the flag|git commit --no-edit --amend|yes" \
+  "a flag behind a short valueless option is the flag|git commit -a --amend|yes" \
+  "an option carrying its own value is read as swallowing: the conservative miss the scan accepts|git commit --message=x --amend|no" \
   "--no-amend after the flag withdraws it|git commit --amend --no-amend|no" \
+  "--no-amend before the flag does not withdraw it: the last word wins|git commit --no-amend --amend|yes" \
   "git's abbreviation of the flag is the flag|git commit --ame|yes" \
   "a bare -- stops the scan: the flag behind it is a path|git commit -- lib.rs --amend|no" \
   "the wrapper's arguments ahead of commit are skipped: -c never reads as swallowing|git -c core.editor=true commit --amend|yes" \


### PR DESCRIPTION
Reshapes `skills/commit-guards/tests/commit-msg-amend.test.sh` to code-quality § Tests.

The suite for the one commit-msg rule that cannot be judged from an index alone (the changelog a commit owes is read against the parent the commit will HAVE, so an amend is judged against HEAD's parent; `scripts/lib/commit-parent.sh` reads the answer off the committing git's argv through /proc, so a host without procfs answers "not an amend") was 109 lines and 4 assertions, each git's exit status read as a bit beside one substring of its output, and one argv asked. It is two tables now. The real-commit table: `staged_on_fragment NAME` builds a repository with the commit-msg hook installed and its output captured, the rule armed for `crates/* ui/*`, HEAD carrying a crate change with its fragment and more crate code staged on top; the fixture reads its seed commit back, since a refused seed would leave the base commit as HEAD, whose `[no-changelog]` header waives the entry (the author's fixture mutant dropping the fragment survived silently that way before the check). `commit ARGS` pins git's exit status with every line the hook wrote. Rows: the control (the NEXT commit after a fragment commit owes its own entry: rc=1, the OK header line then the four owed lines); under /proc, an amend adding more code passes (rc=0, the OK header line) and the must-fail `--mess '--amend'` (git's abbreviation of `--message`, so `--amend` is message TEXT: rc=1, the header refusal's four lines then the owed lines). The argv table (`label|argv words|expect`): `is_amend WORDS...` writes the NUL-delimited bytes the kernel would hold and answers yes or no; eight rows where there was one: the flag behind a message is the flag; behind `--mess` it is a value; behind a clustered `-am` it is a value; behind `--no-edit` it is the flag; `--amend --no-amend` is withdrawn; git's abbreviation `--ame` is the flag; a bare `--` stops the scan; `git rebase --amend` is not a commit. 4 to 16 (13 where /proc is absent, three rows skipped and said so).

Recorded, not pinned: the GIT_INDEX_FILE gate on the /proc walk (a direct run with a `git commit --amend` ancestor and no GIT_INDEX_FILE has no shipped producer this suite can build) and the stop at the nearest git ancestor (an outer git whose argv says `commit --amend` around an inner plain commit cannot be constructed: git refuses an alias named `commit`).

The tracked render is replayed with `patch`. Nothing about `.kendex-generated.json` changed.

## Mutation

16 exact-substring production mutants over `scripts/lib/commit-parent.sh` (`mutate-amend.py`, results `mutants-amend-3.txt` in the session scratchpad), run against the final suite in a scratch copy: 14 killed, 2 recorded.

| mutant | result |
|---|---|
| argv: the swallowed-token guard dropped (a value spelling the flag is the flag) | killed by "the flag behind a value-taking option is that option's value" |
| argv: --no-amend not recognised | killed by "--no-amend after the flag withdraws it" |
| argv: the bare -- does not stop the scan | killed by "a bare -- stops the scan: the flag behind it is a path" |
| argv: the wrapper's arguments are scanned too | killed by "the wrapper's arguments ahead of commit are skipped: -c never reads as swallowing" |
| argv: a git that is not committing is scanned | killed by "a git that is not committing is not an amend" |
| argv: -m joins the no-value options | killed by "the flag behind a clustered short option ending in -m is its value" |
| argv: --no-edit leaves the no-value list | killed by "a flag behind a no-value option is the flag" |
| argv: --amend matched by equality only | killed by "git's abbreviation of the flag is the flag" |
| argv: the words read space-joined, as ps would give them | killed by "must-fail: a message CONTAINING the flag is not the flag" |
| argv: the short valueless class matches nothing | killed by "a flag behind a short valueless option is the flag" |
| argv: --no-amend ends the scan | killed by "--no-amend before the flag does not withdraw it: the last word wins" |
| amend: the widening never happens | killed by "an amend adding more code passes on the fragment the commit already carries" |
| amend: every commit is widened | killed by "control: the commit AFTER a fragment commit still owes its own entry" |
| amend: a direct run without GIT_INDEX_FILE still walks | SURVIVED: recorded, no construction |
| amend: the walk keeps going past the nearest git | SURVIVED: recorded, no construction |
| amend: the parent is HEAD, not HEAD^ | killed by "an amend adding more code passes on the fragment the commit already carries" |

5 fixture mutants: 4 killed by a row, 1 by the fixture's own premise check (the suite aborts naming the refused seed).

| fixture mutant | result |
|---|---|
| F1 fixture: no fragment in the HEAD commit | aborts the suite with its diagnostic: "harness: fixture next's seed commit was refused" |
| F2 fixture: no crate code staged on top | killed by "control: the commit AFTER a fragment commit still owes its own entry" |
| F3 fixture: the rule not armed | killed by the same row |
| F4 commit: the hook's output not read | killed by the same row |
| F5 argv: the words not NUL-delimited | killed by "the flag behind a message is the flag" |

The reviewer round (`review-amend/REPORT-final.md` in the session scratchpad): fix-first. B1 the seed-commit premise check could not fire (a refused seed exited the suite under `set -e` a line earlier; the seed now tolerates refusal and the check reports the fixture by name). B2 no row carried an argument with whitespace, so a scan joining argv with spaces, which reads the flag out of a message merely containing it and excuses the commit, stayed green: a must-fail real-commit row (`fix(KEN-2): wire the --amend path` is owed its entry). B3 no row for a short valueless option before the flag (`-a --amend|yes`). Its suggestions taken: `--message=x --amend|no` (the conservative miss the scan accepts, recorded as such), `--no-amend --amend|yes` (the last word wins). Recorded, not pinned: the empty-tree base when a repository's first commit is amended; the `-c` wrapper row is kept though the rebase row is what pins the pre-scan.

## Checks

- `commit-msg-amend.test.sh`: 16 assertions on this host under TMPDIR=/tmp and a symlinked TMPDIR; 13 passed and the three widening rows skipped on a macOS box (bash 3.2.57, no /proc). `tools/bash32-lint` clean over the tests directory.
- `tools/guard --full`: exit 0 on the first commit under TMPDIR=/tmp; the run on the rebased second commit was launched at PR time, CI is the verdict.
- One reviewer-test round: fix-first, its three rows and two suggestions in the second commit.

KEN-1241

https://claude.ai/code/session_01ESWfqKsTYCo5LjWxeBmaKi
