### PR TITLE
test(KEN-1241): the atomic symlink swap as one table of rows

### DIFF
--- a/.agents/skills/worktree/tests/worktree_atomic_symlink_swap.sh
+++ b/.agents/skills/worktree/tests/worktree_atomic_symlink_swap.sh
@@ -1,14 +1,17 @@
 #!/usr/bin/env bash
-# replacing a configured symlink must not leave the destination absent,
-# so the swap goes through a pre-built temp link and a rename. The hazard that
-# introduces is following a symlinked-to-directory destination — a plain `mv`
-# deposits the temp link INSIDE the target instead of replacing it, which is
-# why the swap needs `mv -T` (GNU) / `mv -h` (BSD). These assertions fail on a
-# naive rename just as loudly as on a failure to the old rm+ln pair.
-#
-# `claude-setup` / `claude-cleanup` must provide the same provisioning
-# and teardown semantics as the Codex pair, for worktrees Claude Code creates
-# itself via its WorktreeCreate hook.
+# The atomic swap of a configured symlink. Replacing a link must never leave
+# its destination absent, so the swap builds the new link under a temp name
+# and renames it over the old one; the hazard that introduces is following a
+# link-to-directory destination, where a plain `mv` deposits the temp link
+# inside the target instead of replacing it (hence `mv -T` on GNU, `mv -h` on
+# BSD). One table, a row per scenario: the fixture builds a checkout with its
+# bare origin, a directory entry and a file entry, and the worktree, and
+# shapes the destination under test; fix-links runs from the checkout, and
+# the row pins its exit status, its stdout, its stderr and what is left:
+# every entry of the worktree and of the main checkout's directory entry (a
+# link with its target, a file by name; a temp name with its number aliased),
+# so a link deposited inside the target, a temp file left behind, or content
+# copied into the source all show.
 set -euo pipefail
 # A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
 # call below at the real repository; -C overrides neither.
@@ -22,128 +25,186 @@ trap 'rm -rf "$TMP_ROOT"' EXIT
 PASS=0
 FAIL=0
 
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
-
-assert_symlink() {
-  local path="$1" name="$2"
-  if [[ -L "$path" ]]; then ok "$name"; else bad "$name" "not a symlink: $path"; fi
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
 }
 
-assert_missing() {
-  local path="$1" name="$2"
-  if [[ -e "$path" || -L "$path" ]]; then bad "$name" "unexpectedly exists: $path"; else ok "$name"; fi
-}
-
-assert_contains() {
-  local haystack="$1" needle="$2" name="$3"
-  if grep -qF -- "$needle" <<<"$haystack"; then ok "$name"; else bad "$name" "wanted: $needle"; fi
-}
-
+# gh is quiet: no row asks about a pull request.
 mkdir -p "$TMP_ROOT/bin"
-cat >"$TMP_ROOT/bin/gh" <<'STUB'
-#!/usr/bin/env bash
-exit 0
-STUB
+printf '#!/usr/bin/env bash\nexit 0\n' >"$TMP_ROOT/bin/gh"
 chmod +x "$TMP_ROOT/bin/gh"
 export PATH="$TMP_ROOT/bin:$PATH"
 
+# --- fixtures -----------------------------------------------------------------
+# Every row's world lives under its own ROOT: the checkout at ROOT/main, its
+# bare origin, and the worktree at ROOT/trees/<id>.
+
+ROOT=""
+MAIN=""
+WT=""
+
 make_repo() {
-  local root="$1"
-  mkdir -p "$root/main"
-  git -C "$root/main" init -q -b main
-  git -C "$root/main" config user.email test@example.com
-  git -C "$root/main" config user.name Test
-  git -C "$root/main" config commit.gpgsign false
-  printf 'base\n' >"$root/main/base.txt"
-  git -C "$root/main" add base.txt
-  git -C "$root/main" commit -q -m base
-  git init -q --bare "$root/origin.git"
-  git -C "$root/main" remote add origin "$root/origin.git"
-  git -C "$root/main" push -q -u origin main
+  mkdir -p "$MAIN"
+  git -C "$MAIN" init -q -b main
+  git -C "$MAIN" config user.email test@example.com
+  git -C "$MAIN" config user.name Test
+  git -C "$MAIN" config commit.gpgsign false
+  printf 'base\n' >"$MAIN/base.txt"
+  git -C "$MAIN" add base.txt
+  git -C "$MAIN" commit -q -m base
+  git init -q --bare "$ROOT/origin.git"
+  git -C "$MAIN" remote add origin "$ROOT/origin.git"
+  git -C "$MAIN" push -q -u origin main
+  printf 'WORKTREE_BASE_DIR="../trees"\n' >"$MAIN/.env.local"
 }
 
