### PR TITLE
test(KEN-1241): the cleanup-scope suite as one table of rows

### DIFF
--- a/.agents/skills/commit-guards/tests/cleanup-scope.test.sh
+++ b/.agents/skills/commit-guards/tests/cleanup-scope.test.sh
@@ -71,19 +71,26 @@ scratch() { # — the gg-*.* scratch directories left in the owned root
 }
 printf 'feat: a message\n' >"$TMP/msg.txt"
 # One line for a run: the lane's exit status and last line, the sentinel's
-# fate, the scratch count afterwards. ENVS is a comma-separated list of
-# assignments; a `GG_TMP=S` entry names the row's sentinel.
+# fate, the scratch directories the run added to the owned root. ENVS is a
+# comma-separated list of assignments; a value `S` names the row's sentinel
+# directory and `F` the file inside it.
 run() { # LANE ENVS
-  local envs=() rc=0 out="" e
+  local envs=() rc=0 out="" e before
   if [ -n "$2" ]; then
     IFS=',' read -ra envs <<<"$2"
-    for e in "${!envs[@]}"; do [ "${envs[$e]}" != "GG_TMP=S" ] || envs[$e]="GG_TMP=$S"; done
+    for e in "${!envs[@]}"; do
+      case "${envs[$e]}" in
+        *=S) envs[$e]="${envs[$e]%=S}=$S" ;;
+        *=F) envs[$e]="${envs[$e]%=F}=$S/keep.txt" ;;
+      esac
+    done
   fi
+  before="$(scratch)"
   case "$1" in
     commit-msg) out="$(cd "$R" && env ${envs[@]+"${envs[@]}"} "$SCRIPTS/commit-msg" "$TMP/msg.txt" 2>&1)" || rc=$? ;;
     *) out="$(cd "$R" && env ${envs[@]+"${envs[@]}"} "$SCRIPTS/$1" 2>&1)" || rc=$? ;;
   esac
