### PR TITLE
test(KEN-1241): kendex-core suites against the tests bar [no-changelog]

### DIFF
--- a/crates/core/tests/adopt_pinned.rs
+++ b/crates/core/tests/adopt_pinned.rs
@@ -96,10 +96,15 @@ fn keeping_a_pinned_item_leaves_the_scope_plannable() {
         !written.contains("rev ="),
         "the pin was carried onto a source that has no revisions:\n{written}"
     );
-    let after = engine::audit(&env, &scope);
+    let after = engine::audit(&env, &scope).unwrap_or_else(|error| {
+        panic!("the scope cannot be planned after keeping the files: {error:?}")
+    });
     assert!(
-        after.is_ok(),
-        "the scope cannot be planned after keeping the files: {:?}",
-        after.err()
+        after
+            .drift
+            .iter()
+            .all(|row| row.state != kendex_core::engine::DriftState::Conflict),
+        "the kept files are still in the way: {:?}",
+        after.drift
     );
 }

--- a/crates/core/tests/authoring.rs
+++ b/crates/core/tests/authoring.rs
@@ -237,65 +237,166 @@ fn create_writes_the_plan_registers_and_checks_clean() {
     assert!(again.to_string().contains("already exists"), "{again}");
 }
 
-/// `nope/..` names no folder of its own. Left unrefused it is a create
-/// into the directory the command was run in, and the failure path's
-/// removal then takes that directory with it.
+/// A request `create` refuses before writing anything, one row per
+/// destination, the `Authoring` message naming what it stopped on and the
+/// tree afterwards untouched. `nope/..` names no folder of its own, and
+/// left unrefused it is a create into the directory the command was run
+/// in, which the failure path's removal would then take with it. A folder
+/// is made inside one that is already there, and a containing folder that
+/// is not gets a refusal naming it rather than being brought into being
+/// (`CreateRequest.dir` requires its parent to exist). A link whose target
+/// is gone answers `exists` with false, and the failure path's
+/// `remove_dir_all` would delete the link itself; asked of the three
+/// spellings that reach one place, because they do not all resolve alike
+/// (`made` stops at the link, `made/` and `made/.` send the kernel
+/// through it and answer NotFound, so a guard on the caller's spelling
+/// passes for the last two while the build and the removal work on the
+/// place all three name). A name no harness accepts is refused before
+/// the folder exists.
 #[test]
-#[allow(clippy::unwrap_used)]
-fn a_path_whose_last_component_is_not_a_name_refuses_and_writes_nothing() {
-    let (tmp, env) = fake();
-    let work = tmp.path().join("work");
-    fs::create_dir_all(work.join("sub")).unwrap();
-    fs::write(work.join("keep.txt"), "somebody's file").unwrap();
-    fs::write(work.join("sub/also.txt"), "and another").unwrap();
+#[allow(
+    clippy::unwrap_used,
+    clippy::too_many_lines,
+    reason = "one table: six destinations refused by one create call, each row a layout of its own"
+)]
+fn a_request_create_refuses_writes_nothing_and_names_why() {
+    type Plant = fn(&Path) -> (CreateRequest, Vec<String>);
+    type Left = fn(&Path);
+    #[cfg_attr(not(unix), allow(unused_mut))]
+    let mut rows: Vec<(&str, Plant, Left)> = vec![
+        (
+            "a last component that is not a name",
+            |root| {
+                let work = root.join("work");
+                fs::create_dir_all(work.join("sub")).unwrap();
+                fs::write(work.join("keep.txt"), "somebody's file").unwrap();
+                fs::write(work.join("sub/also.txt"), "and another").unwrap();
+                (
+                    request(&work.join("nope/.."), License::Mit),
+                    vec!["not a creatable folder path".to_owned()],
+                )
+            },
+            |root| {
+                let work = root.join("work");
+                assert_eq!(
+                    fs::read_to_string(work.join("keep.txt")).unwrap(),
+                    "somebody's file"
+                );
+                assert_eq!(
+                    fs::read_to_string(work.join("sub/also.txt")).unwrap(),
+                    "and another"
+                );
+                assert!(
+                    !work.join("kendex.toml").exists(),
+                    "something was scaffolded"
+                );
+            },
+        ),
+        (
+            "a containing folder that does not exist",
+            |root| {
+                let work = root.join("work");
+                fs::create_dir_all(&work).unwrap();
+                (
+                    request(&work.join("absent/made"), License::Mit),
+                    vec![
+                        "is not a folder that exists".to_owned(),
+                        work.join("absent").display().to_string(),
+                    ],
+                )
+            },
+            |root| {
+                assert!(
+                    !root.join("work/absent").exists(),
+                    "part of the chain was brought into being"
+                );
+            },
+        ),
+        (
+            "a name no harness accepts",
+            |root| {
+                let mut bad = request(&root.join("bad"), License::NoneYet);
+                bad.name = "My Marketplace!".to_owned();
+                (
+                    bad,
+                    vec!["'My Marketplace!' cannot name a marketplace".to_owned()],
+                )
+            },
+            |root| {
+                assert!(
+                    !root.join("bad").exists(),
+                    "a refused create wrote its folder"
+                )
+            },
+        ),
+    ];
+    #[cfg(unix)]
+    rows.extend([
+        (
+            "a dangling link, spelled `made`",
+            (|root| dangling(root, "made")) as Plant,
+            (|root| {
+                assert!(
+                    root.join("made").is_symlink(),
+                    "the link somebody made is gone"
+                )
+            }) as Left,
+        ),
+        (
+            "a dangling link, spelled `made/`",
+            |root| dangling(root, "made/"),
+            |root| {
+                assert!(
+                    root.join("made").is_symlink(),
+                    "the link somebody made is gone"
+                )
+            },
+        ),
+        (
+            "a dangling link, spelled `made/.`",
+            |root| dangling(root, "made/."),
+            |root| {
+                assert!(
+                    root.join("made").is_symlink(),
+                    "the link somebody made is gone"
+                )
+            },
+        ),
+    ]);
+    for (what, plant, left) in rows {
+        let (tmp, env) = fake();
+        let (asked, clauses) = plant(tmp.path());
 
-    let refused = author::create(&env, &request(&work.join("nope/.."), License::Mit)).unwrap_err();
-    assert!(
-        refused.to_string().contains("not a creatable folder path"),
-        "{refused}"
-    );
-    assert_eq!(
-        fs::read_to_string(work.join("keep.txt")).unwrap(),
-        "somebody's file"
-    );
-    assert_eq!(
-        fs::read_to_string(work.join("sub/also.txt")).unwrap(),
-        "and another"
-    );
-    assert!(!work.join("kendex.toml").exists(), "nothing was scaffolded");
-    assert!(
-        author::list(&env).unwrap().is_empty(),
-        "nothing was registered"
-    );
+        let refused = author::create(&env, &asked).unwrap_err();
+
+        let kendex_core::error::CoreError::Authoring { message } = &refused else {
+            panic!("{what}: {refused:?}");
+        };
+        for clause in &clauses {
+            assert!(
+                message.contains(clause),
+                "{what}: {clause:?} missing from {message:?}"
+            );
+        }
+        left(tmp.path());
+        assert!(
+            author::list(&env).unwrap().is_empty(),
+            "{what}: something was registered"
+        );
+    }
 }
 
-/// A folder is made inside one that is already there, and a containing
-/// folder that is not gets a refusal naming it rather than being brought
-/// into being. `CreateRequest.dir` requires its parent to exist.
-#[test]
+/// A link whose target is gone, at the destination, asked for under one
+/// spelling; the refusal reads as an existing folder.
+#[cfg(unix)]
 #[allow(clippy::unwrap_used)]
-fn a_containing_folder_that_does_not_exist_refuses_and_makes_nothing() {
-    let (tmp, env) = fake();
-    let work = tmp.path().join("work");
-    fs::create_dir_all(&work).unwrap();
-
-    let refused = author::create(&env, &request(&work.join("absent/made"), License::Mit))
-        .unwrap_err()
-        .to_string();
-
-    assert!(refused.contains("is not a folder that exists"), "{refused}");
-    assert!(
-        refused.contains(&work.join("absent").display().to_string()),
-        "the refusal names the folder that is missing: {refused}"
-    );
-    assert!(
-        !work.join("absent").exists(),
-        "no part of the chain was brought into being"
-    );
-    assert!(
-        author::list(&env).unwrap().is_empty(),
-        "nothing was registered"
-    );
+fn dangling(root: &Path, spelling: &str) -> (CreateRequest, Vec<String>) {
+    let link = root.join("made");
+    std::os::unix::fs::symlink(root.join("nowhere-at-all"), &link).unwrap();
+    (
+        request(&root.join(spelling), License::Mit),
+        vec!["already exists".to_owned()],
+    )
 }
 
 /// A parent that exists and cannot be traversed is not an absent one.
@@ -330,40 +431,6 @@ fn a_parent_that_cannot_be_reached_is_not_reported_as_missing() {
         refused.contains(&locked.join("inner").display().to_string()),
         "the refusal names the parent it could not reach: {refused}"
     );
-}
-
-/// A link whose target is gone answers `exists` with false, and the
-/// failure path's `remove_dir_all` deletes the link itself.
-///
-/// Asked of the three spellings that reach one place, because they do not
-/// all resolve alike: `made` stops at the link, while `made/` and
-/// `made/.` send the kernel through it and answer NotFound. A guard on
-/// the caller's spelling passes for the last two while the build and the
-/// removal work on the place all three name.
-#[cfg(unix)]
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_dangling_link_at_the_destination_refuses_in_every_spelling() {
-    for spelling in ["made", "made/", "made/."] {
-        let (tmp, env) = fake();
-        let link = tmp.path().join("made");
-        std::os::unix::fs::symlink(tmp.path().join("nowhere-at-all"), &link).unwrap();
-
-        let asked = tmp.path().join(spelling);
-        let refused = author::create(&env, &request(&asked, License::Mit)).unwrap_err();
-        assert!(
-            refused.to_string().contains("already exists"),
-            "{spelling}: {refused}"
-        );
-        assert!(
-            link.is_symlink(),
-            "{spelling}: the link somebody made is still there"
-        );
-        assert!(
-            author::list(&env).unwrap().is_empty(),
-            "{spelling}: nothing was registered"
-        );
-    }
 }
 
 /// A registry that refuses after the build takes the folder back, and
@@ -432,17 +499,6 @@ fn a_registry_refusal_after_the_build_removes_only_the_folder_it_made() {
     );
     assert!(work.join("sub").is_dir(), "nothing else was removed");
     assert!(other.is_dir(), "and nothing of anybody else's");
-}
-
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_name_no_harness_accepts_refuses_before_any_write() {
-    let (tmp, env) = fake();
-    let dir = tmp.path().join("bad");
-    let mut bad = request(&dir, License::NoneYet);
-    bad.name = "My Marketplace!".to_owned();
-    assert!(author::create(&env, &bad).is_err());
-    assert!(!dir.exists(), "a refused create must write nothing");
 }
 
 struct NoNetwork;

--- a/crates/core/tests/credential_store_refusals.rs
+++ b/crates/core/tests/credential_store_refusals.rs
@@ -91,70 +91,73 @@ fn stored() -> SignIn {
     }
 }
 
-#[track_caller]
-fn names_the_store(error: &CoreError, cause: &str) {
-    assert!(
-        matches!(error, CoreError::CredentialStoreUnavailable { .. }),
-        "a keychain refusal is not a registry outage: {error:?}"
-    );
-    let shown = error.to_string();
-    assert!(
-        !shown.contains("community directory"),
-        "the user is sent to check a working network: {shown}"
-    );
-    assert!(
-        shown.contains(cause),
-        "the call that refused is unnamed: {shown}"
-    );
-    assert!(
-        shown.contains("the keyring is locked"),
-        "the reason the OS gave is dropped: {shown}"
-    );
-}
-
+/// Every call the store makes, refused, one row per call and per place
+/// the keychain refuses: with no keychain at all (refusing before an entry
+/// exists, the only way to reach `entry()`'s refusal) every call is the
+/// store's own outage, and with an entry built each call names itself.
 #[test]