-ROOT="$TMP_ROOT/repo"
-make_repo "$ROOT"
-MAIN="$ROOT/main"
-mkdir -p "$MAIN/runtime"
-printf 'runtime/\nharnessrc\n' >"$MAIN/.gitignore"
-printf 'state\n' >"$MAIN/runtime/state.json"
-printf 'rc\n' >"$MAIN/harnessrc"
-printf 'WORKTREE_SYMLINKS="runtime harnessrc"\n' >"$MAIN/.env.local"
-git -C "$MAIN" add .gitignore
-git -C "$MAIN" commit -q -m ignore
-git -C "$MAIN" push -q origin main
+must() {
+  "$@" || { echo "FIXTURE: '$*' failed in $ROOT" >&2; exit 2; }
+}
 
-WT="$(cd "$MAIN" && "$WORKTREE_SCRIPT" create swap-check 2>/dev/null | tail -1)"
+commit_push() {
+  must git -C "$MAIN" commit -q -m "$1"
+  must git -C "$MAIN" push -q origin main
+}
 
-echo "=== baseline: create links both a directory and a file entry ==="
-# Power check for everything below: if these are not symlinks to begin with,
-# the replacement assertions would pass trivially on a broken implementation.
-assert_symlink "$WT/runtime" "directory entry is a symlink"
-assert_symlink "$WT/harnessrc" "file entry is a symlink"
+# The step vocabulary. `repo` builds the world; the rest shape it.
+step() {
+  case "$1" in
+    repo) make_repo ;;
+    # A directory entry and a file entry, both untracked (nothing in the swap
+    # path reads an ignore file, so none is written).
+    entries)
+      mkdir -p "$MAIN/runtime"
+      printf 'state\n' >"$MAIN/runtime/state.json"
+      printf 'rc\n' >"$MAIN/harnessrc"
+      printf 'WORKTREE_SYMLINKS="runtime harnessrc"\n' >>"$MAIN/.env.local"
+      must git -C "$MAIN" add .env.local
+      commit_push entries
+      ;;
+    # A worktree created before the row's command; its own output is not the row's.
+    create:*)
+      WT="$ROOT/trees/${1#create:}"
+      (cd "$MAIN" && "$WORKTREE_SCRIPT" create "${1#create:}" >/dev/null 2>&1) || true
+      [[ -d "$WT" ]] || { echo "FIXTURE: create ${1#create:} left no worktree in $ROOT" >&2; exit 2; }
+      ;;
+    # What a rebase leaves when tracked files exist under the entry: a real
+    # directory where the link was, holding a file of its own.
+    materialized:*)
+      rm -f "$WT/${1#materialized:}"
+      mkdir -p "$WT/${1#materialized:}"
+      printf 'partial\n' >"$WT/${1#materialized:}/leftover.txt"
+      # Reconciliation makes this row's end state the healthy one, so the step
+      # proves here that it built what the row claims to reconcile.
+      [[ -d "$WT/${1#materialized:}" && ! -L "$WT/${1#materialized:}" && -s "$WT/${1#materialized:}/leftover.txt" ]] ||
+        { echo "FIXTURE: materialized:${1#materialized:} left no real directory holding a file in $ROOT" >&2; exit 2; }
+      ;;
+    *)
+      echo "UNKNOWN-STEP: $1" >&2
+      exit 2
+      ;;
+  esac
+}
 
-echo "=== replacing an existing symlink-to-dir must not nest inside the target ==="
-(cd "$MAIN" && "$WORKTREE_SCRIPT" fix-links "$WT" >/dev/null 2>&1)
-assert_symlink "$WT/runtime" "directory entry is still a symlink after re-link"
-# The naive-`mv` failure mode, and the whole reason the swap needs -T/-h: a
-# `mv` that follows the symlinked destination deposits the temp link INSIDE the
-# target directory (as runtime.wt-tmp.NNN, not as "runtime" — checking for the
-# latter is an assertion that can never fire).
-nested="$(find "$MAIN/runtime" -maxdepth 1 -type l 2>/dev/null || true)"
-if [[ -z "$nested" ]]; then
-  ok "no link deposited inside the symlink target"
-else
-  bad "no link deposited inside the symlink target" "$nested"
-fi
-assert_symlink "$WT/harnessrc" "file entry survives re-link"
+build() {
+  local word
+  ROOT="$TMP_ROOT/$1"
+  shift
+  MAIN="$ROOT/main"
+  WT=""
+  mkdir -p "$ROOT"
+  for word in "$@"; do
+    step "$word"
+  done
+}
 
-echo "=== the swap leaves no temp artifacts behind ==="
-leftovers="$(find "$WT" "$MAIN" -maxdepth 2 -name '*.wt-tmp.*' 2>/dev/null || true)"
-if [[ -z "$leftovers" ]]; then ok "no .wt-tmp.* residue"; else bad "no .wt-tmp.* residue" "$leftovers"; fi
+# --- rendering ------------------------------------------------------------------
 
