### PR TITLE
test(KEN-1241): the changelog-record suite as three tables of rows

### DIFF
--- a/.agents/skills/commit-guards/tests/changelog-record.test.sh
+++ b/.agents/skills/commit-guards/tests/changelog-record.test.sh
@@ -88,7 +88,6 @@ UNTOUCHED="record=same fragment=same index=same"
 echo "=== the plain check reads fragments, never the record: any wording passes beside a valid fragment ==="
 rows '' \
   "a record with no Unreleased heading|# Release notes\n|rc=0 changelog-entries: OK — 1 fragment(s) within the cap (200 characters) $UNTOUCHED" \
-  "a record whose heading is reworded|# Changelog\n\n## Upcoming release\n\n- Reworded note.\n|rc=0 changelog-entries: OK — 1 fragment(s) within the cap (200 characters) $UNTOUCHED" \
   "a record with a paragraph under a foreign section|# Changelog\n\n## [Unreleased]\n\n### Details\n\nA new paragraph.\n|rc=0 changelog-entries: OK — 1 fragment(s) within the cap (200 characters) $UNTOUCHED"
 
 echo "=== control: a fragment's own structure still fails beside a reworded record ==="

--- a/.agents/skills/commit-guards/tests/changelog-record.test.sh
+++ b/.agents/skills/commit-guards/tests/changelog-record.test.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
-# Ordinary changelog edits are prose. Only collation reads the record format.
+# Pins for the record's place in the changelog family: ordinary changelog
+# edits are prose, and only collation reads the record format. Three tables:
+# a record wording beside a valid fragment, pinned by the plain check's exit
+# status and lines with the record byte-identical afterwards; a record shape
+# under --collate, pinned by the exit status and lines with the record and
+# the fragment untouched (the one usable shape folds, and is the control);
+# and a destination shape (untracked, symlink, gitlink, binary, not UTF-8)
+# under --collate, pinned by the refusal's cause with the record, the
+# fragment and the index untouched. The fold's own grammar is
+# changelog-collate.test.sh's; this file pins the refusals around it.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -7,113 +16,127 @@ SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 CE="$SKILL_DIR/scripts/changelog-entries"
 # shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
-
-# Hermetic: a leaked setting would mask every case below.
+# Hermetic: a leaked setting would mask every row below.
 unset COMMIT_GUARDS_CHANGELOG_CAP COMMIT_GUARDS_CHANGELOG_PATHS \
   COMMIT_GUARDS_CHANGELOG_RECORD COMMIT_GUARDS_CHANGELOG_COLLATE \
   COMMIT_GUARDS_SETTINGS_FILE 2>/dev/null || true
-
 export COMMIT_GUARDS_CHANGELOG_COLLATE=1
 
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
 