-  printf 'rc=%s last=%s sentinel=%s scratch=%s' "$rc" "$(printf '%s\n' "$out" | tail -n 1)" "$(kept)" "$(scratch)"
+  printf 'rc=%s last=%s sentinel=%s scratch=%s' "$rc" "$(printf '%s\n' "$out" | tail -n 1)" "$(kept)" "$(( $(scratch) - before ))"
 }
 ROW=0
 run_rows() { # label | lane | envs | expect
@@ -106,12 +113,13 @@ assert_eq "control: the root is empty before any row" "0" "$(scratch)"
 echo "=== a check or a lane never deletes an inherited GG_TMP, an inherited ownership flag never deletes the settings cache, and a check's own scratch is removed ==="
 CHAIN="pre-commit: OK — staged guard chain clean"
 run_rows \
-  "standalone: a check with GG_TMP inherited passes and leaves the inherited directory|todo-ban|GG_TMP=S|rc=0 last=todo-ban: OK — no work markers in tracked files sentinel=kept scratch=0" \
+  "standalone: a check with GG_TMP inherited passes, leaves the inherited directory and its own scratch removed|todo-ban|GG_TMP=S|rc=0 last=todo-ban: OK — no work markers in tracked files sentinel=kept scratch=0" \
+  "install: a check with GG_INSTALL_TMP inherited leaves the inherited file|todo-ban|GG_INSTALL_TMP=F|rc=0 last=todo-ban: OK — no work markers in tracked files sentinel=kept scratch=0" \
   "hooklane: the pre-commit chain with GG_TMP inherited passes and leaves it|pre-commit|GG_TMP=S|rc=0 last=$CHAIN sentinel=kept scratch=0" \
   "msglane: the commit-msg gate with GG_TMP inherited passes and leaves it|commit-msg|GG_TMP=S|rc=0 last=commit-msg: OK — conventional header: feat: a message sentinel=kept scratch=0" \
   "ownership: the chain completes with the ownership flag inherited, no check losing the cache mid-run|pre-commit|GG_SETTINGS_INDEX_OWNED=1|rc=0 last=$CHAIN sentinel=kept scratch=0" \
-  "control: the same chain in a clean environment|pre-commit||rc=0 last=$CHAIN sentinel=kept scratch=0" \
-  "owncleanup: a check leaves no scratch directory of its own behind|todo-ban||rc=0 last=todo-ban: OK — no work markers in tracked files sentinel=kept scratch=0"
+  "cachedir: the chain with GG_SETTINGS_INDEX_DIR inherited makes its own cache and leaves the inherited one|pre-commit|GG_SETTINGS_INDEX_DIR=S|rc=0 last=$CHAIN sentinel=kept scratch=0" \
+  "control: the same chain in a clean environment|pre-commit||rc=0 last=$CHAIN sentinel=kept scratch=0"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.agents/skills/commit-guards/tests/cleanup-scope.test.sh
+++ b/.agents/skills/commit-guards/tests/cleanup-scope.test.sh
@@ -2,13 +2,16 @@
 # Pins for the family's EXIT cleanup: it removes only what THIS process
 # created. An inherited GG_TMP or ownership flag must never decide what a
 # guard deletes, and a check a hook lane runs must not remove the settings
-# cache its parent is still reading. Every hostile-environment pin is paired
-# with the clean-environment control.
+# cache its parent is still reading. One table: a lane runs in a fresh
+# repository under ENVS, and the row pins the exit status, the lane's last
+# line (a chain that lost its cache mid-run ends otherwise), whether the
+# sentinel directory an inherited GG_TMP names survived, and how many
+# scratch directories the run left in the root this suite owns.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
-TB="$SKILL_DIR/scripts/todo-ban"
+# shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
 
 # The chain runs from an install that carries no sibling skills: this suite
@@ -17,112 +20,98 @@ TB="$SKILL_DIR/scripts/todo-ban"
 BARE_INSTALL="$TMP/install/skills"
 mkdir -p "$BARE_INSTALL"
 cp -R "$SKILL_DIR" "$BARE_INSTALL/commit-guards"
-PC="$BARE_INSTALL/commit-guards/scripts/pre-commit"
-
+SCRIPTS="$BARE_INSTALL/commit-guards/scripts"
 unset COMMIT_GUARDS_CHECKS COMMIT_GUARDS_SETTINGS_FILE GG_TMP \
   GG_SETTINGS_INDEX_OWNED GG_SETTINGS_INDEX_DIR GG_SETTINGS_FROM_INDEX 2>/dev/null || true
 
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
-
-new_repo() { # NAME -> repo path on stdout
-  local r="$TMP/$1"
-  mkdir -p "$r"
-  git -C "$r" -c init.defaultBranch=main init -q
-  git -C "$r" config user.email test@example.com
-  git -C "$r" config user.name test
-  printf '[]\n' >"$r/.kendex-generated.json"
-  printf 'fn main() {}\n' >"$r/ok.rs"
-  # A TRACKED settings source, so the hook lane materializes an index copy
-  # into the cache the children inherit.
-  printf '[env]\nCOMMIT_GUARDS_BYTE_CEILING_KB = "200"\n' >"$r/kendex.settings.toml"
-  git -C "$r" add -A
-  printf '%s' "$r"
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
 }
 
-# A sentinel a correct cleanup never touches: an inherited GG_TMP naming it
-# would be rm -rf'd by the guard's own EXIT trap.
-new_sentinel() { # NAME -> path on stdout
-  local d="$TMP/$1"
-  mkdir -p "$d"
-  printf 'precious\n' >"$d/keep.txt"
-  printf '%s' "$d"
+# A repository with a TRACKED settings source, so the hook lane materializes
+# an index copy into the cache the children inherit.
+R=""
+repo() { # NAME
+  R="$TMP/$1"
+  [ ! -e "$R" ] || { echo "harness: fixture $1 already exists" >&2; exit 2; }
+  mkdir -p "$R"
+  git -C "$R" -c init.defaultBranch=main init -q
+  git -C "$R" config user.email test@example.com
+  git -C "$R" config user.name test
+  printf '[]\n' >"$R/.kendex-generated.json"
+  printf 'fn main() {}\n' >"$R/ok.rs"
+  printf '[env]\nCOMMIT_GUARDS_BYTE_CEILING_KB = "200"\n' >"$R/kendex.settings.toml"
+  git -C "$R" add -A
 }
-
-echo "=== a standalone check never deletes an inherited GG_TMP ==="
-R="$(new_repo standalone)"
-S="$(new_sentinel sentinel-standalone)"
-RC=0
-OUT="$(cd "$R" && GG_TMP="$S" "$TB" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "control: the check itself still passes with GG_TMP inherited" \
-  || bad "check passes with GG_TMP inherited" "rc=$RC out=$OUT"
-[ -f "$S/keep.txt" ] && ok "the inherited directory survives the check's exit" \
-  || bad "inherited GG_TMP survives todo-ban" "$S/keep.txt is gone"
-
-echo "=== a hook lane never deletes an inherited GG_TMP ==="
-R2="$(new_repo hooklane)"
-S2="$(new_sentinel sentinel-hooklane)"
-RC=0
-OUT="$(cd "$R2" && GG_TMP="$S2" "$PC" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "control: the pre-commit chain still passes with GG_TMP inherited" \
-  || bad "pre-commit passes with GG_TMP inherited" "rc=$RC out=$OUT"
-# pre-commit arms the cleanup trap through gg_settings_index_mode, which
-# creates no scratch directory of its own — so an inherited name is the only
-# thing the trap could act on.
-[ -f "$S2/keep.txt" ] && ok "the inherited directory survives the hook lane's exit" \
-  || bad "inherited GG_TMP survives pre-commit" "$S2/keep.txt is gone"
-
-R2B="$(new_repo hooklane-msg)"
-S2B="$(new_sentinel sentinel-hooklane-msg)"
-printf 'feat: a message\n' >"$TMP/msg.txt"
-RC=0
-OUT="$(cd "$R2B" && GG_TMP="$S2B" "$SKILL_DIR/scripts/commit-msg" "$TMP/msg.txt" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "control: the commit-msg gate still passes with GG_TMP inherited" \
-  || bad "commit-msg passes with GG_TMP inherited" "rc=$RC out=$OUT"
-[ -f "$S2B/keep.txt" ] && ok "the inherited directory survives the commit-msg lane's exit" \
-  || bad "inherited GG_TMP survives commit-msg" "$S2B/keep.txt is gone"
-
-echo "=== an inherited ownership flag cannot make a child delete the settings cache ==="
-R3="$(new_repo ownership)"
-RC=0
-OUT="$(cd "$R3" && GG_SETTINGS_INDEX_OWNED=1 "$PC" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "the chain completes with the ownership flag inherited" \
-  || bad "chain completes with GG_SETTINGS_INDEX_OWNED inherited" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"could not read the staged copy while resolving a setting"* | *"did not complete"*)
-    bad "no check lost the settings cache" "out=$OUT" ;;
-  *) ok "no check lost the settings cache mid-run" ;;
-esac
-RC=0
-OUT="$(cd "$R3" && "$PC" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "control: the same chain passes with a clean environment" \
-  || bad "control: clean-environment chain passes" "rc=$RC out=$OUT"
-
-echo "=== the scratch directory a check DOES create is still removed ==="
+# The sentinel a correct cleanup never touches: an inherited GG_TMP naming it
+# would be rm -rf'd by a guard's own EXIT trap. One per row.
+S=""
+sentinel() { # NAME
+  S="$TMP/$1"
+  mkdir -p "$S"
+  printf 'precious\n' >"$S/keep.txt"
+}
+kept() { if [ -f "$S/keep.txt" ]; then echo kept; else echo gone; fi; }
 # Counted inside the scratch root the harness owns and points TMPDIR at, so
 # the number answers for this run alone and no concurrent run moves it.
-scratch_dirs() { # -> count of gg-todo-ban.* directories in the owned root
+scratch() { # — the gg-*.* scratch directories left in the owned root
   local n=0 d
-  for d in "$TMPDIR"/gg-todo-ban.*; do
+  for d in "$TMPDIR"/gg-*.*; do
     if [ -d "$d" ]; then n=$((n + 1)); fi
   done
   printf '%s' "$n"
 }
-mkdir -p "$TMPDIR/gg-todo-ban.decoy"
-[ "$(scratch_dirs)" -eq 1 ] && ok "control: the count sees a scratch directory in the owned root" \
-  || bad "control: the count sees a scratch directory in the owned root" "count=$(scratch_dirs)"
-rmdir "$TMPDIR/gg-todo-ban.decoy"
+printf 'feat: a message\n' >"$TMP/msg.txt"
+# One line for a run: the lane's exit status and last line, the sentinel's
+# fate, the scratch count afterwards. ENVS is a comma-separated list of
+# assignments; a `GG_TMP=S` entry names the row's sentinel.
+run() { # LANE ENVS
+  local envs=() rc=0 out="" e
+  if [ -n "$2" ]; then
+    IFS=',' read -ra envs <<<"$2"
+    for e in "${!envs[@]}"; do [ "${envs[$e]}" != "GG_TMP=S" ] || envs[$e]="GG_TMP=$S"; done
+  fi
+  case "$1" in
+    commit-msg) out="$(cd "$R" && env ${envs[@]+"${envs[@]}"} "$SCRIPTS/commit-msg" "$TMP/msg.txt" 2>&1)" || rc=$? ;;
+    *) out="$(cd "$R" && env ${envs[@]+"${envs[@]}"} "$SCRIPTS/$1" 2>&1)" || rc=$? ;;
+  esac
+  printf 'rc=%s last=%s sentinel=%s scratch=%s' "$rc" "$(printf '%s\n' "$out" | tail -n 1)" "$(kept)" "$(scratch)"
+}
+ROW=0
+run_rows() { # label | lane | envs | expect
+  local row label lane envs expect
+  for row in "$@"; do
+    IFS='|' read -r label lane envs expect <<<"$row"
+    ROW=$((ROW + 1))
+    repo "repo-$ROW"
+    sentinel "sentinel-$ROW"
+    assert_eq "$label" "$expect" "$(run "$lane" "$envs")"
+  done
+}
 