-echo "=== a materialized real directory is reconciled back to a symlink ==="
-# What a rebase does when tracked files exist under the symlinked path: the
-# symlink becomes a real directory holding only the tracked subset.
-rm -f "$WT/runtime"
-mkdir -p "$WT/runtime"
-printf 'partial\n' >"$WT/runtime/leftover.txt"
-(cd "$MAIN" && "$WORKTREE_SCRIPT" fix-links "$WT" >/dev/null 2>&1)
-assert_symlink "$WT/runtime" "real directory replaced by a symlink"
-assert_missing "$MAIN/runtime/leftover.txt" "materialized content was not copied into the source"
+alias_text() {
+  sed -e "s|$WT|<wt>|g" -e "s|$MAIN|<main>|g" -e "s|$ROOT|<root>|g" -e "s|$WORKTREE_SCRIPT|<worktree>|g" |
+    paste -s -d ';' -
+}
 
-echo "=== #860: claude-setup restores provisioning like codex-setup ==="
-rm -f "$WT/runtime" "$WT/harnessrc"
-set +e
-claude_out="$(cd "$MAIN" && "$WORKTREE_SCRIPT" claude-setup "$WT" 2>&1)"
-claude_rc=$?
-set -e
-if [[ "$claude_rc" -eq 0 ]]; then ok "claude-setup exits 0"; else bad "claude-setup exits 0" "rc=$claude_rc: $claude_out"; fi
-assert_contains "$claude_out" "Configured Claude worktree" "claude-setup reports what it configured"
-assert_symlink "$WT/runtime" "claude-setup restored the directory symlink"
-assert_symlink "$WT/harnessrc" "claude-setup restored the file symlink"
+# Every entry of the worktree, then of the main checkout's directory entry (a
+# link with its target, a file by name, an empty directory with a slash;
+# git's own directory left out, links not followed); a temp name's number is
+# aliased so a leftover shows as one.
+entries_of() {
+  (cd "$1" && find . -mindepth 1 \( -path ./.git -prune \) -o \( -type f -o -type l -o \( -type d -empty \) \) -print | LC_ALL=C sort | while IFS= read -r path; do
+    if [[ -L "$path" ]]; then printf '%s->%s,' "${path#./}" "$(readlink "$path" | sed -e "s|$MAIN|<main>|" -e "s|$ROOT|<root>|")"
+    elif [[ -d "$path" ]]; then printf '%s/,' "${path#./}"
+    else printf '%s,' "${path#./}"; fi
+  done | sed -e 's/,$//' -e 's/\.wt-tmp\.[0-9]*/.wt-tmp.<n>/g')
+}
 
-echo "=== #860: claude-setup refuses the main checkout ==="
-set +e
-main_out="$(cd "$MAIN" && "$WORKTREE_SCRIPT" claude-setup "$MAIN" 2>&1)"
-main_rc=$?
-set -e
-if [[ "$main_rc" -ne 0 ]]; then ok "claude-setup refuses the main checkout"; else bad "claude-setup refuses the main checkout" "exited 0: $main_out"; fi
+state() {
+  local wt_entries="" src_entries=""
+  wt_entries="$(entries_of "$WT")"
+  src_entries="$(entries_of "$MAIN/runtime")"
+  printf 'wt=%s src=%s' "${wt_entries:--}" "${src_entries:--}"
+}
 
-echo "=== #860: claude-cleanup is non-destructive ==="
-set +e
-cleanup_out="$(cd "$MAIN" && "$WORKTREE_SCRIPT" claude-cleanup "$WT" 2>&1)"
-cleanup_rc=$?
-set -e
-if [[ "$cleanup_rc" -eq 0 ]]; then ok "claude-cleanup exits 0"; else bad "claude-cleanup exits 0" "rc=$cleanup_rc: $cleanup_out"; fi
-assert_symlink "$WT/runtime" "claude-cleanup left the symlink in place"
+run() {
+  local -a argv
+  local rc=0
+  read -r -a argv <<<"${1//<wt>/$WT}"
+  if [[ "${argv[0]}" == create ]]; then WT="$ROOT/trees/${argv[1]}"; fi
+  (cd "$MAIN" && LC_ALL=C "$WORKTREE_SCRIPT" "${argv[@]}" >"$ROOT/out" 2>"$ROOT/err") || rc=$?
+  printf 'rc=%s out=%s err=%s %s' "$rc" "$(alias_text <"$ROOT/out")" "$(alias_text <"$ROOT/err")" "$(state)"
+}
 
