### PR TITLE
test(KEN-1241): the help dispatch as one table of rows

### DIFF
--- a/.agents/skills/worktree/tests/worktree_help_dispatch.sh
+++ b/.agents/skills/worktree/tests/worktree_help_dispatch.sh
@@ -1,22 +1,21 @@
 #!/usr/bin/env bash
-# Every worktree command's --help is answered, at any argv position, and the
-# top-level help states the settings loader's real precedence. check takes no
-# target: it inspects only the main checkout, and an argument is a usage
-# error rather than a silently ignored one.
-#
-# No form sources the project's .env.local, held here across every command
-# the dispatcher routes. tools/tests/help-inert.test.sh holds the same
-# contract for the top-level forms, alongside the other CLIs that each
-# carried their own copy of it.
-#
-# The same boundary from the other side: a command that is not help does
-# reach the repository lookup, and outside a repository it refuses with a
-# diagnostic naming the cwd rather than dying at git's bare 128.
+# The dispatcher's boundary: every command's help is answered at any argv
+# position before the repository lookup and the project env load, so no help
+# form sources the project's .env.local and none needs a repository; a
+# command that is not help does reach the lookup, and outside a repository
+# (or without git on PATH) it refuses once with git's own account rather than
+# dying at git's bare 128; check takes no target. One table, a row per
+# scenario: the row names where the command runs (the fixture checkout whose
+# .env.local records being sourced, a directory outside any repository, or
+# this directory with an empty PATH), runs one command, and pins its exit
+# status, its stdout's usage line and the lines carrying the loader's
+# precedence, the usage line path and exists share and check's contract,
+# its stderr whole, and whether the checkout's .env.local ran. tools/tests/help-inert.test.sh holds
+# the same contract for the top-level forms of every CLI.
 set -euo pipefail
-
 # A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
-# call in this file back at the real repository: the fixtures below would be
-# built in it, and the no-repository fixture would look like a repository.
+# call in this file back at the real repository: the fixture would be built
+# in it, and the no-repository directory would look like a repository.
 unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -38,156 +37,134 @@ assert_eq() {
   fi
 }
 
-assert_contains() {
-  local haystack="$1" needle="$2" name="$3"
-  if grep -qF -- "$needle" <<<"$haystack"; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        wanted substring: %s\n' "$name" "$needle"
-  fi
-}
+# --- fixtures -----------------------------------------------------------------
+# One checkout whose .env.local records being sourced, one directory outside
+# any repository (the ceiling keeps git from finding this repository above
+# it), and an empty PATH for the row that runs without git. The marker is
+# cleared before every row. Every row runs under LC_ALL=C: two rows quote
+# git's own account of a missing repository, which git translates.
 
-echo "=== worktree help dispatch runs before repository and env initialization ==="
-
-# A repo whose .env.local records that it was sourced. Any help invocation
-# that loads project config trips the marker.
 REPO="$TMP_ROOT/repo"
 mkdir -p "$REPO"
-git -C "$REPO" init -q
+git -C "$REPO" init -q -b main
 printf 'touch "%s/env-executed"\n' "$TMP_ROOT" >"$REPO/.env.local"
-
-for form in "--help" "-h" "help"; do
-  out=$(cd "$REPO" && "$WORKTREE_SCRIPT" "$form")
-  assert_eq "$?" 0 "worktree $form exits 0"
-  assert_contains "$out" "Usage: worktree <command>" "worktree $form prints the command index"
-done
-
-for cmd in restack create remove cleanup check list path exists push \
-  fix-links repair-links \
-  codex-setup codex-branch codex-cleanup claude-setup claude-cleanup; do
-  out=$(cd "$REPO" && "$WORKTREE_SCRIPT" "$cmd" --help)
-  assert_eq "$?" 0 "worktree $cmd --help exits 0"
-  [[ -n "$out" ]] || { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "worktree $cmd --help prints something"; }
-done
-
-out=$(cd "$REPO" && "$WORKTREE_SCRIPT" claude-setup --help)
-assert_contains "$out" "App-created worktree hooks" "hook commands share the app-hook help"
-
-# Help at ANY argv position, not only right after the command: enumerating
-# positions is how this class leaks.
-out=$(cd "$REPO" && "$WORKTREE_SCRIPT" remove CC-1 --help)
-assert_eq "$?" 0 "worktree remove CC-1 --help exits 0"
-assert_contains "$out" "Usage: worktree remove" "late --help prints the remove help"
-out=$(cd "$REPO" && "$WORKTREE_SCRIPT" cleanup --stale --help)
-assert_eq "$?" 0 "worktree cleanup --stale --help exits 0"
-assert_contains "$out" "Usage: worktree cleanup" "late --help prints the cleanup help"
-out=$(cd "$REPO" && "$WORKTREE_SCRIPT" push some-id -h)
-assert_eq "$?" 0 "worktree push some-id -h exits 0"
-assert_contains "$out" "Usage: worktree push" "late -h prints the push help"
-
-out=$(cd "$REPO" && "$WORKTREE_SCRIPT" list --help)
-assert_contains "$out" "Usage: worktree list" "list --help prints the list help"
-out=$(cd "$REPO" && "$WORKTREE_SCRIPT" path --help)
-assert_contains "$out" "Usage: worktree path" "path --help prints help, not an issue lookup"
-out=$(cd "$REPO" && "$WORKTREE_SCRIPT" exists -h)
-assert_contains "$out" "worktree exists" "exists -h prints help, not an issue lookup"
-
-# Every help form run inside $REPO is above this line except `check --help`,
-# which the 16-command loop already ran here — so the marker answers for all
-# of them at once.
-if [[ -e "$TMP_ROOT/env-executed" ]]; then
-  FAIL=$((FAIL + 1))
-  printf '  FAIL  %s\n' "help sourced the project .env.local"
-else
-  PASS=$((PASS + 1))
-  printf '  ok    %s\n' "no help form sourced the project .env.local"
-fi
-
-# Per-command help needs no repository at all. The top-level form is
-# tools/tests/help-inert.test.sh's; these three resolve a worktree when they
-# run, so their help is the one that could reach for a repository.
 NOREPO="$TMP_ROOT/norepo"
