### PR TITLE
test(KEN-1241): kendex-app suites against the tests bar [no-changelog]

### DIFF
--- a/crates/app/src/account.rs
+++ b/crates/app/src/account.rs
@@ -216,12 +216,6 @@ mod tests {
     #[test]
     fn expiry_is_the_one_refusal_that_is_news_about_the_account() {
         assert!(matches!(
-            refused(CoreError::SignInExpired {
-                why: "the server does not accept this sign-in".to_owned()
-            }),
-            AccountCallRefused::Expired { .. }
-        ));
-        assert!(matches!(
             refused(CoreError::Authoring {
                 message: "that repository is already submitted".to_owned()
             }),
@@ -241,16 +235,14 @@ mod tests {
     /// the surface shows beside the retry.
     #[test]
     fn the_read_failure_reaches_the_surface_as_the_half_that_failed() {
-        let locked = "the credential store on this machine could not be used";
         let refusal = AccountReadFailed::from(AccountUnread::Local(
             CoreError::CredentialStoreUnavailable {
                 why: "the keyring is locked".to_owned(),
             },
         ));
-        let AccountReadFailed::Local { message } = refusal else {
+        let AccountReadFailed::Local { .. } = refusal else {
             panic!("a store this machine refused is local");
         };
-        assert!(message.starts_with(locked), "{message}");
 
         let away =
             AccountReadFailed::from(AccountUnread::Unreachable(CoreError::RegistryUnavailable {

--- a/crates/app/src/app_update/tests.rs
+++ b/crates/app/src/app_update/tests.rs
@@ -78,8 +78,7 @@ fn the_install_holds_its_download_to_what_this_release_published() {
 
     // The manifest is unsigned, so the version it offers is whoever wrote
     // it to choose; the document is what that claim is held to.
-    let claimed = read_published(TEST_KEY, TEST_TARGET, "9.9.8", serve).unwrap_err();
-    assert!(claimed.contains("the feed offers 9.9.8"), "{claimed}");
+    read_published(TEST_KEY, TEST_TARGET, "9.9.8", serve).unwrap_err();
 }
 
 /// A channel serving what this release published, and answering at exactly
@@ -129,12 +128,8 @@ fn only_the_download_this_release_published_reaches_the_installer() {
     assert_eq!(landed.0.borrow().as_deref(), Some(PUBLISHED_APP));
 
     let refused = Placed::default();
-    let error = install_published(&digests, ANOTHER_RELEASE_APP.to_vec(), &refused)
+    install_published(&digests, ANOTHER_RELEASE_APP.to_vec(), &refused)
         .expect_err("a download this release never published");
-    assert!(
-        error.contains("the desktop app download hashes to"),
-        "{error}"
-    );
     assert!(
         refused.0.borrow().is_none(),
         "a download this release never published reached the installer"
@@ -258,7 +253,6 @@ fn a_failed_app_half_says_whether_the_command_went_ahead_of_it() {
     let split = app_half_failed("5.1.0", CommandHalf::Moved, "permission denied");
     assert!(split.contains("the kendex command is on 5.1.0"), "{split}");
     assert!(split.contains("permission denied"), "{split}");
-    assert!(split.contains("press Update now again"), "{split}");
 
     let neither = app_half_failed("5.1.0", CommandHalf::Untouched, "permission denied");
     assert!(!neither.contains("kendex command"), "{neither}");

--- a/crates/app/src/editor.rs
+++ b/crates/app/src/editor.rs
@@ -279,52 +279,80 @@ mod tests {
         manifest
     }
 
+    /// Which agents reach `automatic`, and with what: each agent's recorded
+    /// assignment, from its own lock entry. Only an agent is assigned skills,
+    /// so a list recorded under any other kind is not an assignment; an agent
+    /// with nothing recorded is absent, not empty (the editor prints "the
+    /// catalog gives this agent no skills" for an empty list, and an
+    /// unrecorded assignment is a different fact); an absent lock records
+    /// nothing. One row per shape of lock.
     #[test]
     #[allow(clippy::unwrap_used)]
-    fn reads_each_agents_recorded_assignment() {
-        let (_tmp, env, scope) = scope_with(vec![
-            entry(ItemKind::Agent, "orch", Some(&["dev", "github"])),
-            // Only an agent is assigned skills. A list recorded under any
-            // other kind is not an assignment and is not reported as one.
-            entry(ItemKind::Skill, "dev", Some(&["worktree"])),
-        ]);
-        let automatic = agent_skill_facts(&env, &scope, None).unwrap().automatic;
-        assert_eq!(
-            automatic.get("orch").map(Vec::as_slice),
-            Some(&["dev".to_owned(), "github".to_owned()][..])
+    fn the_automatic_assignments_are_the_agents_own_lock_entries() {
+        type Row<'a> = (
+            &'a str,
+            Option<Vec<LockEntry>>,
+            &'a [(&'a str, &'a [&'a str])],
         );
-        assert!(!automatic.contains_key("dev"));
+        let rows: [Row; 3] = [
+            (
+                "an agent's list, and a list under another kind",
+                Some(vec![
+                    entry(ItemKind::Agent, "orch", Some(&["dev", "github"])),
+                    entry(ItemKind::Skill, "dev", Some(&["worktree"])),
+                ]),
+                &[("orch", &["dev", "github"])],
+            ),
+            (
+                "an agent with nothing recorded",
+                Some(vec![entry(ItemKind::Agent, "scout", None)]),
+                &[],
+            ),
+            ("no lock at all", None, &[]),
+        ];
+        for (what, entries, expected) in rows {
+            let (_tmp, env, scope) = match entries {
+                Some(entries) => scope_with(entries),
+                None => {
+                    let tmp = tempfile::tempdir().unwrap();
+                    let env = Env::fake(tmp.path(), FakeOs::Linux);
+                    let root = tmp.path().join("dev/app");
+                    std::fs::create_dir_all(&root).unwrap();
+                    (tmp, env, Scope::Project { root })
+                }
+            };
+            let facts = agent_skill_facts(&env, &scope, None).unwrap();
+            let expected: std::collections::BTreeMap<String, Vec<String>> = expected
+                .iter()
+                .map(|(agent, skills)| {
+                    (
+                        (*agent).to_owned(),
+                        skills.iter().map(|s| (*s).to_owned()).collect(),
+                    )
+                })
+                .collect();
+            assert_eq!(facts.automatic, expected, "{what}");
+            assert!(
+                facts.declared.is_empty(),
+                "{what}: nothing declared without a manifest"
+            );
+        }
     }
 
-    // An agent with nothing recorded is absent, not empty: the editor
-    // prints "the catalog gives this agent no skills" for an empty list,
-    // and an unrecorded assignment is a different fact from that one.
+    /// An unreadable lock is a parse error, not an empty record.
     #[test]
     #[allow(clippy::unwrap_used)]
-    fn leaves_an_unrecorded_agent_out_rather_than_calling_it_empty() {
-        let (_tmp, env, scope) = scope_with(vec![entry(ItemKind::Agent, "scout", None)]);
-        let automatic = agent_skill_facts(&env, &scope, None).unwrap().automatic;
-        assert!(!automatic.contains_key("scout"));
-    }
-
-    /// An absent lock records nothing. An unreadable lock is a parse error.
-    #[test]
-    #[allow(clippy::unwrap_used)]
-    fn absent_and_unreadable_locks_are_distinct() {
+    fn an_unreadable_lock_is_an_error() {
         let tmp = tempfile::tempdir().unwrap();
         let env = Env::fake(tmp.path(), FakeOs::Linux);
         let root = tmp.path().join("dev/app");
         std::fs::create_dir_all(&root).unwrap();
-        let scope = Scope::Project { root: root.clone() };
-
-        let facts = agent_skill_facts(&env, &scope, None).unwrap();
-        assert!(facts.automatic.is_empty() && facts.declared.is_empty());
-
         std::fs::write(
             root.join(".kendex-lock.json"),
             r#"{"version":1,"entries":{}}"#,
         )
         .unwrap();
+        let scope = Scope::Project { root };
         assert!(agent_skill_facts(&env, &scope, None).is_err());
     }
 

--- a/crates/app/src/editor/save/tests.rs
+++ b/crates/app/src/editor/save/tests.rs
@@ -223,10 +223,9 @@ fn a_first_save_creates_the_manifest_and_the_draft_schema_decides_it() {
     else {
         panic!("a draft below this build's schema must not create a file");
     };
-    let WriteRefused::Failed { message } = &refused else {
+    let WriteRefused::Failed { .. } = &refused else {
         panic!("the schema refusal is a validation failure, not a stale copy: {refused:?}");
     };
-    assert!(message.contains("schema"), "{message}");
     assert!(!path.exists(), "and nothing is created: {}", path.display());
 
     let draft = Manifest {
@@ -361,23 +360,22 @@ fn creating_a_manifest_here_still_seeds_the_default_source() {
         },
         manifest::seed(&[HarnessId::Claude]),
     );
-    assert!(seeded.sources.contains_key("kendex"));
+    assert_eq!(seeded.sources, manifest::seed(&[HarnessId::Claude]).sources);
     assert_eq!(seeded.install.harnesses, [HarnessId::Claude]);
 
     let declared = on_first_creation(manifest(), manifest::seed(&[HarnessId::Pi]));
-    assert_eq!(declared.sources.len(), 1);
+    assert_eq!(declared.sources, manifest().sources);
     assert!(declared.install.harnesses.is_empty());
 }
 
 #[test]
-fn rejected_edits_come_back_with_their_fix_string() {
+fn rejected_edits_name_the_offending_key() {
     let mut edited = manifest();
     edited
         .skills
         .insert("github".to_owned(), ItemDecl::from_source("gone"));
     let error = check(&edited).expect_err("undeclared source must be rejected");
     assert!(error.contains("skills.github"), "{error}");
-    assert!(error.contains("fix: declare [sources.gone]"), "{error}");
 }
 
 /// A key the skill's own code already defaults, which an install never
@@ -771,9 +769,5 @@ fn a_refusal_after_the_uninstaller_ran_says_what_it_ran() {
     assert!(
         message.contains("guards: disarmed"),
         "the refusal carried only part of the account: {message}"
-    );
-    assert!(
-        message.lines().count() > 2,
-        "the refusal said nothing about why it refused: {message}"
     );
 }

--- a/crates/app/src/launch_env/tests.rs
+++ b/crates/app/src/launch_env/tests.rs
@@ -194,83 +194,101 @@ fn the_appimage_stops_pinning_the_window_to_xwayland() {
     );
 }
 
-/// GDK already tries Wayland before X11 when the variable is unset, so
-/// pushing the same order onto a deb, an rpm, or a source build buys
-/// nothing and costs a relaunch.
+/// Which `GDK_BACKEND` the plan pushes, one row per shape of session. GDK
+/// already tries Wayland before X11 when the variable is unset, so only the
+/// AppImage (whose bundled hook pins x11) is pushed off it; a choice the
+/// person made, by our variable or by GDK's own, is heard and never
+/// overridden, even on a deb that inherited both variables from an AppImage
+/// launched in the same terminal.
 #[test]
-fn no_other_packaging_is_pushed_onto_a_backend() {
-    assert_eq!(backend(wayland()), None);
-    assert!(
-        plan(Session {
-            webkit: Some("0"),
-            ..wayland()
-        })
-        .is_empty()
-    );
-}
-
-#[test]
-fn our_variable_chooses_a_backend_the_appimage_would_not_let_through() {
-    for chosen in ["wayland", "broadway"] {
-        assert_eq!(
-            backend(Session {
-                ours: Some(chosen),
+fn the_backend_the_plan_pushes_is_decided_by_who_set_what() {
+    let other_appimage = Some(OsStr::new("/home/me/other.AppImage"));
+    let other_appdir = Some(OsStr::new("/tmp/.mount_otherXyz"));
+    let deb = Some(Path::new("/usr/bin/kendex-app"));
+    let inherited = |appimage, appdir| Session {
+        in_appimage: in_appimage(appimage, appdir, deb),
+        gdk: Some("x11"),
+        ..wayland()
+    };
+    let rows = [
+        ("a deb on Wayland is not pushed", wayland(), None),
+        (
+            "our variable chooses wayland on the AppImage",
+            Session {
+                ours: Some("wayland"),
                 ..appimage()
-            }),
-            Some(chosen.to_owned()),
-            "{chosen}"
-        );
+            },
+            Some("wayland"),
+        ),
+        (
+            "our variable chooses broadway on the AppImage",
+            Session {
+                ours: Some("broadway"),
+                ..appimage()
+            },
+            Some("broadway"),
+        ),
+        (
+            "our variable naming what the bundle already set changes nothing",
+            Session {
+                ours: Some("x11"),
+                ..appimage()
+            },
+            None,
+        ),
+        (
+            "GDK's own variable naming what it already has changes nothing",
+            Session {
+                gdk: Some("broadway"),
+                ..wayland()
+            },
+            None,
+        ),
+        (
+            "our variable is heard on a session that is not Wayland",
+            Session {
+                session_type: Some("x11"),
+                ours: Some("wayland"),
+                ..Session::default()
+            },
+            Some("wayland"),
+        ),
+        (
+            "a backend the person chose is left alone",
+            Session {
+                gdk: Some("x11"),
+                ..wayland()
+            },
+            None,
+        ),
+        (
+            "a blank of ours beside the person's choice is no choice",
+            Session {
+                ours: Some(" "),
+                gdk: Some("x11"),
+                ..wayland()
+            },
+            None,
+        ),
+        (
+            "a deb that inherited APPIMAGE keeps the person's backend",
+            inherited(other_appimage, None),
+            None,
+        ),
+        (
+            "a deb that inherited APPDIR keeps the person's backend",
+            inherited(None, other_appdir),
+            None,
+        ),
+        (
+            "a deb that inherited both keeps the person's backend",
+            inherited(other_appimage, other_appdir),
+            None,
+        ),
+    ];
+    for (what, session, expected) in rows {
+        assert_eq!(backend(session), expected.map(str::to_owned), "{what}");
     }
-}
-
-/// The one value that needs no push: it is already what the bundle set.
-#[test]
-fn choosing_the_backend_the_environment_already_has_changes_nothing() {
-    assert_eq!(
-        backend(Session {
-            ours: Some("x11"),
-            ..appimage()
-        }),
-        None
-    );
-    assert_eq!(
-        backend(Session {
-            gdk: Some("broadway"),
-            ..wayland()
-        }),
-        None
-    );
-}
-
-#[test]
-fn our_variable_is_heard_on_a_session_that_is_not_wayland() {
-    assert_eq!(
-        backend(Session {
-            session_type: Some("x11"),
-            ours: Some("wayland"),
-            ..Session::default()
-        }),
-        Some("wayland".to_owned())
-    );
-}
-
-#[test]
-fn a_backend_the_person_chose_is_left_alone() {
-    assert_eq!(
-        backend(Session {
-            gdk: Some("x11"),
-            ..wayland()
-        }),
-        None
-    );
-    assert_eq!(
-        backend(Session {
-            ours: Some(" "),
-            gdk: Some("x11"),
-            ..wayland()
-        }),
-        None
-    );
 }
 
 /// What stops a relaunch looping: applying the plan leaves nothing to do.
@@ -338,28 +356,6 @@ fn only_an_ignored_bundle_pin_is_explained() {
         );
     }
     assert!(!explained(wayland()));
-}
-
-/// The whole point of the narrower signal: a deb launched from a terminal
-/// that came out of an AppImage inherits both variables, and must still
-/// treat GDK_BACKEND as the person's word.
-#[test]
-fn a_deb_that_inherited_the_variables_keeps_the_backend_the_person_set() {
-    for (appimage, appdir) in [
-        (Some(OsStr::new("/home/me/other.AppImage")), None),
-        (None, Some(OsStr::new("/tmp/.mount_otherXyz"))),
-        (
-            Some(OsStr::new("/home/me/other.AppImage")),
-            Some(OsStr::new("/tmp/.mount_otherXyz")),
-        ),
-    ] {
-        let session = Session {
-            in_appimage: in_appimage(appimage, appdir, Some(Path::new("/usr/bin/kendex-app"))),
-            gdk: Some("x11"),
-            ..wayland()
-        };
-        assert_eq!(backend(session), None, "{appimage:?} {appdir:?}");
-    }
 }
 
 /// A stand-in for a login shell: a script that ignores `-l -c` and does

--- a/crates/app/src/native.rs
+++ b/crates/app/src/native.rs
@@ -187,46 +187,87 @@ mod tests {
         path
     }
 
+    /// Which editor a `PATH` resolves to: the first candidate of the
+    /// built-in list that is executable there, or the override when one is
+    /// named, whether by name on that `PATH` or by an absolute path. One row
+    /// per shape of directory and override; `Named` is what the row expects
+    /// back, by the name it was written under.
     #[cfg(unix)]
     #[test]
-    fn resolves_the_first_candidate_present_on_path() {
-        let tmp = tempfile::tempdir().unwrap();
-        write_non_executable(tmp.path(), "codium");
-        let code = write_executable(tmp.path(), "code");
-
-        let found = resolve_editor_at(tmp.path().to_str().unwrap(), None).unwrap();
-        assert_eq!(found, code);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn skips_non_executable_matches() {
-        let tmp = tempfile::tempdir().unwrap();
-        write_non_executable(tmp.path(), "codium");
-        write_non_executable(tmp.path(), "code");
-
-        assert_eq!(resolve_editor_at(tmp.path().to_str().unwrap(), None), None);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn kendex_editor_override_wins_over_the_built_in_list() {
-        let tmp = tempfile::tempdir().unwrap();
-        write_executable(tmp.path(), "code");
-        let hx = write_executable(tmp.path(), "hx");
-
-        let found = resolve_editor_at(tmp.path().to_str().unwrap(), Some("hx")).unwrap();
-        assert_eq!(found, hx);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn kendex_editor_override_accepts_an_absolute_path() {
-        let tmp = tempfile::tempdir().unwrap();
-        let hx = write_executable(tmp.path(), "hx");
-
-        let found = resolve_editor_at("", Some(hx.to_str().unwrap())).unwrap();
-        assert_eq!(found, hx);
+    fn the_editor_is_the_first_executable_candidate_or_the_override() {
+        enum Override {
+            None,
+            Name(&'static str),
+            AbsolutePathOf(&'static str),
+        }
+        type Row<'a> = (
+            &'a str,
+            &'a [&'a str],
+            &'a [&'a str],
+            Override,
+            Option<&'a str>,
+        );
+        let rows: [Row; 5] = [
+            (
+                "the first candidate present and executable wins",
+                &["code"],
+                &["codium"],
+                Override::None,
+                Some("code"),
+            ),
+            (
+                "a candidate that is not executable is skipped",
+                &[],
+                &["codium", "code"],
+                Override::None,
+                None,
+            ),
+            (
+                "an override by name wins over the built-in list",
+                &["code", "hx"],
+                &[],
+                Override::Name("hx"),
+                Some("hx"),
+            ),
+            (
+                "an override by absolute path needs no PATH",
+                &["hx"],
+                &[],
+                Override::AbsolutePathOf("hx"),
+                Some("hx"),
+            ),
+            (
+                "no candidate on the PATH is none",
+                &[],
+                &[],
+                Override::None,
+                None,
+            ),
+        ];
+        for (what, executables, non_executables, override_, expected) in rows {
+            let tmp = tempfile::tempdir().unwrap();
+            let mut written = std::collections::BTreeMap::new();
+            for name in executables {
+                written.insert(*name, write_executable(tmp.path(), name));
+            }
+            for name in non_executables {
+                write_non_executable(tmp.path(), name);
+            }
+            let on_path = tmp.path().to_str().unwrap().to_owned();
+            let (path_var, override_) = match override_ {
+                Override::None => (on_path, None),
+                Override::Name(name) => (on_path, Some(name.to_owned())),
+                Override::AbsolutePathOf(name) => (
+                    String::new(),
+                    Some(written[name].to_str().unwrap().to_owned()),
+                ),
+            };
+            assert_eq!(
+                resolve_editor_at(&path_var, override_.as_deref()),
+                expected.map(|name| written[name].clone()),
+                "{what}"
+            );
+        }
     }
 
     #[test]
@@ -236,12 +277,5 @@ mod tests {
             ["code", "code.com", "code.exe", "code.cmd"]
         );
         assert_eq!(spellings("code", None), ["code"]);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn none_found_when_no_candidate_is_on_path() {
-        let tmp = tempfile::tempdir().unwrap();
-        assert_eq!(resolve_editor_at(tmp.path().to_str().unwrap(), None), None);
     }
 }

--- a/crates/app/src/packages.rs
+++ b/crates/app/src/packages.rs
@@ -269,41 +269,52 @@ mod tests {
     use super::*;
     use kendex_core::model::ItemKind;
 
-    // The two the page draws nothing for and reports nothing about. Both are
-    // answers about the manifest: a derived member or an unmanaged copy is in
-    // no declared map, and a fork, path or local install has no repository to
-    // take revisions from.
+    // Which refusals the page draws nothing for and reports nothing about:
+    // the two answers about the manifest (a derived member or an unmanaged
+    // copy is in no declared map; a fork, path or local install has no
+    // repository to take revisions from). Everything else is a read that
+    // went wrong, and the page says so with a way to run it again: a lock
+    // this build refuses is the same shape as the two and a real failure,
+    // and an unfetched source is its own shape (below). One row per variant.
     #[test]
-    fn no_managed_package_covers_the_manifest_answers() {
-        assert!(no_managed_package(&CoreError::NotDeclared {
-            kind: ItemKind::Skill,
-            name: "gh".to_owned(),
-        }));
-        assert!(no_managed_package(&CoreError::ItemRevUnsupported {
-            source_name: "local".to_owned(),
-        }));
+    fn only_the_two_manifest_answers_are_no_managed_package() {
+        let rows = [
+            (
+                CoreError::NotDeclared {
+                    kind: ItemKind::Skill,
+                    name: "gh".to_owned(),
+                },
+                true,
+            ),
+            (
+                CoreError::ItemRevUnsupported {
+                    source_name: "local".to_owned(),
+                },
+                true,
+            ),
+            (
+                CoreError::LockCorrupt {
+                    path: "lock".into(),
+                    message: "unparsable".to_owned(),
+                },
+                false,
+            ),
+            (
+                CoreError::SourcePending {
+                    name: "tools".to_owned(),
+                },
+                false,
+            ),
+        ];
+        for (error, expected) in rows {
+            assert_eq!(no_managed_package(&error), expected, "{error:?}");
+        }
     }
 
-    // Everything else is a read that went wrong, and the page says so with a
-    // way to run it again. A lock this build refuses is the case that must
-    // not be swallowed: it is the same shape as the two above and a real
-    // failure.
-    #[test]
-    fn a_read_that_failed_is_not_one_of_them() {
-        assert!(!no_managed_package(&CoreError::LockCorrupt {
-            path: "lock".into(),
-            message: "unparsable".to_owned(),
-        }));
-    }
-
-    // An unfetched source is neither of them and not a failure either: it
-    // reaches the page as its own shape, naming the source, and every other
-    // refusal keeps core's words.
+    // An unfetched source reaches the page as its own shape, naming the
+    // source, and every other refusal keeps core's words.
     #[test]
     fn an_unfetched_source_is_its_own_shape() {
-        assert!(!no_managed_package(&CoreError::SourcePending {
-            name: "tools".to_owned(),
-        }));
         assert!(matches!(
             timeline_refused(CoreError::SourcePending {
                 name: "tools".to_owned(),

--- a/crates/app/src/repo_effects.rs
+++ b/crates/app/src/repo_effects.rs
@@ -247,37 +247,40 @@ pub fn write_nothing_leaving(env: &Env, report: &EngineReport) -> Result<(), Str
 mod tests {
     use super::after_writing;
 
-    /// The shape every post-write read shares: the account rides on the
-    /// failure, and the failure is not swallowed to carry it.
+    /// The shape every post-write read shares: the account of what the write
+    /// undid rides on a failed read, the failure is not swallowed to carry
+    /// it, a write that undid nothing adds nothing, and a read that worked
+    /// is handed straight back. One row per pair.
     #[test]
-    fn a_read_that_fails_after_the_write_carries_the_account_and_the_error() {
+    fn the_account_of_the_write_rides_on_a_failed_read_only() {
         let undone = ["guards: running scripts/arm --uninstall".to_owned()];
-        let refused: Result<(), String> = Err("the source list could not be read".to_owned());
-
-        let Err(message) = after_writing(&undone, refused) else {
-            panic!("a failed read must stay a failure");
-        };
-
-        assert_eq!(
-            message,
-            "guards: running scripts/arm --uninstall\nthe source list could not be read"
+        let refused = || Err::<u8, String>("the source list could not be read".to_owned());
+        type Row<'a> = (
+            &'a str,
+            &'a [String],
+            Result<u8, String>,
+            Result<u8, String>,
         );
-    }
-
-    /// Nothing left the scope, so there is nothing to add to the failure.
-    #[test]
-    fn a_read_that_fails_after_a_write_that_removed_nothing_says_only_why() {
-        let refused: Result<(), String> = Err("the source list could not be read".to_owned());
-        let Err(message) = after_writing(&[], refused) else {
-            panic!("a failed read must stay a failure");
-        };
-        assert_eq!(message, "the source list could not be read");
-    }
-
-    /// A read that worked is handed straight back.
-    #[test]
-    fn a_read_that_worked_is_untouched() {
-        let undone = ["guards: running scripts/arm --uninstall".to_owned()];
-        assert_eq!(after_writing(&undone, Ok::<u8, String>(7)), Ok(7));
+        let rows: [Row; 3] = [
+            (
+                "a failed read after a write that undid something",
+                &undone,
+                refused(),
+                Err(
+                    "guards: running scripts/arm --uninstall\nthe source list could not be read"
+                        .to_owned(),
+                ),
+            ),
+            (
+                "a failed read after a write that undid nothing",
+                &[],
+                refused(),
+                Err("the source list could not be read".to_owned()),
+            ),
+            ("a read that worked", &undone, Ok(7), Ok(7)),
+        ];
+        for (what, undone, read, expected) in rows {
+            assert_eq!(after_writing(undone, read), expected, "{what}");
+        }
     }
 }

--- a/crates/app/src/update_check.rs
+++ b/crates/app/src/update_check.rs
@@ -132,37 +132,40 @@ mod tests {
     }
 
     /// The scopes are drawn together under one hint, so it answers when this
-    /// view last reached the network — the newest of them.
+    /// view last reached the network: the newest of them. A project just
+    /// registered, or one whose sources are all local paths, has never
+    /// fetched, and global is folded first, so an oldest-wins rule would let
+    /// that scope drag the header to "Not checked for updates yet" while
+    /// every other scope fetched minutes ago; nothing fetched anywhere says
+    /// so rather than naming an instant. One row per shape of scope list.
     #[test]
-    fn the_page_is_dated_by_the_newest_scope() {
-        assert_eq!(
-            merge([dated(Some(1_000)), dated(Some(2_000)), dated(Some(1_500))]).last_fetched,
-            Some(2_000)
-        );
-    }
-
-    /// A project just registered, or one whose sources are all local paths,
-    /// has never fetched. Global is folded first, so an oldest-wins rule
-    /// would let that scope drag the header to "Not checked for updates yet"
-    /// while every other scope fetched minutes ago.
-    #[test]
-    fn a_scope_that_never_fetched_does_not_drag_the_page_back() {
-        assert_eq!(
-            merge([dated(Some(2_000)), dated(None)]).last_fetched,
-            Some(2_000)
-        );
-        assert_eq!(
-            merge([dated(None), dated(Some(2_000))]).last_fetched,
-            Some(2_000),
-            "the fold cannot depend on which scope comes first"
-        );
-    }
-
-    /// Nothing anywhere has ever fetched: the page says so rather than
-    /// naming an instant.
-    #[test]
-    fn all_scopes_unfetched_stays_unfetched() {
-        assert_eq!(merge([dated(None), dated(None)]).last_fetched, None);
-        assert_eq!(merge([]).last_fetched, None);
+    fn the_page_is_dated_by_the_newest_scope_that_fetched() {
+        type Row<'a> = (&'a str, Vec<Option<u32>>, Option<u32>);
+        let rows: [Row; 5] = [
+            (
+                "the newest of three",
+                vec![Some(1_000), Some(2_000), Some(1_500)],
+                Some(2_000),
+            ),
+            (
+                "an unfetched scope after a fetched one",
+                vec![Some(2_000), None],
+                Some(2_000),
+            ),
+            (
+                "an unfetched scope before a fetched one",
+                vec![None, Some(2_000)],
+                Some(2_000),
+            ),
+            ("every scope unfetched", vec![None, None], None),
+            ("no scope at all", vec![], None),
+        ];
+        for (what, scopes, expected) in rows {
+            assert_eq!(
+                merge(scopes.into_iter().map(dated)).last_fetched,
+                expected,
+                "{what}"
+            );
+        }
     }
 }

--- a/crates/app/src/window.rs
+++ b/crates/app/src/window.rs
@@ -231,32 +231,41 @@ mod tests {
         }
     }
 
-    /// The saved size has to be the size the window is given, and it has to
-    /// arrive before the window does: the whole reason the window is built
-    /// hidden is that the person never sees it at the wrong size.
+    /// The size the window is given at the reveal is the saved one, as a
+    /// scale factor, and it arrives before the window does: the whole reason
+    /// the window is built hidden is that the person never sees it at the
+    /// wrong size. Full size is what an unreadable settings file falls back
+    /// to, so a reveal that always applied it would look right in exactly
+    /// the case nothing was saved; and the scaling clamps whatever it is
+    /// handed, so the record holds the size the window was put at, not the
+    /// raw number, at both ends of the range. One row per saved size.
     #[test]
-    fn the_saved_size_reaches_the_window_before_it_is_shown() {
-        let window = Recorder::default();
-
-        let zoom = reveal_at(&window, 150).unwrap();
-
-        assert_eq!(zoom.read(), state(150, false));
-        assert_eq!(
-            window.told.into_inner(),
-            [Told::ScaleTo(1.5), Told::Unhide],
-            "the saved percent, as a scale factor, then the reveal"
-        );
-    }
-
-    /// Full size is what an unreadable settings file falls back to, so a
-    /// reveal that always applied it would look right in exactly the case
-    /// nothing was saved.
-    #[test]
-    fn a_size_away_from_full_is_the_one_applied() {
-        for (percent, factor) in [(50u16, 0.5), (100, 1.0), (200, 2.0)] {
+    fn the_saved_size_reaches_the_window_before_it_is_shown_and_is_what_is_recorded() {
+        let rows = [
+            (150u16, 150u16, 1.5),
+            (50, 50, 0.5),
+            (100, 100, 1.0),
+            (200, 200, 2.0),
+            (
+                5000,
+                kendex_core::settings::ZOOM.max,
+                kendex_core::settings::zoom_scale(kendex_core::settings::ZOOM.max),
+            ),
+            (
+                1,
+                kendex_core::settings::ZOOM.min,
+                kendex_core::settings::zoom_scale(kendex_core::settings::ZOOM.min),
+            ),
+        ];
+        for (asked, recorded, factor) in rows {
             let window = Recorder::default();
-            reveal_at(&window, percent).unwrap();
-            assert_eq!(window.told.into_inner()[0], Told::ScaleTo(factor));
+            let zoom = reveal_at(&window, asked).unwrap();
+            assert_eq!(zoom.read(), state(recorded, false), "asked {asked}");
+            assert_eq!(
+                window.told.into_inner(),
+                [Told::ScaleTo(factor), Told::Unhide],
+                "asked {asked}: the recorded percent, as a scale factor, then the reveal"
+            );
         }
     }
 
@@ -291,27 +300,20 @@ mod tests {
         assert_eq!(zoom.read(), state(150, false));
     }
 
-    /// The scaling clamps whatever it is handed, so a record taken from the
-    /// raw number would claim a size the window was never put at — and the
-    /// page that reloads believes the record. Both ends of the range, and
-    /// both ways in: the opening and a resize.
+    /// The same clamp on the way in by a resize: the page that reloads
+    /// believes the record, so it holds the size the window was given.
     #[test]
-    fn a_size_outside_the_range_is_recorded_as_the_one_the_window_was_given() {
+    fn a_resize_outside_the_range_is_recorded_as_the_one_the_window_was_given() {
         for (asked, given) in [
             (5000u16, kendex_core::settings::ZOOM.max),
             (1, kendex_core::settings::ZOOM.min),
         ] {
             let window = Recorder::default();
-            let zoom = reveal_at(&window, asked).unwrap();
-            assert_eq!(zoom.read(), state(given, false), "the opening");
-            assert_eq!(
-                window.told.borrow()[0],
-                Told::ScaleTo(kendex_core::settings::zoom_scale(given)),
-                "the opening put the window at a different size than it recorded"
-            );
+            let zoom = reveal_at(&window, 100).unwrap();
 
             resize(&window, &zoom, asked).unwrap();
-            assert_eq!(zoom.read(), state(given, false), "a resize");
+
+            assert_eq!(zoom.read(), state(given, false), "asked {asked}");
             assert_eq!(
                 window.told.borrow().last(),
                 Some(&Told::ScaleTo(kendex_core::settings::zoom_scale(given))),

--- a/crates/app/tests/apply_migration.rs
+++ b/crates/app/tests/apply_migration.rs
@@ -82,78 +82,83 @@ fn fixture(manifest: impl FnOnce(&std::path::Path) -> String) -> Fixture {
     }
 }
 
-/// A schema-5 manifest still carrying the retired safety tables. The
-/// preview says it cannot be read, the apply refuses, and every byte —
-/// comments and trailing comments included — is exactly where it was.
+/// A manifest this build cannot read is a scope error of its own kind, so
+/// the page can say what to do with a file that is intact and the person's
+/// own, and every byte of it (comments and trailing comments included) is
+/// exactly where it was. One row per shape: a schema-5 manifest still
+/// carrying the retired safety tables; a manifest naming no schema (a v0.1
+/// file); a retired table put back by hand into a current manifest, which
+/// is invalid rather than outdated.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn an_older_manifest_is_refused_and_left_byte_identical() {
+fn a_manifest_this_build_cannot_read_is_refused_and_left_byte_identical() {
+    type Build = fn(&std::path::Path) -> String;
+    let rows: [(&str, Build, ScopeErrorKind); 3] = [
+        (
+            "schema 5 with the retired tables",
+            |source| {
+                format!(
+                    "{}\n{RETIRED}",
+                    KEPT.replace("{schema}", "5")
+                        .replace("{source}", &source_path(source))
+                )
+            },
+            ScopeErrorKind::ManifestOutdated,
+        ),
+        (
+            "no schema at all",
+            |source| {
+                KEPT.replace("schema = {schema}\n", "")
+                    .replace("{source}", &source_path(source))
+            },
+            ScopeErrorKind::ManifestOutdated,
+        ),
+        (
+            "a retired table in a current schema",
+            |source| {
+                format!(
+                    "{}\n{RETIRED}",
+                    KEPT.replace("{schema}", &MANIFEST_SCHEMA.to_string())
+                        .replace("{source}", &source_path(source))
+                )
+            },
+            ScopeErrorKind::ManifestInvalid,
+        ),
+    ];
+    for (what, build, kind) in rows {
+        let f = fixture(build);
+        let original = fs::read_to_string(&f.manifest_path).unwrap();
+
+        let before = view(&f.env, &f.scope);
+        let error = before.error.expect(what);
+        assert!(
+            std::mem::discriminant(&error.kind) == std::mem::discriminant(&kind),
+            "{what}: {}",
+            error.message
+        );
+        assert!(before.plan.is_empty(), "{what}: {:?}", before.plan);
+        assert_eq!(
+            fs::read_to_string(&f.manifest_path).unwrap(),
+            original,
+            "{what}"
+        );
+    }
+}
+
+/// The apply refuses the same file the preview refused, and installs
+/// nothing.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn applying_an_older_manifest_refuses_and_installs_nothing() {
     let f = schema5_fixture();
     let original = fs::read_to_string(&f.manifest_path).unwrap();
 
-    let before = view(&f.env, &f.scope);
-    let error = before.error.expect("an older manifest is a scope error");
-    assert!(
-        matches!(error.kind, ScopeErrorKind::ManifestOutdated),
-        "its own kind, so the page can say what to do with a file that is
-         intact and the person's own"
-    );
-    assert!(error.message.contains("schema 5"), "{}", error.message);
-    assert!(error.message.contains("install fresh"), "{}", error.message);
-    assert!(before.plan.is_empty(), "{:?}", before.plan);
-
-    let Err(refused) = apply_scope(&f.env, &f.scope, false) else {
-        panic!("applying an older manifest must refuse");
-    };
-    assert!(refused.contains("install fresh"), "{refused}");
+    assert!(apply_scope(&f.env, &f.scope, false).is_err());
     assert_eq!(fs::read_to_string(&f.manifest_path).unwrap(), original);
     assert!(
         !f.scope_root().join(".claude/skills/gh").exists(),
         "a refused scope installs nothing"
     );
-}
-
-/// A manifest naming no schema — a v0.1 file — is the same refusal.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_schema_less_manifest_is_refused_the_same_way() {
-    let f = fixture(|source| {
-        KEPT.replace("schema = {schema}\n", "")
-            .replace("{source}", &source_path(source))
-    });
-    let original = fs::read_to_string(&f.manifest_path).unwrap();
-
-    let error = view(&f.env, &f.scope)
-        .error
-        .expect("a schema-less manifest is a scope error");
-    assert!(error.message.contains("no schema"), "{}", error.message);
-    assert_eq!(fs::read_to_string(&f.manifest_path).unwrap(), original);
-}
-
-/// A retired table put back by hand into a current manifest is named as
-/// the stray key it is, not silently dropped on the next write.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_retired_table_in_a_current_manifest_is_named_not_dropped() {
-    let f = fixture(|source| {
-        format!(
-            "{}\n{RETIRED}",
-            KEPT.replace("{schema}", &MANIFEST_SCHEMA.to_string())
-                .replace("{source}", &source_path(source))
-        )
-    });
-    let original = fs::read_to_string(&f.manifest_path).unwrap();
-
-    let error = view(&f.env, &f.scope)
-        .error
-        .expect("a stray table is a scope error");
-    assert!(matches!(error.kind, ScopeErrorKind::ManifestInvalid));
-    assert!(
-        error.message.contains("safety-overrides"),
-        "the table is named: {}",
-        error.message
-    );
-    assert_eq!(fs::read_to_string(&f.manifest_path).unwrap(), original);
 }
 
 /// A manifest that vanished between the preview and the click is an error

--- a/crates/app/tests/audit_scope_error.rs
+++ b/crates/app/tests/audit_scope_error.rs
@@ -58,7 +58,6 @@ fn a_v1_lock_scope_carries_a_structured_error() {
     let result = view(&f.env, &f.scope);
     let error = result.error.expect("a v1 lock is a scope error");
     assert!(matches!(error.kind, ScopeErrorKind::LockCorrupt));
-    assert!(error.message.contains("install fresh"), "{}", error.message);
 }
 
 #[test]

--- a/crates/app/tests/cask_symlink_launch.rs
+++ b/crates/app/tests/cask_symlink_launch.rs
@@ -25,9 +25,6 @@ const PROBE_OK: &str = "cask-symlink probe named ";
 /// The probe's own name, as the harness filter spells it.
 const PROBE_TEST: &str = "a_symlinked_launch_path_names_its_own_binary";
 
-/// The tauri feature that turns the refusal off.
-const SYMLINK_FEATURE: &str = "process-relaunch-dangerous-allow-symlink-macos";
-
 /// A cask's shape under `root`: the versioned bundle in the Caskroom, and
 /// `Applications/kendex.app` linked at it. Returns the path a launch from
 /// `/Applications` is handed, then the bundle really holding those bytes.
@@ -132,26 +129,5 @@ fn a_symlinked_launch_path_names_its_own_binary() {
         launch.display(),
         child.status,
         String::from_utf8_lossy(&child.stderr)
-    );
-}
-
-/// The refusal is macOS-only and no CI lane runs this crate's tests there,
-/// so the probe above would stay green on every machine that could notice
-/// the feature going missing. This notices.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn the_manifest_still_turns_the_refusal_off() {
-    let manifest =
-        std::fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml")).unwrap();
-    let features = manifest.parse::<toml::Table>().unwrap()["dependencies"]["tauri"]["features"]
-        .as_array()
-        .expect("the tauri dependency names the features it turns on")
-        .clone();
-    assert!(
-        features
-            .iter()
-            .any(|name| name.as_str() == Some(SYMLINK_FEATURE)),
-        "crates/app/Cargo.toml no longer enables {SYMLINK_FEATURE}, so a cask \
-         install's Update button refuses its own launch path again"
     );
 }

--- a/crates/app/tests/recovery.rs
+++ b/crates/app/tests/recovery.rs
@@ -32,9 +32,10 @@ fn launch_recovery_rolls_back_pending_journals_in_registered_projects() {
     let messages = kendex_app::recovery::recover_on_launch(&env);
     assert_eq!(fs::read_to_string(&victim).unwrap(), "original");
     assert!(!journal::pending(&dir));
-    assert!(
-        messages.iter().any(|m| m.contains("recovered")),
-        "{messages:?}"
+    assert_eq!(
+        messages.len(),
+        1,
+        "one recovery, reported once: {messages:?}"
     );
 
     // Nothing pending: the next launch is silent.

--- a/crates/app/tests/replace_unmanaged.rs
+++ b/crates/app/tests/replace_unmanaged.rs
@@ -160,10 +160,9 @@ fn an_older_schema_refuses_the_take_over_and_writes_nothing() {
     );
     fs::write(&path, &older).unwrap();
 
-    let Err(refused) = replace_unmanaged(&f.env, &f.scope, ItemKind::Skill, "deploy".into()) else {
+    let Err(_) = replace_unmanaged(&f.env, &f.scope, ItemKind::Skill, "deploy".into()) else {
         panic!("a manifest this build cannot read must refuse the take-over");
     };
-    assert!(refused.contains("install fresh"), "{refused}");
     assert_eq!(
         fs::read_to_string(&path).unwrap(),
         older,
@@ -281,32 +280,6 @@ fn replacing_stops_when_one_of_an_item_s_places_stops_allowing_it() {
     assert!(position.is_symlink(), "the link is left exactly as it was");
 }
 
-/// The check and the plan it guards come from one read. Between a separate
-/// look at the disk and the plan, the files can go: the second read sees an
-/// ordinary missing install, and the scope's whole apply runs for a button
-/// that answered a question already gone.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_choice_settled_between_the_look_and_the_plan_changes_nothing() {
-    let f = fixture();
-    let deploy = f.project.join(".claude/skills/deploy");
-
-    // Exactly what a second read would find: nothing in the way any more.
-    fs::remove_dir_all(&deploy).unwrap();
-
-    let refused = replace_unmanaged(&f.env, &f.scope, ItemKind::Skill, "deploy".into());
-    assert!(refused.is_err(), "a stale choice was carried out");
-    assert!(
-        !deploy.join("SKILL.md").exists(),
-        "the item was installed by a choice that was about replacing it"
-    );
-    assert_eq!(
-        body(&f, "lint"),
-        "the tool that came before",
-        "and the rest of the scope was applied on the way past"
-    );
-}
-
 /// A conflict of another kind beside the files. It carries no exit of its
 /// own, and the page has to see it anyway: left out, the row it sits on
 /// would offer a replacement the plan then refuses for the whole item.
@@ -315,7 +288,16 @@ fn a_choice_settled_between_the_look_and_the_plan_changes_nothing() {
 fn a_conflict_with_no_exit_of_its_own_still_reaches_the_page() {
     let f = fixture();
     let installed = view(&f.env, &f.scope);
-    assert!(!installed.drift.is_empty());
+    assert_eq!(
+        installed
+            .drift
+            .iter()
+            .filter(|row| row.cause == Some(kendex_core::engine::DriftCause::UnmanagedContent))
+            .count(),
+        2,
+        "both rows are waiting on a person: {:?}",
+        installed.drift
+    );
 
     // deploy installed from the catalog, then pointed at somewhere else:
     // a clash the exits cannot settle, on an item whose other place holds

--- a/crates/app/tests/repo_effects.rs
+++ b/crates/app/tests/repo_effects.rs
@@ -42,7 +42,6 @@ fn the_effect_comes_back_unrun_and_a_separate_yes_arms_it() {
         panic!("one offer: {:?}", installed.repo_effects);
     };
     assert_eq!(offer.name, "commit-guards");
-    assert!(offer.summary.contains("every commit"));
     let hooks = f.project.join(".git/hooks");
     let written: Vec<&str> = offer.writes.iter().map(|w| w.path.as_str()).collect();
     assert!(
@@ -178,99 +177,72 @@ fn commit(f: &Fixture, message: &str) -> std::process::Output {
     }
 }
 
-/// Removing the package from the window disarms the repository first, and
-/// the action's own result says what ran.
+/// Every door a package leaves by disarms the repository first, and the
+/// action's own result says what ran: removing it from the window,
+/// unsubscribing from the source that brought it, and a whole-scope apply
+/// once the manifest stops declaring it (the shape a hand edit and the
+/// built-in editor both arrive at). The repository commits afterwards with
+/// no kendex in the picture.
 ///
-/// The terminal does the same. A window that executed the plan and
-/// dropped the report would take the scripts and leave the shims — and
-/// every commit in that repository would fail closed until somebody found
-/// two files under `.git/hooks` by hand.
+/// The terminal does the same. A window that executed the plan and dropped
+/// the report would take the scripts and leave the shims, and every commit
+/// in that repository would fail closed until somebody found two files
+/// under `.git/hooks` by hand.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn removing_a_package_disarms_the_repository_and_says_so() {
-    let f = fixture();
-    arm(&f);
-    git(&f.project, &["add", "."]);
+fn every_door_a_package_leaves_by_disarms_the_repository_first() {
+    type Door = fn(&Fixture) -> Vec<String>;
+    let rows: [(&str, Door); 3] = [
+        ("removing the package from the window", |f| {
+            kendex_app::audit::remove(&f.env, &f.scope, ItemKind::Skill, "commit-guards")
+                .unwrap_or_else(|error| panic!("remove: {error}"))
+                .undone
+        }),
+        ("unsubscribing from its source", |f| {
+            kendex_app::unsubscribe::unsubscribe(&f.env, &f.scope, "cat", false, false)
+                .unwrap_or_else(|error| panic!("unsubscribe: {error}"))
+                .undone
+        }),
+        ("applying a manifest that stopped declaring it", |f| {
+            let manifest = f.project.join("kendex.toml");
+            let text = fs::read_to_string(&manifest).unwrap();
+            assert!(text.contains("[skills.commit-guards]"), "{text}");
+            fs::write(
+                &manifest,
+                text.replace("[skills.commit-guards]\nsource = \"cat\"\n", ""),
+            )
+            .unwrap();
+            kendex_app::audit::apply_scope(&f.env, &f.scope, true)
+                .unwrap_or_else(|error| panic!("apply_scope: {error}"))
+                .undone
+        }),
+    ];
+    for (door, leave) in rows {
+        let f = fixture();
+        arm(&f);
+        git(&f.project, &["add", "."]);
 
-    let view = kendex_app::audit::remove(&f.env, &f.scope, ItemKind::Skill, "commit-guards")
-        .unwrap_or_else(|error| panic!("remove: {error}"));
+        let undone = leave(&f);
 
-    assert!(
-        !f.project.join(".git/hooks/kendex-guards").exists(),
-        "the removal left the shim behind"
-    );
-    assert!(
-        view.undone
-            .iter()
-            .any(|line| line == "commit-guards: running scripts/install-git-hooks --uninstall"),
-        "{:?}",
-        view.undone
-    );
-    git(&f.project, &["add", "-A"]);
-    let after = commit(&f, "after removal");
-    assert!(
-        after.status.success(),
-        "the repository could not commit: {}",
-        String::from_utf8_lossy(&after.stderr)
-    );
-}
-
-/// Unsubscribing takes the source's packages with it, so it disarms them
-/// the same way and hands the account back for the window to show.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn unsubscribing_disarms_the_packages_that_leave_with_the_source() {
-    let f = fixture();
-    arm(&f);
-    git(&f.project, &["add", "."]);
-
-    let undone = kendex_app::unsubscribe::unsubscribe(&f.env, &f.scope, "cat", false, false)
-        .unwrap_or_else(|error| panic!("unsubscribe: {error}"));
-
-    assert!(
-        !f.project.join(".git/hooks/kendex-guards").exists(),
-        "the unsubscribe left the shim behind"
-    );
-    assert!(
-        undone
-            .undone
-            .iter()
-            .any(|line| line.starts_with("commit-guards: running")),
-        "{undone:?}"
-    );
-}
-
-/// A whole-scope apply takes a package away when the manifest stops
-/// declaring it — the shape a hand edit and the built-in editor both
-/// arrive at — and that removal disarms first too.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn applying_a_manifest_without_the_package_disarms_first() {
-    let f = fixture();
-    arm(&f);
-    let manifest = f.project.join("kendex.toml");
-    let text = fs::read_to_string(&manifest).unwrap();
-    assert!(text.contains("[skills.commit-guards]"), "{text}");
-    fs::write(
-        &manifest,
-        text.replace("[skills.commit-guards]\nsource = \"cat\"\n", ""),
-    )
-    .unwrap();
-
-    let view = kendex_app::audit::apply_scope(&f.env, &f.scope, true)
-        .unwrap_or_else(|error| panic!("apply_scope: {error}"));
-
-    assert!(
-        !f.project.join(".git/hooks/kendex-guards").exists(),
-        "the apply left the shim behind"
-    );
-    assert!(
-        view.undone
-            .iter()
-            .any(|line| line.starts_with("commit-guards: running")),
-        "{:?}",
-        view.undone
-    );
+        assert!(
+            !f.project.join(".git/hooks/kendex-guards").exists(),
+            "{door}: the shim was left behind"
+        );
+        // The account opens with what ran; what the uninstaller itself said
+        // follows and is its own.
+        assert_eq!(
+            undone.first().map(String::as_str),
+            Some("commit-guards: running scripts/install-git-hooks --uninstall"),
+            "{door}: {undone:?}"
+        );
+        git(&f.project, &["add", "-A"]);
+        let after = commit(&f, "after leaving");
+        assert!(
+            after.status.success(),
+            "{door}: the repository could not commit: {}",
+            String::from_utf8_lossy(&after.stderr)
+        );
+    }
 }
 
 /// An uninstaller that refuses stops the removal with the package's files
@@ -306,7 +278,6 @@ fn a_refusing_uninstaller_stops_the_removal() {
     };
 
     assert!(error.contains("refusing to disarm"), "{error}");
-    assert!(error.contains("its files stay in place"), "{error}");
     assert!(
         installer.is_file(),
         "the package's files went despite the refusal"
@@ -328,13 +299,10 @@ fn a_package_with_no_uninstaller_is_removed_with_that_said() {
     let view = kendex_app::audit::remove(&f.env, &f.scope, ItemKind::Skill, "noisy")
         .unwrap_or_else(|error| panic!("remove: {error}"));
 
-    assert!(
-        view.undone
-            .iter()
-            .any(|line| line.contains("noisy: declares no uninstaller")),
-        "{:?}",
-        view.undone
-    );
+    let [line] = view.undone.as_slice() else {
+        panic!("one line, the package's own: {:?}", view.undone);
+    };
+    assert!(line.starts_with("noisy: declares no uninstaller"), "{line}");
 }
 
 /// An inert package's removal has nothing to account for, so the window is
@@ -384,7 +352,6 @@ fn a_write_that_must_remove_nothing_refuses_when_it_would() {
     let refused = kendex_app::repo_effects::write_nothing_leaving(&f.env, &report).unwrap_err();
 
     assert!(refused.contains("commit-guards"), "{refused}");
-    assert!(refused.contains("Audit page"), "{refused}");
     assert!(
         f.project.join(".git/hooks/kendex-guards").is_file(),
         "the refusal ran the uninstaller anyway"

--- a/crates/app/tests/repo_effects_escaping.rs
+++ b/crates/app/tests/repo_effects_escaping.rs
@@ -148,11 +148,7 @@ fn a_root_this_scope_never_installed_is_refused() {
         },
         ..offer.declared.clone()
     };
-    let error = kendex_app::repo_effects::apply(&f.env, &f.scope, &forged).unwrap_err();
-    assert!(
-        error.contains("no record of installing it there"),
-        "{error}"
-    );
+    kendex_app::repo_effects::apply(&f.env, &f.scope, &forged).unwrap_err();
     assert!(
         !f.project.join(".git/hooks/kendex-guards").exists(),
         "the forged root armed the hooks"

--- a/crates/app/tests/tauri_config.rs
+++ b/crates/app/tests/tauri_config.rs
@@ -12,29 +12,44 @@ fn config() -> serde_json::Value {
         .expect("tauri.conf.json parses")
 }
 
-/// The saved zoom is applied in `setup`, which runs after the window is
-/// built. A window that is visible by then shows one frame at full size and
-/// re-lays out the whole app in front of the person.
+/// The settings the window and the release path lean on, one row per JSON
+/// pointer, each held to the value the code expects (a constant the app or
+/// core owns wherever there is one).
+///
+/// - `visible: false`: the saved zoom is applied in `setup`, after the window
+///   is built; a window visible by then shows one frame at full size.
+/// - `label: "main"`: the label the reveal looks up; left to tauri's default,
+///   a hidden window would never be shown if that default changed.
+/// - the deep-link schemes: the plugin registers only what this file
+///   declares and drops a link in any other scheme before the app sees it.
+/// - `version`: the publish job reads the version out of the built CLI and
+///   refuses a tag naming another; left to drift, the updater reads the app
+///   bundle as current or as older than a release it cannot find.
+/// - the updater endpoints: exactly one, the release channel, so an install
+///   that stopped overriding it falls back to full releases; a second
+///   endpoint the install does not choose is one nothing holds to a channel.
 #[test]
-fn the_window_opens_hidden_so_the_saved_zoom_lands_first() {
-    let window = &config()["app"]["windows"][0];
-    assert_eq!(window["visible"].as_bool(), Some(false));
-    // The label the reveal looks up. Left to tauri's default, a hidden
-    // window would simply never be shown if that default ever changed.
-    assert_eq!(window["label"].as_str(), Some("main"));
-}
-
-/// The scheme the website's "Open in app" links carry. The deep-link
-/// plugin registers only the schemes this file declares, and a link in a
-/// scheme it does not know is dropped before the app sees it, so the
-/// parser's own name for the scheme and the declaration are held together.
-#[test]
-fn the_deep_link_scheme_is_declared_for_the_desktop() {
-    let schemes = &config()["plugins"]["deep-link"]["desktop"]["schemes"];
-    assert_eq!(
-        schemes.as_array().map(Vec::as_slice),
-        Some(&[serde_json::Value::from(kendex_app::deep_link::SCHEME)][..])
-    );
+fn the_settings_the_window_and_the_release_path_lean_on() {
+    let config = config();
+    let rows = [
+        ("/app/windows/0/visible", serde_json::Value::from(false)),
+        ("/app/windows/0/label", serde_json::Value::from("main")),
+        (
+            "/plugins/deep-link/desktop/schemes",
+            serde_json::Value::from(vec![kendex_app::deep_link::SCHEME]),
+        ),
+        (
+            "/version",
+            serde_json::Value::from(env!("CARGO_PKG_VERSION")),
+        ),
+        (
+            "/plugins/updater/endpoints",
+            serde_json::Value::from(vec![kendex_core::update_channel::RELEASE_MANIFEST_URL]),
+        ),
+    ];
+    for (pointer, expected) in rows {
+        assert_eq!(config.pointer(pointer), Some(&expected), "{pointer}");
+    }
 }
 
 /// The app's updater reads its key from this file at build time, so the
@@ -77,39 +92,5 @@ fn the_app_and_the_cli_pin_one_updater_key() {
     assert_eq!(
         key_id, "C922C89178B7C6CC",
         "the pin carries a key id the release signing key does not"
-    );
-}
-
-/// The app bundle and the CLI carry their versions in different files, and
-/// the release is held to one of them: the publish job reads the version
-/// back out of the built CLI and refuses a tag that names another. Left to
-/// drift, a tag matching the CLI would ship an app bundle of some other
-/// version, which the updater then reads as already current or as older
-/// than a release it cannot find.
-#[test]
-fn the_app_and_the_cli_ship_one_version() {
-    assert_eq!(
-        config()["version"].as_str(),
-        Some(env!("CARGO_PKG_VERSION"))
-    );
-}
-
-/// The plugin needs a configured endpoint, and the install hands it core's
-/// choice on top. The configured one is the release channel, so an install
-/// that ever stopped overriding it falls back to full releases rather than
-/// to whatever a stale edit left here — and a build that is not a release
-/// candidate finds the two already equal.
-#[test]
-fn the_configured_endpoint_is_the_release_channel() {
-    assert_eq!(
-        config()["plugins"]["updater"]["endpoints"][0].as_str(),
-        Some(kendex_core::update_channel::RELEASE_MANIFEST_URL)
-    );
-    assert_eq!(
-        config()["plugins"]["updater"]["endpoints"]
-            .as_array()
-            .map(Vec::len),
-        Some(1),
-        "a second endpoint the install does not choose is one nothing holds to a channel"
     );
 }

--- a/crates/app/tests/updates_scope_error.rs
+++ b/crates/app/tests/updates_scope_error.rs
@@ -51,9 +51,8 @@ fn fixture(name: &str) -> Fixture {
 }
 
 /// A lock whose schema this build rejects, alongside the personal scope.
-/// The personal scope's standing still lands; the project is named with the
-/// reason the engine gave, which is what the page shows instead of a bare
-/// "?".
+/// The personal scope's standing still lands; the project is named as the
+/// unreadable one, which is what the page shows instead of a bare "?".
 #[test]
 #[allow(clippy::unwrap_used)]
 fn an_unreadable_project_is_named_and_leaves_the_other_scopes_alone() {
@@ -64,9 +63,4 @@ fn an_unreadable_project_is_named_and_leaves_the_other_scopes_alone() {
     assert_eq!(report.unreadable.len(), 1, "{:?}", report.unreadable);
     let named = &report.unreadable[0];
     assert_eq!(named.scope, f.project);
-    assert!(
-        named.message.contains("version 1 record"),
-        "the reason travels with the scope: {}",
-        named.message
-    );
 }


### PR DESCRIPTION
Every test file under `crates/app` (30 files) judged against code-quality § Tests from a read-only classification pass; twenty reshaped, nine already at the bar. No file exceeded the size caps, so the findings are families of cases calling one function on one input axis (now tables, one asserted row per former case), a case duplicated under a second doc comment, two truthiness bits, a test of `Cargo.toml`, and prose pins on refusals no consumer parses where an enum, exit or disk-state assertion beside them already carries the case. Test code only; no production file changes; `[no-changelog]`.

## Folded or deleted cases, with the surviving row

| Former cases | Surviving table or case |
|---|---|
| `launch_env/tests.rs`: `no_other_packaging_is_pushed_onto_a_backend`, `our_variable_chooses_a_backend_the_appimage_would_not_let_through`, `choosing_the_backend_the_environment_already_has_changes_nothing`, `our_variable_is_heard_on_a_session_that_is_not_wayland`, `a_backend_the_person_chose_is_left_alone`, `a_deb_that_inherited_the_variables_keeps_the_backend_the_person_set` | `the_backend_the_plan_pushes_is_decided_by_who_set_what`, 11 rows; the duplicated `plan(webkit 0).is_empty()` assertion stays in `wayland_gets_the_dmabuf_workaround_whatever_installed_the_app` |
| `native.rs`: the five `resolve_editor_at` cases | `the_editor_is_the_first_executable_candidate_or_the_override`, 5 rows |
| `tauri_config.rs`: `the_window_opens_hidden_so_the_saved_zoom_lands_first`, `the_deep_link_scheme_is_declared_for_the_desktop`, `the_app_and_the_cli_ship_one_version`, `the_configured_endpoint_is_the_release_channel` | `the_settings_the_window_and_the_release_path_lean_on`, 5 JSON-pointer rows (the endpoint row pins the whole one-element list) |
| `window.rs`: `the_saved_size_reaches_the_window_before_it_is_shown`, `a_size_away_from_full_is_the_one_applied`, the opening half of `a_size_outside_the_range_is_recorded_as_the_one_the_window_was_given` | `the_saved_size_reaches_the_window_before_it_is_shown_and_is_what_is_recorded`, 6 rows each pinning `[ScaleTo, Unhide]`; the resize half is `a_resize_outside_the_range_is_recorded_as_the_one_the_window_was_given` |
| `update_check.rs`: the three `merge` cases | `the_page_is_dated_by_the_newest_scope_that_fetched`, 5 rows |
| `packages.rs`: `no_managed_package_covers_the_manifest_answers`, `a_read_that_failed_is_not_one_of_them`, the predicate half of `an_unfetched_source_is_its_own_shape` | `only_the_two_manifest_answers_are_no_managed_package`, 4 rows |
| `repo_effects.rs` (src): the three `after_writing` cases | `the_account_of_the_write_rides_on_a_failed_read_only`, 3 rows |
| `editor.rs`: `reads_each_agents_recorded_assignment`, `leaves_an_unrecorded_agent_out_rather_than_calling_it_empty`, the absent-lock half of `absent_and_unreadable_locks_are_distinct` | `the_automatic_assignments_are_the_agents_own_lock_entries`, 3 rows asserting the whole map; the unreadable half is `an_unreadable_lock_is_an_error` |
| `apply_migration.rs`: the three refusals | `a_manifest_this_build_cannot_read_is_refused_and_left_byte_identical`, 3 rows on `ScopeErrorKind`; the apply half is `applying_an_older_manifest_refuses_and_installs_nothing` |
| `tests/repo_effects.rs`: `removing_a_package_disarms_the_repository_and_says_so`, `unsubscribing_disarms_the_packages_that_leave_with_the_source`, `applying_a_manifest_without_the_package_disarms_first` | `every_door_a_package_leaves_by_disarms_the_repository_first`, 3 rows, each pinning the account's first line byte for byte and a commit afterwards |
| `replace_unmanaged.rs`: `a_choice_settled_between_the_look_and_the_plan_changes_nothing` | **deleted**: the same fixture, call and three assertions as `a_choice_that_is_no_longer_on_offer_changes_nothing` |
| `cask_symlink_launch.rs`: `the_manifest_still_turns_the_refusal_off` | **deleted**: a pin on a `Cargo.toml` features array with no production code under test; the behaviour it guarded is `a_symlinked_launch_path_names_its_own_binary`, which the macOS cargo CI job runs |
| `account.rs`: the `SignInExpired` row of `expiry_is_the_one_refusal_that_is_news_about_the_account` | `the_expired_refusal_carries_the_remedy_with_the_reason`, which destructures the same variant and more |

Truthiness bits now asserting the shape: `a_conflict_with_no_exit_of_its_own_still_reaches_the_page` (two `UnmanagedContent` rows), `creating_a_manifest_here_still_seeds_the_default_source` (the seeded sources map), `launch_recovery_rolls_back_pending_journals_in_registered_projects` (one recovery reported once).

Prose pins dropped, each beside the assertion that carries the case: `a_refusing_uninstaller_stops_the_removal` ("its files stay in place"), `a_write_that_must_remove_nothing_refuses_when_it_would` ("Audit page"), `the_effect_comes_back_unrun_and_a_separate_yes_arms_it` (the summary), `apply_migration` ("schema 5", "install fresh", "no schema", "safety-overrides"), `an_older_schema_refuses_the_take_over_and_writes_nothing`, `a_first_save_creates_the_manifest_and_the_draft_schema_decides_it` ("schema"), `a_refusal_after_the_uninstaller_ran_says_what_it_ran` (a line count), `app_update` (three refusal sentences), `a_v1_lock_scope_carries_a_structured_error`, `the_read_failure_reaches_the_surface_as_the_half_that_failed` (core's Display prefix), `a_root_this_scope_never_installed_is_refused`, `an_unreadable_project_is_named_and_leaves_the_other_scopes_alone`; `rejected_edits_come_back_with_their_fix_string` becomes `rejected_edits_name_the_offending_key` (the remedy wording goes, the key stays).

Kept on judgment: `deep_link/tests.rs`'s eleven `reason.contains(part)` rows (the refusal naming the part is the behaviour; the proposed enum is a production change); `applying_without_a_manifest_is_an_error`'s "no manifest" (a bare string whose subject is saying so); `a_package_with_no_uninstaller_is_removed_with_that_said`'s line (the reviewer's blocker: a prefix alone matched three of undo.rs's lines); `commands.rs`'s warning cause (the reviewer's S2: nothing else pins it).

## Mutation

One must-fail mutant per surviving table, ten tables, all killed (`mutants-app.txt` in the lane scratchpad; `mutate-app.py` mutates production in place and restores it with `git checkout`): our variable ignored in the backend decision; a non-executable candidate taken; the window visible in `tauri.conf.json`; the reveal's clamp dropped (its first run hit the resize arm and survived; the retargeted run is the record); oldest-wins in the updates merge; `ItemRevUnsupported` read as a failure; the write's account dropped from a failed read; a skill-kind entry read as an assignment; `LegacyManifest` mapped to `ManifestInvalid`; the uninstaller's account line reworded.

## Reviewer round

One reviewer-test round, ACCEPT WITH FIXES, all applied: the blocker (the no-uninstaller line's prefix matched three lines; its clause is back), two doc comments trimmed to what their rows hold, the warning's cause pinned again. The reviewer's S3 (no CI runs this crate on macOS) is answered by the `macOS cargo kendex-app` job, which runs the launch-path probe; no follow-up.

## Checks

- `cargo test -p kendex-app`: 118 passed; `cargo clippy -p kendex-app --all-targets -- -D warnings` clean; `cargo fmt -p kendex-app -- --check` clean.
- `tools/guard --full`: exit 0 on dde0eb568 (TMPDIR=/var/tmp/ken-c), the same tree restacked onto main as bc0163e2a.

KEN-1241

https://claude.ai/code/session_01JjdknThZvqDq3HUfHPkRNe