-echo "=== usage lists the new entry points ==="
-set +e
-usage_out="$(cd "$MAIN" && "$WORKTREE_SCRIPT" definitely-not-a-command 2>&1)"
-set -e
-assert_contains "$usage_out" "claude-setup" "usage names claude-setup"
-assert_contains "$usage_out" "claude-cleanup" "usage names claude-cleanup"
+# --- the expected text ----------------------------------------------------------
 
-printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+err_text() {
+  case "$1" in
+    -) printf '' ;;
+    *) printf 'UNKNOWN-ERR-SPEC:%s' "$1" ;;
+  esac
+}
+
+out_text() {
+  case "$1" in
+    -) printf '' ;;
+    wt) printf '<wt>' ;;
+    restored) printf 'Restored symlinks in <wt>' ;;
+    *) printf 'UNKNOWN-OUT-SPEC:%s' "$1" ;;
+  esac
+}
+
+# --- the rows ---------------------------------------------------------------------
+# label|fixture|command|rc|out|err|state
+ROWS='create links a directory entry and a file entry|repo entries|create swap-check|0|wt|-|wt=.env.local,base.txt,harnessrc-><main>/harnessrc,runtime-><main>/runtime src=state.json
+replacing a link to a directory swaps it in place: nothing nested in the target, no temp name left|repo entries create:swap-check|fix-links <wt>|0|restored|-|wt=.env.local,base.txt,harnessrc-><main>/harnessrc,runtime-><main>/runtime src=state.json
+a materialized real directory is reconciled back to a link, its content not copied into the source|repo entries create:swap-check materialized:runtime|fix-links <wt>|0|restored|-|wt=.env.local,base.txt,harnessrc-><main>/harnessrc,runtime-><main>/runtime src=state.json
+'
+
+echo "=== the atomic symlink swap ==="
+n=0
+while IFS= read -r row; do
+  [[ -n "$row" ]] || continue
+  IFS='|' read -r label fixture command rc out err want_state <<<"$row"
+  for field in "$label" "$fixture" "$command" "$rc" "$out" "$err" "$want_state"; do
+    [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+  done
+  n=$((n + 1))
+  # shellcheck disable=SC2086
+  build "row-$n" $fixture
+  # A rendering aid for writing rows: prints what each row produces instead of
+  # asserting it. A run that asserted no row is refused after the loop.
+  if [[ "${WORKTREE_TABLE_PROBE:-}" == 1 ]]; then
+    printf '%s => %s\n' "$label" "$(run "$command")"
+    continue
+  fi
+  assert_eq "$(run "$command")" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want_state" "$label"
+done <<<"$ROWS"
+[[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/worktree/tests/worktree_atomic_symlink_swap.sh
+++ b/skills/worktree/tests/worktree_atomic_symlink_swap.sh
@@ -1,14 +1,17 @@
 #!/usr/bin/env bash
-# replacing a configured symlink must not leave the destination absent,
-# so the swap goes through a pre-built temp link and a rename. The hazard that
-# introduces is following a symlinked-to-directory destination — a plain `mv`
-# deposits the temp link INSIDE the target instead of replacing it, which is
-# why the swap needs `mv -T` (GNU) / `mv -h` (BSD). These assertions fail on a
-# naive rename just as loudly as on a failure to the old rm+ln pair.
-#
-# `claude-setup` / `claude-cleanup` must provide the same provisioning
-# and teardown semantics as the Codex pair, for worktrees Claude Code creates
-# itself via its WorktreeCreate hook.
+# The atomic swap of a configured symlink. Replacing a link must never leave
+# its destination absent, so the swap builds the new link under a temp name
+# and renames it over the old one; the hazard that introduces is following a
+# link-to-directory destination, where a plain `mv` deposits the temp link
+# inside the target instead of replacing it (hence `mv -T` on GNU, `mv -h` on
+# BSD). One table, a row per scenario: the fixture builds a checkout with its
+# bare origin, a directory entry and a file entry, and the worktree, and
+# shapes the destination under test; fix-links runs from the checkout, and
+# the row pins its exit status, its stdout, its stderr and what is left:
+# every entry of the worktree and of the main checkout's directory entry (a
+# link with its target, a file by name; a temp name with its number aliased),
+# so a link deposited inside the target, a temp file left behind, or content
+# copied into the source all show.
 set -euo pipefail
 # A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
 # call below at the real repository; -C overrides neither.
@@ -22,128 +25,186 @@ trap 'rm -rf "$TMP_ROOT"' EXIT
 PASS=0
 FAIL=0
 
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
-
-assert_symlink() {
-  local path="$1" name="$2"
-  if [[ -L "$path" ]]; then ok "$name"; else bad "$name" "not a symlink: $path"; fi
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
 }
 
-assert_missing() {
-  local path="$1" name="$2"
-  if [[ -e "$path" || -L "$path" ]]; then bad "$name" "unexpectedly exists: $path"; else ok "$name"; fi
-}
-
-assert_contains() {
-  local haystack="$1" needle="$2" name="$3"
-  if grep -qF -- "$needle" <<<"$haystack"; then ok "$name"; else bad "$name" "wanted: $needle"; fi
-}
-
+# gh is quiet: no row asks about a pull request.
 mkdir -p "$TMP_ROOT/bin"
-cat >"$TMP_ROOT/bin/gh" <<'STUB'
-#!/usr/bin/env bash
-exit 0
-STUB
+printf '#!/usr/bin/env bash\nexit 0\n' >"$TMP_ROOT/bin/gh"
 chmod +x "$TMP_ROOT/bin/gh"
 export PATH="$TMP_ROOT/bin:$PATH"
 
+# --- fixtures -----------------------------------------------------------------
+# Every row's world lives under its own ROOT: the checkout at ROOT/main, its
+# bare origin, and the worktree at ROOT/trees/<id>.
+
+ROOT=""
+MAIN=""
+WT=""
+
 make_repo() {
-  local root="$1"
-  mkdir -p "$root/main"
-  git -C "$root/main" init -q -b main
-  git -C "$root/main" config user.email test@example.com
-  git -C "$root/main" config user.name Test
-  git -C "$root/main" config commit.gpgsign false
-  printf 'base\n' >"$root/main/base.txt"
-  git -C "$root/main" add base.txt
-  git -C "$root/main" commit -q -m base
-  git init -q --bare "$root/origin.git"
-  git -C "$root/main" remote add origin "$root/origin.git"
-  git -C "$root/main" push -q -u origin main
+  mkdir -p "$MAIN"
+  git -C "$MAIN" init -q -b main
+  git -C "$MAIN" config user.email test@example.com
+  git -C "$MAIN" config user.name Test
+  git -C "$MAIN" config commit.gpgsign false
+  printf 'base\n' >"$MAIN/base.txt"
+  git -C "$MAIN" add base.txt
+  git -C "$MAIN" commit -q -m base
+  git init -q --bare "$ROOT/origin.git"
+  git -C "$MAIN" remote add origin "$ROOT/origin.git"
+  git -C "$MAIN" push -q -u origin main
+  printf 'WORKTREE_BASE_DIR="../trees"\n' >"$MAIN/.env.local"
 }
 
-ROOT="$TMP_ROOT/repo"
-make_repo "$ROOT"
-MAIN="$ROOT/main"
-mkdir -p "$MAIN/runtime"
-printf 'runtime/\nharnessrc\n' >"$MAIN/.gitignore"
-printf 'state\n' >"$MAIN/runtime/state.json"
-printf 'rc\n' >"$MAIN/harnessrc"
-printf 'WORKTREE_SYMLINKS="runtime harnessrc"\n' >"$MAIN/.env.local"
-git -C "$MAIN" add .gitignore
-git -C "$MAIN" commit -q -m ignore
-git -C "$MAIN" push -q origin main
+must() {
+  "$@" || { echo "FIXTURE: '$*' failed in $ROOT" >&2; exit 2; }
+}
 
-WT="$(cd "$MAIN" && "$WORKTREE_SCRIPT" create swap-check 2>/dev/null | tail -1)"
+commit_push() {
+  must git -C "$MAIN" commit -q -m "$1"
+  must git -C "$MAIN" push -q origin main
+}
 
-echo "=== baseline: create links both a directory and a file entry ==="
-# Power check for everything below: if these are not symlinks to begin with,
-# the replacement assertions would pass trivially on a broken implementation.
-assert_symlink "$WT/runtime" "directory entry is a symlink"
-assert_symlink "$WT/harnessrc" "file entry is a symlink"
+# The step vocabulary. `repo` builds the world; the rest shape it.
+step() {
+  case "$1" in
+    repo) make_repo ;;
+    # A directory entry and a file entry, both untracked (nothing in the swap
+    # path reads an ignore file, so none is written).
+    entries)
+      mkdir -p "$MAIN/runtime"
+      printf 'state\n' >"$MAIN/runtime/state.json"
+      printf 'rc\n' >"$MAIN/harnessrc"
+      printf 'WORKTREE_SYMLINKS="runtime harnessrc"\n' >>"$MAIN/.env.local"
+      must git -C "$MAIN" add .env.local
+      commit_push entries
+      ;;
+    # A worktree created before the row's command; its own output is not the row's.
+    create:*)
+      WT="$ROOT/trees/${1#create:}"
+      (cd "$MAIN" && "$WORKTREE_SCRIPT" create "${1#create:}" >/dev/null 2>&1) || true
+      [[ -d "$WT" ]] || { echo "FIXTURE: create ${1#create:} left no worktree in $ROOT" >&2; exit 2; }
+      ;;
+    # What a rebase leaves when tracked files exist under the entry: a real
+    # directory where the link was, holding a file of its own.
+    materialized:*)
+      rm -f "$WT/${1#materialized:}"
+      mkdir -p "$WT/${1#materialized:}"
+      printf 'partial\n' >"$WT/${1#materialized:}/leftover.txt"
+      # Reconciliation makes this row's end state the healthy one, so the step
+      # proves here that it built what the row claims to reconcile.
+      [[ -d "$WT/${1#materialized:}" && ! -L "$WT/${1#materialized:}" && -s "$WT/${1#materialized:}/leftover.txt" ]] ||
+        { echo "FIXTURE: materialized:${1#materialized:} left no real directory holding a file in $ROOT" >&2; exit 2; }
+      ;;
+    *)
+      echo "UNKNOWN-STEP: $1" >&2
+      exit 2
+      ;;
+  esac
+}
 