-new_repo() { # NAME — fresh fixture repo in $R
+# Fixture vocabulary: a fresh repository holding CHANGELOG.md with CONTENT
+# (printf %b) and one fragment, committed; a name used twice is refused.
+R=""
+FRAGMENT="changelog.d/fixed/pending.md"
+repo() { # NAME CONTENT [FRAGMENT-CONTENT]
   R="$TMP/$1"
-  mkdir -p "$R"
+  [ ! -e "$R" ] || { echo "harness: fixture $1 already exists" >&2; exit 2; }
+  mkdir -p "$R/changelog.d/fixed"
   git -C "$R" -c init.defaultBranch=main init -q
   git -C "$R" config user.email test@example.com
   git -C "$R" config user.name test
-}
-
-run_ce() { # [args...] — run in $R; sets OUT and RC
-  OUT=""
-  RC=0
-  OUT="$(cd "$R" && "$CE" "$@" 2>&1)" || RC=$?
-}
-
-stage() { git -C "$R" add -A; }
-
-frag() { # SECTION NAME — content on stdin, written and staged
-  mkdir -p "$R/changelog.d/$1"
-  cat >"$R/changelog.d/$1/$2"
-  stage
-}
-
-new_repo record
-printf '# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- Existing note.\n' >"$R/CHANGELOG.md"
-stage
-git -C "$R" commit -qm seed
-for text in '# Release notes' $'# Changelog\n\n## Upcoming release\n\n- Reworded note.' $'# Changelog\n\n## [Unreleased]\n\n### Details\n\nA new paragraph.'; do
-  printf '%s\n' "$text" >"$R/CHANGELOG.md"
-  stage
-  cp "$R/CHANGELOG.md" "$TMP/before.md"
-  run_ce
-  [ "$RC" -eq 0 ] && cmp -s "$R/CHANGELOG.md" "$TMP/before.md" \
-    && ok "record wording does not block fragment checks" || bad "record wording" "rc=$RC out=$OUT"
-done
-printf '%s\n' 'not a list item' | frag fixed invalid.md
-run_ce
-[ "$RC" -eq 1 ] && case "$OUT" in *"invalid.md"*"list marker"*) true ;; *) false ;; esac \
-  && ok "fragment structure still fails beside a reworded record" || bad "fragment control" "rc=$RC out=$OUT"
-printf '%s\n' '- A fixed defect.' | frag fixed invalid.md
-run_ce
-[ "$RC" -eq 0 ] && ok "the repaired fragment passes" || bad "fragment repair" "rc=$RC out=$OUT"
-
-for text in '# Release notes' $'# Log\n\n## [Unreleased]\n\n## [Unreleased]' $'# Log\n\n## [Unreleased]\n\n```\nunclosed' $'# Log\n\n## [Unreleased]\n\n### Details\n\n- Note.'; do
-  printf '%s\n' "$text" >"$R/CHANGELOG.md"
-  stage
-  cp "$R/CHANGELOG.md" "$TMP/before.md"
-  git -C "$R" commit -qm "prepare destination"
-  run_ce --collate
-  [ "$RC" -gt 0 ] && cmp -s "$R/CHANGELOG.md" "$TMP/before.md" && [ -f "$R/changelog.d/fixed/invalid.md" ] \
-    && ok "collation refuses an unusable destination without writes" || bad "collation destination" "rc=$RC out=$OUT"
-done
-printf '# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- Reworded note.\n' >"$R/CHANGELOG.md"
-stage
-git -C "$R" commit -qm "prepare destination"
-run_ce --collate
-[ "$RC" -eq 0 ] && [ ! -e "$R/changelog.d/fixed/invalid.md" ] && grep -Fxq -- '- A fixed defect.' "$R/CHANGELOG.md" && grep -Fxq -- '- Reworded note.' "$R/CHANGELOG.md" \
-  && ok "collation retains the edited notes and folds the fragment" || bad "collation control" "rc=$RC out=$OUT"
-
-echo "=== collation destination refusals preserve every input ==="
-for row in 'untracked|is not tracked; commit the collation destination first' 'symlink|not a regular collation destination' 'gitlink|not a regular collation destination' 'binary|holds binary content' 'utf8|not valid UTF-8'; do
-  shape="${row%%|*}"
-  expected="${row#*|}"
-  new_repo "destination-$shape"
-  mkdir -p "$R/changelog.d/fixed"
-  printf '# Changelog\n\n## [Unreleased]\n' >"$R/CHANGELOG.md"
-  printf '%s\n' '- A pending change.' >"$R/changelog.d/fixed/pending.md"
-  stage
+  printf '%b' "$2" >"$R/CHANGELOG.md"
+  printf '%b' "${3:-- A pending change.\n}" >"$R/$FRAGMENT"
+  git -C "$R" add -A
   git -C "$R" commit -qm fixture