-mkdir -p "$NOREPO"
+mkdir -p "$NOREPO" "$TMP_ROOT/empty-bin"
 export GIT_CEILING_DIRECTORIES="$TMP_ROOT"
-norepo_status=0
-norepo_probe=$(LC_ALL=C git -C "$NOREPO" rev-parse --show-toplevel 2>&1) || norepo_status=$?
-if [[ "$norepo_status" -eq 0 ]]; then
-  FAIL=$((FAIL + 1))
-  printf '  FAIL  %s\n        got:      %s\n' \
-    "the no-repository fixture is outside a git repository" "$norepo_probe"
-elif [[ "$norepo_status" -eq 128 && "$norepo_probe" == *"not a git repository"* ]]; then
-  PASS=$((PASS + 1))
-  printf '  ok    %s\n' "the no-repository fixture is outside a git repository"
-  for cmd in list path exists; do
-    status=0
-    out=$(cd "$NOREPO" && "$WORKTREE_SCRIPT" "$cmd" --help) || status=$?
-    assert_eq "$status" 0 "worktree $cmd --help exits 0 outside a git repository"
-  done
-
-  # Past help, the repository lookup runs and has nothing to find. It refuses
-  # once, naming the cwd and the checkout to run from; `remove` is the form
-  # that gets run from the worktrees' parent, so it is held here too.
-  for cmd in "list" "remove ISSUE-GONE"; do
-    status=0
-    # shellcheck disable=SC2086
-    out=$(cd "$NOREPO" && "$WORKTREE_SCRIPT" $cmd 2>"$TMP_ROOT/norepo.err") || status=$?
-    err=$(cat "$TMP_ROOT/norepo.err")
-    assert_eq "$status" 1 "worktree $cmd exits 1 outside a git repository"
-    assert_contains "$err" "could not resolve a git repository from: $NOREPO" \
-      "worktree $cmd names the cwd it could not resolve a repository from"
-    assert_contains "$err" "Run it from a checkout of the repository you mean" \
-      "worktree $cmd names what to do instead"
-    # One refusal serves every non-help command, so its example names none: a
-    # subcommand baked in here is the wrong next step for the other callers,
-    # and `remove` deletes a worktree and a branch.
-    assert_contains "$err" "scripts/worktree <command>" \
-      "worktree $cmd offers a recovery example with no subcommand of its own"
-    assert_eq "$out" "" "worktree $cmd prints nothing on stdout outside a git repository"
-  done
-
-  # The cause is git's, not the script's guess at it. A repository with no git
-  # to read it is the case that separates the two: the cwd IS a checkout, and
-  # a message asserting otherwise sends the operator to a second one.
-  # LC_ALL=C like the probe above: the message under test is translated, so an
-  # unpinned locale reddens this on a workstation and nowhere else.
-  mkdir -p "$TMP_ROOT/empty-bin"
-  status=0
-  out=$(cd "$TEST_DIR" && LC_ALL=C PATH="$TMP_ROOT/empty-bin" "$WORKTREE_SCRIPT" list 2>"$TMP_ROOT/nogit.err") || status=$?
-  # Read the quoted line, not the whole stream: without the anchor the needle
-  # also matches the shell's own unredirected message, which is what stderr
-  # carries when the refusal quotes nothing at all.
-  said=""
-  if ! said=$(grep -F '  git said: ' "$TMP_ROOT/nogit.err"); then said=""; fi
-  assert_eq "$status" 1 "worktree list exits 1 when git is not on PATH"
-  assert_contains "$said" "git: command not found" \
-    "the refusal quotes git's own account rather than asserting a cause"
-  assert_eq "$out" "" "worktree list prints nothing on stdout when git is not on PATH"
-else
-  FAIL=$((FAIL + 1))
-  printf '  FAIL  %s\n        status:   %s\n        diagnostic: %s\n' \
-    "the no-repository fixture probe returns Git's expected result" "$norepo_status" "$norepo_probe"
+if LC_ALL=C git -C "$NOREPO" rev-parse --show-toplevel >/dev/null 2>&1; then
+  echo "FIXTURE: $NOREPO resolves a git repository" >&2
+  exit 2
 fi
 
