### PR TITLE
test(KEN-1241): the worktree base directory as one table of rows

### DIFF
--- a/.agents/skills/worktree/tests/worktree_base_dir.sh
+++ b/.agents/skills/worktree/tests/worktree_base_dir.sh
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
-# Tests for an external default worktree base directory.
-# (<parent-of-checkout>/.worktrees/<checkout-name>), absolute and ~ overrides,
-# canonical (symlink-resolved) path comparisons, and compatibility with
-# worktrees registered under an older base-dir convention.
+# Where an issue's worktree lives: the default base directory beside the
+# checkout (<parent>/.worktrees/<checkout name>), the WORKTREE_BASE_DIR
+# overrides and where they are read from, the canonical (symlink-resolved)
+# comparison of the configured path with the registered one, the refusal of
+# another repository's worktree behind that path, the worktrees registered
+# under an older convention that every verb still resolves, and cleanup under
+# the default layout. One table, a row per scenario: the fixture is a word
+# list of steps that builds a checkout with its bare origin and drives it,
+# the command runs from the checkout under the row's environment, and the row
+# pins its exit status, its stdout, its stderr and what is left: every
+# registered worktree with its branch, the local branches beside main, the
+# remote's branch heads, the checkout's own branch and cleanliness, the
+# directories under the checkout's parent and every file or link under them.
 set -euo pipefail
 # A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
 # call below at the real repository; -C overrides neither.
@@ -15,6 +24,16 @@ trap 'rm -rf "$TMP_ROOT"' EXIT
 
 # Default resolution must come from the script, not an inherited override.
 unset WORKTREE_BASE_DIR
+
+# No open PRs anywhere in this file; ownership signals are local/remote refs.
+mkdir -p "$TMP_ROOT/bin"
+cat >"$TMP_ROOT/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$TMP_ROOT/bin/gh"
+export PATH="$TMP_ROOT/bin:$PATH"
+REAL_GIT="$(command -v git)"
 
 PASS=0
 FAIL=0
@@ -30,84 +49,19 @@ assert_eq() {
   fi
 }
 
-assert_contains() {
-  local haystack="$1" needle="$2" name="$3"
-  if grep -qF -- "$needle" <<<"$haystack"; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        wanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
-  fi
-}
+# --- fixtures -----------------------------------------------------------------
+# Every row's world lives under its own ROOT: the checkout at ROOT/<name>
+# (main unless the fixture says otherwise), its bare origin at
+# ROOT/origin-<name>.git, and whatever the row's layout puts beside them.
 
-assert_not_contains() {
-  local haystack="$1" needle="$2" name="$3"
-  if grep -qF -- "$needle" <<<"$haystack"; then
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        unwanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
-  else
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  fi
-}
+ROOT=""
+NAME=""
+MAIN=""
+ROW_PATH=""
+ROW_ENV=()
 
-assert_path_exists() {
-  local path="$1" name="$2"
-  if [[ -e "$path" ]]; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        missing path: %s\n' "$name" "$path"
-  fi
-}
-
-assert_path_absent() {
-  local path="$1" name="$2"
-  if [[ ! -e "$path" ]]; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        unexpected path: %s\n' "$name" "$path"
-  fi
-}
-
-assert_branch_absent() {
-  local repo="$1" branch="$2" name="$3"
-  if git -C "$repo" show-ref --verify --quiet "refs/heads/$branch"; then
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        unexpected branch: %s\n' "$name" "$branch"
-  else
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  fi
-}
-
-assert_branch_exists() {
-  local repo="$1" branch="$2" name="$3"
-  if git -C "$repo" show-ref --verify --quiet "refs/heads/$branch"; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        missing branch: %s\n' "$name" "$branch"
-  fi
-}
-
-# No open PRs anywhere in this file; ownership signals are local/remote refs.
-mkdir -p "$TMP_ROOT/bin"
-cat >"$TMP_ROOT/bin/gh" <<'STUB'
-#!/usr/bin/env bash
-exit 0
-STUB
-chmod +x "$TMP_ROOT/bin/gh"
-export PATH="$TMP_ROOT/bin:$PATH"
-
-# make_repo ROOT [NAME]: main checkout at ROOT/NAME with a bare origin.
 make_repo() {
-  local root="$1" name="${2:-main}"
+  local root="$1" name="$2"
   mkdir -p "$root/$name"
   git -C "$root/$name" init -q -b main
   git -C "$root/$name" config user.email test@example.com
@@ -121,216 +75,225 @@ make_repo() {
   git -C "$root/$name" push -q -u origin main
 }
 
-# merge_worktree_branch REPO WT BRANCH: give WT's branch a unique commit and
-# merge it into main, so `cleanup` sees merged work rather than a zero-commit
-# pending worktree.
-merge_worktree_branch() {
-  local repo="$1" wt="$2" branch="$3"
-  printf '%s\n' "$branch" >"$wt/$branch.txt"
-  git -C "$wt" add "$branch.txt"
-  git -C "$wt" commit -q -m "$branch: work"
-  git -C "$repo" merge -q --no-ff -m "merge $branch" "$branch"
-  git -C "$repo" push -q origin main
+tool() {
+  (cd "$MAIN" && "$WORKTREE_SCRIPT" "$@" >/dev/null 2>&1) || true
 }
 
-echo "=== default base dir: external .worktrees/<repo> beside the checkout ==="
+must() {
+  "$@" || { echo "FIXTURE: '$*' failed in $ROOT" >&2; exit 2; }
+}
 
-DEFAULT_ROOT="$TMP_ROOT/default"
-make_repo "$DEFAULT_ROOT" repo-a
-make_repo "$DEFAULT_ROOT" repo-b
+# The worktree the script resolves for an issue, wherever the layout put it.
+tree_of() {
+  (cd "$MAIN" && "$WORKTREE_SCRIPT" path "$1" 2>/dev/null)
+}
 
-default_path=$(cd "$DEFAULT_ROOT/repo-a" && "$WORKTREE_SCRIPT" path ISSUE-1)
-assert_eq "$default_path" "$DEFAULT_ROOT/.worktrees/repo-a/issue-1" "default resolves outside the repo to .worktrees/<repo>"
+# Give a worktree's branch a commit and merge it into main, so cleanup sees
+# merged work rather than a zero-commit pending worktree.
+merge_branch() {
+  local wt="$1" branch="$2"
+  [[ -d "$wt" ]] || { echo "FIXTURE: no worktree to merge at $wt" >&2; exit 2; }
+  printf '%s\n' "$branch" >"$wt/$branch.txt"
+  must git -C "$wt" add "$branch.txt"
+  must git -C "$wt" commit -q -m "$branch: work"
+  must git -C "$MAIN" merge -q --no-ff -m "merge $branch" "$branch"
+  must git -C "$MAIN" push -q origin main
+}
 
-sibling_path=$(cd "$DEFAULT_ROOT/repo-b" && "$WORKTREE_SCRIPT" path ISSUE-1)
-assert_eq "$sibling_path" "$DEFAULT_ROOT/.worktrees/repo-b/issue-1" "sibling repos get distinct default base dirs for the same ID"
-
-default_create_out=$(cd "$DEFAULT_ROOT/repo-a" && "$WORKTREE_SCRIPT" create issue-default)
-assert_eq "$default_create_out" "$DEFAULT_ROOT/.worktrees/repo-a/issue-default" "create lands in the default external base dir"
-assert_path_exists "$DEFAULT_ROOT/.worktrees/repo-a/issue-default/.git" "default-created worktree is registered"
-assert_path_absent "$DEFAULT_ROOT/repo-a/trees" "create adds nothing under the repo root"
-merge_worktree_branch "$DEFAULT_ROOT/repo-a" "$DEFAULT_ROOT/.worktrees/repo-a/issue-default" issue-default
-
-# cleanup parses the registry under the configured layout, excludes the main checkout
-# by canonical comparison, and removes merged worktrees before deleting their
-# checked-out branches.
-set +e
-(cd "$DEFAULT_ROOT/repo-a" && "$WORKTREE_SCRIPT" cleanup >"$DEFAULT_ROOT/cleanup.out" 2>"$DEFAULT_ROOT/cleanup.err")
-cleanup_code=$?
-set -e
-assert_eq "$cleanup_code" "0" "cleanup runs cleanly under the default external layout"
-assert_path_absent "$DEFAULT_ROOT/.worktrees/repo-a/issue-default" "cleanup removes a merged worktree whose branch was checked out"
-assert_branch_absent "$DEFAULT_ROOT/repo-a" "issue-default" "cleanup deletes the merged worktree branch after removal"
-assert_path_exists "$DEFAULT_ROOT/repo-a/base.txt" "cleanup never touches the main checkout"
-
-invalid_cleanup_path=$(cd "$DEFAULT_ROOT/repo-a" && "$WORKTREE_SCRIPT" create issue-invalid-cleanup)
-merge_worktree_branch "$DEFAULT_ROOT/repo-a" "$invalid_cleanup_path" issue-invalid-cleanup
-printf 'WORKTREE_SYMLINKS="../outside"\n' >"$DEFAULT_ROOT/repo-a/.env.local"
-set +e
-(cd "$DEFAULT_ROOT/repo-a" && "$WORKTREE_SCRIPT" cleanup >"$DEFAULT_ROOT/invalid-cleanup.out" 2>"$DEFAULT_ROOT/invalid-cleanup.err")
-invalid_cleanup_code=$?
-set -e
-assert_eq "$invalid_cleanup_code" "0" "cleanup does not depend on current setup-path configuration"
-assert_path_absent "$invalid_cleanup_path" "cleanup removes the intact merged worktree despite invalid setup config"
-assert_branch_absent "$DEFAULT_ROOT/repo-a" "issue-invalid-cleanup" "cleanup deletes the merged branch despite invalid setup config"
-rm -f "$DEFAULT_ROOT/repo-a/.env.local"
-
-REMOVE_FAIL_ROOT="$TMP_ROOT/remove-failure"
-make_repo "$REMOVE_FAIL_ROOT"
-printf 'TEST_SHARED="shared"\n' >"$REMOVE_FAIL_ROOT/main/.env.local"
-printf '[env]\nWORKTREE_SYMLINKS = ".env.local"\n' >"$REMOVE_FAIL_ROOT/main/kendex.settings.toml"
-remove_fail_path=$(cd "$REMOVE_FAIL_ROOT/main" && "$WORKTREE_SCRIPT" create issue-remove-failure)
-assert_eq "$(readlink "$remove_fail_path/.env.local")" "$REMOVE_FAIL_ROOT/main/.env.local" "removal-failure fixture starts with configured symlink intact"
-merge_worktree_branch "$REMOVE_FAIL_ROOT/main" "$remove_fail_path" issue-remove-failure
-mkdir -p "$REMOVE_FAIL_ROOT/bin"
-cat >"$REMOVE_FAIL_ROOT/bin/git" <<'STUB'
+# The step vocabulary. The first word builds the world; the rest drive it.
+step() {
+  case "$1" in
+    repo) make_repo "$ROOT" "$NAME" ;;
+    repo:*) NAME="${1#repo:}"; MAIN="$ROOT/$NAME"; make_repo "$ROOT" "$NAME" ;;
+    create:*) tool create "${1#create:}"; [[ -d "$(tree_of "${1#create:}")" ]] || { echo "FIXTURE: create ${1#create:} left no worktree in $ROOT" >&2; exit 2; } ;;
+    merge:*) merge_branch "$(tree_of "${1#merge:}")" "${1#merge:}" ;;
+    # The legacy rows address their layout directly, never through the tool
+    # under test, so a resolution defect reddens rows instead of aborting.
+    legacy-merge:*) merge_branch "$ROOT/trees/${1#legacy-merge:}" "${1#legacy-merge:}" ;;
+    legacy-commit:*)
+      printf 'work\n' >"$ROOT/trees/${1#legacy-commit:}/work.txt"
+      must git -C "$ROOT/trees/${1#legacy-commit:}" add work.txt
+      must git -C "$ROOT/trees/${1#legacy-commit:}" commit -q -m 'work'
+      ;;
+    # Setup config that create and fix-links would refuse; cleanup reads none of it.
+    bad-symlinks) printf 'WORKTREE_SYMLINKS="../outside"\n' >"$MAIN/.env.local" ;;
+    # A configured symlink, so a preserved worktree's links can be seen.
+    link-env)
+      printf 'TEST_SHARED="shared"\n' >"$MAIN/.env.local"
+      printf '[env]\nWORKTREE_SYMLINKS = ".env.local"\n' >"$MAIN/kendex.settings.toml"
+      ;;
+    # A git whose `worktree remove --force` of the named tree fails.
+    fail-remove:*)
+      mkdir -p "$ROOT/bin"
+      cat >"$ROOT/bin/git" <<EOF
 #!/usr/bin/env bash