-R4="$(new_repo owncleanup)"
-BEFORE="$(scratch_dirs)"
-RC=0
-OUT="$(cd "$R4" && "$TB" 2>&1)" || RC=$?
-AFTER="$(scratch_dirs)"
-[ "$RC" -eq 0 ] && [ "$BEFORE" -eq 0 ] && [ "$AFTER" -eq 0 ] \
-  && ok "a check leaves no scratch directory behind" \
-  || bad "check cleans up its own scratch directory" "rc=$RC before=$BEFORE after=$AFTER"
+echo "=== premise: the scratch count sees a directory in the owned root ==="
+mkdir -p "$TMPDIR/gg-todo-ban.decoy"
+assert_eq "control: a decoy scratch directory is counted" "1" "$(scratch)"
+rmdir "$TMPDIR/gg-todo-ban.decoy"
+assert_eq "control: the root is empty before any row" "0" "$(scratch)"
+
+echo "=== a check or a lane never deletes an inherited GG_TMP, an inherited ownership flag never deletes the settings cache, and a check's own scratch is removed ==="
+CHAIN="pre-commit: OK — staged guard chain clean"
+run_rows \
+  "standalone: a check with GG_TMP inherited passes and leaves the inherited directory|todo-ban|GG_TMP=S|rc=0 last=todo-ban: OK — no work markers in tracked files sentinel=kept scratch=0" \
+  "hooklane: the pre-commit chain with GG_TMP inherited passes and leaves it|pre-commit|GG_TMP=S|rc=0 last=$CHAIN sentinel=kept scratch=0" \
+  "msglane: the commit-msg gate with GG_TMP inherited passes and leaves it|commit-msg|GG_TMP=S|rc=0 last=commit-msg: OK — conventional header: feat: a message sentinel=kept scratch=0" \
+  "ownership: the chain completes with the ownership flag inherited, no check losing the cache mid-run|pre-commit|GG_SETTINGS_INDEX_OWNED=1|rc=0 last=$CHAIN sentinel=kept scratch=0" \
+  "control: the same chain in a clean environment|pre-commit||rc=0 last=$CHAIN sentinel=kept scratch=0" \
+  "owncleanup: a check leaves no scratch directory of its own behind|todo-ban||rc=0 last=todo-ban: OK — no work markers in tracked files sentinel=kept scratch=0"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/commit-guards/tests/cleanup-scope.test.sh
+++ b/skills/commit-guards/tests/cleanup-scope.test.sh
@@ -71,19 +71,26 @@ scratch() { # — the gg-*.* scratch directories left in the owned root
 }
 printf 'feat: a message\n' >"$TMP/msg.txt"
 # One line for a run: the lane's exit status and last line, the sentinel's