-# The top-level help states the loader's real precedence, lowest to highest.
-out=$(cd "$NOREPO" && "$WORKTREE_SCRIPT" --help)
-assert_contains "$out" "kendex.settings.toml [env], then" "help orders the root settings file below the rest"
-assert_contains "$out" ".kendex/settings.toml" "help names the .kendex settings file"
-assert_contains "$out" "parent environment beats every project file" "help states parent env outranks project files"
+# --- rendering ------------------------------------------------------------------
+
+alias_text() {
+  sed -e "s|$NOREPO|<norepo>|g" -e "s|$REPO|<repo>|g" -e "s|$TEST_DIR|<tests>|g" -e "s|$WORKTREE_SCRIPT|<worktree>|g" -e 's/: line [0-9]*: /: line <n>: /' |
+    paste -s -d ';' -
+}
+
+# stdout: its first line, then the lines opening the loader's precedence
+# claim, the second usage line path and exists share, and check's contract
+# (help is prose; those are the lines the table pins). Then stderr whole,
+# then whether the checkout's .env.local ran.
+run() {
+  local -a argv
+  local where="$1" envspec="$2" rc=0 cwd="" out="" said=""
+  local -a env_words=()
+  read -r -a argv <<<"$3"
+  case "$where" in
+    repo) cwd="$REPO" ;;
+    norepo) cwd="$NOREPO" ;;
+    tests) cwd="$TEST_DIR" ;;
+    *) echo "UNKNOWN-CWD: $where" >&2; exit 2 ;;
+  esac
+  case "$envspec" in
+    -) ;;
+    nogit) env_words=("PATH=$TMP_ROOT/empty-bin") ;;
+    *) echo "UNKNOWN-ENV: $envspec" >&2; exit 2 ;;
+  esac
+  rm -f "$TMP_ROOT/env-executed"
+  (cd "$cwd" && env LC_ALL=C ${env_words[@]+"${env_words[@]}"} "$WORKTREE_SCRIPT" "${argv[@]}" >"$TMP_ROOT/out" 2>"$TMP_ROOT/err") || rc=$?
+  out="$(head -1 "$TMP_ROOT/out")"
+  said="$(grep -E '^(Configuration \(loaded|\.kendex/settings\.toml|parent environment beats|       worktree exists|Pre-create git state check)' "$TMP_ROOT/out" | paste -s -d ';' - || true)"
+  printf 'rc=%s out=%s says=%s err=%s env=%s' "$rc" "${out:--}" "${said:--}" "$(alias_text <"$TMP_ROOT/err")" \
+    "$([[ -e "$TMP_ROOT/env-executed" ]] && printf sourced || printf -)"
+}
+
+# --- the expected text ----------------------------------------------------------
+
+# The production text, held once.
+err_text() {
+  case "$1" in
+    -) printf '' ;;
+    no-repo) printf '%s' 'Error: could not resolve a git repository from: <norepo>;  git said: not a git repository (or any of the parent directories): .git;  Run it from a checkout of the repository you mean:;    cd <main checkout> && .agents/skills/worktree/scripts/worktree <command>' ;;
+    no-git) printf '%s' 'Error: could not resolve a git repository from: <tests>;  git said: <worktree>: line <n>: git: command not found;  Run it from a checkout of the repository you mean:;    cd <main checkout> && .agents/skills/worktree/scripts/worktree <command>' ;;
+    check-arg) printf 'Error: check takes no arguments — it inspects the main checkout' ;;
+    *) printf 'UNKNOWN-ERR-SPEC:%s' "$1" ;;
+  esac
+}
+
+says_text() {
+  case "$1" in
+    -) printf -- '-' ;;
+    precedence) printf 'Configuration (loaded lowest to highest: kendex.settings.toml [env], then;.kendex/settings.toml [env], then .env.local — later wins, and explicit;parent environment beats every project file; use .env.local for secrets or' ;;
+    path-exists) printf '%s' '       worktree exists <ID>' ;;
+    check) printf '%s' 'Pre-create git state check of the MAIN checkout (JSON: uncommitted,' ;;
+    *) printf 'UNKNOWN-SAYS-SPEC:%s' "$1" ;;
+  esac
+}
+
+# --- the rows ---------------------------------------------------------------------
+# label^cwd^env^command^rc^out^says^err^env-ran (^ because usage lines carry |)
+ROWS='--help prints the command index^repo^-^--help^0^Usage: worktree <command> [ID|/path] [options]^precedence^-^-
+-h prints the command index^repo^-^-h^0^Usage: worktree <command> [ID|/path] [options]^precedence^-^-
+help prints the command index^repo^-^help^0^Usage: worktree <command> [ID|/path] [options]^precedence^-^-
+restack --help^repo^-^restack --help^0^Usage: worktree restack continue|skip|abort [ID|/path]^-^-^-
+create --help^repo^-^create --help^0^Usage: worktree create <ID> [BRANCH] [options]^-^-^-
+remove --help^repo^-^remove --help^0^Usage: worktree remove [ID|/path]^-^-^-
+cleanup --help^repo^-^cleanup --help^0^Usage: worktree cleanup [--stale] [--ttl-minutes N]^-^-^-
+check --help says it inspects the main checkout^repo^-^check --help^0^Usage: worktree check^check^-^-
+list --help^repo^-^list --help^0^Usage: worktree list^-^-^-
+path --help prints help, not an issue lookup^repo^-^path --help^0^Usage: worktree path <ID>^path-exists^-^-
+exists -h prints help, not an issue lookup^repo^-^exists -h^0^Usage: worktree path <ID>^path-exists^-^-
+push --help^repo^-^push --help^0^Usage: worktree push [ID|/path] [--set-upstream|-u] [--no-rebase]^-^-^-
+fix-links --help^repo^-^fix-links --help^0^Usage: worktree fix-links [ID|/path]^-^-^-
+repair-links --help points at the fix-links contract^repo^-^repair-links --help^0^repair-links is the git-hook-driven variant of fix-links; the shared contract is under: worktree fix-links --help^-^-^-
+the five hook commands share the app-hook help^repo^-^codex-setup --help^0^Usage: worktree codex-setup    [PATH]^-^-^-
+codex-branch --help^repo^-^codex-branch --help^0^Usage: worktree codex-setup    [PATH]^-^-^-
+codex-cleanup --help^repo^-^codex-cleanup --help^0^Usage: worktree codex-setup    [PATH]^-^-^-
+claude-setup --help^repo^-^claude-setup --help^0^Usage: worktree codex-setup    [PATH]^-^-^-
+claude-cleanup --help^repo^-^claude-cleanup --help^0^Usage: worktree codex-setup    [PATH]^-^-^-
+--help after a positional prints the remove help^repo^-^remove CC-1 --help^0^Usage: worktree remove [ID|/path]^-^-^-
+--help after a flag prints the cleanup help^repo^-^cleanup --stale --help^0^Usage: worktree cleanup [--stale] [--ttl-minutes N]^-^-^-
+-h after a positional prints the push help^repo^-^push some-id -h^0^Usage: worktree push [ID|/path] [--set-upstream|-u] [--no-rebase]^-^-^-
+list --help needs no repository^norepo^-^list --help^0^Usage: worktree list^-^-^-
+path --help needs no repository^norepo^-^path --help^0^Usage: worktree path <ID>^path-exists^-^-
+exists --help needs no repository^norepo^-^exists --help^0^Usage: worktree path <ID>^path-exists^-^-
+the top-level help needs no repository^norepo^-^--help^0^Usage: worktree <command> [ID|/path] [options]^precedence^-^-
+list outside a repository refuses once, naming the cwd, git'"'"'s account and a recovery with no subcommand^norepo^-^list^1^-^-^no-repo^-
+remove outside a repository refuses the same way^norepo^-^remove ISSUE-GONE^1^-^-^no-repo^-
+list without git on PATH quotes git'"'"'s own account^tests^nogit^list^1^-^-^no-git^-
+check with an argument is a usage error^repo^-^check some-id^1^-^-^check-arg^sourced
+'
+
+echo "=== worktree help dispatch runs before repository and env initialization ==="
+while IFS= read -r row; do
+  [[ -n "$row" ]] || continue
+  IFS='^' read -r label where envspec command rc out says err envran <<<"$row"
+  for field in "$label" "$where" "$envspec" "$command" "$rc" "$out" "$says" "$err" "$envran"; do
+    [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+  done
+  # A rendering aid for writing rows: prints what each row produces instead of
+  # asserting it. A run that asserted no row is refused after the loop.
+  if [[ "${WORKTREE_TABLE_PROBE:-}" == 1 ]]; then
+    printf '%s => %s\n' "$label" "$(run "$where" "$envspec" "$command")"
+    continue
+  fi
+  assert_eq "$(run "$where" "$envspec" "$command")" "rc=$rc out=$out says=$(says_text "$says") err=$(err_text "$err") env=$envran" "$label"
+done <<<"$ROWS"
+[[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 
 echo
-echo "=== check takes no target ==="
-
-out=$(cd "$REPO" && "$WORKTREE_SCRIPT" check --help)
-assert_contains "$out" "MAIN checkout" "check --help says it inspects the main checkout"
-
-set +e
-err=$(cd "$REPO" && "$WORKTREE_SCRIPT" check some-id 2>&1)
-code=$?
-set -e
-assert_eq "$code" 1 "check with an argument exits 1"
-assert_contains "$err" "check takes no arguments" "check names the rejection"
-
-printf '\npass: %d   fail: %d\n' "$PASS" "$FAIL"
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/worktree/tests/worktree_help_dispatch.sh
+++ b/skills/worktree/tests/worktree_help_dispatch.sh
@@ -1,22 +1,21 @@
 #!/usr/bin/env bash
-# Every worktree command's --help is answered, at any argv position, and the
-# top-level help states the settings loader's real precedence. check takes no
-# target: it inspects only the main checkout, and an argument is a usage
-# error rather than a silently ignored one.
-#
-# No form sources the project's .env.local, held here across every command
-# the dispatcher routes. tools/tests/help-inert.test.sh holds the same
-# contract for the top-level forms, alongside the other CLIs that each
-# carried their own copy of it.
-#
-# The same boundary from the other side: a command that is not help does
-# reach the repository lookup, and outside a repository it refuses with a
-# diagnostic naming the cwd rather than dying at git's bare 128.
+# The dispatcher's boundary: every command's help is answered at any argv
+# position before the repository lookup and the project env load, so no help
+# form sources the project's .env.local and none needs a repository; a
+# command that is not help does reach the lookup, and outside a repository
+# (or without git on PATH) it refuses once with git's own account rather than
+# dying at git's bare 128; check takes no target. One table, a row per
+# scenario: the row names where the command runs (the fixture checkout whose
+# .env.local records being sourced, a directory outside any repository, or
+# this directory with an empty PATH), runs one command, and pins its exit
+# status, its stdout's usage line and the lines carrying the loader's
+# precedence, the usage line path and exists share and check's contract,
+# its stderr whole, and whether the checkout's .env.local ran. tools/tests/help-inert.test.sh holds
+# the same contract for the top-level forms of every CLI.
 set -euo pipefail
-
 # A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
-# call in this file back at the real repository: the fixtures below would be
-# built in it, and the no-repository fixture would look like a repository.
+# call in this file back at the real repository: the fixture would be built
+# in it, and the no-repository directory would look like a repository.
 unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -38,156 +37,134 @@ assert_eq() {
   fi
 }
 
-assert_contains() {
-  local haystack="$1" needle="$2" name="$3"
-  if grep -qF -- "$needle" <<<"$haystack"; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        wanted substring: %s\n' "$name" "$needle"
-  fi
-}
+# --- fixtures -----------------------------------------------------------------
+# One checkout whose .env.local records being sourced, one directory outside
+# any repository (the ceiling keeps git from finding this repository above
+# it), and an empty PATH for the row that runs without git. The marker is
+# cleared before every row. Every row runs under LC_ALL=C: two rows quote
+# git's own account of a missing repository, which git translates.
 
-echo "=== worktree help dispatch runs before repository and env initialization ==="
-
-# A repo whose .env.local records that it was sourced. Any help invocation
-# that loads project config trips the marker.
 REPO="$TMP_ROOT/repo"
 mkdir -p "$REPO"
-git -C "$REPO" init -q
+git -C "$REPO" init -q -b main
 printf 'touch "%s/env-executed"\n' "$TMP_ROOT" >"$REPO/.env.local"
-
-for form in "--help" "-h" "help"; do
-  out=$(cd "$REPO" && "$WORKTREE_SCRIPT" "$form")
-  assert_eq "$?" 0 "worktree $form exits 0"
-  assert_contains "$out" "Usage: worktree <command>" "worktree $form prints the command index"
-done
-
-for cmd in restack create remove cleanup check list path exists push \
-  fix-links repair-links \
-  codex-setup codex-branch codex-cleanup claude-setup claude-cleanup; do
-  out=$(cd "$REPO" && "$WORKTREE_SCRIPT" "$cmd" --help)
-  assert_eq "$?" 0 "worktree $cmd --help exits 0"
-  [[ -n "$out" ]] || { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "worktree $cmd --help prints something"; }
-done
-
-out=$(cd "$REPO" && "$WORKTREE_SCRIPT" claude-setup --help)
-assert_contains "$out" "App-created worktree hooks" "hook commands share the app-hook help"
-
-# Help at ANY argv position, not only right after the command: enumerating
-# positions is how this class leaks.
-out=$(cd "$REPO" && "$WORKTREE_SCRIPT" remove CC-1 --help)
-assert_eq "$?" 0 "worktree remove CC-1 --help exits 0"
-assert_contains "$out" "Usage: worktree remove" "late --help prints the remove help"
-out=$(cd "$REPO" && "$WORKTREE_SCRIPT" cleanup --stale --help)
-assert_eq "$?" 0 "worktree cleanup --stale --help exits 0"
-assert_contains "$out" "Usage: worktree cleanup" "late --help prints the cleanup help"
-out=$(cd "$REPO" && "$WORKTREE_SCRIPT" push some-id -h)
-assert_eq "$?" 0 "worktree push some-id -h exits 0"
-assert_contains "$out" "Usage: worktree push" "late -h prints the push help"
-
-out=$(cd "$REPO" && "$WORKTREE_SCRIPT" list --help)
-assert_contains "$out" "Usage: worktree list" "list --help prints the list help"
-out=$(cd "$REPO" && "$WORKTREE_SCRIPT" path --help)
-assert_contains "$out" "Usage: worktree path" "path --help prints help, not an issue lookup"
-out=$(cd "$REPO" && "$WORKTREE_SCRIPT" exists -h)
-assert_contains "$out" "worktree exists" "exists -h prints help, not an issue lookup"
-
-# Every help form run inside $REPO is above this line except `check --help`,
-# which the 16-command loop already ran here — so the marker answers for all
-# of them at once.
-if [[ -e "$TMP_ROOT/env-executed" ]]; then
-  FAIL=$((FAIL + 1))
-  printf '  FAIL  %s\n' "help sourced the project .env.local"
-else
-  PASS=$((PASS + 1))
-  printf '  ok    %s\n' "no help form sourced the project .env.local"
-fi
-
-# Per-command help needs no repository at all. The top-level form is
-# tools/tests/help-inert.test.sh's; these three resolve a worktree when they
-# run, so their help is the one that could reach for a repository.
 NOREPO="$TMP_ROOT/norepo"
-mkdir -p "$NOREPO"
+mkdir -p "$NOREPO" "$TMP_ROOT/empty-bin"
 export GIT_CEILING_DIRECTORIES="$TMP_ROOT"
-norepo_status=0
-norepo_probe=$(LC_ALL=C git -C "$NOREPO" rev-parse --show-toplevel 2>&1) || norepo_status=$?
-if [[ "$norepo_status" -eq 0 ]]; then
-  FAIL=$((FAIL + 1))
-  printf '  FAIL  %s\n        got:      %s\n' \
-    "the no-repository fixture is outside a git repository" "$norepo_probe"
-elif [[ "$norepo_status" -eq 128 && "$norepo_probe" == *"not a git repository"* ]]; then
-  PASS=$((PASS + 1))
-  printf '  ok    %s\n' "the no-repository fixture is outside a git repository"
-  for cmd in list path exists; do
-    status=0
-    out=$(cd "$NOREPO" && "$WORKTREE_SCRIPT" "$cmd" --help) || status=$?
-    assert_eq "$status" 0 "worktree $cmd --help exits 0 outside a git repository"
-  done
-
-  # Past help, the repository lookup runs and has nothing to find. It refuses
-  # once, naming the cwd and the checkout to run from; `remove` is the form
-  # that gets run from the worktrees' parent, so it is held here too.
-  for cmd in "list" "remove ISSUE-GONE"; do
-    status=0
-    # shellcheck disable=SC2086
-    out=$(cd "$NOREPO" && "$WORKTREE_SCRIPT" $cmd 2>"$TMP_ROOT/norepo.err") || status=$?
-    err=$(cat "$TMP_ROOT/norepo.err")
-    assert_eq "$status" 1 "worktree $cmd exits 1 outside a git repository"
-    assert_contains "$err" "could not resolve a git repository from: $NOREPO" \
-      "worktree $cmd names the cwd it could not resolve a repository from"
-    assert_contains "$err" "Run it from a checkout of the repository you mean" \
-      "worktree $cmd names what to do instead"
-    # One refusal serves every non-help command, so its example names none: a
-    # subcommand baked in here is the wrong next step for the other callers,
-    # and `remove` deletes a worktree and a branch.
-    assert_contains "$err" "scripts/worktree <command>" \
-      "worktree $cmd offers a recovery example with no subcommand of its own"
-    assert_eq "$out" "" "worktree $cmd prints nothing on stdout outside a git repository"
-  done
-
-  # The cause is git's, not the script's guess at it. A repository with no git
-  # to read it is the case that separates the two: the cwd IS a checkout, and
-  # a message asserting otherwise sends the operator to a second one.
-  # LC_ALL=C like the probe above: the message under test is translated, so an
-  # unpinned locale reddens this on a workstation and nowhere else.
-  mkdir -p "$TMP_ROOT/empty-bin"
-  status=0
-  out=$(cd "$TEST_DIR" && LC_ALL=C PATH="$TMP_ROOT/empty-bin" "$WORKTREE_SCRIPT" list 2>"$TMP_ROOT/nogit.err") || status=$?
-  # Read the quoted line, not the whole stream: without the anchor the needle
-  # also matches the shell's own unredirected message, which is what stderr
-  # carries when the refusal quotes nothing at all.
-  said=""
-  if ! said=$(grep -F '  git said: ' "$TMP_ROOT/nogit.err"); then said=""; fi
-  assert_eq "$status" 1 "worktree list exits 1 when git is not on PATH"
-  assert_contains "$said" "git: command not found" \
-    "the refusal quotes git's own account rather than asserting a cause"
-  assert_eq "$out" "" "worktree list prints nothing on stdout when git is not on PATH"
-else
-  FAIL=$((FAIL + 1))
-  printf '  FAIL  %s\n        status:   %s\n        diagnostic: %s\n' \
-    "the no-repository fixture probe returns Git's expected result" "$norepo_status" "$norepo_probe"
+if LC_ALL=C git -C "$NOREPO" rev-parse --show-toplevel >/dev/null 2>&1; then
+  echo "FIXTURE: $NOREPO resolves a git repository" >&2
+  exit 2
 fi
 
-# The top-level help states the loader's real precedence, lowest to highest.
-out=$(cd "$NOREPO" && "$WORKTREE_SCRIPT" --help)
-assert_contains "$out" "kendex.settings.toml [env], then" "help orders the root settings file below the rest"
-assert_contains "$out" ".kendex/settings.toml" "help names the .kendex settings file"
-assert_contains "$out" "parent environment beats every project file" "help states parent env outranks project files"
+# --- rendering ------------------------------------------------------------------
+
+alias_text() {
+  sed -e "s|$NOREPO|<norepo>|g" -e "s|$REPO|<repo>|g" -e "s|$TEST_DIR|<tests>|g" -e "s|$WORKTREE_SCRIPT|<worktree>|g" -e 's/: line [0-9]*: /: line <n>: /' |
+    paste -s -d ';' -
+}
+
+# stdout: its first line, then the lines opening the loader's precedence
+# claim, the second usage line path and exists share, and check's contract
+# (help is prose; those are the lines the table pins). Then stderr whole,
+# then whether the checkout's .env.local ran.
+run() {
+  local -a argv
+  local where="$1" envspec="$2" rc=0 cwd="" out="" said=""
+  local -a env_words=()
+  read -r -a argv <<<"$3"
+  case "$where" in
+    repo) cwd="$REPO" ;;
+    norepo) cwd="$NOREPO" ;;
+    tests) cwd="$TEST_DIR" ;;
+    *) echo "UNKNOWN-CWD: $where" >&2; exit 2 ;;
+  esac
+  case "$envspec" in
+    -) ;;
+    nogit) env_words=("PATH=$TMP_ROOT/empty-bin") ;;
+    *) echo "UNKNOWN-ENV: $envspec" >&2; exit 2 ;;
+  esac
+  rm -f "$TMP_ROOT/env-executed"
+  (cd "$cwd" && env LC_ALL=C ${env_words[@]+"${env_words[@]}"} "$WORKTREE_SCRIPT" "${argv[@]}" >"$TMP_ROOT/out" 2>"$TMP_ROOT/err") || rc=$?
+  out="$(head -1 "$TMP_ROOT/out")"
+  said="$(grep -E '^(Configuration \(loaded|\.kendex/settings\.toml|parent environment beats|       worktree exists|Pre-create git state check)' "$TMP_ROOT/out" | paste -s -d ';' - || true)"
+  printf 'rc=%s out=%s says=%s err=%s env=%s' "$rc" "${out:--}" "${said:--}" "$(alias_text <"$TMP_ROOT/err")" \
+    "$([[ -e "$TMP_ROOT/env-executed" ]] && printf sourced || printf -)"
+}
+
+# --- the expected text ----------------------------------------------------------
+
+# The production text, held once.
+err_text() {
+  case "$1" in
+    -) printf '' ;;
+    no-repo) printf '%s' 'Error: could not resolve a git repository from: <norepo>;  git said: not a git repository (or any of the parent directories): .git;  Run it from a checkout of the repository you mean:;    cd <main checkout> && .agents/skills/worktree/scripts/worktree <command>' ;;
+    no-git) printf '%s' 'Error: could not resolve a git repository from: <tests>;  git said: <worktree>: line <n>: git: command not found;  Run it from a checkout of the repository you mean:;    cd <main checkout> && .agents/skills/worktree/scripts/worktree <command>' ;;
+    check-arg) printf 'Error: check takes no arguments — it inspects the main checkout' ;;
+    *) printf 'UNKNOWN-ERR-SPEC:%s' "$1" ;;
+  esac
+}
+
+says_text() {
+  case "$1" in
+    -) printf -- '-' ;;
+    precedence) printf 'Configuration (loaded lowest to highest: kendex.settings.toml [env], then;.kendex/settings.toml [env], then .env.local — later wins, and explicit;parent environment beats every project file; use .env.local for secrets or' ;;
+    path-exists) printf '%s' '       worktree exists <ID>' ;;
+    check) printf '%s' 'Pre-create git state check of the MAIN checkout (JSON: uncommitted,' ;;
+    *) printf 'UNKNOWN-SAYS-SPEC:%s' "$1" ;;
+  esac
+}
+
+# --- the rows ---------------------------------------------------------------------
+# label^cwd^env^command^rc^out^says^err^env-ran (^ because usage lines carry |)
+ROWS='--help prints the command index^repo^-^--help^0^Usage: worktree <command> [ID|/path] [options]^precedence^-^-
+-h prints the command index^repo^-^-h^0^Usage: worktree <command> [ID|/path] [options]^precedence^-^-
+help prints the command index^repo^-^help^0^Usage: worktree <command> [ID|/path] [options]^precedence^-^-
+restack --help^repo^-^restack --help^0^Usage: worktree restack continue|skip|abort [ID|/path]^-^-^-
+create --help^repo^-^create --help^0^Usage: worktree create <ID> [BRANCH] [options]^-^-^-
+remove --help^repo^-^remove --help^0^Usage: worktree remove [ID|/path]^-^-^-
+cleanup --help^repo^-^cleanup --help^0^Usage: worktree cleanup [--stale] [--ttl-minutes N]^-^-^-
+check --help says it inspects the main checkout^repo^-^check --help^0^Usage: worktree check^check^-^-
+list --help^repo^-^list --help^0^Usage: worktree list^-^-^-
+path --help prints help, not an issue lookup^repo^-^path --help^0^Usage: worktree path <ID>^path-exists^-^-
+exists -h prints help, not an issue lookup^repo^-^exists -h^0^Usage: worktree path <ID>^path-exists^-^-
+push --help^repo^-^push --help^0^Usage: worktree push [ID|/path] [--set-upstream|-u] [--no-rebase]^-^-^-
+fix-links --help^repo^-^fix-links --help^0^Usage: worktree fix-links [ID|/path]^-^-^-
+repair-links --help points at the fix-links contract^repo^-^repair-links --help^0^repair-links is the git-hook-driven variant of fix-links; the shared contract is under: worktree fix-links --help^-^-^-
+the five hook commands share the app-hook help^repo^-^codex-setup --help^0^Usage: worktree codex-setup    [PATH]^-^-^-
+codex-branch --help^repo^-^codex-branch --help^0^Usage: worktree codex-setup    [PATH]^-^-^-
+codex-cleanup --help^repo^-^codex-cleanup --help^0^Usage: worktree codex-setup    [PATH]^-^-^-
+claude-setup --help^repo^-^claude-setup --help^0^Usage: worktree codex-setup    [PATH]^-^-^-
+claude-cleanup --help^repo^-^claude-cleanup --help^0^Usage: worktree codex-setup    [PATH]^-^-^-
+--help after a positional prints the remove help^repo^-^remove CC-1 --help^0^Usage: worktree remove [ID|/path]^-^-^-
+--help after a flag prints the cleanup help^repo^-^cleanup --stale --help^0^Usage: worktree cleanup [--stale] [--ttl-minutes N]^-^-^-
+-h after a positional prints the push help^repo^-^push some-id -h^0^Usage: worktree push [ID|/path] [--set-upstream|-u] [--no-rebase]^-^-^-
+list --help needs no repository^norepo^-^list --help^0^Usage: worktree list^-^-^-
+path --help needs no repository^norepo^-^path --help^0^Usage: worktree path <ID>^path-exists^-^-
+exists --help needs no repository^norepo^-^exists --help^0^Usage: worktree path <ID>^path-exists^-^-
+the top-level help needs no repository^norepo^-^--help^0^Usage: worktree <command> [ID|/path] [options]^precedence^-^-
+list outside a repository refuses once, naming the cwd, git'"'"'s account and a recovery with no subcommand^norepo^-^list^1^-^-^no-repo^-
+remove outside a repository refuses the same way^norepo^-^remove ISSUE-GONE^1^-^-^no-repo^-
+list without git on PATH quotes git'"'"'s own account^tests^nogit^list^1^-^-^no-git^-
+check with an argument is a usage error^repo^-^check some-id^1^-^-^check-arg^sourced
+'
+
+echo "=== worktree help dispatch runs before repository and env initialization ==="
+while IFS= read -r row; do
+  [[ -n "$row" ]] || continue
+  IFS='^' read -r label where envspec command rc out says err envran <<<"$row"
+  for field in "$label" "$where" "$envspec" "$command" "$rc" "$out" "$says" "$err" "$envran"; do
+    [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+  done
+  # A rendering aid for writing rows: prints what each row produces instead of
+  # asserting it. A run that asserted no row is refused after the loop.
+  if [[ "${WORKTREE_TABLE_PROBE:-}" == 1 ]]; then
+    printf '%s => %s\n' "$label" "$(run "$where" "$envspec" "$command")"
+    continue
+  fi
+  assert_eq "$(run "$where" "$envspec" "$command")" "rc=$rc out=$out says=$(says_text "$says") err=$(err_text "$err") env=$envran" "$label"
+done <<<"$ROWS"
+[[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 
 echo
-echo "=== check takes no target ==="
-
-out=$(cd "$REPO" && "$WORKTREE_SCRIPT" check --help)
-assert_contains "$out" "MAIN checkout" "check --help says it inspects the main checkout"
-
-set +e
-err=$(cd "$REPO" && "$WORKTREE_SCRIPT" check some-id 2>&1)
-code=$?
-set -e
-assert_eq "$code" 1 "check with an argument exits 1"
-assert_contains "$err" "check takes no arguments" "check names the rejection"
-
-printf '\npass: %d   fail: %d\n' "$PASS" "$FAIL"
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Reshapes `skills/worktree/tests/worktree_help_dispatch.sh` to code-quality § Tests. The suite pinned the dispatcher's boundary (every command's help answered at any argv position before the repository lookup and the env load, the refusal outside a repository or without git, check taking no target) in a loop over sixteen commands and a dozen scenarios of substring checks sharing one fixture. Those are now one table of 30 rows over a `^`-separated table (usage lines carry `|`): a row names where the command runs (the fixture checkout whose `.env.local` records being sourced, a directory outside any repository, or the tests directory with an empty PATH), runs one command under `LC_ALL=C`, and pins the exit status, stdout's usage line and the lines opening the loader's precedence claim, the usage line `path` and `exists` share and `check`'s contract, stderr whole, and whether the checkout's `.env.local` ran. The row loop refuses a row with an empty field, and a run that asserted no row exits 2, so the rendering aid (`WORKTREE_TABLE_PROBE=1`) can never pass.

The tracked render under `.agents` is replayed with `patch`.

## Folded or deleted cases, with the surviving row

| Former assertions | Surviving row |
|---|---|
| the three top-level forms exit 0 and print `Usage: worktree <command>` | `--help prints the command index`, `-h ...`, `help ...` (usage line whole, `says=precedence`) |
| sixteen commands' `--help` exit 0 and print something | one row per command, each pinning its own first line whole (`restack`, `create`, `remove`, `cleanup`, `check`, `list`, `path`, `exists`, `push`, `fix-links`, `repair-links`, and the five hook commands) |
| claude-setup's help contains "App-created worktree hooks" | the five hook rows pin `out=Usage: worktree codex-setup    [PATH]`, the shared help's identity; the banner sentence is wording and is not pinned (reviewer S3) |
| late `--help`/`-h` at three argv positions | `--help after a positional prints the remove help`, `--help after a flag prints the cleanup help`, `-h after a positional prints the push help` |
| list/path help substrings; `exists -h` output contains "worktree exists" | `path --help prints help, not an issue lookup`, `exists -h prints help, not an issue lookup` (`says=path-exists`: the shared second usage line, restored from the old suite's one lost assertion, reviewer S1) |
| one aggregate "no help form sourced .env.local" | the `env=` field of every row, the marker cleared before each; `check with an argument is a usage error` is the positive control (`env=sourced`) |
| the no-repository fixture probe, counted as a row | a fixture precondition that exits 2 |
| list/path/exists help outside a repository | `list --help needs no repository`, `path --help ...`, `exists --help ...`, `the top-level help needs no repository` |
| the no-repository refusal: exit 1, the cwd, "Run it from a checkout", the recovery line, empty stdout | `list outside a repository refuses once, naming the cwd, git's account and a recovery with no subcommand`, `remove outside a repository refuses the same way` (stderr whole) |
| the no-git refusal, the anchored `git said:` line | `list without git on PATH quotes git's own account` (stderr whole) |
| three precedence substrings | `says=precedence` on the three index rows: the three lines in output order |
| check --help says "MAIN checkout" | `check --help says it inspects the main checkout` (`says=check`) |
| check with an argument exits 1 | `check with an argument is a usage error` (stderr whole, `env=sourced`) |

## Mutation

Thirty must-fail mutants over a scratch copy of `skills/worktree` (`mutants-hd-3.txt` in the lane scratchpad; `mutate-hd.py` makes them, each run in its own process group under a 300 s bound), all killed: help seen only after the command word, `-h` not help, `help` not help, the env loaded before help (19 rows), the repository resolved before help (6 rows), the refusal dropping git's account, exiting 128, naming a subcommand in its recovery, asserting a cause without git, check accepting an argument, path/exists help swapped, one hook command's help alone, the precedence misstated, the parent-environment clause dropped, each of restack, create, remove, cleanup, list, push and fix-links pointed at another help (one or two rows each), a help writing to stderr, exists routed elsewhere while path keeps its help, the exists usage line dropped, check's help dropping the checkout, repair-links printing fix-links' help; and four fixture mutants (the env marker a no-op, git left on the no-git PATH, a row blanked to its separators, the probe hatch armed by default). `WORKTREE_TABLE_PROBE=1 bash <suite>` exits 2 with no `ok` line; also green under `LC_ALL=de_DE.UTF-8`.

## Reviewer round

One reviewer-test round, ACCEPT WITH FIXES, all applied: B1, the two no-repository rows pinned git's translated message under the ambient locale (every row now runs under `LC_ALL=C`); B2, `PROBE=1` in the environment made the suite a no-op that exited 0; S1, the `exists` usage line restored as a pin; S2, a blanked row was skipped silently; S3, the hook banner pin dropped as wording. The reviewer's per-command, stderr, routing and fixture mutants are folded into the battery.

## Checks

- `worktree_help_dispatch.sh`: 30 assertions, TMPDIR=/var/tmp/ken-c, also green under `init.defaultBranch=master` and `LC_ALL=de_DE.UTF-8`; `shellcheck` clean; `tools/bash32-lint skills/worktree` clean; source and render byte-identical.
- `tools/guard --full`: exit 0 on 3cbb63eb1 (TMPDIR=/var/tmp/ken-c), the same tree restacked onto main as ef2895e7e.

KEN-1241

https://claude.ai/code/session_01624Ks71377efHigfawmVYe