-if [[ " $* " == *" worktree remove --force "* && "$*" == *"issue-remove-failure"* ]]; then
+if [[ " \$* " == *" worktree remove --force "* && "\$*" == *"${1#fail-remove:}"* ]]; then
   echo "simulated worktree removal failure" >&2
   exit 1
 fi
-exec "$REAL_GIT_BIN" "$@"
-STUB
-chmod +x "$REMOVE_FAIL_ROOT/bin/git"
-REAL_GIT_BIN="$(command -v git)"
-set +e
-(cd "$REMOVE_FAIL_ROOT/main" && PATH="$REMOVE_FAIL_ROOT/bin:$PATH" REAL_GIT_BIN="$REAL_GIT_BIN" "$WORKTREE_SCRIPT" cleanup >"$REMOVE_FAIL_ROOT/cleanup.out" 2>"$REMOVE_FAIL_ROOT/cleanup.err")
-remove_fail_code=$?
-set -e
-assert_eq "$remove_fail_code" "1" "cleanup reports git worktree removal failure"
-assert_contains "$(cat "$REMOVE_FAIL_ROOT/cleanup.err")" "preserving it for manual recovery" "cleanup explains that failed removal was preserved"
-assert_path_exists "$remove_fail_path/.git" "cleanup preserves a worktree that Git refused to remove"
-assert_eq "$(readlink "$remove_fail_path/.env.local")" "$REMOVE_FAIL_ROOT/main/.env.local" "cleanup failure preserves configured worktree symlinks"
-assert_branch_exists "$REMOVE_FAIL_ROOT/main" "issue-remove-failure" "cleanup preserves the branch when worktree removal fails"
-(cd "$REMOVE_FAIL_ROOT/main" && "$WORKTREE_SCRIPT" remove issue-remove-failure >/dev/null)
+exec "$REAL_GIT" "\$@"
+EOF
+      chmod +x "$ROOT/bin/git"
+      ROW_PATH="$ROOT/bin"
+      ;;
+    # WORKTREE_BASE_DIR from each place it is read, or not read.
+    env-file) printf 'WORKTREE_BASE_DIR="../from-env"\n' >"$MAIN/.env" ;;
+    settings) printf '[env]\nWORKTREE_BASE_DIR = "../from-settings"\n' >"$MAIN/kendex.settings.toml" ;;
+    local-slash) printf 'WORKTREE_BASE_DIR="%s/from-local/"\n' "$ROOT" >"$MAIN/.env.local" ;;
+    local-custom) printf 'WORKTREE_BASE_DIR="../custom-trees"\n' >"$MAIN/.env.local" ;;
+    # Compatibility shape: an in-repo `trees` symlink pointing at an external dir.
+    symlinked-base)
+      mkdir -p "$ROOT/real-trees"
+      ln -s "$ROOT/real-trees" "$MAIN/trees"
+      printf 'WORKTREE_BASE_DIR="trees"\n' >"$MAIN/.env.local"
+      ;;
+    # Another repository's worktree sits at the configured path for the ID.
+    foreign)
+      make_repo "$ROOT/other" main
+      git -C "$ROOT/other/main" worktree add -q -b issue-foreign "$ROOT/shared-trees/issue-foreign" main
+      printf 'keep\n' >"$ROOT/shared-trees/issue-foreign/marker"
+      printf 'secret\n' >"$ROOT/shared-trees/issue-foreign/.env.local"
+      printf '[env]\nWORKTREE_BASE_DIR = "../shared-trees"\nWORKTREE_SYMLINKS = ".env.local"\n' >"$MAIN/kendex.settings.toml"
+      ;;
+    # Older convention: a sibling trees/ dir, registered directly with git.
+    legacy:*) must git -C "$MAIN" worktree add -q -b "${1#legacy:}" "$ROOT/trees/${1#legacy:}" main ;;
+    *)
+      echo "UNKNOWN-STEP: $1" >&2
+      exit 2
+      ;;
+  esac
+}
 
-echo "=== explicit absolute and ~ overrides ==="
+build() {
+  local word
+  ROOT="$TMP_ROOT/$1"
+  shift
+  NAME=main
+  MAIN="$ROOT/main"
+  ROW_PATH=""
+  ROW_ENV=()
+  mkdir -p "$ROOT"
+  for word in "$@"; do
+    step "$word"
+  done
+}
 
-abs_path=$(cd "$DEFAULT_ROOT/repo-a" && WORKTREE_BASE_DIR="$DEFAULT_ROOT/abs-base" "$WORKTREE_SCRIPT" path ISSUE-2)
-assert_eq "$abs_path" "$DEFAULT_ROOT/abs-base/issue-2" "absolute WORKTREE_BASE_DIR is honored"
+# --- rendering ------------------------------------------------------------------
 
-mkdir -p "$DEFAULT_ROOT/home"
-tilde_path=$(cd "$DEFAULT_ROOT/repo-a" && HOME="$DEFAULT_ROOT/home" WORKTREE_BASE_DIR='~/wt' "$WORKTREE_SCRIPT" path ISSUE-2)
-assert_eq "$tilde_path" "$DEFAULT_ROOT/home/wt/issue-2" "~ WORKTREE_BASE_DIR expands against HOME"
+alias_text() {
+  sed -e "s|$MAIN|<main>|g" -e "s|$ROOT|<root>|g" -e "s|$WORKTREE_SCRIPT|<worktree>|g" \
+    -e '/^To <root>\/origin-[a-z-]*\.git$/d' -e "/^branch '.*' set up to track/d" -e '/^ [-!*+=t] \[/d' \
+    -e 's/;/\\;/g' |
+    paste -s -d ';' -
+}
 
-echo "=== canonical comparison through a symlinked base dir ==="
+state() {
+  local trees="" branches="" remote="" dirs="" files="" checkout="" path branch
+  while IFS= read -r path; do
+    [[ -n "$path" && "$path" != "$MAIN" ]] || continue
+    branch="$(git -C "$path" branch --show-current 2>/dev/null || printf '?')"
+    trees="$trees,$(printf '%s' "$path" | sed -e "s|$MAIN|<main>|" -e "s|$ROOT|<root>|")@${branch:-detached}"
+  done <<<"$(git -C "$MAIN" worktree list --porcelain | sed -n 's/^worktree //p')"
+  branches="$(git -C "$MAIN" for-each-ref --format='%(refname:short)' refs/heads | grep -vx main | paste -s -d ',' -)"
+  remote="$(git --git-dir="$ROOT/origin-$NAME.git" for-each-ref --format='%(refname:short)' refs/heads | grep -vx main | paste -s -d ',' -)"
+  dirs="$(cd "$ROOT" && find . -mindepth 1 -maxdepth 2 -type d ! -name '.git' ! -path './main' ! -path './main/.git*' ! -path './repo-b' ! -path './repo-b/.git*' ! -path './origin-*' ! -path './bin' ! -path './other*' | sed 's|^\./||' | LC_ALL=C sort | paste -s -d ',' -)"
+  files="$(cd "$ROOT" && find . -mindepth 2 -maxdepth 4 \( -type f -o -type l \) ! -name '.git' ! -path '*/.git/*' ! -path './main/*' ! -path './repo-b/*' ! -path './origin-*' ! -path './bin/*' ! -path './other/*' ! -name out ! -name err |
+    LC_ALL=C sort | while IFS= read -r path; do
+      if [[ -L "$path" ]]; then printf '%s->%s,' "${path#./}" "$(readlink "$path" | sed -e "s|$MAIN|<main>|" -e "s|$ROOT|<root>|")"; else printf '%s,' "${path#./}"; fi
+    done | sed 's/,$//')"
+  checkout="$(git -C "$MAIN" branch --show-current)@$([[ -z "$(git -C "$MAIN" status --porcelain --untracked-files=no)" ]] && printf clean || printf dirty)"
+  printf 'trees=%s branches=%s remote=%s checkout=%s dirs=%s files=%s' "${trees:-,-}" "${branches:--}" "${remote:--}" "$checkout" "${dirs:--}" "${files:--}" | sed 's/trees=,/trees=/'
+}
 
-SYM_ROOT="$TMP_ROOT/symlinked"
-make_repo "$SYM_ROOT"
-mkdir -p "$SYM_ROOT/real-trees"
-# Compatibility shape: an in-repo `trees` symlink pointing at an external dir.
-ln -s "$SYM_ROOT/real-trees" "$SYM_ROOT/main/trees"
-printf 'WORKTREE_BASE_DIR="trees"\n' >"$SYM_ROOT/main/.env.local"
+# The command runs from the checkout under the row's environment (`-u VAR`
+# entries unset, `VAR=value` entries set) and PATH prefix.
+run() {
+  local -a argv
+  local rc=0
+  read -r -a argv <<<"$1"
+  (cd "$MAIN" && env ${ROW_ENV[@]+"${ROW_ENV[@]}"} PATH="${ROW_PATH:+$ROW_PATH:}$PATH" "$WORKTREE_SCRIPT" "${argv[@]}" >"$ROOT/out" 2>"$ROOT/err") || rc=$?
+  printf 'rc=%s out=%s err=%s %s' "$rc" \
+    "$(alias_text <"$ROOT/out")" "$(alias_text <"$ROOT/err")" "$(state)"
+}
 
-sym_create_out=$(cd "$SYM_ROOT/main" && "$WORKTREE_SCRIPT" create issue-sym)
-assert_eq "$sym_create_out" "$SYM_ROOT/main/trees/issue-sym" "create reports the configured (symlinked) path"
-assert_path_exists "$SYM_ROOT/real-trees/issue-sym/.git" "worktree physically lands behind the symlink"
+# --- the expected text ----------------------------------------------------------
 
-# The same tree addressed through the symlinked spelling is active work, not a
-# foreign/incomplete target.
-set +e
-(cd "$SYM_ROOT/main" && "$WORKTREE_SCRIPT" create issue-sym >"$SYM_ROOT/again.out" 2>"$SYM_ROOT/again.err")
-sym_again_code=$?
-set -e
-sym_again_err="$(cat "$SYM_ROOT/again.err")"
-assert_eq "$sym_again_code" "75" "bare create through the symlink exits 75 for the owned tree"
-assert_contains "$sym_again_err" "Active work already exists" "symlinked spelling is recognized as the same tree"
-assert_not_contains "$sym_again_err" "not a registered worktree" "same tree is never treated as foreign"
+# The production text, held once. `active:<id>:<path>` is the active-work
+# refusal naming the worktree at the spelling the tool resolved; the other
+# specs carry the path they name after the colon.
+err_text() {
+  local spec="$1" id path
+  case "$spec" in
+    -) printf '' ;;
+    deleted:*) printf "Deleted branch '%s' — merged into origin/main." "${spec#deleted:}" ;;
+    active:*)
+      id="${spec#active:}"; path="${id#*:}"; id="${id%%:*}"
+      printf "Active work already exists for '%s'\\; refusing implicit reuse.;  Worktree: %s;  Branch: %s;  Working tree: clean;  Upstream: none (branch is unpublished or not tracking a remote);No local branch was rebased or modified.;Inspect or monitor the existing work instead of spawning another implementer.;If this session owns the worktree, opt in explicitly:;  <worktree> create %s --reuse;Use --restack instead only when intentionally resolving a rebase conflict." "$id" "$path" "$id" "$id" ;;
+    foreign-reuse:*) printf "Active or incomplete worktree path already exists for 'issue-foreign': %s;The exact path is not a registered worktree of <main>.;Refusing to delete, replace, or reuse it automatically. Inspect it, then remove it explicitly if abandoned." "${spec#foreign-reuse:}" ;;
+    foreign-remove:*) printf 'Error: %s is not a registered worktree of <main>\\; refusing to remove it.' "${spec#foreign-remove:}" ;;
+    no-paused:*) printf "Error: Restack state for %s is missing a paused rebase\\; refusing to run a rebase control command.;Only an exact paused state created by 'worktree create <ID> --restack' can be continued, skipped, or aborted." "${spec#no-paused:}" ;;
+    preserved:*) printf 'Error: Git could not remove merged worktree\\; preserving it for manual recovery: %s;  git: simulated worktree removal failure' "${spec#preserved:}" ;;
+    *) printf 'UNKNOWN-ERR-SPEC:%s' "$spec" ;;
+  esac
+}
 
-# Repoint the config at the physical dir: the tree registered under the
-# symlinked spelling must still be recognized and reusable in place.
-printf 'WORKTREE_BASE_DIR="%s"\n' "$SYM_ROOT/real-trees" >"$SYM_ROOT/main/.env.local"
-sym_reuse_out=$(cd "$SYM_ROOT/main" && "$WORKTREE_SCRIPT" create issue-sym --reuse)
-assert_eq "$sym_reuse_out" "$SYM_ROOT/real-trees/issue-sym" "--reuse recognizes the tree via its physical path"
+out_text() {
+  case "$1" in
+    -) printf '' ;;
+    removed:*) printf 'Removed: %s' "${1#removed:}" ;;
+    cleaned:*) printf 'Cleaned: %s' "${1#cleaned:}" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
 