-  case "$shape" in
+}
+# Tokens for what a run left behind: the record and the fragment compared
+# byte for byte with what the fixture wrote, the index with what it held.
+snapshot() { cp -L "$R/CHANGELOG.md" "$TMP/record-before"; cp "$R/$FRAGMENT" "$TMP/fragment-before"; git -C "$R" ls-files -s >"$TMP/index-before"; }
+left() { # — record=<same|changed> fragment=<same|gone|changed> index=<same|changed>
+  local record=changed fragment=changed index=changed
+  if cmp -s "$R/CHANGELOG.md" "$TMP/record-before"; then record=same; fi
+  if [ ! -e "$R/$FRAGMENT" ]; then fragment=gone; elif cmp -s "$R/$FRAGMENT" "$TMP/fragment-before"; then fragment=same; fi
+  if git -C "$R" ls-files -s | cmp -s - "$TMP/index-before"; then index=same; fi
+  printf 'record=%s fragment=%s index=%s' "$record" "$fragment" "$index"
+}
+# One line for a run: the exit status, every line printed joined by ';',
+# then what it left behind.
+run() { # ARGS...
+  local rc=0 out=""
+  snapshot
+  out="$(cd "$R" && "$CE" "$@" 2>&1)" || rc=$?
+  printf 'rc=%s%s %s' "$rc" "${out:+ $(printf '%s\n' "$out" | LC_ALL=C paste -sd ';' -)}" "$(left)"
+}
+ROW=0
+rows() { # MODE — label | content | expect; MODE is the plain check or --collate
+  local mode="$1" row label content expect
+  shift
+  for row in "$@"; do
+    IFS='|' read -r label content expect <<<"$row"
+    ROW=$((ROW + 1))
+    R=""
+    repo "row-$ROW" "$content"
+    # shellcheck disable=SC2086
+    assert_eq "$label" "$expect" "$(run $mode)"
+  done
+}
+ERR="::error::changelog-entries: "
+VIOLATION="changelog-entries: 1 violation(s) — cap 200 characters, 1 fragment(s) measured"
+UNTOUCHED="record=same fragment=same index=same"
+
+echo "=== the plain check reads fragments, never the record: any wording passes beside a valid fragment ==="
+rows '' \
+  "a record with no Unreleased heading|# Release notes\n|rc=0 changelog-entries: OK — 1 fragment(s) within the cap (200 characters) $UNTOUCHED" \
+  "a record whose heading is reworded|# Changelog\n\n## Upcoming release\n\n- Reworded note.\n|rc=0 changelog-entries: OK — 1 fragment(s) within the cap (200 characters) $UNTOUCHED" \
+  "a record with a paragraph under a foreign section|# Changelog\n\n## [Unreleased]\n\n### Details\n\nA new paragraph.\n|rc=0 changelog-entries: OK — 1 fragment(s) within the cap (200 characters) $UNTOUCHED"
+
+echo "=== control: a fragment's own structure still fails beside a reworded record ==="
+ROW=$((ROW + 1))
+repo "row-$ROW" '# Release notes\n' 'not a list item\n'
+assert_eq "a fragment that is not a list item fails naming it, the record untouched" \
+  "rc=1 changelog-entries FAIL $FRAGMENT does not open with a list marker — a fragment is the Markdown list item it becomes, opening with a hyphen and a space;changelog-entries: 1 violation(s) — cap 200 characters, 0 fragment(s) measured $UNTOUCHED" "$(run)"
+
+echo "=== collation reads the record: an unusable shape is refused without a write, a usable one folds ==="
+rows --collate \
+  "no Unreleased heading is a violation naming the remedy|# Release notes\n|rc=1 changelog-entries FAIL CHANGELOG.md carries no '## [Unreleased]' heading;  open one — a release folds the fragments into it and has nowhere to put them otherwise;$VIOLATION $UNTOUCHED" \
+  "two Unreleased headings cannot be decided between|# Log\n\n## [Unreleased]\n\n## [Unreleased]\n|rc=2 ${ERR}CHANGELOG.md carries more than one '## [Unreleased]' heading — which one is the section cannot be decided $UNTOUCHED" \
+  "an unclosed code fence hides the section|# Log\n\n## [Unreleased]\n\n\`\`\`\nunclosed\n|rc=2 ${ERR}CHANGELOG.md leaves a code fence unclosed — the [Unreleased] section cannot be located $UNTOUCHED" \
+  "a section name outside Keep a Changelog is a violation naming the set|# Log\n\n## [Unreleased]\n\n### Details\n\n- Note.\n|rc=1 changelog-entries FAIL CHANGELOG.md names 'Details' under [Unreleased], which is not a Keep a Changelog section;  section one of: added changed deprecated removed fixed security;$VIOLATION $UNTOUCHED" \
+  "control: a usable record folds the fragment and keeps its edited note|# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- Reworded note.\n|rc=0 changelog-entries: folded 1 entry into CHANGELOG.md's [Unreleased] section record=changed fragment=gone index=same"
+assert_eq "control: the fold appends the fragment under the edited note" \
+  "$(printf '# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- Reworded note.\n- A pending change.\n')" "$(cat "$R/CHANGELOG.md")"
+
+echo "=== collation destination shapes are refused with their cause, every input preserved ==="
+# Each shape is applied to a usable record after the fixture commit and
+# committed again, so the refusal is the destination's, not the grammar's.
+shape() { # NAME SHAPE
+  repo "$1" '# Changelog\n\n## [Unreleased]\n'
+  case "$2" in
     untracked) git -C "$R" rm -q --cached -- CHANGELOG.md ;;
-    symlink)
-      mv "$R/CHANGELOG.md" "$R/record-target.md"
-      ln -s record-target.md "$R/CHANGELOG.md"
-      stage
-      ;;
-    gitlink)
-      oid="$(git -C "$R" rev-parse HEAD)"
-      git -C "$R" update-index --add --cacheinfo "160000,$oid,CHANGELOG.md"
-      ;;
-    binary) printf '\000' >>"$R/CHANGELOG.md"; stage ;;
-    utf8) printf '\377' >>"$R/CHANGELOG.md"; stage ;;
+    symlink) mv "$R/CHANGELOG.md" "$R/record-target.md"; ln -s record-target.md "$R/CHANGELOG.md"; git -C "$R" add -A ;;
+    gitlink) git -C "$R" update-index --add --cacheinfo "160000,$(git -C "$R" rev-parse HEAD),CHANGELOG.md" ;;
+    binary) printf '\000' >>"$R/CHANGELOG.md"; git -C "$R" add -A ;;
+    utf8) printf '\377' >>"$R/CHANGELOG.md"; git -C "$R" add -A ;;
   esac
   git -C "$R" commit -qm "prepare destination"
