### PR TITLE
test(KEN-1241): the exclude entry's shape as one table of rows

### DIFF
--- a/.agents/skills/worktree/tests/worktree_exclude_tracked_paths.sh
+++ b/.agents/skills/worktree/tests/worktree_exclude_tracked_paths.sh
@@ -1,17 +1,23 @@
 #!/usr/bin/env bash
-# `worktree create` writes the configured symlink path into the COMMON git
-# dir's info/exclude, which EVERY checkout of the repo reads — including main,
-# where that path is a real directory rather than the worktree's symlink.
-#
-# A bare entry therefore marked the whole directory ignored in the main
-# checkout, so `git add <tracked file under it>` started refusing with "The
-# following paths are ignored by one of your .gitignore files" while `git
-# status` still listed the file as modified. It also outlived the worktree
-#
-# Fix: when the path holds tracked content, follow the bare entry with
-# `!<path>/`. A trailing-slash pattern matches a real directory but NOT a
-# symlink pointing at one, so main regains the directory while the worktree's
-# symlink stays ignored. Runtime-only paths must keep the plain blanket entry.
+# The shape of the info/exclude entry a configured symlink path gets. The entry
+# lands in the COMMON git dir's info/exclude, which every checkout reads,
+# including main, where the same path is a real directory: a bare entry alone
+# marked that directory ignored in main, so `git add` of a tracked file under
+# it refused with git's ignore complaint while status still listed the file
+# as modified, and the entry outlived the worktree. When the path holds
+# tracked content the bare entry is followed by `!<path>/`: a trailing-slash
+# pattern matches a real directory but not a symlink to one, so main regains
+# the directory and the worktree's link stays ignored. A runtime-only path
+# keeps the plain entry (kendex's own .agents mirror is hidden in main by that
+# entry alone). The shape is recomputed on every pass, so it follows a path
+# that gains or loses tracked content, and lines other tools wrote stay.
+# One table, a row per scenario: the fixture is a word list of steps that
+# builds a checkout with its bare origin, the configured entry's content and
+# any worktree the row needs, the command runs from the checkout, and the row
+# pins its exit status, its stdout, its stderr and what is left: the exclude
+# file's lines, git's status of main, whether main can stage every tracked
+# file under the entry (git's own refusal, first line), and every entry of
+# the worktree with git's status of it.
 set -euo pipefail
 # A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
 # call below at the real repository; -C overrides neither.
@@ -24,142 +30,227 @@ trap 'rm -rf "$TMP_ROOT"' EXIT
 
 PASS=0
 FAIL=0
-pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 
 assert_eq() {
   local got="$1" want="$2" name="$3"
-  if [[ "$got" == "$want" ]]; then pass "$name"; else
-    fail "$name"; printf '        want: %s\n        got:  %s\n' "$want" "$got"; fi
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
 }
 
+# gh is quiet: no row asks about a pull request.
 mkdir -p "$TMP_ROOT/bin"
 printf '#!/usr/bin/env bash\nexit 0\n' >"$TMP_ROOT/bin/gh"
 chmod +x "$TMP_ROOT/bin/gh"
 export PATH="$TMP_ROOT/bin:$PATH"
 
+# --- fixtures -----------------------------------------------------------------
+# Every row's world lives under its own ROOT: the checkout at ROOT/main, its
+# bare origin, and the worktree at ROOT/trees/<id>. ENTRY is the one
+# configured symlink path of the row.
+
+ROOT=""
+MAIN=""
+WT=""
+ENTRY=""
+
 make_repo() {
-  local root="$1"
-  mkdir -p "$root/main"
-  git -C "$root/main" init -q -b main
-  git -C "$root/main" config user.email test@example.com
-  git -C "$root/main" config user.name Test
-  git -C "$root/main" config commit.gpgsign false
-  printf 'base\n' >"$root/main/base.txt"
-  git -C "$root/main" add base.txt
-  git -C "$root/main" commit -q -m base
-  git init -q --bare "$root/origin.git"
-  git -C "$root/main" remote add origin "$root/origin.git"
-  git -C "$root/main" push -q -u origin main
+  mkdir -p "$MAIN"
+  git -C "$MAIN" init -q -b main
+  git -C "$MAIN" config user.email test@example.com
+  git -C "$MAIN" config user.name Test
+  git -C "$MAIN" config commit.gpgsign false
+  printf 'base\n' >"$MAIN/base.txt"
+  git -C "$MAIN" add base.txt
+  git -C "$MAIN" commit -q -m base
+  git init -q --bare "$ROOT/origin.git"
+  git -C "$MAIN" remote add origin "$ROOT/origin.git"
+  git -C "$MAIN" push -q -u origin main
+  printf 'WORKTREE_BASE_DIR="../trees"\n' >"$MAIN/.env.local"
 }
 
-# `rev-parse --git-common-dir` prints a path relative to the repo, so resolve it
-# from inside the checkout rather than the caller's cwd.
-exclude_of() { ( cd "$1" && cat "$(git rev-parse --git-common-dir)/info/exclude" 2>/dev/null ); }
+must() {
+  "$@" || { echo "FIXTURE: '$*' failed in $ROOT" >&2; exit 2; }
+}
 
-############################################################
-echo "=== a symlinked path WITH tracked files stays stageable in main ==="
-############################################################
+commit_push() {
+  must git -C "$MAIN" commit -q -m "$1"
+  must git -C "$MAIN" push -q origin main
+}
 