-sym_remove_out=$(cd "$SYM_ROOT/main" && "$WORKTREE_SCRIPT" remove issue-sym)
-assert_eq "$sym_remove_out" "Removed: $SYM_ROOT/real-trees/issue-sym" "remove works via the physical path"
-assert_path_absent "$SYM_ROOT/real-trees/issue-sym" "removed worktree is gone from the physical dir"
-assert_branch_absent "$SYM_ROOT/main" "issue-sym" "removed merged branch is deleted"
+# --- the rows ---------------------------------------------------------------------
+# label|fixture|env|command|rc|out|err|state
+ROWS='the default base dir is .worktrees/<checkout name> beside the checkout|repo|-|path ISSUE-1|0|<root>/.worktrees/main/issue-1|-|trees=- branches=- remote=- checkout=main@clean dirs=- files=-
+sibling checkouts get distinct default base dirs for the same ID|repo:repo-b|-|path ISSUE-1|0|<root>/.worktrees/repo-b/issue-1|-|trees=- branches=- remote=- checkout=main@clean dirs=- files=-
+create lands in the default external base dir and adds nothing under the checkout|repo|-|create issue-default|0|<root>/.worktrees/main/issue-default|-|trees=<root>/.worktrees/main/issue-default@issue-default branches=issue-default remote=- checkout=main@clean dirs=.worktrees,.worktrees/main files=.worktrees/main/issue-default/base.txt
+an absolute WORKTREE_BASE_DIR is honoured|repo|WORKTREE_BASE_DIR=<root>/abs-base|path ISSUE-2|0|<root>/abs-base/issue-2|-|trees=- branches=- remote=- checkout=main@clean dirs=- files=-
+a ~ WORKTREE_BASE_DIR expands against HOME|repo|HOME=<root>/home WORKTREE_BASE_DIR=~/wt|path ISSUE-2|0|<root>/home/wt/issue-2|-|trees=- branches=- remote=- checkout=main@clean dirs=- files=-
+a .env WORKTREE_BASE_DIR is read by nothing|repo env-file|-|path ISSUE-CONFIG|0|<root>/.worktrees/main/issue-config|-|trees=- branches=- remote=- checkout=main@clean dirs=- files=-
+kendex.settings.toml sets WORKTREE_BASE_DIR while the .env value stays ignored|repo env-file settings|-|path ISSUE-CONFIG|0|<root>/from-settings/issue-config|-|trees=- branches=- remote=- checkout=main@clean dirs=- files=-
+.env.local overrides kendex.settings.toml, and a trailing slash is ignored|repo env-file settings local-slash|-|path ISSUE-CONFIG|0|<root>/from-local/issue-config|-|trees=- branches=- remote=- checkout=main@clean dirs=- files=-
+create writes the worktree under the configured base dir, not only the path helper|repo local-custom|-|create ISSUE-CUSTOM --from main|0|<root>/custom-trees/issue-custom|-|trees=<root>/custom-trees/issue-custom@issue-custom branches=issue-custom remote=- checkout=main@clean dirs=custom-trees,custom-trees/issue-custom files=custom-trees/issue-custom/base.txt
+create through a symlinked base reports the configured spelling and lands behind the link|repo symlinked-base|-|create issue-sym|0|<main>/trees/issue-sym|-|trees=<root>/real-trees/issue-sym@issue-sym branches=issue-sym remote=- checkout=main@clean dirs=real-trees,real-trees/issue-sym files=real-trees/issue-sym/base.txt
+the same tree addressed through the symlinked spelling is active work, not a foreign target|repo symlinked-base create:issue-sym|-|create issue-sym|75|-|active:issue-sym:<main>/trees/issue-sym|trees=<root>/real-trees/issue-sym@issue-sym branches=issue-sym remote=- checkout=main@clean dirs=real-trees,real-trees/issue-sym files=real-trees/issue-sym/base.txt
+--reuse through the symlinked spelling recognizes the registered tree behind it|repo symlinked-base create:issue-sym|-|create issue-sym --reuse|0|<main>/trees/issue-sym|-|trees=<root>/real-trees/issue-sym@issue-sym branches=issue-sym remote=- checkout=main@clean dirs=real-trees,real-trees/issue-sym files=real-trees/issue-sym/base.txt
+remove through the symlinked spelling removes the registered tree behind it|repo symlinked-base create:issue-sym merge:issue-sym|-|remove issue-sym|0|removed:<main>/trees/issue-sym|deleted:issue-sym|trees=- branches=- remote=- checkout=main@clean dirs=real-trees files=-
+--reuse refuses another repository'"'"'s worktree behind the configured path|repo foreign|-|create issue-foreign --reuse|75|-|foreign-reuse:<root>/shared-trees/issue-foreign|trees=- branches=- remote=- checkout=main@clean dirs=shared-trees,shared-trees/issue-foreign files=shared-trees/issue-foreign/.env.local,shared-trees/issue-foreign/base.txt,shared-trees/issue-foreign/marker
+remove refuses another repository'"'"'s worktree and leaves it untouched|repo foreign|-|remove issue-foreign|1|-|foreign-remove:<root>/shared-trees/issue-foreign|trees=- branches=- remote=- checkout=main@clean dirs=shared-trees,shared-trees/issue-foreign files=shared-trees/issue-foreign/.env.local,shared-trees/issue-foreign/base.txt,shared-trees/issue-foreign/marker
+path falls back to a worktree registered under the older convention|repo legacy:issue-legacy|-|path issue-legacy|0|<root>/trees/issue-legacy|-|trees=<root>/trees/issue-legacy@issue-legacy branches=issue-legacy remote=- checkout=main@clean dirs=trees,trees/issue-legacy files=trees/issue-legacy/base.txt
+exists sees the registered legacy worktree|repo legacy:issue-legacy|-|exists issue-legacy|0|true|-|trees=<root>/trees/issue-legacy@issue-legacy branches=issue-legacy remote=- checkout=main@clean dirs=trees,trees/issue-legacy files=trees/issue-legacy/base.txt
+bare create still refuses the active legacy worktree, naming its location|repo legacy:issue-legacy|-|create issue-legacy|75|-|active:issue-legacy:<root>/trees/issue-legacy|trees=<root>/trees/issue-legacy@issue-legacy branches=issue-legacy remote=- checkout=main@clean dirs=trees,trees/issue-legacy files=trees/issue-legacy/base.txt
+--reuse resolves to the legacy worktree unmoved|repo legacy:issue-legacy|-|create issue-legacy --reuse|0|<root>/trees/issue-legacy|-|trees=<root>/trees/issue-legacy@issue-legacy branches=issue-legacy remote=- checkout=main@clean dirs=trees,trees/issue-legacy files=trees/issue-legacy/base.txt
+a restack control resolves the ID to the legacy worktree and fails only on the missing paused state|repo legacy:issue-legacy|-|restack abort issue-legacy|1|-|no-paused:<root>/trees/issue-legacy|trees=<root>/trees/issue-legacy@issue-legacy branches=issue-legacy remote=- checkout=main@clean dirs=trees,trees/issue-legacy files=trees/issue-legacy/base.txt
+push resolves the ID to the legacy worktree and publishes its branch|repo legacy:issue-legacy legacy-commit:issue-legacy|-|push issue-legacy --no-rebase|0|-|-|trees=<root>/trees/issue-legacy@issue-legacy branches=issue-legacy remote=issue-legacy checkout=main@clean dirs=trees,trees/issue-legacy files=trees/issue-legacy/base.txt,trees/issue-legacy/work.txt
+new IDs land in the new default while legacy trees stay unmoved|repo legacy:issue-legacy|-|create issue-fresh|0|<root>/.worktrees/main/issue-fresh|-|trees=<root>/.worktrees/main/issue-fresh@issue-fresh,<root>/trees/issue-legacy@issue-legacy branches=issue-fresh,issue-legacy remote=- checkout=main@clean dirs=.worktrees,.worktrees/main,trees,trees/issue-legacy files=.worktrees/main/issue-fresh/base.txt,trees/issue-legacy/base.txt
+remove resolves the ID to the legacy worktree and deletes its merged branch|repo legacy:issue-legacy legacy-merge:issue-legacy|-|remove issue-legacy|0|removed:<root>/trees/issue-legacy|deleted:issue-legacy|trees=- branches=- remote=- checkout=main@clean dirs=trees files=-
+cleanup under the default layout removes the merged worktree and deletes its branch, never touching the checkout|repo create:issue-default merge:issue-default|-|cleanup|0|cleaned:<root>/.worktrees/main/issue-default|-|trees=- branches=- remote=- checkout=main@clean dirs=.worktrees,.worktrees/main files=-
+cleanup reads no setup config: an invalid WORKTREE_SYMLINKS does not stop it|repo create:issue-x merge:issue-x bad-symlinks|-|cleanup|0|cleaned:<root>/.worktrees/main/issue-x|-|trees=- branches=- remote=- checkout=main@clean dirs=.worktrees,.worktrees/main files=-
+a worktree git refuses to remove is preserved with its links and branch, and cleanup reports it|repo link-env create:issue-rf merge:issue-rf fail-remove:issue-rf|-|cleanup|1|-|preserved:<root>/.worktrees/main/issue-rf|trees=<root>/.worktrees/main/issue-rf@issue-rf branches=issue-rf remote=- checkout=main@clean dirs=.worktrees,.worktrees/main files=.worktrees/main/issue-rf/.env.local-><main>/.env.local,.worktrees/main/issue-rf/base.txt,.worktrees/main/issue-rf/issue-rf.txt
+'
 