-fn no_keychain_at_all_refuses_every_call_as_the_store() {
-    let _held = held();
-    install(true);
+fn every_refused_call_names_the_store_and_the_call() {
+    type Call = fn() -> CoreError;
+    let rows: [(&str, bool, Call, &str); 6] = [
+        (
+            "save, no keychain",
+            true,
+            || KeyringStore.save(&stored()).expect_err("save refuses"),
+            "no keychain answered",
+        ),
+        (
+            "load, no keychain",
+            true,
+            || KeyringStore.load().expect_err("load refuses"),
+            "no keychain answered",
+        ),
+        (
+            "clear, no keychain",
+            true,
+            || KeyringStore.clear().expect_err("clear refuses"),
+            "no keychain answered",
+        ),
+        (
+            "save refused",
+            false,
+            || KeyringStore.save(&stored()).expect_err("save refuses"),
+            "the sign-in was refused",
+        ),
+        (
+            "load refused",
+            false,
+            || KeyringStore.load().expect_err("load refuses"),
+            "the stored sign-in could not be read",
+        ),
+        (
+            "clear refused",
+            false,
+            || KeyringStore.clear().expect_err("clear refuses"),
+            "the removal was refused",
+        ),
+    ];
+    for (what, at_build, call, cause) in rows {
+        let _held = held();
+        install(at_build);
 
-    for error in [
-        KeyringStore.save(&stored()).expect_err("save refuses"),
-        KeyringStore.load().expect_err("load refuses"),
-        KeyringStore.clear().expect_err("clear refuses"),
-    ] {
-        names_the_store(&error, "no keychain answered");
+        let error = call();
+
+        assert!(
+            matches!(error, CoreError::CredentialStoreUnavailable { .. }),
+            "{what}: a keychain refusal is not a registry outage: {error:?}"
+        );
+        let shown = error.to_string();
+        assert!(
+            !shown.contains("community directory"),
+            "{what}: the user is sent to check a working network: {shown}"
+        );
+        assert!(
+            shown.contains(cause),
+            "{what}: the call that refused is unnamed: {shown}"
+        );
+        assert!(
+            shown.contains("the keyring is locked"),
+            "{what}: the reason the OS gave is dropped: {shown}"
+        );
     }
-}
-
-#[test]
-fn a_refused_write_names_the_store() {
-    let _held = held();
-    install(false);
-
-    names_the_store(
-        &KeyringStore.save(&stored()).expect_err("save refuses"),
-        "the sign-in was refused",
-    );
-}
-
-#[test]
-fn a_refused_read_names_the_store() {
-    let _held = held();
-    install(false);
-
-    names_the_store(
-        &KeyringStore.load().expect_err("load refuses"),
-        "the stored sign-in could not be read",
-    );
-}
-
-#[test]
-fn a_refused_removal_names_the_store() {
-    let _held = held();
-    install(false);
-
-    names_the_store(
-        &KeyringStore.clear().expect_err("clear refuses"),
-        "the removal was refused",
-    );
 }

--- a/crates/core/tests/credential_transactions.rs
+++ b/crates/core/tests/credential_transactions.rs
@@ -254,14 +254,12 @@ fn two_rejected_concurrent_tokens_end_the_bounded_retry() {
         refresh_calls: AtomicUsize::new(0),
     };
 
-    let refused = submit(&fetch, store.as_ref(), "jane/skills")
-        .unwrap_err()
-        .to_string();
-
+    let error = submit(&fetch, store.as_ref(), "jane/skills").unwrap_err();
     assert!(
-        refused.contains("server does not accept this sign-in"),
-        "{refused}"
+        matches!(error, CoreError::SignInExpired { .. }),
+        "the server's refusal must reach the caller as the expired sign-in: {error:?}"
     );
+
     assert_eq!(
         fetch.bearers.lock().unwrap().as_slice(),
         ["kxa_old", "kxa_newer-one", "kxa_newer-two"]
@@ -327,17 +325,14 @@ fn a_rotation_the_server_still_rejects_clears_the_sign_in() {
         logout_on_rotated: false,
     };
 
-    let refused = submit(&fetch, store.as_ref(), "jane/skills")
-        .unwrap_err()
-        .to_string();
+    let error = submit(&fetch, store.as_ref(), "jane/skills").unwrap_err();
+    let CoreError::SignInExpired { why: refused } = &error else {
+        panic!("the server's refusal must reach the caller as the expired sign-in: {error:?}");
+    };
 
     assert!(
-        refused.contains("server does not accept this sign-in"),
-        "{refused}"
-    );
-    assert!(
-        refused.contains("— run `kendex login` again"),
-        "with the credential gone, signing in again is what works: {refused}"
+        !refused.contains("could not be removed"),
+        "with the credential gone, the remedy is the plain one: {refused}"
     );
     assert!(
         store.load().unwrap().is_none(),
@@ -354,14 +349,11 @@ fn a_logout_landing_after_rotation_still_answers_expired() {
         logout_on_rotated: true,
     };
 
-    let refused = submit(&fetch, store.as_ref(), "jane/skills")
-        .unwrap_err()
-        .to_string();
+    let error = submit(&fetch, store.as_ref(), "jane/skills").unwrap_err();
+    let CoreError::SignInExpired { why: refused } = &error else {
+        panic!("the server's refusal must reach the caller as the expired sign-in: {error:?}");
+    };
 
-    assert!(
-        refused.contains("server does not accept this sign-in"),
-        "{refused}"
-    );
     assert!(
         !refused.contains("could not be removed"),
         "nothing was left to remove: {refused}"
@@ -380,14 +372,11 @@ fn a_store_that_will_not_open_still_answers_expired() {
         logout_on_rotated: false,
     };
 
-    let refused = submit(&fetch, store.as_ref(), "jane/skills")
-        .unwrap_err()
-        .to_string();
+    let error = submit(&fetch, store.as_ref(), "jane/skills").unwrap_err();
+    let CoreError::SignInExpired { why: refused } = &error else {
+        panic!("the server's refusal must reach the caller as the expired sign-in: {error:?}");
+    };
 
-    assert!(
-        refused.contains("server does not accept this sign-in"),
-        "a store failure must not stand in for the server's refusal: {refused}"
-    );
     assert!(
         refused.contains("the local copy could not be removed: credential refresh is busy"),
         "the user learns the sign-in is dead and still installed: {refused}"
@@ -404,14 +393,11 @@ fn a_store_that_will_not_delete_still_answers_expired() {
         logout_on_rotated: false,
     };
 
-    let refused = submit(&fetch, store.as_ref(), "jane/skills")
-        .unwrap_err()
-        .to_string();
+    let error = submit(&fetch, store.as_ref(), "jane/skills").unwrap_err();
+    let CoreError::SignInExpired { why: refused } = &error else {
+        panic!("the server's refusal must reach the caller as the expired sign-in: {error:?}");
+    };
 
-    assert!(
-        refused.contains("server does not accept this sign-in"),
-        "a delete failure must not stand in for the server's refusal: {refused}"
-    );
     assert!(
         refused.contains("the local copy could not be removed"),
         "the user learns the credential is still installed: {refused}"

--- a/crates/core/tests/dependencies/main.rs
+++ b/crates/core/tests/dependencies/main.rs
@@ -323,80 +323,55 @@ fn a_skill_that_requires_itself_is_named() {
     );
 }
 
-/// A dependency filtered to no tool installs nothing, so the note that
-/// says it co-installs is not made: the missing-dependency finding beside
-/// it is what that arrangement actually produces.
+/// "Also installs" is a claim about every tool, and a reference that lands
+/// on no tool, or not on every tool, makes none, one row per pair of
+/// harness lists. A dependency filtered to no tool installs nothing, so
+/// the note is not made and the missing-dependency finding beside it is
+/// what that arrangement actually produces; both edges installing but the
+/// requested item running on a tool its partner does not carries the cycle
+/// in the graph and still claims nothing, since the claim would be false
+/// for one tool, and that tool's missing dependency is reported; and two
+/// declarations no tool holds install nothing, not
+/// even the vacuous co-install a cycle over them would otherwise produce.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn a_cycle_split_across_tools_claims_no_co_install() {
-    let f = fixture(
-        "[skills.dev]\nsource = \"cat\"\nharnesses = [\"claude\"]\n\n[skills.github]\nsource = \"cat\"\nharnesses = [\"codex\"]\n",
-    );
-    skill(&f.source, "github", "dependencies:\n  required: [dev]\n");
+fn a_reference_that_does_not_reach_every_tool_claims_no_co_install() {
+    let rows: [(&str, &str, &str, bool); 3] = [
+        ("split across tools", "[\"claude\"]", "[\"codex\"]", true),
+        (
+            "reaching only some tools",
+            "[\"claude\", \"codex\"]",
+            "[\"claude\"]",
+            true,
+        ),
+        ("no tool holds either", "[]", "[]", false),
+    ];
+    for (what, dev, github, missing) in rows {
+        let f = fixture(&format!(
+            "[skills.dev]\nsource = \"cat\"\nharnesses = {dev}\n\n[skills.github]\nsource = \"cat\"\nharnesses = {github}\n"
+        ));
+        skill(&f.source, "github", "dependencies:\n  required: [dev]\n");
 
-    let report = audit(&f.env, &f.scope).unwrap();
-    assert!(
-        !report
-            .notes
-            .iter()
-            .any(|note| note.contains("also installs")),
-        "neither declaration installs the other: {:?}",
-        report.notes
-    );
-    assert!(
-        report
-            .warnings
-            .iter()
-            .any(|w| w.message.contains("missing required dependency")),
-        "and the arrangement is still reported: {:?}",
-        report.warnings
-    );
-}
+        let report = audit(&f.env, &f.scope).unwrap();
 
-/// The reaches guard on its own: both edges install, so the graph carries
-/// the cycle, but the requested item runs on a tool its partner does not.
-/// "Also installs" is a claim about every tool, and here it is false for
-/// one of them.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_cycle_reaching_only_some_tools_claims_no_co_install() {
-    let f = fixture(
-        "[skills.dev]\nsource = \"cat\"\nharnesses = [\"claude\", \"codex\"]\n\n[skills.github]\nsource = \"cat\"\nharnesses = [\"claude\"]\n",
-    );
-    skill(&f.source, "github", "dependencies:\n  required: [dev]\n");
-
-    let report = audit(&f.env, &f.scope).unwrap();
-    assert!(
-        !report
-            .notes
-            .iter()
-            .any(|note| note.contains("also installs")),
-        "codex runs dev without github: {:?}",
-        report.notes
-    );
-}
-
-/// The zero-harness guard on its own: neither declaration lands anywhere,
-/// so every reference between them installs nothing and there is no
-/// co-install to report — not even the vacuous one a cycle over two
-/// tool-less declarations would otherwise produce.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn references_between_declarations_no_tool_holds_claim_no_co_install() {
-    let f = fixture(
-        "[skills.dev]\nsource = \"cat\"\nharnesses = []\n\n[skills.github]\nsource = \"cat\"\nharnesses = []\n",
-    );
-    skill(&f.source, "github", "dependencies:\n  required: [dev]\n");
-
-    let report = audit(&f.env, &f.scope).unwrap();
-    assert!(
-        !report
-            .notes
-            .iter()
-            .any(|note| note.contains("also installs")),
-        "a reference that installs nothing was reported as a co-install: {:?}",
-        report.notes
-    );
+        assert!(
+            !report
+                .notes
+                .iter()
+                .any(|note| note.contains("also installs")),
+            "{what}: a reference that does not install everywhere was reported as a co-install: {:?}",
+            report.notes
+        );
+        assert_eq!(
+            report
+                .warnings
+                .iter()
+                .any(|w| w.message.contains("missing required dependency")),
+            missing,
+            "{what}: {:?}",
+            report.warnings
+        );
+    }
 }
 
 mod more;

--- a/crates/core/tests/drift_check.rs
+++ b/crates/core/tests/drift_check.rs
@@ -122,80 +122,89 @@ fn row<'a>(rows: &'a [updates::UpdateRow], name: &str) -> &'a updates::UpdateRow
         .unwrap_or_else(|| panic!("no row for {name}: {rows:?}"))
 }
 
+/// A commit pin is a hold on everything it reaches, one row per route: a
+/// source-level pin holds every package the source carries; a pinned
+/// bundle holds its members; a pinned parent holds its dependencies. Each
+/// row: what the upstream holds, the source's extra lines, the declaration
+/// (both given the first commit), and the package the report must hold.
+/// The control follows the first row: a tracking selector is not a pin, so
+/// the same declaration on a branch name follows and must not read as held.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn a_package_from_a_commit_pinned_source_reports_held() {
+fn a_commit_pin_holds_every_package_it_reaches() {
+    type Upstream = fn(&Path);
+    type Declare = fn(&str) -> (String, String);
+    let rows: [(&str, Upstream, Declare, &str); 3] = [
+        (
+            "a source-level pin",
+            |upstream| write_skill(upstream, "gh", "One."),
+            |first| {
+                (
+                    format!("rev = \"{first}\"\n"),
+                    "[skills.gh]\nsource = \"cat\"\n".to_owned(),
+                )
+            },
+            "gh",
+        ),
+        (
+            "a pinned bundle",
+            |upstream| {
+                write_skill(upstream, "member", "One.");
+                fs::write(
+                    upstream.join("kendex.toml"),
+                    "[bundles.kit]\ndescription = \"a set\"\nskills = [\"member\"]\n",
+                )
+                .unwrap();
+            },
+            |first| {
+                (
+                    String::new(),
+                    format!("[bundles.kit]\nsource = \"cat\"\nrev = \"{first}\"\n"),
+                )
+            },
+            "member",
+        ),
+        (
+            "a pinned parent",
+            |upstream| {
+                write_skill(upstream, "dep", "Dep.");
+                write_skill_with(
+                    upstream,
+                    "parent",
+                    "Parent.",
+                    "dependencies:\n  required: [dep]\n",
+                );
+            },
+            |first| {
+                (
+                    String::new(),
+                    format!("[skills.parent]\nsource = \"cat\"\nrev = \"{first}\"\n"),
+                )
+            },
+            "dep",
+        ),
+    ];
+    for (what, upstream, declaration, held) in rows {
+        let w = world();
+        upstream(&w.upstream);
+        let first = commit(&w.upstream, "one");
+        let (source_extra, declared) = declaration(&first);
+        declare(&w, &source_extra, &declared);
+        sync_and_apply(&w);
+
+        let report = updates::updates(&w.env, &w.scope).unwrap();
+        assert!(row(&report.rows, held).pinned, "{what}: {report:?}");
+    }
+
     let w = world();
     write_skill(&w.upstream, "gh", "One.");
-    let first = commit(&w.upstream, "one");
-    declare(
-        &w,
-        &format!("rev = \"{first}\"\n"),
-        "[skills.gh]\nsource = \"cat\"\n",
-    );
-    sync_and_apply(&w);
-
-    let report = updates::updates(&w.env, &w.scope).unwrap();
-    assert!(
-        row(&report.rows, "gh").pinned,
-        "a source-level pin is a hold on everything it carries"
-    );
-
-    // A tracking selector is not a pin: the same declaration on a branch
-    // name follows, and must not read as held.
+    commit(&w.upstream, "one");
     declare(&w, "rev = \"main\"\n", "[skills.gh]\nsource = \"cat\"\n");
-    let report = updates::updates(&w.env, &w.scope).unwrap();
-    assert!(!row(&report.rows, "gh").pinned);
-}
-
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_pin_reaching_a_member_through_a_bundle_reports_held() {
-    let w = world();
-    write_skill(&w.upstream, "member", "One.");
-    fs::write(
-        w.upstream.join("kendex.toml"),
-        "[bundles.kit]\ndescription = \"a set\"\nskills = [\"member\"]\n",
-    )
-    .unwrap();
-    let first = commit(&w.upstream, "one");
-    declare(
-        &w,
-        "",
-        &format!("[bundles.kit]\nsource = \"cat\"\nrev = \"{first}\"\n"),
-    );
     sync_and_apply(&w);
-
     let report = updates::updates(&w.env, &w.scope).unwrap();
     assert!(
-        row(&report.rows, "member").pinned,
-        "a pinned bundle holds its members: {report:?}"
-    );
-}
-
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_pin_reaching_a_dependency_through_its_parent_reports_held() {
-    let w = world();
-    write_skill(&w.upstream, "dep", "Dep.");
-    write_skill_with(
-        &w.upstream,
-        "parent",
-        "Parent.",
-        "dependencies:\n  required: [dep]\n",
-    );
-    let first = commit(&w.upstream, "one");
-    declare(
-        &w,
-        "",
-        &format!("[skills.parent]\nsource = \"cat\"\nrev = \"{first}\"\n"),
-    );
-    sync_and_apply(&w);
-
-    let report = updates::updates(&w.env, &w.scope).unwrap();
-    assert!(
-        row(&report.rows, "dep").pinned,
-        "a pinned parent holds its dependencies: {report:?}"
+        !row(&report.rows, "gh").pinned,
+        "a tracking selector is not a pin: {report:?}"
     );
 }
 

--- a/crates/core/tests/edits_and_forks/agent_settings.rs
+++ b/crates/core/tests/edits_and_forks/agent_settings.rs
@@ -10,107 +10,212 @@ use kendex_core::error::CoreError;
 
 use super::*;
 
-/// A person who tightens a generated file by hand states something the
-/// local source has no key for and the manifest is not being written from.
-/// Forking anyway would hand them back the tools they took away, so the
-/// fork refuses and writes nothing.
+/// A hand edit the fork cannot carry refuses before writing anything, one
+/// row per edit, the refusal's own `problem` naming what it stopped on. A
+/// person who tightens a generated file by hand states something the local
+/// source has no key for and the manifest is not being written from, so
+/// forking would hand back the tools they took away: a widened deny list;
+/// an allowlist written into a file that stated none (what the fork would
+/// give back is every tool outside it, so the refusal names the allowlist);
+/// frontmatter that will not parse, which is not a file stating nothing
+/// (what the person took away cannot be read, so it cannot be proven
+/// carried either), whether a key stated twice or a block that opens and
+/// never ends; a deleted colour (an override states what a value is and
+/// never that there is none); a Pi allowlist override the renderer cannot
+/// express, which the updates report already marks unforkable; a hook
+/// written into the file (no override table holds one, a hook being a
+/// custom-hooks entry with a selector rather than a field); and the same
+/// hook moved to gate the call before it runs, since a hook is its scope as
+/// well as its command and a reading that compares commands alone would
+/// let the fork restore the looser gate. Afterwards nothing is captured and
+/// the manifest records no fork.
 #[test]
-#[allow(clippy::unwrap_used)]
-fn a_hand_tightened_deny_refuses_the_fork_and_writes_nothing() {
-    let w = agent_world(
-        "\"claude\"",
-        "---\nname: rev\ndescription: agent rev\n---\nUpstream body.\n",
-        "",
-        "",
+#[allow(clippy::unwrap_used, clippy::too_many_lines)]
+fn a_hand_edit_the_fork_cannot_carry_refuses_and_names_it() {
+    type Edit = fn(&World, &std::path::Path);
+    type Row = (
+        &'static str,
+        &'static str,
+        HarnessId,
+        &'static str,
+        &'static str,
+        Edit,
+        &'static [&'static str],
     );
-    let file = rendered(&w, HarnessId::Claude, "rev");
-    let text = fs::read_to_string(&file).unwrap();
-    fs::write(
-        &file,
-        text.replace(
-            "disallowedTools: Agent, AskUserQuestion",
-            "disallowedTools: Agent, AskUserQuestion, Bash, WebFetch",
+    let rows: [Row; 8] = [
+        (
+            "a hand-tightened deny list",
+            "---\nname: rev\ndescription: agent rev\n---\nUpstream body.\n",
+            HarnessId::Claude,
+            "",
+            "",
+            |_, file| {
+                edit_line(
+                    file,
+                    "disallowedTools: Agent, AskUserQuestion",
+                    "disallowedTools: Agent, AskUserQuestion, Bash, WebFetch",
+                );
+            },
+            &["Bash", "WebFetch"],
         ),
-    )
-    .unwrap();
-
-    let refused =
-        fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Claude).unwrap_err();
-    let said = refused.to_string();
-    assert!(
-        matches!(refused, CoreError::ForkWidensAccess { .. }),
-        "{refused:?}"
-    );
-    assert!(
-        said.contains("Bash") && said.contains("WebFetch") && said.contains("nothing was written"),
-        "the refusal names what it stopped on: {said}"
-    );
-    assert!(!captured(&w, "rev").exists(), "nothing was written");
-    assert!(!manifest_text(&w).contains("[forks.agent.rev]"));
-}
-
-/// The same refusal from the other direction: a hand-written allowlist
-/// to a file that stated none. What the fork would give back is every
-/// tool outside it, so the refusal names the allowlist instead.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_hand_added_allowlist_refuses_the_fork() {
-    let w = agent_world(
-        "\"claude\"",
-        "---\nname: rev\ndescription: agent rev\n---\nUpstream body.\n",
-        "",
-        "",
-    );
-    let file = rendered(&w, HarnessId::Claude, "rev");
-    let text = fs::read_to_string(&file).unwrap();
-    fs::write(
-        &file,
-        text.replace("disallowedTools:", "tools: Read, Grep\ndisallowedTools:"),
-    )
-    .unwrap();
-
-    let refused =
-        fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Claude).unwrap_err();
-    let said = refused.to_string();
-    assert!(
-        matches!(refused, CoreError::ForkWidensAccess { .. }),
-        "{refused:?}"
-    );
-    assert!(said.contains("Read, Grep"), "{said}");
-    assert!(!captured(&w, "rev").exists(), "nothing was written");
-}
-
-/// Frontmatter that will not parse is not the same answer as frontmatter
-/// stating nothing. What the person took away cannot be read, so it cannot
-/// be proven carried either, and the fork refuses rather than guess.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn an_unreadable_frontmatter_refuses_the_fork() {
-    let w = agent_world(
-        "\"claude\"",
-        "---\nname: rev\ndescription: agent rev\n---\nUpstream body.\n",
-        "",
-        "",
-    );
-    let file = rendered(&w, HarnessId::Claude, "rev");
-    let text = fs::read_to_string(&file).unwrap();
-    fs::write(
-        &file,
-        text.replace(
-            "disallowedTools:",
-            "tools: Read\ntools: Grep\ndisallowedTools:",
+        (
+            "a hand-added allowlist",
+            "---\nname: rev\ndescription: agent rev\n---\nUpstream body.\n",
+            HarnessId::Claude,
+            "",
+            "",
+            |_, file| {
+                edit_line(
+                    file,
+                    "disallowedTools:",
+                    "tools: Read, Grep\ndisallowedTools:",
+                )
+            },
+            &["Read, Grep"],
         ),
-    )
-    .unwrap();
+        (
+            "a key stated twice",
+            "---\nname: rev\ndescription: agent rev\n---\nUpstream body.\n",
+            HarnessId::Claude,
+            "",
+            "",
+            |_, file| {
+                edit_line(
+                    file,
+                    "disallowedTools:",
+                    "tools: Read\ntools: Grep\ndisallowedTools:",
+                );
+            },
+            &["cannot be read"],
+        ),
+        (
+            "a deleted colour",
+            "---\nname: rev\ndescription: agent rev\ncolor: blue\n---\nUpstream body.\n",
+            HarnessId::Claude,
+            "",
+            "",
+            |_, file| {
+                let rendering = fs::read_to_string(file).unwrap();
+                assert!(rendering.contains("color: blue"), "{rendering}");
+                let without: String = rendering
+                    .lines()
+                    .filter(|line| !line.starts_with("color:"))
+                    .map(|line| format!("{line}\n"))
+                    .collect();
+                fs::write(file, without).unwrap();
+            },
+            &["deleted", "color"],
+        ),
+        (
+            "a Pi allowlist the renderer cannot express",
+            "---\nname: rev\ndescription: agent rev\n---\nUpstream body.\n",
+            HarnessId::Pi,
+            "",
+            "",
+            |w, file| {
+                edit_line(file, "deny-tools:", "deny-tools: Bash,");
+                let manifest = format!(
+                    "{}\n[agent-frontmatter.pi]\nrev = {{ allow-tools = [\"Read\"] }}\n",
+                    manifest_text(w)
+                );
+                fs::write(manifest::manifest_path(&w.env, &w.scope), manifest).unwrap();
+                let report = kendex_core::package::updates::updates(&w.env, &w.scope).unwrap();
+                let row = report
+                    .rows
+                    .iter()
+                    .find(|row| row.kind == ItemKind::Agent && row.name == "rev")
+                    .unwrap();
+                assert_eq!(row.forkable_harness, None, "{row:?}");
+            },
+            &["the access settings its Pi renderer rejected: Pi cannot express a tool allowlist"],
+        ),
+        (
+            "a hand-written hook",
+            "---\nname: rev\ndescription: agent rev\n---\nUpstream body.\n",
+            HarnessId::Claude,
+            "",
+            "",
+            |_, file| {
+                edit_line(
+                    file,
+                    "disallowedTools:",
+                    "hooks:\n  PreToolUse:\n    \"Bash\":\n      - type: command\n        command: \"./guard.sh\"\ndisallowedTools:",
+                );
+            },
+            &["./guard.sh"],
+        ),
+        (
+            "a hook moved to a tighter event",
+            "---\nname: rev\ndescription: agent rev\n---\nUpstream body.\n",
+            HarnessId::Claude,
+            "",
+            "[[custom-hooks]]\nevent = \"PostToolUse\"\nmatcher = \"Bash\"\ncommand = \"./guard.sh\"\nagents = \"rev\"\n",
+            |_, file| {
+                // The same command, moved to gate the call before it runs
+                // instead of reporting on it afterwards.
+                edit_line(file, "PostToolUse:", "PreToolUse:");
+            },
+            &["PreToolUse", "Bash", "./guard.sh"],
+        ),
+        (
+            "an unterminated frontmatter block",
+            "---\nname: rev\ndescription: agent rev\n---\nUpstream body.\n",
+            HarnessId::Claude,
+            "",
+            "[agent-frontmatter.claude]\nrev = { deny-tools = [\"Bash\"] }\n",
+            |_, file| {
+                let text = fs::read_to_string(file).unwrap();
+                assert!(
+                    deny_line(&text, "disallowedTools:").contains("Bash"),
+                    "the block the edit leaves unterminated is the one stating the denies: {text}"
+                );
+                assert_eq!(
+                    times(&text, "---"),
+                    2,
+                    "the rendering opens and closes exactly one block: {text}"
+                );
+                let mut lines: Vec<&str> = text.lines().collect();
+                let closer = lines.iter().rposition(|line| line.trim() == "---").unwrap();
+                lines.remove(closer);
+                fs::write(
+                    file,
+                    lines
+                        .iter()
+                        .map(|line| format!("{line}\n"))
+                        .collect::<String>(),
+                )
+                .unwrap();
+            },
+            &["unterminated frontmatter"],
+        ),
+    ];
+    for (what, agent, harness, catalog, project, edit, names) in rows {
+        let harnesses = format!("\"{}\"", harness.name());
+        let w = agent_world(&harnesses, agent, catalog, project);
+        let file = rendered(&w, harness, "rev");
+        edit(&w, &file);
 
-    let refused =
-        fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Claude).unwrap_err();
-    assert!(
-        matches!(refused, CoreError::ForkWidensAccess { .. }),
-        "{refused:?}"
-    );
-    assert!(refused.to_string().contains("cannot be read"), "{refused}");
-    assert!(!captured(&w, "rev").exists(), "nothing was written");
+        let refused = fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", harness).unwrap_err();
+
+        let CoreError::ForkWidensAccess { name, problem } = &refused else {
+            panic!("{what}: {refused:?}");
+        };
+        assert_eq!(name, "rev", "{what}");
+        for clause in names {
+            assert!(
+                problem.contains(clause),
+                "{what}: {clause:?} missing from {problem:?}"
+            );
+        }
+        assert!(
+            !captured(&w, "rev").exists(),
+            "{what}: something was written"
+        );
+        assert!(
+            !manifest_text(&w).contains("[forks.agent.rev]"),
+            "{what}: the manifest records a fork"
+        );
+    }
 }
 
 /// A person who changes a setting in the generated file changed something