-R="$TMP_ROOT/tracked"
-make_repo "$R"
-mkdir -p "$R/main/harness/skills"
-printf 'harness/state.json\n' >"$R/main/.gitignore"
-printf 'runtime\n' >"$R/main/harness/state.json"
-printf 'v1\n' >"$R/main/harness/skills/tool.md"
-printf 'WORKTREE_SYMLINKS="harness"\n' >"$R/main/.env.local"
-git -C "$R/main" add .gitignore harness/skills/tool.md .env.local
-git -C "$R/main" commit -q -m harness
-git -C "$R/main" push -q origin main
+# The step vocabulary. `repo` builds the world; the rest shape it.
+step() {
+  case "$1" in
+    repo) make_repo ;;
+    # The entry holds a tracked file beside an ignored runtime file.
+    tracked-entry)
+      ENTRY=harness
+      mkdir -p "$MAIN/harness/skills"
+      printf 'harness/state.json\n' >"$MAIN/.gitignore"
+      printf 'runtime\n' >"$MAIN/harness/state.json"
+      printf 'v1\n' >"$MAIN/harness/skills/tool.md"
+      printf 'WORKTREE_SYMLINKS="harness"\n' >>"$MAIN/.env.local"
+      must git -C "$MAIN" add .gitignore .env.local harness/skills/tool.md
+      commit_push harness
+      ;;
+    # The entry holds runtime files only, nothing tracked and no ignore rule.
+    runtime-entry)
+      ENTRY=runtime
+      mkdir -p "$MAIN/runtime/sub"
+      printf 'state\n' >"$MAIN/runtime/state.json"
+      printf 'more\n' >"$MAIN/runtime/sub/x.json"
+      printf 'WORKTREE_SYMLINKS="runtime"\n' >>"$MAIN/.env.local"
+      must git -C "$MAIN" add .env.local
+      commit_push runtime
+      ;;
+    # A file under the entry becomes tracked, or the tracked file stops being.
+    track:*)
+      printf 'now-tracked\n' >"$MAIN/${1#track:}"
+      must git -C "$MAIN" add -f "${1#track:}"
+      commit_push "track ${1#track:}"
+      ;;
+    untrack:*)
+      must git -C "$MAIN" rm -q --cached "${1#untrack:}"
+      commit_push "untrack ${1#untrack:}"
+      ;;
+    # The worktree's branch fast-forwarded to main, so its index agrees with main's.
+    sync-wt) must git -C "$WT" merge -q --ff-only origin/main ;;
+    # A tracked file under the entry edited in main, so staging it means something.
+    edit:*) printf 'v2\n' >"$MAIN/${1#edit:}" ;;
+    # A line another tool wrote into the shared exclude file.
+    foreign-line) printf '%s\n' '**/.claude/*' >>"$MAIN/.git/info/exclude" ;;
+    # A worktree created before the row's command; its own output is not the row's.
+    create:*)
+      WT="$ROOT/trees/${1#create:}"
+      (cd "$MAIN" && "$WORKTREE_SCRIPT" create "${1#create:}" >/dev/null 2>&1) || true
+      [[ -d "$WT" ]] || { echo "FIXTURE: create ${1#create:} left no worktree in $ROOT" >&2; exit 2; }
+      ;;
+    *)
+      echo "UNKNOWN-STEP: $1" >&2
+      exit 2
+      ;;
+  esac
+}
 
-WT="$( (cd "$R/main" && "$WORKTREE_SCRIPT" create tracked-check) 2>/dev/null )"
-[[ -n "$WT" && -d "$WT" ]] || { echo "FATAL: worktree not created"; exit 1; }
+build() {
+  local word
+  ROOT="$TMP_ROOT/$1"
+  shift
+  MAIN="$ROOT/main"
+  WT=""
+  ENTRY=""
+  mkdir -p "$ROOT"
+  for word in "$@"; do
+    step "$word"
+  done
+}
 
-EX="$(exclude_of "$R/main")"
-if grep -qxF 'harness' <<<"$EX"; then pass "bare entry is still written"; else fail "bare entry is still written"; fi
-if grep -qxF '!harness/' <<<"$EX"; then pass "negation is added for a tracked path"; else fail "negation is added for a tracked path"; fi
-# gitignore takes the LAST matching pattern, so order is load-bearing.
-if [[ "$(grep -nxF 'harness' <<<"$EX" | tail -1 | cut -d: -f1)" -lt "$(grep -nxF '!harness/' <<<"$EX" | tail -1 | cut -d: -f1)" ]]; then
-  pass "negation is ordered after the bare entry"
-else
-  fail "negation is ordered after the bare entry"
-fi
+# --- rendering ------------------------------------------------------------------
 
-# The reported symptom: staging a tracked file under that path from MAIN.
-printf 'v2\n' >"$R/main/harness/skills/tool.md"
-set +e
-add_out="$(git -C "$R/main" add harness/skills/tool.md 2>&1)"
-add_status=$?
-set -e
-assert_eq "$add_status" "0" "main checkout can stage a tracked file under the path"
-if [[ -z "$add_out" ]]; then pass "…with no ignore complaint"; else fail "…with no ignore complaint: $add_out"; fi
-assert_eq "$(git -C "$R/main" diff --cached --name-only)" "harness/skills/tool.md" "…and it actually staged"
-git -C "$R/main" reset -q
+alias_text() {
+  sed -e "s|$MAIN|<main>|g" -e "s|$ROOT|<root>|g" -e "s|$WORKTREE_SCRIPT|<worktree>|g" |
+    paste -s -d ';' -
+}
 