-echo "=== foreign worktree behind the configured path is still refused ==="
-
-FOREIGN_ROOT="$TMP_ROOT/foreign"
-make_repo "$FOREIGN_ROOT"
-make_repo "$FOREIGN_ROOT/other"
-git -C "$FOREIGN_ROOT/other/main" worktree add -q -b issue-foreign "$FOREIGN_ROOT/shared-trees/issue-foreign" main
-printf 'keep\n' >"$FOREIGN_ROOT/shared-trees/issue-foreign/marker"
-printf 'secret\n' >"$FOREIGN_ROOT/shared-trees/issue-foreign/.env.local"
-printf '[env]\nWORKTREE_BASE_DIR = "../shared-trees"\nWORKTREE_SYMLINKS = ".env.local"\n' >"$FOREIGN_ROOT/main/kendex.settings.toml"
-
-set +e
-(cd "$FOREIGN_ROOT/main" && "$WORKTREE_SCRIPT" create issue-foreign --reuse >"$FOREIGN_ROOT/reuse.out" 2>"$FOREIGN_ROOT/reuse.err")
-foreign_reuse_code=$?
-set -e
-assert_eq "$foreign_reuse_code" "75" "--reuse exits 75 for another repository's worktree"
-assert_contains "$(cat "$FOREIGN_ROOT/reuse.err")" "not a registered worktree" "foreign tree is reported as unregistered, not reused"
-
-set +e
-(cd "$FOREIGN_ROOT/main" && "$WORKTREE_SCRIPT" remove issue-foreign >"$FOREIGN_ROOT/remove.out" 2>"$FOREIGN_ROOT/remove.err")
-foreign_remove_code=$?
-set -e
-assert_eq "$foreign_remove_code" "1" "remove refuses another repository's worktree"
-assert_contains "$(cat "$FOREIGN_ROOT/remove.err")" "refusing to remove" "remove names the refusal"
-assert_path_exists "$FOREIGN_ROOT/shared-trees/issue-foreign/.git" "foreign worktree registration is untouched"
-assert_path_exists "$FOREIGN_ROOT/shared-trees/issue-foreign/marker" "foreign worktree contents are untouched"
-assert_path_exists "$FOREIGN_ROOT/shared-trees/issue-foreign/.env.local" "foreign worktree keeps files matching configured symlink paths"
-
-echo "=== worktrees registered under an older base-dir convention keep working ==="
-
-LEGACY_ROOT="$TMP_ROOT/legacy"
-make_repo "$LEGACY_ROOT"
-# Legacy convention: sibling trees/ dir, registered directly with git.
-git -C "$LEGACY_ROOT/main" worktree add -q -b issue-legacy "$LEGACY_ROOT/trees/issue-legacy" main
-git -C "$LEGACY_ROOT/main" worktree add -q -b issue-legacy-rm "$LEGACY_ROOT/trees/issue-legacy-rm" main
-
-legacy_path=$(cd "$LEGACY_ROOT/main" && "$WORKTREE_SCRIPT" path issue-legacy)
-assert_eq "$legacy_path" "$LEGACY_ROOT/trees/issue-legacy" "path falls back to the registered legacy worktree"
-
-legacy_exists=$(cd "$LEGACY_ROOT/main" && "$WORKTREE_SCRIPT" exists issue-legacy)
-assert_eq "$legacy_exists" "true" "exists sees the registered legacy worktree"
-
-set +e
-(cd "$LEGACY_ROOT/main" && "$WORKTREE_SCRIPT" create issue-legacy >"$LEGACY_ROOT/create.out" 2>"$LEGACY_ROOT/create.err")
-legacy_create_code=$?
-set -e
-assert_eq "$legacy_create_code" "75" "bare create still refuses the active legacy worktree"
-assert_contains "$(cat "$LEGACY_ROOT/create.err")" "$LEGACY_ROOT/trees/issue-legacy" "refusal names the legacy location"
-
-legacy_reuse_out=$(cd "$LEGACY_ROOT/main" && "$WORKTREE_SCRIPT" create issue-legacy --reuse)
-assert_eq "$legacy_reuse_out" "$LEGACY_ROOT/trees/issue-legacy" "--reuse resolves to the legacy worktree unmoved"
-
-set +e
-legacy_restack_err="$(cd "$LEGACY_ROOT/main" && "$WORKTREE_SCRIPT" restack abort issue-legacy 2>&1)"
-legacy_restack_code=$?
-set -e
-assert_eq "$legacy_restack_code" "1" "restack control on a legacy tree fails only on missing paused state"
-assert_contains "$legacy_restack_err" "$LEGACY_ROOT/trees/issue-legacy" "restack resolves the ID to the legacy worktree"
-assert_contains "$legacy_restack_err" "missing a paused rebase" "restack refusal is the paused-state check, not resolution"
-
-printf 'legacy work\n' >"$LEGACY_ROOT/trees/issue-legacy/work.txt"
-git -C "$LEGACY_ROOT/trees/issue-legacy" add work.txt
-git -C "$LEGACY_ROOT/trees/issue-legacy" commit -q -m 'legacy work'
-set +e
-(cd "$LEGACY_ROOT/main" && "$WORKTREE_SCRIPT" push issue-legacy --no-rebase >"$LEGACY_ROOT/push.out" 2>"$LEGACY_ROOT/push.err")
-legacy_push_code=$?
-set -e
-assert_eq "$legacy_push_code" "0" "push resolves the ID to the legacy worktree"
-if git -C "$LEGACY_ROOT/main" ls-remote --exit-code --heads origin issue-legacy >/dev/null 2>&1; then
-  PASS=$((PASS + 1))
-  printf '  ok    push publishes the legacy worktree branch\n'
-else
-  FAIL=$((FAIL + 1))
-  printf '  FAIL  push publishes the legacy worktree branch\n'
-fi
-
-fresh_create_out=$(cd "$LEGACY_ROOT/main" && "$WORKTREE_SCRIPT" create issue-fresh)
-assert_eq "$fresh_create_out" "$LEGACY_ROOT/.worktrees/main/issue-fresh" "new IDs land in the new default while legacy trees drain"
-assert_path_exists "$LEGACY_ROOT/trees/issue-legacy/.git" "legacy worktree stays unmoved (no auto-migration)"
-
-legacy_remove_out=$(cd "$LEGACY_ROOT/main" && "$WORKTREE_SCRIPT" remove issue-legacy-rm)
-assert_eq "$legacy_remove_out" "Removed: $LEGACY_ROOT/trees/issue-legacy-rm" "remove resolves the ID to the legacy worktree"
-assert_path_absent "$LEGACY_ROOT/trees/issue-legacy-rm" "legacy worktree is removed"
-assert_branch_absent "$LEGACY_ROOT/main" "issue-legacy-rm" "legacy merged branch is deleted"
+echo "=== the worktree base directory ==="
+n=0
+while IFS='|' read -r label fixture envspec command rc out err want_state; do
+  [[ -n "$label$fixture$command$rc$out$err$want_state" ]] || continue
+  n=$((n + 1))
+  # shellcheck disable=SC2086
+  build "row-$n" $fixture
+  ROW_ENV=()
+  if [[ "$envspec" != - ]]; then
+    # shellcheck disable=SC2206
+    ROW_ENV=(${envspec//<root>/$ROOT})
+  fi
+  if [[ "${PROBE:-}" == 1 ]]; then
+    printf '%s => %s\n' "$label" "$(run "$command")"
+    continue
+  fi
+  assert_eq "$(run "$command")" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want_state" "$label"
+done <<<"$ROWS"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/.agents/skills/worktree/tests/worktree_remove.sh
+++ b/.agents/skills/worktree/tests/worktree_remove.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # `worktree remove`: the table below. The blocks after it (fix-links, the
-# Codex hooks, the configured base directory) are other surfaces that move
-# to their own suites as those are reshaped.
+# Codex hooks) are other surfaces that move to their own suites as those are
+# reshaped.
 set -euo pipefail
 # A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
 # call below at the real repository; -C overrides neither.
@@ -393,52 +393,6 @@ git -C "$NOENV_ROOT/main" worktree add -q -b issue-noenv "$NOENV_ROOT/trees/issu
 noenv_out=$(cd "$NOENV_ROOT/main" && "$WORKTREE_SCRIPT" fix-links "$NOENV_ROOT/trees/issue-noenv")
 assert_eq "$noenv_out" "Restored symlinks in $NOENV_ROOT/trees/issue-noenv" "fix-links works without .env.local symlink"
 assert_path_absent "$NOENV_ROOT/trees/issue-noenv/.env.local" ".env.local not linked unless configured"
-
-# WORKTREE_BASE_DIR can be set in kendex.settings.toml [env] or .env.local.
-# Relative values resolve from the main checkout; a .env file is read by
-# nothing, and .env.local overrides the settings files. Trailing slashes are
-# ignored.
-CONFIG_ROOT="$TMP_ROOT/config"
-make_repo "$CONFIG_ROOT/main"
-cat > "$CONFIG_ROOT/main/.env" <<'ENV'
-WORKTREE_BASE_DIR="../from-env"
-ENV
-config_path=$(cd "$CONFIG_ROOT/main" && "$WORKTREE_SCRIPT" path ISSUE-CONFIG)
-assert_eq "$config_path" "$CONFIG_ROOT/.worktrees/main/issue-config" "a .env WORKTREE_BASE_DIR is ignored; the default path stands"
-cat > "$CONFIG_ROOT/main/kendex.settings.toml" <<'TOML'
-[env]
-WORKTREE_BASE_DIR = "../from-settings"
-WORKTREE_MKDIRS = "tmp cache"
-TOML
-config_settings_path=$(cd "$CONFIG_ROOT/main" && "$WORKTREE_SCRIPT" path ISSUE-CONFIG)
-assert_eq "$config_settings_path" "$CONFIG_ROOT/from-settings/issue-config" "kendex.settings.toml WORKTREE_BASE_DIR applies while the .env value stays ignored"
-cat > "$CONFIG_ROOT/main/.env.local" <<ENV
-WORKTREE_BASE_DIR="$CONFIG_ROOT/from-local/"
-ENV
-config_local_path=$(cd "$CONFIG_ROOT/main" && "$WORKTREE_SCRIPT" path ISSUE-CONFIG)
-assert_eq "$config_local_path" "$CONFIG_ROOT/from-local/issue-config" ".env.local WORKTREE_BASE_DIR overrides kendex.settings.toml"
-
-# create uses the configured worktree parent directory, not only the path helper.
-CREATE_ROOT="$TMP_ROOT/create-custom"
-make_repo "$CREATE_ROOT/main"
-git init -q --bare "$CREATE_ROOT/origin.git"
-git -C "$CREATE_ROOT/main" remote add origin "$CREATE_ROOT/origin.git"
-git -C "$CREATE_ROOT/main" push -q -u origin main
-mkdir -p "$CREATE_ROOT/bin"
-cat >"$CREATE_ROOT/bin/gh" <<'STUB'
-#!/usr/bin/env bash
-set -euo pipefail
-case "${1:-}:${2:-}" in
-  pr:list) ;;
-esac
-STUB
-chmod +x "$CREATE_ROOT/bin/gh"
-cat > "$CREATE_ROOT/main/.env.local" <<'ENV'
-WORKTREE_BASE_DIR="../custom-trees"
-ENV
-custom_create_out=$(cd "$CREATE_ROOT/main" && PATH="$CREATE_ROOT/bin:$PATH" "$WORKTREE_SCRIPT" create ISSUE-CUSTOM --from main)
-assert_eq "$custom_create_out" "$CREATE_ROOT/custom-trees/issue-custom" "create reports configured WORKTREE_BASE_DIR path"
-assert_git_worktree "$CREATE_ROOT/custom-trees/issue-custom" "create writes worktree under configured WORKTREE_BASE_DIR"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/worktree/tests/worktree_base_dir.sh
+++ b/skills/worktree/tests/worktree_base_dir.sh
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
-# Tests for an external default worktree base directory.
-# (<parent-of-checkout>/.worktrees/<checkout-name>), absolute and ~ overrides,
-# canonical (symlink-resolved) path comparisons, and compatibility with
-# worktrees registered under an older base-dir convention.
+# Where an issue's worktree lives: the default base directory beside the
+# checkout (<parent>/.worktrees/<checkout name>), the WORKTREE_BASE_DIR
+# overrides and where they are read from, the canonical (symlink-resolved)
+# comparison of the configured path with the registered one, the refusal of
+# another repository's worktree behind that path, the worktrees registered
+# under an older convention that every verb still resolves, and cleanup under
+# the default layout. One table, a row per scenario: the fixture is a word
+# list of steps that builds a checkout with its bare origin and drives it,
+# the command runs from the checkout under the row's environment, and the row
+# pins its exit status, its stdout, its stderr and what is left: every
+# registered worktree with its branch, the local branches beside main, the
+# remote's branch heads, the checkout's own branch and cleanliness, the
+# directories under the checkout's parent and every file or link under them.
 set -euo pipefail
 # A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
 # call below at the real repository; -C overrides neither.
@@ -15,6 +24,16 @@ trap 'rm -rf "$TMP_ROOT"' EXIT
 
 # Default resolution must come from the script, not an inherited override.
 unset WORKTREE_BASE_DIR
+
+# No open PRs anywhere in this file; ownership signals are local/remote refs.
+mkdir -p "$TMP_ROOT/bin"
+cat >"$TMP_ROOT/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$TMP_ROOT/bin/gh"
+export PATH="$TMP_ROOT/bin:$PATH"
+REAL_GIT="$(command -v git)"
 
 PASS=0
 FAIL=0
@@ -30,84 +49,19 @@ assert_eq() {
   fi
 }
 
-assert_contains() {
-  local haystack="$1" needle="$2" name="$3"
-  if grep -qF -- "$needle" <<<"$haystack"; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        wanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
-  fi
-}
+# --- fixtures -----------------------------------------------------------------
+# Every row's world lives under its own ROOT: the checkout at ROOT/<name>
+# (main unless the fixture says otherwise), its bare origin at
+# ROOT/origin-<name>.git, and whatever the row's layout puts beside them.
 
-assert_not_contains() {
-  local haystack="$1" needle="$2" name="$3"
-  if grep -qF -- "$needle" <<<"$haystack"; then
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        unwanted substring: %s\n        in: %s\n' "$name" "$needle" "$haystack"
-  else
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  fi
-}
+ROOT=""
+NAME=""
+MAIN=""
+ROW_PATH=""
+ROW_ENV=()
 
-assert_path_exists() {
-  local path="$1" name="$2"
-  if [[ -e "$path" ]]; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        missing path: %s\n' "$name" "$path"
-  fi
-}
-
-assert_path_absent() {
-  local path="$1" name="$2"
-  if [[ ! -e "$path" ]]; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        unexpected path: %s\n' "$name" "$path"
-  fi
-}
-
-assert_branch_absent() {
-  local repo="$1" branch="$2" name="$3"
-  if git -C "$repo" show-ref --verify --quiet "refs/heads/$branch"; then
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        unexpected branch: %s\n' "$name" "$branch"
-  else
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  fi
-}
-
-assert_branch_exists() {
-  local repo="$1" branch="$2" name="$3"
-  if git -C "$repo" show-ref --verify --quiet "refs/heads/$branch"; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        missing branch: %s\n' "$name" "$branch"
-  fi
-}
-
-# No open PRs anywhere in this file; ownership signals are local/remote refs.
-mkdir -p "$TMP_ROOT/bin"
-cat >"$TMP_ROOT/bin/gh" <<'STUB'
-#!/usr/bin/env bash
-exit 0
-STUB
-chmod +x "$TMP_ROOT/bin/gh"
-export PATH="$TMP_ROOT/bin:$PATH"
-
-# make_repo ROOT [NAME]: main checkout at ROOT/NAME with a bare origin.
 make_repo() {
-  local root="$1" name="${2:-main}"
+  local root="$1" name="$2"
   mkdir -p "$root/$name"
   git -C "$root/$name" init -q -b main
   git -C "$root/$name" config user.email test@example.com
@@ -121,216 +75,225 @@ make_repo() {
   git -C "$root/$name" push -q -u origin main
 }
 
-# merge_worktree_branch REPO WT BRANCH: give WT's branch a unique commit and
-# merge it into main, so `cleanup` sees merged work rather than a zero-commit
-# pending worktree.
-merge_worktree_branch() {
-  local repo="$1" wt="$2" branch="$3"
-  printf '%s\n' "$branch" >"$wt/$branch.txt"
-  git -C "$wt" add "$branch.txt"
-  git -C "$wt" commit -q -m "$branch: work"
-  git -C "$repo" merge -q --no-ff -m "merge $branch" "$branch"
-  git -C "$repo" push -q origin main
+tool() {
+  (cd "$MAIN" && "$WORKTREE_SCRIPT" "$@" >/dev/null 2>&1) || true
 }
 
-echo "=== default base dir: external .worktrees/<repo> beside the checkout ==="
+must() {
+  "$@" || { echo "FIXTURE: '$*' failed in $ROOT" >&2; exit 2; }
+}
 
-DEFAULT_ROOT="$TMP_ROOT/default"
-make_repo "$DEFAULT_ROOT" repo-a
-make_repo "$DEFAULT_ROOT" repo-b
+# The worktree the script resolves for an issue, wherever the layout put it.
+tree_of() {
+  (cd "$MAIN" && "$WORKTREE_SCRIPT" path "$1" 2>/dev/null)
+}
 
-default_path=$(cd "$DEFAULT_ROOT/repo-a" && "$WORKTREE_SCRIPT" path ISSUE-1)
-assert_eq "$default_path" "$DEFAULT_ROOT/.worktrees/repo-a/issue-1" "default resolves outside the repo to .worktrees/<repo>"
+# Give a worktree's branch a commit and merge it into main, so cleanup sees
+# merged work rather than a zero-commit pending worktree.
+merge_branch() {
+  local wt="$1" branch="$2"
+  [[ -d "$wt" ]] || { echo "FIXTURE: no worktree to merge at $wt" >&2; exit 2; }
+  printf '%s\n' "$branch" >"$wt/$branch.txt"
+  must git -C "$wt" add "$branch.txt"
+  must git -C "$wt" commit -q -m "$branch: work"
+  must git -C "$MAIN" merge -q --no-ff -m "merge $branch" "$branch"
+  must git -C "$MAIN" push -q origin main
+}
 
-sibling_path=$(cd "$DEFAULT_ROOT/repo-b" && "$WORKTREE_SCRIPT" path ISSUE-1)
-assert_eq "$sibling_path" "$DEFAULT_ROOT/.worktrees/repo-b/issue-1" "sibling repos get distinct default base dirs for the same ID"
-
-default_create_out=$(cd "$DEFAULT_ROOT/repo-a" && "$WORKTREE_SCRIPT" create issue-default)
-assert_eq "$default_create_out" "$DEFAULT_ROOT/.worktrees/repo-a/issue-default" "create lands in the default external base dir"
-assert_path_exists "$DEFAULT_ROOT/.worktrees/repo-a/issue-default/.git" "default-created worktree is registered"
-assert_path_absent "$DEFAULT_ROOT/repo-a/trees" "create adds nothing under the repo root"
-merge_worktree_branch "$DEFAULT_ROOT/repo-a" "$DEFAULT_ROOT/.worktrees/repo-a/issue-default" issue-default
-
-# cleanup parses the registry under the configured layout, excludes the main checkout
-# by canonical comparison, and removes merged worktrees before deleting their
-# checked-out branches.
-set +e
-(cd "$DEFAULT_ROOT/repo-a" && "$WORKTREE_SCRIPT" cleanup >"$DEFAULT_ROOT/cleanup.out" 2>"$DEFAULT_ROOT/cleanup.err")
-cleanup_code=$?
-set -e
-assert_eq "$cleanup_code" "0" "cleanup runs cleanly under the default external layout"
-assert_path_absent "$DEFAULT_ROOT/.worktrees/repo-a/issue-default" "cleanup removes a merged worktree whose branch was checked out"
-assert_branch_absent "$DEFAULT_ROOT/repo-a" "issue-default" "cleanup deletes the merged worktree branch after removal"
-assert_path_exists "$DEFAULT_ROOT/repo-a/base.txt" "cleanup never touches the main checkout"
-
-invalid_cleanup_path=$(cd "$DEFAULT_ROOT/repo-a" && "$WORKTREE_SCRIPT" create issue-invalid-cleanup)
-merge_worktree_branch "$DEFAULT_ROOT/repo-a" "$invalid_cleanup_path" issue-invalid-cleanup
-printf 'WORKTREE_SYMLINKS="../outside"\n' >"$DEFAULT_ROOT/repo-a/.env.local"
-set +e
-(cd "$DEFAULT_ROOT/repo-a" && "$WORKTREE_SCRIPT" cleanup >"$DEFAULT_ROOT/invalid-cleanup.out" 2>"$DEFAULT_ROOT/invalid-cleanup.err")
-invalid_cleanup_code=$?
-set -e
-assert_eq "$invalid_cleanup_code" "0" "cleanup does not depend on current setup-path configuration"
-assert_path_absent "$invalid_cleanup_path" "cleanup removes the intact merged worktree despite invalid setup config"
-assert_branch_absent "$DEFAULT_ROOT/repo-a" "issue-invalid-cleanup" "cleanup deletes the merged branch despite invalid setup config"
-rm -f "$DEFAULT_ROOT/repo-a/.env.local"
-
-REMOVE_FAIL_ROOT="$TMP_ROOT/remove-failure"
-make_repo "$REMOVE_FAIL_ROOT"
-printf 'TEST_SHARED="shared"\n' >"$REMOVE_FAIL_ROOT/main/.env.local"
-printf '[env]\nWORKTREE_SYMLINKS = ".env.local"\n' >"$REMOVE_FAIL_ROOT/main/kendex.settings.toml"
-remove_fail_path=$(cd "$REMOVE_FAIL_ROOT/main" && "$WORKTREE_SCRIPT" create issue-remove-failure)
-assert_eq "$(readlink "$remove_fail_path/.env.local")" "$REMOVE_FAIL_ROOT/main/.env.local" "removal-failure fixture starts with configured symlink intact"
-merge_worktree_branch "$REMOVE_FAIL_ROOT/main" "$remove_fail_path" issue-remove-failure
-mkdir -p "$REMOVE_FAIL_ROOT/bin"
-cat >"$REMOVE_FAIL_ROOT/bin/git" <<'STUB'
+# The step vocabulary. The first word builds the world; the rest drive it.
+step() {
+  case "$1" in
+    repo) make_repo "$ROOT" "$NAME" ;;
+    repo:*) NAME="${1#repo:}"; MAIN="$ROOT/$NAME"; make_repo "$ROOT" "$NAME" ;;
+    create:*) tool create "${1#create:}"; [[ -d "$(tree_of "${1#create:}")" ]] || { echo "FIXTURE: create ${1#create:} left no worktree in $ROOT" >&2; exit 2; } ;;
+    merge:*) merge_branch "$(tree_of "${1#merge:}")" "${1#merge:}" ;;
+    # The legacy rows address their layout directly, never through the tool
+    # under test, so a resolution defect reddens rows instead of aborting.
+    legacy-merge:*) merge_branch "$ROOT/trees/${1#legacy-merge:}" "${1#legacy-merge:}" ;;
+    legacy-commit:*)
+      printf 'work\n' >"$ROOT/trees/${1#legacy-commit:}/work.txt"
+      must git -C "$ROOT/trees/${1#legacy-commit:}" add work.txt
+      must git -C "$ROOT/trees/${1#legacy-commit:}" commit -q -m 'work'
+      ;;
+    # Setup config that create and fix-links would refuse; cleanup reads none of it.
+    bad-symlinks) printf 'WORKTREE_SYMLINKS="../outside"\n' >"$MAIN/.env.local" ;;
+    # A configured symlink, so a preserved worktree's links can be seen.
+    link-env)
+      printf 'TEST_SHARED="shared"\n' >"$MAIN/.env.local"
+      printf '[env]\nWORKTREE_SYMLINKS = ".env.local"\n' >"$MAIN/kendex.settings.toml"
+      ;;
+    # A git whose `worktree remove --force` of the named tree fails.
+    fail-remove:*)
+      mkdir -p "$ROOT/bin"
+      cat >"$ROOT/bin/git" <<EOF
 #!/usr/bin/env bash