-  cp -L "$R/CHANGELOG.md" "$TMP/record-before"
-  cp "$R/changelog.d/fixed/pending.md" "$TMP/fragment-before"
-  index_before="$(git -C "$R" ls-files -s)"
-  run_ce --collate
-  [ "$RC" -eq 2 ] && case "$OUT" in *"CHANGELOG.md"*"$expected"*) true ;; *) false ;; esac \
-    && ok "$shape refuses collation with its cause" || bad "$shape refusal" "rc=$RC out=$OUT"
-  cmp -s "$R/CHANGELOG.md" "$TMP/record-before" && { [ "$shape" != symlink ] || { [ -L "$R/CHANGELOG.md" ] && [ "$(readlink "$R/CHANGELOG.md")" = record-target.md ]; }; } \
-    && ok "$shape preserves the record" || bad "$shape record preservation" "$OUT"
-  cmp -s "$R/changelog.d/fixed/pending.md" "$TMP/fragment-before" && [ "$(git -C "$R" ls-files -s)" = "$index_before" ] \
-    && ok "$shape preserves fragments and index" || bad "$shape fragment preservation" "$OUT"
-done
+}
+link() { if [ -L "$R/CHANGELOG.md" ] && [ "$(readlink "$R/CHANGELOG.md")" = record-target.md ]; then echo " link=same"; fi; }
+shape_rows() { # label | shape | expect
+  local row label sh expect
+  for row in "$@"; do
+    IFS='|' read -r label sh expect <<<"$row"
+    R=""
+    shape "destination-$sh" "$sh"
+    assert_eq "$label" "$expect" "$(run --collate)$(link)"
+  done
+}
+shape_rows \
+  "an untracked record is refused: commit it first|untracked|rc=2 ${ERR}CHANGELOG.md is not tracked; commit the collation destination first $UNTOUCHED" \
+  "a symlinked record is not a regular destination, and the link is kept|symlink|rc=2 ${ERR}CHANGELOG.md is not a regular collation destination $UNTOUCHED link=same" \
+  "a gitlink at the record's path is not a regular destination|gitlink|rc=2 ${ERR}CHANGELOG.md is not a regular collation destination $UNTOUCHED" \
+  "a record holding binary content is refused|binary|rc=2 ${ERR}CHANGELOG.md holds binary content; collation needs text $UNTOUCHED" \
+  "a record that is not valid UTF-8 is refused naming its line|utf8|rc=2 ${ERR}CHANGELOG.md line 4 is not valid UTF-8 — text with no character count cannot be measured $UNTOUCHED"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/commit-guards/tests/changelog-record.test.sh
+++ b/skills/commit-guards/tests/changelog-record.test.sh
@@ -88,7 +88,6 @@ UNTOUCHED="record=same fragment=same index=same"
 echo "=== the plain check reads fragments, never the record: any wording passes beside a valid fragment ==="
 rows '' \
   "a record with no Unreleased heading|# Release notes\n|rc=0 changelog-entries: OK — 1 fragment(s) within the cap (200 characters) $UNTOUCHED" \
-  "a record whose heading is reworded|# Changelog\n\n## Upcoming release\n\n- Reworded note.\n|rc=0 changelog-entries: OK — 1 fragment(s) within the cap (200 characters) $UNTOUCHED" \
   "a record with a paragraph under a foreign section|# Changelog\n\n## [Unreleased]\n\n### Details\n\nA new paragraph.\n|rc=0 changelog-entries: OK — 1 fragment(s) within the cap (200 characters) $UNTOUCHED"
 
 echo "=== control: a fragment's own structure still fails beside a reworded record ==="

--- a/skills/commit-guards/tests/changelog-record.test.sh
+++ b/skills/commit-guards/tests/changelog-record.test.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
-# Ordinary changelog edits are prose. Only collation reads the record format.
+# Pins for the record's place in the changelog family: ordinary changelog
+# edits are prose, and only collation reads the record format. Three tables:
+# a record wording beside a valid fragment, pinned by the plain check's exit
+# status and lines with the record byte-identical afterwards; a record shape
+# under --collate, pinned by the exit status and lines with the record and
+# the fragment untouched (the one usable shape folds, and is the control);
+# and a destination shape (untracked, symlink, gitlink, binary, not UTF-8)
+# under --collate, pinned by the refusal's cause with the record, the
+# fragment and the index untouched. The fold's own grammar is
+# changelog-collate.test.sh's; this file pins the refusals around it.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -7,113 +16,127 @@ SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 CE="$SKILL_DIR/scripts/changelog-entries"
 # shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
-
-# Hermetic: a leaked setting would mask every case below.
+# Hermetic: a leaked setting would mask every row below.
 unset COMMIT_GUARDS_CHANGELOG_CAP COMMIT_GUARDS_CHANGELOG_PATHS \
   COMMIT_GUARDS_CHANGELOG_RECORD COMMIT_GUARDS_CHANGELOG_COLLATE \
   COMMIT_GUARDS_SETTINGS_FILE 2>/dev/null || true