-# fate, the scratch count afterwards. ENVS is a comma-separated list of
-# assignments; a `GG_TMP=S` entry names the row's sentinel.
+# fate, the scratch directories the run added to the owned root. ENVS is a
+# comma-separated list of assignments; a value `S` names the row's sentinel
+# directory and `F` the file inside it.
 run() { # LANE ENVS
-  local envs=() rc=0 out="" e
+  local envs=() rc=0 out="" e before
   if [ -n "$2" ]; then
     IFS=',' read -ra envs <<<"$2"
-    for e in "${!envs[@]}"; do [ "${envs[$e]}" != "GG_TMP=S" ] || envs[$e]="GG_TMP=$S"; done
+    for e in "${!envs[@]}"; do
+      case "${envs[$e]}" in
+        *=S) envs[$e]="${envs[$e]%=S}=$S" ;;
+        *=F) envs[$e]="${envs[$e]%=F}=$S/keep.txt" ;;
+      esac
+    done
   fi
+  before="$(scratch)"
   case "$1" in
     commit-msg) out="$(cd "$R" && env ${envs[@]+"${envs[@]}"} "$SCRIPTS/commit-msg" "$TMP/msg.txt" 2>&1)" || rc=$? ;;
     *) out="$(cd "$R" && env ${envs[@]+"${envs[@]}"} "$SCRIPTS/$1" 2>&1)" || rc=$? ;;
   esac