-if [[ " $* " == *" worktree remove --force "* && "$*" == *"issue-remove-failure"* ]]; then
+if [[ " \$* " == *" worktree remove --force "* && "\$*" == *"${1#fail-remove:}"* ]]; then
   echo "simulated worktree removal failure" >&2
   exit 1
 fi
-exec "$REAL_GIT_BIN" "$@"
-STUB
-chmod +x "$REMOVE_FAIL_ROOT/bin/git"
-REAL_GIT_BIN="$(command -v git)"
-set +e
-(cd "$REMOVE_FAIL_ROOT/main" && PATH="$REMOVE_FAIL_ROOT/bin:$PATH" REAL_GIT_BIN="$REAL_GIT_BIN" "$WORKTREE_SCRIPT" cleanup >"$REMOVE_FAIL_ROOT/cleanup.out" 2>"$REMOVE_FAIL_ROOT/cleanup.err")
-remove_fail_code=$?
-set -e
-assert_eq "$remove_fail_code" "1" "cleanup reports git worktree removal failure"
-assert_contains "$(cat "$REMOVE_FAIL_ROOT/cleanup.err")" "preserving it for manual recovery" "cleanup explains that failed removal was preserved"
-assert_path_exists "$remove_fail_path/.git" "cleanup preserves a worktree that Git refused to remove"
-assert_eq "$(readlink "$remove_fail_path/.env.local")" "$REMOVE_FAIL_ROOT/main/.env.local" "cleanup failure preserves configured worktree symlinks"
-assert_branch_exists "$REMOVE_FAIL_ROOT/main" "issue-remove-failure" "cleanup preserves the branch when worktree removal fails"
-(cd "$REMOVE_FAIL_ROOT/main" && "$WORKTREE_SCRIPT" remove issue-remove-failure >/dev/null)
+exec "$REAL_GIT" "\$@"
+EOF
+      chmod +x "$ROOT/bin/git"
+      ROW_PATH="$ROOT/bin"
+      ;;
+    # WORKTREE_BASE_DIR from each place it is read, or not read.
+    env-file) printf 'WORKTREE_BASE_DIR="../from-env"\n' >"$MAIN/.env" ;;
+    settings) printf '[env]\nWORKTREE_BASE_DIR = "../from-settings"\n' >"$MAIN/kendex.settings.toml" ;;
+    local-slash) printf 'WORKTREE_BASE_DIR="%s/from-local/"\n' "$ROOT" >"$MAIN/.env.local" ;;
+    local-custom) printf 'WORKTREE_BASE_DIR="../custom-trees"\n' >"$MAIN/.env.local" ;;
+    # Compatibility shape: an in-repo `trees` symlink pointing at an external dir.
+    symlinked-base)
+      mkdir -p "$ROOT/real-trees"
+      ln -s "$ROOT/real-trees" "$MAIN/trees"
+      printf 'WORKTREE_BASE_DIR="trees"\n' >"$MAIN/.env.local"
+      ;;
+    # Another repository's worktree sits at the configured path for the ID.
+    foreign)
+      make_repo "$ROOT/other" main
+      git -C "$ROOT/other/main" worktree add -q -b issue-foreign "$ROOT/shared-trees/issue-foreign" main
+      printf 'keep\n' >"$ROOT/shared-trees/issue-foreign/marker"
+      printf 'secret\n' >"$ROOT/shared-trees/issue-foreign/.env.local"
+      printf '[env]\nWORKTREE_BASE_DIR = "../shared-trees"\nWORKTREE_SYMLINKS = ".env.local"\n' >"$MAIN/kendex.settings.toml"
+      ;;
+    # Older convention: a sibling trees/ dir, registered directly with git.
+    legacy:*) must git -C "$MAIN" worktree add -q -b "${1#legacy:}" "$ROOT/trees/${1#legacy:}" main ;;
+    *)
+      echo "UNKNOWN-STEP: $1" >&2
+      exit 2
+      ;;
+  esac
+}
 
-echo "=== explicit absolute and ~ overrides ==="
+build() {
+  local word
+  ROOT="$TMP_ROOT/$1"
+  shift
+  NAME=main
+  MAIN="$ROOT/main"
+  ROW_PATH=""
+  ROW_ENV=()
+  mkdir -p "$ROOT"
+  for word in "$@"; do
+    step "$word"
+  done
+}
 
-abs_path=$(cd "$DEFAULT_ROOT/repo-a" && WORKTREE_BASE_DIR="$DEFAULT_ROOT/abs-base" "$WORKTREE_SCRIPT" path ISSUE-2)
-assert_eq "$abs_path" "$DEFAULT_ROOT/abs-base/issue-2" "absolute WORKTREE_BASE_DIR is honored"
+# --- rendering ------------------------------------------------------------------
 