@@ -156,12 +261,11 @@ fn a_settings_edit_rides_into_the_manifest_and_a_description_edit_does_not() {
 
 /// Deleting a rendered key is an edit in the restrictive direction, and
 /// the fork must not answer it by putting the publisher's value back. An
-/// override states what a value is and never that there is none, so only
-/// an effort can be cleared; everything else refuses, naming what was
-/// deleted.
+/// effort can be cleared, since every renderer reads `none` as no effort
+/// (the keys nothing can clear are rows of the refusals table above).
 #[test]
 #[allow(clippy::unwrap_used)]
-fn a_deleted_setting_is_carried_where_it_can_be_and_refused_where_it_cannot() {
+fn a_deleted_effort_is_carried_as_cleared() {
     let w = agent_world(
         "\"claude\"",
         "---\nname: rev\ndescription: agent rev\nmodel: sonnet\neffort: high\ncolor: blue\n---\nUpstream body.\n",
@@ -187,33 +291,6 @@ fn a_deleted_setting_is_carried_where_it_can_be_and_refused_where_it_cannot() {
         !settled.lines().any(|line| line.starts_with("effort:")),
         "a cleared effort must not come back: {settled}"
     );
-
-    // A colour cannot: nothing in the override table says there is none.
-    let w = agent_world(
-        "\"claude\"",
-        "---\nname: rev\ndescription: agent rev\ncolor: blue\n---\nUpstream body.\n",
-        "",
-        "",
-    );
-    let file = rendered(&w, HarnessId::Claude, "rev");
-    let rendering = fs::read_to_string(&file).unwrap();
-    let without_color: String = rendering
-        .lines()
-        .filter(|line| !line.starts_with("color:"))
-        .map(|line| format!("{line}\n"))
-        .collect();
-    fs::write(&file, &without_color).unwrap();
-    let refused =
-        fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Claude).unwrap_err();
-    assert!(
-        matches!(refused, CoreError::ForkWidensAccess { .. }),
-        "{refused:?}"
-    );
-    assert!(
-        refused.to_string().contains("deleted") && refused.to_string().contains("color"),
-        "the refusal names the deleted setting: {refused}"
-    );
-    assert!(!captured(&w, "rev").exists(), "nothing was written");
 }
 
 /// Pi's allowed-subagents governs which child agents this one may invoke,
@@ -298,157 +375,6 @@ fn a_deleted_pi_delegation_list_survives_the_fork() {
         deny_line(&settled, "deny-tools:").contains("delegate_subagent"),
         "and the delegation tool goes with it: {settled}"
     );
-}
-
-/// A person can add a Pi allowlist override after tightening the installed file.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_pi_allowlist_that_cannot_render_refuses_the_fork() {
-    let w = agent_world(
-        "\"pi\"",
-        "---\nname: rev\ndescription: agent rev\n---\nUpstream body.\n",
-        "",
-        "",
-    );
-    let file = rendered(&w, HarnessId::Pi, "rev");
-    edit_line(&file, "deny-tools:", "deny-tools: Bash,");
-    let manifest = format!(
-        "{}\n[agent-frontmatter.pi]\nrev = {{ allow-tools = [\"Read\"] }}\n",
-        manifest_text(&w)
-    );
-    fs::write(manifest::manifest_path(&w.env, &w.scope), manifest).unwrap();
-    let report = kendex_core::package::updates::updates(&w.env, &w.scope).unwrap();
-    let row = report
-        .rows
-        .iter()
-        .find(|row| row.kind == ItemKind::Agent && row.name == "rev")
-        .unwrap();
-    assert_eq!(row.forkable_harness, None, "{row:?}");
-    let refused = fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Pi).unwrap_err();
-    assert!(refused.to_string().contains(
-        "the access settings its Pi renderer rejected: Pi cannot express a tool allowlist"
-    ));
-}
-
-/// A hook written into a Claude agent file gates tool use from inside that
-/// file. No override table holds one — a hook is a custom-hooks entry with
-/// a selector, not a field — so a hook the fork would not run again is a
-/// restriction it cannot carry, and it refuses.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_hand_written_hook_refuses_the_fork() {
-    let w = agent_world(
-        "\"claude\"",
-        "---\nname: rev\ndescription: agent rev\n---\nUpstream body.\n",
-        "",
-        "",
-    );
-    let file = rendered(&w, HarnessId::Claude, "rev");
-    let text = fs::read_to_string(&file).unwrap();
-    fs::write(
-        &file,
-        text.replace(
-            "disallowedTools:",
-            "hooks:\n  PreToolUse:\n    \"Bash\":\n      - type: command\n        command: \"./guard.sh\"\ndisallowedTools:",
-        ),
-    )
-    .unwrap();
-
-    let refused =
-        fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Claude).unwrap_err();
-    assert!(
-        matches!(refused, CoreError::ForkWidensAccess { .. }),
-        "{refused:?}"
-    );
-    assert!(
-        refused.to_string().contains("./guard.sh"),
-        "the refusal names the hook it stopped on: {refused}"
-    );
-    assert!(!captured(&w, "rev").exists(), "nothing was written");
-}
-
-/// A hook is its scope as well as its command. Tightening the scope by
-/// hand: the same command moved to a different event, or onto a broader
-/// matcher — leaves the command alone, so a reading that compares commands
-/// sees no difference and lets the fork restore the looser gate.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_hand_tightened_hook_scope_refuses_the_fork() {
-    let w = agent_world(
-        "\"claude\"",
-        "---\nname: rev\ndescription: agent rev\n---\nUpstream body.\n",
-        "",
-        "[[custom-hooks]]\nevent = \"PostToolUse\"\nmatcher = \"Bash\"\ncommand = \"./guard.sh\"\nagents = \"rev\"\n",
-    );
-    let file = rendered(&w, HarnessId::Claude, "rev");
-    let text = fs::read_to_string(&file).unwrap();
-    assert!(text.contains("PostToolUse:"), "{text}");
-    // The same command, moved to gate the call before it runs instead of
-    // reporting on it afterwards.
-    fs::write(&file, text.replace("PostToolUse:", "PreToolUse:")).unwrap();
-
-    let refused =
-        fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Claude).unwrap_err();
-    assert!(
-        matches!(refused, CoreError::ForkWidensAccess { .. }),
-        "{refused:?}"
-    );
-    let said = refused.to_string();
-    assert!(
-        said.contains("PreToolUse") && said.contains("Bash") && said.contains("./guard.sh"),
-        "the refusal names the gate whole, not just its command: {said}"
-    );
-    assert!(!captured(&w, "rev").exists(), "nothing was written");
-}
-
-/// The other reading `split` reports the same error for. A block that
-/// opens and never ends is frontmatter that will not read, not a file
-/// stating nothing: whatever the person restricted in it cannot be read
-/// back, so it cannot be proven carried either, and the fork refuses
-/// rather than proceed on an empty reading of a file full of denies.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn an_unterminated_frontmatter_refuses_the_fork() {
-    let w = agent_world(
-        "\"claude\"",
-        "---\nname: rev\ndescription: agent rev\n---\nUpstream body.\n",
-        "",
-        "[agent-frontmatter.claude]\nrev = { deny-tools = [\"Bash\"] }\n",
-    );
-    let file = rendered(&w, HarnessId::Claude, "rev");
-    let text = fs::read_to_string(&file).unwrap();
-    assert!(
-        deny_line(&text, "disallowedTools:").contains("Bash"),
-        "the block the edit leaves unterminated is the one stating the denies: {text}"
-    );
-    assert_eq!(
-        times(&text, "---"),
-        2,
-        "the rendering opens and closes exactly one block: {text}"
-    );
-    let mut lines: Vec<&str> = text.lines().collect();
-    let closer = lines.iter().rposition(|line| line.trim() == "---").unwrap();
-    lines.remove(closer);
-    fs::write(
-        &file,
-        lines
-            .iter()
-            .map(|line| format!("{line}\n"))
-            .collect::<String>(),
-    )
-    .unwrap();
-
-    let refused =
-        fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Claude).unwrap_err();
-    assert!(
-        matches!(refused, CoreError::ForkWidensAccess { .. }),
-        "{refused:?}"
-    );
-    assert!(
-        refused.to_string().contains("unterminated frontmatter"),
-        "the refusal names why the file could not be read: {refused}"
-    );
-    assert!(!captured(&w, "rev").exists(), "nothing was written");
 }
 
 /// The reading on the other side of that split, which stays a fork rather

--- a/crates/core/tests/edits_and_forks/forks.rs
+++ b/crates/core/tests/edits_and_forks/forks.rs
@@ -87,7 +87,12 @@ fn an_edited_install_deleted_after_planning_fails_the_fork() {
     let plan = fork::fork(&w.env, &w.scope, ItemKind::Skill, "gh", HarnessId::Claude).unwrap();
     fs::remove_dir_all(w.home.join("app/.agents/skills/gh")).unwrap();
 
-    assert!(apply::execute(&w.env, &plan).is_err());
+    let error = apply::execute(&w.env, &plan).unwrap_err();
+    assert!(
+        matches!(&error, CoreError::RolledBack { cause, .. }
+            if matches!(**cause, CoreError::PlanStale { .. })),
+        "{error:?}"
+    );
     assert!(
         !w.home.join("app/.kendex-local/skills/gh").exists(),
         "no fork made of bytes the disk no longer has"
@@ -381,9 +386,13 @@ fn forking_a_codex_agent_is_refused_with_the_fix_named() {
     let error =
         kendex_core::engine::fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Codex)
             .unwrap_err();
+    let CoreError::ItemNotInSource { name, source_name } = &error else {
+        panic!("{error:?}");
+    };
+    assert_eq!(name, "rev");
     assert!(
-        error.to_string().contains("Claude"),
-        "the refusal names the fix: {error}"
+        source_name.contains("fork the Claude copy instead"),
+        "the refusal names the fix: {source_name}"
     );
 }
 

--- a/crates/core/tests/install_into_project.rs
+++ b/crates/core/tests/install_into_project.rs
@@ -8,6 +8,7 @@ use std::process::Command;
 
 use kendex_core::engine::ops;
 use kendex_core::env::{Env, FakeOs};
+use kendex_core::error::CoreError;
 use kendex_core::model::Scope;
 use kendex_core::{apply, remote, source_ops};
 
@@ -86,7 +87,10 @@ fn installing_into_a_project_is_atomic_with_its_subscription() {
             ..ops::AddRequest::default()
         },
     );