-  printf 'rc=%s last=%s sentinel=%s scratch=%s' "$rc" "$(printf '%s\n' "$out" | tail -n 1)" "$(kept)" "$(scratch)"
+  printf 'rc=%s last=%s sentinel=%s scratch=%s' "$rc" "$(printf '%s\n' "$out" | tail -n 1)" "$(kept)" "$(( $(scratch) - before ))"
 }
 ROW=0
 run_rows() { # label | lane | envs | expect
@@ -106,12 +113,13 @@ assert_eq "control: the root is empty before any row" "0" "$(scratch)"
 echo "=== a check or a lane never deletes an inherited GG_TMP, an inherited ownership flag never deletes the settings cache, and a check's own scratch is removed ==="
 CHAIN="pre-commit: OK — staged guard chain clean"
 run_rows \
-  "standalone: a check with GG_TMP inherited passes and leaves the inherited directory|todo-ban|GG_TMP=S|rc=0 last=todo-ban: OK — no work markers in tracked files sentinel=kept scratch=0" \
+  "standalone: a check with GG_TMP inherited passes, leaves the inherited directory and its own scratch removed|todo-ban|GG_TMP=S|rc=0 last=todo-ban: OK — no work markers in tracked files sentinel=kept scratch=0" \
+  "install: a check with GG_INSTALL_TMP inherited leaves the inherited file|todo-ban|GG_INSTALL_TMP=F|rc=0 last=todo-ban: OK — no work markers in tracked files sentinel=kept scratch=0" \
   "hooklane: the pre-commit chain with GG_TMP inherited passes and leaves it|pre-commit|GG_TMP=S|rc=0 last=$CHAIN sentinel=kept scratch=0" \
   "msglane: the commit-msg gate with GG_TMP inherited passes and leaves it|commit-msg|GG_TMP=S|rc=0 last=commit-msg: OK — conventional header: feat: a message sentinel=kept scratch=0" \
   "ownership: the chain completes with the ownership flag inherited, no check losing the cache mid-run|pre-commit|GG_SETTINGS_INDEX_OWNED=1|rc=0 last=$CHAIN sentinel=kept scratch=0" \
-  "control: the same chain in a clean environment|pre-commit||rc=0 last=$CHAIN sentinel=kept scratch=0" \
-  "owncleanup: a check leaves no scratch directory of its own behind|todo-ban||rc=0 last=todo-ban: OK — no work markers in tracked files sentinel=kept scratch=0"
+  "cachedir: the chain with GG_SETTINGS_INDEX_DIR inherited makes its own cache and leaves the inherited one|pre-commit|GG_SETTINGS_INDEX_DIR=S|rc=0 last=$CHAIN sentinel=kept scratch=0" \
+  "control: the same chain in a clean environment|pre-commit||rc=0 last=$CHAIN sentinel=kept scratch=0"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/commit-guards/tests/cleanup-scope.test.sh
+++ b/skills/commit-guards/tests/cleanup-scope.test.sh
@@ -2,13 +2,16 @@
 # Pins for the family's EXIT cleanup: it removes only what THIS process
 # created. An inherited GG_TMP or ownership flag must never decide what a
 # guard deletes, and a check a hook lane runs must not remove the settings
-# cache its parent is still reading. Every hostile-environment pin is paired
-# with the clean-environment control.
+# cache its parent is still reading. One table: a lane runs in a fresh
+# repository under ENVS, and the row pins the exit status, the lane's last
+# line (a chain that lost its cache mid-run ends otherwise), whether the
+# sentinel directory an inherited GG_TMP names survived, and how many
+# scratch directories the run left in the root this suite owns.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
-TB="$SKILL_DIR/scripts/todo-ban"
+# shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
 
 # The chain runs from an install that carries no sibling skills: this suite
@@ -17,112 +20,98 @@ TB="$SKILL_DIR/scripts/todo-ban"
 BARE_INSTALL="$TMP/install/skills"
 mkdir -p "$BARE_INSTALL"
 cp -R "$SKILL_DIR" "$BARE_INSTALL/commit-guards"
-PC="$BARE_INSTALL/commit-guards/scripts/pre-commit"
-
+SCRIPTS="$BARE_INSTALL/commit-guards/scripts"
 unset COMMIT_GUARDS_CHECKS COMMIT_GUARDS_SETTINGS_FILE GG_TMP \
   GG_SETTINGS_INDEX_OWNED GG_SETTINGS_INDEX_DIR GG_SETTINGS_FROM_INDEX 2>/dev/null || true
 
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
-
-new_repo() { # NAME -> repo path on stdout
-  local r="$TMP/$1"
-  mkdir -p "$r"
-  git -C "$r" -c init.defaultBranch=main init -q
-  git -C "$r" config user.email test@example.com
-  git -C "$r" config user.name test
-  printf '[]\n' >"$r/.kendex-generated.json"
-  printf 'fn main() {}\n' >"$r/ok.rs"
-  # A TRACKED settings source, so the hook lane materializes an index copy
-  # into the cache the children inherit.
-  printf '[env]\nCOMMIT_GUARDS_BYTE_CEILING_KB = "200"\n' >"$r/kendex.settings.toml"
-  git -C "$r" add -A
-  printf '%s' "$r"
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
 }
 
-# A sentinel a correct cleanup never touches: an inherited GG_TMP naming it
-# would be rm -rf'd by the guard's own EXIT trap.
-new_sentinel() { # NAME -> path on stdout
-  local d="$TMP/$1"
-  mkdir -p "$d"
-  printf 'precious\n' >"$d/keep.txt"
-  printf '%s' "$d"
+# A repository with a TRACKED settings source, so the hook lane materializes
+# an index copy into the cache the children inherit.
+R=""
+repo() { # NAME
+  R="$TMP/$1"
+  [ ! -e "$R" ] || { echo "harness: fixture $1 already exists" >&2; exit 2; }
+  mkdir -p "$R"
+  git -C "$R" -c init.defaultBranch=main init -q
+  git -C "$R" config user.email test@example.com
+  git -C "$R" config user.name test
+  printf '[]\n' >"$R/.kendex-generated.json"
+  printf 'fn main() {}\n' >"$R/ok.rs"
+  printf '[env]\nCOMMIT_GUARDS_BYTE_CEILING_KB = "200"\n' >"$R/kendex.settings.toml"
+  git -C "$R" add -A
 }
-
-echo "=== a standalone check never deletes an inherited GG_TMP ==="
-R="$(new_repo standalone)"
-S="$(new_sentinel sentinel-standalone)"
-RC=0
-OUT="$(cd "$R" && GG_TMP="$S" "$TB" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "control: the check itself still passes with GG_TMP inherited" \
-  || bad "check passes with GG_TMP inherited" "rc=$RC out=$OUT"
-[ -f "$S/keep.txt" ] && ok "the inherited directory survives the check's exit" \
-  || bad "inherited GG_TMP survives todo-ban" "$S/keep.txt is gone"
-
-echo "=== a hook lane never deletes an inherited GG_TMP ==="
-R2="$(new_repo hooklane)"
-S2="$(new_sentinel sentinel-hooklane)"
-RC=0
-OUT="$(cd "$R2" && GG_TMP="$S2" "$PC" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "control: the pre-commit chain still passes with GG_TMP inherited" \
-  || bad "pre-commit passes with GG_TMP inherited" "rc=$RC out=$OUT"
-# pre-commit arms the cleanup trap through gg_settings_index_mode, which
-# creates no scratch directory of its own — so an inherited name is the only
-# thing the trap could act on.
-[ -f "$S2/keep.txt" ] && ok "the inherited directory survives the hook lane's exit" \
-  || bad "inherited GG_TMP survives pre-commit" "$S2/keep.txt is gone"
-
-R2B="$(new_repo hooklane-msg)"
-S2B="$(new_sentinel sentinel-hooklane-msg)"
-printf 'feat: a message\n' >"$TMP/msg.txt"
-RC=0
-OUT="$(cd "$R2B" && GG_TMP="$S2B" "$SKILL_DIR/scripts/commit-msg" "$TMP/msg.txt" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "control: the commit-msg gate still passes with GG_TMP inherited" \
-  || bad "commit-msg passes with GG_TMP inherited" "rc=$RC out=$OUT"
-[ -f "$S2B/keep.txt" ] && ok "the inherited directory survives the commit-msg lane's exit" \
-  || bad "inherited GG_TMP survives commit-msg" "$S2B/keep.txt is gone"
-
-echo "=== an inherited ownership flag cannot make a child delete the settings cache ==="
-R3="$(new_repo ownership)"
-RC=0
-OUT="$(cd "$R3" && GG_SETTINGS_INDEX_OWNED=1 "$PC" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "the chain completes with the ownership flag inherited" \
-  || bad "chain completes with GG_SETTINGS_INDEX_OWNED inherited" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"could not read the staged copy while resolving a setting"* | *"did not complete"*)
-    bad "no check lost the settings cache" "out=$OUT" ;;
-  *) ok "no check lost the settings cache mid-run" ;;
-esac
-RC=0
-OUT="$(cd "$R3" && "$PC" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && ok "control: the same chain passes with a clean environment" \
-  || bad "control: clean-environment chain passes" "rc=$RC out=$OUT"
-
-echo "=== the scratch directory a check DOES create is still removed ==="
+# The sentinel a correct cleanup never touches: an inherited GG_TMP naming it
+# would be rm -rf'd by a guard's own EXIT trap. One per row.
+S=""
+sentinel() { # NAME
+  S="$TMP/$1"
+  mkdir -p "$S"
+  printf 'precious\n' >"$S/keep.txt"
+}
+kept() { if [ -f "$S/keep.txt" ]; then echo kept; else echo gone; fi; }
 # Counted inside the scratch root the harness owns and points TMPDIR at, so
 # the number answers for this run alone and no concurrent run moves it.
-scratch_dirs() { # -> count of gg-todo-ban.* directories in the owned root
+scratch() { # — the gg-*.* scratch directories left in the owned root
   local n=0 d
-  for d in "$TMPDIR"/gg-todo-ban.*; do
+  for d in "$TMPDIR"/gg-*.*; do
     if [ -d "$d" ]; then n=$((n + 1)); fi
   done
   printf '%s' "$n"
 }
-mkdir -p "$TMPDIR/gg-todo-ban.decoy"
-[ "$(scratch_dirs)" -eq 1 ] && ok "control: the count sees a scratch directory in the owned root" \
-  || bad "control: the count sees a scratch directory in the owned root" "count=$(scratch_dirs)"
-rmdir "$TMPDIR/gg-todo-ban.decoy"
+printf 'feat: a message\n' >"$TMP/msg.txt"
+# One line for a run: the lane's exit status and last line, the sentinel's
+# fate, the scratch count afterwards. ENVS is a comma-separated list of
+# assignments; a `GG_TMP=S` entry names the row's sentinel.
+run() { # LANE ENVS
+  local envs=() rc=0 out="" e
+  if [ -n "$2" ]; then
+    IFS=',' read -ra envs <<<"$2"
+    for e in "${!envs[@]}"; do [ "${envs[$e]}" != "GG_TMP=S" ] || envs[$e]="GG_TMP=$S"; done
+  fi
+  case "$1" in
+    commit-msg) out="$(cd "$R" && env ${envs[@]+"${envs[@]}"} "$SCRIPTS/commit-msg" "$TMP/msg.txt" 2>&1)" || rc=$? ;;
+    *) out="$(cd "$R" && env ${envs[@]+"${envs[@]}"} "$SCRIPTS/$1" 2>&1)" || rc=$? ;;
+  esac
+  printf 'rc=%s last=%s sentinel=%s scratch=%s' "$rc" "$(printf '%s\n' "$out" | tail -n 1)" "$(kept)" "$(scratch)"
+}
+ROW=0
+run_rows() { # label | lane | envs | expect
+  local row label lane envs expect
+  for row in "$@"; do
+    IFS='|' read -r label lane envs expect <<<"$row"
+    ROW=$((ROW + 1))
+    repo "repo-$ROW"
+    sentinel "sentinel-$ROW"
+    assert_eq "$label" "$expect" "$(run "$lane" "$envs")"
+  done
+}
 