-mkdir -p "$DEFAULT_ROOT/home"
-tilde_path=$(cd "$DEFAULT_ROOT/repo-a" && HOME="$DEFAULT_ROOT/home" WORKTREE_BASE_DIR='~/wt' "$WORKTREE_SCRIPT" path ISSUE-2)
-assert_eq "$tilde_path" "$DEFAULT_ROOT/home/wt/issue-2" "~ WORKTREE_BASE_DIR expands against HOME"
+alias_text() {
+  sed -e "s|$MAIN|<main>|g" -e "s|$ROOT|<root>|g" -e "s|$WORKTREE_SCRIPT|<worktree>|g" \
+    -e '/^To <root>\/origin-[a-z-]*\.git$/d' -e "/^branch '.*' set up to track/d" -e '/^ [-!*+=t] \[/d' \
+    -e 's/;/\\;/g' |
+    paste -s -d ';' -
+}
 
-echo "=== canonical comparison through a symlinked base dir ==="
+state() {
+  local trees="" branches="" remote="" dirs="" files="" checkout="" path branch
+  while IFS= read -r path; do
+    [[ -n "$path" && "$path" != "$MAIN" ]] || continue
+    branch="$(git -C "$path" branch --show-current 2>/dev/null || printf '?')"
+    trees="$trees,$(printf '%s' "$path" | sed -e "s|$MAIN|<main>|" -e "s|$ROOT|<root>|")@${branch:-detached}"
+  done <<<"$(git -C "$MAIN" worktree list --porcelain | sed -n 's/^worktree //p')"
+  branches="$(git -C "$MAIN" for-each-ref --format='%(refname:short)' refs/heads | grep -vx main | paste -s -d ',' -)"
+  remote="$(git --git-dir="$ROOT/origin-$NAME.git" for-each-ref --format='%(refname:short)' refs/heads | grep -vx main | paste -s -d ',' -)"
+  dirs="$(cd "$ROOT" && find . -mindepth 1 -maxdepth 2 -type d ! -name '.git' ! -path './main' ! -path './main/.git*' ! -path './repo-b' ! -path './repo-b/.git*' ! -path './origin-*' ! -path './bin' ! -path './other*' | sed 's|^\./||' | LC_ALL=C sort | paste -s -d ',' -)"
+  files="$(cd "$ROOT" && find . -mindepth 2 -maxdepth 4 \( -type f -o -type l \) ! -name '.git' ! -path '*/.git/*' ! -path './main/*' ! -path './repo-b/*' ! -path './origin-*' ! -path './bin/*' ! -path './other/*' ! -name out ! -name err |
+    LC_ALL=C sort | while IFS= read -r path; do
+      if [[ -L "$path" ]]; then printf '%s->%s,' "${path#./}" "$(readlink "$path" | sed -e "s|$MAIN|<main>|" -e "s|$ROOT|<root>|")"; else printf '%s,' "${path#./}"; fi
+    done | sed 's/,$//')"
+  checkout="$(git -C "$MAIN" branch --show-current)@$([[ -z "$(git -C "$MAIN" status --porcelain --untracked-files=no)" ]] && printf clean || printf dirty)"
+  printf 'trees=%s branches=%s remote=%s checkout=%s dirs=%s files=%s' "${trees:-,-}" "${branches:--}" "${remote:--}" "$checkout" "${dirs:--}" "${files:--}" | sed 's/trees=,/trees=/'
+}
 
-SYM_ROOT="$TMP_ROOT/symlinked"
-make_repo "$SYM_ROOT"
-mkdir -p "$SYM_ROOT/real-trees"
-# Compatibility shape: an in-repo `trees` symlink pointing at an external dir.
-ln -s "$SYM_ROOT/real-trees" "$SYM_ROOT/main/trees"
-printf 'WORKTREE_BASE_DIR="trees"\n' >"$SYM_ROOT/main/.env.local"
+# The command runs from the checkout under the row's environment (`-u VAR`
+# entries unset, `VAR=value` entries set) and PATH prefix.
+run() {
+  local -a argv
+  local rc=0
+  read -r -a argv <<<"$1"
+  (cd "$MAIN" && env ${ROW_ENV[@]+"${ROW_ENV[@]}"} PATH="${ROW_PATH:+$ROW_PATH:}$PATH" "$WORKTREE_SCRIPT" "${argv[@]}" >"$ROOT/out" 2>"$ROOT/err") || rc=$?
+  printf 'rc=%s out=%s err=%s %s' "$rc" \
+    "$(alias_text <"$ROOT/out")" "$(alias_text <"$ROOT/err")" "$(state)"
+}
 
-sym_create_out=$(cd "$SYM_ROOT/main" && "$WORKTREE_SCRIPT" create issue-sym)
-assert_eq "$sym_create_out" "$SYM_ROOT/main/trees/issue-sym" "create reports the configured (symlinked) path"
-assert_path_exists "$SYM_ROOT/real-trees/issue-sym/.git" "worktree physically lands behind the symlink"
+# --- the expected text ----------------------------------------------------------
 
-# The same tree addressed through the symlinked spelling is active work, not a
-# foreign/incomplete target.
-set +e
-(cd "$SYM_ROOT/main" && "$WORKTREE_SCRIPT" create issue-sym >"$SYM_ROOT/again.out" 2>"$SYM_ROOT/again.err")
-sym_again_code=$?
-set -e
-sym_again_err="$(cat "$SYM_ROOT/again.err")"
-assert_eq "$sym_again_code" "75" "bare create through the symlink exits 75 for the owned tree"
-assert_contains "$sym_again_err" "Active work already exists" "symlinked spelling is recognized as the same tree"
-assert_not_contains "$sym_again_err" "not a registered worktree" "same tree is never treated as foreign"
+# The production text, held once. `active:<id>:<path>` is the active-work
+# refusal naming the worktree at the spelling the tool resolved; the other
+# specs carry the path they name after the colon.
+err_text() {
+  local spec="$1" id path
+  case "$spec" in
+    -) printf '' ;;
+    deleted:*) printf "Deleted branch '%s' — merged into origin/main." "${spec#deleted:}" ;;
+    active:*)
+      id="${spec#active:}"; path="${id#*:}"; id="${id%%:*}"
+      printf "Active work already exists for '%s'\\; refusing implicit reuse.;  Worktree: %s;  Branch: %s;  Working tree: clean;  Upstream: none (branch is unpublished or not tracking a remote);No local branch was rebased or modified.;Inspect or monitor the existing work instead of spawning another implementer.;If this session owns the worktree, opt in explicitly:;  <worktree> create %s --reuse;Use --restack instead only when intentionally resolving a rebase conflict." "$id" "$path" "$id" "$id" ;;
+    foreign-reuse:*) printf "Active or incomplete worktree path already exists for 'issue-foreign': %s;The exact path is not a registered worktree of <main>.;Refusing to delete, replace, or reuse it automatically. Inspect it, then remove it explicitly if abandoned." "${spec#foreign-reuse:}" ;;
+    foreign-remove:*) printf 'Error: %s is not a registered worktree of <main>\\; refusing to remove it.' "${spec#foreign-remove:}" ;;
+    no-paused:*) printf "Error: Restack state for %s is missing a paused rebase\\; refusing to run a rebase control command.;Only an exact paused state created by 'worktree create <ID> --restack' can be continued, skipped, or aborted." "${spec#no-paused:}" ;;
+    preserved:*) printf 'Error: Git could not remove merged worktree\\; preserving it for manual recovery: %s;  git: simulated worktree removal failure' "${spec#preserved:}" ;;
+    *) printf 'UNKNOWN-ERR-SPEC:%s' "$spec" ;;
+  esac
+}
 
-# Repoint the config at the physical dir: the tree registered under the
-# symlinked spelling must still be recognized and reusable in place.
-printf 'WORKTREE_BASE_DIR="%s"\n' "$SYM_ROOT/real-trees" >"$SYM_ROOT/main/.env.local"
-sym_reuse_out=$(cd "$SYM_ROOT/main" && "$WORKTREE_SCRIPT" create issue-sym --reuse)
-assert_eq "$sym_reuse_out" "$SYM_ROOT/real-trees/issue-sym" "--reuse recognizes the tree via its physical path"
+out_text() {
+  case "$1" in
+    -) printf '' ;;
+    removed:*) printf 'Removed: %s' "${1#removed:}" ;;
+    cleaned:*) printf 'Cleaned: %s' "${1#cleaned:}" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
 