-    assert!(refused.is_err(), "a missing package must be refused");
+    assert!(
+        matches!(&refused, Err(CoreError::ItemNotInSource { name, source_name }) if name == "nope" && source_name == "mkt"),
+        "a missing package must be refused: {refused:?}"
+    );
     assert!(
         !project_path.exists() || !fs::read_to_string(&project_path).unwrap().contains("mkt"),
         "the project must not be left subscribed to a marketplace it installed nothing from"

--- a/crates/core/tests/instruction_shims.rs
+++ b/crates/core/tests/instruction_shims.rs
@@ -17,6 +17,7 @@ use kendex_core::engine::{
     observe_instruction_shims, plan_apply,
 };
 use kendex_core::env::{Env, FakeOs};
+use kendex_core::error::CoreError;
 use kendex_core::model::{HarnessId, ItemKind, Scope};
 use kendex_core::process::Hardened;
 
@@ -288,7 +289,12 @@ fn a_hand_written_claude_file_is_a_conflict_the_take_over_settles() {
     // plan read, so the apply refuses rather than trashing an edit nobody
     // looked at (invariant 7).
     fs::write(&shim, "# edited since\n").unwrap();
-    assert!(apply::execute(&f.env, &taken.plan).is_err());
+    let error = apply::execute(&f.env, &taken.plan).unwrap_err();
+    assert!(
+        matches!(&error, CoreError::RolledBack { cause, .. }
+            if matches!(**cause, CoreError::PlanStale { .. })),
+        "{error:?}"
+    );
     assert_eq!(shim_bytes(&shim), "# edited since\n");
 
     let taken = take_over(&f);

--- a/crates/core/tests/marketplace_subscribe.rs
+++ b/crates/core/tests/marketplace_subscribe.rs
@@ -187,7 +187,10 @@ fn an_offline_tree_url_is_refused_before_any_write() {
         None,
     )
     .unwrap_err();
-    assert!(!error.to_string().is_empty());
+    assert!(
+        matches!(&error, CoreError::GitFailed { command, .. } if command.starts_with("git clone")),
+        "the clone is what refuses: {error:?}"
+    );
     assert_eq!(
         fs::read_to_string(project.join("kendex.toml")).unwrap(),
         existing,

--- a/crates/core/tests/me_client/main.rs
+++ b/crates/core/tests/me_client/main.rs
@@ -305,19 +305,38 @@ fn the_fixture_unlinked_body_reads_as_no_github_login() {
     }
 }
 
+/// A warm cache answers for a directory that could not settle an identity,
+/// one row per answer: the network away, the fixture's database-unavailable
+/// status, and a body that is not the directory's at all.
 #[test]
-fn network_away_serves_the_cached_identity_as_offline() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let env = env_in(dir.path());
-    let store = MemoryStore::signed_in();
-    let first = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
-    me::load(&env, &first, &store).expect("first load");
+fn a_directory_that_cannot_answer_serves_the_cached_identity_as_offline() {
+    type Answer = fn() -> Result<FetchResponse>;
+    let rows: [(&str, Answer); 3] = [
+        ("network away", away),
+        ("database unavailable", || {
+            ok(
+                fixture_status(&["errors", "database_unavailable", "status"]),
+                None,
+                &fixture_body(&["errors", "database_unavailable", "body"]),
+            )
+        }),
+        ("a malformed answer", || ok(200, None, "<!doctype html>")),
+    ];
+    for (what, answer) in rows {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let home = rooted(&dir);
+        let env = env_in(&home);
+        let store = MemoryStore::signed_in();
+        let first = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
+        me::load(&env, &first, &store).expect("first load");
 
-    let down = Canned::new(vec![away()]);
-    let state = me::load(&env, &down, &store).expect("offline load");
-    match state {
-        AccountState::Offline { identity, .. } => assert_eq!(identity.name, "Ada Lovelace"),
-        other => panic!("expected offline, got {other:?}"),
+        let then = Canned::new(vec![answer()]);
+        match me::load(&env, &then, &store).expect("offline load") {
+            AccountState::Offline { identity, .. } => {
+                assert_eq!(identity.name, "Ada Lovelace", "{what}");
+            }
+            other => panic!("{what}: expected offline, got {other:?}"),
+        }
     }
 }
 
@@ -502,26 +521,11 @@ fn an_expiry_survives_a_cache_that_cannot_be_dropped() {
 fn network_away_with_nothing_cached_is_an_error() {
     let dir = tempfile::tempdir().expect("tempdir");
     let down = Canned::new(vec![away()]);
-    assert!(me::load(&env_in(dir.path()), &down, &MemoryStore::signed_in()).is_err());
-}
-
-#[test]
-fn the_fixture_database_status_rides_the_offline_ladder() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let env = env_in(dir.path());
-    let store = MemoryStore::signed_in();
-    let first = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
-    me::load(&env, &first, &store).expect("first load");
-
-    let hurt = Canned::new(vec![ok(
-        fixture_status(&["errors", "database_unavailable", "status"]),
-        None,
-        &fixture_body(&["errors", "database_unavailable", "body"]),
-    )]);
-    assert!(matches!(
-        me::load(&env, &hurt, &store).expect("load"),
-        AccountState::Offline { .. }
-    ));
+    let refused = me::load(&env_in(dir.path()), &down, &MemoryStore::signed_in()).unwrap_err();
+    assert!(
+        matches!(refused, AccountUnread::Unreachable(_)),
+        "the request went out and nothing stands in: {refused:?}"
+    );
 }
 
 #[test]
@@ -616,21 +620,6 @@ fn revalidation_sends_the_etag_and_304_keeps_the_identity() {
 }
 
 #[test]
-fn a_malformed_answer_serves_the_cache_as_offline() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let env = env_in(dir.path());
-    let store = MemoryStore::signed_in();
-    let first = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
-    me::load(&env, &first, &store).expect("first load");
-
-    let garbled = Canned::new(vec![ok(200, None, "<!doctype html>")]);
-    assert!(matches!(
-        me::load(&env, &garbled, &store).expect("load"),
-        AccountState::Offline { .. }
-    ));
-}
-
-#[test]
 fn a_cache_from_another_endpoint_is_never_served() {
     let dir = tempfile::tempdir().expect("tempdir");
     let env = env_in(dir.path());
@@ -651,9 +640,10 @@ fn a_cache_from_another_endpoint_is_never_served() {
     )
     .expect("write");
     let down = Canned::new(vec![away()]);
+    let refused = me::load(&env, &down, &MemoryStore::signed_in()).unwrap_err();
     assert!(
-        me::load(&env, &down, &MemoryStore::signed_in()).is_err(),
-        "another endpoint's identity must not stand in"
+        matches!(refused, AccountUnread::Unreachable(_)),
+        "another endpoint's identity must not stand in: {refused:?}"
     );
 }
 
@@ -689,7 +679,11 @@ fn a_failed_revocation_keeps_credential_and_cache_for_retry() {
     let cache = env.registry_cache_dir().join("me.cache.json");
 
     let refused = Canned::new(vec![ok(503, None, r#"{"error":"down"}"#)]);
-    assert!(me::sign_out(&env, &refused, &store).is_err());
+    let error = me::sign_out(&env, &refused, &store).unwrap_err();
+    assert!(
+        matches!(error, CoreError::RegistryUnavailable { .. }),
+        "{error:?}"
+    );
     assert!(store.load().expect("load").is_some());
     assert!(cache.exists(), "still signed in, so still remembered");
 }
@@ -756,8 +750,9 @@ fn an_oversized_identity_cache_reads_as_no_cache() {
     );
     write_cache(&env, &body, None, Some(ADA));
     let down = Canned::new(vec![away()]);
+    let refused = me::load(&env, &down, &MemoryStore::signed_in()).unwrap_err();
     assert!(
-        me::load(&env, &down, &MemoryStore::signed_in()).is_err(),
-        "a cache past the cap is never read, however well-formed"
+        matches!(refused, AccountUnread::Unreachable(_)),
+        "a cache past the cap is never read, however well-formed: {refused:?}"
     );
 }

--- a/crates/core/tests/migration.rs
+++ b/crates/core/tests/migration.rs
@@ -64,59 +64,64 @@ fn fixture(schema: &str) -> Fixture {
     }
 }
 
-/// A v0.1 manifest is not read, not converted, and not written over. The
-/// refusal names it as an older schema and says what to do with it.
+/// A manifest this build cannot read is refused and left byte for byte
+/// where the person put it, one row per schema: a v0.1 manifest is not
+/// read, not converted and not written over, the refusal naming the
+/// schema it found; the schema this build writes is the schema it reads,
+/// so the same file one number back is refused for the same reason; a
+/// manifest naming no schema at all gets the same refusal, saying that
+/// nothing here can tell what shape the file is; and a newer schema is
+/// its own refusal, naming the format found.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn a_v01_manifest_is_refused_and_left_byte_identical() {
-    let f = fixture("1");
-    let error = audit(&f.env, &f.scope).unwrap_err();
-    assert!(matches!(error, CoreError::LegacyManifest { .. }), "{error}");
-    let said = error.to_string();
-    assert!(said.contains("schema 1"), "{said}");
-    assert!(said.contains("install fresh"), "{said}");
-    assert_eq!(
-        fs::read_to_string(&f.manifest_path).unwrap(),
-        f.original,
-        "a refusal writes nothing"
-    );
-    assert!(!f.scope_lock().exists(), "and installs nothing");
-}
+fn a_manifest_this_build_cannot_read_is_refused_and_left_byte_identical() {
+    enum Refusal {
+        Legacy(String),
+        TooNew(i64),
+    }
+    let one_below = (MANIFEST_SCHEMA - 1).to_string();
+    let rows: [(&str, Option<&str>, Refusal); 4] = [
+        (
+            "schema 1",
+            Some("1"),
+            Refusal::Legacy("schema 1".to_owned()),
+        ),
+        (
+            "one below current",
+            Some(&one_below),
+            Refusal::Legacy(format!("schema {one_below} manifest")),
+        ),
+        ("no schema", None, Refusal::Legacy("no schema".to_owned())),
+        ("schema 99", Some("99"), Refusal::TooNew(99)),
+    ];
+    for (what, schema, refusal) in rows {
+        let f = fixture(schema.unwrap_or("1"));
+        if schema.is_none() {
+            fs::write(&f.manifest_path, f.original.replace("schema = 1\n", "")).unwrap();
+        }
+        let before = fs::read_to_string(&f.manifest_path).unwrap();
 
-/// The schema this build writes is the schema it reads, so the same file
-/// one number back is refused for the same reason as a v0.1 one.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn the_schema_one_below_current_is_refused_too() {
-    let f = fixture(&(MANIFEST_SCHEMA - 1).to_string());
-    let error = audit(&f.env, &f.scope).unwrap_err();
-    assert!(matches!(error, CoreError::LegacyManifest { .. }), "{error}");
-    assert_eq!(fs::read_to_string(&f.manifest_path).unwrap(), f.original);
-}
+        let error = audit(&f.env, &f.scope).unwrap_err();
 
-/// A manifest naming no schema at all: the same refusal, saying that
-/// nothing here can tell what shape the file is.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_manifest_naming_no_schema_is_refused() {
-    let f = fixture("1");
-    let unversioned = f.original.replace("schema = 1\n", "");
-    fs::write(&f.manifest_path, &unversioned).unwrap();
-    let error = audit(&f.env, &f.scope).unwrap_err();
-    assert!(matches!(error, CoreError::LegacyManifest { .. }), "{error}");
-    assert!(error.to_string().contains("no schema"), "{error}");
-    assert_eq!(fs::read_to_string(&f.manifest_path).unwrap(), unversioned);
-}
-
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_newer_schema_refuses_to_load() {
-    let f = fixture("99");
-    assert!(matches!(
-        audit(&f.env, &f.scope),
-        Err(CoreError::SchemaTooNew { found: 99, .. })
-    ));
-    assert_eq!(fs::read_to_string(&f.manifest_path).unwrap(), f.original);
+        match (&refusal, &error) {
+            (Refusal::Legacy(clause), CoreError::LegacyManifest { message, .. }) => {
+                assert!(message.contains(clause), "{what}: {message}");
+            }
+            (Refusal::TooNew(expected), CoreError::SchemaTooNew { found, .. }) => {
+                assert_eq!(found, expected, "{what}");
+            }
+            _ => panic!("{what}: {error:?}"),
+        }
+        assert_eq!(
+            fs::read_to_string(&f.manifest_path).unwrap(),
+            before,
+            "{what}: a refusal writes nothing"
+        );
+        assert!(
+            !f.scope_lock().exists(),
+            "{what}: a refusal installs nothing"
+        );
+    }
 }
 
 /// An apply interrupted at any op boundary rolls the whole scope back:
@@ -257,16 +262,17 @@ fn recording_existing_refuses_a_render_that_does_not_match() {
 fn recovery_requires_the_whole_declared_set() {
     for extra in [
         "\n[bundles.missing]\nsource = \"cat\"\n",
-        "\n[plugins.\"fmt@main\"]\nenabled = true\nharness = \"codex\"\n",
+        "\n[plugins.\"fmt@main\"]\nenabled = true\nharness = \"claude\"\n",
     ] {
         let f = fixture(&MANIFEST_SCHEMA.to_string());
         let install = plan_apply(&f.env, &f.scope, &PlanOptions::default()).unwrap();
         apply::execute(&f.env, &install.plan).unwrap();
         fs::remove_file(f.scope_lock()).unwrap();
         fs::write(&f.manifest_path, format!("{}{extra}", f.original)).unwrap();
+        let error = plan_record_existing(&f.env, &f.scope).unwrap_err();
         assert!(
-            plan_record_existing(&f.env, &f.scope).is_err(),
-            "incomplete declaration accepted: {extra}"
+            matches!(error, CoreError::RecordExistingRefused { .. }),
+            "incomplete declaration accepted: {extra}: {error}"
         );
         assert!(!f.scope_lock().exists());
     }
@@ -281,7 +287,8 @@ fn recovery_rechecks_render_bytes_before_recording() {
     let recovery = plan_record_existing(&f.env, &f.scope).unwrap();
     let rendered = f.project().join(".agents/skills/gh/SKILL.md");
     fs::write(&rendered, "edited during confirmation\n").unwrap();
-    assert!(apply::execute(&f.env, &recovery.plan).is_err());
+    let error = apply::execute(&f.env, &recovery.plan).unwrap_err();
+    assert!(matches!(error, CoreError::RolledBack { .. }), "{error}");
     assert!(!f.scope_lock().exists());
     assert_eq!(
         fs::read_to_string(rendered).unwrap(),
@@ -333,7 +340,11 @@ fn recovery_refuses_an_unresolved_required_dependency() {
     apply::execute(&f.env, &install.plan).unwrap();
     assert!(f.project().join(".agents/skills/gh/SKILL.md").is_file());
     fs::remove_file(f.scope_lock()).unwrap();
-    assert!(plan_record_existing(&f.env, &f.scope).is_err());
+    let error = plan_record_existing(&f.env, &f.scope).unwrap_err();
+    assert!(
+        matches!(error, CoreError::RecordExistingRefused { .. }),
+        "{error}"
+    );
     assert!(!f.scope_lock().exists());
 }
 

--- a/crates/core/tests/package_pins/sets.rs
+++ b/crates/core/tests/package_pins/sets.rs
@@ -654,9 +654,10 @@ fn a_lock_naming_another_version_is_refused_in_both_directions() {
     let error = load_lock(&path).unwrap_err();
     assert!(matches!(error, CoreError::LockCorrupt { .. }), "{error}");
     assert!(error.to_string().contains("install fresh"), "{error}");
+    let error = audit(&w.env, &w.scope).unwrap_err();
     assert!(
-        audit(&w.env, &w.scope).is_err(),
-        "and nothing plans past it"
+        matches!(error, CoreError::LockCorrupt { .. }),
+        "and nothing plans past it: {error:?}"
     );
 
     renumber(LOCK_VERSION + 1);

--- a/crates/core/tests/quality/rules.rs
+++ b/crates/core/tests/quality/rules.rs
@@ -76,8 +76,6 @@ fn prompt_injection_catches_talking_past_the_harness() {
         severity_of(&result, "prompt-injection"),
         Some(Severity::Critical)
     );
-    assert!(result.findings[0].message.contains("set aside"));
-    assert!(!result.findings[0].remediation.is_empty());
 }
 
 /// Any run of whitespace where the phrase has one space is the same phrase.
@@ -244,96 +242,6 @@ fn safety_bypass_leaves_ordinary_tool_flags_alone() {
     );
     assert!(
         !rules_hit(&result).contains(&"safety-bypass"),
-        "{:?}",
-        result.findings
-    );
-}
-
-/// A document naming the switch in a code span is naming it. The control
-/// is the second case, and it is what the rule is worth: a fenced block is
-/// how a skill writes the command it means, so the switch inside one
-/// counts at full weight.
-#[test]
-fn safety_bypass_reads_a_switch_named_in_a_code_span_as_a_mention() {
-    let named = skill(&[("SKILL.md", "The bypass is `git commit --no-verify`.\n")]);
-    assert!(
-        !rules_hit(&named).contains(&"safety-bypass"),
-        "{:?}",
-        named.findings
-    );
-
-    let run = skill(&[("SKILL.md", "```sh\ngit commit --no-verify -m done\n```\n")]);
-    assert_eq!(
-        severity_of(&run, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        run.findings
-    );
-}
-
-/// One named mention must not cover a use standing beside it: the rule
-/// reads every occurrence on the line, not the first.
-#[test]
-fn safety_bypass_reads_past_a_mention_to_the_use_behind_it() {
-    let result = skill(&[(
-        "SKILL.md",
-        "Never `--no-verify`, though this line says --no-verify plainly.\n",
-    )]);
-    assert_eq!(
-        severity_of(&result, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        result.findings
-    );
-}
-
-/// A backtick that closes nothing quotes nothing. Markdown ends a run of
-/// backticks only on a run of the same length, so an opener with no match
-/// is literal text — and treating it as a toggle would let one stray
-/// backtick hide every switch after it on the line, which is this rule
-/// going quiet in a score somebody installs on.
-#[test]
-fn safety_bypass_still_reads_a_switch_after_a_backtick_that_closes_nothing() {
-    let result = skill(&[(
-        "SKILL.md",
-        "Prefer `git commit -m done over git commit --no-verify -m done.\n",
-    )]);
-    assert_eq!(
-        severity_of(&result, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        result.findings
-    );
-}
-
-/// A span opened by two backticks holds single ones as its own text, which
-/// is how markdown writes a backtick at all. Reading the inner one as the
-/// close reports the rest of the span as though it stood in the open.
-#[test]
-fn safety_bypass_leaves_a_backtick_quoted_inside_a_longer_span() {
-    let result = skill(&[(
-        "SKILL.md",
-        "The shape is ``git commit` --no-verify`` in a doc.\n",
-    )]);
-    assert!(
-        !rules_hit(&result).contains(&"safety-bypass"),
-        "{:?}",
-        result.findings
-    );
-}
-
-/// A backslash-escaped backtick is the character, not a delimiter. Reading
-/// it as one let a pair of them quote the switch between, which is the
-/// same silence one character smaller.
-#[test]
-fn safety_bypass_reads_a_switch_between_escaped_backticks() {
-    let result = skill(&[(
-        "SKILL.md",
-        "Write \\`git commit --no-verify\\` and run it.\n",
-    )]);
-    assert_eq!(
-        severity_of(&result, "safety-bypass"),
-        Some(Severity::Critical),
         "{:?}",
         result.findings
     );

--- a/crates/core/tests/quality/rules_blocks.rs
+++ b/crates/core/tests/quality/rules_blocks.rs
@@ -13,505 +13,593 @@ use kendex_core::quality::Severity;
 
 use super::rules::{rules_hit, severity_of, skill};
 
-/// A code span closes on a later line of the same paragraph. Read one line
-/// at a time the opener meets no match on its own line and the close meets
-/// none on the next, so the switch quoted between them was reported as one
-/// standing in the open.
-///
-/// The control is the second case: the reach is the paragraph, not the
-/// document. A backtick whose partner stands past a blank line quotes
-/// nothing, and the switch beside it still counts.
+/// Whether a switch is a use or a mention, one row per document: the
+/// audit reads `--no-verify` as a mention where a code span quotes it and
+/// as a use everywhere else, so every block boundary the reading misses
+/// hides a use, and every boundary it invents reports a mention. Both
+/// directions are here, one against the other, since a fix in either
+/// direction alone is a fix in the wrong one. Each group of rows is one
+/// boundary, its reason above it, the control beside it.
 #[test]
-fn safety_bypass_leaves_a_switch_quoted_by_a_span_that_crosses_a_newline() {
-    let across = skill(&[(
-        "SKILL.md",
-        "The bypass is `git commit\n--no-verify`, which this never runs.\n",
-    )]);
-    assert!(
-        !rules_hit(&across).contains(&"safety-bypass"),
-        "{:?}",
-        across.findings
-    );
-
-    let apart = skill(&[(
-        "SKILL.md",
-        "The bypass is `git commit\n\n--no-verify` runs it.\n",
-    )]);
-    assert_eq!(
-        severity_of(&apart, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        apart.findings
-    );
-}
-
-/// The line an indented block opens on is the block's own text, the same
-/// as the line under it. Reading it as prose let a backtick there quote
-/// what the block prints literally, so a switch on a block's first line
-/// scored nothing and the same switch one line down scored Critical.
-///
-/// The control is the second case: in prose those same marks are
-/// markdown's, and they do quote.
-#[test]
-fn safety_bypass_reads_the_line_an_indented_block_opens_on_as_code() {
-    let opens = skill(&[("SKILL.md", "Run it:\n\n    git commit `--no-verify`\n")]);
-    assert_eq!(
-        severity_of(&opens, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        opens.findings
-    );
-
-    let prose = skill(&[("SKILL.md", "Run it: git commit `--no-verify`\n")]);
-    assert!(
-        !rules_hit(&prose).contains(&"safety-bypass"),
-        "{:?}",
-        prose.findings
-    );
-}
-
-/// A heading is a block of its own, so a run of backticks left open at the
-/// end of one does not reach the paragraph under it. Joining the two into
-/// a single run paired those stray backticks, and the switch standing
-/// between them read as quoted: one unmatched backtick on each of two
-/// lines, and a line telling a reader to pass git the switch scored
-/// nothing.
-#[test]
-fn safety_bypass_reads_a_switch_a_heading_keeps_out_of_a_span() {
-    let result = skill(&[(
-        "SKILL.md",
-        "# Committing past the `hook\nPass --no-verify` when it complains.\n",
-    )]);
-    assert_eq!(
-        severity_of(&result, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        result.findings
-    );
-}
-
-/// A heading underlined with `=` is the same block boundary written the
-/// other way round, and the underline closes it. A run reaching past that
-/// paired the two stray backticks and swallowed the line under it.
-#[test]
-fn safety_bypass_reads_a_switch_a_setext_heading_keeps_out_of_a_span() {
-    let result = skill(&[(
-        "SKILL.md",
-        "Committing past the `hook\n=========================\nPass --no-verify` when it complains.\n",
-    )]);
-    assert_eq!(
-        severity_of(&result, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        result.findings
-    );
-}
-
-/// Each list item is a block of its own, so a backtick left open in one
-/// does not reach the next. A line carrying no marker continues the item
-/// above it, which is the second case: a span still crosses the newline
-/// inside one item.
-#[test]
-fn safety_bypass_reads_a_switch_a_list_item_keeps_out_of_a_span() {
-    let items = skill(&[(
-        "SKILL.md",
-        "- Write `git commit\n- Pass --no-verify` to git.\n",
-    )]);
-    assert_eq!(
-        severity_of(&items, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        items.findings
-    );
-
-    let one = skill(&[(
-        "SKILL.md",
-        "- The bypass is `git commit\n  --no-verify`, which this never runs.\n",
-    )]);
-    assert!(
-        !rules_hit(&one).contains(&"safety-bypass"),
-        "{:?}",
-        one.findings
-    );
-}
-
-/// A blockquote opening inside prose is a block of its own, so a backtick
-/// in the prose above one does not reach into it. Its findings still weigh
-/// one severity less, which is what a quotation is worth.
-///
-/// The control is the second case: two quoted lines are one block, so a
-/// span opened on the first still closes on the second.
-#[test]
-fn safety_bypass_reads_a_switch_a_blockquote_keeps_out_of_a_span() {
-    let into = skill(&[(
-        "SKILL.md",
-        "Write `git commit\n> Pass --no-verify` to git.\n",
-    )]);
-    assert_eq!(
-        severity_of(&into, "safety-bypass"),
-        Some(Severity::High),
-        "{:?}",
-        into.findings
-    );
-
-    let within = skill(&[(
-        "SKILL.md",
-        "> The bypass is `git commit\n> --no-verify`, which this never runs.\n",
-    )]);
-    assert!(
-        !rules_hit(&within).contains(&"safety-bypass"),
-        "{:?}",
-        within.findings
-    );
-}
-
-/// A thematic break ends the block above it, so the two stray backticks on
-/// either side belong to different blocks and quote nothing. A reading that
-/// knows only the boundaries somebody wrote down joins the three lines,
-/// pairs those backticks, and drops the finding — a switch in the open,
-/// scored as a mention, in a number somebody installs on.
-///
-/// The control is the second case: take the break out and the same two
-/// lines are one paragraph, where the span is real and the mention is a
-/// mention.
-#[test]
-fn safety_bypass_reads_a_switch_a_thematic_break_keeps_out_of_a_span() {
-    let across = skill(&[(
-        "SKILL.md",
-        "Describe `the hook\n***\nRun git commit --no-verify` now.\n",
-    )]);
-    assert_eq!(
-        severity_of(&across, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        across.findings
-    );
-
-    let joined = skill(&[(
-        "SKILL.md",
-        "Describe `the hook\nand git commit --no-verify` now.\n",
-    )]);
-    assert!(
-        !rules_hit(&joined).contains(&"safety-bypass"),
-        "{:?}",
-        joined.findings
-    );
-}
-
-/// A line opening a raw HTML block ends the paragraph above it, and what
-/// stands inside the block is HTML rather than prose — no span of markdown's
-/// reaches into it or out of it. Reading those lines as one paragraph paired
-/// the stray backticks and hid the switch between them.
-///
-/// The control is the second case: a tag named in the middle of a sentence
-/// opens no block, so that paragraph still holds its span.
-#[test]
-fn safety_bypass_reads_a_switch_a_raw_html_block_keeps_out_of_a_span() {
-    let across = skill(&[(
-        "SKILL.md",
-        "Describe `the hook\n<div>\nRun git commit --no-verify` now.\n",
-    )]);
-    assert_eq!(
-        severity_of(&across, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        across.findings
-    );
-
-    let named = skill(&[(
-        "SKILL.md",
-        "Describe `the hook\nin a <div> and git commit --no-verify` now.\n",
-    )]);
-    assert!(
-        !rules_hit(&named).contains(&"safety-bypass"),
-        "{:?}",
-        named.findings
-    );
-}
-
-/// A quoted paragraph carries on through a line that drops its `>`, which
-/// is markdown's lazy continuation, and the span opened above it closes
-/// there. Comparing the two lines' markers instead invents a boundary the
-/// document has not got, and a harmless mention was reported Critical.
-///
-/// The control is the second case: a blank line does end the quoted
-/// paragraph, so the line under it opens a block of its own and the switch
-/// there stands in the open.
-#[test]
-fn safety_bypass_leaves_a_switch_quoted_across_a_lazy_blockquote_continuation() {
-    let lazy = skill(&[(
-        "SKILL.md",
-        "> The bypass is `git commit\n--no-verify`, never run it.\n",
-    )]);
-    assert!(
-        !rules_hit(&lazy).contains(&"safety-bypass"),
-        "{:?}",
-        lazy.findings
-    );
-
-    let apart = skill(&[(
-        "SKILL.md",
-        "> The bypass is `git commit\n\n--no-verify`, never run it.\n",
-    )]);
-    assert_eq!(
-        severity_of(&apart, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        apart.findings
-    );
-}
-
-/// Four spaces may not interrupt an open paragraph, so an indented line
-/// under prose is that paragraph's next line and the span on it is real.
-/// Reading the indent as a code block threw the span away and reported the
-/// flag the document was naming as a switch somebody runs.
-///
-/// The control is the second case: with a blank line above it the same
-/// indent does open a block, and the marks there are the shell's.
-#[test]
-fn safety_bypass_leaves_a_switch_quoted_by_an_indented_continuation() {
-    let under = skill(&[("SKILL.md", "Name the flag below:\n    `--no-verify`\n")]);
-    assert!(
-        !rules_hit(&under).contains(&"safety-bypass"),
-        "{:?}",
-        under.findings
-    );
-
-    let apart = skill(&[("SKILL.md", "Name the flag below:\n\n    `--no-verify`\n")]);
-    assert_eq!(
-        severity_of(&apart, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        apart.findings
-    );
-}
-
-/// A fence opens inside a blockquote the same as anywhere else, and what
-/// it holds is code. Reading the line before its markers were consumed
-/// left the fence unrecognised, so the two runs of backticks paired as an
-/// inline span and the switch quoted between them was scored a mention —
-/// the same silence this whole reading exists to close, in the reading
-/// itself.
-///
-/// The control is the second case: a quoted line whose switch stands in an
-/// inline span is still naming it, and naming it is not running it.
-#[test]
-fn safety_bypass_reads_a_switch_a_quoted_fence_holds_as_code() {
-    let fenced = skill(&[("SKILL.md", "> ```sh\n> git commit --no-verify\n> ```\n")]);
-    assert_eq!(
-        severity_of(&fenced, "safety-bypass"),
-        Some(Severity::High),
-        "{:?}",
-        fenced.findings
-    );
-
-    let named = skill(&[(
-        "SKILL.md",
-        "> The bypass is `git commit --no-verify`, never run it.\n",
-    )]);
-    assert!(
-        !rules_hit(&named).contains(&"safety-bypass"),
-        "{:?}",
-        named.findings
-    );
-}
-
-/// A raw HTML block opened inside a blockquote ends where that quote does.
-/// Only a paragraph continues lazily, so a line that has dropped the
-/// marker has left the block; carrying no depth on the open block ran it
-/// on to the next blank line, swallowing a paragraph whose span was real
-/// and reporting the switch it quoted as one standing in the open.
-///
-/// The control is the second case: while the quote does continue, the
-/// block holds, and the marks inside it are the document's own HTML rather
-/// than markdown's.
-#[test]
-fn safety_bypass_ends_a_quoted_html_block_where_its_quote_ends() {
-    let left = skill(&[(
-        "SKILL.md",
-        "> <div>\nThe bypass is `git commit\n--no-verify`, never run it.\n",
-    )]);
-    assert!(
-        !rules_hit(&left).contains(&"safety-bypass"),
-        "{:?}",
-        left.findings
-    );
-
-    let held = skill(&[(
-        "SKILL.md",
-        "> <div>\n> The bypass is `git commit\n> --no-verify`, never run it.\n",
-    )]);
-    assert_eq!(
-        severity_of(&held, "safety-bypass"),
-        Some(Severity::High),
-        "{:?}",
-        held.findings
-    );
-}
-
-/// A fence closes on a marker standing at the depth its opener stood at.
-/// Inside a fenced block every further `>` is the code's own text, so a
-/// quoted marker closes nothing; consuming it as a container marker ended
-/// the block early and turned the code under it back into prose, where a
-/// pair of backticks quoted the switch and the finding went away.
-///
-/// The control is the second case: a marker at the opener's own depth does
-/// close it, and the line under that is prose again.
-#[test]
-fn safety_bypass_closes_a_fence_only_at_the_depth_it_opened_in() {
-    let quoted = skill(&[(
-        "SKILL.md",
-        "```sh\n> ```\nThe bypass is `git commit --no-verify`, never run it.\n",
-    )]);
-    assert_eq!(
-        severity_of(&quoted, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        quoted.findings
-    );
-
-    let plain = skill(&[(
-        "SKILL.md",
-        "```sh\n```\nThe bypass is `git commit --no-verify`, never run it.\n",
-    )]);
-    assert!(
-        !rules_hit(&plain).contains(&"safety-bypass"),
-        "{:?}",
-        plain.findings
-    );
-}
-
-/// A whole tag alone on its line opens a raw HTML block where no paragraph
-/// stands open, whatever its name. Refusing that kind everywhere left the
-/// tag and the line under it reading as one paragraph, where the backticks
-/// paired and quoted a switch nothing had quoted.
-///
-/// The control is the second case, and it is the half the refusal got
-/// right: this kind may not interrupt a paragraph, so under an open one
-/// the same tag is that paragraph's next line and the span across it is
-/// real.
-#[test]
-fn safety_bypass_opens_a_block_at_a_whole_tag_only_where_no_paragraph_is() {
-    let alone = skill(&[(
-        "SKILL.md",
-        "<span>\nThe bypass is `git commit --no-verify`, never run it.\n",
-    )]);
-    assert_eq!(
-        severity_of(&alone, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        alone.findings
-    );
-
-    let within = skill(&[(
-        "SKILL.md",
-        "The bypass is `git commit\n<span>\n--no-verify`, never run it.\n",
-    )]);
-    assert!(
-        !rules_hit(&within).contains(&"safety-bypass"),
-        "{:?}",
-        within.findings
-    );
-}
-
-/// A tag holding nothing opens no raw-text block. `<script/>` has no
-/// content for markdown to read raw and no closing tag coming, so taking
-/// it for the kind that ends at `</script>` ran the block to the end of
-/// the document and threw away every span below it.
-///
-/// The control is the second case: a real `<script>` does hold its content
-/// raw, and the marks in there are the script's rather than markdown's.
-#[test]
-fn safety_bypass_leaves_a_span_under_a_tag_that_holds_nothing() {
-    let empty = skill(&[(
-        "SKILL.md",
-        "<script/>\n\nThe bypass is `git commit --no-verify`, never run it.\n",
-    )]);
-    assert!(
-        !rules_hit(&empty).contains(&"safety-bypass"),
-        "{:?}",
-        empty.findings
-    );
-
-    let holding = skill(&[(
-        "SKILL.md",
-        "<script>\nThe bypass is `git commit --no-verify`, never run it.\n</script>\n",
-    )]);
-    assert_eq!(
-        severity_of(&holding, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        holding.findings
-    );
-}
-
-/// A line entering a deeper quote has left the paragraph above it, so the
-/// paragraph that decides whether a whole tag may open a block is the one
-/// this line could continue rather than any open paragraph at all. Asking
-/// the question globally refused the tag, read both quoted lines as one
-/// paragraph, paired the backticks and suppressed a real bypass.
-///
-/// The control is the second case, and it is the rule the gate is for: at
-/// the paragraph's own depth the tag does continue it, and the span across
-/// it is real.
-#[test]
-fn safety_bypass_opens_a_block_at_a_tag_that_entered_a_deeper_quote() {
-    let deeper = skill(&[(
-        "SKILL.md",
-        "Read this.\n> <span>\n> The bypass is `git commit --no-verify`, never run it.\n",
-    )]);
-    assert_eq!(
-        severity_of(&deeper, "safety-bypass"),
-        Some(Severity::High),
-        "{:?}",
-        deeper.findings
-    );
-
-    let alongside = skill(&[(
-        "SKILL.md",
-        "> The bypass is `git commit\n> <span>\n> --no-verify`, never run it.\n",
-    )]);
-    assert!(
-        !rules_hit(&alongside).contains(&"safety-bypass"),
-        "{:?}",
-        alongside.findings
-    );
-}
-
-/// A whole tag alone on its line opens a block whatever its name.
-/// `<textarea/>` starts no raw-text block — the character behind the name
-/// is neither whitespace nor `>` — and markdown's prose excludes the four
-/// raw-text names from the whole-tag kind as well, so on the page it opens
-/// nothing. No implementation reads it that way: `pulldown-cmark` and
-/// commonmark.js both open the whole-tag block, whose reach is the next
-/// blank line. The line under it is the block's own text, the span it
-/// would have carried is gone, and the switch that span quoted is
-/// reported — over-counting, which is the safe side of this ledger.
-///
-/// The control is the second case: the kind ends at a blank line, so a
-/// paragraph past one carries its span and its switch is a mention again.
-#[test]
-fn safety_bypass_opens_a_block_at_a_raw_text_tag_that_holds_nothing() {
-    let under = skill(&[(
-        "SKILL.md",
-        "<textarea/>\nThe bypass is `git commit --no-verify`, never run it.\n",
-    )]);
-    assert_eq!(
-        severity_of(&under, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        under.findings
-    );
-
-    let past = skill(&[(
-        "SKILL.md",
-        "<textarea/>\n\nThe bypass is `git commit --no-verify`, never run it.\n",
-    )]);
-    assert!(
-        !rules_hit(&past).contains(&"safety-bypass"),
-        "{:?}",
-        past.findings
-    );
+#[allow(
+    clippy::too_many_lines,
+    reason = "one table: every block boundary the span reading has to honour, one document per row"
+)]
+fn safety_bypass_reads_a_switch_as_a_use_exactly_where_no_span_quotes_it() {
+    type Row = (&'static str, &'static str, Option<Severity>);
+    let rows: &[Row] = &[
+        // A document naming the switch in a code span is naming it. The control
+        // is the second case, and it is what the rule is worth: a fenced block is
+        // how a skill writes the command it means, so the switch inside one
+        // counts at full weight.
+        (
+            "reads a switch named in a code span as a mention: named",
+            "The bypass is `git commit --no-verify`.\n",
+            None,
+        ),
+        (
+            "reads a switch named in a code span as a mention: run",
+            "```sh\ngit commit --no-verify -m done\n```\n",
+            Some(Severity::Critical),
+        ),
+        // One named mention must not cover a use standing beside it: the rule
+        // reads every occurrence on the line, not the first.
+        (
+            "reads past a mention to the use behind it: result",
+            "Never `--no-verify`, though this line says --no-verify plainly.\n",
+            Some(Severity::Critical),
+        ),
+        // A backtick that closes nothing quotes nothing. Markdown ends a run of
+        // backticks only on a run of the same length, so an opener with no match
+        // is literal text — and treating it as a toggle would let one stray
+        // backtick hide every switch after it on the line, which is this rule
+        // going quiet in a score somebody installs on.
+        (
+            "still reads a switch after a backtick that closes nothing: result",
+            "Prefer `git commit -m done over git commit --no-verify -m done.\n",
+            Some(Severity::Critical),
+        ),
+        // A span opened by two backticks holds single ones as its own text, which
+        // is how markdown writes a backtick at all. Reading the inner one as the
+        // close reports the rest of the span as though it stood in the open.
+        (
+            "leaves a backtick quoted inside a longer span: result",
+            "The shape is ``git commit` --no-verify`` in a doc.\n",
+            None,
+        ),
+        // A backslash-escaped backtick is the character, not a delimiter. Reading
+        // it as one let a pair of them quote the switch between, which is the
+        // same silence one character smaller.
+        (
+            "reads a switch between escaped backticks: result",
+            "Write \\`git commit --no-verify\\` and run it.\n",
+            Some(Severity::Critical),
+        ),
+        // A code span closes on a later line of the same paragraph. Read one line
+        // at a time the opener meets no match on its own line and the close meets
+        // none on the next, so the switch quoted between them was reported as one
+        // standing in the open.
+        //
+        // The control is the second case: the reach is the paragraph, not the
+        // document. A backtick whose partner stands past a blank line quotes
+        // nothing, and the switch beside it still counts.
+        (
+            "leaves a switch quoted by a span that crosses a newline: across",
+            "The bypass is `git commit\n--no-verify`, which this never runs.\n",
+            None,
+        ),
+        (
+            "leaves a switch quoted by a span that crosses a newline: apart",
+            "The bypass is `git commit\n\n--no-verify` runs it.\n",
+            Some(Severity::Critical),
+        ),
+        // The line an indented block opens on is the block's own text, the same
+        // as the line under it. Reading it as prose let a backtick there quote
+        // what the block prints literally, so a switch on a block's first line
+        // scored nothing and the same switch one line down scored Critical.
+        //
+        // The control is the second case: in prose those same marks are
+        // markdown's, and they do quote.
+        (
+            "reads the line an indented block opens on as code: opens",
+            "Run it:\n\n    git commit `--no-verify`\n",
+            Some(Severity::Critical),
+        ),
+        (
+            "reads the line an indented block opens on as code: prose",
+            "Run it: git commit `--no-verify`\n",
+            None,
+        ),
+        // A heading is a block of its own, so a run of backticks left open at the
+        // end of one does not reach the paragraph under it. Joining the two into
+        // a single run paired those stray backticks, and the switch standing
+        // between them read as quoted: one unmatched backtick on each of two
+        // lines, and a line telling a reader to pass git the switch scored
+        // nothing.
+        (
+            "reads a switch a heading keeps out of a span: result",
+            "# Committing past the `hook\nPass --no-verify` when it complains.\n",
+            Some(Severity::Critical),
+        ),
+        // A heading underlined with `=` is the same block boundary written the
+        // other way round, and the underline closes it. A run reaching past that
+        // paired the two stray backticks and swallowed the line under it.
+        (
+            "reads a switch a setext heading keeps out of a span: result",
+            "Committing past the `hook\n=========================\nPass --no-verify` when it complains.\n",
+            Some(Severity::Critical),
+        ),
+        // Each list item is a block of its own, so a backtick left open in one
+        // does not reach the next. A line carrying no marker continues the item
+        // above it, which is the second case: a span still crosses the newline
+        // inside one item.
+        (
+            "reads a switch a list item keeps out of a span: items",
+            "- Write `git commit\n- Pass --no-verify` to git.\n",
+            Some(Severity::Critical),
+        ),
+        (
+            "reads a switch a list item keeps out of a span: one",
+            "- The bypass is `git commit\n  --no-verify`, which this never runs.\n",
+            None,
+        ),
+        // A blockquote opening inside prose is a block of its own, so a backtick
+        // in the prose above one does not reach into it. Its findings still weigh
+        // one severity less, which is what a quotation is worth.
+        //
+        // The control is the second case: two quoted lines are one block, so a
+        // span opened on the first still closes on the second.
+        (
+            "reads a switch a blockquote keeps out of a span: into",
+            "Write `git commit\n> Pass --no-verify` to git.\n",
+            Some(Severity::High),
+        ),
+        (
+            "reads a switch a blockquote keeps out of a span: within",
+            "> The bypass is `git commit\n> --no-verify`, which this never runs.\n",
+            None,
+        ),
+        // A thematic break ends the block above it, so the two stray backticks on
+        // either side belong to different blocks and quote nothing. A reading that
+        // knows only the boundaries somebody wrote down joins the three lines,
+        // pairs those backticks, and drops the finding — a switch in the open,
+        // scored as a mention, in a number somebody installs on.
+        //
+        // The control is the second case: take the break out and the same two
+        // lines are one paragraph, where the span is real and the mention is a
+        // mention.
+        (
+            "reads a switch a thematic break keeps out of a span: across",
+            "Describe `the hook\n***\nRun git commit --no-verify` now.\n",
+            Some(Severity::Critical),
+        ),
+        (
+            "reads a switch a thematic break keeps out of a span: joined",
+            "Describe `the hook\nand git commit --no-verify` now.\n",
+            None,
+        ),
+        // A line opening a raw HTML block ends the paragraph above it, and what
+        // stands inside the block is HTML rather than prose — no span of markdown's
+        // reaches into it or out of it. Reading those lines as one paragraph paired
+        // the stray backticks and hid the switch between them.
+        //
+        // The control is the second case: a tag named in the middle of a sentence
+        // opens no block, so that paragraph still holds its span.
+        (
+            "reads a switch a raw html block keeps out of a span: across",
+            "Describe `the hook\n<div>\nRun git commit --no-verify` now.\n",
+            Some(Severity::Critical),
+        ),
+        (
+            "reads a switch a raw html block keeps out of a span: named",
+            "Describe `the hook\nin a <div> and git commit --no-verify` now.\n",
+            None,
+        ),
+        // A quoted paragraph carries on through a line that drops its `>`, which
+        // is markdown's lazy continuation, and the span opened above it closes
+        // there. Comparing the two lines' markers instead invents a boundary the
+        // document has not got, and a harmless mention was reported Critical.
+        //
+        // The control is the second case: a blank line does end the quoted
+        // paragraph, so the line under it opens a block of its own and the switch
+        // there stands in the open.
+        (
+            "leaves a switch quoted across a lazy blockquote continuation: lazy",
+            "> The bypass is `git commit\n--no-verify`, never run it.\n",
+            None,
+        ),
+        (
+            "leaves a switch quoted across a lazy blockquote continuation: apart",
+            "> The bypass is `git commit\n\n--no-verify`, never run it.\n",
+            Some(Severity::Critical),
+        ),
+        // Four spaces may not interrupt an open paragraph, so an indented line
+        // under prose is that paragraph's next line and the span on it is real.
+        // Reading the indent as a code block threw the span away and reported the
+        // flag the document was naming as a switch somebody runs.
+        //
+        // The control is the second case: with a blank line above it the same
+        // indent does open a block, and the marks there are the shell's.
+        (
+            "leaves a switch quoted by an indented continuation: under",
+            "Name the flag below:\n    `--no-verify`\n",
+            None,
+        ),
+        (
+            "leaves a switch quoted by an indented continuation: apart",
+            "Name the flag below:\n\n    `--no-verify`\n",
+            Some(Severity::Critical),
+        ),
+        // A fence opens inside a blockquote the same as anywhere else, and what
+        // it holds is code. Reading the line before its markers were consumed
+        // left the fence unrecognised, so the two runs of backticks paired as an
+        // inline span and the switch quoted between them was scored a mention —
+        // the same silence this whole reading exists to close, in the reading
+        // itself.
+        //
+        // The control is the second case: a quoted line whose switch stands in an
+        // inline span is still naming it, and naming it is not running it.
+        (
+            "reads a switch a quoted fence holds as code: fenced",
+            "> ```sh\n> git commit --no-verify\n> ```\n",
+            Some(Severity::High),
+        ),
+        (
+            "reads a switch a quoted fence holds as code: named",
+            "> The bypass is `git commit --no-verify`, never run it.\n",
+            None,
+        ),
+        // A raw HTML block opened inside a blockquote ends where that quote does.
+        // Only a paragraph continues lazily, so a line that has dropped the
+        // marker has left the block; carrying no depth on the open block ran it
+        // on to the next blank line, swallowing a paragraph whose span was real
+        // and reporting the switch it quoted as one standing in the open.
+        //
+        // The control is the second case: while the quote does continue, the
+        // block holds, and the marks inside it are the document's own HTML rather
+        // than markdown's.
+        (
+            "ends a quoted html block where its quote ends: left",
+            "> <div>\nThe bypass is `git commit\n--no-verify`, never run it.\n",
+            None,
+        ),
+        (
+            "ends a quoted html block where its quote ends: held",
+            "> <div>\n> The bypass is `git commit\n> --no-verify`, never run it.\n",
+            Some(Severity::High),
+        ),
+        // A fence closes on a marker standing at the depth its opener stood at.
+        // Inside a fenced block every further `>` is the code's own text, so a
+        // quoted marker closes nothing; consuming it as a container marker ended
+        // the block early and turned the code under it back into prose, where a
+        // pair of backticks quoted the switch and the finding went away.
+        //
+        // The control is the second case: a marker at the opener's own depth does
+        // close it, and the line under that is prose again.
+        (
+            "closes a fence only at the depth it opened in: quoted",
+            "```sh\n> ```\nThe bypass is `git commit --no-verify`, never run it.\n",
+            Some(Severity::Critical),
+        ),
+        (
+            "closes a fence only at the depth it opened in: plain",
+            "```sh\n```\nThe bypass is `git commit --no-verify`, never run it.\n",
+            None,
+        ),
+        // A whole tag alone on its line opens a raw HTML block where no paragraph
+        // stands open, whatever its name. Refusing that kind everywhere left the
+        // tag and the line under it reading as one paragraph, where the backticks
+        // paired and quoted a switch nothing had quoted.
+        //
+        // The control is the second case, and it is the half the refusal got
+        // right: this kind may not interrupt a paragraph, so under an open one
+        // the same tag is that paragraph's next line and the span across it is
+        // real.
+        (
+            "opens a block at a whole tag only where no paragraph is: alone",
+            "<span>\nThe bypass is `git commit --no-verify`, never run it.\n",
+            Some(Severity::Critical),
+        ),
+        (
+            "opens a block at a whole tag only where no paragraph is: within",
+            "The bypass is `git commit\n<span>\n--no-verify`, never run it.\n",
+            None,
+        ),
+        // A tag holding nothing opens no raw-text block. `<script/>` has no
+        // content for markdown to read raw and no closing tag coming, so taking
+        // it for the kind that ends at `</script>` ran the block to the end of
+        // the document and threw away every span below it.
+        //
+        // The control is the second case: a real `<script>` does hold its content
+        // raw, and the marks in there are the script's rather than markdown's.
+        (
+            "leaves a span under a tag that holds nothing: empty",
+            "<script/>\n\nThe bypass is `git commit --no-verify`, never run it.\n",
+            None,
+        ),
+        (
+            "leaves a span under a tag that holds nothing: holding",
+            "<script>\nThe bypass is `git commit --no-verify`, never run it.\n</script>\n",
+            Some(Severity::Critical),
+        ),
+        // A line entering a deeper quote has left the paragraph above it, so the
+        // paragraph that decides whether a whole tag may open a block is the one
+        // this line could continue rather than any open paragraph at all. Asking
+        // the question globally refused the tag, read both quoted lines as one
+        // paragraph, paired the backticks and suppressed a real bypass.
+        //
+        // The control is the second case, and it is the rule the gate is for: at
+        // the paragraph's own depth the tag does continue it, and the span across
+        // it is real.
+        (
+            "opens a block at a tag that entered a deeper quote: deeper",
+            "Read this.\n> <span>\n> The bypass is `git commit --no-verify`, never run it.\n",
+            Some(Severity::High),
+        ),
+        (
+            "opens a block at a tag that entered a deeper quote: alongside",
+            "> The bypass is `git commit\n> <span>\n> --no-verify`, never run it.\n",
+            None,
+        ),
+        // A whole tag alone on its line opens a block whatever its name.
+        // `<textarea/>` starts no raw-text block — the character behind the name
+        // is neither whitespace nor `>` — and markdown's prose excludes the four
+        // raw-text names from the whole-tag kind as well, so on the page it opens
+        // nothing. No implementation reads it that way: `pulldown-cmark` and
+        // commonmark.js both open the whole-tag block, whose reach is the next
+        // blank line. The line under it is the block's own text, the span it
+        // would have carried is gone, and the switch that span quoted is
+        // reported — over-counting, which is the safe side of this ledger.
+        //
+        // The control is the second case: the kind ends at a blank line, so a
+        // paragraph past one carries its span and its switch is a mention again.
+        (
+            "opens a block at a raw text tag that holds nothing: under",
+            "<textarea/>\nThe bypass is `git commit --no-verify`, never run it.\n",
+            Some(Severity::Critical),
+        ),
+        (
+            "opens a block at a raw text tag that holds nothing: past",
+            "<textarea/>\n\nThe bypass is `git commit --no-verify`, never run it.\n",
+            None,
+        ),
+        // A backtick fence's info string may hold no backtick. Markdown reads such
+        // a line as a paragraph carrying a code span, so opening a fence there
+        // swallowed the lines under it, threw away the spans they held, and
+        // reported the switch one of them quoted as a switch standing in the open.
+        //
+        // The control is the second case: an ordinary info string opens the fence
+        // it always did, and what the fence holds is code at full weight.
+        (
+            "opens no fence where an info string holds a backtick: info",
+            "> ``` bad`x` info\n> The bypass is `git commit --no-verify`, never run it.\n",
+            None,
+        ),
+        (
+            "opens no fence where an info string holds a backtick: ordinary",
+            "```sh\ngit commit --no-verify\n```\n",
+            Some(Severity::Critical),
+        ),
+        // The limit belongs to the backtick, not to info strings. A tilde fence's
+        // info string may hold backticks and tildes alike, so it opens the block it
+        // always opened and the switch inside stands as code — which is what a
+        // reader that refused every backtick in an info string would lose.
+        (
+            "opens a tilde fence whose info string holds a backtick: tilde",
+            "~~~ aa ``` ~~~\ngit commit --no-verify\n~~~\n",
+            Some(Severity::Critical),
+        ),
+        // A closing fence carries no info string, so a marker with words behind it
+        // is a line of the block's own text and the block runs on. Accepting it as
+        // a close would end the block early and hand the lines below it back to
+        // markdown, where a pair of backticks quotes the switch and the finding
+        // goes quiet.
+        (
+            "keeps a fence open past a marker carrying words: carried",
+            "```\n``` aaa\nThe bypass is `git commit --no-verify`, never run it.\n",
+            Some(Severity::Critical),
+        ),
+        // The slash and the `>` of an empty tag are one thing. Markdown allows
+        // spacing before that slash and none after it, so `<span/   >` is a line
+        // of prose; taking it for a whole tag opened a block that runs to the next
+        // blank line and threw away every span under it.
+        //
+        // The control is the second case: written contiguously the tag is whole,
+        // and the block it opens is real.
+        (
+            "opens no block at a slash parted from its bracket: parted",
+            "<span/   >\nThe bypass is `git commit --no-verify`, never run it.\n",
+            None,
+        ),
+        (
+            "opens no block at a slash parted from its bracket: whole",
+            "<span/>\nThe bypass is `git commit --no-verify`, never run it.\n",
+            Some(Severity::Critical),
+        ),
+        // A fence's own marker stands at most three spaces into its container, and
+        // a fourth is the indented code block instead. Measured from the start of
+        // the line rather than from where the quote's markers end, a marker four
+        // spaces past a `>` opened a fence markdown has none of, and the quoted
+        // prose under it lost the span it really holds.
+        //
+        // The control is the second case: three spaces past the marker is a fence,
+        // and what it holds is code.
+        (
+            "opens no fence four spaces past a quote: deep",
+            ">     ```sh\n> The bypass is `git commit --no-verify`, never run it.\n",
+            None,
+        ),
+        (
+            "opens no fence four spaces past a quote: near",
+            ">    ```sh\n> git commit --no-verify\n> ```\n",
+            Some(Severity::High),
+        ),
+        // A raw-text block ends on the closing tag of its own name. Markdown
+        // says otherwise in as many words — the end condition is a line holding
+        // `</pre>`, `</script>`, `</style>` or `</textarea>`, "case-insensitive;
+        // it need not match the start tag" — and `pulldown-cmark` requires the
+        // match, so a `</pre>` under a `<script>` leaves the block open and the
+        // paragraph below it is read as the script's own text. The switch that
+        // paragraph's span quoted is reported: over-counting, the safe side, on
+        // a shape that stands nowhere in the shipped tree. Correcting the parser
+        // by hand here would be the walk this module exists to have deleted.
+        //
+        // The control is the second case: the block does end at its own closing
+        // tag, and the paragraph under that carries the span again.
+        (
+            "ends a raw text block at a closing tag of its own name: mismatched",
+            "<script>\nfoo\n</pre>\nThe bypass is `git commit --no-verify`, never run it.\n",
+            Some(Severity::Critical),
+        ),
+        (
+            "ends a raw text block at a closing tag of its own name: matched",
+            "<script>\nfoo\n</script>\nThe bypass is `git commit --no-verify`, never run it.\n",
+            None,
+        ),
+        // A table cell is a leaf block of its own, so a run of backticks opened in
+        // one meets no partner in the next and quotes nothing.
+        //
+        // The control is the second case: take the delimiter row away and the same
+        // three lines are one paragraph, where the span is real.
+        (
+            "reads a switch a table row keeps out of a span: tabled",
+            "| head |\n| --- |\n| Write `git commit |\n| --no-verify` to git. |\n",
+            Some(Severity::Critical),
+        ),
+        (
+            "reads a switch a table row keeps out of a span: joined",
+            "| head |\n| Write `git commit |\n| --no-verify` to git. |\n",
+            None,
+        ),
+        // A link reference definition carries no inline content, so the backticks
+        // in its label are literal characters and quote nothing. Reading the line
+        // as a paragraph quoted the switch its label spells and scored a use as a
+        // mention.
+        //
+        // The control is the second case: the same label in a sentence is inline
+        // content, and there the marks do quote.
+        (
+            "reads a switch a link definition spells: defined",
+            "Read this.\n\n[`git commit --no-verify`]: src/main.rs\n",
+            Some(Severity::Critical),
+        ),
+        (
+            "reads a switch a link definition spells: inline",
+            "Read this.\n\n[`git commit --no-verify`] is the shape.\n",
+            None,
+        ),
+        // Four spaces are measured from a list item's content column, not from the
+        // start of the line. Under an item whose content starts four in, a
+        // continuation paragraph at four is the item's own prose and the marks on
+        // it are markdown's; reading it as an indented code block threw its span
+        // away and reported the switch that span quoted.
+        //
+        // The control is the second case: with no item above it, the same four
+        // spaces do open a code block, and the marks in there are the shell's.
+        (
+            "measures an indent from a list items content column: item",
+            "16. Say this.\n\n    The bypass is `git commit --no-verify`, never run it.\n",
+            None,
+        ),
+        (
+            "measures an indent from a list items content column: alone",
+            "Say this.\n\n    The bypass is `git commit --no-verify`, never run it.\n",
+            Some(Severity::Critical),
+        ),
+        // An indent is a count of columns, and a tab is as many of them as it
+        // takes to reach the next stop. A tab under a two-column list item is two
+        // columns of item content, not the four that open a code block; reading
+        // any leading tab as a block threw the line's span away.
+        //
+        // The control is the second case: with no item above it, that same tab is
+        // four columns from the margin and does open a block.
+        (
+            "measures a tab in columns rather than as an indent: item",
+            "- Say this.\n\n\tThe bypass is `git commit --no-verify`, never run it.\n",
+            None,
+        ),
+        (
+            "measures a tab in columns rather than as an indent: alone",
+            "Say this.\n\n\tThe bypass is `git commit --no-verify`, never run it.\n",
+            Some(Severity::Critical),
+        ),
+        // A backtick inside an autolink is a byte of the address, not a delimiter.
+        // Pairing it with the next one in the line quoted the text between them
+        // and left the switch past it standing in the open.
+        //
+        // The control is the second case: written as bare text the same address
+        // carries a real delimiter, the pair closes early, and the switch is
+        // outside every span.
+        (
+            "leaves a backtick in an autolink unpaired: linked",
+            "See <https://example.com/a`b> and `git commit --no-verify` now.\n",
+            None,
+        ),
+        (
+            "leaves a backtick in an autolink unpaired: bare",
+            "See https://example.com/a`b and `git commit --no-verify` now.\n",
+            Some(Severity::Critical),
+        ),
+        // An ordered list interrupts a paragraph only where it starts at one, so
+        // a `2.` under prose is that paragraph's next line and the span across it
+        // closes. Reading every number alike invented a boundary and reported a
+        // mention.
+        //
+        // The control is the second case: `1.` does interrupt, and the switch
+        // under it stands in a block of its own.
+        (
+            "lets only a first ordered item break a paragraph: second",
+            "The bypass is `git commit\n2. --no-verify` to git.\n",
+            None,
+        ),
+        (
+            "lets only a first ordered item break a paragraph: first",
+            "The bypass is `git commit\n1. --no-verify` to git.\n",
+            Some(Severity::Critical),
+        ),
+        // The block-level tag names are markdown's own list, whoever holds it.
+        // A name on it opens a block wherever it stands, an open paragraph
+        // included, and one off it is the whole-tag kind, which may not interrupt
+        // a paragraph. `search` and `hgroup` are the pair that tells a current
+        // list from a stale one: HTML has both, markdown lists only the first,
+        // and a copy that guessed by looking at HTML would read them alike.
+        (
+            "opens a block at the tags markdown lists and no others: listed",
+            "The bypass is `git commit\n<search>\n--no-verify`, never run it.\n",
+            Some(Severity::Critical),
+        ),
+        (
+            "opens a block at the tags markdown lists and no others: unlisted",
+            "The bypass is `git commit\n<hgroup>\n--no-verify`, never run it.\n",
+            None,
+        ),
+        // A blockquote marker takes the whitespace behind it, a tab included, so
+        // what is left of a quoted prose line is prose. Leaving the tab in the
+        // remainder read the line as an indented code block, threw its span away
+        // and reported the switch the quotation was naming.
+        //
+        // The control is the second case: four columns past the marker really is
+        // a code block inside the quote, and the marks in there are the shell's.
+        (
+            "takes a tab behind a blockquote marker: quoted",
+            ">\tThe bypass is `git commit --no-verify`, never run it.\n",
+            None,
+        ),
+        (
+            "takes a tab behind a blockquote marker: indented",
+            ">     The bypass is `git commit --no-verify`, never run it.\n",
+            Some(Severity::High),
+        ),
+    ];
+    for (what, markdown, expected) in rows {
+        let result = skill(&[("SKILL.md", markdown)]);
+        assert_eq!(
+            severity_of(&result, "safety-bypass"),
+            *expected,
+            "{what}: {:?}",
+            result.findings
+        );
+    }
 }
 
 /// A declaration is `<!` and an ASCII letter of either case, and it opens a
@@ -541,164 +629,6 @@ fn safety_bypass_reads_a_declaration_the_same_in_either_case() {
         "{:?} {:?}",
         lower.findings,
         upper.findings
-    );
-}
-
-/// A backtick fence's info string may hold no backtick. Markdown reads such
-/// a line as a paragraph carrying a code span, so opening a fence there
-/// swallowed the lines under it, threw away the spans they held, and
-/// reported the switch one of them quoted as a switch standing in the open.
-///
-/// The control is the second case: an ordinary info string opens the fence
-/// it always did, and what the fence holds is code at full weight.
-#[test]
-fn safety_bypass_opens_no_fence_where_an_info_string_holds_a_backtick() {
-    let info = skill(&[(
-        "SKILL.md",
-        "> ``` bad`x` info\n> The bypass is `git commit --no-verify`, never run it.\n",
-    )]);
-    assert!(
-        !rules_hit(&info).contains(&"safety-bypass"),
-        "{:?}",
-        info.findings
-    );
-
-    let ordinary = skill(&[("SKILL.md", "```sh\ngit commit --no-verify\n```\n")]);
-    assert_eq!(
-        severity_of(&ordinary, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        ordinary.findings
-    );
-}
-
-/// The limit belongs to the backtick, not to info strings. A tilde fence's
-/// info string may hold backticks and tildes alike, so it opens the block it
-/// always opened and the switch inside stands as code — which is what a
-/// reader that refused every backtick in an info string would lose.
-#[test]
-fn safety_bypass_opens_a_tilde_fence_whose_info_string_holds_a_backtick() {
-    let tilde = skill(&[("SKILL.md", "~~~ aa ``` ~~~\ngit commit --no-verify\n~~~\n")]);
-    assert_eq!(
-        severity_of(&tilde, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        tilde.findings
-    );
-}
-
-/// A closing fence carries no info string, so a marker with words behind it
-/// is a line of the block's own text and the block runs on. Accepting it as
-/// a close would end the block early and hand the lines below it back to
-/// markdown, where a pair of backticks quotes the switch and the finding
-/// goes quiet.
-#[test]
-fn safety_bypass_keeps_a_fence_open_past_a_marker_carrying_words() {
-    let carried = skill(&[(
-        "SKILL.md",
-        "```\n``` aaa\nThe bypass is `git commit --no-verify`, never run it.\n",
-    )]);
-    assert_eq!(
-        severity_of(&carried, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        carried.findings
-    );
-}
-
-/// The slash and the `>` of an empty tag are one thing. Markdown allows
-/// spacing before that slash and none after it, so `<span/   >` is a line
-/// of prose; taking it for a whole tag opened a block that runs to the next
-/// blank line and threw away every span under it.
-///
-/// The control is the second case: written contiguously the tag is whole,
-/// and the block it opens is real.
-#[test]
-fn safety_bypass_opens_no_block_at_a_slash_parted_from_its_bracket() {
-    let parted = skill(&[(
-        "SKILL.md",
-        "<span/   >\nThe bypass is `git commit --no-verify`, never run it.\n",
-    )]);
-    assert!(
-        !rules_hit(&parted).contains(&"safety-bypass"),
-        "{:?}",
-        parted.findings
-    );
-
-    let whole = skill(&[(
-        "SKILL.md",
-        "<span/>\nThe bypass is `git commit --no-verify`, never run it.\n",
-    )]);
-    assert_eq!(
-        severity_of(&whole, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        whole.findings
-    );
-}
-
-/// A fence's own marker stands at most three spaces into its container, and
-/// a fourth is the indented code block instead. Measured from the start of
-/// the line rather than from where the quote's markers end, a marker four
-/// spaces past a `>` opened a fence markdown has none of, and the quoted
-/// prose under it lost the span it really holds.
-///
-/// The control is the second case: three spaces past the marker is a fence,
-/// and what it holds is code.
-#[test]
-fn safety_bypass_opens_no_fence_four_spaces_past_a_quote() {
-    let deep = skill(&[(
-        "SKILL.md",
-        ">     ```sh\n> The bypass is `git commit --no-verify`, never run it.\n",
-    )]);
-    assert!(
-        !rules_hit(&deep).contains(&"safety-bypass"),
-        "{:?}",
-        deep.findings
-    );
-
-    let near = skill(&[("SKILL.md", ">    ```sh\n> git commit --no-verify\n> ```\n")]);
-    assert_eq!(
-        severity_of(&near, "safety-bypass"),
-        Some(Severity::High),
-        "{:?}",
-        near.findings
-    );
-}
-
-/// A raw-text block ends on the closing tag of its own name. Markdown
-/// says otherwise in as many words — the end condition is a line holding
-/// `</pre>`, `</script>`, `</style>` or `</textarea>`, "case-insensitive;
-/// it need not match the start tag" — and `pulldown-cmark` requires the
-/// match, so a `</pre>` under a `<script>` leaves the block open and the
-/// paragraph below it is read as the script's own text. The switch that
-/// paragraph's span quoted is reported: over-counting, the safe side, on
-/// a shape that stands nowhere in the shipped tree. Correcting the parser
-/// by hand here would be the walk this module exists to have deleted.
-///
-/// The control is the second case: the block does end at its own closing
-/// tag, and the paragraph under that carries the span again.
-#[test]
-fn safety_bypass_ends_a_raw_text_block_at_a_closing_tag_of_its_own_name() {
-    let mismatched = skill(&[(
-        "SKILL.md",
-        "<script>\nfoo\n</pre>\nThe bypass is `git commit --no-verify`, never run it.\n",
-    )]);
-    assert_eq!(
-        severity_of(&mismatched, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        mismatched.findings
-    );
-
-    let matched = skill(&[(
-        "SKILL.md",
-        "<script>\nfoo\n</script>\nThe bypass is `git commit --no-verify`, never run it.\n",
-    )]);
-    assert!(
-        !rules_hit(&matched).contains(&"safety-bypass"),
-        "{:?}",
-        matched.findings
     );
 }
 
@@ -733,35 +663,6 @@ fn safety_bypass_opens_no_leaf_block_four_spaces_in() {
             near.findings
         );
     }
-}
-
-/// A table cell is a leaf block of its own, so a run of backticks opened in
-/// one meets no partner in the next and quotes nothing.
-///
-/// The control is the second case: take the delimiter row away and the same
-/// three lines are one paragraph, where the span is real.
-#[test]
-fn safety_bypass_reads_a_switch_a_table_row_keeps_out_of_a_span() {
-    let tabled = skill(&[(
-        "SKILL.md",
-        "| head |\n| --- |\n| Write `git commit |\n| --no-verify` to git. |\n",
-    )]);
-    assert_eq!(
-        severity_of(&tabled, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        tabled.findings
-    );
-
-    let joined = skill(&[(
-        "SKILL.md",
-        "| head |\n| Write `git commit |\n| --no-verify` to git. |\n",
-    )]);
-    assert!(
-        !rules_hit(&joined).contains(&"safety-bypass"),
-        "{:?}",
-        joined.findings
-    );
 }
 
 /// A footnote definition takes four-space-indented content below it as
@@ -799,222 +700,5 @@ fn safety_bypass_survives_a_footnote_label_above_an_indented_block() {
         "{:?} {:?}",
         plain.findings,
         labelled.findings
-    );
-}
-
-/// A link reference definition carries no inline content, so the backticks
-/// in its label are literal characters and quote nothing. Reading the line
-/// as a paragraph quoted the switch its label spells and scored a use as a
-/// mention.
-///
-/// The control is the second case: the same label in a sentence is inline
-/// content, and there the marks do quote.
-#[test]
-fn safety_bypass_reads_a_switch_a_link_definition_spells() {
-    let defined = skill(&[(
-        "SKILL.md",
-        "Read this.\n\n[`git commit --no-verify`]: src/main.rs\n",
-    )]);
-    assert_eq!(
-        severity_of(&defined, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        defined.findings
-    );
-
-    let inline = skill(&[(
-        "SKILL.md",
-        "Read this.\n\n[`git commit --no-verify`] is the shape.\n",
-    )]);
-    assert!(
-        !rules_hit(&inline).contains(&"safety-bypass"),
-        "{:?}",
-        inline.findings
-    );
-}
-
-/// Four spaces are measured from a list item's content column, not from the
-/// start of the line. Under an item whose content starts four in, a
-/// continuation paragraph at four is the item's own prose and the marks on
-/// it are markdown's; reading it as an indented code block threw its span
-/// away and reported the switch that span quoted.
-///
-/// The control is the second case: with no item above it, the same four
-/// spaces do open a code block, and the marks in there are the shell's.
-#[test]
-fn safety_bypass_measures_an_indent_from_a_list_items_content_column() {
-    let item = skill(&[(
-        "SKILL.md",
-        "16. Say this.\n\n    The bypass is `git commit --no-verify`, never run it.\n",
-    )]);
-    assert!(
-        !rules_hit(&item).contains(&"safety-bypass"),
-        "{:?}",
-        item.findings
-    );
-
-    let alone = skill(&[(
-        "SKILL.md",
-        "Say this.\n\n    The bypass is `git commit --no-verify`, never run it.\n",
-    )]);
-    assert_eq!(
-        severity_of(&alone, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        alone.findings
-    );
-}
-
-/// An indent is a count of columns, and a tab is as many of them as it
-/// takes to reach the next stop. A tab under a two-column list item is two
-/// columns of item content, not the four that open a code block; reading
-/// any leading tab as a block threw the line's span away.
-///
-/// The control is the second case: with no item above it, that same tab is
-/// four columns from the margin and does open a block.
-#[test]
-fn safety_bypass_measures_a_tab_in_columns_rather_than_as_an_indent() {
-    let item = skill(&[(
-        "SKILL.md",
-        "- Say this.\n\n\tThe bypass is `git commit --no-verify`, never run it.\n",
-    )]);
-    assert!(
-        !rules_hit(&item).contains(&"safety-bypass"),
-        "{:?}",
-        item.findings
-    );
-
-    let alone = skill(&[(
-        "SKILL.md",
-        "Say this.\n\n\tThe bypass is `git commit --no-verify`, never run it.\n",
-    )]);
-    assert_eq!(
-        severity_of(&alone, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        alone.findings
-    );
-}
-
-/// A backtick inside an autolink is a byte of the address, not a delimiter.
-/// Pairing it with the next one in the line quoted the text between them
-/// and left the switch past it standing in the open.
-///
-/// The control is the second case: written as bare text the same address
-/// carries a real delimiter, the pair closes early, and the switch is
-/// outside every span.
-#[test]
-fn safety_bypass_leaves_a_backtick_in_an_autolink_unpaired() {
-    let linked = skill(&[(
-        "SKILL.md",
-        "See <https://example.com/a`b> and `git commit --no-verify` now.\n",
-    )]);
-    assert!(
-        !rules_hit(&linked).contains(&"safety-bypass"),
-        "{:?}",
-        linked.findings
-    );
-
-    let bare = skill(&[(
-        "SKILL.md",
-        "See https://example.com/a`b and `git commit --no-verify` now.\n",
-    )]);
-    assert_eq!(
-        severity_of(&bare, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        bare.findings
-    );
-}
-
-/// An ordered list interrupts a paragraph only where it starts at one, so
-/// a `2.` under prose is that paragraph's next line and the span across it
-/// closes. Reading every number alike invented a boundary and reported a
-/// mention.
-///
-/// The control is the second case: `1.` does interrupt, and the switch
-/// under it stands in a block of its own.
-#[test]
-fn safety_bypass_lets_only_a_first_ordered_item_break_a_paragraph() {
-    let second = skill(&[(
-        "SKILL.md",
-        "The bypass is `git commit\n2. --no-verify` to git.\n",
-    )]);
-    assert!(
-        !rules_hit(&second).contains(&"safety-bypass"),
-        "{:?}",
-        second.findings
-    );
-
-    let first = skill(&[(
-        "SKILL.md",
-        "The bypass is `git commit\n1. --no-verify` to git.\n",
-    )]);
-    assert_eq!(
-        severity_of(&first, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        first.findings
-    );
-}
-
-/// The block-level tag names are markdown's own list, whoever holds it.
-/// A name on it opens a block wherever it stands, an open paragraph
-/// included, and one off it is the whole-tag kind, which may not interrupt
-/// a paragraph. `search` and `hgroup` are the pair that tells a current
-/// list from a stale one: HTML has both, markdown lists only the first,
-/// and a copy that guessed by looking at HTML would read them alike.
-#[test]
-fn safety_bypass_opens_a_block_at_the_tags_markdown_lists_and_no_others() {
-    let listed = skill(&[(
-        "SKILL.md",
-        "The bypass is `git commit\n<search>\n--no-verify`, never run it.\n",
-    )]);
-    assert_eq!(
-        severity_of(&listed, "safety-bypass"),
-        Some(Severity::Critical),
-        "{:?}",
-        listed.findings
-    );
-
-    let unlisted = skill(&[(
-        "SKILL.md",
-        "The bypass is `git commit\n<hgroup>\n--no-verify`, never run it.\n",
-    )]);
-    assert!(
-        !rules_hit(&unlisted).contains(&"safety-bypass"),
-        "{:?}",
-        unlisted.findings
-    );
-}
-
-/// A blockquote marker takes the whitespace behind it, a tab included, so
-/// what is left of a quoted prose line is prose. Leaving the tab in the
-/// remainder read the line as an indented code block, threw its span away
-/// and reported the switch the quotation was naming.
-///
-/// The control is the second case: four columns past the marker really is
-/// a code block inside the quote, and the marks in there are the shell's.
-#[test]
-fn safety_bypass_takes_a_tab_behind_a_blockquote_marker() {
-    let quoted = skill(&[(
-        "SKILL.md",
-        ">\tThe bypass is `git commit --no-verify`, never run it.\n",
-    )]);
-    assert!(
-        !rules_hit(&quoted).contains(&"safety-bypass"),
-        "{:?}",
-        quoted.findings
-    );
-
-    let indented = skill(&[(
-        "SKILL.md",
-        ">     The bypass is `git commit --no-verify`, never run it.\n",
-    )]);
-    assert_eq!(
-        severity_of(&indented, "safety-bypass"),
-        Some(Severity::High),
-        "{:?}",
-        indented.findings
     );
 }

--- a/crates/core/tests/registry.rs
+++ b/crates/core/tests/registry.rs
@@ -257,7 +257,13 @@ fn no_cache_and_no_network_is_an_error() {
     let down = Canned::new(vec![Err(CoreError::RegistryUnavailable {
         why: "no route".into(),
     })]);
-    assert!(cache::load(&env, &down, false).is_err());
+    let Err(error) = cache::load(&env, &down, false) else {
+        panic!("a directory nothing can read was served");
+    };
+    assert!(
+        matches!(&error, CoreError::RegistryUnavailable { why } if why == "no route"),
+        "the network's own refusal reaches the caller: {error:?}"
+    );
 }
 
 #[test]

--- a/crates/core/tests/structural_claims.rs
+++ b/crates/core/tests/structural_claims.rs
@@ -12,6 +12,7 @@ use std::path::{Path, PathBuf};
 use kendex_core::apply;
 use kendex_core::engine::{audit, ops};
 use kendex_core::env::{Env, FakeOs};
+use kendex_core::error::CoreError;
 use kendex_core::model::Scope;
 
 struct World {
@@ -173,7 +174,11 @@ fn corrupt_state_fails_closed_instead_of_defaulting() {
 
     // Damaged lock: the audit refuses rather than planning against nothing.
     fs::write(w.project.join(".kendex-lock.json"), "{torn").unwrap();
-    assert!(audit(&w.env, &scope).is_err(), "a corrupt lock must refuse");
+    let error = audit(&w.env, &scope).unwrap_err();
+    assert!(
+        matches!(error, CoreError::LockCorrupt { .. }),
+        "a corrupt lock must refuse: {error:?}"
+    );
     fs::remove_file(w.project.join(".kendex-lock.json")).unwrap();
 
     // Damaged app settings: the observed scoring pass and the plan's
@@ -183,19 +188,25 @@ fn corrupt_state_fails_closed_instead_of_defaulting() {
     let settings = w.env.settings_file();
     fs::create_dir_all(settings.parent().unwrap()).unwrap();
     fs::write(&settings, "not = [valid").unwrap();
+    let error = kendex_core::engine::observed_rows(&w.env, &scope).unwrap_err();
     assert!(
-        kendex_core::engine::observed_rows(&w.env, &scope).is_err(),
-        "corrupt settings must fail the audit closed"
+        matches!(&error, CoreError::TomlParse { path, .. } if *path == settings),
+        "corrupt settings must fail the audit closed: {error:?}"
     );
+    let error = audit(&w.env, &scope).unwrap_err();
     assert!(
-        audit(&w.env, &scope).is_err(),
-        "corrupt settings must fail the plan closed"
+        matches!(&error, CoreError::TomlParse { path, .. } if *path == settings),
+        "corrupt settings must fail the plan closed: {error:?}"
     );
     fs::remove_file(&settings).unwrap();
 
     // Damaged manifest: same refusal.
     fs::write(w.project.join("kendex.toml"), "schema = [broken").unwrap();
-    assert!(audit(&w.env, &scope).is_err());
+    let error = audit(&w.env, &scope).unwrap_err();
+    assert!(
+        matches!(&error, CoreError::TomlParse { path, .. } if *path == w.project.join("kendex.toml")),
+        "{error:?}"
+    );
 }
 
 /// `add` mutates nothing user-visible before validation
@@ -223,7 +234,11 @@ fn add_writes_nothing_before_validation_and_confirmation() {
         optional: vec!["no-such-extra".into()],
         ..Default::default()
     };
-    assert!(ops::add(&w.env, &scope, &bad).is_err());
+    let error = ops::add(&w.env, &scope, &bad).unwrap_err();
+    assert!(
+        matches!(&error, CoreError::NoSuchOptional { name, .. } if name == "no-such-extra"),
+        "{error:?}"
+    );
     assert_eq!(
         fs::read_to_string(w.project.join("kendex.toml")).unwrap(),
         manifest_text,

--- a/crates/core/tests/submit_client.rs
+++ b/crates/core/tests/submit_client.rs
@@ -147,10 +147,11 @@ fn a_dead_refresh_grant_signs_this_machine_out() {
         (401, r#"{"error":"invalid_grant"}"#),
     ]);
     let store = MemoryStore::signed_in();
-    let refused = submit(&fetch, &store, "jane/skills")
-        .unwrap_err()
-        .to_string();
-    assert!(refused.contains("run `kendex login` again"), "{refused}");
+    let refused = submit(&fetch, &store, "jane/skills").unwrap_err();
+    assert!(
+        matches!(refused, CoreError::SignInExpired { .. }),
+        "{refused:?}"
+    );
     assert!(
         store.load().unwrap().is_none(),
         "a dead credential must not be kept for endless retries"
@@ -162,10 +163,8 @@ fn a_dead_refresh_grant_signs_this_machine_out() {
 fn signed_out_asks_for_login_before_any_network_call() {
     let fetch = Canned::new(vec![]);
     let store = MemoryStore(RefCell::new(None));
-    let refused = submit(&fetch, &store, "jane/skills")
-        .unwrap_err()
-        .to_string();
-    assert!(refused.contains("not signed in"), "{refused}");
+    let refused = submit(&fetch, &store, "jane/skills").unwrap_err();
+    assert!(matches!(refused, CoreError::NotSignedIn), "{refused:?}");
     assert!(fetch.bearers.borrow().is_empty());
 }
 
@@ -200,42 +199,23 @@ fn submissions_parse_the_versioned_rows() {
     );
 }
 
+/// A refresh the server could not serve is not a dead grant: the server
+/// down (503), a timeout (408) and a rate limit (429) each keep the
+/// credential for the next attempt, one row per status.
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_transient_refresh_failure_keeps_the_credential() {
-    // 401 on the call, then the refresh endpoint answers 503 (server down)
-    // — a transient failure must not sign the machine out.
-    let fetch = Canned::new(vec![
-        (401, r#"{"error":"invalid_token"}"#),
-        (503, r#"{"error":"upstream unavailable"}"#),
-    ]);
-    let store = MemoryStore::signed_in();
-    let refused = submit(&fetch, &store, "jane/skills")
-        .unwrap_err()
-        .to_string();
-    assert!(!refused.contains("run `kendex login`"), "{refused}");
-    assert!(
-        store.load().unwrap().is_some(),
-        "a transient refresh failure must keep the credential"
-    );
-}
-
-#[test]
-#[allow(clippy::unwrap_used)]
-fn rate_limit_and_timeout_refresh_failures_keep_the_credential() {
-    for status in [408, 429] {
+    for status in [503, 408, 429] {
         let fetch = Canned::new(vec![
             (401, r#"{"error":"invalid_token"}"#),
             (status, r#"{"error":"try again later"}"#),
         ]);
         let store = MemoryStore::signed_in();
-        let refused = submit(&fetch, &store, "jane/skills")
-            .unwrap_err()
-            .to_string();
+        let refused = submit(&fetch, &store, "jane/skills").unwrap_err();
 
         assert!(
-            !refused.contains("run `kendex login`"),
-            "{status}: {refused}"
+            !matches!(refused, CoreError::SignInExpired { .. }),
+            "{status}: {refused:?}"
         );
         assert!(
             store.load().unwrap().is_some(),
@@ -484,9 +464,9 @@ fn logout_while_waiting_for_refresh_does_not_resurrect_the_credential() {
     observed.recv().unwrap();
     store.clear().unwrap();
     drop(held);
-    let refused = worker.join().unwrap().unwrap_err().to_string();
+    let refused = worker.join().unwrap().unwrap_err();
 
-    assert!(refused.contains("not signed in"), "{refused}");
+    assert!(matches!(refused, CoreError::NotSignedIn), "{refused:?}");
     assert_eq!(fetch.refresh_calls.load(Ordering::SeqCst), 0);
     assert!(store.load().unwrap().is_none());
 }

--- a/crates/core/tests/unmanaged_ownership.rs
+++ b/crates/core/tests/unmanaged_ownership.rs
@@ -293,7 +293,10 @@ fn what_kendex_already_looks_after_is_never_adopted() {
         &[kendex_core::model::HarnessId::Claude],
     );
 
-    assert!(refused.is_err(), "an installation was captured as a fork");
+    assert!(
+        matches!(refused, Err(kendex_core::error::CoreError::AlreadyManaged { ref name, .. }) if name == "deploy"),
+        "an installation was captured as a fork: {refused:?}"
+    );
     assert!(
         fs::read_to_string(w.home.join("app/kendex.toml"))
             .unwrap()

--- a/crates/core/tests/unmanaged_shapes.rs
+++ b/crates/core/tests/unmanaged_shapes.rs
@@ -16,6 +16,7 @@ use kendex_core::apply;
 use kendex_core::engine::adopt::adopt;
 use kendex_core::engine::{DriftCause, DriftState, PlanOptions, audit, plan_apply};
 use kendex_core::env::{Env, FakeOs};
+use kendex_core::error::CoreError;
 use kendex_core::model::{HarnessId, ItemKind, Scope};
 
 const BEFORE: &str = "laid out by the tool that came before";
@@ -224,7 +225,7 @@ fn a_file_where_a_folder_goes_is_never_offered_the_keep() {
             "deploy",
             &[HarnessId::Claude]
         )
-        .is_err(),
+        .is_err_and(|error| matches!(error, CoreError::ItemNotInSource { .. })),
         "the gate and what adoption can take have drifted apart"
     );
 }
@@ -253,7 +254,10 @@ fn a_folder_where_a_file_goes_is_never_offered_the_keep() {
             "scout",
             &[HarnessId::Claude]
         )
-        .is_err(),
+        // Refused, though by the read tripping over the directory rather
+        // than by a typed refusal: the accident this pins is the one the
+        // verb refuses by today.
+        .is_err_and(|error| matches!(error, CoreError::Io { .. })),
         "the gate and what adoption can take have drifted apart"
     );
 }

--- a/crates/core/tests/unmanaged_takeover/main.rs
+++ b/crates/core/tests/unmanaged_takeover/main.rs
@@ -526,7 +526,7 @@ fn a_keep_is_not_offered_where_the_tools_copies_disagree() {
             "deploy",
             &[HarnessId::Claude, HarnessId::Codex],
         )
-        .is_err()
+        .is_err_and(|error| matches!(error, CoreError::AdoptedCopiesDiffer { .. }))
     );
 
     // The control: the same two places agreeing are one copy, and keeping

--- a/crates/core/tests/unsubscribe.rs
+++ b/crates/core/tests/unsubscribe.rs
@@ -8,10 +8,11 @@ mod test_util;
 use test_util::source_path;
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use kendex_core::engine::detach;
 use kendex_core::env::{Env, FakeOs};
+use kendex_core::error::CoreError;
 use kendex_core::manifest::{self, ManifestFile};
 use kendex_core::model::{ItemKind, Scope};
 use kendex_core::{apply, source_ops};
@@ -125,7 +126,11 @@ fn removing_an_unreachable_source_refuses() {
     apply_now(&env, &scope);
     // Make the catalog unreadable by removing it.
     fs::remove_dir_all(&catalog).unwrap();
-    assert!(detach::remove(&env, &scope, "cat", false).is_err());
+    let error = detach::remove(&env, &scope, "cat", false).unwrap_err();
+    assert!(
+        matches!(&error, CoreError::SourceMissing { name, .. } if name == "cat"),
+        "{error:?}"
+    );
     // The subscription is untouched by the refusal.
     assert!(manifest_of(&env, &scope).sources.contains_key("cat"));
 }
@@ -164,52 +169,63 @@ fn keeping_a_sources_packages_detaches_them_to_local() {
     );
 }
 
-/// Detach refuses while a package is edited — keeping it from source form would
-/// silently drop the edit.
+/// Detach refuses while a package is edited, naming it: keeping it from
+/// source form would silently drop the edit. One row per artifact: a
+/// skill's file, and a hook script (detach compares the installed script
+/// to what apply wrote, so keeping from source form cannot silently revert
+/// a hook the user changed by hand).
 #[test]
 #[allow(clippy::unwrap_used)]
 fn keeping_an_edited_package_refuses_naming_it() {
-    let (_tmp, env, scope, catalog) = world("[skills.gh]\nsource = \"cat\"\n", "");
-    skill(&catalog, "gh", "the gh skill");
-    apply_now(&env, &scope);
-    // Edit the installed skill by hand.
-    let installed = scope_skill(&scope, "gh").join("SKILL.md");
-    let edited = fs::read_to_string(&installed).unwrap() + "\nhand edit\n";
-    fs::write(&installed, edited).unwrap();
+    type Plant = fn(&Path);
+    type Installed = fn(&Path) -> PathBuf;
+    let rows: [(&str, &str, Plant, Installed, &str); 2] = [
+        (
+            "a skill",
+            "[skills.gh]\nsource = \"cat\"\n",
+            |catalog| skill(catalog, "gh", "the gh skill"),
+            |root| root.join(".claude/skills/gh/SKILL.md"),
+            "skill gh",
+        ),
+        (
+            "a hook",
+            "[hooks.guard]\nsource = \"cat\"\n",
+            |catalog| {
+                fs::create_dir_all(catalog.join("hooks")).unwrap();
+                fs::write(catalog.join("kendex.toml"), "is_source_catalog = true\n").unwrap();
+                fs::write(
+                    catalog.join("hooks/guard.sh"),
+                    "#!/usr/bin/env bash\n# ---\n# name: guard\n# event: PreToolUse\n# matcher: Bash\n# description: check\n# ---\nexit 0\n",
+                )
+                .unwrap();
+            },
+            |root| root.join(".claude/hooks/guard.sh"),
+            "hook guard",
+        ),
+    ];
+    for (what, declaration, plant, installed, named) in rows {
+        let (_tmp, env, scope, catalog) = world(declaration, "");
+        plant(&catalog);
+        apply_now(&env, &scope);
+        let Scope::Project { root } = &scope else {
+            unreachable!()
+        };
+        let file = installed(root);
+        assert!(file.exists(), "{what}: not installed");
+        let edited = fs::read_to_string(&file).unwrap() + "\nhand edit\n";
+        fs::write(&file, edited).unwrap();
 
-    let err = detach::source(&env, &scope, "cat").unwrap_err();
-    assert!(format!("{err}").contains("gh"), "{err}");
-    // The subscription is untouched.
-    assert!(manifest_of(&env, &scope).sources.contains_key("cat"));
-}
+        let error = detach::source(&env, &scope, "cat").unwrap_err();
 
-/// An edited hook script is caught too: detach compares the installed script to
-/// what apply wrote, so keeping from source form cannot silently revert a hook
-/// the user changed by hand.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn keeping_an_edited_hook_refuses() {
-    let (_tmp, env, scope, catalog) = world("[hooks.guard]\nsource = \"cat\"\n", "");
-    fs::create_dir_all(catalog.join("hooks")).unwrap();
-    fs::write(catalog.join("kendex.toml"), "is_source_catalog = true\n").unwrap();
-    fs::write(
-        catalog.join("hooks/guard.sh"),
-        "#!/usr/bin/env bash\n# ---\n# name: guard\n# event: PreToolUse\n# matcher: Bash\n# description: check\n# ---\nexit 0\n",
-    )
-    .unwrap();
-    apply_now(&env, &scope);
-
-    // Find and edit the installed hook script.
-    let Scope::Project { root } = &scope else {
-        unreachable!()
-    };
-    let installed = root.join(".claude/hooks/guard.sh");
-    assert!(installed.exists(), "hook installed");
-    fs::write(&installed, "#!/usr/bin/env bash\necho tampered\n").unwrap();
-
-    let err = detach::source(&env, &scope, "cat").unwrap_err();
-    assert!(format!("{err}").contains("guard"), "{err}");
-    assert!(manifest_of(&env, &scope).sources.contains_key("cat"));
+        let CoreError::DetachEdited { names } = &error else {
+            panic!("{what}: {error:?}");
+        };
+        assert_eq!(names, &[named.to_owned()], "{what}");
+        assert!(
+            manifest_of(&env, &scope).sources.contains_key("cat"),
+            "{what}: the subscription was touched"
+        );
+    }
 }
 
 /// A member another marketplace's bundle still carries is not in the closure:


### PR DESCRIPTION
Every file under `crates/core/tests` (120 files holding cases) judged against code-quality § Tests from a read-only classification pass; twenty-five reshaped, ninety-five already at the bar. Two shapes account for nearly every finding: a behaviour whose input is a document, a shape or a state, written as one `#[test]` per input instead of a table; and a refusal asserted as `is_err()` where a neighbouring case in the same file already matches the `CoreError` variant. Test code only; no production Rust changes; `[no-changelog]`.

## Folded or deleted cases, with the surviving row

| Former cases | Surviving table or case |
|---|---|
| `quality/rules.rs`: `safety_bypass_reads_a_switch_named_in_a_code_span_as_a_mention`, `_reads_past_a_mention_to_the_use_behind_it`, `_still_reads_a_switch_after_a_backtick_that_closes_nothing`, `_leaves_a_backtick_quoted_inside_a_longer_span`, `_reads_a_switch_between_escaped_backticks`; `quality/rules_blocks.rs`: thirty-one `safety_bypass_*` cases (every one whose body is `skill(...)` calls and a severity or no-hit assertion per document) | `rules_blocks.rs::safety_bypass_reads_a_switch_as_a_use_exactly_where_no_span_quotes_it`, 64 rows of `(label, markdown, Option<Severity>)`; each former case's doc comment stands above its rows, and its label is the case name plus the document's binding name. The three cases with another shape stay: `_reads_a_declaration_the_same_in_either_case` and `_survives_a_footnote_label_above_an_indented_block` (an equality between two documents), `_opens_no_leaf_block_four_spaces_in` (a loop over five openers) |
| `edits_and_forks/agent_settings.rs`: `a_hand_tightened_deny_refuses_the_fork_and_writes_nothing`, `a_hand_added_allowlist_refuses_the_fork`, `an_unreadable_frontmatter_refuses_the_fork`, the colour half of `a_deleted_setting_is_carried_where_it_can_be_and_refused_where_it_cannot`, `a_pi_allowlist_that_cannot_render_refuses_the_fork`, `a_hand_written_hook_refuses_the_fork`, `a_hand_tightened_hook_scope_refuses_the_fork`, `an_unterminated_frontmatter_refuses_the_fork` | `a_hand_edit_the_fork_cannot_carry_refuses_and_names_it`, 8 rows on the `ForkWidensAccess { name, problem }` fields rather than the Display string; every row now also asserts the manifest records no fork (only the first case did). The effort half is `a_deleted_effort_is_carried_as_cleared` |
| `authoring.rs`: `a_path_whose_last_component_is_not_a_name_refuses_and_writes_nothing`, `a_containing_folder_that_does_not_exist_refuses_and_makes_nothing`, `a_dangling_link_at_the_destination_refuses_in_every_spelling` (three spellings), `a_name_no_harness_accepts_refuses_before_any_write` | `a_request_create_refuses_writes_nothing_and_names_why`, 6 rows on the `Authoring { message }` field with a per-row untouched-tree closure; the three symlink rows are appended under `cfg(unix)` so the table itself runs on every platform |
| `credential_store_refusals.rs`: `no_keychain_at_all_refuses_every_call_as_the_store`, `a_refused_write_names_the_store`, `a_refused_read_names_the_store`, `a_refused_removal_names_the_store` (and the `names_the_store` helper) | `every_refused_call_names_the_store_and_the_call`, 6 rows (call × where the keychain refuses), the helper's four assertions inline |
| `migration.rs`: `a_v01_manifest_is_refused_and_left_byte_identical`, `the_schema_one_below_current_is_refused_too`, `a_manifest_naming_no_schema_is_refused`, `a_newer_schema_refuses_to_load` | `a_manifest_this_build_cannot_read_is_refused_and_left_byte_identical`, 4 rows on the `LegacyManifest { message }` clause or `SchemaTooNew { found }`; the "install fresh" remedy pin dropped |
| `me_client/main.rs`: `network_away_serves_the_cached_identity_as_offline`, `the_fixture_database_status_rides_the_offline_ladder`, `a_malformed_answer_serves_the_cache_as_offline` | `a_directory_that_cannot_answer_serves_the_cached_identity_as_offline`, 3 rows, each asserting the cached identity's name |
| `drift_check.rs`: `a_package_from_a_commit_pinned_source_reports_held`, `a_pin_reaching_a_member_through_a_bundle_reports_held`, `a_pin_reaching_a_dependency_through_its_parent_reports_held` | `a_commit_pin_holds_every_package_it_reaches`, 3 rows, the tracking-selector control after them in a world of its own |
| `dependencies/main.rs`: `a_cycle_split_across_tools_claims_no_co_install`, `a_cycle_reaching_only_some_tools_claims_no_co_install`, `references_between_declarations_no_tool_holds_claim_no_co_install` | `a_reference_that_does_not_reach_every_tool_claims_no_co_install`, 3 rows, each also pinning whether the missing-dependency finding is reported (the reaching-only-some-tools row does report one, which its former case did not assert either way) |
| `unsubscribe.rs`: `keeping_an_edited_package_refuses_naming_it`, `keeping_an_edited_hook_refuses` | `keeping_an_edited_package_refuses_naming_it`, 2 rows pinning `DetachEdited { names }` exactly (`skill gh`, `hook guard`) |
| `submit_client.rs`: `a_transient_refresh_failure_keeps_the_credential` (503) and `rate_limit_and_timeout_refresh_failures_keep_the_credential` (408, 429) | `a_transient_refresh_failure_keeps_the_credential`, one loop over the three statuses, asserting the error is not `SignInExpired` and the credential stays |

Truthiness bits now matching the variant (24 across 15 files): `migration.rs` (three recovery refusals: `RecordExistingRefused` twice, `RolledBack` once; the first one was hiding a fixture whose plugin row named a harness with no plugin switch, so it refused as an invalid manifest, not as an incomplete declaration; the row now names claude), `me_client/main.rs` (three `AccountUnread::Unreachable`, one `RegistryUnavailable` on sign-out), `edits_and_forks/forks.rs` (`RolledBack { cause: PlanStale }`; the Codex-agent fork refusal on `ItemNotInSource { name, source_name }`), `unsubscribe.rs` (`SourceMissing`), `marketplace_subscribe.rs` (`GitFailed` on the clone), `registry.rs` (`RegistryUnavailable` with the network's own reason), `unmanaged_ownership.rs` (`AlreadyManaged`), `unmanaged_shapes.rs` (`ItemNotInSource` for a file where a folder goes; `Io` for a folder where a file goes, see below), `unmanaged_takeover/main.rs` (`AdoptedCopiesDiffer`), `edits_and_forks/main.rs` (unchanged: `rows.is_ok()` there is the whole claim, that updates survives), `instruction_shims.rs` (`RolledBack { cause: PlanStale }`), `structural_claims.rs` (`LockCorrupt`, `TomlParse` at the settings path twice, `TomlParse` at the manifest path, `NoSuchOptional`), `install_into_project.rs` (`ItemNotInSource { name: "nope", source_name: "mkt" }`), `package_pins/sets.rs` (`LockCorrupt`), `adopt_pinned.rs` (no `Conflict` row in the audit after keeping).

Prose pins replaced by variants: `submit_client.rs` (`NotSignedIn` twice, `SignInExpired` once, and the transient loop's negative), `credential_transactions.rs` (five `SignInExpired` matches; the rotation case pins the Removal::Done arm by the absence of "could not be removed" rather than the remedy sentence; the two store-failure cases keep their composed clauses, which are the point), `quality/rules.rs`'s `prompt_injection_catches_talking_past_the_harness` ("set aside" and the non-empty remediation).

Kept on judgment: `pi_carrier.rs`'s `carrier_runner` assertion that CI installs bun (§ 15 of the classification): it is what keeps a skipped end-to-end case from passing silently, which the owner's ruling for this audit asks for, and its message names the CI step to restore.

Finding, pinned as it is and named for the overseer: adopting a folder standing where an agent's file goes (`unmanaged_shapes.rs::a_folder_where_a_file_goes_is_never_offered_the_keep`) refuses by a raw `Io` error (`IsADirectory` from reading the folder as a file), not by a typed refusal; the row pins `CoreError::Io` with a comment saying so.

## Mutation

One must-fail mutant per surviving table, ten tables, all killed (`mutants-core.txt` in the lane scratchpad; `mutate-core.py` mutates production in place and restores it from `HEAD`): a switch at a span's first byte read as a use; unterminated frontmatter read as stating nothing; a space accepted in a marketplace name; the store's load refusal worded as the removal's; the schema one below current read; a stale cache served as signed in; a source pin holding nothing; a co-install claimed for any shared tool; the edited items named without their kind; a 503 on refresh read as a dead grant.

## Reviewer round

One reviewer-test round, ACCEPT WITH FIXES, both applied: the migration table's one-below-current row pinned the bare word "schema", which both LegacyManifest messages carry (the bar's own definition of not a pin); it pins `schema {n} manifest` now. The `cfg(unix)` row append in `authoring.rs` left `let mut rows` unmutated on Windows, an `unused_mut` error under `-D warnings` once a Windows lane builds core's tests; it carries `#[cfg_attr(not(unix), allow(unused_mut))]`. Two losses the reviewer named for the record, no change asked: `prompt_injection_catches_talking_past_the_harness` dropped a "set aside" prose pin and a non-empty-remediation bit, so no test in `crates/core/tests` now asserts a quality rule emits a remediation (the bit was a truthiness read; a pin on the remediation belongs to a case about remediations); and the five `SignInExpired` matches prove less than the "server does not accept this sign-in" substring did, since that variant's Display is its `why` and the phrase is composed by the caller (the store-state assertions beside them carry the behaviour; the phrase is a diagnostic sentence). The reviewer wrote five extra mutants for row groups the recorded mutant does not reach (the High rows, the None control rows, the fork table's hook rows, the no-schema row, the no-tool row); all five killed through the named row.

## Checks

- `cargo test -p kendex-core --no-fail-fast`: all 91 integration targets green; one lib case fails on main in this environment (`discover::tests::project_root_walks_up_and_lock_file_wins_at_home`: the owner's home carries a `.agents` directory and reads as a project root; the diff touches no lib test); CI is its verdict. `cargo clippy -p kendex-core --all-targets -- -D warnings` clean; `cargo fmt -p kendex-core -- --check` clean.
- `tools/guard --full`: exit 0 on 72b9f6557 (TMPDIR=/var/tmp/ken-c), the same tree restacked onto main as 7c568744a.

KEN-1241

https://claude.ai/code/session_011xJpLvrZfz4ZqfQ3ddVTJB