-
 export COMMIT_GUARDS_CHANGELOG_COLLATE=1
 
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
 
-new_repo() { # NAME — fresh fixture repo in $R
+# Fixture vocabulary: a fresh repository holding CHANGELOG.md with CONTENT
+# (printf %b) and one fragment, committed; a name used twice is refused.
+R=""
+FRAGMENT="changelog.d/fixed/pending.md"
+repo() { # NAME CONTENT [FRAGMENT-CONTENT]
   R="$TMP/$1"
-  mkdir -p "$R"
+  [ ! -e "$R" ] || { echo "harness: fixture $1 already exists" >&2; exit 2; }
+  mkdir -p "$R/changelog.d/fixed"
   git -C "$R" -c init.defaultBranch=main init -q
   git -C "$R" config user.email test@example.com
   git -C "$R" config user.name test
-}
-
-run_ce() { # [args...] — run in $R; sets OUT and RC
-  OUT=""
-  RC=0
-  OUT="$(cd "$R" && "$CE" "$@" 2>&1)" || RC=$?
-}
-
-stage() { git -C "$R" add -A; }
-
-frag() { # SECTION NAME — content on stdin, written and staged
-  mkdir -p "$R/changelog.d/$1"
-  cat >"$R/changelog.d/$1/$2"
-  stage
-}
-
-new_repo record
-printf '# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- Existing note.\n' >"$R/CHANGELOG.md"
-stage
-git -C "$R" commit -qm seed
-for text in '# Release notes' $'# Changelog\n\n## Upcoming release\n\n- Reworded note.' $'# Changelog\n\n## [Unreleased]\n\n### Details\n\nA new paragraph.'; do
-  printf '%s\n' "$text" >"$R/CHANGELOG.md"
-  stage
-  cp "$R/CHANGELOG.md" "$TMP/before.md"
-  run_ce
-  [ "$RC" -eq 0 ] && cmp -s "$R/CHANGELOG.md" "$TMP/before.md" \
-    && ok "record wording does not block fragment checks" || bad "record wording" "rc=$RC out=$OUT"
-done
-printf '%s\n' 'not a list item' | frag fixed invalid.md
-run_ce
-[ "$RC" -eq 1 ] && case "$OUT" in *"invalid.md"*"list marker"*) true ;; *) false ;; esac \
-  && ok "fragment structure still fails beside a reworded record" || bad "fragment control" "rc=$RC out=$OUT"
-printf '%s\n' '- A fixed defect.' | frag fixed invalid.md
-run_ce
-[ "$RC" -eq 0 ] && ok "the repaired fragment passes" || bad "fragment repair" "rc=$RC out=$OUT"
-
-for text in '# Release notes' $'# Log\n\n## [Unreleased]\n\n## [Unreleased]' $'# Log\n\n## [Unreleased]\n\n```\nunclosed' $'# Log\n\n## [Unreleased]\n\n### Details\n\n- Note.'; do
-  printf '%s\n' "$text" >"$R/CHANGELOG.md"
-  stage
-  cp "$R/CHANGELOG.md" "$TMP/before.md"
-  git -C "$R" commit -qm "prepare destination"
-  run_ce --collate
-  [ "$RC" -gt 0 ] && cmp -s "$R/CHANGELOG.md" "$TMP/before.md" && [ -f "$R/changelog.d/fixed/invalid.md" ] \
-    && ok "collation refuses an unusable destination without writes" || bad "collation destination" "rc=$RC out=$OUT"
-done
-printf '# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- Reworded note.\n' >"$R/CHANGELOG.md"
-stage
-git -C "$R" commit -qm "prepare destination"
-run_ce --collate
-[ "$RC" -eq 0 ] && [ ! -e "$R/changelog.d/fixed/invalid.md" ] && grep -Fxq -- '- A fixed defect.' "$R/CHANGELOG.md" && grep -Fxq -- '- Reworded note.' "$R/CHANGELOG.md" \
-  && ok "collation retains the edited notes and folds the fragment" || bad "collation control" "rc=$RC out=$OUT"
-
-echo "=== collation destination refusals preserve every input ==="
-for row in 'untracked|is not tracked; commit the collation destination first' 'symlink|not a regular collation destination' 'gitlink|not a regular collation destination' 'binary|holds binary content' 'utf8|not valid UTF-8'; do
-  shape="${row%%|*}"
-  expected="${row#*|}"
-  new_repo "destination-$shape"
-  mkdir -p "$R/changelog.d/fixed"
-  printf '# Changelog\n\n## [Unreleased]\n' >"$R/CHANGELOG.md"
-  printf '%s\n' '- A pending change.' >"$R/changelog.d/fixed/pending.md"
-  stage
+  printf '%b' "$2" >"$R/CHANGELOG.md"
+  printf '%b' "${3:-- A pending change.\n}" >"$R/$FRAGMENT"
+  git -C "$R" add -A
   git -C "$R" commit -qm fixture