-sym_remove_out=$(cd "$SYM_ROOT/main" && "$WORKTREE_SCRIPT" remove issue-sym)
-assert_eq "$sym_remove_out" "Removed: $SYM_ROOT/real-trees/issue-sym" "remove works via the physical path"
-assert_path_absent "$SYM_ROOT/real-trees/issue-sym" "removed worktree is gone from the physical dir"
-assert_branch_absent "$SYM_ROOT/main" "issue-sym" "removed merged branch is deleted"
+# --- the rows ---------------------------------------------------------------------
+# label|fixture|env|command|rc|out|err|state
+ROWS='the default base dir is .worktrees/<checkout name> beside the checkout|repo|-|path ISSUE-1|0|<root>/.worktrees/main/issue-1|-|trees=- branches=- remote=- checkout=main@clean dirs=- files=-
+sibling checkouts get distinct default base dirs for the same ID|repo:repo-b|-|path ISSUE-1|0|<root>/.worktrees/repo-b/issue-1|-|trees=- branches=- remote=- checkout=main@clean dirs=- files=-
+create lands in the default external base dir and adds nothing under the checkout|repo|-|create issue-default|0|<root>/.worktrees/main/issue-default|-|trees=<root>/.worktrees/main/issue-default@issue-default branches=issue-default remote=- checkout=main@clean dirs=.worktrees,.worktrees/main files=.worktrees/main/issue-default/base.txt
+an absolute WORKTREE_BASE_DIR is honoured|repo|WORKTREE_BASE_DIR=<root>/abs-base|path ISSUE-2|0|<root>/abs-base/issue-2|-|trees=- branches=- remote=- checkout=main@clean dirs=- files=-
+a ~ WORKTREE_BASE_DIR expands against HOME|repo|HOME=<root>/home WORKTREE_BASE_DIR=~/wt|path ISSUE-2|0|<root>/home/wt/issue-2|-|trees=- branches=- remote=- checkout=main@clean dirs=- files=-
+a .env WORKTREE_BASE_DIR is read by nothing|repo env-file|-|path ISSUE-CONFIG|0|<root>/.worktrees/main/issue-config|-|trees=- branches=- remote=- checkout=main@clean dirs=- files=-
+kendex.settings.toml sets WORKTREE_BASE_DIR while the .env value stays ignored|repo env-file settings|-|path ISSUE-CONFIG|0|<root>/from-settings/issue-config|-|trees=- branches=- remote=- checkout=main@clean dirs=- files=-
+.env.local overrides kendex.settings.toml, and a trailing slash is ignored|repo env-file settings local-slash|-|path ISSUE-CONFIG|0|<root>/from-local/issue-config|-|trees=- branches=- remote=- checkout=main@clean dirs=- files=-
+create writes the worktree under the configured base dir, not only the path helper|repo local-custom|-|create ISSUE-CUSTOM --from main|0|<root>/custom-trees/issue-custom|-|trees=<root>/custom-trees/issue-custom@issue-custom branches=issue-custom remote=- checkout=main@clean dirs=custom-trees,custom-trees/issue-custom files=custom-trees/issue-custom/base.txt
+create through a symlinked base reports the configured spelling and lands behind the link|repo symlinked-base|-|create issue-sym|0|<main>/trees/issue-sym|-|trees=<root>/real-trees/issue-sym@issue-sym branches=issue-sym remote=- checkout=main@clean dirs=real-trees,real-trees/issue-sym files=real-trees/issue-sym/base.txt
+the same tree addressed through the symlinked spelling is active work, not a foreign target|repo symlinked-base create:issue-sym|-|create issue-sym|75|-|active:issue-sym:<main>/trees/issue-sym|trees=<root>/real-trees/issue-sym@issue-sym branches=issue-sym remote=- checkout=main@clean dirs=real-trees,real-trees/issue-sym files=real-trees/issue-sym/base.txt
+--reuse through the symlinked spelling recognizes the registered tree behind it|repo symlinked-base create:issue-sym|-|create issue-sym --reuse|0|<main>/trees/issue-sym|-|trees=<root>/real-trees/issue-sym@issue-sym branches=issue-sym remote=- checkout=main@clean dirs=real-trees,real-trees/issue-sym files=real-trees/issue-sym/base.txt
+remove through the symlinked spelling removes the registered tree behind it|repo symlinked-base create:issue-sym merge:issue-sym|-|remove issue-sym|0|removed:<main>/trees/issue-sym|deleted:issue-sym|trees=- branches=- remote=- checkout=main@clean dirs=real-trees files=-
+--reuse refuses another repository'"'"'s worktree behind the configured path|repo foreign|-|create issue-foreign --reuse|75|-|foreign-reuse:<root>/shared-trees/issue-foreign|trees=- branches=- remote=- checkout=main@clean dirs=shared-trees,shared-trees/issue-foreign files=shared-trees/issue-foreign/.env.local,shared-trees/issue-foreign/base.txt,shared-trees/issue-foreign/marker
+remove refuses another repository'"'"'s worktree and leaves it untouched|repo foreign|-|remove issue-foreign|1|-|foreign-remove:<root>/shared-trees/issue-foreign|trees=- branches=- remote=- checkout=main@clean dirs=shared-trees,shared-trees/issue-foreign files=shared-trees/issue-foreign/.env.local,shared-trees/issue-foreign/base.txt,shared-trees/issue-foreign/marker
+path falls back to a worktree registered under the older convention|repo legacy:issue-legacy|-|path issue-legacy|0|<root>/trees/issue-legacy|-|trees=<root>/trees/issue-legacy@issue-legacy branches=issue-legacy remote=- checkout=main@clean dirs=trees,trees/issue-legacy files=trees/issue-legacy/base.txt
+exists sees the registered legacy worktree|repo legacy:issue-legacy|-|exists issue-legacy|0|true|-|trees=<root>/trees/issue-legacy@issue-legacy branches=issue-legacy remote=- checkout=main@clean dirs=trees,trees/issue-legacy files=trees/issue-legacy/base.txt
+bare create still refuses the active legacy worktree, naming its location|repo legacy:issue-legacy|-|create issue-legacy|75|-|active:issue-legacy:<root>/trees/issue-legacy|trees=<root>/trees/issue-legacy@issue-legacy branches=issue-legacy remote=- checkout=main@clean dirs=trees,trees/issue-legacy files=trees/issue-legacy/base.txt
+--reuse resolves to the legacy worktree unmoved|repo legacy:issue-legacy|-|create issue-legacy --reuse|0|<root>/trees/issue-legacy|-|trees=<root>/trees/issue-legacy@issue-legacy branches=issue-legacy remote=- checkout=main@clean dirs=trees,trees/issue-legacy files=trees/issue-legacy/base.txt
+a restack control resolves the ID to the legacy worktree and fails only on the missing paused state|repo legacy:issue-legacy|-|restack abort issue-legacy|1|-|no-paused:<root>/trees/issue-legacy|trees=<root>/trees/issue-legacy@issue-legacy branches=issue-legacy remote=- checkout=main@clean dirs=trees,trees/issue-legacy files=trees/issue-legacy/base.txt
+push resolves the ID to the legacy worktree and publishes its branch|repo legacy:issue-legacy legacy-commit:issue-legacy|-|push issue-legacy --no-rebase|0|-|-|trees=<root>/trees/issue-legacy@issue-legacy branches=issue-legacy remote=issue-legacy checkout=main@clean dirs=trees,trees/issue-legacy files=trees/issue-legacy/base.txt,trees/issue-legacy/work.txt
+new IDs land in the new default while legacy trees stay unmoved|repo legacy:issue-legacy|-|create issue-fresh|0|<root>/.worktrees/main/issue-fresh|-|trees=<root>/.worktrees/main/issue-fresh@issue-fresh,<root>/trees/issue-legacy@issue-legacy branches=issue-fresh,issue-legacy remote=- checkout=main@clean dirs=.worktrees,.worktrees/main,trees,trees/issue-legacy files=.worktrees/main/issue-fresh/base.txt,trees/issue-legacy/base.txt
+remove resolves the ID to the legacy worktree and deletes its merged branch|repo legacy:issue-legacy legacy-merge:issue-legacy|-|remove issue-legacy|0|removed:<root>/trees/issue-legacy|deleted:issue-legacy|trees=- branches=- remote=- checkout=main@clean dirs=trees files=-
+cleanup under the default layout removes the merged worktree and deletes its branch, never touching the checkout|repo create:issue-default merge:issue-default|-|cleanup|0|cleaned:<root>/.worktrees/main/issue-default|-|trees=- branches=- remote=- checkout=main@clean dirs=.worktrees,.worktrees/main files=-
+cleanup reads no setup config: an invalid WORKTREE_SYMLINKS does not stop it|repo create:issue-x merge:issue-x bad-symlinks|-|cleanup|0|cleaned:<root>/.worktrees/main/issue-x|-|trees=- branches=- remote=- checkout=main@clean dirs=.worktrees,.worktrees/main files=-
+a worktree git refuses to remove is preserved with its links and branch, and cleanup reports it|repo link-env create:issue-rf merge:issue-rf fail-remove:issue-rf|-|cleanup|1|-|preserved:<root>/.worktrees/main/issue-rf|trees=<root>/.worktrees/main/issue-rf@issue-rf branches=issue-rf remote=- checkout=main@clean dirs=.worktrees,.worktrees/main files=.worktrees/main/issue-rf/.env.local-><main>/.env.local,.worktrees/main/issue-rf/base.txt,.worktrees/main/issue-rf/issue-rf.txt
+'
 
