### PR TITLE
test(KEN-1241): worktree_for_branch as one table of porcelain shapes

### DIFF
--- a/.agents/skills/worktree/tests/worktree_for_branch.sh
+++ b/.agents/skills/worktree/tests/worktree_for_branch.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
-# Tests for worktree_for_branch: success must
-# always carry a non-empty worktree path, so command-substitution callers can
-# treat empty output as "no worktree" without also getting exit 0.
+# `worktree_for_branch`, the parser of `git worktree list --porcelain -z`:
+# success always carries a non-empty worktree path, so a command-substitution
+# caller can read empty output as "no worktree" without also getting exit 0.
+# One table, a row per porcelain shape: the row's listing stands in for git's
+# (a stanza without a worktree line, a pathless stanza before the real match,
+# a pathless stanza after one with a path, a well-formed stanza, an absent
+# branch, a path recorded under a symlinked spelling), and the row pins the
+# function's exit status and output.
 set -euo pipefail
 # A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
 # call below at the real repository; -C overrides neither.
@@ -26,6 +31,10 @@ assert_eq() {
   fi
 }
 
+# --- fixture ------------------------------------------------------------------
+# One checkout to source the script in (the `path` command has no side
+# effects); the rows never touch it.
+
 ROOT="$TMP_ROOT/porcelain"
 mkdir -p "$ROOT/main"
 git -C "$ROOT/main" init -q -b main
@@ -35,11 +44,15 @@ git -C "$ROOT/main" config commit.gpgsign false
 printf 'base\n' >"$ROOT/main/base.txt"
 git -C "$ROOT/main" add base.txt
 git -C "$ROOT/main" commit -q -m base
+# A worktree recorded under a symlinked spelling: the row asserts the physical
+# path, which only the canonicalizing arm can produce.
+mkdir -p "$ROOT/real/ghost"
+ln -s "$ROOT/real" "$ROOT/link"
 