-echo "=== replacing an existing symlink-to-dir must not nest inside the target ==="
-(cd "$MAIN" && "$WORKTREE_SCRIPT" fix-links "$WT" >/dev/null 2>&1)
-assert_symlink "$WT/runtime" "directory entry is still a symlink after re-link"
-# The naive-`mv` failure mode, and the whole reason the swap needs -T/-h: a
-# `mv` that follows the symlinked destination deposits the temp link INSIDE the
-# target directory (as runtime.wt-tmp.NNN, not as "runtime" — checking for the
-# latter is an assertion that can never fire).
-nested="$(find "$MAIN/runtime" -maxdepth 1 -type l 2>/dev/null || true)"
-if [[ -z "$nested" ]]; then
-  ok "no link deposited inside the symlink target"
-else
-  bad "no link deposited inside the symlink target" "$nested"
-fi
-assert_symlink "$WT/harnessrc" "file entry survives re-link"
+build() {
+  local word
+  ROOT="$TMP_ROOT/$1"
+  shift
+  MAIN="$ROOT/main"
+  WT=""
+  mkdir -p "$ROOT"
+  for word in "$@"; do
+    step "$word"
+  done
+}
 
-echo "=== the swap leaves no temp artifacts behind ==="
-leftovers="$(find "$WT" "$MAIN" -maxdepth 2 -name '*.wt-tmp.*' 2>/dev/null || true)"
-if [[ -z "$leftovers" ]]; then ok "no .wt-tmp.* residue"; else bad "no .wt-tmp.* residue" "$leftovers"; fi
+# --- rendering ------------------------------------------------------------------
 