-echo "=== foreign worktree behind the configured path is still refused ==="
-
-FOREIGN_ROOT="$TMP_ROOT/foreign"
-make_repo "$FOREIGN_ROOT"
-make_repo "$FOREIGN_ROOT/other"
-git -C "$FOREIGN_ROOT/other/main" worktree add -q -b issue-foreign "$FOREIGN_ROOT/shared-trees/issue-foreign" main
-printf 'keep\n' >"$FOREIGN_ROOT/shared-trees/issue-foreign/marker"
-printf 'secret\n' >"$FOREIGN_ROOT/shared-trees/issue-foreign/.env.local"
-printf '[env]\nWORKTREE_BASE_DIR = "../shared-trees"\nWORKTREE_SYMLINKS = ".env.local"\n' >"$FOREIGN_ROOT/main/kendex.settings.toml"
-
-set +e
-(cd "$FOREIGN_ROOT/main" && "$WORKTREE_SCRIPT" create issue-foreign --reuse >"$FOREIGN_ROOT/reuse.out" 2>"$FOREIGN_ROOT/reuse.err")
-foreign_reuse_code=$?
-set -e
-assert_eq "$foreign_reuse_code" "75" "--reuse exits 75 for another repository's worktree"
-assert_contains "$(cat "$FOREIGN_ROOT/reuse.err")" "not a registered worktree" "foreign tree is reported as unregistered, not reused"
-
-set +e
-(cd "$FOREIGN_ROOT/main" && "$WORKTREE_SCRIPT" remove issue-foreign >"$FOREIGN_ROOT/remove.out" 2>"$FOREIGN_ROOT/remove.err")
-foreign_remove_code=$?
-set -e
-assert_eq "$foreign_remove_code" "1" "remove refuses another repository's worktree"
-assert_contains "$(cat "$FOREIGN_ROOT/remove.err")" "refusing to remove" "remove names the refusal"
-assert_path_exists "$FOREIGN_ROOT/shared-trees/issue-foreign/.git" "foreign worktree registration is untouched"
-assert_path_exists "$FOREIGN_ROOT/shared-trees/issue-foreign/marker" "foreign worktree contents are untouched"
-assert_path_exists "$FOREIGN_ROOT/shared-trees/issue-foreign/.env.local" "foreign worktree keeps files matching configured symlink paths"
-
-echo "=== worktrees registered under an older base-dir convention keep working ==="
-
-LEGACY_ROOT="$TMP_ROOT/legacy"
-make_repo "$LEGACY_ROOT"
-# Legacy convention: sibling trees/ dir, registered directly with git.
-git -C "$LEGACY_ROOT/main" worktree add -q -b issue-legacy "$LEGACY_ROOT/trees/issue-legacy" main
-git -C "$LEGACY_ROOT/main" worktree add -q -b issue-legacy-rm "$LEGACY_ROOT/trees/issue-legacy-rm" main
-
-legacy_path=$(cd "$LEGACY_ROOT/main" && "$WORKTREE_SCRIPT" path issue-legacy)
-assert_eq "$legacy_path" "$LEGACY_ROOT/trees/issue-legacy" "path falls back to the registered legacy worktree"
-
-legacy_exists=$(cd "$LEGACY_ROOT/main" && "$WORKTREE_SCRIPT" exists issue-legacy)
-assert_eq "$legacy_exists" "true" "exists sees the registered legacy worktree"
-
-set +e
-(cd "$LEGACY_ROOT/main" && "$WORKTREE_SCRIPT" create issue-legacy >"$LEGACY_ROOT/create.out" 2>"$LEGACY_ROOT/create.err")
-legacy_create_code=$?
-set -e
-assert_eq "$legacy_create_code" "75" "bare create still refuses the active legacy worktree"
-assert_contains "$(cat "$LEGACY_ROOT/create.err")" "$LEGACY_ROOT/trees/issue-legacy" "refusal names the legacy location"
-
-legacy_reuse_out=$(cd "$LEGACY_ROOT/main" && "$WORKTREE_SCRIPT" create issue-legacy --reuse)
-assert_eq "$legacy_reuse_out" "$LEGACY_ROOT/trees/issue-legacy" "--reuse resolves to the legacy worktree unmoved"
-
-set +e
-legacy_restack_err="$(cd "$LEGACY_ROOT/main" && "$WORKTREE_SCRIPT" restack abort issue-legacy 2>&1)"
-legacy_restack_code=$?
-set -e
-assert_eq "$legacy_restack_code" "1" "restack control on a legacy tree fails only on missing paused state"
-assert_contains "$legacy_restack_err" "$LEGACY_ROOT/trees/issue-legacy" "restack resolves the ID to the legacy worktree"
-assert_contains "$legacy_restack_err" "missing a paused rebase" "restack refusal is the paused-state check, not resolution"
-
-printf 'legacy work\n' >"$LEGACY_ROOT/trees/issue-legacy/work.txt"
-git -C "$LEGACY_ROOT/trees/issue-legacy" add work.txt
-git -C "$LEGACY_ROOT/trees/issue-legacy" commit -q -m 'legacy work'
-set +e
-(cd "$LEGACY_ROOT/main" && "$WORKTREE_SCRIPT" push issue-legacy --no-rebase >"$LEGACY_ROOT/push.out" 2>"$LEGACY_ROOT/push.err")
-legacy_push_code=$?
-set -e
-assert_eq "$legacy_push_code" "0" "push resolves the ID to the legacy worktree"
-if git -C "$LEGACY_ROOT/main" ls-remote --exit-code --heads origin issue-legacy >/dev/null 2>&1; then
-  PASS=$((PASS + 1))
-  printf '  ok    push publishes the legacy worktree branch\n'
-else
-  FAIL=$((FAIL + 1))
-  printf '  FAIL  push publishes the legacy worktree branch\n'
-fi
-
-fresh_create_out=$(cd "$LEGACY_ROOT/main" && "$WORKTREE_SCRIPT" create issue-fresh)
-assert_eq "$fresh_create_out" "$LEGACY_ROOT/.worktrees/main/issue-fresh" "new IDs land in the new default while legacy trees drain"
-assert_path_exists "$LEGACY_ROOT/trees/issue-legacy/.git" "legacy worktree stays unmoved (no auto-migration)"
-
-legacy_remove_out=$(cd "$LEGACY_ROOT/main" && "$WORKTREE_SCRIPT" remove issue-legacy-rm)
-assert_eq "$legacy_remove_out" "Removed: $LEGACY_ROOT/trees/issue-legacy-rm" "remove resolves the ID to the legacy worktree"
-assert_path_absent "$LEGACY_ROOT/trees/issue-legacy-rm" "legacy worktree is removed"
-assert_branch_absent "$LEGACY_ROOT/main" "issue-legacy-rm" "legacy merged branch is deleted"
+echo "=== the worktree base directory ==="
+n=0
+while IFS='|' read -r label fixture envspec command rc out err want_state; do
+  [[ -n "$label$fixture$command$rc$out$err$want_state" ]] || continue
+  n=$((n + 1))
+  # shellcheck disable=SC2086
+  build "row-$n" $fixture
+  ROW_ENV=()
+  if [[ "$envspec" != - ]]; then
+    # shellcheck disable=SC2206
+    ROW_ENV=(${envspec//<root>/$ROOT})
+  fi
+  if [[ "${PROBE:-}" == 1 ]]; then
+    printf '%s => %s\n' "$label" "$(run "$command")"
+    continue
+  fi
+  assert_eq "$(run "$command")" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want_state" "$label"
+done <<<"$ROWS"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/worktree/tests/worktree_remove.sh
+++ b/skills/worktree/tests/worktree_remove.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # `worktree remove`: the table below. The blocks after it (fix-links, the
-# Codex hooks, the configured base directory) are other surfaces that move
-# to their own suites as those are reshaped.
+# Codex hooks) are other surfaces that move to their own suites as those are
+# reshaped.
 set -euo pipefail
 # A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
 # call below at the real repository; -C overrides neither.
@@ -393,52 +393,6 @@ git -C "$NOENV_ROOT/main" worktree add -q -b issue-noenv "$NOENV_ROOT/trees/issu
 noenv_out=$(cd "$NOENV_ROOT/main" && "$WORKTREE_SCRIPT" fix-links "$NOENV_ROOT/trees/issue-noenv")
 assert_eq "$noenv_out" "Restored symlinks in $NOENV_ROOT/trees/issue-noenv" "fix-links works without .env.local symlink"
 assert_path_absent "$NOENV_ROOT/trees/issue-noenv/.env.local" ".env.local not linked unless configured"
-
-# WORKTREE_BASE_DIR can be set in kendex.settings.toml [env] or .env.local.
-# Relative values resolve from the main checkout; a .env file is read by
-# nothing, and .env.local overrides the settings files. Trailing slashes are
-# ignored.
-CONFIG_ROOT="$TMP_ROOT/config"
-make_repo "$CONFIG_ROOT/main"
-cat > "$CONFIG_ROOT/main/.env" <<'ENV'
-WORKTREE_BASE_DIR="../from-env"
-ENV
-config_path=$(cd "$CONFIG_ROOT/main" && "$WORKTREE_SCRIPT" path ISSUE-CONFIG)
-assert_eq "$config_path" "$CONFIG_ROOT/.worktrees/main/issue-config" "a .env WORKTREE_BASE_DIR is ignored; the default path stands"
-cat > "$CONFIG_ROOT/main/kendex.settings.toml" <<'TOML'
-[env]
-WORKTREE_BASE_DIR = "../from-settings"
-WORKTREE_MKDIRS = "tmp cache"
-TOML
-config_settings_path=$(cd "$CONFIG_ROOT/main" && "$WORKTREE_SCRIPT" path ISSUE-CONFIG)
-assert_eq "$config_settings_path" "$CONFIG_ROOT/from-settings/issue-config" "kendex.settings.toml WORKTREE_BASE_DIR applies while the .env value stays ignored"
-cat > "$CONFIG_ROOT/main/.env.local" <<ENV
-WORKTREE_BASE_DIR="$CONFIG_ROOT/from-local/"
-ENV
-config_local_path=$(cd "$CONFIG_ROOT/main" && "$WORKTREE_SCRIPT" path ISSUE-CONFIG)
-assert_eq "$config_local_path" "$CONFIG_ROOT/from-local/issue-config" ".env.local WORKTREE_BASE_DIR overrides kendex.settings.toml"
-
-# create uses the configured worktree parent directory, not only the path helper.
-CREATE_ROOT="$TMP_ROOT/create-custom"
-make_repo "$CREATE_ROOT/main"
-git init -q --bare "$CREATE_ROOT/origin.git"
-git -C "$CREATE_ROOT/main" remote add origin "$CREATE_ROOT/origin.git"
-git -C "$CREATE_ROOT/main" push -q -u origin main
-mkdir -p "$CREATE_ROOT/bin"
-cat >"$CREATE_ROOT/bin/gh" <<'STUB'
-#!/usr/bin/env bash
-set -euo pipefail
-case "${1:-}:${2:-}" in
-  pr:list) ;;
-esac
-STUB
-chmod +x "$CREATE_ROOT/bin/gh"
-cat > "$CREATE_ROOT/main/.env.local" <<'ENV'
-WORKTREE_BASE_DIR="../custom-trees"
-ENV
-custom_create_out=$(cd "$CREATE_ROOT/main" && PATH="$CREATE_ROOT/bin:$PATH" "$WORKTREE_SCRIPT" create ISSUE-CUSTOM --from main)
-assert_eq "$custom_create_out" "$CREATE_ROOT/custom-trees/issue-custom" "create reports configured WORKTREE_BASE_DIR path"
-assert_git_worktree "$CREATE_ROOT/custom-trees/issue-custom" "create writes worktree under configured WORKTREE_BASE_DIR"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"


### PR DESCRIPTION
Reshapes `skills/worktree/tests/worktree_base_dir.sh` to code-quality § Tests and moves the base-directory configuration cases into it from `worktree_remove.sh` (KEN-1241's multi-surface rule). The suite pinned the default base directory, its absolute and `~` overrides, the canonical comparison through a symlinked base, the refusal of another repository's worktree, the older registration convention and cleanup under the default layout in twenty long-lived scenarios over six shared worlds of substring, path and branch checks; `worktree_remove.sh` held the three configuration sources (a `.env` read by nothing, `kendex.settings.toml`, `.env.local` with a trailing slash) and the create-custom case. Those are now one table of 26 rows: a row builds its own checkout with its bare origin from a step word list (`repo` or `repo:<name>`, then `create:<id> merge:<id> commit:<id> env-file settings local-slash local-custom symlinked-base physical-base foreign legacy:<id> link-env bad-symlinks fail-remove:<id>`), runs one command from the checkout under the row's environment (`-` or `VAR=value` words, `<root>` expanded) and PATH prefix, and pins the exit status, stdout, stderr whole and what is left: every registered worktree with its branch, the local branches beside main, the remote's branch heads, the checkout's branch and tracked-file cleanliness, the directories beside the checkout at depth two and every file or link under them (a link with its target). Fixture steps that fail exit 2 with a `FIXTURE:` line. `worktree_remove.sh` keeps its remove, fix-links and Codex-hook surfaces.

The tracked renders under `.agents` are replayed with `patch`.

## Folded or deleted cases, with the surviving row

| Former assertions | Surviving row |
|---|---|
| default resolves outside the repo to .worktrees/<repo> | `the default base dir is .worktrees/<checkout name> beside the checkout` |
| sibling repos get distinct default base dirs for the same ID | `sibling checkouts get distinct default base dirs for the same ID` (`repo:repo-b`) |
| create lands in the default external base dir; the worktree is registered; nothing added under the repo root | `create lands in the default external base dir and adds nothing under the checkout` (`trees=`, `dirs=`, `files=`) |
| cleanup runs cleanly under the default layout; removes the merged worktree; deletes its branch; never touches the main checkout | `cleanup under the default layout removes the merged worktree and deletes its branch, never touching the checkout` (`checkout=main@clean`, `trees=- branches=-`) |
| cleanup does not depend on setup-path configuration; removes the worktree; deletes the branch | `cleanup reads no setup config: an invalid WORKTREE_SYMLINKS does not stop it` |
| the removal-failure fixture starts with its symlink intact | deleted: a fixture premise; the `files=` field of the surviving row renders the link with its target after the run |
| cleanup reports the removal failure (exit 1); explains the preservation; the worktree, its symlink and its branch survive | `a worktree git refuses to remove is preserved with its links and branch, and cleanup reports it` (`err=preserved:` whole with git's relayed line; `files=...issue-rf/.env.local-><main>/.env.local`) |
| absolute WORKTREE_BASE_DIR honored | `an absolute WORKTREE_BASE_DIR is honoured` |
| ~ WORKTREE_BASE_DIR expands against HOME | `a ~ WORKTREE_BASE_DIR expands against HOME` |
| create reports the configured (symlinked) path; the worktree lands behind the symlink | `create through a symlinked base reports the configured spelling and lands behind the link` (`out=<main>/trees/issue-sym`, `trees=<root>/real-trees/issue-sym@issue-sym`) |
| bare create through the symlink exits 75; "Active work already exists"; never "not a registered worktree" | `the same tree addressed through the symlinked spelling is active work, not a foreign target` (`err=active:issue-sym:<main>/trees/issue-sym` whole) |
| --reuse recognizes the tree via its physical path | `--reuse through the symlinked spelling recognizes the registered tree behind it` (the config keeps the symlinked spelling; git records the physical path, so the canonical comparison is what answers) |
| remove works via the physical path; the worktree gone; the merged branch deleted | `remove through the symlinked spelling removes the registered tree behind it` |
| --reuse exits 75 for another repository's worktree; reported as unregistered | `--reuse refuses another repository's worktree behind the configured path` (`err=foreign-reuse:` whole) |
| remove refuses another repository's worktree (exit 1); names the refusal; its registration, marker and .env.local untouched | `remove refuses another repository's worktree and leaves it untouched` (`files=shared-trees/issue-foreign/.env.local,...base.txt,...marker`) |
| path falls back to the registered legacy worktree | `path falls back to a worktree registered under the older convention` |
| exists sees the registered legacy worktree | `exists sees the registered legacy worktree` |
| bare create refuses the active legacy worktree (75); names the legacy location | `bare create still refuses the active legacy worktree, naming its location` (`err=active:issue-legacy:<root>/trees/issue-legacy`) |
| --reuse resolves to the legacy worktree unmoved | `--reuse resolves to the legacy worktree unmoved` |
| restack control on a legacy tree exits 1; names the legacy worktree; refuses on the paused state, not resolution | `a restack control resolves the ID to the legacy worktree and fails only on the missing paused state` (`err=no-paused:<root>/trees/issue-legacy` whole) |
| push resolves the ID to the legacy worktree; publishes its branch | `push resolves the ID to the legacy worktree and publishes its branch` (`remote=issue-legacy`) |
| new IDs land in the new default while legacy trees drain; the legacy worktree stays unmoved | `new IDs land in the new default while legacy trees stay unmoved` (both in `trees=`) |
| remove resolves the ID to the legacy worktree; the worktree removed; the merged branch deleted | `remove resolves the ID to the legacy worktree and deletes its merged branch` |
| (remove.sh) a .env WORKTREE_BASE_DIR is ignored; the default path stands | `a .env WORKTREE_BASE_DIR is read by nothing` |
| (remove.sh) kendex.settings.toml WORKTREE_BASE_DIR applies while the .env value stays ignored | `kendex.settings.toml sets WORKTREE_BASE_DIR while the .env value stays ignored` |
| (remove.sh) .env.local WORKTREE_BASE_DIR overrides kendex.settings.toml (with a trailing slash) | `.env.local overrides kendex.settings.toml, and a trailing slash is ignored` |
| (remove.sh) create reports the configured WORKTREE_BASE_DIR path; writes the worktree under it | `create writes the worktree under the configured base dir, not only the path helper` |

## Mutation

Twenty-six must-fail mutants over a scratch copy of `skills/worktree` (`mutants-bd-4.txt` in the lane scratchpad; `mutate-bd.py` makes them, each run in its own process group under a 300 s bound), all killed: the default base under the checkout, one default shared across checkouts, `~` unexpanded, an absolute override relativized, a trailing slash kept (with the parent normalisation that also drops it), `.env` read, the settings file not read, `.env.local` not read, the canonical comparison made lexical, another repository's worktree counted as registered (the registry lookup answering with the target and the common-dir check dropped together), remove's unregistered refusal dropped, the registered-branch fallback dropped, push and remove resolving through the configured path only, cleanup considering the main checkout, a failed removal silent, a failed removal still deleting the branch, cleanup validating the setup config, the active-work refusal naming the physical path, create and cleanup each leaving a directory under the checkout; and five fixture mutants (the symlinked base made a real directory, the foreign worktree made ours, the legacy tree not registered, the failing git made to succeed, the merge made a no-op). The legacy-not-registered fixture mutant aborts at the first legacy fixture step with a `FIXTURE:` line after reddening the five rows before it.

Reviewer blockers applied: the checkout's own directories are now rendered in `dirs=`, so a stray directory create or cleanup leaves under the checkout reddens the rows that claim none (the two checkout-touching mutants survived before, and each now kills); and the legacy rows' fixtures no longer ask the tool under test where the worktree is, so the fallback-dropped mutant reddens six rows and finishes instead of aborting the run (the push and remove rows now have per-verb kills). Suggestions applied: the `--reuse` and `remove` rows keep the symlinked spelling in force instead of repointing the config, so the canonical comparison is exercised by three rows; git's push report is dropped by its bracketed status, not by a bare prefix; every fixture step that can fail reports a `FIXTURE:` line; the inert `WORKTREE_MKDIRS` line left the settings step. Not applied: restoring "push" to `worktree_remove.sh`'s header, because #2335 cut that block from the file on main and the restack lands on that state. Recorded: the bare-create refusal against a legacy tree is satisfiable by two guards (the target-path guard with the fallback, the ownership scan without it); its label claims neither, and a later pass may fold it into the active-guard suite.

## Checks

- `worktree_base_dir.sh`: 26 assertions, TMPDIR=/var/tmp/ken-c; `shellcheck` clean on both; `tools/bash32-lint skills/worktree` clean; sources and renders byte-identical.
- `tools/guard --full`: exit 0 on 49fba6d36, the same tree before the restack onto 620629228 (TMPDIR=/var/tmp/ken-c); `worktree_remove.sh` 32/32 after the restack.
- One reviewer-test round: accept-with-fixes, both blockers and five of six suggestions applied as above.

KEN-1241

https://claude.ai/code/session_011qxNLABFza7z5QjT3aHFU3
