### PR TITLE
test(KEN-1241): close the rendering hatch in eight worktree table suites

### DIFF
--- a/.agents/skills/worktree/tests/worktree_autorepair_hooks.sh
+++ b/.agents/skills/worktree/tests/worktree_autorepair_hooks.sh
@@ -309,8 +309,12 @@ an unreadable subdirectory blocks the repair as a failed scan|dash noperm:-dash|
 
 echo "=== the auto-repair hooks ==="
 n=0
-while IFS='|' read -r label fixture command rc out err want; do
-  [[ -n "$label$fixture$command$rc$out$err$want" ]] || continue
+while IFS= read -r row; do
+  [[ -n "$row" ]] || continue
+  IFS='|' read -r label fixture command rc out err want <<<"$row"
+  for field in "$label" "$fixture" "$command" "$rc" "$out" "$err" "$want"; do
+    [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+  done
   n=$((n + 1))
   # Root sees through permission bits, so the failed-scan row cannot be built
   # there (CI runners and dev shells are non-root).
@@ -324,12 +328,15 @@ while IFS='|' read -r label fixture command rc out err want; do
   # The unreadable directory is opened after the command so the data it hid
   # renders: the refusal must have left it in place.
   [[ "$fixture" == *noperm* ]] && { chmod 755 "$WT/-dash/noperm"; got="$got survived=$(head -n 1 "$WT/-dash/noperm/data.txt" 2>/dev/null || printf '?')"; }
-  if [[ "${PROBE:-}" == 1 ]]; then
+  # A rendering aid for writing rows: prints what each row produces instead of
+  # asserting it. A run that asserted no row is refused after the loop.
+  if [[ "${WORKTREE_TABLE_PROBE:-}" == 1 ]]; then
     printf '%s => %s\n' "$label" "$got"
     continue
   fi
   assert_eq "$got" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want" "$label"
 done <<<"$ROWS"
+[[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/.agents/skills/worktree/tests/worktree_base_dir.sh
+++ b/.agents/skills/worktree/tests/worktree_base_dir.sh
@@ -278,8 +278,12 @@ a worktree git refuses to remove is preserved with its links and branch, and cle
 
 echo "=== the worktree base directory ==="
 n=0
-while IFS='|' read -r label fixture envspec command rc out err want_state; do
-  [[ -n "$label$fixture$command$rc$out$err$want_state" ]] || continue
+while IFS= read -r row; do
+  [[ -n "$row" ]] || continue
+  IFS='|' read -r label fixture envspec command rc out err want_state <<<"$row"
+  for field in "$label" "$fixture" "$envspec" "$command" "$rc" "$out" "$err" "$want_state"; do
+    [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+  done
   n=$((n + 1))
   # shellcheck disable=SC2086
   build "row-$n" $fixture
@@ -288,12 +292,15 @@ while IFS='|' read -r label fixture envspec command rc out err want_state; do
     # shellcheck disable=SC2206
     ROW_ENV=(${envspec//<root>/$ROOT})
   fi
-  if [[ "${PROBE:-}" == 1 ]]; then
+  # A rendering aid for writing rows: prints what each row produces instead of
+  # asserting it. A run that asserted no row is refused after the loop.
+  if [[ "${WORKTREE_TABLE_PROBE:-}" == 1 ]]; then
     printf '%s => %s\n' "$label" "$(run "$command")"
     continue
   fi
   assert_eq "$(run "$command")" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want_state" "$label"
 done <<<"$ROWS"
+[[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/.agents/skills/worktree/tests/worktree_create_active_guard.sh
+++ b/.agents/skills/worktree/tests/worktree_create_active_guard.sh
@@ -108,6 +108,8 @@ fixture_create() {
 
 step() {
   case "$1" in
+    # The bare world: the checkout and its origin, nothing else.
+    -) ;;
     wt) fixture_create topic ;;
     # The topic branch has a commit of its own and is published.
     push)
@@ -334,7 +336,7 @@ err_text() {
   esac
 }
 
-# label|fixture|command|rc|out|err|state
+# label|fixture (- for the bare world)|command|rc|out|err|state
 ROWS='
 a published, locked, PR-backed worktree refuses implicit reuse with every signal and moves nothing|wt push advance open-pr lock|create topic|75|-|implicit:topic:clean,up,pr,lock|main=main@end/clean cfg=true trees=topic:reg@topic@pre branches=topic dirty=-
 --reuse rebases the owned branch onto the advanced main|wt push advance open-pr|create topic --reuse|0|topic|-|main=main@end/clean cfg=true trees=topic:reg@topic@on-end branches=topic dirty=-
@@ -350,14 +352,14 @@ BOT_NAME/<id> on the remote is a candidate|remote:robot/topic bot|create topic|7
 a failed PR query is uncertainty: nothing is created|fail-gh|create topic|1|-|gh-fail|main=main@end/clean cfg=- trees= branches=- dirty=-
 a failed final fetch stops before any mutation|fail-fetch|create topic|1|-|fetch-fail|main=main@end/clean cfg=- trees= branches=- dirty=-
 an unreachable origin stops before the claim lock|bad-origin|create topic|1|-|remote-fail|main=main@end/clean cfg=- trees= branches=- dirty=-
---help prints usage and creates nothing||create --help|0|usage|-|main=main@end/clean cfg=- trees= branches=- dirty=-
--h prints usage and creates nothing||create -h|0|usage|-|main=main@end/clean cfg=- trees= branches=- dirty=-
-an option-looking issue id is refused before it becomes a path||create --bogus|1|-|unknown-option|main=main@end/clean cfg=- trees= branches=- dirty=-
-an unknown flag after the id creates neither branch nor worktree||create topic --bogus|1|-|unknown-option|main=main@end/clean cfg=- trees= branches=- dirty=-
-a positional branch name is accepted beside the id||create topic custom-branch-name|0|topic|-|main=main@end/clean cfg=true trees=topic:reg@custom-branch-name@end branches=custom-branch-name dirty=-
---base <default> with no prior work checks out a new issue branch on origin/<default>||create topic --base main|0|topic|-|main=main@end/clean cfg=true trees=topic:reg@topic@end branches=topic dirty=-
---base origin/<default> does the same||create topic --base origin/main|0|topic|-|main=main@end/clean cfg=true trees=topic:reg@topic@end branches=topic dirty=-
-a positional work branch named as the default branch is refused loudly||create topic main|1|-|default-branch|main=main@end/clean cfg=- trees= branches=- dirty=-
+--help prints usage and creates nothing|-|create --help|0|usage|-|main=main@end/clean cfg=- trees= branches=- dirty=-
+-h prints usage and creates nothing|-|create -h|0|usage|-|main=main@end/clean cfg=- trees= branches=- dirty=-
+an option-looking issue id is refused before it becomes a path|-|create --bogus|1|-|unknown-option|main=main@end/clean cfg=- trees= branches=- dirty=-
+an unknown flag after the id creates neither branch nor worktree|-|create topic --bogus|1|-|unknown-option|main=main@end/clean cfg=- trees= branches=- dirty=-
+a positional branch name is accepted beside the id|-|create topic custom-branch-name|0|topic|-|main=main@end/clean cfg=true trees=topic:reg@custom-branch-name@end branches=custom-branch-name dirty=-
+--base <default> with no prior work checks out a new issue branch on origin/<default>|-|create topic --base main|0|topic|-|main=main@end/clean cfg=true trees=topic:reg@topic@end branches=topic dirty=-
+--base origin/<default> does the same|-|create topic --base origin/main|0|topic|-|main=main@end/clean cfg=true trees=topic:reg@topic@end branches=topic dirty=-
+a positional work branch named as the default branch is refused loudly|-|create topic main|1|-|default-branch|main=main@end/clean cfg=- trees= branches=- dirty=-
 --base <default> for an owned issue still refuses, naming the issue worktree (the registered worktree stops it before --base is read; the row guards the composite #1034 regression)|wt|create topic --base main|75|-|implicit:topic:clean,noup|main=main@end/clean cfg=true trees=topic:reg@topic@end branches=topic dirty=-
 the topic branch checked out in the main checkout blocks the id without offering --reuse|main-checkout|create topic|75|-|main-checkout|main=topic@end/clean cfg=- trees= branches=topic dirty=-
 a local branch literally named origin/<default> keeps its ownership checks|local:origin/main|create topic origin/main|75|-|dup:origin/main:local|main=main@end/clean cfg=- trees= branches=origin/main dirty=-
@@ -367,17 +369,24 @@ a non-default --base of an unclaimed remote branch checks that branch out|remote
 
 echo "=== create against active work ==="
 n=0
-while IFS='|' read -r label fixture command rc out err want_state; do
-  [[ -n "$label$fixture$command$rc$out$err$want_state" ]] || continue
+while IFS= read -r row; do
+  [[ -n "$row" ]] || continue
+  IFS='|' read -r label fixture command rc out err want_state <<<"$row"
+  for field in "$label" "$fixture" "$command" "$rc" "$out" "$err" "$want_state"; do
+    [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+  done
   n=$((n + 1))
   # shellcheck disable=SC2086
   build "row-$n" $fixture
-  if [[ "${PROBE:-}" == 1 ]]; then
+  # A rendering aid for writing rows: prints what each row produces instead of
+  # asserting it. A run that asserted no row is refused after the loop.
+  if [[ "${WORKTREE_TABLE_PROBE:-}" == 1 ]]; then
     printf '%s => %s\n' "$label" "$(run "$command")"
     continue
   fi
   assert_eq "$(run "$command")" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want_state" "$label"
 done <<<"$ROWS"
+[[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 
 # --- the concurrent claim -------------------------------------------------------
 # Two claimers both pass their read-only preliminary discovery (the gh stub

--- a/.agents/skills/worktree/tests/worktree_create_fork_pr.sh
+++ b/.agents/skills/worktree/tests/worktree_create_fork_pr.sh
@@ -345,17 +345,24 @@ cleanup keeps a fork branch whose tip is past its merged head, naming the mismat
 
 echo "=== worktree create --pr, remove and cleanup on fork pull requests ==="
 n=0
-while IFS='|' read -r label fixture command rc out err want_state; do
-  [[ -n "$label$fixture$command$rc$out$err$want_state" ]] || continue
+while IFS= read -r row; do
+  [[ -n "$row" ]] || continue
+  IFS='|' read -r label fixture command rc out err want_state <<<"$row"
+  for field in "$label" "$fixture" "$command" "$rc" "$out" "$err" "$want_state"; do
+    [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+  done
   n=$((n + 1))
   # shellcheck disable=SC2086
   build "row-$n" $fixture
-  if [[ "${PROBE:-}" == 1 ]]; then
+  # A rendering aid for writing rows: prints what each row produces instead of
+  # asserting it. A run that asserted no row is refused after the loop.
+  if [[ "${WORKTREE_TABLE_PROBE:-}" == 1 ]]; then
     printf '%s => %s\n' "$label" "$(run "$command")"
     continue
   fi
   assert_eq "$(run "$command")" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want_state" "$label"
 done <<<"$ROWS"
+[[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/.agents/skills/worktree/tests/worktree_path_safety.sh
+++ b/.agents/skills/worktree/tests/worktree_path_safety.sh
@@ -218,17 +218,24 @@ remove refuses the main checkout by its direct path and leaves it intact|repo|re
 
 echo "=== path boundaries ==="
 n=0
-while IFS='|' read -r label fixture command rc out err want_state; do
-  [[ -n "$label$fixture$command$rc$out$err$want_state" ]] || continue
+while IFS= read -r row; do
+  [[ -n "$row" ]] || continue
+  IFS='|' read -r label fixture command rc out err want_state <<<"$row"
+  for field in "$label" "$fixture" "$command" "$rc" "$out" "$err" "$want_state"; do
+    [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+  done
   n=$((n + 1))
   # shellcheck disable=SC2086
   build "row-$n" $fixture
-  if [[ "${PROBE:-}" == 1 ]]; then
+  # A rendering aid for writing rows: prints what each row produces instead of
+  # asserting it. A run that asserted no row is refused after the loop.
+  if [[ "${WORKTREE_TABLE_PROBE:-}" == 1 ]]; then
     printf '%s => %s\n' "$label" "$(run "$command")"
     continue
   fi
   assert_eq "$(run "$command")" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want_state" "$label"
 done <<<"$ROWS"
+[[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/.agents/skills/worktree/tests/worktree_push_rebase.sh
+++ b/.agents/skills/worktree/tests/worktree_push_rebase.sh
@@ -406,17 +406,24 @@ a sibling GitHub helper, when present, owns the git invocation|github fix with-h
 
 echo "=== worktree push ==="
 n=0
-while IFS='|' read -r label fixture command rc out err want_state; do
-  [[ -n "$label$fixture$command$rc$out$err$want_state" ]] || continue
+while IFS= read -r row; do
+  [[ -n "$row" ]] || continue
+  IFS='|' read -r label fixture command rc out err want_state <<<"$row"
+  for field in "$label" "$fixture" "$command" "$rc" "$out" "$err" "$want_state"; do
+    [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+  done
   n=$((n + 1))
   # shellcheck disable=SC2086
   build "row-$n" $fixture
-  if [[ "${PROBE:-}" == 1 ]]; then
+  # A rendering aid for writing rows: prints what each row produces instead of
+  # asserting it. A run that asserted no row is refused after the loop.
+  if [[ "${WORKTREE_TABLE_PROBE:-}" == 1 ]]; then
     printf '%s => %s\n' "$label" "$(run "$command")"
     continue
   fi
   assert_eq "$(run "$command")" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want_state" "$label"
 done <<<"$ROWS"
+[[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/.agents/skills/worktree/tests/worktree_restack_replay.sh
+++ b/.agents/skills/worktree/tests/worktree_restack_replay.sh
@@ -396,17 +396,24 @@ remote movement after authorization fails the exact lease|clean replay move-remo
 
 echo "=== worktree create --replay (the policy-blocked restack engine) ==="
 n=0
-while IFS='|' read -r label fixture command rc out err want_state; do
-  [[ -n "$label$fixture$command$rc$out$err$want_state" ]] || continue
+while IFS= read -r row; do
+  [[ -n "$row" ]] || continue
+  IFS='|' read -r label fixture command rc out err want_state <<<"$row"
+  for field in "$label" "$fixture" "$command" "$rc" "$out" "$err" "$want_state"; do
+    [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+  done
   n=$((n + 1))
   # shellcheck disable=SC2086
   build "row-$n" $fixture
-  if [[ "${PROBE:-}" == 1 ]]; then
+  # A rendering aid for writing rows: prints what each row produces instead of
+  # asserting it. A run that asserted no row is refused after the loop.
+  if [[ "${WORKTREE_TABLE_PROBE:-}" == 1 ]]; then
     printf '%s => %s\n' "$label" "$(run "$command")"
     continue
   fi
   assert_eq "$(run "$command")" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want_state" "$label"
 done <<<"$ROWS"
+[[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/.agents/skills/worktree/tests/worktree_symlink_shadows_tracked.sh
+++ b/.agents/skills/worktree/tests/worktree_symlink_shadows_tracked.sh
@@ -276,8 +276,12 @@ a locked index during the legacy heal reports failure, not a swallowed success|e
 
 echo "=== the symlink layout under a tracked-content entry ==="
 n=0
-while IFS='|' read -r label fixture command rc out err want; do
-  [[ -n "$label$fixture$command$rc$out$err$want" ]] || continue
+while IFS= read -r row; do
+  [[ -n "$row" ]] || continue
+  IFS='|' read -r label fixture command rc out err want <<<"$row"
+  for field in "$label" "$fixture" "$command" "$rc" "$out" "$err" "$want"; do
+    [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+  done
   n=$((n + 1))
   # shellcheck disable=SC2086
   build "row-$n" $fixture
@@ -290,12 +294,15 @@ while IFS='|' read -r label fixture command rc out err want; do
   else
     got="$(run "$command")"
   fi
-  if [[ "${PROBE:-}" == 1 ]]; then
+  # A rendering aid for writing rows: prints what each row produces instead of
+  # asserting it. A run that asserted no row is refused after the loop.
+  if [[ "${WORKTREE_TABLE_PROBE:-}" == 1 ]]; then
     printf '%s => %s\n' "$label" "$got"
     continue
   fi
   assert_eq "$got" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want" "$label"
 done <<<"$ROWS"
+[[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/worktree/tests/worktree_autorepair_hooks.sh
+++ b/skills/worktree/tests/worktree_autorepair_hooks.sh
@@ -309,8 +309,12 @@ an unreadable subdirectory blocks the repair as a failed scan|dash noperm:-dash|
 
 echo "=== the auto-repair hooks ==="
 n=0
-while IFS='|' read -r label fixture command rc out err want; do
-  [[ -n "$label$fixture$command$rc$out$err$want" ]] || continue
+while IFS= read -r row; do
+  [[ -n "$row" ]] || continue
+  IFS='|' read -r label fixture command rc out err want <<<"$row"
+  for field in "$label" "$fixture" "$command" "$rc" "$out" "$err" "$want"; do
+    [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+  done
   n=$((n + 1))
   # Root sees through permission bits, so the failed-scan row cannot be built
   # there (CI runners and dev shells are non-root).
@@ -324,12 +328,15 @@ while IFS='|' read -r label fixture command rc out err want; do
   # The unreadable directory is opened after the command so the data it hid
   # renders: the refusal must have left it in place.
   [[ "$fixture" == *noperm* ]] && { chmod 755 "$WT/-dash/noperm"; got="$got survived=$(head -n 1 "$WT/-dash/noperm/data.txt" 2>/dev/null || printf '?')"; }
-  if [[ "${PROBE:-}" == 1 ]]; then
+  # A rendering aid for writing rows: prints what each row produces instead of
+  # asserting it. A run that asserted no row is refused after the loop.
+  if [[ "${WORKTREE_TABLE_PROBE:-}" == 1 ]]; then
     printf '%s => %s\n' "$label" "$got"
     continue
   fi
   assert_eq "$got" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want" "$label"
 done <<<"$ROWS"
+[[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/worktree/tests/worktree_base_dir.sh
+++ b/skills/worktree/tests/worktree_base_dir.sh
@@ -278,8 +278,12 @@ a worktree git refuses to remove is preserved with its links and branch, and cle
 
 echo "=== the worktree base directory ==="
 n=0
-while IFS='|' read -r label fixture envspec command rc out err want_state; do
-  [[ -n "$label$fixture$command$rc$out$err$want_state" ]] || continue
+while IFS= read -r row; do
+  [[ -n "$row" ]] || continue
+  IFS='|' read -r label fixture envspec command rc out err want_state <<<"$row"
+  for field in "$label" "$fixture" "$envspec" "$command" "$rc" "$out" "$err" "$want_state"; do
+    [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+  done
   n=$((n + 1))
   # shellcheck disable=SC2086
   build "row-$n" $fixture
@@ -288,12 +292,15 @@ while IFS='|' read -r label fixture envspec command rc out err want_state; do
     # shellcheck disable=SC2206
     ROW_ENV=(${envspec//<root>/$ROOT})
   fi
-  if [[ "${PROBE:-}" == 1 ]]; then
+  # A rendering aid for writing rows: prints what each row produces instead of
+  # asserting it. A run that asserted no row is refused after the loop.
+  if [[ "${WORKTREE_TABLE_PROBE:-}" == 1 ]]; then
     printf '%s => %s\n' "$label" "$(run "$command")"
     continue
   fi
   assert_eq "$(run "$command")" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want_state" "$label"
 done <<<"$ROWS"
+[[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/worktree/tests/worktree_create_active_guard.sh
+++ b/skills/worktree/tests/worktree_create_active_guard.sh
@@ -108,6 +108,8 @@ fixture_create() {
 
 step() {
   case "$1" in
+    # The bare world: the checkout and its origin, nothing else.
+    -) ;;
     wt) fixture_create topic ;;
     # The topic branch has a commit of its own and is published.
     push)
@@ -334,7 +336,7 @@ err_text() {
   esac
 }
 
-# label|fixture|command|rc|out|err|state
+# label|fixture (- for the bare world)|command|rc|out|err|state
 ROWS='
 a published, locked, PR-backed worktree refuses implicit reuse with every signal and moves nothing|wt push advance open-pr lock|create topic|75|-|implicit:topic:clean,up,pr,lock|main=main@end/clean cfg=true trees=topic:reg@topic@pre branches=topic dirty=-
 --reuse rebases the owned branch onto the advanced main|wt push advance open-pr|create topic --reuse|0|topic|-|main=main@end/clean cfg=true trees=topic:reg@topic@on-end branches=topic dirty=-
@@ -350,14 +352,14 @@ BOT_NAME/<id> on the remote is a candidate|remote:robot/topic bot|create topic|7
 a failed PR query is uncertainty: nothing is created|fail-gh|create topic|1|-|gh-fail|main=main@end/clean cfg=- trees= branches=- dirty=-
 a failed final fetch stops before any mutation|fail-fetch|create topic|1|-|fetch-fail|main=main@end/clean cfg=- trees= branches=- dirty=-
 an unreachable origin stops before the claim lock|bad-origin|create topic|1|-|remote-fail|main=main@end/clean cfg=- trees= branches=- dirty=-
---help prints usage and creates nothing||create --help|0|usage|-|main=main@end/clean cfg=- trees= branches=- dirty=-
--h prints usage and creates nothing||create -h|0|usage|-|main=main@end/clean cfg=- trees= branches=- dirty=-
-an option-looking issue id is refused before it becomes a path||create --bogus|1|-|unknown-option|main=main@end/clean cfg=- trees= branches=- dirty=-
-an unknown flag after the id creates neither branch nor worktree||create topic --bogus|1|-|unknown-option|main=main@end/clean cfg=- trees= branches=- dirty=-
-a positional branch name is accepted beside the id||create topic custom-branch-name|0|topic|-|main=main@end/clean cfg=true trees=topic:reg@custom-branch-name@end branches=custom-branch-name dirty=-
---base <default> with no prior work checks out a new issue branch on origin/<default>||create topic --base main|0|topic|-|main=main@end/clean cfg=true trees=topic:reg@topic@end branches=topic dirty=-
---base origin/<default> does the same||create topic --base origin/main|0|topic|-|main=main@end/clean cfg=true trees=topic:reg@topic@end branches=topic dirty=-
-a positional work branch named as the default branch is refused loudly||create topic main|1|-|default-branch|main=main@end/clean cfg=- trees= branches=- dirty=-
+--help prints usage and creates nothing|-|create --help|0|usage|-|main=main@end/clean cfg=- trees= branches=- dirty=-
+-h prints usage and creates nothing|-|create -h|0|usage|-|main=main@end/clean cfg=- trees= branches=- dirty=-
+an option-looking issue id is refused before it becomes a path|-|create --bogus|1|-|unknown-option|main=main@end/clean cfg=- trees= branches=- dirty=-
+an unknown flag after the id creates neither branch nor worktree|-|create topic --bogus|1|-|unknown-option|main=main@end/clean cfg=- trees= branches=- dirty=-
+a positional branch name is accepted beside the id|-|create topic custom-branch-name|0|topic|-|main=main@end/clean cfg=true trees=topic:reg@custom-branch-name@end branches=custom-branch-name dirty=-
+--base <default> with no prior work checks out a new issue branch on origin/<default>|-|create topic --base main|0|topic|-|main=main@end/clean cfg=true trees=topic:reg@topic@end branches=topic dirty=-
+--base origin/<default> does the same|-|create topic --base origin/main|0|topic|-|main=main@end/clean cfg=true trees=topic:reg@topic@end branches=topic dirty=-
+a positional work branch named as the default branch is refused loudly|-|create topic main|1|-|default-branch|main=main@end/clean cfg=- trees= branches=- dirty=-
 --base <default> for an owned issue still refuses, naming the issue worktree (the registered worktree stops it before --base is read; the row guards the composite #1034 regression)|wt|create topic --base main|75|-|implicit:topic:clean,noup|main=main@end/clean cfg=true trees=topic:reg@topic@end branches=topic dirty=-
 the topic branch checked out in the main checkout blocks the id without offering --reuse|main-checkout|create topic|75|-|main-checkout|main=topic@end/clean cfg=- trees= branches=topic dirty=-
 a local branch literally named origin/<default> keeps its ownership checks|local:origin/main|create topic origin/main|75|-|dup:origin/main:local|main=main@end/clean cfg=- trees= branches=origin/main dirty=-
@@ -367,17 +369,24 @@ a non-default --base of an unclaimed remote branch checks that branch out|remote
 
 echo "=== create against active work ==="
 n=0
-while IFS='|' read -r label fixture command rc out err want_state; do
-  [[ -n "$label$fixture$command$rc$out$err$want_state" ]] || continue
+while IFS= read -r row; do
+  [[ -n "$row" ]] || continue
+  IFS='|' read -r label fixture command rc out err want_state <<<"$row"
+  for field in "$label" "$fixture" "$command" "$rc" "$out" "$err" "$want_state"; do
+    [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+  done
   n=$((n + 1))
   # shellcheck disable=SC2086
   build "row-$n" $fixture
-  if [[ "${PROBE:-}" == 1 ]]; then
+  # A rendering aid for writing rows: prints what each row produces instead of
+  # asserting it. A run that asserted no row is refused after the loop.
+  if [[ "${WORKTREE_TABLE_PROBE:-}" == 1 ]]; then
     printf '%s => %s\n' "$label" "$(run "$command")"
     continue
   fi
   assert_eq "$(run "$command")" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want_state" "$label"
 done <<<"$ROWS"
+[[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 
 # --- the concurrent claim -------------------------------------------------------
 # Two claimers both pass their read-only preliminary discovery (the gh stub

--- a/skills/worktree/tests/worktree_create_fork_pr.sh
+++ b/skills/worktree/tests/worktree_create_fork_pr.sh
@@ -345,17 +345,24 @@ cleanup keeps a fork branch whose tip is past its merged head, naming the mismat
 
 echo "=== worktree create --pr, remove and cleanup on fork pull requests ==="
 n=0
-while IFS='|' read -r label fixture command rc out err want_state; do
-  [[ -n "$label$fixture$command$rc$out$err$want_state" ]] || continue
+while IFS= read -r row; do
+  [[ -n "$row" ]] || continue
+  IFS='|' read -r label fixture command rc out err want_state <<<"$row"
+  for field in "$label" "$fixture" "$command" "$rc" "$out" "$err" "$want_state"; do
+    [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+  done
   n=$((n + 1))
   # shellcheck disable=SC2086
   build "row-$n" $fixture
-  if [[ "${PROBE:-}" == 1 ]]; then
+  # A rendering aid for writing rows: prints what each row produces instead of
+  # asserting it. A run that asserted no row is refused after the loop.
+  if [[ "${WORKTREE_TABLE_PROBE:-}" == 1 ]]; then
     printf '%s => %s\n' "$label" "$(run "$command")"
     continue
   fi
   assert_eq "$(run "$command")" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want_state" "$label"
 done <<<"$ROWS"
+[[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/worktree/tests/worktree_path_safety.sh
+++ b/skills/worktree/tests/worktree_path_safety.sh
@@ -218,17 +218,24 @@ remove refuses the main checkout by its direct path and leaves it intact|repo|re
 
 echo "=== path boundaries ==="
 n=0
-while IFS='|' read -r label fixture command rc out err want_state; do
-  [[ -n "$label$fixture$command$rc$out$err$want_state" ]] || continue
+while IFS= read -r row; do
+  [[ -n "$row" ]] || continue
+  IFS='|' read -r label fixture command rc out err want_state <<<"$row"
+  for field in "$label" "$fixture" "$command" "$rc" "$out" "$err" "$want_state"; do
+    [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+  done
   n=$((n + 1))
   # shellcheck disable=SC2086
   build "row-$n" $fixture
-  if [[ "${PROBE:-}" == 1 ]]; then
+  # A rendering aid for writing rows: prints what each row produces instead of
+  # asserting it. A run that asserted no row is refused after the loop.
+  if [[ "${WORKTREE_TABLE_PROBE:-}" == 1 ]]; then
     printf '%s => %s\n' "$label" "$(run "$command")"
     continue
   fi
   assert_eq "$(run "$command")" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want_state" "$label"
 done <<<"$ROWS"
+[[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/worktree/tests/worktree_push_rebase.sh
+++ b/skills/worktree/tests/worktree_push_rebase.sh
@@ -406,17 +406,24 @@ a sibling GitHub helper, when present, owns the git invocation|github fix with-h
 
 echo "=== worktree push ==="
 n=0
-while IFS='|' read -r label fixture command rc out err want_state; do
-  [[ -n "$label$fixture$command$rc$out$err$want_state" ]] || continue
+while IFS= read -r row; do
+  [[ -n "$row" ]] || continue
+  IFS='|' read -r label fixture command rc out err want_state <<<"$row"
+  for field in "$label" "$fixture" "$command" "$rc" "$out" "$err" "$want_state"; do
+    [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+  done
   n=$((n + 1))
   # shellcheck disable=SC2086
   build "row-$n" $fixture
-  if [[ "${PROBE:-}" == 1 ]]; then
+  # A rendering aid for writing rows: prints what each row produces instead of
+  # asserting it. A run that asserted no row is refused after the loop.
+  if [[ "${WORKTREE_TABLE_PROBE:-}" == 1 ]]; then
     printf '%s => %s\n' "$label" "$(run "$command")"
     continue
   fi
   assert_eq "$(run "$command")" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want_state" "$label"
 done <<<"$ROWS"
+[[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/worktree/tests/worktree_restack_replay.sh
+++ b/skills/worktree/tests/worktree_restack_replay.sh
@@ -396,17 +396,24 @@ remote movement after authorization fails the exact lease|clean replay move-remo
 
 echo "=== worktree create --replay (the policy-blocked restack engine) ==="
 n=0
-while IFS='|' read -r label fixture command rc out err want_state; do
-  [[ -n "$label$fixture$command$rc$out$err$want_state" ]] || continue
+while IFS= read -r row; do
+  [[ -n "$row" ]] || continue
+  IFS='|' read -r label fixture command rc out err want_state <<<"$row"
+  for field in "$label" "$fixture" "$command" "$rc" "$out" "$err" "$want_state"; do
+    [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+  done
   n=$((n + 1))
   # shellcheck disable=SC2086
   build "row-$n" $fixture
-  if [[ "${PROBE:-}" == 1 ]]; then
+  # A rendering aid for writing rows: prints what each row produces instead of
+  # asserting it. A run that asserted no row is refused after the loop.
+  if [[ "${WORKTREE_TABLE_PROBE:-}" == 1 ]]; then
     printf '%s => %s\n' "$label" "$(run "$command")"
     continue
   fi
   assert_eq "$(run "$command")" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want_state" "$label"
 done <<<"$ROWS"
+[[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/worktree/tests/worktree_symlink_shadows_tracked.sh
+++ b/skills/worktree/tests/worktree_symlink_shadows_tracked.sh
@@ -276,8 +276,12 @@ a locked index during the legacy heal reports failure, not a swallowed success|e
 
 echo "=== the symlink layout under a tracked-content entry ==="
 n=0
-while IFS='|' read -r label fixture command rc out err want; do
-  [[ -n "$label$fixture$command$rc$out$err$want" ]] || continue
+while IFS= read -r row; do
+  [[ -n "$row" ]] || continue
+  IFS='|' read -r label fixture command rc out err want <<<"$row"
+  for field in "$label" "$fixture" "$command" "$rc" "$out" "$err" "$want"; do
+    [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+  done
   n=$((n + 1))
   # shellcheck disable=SC2086
   build "row-$n" $fixture
@@ -290,12 +294,15 @@ while IFS='|' read -r label fixture command rc out err want; do
   else
     got="$(run "$command")"
   fi
-  if [[ "${PROBE:-}" == 1 ]]; then
+  # A rendering aid for writing rows: prints what each row produces instead of
+  # asserting it. A run that asserted no row is refused after the loop.
+  if [[ "${WORKTREE_TABLE_PROBE:-}" == 1 ]]; then
     printf '%s => %s\n' "$label" "$got"
     continue
   fi
   assert_eq "$got" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want" "$label"
 done <<<"$ROWS"
+[[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"


### PR DESCRIPTION
Closes the rendering hatch in the eight merged table suites under `skills/worktree/tests` (the class-wide finding of the help-dispatch reviewer round, applied to the in-flight suites in their own PRs). Every table suite carried a `PROBE=1` mode that printed each row's result instead of asserting it, and a run so made reported `pass: 0 fail: 0` and exited 0. `tools/guard` and the CI workflow run `bash "$t"` under the ambient environment, so an exported `PROBE=1` zeroed every suite's coverage while each reported success.

The fix is the same in all eight (`worktree_autorepair_hooks.sh`, `worktree_base_dir.sh`, `worktree_create_active_guard.sh`, `worktree_path_safety.sh`, `worktree_push_rebase.sh`, `worktree_create_fork_pr.sh`, `worktree_symlink_shadows_tracked.sh`, `worktree_restack_replay.sh`): the variable is `WORKTREE_TABLE_PROBE`, the row loop reads the raw line and refuses a row with an empty field (a blanked row was skipped in silence before), and a run that asserted no row exits 2. The create-active-guard suite's eight bare-world rows spelled their fixture as an empty field; they now say `-`, a step word that builds nothing, so the refusal can be uniform. No row's expectation changes. The tracked renders under `.agents` are replayed with `patch`.

## Must-fail controls

Sixteen suite mutants over a scratch copy of `skills/worktree` (`mutants-tp.txt` in the lane scratchpad; `mutate-tp.py` makes them, each run in its own process group under a 600 s bound), all killed: per suite, the probe hatch armed by default (exit 2, no `ok` line) and the last row blanked to its separators (exit 1, the row named). No reviewer round: the change is mechanical and the reviewer's own finding.

## Checks

- Each suite green (19, 26, 28, 19, 21, 11, 16, 19 assertions), TMPDIR=/var/tmp/ken-c; `shellcheck` clean on all eight; source and render byte-identical.
- `tools/guard --full`: exit 0 on dbee5f944 (TMPDIR=/var/tmp/ken-c), the same tree restacked onto main as dbee5f944.

KEN-1241

https://claude.ai/code/session_01624Ks71377efHigfawmVYe