-echo "=== a materialized real directory is reconciled back to a symlink ==="
-# What a rebase does when tracked files exist under the symlinked path: the
-# symlink becomes a real directory holding only the tracked subset.
-rm -f "$WT/runtime"
-mkdir -p "$WT/runtime"
-printf 'partial\n' >"$WT/runtime/leftover.txt"
-(cd "$MAIN" && "$WORKTREE_SCRIPT" fix-links "$WT" >/dev/null 2>&1)
-assert_symlink "$WT/runtime" "real directory replaced by a symlink"
-assert_missing "$MAIN/runtime/leftover.txt" "materialized content was not copied into the source"
+alias_text() {
+  sed -e "s|$WT|<wt>|g" -e "s|$MAIN|<main>|g" -e "s|$ROOT|<root>|g" -e "s|$WORKTREE_SCRIPT|<worktree>|g" |
+    paste -s -d ';' -
+}
 
-echo "=== #860: claude-setup restores provisioning like codex-setup ==="
-rm -f "$WT/runtime" "$WT/harnessrc"
-set +e
-claude_out="$(cd "$MAIN" && "$WORKTREE_SCRIPT" claude-setup "$WT" 2>&1)"
-claude_rc=$?
-set -e
-if [[ "$claude_rc" -eq 0 ]]; then ok "claude-setup exits 0"; else bad "claude-setup exits 0" "rc=$claude_rc: $claude_out"; fi
-assert_contains "$claude_out" "Configured Claude worktree" "claude-setup reports what it configured"
-assert_symlink "$WT/runtime" "claude-setup restored the directory symlink"
-assert_symlink "$WT/harnessrc" "claude-setup restored the file symlink"
+# Every entry of the worktree, then of the main checkout's directory entry (a
+# link with its target, a file by name, an empty directory with a slash;
+# git's own directory left out, links not followed); a temp name's number is
+# aliased so a leftover shows as one.
+entries_of() {
+  (cd "$1" && find . -mindepth 1 \( -path ./.git -prune \) -o \( -type f -o -type l -o \( -type d -empty \) \) -print | LC_ALL=C sort | while IFS= read -r path; do
+    if [[ -L "$path" ]]; then printf '%s->%s,' "${path#./}" "$(readlink "$path" | sed -e "s|$MAIN|<main>|" -e "s|$ROOT|<root>|")"
+    elif [[ -d "$path" ]]; then printf '%s/,' "${path#./}"
+    else printf '%s,' "${path#./}"; fi
+  done | sed -e 's/,$//' -e 's/\.wt-tmp\.[0-9]*/.wt-tmp.<n>/g')
+}
 