-R4="$(new_repo owncleanup)"
-BEFORE="$(scratch_dirs)"
-RC=0
-OUT="$(cd "$R4" && "$TB" 2>&1)" || RC=$?
-AFTER="$(scratch_dirs)"
-[ "$RC" -eq 0 ] && [ "$BEFORE" -eq 0 ] && [ "$AFTER" -eq 0 ] \
-  && ok "a check leaves no scratch directory behind" \
-  || bad "check cleans up its own scratch directory" "rc=$RC before=$BEFORE after=$AFTER"
+echo "=== premise: the scratch count sees a directory in the owned root ==="
+mkdir -p "$TMPDIR/gg-todo-ban.decoy"
+assert_eq "control: a decoy scratch directory is counted" "1" "$(scratch)"
+rmdir "$TMPDIR/gg-todo-ban.decoy"
+assert_eq "control: the root is empty before any row" "0" "$(scratch)"
+
+echo "=== a check or a lane never deletes an inherited GG_TMP, an inherited ownership flag never deletes the settings cache, and a check's own scratch is removed ==="
+CHAIN="pre-commit: OK — staged guard chain clean"
+run_rows \
+  "standalone: a check with GG_TMP inherited passes and leaves the inherited directory|todo-ban|GG_TMP=S|rc=0 last=todo-ban: OK — no work markers in tracked files sentinel=kept scratch=0" \
+  "hooklane: the pre-commit chain with GG_TMP inherited passes and leaves it|pre-commit|GG_TMP=S|rc=0 last=$CHAIN sentinel=kept scratch=0" \
+  "msglane: the commit-msg gate with GG_TMP inherited passes and leaves it|commit-msg|GG_TMP=S|rc=0 last=commit-msg: OK — conventional header: feat: a message sentinel=kept scratch=0" \
+  "ownership: the chain completes with the ownership flag inherited, no check losing the cache mid-run|pre-commit|GG_SETTINGS_INDEX_OWNED=1|rc=0 last=$CHAIN sentinel=kept scratch=0" \
+  "control: the same chain in a clean environment|pre-commit||rc=0 last=$CHAIN sentinel=kept scratch=0" \
+  "owncleanup: a check leaves no scratch directory of its own behind|todo-ban||rc=0 last=todo-ban: OK — no work markers in tracked files sentinel=kept scratch=0"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Reshapes `skills/commit-guards/tests/cleanup-scope.test.sh` to code-quality § Tests.