-# Sources the script (the `path` command has no side effects) to get
-# worktree_for_branch, overrides git to emit a fixed NUL-delimited porcelain
-# listing, and prints the function's exit status and output for assertions.
-probe_worktree_for_branch() {
+# Sources the script to get worktree_for_branch, overrides git to emit the
+# row's NUL-delimited listing for `worktree list --porcelain -z` (every other
+# git call is the real one), and prints the function's exit status and output.
+run() {
   local porcelain_fmt="$1" branch="$2"
   (
     cd "$ROOT/main"
@@ -58,23 +71,38 @@ probe_worktree_for_branch() {
     set +e
     out="$(worktree_for_branch "$branch")"
     rc=$?
-    printf 'rc=%s out=%s' "$rc" "$out"
+    printf 'rc=%s out=%s' "$rc" "${out:--}"
   )
 }
 
-echo "=== worktree_for_branch porcelain edge cases ==="
+# --- the rows ---------------------------------------------------------------------
+# label|porcelain (printf format, \0 between lines; <root> is the fixture's root)|branch|rc|out
+ROWS='a branch entry without a worktree line is not a match|branch refs/heads/ghost\0|ghost|1|-
+the scan continues past a pathless stanza to the real match|branch refs/heads/ghost\0\0worktree /real/ghost\0branch refs/heads/ghost\0|ghost|0|/real/ghost
+a well-formed stanza resolves the worktree path|worktree /wt/ghost\0HEAD 0000000000000000000000000000000000000000\0branch refs/heads/ghost\0|ghost|0|/wt/ghost
+a pathless stanza after a stanza with a path does not inherit that path|worktree /wt/other\0branch refs/heads/other\0\0branch refs/heads/ghost\0|ghost|1|-
+an absent branch is no worktree, a longer name with its prefix included|worktree /wt/ghostly\0branch refs/heads/ghostly\0|ghost|1|-
+a path recorded under a symlinked spelling is reported as the physical directory|worktree <root>/link/ghost\0branch refs/heads/ghost\0|ghost|0|<root>/real/ghost
+'
 
-got="$(probe_worktree_for_branch 'branch refs/heads/ghost\0' ghost)"
-assert_eq "$got" "rc=1 out=" "branch entry without a worktree path is not a match"
-
-got="$(probe_worktree_for_branch 'branch refs/heads/ghost\0\0worktree /real/ghost\0branch refs/heads/ghost\0' ghost)"
-assert_eq "$got" "rc=0 out=/real/ghost" "scanning continues past a pathless stanza to a real match"
-
-got="$(probe_worktree_for_branch 'worktree /wt/ghost\0HEAD 0000000000000000000000000000000000000000\0branch refs/heads/ghost\0' ghost)"
-assert_eq "$got" "rc=0 out=/wt/ghost" "well-formed stanza still resolves the worktree path"
-
-got="$(probe_worktree_for_branch 'worktree /wt/other\0branch refs/heads/other\0' ghost)"
-assert_eq "$got" "rc=1 out=" "absent branch still returns no-worktree"
+echo "=== worktree_for_branch over porcelain shapes ==="
+while IFS= read -r row; do
+  [[ -n "$row" ]] || continue
+  IFS='|' read -r label porcelain branch rc out <<<"$row"
+  porcelain="${porcelain//<root>/$ROOT}"
+  out="${out//<root>/$ROOT}"
+  for field in "$label" "$porcelain" "$branch" "$rc" "$out"; do
+    [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+  done
+  # A rendering aid for writing rows: prints what each row produces instead of
+  # asserting it. A run that asserted no row is refused after the loop.
+  if [[ "${WORKTREE_TABLE_PROBE:-}" == 1 ]]; then
+    printf '%s => %s\n' "$label" "$(run "$porcelain" "$branch")"
+    continue
+  fi
+  assert_eq "$(run "$porcelain" "$branch")" "rc=$rc out=$out" "$label"
+done <<<"$ROWS"
+[[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/worktree/tests/worktree_for_branch.sh
+++ b/skills/worktree/tests/worktree_for_branch.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
-# Tests for worktree_for_branch: success must
-# always carry a non-empty worktree path, so command-substitution callers can
-# treat empty output as "no worktree" without also getting exit 0.
+# `worktree_for_branch`, the parser of `git worktree list --porcelain -z`:
+# success always carries a non-empty worktree path, so a command-substitution
+# caller can read empty output as "no worktree" without also getting exit 0.
+# One table, a row per porcelain shape: the row's listing stands in for git's
+# (a stanza without a worktree line, a pathless stanza before the real match,
+# a pathless stanza after one with a path, a well-formed stanza, an absent
+# branch, a path recorded under a symlinked spelling), and the row pins the
+# function's exit status and output.
 set -euo pipefail
 # A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
 # call below at the real repository; -C overrides neither.
@@ -26,6 +31,10 @@ assert_eq() {
   fi
 }
 
+# --- fixture ------------------------------------------------------------------
+# One checkout to source the script in (the `path` command has no side
+# effects); the rows never touch it.
+
 ROOT="$TMP_ROOT/porcelain"
 mkdir -p "$ROOT/main"
 git -C "$ROOT/main" init -q -b main
@@ -35,11 +44,15 @@ git -C "$ROOT/main" config commit.gpgsign false
 printf 'base\n' >"$ROOT/main/base.txt"
 git -C "$ROOT/main" add base.txt
 git -C "$ROOT/main" commit -q -m base
+# A worktree recorded under a symlinked spelling: the row asserts the physical
+# path, which only the canonicalizing arm can produce.
+mkdir -p "$ROOT/real/ghost"
+ln -s "$ROOT/real" "$ROOT/link"
 
-# Sources the script (the `path` command has no side effects) to get
-# worktree_for_branch, overrides git to emit a fixed NUL-delimited porcelain
-# listing, and prints the function's exit status and output for assertions.
-probe_worktree_for_branch() {
+# Sources the script to get worktree_for_branch, overrides git to emit the
+# row's NUL-delimited listing for `worktree list --porcelain -z` (every other
+# git call is the real one), and prints the function's exit status and output.
+run() {
   local porcelain_fmt="$1" branch="$2"
   (
     cd "$ROOT/main"
@@ -58,23 +71,38 @@ probe_worktree_for_branch() {
     set +e
     out="$(worktree_for_branch "$branch")"
     rc=$?
-    printf 'rc=%s out=%s' "$rc" "$out"
+    printf 'rc=%s out=%s' "$rc" "${out:--}"
   )
 }
 
-echo "=== worktree_for_branch porcelain edge cases ==="
+# --- the rows ---------------------------------------------------------------------
+# label|porcelain (printf format, \0 between lines; <root> is the fixture's root)|branch|rc|out
+ROWS='a branch entry without a worktree line is not a match|branch refs/heads/ghost\0|ghost|1|-
+the scan continues past a pathless stanza to the real match|branch refs/heads/ghost\0\0worktree /real/ghost\0branch refs/heads/ghost\0|ghost|0|/real/ghost
+a well-formed stanza resolves the worktree path|worktree /wt/ghost\0HEAD 0000000000000000000000000000000000000000\0branch refs/heads/ghost\0|ghost|0|/wt/ghost
+a pathless stanza after a stanza with a path does not inherit that path|worktree /wt/other\0branch refs/heads/other\0\0branch refs/heads/ghost\0|ghost|1|-
+an absent branch is no worktree, a longer name with its prefix included|worktree /wt/ghostly\0branch refs/heads/ghostly\0|ghost|1|-
+a path recorded under a symlinked spelling is reported as the physical directory|worktree <root>/link/ghost\0branch refs/heads/ghost\0|ghost|0|<root>/real/ghost
+'
 
-got="$(probe_worktree_for_branch 'branch refs/heads/ghost\0' ghost)"
-assert_eq "$got" "rc=1 out=" "branch entry without a worktree path is not a match"
-
-got="$(probe_worktree_for_branch 'branch refs/heads/ghost\0\0worktree /real/ghost\0branch refs/heads/ghost\0' ghost)"
-assert_eq "$got" "rc=0 out=/real/ghost" "scanning continues past a pathless stanza to a real match"
-
-got="$(probe_worktree_for_branch 'worktree /wt/ghost\0HEAD 0000000000000000000000000000000000000000\0branch refs/heads/ghost\0' ghost)"
-assert_eq "$got" "rc=0 out=/wt/ghost" "well-formed stanza still resolves the worktree path"
-
-got="$(probe_worktree_for_branch 'worktree /wt/other\0branch refs/heads/other\0' ghost)"
-assert_eq "$got" "rc=1 out=" "absent branch still returns no-worktree"
+echo "=== worktree_for_branch over porcelain shapes ==="
+while IFS= read -r row; do
+  [[ -n "$row" ]] || continue
+  IFS='|' read -r label porcelain branch rc out <<<"$row"
+  porcelain="${porcelain//<root>/$ROOT}"
+  out="${out//<root>/$ROOT}"
+  for field in "$label" "$porcelain" "$branch" "$rc" "$out"; do
+    [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+  done
+  # A rendering aid for writing rows: prints what each row produces instead of
+  # asserting it. A run that asserted no row is refused after the loop.
+  if [[ "${WORKTREE_TABLE_PROBE:-}" == 1 ]]; then
+    printf '%s => %s\n' "$label" "$(run "$porcelain" "$branch")"
+    continue
+  fi
+  assert_eq "$(run "$porcelain" "$branch")" "rc=$rc out=$out" "$label"
+done <<<"$ROWS"
+[[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"


### PR DESCRIPTION
Reshapes `skills/worktree/tests/worktree_for_branch.sh`, the probes of `worktree_for_branch` (the parser of `git worktree list --porcelain -z`), from four calls into one table of six rows. Each row's listing stands in for git's through the same override the old probe used, and the row pins the function's exit status and output. Three shapes are new: a stanza with no worktree line after a stanza with one, which is the only row that reddens when the reset between stanzas is dropped (the previous stanza's path would leak into the match), and the absent branch spelled as a longer name sharing the prefix, so a prefix match reddens; and, from the reviewer round, a path recorded under a symlinked spelling reported as the physical directory, the only pin of the canonicalizing arm anywhere in the skill's tests (every other row's path does not exist, so only the fallback arm ran).

## Folded or deleted cases, with the surviving row

| Former assertions | Surviving row |
|---|---|
| a branch entry without a worktree path is not a match (rc 1, empty) | `a branch entry without a worktree line is not a match` |
| scanning continues past a pathless stanza to a real match | `the scan continues past a pathless stanza to the real match` |
| a well-formed stanza resolves the worktree path | `a well-formed stanza resolves the worktree path` |
| an absent branch returns no-worktree | `an absent branch is no worktree, a longer name with its prefix included` (`ghostly` for `ghost`) |
| (new) | `a pathless stanza after a stanza with a path does not inherit that path` |
| (new, the reviewer's) | `a path recorded under a symlinked spelling is reported as the physical directory` |

## Mutation

Eleven must-fail mutants over a scratch copy of `skills/worktree` (`mutants-fb-2.txt` in the lane scratchpad; `mutate-fb.py`), all killed: a pathless stanza taken as a match, the reset between stanzas dropped (the reset row alone), the branch matched by prefix (the renamed row alone), no match exiting 0, a match printing nothing, the listing read newline-delimited (its first run was a bad edit matching two sites; the retargeted run is the record), the canonicalizing arm dropped (the symlinked row alone), a line matching no clause clobbering the path (the HEAD-line row alone), the prefix strip losing its space, any branch line matching, and the git override made a no-op.

## Reviewer round

One reviewer-test round, ACCEPT WITH FIXES, the one fix applied: the canonicalization row above (the arm was unpinned everywhere; `worktree_path_for_issue` feeds this output into a canonical path comparison). The reviewer's four extra mutants are recorded. The `${out:--}` rendering of an empty output was judged no loss: the function prints an absolute path or nothing, every row expecting `-` expects rc 1, and it is the shape every sibling table uses.

## Checks

- `worktree_for_branch.sh`: 6 rows, green with TMPDIR=/var/tmp/ken-c, under `LC_ALL=de_DE.UTF-8` and under `init.defaultBranch=master`; `shellcheck -x` no worse than at main (the two infos on the sourced script and the overriding `git` function are at main too); `tools/bash32-lint skills/worktree` clean; source and render byte-identical; no inventory change.
- `tools/guard --full`: exit 0 on a1e73b7be (TMPDIR=/var/tmp/ken-c), the same tree restacked onto main as adb100f25.

KEN-1241

https://claude.ai/code/session_01JjdknThZvqDq3HUfHPkRNe