-  case "$shape" in
+}
+# Tokens for what a run left behind: the record and the fragment compared
+# byte for byte with what the fixture wrote, the index with what it held.
+snapshot() { cp -L "$R/CHANGELOG.md" "$TMP/record-before"; cp "$R/$FRAGMENT" "$TMP/fragment-before"; git -C "$R" ls-files -s >"$TMP/index-before"; }
+left() { # — record=<same|changed> fragment=<same|gone|changed> index=<same|changed>
+  local record=changed fragment=changed index=changed
+  if cmp -s "$R/CHANGELOG.md" "$TMP/record-before"; then record=same; fi
+  if [ ! -e "$R/$FRAGMENT" ]; then fragment=gone; elif cmp -s "$R/$FRAGMENT" "$TMP/fragment-before"; then fragment=same; fi
+  if git -C "$R" ls-files -s | cmp -s - "$TMP/index-before"; then index=same; fi
+  printf 'record=%s fragment=%s index=%s' "$record" "$fragment" "$index"
+}
+# One line for a run: the exit status, every line printed joined by ';',
+# then what it left behind.
+run() { # ARGS...
+  local rc=0 out=""
+  snapshot
+  out="$(cd "$R" && "$CE" "$@" 2>&1)" || rc=$?
+  printf 'rc=%s%s %s' "$rc" "${out:+ $(printf '%s\n' "$out" | LC_ALL=C paste -sd ';' -)}" "$(left)"
+}
+ROW=0
+rows() { # MODE — label | content | expect; MODE is the plain check or --collate
+  local mode="$1" row label content expect
+  shift
+  for row in "$@"; do
+    IFS='|' read -r label content expect <<<"$row"
+    ROW=$((ROW + 1))
+    R=""
+    repo "row-$ROW" "$content"
+    # shellcheck disable=SC2086
+    assert_eq "$label" "$expect" "$(run $mode)"
+  done
+}
+ERR="::error::changelog-entries: "
+VIOLATION="changelog-entries: 1 violation(s) — cap 200 characters, 1 fragment(s) measured"
+UNTOUCHED="record=same fragment=same index=same"
+
+echo "=== the plain check reads fragments, never the record: any wording passes beside a valid fragment ==="
+rows '' \
+  "a record with no Unreleased heading|# Release notes\n|rc=0 changelog-entries: OK — 1 fragment(s) within the cap (200 characters) $UNTOUCHED" \
+  "a record whose heading is reworded|# Changelog\n\n## Upcoming release\n\n- Reworded note.\n|rc=0 changelog-entries: OK — 1 fragment(s) within the cap (200 characters) $UNTOUCHED" \
+  "a record with a paragraph under a foreign section|# Changelog\n\n## [Unreleased]\n\n### Details\n\nA new paragraph.\n|rc=0 changelog-entries: OK — 1 fragment(s) within the cap (200 characters) $UNTOUCHED"
+
+echo "=== control: a fragment's own structure still fails beside a reworded record ==="
+ROW=$((ROW + 1))
+repo "row-$ROW" '# Release notes\n' 'not a list item\n'
+assert_eq "a fragment that is not a list item fails naming it, the record untouched" \
+  "rc=1 changelog-entries FAIL $FRAGMENT does not open with a list marker — a fragment is the Markdown list item it becomes, opening with a hyphen and a space;changelog-entries: 1 violation(s) — cap 200 characters, 0 fragment(s) measured $UNTOUCHED" "$(run)"
+
+echo "=== collation reads the record: an unusable shape is refused without a write, a usable one folds ==="
+rows --collate \
+  "no Unreleased heading is a violation naming the remedy|# Release notes\n|rc=1 changelog-entries FAIL CHANGELOG.md carries no '## [Unreleased]' heading;  open one — a release folds the fragments into it and has nowhere to put them otherwise;$VIOLATION $UNTOUCHED" \
+  "two Unreleased headings cannot be decided between|# Log\n\n## [Unreleased]\n\n## [Unreleased]\n|rc=2 ${ERR}CHANGELOG.md carries more than one '## [Unreleased]' heading — which one is the section cannot be decided $UNTOUCHED" \
+  "an unclosed code fence hides the section|# Log\n\n## [Unreleased]\n\n\`\`\`\nunclosed\n|rc=2 ${ERR}CHANGELOG.md leaves a code fence unclosed — the [Unreleased] section cannot be located $UNTOUCHED" \
+  "a section name outside Keep a Changelog is a violation naming the set|# Log\n\n## [Unreleased]\n\n### Details\n\n- Note.\n|rc=1 changelog-entries FAIL CHANGELOG.md names 'Details' under [Unreleased], which is not a Keep a Changelog section;  section one of: added changed deprecated removed fixed security;$VIOLATION $UNTOUCHED" \
+  "control: a usable record folds the fragment and keeps its edited note|# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- Reworded note.\n|rc=0 changelog-entries: folded 1 entry into CHANGELOG.md's [Unreleased] section record=changed fragment=gone index=same"
+assert_eq "control: the fold appends the fragment under the edited note" \
+  "$(printf '# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- Reworded note.\n- A pending change.\n')" "$(cat "$R/CHANGELOG.md")"
+
+echo "=== collation destination shapes are refused with their cause, every input preserved ==="
+# Each shape is applied to a usable record after the fixture commit and
+# committed again, so the refusal is the destination's, not the grammar's.
+shape() { # NAME SHAPE
+  repo "$1" '# Changelog\n\n## [Unreleased]\n'
+  case "$2" in
     untracked) git -C "$R" rm -q --cached -- CHANGELOG.md ;;