-echo "=== #860: claude-setup refuses the main checkout ==="
-set +e
-main_out="$(cd "$MAIN" && "$WORKTREE_SCRIPT" claude-setup "$MAIN" 2>&1)"
-main_rc=$?
-set -e
-if [[ "$main_rc" -ne 0 ]]; then ok "claude-setup refuses the main checkout"; else bad "claude-setup refuses the main checkout" "exited 0: $main_out"; fi
+state() {
+  local wt_entries="" src_entries=""
+  wt_entries="$(entries_of "$WT")"
+  src_entries="$(entries_of "$MAIN/runtime")"
+  printf 'wt=%s src=%s' "${wt_entries:--}" "${src_entries:--}"
+}
 
-echo "=== #860: claude-cleanup is non-destructive ==="
-set +e
-cleanup_out="$(cd "$MAIN" && "$WORKTREE_SCRIPT" claude-cleanup "$WT" 2>&1)"
-cleanup_rc=$?
-set -e
-if [[ "$cleanup_rc" -eq 0 ]]; then ok "claude-cleanup exits 0"; else bad "claude-cleanup exits 0" "rc=$cleanup_rc: $cleanup_out"; fi
-assert_symlink "$WT/runtime" "claude-cleanup left the symlink in place"
+run() {
+  local -a argv
+  local rc=0
+  read -r -a argv <<<"${1//<wt>/$WT}"
+  if [[ "${argv[0]}" == create ]]; then WT="$ROOT/trees/${argv[1]}"; fi
+  (cd "$MAIN" && LC_ALL=C "$WORKTREE_SCRIPT" "${argv[@]}" >"$ROOT/out" 2>"$ROOT/err") || rc=$?
+  printf 'rc=%s out=%s err=%s %s' "$rc" "$(alias_text <"$ROOT/out")" "$(alias_text <"$ROOT/err")" "$(state)"
+}
 
-echo "=== usage lists the new entry points ==="
-set +e
-usage_out="$(cd "$MAIN" && "$WORKTREE_SCRIPT" definitely-not-a-command 2>&1)"
-set -e
-assert_contains "$usage_out" "claude-setup" "usage names claude-setup"
-assert_contains "$usage_out" "claude-cleanup" "usage names claude-cleanup"
+# --- the expected text ----------------------------------------------------------
 
-printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+err_text() {
+  case "$1" in
+    -) printf '' ;;
+    *) printf 'UNKNOWN-ERR-SPEC:%s' "$1" ;;
+  esac
+}
+
+out_text() {
+  case "$1" in
+    -) printf '' ;;
+    wt) printf '<wt>' ;;
+    restored) printf 'Restored symlinks in <wt>' ;;
+    *) printf 'UNKNOWN-OUT-SPEC:%s' "$1" ;;
+  esac
+}
+
+# --- the rows ---------------------------------------------------------------------
+# label|fixture|command|rc|out|err|state
+ROWS='create links a directory entry and a file entry|repo entries|create swap-check|0|wt|-|wt=.env.local,base.txt,harnessrc-><main>/harnessrc,runtime-><main>/runtime src=state.json
+replacing a link to a directory swaps it in place: nothing nested in the target, no temp name left|repo entries create:swap-check|fix-links <wt>|0|restored|-|wt=.env.local,base.txt,harnessrc-><main>/harnessrc,runtime-><main>/runtime src=state.json
+a materialized real directory is reconciled back to a link, its content not copied into the source|repo entries create:swap-check materialized:runtime|fix-links <wt>|0|restored|-|wt=.env.local,base.txt,harnessrc-><main>/harnessrc,runtime-><main>/runtime src=state.json
+'
+
+echo "=== the atomic symlink swap ==="
+n=0
+while IFS= read -r row; do
+  [[ -n "$row" ]] || continue
+  IFS='|' read -r label fixture command rc out err want_state <<<"$row"
+  for field in "$label" "$fixture" "$command" "$rc" "$out" "$err" "$want_state"; do
+    [[ -n "$field" ]] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+  done
+  n=$((n + 1))
+  # shellcheck disable=SC2086
+  build "row-$n" $fixture
+  # A rendering aid for writing rows: prints what each row produces instead of
+  # asserting it. A run that asserted no row is refused after the loop.
+  if [[ "${WORKTREE_TABLE_PROBE:-}" == 1 ]]; then
+    printf '%s => %s\n' "$label" "$(run "$command")"
+    continue
+  fi
+  assert_eq "$(run "$command")" "rc=$rc out=$(out_text "$out") err=$(err_text "$err") $want_state" "$label"
+done <<<"$ROWS"
+[[ "$((PASS + FAIL))" -gt 0 ]] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Reshapes `skills/worktree/tests/worktree_atomic_symlink_swap.sh` into one table of three rows. The suite pinned the swap of a configured symlink in four blocks of is-a-symlink and find checks over one accumulating world (both entries linked by create; a link to a directory replaced in place with nothing deposited inside the target; no temp residue; a materialized real directory reconciled), then the claude hooks in three `#860` blocks and a usage check. Each row now builds its own world (a checkout with its bare origin, a directory entry and a file entry, the worktree), runs from the checkout and pins exit status, stdout, stderr and every entry of the worktree and of the source directory (a link with its target, a file by name, an empty directory; a temp name's number aliased), so a link deposited inside the target, a temp name left behind, or content copied into the source all show in the one state string.

The claude hook blocks are rows of the new `worktree_app_hooks.sh` (the app-hooks PR); the usage check becomes two pins in `worktree_help_dispatch.sh` in that PR (the hook help's index naming both claude hooks, and the unknown-command fallthrough).

## Folded or deleted cases, with the surviving row

| Former assertions | Surviving row |
|---|---|
| both entries are symlinks after create | `create links a directory entry and a file entry` (`harnessrc-><main>/harnessrc,runtime-><main>/runtime`) |
| the directory entry is still a symlink after fix-links; no link deposited inside the target; the file entry survives; no `.wt-tmp.*` residue | `replacing a link to a directory swaps it in place: nothing nested in the target, no temp name left` (`src=state.json`: the target holds only its own file; a leftover would render as `runtime.wt-tmp.<n>`) |
| a real directory is replaced by a symlink; its content is not copied into the source | `a materialized real directory is reconciled back to a link, its content not copied into the source` |
| claude-setup exits 0 and reports; both links restored; claude-setup refuses main; claude-cleanup exits 0 and leaves the link | rows of `worktree_app_hooks.sh` (the app-hooks PR); the one named loss: those rows configure file links only, so "claude-setup specifically reaches the directory branch" is uncovered (the branch is the one fix-links takes, pinned by rows 2 and 3 here) |
| usage names claude-setup and claude-cleanup | `worktree_help_dispatch.sh` rows in the app-hooks PR |
| no `.wt-tmp.*` residue under the main checkout beside the source entries | **declined**: the temp name is built beside the destination inside the worktree, so no shipped producer emits main-side residue; the worktree half is pinned (a leftover renders as `<name>.wt-tmp.<n>`) |

## Mutation

Eleven must-fail mutants (`mutants-as-2.txt` is the record after the review round) over a scratch copy of `skills/worktree` (`mutate-as.py` in the lane scratchpad): a plain `mv` following the link-to-directory destination (killed by the swap row alone), a failed swap leaving its temp link, the temp link never renamed, the materialized directory kept (the fallback drops the link inside it), fix-links silent, the directory entry not linked, the materialized directory's content copied into the source before removal (killed by the materialized row alone), the file entry's branch never running (the reviewer's), the entries fixture a no-op, and a no-op materialization (or one without the leftover file): all killed. The last two survived the first battery because reconciliation makes row 3's end state equal row 2's; the reviewer's blocker was that the step then carried no check of its own, so it now proves it built a real directory holding a file and exits 2 otherwise. The first runs of the two materialization mutants targeted `repair_materialized_path`, which fix-links does not call, and survived for that reason; the record keeps both runs.

## Reviewer round

One reviewer-test round, ACCEPT WITH FIXES: the blocker (the materialized step's postcondition) and the dead `.gitignore` fixture word (nothing in the swap path reads an ignore file) applied; the usage-line pin folded into the app-hooks PR's help-dispatch rows; the main-side residue widening declined as above. The reviewer's non-atomic file-swap mutant survives by the nature of a state table: atomicity is a window, not an end state, and the old suite could not see it either.

## Checks

- `worktree_atomic_symlink_swap.sh`: 3 rows, green with TMPDIR=/var/tmp/ken-c, under `LC_ALL=de_DE.UTF-8` and under `init.defaultBranch=master`; `shellcheck -x` clean; `tools/bash32-lint skills/worktree` clean; source and render byte-identical; no inventory change.
- `tools/guard --full`: exit 0 on c95e9ef7f (TMPDIR=/var/tmp/ken-c), the same tree restacked onto main as c358c0ba3.

KEN-1241

https://claude.ai/code/session_01JjdknThZvqDq3HUfHPkRNe