The suite for the family's EXIT cleanup in `scripts/lib/common.sh` (a guard removes only what THIS process created: GG_TMP and the ownership flag are reset at load so an inherited value never decides what is deleted, and a check a hook lane runs never removes the settings cache its parent still reads) was 128 lines and 11 assertions, each lane's exit status read as a bit and the sentinel's presence as another, a substring negative for the ownership case, a decoy count control and a before-and-after scratch count, over six hand-built repositories. It is two premise assertions and one table now. The premises: a decoy scratch directory is counted; the owned root is empty before any row. The table (`run_rows`, `label|lane|envs|expect`): each row builds a fresh repository with a tracked `kendex.settings.toml` (so the hook lane materializes an index copy into the cache the children inherit) and a fresh sentinel; `GG_TMP=S` in ENVS names the row's sentinel; the lane runs from a bare install under the suite's scratch root with no sibling skills; the row pins `rc=N last=<the lane's last line> sentinel=<kept|gone> scratch=<gg-*.* directories left in the root the suite owns>`. Rows: todo-ban with GG_TMP inherited (its own scratch removed); todo-ban with GG_INSTALL_TMP inherited; the pre-commit chain with GG_TMP inherited; the commit-msg gate with GG_TMP inherited; the chain with GG_SETTINGS_INDEX_OWNED=1 inherited (the last line is the pin that no check lost the cache mid-run, which the old substring negative read); the chain with GG_SETTINGS_INDEX_DIR inherited; the chain in a clean environment. 11 to 9: each old pair (the lane passes, the sentinel survives) is one row's `rc` and `sentinel`, the ownership case's three checks one row, the decoy control a premise, the before-and-after count every row's `scratch=`.

Recorded, not pinned: exporting the ownership flag to the checks (a child's common.sh resets it at load, which the "an inherited ownership flag is honoured" mutant shows is pinned); the bare install is hermeticity, not a row's expectation (running the lanes from the source tree instead reads the same today).

The tracked render is replayed with `patch`. Nothing about `.kendex-generated.json` changed.

## Mutation

8 exact-substring production mutants over `scripts/lib/common.sh` (`mutate-cs.py`, results `mutants-cs-2.txt` in the session scratchpad), run against the final suite in a scratch copy: 7 killed, 1 equivalent.

| mutant | result |
|---|---|
| cleanup: an inherited GG_TMP is not cleared at load | killed by "standalone: a check with GG_TMP inherited passes and leaves the inherited directory" |
| cleanup: an inherited ownership flag is honoured | killed by "ownership: the chain completes with the ownership flag inherited, no check losing the cache mid-run" |
| cleanup: the scratch directory is not removed | killed by "standalone: a check with GG_TMP inherited passes and leaves the inherited directory" |
| cleanup: the trap is not armed | killed by the same row |
| cleanup: the settings cache is removed whoever owns it | killed by "ownership: the chain completes with the ownership flag inherited, no check losing the cache mid-run" |
| cleanup: an inherited GG_INSTALL_TMP is honoured | killed by "install: a check with GG_INSTALL_TMP inherited leaves the inherited file" |
| index mode: an inherited cache directory is reused and owned | killed by "cachedir: the chain with GG_SETTINGS_INDEX_DIR inherited makes its own cache and leaves the inherited one" |
| index mode: the children inherit the ownership flag | SURVIVED: equivalent, the child resets the flag at load |

5 fixture mutants: 2 killed, 3 by design, two of them measured load-bearing for a production kill.

| fixture mutant | result |
|---|---|
| F1 sentinel: the file not planted | killed by "standalone: a check with GG_TMP inherited passes and leaves the inherited directory" |
| F2 run: GG_TMP=S not substituted | no kill by design: a literal `S` is a directory the guard never had; the substitution is what "an inherited GG_TMP is not cleared at load" needs |
| F3 repo: no tracked settings source | no kill by design; measured: without it "the settings cache is removed whoever owns it" survives, since the hook lane materializes no cache to lose |
| F4 scratch: the count reads another root | killed by "control: a decoy scratch directory is counted" |
| F5 install: the bare install is the source tree | no kill by design: the sibling skills pass over the fixtures today; the bare install keeps a future sibling from redding a row for its own reasons |

The reviewer round (`review-cs/REPORT-final.md`): accept. Its suggestions taken: rows for an inherited GG_INSTALL_TMP (reset at load on the same rationale as GG_TMP; `=F` resolves to the sentinel's file) and an inherited GG_SETTINGS_INDEX_DIR (the hook lane makes its own cache and leaves the inherited one); the scratch count is a per-row delta now, so a leak in one row is not charged to every later one; the clean todo-ban row, identical to the inherited-GG_TMP row under every single mutation, is folded into it. Both new production mutants (an inherited GG_INSTALL_TMP honoured; an inherited cache directory reused and owned) are killed by their rows.

## Checks

- `cleanup-scope.test.sh`: 9 assertions on this host under TMPDIR=/tmp and a symlinked TMPDIR, and on a macOS box (bash 3.2.57). `tools/bash32-lint` clean over the tests directory.
- `tools/guard --full`: exit 0 on the first commit under TMPDIR=/tmp; the run on the rebased second commit was launched at PR time, CI is the verdict.
- One reviewer-test round: accept; its suggestions in the second commit.

KEN-1241

https://claude.ai/code/session_01ESWfqKsTYCo5LjWxeBmaKi