-# The worktree side must be unaffected: the tracked-content entry is a real
-# directory with per-child links, all invisible to status.
-assert_eq "$(git -C "$WT" status --porcelain)" "" "worktree stays clean (links still ignored)"
-if [[ -d "$WT/harness" && ! -L "$WT/harness" && -L "$WT/harness/state.json" ]]; then
-  pass "worktree path is a real dir with per-child links"
-else
-  fail "worktree path is a real dir with per-child links"
-fi
+# The exclude file's lines in order (git's template comments left out); main's status; whether main can stage
+# every tracked file under the entry (a dry run: its exit status and first
+# line, git's own refusal when the entry ignores them); then every entry of
+# the worktree (a link with its target, a file by name; git's own directory
+# left out, links not followed) and git's status of it. A removed worktree
+# renders as `wt=gone`.
+state() {
+  local exclude="" main_status="" stage="" entries="" wt_status="" path rc=0 out=""
+  local -a tracked=()
+  exclude="$(grep -v '^#' "$MAIN/.git/info/exclude" 2>/dev/null | paste -s -d ',' - || true)"
+  main_status="$(git -C "$MAIN" status --porcelain | paste -s -d ',' -)"
+  while IFS= read -r path; do
+    [[ -n "$path" ]] && tracked+=("$path")
+  done < <(git -C "$MAIN" ls-files -- "$ENTRY" "$ENTRY/" 2>/dev/null)
+  if [[ ${#tracked[@]} -gt 0 ]]; then
+    out="$(LC_ALL=C git -C "$MAIN" add --dry-run -- "${tracked[@]}" 2>&1)" || rc=$?
+    out="${out%%$'\n'*}"
+    stage="$rc:${out:--}"
+  fi
+  if [[ -n "$WT" && -d "$WT" ]]; then
+    entries="$(cd "$WT" && find . -mindepth 1 \( -path ./.git -prune \) -o \( -type f -o -type l \) -print | LC_ALL=C sort | while IFS= read -r path; do
+      if [[ -L "$path" ]]; then printf '%s->%s,' "${path#./}" "$(readlink "$path" | sed -e "s|$MAIN|<main>|" -e "s|$ROOT|<root>|")"
+      else printf '%s,' "${path#./}"; fi
+    done | sed 's/,$//')"
+    wt_status="$(git -C "$WT" status --porcelain 2>/dev/null | paste -s -d ',' -)"
+    printf 'exclude=%s main=%s stage=%s wt=%s wt-status=%s' "${exclude:--}" "${main_status:--}" "${stage:--}" "${entries:--}" "${wt_status:--}"
+  elif [[ -n "$WT" ]]; then
+    printf 'exclude=%s main=%s stage=%s wt=gone' "${exclude:--}" "${main_status:--}" "${stage:--}"
+  else
+    printf 'exclude=%s main=%s stage=%s' "${exclude:--}" "${main_status:--}" "${stage:--}"
+  fi
+}
 
-# The whole point of the entry: remove must not need --force.
-set +e
-rm_out="$( (cd "$R/main" && "$WORKTREE_SCRIPT" remove tracked-check) 2>&1 )"
-rm_status=$?
-set -e
-assert_eq "$rm_status" "0" "worktree remove still succeeds without --force"
+run() {
+  local -a argv
+  local rc=0
+  read -r -a argv <<<"${1//<wt>/$WT}"
+  if [[ "${argv[0]}" == create ]]; then WT="$ROOT/trees/${argv[1]}"; fi
+  (cd "$MAIN" && LC_ALL=C "$WORKTREE_SCRIPT" "${argv[@]}" >"$ROOT/out" 2>"$ROOT/err") || rc=$?
+  printf 'rc=%s out=%s err=%s %s' "$rc" "$(alias_text <"$ROOT/out")" "$(alias_text <"$ROOT/err")" "$(state)"
+}
 
-############################################################
-echo "=== a runtime-only symlinked path keeps the plain blanket entry ==="
-############################################################
+# --- the expected text ----------------------------------------------------------
 
-# Critical: kendex's own .agents mirror is hidden in main by this entry ALONE,
-# with no .gitignore rule behind it. Adding a negation there would expose the
-# entire runtime mirror as untracked noise.
-C="$TMP_ROOT/clean"
-make_repo "$C"
-mkdir -p "$C/main/runtime/sub"
-printf 'state\n' >"$C/main/runtime/state.json"
-printf 'more\n' >"$C/main/runtime/sub/x.json"
-printf 'WORKTREE_SYMLINKS="runtime"\n' >"$C/main/.env.local"
-git -C "$C/main" add .env.local
-git -C "$C/main" commit -q -m runtime
-git -C "$C/main" push -q origin main
+err_text() {
+  case "$1" in
+    -) printf '' ;;
+    deleted:*) printf "Deleted branch '%s' — merged into origin/main." "${1#deleted:}" ;;
+    *) printf 'UNKNOWN-ERR-SPEC:%s' "$1" ;;
+  esac
+}
 
-CWT="$( (cd "$C/main" && "$WORKTREE_SCRIPT" create clean-check) 2>/dev/null )"
-[[ -n "$CWT" ]] || { echo "FATAL: clean worktree not created"; exit 1; }
+out_text() {
+  case "$1" in
+    -) printf '' ;;
+    wt:*) printf '<root>/trees/%s' "${1#wt:}" ;;
+    restored:*) printf 'Restored symlinks in <root>/trees/%s' "${1#restored:}" ;;
+    removed:*) printf 'Removed: <root>/trees/%s' "${1#removed:}" ;;
+    *) printf 'UNKNOWN-OUT-SPEC:%s' "$1" ;;
+  esac
+}
 