-    symlink)
-      mv "$R/CHANGELOG.md" "$R/record-target.md"
-      ln -s record-target.md "$R/CHANGELOG.md"
-      stage
-      ;;
-    gitlink)
-      oid="$(git -C "$R" rev-parse HEAD)"
-      git -C "$R" update-index --add --cacheinfo "160000,$oid,CHANGELOG.md"
-      ;;
-    binary) printf '\000' >>"$R/CHANGELOG.md"; stage ;;
-    utf8) printf '\377' >>"$R/CHANGELOG.md"; stage ;;
+    symlink) mv "$R/CHANGELOG.md" "$R/record-target.md"; ln -s record-target.md "$R/CHANGELOG.md"; git -C "$R" add -A ;;
+    gitlink) git -C "$R" update-index --add --cacheinfo "160000,$(git -C "$R" rev-parse HEAD),CHANGELOG.md" ;;
+    binary) printf '\000' >>"$R/CHANGELOG.md"; git -C "$R" add -A ;;
+    utf8) printf '\377' >>"$R/CHANGELOG.md"; git -C "$R" add -A ;;
   esac
   git -C "$R" commit -qm "prepare destination"
-  cp -L "$R/CHANGELOG.md" "$TMP/record-before"
-  cp "$R/changelog.d/fixed/pending.md" "$TMP/fragment-before"
-  index_before="$(git -C "$R" ls-files -s)"
-  run_ce --collate
-  [ "$RC" -eq 2 ] && case "$OUT" in *"CHANGELOG.md"*"$expected"*) true ;; *) false ;; esac \
-    && ok "$shape refuses collation with its cause" || bad "$shape refusal" "rc=$RC out=$OUT"
-  cmp -s "$R/CHANGELOG.md" "$TMP/record-before" && { [ "$shape" != symlink ] || { [ -L "$R/CHANGELOG.md" ] && [ "$(readlink "$R/CHANGELOG.md")" = record-target.md ]; }; } \
-    && ok "$shape preserves the record" || bad "$shape record preservation" "$OUT"
-  cmp -s "$R/changelog.d/fixed/pending.md" "$TMP/fragment-before" && [ "$(git -C "$R" ls-files -s)" = "$index_before" ] \
-    && ok "$shape preserves fragments and index" || bad "$shape fragment preservation" "$OUT"
-done
+}
+link() { if [ -L "$R/CHANGELOG.md" ] && [ "$(readlink "$R/CHANGELOG.md")" = record-target.md ]; then echo " link=same"; fi; }
+shape_rows() { # label | shape | expect
+  local row label sh expect
+  for row in "$@"; do
+    IFS='|' read -r label sh expect <<<"$row"
+    R=""
+    shape "destination-$sh" "$sh"
+    assert_eq "$label" "$expect" "$(run --collate)$(link)"
+  done
+}
+shape_rows \
+  "an untracked record is refused: commit it first|untracked|rc=2 ${ERR}CHANGELOG.md is not tracked; commit the collation destination first $UNTOUCHED" \
+  "a symlinked record is not a regular destination, and the link is kept|symlink|rc=2 ${ERR}CHANGELOG.md is not a regular collation destination $UNTOUCHED link=same" \
+  "a gitlink at the record's path is not a regular destination|gitlink|rc=2 ${ERR}CHANGELOG.md is not a regular collation destination $UNTOUCHED" \
+  "a record holding binary content is refused|binary|rc=2 ${ERR}CHANGELOG.md holds binary content; collation needs text $UNTOUCHED" \
+  "a record that is not valid UTF-8 is refused naming its line|utf8|rc=2 ${ERR}CHANGELOG.md line 4 is not valid UTF-8 — text with no character count cannot be measured $UNTOUCHED"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Reshapes `skills/commit-guards/tests/changelog-record.test.sh` to code-quality § Tests.