-CEX="$(exclude_of "$C/main")"
-if grep -qxF 'runtime' <<<"$CEX"; then pass "bare entry written for a runtime-only path"; else fail "bare entry written for a runtime-only path"; fi
-if grep -qxF '!runtime/' <<<"$CEX"; then fail "no negation for a runtime-only path"; else pass "no negation for a runtime-only path"; fi
-# And main must NOT start reporting the runtime tree as untracked.
-assert_eq "$(git -C "$C/main" status --porcelain)" "" "main stays clean — runtime tree not exposed"
+# --- the rows ---------------------------------------------------------------------
+# label|fixture|command|rc|out|err|state
+ROWS='an entry with tracked content gets the bare line and the negation after it, and main stages its tracked file|repo tracked-entry edit:harness/skills/tool.md|create tracked-check|0|wt:tracked-check|-|exclude=harness,!harness/,harness/state.json main= M harness/skills/tool.md stage=0:add '\''harness/skills/tool.md'\'' wt=.env.local,.gitignore,base.txt,harness/skills/tool.md,harness/state.json-><main>/harness/state.json wt-status=-
+the entry'\''s lines stay after the worktree is removed|repo tracked-entry create:tracked-check|remove tracked-check|0|removed:tracked-check|deleted:tracked-check|exclude=harness,!harness/,harness/state.json main=- stage=0:- wt=gone
+a runtime-only entry keeps the plain line, and main does not see the runtime tree|repo runtime-entry|create clean-check|0|wt:clean-check|-|exclude=runtime main=- stage=- wt=.env.local,base.txt,runtime-><main>/runtime wt-status=-
+the negation appears once the entry gains a tracked file, the link becomes per-child links, and main stages it|repo runtime-entry create:clean-check track:runtime/sub/keep.md|fix-links <wt>|0|restored:clean-check|-|exclude=runtime,!runtime/,runtime/state.json,runtime/sub/x.json main=- stage=0:- wt=.env.local,base.txt,runtime/state.json-><main>/runtime/state.json,runtime/sub/x.json-><main>/runtime/sub/x.json wt-status=-
+a repeated pass rewrites the negation after the lines, once|repo tracked-entry create:tracked-check|fix-links <wt>|0|restored:tracked-check|-|exclude=harness,harness/state.json,!harness/ main=- stage=0:- wt=.env.local,.gitignore,base.txt,harness/skills/tool.md,harness/state.json-><main>/harness/state.json wt-status=-
+the negation stays while the worktree'\''s own index still tracks the file main dropped|repo tracked-entry create:tracked-check untrack:harness/skills/tool.md|fix-links <wt>|0|restored:tracked-check|-|exclude=harness,harness/state.json,!harness/ main=?? harness/ stage=- wt=.env.local,.gitignore,base.txt,harness/skills/tool.md,harness/state.json-><main>/harness/state.json wt-status=-
+the negation goes once neither index tracks a file under the entry|repo tracked-entry create:tracked-check untrack:harness/skills/tool.md sync-wt|fix-links <wt>|0|restored:tracked-check|-|exclude=harness,harness/state.json main=- stage=- wt=.env.local,.gitignore,base.txt,harness-><main>/harness wt-status=-
+a line another tool wrote into the exclude file stays, before ours|repo tracked-entry foreign-line|create tracked-check|0|wt:tracked-check|-|exclude=**/.claude/*,harness,!harness/,harness/state.json main=- stage=0:- wt=.env.local,.gitignore,base.txt,harness/skills/tool.md,harness/state.json-><main>/harness/state.json wt-status=-
+'
 
-############################################################
-echo "=== the shape self-heals when a path gains tracked content ==="
-############################################################
+echo "=== the exclude entry of a configured symlink path ==="
+n=0
+while IFS= read -r row; do
+  [[ -n "$row" ]] || continue
+  IFS='|' read -r label fixture command rc out err want_state <<<"$row"
+  for field in "$label" "$fixture" "$command" "$rc" "$out" "$err" "$want_state"; do
+    [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+  done
+  n=$((n + 1))
+  # shellcheck disable=SC2086
+  build "row-$n" $fixture
+  # A rendering aid for writing rows: prints what each row produces instead of
+  # asserting it. A run that asserted no row is refused after the loop.
+  if [[ "${WORKTREE_TABLE_PROBE:-}" == 1 ]]; then
+    printf '%s => %s\n' "$label" "$(run "$command")"
+    continue
+  fi
+  assert_eq "$(run "$command")" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want_state" "$label"
+done <<<"$ROWS"
+[[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 
-# Same repo: commit a file under the beforehand runtime-only path, then
-# re-materialize the links. The negation must appear without a manual edit.
-printf 'now-tracked\n' >"$C/main/runtime/sub/keep.md"
-git -C "$C/main" add -f runtime/sub/keep.md
-git -C "$C/main" commit -q -m 'track a file under the runtime path'
-git -C "$C/main" push -q origin main
-
-(cd "$C/main" && "$WORKTREE_SCRIPT" fix-links "$CWT") >/dev/null 2>&1 || true
-
-CEX2="$(exclude_of "$C/main")"
-if grep -qxF '!runtime/' <<<"$CEX2"; then pass "negation appears once the path gains tracked files"; else fail "negation appears once the path gains tracked files"; fi
-assert_eq "$(grep -cxF '!runtime/' <<<"$CEX2")" "1" "negation is not duplicated on repeat runs"
-
-set +e
-add2_status=0
-git -C "$C/main" add runtime/sub/keep.md 2>/dev/null || add2_status=$?
-set -e
-assert_eq "$add2_status" "0" "main can stage the newly tracked file"
-
-printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/worktree/tests/worktree_exclude_tracked_paths.sh
+++ b/skills/worktree/tests/worktree_exclude_tracked_paths.sh
@@ -1,17 +1,23 @@
 #!/usr/bin/env bash
-# `worktree create` writes the configured symlink path into the COMMON git
-# dir's info/exclude, which EVERY checkout of the repo reads — including main,
-# where that path is a real directory rather than the worktree's symlink.
-#
-# A bare entry therefore marked the whole directory ignored in the main
-# checkout, so `git add <tracked file under it>` started refusing with "The
-# following paths are ignored by one of your .gitignore files" while `git
-# status` still listed the file as modified. It also outlived the worktree
-#
-# Fix: when the path holds tracked content, follow the bare entry with
-# `!<path>/`. A trailing-slash pattern matches a real directory but NOT a
-# symlink pointing at one, so main regains the directory while the worktree's
-# symlink stays ignored. Runtime-only paths must keep the plain blanket entry.
+# The shape of the info/exclude entry a configured symlink path gets. The entry
+# lands in the COMMON git dir's info/exclude, which every checkout reads,
+# including main, where the same path is a real directory: a bare entry alone
+# marked that directory ignored in main, so `git add` of a tracked file under
+# it refused with git's ignore complaint while status still listed the file
+# as modified, and the entry outlived the worktree. When the path holds
+# tracked content the bare entry is followed by `!<path>/`: a trailing-slash
+# pattern matches a real directory but not a symlink to one, so main regains
+# the directory and the worktree's link stays ignored. A runtime-only path
+# keeps the plain entry (kendex's own .agents mirror is hidden in main by that
+# entry alone). The shape is recomputed on every pass, so it follows a path
+# that gains or loses tracked content, and lines other tools wrote stay.
+# One table, a row per scenario: the fixture is a word list of steps that
+# builds a checkout with its bare origin, the configured entry's content and
+# any worktree the row needs, the command runs from the checkout, and the row
+# pins its exit status, its stdout, its stderr and what is left: the exclude
+# file's lines, git's status of main, whether main can stage every tracked
+# file under the entry (git's own refusal, first line), and every entry of
+# the worktree with git's status of it.
 set -euo pipefail
 # A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
 # call below at the real repository; -C overrides neither.
@@ -24,142 +30,227 @@ trap 'rm -rf "$TMP_ROOT"' EXIT
 
 PASS=0
 FAIL=0
-pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
 
 assert_eq() {
   local got="$1" want="$2" name="$3"
-  if [[ "$got" == "$want" ]]; then pass "$name"; else
-    fail "$name"; printf '        want: %s\n        got:  %s\n' "$want" "$got"; fi
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
 }
 
+# gh is quiet: no row asks about a pull request.
 mkdir -p "$TMP_ROOT/bin"
 printf '#!/usr/bin/env bash\nexit 0\n' >"$TMP_ROOT/bin/gh"
 chmod +x "$TMP_ROOT/bin/gh"
 export PATH="$TMP_ROOT/bin:$PATH"
 
+# --- fixtures -----------------------------------------------------------------
+# Every row's world lives under its own ROOT: the checkout at ROOT/main, its
+# bare origin, and the worktree at ROOT/trees/<id>. ENTRY is the one
+# configured symlink path of the row.
+
+ROOT=""
+MAIN=""
+WT=""
+ENTRY=""
+
 make_repo() {
-  local root="$1"
-  mkdir -p "$root/main"
-  git -C "$root/main" init -q -b main
-  git -C "$root/main" config user.email test@example.com
-  git -C "$root/main" config user.name Test
-  git -C "$root/main" config commit.gpgsign false
-  printf 'base\n' >"$root/main/base.txt"
-  git -C "$root/main" add base.txt
-  git -C "$root/main" commit -q -m base
-  git init -q --bare "$root/origin.git"
-  git -C "$root/main" remote add origin "$root/origin.git"
-  git -C "$root/main" push -q -u origin main
+  mkdir -p "$MAIN"
+  git -C "$MAIN" init -q -b main
+  git -C "$MAIN" config user.email test@example.com
+  git -C "$MAIN" config user.name Test
+  git -C "$MAIN" config commit.gpgsign false
+  printf 'base\n' >"$MAIN/base.txt"
+  git -C "$MAIN" add base.txt
+  git -C "$MAIN" commit -q -m base
+  git init -q --bare "$ROOT/origin.git"
+  git -C "$MAIN" remote add origin "$ROOT/origin.git"
+  git -C "$MAIN" push -q -u origin main
+  printf 'WORKTREE_BASE_DIR="../trees"\n' >"$MAIN/.env.local"
 }
 
-# `rev-parse --git-common-dir` prints a path relative to the repo, so resolve it
-# from inside the checkout rather than the caller's cwd.
-exclude_of() { ( cd "$1" && cat "$(git rev-parse --git-common-dir)/info/exclude" 2>/dev/null ); }
+must() {
+  "$@" || { echo "FIXTURE: '$*' failed in $ROOT" >&2; exit 2; }
+}
 
-############################################################
-echo "=== a symlinked path WITH tracked files stays stageable in main ==="
-############################################################
+commit_push() {
+  must git -C "$MAIN" commit -q -m "$1"
+  must git -C "$MAIN" push -q origin main
+}
 
-R="$TMP_ROOT/tracked"
-make_repo "$R"
-mkdir -p "$R/main/harness/skills"
-printf 'harness/state.json\n' >"$R/main/.gitignore"
-printf 'runtime\n' >"$R/main/harness/state.json"
-printf 'v1\n' >"$R/main/harness/skills/tool.md"
-printf 'WORKTREE_SYMLINKS="harness"\n' >"$R/main/.env.local"
-git -C "$R/main" add .gitignore harness/skills/tool.md .env.local
-git -C "$R/main" commit -q -m harness
-git -C "$R/main" push -q origin main
+# The step vocabulary. `repo` builds the world; the rest shape it.
+step() {
+  case "$1" in
+    repo) make_repo ;;
+    # The entry holds a tracked file beside an ignored runtime file.
+    tracked-entry)
+      ENTRY=harness
+      mkdir -p "$MAIN/harness/skills"
+      printf 'harness/state.json\n' >"$MAIN/.gitignore"
+      printf 'runtime\n' >"$MAIN/harness/state.json"
+      printf 'v1\n' >"$MAIN/harness/skills/tool.md"
+      printf 'WORKTREE_SYMLINKS="harness"\n' >>"$MAIN/.env.local"
+      must git -C "$MAIN" add .gitignore .env.local harness/skills/tool.md
+      commit_push harness
+      ;;
+    # The entry holds runtime files only, nothing tracked and no ignore rule.
+    runtime-entry)
+      ENTRY=runtime
+      mkdir -p "$MAIN/runtime/sub"
+      printf 'state\n' >"$MAIN/runtime/state.json"
+      printf 'more\n' >"$MAIN/runtime/sub/x.json"
+      printf 'WORKTREE_SYMLINKS="runtime"\n' >>"$MAIN/.env.local"
+      must git -C "$MAIN" add .env.local
+      commit_push runtime
+      ;;
+    # A file under the entry becomes tracked, or the tracked file stops being.
+    track:*)
+      printf 'now-tracked\n' >"$MAIN/${1#track:}"
+      must git -C "$MAIN" add -f "${1#track:}"
+      commit_push "track ${1#track:}"
+      ;;
+    untrack:*)
+      must git -C "$MAIN" rm -q --cached "${1#untrack:}"
+      commit_push "untrack ${1#untrack:}"
+      ;;
+    # The worktree's branch fast-forwarded to main, so its index agrees with main's.
+    sync-wt) must git -C "$WT" merge -q --ff-only origin/main ;;
+    # A tracked file under the entry edited in main, so staging it means something.
+    edit:*) printf 'v2\n' >"$MAIN/${1#edit:}" ;;
+    # A line another tool wrote into the shared exclude file.
+    foreign-line) printf '%s\n' '**/.claude/*' >>"$MAIN/.git/info/exclude" ;;
+    # A worktree created before the row's command; its own output is not the row's.
+    create:*)
+      WT="$ROOT/trees/${1#create:}"
+      (cd "$MAIN" && "$WORKTREE_SCRIPT" create "${1#create:}" >/dev/null 2>&1) || true
+      [[ -d "$WT" ]] || { echo "FIXTURE: create ${1#create:} left no worktree in $ROOT" >&2; exit 2; }
+      ;;
+    *)
+      echo "UNKNOWN-STEP: $1" >&2
+      exit 2
+      ;;
+  esac
+}
 
-WT="$( (cd "$R/main" && "$WORKTREE_SCRIPT" create tracked-check) 2>/dev/null )"
-[[ -n "$WT" && -d "$WT" ]] || { echo "FATAL: worktree not created"; exit 1; }
+build() {
+  local word
+  ROOT="$TMP_ROOT/$1"
+  shift
+  MAIN="$ROOT/main"
+  WT=""
+  ENTRY=""
+  mkdir -p "$ROOT"
+  for word in "$@"; do
+    step "$word"
+  done
+}
 
-EX="$(exclude_of "$R/main")"
-if grep -qxF 'harness' <<<"$EX"; then pass "bare entry is still written"; else fail "bare entry is still written"; fi
-if grep -qxF '!harness/' <<<"$EX"; then pass "negation is added for a tracked path"; else fail "negation is added for a tracked path"; fi
-# gitignore takes the LAST matching pattern, so order is load-bearing.
-if [[ "$(grep -nxF 'harness' <<<"$EX" | tail -1 | cut -d: -f1)" -lt "$(grep -nxF '!harness/' <<<"$EX" | tail -1 | cut -d: -f1)" ]]; then
-  pass "negation is ordered after the bare entry"
-else
-  fail "negation is ordered after the bare entry"
-fi
+# --- rendering ------------------------------------------------------------------
 
-# The reported symptom: staging a tracked file under that path from MAIN.
-printf 'v2\n' >"$R/main/harness/skills/tool.md"
-set +e
-add_out="$(git -C "$R/main" add harness/skills/tool.md 2>&1)"
-add_status=$?
-set -e
-assert_eq "$add_status" "0" "main checkout can stage a tracked file under the path"
-if [[ -z "$add_out" ]]; then pass "…with no ignore complaint"; else fail "…with no ignore complaint: $add_out"; fi
-assert_eq "$(git -C "$R/main" diff --cached --name-only)" "harness/skills/tool.md" "…and it actually staged"
-git -C "$R/main" reset -q
+alias_text() {
+  sed -e "s|$MAIN|<main>|g" -e "s|$ROOT|<root>|g" -e "s|$WORKTREE_SCRIPT|<worktree>|g" |
+    paste -s -d ';' -
+}
 
-# The worktree side must be unaffected: the tracked-content entry is a real
-# directory with per-child links, all invisible to status.
-assert_eq "$(git -C "$WT" status --porcelain)" "" "worktree stays clean (links still ignored)"
-if [[ -d "$WT/harness" && ! -L "$WT/harness" && -L "$WT/harness/state.json" ]]; then
-  pass "worktree path is a real dir with per-child links"
-else
-  fail "worktree path is a real dir with per-child links"
-fi
+# The exclude file's lines in order (git's template comments left out); main's status; whether main can stage
+# every tracked file under the entry (a dry run: its exit status and first
+# line, git's own refusal when the entry ignores them); then every entry of
+# the worktree (a link with its target, a file by name; git's own directory
+# left out, links not followed) and git's status of it. A removed worktree
+# renders as `wt=gone`.
+state() {
+  local exclude="" main_status="" stage="" entries="" wt_status="" path rc=0 out=""
+  local -a tracked=()
+  exclude="$(grep -v '^#' "$MAIN/.git/info/exclude" 2>/dev/null | paste -s -d ',' - || true)"
+  main_status="$(git -C "$MAIN" status --porcelain | paste -s -d ',' -)"
+  while IFS= read -r path; do
+    [[ -n "$path" ]] && tracked+=("$path")
+  done < <(git -C "$MAIN" ls-files -- "$ENTRY" "$ENTRY/" 2>/dev/null)
+  if [[ ${#tracked[@]} -gt 0 ]]; then
+    out="$(LC_ALL=C git -C "$MAIN" add --dry-run -- "${tracked[@]}" 2>&1)" || rc=$?
+    out="${out%%$'\n'*}"
+    stage="$rc:${out:--}"
+  fi
+  if [[ -n "$WT" && -d "$WT" ]]; then
+    entries="$(cd "$WT" && find . -mindepth 1 \( -path ./.git -prune \) -o \( -type f -o -type l \) -print | LC_ALL=C sort | while IFS= read -r path; do
+      if [[ -L "$path" ]]; then printf '%s->%s,' "${path#./}" "$(readlink "$path" | sed -e "s|$MAIN|<main>|" -e "s|$ROOT|<root>|")"
+      else printf '%s,' "${path#./}"; fi
+    done | sed 's/,$//')"
+    wt_status="$(git -C "$WT" status --porcelain 2>/dev/null | paste -s -d ',' -)"
+    printf 'exclude=%s main=%s stage=%s wt=%s wt-status=%s' "${exclude:--}" "${main_status:--}" "${stage:--}" "${entries:--}" "${wt_status:--}"
+  elif [[ -n "$WT" ]]; then
+    printf 'exclude=%s main=%s stage=%s wt=gone' "${exclude:--}" "${main_status:--}" "${stage:--}"
+  else
+    printf 'exclude=%s main=%s stage=%s' "${exclude:--}" "${main_status:--}" "${stage:--}"
+  fi
+}
 
-# The whole point of the entry: remove must not need --force.
-set +e
-rm_out="$( (cd "$R/main" && "$WORKTREE_SCRIPT" remove tracked-check) 2>&1 )"
-rm_status=$?
-set -e
-assert_eq "$rm_status" "0" "worktree remove still succeeds without --force"
+run() {
+  local -a argv
+  local rc=0
+  read -r -a argv <<<"${1//<wt>/$WT}"
+  if [[ "${argv[0]}" == create ]]; then WT="$ROOT/trees/${argv[1]}"; fi
+  (cd "$MAIN" && LC_ALL=C "$WORKTREE_SCRIPT" "${argv[@]}" >"$ROOT/out" 2>"$ROOT/err") || rc=$?
+  printf 'rc=%s out=%s err=%s %s' "$rc" "$(alias_text <"$ROOT/out")" "$(alias_text <"$ROOT/err")" "$(state)"
+}
 
-############################################################
-echo "=== a runtime-only symlinked path keeps the plain blanket entry ==="
-############################################################
+# --- the expected text ----------------------------------------------------------
 
-# Critical: kendex's own .agents mirror is hidden in main by this entry ALONE,
-# with no .gitignore rule behind it. Adding a negation there would expose the
-# entire runtime mirror as untracked noise.
-C="$TMP_ROOT/clean"
-make_repo "$C"
-mkdir -p "$C/main/runtime/sub"
-printf 'state\n' >"$C/main/runtime/state.json"
-printf 'more\n' >"$C/main/runtime/sub/x.json"
-printf 'WORKTREE_SYMLINKS="runtime"\n' >"$C/main/.env.local"
-git -C "$C/main" add .env.local
-git -C "$C/main" commit -q -m runtime
-git -C "$C/main" push -q origin main
+err_text() {
+  case "$1" in
+    -) printf '' ;;
+    deleted:*) printf "Deleted branch '%s' — merged into origin/main." "${1#deleted:}" ;;
+    *) printf 'UNKNOWN-ERR-SPEC:%s' "$1" ;;
+  esac
+}
 
-CWT="$( (cd "$C/main" && "$WORKTREE_SCRIPT" create clean-check) 2>/dev/null )"
-[[ -n "$CWT" ]] || { echo "FATAL: clean worktree not created"; exit 1; }
+out_text() {
+  case "$1" in
+    -) printf '' ;;
+    wt:*) printf '<root>/trees/%s' "${1#wt:}" ;;
+    restored:*) printf 'Restored symlinks in <root>/trees/%s' "${1#restored:}" ;;
+    removed:*) printf 'Removed: <root>/trees/%s' "${1#removed:}" ;;
+    *) printf 'UNKNOWN-OUT-SPEC:%s' "$1" ;;
+  esac
+}
 
-CEX="$(exclude_of "$C/main")"
-if grep -qxF 'runtime' <<<"$CEX"; then pass "bare entry written for a runtime-only path"; else fail "bare entry written for a runtime-only path"; fi
-if grep -qxF '!runtime/' <<<"$CEX"; then fail "no negation for a runtime-only path"; else pass "no negation for a runtime-only path"; fi
-# And main must NOT start reporting the runtime tree as untracked.
-assert_eq "$(git -C "$C/main" status --porcelain)" "" "main stays clean — runtime tree not exposed"
+# --- the rows ---------------------------------------------------------------------
+# label|fixture|command|rc|out|err|state
+ROWS='an entry with tracked content gets the bare line and the negation after it, and main stages its tracked file|repo tracked-entry edit:harness/skills/tool.md|create tracked-check|0|wt:tracked-check|-|exclude=harness,!harness/,harness/state.json main= M harness/skills/tool.md stage=0:add '\''harness/skills/tool.md'\'' wt=.env.local,.gitignore,base.txt,harness/skills/tool.md,harness/state.json-><main>/harness/state.json wt-status=-
+the entry'\''s lines stay after the worktree is removed|repo tracked-entry create:tracked-check|remove tracked-check|0|removed:tracked-check|deleted:tracked-check|exclude=harness,!harness/,harness/state.json main=- stage=0:- wt=gone
+a runtime-only entry keeps the plain line, and main does not see the runtime tree|repo runtime-entry|create clean-check|0|wt:clean-check|-|exclude=runtime main=- stage=- wt=.env.local,base.txt,runtime-><main>/runtime wt-status=-
+the negation appears once the entry gains a tracked file, the link becomes per-child links, and main stages it|repo runtime-entry create:clean-check track:runtime/sub/keep.md|fix-links <wt>|0|restored:clean-check|-|exclude=runtime,!runtime/,runtime/state.json,runtime/sub/x.json main=- stage=0:- wt=.env.local,base.txt,runtime/state.json-><main>/runtime/state.json,runtime/sub/x.json-><main>/runtime/sub/x.json wt-status=-
+a repeated pass rewrites the negation after the lines, once|repo tracked-entry create:tracked-check|fix-links <wt>|0|restored:tracked-check|-|exclude=harness,harness/state.json,!harness/ main=- stage=0:- wt=.env.local,.gitignore,base.txt,harness/skills/tool.md,harness/state.json-><main>/harness/state.json wt-status=-
+the negation stays while the worktree'\''s own index still tracks the file main dropped|repo tracked-entry create:tracked-check untrack:harness/skills/tool.md|fix-links <wt>|0|restored:tracked-check|-|exclude=harness,harness/state.json,!harness/ main=?? harness/ stage=- wt=.env.local,.gitignore,base.txt,harness/skills/tool.md,harness/state.json-><main>/harness/state.json wt-status=-
+the negation goes once neither index tracks a file under the entry|repo tracked-entry create:tracked-check untrack:harness/skills/tool.md sync-wt|fix-links <wt>|0|restored:tracked-check|-|exclude=harness,harness/state.json main=- stage=- wt=.env.local,.gitignore,base.txt,harness-><main>/harness wt-status=-
+a line another tool wrote into the exclude file stays, before ours|repo tracked-entry foreign-line|create tracked-check|0|wt:tracked-check|-|exclude=**/.claude/*,harness,!harness/,harness/state.json main=- stage=0:- wt=.env.local,.gitignore,base.txt,harness/skills/tool.md,harness/state.json-><main>/harness/state.json wt-status=-
+'
 
-############################################################
-echo "=== the shape self-heals when a path gains tracked content ==="
-############################################################
+echo "=== the exclude entry of a configured symlink path ==="
+n=0
+while IFS= read -r row; do
+  [[ -n "$row" ]] || continue
+  IFS='|' read -r label fixture command rc out err want_state <<<"$row"
+  for field in "$label" "$fixture" "$command" "$rc" "$out" "$err" "$want_state"; do
+    [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+  done
+  n=$((n + 1))
+  # shellcheck disable=SC2086
+  build "row-$n" $fixture
+  # A rendering aid for writing rows: prints what each row produces instead of
+  # asserting it. A run that asserted no row is refused after the loop.
+  if [[ "${WORKTREE_TABLE_PROBE:-}" == 1 ]]; then
+    printf '%s => %s\n' "$label" "$(run "$command")"
+    continue
+  fi
+  assert_eq "$(run "$command")" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want_state" "$label"
+done <<<"$ROWS"
+[[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 
-# Same repo: commit a file under the beforehand runtime-only path, then
-# re-materialize the links. The negation must appear without a manual edit.
-printf 'now-tracked\n' >"$C/main/runtime/sub/keep.md"
-git -C "$C/main" add -f runtime/sub/keep.md
-git -C "$C/main" commit -q -m 'track a file under the runtime path'
-git -C "$C/main" push -q origin main
-
-(cd "$C/main" && "$WORKTREE_SCRIPT" fix-links "$CWT") >/dev/null 2>&1 || true
-
-CEX2="$(exclude_of "$C/main")"
-if grep -qxF '!runtime/' <<<"$CEX2"; then pass "negation appears once the path gains tracked files"; else fail "negation appears once the path gains tracked files"; fi
-assert_eq "$(grep -cxF '!runtime/' <<<"$CEX2")" "1" "negation is not duplicated on repeat runs"
-
-set +e
-add2_status=0
-git -C "$C/main" add runtime/sub/keep.md 2>/dev/null || add2_status=$?
-set -e
-assert_eq "$add2_status" "0" "main can stage the newly tracked file"
-
-printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Reshapes `skills/worktree/tests/worktree_exclude_tracked_paths.sh` to code-quality § Tests. The suite pinned the shape of the info/exclude entry a configured symlink path gets (the bare line; the `!<path>/` negation after it when the path holds tracked content, so the main checkout can still stage files under it; the plain line for a runtime-only path; the negation appearing once the path gains a tracked file) in three long-lived scenarios of grep checks over two worlds. Those are now one table of 8 rows: a row builds its own checkout with its bare origin, the entry's content and any worktree it needs from a step word list (`repo`, `tracked-entry`, `runtime-entry`, `track:<file>`, `untrack:<file>`, `sync-wt`, `edit:<file>`, `foreign-line`, `create:<id>`), runs one command from the checkout, and pins the exit status, stdout, stderr whole and what is left: the exclude file's non-comment lines in order, git's status of main, whether main can stage every tracked file under the entry (a dry run: exit status and first line, git's own refusal when the entry ignores them), and every entry of the worktree with git's status of it. The row loop refuses a row with an empty field, and a run that asserted no row exits 2.

The tracked render under `.agents` is replayed with `patch`.

## Folded or deleted cases, with the surviving row

| Former assertions | Surviving row |
|---|---|
| the bare entry is written; the negation is added; the negation is ordered after the bare entry | `an entry with tracked content gets the bare line and the negation after it, and main stages its tracked file` (`exclude=harness,!harness/,harness/state.json` whole, in order) |
| main stages a tracked file under the path (exit 0, no ignore complaint); it actually staged | the same row's `stage=0:add 'harness/skills/tool.md'` (the index-content claim is the one named loss: the dry run keeps the discriminator, git's refusal versus the add line, without perturbing the row's own `main=`) |
| the worktree stays clean; the path is a real directory with per-child links | the same row's `wt-status=-` and `wt=` (children listed, no parent link) |
| remove succeeds without --force | `the entry's lines stay after the worktree is removed` (the reviewer showed `remove` forces unconditionally, so the row's content is the lines outliving the worktree) |
| a runtime-only path gets the bare entry and no negation; main stays clean | `a runtime-only entry keeps the plain line, and main does not see the runtime tree` |
| the negation appears once the path gains tracked files; it is not duplicated; main can stage the file | `the negation appears once the entry gains a tracked file, the link becomes per-child links, and main stages it`; `a repeated pass rewrites the negation after the lines, once` |

Three rows are new, each a claim the code states: `a line another tool wrote into the exclude file stays, before ours`; `the negation stays while the worktree's own index still tracks the file main dropped` (both indexes decide the shape); `the negation goes once neither index tracks a file under the entry`. Two behaviours of the caller are now pinned because the field is the whole file: each per-child link gets its own exclude line, and an entry that gains tracked content becomes a real directory with per-child links.

## Mutation

Nineteen must-fail mutants over a scratch copy of `skills/worktree` (`mutants-ex-2.txt` in the lane scratchpad; `mutate-ex.py` makes them, each run in its own process group under a 300 s bound), all killed: the negation never written, written before the bare entry, written for every path, not dropped before re-append, only the worktree's index asked (row 4 alone), only main's asked (row 6 alone), the bare entry duplicated, other tools' lines dropped, the negation without its slash, the exclude file wiped on remove (row 2 alone), tracked-ness read off the disk (rows 3 and 7), the entry written to the worktree's own git dir; and seven suite mutants (the edit, foreign-line and sync-wt steps made no-ops, the track and untrack steps acting on a file outside the entry, a row blanked to its separators, the probe hatch armed by default). `WORKTREE_TABLE_PROBE=1 bash <suite>` exits 2 with no `ok` line.

## Reviewer round

One reviewer-test round, ACCEPT WITH FIXES, all applied: S1, row 2's label claimed a `--force`-free remove the row could not test; S2, the stage field read `head`'s SIGPIPE status instead of git's when both lines printed; S3, five of the reviewer's mutants absorbed (an isolator for row 2, a narrower one for row 3, the common-dir claim, and two fixture no-ops that redden rows instead of crashing the fixture).

## Checks

- `worktree_exclude_tracked_paths.sh`: 8 assertions, TMPDIR=/var/tmp/ken-c, also green under `init.defaultBranch=master` and `LC_ALL=de_DE.UTF-8`; `shellcheck` clean; `tools/bash32-lint skills/worktree` clean; source and render byte-identical.
- `tools/guard --full`: exit 0 on 59e1d9773 (TMPDIR=/var/tmp/ken-c), the same tree restacked onto main as 462d6389d.

KEN-1241

https://claude.ai/code/session_01624Ks71377efHigfawmVYe