The suite for the record's place in the changelog family (ordinary `scripts/changelog-entries` runs judge fragments and never read `CHANGELOG.md`; `--collate` reads the record through `scripts/lib/changelog-record-scope.sh` and folds the fragments in) was 119 lines and 25 assertions in loops over one long-lived repository: exit statuses read as bits beside substrings, and the wording loop ran with no fragment present, so the plain check it claimed to prove measured nothing. It is three tables now, each row in a fresh repository holding the record content and one fragment, committed. `run ARGS` snapshots the record, the fragment and the index first and pins `rc=N` with every line printed, then `record=<same|changed> fragment=<same|gone|changed> index=<same|changed>`, each a byte comparison with what the fixture wrote. Table one (the plain check): two wordings beside a valid fragment, each `OK — 1 fragment(s)` with everything untouched, then the control: a fragment that is not a list item fails naming it beside a reworded record. Table two (`--collate`): no `[Unreleased]` heading is a violation with its remedy; two headings and an unclosed fence are errors; a section outside Keep a Changelog is a violation naming the set; each with everything untouched; the control: a usable record folds (`record=changed fragment=gone index=same`, the committer stages) and the folded record is read back whole. Table three (`shape_rows`): a usable record with one destination shape applied and committed again (untracked, a symlink, a gitlink, a NUL appended, a byte that is not UTF-8) is refused with its cause and every input preserved, the symlink row also reading the link back. 25 to 14: the three wording iterations two rows (the reworded heading folded, see below), the invalid-then-repaired pair the control row, the four refusal iterations four rows, the fold control one row plus its read-back, the five shapes five rows each carrying the three preservation tokens the old loop checked one by one. The fold's own grammar is `changelog-collate.test.sh`'s (another lane's); this file pins the refusals around it, as before.

The tracked render is replayed with `patch`. Nothing about `.kendex-generated.json` changed.

## Mutation

9 exact-substring production mutants over `scripts/changelog-entries` and `scripts/lib/changelog-record-scope.sh` (`mutate-cr.py`, results `mutants-cr-2.txt` in the session scratchpad), run against the final suite in a scratch copy: 9 killed.

| mutant | result |
|---|---|
| plain: the record scope read without --collate | killed by "a record with no Unreleased heading" |
| record: an untracked record is accepted | killed by "an untracked record is refused: commit it first" |
| record: a non-regular mode is accepted | killed by "a symlinked record is not a regular destination, and the link is kept" |
| record: binary content is accepted | killed by "a record holding binary content is refused" |
| record: a missing heading is a hard error | killed by "no Unreleased heading is a violation naming the remedy" |
| record: two headings are a violation, not an error | killed by "two Unreleased headings cannot be decided between" |
| record: an unclosed fence is a violation, not an error | killed by "an unclosed code fence hides the section" |
| record: any section name accepted | killed by "a section name outside Keep a Changelog is a violation naming the set" |
| record: the missing-heading remedy dropped | killed by "no Unreleased heading is a violation naming the remedy" |

9 fixture mutants: 2 killed by a row, 5 abort the suite at the shape's second commit (nothing to commit), 2 fail many rows as expected.

| fixture mutant | result |
|---|---|
| F1 left: the record not compared | killed by "control: a usable record folds the fragment and keeps its edited note" |
| F2 left: the fragment not looked for | killed by the same row |
| F3 shape: the symlink not made | aborts the suite: the shape commit has nothing to commit |
| F4 shape: the gitlink not made | aborts the suite the same way |
| F5 shape: no NUL appended | aborts the suite the same way |
| F6 shape: no bad byte appended | aborts the suite the same way |
| F7 shape: the record still tracked | aborts the suite the same way |
| F8 fixture: no fragment beside the record | fails the two wording rows, the fragment control and the fold control |
| F9 collate: the setting not exported | fails the fold control and its read-back |

The reviewer round (`review-cr/REPORT-final.md`): accept. Its one fold taken: the reworded-heading wording row could not fail without the no-heading row failing first (the plain check never reads the record), so one of the two stays. Recorded, not pinned: `--collate` with no fragments never reaches the record scope, so an unusable record with nothing to fold is not refused; the empty COMMIT_GUARDS_CHANGELOG_RECORD refusal has no row anywhere; the foreign-section row overlaps one row of the collate suite (kept, this file's pins the whole line).

## Checks

- `changelog-record.test.sh`: 14 assertions on this host under TMPDIR=/tmp and a symlinked TMPDIR, and on a macOS box (bash 3.2.57). `tools/bash32-lint` clean over the tests directory.
- `tools/guard --full`: exit 0 on the first commit under TMPDIR=/tmp; the run on the rebased second commit was launched at PR time, CI is the verdict.
- One reviewer-test round: accept; its fold in the second commit.

KEN-1241

https://claude.ai/code/session_01ESWfqKsTYCo5LjWxeBmaKi
